### PR TITLE
test(corpus): rebless the windows, darwin and spirv layer B goldens moved by cross-module inlining (#3110)

### DIFF
--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -846,3 +846,107 @@ frame direction: frame larger 37, frame same 45, frame smaller 10
 | vec/vec_u32x4 | 820 | 586 | 78 | 23 | calls removed |
 | vec/vec_u64x2 | 488 | 427 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 1256 | 1545 | 42 | 25 | calls removed |
+
+## aarch64-darwin: 92 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 92 |
+
+calls before 4337, after 1804, cases reaching zero calls 31
+frame direction: frame larger 27, frame same 9, frame smaller 32, no frame adjustment 24
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 125 | 343 | 22 | 5 | calls removed |
+| bits/logic_u64 | 123 | 328 | 22 | 5 | calls removed |
+| bits/shift_i32 | 147 | 355 | 28 | 11 | calls removed |
+| bits/shift_i64 | 136 | 327 | 28 | 11 | calls removed |
+| bits/shift_u32 | 135 | 346 | 27 | 10 | calls removed |
+| bits/shift_u64 | 132 | 326 | 27 | 10 | calls removed |
+| call/call_chain | 332 | 598 | 172 | 154 | calls removed |
+| call/call_float_regs | 653 | 555 | 87 | 30 | calls removed |
+| call/call_indirect | 524 | 635 | 69 | 24 | calls removed |
+| call/call_int_regs | 1103 | 1047 | 123 | 24 | calls removed |
+| call/call_mixed | 294 | 503 | 53 | 35 | calls removed |
+| call/call_rec_edge | 806 | 861 | 87 | 50 | calls removed |
+| call/call_rec_large | 427 | 1256 | 134 | 97 | calls removed |
+| call/call_rec_small | 369 | 695 | 71 | 30 | calls removed |
+| call/call_recursive | 383 | 403 | 53 | 13 | calls removed |
+| call/call_ret_large | 652 | 1189 | 138 | 96 | calls removed |
+| call/call_ret_small | 488 | 855 | 88 | 42 | calls removed |
+| call/call_variadic | 297 | 509 | 158 | 141 | calls removed |
+| cmp/branch_nest | 150 | 172 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 114 | 208 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 145 | 231 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 114 | 208 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 145 | 231 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 110 | 179 | 6 | 0 | calls removed |
+| cmp/short_circuit | 486 | 438 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 368 | 562 | 54 | 37 | calls removed |
+| convert/bitcast | 72 | 204 | 11 | 0 | calls removed |
+| convert/ext_sign | 99 | 282 | 15 | 0 | calls removed |
+| convert/ext_zero | 97 | 280 | 15 | 0 | calls removed |
+| convert/f2f | 76 | 215 | 11 | 0 | calls removed |
+| convert/f2i | 189 | 677 | 54 | 21 | calls removed |
+| convert/f2u_high | 134 | 498 | 25 | 0 | calls removed |
+| convert/i2f | 174 | 690 | 37 | 4 | calls removed |
+| convert/trunc | 71 | 172 | 9 | 0 | calls removed |
+| float/arith_f32 | 838 | 635 | 65 | 46 | calls removed |
+| float/arith_f64 | 914 | 680 | 65 | 46 | calls removed |
+| float/cmp_f32 | 340 | 548 | 20 | 2 | calls removed |
+| float/cmp_f64 | 316 | 556 | 26 | 7 | calls removed |
+| float/special_f32 | 538 | 598 | 117 | 84 | calls removed |
+| float/special_f64 | 588 | 608 | 127 | 94 | calls removed |
+| frame/frame_align | 469 | 493 | 79 | 24 | calls removed |
+| frame/frame_large | 220 | 445 | 16 | 0 | calls removed |
+| frame/frame_spill | 381 | 740 | 32 | 15 | calls removed |
+| imm/imm_add | 141 | 345 | 25 | 8 | calls removed |
+| imm/imm_addr | 187 | 489 | 21 | 4 | calls removed |
+| imm/imm_logic | 128 | 347 | 21 | 4 | calls removed |
+| imm/imm_mov | 98 | 275 | 12 | 0 | calls removed |
+| mem/addr_modes | 379 | 646 | 36 | 19 | calls removed |
+| mem/array_index | 396 | 635 | 36 | 15 | calls removed |
+| mem/global_data | 220 | 429 | 35 | 12 | calls removed |
+| mem/global_zero | 178 | 397 | 28 | 7 | calls removed |
+| mem/loadstore | 218 | 441 | 25 | 8 | calls removed |
+| mem/ptr_arith | 264 | 509 | 29 | 8 | calls removed |
+| mem/rec_layout | 315 | 630 | 50 | 25 | calls removed |
+| mem/uni_layout | 220 | 469 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 91 | 281 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 85 | 275 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 84 | 262 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 91 | 281 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 91 | 281 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 84 | 274 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 83 | 261 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 91 | 281 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 165 | 342 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 164 | 329 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 83 | 213 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 82 | 203 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 48 | 157 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 47 | 149 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 48 | 157 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 47 | 149 | 8 | 0 | calls removed |
+| vec/autovec_loop | 632 | 771 | 10 | 0 | calls removed |
+| vec/vec_cmp_i64 | 630 | 456 | 33 | 13 | calls removed |
+| vec/vec_cmp_select | 1096 | 1026 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 375 | 180 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 390 | 249 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 645 | 248 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 1981 | 1452 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 3389 | 2080 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 398 | 193 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 681 | 318 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 1322 | 541 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 769 | 400 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 505 | 346 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 426 | 599 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 1091 | 717 | 107 | 39 | calls removed |
+| vec/vec_mem | 2747 | 2992 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 698 | 552 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 1322 | 541 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 789 | 420 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 505 | 346 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 425 | 598 | 42 | 25 | calls removed |

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -742,3 +742,107 @@ frame direction: frame larger 15, frame same 28, frame smaller 49
 | vec/vec_u32x4 | 744 | 591 | 78 | 23 | calls removed |
 | vec/vec_u64x2 | 436 | 398 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 1343 | 1610 | 42 | 25 | calls removed |
+
+## x86_64-darwin: 92 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 92 |
+
+calls before 4337, after 1804, cases reaching zero calls 31
+frame direction: frame larger 37, frame same 45, frame smaller 10
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 139 | 421 | 22 | 5 | calls removed |
+| bits/logic_u64 | 137 | 409 | 22 | 5 | calls removed |
+| bits/shift_i32 | 190 | 469 | 28 | 11 | calls removed |
+| bits/shift_i64 | 138 | 415 | 28 | 11 | calls removed |
+| bits/shift_u32 | 185 | 464 | 27 | 10 | calls removed |
+| bits/shift_u64 | 135 | 412 | 27 | 10 | calls removed |
+| call/call_chain | 651 | 933 | 172 | 154 | calls removed |
+| call/call_float_regs | 568 | 673 | 87 | 30 | calls removed |
+| call/call_indirect | 676 | 900 | 69 | 24 | calls removed |
+| call/call_int_regs | 950 | 941 | 123 | 24 | calls removed |
+| call/call_mixed | 603 | 925 | 53 | 35 | calls removed |
+| call/call_rec_edge | 707 | 985 | 87 | 50 | calls removed |
+| call/call_rec_large | 477 | 984 | 134 | 97 | calls removed |
+| call/call_rec_small | 612 | 1026 | 71 | 30 | calls removed |
+| call/call_recursive | 565 | 556 | 53 | 13 | calls removed |
+| call/call_ret_large | 1317 | 1999 | 138 | 96 | calls removed |
+| call/call_ret_small | 678 | 1126 | 88 | 42 | calls removed |
+| call/call_variadic | 389 | 841 | 158 | 141 | calls removed |
+| cmp/branch_nest | 143 | 177 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 126 | 229 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 137 | 238 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 126 | 229 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 137 | 238 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 123 | 210 | 6 | 0 | calls removed |
+| cmp/short_circuit | 597 | 595 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 369 | 628 | 54 | 37 | calls removed |
+| convert/bitcast | 54 | 224 | 11 | 0 | calls removed |
+| convert/ext_sign | 82 | 320 | 15 | 0 | calls removed |
+| convert/ext_zero | 83 | 320 | 15 | 0 | calls removed |
+| convert/f2f | 69 | 236 | 11 | 0 | calls removed |
+| convert/f2i | 321 | 860 | 54 | 21 | calls removed |
+| convert/f2u_high | 233 | 657 | 25 | 0 | calls removed |
+| convert/i2f | 207 | 809 | 37 | 4 | calls removed |
+| convert/trunc | 60 | 197 | 9 | 0 | calls removed |
+| float/arith_f32 | 1076 | 849 | 65 | 46 | calls removed |
+| float/arith_f64 | 1033 | 807 | 65 | 46 | calls removed |
+| float/cmp_f32 | 412 | 626 | 20 | 2 | calls removed |
+| float/cmp_f64 | 491 | 969 | 26 | 7 | calls removed |
+| float/special_f32 | 716 | 730 | 117 | 84 | calls removed |
+| float/special_f64 | 803 | 825 | 127 | 94 | calls removed |
+| frame/frame_align | 677 | 681 | 79 | 24 | calls removed |
+| frame/frame_large | 245 | 510 | 16 | 0 | calls removed |
+| frame/frame_spill | 321 | 571 | 32 | 15 | calls removed |
+| imm/imm_add | 124 | 387 | 25 | 8 | calls removed |
+| imm/imm_addr | 239 | 564 | 21 | 4 | calls removed |
+| imm/imm_logic | 129 | 393 | 21 | 4 | calls removed |
+| imm/imm_mov | 92 | 284 | 12 | 0 | calls removed |
+| mem/addr_modes | 541 | 917 | 36 | 19 | calls removed |
+| mem/array_index | 633 | 1014 | 36 | 15 | calls removed |
+| mem/global_data | 293 | 564 | 35 | 12 | calls removed |
+| mem/global_zero | 309 | 583 | 28 | 7 | calls removed |
+| mem/loadstore | 192 | 479 | 25 | 8 | calls removed |
+| mem/ptr_arith | 391 | 684 | 29 | 8 | calls removed |
+| mem/rec_layout | 802 | 1257 | 50 | 25 | calls removed |
+| mem/uni_layout | 327 | 615 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 108 | 331 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 116 | 332 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 108 | 313 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 108 | 331 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 107 | 330 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 115 | 331 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 108 | 313 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 107 | 330 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 159 | 406 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 147 | 368 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 116 | 293 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 110 | 270 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 71 | 196 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 58 | 176 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 71 | 196 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 59 | 177 | 8 | 0 | calls removed |
+| vec/autovec_loop | 679 | 859 | 10 | 0 | calls removed |
+| vec/vec_cmp_i64 | 597 | 510 | 33 | 13 | calls removed |
+| vec/vec_cmp_select | 877 | 930 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 326 | 262 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 372 | 316 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 514 | 328 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 1882 | 1437 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 2869 | 2088 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 317 | 251 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 499 | 308 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 834 | 393 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 816 | 582 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 488 | 427 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 1256 | 1545 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 1196 | 1150 | 107 | 39 | calls removed |
+| vec/vec_mem | 1784 | 1770 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 815 | 926 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 834 | 393 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 820 | 586 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 488 | 427 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 1256 | 1545 | 42 | 25 | calls removed |

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -950,3 +950,130 @@ frame direction: frame larger 27, frame same 9, frame smaller 32, no frame adjus
 | vec/vec_u32x4 | 789 | 420 | 78 | 23 | calls removed |
 | vec/vec_u64x2 | 505 | 346 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 425 | 598 | 42 | 25 | calls removed |
+
+## spirv: the module column
+
+`spirv` decodes with `spirv-dis` and has no layer C, so a golden move here is
+read more closely than on a machine column. Against `dev` at `da4fe7146`,
+layer B failed 84 cells (167 pass, 84 fail, 101 declared skips; every failure
+a `layer b o2` cell, layer A green). Calls are `OpFunctionCall`. Lines
+removed and added are counted on id-stripped text (every `%id` replaced by
+`%_`, the `; Bound:` line dropped), so id renumbering does not inflate them.
+
+Two module-wide facts hold on every one of the 84 goldens, checked by script:
+no golden gains an opcode kind it did not already use, and the only opcode
+kind that disappears from any module is `OpFunctionCall` (the 31 cases that
+reach zero calls). On 35 goldens the opcode multiset delta is exactly
+`OpFunctionCall` removals, the bodies of helper functions dropped once they
+had no caller left, and copies of the remaining helper bodies. On the other
+49 the residual, listed per golden in the last column, comes from three
+inlining consequences rather than from the copied bodies themselves: a
+same-module callee that grew past the growth bound once its own callees
+were inlined (`fold_vec` in the `vec` family, `fold32`/`fold64` in `float`)
+is now inlined at fewer of its call sites, so the copied `OpCompositeExtract`
+and NaN-check `OpFUnordNotEqual`/`OpSelectionMerge` counts fall while the
+callee stays called; an inlined copy specialized to constant arguments folds
+part of its body (`call/call_float_regs`, `frame/frame_align`,
+`vec/vec_cmp_*`); and single-digit changes in a case's own expressions where
+the copied loop sits between two uses (`+OpBitwiseOr 1` in `bits/logic_*`,
+`OpAccessChain` and `OpTypePointer` for pointer-typed locals and the dropped
+helpers' parameter types). The class rule is unchanged: every golden has fewer
+calls, and the per-golden call counts match the `x86_64-linux` rows on 83
+of the 84 goldens; `frame/frame_align` reads 76 to 21 against 79 to 24, three
+fewer both before and after, the same 55 calls removed.
+
+## spirv: 84 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 84 |
+
+calls (`OpFunctionCall`) before 3880, after 1557, cases reaching zero calls 31
+opcode multiset delta fully accounted for by OpFunctionCall removals, dropped helper functions and inlined helper-body opcodes: 35 of 84; residual across the rest: 105 opcodes up, 1517 down
+
+| golden | lines removed | lines added | calls before | calls after | functions before | functions after | class | residual opcode delta |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 184 | 1090 | 22 | 5 | 3 | 2 | calls removed | +OpBitwiseOr 1 |
+| bits/logic_u64 | 178 | 956 | 22 | 5 | 3 | 2 | calls removed | +OpBitwiseOr 1 |
+| bits/shift_i32 | 193 | 1094 | 28 | 11 | 3 | 2 | calls removed | none |
+| bits/shift_i64 | 200 | 1037 | 28 | 11 | 3 | 2 | calls removed | none |
+| bits/shift_u32 | 204 | 1105 | 27 | 10 | 3 | 2 | calls removed | none |
+| bits/shift_u64 | 200 | 973 | 27 | 10 | 3 | 2 | calls removed | none |
+| call/call_float_regs | 1192 | 1962 | 87 | 30 | 10 | 8 | calls removed | -OpFAdd 2 -OpFMul 2 -OpFSub 2 |
+| call/call_int_regs | 1804 | 1946 | 123 | 24 | 13 | 5 | calls removed | -OpAccessChain 38 |
+| call/call_mixed | 621 | 1256 | 53 | 35 | 14 | 7 | calls removed | +OpCompositeExtract 3 |
+| call/call_rec_edge | 2710 | 3305 | 87 | 50 | 22 | 17 | calls removed | -OpAccessChain 28 |
+| call/call_rec_large | 2438 | 3512 | 134 | 97 | 23 | 19 | calls removed | -OpAccessChain 14 |
+| call/call_rec_small | 1692 | 2554 | 71 | 30 | 19 | 13 | calls removed | -OpAccessChain 13 |
+| call/call_ret_large | 932 | 2162 | 138 | 96 | 26 | 23 | calls removed | +OpAccessChain 13 |
+| call/call_ret_small | 1690 | 2272 | 88 | 42 | 28 | 22 | calls removed | +OpAccessChain 8 |
+| call/call_variadic | 615 | 1450 | 158 | 141 | 24 | 21 | calls removed | none |
+| cmp/branch_nest | 88 | 126 | 3 | 0 | 3 | 1 | calls removed | none |
+| cmp/cmp_i32 | 142 | 403 | 7 | 0 | 3 | 1 | calls removed | -OpTypePointer 1 |
+| cmp/cmp_i64 | 138 | 399 | 7 | 0 | 3 | 1 | calls removed | -OpTypePointer 1 |
+| cmp/cmp_u32 | 150 | 411 | 7 | 0 | 3 | 1 | calls removed | -OpTypePointer 1 |
+| cmp/cmp_u64 | 146 | 407 | 7 | 0 | 3 | 1 | calls removed | -OpTypePointer 1 |
+| cmp/loop_shapes | 134 | 340 | 6 | 0 | 3 | 1 | calls removed | none |
+| comptime/ct_runtime_agree | 299 | 1080 | 54 | 37 | 8 | 5 | calls removed | none |
+| convert/bitcast | 344 | 611 | 11 | 0 | 6 | 1 | calls removed | none |
+| convert/ext_sign | 318 | 886 | 15 | 0 | 5 | 1 | calls removed | none |
+| convert/ext_zero | 314 | 854 | 15 | 0 | 5 | 1 | calls removed | none |
+| convert/f2f | 197 | 626 | 11 | 0 | 4 | 1 | calls removed | none |
+| convert/f2i | 801 | 2217 | 54 | 21 | 12 | 4 | calls removed | none |
+| convert/f2u_high | 452 | 1565 | 25 | 0 | 8 | 5 | calls removed | none |
+| convert/i2f | 297 | 2107 | 37 | 4 | 5 | 3 | calls removed | none |
+| convert/trunc | 362 | 521 | 9 | 0 | 6 | 1 | calls removed | none |
+| float/arith_f32 | 2421 | 1971 | 65 | 46 | 6 | 3 | calls removed | -OpFUnordNotEqual 16 -OpSelectionMerge 16 |
+| float/arith_f64 | 2386 | 1940 | 65 | 46 | 6 | 3 | calls removed | -OpFUnordNotEqual 16 -OpSelectionMerge 16 |
+| float/cmp_f32 | 718 | 1296 | 20 | 2 | 6 | 2 | calls removed | +OpFOrdLessThan 1 -OpFUnordNotEqual 2 -OpSelectionMerge 2 |
+| float/cmp_f64 | 714 | 1457 | 26 | 7 | 7 | 4 | calls removed | +OpFConvert 5 +OpFOrdLessThan 1 -OpFUnordNotEqual 2 -OpSelectionMerge 2 |
+| float/special_f32 | 1321 | 1606 | 117 | 84 | 9 | 4 | calls removed | +OpConstant 1 +OpFNegate 1 -OpFUnordNotEqual 16 -OpSelectionMerge 16 -OpTypePointer 1 |
+| float/special_f64 | 1610 | 1761 | 127 | 94 | 11 | 4 | calls removed | -OpFUnordNotEqual 16 -OpSelectionMerge 16 -OpTypePointer 1 |
+| frame/frame_align | 1133 | 1226 | 76 | 21 | 12 | 6 | calls removed | +OpAccessChain 1 -OpCompositeExtract 54 -OpConstant 1 |
+| frame/frame_large | 335 | 934 | 16 | 0 | 5 | 1 | calls removed | +OpAccessChain 3 |
+| frame/frame_spill | 670 | 1407 | 32 | 15 | 6 | 3 | calls removed | none |
+| imm/imm_add | 335 | 1017 | 25 | 8 | 6 | 2 | calls removed | +OpISub 1 |
+| imm/imm_addr | 335 | 1099 | 21 | 4 | 4 | 2 | calls removed | +OpAccessChain 29 |
+| imm/imm_logic | 349 | 1023 | 21 | 4 | 6 | 2 | calls removed | +OpBitwiseOr 2 +OpNot 2 |
+| imm/imm_mov | 181 | 608 | 12 | 0 | 4 | 1 | calls removed | +OpConstant 2 |
+| mem/addr_modes | 902 | 1648 | 36 | 19 | 6 | 2 | calls removed | +OpAccessChain 9 |
+| mem/array_index | 1064 | 1758 | 36 | 15 | 7 | 3 | calls removed | -OpAccessChain 6 |
+| mem/loadstore | 729 | 1125 | 25 | 8 | 11 | 3 | calls removed | none |
+| mem/rec_layout | 435 | 1515 | 50 | 25 | 11 | 7 | calls removed | +OpAccessChain 4 |
+| scalar/arith_i16 | 173 | 771 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_i32 | 173 | 771 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_i64 | 169 | 723 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_i8 | 173 | 771 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_u16 | 179 | 777 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_u32 | 179 | 777 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_u64 | 165 | 675 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/arith_u8 | 179 | 777 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/divrem_i32 | 172 | 770 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/divrem_i64 | 166 | 720 | 13 | 0 | 3 | 1 | calls removed | none |
+| scalar/divrem_u32 | 142 | 572 | 10 | 0 | 3 | 1 | calls removed | none |
+| scalar/divrem_u64 | 133 | 499 | 10 | 0 | 3 | 1 | calls removed | none |
+| scalar/mul_i32 | 149 | 467 | 8 | 0 | 3 | 1 | calls removed | none |
+| scalar/mul_i64 | 146 | 440 | 8 | 0 | 3 | 1 | calls removed | none |
+| scalar/mul_u32 | 175 | 493 | 8 | 0 | 3 | 1 | calls removed | none |
+| scalar/mul_u64 | 162 | 432 | 8 | 0 | 3 | 1 | calls removed | none |
+| vec/autovec_loop | 472 | 841 | 10 | 0 | 4 | 1 | calls removed | none |
+| vec/vec_cmp_i64 | 573 | 514 | 33 | 13 | 6 | 3 | calls removed | -OpCompositeExtract 26 -OpSLessThan 1 -OpSelect 2 |
+| vec/vec_cmp_select | 5507 | 6128 | 169 | 109 | 12 | 7 | calls removed | -OpCompositeConstruct 1 -OpCompositeExtract 68 -OpISub 8 -OpSelect 8 |
+| vec/vec_f32x2 | 476 | 290 | 37 | 16 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 32 |
+| vec/vec_f32x3 | 406 | 308 | 33 | 9 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 27 -OpFAdd 1 -OpFMul 1 |
+| vec/vec_f32x4 | 772 | 418 | 71 | 16 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 64 |
+| vec/vec_f32x5 | 1685 | 1247 | 88 | 16 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 80 |
+| vec/vec_f32x8 | 2632 | 1942 | 139 | 16 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 128 |
+| vec/vec_f64x2 | 472 | 282 | 37 | 16 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 32 |
+| vec/vec_i16x4 | 799 | 428 | 78 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 64 |
+| vec/vec_i16x8 | 2810 | 1948 | 146 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 144 -OpCompositeInsert 8 |
+| vec/vec_i32x4 | 796 | 426 | 78 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 64 |
+| vec/vec_i64x2 | 499 | 300 | 44 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 32 |
+| vec/vec_i8x16 | 161 | 993 | 42 | 25 | 5 | 3 | calls removed | +OpAccessChain 2 |
+| vec/vec_lane_ops | 2766 | 2927 | 107 | 39 | 10 | 6 | calls removed | -OpCompositeExtract 83 |
+| vec/vec_mem | 1187 | 1475 | 78 | 19 | 7 | 4 | calls removed | -OpAccessChain 2 -OpCompositeExtract 58 |
+| vec/vec_scalar_mix | 1050 | 1606 | 67 | 20 | 8 | 5 | calls removed | -OpCompositeExtract 33 |
+| vec/vec_u16x8 | 2808 | 1946 | 146 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 144 -OpCompositeInsert 8 |
+| vec/vec_u32x4 | 747 | 445 | 78 | 23 | 4 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 64 |
+| vec/vec_u64x2 | 500 | 297 | 44 | 23 | 5 | 2 | calls removed | +OpAccessChain 1 -OpCompositeExtract 32 |
+| vec/vec_u8x16 | 161 | 993 | 42 | 25 | 5 | 3 | calls removed | +OpAccessChain 2 |

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -624,3 +624,121 @@ their calls.
 | x86_64-linux | 433 | 297 | 33 | 13 | same | calls removed |
 | aarch64-linux | 269 | 164 | 33 | 13 | larger | calls removed |
 | riscv64-linux | 690 | 679 | 33 | 13 | smaller | calls removed |
+
+## The windows and darwin columns, blessed after the merge
+
+`x86_64-windows`, `x86_64-darwin` and `aarch64-darwin` decode on the pr lane
+but were not re-blessed in #3270, so all 92 layer B cells per column failed
+against `dev` at `da4fe7146` while layer A stayed green (184 pass, 92 fail,
+92 skip on each column before the bless; every failure a `layer b o2` cell).
+The tables below use the same method as the linux ones, computed by comparing
+each blessed golden with its `HEAD` version, except that lines removed and
+added are `git diff --numstat` counts so a reviewer reproduces them with the
+commit's own stat. Every golden's call count before and after is identical to
+its `x86_64-linux` or `aarch64-linux` counterpart, which is what the
+target-independent case contract predicts: the fold sites are the same source
+on every column and each one loses the same calls.
+
+## x86_64-windows: 92 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 92 |
+
+calls before 4337, after 1804, cases reaching zero calls 31
+frame direction: frame larger 15, frame same 28, frame smaller 49
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 133 | 441 | 22 | 5 | calls removed |
+| bits/logic_u64 | 137 | 430 | 22 | 5 | calls removed |
+| bits/shift_i32 | 206 | 471 | 28 | 11 | calls removed |
+| bits/shift_i64 | 183 | 433 | 28 | 11 | calls removed |
+| bits/shift_u32 | 201 | 468 | 27 | 10 | calls removed |
+| bits/shift_u64 | 178 | 430 | 27 | 10 | calls removed |
+| call/call_chain | 797 | 1122 | 172 | 154 | calls removed |
+| call/call_float_regs | 595 | 723 | 87 | 30 | calls removed |
+| call/call_indirect | 666 | 909 | 69 | 24 | calls removed |
+| call/call_int_regs | 907 | 946 | 123 | 24 | calls removed |
+| call/call_mixed | 647 | 1055 | 53 | 35 | calls removed |
+| call/call_rec_edge | 714 | 1044 | 87 | 50 | calls removed |
+| call/call_rec_large | 560 | 1168 | 134 | 97 | calls removed |
+| call/call_rec_small | 612 | 1051 | 71 | 30 | calls removed |
+| call/call_recursive | 580 | 647 | 53 | 13 | calls removed |
+| call/call_ret_large | 1234 | 1979 | 138 | 96 | calls removed |
+| call/call_ret_small | 642 | 1174 | 88 | 42 | calls removed |
+| call/call_variadic | 408 | 966 | 158 | 141 | calls removed |
+| cmp/branch_nest | 142 | 180 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 114 | 232 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 139 | 254 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 114 | 232 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 139 | 254 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 115 | 217 | 6 | 0 | calls removed |
+| cmp/short_circuit | 597 | 606 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 418 | 726 | 54 | 37 | calls removed |
+| convert/bitcast | 47 | 223 | 11 | 0 | calls removed |
+| convert/ext_sign | 83 | 331 | 15 | 0 | calls removed |
+| convert/ext_zero | 83 | 329 | 15 | 0 | calls removed |
+| convert/f2f | 72 | 245 | 11 | 0 | calls removed |
+| convert/f2i | 273 | 874 | 54 | 21 | calls removed |
+| convert/f2u_high | 233 | 684 | 25 | 0 | calls removed |
+| convert/i2f | 288 | 885 | 37 | 4 | calls removed |
+| convert/trunc | 64 | 209 | 9 | 0 | calls removed |
+| float/arith_f32 | 1128 | 909 | 65 | 46 | calls removed |
+| float/arith_f64 | 1120 | 902 | 65 | 46 | calls removed |
+| float/cmp_f32 | 416 | 672 | 20 | 2 | calls removed |
+| float/cmp_f64 | 467 | 943 | 26 | 7 | calls removed |
+| float/special_f32 | 755 | 811 | 117 | 84 | calls removed |
+| float/special_f64 | 833 | 883 | 127 | 94 | calls removed |
+| frame/frame_align | 711 | 781 | 79 | 24 | calls removed |
+| frame/frame_large | 244 | 511 | 16 | 0 | calls removed |
+| frame/frame_spill | 424 | 782 | 32 | 15 | calls removed |
+| imm/imm_add | 119 | 385 | 25 | 8 | calls removed |
+| imm/imm_addr | 232 | 556 | 21 | 4 | calls removed |
+| imm/imm_logic | 115 | 396 | 21 | 4 | calls removed |
+| imm/imm_mov | 92 | 280 | 12 | 0 | calls removed |
+| mem/addr_modes | 673 | 1049 | 36 | 19 | calls removed |
+| mem/array_index | 588 | 1009 | 36 | 15 | calls removed |
+| mem/global_data | 284 | 569 | 35 | 12 | calls removed |
+| mem/global_zero | 329 | 615 | 28 | 7 | calls removed |
+| mem/loadstore | 227 | 572 | 25 | 8 | calls removed |
+| mem/ptr_arith | 308 | 669 | 29 | 8 | calls removed |
+| mem/rec_layout | 849 | 1302 | 50 | 25 | calls removed |
+| mem/uni_layout | 330 | 641 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 101 | 329 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 97 | 325 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 100 | 309 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 101 | 329 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 100 | 328 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 96 | 324 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 100 | 309 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 100 | 328 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 160 | 411 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 145 | 369 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 111 | 292 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 100 | 263 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 65 | 198 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 56 | 179 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 64 | 197 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 57 | 180 | 8 | 0 | calls removed |
+| vec/autovec_loop | 709 | 896 | 10 | 0 | calls removed |
+| vec/vec_cmp_i64 | 484 | 481 | 33 | 13 | calls removed |
+| vec/vec_cmp_select | 824 | 985 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 352 | 280 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 398 | 383 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 566 | 370 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 1905 | 1683 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 2957 | 2419 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 314 | 306 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 516 | 331 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 855 | 434 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 736 | 589 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 436 | 398 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 1311 | 1578 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 1027 | 1036 | 107 | 39 | calls removed |
+| vec/vec_mem | 1842 | 1918 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 825 | 960 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 855 | 434 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 744 | 591 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 436 | 398 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 1343 | 1610 | 42 | 25 | calls removed |

--- a/test/golden/aarch64-darwin/bits/logic_u32.dis
+++ b/test/golden/aarch64-darwin/bits/logic_u32.dis
@@ -5,164 +5,382 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.logic_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x30
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
                	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            ; =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            ; =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	and	w23, w20, w19
-               	mov	x0, x1
-               	mov	w1, w23
+               	eor	w22, w17, w19
+               	and	w0, w19, w20
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	orr	w24, w20, w19
-               	mov	x0, x1
-               	mov	w1, w24
+               	orr	w1, w19, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	eor	w2, w20, w19
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mvn	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	eor	w1, w19, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	w2, w19
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	and	w2, w21, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w19
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	orr	w2, w21, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	eor	w25, w21, w22
-               	mov	x0, x1
-               	mov	w1, w25
+               	mvn	w1, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mvn	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mvn	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	and	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	and	w2, w20, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	orr	w2, w19, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	orr	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	and	w2, w20, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	orr	w2, w19, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	eor	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	orr	w2, w23, w25
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mvn	w2, w24
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w21
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mvn	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mvn	w2, w25
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x23, x0
-               	mov	w24, #0x0               ; =0
-               	cmp	w24, #0x8
-               	b.lo	 <L19>
-               	b	 <L23>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	eor	w25, w20, w24
-               	orr	w0, w19, w24
-               	eor	w1, w22, w24
-               	and	w26, w21, w1
-               	and	w1, w25, w0
-               	mov	x0, x23
+               	and	w1, w19, w21
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	orr	w1, w25, w26
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
 <L21>:
-               	bl	 <L21>
-               	eor	w1, w25, w26
+               	orr	w1, w20, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	and	w1, w19, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	orr	w1, w20, w21
+<L26>:
+               	bl	 <L26>
+               	and	w23, w19, w20
+               	eor	w24, w21, w22
+               	orr	w1, w23, w24
+<L27>:
+               	bl	 <L27>
+               	orr	w1, w19, w20
                	mvn	w2, w1
                	mov	w1, w2
-<L22>:
-               	bl	 <L22>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x8
-               	b.lo	 <L19>
-<L23>:
-               	mov	x0, x23
+<L28>:
+               	bl	 <L28>
+               	mvn	w1, w23
+<L29>:
+               	bl	 <L29>
+               	mvn	w1, w24
+<L30>:
+               	bl	 <L30>
+               	mov	w1, #0x0                ; =0
+               	cmp	w1, #0x8
+               	b.lo	 <L31>
+               	b	 <L38>
+<L31>:
+               	eor	w2, w19, w1
+               	orr	w3, w20, w1
+               	eor	w4, w22, w1
+               	and	w5, w21, w4
+               	and	w4, w2, w3
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x3, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	orr	w3, w2, w5
+               	mov	w6, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x3, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	eor	w3, w2, w5
+               	mvn	w2, w3
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	w1, w1, #0x1
+               	mov	x0, x4
+               	cmp	w1, #0x8
+               	b.lo	 <L31>
+<L38>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
                	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/bits/logic_u64.dis
+++ b/test/golden/aarch64-darwin/bits/logic_u64.dis
@@ -5,15 +5,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.logic_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x30
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
                	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,145 +25,354 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	and	x23, x19, x20
-               	mov	x0, x1
-               	mov	x1, x23
+               	and	x0, x19, x20
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	orr	x24, x19, x20
-               	mov	x0, x1
-               	mov	x1, x24
+               	orr	x0, x19, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	eor	x2, x19, x20
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mvn	x2, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	eor	x0, x19, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	x2, x20
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	and	x2, x21, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mvn	x0, x19
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	orr	x2, x21, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	eor	x25, x21, x22
-               	mov	x0, x1
-               	mov	x1, x25
+               	mvn	x0, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mvn	x2, x21
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mvn	x2, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	and	x0, x21, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	and	x2, x19, x21
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	orr	x2, x20, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	orr	x0, x21, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	and	x2, x19, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	eor	x0, x21, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mvn	x0, x21
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mvn	x0, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	and	x0, x19, x21
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	orr	x0, x20, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	and	x0, x19, x22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	orr	x2, x20, x21
                	mov	x0, x1
                	mov	x1, x2
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	orr	x2, x23, x25
-               	mov	x0, x1
-               	mov	x1, x2
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mvn	x2, x24
-               	mov	x0, x1
-               	mov	x1, x2
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mvn	x2, x23
-               	mov	x0, x1
-               	mov	x1, x2
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mvn	x2, x25
-               	mov	x0, x1
-               	mov	x1, x2
-<L18>:
-               	bl	 <L18>
-               	mov	x23, x0
-               	mov	x24, #0x0               ; =0
-               	cmp	x24, #0x8
-               	b.lo	 <L19>
-               	b	 <L23>
-<L19>:
-               	eor	x25, x19, x24
-               	orr	x0, x20, x24
-               	eor	x1, x22, x24
-               	and	x26, x21, x1
-               	and	x1, x25, x0
-               	mov	x0, x23
-<L20>:
-               	bl	 <L20>
-               	orr	x1, x25, x26
-<L21>:
-               	bl	 <L21>
-               	eor	x1, x25, x26
+<L26>:
+               	bl	 <L26>
+               	and	x23, x19, x20
+               	eor	x24, x21, x22
+               	orr	x1, x23, x24
+<L27>:
+               	bl	 <L27>
+               	orr	x1, x19, x20
                	mvn	x2, x1
                	mov	x1, x2
-<L22>:
-               	bl	 <L22>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x8
-               	b.lo	 <L19>
-<L23>:
-               	mov	x0, x23
+<L28>:
+               	bl	 <L28>
+               	mvn	x1, x23
+<L29>:
+               	bl	 <L29>
+               	mvn	x1, x24
+<L30>:
+               	bl	 <L30>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L31>
+               	b	 <L38>
+<L31>:
+               	eor	x2, x19, x1
+               	orr	x3, x20, x1
+               	eor	x4, x22, x1
+               	and	x5, x21, x4
+               	and	x4, x2, x3
+               	mov	x3, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x3, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	orr	x4, x2, x5
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x3, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	eor	x4, x2, x5
+               	mvn	x2, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x8
+               	b.lo	 <L31>
+<L38>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
                	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/bits/shift_i32.dis
+++ b/test/golden/aarch64-darwin/bits/shift_i32.dis
@@ -5,196 +5,404 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.shift_i32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            ; =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            ; =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	mov	x0, x1
-               	mov	w1, w19
+               	eor	w22, w17, w19
+               	sxtw	x0, w20
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w20, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	lsl	w0, w20, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	asr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	asr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtw	x0, w20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	asr	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w20, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	asr	w2, w21, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsl	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w20, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	asr	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsl	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w21, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	asr	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w21, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	asr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w21, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	asr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w22, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	asr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	w2, w21, #0
+               	asr	w2, w22, #1
                	mov	x0, x1
                	mov	w1, w2
 <L20>:
                	bl	 <L20>
-               	mov	x1, x0
-               	asr	w2, w21, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w1, w19, #5
 <L21>:
                	bl	 <L21>
-               	mov	x23, x0
-               	mov	w24, #0x0               ; =0
-               	cmp	w24, #0x20
-               	b.lo	 <L22>
-               	b	 <L27>
+               	asr	w1, w19, #5
 <L22>:
-               	lsl	w1, w19, w24
-               	mov	x0, x23
+               	bl	 <L22>
+               	lsr	w1, w20, #0
 <L23>:
                	bl	 <L23>
-               	asr	w1, w19, w24
+               	asr	w1, w20, #0
 <L24>:
                	bl	 <L24>
-               	add	w25, w24, w20
-               	lsl	w1, w21, w25
+               	lsl	w1, w20, #1
 <L25>:
                	bl	 <L25>
-               	asr	w1, w22, w25
+               	asr	w1, w20, #1
 <L26>:
                	bl	 <L26>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x20
-               	b.lo	 <L22>
+               	lsl	w1, w20, #31
 <L27>:
-               	mov	w21, #0x1e              ; =30
-               	cmp	w21, #0x28
-               	b.lo	 <L28>
-               	b	 <L31>
+               	bl	 <L27>
+               	asr	w1, w20, #31
 <L28>:
-               	add	w22, w21, w20
-               	lsl	w1, w19, w22
-               	mov	x0, x23
+               	bl	 <L28>
+               	lsr	w1, w21, #0
 <L29>:
                	bl	 <L29>
-               	asr	w1, w19, w22
+               	asr	w1, w21, #31
 <L30>:
                	bl	 <L30>
-               	add	w21, w21, #0x1
-               	mov	x23, x0
-               	cmp	w21, #0x28
-               	b.lo	 <L28>
+               	mov	w1, #0x0                ; =0
+               	cmp	w1, #0x20
+               	b.lo	 <L31>
+               	b	 <L40>
 <L31>:
-               	mov	x0, x23
+               	lsl	w2, w20, w1
+               	sxtw	x3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	asr	w3, w20, w1
+               	sxtw	x4, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	w3, w1, w19
+               	lsl	w4, w21, w3
+               	sxtw	x3, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	w3, w1, w19
+               	asr	w4, w22, w3
+               	sxtw	x3, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0x20
+               	b.lo	 <L31>
+<L40>:
+               	mov	w1, #0x1e               ; =30
+               	cmp	w1, #0x28
+               	b.lo	 <L41>
+               	b	 <L46>
+<L41>:
+               	add	w2, w1, w19
+               	lsl	w3, w20, w2
+               	sxtw	x2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	add	w2, w1, w19
+               	asr	w4, w20, w2
+               	sxtw	x2, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L44>
+<L45>:
+               	add	w1, w1, #0x1
+               	mov	x0, x3
+               	cmp	w1, #0x28
+               	b.lo	 <L41>
+<L46>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/bits/shift_i64.dis
+++ b/test/golden/aarch64-darwin/bits/shift_i64.dis
@@ -5,15 +5,10 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.shift_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,177 +24,373 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x20, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	lsl	x1, x20, #63
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	asr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	asr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	asr	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x20, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	asr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsl	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x20, #63
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	asr	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsl	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x21, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	asr	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x21, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	asr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x21, #63
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	asr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x22, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	asr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	x2, x21, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x22, #1
 <L20>:
                	bl	 <L20>
-               	mov	x1, x0
-               	asr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x19, #5
 <L21>:
                	bl	 <L21>
-               	mov	x23, x0
-               	mov	x24, #0x0               ; =0
-               	cmp	x24, #0x40
-               	b.lo	 <L22>
-               	b	 <L27>
+               	asr	x1, x19, #5
 <L22>:
-               	lsl	x1, x20, x24
-               	mov	x0, x23
+               	bl	 <L22>
+               	lsr	x1, x20, #0
 <L23>:
                	bl	 <L23>
-               	asr	x1, x20, x24
+               	asr	x1, x20, #0
 <L24>:
                	bl	 <L24>
-               	add	x25, x24, x19
-               	lsl	x1, x21, x25
+               	lsl	x1, x20, #1
 <L25>:
                	bl	 <L25>
-               	asr	x1, x22, x25
+               	asr	x1, x20, #1
 <L26>:
                	bl	 <L26>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L22>
+               	lsl	x1, x20, #63
 <L27>:
-               	mov	x21, #0x3c              ; =60
-               	cmp	x21, #0x48
-               	b.lo	 <L28>
-               	b	 <L31>
+               	bl	 <L27>
+               	asr	x1, x20, #63
 <L28>:
-               	add	x22, x21, x19
-               	lsl	x1, x20, x22
-               	mov	x0, x23
+               	bl	 <L28>
+               	lsr	x1, x21, #0
 <L29>:
                	bl	 <L29>
-               	asr	x1, x20, x22
+               	asr	x1, x21, #63
 <L30>:
                	bl	 <L30>
-               	add	x21, x21, #0x1
-               	mov	x23, x0
-               	cmp	x21, #0x48
-               	b.lo	 <L28>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x40
+               	b.lo	 <L31>
+               	b	 <L40>
 <L31>:
-               	mov	x0, x23
+               	lsl	x2, x20, x1
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	asr	x2, x20, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	x2, x1, x19
+               	lsl	x4, x21, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x2, x1, x19
+               	asr	x4, x22, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x40
+               	b.lo	 <L31>
+<L40>:
+               	mov	x1, #0x3c               ; =60
+               	cmp	x1, #0x48
+               	b.lo	 <L41>
+               	b	 <L46>
+<L41>:
+               	add	x2, x1, x19
+               	lsl	x3, x20, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	add	x3, x1, x19
+               	asr	x4, x20, x3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L44>
+<L45>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x48
+               	b.lo	 <L41>
+<L46>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/bits/shift_u32.dis
+++ b/test/golden/aarch64-darwin/bits/shift_u32.dis
@@ -5,190 +5,401 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.shift_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            ; =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            ; =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	mov	x0, x1
-               	mov	w1, w19
+               	eor	w22, w17, w19
+               	mov	w0, w20
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w20, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	lsl	w0, w20, #31
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	lsr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	lsr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w0, w20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	lsr	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w20, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	lsl	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsr	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w20, #31
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	lsl	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsr	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w21, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w21, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w22, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w22, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	lsr	w2, w21, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	w2, w21, #31
+               	lsl	w2, w19, #5
                	mov	x0, x1
                	mov	w1, w2
 <L20>:
                	bl	 <L20>
-               	mov	x23, x0
-               	mov	w24, #0x0               ; =0
-               	cmp	w24, #0x20
-               	b.lo	 <L21>
-               	b	 <L26>
+               	lsr	w1, w19, #5
 <L21>:
-               	lsl	w1, w19, w24
-               	mov	x0, x23
+               	bl	 <L21>
+               	lsr	w1, w20, #0
 <L22>:
                	bl	 <L22>
-               	lsr	w1, w19, w24
+               	lsr	w1, w20, #0
 <L23>:
                	bl	 <L23>
-               	add	w25, w24, w20
-               	lsl	w1, w21, w25
+               	lsl	w1, w20, #1
 <L24>:
                	bl	 <L24>
-               	lsr	w1, w22, w25
+               	lsr	w1, w20, #1
 <L25>:
                	bl	 <L25>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x20
-               	b.lo	 <L21>
+               	lsl	w1, w20, #31
 <L26>:
-               	mov	w21, #0x1e              ; =30
-               	cmp	w21, #0x28
-               	b.lo	 <L27>
-               	b	 <L30>
+               	bl	 <L26>
+               	lsr	w1, w20, #31
 <L27>:
-               	add	w22, w21, w20
-               	lsl	w1, w19, w22
-               	mov	x0, x23
+               	bl	 <L27>
+               	lsr	w1, w21, #0
 <L28>:
                	bl	 <L28>
-               	lsr	w1, w19, w22
+               	lsr	w1, w21, #31
 <L29>:
                	bl	 <L29>
-               	add	w21, w21, #0x1
-               	mov	x23, x0
-               	cmp	w21, #0x28
-               	b.lo	 <L27>
+               	mov	w1, #0x0                ; =0
+               	cmp	w1, #0x20
+               	b.lo	 <L30>
+               	b	 <L39>
 <L30>:
-               	mov	x0, x23
+               	lsl	w2, w20, w1
+               	mov	w3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	lsr	w3, w20, w1
+               	mov	w4, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	add	w3, w1, w19
+               	lsl	w4, w21, w3
+               	mov	w3, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	add	w3, w1, w19
+               	lsr	w4, w22, w3
+               	mov	w3, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0x20
+               	b.lo	 <L30>
+<L39>:
+               	mov	w1, #0x1e               ; =30
+               	cmp	w1, #0x28
+               	b.lo	 <L40>
+               	b	 <L45>
+<L40>:
+               	add	w2, w1, w19
+               	lsl	w3, w20, w2
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	add	w2, w1, w19
+               	lsr	w4, w20, w2
+               	mov	w2, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	w1, w1, #0x1
+               	mov	x0, x3
+               	cmp	w1, #0x28
+               	b.lo	 <L40>
+<L45>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/bits/shift_u64.dis
+++ b/test/golden/aarch64-darwin/bits/shift_u64.dis
@@ -5,15 +5,10 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.bits.shift_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,171 +24,370 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x20, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	lsl	x1, x20, #63
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	lsr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	lsr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	lsr	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x20, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	lsl	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsr	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x20, #63
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	lsl	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsr	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x21, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x21, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x22, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x22, #1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	lsr	x2, x21, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x19, #5
 <L20>:
                	bl	 <L20>
-               	mov	x23, x0
-               	mov	x24, #0x0               ; =0
-               	cmp	x24, #0x40
-               	b.lo	 <L21>
-               	b	 <L26>
+               	lsr	x1, x19, #5
 <L21>:
-               	lsl	x1, x20, x24
-               	mov	x0, x23
+               	bl	 <L21>
+               	lsr	x1, x20, #0
 <L22>:
                	bl	 <L22>
-               	lsr	x1, x20, x24
+               	lsr	x1, x20, #0
 <L23>:
                	bl	 <L23>
-               	add	x25, x24, x19
-               	lsl	x1, x21, x25
+               	lsl	x1, x20, #1
 <L24>:
                	bl	 <L24>
-               	lsr	x1, x22, x25
+               	lsr	x1, x20, #1
 <L25>:
                	bl	 <L25>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L21>
+               	lsl	x1, x20, #63
 <L26>:
-               	mov	x21, #0x3c              ; =60
-               	cmp	x21, #0x48
-               	b.lo	 <L27>
-               	b	 <L30>
+               	bl	 <L26>
+               	lsr	x1, x20, #63
 <L27>:
-               	add	x22, x21, x19
-               	lsl	x1, x20, x22
-               	mov	x0, x23
+               	bl	 <L27>
+               	lsr	x1, x21, #0
 <L28>:
                	bl	 <L28>
-               	lsr	x1, x20, x22
+               	lsr	x1, x21, #63
 <L29>:
                	bl	 <L29>
-               	add	x21, x21, #0x1
-               	mov	x23, x0
-               	cmp	x21, #0x48
-               	b.lo	 <L27>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x40
+               	b.lo	 <L30>
+               	b	 <L39>
 <L30>:
-               	mov	x0, x23
+               	lsl	x2, x20, x1
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	lsr	x2, x20, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	add	x2, x1, x19
+               	lsl	x4, x21, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	add	x2, x1, x19
+               	lsr	x4, x22, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x40
+               	b.lo	 <L30>
+<L39>:
+               	mov	x1, #0x3c               ; =60
+               	cmp	x1, #0x48
+               	b.lo	 <L40>
+               	b	 <L45>
+<L40>:
+               	add	x2, x1, x19
+               	lsl	x3, x20, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	add	x3, x1, x19
+               	lsr	x4, x20, x3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x48
+               	b.lo	 <L40>
+<L45>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_chain.dis
+++ b/test/golden/aarch64-darwin/call/call_chain.dis
@@ -40,15 +40,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_chain.burn>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
-               	stp	x19, x20, [x29, #-0x20]
-               	stp	x21, x22, [x29, #-0x30]
-               	stp	x23, x24, [x29, #-0x40]
-               	stp	x25, x26, [x29, #-0x50]
-               	stp	x27, x28, [x29, #-0x60]
-               	stp	d8, d9, [x29, #-0x70]
-               	stp	d10, d11, [x29, #-0x80]
-               	stp	d12, d13, [x29, #-0x90]
+               	sub	sp, sp, #0x10
+               	stp	x19, x20, [x29, #-0x10]
                	mov	x16, #0x1               ; =1
                	eor	x1, x0, x16
                	mov	x16, #0x3               ; =3
@@ -115,95 +108,128 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x0
                	fmov	s30, #4.00000000
                	fdiv	s6, s0, s30
-               	mov	x20, x1
-               	mov	x21, x3
-               	mov	x22, x4
-               	mov	x23, x6
-               	mov	x24, x5
-               	mov	x25, x8
-               	mov	x26, x7
-               	mov	x27, x12
-               	mov	x28, x14
-               	mov	x9, x13
-               	stur	x9, [x29, #-0x8]
-               	mov	x9, x15
-               	stur	x9, [x29, #-0x10]
-               	fmov	d8, d1
-               	fmov	d9, d2
-               	fmov	d10, d3
-               	fmov	d11, d4
-               	fmov	d12, d5
-               	fmov	d13, d6
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x6
                	b.lo	 <L0>
                	b	 <L1>
 <L0>:
-               	add	x20, x20, x21
-               	eor	x21, x21, x22
-               	add	x22, x22, x23
-               	eor	x23, x23, x24
-               	add	x24, x24, x25
-               	eor	x25, x25, x26
-               	add	x26, x26, x27
-               	eor	x27, x27, x28
-               	ldur	x9, [x29, #-0x8]
-               	add	x28, x28, x9
-               	ldur	x9, [x29, #-0x8]
-               	eor	x2, x9, x19
-               	ldur	x9, [x29, #-0x10]
-               	add	x19, x19, x9
-               	ldur	x9, [x29, #-0x10]
-               	eor	x3, x9, x20
-               	fadd	d8, d8, d9
-               	fsub	d9, d9, d10
-               	fadd	d10, d10, d8
-               	fadd	s11, s11, s12
-               	fsub	s12, s12, s13
-               	fadd	s13, s13, s11
+               	add	x1, x1, x3
+               	eor	x3, x3, x4
+               	add	x4, x4, x6
+               	eor	x6, x6, x5
+               	add	x5, x5, x8
+               	eor	x8, x8, x7
+               	add	x7, x7, x12
+               	eor	x12, x12, x14
+               	add	x14, x14, x13
+               	eor	x13, x13, x19
+               	add	x19, x19, x15
+               	eor	x15, x15, x1
+               	fadd	d1, d1, d2
+               	fsub	d2, d2, d3
+               	fadd	d3, d3, d1
+               	fadd	s4, s4, s5
+               	fsub	s5, s5, s6
+               	fadd	s6, s6, s4
                	add	x0, x0, #0x1
-               	mov	x9, x2
-               	stur	x9, [x29, #-0x8]
-               	mov	x9, x3
-               	stur	x9, [x29, #-0x10]
                	cmp	x0, #0x6
                	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	eor	x1, x20, x21
-               	eor	x4, x1, x22
-               	eor	x1, x4, x23
-               	eor	x4, x1, x24
-               	eor	x1, x4, x25
+               	eor	x0, x1, x3
+               	eor	x1, x0, x4
+               	eor	x0, x1, x6
+               	eor	x1, x0, x5
+               	eor	x0, x1, x8
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	eor	x1, x26, x27
-               	eor	x4, x1, x28
-               	ldur	x9, [x29, #-0x8]
-               	eor	x1, x4, x9
-               	eor	x2, x1, x19
-               	ldur	x9, [x29, #-0x10]
-               	eor	x1, x2, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	fadd	d0, d8, d9
-               	fadd	d1, d0, d10
-               	fmov	d0, d1
+               	eor	x0, x7, x12
+               	eor	x2, x0, x14
+               	eor	x0, x2, x13
+               	eor	x2, x0, x19
+               	eor	x0, x2, x15
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fadd	s0, s11, s12
-               	fadd	s1, s0, s13
-               	fmov	s0, s1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ldp	d8, d9, [x29, #-0x70]
-               	ldp	d10, d11, [x29, #-0x80]
-               	ldp	d12, d13, [x29, #-0x90]
-               	ldp	x19, x20, [x29, #-0x20]
-               	ldp	x21, x22, [x29, #-0x30]
-               	ldp	x23, x24, [x29, #-0x40]
-               	ldp	x25, x26, [x29, #-0x50]
-               	ldp	x27, x28, [x29, #-0x60]
+               	fadd	d0, d1, d2
+               	fadd	d1, d0, d3
+               	fmov	x0, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fadd	s0, s4, s5
+               	fadd	s1, s0, s6
+               	fmov	w0, s1
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x0, x1
+               	ldp	x19, x20, [x29, #-0x10]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -296,106 +322,295 @@ Disassembly of section __TEXT,__text:
                	fdiv	s13, s0, s30
                	mov	x17, #0x0               ; =0
                	cmp	x17, x19
-               	b.lo	 <L2>
+               	b.lo	 <L3>
                	mov	x0, x20
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x21
+               	mov	x1, x21
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x9, x0
-               	stur	x9, [x29, #-0x30]
-               	b	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x2, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x1, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x12, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
+               	mov	x9, x1
+               	stur	x9, [x29, #-0x30]
+               	b	 <L5>
+<L3>:
                	sub	x0, x19, #0x1
                	mov	x16, #0x3               ; =3
                	mul	x1, x20, x16
                	add	x2, x1, x19
                	mov	x1, x2
                	mov	x2, x21
-<L3>:
-               	bl	 <L3>
+<L4>:
+               	bl	 <L4>
                	mov	x9, x0
                	stur	x9, [x29, #-0x30]
-<L4>:
-               	ldur	x9, [x29, #-0x30]
-               	mov	x0, x9
-               	mov	x1, x22
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x23
+               	ldur	x9, [x29, #-0x30]
+               	mov	x8, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x22, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x26
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x23, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x27
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x28
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x24, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x25, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0x18]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x26, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x27, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x28, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x8]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x10]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x18]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x20]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x8
                	ldur	x9, [x29, #-0x28]
                	mov	x1, x9
-<L16>:
-               	bl	 <L16>
-               	fmov	d0, d8
-<L17>:
-               	bl	 <L17>
-               	fmov	d0, d9
-<L18>:
-               	bl	 <L18>
-               	fmov	d0, d10
-<L19>:
-               	bl	 <L19>
-               	fmov	s0, s11
-<L20>:
-               	bl	 <L20>
-               	fmov	s0, s12
-<L21>:
-               	bl	 <L21>
-               	fmov	s0, s13
-<L22>:
-               	bl	 <L22>
+<L28>:
+               	bl	 <L28>
+               	fmov	x1, d8
+<L29>:
+               	bl	 <L29>
+               	fmov	x1, d9
+<L30>:
+               	bl	 <L30>
+               	fmov	x1, d10
+<L31>:
+               	bl	 <L31>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
+<L33>:
+               	bl	 <L33>
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
                	fadd	d0, d8, d9
                	fsub	d1, d0, d10
-               	fmov	d0, d1
-<L23>:
-               	bl	 <L23>
+               	fmov	x1, d1
+<L35>:
+               	bl	 <L35>
                	fadd	s0, s11, s12
                	fsub	s1, s0, s13
-               	fmov	s0, s1
-<L24>:
-               	bl	 <L24>
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
                	eor	x1, x22, x27
                	ldur	x9, [x29, #-0x28]
                	eor	x2, x1, x9
                	mov	x1, x2
-<L25>:
-               	bl	 <L25>
+<L37>:
+               	bl	 <L37>
                	ldp	d8, d9, [x29, #-0x90]
                	ldp	d10, d11, [x29, #-0xa0]
                	ldp	d12, d13, [x29, #-0xb0]
@@ -450,10 +665,12 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x22
 <L4>:
                	bl	 <L4>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	fmov	s0, s9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	ldp	d8, d9, [x29, #-0x30]
@@ -543,10 +760,12 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x27
 <L4>:
                	bl	 <L4>
-               	fmov	d0, d11
+               	fmov	x1, d11
 <L5>:
                	bl	 <L5>
-               	fmov	s0, s12
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	mov	x1, x20
@@ -564,13 +783,15 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x24
 <L11>:
                	bl	 <L11>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L12>:
                	bl	 <L12>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L13>:
                	bl	 <L13>
-               	fmov	s0, s10
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	eor	x1, x20, x24
@@ -726,10 +947,12 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L4>:
                	bl	 <L4>
-               	ldur	d0, [x29, #-0x40]
+               	ldur	x1, [x29, #-0x40]
 <L5>:
                	bl	 <L5>
-               	ldur	s0, [x29, #-0x50]
+               	ldur	w1, [x29, #-0x50]
+               	mov	w5, w1
+               	mov	x1, x5
 <L6>:
                	bl	 <L6>
                	mov	x1, x27
@@ -750,13 +973,15 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	fmov	d0, d13
+               	fmov	x1, d13
 <L12>:
                	bl	 <L12>
-               	fmov	d0, d14
+               	fmov	x1, d14
 <L13>:
                	bl	 <L13>
-               	fmov	s0, s15
+               	fmov	w1, s15
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	ldur	x9, [x29, #-0x18]
@@ -784,19 +1009,23 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x26
 <L22>:
                	bl	 <L22>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L23>:
                	bl	 <L23>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L24>:
                	bl	 <L24>
-               	fmov	d0, d10
+               	fmov	x1, d10
 <L25>:
                	bl	 <L25>
-               	fmov	s0, s11
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L26>:
                	bl	 <L26>
-               	fmov	s0, s12
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
                	bl	 <L27>
                	add	x1, x20, x23
@@ -1031,10 +1260,12 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L4>:
                	bl	 <L4>
-               	ldur	d0, [x29, #-0xd8]
+               	ldur	x1, [x29, #-0xd8]
 <L5>:
                	bl	 <L5>
-               	ldur	s0, [x29, #-0xe8]
+               	ldur	w1, [x29, #-0xe8]
+               	mov	w19, w1
+               	mov	x1, x19
 <L6>:
                	bl	 <L6>
                	ldur	x9, [x29, #-0x80]
@@ -1057,13 +1288,15 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	ldur	d0, [x29, #-0xa8]
+               	ldur	x1, [x29, #-0xa8]
 <L12>:
                	bl	 <L12>
-               	ldur	d0, [x29, #-0xb8]
+               	ldur	x1, [x29, #-0xb8]
 <L13>:
                	bl	 <L13>
-               	ldur	s0, [x29, #-0xc8]
+               	ldur	w1, [x29, #-0xc8]
+               	mov	w13, w1
+               	mov	x1, x13
 <L14>:
                	bl	 <L14>
                	ldur	x9, [x29, #-0x80]
@@ -1099,19 +1332,23 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	fmov	d0, d12
+               	fmov	x1, d12
 <L23>:
                	bl	 <L23>
-               	fmov	d0, d13
+               	fmov	x1, d13
 <L24>:
                	bl	 <L24>
-               	fmov	d0, d14
+               	fmov	x1, d14
 <L25>:
                	bl	 <L25>
-               	fmov	s0, s15
+               	fmov	w1, s15
+               	mov	w3, w1
+               	mov	x1, x3
 <L26>:
                	bl	 <L26>
-               	ldur	s0, [x29, #-0x78]
+               	ldur	w1, [x29, #-0x78]
+               	mov	w3, w1
+               	mov	x1, x3
 <L27>:
                	bl	 <L27>
                	ldur	x9, [x29, #-0x38]
@@ -1149,16 +1386,20 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L37>:
                	bl	 <L37>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L38>:
                	bl	 <L38>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L39>:
                	bl	 <L39>
-               	fmov	s0, s10
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L40>:
                	bl	 <L40>
-               	fmov	s0, s11
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L41>:
                	bl	 <L41>
                	eor	x1, x20, x24
@@ -1182,20 +1423,17 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_chain.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1c0
-               	stp	x19, x20, [x29, #-0x140]
-               	stp	x21, x22, [x29, #-0x150]
-               	stp	x23, x24, [x29, #-0x160]
-               	stp	x25, x26, [x29, #-0x170]
-               	stp	x27, x28, [x29, #-0x180]
-               	stp	d8, d9, [x29, #-0x190]
-               	stp	d10, d11, [x29, #-0x1a0]
-               	stp	d12, d13, [x29, #-0x1b0]
-               	stp	d14, d15, [x29, #-0x1c0]
+               	sub	sp, sp, #0x1d0
+               	stp	x19, x20, [x29, #-0x150]
+               	stp	x21, x22, [x29, #-0x160]
+               	stp	x23, x24, [x29, #-0x170]
+               	stp	x25, x26, [x29, #-0x180]
+               	stp	x27, x28, [x29, #-0x190]
+               	stp	d8, d9, [x29, #-0x1a0]
+               	stp	d10, d11, [x29, #-0x1b0]
+               	stp	d12, d13, [x29, #-0x1c0]
+               	stp	d14, d15, [x29, #-0x1d0]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x2, x0
                	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1205,9 +1443,9 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x28]
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1217,35 +1455,39 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x1, x16
-               	add	x1, x3, x19
-               	add	x3, x20, x0, lsl #3
-               	str	x1, [x3]
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x10              ; =16
                	add	x0, x17, x19
                	add	x1, x20, #0x0
-               	ldr	x3, [x1]
-               	mov	x1, x3
-<L3>:
-               	bl	 <L3>
+               	ldr	x2, [x1]
+               	mov	x1, x2
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+<L2>:
+               	bl	 <L2>
                	mov	x2, x0
                	mov	x17, #0x1               ; =1
                	add	x0, x17, x19
                	add	x1, x20, #0x8
                	ldr	x3, [x1]
                	mov	x1, x3
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L5>
-               	b	 <L49>
-<L5>:
+               	b.lo	 <L4>
+               	b	 <L48>
+<L4>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x0, x1, x19
@@ -1264,13 +1506,13 @@ Disassembly of section __TEXT,__text:
                	eor	x28, x0, x16
                	mov	x16, #0x35              ; =53
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0x80]
+               	stur	x9, [x29, #-0x90]
                	add	x9, x1, #0x3b
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x98]
                	mov	x16, #0x3d              ; =61
                	mul	x1, x0, x16
                	add	x9, x1, #0x4
-               	stur	x9, [x29, #-0x90]
+               	stur	x9, [x29, #-0xa0]
                	lsr	x1, x0, #8
                	mov	x16, #0x3ff             ; =1023
                	and	x5, x1, x16
@@ -1301,26 +1543,26 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0xd               ; =13
                	mul	x1, x0, x16
                	add	x9, x1, #0x3
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0xa8]
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0xa0]
+               	stur	x9, [x29, #-0xb0]
                	mvn	x1, x0
                	mov	x16, #0x3               ; =3
                	mul	x9, x1, x16
-               	stur	x9, [x29, #-0xa8]
+               	stur	x9, [x29, #-0xb8]
                	add	x9, x0, #0x11
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0xc0]
                	mov	x16, #0x13              ; =19
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0xb8]
+               	stur	x9, [x29, #-0xc8]
                	mov	x16, #0x5678            ; =22136
                	movk	x16, #0x1234, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0xc0]
+               	stur	x9, [x29, #-0xd0]
                	add	x9, x0, #0x17
-               	stur	x9, [x29, #-0xc8]
+               	stur	x9, [x29, #-0xd8]
                	lsr	x1, x0, #6
                	mov	x16, #0x3ff             ; =1023
                	and	x15, x1, x16
@@ -1351,13 +1593,13 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x15
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	stur	s31, [x29, #-0xd8]
+               	stur	s31, [x29, #-0xe8]
                	add	x9, x0, #0x1d
                	stur	x9, [x29, #-0x58]
                	ldur	x10, [x29, #-0x58]
                	mov	x16, #0xb               ; =11
                	eor	x9, x10, x16
-               	stur	x9, [x29, #-0xe0]
+               	stur	x9, [x29, #-0xf0]
                	ldur	x9, [x29, #-0x58]
                	mov	x16, #0x5               ; =5
                	mul	x0, x9, x16
@@ -1383,7 +1625,7 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	stur	d31, [x29, #-0xf0]
+               	stur	d31, [x29, #-0x100]
                	ldur	x9, [x29, #-0x58]
                	lsr	x0, x9, #14
                	mov	x16, #0x3ff             ; =1023
@@ -1391,7 +1633,11 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	stur	d31, [x29, #-0x100]
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	ldur	x9, [x29, #-0x58]
                	lsr	x0, x9, #21
                	mov	x16, #0xff              ; =255
@@ -1399,7 +1645,7 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x1
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1426,7 +1672,7 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1438,7 +1684,7 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x1
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1446,198 +1692,218 @@ Disassembly of section __TEXT,__text:
                	ldur	x9, [x29, #-0x78]
                	mov	x16, #0x3039            ; =12345
                	eor	x0, x9, x16
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	mov	x1, x0
                	mov	x0, x21
+<L6>:
+               	bl	 <L6>
+               	ldur	x9, [x29, #-0x60]
+               	mov	x1, x9
 <L7>:
                	bl	 <L7>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0x68]
+               	ldur	x9, [x29, #-0x70]
                	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	ldur	x9, [x29, #-0x70]
-               	mov	x1, x9
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d0, [x29, x16]
-<L11>:
-               	bl	 <L11>
                	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
+               	ldr	x1, [x29, x16]
+<L10>:
+               	bl	 <L10>
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	mov	w9, w1
+               	stur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x80]
+               	mov	x1, x9
+<L11>:
+               	bl	 <L11>
+               	ldur	x9, [x29, #-0xf0]
+               	mov	x1, x9
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x50]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x50]
-               	mov	x1, x9
+               	ldur	x1, [x29, #-0x100]
 <L17>:
                	bl	 <L17>
-               	ldur	d0, [x29, #-0xf0]
-<L18>:
-               	bl	 <L18>
-               	ldur	d0, [x29, #-0x100]
-<L19>:
-               	bl	 <L19>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0xe0]
+               	ldr	x1, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	mov	w9, w1
+               	stur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x88]
+               	mov	x1, x9
+<L19>:
+               	bl	 <L19>
+               	ldur	x9, [x29, #-0xf0]
                	ldur	x10, [x29, #-0x50]
                	eor	x1, x9, x10
+<L20>:
+               	bl	 <L20>
+               	ldur	x9, [x29, #-0xa8]
+               	mov	x1, x9
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0x98]
+               	ldur	x9, [x29, #-0xb0]
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0xa0]
+               	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xc8]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0xb8]
+               	ldur	x9, [x29, #-0xd0]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xd8]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0xc8]
-               	mov	x1, x9
+               	fmov	x1, d12
 <L28>:
                	bl	 <L28>
-               	fmov	d0, d12
+               	fmov	x1, d13
 <L29>:
                	bl	 <L29>
-               	fmov	d0, d13
+               	fmov	x1, d14
 <L30>:
                	bl	 <L30>
-               	fmov	d0, d14
+               	fmov	w1, s15
+               	mov	w6, w1
+               	mov	x1, x6
 <L31>:
                	bl	 <L31>
-               	fmov	s0, s15
+               	ldur	w1, [x29, #-0xe8]
+               	mov	w6, w1
+               	mov	x1, x6
 <L32>:
                	bl	 <L32>
-               	ldur	s0, [x29, #-0xd8]
-<L33>:
-               	bl	 <L33>
-               	ldur	x9, [x29, #-0x98]
-               	ldur	x10, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xa8]
+               	ldur	x10, [x29, #-0xc0]
                	add	x1, x9, x10
-               	ldur	x9, [x29, #-0xc8]
+               	ldur	x9, [x29, #-0xd8]
                	add	x5, x1, x9
                	mov	x1, x5
+<L33>:
+               	bl	 <L33>
+               	mov	x1, x23
 <L34>:
                	bl	 <L34>
-               	mov	x1, x23
+               	mov	x1, x24
 <L35>:
                	bl	 <L35>
-               	mov	x1, x24
+               	mov	x1, x25
 <L36>:
                	bl	 <L36>
-               	mov	x1, x25
+               	mov	x1, x26
 <L37>:
                	bl	 <L37>
-               	mov	x1, x26
+               	mov	x1, x27
 <L38>:
                	bl	 <L38>
-               	mov	x1, x27
+               	mov	x1, x28
 <L39>:
                	bl	 <L39>
-               	mov	x1, x28
+               	ldur	x9, [x29, #-0x90]
+               	mov	x1, x9
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x98]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0xa0]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0x90]
-               	mov	x1, x9
+               	fmov	x1, d8
 <L43>:
                	bl	 <L43>
-               	fmov	d0, d8
+               	fmov	x1, d9
 <L44>:
                	bl	 <L44>
-               	fmov	d0, d9
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
-               	fmov	s0, s10
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L46>:
                	bl	 <L46>
-               	fmov	s0, s11
-<L47>:
-               	bl	 <L47>
                	eor	x1, x23, x27
-               	ldur	x9, [x29, #-0x90]
+               	ldur	x9, [x29, #-0xa0]
                	eor	x2, x1, x9
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L47>:
+               	bl	 <L47>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L5>
-<L49>:
+               	b.lo	 <L4>
+<L48>:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	add	x0, x1, x19
-<L50>:
-               	bl	 <L50>
+<L49>:
+               	bl	 <L49>
                	mov	x1, x0
                	mov	x0, x21
-<L51>:
-               	bl	 <L51>
-               	ldp	d8, d9, [x29, #-0x190]
-               	ldp	d10, d11, [x29, #-0x1a0]
-               	ldp	d12, d13, [x29, #-0x1b0]
-               	ldp	d14, d15, [x29, #-0x1c0]
-               	ldp	x19, x20, [x29, #-0x140]
-               	ldp	x21, x22, [x29, #-0x150]
-               	ldp	x23, x24, [x29, #-0x160]
-               	ldp	x25, x26, [x29, #-0x170]
-               	ldp	x27, x28, [x29, #-0x180]
+<L50>:
+               	bl	 <L50>
+               	ldp	d8, d9, [x29, #-0x1a0]
+               	ldp	d10, d11, [x29, #-0x1b0]
+               	ldp	d12, d13, [x29, #-0x1c0]
+               	ldp	d14, d15, [x29, #-0x1d0]
+               	ldp	x19, x20, [x29, #-0x150]
+               	ldp	x21, x22, [x29, #-0x160]
+               	ldp	x23, x24, [x29, #-0x170]
+               	ldp	x25, x26, [x29, #-0x180]
+               	ldp	x27, x28, [x29, #-0x190]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_float_regs.dis
+++ b/test/golden/aarch64-darwin/call/call_float_regs.dis
@@ -44,159 +44,379 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_float_regs.takef16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xc0
-               	stp	d8, d9, [x29, #-0x90]
-               	stp	d10, d11, [x29, #-0xa0]
-               	stp	d12, d13, [x29, #-0xb0]
-               	stp	d14, d15, [x29, #-0xc0]
-               	fmov	s8, s0
-               	fmov	d9, d1
-               	fmov	s10, s2
-               	fmov	d11, d3
-               	fmov	s12, s4
-               	fmov	d13, d5
-               	fmov	s14, s6
-               	fmov	d15, d7
-               	ldr	s31, [x29, #0x10]
-               	stur	s31, [x29, #-0x10]
-               	ldr	d31, [x29, #0x18]
-               	stur	d31, [x29, #-0x20]
-               	ldr	s31, [x29, #0x20]
-               	stur	s31, [x29, #-0x30]
-               	ldr	d31, [x29, #0x28]
-               	stur	d31, [x29, #-0x40]
+               	sub	sp, sp, #0x80
+               	stp	d8, d9, [x29, #-0x50]
+               	stp	d10, d11, [x29, #-0x60]
+               	stp	d12, d13, [x29, #-0x70]
+               	stp	d14, d15, [x29, #-0x80]
+               	fmov	d8, d1
+               	fmov	d9, d3
+               	fmov	d10, d5
+               	fmov	d11, d7
+               	ldr	s12, [x29, #0x10]
+               	ldr	d13, [x29, #0x18]
+               	ldr	s14, [x29, #0x20]
+               	ldr	d15, [x29, #0x28]
                	ldr	s31, [x29, #0x30]
-               	stur	s31, [x29, #-0x50]
+               	stur	s31, [x29, #-0x10]
                	ldr	d31, [x29, #0x38]
-               	stur	d31, [x29, #-0x60]
+               	stur	d31, [x29, #-0x20]
                	ldr	s31, [x29, #0x40]
-               	stur	s31, [x29, #-0x70]
+               	stur	s31, [x29, #-0x30]
                	ldr	d31, [x29, #0x48]
-               	stur	d31, [x29, #-0x80]
+               	stur	d31, [x29, #-0x40]
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d8
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	fmov	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s12
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d13
+               	fmov	x1, d9
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d15
+               	fmov	w1, s4
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x10]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x20]
+               	fmov	x1, d10
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x30]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x40]
+               	fmov	w1, s6
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x50]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x60]
+               	fmov	x1, d11
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x70]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x80]
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	fmul	s0, s10, s12
-               	fadd	s17, s8, s0
-               	fsub	s0, s17, s14
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	fmul	d0, d11, d13
-               	fadd	d17, d9, d0
-               	fsub	d0, d17, d15
-               	mov	x0, x1
+               	fmov	x1, d13
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fmov	x1, d15
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldur	w1, [x29, #-0x10]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	ldur	x1, [x29, #-0x20]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	ldur	w1, [x29, #-0x30]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	ldur	x1, [x29, #-0x40]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fmul	s16, s2, s4
+               	fadd	s2, s0, s16
+               	fsub	s0, s2, s6
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	fmul	d0, d9, d10
+               	fadd	d2, d8, d0
+               	fsub	d0, d2, d11
+               	fmov	x1, d0
+<L33>:
+               	bl	 <L33>
+               	fsub	s0, s12, s14
                	ldur	s31, [x29, #-0x10]
                	ldur	s30, [x29, #-0x30]
-               	fsub	s0, s31, s30
-               	ldur	s31, [x29, #-0x50]
-               	ldur	s30, [x29, #-0x70]
-               	fmul	s1, s31, s30
-               	fadd	s3, s0, s1
-               	mov	x0, x1
-               	fmov	s0, s3
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
+               	fmul	s2, s31, s30
+               	fadd	s1, s0, s2
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	fsub	d0, d13, d15
                	ldur	d31, [x29, #-0x20]
                	ldur	d30, [x29, #-0x40]
-               	fsub	d0, d31, d30
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x80]
                	fmul	d1, d31, d30
                	fadd	d2, d0, d1
-               	mov	x0, x1
-               	fmov	d0, d2
-<L20>:
-               	bl	 <L20>
-               	ldp	d8, d9, [x29, #-0x90]
-               	ldp	d10, d11, [x29, #-0xa0]
-               	ldp	d12, d13, [x29, #-0xb0]
-               	ldp	d14, d15, [x29, #-0xc0]
+               	fmov	x1, d2
+<L35>:
+               	bl	 <L35>
+               	ldp	d8, d9, [x29, #-0x50]
+               	ldp	d10, d11, [x29, #-0x60]
+               	ldp	d12, d13, [x29, #-0x70]
+               	ldp	d14, d15, [x29, #-0x80]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -233,106 +453,81 @@ Disassembly of section __TEXT,__text:
                	stur	s31, [x29, #-0x70]
                	ldr	s31, [x29, #0x2c]
                	stur	s31, [x29, #-0x80]
+               	fmov	w0, s8
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s12
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s13
+               	fmov	s0, s14
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fmov	s0, s15
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s15
+               	ldur	s0, [x29, #-0x10]
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x10]
+               	ldur	s0, [x29, #-0x20]
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x20]
+               	ldur	s0, [x29, #-0x30]
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x30]
+               	ldur	s0, [x29, #-0x40]
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x40]
+               	ldur	s0, [x29, #-0x50]
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x50]
+               	ldur	s0, [x29, #-0x60]
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x60]
+               	ldur	s0, [x29, #-0x70]
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x70]
+               	ldur	s0, [x29, #-0x80]
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x80]
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
                	ldur	s30, [x29, #-0x80]
                	fadd	s0, s8, s30
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
+<L16>:
+               	bl	 <L16>
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s15, s30
-               	mov	x0, x1
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+<L17>:
+               	bl	 <L17>
                	ldur	s30, [x29, #-0x70]
                	fmul	s0, s11, s30
-               	mov	x0, x1
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	ldp	d8, d9, [x29, #-0x90]
                	ldp	d10, d11, [x29, #-0xa0]
                	ldp	d12, d13, [x29, #-0xb0]
@@ -344,36 +539,30 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_float_regs.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x390
-               	sub	x16, x29, #0x2d0
+               	sub	sp, sp, #0x250
+               	sub	x16, x29, #0x1c0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x320
-               	stp	d8, d9, [x16]
-               	stp	d10, d11, [x16, #-0x10]
-               	stp	d12, d13, [x16, #-0x20]
-               	stp	d14, d15, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0xa0
+               	sub	x16, x29, #0x210
+               	str	d8, [x16, #0x8]
+               	sub	x1, x29, #0x190
                	add	x2, x1, #0x0
                	add	x3, x2, #0x0
                	mov	x2, #0xa0               ; =160
-<L1>:
+<L0>:
                	str	xzr, [x3]
                	add	x3, x3, #0x8
                	sub	x2, x2, #0x8
                	cmp	x2, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x14
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -384,75 +573,78 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
                	add	x4, x3, x16
-               	add	x3, x4, x19
+               	add	x3, x4, x0
                	add	x4, x1, x2, lsl #3
                	str	x3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x14
-               	b.lo	 <L2>
+               	b.lo	 <L1>
+<L2>:
+               	sub	x19, x29, #0x50
+               	add	x0, x19, #0x0
+               	add	x2, x0, #0x0
+               	mov	x0, #0x50               ; =80
 <L3>:
-               	sub	x19, x29, #0xf0
-               	add	x2, x19, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x50               ; =80
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L3>
+               	sub	x20, x29, #0xf0
+               	add	x0, x20, #0x0
+               	add	x2, x0, #0x0
+               	mov	x0, #0xa0               ; =160
 <L4>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L4>
-               	sub	x20, x29, #0x190
-               	add	x2, x20, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0xa0               ; =160
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x14
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
-               	b.ne	 <L5>
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x14
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
-               	add	x3, x1, x2, lsl #3
-               	ldr	x4, [x3]
+               	add	x2, x1, x0, lsl #3
+               	ldr	x3, [x2]
                	mov	x16, #0xfff             ; =4095
-               	and	x3, x4, x16
-               	ucvtf	s0, x3
+               	and	x2, x3, x16
+               	ucvtf	s0, x2
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x3, x19, x2, lsl #2
-               	str	s0, [x3]
-               	add	x3, x1, x2, lsl #3
-               	ldr	x4, [x3]
+               	add	x2, x19, x0, lsl #2
+               	str	s0, [x2]
+               	add	x2, x1, x0, lsl #3
+               	ldr	x3, [x2]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x3, x4, x16
-               	ucvtf	d0, x3
+               	and	x2, x3, x16
+               	ucvtf	d0, x2
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
                	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
                	fdiv	d0, d1, d30
-               	add	x3, x20, x2, lsl #3
-               	str	d0, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x14
-               	b.lo	 <L6>
-<L7>:
-               	mov	x21, x0
+               	add	x2, x20, x0, lsl #3
+               	str	d0, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x14
+               	b.lo	 <L5>
+<L6>:
+               	mov	x21, #0x2325            ; =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L8>
-               	b	 <L32>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L12>
+<L7>:
                	mov	x16, #0x3               ; =3
                	and	x0, x23, x16
                	ucvtf	s0, x0
@@ -537,12 +729,12 @@ Disassembly of section __TEXT,__text:
                	fmov	d5, d6
                	fmov	s6, s7
                	fmov	d7, d16
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	mov	x1, x0
                	mov	x0, x21
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	mov	x9, x0
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
@@ -554,400 +746,113 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s9, [x24]
-               	add	x0, x19, #0x4
-               	ldr	s10, [x0]
-               	ldr	s11, [x25]
-               	add	x0, x19, #0xc
-               	ldr	s12, [x0]
-               	ldr	s13, [x26]
-               	add	x0, x19, #0x14
-               	ldr	s14, [x0]
-               	ldr	s15, [x27]
-               	add	x0, x19, #0x1c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	ldr	s31, [x28]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x24
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s0, [x24]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	ldr	s2, [x25]
+               	add	x1, x19, #0xc
+               	ldr	s3, [x1]
+               	ldr	s4, [x26]
+               	add	x1, x19, #0x14
+               	ldr	s5, [x1]
+               	ldr	s6, [x27]
+               	add	x1, x19, #0x1c
+               	ldr	s7, [x1]
+               	ldr	s16, [x28]
+               	add	x1, x19, #0x24
+               	ldr	s17, [x1]
                	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x2c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s18, [x9]
+               	add	x1, x19, #0x2c
+               	ldr	s19, [x1]
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x34
-               	ldr	s31, [x0]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s20, [x9]
+               	add	x1, x19, #0x34
+               	ldr	s21, [x1]
                	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x3c
-               	ldr	s0, [x0]
-               	fadd	s31, s0, s8
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-<L11>:
-               	bl	 <L11>
-               	fmov	s0, s9
-<L12>:
-               	bl	 <L12>
-               	fmov	s0, s10
-<L13>:
-               	bl	 <L13>
-               	fmov	s0, s11
-<L14>:
-               	bl	 <L14>
-               	fmov	s0, s12
-<L15>:
-               	bl	 <L15>
-               	fmov	s0, s13
-<L16>:
-               	bl	 <L16>
-               	fmov	s0, s14
-<L17>:
-               	bl	 <L17>
-               	fmov	s0, s15
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fadd	s0, s9, s30
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fsub	s0, s31, s30
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fmul	s0, s12, s30
-<L30>:
-               	bl	 <L30>
-               	mov	x24, x0
+               	ldr	s22, [x9]
+               	add	x1, x19, #0x3c
+               	ldr	s23, [x1]
+               	fadd	s24, s23, s8
+               	str	s16, [sp]
+               	str	s17, [sp, #0x4]
+               	str	s18, [sp, #0x8]
+               	str	s19, [sp, #0xc]
+               	str	s20, [sp, #0x10]
+               	str	s21, [sp, #0x14]
+               	str	s22, [sp, #0x18]
+               	str	s24, [sp, #0x1c]
+<L10>:
+               	bl	 <L10>
+               	mov	x22, x0
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	x1, x24
-<L31>:
-               	bl	 <L31>
+               	mov	x1, x22
+<L11>:
+               	bl	 <L11>
                	add	x23, x23, #0x1
                	mov	x21, x0
-               	mov	x22, x24
                	cmp	x23, #0x3
-               	b.lo	 <L8>
-<L32>:
+               	b.lo	 <L7>
+<L12>:
                	add	x0, x19, #0x4c
-               	ldr	s8, [x0]
+               	ldr	s0, [x0]
                	add	x0, x19, #0x48
-               	ldr	s9, [x0]
+               	ldr	s1, [x0]
                	add	x0, x19, #0x44
-               	ldr	s10, [x0]
+               	ldr	s2, [x0]
                	add	x0, x19, #0x40
-               	ldr	s11, [x0]
+               	ldr	s3, [x0]
                	add	x0, x19, #0x3c
-               	ldr	s12, [x0]
+               	ldr	s4, [x0]
                	add	x0, x19, #0x38
-               	ldr	s13, [x0]
+               	ldr	s5, [x0]
                	add	x0, x19, #0x34
-               	ldr	s14, [x0]
+               	ldr	s6, [x0]
                	add	x0, x19, #0x30
-               	ldr	s15, [x0]
+               	ldr	s7, [x0]
                	add	x0, x19, #0x2c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s16, [x0]
                	add	x0, x19, #0x28
-               	ldr	s31, [x0]
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s17, [x0]
                	add	x0, x19, #0x24
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s18, [x0]
                	add	x0, x19, #0x20
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s19, [x0]
                	add	x0, x19, #0x1c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s20, [x0]
                	add	x0, x19, #0x18
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s21, [x0]
                	add	x0, x19, #0x14
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s22, [x0]
                	add	x0, x19, #0x10
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-<L33>:
-               	bl	 <L33>
-               	fmov	s0, s8
-<L34>:
-               	bl	 <L34>
-               	fmov	s0, s9
-<L35>:
-               	bl	 <L35>
-               	fmov	s0, s10
-<L36>:
-               	bl	 <L36>
-               	fmov	s0, s11
-<L37>:
-               	bl	 <L37>
-               	fmov	s0, s12
-<L38>:
-               	bl	 <L38>
-               	fmov	s0, s13
-<L39>:
-               	bl	 <L39>
-               	fmov	s0, s14
-<L40>:
-               	bl	 <L40>
-               	fmov	s0, s15
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fadd	s0, s8, s30
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fsub	s0, s15, s30
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fmul	s0, s11, s30
-<L52>:
-               	bl	 <L52>
+               	ldr	s23, [x0]
+               	str	s16, [sp]
+               	str	s17, [sp, #0x4]
+               	str	s18, [sp, #0x8]
+               	str	s19, [sp, #0xc]
+               	str	s20, [sp, #0x10]
+               	str	s21, [sp, #0x14]
+               	str	s22, [sp, #0x18]
+               	str	s23, [sp, #0x1c]
+<L13>:
+               	bl	 <L13>
                	mov	x16, #0xfff             ; =4095
                	and	x1, x0, x16
                	ucvtf	s0, x1
@@ -1000,18 +905,15 @@ Disassembly of section __TEXT,__text:
                	str	d21, [sp, #0x28]
                	str	s22, [sp, #0x30]
                	str	d23, [sp, #0x38]
-<L53>:
-               	bl	 <L53>
+<L14>:
+               	bl	 <L14>
                	mov	x1, x0
                	mov	x0, x21
-<L54>:
-               	bl	 <L54>
-               	sub	x16, x29, #0x320
-               	ldp	d8, d9, [x16]
-               	ldp	d10, d11, [x16, #-0x10]
-               	ldp	d12, d13, [x16, #-0x20]
-               	ldp	d14, d15, [x16, #-0x30]
-               	sub	x16, x29, #0x2d0
+<L15>:
+               	bl	 <L15>
+               	sub	x16, x29, #0x210
+               	ldr	d8, [x16, #0x8]
+               	sub	x16, x29, #0x1c0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/call/call_indirect.dis
+++ b/test/golden/aarch64-darwin/call/call_indirect.dis
@@ -63,34 +63,66 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.call.call_indirect.fold24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_indirect.sum24>:
@@ -167,97 +199,237 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.call.call_indirect.wide>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x60
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	d8, d9, [x29, #-0x50]
-               	stp	d10, d11, [x29, #-0x60]
-               	mov	x19, x0
-               	mov	w20, w1
-               	fmov	d8, d0
-               	mov	x21, x2
-               	fmov	s9, s1
-               	mov	x22, x3
-               	mov	w23, w4
-               	fmov	d10, d2
-               	mov	x24, x5
-               	mov	x25, x6
-               	fmov	s11, s3
-               	mov	x26, x7
+               	mov	x8, #0x2325             ; =8997
+               	movk	x8, #0x8422, lsl #16
+               	movk	x8, #0x9ce4, lsl #32
+               	movk	x8, #0xcbf2, lsl #48
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x0, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x1, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x8, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	fmov	x0, d0
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x1, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x8, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w0, w2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w23
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x12, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x12, x16
+               	eor	x12, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	fmov	w0, s1
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x12, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x12, x16
+               	eor	x12, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x3, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	sxtw	x0, w4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldp	d8, d9, [x29, #-0x50]
-               	ldp	d10, d11, [x29, #-0x60]
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fmov	x0, d2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	uxth	w0, w5
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x6, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fmov	w0, s3
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x7, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x0, x8
                	ret
 
 <corpus.cases.call.call_indirect.apply>:
@@ -331,183 +503,170 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_indirect.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x230
-               	sub	x16, x29, #0x1d0
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x220
+               	sub	sp, sp, #0x200
+               	stp	x19, x20, [x29, #-0x1a0]
+               	stp	x21, x22, [x29, #-0x1b0]
+               	stp	x23, x24, [x29, #-0x1c0]
+               	stp	x25, x26, [x29, #-0x1d0]
+               	stp	x27, x28, [x29, #-0x1e0]
+               	sub	x16, x29, #0x1f0
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	mov	x19, x0
+               	sub	x20, x29, #0xe0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               ; =96
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               ; =96
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            ; =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-<L3>:
-               	sub	x21, x29, #0x90
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+<L2>:
+               	sub	x21, x29, #0x30
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	str	xzr, [x21, #0x18]
                	str	xzr, [x21, #0x20]
                	str	xzr, [x21, #0x28]
-               	add	x1, x21, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x10
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x18
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x20
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x28
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	sub	x22, x29, #0xa0
+               	add	x0, x21, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x10
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x18
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x20
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x28
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	sub	x22, x29, #0x40
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
-               	add	x1, x22, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x22, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	sub	x23, x29, #0xb0
+               	add	x0, x22, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x22, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	sub	x23, x29, #0x50
                	str	xzr, [x23]
                	str	xzr, [x23, #0x8]
-               	add	x1, x23, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x23, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x19, #0x1
-               	mov	x24, x0
-               	mov	x25, x1
+               	add	x0, x23, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x23, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x19, #0x1
+               	mov	x24, #0x2325            ; =8997
+               	movk	x24, #0x8422, lsl #16
+               	movk	x24, #0x9ce4, lsl #32
+               	movk	x24, #0xcbf2, lsl #48
+               	mov	x25, x0
                	mov	x26, #0x0               ; =0
                	cmp	x26, #0xc
-               	b.lo	 <L4>
+               	b.lo	 <L3>
                	b	 <L18>
-<L4>:
-               	add	x27, x20, x26, lsl #3
-               	ldr	x0, [x27]
-               	add	x1, x0, x19
-               	mov	x0, #0x6                ; =6
-               	cbnz	x0,  <L5>
+<L3>:
+               	add	x0, x20, x26, lsl #3
+               	ldr	x1, [x0]
+               	add	x2, x1, x19
+               	mov	x1, #0x6                ; =6
+               	cbnz	x1,  <L4>
                	brk	#0
-<L5>:
-               	udiv	x16, x1, x0
-               	msub	x28, x16, x0, x1
-               	add	x9, x21, x28, lsl #3
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x3, [x9]
-               	ldr	x1, [x27]
+<L4>:
+               	udiv	x16, x2, x1
+               	msub	x27, x16, x1, x2
+               	add	x1, x21, x27, lsl #3
+               	ldr	x28, [x1]
+               	ldr	x1, [x0]
                	mov	x0, x25
-               	blr	x3
-               	mov	x9, x0
-               	mov	x16, #0xfeb0            ; =65200
+               	blr	x28
+               	mov	x28, x0
+               	mov	x9, x24
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x24
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L6>:
-               	bl	 <L6>
-               	mov	x9, x0
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x3, x28, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x3, x16
                	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	x5, [x9]
-               	ldr	x1, [x27]
-               	mov	x16, #0xfeb0            ; =65200
+               	eor	x3, x9, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x2
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	blr	x5
+               	str	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x0, x21, x27, lsl #3
+               	ldr	x3, [x0]
+               	add	x0, x20, x26, lsl #3
+               	ldr	x1, [x0]
+               	mov	x0, x28
+               	blr	x3
                	mov	x1, x0
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -515,19 +674,8 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x9
 <L7>:
                	bl	 <L7>
-               	mov	x27, x0
-               	add	x0, x28, #0x1
-               	mov	x1, #0x6                ; =6
-               	cbnz	x1,  <L8>
-               	brk	#0
-<L8>:
-               	udiv	x16, x0, x1
-               	msub	x2, x16, x1, x0
-               	add	x0, x21, x2, lsl #3
-               	ldr	x28, [x0]
-               	add	x0, x20, x26, lsl #3
-               	ldr	x9, [x0]
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x9, x0
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -537,23 +685,44 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	x16, #0xfea0            ; =65184
+               	add	x0, x27, #0x1
+               	mov	x1, #0x6                ; =6
+               	cbnz	x1,  <L8>
+               	brk	#0
+<L8>:
+               	udiv	x16, x0, x1
+               	msub	x3, x16, x1, x0
+               	add	x0, x21, x3, lsl #3
+               	ldr	x27, [x0]
+               	add	x0, x20, x26, lsl #3
+               	ldr	x9, [x0]
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, x28
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-               	blr	x28
-               	mov	x16, #0xfea0            ; =65184
+               	blr	x27
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-               	blr	x28
+               	blr	x27
                	mov	x1, x0
-               	mov	x0, x27
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
 <L9>:
                	bl	 <L9>
                	mov	x27, x0
@@ -576,52 +745,42 @@ Disassembly of section __TEXT,__text:
                	b.eq	 <L12>
                	cmp	x2, #0x4
                	b.eq	 <L11>
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L11>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L12>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L13>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L14>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L15>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
 <L16>:
                	add	x0, x20, x26, lsl #3
                	ldr	x1, [x0]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	blr	x28
+               	mov	x0, x28
+               	blr	x2
                	mov	x1, x0
                	mov	x0, x27
 <L17>:
                	bl	 <L17>
                	add	x26, x26, #0x1
                	mov	x24, x0
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x25, x9
+               	mov	x25, x28
                	cmp	x26, #0xc
-               	b.lo	 <L4>
+               	b.lo	 <L3>
 <L18>:
                	add	x0, x20, #0x0
                	ldr	x1, [x0]
@@ -672,7 +831,7 @@ Disassembly of section __TEXT,__text:
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x8
                	b.lo	 <L24>
-               	b	 <L32>
+               	b	 <L35>
 <L24>:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
@@ -692,42 +851,42 @@ Disassembly of section __TEXT,__text:
 <L26>:
                	udiv	x16, x1, x2
                	msub	x27, x16, x2, x1
-               	sub	x28, x29, #0xc8
+               	sub	x28, x29, #0x68
                	add	x1, x23, x26, lsl #3
                	ldr	x2, [x1]
                	ldr	x1, [x0]
                	add	x0, x1, x25
-               	sub	x9, x29, #0xe0
-               	mov	x16, #0xfe98            ; =65176
+               	sub	x9, x29, #0x80
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	blr	x2
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x2, [x9, #0x8]
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -739,56 +898,88 @@ Disassembly of section __TEXT,__text:
                	add	x0, x28, #0x0
                	ldr	x1, [x0]
                	add	x0, x28, #0x8
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	ldr	x2, [x0]
                	add	x0, x28, #0x10
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe88            ; =65160
+               	ldr	x3, [x0]
+               	mov	x0, x24
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x9, x0
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x0, x24
-<L27>:
-               	bl	 <L27>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
                	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x9, x0
-               	mov	x16, #0xfe78            ; =65144
+               	eor	x4, x9, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
                	add	x9, x22, x27, lsl #3
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -818,17 +1009,17 @@ Disassembly of section __TEXT,__text:
                	sub	x0, x29, #0x110
                	blr	x27
                	mov	x3, x0
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
                	mov	x1, x3
-<L30>:
-               	bl	 <L30>
+<L33>:
+               	bl	 <L33>
                	mov	x27, x0
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -839,12 +1030,12 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
                	sub	x9, x29, #0x128
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -852,24 +1043,24 @@ Disassembly of section __TEXT,__text:
                	mov	x8, x9
                	mov	x0, x1
                	blr	x26
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x1, [x9, #0x8]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -894,27 +1085,27 @@ Disassembly of section __TEXT,__text:
                	blr	x28
                	mov	x1, x0
                	mov	x0, x27
-<L31>:
-               	bl	 <L31>
+<L34>:
+               	bl	 <L34>
                	add	x21, x21, #0x1
                	mov	x24, x0
                	cmp	x21, #0x8
                	b.lo	 <L24>
-<L32>:
+<L35>:
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L33>
-               	b	 <L62>
-<L33>:
+               	b.lo	 <L36>
+               	b	 <L41>
+<L36>:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
                	add	x22, x1, x19
                	mov	w23, w22
                	mov	x16, #0xfff             ; =4095
                	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	ucvtf	d8, x0
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d0, d8, d30
                	mov	w26, w22
                	mov	x16, #0xff              ; =255
                	and	x0, x22, x16
@@ -923,196 +1114,116 @@ Disassembly of section __TEXT,__text:
                	mul	x27, x22, x16
                	mov	x16, #0xffff            ; =65535
                	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	ucvtf	d10, x0
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d10, d0, d30
+               	fdiv	d2, d10, d30
                	mov	w28, w22
                	mvn	x9, x22
-               	mov	x16, #0xfe68            ; =65128
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x16, #0x3ff             ; =1023
                	and	x0, x22, x16
-               	ucvtf	s0, x0
+               	ucvtf	s1, x0
                	mov	w16, #0x44000000        ; =1140850688
                	fmov	s30, w16
-               	fsub	s11, s0, s30
+               	fsub	s11, s1, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x22
-<L35>:
-               	bl	 <L35>
+               	mov	x0, x22
                	mov	w1, w23
-<L36>:
-               	bl	 <L36>
-               	fmov	d0, d8
+               	mov	x2, x26
+               	fmov	s1, s9
+               	mov	x3, x27
+               	mov	w4, w23
+               	mov	x5, x28
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	fmov	s3, s11
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x7, x9
 <L37>:
                	bl	 <L37>
-               	mov	x1, x26
-<L38>:
-               	bl	 <L38>
-               	fmov	s0, s9
-<L39>:
-               	bl	 <L39>
-               	mov	x1, x27
-<L40>:
-               	bl	 <L40>
-               	mov	w1, w23
-<L41>:
-               	bl	 <L41>
-               	fmov	d0, d10
-<L42>:
-               	bl	 <L42>
-               	mov	x1, x28
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe68            ; =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L44>:
-               	bl	 <L44>
-               	fmov	s0, s11
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L46>:
-               	bl	 <L46>
                	mov	x1, x0
                	mov	x0, x24
-<L47>:
-               	bl	 <L47>
-               	mov	x23, x0
-               	mov	w26, w22
-               	mov	x16, #0xfff             ; =4095
-               	and	x0, x22, x16
-               	ucvtf	d0, x0
+<L38>:
+               	bl	 <L38>
+               	mov	x9, x0
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
-               	mov	w27, w22
-               	mov	x16, #0xff              ; =255
-               	and	x0, x22, x16
-               	ucvtf	s9, x0
-               	mov	x16, #0x3               ; =3
-               	mul	x28, x22, x16
-               	mov	x16, #0xffff            ; =65535
-               	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	fdiv	d0, d8, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d10, d0, d30
-               	mov	w9, w22
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mvn	x9, x22
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0x3ff             ; =1023
-               	and	x0, x22, x16
-               	ucvtf	s0, x0
-               	mov	w16, #0x44000000        ; =1140850688
-               	fmov	s30, w16
-               	fsub	s11, s0, s30
-               	eor	x9, x22, x25
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x22
-<L49>:
-               	bl	 <L49>
-               	mov	w1, w26
-<L50>:
-               	bl	 <L50>
-               	fmov	d0, d8
-<L51>:
-               	bl	 <L51>
-               	mov	x1, x27
-<L52>:
-               	bl	 <L52>
-               	fmov	s0, s9
-<L53>:
-               	bl	 <L53>
-               	mov	x1, x28
-<L54>:
-               	bl	 <L54>
-               	mov	w1, w26
-<L55>:
-               	bl	 <L55>
-               	fmov	d0, d10
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe58            ; =65112
+               	fdiv	d2, d10, d30
+               	mov	x0, x22
+               	mov	w1, w23
+               	mov	x2, x26
+               	fmov	s1, s9
+               	mov	x3, x27
+               	mov	w4, w23
+               	mov	x5, x28
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x6, x9
+               	fmov	s3, s11
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L58>:
-               	bl	 <L58>
-               	fmov	s0, s11
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
+               	mov	x7, x9
+<L39>:
+               	bl	 <L39>
                	mov	x1, x0
-               	mov	x0, x23
-<L61>:
-               	bl	 <L61>
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x24, x0
                	cmp	x21, #0x4
-               	b.lo	 <L33>
-<L62>:
+               	b.lo	 <L36>
+<L41>:
                	mov	x0, x24
-               	sub	x16, x29, #0x220
+               	sub	x16, x29, #0x1f0
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
-               	sub	x16, x29, #0x1d0
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
-               	ldp	x27, x28, [x16, #-0x40]
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	ldp	x21, x22, [x29, #-0x1b0]
+               	ldp	x23, x24, [x29, #-0x1c0]
+               	ldp	x25, x26, [x29, #-0x1d0]
+               	ldp	x27, x28, [x29, #-0x1e0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_int_regs.dis
+++ b/test/golden/aarch64-darwin/call/call_int_regs.dis
@@ -20,127 +20,327 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_int_regs.take16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
-               	stp	x27, x28, [x29, #-0x80]
-               	mov	x19, x0
-               	mov	x20, x1
-               	mov	x21, x2
-               	mov	x22, x3
-               	mov	w23, w4
-               	mov	w24, w5
-               	mov	x25, x6
-               	mov	x26, x7
-               	ldrb	w27, [x29, #0x10]
-               	ldrb	w28, [x29, #0x11]
-               	ldrh	w9, [x29, #0x12]
-               	stur	x9, [x29, #-0x8]
-               	ldrh	w9, [x29, #0x14]
-               	stur	x9, [x29, #-0x10]
-               	ldr	w9, [x29, #0x18]
-               	stur	x9, [x29, #-0x18]
-               	ldr	w9, [x29, #0x1c]
-               	stur	x9, [x29, #-0x20]
-               	ldr	x9, [x29, #0x20]
-               	stur	x9, [x29, #-0x28]
-               	ldr	x9, [x29, #0x28]
-               	stur	x9, [x29, #-0x30]
+               	sub	sp, sp, #0x40
+               	stp	x19, x20, [x29, #-0x10]
+               	stp	x21, x22, [x29, #-0x20]
+               	stp	x23, x24, [x29, #-0x30]
+               	stur	x25, [x29, #-0x38]
+               	ldrb	w8, [x29, #0x10]
+               	ldrb	w12, [x29, #0x11]
+               	ldrh	w13, [x29, #0x12]
+               	ldrh	w14, [x29, #0x14]
+               	ldr	w15, [x29, #0x18]
+               	ldr	w19, [x29, #0x1c]
+               	ldr	x20, [x29, #0x20]
+               	ldr	x21, [x29, #0x28]
+               	uxtb	w22, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x23, #0x0               ; =0
+               	cmp	x23, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x24, x23, x16
+               	lsr	x25, x22, x24
+               	mov	x16, #0xff              ; =255
+               	and	x24, x25, x16
+               	eor	x25, x0, x24
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x25, x16
+               	add	x23, x23, #0x1
+               	cmp	x23, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	x22, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x23, x1, x16
+               	lsr	x24, x22, x23
+               	mov	x16, #0xff              ; =255
+               	and	x23, x24, x16
+               	eor	x24, x0, x23
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x24, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxth	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w23
+               	mov	x16, #0x8               ; =8
+               	mul	x22, x2, x16
+               	lsr	x23, x1, x22
+               	mov	x16, #0xff              ; =255
+               	and	x22, x23, x16
+               	eor	x23, x0, x22
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x23, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w24
+               	sxth	x1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x22, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x22, x16
+               	eor	x22, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x22, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	mov	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x28
+               	sxtw	x1, w5
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x18]
-               	mov	w1, w9
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x6, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x20]
-               	mov	w1, w9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x28]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x7, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
+               	uxtb	w1, w8
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
-               	ldp	x27, x28, [x29, #-0x80]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxtb	x1, w12
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	uxth	w1, w13
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	x1, w14
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	w1, w15
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sxtw	x1, w19
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x21, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	ldp	x19, x20, [x29, #-0x10]
+               	ldp	x21, x22, [x29, #-0x20]
+               	ldp	x23, x24, [x29, #-0x30]
+               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -154,116 +354,83 @@ Disassembly of section __TEXT,__text:
                	stp	x23, x24, [x29, #-0x60]
                	stp	x25, x26, [x29, #-0x70]
                	stp	x27, x28, [x29, #-0x80]
-               	mov	x19, x0
-               	mov	x20, x1
-               	mov	x21, x2
-               	mov	x22, x3
-               	mov	x23, x4
-               	mov	x24, x5
-               	mov	x25, x6
-               	mov	x26, x7
-               	ldrb	w27, [x29, #0x10]
-               	ldrb	w28, [x29, #0x11]
-               	ldrh	w9, [x29, #0x12]
-               	stur	x9, [x29, #-0x8]
+               	mov	x19, x1
+               	mov	x20, x2
+               	mov	x21, x3
+               	mov	x22, x4
+               	mov	x23, x5
+               	mov	x24, x6
+               	mov	x25, x7
+               	ldrb	w26, [x29, #0x10]
+               	ldrb	w27, [x29, #0x11]
+               	ldrh	w28, [x29, #0x12]
                	ldrh	w9, [x29, #0x14]
-               	stur	x9, [x29, #-0x10]
+               	stur	x9, [x29, #-0x8]
                	ldrb	w9, [x29, #0x16]
-               	stur	x9, [x29, #-0x18]
+               	stur	x9, [x29, #-0x10]
                	ldrb	w9, [x29, #0x17]
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x18]
                	ldrh	w9, [x29, #0x18]
-               	stur	x9, [x29, #-0x28]
+               	stur	x9, [x29, #-0x20]
                	ldrh	w9, [x29, #0x1a]
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x28]
+               	uxtb	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxtb	w1, w19
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	x1, w20
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	sxtb	x1, w21
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxth	w1, w22
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	uxth	w1, w23
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	sxth	x1, w24
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	sxth	x1, w25
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	uxtb	w1, w26
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	sxtb	x1, w27
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x28
+               	uxth	w1, w28
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	sxth	x1, w9
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	uxtb	w1, w9
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x18]
-               	mov	x1, x9
+               	sxtb	x1, w9
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	uxth	w1, w9
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x28]
-               	mov	x1, x9
+               	sxth	x1, w9
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
-<L16>:
-               	bl	 <L16>
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
                	ldp	x23, x24, [x29, #-0x60]
@@ -276,1016 +443,793 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_int_regs.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x2b0
-               	sub	x16, x29, #0x270
+               	sub	sp, sp, #0x260
+               	sub	x16, x29, #0x200
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	sub	x20, x29, #0xa0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xa0               ; =160
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xa0               ; =160
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x14
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x14
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            ; =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x14
-               	b.lo	 <L2>
-<L3>:
-               	mov	x21, x0
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x14
+               	b.lo	 <L1>
+<L2>:
+               	mov	x9, #0x2325             ; =8997
+               	movk	x9, #0x8422, lsl #16
+               	movk	x9, #0x9ce4, lsl #32
+               	movk	x9, #0xcbf2, lsl #48
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-               	b	 <L41>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L8>
+<L3>:
                	mov	x16, #0x7               ; =7
                	mul	x0, x23, x16
                	add	x24, x0, x19
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w28, w1
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xe0]
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xe8]
-               	add	x0, x20, #0x30
-               	ldr	x1, [x0]
-               	add	x9, x1, x24
-               	stur	x9, [x29, #-0xf0]
-               	add	x0, x20, #0x38
-               	ldr	x9, [x0]
-               	stur	x9, [x29, #-0xf8]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0x100]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfed8            ; =65240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	add	x9, x1, x24
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x9, [x0]
-               	stur	x9, [x29, #-0xa8]
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x25
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x26
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x27
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x28
-<L9>:
-               	bl	 <L9>
-               	ldur	x9, [x29, #-0xe0]
-               	mov	w1, w9
-<L10>:
-               	bl	 <L10>
-               	ldur	x9, [x29, #-0xe8]
-               	mov	w1, w9
-<L11>:
-               	bl	 <L11>
-               	ldur	x9, [x29, #-0xf0]
-               	mov	x1, x9
-<L12>:
-               	bl	 <L12>
-               	ldur	x9, [x29, #-0xf8]
-               	mov	x1, x9
-<L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0x100]
-               	mov	x1, x9
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfed8            ; =65240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0xa8]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x21
-<L22>:
-               	bl	 <L22>
-               	mov	x25, x0
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w28, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfec8            ; =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x30
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x38
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	add	x0, x1, x24
+               	add	x25, x20, #0x0
+               	ldr	x0, [x25]
                	mov	w9, w0
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe98            ; =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	mov	w9, w1
                	stur	x9, [x29, #-0xb0]
-               	add	x0, x20, #0x78
-               	ldr	x1, [x0]
-               	add	x0, x1, x24
-               	mov	w24, w0
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x26
-<L24>:
-               	bl	 <L24>
-               	mov	x1, x27
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x28
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfec8            ; =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe98            ; =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L37>:
-               	bl	 <L37>
-               	ldur	x9, [x29, #-0xb0]
-               	mov	x1, x9
-<L38>:
-               	bl	 <L38>
-               	mov	x1, x24
-<L39>:
-               	bl	 <L39>
-               	mov	x24, x0
-               	mov	x0, x25
-               	mov	x1, x24
-<L40>:
-               	bl	 <L40>
-               	add	x23, x23, #0x1
-               	mov	x21, x0
-               	mov	x22, x24
-               	cmp	x23, #0x3
-               	b.lo	 <L4>
-<L41>:
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w19, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w23, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w24, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x30
-               	ldr	x28, [x0]
-               	add	x0, x20, #0x38
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe68            ; =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe38            ; =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	mov	x1, x19
-<L43>:
-               	bl	 <L43>
-               	mov	x1, x23
-<L44>:
-               	bl	 <L44>
-               	mov	x1, x24
-<L45>:
-               	bl	 <L45>
-               	mov	x1, x25
-<L46>:
-               	bl	 <L46>
-               	mov	w1, w26
-<L47>:
-               	bl	 <L47>
-               	mov	w1, w27
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x28
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe68            ; =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe38            ; =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L58>:
-               	bl	 <L58>
-               	mov	w19, w0
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w23, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w24, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	mov	w26, w22
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w22, w1
-               	add	x1, x20, #0x30
-               	ldr	x27, [x1]
-               	add	x2, x20, #0x38
-               	ldr	x28, [x2]
-               	add	x3, x20, #0x80
-               	ldr	x4, [x3]
-               	mov	w9, w4
-               	mov	x16, #0xfe28            ; =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x4, x20, #0x88
-               	ldr	x5, [x4]
-               	mov	w9, w5
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x5, x20, #0x90
-               	ldr	x6, [x5]
-               	mov	w9, w6
-               	mov	x16, #0xfe18            ; =65048
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x6, x20, #0x98
-               	ldr	x7, [x6]
-               	mov	w9, w7
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x7, x20, #0x20
-               	ldr	x8, [x7]
-               	mov	w9, w8
-               	mov	x16, #0xfe08            ; =65032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x8, [x0]
-               	mov	w9, w8
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x0, [x1]
+               	add	x26, x20, #0x8
+               	ldr	x0, [x26]
                	mov	w9, w0
-               	mov	x16, #0xfdf8            ; =65016
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x0, [x2]
-               	mov	w9, w0
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfde8            ; =65000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdd8            ; =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xb8]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
                	stur	x9, [x29, #-0xc0]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xc8]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	mov	w9, w1
+               	add	x27, x20, #0x10
+               	ldr	x0, [x27]
+               	mov	w9, w0
                	stur	x9, [x29, #-0xd0]
-               	add	x0, x20, #0x78
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xd8]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe28            ; =65064
+               	add	x28, x20, #0x18
+               	ldr	x0, [x28]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xe0]
+               	add	x9, x20, #0x20
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe20            ; =65056
+               	ldr	x0, [x9]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xf0]
+               	add	x9, x20, #0x28
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe18            ; =65048
+               	ldr	x0, [x9]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0x100]
+               	add	x9, x20, #0x30
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe10            ; =65040
+               	ldr	x0, [x9]
+               	add	x9, x0, x24
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x9, x20, #0x38
+               	mov	x16, #0xfe48            ; =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe08            ; =65032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfdf8            ; =65016
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfde8            ; =65000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfdd8            ; =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L70>:
-               	bl	 <L70>
+               	ldr	x15, [x9]
+               	add	x9, x20, #0x40
+               	stur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xa8]
+               	ldr	x0, [x9]
+               	mov	w1, w0
+               	add	x9, x20, #0x48
+               	stur	x9, [x29, #-0xb8]
                	ldur	x9, [x29, #-0xb8]
-               	mov	x1, x9
-<L71>:
-               	bl	 <L71>
+               	ldr	x0, [x9]
+               	mov	w2, w0
+               	add	x9, x20, #0x50
+               	stur	x9, [x29, #-0xc8]
+               	ldur	x9, [x29, #-0xc8]
+               	ldr	x0, [x9]
+               	mov	w3, w0
+               	add	x9, x20, #0x58
+               	stur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xd8]
+               	ldr	x0, [x9]
+               	mov	w4, w0
+               	add	x9, x20, #0x60
+               	stur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xe8]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	add	x9, x20, #0x68
+               	stur	x9, [x29, #-0xf8]
+               	ldur	x9, [x29, #-0xf8]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	add	x9, x20, #0x70
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	add	x7, x0, x24
+               	add	x9, x20, #0x78
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	strb	w1, [sp]
+               	strb	w2, [sp, #0x1]
+               	strh	w3, [sp, #0x2]
+               	strh	w4, [sp, #0x4]
+               	str	w5, [sp, #0x8]
+               	str	w6, [sp, #0xc]
+               	str	x7, [sp, #0x10]
+               	str	x0, [sp, #0x18]
+               	ldur	x9, [x29, #-0xb0]
+               	mov	x0, x9
                	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
-<L72>:
-               	bl	 <L72>
-               	ldur	x9, [x29, #-0xc8]
-               	mov	x1, x9
-<L73>:
-               	bl	 <L73>
                	ldur	x9, [x29, #-0xd0]
-               	mov	x1, x9
-<L74>:
-               	bl	 <L74>
-               	ldur	x9, [x29, #-0xd8]
-               	mov	x1, x9
-<L75>:
-               	bl	 <L75>
-               	mov	w9, w0
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdc8            ; =64968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdb8            ; =64952
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfda8            ; =64936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x9, [x0]
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x20, [x0]
-<L76>:
-               	bl	 <L76>
-               	mov	x1, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x1, x23
-<L78>:
-               	bl	 <L78>
-               	mov	x1, x24
-<L79>:
-               	bl	 <L79>
-               	mov	x1, x25
-<L80>:
-               	bl	 <L80>
-               	mov	w1, w26
-<L81>:
-               	bl	 <L81>
-               	mov	w1, w22
-<L82>:
-               	bl	 <L82>
-               	mov	x1, x27
-<L83>:
-               	bl	 <L83>
-               	mov	x1, x28
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x2, x9
+               	ldur	x9, [x29, #-0xe0]
+               	mov	x3, x9
+               	ldur	x9, [x29, #-0xf0]
+               	mov	w4, w9
+               	ldur	x9, [x29, #-0x100]
+               	mov	w5, w9
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfdc8            ; =64968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfdb8            ; =64952
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfda8            ; =64936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L91>:
-               	bl	 <L91>
-               	mov	x1, x20
-<L92>:
-               	bl	 <L92>
+               	mov	x6, x9
+               	mov	x7, x15
+<L4>:
+               	bl	 <L4>
                	mov	x1, x0
-               	mov	x0, x21
-<L93>:
-               	bl	 <L93>
-               	sub	x16, x29, #0x270
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L5>:
+               	bl	 <L5>
+               	mov	x9, x0
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x25]
+               	mov	w9, w0
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x26]
+               	mov	w2, w0
+               	ldr	x0, [x27]
+               	mov	w3, w0
+               	ldr	x0, [x28]
+               	mov	w4, w0
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w7, w0
+               	mov	x16, #0xfe48            ; =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w8, w0
+               	ldur	x9, [x29, #-0xa8]
+               	ldr	x0, [x9]
+               	add	x12, x0, x24
+               	mov	w0, w12
+               	ldur	x9, [x29, #-0xb8]
+               	ldr	x12, [x9]
+               	mov	w13, w12
+               	ldur	x9, [x29, #-0xc8]
+               	ldr	x12, [x9]
+               	mov	w14, w12
+               	ldur	x9, [x29, #-0xd8]
+               	ldr	x12, [x9]
+               	mov	w25, w12
+               	ldur	x9, [x29, #-0xe8]
+               	ldr	x12, [x9]
+               	mov	w26, w12
+               	ldur	x9, [x29, #-0xf8]
+               	ldr	x12, [x9]
+               	mov	w27, w12
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x12, [x9]
+               	mov	w28, w12
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x12, [x9]
+               	add	x1, x12, x24
+               	mov	w12, w1
+               	strb	w0, [sp]
+               	strb	w13, [sp, #0x1]
+               	strh	w14, [sp, #0x2]
+               	strh	w25, [sp, #0x4]
+               	strb	w26, [sp, #0x6]
+               	strb	w27, [sp, #0x7]
+               	strh	w28, [sp, #0x8]
+               	strh	w12, [sp, #0xa]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x2
+               	mov	x2, x3
+               	mov	x3, x4
+               	mov	x4, x5
+               	mov	x5, x6
+               	mov	x6, x7
+               	mov	x7, x8
+<L6>:
+               	bl	 <L6>
+               	mov	x22, x0
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x22
+<L7>:
+               	bl	 <L7>
+               	add	x23, x23, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x23, #0x3
+               	b.lo	 <L3>
+<L8>:
+               	add	x0, x20, #0x0
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x19, x20, #0x8
+               	ldr	x1, [x19]
+               	mov	w9, w1
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x23, x20, #0x10
+               	ldr	x1, [x23]
+               	mov	w9, w1
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x24, x20, #0x18
+               	ldr	x1, [x24]
+               	mov	w9, w1
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x25, x20, #0x20
+               	ldr	x1, [x25]
+               	mov	w9, w1
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x26, x20, #0x28
+               	ldr	x1, [x26]
+               	mov	w6, w1
+               	add	x27, x20, #0x30
+               	ldr	x7, [x27]
+               	add	x28, x20, #0x38
+               	ldr	x8, [x28]
+               	add	x9, x20, #0x40
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w13, w1
+               	add	x9, x20, #0x48
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w15, w1
+               	add	x9, x20, #0x50
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w0, w1
+               	add	x9, x20, #0x58
+               	mov	x16, #0xfec8            ; =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfec8            ; =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w2, w1
+               	add	x9, x20, #0x60
+               	mov	x16, #0xfeb8            ; =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfeb8            ; =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w3, w1
+               	add	x9, x20, #0x68
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w4, w1
+               	add	x9, x20, #0x70
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	add	x9, x20, #0x78
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9]
+               	strb	w13, [sp]
+               	strb	w15, [sp, #0x1]
+               	strh	w0, [sp, #0x2]
+               	strh	w2, [sp, #0x4]
+               	str	w3, [sp, #0x8]
+               	str	w4, [sp, #0xc]
+               	str	x1, [sp, #0x10]
+               	str	x5, [sp, #0x18]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x2, x9
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x3, x9
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w4, w9
+               	mov	w5, w6
+               	mov	x6, x7
+               	mov	x7, x8
+<L9>:
+               	bl	 <L9>
+               	mov	w9, w0
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x19]
+               	mov	w19, w0
+               	ldr	x0, [x23]
+               	mov	w23, w0
+               	ldr	x0, [x24]
+               	mov	w24, w0
+               	mov	w9, w22
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x26]
+               	mov	w22, w0
+               	ldr	x9, [x27]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x21, [x28]
+               	add	x0, x20, #0x80
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x1, x20, #0x88
+               	ldr	x2, [x1]
+               	mov	w9, w2
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x2, x20, #0x90
+               	ldr	x3, [x2]
+               	mov	w9, w3
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x3, x20, #0x98
+               	ldr	x4, [x3]
+               	mov	w3, w4
+               	ldr	x4, [x25]
+               	mov	w5, w4
+               	ldr	x4, [x26]
+               	mov	w6, w4
+               	ldr	x4, [x27]
+               	mov	w7, w4
+               	ldr	x4, [x28]
+               	mov	w20, w4
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w12, w4
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w25, w4
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w26, w4
+               	mov	x16, #0xfec8            ; =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w27, w4
+               	mov	x16, #0xfeb8            ; =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w28, w4
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w0, w4
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w1, w4
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w2, w4
+               	strb	w12, [sp]
+               	strb	w25, [sp, #0x1]
+               	strh	w26, [sp, #0x2]
+               	strh	w27, [sp, #0x4]
+               	strb	w28, [sp, #0x6]
+               	strb	w0, [sp, #0x7]
+               	strh	w1, [sp, #0x8]
+               	strh	w2, [sp, #0xa]
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x2, x9
+               	mov	x4, x5
+               	mov	x5, x6
+               	mov	x6, x7
+               	mov	x7, x20
+<L10>:
+               	bl	 <L10>
+               	mov	w1, w0
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w2, w0
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w3, w0
+               	mov	x16, #0xfec8            ; =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w4, w0
+               	mov	x16, #0xfeb8            ; =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9]
+               	strb	w1, [sp]
+               	strb	w2, [sp, #0x1]
+               	strh	w3, [sp, #0x2]
+               	strh	w4, [sp, #0x4]
+               	str	w5, [sp, #0x8]
+               	str	w6, [sp, #0xc]
+               	str	x0, [sp, #0x10]
+               	str	x7, [sp, #0x18]
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x19
+               	mov	x2, x23
+               	mov	x3, x24
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w4, w9
+               	mov	w5, w22
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	mov	x7, x21
+<L11>:
+               	bl	 <L11>
+               	mov	x1, x0
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L12>:
+               	bl	 <L12>
+               	sub	x16, x29, #0x200
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/call/call_mixed.dis
+++ b/test/golden/aarch64-darwin/call/call_mixed.dis
@@ -44,263 +44,471 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_mixed.mixed>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xb0]
-               	stp	x21, x22, [x29, #-0xc0]
-               	stp	x23, x24, [x29, #-0xd0]
-               	stp	x25, x26, [x29, #-0xe0]
-               	stur	x27, [x29, #-0xe8]
-               	stp	d8, d9, [x29, #-0xf8]
-               	stp	d11, d12, [x29, #-0x108]
-               	stp	d13, d14, [x29, #-0x118]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d15, [x29, x16]
+               	sub	sp, sp, #0xe0
+               	stp	x19, x20, [x29, #-0x90]
+               	stp	x21, x22, [x29, #-0xa0]
+               	stp	x23, x24, [x29, #-0xb0]
+               	stp	d8, d9, [x29, #-0xc0]
+               	stp	d11, d13, [x29, #-0xd0]
+               	stp	d14, d15, [x29, #-0xe0]
                	mov	x19, x0
                	fmov	s8, s0
-               	mov	w20, w1
                	fmov	d9, d1
                	stur	q2, [x29, #-0x30]
-               	mov	x21, x2
                	fmov	s11, s3
-               	mov	x22, x3
                	stur	q4, [x29, #-0x40]
                	fmov	d13, d5
-               	mov	x23, x4
+               	mov	x20, x4
                	fmov	s14, s6
-               	mov	x24, x5
+               	mov	x21, x5
                	fmov	d15, d7
                	ldr	d31, [x29, #0x10]
                	stur	d31, [x29, #-0x50]
-               	mov	x25, x6
+               	mov	x22, x6
                	ldr	s31, [x29, #0x18]
                	stur	s31, [x29, #-0x60]
-               	mov	w26, w7
+               	mov	w23, w7
                	ldr	d31, [x29, #0x20]
                	stur	d31, [x29, #-0x70]
-               	ldr	x27, [x29, #0x28]
+               	ldr	x24, [x29, #0x28]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x19, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w4, s8
+               	mov	w5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	fmov	x1, d9
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31[0]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31[1]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s30, v31[0]
-               	stur	s30, [x29, #-0x80]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x80]
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s30, v31[1]
-               	stur	s30, [x29, #-0x90]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x90]
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31[2]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s0, v31[3]
-               	mov	x0, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d13
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	uxth	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d15
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x50]
-               	mov	s12, v31[0]
-               	mov	x0, x1
-               	fmov	s0, s12
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31[0]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x50]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
 <L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31[1]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
 <L22>:
-               	bl	 <L22>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x60]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
 <L23>:
-               	bl	 <L23>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w26
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31[2]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
 <L24>:
-               	bl	 <L24>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x70]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
 <L25>:
-               	bl	 <L25>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31[3]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	mov	x1, x0
-               	mul	x2, x23, x25
-               	add	x3, x19, x2
-               	sub	x2, x3, x27
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	mov	x1, x0
-               	fmul	s0, s11, s14
-               	fadd	s1, s8, s0
-               	ldur	s30, [x29, #-0x60]
-               	fsub	s0, s1, s30
-               	mov	x0, x1
+               	fmov	x1, d13
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	mov	x1, x0
-               	fmul	d0, d13, d15
-               	fadd	d1, d9, d0
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d1, d30
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	bl	 <L29>
-               	mov	x1, x0
-               	sub	x2, x29, #0xc
-               	add	x3, x2, #0x0
-               	ldur	s31, [x29, #-0x80]
-               	str	s31, [x3]
-               	add	x3, x2, #0x4
-               	ldur	s31, [x29, #-0x90]
-               	str	s31, [x3]
-               	add	x3, x2, #0x8
-               	str	s12, [x3]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	uxtb	w1, w21
+<L33>:
+               	bl	 <L33>
+               	fmov	x1, d15
+<L34>:
+               	bl	 <L34>
+               	ldur	q31, [x29, #-0x50]
+               	mov	s3, v31[0]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	ldur	q31, [x29, #-0x50]
+               	mov	s3, v31[1]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	mov	x1, x22
+<L37>:
+               	bl	 <L37>
+               	ldur	w1, [x29, #-0x60]
+               	mov	w2, w1
+               	mov	x1, x2
+<L38>:
+               	bl	 <L38>
+               	sxtw	x1, w23
+<L39>:
+               	bl	 <L39>
+               	ldur	x1, [x29, #-0x70]
+<L40>:
+               	bl	 <L40>
+               	mov	x1, x24
+<L41>:
+               	bl	 <L41>
+               	mul	x1, x20, x22
+               	add	x2, x19, x1
+               	sub	x1, x2, x24
+<L42>:
+               	bl	 <L42>
+               	fmul	s3, s11, s14
+               	fadd	s4, s8, s3
+               	ldur	s30, [x29, #-0x60]
+               	fsub	s3, s4, s30
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L43>:
+               	bl	 <L43>
+               	fmul	d1, d13, d15
+               	fadd	d3, d9, d1
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d1, d3, d30
+               	fmov	x1, d1
+<L44>:
+               	bl	 <L44>
+               	sub	x1, x29, #0xc
+               	ldur	q31, [x29, #-0x40]
+               	mov	s1, v31[0]
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
+               	ldur	q31, [x29, #-0x40]
+               	mov	s1, v31[1]
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	ldur	q31, [x29, #-0x50]
+               	mov	s1, v31[0]
+               	add	x2, x1, #0x8
+               	str	s1, [x2]
                	stur	xzr, [x29, #-0x1c]
                	stur	xzr, [x29, #-0x14]
-               	ldr	x3, [x2]
-               	stur	x3, [x29, #-0x1c]
-               	ldr	w3, [x2, #0x8]
-               	stur	w3, [x29, #-0x14]
+               	ldr	x2, [x1]
+               	stur	x2, [x29, #-0x1c]
+               	ldr	w2, [x1, #0x8]
+               	stur	w2, [x29, #-0x14]
                	ldur	q0, [x29, #-0x1c]
                	ldur	q31, [x29, #-0x30]
                	fadd.4s	v31, v31, v0
-               	stur	q31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0xa0]
+               	stur	q31, [x29, #-0x80]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[0]
-               	mov	x0, x1
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0xa0]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[1]
-               	mov	x0, x1
-<L31>:
-               	bl	 <L31>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0xa0]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[2]
-               	mov	x0, x1
-<L32>:
-               	bl	 <L32>
-               	ldp	d8, d9, [x29, #-0xf8]
-               	ldp	d11, d12, [x29, #-0x108]
-               	ldp	d13, d14, [x29, #-0x118]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d15, [x29, x16]
-               	ldp	x19, x20, [x29, #-0xb0]
-               	ldp	x21, x22, [x29, #-0xc0]
-               	ldp	x23, x24, [x29, #-0xd0]
-               	ldp	x25, x26, [x29, #-0xe0]
-               	ldur	x27, [x29, #-0xe8]
+<L47>:
+               	bl	 <L47>
+               	ldp	d8, d9, [x29, #-0xc0]
+               	ldp	d11, d13, [x29, #-0xd0]
+               	ldp	d14, d15, [x29, #-0xe0]
+               	ldp	x19, x20, [x29, #-0x90]
+               	ldp	x21, x22, [x29, #-0xa0]
+               	ldp	x23, x24, [x29, #-0xb0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -320,51 +528,52 @@ Disassembly of section __TEXT,__text:
                	stp	d13, d14, [x16, #-0x10]
                	stur	d15, [x16, #-0x18]
                	mov	x19, x0
+               	sub	x20, x29, #0xd8
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xc0               ; =192
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0xc0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xc0               ; =192
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x18
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x18
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            ; =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x18
-               	b.lo	 <L2>
-<L3>:
-               	mov	x21, x0
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x18
+               	b.lo	 <L1>
+<L2>:
+               	mov	x21, #0x2325            ; =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-               	b	 <L12>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L11>
+<L3>:
                	mov	x16, #0xb               ; =11
                	mul	x0, x23, x16
                	add	x24, x0, x19
-               	sub	x0, x29, #0xcc
+               	sub	x0, x29, #0xc
                	add	x1, x20, #0x80
                	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
@@ -485,8 +694,8 @@ Disassembly of section __TEXT,__text:
                	ldr	x0, [x26]
                	add	x1, x0, x24
                	mov	x0, x1
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	add	x0, x25, #0x4
                	str	s0, [x0]
                	ldr	d31, [x25]
@@ -500,8 +709,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x1
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	fmov	s11, s0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
@@ -523,8 +732,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	x0, x1
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	fmov	s13, s0
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
@@ -551,8 +760,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L8>:
-               	bl	 <L8>
+<L7>:
+               	bl	 <L7>
                	fmov	s15, s0
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
@@ -589,8 +798,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	x0, x1
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -660,19 +869,19 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x6, x9
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L11>:
-               	bl	 <L11>
+<L10>:
+               	bl	 <L10>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-<L12>:
-               	sub	x0, x29, #0xd8
+               	b.lo	 <L3>
+<L11>:
+               	sub	x0, x29, #0x18
                	mov	x16, #0xfff             ; =4095
                	and	x1, x22, x16
                	ucvtf	s0, x1
@@ -810,8 +1019,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L13>:
-               	bl	 <L13>
+<L12>:
+               	bl	 <L12>
                	add	x0, x19, #0x4
                	str	s0, [x0]
                	ldr	d31, [x19]
@@ -825,8 +1034,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x1
-<L14>:
-               	bl	 <L14>
+<L13>:
+               	bl	 <L13>
                	fmov	s11, s0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
@@ -848,8 +1057,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	x0, x1
-<L15>:
-               	bl	 <L15>
+<L14>:
+               	bl	 <L14>
                	fmov	s13, s0
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
@@ -871,8 +1080,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L16>:
-               	bl	 <L16>
+<L15>:
+               	bl	 <L15>
                	fmov	s15, s0
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
@@ -899,8 +1108,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -954,14 +1163,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	d7, [x29, x16]
                	mov	x6, x28
-<L18>:
-               	bl	 <L18>
+<L17>:
+               	bl	 <L17>
                	mov	x19, x0
                	add	x0, x20, #0x18
                	ldr	x1, [x0]
                	mov	x0, x1
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	fmov	s11, s0
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
@@ -983,8 +1192,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
                	mov	x0, x1
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	fmov	s13, s0
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
@@ -1006,8 +1215,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x98
                	ldr	x1, [x0]
                	mov	x0, x1
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	fmov	s15, s0
                	add	x0, x20, #0xa8
                	ldr	x1, [x0]
@@ -1034,8 +1243,8 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	ldr	x1, [x0]
                	mov	x0, x1
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -1087,12 +1296,12 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	d7, [x29, x16]
                	mov	x6, x28
-<L23>:
-               	bl	 <L23>
+<L22>:
+               	bl	 <L22>
                	mov	x1, x0
                	mov	x0, x21
-<L24>:
-               	bl	 <L24>
+<L23>:
+               	bl	 <L23>
                	sub	x16, x29, #0x240
                	ldp	d11, d12, [x16]
                	ldp	d13, d14, [x16, #-0x10]

--- a/test/golden/aarch64-darwin/call/call_rec_edge.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_edge.dis
@@ -20,41 +20,66 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e9>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x3, x0
+               	sub	sp, sp, #0x20
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
-               	sub	x19, x29, #0x18
-               	sub	x1, x29, #0x10
-               	ldrb	w2, [x1]
-               	sub	x1, x29, #0xf
-               	ldr	x4, [x1]
-               	str	x4, [x19]
-               	mov	x0, x3
-               	mov	x1, x2
+               	sub	x1, x29, #0x18
+               	sub	x2, x29, #0x10
+               	ldrb	w3, [x2]
+               	sub	x2, x29, #0xf
+               	ldr	x4, [x2]
+               	str	x4, [x1]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x8
-               	b.lo	 <L1>
-               	b	 <L3>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, x21
-               	ldrb	w1, [x0]
-               	mov	x0, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L5>
 <L2>:
-               	bl	 <L2>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L1>
+               	add	x3, x1, x2
+               	ldrb	w4, [x3]
+               	uxtb	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -62,32 +87,72 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e12>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	w20, [x1]
-               	mov	x0, x3
+               	ldr	w4, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -95,25 +160,49 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x3, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -121,24 +210,51 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e16f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	d0, [x29, #-0x10]
                	stur	d1, [x29, #-0x8]
-               	sub	x2, x29, #0x10
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x10
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d1, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -146,25 +262,50 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e16m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	d8, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	d0, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -172,44 +313,68 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e17>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x2, x0
-               	sub	x19, x29, #0x11
+               	sub	sp, sp, #0x20
+               	sub	x2, x29, #0x11
                	ldr	x3, [x1]
                	ldr	x4, [x1, #0x8]
                	ldrb	w5, [x1, #0x10]
-               	str	x3, [x19]
-               	str	x4, [x19, #0x8]
-               	strb	w5, [x19, #0x10]
-               	add	x1, x19, #0x0
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	strb	w5, [x2, #0x10]
+               	add	x1, x2, #0x0
                	ldrb	w3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	uxtb	w1, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x10
-               	b.lo	 <L1>
-               	b	 <L3>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
+               	b	 <L5>
 <L2>:
-               	bl	 <L2>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L1>
+               	add	x3, x2, #0x1
+               	add	x4, x3, x1
+               	ldrb	w3, [x4]
+               	uxtb	w4, w3
+               	mov	x3, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -217,117 +382,129 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x9                ; =9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xc                ; =12
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x9               ; =9
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               ; =16
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               ; =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x11               ; =17
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x10              ; =16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x10               ; =16
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x10               ; =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x11               ; =17
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x4                ; =4
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                ; =8
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                ; =8
 <L16>:
                	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L17>:
                	bl	 <L17>
+               	mov	x1, #0x8                ; =8
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x8                ; =8
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x1                ; =1
+<L20>:
+               	bl	 <L20>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_edge.take_edge>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x260
-               	sub	x16, x29, #0x1f0
+               	sub	sp, sp, #0x290
+               	sub	x16, x29, #0x220
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x240
+               	sub	x16, x29, #0x270
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	stur	d12, [x16, #-0x18]
-               	mov	x19, x0
+               	mov	x8, x0
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
-               	mov	w20, w3
+               	mov	w19, w3
                	stur	x4, [x29, #-0x20]
                	stur	x5, [x29, #-0x18]
                	fmov	d8, d0
@@ -335,531 +512,413 @@ Disassembly of section __TEXT,__text:
                	stur	x7, [x29, #-0x28]
                	stur	d1, [x29, #-0x40]
                	stur	d2, [x29, #-0x38]
-               	add	x1, x29, #0x10
-               	ldr	x21, [x29, #0x20]
-               	ldr	x2, [x29, #0x28]
-               	add	x9, x29, #0x30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x4, x29, #0x3c
-               	add	x9, x29, #0x48
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x6, [x29, #0x58]
+               	add	x0, x29, #0x10
+               	ldr	x20, [x29, #0x20]
+               	ldr	x1, [x29, #0x28]
+               	add	x2, x29, #0x30
+               	add	x3, x29, #0x3c
+               	add	x4, x29, #0x48
+               	ldr	x5, [x29, #0x58]
                	fmov	s9, s3
-               	ldr	x22, [x29, #0x60]
-               	sub	x23, x29, #0x48
-               	sub	x24, x29, #0x50
-               	sub	x25, x29, #0x58
-               	sub	x26, x29, #0x60
-               	sub	x27, x29, #0x68
-               	sub	x28, x29, #0x70
-               	sub	x7, x29, #0x10
-               	ldrb	w9, [x7]
-               	mov	x16, #0xfe68            ; =65128
+               	ldr	x21, [x29, #0x60]
+               	sub	x22, x29, #0x49
+               	ldur	x6, [x29, #-0x10]
+               	ldurb	w7, [x29, #-0x8]
+               	str	x6, [x22]
+               	strb	w7, [x22, #0x8]
+               	sub	x23, x29, #0x58
+               	ldur	x6, [x29, #-0x20]
+               	ldur	w7, [x29, #-0x18]
+               	str	x6, [x23]
+               	str	w7, [x23, #0x8]
+               	sub	x24, x29, #0x68
+               	ldur	x6, [x29, #-0x30]
+               	ldur	x7, [x29, #-0x28]
+               	str	x6, [x24]
+               	str	x7, [x24, #0x8]
+               	sub	x6, x29, #0x40
+               	ldr	d10, [x6]
+               	sub	x6, x29, #0x38
+               	ldr	d11, [x6]
+               	add	x6, x0, #0x0
+               	ldr	x25, [x6]
+               	add	x6, x0, #0x8
+               	ldr	d12, [x6]
+               	sub	x26, x29, #0x79
+               	ldr	x0, [x1]
+               	ldr	x6, [x1, #0x8]
+               	ldrb	w7, [x1, #0x10]
+               	str	x0, [x26]
+               	str	x6, [x26, #0x8]
+               	strb	w7, [x26, #0x10]
+               	sub	x27, x29, #0x82
+               	ldr	x0, [x2]
+               	ldrb	w1, [x2, #0x8]
+               	str	x0, [x27]
+               	strb	w1, [x27, #0x8]
+               	sub	x28, x29, #0x90
+               	ldr	x0, [x3]
+               	ldr	w1, [x3, #0x8]
+               	str	x0, [x28]
+               	str	w1, [x28, #0x8]
+               	sub	x9, x29, #0xa0
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0xf
-               	ldr	x12, [x7]
-               	str	x12, [x23]
-               	sub	x7, x29, #0x20
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x1c
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x18
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x30
-               	ldr	x9, [x7]
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x28
-               	ldr	x9, [x7]
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x40
-               	ldr	d10, [x7]
-               	sub	x7, x29, #0x38
-               	ldr	d11, [x7]
-               	add	x7, x1, #0x0
-               	ldr	x9, [x7]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x7, x1, #0x8
-               	ldr	d12, [x7]
-               	sub	x9, x29, #0x81
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x1, [x2]
-               	ldr	x5, [x2, #0x8]
-               	ldrb	w3, [x2, #0x10]
-               	mov	x16, #0xfe70            ; =65136
+               	ldr	x0, [x4]
+               	ldr	x1, [x4, #0x8]
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfe70            ; =65136
+               	str	x0, [x9]
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	str	x5, [x9, #0x8]
-               	mov	x16, #0xfe70            ; =65136
+               	str	x1, [x9, #0x8]
+               	sub	x9, x29, #0xb1
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x5]
+               	ldr	x1, [x5, #0x8]
+               	ldrb	w2, [x5, #0x10]
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	strb	w3, [x9, #0x10]
-               	mov	x16, #0xfea0            ; =65184
+               	str	x0, [x9]
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrb	w9, [x1]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
+               	str	x1, [x9, #0x8]
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1
-               	ldr	x3, [x1]
-               	str	x3, [x24]
-               	add	x1, x4, #0x0
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe38            ; =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x1, x4, #0x4
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x1, x4, #0x8
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe28            ; =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	x9, [x1]
-               	mov	x16, #0xfe98            ; =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea8            ; =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	x9, [x1]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0x92
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x1, [x6]
-               	ldr	x9, [x6, #0x8]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldrb	w9, [x6, #0x10]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	str	x10, [x9, #0x8]
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	strb	w10, [x9, #0x10]
+               	strb	w2, [x9, #0x10]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x8
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	sub	x1, x29, #0x10c
+               	ldr	x2, [x22]
+               	ldrb	w5, [x22, #0x8]
+               	str	x2, [x1]
+               	strb	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldrb	w5, [x1, #0x8]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w5, [x29, x16]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
 <L1>:
                	bl	 <L1>
-               	ldr	x1, [x23]
-               	str	x1, [x25]
-               	ldr	x1, [x25]
-               	str	x1, [x27]
+               	mov	w1, w19
+<L2>:
+               	bl	 <L2>
+               	sub	x1, x29, #0x124
+               	ldr	x2, [x23]
+               	ldr	w5, [x23, #0x8]
+               	str	x2, [x1]
+               	str	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	w5, [x1, #0x8]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w5, [x29, x16]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
+<L3>:
+               	bl	 <L3>
+               	fmov	x1, d8
+<L4>:
+               	bl	 <L4>
+               	sub	x1, x29, #0x140
+               	ldr	x2, [x24]
+               	ldr	x5, [x24, #0x8]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x5, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x5
+<L5>:
+               	bl	 <L5>
+               	fmov	x1, d10
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fmov	x1, d11
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x5, x25, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x5, x16
+               	eor	x5, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	fmov	x1, d12
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x1, x20
+<L14>:
+               	bl	 <L14>
+               	sub	x1, x29, #0x151
+               	ldr	x2, [x26]
+               	ldr	x5, [x26, #0x8]
+               	ldrb	w6, [x26, #0x10]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	strb	w6, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x5, [x1, #0x8]
+               	ldrb	w6, [x1, #0x10]
+               	mov	x16, #0xfe97            ; =65175
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe9f            ; =65183
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	mov	x16, #0xfea7            ; =65191
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w6, [x29, x16]
+               	sub	x1, x29, #0x169
+<L15>:
+               	bl	 <L15>
+               	sub	x1, x29, #0x172
+               	ldr	x2, [x27]
+               	ldrb	w5, [x27, #0x8]
+               	str	x2, [x1]
+               	strb	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldrb	w5, [x1, #0x8]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w5, [x29, x16]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
+<L16>:
+               	bl	 <L16>
+               	sub	x1, x29, #0x18c
+               	ldr	x2, [x28]
+               	ldr	w5, [x28, #0x8]
+               	str	x2, [x1]
+               	str	w5, [x1, #0x8]
+               	ldr	x2, [x1]
                	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L2>:
-               	bl	 <L2>
-               	mov	x19, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x8
-               	b.lo	 <L3>
-               	b	 <L5>
-<L3>:
-               	add	x0, x27, x23
-               	ldrb	w1, [x0]
-               	mov	x0, x19
-<L4>:
-               	bl	 <L4>
-               	add	x23, x23, #0x1
-               	mov	x19, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L3>
-<L5>:
-               	mov	x0, x19
-               	mov	w1, w20
-<L6>:
-               	bl	 <L6>
-               	mov	x16, #0xfe60            ; =65120
+               	str	xzr, [x29, x16]
+               	ldr	w5, [x1, #0x8]
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfe58            ; =65112
+               	str	w5, [x29, x16]
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L9>:
-               	bl	 <L9>
-               	fmov	d0, d8
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfe48            ; =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L12>:
-               	bl	 <L12>
-               	fmov	d0, d10
-<L13>:
-               	bl	 <L13>
-               	fmov	d0, d11
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L15>:
-               	bl	 <L15>
-               	fmov	d0, d12
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x21
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
 <L17>:
                	bl	 <L17>
-               	sub	x1, x29, #0xe7
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x6, [x9]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x8, [x9, #0x8]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w12, [x9, #0x10]
-               	str	x6, [x1]
-               	str	x8, [x1, #0x8]
-               	strb	w12, [x1, #0x10]
-               	sub	x19, x29, #0xf8
-               	ldr	x6, [x1]
-               	ldr	x8, [x1, #0x8]
-               	ldrb	w12, [x1, #0x10]
-               	str	x6, [x19]
-               	str	x8, [x19, #0x8]
-               	strb	w12, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w6, [x1]
-               	mov	x1, x6
-<L18>:
-               	bl	 <L18>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x10
-               	b.lo	 <L19>
-               	b	 <L21>
-<L19>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w6, [x1]
-               	mov	x0, x20
-               	mov	x1, x6
-<L20>:
-               	bl	 <L20>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L19>
-<L21>:
-               	ldr	x0, [x24]
-               	str	x0, [x26]
-               	ldr	x0, [x26]
-               	str	x0, [x28]
-               	mov	x0, x20
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	mov	x19, x0
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x8
-               	b.lo	 <L23>
-               	b	 <L25>
-<L23>:
-               	add	x0, x28, x20
-               	ldrb	w1, [x0]
-               	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x8
-               	b.lo	 <L23>
-<L25>:
-               	mov	x0, x19
-               	mov	x16, #0xfe38            ; =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe28            ; =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe98            ; =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	sub	x1, x29, #0x109
-               	mov	x16, #0xfe88            ; =65160
+               	sub	x1, x29, #0x1a8
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x2, [x9]
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9, #0x8]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L18>:
+               	bl	 <L18>
+               	sub	x1, x29, #0x1b9
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x2, [x9]
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x3, [x9, #0x8]
-               	mov	x16, #0xfe88            ; =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w4, [x9, #0x10]
-               	str	x2, [x1]
-               	str	x3, [x1, #0x8]
-               	strb	w4, [x1, #0x10]
-               	sub	x19, x29, #0x11a
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldrb	w4, [x1, #0x10]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	strb	w4, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x10
-               	b.lo	 <L32>
-               	b	 <L34>
-<L32>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L32>
-<L34>:
-               	mov	x0, x20
-               	fmov	s0, s9
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x22
-<L36>:
-               	bl	 <L36>
-               	sub	x1, x29, #0x12b
-               	sub	x2, x29, #0x13c
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x3, [x9]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x4, [x9, #0x8]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldrb	w5, [x9, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	strb	w5, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldrb	w4, [x1, #0x10]
+               	mov	x16, #0xfe2f            ; =65071
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe37            ; =65079
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfe3f            ; =65087
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w4, [x29, x16]
+               	sub	x1, x29, #0x1d1
+<L19>:
+               	bl	 <L19>
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x1, x21
+<L21>:
+               	bl	 <L21>
+               	sub	x1, x29, #0x1e2
+               	sub	x2, x29, #0x1f3
+               	ldr	x3, [x26]
+               	ldr	x4, [x26, #0x8]
+               	ldrb	w5, [x26, #0x10]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
                	strb	w5, [x2, #0x10]
@@ -875,9 +934,9 @@ Disassembly of section __TEXT,__text:
                	strb	w4, [x2]
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x10
-               	b.lo	 <L37>
-               	b	 <L38>
-<L37>:
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
                	add	x3, x1, #0x1
                	add	x4, x3, x2
                	ldrb	w3, [x4]
@@ -887,103 +946,49 @@ Disassembly of section __TEXT,__text:
                	strb	w3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x10
-               	b.lo	 <L37>
-<L38>:
-               	sub	x2, x29, #0xa3
+               	b.lo	 <L22>
+<L23>:
+               	sub	x2, x29, #0xc2
                	ldr	x3, [x1]
                	ldr	x4, [x1, #0x8]
                	ldrb	w5, [x1, #0x10]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
                	strb	w5, [x2, #0x10]
-               	sub	x19, x29, #0xb4
                	ldr	x1, [x2]
                	ldr	x3, [x2, #0x8]
                	ldrb	w4, [x2, #0x10]
-               	str	x1, [x19]
-               	str	x3, [x19, #0x8]
-               	strb	w4, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x10
-               	b.lo	 <L40>
-               	b	 <L42>
-<L40>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L41>:
-               	bl	 <L41>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L40>
-<L42>:
-               	sub	x0, x29, #0xc5
-               	mov	x16, #0xfe70            ; =65136
+               	stur	x1, [x29, #-0xda]
+               	stur	x3, [x29, #-0xd2]
+               	sturb	w4, [x29, #-0xca]
+               	sub	x1, x29, #0xda
+<L24>:
+               	bl	 <L24>
+               	sub	x1, x29, #0xeb
+               	ldr	x2, [x26]
+               	ldr	x3, [x26, #0x8]
+               	ldrb	w4, [x26, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	strb	w4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldrb	w4, [x1, #0x10]
+               	mov	x16, #0xfefd            ; =65277
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x2, [x9, #0x8]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w3, [x9, #0x10]
-               	str	x1, [x0]
-               	str	x2, [x0, #0x8]
-               	strb	w3, [x0, #0x10]
-               	sub	x19, x29, #0xd6
-               	ldr	x1, [x0]
-               	ldr	x2, [x0, #0x8]
-               	ldrb	w3, [x0, #0x10]
-               	str	x1, [x19]
-               	str	x2, [x19, #0x8]
-               	strb	w3, [x19, #0x10]
-               	add	x0, x19, #0x0
-               	ldrb	w1, [x0]
-               	mov	x0, x20
-<L43>:
-               	bl	 <L43>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x10
-               	b.lo	 <L44>
-               	b	 <L46>
-<L44>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L45>:
-               	bl	 <L45>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L44>
-<L46>:
-               	mov	x0, x20
-               	sub	x16, x29, #0x240
+               	str	x2, [x29, x16]
+               	stur	x3, [x29, #-0xfb]
+               	sturb	w4, [x29, #-0xf3]
+               	sub	x1, x29, #0x103
+<L25>:
+               	bl	 <L25>
+               	sub	x16, x29, #0x270
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
                	ldur	d12, [x16, #-0x18]
-               	sub	x16, x29, #0x1f0
+               	sub	x16, x29, #0x220
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]
@@ -1191,51 +1196,95 @@ Disassembly of section __TEXT,__text:
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x9                ; =9
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x9               ; =9
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, #0xc                ; =12
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, #0x10               ; =16
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               ; =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, #0x10               ; =16
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x10              ; =16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x11               ; =17
+               	mov	x1, #0x10               ; =16
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x10               ; =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x11               ; =17
 <L8>:
                	bl	 <L8>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L9>:
                	bl	 <L9>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x4                ; =4
 <L10>:
                	bl	 <L10>
                	mov	x1, #0x8                ; =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L13>:
                	bl	 <L13>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L14>:
                	bl	 <L14>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x1                ; =1
 <L15>:
                	bl	 <L15>
                	mov	x1, #0x8                ; =8
@@ -1244,24 +1293,30 @@ Disassembly of section __TEXT,__text:
                	mov	x1, #0x8                ; =8
 <L17>:
                	bl	 <L17>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x8                ; =8
 <L18>:
                	bl	 <L18>
-               	sub	x20, x29, #0x60
+               	mov	x1, #0x8                ; =8
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x1                ; =1
+<L20>:
+               	bl	 <L20>
+               	sub	x20, x29, #0x88
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L19>:
+<L21>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L19>
+               	b.ne	 <L21>
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0xc
-               	b.lo	 <L20>
-               	b	 <L21>
-<L20>:
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1277,15 +1332,15 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L20>
-<L21>:
+               	b.lo	 <L22>
+<L23>:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L22>
-               	b	 <L33>
-<L22>:
+               	b.lo	 <L24>
+               	b	 <L35>
+<L24>:
                	mov	x16, #0x11              ; =17
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -1294,7 +1349,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x2, x1
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
-               	sub	x2, x29, #0x69
+               	sub	x2, x29, #0x9
                	str	xzr, [x2]
                	strb	wzr, [x2, #0x8]
                	mov	w4, w3
@@ -1302,9 +1357,9 @@ Disassembly of section __TEXT,__text:
                	strb	w4, [x5]
                	mov	x4, #0x0                ; =0
                	cmp	x4, #0x8
-               	b.lo	 <L23>
-               	b	 <L24>
-<L23>:
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
                	mov	x16, #0x8               ; =8
                	mul	x5, x4, x16
                	lsr	x6, x3, x5
@@ -1316,9 +1371,9 @@ Disassembly of section __TEXT,__text:
                	strb	w7, [x6]
                	add	x4, x4, #0x1
                	cmp	x4, #0x8
-               	b.lo	 <L23>
-<L24>:
-               	sub	x3, x29, #0x72
+               	b.lo	 <L25>
+<L26>:
+               	sub	x3, x29, #0x12
                	ldr	x4, [x2]
                	ldrb	w5, [x2, #0x8]
                	str	x4, [x3]
@@ -1328,7 +1383,7 @@ Disassembly of section __TEXT,__text:
                	mov	w5, w4
                	add	x2, x20, #0x18
                	ldr	x4, [x2]
-               	sub	x2, x29, #0x90
+               	sub	x2, x29, #0x94
                	mov	w6, w4
                	add	x7, x2, #0x0
                	str	w6, [x7]
@@ -1405,9 +1460,9 @@ Disassembly of section __TEXT,__text:
                	strb	w14, [x13]
                	mov	x13, #0x0               ; =0
                	cmp	x13, #0x10
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
                	mov	x16, #0x4               ; =4
                	mul	x14, x13, x16
                	lsr	x15, x12, x14
@@ -1419,8 +1474,8 @@ Disassembly of section __TEXT,__text:
                	strb	w24, [x15]
                	add	x13, x13, #0x1
                	cmp	x13, #0x10
-               	b.lo	 <L25>
-<L26>:
+               	b.lo	 <L27>
+<L28>:
                	sub	x12, x29, #0x122
                	ldr	x13, [x7]
                	ldr	x14, [x7, #0x8]
@@ -1438,9 +1493,9 @@ Disassembly of section __TEXT,__text:
                	strb	w14, [x15]
                	mov	x14, #0x0               ; =0
                	cmp	x14, #0x8
-               	b.lo	 <L27>
-               	b	 <L28>
-<L27>:
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
                	mov	x16, #0x8               ; =8
                	mul	x15, x14, x16
                	lsr	x24, x13, x15
@@ -1452,8 +1507,8 @@ Disassembly of section __TEXT,__text:
                	strb	w25, [x24]
                	add	x14, x14, #0x1
                	cmp	x14, #0x8
-               	b.lo	 <L27>
-<L28>:
+               	b.lo	 <L29>
+<L30>:
                	sub	x13, x29, #0x156
                	ldr	x14, [x7]
                	ldrb	w15, [x7, #0x8]
@@ -1495,9 +1550,9 @@ Disassembly of section __TEXT,__text:
                	strb	w26, [x25]
                	mov	x25, #0x0               ; =0
                	cmp	x25, #0x10
-               	b.lo	 <L29>
-               	b	 <L30>
-<L29>:
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
                	mov	x16, #0x4               ; =4
                	mul	x26, x25, x16
                	lsr	x27, x24, x26
@@ -1509,8 +1564,8 @@ Disassembly of section __TEXT,__text:
                	strb	w28, [x27]
                	add	x25, x25, #0x1
                	cmp	x25, #0x10
-               	b.lo	 <L29>
-<L30>:
+               	b.lo	 <L31>
+<L32>:
                	sub	x24, x29, #0x1c2
                	ldr	x25, [x15]
                	ldr	x26, [x15, #0x8]
@@ -1638,19 +1693,19 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x7, x9
-<L31>:
-               	bl	 <L31>
+<L33>:
+               	bl	 <L33>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L32>:
-               	bl	 <L32>
+<L34>:
+               	bl	 <L34>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L22>
-<L33>:
-               	sub	x0, x29, #0x7b
+               	b.lo	 <L24>
+<L35>:
+               	sub	x0, x29, #0x1b
                	str	xzr, [x0]
                	strb	wzr, [x0, #0x8]
                	mov	w1, w22
@@ -1658,9 +1713,9 @@ Disassembly of section __TEXT,__text:
                	strb	w1, [x2]
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x8
-               	b.lo	 <L34>
-               	b	 <L35>
-<L34>:
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
                	mov	x16, #0x8               ; =8
                	mul	x2, x1, x16
                	lsr	x3, x22, x2
@@ -1672,15 +1727,15 @@ Disassembly of section __TEXT,__text:
                	strb	w4, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L34>
-<L35>:
-               	sub	x1, x29, #0x84
+               	b.lo	 <L36>
+<L37>:
+               	sub	x1, x29, #0x24
                	ldr	x2, [x0]
                	ldrb	w3, [x0, #0x8]
                	str	x2, [x1]
                	strb	w3, [x1, #0x8]
                	mov	w3, w22
-               	sub	x0, x29, #0x9c
+               	sub	x0, x29, #0xa0
                	mov	w2, w22
                	add	x4, x0, #0x0
                	str	w2, [x4]
@@ -1746,9 +1801,9 @@ Disassembly of section __TEXT,__text:
                	strb	w12, [x8]
                	mov	x8, #0x0                ; =0
                	cmp	x8, #0x10
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
                	mov	x16, #0x4               ; =4
                	mul	x12, x8, x16
                	lsr	x13, x22, x12
@@ -1760,8 +1815,8 @@ Disassembly of section __TEXT,__text:
                	strb	w14, [x13]
                	add	x8, x8, #0x1
                	cmp	x8, #0x10
-               	b.lo	 <L36>
-<L37>:
+               	b.lo	 <L38>
+<L39>:
                	sub	x8, x29, #0x144
                	ldr	x12, [x6]
                	ldr	x13, [x6, #0x8]
@@ -1779,9 +1834,9 @@ Disassembly of section __TEXT,__text:
                	strb	w13, [x14]
                	mov	x13, #0x0               ; =0
                	cmp	x13, #0x8
-               	b.lo	 <L38>
-               	b	 <L39>
-<L38>:
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
                	mov	x16, #0x8               ; =8
                	mul	x14, x13, x16
                	lsr	x15, x12, x14
@@ -1793,8 +1848,8 @@ Disassembly of section __TEXT,__text:
                	strb	w19, [x15]
                	add	x13, x13, #0x1
                	cmp	x13, #0x8
-               	b.lo	 <L38>
-<L39>:
+               	b.lo	 <L40>
+<L41>:
                	sub	x12, x29, #0x168
                	ldr	x13, [x6]
                	ldrb	w14, [x6, #0x8]
@@ -1836,9 +1891,9 @@ Disassembly of section __TEXT,__text:
                	strb	w23, [x19]
                	mov	x19, #0x0               ; =0
                	cmp	x19, #0x10
-               	b.lo	 <L40>
-               	b	 <L41>
-<L40>:
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
                	mov	x16, #0x4               ; =4
                	mul	x23, x19, x16
                	lsr	x24, x15, x23
@@ -1850,8 +1905,8 @@ Disassembly of section __TEXT,__text:
                	strb	w25, [x24]
                	add	x19, x19, #0x1
                	cmp	x19, #0x10
-               	b.lo	 <L40>
-<L41>:
+               	b.lo	 <L42>
+<L43>:
                	sub	x15, x29, #0x22a
                	ldr	x19, [x14]
                	ldr	x23, [x14, #0x8]
@@ -1969,12 +2024,12 @@ Disassembly of section __TEXT,__text:
                	mov	x5, x24
                	mov	x6, x25
                	mov	x7, x26
-<L42>:
-               	bl	 <L42>
+<L44>:
+               	bl	 <L44>
                	mov	x1, x0
                	mov	x0, x21
-<L43>:
-               	bl	 <L43>
+<L45>:
+               	bl	 <L45>
                	sub	x16, x29, #0x290
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]

--- a/test/golden/aarch64-darwin/call/call_rec_large.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_large.dis
@@ -18,187 +18,369 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	d8, d9, [x29, #-0x30]
-               	mov	x1, x0
+               	sub	sp, sp, #0x20
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	sub	x2, x29, #0x18
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	ldr	d8, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d9, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x18
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x10
+               	ldr	d1, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d2, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	d8, d9, [x29, #-0x30]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	fmov	x1, d2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24m>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	d8, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	d8, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x14
-               	ldr	w20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	d0, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w4, [x2]
+               	add	x2, x1, #0x14
+               	ldr	w1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	fmov	x2, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldur	d8, [x29, #-0x18]
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w2, w4
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x5, [x2]
+               	add	x2, x1, #0x18
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x5, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l32n>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	add	x4, x3, #0x0
-               	ldr	x5, [x4]
-               	add	x4, x3, #0x8
-               	ldr	x19, [x4]
+               	sub	sp, sp, #0x10
+               	stur	x19, [x29, #-0x8]
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldr	x4, [x3]
+               	add	x3, x2, #0x8
+               	ldr	x2, [x3]
                	add	x3, x1, #0x10
                	add	x1, x3, #0x0
-               	ldr	x20, [x1]
+               	ldr	x5, [x1]
                	add	x1, x3, #0x8
-               	ldr	x21, [x1]
-               	mov	x0, x2
-               	mov	x1, x5
+               	ldr	x19, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
+               	mov	x1, x5
+<L4>:
+               	bl	 <L4>
+               	mov	x1, x19
+<L5>:
+               	bl	 <L5>
+               	ldur	x19, [x29, #-0x8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -285,33 +467,21 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x4
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	w1, w19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	w1, w20
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x21
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x22
 <L6>:
                	bl	 <L6>
@@ -416,33 +586,41 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_large.take_large>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1a0
-               	stp	x19, x20, [x29, #-0x120]
-               	stp	x21, x22, [x29, #-0x130]
-               	stp	x23, x24, [x29, #-0x140]
-               	stp	x25, x26, [x29, #-0x150]
-               	stp	x27, x28, [x29, #-0x160]
-               	stp	d8, d9, [x29, #-0x170]
-               	stp	d10, d11, [x29, #-0x180]
-               	stp	d12, d13, [x29, #-0x190]
-               	stp	d14, d15, [x29, #-0x1a0]
-               	mov	x19, x0
+               	sub	sp, sp, #0x320
+               	sub	x16, x29, #0x2a0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x2f0
+               	stp	d8, d9, [x16]
+               	stp	d10, d11, [x16, #-0x10]
+               	stp	d12, d13, [x16, #-0x20]
+               	stp	d14, d15, [x16, #-0x30]
+               	mov	x9, x0
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	mov	w20, w3
+               	mov	w19, w3
                	fmov	d8, d3
-               	ldr	x3, [x29, #0x10]
-               	ldr	x8, [x29, #0x18]
+               	ldr	x0, [x29, #0x10]
+               	ldr	x3, [x29, #0x18]
                	ldr	x12, [x29, #0x20]
                	fmov	s9, s4
-               	ldr	x21, [x29, #0x28]
-               	add	x13, x1, #0x0
-               	ldr	x22, [x13]
-               	add	x13, x1, #0x8
-               	ldr	x23, [x13]
-               	add	x13, x1, #0x10
-               	ldr	x24, [x13]
+               	ldr	x20, [x29, #0x28]
+               	sub	x21, x29, #0x30
+               	ldr	x13, [x1]
+               	ldr	x14, [x1, #0x8]
+               	ldr	x15, [x1, #0x10]
+               	str	x13, [x21]
+               	str	x14, [x21, #0x8]
+               	str	x15, [x21, #0x10]
                	sub	x1, x29, #0x18
                	ldr	d10, [x1]
                	sub	x1, x29, #0x10
@@ -450,372 +628,1021 @@ Disassembly of section __TEXT,__text:
                	sub	x1, x29, #0x8
                	ldr	d12, [x1]
                	add	x1, x2, #0x0
-               	ldr	x25, [x1]
+               	ldr	x22, [x1]
                	add	x1, x2, #0x8
                	ldr	d13, [x1]
                	add	x1, x2, #0x10
-               	ldr	w26, [x1]
+               	ldr	w23, [x1]
                	add	x1, x2, #0x14
-               	ldr	w27, [x1]
-               	add	x1, x4, #0x0
-               	ldr	x28, [x1]
-               	add	x1, x4, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc0]
-               	add	x1, x4, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc8]
-               	add	x1, x4, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd0]
+               	ldr	w24, [x1]
+               	sub	x25, x29, #0x50
+               	ldr	x1, [x4]
+               	ldr	x2, [x4, #0x8]
+               	ldr	x13, [x4, #0x10]
+               	ldr	x14, [x4, #0x18]
+               	str	x1, [x25]
+               	str	x2, [x25, #0x8]
+               	str	x13, [x25, #0x10]
+               	str	x14, [x25, #0x18]
                	add	x1, x5, #0x0
-               	add	x14, x1, #0x0
-               	ldr	x9, [x14]
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x14, x1, #0x8
-               	ldr	x9, [x14]
-               	stur	x9, [x29, #-0x20]
+               	add	x2, x1, #0x0
+               	ldr	x26, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x27, [x2]
                	add	x1, x5, #0x10
-               	add	x5, x1, #0x0
-               	ldr	x9, [x5]
-               	mov	x16, #0xfef0            ; =65264
+               	add	x2, x1, #0x0
+               	ldr	x28, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x9, [x2]
+               	mov	x16, #0xfd78            ; =64888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	add	x5, x1, #0x8
-               	ldr	x9, [x5]
-               	stur	x9, [x29, #-0x28]
                	add	x1, x6, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x30]
+               	mov	x16, #0xfdb8            ; =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x38]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x40]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x48]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe0]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x50]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x8
                	ldr	d14, [x1]
                	add	x1, x7, #0x10
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x58]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x14
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x60]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x18
                	ldr	d15, [x1]
                	add	x1, x7, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x68]
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe8]
-               	add	x1, x3, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x70]
-               	add	x1, x3, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x78]
-               	add	x1, x3, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf0]
-               	add	x1, x8, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x80]
-               	add	x1, x8, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x88]
-               	add	x1, x8, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x90]
-               	add	x1, x8, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf8]
-               	add	x1, x12, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x98]
-               	add	x1, x12, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa0]
-               	add	x1, x12, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa8]
-               	add	x1, x12, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb0]
-               	add	x1, x12, #0x20
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb8]
-               	add	x1, x12, #0x28
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x100]
+               	mov	x16, #0xfd90            ; =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x9, x29, #0x68
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x1, [x0]
+               	ldr	x8, [x0, #0x8]
+               	ldr	x9, [x0, #0x10]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x1, [x9]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x8, [x9, #0x8]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x10]
+               	sub	x9, x29, #0x88
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x3]
+               	ldr	x1, [x3, #0x8]
+               	ldr	x9, [x3, #0x10]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x9, [x3, #0x18]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x1, [x9, #0x8]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x10]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x18]
+               	add	x0, x12, #0x0
+               	ldr	x9, [x0]
+               	mov	x16, #0xfd88            ; =64904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x8
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe48            ; =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x10
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x18
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x20
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x28
+               	ldr	x9, [x0]
+               	mov	x16, #0xfd80            ; =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x9, x0
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	sub	x1, x29, #0xa0
+               	ldr	x0, [x21]
+               	ldr	x9, [x21, #0x8]
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x9, [x21, #0x10]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	str	x0, [x1]
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x1, #0x8]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x1, #0x10]
+               	ldr	x0, [x1]
+               	ldr	x21, [x1, #0x8]
+               	ldr	x9, [x1, #0x10]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	stur	x0, [x29, #-0xb8]
+               	stur	x21, [x29, #-0xb0]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	stur	x9, [x29, #-0xa8]
+               	sub	x1, x29, #0xb8
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
 <L1>:
                	bl	 <L1>
-               	mov	x1, x22
+               	fmov	x9, d10
+               	mov	x16, #0xfe08            ; =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x21, x16
+               	mov	x16, #0xfe08            ; =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x0, x16
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x0, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x24
+               	fmov	x9, d11
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fmov	d0, d10
+               	mov	x16, #0x8               ; =8
+               	mul	x0, x21, x16
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              ; =255
+               	and	x0, x1, x16
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	fmov	d0, d11
+               	fmov	x9, d12
+               	mov	x16, #0xfde8            ; =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	fmov	d0, d12
+               	mov	x16, #0x8               ; =8
+               	mul	x0, x21, x16
+               	mov	x16, #0xfde8            ; =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              ; =255
+               	and	x0, x1, x16
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfdd8            ; =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	fmov	d0, d13
+               	mov	x16, #0x8               ; =8
+               	mul	x21, x1, x16
+               	lsr	x0, x22, x21
+               	mov	x16, #0xff              ; =255
+               	and	x21, x0, x16
+               	mov	x16, #0xfdd8            ; =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x21
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x0, x16
+               	add	x1, x1, #0x1
+               	mov	x9, x21
+               	mov	x16, #0xfdd8            ; =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	w1, w26
+               	fmov	x9, d13
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfdd8            ; =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w1, w27
+               	mov	x16, #0x8               ; =8
+               	mul	x22, x21, x16
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x22
+               	mov	x16, #0xff              ; =255
+               	and	x22, x0, x16
+               	eor	x0, x1, x22
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x0, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w1, w20
+               	mov	w0, w23
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x28
+               	mov	x16, #0x8               ; =8
+               	mul	x22, x21, x16
+               	lsr	x23, x0, x22
+               	mov	x16, #0xff              ; =255
+               	and	x22, x23, x16
+               	eor	x23, x1, x22
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x23, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
+               	mov	w0, w24
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0xc8]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x22, x21, x16
+               	lsr	x23, x0, x22
+               	mov	x16, #0xff              ; =255
+               	and	x22, x23, x16
+               	eor	x23, x1, x22
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x23, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldur	x9, [x29, #-0xd0]
-               	mov	x1, x9
+               	mov	w21, w19
+               	mov	x0, x1
+               	mov	x1, x21
 <L16>:
                	bl	 <L16>
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	sub	x1, x29, #0xd8
+               	ldr	x19, [x25]
+               	ldr	x21, [x25, #0x8]
+               	ldr	x22, [x25, #0x10]
+               	ldr	x23, [x25, #0x18]
+               	str	x19, [x1]
+               	str	x21, [x1, #0x8]
+               	str	x22, [x1, #0x10]
+               	str	x23, [x1, #0x18]
+               	ldr	x19, [x1]
+               	ldr	x21, [x1, #0x8]
+               	ldr	x22, [x1, #0x10]
+               	ldr	x23, [x1, #0x18]
+               	stur	x19, [x29, #-0xf8]
+               	stur	x21, [x29, #-0xf0]
+               	stur	x22, [x29, #-0xe8]
+               	stur	x23, [x29, #-0xe0]
+               	sub	x1, x29, #0xf8
 <L17>:
                	bl	 <L17>
-               	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0x8               ; =8
+               	mul	x19, x1, x16
+               	lsr	x21, x26, x19
+               	mov	x16, #0xff              ; =255
+               	and	x19, x21, x16
+               	eor	x21, x0, x19
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x21, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x19, x1, x16
+               	lsr	x21, x27, x19
+               	mov	x16, #0xff              ; =255
+               	and	x19, x21, x16
+               	eor	x21, x0, x19
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x21, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x1, x28
+<L22>:
+               	bl	 <L22>
+               	mov	x16, #0xfd78            ; =64888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x28]
-               	mov	x1, x9
-<L20>:
-               	bl	 <L20>
-               	fmov	d0, d8
-<L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0xd8]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	ldur	x9, [x29, #-0x30]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0x38]
-               	mov	x1, x9
+               	fmov	x1, d8
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0x40]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0x48]
+               	mov	x16, #0xfdb8            ; =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xe0]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0x50]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L28>:
                	bl	 <L28>
-               	fmov	d0, d14
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L29>:
                	bl	 <L29>
-               	ldur	x9, [x29, #-0x58]
-               	mov	w1, w9
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L30>:
                	bl	 <L30>
-               	ldur	x9, [x29, #-0x60]
-               	mov	w1, w9
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L31>:
                	bl	 <L31>
-               	fmov	d0, d15
+               	fmov	x1, d14
 <L32>:
                	bl	 <L32>
-               	ldur	x9, [x29, #-0x68]
-               	mov	x1, x9
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w1, w9
 <L33>:
                	bl	 <L33>
-               	ldur	x9, [x29, #-0xe8]
-               	mov	x1, x9
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w1, w9
 <L34>:
                	bl	 <L34>
-               	ldur	x9, [x29, #-0x70]
-               	mov	x1, x9
+               	fmov	x1, d15
 <L35>:
                	bl	 <L35>
-               	ldur	x9, [x29, #-0x78]
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	ldur	x9, [x29, #-0xf0]
+               	mov	x16, #0xfd90            ; =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L37>:
                	bl	 <L37>
-               	ldur	x9, [x29, #-0x80]
-               	mov	x1, x9
+               	sub	x1, x29, #0x110
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9, #0x8]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x19, [x9, #0x10]
+               	str	x4, [x1]
+               	str	x7, [x1, #0x8]
+               	str	x19, [x1, #0x10]
+               	ldr	x4, [x1]
+               	ldr	x7, [x1, #0x8]
+               	ldr	x19, [x1, #0x10]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x7, [x29, x16]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x19, [x29, x16]
+               	sub	x1, x29, #0x128
 <L38>:
                	bl	 <L38>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
+               	sub	x1, x29, #0x148
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9, #0x8]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x19, [x9, #0x10]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x21, [x9, #0x18]
+               	str	x4, [x1]
+               	str	x7, [x1, #0x8]
+               	str	x19, [x1, #0x10]
+               	str	x21, [x1, #0x18]
+               	ldr	x4, [x1]
+               	ldr	x7, [x1, #0x8]
+               	ldr	x8, [x1, #0x10]
+               	ldr	x19, [x1, #0x18]
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x7, [x29, x16]
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x19, [x29, x16]
+               	sub	x1, x29, #0x168
 <L39>:
                	bl	 <L39>
-               	ldur	x9, [x29, #-0x90]
+               	mov	x16, #0xfd88            ; =64904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0xf8]
+               	mov	x16, #0xfe48            ; =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x98]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0xa0]
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L43>:
                	bl	 <L43>
-               	ldur	x9, [x29, #-0xa8]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L44>:
                	bl	 <L44>
-               	ldur	x9, [x29, #-0xb0]
+               	mov	x16, #0xfd80            ; =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L45>:
                	bl	 <L45>
-               	ldur	x9, [x29, #-0xb8]
-               	mov	x1, x9
+               	fmov	w1, s9
+               	mov	w3, w1
+               	mov	x1, x3
 <L46>:
                	bl	 <L46>
-               	ldur	x9, [x29, #-0x100]
-               	mov	x1, x9
+               	mov	x1, x20
 <L47>:
                	bl	 <L47>
-               	fmov	s0, s9
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x21
-<L49>:
-               	bl	 <L49>
-               	ldur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1
-               	ldur	x9, [x29, #-0xe0]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	eor	x19, x9, x16
+<L48>:
+               	bl	 <L48>
+               	mov	x16, #0xfdb8            ; =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L49>:
+               	bl	 <L49>
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L50>:
                	bl	 <L50>
-               	ldur	x9, [x29, #-0x30]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L51>:
                	bl	 <L51>
-               	ldur	x9, [x29, #-0x38]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L52>:
                	bl	 <L52>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
+               	mov	x1, x19
 <L53>:
                	bl	 <L53>
-               	ldur	x9, [x29, #-0x48]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L54>:
                	bl	 <L54>
-               	mov	x1, x19
+               	mov	x16, #0xfdb8            ; =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L55>:
                	bl	 <L55>
-               	ldur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	ldur	x9, [x29, #-0x30]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L57>:
                	bl	 <L57>
-               	ldur	x9, [x29, #-0x38]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L58>:
                	bl	 <L58>
-               	ldur	x9, [x29, #-0x40]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L59>:
                	bl	 <L59>
-               	ldur	x9, [x29, #-0x48]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
-               	ldur	x9, [x29, #-0xe0]
-               	mov	x1, x9
-<L61>:
-               	bl	 <L61>
-               	ldp	d8, d9, [x29, #-0x170]
-               	ldp	d10, d11, [x29, #-0x180]
-               	ldp	d12, d13, [x29, #-0x190]
-               	ldp	d14, d15, [x29, #-0x1a0]
-               	ldp	x19, x20, [x29, #-0x120]
-               	ldp	x21, x22, [x29, #-0x130]
-               	ldp	x23, x24, [x29, #-0x140]
-               	ldp	x25, x26, [x29, #-0x150]
-               	ldp	x27, x28, [x29, #-0x160]
+               	sub	x16, x29, #0x2f0
+               	ldp	d8, d9, [x16]
+               	ldp	d10, d11, [x16, #-0x10]
+               	ldp	d12, d13, [x16, #-0x20]
+               	ldp	d14, d15, [x16, #-0x30]
+               	sub	x16, x29, #0x2a0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -1091,6 +1918,11 @@ Disassembly of section __TEXT,__text:
                	sub	x16, x29, #0x640
                	str	d8, [x16, #0x8]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x18               ; =24
 <L0>:
                	bl	 <L0>
                	mov	x1, #0x18               ; =24
@@ -1099,19 +1931,19 @@ Disassembly of section __TEXT,__text:
                	mov	x1, #0x18               ; =24
 <L2>:
                	bl	 <L2>
-               	mov	x1, #0x18               ; =24
+               	mov	x1, #0x20               ; =32
 <L3>:
                	bl	 <L3>
                	mov	x1, #0x20               ; =32
 <L4>:
                	bl	 <L4>
-               	mov	x1, #0x20               ; =32
+               	mov	x1, #0x30               ; =48
 <L5>:
                	bl	 <L5>
                	mov	x1, #0x30               ; =48
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x30               ; =48
+               	mov	x1, #0x8                ; =8
 <L7>:
                	bl	 <L7>
                	mov	x1, #0x8                ; =8
@@ -1120,45 +1952,42 @@ Disassembly of section __TEXT,__text:
                	mov	x1, #0x8                ; =8
 <L9>:
                	bl	 <L9>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x10               ; =16
 <L10>:
                	bl	 <L10>
                	mov	x1, #0x10               ; =16
 <L11>:
                	bl	 <L11>
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x14               ; =20
 <L12>:
                	bl	 <L12>
-               	mov	x1, #0x14               ; =20
+               	mov	x1, #0x10               ; =16
 <L13>:
                	bl	 <L13>
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x28               ; =40
 <L14>:
                	bl	 <L14>
-               	mov	x1, #0x28               ; =40
+               	mov	x1, #0x18               ; =24
 <L15>:
                	bl	 <L15>
-               	mov	x1, #0x18               ; =24
+               	mov	x1, #0x28               ; =40
 <L16>:
                	bl	 <L16>
-               	mov	x1, #0x28               ; =40
-<L17>:
-               	bl	 <L17>
-               	sub	x20, x29, #0x60
+               	sub	x20, x29, #0x90
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L18>:
+<L17>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L18>
+               	b.ne	 <L17>
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0xc
-               	b.lo	 <L19>
-               	b	 <L20>
-<L19>:
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1174,15 +2003,15 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L19>
-<L20>:
+               	b.lo	 <L18>
+<L19>:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L21>
-               	b	 <L25>
-<L21>:
+               	b.lo	 <L20>
+               	b	 <L24>
+<L20>:
                	mov	x16, #0x13              ; =19
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -1191,7 +2020,7 @@ Disassembly of section __TEXT,__text:
                	add	x24, x2, x1
                	add	x0, x20, #0x8
                	ldr	x2, [x0]
-               	sub	x25, x29, #0x78
+               	sub	x25, x29, #0x18
                	add	x0, x25, #0x0
                	str	x2, [x0]
                	mov	x16, #0x3               ; =3
@@ -1414,8 +2243,8 @@ Disassembly of section __TEXT,__text:
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	mov	x0, x2
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1840,19 +2669,19 @@ Disassembly of section __TEXT,__text:
                	fmov	d3, d8
                	mov	x6, x15
                	mov	x7, x25
-<L23>:
-               	bl	 <L23>
+<L22>:
+               	bl	 <L22>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L24>:
-               	bl	 <L24>
+<L23>:
+               	bl	 <L23>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L21>
-<L25>:
-               	sub	x19, x29, #0x90
+               	b.lo	 <L20>
+<L24>:
+               	sub	x19, x29, #0x30
                	add	x0, x19, #0x0
                	str	x22, [x0]
                	mov	x16, #0x3               ; =3
@@ -1983,8 +2812,8 @@ Disassembly of section __TEXT,__text:
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	mov	x0, x22
-<L26>:
-               	bl	 <L26>
+<L25>:
+               	bl	 <L25>
                	mov	x16, #0xfa28            ; =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -2339,12 +3168,12 @@ Disassembly of section __TEXT,__text:
                	fmov	d3, d8
                	mov	x6, x12
                	mov	x7, x13
-<L27>:
-               	bl	 <L27>
+<L26>:
+               	bl	 <L26>
                	mov	x1, x0
                	mov	x0, x21
-<L28>:
-               	bl	 <L28>
+<L27>:
+               	bl	 <L27>
                	sub	x16, x29, #0x640
                	ldr	d8, [x16, #0x8]
                	sub	x16, x29, #0x5f0

--- a/test/golden/aarch64-darwin/call/call_rec_small.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_small.dis
@@ -21,14 +21,28 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x2, x0
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -36,24 +50,50 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r2>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
+               	ldrb	w2, [x1]
                	sub	x1, x29, #0x7
-               	ldrb	w19, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrb	w3, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -61,31 +101,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r4>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
+               	ldrb	w2, [x1]
                	sub	x1, x29, #0x7
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x6
-               	ldrh	w20, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrh	w4, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxth	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -93,31 +173,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldr	w3, [x1]
+               	ldr	w2, [x1]
                	sub	x1, x29, #0x4
-               	ldrh	w19, [x1]
+               	ldrh	w3, [x1]
                	sub	x1, x29, #0x2
-               	ldrb	w20, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
+               	ldrb	w4, [x1]
+               	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxth	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxtb	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -125,266 +245,358 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                ; =2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               ; =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               ; =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                ; =2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x8               ; =8
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                ; =2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x6                ; =6
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               ; =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x1, #0x4                ; =4
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x1                ; =1
+<L15>:
+               	bl	 <L15>
+               	mov	x1, #0x1                ; =1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, #0x2                ; =2
+<L17>:
+               	bl	 <L17>
+               	mov	x1, #0x4                ; =4
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x6                ; =6
+<L19>:
+               	bl	 <L19>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_small.take_small>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xf0
-               	stp	x19, x20, [x29, #-0xa0]
-               	stp	x21, x22, [x29, #-0xb0]
-               	stp	x23, x24, [x29, #-0xc0]
-               	stp	x25, x26, [x29, #-0xd0]
-               	stp	x27, x28, [x29, #-0xe0]
-               	stp	d8, d9, [x29, #-0xf0]
-               	mov	x19, x0
+               	sub	sp, sp, #0x120
+               	stp	x19, x20, [x29, #-0xd0]
+               	stp	x21, x22, [x29, #-0xe0]
+               	stp	x23, x24, [x29, #-0xf0]
+               	stp	x25, x26, [x29, #-0x100]
+               	stp	x27, x28, [x29, #-0x110]
+               	stp	d8, d9, [x29, #-0x120]
+               	mov	x8, x0
                	stur	x1, [x29, #-0x8]
-               	mov	w20, w2
+               	mov	w19, w2
                	stur	x3, [x29, #-0x10]
                	fmov	d8, d0
                	stur	x4, [x29, #-0x18]
-               	mov	x21, x5
+               	mov	x20, x5
                	stur	x6, [x29, #-0x20]
                	stur	x7, [x29, #-0x28]
-               	add	x1, x29, #0x10
-               	add	x2, x29, #0x12
-               	add	x3, x29, #0x18
+               	add	x0, x29, #0x10
+               	add	x1, x29, #0x12
+               	add	x2, x29, #0x18
                	fmov	s9, s1
-               	ldr	x22, [x29, #0x20]
-               	sub	x4, x29, #0x8
-               	ldrb	w23, [x4]
-               	sub	x4, x29, #0x10
-               	ldrb	w24, [x4]
-               	sub	x4, x29, #0xf
-               	ldrb	w25, [x4]
-               	sub	x4, x29, #0x18
-               	ldrb	w26, [x4]
-               	sub	x4, x29, #0x17
-               	ldrb	w27, [x4]
-               	sub	x4, x29, #0x16
-               	ldrh	w28, [x4]
-               	sub	x4, x29, #0x20
-               	ldr	w9, [x4]
-               	stur	x9, [x29, #-0x38]
-               	sub	x4, x29, #0x1c
-               	ldrh	w9, [x4]
-               	stur	x9, [x29, #-0x40]
-               	sub	x4, x29, #0x1a
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x48]
-               	sub	x4, x29, #0x28
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x50]
-               	add	x4, x1, #0x0
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x58]
-               	add	x4, x1, #0x1
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x60]
-               	add	x1, x2, #0x0
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x68]
-               	add	x1, x2, #0x1
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x70]
-               	add	x1, x2, #0x2
-               	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x78]
-               	add	x1, x3, #0x0
-               	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x80]
-               	add	x1, x3, #0x4
-               	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x30]
-               	add	x1, x3, #0x6
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x88]
+               	ldr	x21, [x29, #0x20]
+               	sub	x3, x29, #0x8
+               	ldrb	w22, [x3]
+               	sub	x23, x29, #0x2a
+               	ldurh	w3, [x29, #-0x10]
+               	strh	w3, [x23]
+               	sub	x24, x29, #0x2e
+               	ldur	w3, [x29, #-0x18]
+               	str	w3, [x24]
+               	sub	x25, x29, #0x38
+               	ldur	x3, [x29, #-0x20]
+               	str	x3, [x25]
+               	sub	x3, x29, #0x28
+               	ldrb	w26, [x3]
+               	sub	x27, x29, #0x3a
+               	ldrh	w3, [x0]
+               	strh	w3, [x27]
+               	sub	x28, x29, #0x3e
+               	ldr	w0, [x1]
+               	str	w0, [x28]
+               	sub	x9, x29, #0x48
+               	stur	x9, [x29, #-0xc0]
+               	ldr	x0, [x2]
+               	ldur	x9, [x29, #-0xc0]
+               	str	x0, [x9]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x8
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxtb	w1, w22
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	w1, w20
+               	mov	w1, w19
 <L3>:
                	bl	 <L3>
-               	mov	x1, x24
+               	sub	x1, x29, #0x4a
+               	ldrh	w2, [x23]
+               	strh	w2, [x1]
+               	stur	xzr, [x29, #-0x58]
+               	ldrh	w2, [x1]
+               	sturh	w2, [x29, #-0x58]
+               	ldur	x1, [x29, #-0x58]
 <L4>:
                	bl	 <L4>
-               	mov	x1, x25
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	fmov	d0, d8
+               	sub	x1, x29, #0x5c
+               	ldr	w2, [x24]
+               	str	w2, [x1]
+               	stur	xzr, [x29, #-0x68]
+               	ldr	w2, [x1]
+               	stur	w2, [x29, #-0x68]
+               	ldur	x1, [x29, #-0x68]
 <L6>:
                	bl	 <L6>
-               	mov	x1, x26
+               	mov	x1, x20
 <L7>:
                	bl	 <L7>
-               	mov	x1, x27
+               	sub	x1, x29, #0x70
+               	ldr	x2, [x25]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L8>:
                	bl	 <L8>
-               	mov	x1, x28
+               	uxtb	w1, w26
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	ldur	x9, [x29, #-0x38]
-               	mov	w1, w9
+               	sub	x1, x29, #0x72
+               	ldrh	w2, [x27]
+               	strh	w2, [x1]
+               	stur	xzr, [x29, #-0x80]
+               	ldrh	w2, [x1]
+               	sturh	w2, [x29, #-0x80]
+               	ldur	x1, [x29, #-0x80]
 <L11>:
                	bl	 <L11>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
+               	sub	x1, x29, #0x84
+               	ldr	w2, [x28]
+               	str	w2, [x1]
+               	stur	xzr, [x29, #-0x90]
+               	ldr	w2, [x1]
+               	stur	w2, [x29, #-0x90]
+               	ldur	x1, [x29, #-0x90]
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0x48]
-               	mov	x1, x9
+               	sub	x1, x29, #0x98
+               	ldur	x9, [x29, #-0xc0]
+               	ldr	x2, [x9]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0x50]
-               	mov	x1, x9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x58]
-               	mov	x1, x9
+               	mov	x1, x21
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x60]
-               	mov	x1, x9
+               	sub	x1, x29, #0xa0
+               	sub	x2, x29, #0xa8
+               	ldr	x3, [x25]
+               	str	x3, [x2]
+               	ldr	x3, [x2]
+               	str	x3, [x1]
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	add	w4, w3, #0x1
+               	str	w4, [x2]
+               	add	x2, x1, #0x4
+               	ldrh	w3, [x2]
+               	add	w4, w3, #0x2
+               	strh	w4, [x2]
+               	add	x2, x1, #0x6
+               	ldrb	w3, [x2]
+               	add	w4, w3, #0x3
+               	strb	w4, [x2]
+               	sub	x2, x29, #0xb0
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	ldr	x1, [x2]
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x68]
-               	mov	x1, x9
+               	sub	x1, x29, #0xb8
+               	ldr	x2, [x25]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
-               	ldur	x9, [x29, #-0x70]
-               	mov	x1, x9
-<L18>:
-               	bl	 <L18>
-               	ldur	x9, [x29, #-0x78]
-               	mov	x1, x9
-<L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x80]
-               	mov	w1, w9
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	fmov	s0, s9
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x22
-<L24>:
-               	bl	 <L24>
-               	ldur	x9, [x29, #-0x38]
-               	add	w1, w9, #0x1
-               	ldur	x9, [x29, #-0x40]
-               	add	w19, w9, #0x2
-               	ldur	x9, [x29, #-0x48]
-               	add	w20, w9, #0x3
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x19
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x20
-<L27>:
-               	bl	 <L27>
-               	ldur	x9, [x29, #-0x38]
-               	mov	w1, w9
-<L28>:
-               	bl	 <L28>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	ldur	x9, [x29, #-0x48]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	ldp	d8, d9, [x29, #-0xf0]
-               	ldp	x19, x20, [x29, #-0xa0]
-               	ldp	x21, x22, [x29, #-0xb0]
-               	ldp	x23, x24, [x29, #-0xc0]
-               	ldp	x25, x26, [x29, #-0xd0]
-               	ldp	x27, x28, [x29, #-0xe0]
+               	ldp	d8, d9, [x29, #-0x120]
+               	ldp	x19, x20, [x29, #-0xd0]
+               	ldp	x21, x22, [x29, #-0xe0]
+               	ldp	x23, x24, [x29, #-0xf0]
+               	ldp	x25, x26, [x29, #-0x100]
+               	ldp	x27, x28, [x29, #-0x110]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -473,67 +685,181 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x130
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	stp	x23, x24, [x29, #-0x110]
+               	sub	sp, sp, #0x140
+               	stp	x19, x20, [x29, #-0x100]
+               	stp	x21, x22, [x29, #-0x110]
+               	stp	x23, x24, [x29, #-0x120]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, #0x2                ; =2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               ; =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               ; =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, #0x2                ; =2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x8               ; =8
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, #0x2                ; =2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, #0x6                ; =6
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               ; =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	sub	x20, x29, #0x60
+               	mov	x1, #0x4                ; =4
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x1                ; =1
+<L15>:
+               	bl	 <L15>
+               	mov	x1, #0x1                ; =1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, #0x2                ; =2
+<L17>:
+               	bl	 <L17>
+               	mov	x1, #0x4                ; =4
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x6                ; =6
+<L19>:
+               	bl	 <L19>
+               	sub	x20, x29, #0x68
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L14>:
+<L20>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L14>
+               	b.ne	 <L20>
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0xc
-               	b.lo	 <L15>
-               	b	 <L16>
-<L15>:
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -549,15 +875,15 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L15>
-<L16>:
+               	b.lo	 <L21>
+<L22>:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
-               	b.lo	 <L17>
-               	b	 <L20>
-<L17>:
+               	b.lo	 <L23>
+               	b	 <L26>
+<L23>:
                	mov	x16, #0xd               ; =13
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -566,7 +892,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x2, x1
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
-               	sub	x2, x29, #0x61
+               	sub	x2, x29, #0x1
                	mov	w4, w3
                	add	x3, x2, #0x0
                	strb	w4, [x3]
@@ -575,7 +901,7 @@ Disassembly of section __TEXT,__text:
                	mov	w3, w4
                	add	x4, x20, #0x18
                	ldr	x5, [x4]
-               	sub	x4, x29, #0x64
+               	sub	x4, x29, #0x6a
                	mov	w6, w5
                	add	x7, x4, #0x0
                	strb	w6, [x7]
@@ -590,7 +916,7 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x5
                	add	x5, x20, #0x28
                	ldr	x6, [x5]
-               	sub	x5, x29, #0x6a
+               	sub	x5, x29, #0x70
                	mov	w7, w6
                	add	x8, x5, #0x0
                	strb	w7, [x8]
@@ -607,7 +933,7 @@ Disassembly of section __TEXT,__text:
                	add	x6, x20, #0x38
                	ldr	x8, [x6]
                	add	x6, x8, x1
-               	sub	x1, x29, #0x78
+               	sub	x1, x29, #0x7c
                	mov	w8, w6
                	add	x12, x1, #0x0
                	str	w8, [x12]
@@ -621,13 +947,13 @@ Disassembly of section __TEXT,__text:
                	strb	w6, [x8]
                	add	x6, x20, #0x40
                	ldr	x8, [x6]
-               	sub	x6, x29, #0x81
+               	sub	x6, x29, #0x85
                	mov	w12, w8
                	add	x8, x6, #0x0
                	strb	w12, [x8]
                	add	x8, x20, #0x48
                	ldr	x12, [x8]
-               	sub	x8, x29, #0x84
+               	sub	x8, x29, #0x88
                	mov	w13, w12
                	add	x14, x8, #0x0
                	strb	w13, [x14]
@@ -637,7 +963,7 @@ Disassembly of section __TEXT,__text:
                	strb	w12, [x13]
                	add	x12, x20, #0x50
                	ldr	x13, [x12]
-               	sub	x12, x29, #0x8a
+               	sub	x12, x29, #0x8e
                	mov	w14, w13
                	add	x15, x12, #0x0
                	strb	w14, [x15]
@@ -651,7 +977,7 @@ Disassembly of section __TEXT,__text:
                	strh	w13, [x14]
                	add	x13, x20, #0x58
                	ldr	x14, [x13]
-               	sub	x13, x29, #0x98
+               	sub	x13, x29, #0x9c
                	mov	w15, w14
                	add	x24, x13, #0x0
                	str	w15, [x24]
@@ -670,23 +996,23 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s1, x14
                	add	x14, x20, #0x8
                	ldr	x15, [x14]
-               	stur	xzr, [x29, #-0xa0]
-               	ldrb	w14, [x2]
-               	sturb	w14, [x29, #-0xa0]
-               	ldur	x2, [x29, #-0xa0]
                	stur	xzr, [x29, #-0xa8]
-               	ldrh	w14, [x4]
-               	sturh	w14, [x29, #-0xa8]
-               	ldur	x4, [x29, #-0xa8]
+               	ldrb	w14, [x2]
+               	sturb	w14, [x29, #-0xa8]
+               	ldur	x2, [x29, #-0xa8]
                	stur	xzr, [x29, #-0xb0]
-               	ldr	w14, [x5]
-               	stur	w14, [x29, #-0xb0]
-               	ldur	x5, [x29, #-0xb0]
-               	ldr	x14, [x1]
+               	ldrh	w14, [x4]
+               	sturh	w14, [x29, #-0xb0]
+               	ldur	x4, [x29, #-0xb0]
                	stur	xzr, [x29, #-0xb8]
+               	ldr	w14, [x5]
+               	stur	w14, [x29, #-0xb8]
+               	ldur	x5, [x29, #-0xb8]
+               	ldr	x14, [x1]
+               	stur	xzr, [x29, #-0xc0]
                	ldrb	w1, [x6]
-               	sturb	w1, [x29, #-0xb8]
-               	ldur	x24, [x29, #-0xb8]
+               	sturb	w1, [x29, #-0xc0]
+               	ldur	x24, [x29, #-0xc0]
                	ldrh	w1, [x8]
                	strh	w1, [sp]
                	ldr	w1, [x12]
@@ -701,24 +1027,24 @@ Disassembly of section __TEXT,__text:
                	mov	x5, x7
                	mov	x6, x14
                	mov	x7, x24
-<L18>:
-               	bl	 <L18>
+<L24>:
+               	bl	 <L24>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L19>:
-               	bl	 <L19>
+<L25>:
+               	bl	 <L25>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L17>
-<L20>:
-               	sub	x0, x29, #0x62
+               	b.lo	 <L23>
+<L26>:
+               	sub	x0, x29, #0x2
                	mov	w1, w22
                	add	x2, x0, #0x0
                	strb	w1, [x2]
                	mov	w2, w22
-               	sub	x1, x29, #0x66
+               	sub	x1, x29, #0x6c
                	mov	w3, w22
                	add	x4, x1, #0x0
                	strb	w3, [x4]
@@ -729,7 +1055,7 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0x3ff             ; =1023
                	and	x3, x22, x16
                	ucvtf	d0, x3
-               	sub	x3, x29, #0x6e
+               	sub	x3, x29, #0x74
                	mov	w4, w22
                	add	x5, x3, #0x0
                	strb	w4, [x5]
@@ -743,7 +1069,7 @@ Disassembly of section __TEXT,__text:
                	strh	w5, [x4]
                	add	x4, x20, #0x30
                	ldr	x5, [x4]
-               	sub	x4, x29, #0x80
+               	sub	x4, x29, #0x84
                	mov	w6, w22
                	add	x7, x4, #0x0
                	str	w6, [x7]
@@ -757,13 +1083,13 @@ Disassembly of section __TEXT,__text:
                	strb	w7, [x6]
                	add	x6, x20, #0x40
                	ldr	x7, [x6]
-               	sub	x6, x29, #0x82
+               	sub	x6, x29, #0x86
                	mov	w8, w7
                	add	x7, x6, #0x0
                	strb	w8, [x7]
                	add	x7, x20, #0x48
                	ldr	x8, [x7]
-               	sub	x7, x29, #0x86
+               	sub	x7, x29, #0x8a
                	mov	w12, w8
                	add	x13, x7, #0x0
                	strb	w12, [x13]
@@ -773,7 +1099,7 @@ Disassembly of section __TEXT,__text:
                	strb	w8, [x12]
                	add	x8, x20, #0x50
                	ldr	x12, [x8]
-               	sub	x8, x29, #0x8e
+               	sub	x8, x29, #0x92
                	mov	w13, w12
                	add	x14, x8, #0x0
                	strb	w13, [x14]
@@ -787,7 +1113,7 @@ Disassembly of section __TEXT,__text:
                	strh	w12, [x13]
                	add	x12, x20, #0x58
                	ldr	x13, [x12]
-               	sub	x12, x29, #0xc0
+               	sub	x12, x29, #0xc8
                	mov	w14, w13
                	add	x15, x12, #0x0
                	str	w14, [x15]
@@ -806,23 +1132,23 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s1, x13
                	add	x13, x20, #0x10
                	ldr	x14, [x13]
-               	stur	xzr, [x29, #-0xc8]
-               	ldrb	w13, [x0]
-               	sturb	w13, [x29, #-0xc8]
-               	ldur	x13, [x29, #-0xc8]
                	stur	xzr, [x29, #-0xd0]
-               	ldrh	w0, [x1]
-               	sturh	w0, [x29, #-0xd0]
-               	ldur	x15, [x29, #-0xd0]
+               	ldrb	w13, [x0]
+               	sturb	w13, [x29, #-0xd0]
+               	ldur	x13, [x29, #-0xd0]
                	stur	xzr, [x29, #-0xd8]
-               	ldr	w0, [x3]
-               	stur	w0, [x29, #-0xd8]
-               	ldur	x19, [x29, #-0xd8]
-               	ldr	x20, [x4]
+               	ldrh	w0, [x1]
+               	sturh	w0, [x29, #-0xd8]
+               	ldur	x15, [x29, #-0xd8]
                	stur	xzr, [x29, #-0xe0]
+               	ldr	w0, [x3]
+               	stur	w0, [x29, #-0xe0]
+               	ldur	x19, [x29, #-0xe0]
+               	ldr	x20, [x4]
+               	stur	xzr, [x29, #-0xe8]
                	ldrb	w0, [x6]
-               	sturb	w0, [x29, #-0xe0]
-               	ldur	x23, [x29, #-0xe0]
+               	sturb	w0, [x29, #-0xe8]
+               	ldur	x23, [x29, #-0xe8]
                	ldrh	w0, [x7]
                	strh	w0, [sp]
                	ldr	w0, [x8]
@@ -836,15 +1162,15 @@ Disassembly of section __TEXT,__text:
                	mov	x4, x19
                	mov	x6, x20
                	mov	x7, x23
-<L21>:
-               	bl	 <L21>
+<L27>:
+               	bl	 <L27>
                	mov	x1, x0
                	mov	x0, x21
-<L22>:
-               	bl	 <L22>
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	ldp	x23, x24, [x29, #-0x110]
+<L28>:
+               	bl	 <L28>
+               	ldp	x19, x20, [x29, #-0x100]
+               	ldp	x21, x22, [x29, #-0x110]
+               	ldp	x23, x24, [x29, #-0x120]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_recursive.dis
+++ b/test/golden/aarch64-darwin/call/call_recursive.dis
@@ -20,10 +20,9 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.descend>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x70
+               	sub	sp, sp, #0x60
                	stp	x19, x20, [x29, #-0x50]
                	stp	x21, x22, [x29, #-0x60]
-               	stur	x23, [x29, #-0x68]
                	mov	x19, x0
                	sub	x20, x29, #0x40
                	str	xzr, [x20]
@@ -63,31 +62,76 @@ Disassembly of section __TEXT,__text:
                	bl	 <L3>
                	mov	x22, x0
 <L4>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x8
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x22
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x22
-               	mov	x1, x21
+               	add	x0, x0, #0x1
+               	mov	x22, x1
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x19
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x21, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x19, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x50]
                	ldp	x21, x22, [x29, #-0x60]
-               	ldur	x23, [x29, #-0x68]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -97,7 +141,7 @@ Disassembly of section __TEXT,__text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x30]
-               	stp	x21, x22, [x29, #-0x40]
+               	stur	x21, [x29, #-0x38]
                	mov	x19, x0
                	sub	x20, x29, #0x20
                	str	xzr, [x20]
@@ -134,28 +178,60 @@ Disassembly of section __TEXT,__text:
                	bl	 <L3>
                	mov	x21, x0
 <L4>:
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x4
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x4
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x21
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L5>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x16, #0x2               ; =2
-               	mul	x1, x19, x16
-               	mov	x0, x21
+               	add	x0, x0, #0x1
+               	mov	x21, x1
+               	cmp	x0, #0x4
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
+               	mov	x16, #0x2               ; =2
+               	mul	x0, x19, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x0, x21
                	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
+               	ldur	x21, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -163,10 +239,9 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.pong>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x60
+               	sub	sp, sp, #0x50
                	stp	x19, x20, [x29, #-0x40]
                	stp	x21, x22, [x29, #-0x50]
-               	stur	x23, [x29, #-0x58]
                	mov	x19, x0
                	sub	x20, x29, #0x30
                	str	xzr, [x20]
@@ -203,34 +278,79 @@ Disassembly of section __TEXT,__text:
                	bl	 <L3>
                	mov	x22, x0
 <L4>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x6
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x6
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x22
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x6
-               	b.lo	 <L5>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x22
-               	mov	x1, x21
+               	add	x0, x0, #0x1
+               	mov	x22, x1
+               	cmp	x0, #0x6
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
-               	mov	x16, #0x3               ; =3
-               	mul	x1, x19, x16
-               	add	x2, x1, #0x1
-               	mov	x1, x2
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x21, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x16, #0x3               ; =3
+               	mul	x0, x19, x16
+               	add	x1, x0, #0x1
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
-               	ldur	x23, [x29, #-0x58]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -238,243 +358,90 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.tree>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	x27, x28, [x29, #-0x50]
+               	stur	x21, [x29, #-0x18]
                	mov	x19, x0
                	mov	x16, #0x79b1            ; =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x3, x1, x16
-               	add	x20, x3, x19
-               	mov	x0, x2
-               	mov	x1, x20
+               	mul	x0, x1, x16
+               	add	x20, x0, x19
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x3, x20, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x3, x16
+               	eor	x3, x2, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x0               ; =0
                	cmp	x17, x19
-               	b.lo	 <L1>
-               	mov	x21, x0
-               	b	 <L41>
-<L1>:
-               	sub	x22, x19, #0x1
-               	add	x1, x20, #0x1
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x23, x2, x22
-               	mov	x1, x23
+               	b.lo	 <L2>
+               	mov	x21, x2
+               	b	 <L7>
 <L2>:
-               	bl	 <L2>
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x22
-               	b.lo	 <L3>
-               	mov	x24, x0
-               	b	 <L19>
+               	sub	x0, x19, #0x1
+               	add	x1, x20, #0x1
 <L3>:
-               	sub	x25, x22, #0x1
-               	add	x1, x23, #0x1
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x26, x2, x25
-               	mov	x1, x26
+               	bl	 <L3>
+               	mov	x2, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x2, x0
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x25
-               	b.lo	 <L5>
-               	mov	x27, x2
-               	b	 <L9>
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x3, x20, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x3, x16
+               	eor	x3, x2, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	sub	x28, x25, #0x1
-               	add	x1, x26, #0x1
-               	mov	x0, x28
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x26
-<L7>:
-               	bl	 <L7>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x26, x16
-               	mov	x0, x28
-<L8>:
-               	bl	 <L8>
-               	mov	x27, x0
-<L9>:
-               	mov	x0, x27
-               	mov	x1, x26
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x23
-<L11>:
-               	bl	 <L11>
-               	sub	x25, x22, #0x1
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x23, x16
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x22, x2, x25
-               	mov	x1, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x2, x0
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x25
-               	b.lo	 <L13>
-               	mov	x26, x2
-               	b	 <L17>
-<L13>:
-               	sub	x27, x25, #0x1
-               	add	x1, x22, #0x1
-               	mov	x0, x27
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x22
-<L15>:
-               	bl	 <L15>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x22, x16
-               	mov	x0, x27
-<L16>:
-               	bl	 <L16>
-               	mov	x26, x0
-<L17>:
-               	mov	x0, x26
-               	mov	x1, x22
-<L18>:
-               	bl	 <L18>
-               	mov	x24, x0
-<L19>:
-               	mov	x0, x24
-               	mov	x1, x23
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x20
-<L21>:
-               	bl	 <L21>
-               	sub	x22, x19, #0x1
+               	sub	x0, x19, #0x1
                	mov	x16, #0xaaaa            ; =43690
                	movk	x16, #0xaaaa, lsl #16
                	eor	x1, x20, x16
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x19, x2, x22
-               	mov	x1, x19
-<L22>:
-               	bl	 <L22>
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x22
-               	b.lo	 <L23>
-               	mov	x23, x0
-               	b	 <L39>
-<L23>:
-               	sub	x24, x22, #0x1
-               	add	x1, x19, #0x1
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x25, x2, x24
-               	mov	x1, x25
-<L24>:
-               	bl	 <L24>
-               	mov	x2, x0
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x24
-               	b.lo	 <L25>
-               	mov	x26, x2
-               	b	 <L29>
-<L25>:
-               	sub	x27, x24, #0x1
-               	add	x1, x25, #0x1
-               	mov	x0, x27
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x25
-<L27>:
-               	bl	 <L27>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x25, x16
-               	mov	x0, x27
-<L28>:
-               	bl	 <L28>
-               	mov	x26, x0
-<L29>:
-               	mov	x0, x26
-               	mov	x1, x25
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x19
-<L31>:
-               	bl	 <L31>
-               	sub	x24, x22, #0x1
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x19, x16
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x22, x2, x24
-               	mov	x1, x22
-<L32>:
-               	bl	 <L32>
-               	mov	x2, x0
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x24
-               	b.lo	 <L33>
-               	mov	x25, x2
-               	b	 <L37>
-<L33>:
-               	sub	x26, x24, #0x1
-               	add	x1, x22, #0x1
-               	mov	x0, x26
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x22
-<L35>:
-               	bl	 <L35>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            ; =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x22, x16
-               	mov	x0, x26
-<L36>:
-               	bl	 <L36>
-               	mov	x25, x0
-<L37>:
-               	mov	x0, x25
-               	mov	x1, x22
-<L38>:
-               	bl	 <L38>
-               	mov	x23, x0
-<L39>:
-               	mov	x0, x23
-               	mov	x1, x19
-<L40>:
-               	bl	 <L40>
+<L6>:
+               	bl	 <L6>
                	mov	x21, x0
-<L41>:
+<L7>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x2, x20, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x21, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	x0, x21
-               	mov	x1, x20
-<L42>:
-               	bl	 <L42>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	ldp	x27, x28, [x29, #-0x50]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -482,70 +449,78 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.tail>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
-               	stp	x19, x20, [x29, #-0x30]
-               	stp	x21, x22, [x29, #-0x40]
-               	stur	x23, [x29, #-0x48]
-               	mov	x19, x0
-               	mov	x20, x1
-               	sub	x21, x29, #0x20
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, #0x4
+               	sub	sp, sp, #0x30
+               	stur	x19, [x29, #-0x28]
+               	sub	x3, x29, #0x20
+               	str	xzr, [x3]
+               	str	xzr, [x3, #0x8]
+               	str	xzr, [x3, #0x10]
+               	str	xzr, [x3, #0x18]
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x4
                	b.lo	 <L0>
                	b	 <L1>
 <L0>:
                	mov	x16, #0x1b3             ; =435
                	movk	x16, #0x100, lsl #32
-               	mul	x1, x0, x16
-               	add	x3, x1, x19
-               	eor	x1, x20, x3
-               	add	x3, x21, x0, lsl #3
-               	str	x1, [x3]
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x4
+               	mul	x5, x4, x16
+               	add	x6, x5, x0
+               	eor	x5, x1, x6
+               	add	x6, x3, x4, lsl #3
+               	str	x5, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x4
                	b.lo	 <L0>
 <L1>:
-               	mov	x22, #0x0               ; =0
-               	mov	x23, x2
-               	cmp	x22, #0x4
+               	mov	x4, #0x0                ; =0
+               	mov	x19, x2
+               	cmp	x4, #0x4
                	b.lo	 <L2>
-               	b	 <L4>
+               	b	 <L5>
 <L2>:
-               	add	x0, x21, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	add	x2, x3, x4, lsl #3
+               	ldr	x5, [x2]
+               	mov	x2, x19
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x23, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L2>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	cmp	x19, #0x0
-               	b.eq	 <L6>
-               	sub	x0, x19, #0x1
-               	mov	x16, #0x5               ; =5
-               	mul	x1, x20, x16
-               	add	x2, x1, #0x3
-               	mov	x1, x2
-               	mov	x2, x23
+               	add	x4, x4, #0x1
+               	mov	x19, x2
+               	cmp	x4, #0x4
+               	b.lo	 <L2>
 <L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
-               	ldur	x23, [x29, #-0x48]
+               	cmp	x0, #0x0
+               	b.eq	 <L7>
+               	sub	x2, x0, #0x1
+               	mov	x16, #0x5               ; =5
+               	mul	x0, x1, x16
+               	add	x1, x0, #0x3
+               	mov	x0, x2
+               	mov	x2, x19
+<L6>:
+               	bl	 <L6>
+               	ldur	x19, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
-<L6>:
-               	mov	x0, x23
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
-               	ldur	x23, [x29, #-0x48]
+<L7>:
+               	mov	x0, x19
+               	ldur	x19, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -642,16 +617,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
+               	sub	sp, sp, #0x80
                	stp	x19, x20, [x29, #-0x60]
                	stp	x21, x22, [x29, #-0x70]
                	stp	x23, x24, [x29, #-0x80]
-               	stur	x25, [x29, #-0x88]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x2, x0
-               	sub	x20, x29, #0x30
+               	sub	x20, x29, #0x48
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -660,9 +631,9 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x28]
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -672,93 +643,142 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x1, x16
-               	add	x1, x3, x19
-               	add	x3, x20, x0, lsl #3
-               	str	x1, [x3]
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x28              ; =40
                	add	x0, x17, x19
                	add	x1, x20, #0x0
-               	ldr	x3, [x1]
-               	mov	x1, x3
-<L3>:
-               	bl	 <L3>
+               	ldr	x2, [x1]
+               	mov	x1, x2
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+<L2>:
+               	bl	 <L2>
                	mov	x2, x0
                	mov	x17, #0x21              ; =33
                	add	x21, x17, x19
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x21
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x2, x0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
                	mov	x0, x21
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	mov	x2, x0
                	add	x0, x20, #0x18
                	ldr	x1, [x0]
                	add	x3, x1, x19
                	mov	x0, #0x8                ; =8
                	mov	x1, x3
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	mov	x2, x0
                	mov	x17, #0x30              ; =48
                	add	x0, x17, x19
                	add	x1, x20, #0x20
                	ldr	x3, [x1]
                	mov	x1, x3
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	mov	x17, #0x18              ; =24
                	add	x21, x17, x19
                	mov	x22, x0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x4
-               	b.lo	 <L8>
-               	b	 <L13>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L15>
+<L7>:
                	add	x0, x20, x23, lsl #3
                	ldr	x1, [x0]
                	add	x2, x1, x19
-               	sub	x24, x29, #0x48
+               	sub	x24, x29, #0x18
                	mov	x8, x24
                	mov	x0, x21
                	mov	x1, x2
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	add	x0, x24, #0x0
                	ldr	x1, [x0]
                	add	x0, x24, #0x8
-               	ldr	x25, [x0]
+               	ldr	x2, [x0]
                	add	x0, x24, #0x10
-               	ldr	x24, [x0]
+               	ldr	x3, [x0]
                	mov	x0, x22
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x25
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L13>
+<L14>:
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x4
-               	b.lo	 <L8>
-<L13>:
+               	b.lo	 <L7>
+<L15>:
                	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x60]
                	ldp	x21, x22, [x29, #-0x70]
                	ldp	x23, x24, [x29, #-0x80]
-               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_ret_large.dis
+++ b/test/golden/aarch64-darwin/call/call_ret_large.dis
@@ -18,206 +18,386 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.call.call_ret_large.fold20>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	w4, [x3]
-               	add	x3, x1, #0x4
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x8
-               	ldr	w20, [x3]
-               	add	x3, x1, #0xc
-               	ldr	w21, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w22, [x3]
-               	mov	x0, x2
-               	mov	w1, w4
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	add	x2, x1, #0x4
+               	ldr	w4, [x2]
+               	add	x2, x1, #0x8
+               	ldr	w5, [x2]
+               	add	x2, x1, #0xc
+               	ldr	w6, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w1, [x2]
+               	mov	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x3, x16
+               	lsr	x8, x2, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w2, w4
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x7, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x7, x16
+               	eor	x7, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	w2, w5
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w2, w6
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold24f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	d8, d9, [x29, #-0x30]
-               	mov	x1, x0
+               	sub	sp, sp, #0x20
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	sub	x2, x29, #0x18
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	ldr	d8, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d9, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x18
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x10
+               	ldr	d1, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d2, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	d8, d9, [x29, #-0x30]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	fmov	x1, d2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_ret_large.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x5, [x2]
+               	add	x2, x1, #0x18
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x5, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold40m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stur	x21, [x29, #-0x18]
-               	stp	d8, d9, [x29, #-0x28]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	d8, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x14
-               	ldr	w20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	d9, [x3]
-               	add	x3, x1, #0x20
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	stur	d8, [x29, #-0x20]
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	d0, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w19, [x2]
+               	add	x2, x1, #0x14
+               	ldr	w20, [x2]
+               	add	x2, x1, #0x18
+               	ldr	d8, [x2]
+               	add	x2, x1, #0x20
+               	ldr	x21, [x2]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	fmov	x1, d0
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w19
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	mov	w1, w20
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	ldp	d8, d9, [x29, #-0x28]
+               	mov	x1, x21
+<L6>:
+               	bl	 <L6>
+               	ldur	d8, [x29, #-0x20]
                	ldp	x19, x20, [x29, #-0x10]
                	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
@@ -283,47 +463,55 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold_nest>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	w4, [x3]
-               	add	x3, x1, #0x8
-               	add	x5, x3, #0x0
-               	ldr	x19, [x5]
-               	add	x5, x3, #0x8
-               	ldr	x20, [x5]
-               	add	x5, x3, #0x10
-               	ldr	x21, [x5]
-               	add	x3, x1, #0x20
-               	add	x1, x3, #0x0
-               	ldr	x22, [x1]
-               	add	x1, x3, #0x8
-               	ldr	x23, [x1]
-               	mov	x0, x2
-               	mov	w1, w4
+               	sub	sp, sp, #0x70
+               	stp	x19, x20, [x29, #-0x70]
+               	sub	x19, x29, #0x30
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	ldr	x6, [x1, #0x20]
+               	ldr	x7, [x1, #0x28]
+               	str	x2, [x19]
+               	str	x3, [x19, #0x8]
+               	str	x4, [x19, #0x10]
+               	str	x5, [x19, #0x18]
+               	str	x6, [x19, #0x20]
+               	str	x7, [x19, #0x28]
+               	add	x1, x19, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x19
+               	add	x1, x19, #0x8
+               	sub	x2, x29, #0x48
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	stur	x1, [x29, #-0x60]
+               	stur	x3, [x29, #-0x58]
+               	stur	x4, [x29, #-0x50]
+               	sub	x1, x29, #0x60
 <L1>:
                	bl	 <L1>
-               	mov	x1, x20
+               	add	x20, x19, #0x20
+               	add	x1, x20, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x21
+               	add	x1, x20, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x22
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x23
-<L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	ldp	x19, x20, [x29, #-0x70]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -809,32 +997,36 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.take_two>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	x27, x28, [x29, #-0x50]
-               	mov	x3, x0
+               	sub	sp, sp, #0x90
+               	stp	x19, x20, [x29, #-0x60]
+               	stp	x21, x22, [x29, #-0x70]
+               	stp	x23, x24, [x29, #-0x80]
+               	stur	x25, [x29, #-0x88]
                	mov	x19, x2
-               	add	x2, x3, #0x0
+               	add	x2, x0, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x0, #0x8
                	ldr	x20, [x2]
-               	add	x2, x3, #0x8
+               	add	x2, x0, #0x10
                	ldr	x21, [x2]
-               	add	x2, x3, #0x10
+               	add	x2, x0, #0x18
                	ldr	x22, [x2]
-               	add	x2, x3, #0x18
+               	add	x2, x0, #0x20
                	ldr	x23, [x2]
-               	add	x2, x3, #0x20
+               	add	x2, x0, #0x28
                	ldr	x24, [x2]
-               	add	x2, x3, #0x28
-               	ldr	x25, [x2]
-               	add	x2, x1, #0x0
-               	ldr	x26, [x2]
-               	add	x2, x1, #0x8
-               	ldr	x27, [x2]
-               	add	x2, x1, #0x10
-               	ldr	x28, [x2]
+               	sub	x25, x29, #0x18
+               	ldr	x0, [x1]
+               	ldr	x2, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	str	x0, [x25]
+               	str	x2, [x25, #0x8]
+               	str	x4, [x25, #0x10]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x3
 <L0>:
                	bl	 <L0>
                	mov	x1, x20
@@ -852,26 +1044,29 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x24
 <L5>:
                	bl	 <L5>
-               	mov	x1, x25
+               	sub	x1, x29, #0x30
+               	ldr	x2, [x25]
+               	ldr	x3, [x25, #0x8]
+               	ldr	x4, [x25, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	str	x4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	stur	x2, [x29, #-0x48]
+               	stur	x3, [x29, #-0x40]
+               	stur	x4, [x29, #-0x38]
+               	sub	x1, x29, #0x48
 <L6>:
                	bl	 <L6>
-               	mov	x1, x26
+               	mov	x1, x19
 <L7>:
                	bl	 <L7>
-               	mov	x1, x27
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x28
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x19
-<L10>:
-               	bl	 <L10>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	ldp	x27, x28, [x29, #-0x50]
+               	ldp	x19, x20, [x29, #-0x60]
+               	ldp	x21, x22, [x29, #-0x70]
+               	ldp	x23, x24, [x29, #-0x80]
+               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -879,46 +1074,48 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x6f0
-               	sub	x16, x29, #0x6a0
+               	sub	sp, sp, #0x900
+               	sub	x16, x29, #0x8b0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x6f0
-               	stp	d8, d9, [x16]
+               	sub	x16, x29, #0x900
+               	str	d8, [x16, #0x8]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x14               ; =20
 <L0>:
                	bl	 <L0>
-               	mov	x1, #0x14               ; =20
+               	mov	x1, #0x18               ; =24
 <L1>:
                	bl	 <L1>
                	mov	x1, #0x18               ; =24
 <L2>:
                	bl	 <L2>
-               	mov	x1, #0x18               ; =24
+               	mov	x1, #0x20               ; =32
 <L3>:
                	bl	 <L3>
-               	mov	x1, #0x20               ; =32
+               	mov	x1, #0x28               ; =40
 <L4>:
                	bl	 <L4>
-               	mov	x1, #0x28               ; =40
+               	mov	x1, #0x30               ; =48
 <L5>:
                	bl	 <L5>
                	mov	x1, #0x30               ; =48
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x30               ; =48
+               	mov	x1, #0x8                ; =8
 <L7>:
                	bl	 <L7>
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x20               ; =32
 <L8>:
                	bl	 <L8>
-               	mov	x1, #0x20               ; =32
-<L9>:
-               	bl	 <L9>
-               	sub	x20, x29, #0x1f0
+               	sub	x20, x29, #0x358
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -929,9 +1126,9 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x38]
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x8
-               	b.lo	 <L10>
-               	b	 <L11>
-<L10>:
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -947,54 +1144,154 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L10>
-<L11>:
+               	b.lo	 <L9>
+<L10>:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x8
-               	b.lo	 <L12>
-               	b	 <L41>
-<L12>:
+               	b.lo	 <L11>
+               	b	 <L47>
+<L11>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	mov	w1, w23
-               	lsr	x0, x23, #8
-               	mov	w24, w0
-               	lsr	x0, x23, #16
-               	mov	w25, w0
-               	lsr	x0, x23, #24
-               	mov	w26, w0
-               	lsr	x0, x23, #32
-               	mov	w27, w0
+               	mov	w0, w23
+               	lsr	x1, x23, #8
+               	mov	w2, w1
+               	lsr	x1, x23, #16
+               	mov	w3, w1
+               	lsr	x1, x23, #24
+               	mov	w4, w1
+               	lsr	x1, x23, #32
+               	mov	w5, w1
+               	mov	w1, w0
                	mov	x0, x21
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x1, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	w1, w24
+               	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	w1, w25
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x2, x16
+               	lsr	x7, x1, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w26
+               	mov	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	w1, w27
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x6, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mvn	x24, x23
-               	mov	x16, #0x3               ; =3
-               	mul	x1, x23, x16
-               	add	x25, x1, #0x1
-               	mov	x1, x23
+               	mov	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x25
+               	mov	w1, w5
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sub	x1, x29, #0x440
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	mvn	x2, x23
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x3               ; =3
+               	mul	x2, x23, x16
+               	add	x3, x2, #0x1
+               	add	x2, x1, #0x10
+               	str	x3, [x2]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	mov	x16, #0xfba8            ; =64424
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfbb0            ; =64432
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfbb8            ; =64440
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x458
+<L22>:
+               	bl	 <L22>
                	mov	x16, #0xffff            ; =65535
                	and	x1, x23, x16
                	ucvtf	d0, x1
@@ -1005,44 +1302,116 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x1
                	mov	x16, #0x40a0000000000000 ; =4656722014701092864
                	fmov	d30, x16
-               	fsub	d8, d0, d30
+               	fsub	d2, d0, d30
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x3, lsl #16
                	and	x1, x23, x16
                	ucvtf	d0, x1
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
-               	fmov	d0, d1
-<L21>:
-               	bl	 <L21>
-               	fmov	d0, d8
-<L22>:
-               	bl	 <L22>
-               	fmov	d0, d9
+               	fdiv	d3, d0, d30
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	bl	 <L23>
-               	add	x24, x23, #0x1
-               	mov	x16, #0x5               ; =5
-               	mul	x25, x23, x16
-               	mvn	x26, x23
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
-               	mov	x1, x24
+               	fmov	x1, d2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
 <L25>:
-               	bl	 <L25>
-               	mov	x1, x25
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	bl	 <L26>
-               	mov	x1, x26
+               	fmov	x1, d3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
 <L27>:
-               	bl	 <L27>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	sub	x1, x29, #0x5e0
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	add	x2, x23, #0x1
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x5               ; =5
+               	mul	x2, x23, x16
+               	add	x3, x1, #0x10
+               	str	x2, [x3]
+               	mvn	x2, x23
+               	add	x3, x1, #0x18
+               	str	x2, [x3]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	mov	x16, #0xfa00            ; =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfa08            ; =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfa10            ; =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfa18            ; =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	sub	x1, x29, #0x600
+<L29>:
+               	bl	 <L29>
                	mov	x16, #0x1fff            ; =8191
                	and	x1, x23, x16
                	ucvtf	d0, x1
                	fmov	d30, #2.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
                	mov	w24, w23
                	lsr	x1, x23, #16
                	mov	w25, w1
@@ -1052,27 +1421,42 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x1
                	mov	x16, #0x4040000000000000 ; =4629700416936869888
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
+               	fdiv	d8, d0, d30
                	mov	x16, #0x7               ; =7
                	mul	x26, x23, x16
-               	mov	x1, x23
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d8
-<L29>:
-               	bl	 <L29>
-               	mov	w1, w24
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	w1, w25
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	fmov	d0, d9
+               	fmov	x1, d1
 <L32>:
                	bl	 <L32>
-               	mov	x1, x26
+               	mov	w1, w24
 <L33>:
                	bl	 <L33>
+               	mov	w1, w25
+<L34>:
+               	bl	 <L34>
+               	fmov	x1, d8
+<L35>:
+               	bl	 <L35>
+               	mov	x1, x26
+<L36>:
+               	bl	 <L36>
                	add	x24, x23, #0x1
                	add	x25, x23, #0x2
                	mov	x16, #0x9               ; =9
@@ -1082,28 +1466,28 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xaaaa, lsl #16
                	eor	x28, x23, x16
                	mov	x1, x23
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x24
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x25
-<L36>:
-               	bl	 <L36>
-               	mov	x1, x26
 <L37>:
                	bl	 <L37>
-               	mov	x1, x27
+               	mov	x1, x24
 <L38>:
                	bl	 <L38>
-               	mov	x1, x28
+               	mov	x1, x25
 <L39>:
                	bl	 <L39>
-               	sub	x1, x29, #0x610
+               	mov	x1, x26
+<L40>:
+               	bl	 <L40>
+               	mov	x1, x27
+<L41>:
+               	bl	 <L41>
+               	mov	x1, x28
+<L42>:
+               	bl	 <L42>
+               	sub	x1, x29, #0x7f8
                	mov	w2, w23
                	add	x3, x1, #0x0
                	str	w2, [x3]
-               	sub	x2, x29, #0x628
+               	sub	x2, x29, #0x810
                	add	x3, x2, #0x0
                	str	x23, [x3]
                	mvn	x3, x23
@@ -1121,7 +1505,7 @@ Disassembly of section __TEXT,__text:
                	str	x4, [x3]
                	str	x5, [x3, #0x8]
                	str	x6, [x3, #0x10]
-               	sub	x2, x29, #0x638
+               	sub	x2, x29, #0x820
                	mov	x16, #0xb               ; =11
                	mul	x3, x23, x16
                	add	x4, x2, #0x0
@@ -1134,89 +1518,154 @@ Disassembly of section __TEXT,__text:
                	ldr	x5, [x2, #0x8]
                	str	x4, [x3]
                	str	x5, [x3, #0x8]
+               	sub	x23, x29, #0x850
                	ldr	x2, [x1]
                	ldr	x3, [x1, #0x8]
                	ldr	x4, [x1, #0x10]
                	ldr	x5, [x1, #0x18]
                	ldr	x6, [x1, #0x20]
                	ldr	x7, [x1, #0x28]
-               	mov	x16, #0xf998            ; =63896
+               	str	x2, [x23]
+               	str	x3, [x23, #0x8]
+               	str	x4, [x23, #0x10]
+               	str	x5, [x23, #0x18]
+               	str	x6, [x23, #0x20]
+               	str	x7, [x23, #0x28]
+               	add	x1, x23, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L43>:
+               	bl	 <L43>
+               	add	x1, x23, #0x8
+               	sub	x2, x29, #0x868
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	mov	x16, #0xf780            ; =63360
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x2, [x29, x16]
-               	mov	x16, #0xf9a0            ; =63904
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf788            ; =63368
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xf9a8            ; =63912
+               	mov	x16, #0xf790            ; =63376
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xf9b0            ; =63920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x5, [x29, x16]
-               	mov	x16, #0xf9b8            ; =63928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x6, [x29, x16]
-               	mov	x16, #0xf9c0            ; =63936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x7, [x29, x16]
-               	sub	x1, x29, #0x668
-<L40>:
-               	bl	 <L40>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x8
-               	b.lo	 <L12>
-<L41>:
-               	add	x0, x19, #0x1
-               	mvn	x1, x0
-               	mov	x16, #0x3               ; =3
-               	mul	x2, x0, x16
-               	add	x3, x2, #0x1
-               	mov	x22, #0x0               ; =0
-               	mov	x23, x0
-               	mov	x24, x1
-               	mov	x25, x3
-               	cmp	x22, #0x8
-               	b.lo	 <L42>
-               	b	 <L46>
-<L42>:
-               	add	x0, x20, x22, lsl #3
-               	ldr	x1, [x0]
-               	add	x26, x23, x1
-               	eor	x27, x24, x1
-               	add	x28, x25, x23
-               	mov	x0, x21
-               	mov	x1, x26
-<L43>:
-               	bl	 <L43>
-               	mov	x1, x27
+               	sub	x1, x29, #0x880
 <L44>:
                	bl	 <L44>
-               	mov	x1, x28
+               	add	x24, x23, #0x20
+               	add	x1, x24, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
+               	add	x1, x24, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	add	x22, x22, #0x1
                	mov	x21, x0
-               	mov	x23, x26
-               	mov	x24, x27
-               	mov	x25, x28
                	cmp	x22, #0x8
-               	b.lo	 <L42>
-<L46>:
-               	sub	x22, x29, #0x30
-               	add	x0, x19, #0x2
+               	b.lo	 <L11>
+<L47>:
+               	sub	x22, x29, #0x18
+               	add	x0, x19, #0x1
                	sub	x1, x29, #0x220
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	mvn	x2, x0
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x3               ; =3
+               	mul	x2, x0, x16
+               	add	x0, x2, #0x1
+               	add	x2, x1, #0x10
+               	str	x0, [x2]
+               	ldr	x0, [x1]
+               	ldr	x2, [x1, #0x8]
+               	ldr	x3, [x1, #0x10]
+               	str	x0, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	mov	x23, #0x0               ; =0
+               	cmp	x23, #0x8
+               	b.lo	 <L48>
+               	b	 <L50>
+<L48>:
+               	add	x0, x22, #0x0
+               	ldr	x1, [x0]
+               	add	x0, x22, #0x8
+               	ldr	x2, [x0]
+               	add	x0, x22, #0x10
+               	ldr	x3, [x0]
+               	add	x0, x20, x23, lsl #3
+               	ldr	x4, [x0]
+               	sub	x0, x29, #0x238
+               	add	x5, x1, x4
+               	add	x6, x0, #0x0
+               	str	x5, [x6]
+               	eor	x5, x2, x4
+               	add	x2, x0, #0x8
+               	str	x5, [x2]
+               	add	x2, x3, x1
+               	add	x1, x0, #0x10
+               	str	x2, [x1]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	str	x1, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	sub	x0, x29, #0x250
+               	ldr	x1, [x22]
+               	ldr	x2, [x22, #0x8]
+               	ldr	x3, [x22, #0x10]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	str	x3, [x0, #0x10]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	sub	x1, x29, #0x268
+               	mov	x0, x21
+<L49>:
+               	bl	 <L49>
+               	add	x23, x23, #0x1
+               	mov	x21, x0
+               	cmp	x23, #0x8
+               	b.lo	 <L48>
+<L50>:
+               	sub	x22, x29, #0x48
+               	add	x0, x19, #0x2
+               	sub	x1, x29, #0x298
                	add	x2, x1, #0x0
                	str	x0, [x2]
                	add	x2, x0, #0x1
@@ -1251,10 +1700,10 @@ Disassembly of section __TEXT,__text:
                	str	x6, [x22, #0x28]
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x8
-               	b.lo	 <L47>
-               	b	 <L55>
-<L47>:
-               	sub	x0, x29, #0x60
+               	b.lo	 <L51>
+               	b	 <L59>
+<L51>:
+               	sub	x0, x29, #0x78
                	ldr	x1, [x22]
                	ldr	x2, [x22, #0x8]
                	ldr	x3, [x22, #0x10]
@@ -1269,24 +1718,24 @@ Disassembly of section __TEXT,__text:
                	str	x6, [x0, #0x28]
                	add	x1, x20, x23, lsl #3
                	ldr	x2, [x1]
-               	sub	x24, x29, #0x90
+               	sub	x24, x29, #0xa8
                	ldr	x1, [x0]
                	ldr	x3, [x0, #0x8]
                	ldr	x4, [x0, #0x10]
                	ldr	x5, [x0, #0x18]
                	ldr	x6, [x0, #0x20]
                	ldr	x7, [x0, #0x28]
-               	stur	x1, [x29, #-0xc0]
-               	stur	x3, [x29, #-0xb8]
-               	stur	x4, [x29, #-0xb0]
-               	stur	x5, [x29, #-0xa8]
-               	stur	x6, [x29, #-0xa0]
-               	stur	x7, [x29, #-0x98]
-               	sub	x0, x29, #0xc0
+               	stur	x1, [x29, #-0xd8]
+               	stur	x3, [x29, #-0xd0]
+               	stur	x4, [x29, #-0xc8]
+               	stur	x5, [x29, #-0xc0]
+               	stur	x6, [x29, #-0xb8]
+               	stur	x7, [x29, #-0xb0]
+               	sub	x0, x29, #0xd8
                	mov	x8, x24
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L52>:
+               	bl	 <L52>
                	ldr	x0, [x24]
                	ldr	x1, [x24, #0x8]
                	ldr	x2, [x24, #0x10]
@@ -1312,47 +1761,47 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x28
                	ldr	x28, [x0]
                	mov	x0, x21
-<L49>:
-               	bl	 <L49>
-               	mov	x1, x24
-<L50>:
-               	bl	 <L50>
-               	mov	x1, x25
-<L51>:
-               	bl	 <L51>
-               	mov	x1, x26
-<L52>:
-               	bl	 <L52>
-               	mov	x1, x27
 <L53>:
                	bl	 <L53>
-               	mov	x1, x28
+               	mov	x1, x24
 <L54>:
                	bl	 <L54>
+               	mov	x1, x25
+<L55>:
+               	bl	 <L55>
+               	mov	x1, x26
+<L56>:
+               	bl	 <L56>
+               	mov	x1, x27
+<L57>:
+               	bl	 <L57>
+               	mov	x1, x28
+<L58>:
+               	bl	 <L58>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x8
-               	b.lo	 <L47>
-<L55>:
-               	sub	x22, x29, #0x180
+               	b.lo	 <L51>
+<L59>:
+               	sub	x22, x29, #0x198
                	add	x0, x22, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0xc0               ; =192
-<L56>:
+<L60>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L56>
+               	b.ne	 <L60>
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x6
-               	b.lo	 <L57>
-               	b	 <L58>
-<L57>:
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0x240
+               	sub	x2, x29, #0x2b8
                	add	x3, x2, #0x0
                	str	x1, [x3]
                	add	x3, x1, #0x1
@@ -1378,43 +1827,59 @@ Disassembly of section __TEXT,__text:
                	str	x6, [x3, #0x18]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L57>
-<L58>:
+               	b.lo	 <L61>
+<L62>:
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x6
-               	b.lo	 <L59>
-               	b	 <L64>
-<L59>:
+               	b.lo	 <L63>
+               	b	 <L65>
+<L63>:
                	mov	x16, #0x20              ; =32
                	mul	x0, x23, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldr	x2, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x24, [x0]
-               	add	x0, x1, #0x10
-               	ldr	x25, [x0]
-               	add	x0, x1, #0x18
-               	ldr	x26, [x0]
+               	sub	x0, x29, #0x1b8
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	str	x4, [x0, #0x10]
+               	str	x5, [x0, #0x18]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	ldr	x4, [x0, #0x18]
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x1d8
                	mov	x0, x21
-               	mov	x1, x2
-<L60>:
-               	bl	 <L60>
-               	mov	x1, x24
-<L61>:
-               	bl	 <L61>
-               	mov	x1, x25
-<L62>:
-               	bl	 <L62>
-               	mov	x1, x26
-<L63>:
-               	bl	 <L63>
+<L64>:
+               	bl	 <L64>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x6
-               	b.lo	 <L59>
-<L64>:
-               	sub	x0, x29, #0x1b0
+               	b.lo	 <L63>
+<L65>:
+               	sub	x0, x29, #0x208
                	str	xzr, [x0]
                	str	xzr, [x0, #0x8]
                	str	xzr, [x0, #0x10]
@@ -1432,7 +1897,7 @@ Disassembly of section __TEXT,__text:
                	add	x4, x3, #0x1
                	add	x3, x20, #0x0
                	ldr	x5, [x3]
-               	sub	x3, x29, #0x2b8
+               	sub	x3, x29, #0x370
                	add	x6, x1, x5
                	add	x7, x3, #0x0
                	str	x6, [x7]
@@ -1449,7 +1914,7 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x1]
                	str	x4, [x1, #0x8]
                	str	x5, [x1, #0x10]
-               	sub	x1, x29, #0x2c8
+               	sub	x1, x29, #0x380
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
                	add	x2, x1, #0x0
@@ -1463,7 +1928,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x4, [x1, #0x8]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
-               	sub	x1, x29, #0x2f8
+               	sub	x1, x29, #0x3b0
                	ldr	x2, [x0]
                	ldr	x3, [x0, #0x8]
                	ldr	x4, [x0, #0x10]
@@ -1476,56 +1941,76 @@ Disassembly of section __TEXT,__text:
                	str	x5, [x1, #0x18]
                	str	x6, [x1, #0x20]
                	str	x7, [x1, #0x28]
+               	sub	x22, x29, #0x488
                	ldr	x0, [x1]
                	ldr	x2, [x1, #0x8]
                	ldr	x3, [x1, #0x10]
                	ldr	x4, [x1, #0x18]
                	ldr	x5, [x1, #0x20]
                	ldr	x6, [x1, #0x28]
-               	mov	x16, #0xfcd8            ; =64728
+               	str	x0, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	str	x4, [x22, #0x18]
+               	str	x5, [x22, #0x20]
+               	str	x6, [x22, #0x28]
+               	add	x0, x22, #0x0
+               	ldr	w1, [x0]
+               	mov	w2, w1
+               	mov	x0, x21
+               	mov	x1, x2
+<L66>:
+               	bl	 <L66>
+               	add	x1, x22, #0x8
+               	sub	x2, x29, #0x4a0
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	mov	x16, #0xfb48            ; =64328
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x2, [x29, x16]
-               	mov	x16, #0xfce8            ; =64744
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfb50            ; =64336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfcf0            ; =64752
+               	mov	x16, #0xfb58            ; =64344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfcf8            ; =64760
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x5, [x29, x16]
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x6, [x29, x16]
-               	sub	x1, x29, #0x328
-               	mov	x0, x21
-<L65>:
-               	bl	 <L65>
+               	sub	x1, x29, #0x4b8
+<L67>:
+               	bl	 <L67>
+               	add	x21, x22, #0x20
+               	add	x1, x21, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L68>:
+               	bl	 <L68>
+               	add	x1, x21, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L69>:
+               	bl	 <L69>
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L66>
-               	b	 <L99>
-<L66>:
+               	b.lo	 <L70>
+               	b	 <L96>
+<L70>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	sub	x0, x29, #0x258
+               	sub	x0, x29, #0x2d0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1536,30 +2021,30 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x24, x29, #0x288
+               	sub	x24, x29, #0x300
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	mov	x16, #0xfd60            ; =64864
+               	mov	x16, #0xfce8            ; =64744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfd68            ; =64872
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfd70            ; =64880
+               	mov	x16, #0xfcf8            ; =64760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	sub	x0, x29, #0x2a0
+               	sub	x0, x29, #0x318
                	mov	x8, x24
-<L67>:
-               	bl	 <L67>
-               	sub	x0, x29, #0x358
+<L71>:
+               	bl	 <L71>
+               	sub	x0, x29, #0x3e0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1580,124 +2065,107 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x370
+               	sub	x25, x29, #0x3f8
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfbd8            ; =64472
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfc68            ; =64616
+               	mov	x16, #0xfbe0            ; =64480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfc70            ; =64624
+               	mov	x16, #0xfbe8            ; =64488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfc78            ; =64632
+               	mov	x16, #0xfbf0            ; =64496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfc80            ; =64640
+               	mov	x16, #0xfbf8            ; =64504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfc88            ; =64648
+               	mov	x16, #0xfc00            ; =64512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x3a0
+               	sub	x0, x29, #0x428
                	mov	x8, x25
-<L68>:
-               	bl	 <L68>
+<L72>:
+               	bl	 <L72>
                	add	x0, x24, #0x0
-               	ldr	x26, [x0]
+               	ldr	x1, [x0]
                	add	x0, x24, #0x8
-               	ldr	x27, [x0]
+               	ldr	x26, [x0]
                	add	x0, x24, #0x10
-               	ldr	x28, [x0]
+               	ldr	x27, [x0]
                	add	x0, x24, #0x18
-               	ldr	x9, [x0]
-               	mov	x16, #0xf990            ; =63888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	ldr	x28, [x0]
                	add	x0, x24, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xf988            ; =63880
+               	mov	x16, #0xf770            ; =63344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x24, #0x28
                	ldr	x24, [x0]
-               	add	x0, x25, #0x0
-               	ldr	x9, [x0]
-               	mov	x16, #0xf980            ; =63872
+               	sub	x9, x29, #0x4d0
+               	mov	x16, #0xf778            ; =63352
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	add	x0, x25, #0x8
-               	ldr	x9, [x0]
-               	mov	x16, #0xf978            ; =63864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x25, #0x10
-               	ldr	x25, [x0]
-<L69>:
-               	bl	 <L69>
-               	mov	x1, x26
-<L70>:
-               	bl	 <L70>
-               	mov	x1, x27
-<L71>:
-               	bl	 <L71>
-               	mov	x1, x28
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xf990            ; =63888
+               	ldr	x0, [x25]
+               	ldr	x4, [x25, #0x8]
+               	ldr	x5, [x25, #0x10]
+               	mov	x16, #0xf778            ; =63352
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	str	x0, [x9]
+               	mov	x16, #0xf778            ; =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x4, [x9, #0x8]
+               	mov	x16, #0xf778            ; =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x5, [x9, #0x10]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L73>:
                	bl	 <L73>
-               	mov	x16, #0xf988            ; =63880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, x26
 <L74>:
                	bl	 <L74>
-               	mov	x1, x24
+               	mov	x1, x27
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xf980            ; =63872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, x28
 <L76>:
                	bl	 <L76>
-               	mov	x16, #0xf978            ; =63864
+               	mov	x16, #0xf770            ; =63344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1705,18 +2173,61 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L77>:
                	bl	 <L77>
-               	mov	x1, x25
+               	mov	x1, x24
 <L78>:
                	bl	 <L78>
-               	mov	x1, x23
+               	sub	x1, x29, #0x4e8
+               	mov	x16, #0xf778            ; =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x2, [x9]
+               	mov	x16, #0xf778            ; =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9, #0x8]
+               	mov	x16, #0xf778            ; =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9, #0x10]
+               	str	x2, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	mov	x16, #0xfb00            ; =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfb08            ; =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfb10            ; =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x500
 <L79>:
                	bl	 <L79>
-               	mov	x1, x0
-               	mov	x0, x21
+               	mov	x1, x23
 <L80>:
                	bl	 <L80>
+               	mov	x1, x0
+               	mov	x0, x21
+<L81>:
+               	bl	 <L81>
                	mov	x24, x0
-               	sub	x0, x29, #0x3d0
+               	sub	x0, x29, #0x530
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1737,70 +2248,70 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x3e8
+               	sub	x25, x29, #0x548
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfbe8            ; =64488
+               	mov	x16, #0xfa88            ; =64136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfbf0            ; =64496
+               	mov	x16, #0xfa90            ; =64144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfbf8            ; =64504
+               	mov	x16, #0xfa98            ; =64152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfc00            ; =64512
+               	mov	x16, #0xfaa0            ; =64160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfc08            ; =64520
+               	mov	x16, #0xfaa8            ; =64168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfc10            ; =64528
+               	mov	x16, #0xfab0            ; =64176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x418
+               	sub	x0, x29, #0x578
                	mov	x8, x25
-<L81>:
-               	bl	 <L81>
-               	sub	x26, x29, #0x448
+<L82>:
+               	bl	 <L82>
+               	sub	x26, x29, #0x5a8
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
-               	mov	x16, #0xfba0            ; =64416
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfba8            ; =64424
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfbb0            ; =64432
+               	mov	x16, #0xfa50            ; =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	sub	x0, x29, #0x460
+               	sub	x0, x29, #0x5c0
                	mov	x8, x26
-<L82>:
-               	bl	 <L82>
+<L83>:
+               	bl	 <L83>
                	add	x0, x26, #0x0
                	ldr	x1, [x0]
                	add	x0, x26, #0x8
@@ -1811,7 +2322,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x0]
                	add	x0, x26, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xf970            ; =63856
+               	mov	x16, #0xf768            ; =63336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1819,30 +2330,30 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x28
                	ldr	x26, [x0]
                	mov	x0, x24
-<L83>:
-               	bl	 <L83>
-               	mov	x1, x25
 <L84>:
                	bl	 <L84>
-               	mov	x1, x27
+               	mov	x1, x25
 <L85>:
                	bl	 <L85>
-               	mov	x1, x28
+               	mov	x1, x27
 <L86>:
                	bl	 <L86>
-               	mov	x16, #0xf970            ; =63856
+               	mov	x1, x28
+<L87>:
+               	bl	 <L87>
+               	mov	x16, #0xf768            ; =63336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-<L87>:
-               	bl	 <L87>
-               	mov	x1, x26
 <L88>:
                	bl	 <L88>
+               	mov	x1, x26
+<L89>:
+               	bl	 <L89>
                	mov	x24, x0
-               	sub	x0, x29, #0x478
+               	sub	x0, x29, #0x618
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1853,87 +2364,94 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x25, x29, #0x4a8
+               	sub	x25, x29, #0x648
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	mov	x16, #0xfb40            ; =64320
+               	mov	x16, #0xf9a0            ; =63904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfb48            ; =64328
+               	mov	x16, #0xf9a8            ; =63912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfb50            ; =64336
+               	mov	x16, #0xf9b0            ; =63920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	sub	x0, x29, #0x4c0
+               	sub	x0, x29, #0x660
                	mov	x8, x25
-<L89>:
-               	bl	 <L89>
-               	sub	x26, x29, #0x4d8
+<L90>:
+               	bl	 <L90>
+               	sub	x26, x29, #0x678
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
                	ldr	x3, [x25, #0x18]
                	ldr	x4, [x25, #0x20]
                	ldr	x5, [x25, #0x28]
-               	mov	x16, #0xfaf8            ; =64248
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfb00            ; =64256
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfb08            ; =64264
+               	mov	x16, #0xf968            ; =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfb10            ; =64272
+               	mov	x16, #0xf970            ; =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfb18            ; =64280
+               	mov	x16, #0xf978            ; =63864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfb20            ; =64288
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	sub	x0, x29, #0x508
+               	sub	x0, x29, #0x6a8
                	mov	x8, x26
-<L90>:
-               	bl	 <L90>
-               	add	x0, x26, #0x0
-               	ldr	x1, [x0]
-               	add	x0, x26, #0x8
-               	ldr	x25, [x0]
-               	add	x0, x26, #0x10
-               	ldr	x26, [x0]
-               	mov	x0, x24
 <L91>:
                	bl	 <L91>
-               	mov	x1, x25
+               	ldr	x0, [x26]
+               	ldr	x1, [x26, #0x8]
+               	ldr	x2, [x26, #0x10]
+               	mov	x16, #0xf940            ; =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf948            ; =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x6c0
+               	mov	x0, x24
 <L92>:
                	bl	 <L92>
-               	mov	x1, x26
-<L93>:
-               	bl	 <L93>
                	mov	x24, x0
-               	sub	x0, x29, #0x538
+               	sub	x0, x29, #0x6f0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1954,117 +2472,136 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x568
+               	sub	x25, x29, #0x720
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfa68            ; =64104
+               	mov	x16, #0xf8b0            ; =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfa70            ; =64112
+               	mov	x16, #0xf8b8            ; =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfa78            ; =64120
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfa80            ; =64128
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfa88            ; =64136
+               	mov	x16, #0xf8d0            ; =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfa90            ; =64144
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x598
+               	sub	x0, x29, #0x750
                	mov	x8, x25
                	mov	x1, x23
-<L94>:
-               	bl	 <L94>
-               	sub	x26, x29, #0x5b0
+<L93>:
+               	bl	 <L93>
+               	sub	x26, x29, #0x768
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
                	ldr	x3, [x25, #0x18]
                	ldr	x4, [x25, #0x20]
                	ldr	x5, [x25, #0x28]
-               	mov	x16, #0xfa20            ; =64032
+               	mov	x16, #0xf868            ; =63592
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfa28            ; =64040
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfa30            ; =64048
+               	mov	x16, #0xf878            ; =63608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfa38            ; =64056
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfa40            ; =64064
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfa48            ; =64072
+               	mov	x16, #0xf890            ; =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	sub	x0, x29, #0x5e0
+               	sub	x0, x29, #0x798
                	mov	x8, x26
-<L95>:
-               	bl	 <L95>
+<L94>:
+               	bl	 <L94>
                	add	x0, x26, #0x0
                	ldr	x1, [x0]
                	add	x0, x26, #0x8
                	ldr	x2, [x0]
                	add	x0, x26, #0x10
                	ldr	x3, [x0]
+               	sub	x0, x29, #0x7b0
                	add	x4, x1, x23
-               	eor	x25, x2, x23
-               	add	x23, x3, x1
+               	add	x5, x0, #0x0
+               	str	x4, [x5]
+               	eor	x4, x2, x23
+               	add	x2, x0, #0x8
+               	str	x4, [x2]
+               	add	x2, x3, x1
+               	add	x1, x0, #0x10
+               	str	x2, [x1]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	mov	x16, #0xf838            ; =63544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf840            ; =63552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xf848            ; =63560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	sub	x1, x29, #0x7c8
                	mov	x0, x24
-               	mov	x1, x4
-<L96>:
-               	bl	 <L96>
-               	mov	x1, x25
-<L97>:
-               	bl	 <L97>
-               	mov	x1, x23
-<L98>:
-               	bl	 <L98>
+<L95>:
+               	bl	 <L95>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L66>
-<L99>:
+               	b.lo	 <L70>
+<L96>:
                	mov	x0, x21
-               	sub	x16, x29, #0x6f0
-               	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x6a0
+               	sub	x16, x29, #0x900
+               	ldr	d8, [x16, #0x8]
+               	sub	x16, x29, #0x8b0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/call/call_ret_small.dis
+++ b/test/golden/aarch64-darwin/call/call_ret_small.dis
@@ -228,24 +228,50 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldr	w3, [x1]
+               	ldr	w2, [x1]
                	sub	x1, x29, #0x4
-               	ldr	w19, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
+               	ldr	w3, [x1]
+               	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -253,24 +279,53 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold8f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	s0, [x29, #-0x8]
                	stur	s1, [x29, #-0x4]
-               	sub	x2, x29, #0x8
-               	ldr	s0, [x2]
-               	sub	x2, x29, #0x4
-               	ldr	s8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x8
+               	ldr	s0, [x1]
+               	sub	x1, x29, #0x4
+               	ldr	s1, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -278,32 +333,72 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold12>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	w20, [x1]
-               	mov	x0, x3
+               	ldr	w4, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -311,25 +406,49 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x3, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -337,24 +456,51 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold16f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	d0, [x29, #-0x10]
                	stur	d1, [x29, #-0x8]
-               	sub	x2, x29, #0x10
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x10
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d1, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -362,25 +508,50 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold16m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	d8, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	d0, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -388,24 +559,50 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold16n>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	d0, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
+               	ldr	x2, [x1]
+               	fmov	x1, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -413,70 +610,66 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                ; =1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                ; =2
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x2                ; =2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x4                ; =4
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                ; =8
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xc                ; =12
+               	mov	x1, #0x8                ; =8
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0xc                ; =12
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               ; =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               ; =16
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               ; =16
 <L9>:
                	bl	 <L9>
+               	mov	x1, #0x10               ; =16
+<L10>:
+               	bl	 <L10>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_ret_small.regain>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xc0
-               	stp	x19, x20, [x29, #-0x60]
-               	stp	x21, x22, [x29, #-0x70]
-               	stp	x23, x24, [x29, #-0x80]
-               	stp	x25, x26, [x29, #-0x90]
-               	stp	d8, d9, [x29, #-0xa0]
-               	stp	d10, d11, [x29, #-0xb0]
-               	stur	d12, [x29, #-0xb8]
+               	sub	sp, sp, #0x130
+               	stp	x19, x20, [x29, #-0x110]
+               	stp	x21, x22, [x29, #-0x120]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x23, [x29, x16]
                	stur	x0, [x29, #-0x10]
                	stur	x1, [x29, #-0x8]
                	stur	d0, [x29, #-0x20]
@@ -488,80 +681,102 @@ Disassembly of section __TEXT,__text:
                	stur	x6, [x29, #-0x48]
                	stur	s2, [x29, #-0x50]
                	stur	s3, [x29, #-0x4c]
-               	sub	x1, x29, #0x10
-               	ldr	x19, [x1]
-               	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	sub	x1, x29, #0x20
-               	ldr	d8, [x1]
-               	sub	x1, x29, #0x18
-               	ldr	d9, [x1]
-               	sub	x1, x29, #0x30
-               	ldr	x21, [x1]
-               	sub	x1, x29, #0x28
-               	ldr	d10, [x1]
-               	sub	x1, x29, #0x40
-               	ldr	w22, [x1]
-               	sub	x1, x29, #0x3c
-               	ldr	w23, [x1]
-               	sub	x1, x29, #0x38
-               	ldr	w24, [x1]
-               	sub	x1, x29, #0x48
-               	ldr	w25, [x1]
-               	sub	x1, x29, #0x44
-               	ldr	w26, [x1]
-               	sub	x1, x29, #0x50
-               	ldr	s11, [x1]
-               	sub	x1, x29, #0x4c
-               	ldr	s12, [x1]
+               	sub	x0, x29, #0x60
+               	ldur	x1, [x29, #-0x10]
+               	ldur	x2, [x29, #-0x8]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	sub	x19, x29, #0x70
+               	ldur	x1, [x29, #-0x20]
+               	ldur	x2, [x29, #-0x18]
+               	str	x1, [x19]
+               	str	x2, [x19, #0x8]
+               	sub	x20, x29, #0x80
+               	ldur	x1, [x29, #-0x30]
+               	ldur	x2, [x29, #-0x28]
+               	str	x1, [x20]
+               	str	x2, [x20, #0x8]
+               	sub	x21, x29, #0x8c
+               	ldur	x1, [x29, #-0x40]
+               	ldur	w2, [x29, #-0x38]
+               	str	x1, [x21]
+               	str	w2, [x21, #0x8]
+               	sub	x22, x29, #0x94
+               	ldur	x1, [x29, #-0x48]
+               	str	x1, [x22]
+               	sub	x23, x29, #0x9c
+               	ldur	x1, [x29, #-0x50]
+               	str	x1, [x23]
+               	sub	x1, x29, #0xb0
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x2
+               	mov	x2, x3
 <L0>:
                	bl	 <L0>
-               	mov	x1, x19
+               	sub	x1, x29, #0xc0
+               	ldr	x2, [x19]
+               	ldr	x3, [x19, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x20
+               	sub	x1, x29, #0xd0
+               	ldr	x2, [x20]
+               	ldr	x3, [x20, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L2>:
                	bl	 <L2>
-               	fmov	d0, d8
+               	sub	x1, x29, #0xdc
+               	ldr	x2, [x21]
+               	ldr	w3, [x21, #0x8]
+               	str	x2, [x1]
+               	str	w3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	stur	xzr, [x29, #-0xe8]
+               	ldr	w3, [x1, #0x8]
+               	stur	w3, [x29, #-0xe8]
+               	ldur	x3, [x29, #-0xe8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L3>:
                	bl	 <L3>
-               	fmov	d0, d9
+               	sub	x1, x29, #0xf0
+               	ldr	x2, [x22]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x21
+               	sub	x1, x29, #0xf8
+               	ldr	x2, [x23]
+               	str	x2, [x1]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
 <L5>:
                	bl	 <L5>
-               	fmov	d0, d10
-<L6>:
-               	bl	 <L6>
-               	mov	w1, w22
-<L7>:
-               	bl	 <L7>
-               	mov	w1, w23
-<L8>:
-               	bl	 <L8>
-               	mov	w1, w24
-<L9>:
-               	bl	 <L9>
-               	mov	w1, w25
-<L10>:
-               	bl	 <L10>
-               	mov	w1, w26
-<L11>:
-               	bl	 <L11>
-               	fmov	s0, s11
-<L12>:
-               	bl	 <L12>
-               	fmov	s0, s12
-<L13>:
-               	bl	 <L13>
-               	ldp	d8, d9, [x29, #-0xa0]
-               	ldp	d10, d11, [x29, #-0xb0]
-               	ldur	d12, [x29, #-0xb8]
-               	ldp	x19, x20, [x29, #-0x60]
-               	ldp	x21, x22, [x29, #-0x70]
-               	ldp	x23, x24, [x29, #-0x80]
-               	ldp	x25, x26, [x29, #-0x90]
+               	ldp	x19, x20, [x29, #-0x110]
+               	ldp	x21, x22, [x29, #-0x120]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x23, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -569,25 +784,37 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1a0
-               	stp	x19, x20, [x29, #-0x130]
-               	stp	x21, x22, [x29, #-0x140]
-               	stp	x23, x24, [x29, #-0x150]
-               	stp	x25, x26, [x29, #-0x160]
-               	stp	x27, x28, [x29, #-0x170]
-               	stp	d8, d9, [x29, #-0x180]
-               	stp	d10, d11, [x29, #-0x190]
-               	mov	x16, #0xfe68            ; =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d12, [x29, x16]
+               	sub	sp, sp, #0x2d0
+               	sub	x16, x29, #0x290
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stur	x27, [x16, #-0x38]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x1                ; =1
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
                	mov	x1, #0x2                ; =2
 <L2>:
                	bl	 <L2>
@@ -615,7 +842,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, #0x10               ; =16
 <L10>:
                	bl	 <L10>
-               	sub	x20, x29, #0xe8
+               	sub	x20, x29, #0x130
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -650,98 +877,143 @@ Disassembly of section __TEXT,__text:
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x8
                	b.lo	 <L13>
-               	b	 <L32>
+               	b	 <L27>
 <L13>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	mov	w1, w23
+               	mov	w0, w23
+               	uxtb	w1, w0
                	mov	x0, x21
 <L14>:
                	bl	 <L14>
                	mov	w1, w23
+               	uxth	w2, w1
+               	mov	x1, x2
 <L15>:
                	bl	 <L15>
                	mov	w1, w23
+               	mov	w2, w1
+               	mov	x1, x2
 <L16>:
                	bl	 <L16>
-               	mov	w1, w23
+               	sub	x1, x29, #0x184
+               	mov	w2, w23
+               	add	x3, x1, #0x0
+               	str	w2, [x3]
                	lsr	x2, x23, #32
-               	mov	w24, w2
+               	mov	w3, w2
+               	add	x2, x1, #0x4
+               	str	w3, [x2]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
-               	mov	w1, w24
-<L18>:
-               	bl	 <L18>
+               	sub	x1, x29, #0x238
                	mov	x16, #0xfff             ; =4095
-               	and	x1, x23, x16
-               	ucvtf	s0, x1
+               	and	x2, x23, x16
+               	ucvtf	s0, x2
                	fmov	s30, #8.00000000
                	fdiv	s1, s0, s30
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
                	mov	x16, #0xff              ; =255
-               	and	x1, x23, x16
-               	ucvtf	s0, x1
+               	and	x2, x23, x16
+               	ucvtf	s0, x2
                	mov	w16, #0x43000000        ; =1124073472
                	fmov	s30, w16
-               	fsub	s8, s0, s30
-               	fmov	s0, s1
+               	fsub	s1, s0, s30
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
+<L18>:
+               	bl	 <L18>
+               	sub	x1, x29, #0x244
+               	mov	w2, w23
+               	add	x3, x1, #0x0
+               	str	w2, [x3]
+               	lsr	x2, x23, #16
+               	mov	w3, w2
+               	add	x2, x1, #0x4
+               	str	w3, [x2]
+               	lsr	x2, x23, #32
+               	mov	w3, w2
+               	add	x2, x1, #0x8
+               	str	w3, [x2]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	w3, [x1, #0x8]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w3, [x29, x16]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x3, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x3
 <L19>:
                	bl	 <L19>
-               	fmov	s0, s8
+               	sub	x1, x29, #0x260
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	mvn	x2, x23
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L20>:
                	bl	 <L20>
-               	mov	w1, w23
-               	lsr	x2, x23, #16
-               	mov	w24, w2
-               	lsr	x2, x23, #32
-               	mov	w25, w2
-<L21>:
-               	bl	 <L21>
-               	mov	w1, w24
-<L22>:
-               	bl	 <L22>
-               	mov	w1, w25
-<L23>:
-               	bl	 <L23>
-               	mvn	x24, x23
-               	mov	x1, x23
-<L24>:
-               	bl	 <L24>
-               	mov	x1, x24
-<L25>:
-               	bl	 <L25>
+               	sub	x1, x29, #0x270
                	mov	x16, #0xffff            ; =65535
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	fmov	d30, #8.00000000
                	fdiv	d1, d0, d30
+               	add	x2, x1, #0x0
+               	str	d1, [x2]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x3, lsl #16
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d8, d0, d30
-               	fmov	d0, d1
-<L26>:
-               	bl	 <L26>
-               	fmov	d0, d8
-<L27>:
-               	bl	 <L27>
+               	fdiv	d1, d0, d30
+               	add	x2, x1, #0x8
+               	str	d1, [x2]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
+<L21>:
+               	bl	 <L21>
+               	sub	x1, x29, #0x280
                	mov	x16, #0x3               ; =3
-               	mul	x1, x23, x16
-               	add	x2, x1, #0x1
+               	mul	x2, x23, x16
+               	add	x3, x2, #0x1
+               	add	x2, x1, #0x0
+               	str	x3, [x2]
                	mov	x16, #0x7fff            ; =32767
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	fmov	d30, #4.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x2, x1, #0x8
+               	str	d1, [x2]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d8
-<L29>:
-               	bl	 <L29>
+               	mov	x2, x3
+<L22>:
+               	bl	 <L22>
                	mov	x16, #0x1fff            ; =8191
                	and	x1, x23, x16
                	ucvtf	d0, x1
@@ -749,47 +1021,78 @@ Disassembly of section __TEXT,__text:
                	fdiv	d1, d0, d30
                	mov	x16, #0x5678            ; =22136
                	movk	x16, #0x1234, lsl #16
-               	eor	x24, x23, x16
-               	fmov	d0, d1
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x24
-<L31>:
-               	bl	 <L31>
+               	eor	x1, x23, x16
+               	fmov	x2, d1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+<L26>:
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x8
                	b.lo	 <L13>
-<L32>:
+<L27>:
                	sub	x22, x29, #0x48
                	add	x0, x22, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x48               ; =72
-<L33>:
+<L28>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L33>
+               	b.ne	 <L28>
                	sub	x23, x29, #0xa8
                	add	x0, x23, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x60               ; =96
-<L34>:
+<L29>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L34>
+               	b.ne	 <L29>
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x6
-               	b.lo	 <L35>
-               	b	 <L36>
-<L35>:
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0xf4
+               	sub	x2, x29, #0xdc
                	mov	w3, w1
                	add	x4, x2, #0x0
                	str	w3, [x4]
@@ -813,7 +1116,7 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0x3               ; =3
                	mul	x1, x2, x16
                	add	x2, x1, x19
-               	sub	x1, x29, #0x108
+               	sub	x1, x29, #0x140
                	mov	x16, #0x3               ; =3
                	mul	x3, x2, x16
                	add	x4, x3, #0x1
@@ -835,181 +1138,245 @@ Disassembly of section __TEXT,__text:
                	str	x4, [x3, #0x8]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L35>
-<L36>:
+               	b.lo	 <L30>
+<L31>:
                	mov	x24, #0x0               ; =0
                	cmp	x24, #0x6
-               	b.lo	 <L37>
-               	b	 <L43>
-<L37>:
+               	b.lo	 <L32>
+               	b	 <L35>
+<L32>:
                	mov	x16, #0xc               ; =12
                	mul	x0, x24, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldr	w2, [x0]
-               	add	x0, x1, #0x4
-               	ldr	w25, [x0]
-               	add	x0, x1, #0x8
-               	ldr	w26, [x0]
+               	sub	x0, x29, #0xb4
+               	ldr	x2, [x1]
+               	ldr	w3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	w3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	stur	xzr, [x29, #-0xc0]
+               	ldr	w2, [x0, #0x8]
+               	stur	w2, [x29, #-0xc0]
+               	ldur	x2, [x29, #-0xc0]
                	mov	x0, x21
-               	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	mov	w1, w25
-<L39>:
-               	bl	 <L39>
-               	mov	w1, w26
-<L40>:
-               	bl	 <L40>
+<L33>:
+               	bl	 <L33>
                	mov	x16, #0x10              ; =16
                	mul	x1, x24, x16
                	add	x2, x23, x1
-               	add	x1, x2, #0x0
-               	ldr	x3, [x1]
-               	add	x1, x2, #0x8
-               	ldr	d8, [x1]
-               	mov	x1, x3
-<L41>:
-               	bl	 <L41>
-               	fmov	d0, d8
-<L42>:
-               	bl	 <L42>
+               	sub	x1, x29, #0xd0
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L34>:
+               	bl	 <L34>
                	add	x24, x24, #0x1
                	mov	x21, x0
                	cmp	x24, #0x6
-               	b.lo	 <L37>
-<L43>:
+               	b.lo	 <L32>
+<L35>:
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L44>
-               	b	 <L60>
-<L44>:
+               	b.lo	 <L36>
+               	b	 <L44>
+<L36>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
-               	add	x23, x1, x19
-               	mvn	x24, x23
+               	add	x0, x1, x19
+               	sub	x1, x29, #0xf0
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	mvn	x2, x0
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	sub	x2, x29, #0x150
                	mov	x16, #0xffff            ; =65535
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x3, x0, x16
+               	ucvtf	d0, x3
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x3, x2, #0x0
+               	str	d1, [x3]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x3, lsl #16
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x3, x0, x16
+               	ucvtf	d0, x3
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x3, x2, #0x8
+               	str	d1, [x3]
+               	sub	x3, x29, #0x160
                	mov	x16, #0x3               ; =3
-               	mul	x0, x23, x16
-               	add	x25, x0, #0x1
+               	mul	x4, x0, x16
+               	add	x5, x4, #0x1
+               	add	x4, x3, #0x0
+               	str	x5, [x4]
                	mov	x16, #0x7fff            ; =32767
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x4, x0, x16
+               	ucvtf	d0, x4
                	fmov	d30, #4.00000000
-               	fdiv	d10, d0, d30
-               	mov	w26, w23
-               	lsr	x0, x23, #16
-               	mov	w27, w0
-               	lsr	x0, x23, #32
-               	mov	w28, w0
-               	mov	w9, w23
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	lsr	x0, x23, #32
-               	mov	w9, w0
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	fdiv	d1, d0, d30
+               	add	x4, x3, #0x8
+               	str	d1, [x4]
+               	sub	x4, x29, #0x16c
+               	mov	w5, w0
+               	add	x6, x4, #0x0
+               	str	w5, [x6]
+               	lsr	x5, x0, #16
+               	mov	w6, w5
+               	add	x5, x4, #0x4
+               	str	w6, [x5]
+               	lsr	x5, x0, #32
+               	mov	w6, w5
+               	add	x5, x4, #0x8
+               	str	w6, [x5]
+               	sub	x5, x29, #0x174
+               	mov	w6, w0
+               	add	x7, x5, #0x0
+               	str	w6, [x7]
+               	lsr	x6, x0, #32
+               	mov	w7, w6
+               	add	x6, x5, #0x4
+               	str	w7, [x6]
+               	sub	x6, x29, #0x17c
                	mov	x16, #0xfff             ; =4095
-               	and	x0, x23, x16
-               	ucvtf	s0, x0
+               	and	x7, x0, x16
+               	ucvtf	s0, x7
                	fmov	s30, #8.00000000
-               	fdiv	s11, s0, s30
+               	fdiv	s1, s0, s30
+               	add	x7, x6, #0x0
+               	str	s1, [x7]
                	mov	x16, #0xff              ; =255
-               	and	x0, x23, x16
-               	ucvtf	s0, x0
+               	and	x7, x0, x16
+               	ucvtf	s0, x7
                	mov	w16, #0x43000000        ; =1124073472
                	fmov	s30, w16
-               	fsub	s12, s0, s30
-<L45>:
-               	bl	 <L45>
-               	mov	x1, x23
-<L46>:
-               	bl	 <L46>
-               	mov	x1, x24
-<L47>:
-               	bl	 <L47>
-               	fmov	d0, d8
-<L48>:
-               	bl	 <L48>
-               	fmov	d0, d9
-<L49>:
-               	bl	 <L49>
-               	mov	x1, x25
-<L50>:
-               	bl	 <L50>
-               	fmov	d0, d10
-<L51>:
-               	bl	 <L51>
-               	mov	w1, w26
-<L52>:
-               	bl	 <L52>
-               	mov	w1, w27
-<L53>:
-               	bl	 <L53>
-               	mov	w1, w28
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfef0            ; =65264
+               	fsub	s1, s0, s30
+               	add	x0, x6, #0x4
+               	str	s1, [x0]
+               	sub	x0, x29, #0x198
+               	ldr	x7, [x1]
+               	ldr	x8, [x1, #0x8]
+               	str	x7, [x0]
+               	str	x8, [x0, #0x8]
+               	sub	x23, x29, #0x1a8
+               	ldr	x1, [x2]
+               	ldr	x7, [x2, #0x8]
+               	str	x1, [x23]
+               	str	x7, [x23, #0x8]
+               	sub	x24, x29, #0x1b8
+               	ldr	x1, [x3]
+               	ldr	x2, [x3, #0x8]
+               	str	x1, [x24]
+               	str	x2, [x24, #0x8]
+               	sub	x25, x29, #0x1c4
+               	ldr	x1, [x4]
+               	ldr	w2, [x4, #0x8]
+               	str	x1, [x25]
+               	str	w2, [x25, #0x8]
+               	sub	x26, x29, #0x1cc
+               	ldr	x1, [x5]
+               	str	x1, [x26]
+               	sub	x27, x29, #0x1d4
+               	ldr	x1, [x6]
+               	str	x1, [x27]
+               	sub	x1, x29, #0x1e8
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x2
+               	mov	x2, x3
+<L37>:
+               	bl	 <L37>
+               	sub	x1, x29, #0x1f8
+               	ldr	x2, [x23]
+               	ldr	x3, [x23, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
+<L38>:
+               	bl	 <L38>
+               	sub	x1, x29, #0x208
+               	ldr	x2, [x24]
+               	ldr	x3, [x24, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L39>:
+               	bl	 <L39>
+               	sub	x1, x29, #0x214
+               	ldr	x2, [x25]
+               	ldr	w3, [x25, #0x8]
+               	str	x2, [x1]
+               	str	w3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfee8            ; =65256
+               	str	xzr, [x29, x16]
+               	ldr	w3, [x1, #0x8]
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L56>:
-               	bl	 <L56>
-               	fmov	s0, s11
-<L57>:
-               	bl	 <L57>
-               	fmov	s0, s12
-<L58>:
-               	bl	 <L58>
+               	str	w3, [x29, x16]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x3, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x3
+<L40>:
+               	bl	 <L40>
+               	sub	x1, x29, #0x228
+               	ldr	x2, [x26]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L41>:
+               	bl	 <L41>
+               	sub	x1, x29, #0x230
+               	ldr	x2, [x27]
+               	str	x2, [x1]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
+<L42>:
+               	bl	 <L42>
                	mov	x1, x0
                	mov	x0, x21
-<L59>:
-               	bl	 <L59>
+<L43>:
+               	bl	 <L43>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L44>
-<L60>:
+               	b.lo	 <L36>
+<L44>:
                	mov	x0, x21
-               	ldp	d8, d9, [x29, #-0x180]
-               	ldp	d10, d11, [x29, #-0x190]
-               	mov	x16, #0xfe68            ; =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d12, [x29, x16]
-               	ldp	x19, x20, [x29, #-0x130]
-               	ldp	x21, x22, [x29, #-0x140]
-               	ldp	x23, x24, [x29, #-0x150]
-               	ldp	x25, x26, [x29, #-0x160]
-               	ldp	x27, x28, [x29, #-0x170]
+               	sub	x16, x29, #0x290
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldur	x27, [x16, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_variadic.dis
+++ b/test/golden/aarch64-darwin/call/call_variadic.dis
@@ -20,70 +20,99 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_variadic.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x150
-               	stp	x19, x20, [x29, #-0xd0]
-               	stp	x21, x22, [x29, #-0xe0]
-               	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
-               	stp	x27, x28, [x29, #-0x110]
-               	stp	d8, d9, [x29, #-0x120]
-               	stp	d10, d11, [x29, #-0x130]
-               	stp	d12, d13, [x29, #-0x140]
-               	mov	x16, #0xfeb8            ; =65208
+               	sub	sp, sp, #0x140
+               	stp	x19, x20, [x29, #-0xc0]
+               	stp	x21, x22, [x29, #-0xd0]
+               	stp	x23, x24, [x29, #-0xe0]
+               	stp	x25, x26, [x29, #-0xf0]
+               	stp	x27, x28, [x29, #-0x100]
+               	stp	d8, d9, [x29, #-0x110]
+               	stp	d10, d11, [x29, #-0x120]
+               	stp	d12, d13, [x29, #-0x130]
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d14, [x29, x16]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               ; =96
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               ; =96
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            ; =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+<L2>:
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x1, #0x0                ; =0
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x0                ; =0
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L7>
-               	b	 <L77>
-<L7>:
+               	b.lo	 <L9>
+               	b	 <L92>
+<L9>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
@@ -91,12 +120,11 @@ Disassembly of section __TEXT,__text:
                	mov	w25, w23
                	mov	w26, w23
                	lsr	x0, x23, #7
-               	mov	w27, w0
+               	mov	w1, w0
                	lsr	x0, x23, #3
-               	mov	w28, w0
+               	mov	w27, w0
                	lsr	x0, x23, #11
-               	mov	w9, w0
-               	stur	x9, [x29, #-0x68]
+               	mov	w28, w0
                	mov	x16, #0xfff             ; =4095
                	and	x0, x23, x16
                	ucvtf	s0, x0
@@ -138,224 +166,382 @@ Disassembly of section __TEXT,__text:
                	fdiv	d14, d0, d30
                	mov	x16, #0x3               ; =3
                	mul	x9, x23, x16
-               	stur	x9, [x29, #-0x70]
-               	uxtb	w1, w24
-               	mov	x0, x21
-<L8>:
-               	bl	 <L8>
-               	sxth	x1, w25
-<L9>:
-               	bl	 <L9>
-               	mov	w1, w26
+               	stur	x9, [x29, #-0x78]
+               	uxtb	w0, w24
+               	mov	x3, x21
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	uxtb	w1, w27
+               	sxth	x0, w25
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	uxth	w1, w28
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0x68]
-               	sxtw	x1, w9
+               	mov	w0, w26
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0x70]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, #0x8                ; =8
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x0, x16
+               	lsr	x5, x23, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	uxtb	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	uxth	w1, w27
+               	mov	x0, x3
+<L20>:
+               	bl	 <L20>
+               	sxtw	x1, w28
+<L21>:
+               	bl	 <L21>
+               	ldur	x9, [x29, #-0x78]
+               	mov	x1, x9
+<L22>:
+               	bl	 <L22>
+               	mov	x1, #0x8                ; =8
+<L23>:
+               	bl	 <L23>
                	add	x1, x20, #0x0
                	ldr	x2, [x1]
                	add	x1, x2, x23
                	add	x2, x20, #0x8
-               	ldr	x27, [x2]
+               	ldr	x3, [x2]
                	add	x2, x20, #0x10
-               	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x78]
+               	ldr	x4, [x2]
                	add	x2, x20, #0x18
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x80]
+               	stur	x9, [x29, #-0x70]
                	add	x2, x20, #0x20
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x68]
                	add	x2, x20, #0x28
-               	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x90]
+               	ldr	x28, [x2]
                	add	x2, x20, #0x30
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0x80]
                	add	x2, x20, #0x38
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xa0]
+               	stur	x9, [x29, #-0x88]
                	add	x2, x20, #0x40
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xa8]
+               	stur	x9, [x29, #-0x90]
                	add	x2, x20, #0x48
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0x98]
                	add	x2, x20, #0x50
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xb8]
+               	stur	x9, [x29, #-0xa0]
                	add	x2, x20, #0x58
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xc0]
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x27
-<L18>:
-               	bl	 <L18>
-               	ldur	x9, [x29, #-0x78]
-               	mov	x1, x9
-<L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x80]
-               	mov	x1, x9
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x90]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	ldur	x9, [x29, #-0x98]
-               	mov	x1, x9
-<L23>:
-               	bl	 <L23>
-               	ldur	x9, [x29, #-0xa0]
-               	mov	x1, x9
+               	stur	x9, [x29, #-0xa8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
 <L24>:
-               	bl	 <L24>
-               	ldur	x9, [x29, #-0xa8]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x2, x16
+               	lsr	x5, x1, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x5, x16
+               	eor	x5, x0, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
 <L25>:
-               	bl	 <L25>
-               	ldur	x9, [x29, #-0xb0]
-               	mov	x1, x9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	ldur	x9, [x29, #-0xb8]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x5, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x5, x16
+               	eor	x5, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	mov	x1, #0xc                ; =12
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	bl	 <L29>
-               	fmov	s0, s8
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	fmov	d0, d12
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	ldur	x9, [x29, #-0x70]
+               	lsr	x3, x9, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	fmov	s0, s9
+               	ldur	x9, [x29, #-0x68]
+               	mov	x1, x9
 <L32>:
                	bl	 <L32>
-               	fmov	d0, d13
+               	mov	x1, x28
 <L33>:
                	bl	 <L33>
-               	mov	x1, #0x4                ; =4
+               	ldur	x9, [x29, #-0x80]
+               	mov	x1, x9
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0x5               ; =5
-               	mul	x27, x23, x16
-               	mov	x1, x23
+               	ldur	x9, [x29, #-0x88]
+               	mov	x1, x9
 <L35>:
                	bl	 <L35>
-               	fmov	s0, s8
+               	ldur	x9, [x29, #-0x90]
+               	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	mov	w1, w26
+               	ldur	x9, [x29, #-0x98]
+               	mov	x1, x9
 <L37>:
                	bl	 <L37>
-               	fmov	d0, d12
+               	ldur	x9, [x29, #-0xa0]
+               	mov	x1, x9
 <L38>:
                	bl	 <L38>
-               	sxth	x1, w25
+               	ldur	x9, [x29, #-0xa8]
+               	mov	x1, x9
 <L39>:
                	bl	 <L39>
-               	mov	x1, x27
+               	mov	x1, #0xc                ; =12
 <L40>:
                	bl	 <L40>
-               	mov	x1, #0x6                ; =6
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
 <L41>:
-               	bl	 <L41>
-               	mov	x16, #0x7               ; =7
-               	mul	x27, x23, x16
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L41>
 <L42>:
-               	bl	 <L42>
-               	uxtb	w1, w24
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	fmov	x1, d12
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
 <L43>:
-               	bl	 <L43>
-               	mov	w1, w26
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
 <L44>:
-               	bl	 <L44>
-               	add	x1, x27, x23
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
-               	uxth	w1, w28
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	fmov	x1, d13
 <L46>:
                	bl	 <L46>
                	mov	x1, #0x4                ; =4
 <L47>:
                	bl	 <L47>
-               	mov	x1, x23
+               	mov	x16, #0x5               ; =5
+               	mul	x28, x23, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
+               	b	 <L49>
 <L48>:
-               	bl	 <L48>
-               	fmov	s0, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
 <L49>:
-               	bl	 <L49>
-               	add	x1, x23, x23
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L50>:
                	bl	 <L50>
-               	fmov	d0, d14
+               	mov	w1, w26
 <L51>:
                	bl	 <L51>
-               	mov	x1, #0x3                ; =3
+               	fmov	x1, d12
 <L52>:
                	bl	 <L52>
-               	uxtb	w1, w24
+               	sxth	x1, w25
 <L53>:
                	bl	 <L53>
-               	sxth	x1, w25
+               	mov	x1, x28
 <L54>:
                	bl	 <L54>
-               	mov	w1, w26
+               	mov	x1, #0x6                ; =6
 <L55>:
                	bl	 <L55>
-               	mov	x1, x23
+               	mov	x16, #0x7               ; =7
+               	mul	x28, x23, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
 <L56>:
-               	bl	 <L56>
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
 <L57>:
-               	bl	 <L57>
                	uxtb	w1, w24
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L58>:
                	bl	 <L58>
-               	sxth	x1, w25
+               	mov	w1, w26
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L59>:
                	bl	 <L59>
-               	mov	w1, w26
+               	add	x1, x28, x23
 <L60>:
                	bl	 <L60>
-               	mov	x1, x23
+               	uxth	w1, w27
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L61>:
                	bl	 <L61>
                	mov	x1, #0x4                ; =4
@@ -364,74 +550,125 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x23
 <L63>:
                	bl	 <L63>
-               	fmov	s0, s8
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L64>:
                	bl	 <L64>
-               	fmov	d0, d12
+               	add	x1, x23, x23
 <L65>:
                	bl	 <L65>
-               	mov	x1, #0x3                ; =3
+               	fmov	x1, d14
 <L66>:
                	bl	 <L66>
-               	mov	x16, #0x7               ; =7
-               	mul	x25, x23, x16
-               	mov	x16, #0x3               ; =3
-               	mul	x27, x23, x16
-               	mov	x1, x27
+               	mov	x1, #0x3                ; =3
 <L67>:
                	bl	 <L67>
                	uxtb	w1, w24
-               	add	x2, x1, x27
-               	mov	x1, x2
 <L68>:
                	bl	 <L68>
-               	mov	w1, w26
-               	add	x2, x1, x27
-               	mov	x1, x2
+               	sxth	x1, w25
 <L69>:
                	bl	 <L69>
-               	add	x1, x25, x27
+               	mov	w1, w26
 <L70>:
                	bl	 <L70>
-               	uxth	w1, w28
-               	add	x2, x1, x27
-               	mov	x1, x2
+               	mov	x1, x23
 <L71>:
                	bl	 <L71>
                	mov	x1, #0x4                ; =4
 <L72>:
                	bl	 <L72>
-               	mov	x1, x23
+               	uxtb	w1, w24
 <L73>:
                	bl	 <L73>
-               	mov	x1, #0x1                ; =1
+               	sxth	x1, w25
 <L74>:
                	bl	 <L74>
-               	fmov	s0, s11
+               	mov	w1, w26
 <L75>:
                	bl	 <L75>
-               	mov	x1, #0x1                ; =1
+               	mov	x1, x23
 <L76>:
                	bl	 <L76>
+               	mov	x1, #0x4                ; =4
+<L77>:
+               	bl	 <L77>
+               	mov	x1, x23
+<L78>:
+               	bl	 <L78>
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
+               	fmov	x1, d12
+<L80>:
+               	bl	 <L80>
+               	mov	x1, #0x3                ; =3
+<L81>:
+               	bl	 <L81>
+               	mov	x16, #0x7               ; =7
+               	mul	x25, x23, x16
+               	mov	x16, #0x3               ; =3
+               	mul	x28, x23, x16
+               	mov	x1, x28
+<L82>:
+               	bl	 <L82>
+               	uxtb	w1, w24
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L83>:
+               	bl	 <L83>
+               	mov	w1, w26
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L84>:
+               	bl	 <L84>
+               	add	x1, x25, x28
+<L85>:
+               	bl	 <L85>
+               	uxth	w1, w27
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L86>:
+               	bl	 <L86>
+               	mov	x1, #0x4                ; =4
+<L87>:
+               	bl	 <L87>
+               	mov	x1, x23
+<L88>:
+               	bl	 <L88>
+               	mov	x1, #0x1                ; =1
+<L89>:
+               	bl	 <L89>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L90>:
+               	bl	 <L90>
+               	mov	x1, #0x1                ; =1
+<L91>:
+               	bl	 <L91>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L7>
-<L77>:
+               	b.lo	 <L9>
+<L92>:
                	mov	x0, x21
-               	ldp	d8, d9, [x29, #-0x120]
-               	ldp	d10, d11, [x29, #-0x130]
-               	ldp	d12, d13, [x29, #-0x140]
-               	mov	x16, #0xfeb8            ; =65208
+               	ldp	d8, d9, [x29, #-0x110]
+               	ldp	d10, d11, [x29, #-0x120]
+               	ldp	d12, d13, [x29, #-0x130]
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d14, [x29, x16]
-               	ldp	x19, x20, [x29, #-0xd0]
-               	ldp	x21, x22, [x29, #-0xe0]
-               	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
-               	ldp	x27, x28, [x29, #-0x110]
+               	ldp	x19, x20, [x29, #-0xc0]
+               	ldp	x21, x22, [x29, #-0xd0]
+               	ldp	x23, x24, [x29, #-0xe0]
+               	ldp	x25, x26, [x29, #-0xf0]
+               	ldp	x27, x28, [x29, #-0x100]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -640,30 +877,25 @@ Disassembly of section __TEXT,__text:
                	sub	sp, sp, #0x20
                	stp	d8, d9, [x29, #-0x10]
                	stur	d10, [x29, #-0x18]
-               	mov	x1, x0
                	fmov	d8, d1
                	fmov	s9, s2
                	fmov	d10, d3
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	fmov	x1, d10
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x4                ; =4
 <L4>:
                	bl	 <L4>
@@ -689,35 +921,23 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x5
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	w2, w19
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	w1, w19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	sxth	x2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	sxth	x1, w20
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x21
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x6                ; =6
 <L6>:
                	bl	 <L6>
@@ -799,24 +1019,17 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x19
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x20, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	add	x1, x20, x19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x3                ; =3
 <L4>:
                	bl	 <L4>
@@ -897,10 +1110,12 @@ Disassembly of section __TEXT,__text:
                	fmov	d9, d1
 <L0>:
                	bl	 <L0>
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
                	mov	x1, #0x3                ; =3
@@ -973,12 +1188,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_variadic.fold_pack$pack$f32>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x1                ; =1
 <L1>:
                	bl	 <L1>
@@ -1037,10 +1251,12 @@ Disassembly of section __TEXT,__text:
                	fmov	d9, d1
 <L0>:
                	bl	 <L0>
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
                	mov	x1, #0x3                ; =3
@@ -1062,18 +1278,14 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x3                ; =3
 <L3>:
                	bl	 <L3>

--- a/test/golden/aarch64-darwin/cmp/branch_nest.dis
+++ b/test/golden/aarch64-darwin/cmp/branch_nest.dis
@@ -3,158 +3,180 @@ cmp/branch_nest.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.cmp.branch_nest.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	w2, #0x0                ; =0
+               	cmp	w2, #0x14
+               	b.lo	 <L0>
+               	b	 <L43>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	mov	x19, x0
-               	mov	w21, #0x0               ; =0
-               	cmp	w21, #0x14
-               	b.lo	 <L1>
-               	b	 <L42>
+               	add	w3, w2, w1
+               	cmp	w3, #0x4
+               	b.lo	 <L31>
+               	cmp	w3, #0x8
+               	b.lo	 <L23>
+               	cmp	w3, #0xc
+               	b.lo	 <L15>
+               	cmp	w3, #0x10
+               	b.lo	 <L7>
+               	cmp	w3, #0x10
+               	b.eq	 <L5>
+               	cmp	w3, #0x11
+               	b.eq	 <L3>
+               	cmp	w3, #0x12
+               	b.eq	 <L1>
+               	mov	w4, #0x1f7              ; =503
+               	b	 <L2>
 <L1>:
-               	add	w22, w21, w20
-               	cmp	w22, #0x4
-               	b.lo	 <L32>
-               	cmp	w22, #0x8
-               	b.lo	 <L24>
-               	cmp	w22, #0xc
-               	b.lo	 <L16>
-               	cmp	w22, #0x10
-               	b.lo	 <L8>
-               	cmp	w22, #0x10
-               	b.eq	 <L6>
-               	cmp	w22, #0x11
-               	b.eq	 <L4>
-               	cmp	w22, #0x12
-               	b.eq	 <L2>
-               	mov	w0, #0x1f7              ; =503
-               	b	 <L3>
+               	mov	w4, #0x1f6              ; =502
 <L2>:
-               	mov	w0, #0x1f6              ; =502
+               	b	 <L4>
 <L3>:
-               	b	 <L5>
+               	mov	w4, #0x1f5              ; =501
 <L4>:
-               	mov	w0, #0x1f5              ; =501
+               	b	 <L6>
 <L5>:
-               	b	 <L7>
+               	mov	w4, #0x1f4              ; =500
 <L6>:
-               	mov	w0, #0x1f4              ; =500
-<L7>:
-               	b	 <L15>
-<L8>:
-               	cmp	w22, #0xe
-               	b.lo	 <L11>
-               	cmp	w22, #0xe
-               	b.eq	 <L9>
-               	mov	w1, #0x193              ; =403
-               	b	 <L10>
-<L9>:
-               	mov	w1, #0x192              ; =402
-<L10>:
                	b	 <L14>
-<L11>:
-               	cmp	w22, #0xc
-               	b.eq	 <L12>
-               	mov	w2, #0x191              ; =401
+<L7>:
+               	cmp	w3, #0xe
+               	b.lo	 <L10>
+               	cmp	w3, #0xe
+               	b.eq	 <L8>
+               	mov	w5, #0x193              ; =403
+               	b	 <L9>
+<L8>:
+               	mov	w5, #0x192              ; =402
+<L9>:
                	b	 <L13>
+<L10>:
+               	cmp	w3, #0xc
+               	b.eq	 <L11>
+               	mov	w6, #0x191              ; =401
+               	b	 <L12>
+<L11>:
+               	mov	w6, #0x190              ; =400
 <L12>:
-               	mov	w2, #0x190              ; =400
+               	mov	x5, x6
 <L13>:
-               	mov	x1, x2
+               	mov	x4, x5
 <L14>:
-               	mov	x0, x1
-<L15>:
-               	b	 <L23>
-<L16>:
-               	cmp	w22, #0x8
-               	b.eq	 <L21>
-               	cmp	w22, #0x9
-               	b.eq	 <L19>
-               	cmp	w22, #0xa
-               	b.eq	 <L17>
-               	mov	w1, #0x12f              ; =303
-               	b	 <L18>
-<L17>:
-               	mov	w1, #0x12e              ; =302
-<L18>:
-               	b	 <L20>
-<L19>:
-               	mov	w1, #0x12d              ; =301
-<L20>:
                	b	 <L22>
+<L15>:
+               	cmp	w3, #0x8
+               	b.eq	 <L20>
+               	cmp	w3, #0x9
+               	b.eq	 <L18>
+               	cmp	w3, #0xa
+               	b.eq	 <L16>
+               	mov	w5, #0x12f              ; =303
+               	b	 <L17>
+<L16>:
+               	mov	w5, #0x12e              ; =302
+<L17>:
+               	b	 <L19>
+<L18>:
+               	mov	w5, #0x12d              ; =301
+<L19>:
+               	b	 <L21>
+<L20>:
+               	mov	w5, #0x12c              ; =300
 <L21>:
-               	mov	w1, #0x12c              ; =300
+               	mov	x4, x5
 <L22>:
-               	mov	x0, x1
-<L23>:
-               	b	 <L31>
-<L24>:
-               	cmp	w22, #0x6
-               	b.lo	 <L27>
-               	cmp	w22, #0x6
-               	b.eq	 <L25>
-               	mov	w1, #0xcb               ; =203
-               	b	 <L26>
-<L25>:
-               	mov	w1, #0xca               ; =202
-<L26>:
                	b	 <L30>
-<L27>:
-               	cmp	w22, #0x4
-               	b.eq	 <L28>
-               	mov	w2, #0xc9               ; =201
+<L23>:
+               	cmp	w3, #0x6
+               	b.lo	 <L26>
+               	cmp	w3, #0x6
+               	b.eq	 <L24>
+               	mov	w5, #0xcb               ; =203
+               	b	 <L25>
+<L24>:
+               	mov	w5, #0xca               ; =202
+<L25>:
                	b	 <L29>
+<L26>:
+               	cmp	w3, #0x4
+               	b.eq	 <L27>
+               	mov	w6, #0xc9               ; =201
+               	b	 <L28>
+<L27>:
+               	mov	w6, #0xc8               ; =200
 <L28>:
-               	mov	w2, #0xc8               ; =200
+               	mov	x5, x6
 <L29>:
-               	mov	x1, x2
+               	mov	x4, x5
 <L30>:
-               	mov	x0, x1
-<L31>:
-               	mov	x1, x0
-               	b	 <L39>
-<L32>:
-               	cmp	w22, #0x0
-               	b.eq	 <L37>
-               	cmp	w22, #0x1
-               	b.eq	 <L35>
-               	cmp	w22, #0x2
-               	b.eq	 <L33>
-               	mov	w0, #0x67               ; =103
-               	b	 <L34>
-<L33>:
-               	mov	w0, #0x66               ; =102
-<L34>:
-               	b	 <L36>
-<L35>:
-               	mov	w0, #0x65               ; =101
-<L36>:
                	b	 <L38>
+<L31>:
+               	cmp	w3, #0x0
+               	b.eq	 <L36>
+               	cmp	w3, #0x1
+               	b.eq	 <L34>
+               	cmp	w3, #0x2
+               	b.eq	 <L32>
+               	mov	w5, #0x67               ; =103
+               	b	 <L33>
+<L32>:
+               	mov	w5, #0x66               ; =102
+<L33>:
+               	b	 <L35>
+<L34>:
+               	mov	w5, #0x65               ; =101
+<L35>:
+               	b	 <L37>
+<L36>:
+               	mov	w5, #0x64               ; =100
 <L37>:
-               	mov	w0, #0x64               ; =100
+               	mov	x4, x5
 <L38>:
-               	mov	x1, x0
+               	mov	w5, w4
+               	mov	x4, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
 <L39>:
-               	mov	x0, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L39>
 <L40>:
-               	bl	 <L40>
-               	mov	w1, w22
+               	mov	w5, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
 <L41>:
-               	bl	 <L41>
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x14
-               	b.lo	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L41>
 <L42>:
-               	mov	x0, x19
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w2, w2, #0x1
+               	mov	x0, x4
+               	cmp	w2, #0x14
+               	b.lo	 <L0>
+<L43>:
                	ret

--- a/test/golden/aarch64-darwin/cmp/cmp_i32.dis
+++ b/test/golden/aarch64-darwin/cmp/cmp_i32.dis
@@ -5,125 +5,219 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_i32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xb0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
-               	stur	x25, [x29, #-0xa8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x70
+               	mov	w1, w0
+               	sub	x0, x29, #0x1c
+               	sub	x2, x29, #0x38
+               	add	x3, x2, #0x0
+               	str	wzr, [x3]
+               	add	x3, x2, #0x4
+               	str	wzr, [x3]
+               	add	x3, x2, #0x8
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0xc
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x10
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x3]
+               	add	x3, x2, #0x14
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x18
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	w6, [x2, #0x18]
+               	str	x3, [x0]
+               	str	x4, [x0, #0x8]
+               	str	x5, [x0, #0x10]
+               	str	w6, [x0, #0x18]
+               	sub	x2, x29, #0x54
+               	sub	x3, x29, #0x70
+               	add	x4, x3, #0x0
+               	str	wzr, [x4]
+               	add	x4, x3, #0x4
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x8
+               	str	wzr, [x4]
+               	add	x4, x3, #0xc
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x4]
+               	add	x4, x3, #0x10
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x14
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x18
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	w7, [x3, #0x18]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	w7, [x2, #0x18]
+               	mov	x3, #0x2325             ; =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x19, x29, #0x1c
-               	sub	x1, x29, #0x38
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	str	wzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	str	x4, [x19, #0x10]
-               	str	w5, [x19, #0x18]
-               	sub	x21, x29, #0x54
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	str	wzr, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	w5, [x21, #0x18]
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x7
+               	add	x5, x0, x4, lsl #2
+               	ldr	w6, [x5]
+               	add	w5, w6, w1
+               	add	x6, x2, x4, lsl #2
+               	ldr	w7, [x6]
+               	cmp	w5, w7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x19, x23, lsl #2
-               	ldr	w1, [x0]
-               	add	w24, w1, w20
-               	add	x0, x21, x23, lsl #2
-               	ldr	w25, [x0]
-               	cmp	w24, w25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	w24, w25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	w24, w25
-               	cset	w1, lt
-<L4>:
-               	bl	 <L4>
-               	cmp	w25, w24
-               	cset	w1, lt
-<L5>:
-               	bl	 <L5>
-               	cmp	w24, w25
-               	cset	w1, le
-<L6>:
-               	bl	 <L6>
-               	cmp	w25, w24
-               	cset	w1, le
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	w5, w7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	w5, w7
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	w7, w5
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
-               	ldur	x25, [x29, #-0xa8]
+               	cmp	w5, w7
+               	cset	w8, le
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	w7, w5
+               	cset	w8, le
+               	uxtb	w5, w8
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/cmp/cmp_i64.dis
+++ b/test/golden/aarch64-darwin/cmp/cmp_i64.dis
@@ -5,156 +5,242 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	stp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x25, [x29, x16]
-               	mov	x19, x0
+               	sub	sp, sp, #0xe0
+               	sub	x1, x29, #0x38
+               	sub	x2, x29, #0x70
+               	add	x3, x2, #0x0
+               	str	xzr, [x3]
+               	add	x3, x2, #0x8
+               	str	xzr, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x18
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x20
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x28
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x30
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	x6, [x2, #0x18]
+               	ldr	x7, [x2, #0x20]
+               	ldr	x8, [x2, #0x28]
+               	ldr	x12, [x2, #0x30]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	str	x6, [x1, #0x18]
+               	str	x7, [x1, #0x20]
+               	str	x8, [x1, #0x28]
+               	str	x12, [x1, #0x30]
+               	sub	x2, x29, #0xa8
+               	sub	x3, x29, #0xe0
+               	add	x4, x3, #0x0
+               	str	xzr, [x4]
+               	add	x4, x3, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x10
+               	str	xzr, [x4]
+               	add	x4, x3, #0x18
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x4]
+               	add	x4, x3, #0x20
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x28
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x30
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	x7, [x3, #0x18]
+               	ldr	x8, [x3, #0x20]
+               	ldr	x12, [x3, #0x28]
+               	ldr	x13, [x3, #0x30]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	x7, [x2, #0x18]
+               	str	x8, [x2, #0x20]
+               	str	x12, [x2, #0x28]
+               	str	x13, [x2, #0x30]
+               	mov	x3, #0x2325             ; =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x38
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	add	x2, x1, #0x10
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x20]
-               	str	x3, [x20, #0x8]
-               	str	x4, [x20, #0x10]
-               	str	x5, [x20, #0x18]
-               	str	x6, [x20, #0x20]
-               	str	x7, [x20, #0x28]
-               	str	x8, [x20, #0x30]
-               	sub	x21, x29, #0xa8
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x10
-               	str	xzr, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	x5, [x21, #0x18]
-               	str	x6, [x21, #0x20]
-               	str	x7, [x21, #0x28]
-               	str	x8, [x21, #0x30]
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x7
+               	add	x5, x1, x4, lsl #3
+               	ldr	x6, [x5]
+               	add	x5, x6, x0
+               	add	x6, x2, x4, lsl #3
+               	ldr	x7, [x6]
+               	cmp	x5, x7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	add	x24, x1, x19
-               	add	x0, x21, x23, lsl #3
-               	ldr	x25, [x0]
-               	cmp	x24, x25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	x24, x25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	x24, x25
-               	cset	w1, lt
-<L4>:
-               	bl	 <L4>
-               	cmp	x25, x24
-               	cset	w1, lt
-<L5>:
-               	bl	 <L5>
-               	cmp	x24, x25
-               	cset	w1, le
-<L6>:
-               	bl	 <L6>
-               	cmp	x25, x24
-               	cset	w1, le
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	x5, x7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	x5, x7
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	x7, x5
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	ldp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x25, [x29, x16]
+               	cmp	x5, x7
+               	cset	w8, le
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	x7, x5
+               	cset	w8, le
+               	uxtb	w5, w8
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/cmp/cmp_u32.dis
+++ b/test/golden/aarch64-darwin/cmp/cmp_u32.dis
@@ -5,125 +5,219 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xb0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
-               	stur	x25, [x29, #-0xa8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x70
+               	mov	w1, w0
+               	sub	x0, x29, #0x1c
+               	sub	x2, x29, #0x38
+               	add	x3, x2, #0x0
+               	str	wzr, [x3]
+               	add	x3, x2, #0x4
+               	str	wzr, [x3]
+               	add	x3, x2, #0x8
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0xc
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x10
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x3]
+               	add	x3, x2, #0x14
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x18
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	w6, [x2, #0x18]
+               	str	x3, [x0]
+               	str	x4, [x0, #0x8]
+               	str	x5, [x0, #0x10]
+               	str	w6, [x0, #0x18]
+               	sub	x2, x29, #0x54
+               	sub	x3, x29, #0x70
+               	add	x4, x3, #0x0
+               	str	wzr, [x4]
+               	add	x4, x3, #0x4
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x8
+               	str	wzr, [x4]
+               	add	x4, x3, #0xc
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x4]
+               	add	x4, x3, #0x10
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x14
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x18
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	str	w17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	w7, [x3, #0x18]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	w7, [x2, #0x18]
+               	mov	x3, #0x2325             ; =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x19, x29, #0x1c
-               	sub	x1, x29, #0x38
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	str	wzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	str	x4, [x19, #0x10]
-               	str	w5, [x19, #0x18]
-               	sub	x21, x29, #0x54
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	str	wzr, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	w5, [x21, #0x18]
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x7
+               	add	x5, x0, x4, lsl #2
+               	ldr	w6, [x5]
+               	add	w5, w6, w1
+               	add	x6, x2, x4, lsl #2
+               	ldr	w7, [x6]
+               	cmp	w5, w7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x19, x23, lsl #2
-               	ldr	w1, [x0]
-               	add	w24, w1, w20
-               	add	x0, x21, x23, lsl #2
-               	ldr	w25, [x0]
-               	cmp	w24, w25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	w24, w25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	w24, w25
-               	cset	w1, lo
-<L4>:
-               	bl	 <L4>
-               	cmp	w25, w24
-               	cset	w1, lo
-<L5>:
-               	bl	 <L5>
-               	cmp	w24, w25
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	cmp	w25, w24
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	w5, w7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	w5, w7
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	w7, w5
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
-               	ldur	x25, [x29, #-0xa8]
+               	cmp	w5, w7
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	w7, w5
+               	cset	w8, ls
+               	uxtb	w5, w8
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/cmp/cmp_u64.dis
+++ b/test/golden/aarch64-darwin/cmp/cmp_u64.dis
@@ -5,156 +5,242 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	stp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x25, [x29, x16]
-               	mov	x19, x0
+               	sub	sp, sp, #0xe0
+               	sub	x1, x29, #0x38
+               	sub	x2, x29, #0x70
+               	add	x3, x2, #0x0
+               	str	xzr, [x3]
+               	add	x3, x2, #0x8
+               	str	xzr, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x18
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x20
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x28
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x30
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	x6, [x2, #0x18]
+               	ldr	x7, [x2, #0x20]
+               	ldr	x8, [x2, #0x28]
+               	ldr	x12, [x2, #0x30]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	str	x6, [x1, #0x18]
+               	str	x7, [x1, #0x20]
+               	str	x8, [x1, #0x28]
+               	str	x12, [x1, #0x30]
+               	sub	x2, x29, #0xa8
+               	sub	x3, x29, #0xe0
+               	add	x4, x3, #0x0
+               	str	xzr, [x4]
+               	add	x4, x3, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x10
+               	str	xzr, [x4]
+               	add	x4, x3, #0x18
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x4]
+               	add	x4, x3, #0x20
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x28
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x30
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	x7, [x3, #0x18]
+               	ldr	x8, [x3, #0x20]
+               	ldr	x12, [x3, #0x28]
+               	ldr	x13, [x3, #0x30]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	x7, [x2, #0x18]
+               	str	x8, [x2, #0x20]
+               	str	x12, [x2, #0x28]
+               	str	x13, [x2, #0x30]
+               	mov	x3, #0x2325             ; =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x38
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	add	x2, x1, #0x10
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x20]
-               	str	x3, [x20, #0x8]
-               	str	x4, [x20, #0x10]
-               	str	x5, [x20, #0x18]
-               	str	x6, [x20, #0x20]
-               	str	x7, [x20, #0x28]
-               	str	x8, [x20, #0x30]
-               	sub	x21, x29, #0xa8
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x10
-               	str	xzr, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            ; =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	x5, [x21, #0x18]
-               	str	x6, [x21, #0x20]
-               	str	x7, [x21, #0x28]
-               	str	x8, [x21, #0x30]
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x7
+               	add	x5, x1, x4, lsl #3
+               	ldr	x6, [x5]
+               	add	x5, x6, x0
+               	add	x6, x2, x4, lsl #3
+               	ldr	x7, [x6]
+               	cmp	x5, x7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	add	x24, x1, x19
-               	add	x0, x21, x23, lsl #3
-               	ldr	x25, [x0]
-               	cmp	x24, x25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	x24, x25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	x24, x25
-               	cset	w1, lo
-<L4>:
-               	bl	 <L4>
-               	cmp	x25, x24
-               	cset	w1, lo
-<L5>:
-               	bl	 <L5>
-               	cmp	x24, x25
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	cmp	x25, x24
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	x5, x7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	x5, x7
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	x7, x5
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	ldp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x25, [x29, x16]
+               	cmp	x5, x7
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	x7, x5
+               	cset	w8, ls
+               	uxtb	w5, w8
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/cmp/loop_shapes.dis
+++ b/test/golden/aarch64-darwin/cmp/loop_shapes.dis
@@ -3,139 +3,208 @@ cmp/loop_shapes.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.cmp.loop_shapes.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	mov	x19, x0
-               	mov	w21, #0x0               ; =0
-               	mov	x22, x20
-               	cmp	w21, #0x10
-               	b.lo	 <L1>
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	w2, #0x0                ; =0
+               	mov	x3, x1
+               	cmp	w2, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w16, #0x3               ; =3
-               	mul	w0, w21, w16
-               	add	w1, w22, w0
-               	add	w22, w1, #0x1
-               	mov	x0, x19
-               	mov	w1, w22
-<L2>:
-               	bl	 <L2>
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x10
+               	mul	w4, w2, w16
+               	add	w5, w3, w4
+               	add	w4, w5, #0x1
+               	mov	w5, w4
+               	mov	x6, x0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	w2, w2, #0x1
+               	mov	x0, x6
+               	mov	x3, x4
+               	cmp	w2, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	w17, #0x62              ; =98
-               	add	w0, w17, w20
-               	mov	x21, x0
+               	add	w2, w17, w1
                	mov	w17, #0x0               ; =0
-               	cmp	w17, w21
+               	cmp	w17, w2
                	b.lo	 <L4>
-               	b	 <L6>
+               	b	 <L7>
 <L4>:
-               	sub	w21, w21, #0x7
-               	mov	x0, x19
-               	mov	w1, w21
+               	sub	w3, w2, #0x7
+               	mov	w4, w3
+               	mov	x5, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x19, x0
-               	mov	w17, #0x0               ; =0
-               	cmp	w17, w21
-               	b.lo	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	mov	w21, #0x0               ; =0
-               	cmp	w21, #0x6
-               	b.lo	 <L7>
-               	b	 <L13>
+               	mov	x0, x5
+               	mov	x2, x3
+               	mov	w17, #0x0               ; =0
+               	cmp	w17, w2
+               	b.lo	 <L4>
 <L7>:
-               	mov	w16, #0x6               ; =6
-               	mul	w22, w21, w16
-               	mov	x23, x19
-               	mov	w24, #0x0               ; =0
-               	cmp	w24, #0x6
+               	mov	w2, #0x0                ; =0
+               	cmp	w2, #0x6
                	b.lo	 <L8>
-               	b	 <L12>
+               	b	 <L15>
 <L8>:
-               	cmp	w24, #0x3
-               	b.eq	 <L10>
-               	add	w0, w22, w24
-               	add	w1, w0, w20
-               	mov	x0, x23
+               	mov	w16, #0x6               ; =6
+               	mul	w3, w2, w16
+               	mov	x4, x0
+               	mov	w5, #0x0                ; =0
+               	cmp	w5, #0x6
+               	b.lo	 <L9>
+               	b	 <L14>
 <L9>:
-               	bl	 <L9>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
+               	cmp	w5, #0x3
+               	b.eq	 <L12>
+               	add	w6, w3, w5
+               	add	w7, w6, w1
+               	mov	w6, w7
+               	mov	x7, x4
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
                	b	 <L11>
 <L10>:
-               	add	w24, w24, #0x1
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	cmp	w24, #0x6
-               	b.lo	 <L8>
+               	add	w5, w5, #0x1
+               	mov	x4, x7
+               	b	 <L13>
 <L12>:
-               	add	w21, w21, #0x1
-               	mov	x19, x23
-               	cmp	w21, #0x6
-               	b.lo	 <L7>
+               	add	w5, w5, #0x1
 <L13>:
-               	mov	w17, #0x9               ; =9
-               	add	w21, w17, w20
-               	mov	x22, x20
-               	mov	w16, #0x4240            ; =16960
-               	movk	w16, #0xf, lsl #16
-               	cmp	w22, w16
-               	b.lo	 <L14>
-               	b	 <L16>
+               	cmp	w5, #0x6
+               	b.lo	 <L9>
 <L14>:
-               	mov	x0, x19
-               	mov	w1, w22
+               	add	w2, w2, #0x1
+               	mov	x0, x4
+               	cmp	w2, #0x6
+               	b.lo	 <L8>
 <L15>:
-               	bl	 <L15>
-               	cmp	w22, w21
-               	b.eq	 <L17>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
+               	mov	w17, #0x9               ; =9
+               	add	w2, w17, w1
+               	mov	x3, x1
                	mov	w16, #0x4240            ; =16960
                	movk	w16, #0xf, lsl #16
-               	cmp	w22, w16
-               	b.lo	 <L14>
+               	cmp	w3, w16
+               	b.lo	 <L16>
+               	b	 <L19>
 <L16>:
+               	mov	w4, w3
+               	mov	x5, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L17>
                	b	 <L18>
 <L17>:
-               	mov	x19, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	mov	w17, #0x1               ; =1
-               	add	w0, w17, w20
-               	mov	x20, x0
-               	mov	w21, #0x1               ; =1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x14
-               	b.lo	 <L19>
-               	b	 <L21>
+               	cmp	w3, w2
+               	b.eq	 <L20>
+               	add	w3, w3, #0x1
+               	mov	x0, x5
+               	mov	w16, #0x4240            ; =16960
+               	movk	w16, #0xf, lsl #16
+               	cmp	w3, w16
+               	b.lo	 <L16>
 <L19>:
-               	add	w23, w20, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	mov	x20, x21
-               	mov	x21, x23
-               	cmp	w22, #0x14
-               	b.lo	 <L19>
+               	mov	x0, x5
 <L21>:
-               	mov	x0, x19
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w17, #0x1               ; =1
+               	add	w2, w17, w1
+               	mov	w1, #0x1                ; =1
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x14
+               	b.lo	 <L22>
+               	b	 <L25>
+<L22>:
+               	add	w4, w2, w1
+               	mov	w5, w4
+               	mov	x6, x0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	add	w3, w3, #0x1
+               	mov	x0, x6
+               	mov	x2, x1
+               	mov	x1, x4
+               	cmp	w3, #0x14
+               	b.lo	 <L22>
+<L25>:
                	ret

--- a/test/golden/aarch64-darwin/cmp/short_circuit.dis
+++ b/test/golden/aarch64-darwin/cmp/short_circuit.dis
@@ -47,61 +47,147 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.cmp.short_circuit.fold_state>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x20, x20, #0x0
-               	mov	x21, x0
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x4
-               	b.lo	 <L1>
-               	b	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x4
+               	b.lo	 <L2>
+               	b	 <L7>
 <L2>:
-               	bl	 <L2>
-               	add	x1, x20, x22, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x4, x1, x3, lsl #3
+               	ldr	x5, [x4]
+               	mov	x4, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x0, x21
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x5, x2, x3, lsl #3
+               	ldr	x6, [x5]
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x5, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x3, x3, #0x1
+               	mov	x0, x4
+               	cmp	x3, #0x4
+               	b.lo	 <L2>
+<L7>:
                	ret
 
 <corpus.cases.cmp.short_circuit.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
+               	mov	w19, w0
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x4
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L0>
+<L1>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x1, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x1, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x1, [x0]
+               	add	x2, x1, #0x1
+               	str	x2, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	str	x0, [x1]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x0               ; =0
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	bl	 <L3>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -110,17 +196,17 @@ Disassembly of section __TEXT,__text:
                	add	x2, x2, #0x0
                	mov	x3, #0x0                ; =0
                	cmp	x3, #0x4
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
                	add	x4, x1, x3, lsl #3
                	str	xzr, [x4]
                	add	x4, x2, x3, lsl #3
                	str	xzr, [x4]
                	add	x3, x3, #0x1
                	cmp	x3, #0x4
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L4>
+<L5>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
                	add	x2, x1, #0x1
@@ -136,74 +222,65 @@ Disassembly of section __TEXT,__text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x1, [x2]
-               	mov	x1, #0x0                ; =0
-<L3>:
-               	bl	 <L3>
+               	mov	w17, #0x1               ; =1
+               	eor	w1, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L4>:
-               	bl	 <L4>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L5>
-               	b	 <L8>
-<L5>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w1
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
                	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L5>
-<L8>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
                	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x1, x1, #0x0
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x4
-               	b.lo	 <L9>
-               	b	 <L10>
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x4
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	add	x4, x1, x3, lsl #3
+               	str	xzr, [x4]
+               	add	x4, x2, x3, lsl #3
+               	str	xzr, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x4
+               	b.lo	 <L8>
 <L9>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L9>
-<L10>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               ; =1
-               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
                	add	x2, x1, #0x1
@@ -219,137 +296,56 @@ Disassembly of section __TEXT,__text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x1, [x2]
-               	uxtb	w17, w0
-               	cmp	w17, #0x1
-               	cset	w1, eq
-               	mov	x0, x22
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               ; =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
                	bl	 <L11>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x4
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L13>
-               	b	 <L16>
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L12>
 <L13>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L14>:
-               	bl	 <L14>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L15>:
-               	bl	 <L15>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L13>
-<L16>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x4
-               	b.lo	 <L17>
-               	b	 <L18>
-<L17>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L17>
-<L18>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x0, x22
-               	mov	x1, #0x1                ; =1
-<L19>:
-               	bl	 <L19>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L20>:
-               	bl	 <L20>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L21>
-               	b	 <L24>
-<L21>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L22>:
-               	bl	 <L22>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L21>
-<L24>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x4
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L25>
-<L26>:
                	mov	x0, #0x0                ; =0
                	mov	x1, #0x0                ; =0
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L28>
+               	cbnz	w1,  <L15>
                	mov	w17, #0x1               ; =1
-               	eor	w0, w17, w20
+               	eor	w0, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -368,43 +364,33 @@ Disassembly of section __TEXT,__text:
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w2, eq
-               	b	 <L29>
-<L28>:
+               	b	 <L16>
+<L15>:
                	mov	x2, x1
-<L29>:
-               	mov	x0, x22
-               	mov	x1, x2
-<L30>:
-               	bl	 <L30>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L31>:
-               	bl	 <L31>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L32>
-               	b	 <L35>
-<L32>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L33>:
-               	bl	 <L33>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L34>:
-               	bl	 <L34>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L32>
-<L35>:
+<L16>:
+               	uxtb	w0, w2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	mov	x0, x20
+<L19>:
+               	bl	 <L19>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -413,25 +399,25 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x4
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L36>
-<L37>:
+               	b.lo	 <L20>
+<L21>:
                	mov	x0, #0x0                ; =0
                	mov	x1, #0x0                ; =0
-<L38>:
-               	bl	 <L38>
+<L22>:
+               	bl	 <L22>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L39>
+               	cbnz	w1,  <L23>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -448,33 +434,32 @@ Disassembly of section __TEXT,__text:
                	add	x2, x2, #0x0
                	str	x0, [x2]
                	mov	x0, #0x1                ; =1
-               	b	 <L40>
-<L39>:
+               	b	 <L24>
+<L23>:
                	mov	x0, x1
-<L40>:
-               	cbnz	w0,  <L41>
-               	mov	x1, x0
-               	b	 <L44>
-<L41>:
+<L24>:
+               	cbnz	w0,  <L25>
+               	b	 <L28>
+<L25>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	uxtb	w17, w20
+               	str	x1, [x2]
+               	uxtb	w17, w19
                	cmp	w17, #0x1
-               	cset	w0, eq
-               	cbnz	w0,  <L42>
+               	cset	w1, eq
+               	cbnz	w1,  <L26>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -491,44 +476,35 @@ Disassembly of section __TEXT,__text:
                	add	x3, x3, #0x0
                	str	x2, [x3]
                	mov	x2, #0x1                ; =1
-               	b	 <L43>
-<L42>:
-               	mov	x2, x0
-<L43>:
-               	mov	x1, x2
-<L44>:
-               	mov	x0, x22
-<L45>:
-               	bl	 <L45>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L46>:
-               	bl	 <L46>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L47>
-               	b	 <L50>
-<L47>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L48>:
-               	bl	 <L48>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L49>:
-               	bl	 <L49>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L47>
-<L50>:
+               	b	 <L27>
+<L26>:
+               	mov	x2, x1
+<L27>:
+               	mov	x0, x2
+<L28>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, x20
+<L31>:
+               	bl	 <L31>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -537,25 +513,25 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x4
-               	b.lo	 <L51>
-               	b	 <L52>
-<L51>:
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L51>
-<L52>:
+               	b.lo	 <L32>
+<L33>:
                	mov	x0, #0x0                ; =0
                	mov	x1, #0x1                ; =1
-<L53>:
-               	bl	 <L53>
+<L34>:
+               	bl	 <L34>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L54>
+               	cbnz	w1,  <L35>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -572,31 +548,30 @@ Disassembly of section __TEXT,__text:
                	add	x2, x2, #0x0
                	str	x0, [x2]
                	mov	x0, #0x1                ; =1
-               	b	 <L55>
-<L54>:
+               	b	 <L36>
+<L35>:
                	mov	x0, x1
-<L55>:
-               	cbnz	w0,  <L56>
-               	mov	x1, x0
-               	b	 <L57>
-<L56>:
+<L36>:
+               	cbnz	w0,  <L37>
+               	b	 <L38>
+<L37>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
+               	str	x1, [x2]
                	mov	w17, #0x1               ; =1
-               	eor	w0, w17, w20
+               	eor	w1, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -612,43 +587,34 @@ Disassembly of section __TEXT,__text:
                	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x3, x3, #0x0
                	str	x2, [x3]
-               	uxtb	w17, w0
+               	uxtb	w17, w1
                	cmp	w17, #0x1
                	cset	w2, eq
-               	mov	x1, x2
-<L57>:
-               	mov	x0, x22
-<L58>:
-               	bl	 <L58>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L59>:
-               	bl	 <L59>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L60>
-               	b	 <L63>
-<L60>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L61>:
-               	bl	 <L61>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L62>:
-               	bl	 <L62>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L60>
-<L63>:
+               	mov	x0, x2
+<L38>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	mov	x0, x20
+<L41>:
+               	bl	 <L41>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -657,25 +623,25 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x4
-               	b.lo	 <L64>
-               	b	 <L65>
-<L64>:
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L64>
-<L65>:
+               	b.lo	 <L42>
+<L43>:
                	mov	x0, #0x0                ; =0
                	mov	x1, #0x0                ; =0
-<L66>:
-               	bl	 <L66>
+<L44>:
+               	bl	 <L44>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L67>
+               	cbnz	w1,  <L45>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -691,70 +657,56 @@ Disassembly of section __TEXT,__text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x0, [x2]
-               	uxtb	w17, w20
+               	uxtb	w17, w19
                	cmp	w17, #0x1
                	cset	w0, eq
-               	b	 <L68>
-<L67>:
+               	b	 <L46>
+<L45>:
                	mov	x0, x1
-<L68>:
-               	cbnz	w0,  <L69>
-               	mov	x1, x0
-               	b	 <L70>
-<L69>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
-               	add	x3, x2, #0x1
-               	str	x3, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	mov	x1, #0x1                ; =1
-<L70>:
-               	mov	x0, x22
-<L71>:
-               	bl	 <L71>
+<L46>:
+               	cbnz	w0,  <L47>
+               	b	 <L48>
+<L47>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L72>:
-               	bl	 <L72>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x20, x20, #0x0
-               	mov	x21, x0
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x4
-               	b.lo	 <L73>
-               	b	 <L76>
-<L73>:
-               	add	x0, x19, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
-<L74>:
-               	bl	 <L74>
-               	add	x1, x20, x22, lsl #3
+               	add	x2, x1, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
                	ldr	x2, [x1]
-               	mov	x1, x2
-<L75>:
-               	bl	 <L75>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L73>
-<L76>:
-               	mov	x0, x21
+               	add	x3, x2, #0x1
+               	str	x3, [x1]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x1, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x1, [x2]
+               	mov	x0, #0x1                ; =1
+<L48>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	mov	x0, x20
+<L51>:
+               	bl	 <L51>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/comptime/ct_runtime_agree.dis
+++ b/test/golden/aarch64-darwin/comptime/ct_runtime_agree.dis
@@ -31,133 +31,194 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xa0
+               	sub	sp, sp, #0x80
                	stp	x19, x20, [x29, #-0x40]
                	stp	x21, x22, [x29, #-0x50]
                	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
-               	stur	x27, [x29, #-0x78]
-               	stp	d8, d9, [x29, #-0x88]
-               	stp	d10, d11, [x29, #-0x98]
+               	stp	d8, d9, [x29, #-0x70]
+               	stp	d10, d11, [x29, #-0x80]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0x5678            ; =22136
                	movk	x17, #0x1234, lsl #16
-               	add	x20, x17, x19
+               	add	x0, x17, x19
                	mov	x16, #0x3               ; =3
-               	mul	x2, x20, x16
-               	add	x21, x2, #0x7
-               	lsl	x2, x21, #13
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x7
+               	lsl	x1, x2, #13
                	mov	x16, #0xf0f             ; =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf, lsl #32
-               	eor	x22, x2, x16
-               	lsr	x2, x22, #7
-               	eor	x23, x22, x2
+               	eor	x3, x1, x16
+               	lsr	x1, x3, #7
+               	eor	x20, x3, x1
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
-               	and	x24, x23, x16
+               	and	x21, x20, x16
                	mov	x16, #0x79b1            ; =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x25, x24, x16
-               	lsr	x26, x25, #17
-               	add	x27, x26, x24
-               	mov	x0, x1
-               	mov	x1, #0x5678             ; =22136
-               	movk	x1, #0x1234, lsl #16
+               	mul	x22, x21, x16
+               	lsr	x23, x22, #17
+               	add	x24, x23, x21
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	mov	x17, #0x5678            ; =22136
+               	movk	x17, #0x1234, lsl #16
+               	lsr	x6, x17, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x36f              ; =879
-               	movk	x1, #0x369d, lsl #16
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xef0f             ; =61199
-               	movk	x1, #0xaf62, lsl #16
-               	movk	x1, #0x6dc, lsl #32
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x0, x16
+               	mov	x17, #0x36f             ; =879
+               	movk	x17, #0x369d, lsl #16
+               	lsr	x5, x17, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x0, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xef0f            ; =61199
+               	movk	x17, #0xaf62, lsl #16
+               	movk	x17, #0x6dc, lsl #32
+               	lsr	x4, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x4, x16
+               	eor	x4, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x0, x1
                	mov	x1, #0x2ad1             ; =10961
                	movk	x1, #0x163c, lsl #16
                	movk	x1, #0x6d1, lsl #32
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
+<L12>:
+               	bl	 <L12>
+               	mov	x1, x20
+<L13>:
+               	bl	 <L13>
                	mov	x1, #0x2ad1             ; =10961
                	movk	x1, #0x163c, lsl #16
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
+<L14>:
+               	bl	 <L14>
+               	mov	x1, x21
+<L15>:
+               	bl	 <L15>
                	mov	x1, #0x6381             ; =25473
                	movk	x1, #0xbd, lsl #16
                	movk	x1, #0xf3ec, lsl #32
                	movk	x1, #0xdbd, lsl #48
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, x22
+<L17>:
+               	bl	 <L17>
                	mov	x1, #0x5e               ; =94
                	movk	x1, #0xf9f6, lsl #16
                	movk	x1, #0x6de, lsl #32
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
+<L18>:
+               	bl	 <L18>
+               	mov	x1, x23
+<L19>:
+               	bl	 <L19>
                	mov	x1, #0x2b2f             ; =11055
                	movk	x1, #0x1032, lsl #16
                	movk	x1, #0x6df, lsl #32
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L20>:
+               	bl	 <L20>
+               	mov	x1, x24
+<L21>:
+               	bl	 <L21>
                	ucvtf	d0, x19
                	fmov	d31, #1.00000000
                	fadd	d1, d31, d0
@@ -172,50 +233,42 @@ Disassembly of section __TEXT,__text:
                	fdiv	d10, d9, d30
                	fmul	d0, d10, d10
                	fadd	d11, d0, d8
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	mov	x1, #0x5555             ; =21845
+               	movk	x1, #0x5555, lsl #16
+               	movk	x1, #0x5555, lsl #32
+               	movk	x1, #0x3fd5, lsl #48
 <L22>:
                	bl	 <L22>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
+               	fmov	x1, d8
 <L23>:
                	bl	 <L23>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	mov	x1, #0x5550             ; =21840
+               	movk	x1, #0x5555, lsl #16
+               	movk	x1, #0x5555, lsl #32
+               	movk	x1, #0x3fd5, lsl #48
 <L24>:
                	bl	 <L24>
-               	mov	x1, x0
+               	fmov	x1, d9
+<L25>:
+               	bl	 <L25>
+               	mov	x1, #0x9360             ; =37728
+               	movk	x1, #0x364d, lsl #16
+               	movk	x1, #0x64d9, lsl #32
+               	movk	x1, #0x3fd3, lsl #48
+<L26>:
+               	bl	 <L26>
+               	fmov	x1, d10
+<L27>:
+               	bl	 <L27>
+               	mov	x1, #0x4baf             ; =19375
+               	movk	x1, #0x373e, lsl #16
+               	movk	x1, #0x35d5, lsl #32
+               	movk	x1, #0x3fdb, lsl #48
+<L28>:
+               	bl	 <L28>
+               	fmov	x1, d11
+<L29>:
+               	bl	 <L29>
                	ucvtf	s0, x19
                	fmov	s31, #1.00000000
                	fadd	s1, s31, s0
@@ -230,320 +283,461 @@ Disassembly of section __TEXT,__text:
                	fdiv	s10, s9, s30
                	fmul	s0, s10, s10
                	fadd	s11, s0, s8
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L27>:
-               	bl	 <L27>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
-<L28>:
-               	bl	 <L28>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L29>:
-               	bl	 <L29>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	w16, #0xaaab            ; =43691
+               	movk	w16, #0x3eaa, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L31>:
                	bl	 <L31>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	w16, #0xaab0            ; =43696
+               	movk	w16, #0x3eaa, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
 <L32>:
                	bl	 <L32>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x79b1             ; =31153
-               	movk	x1, #0x9e37, lsl #16
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L33>:
                	bl	 <L33>
-               	mov	x1, x0
-               	mov	x0, x1
+               	mov	w16, #0x26ce            ; =9934
+               	movk	w16, #0x3e9b, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	mov	w16, #0xaead            ; =44717
+               	movk	w16, #0x3ed9, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L37>:
+               	bl	 <L37>
+               	mov	x1, #0x79b1             ; =31153
+               	movk	x1, #0x9e37, lsl #16
+<L38>:
+               	bl	 <L38>
                	mov	x1, #0x14a2             ; =5282
                	movk	x1, #0x4491, lsl #16
                	movk	x1, #0x1, lsl #32
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x0
-               	mov	x0, x1
+<L39>:
+               	bl	 <L39>
                	mov	x1, #0x4775             ; =18293
                	movk	x1, #0x1715, lsl #16
                	movk	x1, #0x5, lsl #32
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x0
-               	mov	x0, x1
+<L40>:
+               	bl	 <L40>
                	mov	x1, #0x662a             ; =26154
                	movk	x1, #0x5255, lsl #16
                	movk	x1, #0xc, lsl #32
-<L36>:
-               	bl	 <L36>
-               	mov	x1, x0
-               	mov	x0, x1
+<L41>:
+               	bl	 <L41>
                	mov	x1, #0xda45             ; =55877
                	movk	x1, #0x7ae2, lsl #16
                	movk	x1, #0x1f, lsl #32
-<L37>:
-               	bl	 <L37>
-               	mov	x1, x0
-               	mov	x0, x1
+<L42>:
+               	bl	 <L42>
                	mov	x1, #0x28ca             ; =10442
                	movk	x1, #0x9544, lsl #16
                	movk	x1, #0x39, lsl #32
-<L38>:
-               	bl	 <L38>
-               	sub	x20, x29, #0x30
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	mov	x17, #0x1               ; =1
-               	add	x1, x17, x19
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	mov	x17, #0x3               ; =3
-               	add	x1, x17, x19
-               	add	x2, x20, #0x8
-               	str	x1, [x2]
-               	mov	x17, #0x7               ; =7
-               	add	x1, x17, x19
-               	add	x2, x20, #0x10
-               	str	x1, [x2]
-               	mov	x17, #0xf               ; =15
-               	add	x1, x17, x19
-               	add	x2, x20, #0x18
-               	str	x1, [x2]
-               	mov	x17, #0x1f              ; =31
-               	add	x1, x17, x19
-               	add	x2, x20, #0x20
-               	str	x1, [x2]
-               	mov	x17, #0x3f              ; =63
-               	add	x1, x17, x19
-               	add	x2, x20, #0x28
-               	str	x1, [x2]
-               	mov	x21, x0
-               	mov	x22, #0x0               ; =0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x6
-               	b.lo	 <L39>
-               	b	 <L41>
-<L39>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x16, #0x79b1            ; =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x0, x1, x16
-               	eor	x22, x22, x0
-               	mov	x0, x21
-               	mov	x1, x22
-<L40>:
-               	bl	 <L40>
-               	add	x23, x23, #0x1
-               	mov	x21, x0
-               	cmp	x23, #0x6
-               	b.lo	 <L39>
-<L41>:
-               	mov	x0, x21
-               	mov	x1, #0xb                ; =11
-<L42>:
-               	bl	 <L42>
-               	mov	x20, x0
-               	cmp	x27, x25
-               	b.lo	 <L44>
-               	mov	x0, x20
-               	mov	x1, #0x16               ; =22
 <L43>:
                	bl	 <L43>
-               	mov	x21, x0
-               	b	 <L46>
+               	sub	x1, x29, #0x30
+               	str	xzr, [x1]
+               	str	xzr, [x1, #0x8]
+               	str	xzr, [x1, #0x10]
+               	str	xzr, [x1, #0x18]
+               	str	xzr, [x1, #0x20]
+               	str	xzr, [x1, #0x28]
+               	mov	x17, #0x1               ; =1
+               	add	x2, x17, x19
+               	add	x3, x1, #0x0
+               	str	x2, [x3]
+               	mov	x17, #0x3               ; =3
+               	add	x2, x17, x19
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x17, #0x7               ; =7
+               	add	x2, x17, x19
+               	add	x3, x1, #0x10
+               	str	x2, [x3]
+               	mov	x17, #0xf               ; =15
+               	add	x2, x17, x19
+               	add	x3, x1, #0x18
+               	str	x2, [x3]
+               	mov	x17, #0x1f              ; =31
+               	add	x2, x17, x19
+               	add	x3, x1, #0x20
+               	str	x2, [x3]
+               	mov	x17, #0x3f              ; =63
+               	add	x2, x17, x19
+               	add	x3, x1, #0x28
+               	str	x2, [x3]
+               	mov	x2, #0x0                ; =0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x6
+               	b.lo	 <L44>
+               	b	 <L47>
 <L44>:
-               	mov	x0, x20
-               	mov	x1, #0xb                ; =11
+               	add	x4, x1, x3, lsl #3
+               	ldr	x5, [x4]
+               	mov	x16, #0x79b1            ; =31153
+               	movk	x16, #0x9e37, lsl #16
+               	mul	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x4, x0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L45>
+               	b	 <L46>
 <L45>:
-               	bl	 <L45>
-               	mov	x21, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L45>
 <L46>:
-               	mov	x0, x21
-               	mov	x1, #0x21               ; =33
+               	add	x3, x3, #0x1
+               	mov	x0, x4
+               	mov	x2, x5
+               	cmp	x3, #0x6
+               	b.lo	 <L44>
 <L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-               	mov	x17, #0xffff            ; =65535
-               	cmp	x17, x24
-               	b.lo	 <L49>
-               	mov	x0, x20
-               	mov	x1, #0x2c               ; =44
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
+               	b	 <L49>
 <L48>:
-               	bl	 <L48>
-               	mov	x21, x0
-               	b	 <L51>
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xb               ; =11
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
 <L49>:
-               	mov	x0, x20
-               	mov	x1, #0x21               ; =33
+               	cmp	x24, x22
+               	b.lo	 <L52>
+               	mov	x1, x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L50>
+               	b	 <L51>
 <L50>:
-               	bl	 <L50>
-               	mov	x21, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x16              ; =22
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L50>
 <L51>:
+               	b	 <L55>
+<L52>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L53>
+               	b	 <L54>
+<L53>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	mov	x17, #0xb               ; =11
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L53>
+<L54>:
+               	mov	x1, x0
+<L55>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x21              ; =33
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L56>
+<L57>:
+               	mov	x17, #0xffff            ; =65535
+               	cmp	x17, x21
+               	b.lo	 <L60>
+               	mov	x0, x1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L58>
+               	b	 <L59>
+<L58>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x2c              ; =44
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L58>
+<L59>:
+               	b	 <L63>
+<L60>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x21              ; =33
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L61>
+<L62>:
+               	mov	x0, x1
+<L63>:
                	mov	w20, w19
                	mov	w17, #0x1               ; =1
                	add	w19, w17, w20
-               	lsr	x0, x27, #29
-               	eor	x1, x27, x0
-               	mov	x16, #0x1b3             ; =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x2, x1, x16
-               	mov	x0, x21
-               	mov	x1, x2
-<L52>:
-               	bl	 <L52>
-               	uxtb	w17, w20
-               	cmp	w17, #0x0
-               	b.eq	 <L55>
-               	uxtb	w17, w20
-               	cmp	w17, #0x1
-               	b.eq	 <L53>
-               	mov	x1, #0x0                ; =0
-               	b	 <L54>
-<L53>:
-               	lsl	x2, x27, #17
-               	lsr	x3, x27, #47
-               	orr	x4, x2, x3
-               	mov	x16, #0x3039            ; =12345
-               	add	x1, x4, x16
-<L54>:
-               	b	 <L56>
-<L55>:
-               	lsr	x2, x27, #29
-               	eor	x3, x27, x2
-               	mov	x16, #0x1b3             ; =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x1, x3, x16
-<L56>:
-               	bl	 <L56>
-               	lsl	x1, x27, #17
-               	lsr	x2, x27, #47
-               	orr	x3, x1, x2
-               	mov	x16, #0x3039            ; =12345
-               	add	x1, x3, x16
-<L57>:
-               	bl	 <L57>
-               	uxtb	w17, w19
-               	cmp	w17, #0x0
-               	b.eq	 <L60>
-               	uxtb	w17, w19
-               	cmp	w17, #0x1
-               	b.eq	 <L58>
-               	mov	x1, #0x0                ; =0
-               	b	 <L59>
-<L58>:
-               	lsl	x2, x27, #17
-               	lsr	x3, x27, #47
-               	orr	x4, x2, x3
-               	mov	x16, #0x3039            ; =12345
-               	add	x1, x4, x16
-<L59>:
-               	b	 <L61>
-<L60>:
-               	lsr	x2, x27, #29
-               	eor	x3, x27, x2
-               	mov	x16, #0x1b3             ; =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x1, x3, x16
-<L61>:
-               	bl	 <L61>
                	lsr	x1, x24, #29
                	eor	x2, x24, x1
                	mov	x16, #0x1b3             ; =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x2, x16
-<L62>:
-               	bl	 <L62>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L64>
+               	b	 <L65>
+<L64>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L64>
+<L65>:
                	uxtb	w17, w20
                	cmp	w17, #0x0
-               	b.eq	 <L65>
+               	b.eq	 <L68>
                	uxtb	w17, w20
                	cmp	w17, #0x1
-               	b.eq	 <L63>
+               	b.eq	 <L66>
                	mov	x1, #0x0                ; =0
-               	b	 <L64>
-<L63>:
+               	b	 <L67>
+<L66>:
                	lsl	x2, x24, #17
                	lsr	x3, x24, #47
                	orr	x4, x2, x3
                	mov	x16, #0x3039            ; =12345
                	add	x1, x4, x16
-<L64>:
-               	b	 <L66>
-<L65>:
+<L67>:
+               	b	 <L69>
+<L68>:
                	lsr	x2, x24, #29
                	eor	x3, x24, x2
                	mov	x16, #0x1b3             ; =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x3, x16
-<L66>:
-               	bl	 <L66>
+<L69>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L70>
+               	b	 <L71>
+<L70>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L70>
+<L71>:
                	lsl	x1, x24, #17
                	lsr	x2, x24, #47
                	orr	x3, x1, x2
                	mov	x16, #0x3039            ; =12345
                	add	x1, x3, x16
-<L67>:
-               	bl	 <L67>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L72>
+<L73>:
                	uxtb	w17, w19
                	cmp	w17, #0x0
-               	b.eq	 <L70>
+               	b.eq	 <L76>
                	uxtb	w17, w19
                	cmp	w17, #0x1
-               	b.eq	 <L68>
+               	b.eq	 <L74>
                	mov	x1, #0x0                ; =0
-               	b	 <L69>
-<L68>:
+               	b	 <L75>
+<L74>:
                	lsl	x2, x24, #17
                	lsr	x3, x24, #47
                	orr	x4, x2, x3
                	mov	x16, #0x3039            ; =12345
                	add	x1, x4, x16
-<L69>:
-               	b	 <L71>
-<L70>:
+<L75>:
+               	b	 <L77>
+<L76>:
                	lsr	x2, x24, #29
                	eor	x3, x24, x2
                	mov	x16, #0x1b3             ; =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x3, x16
-<L71>:
-               	bl	 <L71>
-               	ldp	d8, d9, [x29, #-0x88]
-               	ldp	d10, d11, [x29, #-0x98]
+<L77>:
+               	bl	 <L77>
+               	lsr	x1, x21, #29
+               	eor	x2, x21, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x2, x16
+<L78>:
+               	bl	 <L78>
+               	uxtb	w17, w20
+               	cmp	w17, #0x0
+               	b.eq	 <L81>
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	b.eq	 <L79>
+               	mov	x1, #0x0                ; =0
+               	b	 <L80>
+<L79>:
+               	lsl	x2, x21, #17
+               	lsr	x3, x21, #47
+               	orr	x4, x2, x3
+               	mov	x16, #0x3039            ; =12345
+               	add	x1, x4, x16
+<L80>:
+               	b	 <L82>
+<L81>:
+               	lsr	x2, x21, #29
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+<L82>:
+               	bl	 <L82>
+               	lsl	x1, x21, #17
+               	lsr	x2, x21, #47
+               	orr	x3, x1, x2
+               	mov	x16, #0x3039            ; =12345
+               	add	x1, x3, x16
+<L83>:
+               	bl	 <L83>
+               	uxtb	w17, w19
+               	cmp	w17, #0x0
+               	b.eq	 <L86>
+               	uxtb	w17, w19
+               	cmp	w17, #0x1
+               	b.eq	 <L84>
+               	mov	x1, #0x0                ; =0
+               	b	 <L85>
+<L84>:
+               	lsl	x2, x21, #17
+               	lsr	x3, x21, #47
+               	orr	x4, x2, x3
+               	mov	x16, #0x3039            ; =12345
+               	add	x1, x4, x16
+<L85>:
+               	b	 <L87>
+<L86>:
+               	lsr	x2, x21, #29
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+<L87>:
+               	bl	 <L87>
+               	ldp	d8, d9, [x29, #-0x70]
+               	ldp	d10, d11, [x29, #-0x80]
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
                	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
-               	ldur	x27, [x29, #-0x78]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/convert/bitcast.dis
+++ b/test/golden/aarch64-darwin/convert/bitcast.dis
@@ -3,88 +3,220 @@ convert/bitcast.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.bitcast.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	d8, [x29, #-0x18]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0xfdb             ; =4059
                	movk	w16, #0xc049, lsl #16
-               	eor	w3, w2, w16
-               	fmov	s8, w3
-               	fmov	w20, s8
-               	mov	x0, x1
-               	mov	w1, w3
+               	eor	w2, w1, w16
+               	fmov	s0, w2
+               	fmov	w1, s0
+               	mov	w3, w2
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w3, s0
+               	mov	w4, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+               	mov	w3, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0x2d18            ; =11544
                	movk	x16, #0x5444, lsl #16
                	movk	x16, #0x21fb, lsl #32
                	movk	x16, #0x4009, lsl #48
-               	eor	x2, x19, x16
-               	fmov	d8, x2
-               	fmov	x19, d8
-               	mov	x0, x1
-               	mov	x1, x2
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	eor	x1, x0, x16
+               	fmov	d0, x1
+               	fmov	x0, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fmov	x1, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xfdb             ; =4059
                	movk	w16, #0x4049, lsl #16
-               	mov	w2, w16
-               	fmov	s8, w2
-               	mov	x0, x1
-               	mov	w1, w2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x2, #0x5769             ; =22377
-               	movk	x2, #0x8b14, lsl #16
-               	movk	x2, #0xbf0a, lsl #32
-               	movk	x2, #0x4005, lsl #48
-               	fmov	d8, x2
-               	mov	x0, x1
-               	mov	x1, x2
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L10>:
-               	bl	 <L10>
-               	ldur	d8, [x29, #-0x18]
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w0, w16
+               	fmov	s0, w0
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, #0x5769             ; =22377
+               	movk	x0, #0x8b14, lsl #16
+               	movk	x0, #0xbf0a, lsl #32
+               	movk	x0, #0x4005, lsl #48
+               	fmov	d0, x0
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fmov	x0, d0
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/convert/ext_sign.dis
+++ b/test/golden/aarch64-darwin/convert/ext_sign.dis
@@ -3,118 +3,301 @@ convert/ext_sign.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.ext_sign.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0x80              ; =128
-               	orr	w20, w2, w16
-               	mvn	w21, w20
-               	mov	w2, w19
+               	orr	w2, w1, w16
+               	mvn	w1, w2
+               	mov	w3, w0
                	mov	w16, #0x8000            ; =32768
-               	orr	w22, w2, w16
-               	mvn	w23, w22
-               	mov	w2, w19
+               	orr	w4, w3, w16
+               	mvn	w3, w4
+               	mov	w5, w0
                	mov	w16, #-0x80000000       ; =-2147483648
-               	orr	w19, w2, w16
-               	mvn	w24, w19
-               	sxtb	w2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	orr	w0, w5, w16
+               	mvn	w5, w0
+               	sxtb	w6, w2
+               	sxth	x7, w6
+               	mov	x6, #0x2325             ; =8997
+               	movk	x6, #0x8422, lsl #16
+               	movk	x6, #0x9ce4, lsl #32
+               	movk	x6, #0xcbf2, lsl #48
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	sxtb	w2, w21
-               	mov	x0, x1
-               	mov	x1, x2
+               	sxtb	w7, w1
+               	sxth	x8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	sxtb	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	sxtb	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtb	w7, w2
+               	sxtw	x8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	sxtb	x25, w20
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	sxtb	x20, w21
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	w7, w1
+               	sxtw	x8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	sxth	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	sxth	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtb	x7, w2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sxth	x21, w22
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	sxth	x22, w23
-               	mov	x0, x1
-               	mov	x1, x22
+               	sxtb	x7, w1
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	sxtw	x23, w19
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	sxtw	x19, w24
-               	mov	x0, x1
-               	mov	x1, x19
+               	sxth	w7, w4
+               	sxtw	x8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	add	x2, x25, x21
-               	add	x3, x2, x23
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	add	x2, x20, x22
-               	add	x3, x2, x19
-               	mov	x0, x1
-               	mov	x1, x3
+               	sxth	w7, w3
+               	sxtw	x8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	sxth	x7, w4
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxth	x7, w3
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	sxtw	x7, w0
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxtw	x7, w5
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sxtb	x7, w2
+               	sxth	x2, w4
+               	add	x4, x7, x2
+               	sxtw	x2, w0
+               	add	x0, x4, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x7, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x7, x16
+               	eor	x7, x6, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sxtb	x0, w1
+               	sxth	x1, w3
+               	add	x2, x0, x1
+               	sxtw	x0, w5
+               	add	x1, x2, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x6, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x6
                	ret

--- a/test/golden/aarch64-darwin/convert/ext_zero.dis
+++ b/test/golden/aarch64-darwin/convert/ext_zero.dis
@@ -3,122 +3,305 @@ convert/ext_zero.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.ext_zero.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0x80              ; =128
-               	orr	w20, w2, w16
+               	orr	w2, w1, w16
                	mov	w17, #0xff              ; =255
-               	sub	w21, w17, w20
-               	mov	w2, w19
+               	sub	w1, w17, w2
+               	mov	w3, w0
                	mov	w16, #0x8000            ; =32768
-               	orr	w22, w2, w16
+               	orr	w4, w3, w16
                	mov	w17, #0xffff            ; =65535
-               	sub	w23, w17, w22
-               	mov	w2, w19
+               	sub	w3, w17, w4
+               	mov	w5, w0
                	mov	w16, #-0x80000000       ; =-2147483648
-               	orr	w19, w2, w16
+               	orr	w0, w5, w16
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w24, w17, w19
-               	uxtb	w2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	sub	w5, w17, w0
+               	uxtb	w6, w2
+               	uxth	w7, w6
+               	mov	x6, #0x2325             ; =8997
+               	movk	x6, #0x8422, lsl #16
+               	movk	x6, #0x9ce4, lsl #32
+               	movk	x6, #0xcbf2, lsl #48
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	uxtb	w2, w21
-               	mov	x0, x1
-               	mov	x1, x2
+               	uxtb	w7, w1
+               	uxth	w8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	uxtb	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	uxtb	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	uxtb	w7, w2
+               	mov	w8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	uxtb	w25, w20
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	uxtb	w20, w21
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w7, w1
+               	mov	w8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	uxth	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	uxth	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	uxtb	w7, w2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	uxth	w21, w22
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	uxth	w22, w23
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w7, w1
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	w23, w19
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	w19, w24
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxth	w7, w4
+               	mov	w8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	add	x2, x25, x21
-               	add	x3, x2, x23
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	add	x2, x20, x22
-               	add	x3, x2, x19
-               	mov	x0, x1
-               	mov	x1, x3
+               	uxth	w7, w3
+               	mov	w8, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	uxth	w7, w4
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	uxth	w7, w3
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w7, w0
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	w7, w5
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	uxtb	w7, w2
+               	uxth	w2, w4
+               	add	x4, x7, x2
+               	mov	w2, w0
+               	add	x0, x4, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x7, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x7, x16
+               	eor	x7, x6, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	uxtb	w0, w1
+               	uxth	w1, w3
+               	add	x2, x0, x1
+               	mov	w0, w5
+               	add	x1, x2, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x6, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x6
                	ret

--- a/test/golden/aarch64-darwin/convert/f2f.dis
+++ b/test/golden/aarch64-darwin/convert/f2f.dis
@@ -4,84 +4,223 @@ Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.f2f.checksum>:
 <L0>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	stp	d10, d11, [x29, #-0x28]
-               	mov	x19, x0
+               	ucvtf	d0, x0
+               	ucvtf	s1, x0
+               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
+               	ldr	d31, [x16]
+               	fadd	d2, d31, d0
+               	fcvt	s3, d2
+               	fcvt	d4, s3
+               	fmov	x0, d2
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ucvtf	d8, x19
-               	ucvtf	s9, x19
-               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
-               	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s10, d0
-               	fcvt	d11, s10
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	fmov	w0, s3
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
-               	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s10, d0
-               	fcvt	d11, s10
-               	mov	x0, x1
+               	fmov	x0, d4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s8, d0
-               	mov	x0, x1
+               	fadd	d2, d31, d0
+               	fcvt	s3, d2
+               	fcvt	d4, s3
+               	fmov	x0, d2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w0, s3
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	fmov	x0, d4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
+               	ldr	d31, [x16]
+               	fadd	d2, d31, d0
+               	fcvt	s0, d2
+               	fmov	x0, d2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+<L16>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s9
-               	fcvt	d8, s0
+               	fadd	s0, s31, s1
+               	fcvt	d1, s0
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	fmov	x0, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+<L20>:
                	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L11>:
-               	bl	 <L11>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldp	d10, d11, [x29, #-0x28]
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/convert/f2i.dis
+++ b/test/golden/aarch64-darwin/convert/f2i.dis
@@ -3,111 +3,322 @@ convert/f2i.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.f2i.fold_pos>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	d8, d9, [x29, #-0x10]
-               	mov	x1, x0
-               	fmov	s8, s0
-               	fmov	d9, d1
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	w1, s0
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, s0
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	fcvtzu	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	fcvtzs	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	w1, s0
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, s0
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	fcvtzu	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	w1, s0
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	x1, s0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	fcvtzs	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldp	d8, d9, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	fcvtzu	w1, d1
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fcvtzu	w1, d1
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fcvtzu	w1, d1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fcvtzu	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	fcvtzs	w1, d1
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	fcvtzs	w1, d1
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcvtzs	w1, d1
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	fcvtzs	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.convert.f2i.fold_neg>:
@@ -115,54 +326,42 @@ Disassembly of section __TEXT,__text:
                	mov	x29, sp
                	sub	sp, sp, #0x10
                	stp	d8, d9, [x29, #-0x10]
-               	mov	x1, x0
                	fmov	s8, s0
                	fmov	d9, d1
-               	fcvtzs	w2, s8
-               	mov	x0, x1
+               	fcvtzs	w1, s8
+               	sxtb	x2, w1
                	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
+               	fcvtzs	w1, s8
+               	sxth	x2, w1
                	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, s8
+               	sxtw	x2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	fcvtzs	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	x1, s8
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
+               	fcvtzs	w1, d9
+               	sxtb	x2, w1
                	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
+               	fcvtzs	w1, d9
+               	sxth	x2, w1
                	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, d9
+               	sxtw	x2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	fcvtzs	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	x1, d9
 <L7>:
                	bl	 <L7>
                	ldp	d8, d9, [x29, #-0x10]
@@ -173,69 +372,337 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2i.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	stp	d10, d11, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
+               	sub	sp, sp, #0x20
+               	stp	d8, d9, [x29, #-0x10]
+               	stp	d10, d11, [x29, #-0x20]
+               	ucvtf	s8, x0
+               	ucvtf	d9, x0
                	mov	w16, #0x42230000        ; =1109590016
                	fmov	s31, w16
-               	fadd	s10, s31, s8
+               	fadd	s0, s31, s8
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
-               	fadd	d11, d31, d9
-               	fcvtzu	w1, s10
+               	fadd	d1, d31, d9
+               	fcvtzu	w0, s0
+               	uxtb	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	fcvtzu	w1, s10
+               	fcvtzu	w1, s0
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	fcvtzu	w1, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	fcvtzu	x1, s10
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fcvtzs	w1, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	fcvtzs	w1, s10
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	fcvtzs	w1, s10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	fcvtzs	x1, s10
+               	fcvtzs	w1, s0
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	fcvtzu	w1, d11
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	fcvtzu	w1, d11
+               	fcvtzs	w1, s0
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	fcvtzu	w1, d11
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	fcvtzu	x1, d11
+               	fcvtzs	w1, s0
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	fcvtzs	w1, d11
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	fcvtzs	w1, d11
+               	fcvtzs	x1, s0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	fcvtzs	w1, d11
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	fcvtzs	x1, d11
+               	fcvtzu	w1, d1
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fcvtzu	w1, d1
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fcvtzu	w1, d1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fcvtzu	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	fcvtzs	w1, d1
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	fcvtzs	w1, d1
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcvtzs	w1, d1
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	fcvtzs	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	w16, #0x42230000        ; =1109590016
                	fmov	s31, w16
                	fneg	s0, s31
@@ -244,59 +711,80 @@ Disassembly of section __TEXT,__text:
                	ldr	d31, [x16]
                	fsub	d11, d31, d9
                	fcvtzs	w1, s10
-<L17>:
-               	bl	 <L17>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
                	fcvtzs	w1, s10
-<L18>:
-               	bl	 <L18>
+               	sxth	x2, w1
+               	mov	x1, x2
+<L33>:
+               	bl	 <L33>
                	fcvtzs	w1, s10
-<L19>:
-               	bl	 <L19>
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
                	fcvtzs	x1, s10
-<L20>:
-               	bl	 <L20>
+<L35>:
+               	bl	 <L35>
                	fcvtzs	w1, d11
-<L21>:
-               	bl	 <L21>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
                	fcvtzs	w1, d11
-<L22>:
-               	bl	 <L22>
+               	sxth	x2, w1
+               	mov	x1, x2
+<L37>:
+               	bl	 <L37>
                	fcvtzs	w1, d11
-<L23>:
-               	bl	 <L23>
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L38>:
+               	bl	 <L38>
                	fcvtzs	x1, d11
-<L24>:
-               	bl	 <L24>
+<L39>:
+               	bl	 <L39>
                	mov	w16, #0x42fe0000        ; =1123942400
                	fmov	s31, w16
                	fadd	s0, s31, s8
                	fcvtzs	w1, s0
-<L25>:
-               	bl	 <L25>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
                	mov	w16, #0x437f0000        ; =1132396544
                	fmov	s31, w16
                	fadd	s0, s31, s8
                	fcvtzu	w1, s0
-<L26>:
-               	bl	 <L26>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L41>:
+               	bl	 <L41>
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
                	fadd	d8, d31, d9
                	fcvtzu	w1, d8
-<L27>:
-               	bl	 <L27>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L42>:
+               	bl	 <L42>
                	fcvtzs	w1, d8
-<L28>:
-               	bl	 <L28>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L43>:
+               	bl	 <L43>
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
                	fsub	d0, d31, d9
                	fcvtzs	w1, d0
-<L29>:
-               	bl	 <L29>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldp	d10, d11, [x29, #-0x28]
-               	ldur	x19, [x29, #-0x8]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L44>:
+               	bl	 <L44>
+               	ldp	d8, d9, [x29, #-0x10]
+               	ldp	d10, d11, [x29, #-0x20]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/convert/f2u_high.dis
+++ b/test/golden/aarch64-darwin/convert/f2u_high.dis
@@ -3,186 +3,550 @@ convert/f2u_high.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.f2u_high.f32_u32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	w2, s0
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	w2, d0
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, d0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f32_u64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	x2, s0
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	x2, d0
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
+               	ucvtf	s0, x0
+               	ucvtf	d1, x0
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
+               	fadd	s2, s31, s0
+               	fcvtzu	w0, s2
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
                	mov	w16, #0x4f000000        ; =1325400064
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L3>:
-               	bl	 <L3>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0x4f400000        ; =1329594368
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L4>:
-               	bl	 <L4>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L5>:
-               	bl	 <L5>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L6>:
-               	bl	 <L6>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x16, #0x41e0000000000000 ; =4746794007248502784
                	fmov	d31, x16
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L7>:
-               	bl	 <L7>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L8>:
-               	bl	 <L8>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L9>:
-               	bl	 <L9>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L10>:
-               	bl	 <L10>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w16, #0x5e800000        ; =1585446912
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L11>:
-               	bl	 <L11>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
                	mov	w16, #0x5f000000        ; =1593835520
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L12>:
-               	bl	 <L12>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L13>:
-               	bl	 <L13>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	w16, #0x5f400000        ; =1598029824
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L14>:
-               	bl	 <L14>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L15>:
-               	bl	 <L15>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L16>:
-               	bl	 <L16>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	x16, #0x43e0000000000000 ; =4890909195324358656
                	fmov	d31, x16
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L17>:
-               	bl	 <L17>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L32>
+<L33>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L18>:
-               	bl	 <L18>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L34>
+<L35>:
                	mov	x16, #0x43e8000000000000 ; =4893160995138043904
                	fmov	d31, x16
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L19>:
-               	bl	 <L19>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L20>:
-               	bl	 <L20>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+<L39>:
                	ret

--- a/test/golden/aarch64-darwin/convert/i2f.dis
+++ b/test/golden/aarch64-darwin/convert/i2f.dis
@@ -5,211 +5,727 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.i2f.fold_from>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	mov	x8, x0
-               	mov	x19, x1
-               	mov	x20, x2
-               	mov	w21, w3
-               	mov	x22, x4
-               	mov	x23, x5
-               	mov	x24, x6
-               	mov	w25, w7
-               	ldr	x26, [x29, #0x10]
-               	uxtb	w16, w19
+               	ldr	x8, [x29, #0x10]
+               	uxtb	w16, w1
                	ucvtf	s0, w16
-               	mov	x0, x8
+               	fmov	w12, s0
+               	mov	w13, w12
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	uxtb	w16, w19
-               	ucvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x14, x12, x16
+               	lsr	x15, x13, x14
+               	mov	x16, #0xff              ; =255
+               	and	x14, x15, x16
+               	eor	x15, x0, x14
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x15, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	uxth	w16, w20
-               	ucvtf	s0, w16
-               	mov	x0, x1
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	uxth	w16, w20
+               	uxtb	w16, w1
                	ucvtf	d0, w16
-               	mov	x0, x1
+               	fmov	x1, d0
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x1, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ucvtf	s0, w21
-               	mov	x0, x1
+               	uxth	w16, w2
+               	ucvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w12, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ucvtf	d0, w21
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x1, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ucvtf	s0, x22
-               	mov	x0, x1
+               	uxth	w16, w2
+               	ucvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ucvtf	d0, x22
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x2, x16
+               	lsr	x13, x1, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x0, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	sxtb	w16, w23
-               	scvtf	s0, w16
-               	mov	x0, x1
+               	ucvtf	s0, w3
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sxtb	w16, w23
-               	scvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x1, x16
+               	lsr	x13, x2, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x0, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	sxth	w16, w24
-               	scvtf	s0, w16
-               	mov	x0, x1
+               	ucvtf	d0, w3
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	sxth	w16, w24
-               	scvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x12, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x12, x16
+               	eor	x12, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x12, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	scvtf	s0, w25
-               	mov	x0, x1
+               	ucvtf	s0, x4
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	scvtf	d0, w25
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x12, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x12, x16
+               	eor	x12, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x12, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	scvtf	s0, x26
-               	mov	x0, x1
+               	ucvtf	d0, x4
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	scvtf	d0, x26
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	mov	sp, x29
+               	sxtb	w16, w5
+               	scvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxtb	w16, w5
+               	scvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	sxth	w16, w6
+               	scvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	w16, w6
+               	scvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	scvtf	s0, w7
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	scvtf	d0, w7
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	scvtf	s0, x8
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	scvtf	d0, x8
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.convert.i2f.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
+               	mov	w1, w0
                	mov	w16, #0x80              ; =128
-               	orr	w20, w1, w16
-               	mov	w1, w19
+               	orr	w2, w1, w16
+               	mov	w1, w0
                	mov	w16, #0x8000            ; =32768
-               	orr	w21, w1, w16
-               	mov	w1, w19
+               	orr	w3, w1, w16
+               	mov	w1, w0
                	mov	w16, #-0x80000000       ; =-2147483648
-               	orr	w22, w1, w16
+               	orr	w4, w1, w16
                	mov	x16, #-0x8000000000000000 ; =-9223372036854775808
-               	orr	x23, x19, x16
-               	uxtb	w16, w20
+               	orr	x1, x0, x16
+               	uxtb	w16, w2
                	ucvtf	s0, w16
+               	fmov	w5, s0
+               	mov	w6, w5
+               	mov	x5, #0x2325             ; =8997
+               	movk	x5, #0x8422, lsl #16
+               	movk	x5, #0x9ce4, lsl #32
+               	movk	x5, #0xcbf2, lsl #48
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	uxtb	w16, w20
+               	uxtb	w16, w2
                	ucvtf	d0, w16
+               	fmov	x6, d0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	uxth	w16, w21
-               	ucvtf	s0, w16
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	uxth	w16, w21
-               	ucvtf	d0, w16
+               	uxth	w16, w3
+               	ucvtf	s0, w16
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ucvtf	s0, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ucvtf	d0, w22
+               	uxth	w16, w3
+               	ucvtf	d0, w16
+               	fmov	x6, d0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ucvtf	s0, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ucvtf	d0, x23
+               	ucvtf	s0, w4
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	sxtb	w16, w20
-               	scvtf	s0, w16
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	sxtb	w16, w20
-               	scvtf	d0, w16
+               	ucvtf	d0, w4
+               	fmov	x6, d0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	sxth	w16, w21
-               	scvtf	s0, w16
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	sxth	w16, w21
-               	scvtf	d0, w16
+               	ucvtf	s0, x1
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	scvtf	s0, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	scvtf	d0, w22
+               	ucvtf	d0, x1
+               	fmov	x6, d0
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	scvtf	s0, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	scvtf	d0, x23
+               	sxtb	w16, w2
+               	scvtf	s0, w16
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x16, #0x1               ; =1
-               	orr	x20, x19, x16
-               	mov	x17, #0x0               ; =0
-               	sub	x19, x17, x20
-               	ucvtf	s0, x20
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ucvtf	d0, x20
+               	sxtb	w16, w2
+               	scvtf	d0, w16
+               	fmov	x2, d0
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	scvtf	s0, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x2, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	scvtf	d0, x19
+               	sxth	w16, w3
+               	scvtf	s0, w16
+               	fmov	w2, s0
+               	mov	w6, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x2, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	w16, w3
+               	scvtf	d0, w16
+               	fmov	x2, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x3, x16
+               	lsr	x7, x2, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x5, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	scvtf	s0, w4
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x5, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	scvtf	d0, w4
+               	fmov	x2, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x6, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x6, x16
+               	eor	x6, x5, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	scvtf	s0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x6, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x6, x16
+               	eor	x6, x5, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	scvtf	d0, x1
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x5, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	x16, #0x1               ; =1
+               	orr	x19, x0, x16
+               	mov	x17, #0x0               ; =0
+               	sub	x20, x17, x19
+               	ucvtf	s0, x19
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, x5
+<L32>:
+               	bl	 <L32>
+               	ucvtf	d0, x19
+               	fmov	x1, d0
+<L33>:
+               	bl	 <L33>
+               	scvtf	s0, x20
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	scvtf	d0, x20
+               	fmov	x1, d0
+<L35>:
+               	bl	 <L35>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/convert/trunc.dis
+++ b/test/golden/aarch64-darwin/convert/trunc.dis
@@ -3,86 +3,187 @@ convert/trunc.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.convert.trunc.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x16, #0xdef0            ; =57072
                	movk	x16, #0x9abc, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	eor	x2, x19, x16
+               	eor	x1, x0, x16
                	mov	x16, #0x1               ; =1
-               	orr	x3, x2, x16
-               	mov	w19, w3
-               	mov	w20, w3
-               	mov	w21, w3
-               	mov	x0, x1
-               	mov	w1, w19
+               	orr	x0, x1, x16
+               	mov	w1, w0
+               	mov	w2, w0
+               	mov	w3, w0
+               	mov	w0, w1
+               	mov	x4, #0x2325             ; =8997
+               	movk	x4, #0x8422, lsl #16
+               	movk	x4, #0x9ce4, lsl #32
+               	movk	x4, #0xcbf2, lsl #48
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxth	w0, w2
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+               	uxtb	w0, w3
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0x5555            ; =21845
                	movk	w16, #0x5555, lsl #16
-               	eor	w2, w19, w16
-               	mov	w22, w2
-               	mov	w23, w2
-               	mov	x0, x1
-               	mov	x1, x22
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	w16, #0x5555            ; =21845
-               	eor	w2, w20, w16
-               	mov	w24, w2
-               	mov	x0, x1
-               	mov	x1, x24
+               	eor	w0, w1, w16
+               	mov	w5, w0
+               	mov	w6, w0
+               	uxth	w0, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	w2, w19
-               	uxth	w3, w20
-               	add	x4, x2, x3
-               	uxtb	w2, w21
-               	add	x3, x4, x2
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x4, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	uxth	w2, w22
-               	uxtb	w3, w23
-               	add	x4, x2, x3
-               	uxtb	w2, w24
-               	add	x3, x4, x2
-               	mov	x0, x1
-               	mov	x1, x3
+               	uxtb	w0, w6
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x4, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	w16, #0x5555            ; =21845
+               	eor	w0, w2, w16
+               	mov	w7, w0
+               	uxtb	w0, w7
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x4, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w0, w1
+               	uxth	w1, w2
+               	add	x2, x0, x1
+               	uxtb	w0, w3
+               	add	x1, x2, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	uxth	w0, w5
+               	uxtb	w1, w6
+               	add	x2, x0, x1
+               	uxtb	w0, w7
+               	add	x1, x2, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x4
                	ret

--- a/test/golden/aarch64-darwin/float/arith_f32.dis
+++ b/test/golden/aarch64-darwin/float/arith_f32.dis
@@ -8,30 +8,54 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.float.arith_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.arith_f32.checksum>:
@@ -39,1142 +63,915 @@ Disassembly of section __TEXT,__text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	d8, d9, [x29, #-0x30]
-               	stp	d10, d11, [x29, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	w21, w19
+               	stur	x21, [x29, #-0x18]
+               	stp	d8, d9, [x29, #-0x28]
+               	stp	d10, d11, [x29, #-0x38]
+               	mov	w19, w0
                	mov	w17, #0x3f800000        ; =1065353216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s8, w0
                	fmov	s31, #1.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #0.25000000
                	fmul	s10, s31, s8
                	fadd	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	fsub	s0, s9, s10
 <L1>:
                	bl	 <L1>
-               	mov	x19, x0
-               	b	 <L4>
+               	fsub	s0, s10, s9
 <L2>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L2>
+               	fmul	s0, s9, s10
 <L3>:
                	bl	 <L3>
-               	mov	x19, x0
+               	fdiv	s0, s9, s10
 <L4>:
-               	fsub	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x19
+               	bl	 <L4>
+               	fdiv	s0, s10, s9
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
-<L6>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L7>:
-               	bl	 <L7>
-               	mov	x20, x0
-<L8>:
-               	fsub	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
-<L9>:
-               	bl	 <L9>
-               	mov	x19, x0
-               	b	 <L12>
-<L10>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L11>:
-               	bl	 <L11>
-               	mov	x19, x0
-<L12>:
-               	fmul	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x19
-<L13>:
-               	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
-<L14>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L15>:
-               	bl	 <L15>
-               	mov	x20, x0
-<L16>:
-               	fdiv	s0, s9, s10
-               	mov	x0, x20
-<L17>:
-               	bl	 <L17>
-               	fdiv	s0, s10, s9
-<L18>:
-               	bl	 <L18>
                	fneg	s0, s9
-<L19>:
-               	bl	 <L19>
+<L6>:
+               	bl	 <L6>
                	fmov	s31, wzr
                	fsub	s10, s31, s9
                	fmov	s0, s10
-<L20>:
-               	bl	 <L20>
+<L7>:
+               	bl	 <L7>
                	fsub	s0, s9, s9
-<L21>:
-               	bl	 <L21>
+<L8>:
+               	bl	 <L8>
                	fadd	s0, s10, s9
-<L22>:
-               	bl	 <L22>
+<L9>:
+               	bl	 <L9>
                	fmov	s31, #3.00000000
                	fmul	s9, s31, s8
                	fdiv	s10, s8, s9
                	fmov	s0, s10
-<L23>:
-               	bl	 <L23>
+<L10>:
+               	bl	 <L10>
                	fmul	s0, s10, s9
-<L24>:
-               	bl	 <L24>
+<L11>:
+               	bl	 <L11>
                	fsub	s0, s8, s10
                	fsub	s1, s0, s10
                	fsub	s0, s1, s10
-<L25>:
-               	bl	 <L25>
+<L12>:
+               	bl	 <L12>
                	mov	w16, #0x42440000        ; =1111752704
                	fmov	s30, w16
                	fdiv	s0, s8, s30
-<L26>:
-               	bl	 <L26>
+<L13>:
+               	bl	 <L13>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s30, [x16]
                	fdiv	s0, s8, s30
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s31, [x16]
                	fdiv	s0, s31, s9
-<L28>:
-               	bl	 <L28>
+<L15>:
+               	bl	 <L15>
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
                	fadd	s11, s9, s8
                	fmov	s0, s11
-<L29>:
-               	bl	 <L29>
+<L16>:
+               	bl	 <L16>
                	fadd	s0, s11, s8
-<L30>:
-               	bl	 <L30>
+<L17>:
+               	bl	 <L17>
                	fadd	s0, s8, s8
                	fadd	s1, s9, s0
                	fmov	s0, s1
-<L31>:
-               	bl	 <L31>
+<L18>:
+               	bl	 <L18>
                	fsub	s0, s9, s8
-<L32>:
-               	bl	 <L32>
+<L19>:
+               	bl	 <L19>
                	fsub	s0, s11, s9
-<L33>:
-               	bl	 <L33>
+<L20>:
+               	bl	 <L20>
                	fmov	s31, wzr
                	fmul	s0, s31, s8
-               	mov	x19, x0
+               	mov	x20, x0
                	fmov	d9, d0
-               	mov	w20, #0x0               ; =0
-               	cmp	w20, #0x18
-               	b.lo	 <L34>
-               	b	 <L39>
-<L34>:
+               	mov	w21, #0x0               ; =0
+               	cmp	w21, #0x18
+               	b.lo	 <L21>
+               	b	 <L23>
+<L21>:
                	fadd	s0, s9, s10
                	fmov	s30, #1.50000000
-               	fmul	s11, s0, s30
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L36>
-               	mov	x0, x19
-               	fmov	s0, s11
-<L35>:
-               	bl	 <L35>
-               	mov	x22, x0
-               	b	 <L38>
-<L36>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L37>:
-               	bl	 <L37>
-               	mov	x22, x0
-<L38>:
-               	add	w20, w20, #0x1
-               	mov	x19, x22
-               	fmov	d9, d11
-               	cmp	w20, #0x18
-               	b.lo	 <L34>
-<L39>:
+               	fmul	s9, s0, s30
+               	mov	x0, x20
+               	fmov	s0, s9
+<L22>:
+               	bl	 <L22>
+               	add	w21, w21, #0x1
+               	mov	x20, x0
+               	cmp	w21, #0x18
+               	b.lo	 <L21>
+<L23>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s9, w0
-               	fcmp	s9, s9
-               	cset	w0, ne
-               	cbnz	w0,  <L41>
-               	mov	x0, x19
+               	mov	x0, x20
                	fmov	s0, s9
-<L40>:
-               	bl	 <L40>
-               	mov	x20, x0
-               	b	 <L43>
-<L41>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L42>:
-               	bl	 <L42>
-               	mov	x20, x0
-<L43>:
+<L24>:
+               	bl	 <L24>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L45>
-               	mov	x0, x20
-<L44>:
-               	bl	 <L44>
-               	mov	x19, x0
-               	b	 <L47>
-<L45>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L46>:
-               	bl	 <L46>
-               	mov	x19, x0
-<L47>:
+<L25>:
+               	bl	 <L25>
                	fadd	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L49>
-               	mov	x0, x19
-<L48>:
-               	bl	 <L48>
-               	mov	x20, x0
-               	b	 <L51>
-<L49>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L50>:
-               	bl	 <L50>
-               	mov	x20, x0
-<L51>:
+<L26>:
+               	bl	 <L26>
                	fmov	s30, #2.00000000
                	fmul	s10, s9, s30
-               	mov	x0, x20
                	fmov	s0, s10
-<L52>:
-               	bl	 <L52>
+<L27>:
+               	bl	 <L27>
                	fmov	s31, wzr
                	fsub	s0, s31, s10
-<L53>:
-               	bl	 <L53>
+<L28>:
+               	bl	 <L28>
                	fmul	s0, s9, s9
-<L54>:
-               	bl	 <L54>
+<L29>:
+               	bl	 <L29>
                	fsub	s0, s9, s9
-<L55>:
-               	bl	 <L55>
+<L30>:
+               	bl	 <L30>
                	mov	w17, #0x800000          ; =8388608
-               	add	w1, w17, w21
+               	add	w1, w17, w19
                	fmov	s9, w1
                	mov	w17, #0x1               ; =1
-               	add	w1, w17, w21
+               	add	w1, w17, w19
                	fmov	s10, w1
                	fmov	s30, #0.50000000
                	fmul	s0, s9, s30
-<L56>:
-               	bl	 <L56>
+<L31>:
+               	bl	 <L31>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-<L57>:
-               	bl	 <L57>
+<L32>:
+               	bl	 <L32>
                	fsub	s0, s9, s10
-<L58>:
-               	bl	 <L58>
+<L33>:
+               	bl	 <L33>
                	fmul	s0, s9, s8
-<L59>:
-               	bl	 <L59>
+<L34>:
+               	bl	 <L34>
                	fadd	s0, s10, s10
-<L60>:
-               	bl	 <L60>
+<L35>:
+               	bl	 <L35>
                	fmov	s30, #0.50000000
                	fmul	s0, s10, s30
-<L61>:
-               	bl	 <L61>
+<L36>:
+               	bl	 <L36>
                	fmov	s30, #0.75000000
                	fmul	s0, s10, s30
-<L62>:
-               	bl	 <L62>
+<L37>:
+               	bl	 <L37>
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s30, w16
                	fmul	s0, s10, s30
-<L63>:
-               	bl	 <L63>
+<L38>:
+               	bl	 <L38>
                	fdiv	s0, s10, s9
-<L64>:
-               	bl	 <L64>
-               	mov	x19, x0
+<L39>:
+               	bl	 <L39>
                	fmov	s31, #5.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #3.00000000
                	fmul	s10, s31, s8
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L67>
+               	cset	w1, eq
+               	cbnz	w1,  <L42>
                	fmov	s30, #2.00000000
                	fmul	s0, s9, s30
                	fcmp	s9, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L65>
-               	b	 <L66>
-<L65>:
+               	cset	w2, eq
+               	cbnz	w2,  <L40>
+               	b	 <L41>
+<L40>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w1, ne
-<L66>:
-               	b	 <L68>
-<L67>:
-               	mov	x1, x0
-<L68>:
-               	cbnz	w1,  <L81>
+               	cset	w2, ne
+<L41>:
+               	b	 <L43>
+<L42>:
+               	mov	x2, x1
+<L43>:
+               	cbnz	w2,  <L56>
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L69>
+               	cset	w1, mi
+               	cbnz	w1,  <L44>
                	fmov	d0, d9
-               	b	 <L70>
-<L69>:
+               	b	 <L45>
+<L44>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
-<L70>:
+<L45>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L71>
+               	cset	w2, mi
+               	cbnz	w2,  <L46>
                	fmov	d1, d10
-               	b	 <L72>
-<L71>:
+               	b	 <L47>
+<L46>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L72>:
+<L47>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L73>:
+<L48>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L80>
+               	cset	w2, ls
+               	cbnz	w2,  <L55>
                	fmov	d4, d0
                	fmov	d5, d3
-<L74>:
+<L49>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L77>
-               	cbnz	w0,  <L75>
+               	cset	w2, ls
+               	cbnz	w2,  <L52>
+               	cbnz	w1,  <L50>
                	fmov	d6, d4
-               	b	 <L76>
-<L75>:
+               	b	 <L51>
+<L50>:
                	fneg	s6, s4
-<L76>:
-               	b	 <L82>
-<L77>:
+<L51>:
+               	b	 <L57>
+<L52>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cset	w2, ls
+               	cbnz	w2,  <L53>
                	fmov	d7, d4
-               	b	 <L79>
-<L78>:
+               	b	 <L54>
+<L53>:
                	fsub	s7, s4, s5
-<L79>:
+<L54>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L74>
-<L80>:
+               	b	 <L49>
+<L55>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L73>
-<L81>:
+               	b	 <L48>
+<L56>:
                	fdiv	s0, s9, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s9, s1
-<L82>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L84>
-               	mov	x0, x19
+<L57>:
                	fmov	s0, s6
-<L83>:
-               	bl	 <L83>
-               	mov	x20, x0
-               	b	 <L86>
-<L84>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-<L86>:
+<L58>:
+               	bl	 <L58>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L89>
+               	cset	w1, eq
+               	cbnz	w1,  <L61>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L87>
-               	b	 <L88>
-<L87>:
+               	cset	w2, eq
+               	cbnz	w2,  <L59>
+               	b	 <L60>
+<L59>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L88>:
-               	b	 <L90>
-<L89>:
-               	mov	x1, x0
-<L90>:
-               	cbnz	w1,  <L103>
+               	cset	w2, ne
+<L60>:
+               	b	 <L62>
+<L61>:
+               	mov	x2, x1
+<L62>:
+               	cbnz	w2,  <L75>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L91>
+               	cset	w1, mi
+               	cbnz	w1,  <L63>
                	fmov	d1, d0
-               	b	 <L92>
-<L91>:
+               	b	 <L64>
+<L63>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L92>:
+<L64>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L93>
+               	cset	w2, mi
+               	cbnz	w2,  <L65>
                	fmov	d2, d10
-               	b	 <L94>
-<L93>:
+               	b	 <L66>
+<L65>:
                	fmov	s31, wzr
                	fsub	s2, s31, s10
-<L94>:
+<L66>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L95>:
+<L67>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L102>
+               	cset	w2, ls
+               	cbnz	w2,  <L74>
                	fmov	d5, d1
                	fmov	d6, d4
-<L96>:
+<L68>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L99>
-               	cbnz	w0,  <L97>
+               	cset	w2, ls
+               	cbnz	w2,  <L71>
+               	cbnz	w1,  <L69>
                	fmov	d7, d5
-               	b	 <L98>
-<L97>:
+               	b	 <L70>
+<L69>:
                	fneg	s7, s5
-<L98>:
-               	b	 <L104>
-<L99>:
+<L70>:
+               	b	 <L76>
+<L71>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L100>
+               	cset	w2, ls
+               	cbnz	w2,  <L72>
                	fmov	d16, d5
-               	b	 <L101>
-<L100>:
+               	b	 <L73>
+<L72>:
                	fsub	s16, s5, s6
-<L101>:
+<L73>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L96>
-<L102>:
+               	b	 <L68>
+<L74>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L95>
-<L103>:
+               	b	 <L67>
+<L75>:
                	fdiv	s1, s0, s10
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L104>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x20
+<L76>:
                	fmov	s0, s7
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L107>:
-               	bl	 <L107>
-               	mov	x19, x0
-<L108>:
+<L77>:
+               	bl	 <L77>
                	fmov	s31, wzr
                	fsub	s0, s31, s10
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L111>
+               	cset	w1, eq
+               	cbnz	w1,  <L80>
                	fmov	s30, #2.00000000
                	fmul	s1, s9, s30
                	fcmp	s9, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L109>
-               	b	 <L110>
-<L109>:
+               	cset	w2, eq
+               	cbnz	w2,  <L78>
+               	b	 <L79>
+<L78>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w1, ne
-<L110>:
-               	b	 <L112>
-<L111>:
-               	mov	x1, x0
-<L112>:
-               	cbnz	w1,  <L125>
+               	cset	w2, ne
+<L79>:
+               	b	 <L81>
+<L80>:
+               	mov	x2, x1
+<L81>:
+               	cbnz	w2,  <L94>
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L113>
+               	cset	w1, mi
+               	cbnz	w1,  <L82>
                	fmov	d1, d9
-               	b	 <L114>
-<L113>:
+               	b	 <L83>
+<L82>:
                	fmov	s31, wzr
                	fsub	s1, s31, s9
-<L114>:
+<L83>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L115>
+               	cset	w2, mi
+               	cbnz	w2,  <L84>
                	fmov	d2, d0
-               	b	 <L116>
-<L115>:
+               	b	 <L85>
+<L84>:
                	fmov	s31, wzr
                	fsub	s2, s31, s0
-<L116>:
+<L85>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L117>:
+<L86>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L124>
+               	cset	w2, ls
+               	cbnz	w2,  <L93>
                	fmov	d5, d1
                	fmov	d6, d4
-<L118>:
+<L87>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L121>
-               	cbnz	w0,  <L119>
+               	cset	w2, ls
+               	cbnz	w2,  <L90>
+               	cbnz	w1,  <L88>
                	fmov	d7, d5
-               	b	 <L120>
-<L119>:
+               	b	 <L89>
+<L88>:
                	fneg	s7, s5
-<L120>:
-               	b	 <L126>
-<L121>:
+<L89>:
+               	b	 <L95>
+<L90>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L122>
+               	cset	w2, ls
+               	cbnz	w2,  <L91>
                	fmov	d16, d5
-               	b	 <L123>
-<L122>:
+               	b	 <L92>
+<L91>:
                	fsub	s16, s5, s6
-<L123>:
+<L92>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L118>
-<L124>:
+               	b	 <L87>
+<L93>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L117>
-<L125>:
+               	b	 <L86>
+<L94>:
                	fdiv	s1, s9, s0
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s0
                	fsub	s7, s9, s2
-<L126>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x19
+<L95>:
                	fmov	s0, s7
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L96>:
+               	bl	 <L96>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s31, wzr
                	fsub	s1, s31, s10
                	fmov	s30, wzr
                	fcmp	s1, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L133>
+               	cset	w1, eq
+               	cbnz	w1,  <L99>
                	fmov	s30, #2.00000000
                	fmul	s2, s0, s30
                	fcmp	s0, s2
-               	cset	w1, eq
-               	cbnz	w1,  <L131>
-               	b	 <L132>
-<L131>:
+               	cset	w2, eq
+               	cbnz	w2,  <L97>
+               	b	 <L98>
+<L97>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L132>:
-               	b	 <L134>
-<L133>:
-               	mov	x1, x0
-<L134>:
-               	cbnz	w1,  <L147>
+               	cset	w2, ne
+<L98>:
+               	b	 <L100>
+<L99>:
+               	mov	x2, x1
+<L100>:
+               	cbnz	w2,  <L113>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L135>
+               	cset	w1, mi
+               	cbnz	w1,  <L101>
                	fmov	d2, d0
-               	b	 <L136>
-<L135>:
+               	b	 <L102>
+<L101>:
                	fmov	s31, wzr
                	fsub	s2, s31, s0
-<L136>:
+<L102>:
                	fmov	s30, wzr
                	fcmp	s1, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L137>
+               	cset	w2, mi
+               	cbnz	w2,  <L103>
                	fmov	d3, d1
-               	b	 <L138>
-<L137>:
+               	b	 <L104>
+<L103>:
                	fmov	s31, wzr
                	fsub	s3, s31, s1
-<L138>:
+<L104>:
                	fmov	s30, #2.00000000
                	fdiv	s4, s2, s30
                	fmov	d5, d3
-<L139>:
+<L105>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L146>
+               	cset	w2, ls
+               	cbnz	w2,  <L112>
                	fmov	d6, d2
                	fmov	d7, d5
-<L140>:
+<L106>:
                	fcmp	s3, s7
-               	cset	w1, ls
-               	cbnz	w1,  <L143>
-               	cbnz	w0,  <L141>
+               	cset	w2, ls
+               	cbnz	w2,  <L109>
+               	cbnz	w1,  <L107>
                	fmov	d16, d6
-               	b	 <L142>
-<L141>:
+               	b	 <L108>
+<L107>:
                	fneg	s16, s6
-<L142>:
-               	b	 <L148>
-<L143>:
+<L108>:
+               	b	 <L114>
+<L109>:
                	fcmp	s7, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L144>
+               	cset	w2, ls
+               	cbnz	w2,  <L110>
                	fmov	d17, d6
-               	b	 <L145>
-<L144>:
+               	b	 <L111>
+<L110>:
                	fsub	s17, s6, s7
-<L145>:
+<L111>:
                	fmov	s30, #2.00000000
                	fdiv	s7, s7, s30
                	fmov	d6, d17
-               	b	 <L140>
-<L146>:
+               	b	 <L106>
+<L112>:
                	fmov	s30, #2.00000000
                	fmul	s5, s5, s30
-               	b	 <L139>
-<L147>:
+               	b	 <L105>
+<L113>:
                	fdiv	s2, s0, s1
-               	fcvtzs	x0, s2
-               	scvtf	s2, x0
+               	fcvtzs	x1, s2
+               	scvtf	s2, x1
                	fmul	s3, s2, s1
                	fsub	s16, s0, s3
-<L148>:
-               	fcmp	s16, s16
-               	cset	w0, ne
-               	cbnz	w0,  <L150>
-               	mov	x0, x20
+<L114>:
                	fmov	s0, s16
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-               	b	 <L152>
-<L150>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L151>:
-               	bl	 <L151>
-               	mov	x19, x0
-<L152>:
+<L115>:
+               	bl	 <L115>
                	fmov	s31, #7.00000000
                	fmul	s0, s31, s8
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L155>
+               	cset	w1, eq
+               	cbnz	w1,  <L118>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L153>
-               	b	 <L154>
-<L153>:
+               	cset	w2, eq
+               	cbnz	w2,  <L116>
+               	b	 <L117>
+<L116>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L154>:
-               	b	 <L156>
-<L155>:
-               	mov	x1, x0
-<L156>:
-               	cbnz	w1,  <L169>
+               	cset	w2, ne
+<L117>:
+               	b	 <L119>
+<L118>:
+               	mov	x2, x1
+<L119>:
+               	cbnz	w2,  <L132>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L157>
+               	cset	w1, mi
+               	cbnz	w1,  <L120>
                	fmov	d1, d0
-               	b	 <L158>
-<L157>:
+               	b	 <L121>
+<L120>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L158>:
+<L121>:
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L159>
+               	cset	w2, mi
+               	cbnz	w2,  <L122>
                	fmov	s2, #0.50000000
-               	b	 <L160>
-<L159>:
+               	b	 <L123>
+<L122>:
                	fmov	s31, wzr
                	fmov	s30, #0.50000000
                	fsub	s2, s31, s30
-<L160>:
+<L123>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L161>:
+<L124>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L168>
+               	cset	w2, ls
+               	cbnz	w2,  <L131>
                	fmov	d5, d1
                	fmov	d6, d4
-<L162>:
+<L125>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L165>
-               	cbnz	w0,  <L163>
+               	cset	w2, ls
+               	cbnz	w2,  <L128>
+               	cbnz	w1,  <L126>
                	fmov	d7, d5
-               	b	 <L164>
-<L163>:
+               	b	 <L127>
+<L126>:
                	fneg	s7, s5
-<L164>:
-               	b	 <L170>
-<L165>:
+<L127>:
+               	b	 <L133>
+<L128>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L166>
+               	cset	w2, ls
+               	cbnz	w2,  <L129>
                	fmov	d16, d5
-               	b	 <L167>
-<L166>:
+               	b	 <L130>
+<L129>:
                	fsub	s16, s5, s6
-<L167>:
+<L130>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L162>
-<L168>:
+               	b	 <L125>
+<L131>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L161>
-<L169>:
+               	b	 <L124>
+<L132>:
                	fmov	s30, #0.50000000
                	fdiv	s1, s0, s30
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmov	s30, #0.50000000
                	fmul	s2, s1, s30
                	fsub	s7, s0, s2
-<L170>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L172>
-               	mov	x0, x19
+<L133>:
                	fmov	s0, s7
-<L171>:
-               	bl	 <L171>
-               	mov	x20, x0
-               	b	 <L174>
-<L172>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L173>:
-               	bl	 <L173>
-               	mov	x20, x0
-<L174>:
+<L134>:
+               	bl	 <L134>
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L177>
+               	cset	w1, eq
+               	cbnz	w1,  <L137>
                	fmov	s30, #2.00000000
                	fmul	s0, s8, s30
                	fcmp	s8, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L175>
-               	b	 <L176>
-<L175>:
+               	cset	w2, eq
+               	cbnz	w2,  <L135>
+               	b	 <L136>
+<L135>:
                	fmov	s30, wzr
                	fcmp	s8, s30
-               	cset	w1, ne
-<L176>:
-               	b	 <L178>
-<L177>:
-               	mov	x1, x0
-<L178>:
-               	cbnz	w1,  <L191>
+               	cset	w2, ne
+<L136>:
+               	b	 <L138>
+<L137>:
+               	mov	x2, x1
+<L138>:
+               	cbnz	w2,  <L151>
                	fmov	s30, wzr
                	fcmp	s8, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L179>
+               	cset	w1, mi
+               	cbnz	w1,  <L139>
                	fmov	d0, d8
-               	b	 <L180>
-<L179>:
+               	b	 <L140>
+<L139>:
                	fmov	s31, wzr
                	fsub	s0, s31, s8
-<L180>:
+<L140>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L181>
+               	cset	w2, mi
+               	cbnz	w2,  <L141>
                	fmov	d1, d10
-               	b	 <L182>
-<L181>:
+               	b	 <L142>
+<L141>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L182>:
+<L142>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L183>:
+<L143>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L190>
+               	cset	w2, ls
+               	cbnz	w2,  <L150>
                	fmov	d4, d0
                	fmov	d5, d3
-<L184>:
+<L144>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L187>
-               	cbnz	w0,  <L185>
+               	cset	w2, ls
+               	cbnz	w2,  <L147>
+               	cbnz	w1,  <L145>
                	fmov	d6, d4
-               	b	 <L186>
-<L185>:
+               	b	 <L146>
+<L145>:
                	fneg	s6, s4
-<L186>:
-               	b	 <L192>
-<L187>:
+<L146>:
+               	b	 <L152>
+<L147>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L188>
+               	cset	w2, ls
+               	cbnz	w2,  <L148>
                	fmov	d7, d4
-               	b	 <L189>
-<L188>:
+               	b	 <L149>
+<L148>:
                	fsub	s7, s4, s5
-<L189>:
+<L149>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L184>
-<L190>:
+               	b	 <L144>
+<L150>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L183>
-<L191>:
+               	b	 <L143>
+<L151>:
                	fdiv	s0, s8, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s8, s1
-<L192>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L194>
-               	mov	x0, x20
+<L152>:
                	fmov	s0, s6
-<L193>:
-               	bl	 <L193>
-               	mov	x19, x0
-               	b	 <L196>
-<L194>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L195>:
-               	bl	 <L195>
-               	mov	x19, x0
-<L196>:
+<L153>:
+               	bl	 <L153>
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L199>
+               	cset	w1, eq
+               	cbnz	w1,  <L156>
                	fmov	s30, #2.00000000
                	fmul	s0, s10, s30
                	fcmp	s10, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L197>
-               	b	 <L198>
-<L197>:
+               	cset	w2, eq
+               	cbnz	w2,  <L154>
+               	b	 <L155>
+<L154>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, ne
-<L198>:
-               	b	 <L200>
-<L199>:
-               	mov	x1, x0
-<L200>:
-               	cbnz	w1,  <L213>
-               	fmov	s30, wzr
-               	fcmp	s10, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L201>
-               	fmov	d0, d10
-               	b	 <L202>
-<L201>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s10
-<L202>:
+               	cset	w2, ne
+<L155>:
+               	b	 <L157>
+<L156>:
+               	mov	x2, x1
+<L157>:
+               	cbnz	w2,  <L170>
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L203>
+               	cbnz	w1,  <L158>
+               	fmov	d0, d10
+               	b	 <L159>
+<L158>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s10
+<L159>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w2, mi
+               	cbnz	w2,  <L160>
                	fmov	d1, d10
-               	b	 <L204>
-<L203>:
+               	b	 <L161>
+<L160>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L204>:
+<L161>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L205>:
+<L162>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L212>
+               	cset	w2, ls
+               	cbnz	w2,  <L169>
                	fmov	d4, d0
                	fmov	d5, d3
-<L206>:
+<L163>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L209>
-               	cbnz	w0,  <L207>
+               	cset	w2, ls
+               	cbnz	w2,  <L166>
+               	cbnz	w1,  <L164>
                	fmov	d6, d4
-               	b	 <L208>
-<L207>:
+               	b	 <L165>
+<L164>:
                	fneg	s6, s4
-<L208>:
-               	b	 <L214>
-<L209>:
+<L165>:
+               	b	 <L171>
+<L166>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L210>
+               	cset	w2, ls
+               	cbnz	w2,  <L167>
                	fmov	d7, d4
-               	b	 <L211>
-<L210>:
+               	b	 <L168>
+<L167>:
                	fsub	s7, s4, s5
-<L211>:
+<L168>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L206>
-<L212>:
+               	b	 <L163>
+<L169>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L205>
-<L213>:
+               	b	 <L162>
+<L170>:
                	fdiv	s0, s10, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s10, s1
-<L214>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L216>
-               	mov	x0, x19
+<L171>:
                	fmov	s0, s6
-<L215>:
-               	bl	 <L215>
-               	mov	x20, x0
-               	b	 <L218>
-<L216>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L217>:
-               	bl	 <L217>
-               	mov	x20, x0
-<L218>:
+<L172>:
+               	bl	 <L172>
                	mov	w16, #0x49800000        ; =1233125376
                	fmov	s31, w16
                	fmul	s0, s31, s8
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L221>
+               	cset	w1, eq
+               	cbnz	w1,  <L175>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L219>
-               	b	 <L220>
-<L219>:
+               	cset	w2, eq
+               	cbnz	w2,  <L173>
+               	b	 <L174>
+<L173>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L220>:
-               	b	 <L222>
-<L221>:
-               	mov	x1, x0
-<L222>:
-               	cbnz	w1,  <L235>
+               	cset	w2, ne
+<L174>:
+               	b	 <L176>
+<L175>:
+               	mov	x2, x1
+<L176>:
+               	cbnz	w2,  <L189>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L223>
+               	cset	w1, mi
+               	cbnz	w1,  <L177>
                	fmov	d1, d0
-               	b	 <L224>
-<L223>:
+               	b	 <L178>
+<L177>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L224>:
+<L178>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L225>
+               	cset	w2, mi
+               	cbnz	w2,  <L179>
                	fmov	d2, d10
-               	b	 <L226>
-<L225>:
+               	b	 <L180>
+<L179>:
                	fmov	s31, wzr
                	fsub	s2, s31, s10
-<L226>:
+<L180>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L227>:
+<L181>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L234>
+               	cset	w2, ls
+               	cbnz	w2,  <L188>
                	fmov	d5, d1
                	fmov	d6, d4
-<L228>:
+<L182>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L231>
-               	cbnz	w0,  <L229>
+               	cset	w2, ls
+               	cbnz	w2,  <L185>
+               	cbnz	w1,  <L183>
                	fmov	d7, d5
-               	b	 <L230>
-<L229>:
+               	b	 <L184>
+<L183>:
                	fneg	s7, s5
-<L230>:
-               	b	 <L236>
-<L231>:
+<L184>:
+               	b	 <L190>
+<L185>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L232>
+               	cset	w2, ls
+               	cbnz	w2,  <L186>
                	fmov	d16, d5
-               	b	 <L233>
-<L232>:
+               	b	 <L187>
+<L186>:
                	fsub	s16, s5, s6
-<L233>:
+<L187>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L228>
-<L234>:
+               	b	 <L182>
+<L188>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L227>
-<L235>:
+               	b	 <L181>
+<L189>:
                	fdiv	s1, s0, s10
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L236>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x20
+<L190>:
                	fmov	s0, s7
-<L237>:
-               	bl	 <L237>
-               	mov	x19, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L239>:
-               	bl	 <L239>
-               	mov	x19, x0
-<L240>:
-               	mov	x0, x19
-               	ldp	d8, d9, [x29, #-0x30]
-               	ldp	d10, d11, [x29, #-0x40]
+<L191>:
+               	bl	 <L191>
+               	ldp	d8, d9, [x29, #-0x28]
+               	ldp	d10, d11, [x29, #-0x38]
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/float/arith_f64.dis
+++ b/test/golden/aarch64-darwin/float/arith_f64.dis
@@ -8,32 +8,56 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.float.arith_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.arith_f64.checksum>:
@@ -41,13 +65,10 @@ Disassembly of section __TEXT,__text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	d8, d9, [x29, #-0x30]
-               	stp	d10, d11, [x29, #-0x40]
+               	stur	x21, [x29, #-0x18]
+               	stp	d8, d9, [x29, #-0x28]
+               	stp	d10, d11, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
                	mov	x17, #0x3ff0000000000000 ; =4607182418800017408
                	add	x0, x17, x19
                	fmov	d8, x0
@@ -56,269 +77,144 @@ Disassembly of section __TEXT,__text:
                	fmov	d31, #0.25000000
                	fmul	d10, d31, d8
                	fadd	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	fsub	d0, d9, d10
 <L1>:
                	bl	 <L1>
-               	mov	x21, x0
-               	b	 <L4>
+               	fsub	d0, d10, d9
 <L2>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L2>
+               	fmul	d0, d9, d10
 <L3>:
                	bl	 <L3>
-               	mov	x21, x0
+               	fdiv	d0, d9, d10
 <L4>:
-               	fsub	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x21
+               	bl	 <L4>
+               	fdiv	d0, d10, d9
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
-<L6>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L7>:
-               	bl	 <L7>
-               	mov	x20, x0
-<L8>:
-               	fsub	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
-<L9>:
-               	bl	 <L9>
-               	mov	x21, x0
-               	b	 <L12>
-<L10>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L11>:
-               	bl	 <L11>
-               	mov	x21, x0
-<L12>:
-               	fmul	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x21
-<L13>:
-               	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
-<L14>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L15>:
-               	bl	 <L15>
-               	mov	x20, x0
-<L16>:
-               	fdiv	d0, d9, d10
-               	mov	x0, x20
-<L17>:
-               	bl	 <L17>
-               	fdiv	d0, d10, d9
-<L18>:
-               	bl	 <L18>
                	fneg	d0, d9
-<L19>:
-               	bl	 <L19>
+<L6>:
+               	bl	 <L6>
                	fmov	d31, xzr
                	fsub	d10, d31, d9
                	fmov	d0, d10
-<L20>:
-               	bl	 <L20>
+<L7>:
+               	bl	 <L7>
                	fsub	d0, d9, d9
-<L21>:
-               	bl	 <L21>
+<L8>:
+               	bl	 <L8>
                	fadd	d0, d10, d9
-<L22>:
-               	bl	 <L22>
+<L9>:
+               	bl	 <L9>
                	fmov	d31, #3.00000000
                	fmul	d9, d31, d8
                	fdiv	d10, d8, d9
                	fmov	d0, d10
-<L23>:
-               	bl	 <L23>
+<L10>:
+               	bl	 <L10>
                	fmul	d0, d10, d9
-<L24>:
-               	bl	 <L24>
+<L11>:
+               	bl	 <L11>
                	fsub	d0, d8, d10
                	fsub	d1, d0, d10
                	fsub	d0, d1, d10
-<L25>:
-               	bl	 <L25>
+<L12>:
+               	bl	 <L12>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-<L26>:
-               	bl	 <L26>
+<L13>:
+               	bl	 <L13>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d31, [x16]
                	fdiv	d0, d31, d9
-<L28>:
-               	bl	 <L28>
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0x4340000000000000 ; =4845873199050653696
                	fmov	d31, x16
                	fmul	d9, d31, d8
                	fadd	d11, d9, d8
                	fmov	d0, d11
-<L29>:
-               	bl	 <L29>
+<L16>:
+               	bl	 <L16>
                	fadd	d0, d11, d8
-<L30>:
-               	bl	 <L30>
+<L17>:
+               	bl	 <L17>
                	fadd	d0, d8, d8
                	fadd	d1, d9, d0
                	fmov	d0, d1
-<L31>:
-               	bl	 <L31>
+<L18>:
+               	bl	 <L18>
                	fsub	d0, d9, d8
-<L32>:
-               	bl	 <L32>
+<L19>:
+               	bl	 <L19>
                	fsub	d0, d11, d9
-<L33>:
-               	bl	 <L33>
+<L20>:
+               	bl	 <L20>
                	fmov	d31, xzr
                	fmul	d0, d31, d8
                	mov	x20, x0
                	fmov	d9, d0
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x18
-               	b.lo	 <L34>
-               	b	 <L39>
-<L34>:
+               	b.lo	 <L21>
+               	b	 <L23>
+<L21>:
                	fadd	d0, d9, d10
                	fmov	d30, #1.50000000
-               	fmul	d11, d0, d30
-               	fcmp	d11, d11
-               	cset	w0, ne
-               	cbnz	w0,  <L36>
+               	fmul	d9, d0, d30
                	mov	x0, x20
-               	fmov	d0, d11
-<L35>:
-               	bl	 <L35>
-               	mov	x22, x0
-               	b	 <L38>
-<L36>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L37>:
-               	bl	 <L37>
-               	mov	x22, x0
-<L38>:
+               	fmov	d0, d9
+<L22>:
+               	bl	 <L22>
                	add	x21, x21, #0x1
-               	mov	x20, x22
-               	fmov	d9, d11
+               	mov	x20, x0
                	cmp	x21, #0x18
-               	b.lo	 <L34>
-<L39>:
+               	b.lo	 <L21>
+<L23>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fef, lsl #48
                	add	x0, x17, x19
                	fmov	d9, x0
-               	fcmp	d9, d9
-               	cset	w0, ne
-               	cbnz	w0,  <L41>
                	mov	x0, x20
                	fmov	d0, d9
-<L40>:
-               	bl	 <L40>
-               	mov	x21, x0
-               	b	 <L43>
-<L41>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L42>:
-               	bl	 <L42>
-               	mov	x21, x0
-<L43>:
+<L24>:
+               	bl	 <L24>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L45>
-               	mov	x0, x21
-<L44>:
-               	bl	 <L44>
-               	mov	x20, x0
-               	b	 <L47>
-<L45>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L46>:
-               	bl	 <L46>
-               	mov	x20, x0
-<L47>:
+<L25>:
+               	bl	 <L25>
                	fadd	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L49>
-               	mov	x0, x20
-<L48>:
-               	bl	 <L48>
-               	mov	x21, x0
-               	b	 <L51>
-<L49>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L50>:
-               	bl	 <L50>
-               	mov	x21, x0
-<L51>:
+<L26>:
+               	bl	 <L26>
                	fmov	d30, #2.00000000
                	fmul	d10, d9, d30
-               	mov	x0, x21
                	fmov	d0, d10
-<L52>:
-               	bl	 <L52>
+<L27>:
+               	bl	 <L27>
                	fmov	d31, xzr
                	fsub	d0, d31, d10
-<L53>:
-               	bl	 <L53>
+<L28>:
+               	bl	 <L28>
                	fmul	d0, d9, d9
-<L54>:
-               	bl	 <L54>
+<L29>:
+               	bl	 <L29>
                	fsub	d0, d9, d9
-<L55>:
-               	bl	 <L55>
+<L30>:
+               	bl	 <L30>
                	mov	x17, #0x10000000000000  ; =4503599627370496
                	add	x1, x17, x19
                	fmov	d9, x1
@@ -327,869 +223,739 @@ Disassembly of section __TEXT,__text:
                	fmov	d10, x1
                	fmov	d30, #0.50000000
                	fmul	d0, d9, d30
-<L56>:
-               	bl	 <L56>
+<L31>:
+               	bl	 <L31>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-<L57>:
-               	bl	 <L57>
+<L32>:
+               	bl	 <L32>
                	fsub	d0, d9, d10
-<L58>:
-               	bl	 <L58>
+<L33>:
+               	bl	 <L33>
                	fmul	d0, d9, d8
-<L59>:
-               	bl	 <L59>
+<L34>:
+               	bl	 <L34>
                	fadd	d0, d10, d10
-<L60>:
-               	bl	 <L60>
+<L35>:
+               	bl	 <L35>
                	fmov	d30, #0.50000000
                	fmul	d0, d10, d30
-<L61>:
-               	bl	 <L61>
+<L36>:
+               	bl	 <L36>
                	fmov	d30, #0.75000000
                	fmul	d0, d10, d30
-<L62>:
-               	bl	 <L62>
+<L37>:
+               	bl	 <L37>
                	mov	x16, #0x4340000000000000 ; =4845873199050653696
                	fmov	d30, x16
                	fmul	d0, d10, d30
-<L63>:
-               	bl	 <L63>
+<L38>:
+               	bl	 <L38>
                	fdiv	d0, d10, d9
-<L64>:
-               	bl	 <L64>
-               	mov	x19, x0
+<L39>:
+               	bl	 <L39>
                	fmov	d31, #5.50000000
                	fmul	d9, d31, d8
                	fmov	d31, #3.00000000
                	fmul	d10, d31, d8
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L67>
+               	cset	w1, eq
+               	cbnz	w1,  <L42>
                	fmov	d30, #2.00000000
                	fmul	d0, d9, d30
                	fcmp	d9, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L65>
-               	b	 <L66>
-<L65>:
+               	cset	w2, eq
+               	cbnz	w2,  <L40>
+               	b	 <L41>
+<L40>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w1, ne
-<L66>:
-               	b	 <L68>
-<L67>:
-               	mov	x1, x0
-<L68>:
-               	cbnz	w1,  <L81>
+               	cset	w2, ne
+<L41>:
+               	b	 <L43>
+<L42>:
+               	mov	x2, x1
+<L43>:
+               	cbnz	w2,  <L56>
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L69>
+               	cset	w1, mi
+               	cbnz	w1,  <L44>
                	fmov	d0, d9
-               	b	 <L70>
-<L69>:
+               	b	 <L45>
+<L44>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
-<L70>:
+<L45>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L71>
+               	cset	w2, mi
+               	cbnz	w2,  <L46>
                	fmov	d1, d10
-               	b	 <L72>
-<L71>:
+               	b	 <L47>
+<L46>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L72>:
+<L47>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L73>:
+<L48>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L80>
+               	cset	w2, ls
+               	cbnz	w2,  <L55>
                	fmov	d4, d0
                	fmov	d5, d3
-<L74>:
+<L49>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L77>
-               	cbnz	w0,  <L75>
+               	cset	w2, ls
+               	cbnz	w2,  <L52>
+               	cbnz	w1,  <L50>
                	fmov	d6, d4
-               	b	 <L76>
-<L75>:
+               	b	 <L51>
+<L50>:
                	fneg	d6, d4
-<L76>:
-               	b	 <L82>
-<L77>:
+<L51>:
+               	b	 <L57>
+<L52>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cset	w2, ls
+               	cbnz	w2,  <L53>
                	fmov	d7, d4
-               	b	 <L79>
-<L78>:
+               	b	 <L54>
+<L53>:
                	fsub	d7, d4, d5
-<L79>:
+<L54>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L74>
-<L80>:
+               	b	 <L49>
+<L55>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L73>
-<L81>:
+               	b	 <L48>
+<L56>:
                	fdiv	d0, d9, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d9, d1
-<L82>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L84>
-               	mov	x0, x19
+<L57>:
                	fmov	d0, d6
-<L83>:
-               	bl	 <L83>
-               	mov	x20, x0
-               	b	 <L86>
-<L84>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-<L86>:
+<L58>:
+               	bl	 <L58>
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L89>
+               	cset	w1, eq
+               	cbnz	w1,  <L61>
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L87>
-               	b	 <L88>
-<L87>:
+               	cset	w2, eq
+               	cbnz	w2,  <L59>
+               	b	 <L60>
+<L59>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L88>:
-               	b	 <L90>
-<L89>:
-               	mov	x1, x0
-<L90>:
-               	cbnz	w1,  <L103>
+               	cset	w2, ne
+<L60>:
+               	b	 <L62>
+<L61>:
+               	mov	x2, x1
+<L62>:
+               	cbnz	w2,  <L75>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L91>
+               	cset	w1, mi
+               	cbnz	w1,  <L63>
                	fmov	d1, d0
-               	b	 <L92>
-<L91>:
+               	b	 <L64>
+<L63>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L92>:
+<L64>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L93>
+               	cset	w2, mi
+               	cbnz	w2,  <L65>
                	fmov	d2, d10
-               	b	 <L94>
-<L93>:
+               	b	 <L66>
+<L65>:
                	fmov	d31, xzr
                	fsub	d2, d31, d10
-<L94>:
+<L66>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L95>:
+<L67>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L102>
+               	cset	w2, ls
+               	cbnz	w2,  <L74>
                	fmov	d5, d1
                	fmov	d6, d4
-<L96>:
+<L68>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L99>
-               	cbnz	w0,  <L97>
+               	cset	w2, ls
+               	cbnz	w2,  <L71>
+               	cbnz	w1,  <L69>
                	fmov	d7, d5
-               	b	 <L98>
-<L97>:
+               	b	 <L70>
+<L69>:
                	fneg	d7, d5
-<L98>:
-               	b	 <L104>
-<L99>:
+<L70>:
+               	b	 <L76>
+<L71>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L100>
+               	cset	w2, ls
+               	cbnz	w2,  <L72>
                	fmov	d16, d5
-               	b	 <L101>
-<L100>:
+               	b	 <L73>
+<L72>:
                	fsub	d16, d5, d6
-<L101>:
+<L73>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L96>
-<L102>:
+               	b	 <L68>
+<L74>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L95>
-<L103>:
+               	b	 <L67>
+<L75>:
                	fdiv	d1, d0, d10
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L104>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x20
+<L76>:
                	fmov	d0, d7
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L107>:
-               	bl	 <L107>
-               	mov	x19, x0
-<L108>:
+<L77>:
+               	bl	 <L77>
                	fmov	d31, xzr
                	fsub	d0, d31, d10
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L111>
+               	cset	w1, eq
+               	cbnz	w1,  <L80>
                	fmov	d30, #2.00000000
                	fmul	d1, d9, d30
                	fcmp	d9, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L109>
-               	b	 <L110>
-<L109>:
+               	cset	w2, eq
+               	cbnz	w2,  <L78>
+               	b	 <L79>
+<L78>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w1, ne
-<L110>:
-               	b	 <L112>
-<L111>:
-               	mov	x1, x0
-<L112>:
-               	cbnz	w1,  <L125>
+               	cset	w2, ne
+<L79>:
+               	b	 <L81>
+<L80>:
+               	mov	x2, x1
+<L81>:
+               	cbnz	w2,  <L94>
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L113>
+               	cset	w1, mi
+               	cbnz	w1,  <L82>
                	fmov	d1, d9
-               	b	 <L114>
-<L113>:
+               	b	 <L83>
+<L82>:
                	fmov	d31, xzr
                	fsub	d1, d31, d9
-<L114>:
+<L83>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L115>
+               	cset	w2, mi
+               	cbnz	w2,  <L84>
                	fmov	d2, d0
-               	b	 <L116>
-<L115>:
+               	b	 <L85>
+<L84>:
                	fmov	d31, xzr
                	fsub	d2, d31, d0
-<L116>:
+<L85>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L117>:
+<L86>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L124>
+               	cset	w2, ls
+               	cbnz	w2,  <L93>
                	fmov	d5, d1
                	fmov	d6, d4
-<L118>:
+<L87>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L121>
-               	cbnz	w0,  <L119>
+               	cset	w2, ls
+               	cbnz	w2,  <L90>
+               	cbnz	w1,  <L88>
                	fmov	d7, d5
-               	b	 <L120>
-<L119>:
+               	b	 <L89>
+<L88>:
                	fneg	d7, d5
-<L120>:
-               	b	 <L126>
-<L121>:
+<L89>:
+               	b	 <L95>
+<L90>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L122>
+               	cset	w2, ls
+               	cbnz	w2,  <L91>
                	fmov	d16, d5
-               	b	 <L123>
-<L122>:
+               	b	 <L92>
+<L91>:
                	fsub	d16, d5, d6
-<L123>:
+<L92>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L118>
-<L124>:
+               	b	 <L87>
+<L93>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L117>
-<L125>:
+               	b	 <L86>
+<L94>:
                	fdiv	d1, d9, d0
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d0
                	fsub	d7, d9, d2
-<L126>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x19
+<L95>:
                	fmov	d0, d7
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L96>:
+               	bl	 <L96>
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d31, xzr
                	fsub	d1, d31, d10
                	fmov	d30, xzr
                	fcmp	d1, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L133>
+               	cset	w1, eq
+               	cbnz	w1,  <L99>
                	fmov	d30, #2.00000000
                	fmul	d2, d0, d30
                	fcmp	d0, d2
-               	cset	w1, eq
-               	cbnz	w1,  <L131>
-               	b	 <L132>
-<L131>:
+               	cset	w2, eq
+               	cbnz	w2,  <L97>
+               	b	 <L98>
+<L97>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L132>:
-               	b	 <L134>
-<L133>:
-               	mov	x1, x0
-<L134>:
-               	cbnz	w1,  <L147>
+               	cset	w2, ne
+<L98>:
+               	b	 <L100>
+<L99>:
+               	mov	x2, x1
+<L100>:
+               	cbnz	w2,  <L113>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L135>
+               	cset	w1, mi
+               	cbnz	w1,  <L101>
                	fmov	d2, d0
-               	b	 <L136>
-<L135>:
+               	b	 <L102>
+<L101>:
                	fmov	d31, xzr
                	fsub	d2, d31, d0
-<L136>:
+<L102>:
                	fmov	d30, xzr
                	fcmp	d1, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L137>
+               	cset	w2, mi
+               	cbnz	w2,  <L103>
                	fmov	d3, d1
-               	b	 <L138>
-<L137>:
+               	b	 <L104>
+<L103>:
                	fmov	d31, xzr
                	fsub	d3, d31, d1
-<L138>:
+<L104>:
                	fmov	d30, #2.00000000
                	fdiv	d4, d2, d30
                	fmov	d5, d3
-<L139>:
+<L105>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L146>
+               	cset	w2, ls
+               	cbnz	w2,  <L112>
                	fmov	d6, d2
                	fmov	d7, d5
-<L140>:
+<L106>:
                	fcmp	d3, d7
-               	cset	w1, ls
-               	cbnz	w1,  <L143>
-               	cbnz	w0,  <L141>
+               	cset	w2, ls
+               	cbnz	w2,  <L109>
+               	cbnz	w1,  <L107>
                	fmov	d16, d6
-               	b	 <L142>
-<L141>:
+               	b	 <L108>
+<L107>:
                	fneg	d16, d6
-<L142>:
-               	b	 <L148>
-<L143>:
+<L108>:
+               	b	 <L114>
+<L109>:
                	fcmp	d7, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L144>
+               	cset	w2, ls
+               	cbnz	w2,  <L110>
                	fmov	d17, d6
-               	b	 <L145>
-<L144>:
+               	b	 <L111>
+<L110>:
                	fsub	d17, d6, d7
-<L145>:
+<L111>:
                	fmov	d30, #2.00000000
                	fdiv	d7, d7, d30
                	fmov	d6, d17
-               	b	 <L140>
-<L146>:
+               	b	 <L106>
+<L112>:
                	fmov	d30, #2.00000000
                	fmul	d5, d5, d30
-               	b	 <L139>
-<L147>:
+               	b	 <L105>
+<L113>:
                	fdiv	d2, d0, d1
-               	fcvtzs	x0, d2
-               	scvtf	d2, x0
+               	fcvtzs	x1, d2
+               	scvtf	d2, x1
                	fmul	d3, d2, d1
                	fsub	d16, d0, d3
-<L148>:
-               	fcmp	d16, d16
-               	cset	w0, ne
-               	cbnz	w0,  <L150>
-               	mov	x0, x20
+<L114>:
                	fmov	d0, d16
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-               	b	 <L152>
-<L150>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L151>:
-               	bl	 <L151>
-               	mov	x19, x0
-<L152>:
+<L115>:
+               	bl	 <L115>
                	fmov	d31, #7.00000000
                	fmul	d0, d31, d8
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w0, eq
-               	cbnz	w0,  <L153>
-               	b	 <L154>
-<L153>:
+               	cset	w1, eq
+               	cbnz	w1,  <L116>
+               	b	 <L117>
+<L116>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, ne
-<L154>:
-               	cbnz	w0,  <L165>
+               	cset	w1, ne
+<L117>:
+               	cbnz	w1,  <L128>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L155>
+               	cset	w1, mi
+               	cbnz	w1,  <L118>
                	fmov	d1, d0
-               	b	 <L156>
-<L155>:
+               	b	 <L119>
+<L118>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L156>:
+<L119>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d1, d30
                	fmov	d3, #0.50000000
-<L157>:
+<L120>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L164>
+               	cset	w2, ls
+               	cbnz	w2,  <L127>
                	fmov	d4, d1
                	fmov	d5, d3
-<L158>:
+<L121>:
                	fmov	d31, #0.50000000
                	fcmp	d31, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L161>
-               	cbnz	w0,  <L159>
+               	cset	w2, ls
+               	cbnz	w2,  <L124>
+               	cbnz	w1,  <L122>
                	fmov	d6, d4
-               	b	 <L160>
-<L159>:
+               	b	 <L123>
+<L122>:
                	fneg	d6, d4
-<L160>:
-               	b	 <L166>
-<L161>:
+<L123>:
+               	b	 <L129>
+<L124>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L162>
+               	cset	w2, ls
+               	cbnz	w2,  <L125>
                	fmov	d7, d4
-               	b	 <L163>
-<L162>:
+               	b	 <L126>
+<L125>:
                	fsub	d7, d4, d5
-<L163>:
+<L126>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L158>
-<L164>:
+               	b	 <L121>
+<L127>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L157>
-<L165>:
+               	b	 <L120>
+<L128>:
                	fmov	d30, #0.50000000
                	fdiv	d1, d0, d30
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmov	d30, #0.50000000
                	fmul	d2, d1, d30
                	fsub	d6, d0, d2
-<L166>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L168>
-               	mov	x0, x19
+<L129>:
                	fmov	d0, d6
-<L167>:
-               	bl	 <L167>
-               	mov	x20, x0
-               	b	 <L170>
-<L168>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L169>:
-               	bl	 <L169>
-               	mov	x20, x0
-<L170>:
+<L130>:
+               	bl	 <L130>
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L173>
+               	cset	w1, eq
+               	cbnz	w1,  <L133>
                	fmov	d30, #2.00000000
                	fmul	d0, d8, d30
                	fcmp	d8, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L171>
-               	b	 <L172>
-<L171>:
+               	cset	w2, eq
+               	cbnz	w2,  <L131>
+               	b	 <L132>
+<L131>:
                	fmov	d30, xzr
                	fcmp	d8, d30
-               	cset	w1, ne
-<L172>:
-               	b	 <L174>
-<L173>:
-               	mov	x1, x0
-<L174>:
-               	cbnz	w1,  <L187>
+               	cset	w2, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x2, x1
+<L134>:
+               	cbnz	w2,  <L147>
                	fmov	d30, xzr
                	fcmp	d8, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L175>
+               	cset	w1, mi
+               	cbnz	w1,  <L135>
                	fmov	d0, d8
-               	b	 <L176>
-<L175>:
+               	b	 <L136>
+<L135>:
                	fmov	d31, xzr
                	fsub	d0, d31, d8
-<L176>:
+<L136>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L177>
+               	cset	w2, mi
+               	cbnz	w2,  <L137>
                	fmov	d1, d10
-               	b	 <L178>
-<L177>:
+               	b	 <L138>
+<L137>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L178>:
+<L138>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L179>:
+<L139>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L186>
+               	cset	w2, ls
+               	cbnz	w2,  <L146>
                	fmov	d4, d0
                	fmov	d5, d3
-<L180>:
+<L140>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L183>
-               	cbnz	w0,  <L181>
+               	cset	w2, ls
+               	cbnz	w2,  <L143>
+               	cbnz	w1,  <L141>
                	fmov	d6, d4
-               	b	 <L182>
-<L181>:
+               	b	 <L142>
+<L141>:
                	fneg	d6, d4
-<L182>:
-               	b	 <L188>
-<L183>:
+<L142>:
+               	b	 <L148>
+<L143>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L184>
+               	cset	w2, ls
+               	cbnz	w2,  <L144>
                	fmov	d7, d4
-               	b	 <L185>
-<L184>:
+               	b	 <L145>
+<L144>:
                	fsub	d7, d4, d5
-<L185>:
+<L145>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L180>
-<L186>:
+               	b	 <L140>
+<L146>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L179>
-<L187>:
+               	b	 <L139>
+<L147>:
                	fdiv	d0, d8, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d8, d1
-<L188>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L190>
-               	mov	x0, x20
+<L148>:
                	fmov	d0, d6
-<L189>:
-               	bl	 <L189>
-               	mov	x19, x0
-               	b	 <L192>
-<L190>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L191>:
-               	bl	 <L191>
-               	mov	x19, x0
-<L192>:
+<L149>:
+               	bl	 <L149>
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L195>
+               	cset	w1, eq
+               	cbnz	w1,  <L152>
                	fmov	d30, #2.00000000
                	fmul	d0, d10, d30
                	fcmp	d10, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L193>
-               	b	 <L194>
-<L193>:
+               	cset	w2, eq
+               	cbnz	w2,  <L150>
+               	b	 <L151>
+<L150>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, ne
-<L194>:
-               	b	 <L196>
-<L195>:
-               	mov	x1, x0
-<L196>:
-               	cbnz	w1,  <L209>
-               	fmov	d30, xzr
-               	fcmp	d10, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L197>
-               	fmov	d0, d10
-               	b	 <L198>
-<L197>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d10
-<L198>:
+               	cset	w2, ne
+<L151>:
+               	b	 <L153>
+<L152>:
+               	mov	x2, x1
+<L153>:
+               	cbnz	w2,  <L166>
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L199>
+               	cbnz	w1,  <L154>
+               	fmov	d0, d10
+               	b	 <L155>
+<L154>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d10
+<L155>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w2, mi
+               	cbnz	w2,  <L156>
                	fmov	d1, d10
-               	b	 <L200>
-<L199>:
+               	b	 <L157>
+<L156>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L200>:
+<L157>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L201>:
+<L158>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L208>
+               	cset	w2, ls
+               	cbnz	w2,  <L165>
                	fmov	d4, d0
                	fmov	d5, d3
-<L202>:
+<L159>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L205>
-               	cbnz	w0,  <L203>
+               	cset	w2, ls
+               	cbnz	w2,  <L162>
+               	cbnz	w1,  <L160>
                	fmov	d6, d4
-               	b	 <L204>
-<L203>:
+               	b	 <L161>
+<L160>:
                	fneg	d6, d4
-<L204>:
-               	b	 <L210>
-<L205>:
+<L161>:
+               	b	 <L167>
+<L162>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L206>
+               	cset	w2, ls
+               	cbnz	w2,  <L163>
                	fmov	d7, d4
-               	b	 <L207>
-<L206>:
+               	b	 <L164>
+<L163>:
                	fsub	d7, d4, d5
-<L207>:
+<L164>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L202>
-<L208>:
+               	b	 <L159>
+<L165>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L201>
-<L209>:
+               	b	 <L158>
+<L166>:
                	fdiv	d0, d10, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d10, d1
-<L210>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L212>
-               	mov	x0, x19
+<L167>:
                	fmov	d0, d6
-<L211>:
-               	bl	 <L211>
-               	mov	x20, x0
-               	b	 <L214>
-<L212>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L213>:
-               	bl	 <L213>
-               	mov	x20, x0
-<L214>:
+<L168>:
+               	bl	 <L168>
                	mov	x16, #0x4130000000000000 ; =4697254411347427328
                	fmov	d31, x16
                	fmul	d0, d31, d8
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L217>
+               	cset	w1, eq
+               	cbnz	w1,  <L171>
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L215>
-               	b	 <L216>
-<L215>:
+               	cset	w2, eq
+               	cbnz	w2,  <L169>
+               	b	 <L170>
+<L169>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L216>:
-               	b	 <L218>
-<L217>:
-               	mov	x1, x0
-<L218>:
-               	cbnz	w1,  <L231>
+               	cset	w2, ne
+<L170>:
+               	b	 <L172>
+<L171>:
+               	mov	x2, x1
+<L172>:
+               	cbnz	w2,  <L185>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L219>
+               	cset	w1, mi
+               	cbnz	w1,  <L173>
                	fmov	d1, d0
-               	b	 <L220>
-<L219>:
+               	b	 <L174>
+<L173>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L220>:
+<L174>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L221>
+               	cset	w2, mi
+               	cbnz	w2,  <L175>
                	fmov	d2, d10
-               	b	 <L222>
-<L221>:
+               	b	 <L176>
+<L175>:
                	fmov	d31, xzr
                	fsub	d2, d31, d10
-<L222>:
+<L176>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L223>:
+<L177>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L230>
+               	cset	w2, ls
+               	cbnz	w2,  <L184>
                	fmov	d5, d1
                	fmov	d6, d4
-<L224>:
+<L178>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L227>
-               	cbnz	w0,  <L225>
+               	cset	w2, ls
+               	cbnz	w2,  <L181>
+               	cbnz	w1,  <L179>
                	fmov	d7, d5
-               	b	 <L226>
-<L225>:
+               	b	 <L180>
+<L179>:
                	fneg	d7, d5
-<L226>:
-               	b	 <L232>
-<L227>:
+<L180>:
+               	b	 <L186>
+<L181>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L228>
+               	cset	w2, ls
+               	cbnz	w2,  <L182>
                	fmov	d16, d5
-               	b	 <L229>
-<L228>:
+               	b	 <L183>
+<L182>:
                	fsub	d16, d5, d6
-<L229>:
+<L183>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L224>
-<L230>:
+               	b	 <L178>
+<L184>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L223>
-<L231>:
+               	b	 <L177>
+<L185>:
                	fdiv	d1, d0, d10
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L232>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x20
+<L186>:
                	fmov	d0, d7
-<L233>:
-               	bl	 <L233>
-               	mov	x19, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L235>:
-               	bl	 <L235>
-               	mov	x19, x0
-<L236>:
-               	mov	x0, x19
-               	ldp	d8, d9, [x29, #-0x30]
-               	ldp	d10, d11, [x29, #-0x40]
+<L187>:
+               	bl	 <L187>
+               	ldp	d8, d9, [x29, #-0x28]
+               	ldp	d10, d11, [x29, #-0x38]
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/float/cmp_f32.dis
+++ b/test/golden/aarch64-darwin/float/cmp_f32.dis
@@ -3,45 +3,63 @@ float/cmp_f32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.float.cmp_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.cmp_f32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stur	x25, [x29, #-0x68]
-               	stp	d8, d9, [x29, #-0x78]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
+               	sub	sp, sp, #0x40
+               	stur	x19, [x29, #-0x38]
+               	stur	d8, [x29, #-0x40]
+               	mov	w1, w0
                	sub	x19, x29, #0x30
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
@@ -50,350 +68,540 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x19, #0x20]
                	str	xzr, [x19, #0x28]
                	mov	w17, #-0x800000         ; =-8388608
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x0
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x0
+               	str	s0, [x0]
                	mov	w17, #-0x40800000       ; =-1082130432
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x4
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x4
+               	str	s0, [x0]
                	mov	w17, #-0x7f800000       ; =-2139095040
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x8
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x8
+               	str	s0, [x0]
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x8000, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0xc
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0xc
+               	str	s0, [x0]
                	mov	w17, #-0x80000000       ; =-2147483648
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x10
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x10
+               	str	s0, [x0]
                	fmov	s0, w1
-               	add	x2, x19, #0x14
-               	str	s0, [x2]
+               	add	x0, x19, #0x14
+               	str	s0, [x0]
                	mov	w17, #0x1               ; =1
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x18
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x18
+               	str	s0, [x0]
                	mov	w17, #0x3f800000        ; =1065353216
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x1c
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x1c
+               	str	s0, [x0]
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x20
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x20
+               	str	s0, [x0]
                	mov	w17, #0x7f800000        ; =2139095040
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x24
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x24
+               	str	s0, [x0]
                	mov	w17, #0x7fc00000        ; =2143289344
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x28
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x28
+               	str	s0, [x0]
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x7f80, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x1, x19, #0x2c
-               	str	s0, [x1]
-               	mov	x20, x0
-               	mov	w21, #0x0               ; =0
-               	cmp	w21, #0xc
-               	b.lo	 <L1>
-               	b	 <L34>
-<L1>:
-               	mov	w0, w21
-               	add	x22, x19, x0, lsl #2
-               	mov	x23, x20
-               	mov	w24, #0x0               ; =0
-               	cmp	w24, #0xc
-               	b.lo	 <L2>
-               	b	 <L33>
-<L2>:
-               	ldr	s8, [x22]
-               	mov	w0, w24
-               	add	x1, x19, x0, lsl #2
-               	ldr	s9, [x1]
-               	fcmp	s8, s9
-               	cset	w1, eq
-               	mov	x0, x23
-<L3>:
-               	bl	 <L3>
-               	fcmp	s8, s9
-               	cset	w1, ne
-<L4>:
-               	bl	 <L4>
-               	fcmp	s8, s9
-               	cset	w25, mi
-               	mov	x1, x25
-<L5>:
-               	bl	 <L5>
-               	fcmp	s8, s9
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	fcmp	s9, s8
-               	cset	w1, mi
-<L7>:
-               	bl	 <L7>
-               	fcmp	s9, s8
-               	cset	w1, ls
-<L8>:
-               	bl	 <L8>
-               	cbnz	w25,  <L9>
-               	mov	x1, #0x0                ; =0
-               	b	 <L10>
-<L9>:
-               	mov	x1, #0x1                ; =1
-<L10>:
-               	fcmp	s8, s9
-               	cset	w2, ls
-               	cbnz	w2,  <L11>
-               	mov	x2, x1
-               	b	 <L12>
-<L11>:
-               	add	w2, w1, #0x2
-<L12>:
-               	fcmp	s9, s8
-               	cset	w1, mi
-               	cbnz	w1,  <L13>
-               	mov	x1, x2
-               	b	 <L14>
-<L13>:
-               	add	w1, w2, #0x4
-<L14>:
-               	fcmp	s9, s8
-               	cset	w2, ls
-               	cbnz	w2,  <L15>
-               	mov	x2, x1
-               	b	 <L16>
-<L15>:
-               	add	w2, w1, #0x8
-<L16>:
-               	fcmp	s8, s9
-               	cset	w1, eq
-               	cbnz	w1,  <L17>
-               	mov	x1, x2
-               	b	 <L18>
-<L17>:
-               	add	w1, w2, #0x10
-<L18>:
-               	fcmp	s8, s9
-               	cset	w2, ne
-               	cbnz	w2,  <L19>
-               	mov	x2, x1
-               	b	 <L20>
-<L19>:
-               	add	w2, w1, #0x20
-<L20>:
-               	mov	x1, x2
-<L21>:
-               	bl	 <L21>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	cbnz	w1,  <L22>
-               	b	 <L23>
-<L22>:
-               	fcmp	s9, s8
-               	cset	w1, mi
-<L23>:
-               	bl	 <L23>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	cbnz	w1,  <L24>
-               	fcmp	s9, s8
-               	cset	w2, mi
-               	b	 <L25>
-<L24>:
-               	mov	x2, x1
-<L25>:
-               	mov	x1, x2
-<L26>:
-               	bl	 <L26>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	uxtb	w17, w1
-               	cmp	w17, #0x1
-               	cset	w2, ne
-               	mov	x1, x2
-<L27>:
-               	bl	 <L27>
-               	fcmp	s8, s8
-               	cset	w1, eq
-               	cbnz	w1,  <L28>
-               	b	 <L29>
-<L28>:
-               	fcmp	s9, s9
-               	cset	w1, eq
-<L29>:
-               	bl	 <L29>
-               	fcmp	s8, s8
-               	cset	w1, ne
-               	cbnz	w1,  <L30>
-               	fcmp	s9, s9
-               	cset	w2, ne
-               	b	 <L31>
-<L30>:
-               	mov	x2, x1
-<L31>:
-               	mov	x1, x2
-<L32>:
-               	bl	 <L32>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0xc
-               	b.lo	 <L2>
-<L33>:
-               	add	w21, w21, #0x1
-               	mov	x20, x23
-               	cmp	w21, #0xc
-               	b.lo	 <L1>
-<L34>:
-               	add	x0, x19, #0x0
-               	ldr	s0, [x0]
-               	ldr	s1, [x0]
-               	fmov	d8, d1
-               	mov	w0, #0x1                ; =1
-               	cmp	w0, #0xc
-               	b.lo	 <L35>
-               	b	 <L40>
-<L35>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s1, [x2]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L36>
-               	fmov	d1, d0
-               	b	 <L37>
-<L36>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s1, [x2]
-<L37>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s2, [x2]
-               	fcmp	s8, s2
-               	cset	w1, mi
-               	cbnz	w1,  <L38>
-               	fmov	d2, d8
-               	b	 <L39>
-<L38>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s2, [x2]
-<L39>:
-               	add	w0, w0, #0x1
-               	fmov	d0, d1
-               	fmov	d8, d2
-               	cmp	w0, #0xc
-               	b.lo	 <L35>
-<L40>:
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
-               	fcmp	s8, s8
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-               	fmov	s0, s8
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x2c
+               	str	s0, [x0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	mov	w1, #0x0                ; =0
-               	mov	w0, #0x0                ; =0
-               	cmp	w0, #0xc
-               	b.lo	 <L49>
-               	b	 <L52>
-<L49>:
-               	mov	w2, w0
+               	cmp	w1, #0xc
+               	b.lo	 <L0>
+               	b	 <L47>
+<L0>:
+               	mov	w2, w1
                	add	x3, x19, x2, lsl #2
-               	mov	x2, x1
+               	mov	x2, x0
                	mov	w4, #0x0                ; =0
                	cmp	w4, #0xc
-               	b.lo	 <L50>
-               	b	 <L51>
-<L50>:
+               	b.lo	 <L1>
+               	b	 <L46>
+<L1>:
                	ldr	s0, [x3]
                	mov	w5, w4
                	add	x6, x19, x5, lsl #2
                	ldr	s1, [x6]
                	fcmp	s0, s1
-               	cset	w5, mi
-               	uxtb	w7, w5
-               	add	w5, w2, w7
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
-               	fcmp	s0, s1
-               	cset	w7, ls
-               	uxtb	w8, w7
-               	add	w7, w5, w8
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
-               	fcmp	s0, s1
                	cset	w5, eq
-               	uxtb	w8, w5
-               	add	w5, w7, w8
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
+               	uxtb	w6, w5
+               	mov	x5, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+<L3>:
                	fcmp	s0, s1
                	cset	w6, ne
                	uxtb	w7, w6
-               	add	w2, w5, w7
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fcmp	s0, s1
+               	cset	w6, ls
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	fcmp	s1, s0
+               	cset	w6, ls
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L14>
+               	mov	x6, #0x0                ; =0
+               	b	 <L15>
+<L14>:
+               	mov	x6, #0x1                ; =1
+<L15>:
+               	fcmp	s0, s1
+               	cset	w7, ls
+               	cbnz	w7,  <L16>
+               	mov	x7, x6
+               	b	 <L17>
+<L16>:
+               	add	w7, w6, #0x2
+<L17>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+               	cbnz	w6,  <L18>
+               	mov	x6, x7
+               	b	 <L19>
+<L18>:
+               	add	w6, w7, #0x4
+<L19>:
+               	fcmp	s1, s0
+               	cset	w7, ls
+               	cbnz	w7,  <L20>
+               	mov	x7, x6
+               	b	 <L21>
+<L20>:
+               	add	w7, w6, #0x8
+<L21>:
+               	fcmp	s0, s1
+               	cset	w6, eq
+               	cbnz	w6,  <L22>
+               	mov	x6, x7
+               	b	 <L23>
+<L22>:
+               	add	w6, w7, #0x10
+<L23>:
+               	fcmp	s0, s1
+               	cset	w7, ne
+               	cbnz	w7,  <L24>
+               	mov	x7, x6
+               	b	 <L25>
+<L24>:
+               	add	w7, w6, #0x20
+<L25>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L28>
+               	b	 <L29>
+<L28>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+<L29>:
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L32>
+               	fcmp	s1, s0
+               	cset	w7, mi
+               	b	 <L33>
+<L32>:
+               	mov	x7, x6
+<L33>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w17, w6
+               	cmp	w17, #0x1
+               	cset	w7, ne
+               	uxtb	w6, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	fcmp	s0, s0
+               	cset	w6, eq
+               	cbnz	w6,  <L38>
+               	b	 <L39>
+<L38>:
+               	fcmp	s1, s1
+               	cset	w6, eq
+<L39>:
+               	uxtb	w7, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	fcmp	s0, s0
+               	cset	w6, ne
+               	cbnz	w6,  <L42>
+               	fcmp	s1, s1
+               	cset	w7, ne
+               	b	 <L43>
+<L42>:
+               	mov	x7, x6
+<L43>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L44>
+<L45>:
                	add	w4, w4, #0x1
+               	mov	x2, x5
                	cmp	w4, #0xc
-               	b.lo	 <L50>
+               	b.lo	 <L1>
+<L46>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0xc
+               	b.lo	 <L0>
+<L47>:
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	ldr	s1, [x1]
+               	fmov	d8, d1
+               	mov	w1, #0x1                ; =1
+               	cmp	w1, #0xc
+               	b.lo	 <L48>
+               	b	 <L53>
+<L48>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s1, [x3]
+               	fcmp	s1, s0
+               	cset	w2, mi
+               	cbnz	w2,  <L49>
+               	fmov	d1, d0
+               	b	 <L50>
+<L49>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s1, [x3]
+<L50>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s2, [x3]
+               	fcmp	s8, s2
+               	cset	w2, mi
+               	cbnz	w2,  <L51>
+               	fmov	d2, d8
+               	b	 <L52>
 <L51>:
-               	add	w0, w0, #0x1
-               	mov	x1, x2
-               	cmp	w0, #0xc
-               	b.lo	 <L49>
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s2, [x3]
 <L52>:
-               	mov	x0, x20
+               	add	w1, w1, #0x1
+               	fmov	d0, d1
+               	fmov	d8, d2
+               	cmp	w1, #0xc
+               	b.lo	 <L48>
 <L53>:
                	bl	 <L53>
-               	ldp	d8, d9, [x29, #-0x78]
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldur	x25, [x29, #-0x68]
+               	fmov	s0, s8
+<L54>:
+               	bl	 <L54>
+               	mov	w1, #0x0                ; =0
+               	mov	w2, #0x0                ; =0
+               	cmp	w2, #0xc
+               	b.lo	 <L55>
+               	b	 <L58>
+<L55>:
+               	mov	w3, w2
+               	add	x4, x19, x3, lsl #2
+               	mov	x3, x1
+               	mov	w5, #0x0                ; =0
+               	cmp	w5, #0xc
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	ldr	s0, [x4]
+               	mov	w6, w5
+               	add	x7, x19, x6, lsl #2
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w8, w6
+               	add	w6, w3, w8
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	add	w8, w6, w12
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w6, eq
+               	uxtb	w12, w6
+               	add	w6, w8, w12
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w7, ne
+               	uxtb	w8, w7
+               	add	w3, w6, w8
+               	add	w5, w5, #0x1
+               	cmp	w5, #0xc
+               	b.lo	 <L56>
+<L57>:
+               	add	w2, w2, #0x1
+               	mov	x1, x3
+               	cmp	w2, #0xc
+               	b.lo	 <L55>
+<L58>:
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L59>
+               	b	 <L60>
+<L59>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L59>
+<L60>:
+               	ldur	d8, [x29, #-0x40]
+               	ldur	x19, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/float/cmp_f64.dis
+++ b/test/golden/aarch64-darwin/float/cmp_f64.dis
@@ -3,32 +3,56 @@ float/cmp_f64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.float.cmp_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.cmp_f64.checksum>:
@@ -38,459 +62,675 @@ Disassembly of section __TEXT,__text:
                	stp	x19, x20, [x29, #-0x90]
                	stp	x21, x22, [x29, #-0xa0]
                	stp	x23, x24, [x29, #-0xb0]
-               	stp	x25, x26, [x29, #-0xc0]
-               	stp	d8, d9, [x29, #-0xd0]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x21, x29, #0x60
-               	add	x1, x21, #0x0
+               	stur	x25, [x29, #-0xb8]
+               	stp	d8, d9, [x29, #-0xc8]
+               	mov	w19, w0
+               	sub	x20, x29, #0x80
+               	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L1>:
+<L0>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x17, #-0x10000000000000 ; =-4503599627370496
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x0
+               	add	x1, x20, #0x0
                	str	d0, [x1]
                	mov	x17, #-0x4010000000000000 ; =-4616189618054758400
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x8
+               	add	x1, x20, #0x8
                	str	d0, [x1]
                	mov	x17, #-0x7ff0000000000000 ; =-9218868437227405312
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x10
+               	add	x1, x20, #0x10
                	str	d0, [x1]
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x8000, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x18
+               	add	x1, x20, #0x18
                	str	d0, [x1]
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x20
+               	add	x1, x20, #0x20
                	str	d0, [x1]
-               	fmov	d0, x19
-               	add	x1, x21, #0x28
+               	fmov	d0, x0
+               	add	x1, x20, #0x28
                	str	d0, [x1]
                	mov	x17, #0x1               ; =1
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x30
+               	add	x1, x20, #0x30
                	str	d0, [x1]
                	mov	x17, #0x3ff0000000000000 ; =4607182418800017408
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x38
+               	add	x1, x20, #0x38
                	str	d0, [x1]
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fef, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x40
+               	add	x1, x20, #0x40
                	str	d0, [x1]
                	mov	x17, #0x7ff0000000000000 ; =9218868437227405312
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x48
+               	add	x1, x20, #0x48
                	str	d0, [x1]
                	mov	x17, #0x7ff8000000000000 ; =9221120237041090560
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x50
+               	add	x1, x20, #0x50
                	str	d0, [x1]
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x7ff0, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x58
-               	str	d0, [x1]
-               	mov	x19, x0
+               	add	x0, x20, #0x58
+               	str	d0, [x0]
+               	mov	x21, #0x2325            ; =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0xc
-               	b.lo	 <L2>
-               	b	 <L35>
-<L2>:
-               	add	x23, x21, x22, lsl #3
-               	mov	x24, x19
+               	b.lo	 <L1>
+               	b	 <L46>
+<L1>:
+               	add	x23, x20, x22, lsl #3
+               	mov	x24, x21
                	mov	x25, #0x0               ; =0
                	cmp	x25, #0xc
-               	b.lo	 <L3>
-               	b	 <L34>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L45>
+<L2>:
                	ldr	d8, [x23]
-               	add	x0, x21, x25, lsl #3
+               	add	x0, x20, x25, lsl #3
                	ldr	d9, [x0]
                	fcmp	d8, d9
-               	cset	w1, eq
+               	cset	w0, eq
+               	uxtb	w1, w0
                	mov	x0, x24
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	fcmp	d8, d9
                	cset	w1, ne
-<L5>:
-               	bl	 <L5>
-               	fcmp	d8, d9
-               	cset	w26, mi
-               	mov	x1, x26
-<L6>:
-               	bl	 <L6>
-               	fcmp	d8, d9
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	fcmp	d9, d8
-               	cset	w1, mi
-<L8>:
-               	bl	 <L8>
-               	fcmp	d9, d8
-               	cset	w1, ls
-<L9>:
-               	bl	 <L9>
-               	cbnz	w26,  <L10>
+               	uxtb	w2, w1
                	mov	x1, #0x0                ; =0
-               	b	 <L11>
-<L10>:
-               	mov	x1, #0x1                ; =1
-<L11>:
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+<L6>:
                	fcmp	d8, d9
-               	cset	w2, ls
-               	cbnz	w2,  <L12>
-               	mov	x2, x1
-               	b	 <L13>
-<L12>:
-               	add	w2, w1, #0x2
-<L13>:
+               	cset	w1, mi
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	fcmp	d8, d9
+               	cset	w1, ls
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
                	fcmp	d9, d8
                	cset	w1, mi
-               	cbnz	w1,  <L14>
+               	uxtb	w2, w1
                	mov	x1, x2
-               	b	 <L15>
+<L11>:
+               	bl	 <L11>
+               	fcmp	d9, d8
+               	cset	w1, ls
+<L12>:
+               	bl	 <L12>
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L13>
+               	mov	x1, #0x0                ; =0
+               	b	 <L14>
+<L13>:
+               	mov	x1, #0x1                ; =1
 <L14>:
-               	add	w1, w2, #0x4
+               	fcmp	d8, d9
+               	cset	w2, ls
+               	cbnz	w2,  <L15>
+               	mov	x2, x1
+               	b	 <L16>
 <L15>:
+               	add	w2, w1, #0x2
+<L16>:
+               	fcmp	d9, d8
+               	cset	w1, mi
+               	cbnz	w1,  <L17>
+               	mov	x1, x2
+               	b	 <L18>
+<L17>:
+               	add	w1, w2, #0x4
+<L18>:
                	fcmp	d9, d8
                	cset	w2, ls
-               	cbnz	w2,  <L16>
+               	cbnz	w2,  <L19>
                	mov	x2, x1
-               	b	 <L17>
-<L16>:
+               	b	 <L20>
+<L19>:
                	add	w2, w1, #0x8
-<L17>:
+<L20>:
                	fcmp	d8, d9
                	cset	w1, eq
-               	cbnz	w1,  <L18>
+               	cbnz	w1,  <L21>
                	mov	x1, x2
-               	b	 <L19>
-<L18>:
+               	b	 <L22>
+<L21>:
                	add	w1, w2, #0x10
-<L19>:
+<L22>:
                	fcmp	d8, d9
                	cset	w2, ne
-               	cbnz	w2,  <L20>
+               	cbnz	w2,  <L23>
                	mov	x2, x1
-               	b	 <L21>
-<L20>:
-               	add	w2, w1, #0x20
-<L21>:
-               	mov	x1, x2
-<L22>:
-               	bl	 <L22>
-               	fcmp	d8, d9
-               	cset	w1, mi
-               	cbnz	w1,  <L23>
                	b	 <L24>
 <L23>:
-               	fcmp	d9, d8
-               	cset	w1, mi
+               	add	w2, w1, #0x20
 <L24>:
-               	bl	 <L24>
-               	fcmp	d8, d9
-               	cset	w1, mi
-               	cbnz	w1,  <L25>
-               	fcmp	d9, d8
-               	cset	w2, mi
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
                	b	 <L26>
 <L25>:
-               	mov	x2, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	mov	x1, x2
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L27>
+               	b	 <L28>
 <L27>:
-               	bl	 <L27>
+               	fcmp	d9, d8
+               	cset	w1, mi
+<L28>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L31>
+               	fcmp	d9, d8
+               	cset	w2, mi
+               	b	 <L32>
+<L31>:
+               	mov	x2, x1
+<L32>:
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+<L34>:
                	fcmp	d8, d9
                	cset	w1, mi
                	uxtb	w17, w1
                	cmp	w17, #0x1
                	cset	w2, ne
-               	mov	x1, x2
-<L28>:
-               	bl	 <L28>
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
                	fcmp	d8, d8
                	cset	w1, eq
-               	cbnz	w1,  <L29>
-               	b	 <L30>
-<L29>:
+               	cbnz	w1,  <L37>
+               	b	 <L38>
+<L37>:
                	fcmp	d9, d9
                	cset	w1, eq
-<L30>:
-               	bl	 <L30>
+<L38>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+<L40>:
                	fcmp	d8, d8
                	cset	w1, ne
-               	cbnz	w1,  <L31>
+               	cbnz	w1,  <L41>
                	fcmp	d9, d9
                	cset	w2, ne
-               	b	 <L32>
-<L31>:
+               	b	 <L42>
+<L41>:
                	mov	x2, x1
-<L32>:
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
+<L42>:
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+<L44>:
                	add	x25, x25, #0x1
                	mov	x24, x0
                	cmp	x25, #0xc
-               	b.lo	 <L3>
-<L34>:
-               	add	x22, x22, #0x1
-               	mov	x19, x24
-               	cmp	x22, #0xc
                	b.lo	 <L2>
-<L35>:
-               	sub	x22, x29, #0x80
+<L45>:
+               	add	x22, x22, #0x1
+               	mov	x21, x24
+               	cmp	x22, #0xc
+               	b.lo	 <L1>
+<L46>:
+               	sub	x22, x29, #0x20
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
                	str	xzr, [x22, #0x10]
                	str	xzr, [x22, #0x18]
                	mov	w17, #-0x800000         ; =-8388608
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x0
                	str	s0, [x0]
                	mov	w17, #-0x40800000       ; =-1082130432
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x4
                	str	s0, [x0]
                	mov	w17, #-0x80000000       ; =-2147483648
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x8
                	str	s0, [x0]
-               	fmov	s0, w20
+               	fmov	s0, w19
                	add	x0, x22, #0xc
                	str	s0, [x0]
                	mov	w17, #0x1               ; =1
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x10
                	str	s0, [x0]
                	mov	w17, #0x3f800000        ; =1065353216
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x14
                	str	s0, [x0]
                	mov	w17, #0x7f800000        ; =2139095040
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x18
                	str	s0, [x0]
                	mov	w17, #0x7fc00000        ; =2143289344
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x1c
                	str	s0, [x0]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0xc
-               	b.lo	 <L36>
-               	b	 <L45>
-<L36>:
-               	add	x23, x21, x20, lsl #3
-               	mov	x24, x19
+               	mov	x19, #0x0               ; =0
+               	cmp	x19, #0xc
+               	b.lo	 <L47>
+               	b	 <L59>
+<L47>:
+               	add	x23, x20, x19, lsl #3
+               	mov	x24, x21
                	mov	x25, #0x0               ; =0
                	cmp	x25, #0x8
-               	b.lo	 <L37>
-               	b	 <L44>
-<L37>:
+               	b.lo	 <L48>
+               	b	 <L58>
+<L48>:
                	ldr	d8, [x23]
                	add	x0, x22, x25, lsl #2
-               	ldr	s0, [x0]
-               	fcvt	d9, s0
-               	fcmp	d8, d9
-               	cset	w1, eq
+               	ldr	s9, [x0]
+               	fcvt	d0, s9
+               	fcmp	d8, d0
+               	cset	w0, eq
+               	uxtb	w1, w0
                	mov	x0, x24
-<L38>:
-               	bl	 <L38>
-               	fcmp	d8, d9
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, ne
-<L39>:
-               	bl	 <L39>
-               	fcmp	d8, d9
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L51>
+               	b	 <L52>
+<L51>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L51>
+<L52>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, mi
-<L40>:
-               	bl	 <L40>
-               	fcmp	d8, d9
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L53>
+               	b	 <L54>
+<L53>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L53>
+<L54>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, ls
-<L41>:
-               	bl	 <L41>
-               	fcmp	d9, d8
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
+               	fcvt	d0, s9
+               	fcmp	d0, d8
                	cset	w1, mi
-<L42>:
-               	bl	 <L42>
-               	fcmp	d9, d8
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
+               	fcvt	d0, s9
+               	fcmp	d0, d8
                	cset	w1, ls
-<L43>:
-               	bl	 <L43>
+<L57>:
+               	bl	 <L57>
                	add	x25, x25, #0x1
                	mov	x24, x0
                	cmp	x25, #0x8
-               	b.lo	 <L37>
-<L44>:
-               	add	x20, x20, #0x1
-               	mov	x19, x24
-               	cmp	x20, #0xc
-               	b.lo	 <L36>
-<L45>:
-               	add	x0, x21, #0x0
+               	b.lo	 <L48>
+<L58>:
+               	add	x19, x19, #0x1
+               	mov	x21, x24
+               	cmp	x19, #0xc
+               	b.lo	 <L47>
+<L59>:
+               	add	x0, x20, #0x0
                	ldr	d0, [x0]
                	ldr	d1, [x0]
                	fmov	d8, d1
                	mov	x0, #0x1                ; =1
                	cmp	x0, #0xc
-               	b.lo	 <L46>
-               	b	 <L51>
-<L46>:
-               	add	x1, x21, x0, lsl #3
+               	b.lo	 <L60>
+               	b	 <L65>
+<L60>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d1, [x1]
                	fcmp	d1, d0
                	cset	w1, mi
-               	cbnz	w1,  <L47>
+               	cbnz	w1,  <L61>
                	fmov	d1, d0
-               	b	 <L48>
-<L47>:
-               	add	x1, x21, x0, lsl #3
+               	b	 <L62>
+<L61>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d1, [x1]
-<L48>:
-               	add	x1, x21, x0, lsl #3
+<L62>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d2, [x1]
                	fcmp	d8, d2
                	cset	w1, mi
-               	cbnz	w1,  <L49>
+               	cbnz	w1,  <L63>
                	fmov	d2, d8
-               	b	 <L50>
-<L49>:
-               	add	x1, x21, x0, lsl #3
+               	b	 <L64>
+<L63>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d2, [x1]
-<L50>:
+<L64>:
                	add	x0, x0, #0x1
                	fmov	d0, d1
                	fmov	d8, d2
                	cmp	x0, #0xc
-               	b.lo	 <L46>
-<L51>:
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L53>
-               	mov	x0, x19
-<L52>:
-               	bl	 <L52>
-               	mov	x20, x0
-               	b	 <L55>
-<L53>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L54>:
-               	bl	 <L54>
-               	mov	x20, x0
-<L55>:
-               	fcmp	d8, d8
-               	cset	w0, ne
-               	cbnz	w0,  <L57>
-               	mov	x0, x20
+               	b.lo	 <L60>
+<L65>:
+               	mov	x0, x21
+<L66>:
+               	bl	 <L66>
                	fmov	d0, d8
-<L56>:
-               	bl	 <L56>
-               	mov	x19, x0
-               	b	 <L59>
-<L57>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L58>:
-               	bl	 <L58>
-               	mov	x19, x0
-<L59>:
+<L67>:
+               	bl	 <L67>
                	mov	w1, #0x0                ; =0
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, #0xc
-               	b.lo	 <L60>
-               	b	 <L63>
-<L60>:
-               	add	x2, x21, x0, lsl #3
-               	mov	x3, x1
-               	mov	x4, #0x0                ; =0
-               	cmp	x4, #0xc
-               	b.lo	 <L61>
-               	b	 <L62>
-<L61>:
-               	ldr	d0, [x2]
-               	add	x5, x21, x4, lsl #3
-               	ldr	d1, [x5]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0xc
+               	b.lo	 <L68>
+               	b	 <L71>
+<L68>:
+               	add	x3, x20, x2, lsl #3
+               	mov	x4, x1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0xc
+               	b.lo	 <L69>
+               	b	 <L70>
+<L69>:
+               	ldr	d0, [x3]
+               	add	x6, x20, x5, lsl #3
+               	ldr	d1, [x6]
                	fcmp	d0, d1
-               	cset	w6, mi
-               	uxtb	w7, w6
-               	add	w6, w3, w7
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
-               	fcmp	d0, d1
-               	cset	w7, ls
+               	cset	w7, mi
                	uxtb	w8, w7
-               	add	w7, w6, w8
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
+               	add	w7, w4, w8
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
                	fcmp	d0, d1
-               	cset	w6, eq
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	add	w8, w7, w12
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
+               	fcmp	d0, d1
+               	cset	w7, eq
+               	uxtb	w12, w7
+               	add	w7, w8, w12
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
+               	fcmp	d0, d1
+               	cset	w6, ne
                	uxtb	w8, w6
-               	add	w6, w7, w8
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
-               	fcmp	d0, d1
-               	cset	w5, ne
-               	uxtb	w7, w5
-               	add	w3, w6, w7
-               	add	x4, x4, #0x1
-               	cmp	x4, #0xc
-               	b.lo	 <L61>
-<L62>:
-               	add	x0, x0, #0x1
-               	mov	x1, x3
-               	cmp	x0, #0xc
-               	b.lo	 <L60>
-<L63>:
-               	mov	x0, x19
-<L64>:
-               	bl	 <L64>
-               	ldp	d8, d9, [x29, #-0xd0]
+               	add	w4, w7, w8
+               	add	x5, x5, #0x1
+               	cmp	x5, #0xc
+               	b.lo	 <L69>
+<L70>:
+               	add	x2, x2, #0x1
+               	mov	x1, x4
+               	cmp	x2, #0xc
+               	b.lo	 <L68>
+<L71>:
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L72>
+<L73>:
+               	ldp	d8, d9, [x29, #-0xc8]
                	ldp	x19, x20, [x29, #-0x90]
                	ldp	x21, x22, [x29, #-0xa0]
                	ldp	x23, x24, [x29, #-0xb0]
-               	ldp	x25, x26, [x29, #-0xc0]
+               	ldur	x25, [x29, #-0xb8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/float/special_f32.dis
+++ b/test/golden/aarch64-darwin/float/special_f32.dis
@@ -8,30 +8,54 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.float.special_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.special_f32.checksum>:
@@ -41,707 +65,743 @@ Disassembly of section __TEXT,__text:
                	stp	x19, x20, [x29, #-0x60]
                	stp	x21, x22, [x29, #-0x70]
                	stp	x23, x24, [x29, #-0x80]
-               	stp	x25, x26, [x29, #-0x90]
-               	stp	d8, d9, [x29, #-0xa0]
-               	stp	d10, d11, [x29, #-0xb0]
-               	stp	d12, d13, [x29, #-0xc0]
-               	stp	d14, d15, [x29, #-0xd0]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	w21, w19
+               	stur	x25, [x29, #-0x88]
+               	stp	d8, d9, [x29, #-0x98]
+               	stp	d10, d11, [x29, #-0xa8]
+               	stp	d12, d13, [x29, #-0xb8]
+               	stp	d14, d15, [x29, #-0xc8]
+               	mov	w19, w0
                	mov	w17, #0x3f800000        ; =1065353216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s8, w0
                	mov	w17, #-0x40800000       ; =-1082130432
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s9, w0
-               	fmov	s10, w21
+               	fmov	s10, w19
                	mov	w17, #-0x80000000       ; =-2147483648
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s11, w0
                	mov	w17, #0x7f800000        ; =2139095040
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s12, w0
                	mov	w17, #-0x800000         ; =-8388608
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s13, w0
                	mov	w17, #0x7fc00000        ; =2143289344
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s14, w0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s15, w0
                	mov	w17, #0x800000          ; =8388608
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x30]
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x40]
                	mov	w17, #0x1               ; =1
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x50]
-               	fcmp	s10, s10
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	fmov	s0, s10
+<L0>:
+               	bl	 <L0>
+               	fmov	s0, s11
 <L1>:
                	bl	 <L1>
-               	mov	x19, x0
-               	b	 <L4>
+               	fadd	s0, s10, s10
 <L2>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L2>
+               	fadd	s0, s10, s11
 <L3>:
                	bl	 <L3>
-               	mov	x19, x0
+               	fadd	s0, s11, s10
 <L4>:
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x19
-               	fmov	s0, s11
+               	bl	 <L4>
+               	fadd	s0, s11, s11
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
+               	fsub	s0, s10, s10
 <L6>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L6>
+               	fsub	s0, s10, s11
 <L7>:
                	bl	 <L7>
-               	mov	x20, x0
+               	fsub	s0, s11, s10
 <L8>:
-               	fadd	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
+               	bl	 <L8>
+               	fsub	s0, s11, s11
 <L9>:
                	bl	 <L9>
-               	mov	x19, x0
-               	b	 <L12>
+               	fmul	s0, s10, s8
 <L10>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L10>
+               	fmul	s0, s10, s9
 <L11>:
                	bl	 <L11>
-               	mov	x19, x0
+               	fmul	s0, s11, s8
 <L12>:
-               	fadd	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x19
+               	bl	 <L12>
+               	fmul	s0, s11, s9
 <L13>:
                	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
+               	fmul	s0, s11, s11
 <L14>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L14>
+               	fmul	s0, s10, s11
 <L15>:
                	bl	 <L15>
-               	mov	x20, x0
+               	fneg	s0, s10
 <L16>:
-               	fadd	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
-               	mov	x0, x20
+               	bl	 <L16>
+               	fneg	s0, s11
 <L17>:
                	bl	 <L17>
-               	mov	x19, x0
-               	b	 <L20>
+               	fdiv	s0, s10, s8
 <L18>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L18>
+               	fdiv	s0, s10, s9
 <L19>:
                	bl	 <L19>
-               	mov	x19, x0
+               	fdiv	s0, s11, s8
 <L20>:
-               	fadd	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x19
+               	bl	 <L20>
+               	fdiv	s0, s11, s9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
-<L22>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fsub	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x19, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L27>:
-               	bl	 <L27>
-               	mov	x19, x0
-<L28>:
-               	fsub	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	s0, s11, s10
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	fsub	s0, s11, s11
-<L34>:
-               	bl	 <L34>
-               	fmul	s0, s10, s8
-<L35>:
-               	bl	 <L35>
-               	fmul	s0, s10, s9
-<L36>:
-               	bl	 <L36>
-               	fmul	s0, s11, s8
-<L37>:
-               	bl	 <L37>
-               	fmul	s0, s11, s9
-<L38>:
-               	bl	 <L38>
-               	fmul	s0, s11, s11
-<L39>:
-               	bl	 <L39>
-               	fmul	s0, s10, s11
-<L40>:
-               	bl	 <L40>
-               	fneg	s0, s10
-<L41>:
-               	bl	 <L41>
-               	fneg	s0, s11
-<L42>:
-               	bl	 <L42>
-               	fdiv	s0, s10, s8
-<L43>:
-               	bl	 <L43>
-               	fdiv	s0, s10, s9
-<L44>:
-               	bl	 <L44>
-               	fdiv	s0, s11, s8
-<L45>:
-               	bl	 <L45>
-               	fdiv	s0, s11, s9
-<L46>:
-               	bl	 <L46>
                	fcmp	s10, s11
                	cset	w1, eq
-<L47>:
-               	bl	 <L47>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	fcmp	s10, s11
                	cset	w1, mi
-<L48>:
-               	bl	 <L48>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	fcmp	s11, s10
                	cset	w1, mi
-<L49>:
-               	bl	 <L49>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
                	fmov	s0, s12
-<L50>:
-               	bl	 <L50>
+<L28>:
+               	bl	 <L28>
                	fmov	s0, s13
-<L51>:
-               	bl	 <L51>
+<L29>:
+               	bl	 <L29>
                	fneg	s0, s12
-<L52>:
-               	bl	 <L52>
+<L30>:
+               	bl	 <L30>
                	fdiv	s0, s8, s10
-<L53>:
-               	bl	 <L53>
+<L31>:
+               	bl	 <L31>
                	fdiv	s0, s8, s11
-<L54>:
-               	bl	 <L54>
+<L32>:
+               	bl	 <L32>
                	fdiv	s0, s9, s10
-<L55>:
-               	bl	 <L55>
+<L33>:
+               	bl	 <L33>
                	fdiv	s0, s9, s11
-<L56>:
-               	bl	 <L56>
+<L34>:
+               	bl	 <L34>
                	fadd	s0, s12, s8
-<L57>:
-               	bl	 <L57>
+<L35>:
+               	bl	 <L35>
                	fadd	s0, s12, s12
-<L58>:
-               	bl	 <L58>
+<L36>:
+               	bl	 <L36>
                	fsub	s0, s12, s13
-<L59>:
-               	bl	 <L59>
+<L37>:
+               	bl	 <L37>
                	fmul	s0, s12, s12
-<L60>:
-               	bl	 <L60>
+<L38>:
+               	bl	 <L38>
                	fmul	s0, s12, s13
-<L61>:
-               	bl	 <L61>
+<L39>:
+               	bl	 <L39>
                	fmul	s0, s12, s9
-<L62>:
-               	bl	 <L62>
+<L40>:
+               	bl	 <L40>
                	fdiv	s0, s8, s12
-<L63>:
-               	bl	 <L63>
+<L41>:
+               	bl	 <L41>
                	fdiv	s0, s9, s12
-<L64>:
-               	bl	 <L64>
+<L42>:
+               	bl	 <L42>
                	fdiv	s0, s8, s13
-<L65>:
-               	bl	 <L65>
+<L43>:
+               	bl	 <L43>
                	fdiv	s0, s12, s8
-<L66>:
-               	bl	 <L66>
+<L44>:
+               	bl	 <L44>
                	fadd	s0, s15, s15
-<L67>:
-               	bl	 <L67>
+<L45>:
+               	bl	 <L45>
                	fcmp	s15, s12
                	cset	w1, mi
-<L68>:
-               	bl	 <L68>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	fmov	s31, wzr
                	fsub	s0, s31, s15
                	fcmp	s13, s0
                	cset	w1, mi
-<L69>:
-               	bl	 <L69>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L47>:
+               	bl	 <L47>
                	fsub	s0, s12, s12
-<L70>:
-               	bl	 <L70>
+<L48>:
+               	bl	 <L48>
                	fadd	s0, s13, s12
-<L71>:
-               	bl	 <L71>
+<L49>:
+               	bl	 <L49>
                	fmul	s0, s12, s10
-<L72>:
-               	bl	 <L72>
+<L50>:
+               	bl	 <L50>
                	fmul	s0, s13, s11
-<L73>:
-               	bl	 <L73>
+<L51>:
+               	bl	 <L51>
                	fdiv	s0, s12, s12
-<L74>:
-               	bl	 <L74>
+<L52>:
+               	bl	 <L52>
                	fdiv	s0, s10, s10
-<L75>:
-               	bl	 <L75>
+<L53>:
+               	bl	 <L53>
                	fdiv	s0, s11, s10
-<L76>:
-               	bl	 <L76>
+<L54>:
+               	bl	 <L54>
                	fmov	w1, s14
-<L77>:
-               	bl	 <L77>
+               	mov	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
                	fcmp	s14, s14
                	cset	w1, ne
-<L78>:
-               	bl	 <L78>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
                	fcmp	s14, s14
                	cset	w1, eq
-<L79>:
-               	bl	 <L79>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L57>:
+               	bl	 <L57>
                	fcmp	s14, s14
                	cset	w1, mi
-<L80>:
-               	bl	 <L80>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L58>:
+               	bl	 <L58>
                	fcmp	s14, s14
                	cset	w1, ls
-<L81>:
-               	bl	 <L81>
-               	fneg	s9, s14
-               	fmov	w1, s9
-<L82>:
-               	bl	 <L82>
-               	fneg	s0, s9
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L59>:
+               	bl	 <L59>
+               	fneg	s0, s14
                	fmov	w1, s0
-<L83>:
-               	bl	 <L83>
+               	mov	w2, w1
+               	mov	x1, x2
+<L60>:
+               	bl	 <L60>
+               	fneg	s0, s14
+               	fneg	s4, s0
+               	fmov	w1, s4
+               	mov	w2, w1
+               	mov	x1, x2
+<L61>:
+               	bl	 <L61>
                	fadd	s0, s14, s8
-<L84>:
-               	bl	 <L84>
+<L62>:
+               	bl	 <L62>
                	fadd	s0, s8, s14
-<L85>:
-               	bl	 <L85>
+<L63>:
+               	bl	 <L63>
                	fmul	s0, s14, s10
-<L86>:
-               	bl	 <L86>
+<L64>:
+               	bl	 <L64>
                	fsub	s0, s14, s14
-<L87>:
-               	bl	 <L87>
+<L65>:
+               	bl	 <L65>
                	fdiv	s0, s14, s14
-<L88>:
-               	bl	 <L88>
+<L66>:
+               	bl	 <L66>
                	fdiv	s0, s14, s12
-<L89>:
-               	bl	 <L89>
+<L67>:
+               	bl	 <L67>
                	ldur	s0, [x29, #-0x50]
-<L90>:
-               	bl	 <L90>
+<L68>:
+               	bl	 <L68>
                	ldur	s0, [x29, #-0x40]
-<L91>:
-               	bl	 <L91>
+<L69>:
+               	bl	 <L69>
                	ldur	s0, [x29, #-0x30]
-<L92>:
-               	bl	 <L92>
+<L70>:
+               	bl	 <L70>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-<L93>:
-               	bl	 <L93>
+<L71>:
+               	bl	 <L71>
                	ldur	s31, [x29, #-0x30]
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
-<L94>:
-               	bl	 <L94>
+<L72>:
+               	bl	 <L72>
                	ldur	s31, [x29, #-0x50]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-<L95>:
-               	bl	 <L95>
+<L73>:
+               	bl	 <L73>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #1.50000000
                	fmul	s0, s31, s30
-<L96>:
-               	bl	 <L96>
+<L74>:
+               	bl	 <L74>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #0.50000000
                	fmul	s0, s31, s30
-<L97>:
-               	bl	 <L97>
+<L75>:
+               	bl	 <L75>
                	ldur	s31, [x29, #-0x50]
                	fneg	s0, s31
-<L98>:
-               	bl	 <L98>
+<L76>:
+               	bl	 <L76>
                	ldur	s31, [x29, #-0x50]
                	mov	w16, #0x4b000000        ; =1258291200
                	fmov	s30, w16
                	fmul	s0, s31, s30
-<L99>:
-               	bl	 <L99>
+<L77>:
+               	bl	 <L77>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x30]
                	fdiv	s0, s31, s30
-<L100>:
-               	bl	 <L100>
+<L78>:
+               	bl	 <L78>
                	ldur	s30, [x29, #-0x50]
                	fcmp	s10, s30
                	cset	w1, mi
-<L101>:
-               	bl	 <L101>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
                	ldur	s31, [x29, #-0x50]
                	fcmp	s31, s10
                	cset	w1, eq
-<L102>:
-               	bl	 <L102>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L80>:
+               	bl	 <L80>
                	fmov	s31, wzr
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
                	fcmp	s0, s11
                	cset	w1, mi
-<L103>:
-               	bl	 <L103>
-               	mov	x19, x0
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L81>:
+               	bl	 <L81>
+               	mov	x20, x0
                	ldur	d9, [x29, #-0x30]
-               	mov	w20, #0x0               ; =0
-               	cmp	w20, #0x1e
-               	b.lo	 <L104>
-               	b	 <L109>
-<L104>:
+               	mov	w21, #0x0               ; =0
+               	cmp	w21, #0x1e
+               	b.lo	 <L82>
+               	b	 <L84>
+<L82>:
                	fmov	s30, #0.50000000
-               	fmul	s11, s9, s30
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x19
-               	fmov	s0, s11
-<L105>:
-               	bl	 <L105>
-               	mov	x22, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L107>:
-               	bl	 <L107>
-               	mov	x22, x0
-<L108>:
-               	add	w20, w20, #0x1
-               	mov	x19, x22
-               	fmov	d9, d11
-               	cmp	w20, #0x1e
-               	b.lo	 <L104>
-<L109>:
-               	sub	x20, x29, #0x20
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	add	x0, x20, #0x0
-               	str	wzr, [x0]
-               	add	x0, x20, #0x4
+               	fmul	s9, s9, s30
+               	mov	x0, x20
+               	fmov	s0, s9
+<L83>:
+               	bl	 <L83>
+               	add	w21, w21, #0x1
+               	mov	x20, x0
+               	cmp	w21, #0x1e
+               	b.lo	 <L82>
+<L84>:
+               	sub	x0, x29, #0x20
+               	str	xzr, [x0]
+               	str	xzr, [x0, #0x8]
+               	str	xzr, [x0, #0x10]
+               	str	xzr, [x0, #0x18]
+               	add	x1, x0, #0x0
+               	str	wzr, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x0]
-               	add	x0, x20, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x1               ; =1
-               	str	w17, [x0]
-               	add	x0, x20, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x7f800000        ; =2139095040
-               	str	w17, [x0]
-               	add	x0, x20, #0x10
+               	str	w17, [x1]
+               	add	x1, x0, #0x10
                	mov	w17, #-0x800000         ; =-8388608
-               	str	w17, [x0]
-               	add	x0, x20, #0x14
+               	str	w17, [x1]
+               	add	x1, x0, #0x14
                	mov	w17, #0x7fc00000        ; =2143289344
-               	str	w17, [x0]
-               	add	x0, x20, #0x18
+               	str	w17, [x1]
+               	add	x1, x0, #0x18
                	mov	w17, #0xdead            ; =57005
                	movk	w17, #0xffc0, lsl #16
-               	str	w17, [x0]
-               	add	x0, x20, #0x1c
+               	str	w17, [x1]
+               	add	x1, x0, #0x1c
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x7f80, lsl #16
-               	str	w17, [x0]
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x8
-               	b.lo	 <L110>
-               	b	 <L112>
-<L110>:
-               	mov	w0, w22
-               	add	x1, x20, x0, lsl #2
-               	ldr	w0, [x1]
-               	add	w1, w0, w21
-               	fmov	s0, w1
-               	fmov	w1, s0
-               	mov	x0, x19
-<L111>:
-               	bl	 <L111>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x8
-               	b.lo	 <L110>
-<L112>:
+               	str	w17, [x1]
+               	mov	w1, #0x0                ; =0
+               	cmp	w1, #0x8
+               	b.lo	 <L85>
+               	b	 <L88>
+<L85>:
+               	mov	w2, w1
+               	add	x3, x0, x2, lsl #2
+               	ldr	w2, [x3]
+               	add	w3, w2, w19
+               	fmov	s0, w3
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, x20
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L86>
+               	b	 <L87>
+<L86>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L86>
+<L87>:
+               	add	w1, w1, #0x1
+               	mov	x20, x2
+               	cmp	w1, #0x8
+               	b.lo	 <L85>
+<L88>:
                	mov	w17, #0x1000000         ; =16777216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x100, lsl #16
-               	add	w20, w17, w21
+               	add	w21, w17, w19
                	mov	w17, #0x3               ; =3
                	movk	w17, #0x100, lsl #16
-               	add	w22, w17, w21
+               	add	w22, w17, w19
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w23, w17, w21
+               	add	w23, w17, w19
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xfeff, lsl #16
-               	add	w24, w17, w21
+               	add	w24, w17, w19
                	mov	w17, #-0x80000000       ; =-2147483648
-               	add	w25, w17, w21
+               	add	w25, w17, w19
                	ucvtf	s0, w0
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L114>
-               	mov	x0, x19
-<L113>:
-               	bl	 <L113>
-               	mov	x26, x0
-               	b	 <L116>
-<L114>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L115>:
-               	bl	 <L115>
-               	mov	x26, x0
-<L116>:
-               	ucvtf	s0, w20
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L118>
-               	mov	x0, x26
-<L117>:
-               	bl	 <L117>
-               	mov	x19, x0
-               	b	 <L120>
-<L118>:
-               	mov	x0, x26
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-<L120>:
-               	ucvtf	s0, w22
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L122>
-               	mov	x0, x19
-<L121>:
-               	bl	 <L121>
-               	mov	x20, x0
-               	b	 <L124>
-<L122>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L123>:
-               	bl	 <L123>
-               	mov	x20, x0
-<L124>:
-               	ucvtf	s0, w23
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L126>
                	mov	x0, x20
-<L125>:
-               	bl	 <L125>
-               	mov	x19, x0
-               	b	 <L128>
-<L126>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L127>:
-               	bl	 <L127>
-               	mov	x19, x0
-<L128>:
+<L89>:
+               	bl	 <L89>
                	ucvtf	s0, w21
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L130>
-               	mov	x0, x19
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-               	b	 <L132>
-<L130>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-<L132>:
+<L90>:
+               	bl	 <L90>
+               	ucvtf	s0, w22
+<L91>:
+               	bl	 <L91>
+               	ucvtf	s0, w23
+<L92>:
+               	bl	 <L92>
+               	ucvtf	s0, w19
+<L93>:
+               	bl	 <L93>
                	scvtf	s0, w24
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L134>
-               	mov	x0, x20
-<L133>:
-               	bl	 <L133>
-               	mov	x19, x0
-               	b	 <L136>
-<L134>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-<L136>:
+<L94>:
+               	bl	 <L94>
                	scvtf	s0, w25
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L138>
-               	mov	x0, x19
-<L137>:
-               	bl	 <L137>
-               	mov	x20, x0
-               	b	 <L140>
-<L138>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-<L140>:
+<L95>:
+               	bl	 <L95>
                	fmov	s31, #1.50000000
                	fmul	s0, s31, s8
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s31, w16
-               	fmul	s9, s31, s8
+               	fmul	s1, s31, s8
                	adrp	x16, 0x0 <corpus.cases.float.special_f32.opaque_f32>
                	ldr	s31, [x16]
-               	fmul	s11, s31, s8
+               	fmul	s2, s31, s8
                	fmov	s31, wzr
-               	fsub	s12, s31, s0
+               	fsub	s3, s31, s0
                	fmov	s31, #0.50000000
-               	fmul	s13, s31, s8
+               	fmul	s4, s31, s8
                	fcvtzu	w1, s0
-               	mov	x0, x20
-<L141>:
-               	bl	 <L141>
-               	fcvtzu	w1, s9
-<L142>:
-               	bl	 <L142>
-               	fcvtzu	w1, s11
-<L143>:
-               	bl	 <L143>
-               	fcvtzu	w1, s13
-<L144>:
-               	bl	 <L144>
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L96>
+               	b	 <L97>
+<L96>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L96>
+<L97>:
+               	fcvtzu	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L98>
+               	b	 <L99>
+<L98>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L98>
+<L99>:
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L100>
+               	b	 <L101>
+<L100>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L100>
+<L101>:
+               	fcvtzu	w1, s4
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L102>
+               	b	 <L103>
+<L102>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L102>
+<L103>:
                	fcvtzu	w1, s10
-<L145>:
-               	bl	 <L145>
-               	fcvtzs	w1, s12
-<L146>:
-               	bl	 <L146>
-               	fcvtzs	w1, s11
-<L147>:
-               	bl	 <L147>
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L104>
+               	b	 <L105>
+<L104>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L104>
+<L105>:
+               	fcvtzs	w1, s3
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L106>
+               	b	 <L107>
+<L106>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L106>
+<L107>:
+               	fcvtzs	w1, s2
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L108>
+               	b	 <L109>
+<L108>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L108>
+<L109>:
                	fmov	s31, wzr
-               	fsub	s0, s31, s13
+               	fsub	s0, s31, s4
                	fcvtzs	w1, s0
-<L148>:
-               	bl	 <L148>
-               	fcvtzs	x1, s12
-<L149>:
-               	bl	 <L149>
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L110>
+               	b	 <L111>
+<L110>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L110>
+<L111>:
+               	fcvtzs	x1, s3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+               	b	 <L113>
+<L112>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+<L113>:
                	fmov	s31, wzr
-               	fsub	s0, s31, s9
+               	fsub	s0, s31, s1
                	fcvtzs	x1, s0
-<L150>:
-               	bl	 <L150>
-               	ldp	d8, d9, [x29, #-0xa0]
-               	ldp	d10, d11, [x29, #-0xb0]
-               	ldp	d12, d13, [x29, #-0xc0]
-               	ldp	d14, d15, [x29, #-0xd0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+               	b	 <L115>
+<L114>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+<L115>:
+               	ldp	d8, d9, [x29, #-0x98]
+               	ldp	d10, d11, [x29, #-0xa8]
+               	ldp	d12, d13, [x29, #-0xb8]
+               	ldp	d14, d15, [x29, #-0xc8]
                	ldp	x19, x20, [x29, #-0x60]
                	ldp	x21, x22, [x29, #-0x70]
                	ldp	x23, x24, [x29, #-0x80]
-               	ldp	x25, x26, [x29, #-0x90]
+               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/float/special_f64.dis
+++ b/test/golden/aarch64-darwin/float/special_f64.dis
@@ -8,50 +8,70 @@ Disassembly of section __TEXT,__text:
                	ret
 
 <corpus.cases.float.special_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.special_f64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
-               	stp	x19, x20, [x29, #-0x90]
-               	stp	x21, x22, [x29, #-0xa0]
-               	stp	x23, x24, [x29, #-0xb0]
-               	stp	x25, x26, [x29, #-0xc0]
-               	stp	d8, d9, [x29, #-0xd0]
-               	stp	d10, d11, [x29, #-0xe0]
-               	stp	d12, d13, [x29, #-0xf0]
-               	stp	d14, d15, [x29, #-0x100]
+               	sub	sp, sp, #0xe0
+               	stp	x19, x20, [x29, #-0x80]
+               	stp	x21, x22, [x29, #-0x90]
+               	stp	x23, x24, [x29, #-0xa0]
+               	stp	d8, d9, [x29, #-0xb0]
+               	stp	d10, d11, [x29, #-0xc0]
+               	stp	d12, d13, [x29, #-0xd0]
+               	stp	d14, d15, [x29, #-0xe0]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
                	mov	x17, #0x3ff0000000000000 ; =4607182418800017408
                	add	x0, x17, x19
                	fmov	d8, x0
@@ -89,754 +109,754 @@ Disassembly of section __TEXT,__text:
                	mov	x17, #0x1               ; =1
                	add	x0, x17, x19
                	stur	x0, [x29, #-0x70]
-               	fcmp	d10, d10
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	fmov	d0, d10
+<L0>:
+               	bl	 <L0>
+               	fmov	d0, d11
 <L1>:
                	bl	 <L1>
-               	mov	x21, x0
-               	b	 <L4>
+               	fadd	d0, d10, d10
 <L2>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L2>
+               	fadd	d0, d10, d11
 <L3>:
                	bl	 <L3>
-               	mov	x21, x0
+               	fadd	d0, d11, d10
 <L4>:
-               	fcmp	d11, d11
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x21
-               	fmov	d0, d11
+               	bl	 <L4>
+               	fadd	d0, d11, d11
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
+               	fsub	d0, d10, d10
 <L6>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L6>
+               	fsub	d0, d10, d11
 <L7>:
                	bl	 <L7>
-               	mov	x20, x0
+               	fsub	d0, d11, d10
 <L8>:
-               	fadd	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
+               	bl	 <L8>
+               	fsub	d0, d11, d11
 <L9>:
                	bl	 <L9>
-               	mov	x21, x0
-               	b	 <L12>
+               	fmul	d0, d10, d8
 <L10>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L10>
+               	fmul	d0, d10, d9
 <L11>:
                	bl	 <L11>
-               	mov	x21, x0
+               	fmul	d0, d11, d8
 <L12>:
-               	fadd	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x21
+               	bl	 <L12>
+               	fmul	d0, d11, d9
 <L13>:
                	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
+               	fmul	d0, d11, d11
 <L14>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L14>
+               	fmul	d0, d10, d11
 <L15>:
                	bl	 <L15>
-               	mov	x20, x0
+               	fneg	d0, d10
 <L16>:
-               	fadd	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
-               	mov	x0, x20
+               	bl	 <L16>
+               	fneg	d0, d11
 <L17>:
                	bl	 <L17>
-               	mov	x21, x0
-               	b	 <L20>
+               	fdiv	d0, d10, d8
 <L18>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L18>
+               	fdiv	d0, d10, d9
 <L19>:
                	bl	 <L19>
-               	mov	x21, x0
+               	fdiv	d0, d11, d8
 <L20>:
-               	fadd	d0, d11, d11
-               	mov	x0, x21
+               	bl	 <L20>
+               	fdiv	d0, d11, d9
 <L21>:
                	bl	 <L21>
-               	fsub	d0, d10, d10
-<L22>:
-               	bl	 <L22>
-               	fsub	d0, d10, d11
-<L23>:
-               	bl	 <L23>
-               	fsub	d0, d11, d10
-<L24>:
-               	bl	 <L24>
-               	fsub	d0, d11, d11
-<L25>:
-               	bl	 <L25>
-               	fmul	d0, d10, d8
-<L26>:
-               	bl	 <L26>
-               	fmul	d0, d10, d9
-<L27>:
-               	bl	 <L27>
-               	fmul	d0, d11, d8
-<L28>:
-               	bl	 <L28>
-               	fmul	d0, d11, d9
-<L29>:
-               	bl	 <L29>
-               	fmul	d0, d11, d11
-<L30>:
-               	bl	 <L30>
-               	fmul	d0, d10, d11
-<L31>:
-               	bl	 <L31>
-               	fneg	d0, d10
-<L32>:
-               	bl	 <L32>
-               	fneg	d0, d11
-<L33>:
-               	bl	 <L33>
-               	fdiv	d0, d10, d8
-<L34>:
-               	bl	 <L34>
-               	fdiv	d0, d10, d9
-<L35>:
-               	bl	 <L35>
-               	fdiv	d0, d11, d8
-<L36>:
-               	bl	 <L36>
-               	fdiv	d0, d11, d9
-<L37>:
-               	bl	 <L37>
                	fcmp	d10, d11
                	cset	w1, eq
-<L38>:
-               	bl	 <L38>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	fcmp	d10, d11
                	cset	w1, mi
-<L39>:
-               	bl	 <L39>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	fcmp	d11, d10
                	cset	w1, mi
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	fmov	d0, d12
+<L27>:
+               	bl	 <L27>
+               	fmov	d0, d13
+<L28>:
+               	bl	 <L28>
+               	fneg	d0, d12
+<L29>:
+               	bl	 <L29>
+               	fdiv	d0, d8, d10
+<L30>:
+               	bl	 <L30>
+               	fdiv	d0, d8, d11
+<L31>:
+               	bl	 <L31>
+               	fdiv	d0, d9, d10
+<L32>:
+               	bl	 <L32>
+               	fdiv	d0, d9, d11
+<L33>:
+               	bl	 <L33>
+               	fadd	d0, d12, d8
+<L34>:
+               	bl	 <L34>
+               	fadd	d0, d12, d12
+<L35>:
+               	bl	 <L35>
+               	fsub	d0, d12, d13
+<L36>:
+               	bl	 <L36>
+               	fmul	d0, d12, d12
+<L37>:
+               	bl	 <L37>
+               	fmul	d0, d12, d13
+<L38>:
+               	bl	 <L38>
+               	fmul	d0, d12, d9
+<L39>:
+               	bl	 <L39>
+               	fdiv	d0, d8, d12
 <L40>:
                	bl	 <L40>
-               	fmov	d0, d12
+               	fdiv	d0, d9, d12
 <L41>:
                	bl	 <L41>
-               	fmov	d0, d13
+               	fdiv	d0, d8, d13
 <L42>:
                	bl	 <L42>
-               	fneg	d0, d12
+               	fdiv	d0, d12, d8
 <L43>:
                	bl	 <L43>
-               	fdiv	d0, d8, d10
+               	fadd	d0, d15, d15
 <L44>:
                	bl	 <L44>
-               	fdiv	d0, d8, d11
-<L45>:
-               	bl	 <L45>
-               	fdiv	d0, d9, d10
-<L46>:
-               	bl	 <L46>
-               	fdiv	d0, d9, d11
-<L47>:
-               	bl	 <L47>
-               	fadd	d0, d12, d8
-<L48>:
-               	bl	 <L48>
-               	fadd	d0, d12, d12
-<L49>:
-               	bl	 <L49>
-               	fsub	d0, d12, d13
-<L50>:
-               	bl	 <L50>
-               	fmul	d0, d12, d12
-<L51>:
-               	bl	 <L51>
-               	fmul	d0, d12, d13
-<L52>:
-               	bl	 <L52>
-               	fmul	d0, d12, d9
-<L53>:
-               	bl	 <L53>
-               	fdiv	d0, d8, d12
-<L54>:
-               	bl	 <L54>
-               	fdiv	d0, d9, d12
-<L55>:
-               	bl	 <L55>
-               	fdiv	d0, d8, d13
-<L56>:
-               	bl	 <L56>
-               	fdiv	d0, d12, d8
-<L57>:
-               	bl	 <L57>
-               	fadd	d0, d15, d15
-<L58>:
-               	bl	 <L58>
                	fcmp	d15, d12
                	cset	w1, mi
-<L59>:
-               	bl	 <L59>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L45>:
+               	bl	 <L45>
                	fmov	d31, xzr
                	fsub	d0, d31, d15
                	fcmp	d13, d0
                	cset	w1, mi
-<L60>:
-               	bl	 <L60>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	fsub	d0, d12, d12
-<L61>:
-               	bl	 <L61>
+<L47>:
+               	bl	 <L47>
                	fadd	d0, d13, d12
-<L62>:
-               	bl	 <L62>
+<L48>:
+               	bl	 <L48>
                	fmul	d0, d12, d10
-<L63>:
-               	bl	 <L63>
+<L49>:
+               	bl	 <L49>
                	fmul	d0, d13, d11
-<L64>:
-               	bl	 <L64>
+<L50>:
+               	bl	 <L50>
                	fdiv	d0, d12, d12
-<L65>:
-               	bl	 <L65>
+<L51>:
+               	bl	 <L51>
                	fdiv	d0, d10, d10
-<L66>:
-               	bl	 <L66>
+<L52>:
+               	bl	 <L52>
                	fdiv	d0, d11, d10
-<L67>:
-               	bl	 <L67>
+<L53>:
+               	bl	 <L53>
                	fmov	x1, d14
-<L68>:
-               	bl	 <L68>
+<L54>:
+               	bl	 <L54>
                	fcmp	d14, d14
                	cset	w1, ne
-<L69>:
-               	bl	 <L69>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
                	fcmp	d14, d14
                	cset	w1, eq
-<L70>:
-               	bl	 <L70>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
                	fcmp	d14, d14
                	cset	w1, mi
-<L71>:
-               	bl	 <L71>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L57>:
+               	bl	 <L57>
                	fcmp	d14, d14
                	cset	w1, ls
-<L72>:
-               	bl	 <L72>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L58>:
+               	bl	 <L58>
                	fneg	d9, d14
                	fmov	x1, d9
-<L73>:
-               	bl	 <L73>
+<L59>:
+               	bl	 <L59>
                	fneg	d0, d9
                	fmov	x1, d0
-<L74>:
-               	bl	 <L74>
+<L60>:
+               	bl	 <L60>
                	fadd	d0, d14, d8
-<L75>:
-               	bl	 <L75>
+<L61>:
+               	bl	 <L61>
                	fadd	d0, d8, d14
-<L76>:
-               	bl	 <L76>
+<L62>:
+               	bl	 <L62>
                	fmul	d0, d14, d10
-<L77>:
-               	bl	 <L77>
+<L63>:
+               	bl	 <L63>
                	fsub	d0, d14, d14
-<L78>:
-               	bl	 <L78>
+<L64>:
+               	bl	 <L64>
                	fdiv	d0, d14, d14
-<L79>:
-               	bl	 <L79>
+<L65>:
+               	bl	 <L65>
                	fdiv	d0, d14, d12
-<L80>:
-               	bl	 <L80>
+<L66>:
+               	bl	 <L66>
                	ldur	d0, [x29, #-0x70]
-<L81>:
-               	bl	 <L81>
+<L67>:
+               	bl	 <L67>
                	ldur	d0, [x29, #-0x60]
-<L82>:
-               	bl	 <L82>
+<L68>:
+               	bl	 <L68>
                	ldur	d0, [x29, #-0x50]
-<L83>:
-               	bl	 <L83>
+<L69>:
+               	bl	 <L69>
                	ldur	d31, [x29, #-0x60]
                	ldur	d30, [x29, #-0x70]
                	fadd	d0, d31, d30
-<L84>:
-               	bl	 <L84>
+<L70>:
+               	bl	 <L70>
                	ldur	d31, [x29, #-0x50]
                	ldur	d30, [x29, #-0x70]
                	fsub	d0, d31, d30
-<L85>:
-               	bl	 <L85>
+<L71>:
+               	bl	 <L71>
                	ldur	d31, [x29, #-0x70]
                	ldur	d30, [x29, #-0x70]
                	fadd	d0, d31, d30
-<L86>:
-               	bl	 <L86>
+<L72>:
+               	bl	 <L72>
                	ldur	d31, [x29, #-0x70]
                	fmov	d30, #1.50000000
                	fmul	d0, d31, d30
-<L87>:
-               	bl	 <L87>
+<L73>:
+               	bl	 <L73>
                	ldur	d31, [x29, #-0x70]
                	fmov	d30, #0.50000000
                	fmul	d0, d31, d30
-<L88>:
-               	bl	 <L88>
+<L74>:
+               	bl	 <L74>
                	ldur	d31, [x29, #-0x70]
                	fneg	d0, d31
-<L89>:
-               	bl	 <L89>
+<L75>:
+               	bl	 <L75>
                	ldur	d31, [x29, #-0x70]
                	mov	x16, #0x4330000000000000 ; =4841369599423283200
                	fmov	d30, x16
                	fmul	d0, d31, d30
-<L90>:
-               	bl	 <L90>
+<L76>:
+               	bl	 <L76>
                	ldur	d31, [x29, #-0x60]
                	ldur	d30, [x29, #-0x50]
                	fdiv	d0, d31, d30
-<L91>:
-               	bl	 <L91>
+<L77>:
+               	bl	 <L77>
                	ldur	d30, [x29, #-0x70]
                	fcmp	d10, d30
                	cset	w1, mi
-<L92>:
-               	bl	 <L92>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L78>:
+               	bl	 <L78>
                	ldur	d31, [x29, #-0x70]
                	fcmp	d31, d10
                	cset	w1, eq
-<L93>:
-               	bl	 <L93>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
                	fmov	d31, xzr
                	ldur	d30, [x29, #-0x70]
                	fsub	d0, d31, d30
                	fcmp	d0, d11
                	cset	w1, mi
-<L94>:
-               	bl	 <L94>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L80>:
+               	bl	 <L80>
                	mov	x20, x0
                	ldur	d9, [x29, #-0x50]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x3c
-               	b.lo	 <L95>
-               	b	 <L100>
-<L95>:
+               	b.lo	 <L81>
+               	b	 <L83>
+<L81>:
                	fmov	d30, #0.50000000
-               	fmul	d12, d9, d30
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L97>
+               	fmul	d9, d9, d30
                	mov	x0, x20
-               	fmov	d0, d12
-<L96>:
-               	bl	 <L96>
-               	mov	x22, x0
-               	b	 <L99>
-<L97>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L98>:
-               	bl	 <L98>
-               	mov	x22, x0
-<L99>:
+               	fmov	d0, d9
+<L82>:
+               	bl	 <L82>
                	add	x21, x21, #0x1
-               	mov	x20, x22
-               	fmov	d9, d12
+               	mov	x20, x0
                	cmp	x21, #0x3c
-               	b.lo	 <L95>
-<L100>:
-               	sub	x21, x29, #0x40
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	str	xzr, [x21, #0x20]
-               	str	xzr, [x21, #0x28]
-               	str	xzr, [x21, #0x30]
-               	str	xzr, [x21, #0x38]
-               	add	x0, x21, #0x0
+               	b.lo	 <L81>
+<L83>:
+               	sub	x0, x29, #0x40
                	str	xzr, [x0]
-               	add	x0, x21, #0x8
+               	str	xzr, [x0, #0x8]
+               	str	xzr, [x0, #0x10]
+               	str	xzr, [x0, #0x18]
+               	str	xzr, [x0, #0x20]
+               	str	xzr, [x0, #0x28]
+               	str	xzr, [x0, #0x30]
+               	str	xzr, [x0, #0x38]
+               	add	x1, x0, #0x0
+               	str	xzr, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x0]
-               	add	x0, x21, #0x10
+               	str	x17, [x1]
+               	add	x1, x0, #0x10
                	mov	x17, #0x1               ; =1
-               	str	x17, [x0]
-               	add	x0, x21, #0x18
+               	str	x17, [x1]
+               	add	x1, x0, #0x18
                	mov	x17, #0x7ff0000000000000 ; =9218868437227405312
-               	str	x17, [x0]
-               	add	x0, x21, #0x20
+               	str	x17, [x1]
+               	add	x1, x0, #0x20
                	mov	x17, #-0x10000000000000 ; =-4503599627370496
-               	str	x17, [x0]
-               	add	x0, x21, #0x28
+               	str	x17, [x1]
+               	add	x1, x0, #0x28
                	mov	x17, #0x7ff8000000000000 ; =9221120237041090560
-               	str	x17, [x0]
-               	add	x0, x21, #0x30
+               	str	x17, [x1]
+               	add	x1, x0, #0x30
                	mov	x17, #0xdead            ; =57005
                	movk	x17, #0xc0, lsl #16
                	movk	x17, #0xfff8, lsl #48
-               	str	x17, [x0]
-               	add	x0, x21, #0x38
+               	str	x17, [x1]
+               	add	x1, x0, #0x38
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x7ff0, lsl #48
-               	str	x17, [x0]
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x8
-               	b.lo	 <L101>
-               	b	 <L103>
-<L101>:
-               	add	x0, x21, x22, lsl #3
-               	ldr	x1, [x0]
-               	add	x0, x1, x19
-               	fmov	d0, x0
-               	fmov	x1, d0
-               	mov	x0, x20
-<L102>:
-               	bl	 <L102>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x8
-               	b.lo	 <L101>
-<L103>:
+               	str	x17, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L84>
+               	b	 <L87>
+<L84>:
+               	add	x2, x0, x1, lsl #3
+               	ldr	x3, [x2]
+               	add	x2, x3, x19
+               	fmov	d0, x2
+               	fmov	x2, d0
+               	mov	x3, x20
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L85>
+               	b	 <L86>
+<L85>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L85>
+<L86>:
+               	add	x1, x1, #0x1
+               	mov	x20, x3
+               	cmp	x1, #0x8
+               	b.lo	 <L84>
+<L87>:
                	fcvt	s0, d15
                	ldur	d31, [x29, #-0x70]
-               	fcvt	s9, d31
+               	fcvt	s1, d31
                	mov	x17, #0x36a0000000000000 ; =3936146074321813504
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s12, d1
+               	fmov	d2, x0
+               	fcvt	s3, d2
                	mov	x17, #0x10000000        ; =268435456
                	movk	x17, #0x3ff0, lsl #48
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s14, d1
+               	fmov	d2, x0
+               	fcvt	s4, d2
                	mov	x17, #0x30000000        ; =805306368
                	movk	x17, #0x3ff0, lsl #48
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s15, d1
-               	fcvt	s31, d11
-               	stur	s31, [x29, #-0x80]
+               	fmov	d2, x0
+               	fcvt	s5, d2
+               	fcvt	s9, d11
                	fcvt	s11, d13
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L88>
+               	b	 <L89>
+<L88>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L88>
+<L89>:
+               	fmov	w0, s1
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L90>
+               	b	 <L91>
+<L90>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L90>
+<L91>:
+               	fmov	w0, s3
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L92>
+               	b	 <L93>
+<L92>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L92>
+<L93>:
+               	fmov	w0, s4
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L94>
+               	b	 <L95>
+<L94>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L94>
+<L95>:
+               	fmov	w0, s5
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L96>
+               	b	 <L97>
+<L96>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L96>
+<L97>:
+               	fmov	w0, s9
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L98>
+               	b	 <L99>
+<L98>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L98>
+<L99>:
+               	fmov	w0, s11
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L100>
+               	b	 <L101>
+<L100>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L100>
+<L101>:
+               	fcvt	d0, s3
                	mov	x0, x20
+<L102>:
+               	bl	 <L102>
+               	fcvt	d0, s9
+<L103>:
+               	bl	 <L103>
+               	fcvt	d0, s11
 <L104>:
                	bl	 <L104>
-               	fmov	s0, s9
-<L105>:
-               	bl	 <L105>
-               	fmov	s0, s12
-<L106>:
-               	bl	 <L106>
-               	fmov	s0, s14
-<L107>:
-               	bl	 <L107>
-               	fmov	s0, s15
-<L108>:
-               	bl	 <L108>
-               	ldur	s0, [x29, #-0x80]
-<L109>:
-               	bl	 <L109>
-               	fmov	s0, s11
-<L110>:
-               	bl	 <L110>
-               	mov	x20, x0
-               	fcvt	d0, s12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x21, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L113>:
-               	bl	 <L113>
-               	mov	x21, x0
-<L114>:
-               	ldur	s31, [x29, #-0x80]
-               	fcvt	d0, s31
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x21
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
-               	fcvt	d0, s11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x21, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L121>:
-               	bl	 <L121>
-               	mov	x21, x0
-<L122>:
                	mov	x17, #0x20000000000000  ; =9007199254740992
-               	add	x0, x17, x19
+               	add	x1, x17, x19
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x20, lsl #48
                	add	x20, x17, x19
                	mov	x17, #0x3               ; =3
                	movk	x17, #0x20, lsl #48
-               	add	x22, x17, x19
+               	add	x21, x17, x19
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x23, x17, x19
+               	add	x22, x17, x19
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffdf, lsl #48
-               	add	x24, x17, x19
+               	add	x23, x17, x19
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	add	x25, x17, x19
-               	ucvtf	d0, x0
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L124>
-               	mov	x0, x21
-<L123>:
-               	bl	 <L123>
-               	mov	x26, x0
-               	b	 <L126>
-<L124>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L125>:
-               	bl	 <L125>
-               	mov	x26, x0
-<L126>:
+               	add	x24, x17, x19
+               	ucvtf	d0, x1
+<L105>:
+               	bl	 <L105>
                	ucvtf	d0, x20
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x26
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x26
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L106>:
+               	bl	 <L106>
+               	ucvtf	d0, x21
+<L107>:
+               	bl	 <L107>
                	ucvtf	d0, x22
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x20
-<L131>:
-               	bl	 <L131>
-               	mov	x21, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L133>:
-               	bl	 <L133>
-               	mov	x21, x0
-<L134>:
-               	ucvtf	d0, x23
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x21
-<L135>:
-               	bl	 <L135>
-               	mov	x20, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L137>:
-               	bl	 <L137>
-               	mov	x20, x0
-<L138>:
+<L108>:
+               	bl	 <L108>
                	ucvtf	d0, x19
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x20
-<L139>:
-               	bl	 <L139>
-               	mov	x19, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L141>:
-               	bl	 <L141>
-               	mov	x19, x0
-<L142>:
+<L109>:
+               	bl	 <L109>
+               	scvtf	d0, x23
+<L110>:
+               	bl	 <L110>
                	scvtf	d0, x24
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x19
-<L143>:
-               	bl	 <L143>
-               	mov	x20, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L145>:
-               	bl	 <L145>
-               	mov	x20, x0
-<L146>:
-               	scvtf	d0, x25
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x20
-<L147>:
-               	bl	 <L147>
-               	mov	x19, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-<L150>:
+<L111>:
+               	bl	 <L111>
                	fmov	d31, #1.50000000
                	fmul	d9, d31, d8
                	mov	x16, #0x4340000000000000 ; =4845873199050653696
                	fmov	d31, x16
-               	fmul	d11, d31, d8
+               	fmul	d0, d31, d8
                	mov	x16, #0x43d0000000000000 ; =4886405595696988160
                	fmov	d31, x16
-               	fmul	d12, d31, d8
+               	fmul	d11, d31, d8
                	fmov	d31, xzr
-               	fsub	d13, d31, d9
+               	fsub	d12, d31, d9
                	fmov	d31, #0.50000000
-               	fmul	d14, d31, d8
+               	fmul	d13, d31, d8
                	fcvtzu	x1, d9
-               	mov	x0, x19
-<L151>:
-               	bl	 <L151>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+               	b	 <L113>
+<L112>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+<L113>:
+               	fcvtzu	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+               	b	 <L115>
+<L114>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+<L115>:
                	fcvtzu	x1, d11
-<L152>:
-               	bl	 <L152>
-               	fcvtzu	x1, d12
-<L153>:
-               	bl	 <L153>
-               	fcvtzu	x1, d14
-<L154>:
-               	bl	 <L154>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L116>
+               	b	 <L117>
+<L116>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L116>
+<L117>:
+               	fcvtzu	x1, d13
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L118>
+               	b	 <L119>
+<L118>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L118>
+<L119>:
                	fcvtzu	x1, d10
-<L155>:
-               	bl	 <L155>
-               	fcvtzs	x1, d13
-<L156>:
-               	bl	 <L156>
+<L120>:
+               	bl	 <L120>
                	fcvtzs	x1, d12
-<L157>:
-               	bl	 <L157>
+<L121>:
+               	bl	 <L121>
+               	fcvtzs	x1, d11
+<L122>:
+               	bl	 <L122>
                	fmov	d31, xzr
-               	fsub	d0, d31, d14
+               	fsub	d0, d31, d13
                	fcvtzs	x1, d0
-<L158>:
-               	bl	 <L158>
-               	fcvtzs	w1, d13
-<L159>:
-               	bl	 <L159>
+<L123>:
+               	bl	 <L123>
+               	fcvtzs	w1, d12
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L124>:
+               	bl	 <L124>
                	fcvtzu	w1, d9
-<L160>:
-               	bl	 <L160>
-               	ldp	d8, d9, [x29, #-0xd0]
-               	ldp	d10, d11, [x29, #-0xe0]
-               	ldp	d12, d13, [x29, #-0xf0]
-               	ldp	d14, d15, [x29, #-0x100]
-               	ldp	x19, x20, [x29, #-0x90]
-               	ldp	x21, x22, [x29, #-0xa0]
-               	ldp	x23, x24, [x29, #-0xb0]
-               	ldp	x25, x26, [x29, #-0xc0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L125>:
+               	bl	 <L125>
+               	ldp	d8, d9, [x29, #-0xb0]
+               	ldp	d10, d11, [x29, #-0xc0]
+               	ldp	d12, d13, [x29, #-0xd0]
+               	ldp	d14, d15, [x29, #-0xe0]
+               	ldp	x19, x20, [x29, #-0x80]
+               	ldp	x21, x22, [x29, #-0x90]
+               	ldp	x23, x24, [x29, #-0xa0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/frame/frame_align.dis
+++ b/test/golden/aarch64-darwin/frame/frame_align.dis
@@ -3,94 +3,216 @@ frame/frame_align.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.frame.frame_align.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.frame.frame_align.fold_f64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[0]
-               	mov	x0, x1
+               	mov	d1, v0[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.frame.frame_align.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.frame.frame_align.spin>:
@@ -160,97 +282,95 @@ Disassembly of section __TEXT,__text:
                	lsr	x16, x16, #6
                	lsl	x16, x16, #6
                	mov	sp, x16
-               	sub	sp, sp, #0x300
-               	add	x16, sp, #0x60
+               	sub	sp, sp, #0x280
+               	add	x16, sp, #0x70
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	ucvtf	s0, x19
                	ucvtf	d1, x19
-               	add	x1, sp, #0x2f0
-               	add	x2, x1, #0x0
+               	add	x0, sp, #0x270
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s2, s31
-               	add	x2, x1, #0x4
-               	str	s2, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s2, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s2, s31
-               	add	x2, x1, #0xc
-               	str	s2, [x2]
-               	ldr	q2, [x1]
-               	add	x1, sp, #0x2e0
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0xc
+               	str	s2, [x1]
+               	ldr	q2, [x0]
+               	add	x0, sp, #0x260
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff4000000000000 ; =4608308318706860032
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x3ff4000000000000 ; =-4608308318706860032
-               	str	x17, [x2]
-               	ldr	q3, [x1]
-               	add	x1, sp, #0x2d0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q3, [x0]
+               	add	x0, sp, #0x250
+               	add	x1, x0, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x1               ; =1
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x79b1            ; =31153
                	movk	w17, #0x9e37, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x2]
-               	ldr	q4, [x1]
-               	add	x1, sp, #0x2c0
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q4, [x0]
+               	add	x0, sp, #0x240
+               	add	x1, x0, #0x0
                	mov	x17, #0x3fe0000000000000 ; =4602678819172646912
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x4019000000000000 ; =4618722892845154304
-               	str	x17, [x2]
-               	ldr	q31, [x1]
-               	str	q31, [sp, #0x170]
-               	add	x1, sp, #0x2b0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q31, [x0]
+               	str	q31, [sp, #0xf0]
+               	add	x0, sp, #0x230
+               	add	x1, x0, #0x0
                	mov	w17, #0xae3d            ; =44605
                	movk	w17, #0xc2b2, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0xca77            ; =51831
                	movk	w17, #0x85eb, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x7               ; =7
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0xfffb            ; =65531
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	ldr	q31, [x1]
-               	str	q31, [sp, #0x160]
-               	add	x20, sp, #0x1c0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xc0               ; =192
-<L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	add	x21, sp, #0x180
+               	str	w17, [x1]
+               	ldr	q31, [x0]
+               	str	q31, [sp, #0xe0]
+               	add	x20, sp, #0x140
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xc0               ; =192
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	add	x21, sp, #0x100
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -259,363 +379,202 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x21, #0x28]
                	str	xzr, [x21, #0x30]
                	str	xzr, [x21, #0x38]
-               	add	x1, x19, #0x1
-               	mov	w22, w1
-               	add	x1, x19, #0x3
-               	mov	w23, w1
-               	add	x1, x19, #0x5
-               	mov	w24, w1
-               	add	x1, x19, #0x7
-               	mov	w25, w1
+               	add	x0, x19, #0x1
+               	mov	w22, w0
+               	add	x0, x19, #0x3
+               	mov	w23, w0
+               	add	x0, x19, #0x5
+               	mov	w24, w0
+               	add	x0, x19, #0x7
+               	mov	w25, w0
                	mov	x16, #0xfff1            ; =65521
-               	add	x1, x19, x16
-               	mov	w26, w1
-               	add	x1, x19, #0xfb
-               	mov	w27, w1
+               	add	x0, x19, x16
+               	mov	w26, w0
+               	add	x0, x19, #0xfb
+               	mov	w27, w0
                	mov	s5, v2[0]
                	fadd	s6, s5, s0
                	mov.16b	v30, v2
                	mov.s	v30[0], v6[0]
-               	str	q30, [sp, #0x150]
+               	str	q30, [sp, #0xd0]
                	mov	d0, v3[1]
                	fadd	d2, d0, d1
                	mov.16b	v30, v3
                	mov.d	v30[1], v2[0]
-               	str	q30, [sp, #0x140]
-               	mov.s	w1, v4[2]
-               	mov	w2, w19
-               	add	w3, w1, w2
+               	str	q30, [sp, #0xc0]
+               	mov.s	w0, v4[2]
+               	mov	w1, w19
+               	add	w2, w0, w1
                	mov.16b	v30, v4
-               	mov.s	v30[2], w3
-               	str	q30, [sp, #0x130]
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31[0]
+               	mov.s	v30[2], w2
+               	str	q30, [sp, #0xb0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldr	q0, [sp, #0xd0]
+<L1>:
+               	bl	 <L1>
+               	ldr	q0, [sp, #0xc0]
 <L2>:
                	bl	 <L2>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31[1]
+               	ldr	q0, [sp, #0xb0]
 <L3>:
                	bl	 <L3>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31[2]
+               	ldr	q31, [sp, #0xd0]
+               	ldr	q30, [sp, #0xd0]
+               	fadd.4s	v31, v31, v30
+               	str	q31, [sp, #0xa0]
+               	ldr	q0, [sp, #0xa0]
 <L4>:
                	bl	 <L4>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31[3]
+               	ldr	q31, [sp, #0xd0]
+               	ldr	q30, [sp, #0xd0]
+               	fmul.4s	v31, v31, v30
+               	str	q31, [sp, #0x90]
+               	ldr	q0, [sp, #0x90]
 <L5>:
                	bl	 <L5>
-               	ldr	q31, [sp, #0x140]
-               	mov	d0, v31[0]
+               	ldr	q0, [sp, #0xf0]
 <L6>:
                	bl	 <L6>
-               	ldr	q31, [sp, #0x140]
-               	mov	d0, v31[1]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fmul.2d	v0, v31, v30
 <L7>:
                	bl	 <L7>
-               	ldr	q31, [sp, #0x130]
-               	mov.s	w1, v31[0]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fsub.2d	v0, v31, v30
 <L8>:
                	bl	 <L8>
-               	ldr	q31, [sp, #0x130]
-               	mov.s	w1, v31[1]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fdiv.2d	v0, v31, v30
 <L9>:
                	bl	 <L9>
-               	ldr	q31, [sp, #0x130]
-               	mov.s	w1, v31[2]
+               	ldr	q0, [sp, #0xe0]
 <L10>:
                	bl	 <L10>
-               	ldr	q31, [sp, #0x130]
-               	mov.s	w1, v31[3]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	mul.4s	v0, v31, v30
 <L11>:
                	bl	 <L11>
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fadd.4s	v31, v31, v30
-               	str	q31, [sp, #0x120]
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31[0]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	add.4s	v0, v31, v30
 <L12>:
                	bl	 <L12>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31[1]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	eor.16b	v0, v31, v30
 <L13>:
                	bl	 <L13>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31[2]
+               	mov	x28, x0
+               	ldr	q0, [sp, #0xd0]
 <L14>:
                	bl	 <L14>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31[3]
+               	mov	x0, x28
 <L15>:
                	bl	 <L15>
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul.4s	v31, v31, v30
-               	str	q31, [sp, #0x110]
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31[0]
+               	mov	x28, x0
+               	ldr	q0, [sp, #0x90]
 <L16>:
                	bl	 <L16>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31[1]
+               	mov	x0, x28
 <L17>:
                	bl	 <L17>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31[2]
-<L18>:
-               	bl	 <L18>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31[3]
-<L19>:
-               	bl	 <L19>
-               	ldr	q31, [sp, #0x170]
-               	mov	d0, v31[0]
-<L20>:
-               	bl	 <L20>
-               	ldr	q31, [sp, #0x170]
-               	mov	d0, v31[1]
-<L21>:
-               	bl	 <L21>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fmul.2d	v31, v31, v30
-               	str	q31, [sp, #0x100]
-               	ldr	q31, [sp, #0x100]
-               	mov	d0, v31[0]
-<L22>:
-               	bl	 <L22>
-               	ldr	q31, [sp, #0x100]
-               	mov	d0, v31[1]
-<L23>:
-               	bl	 <L23>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fsub.2d	v31, v31, v30
-               	str	q31, [sp, #0xf0]
-               	ldr	q31, [sp, #0xf0]
-               	mov	d0, v31[0]
-<L24>:
-               	bl	 <L24>
-               	ldr	q31, [sp, #0xf0]
-               	mov	d0, v31[1]
-<L25>:
-               	bl	 <L25>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fdiv.2d	v31, v31, v30
-               	str	q31, [sp, #0xe0]
-               	ldr	q31, [sp, #0xe0]
-               	mov	d0, v31[0]
-<L26>:
-               	bl	 <L26>
-               	ldr	q31, [sp, #0xe0]
-               	mov	d0, v31[1]
-<L27>:
-               	bl	 <L27>
-               	ldr	q31, [sp, #0x160]
-               	mov.s	w1, v31[0]
-<L28>:
-               	bl	 <L28>
-               	ldr	q31, [sp, #0x160]
-               	mov.s	w1, v31[1]
-<L29>:
-               	bl	 <L29>
-               	ldr	q31, [sp, #0x160]
-               	mov.s	w1, v31[2]
-<L30>:
-               	bl	 <L30>
-               	ldr	q31, [sp, #0x160]
-               	mov.s	w1, v31[3]
-<L31>:
-               	bl	 <L31>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	mul.4s	v31, v31, v30
-               	str	q31, [sp, #0xd0]
-               	ldr	q31, [sp, #0xd0]
-               	mov.s	w1, v31[0]
-<L32>:
-               	bl	 <L32>
-               	ldr	q31, [sp, #0xd0]
-               	mov.s	w1, v31[1]
-<L33>:
-               	bl	 <L33>
-               	ldr	q31, [sp, #0xd0]
-               	mov.s	w1, v31[2]
-<L34>:
-               	bl	 <L34>
-               	ldr	q31, [sp, #0xd0]
-               	mov.s	w1, v31[3]
-<L35>:
-               	bl	 <L35>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	add.4s	v31, v31, v30
-               	str	q31, [sp, #0xc0]
-               	ldr	q31, [sp, #0xc0]
-               	mov.s	w1, v31[0]
-<L36>:
-               	bl	 <L36>
-               	ldr	q31, [sp, #0xc0]
-               	mov.s	w1, v31[1]
-<L37>:
-               	bl	 <L37>
-               	ldr	q31, [sp, #0xc0]
-               	mov.s	w1, v31[2]
-<L38>:
-               	bl	 <L38>
-               	ldr	q31, [sp, #0xc0]
-               	mov.s	w1, v31[3]
-<L39>:
-               	bl	 <L39>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	eor.16b	v31, v31, v30
-               	str	q31, [sp, #0xb0]
-               	ldr	q31, [sp, #0xb0]
-               	mov.s	w1, v31[0]
-<L40>:
-               	bl	 <L40>
-               	ldr	q31, [sp, #0xb0]
-               	mov.s	w1, v31[1]
-<L41>:
-               	bl	 <L41>
-               	ldr	q31, [sp, #0xb0]
-               	mov.s	w1, v31[2]
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [sp, #0xb0]
-               	mov.s	w1, v31[3]
-<L43>:
-               	bl	 <L43>
-               	mov	x28, x0
-               	ldr	q0, [sp, #0x150]
-<L44>:
-               	bl	 <L44>
-               	str	q0, [sp, #0xa0]
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31[0]
-               	mov	x0, x28
-<L45>:
-               	bl	 <L45>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31[1]
-<L46>:
-               	bl	 <L46>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31[2]
-<L47>:
-               	bl	 <L47>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31[3]
-<L48>:
-               	bl	 <L48>
-               	mov	x28, x0
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul.4s	v0, v31, v30
-<L49>:
-               	bl	 <L49>
-               	str	q0, [sp, #0x90]
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31[0]
-               	mov	x0, x28
-<L50>:
-               	bl	 <L50>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31[1]
-<L51>:
-               	bl	 <L51>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31[2]
-<L52>:
-               	bl	 <L52>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31[3]
-<L53>:
-               	bl	 <L53>
                	mov	x28, x0
                	add	x0, x21, #0x0
-               	ldr	q31, [sp, #0x150]
+               	ldr	q31, [sp, #0xd0]
                	str	q31, [x0]
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fadd.4s	v0, v31, v30
                	add	x0, x21, #0x10
-               	str	q0, [x0]
-               	ldr	q0, [sp, #0x150]
-<L54>:
-               	bl	 <L54>
+               	ldr	q31, [sp, #0xa0]
+               	str	q31, [x0]
+               	ldr	q0, [sp, #0xd0]
+<L18>:
+               	bl	 <L18>
                	add	x0, x21, #0x20
                	str	q0, [x0]
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul.4s	v0, v31, v30
                	add	x0, x21, #0x30
-               	str	q0, [x0]
+               	ldr	q31, [sp, #0x90]
+               	str	q31, [x0]
                	mov	x9, #0x0                ; =0
-               	str	x9, [sp, #0x78]
-               	ldr	x9, [sp, #0x78]
+               	str	x9, [sp, #0x88]
+               	ldr	x9, [sp, #0x88]
                	cmp	x9, #0x4
-               	b.lo	 <L55>
-               	b	 <L60>
-<L55>:
-               	ldr	x9, [sp, #0x78]
+               	b.lo	 <L19>
+               	b	 <L21>
+<L19>:
+               	ldr	x9, [sp, #0x88]
                	mov	x16, #0x10              ; =16
                	mul	x0, x9, x16
                	add	x2, x21, x0
-               	ldr	q31, [x2]
-               	str	q31, [sp, #0x80]
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31[0]
+               	ldr	q0, [x2]
                	mov	x0, x28
-<L56>:
-               	bl	 <L56>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31[1]
-<L57>:
-               	bl	 <L57>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31[2]
-<L58>:
-               	bl	 <L58>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31[3]
-<L59>:
-               	bl	 <L59>
-               	ldr	x9, [sp, #0x78]
+<L20>:
+               	bl	 <L20>
+               	ldr	x9, [sp, #0x88]
                	add	x1, x9, #0x1
                	mov	x28, x0
                	mov	x9, x1
-               	str	x9, [sp, #0x78]
-               	ldr	x9, [sp, #0x78]
+               	str	x9, [sp, #0x88]
+               	ldr	x9, [sp, #0x88]
                	cmp	x9, #0x4
-               	b.lo	 <L55>
-<L60>:
+               	b.lo	 <L19>
+<L21>:
                	mov	x17, #0x1111            ; =4369
                	movk	x17, #0x1111, lsl #16
                	movk	x17, #0x1111, lsl #32
                	movk	x17, #0x1111, lsl #48
-               	add	x21, x17, x19
+               	add	x0, x17, x19
                	mov	x17, #0x7777            ; =30583
                	movk	x17, #0x7777, lsl #16
                	movk	x17, #0x7777, lsl #32
                	movk	x17, #0x7777, lsl #48
-               	eor	x9, x17, x19
-               	str	x9, [sp, #0x70]
-               	mov	x0, x28
-               	mov	x1, x21
-<L61>:
-               	bl	 <L61>
-               	ldr	x9, [sp, #0x70]
-               	mov	x1, x9
-<L62>:
-               	bl	 <L62>
+               	eor	x1, x17, x19
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x28, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x28, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x3
-               	b.lo	 <L63>
-               	b	 <L64>
-<L63>:
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
                	mov	x16, #0x79b1            ; =31153
                	movk	x16, #0x9e37, lsl #16
                	mul	x2, x1, x16
@@ -626,60 +585,125 @@ Disassembly of section __TEXT,__text:
                	add	x2, x4, #0x0
                	str	x3, [x2]
                	lsl	x2, x1, #40
-               	eor	x3, x2, x21
+               	eor	x3, x2, x0
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	add	x1, x1, #0x1
                	cmp	x1, #0x3
-               	b.lo	 <L63>
-<L64>:
-               	mov	x19, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x3
-               	b.lo	 <L65>
-               	b	 <L68>
-<L65>:
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x3
+               	b.lo	 <L28>
+               	b	 <L33>
+<L28>:
                	mov	x16, #0x40              ; =64
-               	mul	x0, x21, x16
-               	add	x28, x20, x0
-               	add	x0, x28, #0x0
-               	ldr	x1, [x0]
-               	mov	x0, x19
-<L66>:
-               	bl	 <L66>
-               	add	x1, x28, #0x8
+               	mul	x1, x0, x16
+               	add	x2, x20, x1
+               	add	x1, x2, #0x0
                	ldr	x2, [x1]
-               	mov	x1, x2
-<L67>:
-               	bl	 <L67>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	cmp	x21, #0x3
-               	b.lo	 <L65>
-<L68>:
-               	mov	x0, x19
-               	mov	x1, x22
-<L69>:
-               	bl	 <L69>
+               	mov	x1, x28
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x16, #0x40              ; =64
+               	mul	x2, x0, x16
+               	add	x3, x20, x2
+               	add	x2, x3, #0x8
+               	ldr	x3, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	add	x0, x0, #0x1
+               	mov	x28, x1
+               	cmp	x0, #0x3
+               	b.lo	 <L28>
+<L33>:
+               	uxtb	w0, w22
                	mov	x1, #0x0                ; =0
-<L70>:
-               	bl	 <L70>
-               	mov	x1, x23
-<L71>:
-               	bl	 <L71>
-               	mov	x1, x24
-<L72>:
-               	bl	 <L72>
-               	mov	x1, x25
-<L73>:
-               	bl	 <L73>
-               	mov	x1, x26
-<L74>:
-               	bl	 <L74>
-               	mov	x1, x27
-<L75>:
-               	bl	 <L75>
-               	add	x16, sp, #0x60
+               	cmp	x1, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x28, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x17, #0x0               ; =0
+               	lsr	x2, x17, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x28, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	uxtb	w1, w23
+               	mov	x0, x28
+<L38>:
+               	bl	 <L38>
+               	uxtb	w1, w24
+<L39>:
+               	bl	 <L39>
+               	uxtb	w1, w25
+<L40>:
+               	bl	 <L40>
+               	uxth	w1, w26
+<L41>:
+               	bl	 <L41>
+               	uxtb	w1, w27
+<L42>:
+               	bl	 <L42>
+               	add	x16, sp, #0x70
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/frame/frame_large.dis
+++ b/test/golden/aarch64-darwin/frame/frame_large.dis
@@ -6,257 +6,482 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x2, lsl #12   ; =0x2000
-               	sub	sp, sp, #0x40
-               	mov	x16, #0xdff0            ; =57328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x16, #0xec00            ; =60416
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	add	x1, x20, #0x0
+               	add	x1, x29, x16
                	add	x2, x1, #0x0
-               	mov	x1, #0x1400             ; =5120
-<L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	add	x3, x2, #0x0
+               	mov	x2, #0x1400             ; =5120
+<L0>:
+               	str	xzr, [x3]
+               	add	x3, x3, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L0>
                	mov	x16, #0xe400            ; =58368
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x800              ; =2048
+               	add	x2, x29, x16
+               	add	x3, x2, #0x0
+               	add	x4, x3, #0x0
+               	mov	x3, #0x800              ; =2048
+<L1>:
+               	str	xzr, [x4]
+               	add	x4, x4, #0x8
+               	sub	x3, x3, #0x8
+               	cmp	x3, #0x0
+               	b.ne	 <L1>
+               	sub	x3, x29, #0x2, lsl #12  ; =0x2000
+               	add	x4, x3, #0x0
+               	add	x5, x4, #0x0
+               	mov	x4, #0x400              ; =1024
 <L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x5]
+               	add	x5, x5, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
                	b.ne	 <L2>
-               	sub	x22, x29, #0x2, lsl #12 ; =0x2000
-               	add	x1, x22, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x400              ; =1024
+               	add	x4, x1, #0x0
+               	ldr	x5, [x4]
+               	mov	x4, #0x2325             ; =8997
+               	movk	x4, #0x8422, lsl #16
+               	movk	x4, #0x9ce4, lsl #32
+               	movk	x4, #0xcbf2, lsl #48
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L3>
-               	add	x1, x20, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	mov	x16, #0x13f8            ; =5112
-               	add	x1, x20, x16
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x5, x1, x16
+               	ldr	x6, [x5]
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x5, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, #0x7fc
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x5, x2, #0x0
+               	ldr	w6, [x5]
+               	mov	w5, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x1, x22, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	add	x1, x22, #0x3ff
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	add	x5, x2, #0x7fc
+               	ldr	w6, [x5]
+               	mov	w5, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x280
-               	b.lo	 <L10>
-               	b	 <L11>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	add	x2, x1, x19
+               	add	x5, x3, #0x0
+               	ldrb	w6, [x5]
+               	uxtb	w5, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x5, x3, #0x3ff
+               	ldrb	w6, [x5]
+               	uxtb	w5, w6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x280
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
+               	add	x6, x5, x0
                	mov	x16, #0x7f2d            ; =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x3, x2, x16
-               	lsl	x2, x1, #17
-               	eor	x4, x3, x2
-               	add	x2, x20, x1, lsl #3
-               	str	x4, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x280
-               	b.lo	 <L10>
-<L11>:
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x200
-               	b.lo	 <L12>
-               	b	 <L13>
-<L12>:
+               	mul	x7, x6, x16
+               	lsl	x6, x5, #17
+               	eor	x8, x7, x6
+               	add	x6, x1, x5, lsl #3
+               	str	x8, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x280
+               	b.lo	 <L15>
+<L16>:
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x200
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
                	mov	x16, #0x79b1            ; =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	lsr	x2, x1, #3
-               	eor	x4, x3, x2
-               	mov	w2, w4
-               	add	x3, x21, x1, lsl #2
-               	str	w2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x200
-               	b.lo	 <L12>
-<L13>:
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x400
-               	b.lo	 <L14>
-               	b	 <L15>
-<L14>:
-               	mov	x16, #0x83              ; =131
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	lsr	x2, x1, #2
-               	eor	x4, x3, x2
-               	mov	w2, w4
-               	add	x3, x22, x1
-               	strb	w2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x400
-               	b.lo	 <L14>
-<L15>:
-               	mov	x23, x0
-               	mov	x24, #0x0               ; =0
-               	cmp	x24, #0x40
-               	b.lo	 <L16>
-               	b	 <L23>
-<L16>:
-               	mov	x16, #0x9               ; =9
-               	mul	x0, x24, x16
-               	add	x1, x0, x19
-               	mov	x0, #0x280              ; =640
-               	cbnz	x0,  <L17>
-               	brk	#0
-<L17>:
-               	udiv	x16, x1, x0
-               	msub	x2, x16, x0, x1
-               	add	x0, x20, x2, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	lsr	x6, x5, #3
+               	eor	x8, x7, x6
+               	mov	w6, w8
+               	add	x7, x2, x5, lsl #2
+               	str	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x200
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	mov	x16, #0xd               ; =13
-               	mul	x1, x24, x16
-               	add	x2, x1, x19
-               	mov	x1, #0x200              ; =512
-               	cbnz	x1,  <L19>
-               	brk	#0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x400
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
-               	udiv	x16, x2, x1
-               	msub	x3, x16, x1, x2
-               	add	x1, x21, x3, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x83              ; =131
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	lsr	x6, x5, #2
+               	eor	x8, x7, x6
+               	mov	w6, w8
+               	add	x7, x3, x5
+               	strb	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x400
+               	b.lo	 <L19>
 <L20>:
-               	bl	 <L20>
-               	mov	x16, #0x1d              ; =29
-               	mul	x1, x24, x16
-               	add	x2, x1, x19
-               	mov	x1, #0x400              ; =1024
-               	cbnz	x1,  <L21>
-               	brk	#0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x40
+               	b.lo	 <L21>
+               	b	 <L31>
 <L21>:
-               	udiv	x16, x2, x1
-               	msub	x3, x16, x1, x2
-               	add	x1, x22, x3
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x9               ; =9
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	mov	x6, #0x280              ; =640
+               	cbnz	x6,  <L22>
+               	brk	#0
 <L22>:
-               	bl	 <L22>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L16>
+               	udiv	x16, x7, x6
+               	msub	x8, x16, x6, x7
+               	add	x6, x1, x8, lsl #3
+               	ldr	x7, [x6]
+               	mov	x6, x4
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	mov	x16, #0x13f8            ; =5112
-               	add	x24, x20, x16
-               	ldr	x0, [x24]
-               	add	x1, x0, #0x1
-               	mov	x16, #0x1               ; =1
-               	and	x0, x19, x16
-               	mov	x17, #0x27f             ; =639
-               	sub	x2, x17, x0
-               	add	x0, x20, x2, lsl #3
-               	str	x1, [x0]
-               	add	x25, x21, #0x7fc
-               	ldr	w0, [x25]
-               	add	w1, w0, #0x7
-               	mov	x16, #0x3               ; =3
-               	and	x0, x19, x16
-               	mov	x17, #0x1ff             ; =511
-               	sub	x2, x17, x0
-               	add	x0, x21, x2, lsl #2
-               	str	w1, [x0]
-               	add	x26, x22, #0x3ff
-               	ldrb	w0, [x26]
-               	add	w1, w0, #0xb
-               	mov	x16, #0x7               ; =7
-               	and	x0, x19, x16
-               	mov	x17, #0x3ff             ; =1023
-               	sub	x2, x17, x0
-               	add	x0, x22, x2
-               	strb	w1, [x0]
-               	mov	x16, #0x13f0            ; =5104
-               	add	x0, x20, x16
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
-               	ldr	x1, [x24]
+               	mov	x16, #0xd               ; =13
+               	mul	x7, x5, x16
+               	add	x8, x7, x0
+               	mov	x7, #0x200              ; =512
+               	cbnz	x7,  <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	add	x1, x21, #0x7f0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	udiv	x16, x8, x7
+               	msub	x12, x16, x7, x8
+               	add	x7, x2, x12, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	ldr	w1, [x25]
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	add	x1, x22, #0x3f8
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x1d              ; =29
+               	mul	x7, x5, x16
+               	add	x8, x7, x0
+               	mov	x7, #0x400              ; =1024
+               	cbnz	x7,  <L28>
+               	brk	#0
 <L28>:
-               	bl	 <L28>
-               	ldrb	w1, [x26]
+               	udiv	x16, x8, x7
+               	msub	x12, x16, x7, x8
+               	add	x7, x3, x12
+               	ldrb	w8, [x7]
+               	uxtb	w7, w8
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
 <L29>:
-               	bl	 <L29>
-               	mov	x16, #0xdff0            ; =57328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	add	x5, x5, #0x1
+               	mov	x4, x6
+               	cmp	x5, #0x40
+               	b.lo	 <L21>
+<L31>:
+               	mov	x16, #0x13f8            ; =5112
+               	add	x5, x1, x16
+               	ldr	x6, [x5]
+               	add	x5, x6, #0x1
+               	mov	x16, #0x1               ; =1
+               	and	x6, x0, x16
+               	mov	x17, #0x27f             ; =639
+               	sub	x7, x17, x6
+               	add	x6, x1, x7, lsl #3
+               	str	x5, [x6]
+               	add	x5, x2, #0x7fc
+               	ldr	w6, [x5]
+               	add	w5, w6, #0x7
+               	mov	x16, #0x3               ; =3
+               	and	x6, x0, x16
+               	mov	x17, #0x1ff             ; =511
+               	sub	x7, x17, x6
+               	add	x6, x2, x7, lsl #2
+               	str	w5, [x6]
+               	add	x5, x3, #0x3ff
+               	ldrb	w6, [x5]
+               	add	w5, w6, #0xb
+               	mov	x16, #0x7               ; =7
+               	and	x6, x0, x16
+               	mov	x17, #0x3ff             ; =1023
+               	sub	x0, x17, x6
+               	add	x6, x3, x0
+               	strb	w5, [x6]
+               	mov	x16, #0x13f0            ; =5104
+               	add	x0, x1, x16
+               	ldr	x5, [x0]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x0, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	mov	x16, #0x13f8            ; =5112
+               	add	x0, x1, x16
+               	ldr	x1, [x0]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x0, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	x0, x2, #0x7f0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x0, x2, #0x7fc
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x5, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x5, x16
+               	eor	x5, x4, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	x0, x3, #0x3f8
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x5, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x5, x16
+               	eor	x5, x4, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	add	x0, x3, #0x3ff
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x4
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/frame/frame_spill.dis
+++ b/test/golden/aarch64-darwin/frame/frame_spill.dis
@@ -13,116 +13,114 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.frame.frame_spill.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x220
-               	stp	x19, x20, [x29, #-0x1a0]
-               	stp	x21, x22, [x29, #-0x1b0]
-               	stp	x23, x24, [x29, #-0x1c0]
-               	stp	x25, x26, [x29, #-0x1d0]
-               	stp	x27, x28, [x29, #-0x1e0]
-               	sub	x16, x29, #0x1f0
+               	sub	sp, sp, #0x2a0
+               	sub	x16, x29, #0x220
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x270
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	stp	d12, d13, [x16, #-0x20]
                	stp	d14, d15, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7f2d            ; =32557
                	movk	x17, #0x4c95, lsl #16
                	movk	x17, #0xf42d, lsl #32
                	movk	x17, #0x5851, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x814f            ; =33103
                	movk	x17, #0xf767, lsl #16
                	movk	x17, #0x7b7e, lsl #32
                	movk	x17, #0x1405, lsl #48
-               	eor	x2, x17, x19
+               	eor	x2, x17, x0
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x3, x17, x19
+               	add	x3, x17, x0
                	mov	x17, #0xeb4f            ; =60239
                	movk	x17, #0x27d4, lsl #16
                	movk	x17, #0xae3d, lsl #32
                	movk	x17, #0xc2b2, lsl #48
-               	eor	x4, x17, x19
+               	eor	x4, x17, x0
                	mov	x17, #0x79f9            ; =31225
                	movk	x17, #0x9e37, lsl #16
                	movk	x17, #0x67b1, lsl #32
                	movk	x17, #0x1656, lsl #48
-               	add	x5, x17, x19
+               	add	x5, x17, x0
                	mov	x17, #0xae63            ; =44643
                	movk	x17, #0xc2b2, lsl #16
                	movk	x17, #0xca77, lsl #32
                	movk	x17, #0x85eb, lsl #48
-               	eor	x6, x17, x19
+               	eor	x6, x17, x0
                	mov	x17, #0x67c5            ; =26565
                	movk	x17, #0x1656, lsl #16
                	movk	x17, #0xeb2f, lsl #32
                	movk	x17, #0x27d4, lsl #48
-               	add	x7, x17, x19
+               	add	x7, x17, x0
                	mov	x17, #0x1e61            ; =7777
                	movk	x17, #0x2e2d, lsl #16
                	movk	x17, #0x3cd7, lsl #32
                	movk	x17, #0x72a6, lsl #48
-               	eor	x8, x17, x19
+               	eor	x8, x17, x0
                	mov	x17, #0x1475            ; =5237
                	movk	x17, #0x85a5, lsl #16
                	movk	x17, #0xea7f, lsl #32
                	movk	x17, #0x42f1, lsl #48
-               	add	x12, x17, x19
+               	add	x12, x17, x0
                	mov	x17, #0xdf1f            ; =57119
                	movk	x17, #0xbe84, lsl #16
                	movk	x17, #0xfe08, lsl #32
                	movk	x17, #0x30be, lsl #48
-               	eor	x13, x17, x19
+               	eor	x13, x17, x0
                	mov	x17, #0x83eb            ; =33771
                	movk	x17, #0x80b5, lsl #16
                	movk	x17, #0x8646, lsl #32
                	movk	x17, #0x61c8, lsl #48
-               	add	x14, x17, x19
+               	add	x14, x17, x0
                	mov	x17, #0x99b1            ; =39345
                	movk	x17, #0x9dbb, lsl #16
                	movk	x17, #0x3f34, lsl #32
                	movk	x17, #0x4cf4, lsl #48
-               	eor	x15, x17, x19
+               	eor	x15, x17, x0
                	mov	x17, #0xaaab            ; =43691
                	movk	x17, #0xaaaa, lsl #16
                	movk	x17, #0xaaaa, lsl #32
                	movk	x17, #0xaaaa, lsl #48
-               	add	x20, x17, x19
+               	add	x19, x17, x0
                	mov	x17, #0x5bdb            ; =23515
                	movk	x17, #0x94b9, lsl #16
                	movk	x17, #0x39cb, lsl #32
                	movk	x17, #0xda3e, lsl #48
-               	eor	x21, x17, x19
+               	eor	x20, x17, x0
                	mov	x17, #0x2ad1            ; =10961
                	movk	x17, #0x5ac2, lsl #16
                	movk	x17, #0x512d, lsl #32
                	movk	x17, #0x1f2e, lsl #48
-               	add	x22, x17, x19
+               	add	x21, x17, x0
                	mov	x17, #0x977f            ; =38783
                	movk	x17, #0x111a, lsl #16
                	movk	x17, #0xe746, lsl #32
                	movk	x17, #0x2d54, lsl #48
-               	eor	x23, x17, x19
+               	eor	x22, x17, x0
                	mov	x17, #0x79b1            ; =31153
                	movk	x17, #0x9e37, lsl #16
-               	add	x24, x17, x19
-               	mov	w25, w24
+               	add	x23, x17, x0
+               	mov	w24, w23
                	mov	x17, #0x9e37            ; =40503
-               	eor	x24, x17, x19
-               	mov	w26, w24
+               	eor	x23, x17, x0
+               	mov	w25, w23
                	mov	x17, #0xca77            ; =51831
                	movk	x17, #0x85eb, lsl #16
-               	add	x24, x17, x19
-               	mov	w27, w24
+               	add	x23, x17, x0
+               	mov	w26, w23
                	mov	x17, #0xae3d            ; =44605
                	movk	x17, #0xc2b2, lsl #16
-               	eor	x24, x17, x19
-               	mov	w28, w24
-               	ucvtf	d0, x19
+               	eor	x23, x17, x0
+               	mov	w27, w23
+               	ucvtf	d0, x0
                	fmov	d31, #1.50000000
                	fadd	d1, d31, d0
                	fmov	d31, #-2.25000000
@@ -140,78 +138,89 @@ Disassembly of section __TEXT,__text:
                	fadd	d7, d31, d0
                	fmov	d31, #-4.50000000
                	fadd	d16, d31, d0
-               	mov	x19, x0
-               	mov	x24, x1
+               	mov	x23, #0x2325            ; =8997
+               	movk	x23, #0x8422, lsl #16
+               	movk	x23, #0x9ce4, lsl #32
+               	movk	x23, #0xcbf2, lsl #48
+               	mov	x28, x1
                	mov	x9, x2
                	stur	x9, [x29, #-0x8]
                	mov	x9, x3
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x4
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x5
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x6
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x7
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x8
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x12
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x13
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x14
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x15
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
+               	mov	x9, x19
+               	stur	x9, [x29, #-0x98]
+               	mov	x9, x20
+               	stur	x9, [x29, #-0x78]
+               	mov	x9, x21
+               	stur	x9, [x29, #-0x88]
+               	mov	x9, x22
+               	stur	x9, [x29, #-0x68]
+               	mov	x9, x24
+               	stur	x9, [x29, #-0x48]
                	mov	x9, x25
                	stur	x9, [x29, #-0x58]
                	mov	x9, x26
                	stur	x9, [x29, #-0x28]
                	mov	x9, x27
                	stur	x9, [x29, #-0x38]
-               	mov	x9, x28
-               	stur	x9, [x29, #-0x48]
                	fmov	d8, d1
                	fmov	d9, d2
                	fmov	d10, d3
@@ -221,29 +230,31 @@ Disassembly of section __TEXT,__text:
                	fmov	d14, d7
                	fmov	d15, d16
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x18
-               	b.lo	 <L1>
-               	b	 <L5>
-<L1>:
-               	lsl	x0, x23, #29
-               	lsr	x1, x23, #35
+               	b.lo	 <L0>
+               	b	 <L4>
+<L0>:
+               	ldur	x9, [x29, #-0x68]
+               	lsl	x0, x9, #29
+               	ldur	x9, [x29, #-0x68]
+               	lsr	x1, x9, #35
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x10]
                	ldur	x10, [x29, #-0x10]
-               	eor	x9, x24, x10
+               	eor	x9, x28, x10
                	stur	x9, [x29, #-0x18]
-               	lsl	x1, x24, #7
-               	lsr	x0, x24, #57
+               	lsl	x1, x28, #7
+               	lsr	x0, x28, #57
                	orr	x9, x1, x0
                	stur	x9, [x29, #-0x20]
                	ldur	x9, [x29, #-0x8]
@@ -255,20 +266,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #53
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x30]
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x30]
                	eor	x27, x9, x10
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #13
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -276,20 +287,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #51
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x40]
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x40]
-               	add	x28, x9, x10
-               	mov	x16, #0xfec0            ; =65216
+               	add	x24, x9, x10
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #17
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -297,20 +308,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #47
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x50]
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x50]
                	eor	x25, x9, x10
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #19
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -318,21 +329,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #45
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x60]
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x60]
-               	add	x9, x10, x11
-               	stur	x9, [x29, #-0x68]
-               	mov	x16, #0xfeb0            ; =65200
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x60]
+               	add	x22, x9, x10
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #23
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -340,21 +350,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #41
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x70]
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x70]
-               	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x78]
-               	mov	x16, #0xfea8            ; =65192
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x70]
+               	eor	x20, x9, x10
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #31
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -362,21 +371,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #33
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x80]
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x80]
-               	add	x9, x10, x11
-               	stur	x9, [x29, #-0x88]
-               	mov	x16, #0xfea0            ; =65184
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x80]
+               	add	x21, x9, x10
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #37
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -384,21 +392,20 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #27
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x90]
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x90]
-               	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x98]
-               	mov	x16, #0xfe98            ; =65176
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x90]
+               	eor	x19, x9, x10
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #41
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -406,7 +413,7 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #23
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xa0]
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -414,13 +421,13 @@ Disassembly of section __TEXT,__text:
                	ldur	x11, [x29, #-0xa0]
                	add	x9, x10, x11
                	stur	x9, [x29, #-0xa8]
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #43
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -428,7 +435,7 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #21
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xb0]
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -436,13 +443,13 @@ Disassembly of section __TEXT,__text:
                	ldur	x11, [x29, #-0xb0]
                	eor	x9, x10, x11
                	stur	x9, [x29, #-0xb8]
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #47
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -450,7 +457,7 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #17
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xc0]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -458,13 +465,13 @@ Disassembly of section __TEXT,__text:
                	ldur	x11, [x29, #-0xc0]
                	add	x9, x10, x11
                	stur	x9, [x29, #-0xc8]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #53
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -472,67 +479,86 @@ Disassembly of section __TEXT,__text:
                	lsr	x1, x9, #11
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xd0]
-               	ldur	x10, [x29, #-0xd0]
-               	eor	x9, x20, x10
+               	ldur	x10, [x29, #-0x98]
+               	ldur	x11, [x29, #-0xd0]
+               	eor	x9, x10, x11
                	stur	x9, [x29, #-0xd8]
-               	lsl	x0, x20, #59
-               	lsr	x1, x20, #5
+               	ldur	x9, [x29, #-0x98]
+               	lsl	x0, x9, #59
+               	ldur	x9, [x29, #-0x98]
+               	lsr	x1, x9, #5
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xe0]
-               	ldur	x10, [x29, #-0xe0]
-               	add	x9, x21, x10
+               	ldur	x10, [x29, #-0x78]
+               	ldur	x11, [x29, #-0xe0]
+               	add	x9, x10, x11
                	stur	x9, [x29, #-0xe8]
-               	lsl	x0, x21, #61
-               	lsr	x1, x21, #3
+               	ldur	x9, [x29, #-0x78]
+               	lsl	x0, x9, #61
+               	ldur	x9, [x29, #-0x78]
+               	lsr	x1, x9, #3
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xf0]
-               	ldur	x10, [x29, #-0xf0]
-               	eor	x9, x22, x10
+               	ldur	x10, [x29, #-0x88]
+               	ldur	x11, [x29, #-0xf0]
+               	eor	x9, x10, x11
                	stur	x9, [x29, #-0xf8]
-               	lsl	x0, x22, #3
-               	lsr	x1, x22, #61
+               	ldur	x9, [x29, #-0x88]
+               	lsl	x0, x9, #3
+               	ldur	x9, [x29, #-0x88]
+               	lsr	x1, x9, #61
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x100]
-               	ldur	x9, [x29, #-0x100]
-               	add	x22, x23, x9
-               	ldur	x9, [x29, #-0x18]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	add	x23, x9, x10
-               	ldur	x9, [x29, #-0xe8]
-               	mov	w0, w9
-               	ldur	x10, [x29, #-0x58]
-               	eor	w9, w10, w0
+               	ldur	x10, [x29, #-0x68]
+               	ldur	x11, [x29, #-0x100]
+               	add	x9, x10, x11
                	mov	x16, #0xfef8            ; =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	w0, w26
-               	ldur	x10, [x29, #-0x28]
-               	add	w9, w10, w0
+               	ldur	x10, [x29, #-0x18]
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x11, [x29, x16]
+               	add	x9, x10, x11
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0x68]
+               	ldur	x9, [x29, #-0xe8]
                	mov	w0, w9
-               	ldur	x10, [x29, #-0x38]
+               	ldur	x10, [x29, #-0x48]
                	eor	w9, w10, w0
                	mov	x16, #0xfee8            ; =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xa8]
-               	mov	w0, w9
-               	ldur	x10, [x29, #-0x48]
+               	mov	w0, w26
+               	ldur	x10, [x29, #-0x58]
                	add	w9, w10, w0
                	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	w0, w22
+               	ldur	x10, [x29, #-0x28]
+               	eor	w9, w10, w0
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xa8]
+               	mov	w0, w9
+               	ldur	x10, [x29, #-0x38]
+               	add	w9, w10, w0
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -540,332 +566,665 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #1.50000000
                	fmul	d0, d8, d30
                	fadd	d31, d0, d9
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
                	fmov	d30, #0.75000000
                	fmul	d0, d9, d30
-               	fadd	d9, d0, d10
+               	fadd	d31, d0, d10
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.25000000
                	fmul	d0, d10, d30
-               	fadd	d10, d0, d11
+               	fadd	d31, d0, d11
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.50000000
                	fmul	d0, d11, d30
-               	fadd	d11, d0, d12
+               	fadd	d31, d0, d12
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.75000000
                	fmul	d0, d12, d30
-               	fadd	d12, d0, d13
+               	fadd	d31, d0, d13
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.62500000
                	fmul	d0, d13, d30
-               	fadd	d13, d0, d14
+               	fadd	d31, d0, d14
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.12500000
                	fmul	d0, d14, d30
-               	fadd	d14, d0, d15
+               	fadd	d31, d0, d15
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.87500000
                	fmul	d0, d15, d30
-               	fadd	d15, d0, d8
+               	fadd	d31, d0, d8
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	ldur	x9, [x29, #-0xa8]
                	eor	x1, x26, x9
-               	mov	x0, x19
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x0, x23
+<L1>:
+               	bl	 <L1>
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	w1, w9
-<L3>:
-               	bl	 <L3>
-               	mov	x16, #0xfed0            ; =65232
+<L2>:
+               	bl	 <L2>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
-               	fadd	d0, d31, d12
-<L4>:
-               	bl	 <L4>
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d30, [x29, x16]
+               	fadd	d0, d31, d30
+               	fmov	x1, d0
+<L3>:
+               	bl	 <L3>
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x15, x9, #0x1
-               	mov	x19, x0
-               	mov	x24, x26
+               	mov	x23, x0
+               	mov	x28, x26
                	mov	x9, x27
                	stur	x9, [x29, #-0x8]
-               	mov	x9, x28
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x9, x24
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x25
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x68]
-               	mov	x9, x10
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x9, x22
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x78]
-               	mov	x9, x10
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x9, x20
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x88]
-               	mov	x9, x10
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x9, x21
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x98]
-               	mov	x9, x10
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x9, x19
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xa8]
                	mov	x9, x10
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xb8]
                	mov	x9, x10
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xc8]
                	mov	x9, x10
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xd8]
                	mov	x9, x10
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xe8]
-               	mov	x20, x9
-               	ldur	x9, [x29, #-0xf8]
-               	mov	x21, x9
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
+               	ldur	x10, [x29, #-0xe8]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x58]
-               	mov	x16, #0xfee8            ; =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
+               	stur	x9, [x29, #-0x98]
+               	ldur	x10, [x29, #-0xf8]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x28]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	mov	x9, x10
-               	stur	x9, [x29, #-0x38]
+               	stur	x9, [x29, #-0x78]
                	mov	x16, #0xfef8            ; =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
+               	stur	x9, [x29, #-0x88]
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x68]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
                	stur	x9, [x29, #-0x48]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x58]
                	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x28]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x38]
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	ldr	d8, [x29, x16]
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d9, [x29, x16]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d10, [x29, x16]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d11, [x29, x16]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d12, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d13, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d14, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d15, [x29, x16]
                	mov	x9, x15
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x18
-               	b.lo	 <L1>
+               	b.lo	 <L0>
+<L4>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	mov	x0, x19
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	lsr	x15, x28, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x15, x16
+               	eor	x15, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfec8            ; =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x8]
+               	lsr	x15, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x15, x16
+               	eor	x15, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x15, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x15, x16
+               	eor	x15, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
 <L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
 <L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
 <L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
 <L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x20
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x21
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x22
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L19>
 <L20>:
-               	bl	 <L20>
-               	mov	x1, x23
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x58]
-               	mov	w1, w9
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L21>
 <L22>:
-               	bl	 <L22>
-               	ldur	x9, [x29, #-0x28]
-               	mov	w1, w9
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	bl	 <L23>
-               	ldur	x9, [x29, #-0x38]
-               	mov	w1, w9
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe08            ; =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x98]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x78]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x88]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x68]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x2, x16
+               	eor	x2, x23, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L35>
+<L36>:
                	ldur	x9, [x29, #-0x48]
                	mov	w1, w9
-<L25>:
-               	bl	 <L25>
-               	fmov	d0, d8
-<L26>:
-               	bl	 <L26>
-               	fmov	d0, d9
-<L27>:
-               	bl	 <L27>
-               	fmov	d0, d10
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d11
-<L29>:
-               	bl	 <L29>
-               	fmov	d0, d12
-<L30>:
-               	bl	 <L30>
-               	fmov	d0, d13
-<L31>:
-               	bl	 <L31>
-               	fmov	d0, d14
-<L32>:
-               	bl	 <L32>
-               	fmov	d0, d15
-<L33>:
-               	bl	 <L33>
-               	sub	x16, x29, #0x1f0
+               	mov	x0, x23
+<L37>:
+               	bl	 <L37>
+               	ldur	x9, [x29, #-0x58]
+               	mov	w1, w9
+<L38>:
+               	bl	 <L38>
+               	ldur	x9, [x29, #-0x28]
+               	mov	w1, w9
+<L39>:
+               	bl	 <L39>
+               	ldur	x9, [x29, #-0x38]
+               	mov	w1, w9
+<L40>:
+               	bl	 <L40>
+               	fmov	x1, d8
+<L41>:
+               	bl	 <L41>
+               	fmov	x1, d9
+<L42>:
+               	bl	 <L42>
+               	fmov	x1, d10
+<L43>:
+               	bl	 <L43>
+               	fmov	x1, d11
+<L44>:
+               	bl	 <L44>
+               	fmov	x1, d12
+<L45>:
+               	bl	 <L45>
+               	fmov	x1, d13
+<L46>:
+               	bl	 <L46>
+               	fmov	x1, d14
+<L47>:
+               	bl	 <L47>
+               	fmov	x1, d15
+<L48>:
+               	bl	 <L48>
+               	sub	x16, x29, #0x270
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
                	ldp	d12, d13, [x16, #-0x20]
                	ldp	d14, d15, [x16, #-0x30]
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	ldp	x21, x22, [x29, #-0x1b0]
-               	ldp	x23, x24, [x29, #-0x1c0]
-               	ldp	x25, x26, [x29, #-0x1d0]
-               	ldp	x27, x28, [x29, #-0x1e0]
+               	sub	x16, x29, #0x220
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/imm/imm_add.dis
+++ b/test/golden/aarch64-darwin/imm/imm_add.dis
@@ -5,178 +5,382 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_add.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
+               	stur	x21, [x29, #-0x18]
                	mov	x19, x0
+               	mov	w0, w19
+               	add	w1, w0, #0x7ff
+               	mov	w0, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	add	w20, w2, #0x7ff
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	w21, w20, #0x800
-               	mov	x0, x1
-               	mov	w1, w21
+               	add	w0, w1, #0x800
+               	mov	w1, w0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	w22, w21, #0xfff
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	w21, w22, #0x1, lsl #12 ; =0x1000
-               	mov	x0, x1
-               	mov	w1, w21
+               	add	w1, w0, #0xfff
+               	mov	w0, w1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	w0, w1, #0x1, lsl #12   ; =0x1000
+               	mov	w1, w0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0x7fff, lsl #16
-               	add	w22, w21, w16
-               	mov	x0, x1
-               	mov	w1, w22
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+               	add	w1, w0, w16
+               	mov	w0, w1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	w16, #-0x80000000       ; =-2147483648
-               	add	w21, w22, w16
-               	mov	x0, x1
-               	mov	w1, w21
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	add	w0, w1, w16
+               	mov	w1, w0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0xffff, lsl #16
-               	add	w2, w21, w16
-               	mov	x0, x1
-               	mov	w1, w2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	add	x21, x19, #0x7ff
-               	mov	x0, x1
-               	mov	x1, x21
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sub	x19, x21, #0x800
-               	mov	x0, x1
-               	mov	x1, x19
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	add	x22, x19, #0xfff, lsl #12 ; =0xfff000
-               	mov	x0, x1
-               	mov	x1, x22
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+               	add	w1, w0, w16
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x0, x19, #0x7ff
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	sub	x1, x0, #0x800
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	add	x0, x1, #0xfff, lsl #12 ; =0xfff000
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xff, lsl #16
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x7fff, lsl #16
-               	add	x22, x23, x16
-               	mov	x0, x1
-               	mov	x1, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	mov	x16, #0x80000000        ; =2147483648
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
-               	add	x22, x23, x16
-               	mov	x0, x1
-               	mov	x1, x22
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
                	mov	x16, #0x100000000       ; =4294967296
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L28>
+<L29>:
                	mov	x16, #-0x8000000000000000 ; =-9223372036854775808
-               	add	x2, x23, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	sub	w22, w20, #0x800
-               	mov	x0, x1
-               	mov	w1, w22
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	w0, w19
+               	add	w20, w0, #0x7ff
+               	sxtw	x1, w20
+               	mov	x0, x2
+<L32>:
+               	bl	 <L32>
+               	sub	w21, w20, #0x800
+               	sxtw	x1, w21
+<L33>:
+               	bl	 <L33>
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0x7fff, lsl #16
-               	add	w20, w22, w16
-               	mov	x0, x1
-               	mov	w1, w20
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
+               	add	w20, w21, w16
+               	sxtw	x1, w20
+<L34>:
+               	bl	 <L34>
                	mov	w16, #-0x80000000       ; =-2147483648
-               	sub	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
+               	sub	w1, w20, w16
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	add	x20, x19, #0x7ff
+               	mov	x1, x20
+<L36>:
+               	bl	 <L36>
+               	sub	x19, x20, #0x800
                	mov	x1, x19
-<L22>:
-               	bl	 <L22>
-               	mov	x1, x0
+<L37>:
+               	bl	 <L37>
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x7fff, lsl #16
                	add	x20, x19, x16
-               	mov	x0, x1
                	mov	x1, x20
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x0
+<L38>:
+               	bl	 <L38>
                	mov	x16, #-0x8000000000000000 ; =-9223372036854775808
-               	sub	x2, x20, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L24>:
-               	bl	 <L24>
+               	sub	x1, x20, x16
+<L39>:
+               	bl	 <L39>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/imm/imm_addr.dis
+++ b/test/golden/aarch64-darwin/imm/imm_addr.dis
@@ -6,230 +6,532 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x9, lsl #12   ; =0x9000
-               	sub	sp, sp, #0x350
+               	sub	sp, sp, #0x320
                	mov	x16, #0x6cf0            ; =27888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x16, x29, x16
                	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
+               	stur	x21, [x16, #-0x8]
                	mov	x16, #0x7c00            ; =31744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	add	x1, x20, #0x0
+               	add	x19, x29, x16
+               	add	x1, x19, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x8400             ; =33792
-<L1>:
+<L0>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x16, #0x6d00            ; =27904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x1, x21, #0x0
+               	add	x1, x29, x16
                	add	x2, x1, #0x0
-               	mov	x1, #0xf00              ; =3840
-<L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L2>
-               	add	x1, x19, #0x1
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	add	x1, x19, #0x2
-               	add	x22, x20, #0x7f8
-               	str	x1, [x22]
-               	add	x1, x19, #0x3
-               	add	x23, x20, #0x800
-               	str	x1, [x23]
-               	add	x1, x19, #0x4
+               	add	x3, x2, #0x0
+               	mov	x2, #0xf00              ; =3840
+<L1>:
+               	str	xzr, [x3]
+               	add	x3, x3, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L1>
+               	add	x2, x0, #0x1
+               	add	x3, x19, #0x0
+               	str	x2, [x3]
+               	add	x2, x0, #0x2
+               	add	x4, x19, #0x7f8
+               	str	x2, [x4]
+               	add	x2, x0, #0x3
+               	add	x4, x19, #0x800
+               	str	x2, [x4]
+               	add	x2, x0, #0x4
                	mov	x16, #0x7ff8            ; =32760
-               	add	x24, x20, x16
-               	str	x1, [x24]
-               	add	x1, x19, #0x5
-               	add	x25, x20, #0x8, lsl #12 ; =0x8000
-               	str	x1, [x25]
-               	add	x1, x19, #0x6
+               	add	x4, x19, x16
+               	str	x2, [x4]
+               	add	x2, x0, #0x5
+               	add	x4, x19, #0x8, lsl #12  ; =0x8000
+               	str	x2, [x4]
+               	add	x2, x0, #0x6
                	mov	x16, #0x83f8            ; =33784
-               	add	x26, x20, x16
-               	str	x1, [x26]
-               	ldr	x1, [x2]
+               	add	x4, x19, x16
+               	str	x2, [x4]
+               	ldr	x2, [x3]
+               	mov	x3, #0x2325             ; =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldr	x1, [x22]
+               	add	x2, x19, #0x7f8
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldr	x1, [x23]
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ldr	x1, [x24]
+               	add	x2, x19, #0x800
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ldr	x1, [x25]
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ldr	x1, [x26]
+               	mov	x16, #0x7ff8            ; =32760
+               	add	x2, x19, x16
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, #0x1080             ; =4224
-               	cbnz	x1,  <L9>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x19, #0xfff
-               	mov	x3, #0x1080             ; =4224
-               	cbnz	x3,  <L10>
-               	brk	#0
+               	add	x2, x19, #0x8, lsl #12  ; =0x8000
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
-               	add	x1, x19, #0x800
-               	mov	x3, #0x1080             ; =4224
-               	cbnz	x3,  <L11>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	udiv	x16, x1, x3
-               	msub	x5, x16, x3, x1
-               	add	x1, x20, x2, lsl #3
-               	ldr	x2, [x1]
-               	add	x3, x2, #0x7
-               	str	x3, [x1]
-               	add	x22, x20, x4, lsl #3
-               	ldr	x2, [x22]
-               	add	x3, x2, #0x8
-               	str	x3, [x22]
-               	add	x23, x20, x5, lsl #3
-               	ldr	x2, [x23]
-               	add	x3, x2, #0x9
-               	str	x3, [x23]
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x83f8            ; =33784
+               	add	x2, x19, x16
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldr	x1, [x22]
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldr	x1, [x23]
+               	mov	x2, #0x1080             ; =4224
+               	cbnz	x2,  <L14>
+               	brk	#0
 <L14>:
-               	bl	 <L14>
-               	mov	x1, #0x60               ; =96
-               	cbnz	x1,  <L15>
+               	udiv	x16, x0, x2
+               	msub	x4, x16, x2, x0
+               	add	x2, x0, #0xfff
+               	mov	x5, #0x1080             ; =4224
+               	cbnz	x5,  <L15>
                	brk	#0
 <L15>:
-               	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x19, #0x3f
-               	mov	x3, #0x60               ; =96
-               	cbnz	x3,  <L16>
+               	udiv	x16, x2, x5
+               	msub	x6, x16, x5, x2
+               	add	x2, x0, #0x800
+               	mov	x5, #0x1080             ; =4224
+               	cbnz	x5,  <L16>
                	brk	#0
 <L16>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
-               	mov	x16, #0x28              ; =40
-               	mul	x1, x2, x16
-               	add	x2, x21, x1
-               	add	x1, x2, #0x0
-               	mov	w17, #0xffff            ; =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x3, x19, #0xa
-               	add	x5, x2, #0x8
-               	add	x20, x5, #0x0
-               	str	x3, [x20]
-               	add	x3, x19, #0xb
-               	add	x22, x5, #0x8
-               	str	x3, [x22]
-               	add	x3, x19, #0xc
-               	add	x23, x5, #0x10
-               	str	x3, [x23]
-               	add	x25, x2, #0x20
-               	mov	w17, #0x5678            ; =22136
-               	movk	w17, #0x1234, lsl #16
-               	str	w17, [x25]
+               	udiv	x16, x2, x5
+               	msub	x7, x16, x5, x2
+               	add	x2, x19, x4, lsl #3
+               	ldr	x4, [x2]
+               	add	x5, x4, #0x7
+               	str	x5, [x2]
+               	add	x4, x19, x6, lsl #3
+               	ldr	x5, [x4]
+               	add	x8, x5, #0x8
+               	str	x8, [x4]
+               	add	x4, x19, x7, lsl #3
+               	ldr	x5, [x4]
+               	add	x8, x5, #0x9
+               	str	x8, [x4]
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x8, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x8, x16
+               	eor	x8, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	add	x2, x19, x6, lsl #3
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x19, x7, lsl #3
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	mov	x2, #0x60               ; =96
+               	cbnz	x2,  <L23>
+               	brk	#0
+<L23>:
+               	udiv	x16, x0, x2
+               	msub	x4, x16, x2, x0
+               	add	x2, x0, #0x3f
+               	mov	x5, #0x60               ; =96
+               	cbnz	x5,  <L24>
+               	brk	#0
+<L24>:
+               	udiv	x16, x2, x5
+               	msub	x6, x16, x5, x2
                	mov	x16, #0x28              ; =40
                	mul	x2, x4, x16
-               	add	x3, x21, x2
-               	add	x21, x3, #0x0
+               	add	x5, x1, x2
+               	add	x2, x5, #0x0
+               	mov	w17, #0xffff            ; =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x2]
+               	add	x7, x0, #0xa
+               	add	x8, x5, #0x8
+               	add	x12, x8, #0x0
+               	str	x7, [x12]
+               	add	x7, x0, #0xb
+               	add	x12, x8, #0x8
+               	str	x7, [x12]
+               	add	x7, x0, #0xc
+               	add	x12, x8, #0x10
+               	str	x7, [x12]
+               	add	x7, x5, #0x20
+               	mov	w17, #0x5678            ; =22136
+               	movk	w17, #0x1234, lsl #16
+               	str	w17, [x7]
+               	mov	x16, #0x28              ; =40
+               	mul	x5, x6, x16
+               	add	x7, x1, x5
+               	add	x5, x7, #0x0
                	mov	w17, #0xef01            ; =61185
                	movk	w17, #0xabcd, lsl #16
-               	str	w17, [x21]
-               	add	x2, x19, #0xd
-               	add	x4, x3, #0x8
-               	add	x26, x4, #0x0
-               	str	x2, [x26]
-               	add	x2, x19, #0xe
-               	add	x27, x4, #0x8
-               	str	x2, [x27]
-               	add	x2, x19, #0xf
-               	add	x19, x4, #0x10
-               	str	x2, [x19]
-               	add	x28, x3, #0x20
+               	str	w17, [x5]
+               	add	x5, x0, #0xd
+               	add	x8, x7, #0x8
+               	add	x12, x8, #0x0
+               	str	x5, [x12]
+               	add	x5, x0, #0xe
+               	add	x12, x8, #0x8
+               	str	x5, [x12]
+               	add	x5, x0, #0xf
+               	add	x0, x8, #0x10
+               	str	x5, [x0]
+               	add	x0, x7, #0x20
                	mov	w17, #0x4567            ; =17767
                	movk	w17, #0x123, lsl #16
-               	str	w17, [x28]
+               	str	w17, [x0]
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x0, x16
+               	lsr	x7, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x0
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x8
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x10
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x20
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x6, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x0
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x6, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x0
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	mov	x16, #0x28              ; =40
+               	mul	x0, x6, x16
+               	add	x20, x1, x0
+               	add	x21, x20, #0x8
+               	add	x0, x21, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x3
+<L39>:
+               	bl	 <L39>
+               	add	x1, x21, #0x10
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
+               	add	x1, x20, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L17>:
-               	bl	 <L17>
-               	ldr	x1, [x20]
-<L18>:
-               	bl	 <L18>
-               	ldr	x1, [x22]
-<L19>:
-               	bl	 <L19>
-               	ldr	x1, [x23]
-<L20>:
-               	bl	 <L20>
-               	ldr	w1, [x25]
-<L21>:
-               	bl	 <L21>
-               	ldr	w1, [x21]
-<L22>:
-               	bl	 <L22>
-               	ldr	x1, [x26]
-<L23>:
-               	bl	 <L23>
-               	ldr	x1, [x27]
-<L24>:
-               	bl	 <L24>
-               	ldr	x1, [x19]
-<L25>:
-               	bl	 <L25>
-               	ldr	w1, [x28]
-<L26>:
-               	bl	 <L26>
-               	ldr	x1, [x24]
-               	add	x2, x1, #0x10
-               	str	x2, [x24]
-               	ldr	x1, [x24]
-<L27>:
-               	bl	 <L27>
+<L41>:
+               	bl	 <L41>
+               	mov	x16, #0x7ff8            ; =32760
+               	add	x1, x19, x16
+               	ldr	x2, [x1]
+               	add	x3, x2, #0x10
+               	str	x3, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L42>:
+               	bl	 <L42>
                	mov	x16, #0x6cf0            ; =27888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x16, x29, x16
                	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
-               	ldp	x27, x28, [x16, #-0x40]
+               	ldur	x21, [x16, #-0x8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/imm/imm_logic.dis
+++ b/test/golden/aarch64-darwin/imm/imm_logic.dis
@@ -5,188 +5,407 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_logic.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
                	mov	x19, x0
+               	mov	w0, w19
+               	mov	w16, #0x5555            ; =21845
+               	movk	w16, #0x5555, lsl #16
+               	orr	w1, w0, w16
+               	mov	w2, w1
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
-               	mov	w16, #0x5555            ; =21845
-               	movk	w16, #0x5555, lsl #16
-               	orr	w21, w20, w16
-               	mov	x0, x1
-               	mov	w1, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	mov	w16, #0x5555            ; =21845
                	movk	w16, #0x5555, lsl #16
-               	eor	w2, w20, w16
+               	eor	w2, w0, w16
                	mov	w16, #0xf0f             ; =3855
                	movk	w16, #0xf0f, lsl #16
                	and	w3, w2, w16
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	w16, #-0x10000          ; =-65536
-               	orr	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	w16, #0xffff            ; =65535
-               	and	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w16, #-0x10000          ; =-65536
+               	orr	w2, w0, w16
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	w22, w20
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+               	mov	w16, #0xffff            ; =65535
+               	and	w2, w0, w16
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mvn	w2, w0
+               	mov	w3, w2
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	w16, #0x5555            ; =21845
                	movk	w16, #0x5555, lsl #16
-               	orr	w2, w22, w16
-               	mvn	w3, w2
-               	mov	x0, x1
-               	mov	w1, w3
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	orr	w3, w2, w16
+               	mvn	w2, w3
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xf0f             ; =3855
                	movk	w16, #0xf0f, lsl #16
-               	and	w2, w20, w16
+               	and	w2, w0, w16
                	mov	w16, #-0x10000          ; =-65536
-               	eor	w3, w2, w16
-               	mov	x0, x1
-               	mov	w1, w3
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+               	eor	w0, w2, w16
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	orr	x23, x19, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+               	orr	x0, x19, x16
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	eor	x2, x19, x16
+               	eor	x0, x19, x16
                	mov	x16, #0xf0f             ; =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+               	and	x2, x0, x16
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x16, #0xffff0000        ; =4294901760
                	movk	x16, #0xffff, lsl #48
-               	orr	x2, x19, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+               	orr	x0, x19, x16
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x16, #0xff              ; =255
                	movk	x16, #0xff, lsl #16
                	movk	x16, #0xff, lsl #32
                	movk	x16, #0xff, lsl #48
-               	and	x2, x19, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mvn	x24, x19
-               	mov	x0, x1
-               	mov	x1, x24
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+               	and	x0, x19, x16
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mvn	x0, x19
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	orr	x2, x24, x16
-               	mvn	x3, x2
-               	mov	x0, x1
-               	mov	x1, x3
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	orr	x2, x0, x16
+               	mvn	x0, x2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x16, #0xf0f             ; =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x2, x19, x16
+               	and	x0, x19, x16
                	mov	x16, #0xffff0000        ; =4294901760
                	movk	x16, #0xffff, lsl #48
-               	eor	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w21
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w22
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	eor	w2, w20, w22
+               	eor	x2, x0, x16
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	w0, w19
+               	mov	w16, #0x5555            ; =21845
+               	movk	w16, #0x5555, lsl #16
+               	orr	w2, w0, w16
+               	sxtw	x3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mvn	w2, w0
+               	sxtw	x3, w2
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	eor	w3, w0, w2
                	mov	w16, #0xf0f             ; =3855
                	movk	w16, #0xf0f, lsl #16
-               	and	w3, w2, w16
+               	and	w0, w3, w16
+               	sxtw	x2, w0
                	mov	x0, x1
-               	mov	w1, w3
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	eor	x2, x19, x24
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0x5555            ; =21845
+               	movk	x16, #0x5555, lsl #16
+               	movk	x16, #0x5555, lsl #32
+               	movk	x16, #0x5555, lsl #48
+               	orr	x1, x19, x16
+<L33>:
+               	bl	 <L33>
+               	mvn	x20, x19
+               	mov	x1, x20
+<L34>:
+               	bl	 <L34>
+               	eor	x1, x19, x20
                	mov	x16, #0xf0f             ; =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L20>:
-               	bl	 <L20>
+               	and	x2, x1, x16
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/imm/imm_mov.dis
+++ b/test/golden/aarch64-darwin/imm/imm_mov.dis
@@ -5,120 +5,297 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_mov.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x19, x0
+               	sub	sp, sp, #0x20
+               	cmp	x0, #0x0
+               	b.eq	 <L0>
+               	mov	w1, #-0x80000000        ; =-2147483648
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	cmp	x19, #0x0
-               	b.eq	 <L1>
-               	mov	w1, #-0x80000000        ; =-2147483648
-               	b	 <L2>
-<L1>:
                	mov	w1, #0x7ff              ; =2047
+<L1>:
+               	mov	w2, w1
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	cmp	x19, #0x1
-               	b.eq	 <L3>
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0x7fff, lsl #48
-               	b	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
+               	cmp	x0, #0x1
+               	b.eq	 <L4>
+               	mov	x2, #0xffff             ; =65535
+               	movk	x2, #0xffff, lsl #16
+               	movk	x2, #0xffff, lsl #32
+               	movk	x2, #0x7fff, lsl #48
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	cmp	x19, #0x2
-               	b.eq	 <L5>
-               	mov	w1, #0xf0f              ; =3855
-               	movk	w1, #0xf0f, lsl #16
-               	b	 <L6>
+               	mov	x2, #0xffff             ; =65535
+               	movk	x2, #0xffff, lsl #16
 <L5>:
-               	mov	w1, #0x5555             ; =21845
-               	movk	w1, #0x5555, lsl #16
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	cmp	x19, #0x3
-               	b.eq	 <L7>
-               	mov	x1, #0xffff0000         ; =4294901760
-               	movk	x1, #0xffff, lsl #48
-               	b	 <L8>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x1, #0x5555             ; =21845
-               	movk	x1, #0x5555, lsl #16
-               	movk	x1, #0x5555, lsl #32
-               	movk	x1, #0x5555, lsl #48
+               	cmp	x0, #0x2
+               	b.eq	 <L8>
+               	mov	w2, #0xf0f              ; =3855
+               	movk	w2, #0xf0f, lsl #16
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	sub	x20, x29, #0x18
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	add	x1, x20, #0x0
-               	mov	x17, #0x100000000       ; =4294967296
-               	str	x17, [x1]
-               	add	x1, x20, #0x8
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x1]
-               	add	x1, x20, #0x10
-               	mov	x17, #0xffff0000        ; =4294901760
-               	str	x17, [x1]
-               	mov	x1, #0x3                ; =3
-               	cbnz	x1,  <L9>
-               	brk	#0
+               	mov	w2, #0x5555             ; =21845
+               	movk	w2, #0x5555, lsl #16
 <L9>:
-               	udiv	x16, x19, x1
-               	msub	x21, x16, x1, x19
-               	add	x1, x20, x21, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x1, x21, #0x1
-               	mov	x2, #0x3                ; =3
-               	cbnz	x2,  <L11>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x20, x3, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	cmp	x0, #0x3
+               	b.eq	 <L12>
+               	mov	x2, #0xffff0000         ; =4294901760
+               	movk	x2, #0xffff, lsl #48
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	add	x1, x21, #0x2
-               	mov	x2, #0x3                ; =3
-               	cbnz	x2,  <L13>
-               	brk	#0
+               	mov	x2, #0x5555             ; =21845
+               	movk	x2, #0x5555, lsl #16
+               	movk	x2, #0x5555, lsl #32
+               	movk	x2, #0x5555, lsl #48
 <L13>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x20, x3, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	w1, w19
-               	mov	w17, #0x7ff             ; =2047
-               	add	w2, w17, w1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, #-0x80000000        ; =-2147483648
+               	sub	x2, x29, #0x18
+               	str	xzr, [x2]
+               	str	xzr, [x2, #0x8]
+               	str	xzr, [x2, #0x10]
+               	add	x3, x2, #0x0
+               	mov	x17, #0x100000000       ; =4294967296
+               	str	x17, [x3]
+               	add	x3, x2, #0x8
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff0000        ; =4294901760
+               	str	x17, [x3]
+               	mov	x3, #0x3                ; =3
+               	cbnz	x3,  <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mov	x1, #-0x8000000000000000 ; =-9223372036854775808
+               	udiv	x16, x0, x3
+               	msub	x4, x16, x3, x0
+               	add	x3, x2, x4, lsl #3
+               	ldr	x5, [x3]
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	mov	w1, #0x5555             ; =21845
-               	movk	w1, #0x5555, lsl #16
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x1, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	add	x3, x4, #0x1
+               	mov	x5, #0x3                ; =3
+               	cbnz	x5,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	x16, x3, x5
+               	msub	x6, x16, x5, x3
+               	add	x3, x2, x6, lsl #3
+               	ldr	x5, [x3]
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x1, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x3, x4, #0x2
+               	mov	x4, #0x3                ; =3
+               	cbnz	x4,  <L22>
+               	brk	#0
+<L22>:
+               	udiv	x16, x3, x4
+               	msub	x5, x16, x4, x3
+               	add	x3, x2, x5, lsl #3
+               	ldr	x2, [x3]
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	mov	w2, w0
+               	mov	w17, #0x7ff             ; =2047
+               	add	w0, w17, w2
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x80000000        ; =2147483648
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x5555            ; =21845
+               	movk	x17, #0x5555, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x0, x1
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/addr_modes.dis
+++ b/test/golden/aarch64-darwin/mem/addr_modes.dis
@@ -6,8 +6,8 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x3, lsl #12   ; =0x3000
-               	sub	sp, sp, #0x430
-               	mov	x16, #0xcc10            ; =52240
+               	sub	sp, sp, #0x420
+               	mov	x16, #0xcc20            ; =52256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -18,9 +18,7 @@ Disassembly of section __TEXT,__text:
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x40
+               	sub	x20, x29, #0x140
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -29,142 +27,145 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x28]
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
-               	sub	x21, x29, #0xc0
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x80               ; =128
+               	sub	x21, x29, #0x1c0
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x80               ; =128
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	sub	x22, x29, #0x2c0
+               	add	x0, x22, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x100              ; =256
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L1>
-               	sub	x22, x29, #0x1c0
-               	add	x1, x22, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x100              ; =256
+               	sub	x23, x29, #0x4c0
+               	add	x0, x23, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x200              ; =512
 <L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L2>
-               	sub	x23, x29, #0x3c0
-               	add	x1, x23, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x200              ; =512
+               	sub	x24, x29, #0x8c0
+               	add	x0, x24, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x400              ; =1024
 <L3>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L3>
-               	sub	x24, x29, #0x7c0
-               	add	x1, x24, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x400              ; =1024
+               	sub	x25, x29, #0xbc0
+               	add	x0, x25, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x300              ; =768
 <L4>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L4>
-               	sub	x25, x29, #0xac0
-               	add	x1, x25, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x300              ; =768
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x40
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L5>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x40
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
                	mov	x16, #0x3               ; =3
-               	mul	x2, x1, x16
-               	add	x3, x2, #0x1
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x20, x1
-               	strb	w3, [x2]
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x1
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x20, x0
+               	strb	w2, [x1]
                	mov	x16, #0x44f             ; =1103
-               	mul	x2, x1, x16
-               	add	x3, x2, #0x7
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x21, x1, lsl #1
-               	strh	w3, [x2]
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x7
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x21, x0, lsl #1
+               	strh	w2, [x1]
                	mov	x16, #0x79b1            ; =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x3, x2, #0xb
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x22, x1, lsl #2
-               	str	w3, [x2]
-               	add	x2, x1, #0x1
+               	mul	x1, x0, x16
+               	add	x2, x1, #0xb
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x22, x0, lsl #2
+               	str	w2, [x1]
+               	add	x1, x0, #0x1
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	add	x3, x23, x1, lsl #3
-               	str	x4, [x3]
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	add	x2, x23, x0, lsl #3
+               	str	x3, [x2]
                	mov	x16, #0x5               ; =5
-               	mul	x3, x1, x16
-               	add	x4, x3, #0x2
-               	add	x3, x4, x19
-               	mov	w4, w3
+               	mul	x2, x0, x16
+               	add	x3, x2, #0x2
+               	add	x2, x3, x19
+               	mov	w3, w2
                	mov	x16, #0x10              ; =16
-               	mul	x3, x1, x16
-               	add	x5, x24, x3
-               	add	x3, x5, #0x0
-               	strh	w4, [x3]
-               	add	x3, x1, #0x80
-               	mov	w4, w3
-               	add	x3, x5, #0x2
-               	strb	w4, [x3]
+               	mul	x2, x0, x16
+               	add	x4, x24, x2
+               	add	x2, x4, #0x0
+               	strh	w3, [x2]
+               	add	x2, x0, #0x80
+               	mov	w3, w2
+               	add	x2, x4, #0x2
+               	strb	w3, [x2]
                	mov	x17, #0x1b3             ; =435
                	movk	x17, #0x100, lsl #32
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	add	x3, x5, #0x8
-               	str	x4, [x3]
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	add	x2, x4, #0x8
+               	str	x3, [x2]
                	mov	x16, #0x11              ; =17
-               	mul	x3, x1, x16
-               	add	x4, x3, #0x1
-               	add	x5, x4, x19
-               	mov	w4, w5
+               	mul	x2, x0, x16
+               	add	x3, x2, #0x1
+               	add	x4, x3, x19
+               	mov	w3, w4
                	mov	x16, #0xc               ; =12
-               	mul	x5, x1, x16
-               	add	x6, x25, x5
-               	add	x5, x6, #0x0
-               	str	w4, [x5]
-               	add	x4, x3, #0x2
-               	add	x5, x4, x19
-               	mov	w4, w5
-               	add	x5, x6, #0x4
-               	str	w4, [x5]
-               	add	x4, x3, #0x3
-               	add	x3, x4, x19
-               	mov	w4, w3
-               	add	x3, x6, #0x8
-               	str	w4, [x3]
-               	mov	x1, x2
-               	cmp	x1, #0x40
-               	b.lo	 <L6>
-<L7>:
-               	mov	x26, x0
+               	mul	x4, x0, x16
+               	add	x5, x25, x4
+               	add	x4, x5, #0x0
+               	str	w3, [x4]
+               	add	x3, x2, #0x2
+               	add	x4, x3, x19
+               	mov	w3, w4
+               	add	x4, x5, #0x4
+               	str	w3, [x4]
+               	add	x3, x2, #0x3
+               	add	x2, x3, x19
+               	mov	w3, w2
+               	add	x2, x5, #0x8
+               	str	w3, [x2]
+               	mov	x0, x1
+               	cmp	x0, #0x40
+               	b.lo	 <L5>
+<L6>:
+               	mov	x26, #0x2325            ; =8997
+               	movk	x26, #0x8422, lsl #16
+               	movk	x26, #0x9ce4, lsl #32
+               	movk	x26, #0xcbf2, lsl #48
                	mov	x27, #0x0               ; =0
                	cmp	x27, #0x40
-               	b.lo	 <L8>
-               	b	 <L19>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L22>
+<L7>:
                	mov	x16, #0xd               ; =13
                	mul	x0, x27, x16
                	add	x1, x0, x19
@@ -172,148 +173,258 @@ Disassembly of section __TEXT,__text:
                	and	x28, x1, x16
                	add	x0, x20, x28
                	ldrb	w1, [x0]
-               	mov	x0, x26
+               	uxtb	w0, w1
+               	mov	x1, x26
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	add	x1, x21, x28, lsl #1
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	add	x0, x21, x28, lsl #1
+               	ldrh	w2, [x0]
+               	uxth	w0, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x1, x22, x28, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	add	x1, x23, x28, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x0, x22, x28, lsl #2
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0x10              ; =16
-               	mul	x1, x28, x16
-               	add	x9, x24, x1
-               	mov	x16, #0xcc28            ; =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xcc28            ; =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrh	w3, [x1]
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x16, #0xcc28            ; =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x2
-               	ldrb	w3, [x1]
-               	mov	x1, x3
+               	add	x0, x23, x28, lsl #3
+               	ldr	x2, [x0]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x16, #0xcc28            ; =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x16, #0xc               ; =12
-               	mul	x1, x28, x16
-               	add	x28, x25, x1
-               	add	x1, x28, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x10              ; =16
+               	mul	x0, x28, x16
+               	add	x2, x24, x0
+               	add	x0, x2, #0x0
+               	ldrh	w2, [x0]
+               	uxth	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
 <L16>:
                	bl	 <L16>
-               	add	x1, x28, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x10              ; =16
+               	mul	x1, x28, x16
+               	add	x2, x24, x1
+               	add	x1, x2, #0x2
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
 <L17>:
                	bl	 <L17>
-               	add	x1, x28, #0x8
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L18>:
-               	bl	 <L18>
-               	add	x27, x27, #0x1
-               	mov	x26, x0
-               	cmp	x27, #0x40
-               	b.lo	 <L8>
-<L19>:
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x20
-               	b.lo	 <L20>
-               	b	 <L26>
-<L20>:
-               	mov	x16, #0x2               ; =2
-               	mul	x25, x21, x16
-               	add	x0, x22, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x26
-<L21>:
-               	bl	 <L21>
-               	lsl	x1, x21, #1
-               	add	x2, x22, x1, lsl #2
-               	ldr	w1, [x2]
-<L22>:
-               	bl	 <L22>
-               	add	x27, x21, #0x1
-               	mov	x16, #0x2               ; =2
-               	mul	x1, x27, x16
-               	sub	x2, x1, #0x2
-               	add	x1, x23, x2, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	mov	x17, #0x3f              ; =63
-               	sub	x1, x17, x21
-               	add	x2, x20, x1
-               	ldrb	w1, [x2]
-<L24>:
-               	bl	 <L24>
-               	add	x1, x25, x19
-               	mov	x16, #0x3f              ; =63
-               	and	x2, x1, x16
                	mov	x16, #0x10              ; =16
-               	mul	x1, x2, x16
+               	mul	x1, x28, x16
                	add	x2, x24, x1
                	add	x1, x2, #0x8
                	ldr	x2, [x1]
                	mov	x1, x2
-<L25>:
-               	bl	 <L25>
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xc               ; =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xc               ; =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x4
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xc               ; =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x8
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L21>:
+               	bl	 <L21>
+               	add	x27, x27, #0x1
                	mov	x26, x0
-               	mov	x21, x27
+               	cmp	x27, #0x40
+               	b.lo	 <L7>
+<L22>:
+               	mov	x21, #0x0               ; =0
                	cmp	x21, #0x20
-               	b.lo	 <L20>
+               	b.lo	 <L23>
+               	b	 <L32>
+<L23>:
+               	mov	x16, #0x2               ; =2
+               	mul	x0, x21, x16
+               	add	x1, x22, x0, lsl #2
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, x26
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	lsl	x1, x21, #1
+               	add	x2, x22, x1, lsl #2
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	sub	x20, x29, #0xbc0
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x1, x21, #0x1
+               	mov	x16, #0x2               ; =2
+               	mul	x2, x1, x16
+               	sub	x1, x2, #0x2
+               	add	x2, x23, x1, lsl #3
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mov	x17, #0x3f              ; =63
+               	sub	x1, x17, x21
+               	add	x2, x20, x1
+               	ldrb	w1, [x2]
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0x2               ; =2
+               	mul	x1, x21, x16
+               	add	x2, x1, x19
+               	mov	x16, #0x3f              ; =63
+               	and	x1, x2, x16
+               	mov	x16, #0x10              ; =16
+               	mul	x2, x1, x16
+               	add	x1, x24, x2
+               	add	x2, x1, #0x8
+               	ldr	x1, [x2]
+<L31>:
+               	bl	 <L31>
+               	add	x21, x21, #0x1
+               	mov	x26, x0
+               	cmp	x21, #0x20
+               	b.lo	 <L23>
+<L32>:
+               	sub	x20, x29, #0x100
                	add	x0, x20, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x100              ; =256
-<L27>:
+<L33>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L27>
+               	b.ne	 <L33>
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x8
-               	b.lo	 <L28>
-               	b	 <L31>
-<L28>:
+               	b.lo	 <L34>
+               	b	 <L37>
+<L34>:
                	mov	x16, #0x47              ; =71
                	mul	x1, x0, x16
                	mov	x16, #0x20              ; =32
@@ -321,9 +432,9 @@ Disassembly of section __TEXT,__text:
                	add	x3, x20, x2
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x8
-               	b.lo	 <L29>
-               	b	 <L30>
-<L29>:
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
                	mov	x16, #0xd               ; =13
                	mul	x4, x2, x16
                	add	x5, x1, x4
@@ -333,202 +444,328 @@ Disassembly of section __TEXT,__text:
                	str	w5, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x8
-               	b.lo	 <L29>
-<L30>:
+               	b.lo	 <L35>
+<L36>:
                	add	x0, x0, #0x1
                	cmp	x0, #0x8
-               	b.lo	 <L28>
-<L31>:
+               	b.lo	 <L34>
+<L37>:
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x8
-               	b.lo	 <L32>
-               	b	 <L36>
-<L32>:
+               	b.lo	 <L38>
+               	b	 <L44>
+<L38>:
                	mov	x16, #0x20              ; =32
                	mul	x0, x21, x16
-               	add	x22, x20, x0
-               	add	x0, x22, #0xc
+               	add	x1, x20, x0
+               	add	x0, x1, #0xc
                	ldr	w1, [x0]
-               	mov	x0, x26
-<L33>:
-               	bl	 <L33>
-               	add	x1, x20, #0x60
-               	add	x2, x1, x21, lsl #2
-               	ldr	w1, [x2]
-<L34>:
-               	bl	 <L34>
-               	add	x1, x21, x19
+               	mov	w0, w1
+               	mov	x1, x26
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	add	x0, x20, #0x60
+               	add	x2, x0, x21, lsl #2
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	mov	x16, #0x20              ; =32
+               	mul	x0, x21, x16
+               	add	x2, x20, x0
+               	add	x0, x21, x19
                	mov	x16, #0x7               ; =7
-               	and	x2, x1, x16
-               	add	x1, x22, x2, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L35>:
-               	bl	 <L35>
+               	and	x3, x0, x16
+               	add	x0, x2, x3, lsl #2
+               	ldr	w2, [x0]
+               	mov	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
+<L43>:
+               	bl	 <L43>
                	add	x21, x21, #0x1
                	mov	x26, x0
                	cmp	x21, #0x8
-               	b.lo	 <L32>
-<L36>:
+               	b.lo	 <L38>
+<L44>:
                	add	x0, x20, #0xe0
                	add	x1, x0, #0x1c
-               	ldr	w2, [x1]
-               	mov	x0, x26
-               	mov	w1, w2
-<L37>:
-               	bl	 <L37>
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	ldr	w1, [x2]
-<L38>:
-               	bl	 <L38>
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L45>
+               	b	 <L46>
+<L45>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L45>
+<L46>:
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L47>
+               	b	 <L48>
+<L47>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L47>
+<L48>:
                	mov	x16, #0xcc30            ; =52272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x20, x29, x16
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x2810             ; =10256
-<L39>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L39>
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x2810             ; =10256
+<L49>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L49>
                	mov	x17, #0x5678            ; =22136
                	movk	x17, #0x1234, lsl #16
-               	add	x1, x17, x19
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	mov	w1, w19
+               	add	x0, x17, x19
+               	add	x1, x20, #0x0
+               	str	x0, [x1]
+               	mov	w0, w19
                	mov	w17, #0xdef0            ; =57072
                	movk	w17, #0x9abc, lsl #16
-               	add	w2, w17, w1
+               	add	w1, w17, w0
                	mov	x16, #0x2008            ; =8200
-               	add	x1, x20, x16
-               	str	w2, [x1]
-               	mov	w1, w19
+               	add	x0, x20, x16
+               	str	w1, [x0]
+               	mov	w0, w19
                	mov	w17, #0x1234            ; =4660
-               	add	w2, w17, w1
+               	add	w1, w17, w0
                	mov	x16, #0x280c            ; =10252
-               	add	x1, x20, x16
-               	strh	w2, [x1]
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x400
-               	b.lo	 <L40>
-               	b	 <L41>
-<L40>:
+               	add	x0, x20, x16
+               	strh	w1, [x0]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x400
+               	b.lo	 <L50>
+               	b	 <L51>
+<L50>:
                	mov	x16, #0x1f              ; =31
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	add	x2, x20, #0x8
-               	add	x4, x2, x1, lsl #3
-               	str	x3, [x4]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x400
-               	b.lo	 <L40>
-<L41>:
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x200
-               	b.lo	 <L42>
-               	b	 <L43>
-<L42>:
+               	mul	x1, x0, x16
+               	add	x2, x1, x19
+               	add	x1, x20, #0x8
+               	add	x3, x1, x0, lsl #3
+               	str	x2, [x3]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x400
+               	b.lo	 <L50>
+<L51>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x200
+               	b.lo	 <L52>
+               	b	 <L53>
+<L52>:
                	mov	x16, #0x25              ; =37
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	mov	w2, w3
+               	mul	x1, x0, x16
+               	add	x2, x1, x19
+               	mov	w1, w2
                	mov	x16, #0x200c            ; =8204
-               	add	x3, x20, x16
-               	add	x4, x3, x1, lsl #2
-               	str	w2, [x4]
+               	add	x2, x20, x16
+               	add	x3, x2, x0, lsl #2
+               	str	w1, [x3]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x200
+               	b.lo	 <L52>
+<L53>:
+               	add	x0, x20, #0x0
+               	ldr	x1, [x0]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x0, x20, #0x8
+               	add	x1, x0, #0x0
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
                	add	x1, x1, #0x1
-               	cmp	x1, #0x200
-               	b.lo	 <L42>
-<L43>:
-               	add	x1, x20, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L44>:
-               	bl	 <L44>
-               	add	x21, x20, #0x8
-               	add	x1, x21, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L45>:
-               	bl	 <L45>
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+<L57>:
+               	add	x0, x20, #0x8
                	mov	x16, #0x1ff8            ; =8184
-               	add	x1, x21, x16
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L46>:
-               	bl	 <L46>
+               	add	x1, x0, x16
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L58>
+               	b	 <L59>
+<L58>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L58>
+<L59>:
+               	add	x0, x20, #0x8
                	add	x1, x19, #0x2bc
                	mov	x2, #0x400              ; =1024
-               	cbnz	x2,  <L47>
+               	cbnz	x2,  <L60>
                	brk	#0
-<L47>:
+<L60>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
-               	add	x1, x21, x3, lsl #3
+               	add	x1, x0, x3, lsl #3
                	ldr	x2, [x1]
+               	mov	x0, x26
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L61>:
+               	bl	 <L61>
                	mov	x16, #0x2008            ; =8200
                	add	x1, x20, x16
                	ldr	w2, [x1]
                	mov	w1, w2
-<L49>:
-               	bl	 <L49>
+<L62>:
+               	bl	 <L62>
                	mov	x16, #0x200c            ; =8204
-               	add	x21, x20, x16
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L50>:
-               	bl	 <L50>
-               	add	x1, x21, #0x7fc
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L51>:
-               	bl	 <L51>
-               	add	x1, x19, #0x12c
-               	mov	x2, #0x200              ; =512
-               	cbnz	x2,  <L52>
+               	add	x1, x20, x16
+               	add	x2, x1, #0x0
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L63>:
+               	bl	 <L63>
+               	mov	x16, #0x200c            ; =8204
+               	add	x1, x20, x16
+               	add	x2, x1, #0x7fc
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L64>:
+               	bl	 <L64>
+               	mov	x16, #0x200c            ; =8204
+               	add	x1, x20, x16
+               	add	x2, x19, #0x12c
+               	mov	x3, #0x200              ; =512
+               	cbnz	x3,  <L65>
                	brk	#0
-<L52>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x21, x3, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L53>:
-               	bl	 <L53>
+<L65>:
+               	udiv	x16, x2, x3
+               	msub	x4, x16, x3, x2
+               	add	x2, x1, x4, lsl #2
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L66>:
+               	bl	 <L66>
                	mov	x16, #0x280c            ; =10252
                	add	x1, x20, x16
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L54>:
-               	bl	 <L54>
+               	uxth	w1, w2
+<L67>:
+               	bl	 <L67>
                	mov	x1, #0x2008             ; =8200
-<L55>:
-               	bl	 <L55>
+<L68>:
+               	bl	 <L68>
                	mov	x1, #0x200c             ; =8204
-<L56>:
-               	bl	 <L56>
+<L69>:
+               	bl	 <L69>
                	mov	x1, #0x280c             ; =10252
-<L57>:
-               	bl	 <L57>
+<L70>:
+               	bl	 <L70>
                	mov	x1, #0x2810             ; =10256
-<L58>:
-               	bl	 <L58>
+<L71>:
+               	bl	 <L71>
                	mov	x1, #0x0                ; =0
                	mov	x2, #0x0                ; =0
                	cmp	x1, #0x400
-               	b.lo	 <L59>
-               	b	 <L60>
-<L59>:
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
                	add	x3, x20, #0x8
                	add	x4, x3, x1, lsl #3
                	ldr	x3, [x4]
@@ -536,17 +773,32 @@ Disassembly of section __TEXT,__text:
                	mul	x4, x3, x1
                	eor	x2, x2, x4
                	cmp	x1, #0x400
-               	b.lo	 <L59>
-<L60>:
-               	mov	x1, x2
-<L61>:
-               	bl	 <L61>
+               	b.lo	 <L72>
+<L73>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L74>
+               	b	 <L75>
+<L74>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L74>
+<L75>:
                	mov	x1, #0x0                ; =0
                	mov	x2, #0x0                ; =0
                	cmp	x1, #0x200
-               	b.lo	 <L62>
-               	b	 <L63>
-<L62>:
+               	b.lo	 <L76>
+               	b	 <L77>
+<L76>:
                	mov	x16, #0x200c            ; =8204
                	add	x3, x20, x16
                	add	x4, x3, x1, lsl #2
@@ -557,12 +809,27 @@ Disassembly of section __TEXT,__text:
                	add	x2, x2, x5
                	add	x1, x1, #0x1
                	cmp	x1, #0x200
-               	b.lo	 <L62>
-<L63>:
-               	mov	x1, x2
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xcc10            ; =52240
+               	b.lo	 <L76>
+<L77>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L78>
+               	b	 <L79>
+<L78>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L78>
+<L79>:
+               	mov	x16, #0xcc20            ; =52256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/mem/array_index.dis
+++ b/test/golden/aarch64-darwin/mem/array_index.dis
@@ -5,32 +5,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.array_index.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -39,54 +78,72 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x190
-               	stp	x19, x20, [x29, #-0x150]
-               	stp	x21, x22, [x29, #-0x160]
-               	stp	x23, x24, [x29, #-0x170]
-               	stp	x25, x26, [x29, #-0x180]
+               	stp	x19, x20, [x29, #-0x170]
+               	stp	x21, x22, [x29, #-0x180]
                	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x27, [x29, x16]
+               	str	x23, [x29, x16]
                	mov	x19, x0
                	sub	x20, x29, #0x1c
+               	sub	x21, x29, #0x108
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x80               ; =128
 <L0>:
-               	bl	 <L0>
-               	sub	x21, x29, #0x9c
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x80               ; =128
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x20
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x20
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
-               	add	x2, x1, #0x1
+               	add	x1, x0, #0x1
                	mov	x17, #0x79b1            ; =31153
                	movk	x17, #0x9e37, lsl #16
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	mov	w3, w4
-               	add	x4, x21, x1, lsl #2
-               	str	w3, [x4]
-               	mov	x1, x2
-               	cmp	x1, #0x20
-               	b.lo	 <L2>
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	mov	w2, w3
+               	add	x3, x21, x0, lsl #2
+               	str	w2, [x3]
+               	mov	x0, x1
+               	cmp	x0, #0x20
+               	b.lo	 <L1>
+<L2>:
+               	add	x0, x21, #0x0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x2325             ; =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	add	x1, x21, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x0, x21, #0x4
+               	ldr	w2, [x0]
+               	mov	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
 <L5>:
                	bl	 <L5>
                	add	x1, x21, #0x3c
@@ -99,109 +156,176 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w2
 <L7>:
                	bl	 <L7>
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x20
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x20
                	b.lo	 <L8>
-               	b	 <L10>
+               	b	 <L11>
 <L8>:
                	mov	x16, #0x7               ; =7
-               	mul	x0, x23, x16
-               	add	x1, x0, x19
+               	mul	x2, x1, x16
+               	add	x3, x2, x19
                	mov	x16, #0x1f              ; =31
-               	and	x0, x1, x16
-               	add	x1, x21, x0, lsl #2
-               	ldr	w2, [x1]
-               	mov	x0, x22
-               	mov	w1, w2
+               	and	x2, x3, x16
+               	add	x3, x21, x2, lsl #2
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x20
-               	b.lo	 <L8>
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	mov	x23, #0x20              ; =32
-               	mov	x17, #0x0               ; =0
-               	cmp	x17, x23
-               	b.lo	 <L11>
-               	b	 <L13>
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x20
+               	b.lo	 <L8>
 <L11>:
-               	sub	x23, x23, #0x1
-               	add	x0, x21, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x22, x0
+               	mov	x1, #0x20               ; =32
                	mov	x17, #0x0               ; =0
-               	cmp	x17, x23
-               	b.lo	 <L11>
+               	cmp	x17, x1
+               	b.lo	 <L12>
+               	b	 <L15>
+<L12>:
+               	sub	x2, x1, #0x1
+               	add	x3, x21, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
 <L13>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x20
-               	b.lo	 <L14>
-               	b	 <L16>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L13>
 <L14>:
-               	add	x0, x21, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
+               	mov	x0, x4
+               	mov	x1, x2
+               	mov	x17, #0x0               ; =0
+               	cmp	x17, x1
+               	b.lo	 <L12>
 <L15>:
-               	bl	 <L15>
-               	add	x23, x23, #0x5
-               	mov	x22, x0
-               	cmp	x23, #0x20
-               	b.lo	 <L14>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x20
+               	b.lo	 <L16>
+               	b	 <L19>
 <L16>:
-               	sub	x21, x29, #0xcc
+               	add	x2, x21, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	add	x1, x1, #0x5
+               	mov	x0, x3
+               	cmp	x1, #0x20
+               	b.lo	 <L16>
+<L19>:
+               	sub	x21, x29, #0x4c
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	str	xzr, [x21, #0x18]
                	str	xzr, [x21, #0x20]
                	str	xzr, [x21, #0x28]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, #0x4
-               	b.lo	 <L17>
-               	b	 <L20>
-<L17>:
-               	mov	x16, #0x64              ; =100
-               	mul	x1, x0, x16
-               	mov	x16, #0xc               ; =12
-               	mul	x2, x0, x16
-               	add	x3, x21, x2
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x6
-               	b.lo	 <L18>
-               	b	 <L19>
-<L18>:
-               	mov	x16, #0x7               ; =7
-               	mul	x4, x2, x16
-               	add	x5, x1, x4
-               	add	x4, x5, x19
-               	mov	w5, w4
-               	add	x4, x3, x2, lsl #1
-               	strh	w5, [x4]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x6
-               	b.lo	 <L18>
-<L19>:
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x4
-               	b.lo	 <L17>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x4
+               	b.lo	 <L20>
+               	b	 <L23>
 <L20>:
-               	add	x0, x21, #0x0
-               	add	x1, x0, #0x0
-               	ldrh	w2, [x1]
-               	mov	x0, x22
-               	mov	x1, x2
+               	mov	x16, #0x64              ; =100
+               	mul	x2, x1, x16
+               	mov	x16, #0xc               ; =12
+               	mul	x3, x1, x16
+               	add	x4, x21, x3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x6
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
+               	mov	x16, #0x7               ; =7
+               	mul	x5, x3, x16
+               	add	x6, x2, x5
+               	add	x5, x6, x19
+               	mov	w6, w5
+               	add	x5, x4, x3, lsl #1
+               	strh	w6, [x5]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x6
+               	b.lo	 <L21>
+<L22>:
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x4
+               	b.lo	 <L20>
+<L23>:
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	add	x1, x21, #0x24
                	add	x2, x1, #0xa
                	ldrh	w1, [x2]
-<L22>:
-               	bl	 <L22>
+               	uxth	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
                	add	x1, x19, #0x2
                	mov	x16, #0x3               ; =3
                	and	x2, x1, x16
@@ -213,213 +337,279 @@ Disassembly of section __TEXT,__text:
                	and	x3, x1, x16
                	add	x1, x2, x3, lsl #1
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L24>
-               	b	 <L28>
-<L24>:
-               	mov	x16, #0xc               ; =12
-               	mul	x0, x23, x16
-               	add	x24, x21, x0
-               	mov	x25, x22
-               	mov	x26, #0x0               ; =0
-               	cmp	x26, #0x6
-               	b.lo	 <L25>
-               	b	 <L27>
-<L25>:
-               	add	x0, x24, x26, lsl #1
-               	ldrh	w1, [x0]
-               	mov	x0, x25
-<L26>:
-               	bl	 <L26>
-               	add	x26, x26, #0x1
-               	mov	x25, x0
-               	cmp	x26, #0x6
-               	b.lo	 <L25>
+               	uxth	w1, w2
 <L27>:
-               	add	x23, x23, #0x1
-               	mov	x22, x25
-               	cmp	x23, #0x4
-               	b.lo	 <L24>
-<L28>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x6
-               	b.lo	 <L29>
+               	bl	 <L27>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x4
+               	b.lo	 <L28>
                	b	 <L33>
-<L29>:
-               	mov	x24, x22
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, #0x4
-               	b.lo	 <L30>
-               	b	 <L32>
-<L30>:
+<L28>:
                	mov	x16, #0xc               ; =12
-               	mul	x0, x25, x16
-               	add	x1, x21, x0
-               	add	x0, x1, x23, lsl #1
-               	ldrh	w1, [x0]
-               	mov	x0, x24
-<L31>:
-               	bl	 <L31>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x4
-               	b.lo	 <L30>
-<L32>:
-               	add	x23, x23, #0x1
-               	mov	x22, x24
-               	cmp	x23, #0x6
+               	mul	x2, x1, x16
+               	add	x3, x21, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x6
                	b.lo	 <L29>
+               	b	 <L32>
+<L29>:
+               	add	x5, x3, x4, lsl #1
+               	ldrh	w6, [x5]
+               	uxth	w5, w6
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	cmp	x4, #0x6
+               	b.lo	 <L29>
+<L32>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x4
+               	b.lo	 <L28>
 <L33>:
-               	sub	x21, x29, #0xe7
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	strh	wzr, [x21, #0x18]
-               	strb	wzr, [x21, #0x1a]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, #0x3
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x6
                	b.lo	 <L34>
                	b	 <L39>
 <L34>:
-               	mov	x16, #0x9               ; =9
-               	mul	x1, x0, x16
-               	mov	x16, #0x9               ; =9
-               	mul	x2, x0, x16
-               	add	x3, x21, x2
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x3
+               	mov	x2, x0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x4
                	b.lo	 <L35>
                	b	 <L38>
 <L35>:
-               	mov	x16, #0x3               ; =3
-               	mul	x4, x2, x16
-               	add	x5, x1, x4
-               	mov	x16, #0x3               ; =3
-               	mul	x4, x2, x16
-               	add	x6, x3, x4
-               	mov	x4, #0x0                ; =0
-               	cmp	x4, #0x3
+               	mov	x16, #0xc               ; =12
+               	mul	x4, x3, x16
+               	add	x5, x21, x4
+               	add	x4, x5, x1, lsl #1
+               	ldrh	w5, [x4]
+               	uxth	w4, w5
+               	mov	x5, x2
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
                	b.lo	 <L36>
                	b	 <L37>
 <L36>:
-               	add	x7, x5, x4
-               	add	x8, x7, x19
-               	mov	w7, w8
-               	add	x8, x6, x4
-               	strb	w7, [x8]
-               	add	x4, x4, #0x1
-               	cmp	x4, #0x3
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
                	b.lo	 <L36>
 <L37>:
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x3
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	cmp	x3, #0x4
                	b.lo	 <L35>
 <L38>:
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x3
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x6
                	b.lo	 <L34>
 <L39>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x3
+               	sub	x1, x29, #0x67
+               	str	xzr, [x1]
+               	str	xzr, [x1, #0x8]
+               	str	xzr, [x1, #0x10]
+               	strh	wzr, [x1, #0x18]
+               	strb	wzr, [x1, #0x1a]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x3
                	b.lo	 <L40>
-               	b	 <L46>
-<L40>:
-               	mov	x24, x22
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, #0x3
-               	b.lo	 <L41>
                	b	 <L45>
-<L41>:
-               	mov	x26, x24
-               	mov	x27, #0x0               ; =0
-               	cmp	x27, #0x3
-               	b.lo	 <L42>
-               	b	 <L44>
-<L42>:
+<L40>:
                	mov	x16, #0x9               ; =9
-               	mul	x0, x27, x16
-               	add	x1, x21, x0
-               	mov	x16, #0x3               ; =3
-               	mul	x0, x25, x16
-               	add	x2, x1, x0
-               	add	x0, x2, x23
-               	ldrb	w1, [x0]
-               	mov	x0, x26
-<L43>:
-               	bl	 <L43>
-               	add	x27, x27, #0x1
-               	mov	x26, x0
-               	cmp	x27, #0x3
-               	b.lo	 <L42>
-<L44>:
-               	add	x25, x25, #0x1
-               	mov	x24, x26
-               	cmp	x25, #0x3
+               	mul	x3, x2, x16
+               	mov	x16, #0x9               ; =9
+               	mul	x4, x2, x16
+               	add	x5, x1, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x3
                	b.lo	 <L41>
-<L45>:
-               	add	x23, x23, #0x1
-               	mov	x22, x24
-               	cmp	x23, #0x3
+               	b	 <L44>
+<L41>:
+               	mov	x16, #0x3               ; =3
+               	mul	x6, x4, x16
+               	add	x7, x3, x6
+               	mov	x16, #0x3               ; =3
+               	mul	x6, x4, x16
+               	add	x8, x5, x6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x3
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	add	x12, x7, x6
+               	add	x13, x12, x19
+               	mov	w12, w13
+               	add	x13, x8, x6
+               	strb	w12, [x13]
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x3
+               	b.lo	 <L42>
+<L43>:
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x3
+               	b.lo	 <L41>
+<L44>:
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x3
                	b.lo	 <L40>
+<L45>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x3
+               	b.lo	 <L46>
+               	b	 <L53>
 <L46>:
-               	add	x0, x21, #0x12
-               	add	x1, x0, #0x0
-               	add	x0, x1, #0x1
-               	ldrb	w1, [x0]
-               	mov	x0, x22
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x3
+               	b.lo	 <L47>
+               	b	 <L52>
 <L47>:
-               	bl	 <L47>
-               	add	x1, x19, #0x1
-               	mov	x2, #0x3                ; =3
-               	cbnz	x2,  <L48>
-               	brk	#0
+               	mov	x5, x3
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x3
+               	b.lo	 <L48>
+               	b	 <L51>
 <L48>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
                	mov	x16, #0x9               ; =9
-               	mul	x1, x3, x16
-               	add	x2, x21, x1
-               	add	x1, x19, #0x2
-               	mov	x3, #0x3                ; =3
-               	cbnz	x3,  <L49>
-               	brk	#0
+               	mul	x7, x6, x16
+               	add	x8, x1, x7
+               	mov	x16, #0x3               ; =3
+               	mul	x7, x4, x16
+               	add	x12, x8, x7
+               	add	x7, x12, x2
+               	ldrb	w8, [x7]
+               	uxtb	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
 <L49>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	add	x6, x6, #0x1
+               	mov	x5, x8
+               	cmp	x6, #0x3
+               	b.lo	 <L48>
+<L51>:
+               	add	x4, x4, #0x1
+               	mov	x3, x5
+               	cmp	x4, #0x3
+               	b.lo	 <L47>
+<L52>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x3
+               	b.lo	 <L46>
+<L53>:
+               	add	x2, x1, #0x12
+               	add	x3, x2, #0x0
+               	add	x2, x3, #0x1
+               	ldrb	w3, [x2]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x2, x19, #0x1
+               	mov	x3, #0x3                ; =3
+               	cbnz	x3,  <L56>
+               	brk	#0
+<L56>:
+               	udiv	x16, x2, x3
+               	msub	x4, x16, x3, x2
+               	mov	x16, #0x9               ; =9
+               	mul	x2, x4, x16
+               	add	x3, x1, x2
+               	add	x1, x19, #0x2
+               	mov	x2, #0x3                ; =3
+               	cbnz	x2,  <L57>
+               	brk	#0
+<L57>:
+               	udiv	x16, x1, x2
+               	msub	x4, x16, x2, x1
                	mov	x16, #0x3               ; =3
                	mul	x1, x4, x16
-               	add	x3, x2, x1
+               	add	x2, x3, x1
                	mov	x1, #0x3                ; =3
-               	cbnz	x1,  <L50>
+               	cbnz	x1,  <L58>
                	brk	#0
-<L50>:
+<L58>:
                	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x3, x2
+               	msub	x3, x16, x1, x19
+               	add	x1, x2, x3
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L51>:
-               	bl	 <L51>
-               	sub	x21, x29, #0x138
+               	uxtb	w1, w2
+<L59>:
+               	bl	 <L59>
+               	sub	x21, x29, #0x158
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x50               ; =80
-<L52>:
+<L60>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L52>
+               	b.ne	 <L60>
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x5
-               	b.lo	 <L53>
-               	b	 <L54>
-<L53>:
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
                	mov	x16, #0x3               ; =3
                	mul	x2, x1, x16
                	add	x3, x2, #0x1
@@ -442,74 +632,78 @@ Disassembly of section __TEXT,__text:
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	cmp	x1, #0x5
-               	b.lo	 <L53>
-<L54>:
+               	b.lo	 <L61>
+<L62>:
                	mov	x22, x0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x5
-               	b.lo	 <L55>
-               	b	 <L59>
-<L55>:
+               	b.lo	 <L63>
+               	b	 <L65>
+<L63>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x23, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w24, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x25, [x0]
+               	sub	x0, x29, #0x78
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x22
-               	mov	x1, x2
-<L56>:
-               	bl	 <L56>
-               	mov	x1, x24
-<L57>:
-               	bl	 <L57>
-               	mov	x1, x25
-<L58>:
-               	bl	 <L58>
+<L64>:
+               	bl	 <L64>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x5
-               	b.lo	 <L55>
-<L59>:
+               	b.lo	 <L63>
+<L65>:
                	add	x0, x19, #0x3
                	mov	x1, #0x5                ; =5
-               	cbnz	x1,  <L60>
+               	cbnz	x1,  <L66>
                	brk	#0
-<L60>:
+<L66>:
                	udiv	x16, x0, x1
                	msub	x2, x16, x1, x0
                	mov	x16, #0x10              ; =16
                	mul	x0, x2, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w23, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x24, [x0]
+               	sub	x0, x29, #0x88
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x22
-               	mov	x1, x2
-<L61>:
-               	bl	 <L61>
-               	mov	x1, x23
-<L62>:
-               	bl	 <L62>
-               	mov	x1, x24
-<L63>:
-               	bl	 <L63>
+<L67>:
+               	bl	 <L67>
                	add	x1, x21, #0x40
                	add	x2, x1, #0x8
                	ldr	x1, [x2]
-<L64>:
-               	bl	 <L64>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L68>
+               	b	 <L69>
+<L68>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L68>
+<L69>:
                	add	x1, x19, #0x1
                	mov	x2, #0x5                ; =5
-               	cbnz	x2,  <L65>
+               	cbnz	x2,  <L70>
                	brk	#0
-<L65>:
+<L70>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
                	mov	x16, #0x10              ; =16
@@ -517,12 +711,12 @@ Disassembly of section __TEXT,__text:
                	add	x2, x21, x1
                	add	x1, x2, #0x0
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L66>:
-               	bl	 <L66>
+               	uxth	w1, w2
+<L71>:
+               	bl	 <L71>
                	mov	x1, #0x10               ; =16
-<L67>:
-               	bl	 <L67>
+<L72>:
+               	bl	 <L72>
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -530,9 +724,9 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w19
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x7
-               	b.lo	 <L68>
-               	b	 <L69>
-<L68>:
+               	b.lo	 <L73>
+               	b	 <L74>
+<L73>:
                	mov	w3, w2
                	mov	w16, #0x5678            ; =22136
                	movk	w16, #0x1234, lsl #16
@@ -542,43 +736,90 @@ Disassembly of section __TEXT,__text:
                	str	w3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x7
-               	b.lo	 <L68>
-<L69>:
-               	mov	x1, #0x11               ; =17
-<L70>:
-               	bl	 <L70>
-               	mov	x21, x0
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x7
-               	b.lo	 <L71>
-               	b	 <L74>
-<L71>:
-               	mov	x16, #0x3               ; =3
-               	mul	x0, x22, x16
-               	add	x1, x0, x19
-               	mov	x0, #0x7                ; =7
-               	cbnz	x0,  <L72>
-               	brk	#0
-<L72>:
-               	udiv	x16, x1, x0
-               	msub	x2, x16, x0, x1
-               	add	x0, x20, x2, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x21
-<L73>:
-               	bl	 <L73>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x7
-               	b.lo	 <L71>
+               	b.lo	 <L73>
 <L74>:
-               	mov	x0, x21
-               	mov	x1, #0x1234             ; =4660
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L75>
+               	b	 <L76>
 <L75>:
-               	bl	 <L75>
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x11              ; =17
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L75>
 <L76>:
-               	bl	 <L76>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x7
+               	b.lo	 <L77>
+               	b	 <L81>
+<L77>:
+               	mov	x16, #0x3               ; =3
+               	mul	x2, x1, x16
+               	add	x3, x2, x19
+               	mov	x2, #0x7                ; =7
+               	cbnz	x2,  <L78>
+               	brk	#0
+<L78>:
+               	udiv	x16, x3, x2
+               	msub	x4, x16, x2, x3
+               	add	x2, x20, x4, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L79>
+               	b	 <L80>
+<L79>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L79>
+<L80>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x7
+               	b.lo	 <L77>
+<L81>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L82>
+               	b	 <L83>
+<L82>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1234            ; =4660
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L82>
+<L83>:
+               	mov	x1, #0x4                ; =4
+<L84>:
+               	bl	 <L84>
                	add	x1, x20, #0x0
                	ldr	w2, [x1]
                	add	x1, x20, #0x4
@@ -598,26 +839,24 @@ Disassembly of section __TEXT,__text:
                	eor	w19, w2, w16
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
+<L85>:
+               	bl	 <L85>
                	mov	w1, w19
-<L78>:
-               	bl	 <L78>
+<L86>:
+               	bl	 <L86>
                	mov	x1, #0x11               ; =17
-<L79>:
-               	bl	 <L79>
+<L87>:
+               	bl	 <L87>
                	mov	x1, #0x1234             ; =4660
-<L80>:
-               	bl	 <L80>
-               	ldp	x19, x20, [x29, #-0x150]
-               	ldp	x21, x22, [x29, #-0x160]
-               	ldp	x23, x24, [x29, #-0x170]
-               	ldp	x25, x26, [x29, #-0x180]
+<L88>:
+               	bl	 <L88>
+               	ldp	x19, x20, [x29, #-0x170]
+               	ldp	x21, x22, [x29, #-0x180]
                	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x27, [x29, x16]
+               	ldr	x23, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/global_data.dis
+++ b/test/golden/aarch64-darwin/mem/global_data.dis
@@ -5,32 +5,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -39,156 +78,336 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldrb	w1, [x16]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldrh	w1, [x16]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	w1, [x16]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldrb	w1, [x16]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldrh	w1, [x16]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	w1, [x16]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	d0, [x1]
+               	fmov	x1, d0
+<L17>:
+               	bl	 <L17>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x6
+               	b.lo	 <L18>
+               	b	 <L21>
+<L18>:
+               	add	x3, x1, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x6
+               	b.lo	 <L18>
+<L21>:
+               	sub	x1, x29, #0x10
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
-               	mov	x0, x1
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x3, [x16]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x6
-               	b.lo	 <L10>
-               	b	 <L12>
-<L10>:
-               	add	x0, x19, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x20
-<L11>:
-               	bl	 <L11>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x6
-               	b.lo	 <L10>
-<L12>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrh	w1, [x0]
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrb	w19, [x0]
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldr	x21, [x0]
-               	mov	x0, x20
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x19
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x21
-<L15>:
-               	bl	 <L15>
+               	mov	x2, x3
+<L22>:
+               	bl	 <L22>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	sub	x2, x29, #0x20
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	mov	x2, x3
+<L23>:
+               	bl	 <L23>
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	add	x2, x1, #0x0
-               	ldrh	w3, [x2]
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
                	add	x2, x1, #0x2
-               	ldrb	w19, [x2]
-               	add	x2, x1, #0x8
-               	ldr	x20, [x2]
-               	mov	x1, x3
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x19
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x20
-<L18>:
-               	bl	 <L18>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x19, x19, #0x0
-               	add	x1, x19, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L19>:
-               	bl	 <L19>
-               	add	x1, x19, #0x2
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L20>:
-               	bl	 <L20>
-               	add	x1, x19, #0x4
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L21>:
-               	bl	 <L21>
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
                	mov	w1, w2
-<L22>:
-               	bl	 <L22>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -341,40 +560,35 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
-               	stp	x19, x20, [x29, #-0x50]
-               	stp	x21, x22, [x29, #-0x60]
-               	stp	x23, x24, [x29, #-0x70]
-               	stp	x25, x26, [x29, #-0x80]
-               	stp	x27, x28, [x29, #-0x90]
+               	sub	sp, sp, #0xa0
+               	stp	x19, x20, [x29, #-0x60]
+               	stp	x21, x22, [x29, #-0x70]
+               	stp	x23, x24, [x29, #-0x80]
+               	stp	x25, x26, [x29, #-0x90]
+               	stp	x27, x28, [x29, #-0xa0]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-<L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x2, x17, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	add	x1, x17, x19
+<L1>:
+               	bl	 <L1>
+               	mov	x1, #0x2979             ; =10617
+               	movk	x1, #0xffed, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, #0x2979             ; =10617
-               	movk	w1, #0xffed, lsl #16
+               	mov	x1, #0x3fc4000000000000 ; =4594797519824748544
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, #0.15625000
-<L4>:
-               	bl	 <L4>
                	adrp	x20, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x20, x20, #0x0
                	adrp	x21, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -392,9 +606,9 @@ Disassembly of section __TEXT,__text:
                	mov	x27, x0
                	mov	x28, #0x0               ; =0
                	cmp	x28, #0x5
-               	b.lo	 <L5>
-               	b	 <L11>
-<L5>:
+               	b.lo	 <L4>
+               	b	 <L10>
+<L4>:
                	add	x0, x28, #0x1
                	add	x1, x0, x19
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -461,9 +675,9 @@ Disassembly of section __TEXT,__text:
                	mov	w0, w1
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x6
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
                	add	x3, x20, x2, lsl #2
                	ldr	w4, [x3]
                	mov	w5, w2
@@ -473,8 +687,8 @@ Disassembly of section __TEXT,__text:
                	str	w6, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x6
-               	b.lo	 <L6>
-<L7>:
+               	b.lo	 <L5>
+<L6>:
                	ldrh	w0, [x21]
                	mov	w2, w1
                	add	w3, w0, w2
@@ -488,7 +702,7 @@ Disassembly of section __TEXT,__text:
                	mul	x2, x0, x16
                	add	x0, x2, x1
                	str	x0, [x23]
-               	sub	x0, x29, #0x40
+               	sub	x0, x29, #0x50
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -500,18 +714,18 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x24]
                	str	x3, [x24, #0x8]
                	mov	x0, #0x3                ; =3
-               	cbnz	x0,  <L8>
+               	cbnz	x0,  <L7>
                	brk	#0
-<L8>:
+<L7>:
                	udiv	x16, x1, x0
                	msub	x2, x16, x0, x1
                	add	x0, x25, x2, lsl #1
                	ldrh	w2, [x0]
                	add	w0, w2, #0x64
                	mov	x2, #0x3                ; =3
-               	cbnz	x2,  <L9>
+               	cbnz	x2,  <L8>
                	brk	#0
-<L9>:
+<L8>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
                	add	x2, x25, x3, lsl #1
@@ -521,13 +735,13 @@ Disassembly of section __TEXT,__text:
                	sub	w1, w0, w2
                	str	w1, [x26]
                	mov	x0, x27
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	add	x28, x28, #0x1
                	mov	x27, x0
                	cmp	x28, #0x5
-               	b.lo	 <L5>
-<L11>:
+               	b.lo	 <L4>
+<L10>:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x0, [x16]
                	mov	x16, #0x7c15            ; =31765
@@ -540,8 +754,8 @@ Disassembly of section __TEXT,__text:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x1, [x16]
                	mov	x0, x27
-<L12>:
-               	bl	 <L12>
+<L11>:
+               	bl	 <L11>
                	sub	x1, x29, #0x10
                	sub	x2, x29, #0x20
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -569,31 +783,26 @@ Disassembly of section __TEXT,__text:
                	str	x1, [x16]
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	str	x3, [x16]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldrh	w2, [x1]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldrb	w19, [x1]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldr	x20, [x1]
+               	sub	x1, x29, #0x40
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x2, [x16]
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x3, [x16]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
+               	mov	x2, x3
+<L12>:
+               	bl	 <L12>
 <L13>:
                	bl	 <L13>
-               	mov	x1, x19
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x20
-<L15>:
-               	bl	 <L15>
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x50]
-               	ldp	x21, x22, [x29, #-0x60]
-               	ldp	x23, x24, [x29, #-0x70]
-               	ldp	x25, x26, [x29, #-0x80]
-               	ldp	x27, x28, [x29, #-0x90]
+               	ldp	x19, x20, [x29, #-0x60]
+               	ldp	x21, x22, [x29, #-0x70]
+               	ldp	x23, x24, [x29, #-0x80]
+               	ldp	x25, x26, [x29, #-0x90]
+               	ldp	x27, x28, [x29, #-0xa0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/global_zero.dis
+++ b/test/golden/aarch64-darwin/mem/global_zero.dis
@@ -5,32 +5,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_zero.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -38,167 +77,329 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_zero.fold_zeros>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x1, x0
+               	sub	sp, sp, #0x40
+               	stp	x19, x20, [x29, #-0x30]
+               	stur	x21, [x29, #-0x38]
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldrb	w1, [x16]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldrh	w1, [x16]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldr	w1, [x16]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	w1, [x16]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x200
-               	b.lo	 <L9>
-               	b	 <L11>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	add	x0, x19, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x20
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x200
-               	b.lo	 <L9>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	d0, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x200
+               	b.lo	 <L18>
+               	b	 <L21>
+<L18>:
+               	add	x3, x1, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x200
+               	b.lo	 <L18>
+<L21>:
                	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x19, x19, #0x0
+               	mov	x20, x0
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x8
-               	b.lo	 <L12>
-               	b	 <L16>
-<L12>:
+               	b.lo	 <L22>
+               	b	 <L24>
+<L22>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x19, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w22, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x23, [x0]
-               	mov	x0, x20
-               	mov	x1, x2
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x22
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x23
-<L15>:
-               	bl	 <L15>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L12>
-<L16>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x0, x0, #0x0
-               	add	x1, x0, #0x0
-               	ldrh	w2, [x1]
-               	add	x1, x0, #0x2
-               	ldrb	w19, [x1]
-               	add	x1, x0, #0x8
-               	ldr	x21, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x19
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x21
-<L19>:
-               	bl	 <L19>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x4
-               	b.lo	 <L20>
-               	b	 <L22>
-<L20>:
-               	add	x0, x19, x21, lsl #3
+               	sub	x0, x29, #0x10
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
                	ldr	x1, [x0]
-               	mov	x0, x20
-<L21>:
-               	bl	 <L21>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x4
-               	b.lo	 <L20>
-<L22>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrb	w1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x20
 <L23>:
                	bl	 <L23>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	add	x21, x21, #0x1
+               	mov	x20, x0
+               	cmp	x21, #0x8
+               	b.lo	 <L22>
+<L24>:
+               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x0, x0, #0x0
+               	sub	x1, x29, #0x20
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, x20
+               	mov	x1, x2
+               	mov	x2, x3
+<L25>:
+               	bl	 <L25>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x4
+               	b.lo	 <L26>
+               	b	 <L29>
+<L26>:
+               	add	x3, x1, x2, lsl #3
+               	ldr	x4, [x3]
+               	mov	x3, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x4
+               	b.lo	 <L26>
+<L29>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	ldp	x19, x20, [x29, #-0x30]
+               	ldur	x21, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -209,12 +410,12 @@ Disassembly of section __TEXT,__text:
                	sub	sp, sp, #0x40
                	stur	x19, [x29, #-0x38]
                	mov	x19, x0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-<L1>:
-               	bl	 <L1>
                	mov	w1, w19
                	mov	w17, #0xc8              ; =200
                	add	w2, w17, w1
@@ -266,9 +467,9 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x200
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
                	add	x3, x2, #0x1
                	mov	x17, #0x79b1            ; =31153
                	movk	x17, #0x9e37, lsl #16
@@ -279,15 +480,15 @@ Disassembly of section __TEXT,__text:
                	str	w4, [x5]
                	mov	x2, x3
                	cmp	x2, #0x200
-               	b.lo	 <L2>
-<L3>:
+               	b.lo	 <L1>
+<L2>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x8
-               	b.lo	 <L4>
-               	b	 <L5>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
                	mov	x16, #0xb               ; =11
                	mul	x3, x2, x16
                	add	x4, x3, #0x3
@@ -312,8 +513,8 @@ Disassembly of section __TEXT,__text:
                	add	x3, x5, #0x8
                	str	x4, [x3]
                	cmp	x2, #0x8
-               	b.lo	 <L4>
-<L5>:
+               	b.lo	 <L3>
+<L4>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	sub	x2, x29, #0x10
@@ -331,9 +532,9 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x4
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
                	add	x3, x2, #0x1
                	mov	x17, #0x5678            ; =22136
                	movk	x17, #0x1234, lsl #16
@@ -343,20 +544,36 @@ Disassembly of section __TEXT,__text:
                	str	x5, [x4]
                	mov	x2, x3
                	cmp	x2, #0x4
-               	b.lo	 <L6>
-<L7>:
+               	b.lo	 <L5>
+<L6>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	mov	w17, #0x4d              ; =77
                	strb	w17, [x1]
-<L8>:
-               	bl	 <L8>
+<L7>:
+               	bl	 <L7>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
@@ -374,6 +591,8 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	add	x2, x1, x3, lsl #2
                	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L12>:
                	bl	 <L12>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>

--- a/test/golden/aarch64-darwin/mem/loadstore.dis
+++ b/test/golden/aarch64-darwin/mem/loadstore.dis
@@ -3,75 +3,173 @@ mem/loadstore.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.mem.loadstore.fold_packed>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldrb	w4, [x3]
-               	add	x3, x1, #0x1
-               	ldrb	w19, [x3]
-               	add	x3, x1, #0x2
-               	ldrb	w20, [x3]
-               	add	x3, x1, #0x3
-               	ldrb	w21, [x3]
-               	add	x3, x1, #0x4
-               	ldrh	w22, [x3]
-               	add	x3, x1, #0x6
-               	ldrh	w23, [x3]
-               	add	x3, x1, #0x8
-               	ldr	w24, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x25, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldrb	w3, [x2]
+               	add	x2, x1, #0x1
+               	ldrb	w4, [x2]
+               	add	x2, x1, #0x2
+               	ldrb	w5, [x2]
+               	add	x2, x1, #0x3
+               	ldrb	w6, [x2]
+               	add	x2, x1, #0x4
+               	ldrh	w7, [x2]
+               	add	x2, x1, #0x6
+               	ldrh	w8, [x2]
+               	add	x2, x1, #0x8
+               	ldr	w12, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x3, x16
+               	lsr	x14, x2, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w2, w4
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x13, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x13, x16
+               	eor	x13, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w2, w5
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w24
+               	uxtb	w2, w6
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	uxth	w2, w7
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	uxth	w2, w8
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w2, w12
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.mem.loadstore.checksum>:
@@ -81,90 +179,86 @@ Disassembly of section __TEXT,__text:
                	stp	x19, x20, [x29, #-0xd0]
                	stp	x21, x22, [x29, #-0xe0]
                	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
+               	stur	x25, [x29, #-0xf8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	sub	x20, x29, #0x18
+               	sub	x20, x29, #0x58
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
-               	sub	x2, x29, #0x30
-               	ldr	x3, [x20]
-               	ldr	x4, [x20, #0x8]
-               	ldr	x5, [x20, #0x10]
-               	str	x3, [x2]
-               	str	x4, [x2, #0x8]
-               	str	x5, [x2, #0x10]
-               	ldr	x3, [x2]
-               	ldr	x4, [x2, #0x8]
-               	ldr	x5, [x2, #0x10]
-               	stur	x3, [x29, #-0x48]
-               	stur	x4, [x29, #-0x40]
-               	stur	x5, [x29, #-0x38]
-               	sub	x2, x29, #0x48
-               	mov	x0, x1
-               	mov	x1, x2
-<L1>:
-               	bl	 <L1>
-               	mov	x1, x0
+               	sub	x0, x29, #0x70
+               	ldr	x1, [x20]
+               	ldr	x2, [x20, #0x8]
+               	ldr	x3, [x20, #0x10]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	str	x3, [x0, #0x10]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	stur	x1, [x29, #-0x88]
+               	stur	x2, [x29, #-0x80]
+               	stur	x3, [x29, #-0x78]
+               	sub	x1, x29, #0x88
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
                	mov	x17, #0x3210            ; =12816
                	movk	x17, #0x7654, lsl #16
                	movk	x17, #0xba98, lsl #32
                	movk	x17, #0xfedc, lsl #48
                	add	x21, x17, x19
-               	mov	w2, w21
-               	add	x3, x20, #0x0
-               	strb	w2, [x3]
-               	lsr	x2, x21, #8
-               	mov	w3, w2
-               	add	x2, x20, #0x1
-               	strb	w3, [x2]
-               	lsr	x2, x21, #16
-               	mov	w3, w2
-               	add	x2, x20, #0x2
-               	strb	w3, [x2]
-               	lsr	x2, x21, #24
-               	mov	w3, w2
-               	add	x2, x20, #0x3
-               	strb	w3, [x2]
-               	mov	w2, w21
-               	add	x3, x20, #0x4
-               	strh	w2, [x3]
-               	lsr	x2, x21, #32
-               	mov	w3, w2
-               	add	x2, x20, #0x6
-               	strh	w3, [x2]
-               	mov	w2, w21
-               	add	x3, x20, #0x8
-               	str	w2, [x3]
-               	add	x2, x20, #0x10
-               	str	x21, [x2]
-               	sub	x2, x29, #0x60
-               	ldr	x3, [x20]
-               	ldr	x4, [x20, #0x8]
-               	ldr	x5, [x20, #0x10]
-               	str	x3, [x2]
-               	str	x4, [x2, #0x8]
-               	str	x5, [x2, #0x10]
-               	ldr	x3, [x2]
-               	ldr	x4, [x2, #0x8]
-               	ldr	x5, [x2, #0x10]
-               	stur	x3, [x29, #-0x78]
-               	stur	x4, [x29, #-0x70]
-               	stur	x5, [x29, #-0x68]
-               	sub	x2, x29, #0x78
-               	mov	x0, x1
-               	mov	x1, x2
-<L2>:
-               	bl	 <L2>
+               	mov	w1, w21
+               	add	x2, x20, #0x0
+               	strb	w1, [x2]
+               	lsr	x1, x21, #8
+               	mov	w2, w1
+               	add	x1, x20, #0x1
+               	strb	w2, [x1]
+               	lsr	x1, x21, #16
+               	mov	w2, w1
+               	add	x1, x20, #0x2
+               	strb	w2, [x1]
+               	lsr	x1, x21, #24
+               	mov	w2, w1
+               	add	x1, x20, #0x3
+               	strb	w2, [x1]
+               	mov	w1, w21
+               	add	x2, x20, #0x4
+               	strh	w1, [x2]
+               	lsr	x1, x21, #32
+               	mov	w2, w1
+               	add	x1, x20, #0x6
+               	strh	w2, [x1]
+               	mov	w1, w21
+               	add	x2, x20, #0x8
+               	str	w1, [x2]
+               	add	x1, x20, #0x10
+               	str	x21, [x1]
+               	sub	x1, x29, #0xa0
+               	ldr	x2, [x20]
+               	ldr	x3, [x20, #0x8]
+               	ldr	x4, [x20, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	str	x4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	stur	x2, [x29, #-0xb8]
+               	stur	x3, [x29, #-0xb0]
+               	stur	x4, [x29, #-0xa8]
+               	sub	x1, x29, #0xb8
+<L1>:
+               	bl	 <L1>
                	mov	x22, x0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x8
-               	b.lo	 <L3>
-               	b	 <L5>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L4>
+<L2>:
                	add	x23, x23, #0x1
                	mul	x0, x21, x23
                	add	x1, x0, x19
@@ -179,7 +273,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w0
                	add	x0, x20, #0x8
                	str	w1, [x0]
-               	sub	x0, x29, #0x90
+               	sub	x0, x29, #0x18
                	ldr	x1, [x20]
                	ldr	x2, [x20, #0x8]
                	ldr	x3, [x20, #0x10]
@@ -189,122 +283,251 @@ Disassembly of section __TEXT,__text:
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	stur	x1, [x29, #-0xa8]
-               	stur	x2, [x29, #-0xa0]
-               	stur	x3, [x29, #-0x98]
-               	sub	x1, x29, #0xa8
+               	stur	x1, [x29, #-0x30]
+               	stur	x2, [x29, #-0x28]
+               	stur	x3, [x29, #-0x20]
+               	sub	x1, x29, #0x30
                	mov	x0, x22
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x22, x0
                	cmp	x23, #0x8
-               	b.lo	 <L3>
-<L5>:
+               	b.lo	 <L2>
+<L4>:
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L6>
-               	b	 <L17>
-<L6>:
-               	add	x20, x20, #0x1
+               	b.lo	 <L5>
+               	b	 <L21>
+<L5>:
+               	add	x0, x20, #0x1
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	mul	x0, x17, x20
-               	add	x23, x0, x19
-               	mov	w24, w23
-               	lsr	x0, x23, #8
-               	mov	w25, w0
-               	lsr	x0, x23, #16
-               	mov	w26, w0
-               	mov	x0, x22
-               	mov	x1, x24
+               	mul	x1, x17, x0
+               	add	x0, x1, x19
+               	mov	w23, w0
+               	lsr	x1, x0, #8
+               	mov	w24, w1
+               	lsr	x1, x0, #16
+               	mov	w25, w1
+               	sxtb	x1, w23
+               	mov	x2, x22
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	sxth	x1, w24
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	w1, w26
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x23
+               	sxtw	x1, w25
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	sxtb	x1, w24
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	sxth	x1, w25
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	sxtw	x1, w26
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	uxtb	w1, w24
+               	sxtb	x0, w23
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	uxth	w1, w25
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w26
+               	sxth	x1, w24
+               	mov	x0, x2
 <L16>:
                	bl	 <L16>
-               	mov	x22, x0
-               	cmp	x20, #0x6
-               	b.lo	 <L6>
+               	sxtw	x1, w25
 <L17>:
-               	sub	x19, x29, #0xb8
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, #0x10
-               	b.lo	 <L18>
-               	b	 <L19>
+               	bl	 <L17>
+               	uxtb	w1, w23
 <L18>:
-               	mov	x16, #0x7               ; =7
-               	and	x1, x0, x16
-               	mov	x16, #0x8               ; =8
-               	mul	x2, x1, x16
-               	lsr	x1, x21, x2
-               	mov	w2, w1
-               	mov	w1, w0
-               	add	w3, w2, w1
-               	add	x1, x19, x0
-               	strb	w3, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x10
-               	b.lo	 <L18>
+               	bl	 <L18>
+               	uxth	w1, w24
 <L19>:
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x10
-               	b.lo	 <L20>
-               	b	 <L22>
+               	bl	 <L19>
+               	mov	w1, w25
 <L20>:
-               	add	x0, x19, x20
-               	ldrb	w1, [x0]
-               	mov	x0, x22
-<L21>:
-               	bl	 <L21>
+               	bl	 <L20>
                	add	x20, x20, #0x1
                	mov	x22, x0
-               	cmp	x20, #0x10
-               	b.lo	 <L20>
+               	cmp	x20, #0x6
+               	b.lo	 <L5>
+<L21>:
+               	sub	x0, x29, #0x40
+               	str	xzr, [x0]
+               	str	xzr, [x0, #0x8]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x10
+               	b.lo	 <L22>
+               	b	 <L23>
 <L22>:
+               	mov	x16, #0x7               ; =7
+               	and	x2, x1, x16
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x2, x21, x3
+               	mov	w3, w2
+               	mov	w2, w1
+               	add	w4, w3, w2
+               	add	x2, x0, x1
+               	strb	w4, [x2]
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x10
+               	b.lo	 <L22>
+<L23>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x10
+               	b.lo	 <L24>
+               	b	 <L27>
+<L24>:
+               	add	x2, x0, x1
+               	ldrb	w3, [x2]
+               	uxtb	w2, w3
+               	mov	x3, x22
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	add	x1, x1, #0x1
+               	mov	x22, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L24>
+<L27>:
                	mov	x16, #0x7c15            ; =31765
                	movk	x16, #0x7f4a, lsl #16
                	movk	x16, #0x79b9, lsl #32
                	movk	x16, #0x9e37, lsl #48
-               	eor	x19, x21, x16
+               	eor	x0, x21, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	add	x1, x0, #0x1
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	x0, x22
-               	mov	x1, x19
-<L23>:
-               	bl	 <L23>
-               	add	x1, x19, #0x1
-<L24>:
-               	bl	 <L24>
                	ldp	x19, x20, [x29, #-0xd0]
                	ldp	x21, x22, [x29, #-0xe0]
                	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
+               	ldur	x25, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/ptr_arith.dis
+++ b/test/golden/aarch64-darwin/mem/ptr_arith.dis
@@ -5,32 +5,71 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.ptr_arith.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -56,16 +95,13 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.ptr_arith.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
-               	stp	x19, x20, [x29, #-0xd0]
-               	stp	x21, x22, [x29, #-0xe0]
-               	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
+               	sub	sp, sp, #0x110
+               	stp	x19, x20, [x29, #-0xf0]
+               	stp	x21, x22, [x29, #-0x100]
+               	stp	x23, x24, [x29, #-0x110]
                	mov	x19, x0
                	sub	x20, x29, #0x20
-<L0>:
-               	bl	 <L0>
-               	sub	x21, x29, #0x60
+               	sub	x21, x29, #0x80
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -74,78 +110,147 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x21, #0x28]
                	str	xzr, [x21, #0x30]
                	str	xzr, [x21, #0x38]
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x10
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
-               	add	x2, x1, #0x1
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x10
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	add	x1, x0, #0x1
                	mov	x17, #0x79b1            ; =31153
                	movk	x17, #0x9e37, lsl #16
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	mov	w3, w4
-               	add	x4, x21, x1, lsl #2
-               	str	w3, [x4]
-               	mov	x1, x2
-               	cmp	x1, #0x10
-               	b.lo	 <L1>
-<L2>:
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	mov	w2, w3
+               	add	x3, x21, x0, lsl #2
+               	str	w2, [x3]
+               	mov	x0, x1
+               	cmp	x0, #0x10
+               	b.lo	 <L0>
+<L1>:
                	add	x22, x21, #0x0
                	add	x23, x21, #0x20
-               	mov	x24, x0
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, #0x10
-               	b.lo	 <L3>
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
                	b	 <L5>
-<L3>:
-               	add	x0, x22, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L4>:
-               	bl	 <L4>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x10
+<L2>:
+               	add	x2, x22, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
                	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
 <L5>:
-               	mov	x25, #0xfff8            ; =65528
-               	movk	x25, #0xffff, lsl #16
-               	movk	x25, #0xffff, lsl #32
-               	movk	x25, #0xffff, lsl #48
-               	cmp	x25, #0x8
+               	mov	x1, #0xfff8             ; =65528
+               	movk	x1, #0xffff, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
+               	cmp	x1, #0x8
                	b.lt	 <L6>
-               	b	 <L8>
+               	b	 <L9>
 <L6>:
-               	add	x0, x23, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
+               	add	x2, x23, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x8
-               	b.lt	 <L6>
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	ldr	w1, [x23]
-               	mov	x0, x24
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
+               	ldr	w1, [x23]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	sub	x1, x23, #0x4
                	ldr	w2, [x1]
                	mov	w1, w2
-<L10>:
-               	bl	 <L10>
-               	add	x1, x23, #0x1c
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L11>:
-               	bl	 <L11>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x8
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
                	b.lo	 <L12>
                	b	 <L13>
 <L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x1, x23, #0x1c
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
                	add	x2, x23, x1, lsl #2
                	ldr	w3, [x2]
                	mov	w4, w1
@@ -154,74 +259,133 @@ Disassembly of section __TEXT,__text:
                	str	w3, [x2]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L12>
-<L13>:
-               	mov	x24, x0
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, #0x10
-               	b.lo	 <L14>
-               	b	 <L16>
-<L14>:
-               	add	x0, x21, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L15>:
-               	bl	 <L15>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x10
-               	b.lo	 <L14>
+               	b.lo	 <L15>
 <L16>:
-               	add	x25, x21, #0x14
-               	ldr	w0, [x25]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x10
+               	b.lo	 <L17>
+               	b	 <L20>
+<L17>:
+               	add	x2, x21, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L17>
+<L20>:
+               	add	x24, x21, #0x14
+               	ldr	w1, [x24]
                	mov	w16, #0xf0f0            ; =61680
                	movk	w16, #0xf0f0, lsl #16
-               	eor	w1, w0, w16
-               	str	w1, [x25]
-               	ldr	w1, [x25]
-               	mov	x0, x24
-<L17>:
-               	bl	 <L17>
-               	ldr	w1, [x25]
-               	add	w2, w1, #0x3
-               	str	w2, [x25]
-               	ldr	w1, [x25]
-<L18>:
-               	bl	 <L18>
-               	ldr	w1, [x25]
-<L19>:
-               	bl	 <L19>
-               	cmp	x25, x25
-               	cset	w1, eq
-<L20>:
-               	bl	 <L20>
-               	cmp	x25, x22
-               	cset	w1, eq
+               	eor	w2, w1, w16
+               	str	w2, [x24]
+               	ldr	w1, [x24]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	ldr	w1, [x24]
+               	add	w2, w1, #0x3
+               	str	w2, [x24]
+               	ldr	w1, [x24]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	add	x1, x21, #0x14
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L25>:
+               	bl	 <L25>
+               	cmp	x24, x24
+               	cset	w1, eq
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	cmp	x24, x22
+               	cset	w1, eq
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L27>:
+               	bl	 <L27>
                	cmp	x22, #0x0
                	cset	w1, eq
-<L22>:
-               	bl	 <L22>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L28>:
+               	bl	 <L28>
                	cmp	x23, x22
                	cset	w1, ne
-<L23>:
-               	bl	 <L23>
-               	sub	x21, x29, #0xc0
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L29>:
+               	bl	 <L29>
+               	sub	x21, x29, #0xe0
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L24>:
+<L30>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L24>
+               	b.ne	 <L30>
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x6
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
                	mov	x16, #0x5               ; =5
                	mul	x2, x1, x16
                	add	x3, x2, #0x1
@@ -244,8 +408,8 @@ Disassembly of section __TEXT,__text:
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	cmp	x1, #0x6
-               	b.lo	 <L25>
-<L26>:
+               	b.lo	 <L31>
+<L32>:
                	add	x22, x21, #0x20
                	mov	x23, x0
                	mov	x24, #0xfffe            ; =65534
@@ -253,33 +417,27 @@ Disassembly of section __TEXT,__text:
                	movk	x24, #0xffff, lsl #32
                	movk	x24, #0xffff, lsl #48
                	cmp	x24, #0x4
-               	b.lt	 <L27>
-               	b	 <L31>
-<L27>:
+               	b.lt	 <L33>
+               	b	 <L35>
+<L33>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x24, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w25, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x26, [x0]
+               	sub	x0, x29, #0x30
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x23
-               	mov	x1, x2
-<L28>:
-               	bl	 <L28>
-               	mov	x1, x25
-<L29>:
-               	bl	 <L29>
-               	mov	x1, x26
-<L30>:
-               	bl	 <L30>
+<L34>:
+               	bl	 <L34>
                	add	x24, x24, #0x1
                	mov	x23, x0
                	cmp	x24, #0x4
-               	b.lt	 <L27>
-<L31>:
+               	b.lt	 <L33>
+<L35>:
                	add	x0, x22, #0x10
                	add	x1, x0, #0x8
                	ldr	x0, [x1]
@@ -292,144 +450,231 @@ Disassembly of section __TEXT,__text:
                	strh	w2, [x1]
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x6
-               	b.lo	 <L32>
-               	b	 <L36>
-<L32>:
+               	b.lo	 <L36>
+               	b	 <L38>
+<L36>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x22, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w24, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x25, [x0]
+               	sub	x0, x29, #0x40
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x23
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
-               	mov	x1, x24
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x25
-<L35>:
-               	bl	 <L35>
+<L37>:
+               	bl	 <L37>
                	add	x22, x22, #0x1
                	mov	x23, x0
                	cmp	x22, #0x6
-               	b.lo	 <L32>
-<L36>:
+               	b.lo	 <L36>
+<L38>:
                	add	x0, x21, #0x40
                	add	x1, x0, #0x8
                	ldr	x0, [x1]
                	mov	x16, #0x3               ; =3
                	mul	x2, x0, x16
                	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x0, x23
-               	mov	x1, x2
-<L37>:
-               	bl	 <L37>
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	ldrh	w1, [x2]
-               	add	w3, w1, #0x1
-               	strh	w3, [x2]
-               	ldrh	w1, [x2]
-<L38>:
-               	bl	 <L38>
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	ldrh	w0, [x1]
+               	add	w2, w0, #0x1
+               	strh	w2, [x1]
+               	ldrh	w0, [x1]
+               	uxth	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+<L42>:
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
                	str	xzr, [x20, #0x18]
-               	mov	w1, w19
+               	mov	w0, w19
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
-               	add	w21, w17, w1
+               	add	w1, w17, w0
                	mov	w17, #0xdef0            ; =57072
                	movk	w17, #0x9abc, lsl #16
-               	add	w22, w17, w1
-               	mov	w1, w19
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x8
-               	b.lo	 <L39>
-               	b	 <L40>
-<L39>:
-               	mov	w3, w2
-               	mov	w16, #0x7               ; =7
-               	mul	w4, w3, w16
-               	add	w3, w4, #0x3
-               	add	w4, w3, w1
-               	add	x3, x20, x2, lsl #2
-               	str	w4, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x8
-               	b.lo	 <L39>
-<L40>:
-               	add	x19, x20, #0xc
-               	mov	x23, x0
-               	mov	x24, #0xfffd            ; =65533
-               	movk	x24, #0xffff, lsl #16
-               	movk	x24, #0xffff, lsl #32
-               	movk	x24, #0xffff, lsl #48
-               	cmp	x24, #0x5
-               	b.lt	 <L41>
-               	b	 <L43>
-<L41>:
-               	add	x0, x19, x24, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x23
-<L42>:
-               	bl	 <L42>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x5
-               	b.lt	 <L41>
+               	add	w2, w17, w0
+               	mov	w0, w19
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
 <L43>:
+               	mov	w4, w3
+               	mov	w16, #0x7               ; =7
+               	mul	w5, w4, w16
+               	add	w4, w5, #0x3
+               	add	w5, w4, w0
+               	add	x4, x20, x3, lsl #2
+               	str	w5, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x20, #0xc
+               	mov	x3, #0xfffd             ; =65533
+               	movk	x3, #0xffff, lsl #16
+               	movk	x3, #0xffff, lsl #32
+               	movk	x3, #0xffff, lsl #48
+               	cmp	x3, #0x5
+               	b.lt	 <L45>
+               	b	 <L48>
+<L45>:
+               	add	x4, x0, x3, lsl #2
+               	ldr	w5, [x4]
+               	mov	w4, w5
+               	mov	x5, x23
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L46>
+               	b	 <L47>
+<L46>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L46>
+<L47>:
+               	add	x3, x3, #0x1
+               	mov	x23, x5
+               	cmp	x3, #0x5
+               	b.lt	 <L45>
+<L48>:
                	add	x0, x20, #0x0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	add	x4, x0, x3, lsl #2
+               	ldr	w5, [x4]
+               	mov	w6, w3
+               	add	w7, w5, w6
+               	add	w5, w7, #0x1
+               	str	w5, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	mov	w0, w1
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x8
-               	b.lo	 <L44>
-               	b	 <L45>
-<L44>:
-               	add	x2, x0, x1, lsl #2
-               	ldr	w3, [x2]
-               	mov	w4, w1
-               	add	w5, w3, w4
-               	add	w3, w5, #0x1
-               	str	w3, [x2]
+               	b.lo	 <L51>
+               	b	 <L52>
+<L51>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x23, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x4, x16
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L44>
-<L45>:
+               	b.lo	 <L51>
+<L52>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L53>
+               	b	 <L56>
+<L53>:
+               	add	x1, x20, x0, lsl #2
+               	ldr	w3, [x1]
+               	mov	w1, w3
+               	mov	x3, x23
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x0, x0, #0x1
+               	mov	x23, x3
+               	cmp	x0, #0x8
+               	b.lo	 <L53>
+<L56>:
+               	mov	w0, w2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L57>
+               	b	 <L58>
+<L57>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L57>
+<L58>:
                	mov	x0, x23
-               	mov	w1, w21
-<L46>:
-               	bl	 <L46>
-               	mov	x19, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x8
-               	b.lo	 <L47>
-               	b	 <L49>
-<L47>:
-               	add	x0, x20, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x19
-<L48>:
-               	bl	 <L48>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L47>
-<L49>:
-               	mov	x0, x19
-               	mov	w1, w22
-<L50>:
-               	bl	 <L50>
-               	ldp	x19, x20, [x29, #-0xd0]
-               	ldp	x21, x22, [x29, #-0xe0]
-               	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldp	x21, x22, [x29, #-0x100]
+               	ldp	x23, x24, [x29, #-0x110]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/rec_layout.dis
+++ b/test/golden/aarch64-darwin/mem/rec_layout.dis
@@ -5,81 +5,190 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_tiny>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrb	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldrb	w20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldrb	w4, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	w1, w3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxtb	w1, w4
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.mem.rec_layout.fold_mid>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldrh	w4, [x3]
-               	add	x3, x1, #0x4
-               	add	x5, x3, #0x0
-               	ldrb	w19, [x5]
-               	add	x5, x3, #0x4
-               	ldr	w20, [x5]
-               	add	x5, x3, #0x8
-               	ldrb	w21, [x5]
-               	add	x3, x1, #0x10
-               	ldrb	w22, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldrh	w3, [x2]
+               	add	x2, x1, #0x4
+               	add	x4, x2, #0x0
+               	ldrb	w5, [x4]
+               	add	x4, x2, #0x4
+               	ldr	w6, [x4]
+               	add	x4, x2, #0x8
+               	ldrb	w2, [x4]
+               	add	x4, x1, #0x10
+               	ldrb	w1, [x4]
+               	uxth	w4, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x3, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	w1, w20
+               	uxtb	w3, w5
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x7, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x7, x16
+               	eor	x7, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x22
+               	mov	w3, w6
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	uxtb	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	ret
 
 <corpus.cases.mem.rec_layout.fold_wide>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x70
-               	stp	x19, x20, [x29, #-0x70]
+               	stur	x19, [x29, #-0x68]
                	mov	x2, x0
                	sub	x19, x29, #0x28
                	ldr	x3, [x1]
@@ -110,43 +219,114 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x18
-               	ldr	x3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x18
+               	ldr	x2, [x1]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x20, x19, #0x20
-               	add	x2, x20, #0x0
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x20, #0x2
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x4
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x19, #0x26
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x70]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	add	x1, x19, #0x26
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	ldur	x19, [x29, #-0x68]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -154,13 +334,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_nest>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x150
+               	sub	sp, sp, #0x140
                	stp	x19, x20, [x29, #-0x140]
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x21, [x29, x16]
                	sub	x19, x29, #0x58
                	add	x2, x19, #0x0
                	add	x3, x1, #0x0
@@ -233,30 +408,111 @@ Disassembly of section __TEXT,__text:
                	bl	 <L4>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	add	x21, x20, #0x20
-               	add	x1, x21, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, #0x2
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x1, x21, #0x4
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+<L12>:
                	add	x1, x20, #0x26
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L9>:
-               	bl	 <L9>
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
                	add	x20, x19, #0x28
                	add	x1, x20, #0x0
                	sub	x2, x29, #0xe8
@@ -273,8 +529,8 @@ Disassembly of section __TEXT,__text:
                	stur	x3, [x29, #-0xf8]
                	stur	w4, [x29, #-0xf0]
                	sub	x1, x29, #0x100
-<L10>:
-               	bl	 <L10>
+<L15>:
+               	bl	 <L15>
                	add	x1, x20, #0x14
                	sub	x2, x29, #0x114
                	ldr	x3, [x1]
@@ -302,19 +558,30 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x12c
-<L11>:
-               	bl	 <L11>
+<L16>:
+               	bl	 <L16>
                	add	x1, x19, #0x50
                	ldr	w2, [x1]
                	mov	w1, w2
-<L12>:
-               	bl	 <L12>
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+<L18>:
                	ldp	x19, x20, [x29, #-0x140]
-               	mov	x16, #0xfeb8            ; =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -349,166 +616,214 @@ Disassembly of section __TEXT,__text:
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	w20, w19
-               	mov	x0, x1
-               	mov	x1, #0xc                ; =12
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               ; =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x14               ; =20
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x28               ; =40
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x14              ; =20
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x58               ; =88
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x28              ; =40
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x58              ; =88
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               ; =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                ; =8
+               	mov	x1, #0x4                ; =4
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                ; =4
+               	mov	x1, #0x8                ; =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               ; =16
+               	mov	x1, #0x8                ; =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x18               ; =24
+               	mov	x1, #0x4                ; =4
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x20               ; =32
+               	mov	x1, #0x8                ; =8
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x26               ; =38
+               	mov	x1, #0x4                ; =4
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x28               ; =40
+               	mov	x1, #0x10               ; =16
 <L16>:
                	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x50               ; =80
+               	mov	x1, #0x18               ; =24
 <L17>:
                	bl	 <L17>
+               	mov	x1, #0x20               ; =32
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x26               ; =38
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x28               ; =40
+<L20>:
+               	bl	 <L20>
+               	mov	x1, #0x50               ; =80
+<L21>:
+               	bl	 <L21>
                	sub	x21, x29, #0x58
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x58               ; =88
-<L18>:
+<L22>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L18>
+               	b.ne	 <L22>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L20>
+               	b.lo	 <L24>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L19>:
+<L23>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L19>
-               	b	 <L22>
-<L20>:
+               	b.ne	 <L23>
+               	b	 <L26>
+<L24>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L21>:
+<L25>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L21>
-<L22>:
+               	b.ne	 <L25>
+<L26>:
                	sub	x2, x29, #0x108
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L24>
+               	b.lo	 <L28>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L23>:
+<L27>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L23>
-               	b	 <L26>
-<L24>:
+               	b.ne	 <L27>
+               	b	 <L30>
+<L28>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L25>:
+<L29>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L25>
-<L26>:
+               	b.ne	 <L29>
+<L30>:
                	sub	x1, x29, #0x108
-<L27>:
-               	bl	 <L27>
+<L31>:
+               	bl	 <L31>
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	w17, #0xa               ; =10
@@ -615,64 +930,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L29>
+               	b.lo	 <L33>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L28>:
+<L32>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L28>
-               	b	 <L31>
-<L29>:
+               	b.ne	 <L32>
+               	b	 <L35>
+<L33>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L30>:
+<L34>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L30>
-<L31>:
+               	b.ne	 <L34>
+<L35>:
                	sub	x2, x29, #0x1b8
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L33>
+               	b.lo	 <L37>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L32>:
+<L36>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L32>
-               	b	 <L35>
-<L33>:
+               	b.ne	 <L36>
+               	b	 <L39>
+<L37>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L34>:
+<L38>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L34>
-<L35>:
+               	b.ne	 <L38>
+<L39>:
                	sub	x1, x29, #0x1b8
-<L36>:
-               	bl	 <L36>
+<L40>:
+               	bl	 <L40>
                	add	x20, x21, #0x0
                	add	x1, x20, #0x0
                	add	x2, x1, #0x4
@@ -686,64 +1001,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L38>
+               	b.lo	 <L42>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L37>:
+<L41>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L37>
-               	b	 <L40>
-<L38>:
+               	b.ne	 <L41>
+               	b	 <L44>
+<L42>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L39>:
+<L43>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L39>
-<L40>:
+               	b.ne	 <L43>
+<L44>:
                	sub	x2, x29, #0x268
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L42>
+               	b.lo	 <L46>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L41>:
+<L45>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L41>
-               	b	 <L44>
-<L42>:
+               	b.ne	 <L45>
+               	b	 <L48>
+<L46>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L43>:
+<L47>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L43>
-<L44>:
+               	b.ne	 <L47>
+<L48>:
                	sub	x1, x29, #0x268
-<L45>:
-               	bl	 <L45>
+<L49>:
+               	bl	 <L49>
                	add	x22, x21, #0x28
                	add	x1, x22, #0x14
                	add	x2, x1, #0x4
@@ -755,64 +1070,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L47>
+               	b.lo	 <L51>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L46>:
+<L50>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L46>
-               	b	 <L49>
-<L47>:
+               	b.ne	 <L50>
+               	b	 <L53>
+<L51>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L48>:
+<L52>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L48>
-<L49>:
+               	b.ne	 <L52>
+<L53>:
                	sub	x2, x29, #0x318
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L51>
+               	b.lo	 <L55>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L50>:
+<L54>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L50>
-               	b	 <L53>
-<L51>:
+               	b.ne	 <L54>
+               	b	 <L57>
+<L55>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L52>:
+<L56>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L52>
-<L53>:
+               	b.ne	 <L56>
+<L57>:
                	sub	x1, x29, #0x318
-<L54>:
-               	bl	 <L54>
+<L58>:
+               	bl	 <L58>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
                	lsr	x3, x2, #3
@@ -821,64 +1136,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L56>
+               	b.lo	 <L60>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L55>:
+<L59>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L55>
-               	b	 <L58>
-<L56>:
+               	b.ne	 <L59>
+               	b	 <L62>
+<L60>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L57>:
+<L61>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L57>
-<L58>:
+               	b.ne	 <L61>
+<L62>:
                	sub	x2, x29, #0x3c8
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L60>
+               	b.lo	 <L64>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L59>:
+<L63>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L59>
-               	b	 <L62>
-<L60>:
+               	b.ne	 <L63>
+               	b	 <L66>
+<L64>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L61>:
+<L65>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L61>
-<L62>:
+               	b.ne	 <L65>
+<L66>:
                	sub	x1, x29, #0x3c8
-<L63>:
-               	bl	 <L63>
+<L67>:
+               	bl	 <L67>
                	ldr	w1, [x19]
                	mov	w16, #0x3               ; =3
                	mul	w2, w1, w16
@@ -887,64 +1202,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L65>
+               	b.lo	 <L69>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L64>:
+<L68>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L64>
-               	b	 <L67>
-<L65>:
+               	b.ne	 <L68>
+               	b	 <L71>
+<L69>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L66>:
+<L70>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L66>
-<L67>:
+               	b.ne	 <L70>
+<L71>:
                	sub	x2, x29, #0x478
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L69>
+               	b.lo	 <L73>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L68>:
+<L72>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L68>
-               	b	 <L71>
-<L69>:
+               	b.ne	 <L72>
+               	b	 <L75>
+<L73>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L70>:
+<L74>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L70>
-<L71>:
+               	b.ne	 <L74>
+<L75>:
                	sub	x1, x29, #0x478
-<L72>:
-               	bl	 <L72>
+<L76>:
+               	bl	 <L76>
                	sub	x19, x29, #0x48c
                	add	x20, x22, #0x0
                	sub	x1, x29, #0x4a0
@@ -991,8 +1306,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x4cc
-<L73>:
-               	bl	 <L73>
+<L77>:
+               	bl	 <L77>
                	sub	x1, x29, #0x4e0
                	ldr	x2, [x20]
                	ldr	x3, [x20, #0x8]
@@ -1019,8 +1334,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x4f8
-<L74>:
-               	bl	 <L74>
+<L78>:
+               	bl	 <L78>
                	sub	x1, x29, #0x50c
                	ldr	x2, [x19]
                	ldr	x3, [x19, #0x8]
@@ -1038,64 +1353,64 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L76>
+               	b.lo	 <L80>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               ; =88
-<L75>:
+<L79>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L75>
-               	b	 <L78>
-<L76>:
+               	b.ne	 <L79>
+               	b	 <L82>
+<L80>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L77>:
+<L81>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L77>
-<L78>:
+               	b.ne	 <L81>
+<L82>:
                	sub	x2, x29, #0x5c0
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L80>
+               	b.lo	 <L84>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               ; =88
-<L79>:
+<L83>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L79>
-               	b	 <L82>
-<L80>:
+               	b.ne	 <L83>
+               	b	 <L86>
+<L84>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               ; =88
-<L81>:
+<L85>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L81>
-<L82>:
+               	b.ne	 <L85>
+<L86>:
                	sub	x1, x29, #0x5c0
-<L83>:
-               	bl	 <L83>
+<L87>:
+               	bl	 <L87>
                	sub	x16, x29, #0x5d0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]

--- a/test/golden/aarch64-darwin/mem/uni_layout.dis
+++ b/test/golden/aarch64-darwin/mem/uni_layout.dis
@@ -26,62 +26,163 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.uni_layout.fold_w4>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
-               	sub	x19, x29, #0xc
-               	ldur	w1, [x29, #-0x8]
-               	str	w1, [x19]
-               	add	x1, x19, #0x0
-               	ldr	w3, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
+               	sub	x1, x29, #0xc
+               	ldur	w2, [x29, #-0x8]
+               	str	w2, [x1]
+               	add	x2, x1, #0x0
                	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	w2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	sxtw	x2, w3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x20, x19, #0x0
-               	add	x2, x20, #0x0
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x1
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x20, #0x2
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	add	x2, x20, #0x3
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x1
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x2
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x2, x1, #0x0
+               	add	x1, x2, #0x3
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -89,69 +190,149 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.uni_layout.fold_w8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x20]
-               	stur	x21, [x29, #-0x28]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
-               	sub	x19, x29, #0x10
-               	ldur	x1, [x29, #-0x8]
-               	str	x1, [x19]
-               	add	x1, x19, #0x0
-               	ldr	x3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
+               	sub	x1, x29, #0x10
+               	ldur	x2, [x29, #-0x8]
+               	str	x2, [x1]
+               	add	x2, x1, #0x0
                	ldr	x3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x20, x19, #0x0
-               	add	x2, x20, #0x0
-               	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x4
-               	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	add	x2, x1, #0x0
+               	ldr	d0, [x2]
+               	fmov	x2, d0
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x20, x0
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	add	x0, x19, #0x0
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L5>
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x20]
-               	ldur	x21, [x29, #-0x28]
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x4
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L13>
+<L10>:
+               	add	x3, x1, #0x0
+               	add	x4, x3, x2
+               	ldrb	w3, [x4]
+               	uxtb	w4, w3
+               	mov	x3, x0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L13>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -159,21 +340,20 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.uni_layout.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
+               	sub	sp, sp, #0xe0
                	stp	x19, x20, [x29, #-0xc0]
                	stp	x21, x22, [x29, #-0xd0]
                	stp	x23, x24, [x29, #-0xe0]
-               	stp	x25, x26, [x29, #-0xf0]
-               	stur	x27, [x29, #-0xf8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
+               	mov	x20, #0x2325            ; =8997
+               	movk	x20, #0x8422, lsl #16
+               	movk	x20, #0x9ce4, lsl #32
+               	movk	x20, #0xcbf2, lsl #48
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x6
-               	b.lo	 <L1>
-               	b	 <L8>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L7>
+<L0>:
                	add	x0, x21, #0x1
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
@@ -191,16 +371,16 @@ Disassembly of section __TEXT,__text:
                	orr	w0, w1, w16
                	add	x1, x23, #0x0
                	str	w0, [x1]
-               	sub	x0, x29, #0x54
+               	sub	x0, x29, #0x4c
                	ldr	w1, [x23]
                	str	w1, [x0]
-               	stur	xzr, [x29, #-0x60]
+               	stur	xzr, [x29, #-0x58]
                	ldr	w1, [x0]
-               	stur	w1, [x29, #-0x60]
-               	ldur	x1, [x29, #-0x60]
+               	stur	w1, [x29, #-0x58]
+               	ldur	x1, [x29, #-0x58]
                	mov	x0, x20
-<L2>:
-               	bl	 <L2>
+<L1>:
+               	bl	 <L1>
                	lsr	x1, x22, #7
                	mov	w2, w1
                	mov	w16, #0xffff            ; =65535
@@ -210,30 +390,30 @@ Disassembly of section __TEXT,__text:
                	orr	w2, w1, w16
                	add	x1, x23, #0x0
                	str	w2, [x1]
-               	sub	x1, x29, #0x74
+               	sub	x1, x29, #0x5c
                	ldr	w2, [x23]
                	str	w2, [x1]
-               	stur	xzr, [x29, #-0x80]
+               	stur	xzr, [x29, #-0x68]
                	ldr	w2, [x1]
-               	stur	w2, [x29, #-0x80]
-               	ldur	x1, [x29, #-0x80]
-<L3>:
-               	bl	 <L3>
+               	stur	w2, [x29, #-0x68]
+               	ldur	x1, [x29, #-0x68]
+<L2>:
+               	bl	 <L2>
                	add	x1, x23, #0x0
                	ldr	s0, [x1]
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	str	s1, [x1]
-               	sub	x1, x29, #0x84
+               	sub	x1, x29, #0x6c
                	ldr	w2, [x23]
                	str	w2, [x1]
-               	stur	xzr, [x29, #-0x90]
+               	stur	xzr, [x29, #-0x78]
                	ldr	w2, [x1]
-               	stur	w2, [x29, #-0x90]
-               	ldur	x1, [x29, #-0x90]
-<L4>:
-               	bl	 <L4>
-               	sub	x23, x29, #0x98
+               	stur	w2, [x29, #-0x78]
+               	ldur	x1, [x29, #-0x78]
+<L3>:
+               	bl	 <L3>
+               	sub	x23, x29, #0x80
                	str	xzr, [x23]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x1f, lsl #16
@@ -247,13 +427,13 @@ Disassembly of section __TEXT,__text:
                	orr	x2, x1, x16
                	add	x1, x23, #0x0
                	str	x2, [x1]
-               	sub	x1, x29, #0xa0
+               	sub	x1, x29, #0x90
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	lsr	x1, x22, #9
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0x1f, lsl #16
@@ -267,13 +447,13 @@ Disassembly of section __TEXT,__text:
                	orr	x1, x2, x16
                	add	x2, x23, #0x0
                	str	x1, [x2]
-               	sub	x1, x29, #0xa8
+               	sub	x1, x29, #0xa0
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	add	x1, x23, #0x0
                	ldr	d0, [x1]
                	fmov	d30, #3.00000000
@@ -281,26 +461,26 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #1.00000000
                	fadd	d0, d1, d30
                	str	d0, [x1]
-               	sub	x1, x29, #0xb0
+               	sub	x1, x29, #0xa8
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	add	x21, x21, #0x1
                	mov	x20, x0
                	cmp	x21, #0x6
-               	b.lo	 <L1>
-<L8>:
+               	b.lo	 <L0>
+<L7>:
                	sub	x21, x29, #0xc
                	str	xzr, [x21]
                	mov	w22, w19
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x4
-               	b.lo	 <L9>
-               	b	 <L17>
-<L9>:
+               	b.lo	 <L8>
+               	b	 <L18>
+<L8>:
                	mov	w0, w23
                	add	w1, w0, #0x1
                	mov	w17, #0x79b1            ; =31153
@@ -315,35 +495,76 @@ Disassembly of section __TEXT,__text:
                	eor	w1, w24, w16
                	add	x2, x0, #0x4
                	str	w1, [x2]
-               	add	x25, x21, #0x0
-               	ldr	x1, [x0]
-               	str	x1, [x25]
-               	add	x26, x25, #0x0
-               	ldr	w1, [x26]
-               	mov	x0, x20
+               	add	x1, x21, #0x0
+               	ldr	x2, [x0]
+               	str	x2, [x1]
+               	add	x0, x1, #0x0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	add	x27, x25, #0x4
-               	ldr	w1, [x27]
+               	add	x0, x21, #0x0
+               	add	x2, x0, #0x4
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	add	x25, x21, #0x0
-               	add	x1, x25, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	add	x1, x25, #0x2
-               	ldrh	w2, [x1]
+               	add	x0, x21, #0x0
+               	add	x2, x0, #0x0
+               	ldrh	w0, [x2]
+               	uxth	w2, w0
+               	mov	x0, x1
                	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	add	x1, x25, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	sub	x1, x29, #0x1c
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x4
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L15>:
+               	bl	 <L15>
+               	sub	x1, x29, #0xb0
                	mov	w2, w24
                	add	x3, x1, #0x0
                	strh	w2, [x3]
@@ -354,27 +575,36 @@ Disassembly of section __TEXT,__text:
                	add	w2, w24, #0x1
                	add	x3, x1, #0x4
                	str	w2, [x3]
-               	ldr	x2, [x1]
-               	str	x2, [x25]
-               	ldr	w1, [x26]
-<L15>:
-               	bl	 <L15>
-               	ldr	w1, [x27]
+               	add	x2, x21, #0x0
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L16>:
                	bl	 <L16>
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x4
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L17>:
+               	bl	 <L17>
                	add	x23, x23, #0x1
                	mov	x20, x0
                	cmp	x23, #0x4
-               	b.lo	 <L9>
-<L17>:
-               	sub	x21, x29, #0x30
+               	b.lo	 <L8>
+<L18>:
+               	sub	x21, x29, #0x28
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L19>
+               	b	 <L25>
+<L19>:
                	add	x0, x22, #0x1
                	mov	w1, w0
                	add	x2, x21, #0x0
@@ -395,50 +625,71 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0x9999, lsl #32
                	movk	x16, #0x3fd9, lsl #48
                	orr	x0, x1, x16
-               	add	x23, x21, #0x8
-               	add	x1, x23, #0x0
-               	str	x0, [x1]
-               	add	x24, x21, #0x0
-               	ldrb	w1, [x24]
-               	mov	x0, x20
-<L19>:
-               	bl	 <L19>
-               	sub	x1, x29, #0x68
-               	ldr	x2, [x23]
-               	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x1, x21, #0x8
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	add	x0, x21, #0x0
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, x20
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x23, x21, #0x8
+               	sub	x0, x29, #0x88
+               	ldr	x2, [x23]
+               	str	x2, [x0]
+               	ldr	x2, [x0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L22>:
+               	bl	 <L22>
                	add	x1, x23, #0x0
                	ldr	d0, [x1]
                	fmov	d30, #0.50000000
                	fadd	d1, d0, d30
                	str	d1, [x1]
-               	ldrb	w1, [x24]
-<L21>:
-               	bl	 <L21>
-               	sub	x1, x29, #0x70
-               	ldr	x2, [x23]
-               	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L22>:
-               	bl	 <L22>
+               	add	x1, x21, #0x0
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+<L23>:
+               	bl	 <L23>
+               	add	x1, x21, #0x8
+               	sub	x2, x29, #0x98
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	ldr	x1, [x2]
+<L24>:
+               	bl	 <L24>
                	add	x22, x22, #0x1
                	mov	x20, x0
                	cmp	x22, #0x4
-               	b.lo	 <L18>
-<L23>:
-               	sub	x21, x29, #0x48
+               	b.lo	 <L19>
+<L25>:
+               	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x3
-               	b.lo	 <L24>
-               	b	 <L25>
-<L24>:
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
                	add	x1, x0, #0x1
                	mov	x17, #0x1b3             ; =435
                	movk	x17, #0x100, lsl #32
@@ -459,33 +710,31 @@ Disassembly of section __TEXT,__text:
                	str	x1, [x3]
                	add	x0, x0, #0x1
                	cmp	x0, #0x3
-               	b.lo	 <L24>
-<L25>:
+               	b.lo	 <L26>
+<L27>:
                	mov	x19, #0x0               ; =0
                	cmp	x19, #0x3
-               	b.lo	 <L26>
-               	b	 <L28>
-<L26>:
+               	b.lo	 <L28>
+               	b	 <L30>
+<L28>:
                	add	x0, x21, x19, lsl #3
-               	sub	x1, x29, #0x50
+               	sub	x1, x29, #0x48
                	ldr	x2, [x0]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x0, x20
                	mov	x1, x2
-<L27>:
-               	bl	 <L27>
+<L29>:
+               	bl	 <L29>
                	add	x19, x19, #0x1
                	mov	x20, x0
                	cmp	x19, #0x3
-               	b.lo	 <L26>
-<L28>:
+               	b.lo	 <L28>
+<L30>:
                	mov	x0, x20
                	ldp	x19, x20, [x29, #-0xc0]
                	ldp	x21, x22, [x29, #-0xd0]
                	ldp	x23, x24, [x29, #-0xe0]
-               	ldp	x25, x26, [x29, #-0xf0]
-               	ldur	x27, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_i16.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_i16.dis
@@ -3,106 +3,296 @@ scalar/arith_i16.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_i16.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            ; =65520
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	sxth	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	sxth	w17, w3
                	cmp	w17, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxth	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxth	x4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	sxth	w17, w22
-               	cmp	w17, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               ; =0
-               	sxth	w17, w23
-               	cmp	w17, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	sxth	w17, w3
+               	cmp	w17, #0x20
+               	b.lt	 <L0>
 <L5>:
-               	mov	w16, #0x3039            ; =12345
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	sxth	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                ; =0
+               	sxth	w17, w4
                	cmp	w17, #0x8
-               	b.lt	 <L5>
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0x3039            ; =12345
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxth	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	sxth	w17, w4
+               	cmp	w17, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxth	x5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7fff            ; =32767
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x8000            ; =32768
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	sxth	x4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xffff            ; =65535
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	sxth	x1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7fff            ; =32767
+               	add	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x8000            ; =32768
+               	sub	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xffff            ; =65535
+               	add	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxth	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxth	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxth	x0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_i32.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_i32.dis
@@ -3,106 +3,296 @@ scalar/arith_i32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            ; =65520
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x20
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	w1, w23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxtw	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	w1, w21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxtw	x4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	w23, #0x0               ; =0
-               	cmp	w23, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	cmp	w3, #0x20
+               	b.lt	 <L0>
 <L5>:
+               	mov	x3, x1
+               	mov	w4, #0x0                ; =0
+               	cmp	w4, #0x8
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	w16, #0x5678            ; =22136
                	movk	w16, #0x1234, lsl #16
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	w1, w22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	cmp	w23, #0x8
-               	b.lt	 <L5>
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxtw	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	cmp	w4, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxtw	x5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	sxtw	x4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	sxtw	x1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7fff, lsl #16
-               	add	w1, w17, w21
-<L11>:
-               	bl	 <L11>
+               	add	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	w17, #-0x80000000       ; =-2147483648
-               	sub	w1, w17, w21
-<L12>:
-               	bl	 <L12>
+               	sub	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w21
-<L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
-<L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
-<L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxtw	x0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_i64.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_i64.dis
@@ -3,113 +3,291 @@ scalar/arith_i64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xfff0            ; =65520
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x20
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	x16, #0x7               ; =7
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x1
-               	add	x23, x21, x1
-               	mov	x0, x20
-               	mov	x1, x23
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x1
+               	add	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	x16, #0x3               ; =3
-               	mul	x1, x22, x16
-               	add	x2, x1, #0x2
-               	sub	x21, x23, x2
-               	mov	x1, x21
+               	mul	x6, x3, x16
+               	add	x7, x6, #0x2
+               	sub	x6, x4, x7
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x4, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x19
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x6
+               	cmp	x3, #0x20
+               	b.lt	 <L0>
 <L5>:
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	x16, #0xcdef            ; =52719
                	movk	x16, #0x90ab, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	mul	x0, x23, x16
-               	add	x1, x0, #0x1
-               	sub	x22, x22, x1
-               	mov	x0, x20
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x20, x0
-               	cmp	x23, #0x8
-               	b.lt	 <L5>
+               	mul	x5, x4, x16
+               	add	x6, x5, #0x1
+               	sub	x5, x3, x6
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	x17, #0x0               ; =0
-               	sub	x23, x17, x21
-               	mov	x0, x20
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x17, #0x0               ; =0
-               	sub	x1, x17, x23
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	mov	x3, x5
+               	cmp	x4, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	x17, #0x0               ; =0
-               	sub	x1, x17, x19
+               	sub	x4, x17, x1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x17, #0x0               ; =0
+               	sub	x5, x17, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x17, #0x0               ; =0
+               	sub	x4, x17, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x0, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x1, x17, x21
-<L11>:
-               	bl	 <L11>
+               	add	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	sub	x1, x17, x21
-<L12>:
-               	bl	 <L12>
+               	sub	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x21
-<L13>:
-               	bl	 <L13>
-               	add	x1, x21, x22
-<L14>:
-               	bl	 <L14>
-               	sub	x1, x21, x22
-<L15>:
-               	bl	 <L15>
-               	sub	x1, x22, x21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x1, x3
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	x0, x1, x3
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	x0, x3, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_i8.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_i8.dis
@@ -3,106 +3,296 @@ scalar/arith_i8.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_i8.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xf0              ; =240
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	sxtb	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	sxtb	w17, w3
                	cmp	w17, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxtb	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxtb	x4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	sxtb	w17, w22
-               	cmp	w17, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               ; =0
-               	sxtb	w17, w23
-               	cmp	w17, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	sxtb	w17, w3
+               	cmp	w17, #0x20
+               	b.lt	 <L0>
 <L5>:
-               	mov	w16, #0x35              ; =53
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	sxtb	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                ; =0
+               	sxtb	w17, w4
                	cmp	w17, #0x8
-               	b.lt	 <L5>
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0x35              ; =53
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxtb	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	sxtb	w17, w4
+               	cmp	w17, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxtb	x5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7f              ; =127
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x80              ; =128
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	sxtb	x4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xff              ; =255
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	sxtb	x1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7f              ; =127
+               	add	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x80              ; =128
+               	sub	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xff              ; =255
+               	add	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxtb	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxtb	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxtb	x0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_u16.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_u16.dis
@@ -3,106 +3,296 @@ scalar/arith_u16.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_u16.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            ; =65520
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	uxth	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	uxth	w17, w3
                	cmp	w17, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	uxth	w17, w22
-               	cmp	w17, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	uxth	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               ; =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	uxth	w4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               ; =0
-               	uxth	w17, w23
-               	cmp	w17, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	uxth	w17, w3
+               	cmp	w17, #0x20
+               	b.lo	 <L0>
 <L5>:
-               	mov	w16, #0xabcd            ; =43981
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	uxth	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                ; =0
+               	uxth	w17, w4
                	cmp	w17, #0x8
-               	b.lo	 <L5>
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0xabcd            ; =43981
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	uxth	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	uxth	w17, w4
+               	cmp	w17, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	uxth	w5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7fff            ; =32767
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x8000            ; =32768
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	uxth	w4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xffff            ; =65535
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	uxth	w1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7fff            ; =32767
+               	add	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x8000            ; =32768
+               	sub	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xffff            ; =65535
+               	add	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	uxth	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	uxth	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	uxth	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_u32.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_u32.dis
@@ -3,106 +3,296 @@ scalar/arith_u32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            ; =65520
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x20
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	w1, w23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	w1, w21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	mov	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               ; =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	mov	w4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	w23, #0x0               ; =0
-               	cmp	w23, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	cmp	w3, #0x20
+               	b.lo	 <L0>
 <L5>:
+               	mov	x3, x1
+               	mov	w4, #0x0                ; =0
+               	cmp	w4, #0x8
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	w16, #0x5678            ; =22136
                	movk	w16, #0x1234, lsl #16
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	w1, w22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	cmp	w23, #0x8
-               	b.lo	 <L5>
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	mov	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	cmp	w4, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	mov	w5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	mov	w4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	mov	w1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7fff, lsl #16
-               	add	w1, w17, w21
-<L11>:
-               	bl	 <L11>
+               	add	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	w17, #-0x80000000       ; =-2147483648
-               	sub	w1, w17, w21
-<L12>:
-               	bl	 <L12>
+               	sub	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w21
-<L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
-<L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
-<L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_u64.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_u64.dis
@@ -3,113 +3,291 @@ scalar/arith_u64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xfff0            ; =65520
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x20
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	x16, #0x7               ; =7
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x1
-               	add	x23, x21, x1
-               	mov	x0, x20
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0x3               ; =3
-               	mul	x1, x22, x16
-               	add	x2, x1, #0x2
-               	sub	x21, x23, x2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x20
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x1
+               	add	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	x16, #0x3               ; =3
+               	mul	x6, x3, x16
+               	add	x7, x6, #0x2
+               	sub	x6, x4, x7
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x4, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x19
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x6
+               	cmp	x3, #0x20
+               	b.lo	 <L0>
 <L5>:
+               	mov	x3, x0
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	x16, #0xcdef            ; =52719
                	movk	x16, #0x90ab, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	mul	x0, x23, x16
-               	add	x1, x0, #0x1
-               	sub	x22, x22, x1
-               	mov	x0, x20
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x20, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
+               	mul	x5, x4, x16
+               	add	x6, x5, #0x1
+               	sub	x5, x3, x6
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	x17, #0x0               ; =0
-               	sub	x23, x17, x21
-               	mov	x0, x20
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x17, #0x0               ; =0
-               	sub	x1, x17, x23
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	mov	x3, x5
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	x17, #0x0               ; =0
-               	sub	x1, x17, x19
+               	sub	x4, x17, x1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x17, #0x0               ; =0
+               	sub	x5, x17, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x17, #0x0               ; =0
+               	sub	x4, x17, x0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x0, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x1, x17, x21
-<L11>:
-               	bl	 <L11>
+               	add	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	sub	x1, x17, x21
-<L12>:
-               	bl	 <L12>
+               	sub	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x21
-<L13>:
-               	bl	 <L13>
-               	add	x1, x21, x22
-<L14>:
-               	bl	 <L14>
-               	sub	x1, x21, x22
-<L15>:
-               	bl	 <L15>
-               	sub	x1, x22, x21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x0, x17, x1
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x1, x3
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	x0, x1, x3
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	x0, x3, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/arith_u8.dis
+++ b/test/golden/aarch64-darwin/scalar/arith_u8.dis
@@ -3,106 +3,296 @@ scalar/arith_u8.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.arith_u8.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xf0              ; =240
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	uxtb	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	uxtb	w17, w3
                	cmp	w17, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               ; =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               ; =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	uxtb	w17, w22
-               	cmp	w17, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	uxtb	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               ; =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	uxtb	w4, w5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               ; =0
-               	uxtb	w17, w23
-               	cmp	w17, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	uxtb	w17, w3
+               	cmp	w17, #0x20
+               	b.lo	 <L0>
 <L5>:
-               	mov	w16, #0xb5              ; =181
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	uxtb	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                ; =0
+               	uxtb	w17, w4
                	cmp	w17, #0x8
-               	b.lo	 <L5>
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0xb5              ; =181
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	uxtb	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               ; =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	uxtb	w17, w4
+               	cmp	w17, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	uxtb	w5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7f              ; =127
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x80              ; =128
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               ; =0
+               	sub	w5, w17, w4
+               	uxtb	w4, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xff              ; =255
-               	add	w1, w17, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               ; =0
+               	sub	w4, w17, w1
+               	uxtb	w1, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7f              ; =127
+               	add	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x80              ; =128
+               	sub	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xff              ; =255
+               	add	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	uxtb	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	uxtb	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	uxtb	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/divrem_i32.dis
+++ b/test/golden/aarch64-darwin/scalar/divrem_i32.dis
@@ -3,206 +3,383 @@ scalar/divrem_i32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.divrem_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x9400            ; =37888
                	movk	w17, #0x7735, lsl #16
-               	sub	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
-               	b	 <L9>
-<L1>:
+               	sub	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
+               	b	 <L11>
+<L0>:
                	mov	w16, #0x83              ; =131
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x3
-               	add	w23, w1, w20
-               	cbnz	w23,  <L2>
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x3
+               	add	w4, w5, w1
+               	cbnz	w4,  <L1>
+               	brk	#0
+<L1>:
+               	cmn	w4, #0x1
+               	b.ne	 <L2>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L2>
                	brk	#0
 <L2>:
-               	cmn	w23, #0x1
-               	b.ne	 <L3>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L3>
+               	sdiv	w5, w0, w4
+               	cbnz	w4,  <L3>
                	brk	#0
 <L3>:
-               	sdiv	w24, w21, w23
-               	cbnz	w23,  <L4>
+               	cmn	w4, #0x1
+               	b.ne	 <L4>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L4>
                	brk	#0
 <L4>:
-               	cmn	w23, #0x1
-               	b.ne	 <L5>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L5>
-               	brk	#0
+               	sdiv	w16, w0, w4
+               	msub	w6, w16, w4, w0
+               	sxtw	x7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	sdiv	w16, w21, w23
-               	msub	w25, w16, w23, w21
-               	mov	x0, x19
-               	mov	w1, w24
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	w1, w25
+               	sxtw	x7, w6
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	sub	w21, w21, w23
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	sxtw	x6, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	sub	w0, w0, w4
+               	add	w3, w3, #0x1
+               	mov	x2, x8
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
+<L11>:
                	mov	w17, #0x9400            ; =37888
                	movk	w17, #0x7735, lsl #16
-               	add	w0, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x0               ; =0
-               	sub	w1, w17, w0
-               	mov	w21, #0x0               ; =0
-               	mov	x22, x1
-               	cmp	w21, #0x8
-               	b.lt	 <L10>
-               	b	 <L18>
-<L10>:
-               	mov	w16, #0xc5              ; =197
-               	mul	w0, w21, w16
-               	add	w1, w0, #0x5
-               	add	w23, w1, w20
-               	cbnz	w23,  <L11>
-               	brk	#0
-<L11>:
-               	cmn	w23, #0x1
-               	b.ne	 <L12>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w22, w17
-               	b.ne	 <L12>
-               	brk	#0
+               	sub	w3, w17, w0
+               	mov	w0, #0x0                ; =0
+               	cmp	w0, #0x8
+               	b.lt	 <L12>
+               	b	 <L23>
 <L12>:
-               	sdiv	w24, w22, w23
-               	cbnz	w23,  <L13>
+               	mov	w16, #0xc5              ; =197
+               	mul	w4, w0, w16
+               	add	w5, w4, #0x5
+               	add	w4, w5, w1
+               	cbnz	w4,  <L13>
                	brk	#0
 <L13>:
-               	cmn	w23, #0x1
+               	cmn	w4, #0x1
                	b.ne	 <L14>
                	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w22, w17
+               	cmp	w3, w17
                	b.ne	 <L14>
                	brk	#0
 <L14>:
-               	sdiv	w16, w22, w23
-               	msub	w25, w16, w23, w22
-               	mov	x0, x19
-               	mov	w1, w24
+               	sdiv	w5, w3, w4
+               	cbnz	w4,  <L15>
+               	brk	#0
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w25
+               	cmn	w4, #0x1
+               	b.ne	 <L16>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	sdiv	w16, w3, w4
+               	msub	w6, w16, w4, w3
+               	sxtw	x7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	add	w22, w22, w23
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x8
-               	b.lt	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L17>
 <L18>:
+               	sxtw	x7, w6
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	sxtw	x6, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	add	w3, w3, w4
+               	add	w0, w0, #0x1
+               	mov	x2, x8
+               	cmp	w0, #0x8
+               	b.lt	 <L12>
+<L23>:
                	mov	w17, #0xfffc            ; =65532
                	movk	w17, #0x7fff, lsl #16
-               	add	w21, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x3               ; =3
-               	add	w22, w17, w20
-               	cbnz	w22,  <L19>
+               	add	w3, w17, w1
+               	cbnz	w3,  <L24>
                	brk	#0
-<L19>:
-               	cmn	w22, #0x1
-               	b.ne	 <L20>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L20>
-               	brk	#0
-<L20>:
-               	sdiv	w20, w21, w22
-               	cbnz	w22,  <L21>
-               	brk	#0
-<L21>:
-               	cmn	w22, #0x1
-               	b.ne	 <L22>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L22>
-               	brk	#0
-<L22>:
-               	sdiv	w16, w21, w22
-               	msub	w23, w16, w22, w21
-               	mov	x0, x19
-               	mov	w1, w20
-<L23>:
-               	bl	 <L23>
-               	mov	w1, w23
 <L24>:
-               	bl	 <L24>
-               	mul	w1, w22, w20
-               	add	w2, w1, w23
-               	mov	w1, w2
+               	cmn	w3, #0x1
+               	b.ne	 <L25>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	cbnz	w21,  <L26>
+               	sdiv	w1, w0, w3
+               	cbnz	w3,  <L26>
                	brk	#0
 <L26>:
-               	cmn	w21, #0x1
+               	cmn	w3, #0x1
                	b.ne	 <L27>
                	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w22, w17
+               	cmp	w0, w17
                	b.ne	 <L27>
                	brk	#0
 <L27>:
-               	sdiv	w19, w22, w21
-               	cbnz	w21,  <L28>
-               	brk	#0
+               	sdiv	w16, w0, w3
+               	msub	w4, w16, w3, w0
+               	sxtw	x5, w1
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	cmn	w21, #0x1
-               	b.ne	 <L29>
-               	mov	w17, #-0x80000000       ; =-2147483648
-               	cmp	w22, w17
-               	b.ne	 <L29>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	sdiv	w16, w22, w21
-               	msub	w20, w16, w21, w22
-               	mov	w1, w19
+               	sxtw	x5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	w1, w20
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	mul	w1, w21, w19
-               	add	w2, w1, w20
-               	mov	w1, w2
+               	mul	w5, w3, w1
+               	add	w1, w5, w4
+               	sxtw	x4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
 <L32>:
-               	bl	 <L32>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	cbnz	w0,  <L34>
+               	brk	#0
+<L34>:
+               	cmn	w0, #0x1
+               	b.ne	 <L35>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L35>
+               	brk	#0
+<L35>:
+               	sdiv	w1, w3, w0
+               	cbnz	w0,  <L36>
+               	brk	#0
+<L36>:
+               	cmn	w0, #0x1
+               	b.ne	 <L37>
+               	mov	w17, #-0x80000000       ; =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L37>
+               	brk	#0
+<L37>:
+               	sdiv	w16, w3, w0
+               	msub	w4, w16, w0, w3
+               	sxtw	x3, w1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	sxtw	x3, w4
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	mul	w3, w0, w1
+               	add	w0, w3, w4
+               	sxtw	x1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/divrem_i64.dis
+++ b/test/golden/aarch64-darwin/scalar/divrem_i64.dis
@@ -3,209 +3,374 @@ scalar/divrem_i64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.divrem_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xe2840000        ; =3800301568
                	movk	x17, #0x6c50, lsl #32
                	movk	x17, #0x7ce6, lsl #48
-               	sub	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
-               	b	 <L9>
-<L1>:
+               	sub	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
+               	b	 <L11>
+<L0>:
                	mov	x16, #0x83              ; =131
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x3
-               	add	x23, x1, x19
-               	cbnz	x23,  <L2>
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x3
+               	add	x4, x5, x0
+               	cbnz	x4,  <L1>
+               	brk	#0
+<L1>:
+               	cmn	x4, #0x1
+               	b.ne	 <L2>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L2>
                	brk	#0
 <L2>:
-               	cmn	x23, #0x1
-               	b.ne	 <L3>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L3>
+               	sdiv	x5, x1, x4
+               	cbnz	x4,  <L3>
                	brk	#0
 <L3>:
-               	sdiv	x24, x21, x23
-               	cbnz	x23,  <L4>
+               	cmn	x4, #0x1
+               	b.ne	 <L4>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L4>
                	brk	#0
 <L4>:
-               	cmn	x23, #0x1
-               	b.ne	 <L5>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L5>
-               	brk	#0
+               	sdiv	x16, x1, x4
+               	msub	x6, x16, x4, x1
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	sdiv	x16, x21, x23
-               	msub	x25, x16, x23, x21
-               	mov	x0, x20
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x25
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	sub	x21, x21, x23
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	sub	x1, x1, x4
+               	add	x3, x3, #0x1
+               	mov	x2, x7
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
+<L11>:
                	mov	x17, #0xe2840000        ; =3800301568
                	movk	x17, #0x6c50, lsl #32
                	movk	x17, #0x7ce6, lsl #48
-               	add	x0, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x0               ; =0
-               	sub	x1, x17, x0
-               	mov	x21, #0x0               ; =0
-               	mov	x22, x1
-               	cmp	x21, #0x8
-               	b.lt	 <L10>
-               	b	 <L18>
-<L10>:
-               	mov	x16, #0xc5              ; =197
-               	mul	x0, x21, x16
-               	add	x1, x0, #0x5
-               	add	x23, x1, x19
-               	cbnz	x23,  <L11>
-               	brk	#0
-<L11>:
-               	cmn	x23, #0x1
-               	b.ne	 <L12>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x22, x17
-               	b.ne	 <L12>
-               	brk	#0
+               	sub	x3, x17, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lt	 <L12>
+               	b	 <L23>
 <L12>:
-               	sdiv	x24, x22, x23
-               	cbnz	x23,  <L13>
+               	mov	x16, #0xc5              ; =197
+               	mul	x4, x1, x16
+               	add	x5, x4, #0x5
+               	add	x4, x5, x0
+               	cbnz	x4,  <L13>
                	brk	#0
 <L13>:
-               	cmn	x23, #0x1
+               	cmn	x4, #0x1
                	b.ne	 <L14>
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x22, x17
+               	cmp	x3, x17
                	b.ne	 <L14>
                	brk	#0
 <L14>:
-               	sdiv	x16, x22, x23
-               	msub	x25, x16, x23, x22
-               	mov	x0, x20
-               	mov	x1, x24
+               	sdiv	x5, x3, x4
+               	cbnz	x4,  <L15>
+               	brk	#0
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x25
+               	cmn	x4, #0x1
+               	b.ne	 <L16>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	sdiv	x16, x3, x4
+               	msub	x6, x16, x4, x3
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	add	x22, x22, x23
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lt	 <L10>
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L17>
 <L18>:
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	add	x3, x3, x4
+               	add	x1, x1, #0x1
+               	mov	x2, x7
+               	cmp	x1, #0x8
+               	b.lt	 <L12>
+<L23>:
                	mov	x17, #0xfffc            ; =65532
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x21, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x3               ; =3
-               	add	x22, x17, x19
-               	cbnz	x22,  <L19>
+               	add	x3, x17, x0
+               	cbnz	x3,  <L24>
                	brk	#0
-<L19>:
-               	cmn	x22, #0x1
-               	b.ne	 <L20>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L20>
-               	brk	#0
-<L20>:
-               	sdiv	x19, x21, x22
-               	cbnz	x22,  <L21>
-               	brk	#0
-<L21>:
-               	cmn	x22, #0x1
-               	b.ne	 <L22>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L22>
-               	brk	#0
-<L22>:
-               	sdiv	x16, x21, x22
-               	msub	x23, x16, x22, x21
-               	mov	x0, x20
-               	mov	x1, x19
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x23
 <L24>:
-               	bl	 <L24>
-               	mul	x1, x22, x19
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	cmn	x3, #0x1
+               	b.ne	 <L25>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	cbnz	x21,  <L26>
+               	sdiv	x0, x1, x3
+               	cbnz	x3,  <L26>
                	brk	#0
 <L26>:
-               	cmn	x21, #0x1
+               	cmn	x3, #0x1
                	b.ne	 <L27>
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x22, x17
+               	cmp	x1, x17
                	b.ne	 <L27>
                	brk	#0
 <L27>:
-               	sdiv	x19, x22, x21
-               	cbnz	x21,  <L28>
-               	brk	#0
+               	sdiv	x16, x1, x3
+               	msub	x4, x16, x3, x1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	cmn	x21, #0x1
-               	b.ne	 <L29>
-               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	cmp	x22, x17
-               	b.ne	 <L29>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	sdiv	x16, x22, x21
-               	msub	x20, x16, x21, x22
-               	mov	x1, x19
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	x1, x20
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	mul	x1, x21, x19
-               	add	x2, x1, x20
-               	mov	x1, x2
+               	mul	x5, x3, x0
+               	add	x0, x5, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
 <L32>:
-               	bl	 <L32>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	cbnz	x1,  <L34>
+               	brk	#0
+<L34>:
+               	cmn	x1, #0x1
+               	b.ne	 <L35>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L35>
+               	brk	#0
+<L35>:
+               	sdiv	x0, x3, x1
+               	cbnz	x1,  <L36>
+               	brk	#0
+<L36>:
+               	cmn	x1, #0x1
+               	b.ne	 <L37>
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L37>
+               	brk	#0
+<L37>:
+               	sdiv	x16, x3, x1
+               	msub	x4, x16, x1, x3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	mul	x3, x1, x0
+               	add	x0, x3, x4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/divrem_u32.dis
+++ b/test/golden/aarch64-darwin/scalar/divrem_u32.dis
@@ -3,108 +3,238 @@ scalar/divrem_u32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.divrem_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
-               	b	 <L7>
-<L1>:
+               	sub	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
+               	b	 <L9>
+<L0>:
                	mov	w16, #0x83              ; =131
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x3
-               	add	w23, w1, w20
-               	cbnz	w23,  <L2>
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x3
+               	add	w4, w5, w1
+               	cbnz	w4,  <L1>
+               	brk	#0
+<L1>:
+               	udiv	w5, w0, w4
+               	cbnz	w4,  <L2>
                	brk	#0
 <L2>:
-               	udiv	w24, w21, w23
-               	cbnz	w23,  <L3>
-               	brk	#0
+               	udiv	w16, w0, w4
+               	msub	w6, w16, w4, w0
+               	mov	w7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	udiv	w16, w21, w23
-               	msub	w25, w16, w23, w21
-               	mov	x0, x19
-               	mov	w1, w24
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	w1, w25
+               	mov	w7, w6
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	sub	w21, w21, w23
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	mov	w6, w5
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	sub	w0, w0, w4
+               	add	w3, w3, #0x1
+               	mov	x2, x8
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
+<L9>:
                	mov	w17, #0xfffd            ; =65533
                	movk	w17, #0xffff, lsl #16
-               	add	w21, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x3               ; =3
-               	add	w22, w17, w20
-               	cbnz	w22,  <L8>
+               	add	w3, w17, w1
+               	cbnz	w3,  <L10>
                	brk	#0
-<L8>:
-               	udiv	w20, w21, w22
-               	cbnz	w22,  <L9>
-               	brk	#0
-<L9>:
-               	udiv	w16, w21, w22
-               	msub	w23, w16, w22, w21
-               	mov	x0, x19
-               	mov	w1, w20
 <L10>:
-               	bl	 <L10>
-               	mov	w1, w23
+               	udiv	w1, w0, w3
+               	cbnz	w3,  <L11>
+               	brk	#0
 <L11>:
-               	bl	 <L11>
-               	mul	w1, w22, w20
-               	add	w2, w1, w23
-               	mov	w1, w2
+               	udiv	w16, w0, w3
+               	msub	w4, w16, w3, w0
+               	mov	w5, w1
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	cbnz	w21,  <L13>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	udiv	w19, w22, w21
-               	cbnz	w21,  <L14>
-               	brk	#0
+               	mov	w5, w4
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	udiv	w16, w22, w21
-               	msub	w20, w16, w21, w22
-               	mov	w1, w19
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w20
+               	mul	w5, w3, w1
+               	add	w1, w5, w4
+               	mov	w4, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mul	w1, w21, w19
-               	add	w2, w1, w20
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	cbnz	w0,  <L18>
+               	brk	#0
+<L18>:
+               	udiv	w1, w3, w0
+               	cbnz	w0,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	w16, w3, w0
+               	msub	w4, w16, w0, w3
+               	mov	w3, w1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	w3, w4
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mul	w3, w0, w1
+               	add	w0, w3, w4
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/divrem_u64.dis
+++ b/test/golden/aarch64-darwin/scalar/divrem_u64.dis
@@ -3,111 +3,232 @@ scalar/divrem_u64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.divrem_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	sub	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
-               	b	 <L7>
-<L1>:
+               	sub	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
+               	b	 <L9>
+<L0>:
                	mov	x16, #0x83              ; =131
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x3
-               	add	x23, x1, x19
-               	cbnz	x23,  <L2>
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x3
+               	add	x4, x5, x0
+               	cbnz	x4,  <L1>
+               	brk	#0
+<L1>:
+               	udiv	x5, x1, x4
+               	cbnz	x4,  <L2>
                	brk	#0
 <L2>:
-               	udiv	x24, x21, x23
-               	cbnz	x23,  <L3>
-               	brk	#0
+               	udiv	x16, x1, x4
+               	msub	x6, x16, x4, x1
+               	mov	x7, x2
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	udiv	x16, x21, x23
-               	msub	x25, x16, x23, x21
-               	mov	x0, x20
-               	mov	x1, x24
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x25
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	sub	x21, x21, x23
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	sub	x1, x1, x4
+               	add	x3, x3, #0x1
+               	mov	x2, x7
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
+<L9>:
                	mov	x17, #0xfffd            ; =65533
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x21, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x3               ; =3
-               	add	x22, x17, x19
-               	cbnz	x22,  <L8>
+               	add	x3, x17, x0
+               	cbnz	x3,  <L10>
                	brk	#0
-<L8>:
-               	udiv	x19, x21, x22
-               	cbnz	x22,  <L9>
-               	brk	#0
-<L9>:
-               	udiv	x16, x21, x22
-               	msub	x23, x16, x22, x21
-               	mov	x0, x20
-               	mov	x1, x19
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x23
+               	udiv	x0, x1, x3
+               	cbnz	x3,  <L11>
+               	brk	#0
 <L11>:
-               	bl	 <L11>
-               	mul	x1, x22, x19
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	udiv	x16, x1, x3
+               	msub	x4, x16, x3, x1
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	cbnz	x21,  <L13>
-               	brk	#0
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	udiv	x19, x22, x21
-               	cbnz	x21,  <L14>
-               	brk	#0
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	udiv	x16, x22, x21
-               	msub	x20, x16, x21, x22
-               	mov	x1, x19
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x20
+               	mul	x5, x3, x0
+               	add	x0, x5, x4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mul	x1, x21, x19
-               	add	x2, x1, x20
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	cbnz	x1,  <L18>
+               	brk	#0
+<L18>:
+               	udiv	x0, x3, x1
+               	cbnz	x1,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	x16, x3, x1
+               	msub	x4, x16, x1, x3
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              ; =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mul	x3, x1, x0
+               	add	x0, x3, x4
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/mul_i32.dis
+++ b/test/golden/aarch64-darwin/scalar/mul_i32.dis
@@ -3,69 +3,178 @@ scalar/mul_i32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.mul_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x79b9            ; =31161
                	movk	w17, #0x9e37, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w17, #0x2               ; =2
-               	mul	w0, w17, w22
-               	add	w1, w0, #0x3
-               	mul	w21, w21, w1
-               	mov	x0, x19
-               	mov	w1, w21
+               	mul	w4, w17, w3
+               	add	w5, w4, #0x3
+               	mul	w4, w0, w5
+               	sxtw	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x4
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
 <L3>:
                	mov	w17, #0xffbf            ; =65471
                	movk	w17, #0xffff, lsl #16
-               	add	w22, w17, w20
-               	mul	w1, w22, w22
-               	mov	x0, x19
+               	add	w3, w17, w1
+               	mul	w4, w3, w3
+               	sxtw	x5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w22, w16
-<L5>:
-               	bl	 <L5>
-               	mul	w1, w21, w22
+               	mul	w4, w3, w16
+               	sxtw	x5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	w1, w22, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	w4, w0, w3
+               	sxtw	x5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	w4, w3, w0
+               	sxtw	x0, w4
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x1, lsl #16
-               	add	w19, w17, w20
-               	mul	w1, w19, w19
-<L8>:
-               	bl	 <L8>
+               	add	w0, w17, w1
+               	mul	w1, w0, w0
+               	sxtw	x3, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w19, w16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	w1, w0, w16
+               	sxtw	x0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/mul_i64.dis
+++ b/test/golden/aarch64-darwin/scalar/mul_i64.dis
@@ -3,76 +3,178 @@ scalar/mul_i64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.mul_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	x17, #0x2               ; =2
-               	mul	x0, x17, x22
-               	add	x1, x0, #0x3
-               	mul	x21, x21, x1
-               	mov	x0, x20
-               	mov	x1, x21
+               	mul	x4, x17, x3
+               	add	x5, x4, #0x3
+               	mul	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x4
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
 <L3>:
                	mov	x17, #0xffc1            ; =65473
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x22, x17, x19
-               	mul	x1, x22, x22
-               	mov	x0, x20
+               	add	x3, x17, x0
+               	mul	x4, x3, x3
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x22, x16
-<L5>:
-               	bl	 <L5>
-               	mul	x1, x21, x22
+               	mul	x4, x3, x16
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	x1, x22, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	x4, x1, x3
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	x4, x3, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x17, #0xf               ; =15
                	movk	x17, #0x1, lsl #32
-               	add	x20, x17, x19
-               	mul	x1, x20, x20
-<L8>:
-               	bl	 <L8>
+               	add	x1, x17, x0
+               	mul	x0, x1, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x20, x16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	x0, x1, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/mul_u32.dis
+++ b/test/golden/aarch64-darwin/scalar/mul_u32.dis
@@ -3,68 +3,177 @@ scalar/mul_u32.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.mul_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x79b1            ; =31153
                	movk	w17, #0x9e37, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               ; =0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                ; =0
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w17, #0x2               ; =2
-               	mul	w0, w17, w22
-               	add	w1, w0, #0x3
-               	mul	w21, w21, w1
-               	mov	x0, x19
-               	mov	w1, w21
-<L2>:
-               	bl	 <L2>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
+               	mul	w4, w17, w3
+               	add	w5, w4, #0x3
+               	mul	w4, w0, w5
+               	mov	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x4
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	w17, #0xffbf            ; =65471
                	movk	w17, #0xffff, lsl #16
-               	add	w22, w17, w20
-               	mul	w1, w22, w22
-               	mov	x0, x19
+               	add	w3, w17, w1
+               	mul	w4, w3, w3
+               	mov	w5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0xffff            ; =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w22, w16
-<L5>:
-               	bl	 <L5>
-               	mul	w1, w21, w22
+               	mul	w4, w3, w16
+               	mov	w5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	w1, w22, w21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	w4, w0, w3
+               	mov	w5, w4
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	w4, w3, w0
+               	mov	w0, w4
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x1, lsl #16
-               	add	w19, w17, w20
-               	mul	w1, w19, w19
-<L8>:
-               	bl	 <L8>
+               	add	w0, w17, w1
+               	mul	w1, w0, w0
+               	mov	w3, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	w16, #0xffff            ; =65535
-               	mul	w1, w19, w16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	w1, w0, w16
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/scalar/mul_u64.dis
+++ b/test/golden/aarch64-darwin/scalar/mul_u64.dis
@@ -3,74 +3,176 @@ scalar/mul_u64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.scalar.mul_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7c15            ; =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               ; =0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             ; =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	x17, #0x2               ; =2
-               	mul	x0, x17, x22
-               	add	x1, x0, #0x3
-               	mul	x21, x21, x1
-               	mov	x0, x20
-               	mov	x1, x21
-<L2>:
-               	bl	 <L2>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
+               	mul	x4, x17, x3
+               	add	x5, x4, #0x3
+               	mul	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x4
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	x17, #0xffc1            ; =65473
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x22, x17, x19
-               	mul	x1, x22, x22
-               	mov	x0, x20
+               	add	x3, x17, x0
+               	mul	x4, x3, x3
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x22, x16
-<L5>:
-               	bl	 <L5>
-               	mul	x1, x21, x22
+               	mul	x4, x3, x16
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	x1, x22, x21
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	x4, x1, x3
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              ; =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	x4, x3, x1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x5, x16
+               	eor	x5, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x17, #0xf               ; =15
                	movk	x17, #0x1, lsl #32
-               	add	x20, x17, x19
-               	mul	x1, x20, x20
-<L8>:
-               	bl	 <L8>
+               	add	x1, x17, x0
+               	mul	x0, x1, x1
+               	mov	x3, #0x0                ; =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
-               	mul	x1, x20, x16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	x0, x1, x16
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-darwin/vec/autovec_loop.dis
+++ b/test/golden/aarch64-darwin/vec/autovec_loop.dis
@@ -5,673 +5,812 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x8f0
-               	sub	x16, x29, #0x8c0
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stur	x25, [x16, #-0x28]
-               	sub	x16, x29, #0x8f8
-               	str	d8, [x16, #0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
+               	sub	sp, sp, #0x8b0
                	mov	x16, #0x1               ; =1
-               	and	x1, x19, x16
+               	and	x1, x0, x16
                	mov	x17, #0x43              ; =67
-               	sub	x20, x17, x1
+               	sub	x2, x17, x1
                	mov	x17, #0x25              ; =37
-               	sub	x21, x17, x1
-               	mov	w1, w19
-               	ucvtf	s8, x19
-               	sub	x19, x29, #0x10c
-               	add	x2, x19, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x108              ; =264
+               	sub	x3, x17, x1
+               	mov	w1, w0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x680
+               	add	x4, x0, #0x0
+               	add	x5, x4, #0x0
+               	mov	x4, #0x108              ; =264
+<L0>:
+               	str	xzr, [x5]
+               	add	x5, x5, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L0>
+               	str	wzr, [x5]
+               	sub	x4, x29, #0x78c
+               	add	x5, x4, #0x0
+               	add	x6, x5, #0x0
+               	mov	x5, #0x108              ; =264
 <L1>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x5, x5, #0x8
+               	cmp	x5, #0x0
                	b.ne	 <L1>
-               	str	wzr, [x3]
-               	sub	x22, x29, #0x218
-               	add	x2, x22, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x108              ; =264
+               	str	wzr, [x6]
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, x2
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
-               	b.ne	 <L2>
-               	str	wzr, [x3]
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, x20
-               	b.lo	 <L3>
-               	b	 <L4>
-<L3>:
-               	mov	w3, w2
+               	mov	w6, w5
                	mov	w16, #0x79b1            ; =31153
                	movk	w16, #0x9e37, lsl #16
-               	mul	w4, w3, w16
+               	mul	w7, w6, w16
                	mov	w16, #0x3039            ; =12345
-               	add	w5, w4, w16
-               	add	x4, x19, x2, lsl #2
-               	str	w5, [x4]
+               	add	w8, w7, w16
+               	add	x7, x0, x5, lsl #2
+               	str	w8, [x7]
                	mov	w16, #0x9e37            ; =40503
-               	mul	w4, w3, w16
+               	mul	w7, w6, w16
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w3, w17, w4
-               	add	x4, x22, x2, lsl #2
-               	str	w3, [x4]
-               	add	x2, x2, #0x1
-               	cmp	x2, x20
-               	b.lo	 <L3>
+               	sub	w6, w17, w7
+               	add	x7, x4, x5, lsl #2
+               	str	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L2>
+<L3>:
+               	add	x5, x0, #0x0
+               	ldr	w6, [x5]
+               	add	w7, w6, w1
+               	str	w7, [x5]
+               	add	x5, x4, #0x4
+               	ldr	w6, [x5]
+               	add	w7, w6, w1
+               	str	w7, [x5]
+               	sub	x1, x29, #0x10c
+               	add	x5, x1, #0x0
+               	add	x6, x5, #0x0
+               	mov	x5, #0x108              ; =264
 <L4>:
-               	add	x2, x19, #0x0
-               	ldr	w3, [x2]
-               	add	w4, w3, w1
-               	str	w4, [x2]
-               	add	x2, x22, #0x4
-               	ldr	w3, [x2]
-               	add	w4, w3, w1
-               	str	w4, [x2]
-               	sub	x23, x29, #0x324
-               	add	x1, x23, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x108              ; =264
-<L5>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L5>
-               	str	wzr, [x2]
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x5, x5, #0x8
+               	cmp	x5, #0x0
+               	b.ne	 <L4>
+               	str	wzr, [x6]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xfffe, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	cmp	x20, x16
-               	cset	w1, ls
+               	cmp	x2, x16
+               	cset	w5, ls
                	mov	w16, #0x1               ; =1
-               	and	w2, w1, w16
+               	and	w6, w5, w16
                	mov	w16, #0x1               ; =1
-               	and	w1, w2, w16
+               	and	w5, w6, w16
                	mov	w16, #0x1               ; =1
-               	and	w2, w1, w16
+               	and	w6, w5, w16
                	mov	w16, #0x1               ; =1
-               	and	w1, w2, w16
-               	add	x2, x19, #0x0
-               	add	x3, x19, x20, lsl #2
-               	add	x4, x22, #0x0
-               	add	x5, x22, x20, lsl #2
-               	add	x6, x23, #0x0
-               	add	x7, x23, x20, lsl #2
-               	cmp	x7, x2
+               	and	w5, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x2, lsl #2
+               	add	x8, x4, #0x0
+               	add	x12, x4, x2, lsl #2
+               	add	x13, x1, #0x0
+               	add	x14, x1, x2, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
                	cset	w8, ls
-               	cmp	x3, x6
-               	cset	w2, ls
-               	orr	w3, w8, w2
-               	cmp	x7, x4
-               	cset	w2, ls
-               	cmp	x5, x6
-               	cset	w4, ls
-               	orr	w5, w2, w4
-               	and	w2, w3, w5
-               	and	w3, w1, w2
-               	cbnz	w3,  <L7>
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, x20
-               	b.lo	 <L6>
-               	b	 <L11>
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w5, w6
+               	cbnz	w7,  <L6>
+               	mov	x5, #0x0                ; =0
+               	cmp	x5, x2
+               	b.lo	 <L5>
+               	b	 <L10>
+<L5>:
+               	add	x6, x0, x5, lsl #2
+               	ldr	w7, [x6]
+               	mov	w16, #0x3               ; =3
+               	mul	w6, w7, w16
+               	add	x7, x4, x5, lsl #2
+               	ldr	w8, [x7]
+               	add	w7, w6, w8
+               	add	x6, x1, x5, lsl #2
+               	str	w7, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L5>
+               	b	 <L10>
 <L6>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	mov	w16, #0x3               ; =3
-               	mul	w2, w3, w16
-               	add	x3, x22, x1, lsl #2
-               	ldr	w4, [x3]
-               	add	w3, w2, w4
-               	add	x2, x23, x1, lsl #2
-               	str	w3, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L6>
-               	b	 <L11>
+               	sub	x5, x29, #0x8a8
+               	add	x6, x5, #0x0
+               	mov	w17, #0x3               ; =3
+               	str	w17, [x6]
+               	add	x6, x5, #0x4
+               	mov	w17, #0x3               ; =3
+               	str	w17, [x6]
+               	add	x6, x5, #0x8
+               	mov	w17, #0x3               ; =3
+               	str	w17, [x6]
+               	add	x6, x5, #0xc
+               	mov	w17, #0x3               ; =3
+               	str	w17, [x6]
+               	ldr	q1, [x5]
+               	mov	x5, #0x0                ; =0
+               	add	x6, x5, #0x4
+               	cmp	x6, x2
+               	b.ls	 <L7>
+               	b	 <L8>
 <L7>:
-               	sub	x1, x29, #0x8a8
-               	add	x2, x1, #0x0
-               	mov	w17, #0x3               ; =3
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0x3               ; =3
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0x3               ; =3
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0x3               ; =3
-               	str	w17, [x2]
-               	ldr	q0, [x1]
-               	mov	x1, #0x0                ; =0
-               	add	x2, x1, #0x4
-               	cmp	x2, x20
-               	b.ls	 <L8>
-               	b	 <L9>
+               	add	x6, x0, x5, lsl #2
+               	ldr	q2, [x6]
+               	mul.4s	v3, v2, v1
+               	add	x6, x4, x5, lsl #2
+               	ldr	q2, [x6]
+               	add.4s	v4, v3, v2
+               	add	x6, x1, x5, lsl #2
+               	str	q4, [x6]
+               	add	x5, x5, #0x4
+               	add	x6, x5, #0x4
+               	cmp	x6, x2
+               	b.ls	 <L7>
 <L8>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q1, [x2]
-               	mul.4s	v2, v1, v0
-               	add	x2, x22, x1, lsl #2
-               	ldr	q1, [x2]
-               	add.4s	v3, v2, v1
-               	add	x2, x23, x1, lsl #2
-               	str	q3, [x2]
-               	add	x1, x1, #0x4
-               	add	x2, x1, #0x4
-               	cmp	x2, x20
-               	b.ls	 <L8>
+               	cmp	x5, x2
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	cmp	x1, x20
-               	b.lo	 <L10>
-               	b	 <L11>
-<L10>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
+               	add	x6, x0, x5, lsl #2
+               	ldr	w7, [x6]
                	mov	w16, #0x3               ; =3
-               	mul	w2, w3, w16
-               	add	x3, x22, x1, lsl #2
-               	ldr	w4, [x3]
-               	add	w3, w2, w4
-               	add	x2, x23, x1, lsl #2
-               	str	w3, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L10>
-<L11>:
-               	mov	x24, x0
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, x20
-               	b.lo	 <L12>
+               	mul	w6, w7, w16
+               	add	x7, x4, x5, lsl #2
+               	ldr	w8, [x7]
+               	add	w7, w6, w8
+               	add	x6, x1, x5, lsl #2
+               	str	w7, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L9>
+<L10>:
+               	mov	x5, #0x2325             ; =8997
+               	movk	x5, #0x8422, lsl #16
+               	movk	x5, #0x9ce4, lsl #32
+               	movk	x5, #0xcbf2, lsl #48
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, x2
+               	b.lo	 <L11>
                	b	 <L14>
-<L12>:
-               	add	x0, x23, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L13>:
-               	bl	 <L13>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, x20
+<L11>:
+               	add	x7, x1, x6, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
                	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x6, x6, #0x1
+               	mov	x5, x8
+               	cmp	x6, x2
+               	b.lo	 <L11>
 <L14>:
-               	mov	x0, #0x0                ; =0
-               	mov	w1, #0x0                ; =0
-               	mov	w25, #0x0               ; =0
-               	cmp	x0, x20
+               	mov	x6, #0x0                ; =0
+               	mov	w7, #0x0                ; =0
+               	mov	w8, #0x0                ; =0
+               	cmp	x6, x2
                	b.lo	 <L15>
                	b	 <L16>
 <L15>:
-               	add	x2, x23, x0, lsl #2
-               	ldr	w3, [x2]
-               	add	w1, w1, w3
-               	add	x2, x19, x0, lsl #2
-               	ldr	w3, [x2]
-               	eor	w25, w25, w3
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
+               	add	x12, x1, x6, lsl #2
+               	ldr	w13, [x12]
+               	add	w7, w7, w13
+               	add	x12, x0, x6, lsl #2
+               	ldr	w13, [x12]
+               	eor	w8, w8, w13
+               	add	x6, x6, #0x1
+               	cmp	x6, x2
                	b.lo	 <L15>
 <L16>:
-               	mov	x0, x24
+               	mov	w6, w7
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	mov	w1, w25
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x7, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x5, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	sub	x24, x29, #0x430
-               	add	x1, x24, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x108              ; =264
+               	mov	w6, w8
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	sub	x6, x29, #0x898
+               	add	x7, x6, #0x0
+               	add	x8, x7, #0x0
+               	mov	x7, #0x108              ; =264
+<L21>:
+               	str	xzr, [x8]
+               	add	x8, x8, #0x8
+               	sub	x7, x7, #0x8
+               	cmp	x7, #0x0
+               	b.ne	 <L21>
+               	str	wzr, [x8]
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, x2
+               	b.lo	 <L22>
+               	b	 <L25>
+<L22>:
+               	add	x8, x0, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x4, x7, lsl #2
+               	ldr	w13, [x8]
+               	cmp	w13, w12
+               	b.lo	 <L23>
+               	add	x8, x4, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x0, x7, lsl #2
+               	ldr	w13, [x8]
+               	sub	w8, w12, w13
+               	add	x12, x6, x7, lsl #2
+               	str	w8, [x12]
+               	b	 <L24>
+<L23>:
+               	add	x8, x0, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x4, x7, lsl #2
+               	ldr	w13, [x8]
+               	sub	w8, w12, w13
+               	add	x12, x6, x7, lsl #2
+               	str	w8, [x12]
+<L24>:
+               	add	x7, x7, #0x1
+               	cmp	x7, x2
+               	b.lo	 <L22>
+<L25>:
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, x2
+               	b.lo	 <L26>
+               	b	 <L29>
+<L26>:
+               	add	x7, x6, x4, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	add	x4, x4, #0x1
+               	mov	x5, x8
+               	cmp	x4, x2
+               	b.lo	 <L26>
+<L29>:
+               	sub	x4, x29, #0x218
+               	add	x6, x4, #0x0
+               	add	x7, x6, #0x0
+               	mov	x6, #0x108              ; =264
+<L30>:
+               	str	xzr, [x7]
+               	add	x7, x7, #0x8
+               	sub	x6, x6, #0x8
+               	cmp	x6, #0x0
+               	b.ne	 <L30>
+               	str	wzr, [x7]
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, x2
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	add	x7, x4, x6, lsl #2
+               	mov	w17, #0xaaaa            ; =43690
+               	movk	w17, #0xaaaa, lsl #16
+               	str	w17, [x7]
+               	add	x6, x6, #0x1
+               	cmp	x6, x2
+               	b.lo	 <L31>
+<L32>:
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, x2
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	add	x7, x1, x6, lsl #2
+               	ldr	w8, [x7]
+               	mov	w16, #0x1               ; =1
+               	eor	w7, w8, w16
+               	add	x8, x4, x6, lsl #2
+               	str	w7, [x8]
+               	add	x6, x6, #0x2
+               	cmp	x6, x2
+               	b.lo	 <L33>
+<L34>:
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, x2
+               	b.lo	 <L35>
+               	b	 <L38>
+<L35>:
+               	add	x6, x4, x1, lsl #2
+               	ldr	w7, [x6]
+               	mov	w6, w7
+               	mov	x7, x5
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x1, x1, #0x1
+               	mov	x5, x7
+               	cmp	x1, x2
+               	b.lo	 <L35>
+<L38>:
+               	sub	x1, x29, #0x324
+               	add	x4, x1, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x108              ; =264
+<L39>:
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L39>
+               	str	wzr, [x6]
+               	add	x4, x0, #0x0
+               	ldr	w6, [x4]
+               	add	x4, x1, #0x0
+               	str	w6, [x4]
+               	mov	x4, #0x1                ; =1
+               	cmp	x4, x2
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	sub	x6, x4, #0x1
+               	add	x7, x1, x6, lsl #2
+               	ldr	w6, [x7]
+               	mov	w16, #0x1f              ; =31
+               	mul	w7, w6, w16
+               	add	x6, x0, x4, lsl #2
+               	ldr	w8, [x6]
+               	add	w6, w7, w8
+               	add	x7, x1, x4, lsl #2
+               	str	w6, [x7]
+               	add	x4, x4, #0x1
+               	cmp	x4, x2
+               	b.lo	 <L40>
+<L41>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, x2
+               	b.lo	 <L42>
+               	b	 <L45>
+<L42>:
+               	add	x4, x1, x0, lsl #2
+               	ldr	w6, [x4]
+               	mov	w4, w6
+               	mov	x6, x5
+               	mov	x7, #0x0                ; =0
+               	cmp	x7, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               ; =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              ; =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x0, #0x1
+               	mov	x5, x6
+               	cmp	x0, x2
+               	b.lo	 <L42>
+<L45>:
+               	sub	x0, x29, #0x3b8
+               	add	x1, x0, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x90               ; =144
+<L46>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L19>
+               	b.ne	 <L46>
                	str	wzr, [x2]
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, x20
-               	b.lo	 <L20>
-               	b	 <L23>
-<L20>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x22, x1, lsl #2
-               	ldr	w4, [x2]
-               	cmp	w4, w3
-               	b.lo	 <L21>
-               	add	x2, x22, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x19, x1, lsl #2
-               	ldr	w4, [x2]
-               	sub	w2, w3, w4
-               	add	x3, x24, x1, lsl #2
-               	str	w2, [x3]
-               	b	 <L22>
-<L21>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x22, x1, lsl #2
-               	ldr	w4, [x2]
-               	sub	w2, w3, w4
-               	add	x3, x24, x1, lsl #2
-               	str	w2, [x3]
-<L22>:
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L20>
-<L23>:
-               	mov	x22, x0
-               	mov	x25, #0x0               ; =0
-               	cmp	x25, x20
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
-               	add	x0, x24, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L25>:
-               	bl	 <L25>
-               	add	x25, x25, #0x1
-               	mov	x22, x0
-               	cmp	x25, x20
-               	b.lo	 <L24>
-<L26>:
-               	sub	x24, x29, #0x53c
-               	add	x0, x24, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x108              ; =264
-<L27>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L27>
-               	str	wzr, [x1]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, x20
-               	b.lo	 <L28>
-               	b	 <L29>
-<L28>:
-               	add	x1, x24, x0, lsl #2
-               	mov	w17, #0xaaaa            ; =43690
-               	movk	w17, #0xaaaa, lsl #16
-               	str	w17, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
-               	b.lo	 <L28>
-<L29>:
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, x20
-               	b.lo	 <L30>
-               	b	 <L31>
-<L30>:
-               	add	x1, x23, x0, lsl #2
-               	ldr	w2, [x1]
-               	mov	w16, #0x1               ; =1
-               	eor	w1, w2, w16
-               	add	x2, x24, x0, lsl #2
-               	str	w1, [x2]
-               	add	x0, x0, #0x2
-               	cmp	x0, x20
-               	b.lo	 <L30>
-<L31>:
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, x20
-               	b.lo	 <L32>
-               	b	 <L34>
-<L32>:
-               	add	x0, x24, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L33>:
-               	bl	 <L33>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, x20
-               	b.lo	 <L32>
-<L34>:
-               	sub	x23, x29, #0x648
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x108              ; =264
-<L35>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L35>
-               	str	wzr, [x1]
-               	add	x0, x19, #0x0
-               	ldr	w1, [x0]
-               	add	x0, x23, #0x0
-               	str	w1, [x0]
-               	mov	x0, #0x1                ; =1
-               	cmp	x0, x20
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
-               	sub	x1, x0, #0x1
-               	add	x2, x23, x1, lsl #2
-               	ldr	w1, [x2]
-               	mov	w16, #0x1f              ; =31
-               	mul	w2, w1, w16
-               	add	x1, x19, x0, lsl #2
-               	ldr	w3, [x1]
-               	add	w1, w2, w3
-               	add	x2, x23, x0, lsl #2
-               	str	w1, [x2]
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
-               	b.lo	 <L36>
-<L37>:
-               	mov	x19, #0x0               ; =0
-               	cmp	x19, x20
-               	b.lo	 <L38>
-               	b	 <L40>
-<L38>:
-               	add	x0, x23, x19, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L39>:
-               	bl	 <L39>
-               	add	x19, x19, #0x1
-               	mov	x22, x0
-               	cmp	x19, x20
-               	b.lo	 <L38>
-<L40>:
-               	sub	x19, x29, #0x6dc
-               	add	x0, x19, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               ; =144
-<L41>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L41>
-               	str	wzr, [x1]
-               	sub	x20, x29, #0x770
-               	add	x0, x20, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               ; =144
-<L42>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L42>
-               	str	wzr, [x1]
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, x21
-               	b.lo	 <L43>
-               	b	 <L44>
-<L43>:
-               	ucvtf	s0, x0
-               	fadd	s1, s0, s8
-               	add	x1, x19, x0, lsl #2
-               	str	s1, [x1]
-               	fmov	s31, #1.25000000
-               	fsub	s1, s31, s0
-               	add	x1, x20, x0, lsl #2
-               	str	s1, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L43>
-<L44>:
-               	sub	x23, x29, #0x804
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               ; =144
-<L45>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L45>
-               	str	wzr, [x1]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xfffe, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	cmp	x21, x16
-               	cset	w0, ls
-               	mov	w16, #0x1               ; =1
-               	and	w1, w0, w16
-               	mov	w16, #0x1               ; =1
-               	and	w0, w1, w16
-               	mov	w16, #0x1               ; =1
-               	and	w1, w0, w16
-               	mov	w16, #0x1               ; =1
-               	and	w0, w1, w16
-               	add	x1, x19, #0x0
-               	add	x2, x19, x21, lsl #2
-               	add	x3, x20, #0x0
-               	add	x4, x20, x21, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x21, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
-               	cset	w1, ls
-               	orr	w2, w7, w1
-               	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	and	w2, w0, w1
-               	cbnz	w2,  <L47>
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, x21
-               	b.lo	 <L46>
-               	b	 <L51>
-<L46>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L46>
-               	b	 <L51>
+               	sub	x1, x29, #0x44c
+               	add	x2, x1, #0x0
+               	add	x4, x2, #0x0
+               	mov	x2, #0x90               ; =144
 <L47>:
-               	mov	x0, #0x0                ; =0
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L48>
+               	str	xzr, [x4]
+               	add	x4, x4, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L47>
+               	str	wzr, [x4]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, x3
+               	b.lo	 <L48>
                	b	 <L49>
 <L48>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	q0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	q1, [x1]
-               	fmul.4s	v2, v0, v1
-               	add	x1, x23, x0, lsl #2
-               	str	q2, [x1]
-               	add	x0, x0, #0x4
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L48>
+               	ucvtf	s1, x2
+               	fadd	s2, s1, s0
+               	add	x4, x0, x2, lsl #2
+               	str	s2, [x4]
+               	fmov	s31, #1.25000000
+               	fsub	s2, s31, s1
+               	add	x4, x1, x2, lsl #2
+               	str	s2, [x4]
+               	add	x2, x2, #0x1
+               	cmp	x2, x3
+               	b.lo	 <L48>
 <L49>:
-               	cmp	x0, x21
-               	b.lo	 <L50>
-               	b	 <L51>
+               	sub	x2, x29, #0x4e0
+               	add	x4, x2, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x90               ; =144
 <L50>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L50>
-<L51>:
-               	mov	x24, #0x0               ; =0
-               	cmp	x24, x21
-               	b.lo	 <L52>
-               	b	 <L54>
-<L52>:
-               	add	x0, x23, x24, lsl #2
-               	ldr	s0, [x0]
-               	mov	x0, x22
-<L53>:
-               	bl	 <L53>
-               	add	x24, x24, #0x1
-               	mov	x22, x0
-               	cmp	x24, x21
-               	b.lo	 <L52>
-<L54>:
-               	sub	x23, x29, #0x898
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               ; =144
-<L55>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L55>
-               	str	wzr, [x1]
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L50>
+               	str	wzr, [x6]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xfffe, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	cmp	x21, x16
-               	cset	w0, ls
+               	cmp	x3, x16
+               	cset	w4, ls
                	mov	w16, #0x1               ; =1
-               	and	w1, w0, w16
+               	and	w6, w4, w16
                	mov	w16, #0x1               ; =1
-               	and	w0, w1, w16
+               	and	w4, w6, w16
                	mov	w16, #0x1               ; =1
-               	and	w1, w0, w16
+               	and	w6, w4, w16
                	mov	w16, #0x1               ; =1
-               	and	w0, w1, w16
-               	add	x1, x19, #0x0
-               	add	x2, x19, x21, lsl #2
-               	add	x3, x20, #0x0
-               	add	x4, x20, x21, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x21, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
-               	cset	w1, ls
-               	orr	w2, w7, w1
+               	and	w4, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x3, lsl #2
+               	add	x8, x1, #0x0
+               	add	x12, x1, x3, lsl #2
+               	add	x13, x2, #0x0
+               	add	x14, x2, x3, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
+               	cset	w8, ls
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w4, w6
+               	cbnz	w7,  <L52>
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, x3
+               	b.lo	 <L51>
+               	b	 <L56>
+<L51>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fmul	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L51>
+               	b	 <L56>
+<L52>:
+               	mov	x4, #0x0                ; =0
+               	add	x6, x4, #0x4
                	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	and	w2, w0, w1
-               	cbnz	w2,  <L57>
-               	mov	x0, #0x0                ; =0
-               	cmp	x0, x21
-               	b.lo	 <L56>
-               	b	 <L61>
+               	b.ls	 <L53>
+               	b	 <L54>
+<L53>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	q0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	q1, [x6]
+               	fmul.4s	v2, v0, v1
+               	add	x6, x2, x4, lsl #2
+               	str	q2, [x6]
+               	add	x4, x4, #0x4
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L53>
+<L54>:
+               	cmp	x4, x3
+               	b.lo	 <L55>
+               	b	 <L56>
+<L55>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fmul	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L55>
 <L56>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L56>
-               	b	 <L61>
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, x3
+               	b.lo	 <L57>
+               	b	 <L60>
 <L57>:
-               	mov	x0, #0x0                ; =0
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L58>
+               	add	x6, x2, x4, lsl #2
+               	ldr	s0, [x6]
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, x5
+               	mov	x8, #0x0                ; =0
+               	cmp	x8, #0x8
+               	b.lo	 <L58>
                	b	 <L59>
 <L58>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	q0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	q1, [x1]
-               	fdiv.4s	v2, v0, v1
-               	add	x1, x23, x0, lsl #2
-               	str	q2, [x1]
-               	add	x0, x0, #0x4
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L58>
+               	mov	x16, #0x8               ; =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              ; =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L58>
 <L59>:
-               	cmp	x0, x21
-               	b.lo	 <L60>
-               	b	 <L61>
+               	add	x4, x4, #0x1
+               	mov	x5, x6
+               	cmp	x4, x3
+               	b.lo	 <L57>
 <L60>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L60>
+               	sub	x2, x29, #0x574
+               	add	x4, x2, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x90               ; =144
 <L61>:
-               	mov	x19, #0x0               ; =0
-               	cmp	x19, x21
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L61>
+               	str	wzr, [x6]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x3, x16
+               	cset	w4, ls
+               	mov	w16, #0x1               ; =1
+               	and	w6, w4, w16
+               	mov	w16, #0x1               ; =1
+               	and	w4, w6, w16
+               	mov	w16, #0x1               ; =1
+               	and	w6, w4, w16
+               	mov	w16, #0x1               ; =1
+               	and	w4, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x3, lsl #2
+               	add	x8, x1, #0x0
+               	add	x12, x1, x3, lsl #2
+               	add	x13, x2, #0x0
+               	add	x14, x2, x3, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
+               	cset	w8, ls
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w4, w6
+               	cbnz	w7,  <L63>
+               	mov	x4, #0x0                ; =0
+               	cmp	x4, x3
                	b.lo	 <L62>
-               	b	 <L64>
+               	b	 <L67>
 <L62>:
-               	add	x0, x23, x19, lsl #2
-               	ldr	s0, [x0]
-               	mov	x0, x22
-<L63>:
-               	bl	 <L63>
-               	add	x19, x19, #0x1
-               	mov	x22, x0
-               	cmp	x19, x21
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fdiv	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
                	b.lo	 <L62>
+               	b	 <L67>
+<L63>:
+               	mov	x4, #0x0                ; =0
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L64>
+               	b	 <L65>
 <L64>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	q0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	q1, [x6]
+               	fdiv.4s	v2, v0, v1
+               	add	x6, x2, x4, lsl #2
+               	str	q2, [x6]
+               	add	x4, x4, #0x4
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L64>
+<L65>:
+               	cmp	x4, x3
+               	b.lo	 <L66>
+               	b	 <L67>
+<L66>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fdiv	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L66>
+<L67>:
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, x3
+               	b.lo	 <L68>
+               	b	 <L71>
+<L68>:
+               	add	x1, x2, x0, lsl #2
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w4, w1
+               	mov	x1, x5
+               	mov	x6, #0x0                ; =0
+               	cmp	x6, #0x8
+               	b.lo	 <L69>
+               	b	 <L70>
+<L69>:
+               	mov	x16, #0x8               ; =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              ; =255
+               	and	x7, x8, x16
+               	eor	x8, x1, x7
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L69>
+<L70>:
+               	add	x0, x0, #0x1
+               	mov	x5, x1
+               	cmp	x0, x3
+               	b.lo	 <L68>
+<L71>:
                	mov	x0, #0x0                ; =0
                	fmov	s0, wzr
-               	cmp	x0, x21
-               	b.lo	 <L65>
-               	b	 <L66>
-<L65>:
-               	add	x1, x23, x0, lsl #2
+               	cmp	x0, x3
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	add	x1, x2, x0, lsl #2
                	ldr	s1, [x1]
                	fadd	s0, s0, s1
                	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L65>
-<L66>:
-               	mov	x0, x22
-<L67>:
-               	bl	 <L67>
-               	sub	x16, x29, #0x8f8
-               	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x8c0
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldur	x25, [x16, #-0x28]
+               	cmp	x0, x3
+               	b.lo	 <L72>
+<L73>:
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L74>
+               	b	 <L75>
+<L74>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x5, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L74>
+<L75>:
+               	mov	x0, x5
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_cmp_i64.dis
+++ b/test/golden/aarch64-darwin/vec/vec_cmp_i64.dis
@@ -3,243 +3,280 @@ vec/vec_cmp_i64.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov.d	x1, v0[0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.d	x1, v0[1]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov.d	x1, v0[0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.d	x1, v0[1]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x410
-               	sub	x16, x29, #0x3f0
+               	sub	sp, sp, #0x350
+               	sub	x16, x29, #0x330
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stur	x23, [x16, #-0x18]
                	mov	x19, x0
+               	sub	x20, x29, #0x1a0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               ; =96
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               ; =96
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	sub	x21, x29, #0x200
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               ; =96
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L1>
-               	sub	x21, x29, #0xc0
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               ; =96
-<L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L2>
-               	sub	x1, x29, #0xd0
-               	add	x2, x1, #0x0
+               	sub	x0, x29, #0x210
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x0
-               	str	q0, [x1]
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x220
+               	add	x1, x0, #0x0
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x0
-               	str	q0, [x1]
-               	sub	x1, x29, #0xf0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x230
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff00000000    ; =281470681743360
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x10
-               	str	q0, [x1]
-               	sub	x1, x29, #0x100
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x240
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff00000000    ; =281470681743360
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x10
-               	str	q0, [x1]
-               	sub	x1, x29, #0x110
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x250
+               	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x20
-               	str	q0, [x1]
-               	sub	x1, x29, #0x120
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x260
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x20
-               	str	q0, [x1]
-               	sub	x1, x29, #0x130
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x270
+               	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xdef0            ; =57072
                	movk	x17, #0x9abc, lsl #16
                	movk	x17, #0x5678, lsl #32
                	movk	x17, #0x1234, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x30
-               	str	q0, [x1]
-               	sub	x1, x29, #0x140
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x280
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xdef0            ; =57072
                	movk	x17, #0x9abc, lsl #16
                	movk	x17, #0x5678, lsl #32
                	movk	x17, #0x1234, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x30
-               	str	q0, [x1]
-               	sub	x1, x29, #0x150
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x290
+               	add	x1, x0, #0x0
                	mov	x17, #0x200000000       ; =8589934592
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x40
-               	str	q0, [x1]
-               	sub	x1, x29, #0x160
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2a0
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x40
-               	str	q0, [x1]
-               	sub	x1, x29, #0x170
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2b0
+               	add	x1, x0, #0x0
                	mov	x17, #0x10a             ; =266
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x50
-               	str	q0, [x1]
-               	sub	x1, x29, #0x180
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x50
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2c0
+               	add	x1, x0, #0x0
                	mov	x17, #0xa               ; =10
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x50
-               	str	q0, [x1]
-               	mov	x22, x0
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x50
+               	str	q0, [x0]
+               	mov	x22, #0x2325            ; =8997
+               	movk	x22, #0x8422, lsl #16
+               	movk	x22, #0x9ce4, lsl #32
+               	movk	x22, #0xcbf2, lsl #48
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x6
-               	b.lo	 <L3>
-               	b	 <L18>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L13>
+<L2>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x23, x16
                	add	x1, x20, x0
@@ -282,23 +319,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd10            ; =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
                	mov	x0, x22
-<L4>:
-               	bl	 <L4>
                	mov	x16, #0xfd10            ; =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L5>:
-               	bl	 <L5>
+               	ldr	q0, [x29, x16]
+<L3>:
+               	bl	 <L3>
                	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -309,26 +337,46 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmge.2d	v31, v31, v30
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            ; =64768
+               	cmge.2d	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt.2d	v0, v31, v30
+<L5>:
+               	bl	 <L5>
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge.2d	v0, v31, v30
 <L6>:
                	bl	 <L6>
-               	mov	x16, #0xfd00            ; =64768
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v0, v31, v30
 <L7>:
                	bl	 <L7>
                	mov	x16, #0xfd30            ; =64816
@@ -341,197 +389,98 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmgt.2d	v31, v31, v30
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	cmeq.2d	v0, v31, v30
+               	mvn.16b	v0, v0
 <L8>:
                	bl	 <L8>
-               	mov	x16, #0xfcf0            ; =64752
+               	mov	x16, #0xfd10            ; =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v31, v30
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn.16b	v1, v31
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v2, v1, v30
+               	orr.16b	v1, v0, v2
+               	mov.d	x1, v1[0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfd30            ; =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmge.2d	v31, v31, v30
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	mov.d	x1, v1[1]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfd30            ; =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq.2d	v31, v31, v30
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfd30            ; =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq.2d	v31, v31, v30
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmgt.2d	v0, v31, v30
-               	mov	x16, #0xfd30            ; =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mvn.16b	v2, v0
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v0, v2, v30
-               	orr.16b	v31, v1, v0
-               	mov	x16, #0xfcb0            ; =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfcb0            ; =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L17>:
-               	bl	 <L17>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x6
-               	b.lo	 <L3>
-<L18>:
-               	sub	x20, x29, #0x1d0
+               	b.lo	 <L2>
+<L13>:
+               	sub	x20, x29, #0x50
                	add	x0, x20, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x50               ; =80
-<L19>:
+<L14>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L19>
-               	sub	x21, x29, #0x220
+               	b.ne	 <L14>
+               	sub	x21, x29, #0xa0
                	add	x0, x21, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x50               ; =80
-<L20>:
+<L15>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L20>
-               	sub	x0, x29, #0x230
+               	b.ne	 <L15>
+               	sub	x0, x29, #0xb0
                	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
                	str	x17, [x1]
@@ -544,7 +493,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x0
                	str	q0, [x0]
-               	sub	x0, x29, #0x240
+               	sub	x0, x29, #0xc0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
@@ -557,7 +506,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x0
                	str	q0, [x0]
-               	sub	x0, x29, #0x250
+               	sub	x0, x29, #0xd0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
@@ -570,7 +519,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	sub	x0, x29, #0x260
+               	sub	x0, x29, #0xe0
                	add	x1, x0, #0x0
                	mov	x17, #0x1               ; =1
                	movk	x17, #0x1, lsl #32
@@ -583,7 +532,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x10
                	str	q0, [x0]
-               	sub	x0, x29, #0x270
+               	sub	x0, x29, #0xf0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
@@ -595,7 +544,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x20
                	str	q0, [x0]
-               	sub	x0, x29, #0x280
+               	sub	x0, x29, #0x100
                	add	x1, x0, #0x0
                	str	xzr, [x1]
                	add	x1, x0, #0x8
@@ -607,7 +556,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x20
                	str	q0, [x0]
-               	sub	x0, x29, #0x290
+               	sub	x0, x29, #0x110
                	add	x1, x0, #0x0
                	mov	x17, #0x80000000        ; =2147483648
                	movk	x17, #0x8000, lsl #48
@@ -619,7 +568,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x30
                	str	q0, [x0]
-               	sub	x0, x29, #0x2a0
+               	sub	x0, x29, #0x120
                	add	x1, x0, #0x0
                	mov	x17, #0x80000000        ; =2147483648
                	movk	x17, #0x8000, lsl #48
@@ -633,7 +582,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x30
                	str	q0, [x0]
-               	sub	x0, x29, #0x2b0
+               	sub	x0, x29, #0x130
                	add	x1, x0, #0x0
                	mov	x17, #0x10a             ; =266
                	str	x17, [x1]
@@ -646,7 +595,7 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x40
                	str	q0, [x0]
-               	sub	x0, x29, #0x2c0
+               	sub	x0, x29, #0x140
                	add	x1, x0, #0x0
                	mov	x17, #0xa               ; =10
                	str	x17, [x1]
@@ -657,9 +606,9 @@ Disassembly of section __TEXT,__text:
                	str	q0, [x0]
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x5
-               	b.lo	 <L21>
-               	b	 <L36>
-<L21>:
+               	b.lo	 <L16>
+               	b	 <L24>
+<L16>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x23, x16
                	add	x1, x20, x0
@@ -672,7 +621,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x0, x19
                	mov.16b	v30, v0
                	mov.d	v30[0], x1
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -681,258 +630,135 @@ Disassembly of section __TEXT,__text:
                	add	x1, x0, x19
                	mov.16b	v30, v1
                	mov.d	v30[1], x1
-               	mov	x16, #0xfc90            ; =64656
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.2d	v31, v31, v30
-               	mov	x16, #0xfc80            ; =64640
+               	mov	x16, #0xfce0            ; =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
                	mov	x0, x22
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfc80            ; =64640
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L17>:
+               	bl	 <L17>
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmhs.2d	v31, v31, v30
-               	mov	x16, #0xfc70            ; =64624
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc70            ; =64624
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfc70            ; =64624
+               	cmhs.2d	v0, v31, v30
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi.2d	v31, v31, v30
-               	mov	x16, #0xfc60            ; =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc60            ; =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfc60            ; =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhs.2d	v31, v31, v30
-               	mov	x16, #0xfc50            ; =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc50            ; =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfc50            ; =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq.2d	v31, v31, v30
-               	mov	x16, #0xfc40            ; =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc40            ; =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfc40            ; =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq.2d	v31, v31, v30
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfc30            ; =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc30            ; =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfc30            ; =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.2d	v0, v31, v30
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mvn.16b	v2, v0
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v0, v2, v30
-               	orr.16b	v31, v1, v0
-               	mov	x16, #0xfc20            ; =64544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc20            ; =64544
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfc20            ; =64544
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs.2d	v0, v31, v30
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L35>:
-               	bl	 <L35>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v0, v31, v30
+<L21>:
+               	bl	 <L21>
+               	mov	x16, #0xfd00            ; =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v0, v31, v30
+               	mvn.16b	v0, v0
+<L22>:
+               	bl	 <L22>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd00            ; =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v31, v30
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn.16b	v1, v31
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v2, v1, v30
+               	orr.16b	v1, v0, v2
+               	mov.16b	v0, v1
+<L23>:
+               	bl	 <L23>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x5
-               	b.lo	 <L21>
-<L36>:
+               	b.lo	 <L16>
+<L24>:
                	mov	x0, x22
-               	sub	x16, x29, #0x3f0
+               	sub	x16, x29, #0x330
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldur	x23, [x16, #-0x18]

--- a/test/golden/aarch64-darwin/vec/vec_cmp_select.dis
+++ b/test/golden/aarch64-darwin/vec/vec_cmp_select.dis
@@ -3,184 +3,378 @@ vec/vec_cmp_select.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_cmp_select.fold_u8x16>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[0]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[1]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[2]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[3]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[4]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[5]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[6]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[7]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.b	w1, v0[8]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov.b	w1, v0[9]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov.b	w1, v0[10]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov.b	w1, v0[11]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov.b	w1, v0[12]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov.b	w1, v0[13]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov.b	w1, v0[14]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov.b	w1, v0[15]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_cmp_select.fold_u16x8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[0]
-               	mov	x0, x1
+               	umov.h	w1, v31[0]
+               	uxth	w2, w1
                	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[1]
-               	mov	x0, x1
+               	umov.h	w1, v31[1]
+               	uxth	w2, w1
                	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[2]
-               	mov	x0, x1
+               	umov.h	w1, v31[2]
+               	uxth	w2, w1
                	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[3]
-               	mov	x0, x1
+               	umov.h	w1, v31[3]
+               	uxth	w2, w1
                	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[4]
-               	mov	x0, x1
+               	umov.h	w1, v31[4]
+               	uxth	w2, w1
                	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[5]
-               	mov	x0, x1
+               	umov.h	w1, v31[5]
+               	uxth	w2, w1
                	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[6]
-               	mov	x0, x1
+               	umov.h	w1, v31[6]
+               	uxth	w2, w1
                	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[7]
-               	mov	x0, x1
+               	umov.h	w1, v31[7]
+               	uxth	w2, w1
                	mov	x1, x2
 <L7>:
                	bl	 <L7>
@@ -192,33 +386,29 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
                	mov	sp, x29
@@ -252,29 +442,33 @@ Disassembly of section __TEXT,__text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31[0]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31[1]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31[2]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31[3]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
                	mov	sp, x29
@@ -284,98 +478,115 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x390
-               	sub	x16, x29, #0x370
+               	sub	sp, sp, #0x350
+               	sub	x16, x29, #0x330
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
-               	sub	x16, x29, #0x390
+               	sub	x16, x29, #0x350
                	str	d8, [x16, #0x8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	w20, w19
                	ucvtf	s8, x19
                	mov	w21, w19
                	mov	w22, w19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	sub	x0, x29, #0x10
+               	add	x1, x0, #0x0
                	mov	w17, #0xa               ; =10
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x14              ; =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x1e              ; =30
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x20
+               	add	x1, x0, #0x0
                	mov	w17, #0x14              ; =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x14              ; =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0xa               ; =10
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x1               ; =1
-               	str	w17, [x2]
-               	ldr	q1, [x1]
-               	mov.s	w1, v0[0]
-               	add	w2, w1, w20
+               	str	w17, [x1]
+               	ldr	q1, [x0]
+               	mov.s	w0, v0[0]
+               	add	w1, w0, w20
                	mov.16b	v30, v0
-               	mov.s	v30[0], w2
+               	mov.s	v30[0], w1
                	stur	q30, [x29, #-0xd0]
-               	mov.s	w1, v1[3]
-               	add	w2, w1, w20
+               	mov.s	w0, v1[3]
+               	add	w1, w0, w20
                	mov.16b	v30, v1
-               	mov.s	v30[3], w2
+               	mov.s	v30[3], w1
                	stur	q30, [x29, #-0xe0]
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhi.4s	v31, v31, v30
                	stur	q31, [x29, #-0xf0]
                	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
+               	mov.s	w0, v31[0]
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
                	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmhi.4s	v31, v31, v30
                	stur	q31, [x29, #-0x100]
                	ldur	q31, [x29, #-0x100]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0x100]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
                	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmeq.4s	v31, v31, v30
@@ -390,6 +601,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L9>:
                	bl	 <L9>
                	mov	x16, #0xfef0            ; =65264
@@ -397,7 +620,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L10>:
                	bl	 <L10>
                	mov	x16, #0xfef0            ; =65264
@@ -405,17 +630,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L11>:
                	bl	 <L11>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L12>:
-               	bl	 <L12>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmeq.4s	v31, v31, v30
@@ -431,6 +650,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L13>:
                	bl	 <L13>
                	mov	x16, #0xfee0            ; =65248
@@ -438,7 +669,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	mov	x16, #0xfee0            ; =65248
@@ -446,17 +679,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L15>:
                	bl	 <L15>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhs.4s	v31, v31, v30
@@ -471,6 +698,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
                	mov	x16, #0xfed0            ; =65232
@@ -478,7 +717,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L18>:
                	bl	 <L18>
                	mov	x16, #0xfed0            ; =65232
@@ -486,17 +727,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L19>:
                	bl	 <L19>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L20>:
-               	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmhs.4s	v31, v31, v30
@@ -511,6 +746,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L21>:
                	bl	 <L21>
                	mov	x16, #0xfec0            ; =65216
@@ -518,7 +765,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L22>:
                	bl	 <L22>
                	mov	x16, #0xfec0            ; =65216
@@ -526,17 +775,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L24>:
-               	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhi.4s	v31, v31, v30
@@ -572,6 +815,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L25>:
                	bl	 <L25>
                	mov	x16, #0xfea0            ; =65184
@@ -579,7 +834,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L26>:
                	bl	 <L26>
                	mov	x16, #0xfea0            ; =65184
@@ -587,17 +844,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L28>:
-               	bl	 <L28>
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -625,6 +876,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L29>:
                	bl	 <L29>
                	mov	x16, #0xfe90            ; =65168
@@ -632,7 +895,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
                	mov	x16, #0xfe90            ; =65168
@@ -640,17 +905,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L31>:
                	bl	 <L31>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L32>:
-               	bl	 <L32>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	add.4s	v0, v31, v30
@@ -671,6 +930,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L33>:
                	bl	 <L33>
                	mov	x16, #0xfe80            ; =65152
@@ -678,7 +949,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L34>:
                	bl	 <L34>
                	mov	x16, #0xfe80            ; =65152
@@ -686,17 +959,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L36>:
-               	bl	 <L36>
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -718,6 +985,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L37>:
                	bl	 <L37>
                	mov	x16, #0xfe70            ; =65136
@@ -725,7 +1004,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L38>:
                	bl	 <L38>
                	mov	x16, #0xfe70            ; =65136
@@ -733,17 +1014,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L39>:
                	bl	 <L39>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L40>:
-               	bl	 <L40>
                	sub	x1, x29, #0x30
                	add	x2, x1, #0x0
                	mov	w17, #0xffff            ; =65535
@@ -816,6 +1091,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L41>:
                	bl	 <L41>
                	mov	x16, #0xfe40            ; =65088
@@ -823,7 +1110,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L42>:
                	bl	 <L42>
                	mov	x16, #0xfe40            ; =65088
@@ -831,17 +1120,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L43>:
                	bl	 <L43>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L44>:
-               	bl	 <L44>
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -864,6 +1147,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L44>:
+               	bl	 <L44>
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
                	mov	x16, #0xfe30            ; =65072
@@ -871,7 +1166,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L46>:
                	bl	 <L46>
                	mov	x16, #0xfe30            ; =65072
@@ -879,17 +1176,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L47>:
                	bl	 <L47>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L48>:
-               	bl	 <L48>
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -912,6 +1203,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L48>:
+               	bl	 <L48>
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe20            ; =65056
@@ -919,7 +1222,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L50>:
                	bl	 <L50>
                	mov	x16, #0xfe20            ; =65056
@@ -927,17 +1232,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L51>:
                	bl	 <L51>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L52>:
-               	bl	 <L52>
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -961,6 +1260,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L52>:
+               	bl	 <L52>
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L53>:
                	bl	 <L53>
                	mov	x16, #0xfe10            ; =65040
@@ -968,7 +1279,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L54>:
                	bl	 <L54>
                	mov	x16, #0xfe10            ; =65040
@@ -976,17 +1289,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L56>:
-               	bl	 <L56>
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1009,6 +1316,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L57>:
                	bl	 <L57>
                	mov	x16, #0xfe00            ; =65024
@@ -1016,7 +1335,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L58>:
                	bl	 <L58>
                	mov	x16, #0xfe00            ; =65024
@@ -1024,17 +1345,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L60>:
-               	bl	 <L60>
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1057,6 +1372,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L60>:
+               	bl	 <L60>
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L61>:
                	bl	 <L61>
                	mov	x16, #0xfdf0            ; =65008
@@ -1064,7 +1391,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov.s	w1, v31[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L62>:
                	bl	 <L62>
                	mov	x16, #0xfdf0            ; =65008
@@ -1072,17 +1401,11 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov.s	w1, v31[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L64>:
-               	bl	 <L64>
                	sub	x1, x29, #0x50
                	add	x2, x1, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
@@ -1131,66 +1454,16 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	ldr	q0, [x29, x16]
+<L64>:
+               	bl	 <L64>
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L72>:
-               	bl	 <L72>
                	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1212,8 +1485,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L73>:
-               	bl	 <L73>
+<L66>:
+               	bl	 <L66>
                	mov	x16, #0xfdd0            ; =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1225,8 +1498,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt.4s	v0, v31, v30
-<L74>:
-               	bl	 <L74>
+<L67>:
+               	bl	 <L67>
                	mov	x16, #0xfdd0            ; =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1238,8 +1511,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq.4s	v0, v31, v30
-<L75>:
-               	bl	 <L75>
+<L68>:
+               	bl	 <L68>
                	mov	x16, #0xfdd0            ; =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1252,8 +1525,8 @@ Disassembly of section __TEXT,__text:
                	ldr	q30, [x29, x16]
                	fcmeq.4s	v0, v31, v30
                	mvn.16b	v0, v0
-<L76>:
-               	bl	 <L76>
+<L69>:
+               	bl	 <L69>
                	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1265,8 +1538,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge.4s	v0, v31, v30
-<L77>:
-               	bl	 <L77>
+<L70>:
+               	bl	 <L70>
                	mov	x16, #0xfdd0            ; =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1278,8 +1551,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge.4s	v0, v31, v30
-<L78>:
-               	bl	 <L78>
+<L71>:
+               	bl	 <L71>
                	mov	x16, #0xfdc0            ; =64960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1336,66 +1609,16 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L82>:
-               	bl	 <L82>
+               	ldr	q0, [x29, x16]
+<L72>:
+               	bl	 <L72>
                	mov	x16, #0xfda0            ; =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L86>:
-               	bl	 <L86>
+               	ldr	q0, [x29, x16]
+<L73>:
+               	bl	 <L73>
                	mov	x16, #0xfda0            ; =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1406,44 +1629,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L90>:
-               	bl	 <L90>
+               	fsub.4s	v0, v31, v30
+<L74>:
+               	bl	 <L74>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 ; =4609434218613702656
@@ -1459,7 +1647,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x8
                	str	xzr, [x2]
                	ldr	q31, [x1]
-               	mov	x16, #0xfd80            ; =64896
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1469,140 +1657,140 @@ Disassembly of section __TEXT,__text:
                	fadd	d3, d1, d2
                	mov.16b	v30, v0
                	mov.d	v30[0], v3[0]
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
                	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfd90            ; =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd70            ; =64880
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt.2d	v31, v31, v30
-               	mov	x16, #0xfd60            ; =64864
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L92>:
-               	bl	 <L92>
                	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfd70            ; =64880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L76>:
+               	bl	 <L76>
                	mov	x16, #0xfd80            ; =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq.2d	v31, v31, v30
-               	mov	x16, #0xfd50            ; =64848
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd50            ; =64848
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfd50            ; =64848
+<L77>:
+               	bl	 <L77>
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd70            ; =64880
+<L78>:
+               	bl	 <L78>
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd80            ; =64896
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq.2d	v31, v31, v30
                	mvn.16b	v31, v31
-               	mov	x16, #0xfd40            ; =64832
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd40            ; =64832
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd40            ; =64832
+<L79>:
+               	bl	 <L79>
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfd70            ; =64880
+<L80>:
+               	bl	 <L80>
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd80            ; =64896
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge.2d	v31, v31, v30
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfd30            ; =64816
+<L81>:
+               	bl	 <L81>
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L98>:
-               	bl	 <L98>
+<L82>:
+               	bl	 <L82>
                	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	w17, #0x1               ; =1
@@ -1658,7 +1846,7 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w21
                	mov.16b	v30, v0
                	mov.h	v30[0], w2
-               	mov	x16, #0xfd20            ; =64800
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1667,252 +1855,48 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w21
                	mov.16b	v30, v1
                	mov.h	v30[7], w2
-               	mov	x16, #0xfd10            ; =64784
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfd10            ; =64784
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            ; =64800
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.8h	v31, v31, v30
-               	mov	x16, #0xfd00            ; =64768
+               	mov	x16, #0xfd10            ; =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            ; =64768
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L83>:
+               	bl	 <L83>
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfd00            ; =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L106>:
-               	bl	 <L106>
                	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd10            ; =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmeq.8h	v31, v31, v30
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfcf0            ; =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfd20            ; =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd10            ; =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi.8h	v31, v31, v30
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfce0            ; =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfd10            ; =64784
+               	cmeq.8h	v0, v31, v30
+<L84>:
+               	bl	 <L84>
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1923,89 +1907,35 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.8h	v0, v31, v30
+<L85>:
+               	bl	 <L85>
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v31, v30
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn.16b	v1, v31
                	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mvn.16b	v2, v0
-               	mov	x16, #0xfd10            ; =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v0, v2, v30
-               	orr.16b	v31, v1, v0
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L130>:
-               	bl	 <L130>
+               	and.16b	v2, v1, v30
+               	orr.16b	v1, v0, v2
+               	mov.16b	v0, v1
+<L86>:
+               	bl	 <L86>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	w17, #0x1               ; =1
@@ -2109,7 +2039,7 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w22
                	mov.16b	v30, v0
                	mov.b	v30[0], w2
-               	mov	x16, #0xfcc0            ; =64704
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2118,78 +2048,78 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w22
                	mov.16b	v30, v1
                	mov.b	v30[15], w2
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.16b	v31, v31, v30
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfce0            ; =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfce0            ; =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfcc0            ; =64704
+<L87>:
+               	bl	 <L87>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmeq.16b	v0, v31, v30
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfcc0            ; =64704
+<L88>:
+               	bl	 <L88>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhs.16b	v0, v31, v30
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfca0            ; =64672
+<L89>:
+               	bl	 <L89>
+               	mov	x16, #0xfce0            ; =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	and.16b	v0, v31, v30
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfce0            ; =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mvn.16b	v1, v31
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfcf0            ; =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2197,11 +2127,11 @@ Disassembly of section __TEXT,__text:
                	and.16b	v2, v1, v30
                	orr.16b	v1, v0, v2
                	mov.16b	v0, v1
-<L134>:
-               	bl	 <L134>
-               	sub	x16, x29, #0x390
+<L90>:
+               	bl	 <L90>
+               	sub	x16, x29, #0x350
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x370
+               	sub	x16, x29, #0x330
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_f32x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x2.dis
@@ -3,65 +3,82 @@ vec/vec_f32x2.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_f32x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_f32x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0x8
-               	add	x2, x1, #0x0
+               	sub	sp, sp, #0x100
+               	stp	x19, x20, [x29, #-0xf0]
+               	stur	x21, [x29, #-0xf8]
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x48
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	ldr	d1, [x1]
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	ldr	d1, [x0]
+               	sub	x0, x29, #0x50
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x2]
-               	ldr	d2, [x1]
-               	sub	x1, x29, #0x18
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	d2, [x0]
+               	sub	x0, x29, #0x58
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x41d80000        ; =1104674816
-               	str	w17, [x2]
-               	ldr	d31, [x1]
+               	str	w17, [x1]
+               	ldr	d31, [x0]
                	stur	d31, [x29, #-0x70]
                	mov	s3, v1[0]
                	fadd	s4, s3, s0
@@ -73,154 +90,61 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v30, v2
                	mov.s	v30[1], v3[0]
                	stur	q30, [x29, #-0x90]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0x80]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0x90]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[1]
+               	ldur	q30, [x29, #-0x90]
+               	fadd.4s	v0, v31, v30
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0x90]
-               	mov	s0, v31[0]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	fsub.4s	v0, v31, v30
 <L3>:
                	bl	 <L3>
                	ldur	q31, [x29, #-0x90]
-               	mov	s0, v31[1]
+               	ldur	q30, [x29, #-0x80]
+               	fsub.4s	v0, v31, v30
 <L4>:
                	bl	 <L4>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0x90]
-               	fadd.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0xa0]
-               	mov	s0, v31[0]
+               	fmul.4s	v0, v31, v30
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xa0]
-               	mov	s0, v31[1]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	fdiv.4s	v0, v31, v30
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fsub.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xb0]
-               	ldur	q31, [x29, #-0xb0]
-               	mov	s0, v31[0]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0x80]
+               	fdiv.4s	v0, v31, v30
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0xb0]
-               	mov	s0, v31[1]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x80]
-               	fsub.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xc0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	s0, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xc0]
-               	mov	s0, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fmul.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xd0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[0]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fdiv.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[0]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x80]
-               	fdiv.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[0]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[1]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0x70]
-               	fmul.4s	v31, v31, v30
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[1]
-<L18>:
-               	bl	 <L18>
+               	fmul.4s	v0, v31, v30
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0x70]
                	ldur	q30, [x29, #-0x90]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L20>:
-               	bl	 <L20>
+               	fsub.4s	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0x70]
                	ldur	q30, [x29, #-0x80]
-               	fdiv.4s	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L22>:
-               	bl	 <L22>
+               	fdiv.4s	v0, v31, v30
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0x60
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -229,136 +153,45 @@ Disassembly of section __TEXT,__text:
                	ldr	d0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
+               	stur	q31, [x29, #-0xb0]
+               	stur	q0, [x29, #-0xc0]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-               	b	 <L30>
-<L23>:
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x70]
                	fmul.4s	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	stur	q31, [x29, #-0xa0]
                	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q0, [x29, #-0xa0]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xc0]
+               	ldur	q30, [x29, #-0xa0]
                	fadd.4s	v31, v31, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	stur	q31, [x29, #-0xd0]
+               	ldur	q0, [x29, #-0xd0]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x90]
                	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L29>:
-               	bl	 <L29>
+               	stur	q31, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xe0]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
+               	stur	q31, [x29, #-0xb0]
+               	ldur	q31, [x29, #-0xd0]
+               	stur	q31, [x29, #-0xc0]
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-<L30>:
-               	sub	x20, x29, #0x48
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -366,43 +199,23 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xb0]
                	str	d31, [x0]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x90]
                	fadd.4s	v0, v31, v30
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x70]
                	fmul.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xc0]
                	str	d31, [x0]
                	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xb0]
                	fsub.4s	v0, v31, v30
                	add	x0, x20, #0x20
                	str	d0, [x0]
@@ -411,39 +224,20 @@ Disassembly of section __TEXT,__text:
                	str	d31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x6
-               	b.lo	 <L31>
-               	b	 <L34>
-<L31>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	add	x0, x20, x21, lsl #3
-               	ldr	d31, [x0]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L33>:
-               	bl	 <L33>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L31>
-<L34>:
-               	sub	x21, x29, #0x58
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	add	x0, x21, #0x0
@@ -452,49 +246,60 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x10
                	ldr	d0, [x1]
-               	add	x20, x21, #0x4
-               	str	d0, [x20]
+               	add	x1, x21, #0x4
+               	str	d0, [x1]
                	add	x1, x21, #0xc
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x4
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L35>:
-               	bl	 <L35>
-               	ldr	d31, [x20]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L37>:
-               	bl	 <L37>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0xc
                	ldr	w2, [x1]
                	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            ; =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x21, [x29, x16]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldur	x21, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_f32x3.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x3.dis
@@ -3,82 +3,118 @@ vec/vec_f32x3.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_f32x3.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.vec.vec_f32x3.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            ; =65112
+               	sub	sp, sp, #0x160
+               	stp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0xc
-               	add	x2, x1, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x50
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x2]
-               	stur	xzr, [x29, #-0x1c]
-               	stur	xzr, [x29, #-0x14]
-               	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x1c]
-               	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x14]
-               	ldur	q1, [x29, #-0x1c]
-               	sub	x1, x29, #0x28
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	stur	xzr, [x29, #-0x60]
+               	stur	xzr, [x29, #-0x58]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0x60]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0x58]
+               	ldur	q1, [x29, #-0x60]
+               	sub	x0, x29, #0x6c
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x2, x1, #0x8
-               	str	s2, [x2]
-               	stur	xzr, [x29, #-0x38]
-               	stur	xzr, [x29, #-0x30]
-               	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x38]
-               	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x30]
-               	ldur	q2, [x29, #-0x38]
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	stur	xzr, [x29, #-0x7c]
+               	stur	xzr, [x29, #-0x74]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0x7c]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0x74]
+               	ldur	q2, [x29, #-0x7c]
                	mov	s3, v1[0]
                	fadd	s4, s3, s0
                	mov.16b	v30, v1
@@ -97,54 +133,24 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	ldr	q0, [x29, x16]
+<L0>:
+               	bl	 <L0>
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L1>:
                	bl	 <L1>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L3>:
-               	bl	 <L3>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L4>:
-               	bl	 <L4>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L5>:
-               	bl	 <L5>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L6>:
-               	bl	 <L6>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -165,26 +171,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L9>:
-               	bl	 <L9>
+               	ldr	q0, [x29, x16]
+<L2>:
+               	bl	 <L2>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -195,36 +184,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L12>:
-               	bl	 <L12>
+               	fsub.4s	v0, v31, v30
+<L3>:
+               	bl	 <L3>
                	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -235,36 +197,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L15>:
-               	bl	 <L15>
+               	fsub.4s	v0, v31, v30
+<L4>:
+               	bl	 <L4>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -276,35 +211,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fmul.4s	v31, v31, v30
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L18>:
-               	bl	 <L18>
+               	ldr	q0, [x29, x16]
+<L5>:
+               	bl	 <L5>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -315,37 +233,10 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fdiv.4s	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L21>:
-               	bl	 <L21>
-               	sub	x19, x29, #0xbc
+               	fdiv.4s	v0, v31, v30
+<L6>:
+               	bl	 <L6>
+               	sub	x19, x29, #0xac
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
                	str	xzr, [x19, #0x10]
@@ -358,44 +249,32 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
+               	stur	q31, [x29, #-0xbc]
+               	ldur	x2, [x29, #-0xbc]
+               	str	x2, [x1]
+               	ldur	w2, [x29, #-0xb4]
+               	str	w2, [x1, #0x8]
+               	add	x1, x19, #0xc
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	stur	q31, [x29, #-0xcc]
                	ldur	x2, [x29, #-0xcc]
                	str	x2, [x1]
                	ldur	w2, [x29, #-0xc4]
                	str	w2, [x1, #0x8]
-               	mov	x16, #0xfef0            ; =65264
+               	add	x1, x19, #0x18
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fadd.4s	v0, v31, v30
-               	add	x1, x19, #0xc
-               	stur	q0, [x29, #-0xdc]
+               	stur	q31, [x29, #-0xdc]
                	ldur	x2, [x29, #-0xdc]
                	str	x2, [x1]
                	ldur	w2, [x29, #-0xd4]
-               	str	w2, [x1, #0x8]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fmul.4s	v0, v31, v30
-               	add	x1, x19, #0x18
-               	stur	q0, [x29, #-0xec]
-               	ldur	x2, [x29, #-0xec]
-               	str	x2, [x1]
-               	ldur	w2, [x29, #-0xe4]
                	str	w2, [x1, #0x8]
                	add	x1, x19, #0x24
                	mov	x16, #0xfee0            ; =65248
@@ -403,63 +282,36 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	stur	q31, [x29, #-0xfc]
-               	ldur	x2, [x29, #-0xfc]
+               	stur	q31, [x29, #-0xec]
+               	ldur	x2, [x29, #-0xec]
                	str	x2, [x1]
-               	ldur	w2, [x29, #-0xf4]
+               	ldur	w2, [x29, #-0xe4]
                	str	w2, [x1, #0x8]
                	mov	x20, x0
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L22>
-               	b	 <L26>
-<L22>:
+               	b.lo	 <L7>
+               	b	 <L9>
+<L7>:
                	mov	x16, #0xc               ; =12
                	mul	x0, x21, x16
                	add	x1, x19, x0
-               	stur	xzr, [x29, #-0x48]
-               	stur	xzr, [x29, #-0x40]
+               	stur	xzr, [x29, #-0x10]
+               	stur	xzr, [x29, #-0x8]
                	ldr	x0, [x1]
-               	stur	x0, [x29, #-0x48]
+               	stur	x0, [x29, #-0x10]
                	ldr	w0, [x1, #0x8]
-               	stur	w0, [x29, #-0x40]
-               	ldur	q31, [x29, #-0x48]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	stur	w0, [x29, #-0x8]
+               	ldur	q0, [x29, #-0x10]
                	mov	x0, x20
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L25>:
-               	bl	 <L25>
+<L8>:
+               	bl	 <L8>
                	add	x21, x21, #0x1
                	mov	x20, x0
                	cmp	x21, #0x4
-               	b.lo	 <L22>
-<L26>:
-               	sub	x21, x29, #0x5c
+               	b.lo	 <L7>
+<L9>:
+               	sub	x21, x29, #0x24
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	wzr, [x21, #0x10]
@@ -468,70 +320,77 @@ Disassembly of section __TEXT,__text:
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
                	add	x1, x19, #0x18
-               	stur	xzr, [x29, #-0x6c]
-               	stur	xzr, [x29, #-0x64]
+               	stur	xzr, [x29, #-0x34]
+               	stur	xzr, [x29, #-0x2c]
                	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x6c]
+               	stur	x2, [x29, #-0x34]
                	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x64]
-               	ldur	q0, [x29, #-0x6c]
-               	add	x19, x21, #0x4
-               	stur	q0, [x29, #-0x7c]
-               	ldur	x1, [x29, #-0x7c]
-               	str	x1, [x19]
-               	ldur	w1, [x29, #-0x74]
-               	str	w1, [x19, #0x8]
+               	stur	w2, [x29, #-0x2c]
+               	ldur	q0, [x29, #-0x34]
+               	add	x1, x21, #0x4
+               	stur	q0, [x29, #-0x44]
+               	ldur	x2, [x29, #-0x44]
+               	str	x2, [x1]
+               	ldur	w2, [x29, #-0x3c]
+               	str	w2, [x1, #0x8]
                	add	x1, x21, #0x10
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x0, x21, #0x4
+               	stur	xzr, [x29, #-0xfc]
+               	stur	xzr, [x29, #-0xf4]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0xfc]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0xf4]
+               	ldur	q0, [x29, #-0xfc]
                	mov	x0, x20
-<L27>:
-               	bl	 <L27>
-               	stur	xzr, [x29, #-0x8c]
-               	stur	xzr, [x29, #-0x84]
-               	ldr	x1, [x19]
-               	stur	x1, [x29, #-0x8c]
-               	ldr	w1, [x19, #0x8]
-               	stur	w1, [x29, #-0x84]
-               	ldur	q31, [x29, #-0x8c]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L30>:
-               	bl	 <L30>
+<L12>:
+               	bl	 <L12>
                	add	x1, x21, #0x10
                	ldr	w2, [x1]
                	mov	w1, w2
-<L31>:
-               	bl	 <L31>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            ; =65112
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	ldp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_f32x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x4.dis
@@ -3,97 +3,148 @@ vec/vec_f32x4.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_f32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_f32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            ; =65032
+               	sub	sp, sp, #0x150
+               	stp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x80
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x2, x1, #0xc
-               	str	s1, [x2]
-               	ldr	q1, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0xc
+               	str	s1, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x90
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x2, x1, #0x8
-               	str	s2, [x2]
-               	add	x2, x1, #0xc
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41000000        ; =1090519040
-               	str	w17, [x2]
-               	ldr	q2, [x1]
-               	sub	x1, x29, #0x30
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q2, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40400000        ; =1077936128
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x41100000        ; =1091567616
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41d80000        ; =1104674816
-               	str	w17, [x2]
-               	ldr	q31, [x1]
+               	str	w17, [x1]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
                	mov	s3, v1[0]
                	fadd	s4, s3, s0
@@ -113,358 +164,61 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v30, v1
                	mov.s	v30[2], v3[0]
                	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xd0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xe0]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[1]
+               	ldur	q30, [x29, #-0xe0]
+               	fadd.4s	v0, v31, v30
 <L2>:
                	bl	 <L2>
                	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[2]
+               	ldur	q30, [x29, #-0xe0]
+               	fsub.4s	v0, v31, v30
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xd0]
+               	fsub.4s	v0, v31, v30
 <L4>:
                	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[0]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fmul.4s	v0, v31, v30
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[1]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fdiv.4s	v0, v31, v30
 <L6>:
                	bl	 <L6>
                	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[2]
+               	ldur	q30, [x29, #-0xd0]
+               	fdiv.4s	v0, v31, v30
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[3]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fadd.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fsub.4s	v31, v31, v30
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[0]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[2]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fmul.4s	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fdiv.4s	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fdiv.4s	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L32>:
-               	bl	 <L32>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xc0]
-               	fmul.4s	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L36>:
-               	bl	 <L36>
+               	fmul.4s	v0, v31, v30
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xe0]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L40>:
-               	bl	 <L40>
+               	fsub.4s	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xd0]
-               	fdiv.4s	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L44>:
-               	bl	 <L44>
+               	fdiv.4s	v0, v31, v30
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -477,184 +231,81 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L45>
-               	b	 <L58>
-<L45>:
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul.4s	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	stur	q31, [x29, #-0xf0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            ; =65152
+               	ldur	q0, [x29, #-0xf0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	fadd.4s	v31, v31, v30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L57>:
-               	bl	 <L57>
+               	ldr	q0, [x29, x16]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L45>
-<L58>:
-               	sub	x20, x29, #0x70
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -664,32 +315,20 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	str	q31, [x0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fadd.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul.4s	v0, v31, v30
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -697,57 +336,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L59>
-               	b	 <L64>
-<L59>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L63>:
-               	bl	 <L63>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L59>
-<L64>:
-               	sub	x21, x29, #0xa0
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -760,61 +364,60 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L65>:
-               	bl	 <L65>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L69>:
-               	bl	 <L69>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L70>:
-               	bl	 <L70>
-               	ldp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            ; =65032
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_f32x5.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x5.dis
@@ -5,45 +5,122 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x5.fold_vec>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stur	x19, [x29, #-0x78]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x14
-               	sub	x1, x29, #0x28
-               	sub	x1, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x70
+               	sub	x2, x29, #0x14
+               	sub	x2, x29, #0x28
+               	sub	x2, x29, #0x3c
+               	sub	x2, x29, #0x50
+               	sub	x2, x29, #0x64
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldur	x19, [x29, #-0x78]
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	x2, x1, #0xc
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -51,1269 +128,814 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x5.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xd80
-               	sub	x16, x29, #0xd40
+               	sub	sp, sp, #0x720
+               	sub	x16, x29, #0x6e0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-               	sub	x20, x29, #0x14
-               	sub	x21, x29, #0x28
-               	sub	x22, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	sub	x23, x29, #0x78
-               	sub	x1, x29, #0x8c
-               	sub	x1, x29, #0xa0
-               	sub	x24, x29, #0xb4
-               	sub	x1, x29, #0xc8
-               	sub	x1, x29, #0xdc
-               	sub	x25, x29, #0xf0
-               	sub	x1, x29, #0x104
-               	sub	x1, x29, #0x118
-               	sub	x1, x29, #0x12c
-               	sub	x1, x29, #0x140
-               	sub	x26, x29, #0x154
-               	sub	x1, x29, #0x168
-               	sub	x1, x29, #0x17c
-               	sub	x27, x29, #0x190
-               	sub	x1, x29, #0x1a4
-               	sub	x1, x29, #0x1b8
-               	sub	x28, x29, #0x1cc
-               	sub	x1, x29, #0x1e0
-               	sub	x1, x29, #0x1f4
-               	sub	x9, x29, #0x208
-               	mov	x16, #0xf328            ; =62248
+               	mov	x9, x0
+               	mov	x16, #0xf998            ; =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x2, x29, #0x21c
-               	sub	x2, x29, #0x230
-               	sub	x9, x29, #0x244
-               	mov	x16, #0xf320            ; =62240
+               	sub	x1, x29, #0x14
+               	sub	x9, x29, #0x28
+               	mov	x16, #0xf978            ; =63864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x3, x29, #0x258
-               	sub	x3, x29, #0x26c
-               	sub	x9, x29, #0x280
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x19, x29, #0x3c
+               	sub	x3, x29, #0x50
+               	sub	x3, x29, #0x64
+               	sub	x3, x29, #0x78
+               	sub	x4, x29, #0x8c
+               	sub	x4, x29, #0xa0
+               	sub	x20, x29, #0xb4
+               	sub	x4, x29, #0xc8
+               	sub	x4, x29, #0xdc
+               	sub	x21, x29, #0xf0
+               	sub	x4, x29, #0x104
+               	sub	x4, x29, #0x118
+               	sub	x4, x29, #0x12c
+               	sub	x4, x29, #0x140
+               	sub	x22, x29, #0x154
+               	sub	x4, x29, #0x168
+               	sub	x4, x29, #0x17c
+               	sub	x23, x29, #0x190
+               	sub	x4, x29, #0x1a4
+               	sub	x4, x29, #0x1b8
+               	sub	x24, x29, #0x1cc
+               	sub	x4, x29, #0x1e0
+               	sub	x4, x29, #0x1f4
+               	sub	x25, x29, #0x208
+               	sub	x4, x29, #0x21c
+               	sub	x4, x29, #0x230
+               	sub	x26, x29, #0x244
+               	sub	x4, x29, #0x258
+               	sub	x4, x29, #0x26c
+               	sub	x27, x29, #0x280
                	sub	x4, x29, #0x294
                	sub	x4, x29, #0x2a8
-               	sub	x9, x29, #0x2bc
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x5, x29, #0x2d0
-               	sub	x5, x29, #0x2e4
+               	sub	x28, x29, #0x2bc
+               	sub	x4, x29, #0x2d0
+               	sub	x4, x29, #0x2e4
                	sub	x9, x29, #0x2f8
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf970            ; =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x6, x29, #0x30c
-               	sub	x6, x29, #0x320
+               	sub	x5, x29, #0x30c
+               	sub	x5, x29, #0x320
                	sub	x9, x29, #0x334
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf968            ; =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x348
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x35c
-               	sub	x8, x29, #0x370
+               	sub	x7, x29, #0x35c
+               	sub	x7, x29, #0x370
                	sub	x9, x29, #0x384
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x12, x29, #0x398
-               	sub	x12, x29, #0x3ac
-               	sub	x12, x29, #0x3c0
+               	sub	x8, x29, #0x398
+               	sub	x8, x29, #0x3ac
+               	sub	x8, x29, #0x3c0
                	sub	x9, x29, #0x3d4
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf950            ; =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x13, x29, #0x3e8
-               	sub	x13, x29, #0x3fc
-               	sub	x13, x29, #0x410
+               	sub	x12, x29, #0x3e8
+               	sub	x12, x29, #0x3fc
+               	sub	x12, x29, #0x410
                	sub	x9, x29, #0x424
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x14, x29, #0x438
-               	sub	x14, x29, #0x44c
-               	sub	x14, x29, #0x460
-               	sub	x14, x29, #0x474
+               	sub	x13, x29, #0x438
+               	sub	x13, x29, #0x44c
+               	sub	x13, x29, #0x460
+               	sub	x13, x29, #0x474
                	sub	x9, x29, #0x488
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x49c
-               	sub	x15, x29, #0x4b0
+               	sub	x14, x29, #0x49c
+               	sub	x14, x29, #0x4b0
                	sub	x9, x29, #0x4c4
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf938            ; =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x4d8
-               	sub	x7, x29, #0x4ec
-               	sub	x7, x29, #0x500
+               	sub	x15, x29, #0x4d8
+               	sub	x15, x29, #0x4ec
+               	sub	x15, x29, #0x500
                	sub	x9, x29, #0x514
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf930            ; =63792
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x528
+               	sub	x0, x29, #0x528
                	sub	x9, x29, #0x53c
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x550
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x564
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x578
-               	sub	x7, x29, #0x58c
-               	sub	x7, x29, #0x5a0
-               	sub	x7, x29, #0x5b4
-               	sub	x7, x29, #0x5c8
-               	sub	x7, x29, #0x5dc
-               	sub	x7, x29, #0x5f0
-               	sub	x7, x29, #0x604
-               	sub	x7, x29, #0x618
-               	sub	x7, x29, #0x62c
-               	sub	x7, x29, #0x640
-               	sub	x7, x29, #0x654
-               	sub	x7, x29, #0x668
-               	sub	x7, x29, #0x67c
-               	sub	x7, x29, #0x690
-               	sub	x7, x29, #0x6a4
-               	sub	x7, x29, #0x6b8
-               	sub	x7, x29, #0x6cc
-               	sub	x7, x29, #0x6e0
-               	sub	x7, x29, #0x6f4
-               	sub	x7, x29, #0x708
-               	sub	x7, x29, #0x71c
-               	sub	x7, x29, #0x730
-               	sub	x7, x29, #0x744
-               	sub	x7, x29, #0x758
-               	sub	x7, x29, #0x76c
-               	sub	x7, x29, #0x780
-               	sub	x7, x29, #0x794
-               	sub	x7, x29, #0x7a8
-               	sub	x7, x29, #0x7bc
-               	sub	x7, x29, #0x7d0
-               	sub	x7, x29, #0x7e4
-               	sub	x7, x29, #0x7f8
-               	sub	x7, x29, #0x80c
-               	sub	x7, x29, #0x820
-               	sub	x7, x29, #0x834
-               	sub	x7, x29, #0x848
-               	sub	x7, x29, #0x85c
-               	sub	x7, x29, #0x870
-               	sub	x7, x29, #0x884
-               	sub	x7, x29, #0x898
-               	sub	x7, x29, #0x8ac
-               	sub	x7, x29, #0x8c0
-               	sub	x7, x29, #0x8d4
-               	sub	x7, x29, #0x8e8
-               	sub	x7, x29, #0x8fc
-               	sub	x7, x29, #0x910
-               	sub	x7, x29, #0x924
-               	sub	x7, x29, #0x938
-               	sub	x7, x29, #0x94c
-               	sub	x7, x29, #0x960
-               	sub	x7, x29, #0x974
-               	sub	x7, x29, #0x988
-               	sub	x7, x29, #0x99c
-               	sub	x7, x29, #0x9b0
-               	sub	x7, x29, #0x9c4
-               	sub	x7, x29, #0x9d8
-               	sub	x7, x29, #0x9ec
-               	sub	x7, x29, #0xa00
-               	sub	x7, x29, #0xa14
-               	sub	x7, x29, #0xa28
-               	sub	x7, x29, #0xa3c
-               	sub	x7, x29, #0xa50
-               	sub	x7, x29, #0xa64
-               	sub	x7, x29, #0xa78
-               	sub	x7, x29, #0xa8c
-               	sub	x7, x29, #0xaa0
-               	sub	x7, x29, #0xab4
-               	sub	x7, x29, #0xac8
-               	sub	x7, x29, #0xadc
-               	sub	x7, x29, #0xaf0
-               	sub	x7, x29, #0xb04
-               	sub	x7, x29, #0xb18
-               	sub	x7, x29, #0xb2c
-               	sub	x7, x29, #0xb40
-               	sub	x7, x29, #0xb54
-               	sub	x7, x29, #0xb68
-               	sub	x7, x29, #0xb7c
-               	sub	x7, x29, #0xb90
-               	sub	x7, x29, #0xba4
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x7, x29, #0xbb8
-               	add	x19, x7, #0x0
+               	mov	x16, #0xf998            ; =63896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ucvtf	s0, x9
+               	sub	x0, x29, #0x624
+               	add	x2, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x7, #0x4
-               	str	s1, [x19]
-               	add	x19, x7, #0x8
+               	add	x2, x0, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x7, #0xc
-               	str	s1, [x19]
-               	add	x19, x7, #0x10
+               	add	x2, x0, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
                	mov	w17, #0x40c80000        ; =1086849024
-               	str	w17, [x19]
-               	add	x19, x7, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x0
-               	str	s1, [x19]
-               	add	x19, x7, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x4
-               	str	s1, [x19]
-               	add	x19, x7, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x8
-               	str	s1, [x19]
-               	add	x19, x7, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x20, #0xc
-               	str	s1, [x19]
-               	add	x19, x7, #0x10
-               	ldr	s1, [x19]
-               	add	x7, x20, #0x10
-               	str	s1, [x7]
-               	sub	x7, x29, #0xbcc
-               	add	x19, x7, #0x0
+               	str	w17, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	add	x2, x1, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	add	x0, x1, #0x10
+               	str	s1, [x0]
+               	sub	x0, x29, #0x638
+               	add	x2, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x19]
-               	add	x19, x7, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x7, #0x8
-               	str	s1, [x19]
-               	add	x19, x7, #0xc
+               	add	x2, x0, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x41000000        ; =1090519040
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x7, #0x10
-               	str	s1, [x19]
-               	add	x19, x7, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x0
-               	str	s1, [x19]
-               	add	x19, x7, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x4
-               	str	s1, [x19]
-               	add	x19, x7, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x8
-               	str	s1, [x19]
-               	add	x19, x7, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x21, #0xc
-               	str	s1, [x19]
-               	add	x19, x7, #0x10
-               	ldr	s1, [x19]
-               	add	x7, x21, #0x10
-               	str	s1, [x7]
-               	sub	x7, x29, #0xbe0
-               	add	x19, x7, #0x0
+               	add	x2, x0, #0x10
+               	str	s1, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s1, [x0]
+               	sub	x0, x29, #0x64c
+               	add	x2, x0, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
-               	str	w17, [x19]
-               	add	x19, x7, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x40400000        ; =1077936128
-               	str	w17, [x19]
-               	add	x19, x7, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x41100000        ; =1091567616
-               	str	w17, [x19]
-               	add	x19, x7, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x41d80000        ; =1104674816
-               	str	w17, [x19]
-               	add	x19, x7, #0x10
+               	str	w17, [x2]
+               	add	x2, x0, #0x10
                	mov	w17, #0x42a20000        ; =1117913088
-               	str	w17, [x19]
-               	add	x19, x7, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x0
-               	str	s1, [x19]
-               	add	x19, x7, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x4
-               	str	s1, [x19]
-               	add	x19, x7, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x8
-               	str	s1, [x19]
-               	add	x19, x7, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x22, #0xc
-               	str	s1, [x19]
-               	add	x19, x7, #0x10
-               	ldr	s1, [x19]
-               	add	x7, x22, #0x10
-               	str	s1, [x7]
-               	add	x7, x20, #0x0
-               	ldr	s1, [x7]
+               	str	w17, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	add	x2, x19, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	add	x0, x19, #0x10
+               	str	s1, [x0]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x7, x20, #0x0
-               	ldr	s1, [x7]
-               	add	x7, x23, #0x0
-               	str	s1, [x7]
-               	add	x7, x20, #0x4
-               	ldr	s1, [x7]
-               	add	x7, x23, #0x4
-               	str	s1, [x7]
-               	add	x7, x20, #0x8
-               	ldr	s1, [x7]
-               	add	x7, x23, #0x8
-               	str	s1, [x7]
-               	add	x7, x20, #0xc
-               	ldr	s1, [x7]
-               	add	x7, x23, #0xc
-               	str	s1, [x7]
-               	add	x7, x20, #0x10
-               	ldr	s1, [x7]
-               	add	x7, x23, #0x10
-               	str	s1, [x7]
-               	add	x7, x23, #0x0
-               	str	s2, [x7]
-               	add	x7, x23, #0x10
-               	ldr	s1, [x7]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s1, [x0]
+               	add	x0, x1, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x4
+               	str	s1, [x0]
+               	add	x0, x1, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x8
+               	str	s1, [x0]
+               	add	x0, x1, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x3, #0xc
+               	str	s1, [x0]
+               	add	x0, x1, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x10
+               	str	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s2, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x7, x23, #0x0
-               	ldr	s1, [x7]
-               	add	x7, x24, #0x0
-               	str	s1, [x7]
-               	add	x7, x23, #0x4
-               	ldr	s1, [x7]
-               	add	x7, x24, #0x4
-               	str	s1, [x7]
-               	add	x7, x23, #0x8
-               	ldr	s1, [x7]
-               	add	x7, x24, #0x8
-               	str	s1, [x7]
-               	add	x7, x23, #0xc
-               	ldr	s1, [x7]
-               	add	x7, x24, #0xc
-               	str	s1, [x7]
-               	add	x7, x23, #0x10
-               	ldr	s1, [x7]
-               	add	x7, x24, #0x10
-               	str	s1, [x7]
-               	add	x7, x24, #0x10
-               	str	s2, [x7]
-               	add	x7, x21, #0x8
-               	ldr	s1, [x7]
+               	add	x0, x3, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x0
+               	str	s1, [x0]
+               	add	x0, x3, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x4
+               	str	s1, [x0]
+               	add	x0, x3, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x8
+               	str	s1, [x0]
+               	add	x0, x3, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x20, #0xc
+               	str	s1, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s2, [x0]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x7, x21, #0x0
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x0
-               	str	s0, [x7]
-               	add	x7, x21, #0x4
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x4
-               	str	s0, [x7]
-               	add	x7, x21, #0x8
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x8
-               	str	s0, [x7]
-               	add	x7, x21, #0xc
-               	ldr	s0, [x7]
-               	add	x7, x25, #0xc
-               	str	s0, [x7]
-               	add	x7, x21, #0x10
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x10
-               	str	s0, [x7]
-               	add	x7, x25, #0x8
-               	str	s2, [x7]
-               	add	x7, x24, #0x0
-               	ldr	s0, [x7]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	str	s0, [x0]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	str	s0, [x0]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s0, [x0]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	str	s0, [x0]
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s2, [x0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x20
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x21
 <L1>:
                	bl	 <L1>
-               	add	x7, x24, #0x4
-               	ldr	s0, [x7]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x10
+               	str	s2, [x1]
+               	mov	x1, x22
 <L2>:
                	bl	 <L2>
-               	add	x7, x24, #0x8
-               	ldr	s0, [x7]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x10
+               	str	s2, [x1]
+               	mov	x1, x23
 <L3>:
                	bl	 <L3>
-               	add	x7, x24, #0xc
-               	ldr	s0, [x7]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x10
+               	str	s2, [x1]
+               	mov	x1, x24
 <L4>:
                	bl	 <L4>
-               	add	x7, x24, #0x10
-               	ldr	s0, [x7]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x10
+               	str	s2, [x1]
+               	mov	x1, x25
 <L5>:
                	bl	 <L5>
-               	add	x7, x25, #0x0
-               	ldr	s0, [x7]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x10
+               	str	s2, [x1]
+               	mov	x1, x26
 <L6>:
                	bl	 <L6>
-               	add	x7, x25, #0x4
-               	ldr	s0, [x7]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x10
+               	str	s2, [x1]
+               	mov	x1, x27
 <L7>:
                	bl	 <L7>
-               	add	x7, x25, #0x8
-               	ldr	s0, [x7]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x10
+               	str	s2, [x1]
+               	mov	x1, x28
 <L8>:
                	bl	 <L8>
-               	add	x7, x25, #0xc
-               	ldr	s0, [x7]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	add	x7, x25, #0x10
-               	ldr	s0, [x7]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	add	x7, x24, #0x0
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x0
-               	ldr	s1, [x7]
-               	fadd	s2, s0, s1
-               	add	x7, x26, #0x0
-               	str	s2, [x7]
-               	add	x7, x24, #0x4
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x4
-               	ldr	s1, [x7]
-               	fadd	s2, s0, s1
-               	add	x7, x26, #0x4
-               	str	s2, [x7]
-               	add	x7, x24, #0x8
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x8
-               	ldr	s1, [x7]
-               	fadd	s2, s0, s1
-               	add	x7, x26, #0x8
-               	str	s2, [x7]
-               	add	x7, x24, #0xc
-               	ldr	s0, [x7]
-               	add	x7, x25, #0xc
-               	ldr	s1, [x7]
-               	fadd	s2, s0, s1
-               	add	x7, x26, #0xc
-               	str	s2, [x7]
-               	add	x7, x24, #0x10
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x10
-               	ldr	s1, [x7]
-               	fadd	s2, s0, s1
-               	add	x7, x26, #0x10
-               	str	s2, [x7]
-               	add	x7, x26, #0x0
-               	ldr	s0, [x7]
-<L11>:
-               	bl	 <L11>
-               	add	x7, x26, #0x4
-               	ldr	s0, [x7]
-<L12>:
-               	bl	 <L12>
-               	add	x7, x26, #0x8
-               	ldr	s0, [x7]
-<L13>:
-               	bl	 <L13>
-               	add	x7, x26, #0xc
-               	ldr	s0, [x7]
-<L14>:
-               	bl	 <L14>
-               	add	x7, x26, #0x10
-               	ldr	s0, [x7]
-<L15>:
-               	bl	 <L15>
-               	add	x7, x24, #0x0
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x0
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x27, #0x0
-               	str	s2, [x7]
-               	add	x7, x24, #0x4
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x4
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x27, #0x4
-               	str	s2, [x7]
-               	add	x7, x24, #0x8
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x8
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x27, #0x8
-               	str	s2, [x7]
-               	add	x7, x24, #0xc
-               	ldr	s0, [x7]
-               	add	x7, x25, #0xc
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x27, #0xc
-               	str	s2, [x7]
-               	add	x7, x24, #0x10
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x10
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x27, #0x10
-               	str	s2, [x7]
-               	add	x7, x27, #0x0
-               	ldr	s0, [x7]
-<L16>:
-               	bl	 <L16>
-               	add	x7, x27, #0x4
-               	ldr	s0, [x7]
-<L17>:
-               	bl	 <L17>
-               	add	x7, x27, #0x8
-               	ldr	s0, [x7]
-<L18>:
-               	bl	 <L18>
-               	add	x7, x27, #0xc
-               	ldr	s0, [x7]
-<L19>:
-               	bl	 <L19>
-               	add	x7, x27, #0x10
-               	ldr	s0, [x7]
-<L20>:
-               	bl	 <L20>
-               	add	x7, x25, #0x0
-               	ldr	s0, [x7]
-               	add	x7, x24, #0x0
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x28, #0x0
-               	str	s2, [x7]
-               	add	x7, x25, #0x4
-               	ldr	s0, [x7]
-               	add	x7, x24, #0x4
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x28, #0x4
-               	str	s2, [x7]
-               	add	x7, x25, #0x8
-               	ldr	s0, [x7]
-               	add	x7, x24, #0x8
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x28, #0x8
-               	str	s2, [x7]
-               	add	x7, x25, #0xc
-               	ldr	s0, [x7]
-               	add	x7, x24, #0xc
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x28, #0xc
-               	str	s2, [x7]
-               	add	x7, x25, #0x10
-               	ldr	s0, [x7]
-               	add	x7, x24, #0x10
-               	ldr	s1, [x7]
-               	fsub	s2, s0, s1
-               	add	x7, x28, #0x10
-               	str	s2, [x7]
-               	add	x7, x28, #0x0
-               	ldr	s0, [x7]
-<L21>:
-               	bl	 <L21>
-               	add	x7, x28, #0x4
-               	ldr	s0, [x7]
-<L22>:
-               	bl	 <L22>
-               	add	x7, x28, #0x8
-               	ldr	s0, [x7]
-<L23>:
-               	bl	 <L23>
-               	add	x7, x28, #0xc
-               	ldr	s0, [x7]
-<L24>:
-               	bl	 <L24>
-               	add	x7, x28, #0x10
-               	ldr	s0, [x7]
-<L25>:
-               	bl	 <L25>
-               	add	x7, x24, #0x0
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x0
-               	ldr	s1, [x7]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x0
-               	str	s2, [x7]
-               	add	x7, x24, #0x4
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x4
-               	ldr	s1, [x7]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x4
-               	str	s2, [x7]
-               	add	x7, x24, #0x8
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x8
-               	ldr	s1, [x7]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x8
-               	str	s2, [x7]
-               	add	x7, x24, #0xc
-               	ldr	s0, [x7]
-               	add	x7, x25, #0xc
-               	ldr	s1, [x7]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0xc
-               	str	s2, [x7]
-               	add	x7, x24, #0x10
-               	ldr	s0, [x7]
-               	add	x7, x25, #0x10
-               	ldr	s1, [x7]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x10
-               	str	s2, [x7]
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x0
-               	ldr	s0, [x7]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x4
-               	ldr	s0, [x7]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x8
-               	ldr	s0, [x7]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0xc
-               	ldr	s0, [x7]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xf328            ; =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x7, x9, #0x10
-               	ldr	s0, [x7]
-<L30>:
-               	bl	 <L30>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xf320            ; =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L35>:
-               	bl	 <L35>
-               	add	x1, x25, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xf318            ; =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L40>:
-               	bl	 <L40>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xf310            ; =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L45>:
-               	bl	 <L45>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xf308            ; =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L50>:
-               	bl	 <L50>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xf300            ; =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L55>:
-               	bl	 <L55>
-               	sub	x1, x29, #0xca4
+               	sub	x1, x29, #0x660
                	add	x2, x1, #0x0
                	str	wzr, [x2]
                	add	x2, x1, #0x4
@@ -1326,7 +948,7 @@ Disassembly of section __TEXT,__text:
                	str	wzr, [x2]
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1335,7 +957,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1344,7 +966,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1353,7 +975,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1362,134 +984,97 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            ; =62288
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x19, x0
-               	mov	x16, #0xf350            ; =62288
+               	mov	x22, x0
+               	mov	x16, #0xf960            ; =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x20, x9
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x6
-               	b.lo	 <L56>
-               	b	 <L72>
-<L56>:
-               	add	x0, x24, #0x0
+               	mov	x23, x9
+               	mov	x24, #0x0               ; =0
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x22, #0x0
+               	add	x0, x19, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x22, #0x4
+               	add	x0, x19, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x22, #0x8
+               	add	x0, x19, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x22, #0xc
+               	add	x0, x19, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x22, #0x10
+               	add	x0, x19, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x0, x22
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	mov	x1, x9
+<L12>:
+               	bl	 <L12>
+               	add	x1, x23, #0x0
                	ldr	s0, [x1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	add	x1, x20, #0x0
-               	ldr	s0, [x1]
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf958            ; =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1497,7 +1082,95 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L13>:
+               	bl	 <L13>
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1506,15 +1179,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	add	x1, x21, #0x4
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1523,15 +1191,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
+               	add	x1, x21, #0x8
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1540,15 +1203,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
+               	add	x1, x21, #0xc
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1557,432 +1215,52 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf2f8            ; =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
+               	add	x1, x21, #0x10
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xf2f0            ; =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xf2f0            ; =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xf2f0            ; =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xf2f0            ; =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xf2e8            ; =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x24, x9
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x1, x9
+<L14>:
+               	bl	 <L14>
+               	add	x24, x24, #0x1
+               	mov	x22, x0
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x20, x9
-               	cmp	x21, #0x6
-               	b.lo	 <L56>
-<L72>:
-               	sub	x21, x29, #0xc60
-               	add	x0, x21, #0x0
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x23, x9
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+<L15>:
+               	sub	x24, x29, #0x5e0
+               	add	x0, x24, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x78               ; =120
-<L73>:
+<L16>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L73>
-               	add	x0, x21, #0x0
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
+               	b.ne	 <L16>
                	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x0
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x4
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x8
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x25, #0xc
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x10
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x21, #0x14
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x0
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x4
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x8
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x22, #0xc
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x10
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x21, #0x28
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x0, x21, #0x3c
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
@@ -2003,68 +1281,68 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	add	x0, x25, #0x0
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x24, #0x0
+               	add	x0, x21, #0x0
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x25, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x21, #0x4
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x25, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x21, #0x8
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x25, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x21, #0xc
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x25, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x21, #0x10
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	add	x0, x21, #0x50
-               	mov	x16, #0xf330            ; =62256
+               	add	x0, x24, #0x14
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2073,7 +1351,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2082,7 +1360,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2091,7 +1369,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2100,7 +1378,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf940            ; =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2109,38 +1387,271 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	add	x0, x21, #0x64
-               	add	x1, x25, #0x0
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x0
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x4
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x8
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x19, #0xc
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x10
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x24, #0x28
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	add	x1, x25, #0x4
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	add	x1, x25, #0x8
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	add	x1, x25, #0xc
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	add	x1, x25, #0x10
+               	mov	x16, #0xf938            ; =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L74>
-               	b	 <L80>
-<L74>:
+               	add	x0, x24, #0x3c
+               	add	x1, x23, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x0, x21, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x0
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x21, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x21, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x21, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x21, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x24, #0x50
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x0, x24, #0x64
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x19, #0x0               ; =0
+               	cmp	x19, #0x6
+               	b.lo	 <L17>
+               	b	 <L19>
+<L17>:
                	mov	x16, #0x14              ; =20
-               	mul	x0, x20, x16
-               	add	x1, x21, x0
+               	mul	x0, x19, x16
+               	add	x1, x24, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2149,7 +1660,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2158,7 +1669,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2167,7 +1678,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2176,79 +1687,42 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s0, [x0]
-               	mov	x16, #0xf2d8            ; =62168
+               	mov	x0, x22
+               	mov	x16, #0xf990            ; =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xf2d8            ; =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xf2d8            ; =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xf2d8            ; =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xf2d8            ; =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x6
-               	b.lo	 <L74>
-<L80>:
-               	sub	x20, x29, #0xc90
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	add	x0, x20, #0x0
+               	mov	x1, x9
+<L18>:
+               	bl	 <L18>
+               	add	x19, x19, #0x1
+               	mov	x22, x0
+               	cmp	x19, #0x6
+               	b.lo	 <L17>
+<L19>:
+               	sub	x19, x29, #0x610
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	str	xzr, [x19, #0x10]
+               	str	xzr, [x19, #0x18]
+               	str	xzr, [x19, #0x20]
+               	str	xzr, [x19, #0x28]
+               	add	x0, x19, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x21, #0x28
+               	add	x1, x24, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2257,7 +1731,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2266,7 +1740,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2275,7 +1749,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2284,163 +1758,160 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x21, x20, #0x10
-               	mov	x16, #0xf340            ; =62272
+               	add	x1, x19, #0x10
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x21, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf988            ; =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x10
-               	str	s0, [x1]
-               	add	x1, x20, #0x24
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	add	x1, x19, #0x24
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x19
-<L81>:
-               	bl	 <L81>
-               	add	x1, x21, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x19, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x21, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x21, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x21, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x21, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	add	x0, x9, #0x10
+               	str	s0, [x0]
+               	mov	x0, x22
+               	mov	x16, #0xf980            ; =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xf338            ; =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xf338            ; =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xf338            ; =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xf338            ; =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L86>:
-               	bl	 <L86>
-               	add	x1, x20, #0x24
+               	mov	x1, x9
+<L22>:
+               	bl	 <L22>
+               	add	x1, x19, #0x24
                	ldr	w2, [x1]
                	mov	w1, w2
-<L87>:
-               	bl	 <L87>
-               	sub	x16, x29, #0xd40
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	sub	x16, x29, #0x6e0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/vec/vec_f32x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x8.dis
@@ -5,74 +5,191 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x8.fold_vec>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x110
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x19, [x29, x16]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x20
-               	sub	x1, x29, #0x40
-               	sub	x1, x29, #0x60
-               	sub	x1, x29, #0x80
-               	sub	x1, x29, #0xa0
-               	sub	x1, x29, #0xc0
-               	sub	x1, x29, #0xe0
-               	sub	x1, x29, #0x100
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x100
+               	sub	x2, x29, #0x20
+               	sub	x2, x29, #0x40
+               	sub	x2, x29, #0x60
+               	sub	x2, x29, #0x80
+               	sub	x2, x29, #0xa0
+               	sub	x2, x29, #0xc0
+               	sub	x2, x29, #0xe0
+               	sub	x2, x29, #0x100
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x19, #0x14
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	add	x2, x19, #0x18
+               	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	add	x2, x19, #0x1c
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x19, [x29, x16]
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	add	x2, x1, #0x14
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x2, x1, #0x18
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x2, x1, #0x1c
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -80,2333 +197,1205 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1, lsl #12   ; =0x1000
-               	sub	sp, sp, #0xa90
-               	mov	x16, #0xe5b0            ; =58800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
+               	sub	sp, sp, #0xa80
+               	sub	x16, x29, #0xa40
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-               	sub	x20, x29, #0x20
-               	sub	x21, x29, #0x40
-               	sub	x22, x29, #0x60
-               	sub	x1, x29, #0x80
-               	sub	x1, x29, #0xa0
-               	sub	x23, x29, #0xc0
-               	sub	x1, x29, #0xe0
-               	sub	x1, x29, #0x100
-               	sub	x24, x29, #0x120
-               	sub	x1, x29, #0x140
-               	sub	x1, x29, #0x160
-               	sub	x25, x29, #0x180
-               	sub	x1, x29, #0x1a0
-               	sub	x1, x29, #0x1c0
-               	sub	x26, x29, #0x1e0
-               	sub	x1, x29, #0x200
-               	sub	x1, x29, #0x220
-               	sub	x1, x29, #0x240
-               	sub	x1, x29, #0x260
-               	sub	x27, x29, #0x280
-               	sub	x1, x29, #0x2a0
-               	sub	x1, x29, #0x2c0
-               	sub	x28, x29, #0x2e0
-               	sub	x1, x29, #0x300
-               	sub	x1, x29, #0x320
-               	sub	x9, x29, #0x340
-               	mov	x16, #0xe610            ; =58896
+               	mov	x9, x0
+               	mov	x16, #0xf638            ; =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x2, x29, #0x360
-               	sub	x2, x29, #0x380
-               	sub	x9, x29, #0x3a0
-               	mov	x16, #0xe608            ; =58888
+               	sub	x1, x29, #0x20
+               	sub	x2, x29, #0x40
+               	sub	x19, x29, #0x60
+               	sub	x3, x29, #0x80
+               	sub	x3, x29, #0xa0
+               	sub	x3, x29, #0xc0
+               	sub	x4, x29, #0xe0
+               	sub	x4, x29, #0x100
+               	sub	x20, x29, #0x120
+               	sub	x4, x29, #0x140
+               	sub	x4, x29, #0x160
+               	sub	x9, x29, #0x180
+               	mov	x16, #0xf618            ; =63000
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x3, x29, #0x3c0
-               	sub	x3, x29, #0x3e0
-               	sub	x9, x29, #0x400
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x4, x29, #0x420
-               	sub	x4, x29, #0x440
-               	sub	x9, x29, #0x460
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x5, x29, #0x1a0
+               	sub	x5, x29, #0x1c0
+               	sub	x21, x29, #0x1e0
+               	sub	x5, x29, #0x200
+               	sub	x5, x29, #0x220
+               	sub	x5, x29, #0x240
+               	sub	x5, x29, #0x260
+               	sub	x22, x29, #0x280
+               	sub	x5, x29, #0x2a0
+               	sub	x5, x29, #0x2c0
+               	sub	x23, x29, #0x2e0
+               	sub	x5, x29, #0x300
+               	sub	x5, x29, #0x320
+               	sub	x24, x29, #0x340
+               	sub	x5, x29, #0x360
+               	sub	x5, x29, #0x380
+               	sub	x25, x29, #0x3a0
+               	sub	x5, x29, #0x3c0
+               	sub	x5, x29, #0x3e0
+               	sub	x26, x29, #0x400
+               	sub	x5, x29, #0x420
+               	sub	x5, x29, #0x440
+               	sub	x27, x29, #0x460
                	sub	x5, x29, #0x480
                	sub	x5, x29, #0x4a0
-               	sub	x9, x29, #0x4c0
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x6, x29, #0x4e0
-               	sub	x6, x29, #0x500
+               	sub	x28, x29, #0x4c0
+               	sub	x5, x29, #0x4e0
+               	sub	x5, x29, #0x500
                	sub	x9, x29, #0x520
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xf610            ; =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x540
-               	sub	x7, x29, #0x560
+               	sub	x6, x29, #0x540
+               	sub	x6, x29, #0x560
                	sub	x9, x29, #0x580
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xf608            ; =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x5a0
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x12, x29, #0x5c0
-               	sub	x12, x29, #0x5e0
+               	sub	x8, x29, #0x5c0
+               	sub	x8, x29, #0x5e0
                	sub	x9, x29, #0x600
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x13, x29, #0x620
-               	sub	x13, x29, #0x640
-               	sub	x13, x29, #0x660
+               	sub	x12, x29, #0x620
+               	sub	x12, x29, #0x640
+               	sub	x12, x29, #0x660
                	sub	x9, x29, #0x680
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xf5f0            ; =62960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x14, x29, #0x6a0
-               	sub	x14, x29, #0x6c0
-               	sub	x14, x29, #0x6e0
+               	sub	x13, x29, #0x6a0
+               	sub	x13, x29, #0x6c0
+               	sub	x13, x29, #0x6e0
                	sub	x9, x29, #0x700
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x720
-               	sub	x15, x29, #0x740
-               	sub	x15, x29, #0x760
-               	sub	x15, x29, #0x780
+               	sub	x14, x29, #0x720
+               	sub	x14, x29, #0x740
+               	sub	x14, x29, #0x760
+               	sub	x14, x29, #0x780
                	sub	x9, x29, #0x7a0
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xf5e0            ; =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x7c0
-               	sub	x8, x29, #0x7e0
+               	sub	x15, x29, #0x7c0
+               	sub	x15, x29, #0x7e0
                	sub	x9, x29, #0x800
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xf5d8            ; =62936
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x820
+               	sub	x0, x29, #0x820
                	sub	x9, x29, #0x840
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x860
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x880
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x8a0
-               	sub	x8, x29, #0x8c0
-               	sub	x8, x29, #0x8e0
-               	sub	x8, x29, #0x900
-               	sub	x8, x29, #0x920
-               	sub	x8, x29, #0x940
-               	sub	x8, x29, #0x960
-               	sub	x8, x29, #0x980
-               	sub	x8, x29, #0x9a0
-               	sub	x8, x29, #0x9c0
-               	sub	x8, x29, #0x9e0
-               	sub	x8, x29, #0xa00
-               	sub	x8, x29, #0xa20
-               	sub	x8, x29, #0xa40
-               	sub	x8, x29, #0xa60
-               	sub	x8, x29, #0xa80
-               	sub	x8, x29, #0xaa0
-               	sub	x8, x29, #0xac0
-               	sub	x8, x29, #0xae0
-               	sub	x8, x29, #0xb00
-               	sub	x8, x29, #0xb20
-               	sub	x8, x29, #0xb40
-               	sub	x8, x29, #0xb60
-               	sub	x8, x29, #0xb80
-               	sub	x8, x29, #0xba0
-               	sub	x8, x29, #0xbc0
-               	sub	x8, x29, #0xbe0
-               	sub	x8, x29, #0xc00
-               	sub	x8, x29, #0xc20
-               	sub	x8, x29, #0xc40
-               	sub	x8, x29, #0xc60
-               	sub	x8, x29, #0xc80
-               	sub	x8, x29, #0xca0
-               	sub	x8, x29, #0xcc0
-               	sub	x8, x29, #0xce0
-               	sub	x8, x29, #0xd00
-               	sub	x8, x29, #0xd20
-               	sub	x8, x29, #0xd40
-               	sub	x8, x29, #0xd60
-               	sub	x8, x29, #0xd80
-               	sub	x8, x29, #0xda0
-               	sub	x8, x29, #0xdc0
-               	sub	x8, x29, #0xde0
-               	sub	x8, x29, #0xe00
-               	sub	x8, x29, #0xe20
-               	sub	x8, x29, #0xe40
-               	sub	x8, x29, #0xe60
-               	sub	x8, x29, #0xe80
-               	sub	x8, x29, #0xea0
-               	sub	x8, x29, #0xec0
-               	sub	x8, x29, #0xee0
-               	sub	x8, x29, #0xf00
-               	sub	x8, x29, #0xf20
-               	sub	x8, x29, #0xf40
-               	sub	x8, x29, #0xf60
-               	sub	x8, x29, #0xf80
-               	sub	x8, x29, #0xfa0
-               	sub	x8, x29, #0xfc0
-               	sub	x8, x29, #0xfe0
-               	sub	x8, x29, #0x1, lsl #12  ; =0x1000
-               	mov	x16, #0xefe0            ; =61408
+               	mov	x16, #0xf638            ; =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xefc0            ; =61376
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xefa0            ; =61344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xef80            ; =61312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xef60            ; =61280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xef40            ; =61248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xef20            ; =61216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xef00            ; =61184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeee0            ; =61152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeec0            ; =61120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeea0            ; =61088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xee80            ; =61056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xee60            ; =61024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xee40            ; =60992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xee20            ; =60960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xee00            ; =60928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xede0            ; =60896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xedc0            ; =60864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeda0            ; =60832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xed80            ; =60800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xed60            ; =60768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xed40            ; =60736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xed20            ; =60704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xed00            ; =60672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xece0            ; =60640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xecc0            ; =60608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeca0            ; =60576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xec80            ; =60544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xec60            ; =60512
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xec40            ; =60480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xec20            ; =60448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xec00            ; =60416
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xebe0            ; =60384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xebc0            ; =60352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeba0            ; =60320
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeb80            ; =60288
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeb60            ; =60256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeb40            ; =60224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeb20            ; =60192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeb00            ; =60160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeae0            ; =60128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeac0            ; =60096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xeaa0            ; =60064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xea80            ; =60032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xea60            ; =60000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xea40            ; =59968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xea20            ; =59936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xea00            ; =59904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe9e0            ; =59872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe9c0            ; =59840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe9a0            ; =59808
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe980            ; =59776
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe960            ; =59744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe940            ; =59712
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe920            ; =59680
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe900            ; =59648
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe8e0            ; =59616
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe8c0            ; =59584
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe8a0            ; =59552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe880            ; =59520
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe860            ; =59488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe840            ; =59456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe820            ; =59424
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe800            ; =59392
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe7e0            ; =59360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe7c0            ; =59328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe7a0            ; =59296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	mov	x16, #0xe780            ; =59264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	mov	x16, #0xe760            ; =59232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	add	x19, x8, #0x0
+               	ldr	x9, [x29, x16]
+               	ucvtf	s0, x9
+               	sub	x0, x29, #0x960
+               	add	x4, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x8, #0x4
-               	str	s1, [x19]
-               	add	x19, x8, #0x8
+               	add	x4, x0, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x8, #0xc
-               	str	s1, [x19]
-               	add	x19, x8, #0x10
+               	add	x4, x0, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
                	mov	w17, #0x40c80000        ; =1086849024
-               	str	w17, [x19]
+               	str	w17, [x4]
                	mov	w16, #0x41020000        ; =1090650112
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x8, #0x14
-               	str	s1, [x19]
-               	add	x19, x8, #0x18
+               	add	x4, x0, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
                	mov	w17, #0x3f400000        ; =1061158912
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #16.00000000
                	fneg	s1, s31
-               	add	x19, x8, #0x1c
-               	str	s1, [x19]
-               	add	x19, x8, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x0
-               	str	s1, [x19]
-               	add	x19, x8, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x4
-               	str	s1, [x19]
-               	add	x19, x8, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x8
-               	str	s1, [x19]
-               	add	x19, x8, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x20, #0xc
-               	str	s1, [x19]
-               	add	x19, x8, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x10
-               	str	s1, [x19]
-               	add	x19, x8, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x14
-               	str	s1, [x19]
-               	add	x19, x8, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x18
-               	str	s1, [x19]
-               	add	x19, x8, #0x1c
-               	ldr	s1, [x19]
-               	add	x8, x20, #0x1c
-               	str	s1, [x8]
-               	mov	x16, #0xe740            ; =59200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	add	x19, x8, #0x0
+               	add	x4, x0, #0x1c
+               	str	s1, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x1, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x1, #0x1c
+               	str	s1, [x0]
+               	sub	x0, x29, #0x980
+               	add	x4, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x19]
-               	add	x19, x8, #0x4
+               	str	w17, [x4]
+               	add	x4, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x8, #0x8
-               	str	s1, [x19]
-               	add	x19, x8, #0xc
+               	add	x4, x0, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
                	mov	w17, #0x41000000        ; =1090519040
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x8, #0x10
-               	str	s1, [x19]
-               	add	x19, x8, #0x14
+               	add	x4, x0, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
                	mov	w17, #0x3fa00000        ; =1067450368
-               	str	w17, [x19]
+               	str	w17, [x4]
                	mov	w16, #0x42000000        ; =1107296256
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x8, #0x18
-               	str	s1, [x19]
-               	add	x19, x8, #0x1c
+               	add	x4, x0, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
                	mov	w17, #0x3d800000        ; =1031798784
-               	str	w17, [x19]
-               	add	x19, x8, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x0
-               	str	s1, [x19]
-               	add	x19, x8, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x4
-               	str	s1, [x19]
-               	add	x19, x8, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x8
-               	str	s1, [x19]
-               	add	x19, x8, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x21, #0xc
-               	str	s1, [x19]
-               	add	x19, x8, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x10
-               	str	s1, [x19]
-               	add	x19, x8, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x14
-               	str	s1, [x19]
-               	add	x19, x8, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x18
-               	str	s1, [x19]
-               	add	x19, x8, #0x1c
-               	ldr	s1, [x19]
-               	add	x8, x21, #0x1c
-               	str	s1, [x8]
-               	mov	x16, #0xe720            ; =59168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x8, x29, x16
-               	add	x19, x8, #0x0
+               	str	w17, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x2, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x2, #0x1c
+               	str	s1, [x0]
+               	sub	x0, x29, #0x9a0
+               	add	x4, x0, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
-               	str	w17, [x19]
-               	add	x19, x8, #0x4
+               	str	w17, [x4]
+               	add	x4, x0, #0x4
                	mov	w17, #0x40400000        ; =1077936128
-               	str	w17, [x19]
-               	add	x19, x8, #0x8
+               	str	w17, [x4]
+               	add	x4, x0, #0x8
                	mov	w17, #0x41100000        ; =1091567616
-               	str	w17, [x19]
-               	add	x19, x8, #0xc
+               	str	w17, [x4]
+               	add	x4, x0, #0xc
                	mov	w17, #0x41d80000        ; =1104674816
-               	str	w17, [x19]
-               	add	x19, x8, #0x10
+               	str	w17, [x4]
+               	add	x4, x0, #0x10
                	mov	w17, #0x42a20000        ; =1117913088
-               	str	w17, [x19]
-               	add	x19, x8, #0x14
+               	str	w17, [x4]
+               	add	x4, x0, #0x14
                	mov	w17, #0x43730000        ; =1131610112
-               	str	w17, [x19]
-               	add	x19, x8, #0x18
+               	str	w17, [x4]
+               	add	x4, x0, #0x18
                	mov	w17, #0x4000            ; =16384
                	movk	w17, #0x4436, lsl #16
-               	str	w17, [x19]
-               	add	x19, x8, #0x1c
+               	str	w17, [x4]
+               	add	x4, x0, #0x1c
                	mov	w17, #0xb000            ; =45056
                	movk	w17, #0x4508, lsl #16
-               	str	w17, [x19]
-               	add	x19, x8, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x0
-               	str	s1, [x19]
-               	add	x19, x8, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x4
-               	str	s1, [x19]
-               	add	x19, x8, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x8
-               	str	s1, [x19]
-               	add	x19, x8, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x22, #0xc
-               	str	s1, [x19]
-               	add	x19, x8, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x10
-               	str	s1, [x19]
-               	add	x19, x8, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x14
-               	str	s1, [x19]
-               	add	x19, x8, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x18
-               	str	s1, [x19]
-               	add	x19, x8, #0x1c
-               	ldr	s1, [x19]
-               	add	x8, x22, #0x1c
-               	str	s1, [x8]
-               	add	x8, x20, #0x0
-               	ldr	s1, [x8]
+               	str	w17, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x19, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x19, #0x1c
+               	str	s1, [x0]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x8, x20, #0x0
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x0
-               	str	s1, [x8]
-               	add	x8, x20, #0x4
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x4
-               	str	s1, [x8]
-               	add	x8, x20, #0x8
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x8
-               	str	s1, [x8]
-               	add	x8, x20, #0xc
-               	ldr	s1, [x8]
-               	add	x8, x23, #0xc
-               	str	s1, [x8]
-               	add	x8, x20, #0x10
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x10
-               	str	s1, [x8]
-               	add	x8, x20, #0x14
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x14
-               	str	s1, [x8]
-               	add	x8, x20, #0x18
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x18
-               	str	s1, [x8]
-               	add	x8, x20, #0x1c
-               	ldr	s1, [x8]
-               	add	x8, x23, #0x1c
-               	str	s1, [x8]
-               	add	x8, x23, #0x0
-               	str	s2, [x8]
-               	add	x8, x23, #0x1c
-               	ldr	s1, [x8]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s1, [x0]
+               	add	x0, x1, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x4
+               	str	s1, [x0]
+               	add	x0, x1, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x8
+               	str	s1, [x0]
+               	add	x0, x1, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x3, #0xc
+               	str	s1, [x0]
+               	add	x0, x1, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x10
+               	str	s1, [x0]
+               	add	x0, x1, #0x14
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x14
+               	str	s1, [x0]
+               	add	x0, x1, #0x18
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x18
+               	str	s1, [x0]
+               	add	x0, x1, #0x1c
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x1c
+               	str	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s2, [x0]
+               	add	x0, x3, #0x1c
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x8, x23, #0x0
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x0
-               	str	s1, [x8]
-               	add	x8, x23, #0x4
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x4
-               	str	s1, [x8]
-               	add	x8, x23, #0x8
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x8
-               	str	s1, [x8]
-               	add	x8, x23, #0xc
-               	ldr	s1, [x8]
-               	add	x8, x24, #0xc
-               	str	s1, [x8]
-               	add	x8, x23, #0x10
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x10
-               	str	s1, [x8]
-               	add	x8, x23, #0x14
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x14
-               	str	s1, [x8]
-               	add	x8, x23, #0x18
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x18
-               	str	s1, [x8]
-               	add	x8, x23, #0x1c
-               	ldr	s1, [x8]
-               	add	x8, x24, #0x1c
-               	str	s1, [x8]
-               	add	x8, x24, #0x1c
-               	str	s2, [x8]
-               	add	x8, x21, #0xc
-               	ldr	s1, [x8]
+               	add	x0, x3, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x0
+               	str	s1, [x0]
+               	add	x0, x3, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x4
+               	str	s1, [x0]
+               	add	x0, x3, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x8
+               	str	s1, [x0]
+               	add	x0, x3, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x20, #0xc
+               	str	s1, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s1, [x0]
+               	add	x0, x3, #0x14
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x14
+               	str	s1, [x0]
+               	add	x0, x3, #0x18
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x18
+               	str	s1, [x0]
+               	add	x0, x3, #0x1c
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x1c
+               	str	s1, [x0]
+               	add	x0, x20, #0x1c
+               	str	s2, [x0]
+               	add	x0, x2, #0xc
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x8, x21, #0x0
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x0
-               	str	s1, [x8]
-               	add	x8, x21, #0x4
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x4
-               	str	s1, [x8]
-               	add	x8, x21, #0x8
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x8
-               	str	s1, [x8]
-               	add	x8, x21, #0xc
-               	ldr	s1, [x8]
-               	add	x8, x25, #0xc
-               	str	s1, [x8]
-               	add	x8, x21, #0x10
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x10
-               	str	s1, [x8]
-               	add	x8, x21, #0x14
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x14
-               	str	s1, [x8]
-               	add	x8, x21, #0x18
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x18
-               	str	s1, [x8]
-               	add	x8, x21, #0x1c
-               	ldr	s1, [x8]
-               	add	x8, x25, #0x1c
-               	str	s1, [x8]
-               	add	x8, x25, #0xc
-               	str	s2, [x8]
-               	add	x8, x25, #0x10
-               	ldr	s1, [x8]
+               	add	x0, x2, #0x0
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s1, [x0]
+               	add	x0, x2, #0x4
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s1, [x0]
+               	add	x0, x2, #0x8
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s1, [x0]
+               	add	x0, x2, #0xc
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s1, [x0]
+               	add	x0, x2, #0x10
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s1, [x0]
+               	add	x0, x2, #0x14
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s1, [x0]
+               	add	x0, x2, #0x18
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s1, [x0]
+               	add	x0, x2, #0x1c
+               	ldr	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s1, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x8, x25, #0x0
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x0
-               	str	s0, [x8]
-               	add	x8, x25, #0x4
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x4
-               	str	s0, [x8]
-               	add	x8, x25, #0x8
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x8
-               	str	s0, [x8]
-               	add	x8, x25, #0xc
-               	ldr	s0, [x8]
-               	add	x8, x26, #0xc
-               	str	s0, [x8]
-               	add	x8, x25, #0x10
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x10
-               	str	s0, [x8]
-               	add	x8, x25, #0x14
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x14
-               	str	s0, [x8]
-               	add	x8, x25, #0x18
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x18
-               	str	s0, [x8]
-               	add	x8, x25, #0x1c
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x1c
-               	str	s0, [x8]
-               	add	x8, x26, #0x10
-               	str	s2, [x8]
-               	add	x8, x24, #0x0
-               	ldr	s0, [x8]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x14
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x18
+               	str	s0, [x0]
+               	mov	x16, #0xf618            ; =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x1c
+               	str	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s2, [x0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x20
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x21
 <L1>:
                	bl	 <L1>
-               	add	x8, x24, #0x4
-               	ldr	s0, [x8]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x22
 <L2>:
                	bl	 <L2>
-               	add	x8, x24, #0x8
-               	ldr	s0, [x8]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x23
 <L3>:
                	bl	 <L3>
-               	add	x8, x24, #0xc
-               	ldr	s0, [x8]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x10
+               	str	s2, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x14
+               	str	s2, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x18
+               	str	s2, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x24
 <L4>:
                	bl	 <L4>
-               	add	x8, x24, #0x10
-               	ldr	s0, [x8]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x25
 <L5>:
                	bl	 <L5>
-               	add	x8, x24, #0x14
-               	ldr	s0, [x8]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x26
 <L6>:
                	bl	 <L6>
-               	add	x8, x24, #0x18
-               	ldr	s0, [x8]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x10
+               	str	s2, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x14
+               	str	s2, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x18
+               	str	s2, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x27
 <L7>:
                	bl	 <L7>
-               	add	x8, x24, #0x1c
-               	ldr	s0, [x8]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x28
 <L8>:
                	bl	 <L8>
-               	add	x8, x26, #0x0
-               	ldr	s0, [x8]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf610            ; =62992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	add	x8, x26, #0x4
-               	ldr	s0, [x8]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf608            ; =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	add	x8, x26, #0x8
-               	ldr	s0, [x8]
-<L11>:
-               	bl	 <L11>
-               	add	x8, x26, #0xc
-               	ldr	s0, [x8]
-<L12>:
-               	bl	 <L12>
-               	add	x8, x26, #0x10
-               	ldr	s0, [x8]
-<L13>:
-               	bl	 <L13>
-               	add	x8, x26, #0x14
-               	ldr	s0, [x8]
-<L14>:
-               	bl	 <L14>
-               	add	x8, x26, #0x18
-               	ldr	s0, [x8]
-<L15>:
-               	bl	 <L15>
-               	add	x8, x26, #0x1c
-               	ldr	s0, [x8]
-<L16>:
-               	bl	 <L16>
-               	add	x8, x24, #0x0
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x0
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x0
-               	str	s2, [x8]
-               	add	x8, x24, #0x4
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x4
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x4
-               	str	s2, [x8]
-               	add	x8, x24, #0x8
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x8
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x8
-               	str	s2, [x8]
-               	add	x8, x24, #0xc
-               	ldr	s0, [x8]
-               	add	x8, x26, #0xc
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0xc
-               	str	s2, [x8]
-               	add	x8, x24, #0x10
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x10
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x10
-               	str	s2, [x8]
-               	add	x8, x24, #0x14
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x14
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x14
-               	str	s2, [x8]
-               	add	x8, x24, #0x18
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x18
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x18
-               	str	s2, [x8]
-               	add	x8, x24, #0x1c
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x1c
-               	ldr	s1, [x8]
-               	fadd	s2, s0, s1
-               	add	x8, x27, #0x1c
-               	str	s2, [x8]
-               	add	x8, x27, #0x0
-               	ldr	s0, [x8]
-<L17>:
-               	bl	 <L17>
-               	add	x8, x27, #0x4
-               	ldr	s0, [x8]
-<L18>:
-               	bl	 <L18>
-               	add	x8, x27, #0x8
-               	ldr	s0, [x8]
-<L19>:
-               	bl	 <L19>
-               	add	x8, x27, #0xc
-               	ldr	s0, [x8]
-<L20>:
-               	bl	 <L20>
-               	add	x8, x27, #0x10
-               	ldr	s0, [x8]
-<L21>:
-               	bl	 <L21>
-               	add	x8, x27, #0x14
-               	ldr	s0, [x8]
-<L22>:
-               	bl	 <L22>
-               	add	x8, x27, #0x18
-               	ldr	s0, [x8]
-<L23>:
-               	bl	 <L23>
-               	add	x8, x27, #0x1c
-               	ldr	s0, [x8]
-<L24>:
-               	bl	 <L24>
-               	add	x8, x24, #0x0
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x0
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x0
-               	str	s2, [x8]
-               	add	x8, x24, #0x4
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x4
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x4
-               	str	s2, [x8]
-               	add	x8, x24, #0x8
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x8
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x8
-               	str	s2, [x8]
-               	add	x8, x24, #0xc
-               	ldr	s0, [x8]
-               	add	x8, x26, #0xc
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0xc
-               	str	s2, [x8]
-               	add	x8, x24, #0x10
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x10
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x10
-               	str	s2, [x8]
-               	add	x8, x24, #0x14
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x14
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x14
-               	str	s2, [x8]
-               	add	x8, x24, #0x18
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x18
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x18
-               	str	s2, [x8]
-               	add	x8, x24, #0x1c
-               	ldr	s0, [x8]
-               	add	x8, x26, #0x1c
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	add	x8, x28, #0x1c
-               	str	s2, [x8]
-               	add	x8, x28, #0x0
-               	ldr	s0, [x8]
-<L25>:
-               	bl	 <L25>
-               	add	x8, x28, #0x4
-               	ldr	s0, [x8]
-<L26>:
-               	bl	 <L26>
-               	add	x8, x28, #0x8
-               	ldr	s0, [x8]
-<L27>:
-               	bl	 <L27>
-               	add	x8, x28, #0xc
-               	ldr	s0, [x8]
-<L28>:
-               	bl	 <L28>
-               	add	x8, x28, #0x10
-               	ldr	s0, [x8]
-<L29>:
-               	bl	 <L29>
-               	add	x8, x28, #0x14
-               	ldr	s0, [x8]
-<L30>:
-               	bl	 <L30>
-               	add	x8, x28, #0x18
-               	ldr	s0, [x8]
-<L31>:
-               	bl	 <L31>
-               	add	x8, x28, #0x1c
-               	ldr	s0, [x8]
-<L32>:
-               	bl	 <L32>
-               	add	x8, x26, #0x0
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x0
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x0
-               	str	s2, [x8]
-               	add	x8, x26, #0x4
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x4
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x4
-               	str	s2, [x8]
-               	add	x8, x26, #0x8
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x8
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x8
-               	str	s2, [x8]
-               	add	x8, x26, #0xc
-               	ldr	s0, [x8]
-               	add	x8, x24, #0xc
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0xc
-               	str	s2, [x8]
-               	add	x8, x26, #0x10
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x10
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x10
-               	str	s2, [x8]
-               	add	x8, x26, #0x14
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x14
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x14
-               	str	s2, [x8]
-               	add	x8, x26, #0x18
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x18
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x18
-               	str	s2, [x8]
-               	add	x8, x26, #0x1c
-               	ldr	s0, [x8]
-               	add	x8, x24, #0x1c
-               	ldr	s1, [x8]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x1c
-               	str	s2, [x8]
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x0
-               	ldr	s0, [x8]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x4
-               	ldr	s0, [x8]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x8
-               	ldr	s0, [x8]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0xc
-               	ldr	s0, [x8]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x10
-               	ldr	s0, [x8]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x14
-               	ldr	s0, [x8]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x18
-               	ldr	s0, [x8]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xe610            ; =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x8, x9, #0x1c
-               	ldr	s0, [x8]
-<L40>:
-               	bl	 <L40>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xe608            ; =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L48>:
-               	bl	 <L48>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xe600            ; =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L56>:
-               	bl	 <L56>
-               	add	x1, x26, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xe5f8            ; =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L64>:
-               	bl	 <L64>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xe5f0            ; =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L72>:
-               	bl	 <L72>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xe5e8            ; =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L80>:
-               	bl	 <L80>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xe5e0            ; =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xe640            ; =58944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x1, x29, x16
+               	sub	x1, x29, #0x9c0
                	add	x2, x1, #0x0
                	str	wzr, [x2]
                	add	x2, x1, #0x4
@@ -2425,7 +1414,7 @@ Disassembly of section __TEXT,__text:
                	str	wzr, [x2]
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2434,7 +1423,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2443,7 +1432,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2452,7 +1441,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2461,7 +1450,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2470,7 +1459,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x14
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2479,7 +1468,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x18
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2488,197 +1477,133 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x1c
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            ; =58936
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s0, [x1]
-               	mov	x19, x0
-               	mov	x16, #0xe638            ; =58936
+               	mov	x22, x0
+               	mov	x16, #0xf600            ; =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x20, x9
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x6
-               	b.lo	 <L89>
-               	b	 <L114>
-<L89>:
-               	add	x0, x24, #0x0
+               	mov	x23, x9
+               	mov	x24, #0x0               ; =0
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x22, #0x0
+               	add	x0, x19, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x22, #0x4
+               	add	x0, x19, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x22, #0x8
+               	add	x0, x19, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x22, #0xc
+               	add	x0, x19, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x22, #0x10
+               	add	x0, x19, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	add	x0, x24, #0x14
+               	add	x0, x20, #0x14
                	ldr	s0, [x0]
-               	add	x0, x22, #0x14
+               	add	x0, x19, #0x14
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x14
                	str	s2, [x0]
-               	add	x0, x24, #0x18
+               	add	x0, x20, #0x18
                	ldr	s0, [x0]
-               	add	x0, x22, #0x18
+               	add	x0, x19, #0x18
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x18
                	str	s2, [x0]
-               	add	x0, x24, #0x1c
+               	add	x0, x20, #0x1c
                	ldr	s0, [x0]
-               	add	x0, x22, #0x1c
+               	add	x0, x19, #0x1c
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s2, [x0]
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x0, x22
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	mov	x1, x9
+<L12>:
+               	bl	 <L12>
+               	add	x1, x23, #0x0
                	ldr	s0, [x1]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L97>:
-               	bl	 <L97>
-               	add	x1, x20, #0x0
-               	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xf5f8            ; =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2686,7 +1611,146 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x23, #0x14
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x23, #0x18
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x23, #0x1c
+               	ldr	s0, [x1]
+               	mov	x16, #0xf5f8            ; =62968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf5f0            ; =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L13>:
+               	bl	 <L13>
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2695,15 +1759,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	add	x1, x21, #0x4
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2712,15 +1771,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
+               	add	x1, x21, #0x8
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2729,15 +1783,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
+               	add	x1, x21, #0xc
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2746,15 +1795,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
+               	add	x1, x21, #0x10
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2763,15 +1807,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
+               	add	x1, x21, #0x14
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2780,15 +1819,10 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
+               	add	x1, x21, #0x18
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2797,664 +1831,52 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe5d8            ; =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
+               	add	x1, x21, #0x1c
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xe5d0            ; =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L105>:
-               	bl	 <L105>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L113>:
-               	bl	 <L113>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xe5c8            ; =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x24, x9
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x1, x9
+<L14>:
+               	bl	 <L14>
+               	add	x24, x24, #0x1
+               	mov	x22, x0
+               	mov	x16, #0xf5e8            ; =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x20, x9
-               	cmp	x21, #0x6
-               	b.lo	 <L89>
-<L114>:
-               	mov	x16, #0xe6a0            ; =59040
+               	mov	x16, #0xf5f0            ; =62960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x0, x21, #0x0
+               	ldr	x9, [x29, x16]
+               	mov	x23, x9
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+<L15>:
+               	sub	x24, x29, #0x900
+               	add	x0, x24, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x80               ; =128
-<L115>:
+<L16>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L115>
-               	add	x0, x21, #0x0
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
+               	b.ne	 <L16>
                	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x0
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x4
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x8
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x26, #0xc
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x10
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x24, #0x14
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x14
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x14
-               	str	s2, [x0]
-               	add	x0, x24, #0x18
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x18
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x18
-               	str	s2, [x0]
-               	add	x0, x24, #0x1c
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x1c
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x1c
-               	str	s2, [x0]
-               	add	x0, x21, #0x20
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe5c0            ; =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
-               	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x0
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x4
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x8
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x22, #0xc
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x10
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x24, #0x14
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x14
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x14
-               	str	s2, [x0]
-               	add	x0, x24, #0x18
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x18
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x18
-               	str	s2, [x0]
-               	add	x0, x24, #0x1c
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x1c
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x1c
-               	str	s2, [x0]
-               	add	x0, x21, #0x40
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
-               	add	x0, x21, #0x60
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
@@ -3487,17 +1909,388 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x1c
                	str	s0, [x1]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x4
-               	b.lo	 <L116>
-               	b	 <L125>
-<L116>:
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x20, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x14
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s2, [x0]
+               	add	x0, x20, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x18
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s2, [x0]
+               	add	x0, x20, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x1c
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s2, [x0]
+               	add	x0, x24, #0x20
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	mov	x16, #0xf5e0            ; =62944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x0
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x4
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x8
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x19, #0xc
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x10
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x20, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x14
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s2, [x0]
+               	add	x0, x20, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x18
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s2, [x0]
+               	add	x0, x20, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x1c
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s2, [x0]
+               	add	x0, x24, #0x40
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	mov	x16, #0xf5d8            ; =62936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	add	x0, x24, #0x60
+               	add	x1, x23, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x1, x23, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	add	x1, x23, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	add	x1, x23, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	mov	x19, #0x0               ; =0
+               	cmp	x19, #0x4
+               	b.lo	 <L17>
+               	b	 <L19>
+<L17>:
                	mov	x16, #0x20              ; =32
-               	mul	x0, x20, x16
-               	add	x1, x21, x0
+               	mul	x0, x19, x16
+               	add	x1, x24, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3506,7 +2299,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3515,7 +2308,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3524,7 +2317,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3533,7 +2326,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3542,7 +2335,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x14
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3551,7 +2344,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x18
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3560,112 +2353,44 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x1c
                	ldr	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s0, [x0]
-               	mov	x16, #0xe618            ; =58904
+               	mov	x0, x22
+               	mov	x16, #0xf630            ; =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xe618            ; =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L124>:
-               	bl	 <L124>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x4
-               	b.lo	 <L116>
-<L125>:
-               	mov	x16, #0xe660            ; =58976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	str	xzr, [x20, #0x30]
-               	str	xzr, [x20, #0x38]
-               	add	x0, x20, #0x0
+               	mov	x1, x9
+<L18>:
+               	bl	 <L18>
+               	add	x19, x19, #0x1
+               	mov	x22, x0
+               	cmp	x19, #0x4
+               	b.lo	 <L17>
+<L19>:
+               	sub	x19, x29, #0x940
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	str	xzr, [x19, #0x10]
+               	str	xzr, [x19, #0x18]
+               	str	xzr, [x19, #0x20]
+               	str	xzr, [x19, #0x28]
+               	str	xzr, [x19, #0x30]
+               	str	xzr, [x19, #0x38]
+               	add	x0, x19, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x21, #0x40
+               	add	x1, x24, #0x40
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3674,7 +2399,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3683,7 +2408,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3692,7 +2417,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3701,7 +2426,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3710,7 +2435,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x14
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3719,7 +2444,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x18
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3728,248 +2453,214 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x1c
                	ldr	s0, [x2]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s0, [x1]
-               	add	x21, x20, #0x10
-               	mov	x16, #0xe628            ; =58920
+               	add	x1, x19, #0x10
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x21, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x14
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x14
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	add	x2, x9, #0x18
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x18
+               	str	s0, [x2]
+               	mov	x16, #0xf628            ; =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x1c
-               	str	s0, [x1]
-               	add	x1, x20, #0x30
+               	add	x2, x9, #0x1c
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x1c
+               	str	s0, [x2]
+               	add	x1, x19, #0x30
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x19
-<L126>:
-               	bl	 <L126>
-               	add	x1, x21, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x19, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x21, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x21, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x21, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x21, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x1, x21, #0x14
+               	add	x1, x0, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x14
                	str	s0, [x1]
-               	add	x1, x21, #0x18
+               	add	x1, x0, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x18
                	str	s0, [x1]
-               	add	x1, x21, #0x1c
+               	add	x1, x0, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	add	x0, x9, #0x1c
+               	str	s0, [x0]
+               	mov	x0, x22
+               	mov	x16, #0xf620            ; =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xe620            ; =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L134>:
-               	bl	 <L134>
-               	add	x1, x20, #0x30
+               	mov	x1, x9
+<L22>:
+               	bl	 <L22>
+               	add	x1, x19, #0x30
                	ldr	w2, [x1]
                	mov	w1, w2
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xe5b0            ; =58800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	sub	x16, x29, #0xa40
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/vec/vec_f64x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f64x2.dis
@@ -3,64 +3,83 @@ vec/vec_f64x2.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_f64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[0]
-               	mov	x0, x1
+               	mov	d1, v0[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_f64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            ; =65032
+               	sub	sp, sp, #0x150
+               	stp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	d0, x19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	ucvtf	d0, x0
+               	sub	x0, x29, #0x80
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff8000000000000 ; =4609434218613702656
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x3ffe000000000000 ; =-4611123068473966592
-               	str	x17, [x2]
-               	ldr	q1, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x90
+               	add	x1, x0, #0x0
                	mov	x17, #0x3fe0000000000000 ; =4602678819172646912
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x4010000000000000 ; =4616189618054758400
-               	str	x17, [x2]
-               	ldr	q2, [x1]
-               	sub	x1, x29, #0x30
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q2, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff0000000000000 ; =4607182418800017408
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x403b000000000000 ; =4628293042053316608
-               	str	x17, [x2]
-               	ldr	q31, [x1]
+               	str	x17, [x1]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
                	mov	d3, v1[0]
                	fadd	d4, d3, d0
@@ -72,214 +91,61 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v30, v2
                	mov.d	v30[1], v3[0]
                	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	d0, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xd0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xe0]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xd0]
-               	mov	d0, v31[1]
+               	ldur	q30, [x29, #-0xe0]
+               	fadd.2d	v0, v31, v30
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	d0, v31[0]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fsub.2d	v0, v31, v30
 <L3>:
                	bl	 <L3>
                	ldur	q31, [x29, #-0xe0]
-               	mov	d0, v31[1]
+               	ldur	q30, [x29, #-0xd0]
+               	fsub.2d	v0, v31, v30
 <L4>:
                	bl	 <L4>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	fadd.2d	v31, v31, v30
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	d0, v31[0]
+               	fmul.2d	v0, v31, v30
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	d0, v31[1]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fdiv.2d	v0, v31, v30
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fsub.2d	v31, v31, v30
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	d0, v31[0]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xd0]
+               	fdiv.2d	v0, v31, v30
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov	d0, v31[1]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fsub.2d	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fmul.2d	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fdiv.2d	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fdiv.2d	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xc0]
-               	fmul.2d	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L18>:
-               	bl	 <L18>
+               	fmul.2d	v0, v31, v30
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xe0]
-               	fsub.2d	v31, v31, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L20>:
-               	bl	 <L20>
+               	fsub.2d	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xd0]
-               	fdiv.2d	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L22>:
-               	bl	 <L22>
+               	fdiv.2d	v0, v31, v30
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
@@ -288,136 +154,81 @@ Disassembly of section __TEXT,__text:
                	ldr	q0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-               	b	 <L30>
-<L23>:
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul.2d	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
+               	stur	q31, [x29, #-0xf0]
                	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfe80            ; =65152
+               	ldur	q0, [x29, #-0xf0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	fadd.2d	v31, v31, v30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fsub.2d	v31, v31, v30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L29>:
-               	bl	 <L29>
+               	ldr	q0, [x29, x16]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-<L30>:
-               	sub	x20, x29, #0x70
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -427,32 +238,20 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	str	q31, [x0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fadd.2d	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul.2d	v0, v31, v30
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -460,41 +259,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L31>
-               	b	 <L34>
-<L31>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L33>:
-               	bl	 <L33>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L31>
-<L34>:
-               	sub	x21, x29, #0xa0
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -507,45 +287,60 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L35>:
-               	bl	 <L35>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L37>:
-               	bl	 <L37>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	ldp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            ; =65032
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_i16x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i16x4.dis
@@ -3,668 +3,361 @@ vec/vec_i16x4.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_i16x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[0]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[1]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.h	w1, v0[2]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	umov.h	w1, v0[3]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_i16x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1f0
-               	stp	x19, x20, [x29, #-0x1e0]
-               	mov	x16, #0xfe18            ; =65048
+               	sub	sp, sp, #0x160
+               	stp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x44
+               	add	x2, x0, #0x0
+               	mov	w17, #0x3e9             ; =1001
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfbb1            ; =64433
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x4b7             ; =1207
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfaeb            ; =64235
+               	strh	w17, [x2]
+               	ldr	d0, [x0]
+               	sub	x0, x29, #0x4c
+               	add	x2, x0, #0x0
+               	mov	w17, #0xd               ; =13
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfff5            ; =65525
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               ; =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfff9            ; =65529
+               	strh	w17, [x2]
+               	ldr	d1, [x0]
+               	sub	x0, x29, #0x54
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               ; =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x2               ; =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x3               ; =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x4               ; =4
+               	strh	w17, [x2]
+               	ldr	d31, [x0]
+               	stur	d31, [x29, #-0x70]
+               	sub	x0, x29, #0x5c
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	ldr	d31, [x0]
+               	stur	d31, [x29, #-0x80]
+               	umov.h	w0, v0[0]
+               	add	w2, w0, w1
+               	mov.16b	v2, v0
+               	mov.h	v2[0], w2
+               	umov.h	w0, v2[3]
+               	add	w2, w0, w1
+               	mov.16b	v30, v2
+               	mov.h	v30[3], w2
+               	stur	q30, [x29, #-0x90]
+               	umov.h	w0, v1[1]
+               	add	w2, w0, w1
+               	mov.16b	v0, v1
+               	mov.h	v0[1], w2
+               	umov.h	w0, v0[2]
+               	add	w2, w0, w1
+               	mov.16b	v30, v0
+               	mov.h	v30[2], w2
+               	stur	q30, [x29, #-0xa0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0x90]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x8
-               	add	x3, x2, #0x0
-               	mov	w17, #0x3e9             ; =1001
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfbb1            ; =64433
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x4b7             ; =1207
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfaeb            ; =64235
-               	strh	w17, [x3]
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0xd               ; =13
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfff5            ; =65525
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               ; =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfff9            ; =65529
-               	strh	w17, [x3]
-               	ldr	d1, [x2]
-               	sub	x2, x29, #0x18
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               ; =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x2               ; =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x3               ; =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x4               ; =4
-               	strh	w17, [x3]
-               	ldr	d31, [x2]
-               	stur	d31, [x29, #-0x70]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	ldr	d31, [x2]
-               	stur	d31, [x29, #-0x80]
-               	umov.h	w2, v0[0]
-               	add	w3, w2, w1
-               	mov.16b	v2, v0
-               	mov.h	v2[0], w3
-               	umov.h	w2, v2[3]
-               	add	w3, w2, w1
-               	mov.16b	v30, v2
-               	mov.h	v30[3], w3
-               	stur	q30, [x29, #-0x90]
-               	umov.h	w2, v1[1]
-               	add	w3, w2, w1
-               	mov.16b	v0, v1
-               	mov.h	v0[1], w3
-               	umov.h	w2, v0[2]
-               	add	w3, w2, w1
-               	mov.16b	v30, v0
-               	mov.h	v30[2], w3
-               	stur	q30, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0x90]
-               	umov.h	w1, v31[0]
+               	ldur	q0, [x29, #-0xa0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0x90]
-               	umov.h	w1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0x90]
-               	umov.h	w1, v31[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0x90]
-               	umov.h	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xa0]
-               	umov.h	w1, v31[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xa0]
-               	umov.h	w1, v31[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xa0]
-               	umov.h	w1, v31[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xa0]
-               	umov.h	w1, v31[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	add.8h	v31, v31, v30
                	stur	q31, [x29, #-0xb0]
+               	ldur	q0, [x29, #-0xb0]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	sub.8h	v0, v31, v30
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x90]
+               	sub.8h	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	mul.8h	v0, v31, v30
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0x70]
+               	mul.8h	v0, v31, v30
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x70]
+               	mul.8h	v0, v31, v30
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0xb0]
-               	umov.h	w1, v31[0]
+               	ldur	q30, [x29, #-0x70]
+               	mul.8h	v0, v31, v30
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	sub.8h	v0, v31, v30
 <L9>:
                	bl	 <L9>
-               	ldur	q31, [x29, #-0xb0]
-               	umov.h	w1, v31[1]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0xa0]
+               	sub.8h	v0, v31, v30
 <L10>:
                	bl	 <L10>
-               	ldur	q31, [x29, #-0xb0]
-               	umov.h	w1, v31[2]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	and.16b	v31, v31, v30
+               	stur	q31, [x29, #-0xc0]
+               	ldur	q0, [x29, #-0xc0]
 <L11>:
                	bl	 <L11>
-               	ldur	q31, [x29, #-0xb0]
-               	umov.h	w1, v31[3]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	orr.16b	v31, v31, v30
+               	stur	q31, [x29, #-0xd0]
+               	ldur	q0, [x29, #-0xd0]
 <L12>:
                	bl	 <L12>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
-               	sub.8h	v31, v31, v30
-               	stur	q31, [x29, #-0xc0]
-               	ldur	q31, [x29, #-0xc0]
-               	umov.h	w1, v31[0]
+               	eor.16b	v0, v31, v30
 <L13>:
                	bl	 <L13>
-               	ldur	q31, [x29, #-0xc0]
-               	umov.h	w1, v31[1]
+               	ldur	q31, [x29, #-0x90]
+               	mvn.16b	v0, v31
 <L14>:
                	bl	 <L14>
-               	ldur	q31, [x29, #-0xc0]
-               	umov.h	w1, v31[2]
+               	ldur	q31, [x29, #-0xa0]
+               	mvn.16b	v0, v31
 <L15>:
                	bl	 <L15>
                	ldur	q31, [x29, #-0xc0]
-               	umov.h	w1, v31[3]
+               	ldur	q30, [x29, #-0xd0]
+               	eor.16b	v0, v31, v30
 <L16>:
                	bl	 <L16>
-               	ldur	q31, [x29, #-0xa0]
-               	ldur	q30, [x29, #-0x90]
-               	sub.8h	v31, v31, v30
-               	stur	q31, [x29, #-0xd0]
-               	ldur	q31, [x29, #-0xd0]
-               	umov.h	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0xd0]
-               	umov.h	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0xd0]
-               	umov.h	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0xd0]
-               	umov.h	w1, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	mul.8h	v31, v31, v30
-               	stur	q31, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[1]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[2]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x70]
-               	mul.8h	v31, v31, v30
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xa0]
-               	ldur	q30, [x29, #-0x70]
-               	mul.8h	v31, v31, v30
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[0]
-<L29>:
-               	bl	 <L29>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[2]
-<L31>:
-               	bl	 <L31>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	add.8h	v0, v31, v30
-               	ldur	q30, [x29, #-0x70]
-               	mul.8h	v31, v0, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0xa0]
-               	sub.8h	v0, v31, v30
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	and.16b	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	orr.16b	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	eor.16b	v0, v31, v30
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0x90]
-               	mvn.16b	v0, v31
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xa0]
-               	mvn.16b	v0, v31
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor.16b	v0, v31, v30
-<L47>:
-               	bl	 <L47>
                	mov	x19, x0
                	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0xf0]
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0x100]
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0x70]
                	mul.8h	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	stur	q31, [x29, #-0xe0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q0, [x29, #-0xe0]
+<L18>:
+               	bl	 <L18>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xe0]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	stur	q31, [x29, #-0xf0]
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x50
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -672,104 +365,49 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xf0]
                	str	d31, [x0]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0x70]
                	mul.8h	v0, v31, v30
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0x100]
                	str	d31, [x0]
                	add	x0, x20, #0x20
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	eor.16b	v0, v31, v30
                	add	x0, x20, #0x28
                	str	d0, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x6
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	add	x0, x20, x21, lsl #3
-               	ldr	d31, [x0]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0x5c
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x3c
                	str	xzr, [x21]
                	str	wzr, [x21, #0x8]
                	add	x0, x21, #0x0
@@ -777,60 +415,59 @@ Disassembly of section __TEXT,__text:
                	strb	w17, [x0]
                	add	x1, x20, #0x10
                	ldr	d0, [x1]
-               	add	x20, x21, #0x2
-               	str	d0, [x20]
+               	add	x1, x21, #0x2
+               	str	d0, [x1]
                	add	x1, x21, #0xa
                	mov	w17, #0xad              ; =173
                	strb	w17, [x1]
                	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x2
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	d31, [x20]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0xa
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L77>:
-               	bl	 <L77>
-               	ldp	x19, x20, [x29, #-0x1e0]
-               	mov	x16, #0xfe18            ; =65048
+               	uxtb	w1, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_i16x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i16x8.dis
@@ -3,1237 +3,553 @@ vec/vec_i16x8.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_i16x8.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[0]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[1]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[2]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[3]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.h	w1, v0[4]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	umov.h	w1, v0[5]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	umov.h	w1, v0[6]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	umov.h	w1, v0[7]
+               	sxth	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.vec.vec_i16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0x3e9             ; =1001
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfbb1            ; =64433
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x4b7             ; =1207
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfaeb            ; =64235
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x581             ; =1409
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfa19            ; =64025
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x641             ; =1601
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xf953            ; =63827
+               	strh	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0xd               ; =13
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfff5            ; =65525
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               ; =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfff9            ; =65529
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x5               ; =5
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfffd            ; =65533
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x2               ; =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xffff            ; =65535
+               	strh	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               ; =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x2               ; =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x3               ; =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x4               ; =4
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x5               ; =5
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x6               ; =6
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x7               ; =7
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x8               ; =8
+               	strh	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strh	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov.h	w0, v0[0]
+               	add	w2, w0, w1
+               	mov.16b	v2, v0
+               	mov.h	v2[0], w2
+               	umov.h	w0, v2[6]
+               	add	w2, w0, w1
+               	mov.16b	v30, v2
+               	mov.h	v30[6], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov.h	w0, v1[2]
+               	add	w2, w0, w1
+               	mov.16b	v0, v1
+               	mov.h	v0[2], w2
+               	umov.h	w0, v0[7]
+               	add	w2, w0, w1
+               	mov.16b	v30, v0
+               	mov.h	v30[7], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0x3e9             ; =1001
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfbb1            ; =64433
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x4b7             ; =1207
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfaeb            ; =64235
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x581             ; =1409
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xfa19            ; =64025
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x641             ; =1601
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xf953            ; =63827
-               	strh	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	mov	w17, #0xd               ; =13
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfff5            ; =65525
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               ; =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfff9            ; =65529
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x5               ; =5
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xfffd            ; =65533
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x2               ; =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xffff            ; =65535
-               	strh	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               ; =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x2               ; =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x3               ; =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x4               ; =4
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x5               ; =5
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x6               ; =6
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x7               ; =7
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x8               ; =8
-               	strh	w17, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x8
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xa
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xc
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xe
-               	strh	wzr, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xd0]
-               	umov.h	w2, v0[0]
-               	add	w3, w2, w1
-               	mov.16b	v2, v0
-               	mov.h	v2[0], w3
-               	umov.h	w2, v2[6]
-               	add	w3, w2, w1
-               	mov.16b	v30, v2
-               	mov.h	v30[6], w3
-               	stur	q30, [x29, #-0xe0]
-               	umov.h	w2, v1[2]
-               	add	w3, w2, w1
-               	mov.16b	v0, v1
-               	mov.h	v0[2], w3
-               	umov.h	w2, v0[7]
-               	add	w3, w2, w1
-               	mov.16b	v30, v0
-               	mov.h	v30[7], w3
-               	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[4]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[5]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[6]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[7]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[4]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[5]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[6]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[7]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.8h	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[4]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[5]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[6]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[7]
-<L24>:
-               	bl	 <L24>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L32>:
-               	bl	 <L32>
+               	sub.8h	v0, v31, v30
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L40>:
-               	bl	 <L40>
+               	sub.8h	v0, v31, v30
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L48>:
-               	bl	 <L48>
+               	mul.8h	v0, v31, v30
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L56>:
-               	bl	 <L56>
+               	mul.8h	v0, v31, v30
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L64>:
-               	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.8h	v0, v31, v30
+               	mul.8h	v0, v31, v30
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v0, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L72>:
-               	bl	 <L72>
+               	mul.8h	v0, v31, v30
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L80>:
-               	bl	 <L80>
+               	sub.8h	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.8h	v0, v31, v30
-<L81>:
-               	bl	 <L81>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L82>:
-               	bl	 <L82>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L83>:
-               	bl	 <L83>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-<L84>:
-               	bl	 <L84>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-<L85>:
-               	bl	 <L85>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfe80            ; =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L87>:
-               	bl	 <L87>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-               	b	 <L121>
-<L88>:
-               	mov	x16, #0xfe50            ; =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul.8h	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
                	mov	x0, x19
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfe50            ; =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L120>:
-               	bl	 <L120>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-<L121>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1243,13 +559,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1258,7 +574,7 @@ Disassembly of section __TEXT,__text:
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1268,7 +584,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1276,89 +592,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-               	b	 <L131>
-<L122>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L130>:
-               	bl	 <L130>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-<L131>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -1371,94 +620,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L140>:
-               	bl	 <L140>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L141>:
-               	bl	 <L141>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_i32x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i32x4.dis
@@ -3,184 +3,235 @@ vec/vec_i32x4.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_i32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_i32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x230
-               	sub	x16, x29, #0x220
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1a0
+               	stp	x19, x20, [x29, #-0x190]
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
                	mov	w17, #0x2717            ; =10007
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0xb1d5            ; =45525
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x753d            ; =30013
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x8000            ; =32768
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
                	mov	w17, #0xfff9            ; =65529
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x83              ; =131
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0xfc0f            ; =64527
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
                	mov	w17, #0x1               ; =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x9               ; =9
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1b              ; =27
-               	str	w17, [x3]
-               	ldr	q31, [x2]
+               	str	w17, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	str	wzr, [x3]
-               	add	x3, x2, #0x4
-               	str	wzr, [x3]
-               	add	x3, x2, #0x8
-               	str	wzr, [x3]
-               	add	x3, x2, #0xc
-               	str	wzr, [x3]
-               	ldr	q31, [x2]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	str	wzr, [x2]
+               	add	x2, x0, #0x4
+               	str	wzr, [x2]
+               	add	x2, x0, #0x8
+               	str	wzr, [x2]
+               	add	x2, x0, #0xc
+               	str	wzr, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xd0]
-               	mov.s	w2, v0[0]
-               	add	w3, w2, w1
+               	mov.s	w0, v0[0]
+               	add	w2, w0, w1
                	mov.16b	v2, v0
-               	mov.s	v2[0], w3
-               	mov.s	w2, v2[2]
-               	add	w3, w2, w1
+               	mov.s	v2[0], w2
+               	mov.s	w0, v2[2]
+               	add	w2, w0, w1
                	mov.16b	v30, v2
-               	mov.s	v30[2], w3
+               	mov.s	v30[2], w2
                	stur	q30, [x29, #-0xe0]
-               	mov.s	w2, v1[1]
-               	add	w3, w2, w1
+               	mov.s	w0, v1[1]
+               	add	w2, w0, w1
                	mov.16b	v0, v1
-               	mov.s	v0[1], w3
-               	mov.s	w2, v0[3]
-               	add	w3, w2, w1
+               	mov.s	v0[1], w2
+               	mov.s	w0, v0[3]
+               	add	w2, w0, w1
                	mov.16b	v30, v0
-               	mov.s	v30[3], w3
+               	mov.s	v30[3], w2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.4s	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[3]
-<L12>:
-               	bl	 <L12>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v31, v31, v30
+               	sub.4s	v0, v31, v30
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.4s	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	mul.4s	v0, v31, v30
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.4s	v0, v31, v30
+<L9>:
+               	bl	 <L9>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub.4s	v0, v31, v30
+<L10>:
+               	bl	 <L10>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -190,24 +241,35 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L13>:
                	bl	 <L13>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
 <L15>:
                	bl	 <L15>
                	mov	x16, #0xfef0            ; =65264
@@ -215,537 +277,139 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.4s	v31, v31, v30
                	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.4s	v0, v31, v30
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v0, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.4s	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v0, v31, v30
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v0, v31, v30
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v0, v31
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v0, v31
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L47>:
-               	bl	 <L47>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfe50            ; =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul.4s	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.4s	v31, v31, v30
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe30            ; =65072
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe50            ; =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.4s	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -755,13 +419,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -770,7 +434,7 @@ Disassembly of section __TEXT,__text:
                	add.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -780,7 +444,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -788,57 +452,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -851,62 +480,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
-               	sub	x16, x29, #0x220
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x190]
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_i64x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i64x2.dis
@@ -3,39 +3,57 @@ vec/vec_i64x2.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_i64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov.d	x1, v0[0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.d	x1, v0[1]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_i64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0x10
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	x17, #0xca07            ; =51719
                	movk	x17, #0x3b9a, lsl #16
@@ -47,7 +65,7 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
+               	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	x17, #0x5e13            ; =24083
                	movk	x17, #0xb2d0, lsl #16
@@ -59,7 +77,7 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q1, [x1]
-               	sub	x1, x29, #0x30
+               	sub	x1, x29, #0xa0
                	add	x2, x1, #0x0
                	mov	x17, #0x1               ; =1
                	str	x17, [x2]
@@ -68,7 +86,7 @@ Disassembly of section __TEXT,__text:
                	str	x17, [x2]
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xc0]
-               	sub	x1, x29, #0x40
+               	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
                	add	x2, x1, #0x8
@@ -76,345 +94,205 @@ Disassembly of section __TEXT,__text:
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xd0]
                	mov.d	x1, v0[0]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov.16b	v30, v0
                	mov.d	v30[0], x2
                	stur	q30, [x29, #-0xe0]
                	mov.d	x1, v1[1]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov.16b	v30, v1
                	mov.d	v30[1], x2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[0]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[1]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub.2d	v0, v31, v30
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.2d	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
                	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xe0]
+               	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
                	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L7>:
                	bl	 <L7>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
+               	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0x100]
                	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0x100]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.2d	v0, v31, v30
-               	mov.d	x1, v0[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	mov.d	x1, v0[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	mov.16b	v1, v0
-               	mov.d	v1[0], x3
-               	mov.16b	v30, v1
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L18>:
-               	bl	 <L18>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L20>:
-               	bl	 <L20>
+               	sub.2d	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.2d	v0, v31, v30
-<L21>:
-               	bl	 <L21>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L23>:
-               	bl	 <L23>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-<L24>:
-               	bl	 <L24>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-<L25>:
-               	bl	 <L25>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe80            ; =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L27>:
-               	bl	 <L27>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-               	b	 <L37>
-<L28>:
-               	mov	x16, #0xfe60            ; =65120
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -423,7 +301,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -432,7 +310,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -441,156 +319,120 @@ Disassembly of section __TEXT,__text:
                	mov.d	v0[0], x2
                	mov.16b	v30, v0
                	mov.d	v30[1], x3
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
                	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe60            ; =65120
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L36>:
-               	bl	 <L36>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-<L37>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -600,13 +442,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -615,7 +457,7 @@ Disassembly of section __TEXT,__text:
                	add.2d	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -624,7 +466,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -633,7 +475,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -645,7 +487,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -653,41 +495,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-               	b	 <L41>
-<L38>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L40>:
-               	bl	 <L40>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-<L41>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -700,46 +523,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L44>:
-               	bl	 <L44>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L45>:
-               	bl	 <L45>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_i8x16.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i8x16.dis
@@ -3,124 +3,326 @@ vec/vec_i8x16.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_i8x16.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[0]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[1]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[2]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[3]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[4]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[5]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[6]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[7]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.b	w1, v0[8]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov.b	w1, v0[9]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov.b	w1, v0[10]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov.b	w1, v0[11]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov.b	w1, v0[12]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov.b	w1, v0[13]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov.b	w1, v0[14]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov.b	w1, v0[15]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_i8x16.checksum>:
@@ -133,290 +335,268 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xf7              ; =247
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x7               ; =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfb              ; =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0xff              ; =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfc              ; =252
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x6               ; =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xf8              ; =248
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x9               ; =9
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfd              ; =253
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0xfe              ; =254
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x4               ; =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xfa              ; =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x8               ; =8
+               	strb	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0xfd              ; =253
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x4               ; =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0xfb              ; =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x6               ; =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0xf9              ; =249
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x8               ; =8
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0xf7              ; =247
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0xfe              ; =254
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0xfc              ; =252
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x5               ; =5
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0xfa              ; =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x7               ; =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xff              ; =255
+               	strb	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x1
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x3
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x5
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x7
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xb
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xd
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xf
+               	strb	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov.b	w0, v0[0]
+               	add	w2, w0, w1
+               	mov.16b	v2, v0
+               	mov.b	v2[0], w2
+               	umov.b	w0, v2[7]
+               	add	w2, w0, w1
+               	mov.16b	v30, v2
+               	mov.b	v30[7], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov.b	w0, v1[3]
+               	add	w2, w0, w1
+               	mov.16b	v0, v1
+               	mov.b	v0[3], w2
+               	umov.b	w0, v0[12]
+               	add	w2, w0, w1
+               	mov.16b	v30, v0
+               	mov.b	v30[12], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	sub	x3, x29, #0x10
-               	add	x4, x3, #0x0
-               	mov	w17, #0xf7              ; =247
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x7               ; =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0xfb              ; =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0xff              ; =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0xfc              ; =252
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x6               ; =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0xf8              ; =248
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x9               ; =9
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0xfd              ; =253
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0xfe              ; =254
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x4               ; =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0xfa              ; =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x8               ; =8
-               	strb	w17, [x4]
-               	ldr	q0, [x3]
-               	sub	x3, x29, #0x20
-               	add	x4, x3, #0x0
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0xfd              ; =253
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x4               ; =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0xfb              ; =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x6               ; =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0xf9              ; =249
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x8               ; =8
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0xf7              ; =247
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0xfe              ; =254
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0xfc              ; =252
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x5               ; =5
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0xfa              ; =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x7               ; =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xff              ; =255
-               	strb	w17, [x4]
-               	ldr	q1, [x3]
-               	sub	x3, x29, #0x30
-               	add	x4, x3, #0x0
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x3, x29, #0x40
-               	add	x4, x3, #0x0
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x1
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x2
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x3
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x4
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x5
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x6
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x7
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xa
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xb
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xc
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xd
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xe
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xf
-               	strb	wzr, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xd0]
-               	umov.b	w3, v0[0]
-               	add	w4, w3, w2
-               	mov.16b	v2, v0
-               	mov.b	v2[0], w4
-               	umov.b	w3, v2[7]
-               	add	w4, w3, w2
-               	mov.16b	v30, v2
-               	mov.b	v30[7], w4
-               	stur	q30, [x29, #-0xe0]
-               	umov.b	w3, v1[3]
-               	add	w4, w3, w2
-               	mov.16b	v0, v1
-               	mov.b	v0[3], w4
-               	umov.b	w3, v0[12]
-               	add	w4, w3, w2
-               	mov.16b	v30, v0
-               	mov.b	v30[12], w4
-               	stur	q30, [x29, #-0xf0]
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xf0]
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.16b	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	mov	x0, x1
                	ldur	q0, [x29, #-0x100]
-<L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
@@ -425,15 +605,13 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
@@ -442,34 +620,26 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-               	mov	x0, x1
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-               	mov	x0, x1
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-               	mov	x0, x1
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -481,9 +651,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfec0            ; =65216
@@ -505,9 +674,9 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x3
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -526,8 +695,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -549,8 +718,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -572,8 +741,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -591,8 +760,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
                	mov	x16, #0xfe70            ; =65136
@@ -626,9 +795,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x3
-               	b.lo	 <L18>
-<L23>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -671,51 +840,55 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q0, [x1]
                	mov	x0, x19
-<L25>:
-               	bl	 <L25>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-<L26>:
-               	sub	x0, x29, #0xb0
-               	str	xzr, [x0]
-               	str	xzr, [x0, #0x8]
-               	str	xzr, [x0, #0x10]
-               	str	xzr, [x0, #0x18]
-               	str	xzr, [x0, #0x20]
-               	str	xzr, [x0, #0x28]
-               	add	x1, x0, #0x0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
+               	str	xzr, [x21]
+               	str	xzr, [x21, #0x8]
+               	str	xzr, [x21, #0x10]
+               	str	xzr, [x21, #0x18]
+               	str	xzr, [x21, #0x20]
+               	str	xzr, [x21, #0x28]
+               	add	x0, x21, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x2, x20, #0x20
-               	ldr	q0, [x2]
-               	add	x20, x0, #0x10
-               	str	q0, [x20]
-               	add	x21, x0, #0x20
+               	str	w17, [x0]
+               	add	x1, x20, #0x20
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x21]
-               	ldr	w2, [x1]
+               	str	w17, [x1]
+               	ldr	w1, [x0]
+               	mov	w2, w1
                	mov	x0, x19
-               	mov	w1, w2
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	add	x1, x21, #0x10
+               	ldr	q0, [x1]
 <L27>:
                	bl	 <L27>
-               	ldr	q0, [x20]
+               	add	x1, x21, #0x20
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L28>:
                	bl	 <L28>
-               	ldr	w1, [x21]
-<L29>:
-               	bl	 <L29>
                	ldp	x19, x20, [x29, #-0x1a0]
                	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16

--- a/test/golden/aarch64-darwin/vec/vec_lane_ops.dis
+++ b/test/golden/aarch64-darwin/vec/vec_lane_ops.dis
@@ -3,213 +3,409 @@ vec/vec_lane_ops.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_lane_ops.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[0]
-               	mov	x0, x1
+               	mov	d1, v0[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_i8x16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[0]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[1]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[2]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[3]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[4]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v31[5]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[12]
-               	mov	x0, x1
+               	umov.b	w1, v31[6]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[13]
-               	mov	x0, x1
+               	umov.b	w1, v31[7]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[14]
-               	mov	x0, x1
+               	umov.b	w1, v31[8]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[15]
-               	mov	x0, x1
+               	umov.b	w1, v31[9]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L15>:
                	bl	 <L15>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[10]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[11]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L17>:
+               	bl	 <L17>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[12]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L18>:
+               	bl	 <L18>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[13]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L19>:
+               	bl	 <L19>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[14]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	ldur	q31, [x29, #-0x10]
+               	umov.b	w1, v31[15]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L21>:
+               	bl	 <L21>
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -217,390 +413,165 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x260
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stur	x23, [x16, #-0x18]
-               	sub	x16, x29, #0x288
-               	stp	d8, d9, [x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
-               	mov	w20, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1c0
+               	stp	x19, x20, [x29, #-0x170]
+               	stp	x21, x22, [x29, #-0x180]
+               	stp	x23, x24, [x29, #-0x190]
+               	stp	x25, x26, [x29, #-0x1a0]
+               	stp	d8, d9, [x29, #-0x1b0]
+               	stp	d10, d11, [x29, #-0x1c0]
+               	mov	w1, w0
+               	ucvtf	s8, x0
+               	ucvtf	d9, x0
+               	mov	w19, w0
+               	sub	x0, x29, #0x10
+               	add	x2, x0, #0x0
                	mov	w17, #0x1111            ; =4369
                	movk	w17, #0x1111, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x2222            ; =8738
                	movk	w17, #0x2222, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x3333            ; =13107
                	movk	w17, #0x3333, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x4444            ; =17476
                	movk	w17, #0x4444, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	mov.s	w2, v0[0]
-               	add	w3, w2, w1
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	mov.s	w0, v0[0]
+               	add	w2, w0, w1
                	mov.16b	v1, v0
-               	mov.s	v1[0], w3
-               	mov.s	w2, v1[3]
-               	add	w3, w2, w1
+               	mov.s	v1[0], w2
+               	mov.s	w0, v1[3]
+               	add	w2, w0, w1
                	mov.16b	v30, v1
-               	mov.s	v30[3], w3
+               	mov.s	v30[3], w2
                	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xf0]
+<L0>:
+               	bl	 <L0>
+               	sub	x20, x29, #0x20
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
                	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
+               	mov.s	w21, v31[3]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[0], w21
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w22, v31[2]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[1], w22
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w23, v31[1]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[2], w23
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w24, v31[0]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[3], w24
+               	str	q1, [x20]
+               	ldr	q0, [x20]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
+               	sub	x25, x29, #0x30
+               	str	xzr, [x25]
+               	str	xzr, [x25, #0x8]
+               	ldr	q0, [x25]
+               	mov.16b	v1, v0
+               	mov.s	v1[0], w23
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov.16b	v1, v0
+               	mov.s	v1[1], w22
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov.16b	v1, v0
+               	mov.s	v1[2], w21
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov.16b	v1, v0
+               	mov.s	v1[3], w24
+               	str	q1, [x25]
+               	ldr	q0, [x25]
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
+               	sub	x26, x29, #0x40
+               	str	xzr, [x26]
+               	str	xzr, [x26, #0x8]
+               	ldr	q0, [x26]
+               	mov.16b	v1, v0
+               	mov.s	v1[0], w22
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov.16b	v1, v0
+               	mov.s	v1[1], w21
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov.16b	v1, v0
+               	mov.s	v1[2], w24
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov.16b	v1, v0
+               	mov.s	v1[3], w23
+               	str	q1, [x26]
+               	ldr	q0, [x26]
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	sub	x19, x29, #0x20
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-               	ldr	q0, [x19]
-               	mov.16b	v1, v0
-               	mov.s	v1[0], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
-               	ldr	q0, [x19]
-               	mov.16b	v1, v0
-               	mov.s	v1[1], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
-               	ldr	q0, [x19]
-               	mov.16b	v1, v0
-               	mov.s	v1[2], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-               	ldr	q0, [x19]
-               	mov.16b	v1, v0
-               	mov.s	v1[3], w1
-               	str	q1, [x19]
-               	ldr	q31, [x19]
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[3]
-<L8>:
-               	bl	 <L8>
-               	sub	x21, x29, #0x30
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
-               	ldr	q0, [x21]
-               	mov.16b	v1, v0
-               	mov.s	v1[0], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
-               	ldr	q0, [x21]
-               	mov.16b	v1, v0
-               	mov.s	v1[1], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-               	ldr	q0, [x21]
-               	mov.16b	v1, v0
-               	mov.s	v1[2], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-               	ldr	q0, [x21]
-               	mov.16b	v1, v0
-               	mov.s	v1[3], w1
-               	str	q1, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L12>:
-               	bl	 <L12>
-               	sub	x22, x29, #0x40
-               	str	xzr, [x22]
-               	str	xzr, [x22, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
-               	ldr	q0, [x22]
-               	mov.16b	v1, v0
-               	mov.s	v1[0], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-               	ldr	q0, [x22]
-               	mov.16b	v1, v0
-               	mov.s	v1[1], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-               	ldr	q0, [x22]
-               	mov.16b	v1, v0
-               	mov.s	v1[2], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
-               	ldr	q0, [x22]
-               	mov.16b	v1, v0
-               	mov.s	v1[3], w1
-               	str	q1, [x22]
-               	ldr	q31, [x22]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L16>:
-               	bl	 <L16>
                	sub	x1, x29, #0x50
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w2, v31[2]
                	ldr	q0, [x1]
                	mov.16b	v1, v0
-               	mov.s	v1[0], w2
+               	mov.s	v1[0], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov.16b	v1, v0
-               	mov.s	v1[1], w2
+               	mov.s	v1[1], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov.16b	v1, v0
-               	mov.s	v1[2], w2
+               	mov.s	v1[2], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov.16b	v1, v0
-               	mov.s	v1[3], w2
+               	mov.s	v1[3], w22
                	str	q1, [x1]
-               	ldr	q31, [x1]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L20>:
-               	bl	 <L20>
+               	ldr	q0, [x1]
+<L4>:
+               	bl	 <L4>
                	sub	x1, x29, #0x60
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w2, v31[0]
                	ldr	q0, [x1]
                	mov.16b	v1, v0
-               	mov.s	v1[1], w2
+               	mov.s	v1[1], w24
                	str	q1, [x1]
-               	ldr	q31, [x1]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x1]
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xf0]
                	mov.16b	v0, v31
-               	mov.s	v0[1], w1
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-               	mov.16b	v30, v0
-               	mov.s	v30[1], w1
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L28>:
-               	bl	 <L28>
+               	mov.s	v0[1], w24
+               	mov.16b	v1, v0
+               	mov.s	v1[1], w21
+               	mov.16b	v0, v1
+<L6>:
+               	bl	 <L6>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -611,288 +582,132 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0xc
                	str	wzr, [x2]
                	ldr	q0, [x1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-               	add	w2, w1, #0x1
+               	add	w1, w24, #0x1
                	mov.16b	v30, v0
-               	mov.s	v30[0], w2
-               	mov	x16, #0xfea0            ; =65184
+               	mov.s	v30[0], w1
+               	stur	q30, [x29, #-0x100]
+               	ldur	q31, [x29, #-0x100]
+               	mov.s	w1, v31[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	mov.s	w1, v31[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w2, v31[1]
+               	add	w3, w1, w2
+               	ldur	q31, [x29, #-0x100]
+               	mov.16b	v30, v31
+               	mov.s	v30[1], w3
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w23, v31[0]
-               	mov	w1, w23
-<L29>:
-               	bl	 <L29>
-               	ldur	q31, [x29, #-0xf0]
                	mov.s	w1, v31[1]
-               	add	w2, w23, w1
-               	mov	x16, #0xfea0            ; =65184
+               	mov	w2, w1
+               	mov	x1, x2
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w2, v31[2]
+               	eor	w3, w1, w2
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.16b	v30, v31
-               	mov.s	v30[1], w2
-               	mov	x16, #0xfe90            ; =65168
+               	mov.s	v30[2], w3
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w23, v31[1]
-               	mov	w1, w23
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
                	mov.s	w1, v31[2]
-               	eor	w2, w23, w1
-               	mov	x16, #0xfe90            ; =65168
+               	mov	w2, w1
+               	mov	x1, x2
+<L9>:
+               	bl	 <L9>
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.s	w1, v31[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.s	w2, v31[3]
+               	sub	w3, w1, w2
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.16b	v30, v31
-               	mov.s	v30[2], w2
-               	mov	x16, #0xfe80            ; =65152
+               	mov.s	v30[3], w3
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w23, v31[2]
-               	mov	w1, w23
-<L31>:
-               	bl	 <L31>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-               	sub	w2, w23, w1
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.16b	v30, v31
-               	mov.s	v30[3], w2
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[3]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	w2, w1
+               	mov	x1, x2
+<L10>:
+               	bl	 <L10>
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	ldr	q0, [x19]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldr	q0, [x20]
                	ldur	q30, [x29, #-0xf0]
-               	add.4s	v31, v0, v30
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L40>:
-               	bl	 <L40>
-               	ldr	q0, [x21]
+               	add.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L12>:
+               	bl	 <L12>
+               	ldr	q0, [x25]
                	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v31, v0, v30
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L44>:
-               	bl	 <L44>
-               	ldr	q0, [x22]
+               	sub.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L13>:
+               	bl	 <L13>
+               	ldr	q0, [x26]
                	ldur	q30, [x29, #-0xf0]
-               	mul.4s	v31, v0, v30
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L48>:
-               	bl	 <L48>
-               	ldr	q0, [x19]
-               	ldr	q1, [x21]
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L52>:
-               	bl	 <L52>
+               	mul.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L14>:
+               	bl	 <L14>
+               	ldr	q0, [x20]
+               	ldr	q1, [x25]
+               	eor.16b	v2, v0, v1
+               	mov.16b	v0, v2
+<L15>:
+               	bl	 <L15>
                	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
@@ -913,261 +728,118 @@ Disassembly of section __TEXT,__text:
                	fadd	s2, s1, s8
                	mov.16b	v30, v0
                	mov.s	v30[1], v2[0]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe20            ; =65056
+               	ldr	q0, [x29, x16]
+<L16>:
+               	bl	 <L16>
+               	sub	x20, x29, #0x90
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31[3]
-<L56>:
-               	bl	 <L56>
-               	sub	x19, x29, #0x90
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov.16b	v2, v1
                	mov.s	v2[0], v0[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            ; =65056
+               	str	q2, [x20]
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-               	ldr	q1, [x19]
-               	mov.16b	v2, v1
-               	mov.s	v2[1], v0[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	s10, v31[2]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[1], v10[0]
+               	str	q1, [x20]
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31[1]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov.16b	v2, v1
                	mov.s	v2[2], v0[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            ; =65056
+               	str	q2, [x20]
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	ldr	q1, [x19]
-               	mov.16b	v2, v1
-               	mov.s	v2[3], v0[0]
-               	str	q2, [x19]
-               	ldr	q31, [x19]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L60>:
-               	bl	 <L60>
+               	mov	s11, v31[0]
+               	ldr	q0, [x20]
+               	mov.16b	v1, v0
+               	mov.s	v1[3], v11[0]
+               	str	q1, [x20]
+               	ldr	q0, [x20]
+<L17>:
+               	bl	 <L17>
                	sub	x21, x29, #0xa0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	ldr	q1, [x21]
-               	mov.16b	v2, v1
-               	mov.s	v2[0], v0[0]
-               	str	q2, [x21]
-               	ldr	q0, [x19]
+               	ldr	q0, [x21]
+               	mov.16b	v1, v0
+               	mov.s	v1[0], v11[0]
+               	str	q1, [x21]
+               	ldr	q0, [x20]
                	mov	s1, v0[1]
                	ldr	q0, [x21]
                	mov.16b	v2, v0
                	mov.s	v2[1], v1[0]
                	str	q2, [x21]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-               	ldr	q1, [x21]
-               	mov.16b	v2, v1
-               	mov.s	v2[2], v0[0]
-               	str	q2, [x21]
-               	ldr	q0, [x19]
+               	ldr	q0, [x21]
+               	mov.16b	v1, v0
+               	mov.s	v1[2], v10[0]
+               	str	q1, [x21]
+               	ldr	q0, [x20]
                	mov	s1, v0[3]
                	ldr	q0, [x21]
                	mov.16b	v2, v0
                	mov.s	v2[3], v1[0]
                	str	q2, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L64>:
-               	bl	 <L64>
                	ldr	q0, [x21]
-               	ldr	q1, [x19]
-               	fmul.4s	v31, v0, v1
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdf0            ; =65008
+<L18>:
+               	bl	 <L18>
+               	ldr	q0, [x21]
+               	ldr	q1, [x20]
+               	fmul.4s	v2, v0, v1
+               	mov.16b	v0, v2
+<L19>:
+               	bl	 <L19>
+               	ldr	q0, [x20]
+               	mov	s1, v0[0]
+               	fsub	s0, s11, s1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	ldr	q1, [x19]
-               	mov	s2, v1[0]
-               	fsub	s1, s0, s2
-               	fmov	s0, s1
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	s2, v1[3]
                	fsub	s1, s0, s2
-               	fmov	s0, s1
-<L70>:
-               	bl	 <L70>
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L21>:
+               	bl	 <L21>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 ; =4609434218613702656
@@ -1180,100 +852,54 @@ Disassembly of section __TEXT,__text:
                	fadd	d2, d1, d9
                	mov.16b	v30, v0
                	mov.d	v30[0], v2[0]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	sub	x19, x29, #0xc0
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfde0            ; =64992
+               	sub	x20, x29, #0xc0
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	d0, v31[1]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov.16b	v2, v1
                	mov.d	v2[0], v0[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfde0            ; =64992
+               	str	q2, [x20]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	d0, v31[0]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov.16b	v2, v1
                	mov.d	v2[1], v0[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfde0            ; =64992
+               	str	q2, [x20]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x19]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L74>:
-               	bl	 <L74>
-               	ldr	q0, [x19]
-               	mov	x16, #0xfde0            ; =64992
+               	ldr	q0, [x29, x16]
+<L22>:
+               	bl	 <L22>
+               	ldr	q0, [x20]
+<L23>:
+               	bl	 <L23>
+               	ldr	q0, [x20]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub.2d	v31, v0, v30
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[0]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31[1]
-<L76>:
-               	bl	 <L76>
+               	fsub.2d	v1, v0, v30
+               	mov.16b	v0, v1
+<L24>:
+               	bl	 <L24>
                	sub	x1, x29, #0xd0
                	add	x2, x1, #0x0
                	mov	w17, #0xf7              ; =247
@@ -1325,29 +951,29 @@ Disassembly of section __TEXT,__text:
                	strb	w17, [x2]
                	ldr	q0, [x1]
                	umov.b	w1, v0[0]
-               	add	w2, w1, w20
+               	add	w2, w1, w19
                	mov.16b	v1, v0
                	mov.b	v1[0], w2
                	umov.b	w1, v1[15]
-               	add	w2, w1, w20
+               	add	w2, w1, w19
                	mov.16b	v30, v1
                	mov.b	v30[15], w2
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L77>:
-               	bl	 <L77>
+<L25>:
+               	bl	 <L25>
                	sub	x19, x29, #0xe0
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1357,7 +983,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[0], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1367,7 +993,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[1], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1377,7 +1003,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[2], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1387,7 +1013,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[3], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1397,7 +1023,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[4], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1407,7 +1033,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[5], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1417,7 +1043,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[6], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1427,7 +1053,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[7], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1437,7 +1063,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[8], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1447,7 +1073,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[9], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1457,7 +1083,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[10], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1467,7 +1093,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[11], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1477,7 +1103,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[12], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1487,7 +1113,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[13], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1497,7 +1123,7 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.b	v1[14], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1508,34 +1134,34 @@ Disassembly of section __TEXT,__text:
                	mov.b	v1[15], w1
                	str	q1, [x19]
                	ldr	q0, [x19]
-<L78>:
-               	bl	 <L78>
+<L26>:
+               	bl	 <L26>
                	ldr	q0, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.16b	v1, v0, v30
                	mov.16b	v0, v1
-<L79>:
-               	bl	 <L79>
+<L27>:
+               	bl	 <L27>
                	ldr	q0, [x19]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v1, v0, v30
                	mov.16b	v0, v1
-<L80>:
-               	bl	 <L80>
-               	sub	x16, x29, #0x288
-               	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x260
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldur	x23, [x16, #-0x18]
+<L28>:
+               	bl	 <L28>
+               	ldp	d8, d9, [x29, #-0x1b0]
+               	ldp	d10, d11, [x29, #-0x1c0]
+               	ldp	x19, x20, [x29, #-0x170]
+               	ldp	x21, x22, [x29, #-0x180]
+               	ldp	x23, x24, [x29, #-0x190]
+               	ldp	x25, x26, [x29, #-0x1a0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_mem.dis
+++ b/test/golden/aarch64-darwin/vec/vec_mem.dis
@@ -3,74 +3,190 @@ vec/vec_mem.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_mem.fold3>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.vec.vec_mem.fold5>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stur	x19, [x29, #-0x78]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x14
-               	sub	x1, x29, #0x28
-               	sub	x1, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x70
+               	sub	x2, x29, #0x14
+               	sub	x2, x29, #0x28
+               	sub	x2, x29, #0x3c
+               	sub	x2, x29, #0x50
+               	sub	x2, x29, #0x64
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldur	x19, [x29, #-0x78]
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	x2, x1, #0xc
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              ; =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -78,207 +194,173 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_mem.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x9b0
-               	sub	x16, x29, #0x960
+               	sub	sp, sp, #0x810
+               	sub	x16, x29, #0x7c0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x9b0
+               	sub	x16, x29, #0x810
                	str	d8, [x16, #0x8]
-               	mov	x19, x0
-               	sub	x20, x29, #0x14
-               	sub	x21, x29, #0x28
-               	sub	x22, x29, #0x3c
-               	sub	x23, x29, #0x50
-               	sub	x24, x29, #0x64
-               	sub	x25, x29, #0x78
-               	sub	x26, x29, #0x8c
-               	sub	x27, x29, #0xa0
-               	sub	x28, x29, #0xb4
-               	sub	x9, x29, #0xc8
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x19, x29, #0x14
+               	sub	x20, x29, #0x28
+               	sub	x21, x29, #0x3c
+               	sub	x22, x29, #0x50
+               	sub	x23, x29, #0x64
+               	sub	x24, x29, #0x78
+               	sub	x25, x29, #0x8c
+               	sub	x26, x29, #0xa0
+               	sub	x27, x29, #0xb4
+               	sub	x28, x29, #0xc8
                	sub	x9, x29, #0xdc
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0xf0
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x104
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x118
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x12c
-               	mov	x16, #0xf7d8            ; =63448
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x140
-               	mov	x16, #0xf7d0            ; =63440
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x154
-               	mov	x16, #0xf7c8            ; =63432
+               	mov	x16, #0xf8d0            ; =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x168
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x17c
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x190
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x1, x29, #0x1a4
-               	sub	x1, x29, #0x1b8
-               	sub	x1, x29, #0x1cc
-               	sub	x1, x29, #0x1e0
-               	sub	x1, x29, #0x1f4
-               	sub	x1, x29, #0x208
-               	sub	x1, x29, #0x21c
-               	sub	x1, x29, #0x230
-               	sub	x1, x29, #0x244
-               	sub	x1, x29, #0x258
-               	sub	x1, x29, #0x26c
-               	sub	x1, x29, #0x280
-               	sub	x1, x29, #0x294
-               	sub	x1, x29, #0x2a8
-               	sub	x1, x29, #0x2bc
-               	sub	x1, x29, #0x2d0
-               	sub	x1, x29, #0x2e4
-               	sub	x1, x29, #0x2f8
-               	sub	x1, x29, #0x30c
-               	sub	x1, x29, #0x320
-               	sub	x1, x29, #0x334
-               	sub	x1, x29, #0x348
-               	sub	x1, x29, #0x35c
-               	sub	x1, x29, #0x370
-               	sub	x1, x29, #0x384
-<L0>:
-               	bl	 <L0>
-               	mov	x9, x0
-               	mov	x16, #0xf878            ; =63608
+               	ucvtf	s8, x0
+               	sub	x9, x29, #0x384
+               	mov	x16, #0xf920            ; =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf878            ; =63608
+               	mov	x16, #0xf920            ; =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ucvtf	s8, x19
-               	sub	x19, x29, #0x3d8
-               	add	x1, x19, #0x0
-               	add	x0, x1, #0x0
-               	mov	x1, #0x50               ; =80
-<L1>:
-               	str	xzr, [x0]
-               	add	x0, x0, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	str	wzr, [x0]
+               	add	x0, x9, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               ; =80
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	str	wzr, [x1]
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x7
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
-               	mov	x16, #0xf870            ; =63600
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ucvtf	s0, x9
-               	sub	x1, x29, #0x3e4
+               	sub	x1, x29, #0x19c
                	str	xzr, [x1]
                	str	wzr, [x1, #0x8]
                	fadd	s1, s0, s8
-               	mov	x16, #0xfc0c            ; =64524
+               	mov	x16, #0xfe54            ; =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfc14            ; =64532
+               	mov	x16, #0xfe5c            ; =65116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
                	ldr	x0, [x1]
-               	mov	x16, #0xfc0c            ; =64524
+               	mov	x16, #0xfe54            ; =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
                	ldr	w0, [x1, #0x8]
-               	mov	x16, #0xfc14            ; =64532
+               	mov	x16, #0xfe5c            ; =65116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfc0c            ; =64524
+               	mov	x16, #0xfe54            ; =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
                	mov.16b	v3, v2
                	mov.s	v3[0], v1[0]
-               	mov	x16, #0xfbfc            ; =64508
+               	mov	x16, #0xfe44            ; =65092
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q3, [x29, x16]
-               	mov	x16, #0xfbfc            ; =64508
+               	mov	x16, #0xfe44            ; =65092
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
                	str	x0, [x1]
-               	mov	x16, #0xfc04            ; =64516
+               	mov	x16, #0xfe4c            ; =65100
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -286,47 +368,47 @@ Disassembly of section __TEXT,__text:
                	str	w0, [x1, #0x8]
                	fmov	s30, #1.25000000
                	fsub	s1, s0, s30
-               	mov	x16, #0xfbec            ; =64492
+               	mov	x16, #0xfe34            ; =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfbf4            ; =64500
+               	mov	x16, #0xfe3c            ; =65084
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
                	ldr	x0, [x1]
-               	mov	x16, #0xfbec            ; =64492
+               	mov	x16, #0xfe34            ; =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
                	ldr	w0, [x1, #0x8]
-               	mov	x16, #0xfbf4            ; =64500
+               	mov	x16, #0xfe3c            ; =65084
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfbec            ; =64492
+               	mov	x16, #0xfe34            ; =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
                	mov.16b	v3, v2
                	mov.s	v3[1], v1[0]
-               	mov	x16, #0xfbdc            ; =64476
+               	mov	x16, #0xfe24            ; =65060
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q3, [x29, x16]
-               	mov	x16, #0xfbdc            ; =64476
+               	mov	x16, #0xfe24            ; =65060
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
                	str	x0, [x1]
-               	mov	x16, #0xfbe4            ; =64484
+               	mov	x16, #0xfe2c            ; =65068
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -335,419 +417,435 @@ Disassembly of section __TEXT,__text:
                	mov	w16, #0x42c80000        ; =1120403456
                	fmov	s31, w16
                	fsub	s1, s31, s0
-               	mov	x16, #0xfbcc            ; =64460
+               	mov	x16, #0xfe14            ; =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfbd4            ; =64468
+               	mov	x16, #0xfe1c            ; =65052
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
                	ldr	x0, [x1]
-               	mov	x16, #0xfbcc            ; =64460
+               	mov	x16, #0xfe14            ; =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
                	ldr	w0, [x1, #0x8]
-               	mov	x16, #0xfbd4            ; =64468
+               	mov	x16, #0xfe1c            ; =65052
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfbcc            ; =64460
+               	mov	x16, #0xfe14            ; =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
                	mov.16b	v2, v0
                	mov.s	v2[2], v1[0]
-               	mov	x16, #0xfbbc            ; =64444
+               	mov	x16, #0xfe04            ; =65028
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q2, [x29, x16]
-               	mov	x16, #0xfbbc            ; =64444
+               	mov	x16, #0xfe04            ; =65028
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
                	str	x0, [x1]
-               	mov	x16, #0xfbc4            ; =64452
+               	mov	x16, #0xfe0c            ; =65036
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
                	str	w0, [x1, #0x8]
-               	mov	x16, #0xfbac            ; =64428
+               	mov	x16, #0xfdf4            ; =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfbb4            ; =64436
+               	mov	x16, #0xfdfc            ; =65020
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
                	ldr	x0, [x1]
-               	mov	x16, #0xfbac            ; =64428
+               	mov	x16, #0xfdf4            ; =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
                	ldr	w0, [x1, #0x8]
-               	mov	x16, #0xfbb4            ; =64436
+               	mov	x16, #0xfdfc            ; =65020
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfbac            ; =64428
+               	mov	x16, #0xfdf4            ; =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
                	mul	x0, x9, x16
-               	add	x1, x19, x0
-               	mov	x16, #0xfb9c            ; =64412
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, x0
+               	mov	x16, #0xfde4            ; =64996
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xfb9c            ; =64412
+               	mov	x16, #0xfde4            ; =64996
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
                	str	x0, [x1]
-               	mov	x16, #0xfba4            ; =64420
+               	mov	x16, #0xfdec            ; =65004
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
                	str	w0, [x1, #0x8]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1
                	mov	x9, x0
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xfa60            ; =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x7
-               	b.lo	 <L2>
-<L3>:
-               	mov	x16, #0xf878            ; =63608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	mov	x9, x10
-               	mov	x16, #0xf7a8            ; =63400
+               	b.lo	 <L1>
+<L2>:
+               	mov	x9, #0x2325             ; =8997
+               	movk	x9, #0x8422, lsl #16
+               	movk	x9, #0x9ce4, lsl #32
+               	movk	x9, #0xcbf2, lsl #48
+               	mov	x16, #0xf910            ; =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x7                ; =7
-               	mov	x16, #0xf7a0            ; =63392
+               	mov	x16, #0xf908            ; =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7a0            ; =63392
+               	mov	x16, #0xf908            ; =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x17, #0x0               ; =0
                	cmp	x17, x9
-               	b.lo	 <L4>
-               	b	 <L8>
-<L4>:
-               	mov	x16, #0xf7a0            ; =63392
+               	b.lo	 <L3>
+               	b	 <L5>
+<L3>:
+               	mov	x16, #0xf908            ; =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	sub	x9, x10, #0x1
-               	mov	x16, #0xf7c0            ; =63424
+               	mov	x16, #0xf918            ; =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7c0            ; =63424
+               	mov	x16, #0xf918            ; =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
                	mul	x0, x9, x16
-               	add	x9, x19, x0
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xfa50            ; =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfb8c            ; =64396
+               	mov	x16, #0xfdd4            ; =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfb94            ; =64404
+               	mov	x16, #0xfddc            ; =64988
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xfa50            ; =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfb8c            ; =64396
+               	mov	x16, #0xfdd4            ; =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xfa50            ; =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfb94            ; =64404
+               	mov	x16, #0xfddc            ; =64988
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfb8c            ; =64396
+               	mov	x16, #0xfdd4            ; =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf7b0            ; =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf7b0            ; =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	mov	x16, #0xf7a8            ; =63400
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf910            ; =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-<L5>:
-               	bl	 <L5>
-               	mov	x16, #0xf7b0            ; =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L6>:
-               	bl	 <L6>
-               	mov	x16, #0xf7b0            ; =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L7>:
-               	bl	 <L7>
+<L4>:
+               	bl	 <L4>
                	mov	x9, x0
-               	mov	x16, #0xf7a8            ; =63400
+               	mov	x16, #0xf910            ; =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7c0            ; =63424
+               	mov	x16, #0xf918            ; =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	mov	x16, #0xf7a0            ; =63392
+               	mov	x16, #0xf908            ; =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7a0            ; =63392
+               	mov	x16, #0xf908            ; =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x17, #0x0               ; =0
                	cmp	x17, x9
-               	b.lo	 <L4>
-<L8>:
-               	sub	x9, x29, #0x4b4
-               	mov	x16, #0xf798            ; =63384
+               	b.lo	 <L3>
+<L5>:
+               	sub	x9, x29, #0x26c
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x10]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x18]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x20]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x28]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x30]
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x38]
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L9>
-               	b	 <L10>
-<L9>:
-               	mov	x16, #0xf850            ; =63568
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
-               	mul	x14, x9, x16
-               	add	x0, x19, x14
-               	mov	x16, #0xfb3c            ; =64316
+               	mul	x0, x9, x16
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xfa40            ; =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfd84            ; =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfb44            ; =64324
+               	mov	x16, #0xfd8c            ; =64908
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x14, [x0]
-               	mov	x16, #0xfb3c            ; =64316
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x0, #0x8]
-               	mov	x16, #0xfb44            ; =64324
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfd84            ; =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xfb3c            ; =64316
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfa40            ; =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfd8c            ; =64908
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfd84            ; =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0x10              ; =16
                	mul	x0, x9, x16
-               	mov	x16, #0xf798            ; =63384
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	add	x9, x10, x0
-               	mov	x16, #0xf848            ; =63560
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf848            ; =63560
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	mov	x16, #0xfb2c            ; =64300
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfd74            ; =64884
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xfb2c            ; =64300
+               	mov	x16, #0xfd74            ; =64884
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x14, [x29, x16]
-               	str	x14, [x0]
-               	mov	x16, #0xfb34            ; =64308
+               	ldr	x0, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w14, [x29, x16]
-               	str	w14, [x0, #0x8]
-               	mov	x16, #0xf850            ; =63568
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfd7c            ; =64892
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w0, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w0, [x9, #0x8]
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -755,962 +853,1247 @@ Disassembly of section __TEXT,__text:
                	mov	w0, w9
                	mov	w17, #0xaaaa            ; =43690
                	movk	w17, #0xaaaa, lsl #16
-               	sub	w14, w17, w0
-               	mov	x16, #0xf848            ; =63560
+               	sub	w9, w17, w0
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
-               	str	w14, [x0]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w9, [x0]
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1
                	mov	x9, x0
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L9>
-<L10>:
-               	mov	x16, #0xf7a8            ; =63400
+               	b.lo	 <L6>
+<L7>:
+               	mov	x16, #0xf910            ; =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	mov	x16, #0xf778            ; =63352
+               	mov	x16, #0xf8b8            ; =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xf770            ; =63344
+               	mov	x16, #0xf8b0            ; =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf770            ; =63344
+               	mov	x16, #0xf8b0            ; =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L11>
-               	b	 <L16>
-<L11>:
-               	mov	x16, #0xf770            ; =63344
+               	b.lo	 <L8>
+               	b	 <L12>
+<L8>:
+               	mov	x16, #0xf8b0            ; =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0x10              ; =16
                	mul	x0, x9, x16
-               	mov	x16, #0xf798            ; =63384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, x0
-               	add	x0, x1, #0x0
-               	mov	x16, #0xfb1c            ; =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfb24            ; =64292
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x1, [x0]
-               	mov	x16, #0xfb1c            ; =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	ldr	w1, [x0, #0x8]
-               	mov	x16, #0xfb24            ; =64292
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xfb1c            ; =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf780            ; =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf780            ; =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	mov	x16, #0xf778            ; =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-<L12>:
-               	bl	 <L12>
-               	mov	x16, #0xf780            ; =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xf780            ; =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L14>:
-               	bl	 <L14>
-               	mov	x9, x0
-               	mov	x16, #0xf838            ; =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf838            ; =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xf770            ; =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0x10              ; =16
-               	mul	x1, x9, x16
-               	mov	x16, #0xf798            ; =63384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, x1
-               	add	x1, x0, #0xc
-               	ldr	w9, [x1]
-               	mov	x16, #0xf830            ; =63536
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf838            ; =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	x16, #0xf830            ; =63536
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xf770            ; =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x1
-               	mov	x9, x0
-               	mov	x16, #0xf778            ; =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x9, x15
-               	mov	x16, #0xf770            ; =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf770            ; =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	cmp	x9, #0x4
-               	b.lo	 <L11>
-<L16>:
-               	sub	x9, x29, #0x4f8
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	xzr, [x9]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	wzr, [x9, #0x10]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	mov	w17, #0xdb              ; =219
-               	strb	w17, [x0]
-               	add	x1, x19, #0x3c
-               	mov	x16, #0xfaf8            ; =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfb00            ; =64256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x15, [x1]
-               	mov	x16, #0xfaf8            ; =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x15, [x29, x16]
-               	ldr	w15, [x1, #0x8]
-               	mov	x16, #0xfb00            ; =64256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w15, [x29, x16]
-               	mov	x16, #0xfaf8            ; =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	mov	x16, #0xf768            ; =63336
+               	mov	x16, #0xf8c0            ; =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	add	x9, x10, #0x4
-               	mov	x16, #0xf760            ; =63328
+               	add	x9, x10, x0
+               	mov	x16, #0xfa18            ; =64024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfae8            ; =64232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
-               	mov	x16, #0xfae8            ; =64232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x1, [x29, x16]
-               	mov	x16, #0xf760            ; =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfaf0            ; =64240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w1, [x29, x16]
-               	mov	x16, #0xf760            ; =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	w1, [x9, #0x8]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	mov	w17, #0xad              ; =173
-               	strb	w17, [x1]
-               	ldrb	w1, [x0]
-               	mov	x16, #0xf778            ; =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfad8            ; =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfae0            ; =64224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf760            ; =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
-               	mov	x16, #0xfad8            ; =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	mov	x16, #0xf760            ; =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	w1, [x9, #0x8]
-               	mov	x16, #0xfae0            ; =64224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xfad8            ; =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf750            ; =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf750            ; =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xf750            ; =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xf750            ; =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L21>:
-               	bl	 <L21>
-               	mov	x9, x0
-               	mov	x16, #0xf828            ; =63528
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf828            ; =63528
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	sub	x9, x29, #0x5b4
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x1, x29, #0x5c8
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x15, [x9]
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x0, [x9, #0x8]
-               	mov	x16, #0xf768            ; =63336
+               	mov	x16, #0xfa18            ; =64024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldr	w9, [x10, #0x10]
-               	mov	x16, #0xf820            ; =63520
+               	add	x9, x10, #0x0
+               	mov	x16, #0xfa10            ; =64016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	str	x15, [x1]
-               	str	x0, [x1, #0x8]
-               	mov	x16, #0xf820            ; =63520
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	w9, [x1, #0x10]
-               	ldr	x0, [x1]
-               	ldr	x15, [x1, #0x8]
-               	ldr	w9, [x1, #0x10]
-               	mov	x16, #0xf818            ; =63512
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x0, [x9]
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x15, [x9, #0x8]
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xf818            ; =63512
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	str	w10, [x9, #0x10]
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	add	x9, x10, #0x4
-               	mov	x16, #0xf740            ; =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfa28            ; =64040
+               	mov	x16, #0xfd64            ; =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfa30            ; =64048
+               	mov	x16, #0xfd6c            ; =64876
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
+               	mov	x16, #0xfa10            ; =64016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfa28            ; =64040
+               	mov	x16, #0xfd64            ; =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
+               	mov	x16, #0xfa10            ; =64016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfa30            ; =64048
+               	mov	x16, #0xfd6c            ; =64876
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfa28            ; =64040
+               	mov	x16, #0xfd64            ; =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	add	x0, x19, #0xc
-               	mov	x16, #0xfa18            ; =64024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfa20            ; =64032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x1, [x0]
-               	mov	x16, #0xfa18            ; =64024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	ldr	w1, [x0, #0x8]
-               	mov	x16, #0xfa20            ; =64032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xfa18            ; =64024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q1, [x29, x16]
-               	fadd.4s	v2, v0, v1
-               	mov	x16, #0xfa08            ; =64008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q2, [x29, x16]
-               	mov	x16, #0xfa08            ; =64008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x0, [x9]
-               	mov	x16, #0xfa10            ; =64016
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	w0, [x9, #0x8]
-               	mov	x16, #0xf748            ; =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldrb	w1, [x0]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf8b8            ; =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xf9f8            ; =63992
+<L9>:
+               	bl	 <L9>
+               	mov	x9, x0
+               	mov	x16, #0xfa08            ; =64008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfa00            ; =64000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa08            ; =64008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
+               	mov	x16, #0xfa18            ; =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	w9, [x0]
+               	mov	x16, #0xfa00            ; =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa00            ; =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	w9, w10
+               	mov	x16, #0xf9f0            ; =63984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa08            ; =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
                	mov	x16, #0xf9f8            ; =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, #0x0                ; =0
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x8               ; =8
+               	mul	x0, x9, x16
+               	mov	x16, #0xf9f0            ; =63984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	lsr	x9, x10, x0
+               	mov	x16, #0xf9e0            ; =63968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9e0            ; =63968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xff              ; =255
+               	and	x0, x9, x16
+               	mov	x16, #0xf9f8            ; =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	eor	x9, x10, x0
+               	mov	x16, #0xf9d8            ; =63960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9d8            ; =63960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x9, x16
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x1
+               	mov	x16, #0xf9d0            ; =63952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf9f8            ; =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9d0            ; =63952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9e8            ; =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x16, #0xf8b0            ; =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1
+               	mov	x16, #0xf9f8            ; =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf8b8            ; =63672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x1
+               	mov	x16, #0xf8b0            ; =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8b0            ; =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x4
+               	b.lo	 <L8>
+<L12>:
+               	sub	x9, x29, #0x2b0
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	xzr, [x9]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	xzr, [x9, #0x8]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	wzr, [x9, #0x10]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xf9c8            ; =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9c8            ; =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w17, #0xdb              ; =219
+               	strb	w17, [x9]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x3c
+               	mov	x16, #0xfd40            ; =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfd48            ; =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x1]
+               	mov	x16, #0xfd40            ; =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x1, #0x8]
+               	mov	x16, #0xfd48            ; =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfd40            ; =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q0, [x29, x16]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x1, [x29, x16]
+               	str	x1, [x0]
+               	mov	x16, #0xfd38            ; =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	str	w1, [x0, #0x8]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	mov	w17, #0xad              ; =173
+               	strb	w17, [x0]
+               	mov	x16, #0xf9c8            ; =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldrb	w0, [x9]
+               	uxtb	w9, w0
+               	mov	x16, #0xf9c0            ; =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8b8            ; =63672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf9b8            ; =63928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, #0x0                ; =0
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               ; =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xf9c0            ; =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x13, x9, x1
+               	mov	x16, #0xff              ; =255
+               	and	x1, x13, x16
+               	mov	x16, #0xf9b8            ; =63928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x13, x9, x1
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x13, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xf9b8            ; =63928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfc6c            ; =64620
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc74            ; =64628
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x1, [x0]
+               	mov	x16, #0xfc6c            ; =64620
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xf740            ; =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	w1, [x9, #0x8]
-               	mov	x16, #0xfa00            ; =64000
+               	ldr	w1, [x0, #0x8]
+               	mov	x16, #0xfc74            ; =64628
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w1, [x29, x16]
-               	mov	x16, #0xf9f8            ; =63992
+               	mov	x16, #0xfc6c            ; =64620
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf730            ; =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf730            ; =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xf730            ; =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xf730            ; =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xf748            ; =63304
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf9b8            ; =63928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xf768            ; =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	mov	x16, #0xf9e8            ; =63976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9f0            ; =63984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x14, [x1]
-               	mov	x16, #0xf9e8            ; =63976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x1, #0x8]
-               	mov	x16, #0xf9f0            ; =63984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xf9e8            ; =63976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf720            ; =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf720            ; =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xf720            ; =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xf720            ; =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xf768            ; =63336
+               	mov	x0, x9
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xf8a8            ; =63656
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	ldrb	w13, [x1]
-               	mov	x1, x13
-<L31>:
-               	bl	 <L31>
-               	mov	x9, x0
-               	mov	x16, #0xf810            ; =63504
+               	uxtb	w9, w13
+               	mov	x16, #0xf9a8            ; =63912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x9, x0
+               	mov	x16, #0xf9b0            ; =63920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x13, #0x0               ; =0
+               	cmp	x13, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x0, x13, x16
+               	mov	x16, #0xf9a8            ; =63912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	sub	x9, x29, #0x690
-               	mov	x16, #0xf718            ; =63256
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              ; =255
+               	and	x0, x1, x16
+               	mov	x16, #0xf9b0            ; =63920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x13, x13, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xf9b0            ; =63920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf718            ; =63256
+               	cmp	x13, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sub	x9, x29, #0x4a4
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x0, x29, #0x4b8
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x13, [x9]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	ldr	x9, [x10, #0x8]
+               	mov	x16, #0xf9a0            ; =63904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	ldr	w9, [x10, #0x10]
+               	mov	x16, #0xf998            ; =63896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	str	x13, [x0]
+               	mov	x16, #0xf9a0            ; =63904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x0, #0x8]
+               	mov	x16, #0xf998            ; =63896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w9, [x0, #0x10]
+               	ldr	x13, [x0]
+               	ldr	x9, [x0, #0x8]
+               	mov	x16, #0xf990            ; =63888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	w9, [x0, #0x10]
+               	mov	x16, #0xf988            ; =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x13, [x9]
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf990            ; =63888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x8]
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf988            ; =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	w10, [x9, #0x10]
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x4
+               	mov	x16, #0xf980            ; =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfb38            ; =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb40            ; =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf980            ; =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x13, [x9]
+               	mov	x16, #0xfb38            ; =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x13, [x29, x16]
+               	mov	x16, #0xf980            ; =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w13, [x9, #0x8]
+               	mov	x16, #0xfb40            ; =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w13, [x29, x16]
+               	mov	x16, #0xfb38            ; =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x13, x9, #0xc
+               	mov	x16, #0xfb28            ; =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb30            ; =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x13]
+               	mov	x16, #0xfb28            ; =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x13, #0x8]
+               	mov	x16, #0xfb30            ; =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfb28            ; =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q1, [x29, x16]
+               	fadd.4s	v2, v0, v1
+               	mov	x16, #0xfb18            ; =64280
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q2, [x29, x16]
+               	mov	x16, #0xfb18            ; =64280
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x0, [x29, x16]
+               	mov	x16, #0xf980            ; =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfb20            ; =64288
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w0, [x29, x16]
+               	mov	x16, #0xf980            ; =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w0, [x9, #0x8]
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldrb	w13, [x0]
+               	uxtb	w9, w13
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9b0            ; =63920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, #0x0                ; =0
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x9, x16
+               	mov	x16, #0xf978            ; =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x0, x16
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x13, x0, x16
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1
+               	mov	x9, x13
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf968            ; =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfb08            ; =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb10            ; =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x13, [x0]
+               	mov	x16, #0xfb08            ; =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x13, [x29, x16]
+               	ldr	w13, [x0, #0x8]
+               	mov	x16, #0xfb10            ; =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w13, [x29, x16]
+               	mov	x16, #0xfb08            ; =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf970            ; =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xf8a0            ; =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x13, x9, #0x10
+               	ldrb	w1, [x13]
+               	uxtb	w9, w1
+               	mov	x16, #0xf960            ; =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x1, x16
+               	mov	x16, #0xf960            ; =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x0, x16
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x13, x0, x16
+               	add	x1, x1, #0x1
+               	mov	x9, x13
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldrb	w1, [x0]
+               	uxtb	w13, w1
+               	mov	x16, #0xf958            ; =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x13
+<L23>:
+               	bl	 <L23>
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	mov	x16, #0xfaf8            ; =64248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb00            ; =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x13, [x1]
+               	mov	x16, #0xfaf8            ; =64248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x13, [x29, x16]
+               	ldr	w13, [x1, #0x8]
+               	mov	x16, #0xfb00            ; =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w13, [x29, x16]
+               	mov	x16, #0xfaf8            ; =64248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xf8a8            ; =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldrb	w12, [x1]
+               	uxtb	w1, w12
+<L25>:
+               	bl	 <L25>
+               	mov	x9, x0
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf950            ; =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	sub	x9, x29, #0x534
+               	mov	x16, #0xf898            ; =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x10]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x18]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x20]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	wzr, [x9, #0x28]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xf948            ; =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf948            ; =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x14, x19, #0x0
-               	mov	x16, #0xf960            ; =63840
+               	str	w17, [x9]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x13, x9, #0x0
+               	mov	x16, #0xfabc            ; =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf968            ; =63848
+               	mov	x16, #0xfac4            ; =64196
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x15, [x14]
-               	mov	x16, #0xf960            ; =63840
+               	ldr	x0, [x13]
+               	mov	x16, #0xfabc            ; =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x15, [x29, x16]
-               	ldr	w15, [x14, #0x8]
-               	mov	x16, #0xf968            ; =63848
+               	str	x0, [x29, x16]
+               	ldr	w0, [x13, #0x8]
+               	mov	x16, #0xfac4            ; =64196
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w15, [x29, x16]
-               	mov	x16, #0xf960            ; =63840
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfabc            ; =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	mov	x16, #0xf718            ; =63256
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	add	x15, x14, #0x0
-               	mov	x16, #0xf950            ; =63824
+               	add	x0, x9, #0x4
+               	add	x13, x0, #0x0
+               	mov	x16, #0xfaac            ; =64172
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xf950            ; =63824
+               	mov	x16, #0xfaac            ; =64172
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x1, [x29, x16]
+               	str	x1, [x13]
+               	mov	x16, #0xfab4            ; =64180
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	str	w1, [x13, #0x8]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x24
+               	mov	x16, #0xfa9c            ; =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfaa4            ; =64164
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x13, [x1]
+               	mov	x16, #0xfa9c            ; =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x13, [x29, x16]
+               	ldr	w13, [x1, #0x8]
+               	mov	x16, #0xfaa4            ; =64164
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w13, [x29, x16]
+               	mov	x16, #0xfa9c            ; =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	add	x1, x0, #0xc
+               	mov	x16, #0xfa8c            ; =64140
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q0, [x29, x16]
+               	mov	x16, #0xfa8c            ; =64140
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x13, [x29, x16]
+               	str	x13, [x1]
+               	mov	x16, #0xfa94            ; =64148
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w13, [x29, x16]
+               	str	w13, [x1, #0x8]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x48
+               	mov	x16, #0xfa7c            ; =64124
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfa84            ; =64132
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x13, [x1]
+               	mov	x16, #0xfa7c            ; =64124
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x13, [x29, x16]
+               	ldr	w13, [x1, #0x8]
+               	mov	x16, #0xfa84            ; =64132
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w13, [x29, x16]
+               	mov	x16, #0xfa7c            ; =64124
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	add	x1, x0, #0x18
+               	mov	x16, #0xfa6c            ; =64108
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q0, [x29, x16]
+               	mov	x16, #0xfa6c            ; =64108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
-               	str	x0, [x15]
-               	mov	x16, #0xf958            ; =63832
+               	str	x0, [x1]
+               	mov	x16, #0xfa74            ; =64116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
-               	str	w0, [x15, #0x8]
-               	add	x0, x19, #0x24
-               	mov	x16, #0xf940            ; =63808
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf948            ; =63816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x15, [x0]
-               	mov	x16, #0xf940            ; =63808
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x15, [x29, x16]
-               	ldr	w15, [x0, #0x8]
-               	mov	x16, #0xf948            ; =63816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w15, [x29, x16]
-               	mov	x16, #0xf940            ; =63808
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	add	x0, x14, #0xc
-               	mov	x16, #0xf930            ; =63792
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
-               	mov	x16, #0xf930            ; =63792
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x15, [x29, x16]
-               	str	x15, [x0]
-               	mov	x16, #0xf938            ; =63800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w15, [x29, x16]
-               	str	w15, [x0, #0x8]
-               	add	x0, x19, #0x48
-               	mov	x16, #0xf920            ; =63776
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf928            ; =63784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x15, [x0]
-               	mov	x16, #0xf920            ; =63776
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x15, [x29, x16]
-               	ldr	w15, [x0, #0x8]
-               	mov	x16, #0xf928            ; =63784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w15, [x29, x16]
-               	mov	x16, #0xf920            ; =63776
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	add	x0, x14, #0x18
-               	mov	x16, #0xf910            ; =63760
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
-               	mov	x16, #0xf910            ; =63760
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x14, [x29, x16]
-               	str	x14, [x0]
-               	mov	x16, #0xf918            ; =63768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w14, [x29, x16]
-               	str	w14, [x0, #0x8]
-               	mov	x16, #0xf718            ; =63256
+               	str	w0, [x1, #0x8]
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1719,105 +2102,474 @@ Disassembly of section __TEXT,__text:
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x0]
-               	ldr	w14, [x1]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf948            ; =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9]
+               	mov	w1, w0
+               	mov	x16, #0xf950            ; =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	w1, w14
-<L32>:
-               	bl	 <L32>
+<L26>:
+               	bl	 <L26>
                	mov	x9, x0
-               	mov	x16, #0xf6f8            ; =63224
+               	mov	x16, #0xf890            ; =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xf6f0            ; =63216
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf6f0            ; =63216
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x3
-               	b.lo	 <L33>
-               	b	 <L37>
-<L33>:
-               	mov	x16, #0xf718            ; =63256
+               	b.lo	 <L27>
+               	b	 <L29>
+<L27>:
+               	mov	x16, #0xf898            ; =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	mov	x16, #0xf6f0            ; =63216
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x4
+               	mov	x16, #0xf940            ; =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
-               	mul	x15, x9, x16
-               	add	x9, x0, x15
-               	mov	x16, #0xf808            ; =63496
+               	mul	x0, x9, x16
+               	mov	x16, #0xf940            ; =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xf938            ; =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfac8            ; =64200
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfad0            ; =64208
+               	mov	x16, #0xfd28            ; =64808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf938            ; =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfac8            ; =64200
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf938            ; =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfad0            ; =64208
+               	mov	x16, #0xfd28            ; =64808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfac8            ; =64200
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf700            ; =63232
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xf888            ; =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x13, x9, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x13
+               	mov	x16, #0xf888            ; =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf888            ; =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x3
+               	b.lo	 <L27>
+<L29>:
+               	mov	x16, #0xf898            ; =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x28
+               	ldr	w12, [x0]
+               	mov	w0, w12
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x12, #0x0               ; =0
+               	cmp	x12, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x13, x12, x16
+               	lsr	x1, x0, x13
+               	mov	x16, #0xff              ; =255
+               	and	x13, x1, x16
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x13
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x13, x1, x16
+               	add	x12, x12, #0x1
+               	mov	x9, x13
+               	mov	x16, #0xf930            ; =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x12, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x18
+               	mov	x16, #0xf880            ; =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc5c            ; =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc64            ; =64612
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf880            ; =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc5c            ; =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf880            ; =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc64            ; =64612
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc5c            ; =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x30
+               	mov	x16, #0xf878            ; =63608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc4c            ; =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc54            ; =64596
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf878            ; =63608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc4c            ; =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf878            ; =63608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc54            ; =64596
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc4c            ; =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q1, [x29, x16]
+               	fadd.4s	v31, v0, v1
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xf700            ; =63232
+               	mov	x16, #0xf930            ; =63792
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-               	mov	x16, #0xf6f8            ; =63224
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xf860            ; =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xf860            ; =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L33>:
+               	bl	 <L33>
+               	mov	x9, x0
+               	mov	x16, #0xf928            ; =63784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf928            ; =63784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf920            ; =63776
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x24
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc3c            ; =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc44            ; =64580
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc3c            ; =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w15, [x9, #0x8]
+               	mov	x16, #0xfc44            ; =64580
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w15, [x29, x16]
+               	mov	x16, #0xfc3c            ; =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	sub	x15, x29, #0x3d0
+               	add	x0, x15, #0x0
+               	mov	w17, #0x40000000        ; =1073741824
+               	str	w17, [x0]
+               	add	x0, x15, #0x4
+               	mov	w17, #0x40800000        ; =1082130432
+               	str	w17, [x0]
+               	add	x0, x15, #0x8
+               	mov	w17, #0x41000000        ; =1090519040
+               	str	w17, [x0]
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc28            ; =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x15]
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x15, #0x8]
+               	mov	x16, #0xfc28            ; =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q1, [x29, x16]
+               	fmul.4s	v2, v0, v1
+               	mov	x16, #0xfc10            ; =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q2, [x29, x16]
+               	mov	x16, #0xfc10            ; =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x0, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfc18            ; =64536
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w0, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w0, [x9, #0x8]
+               	mov	x16, #0xfc00            ; =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc08            ; =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf880            ; =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc00            ; =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf880            ; =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc08            ; =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc00            ; =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf928            ; =63784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1825,863 +2577,474 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x9
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0xf700            ; =63232
+               	mov	x16, #0xfbf0            ; =64496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfbf8            ; =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	x16, #0xfbf0            ; =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf858            ; =63576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w1, [x9, #0x8]
+               	mov	x16, #0xfbf8            ; =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w1, [x29, x16]
+               	mov	x16, #0xfbf0            ; =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xf700            ; =63232
+               	mov	x16, #0xfbe0            ; =64480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfbe8            ; =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf878            ; =63608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	x16, #0xfbe0            ; =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf878            ; =63608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w1, [x9, #0x8]
+               	mov	x16, #0xfbe8            ; =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w1, [x29, x16]
+               	mov	x16, #0xfbe0            ; =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L36>:
                	bl	 <L36>
-               	mov	x16, #0xf6f0            ; =63216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x1
-               	mov	x9, x0
-               	mov	x16, #0xf6f8            ; =63224
+               	sub	x9, x29, #0x490
+               	mov	x16, #0xf850            ; =63568
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x14
-               	mov	x16, #0xf6f0            ; =63216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf6f0            ; =63216
+               	mov	x16, #0xf850            ; =63568
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	cmp	x9, #0x3
-               	b.lo	 <L33>
-<L37>:
-               	mov	x16, #0xf718            ; =63256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x28
-               	ldr	w13, [x0]
-               	mov	x16, #0xf6f8            ; =63224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	w1, w13
-<L38>:
-               	bl	 <L38>
-               	add	x1, x19, #0x18
-               	mov	x16, #0xfab8            ; =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfac0            ; =64192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xfab8            ; =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xfac0            ; =64192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xfab8            ; =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	add	x1, x19, #0x30
-               	mov	x16, #0xfaa8            ; =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfab0            ; =64176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xfaa8            ; =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xfab0            ; =64176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xfaa8            ; =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q1, [x29, x16]
-               	fadd.4s	v31, v0, v1
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xf6e0            ; =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L44>:
-               	bl	 <L44>
-               	add	x1, x19, #0x24
-               	mov	x16, #0xf9d8            ; =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9e0            ; =63968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf9d8            ; =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf9e0            ; =63968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf9d8            ; =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	sub	x13, x29, #0x634
-               	add	x14, x13, #0x0
-               	mov	w17, #0x40000000        ; =1073741824
-               	str	w17, [x14]
-               	add	x14, x13, #0x4
-               	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x14]
-               	add	x14, x13, #0x8
-               	mov	w17, #0x41000000        ; =1090519040
-               	str	w17, [x14]
-               	mov	x16, #0xf9bc            ; =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9c4            ; =63940
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x14, [x13]
-               	mov	x16, #0xf9bc            ; =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x13, #0x8]
-               	mov	x16, #0xf9c4            ; =63940
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xf9bc            ; =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q1, [x29, x16]
-               	fmul.4s	v2, v0, v1
-               	mov	x16, #0xf9ac            ; =63916
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q2, [x29, x16]
-               	mov	x16, #0xf9ac            ; =63916
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x13, [x29, x16]
-               	str	x13, [x1]
-               	mov	x16, #0xf9b4            ; =63924
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w13, [x29, x16]
-               	str	w13, [x1, #0x8]
-               	add	x1, x19, #0x18
-               	mov	x16, #0xf99c            ; =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9a4            ; =63908
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf99c            ; =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf9a4            ; =63908
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf99c            ; =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6d0            ; =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6d0            ; =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xf6d0            ; =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xf6d0            ; =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L47>:
-               	bl	 <L47>
-               	add	x1, x19, #0x24
-               	mov	x16, #0xf900            ; =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf908            ; =63752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf900            ; =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf908            ; =63752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf900            ; =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6c0            ; =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6c0            ; =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xf6c0            ; =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xf6c0            ; =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L50>:
-               	bl	 <L50>
-               	add	x1, x19, #0x30
-               	mov	x16, #0xf8f0            ; =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf8f8            ; =63736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf8f0            ; =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf8f8            ; =63736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf8f0            ; =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6b0            ; =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6b0            ; =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xf6b0            ; =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xf6b0            ; =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L53>:
-               	bl	 <L53>
-               	sub	x19, x29, #0x780
-               	add	x1, x19, #0x0
+               	add	x1, x9, #0x0
                	add	x13, x1, #0x0
                	mov	x1, #0x60               ; =96
-<L54>:
+<L37>:
                	str	xzr, [x13]
                	add	x13, x13, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L54>
+               	b.ne	 <L37>
                	str	wzr, [x13]
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x5
-               	b.lo	 <L55>
-               	b	 <L56>
-<L55>:
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
                	ucvtf	s0, x1
-               	sub	x13, x29, #0x56c
+               	sub	x13, x29, #0x2f4
                	str	xzr, [x13]
                	str	xzr, [x13, #0x8]
                	str	wzr, [x13, #0x10]
                	fadd	s1, s0, s8
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x20, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x10
-               	str	s2, [x14]
-               	add	x14, x20, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x0
-               	str	s2, [x14]
-               	add	x14, x20, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x4
-               	str	s2, [x14]
-               	add	x14, x20, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x8
-               	str	s2, [x14]
-               	add	x14, x20, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x21, #0xc
-               	str	s2, [x14]
-               	add	x14, x20, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x10
-               	str	s2, [x14]
-               	add	x14, x21, #0x0
-               	str	s1, [x14]
-               	add	x14, x21, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x21, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x21, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x21, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x21, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x15, x13, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x19, #0x0
+               	str	s2, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x19, #0x4
+               	str	s2, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x19, #0x8
+               	str	s2, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x19, #0xc
+               	str	s2, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x19, #0x10
+               	str	s2, [x15]
+               	add	x15, x19, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x20, #0x0
+               	str	s2, [x15]
+               	add	x15, x19, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x20, #0x4
+               	str	s2, [x15]
+               	add	x15, x19, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x20, #0x8
+               	str	s2, [x15]
+               	add	x15, x19, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x20, #0xc
+               	str	s2, [x15]
+               	add	x15, x19, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x20, #0x10
+               	str	s2, [x15]
+               	add	x15, x20, #0x0
+               	str	s1, [x15]
+               	add	x15, x20, #0x0
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x0
+               	str	s1, [x15]
+               	add	x15, x20, #0x4
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x4
+               	str	s1, [x15]
+               	add	x15, x20, #0x8
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x8
+               	str	s1, [x15]
+               	add	x15, x20, #0xc
+               	ldr	s1, [x15]
+               	add	x15, x13, #0xc
+               	str	s1, [x15]
+               	add	x15, x20, #0x10
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x10
+               	str	s1, [x15]
                	fmov	s30, #1.25000000
                	fsub	s1, s0, s30
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x22, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x10
-               	str	s2, [x14]
-               	add	x14, x22, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x0
-               	str	s2, [x14]
-               	add	x14, x22, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x4
-               	str	s2, [x14]
-               	add	x14, x22, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x8
-               	str	s2, [x14]
-               	add	x14, x22, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x23, #0xc
-               	str	s2, [x14]
-               	add	x14, x22, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x10
-               	str	s2, [x14]
-               	add	x14, x23, #0x4
-               	str	s1, [x14]
-               	add	x14, x23, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x23, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x23, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x23, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x23, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x15, x13, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x21, #0x0
+               	str	s2, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x21, #0x4
+               	str	s2, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x21, #0x8
+               	str	s2, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x21, #0xc
+               	str	s2, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x21, #0x10
+               	str	s2, [x15]
+               	add	x15, x21, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x22, #0x0
+               	str	s2, [x15]
+               	add	x15, x21, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x22, #0x4
+               	str	s2, [x15]
+               	add	x15, x21, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x22, #0x8
+               	str	s2, [x15]
+               	add	x15, x21, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x22, #0xc
+               	str	s2, [x15]
+               	add	x15, x21, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x22, #0x10
+               	str	s2, [x15]
+               	add	x15, x22, #0x4
+               	str	s1, [x15]
+               	add	x15, x22, #0x0
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x0
+               	str	s1, [x15]
+               	add	x15, x22, #0x4
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x4
+               	str	s1, [x15]
+               	add	x15, x22, #0x8
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x8
+               	str	s1, [x15]
+               	add	x15, x22, #0xc
+               	ldr	s1, [x15]
+               	add	x15, x13, #0xc
+               	str	s1, [x15]
+               	add	x15, x22, #0x10
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x10
+               	str	s1, [x15]
                	mov	w16, #0x42c80000        ; =1120403456
                	fmov	s31, w16
                	fsub	s1, s31, s0
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x24, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x10
-               	str	s2, [x14]
-               	add	x14, x24, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x0
-               	str	s2, [x14]
-               	add	x14, x24, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x4
-               	str	s2, [x14]
-               	add	x14, x24, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x8
-               	str	s2, [x14]
-               	add	x14, x24, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x25, #0xc
-               	str	s2, [x14]
-               	add	x14, x24, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x10
-               	str	s2, [x14]
-               	add	x14, x25, #0x8
-               	str	s1, [x14]
-               	add	x14, x25, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x25, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x25, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x25, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x25, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x15, x13, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x23, #0x0
+               	str	s2, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x23, #0x4
+               	str	s2, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x23, #0x8
+               	str	s2, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x23, #0xc
+               	str	s2, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x23, #0x10
+               	str	s2, [x15]
+               	add	x15, x23, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x24, #0x0
+               	str	s2, [x15]
+               	add	x15, x23, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x24, #0x4
+               	str	s2, [x15]
+               	add	x15, x23, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x24, #0x8
+               	str	s2, [x15]
+               	add	x15, x23, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x24, #0xc
+               	str	s2, [x15]
+               	add	x15, x23, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x24, #0x10
+               	str	s2, [x15]
+               	add	x15, x24, #0x8
+               	str	s1, [x15]
+               	add	x15, x24, #0x0
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x0
+               	str	s1, [x15]
+               	add	x15, x24, #0x4
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x4
+               	str	s1, [x15]
+               	add	x15, x24, #0x8
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x8
+               	str	s1, [x15]
+               	add	x15, x24, #0xc
+               	ldr	s1, [x15]
+               	add	x15, x13, #0xc
+               	str	s1, [x15]
+               	add	x15, x24, #0x10
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x10
+               	str	s1, [x15]
                	fmov	s30, #7.50000000
                	fadd	s1, s0, s30
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x26, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x10
-               	str	s2, [x14]
-               	add	x14, x26, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x0
-               	str	s2, [x14]
-               	add	x14, x26, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x4
-               	str	s2, [x14]
-               	add	x14, x26, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x8
-               	str	s2, [x14]
-               	add	x14, x26, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x27, #0xc
-               	str	s2, [x14]
-               	add	x14, x26, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x10
-               	str	s2, [x14]
-               	add	x14, x27, #0xc
-               	str	s1, [x14]
-               	add	x14, x27, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x27, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x27, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x27, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x27, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x15, x13, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x25, #0x0
+               	str	s2, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x25, #0x4
+               	str	s2, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x25, #0x8
+               	str	s2, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x25, #0xc
+               	str	s2, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x25, #0x10
+               	str	s2, [x15]
+               	add	x15, x25, #0x0
+               	ldr	s2, [x15]
+               	add	x15, x26, #0x0
+               	str	s2, [x15]
+               	add	x15, x25, #0x4
+               	ldr	s2, [x15]
+               	add	x15, x26, #0x4
+               	str	s2, [x15]
+               	add	x15, x25, #0x8
+               	ldr	s2, [x15]
+               	add	x15, x26, #0x8
+               	str	s2, [x15]
+               	add	x15, x25, #0xc
+               	ldr	s2, [x15]
+               	add	x15, x26, #0xc
+               	str	s2, [x15]
+               	add	x15, x25, #0x10
+               	ldr	s2, [x15]
+               	add	x15, x26, #0x10
+               	str	s2, [x15]
+               	add	x15, x26, #0xc
+               	str	s1, [x15]
+               	add	x15, x26, #0x0
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x0
+               	str	s1, [x15]
+               	add	x15, x26, #0x4
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x4
+               	str	s1, [x15]
+               	add	x15, x26, #0x8
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x8
+               	str	s1, [x15]
+               	add	x15, x26, #0xc
+               	ldr	s1, [x15]
+               	add	x15, x13, #0xc
+               	str	s1, [x15]
+               	add	x15, x26, #0x10
+               	ldr	s1, [x15]
+               	add	x15, x13, #0x10
+               	str	s1, [x15]
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-               	add	x14, x13, #0x0
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x0
-               	str	s0, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x4
-               	str	s0, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x8
-               	str	s0, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s0, [x14]
-               	add	x14, x28, #0xc
-               	str	s0, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x10
-               	str	s0, [x14]
-               	add	x14, x28, #0x0
-               	ldr	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
+               	add	x15, x13, #0x0
+               	ldr	s0, [x15]
+               	add	x15, x27, #0x0
+               	str	s0, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s0, [x15]
+               	add	x15, x27, #0x4
+               	str	s0, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s0, [x15]
+               	add	x15, x27, #0x8
+               	str	s0, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s0, [x15]
+               	add	x15, x27, #0xc
+               	str	s0, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s0, [x15]
+               	add	x15, x27, #0x10
+               	str	s0, [x15]
+               	add	x15, x27, #0x0
+               	ldr	s0, [x15]
+               	add	x15, x28, #0x0
+               	str	s0, [x15]
+               	add	x15, x27, #0x4
+               	ldr	s0, [x15]
+               	add	x15, x28, #0x4
+               	str	s0, [x15]
+               	add	x15, x27, #0x8
+               	ldr	s0, [x15]
+               	add	x15, x28, #0x8
+               	str	s0, [x15]
+               	add	x15, x27, #0xc
+               	ldr	s0, [x15]
+               	add	x15, x28, #0xc
+               	str	s0, [x15]
+               	add	x15, x27, #0x10
+               	ldr	s0, [x15]
+               	add	x15, x28, #0x10
+               	str	s0, [x15]
+               	add	x15, x28, #0x10
+               	str	s1, [x15]
+               	add	x15, x28, #0x0
+               	ldr	s0, [x15]
+               	add	x15, x13, #0x0
+               	str	s0, [x15]
+               	add	x15, x28, #0x4
+               	ldr	s0, [x15]
+               	add	x15, x13, #0x4
+               	str	s0, [x15]
+               	add	x15, x28, #0x8
+               	ldr	s0, [x15]
+               	add	x15, x13, #0x8
+               	str	s0, [x15]
+               	add	x15, x28, #0xc
+               	ldr	s0, [x15]
+               	add	x15, x13, #0xc
+               	str	s0, [x15]
+               	add	x15, x28, #0x10
+               	ldr	s0, [x15]
+               	add	x15, x13, #0x10
+               	str	s0, [x15]
+               	add	x15, x13, #0x0
+               	ldr	s0, [x15]
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	str	s0, [x14]
-               	add	x14, x28, #0x4
-               	ldr	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
+               	add	x15, x9, #0x0
+               	str	s0, [x15]
+               	add	x15, x13, #0x4
+               	ldr	s0, [x15]
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	str	s0, [x14]
-               	add	x14, x28, #0x8
-               	ldr	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
+               	add	x15, x9, #0x4
+               	str	s0, [x15]
+               	add	x15, x13, #0x8
+               	ldr	s0, [x15]
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	str	s0, [x14]
-               	add	x14, x28, #0xc
-               	ldr	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
+               	add	x15, x9, #0x8
+               	str	s0, [x15]
+               	add	x15, x13, #0xc
+               	ldr	s0, [x15]
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	str	s0, [x14]
-               	add	x14, x28, #0x10
-               	ldr	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	str	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	str	s1, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x0
-               	str	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x4
-               	str	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x8
-               	str	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	ldr	s0, [x14]
-               	add	x14, x13, #0xc
-               	str	s0, [x14]
-               	mov	x16, #0xf800            ; =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x10
-               	str	s0, [x14]
-               	add	x14, x13, #0x0
-               	ldr	s0, [x14]
-               	mov	x16, #0xf7f8            ; =63480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	str	s0, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s0, [x14]
-               	mov	x16, #0xf7f8            ; =63480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	str	s0, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s0, [x14]
-               	mov	x16, #0xf7f8            ; =63480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	str	s0, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s0, [x14]
-               	mov	x16, #0xf7f8            ; =63480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	str	s0, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s0, [x14]
-               	mov	x16, #0xf7f8            ; =63480
+               	add	x15, x9, #0xc
+               	str	s0, [x15]
+               	add	x15, x13, #0x10
+               	ldr	s0, [x15]
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2690,70 +3053,80 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x13]
                	mov	x16, #0x14              ; =20
                	mul	x13, x1, x16
-               	add	x14, x19, x13
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x15, x9, x13
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x13, x9, #0x0
                	ldr	s0, [x13]
-               	add	x13, x14, #0x0
+               	add	x13, x15, #0x0
                	str	s0, [x13]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x13, x9, #0x4
                	ldr	s0, [x13]
-               	add	x13, x14, #0x4
+               	add	x13, x15, #0x4
                	str	s0, [x13]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x13, x9, #0x8
                	ldr	s0, [x13]
-               	add	x13, x14, #0x8
+               	add	x13, x15, #0x8
                	str	s0, [x13]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x13, x9, #0xc
                	ldr	s0, [x13]
-               	add	x13, x14, #0xc
+               	add	x13, x15, #0xc
                	str	s0, [x13]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf900            ; =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x13, x9, #0x10
                	ldr	s0, [x13]
-               	add	x13, x14, #0x10
+               	add	x13, x15, #0x10
                	str	s0, [x13]
                	add	x1, x1, #0x1
                	cmp	x1, #0x5
-               	b.lo	 <L55>
-<L56>:
-               	mov	x20, x0
-               	mov	x21, #0x5               ; =5
+               	b.lo	 <L38>
+<L39>:
+               	mov	x19, x0
+               	mov	x20, #0x5               ; =5
                	mov	x17, #0x0               ; =0
-               	cmp	x17, x21
-               	b.lo	 <L57>
-               	b	 <L63>
-<L57>:
-               	sub	x22, x21, #0x1
+               	cmp	x17, x20
+               	b.lo	 <L40>
+               	b	 <L42>
+<L40>:
+               	sub	x20, x20, #0x1
                	mov	x16, #0x14              ; =20
-               	mul	x0, x22, x16
-               	add	x1, x19, x0
+               	mul	x0, x20, x16
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2762,7 +3135,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2771,7 +3144,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2780,7 +3153,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2789,80 +3162,47 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s0, [x0]
-               	mov	x16, #0xf7f0            ; =63472
+               	mov	x0, x19
+               	mov	x16, #0xf8f8            ; =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x20
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xf7f0            ; =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xf7f0            ; =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xf7f0            ; =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xf7f0            ; =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x20, x0
-               	mov	x21, x22
+               	mov	x1, x9
+<L41>:
+               	bl	 <L41>
+               	mov	x19, x0
                	mov	x17, #0x0               ; =0
-               	cmp	x17, x21
-               	b.lo	 <L57>
-<L63>:
-               	sub	x21, x29, #0x5a0
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	str	xzr, [x21, #0x20]
-               	str	xzr, [x21, #0x28]
-               	add	x0, x21, #0x0
+               	cmp	x17, x20
+               	b.lo	 <L40>
+<L42>:
+               	sub	x20, x29, #0x330
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	str	xzr, [x20, #0x10]
+               	str	xzr, [x20, #0x18]
+               	str	xzr, [x20, #0x20]
+               	str	xzr, [x20, #0x28]
+               	add	x0, x20, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x19, #0x3c
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x3c
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2871,7 +3211,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2880,7 +3220,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2889,7 +3229,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2898,413 +3238,219 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            ; =63464
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x22, x21, #0x10
-               	mov	x16, #0xf7e8            ; =63464
+               	add	x1, x20, #0x10
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf7e8            ; =63464
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf7e8            ; =63464
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf7e8            ; =63464
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf7e8            ; =63464
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf8f0            ; =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	str	s0, [x1]
-               	add	x1, x21, #0x24
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	add	x1, x20, #0x24
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x20
-<L64>:
-               	bl	 <L64>
-               	add	x1, x22, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x20, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x22, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x22, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x22, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x22, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xf7e0            ; =63456
+               	add	x0, x9, #0x10
+               	str	s0, [x0]
+               	mov	x0, x19
+               	mov	x16, #0xf8e8            ; =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xf7e0            ; =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xf7e0            ; =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xf7e0            ; =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xf7e0            ; =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	add	x1, x21, #0x24
+               	mov	x1, x9
+<L45>:
+               	bl	 <L45>
+               	add	x1, x20, #0x24
                	ldr	w2, [x1]
                	mov	w1, w2
-<L70>:
-               	bl	 <L70>
-               	add	x1, x19, #0x14
-               	add	x2, x1, #0x0
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L46>
+               	b	 <L47>
+<L46>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L46>
+<L47>:
+               	mov	x16, #0xf850            ; =63568
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	str	s0, [x2]
-               	add	x2, x1, #0x4
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	str	s0, [x2]
-               	add	x2, x1, #0x8
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	str	s0, [x2]
-               	add	x2, x1, #0xc
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	str	s0, [x2]
-               	add	x2, x1, #0x10
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s0, [x2]
-               	add	x2, x19, #0x50
-               	add	x3, x2, #0x0
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x0
-               	str	s0, [x3]
-               	add	x3, x2, #0x4
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x4
-               	str	s0, [x3]
-               	add	x3, x2, #0x8
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x8
-               	str	s0, [x3]
-               	add	x3, x2, #0xc
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0xc
-               	str	s0, [x3]
-               	add	x3, x2, #0x10
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s0, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	str	s2, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	str	s2, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	str	s2, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	str	s2, [x2]
-               	mov	x16, #0xf7d8            ; =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            ; =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s2, [x2]
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x0
-               	str	s0, [x2]
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x4
-               	str	s0, [x2]
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x8
-               	str	s0, [x2]
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s0, [x2]
-               	add	x2, x1, #0xc
-               	str	s0, [x2]
-               	mov	x16, #0xf7c8            ; =63432
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x10
-               	str	s0, [x2]
+               	add	x19, x9, #0x14
                	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8e0            ; =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8e0            ; =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8e0            ; =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8e0            ; =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8e0            ; =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x50
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3313,7 +3459,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3322,7 +3468,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3331,7 +3477,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3340,62 +3486,177 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	ldr	s0, [x1]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	ldr	s0, [x1]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	ldr	s0, [x1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf8d8            ; =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	mov	x16, #0xf8e0            ; =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	ldr	s0, [x1]
-<L75>:
-               	bl	 <L75>
-               	add	x1, x19, #0x14
+               	mov	x16, #0xf8d8            ; =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf8d0            ; =63696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3404,7 +3665,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3413,7 +3674,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3422,7 +3683,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3431,62 +3692,83 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa58            ; =64088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L48>:
+               	bl	 <L48>
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
+               	str	s0, [x1]
+               	add	x1, x19, #0x4
                	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
+               	str	s0, [x1]
+               	add	x1, x19, #0x8
                	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
+               	str	s0, [x1]
+               	add	x1, x19, #0xc
                	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
+               	str	s0, [x1]
+               	add	x1, x19, #0x10
                	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xfa20            ; =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L80>:
-               	bl	 <L80>
-               	add	x1, x19, #0x28
+               	str	s0, [x1]
+               	mov	x16, #0xfa20            ; =64032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L49>:
+               	bl	 <L49>
+               	mov	x16, #0xf850            ; =63568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3495,7 +3777,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3504,7 +3786,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3513,7 +3795,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3522,61 +3804,24 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf8c8            ; =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xf840            ; =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xf840            ; =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xf840            ; =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xf840            ; =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	sub	x16, x29, #0x9b0
+               	mov	x1, x9
+<L50>:
+               	bl	 <L50>
+               	sub	x16, x29, #0x810
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x960
+               	sub	x16, x29, #0x7c0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/vec/vec_scalar_mix.dis
+++ b/test/golden/aarch64-darwin/vec/vec_scalar_mix.dis
@@ -3,165 +3,305 @@ vec/vec_scalar_mix.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_scalar_mix.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[0]
-               	mov	x0, x1
+               	mov	s1, v0[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[2]
-               	mov	x0, x1
+               	mov	s1, v0[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_i32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1b0]
-               	stp	x21, x22, [x29, #-0x1c0]
-               	mov	x16, #0xfe38            ; =65080
+               	sub	sp, sp, #0x120
+               	stp	x19, x20, [x29, #-0xf0]
+               	stur	x21, [x29, #-0xf8]
+               	stp	d10, d11, [x29, #-0x108]
+               	stp	d12, d13, [x29, #-0x118]
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x23, [x29, x16]
-               	sub	x16, x29, #0x1d8
-               	stp	d9, d10, [x16]
-               	stp	d11, d12, [x16, #-0x10]
-               	stp	d13, d14, [x16, #-0x20]
-               	stur	d15, [x16, #-0x28]
+               	str	d14, [x29, x16]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	ucvtf	s0, x19
                	mov	w20, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	x0, x29, #0x10
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x3, x2, #0x4
-               	str	s1, [x3]
-               	add	x3, x2, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        ; =1081081856
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x3, x2, #0xc
-               	str	s1, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	add	x1, x0, #0xc
+               	str	s1, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x20
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        ; =1082130432
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x3, x2, #0x8
-               	str	s2, [x3]
-               	add	x3, x2, #0xc
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41000000        ; =1090519040
-               	str	w17, [x3]
-               	ldr	q2, [x2]
+               	str	w17, [x1]
+               	ldr	q2, [x0]
                	mov	s3, v1[0]
                	fadd	s4, s3, s0
                	mov.16b	v30, v1
@@ -175,194 +315,235 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[0]
                	ldur	q31, [x29, #-0x90]
-               	mov	s10, v31[0]
-               	fmul	s11, s0, s10
+               	mov	s1, v31[0]
+               	fmul	s10, s0, s1
                	ldur	q31, [x29, #-0x80]
-               	mov	s12, v31[1]
+               	mov	s0, v31[1]
                	ldur	q31, [x29, #-0x90]
-               	mov	s13, v31[1]
-               	fmul	s14, s12, s13
+               	mov	s1, v31[1]
+               	fmul	s11, s0, s1
                	ldur	q31, [x29, #-0x80]
-               	mov	s15, v31[2]
-               	ldur	q31, [x29, #-0x90]
                	mov	s0, v31[2]
-               	fmul	s31, s15, s0
-               	stur	s31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s30, v31[3]
-               	stur	s30, [x29, #-0xb0]
                	ldur	q31, [x29, #-0x90]
+               	mov	s1, v31[2]
+               	fmul	s12, s0, s1
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[3]
-               	ldur	s31, [x29, #-0xb0]
-               	fmul	s31, s31, s0
-               	stur	s31, [x29, #-0xc0]
-               	mov	x0, x1
-               	fmov	s0, s11
+               	ldur	q31, [x29, #-0x90]
+               	mov	s1, v31[3]
+               	fmul	s13, s0, s1
+               	fmov	w0, s10
+               	mov	w1, w0
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xa0]
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xc0]
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	fadd	s31, s11, s14
-               	stur	s31, [x29, #-0xd0]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xd0]
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	ldur	s31, [x29, #-0xd0]
-               	ldur	s30, [x29, #-0xa0]
-               	fadd	s11, s31, s30
-               	mov	x0, x1
-               	fmov	s0, s11
+               	fadd	s14, s10, s11
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	ldur	s30, [x29, #-0xc0]
-               	fadd	s14, s11, s30
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fadd	s10, s14, s12
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x80]
-               	mov.16b	v0, v31
-               	mov.s	v0[0], v14[0]
-               	ldur	s31, [x29, #-0xb0]
-               	fsub	s1, s31, s10
-               	mov.16b	v2, v0
-               	mov.s	v2[1], v1[0]
-               	fadd	s0, s13, s15
-               	mov.16b	v1, v2
-               	mov.s	v1[2], v0[0]
-               	fmov	s31, wzr
-               	fsub	s0, s31, s12
-               	mov.16b	v30, v1
-               	mov.s	v30[3], v0[0]
-               	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[0]
+               	fadd	s11, s10, s13
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xe0]
+               	ldur	q31, [x29, #-0x80]
+               	mov.16b	v0, v31
+               	mov.s	v0[0], v11[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s1, v31[3]
+               	ldur	q31, [x29, #-0x90]
+               	mov	s2, v31[0]
+               	fsub	s3, s1, s2
+               	mov.16b	v1, v0
+               	mov.s	v1[1], v3[0]
+               	ldur	q31, [x29, #-0x90]
                	mov	s0, v31[1]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s2, v31[2]
+               	fadd	s3, s0, s2
+               	mov.16b	v0, v1
+               	mov.s	v0[2], v3[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s10, v31[1]
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+               	mov.16b	v30, v0
+               	mov.s	v30[3], v1[0]
+               	stur	q30, [x29, #-0xa0]
+               	ldur	q0, [x29, #-0xa0]
 <L9>:
                	bl	 <L9>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[2]
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x90]
+               	fmul.4s	v0, v31, v30
 <L10>:
                	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31[3]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0x90]
-               	fmul.4s	v31, v31, v30
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[0]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
+               	fcmp	s0, s10
+               	cset	w1, mi
+               	cbnz	w1,  <L11>
+               	b	 <L12>
+<L11>:
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[1]
+<L12>:
+               	ldur	q31, [x29, #-0x80]
+               	mov	s1, v31[2]
+               	fcmp	s0, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L13>
+               	b	 <L14>
 <L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31[2]
 <L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31[3]
-<L15>:
-               	bl	 <L15>
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31[1]
+               	mov	s1, v31[3]
                	fcmp	s0, s1
                	cset	w1, mi
-               	cbnz	w1,  <L16>
-               	b	 <L17>
+               	cbnz	w1,  <L15>
+               	b	 <L16>
+<L15>:
+               	ldur	q31, [x29, #-0x80]
+               	mov	s0, v31[3]
 <L16>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[1]
+               	mov	s1, v31[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s2, v31[1]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L17>
+               	b	 <L18>
 <L17>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31[2]
-               	fcmp	s0, s1
-               	cset	w1, mi
-               	cbnz	w1,  <L18>
-               	b	 <L19>
+               	mov	s1, v31[1]
 <L18>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[2]
+               	mov	s2, v31[2]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L19>
+               	b	 <L20>
 <L19>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31[3]
-               	fcmp	s0, s1
-               	cset	w1, mi
-               	cbnz	w1,  <L20>
-               	fmov	d9, d0
-               	b	 <L21>
+               	mov	s1, v31[2]
 <L20>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s9, v31[3]
+               	mov	s2, v31[3]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L21>
+               	b	 <L22>
 <L21>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31[1]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L22>
-               	b	 <L23>
-<L22>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[1]
-<L23>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31[2]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L24>
-               	b	 <L25>
-<L24>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31[2]
-<L25>:
-               	ldur	q31, [x29, #-0x80]
                	mov	s1, v31[3]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L26>
-               	fmov	d10, d0
-               	b	 <L27>
+<L22>:
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s10, v31[3]
+               	fsub	s2, s0, s1
+               	fmov	w1, s2
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
-               	fmov	s0, s9
-<L28>:
-               	bl	 <L28>
-               	fmov	s0, s10
-<L29>:
-               	bl	 <L29>
-               	fsub	s0, s9, s10
-<L30>:
-               	bl	 <L30>
+               	bl	 <L27>
                	sub	x1, x29, #0x30
                	add	x2, x1, #0x0
                	mov	w17, #0x7               ; =7
@@ -384,116 +565,47 @@ Disassembly of section __TEXT,__text:
                	add	w3, w1, w2
                	mov.16b	v30, v0
                	mov.s	v30[1], w3
-               	stur	q30, [x29, #-0x100]
+               	stur	q30, [x29, #-0xb0]
                	sub	x19, x29, #0x40
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov.s	w1, v31[0]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov.16b	v2, v1
                	mov.s	v2[0], v0[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov.s	w1, v31[1]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov.16b	v2, v1
                	mov.s	v2[1], v0[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov.s	w1, v31[2]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov.16b	v2, v1
                	mov.s	v2[2], v0[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov.s	w1, v31[3]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov.16b	v2, v1
                	mov.s	v2[3], v0[0]
                	str	q2, [x19]
-               	ldr	q31, [x19]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L34>:
-               	bl	 <L34>
+               	ldr	q0, [x19]
+<L28>:
+               	bl	 <L28>
                	ldr	q0, [x19]
                	ldur	q30, [x29, #-0x80]
-               	fmul.4s	v31, v0, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L38>:
-               	bl	 <L38>
+               	fmul.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L29>:
+               	bl	 <L29>
                	sub	x21, x29, #0x50
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -533,124 +645,21 @@ Disassembly of section __TEXT,__text:
                	mov.16b	v1, v0
                	mov.s	v1[3], w1
                	str	q1, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L42>:
-               	bl	 <L42>
                	ldr	q0, [x21]
-               	ldur	q30, [x29, #-0x100]
-               	mul.4s	v31, v0, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L46>:
-               	bl	 <L46>
+<L30>:
+               	bl	 <L30>
                	ldr	q0, [x21]
-               	ldur	q30, [x29, #-0x100]
-               	sub.4s	v31, v0, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L50>:
-               	bl	 <L50>
+               	ldur	q30, [x29, #-0xb0]
+               	mul.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L31>:
+               	bl	 <L31>
+               	ldr	q0, [x21]
+               	ldur	q30, [x29, #-0xb0]
+               	sub.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L32>:
+               	bl	 <L32>
                	sub	x1, x29, #0x60
                	add	x2, x1, #0x0
                	mov	w17, #0xffff            ; =65535
@@ -672,201 +681,90 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w20
                	mov.16b	v30, v0
                	mov.s	v30[3], w2
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	stur	q30, [x29, #-0xc0]
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w19, v31[0]
                	mov	w1, w19
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w20, v31[1]
-               	eor	w21, w19, w20
-               	mov	w1, w21
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w22, v31[2]
-               	mul	w23, w21, w22
-               	mov	w1, w23
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-               	sub	w21, w23, w1
-               	mov	w1, w21
-<L54>:
-               	bl	 <L54>
-               	sub	x23, x29, #0x70
-               	str	xzr, [x23]
-               	str	xzr, [x23, #0x8]
-               	ldr	q0, [x23]
-               	mov.16b	v1, v0
-               	mov.s	v1[0], w21
-               	str	q1, [x23]
-               	eor	w1, w21, w19
-               	ldr	q0, [x23]
-               	mov.16b	v1, v0
-               	mov.s	v1[1], w1
-               	str	q1, [x23]
-               	add	w1, w21, w20
-               	ldr	q0, [x23]
-               	mov.16b	v1, v0
-               	mov.s	v1[2], w1
-               	str	q1, [x23]
-               	sub	w1, w21, w22
-               	ldr	q0, [x23]
-               	mov.16b	v1, v0
-               	mov.s	v1[3], w1
-               	str	q1, [x23]
-               	ldr	q31, [x23]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+<L33>:
+               	bl	 <L33>
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[1]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	eor	w20, w19, w1
+               	mov	w1, w20
+<L34>:
+               	bl	 <L34>
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[2]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	mul	w19, w20, w1
+               	mov	w1, w19
+<L35>:
+               	bl	 <L35>
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[3]
-<L58>:
-               	bl	 <L58>
-               	ldr	q0, [x23]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.4s	v31, v0, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	sub	w20, w19, w1
+               	mov	w1, w20
+<L36>:
+               	bl	 <L36>
+               	sub	x19, x29, #0x70
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	ldr	q0, [x19]
+               	mov.16b	v1, v0
+               	mov.s	v1[0], w20
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[0]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	eor	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov.16b	v1, v0
+               	mov.s	v1[1], w2
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	add	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov.16b	v1, v0
+               	mov.s	v1[2], w2
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov.s	w1, v31[2]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L62>:
-               	bl	 <L62>
+               	sub	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov.16b	v1, v0
+               	mov.s	v1[3], w2
+               	str	q1, [x19]
+               	ldr	q0, [x19]
+<L37>:
+               	bl	 <L37>
+               	ldr	q0, [x19]
+               	ldur	q30, [x29, #-0xc0]
+               	add.4s	v1, v0, v30
+               	mov.16b	v0, v1
+<L38>:
+               	bl	 <L38>
                	mov	x19, x0
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0xe0]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x4
-               	b.lo	 <L63>
-               	b	 <L68>
-<L63>:
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L39>
+               	b	 <L41>
+<L39>:
+               	ldur	q31, [x29, #-0xe0]
                	mov	s0, v31[0]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s1, v31[3]
                	fadd	s2, s0, s1
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s0, v31[1]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s3, v31[2]
                	fsub	s4, s0, s3
                	fmov	s30, #0.50000000
                	fmul	s0, s3, s30
                	fmov	s30, #1.25000000
                	fadd	s3, s1, s30
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov.16b	v1, v31
                	mov.s	v1[0], v2[0]
                	mov.16b	v2, v1
@@ -875,72 +773,28 @@ Disassembly of section __TEXT,__text:
                	mov.s	v1[2], v0[0]
                	mov.16b	v30, v1
                	mov.s	v30[3], v3[0]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
+               	stur	q30, [x29, #-0xd0]
                	mov	x0, x19
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L67>:
-               	bl	 <L67>
+               	ldur	q0, [x29, #-0xd0]
+<L40>:
+               	bl	 <L40>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	stur	q31, [x29, #-0xe0]
                	cmp	x20, #0x4
-               	b.lo	 <L63>
-<L68>:
+               	b.lo	 <L39>
+<L41>:
                	mov	x0, x19
-               	sub	x16, x29, #0x1d8
-               	ldp	d9, d10, [x16]
-               	ldp	d11, d12, [x16, #-0x10]
-               	ldp	d13, d14, [x16, #-0x20]
-               	ldur	d15, [x16, #-0x28]
-               	ldp	x19, x20, [x29, #-0x1b0]
-               	ldp	x21, x22, [x29, #-0x1c0]
-               	mov	x16, #0xfe38            ; =65080
+               	ldp	d10, d11, [x29, #-0x108]
+               	ldp	d12, d13, [x29, #-0x118]
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x23, [x29, x16]
+               	ldr	d14, [x29, x16]
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldur	x21, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_u16x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u16x8.dis
@@ -3,1237 +3,553 @@ vec/vec_u16x8.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_u16x8.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[0]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[1]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.h	w1, v0[3]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.h	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.h	w1, v0[4]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	umov.h	w1, v0[5]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	umov.h	w1, v0[6]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	umov.h	w1, v0[7]
+               	uxth	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.vec.vec_u16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xfff0            ; =65520
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x1               ; =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x8000            ; =32768
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xffff            ; =65535
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1001            ; =4097
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x2               ; =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x9c40            ; =40000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x3039            ; =12345
+               	strh	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x11              ; =17
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xffff            ; =65535
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x8001            ; =32769
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x1               ; =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xea60            ; =60000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x7530            ; =30000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x63c1            ; =25537
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xd431            ; =54321
+               	strh	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               ; =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x3               ; =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               ; =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x1b              ; =27
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x51              ; =81
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xf3              ; =243
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x2d9             ; =729
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x88b             ; =2187
+               	strh	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strh	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov.h	w0, v0[0]
+               	add	w2, w0, w1
+               	mov.16b	v2, v0
+               	mov.h	v2[0], w2
+               	umov.h	w0, v2[6]
+               	add	w2, w0, w1
+               	mov.16b	v30, v2
+               	mov.h	v30[6], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov.h	w0, v1[2]
+               	add	w2, w0, w1
+               	mov.16b	v0, v1
+               	mov.h	v0[2], w2
+               	umov.h	w0, v0[7]
+               	add	w2, w0, w1
+               	mov.16b	v30, v0
+               	mov.h	v30[7], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0xfff0            ; =65520
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x1               ; =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x8000            ; =32768
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xffff            ; =65535
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x1001            ; =4097
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x2               ; =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x9c40            ; =40000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x3039            ; =12345
-               	strh	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	mov	w17, #0x11              ; =17
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xffff            ; =65535
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x8001            ; =32769
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x1               ; =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0xea60            ; =60000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x7530            ; =30000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x63c1            ; =25537
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xd431            ; =54321
-               	strh	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               ; =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x3               ; =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               ; =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x1b              ; =27
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x51              ; =81
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xf3              ; =243
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x2d9             ; =729
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x88b             ; =2187
-               	strh	w17, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x8
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xa
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xc
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xe
-               	strh	wzr, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xd0]
-               	umov.h	w2, v0[0]
-               	add	w3, w2, w1
-               	mov.16b	v2, v0
-               	mov.h	v2[0], w3
-               	umov.h	w2, v2[6]
-               	add	w3, w2, w1
-               	mov.16b	v30, v2
-               	mov.h	v30[6], w3
-               	stur	q30, [x29, #-0xe0]
-               	umov.h	w2, v1[2]
-               	add	w3, w2, w1
-               	mov.16b	v0, v1
-               	mov.h	v0[2], w3
-               	umov.h	w2, v0[7]
-               	add	w3, w2, w1
-               	mov.16b	v30, v0
-               	mov.h	v30[7], w3
-               	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[4]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[5]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[6]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	umov.h	w1, v31[7]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[4]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[5]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[6]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	umov.h	w1, v31[7]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.8h	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[4]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[5]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[6]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0x100]
-               	umov.h	w1, v31[7]
-<L24>:
-               	bl	 <L24>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L32>:
-               	bl	 <L32>
+               	sub.8h	v0, v31, v30
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L40>:
-               	bl	 <L40>
+               	sub.8h	v0, v31, v30
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L48>:
-               	bl	 <L48>
+               	mul.8h	v0, v31, v30
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L56>:
-               	bl	 <L56>
+               	mul.8h	v0, v31, v30
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L64>:
-               	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.8h	v0, v31, v30
+               	mul.8h	v0, v31, v30
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v0, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L72>:
-               	bl	 <L72>
+               	mul.8h	v0, v31, v30
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L80>:
-               	bl	 <L80>
+               	sub.8h	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.8h	v0, v31, v30
-<L81>:
-               	bl	 <L81>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L82>:
-               	bl	 <L82>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L83>:
-               	bl	 <L83>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-<L84>:
-               	bl	 <L84>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-<L85>:
-               	bl	 <L85>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfe80            ; =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L87>:
-               	bl	 <L87>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-               	b	 <L121>
-<L88>:
-               	mov	x16, #0xfe50            ; =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul.8h	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
                	mov	x0, x19
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfe50            ; =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.8h	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L120>:
-               	bl	 <L120>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-<L121>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1243,13 +559,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1258,7 +574,7 @@ Disassembly of section __TEXT,__text:
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1268,7 +584,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1276,89 +592,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-               	b	 <L131>
-<L122>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L130>:
-               	bl	 <L130>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-<L131>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -1371,94 +620,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L140>:
-               	bl	 <L140>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L141>:
-               	bl	 <L141>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_u32x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u32x4.dis
@@ -3,184 +3,235 @@ vec/vec_u32x4.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_u32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov.s	w1, v0[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.s	w2, v31[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.s	w1, v0[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov.s	w1, v0[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_u32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
                	mov	w17, #0xfff0            ; =65520
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x1               ; =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #-0x80000000       ; =-2147483648
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
                	mov	w17, #0x11              ; =17
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x1               ; =1
                	movk	w17, #0x8000, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1               ; =1
-               	str	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
                	mov	w17, #0x1               ; =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x9               ; =9
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1b              ; =27
-               	str	w17, [x3]
-               	ldr	q31, [x2]
+               	str	w17, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	str	wzr, [x3]
-               	add	x3, x2, #0x4
-               	str	wzr, [x3]
-               	add	x3, x2, #0x8
-               	str	wzr, [x3]
-               	add	x3, x2, #0xc
-               	str	wzr, [x3]
-               	ldr	q31, [x2]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	str	wzr, [x2]
+               	add	x2, x0, #0x4
+               	str	wzr, [x2]
+               	add	x2, x0, #0x8
+               	str	wzr, [x2]
+               	add	x2, x0, #0xc
+               	str	wzr, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xd0]
-               	mov.s	w2, v0[0]
-               	add	w3, w2, w1
+               	mov.s	w0, v0[0]
+               	add	w2, w0, w1
                	mov.16b	v2, v0
-               	mov.s	v2[0], w3
-               	mov.s	w2, v2[2]
-               	add	w3, w2, w1
+               	mov.s	v2[0], w2
+               	mov.s	w0, v2[2]
+               	add	w2, w0, w1
                	mov.16b	v30, v2
-               	mov.s	v30[2], w3
+               	mov.s	v30[2], w2
                	stur	q30, [x29, #-0xe0]
-               	mov.s	w2, v1[1]
-               	add	w3, w2, w1
+               	mov.s	w0, v1[1]
+               	add	w2, w0, w1
                	mov.16b	v0, v1
-               	mov.s	v0[1], w3
-               	mov.s	w2, v0[3]
-               	add	w3, w2, w1
+               	mov.s	v0[1], w2
+               	mov.s	w0, v0[3]
+               	add	w2, w0, w1
                	mov.16b	v30, v0
-               	mov.s	v30[3], w3
+               	mov.s	v30[3], w2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.s	w1, v31[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.s	w1, v31[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.4s	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0x100]
-               	mov.s	w1, v31[3]
-<L12>:
-               	bl	 <L12>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v31, v31, v30
+               	sub.4s	v0, v31, v30
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.4s	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	mul.4s	v0, v31, v30
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v0, v31, v30
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.4s	v0, v31, v30
+<L9>:
+               	bl	 <L9>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub.4s	v0, v31, v30
+<L10>:
+               	bl	 <L10>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -190,24 +241,35 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L13>:
                	bl	 <L13>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
 <L15>:
                	bl	 <L15>
                	mov	x16, #0xfef0            ; =65264
@@ -215,557 +277,159 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.4s	v31, v31, v30
                	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.4s	v0, v31, v30
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v0, v30
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.4s	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v0, v31, v30
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v0, v31, v30
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v0, v31
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v0, v31
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L47>:
-               	bl	 <L47>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfe50            ; =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul.4s	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.4s	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe50            ; =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.4s	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -775,13 +439,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -790,7 +454,7 @@ Disassembly of section __TEXT,__text:
                	add.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -800,7 +464,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -808,57 +472,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -871,62 +500,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_u64x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u64x2.dis
@@ -3,39 +3,57 @@ vec/vec_u64x2.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_u64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov.d	x1, v0[0]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov.d	x2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov.d	x1, v0[1]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_u64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0x10
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	x17, #0xfff0            ; =65520
                	movk	x17, #0xffff, lsl #16
@@ -47,7 +65,7 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0x1234, lsl #16
                	str	x17, [x2]
                	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
+               	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	x17, #0x11              ; =17
                	str	x17, [x2]
@@ -58,7 +76,7 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q1, [x1]
-               	sub	x1, x29, #0x30
+               	sub	x1, x29, #0xa0
                	add	x2, x1, #0x0
                	mov	x17, #0x1               ; =1
                	str	x17, [x2]
@@ -67,7 +85,7 @@ Disassembly of section __TEXT,__text:
                	str	x17, [x2]
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xc0]
-               	sub	x1, x29, #0x40
+               	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
                	add	x2, x1, #0x8
@@ -75,345 +93,205 @@ Disassembly of section __TEXT,__text:
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xd0]
                	mov.d	x1, v0[0]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov.16b	v30, v0
                	mov.d	v30[0], x2
                	stur	q30, [x29, #-0xe0]
                	mov.d	x1, v1[1]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov.16b	v30, v1
                	mov.d	v30[1], x2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[0]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[1]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub.2d	v0, v31, v30
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub.2d	v0, v31, v30
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
                	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xe0]
+               	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
                	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L7>:
                	bl	 <L7>
-               	mov	x16, #0xfef0            ; =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
+               	mov.d	x1, v31[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0x100]
                	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov.d	x2, v31[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0x100]
+               	mov.16b	v0, v31
+               	mov.d	v0[0], x3
+               	mov.16b	v1, v0
+               	mov.d	v1[1], x4
+               	mov.16b	v0, v1
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov.d	x1, v31[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov.16b	v0, v31
-               	mov.d	v0[0], x3
-               	mov.16b	v30, v0
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfeb0            ; =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add.2d	v0, v31, v30
-               	mov.d	x1, v0[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[0]
-               	mul	x3, x1, x2
-               	mov.d	x1, v0[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov.d	x2, v31[1]
-               	mul	x4, x1, x2
-               	mov.16b	v1, v0
-               	mov.d	v1[0], x3
-               	mov.16b	v30, v1
-               	mov.d	v30[1], x4
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L18>:
-               	bl	 <L18>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub.2d	v31, v31, v30
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            ; =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L20>:
-               	bl	 <L20>
+               	sub.2d	v0, v31, v30
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.2d	v0, v31, v30
-<L21>:
-               	bl	 <L21>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L23>:
-               	bl	 <L23>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-<L24>:
-               	bl	 <L24>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-<L25>:
-               	bl	 <L25>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe80            ; =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-<L27>:
-               	bl	 <L27>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-               	b	 <L37>
-<L28>:
-               	mov	x16, #0xfe60            ; =65120
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -422,7 +300,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -431,7 +309,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -440,156 +318,120 @@ Disassembly of section __TEXT,__text:
                	mov.d	v0[0], x2
                	mov.16b	v30, v0
                	mov.d	v30[1], x3
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
                	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe60            ; =65120
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L36>:
-               	bl	 <L36>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-<L37>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -599,13 +441,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -614,7 +456,7 @@ Disassembly of section __TEXT,__text:
                	add.2d	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -623,7 +465,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -632,7 +474,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -644,7 +486,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -652,41 +494,22 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-               	b	 <L41>
-<L38>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L40>:
-               	bl	 <L40>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-<L41>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -699,46 +522,64 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              ; =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L44>:
-               	bl	 <L44>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L45>:
-               	bl	 <L45>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_u8x16.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u8x16.dis
@@ -3,124 +3,326 @@ vec/vec_u8x16.o:
 Disassembly of section __TEXT,__text:
 
 <corpus.cases.vec.vec_u8x16.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[0]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[1]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[2]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[3]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[4]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[5]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[6]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov.b	w1, v0[7]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov.b	w2, v31[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov.b	w1, v0[8]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov.b	w1, v0[9]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov.b	w1, v0[10]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov.b	w1, v0[11]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov.b	w1, v0[12]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov.b	w1, v0[13]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov.b	w1, v0[14]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov.b	w1, v0[15]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                ; =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               ; =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              ; =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             ; =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_u8x16.checksum>:
@@ -133,289 +335,267 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xf0              ; =240
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x80              ; =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0xff              ; =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x11              ; =17
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xc8              ; =200
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x63              ; =99
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x7               ; =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfa              ; =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x21              ; =33
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x80              ; =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x40              ; =64
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x5               ; =5
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xc7              ; =199
+               	strb	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x11              ; =17
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0xff              ; =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x81              ; =129
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0xc8              ; =200
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x64              ; =100
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x39              ; =57
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x15              ; =21
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xff              ; =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x6               ; =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0xde              ; =222
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x80              ; =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0xc0              ; =192
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xfb              ; =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x39              ; =57
+               	strb	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               ; =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x3               ; =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x9               ; =9
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x1b              ; =27
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x2               ; =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x6               ; =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x12              ; =18
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x36              ; =54
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x4               ; =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0xc               ; =12
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x24              ; =36
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x6c              ; =108
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x8               ; =8
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x18              ; =24
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x48              ; =72
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xd8              ; =216
+               	strb	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x1
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x3
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x5
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x7
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xb
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xd
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xf
+               	strb	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov.b	w0, v0[0]
+               	add	w2, w0, w1
+               	mov.16b	v2, v0
+               	mov.b	v2[0], w2
+               	umov.b	w0, v2[7]
+               	add	w2, w0, w1
+               	mov.16b	v30, v2
+               	mov.b	v30[7], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov.b	w0, v1[3]
+               	add	w2, w0, w1
+               	mov.16b	v0, v1
+               	mov.b	v0[3], w2
+               	umov.b	w0, v0[12]
+               	add	w2, w0, w1
+               	mov.16b	v30, v0
+               	mov.b	v30[12], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             ; =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	sub	x3, x29, #0x10
-               	add	x4, x3, #0x0
-               	mov	w17, #0xf0              ; =240
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x80              ; =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0xff              ; =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x11              ; =17
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0xc8              ; =200
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x63              ; =99
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x7               ; =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0xfa              ; =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x21              ; =33
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x80              ; =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x40              ; =64
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x5               ; =5
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xc7              ; =199
-               	strb	w17, [x4]
-               	ldr	q0, [x3]
-               	sub	x3, x29, #0x20
-               	add	x4, x3, #0x0
-               	mov	w17, #0x11              ; =17
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0xff              ; =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x81              ; =129
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0xc8              ; =200
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x64              ; =100
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x39              ; =57
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x15              ; =21
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0xff              ; =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x6               ; =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0xde              ; =222
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x80              ; =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0xc0              ; =192
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0xfb              ; =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x39              ; =57
-               	strb	w17, [x4]
-               	ldr	q1, [x3]
-               	sub	x3, x29, #0x30
-               	add	x4, x3, #0x0
-               	mov	w17, #0x1               ; =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x3               ; =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x9               ; =9
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x1b              ; =27
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x2               ; =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x6               ; =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x12              ; =18
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x36              ; =54
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x4               ; =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0xc               ; =12
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x24              ; =36
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x6c              ; =108
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x8               ; =8
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x18              ; =24
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x48              ; =72
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xd8              ; =216
-               	strb	w17, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x3, x29, #0x40
-               	add	x4, x3, #0x0
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x1
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x2
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x3
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x4
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x5
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x6
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x7
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xa
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xb
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xc
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xd
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xe
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xf
-               	strb	wzr, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xd0]
-               	umov.b	w3, v0[0]
-               	add	w4, w3, w2
-               	mov.16b	v2, v0
-               	mov.b	v2[0], w4
-               	umov.b	w3, v2[7]
-               	add	w4, w3, w2
-               	mov.16b	v30, v2
-               	mov.b	v30[7], w4
-               	stur	q30, [x29, #-0xe0]
-               	umov.b	w3, v1[3]
-               	add	w4, w3, w2
-               	mov.16b	v0, v1
-               	mov.b	v0[3], w4
-               	umov.b	w3, v0[12]
-               	add	w4, w3, w2
-               	mov.16b	v30, v0
-               	mov.b	v30[12], w4
-               	stur	q30, [x29, #-0xf0]
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xf0]
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add.16b	v31, v31, v30
                	stur	q31, [x29, #-0x100]
-               	mov	x0, x1
                	ldur	q0, [x29, #-0x100]
-<L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	mul.16b	v0, v31, v30
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub.16b	v0, v31, v30
-               	mov	x0, x1
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
@@ -424,15 +604,13 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
@@ -441,34 +619,26 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor.16b	v0, v31, v30
-               	mov	x0, x1
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn.16b	v0, v31
-               	mov	x0, x1
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn.16b	v0, v31
-               	mov	x0, x1
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -480,9 +650,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v0, v31, v30
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfec0            ; =65216
@@ -504,9 +673,9 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -525,8 +694,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -548,8 +717,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -571,8 +740,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -590,8 +759,8 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
                	mov	x16, #0xfe70            ; =65136
@@ -625,9 +794,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L18>
-<L23>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -670,51 +839,55 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q0, [x1]
                	mov	x0, x19
-<L25>:
-               	bl	 <L25>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-<L26>:
-               	sub	x0, x29, #0xb0
-               	str	xzr, [x0]
-               	str	xzr, [x0, #0x8]
-               	str	xzr, [x0, #0x10]
-               	str	xzr, [x0, #0x18]
-               	str	xzr, [x0, #0x20]
-               	str	xzr, [x0, #0x28]
-               	add	x1, x0, #0x0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
+               	str	xzr, [x21]
+               	str	xzr, [x21, #0x8]
+               	str	xzr, [x21, #0x10]
+               	str	xzr, [x21, #0x18]
+               	str	xzr, [x21, #0x20]
+               	str	xzr, [x21, #0x28]
+               	add	x0, x21, #0x0
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x2, x20, #0x20
-               	ldr	q0, [x2]
-               	add	x20, x0, #0x10
-               	str	q0, [x20]
-               	add	x21, x0, #0x20
+               	str	w17, [x0]
+               	add	x1, x20, #0x20
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	add	x1, x21, #0x20
                	mov	w17, #0x5678            ; =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x21]
-               	ldr	w2, [x1]
+               	str	w17, [x1]
+               	ldr	w1, [x0]
+               	mov	w2, w1
                	mov	x0, x19
-               	mov	w1, w2
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	add	x1, x21, #0x10
+               	ldr	q0, [x1]
 <L27>:
                	bl	 <L27>
-               	ldr	q0, [x20]
+               	add	x1, x21, #0x20
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L28>:
                	bl	 <L28>
-               	ldr	w1, [x21]
-<L29>:
-               	bl	 <L29>
                	ldp	x19, x20, [x29, #-0x1a0]
                	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16

--- a/test/golden/spirv/bits/logic_u32.dis
+++ b/test/golden/spirv/bits/logic_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 284
+; Bound: 868
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,376 +9,1282 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.logic_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_2863311530 = OpConstant %uint 2863311530
 %uint_1431655765 = OpConstant %uint 1431655765
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_0 = OpConstant %uint 0
 %uint_8 = OpConstant %uint 8
 %uint_1 = OpConstant %uint 1
-%231 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%234 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%20 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_uint Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_uint Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_uint Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uint Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uint Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_uint Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_bool Function
-%60 = OpVariable %_ptr_Function_uint Function
-%61 = OpVariable %_ptr_Function_uint Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_uint Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_uint Function
-%69 = OpVariable %_ptr_Function_uint Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_uint Function
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_uint Function
-OpStore %15 %6
-%74 = OpFunctionCall %ulong %2
-OpStore %16 %74
-%75 = OpLoad %ulong %15
-%76 = OpUConvert %uint %75
-OpStore %18 %76
-%78 = OpLoad %uint %18
-%79 = OpBitwiseXor %uint %uint_4294967295 %78
-OpStore %19 %79
-%81 = OpLoad %uint %18
-%82 = OpBitwiseXor %uint %uint_2863311530 %81
-OpStore %20 %82
-%84 = OpLoad %uint %18
-%85 = OpBitwiseXor %uint %uint_1431655765 %84
-OpStore %21 %85
-%86 = OpLoad %uint %18
-%87 = OpLoad %uint %19
-%88 = OpBitwiseAnd %uint %86 %87
-OpStore %22 %88
-%89 = OpLoad %ulong %16
-%90 = OpLoad %uint %22
-%91 = OpFunctionCall %ulong %3 %89 %90
-OpStore %23 %91
-%92 = OpLoad %uint %18
-%93 = OpLoad %uint %19
-%94 = OpBitwiseOr %uint %92 %93
-OpStore %24 %94
-%95 = OpLoad %ulong %23
-%96 = OpLoad %uint %24
-%97 = OpFunctionCall %ulong %3 %95 %96
-OpStore %25 %97
-%98 = OpLoad %uint %18
-%99 = OpLoad %uint %19
-%100 = OpBitwiseXor %uint %98 %99
-OpStore %26 %100
-%101 = OpLoad %ulong %25
-%102 = OpLoad %uint %26
-%103 = OpFunctionCall %ulong %3 %101 %102
-OpStore %27 %103
-%104 = OpLoad %uint %18
-%105 = OpNot %uint %104
-OpStore %28 %105
-%106 = OpLoad %ulong %27
-%107 = OpLoad %uint %28
-%108 = OpFunctionCall %ulong %3 %106 %107
-OpStore %29 %108
-%109 = OpLoad %uint %19
-%110 = OpNot %uint %109
-OpStore %30 %110
-%111 = OpLoad %ulong %29
-%112 = OpLoad %uint %30
-%113 = OpFunctionCall %ulong %3 %111 %112
-OpStore %31 %113
-%114 = OpLoad %uint %20
-%115 = OpLoad %uint %21
-%116 = OpBitwiseAnd %uint %114 %115
-OpStore %32 %116
-%117 = OpLoad %ulong %31
-%118 = OpLoad %uint %32
-%119 = OpFunctionCall %ulong %3 %117 %118
-OpStore %33 %119
-%120 = OpLoad %uint %20
-%121 = OpLoad %uint %21
-%122 = OpBitwiseOr %uint %120 %121
-OpStore %34 %122
-%123 = OpLoad %ulong %33
-%124 = OpLoad %uint %34
-%125 = OpFunctionCall %ulong %3 %123 %124
-OpStore %35 %125
-%126 = OpLoad %uint %20
-%127 = OpLoad %uint %21
-%128 = OpBitwiseXor %uint %126 %127
-OpStore %36 %128
-%129 = OpLoad %ulong %35
-%130 = OpLoad %uint %36
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %37 %131
-%132 = OpLoad %uint %20
-%133 = OpNot %uint %132
-OpStore %38 %133
-%134 = OpLoad %ulong %37
-%135 = OpLoad %uint %38
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %39 %136
-%137 = OpLoad %uint %21
-%138 = OpNot %uint %137
-OpStore %40 %138
-%139 = OpLoad %ulong %39
-%140 = OpLoad %uint %40
-%141 = OpFunctionCall %ulong %3 %139 %140
-OpStore %41 %141
-%142 = OpLoad %uint %18
-%143 = OpLoad %uint %20
-%144 = OpBitwiseAnd %uint %142 %143
-OpStore %42 %144
-%145 = OpLoad %ulong %41
-%146 = OpLoad %uint %42
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %43 %147
-%148 = OpLoad %uint %19
-%149 = OpLoad %uint %21
-%150 = OpBitwiseOr %uint %148 %149
-OpStore %44 %150
-%151 = OpLoad %ulong %43
-%152 = OpLoad %uint %44
-%153 = OpFunctionCall %ulong %3 %151 %152
-OpStore %45 %153
-%154 = OpLoad %uint %18
-%155 = OpLoad %uint %21
-%156 = OpBitwiseAnd %uint %154 %155
-OpStore %46 %156
-%157 = OpLoad %ulong %45
-%158 = OpLoad %uint %46
-%159 = OpFunctionCall %ulong %3 %157 %158
-OpStore %47 %159
-%160 = OpLoad %uint %19
-%161 = OpLoad %uint %20
-%162 = OpBitwiseOr %uint %160 %161
-OpStore %48 %162
-%163 = OpLoad %ulong %47
-%164 = OpLoad %uint %48
-%165 = OpFunctionCall %ulong %3 %163 %164
-OpStore %49 %165
-%166 = OpLoad %uint %22
-%167 = OpLoad %uint %36
-%168 = OpBitwiseOr %uint %166 %167
-OpStore %50 %168
-%169 = OpLoad %ulong %49
-%170 = OpLoad %uint %50
-%171 = OpFunctionCall %ulong %3 %169 %170
-OpStore %51 %171
-%172 = OpLoad %uint %24
-%173 = OpNot %uint %172
-OpStore %52 %173
-%174 = OpLoad %ulong %51
-%175 = OpLoad %uint %52
-%176 = OpFunctionCall %ulong %3 %174 %175
-OpStore %53 %176
-%177 = OpLoad %uint %22
-%178 = OpNot %uint %177
-OpStore %54 %178
-%179 = OpLoad %ulong %53
-%180 = OpLoad %uint %54
-%181 = OpFunctionCall %ulong %3 %179 %180
-OpStore %55 %181
-%182 = OpLoad %uint %36
-%183 = OpNot %uint %182
-OpStore %56 %183
-%184 = OpLoad %ulong %55
-%185 = OpLoad %uint %56
-%186 = OpFunctionCall %ulong %3 %184 %185
-OpStore %57 %186
-%187 = OpLoad %ulong %57
-OpStore %72 %187
-OpStore %73 %uint_0
-OpBranch %8
-%8 = OpLabel
-%189 = OpLoad %uint %73
-%191 = OpULessThan %bool %189 %uint_8
-OpStore %59 %191
-%192 = OpLoad %bool %59
-OpLoopMerge %10 %11 None
-OpBranchConditional %192 %9 %10
-%10 = OpLabel
-%193 = OpLoad %ulong %72
-OpReturnValue %193
-%9 = OpLabel
-%194 = OpLoad %uint %18
-%195 = OpLoad %uint %73
-%196 = OpBitwiseXor %uint %194 %195
-OpStore %60 %196
-%197 = OpLoad %uint %19
-%198 = OpLoad %uint %73
-%199 = OpBitwiseOr %uint %197 %198
-OpStore %61 %199
-%200 = OpLoad %uint %21
-%201 = OpLoad %uint %73
-%202 = OpBitwiseXor %uint %200 %201
-OpStore %62 %202
-%203 = OpLoad %uint %20
-%204 = OpLoad %uint %62
-%205 = OpBitwiseAnd %uint %203 %204
-OpStore %63 %205
-%206 = OpLoad %uint %60
-%207 = OpLoad %uint %61
-%208 = OpBitwiseAnd %uint %206 %207
-OpStore %64 %208
-%209 = OpLoad %ulong %72
-%210 = OpLoad %uint %64
-%211 = OpFunctionCall %ulong %3 %209 %210
-OpStore %65 %211
-%212 = OpLoad %uint %60
-%213 = OpLoad %uint %63
-%214 = OpBitwiseOr %uint %212 %213
-OpStore %66 %214
-%215 = OpLoad %ulong %65
-%216 = OpLoad %uint %66
-%217 = OpFunctionCall %ulong %3 %215 %216
-OpStore %67 %217
-%218 = OpLoad %uint %60
-%219 = OpLoad %uint %63
-%220 = OpBitwiseXor %uint %218 %219
-OpStore %68 %220
-%221 = OpLoad %uint %68
-%222 = OpNot %uint %221
-OpStore %69 %222
-%223 = OpLoad %ulong %67
-%224 = OpLoad %uint %69
-%225 = OpFunctionCall %ulong %3 %223 %224
-OpStore %70 %225
-%226 = OpLoad %uint %73
-%228 = OpIAdd %uint %226 %uint_1
-OpStore %71 %228
-%229 = OpLoad %ulong %70
-OpStore %72 %229
-%230 = OpLoad %uint %71
-OpStore %73 %230
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %231
-%232 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %234
-%235 = OpFunctionParameter %ulong
-%236 = OpFunctionParameter %uint
-%237 = OpLabel
+%823 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%144 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_uint Function
+%149 = OpVariable %_ptr_Function_uint Function
+%150 = OpVariable %_ptr_Function_uint Function
+%151 = OpVariable %_ptr_Function_uint Function
+%152 = OpVariable %_ptr_Function_uint Function
+%153 = OpVariable %_ptr_Function_uint Function
+%154 = OpVariable %_ptr_Function_uint Function
+%155 = OpVariable %_ptr_Function_uint Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_uint Function
+%163 = OpVariable %_ptr_Function_uint Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_uint Function
+%166 = OpVariable %_ptr_Function_uint Function
+%167 = OpVariable %_ptr_Function_uint Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_uint Function
+%170 = OpVariable %_ptr_Function_uint Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_uint Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_uint Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_bool Function
+%178 = OpVariable %_ptr_Function_uint Function
+%179 = OpVariable %_ptr_Function_uint Function
+%180 = OpVariable %_ptr_Function_uint Function
+%181 = OpVariable %_ptr_Function_uint Function
+%182 = OpVariable %_ptr_Function_uint Function
+%183 = OpVariable %_ptr_Function_uint Function
+%184 = OpVariable %_ptr_Function_uint Function
+%185 = OpVariable %_ptr_Function_uint Function
+%186 = OpVariable %_ptr_Function_uint Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_uint Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_bool Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_bool Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_bool Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_bool Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_bool Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
 %244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_uint Function
+%245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_bool Function
+%247 = OpVariable %_ptr_Function_ulong Function
 %248 = OpVariable %_ptr_Function_ulong Function
 %249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_bool Function
 %251 = OpVariable %_ptr_Function_ulong Function
 %252 = OpVariable %_ptr_Function_ulong Function
 %253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
 %255 = OpVariable %_ptr_Function_ulong Function
-OpStore %244 %235
-OpStore %245 %236
-%256 = OpLoad %uint %245
-%257 = OpUConvert %ulong %256
-OpStore %246 %257
-OpBranch %238
-%238 = OpLabel
-%258 = OpLoad %ulong %244
-OpStore %254 %258
-OpStore %255 %ulong_0
-OpBranch %239
-%239 = OpLabel
-%260 = OpLoad %ulong %255
-%262 = OpULessThan %bool %260 %ulong_8
-OpStore %247 %262
-%263 = OpLoad %bool %247
-OpLoopMerge %241 %243 None
-OpBranchConditional %263 %240 %241
-%241 = OpLabel
-OpBranch %242
-%242 = OpLabel
-%264 = OpLoad %ulong %254
-OpReturnValue %264
-%240 = OpLabel
-%265 = OpLoad %ulong %255
-%266 = OpIMul %ulong %265 %ulong_8
-OpStore %248 %266
-%267 = OpLoad %ulong %246
-%268 = OpLoad %ulong %248
-%269 = OpShiftRightLogical %ulong %267 %268
-OpStore %249 %269
-%270 = OpLoad %ulong %249
-%272 = OpBitwiseAnd %ulong %270 %ulong_255
-OpStore %250 %272
-%273 = OpLoad %ulong %254
-%274 = OpLoad %ulong %250
-%275 = OpBitwiseXor %ulong %273 %274
-OpStore %251 %275
-%276 = OpLoad %ulong %251
-%278 = OpIMul %ulong %276 %ulong_1099511628211
-OpStore %252 %278
-%279 = OpLoad %ulong %255
-%281 = OpIAdd %ulong %279 %ulong_1
-OpStore %253 %281
-%282 = OpLoad %ulong %252
-OpStore %254 %282
-%283 = OpLoad %ulong %253
-OpStore %255 %283
-OpBranch %243
-%243 = OpLabel
-OpBranch %239
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_bool Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_bool Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_bool Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_bool Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_bool Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_bool Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_bool Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_bool Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+OpStore %144 %5
+OpBranch %10
+%10 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%349 = OpLoad %ulong %144
+%350 = OpUConvert %uint %349
+OpStore %146 %350
+%352 = OpLoad %uint %146
+%353 = OpBitwiseXor %uint %uint_4294967295 %352
+OpStore %147 %353
+%355 = OpLoad %uint %146
+%356 = OpBitwiseXor %uint %uint_2863311530 %355
+OpStore %148 %356
+%358 = OpLoad %uint %146
+%359 = OpBitwiseXor %uint %uint_1431655765 %358
+OpStore %149 %359
+%360 = OpLoad %uint %146
+%361 = OpLoad %uint %147
+%362 = OpBitwiseAnd %uint %360 %361
+OpStore %150 %362
+OpBranch %14
+%14 = OpLabel
+%363 = OpLoad %uint %150
+%364 = OpUConvert %ulong %363
+OpStore %190 %364
+OpBranch %23
+%23 = OpLabel
+OpStore %208 %ulong_14695981039346656037
+OpStore %209 %ulong_0
+OpBranch %24
+%24 = OpLabel
+%367 = OpLoad %ulong %209
+%369 = OpULessThan %bool %367 %ulong_8
+OpStore %201 %369
+%370 = OpLoad %bool %201
+OpLoopMerge %26 %140 None
+OpBranchConditional %370 %25 %26
+%26 = OpLabel
+OpBranch %27
+%27 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%371 = OpLoad %uint %146
+%372 = OpLoad %uint %147
+%373 = OpBitwiseOr %uint %371 %372
+OpStore %151 %373
+OpBranch %28
+%28 = OpLabel
+%374 = OpLoad %uint %151
+%375 = OpUConvert %ulong %374
+OpStore %210 %375
+OpBranch %37
+%37 = OpLabel
+%376 = OpLoad %ulong %208
+OpStore %228 %376
+OpStore %229 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%377 = OpLoad %ulong %229
+%378 = OpULessThan %bool %377 %ulong_8
+OpStore %221 %378
+%379 = OpLoad %bool %221
+OpLoopMerge %40 %139 None
+OpBranchConditional %379 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%380 = OpLoad %uint %146
+%381 = OpLoad %uint %147
+%382 = OpBitwiseXor %uint %380 %381
+OpStore %152 %382
+OpBranch %42
+%42 = OpLabel
+%383 = OpLoad %uint %152
+%384 = OpUConvert %ulong %383
+OpStore %230 %384
+OpBranch %49
+%49 = OpLabel
+%385 = OpLoad %ulong %228
+OpStore %247 %385
+OpStore %248 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%386 = OpLoad %ulong %248
+%387 = OpULessThan %bool %386 %ulong_8
+OpStore %240 %387
+%388 = OpLoad %bool %240
+OpLoopMerge %52 %138 None
+OpBranchConditional %388 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %43
+%43 = OpLabel
+%389 = OpLoad %uint %146
+%390 = OpNot %uint %389
+OpStore %153 %390
+OpBranch %54
+%54 = OpLabel
+%391 = OpLoad %uint %153
+%392 = OpUConvert %ulong %391
+OpStore %249 %392
+OpBranch %56
+%56 = OpLabel
+%393 = OpLoad %ulong %247
+OpStore %257 %393
+OpStore %258 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%394 = OpLoad %ulong %258
+%395 = OpULessThan %bool %394 %ulong_8
+OpStore %250 %395
+%396 = OpLoad %bool %250
+OpLoopMerge %59 %137 None
+OpBranchConditional %396 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%397 = OpLoad %uint %147
+%398 = OpNot %uint %397
+OpStore %154 %398
+OpBranch %61
+%61 = OpLabel
+%399 = OpLoad %uint %154
+%400 = OpUConvert %ulong %399
+OpStore %259 %400
+OpBranch %63
+%63 = OpLabel
+%401 = OpLoad %ulong %257
+OpStore %267 %401
+OpStore %268 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%402 = OpLoad %ulong %268
+%403 = OpULessThan %bool %402 %ulong_8
+OpStore %260 %403
+%404 = OpLoad %bool %260
+OpLoopMerge %66 %136 None
+OpBranchConditional %404 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%405 = OpLoad %uint %148
+%406 = OpLoad %uint %149
+%407 = OpBitwiseAnd %uint %405 %406
+OpStore %155 %407
+OpBranch %68
+%68 = OpLabel
+%408 = OpLoad %uint %155
+%409 = OpUConvert %ulong %408
+OpStore %269 %409
+OpBranch %70
+%70 = OpLabel
+%410 = OpLoad %ulong %267
+OpStore %277 %410
+OpStore %278 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%411 = OpLoad %ulong %278
+%412 = OpULessThan %bool %411 %ulong_8
+OpStore %270 %412
+%413 = OpLoad %bool %270
+OpLoopMerge %73 %135 None
+OpBranchConditional %413 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%414 = OpLoad %uint %148
+%415 = OpLoad %uint %149
+%416 = OpBitwiseOr %uint %414 %415
+OpStore %156 %416
+OpBranch %75
+%75 = OpLabel
+%417 = OpLoad %uint %156
+%418 = OpUConvert %ulong %417
+OpStore %279 %418
+OpBranch %77
+%77 = OpLabel
+%419 = OpLoad %ulong %277
+OpStore %287 %419
+OpStore %288 %ulong_0
+OpBranch %78
+%78 = OpLabel
+%420 = OpLoad %ulong %288
+%421 = OpULessThan %bool %420 %ulong_8
+OpStore %280 %421
+%422 = OpLoad %bool %280
+OpLoopMerge %80 %134 None
+OpBranchConditional %422 %79 %80
+%80 = OpLabel
+OpBranch %81
+%81 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%423 = OpLoad %uint %148
+%424 = OpLoad %uint %149
+%425 = OpBitwiseXor %uint %423 %424
+OpStore %157 %425
+OpBranch %82
+%82 = OpLabel
+%426 = OpLoad %uint %157
+%427 = OpUConvert %ulong %426
+OpStore %289 %427
+OpBranch %84
+%84 = OpLabel
+%428 = OpLoad %ulong %287
+OpStore %297 %428
+OpStore %298 %ulong_0
+OpBranch %85
+%85 = OpLabel
+%429 = OpLoad %ulong %298
+%430 = OpULessThan %bool %429 %ulong_8
+OpStore %290 %430
+%431 = OpLoad %bool %290
+OpLoopMerge %87 %133 None
+OpBranchConditional %431 %86 %87
+%87 = OpLabel
+OpBranch %88
+%88 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%432 = OpLoad %uint %148
+%433 = OpNot %uint %432
+OpStore %158 %433
+OpBranch %89
+%89 = OpLabel
+%434 = OpLoad %uint %158
+%435 = OpUConvert %ulong %434
+OpStore %299 %435
+OpBranch %91
+%91 = OpLabel
+%436 = OpLoad %ulong %297
+OpStore %307 %436
+OpStore %308 %ulong_0
+OpBranch %92
+%92 = OpLabel
+%437 = OpLoad %ulong %308
+%438 = OpULessThan %bool %437 %ulong_8
+OpStore %300 %438
+%439 = OpLoad %bool %300
+OpLoopMerge %94 %132 None
+OpBranchConditional %439 %93 %94
+%94 = OpLabel
+OpBranch %95
+%95 = OpLabel
+OpBranch %90
+%90 = OpLabel
+%440 = OpLoad %uint %149
+%441 = OpNot %uint %440
+OpStore %159 %441
+OpBranch %96
+%96 = OpLabel
+%442 = OpLoad %uint %159
+%443 = OpUConvert %ulong %442
+OpStore %309 %443
+OpBranch %98
+%98 = OpLabel
+%444 = OpLoad %ulong %307
+OpStore %317 %444
+OpStore %318 %ulong_0
+OpBranch %99
+%99 = OpLabel
+%445 = OpLoad %ulong %318
+%446 = OpULessThan %bool %445 %ulong_8
+OpStore %310 %446
+%447 = OpLoad %bool %310
+OpLoopMerge %101 %131 None
+OpBranchConditional %447 %100 %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%448 = OpLoad %uint %146
+%449 = OpLoad %uint %148
+%450 = OpBitwiseAnd %uint %448 %449
+OpStore %160 %450
+OpBranch %103
+%103 = OpLabel
+%451 = OpLoad %uint %160
+%452 = OpUConvert %ulong %451
+OpStore %319 %452
+OpBranch %105
+%105 = OpLabel
+%453 = OpLoad %ulong %317
+OpStore %327 %453
+OpStore %328 %ulong_0
+OpBranch %106
+%106 = OpLabel
+%454 = OpLoad %ulong %328
+%455 = OpULessThan %bool %454 %ulong_8
+OpStore %320 %455
+%456 = OpLoad %bool %320
+OpLoopMerge %108 %130 None
+OpBranchConditional %456 %107 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %104
+%104 = OpLabel
+%457 = OpLoad %uint %147
+%458 = OpLoad %uint %149
+%459 = OpBitwiseOr %uint %457 %458
+OpStore %161 %459
+OpBranch %110
+%110 = OpLabel
+%460 = OpLoad %uint %161
+%461 = OpUConvert %ulong %460
+OpStore %329 %461
+OpBranch %112
+%112 = OpLabel
+%462 = OpLoad %ulong %327
+OpStore %337 %462
+OpStore %338 %ulong_0
+OpBranch %113
+%113 = OpLabel
+%463 = OpLoad %ulong %338
+%464 = OpULessThan %bool %463 %ulong_8
+OpStore %330 %464
+%465 = OpLoad %bool %330
+OpLoopMerge %115 %129 None
+OpBranchConditional %465 %114 %115
+%115 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%466 = OpLoad %uint %146
+%467 = OpLoad %uint %149
+%468 = OpBitwiseAnd %uint %466 %467
+OpStore %162 %468
+OpBranch %117
+%117 = OpLabel
+%469 = OpLoad %uint %162
+%470 = OpUConvert %ulong %469
+OpStore %339 %470
+OpBranch %119
+%119 = OpLabel
+%471 = OpLoad %ulong %337
+OpStore %347 %471
+OpStore %348 %ulong_0
+OpBranch %120
+%120 = OpLabel
+%472 = OpLoad %ulong %348
+%473 = OpULessThan %bool %472 %ulong_8
+OpStore %340 %473
+%474 = OpLoad %bool %340
+OpLoopMerge %122 %128 None
+OpBranchConditional %474 %121 %122
+%122 = OpLabel
+OpBranch %123
+%123 = OpLabel
+OpBranch %118
+%118 = OpLabel
+%475 = OpLoad %uint %147
+%476 = OpLoad %uint %148
+%477 = OpBitwiseOr %uint %475 %476
+OpStore %163 %477
+%478 = OpLoad %ulong %347
+%479 = OpLoad %uint %163
+%480 = OpFunctionCall %ulong %2 %478 %479
+OpStore %164 %480
+%481 = OpLoad %uint %146
+%482 = OpLoad %uint %147
+%483 = OpBitwiseAnd %uint %481 %482
+OpStore %165 %483
+%484 = OpLoad %uint %148
+%485 = OpLoad %uint %149
+%486 = OpBitwiseXor %uint %484 %485
+OpStore %166 %486
+%487 = OpLoad %uint %165
+%488 = OpLoad %uint %166
+%489 = OpBitwiseOr %uint %487 %488
+OpStore %167 %489
+%490 = OpLoad %ulong %164
+%491 = OpLoad %uint %167
+%492 = OpFunctionCall %ulong %2 %490 %491
+OpStore %168 %492
+%493 = OpLoad %uint %146
+%494 = OpLoad %uint %147
+%495 = OpBitwiseOr %uint %493 %494
+OpStore %169 %495
+%496 = OpLoad %uint %169
+%497 = OpNot %uint %496
+OpStore %170 %497
+%498 = OpLoad %ulong %168
+%499 = OpLoad %uint %170
+%500 = OpFunctionCall %ulong %2 %498 %499
+OpStore %171 %500
+%501 = OpLoad %uint %165
+%502 = OpNot %uint %501
+OpStore %172 %502
+%503 = OpLoad %ulong %171
+%504 = OpLoad %uint %172
+%505 = OpFunctionCall %ulong %2 %503 %504
+OpStore %173 %505
+%506 = OpLoad %uint %166
+%507 = OpNot %uint %506
+OpStore %174 %507
+%508 = OpLoad %ulong %173
+%509 = OpLoad %uint %174
+%510 = OpFunctionCall %ulong %2 %508 %509
+OpStore %175 %510
+%511 = OpLoad %ulong %175
+OpStore %187 %511
+OpStore %188 %uint_0
+OpBranch %7
+%7 = OpLabel
+%513 = OpLoad %uint %188
+%515 = OpULessThan %bool %513 %uint_8
+OpStore %177 %515
+%516 = OpLoad %bool %177
+OpLoopMerge %9 %127 None
+OpBranchConditional %516 %8 %9
+%9 = OpLabel
+%517 = OpLoad %ulong %187
+OpReturnValue %517
+%8 = OpLabel
+%518 = OpLoad %uint %146
+%519 = OpLoad %uint %188
+%520 = OpBitwiseXor %uint %518 %519
+OpStore %178 %520
+%521 = OpLoad %uint %147
+%522 = OpLoad %uint %188
+%523 = OpBitwiseOr %uint %521 %522
+OpStore %179 %523
+%524 = OpLoad %uint %149
+%525 = OpLoad %uint %188
+%526 = OpBitwiseXor %uint %524 %525
+OpStore %180 %526
+%527 = OpLoad %uint %148
+%528 = OpLoad %uint %180
+%529 = OpBitwiseAnd %uint %527 %528
+OpStore %181 %529
+%530 = OpLoad %uint %178
+%531 = OpLoad %uint %179
+%532 = OpBitwiseAnd %uint %530 %531
+OpStore %182 %532
+OpBranch %12
+%12 = OpLabel
+%533 = OpLoad %uint %182
+%534 = OpUConvert %ulong %533
+OpStore %189 %534
+OpBranch %16
+%16 = OpLabel
+%535 = OpLoad %ulong %187
+OpStore %198 %535
+OpStore %199 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%536 = OpLoad %ulong %199
+%537 = OpULessThan %bool %536 %ulong_8
+OpStore %191 %537
+%538 = OpLoad %bool %191
+OpLoopMerge %19 %126 None
+OpBranchConditional %538 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%539 = OpLoad %uint %178
+%540 = OpLoad %uint %181
+%541 = OpBitwiseOr %uint %539 %540
+OpStore %183 %541
+OpBranch %21
+%21 = OpLabel
+%542 = OpLoad %uint %183
+%543 = OpUConvert %ulong %542
+OpStore %200 %543
+OpBranch %30
+%30 = OpLabel
+%544 = OpLoad %ulong %198
+OpStore %218 %544
+OpStore %219 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%545 = OpLoad %ulong %219
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %211 %546
+%547 = OpLoad %bool %211
+OpLoopMerge %33 %125 None
+OpBranchConditional %547 %32 %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%548 = OpLoad %uint %178
+%549 = OpLoad %uint %181
+%550 = OpBitwiseXor %uint %548 %549
+OpStore %184 %550
+%551 = OpLoad %uint %184
+%552 = OpNot %uint %551
+OpStore %185 %552
+OpBranch %35
+%35 = OpLabel
+%553 = OpLoad %uint %185
+%554 = OpUConvert %ulong %553
+OpStore %220 %554
+OpBranch %44
+%44 = OpLabel
+%555 = OpLoad %ulong %218
+OpStore %238 %555
+OpStore %239 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%556 = OpLoad %ulong %239
+%557 = OpULessThan %bool %556 %ulong_8
+OpStore %231 %557
+%558 = OpLoad %bool %231
+OpLoopMerge %47 %124 None
+OpBranchConditional %558 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%559 = OpLoad %uint %188
+%561 = OpIAdd %uint %559 %uint_1
+OpStore %186 %561
+%562 = OpLoad %ulong %238
+OpStore %187 %562
+%563 = OpLoad %uint %186
+OpStore %188 %563
+OpBranch %127
+%46 = OpLabel
+%564 = OpLoad %ulong %239
+%565 = OpIMul %ulong %564 %ulong_8
+OpStore %232 %565
+%566 = OpLoad %ulong %220
+%567 = OpLoad %ulong %232
+%568 = OpShiftRightLogical %ulong %566 %567
+OpStore %233 %568
+%569 = OpLoad %ulong %233
+%571 = OpBitwiseAnd %ulong %569 %ulong_255
+OpStore %234 %571
+%572 = OpLoad %ulong %238
+%573 = OpLoad %ulong %234
+%574 = OpBitwiseXor %ulong %572 %573
+OpStore %235 %574
+%575 = OpLoad %ulong %235
+%577 = OpIMul %ulong %575 %ulong_1099511628211
+OpStore %236 %577
+%578 = OpLoad %ulong %239
+%580 = OpIAdd %ulong %578 %ulong_1
+OpStore %237 %580
+%581 = OpLoad %ulong %236
+OpStore %238 %581
+%582 = OpLoad %ulong %237
+OpStore %239 %582
+OpBranch %124
+%32 = OpLabel
+%583 = OpLoad %ulong %219
+%584 = OpIMul %ulong %583 %ulong_8
+OpStore %212 %584
+%585 = OpLoad %ulong %200
+%586 = OpLoad %ulong %212
+%587 = OpShiftRightLogical %ulong %585 %586
+OpStore %213 %587
+%588 = OpLoad %ulong %213
+%589 = OpBitwiseAnd %ulong %588 %ulong_255
+OpStore %214 %589
+%590 = OpLoad %ulong %218
+%591 = OpLoad %ulong %214
+%592 = OpBitwiseXor %ulong %590 %591
+OpStore %215 %592
+%593 = OpLoad %ulong %215
+%594 = OpIMul %ulong %593 %ulong_1099511628211
+OpStore %216 %594
+%595 = OpLoad %ulong %219
+%596 = OpIAdd %ulong %595 %ulong_1
+OpStore %217 %596
+%597 = OpLoad %ulong %216
+OpStore %218 %597
+%598 = OpLoad %ulong %217
+OpStore %219 %598
+OpBranch %125
+%18 = OpLabel
+%599 = OpLoad %ulong %199
+%600 = OpIMul %ulong %599 %ulong_8
+OpStore %192 %600
+%601 = OpLoad %ulong %189
+%602 = OpLoad %ulong %192
+%603 = OpShiftRightLogical %ulong %601 %602
+OpStore %193 %603
+%604 = OpLoad %ulong %193
+%605 = OpBitwiseAnd %ulong %604 %ulong_255
+OpStore %194 %605
+%606 = OpLoad %ulong %198
+%607 = OpLoad %ulong %194
+%608 = OpBitwiseXor %ulong %606 %607
+OpStore %195 %608
+%609 = OpLoad %ulong %195
+%610 = OpIMul %ulong %609 %ulong_1099511628211
+OpStore %196 %610
+%611 = OpLoad %ulong %199
+%612 = OpIAdd %ulong %611 %ulong_1
+OpStore %197 %612
+%613 = OpLoad %ulong %196
+OpStore %198 %613
+%614 = OpLoad %ulong %197
+OpStore %199 %614
+OpBranch %126
+%121 = OpLabel
+%615 = OpLoad %ulong %348
+%616 = OpIMul %ulong %615 %ulong_8
+OpStore %341 %616
+%617 = OpLoad %ulong %339
+%618 = OpLoad %ulong %341
+%619 = OpShiftRightLogical %ulong %617 %618
+OpStore %342 %619
+%620 = OpLoad %ulong %342
+%621 = OpBitwiseAnd %ulong %620 %ulong_255
+OpStore %343 %621
+%622 = OpLoad %ulong %347
+%623 = OpLoad %ulong %343
+%624 = OpBitwiseXor %ulong %622 %623
+OpStore %344 %624
+%625 = OpLoad %ulong %344
+%626 = OpIMul %ulong %625 %ulong_1099511628211
+OpStore %345 %626
+%627 = OpLoad %ulong %348
+%628 = OpIAdd %ulong %627 %ulong_1
+OpStore %346 %628
+%629 = OpLoad %ulong %345
+OpStore %347 %629
+%630 = OpLoad %ulong %346
+OpStore %348 %630
+OpBranch %128
+%114 = OpLabel
+%631 = OpLoad %ulong %338
+%632 = OpIMul %ulong %631 %ulong_8
+OpStore %331 %632
+%633 = OpLoad %ulong %329
+%634 = OpLoad %ulong %331
+%635 = OpShiftRightLogical %ulong %633 %634
+OpStore %332 %635
+%636 = OpLoad %ulong %332
+%637 = OpBitwiseAnd %ulong %636 %ulong_255
+OpStore %333 %637
+%638 = OpLoad %ulong %337
+%639 = OpLoad %ulong %333
+%640 = OpBitwiseXor %ulong %638 %639
+OpStore %334 %640
+%641 = OpLoad %ulong %334
+%642 = OpIMul %ulong %641 %ulong_1099511628211
+OpStore %335 %642
+%643 = OpLoad %ulong %338
+%644 = OpIAdd %ulong %643 %ulong_1
+OpStore %336 %644
+%645 = OpLoad %ulong %335
+OpStore %337 %645
+%646 = OpLoad %ulong %336
+OpStore %338 %646
+OpBranch %129
+%107 = OpLabel
+%647 = OpLoad %ulong %328
+%648 = OpIMul %ulong %647 %ulong_8
+OpStore %321 %648
+%649 = OpLoad %ulong %319
+%650 = OpLoad %ulong %321
+%651 = OpShiftRightLogical %ulong %649 %650
+OpStore %322 %651
+%652 = OpLoad %ulong %322
+%653 = OpBitwiseAnd %ulong %652 %ulong_255
+OpStore %323 %653
+%654 = OpLoad %ulong %327
+%655 = OpLoad %ulong %323
+%656 = OpBitwiseXor %ulong %654 %655
+OpStore %324 %656
+%657 = OpLoad %ulong %324
+%658 = OpIMul %ulong %657 %ulong_1099511628211
+OpStore %325 %658
+%659 = OpLoad %ulong %328
+%660 = OpIAdd %ulong %659 %ulong_1
+OpStore %326 %660
+%661 = OpLoad %ulong %325
+OpStore %327 %661
+%662 = OpLoad %ulong %326
+OpStore %328 %662
+OpBranch %130
+%100 = OpLabel
+%663 = OpLoad %ulong %318
+%664 = OpIMul %ulong %663 %ulong_8
+OpStore %311 %664
+%665 = OpLoad %ulong %309
+%666 = OpLoad %ulong %311
+%667 = OpShiftRightLogical %ulong %665 %666
+OpStore %312 %667
+%668 = OpLoad %ulong %312
+%669 = OpBitwiseAnd %ulong %668 %ulong_255
+OpStore %313 %669
+%670 = OpLoad %ulong %317
+%671 = OpLoad %ulong %313
+%672 = OpBitwiseXor %ulong %670 %671
+OpStore %314 %672
+%673 = OpLoad %ulong %314
+%674 = OpIMul %ulong %673 %ulong_1099511628211
+OpStore %315 %674
+%675 = OpLoad %ulong %318
+%676 = OpIAdd %ulong %675 %ulong_1
+OpStore %316 %676
+%677 = OpLoad %ulong %315
+OpStore %317 %677
+%678 = OpLoad %ulong %316
+OpStore %318 %678
+OpBranch %131
+%93 = OpLabel
+%679 = OpLoad %ulong %308
+%680 = OpIMul %ulong %679 %ulong_8
+OpStore %301 %680
+%681 = OpLoad %ulong %299
+%682 = OpLoad %ulong %301
+%683 = OpShiftRightLogical %ulong %681 %682
+OpStore %302 %683
+%684 = OpLoad %ulong %302
+%685 = OpBitwiseAnd %ulong %684 %ulong_255
+OpStore %303 %685
+%686 = OpLoad %ulong %307
+%687 = OpLoad %ulong %303
+%688 = OpBitwiseXor %ulong %686 %687
+OpStore %304 %688
+%689 = OpLoad %ulong %304
+%690 = OpIMul %ulong %689 %ulong_1099511628211
+OpStore %305 %690
+%691 = OpLoad %ulong %308
+%692 = OpIAdd %ulong %691 %ulong_1
+OpStore %306 %692
+%693 = OpLoad %ulong %305
+OpStore %307 %693
+%694 = OpLoad %ulong %306
+OpStore %308 %694
+OpBranch %132
+%86 = OpLabel
+%695 = OpLoad %ulong %298
+%696 = OpIMul %ulong %695 %ulong_8
+OpStore %291 %696
+%697 = OpLoad %ulong %289
+%698 = OpLoad %ulong %291
+%699 = OpShiftRightLogical %ulong %697 %698
+OpStore %292 %699
+%700 = OpLoad %ulong %292
+%701 = OpBitwiseAnd %ulong %700 %ulong_255
+OpStore %293 %701
+%702 = OpLoad %ulong %297
+%703 = OpLoad %ulong %293
+%704 = OpBitwiseXor %ulong %702 %703
+OpStore %294 %704
+%705 = OpLoad %ulong %294
+%706 = OpIMul %ulong %705 %ulong_1099511628211
+OpStore %295 %706
+%707 = OpLoad %ulong %298
+%708 = OpIAdd %ulong %707 %ulong_1
+OpStore %296 %708
+%709 = OpLoad %ulong %295
+OpStore %297 %709
+%710 = OpLoad %ulong %296
+OpStore %298 %710
+OpBranch %133
+%79 = OpLabel
+%711 = OpLoad %ulong %288
+%712 = OpIMul %ulong %711 %ulong_8
+OpStore %281 %712
+%713 = OpLoad %ulong %279
+%714 = OpLoad %ulong %281
+%715 = OpShiftRightLogical %ulong %713 %714
+OpStore %282 %715
+%716 = OpLoad %ulong %282
+%717 = OpBitwiseAnd %ulong %716 %ulong_255
+OpStore %283 %717
+%718 = OpLoad %ulong %287
+%719 = OpLoad %ulong %283
+%720 = OpBitwiseXor %ulong %718 %719
+OpStore %284 %720
+%721 = OpLoad %ulong %284
+%722 = OpIMul %ulong %721 %ulong_1099511628211
+OpStore %285 %722
+%723 = OpLoad %ulong %288
+%724 = OpIAdd %ulong %723 %ulong_1
+OpStore %286 %724
+%725 = OpLoad %ulong %285
+OpStore %287 %725
+%726 = OpLoad %ulong %286
+OpStore %288 %726
+OpBranch %134
+%72 = OpLabel
+%727 = OpLoad %ulong %278
+%728 = OpIMul %ulong %727 %ulong_8
+OpStore %271 %728
+%729 = OpLoad %ulong %269
+%730 = OpLoad %ulong %271
+%731 = OpShiftRightLogical %ulong %729 %730
+OpStore %272 %731
+%732 = OpLoad %ulong %272
+%733 = OpBitwiseAnd %ulong %732 %ulong_255
+OpStore %273 %733
+%734 = OpLoad %ulong %277
+%735 = OpLoad %ulong %273
+%736 = OpBitwiseXor %ulong %734 %735
+OpStore %274 %736
+%737 = OpLoad %ulong %274
+%738 = OpIMul %ulong %737 %ulong_1099511628211
+OpStore %275 %738
+%739 = OpLoad %ulong %278
+%740 = OpIAdd %ulong %739 %ulong_1
+OpStore %276 %740
+%741 = OpLoad %ulong %275
+OpStore %277 %741
+%742 = OpLoad %ulong %276
+OpStore %278 %742
+OpBranch %135
+%65 = OpLabel
+%743 = OpLoad %ulong %268
+%744 = OpIMul %ulong %743 %ulong_8
+OpStore %261 %744
+%745 = OpLoad %ulong %259
+%746 = OpLoad %ulong %261
+%747 = OpShiftRightLogical %ulong %745 %746
+OpStore %262 %747
+%748 = OpLoad %ulong %262
+%749 = OpBitwiseAnd %ulong %748 %ulong_255
+OpStore %263 %749
+%750 = OpLoad %ulong %267
+%751 = OpLoad %ulong %263
+%752 = OpBitwiseXor %ulong %750 %751
+OpStore %264 %752
+%753 = OpLoad %ulong %264
+%754 = OpIMul %ulong %753 %ulong_1099511628211
+OpStore %265 %754
+%755 = OpLoad %ulong %268
+%756 = OpIAdd %ulong %755 %ulong_1
+OpStore %266 %756
+%757 = OpLoad %ulong %265
+OpStore %267 %757
+%758 = OpLoad %ulong %266
+OpStore %268 %758
+OpBranch %136
+%58 = OpLabel
+%759 = OpLoad %ulong %258
+%760 = OpIMul %ulong %759 %ulong_8
+OpStore %251 %760
+%761 = OpLoad %ulong %249
+%762 = OpLoad %ulong %251
+%763 = OpShiftRightLogical %ulong %761 %762
+OpStore %252 %763
+%764 = OpLoad %ulong %252
+%765 = OpBitwiseAnd %ulong %764 %ulong_255
+OpStore %253 %765
+%766 = OpLoad %ulong %257
+%767 = OpLoad %ulong %253
+%768 = OpBitwiseXor %ulong %766 %767
+OpStore %254 %768
+%769 = OpLoad %ulong %254
+%770 = OpIMul %ulong %769 %ulong_1099511628211
+OpStore %255 %770
+%771 = OpLoad %ulong %258
+%772 = OpIAdd %ulong %771 %ulong_1
+OpStore %256 %772
+%773 = OpLoad %ulong %255
+OpStore %257 %773
+%774 = OpLoad %ulong %256
+OpStore %258 %774
+OpBranch %137
+%51 = OpLabel
+%775 = OpLoad %ulong %248
+%776 = OpIMul %ulong %775 %ulong_8
+OpStore %241 %776
+%777 = OpLoad %ulong %230
+%778 = OpLoad %ulong %241
+%779 = OpShiftRightLogical %ulong %777 %778
+OpStore %242 %779
+%780 = OpLoad %ulong %242
+%781 = OpBitwiseAnd %ulong %780 %ulong_255
+OpStore %243 %781
+%782 = OpLoad %ulong %247
+%783 = OpLoad %ulong %243
+%784 = OpBitwiseXor %ulong %782 %783
+OpStore %244 %784
+%785 = OpLoad %ulong %244
+%786 = OpIMul %ulong %785 %ulong_1099511628211
+OpStore %245 %786
+%787 = OpLoad %ulong %248
+%788 = OpIAdd %ulong %787 %ulong_1
+OpStore %246 %788
+%789 = OpLoad %ulong %245
+OpStore %247 %789
+%790 = OpLoad %ulong %246
+OpStore %248 %790
+OpBranch %138
+%39 = OpLabel
+%791 = OpLoad %ulong %229
+%792 = OpIMul %ulong %791 %ulong_8
+OpStore %222 %792
+%793 = OpLoad %ulong %210
+%794 = OpLoad %ulong %222
+%795 = OpShiftRightLogical %ulong %793 %794
+OpStore %223 %795
+%796 = OpLoad %ulong %223
+%797 = OpBitwiseAnd %ulong %796 %ulong_255
+OpStore %224 %797
+%798 = OpLoad %ulong %228
+%799 = OpLoad %ulong %224
+%800 = OpBitwiseXor %ulong %798 %799
+OpStore %225 %800
+%801 = OpLoad %ulong %225
+%802 = OpIMul %ulong %801 %ulong_1099511628211
+OpStore %226 %802
+%803 = OpLoad %ulong %229
+%804 = OpIAdd %ulong %803 %ulong_1
+OpStore %227 %804
+%805 = OpLoad %ulong %226
+OpStore %228 %805
+%806 = OpLoad %ulong %227
+OpStore %229 %806
+OpBranch %139
+%25 = OpLabel
+%807 = OpLoad %ulong %209
+%808 = OpIMul %ulong %807 %ulong_8
+OpStore %202 %808
+%809 = OpLoad %ulong %190
+%810 = OpLoad %ulong %202
+%811 = OpShiftRightLogical %ulong %809 %810
+OpStore %203 %811
+%812 = OpLoad %ulong %203
+%813 = OpBitwiseAnd %ulong %812 %ulong_255
+OpStore %204 %813
+%814 = OpLoad %ulong %208
+%815 = OpLoad %ulong %204
+%816 = OpBitwiseXor %ulong %814 %815
+OpStore %205 %816
+%817 = OpLoad %ulong %205
+%818 = OpIMul %ulong %817 %ulong_1099511628211
+OpStore %206 %818
+%819 = OpLoad %ulong %209
+%820 = OpIAdd %ulong %819 %ulong_1
+OpStore %207 %820
+%821 = OpLoad %ulong %206
+OpStore %208 %821
+%822 = OpLoad %ulong %207
+OpStore %209 %822
+OpBranch %140
+%124 = OpLabel
+OpBranch %45
+%125 = OpLabel
+OpBranch %31
+%126 = OpLabel
+OpBranch %17
+%127 = OpLabel
+OpBranch %7
+%128 = OpLabel
+OpBranch %120
+%129 = OpLabel
+OpBranch %113
+%130 = OpLabel
+OpBranch %106
+%131 = OpLabel
+OpBranch %99
+%132 = OpLabel
+OpBranch %92
+%133 = OpLabel
+OpBranch %85
+%134 = OpLabel
+OpBranch %78
+%135 = OpLabel
+OpBranch %71
+%136 = OpLabel
+OpBranch %64
+%137 = OpLabel
+OpBranch %57
+%138 = OpLabel
+OpBranch %50
+%139 = OpLabel
+OpBranch %38
+%140 = OpLabel
+OpBranch %24
+OpFunctionEnd
+%2 = OpFunction %ulong None %823
+%824 = OpFunctionParameter %ulong
+%825 = OpFunctionParameter %uint
+%826 = OpLabel
+%833 = OpVariable %_ptr_Function_ulong Function
+%834 = OpVariable %_ptr_Function_uint Function
+%835 = OpVariable %_ptr_Function_ulong Function
+%836 = OpVariable %_ptr_Function_bool Function
+%837 = OpVariable %_ptr_Function_ulong Function
+%838 = OpVariable %_ptr_Function_ulong Function
+%839 = OpVariable %_ptr_Function_ulong Function
+%840 = OpVariable %_ptr_Function_ulong Function
+%841 = OpVariable %_ptr_Function_ulong Function
+%842 = OpVariable %_ptr_Function_ulong Function
+%843 = OpVariable %_ptr_Function_ulong Function
+%844 = OpVariable %_ptr_Function_ulong Function
+OpStore %833 %824
+OpStore %834 %825
+%845 = OpLoad %uint %834
+%846 = OpUConvert %ulong %845
+OpStore %835 %846
+OpBranch %827
+%827 = OpLabel
+%847 = OpLoad %ulong %833
+OpStore %843 %847
+OpStore %844 %ulong_0
+OpBranch %828
+%828 = OpLabel
+%848 = OpLoad %ulong %844
+%849 = OpULessThan %bool %848 %ulong_8
+OpStore %836 %849
+%850 = OpLoad %bool %836
+OpLoopMerge %830 %832 None
+OpBranchConditional %850 %829 %830
+%830 = OpLabel
+OpBranch %831
+%831 = OpLabel
+%851 = OpLoad %ulong %843
+OpReturnValue %851
+%829 = OpLabel
+%852 = OpLoad %ulong %844
+%853 = OpIMul %ulong %852 %ulong_8
+OpStore %837 %853
+%854 = OpLoad %ulong %835
+%855 = OpLoad %ulong %837
+%856 = OpShiftRightLogical %ulong %854 %855
+OpStore %838 %856
+%857 = OpLoad %ulong %838
+%858 = OpBitwiseAnd %ulong %857 %ulong_255
+OpStore %839 %858
+%859 = OpLoad %ulong %843
+%860 = OpLoad %ulong %839
+%861 = OpBitwiseXor %ulong %859 %860
+OpStore %840 %861
+%862 = OpLoad %ulong %840
+%863 = OpIMul %ulong %862 %ulong_1099511628211
+OpStore %841 %863
+%864 = OpLoad %ulong %844
+%865 = OpIAdd %ulong %864 %ulong_1
+OpStore %842 %865
+%866 = OpLoad %ulong %841
+OpStore %843 %866
+%867 = OpLoad %ulong %842
+OpStore %844 %867
+OpBranch %832
+%832 = OpLabel
+OpBranch %828
 OpFunctionEnd

--- a/test/golden/spirv/bits/logic_u64.dis
+++ b/test/golden/spirv/bits/logic_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 271
+; Bound: 775
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,359 +9,1137 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.logic_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
 %ulong_12297829382473034410 = OpConstant %ulong 12297829382473034410
 %ulong_6148914691236517205 = OpConstant %ulong 6148914691236517205
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_1 = OpConstant %ulong 1
-%226 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%229 = OpTypeFunction %ulong %ulong %ulong
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_bool Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %6
-%71 = OpFunctionCall %ulong %2
-OpStore %15 %71
-%73 = OpLoad %ulong %14
-%74 = OpBitwiseXor %ulong %ulong_18446744073709551615 %73
-OpStore %16 %74
-%76 = OpLoad %ulong %14
-%77 = OpBitwiseXor %ulong %ulong_12297829382473034410 %76
-OpStore %17 %77
-%79 = OpLoad %ulong %14
-%80 = OpBitwiseXor %ulong %ulong_6148914691236517205 %79
-OpStore %18 %80
-%81 = OpLoad %ulong %14
-%82 = OpLoad %ulong %16
-%83 = OpBitwiseAnd %ulong %81 %82
-OpStore %19 %83
-%84 = OpLoad %ulong %15
-%85 = OpLoad %ulong %19
-%86 = OpFunctionCall %ulong %3 %84 %85
-OpStore %20 %86
-%87 = OpLoad %ulong %14
-%88 = OpLoad %ulong %16
-%89 = OpBitwiseOr %ulong %87 %88
-OpStore %21 %89
-%90 = OpLoad %ulong %20
-%91 = OpLoad %ulong %21
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %22 %92
-%93 = OpLoad %ulong %14
-%94 = OpLoad %ulong %16
-%95 = OpBitwiseXor %ulong %93 %94
-OpStore %23 %95
-%96 = OpLoad %ulong %22
-%97 = OpLoad %ulong %23
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %24 %98
-%99 = OpLoad %ulong %14
-%100 = OpNot %ulong %99
-OpStore %25 %100
-%101 = OpLoad %ulong %24
-%102 = OpLoad %ulong %25
-%103 = OpFunctionCall %ulong %3 %101 %102
-OpStore %26 %103
-%104 = OpLoad %ulong %16
-%105 = OpNot %ulong %104
-OpStore %27 %105
-%106 = OpLoad %ulong %26
-%107 = OpLoad %ulong %27
-%108 = OpFunctionCall %ulong %3 %106 %107
-OpStore %28 %108
-%109 = OpLoad %ulong %17
-%110 = OpLoad %ulong %18
-%111 = OpBitwiseAnd %ulong %109 %110
-OpStore %29 %111
-%112 = OpLoad %ulong %28
-%113 = OpLoad %ulong %29
-%114 = OpFunctionCall %ulong %3 %112 %113
-OpStore %30 %114
-%115 = OpLoad %ulong %17
-%116 = OpLoad %ulong %18
-%117 = OpBitwiseOr %ulong %115 %116
-OpStore %31 %117
-%118 = OpLoad %ulong %30
-%119 = OpLoad %ulong %31
-%120 = OpFunctionCall %ulong %3 %118 %119
-OpStore %32 %120
-%121 = OpLoad %ulong %17
-%122 = OpLoad %ulong %18
-%123 = OpBitwiseXor %ulong %121 %122
-OpStore %33 %123
-%124 = OpLoad %ulong %32
-%125 = OpLoad %ulong %33
-%126 = OpFunctionCall %ulong %3 %124 %125
-OpStore %34 %126
-%127 = OpLoad %ulong %17
-%128 = OpNot %ulong %127
-OpStore %35 %128
-%129 = OpLoad %ulong %34
-%130 = OpLoad %ulong %35
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %36 %131
-%132 = OpLoad %ulong %18
-%133 = OpNot %ulong %132
-OpStore %37 %133
-%134 = OpLoad %ulong %36
-%135 = OpLoad %ulong %37
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %38 %136
-%137 = OpLoad %ulong %14
-%138 = OpLoad %ulong %17
-%139 = OpBitwiseAnd %ulong %137 %138
-OpStore %39 %139
-%140 = OpLoad %ulong %38
-%141 = OpLoad %ulong %39
-%142 = OpFunctionCall %ulong %3 %140 %141
-OpStore %40 %142
-%143 = OpLoad %ulong %16
-%144 = OpLoad %ulong %18
-%145 = OpBitwiseOr %ulong %143 %144
-OpStore %41 %145
-%146 = OpLoad %ulong %40
-%147 = OpLoad %ulong %41
-%148 = OpFunctionCall %ulong %3 %146 %147
-OpStore %42 %148
-%149 = OpLoad %ulong %14
-%150 = OpLoad %ulong %18
-%151 = OpBitwiseAnd %ulong %149 %150
-OpStore %43 %151
-%152 = OpLoad %ulong %42
-%153 = OpLoad %ulong %43
-%154 = OpFunctionCall %ulong %3 %152 %153
-OpStore %44 %154
-%155 = OpLoad %ulong %16
-%156 = OpLoad %ulong %17
-%157 = OpBitwiseOr %ulong %155 %156
-OpStore %45 %157
-%158 = OpLoad %ulong %44
-%159 = OpLoad %ulong %45
-%160 = OpFunctionCall %ulong %3 %158 %159
-OpStore %46 %160
-%161 = OpLoad %ulong %19
-%162 = OpLoad %ulong %33
-%163 = OpBitwiseOr %ulong %161 %162
-OpStore %47 %163
-%164 = OpLoad %ulong %46
-%165 = OpLoad %ulong %47
-%166 = OpFunctionCall %ulong %3 %164 %165
-OpStore %48 %166
-%167 = OpLoad %ulong %21
-%168 = OpNot %ulong %167
-OpStore %49 %168
-%169 = OpLoad %ulong %48
-%170 = OpLoad %ulong %49
-%171 = OpFunctionCall %ulong %3 %169 %170
-OpStore %50 %171
-%172 = OpLoad %ulong %19
-%173 = OpNot %ulong %172
-OpStore %51 %173
-%174 = OpLoad %ulong %50
-%175 = OpLoad %ulong %51
-%176 = OpFunctionCall %ulong %3 %174 %175
-OpStore %52 %176
-%177 = OpLoad %ulong %33
-%178 = OpNot %ulong %177
-OpStore %53 %178
-%179 = OpLoad %ulong %52
-%180 = OpLoad %ulong %53
-%181 = OpFunctionCall %ulong %3 %179 %180
-OpStore %54 %181
-%182 = OpLoad %ulong %54
-OpStore %69 %182
-OpStore %70 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%184 = OpLoad %ulong %70
-%186 = OpULessThan %bool %184 %ulong_8
-OpStore %56 %186
-%187 = OpLoad %bool %56
-OpLoopMerge %10 %11 None
-OpBranchConditional %187 %9 %10
-%10 = OpLabel
-%188 = OpLoad %ulong %69
-OpReturnValue %188
-%9 = OpLabel
-%189 = OpLoad %ulong %14
-%190 = OpLoad %ulong %70
-%191 = OpBitwiseXor %ulong %189 %190
-OpStore %57 %191
-%192 = OpLoad %ulong %16
-%193 = OpLoad %ulong %70
-%194 = OpBitwiseOr %ulong %192 %193
-OpStore %58 %194
-%195 = OpLoad %ulong %18
-%196 = OpLoad %ulong %70
-%197 = OpBitwiseXor %ulong %195 %196
-OpStore %59 %197
-%198 = OpLoad %ulong %17
-%199 = OpLoad %ulong %59
-%200 = OpBitwiseAnd %ulong %198 %199
-OpStore %60 %200
-%201 = OpLoad %ulong %57
-%202 = OpLoad %ulong %58
-%203 = OpBitwiseAnd %ulong %201 %202
-OpStore %61 %203
-%204 = OpLoad %ulong %69
-%205 = OpLoad %ulong %61
-%206 = OpFunctionCall %ulong %3 %204 %205
-OpStore %62 %206
-%207 = OpLoad %ulong %57
-%208 = OpLoad %ulong %60
-%209 = OpBitwiseOr %ulong %207 %208
-OpStore %63 %209
-%210 = OpLoad %ulong %62
-%211 = OpLoad %ulong %63
-%212 = OpFunctionCall %ulong %3 %210 %211
-OpStore %64 %212
-%213 = OpLoad %ulong %57
-%214 = OpLoad %ulong %60
-%215 = OpBitwiseXor %ulong %213 %214
-OpStore %65 %215
-%216 = OpLoad %ulong %65
-%217 = OpNot %ulong %216
-OpStore %66 %217
-%218 = OpLoad %ulong %64
-%219 = OpLoad %ulong %66
-%220 = OpFunctionCall %ulong %3 %218 %219
-OpStore %67 %220
-%221 = OpLoad %ulong %70
-%223 = OpIAdd %ulong %221 %ulong_1
-OpStore %68 %223
-%224 = OpLoad %ulong %67
-OpStore %69 %224
-%225 = OpLoad %ulong %68
-OpStore %70 %225
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %226
-%227 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %229
-%230 = OpFunctionParameter %ulong
-%231 = OpFunctionParameter %ulong
-%232 = OpLabel
+%735 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_bool Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_bool Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_bool Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_bool Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_bool Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
 %237 = OpVariable %_ptr_Function_ulong Function
 %238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_bool Function
+%239 = OpVariable %_ptr_Function_ulong Function
 %240 = OpVariable %_ptr_Function_ulong Function
 %241 = OpVariable %_ptr_Function_ulong Function
 %242 = OpVariable %_ptr_Function_ulong Function
 %243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
 %245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_ulong Function
 %247 = OpVariable %_ptr_Function_ulong Function
-OpStore %237 %230
-OpStore %238 %231
-%248 = OpLoad %ulong %237
-OpStore %246 %248
-OpStore %247 %ulong_0
-OpBranch %233
-%233 = OpLabel
-%249 = OpLoad %ulong %247
-%250 = OpULessThan %bool %249 %ulong_8
-OpStore %239 %250
-%251 = OpLoad %bool %239
-OpLoopMerge %235 %236 None
-OpBranchConditional %251 %234 %235
-%235 = OpLabel
-%252 = OpLoad %ulong %246
-OpReturnValue %252
-%234 = OpLabel
-%253 = OpLoad %ulong %247
-%254 = OpIMul %ulong %253 %ulong_8
-OpStore %240 %254
-%255 = OpLoad %ulong %238
-%256 = OpLoad %ulong %240
-%257 = OpShiftRightLogical %ulong %255 %256
-OpStore %241 %257
-%258 = OpLoad %ulong %241
-%260 = OpBitwiseAnd %ulong %258 %ulong_255
-OpStore %242 %260
-%261 = OpLoad %ulong %246
-%262 = OpLoad %ulong %242
-%263 = OpBitwiseXor %ulong %261 %262
-OpStore %243 %263
-%264 = OpLoad %ulong %243
-%266 = OpIMul %ulong %264 %ulong_1099511628211
-OpStore %244 %266
-%267 = OpLoad %ulong %247
-%268 = OpIAdd %ulong %267 %ulong_1
-OpStore %245 %268
-%269 = OpLoad %ulong %244
-OpStore %246 %269
-%270 = OpLoad %ulong %245
-OpStore %247 %270
-OpBranch %236
-%236 = OpLabel
-OpBranch %233
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_bool Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_bool Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_bool Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_bool Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_bool Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+OpStore %111 %5
+OpBranch %10
+%10 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%299 = OpLoad %ulong %111
+%300 = OpBitwiseXor %ulong %ulong_18446744073709551615 %299
+OpStore %112 %300
+%302 = OpLoad %ulong %111
+%303 = OpBitwiseXor %ulong %ulong_12297829382473034410 %302
+OpStore %113 %303
+%305 = OpLoad %ulong %111
+%306 = OpBitwiseXor %ulong %ulong_6148914691236517205 %305
+OpStore %114 %306
+%307 = OpLoad %ulong %111
+%308 = OpLoad %ulong %112
+%309 = OpBitwiseAnd %ulong %307 %308
+OpStore %115 %309
+OpBranch %17
+%17 = OpLabel
+OpStore %170 %ulong_14695981039346656037
+OpStore %171 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%312 = OpLoad %ulong %171
+%314 = OpULessThan %bool %312 %ulong_8
+OpStore %163 %314
+%315 = OpLoad %bool %163
+OpLoopMerge %20 %108 None
+OpBranchConditional %315 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%316 = OpLoad %ulong %111
+%317 = OpLoad %ulong %112
+%318 = OpBitwiseOr %ulong %316 %317
+OpStore %116 %318
+OpBranch %27
+%27 = OpLabel
+%319 = OpLoad %ulong %170
+OpStore %188 %319
+OpStore %189 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%320 = OpLoad %ulong %189
+%321 = OpULessThan %bool %320 %ulong_8
+OpStore %181 %321
+%322 = OpLoad %bool %181
+OpLoopMerge %30 %107 None
+OpBranchConditional %322 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%323 = OpLoad %ulong %111
+%324 = OpLoad %ulong %112
+%325 = OpBitwiseXor %ulong %323 %324
+OpStore %117 %325
+OpBranch %37
+%37 = OpLabel
+%326 = OpLoad %ulong %188
+OpStore %206 %326
+OpStore %207 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%327 = OpLoad %ulong %207
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %199 %328
+%329 = OpLoad %bool %199
+OpLoopMerge %40 %106 None
+OpBranchConditional %329 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%330 = OpLoad %ulong %111
+%331 = OpNot %ulong %330
+OpStore %118 %331
+OpBranch %42
+%42 = OpLabel
+%332 = OpLoad %ulong %206
+OpStore %215 %332
+OpStore %216 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%333 = OpLoad %ulong %216
+%334 = OpULessThan %bool %333 %ulong_8
+OpStore %208 %334
+%335 = OpLoad %bool %208
+OpLoopMerge %45 %105 None
+OpBranchConditional %335 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+%336 = OpLoad %ulong %112
+%337 = OpNot %ulong %336
+OpStore %119 %337
+OpBranch %47
+%47 = OpLabel
+%338 = OpLoad %ulong %215
+OpStore %224 %338
+OpStore %225 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%339 = OpLoad %ulong %225
+%340 = OpULessThan %bool %339 %ulong_8
+OpStore %217 %340
+%341 = OpLoad %bool %217
+OpLoopMerge %50 %104 None
+OpBranchConditional %341 %49 %50
+%50 = OpLabel
+OpBranch %51
+%51 = OpLabel
+%342 = OpLoad %ulong %113
+%343 = OpLoad %ulong %114
+%344 = OpBitwiseAnd %ulong %342 %343
+OpStore %120 %344
+OpBranch %52
+%52 = OpLabel
+%345 = OpLoad %ulong %224
+OpStore %233 %345
+OpStore %234 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%346 = OpLoad %ulong %234
+%347 = OpULessThan %bool %346 %ulong_8
+OpStore %226 %347
+%348 = OpLoad %bool %226
+OpLoopMerge %55 %103 None
+OpBranchConditional %348 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+%349 = OpLoad %ulong %113
+%350 = OpLoad %ulong %114
+%351 = OpBitwiseOr %ulong %349 %350
+OpStore %121 %351
+OpBranch %57
+%57 = OpLabel
+%352 = OpLoad %ulong %233
+OpStore %242 %352
+OpStore %243 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%353 = OpLoad %ulong %243
+%354 = OpULessThan %bool %353 %ulong_8
+OpStore %235 %354
+%355 = OpLoad %bool %235
+OpLoopMerge %60 %102 None
+OpBranchConditional %355 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%356 = OpLoad %ulong %113
+%357 = OpLoad %ulong %114
+%358 = OpBitwiseXor %ulong %356 %357
+OpStore %122 %358
+OpBranch %62
+%62 = OpLabel
+%359 = OpLoad %ulong %242
+OpStore %251 %359
+OpStore %252 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%360 = OpLoad %ulong %252
+%361 = OpULessThan %bool %360 %ulong_8
+OpStore %244 %361
+%362 = OpLoad %bool %244
+OpLoopMerge %65 %101 None
+OpBranchConditional %362 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+%363 = OpLoad %ulong %113
+%364 = OpNot %ulong %363
+OpStore %123 %364
+OpBranch %67
+%67 = OpLabel
+%365 = OpLoad %ulong %251
+OpStore %260 %365
+OpStore %261 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%366 = OpLoad %ulong %261
+%367 = OpULessThan %bool %366 %ulong_8
+OpStore %253 %367
+%368 = OpLoad %bool %253
+OpLoopMerge %70 %100 None
+OpBranchConditional %368 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%369 = OpLoad %ulong %114
+%370 = OpNot %ulong %369
+OpStore %124 %370
+OpBranch %72
+%72 = OpLabel
+%371 = OpLoad %ulong %260
+OpStore %269 %371
+OpStore %270 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%372 = OpLoad %ulong %270
+%373 = OpULessThan %bool %372 %ulong_8
+OpStore %262 %373
+%374 = OpLoad %bool %262
+OpLoopMerge %75 %99 None
+OpBranchConditional %374 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%375 = OpLoad %ulong %111
+%376 = OpLoad %ulong %113
+%377 = OpBitwiseAnd %ulong %375 %376
+OpStore %125 %377
+OpBranch %77
+%77 = OpLabel
+%378 = OpLoad %ulong %269
+OpStore %278 %378
+OpStore %279 %ulong_0
+OpBranch %78
+%78 = OpLabel
+%379 = OpLoad %ulong %279
+%380 = OpULessThan %bool %379 %ulong_8
+OpStore %271 %380
+%381 = OpLoad %bool %271
+OpLoopMerge %80 %98 None
+OpBranchConditional %381 %79 %80
+%80 = OpLabel
+OpBranch %81
+%81 = OpLabel
+%382 = OpLoad %ulong %112
+%383 = OpLoad %ulong %114
+%384 = OpBitwiseOr %ulong %382 %383
+OpStore %126 %384
+OpBranch %82
+%82 = OpLabel
+%385 = OpLoad %ulong %278
+OpStore %287 %385
+OpStore %288 %ulong_0
+OpBranch %83
+%83 = OpLabel
+%386 = OpLoad %ulong %288
+%387 = OpULessThan %bool %386 %ulong_8
+OpStore %280 %387
+%388 = OpLoad %bool %280
+OpLoopMerge %85 %97 None
+OpBranchConditional %388 %84 %85
+%85 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%389 = OpLoad %ulong %111
+%390 = OpLoad %ulong %114
+%391 = OpBitwiseAnd %ulong %389 %390
+OpStore %127 %391
+OpBranch %87
+%87 = OpLabel
+%392 = OpLoad %ulong %287
+OpStore %296 %392
+OpStore %297 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%393 = OpLoad %ulong %297
+%394 = OpULessThan %bool %393 %ulong_8
+OpStore %289 %394
+%395 = OpLoad %bool %289
+OpLoopMerge %90 %96 None
+OpBranchConditional %395 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+%396 = OpLoad %ulong %112
+%397 = OpLoad %ulong %113
+%398 = OpBitwiseOr %ulong %396 %397
+OpStore %128 %398
+%399 = OpLoad %ulong %296
+%400 = OpLoad %ulong %128
+%401 = OpFunctionCall %ulong %2 %399 %400
+OpStore %129 %401
+%402 = OpLoad %ulong %111
+%403 = OpLoad %ulong %112
+%404 = OpBitwiseAnd %ulong %402 %403
+OpStore %130 %404
+%405 = OpLoad %ulong %113
+%406 = OpLoad %ulong %114
+%407 = OpBitwiseXor %ulong %405 %406
+OpStore %131 %407
+%408 = OpLoad %ulong %130
+%409 = OpLoad %ulong %131
+%410 = OpBitwiseOr %ulong %408 %409
+OpStore %132 %410
+%411 = OpLoad %ulong %129
+%412 = OpLoad %ulong %132
+%413 = OpFunctionCall %ulong %2 %411 %412
+OpStore %133 %413
+%414 = OpLoad %ulong %111
+%415 = OpLoad %ulong %112
+%416 = OpBitwiseOr %ulong %414 %415
+OpStore %134 %416
+%417 = OpLoad %ulong %134
+%418 = OpNot %ulong %417
+OpStore %135 %418
+%419 = OpLoad %ulong %133
+%420 = OpLoad %ulong %135
+%421 = OpFunctionCall %ulong %2 %419 %420
+OpStore %136 %421
+%422 = OpLoad %ulong %130
+%423 = OpNot %ulong %422
+OpStore %137 %423
+%424 = OpLoad %ulong %136
+%425 = OpLoad %ulong %137
+%426 = OpFunctionCall %ulong %2 %424 %425
+OpStore %138 %426
+%427 = OpLoad %ulong %131
+%428 = OpNot %ulong %427
+OpStore %139 %428
+%429 = OpLoad %ulong %138
+%430 = OpLoad %ulong %139
+%431 = OpFunctionCall %ulong %2 %429 %430
+OpStore %140 %431
+%432 = OpLoad %ulong %140
+OpStore %152 %432
+OpStore %153 %ulong_0
+OpBranch %7
+%7 = OpLabel
+%433 = OpLoad %ulong %153
+%434 = OpULessThan %bool %433 %ulong_8
+OpStore %142 %434
+%435 = OpLoad %bool %142
+OpLoopMerge %9 %95 None
+OpBranchConditional %435 %8 %9
+%9 = OpLabel
+%436 = OpLoad %ulong %152
+OpReturnValue %436
+%8 = OpLabel
+%437 = OpLoad %ulong %111
+%438 = OpLoad %ulong %153
+%439 = OpBitwiseXor %ulong %437 %438
+OpStore %143 %439
+%440 = OpLoad %ulong %112
+%441 = OpLoad %ulong %153
+%442 = OpBitwiseOr %ulong %440 %441
+OpStore %144 %442
+%443 = OpLoad %ulong %114
+%444 = OpLoad %ulong %153
+%445 = OpBitwiseXor %ulong %443 %444
+OpStore %145 %445
+%446 = OpLoad %ulong %113
+%447 = OpLoad %ulong %145
+%448 = OpBitwiseAnd %ulong %446 %447
+OpStore %146 %448
+%449 = OpLoad %ulong %143
+%450 = OpLoad %ulong %144
+%451 = OpBitwiseAnd %ulong %449 %450
+OpStore %147 %451
+OpBranch %12
+%12 = OpLabel
+%452 = OpLoad %ulong %152
+OpStore %161 %452
+OpStore %162 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%453 = OpLoad %ulong %162
+%454 = OpULessThan %bool %453 %ulong_8
+OpStore %154 %454
+%455 = OpLoad %bool %154
+OpLoopMerge %15 %94 None
+OpBranchConditional %455 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%456 = OpLoad %ulong %143
+%457 = OpLoad %ulong %146
+%458 = OpBitwiseOr %ulong %456 %457
+OpStore %148 %458
+OpBranch %22
+%22 = OpLabel
+%459 = OpLoad %ulong %161
+OpStore %179 %459
+OpStore %180 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%460 = OpLoad %ulong %180
+%461 = OpULessThan %bool %460 %ulong_8
+OpStore %172 %461
+%462 = OpLoad %bool %172
+OpLoopMerge %25 %93 None
+OpBranchConditional %462 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%463 = OpLoad %ulong %143
+%464 = OpLoad %ulong %146
+%465 = OpBitwiseXor %ulong %463 %464
+OpStore %149 %465
+%466 = OpLoad %ulong %149
+%467 = OpNot %ulong %466
+OpStore %150 %467
+OpBranch %32
+%32 = OpLabel
+%468 = OpLoad %ulong %179
+OpStore %197 %468
+OpStore %198 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%469 = OpLoad %ulong %198
+%470 = OpULessThan %bool %469 %ulong_8
+OpStore %190 %470
+%471 = OpLoad %bool %190
+OpLoopMerge %35 %92 None
+OpBranchConditional %471 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%472 = OpLoad %ulong %153
+%474 = OpIAdd %ulong %472 %ulong_1
+OpStore %151 %474
+%475 = OpLoad %ulong %197
+OpStore %152 %475
+%476 = OpLoad %ulong %151
+OpStore %153 %476
+OpBranch %95
+%34 = OpLabel
+%477 = OpLoad %ulong %198
+%478 = OpIMul %ulong %477 %ulong_8
+OpStore %191 %478
+%479 = OpLoad %ulong %150
+%480 = OpLoad %ulong %191
+%481 = OpShiftRightLogical %ulong %479 %480
+OpStore %192 %481
+%482 = OpLoad %ulong %192
+%484 = OpBitwiseAnd %ulong %482 %ulong_255
+OpStore %193 %484
+%485 = OpLoad %ulong %197
+%486 = OpLoad %ulong %193
+%487 = OpBitwiseXor %ulong %485 %486
+OpStore %194 %487
+%488 = OpLoad %ulong %194
+%490 = OpIMul %ulong %488 %ulong_1099511628211
+OpStore %195 %490
+%491 = OpLoad %ulong %198
+%492 = OpIAdd %ulong %491 %ulong_1
+OpStore %196 %492
+%493 = OpLoad %ulong %195
+OpStore %197 %493
+%494 = OpLoad %ulong %196
+OpStore %198 %494
+OpBranch %92
+%24 = OpLabel
+%495 = OpLoad %ulong %180
+%496 = OpIMul %ulong %495 %ulong_8
+OpStore %173 %496
+%497 = OpLoad %ulong %148
+%498 = OpLoad %ulong %173
+%499 = OpShiftRightLogical %ulong %497 %498
+OpStore %174 %499
+%500 = OpLoad %ulong %174
+%501 = OpBitwiseAnd %ulong %500 %ulong_255
+OpStore %175 %501
+%502 = OpLoad %ulong %179
+%503 = OpLoad %ulong %175
+%504 = OpBitwiseXor %ulong %502 %503
+OpStore %176 %504
+%505 = OpLoad %ulong %176
+%506 = OpIMul %ulong %505 %ulong_1099511628211
+OpStore %177 %506
+%507 = OpLoad %ulong %180
+%508 = OpIAdd %ulong %507 %ulong_1
+OpStore %178 %508
+%509 = OpLoad %ulong %177
+OpStore %179 %509
+%510 = OpLoad %ulong %178
+OpStore %180 %510
+OpBranch %93
+%14 = OpLabel
+%511 = OpLoad %ulong %162
+%512 = OpIMul %ulong %511 %ulong_8
+OpStore %155 %512
+%513 = OpLoad %ulong %147
+%514 = OpLoad %ulong %155
+%515 = OpShiftRightLogical %ulong %513 %514
+OpStore %156 %515
+%516 = OpLoad %ulong %156
+%517 = OpBitwiseAnd %ulong %516 %ulong_255
+OpStore %157 %517
+%518 = OpLoad %ulong %161
+%519 = OpLoad %ulong %157
+%520 = OpBitwiseXor %ulong %518 %519
+OpStore %158 %520
+%521 = OpLoad %ulong %158
+%522 = OpIMul %ulong %521 %ulong_1099511628211
+OpStore %159 %522
+%523 = OpLoad %ulong %162
+%524 = OpIAdd %ulong %523 %ulong_1
+OpStore %160 %524
+%525 = OpLoad %ulong %159
+OpStore %161 %525
+%526 = OpLoad %ulong %160
+OpStore %162 %526
+OpBranch %94
+%89 = OpLabel
+%527 = OpLoad %ulong %297
+%528 = OpIMul %ulong %527 %ulong_8
+OpStore %290 %528
+%529 = OpLoad %ulong %127
+%530 = OpLoad %ulong %290
+%531 = OpShiftRightLogical %ulong %529 %530
+OpStore %291 %531
+%532 = OpLoad %ulong %291
+%533 = OpBitwiseAnd %ulong %532 %ulong_255
+OpStore %292 %533
+%534 = OpLoad %ulong %296
+%535 = OpLoad %ulong %292
+%536 = OpBitwiseXor %ulong %534 %535
+OpStore %293 %536
+%537 = OpLoad %ulong %293
+%538 = OpIMul %ulong %537 %ulong_1099511628211
+OpStore %294 %538
+%539 = OpLoad %ulong %297
+%540 = OpIAdd %ulong %539 %ulong_1
+OpStore %295 %540
+%541 = OpLoad %ulong %294
+OpStore %296 %541
+%542 = OpLoad %ulong %295
+OpStore %297 %542
+OpBranch %96
+%84 = OpLabel
+%543 = OpLoad %ulong %288
+%544 = OpIMul %ulong %543 %ulong_8
+OpStore %281 %544
+%545 = OpLoad %ulong %126
+%546 = OpLoad %ulong %281
+%547 = OpShiftRightLogical %ulong %545 %546
+OpStore %282 %547
+%548 = OpLoad %ulong %282
+%549 = OpBitwiseAnd %ulong %548 %ulong_255
+OpStore %283 %549
+%550 = OpLoad %ulong %287
+%551 = OpLoad %ulong %283
+%552 = OpBitwiseXor %ulong %550 %551
+OpStore %284 %552
+%553 = OpLoad %ulong %284
+%554 = OpIMul %ulong %553 %ulong_1099511628211
+OpStore %285 %554
+%555 = OpLoad %ulong %288
+%556 = OpIAdd %ulong %555 %ulong_1
+OpStore %286 %556
+%557 = OpLoad %ulong %285
+OpStore %287 %557
+%558 = OpLoad %ulong %286
+OpStore %288 %558
+OpBranch %97
+%79 = OpLabel
+%559 = OpLoad %ulong %279
+%560 = OpIMul %ulong %559 %ulong_8
+OpStore %272 %560
+%561 = OpLoad %ulong %125
+%562 = OpLoad %ulong %272
+%563 = OpShiftRightLogical %ulong %561 %562
+OpStore %273 %563
+%564 = OpLoad %ulong %273
+%565 = OpBitwiseAnd %ulong %564 %ulong_255
+OpStore %274 %565
+%566 = OpLoad %ulong %278
+%567 = OpLoad %ulong %274
+%568 = OpBitwiseXor %ulong %566 %567
+OpStore %275 %568
+%569 = OpLoad %ulong %275
+%570 = OpIMul %ulong %569 %ulong_1099511628211
+OpStore %276 %570
+%571 = OpLoad %ulong %279
+%572 = OpIAdd %ulong %571 %ulong_1
+OpStore %277 %572
+%573 = OpLoad %ulong %276
+OpStore %278 %573
+%574 = OpLoad %ulong %277
+OpStore %279 %574
+OpBranch %98
+%74 = OpLabel
+%575 = OpLoad %ulong %270
+%576 = OpIMul %ulong %575 %ulong_8
+OpStore %263 %576
+%577 = OpLoad %ulong %124
+%578 = OpLoad %ulong %263
+%579 = OpShiftRightLogical %ulong %577 %578
+OpStore %264 %579
+%580 = OpLoad %ulong %264
+%581 = OpBitwiseAnd %ulong %580 %ulong_255
+OpStore %265 %581
+%582 = OpLoad %ulong %269
+%583 = OpLoad %ulong %265
+%584 = OpBitwiseXor %ulong %582 %583
+OpStore %266 %584
+%585 = OpLoad %ulong %266
+%586 = OpIMul %ulong %585 %ulong_1099511628211
+OpStore %267 %586
+%587 = OpLoad %ulong %270
+%588 = OpIAdd %ulong %587 %ulong_1
+OpStore %268 %588
+%589 = OpLoad %ulong %267
+OpStore %269 %589
+%590 = OpLoad %ulong %268
+OpStore %270 %590
+OpBranch %99
+%69 = OpLabel
+%591 = OpLoad %ulong %261
+%592 = OpIMul %ulong %591 %ulong_8
+OpStore %254 %592
+%593 = OpLoad %ulong %123
+%594 = OpLoad %ulong %254
+%595 = OpShiftRightLogical %ulong %593 %594
+OpStore %255 %595
+%596 = OpLoad %ulong %255
+%597 = OpBitwiseAnd %ulong %596 %ulong_255
+OpStore %256 %597
+%598 = OpLoad %ulong %260
+%599 = OpLoad %ulong %256
+%600 = OpBitwiseXor %ulong %598 %599
+OpStore %257 %600
+%601 = OpLoad %ulong %257
+%602 = OpIMul %ulong %601 %ulong_1099511628211
+OpStore %258 %602
+%603 = OpLoad %ulong %261
+%604 = OpIAdd %ulong %603 %ulong_1
+OpStore %259 %604
+%605 = OpLoad %ulong %258
+OpStore %260 %605
+%606 = OpLoad %ulong %259
+OpStore %261 %606
+OpBranch %100
+%64 = OpLabel
+%607 = OpLoad %ulong %252
+%608 = OpIMul %ulong %607 %ulong_8
+OpStore %245 %608
+%609 = OpLoad %ulong %122
+%610 = OpLoad %ulong %245
+%611 = OpShiftRightLogical %ulong %609 %610
+OpStore %246 %611
+%612 = OpLoad %ulong %246
+%613 = OpBitwiseAnd %ulong %612 %ulong_255
+OpStore %247 %613
+%614 = OpLoad %ulong %251
+%615 = OpLoad %ulong %247
+%616 = OpBitwiseXor %ulong %614 %615
+OpStore %248 %616
+%617 = OpLoad %ulong %248
+%618 = OpIMul %ulong %617 %ulong_1099511628211
+OpStore %249 %618
+%619 = OpLoad %ulong %252
+%620 = OpIAdd %ulong %619 %ulong_1
+OpStore %250 %620
+%621 = OpLoad %ulong %249
+OpStore %251 %621
+%622 = OpLoad %ulong %250
+OpStore %252 %622
+OpBranch %101
+%59 = OpLabel
+%623 = OpLoad %ulong %243
+%624 = OpIMul %ulong %623 %ulong_8
+OpStore %236 %624
+%625 = OpLoad %ulong %121
+%626 = OpLoad %ulong %236
+%627 = OpShiftRightLogical %ulong %625 %626
+OpStore %237 %627
+%628 = OpLoad %ulong %237
+%629 = OpBitwiseAnd %ulong %628 %ulong_255
+OpStore %238 %629
+%630 = OpLoad %ulong %242
+%631 = OpLoad %ulong %238
+%632 = OpBitwiseXor %ulong %630 %631
+OpStore %239 %632
+%633 = OpLoad %ulong %239
+%634 = OpIMul %ulong %633 %ulong_1099511628211
+OpStore %240 %634
+%635 = OpLoad %ulong %243
+%636 = OpIAdd %ulong %635 %ulong_1
+OpStore %241 %636
+%637 = OpLoad %ulong %240
+OpStore %242 %637
+%638 = OpLoad %ulong %241
+OpStore %243 %638
+OpBranch %102
+%54 = OpLabel
+%639 = OpLoad %ulong %234
+%640 = OpIMul %ulong %639 %ulong_8
+OpStore %227 %640
+%641 = OpLoad %ulong %120
+%642 = OpLoad %ulong %227
+%643 = OpShiftRightLogical %ulong %641 %642
+OpStore %228 %643
+%644 = OpLoad %ulong %228
+%645 = OpBitwiseAnd %ulong %644 %ulong_255
+OpStore %229 %645
+%646 = OpLoad %ulong %233
+%647 = OpLoad %ulong %229
+%648 = OpBitwiseXor %ulong %646 %647
+OpStore %230 %648
+%649 = OpLoad %ulong %230
+%650 = OpIMul %ulong %649 %ulong_1099511628211
+OpStore %231 %650
+%651 = OpLoad %ulong %234
+%652 = OpIAdd %ulong %651 %ulong_1
+OpStore %232 %652
+%653 = OpLoad %ulong %231
+OpStore %233 %653
+%654 = OpLoad %ulong %232
+OpStore %234 %654
+OpBranch %103
+%49 = OpLabel
+%655 = OpLoad %ulong %225
+%656 = OpIMul %ulong %655 %ulong_8
+OpStore %218 %656
+%657 = OpLoad %ulong %119
+%658 = OpLoad %ulong %218
+%659 = OpShiftRightLogical %ulong %657 %658
+OpStore %219 %659
+%660 = OpLoad %ulong %219
+%661 = OpBitwiseAnd %ulong %660 %ulong_255
+OpStore %220 %661
+%662 = OpLoad %ulong %224
+%663 = OpLoad %ulong %220
+%664 = OpBitwiseXor %ulong %662 %663
+OpStore %221 %664
+%665 = OpLoad %ulong %221
+%666 = OpIMul %ulong %665 %ulong_1099511628211
+OpStore %222 %666
+%667 = OpLoad %ulong %225
+%668 = OpIAdd %ulong %667 %ulong_1
+OpStore %223 %668
+%669 = OpLoad %ulong %222
+OpStore %224 %669
+%670 = OpLoad %ulong %223
+OpStore %225 %670
+OpBranch %104
+%44 = OpLabel
+%671 = OpLoad %ulong %216
+%672 = OpIMul %ulong %671 %ulong_8
+OpStore %209 %672
+%673 = OpLoad %ulong %118
+%674 = OpLoad %ulong %209
+%675 = OpShiftRightLogical %ulong %673 %674
+OpStore %210 %675
+%676 = OpLoad %ulong %210
+%677 = OpBitwiseAnd %ulong %676 %ulong_255
+OpStore %211 %677
+%678 = OpLoad %ulong %215
+%679 = OpLoad %ulong %211
+%680 = OpBitwiseXor %ulong %678 %679
+OpStore %212 %680
+%681 = OpLoad %ulong %212
+%682 = OpIMul %ulong %681 %ulong_1099511628211
+OpStore %213 %682
+%683 = OpLoad %ulong %216
+%684 = OpIAdd %ulong %683 %ulong_1
+OpStore %214 %684
+%685 = OpLoad %ulong %213
+OpStore %215 %685
+%686 = OpLoad %ulong %214
+OpStore %216 %686
+OpBranch %105
+%39 = OpLabel
+%687 = OpLoad %ulong %207
+%688 = OpIMul %ulong %687 %ulong_8
+OpStore %200 %688
+%689 = OpLoad %ulong %117
+%690 = OpLoad %ulong %200
+%691 = OpShiftRightLogical %ulong %689 %690
+OpStore %201 %691
+%692 = OpLoad %ulong %201
+%693 = OpBitwiseAnd %ulong %692 %ulong_255
+OpStore %202 %693
+%694 = OpLoad %ulong %206
+%695 = OpLoad %ulong %202
+%696 = OpBitwiseXor %ulong %694 %695
+OpStore %203 %696
+%697 = OpLoad %ulong %203
+%698 = OpIMul %ulong %697 %ulong_1099511628211
+OpStore %204 %698
+%699 = OpLoad %ulong %207
+%700 = OpIAdd %ulong %699 %ulong_1
+OpStore %205 %700
+%701 = OpLoad %ulong %204
+OpStore %206 %701
+%702 = OpLoad %ulong %205
+OpStore %207 %702
+OpBranch %106
+%29 = OpLabel
+%703 = OpLoad %ulong %189
+%704 = OpIMul %ulong %703 %ulong_8
+OpStore %182 %704
+%705 = OpLoad %ulong %116
+%706 = OpLoad %ulong %182
+%707 = OpShiftRightLogical %ulong %705 %706
+OpStore %183 %707
+%708 = OpLoad %ulong %183
+%709 = OpBitwiseAnd %ulong %708 %ulong_255
+OpStore %184 %709
+%710 = OpLoad %ulong %188
+%711 = OpLoad %ulong %184
+%712 = OpBitwiseXor %ulong %710 %711
+OpStore %185 %712
+%713 = OpLoad %ulong %185
+%714 = OpIMul %ulong %713 %ulong_1099511628211
+OpStore %186 %714
+%715 = OpLoad %ulong %189
+%716 = OpIAdd %ulong %715 %ulong_1
+OpStore %187 %716
+%717 = OpLoad %ulong %186
+OpStore %188 %717
+%718 = OpLoad %ulong %187
+OpStore %189 %718
+OpBranch %107
+%19 = OpLabel
+%719 = OpLoad %ulong %171
+%720 = OpIMul %ulong %719 %ulong_8
+OpStore %164 %720
+%721 = OpLoad %ulong %115
+%722 = OpLoad %ulong %164
+%723 = OpShiftRightLogical %ulong %721 %722
+OpStore %165 %723
+%724 = OpLoad %ulong %165
+%725 = OpBitwiseAnd %ulong %724 %ulong_255
+OpStore %166 %725
+%726 = OpLoad %ulong %170
+%727 = OpLoad %ulong %166
+%728 = OpBitwiseXor %ulong %726 %727
+OpStore %167 %728
+%729 = OpLoad %ulong %167
+%730 = OpIMul %ulong %729 %ulong_1099511628211
+OpStore %168 %730
+%731 = OpLoad %ulong %171
+%732 = OpIAdd %ulong %731 %ulong_1
+OpStore %169 %732
+%733 = OpLoad %ulong %168
+OpStore %170 %733
+%734 = OpLoad %ulong %169
+OpStore %171 %734
+OpBranch %108
+%92 = OpLabel
+OpBranch %33
+%93 = OpLabel
+OpBranch %23
+%94 = OpLabel
+OpBranch %13
+%95 = OpLabel
+OpBranch %7
+%96 = OpLabel
+OpBranch %88
+%97 = OpLabel
+OpBranch %83
+%98 = OpLabel
+OpBranch %78
+%99 = OpLabel
+OpBranch %73
+%100 = OpLabel
+OpBranch %68
+%101 = OpLabel
+OpBranch %63
+%102 = OpLabel
+OpBranch %58
+%103 = OpLabel
+OpBranch %53
+%104 = OpLabel
+OpBranch %48
+%105 = OpLabel
+OpBranch %43
+%106 = OpLabel
+OpBranch %38
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %18
+OpFunctionEnd
+%2 = OpFunction %ulong None %735
+%736 = OpFunctionParameter %ulong
+%737 = OpFunctionParameter %ulong
+%738 = OpLabel
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_bool Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_ulong Function
+%749 = OpVariable %_ptr_Function_ulong Function
+%750 = OpVariable %_ptr_Function_ulong Function
+%751 = OpVariable %_ptr_Function_ulong Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_ulong Function
+OpStore %743 %736
+OpStore %744 %737
+%754 = OpLoad %ulong %743
+OpStore %752 %754
+OpStore %753 %ulong_0
+OpBranch %739
+%739 = OpLabel
+%755 = OpLoad %ulong %753
+%756 = OpULessThan %bool %755 %ulong_8
+OpStore %745 %756
+%757 = OpLoad %bool %745
+OpLoopMerge %741 %742 None
+OpBranchConditional %757 %740 %741
+%741 = OpLabel
+%758 = OpLoad %ulong %752
+OpReturnValue %758
+%740 = OpLabel
+%759 = OpLoad %ulong %753
+%760 = OpIMul %ulong %759 %ulong_8
+OpStore %746 %760
+%761 = OpLoad %ulong %744
+%762 = OpLoad %ulong %746
+%763 = OpShiftRightLogical %ulong %761 %762
+OpStore %747 %763
+%764 = OpLoad %ulong %747
+%765 = OpBitwiseAnd %ulong %764 %ulong_255
+OpStore %748 %765
+%766 = OpLoad %ulong %752
+%767 = OpLoad %ulong %748
+%768 = OpBitwiseXor %ulong %766 %767
+OpStore %749 %768
+%769 = OpLoad %ulong %749
+%770 = OpIMul %ulong %769 %ulong_1099511628211
+OpStore %750 %770
+%771 = OpLoad %ulong %753
+%772 = OpIAdd %ulong %771 %ulong_1
+OpStore %751 %772
+%773 = OpLoad %ulong %750
+OpStore %752 %773
+%774 = OpLoad %ulong %751
+OpStore %753 %774
+OpBranch %742
+%742 = OpLabel
+OpBranch %739
 OpFunctionEnd

--- a/test/golden/spirv/bits/shift_i32.dis
+++ b/test/golden/spirv/bits/shift_i32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 323
+; Bound: 903
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,15 +9,18 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_i32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_2863311530 = OpConstant %uint 2863311530
 %uint_1431655765 = OpConstant %uint 1431655765
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_1 = OpConstant %uint 1
 %uint_31 = OpConstant %uint 31
 %uint_5 = OpConstant %uint 5
@@ -27,358 +30,150 @@ OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_i32.checksum" Export
 %uint_0 = OpConstant %uint 0
 %uint_30 = OpConstant %uint 30
 %uint_40 = OpConstant %uint 40
-%270 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%273 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_uint Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_uint Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uint Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uint Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_uint Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_uint Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_uint Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_uint Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_bool Function
-%68 = OpVariable %_ptr_Function_uint Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_uint Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_uint Function
-%73 = OpVariable %_ptr_Function_uint Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_uint Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_uint Function
-%78 = OpVariable %_ptr_Function_bool Function
-%79 = OpVariable %_ptr_Function_uint Function
-%80 = OpVariable %_ptr_Function_uint Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_uint Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_uint Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_uint Function
-%88 = OpVariable %_ptr_Function_uint Function
-OpStore %19 %6
-%89 = OpFunctionCall %ulong %2
-OpStore %20 %89
-%90 = OpLoad %ulong %19
-%91 = OpUConvert %uint %90
-OpStore %22 %91
-%93 = OpLoad %uint %22
-%94 = OpBitwiseXor %uint %uint_4294967295 %93
-OpStore %23 %94
-%96 = OpLoad %uint %22
-%97 = OpBitwiseXor %uint %uint_2863311530 %96
-OpStore %24 %97
-%99 = OpLoad %uint %22
-%100 = OpBitwiseXor %uint %uint_1431655765 %99
-OpStore %25 %100
-%101 = OpLoad %ulong %20
-%102 = OpLoad %uint %23
-%103 = OpFunctionCall %ulong %3 %101 %102
-OpStore %26 %103
-%104 = OpLoad %uint %23
-%106 = OpShiftLeftLogical %uint %104 %uint_1
-OpStore %27 %106
-%107 = OpLoad %ulong %26
-%108 = OpLoad %uint %27
-%109 = OpFunctionCall %ulong %3 %107 %108
-OpStore %28 %109
-%110 = OpLoad %uint %23
-%112 = OpShiftLeftLogical %uint %110 %uint_31
-OpStore %29 %112
-%113 = OpLoad %ulong %28
-%114 = OpLoad %uint %29
-%115 = OpFunctionCall %ulong %3 %113 %114
-OpStore %30 %115
-%116 = OpLoad %ulong %30
-%117 = OpLoad %uint %23
-%118 = OpFunctionCall %ulong %3 %116 %117
-OpStore %31 %118
-%119 = OpLoad %uint %23
-%120 = OpShiftRightArithmetic %uint %119 %uint_1
-OpStore %32 %120
-%121 = OpLoad %ulong %31
-%122 = OpLoad %uint %32
-%123 = OpFunctionCall %ulong %3 %121 %122
-OpStore %33 %123
-%124 = OpLoad %uint %23
-%125 = OpShiftRightArithmetic %uint %124 %uint_31
-OpStore %34 %125
-%126 = OpLoad %ulong %33
-%127 = OpLoad %uint %34
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %35 %128
-%129 = OpLoad %uint %24
-%130 = OpShiftLeftLogical %uint %129 %uint_1
-OpStore %36 %130
-%131 = OpLoad %ulong %35
-%132 = OpLoad %uint %36
-%133 = OpFunctionCall %ulong %3 %131 %132
-OpStore %37 %133
-%134 = OpLoad %uint %24
-%135 = OpShiftRightArithmetic %uint %134 %uint_1
-OpStore %38 %135
-%136 = OpLoad %ulong %37
-%137 = OpLoad %uint %38
-%138 = OpFunctionCall %ulong %3 %136 %137
-OpStore %39 %138
-%139 = OpLoad %uint %24
-%140 = OpShiftRightArithmetic %uint %139 %uint_31
-OpStore %40 %140
-%141 = OpLoad %ulong %39
-%142 = OpLoad %uint %40
-%143 = OpFunctionCall %ulong %3 %141 %142
-OpStore %41 %143
-%144 = OpLoad %uint %25
-%145 = OpShiftLeftLogical %uint %144 %uint_1
-OpStore %42 %145
-%146 = OpLoad %ulong %41
-%147 = OpLoad %uint %42
-%148 = OpFunctionCall %ulong %3 %146 %147
-OpStore %43 %148
-%149 = OpLoad %uint %25
-%150 = OpShiftRightArithmetic %uint %149 %uint_1
-OpStore %44 %150
-%151 = OpLoad %ulong %43
-%152 = OpLoad %uint %44
-%153 = OpFunctionCall %ulong %3 %151 %152
-OpStore %45 %153
-%154 = OpLoad %uint %22
-%156 = OpShiftLeftLogical %uint %154 %uint_5
-OpStore %46 %156
-%157 = OpLoad %ulong %45
-%158 = OpLoad %uint %46
-%159 = OpFunctionCall %ulong %3 %157 %158
-OpStore %47 %159
-%160 = OpLoad %uint %22
-%161 = OpShiftRightArithmetic %uint %160 %uint_5
-OpStore %48 %161
-%162 = OpLoad %ulong %47
-%163 = OpLoad %uint %48
-%164 = OpFunctionCall %ulong %3 %162 %163
-OpStore %49 %164
-%165 = OpLoad %uint %23
-%167 = OpShiftLeftLogical %uint %165 %uint_32
-OpStore %50 %167
-%168 = OpLoad %ulong %49
-%169 = OpLoad %uint %50
-%170 = OpFunctionCall %ulong %3 %168 %169
-OpStore %51 %170
-%171 = OpLoad %uint %23
-%172 = OpShiftRightArithmetic %uint %171 %uint_32
-OpStore %52 %172
-%173 = OpLoad %ulong %51
-%174 = OpLoad %uint %52
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %53 %175
-%176 = OpLoad %uint %23
-%178 = OpShiftLeftLogical %uint %176 %uint_33
-OpStore %54 %178
-%179 = OpLoad %ulong %53
-%180 = OpLoad %uint %54
-%181 = OpFunctionCall %ulong %3 %179 %180
-OpStore %55 %181
-%182 = OpLoad %uint %23
-%183 = OpShiftRightArithmetic %uint %182 %uint_33
-OpStore %56 %183
-%184 = OpLoad %ulong %55
-%185 = OpLoad %uint %56
-%186 = OpFunctionCall %ulong %3 %184 %185
-OpStore %57 %186
-%187 = OpLoad %uint %23
-%189 = OpShiftLeftLogical %uint %187 %uint_63
-OpStore %58 %189
-%190 = OpLoad %ulong %57
-%191 = OpLoad %uint %58
-%192 = OpFunctionCall %ulong %3 %190 %191
-OpStore %59 %192
-%193 = OpLoad %uint %23
-%194 = OpShiftRightArithmetic %uint %193 %uint_63
-OpStore %60 %194
-%195 = OpLoad %ulong %59
-%196 = OpLoad %uint %60
-%197 = OpFunctionCall %ulong %3 %195 %196
-OpStore %61 %197
-%198 = OpLoad %uint %24
-%199 = OpShiftLeftLogical %uint %198 %uint_32
-OpStore %62 %199
-%200 = OpLoad %ulong %61
-%201 = OpLoad %uint %62
-%202 = OpFunctionCall %ulong %3 %200 %201
-OpStore %63 %202
-%203 = OpLoad %uint %24
-%204 = OpShiftRightArithmetic %uint %203 %uint_63
-OpStore %64 %204
-%205 = OpLoad %ulong %63
-%206 = OpLoad %uint %64
-%207 = OpFunctionCall %ulong %3 %205 %206
-OpStore %65 %207
-%208 = OpLoad %ulong %65
-OpStore %86 %208
-OpStore %87 %uint_0
-OpBranch %8
-%8 = OpLabel
-%210 = OpLoad %uint %87
-%211 = OpULessThan %bool %210 %uint_32
-OpStore %67 %211
-%212 = OpLoad %bool %67
-OpLoopMerge %10 %15 None
-OpBranchConditional %212 %9 %10
-%10 = OpLabel
-%213 = OpLoad %ulong %86
-OpStore %85 %213
-OpStore %88 %uint_30
-OpBranch %11
-%11 = OpLabel
-%215 = OpLoad %uint %88
-%217 = OpULessThan %bool %215 %uint_40
-OpStore %78 %217
-%218 = OpLoad %bool %78
-OpLoopMerge %13 %14 None
-OpBranchConditional %218 %12 %13
-%13 = OpLabel
-%219 = OpLoad %ulong %85
-OpReturnValue %219
-%12 = OpLabel
-%220 = OpLoad %uint %88
-%221 = OpLoad %uint %22
-%222 = OpIAdd %uint %220 %221
-OpStore %79 %222
-%223 = OpLoad %uint %23
-%224 = OpLoad %uint %79
-%225 = OpShiftLeftLogical %uint %223 %224
-OpStore %80 %225
-%226 = OpLoad %ulong %85
-%227 = OpLoad %uint %80
-%228 = OpFunctionCall %ulong %3 %226 %227
-OpStore %81 %228
-%229 = OpLoad %uint %23
-%230 = OpLoad %uint %79
-%231 = OpShiftRightArithmetic %uint %229 %230
-OpStore %82 %231
-%232 = OpLoad %ulong %81
-%233 = OpLoad %uint %82
-%234 = OpFunctionCall %ulong %3 %232 %233
-OpStore %83 %234
-%235 = OpLoad %uint %88
-%236 = OpIAdd %uint %235 %uint_1
-OpStore %84 %236
-%237 = OpLoad %ulong %83
-OpStore %85 %237
-%238 = OpLoad %uint %84
-OpStore %88 %238
-OpBranch %14
-%9 = OpLabel
-%239 = OpLoad %uint %23
-%240 = OpLoad %uint %87
-%241 = OpShiftLeftLogical %uint %239 %240
-OpStore %68 %241
-%242 = OpLoad %ulong %86
-%243 = OpLoad %uint %68
-%244 = OpFunctionCall %ulong %3 %242 %243
-OpStore %69 %244
-%245 = OpLoad %uint %23
-%246 = OpLoad %uint %87
-%247 = OpShiftRightArithmetic %uint %245 %246
-OpStore %70 %247
-%248 = OpLoad %ulong %69
-%249 = OpLoad %uint %70
-%250 = OpFunctionCall %ulong %3 %248 %249
-OpStore %71 %250
-%251 = OpLoad %uint %87
-%252 = OpLoad %uint %22
-%253 = OpIAdd %uint %251 %252
-OpStore %72 %253
-%254 = OpLoad %uint %24
-%255 = OpLoad %uint %72
-%256 = OpShiftLeftLogical %uint %254 %255
-OpStore %73 %256
-%257 = OpLoad %ulong %71
-%258 = OpLoad %uint %73
-%259 = OpFunctionCall %ulong %3 %257 %258
-OpStore %74 %259
-%260 = OpLoad %uint %25
-%261 = OpLoad %uint %72
-%262 = OpShiftRightArithmetic %uint %260 %261
-OpStore %75 %262
-%263 = OpLoad %ulong %74
-%264 = OpLoad %uint %75
-%265 = OpFunctionCall %ulong %3 %263 %264
-OpStore %76 %265
-%266 = OpLoad %uint %87
-%267 = OpIAdd %uint %266 %uint_1
-OpStore %77 %267
-%268 = OpLoad %ulong %76
-OpStore %86 %268
-%269 = OpLoad %uint %77
-OpStore %87 %269
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %270
-%271 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %273
-%274 = OpFunctionParameter %ulong
-%275 = OpFunctionParameter %uint
-%276 = OpLabel
+%858 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%148 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_uint Function
+%151 = OpVariable %_ptr_Function_uint Function
+%152 = OpVariable %_ptr_Function_uint Function
+%153 = OpVariable %_ptr_Function_uint Function
+%154 = OpVariable %_ptr_Function_uint Function
+%155 = OpVariable %_ptr_Function_uint Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_uint Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_uint Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_uint Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_uint Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_uint Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_uint Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_uint Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_uint Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_uint Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_uint Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_uint Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_bool Function
+%186 = OpVariable %_ptr_Function_uint Function
+%187 = OpVariable %_ptr_Function_uint Function
+%188 = OpVariable %_ptr_Function_uint Function
+%189 = OpVariable %_ptr_Function_uint Function
+%190 = OpVariable %_ptr_Function_uint Function
+%191 = OpVariable %_ptr_Function_uint Function
+%192 = OpVariable %_ptr_Function_uint Function
+%193 = OpVariable %_ptr_Function_bool Function
+%194 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_uint Function
+%196 = OpVariable %_ptr_Function_uint Function
+%197 = OpVariable %_ptr_Function_uint Function
+%198 = OpVariable %_ptr_Function_uint Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_uint Function
+%202 = OpVariable %_ptr_Function_uint Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_bool Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_bool Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_bool Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_bool Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_bool Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
 %283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_uint Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_bool Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_bool Function
+%286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
 %288 = OpVariable %_ptr_Function_ulong Function
 %289 = OpVariable %_ptr_Function_ulong Function
@@ -386,56 +181,1162 @@ OpFunctionEnd
 %291 = OpVariable %_ptr_Function_ulong Function
 %292 = OpVariable %_ptr_Function_ulong Function
 %293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ulong Function
-OpStore %283 %274
-OpStore %284 %275
-%295 = OpLoad %uint %284
-%296 = OpSConvert %ulong %295
-OpStore %285 %296
-OpBranch %277
-%277 = OpLabel
-%297 = OpLoad %ulong %283
-OpStore %293 %297
-OpStore %294 %ulong_0
-OpBranch %278
-%278 = OpLabel
-%299 = OpLoad %ulong %294
-%301 = OpULessThan %bool %299 %ulong_8
-OpStore %286 %301
-%302 = OpLoad %bool %286
-OpLoopMerge %280 %282 None
-OpBranchConditional %302 %279 %280
-%280 = OpLabel
-OpBranch %281
-%281 = OpLabel
-%303 = OpLoad %ulong %293
-OpReturnValue %303
-%279 = OpLabel
-%304 = OpLoad %ulong %294
-%305 = OpIMul %ulong %304 %ulong_8
-OpStore %287 %305
-%306 = OpLoad %ulong %285
-%307 = OpLoad %ulong %287
-%308 = OpShiftRightLogical %ulong %306 %307
-OpStore %288 %308
-%309 = OpLoad %ulong %288
-%311 = OpBitwiseAnd %ulong %309 %ulong_255
-OpStore %289 %311
-%312 = OpLoad %ulong %293
-%313 = OpLoad %ulong %289
-%314 = OpBitwiseXor %ulong %312 %313
-OpStore %290 %314
-%315 = OpLoad %ulong %290
-%317 = OpIMul %ulong %315 %ulong_1099511628211
-OpStore %291 %317
-%318 = OpLoad %ulong %294
-%320 = OpIAdd %ulong %318 %ulong_1
-OpStore %292 %320
-%321 = OpLoad %ulong %291
-OpStore %293 %321
-%322 = OpLoad %ulong %292
-OpStore %294 %322
-OpBranch %282
-%282 = OpLabel
-OpBranch %278
+%294 = OpVariable %_ptr_Function_bool Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_bool Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_bool Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_bool Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_bool Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+OpStore %148 %5
+OpBranch %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%363 = OpLoad %ulong %148
+%364 = OpUConvert %uint %363
+OpStore %150 %364
+%366 = OpLoad %uint %150
+%367 = OpBitwiseXor %uint %uint_4294967295 %366
+OpStore %151 %367
+%369 = OpLoad %uint %150
+%370 = OpBitwiseXor %uint %uint_2863311530 %369
+OpStore %152 %370
+%372 = OpLoad %uint %150
+%373 = OpBitwiseXor %uint %uint_1431655765 %372
+OpStore %153 %373
+OpBranch %19
+%19 = OpLabel
+%374 = OpLoad %uint %151
+%375 = OpSConvert %ulong %374
+OpStore %205 %375
+OpBranch %35
+%35 = OpLabel
+OpStore %233 %ulong_14695981039346656037
+OpStore %234 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%378 = OpLoad %ulong %234
+%380 = OpULessThan %bool %378 %ulong_8
+OpStore %226 %380
+%381 = OpLoad %bool %226
+OpLoopMerge %38 %144 None
+OpBranchConditional %381 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%382 = OpLoad %uint %151
+%384 = OpShiftLeftLogical %uint %382 %uint_1
+OpStore %154 %384
+OpBranch %40
+%40 = OpLabel
+%385 = OpLoad %uint %154
+%386 = OpSConvert %ulong %385
+OpStore %235 %386
+OpBranch %54
+%54 = OpLabel
+%387 = OpLoad %ulong %233
+OpStore %262 %387
+OpStore %263 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%388 = OpLoad %ulong %263
+%389 = OpULessThan %bool %388 %ulong_8
+OpStore %255 %389
+%390 = OpLoad %bool %255
+OpLoopMerge %57 %143 None
+OpBranchConditional %390 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%391 = OpLoad %uint %151
+%393 = OpShiftLeftLogical %uint %391 %uint_31
+OpStore %155 %393
+OpBranch %59
+%59 = OpLabel
+%394 = OpLoad %uint %155
+%395 = OpSConvert %ulong %394
+OpStore %264 %395
+OpBranch %68
+%68 = OpLabel
+%396 = OpLoad %ulong %262
+OpStore %282 %396
+OpStore %283 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%397 = OpLoad %ulong %283
+%398 = OpULessThan %bool %397 %ulong_8
+OpStore %275 %398
+%399 = OpLoad %bool %275
+OpLoopMerge %71 %142 None
+OpBranchConditional %399 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%400 = OpLoad %uint %151
+%401 = OpSConvert %ulong %400
+OpStore %284 %401
+OpBranch %80
+%80 = OpLabel
+%402 = OpLoad %ulong %282
+OpStore %301 %402
+OpStore %302 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%403 = OpLoad %ulong %302
+%404 = OpULessThan %bool %403 %ulong_8
+OpStore %294 %404
+%405 = OpLoad %bool %294
+OpLoopMerge %83 %141 None
+OpBranchConditional %405 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%406 = OpLoad %uint %151
+%407 = OpShiftRightArithmetic %uint %406 %uint_1
+OpStore %156 %407
+OpBranch %85
+%85 = OpLabel
+%408 = OpLoad %uint %156
+%409 = OpSConvert %ulong %408
+OpStore %303 %409
+OpBranch %87
+%87 = OpLabel
+%410 = OpLoad %ulong %301
+OpStore %311 %410
+OpStore %312 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%411 = OpLoad %ulong %312
+%412 = OpULessThan %bool %411 %ulong_8
+OpStore %304 %412
+%413 = OpLoad %bool %304
+OpLoopMerge %90 %140 None
+OpBranchConditional %413 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%414 = OpLoad %uint %151
+%415 = OpShiftRightArithmetic %uint %414 %uint_31
+OpStore %157 %415
+OpBranch %92
+%92 = OpLabel
+%416 = OpLoad %uint %157
+%417 = OpSConvert %ulong %416
+OpStore %313 %417
+OpBranch %94
+%94 = OpLabel
+%418 = OpLoad %ulong %311
+OpStore %321 %418
+OpStore %322 %ulong_0
+OpBranch %95
+%95 = OpLabel
+%419 = OpLoad %ulong %322
+%420 = OpULessThan %bool %419 %ulong_8
+OpStore %314 %420
+%421 = OpLoad %bool %314
+OpLoopMerge %97 %139 None
+OpBranchConditional %421 %96 %97
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%422 = OpLoad %uint %152
+%423 = OpShiftLeftLogical %uint %422 %uint_1
+OpStore %158 %423
+OpBranch %99
+%99 = OpLabel
+%424 = OpLoad %uint %158
+%425 = OpSConvert %ulong %424
+OpStore %323 %425
+OpBranch %101
+%101 = OpLabel
+%426 = OpLoad %ulong %321
+OpStore %331 %426
+OpStore %332 %ulong_0
+OpBranch %102
+%102 = OpLabel
+%427 = OpLoad %ulong %332
+%428 = OpULessThan %bool %427 %ulong_8
+OpStore %324 %428
+%429 = OpLoad %bool %324
+OpLoopMerge %104 %138 None
+OpBranchConditional %429 %103 %104
+%104 = OpLabel
+OpBranch %105
+%105 = OpLabel
+OpBranch %100
+%100 = OpLabel
+%430 = OpLoad %uint %152
+%431 = OpShiftRightArithmetic %uint %430 %uint_1
+OpStore %159 %431
+OpBranch %106
+%106 = OpLabel
+%432 = OpLoad %uint %159
+%433 = OpSConvert %ulong %432
+OpStore %333 %433
+OpBranch %108
+%108 = OpLabel
+%434 = OpLoad %ulong %331
+OpStore %341 %434
+OpStore %342 %ulong_0
+OpBranch %109
+%109 = OpLabel
+%435 = OpLoad %ulong %342
+%436 = OpULessThan %bool %435 %ulong_8
+OpStore %334 %436
+%437 = OpLoad %bool %334
+OpLoopMerge %111 %137 None
+OpBranchConditional %437 %110 %111
+%111 = OpLabel
+OpBranch %112
+%112 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%438 = OpLoad %uint %152
+%439 = OpShiftRightArithmetic %uint %438 %uint_31
+OpStore %160 %439
+OpBranch %113
+%113 = OpLabel
+%440 = OpLoad %uint %160
+%441 = OpSConvert %ulong %440
+OpStore %343 %441
+OpBranch %115
+%115 = OpLabel
+%442 = OpLoad %ulong %341
+OpStore %351 %442
+OpStore %352 %ulong_0
+OpBranch %116
+%116 = OpLabel
+%443 = OpLoad %ulong %352
+%444 = OpULessThan %bool %443 %ulong_8
+OpStore %344 %444
+%445 = OpLoad %bool %344
+OpLoopMerge %118 %136 None
+OpBranchConditional %445 %117 %118
+%118 = OpLabel
+OpBranch %119
+%119 = OpLabel
+OpBranch %114
+%114 = OpLabel
+%446 = OpLoad %uint %153
+%447 = OpShiftLeftLogical %uint %446 %uint_1
+OpStore %161 %447
+OpBranch %120
+%120 = OpLabel
+%448 = OpLoad %uint %161
+%449 = OpSConvert %ulong %448
+OpStore %353 %449
+OpBranch %122
+%122 = OpLabel
+%450 = OpLoad %ulong %351
+OpStore %361 %450
+OpStore %362 %ulong_0
+OpBranch %123
+%123 = OpLabel
+%451 = OpLoad %ulong %362
+%452 = OpULessThan %bool %451 %ulong_8
+OpStore %354 %452
+%453 = OpLoad %bool %354
+OpLoopMerge %125 %135 None
+OpBranchConditional %453 %124 %125
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%454 = OpLoad %uint %153
+%455 = OpShiftRightArithmetic %uint %454 %uint_1
+OpStore %162 %455
+%456 = OpLoad %ulong %361
+%457 = OpLoad %uint %162
+%458 = OpFunctionCall %ulong %2 %456 %457
+OpStore %163 %458
+%459 = OpLoad %uint %150
+%461 = OpShiftLeftLogical %uint %459 %uint_5
+OpStore %164 %461
+%462 = OpLoad %ulong %163
+%463 = OpLoad %uint %164
+%464 = OpFunctionCall %ulong %2 %462 %463
+OpStore %165 %464
+%465 = OpLoad %uint %150
+%466 = OpShiftRightArithmetic %uint %465 %uint_5
+OpStore %166 %466
+%467 = OpLoad %ulong %165
+%468 = OpLoad %uint %166
+%469 = OpFunctionCall %ulong %2 %467 %468
+OpStore %167 %469
+%470 = OpLoad %uint %151
+%472 = OpShiftLeftLogical %uint %470 %uint_32
+OpStore %168 %472
+%473 = OpLoad %ulong %167
+%474 = OpLoad %uint %168
+%475 = OpFunctionCall %ulong %2 %473 %474
+OpStore %169 %475
+%476 = OpLoad %uint %151
+%477 = OpShiftRightArithmetic %uint %476 %uint_32
+OpStore %170 %477
+%478 = OpLoad %ulong %169
+%479 = OpLoad %uint %170
+%480 = OpFunctionCall %ulong %2 %478 %479
+OpStore %171 %480
+%481 = OpLoad %uint %151
+%483 = OpShiftLeftLogical %uint %481 %uint_33
+OpStore %172 %483
+%484 = OpLoad %ulong %171
+%485 = OpLoad %uint %172
+%486 = OpFunctionCall %ulong %2 %484 %485
+OpStore %173 %486
+%487 = OpLoad %uint %151
+%488 = OpShiftRightArithmetic %uint %487 %uint_33
+OpStore %174 %488
+%489 = OpLoad %ulong %173
+%490 = OpLoad %uint %174
+%491 = OpFunctionCall %ulong %2 %489 %490
+OpStore %175 %491
+%492 = OpLoad %uint %151
+%494 = OpShiftLeftLogical %uint %492 %uint_63
+OpStore %176 %494
+%495 = OpLoad %ulong %175
+%496 = OpLoad %uint %176
+%497 = OpFunctionCall %ulong %2 %495 %496
+OpStore %177 %497
+%498 = OpLoad %uint %151
+%499 = OpShiftRightArithmetic %uint %498 %uint_63
+OpStore %178 %499
+%500 = OpLoad %ulong %177
+%501 = OpLoad %uint %178
+%502 = OpFunctionCall %ulong %2 %500 %501
+OpStore %179 %502
+%503 = OpLoad %uint %152
+%504 = OpShiftLeftLogical %uint %503 %uint_32
+OpStore %180 %504
+%505 = OpLoad %ulong %179
+%506 = OpLoad %uint %180
+%507 = OpFunctionCall %ulong %2 %505 %506
+OpStore %181 %507
+%508 = OpLoad %uint %152
+%509 = OpShiftRightArithmetic %uint %508 %uint_63
+OpStore %182 %509
+%510 = OpLoad %ulong %181
+%511 = OpLoad %uint %182
+%512 = OpFunctionCall %ulong %2 %510 %511
+OpStore %183 %512
+%513 = OpLoad %ulong %183
+OpStore %200 %513
+OpStore %201 %uint_0
+OpBranch %7
+%7 = OpLabel
+%515 = OpLoad %uint %201
+%516 = OpULessThan %bool %515 %uint_32
+OpStore %185 %516
+%517 = OpLoad %bool %185
+OpLoopMerge %9 %134 None
+OpBranchConditional %517 %8 %9
+%9 = OpLabel
+%518 = OpLoad %ulong %200
+OpStore %199 %518
+OpStore %202 %uint_30
+OpBranch %10
+%10 = OpLabel
+%520 = OpLoad %uint %202
+%522 = OpULessThan %bool %520 %uint_40
+OpStore %193 %522
+%523 = OpLoad %bool %193
+OpLoopMerge %12 %133 None
+OpBranchConditional %523 %11 %12
+%12 = OpLabel
+%524 = OpLoad %ulong %199
+OpReturnValue %524
+%11 = OpLabel
+%525 = OpLoad %uint %202
+%526 = OpLoad %uint %150
+%527 = OpIAdd %uint %525 %526
+OpStore %194 %527
+%528 = OpLoad %uint %151
+%529 = OpLoad %uint %194
+%530 = OpShiftLeftLogical %uint %528 %529
+OpStore %195 %530
+OpBranch %17
+%17 = OpLabel
+%531 = OpLoad %uint %195
+%532 = OpSConvert %ulong %531
+OpStore %204 %532
+OpBranch %28
+%28 = OpLabel
+%533 = OpLoad %ulong %199
+OpStore %223 %533
+OpStore %224 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%534 = OpLoad %ulong %224
+%535 = OpULessThan %bool %534 %ulong_8
+OpStore %216 %535
+%536 = OpLoad %bool %216
+OpLoopMerge %31 %131 None
+OpBranchConditional %536 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%537 = OpLoad %uint %202
+%538 = OpLoad %uint %150
+%539 = OpIAdd %uint %537 %538
+OpStore %196 %539
+%540 = OpLoad %uint %151
+%541 = OpLoad %uint %196
+%542 = OpShiftRightArithmetic %uint %540 %541
+OpStore %197 %542
+OpBranch %33
+%33 = OpLabel
+%543 = OpLoad %uint %197
+%544 = OpSConvert %ulong %543
+OpStore %225 %544
+OpBranch %49
+%49 = OpLabel
+%545 = OpLoad %ulong %223
+OpStore %253 %545
+OpStore %254 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%546 = OpLoad %ulong %254
+%547 = OpULessThan %bool %546 %ulong_8
+OpStore %246 %547
+%548 = OpLoad %bool %246
+OpLoopMerge %52 %129 None
+OpBranchConditional %548 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%549 = OpLoad %uint %202
+%550 = OpIAdd %uint %549 %uint_1
+OpStore %198 %550
+%551 = OpLoad %ulong %253
+OpStore %199 %551
+%552 = OpLoad %uint %198
+OpStore %202 %552
+OpBranch %133
+%51 = OpLabel
+%553 = OpLoad %ulong %254
+%554 = OpIMul %ulong %553 %ulong_8
+OpStore %247 %554
+%555 = OpLoad %ulong %225
+%556 = OpLoad %ulong %247
+%557 = OpShiftRightLogical %ulong %555 %556
+OpStore %248 %557
+%558 = OpLoad %ulong %248
+%560 = OpBitwiseAnd %ulong %558 %ulong_255
+OpStore %249 %560
+%561 = OpLoad %ulong %253
+%562 = OpLoad %ulong %249
+%563 = OpBitwiseXor %ulong %561 %562
+OpStore %250 %563
+%564 = OpLoad %ulong %250
+%566 = OpIMul %ulong %564 %ulong_1099511628211
+OpStore %251 %566
+%567 = OpLoad %ulong %254
+%569 = OpIAdd %ulong %567 %ulong_1
+OpStore %252 %569
+%570 = OpLoad %ulong %251
+OpStore %253 %570
+%571 = OpLoad %ulong %252
+OpStore %254 %571
+OpBranch %129
+%30 = OpLabel
+%572 = OpLoad %ulong %224
+%573 = OpIMul %ulong %572 %ulong_8
+OpStore %217 %573
+%574 = OpLoad %ulong %204
+%575 = OpLoad %ulong %217
+%576 = OpShiftRightLogical %ulong %574 %575
+OpStore %218 %576
+%577 = OpLoad %ulong %218
+%578 = OpBitwiseAnd %ulong %577 %ulong_255
+OpStore %219 %578
+%579 = OpLoad %ulong %223
+%580 = OpLoad %ulong %219
+%581 = OpBitwiseXor %ulong %579 %580
+OpStore %220 %581
+%582 = OpLoad %ulong %220
+%583 = OpIMul %ulong %582 %ulong_1099511628211
+OpStore %221 %583
+%584 = OpLoad %ulong %224
+%585 = OpIAdd %ulong %584 %ulong_1
+OpStore %222 %585
+%586 = OpLoad %ulong %221
+OpStore %223 %586
+%587 = OpLoad %ulong %222
+OpStore %224 %587
+OpBranch %131
+%8 = OpLabel
+%588 = OpLoad %uint %151
+%589 = OpLoad %uint %201
+%590 = OpShiftLeftLogical %uint %588 %589
+OpStore %186 %590
+OpBranch %15
+%15 = OpLabel
+%591 = OpLoad %uint %186
+%592 = OpSConvert %ulong %591
+OpStore %203 %592
+OpBranch %21
+%21 = OpLabel
+%593 = OpLoad %ulong %200
+OpStore %213 %593
+OpStore %214 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%594 = OpLoad %ulong %214
+%595 = OpULessThan %bool %594 %ulong_8
+OpStore %206 %595
+%596 = OpLoad %bool %206
+OpLoopMerge %24 %132 None
+OpBranchConditional %596 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%597 = OpLoad %uint %151
+%598 = OpLoad %uint %201
+%599 = OpShiftRightArithmetic %uint %597 %598
+OpStore %187 %599
+OpBranch %26
+%26 = OpLabel
+%600 = OpLoad %uint %187
+%601 = OpSConvert %ulong %600
+OpStore %215 %601
+OpBranch %42
+%42 = OpLabel
+%602 = OpLoad %ulong %213
+OpStore %243 %602
+OpStore %244 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%603 = OpLoad %ulong %244
+%604 = OpULessThan %bool %603 %ulong_8
+OpStore %236 %604
+%605 = OpLoad %bool %236
+OpLoopMerge %45 %130 None
+OpBranchConditional %605 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%606 = OpLoad %uint %201
+%607 = OpLoad %uint %150
+%608 = OpIAdd %uint %606 %607
+OpStore %188 %608
+%609 = OpLoad %uint %152
+%610 = OpLoad %uint %188
+%611 = OpShiftLeftLogical %uint %609 %610
+OpStore %189 %611
+OpBranch %47
+%47 = OpLabel
+%612 = OpLoad %uint %189
+%613 = OpSConvert %ulong %612
+OpStore %245 %613
+OpBranch %61
+%61 = OpLabel
+%614 = OpLoad %ulong %243
+OpStore %272 %614
+OpStore %273 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%615 = OpLoad %ulong %273
+%616 = OpULessThan %bool %615 %ulong_8
+OpStore %265 %616
+%617 = OpLoad %bool %265
+OpLoopMerge %64 %128 None
+OpBranchConditional %617 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%618 = OpLoad %uint %201
+%619 = OpLoad %uint %150
+%620 = OpIAdd %uint %618 %619
+OpStore %190 %620
+%621 = OpLoad %uint %153
+%622 = OpLoad %uint %190
+%623 = OpShiftRightArithmetic %uint %621 %622
+OpStore %191 %623
+OpBranch %66
+%66 = OpLabel
+%624 = OpLoad %uint %191
+%625 = OpSConvert %ulong %624
+OpStore %274 %625
+OpBranch %75
+%75 = OpLabel
+%626 = OpLoad %ulong %272
+OpStore %292 %626
+OpStore %293 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%627 = OpLoad %ulong %293
+%628 = OpULessThan %bool %627 %ulong_8
+OpStore %285 %628
+%629 = OpLoad %bool %285
+OpLoopMerge %78 %127 None
+OpBranchConditional %629 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%630 = OpLoad %uint %201
+%631 = OpIAdd %uint %630 %uint_1
+OpStore %192 %631
+%632 = OpLoad %ulong %292
+OpStore %200 %632
+%633 = OpLoad %uint %192
+OpStore %201 %633
+OpBranch %134
+%77 = OpLabel
+%634 = OpLoad %ulong %293
+%635 = OpIMul %ulong %634 %ulong_8
+OpStore %286 %635
+%636 = OpLoad %ulong %274
+%637 = OpLoad %ulong %286
+%638 = OpShiftRightLogical %ulong %636 %637
+OpStore %287 %638
+%639 = OpLoad %ulong %287
+%640 = OpBitwiseAnd %ulong %639 %ulong_255
+OpStore %288 %640
+%641 = OpLoad %ulong %292
+%642 = OpLoad %ulong %288
+%643 = OpBitwiseXor %ulong %641 %642
+OpStore %289 %643
+%644 = OpLoad %ulong %289
+%645 = OpIMul %ulong %644 %ulong_1099511628211
+OpStore %290 %645
+%646 = OpLoad %ulong %293
+%647 = OpIAdd %ulong %646 %ulong_1
+OpStore %291 %647
+%648 = OpLoad %ulong %290
+OpStore %292 %648
+%649 = OpLoad %ulong %291
+OpStore %293 %649
+OpBranch %127
+%63 = OpLabel
+%650 = OpLoad %ulong %273
+%651 = OpIMul %ulong %650 %ulong_8
+OpStore %266 %651
+%652 = OpLoad %ulong %245
+%653 = OpLoad %ulong %266
+%654 = OpShiftRightLogical %ulong %652 %653
+OpStore %267 %654
+%655 = OpLoad %ulong %267
+%656 = OpBitwiseAnd %ulong %655 %ulong_255
+OpStore %268 %656
+%657 = OpLoad %ulong %272
+%658 = OpLoad %ulong %268
+%659 = OpBitwiseXor %ulong %657 %658
+OpStore %269 %659
+%660 = OpLoad %ulong %269
+%661 = OpIMul %ulong %660 %ulong_1099511628211
+OpStore %270 %661
+%662 = OpLoad %ulong %273
+%663 = OpIAdd %ulong %662 %ulong_1
+OpStore %271 %663
+%664 = OpLoad %ulong %270
+OpStore %272 %664
+%665 = OpLoad %ulong %271
+OpStore %273 %665
+OpBranch %128
+%44 = OpLabel
+%666 = OpLoad %ulong %244
+%667 = OpIMul %ulong %666 %ulong_8
+OpStore %237 %667
+%668 = OpLoad %ulong %215
+%669 = OpLoad %ulong %237
+%670 = OpShiftRightLogical %ulong %668 %669
+OpStore %238 %670
+%671 = OpLoad %ulong %238
+%672 = OpBitwiseAnd %ulong %671 %ulong_255
+OpStore %239 %672
+%673 = OpLoad %ulong %243
+%674 = OpLoad %ulong %239
+%675 = OpBitwiseXor %ulong %673 %674
+OpStore %240 %675
+%676 = OpLoad %ulong %240
+%677 = OpIMul %ulong %676 %ulong_1099511628211
+OpStore %241 %677
+%678 = OpLoad %ulong %244
+%679 = OpIAdd %ulong %678 %ulong_1
+OpStore %242 %679
+%680 = OpLoad %ulong %241
+OpStore %243 %680
+%681 = OpLoad %ulong %242
+OpStore %244 %681
+OpBranch %130
+%23 = OpLabel
+%682 = OpLoad %ulong %214
+%683 = OpIMul %ulong %682 %ulong_8
+OpStore %207 %683
+%684 = OpLoad %ulong %203
+%685 = OpLoad %ulong %207
+%686 = OpShiftRightLogical %ulong %684 %685
+OpStore %208 %686
+%687 = OpLoad %ulong %208
+%688 = OpBitwiseAnd %ulong %687 %ulong_255
+OpStore %209 %688
+%689 = OpLoad %ulong %213
+%690 = OpLoad %ulong %209
+%691 = OpBitwiseXor %ulong %689 %690
+OpStore %210 %691
+%692 = OpLoad %ulong %210
+%693 = OpIMul %ulong %692 %ulong_1099511628211
+OpStore %211 %693
+%694 = OpLoad %ulong %214
+%695 = OpIAdd %ulong %694 %ulong_1
+OpStore %212 %695
+%696 = OpLoad %ulong %211
+OpStore %213 %696
+%697 = OpLoad %ulong %212
+OpStore %214 %697
+OpBranch %132
+%124 = OpLabel
+%698 = OpLoad %ulong %362
+%699 = OpIMul %ulong %698 %ulong_8
+OpStore %355 %699
+%700 = OpLoad %ulong %353
+%701 = OpLoad %ulong %355
+%702 = OpShiftRightLogical %ulong %700 %701
+OpStore %356 %702
+%703 = OpLoad %ulong %356
+%704 = OpBitwiseAnd %ulong %703 %ulong_255
+OpStore %357 %704
+%705 = OpLoad %ulong %361
+%706 = OpLoad %ulong %357
+%707 = OpBitwiseXor %ulong %705 %706
+OpStore %358 %707
+%708 = OpLoad %ulong %358
+%709 = OpIMul %ulong %708 %ulong_1099511628211
+OpStore %359 %709
+%710 = OpLoad %ulong %362
+%711 = OpIAdd %ulong %710 %ulong_1
+OpStore %360 %711
+%712 = OpLoad %ulong %359
+OpStore %361 %712
+%713 = OpLoad %ulong %360
+OpStore %362 %713
+OpBranch %135
+%117 = OpLabel
+%714 = OpLoad %ulong %352
+%715 = OpIMul %ulong %714 %ulong_8
+OpStore %345 %715
+%716 = OpLoad %ulong %343
+%717 = OpLoad %ulong %345
+%718 = OpShiftRightLogical %ulong %716 %717
+OpStore %346 %718
+%719 = OpLoad %ulong %346
+%720 = OpBitwiseAnd %ulong %719 %ulong_255
+OpStore %347 %720
+%721 = OpLoad %ulong %351
+%722 = OpLoad %ulong %347
+%723 = OpBitwiseXor %ulong %721 %722
+OpStore %348 %723
+%724 = OpLoad %ulong %348
+%725 = OpIMul %ulong %724 %ulong_1099511628211
+OpStore %349 %725
+%726 = OpLoad %ulong %352
+%727 = OpIAdd %ulong %726 %ulong_1
+OpStore %350 %727
+%728 = OpLoad %ulong %349
+OpStore %351 %728
+%729 = OpLoad %ulong %350
+OpStore %352 %729
+OpBranch %136
+%110 = OpLabel
+%730 = OpLoad %ulong %342
+%731 = OpIMul %ulong %730 %ulong_8
+OpStore %335 %731
+%732 = OpLoad %ulong %333
+%733 = OpLoad %ulong %335
+%734 = OpShiftRightLogical %ulong %732 %733
+OpStore %336 %734
+%735 = OpLoad %ulong %336
+%736 = OpBitwiseAnd %ulong %735 %ulong_255
+OpStore %337 %736
+%737 = OpLoad %ulong %341
+%738 = OpLoad %ulong %337
+%739 = OpBitwiseXor %ulong %737 %738
+OpStore %338 %739
+%740 = OpLoad %ulong %338
+%741 = OpIMul %ulong %740 %ulong_1099511628211
+OpStore %339 %741
+%742 = OpLoad %ulong %342
+%743 = OpIAdd %ulong %742 %ulong_1
+OpStore %340 %743
+%744 = OpLoad %ulong %339
+OpStore %341 %744
+%745 = OpLoad %ulong %340
+OpStore %342 %745
+OpBranch %137
+%103 = OpLabel
+%746 = OpLoad %ulong %332
+%747 = OpIMul %ulong %746 %ulong_8
+OpStore %325 %747
+%748 = OpLoad %ulong %323
+%749 = OpLoad %ulong %325
+%750 = OpShiftRightLogical %ulong %748 %749
+OpStore %326 %750
+%751 = OpLoad %ulong %326
+%752 = OpBitwiseAnd %ulong %751 %ulong_255
+OpStore %327 %752
+%753 = OpLoad %ulong %331
+%754 = OpLoad %ulong %327
+%755 = OpBitwiseXor %ulong %753 %754
+OpStore %328 %755
+%756 = OpLoad %ulong %328
+%757 = OpIMul %ulong %756 %ulong_1099511628211
+OpStore %329 %757
+%758 = OpLoad %ulong %332
+%759 = OpIAdd %ulong %758 %ulong_1
+OpStore %330 %759
+%760 = OpLoad %ulong %329
+OpStore %331 %760
+%761 = OpLoad %ulong %330
+OpStore %332 %761
+OpBranch %138
+%96 = OpLabel
+%762 = OpLoad %ulong %322
+%763 = OpIMul %ulong %762 %ulong_8
+OpStore %315 %763
+%764 = OpLoad %ulong %313
+%765 = OpLoad %ulong %315
+%766 = OpShiftRightLogical %ulong %764 %765
+OpStore %316 %766
+%767 = OpLoad %ulong %316
+%768 = OpBitwiseAnd %ulong %767 %ulong_255
+OpStore %317 %768
+%769 = OpLoad %ulong %321
+%770 = OpLoad %ulong %317
+%771 = OpBitwiseXor %ulong %769 %770
+OpStore %318 %771
+%772 = OpLoad %ulong %318
+%773 = OpIMul %ulong %772 %ulong_1099511628211
+OpStore %319 %773
+%774 = OpLoad %ulong %322
+%775 = OpIAdd %ulong %774 %ulong_1
+OpStore %320 %775
+%776 = OpLoad %ulong %319
+OpStore %321 %776
+%777 = OpLoad %ulong %320
+OpStore %322 %777
+OpBranch %139
+%89 = OpLabel
+%778 = OpLoad %ulong %312
+%779 = OpIMul %ulong %778 %ulong_8
+OpStore %305 %779
+%780 = OpLoad %ulong %303
+%781 = OpLoad %ulong %305
+%782 = OpShiftRightLogical %ulong %780 %781
+OpStore %306 %782
+%783 = OpLoad %ulong %306
+%784 = OpBitwiseAnd %ulong %783 %ulong_255
+OpStore %307 %784
+%785 = OpLoad %ulong %311
+%786 = OpLoad %ulong %307
+%787 = OpBitwiseXor %ulong %785 %786
+OpStore %308 %787
+%788 = OpLoad %ulong %308
+%789 = OpIMul %ulong %788 %ulong_1099511628211
+OpStore %309 %789
+%790 = OpLoad %ulong %312
+%791 = OpIAdd %ulong %790 %ulong_1
+OpStore %310 %791
+%792 = OpLoad %ulong %309
+OpStore %311 %792
+%793 = OpLoad %ulong %310
+OpStore %312 %793
+OpBranch %140
+%82 = OpLabel
+%794 = OpLoad %ulong %302
+%795 = OpIMul %ulong %794 %ulong_8
+OpStore %295 %795
+%796 = OpLoad %ulong %284
+%797 = OpLoad %ulong %295
+%798 = OpShiftRightLogical %ulong %796 %797
+OpStore %296 %798
+%799 = OpLoad %ulong %296
+%800 = OpBitwiseAnd %ulong %799 %ulong_255
+OpStore %297 %800
+%801 = OpLoad %ulong %301
+%802 = OpLoad %ulong %297
+%803 = OpBitwiseXor %ulong %801 %802
+OpStore %298 %803
+%804 = OpLoad %ulong %298
+%805 = OpIMul %ulong %804 %ulong_1099511628211
+OpStore %299 %805
+%806 = OpLoad %ulong %302
+%807 = OpIAdd %ulong %806 %ulong_1
+OpStore %300 %807
+%808 = OpLoad %ulong %299
+OpStore %301 %808
+%809 = OpLoad %ulong %300
+OpStore %302 %809
+OpBranch %141
+%70 = OpLabel
+%810 = OpLoad %ulong %283
+%811 = OpIMul %ulong %810 %ulong_8
+OpStore %276 %811
+%812 = OpLoad %ulong %264
+%813 = OpLoad %ulong %276
+%814 = OpShiftRightLogical %ulong %812 %813
+OpStore %277 %814
+%815 = OpLoad %ulong %277
+%816 = OpBitwiseAnd %ulong %815 %ulong_255
+OpStore %278 %816
+%817 = OpLoad %ulong %282
+%818 = OpLoad %ulong %278
+%819 = OpBitwiseXor %ulong %817 %818
+OpStore %279 %819
+%820 = OpLoad %ulong %279
+%821 = OpIMul %ulong %820 %ulong_1099511628211
+OpStore %280 %821
+%822 = OpLoad %ulong %283
+%823 = OpIAdd %ulong %822 %ulong_1
+OpStore %281 %823
+%824 = OpLoad %ulong %280
+OpStore %282 %824
+%825 = OpLoad %ulong %281
+OpStore %283 %825
+OpBranch %142
+%56 = OpLabel
+%826 = OpLoad %ulong %263
+%827 = OpIMul %ulong %826 %ulong_8
+OpStore %256 %827
+%828 = OpLoad %ulong %235
+%829 = OpLoad %ulong %256
+%830 = OpShiftRightLogical %ulong %828 %829
+OpStore %257 %830
+%831 = OpLoad %ulong %257
+%832 = OpBitwiseAnd %ulong %831 %ulong_255
+OpStore %258 %832
+%833 = OpLoad %ulong %262
+%834 = OpLoad %ulong %258
+%835 = OpBitwiseXor %ulong %833 %834
+OpStore %259 %835
+%836 = OpLoad %ulong %259
+%837 = OpIMul %ulong %836 %ulong_1099511628211
+OpStore %260 %837
+%838 = OpLoad %ulong %263
+%839 = OpIAdd %ulong %838 %ulong_1
+OpStore %261 %839
+%840 = OpLoad %ulong %260
+OpStore %262 %840
+%841 = OpLoad %ulong %261
+OpStore %263 %841
+OpBranch %143
+%37 = OpLabel
+%842 = OpLoad %ulong %234
+%843 = OpIMul %ulong %842 %ulong_8
+OpStore %227 %843
+%844 = OpLoad %ulong %205
+%845 = OpLoad %ulong %227
+%846 = OpShiftRightLogical %ulong %844 %845
+OpStore %228 %846
+%847 = OpLoad %ulong %228
+%848 = OpBitwiseAnd %ulong %847 %ulong_255
+OpStore %229 %848
+%849 = OpLoad %ulong %233
+%850 = OpLoad %ulong %229
+%851 = OpBitwiseXor %ulong %849 %850
+OpStore %230 %851
+%852 = OpLoad %ulong %230
+%853 = OpIMul %ulong %852 %ulong_1099511628211
+OpStore %231 %853
+%854 = OpLoad %ulong %234
+%855 = OpIAdd %ulong %854 %ulong_1
+OpStore %232 %855
+%856 = OpLoad %ulong %231
+OpStore %233 %856
+%857 = OpLoad %ulong %232
+OpStore %234 %857
+OpBranch %144
+%127 = OpLabel
+OpBranch %76
+%128 = OpLabel
+OpBranch %62
+%129 = OpLabel
+OpBranch %50
+%130 = OpLabel
+OpBranch %43
+%131 = OpLabel
+OpBranch %29
+%132 = OpLabel
+OpBranch %22
+%133 = OpLabel
+OpBranch %10
+%134 = OpLabel
+OpBranch %7
+%135 = OpLabel
+OpBranch %123
+%136 = OpLabel
+OpBranch %116
+%137 = OpLabel
+OpBranch %109
+%138 = OpLabel
+OpBranch %102
+%139 = OpLabel
+OpBranch %95
+%140 = OpLabel
+OpBranch %88
+%141 = OpLabel
+OpBranch %81
+%142 = OpLabel
+OpBranch %69
+%143 = OpLabel
+OpBranch %55
+%144 = OpLabel
+OpBranch %36
+OpFunctionEnd
+%2 = OpFunction %ulong None %858
+%859 = OpFunctionParameter %ulong
+%860 = OpFunctionParameter %uint
+%861 = OpLabel
+%868 = OpVariable %_ptr_Function_ulong Function
+%869 = OpVariable %_ptr_Function_uint Function
+%870 = OpVariable %_ptr_Function_ulong Function
+%871 = OpVariable %_ptr_Function_bool Function
+%872 = OpVariable %_ptr_Function_ulong Function
+%873 = OpVariable %_ptr_Function_ulong Function
+%874 = OpVariable %_ptr_Function_ulong Function
+%875 = OpVariable %_ptr_Function_ulong Function
+%876 = OpVariable %_ptr_Function_ulong Function
+%877 = OpVariable %_ptr_Function_ulong Function
+%878 = OpVariable %_ptr_Function_ulong Function
+%879 = OpVariable %_ptr_Function_ulong Function
+OpStore %868 %859
+OpStore %869 %860
+%880 = OpLoad %uint %869
+%881 = OpSConvert %ulong %880
+OpStore %870 %881
+OpBranch %862
+%862 = OpLabel
+%882 = OpLoad %ulong %868
+OpStore %878 %882
+OpStore %879 %ulong_0
+OpBranch %863
+%863 = OpLabel
+%883 = OpLoad %ulong %879
+%884 = OpULessThan %bool %883 %ulong_8
+OpStore %871 %884
+%885 = OpLoad %bool %871
+OpLoopMerge %865 %867 None
+OpBranchConditional %885 %864 %865
+%865 = OpLabel
+OpBranch %866
+%866 = OpLabel
+%886 = OpLoad %ulong %878
+OpReturnValue %886
+%864 = OpLabel
+%887 = OpLoad %ulong %879
+%888 = OpIMul %ulong %887 %ulong_8
+OpStore %872 %888
+%889 = OpLoad %ulong %870
+%890 = OpLoad %ulong %872
+%891 = OpShiftRightLogical %ulong %889 %890
+OpStore %873 %891
+%892 = OpLoad %ulong %873
+%893 = OpBitwiseAnd %ulong %892 %ulong_255
+OpStore %874 %893
+%894 = OpLoad %ulong %878
+%895 = OpLoad %ulong %874
+%896 = OpBitwiseXor %ulong %894 %895
+OpStore %875 %896
+%897 = OpLoad %ulong %875
+%898 = OpIMul %ulong %897 %ulong_1099511628211
+OpStore %876 %898
+%899 = OpLoad %ulong %879
+%900 = OpIAdd %ulong %899 %ulong_1
+OpStore %877 %900
+%901 = OpLoad %ulong %876
+OpStore %878 %901
+%902 = OpLoad %ulong %877
+OpStore %879 %902
+OpBranch %867
+%867 = OpLabel
+OpBranch %863
 OpFunctionEnd

--- a/test/golden/spirv/bits/shift_i64.dis
+++ b/test/golden/spirv/bits/shift_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 313
+; Bound: 845
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,368 +9,164 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_i64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
 %ulong_12297829382473034410 = OpConstant %ulong 12297829382473034410
 %ulong_6148914691236517205 = OpConstant %ulong 6148914691236517205
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ulong_1 = OpConstant %ulong 1
 %ulong_63 = OpConstant %ulong 63
 %ulong_5 = OpConstant %ulong 5
 %ulong_64 = OpConstant %ulong 64
 %ulong_65 = OpConstant %ulong 65
 %ulong_127 = OpConstant %ulong 127
-%ulong_0 = OpConstant %ulong 0
 %ulong_60 = OpConstant %ulong 60
 %ulong_72 = OpConstant %ulong 72
-%265 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%268 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_bool Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_ulong Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_bool Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_ulong Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_ulong Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_ulong Function
-OpStore %18 %6
-%86 = OpFunctionCall %ulong %2
-OpStore %19 %86
-%88 = OpLoad %ulong %18
-%89 = OpBitwiseXor %ulong %ulong_18446744073709551615 %88
-OpStore %20 %89
-%91 = OpLoad %ulong %18
-%92 = OpBitwiseXor %ulong %ulong_12297829382473034410 %91
-OpStore %21 %92
-%94 = OpLoad %ulong %18
-%95 = OpBitwiseXor %ulong %ulong_6148914691236517205 %94
-OpStore %22 %95
-%96 = OpLoad %ulong %19
-%97 = OpLoad %ulong %20
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %23 %98
-%99 = OpLoad %ulong %20
-%101 = OpShiftLeftLogical %ulong %99 %ulong_1
-OpStore %24 %101
-%102 = OpLoad %ulong %23
-%103 = OpLoad %ulong %24
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %25 %104
-%105 = OpLoad %ulong %20
-%107 = OpShiftLeftLogical %ulong %105 %ulong_63
-OpStore %26 %107
-%108 = OpLoad %ulong %25
-%109 = OpLoad %ulong %26
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %27 %110
-%111 = OpLoad %ulong %27
-%112 = OpLoad %ulong %20
-%113 = OpFunctionCall %ulong %3 %111 %112
-OpStore %28 %113
-%114 = OpLoad %ulong %20
-%115 = OpShiftRightArithmetic %ulong %114 %ulong_1
-OpStore %29 %115
-%116 = OpLoad %ulong %28
-%117 = OpLoad %ulong %29
-%118 = OpFunctionCall %ulong %3 %116 %117
-OpStore %30 %118
-%119 = OpLoad %ulong %20
-%120 = OpShiftRightArithmetic %ulong %119 %ulong_63
-OpStore %31 %120
-%121 = OpLoad %ulong %30
-%122 = OpLoad %ulong %31
-%123 = OpFunctionCall %ulong %3 %121 %122
-OpStore %32 %123
-%124 = OpLoad %ulong %21
-%125 = OpShiftLeftLogical %ulong %124 %ulong_1
-OpStore %33 %125
-%126 = OpLoad %ulong %32
-%127 = OpLoad %ulong %33
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %34 %128
-%129 = OpLoad %ulong %21
-%130 = OpShiftRightArithmetic %ulong %129 %ulong_1
-OpStore %35 %130
-%131 = OpLoad %ulong %34
-%132 = OpLoad %ulong %35
-%133 = OpFunctionCall %ulong %3 %131 %132
-OpStore %36 %133
-%134 = OpLoad %ulong %21
-%135 = OpShiftRightArithmetic %ulong %134 %ulong_63
-OpStore %37 %135
-%136 = OpLoad %ulong %36
-%137 = OpLoad %ulong %37
-%138 = OpFunctionCall %ulong %3 %136 %137
-OpStore %38 %138
-%139 = OpLoad %ulong %22
-%140 = OpShiftLeftLogical %ulong %139 %ulong_1
-OpStore %39 %140
-%141 = OpLoad %ulong %38
-%142 = OpLoad %ulong %39
-%143 = OpFunctionCall %ulong %3 %141 %142
-OpStore %40 %143
-%144 = OpLoad %ulong %22
-%145 = OpShiftRightArithmetic %ulong %144 %ulong_1
-OpStore %41 %145
-%146 = OpLoad %ulong %40
-%147 = OpLoad %ulong %41
-%148 = OpFunctionCall %ulong %3 %146 %147
-OpStore %42 %148
-%149 = OpLoad %ulong %18
-%151 = OpShiftLeftLogical %ulong %149 %ulong_5
-OpStore %43 %151
-%152 = OpLoad %ulong %42
-%153 = OpLoad %ulong %43
-%154 = OpFunctionCall %ulong %3 %152 %153
-OpStore %44 %154
-%155 = OpLoad %ulong %18
-%156 = OpShiftRightArithmetic %ulong %155 %ulong_5
-OpStore %45 %156
-%157 = OpLoad %ulong %44
-%158 = OpLoad %ulong %45
-%159 = OpFunctionCall %ulong %3 %157 %158
-OpStore %46 %159
-%160 = OpLoad %ulong %20
-%162 = OpShiftLeftLogical %ulong %160 %ulong_64
-OpStore %47 %162
-%163 = OpLoad %ulong %46
-%164 = OpLoad %ulong %47
-%165 = OpFunctionCall %ulong %3 %163 %164
-OpStore %48 %165
-%166 = OpLoad %ulong %20
-%167 = OpShiftRightArithmetic %ulong %166 %ulong_64
-OpStore %49 %167
-%168 = OpLoad %ulong %48
-%169 = OpLoad %ulong %49
-%170 = OpFunctionCall %ulong %3 %168 %169
-OpStore %50 %170
-%171 = OpLoad %ulong %20
-%173 = OpShiftLeftLogical %ulong %171 %ulong_65
-OpStore %51 %173
-%174 = OpLoad %ulong %50
-%175 = OpLoad %ulong %51
-%176 = OpFunctionCall %ulong %3 %174 %175
-OpStore %52 %176
-%177 = OpLoad %ulong %20
-%178 = OpShiftRightArithmetic %ulong %177 %ulong_65
-OpStore %53 %178
-%179 = OpLoad %ulong %52
-%180 = OpLoad %ulong %53
-%181 = OpFunctionCall %ulong %3 %179 %180
-OpStore %54 %181
-%182 = OpLoad %ulong %20
-%184 = OpShiftLeftLogical %ulong %182 %ulong_127
-OpStore %55 %184
-%185 = OpLoad %ulong %54
-%186 = OpLoad %ulong %55
-%187 = OpFunctionCall %ulong %3 %185 %186
-OpStore %56 %187
-%188 = OpLoad %ulong %20
-%189 = OpShiftRightArithmetic %ulong %188 %ulong_127
-OpStore %57 %189
-%190 = OpLoad %ulong %56
-%191 = OpLoad %ulong %57
-%192 = OpFunctionCall %ulong %3 %190 %191
-OpStore %58 %192
-%193 = OpLoad %ulong %21
-%194 = OpShiftLeftLogical %ulong %193 %ulong_64
-OpStore %59 %194
-%195 = OpLoad %ulong %58
-%196 = OpLoad %ulong %59
-%197 = OpFunctionCall %ulong %3 %195 %196
-OpStore %60 %197
-%198 = OpLoad %ulong %21
-%199 = OpShiftRightArithmetic %ulong %198 %ulong_127
-OpStore %61 %199
-%200 = OpLoad %ulong %60
-%201 = OpLoad %ulong %61
-%202 = OpFunctionCall %ulong %3 %200 %201
-OpStore %62 %202
-%203 = OpLoad %ulong %62
-OpStore %83 %203
-OpStore %84 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%205 = OpLoad %ulong %84
-%206 = OpULessThan %bool %205 %ulong_64
-OpStore %64 %206
-%207 = OpLoad %bool %64
-OpLoopMerge %10 %15 None
-OpBranchConditional %207 %9 %10
-%10 = OpLabel
-%208 = OpLoad %ulong %83
-OpStore %82 %208
-OpStore %85 %ulong_60
-OpBranch %11
-%11 = OpLabel
-%210 = OpLoad %ulong %85
-%212 = OpULessThan %bool %210 %ulong_72
-OpStore %75 %212
-%213 = OpLoad %bool %75
-OpLoopMerge %13 %14 None
-OpBranchConditional %213 %12 %13
-%13 = OpLabel
-%214 = OpLoad %ulong %82
-OpReturnValue %214
-%12 = OpLabel
-%215 = OpLoad %ulong %85
-%216 = OpLoad %ulong %18
-%217 = OpIAdd %ulong %215 %216
-OpStore %76 %217
-%218 = OpLoad %ulong %20
-%219 = OpLoad %ulong %76
-%220 = OpShiftLeftLogical %ulong %218 %219
-OpStore %77 %220
-%221 = OpLoad %ulong %82
-%222 = OpLoad %ulong %77
-%223 = OpFunctionCall %ulong %3 %221 %222
-OpStore %78 %223
-%224 = OpLoad %ulong %20
-%225 = OpLoad %ulong %76
-%226 = OpShiftRightArithmetic %ulong %224 %225
-OpStore %79 %226
-%227 = OpLoad %ulong %78
-%228 = OpLoad %ulong %79
-%229 = OpFunctionCall %ulong %3 %227 %228
-OpStore %80 %229
-%230 = OpLoad %ulong %85
-%231 = OpIAdd %ulong %230 %ulong_1
-OpStore %81 %231
-%232 = OpLoad %ulong %80
-OpStore %82 %232
-%233 = OpLoad %ulong %81
-OpStore %85 %233
-OpBranch %14
-%9 = OpLabel
-%234 = OpLoad %ulong %20
-%235 = OpLoad %ulong %84
-%236 = OpShiftLeftLogical %ulong %234 %235
-OpStore %65 %236
-%237 = OpLoad %ulong %83
-%238 = OpLoad %ulong %65
-%239 = OpFunctionCall %ulong %3 %237 %238
-OpStore %66 %239
-%240 = OpLoad %ulong %20
-%241 = OpLoad %ulong %84
-%242 = OpShiftRightArithmetic %ulong %240 %241
-OpStore %67 %242
-%243 = OpLoad %ulong %66
-%244 = OpLoad %ulong %67
-%245 = OpFunctionCall %ulong %3 %243 %244
-OpStore %68 %245
-%246 = OpLoad %ulong %84
-%247 = OpLoad %ulong %18
-%248 = OpIAdd %ulong %246 %247
-OpStore %69 %248
-%249 = OpLoad %ulong %21
-%250 = OpLoad %ulong %69
-%251 = OpShiftLeftLogical %ulong %249 %250
-OpStore %70 %251
-%252 = OpLoad %ulong %68
-%253 = OpLoad %ulong %70
-%254 = OpFunctionCall %ulong %3 %252 %253
-OpStore %71 %254
-%255 = OpLoad %ulong %22
-%256 = OpLoad %ulong %69
-%257 = OpShiftRightArithmetic %ulong %255 %256
-OpStore %72 %257
-%258 = OpLoad %ulong %71
-%259 = OpLoad %ulong %72
-%260 = OpFunctionCall %ulong %3 %258 %259
-OpStore %73 %260
-%261 = OpLoad %ulong %84
-%262 = OpIAdd %ulong %261 %ulong_1
-OpStore %74 %262
-%263 = OpLoad %ulong %73
-OpStore %83 %263
-%264 = OpLoad %ulong %74
-OpStore %84 %264
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %265
-%266 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %268
-%269 = OpFunctionParameter %ulong
-%270 = OpFunctionParameter %ulong
-%271 = OpLabel
+%803 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_bool Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_bool Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_bool Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_bool Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_bool Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_bool Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_bool Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_bool Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_bool Function
-%281 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_bool Function
 %282 = OpVariable %_ptr_Function_ulong Function
 %283 = OpVariable %_ptr_Function_ulong Function
 %284 = OpVariable %_ptr_Function_ulong Function
@@ -378,52 +174,1093 @@ OpFunctionEnd
 %286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
 %288 = OpVariable %_ptr_Function_ulong Function
-OpStore %278 %269
-OpStore %279 %270
-OpBranch %272
-%272 = OpLabel
-%289 = OpLoad %ulong %278
-OpStore %287 %289
-OpStore %288 %ulong_0
-OpBranch %273
-%273 = OpLabel
-%290 = OpLoad %ulong %288
-%292 = OpULessThan %bool %290 %ulong_8
-OpStore %280 %292
-%293 = OpLoad %bool %280
-OpLoopMerge %275 %277 None
-OpBranchConditional %293 %274 %275
-%275 = OpLabel
-OpBranch %276
-%276 = OpLabel
-%294 = OpLoad %ulong %287
-OpReturnValue %294
-%274 = OpLabel
-%295 = OpLoad %ulong %288
-%296 = OpIMul %ulong %295 %ulong_8
-OpStore %281 %296
-%297 = OpLoad %ulong %279
-%298 = OpLoad %ulong %281
-%299 = OpShiftRightLogical %ulong %297 %298
-OpStore %282 %299
-%300 = OpLoad %ulong %282
-%302 = OpBitwiseAnd %ulong %300 %ulong_255
-OpStore %283 %302
-%303 = OpLoad %ulong %287
-%304 = OpLoad %ulong %283
-%305 = OpBitwiseXor %ulong %303 %304
-OpStore %284 %305
-%306 = OpLoad %ulong %284
-%308 = OpIMul %ulong %306 %ulong_1099511628211
-OpStore %285 %308
-%309 = OpLoad %ulong %288
-%310 = OpIAdd %ulong %309 %ulong_1
-OpStore %286 %310
-%311 = OpLoad %ulong %285
-OpStore %287 %311
-%312 = OpLoad %ulong %286
-OpStore %288 %312
-OpBranch %277
-%277 = OpLabel
-OpBranch %273
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_bool Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_bool Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_bool Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_bool Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_bool Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_bool Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+OpStore %147 %5
+OpBranch %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%345 = OpLoad %ulong %147
+%346 = OpBitwiseXor %ulong %ulong_18446744073709551615 %345
+OpStore %148 %346
+%348 = OpLoad %ulong %147
+%349 = OpBitwiseXor %ulong %ulong_12297829382473034410 %348
+OpStore %149 %349
+%351 = OpLoad %ulong %147
+%352 = OpBitwiseXor %ulong %ulong_6148914691236517205 %351
+OpStore %150 %352
+OpBranch %19
+%19 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpStore %225 %ulong_14695981039346656037
+OpStore %226 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%355 = OpLoad %ulong %226
+%357 = OpULessThan %bool %355 %ulong_8
+OpStore %218 %357
+%358 = OpLoad %bool %218
+OpLoopMerge %38 %144 None
+OpBranchConditional %358 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%359 = OpLoad %ulong %148
+%361 = OpShiftLeftLogical %ulong %359 %ulong_1
+OpStore %151 %361
+OpBranch %40
+%40 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%362 = OpLoad %ulong %225
+OpStore %252 %362
+OpStore %253 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%363 = OpLoad %ulong %253
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %245 %364
+%365 = OpLoad %bool %245
+OpLoopMerge %57 %143 None
+OpBranchConditional %365 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%366 = OpLoad %ulong %148
+%368 = OpShiftLeftLogical %ulong %366 %ulong_63
+OpStore %152 %368
+OpBranch %59
+%59 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%369 = OpLoad %ulong %252
+OpStore %270 %369
+OpStore %271 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%370 = OpLoad %ulong %271
+%371 = OpULessThan %bool %370 %ulong_8
+OpStore %263 %371
+%372 = OpLoad %bool %263
+OpLoopMerge %71 %142 None
+OpBranchConditional %372 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %80
+%80 = OpLabel
+%373 = OpLoad %ulong %270
+OpStore %288 %373
+OpStore %289 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%374 = OpLoad %ulong %289
+%375 = OpULessThan %bool %374 %ulong_8
+OpStore %281 %375
+%376 = OpLoad %bool %281
+OpLoopMerge %83 %141 None
+OpBranchConditional %376 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%377 = OpLoad %ulong %148
+%378 = OpShiftRightArithmetic %ulong %377 %ulong_1
+OpStore %153 %378
+OpBranch %85
+%85 = OpLabel
+OpBranch %87
+%87 = OpLabel
+%379 = OpLoad %ulong %288
+OpStore %297 %379
+OpStore %298 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%380 = OpLoad %ulong %298
+%381 = OpULessThan %bool %380 %ulong_8
+OpStore %290 %381
+%382 = OpLoad %bool %290
+OpLoopMerge %90 %140 None
+OpBranchConditional %382 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%383 = OpLoad %ulong %148
+%384 = OpShiftRightArithmetic %ulong %383 %ulong_63
+OpStore %154 %384
+OpBranch %92
+%92 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%385 = OpLoad %ulong %297
+OpStore %306 %385
+OpStore %307 %ulong_0
+OpBranch %95
+%95 = OpLabel
+%386 = OpLoad %ulong %307
+%387 = OpULessThan %bool %386 %ulong_8
+OpStore %299 %387
+%388 = OpLoad %bool %299
+OpLoopMerge %97 %139 None
+OpBranchConditional %388 %96 %97
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%389 = OpLoad %ulong %149
+%390 = OpShiftLeftLogical %ulong %389 %ulong_1
+OpStore %155 %390
+OpBranch %99
+%99 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%391 = OpLoad %ulong %306
+OpStore %315 %391
+OpStore %316 %ulong_0
+OpBranch %102
+%102 = OpLabel
+%392 = OpLoad %ulong %316
+%393 = OpULessThan %bool %392 %ulong_8
+OpStore %308 %393
+%394 = OpLoad %bool %308
+OpLoopMerge %104 %138 None
+OpBranchConditional %394 %103 %104
+%104 = OpLabel
+OpBranch %105
+%105 = OpLabel
+OpBranch %100
+%100 = OpLabel
+%395 = OpLoad %ulong %149
+%396 = OpShiftRightArithmetic %ulong %395 %ulong_1
+OpStore %156 %396
+OpBranch %106
+%106 = OpLabel
+OpBranch %108
+%108 = OpLabel
+%397 = OpLoad %ulong %315
+OpStore %324 %397
+OpStore %325 %ulong_0
+OpBranch %109
+%109 = OpLabel
+%398 = OpLoad %ulong %325
+%399 = OpULessThan %bool %398 %ulong_8
+OpStore %317 %399
+%400 = OpLoad %bool %317
+OpLoopMerge %111 %137 None
+OpBranchConditional %400 %110 %111
+%111 = OpLabel
+OpBranch %112
+%112 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%401 = OpLoad %ulong %149
+%402 = OpShiftRightArithmetic %ulong %401 %ulong_63
+OpStore %157 %402
+OpBranch %113
+%113 = OpLabel
+OpBranch %115
+%115 = OpLabel
+%403 = OpLoad %ulong %324
+OpStore %333 %403
+OpStore %334 %ulong_0
+OpBranch %116
+%116 = OpLabel
+%404 = OpLoad %ulong %334
+%405 = OpULessThan %bool %404 %ulong_8
+OpStore %326 %405
+%406 = OpLoad %bool %326
+OpLoopMerge %118 %136 None
+OpBranchConditional %406 %117 %118
+%118 = OpLabel
+OpBranch %119
+%119 = OpLabel
+OpBranch %114
+%114 = OpLabel
+%407 = OpLoad %ulong %150
+%408 = OpShiftLeftLogical %ulong %407 %ulong_1
+OpStore %158 %408
+OpBranch %120
+%120 = OpLabel
+OpBranch %122
+%122 = OpLabel
+%409 = OpLoad %ulong %333
+OpStore %342 %409
+OpStore %343 %ulong_0
+OpBranch %123
+%123 = OpLabel
+%410 = OpLoad %ulong %343
+%411 = OpULessThan %bool %410 %ulong_8
+OpStore %335 %411
+%412 = OpLoad %bool %335
+OpLoopMerge %125 %135 None
+OpBranchConditional %412 %124 %125
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%413 = OpLoad %ulong %150
+%414 = OpShiftRightArithmetic %ulong %413 %ulong_1
+OpStore %159 %414
+%415 = OpLoad %ulong %342
+%416 = OpLoad %ulong %159
+%417 = OpFunctionCall %ulong %2 %415 %416
+OpStore %160 %417
+%418 = OpLoad %ulong %147
+%420 = OpShiftLeftLogical %ulong %418 %ulong_5
+OpStore %161 %420
+%421 = OpLoad %ulong %160
+%422 = OpLoad %ulong %161
+%423 = OpFunctionCall %ulong %2 %421 %422
+OpStore %162 %423
+%424 = OpLoad %ulong %147
+%425 = OpShiftRightArithmetic %ulong %424 %ulong_5
+OpStore %163 %425
+%426 = OpLoad %ulong %162
+%427 = OpLoad %ulong %163
+%428 = OpFunctionCall %ulong %2 %426 %427
+OpStore %164 %428
+%429 = OpLoad %ulong %148
+%431 = OpShiftLeftLogical %ulong %429 %ulong_64
+OpStore %165 %431
+%432 = OpLoad %ulong %164
+%433 = OpLoad %ulong %165
+%434 = OpFunctionCall %ulong %2 %432 %433
+OpStore %166 %434
+%435 = OpLoad %ulong %148
+%436 = OpShiftRightArithmetic %ulong %435 %ulong_64
+OpStore %167 %436
+%437 = OpLoad %ulong %166
+%438 = OpLoad %ulong %167
+%439 = OpFunctionCall %ulong %2 %437 %438
+OpStore %168 %439
+%440 = OpLoad %ulong %148
+%442 = OpShiftLeftLogical %ulong %440 %ulong_65
+OpStore %169 %442
+%443 = OpLoad %ulong %168
+%444 = OpLoad %ulong %169
+%445 = OpFunctionCall %ulong %2 %443 %444
+OpStore %170 %445
+%446 = OpLoad %ulong %148
+%447 = OpShiftRightArithmetic %ulong %446 %ulong_65
+OpStore %171 %447
+%448 = OpLoad %ulong %170
+%449 = OpLoad %ulong %171
+%450 = OpFunctionCall %ulong %2 %448 %449
+OpStore %172 %450
+%451 = OpLoad %ulong %148
+%453 = OpShiftLeftLogical %ulong %451 %ulong_127
+OpStore %173 %453
+%454 = OpLoad %ulong %172
+%455 = OpLoad %ulong %173
+%456 = OpFunctionCall %ulong %2 %454 %455
+OpStore %174 %456
+%457 = OpLoad %ulong %148
+%458 = OpShiftRightArithmetic %ulong %457 %ulong_127
+OpStore %175 %458
+%459 = OpLoad %ulong %174
+%460 = OpLoad %ulong %175
+%461 = OpFunctionCall %ulong %2 %459 %460
+OpStore %176 %461
+%462 = OpLoad %ulong %149
+%463 = OpShiftLeftLogical %ulong %462 %ulong_64
+OpStore %177 %463
+%464 = OpLoad %ulong %176
+%465 = OpLoad %ulong %177
+%466 = OpFunctionCall %ulong %2 %464 %465
+OpStore %178 %466
+%467 = OpLoad %ulong %149
+%468 = OpShiftRightArithmetic %ulong %467 %ulong_127
+OpStore %179 %468
+%469 = OpLoad %ulong %178
+%470 = OpLoad %ulong %179
+%471 = OpFunctionCall %ulong %2 %469 %470
+OpStore %180 %471
+%472 = OpLoad %ulong %180
+OpStore %197 %472
+OpStore %198 %ulong_0
+OpBranch %7
+%7 = OpLabel
+%473 = OpLoad %ulong %198
+%474 = OpULessThan %bool %473 %ulong_64
+OpStore %182 %474
+%475 = OpLoad %bool %182
+OpLoopMerge %9 %134 None
+OpBranchConditional %475 %8 %9
+%9 = OpLabel
+%476 = OpLoad %ulong %197
+OpStore %196 %476
+OpStore %199 %ulong_60
+OpBranch %10
+%10 = OpLabel
+%478 = OpLoad %ulong %199
+%480 = OpULessThan %bool %478 %ulong_72
+OpStore %190 %480
+%481 = OpLoad %bool %190
+OpLoopMerge %12 %133 None
+OpBranchConditional %481 %11 %12
+%12 = OpLabel
+%482 = OpLoad %ulong %196
+OpReturnValue %482
+%11 = OpLabel
+%483 = OpLoad %ulong %199
+%484 = OpLoad %ulong %147
+%485 = OpIAdd %ulong %483 %484
+OpStore %191 %485
+%486 = OpLoad %ulong %148
+%487 = OpLoad %ulong %191
+%488 = OpShiftLeftLogical %ulong %486 %487
+OpStore %192 %488
+OpBranch %17
+%17 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%489 = OpLoad %ulong %196
+OpStore %216 %489
+OpStore %217 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%490 = OpLoad %ulong %217
+%491 = OpULessThan %bool %490 %ulong_8
+OpStore %209 %491
+%492 = OpLoad %bool %209
+OpLoopMerge %31 %131 None
+OpBranchConditional %492 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%493 = OpLoad %ulong %199
+%494 = OpLoad %ulong %147
+%495 = OpIAdd %ulong %493 %494
+OpStore %193 %495
+%496 = OpLoad %ulong %148
+%497 = OpLoad %ulong %193
+%498 = OpShiftRightArithmetic %ulong %496 %497
+OpStore %194 %498
+OpBranch %33
+%33 = OpLabel
+OpBranch %49
+%49 = OpLabel
+%499 = OpLoad %ulong %216
+OpStore %243 %499
+OpStore %244 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%500 = OpLoad %ulong %244
+%501 = OpULessThan %bool %500 %ulong_8
+OpStore %236 %501
+%502 = OpLoad %bool %236
+OpLoopMerge %52 %129 None
+OpBranchConditional %502 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%503 = OpLoad %ulong %199
+%504 = OpIAdd %ulong %503 %ulong_1
+OpStore %195 %504
+%505 = OpLoad %ulong %243
+OpStore %196 %505
+%506 = OpLoad %ulong %195
+OpStore %199 %506
+OpBranch %133
+%51 = OpLabel
+%507 = OpLoad %ulong %244
+%508 = OpIMul %ulong %507 %ulong_8
+OpStore %237 %508
+%509 = OpLoad %ulong %194
+%510 = OpLoad %ulong %237
+%511 = OpShiftRightLogical %ulong %509 %510
+OpStore %238 %511
+%512 = OpLoad %ulong %238
+%514 = OpBitwiseAnd %ulong %512 %ulong_255
+OpStore %239 %514
+%515 = OpLoad %ulong %243
+%516 = OpLoad %ulong %239
+%517 = OpBitwiseXor %ulong %515 %516
+OpStore %240 %517
+%518 = OpLoad %ulong %240
+%520 = OpIMul %ulong %518 %ulong_1099511628211
+OpStore %241 %520
+%521 = OpLoad %ulong %244
+%522 = OpIAdd %ulong %521 %ulong_1
+OpStore %242 %522
+%523 = OpLoad %ulong %241
+OpStore %243 %523
+%524 = OpLoad %ulong %242
+OpStore %244 %524
+OpBranch %129
+%30 = OpLabel
+%525 = OpLoad %ulong %217
+%526 = OpIMul %ulong %525 %ulong_8
+OpStore %210 %526
+%527 = OpLoad %ulong %192
+%528 = OpLoad %ulong %210
+%529 = OpShiftRightLogical %ulong %527 %528
+OpStore %211 %529
+%530 = OpLoad %ulong %211
+%531 = OpBitwiseAnd %ulong %530 %ulong_255
+OpStore %212 %531
+%532 = OpLoad %ulong %216
+%533 = OpLoad %ulong %212
+%534 = OpBitwiseXor %ulong %532 %533
+OpStore %213 %534
+%535 = OpLoad %ulong %213
+%536 = OpIMul %ulong %535 %ulong_1099511628211
+OpStore %214 %536
+%537 = OpLoad %ulong %217
+%538 = OpIAdd %ulong %537 %ulong_1
+OpStore %215 %538
+%539 = OpLoad %ulong %214
+OpStore %216 %539
+%540 = OpLoad %ulong %215
+OpStore %217 %540
+OpBranch %131
+%8 = OpLabel
+%541 = OpLoad %ulong %148
+%542 = OpLoad %ulong %198
+%543 = OpShiftLeftLogical %ulong %541 %542
+OpStore %183 %543
+OpBranch %15
+%15 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%544 = OpLoad %ulong %197
+OpStore %207 %544
+OpStore %208 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%545 = OpLoad %ulong %208
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %200 %546
+%547 = OpLoad %bool %200
+OpLoopMerge %24 %132 None
+OpBranchConditional %547 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%548 = OpLoad %ulong %148
+%549 = OpLoad %ulong %198
+%550 = OpShiftRightArithmetic %ulong %548 %549
+OpStore %184 %550
+OpBranch %26
+%26 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%551 = OpLoad %ulong %207
+OpStore %234 %551
+OpStore %235 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%552 = OpLoad %ulong %235
+%553 = OpULessThan %bool %552 %ulong_8
+OpStore %227 %553
+%554 = OpLoad %bool %227
+OpLoopMerge %45 %130 None
+OpBranchConditional %554 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%555 = OpLoad %ulong %198
+%556 = OpLoad %ulong %147
+%557 = OpIAdd %ulong %555 %556
+OpStore %185 %557
+%558 = OpLoad %ulong %149
+%559 = OpLoad %ulong %185
+%560 = OpShiftLeftLogical %ulong %558 %559
+OpStore %186 %560
+OpBranch %47
+%47 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%561 = OpLoad %ulong %234
+OpStore %261 %561
+OpStore %262 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%562 = OpLoad %ulong %262
+%563 = OpULessThan %bool %562 %ulong_8
+OpStore %254 %563
+%564 = OpLoad %bool %254
+OpLoopMerge %64 %128 None
+OpBranchConditional %564 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%565 = OpLoad %ulong %198
+%566 = OpLoad %ulong %147
+%567 = OpIAdd %ulong %565 %566
+OpStore %187 %567
+%568 = OpLoad %ulong %150
+%569 = OpLoad %ulong %187
+%570 = OpShiftRightArithmetic %ulong %568 %569
+OpStore %188 %570
+OpBranch %66
+%66 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%571 = OpLoad %ulong %261
+OpStore %279 %571
+OpStore %280 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%572 = OpLoad %ulong %280
+%573 = OpULessThan %bool %572 %ulong_8
+OpStore %272 %573
+%574 = OpLoad %bool %272
+OpLoopMerge %78 %127 None
+OpBranchConditional %574 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%575 = OpLoad %ulong %198
+%576 = OpIAdd %ulong %575 %ulong_1
+OpStore %189 %576
+%577 = OpLoad %ulong %279
+OpStore %197 %577
+%578 = OpLoad %ulong %189
+OpStore %198 %578
+OpBranch %134
+%77 = OpLabel
+%579 = OpLoad %ulong %280
+%580 = OpIMul %ulong %579 %ulong_8
+OpStore %273 %580
+%581 = OpLoad %ulong %188
+%582 = OpLoad %ulong %273
+%583 = OpShiftRightLogical %ulong %581 %582
+OpStore %274 %583
+%584 = OpLoad %ulong %274
+%585 = OpBitwiseAnd %ulong %584 %ulong_255
+OpStore %275 %585
+%586 = OpLoad %ulong %279
+%587 = OpLoad %ulong %275
+%588 = OpBitwiseXor %ulong %586 %587
+OpStore %276 %588
+%589 = OpLoad %ulong %276
+%590 = OpIMul %ulong %589 %ulong_1099511628211
+OpStore %277 %590
+%591 = OpLoad %ulong %280
+%592 = OpIAdd %ulong %591 %ulong_1
+OpStore %278 %592
+%593 = OpLoad %ulong %277
+OpStore %279 %593
+%594 = OpLoad %ulong %278
+OpStore %280 %594
+OpBranch %127
+%63 = OpLabel
+%595 = OpLoad %ulong %262
+%596 = OpIMul %ulong %595 %ulong_8
+OpStore %255 %596
+%597 = OpLoad %ulong %186
+%598 = OpLoad %ulong %255
+%599 = OpShiftRightLogical %ulong %597 %598
+OpStore %256 %599
+%600 = OpLoad %ulong %256
+%601 = OpBitwiseAnd %ulong %600 %ulong_255
+OpStore %257 %601
+%602 = OpLoad %ulong %261
+%603 = OpLoad %ulong %257
+%604 = OpBitwiseXor %ulong %602 %603
+OpStore %258 %604
+%605 = OpLoad %ulong %258
+%606 = OpIMul %ulong %605 %ulong_1099511628211
+OpStore %259 %606
+%607 = OpLoad %ulong %262
+%608 = OpIAdd %ulong %607 %ulong_1
+OpStore %260 %608
+%609 = OpLoad %ulong %259
+OpStore %261 %609
+%610 = OpLoad %ulong %260
+OpStore %262 %610
+OpBranch %128
+%44 = OpLabel
+%611 = OpLoad %ulong %235
+%612 = OpIMul %ulong %611 %ulong_8
+OpStore %228 %612
+%613 = OpLoad %ulong %184
+%614 = OpLoad %ulong %228
+%615 = OpShiftRightLogical %ulong %613 %614
+OpStore %229 %615
+%616 = OpLoad %ulong %229
+%617 = OpBitwiseAnd %ulong %616 %ulong_255
+OpStore %230 %617
+%618 = OpLoad %ulong %234
+%619 = OpLoad %ulong %230
+%620 = OpBitwiseXor %ulong %618 %619
+OpStore %231 %620
+%621 = OpLoad %ulong %231
+%622 = OpIMul %ulong %621 %ulong_1099511628211
+OpStore %232 %622
+%623 = OpLoad %ulong %235
+%624 = OpIAdd %ulong %623 %ulong_1
+OpStore %233 %624
+%625 = OpLoad %ulong %232
+OpStore %234 %625
+%626 = OpLoad %ulong %233
+OpStore %235 %626
+OpBranch %130
+%23 = OpLabel
+%627 = OpLoad %ulong %208
+%628 = OpIMul %ulong %627 %ulong_8
+OpStore %201 %628
+%629 = OpLoad %ulong %183
+%630 = OpLoad %ulong %201
+%631 = OpShiftRightLogical %ulong %629 %630
+OpStore %202 %631
+%632 = OpLoad %ulong %202
+%633 = OpBitwiseAnd %ulong %632 %ulong_255
+OpStore %203 %633
+%634 = OpLoad %ulong %207
+%635 = OpLoad %ulong %203
+%636 = OpBitwiseXor %ulong %634 %635
+OpStore %204 %636
+%637 = OpLoad %ulong %204
+%638 = OpIMul %ulong %637 %ulong_1099511628211
+OpStore %205 %638
+%639 = OpLoad %ulong %208
+%640 = OpIAdd %ulong %639 %ulong_1
+OpStore %206 %640
+%641 = OpLoad %ulong %205
+OpStore %207 %641
+%642 = OpLoad %ulong %206
+OpStore %208 %642
+OpBranch %132
+%124 = OpLabel
+%643 = OpLoad %ulong %343
+%644 = OpIMul %ulong %643 %ulong_8
+OpStore %336 %644
+%645 = OpLoad %ulong %158
+%646 = OpLoad %ulong %336
+%647 = OpShiftRightLogical %ulong %645 %646
+OpStore %337 %647
+%648 = OpLoad %ulong %337
+%649 = OpBitwiseAnd %ulong %648 %ulong_255
+OpStore %338 %649
+%650 = OpLoad %ulong %342
+%651 = OpLoad %ulong %338
+%652 = OpBitwiseXor %ulong %650 %651
+OpStore %339 %652
+%653 = OpLoad %ulong %339
+%654 = OpIMul %ulong %653 %ulong_1099511628211
+OpStore %340 %654
+%655 = OpLoad %ulong %343
+%656 = OpIAdd %ulong %655 %ulong_1
+OpStore %341 %656
+%657 = OpLoad %ulong %340
+OpStore %342 %657
+%658 = OpLoad %ulong %341
+OpStore %343 %658
+OpBranch %135
+%117 = OpLabel
+%659 = OpLoad %ulong %334
+%660 = OpIMul %ulong %659 %ulong_8
+OpStore %327 %660
+%661 = OpLoad %ulong %157
+%662 = OpLoad %ulong %327
+%663 = OpShiftRightLogical %ulong %661 %662
+OpStore %328 %663
+%664 = OpLoad %ulong %328
+%665 = OpBitwiseAnd %ulong %664 %ulong_255
+OpStore %329 %665
+%666 = OpLoad %ulong %333
+%667 = OpLoad %ulong %329
+%668 = OpBitwiseXor %ulong %666 %667
+OpStore %330 %668
+%669 = OpLoad %ulong %330
+%670 = OpIMul %ulong %669 %ulong_1099511628211
+OpStore %331 %670
+%671 = OpLoad %ulong %334
+%672 = OpIAdd %ulong %671 %ulong_1
+OpStore %332 %672
+%673 = OpLoad %ulong %331
+OpStore %333 %673
+%674 = OpLoad %ulong %332
+OpStore %334 %674
+OpBranch %136
+%110 = OpLabel
+%675 = OpLoad %ulong %325
+%676 = OpIMul %ulong %675 %ulong_8
+OpStore %318 %676
+%677 = OpLoad %ulong %156
+%678 = OpLoad %ulong %318
+%679 = OpShiftRightLogical %ulong %677 %678
+OpStore %319 %679
+%680 = OpLoad %ulong %319
+%681 = OpBitwiseAnd %ulong %680 %ulong_255
+OpStore %320 %681
+%682 = OpLoad %ulong %324
+%683 = OpLoad %ulong %320
+%684 = OpBitwiseXor %ulong %682 %683
+OpStore %321 %684
+%685 = OpLoad %ulong %321
+%686 = OpIMul %ulong %685 %ulong_1099511628211
+OpStore %322 %686
+%687 = OpLoad %ulong %325
+%688 = OpIAdd %ulong %687 %ulong_1
+OpStore %323 %688
+%689 = OpLoad %ulong %322
+OpStore %324 %689
+%690 = OpLoad %ulong %323
+OpStore %325 %690
+OpBranch %137
+%103 = OpLabel
+%691 = OpLoad %ulong %316
+%692 = OpIMul %ulong %691 %ulong_8
+OpStore %309 %692
+%693 = OpLoad %ulong %155
+%694 = OpLoad %ulong %309
+%695 = OpShiftRightLogical %ulong %693 %694
+OpStore %310 %695
+%696 = OpLoad %ulong %310
+%697 = OpBitwiseAnd %ulong %696 %ulong_255
+OpStore %311 %697
+%698 = OpLoad %ulong %315
+%699 = OpLoad %ulong %311
+%700 = OpBitwiseXor %ulong %698 %699
+OpStore %312 %700
+%701 = OpLoad %ulong %312
+%702 = OpIMul %ulong %701 %ulong_1099511628211
+OpStore %313 %702
+%703 = OpLoad %ulong %316
+%704 = OpIAdd %ulong %703 %ulong_1
+OpStore %314 %704
+%705 = OpLoad %ulong %313
+OpStore %315 %705
+%706 = OpLoad %ulong %314
+OpStore %316 %706
+OpBranch %138
+%96 = OpLabel
+%707 = OpLoad %ulong %307
+%708 = OpIMul %ulong %707 %ulong_8
+OpStore %300 %708
+%709 = OpLoad %ulong %154
+%710 = OpLoad %ulong %300
+%711 = OpShiftRightLogical %ulong %709 %710
+OpStore %301 %711
+%712 = OpLoad %ulong %301
+%713 = OpBitwiseAnd %ulong %712 %ulong_255
+OpStore %302 %713
+%714 = OpLoad %ulong %306
+%715 = OpLoad %ulong %302
+%716 = OpBitwiseXor %ulong %714 %715
+OpStore %303 %716
+%717 = OpLoad %ulong %303
+%718 = OpIMul %ulong %717 %ulong_1099511628211
+OpStore %304 %718
+%719 = OpLoad %ulong %307
+%720 = OpIAdd %ulong %719 %ulong_1
+OpStore %305 %720
+%721 = OpLoad %ulong %304
+OpStore %306 %721
+%722 = OpLoad %ulong %305
+OpStore %307 %722
+OpBranch %139
+%89 = OpLabel
+%723 = OpLoad %ulong %298
+%724 = OpIMul %ulong %723 %ulong_8
+OpStore %291 %724
+%725 = OpLoad %ulong %153
+%726 = OpLoad %ulong %291
+%727 = OpShiftRightLogical %ulong %725 %726
+OpStore %292 %727
+%728 = OpLoad %ulong %292
+%729 = OpBitwiseAnd %ulong %728 %ulong_255
+OpStore %293 %729
+%730 = OpLoad %ulong %297
+%731 = OpLoad %ulong %293
+%732 = OpBitwiseXor %ulong %730 %731
+OpStore %294 %732
+%733 = OpLoad %ulong %294
+%734 = OpIMul %ulong %733 %ulong_1099511628211
+OpStore %295 %734
+%735 = OpLoad %ulong %298
+%736 = OpIAdd %ulong %735 %ulong_1
+OpStore %296 %736
+%737 = OpLoad %ulong %295
+OpStore %297 %737
+%738 = OpLoad %ulong %296
+OpStore %298 %738
+OpBranch %140
+%82 = OpLabel
+%739 = OpLoad %ulong %289
+%740 = OpIMul %ulong %739 %ulong_8
+OpStore %282 %740
+%741 = OpLoad %ulong %148
+%742 = OpLoad %ulong %282
+%743 = OpShiftRightLogical %ulong %741 %742
+OpStore %283 %743
+%744 = OpLoad %ulong %283
+%745 = OpBitwiseAnd %ulong %744 %ulong_255
+OpStore %284 %745
+%746 = OpLoad %ulong %288
+%747 = OpLoad %ulong %284
+%748 = OpBitwiseXor %ulong %746 %747
+OpStore %285 %748
+%749 = OpLoad %ulong %285
+%750 = OpIMul %ulong %749 %ulong_1099511628211
+OpStore %286 %750
+%751 = OpLoad %ulong %289
+%752 = OpIAdd %ulong %751 %ulong_1
+OpStore %287 %752
+%753 = OpLoad %ulong %286
+OpStore %288 %753
+%754 = OpLoad %ulong %287
+OpStore %289 %754
+OpBranch %141
+%70 = OpLabel
+%755 = OpLoad %ulong %271
+%756 = OpIMul %ulong %755 %ulong_8
+OpStore %264 %756
+%757 = OpLoad %ulong %152
+%758 = OpLoad %ulong %264
+%759 = OpShiftRightLogical %ulong %757 %758
+OpStore %265 %759
+%760 = OpLoad %ulong %265
+%761 = OpBitwiseAnd %ulong %760 %ulong_255
+OpStore %266 %761
+%762 = OpLoad %ulong %270
+%763 = OpLoad %ulong %266
+%764 = OpBitwiseXor %ulong %762 %763
+OpStore %267 %764
+%765 = OpLoad %ulong %267
+%766 = OpIMul %ulong %765 %ulong_1099511628211
+OpStore %268 %766
+%767 = OpLoad %ulong %271
+%768 = OpIAdd %ulong %767 %ulong_1
+OpStore %269 %768
+%769 = OpLoad %ulong %268
+OpStore %270 %769
+%770 = OpLoad %ulong %269
+OpStore %271 %770
+OpBranch %142
+%56 = OpLabel
+%771 = OpLoad %ulong %253
+%772 = OpIMul %ulong %771 %ulong_8
+OpStore %246 %772
+%773 = OpLoad %ulong %151
+%774 = OpLoad %ulong %246
+%775 = OpShiftRightLogical %ulong %773 %774
+OpStore %247 %775
+%776 = OpLoad %ulong %247
+%777 = OpBitwiseAnd %ulong %776 %ulong_255
+OpStore %248 %777
+%778 = OpLoad %ulong %252
+%779 = OpLoad %ulong %248
+%780 = OpBitwiseXor %ulong %778 %779
+OpStore %249 %780
+%781 = OpLoad %ulong %249
+%782 = OpIMul %ulong %781 %ulong_1099511628211
+OpStore %250 %782
+%783 = OpLoad %ulong %253
+%784 = OpIAdd %ulong %783 %ulong_1
+OpStore %251 %784
+%785 = OpLoad %ulong %250
+OpStore %252 %785
+%786 = OpLoad %ulong %251
+OpStore %253 %786
+OpBranch %143
+%37 = OpLabel
+%787 = OpLoad %ulong %226
+%788 = OpIMul %ulong %787 %ulong_8
+OpStore %219 %788
+%789 = OpLoad %ulong %148
+%790 = OpLoad %ulong %219
+%791 = OpShiftRightLogical %ulong %789 %790
+OpStore %220 %791
+%792 = OpLoad %ulong %220
+%793 = OpBitwiseAnd %ulong %792 %ulong_255
+OpStore %221 %793
+%794 = OpLoad %ulong %225
+%795 = OpLoad %ulong %221
+%796 = OpBitwiseXor %ulong %794 %795
+OpStore %222 %796
+%797 = OpLoad %ulong %222
+%798 = OpIMul %ulong %797 %ulong_1099511628211
+OpStore %223 %798
+%799 = OpLoad %ulong %226
+%800 = OpIAdd %ulong %799 %ulong_1
+OpStore %224 %800
+%801 = OpLoad %ulong %223
+OpStore %225 %801
+%802 = OpLoad %ulong %224
+OpStore %226 %802
+OpBranch %144
+%127 = OpLabel
+OpBranch %76
+%128 = OpLabel
+OpBranch %62
+%129 = OpLabel
+OpBranch %50
+%130 = OpLabel
+OpBranch %43
+%131 = OpLabel
+OpBranch %29
+%132 = OpLabel
+OpBranch %22
+%133 = OpLabel
+OpBranch %10
+%134 = OpLabel
+OpBranch %7
+%135 = OpLabel
+OpBranch %123
+%136 = OpLabel
+OpBranch %116
+%137 = OpLabel
+OpBranch %109
+%138 = OpLabel
+OpBranch %102
+%139 = OpLabel
+OpBranch %95
+%140 = OpLabel
+OpBranch %88
+%141 = OpLabel
+OpBranch %81
+%142 = OpLabel
+OpBranch %69
+%143 = OpLabel
+OpBranch %55
+%144 = OpLabel
+OpBranch %36
+OpFunctionEnd
+%2 = OpFunction %ulong None %803
+%804 = OpFunctionParameter %ulong
+%805 = OpFunctionParameter %ulong
+%806 = OpLabel
+%813 = OpVariable %_ptr_Function_ulong Function
+%814 = OpVariable %_ptr_Function_ulong Function
+%815 = OpVariable %_ptr_Function_bool Function
+%816 = OpVariable %_ptr_Function_ulong Function
+%817 = OpVariable %_ptr_Function_ulong Function
+%818 = OpVariable %_ptr_Function_ulong Function
+%819 = OpVariable %_ptr_Function_ulong Function
+%820 = OpVariable %_ptr_Function_ulong Function
+%821 = OpVariable %_ptr_Function_ulong Function
+%822 = OpVariable %_ptr_Function_ulong Function
+%823 = OpVariable %_ptr_Function_ulong Function
+OpStore %813 %804
+OpStore %814 %805
+OpBranch %807
+%807 = OpLabel
+%824 = OpLoad %ulong %813
+OpStore %822 %824
+OpStore %823 %ulong_0
+OpBranch %808
+%808 = OpLabel
+%825 = OpLoad %ulong %823
+%826 = OpULessThan %bool %825 %ulong_8
+OpStore %815 %826
+%827 = OpLoad %bool %815
+OpLoopMerge %810 %812 None
+OpBranchConditional %827 %809 %810
+%810 = OpLabel
+OpBranch %811
+%811 = OpLabel
+%828 = OpLoad %ulong %822
+OpReturnValue %828
+%809 = OpLabel
+%829 = OpLoad %ulong %823
+%830 = OpIMul %ulong %829 %ulong_8
+OpStore %816 %830
+%831 = OpLoad %ulong %814
+%832 = OpLoad %ulong %816
+%833 = OpShiftRightLogical %ulong %831 %832
+OpStore %817 %833
+%834 = OpLoad %ulong %817
+%835 = OpBitwiseAnd %ulong %834 %ulong_255
+OpStore %818 %835
+%836 = OpLoad %ulong %822
+%837 = OpLoad %ulong %818
+%838 = OpBitwiseXor %ulong %836 %837
+OpStore %819 %838
+%839 = OpLoad %ulong %819
+%840 = OpIMul %ulong %839 %ulong_1099511628211
+OpStore %820 %840
+%841 = OpLoad %ulong %823
+%842 = OpIAdd %ulong %841 %ulong_1
+OpStore %821 %842
+%843 = OpLoad %ulong %820
+OpStore %822 %843
+%844 = OpLoad %ulong %821
+OpStore %823 %844
+OpBranch %812
+%812 = OpLabel
+OpBranch %808
 OpFunctionEnd

--- a/test/golden/spirv/bits/shift_u32.dis
+++ b/test/golden/spirv/bits/shift_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 316
+; Bound: 896
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,15 +9,18 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_2863311530 = OpConstant %uint 2863311530
 %uint_1431655765 = OpConstant %uint 1431655765
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_1 = OpConstant %uint 1
 %uint_31 = OpConstant %uint 31
 %uint_5 = OpConstant %uint 5
@@ -27,406 +30,1304 @@ OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_u32.checksum" Export
 %uint_0 = OpConstant %uint 0
 %uint_30 = OpConstant %uint 30
 %uint_40 = OpConstant %uint 40
-%263 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%266 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_uint Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_uint Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uint Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uint Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_uint Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_uint Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_uint Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_bool Function
-%66 = OpVariable %_ptr_Function_uint Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_uint Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_uint Function
-%71 = OpVariable %_ptr_Function_uint Function
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_uint Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_uint Function
-%76 = OpVariable %_ptr_Function_bool Function
-%77 = OpVariable %_ptr_Function_uint Function
-%78 = OpVariable %_ptr_Function_uint Function
-%79 = OpVariable %_ptr_Function_ulong Function
-%80 = OpVariable %_ptr_Function_uint Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_uint Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_uint Function
-%86 = OpVariable %_ptr_Function_uint Function
-OpStore %19 %6
-%87 = OpFunctionCall %ulong %2
-OpStore %20 %87
-%88 = OpLoad %ulong %19
-%89 = OpUConvert %uint %88
-OpStore %22 %89
-%91 = OpLoad %uint %22
-%92 = OpBitwiseXor %uint %uint_4294967295 %91
-OpStore %23 %92
-%94 = OpLoad %uint %22
-%95 = OpBitwiseXor %uint %uint_2863311530 %94
-OpStore %24 %95
-%97 = OpLoad %uint %22
-%98 = OpBitwiseXor %uint %uint_1431655765 %97
-OpStore %25 %98
-%99 = OpLoad %ulong %20
-%100 = OpLoad %uint %23
-%101 = OpFunctionCall %ulong %3 %99 %100
-OpStore %26 %101
-%102 = OpLoad %uint %23
-%104 = OpShiftLeftLogical %uint %102 %uint_1
-OpStore %27 %104
-%105 = OpLoad %ulong %26
-%106 = OpLoad %uint %27
-%107 = OpFunctionCall %ulong %3 %105 %106
-OpStore %28 %107
-%108 = OpLoad %uint %23
-%110 = OpShiftLeftLogical %uint %108 %uint_31
-OpStore %29 %110
-%111 = OpLoad %ulong %28
-%112 = OpLoad %uint %29
-%113 = OpFunctionCall %ulong %3 %111 %112
-OpStore %30 %113
-%114 = OpLoad %ulong %30
-%115 = OpLoad %uint %23
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %31 %116
-%117 = OpLoad %uint %23
-%118 = OpShiftRightLogical %uint %117 %uint_1
-OpStore %32 %118
-%119 = OpLoad %ulong %31
-%120 = OpLoad %uint %32
-%121 = OpFunctionCall %ulong %3 %119 %120
-OpStore %33 %121
-%122 = OpLoad %uint %23
-%123 = OpShiftRightLogical %uint %122 %uint_31
-OpStore %34 %123
-%124 = OpLoad %ulong %33
-%125 = OpLoad %uint %34
-%126 = OpFunctionCall %ulong %3 %124 %125
-OpStore %35 %126
-%127 = OpLoad %uint %24
-%128 = OpShiftLeftLogical %uint %127 %uint_1
-OpStore %36 %128
-%129 = OpLoad %ulong %35
-%130 = OpLoad %uint %36
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %37 %131
-%132 = OpLoad %uint %24
-%133 = OpShiftRightLogical %uint %132 %uint_1
-OpStore %38 %133
-%134 = OpLoad %ulong %37
-%135 = OpLoad %uint %38
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %39 %136
-%137 = OpLoad %uint %25
-%138 = OpShiftLeftLogical %uint %137 %uint_1
-OpStore %40 %138
-%139 = OpLoad %ulong %39
-%140 = OpLoad %uint %40
-%141 = OpFunctionCall %ulong %3 %139 %140
-OpStore %41 %141
-%142 = OpLoad %uint %25
-%143 = OpShiftRightLogical %uint %142 %uint_1
-OpStore %42 %143
-%144 = OpLoad %ulong %41
-%145 = OpLoad %uint %42
-%146 = OpFunctionCall %ulong %3 %144 %145
-OpStore %43 %146
-%147 = OpLoad %uint %22
-%149 = OpShiftLeftLogical %uint %147 %uint_5
-OpStore %44 %149
-%150 = OpLoad %ulong %43
-%151 = OpLoad %uint %44
-%152 = OpFunctionCall %ulong %3 %150 %151
-OpStore %45 %152
-%153 = OpLoad %uint %22
-%154 = OpShiftRightLogical %uint %153 %uint_5
-OpStore %46 %154
-%155 = OpLoad %ulong %45
-%156 = OpLoad %uint %46
-%157 = OpFunctionCall %ulong %3 %155 %156
-OpStore %47 %157
-%158 = OpLoad %uint %23
-%160 = OpShiftLeftLogical %uint %158 %uint_32
-OpStore %48 %160
-%161 = OpLoad %ulong %47
-%162 = OpLoad %uint %48
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %49 %163
-%164 = OpLoad %uint %23
-%165 = OpShiftRightLogical %uint %164 %uint_32
-OpStore %50 %165
-%166 = OpLoad %ulong %49
-%167 = OpLoad %uint %50
-%168 = OpFunctionCall %ulong %3 %166 %167
-OpStore %51 %168
-%169 = OpLoad %uint %23
-%171 = OpShiftLeftLogical %uint %169 %uint_33
-OpStore %52 %171
-%172 = OpLoad %ulong %51
-%173 = OpLoad %uint %52
-%174 = OpFunctionCall %ulong %3 %172 %173
-OpStore %53 %174
-%175 = OpLoad %uint %23
-%176 = OpShiftRightLogical %uint %175 %uint_33
-OpStore %54 %176
-%177 = OpLoad %ulong %53
-%178 = OpLoad %uint %54
-%179 = OpFunctionCall %ulong %3 %177 %178
-OpStore %55 %179
-%180 = OpLoad %uint %23
-%182 = OpShiftLeftLogical %uint %180 %uint_63
-OpStore %56 %182
-%183 = OpLoad %ulong %55
-%184 = OpLoad %uint %56
-%185 = OpFunctionCall %ulong %3 %183 %184
-OpStore %57 %185
-%186 = OpLoad %uint %23
-%187 = OpShiftRightLogical %uint %186 %uint_63
-OpStore %58 %187
-%188 = OpLoad %ulong %57
-%189 = OpLoad %uint %58
-%190 = OpFunctionCall %ulong %3 %188 %189
-OpStore %59 %190
-%191 = OpLoad %uint %24
-%192 = OpShiftLeftLogical %uint %191 %uint_32
-OpStore %60 %192
-%193 = OpLoad %ulong %59
-%194 = OpLoad %uint %60
-%195 = OpFunctionCall %ulong %3 %193 %194
-OpStore %61 %195
-%196 = OpLoad %uint %24
-%197 = OpShiftRightLogical %uint %196 %uint_63
-OpStore %62 %197
-%198 = OpLoad %ulong %61
-%199 = OpLoad %uint %62
-%200 = OpFunctionCall %ulong %3 %198 %199
-OpStore %63 %200
-%201 = OpLoad %ulong %63
-OpStore %84 %201
-OpStore %85 %uint_0
-OpBranch %8
-%8 = OpLabel
-%203 = OpLoad %uint %85
-%204 = OpULessThan %bool %203 %uint_32
-OpStore %65 %204
-%205 = OpLoad %bool %65
-OpLoopMerge %10 %15 None
-OpBranchConditional %205 %9 %10
-%10 = OpLabel
-%206 = OpLoad %ulong %84
-OpStore %83 %206
-OpStore %86 %uint_30
-OpBranch %11
-%11 = OpLabel
-%208 = OpLoad %uint %86
-%210 = OpULessThan %bool %208 %uint_40
-OpStore %76 %210
-%211 = OpLoad %bool %76
-OpLoopMerge %13 %14 None
-OpBranchConditional %211 %12 %13
-%13 = OpLabel
-%212 = OpLoad %ulong %83
-OpReturnValue %212
-%12 = OpLabel
-%213 = OpLoad %uint %86
-%214 = OpLoad %uint %22
-%215 = OpIAdd %uint %213 %214
-OpStore %77 %215
-%216 = OpLoad %uint %23
-%217 = OpLoad %uint %77
-%218 = OpShiftLeftLogical %uint %216 %217
-OpStore %78 %218
-%219 = OpLoad %ulong %83
-%220 = OpLoad %uint %78
-%221 = OpFunctionCall %ulong %3 %219 %220
-OpStore %79 %221
-%222 = OpLoad %uint %23
-%223 = OpLoad %uint %77
-%224 = OpShiftRightLogical %uint %222 %223
-OpStore %80 %224
-%225 = OpLoad %ulong %79
-%226 = OpLoad %uint %80
-%227 = OpFunctionCall %ulong %3 %225 %226
-OpStore %81 %227
-%228 = OpLoad %uint %86
-%229 = OpIAdd %uint %228 %uint_1
-OpStore %82 %229
-%230 = OpLoad %ulong %81
-OpStore %83 %230
-%231 = OpLoad %uint %82
-OpStore %86 %231
-OpBranch %14
-%9 = OpLabel
-%232 = OpLoad %uint %23
-%233 = OpLoad %uint %85
-%234 = OpShiftLeftLogical %uint %232 %233
-OpStore %66 %234
-%235 = OpLoad %ulong %84
-%236 = OpLoad %uint %66
-%237 = OpFunctionCall %ulong %3 %235 %236
-OpStore %67 %237
-%238 = OpLoad %uint %23
-%239 = OpLoad %uint %85
-%240 = OpShiftRightLogical %uint %238 %239
-OpStore %68 %240
-%241 = OpLoad %ulong %67
-%242 = OpLoad %uint %68
-%243 = OpFunctionCall %ulong %3 %241 %242
-OpStore %69 %243
-%244 = OpLoad %uint %85
-%245 = OpLoad %uint %22
-%246 = OpIAdd %uint %244 %245
-OpStore %70 %246
-%247 = OpLoad %uint %24
-%248 = OpLoad %uint %70
-%249 = OpShiftLeftLogical %uint %247 %248
-OpStore %71 %249
-%250 = OpLoad %ulong %69
-%251 = OpLoad %uint %71
-%252 = OpFunctionCall %ulong %3 %250 %251
-OpStore %72 %252
-%253 = OpLoad %uint %25
-%254 = OpLoad %uint %70
-%255 = OpShiftRightLogical %uint %253 %254
-OpStore %73 %255
-%256 = OpLoad %ulong %72
-%257 = OpLoad %uint %73
-%258 = OpFunctionCall %ulong %3 %256 %257
-OpStore %74 %258
-%259 = OpLoad %uint %85
-%260 = OpIAdd %uint %259 %uint_1
-OpStore %75 %260
-%261 = OpLoad %ulong %74
-OpStore %84 %261
-%262 = OpLoad %uint %75
-OpStore %85 %262
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %263
-%264 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %266
-%267 = OpFunctionParameter %ulong
-%268 = OpFunctionParameter %uint
-%269 = OpLabel
+%851 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%148 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_uint Function
+%151 = OpVariable %_ptr_Function_uint Function
+%152 = OpVariable %_ptr_Function_uint Function
+%153 = OpVariable %_ptr_Function_uint Function
+%154 = OpVariable %_ptr_Function_uint Function
+%155 = OpVariable %_ptr_Function_uint Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_uint Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_uint Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_uint Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_uint Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_uint Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_uint Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_uint Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_uint Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_uint Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_uint Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_bool Function
+%184 = OpVariable %_ptr_Function_uint Function
+%185 = OpVariable %_ptr_Function_uint Function
+%186 = OpVariable %_ptr_Function_uint Function
+%187 = OpVariable %_ptr_Function_uint Function
+%188 = OpVariable %_ptr_Function_uint Function
+%189 = OpVariable %_ptr_Function_uint Function
+%190 = OpVariable %_ptr_Function_uint Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_uint Function
+%193 = OpVariable %_ptr_Function_uint Function
+%194 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_uint Function
+%196 = OpVariable %_ptr_Function_uint Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_uint Function
+%200 = OpVariable %_ptr_Function_uint Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_bool Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_bool Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_bool Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_bool Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_bool Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_bool Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_bool Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
 %276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_uint Function
+%277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_bool Function
+%279 = OpVariable %_ptr_Function_ulong Function
 %280 = OpVariable %_ptr_Function_ulong Function
 %281 = OpVariable %_ptr_Function_ulong Function
 %282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_bool Function
 %284 = OpVariable %_ptr_Function_ulong Function
 %285 = OpVariable %_ptr_Function_ulong Function
 %286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
-OpStore %276 %267
-OpStore %277 %268
-%288 = OpLoad %uint %277
-%289 = OpUConvert %ulong %288
-OpStore %278 %289
-OpBranch %270
-%270 = OpLabel
-%290 = OpLoad %ulong %276
-OpStore %286 %290
-OpStore %287 %ulong_0
-OpBranch %271
-%271 = OpLabel
-%292 = OpLoad %ulong %287
-%294 = OpULessThan %bool %292 %ulong_8
-OpStore %279 %294
-%295 = OpLoad %bool %279
-OpLoopMerge %273 %275 None
-OpBranchConditional %295 %272 %273
-%273 = OpLabel
-OpBranch %274
-%274 = OpLabel
-%296 = OpLoad %ulong %286
-OpReturnValue %296
-%272 = OpLabel
-%297 = OpLoad %ulong %287
-%298 = OpIMul %ulong %297 %ulong_8
-OpStore %280 %298
-%299 = OpLoad %ulong %278
-%300 = OpLoad %ulong %280
-%301 = OpShiftRightLogical %ulong %299 %300
-OpStore %281 %301
-%302 = OpLoad %ulong %281
-%304 = OpBitwiseAnd %ulong %302 %ulong_255
-OpStore %282 %304
-%305 = OpLoad %ulong %286
-%306 = OpLoad %ulong %282
-%307 = OpBitwiseXor %ulong %305 %306
-OpStore %283 %307
-%308 = OpLoad %ulong %283
-%310 = OpIMul %ulong %308 %ulong_1099511628211
-OpStore %284 %310
-%311 = OpLoad %ulong %287
-%313 = OpIAdd %ulong %311 %ulong_1
-OpStore %285 %313
-%314 = OpLoad %ulong %284
-OpStore %286 %314
-%315 = OpLoad %ulong %285
-OpStore %287 %315
-OpBranch %275
-%275 = OpLabel
-OpBranch %271
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_bool Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_bool Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_bool Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_bool Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_bool Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_bool Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_bool Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+OpStore %148 %5
+OpBranch %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%361 = OpLoad %ulong %148
+%362 = OpUConvert %uint %361
+OpStore %150 %362
+%364 = OpLoad %uint %150
+%365 = OpBitwiseXor %uint %uint_4294967295 %364
+OpStore %151 %365
+%367 = OpLoad %uint %150
+%368 = OpBitwiseXor %uint %uint_2863311530 %367
+OpStore %152 %368
+%370 = OpLoad %uint %150
+%371 = OpBitwiseXor %uint %uint_1431655765 %370
+OpStore %153 %371
+OpBranch %19
+%19 = OpLabel
+%372 = OpLoad %uint %151
+%373 = OpUConvert %ulong %372
+OpStore %203 %373
+OpBranch %35
+%35 = OpLabel
+OpStore %231 %ulong_14695981039346656037
+OpStore %232 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%376 = OpLoad %ulong %232
+%378 = OpULessThan %bool %376 %ulong_8
+OpStore %224 %378
+%379 = OpLoad %bool %224
+OpLoopMerge %38 %144 None
+OpBranchConditional %379 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%380 = OpLoad %uint %151
+%382 = OpShiftLeftLogical %uint %380 %uint_1
+OpStore %154 %382
+OpBranch %40
+%40 = OpLabel
+%383 = OpLoad %uint %154
+%384 = OpUConvert %ulong %383
+OpStore %233 %384
+OpBranch %54
+%54 = OpLabel
+%385 = OpLoad %ulong %231
+OpStore %260 %385
+OpStore %261 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%386 = OpLoad %ulong %261
+%387 = OpULessThan %bool %386 %ulong_8
+OpStore %253 %387
+%388 = OpLoad %bool %253
+OpLoopMerge %57 %143 None
+OpBranchConditional %388 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%389 = OpLoad %uint %151
+%391 = OpShiftLeftLogical %uint %389 %uint_31
+OpStore %155 %391
+OpBranch %59
+%59 = OpLabel
+%392 = OpLoad %uint %155
+%393 = OpUConvert %ulong %392
+OpStore %262 %393
+OpBranch %68
+%68 = OpLabel
+%394 = OpLoad %ulong %260
+OpStore %280 %394
+OpStore %281 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%395 = OpLoad %ulong %281
+%396 = OpULessThan %bool %395 %ulong_8
+OpStore %273 %396
+%397 = OpLoad %bool %273
+OpLoopMerge %71 %142 None
+OpBranchConditional %397 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%398 = OpLoad %uint %151
+%399 = OpUConvert %ulong %398
+OpStore %282 %399
+OpBranch %80
+%80 = OpLabel
+%400 = OpLoad %ulong %280
+OpStore %299 %400
+OpStore %300 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%401 = OpLoad %ulong %300
+%402 = OpULessThan %bool %401 %ulong_8
+OpStore %292 %402
+%403 = OpLoad %bool %292
+OpLoopMerge %83 %141 None
+OpBranchConditional %403 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%404 = OpLoad %uint %151
+%405 = OpShiftRightLogical %uint %404 %uint_1
+OpStore %156 %405
+OpBranch %85
+%85 = OpLabel
+%406 = OpLoad %uint %156
+%407 = OpUConvert %ulong %406
+OpStore %301 %407
+OpBranch %87
+%87 = OpLabel
+%408 = OpLoad %ulong %299
+OpStore %309 %408
+OpStore %310 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%409 = OpLoad %ulong %310
+%410 = OpULessThan %bool %409 %ulong_8
+OpStore %302 %410
+%411 = OpLoad %bool %302
+OpLoopMerge %90 %140 None
+OpBranchConditional %411 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%412 = OpLoad %uint %151
+%413 = OpShiftRightLogical %uint %412 %uint_31
+OpStore %157 %413
+OpBranch %92
+%92 = OpLabel
+%414 = OpLoad %uint %157
+%415 = OpUConvert %ulong %414
+OpStore %311 %415
+OpBranch %94
+%94 = OpLabel
+%416 = OpLoad %ulong %309
+OpStore %319 %416
+OpStore %320 %ulong_0
+OpBranch %95
+%95 = OpLabel
+%417 = OpLoad %ulong %320
+%418 = OpULessThan %bool %417 %ulong_8
+OpStore %312 %418
+%419 = OpLoad %bool %312
+OpLoopMerge %97 %139 None
+OpBranchConditional %419 %96 %97
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%420 = OpLoad %uint %152
+%421 = OpShiftLeftLogical %uint %420 %uint_1
+OpStore %158 %421
+OpBranch %99
+%99 = OpLabel
+%422 = OpLoad %uint %158
+%423 = OpUConvert %ulong %422
+OpStore %321 %423
+OpBranch %101
+%101 = OpLabel
+%424 = OpLoad %ulong %319
+OpStore %329 %424
+OpStore %330 %ulong_0
+OpBranch %102
+%102 = OpLabel
+%425 = OpLoad %ulong %330
+%426 = OpULessThan %bool %425 %ulong_8
+OpStore %322 %426
+%427 = OpLoad %bool %322
+OpLoopMerge %104 %138 None
+OpBranchConditional %427 %103 %104
+%104 = OpLabel
+OpBranch %105
+%105 = OpLabel
+OpBranch %100
+%100 = OpLabel
+%428 = OpLoad %uint %152
+%429 = OpShiftRightLogical %uint %428 %uint_1
+OpStore %159 %429
+OpBranch %106
+%106 = OpLabel
+%430 = OpLoad %uint %159
+%431 = OpUConvert %ulong %430
+OpStore %331 %431
+OpBranch %108
+%108 = OpLabel
+%432 = OpLoad %ulong %329
+OpStore %339 %432
+OpStore %340 %ulong_0
+OpBranch %109
+%109 = OpLabel
+%433 = OpLoad %ulong %340
+%434 = OpULessThan %bool %433 %ulong_8
+OpStore %332 %434
+%435 = OpLoad %bool %332
+OpLoopMerge %111 %137 None
+OpBranchConditional %435 %110 %111
+%111 = OpLabel
+OpBranch %112
+%112 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%436 = OpLoad %uint %153
+%437 = OpShiftLeftLogical %uint %436 %uint_1
+OpStore %160 %437
+OpBranch %113
+%113 = OpLabel
+%438 = OpLoad %uint %160
+%439 = OpUConvert %ulong %438
+OpStore %341 %439
+OpBranch %115
+%115 = OpLabel
+%440 = OpLoad %ulong %339
+OpStore %349 %440
+OpStore %350 %ulong_0
+OpBranch %116
+%116 = OpLabel
+%441 = OpLoad %ulong %350
+%442 = OpULessThan %bool %441 %ulong_8
+OpStore %342 %442
+%443 = OpLoad %bool %342
+OpLoopMerge %118 %136 None
+OpBranchConditional %443 %117 %118
+%118 = OpLabel
+OpBranch %119
+%119 = OpLabel
+OpBranch %114
+%114 = OpLabel
+%444 = OpLoad %uint %153
+%445 = OpShiftRightLogical %uint %444 %uint_1
+OpStore %161 %445
+OpBranch %120
+%120 = OpLabel
+%446 = OpLoad %uint %161
+%447 = OpUConvert %ulong %446
+OpStore %351 %447
+OpBranch %122
+%122 = OpLabel
+%448 = OpLoad %ulong %349
+OpStore %359 %448
+OpStore %360 %ulong_0
+OpBranch %123
+%123 = OpLabel
+%449 = OpLoad %ulong %360
+%450 = OpULessThan %bool %449 %ulong_8
+OpStore %352 %450
+%451 = OpLoad %bool %352
+OpLoopMerge %125 %135 None
+OpBranchConditional %451 %124 %125
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%452 = OpLoad %uint %150
+%454 = OpShiftLeftLogical %uint %452 %uint_5
+OpStore %162 %454
+%455 = OpLoad %ulong %359
+%456 = OpLoad %uint %162
+%457 = OpFunctionCall %ulong %2 %455 %456
+OpStore %163 %457
+%458 = OpLoad %uint %150
+%459 = OpShiftRightLogical %uint %458 %uint_5
+OpStore %164 %459
+%460 = OpLoad %ulong %163
+%461 = OpLoad %uint %164
+%462 = OpFunctionCall %ulong %2 %460 %461
+OpStore %165 %462
+%463 = OpLoad %uint %151
+%465 = OpShiftLeftLogical %uint %463 %uint_32
+OpStore %166 %465
+%466 = OpLoad %ulong %165
+%467 = OpLoad %uint %166
+%468 = OpFunctionCall %ulong %2 %466 %467
+OpStore %167 %468
+%469 = OpLoad %uint %151
+%470 = OpShiftRightLogical %uint %469 %uint_32
+OpStore %168 %470
+%471 = OpLoad %ulong %167
+%472 = OpLoad %uint %168
+%473 = OpFunctionCall %ulong %2 %471 %472
+OpStore %169 %473
+%474 = OpLoad %uint %151
+%476 = OpShiftLeftLogical %uint %474 %uint_33
+OpStore %170 %476
+%477 = OpLoad %ulong %169
+%478 = OpLoad %uint %170
+%479 = OpFunctionCall %ulong %2 %477 %478
+OpStore %171 %479
+%480 = OpLoad %uint %151
+%481 = OpShiftRightLogical %uint %480 %uint_33
+OpStore %172 %481
+%482 = OpLoad %ulong %171
+%483 = OpLoad %uint %172
+%484 = OpFunctionCall %ulong %2 %482 %483
+OpStore %173 %484
+%485 = OpLoad %uint %151
+%487 = OpShiftLeftLogical %uint %485 %uint_63
+OpStore %174 %487
+%488 = OpLoad %ulong %173
+%489 = OpLoad %uint %174
+%490 = OpFunctionCall %ulong %2 %488 %489
+OpStore %175 %490
+%491 = OpLoad %uint %151
+%492 = OpShiftRightLogical %uint %491 %uint_63
+OpStore %176 %492
+%493 = OpLoad %ulong %175
+%494 = OpLoad %uint %176
+%495 = OpFunctionCall %ulong %2 %493 %494
+OpStore %177 %495
+%496 = OpLoad %uint %152
+%497 = OpShiftLeftLogical %uint %496 %uint_32
+OpStore %178 %497
+%498 = OpLoad %ulong %177
+%499 = OpLoad %uint %178
+%500 = OpFunctionCall %ulong %2 %498 %499
+OpStore %179 %500
+%501 = OpLoad %uint %152
+%502 = OpShiftRightLogical %uint %501 %uint_63
+OpStore %180 %502
+%503 = OpLoad %ulong %179
+%504 = OpLoad %uint %180
+%505 = OpFunctionCall %ulong %2 %503 %504
+OpStore %181 %505
+%506 = OpLoad %ulong %181
+OpStore %198 %506
+OpStore %199 %uint_0
+OpBranch %7
+%7 = OpLabel
+%508 = OpLoad %uint %199
+%509 = OpULessThan %bool %508 %uint_32
+OpStore %183 %509
+%510 = OpLoad %bool %183
+OpLoopMerge %9 %134 None
+OpBranchConditional %510 %8 %9
+%9 = OpLabel
+%511 = OpLoad %ulong %198
+OpStore %197 %511
+OpStore %200 %uint_30
+OpBranch %10
+%10 = OpLabel
+%513 = OpLoad %uint %200
+%515 = OpULessThan %bool %513 %uint_40
+OpStore %191 %515
+%516 = OpLoad %bool %191
+OpLoopMerge %12 %133 None
+OpBranchConditional %516 %11 %12
+%12 = OpLabel
+%517 = OpLoad %ulong %197
+OpReturnValue %517
+%11 = OpLabel
+%518 = OpLoad %uint %200
+%519 = OpLoad %uint %150
+%520 = OpIAdd %uint %518 %519
+OpStore %192 %520
+%521 = OpLoad %uint %151
+%522 = OpLoad %uint %192
+%523 = OpShiftLeftLogical %uint %521 %522
+OpStore %193 %523
+OpBranch %17
+%17 = OpLabel
+%524 = OpLoad %uint %193
+%525 = OpUConvert %ulong %524
+OpStore %202 %525
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %197
+OpStore %221 %526
+OpStore %222 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%527 = OpLoad %ulong %222
+%528 = OpULessThan %bool %527 %ulong_8
+OpStore %214 %528
+%529 = OpLoad %bool %214
+OpLoopMerge %31 %131 None
+OpBranchConditional %529 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%530 = OpLoad %uint %200
+%531 = OpLoad %uint %150
+%532 = OpIAdd %uint %530 %531
+OpStore %194 %532
+%533 = OpLoad %uint %151
+%534 = OpLoad %uint %194
+%535 = OpShiftRightLogical %uint %533 %534
+OpStore %195 %535
+OpBranch %33
+%33 = OpLabel
+%536 = OpLoad %uint %195
+%537 = OpUConvert %ulong %536
+OpStore %223 %537
+OpBranch %49
+%49 = OpLabel
+%538 = OpLoad %ulong %221
+OpStore %251 %538
+OpStore %252 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%539 = OpLoad %ulong %252
+%540 = OpULessThan %bool %539 %ulong_8
+OpStore %244 %540
+%541 = OpLoad %bool %244
+OpLoopMerge %52 %129 None
+OpBranchConditional %541 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%542 = OpLoad %uint %200
+%543 = OpIAdd %uint %542 %uint_1
+OpStore %196 %543
+%544 = OpLoad %ulong %251
+OpStore %197 %544
+%545 = OpLoad %uint %196
+OpStore %200 %545
+OpBranch %133
+%51 = OpLabel
+%546 = OpLoad %ulong %252
+%547 = OpIMul %ulong %546 %ulong_8
+OpStore %245 %547
+%548 = OpLoad %ulong %223
+%549 = OpLoad %ulong %245
+%550 = OpShiftRightLogical %ulong %548 %549
+OpStore %246 %550
+%551 = OpLoad %ulong %246
+%553 = OpBitwiseAnd %ulong %551 %ulong_255
+OpStore %247 %553
+%554 = OpLoad %ulong %251
+%555 = OpLoad %ulong %247
+%556 = OpBitwiseXor %ulong %554 %555
+OpStore %248 %556
+%557 = OpLoad %ulong %248
+%559 = OpIMul %ulong %557 %ulong_1099511628211
+OpStore %249 %559
+%560 = OpLoad %ulong %252
+%562 = OpIAdd %ulong %560 %ulong_1
+OpStore %250 %562
+%563 = OpLoad %ulong %249
+OpStore %251 %563
+%564 = OpLoad %ulong %250
+OpStore %252 %564
+OpBranch %129
+%30 = OpLabel
+%565 = OpLoad %ulong %222
+%566 = OpIMul %ulong %565 %ulong_8
+OpStore %215 %566
+%567 = OpLoad %ulong %202
+%568 = OpLoad %ulong %215
+%569 = OpShiftRightLogical %ulong %567 %568
+OpStore %216 %569
+%570 = OpLoad %ulong %216
+%571 = OpBitwiseAnd %ulong %570 %ulong_255
+OpStore %217 %571
+%572 = OpLoad %ulong %221
+%573 = OpLoad %ulong %217
+%574 = OpBitwiseXor %ulong %572 %573
+OpStore %218 %574
+%575 = OpLoad %ulong %218
+%576 = OpIMul %ulong %575 %ulong_1099511628211
+OpStore %219 %576
+%577 = OpLoad %ulong %222
+%578 = OpIAdd %ulong %577 %ulong_1
+OpStore %220 %578
+%579 = OpLoad %ulong %219
+OpStore %221 %579
+%580 = OpLoad %ulong %220
+OpStore %222 %580
+OpBranch %131
+%8 = OpLabel
+%581 = OpLoad %uint %151
+%582 = OpLoad %uint %199
+%583 = OpShiftLeftLogical %uint %581 %582
+OpStore %184 %583
+OpBranch %15
+%15 = OpLabel
+%584 = OpLoad %uint %184
+%585 = OpUConvert %ulong %584
+OpStore %201 %585
+OpBranch %21
+%21 = OpLabel
+%586 = OpLoad %ulong %198
+OpStore %211 %586
+OpStore %212 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%587 = OpLoad %ulong %212
+%588 = OpULessThan %bool %587 %ulong_8
+OpStore %204 %588
+%589 = OpLoad %bool %204
+OpLoopMerge %24 %132 None
+OpBranchConditional %589 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%590 = OpLoad %uint %151
+%591 = OpLoad %uint %199
+%592 = OpShiftRightLogical %uint %590 %591
+OpStore %185 %592
+OpBranch %26
+%26 = OpLabel
+%593 = OpLoad %uint %185
+%594 = OpUConvert %ulong %593
+OpStore %213 %594
+OpBranch %42
+%42 = OpLabel
+%595 = OpLoad %ulong %211
+OpStore %241 %595
+OpStore %242 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%596 = OpLoad %ulong %242
+%597 = OpULessThan %bool %596 %ulong_8
+OpStore %234 %597
+%598 = OpLoad %bool %234
+OpLoopMerge %45 %130 None
+OpBranchConditional %598 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%599 = OpLoad %uint %199
+%600 = OpLoad %uint %150
+%601 = OpIAdd %uint %599 %600
+OpStore %186 %601
+%602 = OpLoad %uint %152
+%603 = OpLoad %uint %186
+%604 = OpShiftLeftLogical %uint %602 %603
+OpStore %187 %604
+OpBranch %47
+%47 = OpLabel
+%605 = OpLoad %uint %187
+%606 = OpUConvert %ulong %605
+OpStore %243 %606
+OpBranch %61
+%61 = OpLabel
+%607 = OpLoad %ulong %241
+OpStore %270 %607
+OpStore %271 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%608 = OpLoad %ulong %271
+%609 = OpULessThan %bool %608 %ulong_8
+OpStore %263 %609
+%610 = OpLoad %bool %263
+OpLoopMerge %64 %128 None
+OpBranchConditional %610 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%611 = OpLoad %uint %199
+%612 = OpLoad %uint %150
+%613 = OpIAdd %uint %611 %612
+OpStore %188 %613
+%614 = OpLoad %uint %153
+%615 = OpLoad %uint %188
+%616 = OpShiftRightLogical %uint %614 %615
+OpStore %189 %616
+OpBranch %66
+%66 = OpLabel
+%617 = OpLoad %uint %189
+%618 = OpUConvert %ulong %617
+OpStore %272 %618
+OpBranch %75
+%75 = OpLabel
+%619 = OpLoad %ulong %270
+OpStore %290 %619
+OpStore %291 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%620 = OpLoad %ulong %291
+%621 = OpULessThan %bool %620 %ulong_8
+OpStore %283 %621
+%622 = OpLoad %bool %283
+OpLoopMerge %78 %127 None
+OpBranchConditional %622 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%623 = OpLoad %uint %199
+%624 = OpIAdd %uint %623 %uint_1
+OpStore %190 %624
+%625 = OpLoad %ulong %290
+OpStore %198 %625
+%626 = OpLoad %uint %190
+OpStore %199 %626
+OpBranch %134
+%77 = OpLabel
+%627 = OpLoad %ulong %291
+%628 = OpIMul %ulong %627 %ulong_8
+OpStore %284 %628
+%629 = OpLoad %ulong %272
+%630 = OpLoad %ulong %284
+%631 = OpShiftRightLogical %ulong %629 %630
+OpStore %285 %631
+%632 = OpLoad %ulong %285
+%633 = OpBitwiseAnd %ulong %632 %ulong_255
+OpStore %286 %633
+%634 = OpLoad %ulong %290
+%635 = OpLoad %ulong %286
+%636 = OpBitwiseXor %ulong %634 %635
+OpStore %287 %636
+%637 = OpLoad %ulong %287
+%638 = OpIMul %ulong %637 %ulong_1099511628211
+OpStore %288 %638
+%639 = OpLoad %ulong %291
+%640 = OpIAdd %ulong %639 %ulong_1
+OpStore %289 %640
+%641 = OpLoad %ulong %288
+OpStore %290 %641
+%642 = OpLoad %ulong %289
+OpStore %291 %642
+OpBranch %127
+%63 = OpLabel
+%643 = OpLoad %ulong %271
+%644 = OpIMul %ulong %643 %ulong_8
+OpStore %264 %644
+%645 = OpLoad %ulong %243
+%646 = OpLoad %ulong %264
+%647 = OpShiftRightLogical %ulong %645 %646
+OpStore %265 %647
+%648 = OpLoad %ulong %265
+%649 = OpBitwiseAnd %ulong %648 %ulong_255
+OpStore %266 %649
+%650 = OpLoad %ulong %270
+%651 = OpLoad %ulong %266
+%652 = OpBitwiseXor %ulong %650 %651
+OpStore %267 %652
+%653 = OpLoad %ulong %267
+%654 = OpIMul %ulong %653 %ulong_1099511628211
+OpStore %268 %654
+%655 = OpLoad %ulong %271
+%656 = OpIAdd %ulong %655 %ulong_1
+OpStore %269 %656
+%657 = OpLoad %ulong %268
+OpStore %270 %657
+%658 = OpLoad %ulong %269
+OpStore %271 %658
+OpBranch %128
+%44 = OpLabel
+%659 = OpLoad %ulong %242
+%660 = OpIMul %ulong %659 %ulong_8
+OpStore %235 %660
+%661 = OpLoad %ulong %213
+%662 = OpLoad %ulong %235
+%663 = OpShiftRightLogical %ulong %661 %662
+OpStore %236 %663
+%664 = OpLoad %ulong %236
+%665 = OpBitwiseAnd %ulong %664 %ulong_255
+OpStore %237 %665
+%666 = OpLoad %ulong %241
+%667 = OpLoad %ulong %237
+%668 = OpBitwiseXor %ulong %666 %667
+OpStore %238 %668
+%669 = OpLoad %ulong %238
+%670 = OpIMul %ulong %669 %ulong_1099511628211
+OpStore %239 %670
+%671 = OpLoad %ulong %242
+%672 = OpIAdd %ulong %671 %ulong_1
+OpStore %240 %672
+%673 = OpLoad %ulong %239
+OpStore %241 %673
+%674 = OpLoad %ulong %240
+OpStore %242 %674
+OpBranch %130
+%23 = OpLabel
+%675 = OpLoad %ulong %212
+%676 = OpIMul %ulong %675 %ulong_8
+OpStore %205 %676
+%677 = OpLoad %ulong %201
+%678 = OpLoad %ulong %205
+%679 = OpShiftRightLogical %ulong %677 %678
+OpStore %206 %679
+%680 = OpLoad %ulong %206
+%681 = OpBitwiseAnd %ulong %680 %ulong_255
+OpStore %207 %681
+%682 = OpLoad %ulong %211
+%683 = OpLoad %ulong %207
+%684 = OpBitwiseXor %ulong %682 %683
+OpStore %208 %684
+%685 = OpLoad %ulong %208
+%686 = OpIMul %ulong %685 %ulong_1099511628211
+OpStore %209 %686
+%687 = OpLoad %ulong %212
+%688 = OpIAdd %ulong %687 %ulong_1
+OpStore %210 %688
+%689 = OpLoad %ulong %209
+OpStore %211 %689
+%690 = OpLoad %ulong %210
+OpStore %212 %690
+OpBranch %132
+%124 = OpLabel
+%691 = OpLoad %ulong %360
+%692 = OpIMul %ulong %691 %ulong_8
+OpStore %353 %692
+%693 = OpLoad %ulong %351
+%694 = OpLoad %ulong %353
+%695 = OpShiftRightLogical %ulong %693 %694
+OpStore %354 %695
+%696 = OpLoad %ulong %354
+%697 = OpBitwiseAnd %ulong %696 %ulong_255
+OpStore %355 %697
+%698 = OpLoad %ulong %359
+%699 = OpLoad %ulong %355
+%700 = OpBitwiseXor %ulong %698 %699
+OpStore %356 %700
+%701 = OpLoad %ulong %356
+%702 = OpIMul %ulong %701 %ulong_1099511628211
+OpStore %357 %702
+%703 = OpLoad %ulong %360
+%704 = OpIAdd %ulong %703 %ulong_1
+OpStore %358 %704
+%705 = OpLoad %ulong %357
+OpStore %359 %705
+%706 = OpLoad %ulong %358
+OpStore %360 %706
+OpBranch %135
+%117 = OpLabel
+%707 = OpLoad %ulong %350
+%708 = OpIMul %ulong %707 %ulong_8
+OpStore %343 %708
+%709 = OpLoad %ulong %341
+%710 = OpLoad %ulong %343
+%711 = OpShiftRightLogical %ulong %709 %710
+OpStore %344 %711
+%712 = OpLoad %ulong %344
+%713 = OpBitwiseAnd %ulong %712 %ulong_255
+OpStore %345 %713
+%714 = OpLoad %ulong %349
+%715 = OpLoad %ulong %345
+%716 = OpBitwiseXor %ulong %714 %715
+OpStore %346 %716
+%717 = OpLoad %ulong %346
+%718 = OpIMul %ulong %717 %ulong_1099511628211
+OpStore %347 %718
+%719 = OpLoad %ulong %350
+%720 = OpIAdd %ulong %719 %ulong_1
+OpStore %348 %720
+%721 = OpLoad %ulong %347
+OpStore %349 %721
+%722 = OpLoad %ulong %348
+OpStore %350 %722
+OpBranch %136
+%110 = OpLabel
+%723 = OpLoad %ulong %340
+%724 = OpIMul %ulong %723 %ulong_8
+OpStore %333 %724
+%725 = OpLoad %ulong %331
+%726 = OpLoad %ulong %333
+%727 = OpShiftRightLogical %ulong %725 %726
+OpStore %334 %727
+%728 = OpLoad %ulong %334
+%729 = OpBitwiseAnd %ulong %728 %ulong_255
+OpStore %335 %729
+%730 = OpLoad %ulong %339
+%731 = OpLoad %ulong %335
+%732 = OpBitwiseXor %ulong %730 %731
+OpStore %336 %732
+%733 = OpLoad %ulong %336
+%734 = OpIMul %ulong %733 %ulong_1099511628211
+OpStore %337 %734
+%735 = OpLoad %ulong %340
+%736 = OpIAdd %ulong %735 %ulong_1
+OpStore %338 %736
+%737 = OpLoad %ulong %337
+OpStore %339 %737
+%738 = OpLoad %ulong %338
+OpStore %340 %738
+OpBranch %137
+%103 = OpLabel
+%739 = OpLoad %ulong %330
+%740 = OpIMul %ulong %739 %ulong_8
+OpStore %323 %740
+%741 = OpLoad %ulong %321
+%742 = OpLoad %ulong %323
+%743 = OpShiftRightLogical %ulong %741 %742
+OpStore %324 %743
+%744 = OpLoad %ulong %324
+%745 = OpBitwiseAnd %ulong %744 %ulong_255
+OpStore %325 %745
+%746 = OpLoad %ulong %329
+%747 = OpLoad %ulong %325
+%748 = OpBitwiseXor %ulong %746 %747
+OpStore %326 %748
+%749 = OpLoad %ulong %326
+%750 = OpIMul %ulong %749 %ulong_1099511628211
+OpStore %327 %750
+%751 = OpLoad %ulong %330
+%752 = OpIAdd %ulong %751 %ulong_1
+OpStore %328 %752
+%753 = OpLoad %ulong %327
+OpStore %329 %753
+%754 = OpLoad %ulong %328
+OpStore %330 %754
+OpBranch %138
+%96 = OpLabel
+%755 = OpLoad %ulong %320
+%756 = OpIMul %ulong %755 %ulong_8
+OpStore %313 %756
+%757 = OpLoad %ulong %311
+%758 = OpLoad %ulong %313
+%759 = OpShiftRightLogical %ulong %757 %758
+OpStore %314 %759
+%760 = OpLoad %ulong %314
+%761 = OpBitwiseAnd %ulong %760 %ulong_255
+OpStore %315 %761
+%762 = OpLoad %ulong %319
+%763 = OpLoad %ulong %315
+%764 = OpBitwiseXor %ulong %762 %763
+OpStore %316 %764
+%765 = OpLoad %ulong %316
+%766 = OpIMul %ulong %765 %ulong_1099511628211
+OpStore %317 %766
+%767 = OpLoad %ulong %320
+%768 = OpIAdd %ulong %767 %ulong_1
+OpStore %318 %768
+%769 = OpLoad %ulong %317
+OpStore %319 %769
+%770 = OpLoad %ulong %318
+OpStore %320 %770
+OpBranch %139
+%89 = OpLabel
+%771 = OpLoad %ulong %310
+%772 = OpIMul %ulong %771 %ulong_8
+OpStore %303 %772
+%773 = OpLoad %ulong %301
+%774 = OpLoad %ulong %303
+%775 = OpShiftRightLogical %ulong %773 %774
+OpStore %304 %775
+%776 = OpLoad %ulong %304
+%777 = OpBitwiseAnd %ulong %776 %ulong_255
+OpStore %305 %777
+%778 = OpLoad %ulong %309
+%779 = OpLoad %ulong %305
+%780 = OpBitwiseXor %ulong %778 %779
+OpStore %306 %780
+%781 = OpLoad %ulong %306
+%782 = OpIMul %ulong %781 %ulong_1099511628211
+OpStore %307 %782
+%783 = OpLoad %ulong %310
+%784 = OpIAdd %ulong %783 %ulong_1
+OpStore %308 %784
+%785 = OpLoad %ulong %307
+OpStore %309 %785
+%786 = OpLoad %ulong %308
+OpStore %310 %786
+OpBranch %140
+%82 = OpLabel
+%787 = OpLoad %ulong %300
+%788 = OpIMul %ulong %787 %ulong_8
+OpStore %293 %788
+%789 = OpLoad %ulong %282
+%790 = OpLoad %ulong %293
+%791 = OpShiftRightLogical %ulong %789 %790
+OpStore %294 %791
+%792 = OpLoad %ulong %294
+%793 = OpBitwiseAnd %ulong %792 %ulong_255
+OpStore %295 %793
+%794 = OpLoad %ulong %299
+%795 = OpLoad %ulong %295
+%796 = OpBitwiseXor %ulong %794 %795
+OpStore %296 %796
+%797 = OpLoad %ulong %296
+%798 = OpIMul %ulong %797 %ulong_1099511628211
+OpStore %297 %798
+%799 = OpLoad %ulong %300
+%800 = OpIAdd %ulong %799 %ulong_1
+OpStore %298 %800
+%801 = OpLoad %ulong %297
+OpStore %299 %801
+%802 = OpLoad %ulong %298
+OpStore %300 %802
+OpBranch %141
+%70 = OpLabel
+%803 = OpLoad %ulong %281
+%804 = OpIMul %ulong %803 %ulong_8
+OpStore %274 %804
+%805 = OpLoad %ulong %262
+%806 = OpLoad %ulong %274
+%807 = OpShiftRightLogical %ulong %805 %806
+OpStore %275 %807
+%808 = OpLoad %ulong %275
+%809 = OpBitwiseAnd %ulong %808 %ulong_255
+OpStore %276 %809
+%810 = OpLoad %ulong %280
+%811 = OpLoad %ulong %276
+%812 = OpBitwiseXor %ulong %810 %811
+OpStore %277 %812
+%813 = OpLoad %ulong %277
+%814 = OpIMul %ulong %813 %ulong_1099511628211
+OpStore %278 %814
+%815 = OpLoad %ulong %281
+%816 = OpIAdd %ulong %815 %ulong_1
+OpStore %279 %816
+%817 = OpLoad %ulong %278
+OpStore %280 %817
+%818 = OpLoad %ulong %279
+OpStore %281 %818
+OpBranch %142
+%56 = OpLabel
+%819 = OpLoad %ulong %261
+%820 = OpIMul %ulong %819 %ulong_8
+OpStore %254 %820
+%821 = OpLoad %ulong %233
+%822 = OpLoad %ulong %254
+%823 = OpShiftRightLogical %ulong %821 %822
+OpStore %255 %823
+%824 = OpLoad %ulong %255
+%825 = OpBitwiseAnd %ulong %824 %ulong_255
+OpStore %256 %825
+%826 = OpLoad %ulong %260
+%827 = OpLoad %ulong %256
+%828 = OpBitwiseXor %ulong %826 %827
+OpStore %257 %828
+%829 = OpLoad %ulong %257
+%830 = OpIMul %ulong %829 %ulong_1099511628211
+OpStore %258 %830
+%831 = OpLoad %ulong %261
+%832 = OpIAdd %ulong %831 %ulong_1
+OpStore %259 %832
+%833 = OpLoad %ulong %258
+OpStore %260 %833
+%834 = OpLoad %ulong %259
+OpStore %261 %834
+OpBranch %143
+%37 = OpLabel
+%835 = OpLoad %ulong %232
+%836 = OpIMul %ulong %835 %ulong_8
+OpStore %225 %836
+%837 = OpLoad %ulong %203
+%838 = OpLoad %ulong %225
+%839 = OpShiftRightLogical %ulong %837 %838
+OpStore %226 %839
+%840 = OpLoad %ulong %226
+%841 = OpBitwiseAnd %ulong %840 %ulong_255
+OpStore %227 %841
+%842 = OpLoad %ulong %231
+%843 = OpLoad %ulong %227
+%844 = OpBitwiseXor %ulong %842 %843
+OpStore %228 %844
+%845 = OpLoad %ulong %228
+%846 = OpIMul %ulong %845 %ulong_1099511628211
+OpStore %229 %846
+%847 = OpLoad %ulong %232
+%848 = OpIAdd %ulong %847 %ulong_1
+OpStore %230 %848
+%849 = OpLoad %ulong %229
+OpStore %231 %849
+%850 = OpLoad %ulong %230
+OpStore %232 %850
+OpBranch %144
+%127 = OpLabel
+OpBranch %76
+%128 = OpLabel
+OpBranch %62
+%129 = OpLabel
+OpBranch %50
+%130 = OpLabel
+OpBranch %43
+%131 = OpLabel
+OpBranch %29
+%132 = OpLabel
+OpBranch %22
+%133 = OpLabel
+OpBranch %10
+%134 = OpLabel
+OpBranch %7
+%135 = OpLabel
+OpBranch %123
+%136 = OpLabel
+OpBranch %116
+%137 = OpLabel
+OpBranch %109
+%138 = OpLabel
+OpBranch %102
+%139 = OpLabel
+OpBranch %95
+%140 = OpLabel
+OpBranch %88
+%141 = OpLabel
+OpBranch %81
+%142 = OpLabel
+OpBranch %69
+%143 = OpLabel
+OpBranch %55
+%144 = OpLabel
+OpBranch %36
+OpFunctionEnd
+%2 = OpFunction %ulong None %851
+%852 = OpFunctionParameter %ulong
+%853 = OpFunctionParameter %uint
+%854 = OpLabel
+%861 = OpVariable %_ptr_Function_ulong Function
+%862 = OpVariable %_ptr_Function_uint Function
+%863 = OpVariable %_ptr_Function_ulong Function
+%864 = OpVariable %_ptr_Function_bool Function
+%865 = OpVariable %_ptr_Function_ulong Function
+%866 = OpVariable %_ptr_Function_ulong Function
+%867 = OpVariable %_ptr_Function_ulong Function
+%868 = OpVariable %_ptr_Function_ulong Function
+%869 = OpVariable %_ptr_Function_ulong Function
+%870 = OpVariable %_ptr_Function_ulong Function
+%871 = OpVariable %_ptr_Function_ulong Function
+%872 = OpVariable %_ptr_Function_ulong Function
+OpStore %861 %852
+OpStore %862 %853
+%873 = OpLoad %uint %862
+%874 = OpUConvert %ulong %873
+OpStore %863 %874
+OpBranch %855
+%855 = OpLabel
+%875 = OpLoad %ulong %861
+OpStore %871 %875
+OpStore %872 %ulong_0
+OpBranch %856
+%856 = OpLabel
+%876 = OpLoad %ulong %872
+%877 = OpULessThan %bool %876 %ulong_8
+OpStore %864 %877
+%878 = OpLoad %bool %864
+OpLoopMerge %858 %860 None
+OpBranchConditional %878 %857 %858
+%858 = OpLabel
+OpBranch %859
+%859 = OpLabel
+%879 = OpLoad %ulong %871
+OpReturnValue %879
+%857 = OpLabel
+%880 = OpLoad %ulong %872
+%881 = OpIMul %ulong %880 %ulong_8
+OpStore %865 %881
+%882 = OpLoad %ulong %863
+%883 = OpLoad %ulong %865
+%884 = OpShiftRightLogical %ulong %882 %883
+OpStore %866 %884
+%885 = OpLoad %ulong %866
+%886 = OpBitwiseAnd %ulong %885 %ulong_255
+OpStore %867 %886
+%887 = OpLoad %ulong %871
+%888 = OpLoad %ulong %867
+%889 = OpBitwiseXor %ulong %887 %888
+OpStore %868 %889
+%890 = OpLoad %ulong %868
+%891 = OpIMul %ulong %890 %ulong_1099511628211
+OpStore %869 %891
+%892 = OpLoad %ulong %872
+%893 = OpIAdd %ulong %892 %ulong_1
+OpStore %870 %893
+%894 = OpLoad %ulong %869
+OpStore %871 %894
+%895 = OpLoad %ulong %870
+OpStore %872 %895
+OpBranch %860
+%860 = OpLabel
+OpBranch %856
 OpFunctionEnd

--- a/test/golden/spirv/bits/shift_u64.dis
+++ b/test/golden/spirv/bits/shift_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 304
+; Bound: 804
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,408 +9,1181 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.bits.shift_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
 %ulong_12297829382473034410 = OpConstant %ulong 12297829382473034410
 %ulong_6148914691236517205 = OpConstant %ulong 6148914691236517205
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ulong_1 = OpConstant %ulong 1
 %ulong_63 = OpConstant %ulong 63
 %ulong_5 = OpConstant %ulong 5
 %ulong_64 = OpConstant %ulong 64
 %ulong_65 = OpConstant %ulong 65
 %ulong_127 = OpConstant %ulong 127
-%ulong_0 = OpConstant %ulong 0
 %ulong_60 = OpConstant %ulong 60
 %ulong_72 = OpConstant %ulong 72
-%258 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%261 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_bool Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_bool Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_ulong Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_ulong Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-OpStore %18 %6
-%84 = OpFunctionCall %ulong %2
-OpStore %19 %84
-%86 = OpLoad %ulong %18
-%87 = OpBitwiseXor %ulong %ulong_18446744073709551615 %86
-OpStore %20 %87
-%89 = OpLoad %ulong %18
-%90 = OpBitwiseXor %ulong %ulong_12297829382473034410 %89
-OpStore %21 %90
-%92 = OpLoad %ulong %18
-%93 = OpBitwiseXor %ulong %ulong_6148914691236517205 %92
-OpStore %22 %93
-%94 = OpLoad %ulong %19
-%95 = OpLoad %ulong %20
-%96 = OpFunctionCall %ulong %3 %94 %95
-OpStore %23 %96
-%97 = OpLoad %ulong %20
-%99 = OpShiftLeftLogical %ulong %97 %ulong_1
-OpStore %24 %99
-%100 = OpLoad %ulong %23
-%101 = OpLoad %ulong %24
-%102 = OpFunctionCall %ulong %3 %100 %101
-OpStore %25 %102
-%103 = OpLoad %ulong %20
-%105 = OpShiftLeftLogical %ulong %103 %ulong_63
-OpStore %26 %105
-%106 = OpLoad %ulong %25
-%107 = OpLoad %ulong %26
-%108 = OpFunctionCall %ulong %3 %106 %107
-OpStore %27 %108
-%109 = OpLoad %ulong %27
-%110 = OpLoad %ulong %20
-%111 = OpFunctionCall %ulong %3 %109 %110
-OpStore %28 %111
-%112 = OpLoad %ulong %20
-%113 = OpShiftRightLogical %ulong %112 %ulong_1
-OpStore %29 %113
-%114 = OpLoad %ulong %28
-%115 = OpLoad %ulong %29
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %30 %116
-%117 = OpLoad %ulong %20
-%118 = OpShiftRightLogical %ulong %117 %ulong_63
-OpStore %31 %118
-%119 = OpLoad %ulong %30
-%120 = OpLoad %ulong %31
-%121 = OpFunctionCall %ulong %3 %119 %120
-OpStore %32 %121
-%122 = OpLoad %ulong %21
-%123 = OpShiftLeftLogical %ulong %122 %ulong_1
-OpStore %33 %123
-%124 = OpLoad %ulong %32
-%125 = OpLoad %ulong %33
-%126 = OpFunctionCall %ulong %3 %124 %125
-OpStore %34 %126
-%127 = OpLoad %ulong %21
-%128 = OpShiftRightLogical %ulong %127 %ulong_1
-OpStore %35 %128
-%129 = OpLoad %ulong %34
-%130 = OpLoad %ulong %35
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %36 %131
-%132 = OpLoad %ulong %22
-%133 = OpShiftLeftLogical %ulong %132 %ulong_1
-OpStore %37 %133
-%134 = OpLoad %ulong %36
-%135 = OpLoad %ulong %37
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %38 %136
-%137 = OpLoad %ulong %22
-%138 = OpShiftRightLogical %ulong %137 %ulong_1
-OpStore %39 %138
-%139 = OpLoad %ulong %38
-%140 = OpLoad %ulong %39
-%141 = OpFunctionCall %ulong %3 %139 %140
-OpStore %40 %141
-%142 = OpLoad %ulong %18
-%144 = OpShiftLeftLogical %ulong %142 %ulong_5
-OpStore %41 %144
-%145 = OpLoad %ulong %40
-%146 = OpLoad %ulong %41
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %42 %147
-%148 = OpLoad %ulong %18
-%149 = OpShiftRightLogical %ulong %148 %ulong_5
-OpStore %43 %149
-%150 = OpLoad %ulong %42
-%151 = OpLoad %ulong %43
-%152 = OpFunctionCall %ulong %3 %150 %151
-OpStore %44 %152
-%153 = OpLoad %ulong %20
-%155 = OpShiftLeftLogical %ulong %153 %ulong_64
-OpStore %45 %155
-%156 = OpLoad %ulong %44
-%157 = OpLoad %ulong %45
-%158 = OpFunctionCall %ulong %3 %156 %157
-OpStore %46 %158
-%159 = OpLoad %ulong %20
-%160 = OpShiftRightLogical %ulong %159 %ulong_64
-OpStore %47 %160
-%161 = OpLoad %ulong %46
-%162 = OpLoad %ulong %47
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %48 %163
-%164 = OpLoad %ulong %20
-%166 = OpShiftLeftLogical %ulong %164 %ulong_65
-OpStore %49 %166
-%167 = OpLoad %ulong %48
-%168 = OpLoad %ulong %49
-%169 = OpFunctionCall %ulong %3 %167 %168
-OpStore %50 %169
-%170 = OpLoad %ulong %20
-%171 = OpShiftRightLogical %ulong %170 %ulong_65
-OpStore %51 %171
-%172 = OpLoad %ulong %50
-%173 = OpLoad %ulong %51
-%174 = OpFunctionCall %ulong %3 %172 %173
-OpStore %52 %174
-%175 = OpLoad %ulong %20
-%177 = OpShiftLeftLogical %ulong %175 %ulong_127
-OpStore %53 %177
-%178 = OpLoad %ulong %52
-%179 = OpLoad %ulong %53
-%180 = OpFunctionCall %ulong %3 %178 %179
-OpStore %54 %180
-%181 = OpLoad %ulong %20
-%182 = OpShiftRightLogical %ulong %181 %ulong_127
-OpStore %55 %182
-%183 = OpLoad %ulong %54
-%184 = OpLoad %ulong %55
-%185 = OpFunctionCall %ulong %3 %183 %184
-OpStore %56 %185
-%186 = OpLoad %ulong %21
-%187 = OpShiftLeftLogical %ulong %186 %ulong_64
-OpStore %57 %187
-%188 = OpLoad %ulong %56
-%189 = OpLoad %ulong %57
-%190 = OpFunctionCall %ulong %3 %188 %189
-OpStore %58 %190
-%191 = OpLoad %ulong %21
-%192 = OpShiftRightLogical %ulong %191 %ulong_127
-OpStore %59 %192
-%193 = OpLoad %ulong %58
-%194 = OpLoad %ulong %59
-%195 = OpFunctionCall %ulong %3 %193 %194
-OpStore %60 %195
-%196 = OpLoad %ulong %60
-OpStore %81 %196
-OpStore %82 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%198 = OpLoad %ulong %82
-%199 = OpULessThan %bool %198 %ulong_64
-OpStore %62 %199
-%200 = OpLoad %bool %62
-OpLoopMerge %10 %15 None
-OpBranchConditional %200 %9 %10
-%10 = OpLabel
-%201 = OpLoad %ulong %81
-OpStore %80 %201
-OpStore %83 %ulong_60
-OpBranch %11
-%11 = OpLabel
-%203 = OpLoad %ulong %83
-%205 = OpULessThan %bool %203 %ulong_72
-OpStore %73 %205
-%206 = OpLoad %bool %73
-OpLoopMerge %13 %14 None
-OpBranchConditional %206 %12 %13
-%13 = OpLabel
-%207 = OpLoad %ulong %80
-OpReturnValue %207
-%12 = OpLabel
-%208 = OpLoad %ulong %83
-%209 = OpLoad %ulong %18
-%210 = OpIAdd %ulong %208 %209
-OpStore %74 %210
-%211 = OpLoad %ulong %20
-%212 = OpLoad %ulong %74
-%213 = OpShiftLeftLogical %ulong %211 %212
-OpStore %75 %213
-%214 = OpLoad %ulong %80
-%215 = OpLoad %ulong %75
-%216 = OpFunctionCall %ulong %3 %214 %215
-OpStore %76 %216
-%217 = OpLoad %ulong %20
-%218 = OpLoad %ulong %74
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %77 %219
-%220 = OpLoad %ulong %76
-%221 = OpLoad %ulong %77
-%222 = OpFunctionCall %ulong %3 %220 %221
-OpStore %78 %222
-%223 = OpLoad %ulong %83
-%224 = OpIAdd %ulong %223 %ulong_1
-OpStore %79 %224
-%225 = OpLoad %ulong %78
-OpStore %80 %225
-%226 = OpLoad %ulong %79
-OpStore %83 %226
-OpBranch %14
-%9 = OpLabel
-%227 = OpLoad %ulong %20
-%228 = OpLoad %ulong %82
-%229 = OpShiftLeftLogical %ulong %227 %228
-OpStore %63 %229
-%230 = OpLoad %ulong %81
-%231 = OpLoad %ulong %63
-%232 = OpFunctionCall %ulong %3 %230 %231
-OpStore %64 %232
-%233 = OpLoad %ulong %20
-%234 = OpLoad %ulong %82
-%235 = OpShiftRightLogical %ulong %233 %234
-OpStore %65 %235
-%236 = OpLoad %ulong %64
-%237 = OpLoad %ulong %65
-%238 = OpFunctionCall %ulong %3 %236 %237
-OpStore %66 %238
-%239 = OpLoad %ulong %82
-%240 = OpLoad %ulong %18
-%241 = OpIAdd %ulong %239 %240
-OpStore %67 %241
-%242 = OpLoad %ulong %21
-%243 = OpLoad %ulong %67
-%244 = OpShiftLeftLogical %ulong %242 %243
-OpStore %68 %244
-%245 = OpLoad %ulong %66
-%246 = OpLoad %ulong %68
-%247 = OpFunctionCall %ulong %3 %245 %246
-OpStore %69 %247
-%248 = OpLoad %ulong %22
-%249 = OpLoad %ulong %67
-%250 = OpShiftRightLogical %ulong %248 %249
-OpStore %70 %250
-%251 = OpLoad %ulong %69
-%252 = OpLoad %ulong %70
-%253 = OpFunctionCall %ulong %3 %251 %252
-OpStore %71 %253
-%254 = OpLoad %ulong %82
-%255 = OpIAdd %ulong %254 %ulong_1
-OpStore %72 %255
-%256 = OpLoad %ulong %71
-OpStore %81 %256
-%257 = OpLoad %ulong %72
-OpStore %82 %257
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %258
-%259 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %261
-%262 = OpFunctionParameter %ulong
-%263 = OpFunctionParameter %ulong
-%264 = OpLabel
+%764 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_bool Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_bool Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_bool Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_bool Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_bool Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_bool Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_bool Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_bool Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_bool Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_bool Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_bool Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
 %269 = OpVariable %_ptr_Function_ulong Function
 %270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_bool Function
+%271 = OpVariable %_ptr_Function_ulong Function
 %272 = OpVariable %_ptr_Function_ulong Function
 %273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_bool Function
 %275 = OpVariable %_ptr_Function_ulong Function
 %276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
-OpStore %269 %262
-OpStore %270 %263
-%280 = OpLoad %ulong %269
-OpStore %278 %280
-OpStore %279 %ulong_0
-OpBranch %265
-%265 = OpLabel
-%281 = OpLoad %ulong %279
-%283 = OpULessThan %bool %281 %ulong_8
-OpStore %271 %283
-%284 = OpLoad %bool %271
-OpLoopMerge %267 %268 None
-OpBranchConditional %284 %266 %267
-%267 = OpLabel
-%285 = OpLoad %ulong %278
-OpReturnValue %285
-%266 = OpLabel
-%286 = OpLoad %ulong %279
-%287 = OpIMul %ulong %286 %ulong_8
-OpStore %272 %287
-%288 = OpLoad %ulong %270
-%289 = OpLoad %ulong %272
-%290 = OpShiftRightLogical %ulong %288 %289
-OpStore %273 %290
-%291 = OpLoad %ulong %273
-%293 = OpBitwiseAnd %ulong %291 %ulong_255
-OpStore %274 %293
-%294 = OpLoad %ulong %278
-%295 = OpLoad %ulong %274
-%296 = OpBitwiseXor %ulong %294 %295
-OpStore %275 %296
-%297 = OpLoad %ulong %275
-%299 = OpIMul %ulong %297 %ulong_1099511628211
-OpStore %276 %299
-%300 = OpLoad %ulong %279
-%301 = OpIAdd %ulong %300 %ulong_1
-OpStore %277 %301
-%302 = OpLoad %ulong %276
-OpStore %278 %302
-%303 = OpLoad %ulong %277
-OpStore %279 %303
-OpBranch %268
-%268 = OpLabel
-OpBranch %265
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_bool Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_bool Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_bool Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %5
+OpBranch %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%311 = OpLoad %ulong %115
+%312 = OpBitwiseXor %ulong %ulong_18446744073709551615 %311
+OpStore %116 %312
+%314 = OpLoad %ulong %115
+%315 = OpBitwiseXor %ulong %ulong_12297829382473034410 %314
+OpStore %117 %315
+%317 = OpLoad %ulong %115
+%318 = OpBitwiseXor %ulong %ulong_6148914691236517205 %317
+OpStore %118 %318
+OpBranch %25
+%25 = OpLabel
+OpStore %191 %ulong_14695981039346656037
+OpStore %192 %ulong_0
+OpBranch %26
+%26 = OpLabel
+%321 = OpLoad %ulong %192
+%323 = OpULessThan %bool %321 %ulong_8
+OpStore %184 %323
+%324 = OpLoad %bool %184
+OpLoopMerge %28 %112 None
+OpBranchConditional %324 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%325 = OpLoad %ulong %116
+%327 = OpShiftLeftLogical %ulong %325 %ulong_1
+OpStore %119 %327
+OpBranch %40
+%40 = OpLabel
+%328 = OpLoad %ulong %191
+OpStore %218 %328
+OpStore %219 %ulong_0
+OpBranch %41
+%41 = OpLabel
+%329 = OpLoad %ulong %219
+%330 = OpULessThan %bool %329 %ulong_8
+OpStore %211 %330
+%331 = OpLoad %bool %211
+OpLoopMerge %43 %111 None
+OpBranchConditional %331 %42 %43
+%43 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%332 = OpLoad %ulong %116
+%334 = OpShiftLeftLogical %ulong %332 %ulong_63
+OpStore %120 %334
+OpBranch %50
+%50 = OpLabel
+%335 = OpLoad %ulong %218
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %53 %110 None
+OpBranchConditional %338 %52 %53
+%53 = OpLabel
+OpBranch %54
+%54 = OpLabel
+OpBranch %60
+%60 = OpLabel
+%339 = OpLoad %ulong %236
+OpStore %254 %339
+OpStore %255 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%340 = OpLoad %ulong %255
+%341 = OpULessThan %bool %340 %ulong_8
+OpStore %247 %341
+%342 = OpLoad %bool %247
+OpLoopMerge %63 %109 None
+OpBranchConditional %342 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%343 = OpLoad %ulong %116
+%344 = OpShiftRightLogical %ulong %343 %ulong_1
+OpStore %121 %344
+OpBranch %65
+%65 = OpLabel
+%345 = OpLoad %ulong %254
+OpStore %263 %345
+OpStore %264 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%346 = OpLoad %ulong %264
+%347 = OpULessThan %bool %346 %ulong_8
+OpStore %256 %347
+%348 = OpLoad %bool %256
+OpLoopMerge %68 %108 None
+OpBranchConditional %348 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%349 = OpLoad %ulong %116
+%350 = OpShiftRightLogical %ulong %349 %ulong_63
+OpStore %122 %350
+OpBranch %70
+%70 = OpLabel
+%351 = OpLoad %ulong %263
+OpStore %272 %351
+OpStore %273 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%352 = OpLoad %ulong %273
+%353 = OpULessThan %bool %352 %ulong_8
+OpStore %265 %353
+%354 = OpLoad %bool %265
+OpLoopMerge %73 %107 None
+OpBranchConditional %354 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%355 = OpLoad %ulong %117
+%356 = OpShiftLeftLogical %ulong %355 %ulong_1
+OpStore %123 %356
+OpBranch %75
+%75 = OpLabel
+%357 = OpLoad %ulong %272
+OpStore %281 %357
+OpStore %282 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%358 = OpLoad %ulong %282
+%359 = OpULessThan %bool %358 %ulong_8
+OpStore %274 %359
+%360 = OpLoad %bool %274
+OpLoopMerge %78 %106 None
+OpBranchConditional %360 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%361 = OpLoad %ulong %117
+%362 = OpShiftRightLogical %ulong %361 %ulong_1
+OpStore %124 %362
+OpBranch %80
+%80 = OpLabel
+%363 = OpLoad %ulong %281
+OpStore %290 %363
+OpStore %291 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%364 = OpLoad %ulong %291
+%365 = OpULessThan %bool %364 %ulong_8
+OpStore %283 %365
+%366 = OpLoad %bool %283
+OpLoopMerge %83 %105 None
+OpBranchConditional %366 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%367 = OpLoad %ulong %118
+%368 = OpShiftLeftLogical %ulong %367 %ulong_1
+OpStore %125 %368
+OpBranch %85
+%85 = OpLabel
+%369 = OpLoad %ulong %290
+OpStore %299 %369
+OpStore %300 %ulong_0
+OpBranch %86
+%86 = OpLabel
+%370 = OpLoad %ulong %300
+%371 = OpULessThan %bool %370 %ulong_8
+OpStore %292 %371
+%372 = OpLoad %bool %292
+OpLoopMerge %88 %104 None
+OpBranchConditional %372 %87 %88
+%88 = OpLabel
+OpBranch %89
+%89 = OpLabel
+%373 = OpLoad %ulong %118
+%374 = OpShiftRightLogical %ulong %373 %ulong_1
+OpStore %126 %374
+OpBranch %90
+%90 = OpLabel
+%375 = OpLoad %ulong %299
+OpStore %308 %375
+OpStore %309 %ulong_0
+OpBranch %91
+%91 = OpLabel
+%376 = OpLoad %ulong %309
+%377 = OpULessThan %bool %376 %ulong_8
+OpStore %301 %377
+%378 = OpLoad %bool %301
+OpLoopMerge %93 %103 None
+OpBranchConditional %378 %92 %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%379 = OpLoad %ulong %115
+%381 = OpShiftLeftLogical %ulong %379 %ulong_5
+OpStore %127 %381
+%382 = OpLoad %ulong %308
+%383 = OpLoad %ulong %127
+%384 = OpFunctionCall %ulong %2 %382 %383
+OpStore %128 %384
+%385 = OpLoad %ulong %115
+%386 = OpShiftRightLogical %ulong %385 %ulong_5
+OpStore %129 %386
+%387 = OpLoad %ulong %128
+%388 = OpLoad %ulong %129
+%389 = OpFunctionCall %ulong %2 %387 %388
+OpStore %130 %389
+%390 = OpLoad %ulong %116
+%392 = OpShiftLeftLogical %ulong %390 %ulong_64
+OpStore %131 %392
+%393 = OpLoad %ulong %130
+%394 = OpLoad %ulong %131
+%395 = OpFunctionCall %ulong %2 %393 %394
+OpStore %132 %395
+%396 = OpLoad %ulong %116
+%397 = OpShiftRightLogical %ulong %396 %ulong_64
+OpStore %133 %397
+%398 = OpLoad %ulong %132
+%399 = OpLoad %ulong %133
+%400 = OpFunctionCall %ulong %2 %398 %399
+OpStore %134 %400
+%401 = OpLoad %ulong %116
+%403 = OpShiftLeftLogical %ulong %401 %ulong_65
+OpStore %135 %403
+%404 = OpLoad %ulong %134
+%405 = OpLoad %ulong %135
+%406 = OpFunctionCall %ulong %2 %404 %405
+OpStore %136 %406
+%407 = OpLoad %ulong %116
+%408 = OpShiftRightLogical %ulong %407 %ulong_65
+OpStore %137 %408
+%409 = OpLoad %ulong %136
+%410 = OpLoad %ulong %137
+%411 = OpFunctionCall %ulong %2 %409 %410
+OpStore %138 %411
+%412 = OpLoad %ulong %116
+%414 = OpShiftLeftLogical %ulong %412 %ulong_127
+OpStore %139 %414
+%415 = OpLoad %ulong %138
+%416 = OpLoad %ulong %139
+%417 = OpFunctionCall %ulong %2 %415 %416
+OpStore %140 %417
+%418 = OpLoad %ulong %116
+%419 = OpShiftRightLogical %ulong %418 %ulong_127
+OpStore %141 %419
+%420 = OpLoad %ulong %140
+%421 = OpLoad %ulong %141
+%422 = OpFunctionCall %ulong %2 %420 %421
+OpStore %142 %422
+%423 = OpLoad %ulong %117
+%424 = OpShiftLeftLogical %ulong %423 %ulong_64
+OpStore %143 %424
+%425 = OpLoad %ulong %142
+%426 = OpLoad %ulong %143
+%427 = OpFunctionCall %ulong %2 %425 %426
+OpStore %144 %427
+%428 = OpLoad %ulong %117
+%429 = OpShiftRightLogical %ulong %428 %ulong_127
+OpStore %145 %429
+%430 = OpLoad %ulong %144
+%431 = OpLoad %ulong %145
+%432 = OpFunctionCall %ulong %2 %430 %431
+OpStore %146 %432
+%433 = OpLoad %ulong %146
+OpStore %163 %433
+OpStore %164 %ulong_0
+OpBranch %7
+%7 = OpLabel
+%434 = OpLoad %ulong %164
+%435 = OpULessThan %bool %434 %ulong_64
+OpStore %148 %435
+%436 = OpLoad %bool %148
+OpLoopMerge %9 %102 None
+OpBranchConditional %436 %8 %9
+%9 = OpLabel
+%437 = OpLoad %ulong %163
+OpStore %162 %437
+OpStore %165 %ulong_60
+OpBranch %10
+%10 = OpLabel
+%439 = OpLoad %ulong %165
+%441 = OpULessThan %bool %439 %ulong_72
+OpStore %156 %441
+%442 = OpLoad %bool %156
+OpLoopMerge %12 %101 None
+OpBranchConditional %442 %11 %12
+%12 = OpLabel
+%443 = OpLoad %ulong %162
+OpReturnValue %443
+%11 = OpLabel
+%444 = OpLoad %ulong %165
+%445 = OpLoad %ulong %115
+%446 = OpIAdd %ulong %444 %445
+OpStore %157 %446
+%447 = OpLoad %ulong %116
+%448 = OpLoad %ulong %157
+%449 = OpShiftLeftLogical %ulong %447 %448
+OpStore %158 %449
+OpBranch %20
+%20 = OpLabel
+%450 = OpLoad %ulong %162
+OpStore %182 %450
+OpStore %183 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%451 = OpLoad %ulong %183
+%452 = OpULessThan %bool %451 %ulong_8
+OpStore %175 %452
+%453 = OpLoad %bool %175
+OpLoopMerge %23 %99 None
+OpBranchConditional %453 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+%454 = OpLoad %ulong %165
+%455 = OpLoad %ulong %115
+%456 = OpIAdd %ulong %454 %455
+OpStore %159 %456
+%457 = OpLoad %ulong %116
+%458 = OpLoad %ulong %159
+%459 = OpShiftRightLogical %ulong %457 %458
+OpStore %160 %459
+OpBranch %35
+%35 = OpLabel
+%460 = OpLoad %ulong %182
+OpStore %209 %460
+OpStore %210 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%461 = OpLoad %ulong %210
+%462 = OpULessThan %bool %461 %ulong_8
+OpStore %202 %462
+%463 = OpLoad %bool %202
+OpLoopMerge %38 %97 None
+OpBranchConditional %463 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+%464 = OpLoad %ulong %165
+%465 = OpIAdd %ulong %464 %ulong_1
+OpStore %161 %465
+%466 = OpLoad %ulong %209
+OpStore %162 %466
+%467 = OpLoad %ulong %161
+OpStore %165 %467
+OpBranch %101
+%37 = OpLabel
+%468 = OpLoad %ulong %210
+%469 = OpIMul %ulong %468 %ulong_8
+OpStore %203 %469
+%470 = OpLoad %ulong %160
+%471 = OpLoad %ulong %203
+%472 = OpShiftRightLogical %ulong %470 %471
+OpStore %204 %472
+%473 = OpLoad %ulong %204
+%475 = OpBitwiseAnd %ulong %473 %ulong_255
+OpStore %205 %475
+%476 = OpLoad %ulong %209
+%477 = OpLoad %ulong %205
+%478 = OpBitwiseXor %ulong %476 %477
+OpStore %206 %478
+%479 = OpLoad %ulong %206
+%481 = OpIMul %ulong %479 %ulong_1099511628211
+OpStore %207 %481
+%482 = OpLoad %ulong %210
+%483 = OpIAdd %ulong %482 %ulong_1
+OpStore %208 %483
+%484 = OpLoad %ulong %207
+OpStore %209 %484
+%485 = OpLoad %ulong %208
+OpStore %210 %485
+OpBranch %97
+%22 = OpLabel
+%486 = OpLoad %ulong %183
+%487 = OpIMul %ulong %486 %ulong_8
+OpStore %176 %487
+%488 = OpLoad %ulong %158
+%489 = OpLoad %ulong %176
+%490 = OpShiftRightLogical %ulong %488 %489
+OpStore %177 %490
+%491 = OpLoad %ulong %177
+%492 = OpBitwiseAnd %ulong %491 %ulong_255
+OpStore %178 %492
+%493 = OpLoad %ulong %182
+%494 = OpLoad %ulong %178
+%495 = OpBitwiseXor %ulong %493 %494
+OpStore %179 %495
+%496 = OpLoad %ulong %179
+%497 = OpIMul %ulong %496 %ulong_1099511628211
+OpStore %180 %497
+%498 = OpLoad %ulong %183
+%499 = OpIAdd %ulong %498 %ulong_1
+OpStore %181 %499
+%500 = OpLoad %ulong %180
+OpStore %182 %500
+%501 = OpLoad %ulong %181
+OpStore %183 %501
+OpBranch %99
+%8 = OpLabel
+%502 = OpLoad %ulong %116
+%503 = OpLoad %ulong %164
+%504 = OpShiftLeftLogical %ulong %502 %503
+OpStore %149 %504
+OpBranch %15
+%15 = OpLabel
+%505 = OpLoad %ulong %163
+OpStore %173 %505
+OpStore %174 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%506 = OpLoad %ulong %174
+%507 = OpULessThan %bool %506 %ulong_8
+OpStore %166 %507
+%508 = OpLoad %bool %166
+OpLoopMerge %18 %100 None
+OpBranchConditional %508 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%509 = OpLoad %ulong %116
+%510 = OpLoad %ulong %164
+%511 = OpShiftRightLogical %ulong %509 %510
+OpStore %150 %511
+OpBranch %30
+%30 = OpLabel
+%512 = OpLoad %ulong %173
+OpStore %200 %512
+OpStore %201 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%513 = OpLoad %ulong %201
+%514 = OpULessThan %bool %513 %ulong_8
+OpStore %193 %514
+%515 = OpLoad %bool %193
+OpLoopMerge %33 %98 None
+OpBranchConditional %515 %32 %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%516 = OpLoad %ulong %164
+%517 = OpLoad %ulong %115
+%518 = OpIAdd %ulong %516 %517
+OpStore %151 %518
+%519 = OpLoad %ulong %117
+%520 = OpLoad %ulong %151
+%521 = OpShiftLeftLogical %ulong %519 %520
+OpStore %152 %521
+OpBranch %45
+%45 = OpLabel
+%522 = OpLoad %ulong %200
+OpStore %227 %522
+OpStore %228 %ulong_0
+OpBranch %46
+%46 = OpLabel
+%523 = OpLoad %ulong %228
+%524 = OpULessThan %bool %523 %ulong_8
+OpStore %220 %524
+%525 = OpLoad %bool %220
+OpLoopMerge %48 %96 None
+OpBranchConditional %525 %47 %48
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+%526 = OpLoad %ulong %164
+%527 = OpLoad %ulong %115
+%528 = OpIAdd %ulong %526 %527
+OpStore %153 %528
+%529 = OpLoad %ulong %118
+%530 = OpLoad %ulong %153
+%531 = OpShiftRightLogical %ulong %529 %530
+OpStore %154 %531
+OpBranch %55
+%55 = OpLabel
+%532 = OpLoad %ulong %227
+OpStore %245 %532
+OpStore %246 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%533 = OpLoad %ulong %246
+%534 = OpULessThan %bool %533 %ulong_8
+OpStore %238 %534
+%535 = OpLoad %bool %238
+OpLoopMerge %58 %95 None
+OpBranchConditional %535 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+%536 = OpLoad %ulong %164
+%537 = OpIAdd %ulong %536 %ulong_1
+OpStore %155 %537
+%538 = OpLoad %ulong %245
+OpStore %163 %538
+%539 = OpLoad %ulong %155
+OpStore %164 %539
+OpBranch %102
+%57 = OpLabel
+%540 = OpLoad %ulong %246
+%541 = OpIMul %ulong %540 %ulong_8
+OpStore %239 %541
+%542 = OpLoad %ulong %154
+%543 = OpLoad %ulong %239
+%544 = OpShiftRightLogical %ulong %542 %543
+OpStore %240 %544
+%545 = OpLoad %ulong %240
+%546 = OpBitwiseAnd %ulong %545 %ulong_255
+OpStore %241 %546
+%547 = OpLoad %ulong %245
+%548 = OpLoad %ulong %241
+%549 = OpBitwiseXor %ulong %547 %548
+OpStore %242 %549
+%550 = OpLoad %ulong %242
+%551 = OpIMul %ulong %550 %ulong_1099511628211
+OpStore %243 %551
+%552 = OpLoad %ulong %246
+%553 = OpIAdd %ulong %552 %ulong_1
+OpStore %244 %553
+%554 = OpLoad %ulong %243
+OpStore %245 %554
+%555 = OpLoad %ulong %244
+OpStore %246 %555
+OpBranch %95
+%47 = OpLabel
+%556 = OpLoad %ulong %228
+%557 = OpIMul %ulong %556 %ulong_8
+OpStore %221 %557
+%558 = OpLoad %ulong %152
+%559 = OpLoad %ulong %221
+%560 = OpShiftRightLogical %ulong %558 %559
+OpStore %222 %560
+%561 = OpLoad %ulong %222
+%562 = OpBitwiseAnd %ulong %561 %ulong_255
+OpStore %223 %562
+%563 = OpLoad %ulong %227
+%564 = OpLoad %ulong %223
+%565 = OpBitwiseXor %ulong %563 %564
+OpStore %224 %565
+%566 = OpLoad %ulong %224
+%567 = OpIMul %ulong %566 %ulong_1099511628211
+OpStore %225 %567
+%568 = OpLoad %ulong %228
+%569 = OpIAdd %ulong %568 %ulong_1
+OpStore %226 %569
+%570 = OpLoad %ulong %225
+OpStore %227 %570
+%571 = OpLoad %ulong %226
+OpStore %228 %571
+OpBranch %96
+%32 = OpLabel
+%572 = OpLoad %ulong %201
+%573 = OpIMul %ulong %572 %ulong_8
+OpStore %194 %573
+%574 = OpLoad %ulong %150
+%575 = OpLoad %ulong %194
+%576 = OpShiftRightLogical %ulong %574 %575
+OpStore %195 %576
+%577 = OpLoad %ulong %195
+%578 = OpBitwiseAnd %ulong %577 %ulong_255
+OpStore %196 %578
+%579 = OpLoad %ulong %200
+%580 = OpLoad %ulong %196
+%581 = OpBitwiseXor %ulong %579 %580
+OpStore %197 %581
+%582 = OpLoad %ulong %197
+%583 = OpIMul %ulong %582 %ulong_1099511628211
+OpStore %198 %583
+%584 = OpLoad %ulong %201
+%585 = OpIAdd %ulong %584 %ulong_1
+OpStore %199 %585
+%586 = OpLoad %ulong %198
+OpStore %200 %586
+%587 = OpLoad %ulong %199
+OpStore %201 %587
+OpBranch %98
+%17 = OpLabel
+%588 = OpLoad %ulong %174
+%589 = OpIMul %ulong %588 %ulong_8
+OpStore %167 %589
+%590 = OpLoad %ulong %149
+%591 = OpLoad %ulong %167
+%592 = OpShiftRightLogical %ulong %590 %591
+OpStore %168 %592
+%593 = OpLoad %ulong %168
+%594 = OpBitwiseAnd %ulong %593 %ulong_255
+OpStore %169 %594
+%595 = OpLoad %ulong %173
+%596 = OpLoad %ulong %169
+%597 = OpBitwiseXor %ulong %595 %596
+OpStore %170 %597
+%598 = OpLoad %ulong %170
+%599 = OpIMul %ulong %598 %ulong_1099511628211
+OpStore %171 %599
+%600 = OpLoad %ulong %174
+%601 = OpIAdd %ulong %600 %ulong_1
+OpStore %172 %601
+%602 = OpLoad %ulong %171
+OpStore %173 %602
+%603 = OpLoad %ulong %172
+OpStore %174 %603
+OpBranch %100
+%92 = OpLabel
+%604 = OpLoad %ulong %309
+%605 = OpIMul %ulong %604 %ulong_8
+OpStore %302 %605
+%606 = OpLoad %ulong %126
+%607 = OpLoad %ulong %302
+%608 = OpShiftRightLogical %ulong %606 %607
+OpStore %303 %608
+%609 = OpLoad %ulong %303
+%610 = OpBitwiseAnd %ulong %609 %ulong_255
+OpStore %304 %610
+%611 = OpLoad %ulong %308
+%612 = OpLoad %ulong %304
+%613 = OpBitwiseXor %ulong %611 %612
+OpStore %305 %613
+%614 = OpLoad %ulong %305
+%615 = OpIMul %ulong %614 %ulong_1099511628211
+OpStore %306 %615
+%616 = OpLoad %ulong %309
+%617 = OpIAdd %ulong %616 %ulong_1
+OpStore %307 %617
+%618 = OpLoad %ulong %306
+OpStore %308 %618
+%619 = OpLoad %ulong %307
+OpStore %309 %619
+OpBranch %103
+%87 = OpLabel
+%620 = OpLoad %ulong %300
+%621 = OpIMul %ulong %620 %ulong_8
+OpStore %293 %621
+%622 = OpLoad %ulong %125
+%623 = OpLoad %ulong %293
+%624 = OpShiftRightLogical %ulong %622 %623
+OpStore %294 %624
+%625 = OpLoad %ulong %294
+%626 = OpBitwiseAnd %ulong %625 %ulong_255
+OpStore %295 %626
+%627 = OpLoad %ulong %299
+%628 = OpLoad %ulong %295
+%629 = OpBitwiseXor %ulong %627 %628
+OpStore %296 %629
+%630 = OpLoad %ulong %296
+%631 = OpIMul %ulong %630 %ulong_1099511628211
+OpStore %297 %631
+%632 = OpLoad %ulong %300
+%633 = OpIAdd %ulong %632 %ulong_1
+OpStore %298 %633
+%634 = OpLoad %ulong %297
+OpStore %299 %634
+%635 = OpLoad %ulong %298
+OpStore %300 %635
+OpBranch %104
+%82 = OpLabel
+%636 = OpLoad %ulong %291
+%637 = OpIMul %ulong %636 %ulong_8
+OpStore %284 %637
+%638 = OpLoad %ulong %124
+%639 = OpLoad %ulong %284
+%640 = OpShiftRightLogical %ulong %638 %639
+OpStore %285 %640
+%641 = OpLoad %ulong %285
+%642 = OpBitwiseAnd %ulong %641 %ulong_255
+OpStore %286 %642
+%643 = OpLoad %ulong %290
+%644 = OpLoad %ulong %286
+%645 = OpBitwiseXor %ulong %643 %644
+OpStore %287 %645
+%646 = OpLoad %ulong %287
+%647 = OpIMul %ulong %646 %ulong_1099511628211
+OpStore %288 %647
+%648 = OpLoad %ulong %291
+%649 = OpIAdd %ulong %648 %ulong_1
+OpStore %289 %649
+%650 = OpLoad %ulong %288
+OpStore %290 %650
+%651 = OpLoad %ulong %289
+OpStore %291 %651
+OpBranch %105
+%77 = OpLabel
+%652 = OpLoad %ulong %282
+%653 = OpIMul %ulong %652 %ulong_8
+OpStore %275 %653
+%654 = OpLoad %ulong %123
+%655 = OpLoad %ulong %275
+%656 = OpShiftRightLogical %ulong %654 %655
+OpStore %276 %656
+%657 = OpLoad %ulong %276
+%658 = OpBitwiseAnd %ulong %657 %ulong_255
+OpStore %277 %658
+%659 = OpLoad %ulong %281
+%660 = OpLoad %ulong %277
+%661 = OpBitwiseXor %ulong %659 %660
+OpStore %278 %661
+%662 = OpLoad %ulong %278
+%663 = OpIMul %ulong %662 %ulong_1099511628211
+OpStore %279 %663
+%664 = OpLoad %ulong %282
+%665 = OpIAdd %ulong %664 %ulong_1
+OpStore %280 %665
+%666 = OpLoad %ulong %279
+OpStore %281 %666
+%667 = OpLoad %ulong %280
+OpStore %282 %667
+OpBranch %106
+%72 = OpLabel
+%668 = OpLoad %ulong %273
+%669 = OpIMul %ulong %668 %ulong_8
+OpStore %266 %669
+%670 = OpLoad %ulong %122
+%671 = OpLoad %ulong %266
+%672 = OpShiftRightLogical %ulong %670 %671
+OpStore %267 %672
+%673 = OpLoad %ulong %267
+%674 = OpBitwiseAnd %ulong %673 %ulong_255
+OpStore %268 %674
+%675 = OpLoad %ulong %272
+%676 = OpLoad %ulong %268
+%677 = OpBitwiseXor %ulong %675 %676
+OpStore %269 %677
+%678 = OpLoad %ulong %269
+%679 = OpIMul %ulong %678 %ulong_1099511628211
+OpStore %270 %679
+%680 = OpLoad %ulong %273
+%681 = OpIAdd %ulong %680 %ulong_1
+OpStore %271 %681
+%682 = OpLoad %ulong %270
+OpStore %272 %682
+%683 = OpLoad %ulong %271
+OpStore %273 %683
+OpBranch %107
+%67 = OpLabel
+%684 = OpLoad %ulong %264
+%685 = OpIMul %ulong %684 %ulong_8
+OpStore %257 %685
+%686 = OpLoad %ulong %121
+%687 = OpLoad %ulong %257
+%688 = OpShiftRightLogical %ulong %686 %687
+OpStore %258 %688
+%689 = OpLoad %ulong %258
+%690 = OpBitwiseAnd %ulong %689 %ulong_255
+OpStore %259 %690
+%691 = OpLoad %ulong %263
+%692 = OpLoad %ulong %259
+%693 = OpBitwiseXor %ulong %691 %692
+OpStore %260 %693
+%694 = OpLoad %ulong %260
+%695 = OpIMul %ulong %694 %ulong_1099511628211
+OpStore %261 %695
+%696 = OpLoad %ulong %264
+%697 = OpIAdd %ulong %696 %ulong_1
+OpStore %262 %697
+%698 = OpLoad %ulong %261
+OpStore %263 %698
+%699 = OpLoad %ulong %262
+OpStore %264 %699
+OpBranch %108
+%62 = OpLabel
+%700 = OpLoad %ulong %255
+%701 = OpIMul %ulong %700 %ulong_8
+OpStore %248 %701
+%702 = OpLoad %ulong %116
+%703 = OpLoad %ulong %248
+%704 = OpShiftRightLogical %ulong %702 %703
+OpStore %249 %704
+%705 = OpLoad %ulong %249
+%706 = OpBitwiseAnd %ulong %705 %ulong_255
+OpStore %250 %706
+%707 = OpLoad %ulong %254
+%708 = OpLoad %ulong %250
+%709 = OpBitwiseXor %ulong %707 %708
+OpStore %251 %709
+%710 = OpLoad %ulong %251
+%711 = OpIMul %ulong %710 %ulong_1099511628211
+OpStore %252 %711
+%712 = OpLoad %ulong %255
+%713 = OpIAdd %ulong %712 %ulong_1
+OpStore %253 %713
+%714 = OpLoad %ulong %252
+OpStore %254 %714
+%715 = OpLoad %ulong %253
+OpStore %255 %715
+OpBranch %109
+%52 = OpLabel
+%716 = OpLoad %ulong %237
+%717 = OpIMul %ulong %716 %ulong_8
+OpStore %230 %717
+%718 = OpLoad %ulong %120
+%719 = OpLoad %ulong %230
+%720 = OpShiftRightLogical %ulong %718 %719
+OpStore %231 %720
+%721 = OpLoad %ulong %231
+%722 = OpBitwiseAnd %ulong %721 %ulong_255
+OpStore %232 %722
+%723 = OpLoad %ulong %236
+%724 = OpLoad %ulong %232
+%725 = OpBitwiseXor %ulong %723 %724
+OpStore %233 %725
+%726 = OpLoad %ulong %233
+%727 = OpIMul %ulong %726 %ulong_1099511628211
+OpStore %234 %727
+%728 = OpLoad %ulong %237
+%729 = OpIAdd %ulong %728 %ulong_1
+OpStore %235 %729
+%730 = OpLoad %ulong %234
+OpStore %236 %730
+%731 = OpLoad %ulong %235
+OpStore %237 %731
+OpBranch %110
+%42 = OpLabel
+%732 = OpLoad %ulong %219
+%733 = OpIMul %ulong %732 %ulong_8
+OpStore %212 %733
+%734 = OpLoad %ulong %119
+%735 = OpLoad %ulong %212
+%736 = OpShiftRightLogical %ulong %734 %735
+OpStore %213 %736
+%737 = OpLoad %ulong %213
+%738 = OpBitwiseAnd %ulong %737 %ulong_255
+OpStore %214 %738
+%739 = OpLoad %ulong %218
+%740 = OpLoad %ulong %214
+%741 = OpBitwiseXor %ulong %739 %740
+OpStore %215 %741
+%742 = OpLoad %ulong %215
+%743 = OpIMul %ulong %742 %ulong_1099511628211
+OpStore %216 %743
+%744 = OpLoad %ulong %219
+%745 = OpIAdd %ulong %744 %ulong_1
+OpStore %217 %745
+%746 = OpLoad %ulong %216
+OpStore %218 %746
+%747 = OpLoad %ulong %217
+OpStore %219 %747
+OpBranch %111
+%27 = OpLabel
+%748 = OpLoad %ulong %192
+%749 = OpIMul %ulong %748 %ulong_8
+OpStore %185 %749
+%750 = OpLoad %ulong %116
+%751 = OpLoad %ulong %185
+%752 = OpShiftRightLogical %ulong %750 %751
+OpStore %186 %752
+%753 = OpLoad %ulong %186
+%754 = OpBitwiseAnd %ulong %753 %ulong_255
+OpStore %187 %754
+%755 = OpLoad %ulong %191
+%756 = OpLoad %ulong %187
+%757 = OpBitwiseXor %ulong %755 %756
+OpStore %188 %757
+%758 = OpLoad %ulong %188
+%759 = OpIMul %ulong %758 %ulong_1099511628211
+OpStore %189 %759
+%760 = OpLoad %ulong %192
+%761 = OpIAdd %ulong %760 %ulong_1
+OpStore %190 %761
+%762 = OpLoad %ulong %189
+OpStore %191 %762
+%763 = OpLoad %ulong %190
+OpStore %192 %763
+OpBranch %112
+%95 = OpLabel
+OpBranch %56
+%96 = OpLabel
+OpBranch %46
+%97 = OpLabel
+OpBranch %36
+%98 = OpLabel
+OpBranch %31
+%99 = OpLabel
+OpBranch %21
+%100 = OpLabel
+OpBranch %16
+%101 = OpLabel
+OpBranch %10
+%102 = OpLabel
+OpBranch %7
+%103 = OpLabel
+OpBranch %91
+%104 = OpLabel
+OpBranch %86
+%105 = OpLabel
+OpBranch %81
+%106 = OpLabel
+OpBranch %76
+%107 = OpLabel
+OpBranch %71
+%108 = OpLabel
+OpBranch %66
+%109 = OpLabel
+OpBranch %61
+%110 = OpLabel
+OpBranch %51
+%111 = OpLabel
+OpBranch %41
+%112 = OpLabel
+OpBranch %26
+OpFunctionEnd
+%2 = OpFunction %ulong None %764
+%765 = OpFunctionParameter %ulong
+%766 = OpFunctionParameter %ulong
+%767 = OpLabel
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_ulong Function
+%774 = OpVariable %_ptr_Function_bool Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_ulong Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
+OpStore %772 %765
+OpStore %773 %766
+%783 = OpLoad %ulong %772
+OpStore %781 %783
+OpStore %782 %ulong_0
+OpBranch %768
+%768 = OpLabel
+%784 = OpLoad %ulong %782
+%785 = OpULessThan %bool %784 %ulong_8
+OpStore %774 %785
+%786 = OpLoad %bool %774
+OpLoopMerge %770 %771 None
+OpBranchConditional %786 %769 %770
+%770 = OpLabel
+%787 = OpLoad %ulong %781
+OpReturnValue %787
+%769 = OpLabel
+%788 = OpLoad %ulong %782
+%789 = OpIMul %ulong %788 %ulong_8
+OpStore %775 %789
+%790 = OpLoad %ulong %773
+%791 = OpLoad %ulong %775
+%792 = OpShiftRightLogical %ulong %790 %791
+OpStore %776 %792
+%793 = OpLoad %ulong %776
+%794 = OpBitwiseAnd %ulong %793 %ulong_255
+OpStore %777 %794
+%795 = OpLoad %ulong %781
+%796 = OpLoad %ulong %777
+%797 = OpBitwiseXor %ulong %795 %796
+OpStore %778 %797
+%798 = OpLoad %ulong %778
+%799 = OpIMul %ulong %798 %ulong_1099511628211
+OpStore %779 %799
+%800 = OpLoad %ulong %782
+%801 = OpIAdd %ulong %800 %ulong_1
+OpStore %780 %801
+%802 = OpLoad %ulong %779
+OpStore %781 %802
+%803 = OpLoad %ulong %780
+OpStore %782 %803
+OpBranch %771
+%771 = OpLabel
+OpBranch %768
 OpFunctionEnd

--- a/test/golden/spirv/call/call_float_regs.dis
+++ b/test/golden/spirv/call/call_float_regs.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1109
+; Bound: 1583
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,40 +15,46 @@ OpDecorate %4 LinkageAttributes "corpus.cases.call.call_float_regs.takef16" Expo
 OpDecorate %5 LinkageAttributes "corpus.cases.call.call_float_regs.takef16s" Export
 OpDecorate %6 LinkageAttributes "corpus.cases.call.call_float_regs.checksum" Export
 %ulong = OpTypeInt 64 0
-%12 = OpTypeFunction %ulong %ulong %ulong
+%10 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %float = OpTypeFloat 32
-%33 = OpTypeFunction %float %ulong
+%31 = OpTypeFunction %float %ulong
 %_ptr_Function_float = OpTypePointer Function %float
 %ulong_4095 = OpConstant %ulong 4095
 %float_2048 = OpConstant %float 2048
 %float_8 = OpConstant %float 8
 %double = OpTypeFloat 64
-%55 = OpTypeFunction %double %ulong
+%53 = OpTypeFunction %double %ulong
 %_ptr_Function_double = OpTypePointer Function %double
 %ulong_1048575 = OpConstant %ulong 1048575
 %double_524288 = OpConstant %double 524288
 %double_64 = OpConstant %double 64
-%76 = OpTypeFunction %ulong %float %double %float %double %float %double %float %double %float %double %float %double %float %double %float %double
-%241 = OpTypeFunction %ulong %float %float %float %float %float %float %float %float %float %float %float %float %float %float %float %float
-%366 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%74 = OpTypeFunction %ulong %float %double %float %double %float %double %float %double %float %double %float %double %float %double %float %double
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%874 = OpTypeFunction %ulong %float %float %float %float %float %float %float %float %float %float %float %float %float %float %float %float
+%1046 = OpTypeFunction %ulong %ulong
 %uint_20 = OpConstant %uint 20
-%_arr_ulong_uint_20 = OpTypeArray %ulong %uint_20
-%_ptr_Function__arr_ulong_uint_20 = OpTypePointer Function %_arr_ulong_uint_20
 %_arr_float_uint_20 = OpTypeArray %float %uint_20
 %_ptr_Function__arr_float_uint_20 = OpTypePointer Function %_arr_float_uint_20
 %_arr_double_uint_20 = OpTypeArray %double %uint_20
 %_ptr_Function__arr_double_uint_20 = OpTypePointer Function %_arr_double_uint_20
-%_ptr_Function_bool = OpTypePointer Function %bool
-%561 = OpConstantNull %_arr_ulong_uint_20
-%ulong_0 = OpConstant %ulong 0
+%_arr_ulong_uint_20 = OpTypeArray %ulong %uint_20
+%_ptr_Function__arr_ulong_uint_20 = OpTypePointer Function %_arr_ulong_uint_20
+%1190 = OpConstantNull %_arr_ulong_uint_20
 %ulong_20 = OpConstant %ulong 20
-%567 = OpConstantNull %_arr_float_uint_20
-%568 = OpConstantNull %_arr_double_uint_20
+%1195 = OpConstantNull %_arr_float_uint_20
+%1196 = OpConstantNull %_arr_double_uint_20
 %ulong_3 = OpConstant %ulong 3
 %uint_19 = OpConstant %uint 19
 %uint_18 = OpConstant %uint 18
@@ -71,88 +77,82 @@ OpDecorate %6 LinkageAttributes "corpus.cases.call.call_float_regs.checksum" Exp
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %float_4 = OpConstant %float 4
-%ulong_1 = OpConstant %ulong 1
-%970 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1015 = OpTypeFunction %ulong %ulong %float
-%_ptr_Function_uint = OpTypePointer Function %uint
-%1064 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %12
-%13 = OpFunctionParameter %ulong
-%14 = OpFunctionParameter %ulong
-%15 = OpLabel
+%1535 = OpTypeFunction %ulong %ulong %float
+%1 = OpFunction %ulong None %10
+%11 = OpFunctionParameter %ulong
+%12 = OpFunctionParameter %ulong
+%13 = OpLabel
+%15 = OpVariable %_ptr_Function_ulong Function
+%16 = OpVariable %_ptr_Function_ulong Function
 %17 = OpVariable %_ptr_Function_ulong Function
 %18 = OpVariable %_ptr_Function_ulong Function
 %19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-OpStore %17 %13
-OpStore %18 %14
-%22 = OpLoad %ulong %18
-%24 = OpIMul %ulong %22 %ulong_6364136223846793005
-OpStore %19 %24
-%25 = OpLoad %ulong %19
-%27 = OpIAdd %ulong %25 %ulong_1442695040888963407
-OpStore %20 %27
-%28 = OpLoad %ulong %20
-%29 = OpLoad %ulong %17
-%30 = OpIAdd %ulong %28 %29
-OpStore %21 %30
-%31 = OpLoad %ulong %21
-OpReturnValue %31
+OpStore %15 %11
+OpStore %16 %12
+%20 = OpLoad %ulong %16
+%22 = OpIMul %ulong %20 %ulong_6364136223846793005
+OpStore %17 %22
+%23 = OpLoad %ulong %17
+%25 = OpIAdd %ulong %23 %ulong_1442695040888963407
+OpStore %18 %25
+%26 = OpLoad %ulong %18
+%27 = OpLoad %ulong %15
+%28 = OpIAdd %ulong %26 %27
+OpStore %19 %28
+%29 = OpLoad %ulong %19
+OpReturnValue %29
 OpFunctionEnd
-%2 = OpFunction %float None %33
-%34 = OpFunctionParameter %ulong
-%35 = OpLabel
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %float None %31
+%32 = OpFunctionParameter %ulong
+%33 = OpLabel
+%34 = OpVariable %_ptr_Function_ulong Function
+%35 = OpVariable %_ptr_Function_ulong Function
+%37 = OpVariable %_ptr_Function_float Function
+%38 = OpVariable %_ptr_Function_float Function
 %39 = OpVariable %_ptr_Function_float Function
-%40 = OpVariable %_ptr_Function_float Function
-%41 = OpVariable %_ptr_Function_float Function
-OpStore %36 %34
-%42 = OpLoad %ulong %36
-%44 = OpBitwiseAnd %ulong %42 %ulong_4095
+OpStore %34 %32
+%40 = OpLoad %ulong %34
+%42 = OpBitwiseAnd %ulong %40 %ulong_4095
+OpStore %35 %42
+%43 = OpLoad %ulong %35
+%44 = OpConvertUToF %float %43
 OpStore %37 %44
-%45 = OpLoad %ulong %37
-%46 = OpConvertUToF %float %45
-OpStore %39 %46
-%47 = OpLoad %float %39
-%49 = OpFSub %float %47 %float_2048
-OpStore %40 %49
-%50 = OpLoad %float %40
-%52 = OpFDiv %float %50 %float_8
-OpStore %41 %52
-%53 = OpLoad %float %41
-OpReturnValue %53
+%45 = OpLoad %float %37
+%47 = OpFSub %float %45 %float_2048
+OpStore %38 %47
+%48 = OpLoad %float %38
+%50 = OpFDiv %float %48 %float_8
+OpStore %39 %50
+%51 = OpLoad %float %39
+OpReturnValue %51
 OpFunctionEnd
-%3 = OpFunction %double None %55
-%56 = OpFunctionParameter %ulong
-%57 = OpLabel
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
+%3 = OpFunction %double None %53
+%54 = OpFunctionParameter %ulong
+%55 = OpLabel
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_double Function
+%60 = OpVariable %_ptr_Function_double Function
 %61 = OpVariable %_ptr_Function_double Function
-%62 = OpVariable %_ptr_Function_double Function
-%63 = OpVariable %_ptr_Function_double Function
-OpStore %58 %56
-%64 = OpLoad %ulong %58
-%66 = OpBitwiseAnd %ulong %64 %ulong_1048575
+OpStore %56 %54
+%62 = OpLoad %ulong %56
+%64 = OpBitwiseAnd %ulong %62 %ulong_1048575
+OpStore %57 %64
+%65 = OpLoad %ulong %57
+%66 = OpConvertUToF %double %65
 OpStore %59 %66
-%67 = OpLoad %ulong %59
-%68 = OpConvertUToF %double %67
-OpStore %61 %68
-%69 = OpLoad %double %61
-%71 = OpFSub %double %69 %double_524288
-OpStore %62 %71
-%72 = OpLoad %double %62
-%74 = OpFDiv %double %72 %double_64
-OpStore %63 %74
-%75 = OpLoad %double %63
-OpReturnValue %75
+%67 = OpLoad %double %59
+%69 = OpFSub %double %67 %double_524288
+OpStore %60 %69
+%70 = OpLoad %double %60
+%72 = OpFDiv %double %70 %double_64
+OpStore %61 %72
+%73 = OpLoad %double %61
+OpReturnValue %73
 OpFunctionEnd
-%4 = OpFunction %ulong None %76
+%4 = OpFunction %ulong None %74
+%75 = OpFunctionParameter %float
+%76 = OpFunctionParameter %double
 %77 = OpFunctionParameter %float
 %78 = OpFunctionParameter %double
 %79 = OpFunctionParameter %float
@@ -167,241 +167,48 @@ OpFunctionEnd
 %88 = OpFunctionParameter %double
 %89 = OpFunctionParameter %float
 %90 = OpFunctionParameter %double
-%91 = OpFunctionParameter %float
-%92 = OpFunctionParameter %double
-%93 = OpLabel
-%94 = OpVariable %_ptr_Function_float Function
-%95 = OpVariable %_ptr_Function_double Function
-%96 = OpVariable %_ptr_Function_float Function
-%97 = OpVariable %_ptr_Function_double Function
-%98 = OpVariable %_ptr_Function_float Function
-%99 = OpVariable %_ptr_Function_double Function
-%100 = OpVariable %_ptr_Function_float Function
-%101 = OpVariable %_ptr_Function_double Function
-%102 = OpVariable %_ptr_Function_float Function
-%103 = OpVariable %_ptr_Function_double Function
-%104 = OpVariable %_ptr_Function_float Function
-%105 = OpVariable %_ptr_Function_double Function
-%106 = OpVariable %_ptr_Function_float Function
-%107 = OpVariable %_ptr_Function_double Function
-%108 = OpVariable %_ptr_Function_float Function
-%109 = OpVariable %_ptr_Function_double Function
-%110 = OpVariable %_ptr_Function_ulong Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_ulong Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_ulong Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_float Function
-%128 = OpVariable %_ptr_Function_float Function
-%129 = OpVariable %_ptr_Function_float Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_double Function
-%132 = OpVariable %_ptr_Function_double Function
-%133 = OpVariable %_ptr_Function_double Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_float Function
-%136 = OpVariable %_ptr_Function_float Function
-%137 = OpVariable %_ptr_Function_float Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_double Function
-%140 = OpVariable %_ptr_Function_double Function
-%141 = OpVariable %_ptr_Function_double Function
-%142 = OpVariable %_ptr_Function_ulong Function
-OpStore %94 %77
-OpStore %95 %78
-OpStore %96 %79
-OpStore %97 %80
-OpStore %98 %81
-OpStore %99 %82
-OpStore %100 %83
-OpStore %101 %84
-OpStore %102 %85
-OpStore %103 %86
-OpStore %104 %87
-OpStore %105 %88
-OpStore %106 %89
-OpStore %107 %90
-OpStore %108 %91
-OpStore %109 %92
-%143 = OpFunctionCall %ulong %7
-OpStore %110 %143
-%144 = OpLoad %ulong %110
-%145 = OpLoad %float %94
-%146 = OpFunctionCall %ulong %9 %144 %145
-OpStore %111 %146
-%147 = OpLoad %ulong %111
-%148 = OpLoad %double %95
-%149 = OpFunctionCall %ulong %10 %147 %148
-OpStore %112 %149
-%150 = OpLoad %ulong %112
-%151 = OpLoad %float %96
-%152 = OpFunctionCall %ulong %9 %150 %151
-OpStore %113 %152
-%153 = OpLoad %ulong %113
-%154 = OpLoad %double %97
-%155 = OpFunctionCall %ulong %10 %153 %154
-OpStore %114 %155
-%156 = OpLoad %ulong %114
-%157 = OpLoad %float %98
-%158 = OpFunctionCall %ulong %9 %156 %157
-OpStore %115 %158
-%159 = OpLoad %ulong %115
-%160 = OpLoad %double %99
-%161 = OpFunctionCall %ulong %10 %159 %160
-OpStore %116 %161
-%162 = OpLoad %ulong %116
-%163 = OpLoad %float %100
-%164 = OpFunctionCall %ulong %9 %162 %163
-OpStore %117 %164
-%165 = OpLoad %ulong %117
-%166 = OpLoad %double %101
-%167 = OpFunctionCall %ulong %10 %165 %166
-OpStore %118 %167
-%168 = OpLoad %ulong %118
-%169 = OpLoad %float %102
-%170 = OpFunctionCall %ulong %9 %168 %169
-OpStore %119 %170
-%171 = OpLoad %ulong %119
-%172 = OpLoad %double %103
-%173 = OpFunctionCall %ulong %10 %171 %172
-OpStore %120 %173
-%174 = OpLoad %ulong %120
-%175 = OpLoad %float %104
-%176 = OpFunctionCall %ulong %9 %174 %175
-OpStore %121 %176
-%177 = OpLoad %ulong %121
-%178 = OpLoad %double %105
-%179 = OpFunctionCall %ulong %10 %177 %178
-OpStore %122 %179
-%180 = OpLoad %ulong %122
-%181 = OpLoad %float %106
-%182 = OpFunctionCall %ulong %9 %180 %181
-OpStore %123 %182
-%183 = OpLoad %ulong %123
-%184 = OpLoad %double %107
-%185 = OpFunctionCall %ulong %10 %183 %184
-OpStore %124 %185
-%186 = OpLoad %ulong %124
-%187 = OpLoad %float %108
-%188 = OpFunctionCall %ulong %9 %186 %187
-OpStore %125 %188
-%189 = OpLoad %ulong %125
-%190 = OpLoad %double %109
-%191 = OpFunctionCall %ulong %10 %189 %190
-OpStore %126 %191
-%192 = OpLoad %float %96
-%193 = OpLoad %float %98
-%194 = OpFMul %float %192 %193
-OpStore %127 %194
-%195 = OpLoad %float %94
-%196 = OpLoad %float %127
-%197 = OpFAdd %float %195 %196
-OpStore %128 %197
-%198 = OpLoad %float %128
-%199 = OpLoad %float %100
-%200 = OpFSub %float %198 %199
-OpStore %129 %200
-%201 = OpLoad %ulong %126
-%202 = OpLoad %float %129
-%203 = OpFunctionCall %ulong %9 %201 %202
-OpStore %130 %203
-%204 = OpLoad %double %97
-%205 = OpLoad %double %99
-%206 = OpFMul %double %204 %205
-OpStore %131 %206
-%207 = OpLoad %double %95
-%208 = OpLoad %double %131
-%209 = OpFAdd %double %207 %208
-OpStore %132 %209
-%210 = OpLoad %double %132
-%211 = OpLoad %double %101
-%212 = OpFSub %double %210 %211
-OpStore %133 %212
-%213 = OpLoad %ulong %130
-%214 = OpLoad %double %133
-%215 = OpFunctionCall %ulong %10 %213 %214
-OpStore %134 %215
-%216 = OpLoad %float %102
-%217 = OpLoad %float %104
-%218 = OpFSub %float %216 %217
-OpStore %135 %218
-%219 = OpLoad %float %106
-%220 = OpLoad %float %108
-%221 = OpFMul %float %219 %220
-OpStore %136 %221
-%222 = OpLoad %float %135
-%223 = OpLoad %float %136
-%224 = OpFAdd %float %222 %223
-OpStore %137 %224
-%225 = OpLoad %ulong %134
-%226 = OpLoad %float %137
-%227 = OpFunctionCall %ulong %9 %225 %226
-OpStore %138 %227
-%228 = OpLoad %double %103
-%229 = OpLoad %double %105
-%230 = OpFSub %double %228 %229
-OpStore %139 %230
-%231 = OpLoad %double %107
-%232 = OpLoad %double %109
-%233 = OpFMul %double %231 %232
-OpStore %140 %233
-%234 = OpLoad %double %139
-%235 = OpLoad %double %140
-%236 = OpFAdd %double %234 %235
-OpStore %141 %236
-%237 = OpLoad %ulong %138
-%238 = OpLoad %double %141
-%239 = OpFunctionCall %ulong %10 %237 %238
-OpStore %142 %239
-%240 = OpLoad %ulong %142
-OpReturnValue %240
-OpFunctionEnd
-%5 = OpFunction %ulong None %241
-%242 = OpFunctionParameter %float
-%243 = OpFunctionParameter %float
-%244 = OpFunctionParameter %float
-%245 = OpFunctionParameter %float
-%246 = OpFunctionParameter %float
-%247 = OpFunctionParameter %float
-%248 = OpFunctionParameter %float
-%249 = OpFunctionParameter %float
-%250 = OpFunctionParameter %float
-%251 = OpFunctionParameter %float
-%252 = OpFunctionParameter %float
-%253 = OpFunctionParameter %float
-%254 = OpFunctionParameter %float
-%255 = OpFunctionParameter %float
-%256 = OpFunctionParameter %float
-%257 = OpFunctionParameter %float
-%258 = OpLabel
-%259 = OpVariable %_ptr_Function_float Function
-%260 = OpVariable %_ptr_Function_float Function
-%261 = OpVariable %_ptr_Function_float Function
-%262 = OpVariable %_ptr_Function_float Function
-%263 = OpVariable %_ptr_Function_float Function
-%264 = OpVariable %_ptr_Function_float Function
-%265 = OpVariable %_ptr_Function_float Function
-%266 = OpVariable %_ptr_Function_float Function
-%267 = OpVariable %_ptr_Function_float Function
-%268 = OpVariable %_ptr_Function_float Function
-%269 = OpVariable %_ptr_Function_float Function
-%270 = OpVariable %_ptr_Function_float Function
-%271 = OpVariable %_ptr_Function_float Function
-%272 = OpVariable %_ptr_Function_float Function
-%273 = OpVariable %_ptr_Function_float Function
-%274 = OpVariable %_ptr_Function_float Function
+%91 = OpLabel
+%232 = OpVariable %_ptr_Function_float Function
+%233 = OpVariable %_ptr_Function_double Function
+%234 = OpVariable %_ptr_Function_float Function
+%235 = OpVariable %_ptr_Function_double Function
+%236 = OpVariable %_ptr_Function_float Function
+%237 = OpVariable %_ptr_Function_double Function
+%238 = OpVariable %_ptr_Function_float Function
+%239 = OpVariable %_ptr_Function_double Function
+%240 = OpVariable %_ptr_Function_float Function
+%241 = OpVariable %_ptr_Function_double Function
+%242 = OpVariable %_ptr_Function_float Function
+%243 = OpVariable %_ptr_Function_double Function
+%244 = OpVariable %_ptr_Function_float Function
+%245 = OpVariable %_ptr_Function_double Function
+%246 = OpVariable %_ptr_Function_float Function
+%247 = OpVariable %_ptr_Function_double Function
+%248 = OpVariable %_ptr_Function_float Function
+%249 = OpVariable %_ptr_Function_float Function
+%250 = OpVariable %_ptr_Function_float Function
+%251 = OpVariable %_ptr_Function_double Function
+%252 = OpVariable %_ptr_Function_double Function
+%253 = OpVariable %_ptr_Function_double Function
+%254 = OpVariable %_ptr_Function_float Function
+%255 = OpVariable %_ptr_Function_float Function
+%256 = OpVariable %_ptr_Function_float Function
+%257 = OpVariable %_ptr_Function_double Function
+%258 = OpVariable %_ptr_Function_double Function
+%259 = OpVariable %_ptr_Function_double Function
+%261 = OpVariable %_ptr_Function_uint Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_bool Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_bool Function
 %275 = OpVariable %_ptr_Function_ulong Function
 %276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
@@ -410,1091 +217,2054 @@ OpFunctionEnd
 %280 = OpVariable %_ptr_Function_ulong Function
 %281 = OpVariable %_ptr_Function_ulong Function
 %282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_uint Function
 %284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_bool Function
 %286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
 %288 = OpVariable %_ptr_Function_ulong Function
 %289 = OpVariable %_ptr_Function_ulong Function
 %290 = OpVariable %_ptr_Function_ulong Function
 %291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_float Function
+%292 = OpVariable %_ptr_Function_ulong Function
 %293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_float Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_float Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_bool Function
+%296 = OpVariable %_ptr_Function_ulong Function
 %297 = OpVariable %_ptr_Function_ulong Function
-OpStore %259 %242
-OpStore %260 %243
-OpStore %261 %244
-OpStore %262 %245
-OpStore %263 %246
-OpStore %264 %247
-OpStore %265 %248
-OpStore %266 %249
-OpStore %267 %250
-OpStore %268 %251
-OpStore %269 %252
-OpStore %270 %253
-OpStore %271 %254
-OpStore %272 %255
-OpStore %273 %256
-OpStore %274 %257
-%298 = OpFunctionCall %ulong %7
-OpStore %275 %298
-%299 = OpLoad %ulong %275
-%300 = OpLoad %float %259
-%301 = OpFunctionCall %ulong %9 %299 %300
-OpStore %276 %301
-%302 = OpLoad %ulong %276
-%303 = OpLoad %float %260
-%304 = OpFunctionCall %ulong %9 %302 %303
-OpStore %277 %304
-%305 = OpLoad %ulong %277
-%306 = OpLoad %float %261
-%307 = OpFunctionCall %ulong %9 %305 %306
-OpStore %278 %307
-%308 = OpLoad %ulong %278
-%309 = OpLoad %float %262
-%310 = OpFunctionCall %ulong %9 %308 %309
-OpStore %279 %310
-%311 = OpLoad %ulong %279
-%312 = OpLoad %float %263
-%313 = OpFunctionCall %ulong %9 %311 %312
-OpStore %280 %313
-%314 = OpLoad %ulong %280
-%315 = OpLoad %float %264
-%316 = OpFunctionCall %ulong %9 %314 %315
-OpStore %281 %316
-%317 = OpLoad %ulong %281
-%318 = OpLoad %float %265
-%319 = OpFunctionCall %ulong %9 %317 %318
-OpStore %282 %319
-%320 = OpLoad %ulong %282
-%321 = OpLoad %float %266
-%322 = OpFunctionCall %ulong %9 %320 %321
-OpStore %283 %322
-%323 = OpLoad %ulong %283
-%324 = OpLoad %float %267
-%325 = OpFunctionCall %ulong %9 %323 %324
-OpStore %284 %325
-%326 = OpLoad %ulong %284
-%327 = OpLoad %float %268
-%328 = OpFunctionCall %ulong %9 %326 %327
-OpStore %285 %328
-%329 = OpLoad %ulong %285
-%330 = OpLoad %float %269
-%331 = OpFunctionCall %ulong %9 %329 %330
-OpStore %286 %331
-%332 = OpLoad %ulong %286
-%333 = OpLoad %float %270
-%334 = OpFunctionCall %ulong %9 %332 %333
-OpStore %287 %334
-%335 = OpLoad %ulong %287
-%336 = OpLoad %float %271
-%337 = OpFunctionCall %ulong %9 %335 %336
-OpStore %288 %337
-%338 = OpLoad %ulong %288
-%339 = OpLoad %float %272
-%340 = OpFunctionCall %ulong %9 %338 %339
-OpStore %289 %340
-%341 = OpLoad %ulong %289
-%342 = OpLoad %float %273
-%343 = OpFunctionCall %ulong %9 %341 %342
-OpStore %290 %343
-%344 = OpLoad %ulong %290
-%345 = OpLoad %float %274
-%346 = OpFunctionCall %ulong %9 %344 %345
-OpStore %291 %346
-%347 = OpLoad %float %259
-%348 = OpLoad %float %274
-%349 = OpFAdd %float %347 %348
-OpStore %292 %349
-%350 = OpLoad %ulong %291
-%351 = OpLoad %float %292
-%352 = OpFunctionCall %ulong %9 %350 %351
-OpStore %293 %352
-%353 = OpLoad %float %266
-%354 = OpLoad %float %271
-%355 = OpFSub %float %353 %354
-OpStore %294 %355
-%356 = OpLoad %ulong %293
-%357 = OpLoad %float %294
-%358 = OpFunctionCall %ulong %9 %356 %357
-OpStore %295 %358
-%359 = OpLoad %float %262
-%360 = OpLoad %float %273
-%361 = OpFMul %float %359 %360
-OpStore %296 %361
-%362 = OpLoad %ulong %295
-%363 = OpLoad %float %296
-%364 = OpFunctionCall %ulong %9 %362 %363
-OpStore %297 %364
-%365 = OpLoad %ulong %297
-OpReturnValue %365
-OpFunctionEnd
-%6 = OpFunction %ulong None %366
-%367 = OpFunctionParameter %ulong
-%368 = OpLabel
-%400 = OpVariable %_ptr_Function__arr_ulong_uint_20 Function
-%403 = OpVariable %_ptr_Function__arr_float_uint_20 Function
-%406 = OpVariable %_ptr_Function__arr_double_uint_20 Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_uint Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_bool Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_bool Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_uint Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_bool Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_bool Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_uint Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_bool Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_bool Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_uint Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_bool Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_bool Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_uint Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_bool Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_bool Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_ulong Function
 %407 = OpVariable %_ptr_Function_ulong Function
 %408 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_bool Function
-%411 = OpVariable %_ptr_Function_ulong Function
-%412 = OpVariable %_ptr_Function_bool Function
+%409 = OpVariable %_ptr_Function_uint Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_bool Function
+%412 = OpVariable %_ptr_Function_ulong Function
 %413 = OpVariable %_ptr_Function_ulong Function
 %414 = OpVariable %_ptr_Function_ulong Function
 %415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_bool Function
+%416 = OpVariable %_ptr_Function_ulong Function
 %417 = OpVariable %_ptr_Function_ulong Function
-%418 = OpVariable %_ptr_Function_float Function
-%419 = OpVariable %_ptr_Function_float Function
-%420 = OpVariable %_ptr_Function_float Function
-%421 = OpVariable %_ptr_Function_float Function
-%422 = OpVariable %_ptr_Function_double Function
-%423 = OpVariable %_ptr_Function_float Function
-%424 = OpVariable %_ptr_Function_double Function
-%425 = OpVariable %_ptr_Function_float Function
-%426 = OpVariable %_ptr_Function_double Function
-%427 = OpVariable %_ptr_Function_float Function
-%428 = OpVariable %_ptr_Function_double Function
-%429 = OpVariable %_ptr_Function_float Function
-%430 = OpVariable %_ptr_Function_double Function
-%431 = OpVariable %_ptr_Function_float Function
-%432 = OpVariable %_ptr_Function_double Function
-%433 = OpVariable %_ptr_Function_float Function
-%434 = OpVariable %_ptr_Function_double Function
-%435 = OpVariable %_ptr_Function_float Function
-%436 = OpVariable %_ptr_Function_double Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_bool Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_uint Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_uint Function
+%436 = OpVariable %_ptr_Function_ulong Function
 %437 = OpVariable %_ptr_Function_ulong Function
 %438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_float Function
-%440 = OpVariable %_ptr_Function_float Function
-%441 = OpVariable %_ptr_Function_float Function
-%442 = OpVariable %_ptr_Function_float Function
-%443 = OpVariable %_ptr_Function_float Function
-%444 = OpVariable %_ptr_Function_float Function
-%445 = OpVariable %_ptr_Function_float Function
-%446 = OpVariable %_ptr_Function_float Function
-%447 = OpVariable %_ptr_Function_float Function
-%448 = OpVariable %_ptr_Function_float Function
-%449 = OpVariable %_ptr_Function_float Function
-%450 = OpVariable %_ptr_Function_float Function
-%451 = OpVariable %_ptr_Function_float Function
-%452 = OpVariable %_ptr_Function_float Function
-%453 = OpVariable %_ptr_Function_float Function
-%454 = OpVariable %_ptr_Function_float Function
-%455 = OpVariable %_ptr_Function_float Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_float Function
-%459 = OpVariable %_ptr_Function_float Function
-%460 = OpVariable %_ptr_Function_float Function
-%461 = OpVariable %_ptr_Function_float Function
-%462 = OpVariable %_ptr_Function_float Function
-%463 = OpVariable %_ptr_Function_float Function
-%464 = OpVariable %_ptr_Function_float Function
-%465 = OpVariable %_ptr_Function_float Function
-%466 = OpVariable %_ptr_Function_float Function
-%467 = OpVariable %_ptr_Function_float Function
-%468 = OpVariable %_ptr_Function_float Function
-%469 = OpVariable %_ptr_Function_float Function
-%470 = OpVariable %_ptr_Function_float Function
-%471 = OpVariable %_ptr_Function_float Function
-%472 = OpVariable %_ptr_Function_float Function
-%473 = OpVariable %_ptr_Function_float Function
-%474 = OpVariable %_ptr_Function_double Function
-%475 = OpVariable %_ptr_Function_float Function
-%476 = OpVariable %_ptr_Function_double Function
-%477 = OpVariable %_ptr_Function_float Function
-%478 = OpVariable %_ptr_Function_double Function
-%479 = OpVariable %_ptr_Function_float Function
-%480 = OpVariable %_ptr_Function_double Function
-%481 = OpVariable %_ptr_Function_double Function
-%482 = OpVariable %_ptr_Function_float Function
-%483 = OpVariable %_ptr_Function_double Function
-%484 = OpVariable %_ptr_Function_float Function
-%485 = OpVariable %_ptr_Function_double Function
-%486 = OpVariable %_ptr_Function_float Function
-%487 = OpVariable %_ptr_Function_double Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_ulong Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_ulong Function
-%497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_ulong Function
-%499 = OpVariable %_ptr_Function_float Function
-%500 = OpVariable %_ptr_Function_float Function
-%501 = OpVariable %_ptr_Function_float Function
-%502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_float Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_float Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_float Function
-%524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_ulong Function
-%526 = OpVariable %_ptr_Function_ulong Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_ulong Function
-%529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_ulong Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_ulong Function
-%533 = OpVariable %_ptr_Function_ulong Function
-%534 = OpVariable %_ptr_Function_ulong Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_ulong Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_ulong Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_ulong Function
-%541 = OpVariable %_ptr_Function_ulong Function
-%542 = OpVariable %_ptr_Function_float Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_float Function
-%545 = OpVariable %_ptr_Function_ulong Function
-%546 = OpVariable %_ptr_Function_float Function
-%547 = OpVariable %_ptr_Function_ulong Function
-%548 = OpVariable %_ptr_Function_ulong Function
-%549 = OpVariable %_ptr_Function_double Function
-%550 = OpVariable %_ptr_Function_double Function
-%551 = OpVariable %_ptr_Function_double Function
-%552 = OpVariable %_ptr_Function_ulong Function
-%553 = OpVariable %_ptr_Function_float Function
-%554 = OpVariable %_ptr_Function_float Function
-%555 = OpVariable %_ptr_Function_float Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_float Function
-%558 = OpVariable %_ptr_Function_float Function
-%559 = OpVariable %_ptr_Function_float Function
-OpStore %407 %367
-%560 = OpFunctionCall %ulong %7
-OpStore %408 %560
-OpStore %400 %561
-OpStore %492 %ulong_0
-OpBranch %369
-%369 = OpLabel
-%563 = OpLoad %ulong %492
-%565 = OpULessThan %bool %563 %ulong_20
-OpStore %410 %565
-%566 = OpLoad %bool %410
-OpLoopMerge %371 %394 None
-OpBranchConditional %566 %370 %371
-%371 = OpLabel
-OpStore %403 %567
-OpStore %406 %568
-OpStore %491 %ulong_0
-OpBranch %372
-%372 = OpLabel
-%569 = OpLoad %ulong %491
-%570 = OpULessThan %bool %569 %ulong_20
-OpStore %412 %570
-%571 = OpLoad %bool %412
-OpLoopMerge %374 %393 None
-OpBranchConditional %571 %373 %374
-%374 = OpLabel
-%572 = OpLoad %ulong %408
-OpStore %490 %572
-OpStore %493 %ulong_0
-OpStore %494 %ulong_0
-OpBranch %375
-%375 = OpLabel
-%573 = OpLoad %ulong %494
-%575 = OpULessThan %bool %573 %ulong_3
-OpStore %416 %575
-%576 = OpLoad %bool %416
-OpLoopMerge %377 %392 None
-OpBranchConditional %576 %376 %377
-%377 = OpLabel
-%578 = OpAccessChain %_ptr_Function_float %403 %uint_19
-%579 = OpLoad %float %578
-OpStore %458 %579
-%581 = OpAccessChain %_ptr_Function_float %403 %uint_18
-%582 = OpLoad %float %581
-OpStore %459 %582
-%584 = OpAccessChain %_ptr_Function_float %403 %uint_17
-%585 = OpLoad %float %584
-OpStore %460 %585
-%587 = OpAccessChain %_ptr_Function_float %403 %uint_16
-%588 = OpLoad %float %587
-OpStore %461 %588
-%590 = OpAccessChain %_ptr_Function_float %403 %uint_15
-%591 = OpLoad %float %590
-OpStore %462 %591
-%593 = OpAccessChain %_ptr_Function_float %403 %uint_14
-%594 = OpLoad %float %593
-OpStore %463 %594
-%596 = OpAccessChain %_ptr_Function_float %403 %uint_13
-%597 = OpLoad %float %596
-OpStore %464 %597
-%599 = OpAccessChain %_ptr_Function_float %403 %uint_12
-%600 = OpLoad %float %599
-OpStore %465 %600
-%602 = OpAccessChain %_ptr_Function_float %403 %uint_11
-%603 = OpLoad %float %602
-OpStore %466 %603
-%605 = OpAccessChain %_ptr_Function_float %403 %uint_10
-%606 = OpLoad %float %605
-OpStore %467 %606
-%608 = OpAccessChain %_ptr_Function_float %403 %uint_9
-%609 = OpLoad %float %608
-OpStore %468 %609
-%611 = OpAccessChain %_ptr_Function_float %403 %uint_8
-%612 = OpLoad %float %611
-OpStore %469 %612
-%614 = OpAccessChain %_ptr_Function_float %403 %uint_7
-%615 = OpLoad %float %614
-OpStore %470 %615
-%617 = OpAccessChain %_ptr_Function_float %403 %uint_6
-%618 = OpLoad %float %617
-OpStore %471 %618
-%620 = OpAccessChain %_ptr_Function_float %403 %uint_5
-%621 = OpLoad %float %620
-OpStore %472 %621
-%623 = OpAccessChain %_ptr_Function_float %403 %uint_4
-%624 = OpLoad %float %623
-OpStore %473 %624
-OpBranch %384
-%384 = OpLabel
-%625 = OpFunctionCall %ulong %7
-OpStore %525 %625
-%626 = OpLoad %ulong %525
-%627 = OpLoad %float %458
-%628 = OpFunctionCall %ulong %9 %626 %627
-OpStore %526 %628
-%629 = OpLoad %ulong %526
-%630 = OpLoad %float %459
-%631 = OpFunctionCall %ulong %9 %629 %630
-OpStore %527 %631
-%632 = OpLoad %ulong %527
-%633 = OpLoad %float %460
-%634 = OpFunctionCall %ulong %9 %632 %633
-OpStore %528 %634
-%635 = OpLoad %ulong %528
-%636 = OpLoad %float %461
-%637 = OpFunctionCall %ulong %9 %635 %636
-OpStore %529 %637
-%638 = OpLoad %ulong %529
-%639 = OpLoad %float %462
-%640 = OpFunctionCall %ulong %9 %638 %639
-OpStore %530 %640
-%641 = OpLoad %ulong %530
-%642 = OpLoad %float %463
-%643 = OpFunctionCall %ulong %9 %641 %642
-OpStore %531 %643
-%644 = OpLoad %ulong %531
-%645 = OpLoad %float %464
-%646 = OpFunctionCall %ulong %9 %644 %645
-OpStore %532 %646
-%647 = OpLoad %ulong %532
-%648 = OpLoad %float %465
-%649 = OpFunctionCall %ulong %9 %647 %648
-OpStore %533 %649
-%650 = OpLoad %ulong %533
-%651 = OpLoad %float %466
-%652 = OpFunctionCall %ulong %9 %650 %651
-OpStore %534 %652
-%653 = OpLoad %ulong %534
-%654 = OpLoad %float %467
-%655 = OpFunctionCall %ulong %9 %653 %654
-OpStore %535 %655
-%656 = OpLoad %ulong %535
-%657 = OpLoad %float %468
-%658 = OpFunctionCall %ulong %9 %656 %657
-OpStore %536 %658
-%659 = OpLoad %ulong %536
-%660 = OpLoad %float %469
-%661 = OpFunctionCall %ulong %9 %659 %660
-OpStore %537 %661
-%662 = OpLoad %ulong %537
-%663 = OpLoad %float %470
-%664 = OpFunctionCall %ulong %9 %662 %663
-OpStore %538 %664
-%665 = OpLoad %ulong %538
-%666 = OpLoad %float %471
-%667 = OpFunctionCall %ulong %9 %665 %666
-OpStore %539 %667
-%668 = OpLoad %ulong %539
-%669 = OpLoad %float %472
-%670 = OpFunctionCall %ulong %9 %668 %669
-OpStore %540 %670
-%671 = OpLoad %ulong %540
-%672 = OpLoad %float %473
-%673 = OpFunctionCall %ulong %9 %671 %672
-OpStore %541 %673
-%674 = OpLoad %float %458
-%675 = OpLoad %float %473
-%676 = OpFAdd %float %674 %675
-OpStore %542 %676
-%677 = OpLoad %ulong %541
-%678 = OpLoad %float %542
-%679 = OpFunctionCall %ulong %9 %677 %678
-OpStore %543 %679
-%680 = OpLoad %float %465
-%681 = OpLoad %float %470
-%682 = OpFSub %float %680 %681
-OpStore %544 %682
-%683 = OpLoad %ulong %543
-%684 = OpLoad %float %544
-%685 = OpFunctionCall %ulong %9 %683 %684
-OpStore %545 %685
-%686 = OpLoad %float %461
-%687 = OpLoad %float %472
-%688 = OpFMul %float %686 %687
-OpStore %546 %688
-%689 = OpLoad %ulong %545
-%690 = OpLoad %float %546
-%691 = OpFunctionCall %ulong %9 %689 %690
-OpStore %547 %691
-OpBranch %385
-%385 = OpLabel
-OpBranch %388
-%388 = OpLabel
-%692 = OpLoad %ulong %547
-%693 = OpBitwiseAnd %ulong %692 %ulong_4095
-OpStore %552 %693
-%694 = OpLoad %ulong %552
-%695 = OpConvertUToF %float %694
-OpStore %553 %695
-%696 = OpLoad %float %553
-%697 = OpFSub %float %696 %float_2048
-OpStore %554 %697
-%698 = OpLoad %float %554
-%699 = OpFDiv %float %698 %float_8
-OpStore %555 %699
-OpBranch %389
-%389 = OpLabel
-%701 = OpAccessChain %_ptr_Function_double %406 %uint_0
-%702 = OpLoad %double %701
-OpStore %474 %702
-%704 = OpAccessChain %_ptr_Function_float %403 %uint_1
-%705 = OpLoad %float %704
-OpStore %475 %705
-%707 = OpAccessChain %_ptr_Function_double %406 %uint_2
-%708 = OpLoad %double %707
-OpStore %476 %708
-%710 = OpAccessChain %_ptr_Function_float %403 %uint_3
-%711 = OpLoad %float %710
-OpStore %477 %711
-%712 = OpAccessChain %_ptr_Function_double %406 %uint_4
-%713 = OpLoad %double %712
-OpStore %478 %713
-%714 = OpAccessChain %_ptr_Function_float %403 %uint_5
-%715 = OpLoad %float %714
-OpStore %479 %715
-%716 = OpAccessChain %_ptr_Function_double %406 %uint_6
-%717 = OpLoad %double %716
-OpStore %480 %717
-OpBranch %390
-%390 = OpLabel
-%718 = OpLoad %ulong %493
-%719 = OpBitwiseAnd %ulong %718 %ulong_4095
-OpStore %556 %719
-%720 = OpLoad %ulong %556
-%721 = OpConvertUToF %float %720
-OpStore %557 %721
-%722 = OpLoad %float %557
-%723 = OpFSub %float %722 %float_2048
-OpStore %558 %723
-%724 = OpLoad %float %558
-%725 = OpFDiv %float %724 %float_8
-OpStore %559 %725
-OpBranch %391
-%391 = OpLabel
-%726 = OpAccessChain %_ptr_Function_double %406 %uint_8
-%727 = OpLoad %double %726
-OpStore %481 %727
-%728 = OpAccessChain %_ptr_Function_float %403 %uint_9
-%729 = OpLoad %float %728
-OpStore %482 %729
-%730 = OpAccessChain %_ptr_Function_double %406 %uint_10
-%731 = OpLoad %double %730
-OpStore %483 %731
-%732 = OpAccessChain %_ptr_Function_float %403 %uint_11
-%733 = OpLoad %float %732
-OpStore %484 %733
-%734 = OpAccessChain %_ptr_Function_double %406 %uint_12
-%735 = OpLoad %double %734
-OpStore %485 %735
-%736 = OpAccessChain %_ptr_Function_float %403 %uint_13
-%737 = OpLoad %float %736
-OpStore %486 %737
-%738 = OpAccessChain %_ptr_Function_double %406 %uint_14
-%739 = OpLoad %double %738
-OpStore %487 %739
-%740 = OpLoad %float %555
-%741 = OpLoad %double %474
-%742 = OpLoad %float %475
-%743 = OpLoad %double %476
-%744 = OpLoad %float %477
-%745 = OpLoad %double %478
-%746 = OpLoad %float %479
-%747 = OpLoad %double %480
-%748 = OpLoad %float %559
-%749 = OpLoad %double %481
-%750 = OpLoad %float %482
-%751 = OpLoad %double %483
-%752 = OpLoad %float %484
-%753 = OpLoad %double %485
-%754 = OpLoad %float %486
-%755 = OpLoad %double %487
-%756 = OpFunctionCall %ulong %4 %740 %741 %742 %743 %744 %745 %746 %747 %748 %749 %750 %751 %752 %753 %754 %755
-OpStore %488 %756
-%757 = OpLoad %ulong %490
-%758 = OpLoad %ulong %488
-%759 = OpFunctionCall %ulong %8 %757 %758
-OpStore %489 %759
-%760 = OpLoad %ulong %489
-OpReturnValue %760
-%376 = OpLabel
-%761 = OpLoad %ulong %494
-%762 = OpBitwiseAnd %ulong %761 %ulong_3
-OpStore %417 %762
-%763 = OpLoad %ulong %417
-%764 = OpConvertUToF %float %763
-OpStore %418 %764
-%765 = OpLoad %float %418
-%767 = OpFDiv %float %765 %float_4
-OpStore %419 %767
-%768 = OpAccessChain %_ptr_Function_float %403 %uint_0
-%769 = OpLoad %float %768
-OpStore %420 %769
-%770 = OpLoad %float %420
-%771 = OpLoad %float %419
-%772 = OpFAdd %float %770 %771
-OpStore %421 %772
-%773 = OpAccessChain %_ptr_Function_double %406 %uint_1
-%774 = OpLoad %double %773
-OpStore %422 %774
-%775 = OpAccessChain %_ptr_Function_float %403 %uint_2
-%776 = OpLoad %float %775
-OpStore %423 %776
-%777 = OpAccessChain %_ptr_Function_double %406 %uint_3
-%778 = OpLoad %double %777
-OpStore %424 %778
-%779 = OpAccessChain %_ptr_Function_float %403 %uint_4
-%780 = OpLoad %float %779
-OpStore %425 %780
-%781 = OpAccessChain %_ptr_Function_double %406 %uint_5
-%782 = OpLoad %double %781
-OpStore %426 %782
-%783 = OpAccessChain %_ptr_Function_float %403 %uint_6
-%784 = OpLoad %float %783
-OpStore %427 %784
-%785 = OpAccessChain %_ptr_Function_double %406 %uint_7
-%786 = OpLoad %double %785
-OpStore %428 %786
-%787 = OpAccessChain %_ptr_Function_float %403 %uint_8
-%788 = OpLoad %float %787
-OpStore %429 %788
-%789 = OpAccessChain %_ptr_Function_double %406 %uint_9
-%790 = OpLoad %double %789
-OpStore %430 %790
-%791 = OpAccessChain %_ptr_Function_float %403 %uint_10
-%792 = OpLoad %float %791
-OpStore %431 %792
-%793 = OpAccessChain %_ptr_Function_double %406 %uint_11
-%794 = OpLoad %double %793
-OpStore %432 %794
-%795 = OpAccessChain %_ptr_Function_float %403 %uint_12
-%796 = OpLoad %float %795
-OpStore %433 %796
-%797 = OpAccessChain %_ptr_Function_double %406 %uint_13
-%798 = OpLoad %double %797
-OpStore %434 %798
-%799 = OpAccessChain %_ptr_Function_float %403 %uint_14
-%800 = OpLoad %float %799
-OpStore %435 %800
-%801 = OpAccessChain %_ptr_Function_double %406 %uint_15
-%802 = OpLoad %double %801
-OpStore %436 %802
-%803 = OpLoad %float %421
-%804 = OpLoad %double %422
-%805 = OpLoad %float %423
-%806 = OpLoad %double %424
-%807 = OpLoad %float %425
-%808 = OpLoad %double %426
-%809 = OpLoad %float %427
-%810 = OpLoad %double %428
-%811 = OpLoad %float %429
-%812 = OpLoad %double %430
-%813 = OpLoad %float %431
-%814 = OpLoad %double %432
-%815 = OpLoad %float %433
-%816 = OpLoad %double %434
-%817 = OpLoad %float %435
-%818 = OpLoad %double %436
-%819 = OpFunctionCall %ulong %4 %803 %804 %805 %806 %807 %808 %809 %810 %811 %812 %813 %814 %815 %816 %817 %818
-OpStore %437 %819
-%820 = OpLoad %ulong %490
-%821 = OpLoad %ulong %437
-%822 = OpFunctionCall %ulong %8 %820 %821
-OpStore %438 %822
-%823 = OpLoad %float %768
-OpStore %439 %823
-%824 = OpAccessChain %_ptr_Function_float %403 %uint_1
-%825 = OpLoad %float %824
-OpStore %440 %825
-%826 = OpLoad %float %775
-OpStore %441 %826
-%827 = OpAccessChain %_ptr_Function_float %403 %uint_3
-%828 = OpLoad %float %827
-OpStore %442 %828
-%829 = OpLoad %float %779
-OpStore %443 %829
-%830 = OpAccessChain %_ptr_Function_float %403 %uint_5
-%831 = OpLoad %float %830
-OpStore %444 %831
-%832 = OpLoad %float %783
-OpStore %445 %832
-%833 = OpAccessChain %_ptr_Function_float %403 %uint_7
-%834 = OpLoad %float %833
-OpStore %446 %834
-%835 = OpLoad %float %787
-OpStore %447 %835
-%836 = OpAccessChain %_ptr_Function_float %403 %uint_9
-%837 = OpLoad %float %836
-OpStore %448 %837
-%838 = OpLoad %float %791
-OpStore %449 %838
-%839 = OpAccessChain %_ptr_Function_float %403 %uint_11
-%840 = OpLoad %float %839
-OpStore %450 %840
-%841 = OpLoad %float %795
-OpStore %451 %841
-%842 = OpAccessChain %_ptr_Function_float %403 %uint_13
-%843 = OpLoad %float %842
-OpStore %452 %843
-%844 = OpLoad %float %799
-OpStore %453 %844
-%845 = OpAccessChain %_ptr_Function_float %403 %uint_15
-%846 = OpLoad %float %845
-OpStore %454 %846
-%847 = OpLoad %float %454
-%848 = OpLoad %float %419
-%849 = OpFAdd %float %847 %848
-OpStore %455 %849
-OpBranch %382
-%382 = OpLabel
-%850 = OpFunctionCall %ulong %7
-OpStore %502 %850
-%851 = OpLoad %ulong %502
-%852 = OpLoad %float %439
-%853 = OpFunctionCall %ulong %9 %851 %852
-OpStore %503 %853
-%854 = OpLoad %ulong %503
-%855 = OpLoad %float %440
-%856 = OpFunctionCall %ulong %9 %854 %855
-OpStore %504 %856
-%857 = OpLoad %ulong %504
-%858 = OpLoad %float %441
-%859 = OpFunctionCall %ulong %9 %857 %858
-OpStore %505 %859
-%860 = OpLoad %ulong %505
-%861 = OpLoad %float %442
-%862 = OpFunctionCall %ulong %9 %860 %861
-OpStore %506 %862
-%863 = OpLoad %ulong %506
-%864 = OpLoad %float %443
-%865 = OpFunctionCall %ulong %9 %863 %864
-OpStore %507 %865
-%866 = OpLoad %ulong %507
-%867 = OpLoad %float %444
-%868 = OpFunctionCall %ulong %9 %866 %867
-OpStore %508 %868
-%869 = OpLoad %ulong %508
-%870 = OpLoad %float %445
-%871 = OpFunctionCall %ulong %9 %869 %870
-OpStore %509 %871
-%872 = OpLoad %ulong %509
-%873 = OpLoad %float %446
-%874 = OpFunctionCall %ulong %9 %872 %873
-OpStore %510 %874
-%875 = OpLoad %ulong %510
-%876 = OpLoad %float %447
-%877 = OpFunctionCall %ulong %9 %875 %876
-OpStore %511 %877
-%878 = OpLoad %ulong %511
-%879 = OpLoad %float %448
-%880 = OpFunctionCall %ulong %9 %878 %879
-OpStore %512 %880
-%881 = OpLoad %ulong %512
-%882 = OpLoad %float %449
-%883 = OpFunctionCall %ulong %9 %881 %882
-OpStore %513 %883
-%884 = OpLoad %ulong %513
-%885 = OpLoad %float %450
-%886 = OpFunctionCall %ulong %9 %884 %885
-OpStore %514 %886
-%887 = OpLoad %ulong %514
-%888 = OpLoad %float %451
-%889 = OpFunctionCall %ulong %9 %887 %888
-OpStore %515 %889
-%890 = OpLoad %ulong %515
-%891 = OpLoad %float %452
-%892 = OpFunctionCall %ulong %9 %890 %891
-OpStore %516 %892
-%893 = OpLoad %ulong %516
-%894 = OpLoad %float %453
-%895 = OpFunctionCall %ulong %9 %893 %894
-OpStore %517 %895
-%896 = OpLoad %ulong %517
-%897 = OpLoad %float %455
-%898 = OpFunctionCall %ulong %9 %896 %897
-OpStore %518 %898
-%899 = OpLoad %float %439
-%900 = OpLoad %float %455
-%901 = OpFAdd %float %899 %900
-OpStore %519 %901
-%902 = OpLoad %ulong %518
-%903 = OpLoad %float %519
-%904 = OpFunctionCall %ulong %9 %902 %903
-OpStore %520 %904
-%905 = OpLoad %float %446
-%906 = OpLoad %float %451
-%907 = OpFSub %float %905 %906
-OpStore %521 %907
-%908 = OpLoad %ulong %520
-%909 = OpLoad %float %521
-%910 = OpFunctionCall %ulong %9 %908 %909
-OpStore %522 %910
-%911 = OpLoad %float %442
-%912 = OpLoad %float %453
-%913 = OpFMul %float %911 %912
-OpStore %523 %913
-%914 = OpLoad %ulong %522
-%915 = OpLoad %float %523
-%916 = OpFunctionCall %ulong %9 %914 %915
-OpStore %524 %916
-OpBranch %383
-%383 = OpLabel
-%917 = OpLoad %ulong %438
-%918 = OpLoad %ulong %524
-%919 = OpFunctionCall %ulong %8 %917 %918
-OpStore %456 %919
-%920 = OpLoad %ulong %494
-%922 = OpIAdd %ulong %920 %ulong_1
-OpStore %457 %922
-%923 = OpLoad %ulong %456
-OpStore %490 %923
-%924 = OpLoad %ulong %524
-OpStore %493 %924
-%925 = OpLoad %ulong %457
-OpStore %494 %925
-OpBranch %392
-%373 = OpLabel
-%926 = OpLoad %ulong %491
-%927 = OpAccessChain %_ptr_Function_ulong %400 %926
-%928 = OpLoad %ulong %927
-OpStore %413 %928
-OpBranch %380
-%380 = OpLabel
-%929 = OpLoad %ulong %413
-%930 = OpBitwiseAnd %ulong %929 %ulong_4095
-OpStore %498 %930
-%931 = OpLoad %ulong %498
-%932 = OpConvertUToF %float %931
-OpStore %499 %932
-%933 = OpLoad %float %499
-%934 = OpFSub %float %933 %float_2048
-OpStore %500 %934
-%935 = OpLoad %float %500
-%936 = OpFDiv %float %935 %float_8
-OpStore %501 %936
-OpBranch %381
-%381 = OpLabel
-%937 = OpLoad %ulong %491
-%938 = OpAccessChain %_ptr_Function_float %403 %937
-%939 = OpLoad %float %501
-OpStore %938 %939
-%940 = OpLoad %ulong %491
-%941 = OpAccessChain %_ptr_Function_ulong %400 %940
-%942 = OpLoad %ulong %941
-OpStore %414 %942
-OpBranch %386
-%386 = OpLabel
-%943 = OpLoad %ulong %414
-%944 = OpBitwiseAnd %ulong %943 %ulong_1048575
-OpStore %548 %944
-%945 = OpLoad %ulong %548
-%946 = OpConvertUToF %double %945
-OpStore %549 %946
-%947 = OpLoad %double %549
-%948 = OpFSub %double %947 %double_524288
-OpStore %550 %948
-%949 = OpLoad %double %550
-%950 = OpFDiv %double %949 %double_64
-OpStore %551 %950
-OpBranch %387
-%387 = OpLabel
-%951 = OpLoad %ulong %491
-%952 = OpAccessChain %_ptr_Function_double %406 %951
-%953 = OpLoad %double %551
-OpStore %952 %953
-%954 = OpLoad %ulong %491
-%955 = OpIAdd %ulong %954 %ulong_1
-OpStore %415 %955
-%956 = OpLoad %ulong %415
-OpStore %491 %956
-OpBranch %393
-%370 = OpLabel
-OpBranch %378
-%378 = OpLabel
-%957 = OpLoad %ulong %492
-%958 = OpIMul %ulong %957 %ulong_6364136223846793005
-OpStore %495 %958
-%959 = OpLoad %ulong %495
-%960 = OpIAdd %ulong %959 %ulong_1442695040888963407
-OpStore %496 %960
-%961 = OpLoad %ulong %496
-%962 = OpLoad %ulong %407
-%963 = OpIAdd %ulong %961 %962
-OpStore %497 %963
-OpBranch %379
-%379 = OpLabel
-%964 = OpLoad %ulong %492
-%965 = OpAccessChain %_ptr_Function_ulong %400 %964
-%966 = OpLoad %ulong %497
-OpStore %965 %966
-%967 = OpLoad %ulong %492
-%968 = OpIAdd %ulong %967 %ulong_1
-OpStore %411 %968
-%969 = OpLoad %ulong %411
-OpStore %492 %969
-OpBranch %394
-%392 = OpLabel
-OpBranch %375
-%393 = OpLabel
-OpBranch %372
-%394 = OpLabel
-OpBranch %369
+%439 = OpVariable %_ptr_Function_ulong Function
+OpStore %232 %75
+OpStore %233 %76
+OpStore %234 %77
+OpStore %235 %78
+OpStore %236 %79
+OpStore %237 %80
+OpStore %238 %81
+OpStore %239 %82
+OpStore %240 %83
+OpStore %241 %84
+OpStore %242 %85
+OpStore %243 %86
+OpStore %244 %87
+OpStore %245 %88
+OpStore %246 %89
+OpStore %247 %90
+OpBranch %92
+%92 = OpLabel
+OpBranch %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%440 = OpLoad %float %232
+%441 = OpBitcast %uint %440
+OpStore %261 %441
+%442 = OpLoad %uint %261
+%443 = OpUConvert %ulong %442
+OpStore %262 %443
+OpBranch %96
+%96 = OpLabel
+OpStore %271 %ulong_14695981039346656037
+OpStore %272 %ulong_0
+OpBranch %97
+%97 = OpLabel
+%446 = OpLoad %ulong %272
+%448 = OpULessThan %bool %446 %ulong_8
+OpStore %264 %448
+%449 = OpLoad %bool %264
+OpLoopMerge %99 %229 None
+OpBranchConditional %449 %98 %99
+%99 = OpLabel
+OpBranch %100
+%100 = OpLabel
+OpBranch %95
+%95 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%450 = OpLoad %double %233
+%451 = OpBitcast %ulong %450
+OpStore %273 %451
+OpBranch %103
+%103 = OpLabel
+%452 = OpLoad %ulong %271
+OpStore %281 %452
+OpStore %282 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%453 = OpLoad %ulong %282
+%454 = OpULessThan %bool %453 %ulong_8
+OpStore %274 %454
+%455 = OpLoad %bool %274
+OpLoopMerge %106 %228 None
+OpBranchConditional %455 %105 %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+OpBranch %102
+%102 = OpLabel
+OpBranch %108
+%108 = OpLabel
+%456 = OpLoad %float %234
+%457 = OpBitcast %uint %456
+OpStore %283 %457
+%458 = OpLoad %uint %283
+%459 = OpUConvert %ulong %458
+OpStore %284 %459
+OpBranch %110
+%110 = OpLabel
+%460 = OpLoad %ulong %281
+OpStore %292 %460
+OpStore %293 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%461 = OpLoad %ulong %293
+%462 = OpULessThan %bool %461 %ulong_8
+OpStore %285 %462
+%463 = OpLoad %bool %285
+OpLoopMerge %113 %227 None
+OpBranchConditional %463 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %115
+%115 = OpLabel
+%464 = OpLoad %double %235
+%465 = OpBitcast %ulong %464
+OpStore %294 %465
+OpBranch %117
+%117 = OpLabel
+%466 = OpLoad %ulong %292
+OpStore %302 %466
+OpStore %303 %ulong_0
+OpBranch %118
+%118 = OpLabel
+%467 = OpLoad %ulong %303
+%468 = OpULessThan %bool %467 %ulong_8
+OpStore %295 %468
+%469 = OpLoad %bool %295
+OpLoopMerge %120 %226 None
+OpBranchConditional %469 %119 %120
+%120 = OpLabel
+OpBranch %121
+%121 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %122
+%122 = OpLabel
+%470 = OpLoad %float %236
+%471 = OpBitcast %uint %470
+OpStore %304 %471
+%472 = OpLoad %uint %304
+%473 = OpUConvert %ulong %472
+OpStore %305 %473
+OpBranch %124
+%124 = OpLabel
+%474 = OpLoad %ulong %302
+OpStore %313 %474
+OpStore %314 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%475 = OpLoad %ulong %314
+%476 = OpULessThan %bool %475 %ulong_8
+OpStore %306 %476
+%477 = OpLoad %bool %306
+OpLoopMerge %127 %225 None
+OpBranchConditional %477 %126 %127
+%127 = OpLabel
+OpBranch %128
+%128 = OpLabel
+OpBranch %123
+%123 = OpLabel
+OpBranch %129
+%129 = OpLabel
+%478 = OpLoad %double %237
+%479 = OpBitcast %ulong %478
+OpStore %315 %479
+OpBranch %131
+%131 = OpLabel
+%480 = OpLoad %ulong %313
+OpStore %323 %480
+OpStore %324 %ulong_0
+OpBranch %132
+%132 = OpLabel
+%481 = OpLoad %ulong %324
+%482 = OpULessThan %bool %481 %ulong_8
+OpStore %316 %482
+%483 = OpLoad %bool %316
+OpLoopMerge %134 %224 None
+OpBranchConditional %483 %133 %134
+%134 = OpLabel
+OpBranch %135
+%135 = OpLabel
+OpBranch %130
+%130 = OpLabel
+OpBranch %136
+%136 = OpLabel
+%484 = OpLoad %float %238
+%485 = OpBitcast %uint %484
+OpStore %325 %485
+%486 = OpLoad %uint %325
+%487 = OpUConvert %ulong %486
+OpStore %326 %487
+OpBranch %138
+%138 = OpLabel
+%488 = OpLoad %ulong %323
+OpStore %334 %488
+OpStore %335 %ulong_0
+OpBranch %139
+%139 = OpLabel
+%489 = OpLoad %ulong %335
+%490 = OpULessThan %bool %489 %ulong_8
+OpStore %327 %490
+%491 = OpLoad %bool %327
+OpLoopMerge %141 %223 None
+OpBranchConditional %491 %140 %141
+%141 = OpLabel
+OpBranch %142
+%142 = OpLabel
+OpBranch %137
+%137 = OpLabel
+OpBranch %143
+%143 = OpLabel
+%492 = OpLoad %double %239
+%493 = OpBitcast %ulong %492
+OpStore %336 %493
+OpBranch %145
+%145 = OpLabel
+%494 = OpLoad %ulong %334
+OpStore %344 %494
+OpStore %345 %ulong_0
+OpBranch %146
+%146 = OpLabel
+%495 = OpLoad %ulong %345
+%496 = OpULessThan %bool %495 %ulong_8
+OpStore %337 %496
+%497 = OpLoad %bool %337
+OpLoopMerge %148 %222 None
+OpBranchConditional %497 %147 %148
+%148 = OpLabel
+OpBranch %149
+%149 = OpLabel
+OpBranch %144
+%144 = OpLabel
+OpBranch %150
+%150 = OpLabel
+%498 = OpLoad %float %240
+%499 = OpBitcast %uint %498
+OpStore %346 %499
+%500 = OpLoad %uint %346
+%501 = OpUConvert %ulong %500
+OpStore %347 %501
+OpBranch %152
+%152 = OpLabel
+%502 = OpLoad %ulong %344
+OpStore %355 %502
+OpStore %356 %ulong_0
+OpBranch %153
+%153 = OpLabel
+%503 = OpLoad %ulong %356
+%504 = OpULessThan %bool %503 %ulong_8
+OpStore %348 %504
+%505 = OpLoad %bool %348
+OpLoopMerge %155 %221 None
+OpBranchConditional %505 %154 %155
+%155 = OpLabel
+OpBranch %156
+%156 = OpLabel
+OpBranch %151
+%151 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%506 = OpLoad %double %241
+%507 = OpBitcast %ulong %506
+OpStore %357 %507
+OpBranch %159
+%159 = OpLabel
+%508 = OpLoad %ulong %355
+OpStore %365 %508
+OpStore %366 %ulong_0
+OpBranch %160
+%160 = OpLabel
+%509 = OpLoad %ulong %366
+%510 = OpULessThan %bool %509 %ulong_8
+OpStore %358 %510
+%511 = OpLoad %bool %358
+OpLoopMerge %162 %220 None
+OpBranchConditional %511 %161 %162
+%162 = OpLabel
+OpBranch %163
+%163 = OpLabel
+OpBranch %158
+%158 = OpLabel
+OpBranch %164
+%164 = OpLabel
+%512 = OpLoad %float %242
+%513 = OpBitcast %uint %512
+OpStore %367 %513
+%514 = OpLoad %uint %367
+%515 = OpUConvert %ulong %514
+OpStore %368 %515
+OpBranch %166
+%166 = OpLabel
+%516 = OpLoad %ulong %365
+OpStore %376 %516
+OpStore %377 %ulong_0
+OpBranch %167
+%167 = OpLabel
+%517 = OpLoad %ulong %377
+%518 = OpULessThan %bool %517 %ulong_8
+OpStore %369 %518
+%519 = OpLoad %bool %369
+OpLoopMerge %169 %219 None
+OpBranchConditional %519 %168 %169
+%169 = OpLabel
+OpBranch %170
+%170 = OpLabel
+OpBranch %165
+%165 = OpLabel
+OpBranch %171
+%171 = OpLabel
+%520 = OpLoad %double %243
+%521 = OpBitcast %ulong %520
+OpStore %378 %521
+OpBranch %173
+%173 = OpLabel
+%522 = OpLoad %ulong %376
+OpStore %386 %522
+OpStore %387 %ulong_0
+OpBranch %174
+%174 = OpLabel
+%523 = OpLoad %ulong %387
+%524 = OpULessThan %bool %523 %ulong_8
+OpStore %379 %524
+%525 = OpLoad %bool %379
+OpLoopMerge %176 %218 None
+OpBranchConditional %525 %175 %176
+%176 = OpLabel
+OpBranch %177
+%177 = OpLabel
+OpBranch %172
+%172 = OpLabel
+OpBranch %178
+%178 = OpLabel
+%526 = OpLoad %float %244
+%527 = OpBitcast %uint %526
+OpStore %388 %527
+%528 = OpLoad %uint %388
+%529 = OpUConvert %ulong %528
+OpStore %389 %529
+OpBranch %180
+%180 = OpLabel
+%530 = OpLoad %ulong %386
+OpStore %397 %530
+OpStore %398 %ulong_0
+OpBranch %181
+%181 = OpLabel
+%531 = OpLoad %ulong %398
+%532 = OpULessThan %bool %531 %ulong_8
+OpStore %390 %532
+%533 = OpLoad %bool %390
+OpLoopMerge %183 %217 None
+OpBranchConditional %533 %182 %183
+%183 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %179
+%179 = OpLabel
+OpBranch %185
+%185 = OpLabel
+%534 = OpLoad %double %245
+%535 = OpBitcast %ulong %534
+OpStore %399 %535
+OpBranch %187
+%187 = OpLabel
+%536 = OpLoad %ulong %397
+OpStore %407 %536
+OpStore %408 %ulong_0
+OpBranch %188
+%188 = OpLabel
+%537 = OpLoad %ulong %408
+%538 = OpULessThan %bool %537 %ulong_8
+OpStore %400 %538
+%539 = OpLoad %bool %400
+OpLoopMerge %190 %216 None
+OpBranchConditional %539 %189 %190
+%190 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %186
+%186 = OpLabel
+OpBranch %192
+%192 = OpLabel
+%540 = OpLoad %float %246
+%541 = OpBitcast %uint %540
+OpStore %409 %541
+%542 = OpLoad %uint %409
+%543 = OpUConvert %ulong %542
+OpStore %410 %543
+OpBranch %194
+%194 = OpLabel
+%544 = OpLoad %ulong %407
+OpStore %418 %544
+OpStore %419 %ulong_0
+OpBranch %195
+%195 = OpLabel
+%545 = OpLoad %ulong %419
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %411 %546
+%547 = OpLoad %bool %411
+OpLoopMerge %197 %215 None
+OpBranchConditional %547 %196 %197
+%197 = OpLabel
+OpBranch %198
+%198 = OpLabel
+OpBranch %193
+%193 = OpLabel
+OpBranch %199
+%199 = OpLabel
+%548 = OpLoad %double %247
+%549 = OpBitcast %ulong %548
+OpStore %420 %549
+OpBranch %201
+%201 = OpLabel
+%550 = OpLoad %ulong %418
+OpStore %428 %550
+OpStore %429 %ulong_0
+OpBranch %202
+%202 = OpLabel
+%551 = OpLoad %ulong %429
+%552 = OpULessThan %bool %551 %ulong_8
+OpStore %421 %552
+%553 = OpLoad %bool %421
+OpLoopMerge %204 %214 None
+OpBranchConditional %553 %203 %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+OpBranch %200
+%200 = OpLabel
+%554 = OpLoad %float %234
+%555 = OpLoad %float %236
+%556 = OpFMul %float %554 %555
+OpStore %248 %556
+%557 = OpLoad %float %232
+%558 = OpLoad %float %248
+%559 = OpFAdd %float %557 %558
+OpStore %249 %559
+%560 = OpLoad %float %249
+%561 = OpLoad %float %238
+%562 = OpFSub %float %560 %561
+OpStore %250 %562
+OpBranch %206
+%206 = OpLabel
+%563 = OpLoad %float %250
+%564 = OpBitcast %uint %563
+OpStore %430 %564
+%565 = OpLoad %uint %430
+%566 = OpUConvert %ulong %565
+OpStore %431 %566
+%567 = OpLoad %ulong %428
+%568 = OpLoad %ulong %431
+%569 = OpFunctionCall %ulong %7 %567 %568
+OpStore %432 %569
+OpBranch %207
+%207 = OpLabel
+%570 = OpLoad %double %235
+%571 = OpLoad %double %237
+%572 = OpFMul %double %570 %571
+OpStore %251 %572
+%573 = OpLoad %double %233
+%574 = OpLoad %double %251
+%575 = OpFAdd %double %573 %574
+OpStore %252 %575
+%576 = OpLoad %double %252
+%577 = OpLoad %double %239
+%578 = OpFSub %double %576 %577
+OpStore %253 %578
+OpBranch %208
+%208 = OpLabel
+%579 = OpLoad %double %253
+%580 = OpBitcast %ulong %579
+OpStore %433 %580
+%581 = OpLoad %ulong %432
+%582 = OpLoad %ulong %433
+%583 = OpFunctionCall %ulong %7 %581 %582
+OpStore %434 %583
+OpBranch %209
+%209 = OpLabel
+%584 = OpLoad %float %240
+%585 = OpLoad %float %242
+%586 = OpFSub %float %584 %585
+OpStore %254 %586
+%587 = OpLoad %float %244
+%588 = OpLoad %float %246
+%589 = OpFMul %float %587 %588
+OpStore %255 %589
+%590 = OpLoad %float %254
+%591 = OpLoad %float %255
+%592 = OpFAdd %float %590 %591
+OpStore %256 %592
+OpBranch %210
+%210 = OpLabel
+%593 = OpLoad %float %256
+%594 = OpBitcast %uint %593
+OpStore %435 %594
+%595 = OpLoad %uint %435
+%596 = OpUConvert %ulong %595
+OpStore %436 %596
+%597 = OpLoad %ulong %434
+%598 = OpLoad %ulong %436
+%599 = OpFunctionCall %ulong %7 %597 %598
+OpStore %437 %599
+OpBranch %211
+%211 = OpLabel
+%600 = OpLoad %double %241
+%601 = OpLoad %double %243
+%602 = OpFSub %double %600 %601
+OpStore %257 %602
+%603 = OpLoad %double %245
+%604 = OpLoad %double %247
+%605 = OpFMul %double %603 %604
+OpStore %258 %605
+%606 = OpLoad %double %257
+%607 = OpLoad %double %258
+%608 = OpFAdd %double %606 %607
+OpStore %259 %608
+OpBranch %212
+%212 = OpLabel
+%609 = OpLoad %double %259
+%610 = OpBitcast %ulong %609
+OpStore %438 %610
+%611 = OpLoad %ulong %437
+%612 = OpLoad %ulong %438
+%613 = OpFunctionCall %ulong %7 %611 %612
+OpStore %439 %613
+OpBranch %213
+%213 = OpLabel
+%614 = OpLoad %ulong %439
+OpReturnValue %614
+%203 = OpLabel
+%615 = OpLoad %ulong %429
+%616 = OpIMul %ulong %615 %ulong_8
+OpStore %422 %616
+%617 = OpLoad %ulong %420
+%618 = OpLoad %ulong %422
+%619 = OpShiftRightLogical %ulong %617 %618
+OpStore %423 %619
+%620 = OpLoad %ulong %423
+%622 = OpBitwiseAnd %ulong %620 %ulong_255
+OpStore %424 %622
+%623 = OpLoad %ulong %428
+%624 = OpLoad %ulong %424
+%625 = OpBitwiseXor %ulong %623 %624
+OpStore %425 %625
+%626 = OpLoad %ulong %425
+%628 = OpIMul %ulong %626 %ulong_1099511628211
+OpStore %426 %628
+%629 = OpLoad %ulong %429
+%631 = OpIAdd %ulong %629 %ulong_1
+OpStore %427 %631
+%632 = OpLoad %ulong %426
+OpStore %428 %632
+%633 = OpLoad %ulong %427
+OpStore %429 %633
+OpBranch %214
+%196 = OpLabel
+%634 = OpLoad %ulong %419
+%635 = OpIMul %ulong %634 %ulong_8
+OpStore %412 %635
+%636 = OpLoad %ulong %410
+%637 = OpLoad %ulong %412
+%638 = OpShiftRightLogical %ulong %636 %637
+OpStore %413 %638
+%639 = OpLoad %ulong %413
+%640 = OpBitwiseAnd %ulong %639 %ulong_255
+OpStore %414 %640
+%641 = OpLoad %ulong %418
+%642 = OpLoad %ulong %414
+%643 = OpBitwiseXor %ulong %641 %642
+OpStore %415 %643
+%644 = OpLoad %ulong %415
+%645 = OpIMul %ulong %644 %ulong_1099511628211
+OpStore %416 %645
+%646 = OpLoad %ulong %419
+%647 = OpIAdd %ulong %646 %ulong_1
+OpStore %417 %647
+%648 = OpLoad %ulong %416
+OpStore %418 %648
+%649 = OpLoad %ulong %417
+OpStore %419 %649
+OpBranch %215
+%189 = OpLabel
+%650 = OpLoad %ulong %408
+%651 = OpIMul %ulong %650 %ulong_8
+OpStore %401 %651
+%652 = OpLoad %ulong %399
+%653 = OpLoad %ulong %401
+%654 = OpShiftRightLogical %ulong %652 %653
+OpStore %402 %654
+%655 = OpLoad %ulong %402
+%656 = OpBitwiseAnd %ulong %655 %ulong_255
+OpStore %403 %656
+%657 = OpLoad %ulong %407
+%658 = OpLoad %ulong %403
+%659 = OpBitwiseXor %ulong %657 %658
+OpStore %404 %659
+%660 = OpLoad %ulong %404
+%661 = OpIMul %ulong %660 %ulong_1099511628211
+OpStore %405 %661
+%662 = OpLoad %ulong %408
+%663 = OpIAdd %ulong %662 %ulong_1
+OpStore %406 %663
+%664 = OpLoad %ulong %405
+OpStore %407 %664
+%665 = OpLoad %ulong %406
+OpStore %408 %665
+OpBranch %216
+%182 = OpLabel
+%666 = OpLoad %ulong %398
+%667 = OpIMul %ulong %666 %ulong_8
+OpStore %391 %667
+%668 = OpLoad %ulong %389
+%669 = OpLoad %ulong %391
+%670 = OpShiftRightLogical %ulong %668 %669
+OpStore %392 %670
+%671 = OpLoad %ulong %392
+%672 = OpBitwiseAnd %ulong %671 %ulong_255
+OpStore %393 %672
+%673 = OpLoad %ulong %397
+%674 = OpLoad %ulong %393
+%675 = OpBitwiseXor %ulong %673 %674
+OpStore %394 %675
+%676 = OpLoad %ulong %394
+%677 = OpIMul %ulong %676 %ulong_1099511628211
+OpStore %395 %677
+%678 = OpLoad %ulong %398
+%679 = OpIAdd %ulong %678 %ulong_1
+OpStore %396 %679
+%680 = OpLoad %ulong %395
+OpStore %397 %680
+%681 = OpLoad %ulong %396
+OpStore %398 %681
+OpBranch %217
+%175 = OpLabel
+%682 = OpLoad %ulong %387
+%683 = OpIMul %ulong %682 %ulong_8
+OpStore %380 %683
+%684 = OpLoad %ulong %378
+%685 = OpLoad %ulong %380
+%686 = OpShiftRightLogical %ulong %684 %685
+OpStore %381 %686
+%687 = OpLoad %ulong %381
+%688 = OpBitwiseAnd %ulong %687 %ulong_255
+OpStore %382 %688
+%689 = OpLoad %ulong %386
+%690 = OpLoad %ulong %382
+%691 = OpBitwiseXor %ulong %689 %690
+OpStore %383 %691
+%692 = OpLoad %ulong %383
+%693 = OpIMul %ulong %692 %ulong_1099511628211
+OpStore %384 %693
+%694 = OpLoad %ulong %387
+%695 = OpIAdd %ulong %694 %ulong_1
+OpStore %385 %695
+%696 = OpLoad %ulong %384
+OpStore %386 %696
+%697 = OpLoad %ulong %385
+OpStore %387 %697
+OpBranch %218
+%168 = OpLabel
+%698 = OpLoad %ulong %377
+%699 = OpIMul %ulong %698 %ulong_8
+OpStore %370 %699
+%700 = OpLoad %ulong %368
+%701 = OpLoad %ulong %370
+%702 = OpShiftRightLogical %ulong %700 %701
+OpStore %371 %702
+%703 = OpLoad %ulong %371
+%704 = OpBitwiseAnd %ulong %703 %ulong_255
+OpStore %372 %704
+%705 = OpLoad %ulong %376
+%706 = OpLoad %ulong %372
+%707 = OpBitwiseXor %ulong %705 %706
+OpStore %373 %707
+%708 = OpLoad %ulong %373
+%709 = OpIMul %ulong %708 %ulong_1099511628211
+OpStore %374 %709
+%710 = OpLoad %ulong %377
+%711 = OpIAdd %ulong %710 %ulong_1
+OpStore %375 %711
+%712 = OpLoad %ulong %374
+OpStore %376 %712
+%713 = OpLoad %ulong %375
+OpStore %377 %713
+OpBranch %219
+%161 = OpLabel
+%714 = OpLoad %ulong %366
+%715 = OpIMul %ulong %714 %ulong_8
+OpStore %359 %715
+%716 = OpLoad %ulong %357
+%717 = OpLoad %ulong %359
+%718 = OpShiftRightLogical %ulong %716 %717
+OpStore %360 %718
+%719 = OpLoad %ulong %360
+%720 = OpBitwiseAnd %ulong %719 %ulong_255
+OpStore %361 %720
+%721 = OpLoad %ulong %365
+%722 = OpLoad %ulong %361
+%723 = OpBitwiseXor %ulong %721 %722
+OpStore %362 %723
+%724 = OpLoad %ulong %362
+%725 = OpIMul %ulong %724 %ulong_1099511628211
+OpStore %363 %725
+%726 = OpLoad %ulong %366
+%727 = OpIAdd %ulong %726 %ulong_1
+OpStore %364 %727
+%728 = OpLoad %ulong %363
+OpStore %365 %728
+%729 = OpLoad %ulong %364
+OpStore %366 %729
+OpBranch %220
+%154 = OpLabel
+%730 = OpLoad %ulong %356
+%731 = OpIMul %ulong %730 %ulong_8
+OpStore %349 %731
+%732 = OpLoad %ulong %347
+%733 = OpLoad %ulong %349
+%734 = OpShiftRightLogical %ulong %732 %733
+OpStore %350 %734
+%735 = OpLoad %ulong %350
+%736 = OpBitwiseAnd %ulong %735 %ulong_255
+OpStore %351 %736
+%737 = OpLoad %ulong %355
+%738 = OpLoad %ulong %351
+%739 = OpBitwiseXor %ulong %737 %738
+OpStore %352 %739
+%740 = OpLoad %ulong %352
+%741 = OpIMul %ulong %740 %ulong_1099511628211
+OpStore %353 %741
+%742 = OpLoad %ulong %356
+%743 = OpIAdd %ulong %742 %ulong_1
+OpStore %354 %743
+%744 = OpLoad %ulong %353
+OpStore %355 %744
+%745 = OpLoad %ulong %354
+OpStore %356 %745
+OpBranch %221
+%147 = OpLabel
+%746 = OpLoad %ulong %345
+%747 = OpIMul %ulong %746 %ulong_8
+OpStore %338 %747
+%748 = OpLoad %ulong %336
+%749 = OpLoad %ulong %338
+%750 = OpShiftRightLogical %ulong %748 %749
+OpStore %339 %750
+%751 = OpLoad %ulong %339
+%752 = OpBitwiseAnd %ulong %751 %ulong_255
+OpStore %340 %752
+%753 = OpLoad %ulong %344
+%754 = OpLoad %ulong %340
+%755 = OpBitwiseXor %ulong %753 %754
+OpStore %341 %755
+%756 = OpLoad %ulong %341
+%757 = OpIMul %ulong %756 %ulong_1099511628211
+OpStore %342 %757
+%758 = OpLoad %ulong %345
+%759 = OpIAdd %ulong %758 %ulong_1
+OpStore %343 %759
+%760 = OpLoad %ulong %342
+OpStore %344 %760
+%761 = OpLoad %ulong %343
+OpStore %345 %761
+OpBranch %222
+%140 = OpLabel
+%762 = OpLoad %ulong %335
+%763 = OpIMul %ulong %762 %ulong_8
+OpStore %328 %763
+%764 = OpLoad %ulong %326
+%765 = OpLoad %ulong %328
+%766 = OpShiftRightLogical %ulong %764 %765
+OpStore %329 %766
+%767 = OpLoad %ulong %329
+%768 = OpBitwiseAnd %ulong %767 %ulong_255
+OpStore %330 %768
+%769 = OpLoad %ulong %334
+%770 = OpLoad %ulong %330
+%771 = OpBitwiseXor %ulong %769 %770
+OpStore %331 %771
+%772 = OpLoad %ulong %331
+%773 = OpIMul %ulong %772 %ulong_1099511628211
+OpStore %332 %773
+%774 = OpLoad %ulong %335
+%775 = OpIAdd %ulong %774 %ulong_1
+OpStore %333 %775
+%776 = OpLoad %ulong %332
+OpStore %334 %776
+%777 = OpLoad %ulong %333
+OpStore %335 %777
+OpBranch %223
+%133 = OpLabel
+%778 = OpLoad %ulong %324
+%779 = OpIMul %ulong %778 %ulong_8
+OpStore %317 %779
+%780 = OpLoad %ulong %315
+%781 = OpLoad %ulong %317
+%782 = OpShiftRightLogical %ulong %780 %781
+OpStore %318 %782
+%783 = OpLoad %ulong %318
+%784 = OpBitwiseAnd %ulong %783 %ulong_255
+OpStore %319 %784
+%785 = OpLoad %ulong %323
+%786 = OpLoad %ulong %319
+%787 = OpBitwiseXor %ulong %785 %786
+OpStore %320 %787
+%788 = OpLoad %ulong %320
+%789 = OpIMul %ulong %788 %ulong_1099511628211
+OpStore %321 %789
+%790 = OpLoad %ulong %324
+%791 = OpIAdd %ulong %790 %ulong_1
+OpStore %322 %791
+%792 = OpLoad %ulong %321
+OpStore %323 %792
+%793 = OpLoad %ulong %322
+OpStore %324 %793
+OpBranch %224
+%126 = OpLabel
+%794 = OpLoad %ulong %314
+%795 = OpIMul %ulong %794 %ulong_8
+OpStore %307 %795
+%796 = OpLoad %ulong %305
+%797 = OpLoad %ulong %307
+%798 = OpShiftRightLogical %ulong %796 %797
+OpStore %308 %798
+%799 = OpLoad %ulong %308
+%800 = OpBitwiseAnd %ulong %799 %ulong_255
+OpStore %309 %800
+%801 = OpLoad %ulong %313
+%802 = OpLoad %ulong %309
+%803 = OpBitwiseXor %ulong %801 %802
+OpStore %310 %803
+%804 = OpLoad %ulong %310
+%805 = OpIMul %ulong %804 %ulong_1099511628211
+OpStore %311 %805
+%806 = OpLoad %ulong %314
+%807 = OpIAdd %ulong %806 %ulong_1
+OpStore %312 %807
+%808 = OpLoad %ulong %311
+OpStore %313 %808
+%809 = OpLoad %ulong %312
+OpStore %314 %809
+OpBranch %225
+%119 = OpLabel
+%810 = OpLoad %ulong %303
+%811 = OpIMul %ulong %810 %ulong_8
+OpStore %296 %811
+%812 = OpLoad %ulong %294
+%813 = OpLoad %ulong %296
+%814 = OpShiftRightLogical %ulong %812 %813
+OpStore %297 %814
+%815 = OpLoad %ulong %297
+%816 = OpBitwiseAnd %ulong %815 %ulong_255
+OpStore %298 %816
+%817 = OpLoad %ulong %302
+%818 = OpLoad %ulong %298
+%819 = OpBitwiseXor %ulong %817 %818
+OpStore %299 %819
+%820 = OpLoad %ulong %299
+%821 = OpIMul %ulong %820 %ulong_1099511628211
+OpStore %300 %821
+%822 = OpLoad %ulong %303
+%823 = OpIAdd %ulong %822 %ulong_1
+OpStore %301 %823
+%824 = OpLoad %ulong %300
+OpStore %302 %824
+%825 = OpLoad %ulong %301
+OpStore %303 %825
+OpBranch %226
+%112 = OpLabel
+%826 = OpLoad %ulong %293
+%827 = OpIMul %ulong %826 %ulong_8
+OpStore %286 %827
+%828 = OpLoad %ulong %284
+%829 = OpLoad %ulong %286
+%830 = OpShiftRightLogical %ulong %828 %829
+OpStore %287 %830
+%831 = OpLoad %ulong %287
+%832 = OpBitwiseAnd %ulong %831 %ulong_255
+OpStore %288 %832
+%833 = OpLoad %ulong %292
+%834 = OpLoad %ulong %288
+%835 = OpBitwiseXor %ulong %833 %834
+OpStore %289 %835
+%836 = OpLoad %ulong %289
+%837 = OpIMul %ulong %836 %ulong_1099511628211
+OpStore %290 %837
+%838 = OpLoad %ulong %293
+%839 = OpIAdd %ulong %838 %ulong_1
+OpStore %291 %839
+%840 = OpLoad %ulong %290
+OpStore %292 %840
+%841 = OpLoad %ulong %291
+OpStore %293 %841
+OpBranch %227
+%105 = OpLabel
+%842 = OpLoad %ulong %282
+%843 = OpIMul %ulong %842 %ulong_8
+OpStore %275 %843
+%844 = OpLoad %ulong %273
+%845 = OpLoad %ulong %275
+%846 = OpShiftRightLogical %ulong %844 %845
+OpStore %276 %846
+%847 = OpLoad %ulong %276
+%848 = OpBitwiseAnd %ulong %847 %ulong_255
+OpStore %277 %848
+%849 = OpLoad %ulong %281
+%850 = OpLoad %ulong %277
+%851 = OpBitwiseXor %ulong %849 %850
+OpStore %278 %851
+%852 = OpLoad %ulong %278
+%853 = OpIMul %ulong %852 %ulong_1099511628211
+OpStore %279 %853
+%854 = OpLoad %ulong %282
+%855 = OpIAdd %ulong %854 %ulong_1
+OpStore %280 %855
+%856 = OpLoad %ulong %279
+OpStore %281 %856
+%857 = OpLoad %ulong %280
+OpStore %282 %857
+OpBranch %228
+%98 = OpLabel
+%858 = OpLoad %ulong %272
+%859 = OpIMul %ulong %858 %ulong_8
+OpStore %265 %859
+%860 = OpLoad %ulong %262
+%861 = OpLoad %ulong %265
+%862 = OpShiftRightLogical %ulong %860 %861
+OpStore %266 %862
+%863 = OpLoad %ulong %266
+%864 = OpBitwiseAnd %ulong %863 %ulong_255
+OpStore %267 %864
+%865 = OpLoad %ulong %271
+%866 = OpLoad %ulong %267
+%867 = OpBitwiseXor %ulong %865 %866
+OpStore %268 %867
+%868 = OpLoad %ulong %268
+%869 = OpIMul %ulong %868 %ulong_1099511628211
+OpStore %269 %869
+%870 = OpLoad %ulong %272
+%871 = OpIAdd %ulong %870 %ulong_1
+OpStore %270 %871
+%872 = OpLoad %ulong %269
+OpStore %271 %872
+%873 = OpLoad %ulong %270
+OpStore %272 %873
+OpBranch %229
+%214 = OpLabel
+OpBranch %202
+%215 = OpLabel
+OpBranch %195
+%216 = OpLabel
+OpBranch %188
+%217 = OpLabel
+OpBranch %181
+%218 = OpLabel
+OpBranch %174
+%219 = OpLabel
+OpBranch %167
+%220 = OpLabel
+OpBranch %160
+%221 = OpLabel
+OpBranch %153
+%222 = OpLabel
+OpBranch %146
+%223 = OpLabel
+OpBranch %139
+%224 = OpLabel
+OpBranch %132
+%225 = OpLabel
+OpBranch %125
+%226 = OpLabel
+OpBranch %118
+%227 = OpLabel
+OpBranch %111
+%228 = OpLabel
+OpBranch %104
+%229 = OpLabel
+OpBranch %97
 OpFunctionEnd
-%7 = OpFunction %ulong None %970
-%971 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%5 = OpFunction %ulong None %874
+%875 = OpFunctionParameter %float
+%876 = OpFunctionParameter %float
+%877 = OpFunctionParameter %float
+%878 = OpFunctionParameter %float
+%879 = OpFunctionParameter %float
+%880 = OpFunctionParameter %float
+%881 = OpFunctionParameter %float
+%882 = OpFunctionParameter %float
+%883 = OpFunctionParameter %float
+%884 = OpFunctionParameter %float
+%885 = OpFunctionParameter %float
+%886 = OpFunctionParameter %float
+%887 = OpFunctionParameter %float
+%888 = OpFunctionParameter %float
+%889 = OpFunctionParameter %float
+%890 = OpFunctionParameter %float
+%891 = OpLabel
+%906 = OpVariable %_ptr_Function_float Function
+%907 = OpVariable %_ptr_Function_float Function
+%908 = OpVariable %_ptr_Function_float Function
+%909 = OpVariable %_ptr_Function_float Function
+%910 = OpVariable %_ptr_Function_float Function
+%911 = OpVariable %_ptr_Function_float Function
+%912 = OpVariable %_ptr_Function_float Function
+%913 = OpVariable %_ptr_Function_float Function
+%914 = OpVariable %_ptr_Function_float Function
+%915 = OpVariable %_ptr_Function_float Function
+%916 = OpVariable %_ptr_Function_float Function
+%917 = OpVariable %_ptr_Function_float Function
+%918 = OpVariable %_ptr_Function_float Function
+%919 = OpVariable %_ptr_Function_float Function
+%920 = OpVariable %_ptr_Function_float Function
+%921 = OpVariable %_ptr_Function_float Function
+%922 = OpVariable %_ptr_Function_ulong Function
+%923 = OpVariable %_ptr_Function_ulong Function
+%924 = OpVariable %_ptr_Function_ulong Function
+%925 = OpVariable %_ptr_Function_ulong Function
+%926 = OpVariable %_ptr_Function_ulong Function
+%927 = OpVariable %_ptr_Function_ulong Function
+%928 = OpVariable %_ptr_Function_ulong Function
+%929 = OpVariable %_ptr_Function_ulong Function
+%930 = OpVariable %_ptr_Function_ulong Function
+%931 = OpVariable %_ptr_Function_ulong Function
+%932 = OpVariable %_ptr_Function_float Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_float Function
+%935 = OpVariable %_ptr_Function_ulong Function
+%936 = OpVariable %_ptr_Function_float Function
+%937 = OpVariable %_ptr_Function_ulong Function
+%938 = OpVariable %_ptr_Function_uint Function
+%939 = OpVariable %_ptr_Function_ulong Function
+%940 = OpVariable %_ptr_Function_ulong Function
+%941 = OpVariable %_ptr_Function_uint Function
+%942 = OpVariable %_ptr_Function_ulong Function
+%943 = OpVariable %_ptr_Function_ulong Function
+%944 = OpVariable %_ptr_Function_uint Function
+%945 = OpVariable %_ptr_Function_ulong Function
+%946 = OpVariable %_ptr_Function_ulong Function
+%947 = OpVariable %_ptr_Function_uint Function
+%948 = OpVariable %_ptr_Function_ulong Function
+%949 = OpVariable %_ptr_Function_ulong Function
+%950 = OpVariable %_ptr_Function_uint Function
+%951 = OpVariable %_ptr_Function_ulong Function
+%952 = OpVariable %_ptr_Function_ulong Function
+%953 = OpVariable %_ptr_Function_uint Function
+%954 = OpVariable %_ptr_Function_ulong Function
+%955 = OpVariable %_ptr_Function_ulong Function
+OpStore %906 %875
+OpStore %907 %876
+OpStore %908 %877
+OpStore %909 %878
+OpStore %910 %879
+OpStore %911 %880
+OpStore %912 %881
+OpStore %913 %882
+OpStore %914 %883
+OpStore %915 %884
+OpStore %916 %885
+OpStore %917 %886
+OpStore %918 %887
+OpStore %919 %888
+OpStore %920 %889
+OpStore %921 %890
+OpBranch %892
+%892 = OpLabel
+OpBranch %893
+%893 = OpLabel
+OpBranch %894
+%894 = OpLabel
+%956 = OpLoad %float %906
+%957 = OpBitcast %uint %956
+OpStore %938 %957
+%958 = OpLoad %uint %938
+%959 = OpUConvert %ulong %958
+OpStore %939 %959
+%960 = OpLoad %ulong %939
+%961 = OpFunctionCall %ulong %7 %ulong_14695981039346656037 %960
+OpStore %940 %961
+OpBranch %895
+%895 = OpLabel
+OpBranch %896
+%896 = OpLabel
+%962 = OpLoad %float %907
+%963 = OpBitcast %uint %962
+OpStore %941 %963
+%964 = OpLoad %uint %941
+%965 = OpUConvert %ulong %964
+OpStore %942 %965
+%966 = OpLoad %ulong %940
+%967 = OpLoad %ulong %942
+%968 = OpFunctionCall %ulong %7 %966 %967
+OpStore %943 %968
+OpBranch %897
+%897 = OpLabel
+OpBranch %898
+%898 = OpLabel
+%969 = OpLoad %float %908
+%970 = OpBitcast %uint %969
+OpStore %944 %970
+%971 = OpLoad %uint %944
+%972 = OpUConvert %ulong %971
+OpStore %945 %972
+%973 = OpLoad %ulong %943
+%974 = OpLoad %ulong %945
+%975 = OpFunctionCall %ulong %7 %973 %974
+OpStore %946 %975
+OpBranch %899
+%899 = OpLabel
+OpBranch %900
+%900 = OpLabel
+%976 = OpLoad %float %909
+%977 = OpBitcast %uint %976
+OpStore %947 %977
+%978 = OpLoad %uint %947
+%979 = OpUConvert %ulong %978
+OpStore %948 %979
+%980 = OpLoad %ulong %946
+%981 = OpLoad %ulong %948
+%982 = OpFunctionCall %ulong %7 %980 %981
+OpStore %949 %982
+OpBranch %901
+%901 = OpLabel
+OpBranch %902
+%902 = OpLabel
+%983 = OpLoad %float %910
+%984 = OpBitcast %uint %983
+OpStore %950 %984
+%985 = OpLoad %uint %950
+%986 = OpUConvert %ulong %985
+OpStore %951 %986
+%987 = OpLoad %ulong %949
+%988 = OpLoad %ulong %951
+%989 = OpFunctionCall %ulong %7 %987 %988
+OpStore %952 %989
+OpBranch %903
+%903 = OpLabel
+OpBranch %904
+%904 = OpLabel
+%990 = OpLoad %float %911
+%991 = OpBitcast %uint %990
+OpStore %953 %991
+%992 = OpLoad %uint %953
+%993 = OpUConvert %ulong %992
+OpStore %954 %993
+%994 = OpLoad %ulong %952
+%995 = OpLoad %ulong %954
+%996 = OpFunctionCall %ulong %7 %994 %995
+OpStore %955 %996
+OpBranch %905
+%905 = OpLabel
+%997 = OpLoad %ulong %955
+%998 = OpLoad %float %912
+%999 = OpFunctionCall %ulong %8 %997 %998
+OpStore %922 %999
+%1000 = OpLoad %ulong %922
+%1001 = OpLoad %float %913
+%1002 = OpFunctionCall %ulong %8 %1000 %1001
+OpStore %923 %1002
+%1003 = OpLoad %ulong %923
+%1004 = OpLoad %float %914
+%1005 = OpFunctionCall %ulong %8 %1003 %1004
+OpStore %924 %1005
+%1006 = OpLoad %ulong %924
+%1007 = OpLoad %float %915
+%1008 = OpFunctionCall %ulong %8 %1006 %1007
+OpStore %925 %1008
+%1009 = OpLoad %ulong %925
+%1010 = OpLoad %float %916
+%1011 = OpFunctionCall %ulong %8 %1009 %1010
+OpStore %926 %1011
+%1012 = OpLoad %ulong %926
+%1013 = OpLoad %float %917
+%1014 = OpFunctionCall %ulong %8 %1012 %1013
+OpStore %927 %1014
+%1015 = OpLoad %ulong %927
+%1016 = OpLoad %float %918
+%1017 = OpFunctionCall %ulong %8 %1015 %1016
+OpStore %928 %1017
+%1018 = OpLoad %ulong %928
+%1019 = OpLoad %float %919
+%1020 = OpFunctionCall %ulong %8 %1018 %1019
+OpStore %929 %1020
+%1021 = OpLoad %ulong %929
+%1022 = OpLoad %float %920
+%1023 = OpFunctionCall %ulong %8 %1021 %1022
+OpStore %930 %1023
+%1024 = OpLoad %ulong %930
+%1025 = OpLoad %float %921
+%1026 = OpFunctionCall %ulong %8 %1024 %1025
+OpStore %931 %1026
+%1027 = OpLoad %float %906
+%1028 = OpLoad %float %921
+%1029 = OpFAdd %float %1027 %1028
+OpStore %932 %1029
+%1030 = OpLoad %ulong %931
+%1031 = OpLoad %float %932
+%1032 = OpFunctionCall %ulong %8 %1030 %1031
+OpStore %933 %1032
+%1033 = OpLoad %float %913
+%1034 = OpLoad %float %918
+%1035 = OpFSub %float %1033 %1034
+OpStore %934 %1035
+%1036 = OpLoad %ulong %933
+%1037 = OpLoad %float %934
+%1038 = OpFunctionCall %ulong %8 %1036 %1037
+OpStore %935 %1038
+%1039 = OpLoad %float %909
+%1040 = OpLoad %float %920
+%1041 = OpFMul %float %1039 %1040
+OpStore %936 %1041
+%1042 = OpLoad %ulong %935
+%1043 = OpLoad %float %936
+%1044 = OpFunctionCall %ulong %8 %1042 %1043
+OpStore %937 %1044
+%1045 = OpLoad %ulong %937
+OpReturnValue %1045
 OpFunctionEnd
-%8 = OpFunction %ulong None %12
-%973 = OpFunctionParameter %ulong
-%974 = OpFunctionParameter %ulong
-%975 = OpLabel
-%980 = OpVariable %_ptr_Function_ulong Function
-%981 = OpVariable %_ptr_Function_ulong Function
-%982 = OpVariable %_ptr_Function_bool Function
-%983 = OpVariable %_ptr_Function_ulong Function
-%984 = OpVariable %_ptr_Function_ulong Function
-%985 = OpVariable %_ptr_Function_ulong Function
-%986 = OpVariable %_ptr_Function_ulong Function
-%987 = OpVariable %_ptr_Function_ulong Function
-%988 = OpVariable %_ptr_Function_ulong Function
-%989 = OpVariable %_ptr_Function_ulong Function
-%990 = OpVariable %_ptr_Function_ulong Function
-OpStore %980 %973
-OpStore %981 %974
-%991 = OpLoad %ulong %980
-OpStore %989 %991
-OpStore %990 %ulong_0
-OpBranch %976
-%976 = OpLabel
-%992 = OpLoad %ulong %990
-%994 = OpULessThan %bool %992 %ulong_8
-OpStore %982 %994
-%995 = OpLoad %bool %982
-OpLoopMerge %978 %979 None
-OpBranchConditional %995 %977 %978
-%978 = OpLabel
-%996 = OpLoad %ulong %989
-OpReturnValue %996
-%977 = OpLabel
-%997 = OpLoad %ulong %990
-%998 = OpIMul %ulong %997 %ulong_8
-OpStore %983 %998
-%999 = OpLoad %ulong %981
-%1000 = OpLoad %ulong %983
-%1001 = OpShiftRightLogical %ulong %999 %1000
-OpStore %984 %1001
-%1002 = OpLoad %ulong %984
-%1004 = OpBitwiseAnd %ulong %1002 %ulong_255
-OpStore %985 %1004
-%1005 = OpLoad %ulong %989
-%1006 = OpLoad %ulong %985
-%1007 = OpBitwiseXor %ulong %1005 %1006
-OpStore %986 %1007
-%1008 = OpLoad %ulong %986
-%1010 = OpIMul %ulong %1008 %ulong_1099511628211
-OpStore %987 %1010
-%1011 = OpLoad %ulong %990
-%1012 = OpIAdd %ulong %1011 %ulong_1
-OpStore %988 %1012
-%1013 = OpLoad %ulong %987
-OpStore %989 %1013
-%1014 = OpLoad %ulong %988
-OpStore %990 %1014
-OpBranch %979
-%979 = OpLabel
-OpBranch %976
-OpFunctionEnd
-%9 = OpFunction %ulong None %1015
-%1016 = OpFunctionParameter %ulong
-%1017 = OpFunctionParameter %float
-%1018 = OpLabel
-%1025 = OpVariable %_ptr_Function_ulong Function
-%1026 = OpVariable %_ptr_Function_float Function
-%1028 = OpVariable %_ptr_Function_uint Function
-%1029 = OpVariable %_ptr_Function_ulong Function
-%1030 = OpVariable %_ptr_Function_bool Function
-%1031 = OpVariable %_ptr_Function_ulong Function
-%1032 = OpVariable %_ptr_Function_ulong Function
-%1033 = OpVariable %_ptr_Function_ulong Function
-%1034 = OpVariable %_ptr_Function_ulong Function
-%1035 = OpVariable %_ptr_Function_ulong Function
-%1036 = OpVariable %_ptr_Function_ulong Function
-%1037 = OpVariable %_ptr_Function_ulong Function
-%1038 = OpVariable %_ptr_Function_ulong Function
-OpStore %1025 %1016
-OpStore %1026 %1017
-%1039 = OpLoad %float %1026
-%1040 = OpBitcast %uint %1039
-OpStore %1028 %1040
-%1041 = OpLoad %uint %1028
-%1042 = OpUConvert %ulong %1041
-OpStore %1029 %1042
-OpBranch %1019
-%1019 = OpLabel
-%1043 = OpLoad %ulong %1025
-OpStore %1037 %1043
-OpStore %1038 %ulong_0
-OpBranch %1020
-%1020 = OpLabel
-%1044 = OpLoad %ulong %1038
-%1045 = OpULessThan %bool %1044 %ulong_8
-OpStore %1030 %1045
-%1046 = OpLoad %bool %1030
-OpLoopMerge %1022 %1024 None
-OpBranchConditional %1046 %1021 %1022
-%1022 = OpLabel
-OpBranch %1023
-%1023 = OpLabel
-%1047 = OpLoad %ulong %1037
-OpReturnValue %1047
-%1021 = OpLabel
-%1048 = OpLoad %ulong %1038
-%1049 = OpIMul %ulong %1048 %ulong_8
-OpStore %1031 %1049
-%1050 = OpLoad %ulong %1029
-%1051 = OpLoad %ulong %1031
-%1052 = OpShiftRightLogical %ulong %1050 %1051
-OpStore %1032 %1052
-%1053 = OpLoad %ulong %1032
-%1054 = OpBitwiseAnd %ulong %1053 %ulong_255
-OpStore %1033 %1054
-%1055 = OpLoad %ulong %1037
-%1056 = OpLoad %ulong %1033
-%1057 = OpBitwiseXor %ulong %1055 %1056
-OpStore %1034 %1057
-%1058 = OpLoad %ulong %1034
-%1059 = OpIMul %ulong %1058 %ulong_1099511628211
-OpStore %1035 %1059
-%1060 = OpLoad %ulong %1038
-%1061 = OpIAdd %ulong %1060 %ulong_1
-OpStore %1036 %1061
-%1062 = OpLoad %ulong %1035
-OpStore %1037 %1062
-%1063 = OpLoad %ulong %1036
-OpStore %1038 %1063
-OpBranch %1024
-%1024 = OpLabel
-OpBranch %1020
-OpFunctionEnd
-%10 = OpFunction %ulong None %1064
-%1065 = OpFunctionParameter %ulong
-%1066 = OpFunctionParameter %double
-%1067 = OpLabel
-%1074 = OpVariable %_ptr_Function_ulong Function
-%1075 = OpVariable %_ptr_Function_double Function
-%1076 = OpVariable %_ptr_Function_ulong Function
-%1077 = OpVariable %_ptr_Function_bool Function
-%1078 = OpVariable %_ptr_Function_ulong Function
-%1079 = OpVariable %_ptr_Function_ulong Function
-%1080 = OpVariable %_ptr_Function_ulong Function
-%1081 = OpVariable %_ptr_Function_ulong Function
-%1082 = OpVariable %_ptr_Function_ulong Function
+%6 = OpFunction %ulong None %1046
+%1047 = OpFunctionParameter %ulong
+%1048 = OpLabel
+%1076 = OpVariable %_ptr_Function__arr_float_uint_20 Function
+%1079 = OpVariable %_ptr_Function__arr_double_uint_20 Function
+%1082 = OpVariable %_ptr_Function__arr_ulong_uint_20 Function
 %1083 = OpVariable %_ptr_Function_ulong Function
-%1084 = OpVariable %_ptr_Function_ulong Function
+%1084 = OpVariable %_ptr_Function_bool Function
 %1085 = OpVariable %_ptr_Function_ulong Function
-OpStore %1074 %1065
-OpStore %1075 %1066
-%1086 = OpLoad %double %1075
-%1087 = OpBitcast %ulong %1086
-OpStore %1076 %1087
+%1086 = OpVariable %_ptr_Function_bool Function
+%1087 = OpVariable %_ptr_Function_ulong Function
+%1088 = OpVariable %_ptr_Function_ulong Function
+%1089 = OpVariable %_ptr_Function_ulong Function
+%1090 = OpVariable %_ptr_Function_bool Function
+%1091 = OpVariable %_ptr_Function_ulong Function
+%1092 = OpVariable %_ptr_Function_float Function
+%1093 = OpVariable %_ptr_Function_float Function
+%1094 = OpVariable %_ptr_Function_float Function
+%1095 = OpVariable %_ptr_Function_float Function
+%1096 = OpVariable %_ptr_Function_double Function
+%1097 = OpVariable %_ptr_Function_float Function
+%1098 = OpVariable %_ptr_Function_double Function
+%1099 = OpVariable %_ptr_Function_float Function
+%1100 = OpVariable %_ptr_Function_double Function
+%1101 = OpVariable %_ptr_Function_float Function
+%1102 = OpVariable %_ptr_Function_double Function
+%1103 = OpVariable %_ptr_Function_float Function
+%1104 = OpVariable %_ptr_Function_double Function
+%1105 = OpVariable %_ptr_Function_float Function
+%1106 = OpVariable %_ptr_Function_double Function
+%1107 = OpVariable %_ptr_Function_float Function
+%1108 = OpVariable %_ptr_Function_double Function
+%1109 = OpVariable %_ptr_Function_float Function
+%1110 = OpVariable %_ptr_Function_double Function
+%1111 = OpVariable %_ptr_Function_ulong Function
+%1112 = OpVariable %_ptr_Function_ulong Function
+%1113 = OpVariable %_ptr_Function_float Function
+%1114 = OpVariable %_ptr_Function_float Function
+%1115 = OpVariable %_ptr_Function_float Function
+%1116 = OpVariable %_ptr_Function_float Function
+%1117 = OpVariable %_ptr_Function_float Function
+%1118 = OpVariable %_ptr_Function_float Function
+%1119 = OpVariable %_ptr_Function_float Function
+%1120 = OpVariable %_ptr_Function_float Function
+%1121 = OpVariable %_ptr_Function_float Function
+%1122 = OpVariable %_ptr_Function_float Function
+%1123 = OpVariable %_ptr_Function_float Function
+%1124 = OpVariable %_ptr_Function_float Function
+%1125 = OpVariable %_ptr_Function_float Function
+%1126 = OpVariable %_ptr_Function_float Function
+%1127 = OpVariable %_ptr_Function_float Function
+%1128 = OpVariable %_ptr_Function_float Function
+%1129 = OpVariable %_ptr_Function_float Function
+%1130 = OpVariable %_ptr_Function_ulong Function
+%1131 = OpVariable %_ptr_Function_ulong Function
+%1132 = OpVariable %_ptr_Function_ulong Function
+%1133 = OpVariable %_ptr_Function_float Function
+%1134 = OpVariable %_ptr_Function_float Function
+%1135 = OpVariable %_ptr_Function_float Function
+%1136 = OpVariable %_ptr_Function_float Function
+%1137 = OpVariable %_ptr_Function_float Function
+%1138 = OpVariable %_ptr_Function_float Function
+%1139 = OpVariable %_ptr_Function_float Function
+%1140 = OpVariable %_ptr_Function_float Function
+%1141 = OpVariable %_ptr_Function_float Function
+%1142 = OpVariable %_ptr_Function_float Function
+%1143 = OpVariable %_ptr_Function_float Function
+%1144 = OpVariable %_ptr_Function_float Function
+%1145 = OpVariable %_ptr_Function_float Function
+%1146 = OpVariable %_ptr_Function_float Function
+%1147 = OpVariable %_ptr_Function_float Function
+%1148 = OpVariable %_ptr_Function_float Function
+%1149 = OpVariable %_ptr_Function_ulong Function
+%1150 = OpVariable %_ptr_Function_double Function
+%1151 = OpVariable %_ptr_Function_float Function
+%1152 = OpVariable %_ptr_Function_double Function
+%1153 = OpVariable %_ptr_Function_float Function
+%1154 = OpVariable %_ptr_Function_double Function
+%1155 = OpVariable %_ptr_Function_float Function
+%1156 = OpVariable %_ptr_Function_double Function
+%1157 = OpVariable %_ptr_Function_double Function
+%1158 = OpVariable %_ptr_Function_float Function
+%1159 = OpVariable %_ptr_Function_double Function
+%1160 = OpVariable %_ptr_Function_float Function
+%1161 = OpVariable %_ptr_Function_double Function
+%1162 = OpVariable %_ptr_Function_float Function
+%1163 = OpVariable %_ptr_Function_double Function
+%1164 = OpVariable %_ptr_Function_ulong Function
+%1165 = OpVariable %_ptr_Function_ulong Function
+%1166 = OpVariable %_ptr_Function_ulong Function
+%1167 = OpVariable %_ptr_Function_ulong Function
+%1168 = OpVariable %_ptr_Function_ulong Function
+%1169 = OpVariable %_ptr_Function_ulong Function
+%1170 = OpVariable %_ptr_Function_ulong Function
+%1171 = OpVariable %_ptr_Function_ulong Function
+%1172 = OpVariable %_ptr_Function_ulong Function
+%1173 = OpVariable %_ptr_Function_ulong Function
+%1174 = OpVariable %_ptr_Function_ulong Function
+%1175 = OpVariable %_ptr_Function_float Function
+%1176 = OpVariable %_ptr_Function_float Function
+%1177 = OpVariable %_ptr_Function_float Function
+%1178 = OpVariable %_ptr_Function_ulong Function
+%1179 = OpVariable %_ptr_Function_float Function
+%1180 = OpVariable %_ptr_Function_float Function
+%1181 = OpVariable %_ptr_Function_float Function
+%1182 = OpVariable %_ptr_Function_ulong Function
+%1183 = OpVariable %_ptr_Function_double Function
+%1184 = OpVariable %_ptr_Function_double Function
+%1185 = OpVariable %_ptr_Function_double Function
+%1186 = OpVariable %_ptr_Function_ulong Function
+%1187 = OpVariable %_ptr_Function_float Function
+%1188 = OpVariable %_ptr_Function_float Function
+%1189 = OpVariable %_ptr_Function_float Function
+OpStore %1083 %1047
+OpBranch %1058
+%1058 = OpLabel
+OpBranch %1059
+%1059 = OpLabel
+OpStore %1082 %1190
+OpStore %1168 %ulong_0
+OpBranch %1049
+%1049 = OpLabel
+%1191 = OpLoad %ulong %1168
+%1193 = OpULessThan %bool %1191 %ulong_20
+OpStore %1084 %1193
+%1194 = OpLoad %bool %1084
+OpLoopMerge %1051 %1072 None
+OpBranchConditional %1194 %1050 %1051
+%1051 = OpLabel
+OpStore %1076 %1195
+OpStore %1079 %1196
+OpStore %1167 %ulong_0
+OpBranch %1052
+%1052 = OpLabel
+%1197 = OpLoad %ulong %1167
+%1198 = OpULessThan %bool %1197 %ulong_20
+OpStore %1086 %1198
+%1199 = OpLoad %bool %1086
+OpLoopMerge %1054 %1071 None
+OpBranchConditional %1199 %1053 %1054
+%1054 = OpLabel
+OpStore %1166 %ulong_14695981039346656037
+OpStore %1169 %ulong_0
+OpStore %1170 %ulong_0
+OpBranch %1055
+%1055 = OpLabel
+%1200 = OpLoad %ulong %1170
+%1202 = OpULessThan %bool %1200 %ulong_3
+OpStore %1090 %1202
+%1203 = OpLoad %bool %1090
+OpLoopMerge %1057 %1070 None
+OpBranchConditional %1203 %1056 %1057
+%1057 = OpLabel
+%1205 = OpAccessChain %_ptr_Function_float %1076 %uint_19
+%1206 = OpLoad %float %1205
+OpStore %1133 %1206
+%1208 = OpAccessChain %_ptr_Function_float %1076 %uint_18
+%1209 = OpLoad %float %1208
+OpStore %1134 %1209
+%1211 = OpAccessChain %_ptr_Function_float %1076 %uint_17
+%1212 = OpLoad %float %1211
+OpStore %1135 %1212
+%1214 = OpAccessChain %_ptr_Function_float %1076 %uint_16
+%1215 = OpLoad %float %1214
+OpStore %1136 %1215
+%1217 = OpAccessChain %_ptr_Function_float %1076 %uint_15
+%1218 = OpLoad %float %1217
+OpStore %1137 %1218
+%1220 = OpAccessChain %_ptr_Function_float %1076 %uint_14
+%1221 = OpLoad %float %1220
+OpStore %1138 %1221
+%1223 = OpAccessChain %_ptr_Function_float %1076 %uint_13
+%1224 = OpLoad %float %1223
+OpStore %1139 %1224
+%1226 = OpAccessChain %_ptr_Function_float %1076 %uint_12
+%1227 = OpLoad %float %1226
+OpStore %1140 %1227
+%1229 = OpAccessChain %_ptr_Function_float %1076 %uint_11
+%1230 = OpLoad %float %1229
+OpStore %1141 %1230
+%1232 = OpAccessChain %_ptr_Function_float %1076 %uint_10
+%1233 = OpLoad %float %1232
+OpStore %1142 %1233
+%1235 = OpAccessChain %_ptr_Function_float %1076 %uint_9
+%1236 = OpLoad %float %1235
+OpStore %1143 %1236
+%1238 = OpAccessChain %_ptr_Function_float %1076 %uint_8
+%1239 = OpLoad %float %1238
+OpStore %1144 %1239
+%1241 = OpAccessChain %_ptr_Function_float %1076 %uint_7
+%1242 = OpLoad %float %1241
+OpStore %1145 %1242
+%1244 = OpAccessChain %_ptr_Function_float %1076 %uint_6
+%1245 = OpLoad %float %1244
+OpStore %1146 %1245
+%1247 = OpAccessChain %_ptr_Function_float %1076 %uint_5
+%1248 = OpLoad %float %1247
+OpStore %1147 %1248
+%1250 = OpAccessChain %_ptr_Function_float %1076 %uint_4
+%1251 = OpLoad %float %1250
+OpStore %1148 %1251
+%1252 = OpLoad %float %1133
+%1253 = OpLoad %float %1134
+%1254 = OpLoad %float %1135
+%1255 = OpLoad %float %1136
+%1256 = OpLoad %float %1137
+%1257 = OpLoad %float %1138
+%1258 = OpLoad %float %1139
+%1259 = OpLoad %float %1140
+%1260 = OpLoad %float %1141
+%1261 = OpLoad %float %1142
+%1262 = OpLoad %float %1143
+%1263 = OpLoad %float %1144
+%1264 = OpLoad %float %1145
+%1265 = OpLoad %float %1146
+%1266 = OpLoad %float %1147
+%1267 = OpLoad %float %1148
+%1268 = OpFunctionCall %ulong %5 %1252 %1253 %1254 %1255 %1256 %1257 %1258 %1259 %1260 %1261 %1262 %1263 %1264 %1265 %1266 %1267
+OpStore %1149 %1268
+OpBranch %1064
+%1064 = OpLabel
+%1269 = OpLoad %ulong %1149
+%1270 = OpBitwiseAnd %ulong %1269 %ulong_4095
+OpStore %1178 %1270
+%1271 = OpLoad %ulong %1178
+%1272 = OpConvertUToF %float %1271
+OpStore %1179 %1272
+%1273 = OpLoad %float %1179
+%1274 = OpFSub %float %1273 %float_2048
+OpStore %1180 %1274
+%1275 = OpLoad %float %1180
+%1276 = OpFDiv %float %1275 %float_8
+OpStore %1181 %1276
+OpBranch %1065
+%1065 = OpLabel
+%1278 = OpAccessChain %_ptr_Function_double %1079 %uint_0
+%1279 = OpLoad %double %1278
+OpStore %1150 %1279
+%1281 = OpAccessChain %_ptr_Function_float %1076 %uint_1
+%1282 = OpLoad %float %1281
+OpStore %1151 %1282
+%1284 = OpAccessChain %_ptr_Function_double %1079 %uint_2
+%1285 = OpLoad %double %1284
+OpStore %1152 %1285
+%1287 = OpAccessChain %_ptr_Function_float %1076 %uint_3
+%1288 = OpLoad %float %1287
+OpStore %1153 %1288
+%1289 = OpAccessChain %_ptr_Function_double %1079 %uint_4
+%1290 = OpLoad %double %1289
+OpStore %1154 %1290
+%1291 = OpAccessChain %_ptr_Function_float %1076 %uint_5
+%1292 = OpLoad %float %1291
+OpStore %1155 %1292
+%1293 = OpAccessChain %_ptr_Function_double %1079 %uint_6
+%1294 = OpLoad %double %1293
+OpStore %1156 %1294
 OpBranch %1068
 %1068 = OpLabel
-%1088 = OpLoad %ulong %1074
-OpStore %1084 %1088
-OpStore %1085 %ulong_0
+%1295 = OpLoad %ulong %1169
+%1296 = OpBitwiseAnd %ulong %1295 %ulong_4095
+OpStore %1186 %1296
+%1297 = OpLoad %ulong %1186
+%1298 = OpConvertUToF %float %1297
+OpStore %1187 %1298
+%1299 = OpLoad %float %1187
+%1300 = OpFSub %float %1299 %float_2048
+OpStore %1188 %1300
+%1301 = OpLoad %float %1188
+%1302 = OpFDiv %float %1301 %float_8
+OpStore %1189 %1302
 OpBranch %1069
 %1069 = OpLabel
-%1089 = OpLoad %ulong %1085
-%1090 = OpULessThan %bool %1089 %ulong_8
-OpStore %1077 %1090
-%1091 = OpLoad %bool %1077
-OpLoopMerge %1071 %1073 None
-OpBranchConditional %1091 %1070 %1071
-%1071 = OpLabel
+%1303 = OpAccessChain %_ptr_Function_double %1079 %uint_8
+%1304 = OpLoad %double %1303
+OpStore %1157 %1304
+%1305 = OpAccessChain %_ptr_Function_float %1076 %uint_9
+%1306 = OpLoad %float %1305
+OpStore %1158 %1306
+%1307 = OpAccessChain %_ptr_Function_double %1079 %uint_10
+%1308 = OpLoad %double %1307
+OpStore %1159 %1308
+%1309 = OpAccessChain %_ptr_Function_float %1076 %uint_11
+%1310 = OpLoad %float %1309
+OpStore %1160 %1310
+%1311 = OpAccessChain %_ptr_Function_double %1079 %uint_12
+%1312 = OpLoad %double %1311
+OpStore %1161 %1312
+%1313 = OpAccessChain %_ptr_Function_float %1076 %uint_13
+%1314 = OpLoad %float %1313
+OpStore %1162 %1314
+%1315 = OpAccessChain %_ptr_Function_double %1079 %uint_14
+%1316 = OpLoad %double %1315
+OpStore %1163 %1316
+%1317 = OpLoad %float %1181
+%1318 = OpLoad %double %1150
+%1319 = OpLoad %float %1151
+%1320 = OpLoad %double %1152
+%1321 = OpLoad %float %1153
+%1322 = OpLoad %double %1154
+%1323 = OpLoad %float %1155
+%1324 = OpLoad %double %1156
+%1325 = OpLoad %float %1189
+%1326 = OpLoad %double %1157
+%1327 = OpLoad %float %1158
+%1328 = OpLoad %double %1159
+%1329 = OpLoad %float %1160
+%1330 = OpLoad %double %1161
+%1331 = OpLoad %float %1162
+%1332 = OpLoad %double %1163
+%1333 = OpFunctionCall %ulong %4 %1317 %1318 %1319 %1320 %1321 %1322 %1323 %1324 %1325 %1326 %1327 %1328 %1329 %1330 %1331 %1332
+OpStore %1164 %1333
+%1334 = OpLoad %ulong %1166
+%1335 = OpLoad %ulong %1164
+%1336 = OpFunctionCall %ulong %7 %1334 %1335
+OpStore %1165 %1336
+%1337 = OpLoad %ulong %1165
+OpReturnValue %1337
+%1056 = OpLabel
+%1338 = OpLoad %ulong %1170
+%1339 = OpBitwiseAnd %ulong %1338 %ulong_3
+OpStore %1091 %1339
+%1340 = OpLoad %ulong %1091
+%1341 = OpConvertUToF %float %1340
+OpStore %1092 %1341
+%1342 = OpLoad %float %1092
+%1344 = OpFDiv %float %1342 %float_4
+OpStore %1093 %1344
+%1345 = OpAccessChain %_ptr_Function_float %1076 %uint_0
+%1346 = OpLoad %float %1345
+OpStore %1094 %1346
+%1347 = OpLoad %float %1094
+%1348 = OpLoad %float %1093
+%1349 = OpFAdd %float %1347 %1348
+OpStore %1095 %1349
+%1350 = OpAccessChain %_ptr_Function_double %1079 %uint_1
+%1351 = OpLoad %double %1350
+OpStore %1096 %1351
+%1352 = OpAccessChain %_ptr_Function_float %1076 %uint_2
+%1353 = OpLoad %float %1352
+OpStore %1097 %1353
+%1354 = OpAccessChain %_ptr_Function_double %1079 %uint_3
+%1355 = OpLoad %double %1354
+OpStore %1098 %1355
+%1356 = OpAccessChain %_ptr_Function_float %1076 %uint_4
+%1357 = OpLoad %float %1356
+OpStore %1099 %1357
+%1358 = OpAccessChain %_ptr_Function_double %1079 %uint_5
+%1359 = OpLoad %double %1358
+OpStore %1100 %1359
+%1360 = OpAccessChain %_ptr_Function_float %1076 %uint_6
+%1361 = OpLoad %float %1360
+OpStore %1101 %1361
+%1362 = OpAccessChain %_ptr_Function_double %1079 %uint_7
+%1363 = OpLoad %double %1362
+OpStore %1102 %1363
+%1364 = OpAccessChain %_ptr_Function_float %1076 %uint_8
+%1365 = OpLoad %float %1364
+OpStore %1103 %1365
+%1366 = OpAccessChain %_ptr_Function_double %1079 %uint_9
+%1367 = OpLoad %double %1366
+OpStore %1104 %1367
+%1368 = OpAccessChain %_ptr_Function_float %1076 %uint_10
+%1369 = OpLoad %float %1368
+OpStore %1105 %1369
+%1370 = OpAccessChain %_ptr_Function_double %1079 %uint_11
+%1371 = OpLoad %double %1370
+OpStore %1106 %1371
+%1372 = OpAccessChain %_ptr_Function_float %1076 %uint_12
+%1373 = OpLoad %float %1372
+OpStore %1107 %1373
+%1374 = OpAccessChain %_ptr_Function_double %1079 %uint_13
+%1375 = OpLoad %double %1374
+OpStore %1108 %1375
+%1376 = OpAccessChain %_ptr_Function_float %1076 %uint_14
+%1377 = OpLoad %float %1376
+OpStore %1109 %1377
+%1378 = OpAccessChain %_ptr_Function_double %1079 %uint_15
+%1379 = OpLoad %double %1378
+OpStore %1110 %1379
+%1380 = OpLoad %float %1095
+%1381 = OpLoad %double %1096
+%1382 = OpLoad %float %1097
+%1383 = OpLoad %double %1098
+%1384 = OpLoad %float %1099
+%1385 = OpLoad %double %1100
+%1386 = OpLoad %float %1101
+%1387 = OpLoad %double %1102
+%1388 = OpLoad %float %1103
+%1389 = OpLoad %double %1104
+%1390 = OpLoad %float %1105
+%1391 = OpLoad %double %1106
+%1392 = OpLoad %float %1107
+%1393 = OpLoad %double %1108
+%1394 = OpLoad %float %1109
+%1395 = OpLoad %double %1110
+%1396 = OpFunctionCall %ulong %4 %1380 %1381 %1382 %1383 %1384 %1385 %1386 %1387 %1388 %1389 %1390 %1391 %1392 %1393 %1394 %1395
+OpStore %1111 %1396
+%1397 = OpLoad %ulong %1166
+%1398 = OpLoad %ulong %1111
+%1399 = OpFunctionCall %ulong %7 %1397 %1398
+OpStore %1112 %1399
+%1400 = OpLoad %float %1345
+OpStore %1113 %1400
+%1401 = OpAccessChain %_ptr_Function_float %1076 %uint_1
+%1402 = OpLoad %float %1401
+OpStore %1114 %1402
+%1403 = OpLoad %float %1352
+OpStore %1115 %1403
+%1404 = OpAccessChain %_ptr_Function_float %1076 %uint_3
+%1405 = OpLoad %float %1404
+OpStore %1116 %1405
+%1406 = OpLoad %float %1356
+OpStore %1117 %1406
+%1407 = OpAccessChain %_ptr_Function_float %1076 %uint_5
+%1408 = OpLoad %float %1407
+OpStore %1118 %1408
+%1409 = OpLoad %float %1360
+OpStore %1119 %1409
+%1410 = OpAccessChain %_ptr_Function_float %1076 %uint_7
+%1411 = OpLoad %float %1410
+OpStore %1120 %1411
+%1412 = OpLoad %float %1364
+OpStore %1121 %1412
+%1413 = OpAccessChain %_ptr_Function_float %1076 %uint_9
+%1414 = OpLoad %float %1413
+OpStore %1122 %1414
+%1415 = OpLoad %float %1368
+OpStore %1123 %1415
+%1416 = OpAccessChain %_ptr_Function_float %1076 %uint_11
+%1417 = OpLoad %float %1416
+OpStore %1124 %1417
+%1418 = OpLoad %float %1372
+OpStore %1125 %1418
+%1419 = OpAccessChain %_ptr_Function_float %1076 %uint_13
+%1420 = OpLoad %float %1419
+OpStore %1126 %1420
+%1421 = OpLoad %float %1376
+OpStore %1127 %1421
+%1422 = OpAccessChain %_ptr_Function_float %1076 %uint_15
+%1423 = OpLoad %float %1422
+OpStore %1128 %1423
+%1424 = OpLoad %float %1128
+%1425 = OpLoad %float %1093
+%1426 = OpFAdd %float %1424 %1425
+OpStore %1129 %1426
+%1427 = OpLoad %float %1113
+%1428 = OpLoad %float %1114
+%1429 = OpLoad %float %1115
+%1430 = OpLoad %float %1116
+%1431 = OpLoad %float %1117
+%1432 = OpLoad %float %1118
+%1433 = OpLoad %float %1119
+%1434 = OpLoad %float %1120
+%1435 = OpLoad %float %1121
+%1436 = OpLoad %float %1122
+%1437 = OpLoad %float %1123
+%1438 = OpLoad %float %1124
+%1439 = OpLoad %float %1125
+%1440 = OpLoad %float %1126
+%1441 = OpLoad %float %1127
+%1442 = OpLoad %float %1129
+%1443 = OpFunctionCall %ulong %5 %1427 %1428 %1429 %1430 %1431 %1432 %1433 %1434 %1435 %1436 %1437 %1438 %1439 %1440 %1441 %1442
+OpStore %1130 %1443
+%1444 = OpLoad %ulong %1112
+%1445 = OpLoad %ulong %1130
+%1446 = OpFunctionCall %ulong %7 %1444 %1445
+OpStore %1131 %1446
+%1447 = OpLoad %ulong %1170
+%1448 = OpIAdd %ulong %1447 %ulong_1
+OpStore %1132 %1448
+%1449 = OpLoad %ulong %1131
+OpStore %1166 %1449
+%1450 = OpLoad %ulong %1130
+OpStore %1169 %1450
+%1451 = OpLoad %ulong %1132
+OpStore %1170 %1451
+OpBranch %1070
+%1053 = OpLabel
+%1452 = OpLoad %ulong %1167
+%1453 = OpAccessChain %_ptr_Function_ulong %1082 %1452
+%1454 = OpLoad %ulong %1453
+OpStore %1087 %1454
+OpBranch %1062
+%1062 = OpLabel
+%1455 = OpLoad %ulong %1087
+%1456 = OpBitwiseAnd %ulong %1455 %ulong_4095
+OpStore %1174 %1456
+%1457 = OpLoad %ulong %1174
+%1458 = OpConvertUToF %float %1457
+OpStore %1175 %1458
+%1459 = OpLoad %float %1175
+%1460 = OpFSub %float %1459 %float_2048
+OpStore %1176 %1460
+%1461 = OpLoad %float %1176
+%1462 = OpFDiv %float %1461 %float_8
+OpStore %1177 %1462
+OpBranch %1063
+%1063 = OpLabel
+%1463 = OpLoad %ulong %1167
+%1464 = OpAccessChain %_ptr_Function_float %1076 %1463
+%1465 = OpLoad %float %1177
+OpStore %1464 %1465
+%1466 = OpLoad %ulong %1167
+%1467 = OpAccessChain %_ptr_Function_ulong %1082 %1466
+%1468 = OpLoad %ulong %1467
+OpStore %1088 %1468
+OpBranch %1066
+%1066 = OpLabel
+%1469 = OpLoad %ulong %1088
+%1470 = OpBitwiseAnd %ulong %1469 %ulong_1048575
+OpStore %1182 %1470
+%1471 = OpLoad %ulong %1182
+%1472 = OpConvertUToF %double %1471
+OpStore %1183 %1472
+%1473 = OpLoad %double %1183
+%1474 = OpFSub %double %1473 %double_524288
+OpStore %1184 %1474
+%1475 = OpLoad %double %1184
+%1476 = OpFDiv %double %1475 %double_64
+OpStore %1185 %1476
+OpBranch %1067
+%1067 = OpLabel
+%1477 = OpLoad %ulong %1167
+%1478 = OpAccessChain %_ptr_Function_double %1079 %1477
+%1479 = OpLoad %double %1185
+OpStore %1478 %1479
+%1480 = OpLoad %ulong %1167
+%1481 = OpIAdd %ulong %1480 %ulong_1
+OpStore %1089 %1481
+%1482 = OpLoad %ulong %1089
+OpStore %1167 %1482
+OpBranch %1071
+%1050 = OpLabel
+OpBranch %1060
+%1060 = OpLabel
+%1483 = OpLoad %ulong %1168
+%1484 = OpIMul %ulong %1483 %ulong_6364136223846793005
+OpStore %1171 %1484
+%1485 = OpLoad %ulong %1171
+%1486 = OpIAdd %ulong %1485 %ulong_1442695040888963407
+OpStore %1172 %1486
+%1487 = OpLoad %ulong %1172
+%1488 = OpLoad %ulong %1083
+%1489 = OpIAdd %ulong %1487 %1488
+OpStore %1173 %1489
+OpBranch %1061
+%1061 = OpLabel
+%1490 = OpLoad %ulong %1168
+%1491 = OpAccessChain %_ptr_Function_ulong %1082 %1490
+%1492 = OpLoad %ulong %1173
+OpStore %1491 %1492
+%1493 = OpLoad %ulong %1168
+%1494 = OpIAdd %ulong %1493 %ulong_1
+OpStore %1085 %1494
+%1495 = OpLoad %ulong %1085
+OpStore %1168 %1495
 OpBranch %1072
-%1072 = OpLabel
-%1092 = OpLoad %ulong %1084
-OpReturnValue %1092
 %1070 = OpLabel
-%1093 = OpLoad %ulong %1085
-%1094 = OpIMul %ulong %1093 %ulong_8
-OpStore %1078 %1094
-%1095 = OpLoad %ulong %1076
-%1096 = OpLoad %ulong %1078
-%1097 = OpShiftRightLogical %ulong %1095 %1096
-OpStore %1079 %1097
-%1098 = OpLoad %ulong %1079
-%1099 = OpBitwiseAnd %ulong %1098 %ulong_255
-OpStore %1080 %1099
-%1100 = OpLoad %ulong %1084
-%1101 = OpLoad %ulong %1080
-%1102 = OpBitwiseXor %ulong %1100 %1101
-OpStore %1081 %1102
-%1103 = OpLoad %ulong %1081
-%1104 = OpIMul %ulong %1103 %ulong_1099511628211
-OpStore %1082 %1104
-%1105 = OpLoad %ulong %1085
-%1106 = OpIAdd %ulong %1105 %ulong_1
-OpStore %1083 %1106
-%1107 = OpLoad %ulong %1082
-OpStore %1084 %1107
-%1108 = OpLoad %ulong %1083
-OpStore %1085 %1108
-OpBranch %1073
-%1073 = OpLabel
-OpBranch %1069
+OpBranch %1055
+%1071 = OpLabel
+OpBranch %1052
+%1072 = OpLabel
+OpBranch %1049
+OpFunctionEnd
+%7 = OpFunction %ulong None %10
+%1496 = OpFunctionParameter %ulong
+%1497 = OpFunctionParameter %ulong
+%1498 = OpLabel
+%1503 = OpVariable %_ptr_Function_ulong Function
+%1504 = OpVariable %_ptr_Function_ulong Function
+%1505 = OpVariable %_ptr_Function_bool Function
+%1506 = OpVariable %_ptr_Function_ulong Function
+%1507 = OpVariable %_ptr_Function_ulong Function
+%1508 = OpVariable %_ptr_Function_ulong Function
+%1509 = OpVariable %_ptr_Function_ulong Function
+%1510 = OpVariable %_ptr_Function_ulong Function
+%1511 = OpVariable %_ptr_Function_ulong Function
+%1512 = OpVariable %_ptr_Function_ulong Function
+%1513 = OpVariable %_ptr_Function_ulong Function
+OpStore %1503 %1496
+OpStore %1504 %1497
+%1514 = OpLoad %ulong %1503
+OpStore %1512 %1514
+OpStore %1513 %ulong_0
+OpBranch %1499
+%1499 = OpLabel
+%1515 = OpLoad %ulong %1513
+%1516 = OpULessThan %bool %1515 %ulong_8
+OpStore %1505 %1516
+%1517 = OpLoad %bool %1505
+OpLoopMerge %1501 %1502 None
+OpBranchConditional %1517 %1500 %1501
+%1501 = OpLabel
+%1518 = OpLoad %ulong %1512
+OpReturnValue %1518
+%1500 = OpLabel
+%1519 = OpLoad %ulong %1513
+%1520 = OpIMul %ulong %1519 %ulong_8
+OpStore %1506 %1520
+%1521 = OpLoad %ulong %1504
+%1522 = OpLoad %ulong %1506
+%1523 = OpShiftRightLogical %ulong %1521 %1522
+OpStore %1507 %1523
+%1524 = OpLoad %ulong %1507
+%1525 = OpBitwiseAnd %ulong %1524 %ulong_255
+OpStore %1508 %1525
+%1526 = OpLoad %ulong %1512
+%1527 = OpLoad %ulong %1508
+%1528 = OpBitwiseXor %ulong %1526 %1527
+OpStore %1509 %1528
+%1529 = OpLoad %ulong %1509
+%1530 = OpIMul %ulong %1529 %ulong_1099511628211
+OpStore %1510 %1530
+%1531 = OpLoad %ulong %1513
+%1532 = OpIAdd %ulong %1531 %ulong_1
+OpStore %1511 %1532
+%1533 = OpLoad %ulong %1510
+OpStore %1512 %1533
+%1534 = OpLoad %ulong %1511
+OpStore %1513 %1534
+OpBranch %1502
+%1502 = OpLabel
+OpBranch %1499
+OpFunctionEnd
+%8 = OpFunction %ulong None %1535
+%1536 = OpFunctionParameter %ulong
+%1537 = OpFunctionParameter %float
+%1538 = OpLabel
+%1545 = OpVariable %_ptr_Function_ulong Function
+%1546 = OpVariable %_ptr_Function_float Function
+%1547 = OpVariable %_ptr_Function_uint Function
+%1548 = OpVariable %_ptr_Function_ulong Function
+%1549 = OpVariable %_ptr_Function_bool Function
+%1550 = OpVariable %_ptr_Function_ulong Function
+%1551 = OpVariable %_ptr_Function_ulong Function
+%1552 = OpVariable %_ptr_Function_ulong Function
+%1553 = OpVariable %_ptr_Function_ulong Function
+%1554 = OpVariable %_ptr_Function_ulong Function
+%1555 = OpVariable %_ptr_Function_ulong Function
+%1556 = OpVariable %_ptr_Function_ulong Function
+%1557 = OpVariable %_ptr_Function_ulong Function
+OpStore %1545 %1536
+OpStore %1546 %1537
+%1558 = OpLoad %float %1546
+%1559 = OpBitcast %uint %1558
+OpStore %1547 %1559
+%1560 = OpLoad %uint %1547
+%1561 = OpUConvert %ulong %1560
+OpStore %1548 %1561
+OpBranch %1539
+%1539 = OpLabel
+%1562 = OpLoad %ulong %1545
+OpStore %1556 %1562
+OpStore %1557 %ulong_0
+OpBranch %1540
+%1540 = OpLabel
+%1563 = OpLoad %ulong %1557
+%1564 = OpULessThan %bool %1563 %ulong_8
+OpStore %1549 %1564
+%1565 = OpLoad %bool %1549
+OpLoopMerge %1542 %1544 None
+OpBranchConditional %1565 %1541 %1542
+%1542 = OpLabel
+OpBranch %1543
+%1543 = OpLabel
+%1566 = OpLoad %ulong %1556
+OpReturnValue %1566
+%1541 = OpLabel
+%1567 = OpLoad %ulong %1557
+%1568 = OpIMul %ulong %1567 %ulong_8
+OpStore %1550 %1568
+%1569 = OpLoad %ulong %1548
+%1570 = OpLoad %ulong %1550
+%1571 = OpShiftRightLogical %ulong %1569 %1570
+OpStore %1551 %1571
+%1572 = OpLoad %ulong %1551
+%1573 = OpBitwiseAnd %ulong %1572 %ulong_255
+OpStore %1552 %1573
+%1574 = OpLoad %ulong %1556
+%1575 = OpLoad %ulong %1552
+%1576 = OpBitwiseXor %ulong %1574 %1575
+OpStore %1553 %1576
+%1577 = OpLoad %ulong %1553
+%1578 = OpIMul %ulong %1577 %ulong_1099511628211
+OpStore %1554 %1578
+%1579 = OpLoad %ulong %1557
+%1580 = OpIAdd %ulong %1579 %ulong_1
+OpStore %1555 %1580
+%1581 = OpLoad %ulong %1554
+OpStore %1556 %1581
+%1582 = OpLoad %ulong %1555
+OpStore %1557 %1582
+OpBranch %1544
+%1544 = OpLabel
+OpBranch %1540
 OpFunctionEnd

--- a/test/golden/spirv/call/call_int_regs.dis
+++ b/test/golden/spirv/call/call_int_regs.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1488
+; Bound: 1519
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,26 +14,31 @@ OpDecorate %2 LinkageAttributes "corpus.cases.call.call_int_regs.take16" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.call.call_int_regs.take16n" Export
 OpDecorate %4 LinkageAttributes "corpus.cases.call.call_int_regs.checksum" Export
 %ulong = OpTypeInt 64 0
-%15 = OpTypeFunction %ulong %ulong %ulong
+%7 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
-%38 = OpTypeFunction %ulong %uchar %uchar %ushort %ushort %uint %uint %ulong %ulong %uchar %uchar %ushort %ushort %uint %uint %ulong %ulong
+%30 = OpTypeFunction %ulong %uchar %uchar %ushort %ushort %uint %uint %ulong %ulong %uchar %uchar %ushort %ushort %uint %uint %ulong %ulong
+%bool = OpTypeBool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
-%142 = OpTypeFunction %ulong %uchar %uchar %uchar %uchar %ushort %ushort %ushort %ushort %uchar %uchar %ushort %ushort %uchar %uchar %ushort %ushort
-%243 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%701 = OpTypeFunction %ulong %uchar %uchar %uchar %uchar %ushort %ushort %ushort %ushort %uchar %uchar %ushort %ushort %uchar %uchar %ushort %ushort
+%881 = OpTypeFunction %ulong %ulong
 %uint_20 = OpConstant %uint 20
 %_arr_ulong_uint_20 = OpTypeArray %ulong %uint_20
 %_ptr_Function__arr_ulong_uint_20 = OpTypePointer Function %_arr_ulong_uint_20
-%_ptr_Function_bool = OpTypePointer Function %bool
-%525 = OpConstantNull %_arr_ulong_uint_20
-%ulong_0 = OpConstant %ulong 0
+%1071 = OpConstantNull %_arr_ulong_uint_20
 %ulong_20 = OpConstant %ulong 20
 %ulong_3 = OpConstant %ulong 3
 %uint_0 = OpConstant %uint 0
@@ -57,40 +62,39 @@ OpDecorate %4 LinkageAttributes "corpus.cases.call.call_int_regs.checksum" Expor
 %uint_18 = OpConstant %uint 18
 %uint_19 = OpConstant %uint 19
 %ulong_7 = OpConstant %ulong 7
-%ulong_1 = OpConstant %ulong 1
-%1135 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1180 = OpTypeFunction %ulong %ulong %uchar
-%1225 = OpTypeFunction %ulong %ulong %ushort
-%1270 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %15
-%16 = OpFunctionParameter %ulong
-%17 = OpFunctionParameter %ulong
-%18 = OpLabel
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-OpStore %20 %16
-OpStore %21 %17
-%25 = OpLoad %ulong %21
-%27 = OpIMul %ulong %25 %ulong_6364136223846793005
-OpStore %22 %27
-%28 = OpLoad %ulong %22
-%30 = OpIAdd %ulong %28 %ulong_1442695040888963407
-OpStore %23 %30
-%31 = OpLoad %ulong %23
-%32 = OpLoad %ulong %20
-%33 = OpIAdd %ulong %31 %32
-OpStore %24 %33
-%34 = OpLoad %ulong %24
-OpReturnValue %34
+%1 = OpFunction %ulong None %7
+%8 = OpFunctionParameter %ulong
+%9 = OpFunctionParameter %ulong
+%10 = OpLabel
+%12 = OpVariable %_ptr_Function_ulong Function
+%13 = OpVariable %_ptr_Function_ulong Function
+%14 = OpVariable %_ptr_Function_ulong Function
+%15 = OpVariable %_ptr_Function_ulong Function
+%16 = OpVariable %_ptr_Function_ulong Function
+OpStore %12 %8
+OpStore %13 %9
+%17 = OpLoad %ulong %13
+%19 = OpIMul %ulong %17 %ulong_6364136223846793005
+OpStore %14 %19
+%20 = OpLoad %ulong %14
+%22 = OpIAdd %ulong %20 %ulong_1442695040888963407
+OpStore %15 %22
+%23 = OpLoad %ulong %15
+%24 = OpLoad %ulong %12
+%25 = OpIAdd %ulong %23 %24
+OpStore %16 %25
+%26 = OpLoad %ulong %16
+OpReturnValue %26
 OpFunctionEnd
-%2 = OpFunction %ulong None %38
+%2 = OpFunction %ulong None %30
+%31 = OpFunctionParameter %uchar
+%32 = OpFunctionParameter %uchar
+%33 = OpFunctionParameter %ushort
+%34 = OpFunctionParameter %ushort
+%35 = OpFunctionParameter %uint
+%36 = OpFunctionParameter %uint
+%37 = OpFunctionParameter %ulong
+%38 = OpFunctionParameter %ulong
 %39 = OpFunctionParameter %uchar
 %40 = OpFunctionParameter %uchar
 %41 = OpFunctionParameter %ushort
@@ -99,1945 +103,2083 @@ OpFunctionEnd
 %44 = OpFunctionParameter %uint
 %45 = OpFunctionParameter %ulong
 %46 = OpFunctionParameter %ulong
-%47 = OpFunctionParameter %uchar
-%48 = OpFunctionParameter %uchar
-%49 = OpFunctionParameter %ushort
-%50 = OpFunctionParameter %ushort
-%51 = OpFunctionParameter %uint
-%52 = OpFunctionParameter %uint
-%53 = OpFunctionParameter %ulong
-%54 = OpFunctionParameter %ulong
-%55 = OpLabel
-%57 = OpVariable %_ptr_Function_uchar Function
-%58 = OpVariable %_ptr_Function_uchar Function
-%60 = OpVariable %_ptr_Function_ushort Function
-%61 = OpVariable %_ptr_Function_ushort Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_uchar Function
-%68 = OpVariable %_ptr_Function_uchar Function
-%69 = OpVariable %_ptr_Function_ushort Function
-%70 = OpVariable %_ptr_Function_ushort Function
-%71 = OpVariable %_ptr_Function_uint Function
-%72 = OpVariable %_ptr_Function_uint Function
-%73 = OpVariable %_ptr_Function_ulong Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_ulong Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_ulong Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_ulong Function
-%88 = OpVariable %_ptr_Function_ulong Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_ulong Function
-OpStore %57 %39
-OpStore %58 %40
-OpStore %60 %41
-OpStore %61 %42
-OpStore %63 %43
-OpStore %64 %44
-OpStore %65 %45
-OpStore %66 %46
-OpStore %67 %47
-OpStore %68 %48
-OpStore %69 %49
-OpStore %70 %50
-OpStore %71 %51
-OpStore %72 %52
-OpStore %73 %53
-OpStore %74 %54
-%92 = OpFunctionCall %ulong %5
-OpStore %75 %92
-%93 = OpLoad %ulong %75
-%94 = OpLoad %uchar %57
-%95 = OpFunctionCall %ulong %7 %93 %94
-OpStore %76 %95
-%96 = OpLoad %ulong %76
-%97 = OpLoad %uchar %58
-%98 = OpFunctionCall %ulong %10 %96 %97
-OpStore %77 %98
-%99 = OpLoad %ulong %77
-%100 = OpLoad %ushort %60
-%101 = OpFunctionCall %ulong %8 %99 %100
-OpStore %78 %101
-%102 = OpLoad %ulong %78
-%103 = OpLoad %ushort %61
-%104 = OpFunctionCall %ulong %11 %102 %103
-OpStore %79 %104
-%105 = OpLoad %ulong %79
-%106 = OpLoad %uint %63
-%107 = OpFunctionCall %ulong %9 %105 %106
-OpStore %80 %107
-%108 = OpLoad %ulong %80
-%109 = OpLoad %uint %64
-%110 = OpFunctionCall %ulong %12 %108 %109
-OpStore %81 %110
-%111 = OpLoad %ulong %81
-%112 = OpLoad %ulong %65
-%113 = OpFunctionCall %ulong %6 %111 %112
-OpStore %82 %113
-%114 = OpLoad %ulong %82
-%115 = OpLoad %ulong %66
-%116 = OpFunctionCall %ulong %13 %114 %115
-OpStore %83 %116
-%117 = OpLoad %ulong %83
-%118 = OpLoad %uchar %67
-%119 = OpFunctionCall %ulong %7 %117 %118
-OpStore %84 %119
-%120 = OpLoad %ulong %84
-%121 = OpLoad %uchar %68
-%122 = OpFunctionCall %ulong %10 %120 %121
-OpStore %85 %122
-%123 = OpLoad %ulong %85
-%124 = OpLoad %ushort %69
-%125 = OpFunctionCall %ulong %8 %123 %124
-OpStore %86 %125
-%126 = OpLoad %ulong %86
-%127 = OpLoad %ushort %70
-%128 = OpFunctionCall %ulong %11 %126 %127
-OpStore %87 %128
-%129 = OpLoad %ulong %87
-%130 = OpLoad %uint %71
-%131 = OpFunctionCall %ulong %9 %129 %130
-OpStore %88 %131
-%132 = OpLoad %ulong %88
-%133 = OpLoad %uint %72
-%134 = OpFunctionCall %ulong %12 %132 %133
-OpStore %89 %134
-%135 = OpLoad %ulong %89
-%136 = OpLoad %ulong %73
-%137 = OpFunctionCall %ulong %6 %135 %136
-OpStore %90 %137
-%138 = OpLoad %ulong %90
-%139 = OpLoad %ulong %74
-%140 = OpFunctionCall %ulong %13 %138 %139
-OpStore %91 %140
-%141 = OpLoad %ulong %91
-OpReturnValue %141
-OpFunctionEnd
-%3 = OpFunction %ulong None %142
-%143 = OpFunctionParameter %uchar
-%144 = OpFunctionParameter %uchar
-%145 = OpFunctionParameter %uchar
-%146 = OpFunctionParameter %uchar
-%147 = OpFunctionParameter %ushort
-%148 = OpFunctionParameter %ushort
-%149 = OpFunctionParameter %ushort
-%150 = OpFunctionParameter %ushort
-%151 = OpFunctionParameter %uchar
-%152 = OpFunctionParameter %uchar
-%153 = OpFunctionParameter %ushort
-%154 = OpFunctionParameter %ushort
-%155 = OpFunctionParameter %uchar
-%156 = OpFunctionParameter %uchar
-%157 = OpFunctionParameter %ushort
-%158 = OpFunctionParameter %ushort
-%159 = OpLabel
-%160 = OpVariable %_ptr_Function_uchar Function
-%161 = OpVariable %_ptr_Function_uchar Function
-%162 = OpVariable %_ptr_Function_uchar Function
-%163 = OpVariable %_ptr_Function_uchar Function
-%164 = OpVariable %_ptr_Function_ushort Function
-%165 = OpVariable %_ptr_Function_ushort Function
-%166 = OpVariable %_ptr_Function_ushort Function
-%167 = OpVariable %_ptr_Function_ushort Function
-%168 = OpVariable %_ptr_Function_uchar Function
-%169 = OpVariable %_ptr_Function_uchar Function
-%170 = OpVariable %_ptr_Function_ushort Function
-%171 = OpVariable %_ptr_Function_ushort Function
-%172 = OpVariable %_ptr_Function_uchar Function
-%173 = OpVariable %_ptr_Function_uchar Function
-%174 = OpVariable %_ptr_Function_ushort Function
-%175 = OpVariable %_ptr_Function_ushort Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
+%47 = OpLabel
+%176 = OpVariable %_ptr_Function_uchar Function
+%177 = OpVariable %_ptr_Function_uchar Function
+%179 = OpVariable %_ptr_Function_ushort Function
+%180 = OpVariable %_ptr_Function_ushort Function
+%182 = OpVariable %_ptr_Function_uint Function
+%183 = OpVariable %_ptr_Function_uint Function
 %184 = OpVariable %_ptr_Function_ulong Function
 %185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_uchar Function
+%187 = OpVariable %_ptr_Function_uchar Function
+%188 = OpVariable %_ptr_Function_ushort Function
+%189 = OpVariable %_ptr_Function_ushort Function
+%190 = OpVariable %_ptr_Function_uint Function
+%191 = OpVariable %_ptr_Function_uint Function
 %192 = OpVariable %_ptr_Function_ulong Function
-OpStore %160 %143
-OpStore %161 %144
-OpStore %162 %145
-OpStore %163 %146
-OpStore %164 %147
-OpStore %165 %148
-OpStore %166 %149
-OpStore %167 %150
-OpStore %168 %151
-OpStore %169 %152
-OpStore %170 %153
-OpStore %171 %154
-OpStore %172 %155
-OpStore %173 %156
-OpStore %174 %157
-OpStore %175 %158
-%193 = OpFunctionCall %ulong %5
-OpStore %176 %193
-%194 = OpLoad %ulong %176
-%195 = OpLoad %uchar %160
-%196 = OpFunctionCall %ulong %7 %194 %195
-OpStore %177 %196
-%197 = OpLoad %ulong %177
-%198 = OpLoad %uchar %161
-%199 = OpFunctionCall %ulong %7 %197 %198
-OpStore %178 %199
-%200 = OpLoad %ulong %178
-%201 = OpLoad %uchar %162
-%202 = OpFunctionCall %ulong %10 %200 %201
-OpStore %179 %202
-%203 = OpLoad %ulong %179
-%204 = OpLoad %uchar %163
-%205 = OpFunctionCall %ulong %10 %203 %204
-OpStore %180 %205
-%206 = OpLoad %ulong %180
-%207 = OpLoad %ushort %164
-%208 = OpFunctionCall %ulong %8 %206 %207
-OpStore %181 %208
-%209 = OpLoad %ulong %181
-%210 = OpLoad %ushort %165
-%211 = OpFunctionCall %ulong %8 %209 %210
-OpStore %182 %211
-%212 = OpLoad %ulong %182
-%213 = OpLoad %ushort %166
-%214 = OpFunctionCall %ulong %11 %212 %213
-OpStore %183 %214
-%215 = OpLoad %ulong %183
-%216 = OpLoad %ushort %167
-%217 = OpFunctionCall %ulong %11 %215 %216
-OpStore %184 %217
-%218 = OpLoad %ulong %184
-%219 = OpLoad %uchar %168
-%220 = OpFunctionCall %ulong %7 %218 %219
-OpStore %185 %220
-%221 = OpLoad %ulong %185
-%222 = OpLoad %uchar %169
-%223 = OpFunctionCall %ulong %10 %221 %222
-OpStore %186 %223
-%224 = OpLoad %ulong %186
-%225 = OpLoad %ushort %170
-%226 = OpFunctionCall %ulong %8 %224 %225
-OpStore %187 %226
-%227 = OpLoad %ulong %187
-%228 = OpLoad %ushort %171
-%229 = OpFunctionCall %ulong %11 %227 %228
-OpStore %188 %229
-%230 = OpLoad %ulong %188
-%231 = OpLoad %uchar %172
-%232 = OpFunctionCall %ulong %7 %230 %231
-OpStore %189 %232
-%233 = OpLoad %ulong %189
-%234 = OpLoad %uchar %173
-%235 = OpFunctionCall %ulong %10 %233 %234
-OpStore %190 %235
-%236 = OpLoad %ulong %190
-%237 = OpLoad %ushort %174
-%238 = OpFunctionCall %ulong %8 %236 %237
-OpStore %191 %238
-%239 = OpLoad %ulong %191
-%240 = OpLoad %ushort %175
-%241 = OpFunctionCall %ulong %11 %239 %240
-OpStore %192 %241
-%242 = OpLoad %ulong %192
-OpReturnValue %242
-OpFunctionEnd
-%4 = OpFunction %ulong None %243
-%244 = OpFunctionParameter %ulong
-%245 = OpLabel
-%270 = OpVariable %_ptr_Function__arr_ulong_uint_20 Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_bool Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_bool Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_bool Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_bool Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_bool Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
 %271 = OpVariable %_ptr_Function_ulong Function
 %272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
 %274 = OpVariable %_ptr_Function_bool Function
 %275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_uchar Function
+%280 = OpVariable %_ptr_Function_ulong Function
 %281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_uchar Function
+%282 = OpVariable %_ptr_Function_ulong Function
 %283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_ushort Function
+%284 = OpVariable %_ptr_Function_bool Function
 %285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ushort Function
+%286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_ulong Function
 %289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_uint Function
+%290 = OpVariable %_ptr_Function_ulong Function
 %291 = OpVariable %_ptr_Function_ulong Function
 %292 = OpVariable %_ptr_Function_ulong Function
 %293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_uchar Function
+%294 = OpVariable %_ptr_Function_bool Function
+%295 = OpVariable %_ptr_Function_ulong Function
 %296 = OpVariable %_ptr_Function_ulong Function
-%297 = OpVariable %_ptr_Function_uchar Function
+%297 = OpVariable %_ptr_Function_ulong Function
 %298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_ushort Function
+%299 = OpVariable %_ptr_Function_ulong Function
 %300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_ushort Function
+%301 = OpVariable %_ptr_Function_ulong Function
 %302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_uint Function
-%304 = OpVariable %_ptr_Function_ulong Function
-%305 = OpVariable %_ptr_Function_uint Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_bool Function
+%305 = OpVariable %_ptr_Function_ulong Function
 %306 = OpVariable %_ptr_Function_ulong Function
 %307 = OpVariable %_ptr_Function_ulong Function
 %308 = OpVariable %_ptr_Function_ulong Function
 %309 = OpVariable %_ptr_Function_ulong Function
 %310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_uchar Function
+%311 = OpVariable %_ptr_Function_ulong Function
 %312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_uchar Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_uchar Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
 %316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_uchar Function
+%317 = OpVariable %_ptr_Function_ulong Function
 %318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_ushort Function
+%319 = OpVariable %_ptr_Function_ulong Function
 %320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_ushort Function
+%321 = OpVariable %_ptr_Function_ulong Function
 %322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_ushort Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_ushort Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
 %326 = OpVariable %_ptr_Function_ulong Function
 %327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_uchar Function
+%328 = OpVariable %_ptr_Function_ulong Function
 %329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_uchar Function
+%330 = OpVariable %_ptr_Function_ulong Function
 %331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_ushort Function
-%333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_ushort Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_bool Function
+%334 = OpVariable %_ptr_Function_ulong Function
 %335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_uchar Function
+%336 = OpVariable %_ptr_Function_ulong Function
 %337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_uchar Function
+%338 = OpVariable %_ptr_Function_ulong Function
 %339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ushort Function
+%340 = OpVariable %_ptr_Function_ulong Function
 %341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_ulong Function
-%343 = OpVariable %_ptr_Function_ushort Function
+%342 = OpVariable %_ptr_Function_bool Function
+%343 = OpVariable %_ptr_Function_ulong Function
 %344 = OpVariable %_ptr_Function_ulong Function
 %345 = OpVariable %_ptr_Function_ulong Function
 %346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_uchar Function
+%347 = OpVariable %_ptr_Function_ulong Function
 %348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_uchar Function
+%349 = OpVariable %_ptr_Function_ulong Function
 %350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_ushort Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_ushort Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_uint Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_uint Function
-%358 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_uchar Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_uchar Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_ushort Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_ushort Function
-%368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_uint Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_uint Function
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_uchar Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_uchar Function
-%377 = OpVariable %_ptr_Function_ulong Function
-%378 = OpVariable %_ptr_Function_ushort Function
-%379 = OpVariable %_ptr_Function_ulong Function
-%380 = OpVariable %_ptr_Function_ushort Function
-%381 = OpVariable %_ptr_Function_uint Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_uint Function
-%384 = OpVariable %_ptr_Function_ulong Function
-%385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_uchar Function
-%388 = OpVariable %_ptr_Function_ulong Function
-%389 = OpVariable %_ptr_Function_uchar Function
-%390 = OpVariable %_ptr_Function_ulong Function
-%391 = OpVariable %_ptr_Function_uchar Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_uchar Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_ushort Function
-%396 = OpVariable %_ptr_Function_ulong Function
-%397 = OpVariable %_ptr_Function_ushort Function
-%398 = OpVariable %_ptr_Function_ulong Function
-%399 = OpVariable %_ptr_Function_ushort Function
-%400 = OpVariable %_ptr_Function_ulong Function
-%401 = OpVariable %_ptr_Function_ushort Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_uchar Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_uchar Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_ushort Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_ushort Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_uchar Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_uchar Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_ushort Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_ushort Function
-%418 = OpVariable %_ptr_Function_uchar Function
-%419 = OpVariable %_ptr_Function_ulong Function
-%420 = OpVariable %_ptr_Function_uchar Function
-%421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_ushort Function
-%423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ushort Function
-%425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_uint Function
-%427 = OpVariable %_ptr_Function_ulong Function
-%428 = OpVariable %_ptr_Function_uint Function
-%429 = OpVariable %_ptr_Function_ulong Function
-%430 = OpVariable %_ptr_Function_ulong Function
-%431 = OpVariable %_ptr_Function_ulong Function
-%432 = OpVariable %_ptr_Function_ulong Function
-%433 = OpVariable %_ptr_Function_ulong Function
-%434 = OpVariable %_ptr_Function_ulong Function
-%435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_ulong Function
-%437 = OpVariable %_ptr_Function_ulong Function
-%438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_ulong Function
-%442 = OpVariable %_ptr_Function_ulong Function
-%443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_ulong Function
-%446 = OpVariable %_ptr_Function_ulong Function
-%447 = OpVariable %_ptr_Function_ulong Function
-%448 = OpVariable %_ptr_Function_ulong Function
-%449 = OpVariable %_ptr_Function_ulong Function
-%450 = OpVariable %_ptr_Function_ulong Function
-%451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_ulong Function
-%454 = OpVariable %_ptr_Function_ulong Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_ulong Function
-%470 = OpVariable %_ptr_Function_ulong Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_ulong Function
-%473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_ulong Function
-%476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_ulong Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_ulong Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_ulong Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_ulong Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_ulong Function
-%497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_ulong Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_ulong Function
-%501 = OpVariable %_ptr_Function_ulong Function
-%502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_ulong Function
-OpStore %271 %244
-%524 = OpFunctionCall %ulong %5
-OpStore %272 %524
-OpStore %270 %525
-OpStore %433 %ulong_0
-OpBranch %246
-%246 = OpLabel
-%527 = OpLoad %ulong %433
-%529 = OpULessThan %bool %527 %ulong_20
-OpStore %274 %529
-%530 = OpLoad %bool %274
-OpLoopMerge %248 %265 None
-OpBranchConditional %530 %247 %248
-%248 = OpLabel
-%531 = OpLoad %ulong %272
-OpStore %432 %531
-OpStore %434 %ulong_0
-OpStore %435 %ulong_0
-OpBranch %249
-%249 = OpLabel
-%532 = OpLoad %ulong %435
-%534 = OpULessThan %bool %532 %ulong_3
-OpStore %276 %534
-%535 = OpLoad %bool %276
-OpLoopMerge %251 %264 None
-OpBranchConditional %535 %250 %251
-%251 = OpLabel
-%537 = OpAccessChain %_ptr_Function_ulong %270 %uint_0
-%538 = OpLoad %ulong %537
-OpStore %346 %538
-%539 = OpLoad %ulong %346
-%540 = OpUConvert %uchar %539
-OpStore %347 %540
-%542 = OpAccessChain %_ptr_Function_ulong %270 %uint_1
-%543 = OpLoad %ulong %542
-OpStore %348 %543
-%544 = OpLoad %ulong %348
-%545 = OpUConvert %uchar %544
-OpStore %349 %545
-%547 = OpAccessChain %_ptr_Function_ulong %270 %uint_2
-%548 = OpLoad %ulong %547
-OpStore %350 %548
-%549 = OpLoad %ulong %350
-%550 = OpUConvert %ushort %549
-OpStore %351 %550
-%552 = OpAccessChain %_ptr_Function_ulong %270 %uint_3
-%553 = OpLoad %ulong %552
-OpStore %352 %553
-%554 = OpLoad %ulong %352
-%555 = OpUConvert %ushort %554
-OpStore %353 %555
-%557 = OpAccessChain %_ptr_Function_ulong %270 %uint_4
-%558 = OpLoad %ulong %557
-OpStore %354 %558
-%559 = OpLoad %ulong %354
-%560 = OpUConvert %uint %559
-OpStore %355 %560
-%562 = OpAccessChain %_ptr_Function_ulong %270 %uint_5
-%563 = OpLoad %ulong %562
-OpStore %356 %563
-%564 = OpLoad %ulong %356
-%565 = OpUConvert %uint %564
-OpStore %357 %565
-%567 = OpAccessChain %_ptr_Function_ulong %270 %uint_6
-%568 = OpLoad %ulong %567
-OpStore %358 %568
-%570 = OpAccessChain %_ptr_Function_ulong %270 %uint_7
-%571 = OpLoad %ulong %570
-OpStore %359 %571
-%573 = OpAccessChain %_ptr_Function_ulong %270 %uint_8
-%574 = OpLoad %ulong %573
-OpStore %360 %574
-%575 = OpLoad %ulong %360
-%576 = OpUConvert %uchar %575
-OpStore %361 %576
-%578 = OpAccessChain %_ptr_Function_ulong %270 %uint_9
-%579 = OpLoad %ulong %578
-OpStore %362 %579
-%580 = OpLoad %ulong %362
-%581 = OpUConvert %uchar %580
-OpStore %363 %581
-%583 = OpAccessChain %_ptr_Function_ulong %270 %uint_10
-%584 = OpLoad %ulong %583
-OpStore %364 %584
-%585 = OpLoad %ulong %364
-%586 = OpUConvert %ushort %585
-OpStore %365 %586
-%588 = OpAccessChain %_ptr_Function_ulong %270 %uint_11
-%589 = OpLoad %ulong %588
-OpStore %366 %589
-%590 = OpLoad %ulong %366
-%591 = OpUConvert %ushort %590
-OpStore %367 %591
-%593 = OpAccessChain %_ptr_Function_ulong %270 %uint_12
-%594 = OpLoad %ulong %593
-OpStore %368 %594
-%595 = OpLoad %ulong %368
-%596 = OpUConvert %uint %595
-OpStore %369 %596
-%598 = OpAccessChain %_ptr_Function_ulong %270 %uint_13
-%599 = OpLoad %ulong %598
-OpStore %370 %599
-%600 = OpLoad %ulong %370
-%601 = OpUConvert %uint %600
-OpStore %371 %601
-%603 = OpAccessChain %_ptr_Function_ulong %270 %uint_14
-%604 = OpLoad %ulong %603
-OpStore %372 %604
-%606 = OpAccessChain %_ptr_Function_ulong %270 %uint_15
-%607 = OpLoad %ulong %606
-OpStore %373 %607
-OpBranch %256
-%256 = OpLabel
-%608 = OpFunctionCall %ulong %5
-OpStore %456 %608
-%609 = OpLoad %ulong %456
-%610 = OpLoad %uchar %347
-%611 = OpFunctionCall %ulong %7 %609 %610
-OpStore %457 %611
-%612 = OpLoad %ulong %457
-%613 = OpLoad %uchar %349
-%614 = OpFunctionCall %ulong %10 %612 %613
-OpStore %458 %614
-%615 = OpLoad %ulong %458
-%616 = OpLoad %ushort %351
-%617 = OpFunctionCall %ulong %8 %615 %616
-OpStore %459 %617
-%618 = OpLoad %ulong %459
-%619 = OpLoad %ushort %353
-%620 = OpFunctionCall %ulong %11 %618 %619
-OpStore %460 %620
-%621 = OpLoad %ulong %460
-%622 = OpLoad %uint %355
-%623 = OpFunctionCall %ulong %9 %621 %622
-OpStore %461 %623
-%624 = OpLoad %ulong %461
-%625 = OpLoad %uint %357
-%626 = OpFunctionCall %ulong %12 %624 %625
-OpStore %462 %626
-%627 = OpLoad %ulong %462
-%628 = OpLoad %ulong %358
-%629 = OpFunctionCall %ulong %6 %627 %628
-OpStore %463 %629
-%630 = OpLoad %ulong %463
-%631 = OpLoad %ulong %359
-%632 = OpFunctionCall %ulong %13 %630 %631
-OpStore %464 %632
-%633 = OpLoad %ulong %464
-%634 = OpLoad %uchar %361
-%635 = OpFunctionCall %ulong %7 %633 %634
-OpStore %465 %635
-%636 = OpLoad %ulong %465
-%637 = OpLoad %uchar %363
-%638 = OpFunctionCall %ulong %10 %636 %637
-OpStore %466 %638
-%639 = OpLoad %ulong %466
-%640 = OpLoad %ushort %365
-%641 = OpFunctionCall %ulong %8 %639 %640
-OpStore %467 %641
-%642 = OpLoad %ulong %467
-%643 = OpLoad %ushort %367
-%644 = OpFunctionCall %ulong %11 %642 %643
-OpStore %468 %644
-%645 = OpLoad %ulong %468
-%646 = OpLoad %uint %369
-%647 = OpFunctionCall %ulong %9 %645 %646
-OpStore %469 %647
-%648 = OpLoad %ulong %469
-%649 = OpLoad %uint %371
-%650 = OpFunctionCall %ulong %12 %648 %649
-OpStore %470 %650
-%651 = OpLoad %ulong %470
-%652 = OpLoad %ulong %372
-%653 = OpFunctionCall %ulong %6 %651 %652
-OpStore %471 %653
-%654 = OpLoad %ulong %471
-%655 = OpLoad %ulong %373
-%656 = OpFunctionCall %ulong %13 %654 %655
-OpStore %472 %656
-OpBranch %257
-%257 = OpLabel
-%657 = OpLoad %ulong %472
-%658 = OpUConvert %uchar %657
-OpStore %374 %658
-%659 = OpAccessChain %_ptr_Function_ulong %270 %uint_1
-%660 = OpLoad %ulong %659
-OpStore %375 %660
-%661 = OpLoad %ulong %375
-%662 = OpUConvert %uchar %661
-OpStore %376 %662
-%663 = OpAccessChain %_ptr_Function_ulong %270 %uint_2
-%664 = OpLoad %ulong %663
-OpStore %377 %664
-%665 = OpLoad %ulong %377
-%666 = OpUConvert %ushort %665
-OpStore %378 %666
-%667 = OpAccessChain %_ptr_Function_ulong %270 %uint_3
-%668 = OpLoad %ulong %667
-OpStore %379 %668
-%669 = OpLoad %ulong %379
-%670 = OpUConvert %ushort %669
-OpStore %380 %670
-%671 = OpLoad %ulong %434
-%672 = OpUConvert %uint %671
-OpStore %381 %672
-%673 = OpAccessChain %_ptr_Function_ulong %270 %uint_5
-%674 = OpLoad %ulong %673
-OpStore %382 %674
-%675 = OpLoad %ulong %382
-%676 = OpUConvert %uint %675
-OpStore %383 %676
-%677 = OpAccessChain %_ptr_Function_ulong %270 %uint_6
-%678 = OpLoad %ulong %677
-OpStore %384 %678
-%679 = OpAccessChain %_ptr_Function_ulong %270 %uint_7
-%680 = OpLoad %ulong %679
-OpStore %385 %680
-%682 = OpAccessChain %_ptr_Function_ulong %270 %uint_16
-%683 = OpLoad %ulong %682
-OpStore %386 %683
-%684 = OpLoad %ulong %386
-%685 = OpUConvert %uchar %684
-OpStore %387 %685
-%687 = OpAccessChain %_ptr_Function_ulong %270 %uint_17
-%688 = OpLoad %ulong %687
-OpStore %388 %688
-%689 = OpLoad %ulong %388
-%690 = OpUConvert %uchar %689
-OpStore %389 %690
-%692 = OpAccessChain %_ptr_Function_ulong %270 %uint_18
-%693 = OpLoad %ulong %692
-OpStore %390 %693
-%694 = OpLoad %ulong %390
-%695 = OpUConvert %uchar %694
-OpStore %391 %695
-%697 = OpAccessChain %_ptr_Function_ulong %270 %uint_19
-%698 = OpLoad %ulong %697
-OpStore %392 %698
-%699 = OpLoad %ulong %392
-%700 = OpUConvert %uchar %699
-OpStore %393 %700
-%701 = OpAccessChain %_ptr_Function_ulong %270 %uint_4
-%702 = OpLoad %ulong %701
-OpStore %394 %702
-%703 = OpLoad %ulong %394
-%704 = OpUConvert %ushort %703
-OpStore %395 %704
-%705 = OpLoad %ulong %673
-OpStore %396 %705
-%706 = OpLoad %ulong %396
-%707 = OpUConvert %ushort %706
-OpStore %397 %707
-%708 = OpLoad %ulong %677
-OpStore %398 %708
-%709 = OpLoad %ulong %398
-%710 = OpUConvert %ushort %709
-OpStore %399 %710
-%711 = OpLoad %ulong %679
-OpStore %400 %711
-%712 = OpLoad %ulong %400
-%713 = OpUConvert %ushort %712
-OpStore %401 %713
-%714 = OpAccessChain %_ptr_Function_ulong %270 %uint_8
-%715 = OpLoad %ulong %714
-OpStore %402 %715
-%716 = OpLoad %ulong %402
-%717 = OpUConvert %uchar %716
-OpStore %403 %717
-%718 = OpAccessChain %_ptr_Function_ulong %270 %uint_9
-%719 = OpLoad %ulong %718
-OpStore %404 %719
-%720 = OpLoad %ulong %404
-%721 = OpUConvert %uchar %720
-OpStore %405 %721
-%722 = OpAccessChain %_ptr_Function_ulong %270 %uint_10
-%723 = OpLoad %ulong %722
-OpStore %406 %723
-%724 = OpLoad %ulong %406
-%725 = OpUConvert %ushort %724
-OpStore %407 %725
-%726 = OpAccessChain %_ptr_Function_ulong %270 %uint_11
-%727 = OpLoad %ulong %726
-OpStore %408 %727
-%728 = OpLoad %ulong %408
-%729 = OpUConvert %ushort %728
-OpStore %409 %729
-%730 = OpAccessChain %_ptr_Function_ulong %270 %uint_12
-%731 = OpLoad %ulong %730
-OpStore %410 %731
-%732 = OpLoad %ulong %410
-%733 = OpUConvert %uchar %732
-OpStore %411 %733
-%734 = OpAccessChain %_ptr_Function_ulong %270 %uint_13
-%735 = OpLoad %ulong %734
-OpStore %412 %735
-%736 = OpLoad %ulong %412
-%737 = OpUConvert %uchar %736
-OpStore %413 %737
-%738 = OpAccessChain %_ptr_Function_ulong %270 %uint_14
-%739 = OpLoad %ulong %738
-OpStore %414 %739
-%740 = OpLoad %ulong %414
-%741 = OpUConvert %ushort %740
-OpStore %415 %741
-%742 = OpAccessChain %_ptr_Function_ulong %270 %uint_15
-%743 = OpLoad %ulong %742
-OpStore %416 %743
-%744 = OpLoad %ulong %416
-%745 = OpUConvert %ushort %744
-OpStore %417 %745
-OpBranch %260
-%260 = OpLabel
-%746 = OpFunctionCall %ulong %5
-OpStore %490 %746
-%747 = OpLoad %ulong %490
-%748 = OpLoad %uchar %387
-%749 = OpFunctionCall %ulong %7 %747 %748
-OpStore %491 %749
-%750 = OpLoad %ulong %491
-%751 = OpLoad %uchar %389
-%752 = OpFunctionCall %ulong %7 %750 %751
-OpStore %492 %752
-%753 = OpLoad %ulong %492
-%754 = OpLoad %uchar %391
-%755 = OpFunctionCall %ulong %10 %753 %754
-OpStore %493 %755
-%756 = OpLoad %ulong %493
-%757 = OpLoad %uchar %393
-%758 = OpFunctionCall %ulong %10 %756 %757
-OpStore %494 %758
-%759 = OpLoad %ulong %494
-%760 = OpLoad %ushort %395
-%761 = OpFunctionCall %ulong %8 %759 %760
-OpStore %495 %761
-%762 = OpLoad %ulong %495
-%763 = OpLoad %ushort %397
-%764 = OpFunctionCall %ulong %8 %762 %763
-OpStore %496 %764
-%765 = OpLoad %ulong %496
-%766 = OpLoad %ushort %399
-%767 = OpFunctionCall %ulong %11 %765 %766
-OpStore %497 %767
-%768 = OpLoad %ulong %497
-%769 = OpLoad %ushort %401
-%770 = OpFunctionCall %ulong %11 %768 %769
-OpStore %498 %770
-%771 = OpLoad %ulong %498
-%772 = OpLoad %uchar %403
-%773 = OpFunctionCall %ulong %7 %771 %772
-OpStore %499 %773
-%774 = OpLoad %ulong %499
-%775 = OpLoad %uchar %405
-%776 = OpFunctionCall %ulong %10 %774 %775
-OpStore %500 %776
-%777 = OpLoad %ulong %500
-%778 = OpLoad %ushort %407
-%779 = OpFunctionCall %ulong %8 %777 %778
-OpStore %501 %779
-%780 = OpLoad %ulong %501
-%781 = OpLoad %ushort %409
-%782 = OpFunctionCall %ulong %11 %780 %781
-OpStore %502 %782
-%783 = OpLoad %ulong %502
-%784 = OpLoad %uchar %411
-%785 = OpFunctionCall %ulong %7 %783 %784
-OpStore %503 %785
-%786 = OpLoad %ulong %503
-%787 = OpLoad %uchar %413
-%788 = OpFunctionCall %ulong %10 %786 %787
-OpStore %504 %788
-%789 = OpLoad %ulong %504
-%790 = OpLoad %ushort %415
-%791 = OpFunctionCall %ulong %8 %789 %790
-OpStore %505 %791
-%792 = OpLoad %ulong %505
-%793 = OpLoad %ushort %417
-%794 = OpFunctionCall %ulong %11 %792 %793
-OpStore %506 %794
-OpBranch %261
-%261 = OpLabel
-%795 = OpLoad %ulong %506
-%796 = OpUConvert %uchar %795
-OpStore %418 %796
-%797 = OpAccessChain %_ptr_Function_ulong %270 %uint_9
-%798 = OpLoad %ulong %797
-OpStore %419 %798
-%799 = OpLoad %ulong %419
-%800 = OpUConvert %uchar %799
-OpStore %420 %800
-%801 = OpAccessChain %_ptr_Function_ulong %270 %uint_10
-%802 = OpLoad %ulong %801
-OpStore %421 %802
-%803 = OpLoad %ulong %421
-%804 = OpUConvert %ushort %803
-OpStore %422 %804
-%805 = OpAccessChain %_ptr_Function_ulong %270 %uint_11
-%806 = OpLoad %ulong %805
-OpStore %423 %806
-%807 = OpLoad %ulong %423
-%808 = OpUConvert %ushort %807
-OpStore %424 %808
-%809 = OpAccessChain %_ptr_Function_ulong %270 %uint_12
-%810 = OpLoad %ulong %809
-OpStore %425 %810
-%811 = OpLoad %ulong %425
-%812 = OpUConvert %uint %811
-OpStore %426 %812
-%813 = OpAccessChain %_ptr_Function_ulong %270 %uint_13
-%814 = OpLoad %ulong %813
-OpStore %427 %814
-%815 = OpLoad %ulong %427
-%816 = OpUConvert %uint %815
-OpStore %428 %816
-%817 = OpAccessChain %_ptr_Function_ulong %270 %uint_14
-%818 = OpLoad %ulong %817
-OpStore %429 %818
-%819 = OpAccessChain %_ptr_Function_ulong %270 %uint_15
-%820 = OpLoad %ulong %819
-OpStore %430 %820
-OpBranch %262
-%262 = OpLabel
-%821 = OpFunctionCall %ulong %5
-OpStore %507 %821
-%822 = OpLoad %ulong %507
-%823 = OpLoad %uchar %374
-%824 = OpFunctionCall %ulong %7 %822 %823
-OpStore %508 %824
-%825 = OpLoad %ulong %508
-%826 = OpLoad %uchar %376
-%827 = OpFunctionCall %ulong %10 %825 %826
-OpStore %509 %827
-%828 = OpLoad %ulong %509
-%829 = OpLoad %ushort %378
-%830 = OpFunctionCall %ulong %8 %828 %829
-OpStore %510 %830
-%831 = OpLoad %ulong %510
-%832 = OpLoad %ushort %380
-%833 = OpFunctionCall %ulong %11 %831 %832
-OpStore %511 %833
-%834 = OpLoad %ulong %511
-%835 = OpLoad %uint %381
-%836 = OpFunctionCall %ulong %9 %834 %835
-OpStore %512 %836
-%837 = OpLoad %ulong %512
-%838 = OpLoad %uint %383
-%839 = OpFunctionCall %ulong %12 %837 %838
-OpStore %513 %839
-%840 = OpLoad %ulong %513
-%841 = OpLoad %ulong %384
-%842 = OpFunctionCall %ulong %6 %840 %841
-OpStore %514 %842
-%843 = OpLoad %ulong %514
-%844 = OpLoad %ulong %385
-%845 = OpFunctionCall %ulong %13 %843 %844
-OpStore %515 %845
-%846 = OpLoad %ulong %515
-%847 = OpLoad %uchar %418
-%848 = OpFunctionCall %ulong %7 %846 %847
-OpStore %516 %848
-%849 = OpLoad %ulong %516
-%850 = OpLoad %uchar %420
-%851 = OpFunctionCall %ulong %10 %849 %850
-OpStore %517 %851
-%852 = OpLoad %ulong %517
-%853 = OpLoad %ushort %422
-%854 = OpFunctionCall %ulong %8 %852 %853
-OpStore %518 %854
-%855 = OpLoad %ulong %518
-%856 = OpLoad %ushort %424
-%857 = OpFunctionCall %ulong %11 %855 %856
-OpStore %519 %857
-%858 = OpLoad %ulong %519
-%859 = OpLoad %uint %426
-%860 = OpFunctionCall %ulong %9 %858 %859
-OpStore %520 %860
-%861 = OpLoad %ulong %520
-%862 = OpLoad %uint %428
-%863 = OpFunctionCall %ulong %12 %861 %862
-OpStore %521 %863
-%864 = OpLoad %ulong %521
-%865 = OpLoad %ulong %429
-%866 = OpFunctionCall %ulong %6 %864 %865
-OpStore %522 %866
-%867 = OpLoad %ulong %522
-%868 = OpLoad %ulong %430
-%869 = OpFunctionCall %ulong %13 %867 %868
-OpStore %523 %869
-OpBranch %263
-%263 = OpLabel
-%870 = OpLoad %ulong %432
-%871 = OpLoad %ulong %523
-%872 = OpFunctionCall %ulong %6 %870 %871
-OpStore %431 %872
-%873 = OpLoad %ulong %431
-OpReturnValue %873
-%250 = OpLabel
-%874 = OpLoad %ulong %435
-%876 = OpIMul %ulong %874 %ulong_7
-OpStore %277 %876
-%877 = OpLoad %ulong %277
-%878 = OpLoad %ulong %271
-%879 = OpIAdd %ulong %877 %878
-OpStore %278 %879
-%880 = OpAccessChain %_ptr_Function_ulong %270 %uint_0
-%881 = OpLoad %ulong %880
-OpStore %279 %881
-%882 = OpLoad %ulong %279
-%883 = OpUConvert %uchar %882
-OpStore %280 %883
-%884 = OpAccessChain %_ptr_Function_ulong %270 %uint_1
-%885 = OpLoad %ulong %884
-OpStore %281 %885
-%886 = OpLoad %ulong %281
-%887 = OpUConvert %uchar %886
-OpStore %282 %887
-%888 = OpAccessChain %_ptr_Function_ulong %270 %uint_2
-%889 = OpLoad %ulong %888
-OpStore %283 %889
-%890 = OpLoad %ulong %283
-%891 = OpUConvert %ushort %890
-OpStore %284 %891
-%892 = OpAccessChain %_ptr_Function_ulong %270 %uint_3
-%893 = OpLoad %ulong %892
-OpStore %285 %893
-%894 = OpLoad %ulong %285
-%895 = OpUConvert %ushort %894
-OpStore %286 %895
-%896 = OpAccessChain %_ptr_Function_ulong %270 %uint_4
-%897 = OpLoad %ulong %896
-OpStore %287 %897
-%898 = OpLoad %ulong %287
-%899 = OpUConvert %uint %898
-OpStore %288 %899
-%900 = OpAccessChain %_ptr_Function_ulong %270 %uint_5
-%901 = OpLoad %ulong %900
-OpStore %289 %901
-%902 = OpLoad %ulong %289
-%903 = OpUConvert %uint %902
-OpStore %290 %903
-%904 = OpAccessChain %_ptr_Function_ulong %270 %uint_6
-%905 = OpLoad %ulong %904
-OpStore %291 %905
-%906 = OpLoad %ulong %291
-%907 = OpLoad %ulong %278
-%908 = OpIAdd %ulong %906 %907
-OpStore %292 %908
-%909 = OpAccessChain %_ptr_Function_ulong %270 %uint_7
-%910 = OpLoad %ulong %909
-OpStore %293 %910
-%911 = OpAccessChain %_ptr_Function_ulong %270 %uint_8
-%912 = OpLoad %ulong %911
-OpStore %294 %912
-%913 = OpLoad %ulong %294
-%914 = OpUConvert %uchar %913
-OpStore %295 %914
-%915 = OpAccessChain %_ptr_Function_ulong %270 %uint_9
-%916 = OpLoad %ulong %915
-OpStore %296 %916
-%917 = OpLoad %ulong %296
-%918 = OpUConvert %uchar %917
-OpStore %297 %918
-%919 = OpAccessChain %_ptr_Function_ulong %270 %uint_10
-%920 = OpLoad %ulong %919
-OpStore %298 %920
-%921 = OpLoad %ulong %298
-%922 = OpUConvert %ushort %921
-OpStore %299 %922
-%923 = OpAccessChain %_ptr_Function_ulong %270 %uint_11
-%924 = OpLoad %ulong %923
-OpStore %300 %924
-%925 = OpLoad %ulong %300
-%926 = OpUConvert %ushort %925
-OpStore %301 %926
-%927 = OpAccessChain %_ptr_Function_ulong %270 %uint_12
-%928 = OpLoad %ulong %927
-OpStore %302 %928
-%929 = OpLoad %ulong %302
-%930 = OpUConvert %uint %929
-OpStore %303 %930
-%931 = OpAccessChain %_ptr_Function_ulong %270 %uint_13
-%932 = OpLoad %ulong %931
-OpStore %304 %932
-%933 = OpLoad %ulong %304
-%934 = OpUConvert %uint %933
-OpStore %305 %934
-%935 = OpAccessChain %_ptr_Function_ulong %270 %uint_14
-%936 = OpLoad %ulong %935
-OpStore %306 %936
-%937 = OpLoad %ulong %306
-%938 = OpLoad %ulong %278
-%939 = OpIAdd %ulong %937 %938
-OpStore %307 %939
-%940 = OpAccessChain %_ptr_Function_ulong %270 %uint_15
-%941 = OpLoad %ulong %940
-OpStore %308 %941
-OpBranch %254
-%254 = OpLabel
-%942 = OpFunctionCall %ulong %5
-OpStore %439 %942
-%943 = OpLoad %ulong %439
-%944 = OpLoad %uchar %280
-%945 = OpFunctionCall %ulong %7 %943 %944
-OpStore %440 %945
-%946 = OpLoad %ulong %440
-%947 = OpLoad %uchar %282
-%948 = OpFunctionCall %ulong %10 %946 %947
-OpStore %441 %948
-%949 = OpLoad %ulong %441
-%950 = OpLoad %ushort %284
-%951 = OpFunctionCall %ulong %8 %949 %950
-OpStore %442 %951
-%952 = OpLoad %ulong %442
-%953 = OpLoad %ushort %286
-%954 = OpFunctionCall %ulong %11 %952 %953
-OpStore %443 %954
-%955 = OpLoad %ulong %443
-%956 = OpLoad %uint %288
-%957 = OpFunctionCall %ulong %9 %955 %956
-OpStore %444 %957
-%958 = OpLoad %ulong %444
-%959 = OpLoad %uint %290
-%960 = OpFunctionCall %ulong %12 %958 %959
-OpStore %445 %960
-%961 = OpLoad %ulong %445
-%962 = OpLoad %ulong %292
-%963 = OpFunctionCall %ulong %6 %961 %962
-OpStore %446 %963
-%964 = OpLoad %ulong %446
-%965 = OpLoad %ulong %293
-%966 = OpFunctionCall %ulong %13 %964 %965
-OpStore %447 %966
-%967 = OpLoad %ulong %447
-%968 = OpLoad %uchar %295
-%969 = OpFunctionCall %ulong %7 %967 %968
-OpStore %448 %969
-%970 = OpLoad %ulong %448
-%971 = OpLoad %uchar %297
-%972 = OpFunctionCall %ulong %10 %970 %971
-OpStore %449 %972
-%973 = OpLoad %ulong %449
-%974 = OpLoad %ushort %299
-%975 = OpFunctionCall %ulong %8 %973 %974
-OpStore %450 %975
-%976 = OpLoad %ulong %450
-%977 = OpLoad %ushort %301
-%978 = OpFunctionCall %ulong %11 %976 %977
-OpStore %451 %978
-%979 = OpLoad %ulong %451
-%980 = OpLoad %uint %303
-%981 = OpFunctionCall %ulong %9 %979 %980
-OpStore %452 %981
-%982 = OpLoad %ulong %452
-%983 = OpLoad %uint %305
-%984 = OpFunctionCall %ulong %12 %982 %983
-OpStore %453 %984
-%985 = OpLoad %ulong %453
-%986 = OpLoad %ulong %307
-%987 = OpFunctionCall %ulong %6 %985 %986
-OpStore %454 %987
-%988 = OpLoad %ulong %454
-%989 = OpLoad %ulong %308
-%990 = OpFunctionCall %ulong %13 %988 %989
-OpStore %455 %990
-OpBranch %255
-%255 = OpLabel
-%991 = OpLoad %ulong %432
-%992 = OpLoad %ulong %455
-%993 = OpFunctionCall %ulong %6 %991 %992
-OpStore %309 %993
-%994 = OpAccessChain %_ptr_Function_ulong %270 %uint_0
-%995 = OpLoad %ulong %994
-OpStore %310 %995
-%996 = OpLoad %ulong %310
-%997 = OpUConvert %uchar %996
-OpStore %311 %997
-%998 = OpAccessChain %_ptr_Function_ulong %270 %uint_1
-%999 = OpLoad %ulong %998
-OpStore %312 %999
-%1000 = OpLoad %ulong %312
-%1001 = OpUConvert %uchar %1000
-OpStore %313 %1001
-%1002 = OpAccessChain %_ptr_Function_ulong %270 %uint_2
-%1003 = OpLoad %ulong %1002
-OpStore %314 %1003
-%1004 = OpLoad %ulong %314
-%1005 = OpUConvert %uchar %1004
-OpStore %315 %1005
-%1006 = OpAccessChain %_ptr_Function_ulong %270 %uint_3
-%1007 = OpLoad %ulong %1006
-OpStore %316 %1007
-%1008 = OpLoad %ulong %316
-%1009 = OpUConvert %uchar %1008
-OpStore %317 %1009
-%1010 = OpAccessChain %_ptr_Function_ulong %270 %uint_4
-%1011 = OpLoad %ulong %1010
-OpStore %318 %1011
-%1012 = OpLoad %ulong %318
-%1013 = OpUConvert %ushort %1012
-OpStore %319 %1013
-%1014 = OpAccessChain %_ptr_Function_ulong %270 %uint_5
-%1015 = OpLoad %ulong %1014
-OpStore %320 %1015
-%1016 = OpLoad %ulong %320
-%1017 = OpUConvert %ushort %1016
-OpStore %321 %1017
-%1018 = OpAccessChain %_ptr_Function_ulong %270 %uint_6
-%1019 = OpLoad %ulong %1018
-OpStore %322 %1019
-%1020 = OpLoad %ulong %322
-%1021 = OpUConvert %ushort %1020
-OpStore %323 %1021
-%1022 = OpAccessChain %_ptr_Function_ulong %270 %uint_7
-%1023 = OpLoad %ulong %1022
-OpStore %324 %1023
-%1024 = OpLoad %ulong %324
-%1025 = OpUConvert %ushort %1024
-OpStore %325 %1025
-%1026 = OpAccessChain %_ptr_Function_ulong %270 %uint_8
-%1027 = OpLoad %ulong %1026
-OpStore %326 %1027
-%1028 = OpLoad %ulong %326
-%1029 = OpLoad %ulong %278
-%1030 = OpIAdd %ulong %1028 %1029
-OpStore %327 %1030
-%1031 = OpLoad %ulong %327
-%1032 = OpUConvert %uchar %1031
-OpStore %328 %1032
-%1033 = OpAccessChain %_ptr_Function_ulong %270 %uint_9
-%1034 = OpLoad %ulong %1033
-OpStore %329 %1034
-%1035 = OpLoad %ulong %329
-%1036 = OpUConvert %uchar %1035
-OpStore %330 %1036
-%1037 = OpAccessChain %_ptr_Function_ulong %270 %uint_10
-%1038 = OpLoad %ulong %1037
-OpStore %331 %1038
-%1039 = OpLoad %ulong %331
-%1040 = OpUConvert %ushort %1039
-OpStore %332 %1040
-%1041 = OpAccessChain %_ptr_Function_ulong %270 %uint_11
-%1042 = OpLoad %ulong %1041
-OpStore %333 %1042
-%1043 = OpLoad %ulong %333
-%1044 = OpUConvert %ushort %1043
-OpStore %334 %1044
-%1045 = OpAccessChain %_ptr_Function_ulong %270 %uint_12
-%1046 = OpLoad %ulong %1045
-OpStore %335 %1046
-%1047 = OpLoad %ulong %335
-%1048 = OpUConvert %uchar %1047
-OpStore %336 %1048
-%1049 = OpAccessChain %_ptr_Function_ulong %270 %uint_13
-%1050 = OpLoad %ulong %1049
-OpStore %337 %1050
-%1051 = OpLoad %ulong %337
-%1052 = OpUConvert %uchar %1051
-OpStore %338 %1052
-%1053 = OpAccessChain %_ptr_Function_ulong %270 %uint_14
-%1054 = OpLoad %ulong %1053
-OpStore %339 %1054
-%1055 = OpLoad %ulong %339
-%1056 = OpUConvert %ushort %1055
-OpStore %340 %1056
-%1057 = OpAccessChain %_ptr_Function_ulong %270 %uint_15
-%1058 = OpLoad %ulong %1057
-OpStore %341 %1058
-%1059 = OpLoad %ulong %341
-%1060 = OpLoad %ulong %278
-%1061 = OpIAdd %ulong %1059 %1060
-OpStore %342 %1061
-%1062 = OpLoad %ulong %342
-%1063 = OpUConvert %ushort %1062
-OpStore %343 %1063
-OpBranch %258
-%258 = OpLabel
-%1064 = OpFunctionCall %ulong %5
-OpStore %473 %1064
-%1065 = OpLoad %ulong %473
-%1066 = OpLoad %uchar %311
-%1067 = OpFunctionCall %ulong %7 %1065 %1066
-OpStore %474 %1067
-%1068 = OpLoad %ulong %474
-%1069 = OpLoad %uchar %313
-%1070 = OpFunctionCall %ulong %7 %1068 %1069
-OpStore %475 %1070
-%1071 = OpLoad %ulong %475
-%1072 = OpLoad %uchar %315
-%1073 = OpFunctionCall %ulong %10 %1071 %1072
-OpStore %476 %1073
-%1074 = OpLoad %ulong %476
-%1075 = OpLoad %uchar %317
-%1076 = OpFunctionCall %ulong %10 %1074 %1075
-OpStore %477 %1076
-%1077 = OpLoad %ulong %477
-%1078 = OpLoad %ushort %319
-%1079 = OpFunctionCall %ulong %8 %1077 %1078
-OpStore %478 %1079
-%1080 = OpLoad %ulong %478
-%1081 = OpLoad %ushort %321
-%1082 = OpFunctionCall %ulong %8 %1080 %1081
-OpStore %479 %1082
-%1083 = OpLoad %ulong %479
-%1084 = OpLoad %ushort %323
-%1085 = OpFunctionCall %ulong %11 %1083 %1084
-OpStore %480 %1085
-%1086 = OpLoad %ulong %480
-%1087 = OpLoad %ushort %325
-%1088 = OpFunctionCall %ulong %11 %1086 %1087
-OpStore %481 %1088
-%1089 = OpLoad %ulong %481
-%1090 = OpLoad %uchar %328
-%1091 = OpFunctionCall %ulong %7 %1089 %1090
-OpStore %482 %1091
-%1092 = OpLoad %ulong %482
-%1093 = OpLoad %uchar %330
-%1094 = OpFunctionCall %ulong %10 %1092 %1093
-OpStore %483 %1094
-%1095 = OpLoad %ulong %483
-%1096 = OpLoad %ushort %332
-%1097 = OpFunctionCall %ulong %8 %1095 %1096
-OpStore %484 %1097
-%1098 = OpLoad %ulong %484
-%1099 = OpLoad %ushort %334
-%1100 = OpFunctionCall %ulong %11 %1098 %1099
-OpStore %485 %1100
-%1101 = OpLoad %ulong %485
-%1102 = OpLoad %uchar %336
-%1103 = OpFunctionCall %ulong %7 %1101 %1102
-OpStore %486 %1103
-%1104 = OpLoad %ulong %486
-%1105 = OpLoad %uchar %338
-%1106 = OpFunctionCall %ulong %10 %1104 %1105
-OpStore %487 %1106
-%1107 = OpLoad %ulong %487
-%1108 = OpLoad %ushort %340
-%1109 = OpFunctionCall %ulong %8 %1107 %1108
-OpStore %488 %1109
-%1110 = OpLoad %ulong %488
-%1111 = OpLoad %ushort %343
-%1112 = OpFunctionCall %ulong %11 %1110 %1111
-OpStore %489 %1112
-OpBranch %259
-%259 = OpLabel
-%1113 = OpLoad %ulong %309
-%1114 = OpLoad %ulong %489
-%1115 = OpFunctionCall %ulong %6 %1113 %1114
-OpStore %344 %1115
-%1116 = OpLoad %ulong %435
-%1118 = OpIAdd %ulong %1116 %ulong_1
-OpStore %345 %1118
-%1119 = OpLoad %ulong %344
-OpStore %432 %1119
-%1120 = OpLoad %ulong %489
-OpStore %434 %1120
-%1121 = OpLoad %ulong %345
-OpStore %435 %1121
-OpBranch %264
-%247 = OpLabel
-OpBranch %252
-%252 = OpLabel
-%1122 = OpLoad %ulong %433
-%1123 = OpIMul %ulong %1122 %ulong_6364136223846793005
-OpStore %436 %1123
-%1124 = OpLoad %ulong %436
-%1125 = OpIAdd %ulong %1124 %ulong_1442695040888963407
-OpStore %437 %1125
-%1126 = OpLoad %ulong %437
-%1127 = OpLoad %ulong %271
-%1128 = OpIAdd %ulong %1126 %1127
-OpStore %438 %1128
-OpBranch %253
-%253 = OpLabel
-%1129 = OpLoad %ulong %433
-%1130 = OpAccessChain %_ptr_Function_ulong %270 %1129
-%1131 = OpLoad %ulong %438
-OpStore %1130 %1131
-%1132 = OpLoad %ulong %433
-%1133 = OpIAdd %ulong %1132 %ulong_1
-OpStore %275 %1133
-%1134 = OpLoad %ulong %275
-OpStore %433 %1134
-OpBranch %265
-%264 = OpLabel
-OpBranch %249
-%265 = OpLabel
-OpBranch %246
+OpStore %176 %31
+OpStore %177 %32
+OpStore %179 %33
+OpStore %180 %34
+OpStore %182 %35
+OpStore %183 %36
+OpStore %184 %37
+OpStore %185 %38
+OpStore %186 %39
+OpStore %187 %40
+OpStore %188 %41
+OpStore %189 %42
+OpStore %190 %43
+OpStore %191 %44
+OpStore %192 %45
+OpStore %193 %46
+OpBranch %48
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%351 = OpLoad %uchar %176
+%352 = OpUConvert %ulong %351
+OpStore %194 %352
+OpBranch %52
+%52 = OpLabel
+OpStore %203 %ulong_14695981039346656037
+OpStore %204 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%355 = OpLoad %ulong %204
+%357 = OpULessThan %bool %355 %ulong_8
+OpStore %196 %357
+%358 = OpLoad %bool %196
+OpLoopMerge %55 %173 None
+OpBranchConditional %358 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpBranch %51
+%51 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%359 = OpLoad %uchar %177
+%360 = OpSConvert %ulong %359
+OpStore %205 %360
+OpBranch %59
+%59 = OpLabel
+%361 = OpLoad %ulong %203
+OpStore %213 %361
+OpStore %214 %ulong_0
+OpBranch %60
+%60 = OpLabel
+%362 = OpLoad %ulong %214
+%363 = OpULessThan %bool %362 %ulong_8
+OpStore %206 %363
+%364 = OpLoad %bool %206
+OpLoopMerge %62 %172 None
+OpBranchConditional %364 %61 %62
+%62 = OpLabel
+OpBranch %63
+%63 = OpLabel
+OpBranch %58
+%58 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%365 = OpLoad %ushort %179
+%366 = OpUConvert %ulong %365
+OpStore %215 %366
+OpBranch %66
+%66 = OpLabel
+%367 = OpLoad %ulong %213
+OpStore %223 %367
+OpStore %224 %ulong_0
+OpBranch %67
+%67 = OpLabel
+%368 = OpLoad %ulong %224
+%369 = OpULessThan %bool %368 %ulong_8
+OpStore %216 %369
+%370 = OpLoad %bool %216
+OpLoopMerge %69 %171 None
+OpBranchConditional %370 %68 %69
+%69 = OpLabel
+OpBranch %70
+%70 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%371 = OpLoad %ushort %180
+%372 = OpSConvert %ulong %371
+OpStore %225 %372
+OpBranch %73
+%73 = OpLabel
+%373 = OpLoad %ulong %223
+OpStore %233 %373
+OpStore %234 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%374 = OpLoad %ulong %234
+%375 = OpULessThan %bool %374 %ulong_8
+OpStore %226 %375
+%376 = OpLoad %bool %226
+OpLoopMerge %76 %170 None
+OpBranchConditional %376 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%377 = OpLoad %uint %182
+%378 = OpUConvert %ulong %377
+OpStore %235 %378
+OpBranch %80
+%80 = OpLabel
+%379 = OpLoad %ulong %233
+OpStore %243 %379
+OpStore %244 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%380 = OpLoad %ulong %244
+%381 = OpULessThan %bool %380 %ulong_8
+OpStore %236 %381
+%382 = OpLoad %bool %236
+OpLoopMerge %83 %169 None
+OpBranchConditional %382 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%383 = OpLoad %uint %183
+%384 = OpSConvert %ulong %383
+OpStore %245 %384
+OpBranch %87
+%87 = OpLabel
+%385 = OpLoad %ulong %243
+OpStore %253 %385
+OpStore %254 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%386 = OpLoad %ulong %254
+%387 = OpULessThan %bool %386 %ulong_8
+OpStore %246 %387
+%388 = OpLoad %bool %246
+OpLoopMerge %90 %168 None
+OpBranchConditional %388 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %86
+%86 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%389 = OpLoad %ulong %253
+OpStore %262 %389
+OpStore %263 %ulong_0
+OpBranch %93
+%93 = OpLabel
+%390 = OpLoad %ulong %263
+%391 = OpULessThan %bool %390 %ulong_8
+OpStore %255 %391
+%392 = OpLoad %bool %255
+OpLoopMerge %95 %167 None
+OpBranchConditional %392 %94 %95
+%95 = OpLabel
+OpBranch %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %99
+%99 = OpLabel
+%393 = OpLoad %ulong %262
+OpStore %271 %393
+OpStore %272 %ulong_0
+OpBranch %100
+%100 = OpLabel
+%394 = OpLoad %ulong %272
+%395 = OpULessThan %bool %394 %ulong_8
+OpStore %264 %395
+%396 = OpLoad %bool %264
+OpLoopMerge %102 %166 None
+OpBranchConditional %396 %101 %102
+%102 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpBranch %104
+%104 = OpLabel
+%397 = OpLoad %uchar %186
+%398 = OpUConvert %ulong %397
+OpStore %273 %398
+OpBranch %106
+%106 = OpLabel
+%399 = OpLoad %ulong %271
+OpStore %281 %399
+OpStore %282 %ulong_0
+OpBranch %107
+%107 = OpLabel
+%400 = OpLoad %ulong %282
+%401 = OpULessThan %bool %400 %ulong_8
+OpStore %274 %401
+%402 = OpLoad %bool %274
+OpLoopMerge %109 %165 None
+OpBranchConditional %402 %108 %109
+%109 = OpLabel
+OpBranch %110
+%110 = OpLabel
+OpBranch %105
+%105 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%403 = OpLoad %uchar %187
+%404 = OpSConvert %ulong %403
+OpStore %283 %404
+OpBranch %113
+%113 = OpLabel
+%405 = OpLoad %ulong %281
+OpStore %291 %405
+OpStore %292 %ulong_0
+OpBranch %114
+%114 = OpLabel
+%406 = OpLoad %ulong %292
+%407 = OpULessThan %bool %406 %ulong_8
+OpStore %284 %407
+%408 = OpLoad %bool %284
+OpLoopMerge %116 %164 None
+OpBranchConditional %408 %115 %116
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
+OpBranch %112
+%112 = OpLabel
+OpBranch %118
+%118 = OpLabel
+%409 = OpLoad %ushort %188
+%410 = OpUConvert %ulong %409
+OpStore %293 %410
+OpBranch %120
+%120 = OpLabel
+%411 = OpLoad %ulong %291
+OpStore %301 %411
+OpStore %302 %ulong_0
+OpBranch %121
+%121 = OpLabel
+%412 = OpLoad %ulong %302
+%413 = OpULessThan %bool %412 %ulong_8
+OpStore %294 %413
+%414 = OpLoad %bool %294
+OpLoopMerge %123 %163 None
+OpBranchConditional %414 %122 %123
+%123 = OpLabel
+OpBranch %124
+%124 = OpLabel
+OpBranch %119
+%119 = OpLabel
+OpBranch %125
+%125 = OpLabel
+%415 = OpLoad %ushort %189
+%416 = OpSConvert %ulong %415
+OpStore %303 %416
+OpBranch %127
+%127 = OpLabel
+%417 = OpLoad %ulong %301
+OpStore %311 %417
+OpStore %312 %ulong_0
+OpBranch %128
+%128 = OpLabel
+%418 = OpLoad %ulong %312
+%419 = OpULessThan %bool %418 %ulong_8
+OpStore %304 %419
+%420 = OpLoad %bool %304
+OpLoopMerge %130 %162 None
+OpBranchConditional %420 %129 %130
+%130 = OpLabel
+OpBranch %131
+%131 = OpLabel
+OpBranch %126
+%126 = OpLabel
+OpBranch %132
+%132 = OpLabel
+%421 = OpLoad %uint %190
+%422 = OpUConvert %ulong %421
+OpStore %313 %422
+OpBranch %134
+%134 = OpLabel
+%423 = OpLoad %ulong %311
+OpStore %321 %423
+OpStore %322 %ulong_0
+OpBranch %135
+%135 = OpLabel
+%424 = OpLoad %ulong %322
+%425 = OpULessThan %bool %424 %ulong_8
+OpStore %314 %425
+%426 = OpLoad %bool %314
+OpLoopMerge %137 %161 None
+OpBranchConditional %426 %136 %137
+%137 = OpLabel
+OpBranch %138
+%138 = OpLabel
+OpBranch %133
+%133 = OpLabel
+OpBranch %139
+%139 = OpLabel
+%427 = OpLoad %uint %191
+%428 = OpSConvert %ulong %427
+OpStore %323 %428
+OpBranch %141
+%141 = OpLabel
+%429 = OpLoad %ulong %321
+OpStore %331 %429
+OpStore %332 %ulong_0
+OpBranch %142
+%142 = OpLabel
+%430 = OpLoad %ulong %332
+%431 = OpULessThan %bool %430 %ulong_8
+OpStore %324 %431
+%432 = OpLoad %bool %324
+OpLoopMerge %144 %160 None
+OpBranchConditional %432 %143 %144
+%144 = OpLabel
+OpBranch %145
+%145 = OpLabel
+OpBranch %140
+%140 = OpLabel
+OpBranch %146
+%146 = OpLabel
+%433 = OpLoad %ulong %331
+OpStore %340 %433
+OpStore %341 %ulong_0
+OpBranch %147
+%147 = OpLabel
+%434 = OpLoad %ulong %341
+%435 = OpULessThan %bool %434 %ulong_8
+OpStore %333 %435
+%436 = OpLoad %bool %333
+OpLoopMerge %149 %159 None
+OpBranchConditional %436 %148 %149
+%149 = OpLabel
+OpBranch %150
+%150 = OpLabel
+OpBranch %151
+%151 = OpLabel
+OpBranch %153
+%153 = OpLabel
+%437 = OpLoad %ulong %340
+OpStore %349 %437
+OpStore %350 %ulong_0
+OpBranch %154
+%154 = OpLabel
+%438 = OpLoad %ulong %350
+%439 = OpULessThan %bool %438 %ulong_8
+OpStore %342 %439
+%440 = OpLoad %bool %342
+OpLoopMerge %156 %158 None
+OpBranchConditional %440 %155 %156
+%156 = OpLabel
+OpBranch %157
+%157 = OpLabel
+OpBranch %152
+%152 = OpLabel
+%441 = OpLoad %ulong %349
+OpReturnValue %441
+%155 = OpLabel
+%442 = OpLoad %ulong %350
+%443 = OpIMul %ulong %442 %ulong_8
+OpStore %343 %443
+%444 = OpLoad %ulong %193
+%445 = OpLoad %ulong %343
+%446 = OpShiftRightLogical %ulong %444 %445
+OpStore %344 %446
+%447 = OpLoad %ulong %344
+%449 = OpBitwiseAnd %ulong %447 %ulong_255
+OpStore %345 %449
+%450 = OpLoad %ulong %349
+%451 = OpLoad %ulong %345
+%452 = OpBitwiseXor %ulong %450 %451
+OpStore %346 %452
+%453 = OpLoad %ulong %346
+%455 = OpIMul %ulong %453 %ulong_1099511628211
+OpStore %347 %455
+%456 = OpLoad %ulong %350
+%458 = OpIAdd %ulong %456 %ulong_1
+OpStore %348 %458
+%459 = OpLoad %ulong %347
+OpStore %349 %459
+%460 = OpLoad %ulong %348
+OpStore %350 %460
+OpBranch %158
+%148 = OpLabel
+%461 = OpLoad %ulong %341
+%462 = OpIMul %ulong %461 %ulong_8
+OpStore %334 %462
+%463 = OpLoad %ulong %192
+%464 = OpLoad %ulong %334
+%465 = OpShiftRightLogical %ulong %463 %464
+OpStore %335 %465
+%466 = OpLoad %ulong %335
+%467 = OpBitwiseAnd %ulong %466 %ulong_255
+OpStore %336 %467
+%468 = OpLoad %ulong %340
+%469 = OpLoad %ulong %336
+%470 = OpBitwiseXor %ulong %468 %469
+OpStore %337 %470
+%471 = OpLoad %ulong %337
+%472 = OpIMul %ulong %471 %ulong_1099511628211
+OpStore %338 %472
+%473 = OpLoad %ulong %341
+%474 = OpIAdd %ulong %473 %ulong_1
+OpStore %339 %474
+%475 = OpLoad %ulong %338
+OpStore %340 %475
+%476 = OpLoad %ulong %339
+OpStore %341 %476
+OpBranch %159
+%143 = OpLabel
+%477 = OpLoad %ulong %332
+%478 = OpIMul %ulong %477 %ulong_8
+OpStore %325 %478
+%479 = OpLoad %ulong %323
+%480 = OpLoad %ulong %325
+%481 = OpShiftRightLogical %ulong %479 %480
+OpStore %326 %481
+%482 = OpLoad %ulong %326
+%483 = OpBitwiseAnd %ulong %482 %ulong_255
+OpStore %327 %483
+%484 = OpLoad %ulong %331
+%485 = OpLoad %ulong %327
+%486 = OpBitwiseXor %ulong %484 %485
+OpStore %328 %486
+%487 = OpLoad %ulong %328
+%488 = OpIMul %ulong %487 %ulong_1099511628211
+OpStore %329 %488
+%489 = OpLoad %ulong %332
+%490 = OpIAdd %ulong %489 %ulong_1
+OpStore %330 %490
+%491 = OpLoad %ulong %329
+OpStore %331 %491
+%492 = OpLoad %ulong %330
+OpStore %332 %492
+OpBranch %160
+%136 = OpLabel
+%493 = OpLoad %ulong %322
+%494 = OpIMul %ulong %493 %ulong_8
+OpStore %315 %494
+%495 = OpLoad %ulong %313
+%496 = OpLoad %ulong %315
+%497 = OpShiftRightLogical %ulong %495 %496
+OpStore %316 %497
+%498 = OpLoad %ulong %316
+%499 = OpBitwiseAnd %ulong %498 %ulong_255
+OpStore %317 %499
+%500 = OpLoad %ulong %321
+%501 = OpLoad %ulong %317
+%502 = OpBitwiseXor %ulong %500 %501
+OpStore %318 %502
+%503 = OpLoad %ulong %318
+%504 = OpIMul %ulong %503 %ulong_1099511628211
+OpStore %319 %504
+%505 = OpLoad %ulong %322
+%506 = OpIAdd %ulong %505 %ulong_1
+OpStore %320 %506
+%507 = OpLoad %ulong %319
+OpStore %321 %507
+%508 = OpLoad %ulong %320
+OpStore %322 %508
+OpBranch %161
+%129 = OpLabel
+%509 = OpLoad %ulong %312
+%510 = OpIMul %ulong %509 %ulong_8
+OpStore %305 %510
+%511 = OpLoad %ulong %303
+%512 = OpLoad %ulong %305
+%513 = OpShiftRightLogical %ulong %511 %512
+OpStore %306 %513
+%514 = OpLoad %ulong %306
+%515 = OpBitwiseAnd %ulong %514 %ulong_255
+OpStore %307 %515
+%516 = OpLoad %ulong %311
+%517 = OpLoad %ulong %307
+%518 = OpBitwiseXor %ulong %516 %517
+OpStore %308 %518
+%519 = OpLoad %ulong %308
+%520 = OpIMul %ulong %519 %ulong_1099511628211
+OpStore %309 %520
+%521 = OpLoad %ulong %312
+%522 = OpIAdd %ulong %521 %ulong_1
+OpStore %310 %522
+%523 = OpLoad %ulong %309
+OpStore %311 %523
+%524 = OpLoad %ulong %310
+OpStore %312 %524
+OpBranch %162
+%122 = OpLabel
+%525 = OpLoad %ulong %302
+%526 = OpIMul %ulong %525 %ulong_8
+OpStore %295 %526
+%527 = OpLoad %ulong %293
+%528 = OpLoad %ulong %295
+%529 = OpShiftRightLogical %ulong %527 %528
+OpStore %296 %529
+%530 = OpLoad %ulong %296
+%531 = OpBitwiseAnd %ulong %530 %ulong_255
+OpStore %297 %531
+%532 = OpLoad %ulong %301
+%533 = OpLoad %ulong %297
+%534 = OpBitwiseXor %ulong %532 %533
+OpStore %298 %534
+%535 = OpLoad %ulong %298
+%536 = OpIMul %ulong %535 %ulong_1099511628211
+OpStore %299 %536
+%537 = OpLoad %ulong %302
+%538 = OpIAdd %ulong %537 %ulong_1
+OpStore %300 %538
+%539 = OpLoad %ulong %299
+OpStore %301 %539
+%540 = OpLoad %ulong %300
+OpStore %302 %540
+OpBranch %163
+%115 = OpLabel
+%541 = OpLoad %ulong %292
+%542 = OpIMul %ulong %541 %ulong_8
+OpStore %285 %542
+%543 = OpLoad %ulong %283
+%544 = OpLoad %ulong %285
+%545 = OpShiftRightLogical %ulong %543 %544
+OpStore %286 %545
+%546 = OpLoad %ulong %286
+%547 = OpBitwiseAnd %ulong %546 %ulong_255
+OpStore %287 %547
+%548 = OpLoad %ulong %291
+%549 = OpLoad %ulong %287
+%550 = OpBitwiseXor %ulong %548 %549
+OpStore %288 %550
+%551 = OpLoad %ulong %288
+%552 = OpIMul %ulong %551 %ulong_1099511628211
+OpStore %289 %552
+%553 = OpLoad %ulong %292
+%554 = OpIAdd %ulong %553 %ulong_1
+OpStore %290 %554
+%555 = OpLoad %ulong %289
+OpStore %291 %555
+%556 = OpLoad %ulong %290
+OpStore %292 %556
+OpBranch %164
+%108 = OpLabel
+%557 = OpLoad %ulong %282
+%558 = OpIMul %ulong %557 %ulong_8
+OpStore %275 %558
+%559 = OpLoad %ulong %273
+%560 = OpLoad %ulong %275
+%561 = OpShiftRightLogical %ulong %559 %560
+OpStore %276 %561
+%562 = OpLoad %ulong %276
+%563 = OpBitwiseAnd %ulong %562 %ulong_255
+OpStore %277 %563
+%564 = OpLoad %ulong %281
+%565 = OpLoad %ulong %277
+%566 = OpBitwiseXor %ulong %564 %565
+OpStore %278 %566
+%567 = OpLoad %ulong %278
+%568 = OpIMul %ulong %567 %ulong_1099511628211
+OpStore %279 %568
+%569 = OpLoad %ulong %282
+%570 = OpIAdd %ulong %569 %ulong_1
+OpStore %280 %570
+%571 = OpLoad %ulong %279
+OpStore %281 %571
+%572 = OpLoad %ulong %280
+OpStore %282 %572
+OpBranch %165
+%101 = OpLabel
+%573 = OpLoad %ulong %272
+%574 = OpIMul %ulong %573 %ulong_8
+OpStore %265 %574
+%575 = OpLoad %ulong %185
+%576 = OpLoad %ulong %265
+%577 = OpShiftRightLogical %ulong %575 %576
+OpStore %266 %577
+%578 = OpLoad %ulong %266
+%579 = OpBitwiseAnd %ulong %578 %ulong_255
+OpStore %267 %579
+%580 = OpLoad %ulong %271
+%581 = OpLoad %ulong %267
+%582 = OpBitwiseXor %ulong %580 %581
+OpStore %268 %582
+%583 = OpLoad %ulong %268
+%584 = OpIMul %ulong %583 %ulong_1099511628211
+OpStore %269 %584
+%585 = OpLoad %ulong %272
+%586 = OpIAdd %ulong %585 %ulong_1
+OpStore %270 %586
+%587 = OpLoad %ulong %269
+OpStore %271 %587
+%588 = OpLoad %ulong %270
+OpStore %272 %588
+OpBranch %166
+%94 = OpLabel
+%589 = OpLoad %ulong %263
+%590 = OpIMul %ulong %589 %ulong_8
+OpStore %256 %590
+%591 = OpLoad %ulong %184
+%592 = OpLoad %ulong %256
+%593 = OpShiftRightLogical %ulong %591 %592
+OpStore %257 %593
+%594 = OpLoad %ulong %257
+%595 = OpBitwiseAnd %ulong %594 %ulong_255
+OpStore %258 %595
+%596 = OpLoad %ulong %262
+%597 = OpLoad %ulong %258
+%598 = OpBitwiseXor %ulong %596 %597
+OpStore %259 %598
+%599 = OpLoad %ulong %259
+%600 = OpIMul %ulong %599 %ulong_1099511628211
+OpStore %260 %600
+%601 = OpLoad %ulong %263
+%602 = OpIAdd %ulong %601 %ulong_1
+OpStore %261 %602
+%603 = OpLoad %ulong %260
+OpStore %262 %603
+%604 = OpLoad %ulong %261
+OpStore %263 %604
+OpBranch %167
+%89 = OpLabel
+%605 = OpLoad %ulong %254
+%606 = OpIMul %ulong %605 %ulong_8
+OpStore %247 %606
+%607 = OpLoad %ulong %245
+%608 = OpLoad %ulong %247
+%609 = OpShiftRightLogical %ulong %607 %608
+OpStore %248 %609
+%610 = OpLoad %ulong %248
+%611 = OpBitwiseAnd %ulong %610 %ulong_255
+OpStore %249 %611
+%612 = OpLoad %ulong %253
+%613 = OpLoad %ulong %249
+%614 = OpBitwiseXor %ulong %612 %613
+OpStore %250 %614
+%615 = OpLoad %ulong %250
+%616 = OpIMul %ulong %615 %ulong_1099511628211
+OpStore %251 %616
+%617 = OpLoad %ulong %254
+%618 = OpIAdd %ulong %617 %ulong_1
+OpStore %252 %618
+%619 = OpLoad %ulong %251
+OpStore %253 %619
+%620 = OpLoad %ulong %252
+OpStore %254 %620
+OpBranch %168
+%82 = OpLabel
+%621 = OpLoad %ulong %244
+%622 = OpIMul %ulong %621 %ulong_8
+OpStore %237 %622
+%623 = OpLoad %ulong %235
+%624 = OpLoad %ulong %237
+%625 = OpShiftRightLogical %ulong %623 %624
+OpStore %238 %625
+%626 = OpLoad %ulong %238
+%627 = OpBitwiseAnd %ulong %626 %ulong_255
+OpStore %239 %627
+%628 = OpLoad %ulong %243
+%629 = OpLoad %ulong %239
+%630 = OpBitwiseXor %ulong %628 %629
+OpStore %240 %630
+%631 = OpLoad %ulong %240
+%632 = OpIMul %ulong %631 %ulong_1099511628211
+OpStore %241 %632
+%633 = OpLoad %ulong %244
+%634 = OpIAdd %ulong %633 %ulong_1
+OpStore %242 %634
+%635 = OpLoad %ulong %241
+OpStore %243 %635
+%636 = OpLoad %ulong %242
+OpStore %244 %636
+OpBranch %169
+%75 = OpLabel
+%637 = OpLoad %ulong %234
+%638 = OpIMul %ulong %637 %ulong_8
+OpStore %227 %638
+%639 = OpLoad %ulong %225
+%640 = OpLoad %ulong %227
+%641 = OpShiftRightLogical %ulong %639 %640
+OpStore %228 %641
+%642 = OpLoad %ulong %228
+%643 = OpBitwiseAnd %ulong %642 %ulong_255
+OpStore %229 %643
+%644 = OpLoad %ulong %233
+%645 = OpLoad %ulong %229
+%646 = OpBitwiseXor %ulong %644 %645
+OpStore %230 %646
+%647 = OpLoad %ulong %230
+%648 = OpIMul %ulong %647 %ulong_1099511628211
+OpStore %231 %648
+%649 = OpLoad %ulong %234
+%650 = OpIAdd %ulong %649 %ulong_1
+OpStore %232 %650
+%651 = OpLoad %ulong %231
+OpStore %233 %651
+%652 = OpLoad %ulong %232
+OpStore %234 %652
+OpBranch %170
+%68 = OpLabel
+%653 = OpLoad %ulong %224
+%654 = OpIMul %ulong %653 %ulong_8
+OpStore %217 %654
+%655 = OpLoad %ulong %215
+%656 = OpLoad %ulong %217
+%657 = OpShiftRightLogical %ulong %655 %656
+OpStore %218 %657
+%658 = OpLoad %ulong %218
+%659 = OpBitwiseAnd %ulong %658 %ulong_255
+OpStore %219 %659
+%660 = OpLoad %ulong %223
+%661 = OpLoad %ulong %219
+%662 = OpBitwiseXor %ulong %660 %661
+OpStore %220 %662
+%663 = OpLoad %ulong %220
+%664 = OpIMul %ulong %663 %ulong_1099511628211
+OpStore %221 %664
+%665 = OpLoad %ulong %224
+%666 = OpIAdd %ulong %665 %ulong_1
+OpStore %222 %666
+%667 = OpLoad %ulong %221
+OpStore %223 %667
+%668 = OpLoad %ulong %222
+OpStore %224 %668
+OpBranch %171
+%61 = OpLabel
+%669 = OpLoad %ulong %214
+%670 = OpIMul %ulong %669 %ulong_8
+OpStore %207 %670
+%671 = OpLoad %ulong %205
+%672 = OpLoad %ulong %207
+%673 = OpShiftRightLogical %ulong %671 %672
+OpStore %208 %673
+%674 = OpLoad %ulong %208
+%675 = OpBitwiseAnd %ulong %674 %ulong_255
+OpStore %209 %675
+%676 = OpLoad %ulong %213
+%677 = OpLoad %ulong %209
+%678 = OpBitwiseXor %ulong %676 %677
+OpStore %210 %678
+%679 = OpLoad %ulong %210
+%680 = OpIMul %ulong %679 %ulong_1099511628211
+OpStore %211 %680
+%681 = OpLoad %ulong %214
+%682 = OpIAdd %ulong %681 %ulong_1
+OpStore %212 %682
+%683 = OpLoad %ulong %211
+OpStore %213 %683
+%684 = OpLoad %ulong %212
+OpStore %214 %684
+OpBranch %172
+%54 = OpLabel
+%685 = OpLoad %ulong %204
+%686 = OpIMul %ulong %685 %ulong_8
+OpStore %197 %686
+%687 = OpLoad %ulong %194
+%688 = OpLoad %ulong %197
+%689 = OpShiftRightLogical %ulong %687 %688
+OpStore %198 %689
+%690 = OpLoad %ulong %198
+%691 = OpBitwiseAnd %ulong %690 %ulong_255
+OpStore %199 %691
+%692 = OpLoad %ulong %203
+%693 = OpLoad %ulong %199
+%694 = OpBitwiseXor %ulong %692 %693
+OpStore %200 %694
+%695 = OpLoad %ulong %200
+%696 = OpIMul %ulong %695 %ulong_1099511628211
+OpStore %201 %696
+%697 = OpLoad %ulong %204
+%698 = OpIAdd %ulong %697 %ulong_1
+OpStore %202 %698
+%699 = OpLoad %ulong %201
+OpStore %203 %699
+%700 = OpLoad %ulong %202
+OpStore %204 %700
+OpBranch %173
+%158 = OpLabel
+OpBranch %154
+%159 = OpLabel
+OpBranch %147
+%160 = OpLabel
+OpBranch %142
+%161 = OpLabel
+OpBranch %135
+%162 = OpLabel
+OpBranch %128
+%163 = OpLabel
+OpBranch %121
+%164 = OpLabel
+OpBranch %114
+%165 = OpLabel
+OpBranch %107
+%166 = OpLabel
+OpBranch %100
+%167 = OpLabel
+OpBranch %93
+%168 = OpLabel
+OpBranch %88
+%169 = OpLabel
+OpBranch %81
+%170 = OpLabel
+OpBranch %74
+%171 = OpLabel
+OpBranch %67
+%172 = OpLabel
+OpBranch %60
+%173 = OpLabel
+OpBranch %53
 OpFunctionEnd
-%5 = OpFunction %ulong None %1135
-%1136 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%3 = OpFunction %ulong None %701
+%702 = OpFunctionParameter %uchar
+%703 = OpFunctionParameter %uchar
+%704 = OpFunctionParameter %uchar
+%705 = OpFunctionParameter %uchar
+%706 = OpFunctionParameter %ushort
+%707 = OpFunctionParameter %ushort
+%708 = OpFunctionParameter %ushort
+%709 = OpFunctionParameter %ushort
+%710 = OpFunctionParameter %uchar
+%711 = OpFunctionParameter %uchar
+%712 = OpFunctionParameter %ushort
+%713 = OpFunctionParameter %ushort
+%714 = OpFunctionParameter %uchar
+%715 = OpFunctionParameter %uchar
+%716 = OpFunctionParameter %ushort
+%717 = OpFunctionParameter %ushort
+%718 = OpLabel
+%753 = OpVariable %_ptr_Function_uchar Function
+%754 = OpVariable %_ptr_Function_uchar Function
+%755 = OpVariable %_ptr_Function_uchar Function
+%756 = OpVariable %_ptr_Function_uchar Function
+%757 = OpVariable %_ptr_Function_ushort Function
+%758 = OpVariable %_ptr_Function_ushort Function
+%759 = OpVariable %_ptr_Function_ushort Function
+%760 = OpVariable %_ptr_Function_ushort Function
+%761 = OpVariable %_ptr_Function_uchar Function
+%762 = OpVariable %_ptr_Function_uchar Function
+%763 = OpVariable %_ptr_Function_ushort Function
+%764 = OpVariable %_ptr_Function_ushort Function
+%765 = OpVariable %_ptr_Function_uchar Function
+%766 = OpVariable %_ptr_Function_uchar Function
+%767 = OpVariable %_ptr_Function_ushort Function
+%768 = OpVariable %_ptr_Function_ushort Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_ulong Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_ulong Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
+%783 = OpVariable %_ptr_Function_ulong Function
+%784 = OpVariable %_ptr_Function_ulong Function
+%785 = OpVariable %_ptr_Function_ulong Function
+%786 = OpVariable %_ptr_Function_ulong Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_ulong Function
+%789 = OpVariable %_ptr_Function_ulong Function
+%790 = OpVariable %_ptr_Function_ulong Function
+%791 = OpVariable %_ptr_Function_ulong Function
+%792 = OpVariable %_ptr_Function_ulong Function
+%793 = OpVariable %_ptr_Function_ulong Function
+%794 = OpVariable %_ptr_Function_ulong Function
+%795 = OpVariable %_ptr_Function_ulong Function
+%796 = OpVariable %_ptr_Function_ulong Function
+%797 = OpVariable %_ptr_Function_ulong Function
+%798 = OpVariable %_ptr_Function_ulong Function
+%799 = OpVariable %_ptr_Function_ulong Function
+%800 = OpVariable %_ptr_Function_ulong Function
+OpStore %753 %702
+OpStore %754 %703
+OpStore %755 %704
+OpStore %756 %705
+OpStore %757 %706
+OpStore %758 %707
+OpStore %759 %708
+OpStore %760 %709
+OpStore %761 %710
+OpStore %762 %711
+OpStore %763 %712
+OpStore %764 %713
+OpStore %765 %714
+OpStore %766 %715
+OpStore %767 %716
+OpStore %768 %717
+OpBranch %719
+%719 = OpLabel
+OpBranch %720
+%720 = OpLabel
+OpBranch %721
+%721 = OpLabel
+%801 = OpLoad %uchar %753
+%802 = OpUConvert %ulong %801
+OpStore %769 %802
+%803 = OpLoad %ulong %769
+%804 = OpFunctionCall %ulong %5 %ulong_14695981039346656037 %803
+OpStore %770 %804
+OpBranch %722
+%722 = OpLabel
+OpBranch %723
+%723 = OpLabel
+%805 = OpLoad %uchar %754
+%806 = OpUConvert %ulong %805
+OpStore %771 %806
+%807 = OpLoad %ulong %770
+%808 = OpLoad %ulong %771
+%809 = OpFunctionCall %ulong %5 %807 %808
+OpStore %772 %809
+OpBranch %724
+%724 = OpLabel
+OpBranch %725
+%725 = OpLabel
+%810 = OpLoad %uchar %755
+%811 = OpSConvert %ulong %810
+OpStore %773 %811
+%812 = OpLoad %ulong %772
+%813 = OpLoad %ulong %773
+%814 = OpFunctionCall %ulong %5 %812 %813
+OpStore %774 %814
+OpBranch %726
+%726 = OpLabel
+OpBranch %727
+%727 = OpLabel
+%815 = OpLoad %uchar %756
+%816 = OpSConvert %ulong %815
+OpStore %775 %816
+%817 = OpLoad %ulong %774
+%818 = OpLoad %ulong %775
+%819 = OpFunctionCall %ulong %5 %817 %818
+OpStore %776 %819
+OpBranch %728
+%728 = OpLabel
+OpBranch %729
+%729 = OpLabel
+%820 = OpLoad %ushort %757
+%821 = OpUConvert %ulong %820
+OpStore %777 %821
+%822 = OpLoad %ulong %776
+%823 = OpLoad %ulong %777
+%824 = OpFunctionCall %ulong %5 %822 %823
+OpStore %778 %824
+OpBranch %730
+%730 = OpLabel
+OpBranch %731
+%731 = OpLabel
+%825 = OpLoad %ushort %758
+%826 = OpUConvert %ulong %825
+OpStore %779 %826
+%827 = OpLoad %ulong %778
+%828 = OpLoad %ulong %779
+%829 = OpFunctionCall %ulong %5 %827 %828
+OpStore %780 %829
+OpBranch %732
+%732 = OpLabel
+OpBranch %733
+%733 = OpLabel
+%830 = OpLoad %ushort %759
+%831 = OpSConvert %ulong %830
+OpStore %781 %831
+%832 = OpLoad %ulong %780
+%833 = OpLoad %ulong %781
+%834 = OpFunctionCall %ulong %5 %832 %833
+OpStore %782 %834
+OpBranch %734
+%734 = OpLabel
+OpBranch %735
+%735 = OpLabel
+%835 = OpLoad %ushort %760
+%836 = OpSConvert %ulong %835
+OpStore %783 %836
+%837 = OpLoad %ulong %782
+%838 = OpLoad %ulong %783
+%839 = OpFunctionCall %ulong %5 %837 %838
+OpStore %784 %839
+OpBranch %736
+%736 = OpLabel
+OpBranch %737
+%737 = OpLabel
+%840 = OpLoad %uchar %761
+%841 = OpUConvert %ulong %840
+OpStore %785 %841
+%842 = OpLoad %ulong %784
+%843 = OpLoad %ulong %785
+%844 = OpFunctionCall %ulong %5 %842 %843
+OpStore %786 %844
+OpBranch %738
+%738 = OpLabel
+OpBranch %739
+%739 = OpLabel
+%845 = OpLoad %uchar %762
+%846 = OpSConvert %ulong %845
+OpStore %787 %846
+%847 = OpLoad %ulong %786
+%848 = OpLoad %ulong %787
+%849 = OpFunctionCall %ulong %5 %847 %848
+OpStore %788 %849
+OpBranch %740
+%740 = OpLabel
+OpBranch %741
+%741 = OpLabel
+%850 = OpLoad %ushort %763
+%851 = OpUConvert %ulong %850
+OpStore %789 %851
+%852 = OpLoad %ulong %788
+%853 = OpLoad %ulong %789
+%854 = OpFunctionCall %ulong %5 %852 %853
+OpStore %790 %854
+OpBranch %742
+%742 = OpLabel
+OpBranch %743
+%743 = OpLabel
+%855 = OpLoad %ushort %764
+%856 = OpSConvert %ulong %855
+OpStore %791 %856
+%857 = OpLoad %ulong %790
+%858 = OpLoad %ulong %791
+%859 = OpFunctionCall %ulong %5 %857 %858
+OpStore %792 %859
+OpBranch %744
+%744 = OpLabel
+OpBranch %745
+%745 = OpLabel
+%860 = OpLoad %uchar %765
+%861 = OpUConvert %ulong %860
+OpStore %793 %861
+%862 = OpLoad %ulong %792
+%863 = OpLoad %ulong %793
+%864 = OpFunctionCall %ulong %5 %862 %863
+OpStore %794 %864
+OpBranch %746
+%746 = OpLabel
+OpBranch %747
+%747 = OpLabel
+%865 = OpLoad %uchar %766
+%866 = OpSConvert %ulong %865
+OpStore %795 %866
+%867 = OpLoad %ulong %794
+%868 = OpLoad %ulong %795
+%869 = OpFunctionCall %ulong %5 %867 %868
+OpStore %796 %869
+OpBranch %748
+%748 = OpLabel
+OpBranch %749
+%749 = OpLabel
+%870 = OpLoad %ushort %767
+%871 = OpUConvert %ulong %870
+OpStore %797 %871
+%872 = OpLoad %ulong %796
+%873 = OpLoad %ulong %797
+%874 = OpFunctionCall %ulong %5 %872 %873
+OpStore %798 %874
+OpBranch %750
+%750 = OpLabel
+OpBranch %751
+%751 = OpLabel
+%875 = OpLoad %ushort %768
+%876 = OpSConvert %ulong %875
+OpStore %799 %876
+%877 = OpLoad %ulong %798
+%878 = OpLoad %ulong %799
+%879 = OpFunctionCall %ulong %5 %877 %878
+OpStore %800 %879
+OpBranch %752
+%752 = OpLabel
+%880 = OpLoad %ulong %800
+OpReturnValue %880
 OpFunctionEnd
-%6 = OpFunction %ulong None %15
-%1138 = OpFunctionParameter %ulong
-%1139 = OpFunctionParameter %ulong
-%1140 = OpLabel
-%1145 = OpVariable %_ptr_Function_ulong Function
-%1146 = OpVariable %_ptr_Function_ulong Function
-%1147 = OpVariable %_ptr_Function_bool Function
-%1148 = OpVariable %_ptr_Function_ulong Function
-%1149 = OpVariable %_ptr_Function_ulong Function
-%1150 = OpVariable %_ptr_Function_ulong Function
-%1151 = OpVariable %_ptr_Function_ulong Function
-%1152 = OpVariable %_ptr_Function_ulong Function
-%1153 = OpVariable %_ptr_Function_ulong Function
-%1154 = OpVariable %_ptr_Function_ulong Function
-%1155 = OpVariable %_ptr_Function_ulong Function
-OpStore %1145 %1138
-OpStore %1146 %1139
-%1156 = OpLoad %ulong %1145
-OpStore %1154 %1156
-OpStore %1155 %ulong_0
-OpBranch %1141
-%1141 = OpLabel
-%1157 = OpLoad %ulong %1155
-%1159 = OpULessThan %bool %1157 %ulong_8
-OpStore %1147 %1159
-%1160 = OpLoad %bool %1147
-OpLoopMerge %1143 %1144 None
-OpBranchConditional %1160 %1142 %1143
-%1143 = OpLabel
-%1161 = OpLoad %ulong %1154
-OpReturnValue %1161
-%1142 = OpLabel
-%1162 = OpLoad %ulong %1155
-%1163 = OpIMul %ulong %1162 %ulong_8
-OpStore %1148 %1163
-%1164 = OpLoad %ulong %1146
-%1165 = OpLoad %ulong %1148
-%1166 = OpShiftRightLogical %ulong %1164 %1165
-OpStore %1149 %1166
-%1167 = OpLoad %ulong %1149
-%1169 = OpBitwiseAnd %ulong %1167 %ulong_255
-OpStore %1150 %1169
-%1170 = OpLoad %ulong %1154
-%1171 = OpLoad %ulong %1150
-%1172 = OpBitwiseXor %ulong %1170 %1171
-OpStore %1151 %1172
-%1173 = OpLoad %ulong %1151
-%1175 = OpIMul %ulong %1173 %ulong_1099511628211
-OpStore %1152 %1175
-%1176 = OpLoad %ulong %1155
-%1177 = OpIAdd %ulong %1176 %ulong_1
-OpStore %1153 %1177
-%1178 = OpLoad %ulong %1152
-OpStore %1154 %1178
-%1179 = OpLoad %ulong %1153
-OpStore %1155 %1179
-OpBranch %1144
-%1144 = OpLabel
-OpBranch %1141
+%4 = OpFunction %ulong None %881
+%882 = OpFunctionParameter %ulong
+%883 = OpLabel
+%899 = OpVariable %_ptr_Function__arr_ulong_uint_20 Function
+%900 = OpVariable %_ptr_Function_ulong Function
+%901 = OpVariable %_ptr_Function_bool Function
+%902 = OpVariable %_ptr_Function_ulong Function
+%903 = OpVariable %_ptr_Function_bool Function
+%904 = OpVariable %_ptr_Function_ulong Function
+%905 = OpVariable %_ptr_Function_ulong Function
+%906 = OpVariable %_ptr_Function_ulong Function
+%907 = OpVariable %_ptr_Function_uchar Function
+%908 = OpVariable %_ptr_Function_ulong Function
+%909 = OpVariable %_ptr_Function_uchar Function
+%910 = OpVariable %_ptr_Function_ulong Function
+%911 = OpVariable %_ptr_Function_ushort Function
+%912 = OpVariable %_ptr_Function_ulong Function
+%913 = OpVariable %_ptr_Function_ushort Function
+%914 = OpVariable %_ptr_Function_ulong Function
+%915 = OpVariable %_ptr_Function_uint Function
+%916 = OpVariable %_ptr_Function_ulong Function
+%917 = OpVariable %_ptr_Function_uint Function
+%918 = OpVariable %_ptr_Function_ulong Function
+%919 = OpVariable %_ptr_Function_ulong Function
+%920 = OpVariable %_ptr_Function_ulong Function
+%921 = OpVariable %_ptr_Function_ulong Function
+%922 = OpVariable %_ptr_Function_uchar Function
+%923 = OpVariable %_ptr_Function_ulong Function
+%924 = OpVariable %_ptr_Function_uchar Function
+%925 = OpVariable %_ptr_Function_ulong Function
+%926 = OpVariable %_ptr_Function_ushort Function
+%927 = OpVariable %_ptr_Function_ulong Function
+%928 = OpVariable %_ptr_Function_ushort Function
+%929 = OpVariable %_ptr_Function_ulong Function
+%930 = OpVariable %_ptr_Function_uint Function
+%931 = OpVariable %_ptr_Function_ulong Function
+%932 = OpVariable %_ptr_Function_uint Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_ulong Function
+%935 = OpVariable %_ptr_Function_ulong Function
+%936 = OpVariable %_ptr_Function_ulong Function
+%937 = OpVariable %_ptr_Function_ulong Function
+%938 = OpVariable %_ptr_Function_ulong Function
+%939 = OpVariable %_ptr_Function_uchar Function
+%940 = OpVariable %_ptr_Function_ulong Function
+%941 = OpVariable %_ptr_Function_uchar Function
+%942 = OpVariable %_ptr_Function_ulong Function
+%943 = OpVariable %_ptr_Function_uchar Function
+%944 = OpVariable %_ptr_Function_ulong Function
+%945 = OpVariable %_ptr_Function_uchar Function
+%946 = OpVariable %_ptr_Function_ulong Function
+%947 = OpVariable %_ptr_Function_ushort Function
+%948 = OpVariable %_ptr_Function_ulong Function
+%949 = OpVariable %_ptr_Function_ushort Function
+%950 = OpVariable %_ptr_Function_ulong Function
+%951 = OpVariable %_ptr_Function_ushort Function
+%952 = OpVariable %_ptr_Function_ulong Function
+%953 = OpVariable %_ptr_Function_ushort Function
+%954 = OpVariable %_ptr_Function_ulong Function
+%955 = OpVariable %_ptr_Function_ulong Function
+%956 = OpVariable %_ptr_Function_uchar Function
+%957 = OpVariable %_ptr_Function_ulong Function
+%958 = OpVariable %_ptr_Function_uchar Function
+%959 = OpVariable %_ptr_Function_ulong Function
+%960 = OpVariable %_ptr_Function_ushort Function
+%961 = OpVariable %_ptr_Function_ulong Function
+%962 = OpVariable %_ptr_Function_ushort Function
+%963 = OpVariable %_ptr_Function_ulong Function
+%964 = OpVariable %_ptr_Function_uchar Function
+%965 = OpVariable %_ptr_Function_ulong Function
+%966 = OpVariable %_ptr_Function_uchar Function
+%967 = OpVariable %_ptr_Function_ulong Function
+%968 = OpVariable %_ptr_Function_ushort Function
+%969 = OpVariable %_ptr_Function_ulong Function
+%970 = OpVariable %_ptr_Function_ulong Function
+%971 = OpVariable %_ptr_Function_ushort Function
+%972 = OpVariable %_ptr_Function_ulong Function
+%973 = OpVariable %_ptr_Function_ulong Function
+%974 = OpVariable %_ptr_Function_ulong Function
+%975 = OpVariable %_ptr_Function_ulong Function
+%976 = OpVariable %_ptr_Function_uchar Function
+%977 = OpVariable %_ptr_Function_ulong Function
+%978 = OpVariable %_ptr_Function_uchar Function
+%979 = OpVariable %_ptr_Function_ulong Function
+%980 = OpVariable %_ptr_Function_ushort Function
+%981 = OpVariable %_ptr_Function_ulong Function
+%982 = OpVariable %_ptr_Function_ushort Function
+%983 = OpVariable %_ptr_Function_ulong Function
+%984 = OpVariable %_ptr_Function_uint Function
+%985 = OpVariable %_ptr_Function_ulong Function
+%986 = OpVariable %_ptr_Function_uint Function
+%987 = OpVariable %_ptr_Function_ulong Function
+%988 = OpVariable %_ptr_Function_ulong Function
+%989 = OpVariable %_ptr_Function_ulong Function
+%990 = OpVariable %_ptr_Function_uchar Function
+%991 = OpVariable %_ptr_Function_ulong Function
+%992 = OpVariable %_ptr_Function_uchar Function
+%993 = OpVariable %_ptr_Function_ulong Function
+%994 = OpVariable %_ptr_Function_ushort Function
+%995 = OpVariable %_ptr_Function_ulong Function
+%996 = OpVariable %_ptr_Function_ushort Function
+%997 = OpVariable %_ptr_Function_ulong Function
+%998 = OpVariable %_ptr_Function_uint Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_uint Function
+%1001 = OpVariable %_ptr_Function_ulong Function
+%1002 = OpVariable %_ptr_Function_ulong Function
+%1003 = OpVariable %_ptr_Function_ulong Function
+%1004 = OpVariable %_ptr_Function_uchar Function
+%1005 = OpVariable %_ptr_Function_ulong Function
+%1006 = OpVariable %_ptr_Function_uchar Function
+%1007 = OpVariable %_ptr_Function_ulong Function
+%1008 = OpVariable %_ptr_Function_ushort Function
+%1009 = OpVariable %_ptr_Function_ulong Function
+%1010 = OpVariable %_ptr_Function_ushort Function
+%1011 = OpVariable %_ptr_Function_uint Function
+%1012 = OpVariable %_ptr_Function_ulong Function
+%1013 = OpVariable %_ptr_Function_uint Function
+%1014 = OpVariable %_ptr_Function_ulong Function
+%1015 = OpVariable %_ptr_Function_ulong Function
+%1016 = OpVariable %_ptr_Function_ulong Function
+%1017 = OpVariable %_ptr_Function_uchar Function
+%1018 = OpVariable %_ptr_Function_ulong Function
+%1019 = OpVariable %_ptr_Function_uchar Function
+%1020 = OpVariable %_ptr_Function_ulong Function
+%1021 = OpVariable %_ptr_Function_uchar Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_uchar Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_ushort Function
+%1026 = OpVariable %_ptr_Function_ulong Function
+%1027 = OpVariable %_ptr_Function_ushort Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_ushort Function
+%1030 = OpVariable %_ptr_Function_ulong Function
+%1031 = OpVariable %_ptr_Function_ushort Function
+%1032 = OpVariable %_ptr_Function_ulong Function
+%1033 = OpVariable %_ptr_Function_uchar Function
+%1034 = OpVariable %_ptr_Function_ulong Function
+%1035 = OpVariable %_ptr_Function_uchar Function
+%1036 = OpVariable %_ptr_Function_ulong Function
+%1037 = OpVariable %_ptr_Function_ushort Function
+%1038 = OpVariable %_ptr_Function_ulong Function
+%1039 = OpVariable %_ptr_Function_ushort Function
+%1040 = OpVariable %_ptr_Function_ulong Function
+%1041 = OpVariable %_ptr_Function_uchar Function
+%1042 = OpVariable %_ptr_Function_ulong Function
+%1043 = OpVariable %_ptr_Function_uchar Function
+%1044 = OpVariable %_ptr_Function_ulong Function
+%1045 = OpVariable %_ptr_Function_ushort Function
+%1046 = OpVariable %_ptr_Function_ulong Function
+%1047 = OpVariable %_ptr_Function_ushort Function
+%1048 = OpVariable %_ptr_Function_ulong Function
+%1049 = OpVariable %_ptr_Function_uchar Function
+%1050 = OpVariable %_ptr_Function_ulong Function
+%1051 = OpVariable %_ptr_Function_uchar Function
+%1052 = OpVariable %_ptr_Function_ulong Function
+%1053 = OpVariable %_ptr_Function_ushort Function
+%1054 = OpVariable %_ptr_Function_ulong Function
+%1055 = OpVariable %_ptr_Function_ushort Function
+%1056 = OpVariable %_ptr_Function_ulong Function
+%1057 = OpVariable %_ptr_Function_uint Function
+%1058 = OpVariable %_ptr_Function_ulong Function
+%1059 = OpVariable %_ptr_Function_uint Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_ulong Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_ulong Function
+%1064 = OpVariable %_ptr_Function_ulong Function
+%1065 = OpVariable %_ptr_Function_ulong Function
+%1066 = OpVariable %_ptr_Function_ulong Function
+%1067 = OpVariable %_ptr_Function_ulong Function
+%1068 = OpVariable %_ptr_Function_ulong Function
+%1069 = OpVariable %_ptr_Function_ulong Function
+%1070 = OpVariable %_ptr_Function_ulong Function
+OpStore %900 %882
+OpBranch %890
+%890 = OpLabel
+OpBranch %891
+%891 = OpLabel
+OpStore %899 %1071
+OpStore %1065 %ulong_0
+OpBranch %884
+%884 = OpLabel
+%1072 = OpLoad %ulong %1065
+%1074 = OpULessThan %bool %1072 %ulong_20
+OpStore %901 %1074
+%1075 = OpLoad %bool %901
+OpLoopMerge %886 %895 None
+OpBranchConditional %1075 %885 %886
+%886 = OpLabel
+OpStore %1064 %ulong_14695981039346656037
+OpStore %1066 %ulong_0
+OpStore %1067 %ulong_0
+OpBranch %887
+%887 = OpLabel
+%1076 = OpLoad %ulong %1067
+%1078 = OpULessThan %bool %1076 %ulong_3
+OpStore %903 %1078
+%1079 = OpLoad %bool %903
+OpLoopMerge %889 %894 None
+OpBranchConditional %1079 %888 %889
+%889 = OpLabel
+%1081 = OpAccessChain %_ptr_Function_ulong %899 %uint_0
+%1082 = OpLoad %ulong %1081
+OpStore %975 %1082
+%1083 = OpLoad %ulong %975
+%1084 = OpUConvert %uchar %1083
+OpStore %976 %1084
+%1086 = OpAccessChain %_ptr_Function_ulong %899 %uint_1
+%1087 = OpLoad %ulong %1086
+OpStore %977 %1087
+%1088 = OpLoad %ulong %977
+%1089 = OpUConvert %uchar %1088
+OpStore %978 %1089
+%1091 = OpAccessChain %_ptr_Function_ulong %899 %uint_2
+%1092 = OpLoad %ulong %1091
+OpStore %979 %1092
+%1093 = OpLoad %ulong %979
+%1094 = OpUConvert %ushort %1093
+OpStore %980 %1094
+%1096 = OpAccessChain %_ptr_Function_ulong %899 %uint_3
+%1097 = OpLoad %ulong %1096
+OpStore %981 %1097
+%1098 = OpLoad %ulong %981
+%1099 = OpUConvert %ushort %1098
+OpStore %982 %1099
+%1101 = OpAccessChain %_ptr_Function_ulong %899 %uint_4
+%1102 = OpLoad %ulong %1101
+OpStore %983 %1102
+%1103 = OpLoad %ulong %983
+%1104 = OpUConvert %uint %1103
+OpStore %984 %1104
+%1106 = OpAccessChain %_ptr_Function_ulong %899 %uint_5
+%1107 = OpLoad %ulong %1106
+OpStore %985 %1107
+%1108 = OpLoad %ulong %985
+%1109 = OpUConvert %uint %1108
+OpStore %986 %1109
+%1111 = OpAccessChain %_ptr_Function_ulong %899 %uint_6
+%1112 = OpLoad %ulong %1111
+OpStore %987 %1112
+%1114 = OpAccessChain %_ptr_Function_ulong %899 %uint_7
+%1115 = OpLoad %ulong %1114
+OpStore %988 %1115
+%1117 = OpAccessChain %_ptr_Function_ulong %899 %uint_8
+%1118 = OpLoad %ulong %1117
+OpStore %989 %1118
+%1119 = OpLoad %ulong %989
+%1120 = OpUConvert %uchar %1119
+OpStore %990 %1120
+%1122 = OpAccessChain %_ptr_Function_ulong %899 %uint_9
+%1123 = OpLoad %ulong %1122
+OpStore %991 %1123
+%1124 = OpLoad %ulong %991
+%1125 = OpUConvert %uchar %1124
+OpStore %992 %1125
+%1127 = OpAccessChain %_ptr_Function_ulong %899 %uint_10
+%1128 = OpLoad %ulong %1127
+OpStore %993 %1128
+%1129 = OpLoad %ulong %993
+%1130 = OpUConvert %ushort %1129
+OpStore %994 %1130
+%1132 = OpAccessChain %_ptr_Function_ulong %899 %uint_11
+%1133 = OpLoad %ulong %1132
+OpStore %995 %1133
+%1134 = OpLoad %ulong %995
+%1135 = OpUConvert %ushort %1134
+OpStore %996 %1135
+%1137 = OpAccessChain %_ptr_Function_ulong %899 %uint_12
+%1138 = OpLoad %ulong %1137
+OpStore %997 %1138
+%1139 = OpLoad %ulong %997
+%1140 = OpUConvert %uint %1139
+OpStore %998 %1140
+%1142 = OpAccessChain %_ptr_Function_ulong %899 %uint_13
+%1143 = OpLoad %ulong %1142
+OpStore %999 %1143
+%1144 = OpLoad %ulong %999
+%1145 = OpUConvert %uint %1144
+OpStore %1000 %1145
+%1147 = OpAccessChain %_ptr_Function_ulong %899 %uint_14
+%1148 = OpLoad %ulong %1147
+OpStore %1001 %1148
+%1150 = OpAccessChain %_ptr_Function_ulong %899 %uint_15
+%1151 = OpLoad %ulong %1150
+OpStore %1002 %1151
+%1152 = OpLoad %uchar %976
+%1153 = OpLoad %uchar %978
+%1154 = OpLoad %ushort %980
+%1155 = OpLoad %ushort %982
+%1156 = OpLoad %uint %984
+%1157 = OpLoad %uint %986
+%1158 = OpLoad %ulong %987
+%1159 = OpLoad %ulong %988
+%1160 = OpLoad %uchar %990
+%1161 = OpLoad %uchar %992
+%1162 = OpLoad %ushort %994
+%1163 = OpLoad %ushort %996
+%1164 = OpLoad %uint %998
+%1165 = OpLoad %uint %1000
+%1166 = OpLoad %ulong %1001
+%1167 = OpLoad %ulong %1002
+%1168 = OpFunctionCall %ulong %2 %1152 %1153 %1154 %1155 %1156 %1157 %1158 %1159 %1160 %1161 %1162 %1163 %1164 %1165 %1166 %1167
+OpStore %1003 %1168
+%1169 = OpLoad %ulong %1003
+%1170 = OpUConvert %uchar %1169
+OpStore %1004 %1170
+%1171 = OpLoad %ulong %1086
+OpStore %1005 %1171
+%1172 = OpLoad %ulong %1005
+%1173 = OpUConvert %uchar %1172
+OpStore %1006 %1173
+%1174 = OpLoad %ulong %1091
+OpStore %1007 %1174
+%1175 = OpLoad %ulong %1007
+%1176 = OpUConvert %ushort %1175
+OpStore %1008 %1176
+%1177 = OpLoad %ulong %1096
+OpStore %1009 %1177
+%1178 = OpLoad %ulong %1009
+%1179 = OpUConvert %ushort %1178
+OpStore %1010 %1179
+%1180 = OpLoad %ulong %1066
+%1181 = OpUConvert %uint %1180
+OpStore %1011 %1181
+%1182 = OpLoad %ulong %1106
+OpStore %1012 %1182
+%1183 = OpLoad %ulong %1012
+%1184 = OpUConvert %uint %1183
+OpStore %1013 %1184
+%1185 = OpLoad %ulong %1111
+OpStore %1014 %1185
+%1186 = OpLoad %ulong %1114
+OpStore %1015 %1186
+%1188 = OpAccessChain %_ptr_Function_ulong %899 %uint_16
+%1189 = OpLoad %ulong %1188
+OpStore %1016 %1189
+%1190 = OpLoad %ulong %1016
+%1191 = OpUConvert %uchar %1190
+OpStore %1017 %1191
+%1193 = OpAccessChain %_ptr_Function_ulong %899 %uint_17
+%1194 = OpLoad %ulong %1193
+OpStore %1018 %1194
+%1195 = OpLoad %ulong %1018
+%1196 = OpUConvert %uchar %1195
+OpStore %1019 %1196
+%1198 = OpAccessChain %_ptr_Function_ulong %899 %uint_18
+%1199 = OpLoad %ulong %1198
+OpStore %1020 %1199
+%1200 = OpLoad %ulong %1020
+%1201 = OpUConvert %uchar %1200
+OpStore %1021 %1201
+%1203 = OpAccessChain %_ptr_Function_ulong %899 %uint_19
+%1204 = OpLoad %ulong %1203
+OpStore %1022 %1204
+%1205 = OpLoad %ulong %1022
+%1206 = OpUConvert %uchar %1205
+OpStore %1023 %1206
+%1207 = OpLoad %ulong %1101
+OpStore %1024 %1207
+%1208 = OpLoad %ulong %1024
+%1209 = OpUConvert %ushort %1208
+OpStore %1025 %1209
+%1210 = OpLoad %ulong %1106
+OpStore %1026 %1210
+%1211 = OpLoad %ulong %1026
+%1212 = OpUConvert %ushort %1211
+OpStore %1027 %1212
+%1213 = OpLoad %ulong %1111
+OpStore %1028 %1213
+%1214 = OpLoad %ulong %1028
+%1215 = OpUConvert %ushort %1214
+OpStore %1029 %1215
+%1216 = OpLoad %ulong %1114
+OpStore %1030 %1216
+%1217 = OpLoad %ulong %1030
+%1218 = OpUConvert %ushort %1217
+OpStore %1031 %1218
+%1219 = OpLoad %ulong %1117
+OpStore %1032 %1219
+%1220 = OpLoad %ulong %1032
+%1221 = OpUConvert %uchar %1220
+OpStore %1033 %1221
+%1222 = OpLoad %ulong %1122
+OpStore %1034 %1222
+%1223 = OpLoad %ulong %1034
+%1224 = OpUConvert %uchar %1223
+OpStore %1035 %1224
+%1225 = OpLoad %ulong %1127
+OpStore %1036 %1225
+%1226 = OpLoad %ulong %1036
+%1227 = OpUConvert %ushort %1226
+OpStore %1037 %1227
+%1228 = OpLoad %ulong %1132
+OpStore %1038 %1228
+%1229 = OpLoad %ulong %1038
+%1230 = OpUConvert %ushort %1229
+OpStore %1039 %1230
+%1231 = OpLoad %ulong %1137
+OpStore %1040 %1231
+%1232 = OpLoad %ulong %1040
+%1233 = OpUConvert %uchar %1232
+OpStore %1041 %1233
+%1234 = OpLoad %ulong %1142
+OpStore %1042 %1234
+%1235 = OpLoad %ulong %1042
+%1236 = OpUConvert %uchar %1235
+OpStore %1043 %1236
+%1237 = OpLoad %ulong %1147
+OpStore %1044 %1237
+%1238 = OpLoad %ulong %1044
+%1239 = OpUConvert %ushort %1238
+OpStore %1045 %1239
+%1240 = OpLoad %ulong %1150
+OpStore %1046 %1240
+%1241 = OpLoad %ulong %1046
+%1242 = OpUConvert %ushort %1241
+OpStore %1047 %1242
+%1243 = OpLoad %uchar %1017
+%1244 = OpLoad %uchar %1019
+%1245 = OpLoad %uchar %1021
+%1246 = OpLoad %uchar %1023
+%1247 = OpLoad %ushort %1025
+%1248 = OpLoad %ushort %1027
+%1249 = OpLoad %ushort %1029
+%1250 = OpLoad %ushort %1031
+%1251 = OpLoad %uchar %1033
+%1252 = OpLoad %uchar %1035
+%1253 = OpLoad %ushort %1037
+%1254 = OpLoad %ushort %1039
+%1255 = OpLoad %uchar %1041
+%1256 = OpLoad %uchar %1043
+%1257 = OpLoad %ushort %1045
+%1258 = OpLoad %ushort %1047
+%1259 = OpFunctionCall %ulong %3 %1243 %1244 %1245 %1246 %1247 %1248 %1249 %1250 %1251 %1252 %1253 %1254 %1255 %1256 %1257 %1258
+OpStore %1048 %1259
+%1260 = OpLoad %ulong %1048
+%1261 = OpUConvert %uchar %1260
+OpStore %1049 %1261
+%1262 = OpLoad %ulong %1122
+OpStore %1050 %1262
+%1263 = OpLoad %ulong %1050
+%1264 = OpUConvert %uchar %1263
+OpStore %1051 %1264
+%1265 = OpLoad %ulong %1127
+OpStore %1052 %1265
+%1266 = OpLoad %ulong %1052
+%1267 = OpUConvert %ushort %1266
+OpStore %1053 %1267
+%1268 = OpLoad %ulong %1132
+OpStore %1054 %1268
+%1269 = OpLoad %ulong %1054
+%1270 = OpUConvert %ushort %1269
+OpStore %1055 %1270
+%1271 = OpLoad %ulong %1137
+OpStore %1056 %1271
+%1272 = OpLoad %ulong %1056
+%1273 = OpUConvert %uint %1272
+OpStore %1057 %1273
+%1274 = OpLoad %ulong %1142
+OpStore %1058 %1274
+%1275 = OpLoad %ulong %1058
+%1276 = OpUConvert %uint %1275
+OpStore %1059 %1276
+%1277 = OpLoad %ulong %1147
+OpStore %1060 %1277
+%1278 = OpLoad %ulong %1150
+OpStore %1061 %1278
+%1279 = OpLoad %uchar %1004
+%1280 = OpLoad %uchar %1006
+%1281 = OpLoad %ushort %1008
+%1282 = OpLoad %ushort %1010
+%1283 = OpLoad %uint %1011
+%1284 = OpLoad %uint %1013
+%1285 = OpLoad %ulong %1014
+%1286 = OpLoad %ulong %1015
+%1287 = OpLoad %uchar %1049
+%1288 = OpLoad %uchar %1051
+%1289 = OpLoad %ushort %1053
+%1290 = OpLoad %ushort %1055
+%1291 = OpLoad %uint %1057
+%1292 = OpLoad %uint %1059
+%1293 = OpLoad %ulong %1060
+%1294 = OpLoad %ulong %1061
+%1295 = OpFunctionCall %ulong %2 %1279 %1280 %1281 %1282 %1283 %1284 %1285 %1286 %1287 %1288 %1289 %1290 %1291 %1292 %1293 %1294
+OpStore %1062 %1295
+%1296 = OpLoad %ulong %1064
+%1297 = OpLoad %ulong %1062
+%1298 = OpFunctionCall %ulong %5 %1296 %1297
+OpStore %1063 %1298
+%1299 = OpLoad %ulong %1063
+OpReturnValue %1299
+%888 = OpLabel
+%1300 = OpLoad %ulong %1067
+%1302 = OpIMul %ulong %1300 %ulong_7
+OpStore %904 %1302
+%1303 = OpLoad %ulong %904
+%1304 = OpLoad %ulong %900
+%1305 = OpIAdd %ulong %1303 %1304
+OpStore %905 %1305
+%1306 = OpAccessChain %_ptr_Function_ulong %899 %uint_0
+%1307 = OpLoad %ulong %1306
+OpStore %906 %1307
+%1308 = OpLoad %ulong %906
+%1309 = OpUConvert %uchar %1308
+OpStore %907 %1309
+%1310 = OpAccessChain %_ptr_Function_ulong %899 %uint_1
+%1311 = OpLoad %ulong %1310
+OpStore %908 %1311
+%1312 = OpLoad %ulong %908
+%1313 = OpUConvert %uchar %1312
+OpStore %909 %1313
+%1314 = OpAccessChain %_ptr_Function_ulong %899 %uint_2
+%1315 = OpLoad %ulong %1314
+OpStore %910 %1315
+%1316 = OpLoad %ulong %910
+%1317 = OpUConvert %ushort %1316
+OpStore %911 %1317
+%1318 = OpAccessChain %_ptr_Function_ulong %899 %uint_3
+%1319 = OpLoad %ulong %1318
+OpStore %912 %1319
+%1320 = OpLoad %ulong %912
+%1321 = OpUConvert %ushort %1320
+OpStore %913 %1321
+%1322 = OpAccessChain %_ptr_Function_ulong %899 %uint_4
+%1323 = OpLoad %ulong %1322
+OpStore %914 %1323
+%1324 = OpLoad %ulong %914
+%1325 = OpUConvert %uint %1324
+OpStore %915 %1325
+%1326 = OpAccessChain %_ptr_Function_ulong %899 %uint_5
+%1327 = OpLoad %ulong %1326
+OpStore %916 %1327
+%1328 = OpLoad %ulong %916
+%1329 = OpUConvert %uint %1328
+OpStore %917 %1329
+%1330 = OpAccessChain %_ptr_Function_ulong %899 %uint_6
+%1331 = OpLoad %ulong %1330
+OpStore %918 %1331
+%1332 = OpLoad %ulong %918
+%1333 = OpLoad %ulong %905
+%1334 = OpIAdd %ulong %1332 %1333
+OpStore %919 %1334
+%1335 = OpAccessChain %_ptr_Function_ulong %899 %uint_7
+%1336 = OpLoad %ulong %1335
+OpStore %920 %1336
+%1337 = OpAccessChain %_ptr_Function_ulong %899 %uint_8
+%1338 = OpLoad %ulong %1337
+OpStore %921 %1338
+%1339 = OpLoad %ulong %921
+%1340 = OpUConvert %uchar %1339
+OpStore %922 %1340
+%1341 = OpAccessChain %_ptr_Function_ulong %899 %uint_9
+%1342 = OpLoad %ulong %1341
+OpStore %923 %1342
+%1343 = OpLoad %ulong %923
+%1344 = OpUConvert %uchar %1343
+OpStore %924 %1344
+%1345 = OpAccessChain %_ptr_Function_ulong %899 %uint_10
+%1346 = OpLoad %ulong %1345
+OpStore %925 %1346
+%1347 = OpLoad %ulong %925
+%1348 = OpUConvert %ushort %1347
+OpStore %926 %1348
+%1349 = OpAccessChain %_ptr_Function_ulong %899 %uint_11
+%1350 = OpLoad %ulong %1349
+OpStore %927 %1350
+%1351 = OpLoad %ulong %927
+%1352 = OpUConvert %ushort %1351
+OpStore %928 %1352
+%1353 = OpAccessChain %_ptr_Function_ulong %899 %uint_12
+%1354 = OpLoad %ulong %1353
+OpStore %929 %1354
+%1355 = OpLoad %ulong %929
+%1356 = OpUConvert %uint %1355
+OpStore %930 %1356
+%1357 = OpAccessChain %_ptr_Function_ulong %899 %uint_13
+%1358 = OpLoad %ulong %1357
+OpStore %931 %1358
+%1359 = OpLoad %ulong %931
+%1360 = OpUConvert %uint %1359
+OpStore %932 %1360
+%1361 = OpAccessChain %_ptr_Function_ulong %899 %uint_14
+%1362 = OpLoad %ulong %1361
+OpStore %933 %1362
+%1363 = OpLoad %ulong %933
+%1364 = OpLoad %ulong %905
+%1365 = OpIAdd %ulong %1363 %1364
+OpStore %934 %1365
+%1366 = OpAccessChain %_ptr_Function_ulong %899 %uint_15
+%1367 = OpLoad %ulong %1366
+OpStore %935 %1367
+%1368 = OpLoad %uchar %907
+%1369 = OpLoad %uchar %909
+%1370 = OpLoad %ushort %911
+%1371 = OpLoad %ushort %913
+%1372 = OpLoad %uint %915
+%1373 = OpLoad %uint %917
+%1374 = OpLoad %ulong %919
+%1375 = OpLoad %ulong %920
+%1376 = OpLoad %uchar %922
+%1377 = OpLoad %uchar %924
+%1378 = OpLoad %ushort %926
+%1379 = OpLoad %ushort %928
+%1380 = OpLoad %uint %930
+%1381 = OpLoad %uint %932
+%1382 = OpLoad %ulong %934
+%1383 = OpLoad %ulong %935
+%1384 = OpFunctionCall %ulong %2 %1368 %1369 %1370 %1371 %1372 %1373 %1374 %1375 %1376 %1377 %1378 %1379 %1380 %1381 %1382 %1383
+OpStore %936 %1384
+%1385 = OpLoad %ulong %1064
+%1386 = OpLoad %ulong %936
+%1387 = OpFunctionCall %ulong %5 %1385 %1386
+OpStore %937 %1387
+%1388 = OpLoad %ulong %1306
+OpStore %938 %1388
+%1389 = OpLoad %ulong %938
+%1390 = OpUConvert %uchar %1389
+OpStore %939 %1390
+%1391 = OpLoad %ulong %1310
+OpStore %940 %1391
+%1392 = OpLoad %ulong %940
+%1393 = OpUConvert %uchar %1392
+OpStore %941 %1393
+%1394 = OpLoad %ulong %1314
+OpStore %942 %1394
+%1395 = OpLoad %ulong %942
+%1396 = OpUConvert %uchar %1395
+OpStore %943 %1396
+%1397 = OpLoad %ulong %1318
+OpStore %944 %1397
+%1398 = OpLoad %ulong %944
+%1399 = OpUConvert %uchar %1398
+OpStore %945 %1399
+%1400 = OpLoad %ulong %1322
+OpStore %946 %1400
+%1401 = OpLoad %ulong %946
+%1402 = OpUConvert %ushort %1401
+OpStore %947 %1402
+%1403 = OpLoad %ulong %1326
+OpStore %948 %1403
+%1404 = OpLoad %ulong %948
+%1405 = OpUConvert %ushort %1404
+OpStore %949 %1405
+%1406 = OpLoad %ulong %1330
+OpStore %950 %1406
+%1407 = OpLoad %ulong %950
+%1408 = OpUConvert %ushort %1407
+OpStore %951 %1408
+%1409 = OpLoad %ulong %1335
+OpStore %952 %1409
+%1410 = OpLoad %ulong %952
+%1411 = OpUConvert %ushort %1410
+OpStore %953 %1411
+%1412 = OpLoad %ulong %1337
+OpStore %954 %1412
+%1413 = OpLoad %ulong %954
+%1414 = OpLoad %ulong %905
+%1415 = OpIAdd %ulong %1413 %1414
+OpStore %955 %1415
+%1416 = OpLoad %ulong %955
+%1417 = OpUConvert %uchar %1416
+OpStore %956 %1417
+%1418 = OpLoad %ulong %1341
+OpStore %957 %1418
+%1419 = OpLoad %ulong %957
+%1420 = OpUConvert %uchar %1419
+OpStore %958 %1420
+%1421 = OpLoad %ulong %1345
+OpStore %959 %1421
+%1422 = OpLoad %ulong %959
+%1423 = OpUConvert %ushort %1422
+OpStore %960 %1423
+%1424 = OpLoad %ulong %1349
+OpStore %961 %1424
+%1425 = OpLoad %ulong %961
+%1426 = OpUConvert %ushort %1425
+OpStore %962 %1426
+%1427 = OpLoad %ulong %1353
+OpStore %963 %1427
+%1428 = OpLoad %ulong %963
+%1429 = OpUConvert %uchar %1428
+OpStore %964 %1429
+%1430 = OpLoad %ulong %1357
+OpStore %965 %1430
+%1431 = OpLoad %ulong %965
+%1432 = OpUConvert %uchar %1431
+OpStore %966 %1432
+%1433 = OpLoad %ulong %1361
+OpStore %967 %1433
+%1434 = OpLoad %ulong %967
+%1435 = OpUConvert %ushort %1434
+OpStore %968 %1435
+%1436 = OpLoad %ulong %1366
+OpStore %969 %1436
+%1437 = OpLoad %ulong %969
+%1438 = OpLoad %ulong %905
+%1439 = OpIAdd %ulong %1437 %1438
+OpStore %970 %1439
+%1440 = OpLoad %ulong %970
+%1441 = OpUConvert %ushort %1440
+OpStore %971 %1441
+%1442 = OpLoad %uchar %939
+%1443 = OpLoad %uchar %941
+%1444 = OpLoad %uchar %943
+%1445 = OpLoad %uchar %945
+%1446 = OpLoad %ushort %947
+%1447 = OpLoad %ushort %949
+%1448 = OpLoad %ushort %951
+%1449 = OpLoad %ushort %953
+%1450 = OpLoad %uchar %956
+%1451 = OpLoad %uchar %958
+%1452 = OpLoad %ushort %960
+%1453 = OpLoad %ushort %962
+%1454 = OpLoad %uchar %964
+%1455 = OpLoad %uchar %966
+%1456 = OpLoad %ushort %968
+%1457 = OpLoad %ushort %971
+%1458 = OpFunctionCall %ulong %3 %1442 %1443 %1444 %1445 %1446 %1447 %1448 %1449 %1450 %1451 %1452 %1453 %1454 %1455 %1456 %1457
+OpStore %972 %1458
+%1459 = OpLoad %ulong %937
+%1460 = OpLoad %ulong %972
+%1461 = OpFunctionCall %ulong %5 %1459 %1460
+OpStore %973 %1461
+%1462 = OpLoad %ulong %1067
+%1463 = OpIAdd %ulong %1462 %ulong_1
+OpStore %974 %1463
+%1464 = OpLoad %ulong %973
+OpStore %1064 %1464
+%1465 = OpLoad %ulong %972
+OpStore %1066 %1465
+%1466 = OpLoad %ulong %974
+OpStore %1067 %1466
+OpBranch %894
+%885 = OpLabel
+OpBranch %892
+%892 = OpLabel
+%1467 = OpLoad %ulong %1065
+%1468 = OpIMul %ulong %1467 %ulong_6364136223846793005
+OpStore %1068 %1468
+%1469 = OpLoad %ulong %1068
+%1470 = OpIAdd %ulong %1469 %ulong_1442695040888963407
+OpStore %1069 %1470
+%1471 = OpLoad %ulong %1069
+%1472 = OpLoad %ulong %900
+%1473 = OpIAdd %ulong %1471 %1472
+OpStore %1070 %1473
+OpBranch %893
+%893 = OpLabel
+%1474 = OpLoad %ulong %1065
+%1475 = OpAccessChain %_ptr_Function_ulong %899 %1474
+%1476 = OpLoad %ulong %1070
+OpStore %1475 %1476
+%1477 = OpLoad %ulong %1065
+%1478 = OpIAdd %ulong %1477 %ulong_1
+OpStore %902 %1478
+%1479 = OpLoad %ulong %902
+OpStore %1065 %1479
+OpBranch %895
+%894 = OpLabel
+OpBranch %887
+%895 = OpLabel
+OpBranch %884
 OpFunctionEnd
-%7 = OpFunction %ulong None %1180
-%1181 = OpFunctionParameter %ulong
-%1182 = OpFunctionParameter %uchar
-%1183 = OpLabel
-%1190 = OpVariable %_ptr_Function_ulong Function
-%1191 = OpVariable %_ptr_Function_uchar Function
-%1192 = OpVariable %_ptr_Function_ulong Function
-%1193 = OpVariable %_ptr_Function_bool Function
-%1194 = OpVariable %_ptr_Function_ulong Function
-%1195 = OpVariable %_ptr_Function_ulong Function
-%1196 = OpVariable %_ptr_Function_ulong Function
-%1197 = OpVariable %_ptr_Function_ulong Function
-%1198 = OpVariable %_ptr_Function_ulong Function
-%1199 = OpVariable %_ptr_Function_ulong Function
-%1200 = OpVariable %_ptr_Function_ulong Function
-%1201 = OpVariable %_ptr_Function_ulong Function
-OpStore %1190 %1181
-OpStore %1191 %1182
-%1202 = OpLoad %uchar %1191
-%1203 = OpUConvert %ulong %1202
-OpStore %1192 %1203
-OpBranch %1184
-%1184 = OpLabel
-%1204 = OpLoad %ulong %1190
-OpStore %1200 %1204
-OpStore %1201 %ulong_0
-OpBranch %1185
-%1185 = OpLabel
-%1205 = OpLoad %ulong %1201
-%1206 = OpULessThan %bool %1205 %ulong_8
-OpStore %1193 %1206
-%1207 = OpLoad %bool %1193
-OpLoopMerge %1187 %1189 None
-OpBranchConditional %1207 %1186 %1187
-%1187 = OpLabel
-OpBranch %1188
-%1188 = OpLabel
-%1208 = OpLoad %ulong %1200
-OpReturnValue %1208
-%1186 = OpLabel
-%1209 = OpLoad %ulong %1201
-%1210 = OpIMul %ulong %1209 %ulong_8
-OpStore %1194 %1210
-%1211 = OpLoad %ulong %1192
-%1212 = OpLoad %ulong %1194
-%1213 = OpShiftRightLogical %ulong %1211 %1212
-OpStore %1195 %1213
-%1214 = OpLoad %ulong %1195
-%1215 = OpBitwiseAnd %ulong %1214 %ulong_255
-OpStore %1196 %1215
-%1216 = OpLoad %ulong %1200
-%1217 = OpLoad %ulong %1196
-%1218 = OpBitwiseXor %ulong %1216 %1217
-OpStore %1197 %1218
-%1219 = OpLoad %ulong %1197
-%1220 = OpIMul %ulong %1219 %ulong_1099511628211
-OpStore %1198 %1220
-%1221 = OpLoad %ulong %1201
-%1222 = OpIAdd %ulong %1221 %ulong_1
-OpStore %1199 %1222
-%1223 = OpLoad %ulong %1198
-OpStore %1200 %1223
-%1224 = OpLoad %ulong %1199
-OpStore %1201 %1224
-OpBranch %1189
-%1189 = OpLabel
-OpBranch %1185
-OpFunctionEnd
-%8 = OpFunction %ulong None %1225
-%1226 = OpFunctionParameter %ulong
-%1227 = OpFunctionParameter %ushort
-%1228 = OpLabel
-%1235 = OpVariable %_ptr_Function_ulong Function
-%1236 = OpVariable %_ptr_Function_ushort Function
-%1237 = OpVariable %_ptr_Function_ulong Function
-%1238 = OpVariable %_ptr_Function_bool Function
-%1239 = OpVariable %_ptr_Function_ulong Function
-%1240 = OpVariable %_ptr_Function_ulong Function
-%1241 = OpVariable %_ptr_Function_ulong Function
-%1242 = OpVariable %_ptr_Function_ulong Function
-%1243 = OpVariable %_ptr_Function_ulong Function
-%1244 = OpVariable %_ptr_Function_ulong Function
-%1245 = OpVariable %_ptr_Function_ulong Function
-%1246 = OpVariable %_ptr_Function_ulong Function
-OpStore %1235 %1226
-OpStore %1236 %1227
-%1247 = OpLoad %ushort %1236
-%1248 = OpUConvert %ulong %1247
-OpStore %1237 %1248
-OpBranch %1229
-%1229 = OpLabel
-%1249 = OpLoad %ulong %1235
-OpStore %1245 %1249
-OpStore %1246 %ulong_0
-OpBranch %1230
-%1230 = OpLabel
-%1250 = OpLoad %ulong %1246
-%1251 = OpULessThan %bool %1250 %ulong_8
-OpStore %1238 %1251
-%1252 = OpLoad %bool %1238
-OpLoopMerge %1232 %1234 None
-OpBranchConditional %1252 %1231 %1232
-%1232 = OpLabel
-OpBranch %1233
-%1233 = OpLabel
-%1253 = OpLoad %ulong %1245
-OpReturnValue %1253
-%1231 = OpLabel
-%1254 = OpLoad %ulong %1246
-%1255 = OpIMul %ulong %1254 %ulong_8
-OpStore %1239 %1255
-%1256 = OpLoad %ulong %1237
-%1257 = OpLoad %ulong %1239
-%1258 = OpShiftRightLogical %ulong %1256 %1257
-OpStore %1240 %1258
-%1259 = OpLoad %ulong %1240
-%1260 = OpBitwiseAnd %ulong %1259 %ulong_255
-OpStore %1241 %1260
-%1261 = OpLoad %ulong %1245
-%1262 = OpLoad %ulong %1241
-%1263 = OpBitwiseXor %ulong %1261 %1262
-OpStore %1242 %1263
-%1264 = OpLoad %ulong %1242
-%1265 = OpIMul %ulong %1264 %ulong_1099511628211
-OpStore %1243 %1265
-%1266 = OpLoad %ulong %1246
-%1267 = OpIAdd %ulong %1266 %ulong_1
-OpStore %1244 %1267
-%1268 = OpLoad %ulong %1243
-OpStore %1245 %1268
-%1269 = OpLoad %ulong %1244
-OpStore %1246 %1269
-OpBranch %1234
-%1234 = OpLabel
-OpBranch %1230
-OpFunctionEnd
-%9 = OpFunction %ulong None %1270
-%1271 = OpFunctionParameter %ulong
-%1272 = OpFunctionParameter %uint
-%1273 = OpLabel
-%1280 = OpVariable %_ptr_Function_ulong Function
-%1281 = OpVariable %_ptr_Function_uint Function
-%1282 = OpVariable %_ptr_Function_ulong Function
-%1283 = OpVariable %_ptr_Function_bool Function
-%1284 = OpVariable %_ptr_Function_ulong Function
-%1285 = OpVariable %_ptr_Function_ulong Function
-%1286 = OpVariable %_ptr_Function_ulong Function
-%1287 = OpVariable %_ptr_Function_ulong Function
-%1288 = OpVariable %_ptr_Function_ulong Function
-%1289 = OpVariable %_ptr_Function_ulong Function
-%1290 = OpVariable %_ptr_Function_ulong Function
-%1291 = OpVariable %_ptr_Function_ulong Function
-OpStore %1280 %1271
-OpStore %1281 %1272
-%1292 = OpLoad %uint %1281
-%1293 = OpUConvert %ulong %1292
-OpStore %1282 %1293
-OpBranch %1274
-%1274 = OpLabel
-%1294 = OpLoad %ulong %1280
-OpStore %1290 %1294
-OpStore %1291 %ulong_0
-OpBranch %1275
-%1275 = OpLabel
-%1295 = OpLoad %ulong %1291
-%1296 = OpULessThan %bool %1295 %ulong_8
-OpStore %1283 %1296
-%1297 = OpLoad %bool %1283
-OpLoopMerge %1277 %1279 None
-OpBranchConditional %1297 %1276 %1277
-%1277 = OpLabel
-OpBranch %1278
-%1278 = OpLabel
-%1298 = OpLoad %ulong %1290
-OpReturnValue %1298
-%1276 = OpLabel
-%1299 = OpLoad %ulong %1291
-%1300 = OpIMul %ulong %1299 %ulong_8
-OpStore %1284 %1300
-%1301 = OpLoad %ulong %1282
-%1302 = OpLoad %ulong %1284
-%1303 = OpShiftRightLogical %ulong %1301 %1302
-OpStore %1285 %1303
-%1304 = OpLoad %ulong %1285
-%1305 = OpBitwiseAnd %ulong %1304 %ulong_255
-OpStore %1286 %1305
-%1306 = OpLoad %ulong %1290
-%1307 = OpLoad %ulong %1286
-%1308 = OpBitwiseXor %ulong %1306 %1307
-OpStore %1287 %1308
-%1309 = OpLoad %ulong %1287
-%1310 = OpIMul %ulong %1309 %ulong_1099511628211
-OpStore %1288 %1310
-%1311 = OpLoad %ulong %1291
-%1312 = OpIAdd %ulong %1311 %ulong_1
-OpStore %1289 %1312
-%1313 = OpLoad %ulong %1288
-OpStore %1290 %1313
-%1314 = OpLoad %ulong %1289
-OpStore %1291 %1314
-OpBranch %1279
-%1279 = OpLabel
-OpBranch %1275
-OpFunctionEnd
-%10 = OpFunction %ulong None %1180
-%1315 = OpFunctionParameter %ulong
-%1316 = OpFunctionParameter %uchar
-%1317 = OpLabel
-%1324 = OpVariable %_ptr_Function_ulong Function
-%1325 = OpVariable %_ptr_Function_uchar Function
-%1326 = OpVariable %_ptr_Function_ulong Function
-%1327 = OpVariable %_ptr_Function_bool Function
-%1328 = OpVariable %_ptr_Function_ulong Function
-%1329 = OpVariable %_ptr_Function_ulong Function
-%1330 = OpVariable %_ptr_Function_ulong Function
-%1331 = OpVariable %_ptr_Function_ulong Function
-%1332 = OpVariable %_ptr_Function_ulong Function
-%1333 = OpVariable %_ptr_Function_ulong Function
-%1334 = OpVariable %_ptr_Function_ulong Function
-%1335 = OpVariable %_ptr_Function_ulong Function
-OpStore %1324 %1315
-OpStore %1325 %1316
-%1336 = OpLoad %uchar %1325
-%1337 = OpSConvert %ulong %1336
-OpStore %1326 %1337
-OpBranch %1318
-%1318 = OpLabel
-%1338 = OpLoad %ulong %1324
-OpStore %1334 %1338
-OpStore %1335 %ulong_0
-OpBranch %1319
-%1319 = OpLabel
-%1339 = OpLoad %ulong %1335
-%1340 = OpULessThan %bool %1339 %ulong_8
-OpStore %1327 %1340
-%1341 = OpLoad %bool %1327
-OpLoopMerge %1321 %1323 None
-OpBranchConditional %1341 %1320 %1321
-%1321 = OpLabel
-OpBranch %1322
-%1322 = OpLabel
-%1342 = OpLoad %ulong %1334
-OpReturnValue %1342
-%1320 = OpLabel
-%1343 = OpLoad %ulong %1335
-%1344 = OpIMul %ulong %1343 %ulong_8
-OpStore %1328 %1344
-%1345 = OpLoad %ulong %1326
-%1346 = OpLoad %ulong %1328
-%1347 = OpShiftRightLogical %ulong %1345 %1346
-OpStore %1329 %1347
-%1348 = OpLoad %ulong %1329
-%1349 = OpBitwiseAnd %ulong %1348 %ulong_255
-OpStore %1330 %1349
-%1350 = OpLoad %ulong %1334
-%1351 = OpLoad %ulong %1330
-%1352 = OpBitwiseXor %ulong %1350 %1351
-OpStore %1331 %1352
-%1353 = OpLoad %ulong %1331
-%1354 = OpIMul %ulong %1353 %ulong_1099511628211
-OpStore %1332 %1354
-%1355 = OpLoad %ulong %1335
-%1356 = OpIAdd %ulong %1355 %ulong_1
-OpStore %1333 %1356
-%1357 = OpLoad %ulong %1332
-OpStore %1334 %1357
-%1358 = OpLoad %ulong %1333
-OpStore %1335 %1358
-OpBranch %1323
-%1323 = OpLabel
-OpBranch %1319
-OpFunctionEnd
-%11 = OpFunction %ulong None %1225
-%1359 = OpFunctionParameter %ulong
-%1360 = OpFunctionParameter %ushort
-%1361 = OpLabel
-%1368 = OpVariable %_ptr_Function_ulong Function
-%1369 = OpVariable %_ptr_Function_ushort Function
-%1370 = OpVariable %_ptr_Function_ulong Function
-%1371 = OpVariable %_ptr_Function_bool Function
-%1372 = OpVariable %_ptr_Function_ulong Function
-%1373 = OpVariable %_ptr_Function_ulong Function
-%1374 = OpVariable %_ptr_Function_ulong Function
-%1375 = OpVariable %_ptr_Function_ulong Function
-%1376 = OpVariable %_ptr_Function_ulong Function
-%1377 = OpVariable %_ptr_Function_ulong Function
-%1378 = OpVariable %_ptr_Function_ulong Function
-%1379 = OpVariable %_ptr_Function_ulong Function
-OpStore %1368 %1359
-OpStore %1369 %1360
-%1380 = OpLoad %ushort %1369
-%1381 = OpSConvert %ulong %1380
-OpStore %1370 %1381
-OpBranch %1362
-%1362 = OpLabel
-%1382 = OpLoad %ulong %1368
-OpStore %1378 %1382
-OpStore %1379 %ulong_0
-OpBranch %1363
-%1363 = OpLabel
-%1383 = OpLoad %ulong %1379
-%1384 = OpULessThan %bool %1383 %ulong_8
-OpStore %1371 %1384
-%1385 = OpLoad %bool %1371
-OpLoopMerge %1365 %1367 None
-OpBranchConditional %1385 %1364 %1365
-%1365 = OpLabel
-OpBranch %1366
-%1366 = OpLabel
-%1386 = OpLoad %ulong %1378
-OpReturnValue %1386
-%1364 = OpLabel
-%1387 = OpLoad %ulong %1379
-%1388 = OpIMul %ulong %1387 %ulong_8
-OpStore %1372 %1388
-%1389 = OpLoad %ulong %1370
-%1390 = OpLoad %ulong %1372
-%1391 = OpShiftRightLogical %ulong %1389 %1390
-OpStore %1373 %1391
-%1392 = OpLoad %ulong %1373
-%1393 = OpBitwiseAnd %ulong %1392 %ulong_255
-OpStore %1374 %1393
-%1394 = OpLoad %ulong %1378
-%1395 = OpLoad %ulong %1374
-%1396 = OpBitwiseXor %ulong %1394 %1395
-OpStore %1375 %1396
-%1397 = OpLoad %ulong %1375
-%1398 = OpIMul %ulong %1397 %ulong_1099511628211
-OpStore %1376 %1398
-%1399 = OpLoad %ulong %1379
-%1400 = OpIAdd %ulong %1399 %ulong_1
-OpStore %1377 %1400
-%1401 = OpLoad %ulong %1376
-OpStore %1378 %1401
-%1402 = OpLoad %ulong %1377
-OpStore %1379 %1402
-OpBranch %1367
-%1367 = OpLabel
-OpBranch %1363
-OpFunctionEnd
-%12 = OpFunction %ulong None %1270
-%1403 = OpFunctionParameter %ulong
-%1404 = OpFunctionParameter %uint
-%1405 = OpLabel
-%1412 = OpVariable %_ptr_Function_ulong Function
-%1413 = OpVariable %_ptr_Function_uint Function
-%1414 = OpVariable %_ptr_Function_ulong Function
-%1415 = OpVariable %_ptr_Function_bool Function
-%1416 = OpVariable %_ptr_Function_ulong Function
-%1417 = OpVariable %_ptr_Function_ulong Function
-%1418 = OpVariable %_ptr_Function_ulong Function
-%1419 = OpVariable %_ptr_Function_ulong Function
-%1420 = OpVariable %_ptr_Function_ulong Function
-%1421 = OpVariable %_ptr_Function_ulong Function
-%1422 = OpVariable %_ptr_Function_ulong Function
-%1423 = OpVariable %_ptr_Function_ulong Function
-OpStore %1412 %1403
-OpStore %1413 %1404
-%1424 = OpLoad %uint %1413
-%1425 = OpSConvert %ulong %1424
-OpStore %1414 %1425
-OpBranch %1406
-%1406 = OpLabel
-%1426 = OpLoad %ulong %1412
-OpStore %1422 %1426
-OpStore %1423 %ulong_0
-OpBranch %1407
-%1407 = OpLabel
-%1427 = OpLoad %ulong %1423
-%1428 = OpULessThan %bool %1427 %ulong_8
-OpStore %1415 %1428
-%1429 = OpLoad %bool %1415
-OpLoopMerge %1409 %1411 None
-OpBranchConditional %1429 %1408 %1409
-%1409 = OpLabel
-OpBranch %1410
-%1410 = OpLabel
-%1430 = OpLoad %ulong %1422
-OpReturnValue %1430
-%1408 = OpLabel
-%1431 = OpLoad %ulong %1423
-%1432 = OpIMul %ulong %1431 %ulong_8
-OpStore %1416 %1432
-%1433 = OpLoad %ulong %1414
-%1434 = OpLoad %ulong %1416
-%1435 = OpShiftRightLogical %ulong %1433 %1434
-OpStore %1417 %1435
-%1436 = OpLoad %ulong %1417
-%1437 = OpBitwiseAnd %ulong %1436 %ulong_255
-OpStore %1418 %1437
-%1438 = OpLoad %ulong %1422
-%1439 = OpLoad %ulong %1418
-%1440 = OpBitwiseXor %ulong %1438 %1439
-OpStore %1419 %1440
-%1441 = OpLoad %ulong %1419
-%1442 = OpIMul %ulong %1441 %ulong_1099511628211
-OpStore %1420 %1442
-%1443 = OpLoad %ulong %1423
-%1444 = OpIAdd %ulong %1443 %ulong_1
-OpStore %1421 %1444
-%1445 = OpLoad %ulong %1420
-OpStore %1422 %1445
-%1446 = OpLoad %ulong %1421
-OpStore %1423 %1446
-OpBranch %1411
-%1411 = OpLabel
-OpBranch %1407
-OpFunctionEnd
-%13 = OpFunction %ulong None %15
-%1447 = OpFunctionParameter %ulong
-%1448 = OpFunctionParameter %ulong
-%1449 = OpLabel
-%1456 = OpVariable %_ptr_Function_ulong Function
-%1457 = OpVariable %_ptr_Function_ulong Function
-%1458 = OpVariable %_ptr_Function_bool Function
-%1459 = OpVariable %_ptr_Function_ulong Function
-%1460 = OpVariable %_ptr_Function_ulong Function
-%1461 = OpVariable %_ptr_Function_ulong Function
-%1462 = OpVariable %_ptr_Function_ulong Function
-%1463 = OpVariable %_ptr_Function_ulong Function
-%1464 = OpVariable %_ptr_Function_ulong Function
-%1465 = OpVariable %_ptr_Function_ulong Function
-%1466 = OpVariable %_ptr_Function_ulong Function
-OpStore %1456 %1447
-OpStore %1457 %1448
-OpBranch %1450
-%1450 = OpLabel
-%1467 = OpLoad %ulong %1456
-OpStore %1465 %1467
-OpStore %1466 %ulong_0
-OpBranch %1451
-%1451 = OpLabel
-%1468 = OpLoad %ulong %1466
-%1469 = OpULessThan %bool %1468 %ulong_8
-OpStore %1458 %1469
-%1470 = OpLoad %bool %1458
-OpLoopMerge %1453 %1455 None
-OpBranchConditional %1470 %1452 %1453
-%1453 = OpLabel
-OpBranch %1454
-%1454 = OpLabel
-%1471 = OpLoad %ulong %1465
-OpReturnValue %1471
-%1452 = OpLabel
-%1472 = OpLoad %ulong %1466
-%1473 = OpIMul %ulong %1472 %ulong_8
-OpStore %1459 %1473
-%1474 = OpLoad %ulong %1457
-%1475 = OpLoad %ulong %1459
-%1476 = OpShiftRightLogical %ulong %1474 %1475
-OpStore %1460 %1476
-%1477 = OpLoad %ulong %1460
-%1478 = OpBitwiseAnd %ulong %1477 %ulong_255
-OpStore %1461 %1478
-%1479 = OpLoad %ulong %1465
-%1480 = OpLoad %ulong %1461
-%1481 = OpBitwiseXor %ulong %1479 %1480
-OpStore %1462 %1481
-%1482 = OpLoad %ulong %1462
-%1483 = OpIMul %ulong %1482 %ulong_1099511628211
-OpStore %1463 %1483
-%1484 = OpLoad %ulong %1466
-%1485 = OpIAdd %ulong %1484 %ulong_1
-OpStore %1464 %1485
-%1486 = OpLoad %ulong %1463
-OpStore %1465 %1486
-%1487 = OpLoad %ulong %1464
-OpStore %1466 %1487
-OpBranch %1455
-%1455 = OpLabel
-OpBranch %1451
+%5 = OpFunction %ulong None %7
+%1480 = OpFunctionParameter %ulong
+%1481 = OpFunctionParameter %ulong
+%1482 = OpLabel
+%1487 = OpVariable %_ptr_Function_ulong Function
+%1488 = OpVariable %_ptr_Function_ulong Function
+%1489 = OpVariable %_ptr_Function_bool Function
+%1490 = OpVariable %_ptr_Function_ulong Function
+%1491 = OpVariable %_ptr_Function_ulong Function
+%1492 = OpVariable %_ptr_Function_ulong Function
+%1493 = OpVariable %_ptr_Function_ulong Function
+%1494 = OpVariable %_ptr_Function_ulong Function
+%1495 = OpVariable %_ptr_Function_ulong Function
+%1496 = OpVariable %_ptr_Function_ulong Function
+%1497 = OpVariable %_ptr_Function_ulong Function
+OpStore %1487 %1480
+OpStore %1488 %1481
+%1498 = OpLoad %ulong %1487
+OpStore %1496 %1498
+OpStore %1497 %ulong_0
+OpBranch %1483
+%1483 = OpLabel
+%1499 = OpLoad %ulong %1497
+%1500 = OpULessThan %bool %1499 %ulong_8
+OpStore %1489 %1500
+%1501 = OpLoad %bool %1489
+OpLoopMerge %1485 %1486 None
+OpBranchConditional %1501 %1484 %1485
+%1485 = OpLabel
+%1502 = OpLoad %ulong %1496
+OpReturnValue %1502
+%1484 = OpLabel
+%1503 = OpLoad %ulong %1497
+%1504 = OpIMul %ulong %1503 %ulong_8
+OpStore %1490 %1504
+%1505 = OpLoad %ulong %1488
+%1506 = OpLoad %ulong %1490
+%1507 = OpShiftRightLogical %ulong %1505 %1506
+OpStore %1491 %1507
+%1508 = OpLoad %ulong %1491
+%1509 = OpBitwiseAnd %ulong %1508 %ulong_255
+OpStore %1492 %1509
+%1510 = OpLoad %ulong %1496
+%1511 = OpLoad %ulong %1492
+%1512 = OpBitwiseXor %ulong %1510 %1511
+OpStore %1493 %1512
+%1513 = OpLoad %ulong %1493
+%1514 = OpIMul %ulong %1513 %ulong_1099511628211
+OpStore %1494 %1514
+%1515 = OpLoad %ulong %1497
+%1516 = OpIAdd %ulong %1515 %ulong_1
+OpStore %1495 %1516
+%1517 = OpLoad %ulong %1494
+OpStore %1496 %1517
+%1518 = OpLoad %ulong %1495
+OpStore %1497 %1518
+OpBranch %1486
+%1486 = OpLabel
+OpBranch %1483
 OpFunctionEnd

--- a/test/golden/spirv/call/call_mixed.dis
+++ b/test/golden/spirv/call/call_mixed.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1583
+; Bound: 1987
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -16,18 +16,18 @@ OpDecorate %3 LinkageAttributes "corpus.cases.call.call_mixed.as_f64" Export
 OpDecorate %4 LinkageAttributes "corpus.cases.call.call_mixed.mixed" Export
 OpDecorate %5 LinkageAttributes "corpus.cases.call.call_mixed.checksum" Export
 %ulong = OpTypeInt 64 0
-%16 = OpTypeFunction %ulong %ulong %ulong
+%9 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %float = OpTypeFloat 32
-%37 = OpTypeFunction %float %ulong
+%30 = OpTypeFunction %float %ulong
 %_ptr_Function_float = OpTypePointer Function %float
 %ulong_4095 = OpConstant %ulong 4095
 %float_2048 = OpConstant %float 2048
 %float_8 = OpConstant %float 8
 %double = OpTypeFloat 64
-%59 = OpTypeFunction %double %ulong
+%52 = OpTypeFunction %double %ulong
 %_ptr_Function_double = OpTypePointer Function %double
 %ulong_1048575 = OpConstant %ulong 1048575
 %double_524288 = OpConstant %double 524288
@@ -38,21 +38,26 @@ OpDecorate %5 LinkageAttributes "corpus.cases.call.call_mixed.checksum" Export
 %v4float = OpTypeVector %float 4
 %uchar = OpTypeInt 8 0
 %v2float = OpTypeVector %float 2
-%86 = OpTypeFunction %ulong %ulong %float %uint %double %v3float %ulong %float %ushort %v4float %double %ulong %float %uchar %double %v2float %ulong %float %uint %double %ulong
+%79 = OpTypeFunction %ulong %ulong %float %uint %double %v3float %ulong %float %ushort %v4float %double %ulong %float %uchar %double %v2float %ulong %float %uint %double %ulong
+%bool = OpTypeBool
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_v3float = OpTypePointer Function %v3float
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_v2float = OpTypePointer Function %v2float
-%346 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%1026 = OpTypeFunction %ulong %ulong
 %uint_24 = OpConstant %uint 24
 %_arr_ulong_uint_24 = OpTypeArray %ulong %uint_24
 %_ptr_Function__arr_ulong_uint_24 = OpTypePointer Function %_arr_ulong_uint_24
-%_ptr_Function_bool = OpTypePointer Function %bool
-%655 = OpConstantNull %_arr_ulong_uint_24
-%ulong_0 = OpConstant %ulong 0
+%1333 = OpConstantNull %_arr_ulong_uint_24
 %ulong_24 = OpConstant %ulong 24
 %ulong_3 = OpConstant %ulong 3
 %uint_2 = OpConstant %uint 2
@@ -80,428 +85,266 @@ OpDecorate %5 LinkageAttributes "corpus.cases.call.call_mixed.checksum" Export
 %uint_18 = OpConstant %uint 18
 %uint_20 = OpConstant %uint 20
 %uint_22 = OpConstant %uint 22
-%ulong_1 = OpConstant %ulong 1
-%1225 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1270 = OpTypeFunction %ulong %ulong %uchar
-%1315 = OpTypeFunction %ulong %ulong %ushort
-%1360 = OpTypeFunction %ulong %ulong %uint
-%1490 = OpTypeFunction %ulong %ulong %float
-%1538 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %16
-%17 = OpFunctionParameter %ulong
-%18 = OpFunctionParameter %ulong
-%19 = OpLabel
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %21 %17
-OpStore %22 %18
-%26 = OpLoad %ulong %22
-%28 = OpIMul %ulong %26 %ulong_6364136223846793005
-OpStore %23 %28
-%29 = OpLoad %ulong %23
-%31 = OpIAdd %ulong %29 %ulong_1442695040888963407
-OpStore %24 %31
-%32 = OpLoad %ulong %24
-%33 = OpLoad %ulong %21
-%34 = OpIAdd %ulong %32 %33
-OpStore %25 %34
-%35 = OpLoad %ulong %25
-OpReturnValue %35
+%1939 = OpTypeFunction %ulong %ulong %float
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %ulong
+%12 = OpLabel
+%14 = OpVariable %_ptr_Function_ulong Function
+%15 = OpVariable %_ptr_Function_ulong Function
+%16 = OpVariable %_ptr_Function_ulong Function
+%17 = OpVariable %_ptr_Function_ulong Function
+%18 = OpVariable %_ptr_Function_ulong Function
+OpStore %14 %10
+OpStore %15 %11
+%19 = OpLoad %ulong %15
+%21 = OpIMul %ulong %19 %ulong_6364136223846793005
+OpStore %16 %21
+%22 = OpLoad %ulong %16
+%24 = OpIAdd %ulong %22 %ulong_1442695040888963407
+OpStore %17 %24
+%25 = OpLoad %ulong %17
+%26 = OpLoad %ulong %14
+%27 = OpIAdd %ulong %25 %26
+OpStore %18 %27
+%28 = OpLoad %ulong %18
+OpReturnValue %28
 OpFunctionEnd
-%2 = OpFunction %float None %37
-%38 = OpFunctionParameter %ulong
-%39 = OpLabel
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_float Function
-%44 = OpVariable %_ptr_Function_float Function
-%45 = OpVariable %_ptr_Function_float Function
-OpStore %40 %38
-%46 = OpLoad %ulong %40
-%48 = OpBitwiseAnd %ulong %46 %ulong_4095
-OpStore %41 %48
-%49 = OpLoad %ulong %41
-%50 = OpConvertUToF %float %49
-OpStore %43 %50
-%51 = OpLoad %float %43
-%53 = OpFSub %float %51 %float_2048
-OpStore %44 %53
-%54 = OpLoad %float %44
-%56 = OpFDiv %float %54 %float_8
-OpStore %45 %56
-%57 = OpLoad %float %45
-OpReturnValue %57
+%2 = OpFunction %float None %30
+%31 = OpFunctionParameter %ulong
+%32 = OpLabel
+%33 = OpVariable %_ptr_Function_ulong Function
+%34 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_float Function
+%37 = OpVariable %_ptr_Function_float Function
+%38 = OpVariable %_ptr_Function_float Function
+OpStore %33 %31
+%39 = OpLoad %ulong %33
+%41 = OpBitwiseAnd %ulong %39 %ulong_4095
+OpStore %34 %41
+%42 = OpLoad %ulong %34
+%43 = OpConvertUToF %float %42
+OpStore %36 %43
+%44 = OpLoad %float %36
+%46 = OpFSub %float %44 %float_2048
+OpStore %37 %46
+%47 = OpLoad %float %37
+%49 = OpFDiv %float %47 %float_8
+OpStore %38 %49
+%50 = OpLoad %float %38
+OpReturnValue %50
 OpFunctionEnd
-%3 = OpFunction %double None %59
-%60 = OpFunctionParameter %ulong
-%61 = OpLabel
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_double Function
-%66 = OpVariable %_ptr_Function_double Function
-%67 = OpVariable %_ptr_Function_double Function
-OpStore %62 %60
-%68 = OpLoad %ulong %62
-%70 = OpBitwiseAnd %ulong %68 %ulong_1048575
-OpStore %63 %70
-%71 = OpLoad %ulong %63
-%72 = OpConvertUToF %double %71
-OpStore %65 %72
-%73 = OpLoad %double %65
-%75 = OpFSub %double %73 %double_524288
-OpStore %66 %75
-%76 = OpLoad %double %66
-%78 = OpFDiv %double %76 %double_64
-OpStore %67 %78
-%79 = OpLoad %double %67
-OpReturnValue %79
+%3 = OpFunction %double None %52
+%53 = OpFunctionParameter %ulong
+%54 = OpLabel
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_double Function
+%59 = OpVariable %_ptr_Function_double Function
+%60 = OpVariable %_ptr_Function_double Function
+OpStore %55 %53
+%61 = OpLoad %ulong %55
+%63 = OpBitwiseAnd %ulong %61 %ulong_1048575
+OpStore %56 %63
+%64 = OpLoad %ulong %56
+%65 = OpConvertUToF %double %64
+OpStore %58 %65
+%66 = OpLoad %double %58
+%68 = OpFSub %double %66 %double_524288
+OpStore %59 %68
+%69 = OpLoad %double %59
+%71 = OpFDiv %double %69 %double_64
+OpStore %60 %71
+%72 = OpLoad %double %60
+OpReturnValue %72
 OpFunctionEnd
-%4 = OpFunction %ulong None %86
-%87 = OpFunctionParameter %ulong
-%88 = OpFunctionParameter %float
-%89 = OpFunctionParameter %uint
-%90 = OpFunctionParameter %double
-%91 = OpFunctionParameter %v3float
-%92 = OpFunctionParameter %ulong
-%93 = OpFunctionParameter %float
-%94 = OpFunctionParameter %ushort
-%95 = OpFunctionParameter %v4float
-%96 = OpFunctionParameter %double
-%97 = OpFunctionParameter %ulong
-%98 = OpFunctionParameter %float
-%99 = OpFunctionParameter %uchar
-%100 = OpFunctionParameter %double
-%101 = OpFunctionParameter %v2float
-%102 = OpFunctionParameter %ulong
-%103 = OpFunctionParameter %float
-%104 = OpFunctionParameter %uint
-%105 = OpFunctionParameter %double
-%106 = OpFunctionParameter %ulong
-%107 = OpLabel
-%108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_float Function
-%111 = OpVariable %_ptr_Function_uint Function
-%112 = OpVariable %_ptr_Function_double Function
-%114 = OpVariable %_ptr_Function_v3float Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_float Function
-%118 = OpVariable %_ptr_Function_ushort Function
-%120 = OpVariable %_ptr_Function_v4float Function
-%121 = OpVariable %_ptr_Function_double Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_float Function
-%125 = OpVariable %_ptr_Function_uchar Function
-%126 = OpVariable %_ptr_Function_double Function
-%128 = OpVariable %_ptr_Function_v2float Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_float Function
-%131 = OpVariable %_ptr_Function_uint Function
-%132 = OpVariable %_ptr_Function_double Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_float Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_float Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_float Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_float Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_float Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_float Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_float Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_float Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_float Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_float Function
-%175 = OpVariable %_ptr_Function_float Function
-%176 = OpVariable %_ptr_Function_float Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_double Function
-%179 = OpVariable %_ptr_Function_double Function
-%180 = OpVariable %_ptr_Function_double Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_v3float Function
-%183 = OpVariable %_ptr_Function_v3float Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_float Function
-%189 = OpVariable %_ptr_Function_ulong Function
-OpStore %108 %87
-OpStore %109 %88
-OpStore %111 %89
-OpStore %112 %90
-OpStore %114 %91
-OpStore %115 %92
-OpStore %116 %93
-OpStore %118 %94
-OpStore %120 %95
-OpStore %121 %96
-OpStore %122 %97
-OpStore %123 %98
-OpStore %125 %99
-OpStore %126 %100
-OpStore %128 %101
-OpStore %129 %102
-OpStore %130 %103
-OpStore %131 %104
-OpStore %132 %105
-OpStore %133 %106
-%190 = OpFunctionCall %ulong %6
-OpStore %134 %190
-%191 = OpLoad %ulong %134
-%192 = OpLoad %ulong %108
-%193 = OpFunctionCall %ulong %7 %191 %192
-OpStore %135 %193
-%194 = OpLoad %ulong %135
-%195 = OpLoad %float %109
-%196 = OpFunctionCall %ulong %13 %194 %195
-OpStore %136 %196
-%197 = OpLoad %ulong %136
-%198 = OpLoad %uint %111
-%199 = OpFunctionCall %ulong %10 %197 %198
-OpStore %137 %199
-%200 = OpLoad %ulong %137
-%201 = OpLoad %double %112
-%202 = OpFunctionCall %ulong %14 %200 %201
-OpStore %138 %202
-%203 = OpLoad %v3float %114
-%204 = OpCompositeExtract %float %203 0
-OpStore %139 %204
-%205 = OpLoad %ulong %138
-%206 = OpLoad %float %139
-%207 = OpFunctionCall %ulong %13 %205 %206
-OpStore %140 %207
-%208 = OpLoad %v3float %114
-%209 = OpCompositeExtract %float %208 1
-OpStore %141 %209
-%210 = OpLoad %ulong %140
-%211 = OpLoad %float %141
-%212 = OpFunctionCall %ulong %13 %210 %211
-OpStore %142 %212
-%213 = OpLoad %v3float %114
-%214 = OpCompositeExtract %float %213 2
-OpStore %143 %214
-%215 = OpLoad %ulong %142
-%216 = OpLoad %float %143
-%217 = OpFunctionCall %ulong %13 %215 %216
-OpStore %144 %217
-%218 = OpLoad %ulong %144
-%219 = OpLoad %ulong %115
-%220 = OpFunctionCall %ulong %12 %218 %219
-OpStore %145 %220
-%221 = OpLoad %ulong %145
-%222 = OpLoad %float %116
-%223 = OpFunctionCall %ulong %13 %221 %222
-OpStore %146 %223
-%224 = OpLoad %ulong %146
-%225 = OpLoad %ushort %118
-%226 = OpFunctionCall %ulong %9 %224 %225
-OpStore %147 %226
-%227 = OpLoad %v4float %120
-%228 = OpCompositeExtract %float %227 0
-OpStore %148 %228
-%229 = OpLoad %ulong %147
-%230 = OpLoad %float %148
-%231 = OpFunctionCall %ulong %13 %229 %230
-OpStore %149 %231
-%232 = OpLoad %v4float %120
-%233 = OpCompositeExtract %float %232 1
-OpStore %150 %233
-%234 = OpLoad %ulong %149
-%235 = OpLoad %float %150
-%236 = OpFunctionCall %ulong %13 %234 %235
-OpStore %151 %236
-%237 = OpLoad %v4float %120
-%238 = OpCompositeExtract %float %237 2
-OpStore %152 %238
-%239 = OpLoad %ulong %151
-%240 = OpLoad %float %152
-%241 = OpFunctionCall %ulong %13 %239 %240
-OpStore %153 %241
-%242 = OpLoad %v4float %120
-%243 = OpCompositeExtract %float %242 3
-OpStore %154 %243
-%244 = OpLoad %ulong %153
-%245 = OpLoad %float %154
-%246 = OpFunctionCall %ulong %13 %244 %245
-OpStore %155 %246
-%247 = OpLoad %ulong %155
-%248 = OpLoad %double %121
-%249 = OpFunctionCall %ulong %14 %247 %248
-OpStore %156 %249
-%250 = OpLoad %ulong %156
-%251 = OpLoad %ulong %122
-%252 = OpFunctionCall %ulong %7 %250 %251
-OpStore %157 %252
-%253 = OpLoad %ulong %157
-%254 = OpLoad %float %123
-%255 = OpFunctionCall %ulong %13 %253 %254
-OpStore %158 %255
-%256 = OpLoad %ulong %158
-%257 = OpLoad %uchar %125
-%258 = OpFunctionCall %ulong %8 %256 %257
-OpStore %159 %258
-%259 = OpLoad %ulong %159
-%260 = OpLoad %double %126
-%261 = OpFunctionCall %ulong %14 %259 %260
-OpStore %160 %261
-%262 = OpLoad %v2float %128
-%263 = OpCompositeExtract %float %262 0
-OpStore %161 %263
-%264 = OpLoad %ulong %160
-%265 = OpLoad %float %161
-%266 = OpFunctionCall %ulong %13 %264 %265
-OpStore %162 %266
-%267 = OpLoad %v2float %128
-%268 = OpCompositeExtract %float %267 1
-OpStore %163 %268
-%269 = OpLoad %ulong %162
-%270 = OpLoad %float %163
-%271 = OpFunctionCall %ulong %13 %269 %270
-OpStore %164 %271
-%272 = OpLoad %ulong %164
-%273 = OpLoad %ulong %129
-%274 = OpFunctionCall %ulong %7 %272 %273
-OpStore %165 %274
-%275 = OpLoad %ulong %165
-%276 = OpLoad %float %130
-%277 = OpFunctionCall %ulong %13 %275 %276
-OpStore %166 %277
-%278 = OpLoad %ulong %166
-%279 = OpLoad %uint %131
-%280 = OpFunctionCall %ulong %11 %278 %279
-OpStore %167 %280
-%281 = OpLoad %ulong %167
-%282 = OpLoad %double %132
-%283 = OpFunctionCall %ulong %14 %281 %282
-OpStore %168 %283
-%284 = OpLoad %ulong %168
-%285 = OpLoad %ulong %133
-%286 = OpFunctionCall %ulong %7 %284 %285
-OpStore %169 %286
-%287 = OpLoad %ulong %122
-%288 = OpLoad %ulong %129
-%289 = OpIMul %ulong %287 %288
-OpStore %170 %289
-%290 = OpLoad %ulong %108
-%291 = OpLoad %ulong %170
-%292 = OpIAdd %ulong %290 %291
-OpStore %171 %292
-%293 = OpLoad %ulong %171
-%294 = OpLoad %ulong %133
-%295 = OpISub %ulong %293 %294
-OpStore %172 %295
-%296 = OpLoad %ulong %169
-%297 = OpLoad %ulong %172
-%298 = OpFunctionCall %ulong %7 %296 %297
-OpStore %173 %298
-%299 = OpLoad %float %116
-%300 = OpLoad %float %123
-%301 = OpFMul %float %299 %300
-OpStore %174 %301
-%302 = OpLoad %float %109
-%303 = OpLoad %float %174
-%304 = OpFAdd %float %302 %303
-OpStore %175 %304
-%305 = OpLoad %float %175
-%306 = OpLoad %float %130
-%307 = OpFSub %float %305 %306
-OpStore %176 %307
-%308 = OpLoad %ulong %173
-%309 = OpLoad %float %176
-%310 = OpFunctionCall %ulong %13 %308 %309
-OpStore %177 %310
-%311 = OpLoad %double %121
-%312 = OpLoad %double %126
-%313 = OpFMul %double %311 %312
-OpStore %178 %313
-%314 = OpLoad %double %112
-%315 = OpLoad %double %178
-%316 = OpFAdd %double %314 %315
-OpStore %179 %316
-%317 = OpLoad %double %179
-%318 = OpLoad %double %132
-%319 = OpFSub %double %317 %318
-OpStore %180 %319
-%320 = OpLoad %ulong %177
-%321 = OpLoad %double %180
-%322 = OpFunctionCall %ulong %14 %320 %321
-OpStore %181 %322
-%324 = OpLoad %float %148
-%325 = OpLoad %float %150
-%326 = OpLoad %float %161
-%323 = OpCompositeConstruct %v3float %324 %325 %326
-OpStore %182 %323
-%327 = OpLoad %v3float %114
-%328 = OpLoad %v3float %182
-%329 = OpFAdd %v3float %327 %328
-OpStore %183 %329
-%330 = OpLoad %v3float %183
-%331 = OpCompositeExtract %float %330 0
-OpStore %184 %331
-%332 = OpLoad %ulong %181
-%333 = OpLoad %float %184
-%334 = OpFunctionCall %ulong %13 %332 %333
-OpStore %185 %334
-%335 = OpLoad %v3float %183
-%336 = OpCompositeExtract %float %335 1
-OpStore %186 %336
-%337 = OpLoad %ulong %185
-%338 = OpLoad %float %186
-%339 = OpFunctionCall %ulong %13 %337 %338
-OpStore %187 %339
-%340 = OpLoad %v3float %183
-%341 = OpCompositeExtract %float %340 2
-OpStore %188 %341
-%342 = OpLoad %ulong %187
-%343 = OpLoad %float %188
-%344 = OpFunctionCall %ulong %13 %342 %343
-OpStore %189 %344
-%345 = OpLoad %ulong %189
-OpReturnValue %345
-OpFunctionEnd
-%5 = OpFunction %ulong None %346
-%347 = OpFunctionParameter %ulong
-%348 = OpLabel
-%419 = OpVariable %_ptr_Function__arr_ulong_uint_24 Function
+%4 = OpFunction %ulong None %79
+%80 = OpFunctionParameter %ulong
+%81 = OpFunctionParameter %float
+%82 = OpFunctionParameter %uint
+%83 = OpFunctionParameter %double
+%84 = OpFunctionParameter %v3float
+%85 = OpFunctionParameter %ulong
+%86 = OpFunctionParameter %float
+%87 = OpFunctionParameter %ushort
+%88 = OpFunctionParameter %v4float
+%89 = OpFunctionParameter %double
+%90 = OpFunctionParameter %ulong
+%91 = OpFunctionParameter %float
+%92 = OpFunctionParameter %uchar
+%93 = OpFunctionParameter %double
+%94 = OpFunctionParameter %v2float
+%95 = OpFunctionParameter %ulong
+%96 = OpFunctionParameter %float
+%97 = OpFunctionParameter %uint
+%98 = OpFunctionParameter %double
+%99 = OpFunctionParameter %ulong
+%100 = OpLabel
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_float Function
+%255 = OpVariable %_ptr_Function_uint Function
+%256 = OpVariable %_ptr_Function_double Function
+%258 = OpVariable %_ptr_Function_v3float Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_float Function
+%262 = OpVariable %_ptr_Function_ushort Function
+%264 = OpVariable %_ptr_Function_v4float Function
+%265 = OpVariable %_ptr_Function_double Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_float Function
+%269 = OpVariable %_ptr_Function_uchar Function
+%270 = OpVariable %_ptr_Function_double Function
+%272 = OpVariable %_ptr_Function_v2float Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_float Function
+%275 = OpVariable %_ptr_Function_uint Function
+%276 = OpVariable %_ptr_Function_double Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_float Function
+%279 = OpVariable %_ptr_Function_float Function
+%280 = OpVariable %_ptr_Function_float Function
+%281 = OpVariable %_ptr_Function_float Function
+%282 = OpVariable %_ptr_Function_float Function
+%283 = OpVariable %_ptr_Function_float Function
+%284 = OpVariable %_ptr_Function_float Function
+%285 = OpVariable %_ptr_Function_float Function
+%286 = OpVariable %_ptr_Function_float Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_float Function
+%294 = OpVariable %_ptr_Function_float Function
+%295 = OpVariable %_ptr_Function_float Function
+%296 = OpVariable %_ptr_Function_double Function
+%297 = OpVariable %_ptr_Function_double Function
+%298 = OpVariable %_ptr_Function_double Function
+%299 = OpVariable %_ptr_Function_float Function
+%300 = OpVariable %_ptr_Function_float Function
+%301 = OpVariable %_ptr_Function_float Function
+%302 = OpVariable %_ptr_Function_v3float Function
+%303 = OpVariable %_ptr_Function_v3float Function
+%304 = OpVariable %_ptr_Function_float Function
+%305 = OpVariable %_ptr_Function_float Function
+%306 = OpVariable %_ptr_Function_float Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_uint Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_bool Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_bool Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_uint Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_bool Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_uint Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_bool Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_uint Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_bool Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_bool Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_uint Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_bool Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_bool Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_uint Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_bool Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
 %420 = OpVariable %_ptr_Function_ulong Function
 %421 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_bool Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_uint Function
 %424 = OpVariable %_ptr_Function_ulong Function
 %425 = OpVariable %_ptr_Function_bool Function
 %426 = OpVariable %_ptr_Function_ulong Function
@@ -509,42 +352,42 @@ OpFunctionEnd
 %428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_ulong Function
 %430 = OpVariable %_ptr_Function_ulong Function
-%431 = OpVariable %_ptr_Function_v3float Function
+%431 = OpVariable %_ptr_Function_ulong Function
 %432 = OpVariable %_ptr_Function_ulong Function
 %433 = OpVariable %_ptr_Function_ulong Function
-%434 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_uint Function
 %435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_v4float Function
+%436 = OpVariable %_ptr_Function_bool Function
 %437 = OpVariable %_ptr_Function_ulong Function
 %438 = OpVariable %_ptr_Function_ulong Function
 %439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_float Function
-%441 = OpVariable %_ptr_Function_v2float Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
 %442 = OpVariable %_ptr_Function_ulong Function
 %443 = OpVariable %_ptr_Function_ulong Function
 %444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_float Function
+%445 = OpVariable %_ptr_Function_uint Function
 %446 = OpVariable %_ptr_Function_ulong Function
-%447 = OpVariable %_ptr_Function_uint Function
+%447 = OpVariable %_ptr_Function_bool Function
 %448 = OpVariable %_ptr_Function_ulong Function
 %449 = OpVariable %_ptr_Function_ulong Function
 %450 = OpVariable %_ptr_Function_ulong Function
-%451 = OpVariable %_ptr_Function_float Function
+%451 = OpVariable %_ptr_Function_ulong Function
 %452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_ushort Function
+%453 = OpVariable %_ptr_Function_ulong Function
 %454 = OpVariable %_ptr_Function_ulong Function
 %455 = OpVariable %_ptr_Function_ulong Function
 %456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_float Function
+%457 = OpVariable %_ptr_Function_bool Function
 %458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_uchar Function
+%459 = OpVariable %_ptr_Function_ulong Function
 %460 = OpVariable %_ptr_Function_ulong Function
 %461 = OpVariable %_ptr_Function_ulong Function
 %462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_float Function
+%463 = OpVariable %_ptr_Function_ulong Function
 %464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_uint Function
-%466 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_bool Function
 %467 = OpVariable %_ptr_Function_ulong Function
 %468 = OpVariable %_ptr_Function_ulong Function
 %469 = OpVariable %_ptr_Function_ulong Function
@@ -552,1639 +395,2431 @@ OpFunctionEnd
 %471 = OpVariable %_ptr_Function_ulong Function
 %472 = OpVariable %_ptr_Function_ulong Function
 %473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_v3float Function
-%475 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_uint Function
 %476 = OpVariable %_ptr_Function_ulong Function
 %477 = OpVariable %_ptr_Function_ulong Function
 %478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_v4float Function
+%479 = OpVariable %_ptr_Function_ulong Function
 %480 = OpVariable %_ptr_Function_ulong Function
 %481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_float Function
-%483 = OpVariable %_ptr_Function_v2float Function
+%482 = OpVariable %_ptr_Function_uint Function
+%483 = OpVariable %_ptr_Function_ulong Function
 %484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_float Function
+%485 = OpVariable %_ptr_Function_uint Function
+%486 = OpVariable %_ptr_Function_ulong Function
 %487 = OpVariable %_ptr_Function_ulong Function
 %488 = OpVariable %_ptr_Function_uint Function
 %489 = OpVariable %_ptr_Function_ulong Function
 %490 = OpVariable %_ptr_Function_ulong Function
 %491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_float Function
+%492 = OpVariable %_ptr_Function_ulong Function
 %493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_ushort Function
-%495 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_uint Function
 %496 = OpVariable %_ptr_Function_ulong Function
 %497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_float Function
+%498 = OpVariable %_ptr_Function_ulong Function
 %499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_uchar Function
+%500 = OpVariable %_ptr_Function_uint Function
 %501 = OpVariable %_ptr_Function_ulong Function
 %502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_float Function
+%503 = OpVariable %_ptr_Function_uint Function
+%504 = OpVariable %_ptr_Function_ulong Function
 %505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_uint Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_float Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_uint Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_float Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_ushort Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_float Function
-%524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_uchar Function
-%526 = OpVariable %_ptr_Function_ulong Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_ulong Function
-%529 = OpVariable %_ptr_Function_float Function
-%530 = OpVariable %_ptr_Function_ulong Function
-%531 = OpVariable %_ptr_Function_uint Function
-%532 = OpVariable %_ptr_Function_ulong Function
-%533 = OpVariable %_ptr_Function_ulong Function
-%534 = OpVariable %_ptr_Function_ulong Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_ulong Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_ulong Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_ulong Function
-%541 = OpVariable %_ptr_Function_ulong Function
-%542 = OpVariable %_ptr_Function_ulong Function
-%543 = OpVariable %_ptr_Function_float Function
-%544 = OpVariable %_ptr_Function_float Function
-%545 = OpVariable %_ptr_Function_float Function
-%546 = OpVariable %_ptr_Function_ulong Function
-%547 = OpVariable %_ptr_Function_float Function
-%548 = OpVariable %_ptr_Function_float Function
-%549 = OpVariable %_ptr_Function_float Function
-%550 = OpVariable %_ptr_Function_ulong Function
-%551 = OpVariable %_ptr_Function_float Function
-%552 = OpVariable %_ptr_Function_float Function
-%553 = OpVariable %_ptr_Function_float Function
-%554 = OpVariable %_ptr_Function_ulong Function
-%555 = OpVariable %_ptr_Function_float Function
-%556 = OpVariable %_ptr_Function_float Function
-%557 = OpVariable %_ptr_Function_float Function
-%558 = OpVariable %_ptr_Function_ulong Function
-%559 = OpVariable %_ptr_Function_float Function
-%560 = OpVariable %_ptr_Function_float Function
-%561 = OpVariable %_ptr_Function_float Function
-%562 = OpVariable %_ptr_Function_ulong Function
-%563 = OpVariable %_ptr_Function_float Function
-%564 = OpVariable %_ptr_Function_float Function
-%565 = OpVariable %_ptr_Function_float Function
-%566 = OpVariable %_ptr_Function_ulong Function
-%567 = OpVariable %_ptr_Function_float Function
-%568 = OpVariable %_ptr_Function_float Function
-%569 = OpVariable %_ptr_Function_float Function
-%570 = OpVariable %_ptr_Function_ulong Function
-%571 = OpVariable %_ptr_Function_float Function
-%572 = OpVariable %_ptr_Function_float Function
-%573 = OpVariable %_ptr_Function_float Function
-%574 = OpVariable %_ptr_Function_ulong Function
-%575 = OpVariable %_ptr_Function_float Function
-%576 = OpVariable %_ptr_Function_float Function
-%577 = OpVariable %_ptr_Function_float Function
-%578 = OpVariable %_ptr_Function_ulong Function
-%579 = OpVariable %_ptr_Function_float Function
-%580 = OpVariable %_ptr_Function_float Function
-%581 = OpVariable %_ptr_Function_float Function
-%582 = OpVariable %_ptr_Function_ulong Function
-%583 = OpVariable %_ptr_Function_float Function
-%584 = OpVariable %_ptr_Function_float Function
-%585 = OpVariable %_ptr_Function_float Function
-%586 = OpVariable %_ptr_Function_ulong Function
-%587 = OpVariable %_ptr_Function_float Function
-%588 = OpVariable %_ptr_Function_float Function
-%589 = OpVariable %_ptr_Function_float Function
-%590 = OpVariable %_ptr_Function_ulong Function
-%591 = OpVariable %_ptr_Function_float Function
-%592 = OpVariable %_ptr_Function_float Function
-%593 = OpVariable %_ptr_Function_float Function
-%594 = OpVariable %_ptr_Function_ulong Function
-%595 = OpVariable %_ptr_Function_float Function
-%596 = OpVariable %_ptr_Function_float Function
-%597 = OpVariable %_ptr_Function_float Function
-%598 = OpVariable %_ptr_Function_ulong Function
-%599 = OpVariable %_ptr_Function_float Function
-%600 = OpVariable %_ptr_Function_float Function
-%601 = OpVariable %_ptr_Function_float Function
-%602 = OpVariable %_ptr_Function_ulong Function
-%603 = OpVariable %_ptr_Function_float Function
-%604 = OpVariable %_ptr_Function_float Function
-%605 = OpVariable %_ptr_Function_float Function
-%606 = OpVariable %_ptr_Function_ulong Function
-%607 = OpVariable %_ptr_Function_double Function
-%608 = OpVariable %_ptr_Function_double Function
-%609 = OpVariable %_ptr_Function_double Function
-%610 = OpVariable %_ptr_Function_ulong Function
-%611 = OpVariable %_ptr_Function_double Function
-%612 = OpVariable %_ptr_Function_double Function
-%613 = OpVariable %_ptr_Function_double Function
-%614 = OpVariable %_ptr_Function_ulong Function
-%615 = OpVariable %_ptr_Function_double Function
-%616 = OpVariable %_ptr_Function_double Function
-%617 = OpVariable %_ptr_Function_double Function
-%618 = OpVariable %_ptr_Function_ulong Function
-%619 = OpVariable %_ptr_Function_double Function
-%620 = OpVariable %_ptr_Function_double Function
-%621 = OpVariable %_ptr_Function_double Function
-%622 = OpVariable %_ptr_Function_ulong Function
-%623 = OpVariable %_ptr_Function_double Function
-%624 = OpVariable %_ptr_Function_double Function
-%625 = OpVariable %_ptr_Function_double Function
-%626 = OpVariable %_ptr_Function_ulong Function
-%627 = OpVariable %_ptr_Function_double Function
-%628 = OpVariable %_ptr_Function_double Function
-%629 = OpVariable %_ptr_Function_double Function
-%630 = OpVariable %_ptr_Function_ulong Function
-%631 = OpVariable %_ptr_Function_double Function
-%632 = OpVariable %_ptr_Function_double Function
-%633 = OpVariable %_ptr_Function_double Function
-%634 = OpVariable %_ptr_Function_ulong Function
-%635 = OpVariable %_ptr_Function_double Function
-%636 = OpVariable %_ptr_Function_double Function
-%637 = OpVariable %_ptr_Function_double Function
-%638 = OpVariable %_ptr_Function_ulong Function
-%639 = OpVariable %_ptr_Function_double Function
-%640 = OpVariable %_ptr_Function_double Function
-%641 = OpVariable %_ptr_Function_double Function
-%642 = OpVariable %_ptr_Function_ulong Function
-%643 = OpVariable %_ptr_Function_double Function
-%644 = OpVariable %_ptr_Function_double Function
-%645 = OpVariable %_ptr_Function_double Function
-%646 = OpVariable %_ptr_Function_ulong Function
-%647 = OpVariable %_ptr_Function_double Function
-%648 = OpVariable %_ptr_Function_double Function
-%649 = OpVariable %_ptr_Function_double Function
-%650 = OpVariable %_ptr_Function_ulong Function
-%651 = OpVariable %_ptr_Function_double Function
-%652 = OpVariable %_ptr_Function_double Function
-%653 = OpVariable %_ptr_Function_double Function
-OpStore %420 %347
-%654 = OpFunctionCall %ulong %6
-OpStore %421 %654
-OpStore %419 %655
-OpStore %536 %ulong_0
-OpBranch %349
-%349 = OpLabel
-%657 = OpLoad %ulong %536
-%659 = OpULessThan %bool %657 %ulong_24
-OpStore %423 %659
-%660 = OpLoad %bool %423
-OpLoopMerge %351 %414 None
-OpBranchConditional %660 %350 %351
-%351 = OpLabel
-%661 = OpLoad %ulong %421
-OpStore %535 %661
-OpStore %537 %ulong_0
-OpStore %538 %ulong_0
-OpBranch %352
-%352 = OpLabel
-%662 = OpLoad %ulong %538
-%664 = OpULessThan %bool %662 %ulong_3
-OpStore %425 %664
-%665 = OpLoad %bool %425
-OpLoopMerge %354 %413 None
-OpBranchConditional %665 %353 %354
-%354 = OpLabel
-OpBranch %359
-%359 = OpLabel
-%666 = OpLoad %ulong %537
-%667 = OpBitwiseAnd %ulong %666 %ulong_4095
-OpStore %546 %667
-%668 = OpLoad %ulong %546
-%669 = OpConvertUToF %float %668
-OpStore %547 %669
-%670 = OpLoad %float %547
-%671 = OpFSub %float %670 %float_2048
-OpStore %548 %671
-%672 = OpLoad %float %548
-%673 = OpFDiv %float %672 %float_8
-OpStore %549 %673
-OpBranch %360
-%360 = OpLabel
-%675 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
-%676 = OpLoad %ulong %675
-OpStore %472 %676
-OpBranch %363
-%363 = OpLabel
-%677 = OpLoad %ulong %472
-%678 = OpBitwiseAnd %ulong %677 %ulong_4095
-OpStore %554 %678
-%679 = OpLoad %ulong %554
-%680 = OpConvertUToF %float %679
-OpStore %555 %680
-%681 = OpLoad %float %555
-%682 = OpFSub %float %681 %float_2048
-OpStore %556 %682
-%683 = OpLoad %float %556
-%684 = OpFDiv %float %683 %float_8
-OpStore %557 %684
-OpBranch %364
-%364 = OpLabel
-%686 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
-%687 = OpLoad %ulong %686
-OpStore %473 %687
-OpBranch %367
-%367 = OpLabel
-%688 = OpLoad %ulong %473
-%689 = OpBitwiseAnd %ulong %688 %ulong_4095
-OpStore %562 %689
-%690 = OpLoad %ulong %562
-%691 = OpConvertUToF %float %690
-OpStore %563 %691
-%692 = OpLoad %float %563
-%693 = OpFSub %float %692 %float_2048
-OpStore %564 %693
-%694 = OpLoad %float %564
-%695 = OpFDiv %float %694 %float_8
-OpStore %565 %695
-OpBranch %368
-%368 = OpLabel
-%697 = OpLoad %float %549
-%698 = OpLoad %float %557
-%699 = OpLoad %float %565
-%696 = OpCompositeConstruct %v3float %697 %698 %699
-OpStore %474 %696
-%701 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
-%702 = OpLoad %ulong %701
-OpStore %475 %702
-OpBranch %371
-%371 = OpLabel
-%703 = OpLoad %ulong %475
-%704 = OpBitwiseAnd %ulong %703 %ulong_4095
-OpStore %570 %704
-%705 = OpLoad %ulong %570
-%706 = OpConvertUToF %float %705
-OpStore %571 %706
-%707 = OpLoad %float %571
-%708 = OpFSub %float %707 %float_2048
-OpStore %572 %708
-%709 = OpLoad %float %572
-%710 = OpFDiv %float %709 %float_8
-OpStore %573 %710
-OpBranch %372
-%372 = OpLabel
-%712 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
-%713 = OpLoad %ulong %712
-OpStore %476 %713
-OpBranch %375
-%375 = OpLabel
-%714 = OpLoad %ulong %476
-%715 = OpBitwiseAnd %ulong %714 %ulong_4095
-OpStore %578 %715
-%716 = OpLoad %ulong %578
-%717 = OpConvertUToF %float %716
-OpStore %579 %717
-%718 = OpLoad %float %579
-%719 = OpFSub %float %718 %float_2048
-OpStore %580 %719
-%720 = OpLoad %float %580
-%721 = OpFDiv %float %720 %float_8
-OpStore %581 %721
-OpBranch %376
-%376 = OpLabel
-%723 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
-%724 = OpLoad %ulong %723
-OpStore %477 %724
-OpBranch %379
-%379 = OpLabel
-%725 = OpLoad %ulong %477
-%726 = OpBitwiseAnd %ulong %725 %ulong_4095
-OpStore %586 %726
-%727 = OpLoad %ulong %586
-%728 = OpConvertUToF %float %727
-OpStore %587 %728
-%729 = OpLoad %float %587
-%730 = OpFSub %float %729 %float_2048
-OpStore %588 %730
-%731 = OpLoad %float %588
-%732 = OpFDiv %float %731 %float_8
-OpStore %589 %732
-OpBranch %380
-%380 = OpLabel
-%734 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
-%735 = OpLoad %ulong %734
-OpStore %478 %735
-OpBranch %383
-%383 = OpLabel
-%736 = OpLoad %ulong %478
-%737 = OpBitwiseAnd %ulong %736 %ulong_4095
-OpStore %594 %737
-%738 = OpLoad %ulong %594
-%739 = OpConvertUToF %float %738
-OpStore %595 %739
-%740 = OpLoad %float %595
-%741 = OpFSub %float %740 %float_2048
-OpStore %596 %741
-%742 = OpLoad %float %596
-%743 = OpFDiv %float %742 %float_8
-OpStore %597 %743
-OpBranch %384
-%384 = OpLabel
-%745 = OpLoad %float %573
-%746 = OpLoad %float %581
-%747 = OpLoad %float %589
-%748 = OpLoad %float %597
-%744 = OpCompositeConstruct %v4float %745 %746 %747 %748
-OpStore %479 %744
-%750 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
-%751 = OpLoad %ulong %750
-OpStore %480 %751
-OpBranch %387
-%387 = OpLabel
-%752 = OpLoad %ulong %480
-%753 = OpBitwiseAnd %ulong %752 %ulong_4095
-OpStore %602 %753
-%754 = OpLoad %ulong %602
-%755 = OpConvertUToF %float %754
-OpStore %603 %755
-%756 = OpLoad %float %603
-%757 = OpFSub %float %756 %float_2048
-OpStore %604 %757
-%758 = OpLoad %float %604
-%759 = OpFDiv %float %758 %float_8
-OpStore %605 %759
-OpBranch %388
-%388 = OpLabel
-%761 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
-%762 = OpLoad %ulong %761
-OpStore %481 %762
-%763 = OpLoad %ulong %481
-%764 = OpFunctionCall %float %2 %763
-OpStore %482 %764
-%766 = OpLoad %float %605
-%767 = OpLoad %float %482
-%765 = OpCompositeConstruct %v2float %766 %767
-OpStore %483 %765
-%769 = OpAccessChain %_ptr_Function_ulong %419 %uint_0
-%770 = OpLoad %ulong %769
-OpStore %484 %770
-%772 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
-%773 = OpLoad %ulong %772
-OpStore %485 %773
-%774 = OpLoad %ulong %485
-%775 = OpFunctionCall %float %2 %774
-OpStore %486 %775
-%776 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
-%777 = OpLoad %ulong %776
-OpStore %487 %777
-%778 = OpLoad %ulong %487
-%779 = OpUConvert %uint %778
-OpStore %488 %779
-%780 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
-%781 = OpLoad %ulong %780
-OpStore %489 %781
-OpBranch %391
-%391 = OpLabel
-%782 = OpLoad %ulong %489
-%783 = OpBitwiseAnd %ulong %782 %ulong_1048575
-OpStore %610 %783
-%784 = OpLoad %ulong %610
-%785 = OpConvertUToF %double %784
-OpStore %611 %785
-%786 = OpLoad %double %611
-%787 = OpFSub %double %786 %double_524288
-OpStore %612 %787
-%788 = OpLoad %double %612
-%789 = OpFDiv %double %788 %double_64
-OpStore %613 %789
-OpBranch %392
-%392 = OpLabel
-%790 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
-%791 = OpLoad %ulong %790
-OpStore %490 %791
-%792 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
-%793 = OpLoad %ulong %792
-OpStore %491 %793
-%794 = OpLoad %ulong %491
-%795 = OpFunctionCall %float %2 %794
-OpStore %492 %795
-%796 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
-%797 = OpLoad %ulong %796
-OpStore %493 %797
-%798 = OpLoad %ulong %493
-%799 = OpUConvert %ushort %798
-OpStore %494 %799
-%800 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
-%801 = OpLoad %ulong %800
-OpStore %495 %801
-OpBranch %395
-%395 = OpLabel
-%802 = OpLoad %ulong %495
-%803 = OpBitwiseAnd %ulong %802 %ulong_1048575
-OpStore %618 %803
-%804 = OpLoad %ulong %618
-%805 = OpConvertUToF %double %804
-OpStore %619 %805
-%806 = OpLoad %double %619
-%807 = OpFSub %double %806 %double_524288
-OpStore %620 %807
-%808 = OpLoad %double %620
-%809 = OpFDiv %double %808 %double_64
-OpStore %621 %809
-OpBranch %396
-%396 = OpLabel
-%810 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
-%811 = OpLoad %ulong %810
-OpStore %496 %811
-%812 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
-%813 = OpLoad %ulong %812
-OpStore %497 %813
-%814 = OpLoad %ulong %497
-%815 = OpFunctionCall %float %2 %814
-OpStore %498 %815
-%817 = OpAccessChain %_ptr_Function_ulong %419 %uint_10
-%818 = OpLoad %ulong %817
-OpStore %499 %818
-%819 = OpLoad %ulong %499
-%820 = OpUConvert %uchar %819
-OpStore %500 %820
-%822 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
-%823 = OpLoad %ulong %822
-OpStore %501 %823
-OpBranch %399
-%399 = OpLabel
-%824 = OpLoad %ulong %501
-%825 = OpBitwiseAnd %ulong %824 %ulong_1048575
-OpStore %626 %825
-%826 = OpLoad %ulong %626
-%827 = OpConvertUToF %double %826
-OpStore %627 %827
-%828 = OpLoad %double %627
-%829 = OpFSub %double %828 %double_524288
-OpStore %628 %829
-%830 = OpLoad %double %628
-%831 = OpFDiv %double %830 %double_64
-OpStore %629 %831
-OpBranch %400
-%400 = OpLabel
-%833 = OpAccessChain %_ptr_Function_ulong %419 %uint_12
-%834 = OpLoad %ulong %833
-OpStore %502 %834
-%836 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
-%837 = OpLoad %ulong %836
-OpStore %503 %837
-%838 = OpLoad %ulong %503
-%839 = OpFunctionCall %float %2 %838
-OpStore %504 %839
-%841 = OpAccessChain %_ptr_Function_ulong %419 %uint_14
-%842 = OpLoad %ulong %841
-OpStore %505 %842
-%843 = OpLoad %ulong %505
-%844 = OpUConvert %uint %843
-OpStore %506 %844
-%846 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
-%847 = OpLoad %ulong %846
-OpStore %507 %847
-OpBranch %403
-%403 = OpLabel
-%848 = OpLoad %ulong %507
-%849 = OpBitwiseAnd %ulong %848 %ulong_1048575
-OpStore %634 %849
-%850 = OpLoad %ulong %634
-%851 = OpConvertUToF %double %850
-OpStore %635 %851
-%852 = OpLoad %double %635
-%853 = OpFSub %double %852 %double_524288
-OpStore %636 %853
-%854 = OpLoad %double %636
-%855 = OpFDiv %double %854 %double_64
-OpStore %637 %855
-OpBranch %404
-%404 = OpLabel
-%856 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
-%857 = OpLoad %ulong %856
-OpStore %508 %857
-%858 = OpLoad %ulong %484
-%859 = OpLoad %float %486
-%860 = OpLoad %uint %488
-%861 = OpLoad %double %613
-%862 = OpLoad %v3float %474
-%863 = OpLoad %ulong %490
-%864 = OpLoad %float %492
-%865 = OpLoad %ushort %494
-%866 = OpLoad %v4float %479
-%867 = OpLoad %double %621
-%868 = OpLoad %ulong %496
-%869 = OpLoad %float %498
-%870 = OpLoad %uchar %500
-%871 = OpLoad %double %629
-%872 = OpLoad %v2float %483
-%873 = OpLoad %ulong %502
-%874 = OpLoad %float %504
-%875 = OpLoad %uint %506
-%876 = OpLoad %double %637
-%877 = OpLoad %ulong %508
-%878 = OpFunctionCall %ulong %4 %858 %859 %860 %861 %862 %863 %864 %865 %866 %867 %868 %869 %870 %871 %872 %873 %874 %875 %876 %877
-OpStore %509 %878
-%879 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
-%880 = OpLoad %ulong %879
-OpStore %510 %880
-%881 = OpLoad %ulong %510
-%882 = OpFunctionCall %float %2 %881
-OpStore %511 %882
-%883 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
-%884 = OpLoad %ulong %883
-OpStore %512 %884
-%885 = OpLoad %ulong %512
-%886 = OpUConvert %uint %885
-OpStore %513 %886
-%887 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
-%888 = OpLoad %ulong %887
-OpStore %514 %888
-OpBranch %405
-%405 = OpLabel
-%889 = OpLoad %ulong %514
-%890 = OpBitwiseAnd %ulong %889 %ulong_1048575
-OpStore %638 %890
-%891 = OpLoad %ulong %638
-%892 = OpConvertUToF %double %891
-OpStore %639 %892
-%893 = OpLoad %double %639
-%894 = OpFSub %double %893 %double_524288
-OpStore %640 %894
-%895 = OpLoad %double %640
-%896 = OpFDiv %double %895 %double_64
-OpStore %641 %896
-OpBranch %406
-%406 = OpLabel
-%897 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
-%898 = OpLoad %ulong %897
-OpStore %515 %898
-%899 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
-%900 = OpLoad %ulong %899
-OpStore %516 %900
-%901 = OpLoad %ulong %516
-%902 = OpFunctionCall %float %2 %901
-OpStore %517 %902
-%903 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
-%904 = OpLoad %ulong %903
-OpStore %518 %904
-%905 = OpLoad %ulong %518
-%906 = OpUConvert %ushort %905
-OpStore %519 %906
-%907 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
-%908 = OpLoad %ulong %907
-OpStore %520 %908
-OpBranch %407
-%407 = OpLabel
-%909 = OpLoad %ulong %520
-%910 = OpBitwiseAnd %ulong %909 %ulong_1048575
-OpStore %642 %910
-%911 = OpLoad %ulong %642
-%912 = OpConvertUToF %double %911
-OpStore %643 %912
-%913 = OpLoad %double %643
-%914 = OpFSub %double %913 %double_524288
-OpStore %644 %914
-%915 = OpLoad %double %644
-%916 = OpFDiv %double %915 %double_64
-OpStore %645 %916
-OpBranch %408
-%408 = OpLabel
-%918 = OpAccessChain %_ptr_Function_ulong %419 %uint_17
-%919 = OpLoad %ulong %918
-OpStore %521 %919
-%921 = OpAccessChain %_ptr_Function_ulong %419 %uint_19
-%922 = OpLoad %ulong %921
-OpStore %522 %922
-%923 = OpLoad %ulong %522
-%924 = OpFunctionCall %float %2 %923
-OpStore %523 %924
-%926 = OpAccessChain %_ptr_Function_ulong %419 %uint_21
-%927 = OpLoad %ulong %926
-OpStore %524 %927
-%928 = OpLoad %ulong %524
-%929 = OpUConvert %uchar %928
-OpStore %525 %929
-%931 = OpAccessChain %_ptr_Function_ulong %419 %uint_23
-%932 = OpLoad %ulong %931
-OpStore %526 %932
-OpBranch %409
-%409 = OpLabel
-%933 = OpLoad %ulong %526
-%934 = OpBitwiseAnd %ulong %933 %ulong_1048575
-OpStore %646 %934
-%935 = OpLoad %ulong %646
-%936 = OpConvertUToF %double %935
-OpStore %647 %936
-%937 = OpLoad %double %647
-%938 = OpFSub %double %937 %double_524288
-OpStore %648 %938
-%939 = OpLoad %double %648
-%940 = OpFDiv %double %939 %double_64
-OpStore %649 %940
-OpBranch %410
-%410 = OpLabel
-%941 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
-%942 = OpLoad %ulong %941
-OpStore %527 %942
-%943 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
-%944 = OpLoad %ulong %943
-OpStore %528 %944
-%945 = OpLoad %ulong %528
-%946 = OpFunctionCall %float %2 %945
-OpStore %529 %946
-%947 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
-%948 = OpLoad %ulong %947
-OpStore %530 %948
-%949 = OpLoad %ulong %530
-%950 = OpUConvert %uint %949
-OpStore %531 %950
-%951 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
-%952 = OpLoad %ulong %951
-OpStore %532 %952
-OpBranch %411
-%411 = OpLabel
-%953 = OpLoad %ulong %532
-%954 = OpBitwiseAnd %ulong %953 %ulong_1048575
-OpStore %650 %954
-%955 = OpLoad %ulong %650
-%956 = OpConvertUToF %double %955
-OpStore %651 %956
-%957 = OpLoad %double %651
-%958 = OpFSub %double %957 %double_524288
-OpStore %652 %958
-%959 = OpLoad %double %652
-%960 = OpFDiv %double %959 %double_64
-OpStore %653 %960
-OpBranch %412
-%412 = OpLabel
-%961 = OpLoad %ulong %509
-%962 = OpLoad %float %511
-%963 = OpLoad %uint %513
-%964 = OpLoad %double %641
-%965 = OpLoad %v3float %474
-%966 = OpLoad %ulong %515
-%967 = OpLoad %float %517
-%968 = OpLoad %ushort %519
-%969 = OpLoad %v4float %479
-%970 = OpLoad %double %645
-%971 = OpLoad %ulong %521
-%972 = OpLoad %float %523
-%973 = OpLoad %uchar %525
-%974 = OpLoad %double %649
-%975 = OpLoad %v2float %483
-%976 = OpLoad %ulong %527
-%977 = OpLoad %float %529
-%978 = OpLoad %uint %531
-%979 = OpLoad %double %653
-%980 = OpLoad %ulong %537
-%981 = OpFunctionCall %ulong %4 %961 %962 %963 %964 %965 %966 %967 %968 %969 %970 %971 %972 %973 %974 %975 %976 %977 %978 %979 %980
-OpStore %533 %981
-%982 = OpLoad %ulong %535
-%983 = OpLoad %ulong %533
-%984 = OpFunctionCall %ulong %7 %982 %983
-OpStore %534 %984
-%985 = OpLoad %ulong %534
-OpReturnValue %985
-%353 = OpLabel
-%986 = OpLoad %ulong %538
-%988 = OpIMul %ulong %986 %ulong_11
-OpStore %426 %988
-%989 = OpLoad %ulong %426
-%990 = OpLoad %ulong %420
-%991 = OpIAdd %ulong %989 %990
-OpStore %427 %991
-%993 = OpAccessChain %_ptr_Function_ulong %419 %uint_16
-%994 = OpLoad %ulong %993
-OpStore %428 %994
-OpBranch %357
-%357 = OpLabel
-%995 = OpLoad %ulong %428
-%996 = OpBitwiseAnd %ulong %995 %ulong_4095
-OpStore %542 %996
-%997 = OpLoad %ulong %542
-%998 = OpConvertUToF %float %997
-OpStore %543 %998
-%999 = OpLoad %float %543
-%1000 = OpFSub %float %999 %float_2048
-OpStore %544 %1000
-%1001 = OpLoad %float %544
-%1002 = OpFDiv %float %1001 %float_8
-OpStore %545 %1002
-OpBranch %358
-%358 = OpLabel
-%1003 = OpAccessChain %_ptr_Function_ulong %419 %uint_17
-%1004 = OpLoad %ulong %1003
-OpStore %429 %1004
-OpBranch %361
-%361 = OpLabel
-%1005 = OpLoad %ulong %429
-%1006 = OpBitwiseAnd %ulong %1005 %ulong_4095
-OpStore %550 %1006
-%1007 = OpLoad %ulong %550
-%1008 = OpConvertUToF %float %1007
-OpStore %551 %1008
-%1009 = OpLoad %float %551
-%1010 = OpFSub %float %1009 %float_2048
-OpStore %552 %1010
-%1011 = OpLoad %float %552
-%1012 = OpFDiv %float %1011 %float_8
-OpStore %553 %1012
-OpBranch %362
-%362 = OpLabel
-%1014 = OpAccessChain %_ptr_Function_ulong %419 %uint_18
-%1015 = OpLoad %ulong %1014
-OpStore %430 %1015
-OpBranch %365
-%365 = OpLabel
-%1016 = OpLoad %ulong %430
-%1017 = OpBitwiseAnd %ulong %1016 %ulong_4095
-OpStore %558 %1017
-%1018 = OpLoad %ulong %558
-%1019 = OpConvertUToF %float %1018
-OpStore %559 %1019
-%1020 = OpLoad %float %559
-%1021 = OpFSub %float %1020 %float_2048
-OpStore %560 %1021
-%1022 = OpLoad %float %560
-%1023 = OpFDiv %float %1022 %float_8
-OpStore %561 %1023
-OpBranch %366
-%366 = OpLabel
-%1025 = OpLoad %float %545
-%1026 = OpLoad %float %553
-%1027 = OpLoad %float %561
-%1024 = OpCompositeConstruct %v3float %1025 %1026 %1027
-OpStore %431 %1024
-%1028 = OpAccessChain %_ptr_Function_ulong %419 %uint_19
-%1029 = OpLoad %ulong %1028
-OpStore %432 %1029
-OpBranch %369
-%369 = OpLabel
-%1030 = OpLoad %ulong %432
-%1031 = OpBitwiseAnd %ulong %1030 %ulong_4095
-OpStore %566 %1031
-%1032 = OpLoad %ulong %566
-%1033 = OpConvertUToF %float %1032
-OpStore %567 %1033
-%1034 = OpLoad %float %567
-%1035 = OpFSub %float %1034 %float_2048
-OpStore %568 %1035
-%1036 = OpLoad %float %568
-%1037 = OpFDiv %float %1036 %float_8
-OpStore %569 %1037
-OpBranch %370
-%370 = OpLabel
-%1039 = OpAccessChain %_ptr_Function_ulong %419 %uint_20
-%1040 = OpLoad %ulong %1039
-OpStore %433 %1040
-OpBranch %373
-%373 = OpLabel
-%1041 = OpLoad %ulong %433
-%1042 = OpBitwiseAnd %ulong %1041 %ulong_4095
-OpStore %574 %1042
-%1043 = OpLoad %ulong %574
-%1044 = OpConvertUToF %float %1043
-OpStore %575 %1044
-%1045 = OpLoad %float %575
-%1046 = OpFSub %float %1045 %float_2048
-OpStore %576 %1046
-%1047 = OpLoad %float %576
-%1048 = OpFDiv %float %1047 %float_8
-OpStore %577 %1048
-OpBranch %374
-%374 = OpLabel
-%1049 = OpAccessChain %_ptr_Function_ulong %419 %uint_21
-%1050 = OpLoad %ulong %1049
-OpStore %434 %1050
-OpBranch %377
-%377 = OpLabel
-%1051 = OpLoad %ulong %434
-%1052 = OpBitwiseAnd %ulong %1051 %ulong_4095
-OpStore %582 %1052
-%1053 = OpLoad %ulong %582
-%1054 = OpConvertUToF %float %1053
-OpStore %583 %1054
-%1055 = OpLoad %float %583
-%1056 = OpFSub %float %1055 %float_2048
-OpStore %584 %1056
-%1057 = OpLoad %float %584
-%1058 = OpFDiv %float %1057 %float_8
-OpStore %585 %1058
-OpBranch %378
-%378 = OpLabel
-%1060 = OpAccessChain %_ptr_Function_ulong %419 %uint_22
-%1061 = OpLoad %ulong %1060
-OpStore %435 %1061
-OpBranch %381
-%381 = OpLabel
-%1062 = OpLoad %ulong %435
-%1063 = OpBitwiseAnd %ulong %1062 %ulong_4095
-OpStore %590 %1063
-%1064 = OpLoad %ulong %590
-%1065 = OpConvertUToF %float %1064
-OpStore %591 %1065
-%1066 = OpLoad %float %591
-%1067 = OpFSub %float %1066 %float_2048
-OpStore %592 %1067
-%1068 = OpLoad %float %592
-%1069 = OpFDiv %float %1068 %float_8
-OpStore %593 %1069
-OpBranch %382
-%382 = OpLabel
-%1071 = OpLoad %float %569
-%1072 = OpLoad %float %577
-%1073 = OpLoad %float %585
-%1074 = OpLoad %float %593
-%1070 = OpCompositeConstruct %v4float %1071 %1072 %1073 %1074
-OpStore %436 %1070
-%1075 = OpAccessChain %_ptr_Function_ulong %419 %uint_23
-%1076 = OpLoad %ulong %1075
-OpStore %437 %1076
-OpBranch %385
-%385 = OpLabel
-%1077 = OpLoad %ulong %437
-%1078 = OpBitwiseAnd %ulong %1077 %ulong_4095
-OpStore %598 %1078
-%1079 = OpLoad %ulong %598
-%1080 = OpConvertUToF %float %1079
-OpStore %599 %1080
-%1081 = OpLoad %float %599
-%1082 = OpFSub %float %1081 %float_2048
-OpStore %600 %1082
-%1083 = OpLoad %float %600
-%1084 = OpFDiv %float %1083 %float_8
-OpStore %601 %1084
-OpBranch %386
-%386 = OpLabel
-%1085 = OpAccessChain %_ptr_Function_ulong %419 %uint_0
-%1086 = OpLoad %ulong %1085
-OpStore %438 %1086
-%1087 = OpLoad %ulong %438
-%1088 = OpLoad %ulong %427
-%1089 = OpIAdd %ulong %1087 %1088
-OpStore %439 %1089
-%1090 = OpLoad %ulong %439
-%1091 = OpFunctionCall %float %2 %1090
-OpStore %440 %1091
-%1093 = OpLoad %float %601
-%1094 = OpLoad %float %440
-%1092 = OpCompositeConstruct %v2float %1093 %1094
-OpStore %441 %1092
-%1095 = OpLoad %ulong %1085
-OpStore %442 %1095
-%1096 = OpLoad %ulong %442
-%1097 = OpLoad %ulong %427
-%1098 = OpIAdd %ulong %1096 %1097
-OpStore %443 %1098
-%1099 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
-%1100 = OpLoad %ulong %1099
-OpStore %444 %1100
-%1101 = OpLoad %ulong %444
-%1102 = OpFunctionCall %float %2 %1101
-OpStore %445 %1102
-%1103 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
-%1104 = OpLoad %ulong %1103
-OpStore %446 %1104
-%1105 = OpLoad %ulong %446
-%1106 = OpUConvert %uint %1105
-OpStore %447 %1106
-%1107 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
-%1108 = OpLoad %ulong %1107
-OpStore %448 %1108
-OpBranch %389
-%389 = OpLabel
-%1109 = OpLoad %ulong %448
-%1110 = OpBitwiseAnd %ulong %1109 %ulong_1048575
-OpStore %606 %1110
-%1111 = OpLoad %ulong %606
-%1112 = OpConvertUToF %double %1111
-OpStore %607 %1112
-%1113 = OpLoad %double %607
-%1114 = OpFSub %double %1113 %double_524288
-OpStore %608 %1114
-%1115 = OpLoad %double %608
-%1116 = OpFDiv %double %1115 %double_64
-OpStore %609 %1116
-OpBranch %390
-%390 = OpLabel
-%1117 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
-%1118 = OpLoad %ulong %1117
-OpStore %449 %1118
-%1119 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
-%1120 = OpLoad %ulong %1119
-OpStore %450 %1120
-%1121 = OpLoad %ulong %450
-%1122 = OpFunctionCall %float %2 %1121
-OpStore %451 %1122
-%1123 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
-%1124 = OpLoad %ulong %1123
-OpStore %452 %1124
-%1125 = OpLoad %ulong %452
-%1126 = OpUConvert %ushort %1125
-OpStore %453 %1126
-%1127 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
-%1128 = OpLoad %ulong %1127
-OpStore %454 %1128
-OpBranch %393
-%393 = OpLabel
-%1129 = OpLoad %ulong %454
-%1130 = OpBitwiseAnd %ulong %1129 %ulong_1048575
-OpStore %614 %1130
-%1131 = OpLoad %ulong %614
-%1132 = OpConvertUToF %double %1131
-OpStore %615 %1132
-%1133 = OpLoad %double %615
-%1134 = OpFSub %double %1133 %double_524288
-OpStore %616 %1134
-%1135 = OpLoad %double %616
-%1136 = OpFDiv %double %1135 %double_64
-OpStore %617 %1136
-OpBranch %394
-%394 = OpLabel
-%1137 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
-%1138 = OpLoad %ulong %1137
-OpStore %455 %1138
-%1139 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
-%1140 = OpLoad %ulong %1139
-OpStore %456 %1140
-%1141 = OpLoad %ulong %456
-%1142 = OpFunctionCall %float %2 %1141
-OpStore %457 %1142
-%1143 = OpAccessChain %_ptr_Function_ulong %419 %uint_10
-%1144 = OpLoad %ulong %1143
-OpStore %458 %1144
-%1145 = OpLoad %ulong %458
-%1146 = OpUConvert %uchar %1145
-OpStore %459 %1146
-%1147 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
-%1148 = OpLoad %ulong %1147
-OpStore %460 %1148
-OpBranch %397
-%397 = OpLabel
-%1149 = OpLoad %ulong %460
-%1150 = OpBitwiseAnd %ulong %1149 %ulong_1048575
-OpStore %622 %1150
-%1151 = OpLoad %ulong %622
-%1152 = OpConvertUToF %double %1151
-OpStore %623 %1152
-%1153 = OpLoad %double %623
-%1154 = OpFSub %double %1153 %double_524288
-OpStore %624 %1154
-%1155 = OpLoad %double %624
-%1156 = OpFDiv %double %1155 %double_64
-OpStore %625 %1156
-OpBranch %398
-%398 = OpLabel
-%1157 = OpAccessChain %_ptr_Function_ulong %419 %uint_12
-%1158 = OpLoad %ulong %1157
-OpStore %461 %1158
-%1159 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
-%1160 = OpLoad %ulong %1159
-OpStore %462 %1160
-%1161 = OpLoad %ulong %462
-%1162 = OpFunctionCall %float %2 %1161
-OpStore %463 %1162
-%1163 = OpAccessChain %_ptr_Function_ulong %419 %uint_14
-%1164 = OpLoad %ulong %1163
-OpStore %464 %1164
-%1165 = OpLoad %ulong %464
-%1166 = OpUConvert %uint %1165
-OpStore %465 %1166
-%1167 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
-%1168 = OpLoad %ulong %1167
-OpStore %466 %1168
-OpBranch %401
-%401 = OpLabel
-%1169 = OpLoad %ulong %466
-%1170 = OpBitwiseAnd %ulong %1169 %ulong_1048575
-OpStore %630 %1170
-%1171 = OpLoad %ulong %630
-%1172 = OpConvertUToF %double %1171
-OpStore %631 %1172
-%1173 = OpLoad %double %631
-%1174 = OpFSub %double %1173 %double_524288
-OpStore %632 %1174
-%1175 = OpLoad %double %632
-%1176 = OpFDiv %double %1175 %double_64
-OpStore %633 %1176
-OpBranch %402
-%402 = OpLabel
-%1177 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
-%1178 = OpLoad %ulong %1177
-OpStore %467 %1178
-%1179 = OpLoad %ulong %467
-%1180 = OpLoad %ulong %427
-%1181 = OpIAdd %ulong %1179 %1180
-OpStore %468 %1181
-%1182 = OpLoad %ulong %443
-%1183 = OpLoad %float %445
-%1184 = OpLoad %uint %447
-%1185 = OpLoad %double %609
-%1186 = OpLoad %v3float %431
-%1187 = OpLoad %ulong %449
-%1188 = OpLoad %float %451
-%1189 = OpLoad %ushort %453
-%1190 = OpLoad %v4float %436
-%1191 = OpLoad %double %617
-%1192 = OpLoad %ulong %455
-%1193 = OpLoad %float %457
-%1194 = OpLoad %uchar %459
-%1195 = OpLoad %double %625
-%1196 = OpLoad %v2float %441
-%1197 = OpLoad %ulong %461
-%1198 = OpLoad %float %463
-%1199 = OpLoad %uint %465
-%1200 = OpLoad %double %633
-%1201 = OpLoad %ulong %468
-%1202 = OpFunctionCall %ulong %4 %1182 %1183 %1184 %1185 %1186 %1187 %1188 %1189 %1190 %1191 %1192 %1193 %1194 %1195 %1196 %1197 %1198 %1199 %1200 %1201
-OpStore %469 %1202
-%1203 = OpLoad %ulong %535
-%1204 = OpLoad %ulong %469
-%1205 = OpFunctionCall %ulong %7 %1203 %1204
-OpStore %470 %1205
-%1206 = OpLoad %ulong %538
-%1208 = OpIAdd %ulong %1206 %ulong_1
-OpStore %471 %1208
-%1209 = OpLoad %ulong %470
-OpStore %535 %1209
-%1210 = OpLoad %ulong %469
-OpStore %537 %1210
-%1211 = OpLoad %ulong %471
-OpStore %538 %1211
-OpBranch %413
-%350 = OpLabel
-OpBranch %355
-%355 = OpLabel
-%1212 = OpLoad %ulong %536
-%1213 = OpIMul %ulong %1212 %ulong_6364136223846793005
-OpStore %539 %1213
-%1214 = OpLoad %ulong %539
-%1215 = OpIAdd %ulong %1214 %ulong_1442695040888963407
-OpStore %540 %1215
-%1216 = OpLoad %ulong %540
-%1217 = OpLoad %ulong %420
-%1218 = OpIAdd %ulong %1216 %1217
-OpStore %541 %1218
-OpBranch %356
-%356 = OpLabel
-%1219 = OpLoad %ulong %536
-%1220 = OpAccessChain %_ptr_Function_ulong %419 %1219
-%1221 = OpLoad %ulong %541
-OpStore %1220 %1221
-%1222 = OpLoad %ulong %536
-%1223 = OpIAdd %ulong %1222 %ulong_1
-OpStore %424 %1223
-%1224 = OpLoad %ulong %424
-OpStore %536 %1224
-OpBranch %414
-%413 = OpLabel
-OpBranch %352
-%414 = OpLabel
-OpBranch %349
+OpStore %252 %80
+OpStore %253 %81
+OpStore %255 %82
+OpStore %256 %83
+OpStore %258 %84
+OpStore %259 %85
+OpStore %260 %86
+OpStore %262 %87
+OpStore %264 %88
+OpStore %265 %89
+OpStore %266 %90
+OpStore %267 %91
+OpStore %269 %92
+OpStore %270 %93
+OpStore %272 %94
+OpStore %273 %95
+OpStore %274 %96
+OpStore %275 %97
+OpStore %276 %98
+OpStore %277 %99
+OpBranch %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpStore %316 %ulong_14695981039346656037
+OpStore %317 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%508 = OpLoad %ulong %317
+%510 = OpULessThan %bool %508 %ulong_8
+OpStore %309 %510
+%511 = OpLoad %bool %309
+OpLoopMerge %106 %250 None
+OpBranchConditional %511 %105 %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+OpBranch %108
+%108 = OpLabel
+%512 = OpLoad %float %253
+%513 = OpBitcast %uint %512
+OpStore %318 %513
+%514 = OpLoad %uint %318
+%515 = OpUConvert %ulong %514
+OpStore %319 %515
+OpBranch %110
+%110 = OpLabel
+%516 = OpLoad %ulong %316
+OpStore %327 %516
+OpStore %328 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%517 = OpLoad %ulong %328
+%518 = OpULessThan %bool %517 %ulong_8
+OpStore %320 %518
+%519 = OpLoad %bool %320
+OpLoopMerge %113 %249 None
+OpBranchConditional %519 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %115
+%115 = OpLabel
+%520 = OpLoad %uint %255
+%521 = OpUConvert %ulong %520
+OpStore %329 %521
+OpBranch %117
+%117 = OpLabel
+%522 = OpLoad %ulong %327
+OpStore %337 %522
+OpStore %338 %ulong_0
+OpBranch %118
+%118 = OpLabel
+%523 = OpLoad %ulong %338
+%524 = OpULessThan %bool %523 %ulong_8
+OpStore %330 %524
+%525 = OpLoad %bool %330
+OpLoopMerge %120 %248 None
+OpBranchConditional %525 %119 %120
+%120 = OpLabel
+OpBranch %121
+%121 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %122
+%122 = OpLabel
+%526 = OpLoad %double %256
+%527 = OpBitcast %ulong %526
+OpStore %339 %527
+OpBranch %124
+%124 = OpLabel
+%528 = OpLoad %ulong %337
+OpStore %347 %528
+OpStore %348 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%529 = OpLoad %ulong %348
+%530 = OpULessThan %bool %529 %ulong_8
+OpStore %340 %530
+%531 = OpLoad %bool %340
+OpLoopMerge %127 %247 None
+OpBranchConditional %531 %126 %127
+%127 = OpLabel
+OpBranch %128
+%128 = OpLabel
+OpBranch %123
+%123 = OpLabel
+%532 = OpLoad %v3float %258
+%533 = OpCompositeExtract %float %532 0
+OpStore %278 %533
+OpBranch %129
+%129 = OpLabel
+%534 = OpLoad %float %278
+%535 = OpBitcast %uint %534
+OpStore %349 %535
+%536 = OpLoad %uint %349
+%537 = OpUConvert %ulong %536
+OpStore %350 %537
+OpBranch %131
+%131 = OpLabel
+%538 = OpLoad %ulong %347
+OpStore %358 %538
+OpStore %359 %ulong_0
+OpBranch %132
+%132 = OpLabel
+%539 = OpLoad %ulong %359
+%540 = OpULessThan %bool %539 %ulong_8
+OpStore %351 %540
+%541 = OpLoad %bool %351
+OpLoopMerge %134 %246 None
+OpBranchConditional %541 %133 %134
+%134 = OpLabel
+OpBranch %135
+%135 = OpLabel
+OpBranch %130
+%130 = OpLabel
+%542 = OpLoad %v3float %258
+%543 = OpCompositeExtract %float %542 1
+OpStore %279 %543
+OpBranch %136
+%136 = OpLabel
+%544 = OpLoad %float %279
+%545 = OpBitcast %uint %544
+OpStore %360 %545
+%546 = OpLoad %uint %360
+%547 = OpUConvert %ulong %546
+OpStore %361 %547
+OpBranch %138
+%138 = OpLabel
+%548 = OpLoad %ulong %358
+OpStore %369 %548
+OpStore %370 %ulong_0
+OpBranch %139
+%139 = OpLabel
+%549 = OpLoad %ulong %370
+%550 = OpULessThan %bool %549 %ulong_8
+OpStore %362 %550
+%551 = OpLoad %bool %362
+OpLoopMerge %141 %245 None
+OpBranchConditional %551 %140 %141
+%141 = OpLabel
+OpBranch %142
+%142 = OpLabel
+OpBranch %137
+%137 = OpLabel
+%552 = OpLoad %v3float %258
+%553 = OpCompositeExtract %float %552 2
+OpStore %280 %553
+OpBranch %143
+%143 = OpLabel
+%554 = OpLoad %float %280
+%555 = OpBitcast %uint %554
+OpStore %371 %555
+%556 = OpLoad %uint %371
+%557 = OpUConvert %ulong %556
+OpStore %372 %557
+OpBranch %145
+%145 = OpLabel
+%558 = OpLoad %ulong %369
+OpStore %380 %558
+OpStore %381 %ulong_0
+OpBranch %146
+%146 = OpLabel
+%559 = OpLoad %ulong %381
+%560 = OpULessThan %bool %559 %ulong_8
+OpStore %373 %560
+%561 = OpLoad %bool %373
+OpLoopMerge %148 %244 None
+OpBranchConditional %561 %147 %148
+%148 = OpLabel
+OpBranch %149
+%149 = OpLabel
+OpBranch %144
+%144 = OpLabel
+OpBranch %150
+%150 = OpLabel
+OpBranch %152
+%152 = OpLabel
+%562 = OpLoad %ulong %380
+OpStore %389 %562
+OpStore %390 %ulong_0
+OpBranch %153
+%153 = OpLabel
+%563 = OpLoad %ulong %390
+%564 = OpULessThan %bool %563 %ulong_8
+OpStore %382 %564
+%565 = OpLoad %bool %382
+OpLoopMerge %155 %243 None
+OpBranchConditional %565 %154 %155
+%155 = OpLabel
+OpBranch %156
+%156 = OpLabel
+OpBranch %151
+%151 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%566 = OpLoad %float %260
+%567 = OpBitcast %uint %566
+OpStore %391 %567
+%568 = OpLoad %uint %391
+%569 = OpUConvert %ulong %568
+OpStore %392 %569
+OpBranch %159
+%159 = OpLabel
+%570 = OpLoad %ulong %389
+OpStore %400 %570
+OpStore %401 %ulong_0
+OpBranch %160
+%160 = OpLabel
+%571 = OpLoad %ulong %401
+%572 = OpULessThan %bool %571 %ulong_8
+OpStore %393 %572
+%573 = OpLoad %bool %393
+OpLoopMerge %162 %242 None
+OpBranchConditional %573 %161 %162
+%162 = OpLabel
+OpBranch %163
+%163 = OpLabel
+OpBranch %158
+%158 = OpLabel
+OpBranch %164
+%164 = OpLabel
+%574 = OpLoad %ushort %262
+%575 = OpUConvert %ulong %574
+OpStore %402 %575
+OpBranch %166
+%166 = OpLabel
+%576 = OpLoad %ulong %400
+OpStore %410 %576
+OpStore %411 %ulong_0
+OpBranch %167
+%167 = OpLabel
+%577 = OpLoad %ulong %411
+%578 = OpULessThan %bool %577 %ulong_8
+OpStore %403 %578
+%579 = OpLoad %bool %403
+OpLoopMerge %169 %241 None
+OpBranchConditional %579 %168 %169
+%169 = OpLabel
+OpBranch %170
+%170 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%580 = OpLoad %v4float %264
+%581 = OpCompositeExtract %float %580 0
+OpStore %281 %581
+OpBranch %171
+%171 = OpLabel
+%582 = OpLoad %float %281
+%583 = OpBitcast %uint %582
+OpStore %412 %583
+%584 = OpLoad %uint %412
+%585 = OpUConvert %ulong %584
+OpStore %413 %585
+OpBranch %173
+%173 = OpLabel
+%586 = OpLoad %ulong %410
+OpStore %421 %586
+OpStore %422 %ulong_0
+OpBranch %174
+%174 = OpLabel
+%587 = OpLoad %ulong %422
+%588 = OpULessThan %bool %587 %ulong_8
+OpStore %414 %588
+%589 = OpLoad %bool %414
+OpLoopMerge %176 %240 None
+OpBranchConditional %589 %175 %176
+%176 = OpLabel
+OpBranch %177
+%177 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%590 = OpLoad %v4float %264
+%591 = OpCompositeExtract %float %590 1
+OpStore %282 %591
+OpBranch %178
+%178 = OpLabel
+%592 = OpLoad %float %282
+%593 = OpBitcast %uint %592
+OpStore %423 %593
+%594 = OpLoad %uint %423
+%595 = OpUConvert %ulong %594
+OpStore %424 %595
+OpBranch %180
+%180 = OpLabel
+%596 = OpLoad %ulong %421
+OpStore %432 %596
+OpStore %433 %ulong_0
+OpBranch %181
+%181 = OpLabel
+%597 = OpLoad %ulong %433
+%598 = OpULessThan %bool %597 %ulong_8
+OpStore %425 %598
+%599 = OpLoad %bool %425
+OpLoopMerge %183 %239 None
+OpBranchConditional %599 %182 %183
+%183 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %179
+%179 = OpLabel
+%600 = OpLoad %v4float %264
+%601 = OpCompositeExtract %float %600 2
+OpStore %283 %601
+OpBranch %185
+%185 = OpLabel
+%602 = OpLoad %float %283
+%603 = OpBitcast %uint %602
+OpStore %434 %603
+%604 = OpLoad %uint %434
+%605 = OpUConvert %ulong %604
+OpStore %435 %605
+OpBranch %187
+%187 = OpLabel
+%606 = OpLoad %ulong %432
+OpStore %443 %606
+OpStore %444 %ulong_0
+OpBranch %188
+%188 = OpLabel
+%607 = OpLoad %ulong %444
+%608 = OpULessThan %bool %607 %ulong_8
+OpStore %436 %608
+%609 = OpLoad %bool %436
+OpLoopMerge %190 %238 None
+OpBranchConditional %609 %189 %190
+%190 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %186
+%186 = OpLabel
+%610 = OpLoad %v4float %264
+%611 = OpCompositeExtract %float %610 3
+OpStore %284 %611
+OpBranch %192
+%192 = OpLabel
+%612 = OpLoad %float %284
+%613 = OpBitcast %uint %612
+OpStore %445 %613
+%614 = OpLoad %uint %445
+%615 = OpUConvert %ulong %614
+OpStore %446 %615
+OpBranch %194
+%194 = OpLabel
+%616 = OpLoad %ulong %443
+OpStore %454 %616
+OpStore %455 %ulong_0
+OpBranch %195
+%195 = OpLabel
+%617 = OpLoad %ulong %455
+%618 = OpULessThan %bool %617 %ulong_8
+OpStore %447 %618
+%619 = OpLoad %bool %447
+OpLoopMerge %197 %237 None
+OpBranchConditional %619 %196 %197
+%197 = OpLabel
+OpBranch %198
+%198 = OpLabel
+OpBranch %193
+%193 = OpLabel
+OpBranch %199
+%199 = OpLabel
+%620 = OpLoad %double %265
+%621 = OpBitcast %ulong %620
+OpStore %456 %621
+OpBranch %201
+%201 = OpLabel
+%622 = OpLoad %ulong %454
+OpStore %464 %622
+OpStore %465 %ulong_0
+OpBranch %202
+%202 = OpLabel
+%623 = OpLoad %ulong %465
+%624 = OpULessThan %bool %623 %ulong_8
+OpStore %457 %624
+%625 = OpLoad %bool %457
+OpLoopMerge %204 %236 None
+OpBranchConditional %625 %203 %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+OpBranch %200
+%200 = OpLabel
+OpBranch %206
+%206 = OpLabel
+%626 = OpLoad %ulong %464
+OpStore %473 %626
+OpStore %474 %ulong_0
+OpBranch %207
+%207 = OpLabel
+%627 = OpLoad %ulong %474
+%628 = OpULessThan %bool %627 %ulong_8
+OpStore %466 %628
+%629 = OpLoad %bool %466
+OpLoopMerge %209 %235 None
+OpBranchConditional %629 %208 %209
+%209 = OpLabel
+OpBranch %210
+%210 = OpLabel
+OpBranch %211
+%211 = OpLabel
+%630 = OpLoad %float %267
+%631 = OpBitcast %uint %630
+OpStore %475 %631
+%632 = OpLoad %uint %475
+%633 = OpUConvert %ulong %632
+OpStore %476 %633
+%634 = OpLoad %ulong %473
+%635 = OpLoad %ulong %476
+%636 = OpFunctionCall %ulong %6 %634 %635
+OpStore %477 %636
+OpBranch %212
+%212 = OpLabel
+OpBranch %213
+%213 = OpLabel
+%637 = OpLoad %uchar %269
+%638 = OpUConvert %ulong %637
+OpStore %478 %638
+%639 = OpLoad %ulong %477
+%640 = OpLoad %ulong %478
+%641 = OpFunctionCall %ulong %6 %639 %640
+OpStore %479 %641
+OpBranch %214
+%214 = OpLabel
+OpBranch %215
+%215 = OpLabel
+%642 = OpLoad %double %270
+%643 = OpBitcast %ulong %642
+OpStore %480 %643
+%644 = OpLoad %ulong %479
+%645 = OpLoad %ulong %480
+%646 = OpFunctionCall %ulong %6 %644 %645
+OpStore %481 %646
+OpBranch %216
+%216 = OpLabel
+%647 = OpLoad %v2float %272
+%648 = OpCompositeExtract %float %647 0
+OpStore %285 %648
+OpBranch %217
+%217 = OpLabel
+%649 = OpLoad %float %285
+%650 = OpBitcast %uint %649
+OpStore %482 %650
+%651 = OpLoad %uint %482
+%652 = OpUConvert %ulong %651
+OpStore %483 %652
+%653 = OpLoad %ulong %481
+%654 = OpLoad %ulong %483
+%655 = OpFunctionCall %ulong %6 %653 %654
+OpStore %484 %655
+OpBranch %218
+%218 = OpLabel
+%656 = OpLoad %v2float %272
+%657 = OpCompositeExtract %float %656 1
+OpStore %286 %657
+OpBranch %219
+%219 = OpLabel
+%658 = OpLoad %float %286
+%659 = OpBitcast %uint %658
+OpStore %485 %659
+%660 = OpLoad %uint %485
+%661 = OpUConvert %ulong %660
+OpStore %486 %661
+%662 = OpLoad %ulong %484
+%663 = OpLoad %ulong %486
+%664 = OpFunctionCall %ulong %6 %662 %663
+OpStore %487 %664
+OpBranch %220
+%220 = OpLabel
+%665 = OpLoad %ulong %487
+%666 = OpLoad %ulong %273
+%667 = OpFunctionCall %ulong %6 %665 %666
+OpStore %287 %667
+OpBranch %221
+%221 = OpLabel
+%668 = OpLoad %float %274
+%669 = OpBitcast %uint %668
+OpStore %488 %669
+%670 = OpLoad %uint %488
+%671 = OpUConvert %ulong %670
+OpStore %489 %671
+%672 = OpLoad %ulong %287
+%673 = OpLoad %ulong %489
+%674 = OpFunctionCall %ulong %6 %672 %673
+OpStore %490 %674
+OpBranch %222
+%222 = OpLabel
+OpBranch %223
+%223 = OpLabel
+%675 = OpLoad %uint %275
+%676 = OpSConvert %ulong %675
+OpStore %491 %676
+%677 = OpLoad %ulong %490
+%678 = OpLoad %ulong %491
+%679 = OpFunctionCall %ulong %6 %677 %678
+OpStore %492 %679
+OpBranch %224
+%224 = OpLabel
+OpBranch %225
+%225 = OpLabel
+%680 = OpLoad %double %276
+%681 = OpBitcast %ulong %680
+OpStore %493 %681
+%682 = OpLoad %ulong %492
+%683 = OpLoad %ulong %493
+%684 = OpFunctionCall %ulong %6 %682 %683
+OpStore %494 %684
+OpBranch %226
+%226 = OpLabel
+%685 = OpLoad %ulong %494
+%686 = OpLoad %ulong %277
+%687 = OpFunctionCall %ulong %6 %685 %686
+OpStore %288 %687
+%688 = OpLoad %ulong %266
+%689 = OpLoad %ulong %273
+%690 = OpIMul %ulong %688 %689
+OpStore %289 %690
+%691 = OpLoad %ulong %252
+%692 = OpLoad %ulong %289
+%693 = OpIAdd %ulong %691 %692
+OpStore %290 %693
+%694 = OpLoad %ulong %290
+%695 = OpLoad %ulong %277
+%696 = OpISub %ulong %694 %695
+OpStore %291 %696
+%697 = OpLoad %ulong %288
+%698 = OpLoad %ulong %291
+%699 = OpFunctionCall %ulong %6 %697 %698
+OpStore %292 %699
+%700 = OpLoad %float %260
+%701 = OpLoad %float %267
+%702 = OpFMul %float %700 %701
+OpStore %293 %702
+%703 = OpLoad %float %253
+%704 = OpLoad %float %293
+%705 = OpFAdd %float %703 %704
+OpStore %294 %705
+%706 = OpLoad %float %294
+%707 = OpLoad %float %274
+%708 = OpFSub %float %706 %707
+OpStore %295 %708
+OpBranch %227
+%227 = OpLabel
+%709 = OpLoad %float %295
+%710 = OpBitcast %uint %709
+OpStore %495 %710
+%711 = OpLoad %uint %495
+%712 = OpUConvert %ulong %711
+OpStore %496 %712
+%713 = OpLoad %ulong %292
+%714 = OpLoad %ulong %496
+%715 = OpFunctionCall %ulong %6 %713 %714
+OpStore %497 %715
+OpBranch %228
+%228 = OpLabel
+%716 = OpLoad %double %265
+%717 = OpLoad %double %270
+%718 = OpFMul %double %716 %717
+OpStore %296 %718
+%719 = OpLoad %double %256
+%720 = OpLoad %double %296
+%721 = OpFAdd %double %719 %720
+OpStore %297 %721
+%722 = OpLoad %double %297
+%723 = OpLoad %double %276
+%724 = OpFSub %double %722 %723
+OpStore %298 %724
+OpBranch %229
+%229 = OpLabel
+%725 = OpLoad %double %298
+%726 = OpBitcast %ulong %725
+OpStore %498 %726
+%727 = OpLoad %ulong %497
+%728 = OpLoad %ulong %498
+%729 = OpFunctionCall %ulong %6 %727 %728
+OpStore %499 %729
+OpBranch %230
+%230 = OpLabel
+%730 = OpLoad %v4float %264
+%731 = OpCompositeExtract %float %730 0
+OpStore %299 %731
+%732 = OpLoad %v4float %264
+%733 = OpCompositeExtract %float %732 1
+OpStore %300 %733
+%734 = OpLoad %v2float %272
+%735 = OpCompositeExtract %float %734 0
+OpStore %301 %735
+%737 = OpLoad %float %299
+%738 = OpLoad %float %300
+%739 = OpLoad %float %301
+%736 = OpCompositeConstruct %v3float %737 %738 %739
+OpStore %302 %736
+%740 = OpLoad %v3float %258
+%741 = OpLoad %v3float %302
+%742 = OpFAdd %v3float %740 %741
+OpStore %303 %742
+%743 = OpLoad %v3float %303
+%744 = OpCompositeExtract %float %743 0
+OpStore %304 %744
+OpBranch %231
+%231 = OpLabel
+%745 = OpLoad %float %304
+%746 = OpBitcast %uint %745
+OpStore %500 %746
+%747 = OpLoad %uint %500
+%748 = OpUConvert %ulong %747
+OpStore %501 %748
+%749 = OpLoad %ulong %499
+%750 = OpLoad %ulong %501
+%751 = OpFunctionCall %ulong %6 %749 %750
+OpStore %502 %751
+OpBranch %232
+%232 = OpLabel
+%752 = OpLoad %v3float %303
+%753 = OpCompositeExtract %float %752 1
+OpStore %305 %753
+OpBranch %233
+%233 = OpLabel
+%754 = OpLoad %float %305
+%755 = OpBitcast %uint %754
+OpStore %503 %755
+%756 = OpLoad %uint %503
+%757 = OpUConvert %ulong %756
+OpStore %504 %757
+%758 = OpLoad %ulong %502
+%759 = OpLoad %ulong %504
+%760 = OpFunctionCall %ulong %6 %758 %759
+OpStore %505 %760
+OpBranch %234
+%234 = OpLabel
+%761 = OpLoad %v3float %303
+%762 = OpCompositeExtract %float %761 2
+OpStore %306 %762
+%763 = OpLoad %ulong %505
+%764 = OpLoad %float %306
+%765 = OpFunctionCall %ulong %7 %763 %764
+OpStore %307 %765
+%766 = OpLoad %ulong %307
+OpReturnValue %766
+%208 = OpLabel
+%767 = OpLoad %ulong %474
+%768 = OpIMul %ulong %767 %ulong_8
+OpStore %467 %768
+%769 = OpLoad %ulong %266
+%770 = OpLoad %ulong %467
+%771 = OpShiftRightLogical %ulong %769 %770
+OpStore %468 %771
+%772 = OpLoad %ulong %468
+%774 = OpBitwiseAnd %ulong %772 %ulong_255
+OpStore %469 %774
+%775 = OpLoad %ulong %473
+%776 = OpLoad %ulong %469
+%777 = OpBitwiseXor %ulong %775 %776
+OpStore %470 %777
+%778 = OpLoad %ulong %470
+%780 = OpIMul %ulong %778 %ulong_1099511628211
+OpStore %471 %780
+%781 = OpLoad %ulong %474
+%783 = OpIAdd %ulong %781 %ulong_1
+OpStore %472 %783
+%784 = OpLoad %ulong %471
+OpStore %473 %784
+%785 = OpLoad %ulong %472
+OpStore %474 %785
+OpBranch %235
+%203 = OpLabel
+%786 = OpLoad %ulong %465
+%787 = OpIMul %ulong %786 %ulong_8
+OpStore %458 %787
+%788 = OpLoad %ulong %456
+%789 = OpLoad %ulong %458
+%790 = OpShiftRightLogical %ulong %788 %789
+OpStore %459 %790
+%791 = OpLoad %ulong %459
+%792 = OpBitwiseAnd %ulong %791 %ulong_255
+OpStore %460 %792
+%793 = OpLoad %ulong %464
+%794 = OpLoad %ulong %460
+%795 = OpBitwiseXor %ulong %793 %794
+OpStore %461 %795
+%796 = OpLoad %ulong %461
+%797 = OpIMul %ulong %796 %ulong_1099511628211
+OpStore %462 %797
+%798 = OpLoad %ulong %465
+%799 = OpIAdd %ulong %798 %ulong_1
+OpStore %463 %799
+%800 = OpLoad %ulong %462
+OpStore %464 %800
+%801 = OpLoad %ulong %463
+OpStore %465 %801
+OpBranch %236
+%196 = OpLabel
+%802 = OpLoad %ulong %455
+%803 = OpIMul %ulong %802 %ulong_8
+OpStore %448 %803
+%804 = OpLoad %ulong %446
+%805 = OpLoad %ulong %448
+%806 = OpShiftRightLogical %ulong %804 %805
+OpStore %449 %806
+%807 = OpLoad %ulong %449
+%808 = OpBitwiseAnd %ulong %807 %ulong_255
+OpStore %450 %808
+%809 = OpLoad %ulong %454
+%810 = OpLoad %ulong %450
+%811 = OpBitwiseXor %ulong %809 %810
+OpStore %451 %811
+%812 = OpLoad %ulong %451
+%813 = OpIMul %ulong %812 %ulong_1099511628211
+OpStore %452 %813
+%814 = OpLoad %ulong %455
+%815 = OpIAdd %ulong %814 %ulong_1
+OpStore %453 %815
+%816 = OpLoad %ulong %452
+OpStore %454 %816
+%817 = OpLoad %ulong %453
+OpStore %455 %817
+OpBranch %237
+%189 = OpLabel
+%818 = OpLoad %ulong %444
+%819 = OpIMul %ulong %818 %ulong_8
+OpStore %437 %819
+%820 = OpLoad %ulong %435
+%821 = OpLoad %ulong %437
+%822 = OpShiftRightLogical %ulong %820 %821
+OpStore %438 %822
+%823 = OpLoad %ulong %438
+%824 = OpBitwiseAnd %ulong %823 %ulong_255
+OpStore %439 %824
+%825 = OpLoad %ulong %443
+%826 = OpLoad %ulong %439
+%827 = OpBitwiseXor %ulong %825 %826
+OpStore %440 %827
+%828 = OpLoad %ulong %440
+%829 = OpIMul %ulong %828 %ulong_1099511628211
+OpStore %441 %829
+%830 = OpLoad %ulong %444
+%831 = OpIAdd %ulong %830 %ulong_1
+OpStore %442 %831
+%832 = OpLoad %ulong %441
+OpStore %443 %832
+%833 = OpLoad %ulong %442
+OpStore %444 %833
+OpBranch %238
+%182 = OpLabel
+%834 = OpLoad %ulong %433
+%835 = OpIMul %ulong %834 %ulong_8
+OpStore %426 %835
+%836 = OpLoad %ulong %424
+%837 = OpLoad %ulong %426
+%838 = OpShiftRightLogical %ulong %836 %837
+OpStore %427 %838
+%839 = OpLoad %ulong %427
+%840 = OpBitwiseAnd %ulong %839 %ulong_255
+OpStore %428 %840
+%841 = OpLoad %ulong %432
+%842 = OpLoad %ulong %428
+%843 = OpBitwiseXor %ulong %841 %842
+OpStore %429 %843
+%844 = OpLoad %ulong %429
+%845 = OpIMul %ulong %844 %ulong_1099511628211
+OpStore %430 %845
+%846 = OpLoad %ulong %433
+%847 = OpIAdd %ulong %846 %ulong_1
+OpStore %431 %847
+%848 = OpLoad %ulong %430
+OpStore %432 %848
+%849 = OpLoad %ulong %431
+OpStore %433 %849
+OpBranch %239
+%175 = OpLabel
+%850 = OpLoad %ulong %422
+%851 = OpIMul %ulong %850 %ulong_8
+OpStore %415 %851
+%852 = OpLoad %ulong %413
+%853 = OpLoad %ulong %415
+%854 = OpShiftRightLogical %ulong %852 %853
+OpStore %416 %854
+%855 = OpLoad %ulong %416
+%856 = OpBitwiseAnd %ulong %855 %ulong_255
+OpStore %417 %856
+%857 = OpLoad %ulong %421
+%858 = OpLoad %ulong %417
+%859 = OpBitwiseXor %ulong %857 %858
+OpStore %418 %859
+%860 = OpLoad %ulong %418
+%861 = OpIMul %ulong %860 %ulong_1099511628211
+OpStore %419 %861
+%862 = OpLoad %ulong %422
+%863 = OpIAdd %ulong %862 %ulong_1
+OpStore %420 %863
+%864 = OpLoad %ulong %419
+OpStore %421 %864
+%865 = OpLoad %ulong %420
+OpStore %422 %865
+OpBranch %240
+%168 = OpLabel
+%866 = OpLoad %ulong %411
+%867 = OpIMul %ulong %866 %ulong_8
+OpStore %404 %867
+%868 = OpLoad %ulong %402
+%869 = OpLoad %ulong %404
+%870 = OpShiftRightLogical %ulong %868 %869
+OpStore %405 %870
+%871 = OpLoad %ulong %405
+%872 = OpBitwiseAnd %ulong %871 %ulong_255
+OpStore %406 %872
+%873 = OpLoad %ulong %410
+%874 = OpLoad %ulong %406
+%875 = OpBitwiseXor %ulong %873 %874
+OpStore %407 %875
+%876 = OpLoad %ulong %407
+%877 = OpIMul %ulong %876 %ulong_1099511628211
+OpStore %408 %877
+%878 = OpLoad %ulong %411
+%879 = OpIAdd %ulong %878 %ulong_1
+OpStore %409 %879
+%880 = OpLoad %ulong %408
+OpStore %410 %880
+%881 = OpLoad %ulong %409
+OpStore %411 %881
+OpBranch %241
+%161 = OpLabel
+%882 = OpLoad %ulong %401
+%883 = OpIMul %ulong %882 %ulong_8
+OpStore %394 %883
+%884 = OpLoad %ulong %392
+%885 = OpLoad %ulong %394
+%886 = OpShiftRightLogical %ulong %884 %885
+OpStore %395 %886
+%887 = OpLoad %ulong %395
+%888 = OpBitwiseAnd %ulong %887 %ulong_255
+OpStore %396 %888
+%889 = OpLoad %ulong %400
+%890 = OpLoad %ulong %396
+%891 = OpBitwiseXor %ulong %889 %890
+OpStore %397 %891
+%892 = OpLoad %ulong %397
+%893 = OpIMul %ulong %892 %ulong_1099511628211
+OpStore %398 %893
+%894 = OpLoad %ulong %401
+%895 = OpIAdd %ulong %894 %ulong_1
+OpStore %399 %895
+%896 = OpLoad %ulong %398
+OpStore %400 %896
+%897 = OpLoad %ulong %399
+OpStore %401 %897
+OpBranch %242
+%154 = OpLabel
+%898 = OpLoad %ulong %390
+%899 = OpIMul %ulong %898 %ulong_8
+OpStore %383 %899
+%900 = OpLoad %ulong %259
+%901 = OpLoad %ulong %383
+%902 = OpShiftRightLogical %ulong %900 %901
+OpStore %384 %902
+%903 = OpLoad %ulong %384
+%904 = OpBitwiseAnd %ulong %903 %ulong_255
+OpStore %385 %904
+%905 = OpLoad %ulong %389
+%906 = OpLoad %ulong %385
+%907 = OpBitwiseXor %ulong %905 %906
+OpStore %386 %907
+%908 = OpLoad %ulong %386
+%909 = OpIMul %ulong %908 %ulong_1099511628211
+OpStore %387 %909
+%910 = OpLoad %ulong %390
+%911 = OpIAdd %ulong %910 %ulong_1
+OpStore %388 %911
+%912 = OpLoad %ulong %387
+OpStore %389 %912
+%913 = OpLoad %ulong %388
+OpStore %390 %913
+OpBranch %243
+%147 = OpLabel
+%914 = OpLoad %ulong %381
+%915 = OpIMul %ulong %914 %ulong_8
+OpStore %374 %915
+%916 = OpLoad %ulong %372
+%917 = OpLoad %ulong %374
+%918 = OpShiftRightLogical %ulong %916 %917
+OpStore %375 %918
+%919 = OpLoad %ulong %375
+%920 = OpBitwiseAnd %ulong %919 %ulong_255
+OpStore %376 %920
+%921 = OpLoad %ulong %380
+%922 = OpLoad %ulong %376
+%923 = OpBitwiseXor %ulong %921 %922
+OpStore %377 %923
+%924 = OpLoad %ulong %377
+%925 = OpIMul %ulong %924 %ulong_1099511628211
+OpStore %378 %925
+%926 = OpLoad %ulong %381
+%927 = OpIAdd %ulong %926 %ulong_1
+OpStore %379 %927
+%928 = OpLoad %ulong %378
+OpStore %380 %928
+%929 = OpLoad %ulong %379
+OpStore %381 %929
+OpBranch %244
+%140 = OpLabel
+%930 = OpLoad %ulong %370
+%931 = OpIMul %ulong %930 %ulong_8
+OpStore %363 %931
+%932 = OpLoad %ulong %361
+%933 = OpLoad %ulong %363
+%934 = OpShiftRightLogical %ulong %932 %933
+OpStore %364 %934
+%935 = OpLoad %ulong %364
+%936 = OpBitwiseAnd %ulong %935 %ulong_255
+OpStore %365 %936
+%937 = OpLoad %ulong %369
+%938 = OpLoad %ulong %365
+%939 = OpBitwiseXor %ulong %937 %938
+OpStore %366 %939
+%940 = OpLoad %ulong %366
+%941 = OpIMul %ulong %940 %ulong_1099511628211
+OpStore %367 %941
+%942 = OpLoad %ulong %370
+%943 = OpIAdd %ulong %942 %ulong_1
+OpStore %368 %943
+%944 = OpLoad %ulong %367
+OpStore %369 %944
+%945 = OpLoad %ulong %368
+OpStore %370 %945
+OpBranch %245
+%133 = OpLabel
+%946 = OpLoad %ulong %359
+%947 = OpIMul %ulong %946 %ulong_8
+OpStore %352 %947
+%948 = OpLoad %ulong %350
+%949 = OpLoad %ulong %352
+%950 = OpShiftRightLogical %ulong %948 %949
+OpStore %353 %950
+%951 = OpLoad %ulong %353
+%952 = OpBitwiseAnd %ulong %951 %ulong_255
+OpStore %354 %952
+%953 = OpLoad %ulong %358
+%954 = OpLoad %ulong %354
+%955 = OpBitwiseXor %ulong %953 %954
+OpStore %355 %955
+%956 = OpLoad %ulong %355
+%957 = OpIMul %ulong %956 %ulong_1099511628211
+OpStore %356 %957
+%958 = OpLoad %ulong %359
+%959 = OpIAdd %ulong %958 %ulong_1
+OpStore %357 %959
+%960 = OpLoad %ulong %356
+OpStore %358 %960
+%961 = OpLoad %ulong %357
+OpStore %359 %961
+OpBranch %246
+%126 = OpLabel
+%962 = OpLoad %ulong %348
+%963 = OpIMul %ulong %962 %ulong_8
+OpStore %341 %963
+%964 = OpLoad %ulong %339
+%965 = OpLoad %ulong %341
+%966 = OpShiftRightLogical %ulong %964 %965
+OpStore %342 %966
+%967 = OpLoad %ulong %342
+%968 = OpBitwiseAnd %ulong %967 %ulong_255
+OpStore %343 %968
+%969 = OpLoad %ulong %347
+%970 = OpLoad %ulong %343
+%971 = OpBitwiseXor %ulong %969 %970
+OpStore %344 %971
+%972 = OpLoad %ulong %344
+%973 = OpIMul %ulong %972 %ulong_1099511628211
+OpStore %345 %973
+%974 = OpLoad %ulong %348
+%975 = OpIAdd %ulong %974 %ulong_1
+OpStore %346 %975
+%976 = OpLoad %ulong %345
+OpStore %347 %976
+%977 = OpLoad %ulong %346
+OpStore %348 %977
+OpBranch %247
+%119 = OpLabel
+%978 = OpLoad %ulong %338
+%979 = OpIMul %ulong %978 %ulong_8
+OpStore %331 %979
+%980 = OpLoad %ulong %329
+%981 = OpLoad %ulong %331
+%982 = OpShiftRightLogical %ulong %980 %981
+OpStore %332 %982
+%983 = OpLoad %ulong %332
+%984 = OpBitwiseAnd %ulong %983 %ulong_255
+OpStore %333 %984
+%985 = OpLoad %ulong %337
+%986 = OpLoad %ulong %333
+%987 = OpBitwiseXor %ulong %985 %986
+OpStore %334 %987
+%988 = OpLoad %ulong %334
+%989 = OpIMul %ulong %988 %ulong_1099511628211
+OpStore %335 %989
+%990 = OpLoad %ulong %338
+%991 = OpIAdd %ulong %990 %ulong_1
+OpStore %336 %991
+%992 = OpLoad %ulong %335
+OpStore %337 %992
+%993 = OpLoad %ulong %336
+OpStore %338 %993
+OpBranch %248
+%112 = OpLabel
+%994 = OpLoad %ulong %328
+%995 = OpIMul %ulong %994 %ulong_8
+OpStore %321 %995
+%996 = OpLoad %ulong %319
+%997 = OpLoad %ulong %321
+%998 = OpShiftRightLogical %ulong %996 %997
+OpStore %322 %998
+%999 = OpLoad %ulong %322
+%1000 = OpBitwiseAnd %ulong %999 %ulong_255
+OpStore %323 %1000
+%1001 = OpLoad %ulong %327
+%1002 = OpLoad %ulong %323
+%1003 = OpBitwiseXor %ulong %1001 %1002
+OpStore %324 %1003
+%1004 = OpLoad %ulong %324
+%1005 = OpIMul %ulong %1004 %ulong_1099511628211
+OpStore %325 %1005
+%1006 = OpLoad %ulong %328
+%1007 = OpIAdd %ulong %1006 %ulong_1
+OpStore %326 %1007
+%1008 = OpLoad %ulong %325
+OpStore %327 %1008
+%1009 = OpLoad %ulong %326
+OpStore %328 %1009
+OpBranch %249
+%105 = OpLabel
+%1010 = OpLoad %ulong %317
+%1011 = OpIMul %ulong %1010 %ulong_8
+OpStore %310 %1011
+%1012 = OpLoad %ulong %252
+%1013 = OpLoad %ulong %310
+%1014 = OpShiftRightLogical %ulong %1012 %1013
+OpStore %311 %1014
+%1015 = OpLoad %ulong %311
+%1016 = OpBitwiseAnd %ulong %1015 %ulong_255
+OpStore %312 %1016
+%1017 = OpLoad %ulong %316
+%1018 = OpLoad %ulong %312
+%1019 = OpBitwiseXor %ulong %1017 %1018
+OpStore %313 %1019
+%1020 = OpLoad %ulong %313
+%1021 = OpIMul %ulong %1020 %ulong_1099511628211
+OpStore %314 %1021
+%1022 = OpLoad %ulong %317
+%1023 = OpIAdd %ulong %1022 %ulong_1
+OpStore %315 %1023
+%1024 = OpLoad %ulong %314
+OpStore %316 %1024
+%1025 = OpLoad %ulong %315
+OpStore %317 %1025
+OpBranch %250
+%235 = OpLabel
+OpBranch %207
+%236 = OpLabel
+OpBranch %202
+%237 = OpLabel
+OpBranch %195
+%238 = OpLabel
+OpBranch %188
+%239 = OpLabel
+OpBranch %181
+%240 = OpLabel
+OpBranch %174
+%241 = OpLabel
+OpBranch %167
+%242 = OpLabel
+OpBranch %160
+%243 = OpLabel
+OpBranch %153
+%244 = OpLabel
+OpBranch %146
+%245 = OpLabel
+OpBranch %139
+%246 = OpLabel
+OpBranch %132
+%247 = OpLabel
+OpBranch %125
+%248 = OpLabel
+OpBranch %118
+%249 = OpLabel
+OpBranch %111
+%250 = OpLabel
+OpBranch %104
 OpFunctionEnd
-%6 = OpFunction %ulong None %1225
-%1226 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%7 = OpFunction %ulong None %16
-%1228 = OpFunctionParameter %ulong
-%1229 = OpFunctionParameter %ulong
-%1230 = OpLabel
-%1235 = OpVariable %_ptr_Function_ulong Function
-%1236 = OpVariable %_ptr_Function_ulong Function
-%1237 = OpVariable %_ptr_Function_bool Function
-%1238 = OpVariable %_ptr_Function_ulong Function
-%1239 = OpVariable %_ptr_Function_ulong Function
-%1240 = OpVariable %_ptr_Function_ulong Function
+%5 = OpFunction %ulong None %1026
+%1027 = OpFunctionParameter %ulong
+%1028 = OpLabel
+%1100 = OpVariable %_ptr_Function__arr_ulong_uint_24 Function
+%1101 = OpVariable %_ptr_Function_ulong Function
+%1102 = OpVariable %_ptr_Function_bool Function
+%1103 = OpVariable %_ptr_Function_ulong Function
+%1104 = OpVariable %_ptr_Function_bool Function
+%1105 = OpVariable %_ptr_Function_ulong Function
+%1106 = OpVariable %_ptr_Function_ulong Function
+%1107 = OpVariable %_ptr_Function_ulong Function
+%1108 = OpVariable %_ptr_Function_ulong Function
+%1109 = OpVariable %_ptr_Function_ulong Function
+%1110 = OpVariable %_ptr_Function_v3float Function
+%1111 = OpVariable %_ptr_Function_ulong Function
+%1112 = OpVariable %_ptr_Function_ulong Function
+%1113 = OpVariable %_ptr_Function_ulong Function
+%1114 = OpVariable %_ptr_Function_ulong Function
+%1115 = OpVariable %_ptr_Function_v4float Function
+%1116 = OpVariable %_ptr_Function_ulong Function
+%1117 = OpVariable %_ptr_Function_ulong Function
+%1118 = OpVariable %_ptr_Function_ulong Function
+%1119 = OpVariable %_ptr_Function_float Function
+%1120 = OpVariable %_ptr_Function_v2float Function
+%1121 = OpVariable %_ptr_Function_ulong Function
+%1122 = OpVariable %_ptr_Function_ulong Function
+%1123 = OpVariable %_ptr_Function_ulong Function
+%1124 = OpVariable %_ptr_Function_float Function
+%1125 = OpVariable %_ptr_Function_ulong Function
+%1126 = OpVariable %_ptr_Function_uint Function
+%1127 = OpVariable %_ptr_Function_ulong Function
+%1128 = OpVariable %_ptr_Function_ulong Function
+%1129 = OpVariable %_ptr_Function_ulong Function
+%1130 = OpVariable %_ptr_Function_float Function
+%1131 = OpVariable %_ptr_Function_ulong Function
+%1132 = OpVariable %_ptr_Function_ushort Function
+%1133 = OpVariable %_ptr_Function_ulong Function
+%1134 = OpVariable %_ptr_Function_ulong Function
+%1135 = OpVariable %_ptr_Function_ulong Function
+%1136 = OpVariable %_ptr_Function_float Function
+%1137 = OpVariable %_ptr_Function_ulong Function
+%1138 = OpVariable %_ptr_Function_uchar Function
+%1139 = OpVariable %_ptr_Function_ulong Function
+%1140 = OpVariable %_ptr_Function_ulong Function
+%1141 = OpVariable %_ptr_Function_ulong Function
+%1142 = OpVariable %_ptr_Function_float Function
+%1143 = OpVariable %_ptr_Function_ulong Function
+%1144 = OpVariable %_ptr_Function_uint Function
+%1145 = OpVariable %_ptr_Function_ulong Function
+%1146 = OpVariable %_ptr_Function_ulong Function
+%1147 = OpVariable %_ptr_Function_ulong Function
+%1148 = OpVariable %_ptr_Function_ulong Function
+%1149 = OpVariable %_ptr_Function_ulong Function
+%1150 = OpVariable %_ptr_Function_ulong Function
+%1151 = OpVariable %_ptr_Function_ulong Function
+%1152 = OpVariable %_ptr_Function_ulong Function
+%1153 = OpVariable %_ptr_Function_v3float Function
+%1154 = OpVariable %_ptr_Function_ulong Function
+%1155 = OpVariable %_ptr_Function_ulong Function
+%1156 = OpVariable %_ptr_Function_ulong Function
+%1157 = OpVariable %_ptr_Function_ulong Function
+%1158 = OpVariable %_ptr_Function_v4float Function
+%1159 = OpVariable %_ptr_Function_ulong Function
+%1160 = OpVariable %_ptr_Function_ulong Function
+%1161 = OpVariable %_ptr_Function_float Function
+%1162 = OpVariable %_ptr_Function_v2float Function
+%1163 = OpVariable %_ptr_Function_ulong Function
+%1164 = OpVariable %_ptr_Function_ulong Function
+%1165 = OpVariable %_ptr_Function_float Function
+%1166 = OpVariable %_ptr_Function_ulong Function
+%1167 = OpVariable %_ptr_Function_uint Function
+%1168 = OpVariable %_ptr_Function_ulong Function
+%1169 = OpVariable %_ptr_Function_ulong Function
+%1170 = OpVariable %_ptr_Function_ulong Function
+%1171 = OpVariable %_ptr_Function_float Function
+%1172 = OpVariable %_ptr_Function_ulong Function
+%1173 = OpVariable %_ptr_Function_ushort Function
+%1174 = OpVariable %_ptr_Function_ulong Function
+%1175 = OpVariable %_ptr_Function_ulong Function
+%1176 = OpVariable %_ptr_Function_ulong Function
+%1177 = OpVariable %_ptr_Function_float Function
+%1178 = OpVariable %_ptr_Function_ulong Function
+%1179 = OpVariable %_ptr_Function_uchar Function
+%1180 = OpVariable %_ptr_Function_ulong Function
+%1181 = OpVariable %_ptr_Function_ulong Function
+%1182 = OpVariable %_ptr_Function_ulong Function
+%1183 = OpVariable %_ptr_Function_float Function
+%1184 = OpVariable %_ptr_Function_ulong Function
+%1185 = OpVariable %_ptr_Function_uint Function
+%1186 = OpVariable %_ptr_Function_ulong Function
+%1187 = OpVariable %_ptr_Function_ulong Function
+%1188 = OpVariable %_ptr_Function_ulong Function
+%1189 = OpVariable %_ptr_Function_ulong Function
+%1190 = OpVariable %_ptr_Function_float Function
+%1191 = OpVariable %_ptr_Function_ulong Function
+%1192 = OpVariable %_ptr_Function_uint Function
+%1193 = OpVariable %_ptr_Function_ulong Function
+%1194 = OpVariable %_ptr_Function_ulong Function
+%1195 = OpVariable %_ptr_Function_ulong Function
+%1196 = OpVariable %_ptr_Function_float Function
+%1197 = OpVariable %_ptr_Function_ulong Function
+%1198 = OpVariable %_ptr_Function_ushort Function
+%1199 = OpVariable %_ptr_Function_ulong Function
+%1200 = OpVariable %_ptr_Function_ulong Function
+%1201 = OpVariable %_ptr_Function_ulong Function
+%1202 = OpVariable %_ptr_Function_float Function
+%1203 = OpVariable %_ptr_Function_ulong Function
+%1204 = OpVariable %_ptr_Function_uchar Function
+%1205 = OpVariable %_ptr_Function_ulong Function
+%1206 = OpVariable %_ptr_Function_ulong Function
+%1207 = OpVariable %_ptr_Function_ulong Function
+%1208 = OpVariable %_ptr_Function_float Function
+%1209 = OpVariable %_ptr_Function_ulong Function
+%1210 = OpVariable %_ptr_Function_uint Function
+%1211 = OpVariable %_ptr_Function_ulong Function
+%1212 = OpVariable %_ptr_Function_ulong Function
+%1213 = OpVariable %_ptr_Function_ulong Function
+%1214 = OpVariable %_ptr_Function_ulong Function
+%1215 = OpVariable %_ptr_Function_ulong Function
+%1216 = OpVariable %_ptr_Function_ulong Function
+%1217 = OpVariable %_ptr_Function_ulong Function
+%1218 = OpVariable %_ptr_Function_ulong Function
+%1219 = OpVariable %_ptr_Function_ulong Function
+%1220 = OpVariable %_ptr_Function_ulong Function
+%1221 = OpVariable %_ptr_Function_ulong Function
+%1222 = OpVariable %_ptr_Function_float Function
+%1223 = OpVariable %_ptr_Function_float Function
+%1224 = OpVariable %_ptr_Function_float Function
+%1225 = OpVariable %_ptr_Function_ulong Function
+%1226 = OpVariable %_ptr_Function_float Function
+%1227 = OpVariable %_ptr_Function_float Function
+%1228 = OpVariable %_ptr_Function_float Function
+%1229 = OpVariable %_ptr_Function_ulong Function
+%1230 = OpVariable %_ptr_Function_float Function
+%1231 = OpVariable %_ptr_Function_float Function
+%1232 = OpVariable %_ptr_Function_float Function
+%1233 = OpVariable %_ptr_Function_ulong Function
+%1234 = OpVariable %_ptr_Function_float Function
+%1235 = OpVariable %_ptr_Function_float Function
+%1236 = OpVariable %_ptr_Function_float Function
+%1237 = OpVariable %_ptr_Function_ulong Function
+%1238 = OpVariable %_ptr_Function_float Function
+%1239 = OpVariable %_ptr_Function_float Function
+%1240 = OpVariable %_ptr_Function_float Function
 %1241 = OpVariable %_ptr_Function_ulong Function
-%1242 = OpVariable %_ptr_Function_ulong Function
-%1243 = OpVariable %_ptr_Function_ulong Function
-%1244 = OpVariable %_ptr_Function_ulong Function
+%1242 = OpVariable %_ptr_Function_float Function
+%1243 = OpVariable %_ptr_Function_float Function
+%1244 = OpVariable %_ptr_Function_float Function
 %1245 = OpVariable %_ptr_Function_ulong Function
-OpStore %1235 %1228
-OpStore %1236 %1229
-%1246 = OpLoad %ulong %1235
-OpStore %1244 %1246
-OpStore %1245 %ulong_0
-OpBranch %1231
-%1231 = OpLabel
-%1247 = OpLoad %ulong %1245
-%1249 = OpULessThan %bool %1247 %ulong_8
-OpStore %1237 %1249
-%1250 = OpLoad %bool %1237
-OpLoopMerge %1233 %1234 None
-OpBranchConditional %1250 %1232 %1233
-%1233 = OpLabel
-%1251 = OpLoad %ulong %1244
-OpReturnValue %1251
-%1232 = OpLabel
-%1252 = OpLoad %ulong %1245
-%1253 = OpIMul %ulong %1252 %ulong_8
-OpStore %1238 %1253
-%1254 = OpLoad %ulong %1236
-%1255 = OpLoad %ulong %1238
-%1256 = OpShiftRightLogical %ulong %1254 %1255
-OpStore %1239 %1256
-%1257 = OpLoad %ulong %1239
-%1259 = OpBitwiseAnd %ulong %1257 %ulong_255
-OpStore %1240 %1259
-%1260 = OpLoad %ulong %1244
-%1261 = OpLoad %ulong %1240
-%1262 = OpBitwiseXor %ulong %1260 %1261
-OpStore %1241 %1262
-%1263 = OpLoad %ulong %1241
-%1265 = OpIMul %ulong %1263 %ulong_1099511628211
-OpStore %1242 %1265
-%1266 = OpLoad %ulong %1245
-%1267 = OpIAdd %ulong %1266 %ulong_1
-OpStore %1243 %1267
-%1268 = OpLoad %ulong %1242
-OpStore %1244 %1268
-%1269 = OpLoad %ulong %1243
-OpStore %1245 %1269
-OpBranch %1234
-%1234 = OpLabel
-OpBranch %1231
-OpFunctionEnd
-%8 = OpFunction %ulong None %1270
-%1271 = OpFunctionParameter %ulong
-%1272 = OpFunctionParameter %uchar
-%1273 = OpLabel
-%1280 = OpVariable %_ptr_Function_ulong Function
-%1281 = OpVariable %_ptr_Function_uchar Function
-%1282 = OpVariable %_ptr_Function_ulong Function
-%1283 = OpVariable %_ptr_Function_bool Function
-%1284 = OpVariable %_ptr_Function_ulong Function
+%1246 = OpVariable %_ptr_Function_float Function
+%1247 = OpVariable %_ptr_Function_float Function
+%1248 = OpVariable %_ptr_Function_float Function
+%1249 = OpVariable %_ptr_Function_ulong Function
+%1250 = OpVariable %_ptr_Function_float Function
+%1251 = OpVariable %_ptr_Function_float Function
+%1252 = OpVariable %_ptr_Function_float Function
+%1253 = OpVariable %_ptr_Function_ulong Function
+%1254 = OpVariable %_ptr_Function_float Function
+%1255 = OpVariable %_ptr_Function_float Function
+%1256 = OpVariable %_ptr_Function_float Function
+%1257 = OpVariable %_ptr_Function_ulong Function
+%1258 = OpVariable %_ptr_Function_float Function
+%1259 = OpVariable %_ptr_Function_float Function
+%1260 = OpVariable %_ptr_Function_float Function
+%1261 = OpVariable %_ptr_Function_ulong Function
+%1262 = OpVariable %_ptr_Function_float Function
+%1263 = OpVariable %_ptr_Function_float Function
+%1264 = OpVariable %_ptr_Function_float Function
+%1265 = OpVariable %_ptr_Function_ulong Function
+%1266 = OpVariable %_ptr_Function_float Function
+%1267 = OpVariable %_ptr_Function_float Function
+%1268 = OpVariable %_ptr_Function_float Function
+%1269 = OpVariable %_ptr_Function_ulong Function
+%1270 = OpVariable %_ptr_Function_float Function
+%1271 = OpVariable %_ptr_Function_float Function
+%1272 = OpVariable %_ptr_Function_float Function
+%1273 = OpVariable %_ptr_Function_ulong Function
+%1274 = OpVariable %_ptr_Function_float Function
+%1275 = OpVariable %_ptr_Function_float Function
+%1276 = OpVariable %_ptr_Function_float Function
+%1277 = OpVariable %_ptr_Function_ulong Function
+%1278 = OpVariable %_ptr_Function_float Function
+%1279 = OpVariable %_ptr_Function_float Function
+%1280 = OpVariable %_ptr_Function_float Function
+%1281 = OpVariable %_ptr_Function_ulong Function
+%1282 = OpVariable %_ptr_Function_float Function
+%1283 = OpVariable %_ptr_Function_float Function
+%1284 = OpVariable %_ptr_Function_float Function
 %1285 = OpVariable %_ptr_Function_ulong Function
-%1286 = OpVariable %_ptr_Function_ulong Function
-%1287 = OpVariable %_ptr_Function_ulong Function
-%1288 = OpVariable %_ptr_Function_ulong Function
+%1286 = OpVariable %_ptr_Function_double Function
+%1287 = OpVariable %_ptr_Function_double Function
+%1288 = OpVariable %_ptr_Function_double Function
 %1289 = OpVariable %_ptr_Function_ulong Function
-%1290 = OpVariable %_ptr_Function_ulong Function
-%1291 = OpVariable %_ptr_Function_ulong Function
-OpStore %1280 %1271
-OpStore %1281 %1272
-%1292 = OpLoad %uchar %1281
-%1293 = OpUConvert %ulong %1292
-OpStore %1282 %1293
-OpBranch %1274
-%1274 = OpLabel
-%1294 = OpLoad %ulong %1280
-OpStore %1290 %1294
-OpStore %1291 %ulong_0
-OpBranch %1275
-%1275 = OpLabel
-%1295 = OpLoad %ulong %1291
-%1296 = OpULessThan %bool %1295 %ulong_8
-OpStore %1283 %1296
-%1297 = OpLoad %bool %1283
-OpLoopMerge %1277 %1279 None
-OpBranchConditional %1297 %1276 %1277
-%1277 = OpLabel
-OpBranch %1278
-%1278 = OpLabel
-%1298 = OpLoad %ulong %1290
-OpReturnValue %1298
-%1276 = OpLabel
-%1299 = OpLoad %ulong %1291
-%1300 = OpIMul %ulong %1299 %ulong_8
-OpStore %1284 %1300
-%1301 = OpLoad %ulong %1282
-%1302 = OpLoad %ulong %1284
-%1303 = OpShiftRightLogical %ulong %1301 %1302
-OpStore %1285 %1303
-%1304 = OpLoad %ulong %1285
-%1305 = OpBitwiseAnd %ulong %1304 %ulong_255
-OpStore %1286 %1305
-%1306 = OpLoad %ulong %1290
-%1307 = OpLoad %ulong %1286
-%1308 = OpBitwiseXor %ulong %1306 %1307
-OpStore %1287 %1308
-%1309 = OpLoad %ulong %1287
-%1310 = OpIMul %ulong %1309 %ulong_1099511628211
-OpStore %1288 %1310
-%1311 = OpLoad %ulong %1291
-%1312 = OpIAdd %ulong %1311 %ulong_1
-OpStore %1289 %1312
-%1313 = OpLoad %ulong %1288
-OpStore %1290 %1313
-%1314 = OpLoad %ulong %1289
-OpStore %1291 %1314
-OpBranch %1279
-%1279 = OpLabel
-OpBranch %1275
-OpFunctionEnd
-%9 = OpFunction %ulong None %1315
-%1316 = OpFunctionParameter %ulong
-%1317 = OpFunctionParameter %ushort
-%1318 = OpLabel
+%1290 = OpVariable %_ptr_Function_double Function
+%1291 = OpVariable %_ptr_Function_double Function
+%1292 = OpVariable %_ptr_Function_double Function
+%1293 = OpVariable %_ptr_Function_ulong Function
+%1294 = OpVariable %_ptr_Function_double Function
+%1295 = OpVariable %_ptr_Function_double Function
+%1296 = OpVariable %_ptr_Function_double Function
+%1297 = OpVariable %_ptr_Function_ulong Function
+%1298 = OpVariable %_ptr_Function_double Function
+%1299 = OpVariable %_ptr_Function_double Function
+%1300 = OpVariable %_ptr_Function_double Function
+%1301 = OpVariable %_ptr_Function_ulong Function
+%1302 = OpVariable %_ptr_Function_double Function
+%1303 = OpVariable %_ptr_Function_double Function
+%1304 = OpVariable %_ptr_Function_double Function
+%1305 = OpVariable %_ptr_Function_ulong Function
+%1306 = OpVariable %_ptr_Function_double Function
+%1307 = OpVariable %_ptr_Function_double Function
+%1308 = OpVariable %_ptr_Function_double Function
+%1309 = OpVariable %_ptr_Function_ulong Function
+%1310 = OpVariable %_ptr_Function_double Function
+%1311 = OpVariable %_ptr_Function_double Function
+%1312 = OpVariable %_ptr_Function_double Function
+%1313 = OpVariable %_ptr_Function_ulong Function
+%1314 = OpVariable %_ptr_Function_double Function
+%1315 = OpVariable %_ptr_Function_double Function
+%1316 = OpVariable %_ptr_Function_double Function
+%1317 = OpVariable %_ptr_Function_ulong Function
+%1318 = OpVariable %_ptr_Function_double Function
+%1319 = OpVariable %_ptr_Function_double Function
+%1320 = OpVariable %_ptr_Function_double Function
+%1321 = OpVariable %_ptr_Function_ulong Function
+%1322 = OpVariable %_ptr_Function_double Function
+%1323 = OpVariable %_ptr_Function_double Function
+%1324 = OpVariable %_ptr_Function_double Function
 %1325 = OpVariable %_ptr_Function_ulong Function
-%1326 = OpVariable %_ptr_Function_ushort Function
-%1327 = OpVariable %_ptr_Function_ulong Function
-%1328 = OpVariable %_ptr_Function_bool Function
+%1326 = OpVariable %_ptr_Function_double Function
+%1327 = OpVariable %_ptr_Function_double Function
+%1328 = OpVariable %_ptr_Function_double Function
 %1329 = OpVariable %_ptr_Function_ulong Function
-%1330 = OpVariable %_ptr_Function_ulong Function
-%1331 = OpVariable %_ptr_Function_ulong Function
-%1332 = OpVariable %_ptr_Function_ulong Function
-%1333 = OpVariable %_ptr_Function_ulong Function
-%1334 = OpVariable %_ptr_Function_ulong Function
-%1335 = OpVariable %_ptr_Function_ulong Function
-%1336 = OpVariable %_ptr_Function_ulong Function
-OpStore %1325 %1316
-OpStore %1326 %1317
-%1337 = OpLoad %ushort %1326
-%1338 = OpUConvert %ulong %1337
-OpStore %1327 %1338
-OpBranch %1319
-%1319 = OpLabel
-%1339 = OpLoad %ulong %1325
-OpStore %1335 %1339
-OpStore %1336 %ulong_0
-OpBranch %1320
-%1320 = OpLabel
-%1340 = OpLoad %ulong %1336
-%1341 = OpULessThan %bool %1340 %ulong_8
-OpStore %1328 %1341
-%1342 = OpLoad %bool %1328
-OpLoopMerge %1322 %1324 None
-OpBranchConditional %1342 %1321 %1322
-%1322 = OpLabel
-OpBranch %1323
-%1323 = OpLabel
-%1343 = OpLoad %ulong %1335
-OpReturnValue %1343
-%1321 = OpLabel
-%1344 = OpLoad %ulong %1336
-%1345 = OpIMul %ulong %1344 %ulong_8
-OpStore %1329 %1345
-%1346 = OpLoad %ulong %1327
-%1347 = OpLoad %ulong %1329
-%1348 = OpShiftRightLogical %ulong %1346 %1347
-OpStore %1330 %1348
-%1349 = OpLoad %ulong %1330
-%1350 = OpBitwiseAnd %ulong %1349 %ulong_255
-OpStore %1331 %1350
-%1351 = OpLoad %ulong %1335
-%1352 = OpLoad %ulong %1331
-%1353 = OpBitwiseXor %ulong %1351 %1352
-OpStore %1332 %1353
-%1354 = OpLoad %ulong %1332
-%1355 = OpIMul %ulong %1354 %ulong_1099511628211
-OpStore %1333 %1355
-%1356 = OpLoad %ulong %1336
-%1357 = OpIAdd %ulong %1356 %ulong_1
-OpStore %1334 %1357
-%1358 = OpLoad %ulong %1333
-OpStore %1335 %1358
-%1359 = OpLoad %ulong %1334
-OpStore %1336 %1359
-OpBranch %1324
-%1324 = OpLabel
-OpBranch %1320
+%1330 = OpVariable %_ptr_Function_double Function
+%1331 = OpVariable %_ptr_Function_double Function
+%1332 = OpVariable %_ptr_Function_double Function
+OpStore %1101 %1027
+OpBranch %1035
+%1035 = OpLabel
+OpBranch %1036
+%1036 = OpLabel
+OpStore %1100 %1333
+OpStore %1215 %ulong_0
+OpBranch %1029
+%1029 = OpLabel
+%1334 = OpLoad %ulong %1215
+%1336 = OpULessThan %bool %1334 %ulong_24
+OpStore %1102 %1336
+%1337 = OpLoad %bool %1102
+OpLoopMerge %1031 %1096 None
+OpBranchConditional %1337 %1030 %1031
+%1031 = OpLabel
+OpStore %1214 %ulong_14695981039346656037
+OpStore %1216 %ulong_0
+OpStore %1217 %ulong_0
+OpBranch %1032
+%1032 = OpLabel
+%1338 = OpLoad %ulong %1217
+%1340 = OpULessThan %bool %1338 %ulong_3
+OpStore %1104 %1340
+%1341 = OpLoad %bool %1104
+OpLoopMerge %1034 %1095 None
+OpBranchConditional %1341 %1033 %1034
+%1034 = OpLabel
+OpBranch %1041
+%1041 = OpLabel
+%1342 = OpLoad %ulong %1216
+%1343 = OpBitwiseAnd %ulong %1342 %ulong_4095
+OpStore %1225 %1343
+%1344 = OpLoad %ulong %1225
+%1345 = OpConvertUToF %float %1344
+OpStore %1226 %1345
+%1346 = OpLoad %float %1226
+%1347 = OpFSub %float %1346 %float_2048
+OpStore %1227 %1347
+%1348 = OpLoad %float %1227
+%1349 = OpFDiv %float %1348 %float_8
+OpStore %1228 %1349
+OpBranch %1042
+%1042 = OpLabel
+%1351 = OpAccessChain %_ptr_Function_ulong %1100 %uint_2
+%1352 = OpLoad %ulong %1351
+OpStore %1151 %1352
+OpBranch %1045
+%1045 = OpLabel
+%1353 = OpLoad %ulong %1151
+%1354 = OpBitwiseAnd %ulong %1353 %ulong_4095
+OpStore %1233 %1354
+%1355 = OpLoad %ulong %1233
+%1356 = OpConvertUToF %float %1355
+OpStore %1234 %1356
+%1357 = OpLoad %float %1234
+%1358 = OpFSub %float %1357 %float_2048
+OpStore %1235 %1358
+%1359 = OpLoad %float %1235
+%1360 = OpFDiv %float %1359 %float_8
+OpStore %1236 %1360
+OpBranch %1046
+%1046 = OpLabel
+%1362 = OpAccessChain %_ptr_Function_ulong %1100 %uint_3
+%1363 = OpLoad %ulong %1362
+OpStore %1152 %1363
+OpBranch %1049
+%1049 = OpLabel
+%1364 = OpLoad %ulong %1152
+%1365 = OpBitwiseAnd %ulong %1364 %ulong_4095
+OpStore %1241 %1365
+%1366 = OpLoad %ulong %1241
+%1367 = OpConvertUToF %float %1366
+OpStore %1242 %1367
+%1368 = OpLoad %float %1242
+%1369 = OpFSub %float %1368 %float_2048
+OpStore %1243 %1369
+%1370 = OpLoad %float %1243
+%1371 = OpFDiv %float %1370 %float_8
+OpStore %1244 %1371
+OpBranch %1050
+%1050 = OpLabel
+%1373 = OpLoad %float %1228
+%1374 = OpLoad %float %1236
+%1375 = OpLoad %float %1244
+%1372 = OpCompositeConstruct %v3float %1373 %1374 %1375
+OpStore %1153 %1372
+%1377 = OpAccessChain %_ptr_Function_ulong %1100 %uint_4
+%1378 = OpLoad %ulong %1377
+OpStore %1154 %1378
+OpBranch %1053
+%1053 = OpLabel
+%1379 = OpLoad %ulong %1154
+%1380 = OpBitwiseAnd %ulong %1379 %ulong_4095
+OpStore %1249 %1380
+%1381 = OpLoad %ulong %1249
+%1382 = OpConvertUToF %float %1381
+OpStore %1250 %1382
+%1383 = OpLoad %float %1250
+%1384 = OpFSub %float %1383 %float_2048
+OpStore %1251 %1384
+%1385 = OpLoad %float %1251
+%1386 = OpFDiv %float %1385 %float_8
+OpStore %1252 %1386
+OpBranch %1054
+%1054 = OpLabel
+%1388 = OpAccessChain %_ptr_Function_ulong %1100 %uint_5
+%1389 = OpLoad %ulong %1388
+OpStore %1155 %1389
+OpBranch %1057
+%1057 = OpLabel
+%1390 = OpLoad %ulong %1155
+%1391 = OpBitwiseAnd %ulong %1390 %ulong_4095
+OpStore %1257 %1391
+%1392 = OpLoad %ulong %1257
+%1393 = OpConvertUToF %float %1392
+OpStore %1258 %1393
+%1394 = OpLoad %float %1258
+%1395 = OpFSub %float %1394 %float_2048
+OpStore %1259 %1395
+%1396 = OpLoad %float %1259
+%1397 = OpFDiv %float %1396 %float_8
+OpStore %1260 %1397
+OpBranch %1058
+%1058 = OpLabel
+%1399 = OpAccessChain %_ptr_Function_ulong %1100 %uint_6
+%1400 = OpLoad %ulong %1399
+OpStore %1156 %1400
+OpBranch %1061
+%1061 = OpLabel
+%1401 = OpLoad %ulong %1156
+%1402 = OpBitwiseAnd %ulong %1401 %ulong_4095
+OpStore %1265 %1402
+%1403 = OpLoad %ulong %1265
+%1404 = OpConvertUToF %float %1403
+OpStore %1266 %1404
+%1405 = OpLoad %float %1266
+%1406 = OpFSub %float %1405 %float_2048
+OpStore %1267 %1406
+%1407 = OpLoad %float %1267
+%1408 = OpFDiv %float %1407 %float_8
+OpStore %1268 %1408
+OpBranch %1062
+%1062 = OpLabel
+%1410 = OpAccessChain %_ptr_Function_ulong %1100 %uint_7
+%1411 = OpLoad %ulong %1410
+OpStore %1157 %1411
+OpBranch %1065
+%1065 = OpLabel
+%1412 = OpLoad %ulong %1157
+%1413 = OpBitwiseAnd %ulong %1412 %ulong_4095
+OpStore %1273 %1413
+%1414 = OpLoad %ulong %1273
+%1415 = OpConvertUToF %float %1414
+OpStore %1274 %1415
+%1416 = OpLoad %float %1274
+%1417 = OpFSub %float %1416 %float_2048
+OpStore %1275 %1417
+%1418 = OpLoad %float %1275
+%1419 = OpFDiv %float %1418 %float_8
+OpStore %1276 %1419
+OpBranch %1066
+%1066 = OpLabel
+%1421 = OpLoad %float %1252
+%1422 = OpLoad %float %1260
+%1423 = OpLoad %float %1268
+%1424 = OpLoad %float %1276
+%1420 = OpCompositeConstruct %v4float %1421 %1422 %1423 %1424
+OpStore %1158 %1420
+%1426 = OpAccessChain %_ptr_Function_ulong %1100 %uint_8
+%1427 = OpLoad %ulong %1426
+OpStore %1159 %1427
+OpBranch %1069
+%1069 = OpLabel
+%1428 = OpLoad %ulong %1159
+%1429 = OpBitwiseAnd %ulong %1428 %ulong_4095
+OpStore %1281 %1429
+%1430 = OpLoad %ulong %1281
+%1431 = OpConvertUToF %float %1430
+OpStore %1282 %1431
+%1432 = OpLoad %float %1282
+%1433 = OpFSub %float %1432 %float_2048
+OpStore %1283 %1433
+%1434 = OpLoad %float %1283
+%1435 = OpFDiv %float %1434 %float_8
+OpStore %1284 %1435
+OpBranch %1070
+%1070 = OpLabel
+%1437 = OpAccessChain %_ptr_Function_ulong %1100 %uint_9
+%1438 = OpLoad %ulong %1437
+OpStore %1160 %1438
+%1439 = OpLoad %ulong %1160
+%1440 = OpFunctionCall %float %2 %1439
+OpStore %1161 %1440
+%1442 = OpLoad %float %1284
+%1443 = OpLoad %float %1161
+%1441 = OpCompositeConstruct %v2float %1442 %1443
+OpStore %1162 %1441
+%1445 = OpAccessChain %_ptr_Function_ulong %1100 %uint_0
+%1446 = OpLoad %ulong %1445
+OpStore %1163 %1446
+%1448 = OpAccessChain %_ptr_Function_ulong %1100 %uint_1
+%1449 = OpLoad %ulong %1448
+OpStore %1164 %1449
+%1450 = OpLoad %ulong %1164
+%1451 = OpFunctionCall %float %2 %1450
+OpStore %1165 %1451
+%1452 = OpAccessChain %_ptr_Function_ulong %1100 %uint_2
+%1453 = OpLoad %ulong %1452
+OpStore %1166 %1453
+%1454 = OpLoad %ulong %1166
+%1455 = OpUConvert %uint %1454
+OpStore %1167 %1455
+%1456 = OpAccessChain %_ptr_Function_ulong %1100 %uint_3
+%1457 = OpLoad %ulong %1456
+OpStore %1168 %1457
+OpBranch %1073
+%1073 = OpLabel
+%1458 = OpLoad %ulong %1168
+%1459 = OpBitwiseAnd %ulong %1458 %ulong_1048575
+OpStore %1289 %1459
+%1460 = OpLoad %ulong %1289
+%1461 = OpConvertUToF %double %1460
+OpStore %1290 %1461
+%1462 = OpLoad %double %1290
+%1463 = OpFSub %double %1462 %double_524288
+OpStore %1291 %1463
+%1464 = OpLoad %double %1291
+%1465 = OpFDiv %double %1464 %double_64
+OpStore %1292 %1465
+OpBranch %1074
+%1074 = OpLabel
+%1466 = OpAccessChain %_ptr_Function_ulong %1100 %uint_4
+%1467 = OpLoad %ulong %1466
+OpStore %1169 %1467
+%1468 = OpAccessChain %_ptr_Function_ulong %1100 %uint_5
+%1469 = OpLoad %ulong %1468
+OpStore %1170 %1469
+%1470 = OpLoad %ulong %1170
+%1471 = OpFunctionCall %float %2 %1470
+OpStore %1171 %1471
+%1472 = OpAccessChain %_ptr_Function_ulong %1100 %uint_6
+%1473 = OpLoad %ulong %1472
+OpStore %1172 %1473
+%1474 = OpLoad %ulong %1172
+%1475 = OpUConvert %ushort %1474
+OpStore %1173 %1475
+%1476 = OpAccessChain %_ptr_Function_ulong %1100 %uint_7
+%1477 = OpLoad %ulong %1476
+OpStore %1174 %1477
+OpBranch %1077
+%1077 = OpLabel
+%1478 = OpLoad %ulong %1174
+%1479 = OpBitwiseAnd %ulong %1478 %ulong_1048575
+OpStore %1297 %1479
+%1480 = OpLoad %ulong %1297
+%1481 = OpConvertUToF %double %1480
+OpStore %1298 %1481
+%1482 = OpLoad %double %1298
+%1483 = OpFSub %double %1482 %double_524288
+OpStore %1299 %1483
+%1484 = OpLoad %double %1299
+%1485 = OpFDiv %double %1484 %double_64
+OpStore %1300 %1485
+OpBranch %1078
+%1078 = OpLabel
+%1486 = OpAccessChain %_ptr_Function_ulong %1100 %uint_8
+%1487 = OpLoad %ulong %1486
+OpStore %1175 %1487
+%1488 = OpAccessChain %_ptr_Function_ulong %1100 %uint_9
+%1489 = OpLoad %ulong %1488
+OpStore %1176 %1489
+%1490 = OpLoad %ulong %1176
+%1491 = OpFunctionCall %float %2 %1490
+OpStore %1177 %1491
+%1493 = OpAccessChain %_ptr_Function_ulong %1100 %uint_10
+%1494 = OpLoad %ulong %1493
+OpStore %1178 %1494
+%1495 = OpLoad %ulong %1178
+%1496 = OpUConvert %uchar %1495
+OpStore %1179 %1496
+%1498 = OpAccessChain %_ptr_Function_ulong %1100 %uint_11
+%1499 = OpLoad %ulong %1498
+OpStore %1180 %1499
+OpBranch %1081
+%1081 = OpLabel
+%1500 = OpLoad %ulong %1180
+%1501 = OpBitwiseAnd %ulong %1500 %ulong_1048575
+OpStore %1305 %1501
+%1502 = OpLoad %ulong %1305
+%1503 = OpConvertUToF %double %1502
+OpStore %1306 %1503
+%1504 = OpLoad %double %1306
+%1505 = OpFSub %double %1504 %double_524288
+OpStore %1307 %1505
+%1506 = OpLoad %double %1307
+%1507 = OpFDiv %double %1506 %double_64
+OpStore %1308 %1507
+OpBranch %1082
+%1082 = OpLabel
+%1509 = OpAccessChain %_ptr_Function_ulong %1100 %uint_12
+%1510 = OpLoad %ulong %1509
+OpStore %1181 %1510
+%1512 = OpAccessChain %_ptr_Function_ulong %1100 %uint_13
+%1513 = OpLoad %ulong %1512
+OpStore %1182 %1513
+%1514 = OpLoad %ulong %1182
+%1515 = OpFunctionCall %float %2 %1514
+OpStore %1183 %1515
+%1517 = OpAccessChain %_ptr_Function_ulong %1100 %uint_14
+%1518 = OpLoad %ulong %1517
+OpStore %1184 %1518
+%1519 = OpLoad %ulong %1184
+%1520 = OpUConvert %uint %1519
+OpStore %1185 %1520
+%1522 = OpAccessChain %_ptr_Function_ulong %1100 %uint_15
+%1523 = OpLoad %ulong %1522
+OpStore %1186 %1523
+OpBranch %1085
+%1085 = OpLabel
+%1524 = OpLoad %ulong %1186
+%1525 = OpBitwiseAnd %ulong %1524 %ulong_1048575
+OpStore %1313 %1525
+%1526 = OpLoad %ulong %1313
+%1527 = OpConvertUToF %double %1526
+OpStore %1314 %1527
+%1528 = OpLoad %double %1314
+%1529 = OpFSub %double %1528 %double_524288
+OpStore %1315 %1529
+%1530 = OpLoad %double %1315
+%1531 = OpFDiv %double %1530 %double_64
+OpStore %1316 %1531
+OpBranch %1086
+%1086 = OpLabel
+%1532 = OpAccessChain %_ptr_Function_ulong %1100 %uint_1
+%1533 = OpLoad %ulong %1532
+OpStore %1187 %1533
+%1534 = OpLoad %ulong %1163
+%1535 = OpLoad %float %1165
+%1536 = OpLoad %uint %1167
+%1537 = OpLoad %double %1292
+%1538 = OpLoad %v3float %1153
+%1539 = OpLoad %ulong %1169
+%1540 = OpLoad %float %1171
+%1541 = OpLoad %ushort %1173
+%1542 = OpLoad %v4float %1158
+%1543 = OpLoad %double %1300
+%1544 = OpLoad %ulong %1175
+%1545 = OpLoad %float %1177
+%1546 = OpLoad %uchar %1179
+%1547 = OpLoad %double %1308
+%1548 = OpLoad %v2float %1162
+%1549 = OpLoad %ulong %1181
+%1550 = OpLoad %float %1183
+%1551 = OpLoad %uint %1185
+%1552 = OpLoad %double %1316
+%1553 = OpLoad %ulong %1187
+%1554 = OpFunctionCall %ulong %4 %1534 %1535 %1536 %1537 %1538 %1539 %1540 %1541 %1542 %1543 %1544 %1545 %1546 %1547 %1548 %1549 %1550 %1551 %1552 %1553
+OpStore %1188 %1554
+%1555 = OpAccessChain %_ptr_Function_ulong %1100 %uint_3
+%1556 = OpLoad %ulong %1555
+OpStore %1189 %1556
+%1557 = OpLoad %ulong %1189
+%1558 = OpFunctionCall %float %2 %1557
+OpStore %1190 %1558
+%1559 = OpAccessChain %_ptr_Function_ulong %1100 %uint_5
+%1560 = OpLoad %ulong %1559
+OpStore %1191 %1560
+%1561 = OpLoad %ulong %1191
+%1562 = OpUConvert %uint %1561
+OpStore %1192 %1562
+%1563 = OpAccessChain %_ptr_Function_ulong %1100 %uint_7
+%1564 = OpLoad %ulong %1563
+OpStore %1193 %1564
+OpBranch %1087
+%1087 = OpLabel
+%1565 = OpLoad %ulong %1193
+%1566 = OpBitwiseAnd %ulong %1565 %ulong_1048575
+OpStore %1317 %1566
+%1567 = OpLoad %ulong %1317
+%1568 = OpConvertUToF %double %1567
+OpStore %1318 %1568
+%1569 = OpLoad %double %1318
+%1570 = OpFSub %double %1569 %double_524288
+OpStore %1319 %1570
+%1571 = OpLoad %double %1319
+%1572 = OpFDiv %double %1571 %double_64
+OpStore %1320 %1572
+OpBranch %1088
+%1088 = OpLabel
+%1573 = OpAccessChain %_ptr_Function_ulong %1100 %uint_9
+%1574 = OpLoad %ulong %1573
+OpStore %1194 %1574
+%1575 = OpAccessChain %_ptr_Function_ulong %1100 %uint_11
+%1576 = OpLoad %ulong %1575
+OpStore %1195 %1576
+%1577 = OpLoad %ulong %1195
+%1578 = OpFunctionCall %float %2 %1577
+OpStore %1196 %1578
+%1579 = OpAccessChain %_ptr_Function_ulong %1100 %uint_13
+%1580 = OpLoad %ulong %1579
+OpStore %1197 %1580
+%1581 = OpLoad %ulong %1197
+%1582 = OpUConvert %ushort %1581
+OpStore %1198 %1582
+%1583 = OpAccessChain %_ptr_Function_ulong %1100 %uint_15
+%1584 = OpLoad %ulong %1583
+OpStore %1199 %1584
+OpBranch %1089
+%1089 = OpLabel
+%1585 = OpLoad %ulong %1199
+%1586 = OpBitwiseAnd %ulong %1585 %ulong_1048575
+OpStore %1321 %1586
+%1587 = OpLoad %ulong %1321
+%1588 = OpConvertUToF %double %1587
+OpStore %1322 %1588
+%1589 = OpLoad %double %1322
+%1590 = OpFSub %double %1589 %double_524288
+OpStore %1323 %1590
+%1591 = OpLoad %double %1323
+%1592 = OpFDiv %double %1591 %double_64
+OpStore %1324 %1592
+OpBranch %1090
+%1090 = OpLabel
+%1594 = OpAccessChain %_ptr_Function_ulong %1100 %uint_17
+%1595 = OpLoad %ulong %1594
+OpStore %1200 %1595
+%1597 = OpAccessChain %_ptr_Function_ulong %1100 %uint_19
+%1598 = OpLoad %ulong %1597
+OpStore %1201 %1598
+%1599 = OpLoad %ulong %1201
+%1600 = OpFunctionCall %float %2 %1599
+OpStore %1202 %1600
+%1602 = OpAccessChain %_ptr_Function_ulong %1100 %uint_21
+%1603 = OpLoad %ulong %1602
+OpStore %1203 %1603
+%1604 = OpLoad %ulong %1203
+%1605 = OpUConvert %uchar %1604
+OpStore %1204 %1605
+%1607 = OpAccessChain %_ptr_Function_ulong %1100 %uint_23
+%1608 = OpLoad %ulong %1607
+OpStore %1205 %1608
+OpBranch %1091
+%1091 = OpLabel
+%1609 = OpLoad %ulong %1205
+%1610 = OpBitwiseAnd %ulong %1609 %ulong_1048575
+OpStore %1325 %1610
+%1611 = OpLoad %ulong %1325
+%1612 = OpConvertUToF %double %1611
+OpStore %1326 %1612
+%1613 = OpLoad %double %1326
+%1614 = OpFSub %double %1613 %double_524288
+OpStore %1327 %1614
+%1615 = OpLoad %double %1327
+%1616 = OpFDiv %double %1615 %double_64
+OpStore %1328 %1616
+OpBranch %1092
+%1092 = OpLabel
+%1617 = OpAccessChain %_ptr_Function_ulong %1100 %uint_2
+%1618 = OpLoad %ulong %1617
+OpStore %1206 %1618
+%1619 = OpAccessChain %_ptr_Function_ulong %1100 %uint_4
+%1620 = OpLoad %ulong %1619
+OpStore %1207 %1620
+%1621 = OpLoad %ulong %1207
+%1622 = OpFunctionCall %float %2 %1621
+OpStore %1208 %1622
+%1623 = OpAccessChain %_ptr_Function_ulong %1100 %uint_6
+%1624 = OpLoad %ulong %1623
+OpStore %1209 %1624
+%1625 = OpLoad %ulong %1209
+%1626 = OpUConvert %uint %1625
+OpStore %1210 %1626
+%1627 = OpAccessChain %_ptr_Function_ulong %1100 %uint_8
+%1628 = OpLoad %ulong %1627
+OpStore %1211 %1628
+OpBranch %1093
+%1093 = OpLabel
+%1629 = OpLoad %ulong %1211
+%1630 = OpBitwiseAnd %ulong %1629 %ulong_1048575
+OpStore %1329 %1630
+%1631 = OpLoad %ulong %1329
+%1632 = OpConvertUToF %double %1631
+OpStore %1330 %1632
+%1633 = OpLoad %double %1330
+%1634 = OpFSub %double %1633 %double_524288
+OpStore %1331 %1634
+%1635 = OpLoad %double %1331
+%1636 = OpFDiv %double %1635 %double_64
+OpStore %1332 %1636
+OpBranch %1094
+%1094 = OpLabel
+%1637 = OpLoad %ulong %1188
+%1638 = OpLoad %float %1190
+%1639 = OpLoad %uint %1192
+%1640 = OpLoad %double %1320
+%1641 = OpLoad %v3float %1153
+%1642 = OpLoad %ulong %1194
+%1643 = OpLoad %float %1196
+%1644 = OpLoad %ushort %1198
+%1645 = OpLoad %v4float %1158
+%1646 = OpLoad %double %1324
+%1647 = OpLoad %ulong %1200
+%1648 = OpLoad %float %1202
+%1649 = OpLoad %uchar %1204
+%1650 = OpLoad %double %1328
+%1651 = OpLoad %v2float %1162
+%1652 = OpLoad %ulong %1206
+%1653 = OpLoad %float %1208
+%1654 = OpLoad %uint %1210
+%1655 = OpLoad %double %1332
+%1656 = OpLoad %ulong %1216
+%1657 = OpFunctionCall %ulong %4 %1637 %1638 %1639 %1640 %1641 %1642 %1643 %1644 %1645 %1646 %1647 %1648 %1649 %1650 %1651 %1652 %1653 %1654 %1655 %1656
+OpStore %1212 %1657
+%1658 = OpLoad %ulong %1214
+%1659 = OpLoad %ulong %1212
+%1660 = OpFunctionCall %ulong %6 %1658 %1659
+OpStore %1213 %1660
+%1661 = OpLoad %ulong %1213
+OpReturnValue %1661
+%1033 = OpLabel
+%1662 = OpLoad %ulong %1217
+%1664 = OpIMul %ulong %1662 %ulong_11
+OpStore %1105 %1664
+%1665 = OpLoad %ulong %1105
+%1666 = OpLoad %ulong %1101
+%1667 = OpIAdd %ulong %1665 %1666
+OpStore %1106 %1667
+%1669 = OpAccessChain %_ptr_Function_ulong %1100 %uint_16
+%1670 = OpLoad %ulong %1669
+OpStore %1107 %1670
+OpBranch %1039
+%1039 = OpLabel
+%1671 = OpLoad %ulong %1107
+%1672 = OpBitwiseAnd %ulong %1671 %ulong_4095
+OpStore %1221 %1672
+%1673 = OpLoad %ulong %1221
+%1674 = OpConvertUToF %float %1673
+OpStore %1222 %1674
+%1675 = OpLoad %float %1222
+%1676 = OpFSub %float %1675 %float_2048
+OpStore %1223 %1676
+%1677 = OpLoad %float %1223
+%1678 = OpFDiv %float %1677 %float_8
+OpStore %1224 %1678
+OpBranch %1040
+%1040 = OpLabel
+%1679 = OpAccessChain %_ptr_Function_ulong %1100 %uint_17
+%1680 = OpLoad %ulong %1679
+OpStore %1108 %1680
+OpBranch %1043
+%1043 = OpLabel
+%1681 = OpLoad %ulong %1108
+%1682 = OpBitwiseAnd %ulong %1681 %ulong_4095
+OpStore %1229 %1682
+%1683 = OpLoad %ulong %1229
+%1684 = OpConvertUToF %float %1683
+OpStore %1230 %1684
+%1685 = OpLoad %float %1230
+%1686 = OpFSub %float %1685 %float_2048
+OpStore %1231 %1686
+%1687 = OpLoad %float %1231
+%1688 = OpFDiv %float %1687 %float_8
+OpStore %1232 %1688
+OpBranch %1044
+%1044 = OpLabel
+%1690 = OpAccessChain %_ptr_Function_ulong %1100 %uint_18
+%1691 = OpLoad %ulong %1690
+OpStore %1109 %1691
+OpBranch %1047
+%1047 = OpLabel
+%1692 = OpLoad %ulong %1109
+%1693 = OpBitwiseAnd %ulong %1692 %ulong_4095
+OpStore %1237 %1693
+%1694 = OpLoad %ulong %1237
+%1695 = OpConvertUToF %float %1694
+OpStore %1238 %1695
+%1696 = OpLoad %float %1238
+%1697 = OpFSub %float %1696 %float_2048
+OpStore %1239 %1697
+%1698 = OpLoad %float %1239
+%1699 = OpFDiv %float %1698 %float_8
+OpStore %1240 %1699
+OpBranch %1048
+%1048 = OpLabel
+%1701 = OpLoad %float %1224
+%1702 = OpLoad %float %1232
+%1703 = OpLoad %float %1240
+%1700 = OpCompositeConstruct %v3float %1701 %1702 %1703
+OpStore %1110 %1700
+%1704 = OpAccessChain %_ptr_Function_ulong %1100 %uint_19
+%1705 = OpLoad %ulong %1704
+OpStore %1111 %1705
+OpBranch %1051
+%1051 = OpLabel
+%1706 = OpLoad %ulong %1111
+%1707 = OpBitwiseAnd %ulong %1706 %ulong_4095
+OpStore %1245 %1707
+%1708 = OpLoad %ulong %1245
+%1709 = OpConvertUToF %float %1708
+OpStore %1246 %1709
+%1710 = OpLoad %float %1246
+%1711 = OpFSub %float %1710 %float_2048
+OpStore %1247 %1711
+%1712 = OpLoad %float %1247
+%1713 = OpFDiv %float %1712 %float_8
+OpStore %1248 %1713
+OpBranch %1052
+%1052 = OpLabel
+%1715 = OpAccessChain %_ptr_Function_ulong %1100 %uint_20
+%1716 = OpLoad %ulong %1715
+OpStore %1112 %1716
+OpBranch %1055
+%1055 = OpLabel
+%1717 = OpLoad %ulong %1112
+%1718 = OpBitwiseAnd %ulong %1717 %ulong_4095
+OpStore %1253 %1718
+%1719 = OpLoad %ulong %1253
+%1720 = OpConvertUToF %float %1719
+OpStore %1254 %1720
+%1721 = OpLoad %float %1254
+%1722 = OpFSub %float %1721 %float_2048
+OpStore %1255 %1722
+%1723 = OpLoad %float %1255
+%1724 = OpFDiv %float %1723 %float_8
+OpStore %1256 %1724
+OpBranch %1056
+%1056 = OpLabel
+%1725 = OpAccessChain %_ptr_Function_ulong %1100 %uint_21
+%1726 = OpLoad %ulong %1725
+OpStore %1113 %1726
+OpBranch %1059
+%1059 = OpLabel
+%1727 = OpLoad %ulong %1113
+%1728 = OpBitwiseAnd %ulong %1727 %ulong_4095
+OpStore %1261 %1728
+%1729 = OpLoad %ulong %1261
+%1730 = OpConvertUToF %float %1729
+OpStore %1262 %1730
+%1731 = OpLoad %float %1262
+%1732 = OpFSub %float %1731 %float_2048
+OpStore %1263 %1732
+%1733 = OpLoad %float %1263
+%1734 = OpFDiv %float %1733 %float_8
+OpStore %1264 %1734
+OpBranch %1060
+%1060 = OpLabel
+%1736 = OpAccessChain %_ptr_Function_ulong %1100 %uint_22
+%1737 = OpLoad %ulong %1736
+OpStore %1114 %1737
+OpBranch %1063
+%1063 = OpLabel
+%1738 = OpLoad %ulong %1114
+%1739 = OpBitwiseAnd %ulong %1738 %ulong_4095
+OpStore %1269 %1739
+%1740 = OpLoad %ulong %1269
+%1741 = OpConvertUToF %float %1740
+OpStore %1270 %1741
+%1742 = OpLoad %float %1270
+%1743 = OpFSub %float %1742 %float_2048
+OpStore %1271 %1743
+%1744 = OpLoad %float %1271
+%1745 = OpFDiv %float %1744 %float_8
+OpStore %1272 %1745
+OpBranch %1064
+%1064 = OpLabel
+%1747 = OpLoad %float %1248
+%1748 = OpLoad %float %1256
+%1749 = OpLoad %float %1264
+%1750 = OpLoad %float %1272
+%1746 = OpCompositeConstruct %v4float %1747 %1748 %1749 %1750
+OpStore %1115 %1746
+%1751 = OpAccessChain %_ptr_Function_ulong %1100 %uint_23
+%1752 = OpLoad %ulong %1751
+OpStore %1116 %1752
+OpBranch %1067
+%1067 = OpLabel
+%1753 = OpLoad %ulong %1116
+%1754 = OpBitwiseAnd %ulong %1753 %ulong_4095
+OpStore %1277 %1754
+%1755 = OpLoad %ulong %1277
+%1756 = OpConvertUToF %float %1755
+OpStore %1278 %1756
+%1757 = OpLoad %float %1278
+%1758 = OpFSub %float %1757 %float_2048
+OpStore %1279 %1758
+%1759 = OpLoad %float %1279
+%1760 = OpFDiv %float %1759 %float_8
+OpStore %1280 %1760
+OpBranch %1068
+%1068 = OpLabel
+%1761 = OpAccessChain %_ptr_Function_ulong %1100 %uint_0
+%1762 = OpLoad %ulong %1761
+OpStore %1117 %1762
+%1763 = OpLoad %ulong %1117
+%1764 = OpLoad %ulong %1106
+%1765 = OpIAdd %ulong %1763 %1764
+OpStore %1118 %1765
+%1766 = OpLoad %ulong %1118
+%1767 = OpFunctionCall %float %2 %1766
+OpStore %1119 %1767
+%1769 = OpLoad %float %1280
+%1770 = OpLoad %float %1119
+%1768 = OpCompositeConstruct %v2float %1769 %1770
+OpStore %1120 %1768
+%1771 = OpLoad %ulong %1761
+OpStore %1121 %1771
+%1772 = OpLoad %ulong %1121
+%1773 = OpLoad %ulong %1106
+%1774 = OpIAdd %ulong %1772 %1773
+OpStore %1122 %1774
+%1775 = OpAccessChain %_ptr_Function_ulong %1100 %uint_1
+%1776 = OpLoad %ulong %1775
+OpStore %1123 %1776
+%1777 = OpLoad %ulong %1123
+%1778 = OpFunctionCall %float %2 %1777
+OpStore %1124 %1778
+%1779 = OpAccessChain %_ptr_Function_ulong %1100 %uint_2
+%1780 = OpLoad %ulong %1779
+OpStore %1125 %1780
+%1781 = OpLoad %ulong %1125
+%1782 = OpUConvert %uint %1781
+OpStore %1126 %1782
+%1783 = OpAccessChain %_ptr_Function_ulong %1100 %uint_3
+%1784 = OpLoad %ulong %1783
+OpStore %1127 %1784
+OpBranch %1071
+%1071 = OpLabel
+%1785 = OpLoad %ulong %1127
+%1786 = OpBitwiseAnd %ulong %1785 %ulong_1048575
+OpStore %1285 %1786
+%1787 = OpLoad %ulong %1285
+%1788 = OpConvertUToF %double %1787
+OpStore %1286 %1788
+%1789 = OpLoad %double %1286
+%1790 = OpFSub %double %1789 %double_524288
+OpStore %1287 %1790
+%1791 = OpLoad %double %1287
+%1792 = OpFDiv %double %1791 %double_64
+OpStore %1288 %1792
+OpBranch %1072
+%1072 = OpLabel
+%1793 = OpAccessChain %_ptr_Function_ulong %1100 %uint_4
+%1794 = OpLoad %ulong %1793
+OpStore %1128 %1794
+%1795 = OpAccessChain %_ptr_Function_ulong %1100 %uint_5
+%1796 = OpLoad %ulong %1795
+OpStore %1129 %1796
+%1797 = OpLoad %ulong %1129
+%1798 = OpFunctionCall %float %2 %1797
+OpStore %1130 %1798
+%1799 = OpAccessChain %_ptr_Function_ulong %1100 %uint_6
+%1800 = OpLoad %ulong %1799
+OpStore %1131 %1800
+%1801 = OpLoad %ulong %1131
+%1802 = OpUConvert %ushort %1801
+OpStore %1132 %1802
+%1803 = OpAccessChain %_ptr_Function_ulong %1100 %uint_7
+%1804 = OpLoad %ulong %1803
+OpStore %1133 %1804
+OpBranch %1075
+%1075 = OpLabel
+%1805 = OpLoad %ulong %1133
+%1806 = OpBitwiseAnd %ulong %1805 %ulong_1048575
+OpStore %1293 %1806
+%1807 = OpLoad %ulong %1293
+%1808 = OpConvertUToF %double %1807
+OpStore %1294 %1808
+%1809 = OpLoad %double %1294
+%1810 = OpFSub %double %1809 %double_524288
+OpStore %1295 %1810
+%1811 = OpLoad %double %1295
+%1812 = OpFDiv %double %1811 %double_64
+OpStore %1296 %1812
+OpBranch %1076
+%1076 = OpLabel
+%1813 = OpAccessChain %_ptr_Function_ulong %1100 %uint_8
+%1814 = OpLoad %ulong %1813
+OpStore %1134 %1814
+%1815 = OpAccessChain %_ptr_Function_ulong %1100 %uint_9
+%1816 = OpLoad %ulong %1815
+OpStore %1135 %1816
+%1817 = OpLoad %ulong %1135
+%1818 = OpFunctionCall %float %2 %1817
+OpStore %1136 %1818
+%1819 = OpAccessChain %_ptr_Function_ulong %1100 %uint_10
+%1820 = OpLoad %ulong %1819
+OpStore %1137 %1820
+%1821 = OpLoad %ulong %1137
+%1822 = OpUConvert %uchar %1821
+OpStore %1138 %1822
+%1823 = OpAccessChain %_ptr_Function_ulong %1100 %uint_11
+%1824 = OpLoad %ulong %1823
+OpStore %1139 %1824
+OpBranch %1079
+%1079 = OpLabel
+%1825 = OpLoad %ulong %1139
+%1826 = OpBitwiseAnd %ulong %1825 %ulong_1048575
+OpStore %1301 %1826
+%1827 = OpLoad %ulong %1301
+%1828 = OpConvertUToF %double %1827
+OpStore %1302 %1828
+%1829 = OpLoad %double %1302
+%1830 = OpFSub %double %1829 %double_524288
+OpStore %1303 %1830
+%1831 = OpLoad %double %1303
+%1832 = OpFDiv %double %1831 %double_64
+OpStore %1304 %1832
+OpBranch %1080
+%1080 = OpLabel
+%1833 = OpAccessChain %_ptr_Function_ulong %1100 %uint_12
+%1834 = OpLoad %ulong %1833
+OpStore %1140 %1834
+%1835 = OpAccessChain %_ptr_Function_ulong %1100 %uint_13
+%1836 = OpLoad %ulong %1835
+OpStore %1141 %1836
+%1837 = OpLoad %ulong %1141
+%1838 = OpFunctionCall %float %2 %1837
+OpStore %1142 %1838
+%1839 = OpAccessChain %_ptr_Function_ulong %1100 %uint_14
+%1840 = OpLoad %ulong %1839
+OpStore %1143 %1840
+%1841 = OpLoad %ulong %1143
+%1842 = OpUConvert %uint %1841
+OpStore %1144 %1842
+%1843 = OpAccessChain %_ptr_Function_ulong %1100 %uint_15
+%1844 = OpLoad %ulong %1843
+OpStore %1145 %1844
+OpBranch %1083
+%1083 = OpLabel
+%1845 = OpLoad %ulong %1145
+%1846 = OpBitwiseAnd %ulong %1845 %ulong_1048575
+OpStore %1309 %1846
+%1847 = OpLoad %ulong %1309
+%1848 = OpConvertUToF %double %1847
+OpStore %1310 %1848
+%1849 = OpLoad %double %1310
+%1850 = OpFSub %double %1849 %double_524288
+OpStore %1311 %1850
+%1851 = OpLoad %double %1311
+%1852 = OpFDiv %double %1851 %double_64
+OpStore %1312 %1852
+OpBranch %1084
+%1084 = OpLabel
+%1853 = OpAccessChain %_ptr_Function_ulong %1100 %uint_1
+%1854 = OpLoad %ulong %1853
+OpStore %1146 %1854
+%1855 = OpLoad %ulong %1146
+%1856 = OpLoad %ulong %1106
+%1857 = OpIAdd %ulong %1855 %1856
+OpStore %1147 %1857
+%1858 = OpLoad %ulong %1122
+%1859 = OpLoad %float %1124
+%1860 = OpLoad %uint %1126
+%1861 = OpLoad %double %1288
+%1862 = OpLoad %v3float %1110
+%1863 = OpLoad %ulong %1128
+%1864 = OpLoad %float %1130
+%1865 = OpLoad %ushort %1132
+%1866 = OpLoad %v4float %1115
+%1867 = OpLoad %double %1296
+%1868 = OpLoad %ulong %1134
+%1869 = OpLoad %float %1136
+%1870 = OpLoad %uchar %1138
+%1871 = OpLoad %double %1304
+%1872 = OpLoad %v2float %1120
+%1873 = OpLoad %ulong %1140
+%1874 = OpLoad %float %1142
+%1875 = OpLoad %uint %1144
+%1876 = OpLoad %double %1312
+%1877 = OpLoad %ulong %1147
+%1878 = OpFunctionCall %ulong %4 %1858 %1859 %1860 %1861 %1862 %1863 %1864 %1865 %1866 %1867 %1868 %1869 %1870 %1871 %1872 %1873 %1874 %1875 %1876 %1877
+OpStore %1148 %1878
+%1879 = OpLoad %ulong %1214
+%1880 = OpLoad %ulong %1148
+%1881 = OpFunctionCall %ulong %6 %1879 %1880
+OpStore %1149 %1881
+%1882 = OpLoad %ulong %1217
+%1883 = OpIAdd %ulong %1882 %ulong_1
+OpStore %1150 %1883
+%1884 = OpLoad %ulong %1149
+OpStore %1214 %1884
+%1885 = OpLoad %ulong %1148
+OpStore %1216 %1885
+%1886 = OpLoad %ulong %1150
+OpStore %1217 %1886
+OpBranch %1095
+%1030 = OpLabel
+OpBranch %1037
+%1037 = OpLabel
+%1887 = OpLoad %ulong %1215
+%1888 = OpIMul %ulong %1887 %ulong_6364136223846793005
+OpStore %1218 %1888
+%1889 = OpLoad %ulong %1218
+%1890 = OpIAdd %ulong %1889 %ulong_1442695040888963407
+OpStore %1219 %1890
+%1891 = OpLoad %ulong %1219
+%1892 = OpLoad %ulong %1101
+%1893 = OpIAdd %ulong %1891 %1892
+OpStore %1220 %1893
+OpBranch %1038
+%1038 = OpLabel
+%1894 = OpLoad %ulong %1215
+%1895 = OpAccessChain %_ptr_Function_ulong %1100 %1894
+%1896 = OpLoad %ulong %1220
+OpStore %1895 %1896
+%1897 = OpLoad %ulong %1215
+%1898 = OpIAdd %ulong %1897 %ulong_1
+OpStore %1103 %1898
+%1899 = OpLoad %ulong %1103
+OpStore %1215 %1899
+OpBranch %1096
+%1095 = OpLabel
+OpBranch %1032
+%1096 = OpLabel
+OpBranch %1029
 OpFunctionEnd
-%10 = OpFunction %ulong None %1360
-%1361 = OpFunctionParameter %ulong
-%1362 = OpFunctionParameter %uint
-%1363 = OpLabel
-%1370 = OpVariable %_ptr_Function_ulong Function
-%1371 = OpVariable %_ptr_Function_uint Function
-%1372 = OpVariable %_ptr_Function_ulong Function
-%1373 = OpVariable %_ptr_Function_bool Function
-%1374 = OpVariable %_ptr_Function_ulong Function
-%1375 = OpVariable %_ptr_Function_ulong Function
-%1376 = OpVariable %_ptr_Function_ulong Function
-%1377 = OpVariable %_ptr_Function_ulong Function
-%1378 = OpVariable %_ptr_Function_ulong Function
-%1379 = OpVariable %_ptr_Function_ulong Function
-%1380 = OpVariable %_ptr_Function_ulong Function
-%1381 = OpVariable %_ptr_Function_ulong Function
-OpStore %1370 %1361
-OpStore %1371 %1362
-%1382 = OpLoad %uint %1371
-%1383 = OpUConvert %ulong %1382
-OpStore %1372 %1383
-OpBranch %1364
-%1364 = OpLabel
-%1384 = OpLoad %ulong %1370
-OpStore %1380 %1384
-OpStore %1381 %ulong_0
-OpBranch %1365
-%1365 = OpLabel
-%1385 = OpLoad %ulong %1381
-%1386 = OpULessThan %bool %1385 %ulong_8
-OpStore %1373 %1386
-%1387 = OpLoad %bool %1373
-OpLoopMerge %1367 %1369 None
-OpBranchConditional %1387 %1366 %1367
-%1367 = OpLabel
-OpBranch %1368
-%1368 = OpLabel
-%1388 = OpLoad %ulong %1380
-OpReturnValue %1388
-%1366 = OpLabel
-%1389 = OpLoad %ulong %1381
-%1390 = OpIMul %ulong %1389 %ulong_8
-OpStore %1374 %1390
-%1391 = OpLoad %ulong %1372
-%1392 = OpLoad %ulong %1374
-%1393 = OpShiftRightLogical %ulong %1391 %1392
-OpStore %1375 %1393
-%1394 = OpLoad %ulong %1375
-%1395 = OpBitwiseAnd %ulong %1394 %ulong_255
-OpStore %1376 %1395
-%1396 = OpLoad %ulong %1380
-%1397 = OpLoad %ulong %1376
-%1398 = OpBitwiseXor %ulong %1396 %1397
-OpStore %1377 %1398
-%1399 = OpLoad %ulong %1377
-%1400 = OpIMul %ulong %1399 %ulong_1099511628211
-OpStore %1378 %1400
-%1401 = OpLoad %ulong %1381
-%1402 = OpIAdd %ulong %1401 %ulong_1
-OpStore %1379 %1402
-%1403 = OpLoad %ulong %1378
-OpStore %1380 %1403
-%1404 = OpLoad %ulong %1379
-OpStore %1381 %1404
-OpBranch %1369
-%1369 = OpLabel
-OpBranch %1365
+%6 = OpFunction %ulong None %9
+%1900 = OpFunctionParameter %ulong
+%1901 = OpFunctionParameter %ulong
+%1902 = OpLabel
+%1907 = OpVariable %_ptr_Function_ulong Function
+%1908 = OpVariable %_ptr_Function_ulong Function
+%1909 = OpVariable %_ptr_Function_bool Function
+%1910 = OpVariable %_ptr_Function_ulong Function
+%1911 = OpVariable %_ptr_Function_ulong Function
+%1912 = OpVariable %_ptr_Function_ulong Function
+%1913 = OpVariable %_ptr_Function_ulong Function
+%1914 = OpVariable %_ptr_Function_ulong Function
+%1915 = OpVariable %_ptr_Function_ulong Function
+%1916 = OpVariable %_ptr_Function_ulong Function
+%1917 = OpVariable %_ptr_Function_ulong Function
+OpStore %1907 %1900
+OpStore %1908 %1901
+%1918 = OpLoad %ulong %1907
+OpStore %1916 %1918
+OpStore %1917 %ulong_0
+OpBranch %1903
+%1903 = OpLabel
+%1919 = OpLoad %ulong %1917
+%1920 = OpULessThan %bool %1919 %ulong_8
+OpStore %1909 %1920
+%1921 = OpLoad %bool %1909
+OpLoopMerge %1905 %1906 None
+OpBranchConditional %1921 %1904 %1905
+%1905 = OpLabel
+%1922 = OpLoad %ulong %1916
+OpReturnValue %1922
+%1904 = OpLabel
+%1923 = OpLoad %ulong %1917
+%1924 = OpIMul %ulong %1923 %ulong_8
+OpStore %1910 %1924
+%1925 = OpLoad %ulong %1908
+%1926 = OpLoad %ulong %1910
+%1927 = OpShiftRightLogical %ulong %1925 %1926
+OpStore %1911 %1927
+%1928 = OpLoad %ulong %1911
+%1929 = OpBitwiseAnd %ulong %1928 %ulong_255
+OpStore %1912 %1929
+%1930 = OpLoad %ulong %1916
+%1931 = OpLoad %ulong %1912
+%1932 = OpBitwiseXor %ulong %1930 %1931
+OpStore %1913 %1932
+%1933 = OpLoad %ulong %1913
+%1934 = OpIMul %ulong %1933 %ulong_1099511628211
+OpStore %1914 %1934
+%1935 = OpLoad %ulong %1917
+%1936 = OpIAdd %ulong %1935 %ulong_1
+OpStore %1915 %1936
+%1937 = OpLoad %ulong %1914
+OpStore %1916 %1937
+%1938 = OpLoad %ulong %1915
+OpStore %1917 %1938
+OpBranch %1906
+%1906 = OpLabel
+OpBranch %1903
 OpFunctionEnd
-%11 = OpFunction %ulong None %1360
-%1405 = OpFunctionParameter %ulong
-%1406 = OpFunctionParameter %uint
-%1407 = OpLabel
-%1414 = OpVariable %_ptr_Function_ulong Function
-%1415 = OpVariable %_ptr_Function_uint Function
-%1416 = OpVariable %_ptr_Function_ulong Function
-%1417 = OpVariable %_ptr_Function_bool Function
-%1418 = OpVariable %_ptr_Function_ulong Function
-%1419 = OpVariable %_ptr_Function_ulong Function
-%1420 = OpVariable %_ptr_Function_ulong Function
-%1421 = OpVariable %_ptr_Function_ulong Function
-%1422 = OpVariable %_ptr_Function_ulong Function
-%1423 = OpVariable %_ptr_Function_ulong Function
-%1424 = OpVariable %_ptr_Function_ulong Function
-%1425 = OpVariable %_ptr_Function_ulong Function
-OpStore %1414 %1405
-OpStore %1415 %1406
-%1426 = OpLoad %uint %1415
-%1427 = OpSConvert %ulong %1426
-OpStore %1416 %1427
-OpBranch %1408
-%1408 = OpLabel
-%1428 = OpLoad %ulong %1414
-OpStore %1424 %1428
-OpStore %1425 %ulong_0
-OpBranch %1409
-%1409 = OpLabel
-%1429 = OpLoad %ulong %1425
-%1430 = OpULessThan %bool %1429 %ulong_8
-OpStore %1417 %1430
-%1431 = OpLoad %bool %1417
-OpLoopMerge %1411 %1413 None
-OpBranchConditional %1431 %1410 %1411
-%1411 = OpLabel
-OpBranch %1412
-%1412 = OpLabel
-%1432 = OpLoad %ulong %1424
-OpReturnValue %1432
-%1410 = OpLabel
-%1433 = OpLoad %ulong %1425
-%1434 = OpIMul %ulong %1433 %ulong_8
-OpStore %1418 %1434
-%1435 = OpLoad %ulong %1416
-%1436 = OpLoad %ulong %1418
-%1437 = OpShiftRightLogical %ulong %1435 %1436
-OpStore %1419 %1437
-%1438 = OpLoad %ulong %1419
-%1439 = OpBitwiseAnd %ulong %1438 %ulong_255
-OpStore %1420 %1439
-%1440 = OpLoad %ulong %1424
-%1441 = OpLoad %ulong %1420
-%1442 = OpBitwiseXor %ulong %1440 %1441
-OpStore %1421 %1442
-%1443 = OpLoad %ulong %1421
-%1444 = OpIMul %ulong %1443 %ulong_1099511628211
-OpStore %1422 %1444
-%1445 = OpLoad %ulong %1425
-%1446 = OpIAdd %ulong %1445 %ulong_1
-OpStore %1423 %1446
-%1447 = OpLoad %ulong %1422
-OpStore %1424 %1447
-%1448 = OpLoad %ulong %1423
-OpStore %1425 %1448
-OpBranch %1413
-%1413 = OpLabel
-OpBranch %1409
-OpFunctionEnd
-%12 = OpFunction %ulong None %16
-%1449 = OpFunctionParameter %ulong
-%1450 = OpFunctionParameter %ulong
-%1451 = OpLabel
-%1458 = OpVariable %_ptr_Function_ulong Function
-%1459 = OpVariable %_ptr_Function_ulong Function
-%1460 = OpVariable %_ptr_Function_bool Function
-%1461 = OpVariable %_ptr_Function_ulong Function
-%1462 = OpVariable %_ptr_Function_ulong Function
-%1463 = OpVariable %_ptr_Function_ulong Function
-%1464 = OpVariable %_ptr_Function_ulong Function
-%1465 = OpVariable %_ptr_Function_ulong Function
-%1466 = OpVariable %_ptr_Function_ulong Function
-%1467 = OpVariable %_ptr_Function_ulong Function
-%1468 = OpVariable %_ptr_Function_ulong Function
-OpStore %1458 %1449
-OpStore %1459 %1450
-OpBranch %1452
-%1452 = OpLabel
-%1469 = OpLoad %ulong %1458
-OpStore %1467 %1469
-OpStore %1468 %ulong_0
-OpBranch %1453
-%1453 = OpLabel
-%1470 = OpLoad %ulong %1468
-%1471 = OpULessThan %bool %1470 %ulong_8
-OpStore %1460 %1471
-%1472 = OpLoad %bool %1460
-OpLoopMerge %1455 %1457 None
-OpBranchConditional %1472 %1454 %1455
-%1455 = OpLabel
-OpBranch %1456
-%1456 = OpLabel
-%1473 = OpLoad %ulong %1467
-OpReturnValue %1473
-%1454 = OpLabel
-%1474 = OpLoad %ulong %1468
-%1475 = OpIMul %ulong %1474 %ulong_8
-OpStore %1461 %1475
-%1476 = OpLoad %ulong %1459
-%1477 = OpLoad %ulong %1461
-%1478 = OpShiftRightLogical %ulong %1476 %1477
-OpStore %1462 %1478
-%1479 = OpLoad %ulong %1462
-%1480 = OpBitwiseAnd %ulong %1479 %ulong_255
-OpStore %1463 %1480
-%1481 = OpLoad %ulong %1467
-%1482 = OpLoad %ulong %1463
-%1483 = OpBitwiseXor %ulong %1481 %1482
-OpStore %1464 %1483
-%1484 = OpLoad %ulong %1464
-%1485 = OpIMul %ulong %1484 %ulong_1099511628211
-OpStore %1465 %1485
-%1486 = OpLoad %ulong %1468
-%1487 = OpIAdd %ulong %1486 %ulong_1
-OpStore %1466 %1487
-%1488 = OpLoad %ulong %1465
-OpStore %1467 %1488
-%1489 = OpLoad %ulong %1466
-OpStore %1468 %1489
-OpBranch %1457
-%1457 = OpLabel
-OpBranch %1453
-OpFunctionEnd
-%13 = OpFunction %ulong None %1490
-%1491 = OpFunctionParameter %ulong
-%1492 = OpFunctionParameter %float
-%1493 = OpLabel
-%1500 = OpVariable %_ptr_Function_ulong Function
-%1501 = OpVariable %_ptr_Function_float Function
-%1502 = OpVariable %_ptr_Function_uint Function
-%1503 = OpVariable %_ptr_Function_ulong Function
-%1504 = OpVariable %_ptr_Function_bool Function
-%1505 = OpVariable %_ptr_Function_ulong Function
-%1506 = OpVariable %_ptr_Function_ulong Function
-%1507 = OpVariable %_ptr_Function_ulong Function
-%1508 = OpVariable %_ptr_Function_ulong Function
-%1509 = OpVariable %_ptr_Function_ulong Function
-%1510 = OpVariable %_ptr_Function_ulong Function
-%1511 = OpVariable %_ptr_Function_ulong Function
-%1512 = OpVariable %_ptr_Function_ulong Function
-OpStore %1500 %1491
-OpStore %1501 %1492
-%1513 = OpLoad %float %1501
-%1514 = OpBitcast %uint %1513
-OpStore %1502 %1514
-%1515 = OpLoad %uint %1502
-%1516 = OpUConvert %ulong %1515
-OpStore %1503 %1516
-OpBranch %1494
-%1494 = OpLabel
-%1517 = OpLoad %ulong %1500
-OpStore %1511 %1517
-OpStore %1512 %ulong_0
-OpBranch %1495
-%1495 = OpLabel
-%1518 = OpLoad %ulong %1512
-%1519 = OpULessThan %bool %1518 %ulong_8
-OpStore %1504 %1519
-%1520 = OpLoad %bool %1504
-OpLoopMerge %1497 %1499 None
-OpBranchConditional %1520 %1496 %1497
-%1497 = OpLabel
-OpBranch %1498
-%1498 = OpLabel
-%1521 = OpLoad %ulong %1511
-OpReturnValue %1521
-%1496 = OpLabel
-%1522 = OpLoad %ulong %1512
-%1523 = OpIMul %ulong %1522 %ulong_8
-OpStore %1505 %1523
-%1524 = OpLoad %ulong %1503
-%1525 = OpLoad %ulong %1505
-%1526 = OpShiftRightLogical %ulong %1524 %1525
-OpStore %1506 %1526
-%1527 = OpLoad %ulong %1506
-%1528 = OpBitwiseAnd %ulong %1527 %ulong_255
-OpStore %1507 %1528
-%1529 = OpLoad %ulong %1511
-%1530 = OpLoad %ulong %1507
-%1531 = OpBitwiseXor %ulong %1529 %1530
-OpStore %1508 %1531
-%1532 = OpLoad %ulong %1508
-%1533 = OpIMul %ulong %1532 %ulong_1099511628211
-OpStore %1509 %1533
-%1534 = OpLoad %ulong %1512
-%1535 = OpIAdd %ulong %1534 %ulong_1
-OpStore %1510 %1535
-%1536 = OpLoad %ulong %1509
-OpStore %1511 %1536
-%1537 = OpLoad %ulong %1510
-OpStore %1512 %1537
-OpBranch %1499
-%1499 = OpLabel
-OpBranch %1495
-OpFunctionEnd
-%14 = OpFunction %ulong None %1538
-%1539 = OpFunctionParameter %ulong
-%1540 = OpFunctionParameter %double
-%1541 = OpLabel
-%1548 = OpVariable %_ptr_Function_ulong Function
-%1549 = OpVariable %_ptr_Function_double Function
-%1550 = OpVariable %_ptr_Function_ulong Function
-%1551 = OpVariable %_ptr_Function_bool Function
-%1552 = OpVariable %_ptr_Function_ulong Function
-%1553 = OpVariable %_ptr_Function_ulong Function
-%1554 = OpVariable %_ptr_Function_ulong Function
-%1555 = OpVariable %_ptr_Function_ulong Function
-%1556 = OpVariable %_ptr_Function_ulong Function
-%1557 = OpVariable %_ptr_Function_ulong Function
-%1558 = OpVariable %_ptr_Function_ulong Function
-%1559 = OpVariable %_ptr_Function_ulong Function
-OpStore %1548 %1539
-OpStore %1549 %1540
-%1560 = OpLoad %double %1549
-%1561 = OpBitcast %ulong %1560
-OpStore %1550 %1561
-OpBranch %1542
-%1542 = OpLabel
-%1562 = OpLoad %ulong %1548
-OpStore %1558 %1562
-OpStore %1559 %ulong_0
-OpBranch %1543
-%1543 = OpLabel
-%1563 = OpLoad %ulong %1559
-%1564 = OpULessThan %bool %1563 %ulong_8
-OpStore %1551 %1564
-%1565 = OpLoad %bool %1551
-OpLoopMerge %1545 %1547 None
-OpBranchConditional %1565 %1544 %1545
-%1545 = OpLabel
-OpBranch %1546
-%1546 = OpLabel
-%1566 = OpLoad %ulong %1558
-OpReturnValue %1566
-%1544 = OpLabel
-%1567 = OpLoad %ulong %1559
-%1568 = OpIMul %ulong %1567 %ulong_8
-OpStore %1552 %1568
-%1569 = OpLoad %ulong %1550
-%1570 = OpLoad %ulong %1552
-%1571 = OpShiftRightLogical %ulong %1569 %1570
-OpStore %1553 %1571
-%1572 = OpLoad %ulong %1553
-%1573 = OpBitwiseAnd %ulong %1572 %ulong_255
-OpStore %1554 %1573
-%1574 = OpLoad %ulong %1558
-%1575 = OpLoad %ulong %1554
-%1576 = OpBitwiseXor %ulong %1574 %1575
-OpStore %1555 %1576
-%1577 = OpLoad %ulong %1555
-%1578 = OpIMul %ulong %1577 %ulong_1099511628211
-OpStore %1556 %1578
-%1579 = OpLoad %ulong %1559
-%1580 = OpIAdd %ulong %1579 %ulong_1
-OpStore %1557 %1580
-%1581 = OpLoad %ulong %1556
-OpStore %1558 %1581
-%1582 = OpLoad %ulong %1557
-OpStore %1559 %1582
-OpBranch %1547
-%1547 = OpLabel
-OpBranch %1543
+%7 = OpFunction %ulong None %1939
+%1940 = OpFunctionParameter %ulong
+%1941 = OpFunctionParameter %float
+%1942 = OpLabel
+%1949 = OpVariable %_ptr_Function_ulong Function
+%1950 = OpVariable %_ptr_Function_float Function
+%1951 = OpVariable %_ptr_Function_uint Function
+%1952 = OpVariable %_ptr_Function_ulong Function
+%1953 = OpVariable %_ptr_Function_bool Function
+%1954 = OpVariable %_ptr_Function_ulong Function
+%1955 = OpVariable %_ptr_Function_ulong Function
+%1956 = OpVariable %_ptr_Function_ulong Function
+%1957 = OpVariable %_ptr_Function_ulong Function
+%1958 = OpVariable %_ptr_Function_ulong Function
+%1959 = OpVariable %_ptr_Function_ulong Function
+%1960 = OpVariable %_ptr_Function_ulong Function
+%1961 = OpVariable %_ptr_Function_ulong Function
+OpStore %1949 %1940
+OpStore %1950 %1941
+%1962 = OpLoad %float %1950
+%1963 = OpBitcast %uint %1962
+OpStore %1951 %1963
+%1964 = OpLoad %uint %1951
+%1965 = OpUConvert %ulong %1964
+OpStore %1952 %1965
+OpBranch %1943
+%1943 = OpLabel
+%1966 = OpLoad %ulong %1949
+OpStore %1960 %1966
+OpStore %1961 %ulong_0
+OpBranch %1944
+%1944 = OpLabel
+%1967 = OpLoad %ulong %1961
+%1968 = OpULessThan %bool %1967 %ulong_8
+OpStore %1953 %1968
+%1969 = OpLoad %bool %1953
+OpLoopMerge %1946 %1948 None
+OpBranchConditional %1969 %1945 %1946
+%1946 = OpLabel
+OpBranch %1947
+%1947 = OpLabel
+%1970 = OpLoad %ulong %1960
+OpReturnValue %1970
+%1945 = OpLabel
+%1971 = OpLoad %ulong %1961
+%1972 = OpIMul %ulong %1971 %ulong_8
+OpStore %1954 %1972
+%1973 = OpLoad %ulong %1952
+%1974 = OpLoad %ulong %1954
+%1975 = OpShiftRightLogical %ulong %1973 %1974
+OpStore %1955 %1975
+%1976 = OpLoad %ulong %1955
+%1977 = OpBitwiseAnd %ulong %1976 %ulong_255
+OpStore %1956 %1977
+%1978 = OpLoad %ulong %1960
+%1979 = OpLoad %ulong %1956
+%1980 = OpBitwiseXor %ulong %1978 %1979
+OpStore %1957 %1980
+%1981 = OpLoad %ulong %1957
+%1982 = OpIMul %ulong %1981 %ulong_1099511628211
+OpStore %1958 %1982
+%1983 = OpLoad %ulong %1961
+%1984 = OpIAdd %ulong %1983 %ulong_1
+OpStore %1959 %1984
+%1985 = OpLoad %ulong %1958
+OpStore %1960 %1985
+%1986 = OpLoad %ulong %1959
+OpStore %1961 %1986
+OpBranch %1948
+%1948 = OpLabel
+OpBranch %1944
 OpFunctionEnd

--- a/test/golden/spirv/call/call_rec_edge.dis
+++ b/test/golden/spirv/call/call_rec_edge.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 2072
+; Bound: 2438
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -26,7 +26,7 @@ OpDecorate %14 LinkageAttributes "corpus.cases.call.call_rec_edge.mk16m" Export
 OpDecorate %15 LinkageAttributes "corpus.cases.call.call_rec_edge.mk17" Export
 OpDecorate %16 LinkageAttributes "corpus.cases.call.call_rec_edge.checksum" Export
 %ulong = OpTypeInt 64 0
-%24 = OpTypeFunction %ulong %ulong %ulong
+%19 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
@@ -34,10 +34,10 @@ OpDecorate %16 LinkageAttributes "corpus.cases.call.call_rec_edge.checksum" Expo
 %uint = OpTypeInt 32 0
 %uint_8 = OpConstant %uint 8
 %_arr_uchar_uint_8 = OpTypeArray %uchar %uint_8
-%_struct_48 = OpTypeStruct %uchar %_arr_uchar_uint_8
-%49 = OpTypeFunction %ulong %ulong %_struct_48
+%_struct_43 = OpTypeStruct %uchar %_arr_uchar_uint_8
+%44 = OpTypeFunction %ulong %ulong %_struct_43
 %bool = OpTypeBool
-%_ptr_Function__struct_48 = OpTypePointer Function %_struct_48
+%_ptr_Function__struct_43 = OpTypePointer Function %_struct_43
 %_ptr_Function__arr_uchar_uint_8 = OpTypePointer Function %_arr_uchar_uint_8
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
@@ -46,2921 +46,3516 @@ OpDecorate %16 LinkageAttributes "corpus.cases.call.call_rec_edge.checksum" Expo
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_1 = OpConstant %ulong 1
-%_struct_100 = OpTypeStruct %uint %uint %uint
-%101 = OpTypeFunction %ulong %ulong %_struct_100
-%_ptr_Function__struct_100 = OpTypePointer Function %_struct_100
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%_struct_169 = OpTypeStruct %uint %uint %uint
+%170 = OpTypeFunction %ulong %ulong %_struct_169
+%_ptr_Function__struct_169 = OpTypePointer Function %_struct_169
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uint_2 = OpConstant %uint 2
-%_struct_132 = OpTypeStruct %ulong %ulong
-%133 = OpTypeFunction %ulong %ulong %_struct_132
-%_ptr_Function__struct_132 = OpTypePointer Function %_struct_132
+%_struct_309 = OpTypeStruct %ulong %ulong
+%310 = OpTypeFunction %ulong %ulong %_struct_309
+%_ptr_Function__struct_309 = OpTypePointer Function %_struct_309
 %double = OpTypeFloat 64
-%_struct_156 = OpTypeStruct %double %double
-%157 = OpTypeFunction %ulong %ulong %_struct_156
-%_ptr_Function__struct_156 = OpTypePointer Function %_struct_156
+%_struct_395 = OpTypeStruct %double %double
+%396 = OpTypeFunction %ulong %ulong %_struct_395
+%_ptr_Function__struct_395 = OpTypePointer Function %_struct_395
 %_ptr_Function_double = OpTypePointer Function %double
-%_struct_180 = OpTypeStruct %ulong %double
-%181 = OpTypeFunction %ulong %ulong %_struct_180
-%_ptr_Function__struct_180 = OpTypePointer Function %_struct_180
+%_struct_491 = OpTypeStruct %ulong %double
+%492 = OpTypeFunction %ulong %ulong %_struct_491
+%_ptr_Function__struct_491 = OpTypePointer Function %_struct_491
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
-%_struct_205 = OpTypeStruct %uchar %_arr_uchar_uint_16
-%206 = OpTypeFunction %ulong %ulong %_struct_205
-%_ptr_Function__struct_205 = OpTypePointer Function %_struct_205
+%_struct_583 = OpTypeStruct %uchar %_arr_uchar_uint_16
+%584 = OpTypeFunction %ulong %ulong %_struct_583
+%_ptr_Function__struct_583 = OpTypePointer Function %_struct_583
 %ulong_16 = OpConstant %ulong 16
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
-%250 = OpTypeFunction %ulong %ulong
-%ulong_9 = OpConstant %ulong 9
-%ulong_12 = OpConstant %ulong 12
+%700 = OpTypeFunction %ulong %ulong
 %ulong_17 = OpConstant %ulong 17
 %ulong_4 = OpConstant %ulong 4
+%ulong_12 = OpConstant %ulong 12
+%ulong_9 = OpConstant %ulong 9
 %float = OpTypeFloat 32
-%314 = OpTypeFunction %ulong %ulong %_struct_48 %uint %_struct_100 %double %_struct_132 %_struct_156 %_struct_180 %ulong %_struct_205 %_struct_48 %_struct_100 %_struct_132 %_struct_205 %float %ulong
+%857 = OpTypeFunction %ulong %ulong %_struct_43 %uint %_struct_169 %double %_struct_309 %_struct_395 %_struct_491 %ulong %_struct_583 %_struct_43 %_struct_169 %_struct_309 %_struct_583 %float %ulong
 %_ptr_Function_float = OpTypePointer Function %float
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar_1 = OpConstant %uchar 1
-%763 = OpTypeFunction %_struct_48 %ulong
-%782 = OpConstantNull %_struct_48
-%811 = OpTypeFunction %_struct_100 %ulong
+%1225 = OpTypeFunction %_struct_43 %ulong
+%1244 = OpConstantNull %_struct_43
+%1273 = OpTypeFunction %_struct_169 %ulong
 %ulong_32 = OpConstant %ulong 32
-%839 = OpTypeFunction %_struct_132 %ulong
+%1301 = OpTypeFunction %_struct_309 %ulong
 %ulong_3 = OpConstant %ulong 3
 %ulong_7 = OpConstant %ulong 7
-%857 = OpTypeFunction %_struct_156 %ulong
+%1319 = OpTypeFunction %_struct_395 %ulong
 %ulong_65535 = OpConstant %ulong 65535
 %double_8 = OpConstant %double 8
 %ulong_4095 = OpConstant %ulong 4095
 %double_2048 = OpConstant %double 2048
-%889 = OpTypeFunction %_struct_180 %ulong
+%1351 = OpTypeFunction %_struct_491 %ulong
 %ulong_305419896 = OpConstant %ulong 305419896
 %ulong_262143 = OpConstant %ulong 262143
 %double_64 = OpConstant %double 64
-%914 = OpTypeFunction %_struct_205 %ulong
-%934 = OpConstantNull %_struct_205
+%1376 = OpTypeFunction %_struct_583 %ulong
+%1396 = OpConstantNull %_struct_583
 %uint_12 = OpConstant %uint 12
 %_arr_ulong_uint_12 = OpTypeArray %ulong %uint_12
 %_ptr_Function__arr_ulong_uint_12 = OpTypePointer Function %_arr_ulong_uint_12
-%1316 = OpConstantNull %_arr_ulong_uint_12
+%1825 = OpConstantNull %_arr_ulong_uint_12
 %ulong_1023 = OpConstant %ulong 1023
 %uint_10 = OpConstant %uint 10
 %uint_11 = OpConstant %uint 11
-%ulong_255 = OpConstant %ulong 255
 %uint_4 = OpConstant %uint 4
 %uint_3 = OpConstant %uint 3
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
 %uint_7 = OpConstant %uint 7
 %uint_9 = OpConstant %uint 9
-%1846 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1889 = OpTypeFunction %ulong %ulong %uchar
-%1934 = OpTypeFunction %ulong %ulong %uint
-%1979 = OpTypeFunction %ulong %ulong %float
-%2027 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %24
-%25 = OpFunctionParameter %ulong
-%26 = OpFunctionParameter %ulong
-%27 = OpLabel
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-OpStore %29 %25
-OpStore %30 %26
-%34 = OpLoad %ulong %30
-%36 = OpIMul %ulong %34 %ulong_6364136223846793005
-OpStore %31 %36
-%37 = OpLoad %ulong %31
-%39 = OpIAdd %ulong %37 %ulong_1442695040888963407
-OpStore %32 %39
-%40 = OpLoad %ulong %32
-%41 = OpLoad %ulong %29
-%42 = OpIAdd %ulong %40 %41
-OpStore %33 %42
-%43 = OpLoad %ulong %33
-OpReturnValue %43
+%1 = OpFunction %ulong None %19
+%20 = OpFunctionParameter %ulong
+%21 = OpFunctionParameter %ulong
+%22 = OpLabel
+%24 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_ulong Function
+%26 = OpVariable %_ptr_Function_ulong Function
+%27 = OpVariable %_ptr_Function_ulong Function
+%28 = OpVariable %_ptr_Function_ulong Function
+OpStore %24 %20
+OpStore %25 %21
+%29 = OpLoad %ulong %25
+%31 = OpIMul %ulong %29 %ulong_6364136223846793005
+OpStore %26 %31
+%32 = OpLoad %ulong %26
+%34 = OpIAdd %ulong %32 %ulong_1442695040888963407
+OpStore %27 %34
+%35 = OpLoad %ulong %27
+%36 = OpLoad %ulong %24
+%37 = OpIAdd %ulong %35 %36
+OpStore %28 %37
+%38 = OpLoad %ulong %28
+OpReturnValue %38
 OpFunctionEnd
-%2 = OpFunction %ulong None %49
-%50 = OpFunctionParameter %ulong
-%51 = OpFunctionParameter %_struct_48
-%52 = OpLabel
-%59 = OpVariable %_ptr_Function__struct_48 Function
-%61 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_bool Function
-%67 = OpVariable %_ptr_Function_uchar Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_uchar Function
-OpStore %62 %50
-OpStore %59 %51
-%74 = OpAccessChain %_ptr_Function_uchar %59 %uint_0
-%75 = OpLoad %uchar %74
-OpStore %72 %75
-%77 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %59 %uint_1
-%78 = OpLoad %_arr_uchar_uint_8 %77
-OpStore %61 %78
-%79 = OpLoad %ulong %62
-%80 = OpLoad %uchar %72
-%81 = OpFunctionCall %ulong %19 %79 %80
-OpStore %63 %81
-%82 = OpLoad %ulong %63
-OpStore %70 %82
-OpStore %71 %ulong_0
-OpBranch %53
-%53 = OpLabel
-%84 = OpLoad %ulong %71
-%86 = OpULessThan %bool %84 %ulong_8
-OpStore %65 %86
-%87 = OpLoad %bool %65
-OpLoopMerge %55 %56 None
-OpBranchConditional %87 %54 %55
+%2 = OpFunction %ulong None %44
+%45 = OpFunctionParameter %ulong
+%46 = OpFunctionParameter %_struct_43
+%47 = OpLabel
+%70 = OpVariable %_ptr_Function__struct_43 Function
+%72 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_bool Function
+%77 = OpVariable %_ptr_Function_uchar Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_bool Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_uchar Function
+OpStore %73 %45
+OpStore %70 %46
+%103 = OpAccessChain %_ptr_Function_uchar %70 %uint_0
+%104 = OpLoad %uchar %103
+OpStore %101 %104
+%106 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %70 %uint_1
+%107 = OpLoad %_arr_uchar_uint_8 %106
+OpStore %72 %107
+OpBranch %51
+%51 = OpLabel
+%108 = OpLoad %uchar %101
+%109 = OpUConvert %ulong %108
+OpStore %81 %109
+OpBranch %55
 %55 = OpLabel
-%88 = OpLoad %ulong %70
-OpReturnValue %88
-%54 = OpLabel
-%89 = OpLoad %ulong %71
-%90 = OpAccessChain %_ptr_Function_uchar %61 %89
-%91 = OpLoad %uchar %90
-OpStore %67 %91
-%92 = OpLoad %ulong %70
-%93 = OpLoad %uchar %67
-%94 = OpFunctionCall %ulong %19 %92 %93
-OpStore %68 %94
-%95 = OpLoad %ulong %71
-%97 = OpIAdd %ulong %95 %ulong_1
-OpStore %69 %97
-%98 = OpLoad %ulong %68
-OpStore %70 %98
-%99 = OpLoad %ulong %69
-OpStore %71 %99
+%110 = OpLoad %ulong %73
+OpStore %90 %110
+OpStore %91 %ulong_0
 OpBranch %56
 %56 = OpLabel
+%112 = OpLoad %ulong %91
+%114 = OpULessThan %bool %112 %ulong_8
+OpStore %83 %114
+%115 = OpLoad %bool %83
+OpLoopMerge %58 %67 None
+OpBranchConditional %115 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %52
+%52 = OpLabel
+%116 = OpLoad %ulong %90
+OpStore %79 %116
+OpStore %80 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%117 = OpLoad %ulong %80
+%118 = OpULessThan %bool %117 %ulong_8
+OpStore %75 %118
+%119 = OpLoad %bool %75
+OpLoopMerge %50 %66 None
+OpBranchConditional %119 %49 %50
+%50 = OpLabel
+%120 = OpLoad %ulong %79
+OpReturnValue %120
+%49 = OpLabel
+%121 = OpLoad %ulong %80
+%122 = OpAccessChain %_ptr_Function_uchar %72 %121
+%123 = OpLoad %uchar %122
+OpStore %77 %123
 OpBranch %53
+%53 = OpLabel
+%124 = OpLoad %uchar %77
+%125 = OpUConvert %ulong %124
+OpStore %82 %125
+OpBranch %60
+%60 = OpLabel
+%126 = OpLoad %ulong %79
+OpStore %99 %126
+OpStore %100 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%127 = OpLoad %ulong %100
+%128 = OpULessThan %bool %127 %ulong_8
+OpStore %92 %128
+%129 = OpLoad %bool %92
+OpLoopMerge %63 %65 None
+OpBranchConditional %129 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%130 = OpLoad %ulong %80
+%132 = OpIAdd %ulong %130 %ulong_1
+OpStore %78 %132
+%133 = OpLoad %ulong %99
+OpStore %79 %133
+%134 = OpLoad %ulong %78
+OpStore %80 %134
+OpBranch %66
+%62 = OpLabel
+%135 = OpLoad %ulong %100
+%136 = OpIMul %ulong %135 %ulong_8
+OpStore %93 %136
+%137 = OpLoad %ulong %82
+%138 = OpLoad %ulong %93
+%139 = OpShiftRightLogical %ulong %137 %138
+OpStore %94 %139
+%140 = OpLoad %ulong %94
+%142 = OpBitwiseAnd %ulong %140 %ulong_255
+OpStore %95 %142
+%143 = OpLoad %ulong %99
+%144 = OpLoad %ulong %95
+%145 = OpBitwiseXor %ulong %143 %144
+OpStore %96 %145
+%146 = OpLoad %ulong %96
+%148 = OpIMul %ulong %146 %ulong_1099511628211
+OpStore %97 %148
+%149 = OpLoad %ulong %100
+%150 = OpIAdd %ulong %149 %ulong_1
+OpStore %98 %150
+%151 = OpLoad %ulong %97
+OpStore %99 %151
+%152 = OpLoad %ulong %98
+OpStore %100 %152
+OpBranch %65
+%57 = OpLabel
+%153 = OpLoad %ulong %91
+%154 = OpIMul %ulong %153 %ulong_8
+OpStore %84 %154
+%155 = OpLoad %ulong %81
+%156 = OpLoad %ulong %84
+%157 = OpShiftRightLogical %ulong %155 %156
+OpStore %85 %157
+%158 = OpLoad %ulong %85
+%159 = OpBitwiseAnd %ulong %158 %ulong_255
+OpStore %86 %159
+%160 = OpLoad %ulong %90
+%161 = OpLoad %ulong %86
+%162 = OpBitwiseXor %ulong %160 %161
+OpStore %87 %162
+%163 = OpLoad %ulong %87
+%164 = OpIMul %ulong %163 %ulong_1099511628211
+OpStore %88 %164
+%165 = OpLoad %ulong %91
+%166 = OpIAdd %ulong %165 %ulong_1
+OpStore %89 %166
+%167 = OpLoad %ulong %88
+OpStore %90 %167
+%168 = OpLoad %ulong %89
+OpStore %91 %168
+OpBranch %67
+%65 = OpLabel
+OpBranch %61
+%66 = OpLabel
+OpBranch %48
+%67 = OpLabel
+OpBranch %56
 OpFunctionEnd
-%3 = OpFunction %ulong None %101
-%102 = OpFunctionParameter %ulong
-%103 = OpFunctionParameter %_struct_100
-%104 = OpLabel
-%106 = OpVariable %_ptr_Function__struct_100 Function
-%107 = OpVariable %_ptr_Function_ulong Function
-%108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_ulong Function
-%110 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_uint Function
-%113 = OpVariable %_ptr_Function_uint Function
-%114 = OpVariable %_ptr_Function_uint Function
-OpStore %107 %102
-OpStore %106 %103
-%115 = OpAccessChain %_ptr_Function_uint %106 %uint_0
-%116 = OpLoad %uint %115
-OpStore %112 %116
-%117 = OpAccessChain %_ptr_Function_uint %106 %uint_1
-%118 = OpLoad %uint %117
-OpStore %113 %118
-%120 = OpAccessChain %_ptr_Function_uint %106 %uint_2
-%121 = OpLoad %uint %120
-OpStore %114 %121
-%122 = OpLoad %ulong %107
-%123 = OpLoad %uint %112
-%124 = OpFunctionCall %ulong %20 %122 %123
-OpStore %108 %124
-%125 = OpLoad %ulong %108
-%126 = OpLoad %uint %113
-%127 = OpFunctionCall %ulong %20 %125 %126
-OpStore %109 %127
-%128 = OpLoad %ulong %109
-%129 = OpLoad %uint %114
-%130 = OpFunctionCall %ulong %20 %128 %129
-OpStore %110 %130
-%131 = OpLoad %ulong %110
-OpReturnValue %131
-OpFunctionEnd
-%4 = OpFunction %ulong None %133
-%134 = OpFunctionParameter %ulong
-%135 = OpFunctionParameter %_struct_132
-%136 = OpLabel
-%138 = OpVariable %_ptr_Function__struct_132 Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_ulong Function
-OpStore %139 %134
-OpStore %138 %135
-%144 = OpAccessChain %_ptr_Function_ulong %138 %uint_0
-%145 = OpLoad %ulong %144
-OpStore %142 %145
-%146 = OpAccessChain %_ptr_Function_ulong %138 %uint_1
-%147 = OpLoad %ulong %146
-OpStore %143 %147
-%148 = OpLoad %ulong %139
-%149 = OpLoad %ulong %142
-%150 = OpFunctionCall %ulong %18 %148 %149
-OpStore %140 %150
-%151 = OpLoad %ulong %140
-%152 = OpLoad %ulong %143
-%153 = OpFunctionCall %ulong %18 %151 %152
-OpStore %141 %153
-%154 = OpLoad %ulong %141
-OpReturnValue %154
-OpFunctionEnd
-%5 = OpFunction %ulong None %157
-%158 = OpFunctionParameter %ulong
-%159 = OpFunctionParameter %_struct_156
-%160 = OpLabel
-%162 = OpVariable %_ptr_Function__struct_156 Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_double Function
-%168 = OpVariable %_ptr_Function_double Function
-OpStore %163 %158
-OpStore %162 %159
-%169 = OpAccessChain %_ptr_Function_double %162 %uint_0
-%170 = OpLoad %double %169
-OpStore %167 %170
-%171 = OpAccessChain %_ptr_Function_double %162 %uint_1
-%172 = OpLoad %double %171
-OpStore %168 %172
-%173 = OpLoad %ulong %163
-%174 = OpLoad %double %167
-%175 = OpFunctionCall %ulong %22 %173 %174
-OpStore %164 %175
-%176 = OpLoad %ulong %164
-%177 = OpLoad %double %168
-%178 = OpFunctionCall %ulong %22 %176 %177
-OpStore %165 %178
-%179 = OpLoad %ulong %165
-OpReturnValue %179
-OpFunctionEnd
-%6 = OpFunction %ulong None %181
-%182 = OpFunctionParameter %ulong
-%183 = OpFunctionParameter %_struct_180
-%184 = OpLabel
-%186 = OpVariable %_ptr_Function__struct_180 Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_double Function
-OpStore %187 %182
-OpStore %186 %183
-%192 = OpAccessChain %_ptr_Function_ulong %186 %uint_0
-%193 = OpLoad %ulong %192
-OpStore %190 %193
-%194 = OpAccessChain %_ptr_Function_double %186 %uint_1
-%195 = OpLoad %double %194
-OpStore %191 %195
-%196 = OpLoad %ulong %187
-%197 = OpLoad %ulong %190
-%198 = OpFunctionCall %ulong %18 %196 %197
-OpStore %188 %198
-%199 = OpLoad %ulong %188
-%200 = OpLoad %double %191
-%201 = OpFunctionCall %ulong %22 %199 %200
-OpStore %189 %201
-%202 = OpLoad %ulong %189
-OpReturnValue %202
-OpFunctionEnd
-%7 = OpFunction %ulong None %206
-%207 = OpFunctionParameter %ulong
-%208 = OpFunctionParameter %_struct_205
-%209 = OpLabel
-%215 = OpVariable %_ptr_Function__struct_205 Function
-%216 = OpVariable %_ptr_Function__struct_205 Function
+%3 = OpFunction %ulong None %170
+%171 = OpFunctionParameter %ulong
+%172 = OpFunctionParameter %_struct_169
+%173 = OpLabel
+%199 = OpVariable %_ptr_Function__struct_169 Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_bool Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_bool Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
 %217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_uchar Function
+%218 = OpVariable %_ptr_Function_ulong Function
 %219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_bool Function
-%221 = OpVariable %_ptr_Function_uchar Function
-%222 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_bool Function
 %223 = OpVariable %_ptr_Function_ulong Function
 %224 = OpVariable %_ptr_Function_ulong Function
 %225 = OpVariable %_ptr_Function_ulong Function
-OpStore %217 %207
-OpStore %215 %208
-%226 = OpLoad %_struct_205 %215
-OpStore %216 %226
-%227 = OpAccessChain %_ptr_Function_uchar %216 %uint_0
-%228 = OpLoad %uchar %227
-OpStore %218 %228
-%229 = OpLoad %ulong %217
-%230 = OpLoad %uchar %218
-%231 = OpFunctionCall %ulong %19 %229 %230
-OpStore %219 %231
-%232 = OpLoad %ulong %219
-OpStore %224 %232
-OpStore %225 %ulong_0
-OpBranch %210
-%210 = OpLabel
-%233 = OpLoad %ulong %225
-%235 = OpULessThan %bool %233 %ulong_16
-OpStore %220 %235
-%236 = OpLoad %bool %220
-OpLoopMerge %212 %213 None
-OpBranchConditional %236 %211 %212
-%212 = OpLabel
-%237 = OpLoad %ulong %224
-OpReturnValue %237
-%211 = OpLabel
-%239 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %216 %uint_1
-%240 = OpLoad %ulong %225
-%241 = OpAccessChain %_ptr_Function_uchar %239 %240
-%242 = OpLoad %uchar %241
-OpStore %221 %242
-%243 = OpLoad %ulong %224
-%244 = OpLoad %uchar %221
-%245 = OpFunctionCall %ulong %19 %243 %244
-OpStore %222 %245
-%246 = OpLoad %ulong %225
-%247 = OpIAdd %ulong %246 %ulong_1
-OpStore %223 %247
-%248 = OpLoad %ulong %222
-OpStore %224 %248
-%249 = OpLoad %ulong %223
-OpStore %225 %249
-OpBranch %213
-%213 = OpLabel
-OpBranch %210
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_uint Function
+%233 = OpVariable %_ptr_Function_uint Function
+%234 = OpVariable %_ptr_Function_uint Function
+OpStore %200 %171
+OpStore %199 %172
+%235 = OpAccessChain %_ptr_Function_uint %199 %uint_0
+%236 = OpLoad %uint %235
+OpStore %232 %236
+%237 = OpAccessChain %_ptr_Function_uint %199 %uint_1
+%238 = OpLoad %uint %237
+OpStore %233 %238
+%240 = OpAccessChain %_ptr_Function_uint %199 %uint_2
+%241 = OpLoad %uint %240
+OpStore %234 %241
+OpBranch %174
+%174 = OpLabel
+%242 = OpLoad %uint %232
+%243 = OpUConvert %ulong %242
+OpStore %201 %243
+OpBranch %176
+%176 = OpLabel
+%244 = OpLoad %ulong %200
+OpStore %209 %244
+OpStore %210 %ulong_0
+OpBranch %177
+%177 = OpLabel
+%245 = OpLoad %ulong %210
+%246 = OpULessThan %bool %245 %ulong_8
+OpStore %202 %246
+%247 = OpLoad %bool %202
+OpLoopMerge %179 %197 None
+OpBranchConditional %247 %178 %179
+%179 = OpLabel
+OpBranch %180
+%180 = OpLabel
+OpBranch %175
+%175 = OpLabel
+OpBranch %181
+%181 = OpLabel
+%248 = OpLoad %uint %233
+%249 = OpUConvert %ulong %248
+OpStore %211 %249
+OpBranch %183
+%183 = OpLabel
+%250 = OpLoad %ulong %209
+OpStore %219 %250
+OpStore %220 %ulong_0
+OpBranch %184
+%184 = OpLabel
+%251 = OpLoad %ulong %220
+%252 = OpULessThan %bool %251 %ulong_8
+OpStore %212 %252
+%253 = OpLoad %bool %212
+OpLoopMerge %186 %196 None
+OpBranchConditional %253 %185 %186
+%186 = OpLabel
+OpBranch %187
+%187 = OpLabel
+OpBranch %182
+%182 = OpLabel
+OpBranch %188
+%188 = OpLabel
+%254 = OpLoad %uint %234
+%255 = OpUConvert %ulong %254
+OpStore %221 %255
+OpBranch %190
+%190 = OpLabel
+%256 = OpLoad %ulong %219
+OpStore %229 %256
+OpStore %230 %ulong_0
+OpBranch %191
+%191 = OpLabel
+%257 = OpLoad %ulong %230
+%258 = OpULessThan %bool %257 %ulong_8
+OpStore %222 %258
+%259 = OpLoad %bool %222
+OpLoopMerge %193 %195 None
+OpBranchConditional %259 %192 %193
+%193 = OpLabel
+OpBranch %194
+%194 = OpLabel
+OpBranch %189
+%189 = OpLabel
+%260 = OpLoad %ulong %229
+OpReturnValue %260
+%192 = OpLabel
+%261 = OpLoad %ulong %230
+%262 = OpIMul %ulong %261 %ulong_8
+OpStore %223 %262
+%263 = OpLoad %ulong %221
+%264 = OpLoad %ulong %223
+%265 = OpShiftRightLogical %ulong %263 %264
+OpStore %224 %265
+%266 = OpLoad %ulong %224
+%267 = OpBitwiseAnd %ulong %266 %ulong_255
+OpStore %225 %267
+%268 = OpLoad %ulong %229
+%269 = OpLoad %ulong %225
+%270 = OpBitwiseXor %ulong %268 %269
+OpStore %226 %270
+%271 = OpLoad %ulong %226
+%272 = OpIMul %ulong %271 %ulong_1099511628211
+OpStore %227 %272
+%273 = OpLoad %ulong %230
+%274 = OpIAdd %ulong %273 %ulong_1
+OpStore %228 %274
+%275 = OpLoad %ulong %227
+OpStore %229 %275
+%276 = OpLoad %ulong %228
+OpStore %230 %276
+OpBranch %195
+%185 = OpLabel
+%277 = OpLoad %ulong %220
+%278 = OpIMul %ulong %277 %ulong_8
+OpStore %213 %278
+%279 = OpLoad %ulong %211
+%280 = OpLoad %ulong %213
+%281 = OpShiftRightLogical %ulong %279 %280
+OpStore %214 %281
+%282 = OpLoad %ulong %214
+%283 = OpBitwiseAnd %ulong %282 %ulong_255
+OpStore %215 %283
+%284 = OpLoad %ulong %219
+%285 = OpLoad %ulong %215
+%286 = OpBitwiseXor %ulong %284 %285
+OpStore %216 %286
+%287 = OpLoad %ulong %216
+%288 = OpIMul %ulong %287 %ulong_1099511628211
+OpStore %217 %288
+%289 = OpLoad %ulong %220
+%290 = OpIAdd %ulong %289 %ulong_1
+OpStore %218 %290
+%291 = OpLoad %ulong %217
+OpStore %219 %291
+%292 = OpLoad %ulong %218
+OpStore %220 %292
+OpBranch %196
+%178 = OpLabel
+%293 = OpLoad %ulong %210
+%294 = OpIMul %ulong %293 %ulong_8
+OpStore %203 %294
+%295 = OpLoad %ulong %201
+%296 = OpLoad %ulong %203
+%297 = OpShiftRightLogical %ulong %295 %296
+OpStore %204 %297
+%298 = OpLoad %ulong %204
+%299 = OpBitwiseAnd %ulong %298 %ulong_255
+OpStore %205 %299
+%300 = OpLoad %ulong %209
+%301 = OpLoad %ulong %205
+%302 = OpBitwiseXor %ulong %300 %301
+OpStore %206 %302
+%303 = OpLoad %ulong %206
+%304 = OpIMul %ulong %303 %ulong_1099511628211
+OpStore %207 %304
+%305 = OpLoad %ulong %210
+%306 = OpIAdd %ulong %305 %ulong_1
+OpStore %208 %306
+%307 = OpLoad %ulong %207
+OpStore %209 %307
+%308 = OpLoad %ulong %208
+OpStore %210 %308
+OpBranch %197
+%195 = OpLabel
+OpBranch %191
+%196 = OpLabel
+OpBranch %184
+%197 = OpLabel
+OpBranch %177
 OpFunctionEnd
-%8 = OpFunction %ulong None %250
-%251 = OpFunctionParameter %ulong
-%252 = OpLabel
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ulong Function
-OpStore %253 %251
-%272 = OpLoad %ulong %253
-%274 = OpFunctionCall %ulong %18 %272 %ulong_9
-OpStore %254 %274
-%275 = OpLoad %ulong %254
-%277 = OpFunctionCall %ulong %18 %275 %ulong_12
-OpStore %255 %277
-%278 = OpLoad %ulong %255
-%279 = OpFunctionCall %ulong %18 %278 %ulong_16
-OpStore %256 %279
-%280 = OpLoad %ulong %256
-%281 = OpFunctionCall %ulong %18 %280 %ulong_16
-OpStore %257 %281
-%282 = OpLoad %ulong %257
-%283 = OpFunctionCall %ulong %18 %282 %ulong_16
-OpStore %258 %283
-%284 = OpLoad %ulong %258
-%286 = OpFunctionCall %ulong %18 %284 %ulong_17
-OpStore %259 %286
-%287 = OpLoad %ulong %259
-%288 = OpFunctionCall %ulong %18 %287 %ulong_1
-OpStore %260 %288
-%289 = OpLoad %ulong %260
-%291 = OpFunctionCall %ulong %18 %289 %ulong_4
-OpStore %261 %291
-%292 = OpLoad %ulong %261
-%293 = OpFunctionCall %ulong %18 %292 %ulong_8
-OpStore %262 %293
-%294 = OpLoad %ulong %262
-%295 = OpFunctionCall %ulong %18 %294 %ulong_8
-OpStore %263 %295
-%296 = OpLoad %ulong %263
-%297 = OpFunctionCall %ulong %18 %296 %ulong_8
-OpStore %264 %297
-%298 = OpLoad %ulong %264
-%299 = OpFunctionCall %ulong %18 %298 %ulong_1
-OpStore %265 %299
-%300 = OpLoad %ulong %265
-%301 = OpFunctionCall %ulong %18 %300 %ulong_1
-OpStore %266 %301
-%302 = OpLoad %ulong %266
-%303 = OpFunctionCall %ulong %18 %302 %ulong_8
-OpStore %267 %303
-%304 = OpLoad %ulong %267
-%305 = OpFunctionCall %ulong %18 %304 %ulong_8
-OpStore %268 %305
-%306 = OpLoad %ulong %268
-%307 = OpFunctionCall %ulong %18 %306 %ulong_8
-OpStore %269 %307
-%308 = OpLoad %ulong %269
-%309 = OpFunctionCall %ulong %18 %308 %ulong_8
-OpStore %270 %309
-%310 = OpLoad %ulong %270
-%311 = OpFunctionCall %ulong %18 %310 %ulong_1
-OpStore %271 %311
-%312 = OpLoad %ulong %271
-OpReturnValue %312
+%4 = OpFunction %ulong None %310
+%311 = OpFunctionParameter %ulong
+%312 = OpFunctionParameter %_struct_309
+%313 = OpLabel
+%327 = OpVariable %_ptr_Function__struct_309 Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_bool Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_bool Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+OpStore %328 %311
+OpStore %327 %312
+%349 = OpAccessChain %_ptr_Function_ulong %327 %uint_0
+%350 = OpLoad %ulong %349
+OpStore %347 %350
+%351 = OpAccessChain %_ptr_Function_ulong %327 %uint_1
+%352 = OpLoad %ulong %351
+OpStore %348 %352
+OpBranch %314
+%314 = OpLabel
+%353 = OpLoad %ulong %328
+OpStore %336 %353
+OpStore %337 %ulong_0
+OpBranch %315
+%315 = OpLabel
+%354 = OpLoad %ulong %337
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %329 %355
+%356 = OpLoad %bool %329
+OpLoopMerge %317 %325 None
+OpBranchConditional %356 %316 %317
+%317 = OpLabel
+OpBranch %318
+%318 = OpLabel
+OpBranch %319
+%319 = OpLabel
+%357 = OpLoad %ulong %336
+OpStore %345 %357
+OpStore %346 %ulong_0
+OpBranch %320
+%320 = OpLabel
+%358 = OpLoad %ulong %346
+%359 = OpULessThan %bool %358 %ulong_8
+OpStore %338 %359
+%360 = OpLoad %bool %338
+OpLoopMerge %322 %324 None
+OpBranchConditional %360 %321 %322
+%322 = OpLabel
+OpBranch %323
+%323 = OpLabel
+%361 = OpLoad %ulong %345
+OpReturnValue %361
+%321 = OpLabel
+%362 = OpLoad %ulong %346
+%363 = OpIMul %ulong %362 %ulong_8
+OpStore %339 %363
+%364 = OpLoad %ulong %348
+%365 = OpLoad %ulong %339
+%366 = OpShiftRightLogical %ulong %364 %365
+OpStore %340 %366
+%367 = OpLoad %ulong %340
+%368 = OpBitwiseAnd %ulong %367 %ulong_255
+OpStore %341 %368
+%369 = OpLoad %ulong %345
+%370 = OpLoad %ulong %341
+%371 = OpBitwiseXor %ulong %369 %370
+OpStore %342 %371
+%372 = OpLoad %ulong %342
+%373 = OpIMul %ulong %372 %ulong_1099511628211
+OpStore %343 %373
+%374 = OpLoad %ulong %346
+%375 = OpIAdd %ulong %374 %ulong_1
+OpStore %344 %375
+%376 = OpLoad %ulong %343
+OpStore %345 %376
+%377 = OpLoad %ulong %344
+OpStore %346 %377
+OpBranch %324
+%316 = OpLabel
+%378 = OpLoad %ulong %337
+%379 = OpIMul %ulong %378 %ulong_8
+OpStore %330 %379
+%380 = OpLoad %ulong %347
+%381 = OpLoad %ulong %330
+%382 = OpShiftRightLogical %ulong %380 %381
+OpStore %331 %382
+%383 = OpLoad %ulong %331
+%384 = OpBitwiseAnd %ulong %383 %ulong_255
+OpStore %332 %384
+%385 = OpLoad %ulong %336
+%386 = OpLoad %ulong %332
+%387 = OpBitwiseXor %ulong %385 %386
+OpStore %333 %387
+%388 = OpLoad %ulong %333
+%389 = OpIMul %ulong %388 %ulong_1099511628211
+OpStore %334 %389
+%390 = OpLoad %ulong %337
+%391 = OpIAdd %ulong %390 %ulong_1
+OpStore %335 %391
+%392 = OpLoad %ulong %334
+OpStore %336 %392
+%393 = OpLoad %ulong %335
+OpStore %337 %393
+OpBranch %325
+%324 = OpLabel
+OpBranch %320
+%325 = OpLabel
+OpBranch %315
 OpFunctionEnd
-%9 = OpFunction %ulong None %314
-%315 = OpFunctionParameter %ulong
-%316 = OpFunctionParameter %_struct_48
-%317 = OpFunctionParameter %uint
-%318 = OpFunctionParameter %_struct_100
-%319 = OpFunctionParameter %double
-%320 = OpFunctionParameter %_struct_132
-%321 = OpFunctionParameter %_struct_156
-%322 = OpFunctionParameter %_struct_180
-%323 = OpFunctionParameter %ulong
-%324 = OpFunctionParameter %_struct_205
-%325 = OpFunctionParameter %_struct_48
-%326 = OpFunctionParameter %_struct_100
-%327 = OpFunctionParameter %_struct_132
-%328 = OpFunctionParameter %_struct_205
-%329 = OpFunctionParameter %float
-%330 = OpFunctionParameter %ulong
-%331 = OpLabel
-%384 = OpVariable %_ptr_Function__struct_48 Function
-%385 = OpVariable %_ptr_Function__struct_100 Function
-%386 = OpVariable %_ptr_Function__struct_132 Function
-%387 = OpVariable %_ptr_Function__struct_156 Function
-%388 = OpVariable %_ptr_Function__struct_180 Function
-%389 = OpVariable %_ptr_Function__struct_205 Function
-%390 = OpVariable %_ptr_Function__struct_48 Function
-%391 = OpVariable %_ptr_Function__struct_100 Function
-%392 = OpVariable %_ptr_Function__struct_132 Function
-%393 = OpVariable %_ptr_Function__struct_205 Function
-%394 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%395 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%396 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%397 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%398 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%399 = OpVariable %_ptr_Function__arr_uchar_uint_8 Function
-%400 = OpVariable %_ptr_Function__struct_205 Function
-%401 = OpVariable %_ptr_Function__struct_205 Function
-%402 = OpVariable %_ptr_Function__struct_205 Function
-%403 = OpVariable %_ptr_Function__struct_205 Function
-%404 = OpVariable %_ptr_Function__struct_205 Function
-%405 = OpVariable %_ptr_Function__struct_205 Function
-%406 = OpVariable %_ptr_Function__struct_205 Function
-%407 = OpVariable %_ptr_Function__struct_205 Function
-%408 = OpVariable %_ptr_Function__struct_205 Function
-%409 = OpVariable %_ptr_Function__struct_205 Function
-%410 = OpVariable %_ptr_Function__struct_205 Function
-%411 = OpVariable %_ptr_Function__struct_205 Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_uint Function
-%414 = OpVariable %_ptr_Function_double Function
-%415 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_float Function
+%5 = OpFunction %ulong None %396
+%397 = OpFunctionParameter %ulong
+%398 = OpFunctionParameter %_struct_395
+%399 = OpLabel
+%417 = OpVariable %_ptr_Function__struct_395 Function
 %418 = OpVariable %_ptr_Function_ulong Function
 %419 = OpVariable %_ptr_Function_ulong Function
-%420 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_bool Function
 %421 = OpVariable %_ptr_Function_ulong Function
 %422 = OpVariable %_ptr_Function_ulong Function
 %423 = OpVariable %_ptr_Function_ulong Function
 %424 = OpVariable %_ptr_Function_ulong Function
 %425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_uchar Function
-%427 = OpVariable %_ptr_Function_uchar Function
-%428 = OpVariable %_ptr_Function_bool Function
-%429 = OpVariable %_ptr_Function_uchar Function
-%430 = OpVariable %_ptr_Function_uchar Function
-%431 = OpVariable %_ptr_Function_uchar Function
-%432 = OpVariable %_ptr_Function_uchar Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_bool Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
 %433 = OpVariable %_ptr_Function_ulong Function
 %434 = OpVariable %_ptr_Function_ulong Function
 %435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_bool Function
-%437 = OpVariable %_ptr_Function_uchar Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
 %438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_ulong Function
-%442 = OpVariable %_ptr_Function_uchar Function
-%443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_bool Function
-%445 = OpVariable %_ptr_Function_uchar Function
-%446 = OpVariable %_ptr_Function_ulong Function
-%447 = OpVariable %_ptr_Function_ulong Function
-%448 = OpVariable %_ptr_Function_ulong Function
-%449 = OpVariable %_ptr_Function_ulong Function
-%450 = OpVariable %_ptr_Function_ulong Function
-%451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_uchar Function
-%454 = OpVariable %_ptr_Function_ulong Function
-%455 = OpVariable %_ptr_Function_bool Function
-%456 = OpVariable %_ptr_Function_uchar Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_uchar Function
-%468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_bool Function
-%470 = OpVariable %_ptr_Function_uchar Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_ulong Function
-%473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_ulong Function
-%476 = OpVariable %_ptr_Function_bool Function
-%477 = OpVariable %_ptr_Function_uchar Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_ulong Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_uchar Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_bool Function
-%490 = OpVariable %_ptr_Function_uchar Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_uchar Function
-%496 = OpVariable %_ptr_Function_uint Function
-%497 = OpVariable %_ptr_Function_uint Function
-%498 = OpVariable %_ptr_Function_uint Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_ulong Function
-%501 = OpVariable %_ptr_Function_double Function
-%502 = OpVariable %_ptr_Function_double Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_double Function
-%505 = OpVariable %_ptr_Function_uchar Function
-%506 = OpVariable %_ptr_Function_uint Function
-%507 = OpVariable %_ptr_Function_uint Function
-%508 = OpVariable %_ptr_Function_uint Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-OpStore %412 %315
-OpStore %384 %316
-OpStore %413 %317
-OpStore %385 %318
-OpStore %414 %319
-OpStore %386 %320
-OpStore %387 %321
-OpStore %388 %322
-OpStore %415 %323
-OpStore %389 %324
-OpStore %390 %325
-OpStore %391 %326
-OpStore %392 %327
-OpStore %393 %328
-OpStore %417 %329
-OpStore %418 %330
-%511 = OpAccessChain %_ptr_Function_uchar %384 %uint_0
-%512 = OpLoad %uchar %511
-OpStore %495 %512
-%513 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %384 %uint_1
-%514 = OpLoad %_arr_uchar_uint_8 %513
-OpStore %394 %514
-%515 = OpAccessChain %_ptr_Function_uint %385 %uint_0
-%516 = OpLoad %uint %515
-OpStore %496 %516
-%517 = OpAccessChain %_ptr_Function_uint %385 %uint_1
-%518 = OpLoad %uint %517
-OpStore %497 %518
-%519 = OpAccessChain %_ptr_Function_uint %385 %uint_2
-%520 = OpLoad %uint %519
-OpStore %498 %520
-%521 = OpAccessChain %_ptr_Function_ulong %386 %uint_0
-%522 = OpLoad %ulong %521
-OpStore %499 %522
-%523 = OpAccessChain %_ptr_Function_ulong %386 %uint_1
-%524 = OpLoad %ulong %523
-OpStore %500 %524
-%525 = OpAccessChain %_ptr_Function_double %387 %uint_0
-%526 = OpLoad %double %525
-OpStore %501 %526
-%527 = OpAccessChain %_ptr_Function_double %387 %uint_1
-%528 = OpLoad %double %527
-OpStore %502 %528
-%529 = OpAccessChain %_ptr_Function_ulong %388 %uint_0
-%530 = OpLoad %ulong %529
-OpStore %503 %530
-%531 = OpAccessChain %_ptr_Function_double %388 %uint_1
-%532 = OpLoad %double %531
-OpStore %504 %532
-%533 = OpLoad %_struct_205 %389
-OpStore %400 %533
-%534 = OpAccessChain %_ptr_Function_uchar %390 %uint_0
-%535 = OpLoad %uchar %534
-OpStore %505 %535
-%536 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %390 %uint_1
-%537 = OpLoad %_arr_uchar_uint_8 %536
-OpStore %395 %537
-%538 = OpAccessChain %_ptr_Function_uint %391 %uint_0
-%539 = OpLoad %uint %538
-OpStore %506 %539
-%540 = OpAccessChain %_ptr_Function_uint %391 %uint_1
-%541 = OpLoad %uint %540
-OpStore %507 %541
-%542 = OpAccessChain %_ptr_Function_uint %391 %uint_2
-%543 = OpLoad %uint %542
-OpStore %508 %543
-%544 = OpAccessChain %_ptr_Function_ulong %392 %uint_0
-%545 = OpLoad %ulong %544
-OpStore %509 %545
-%546 = OpAccessChain %_ptr_Function_ulong %392 %uint_1
-%547 = OpLoad %ulong %546
-OpStore %510 %547
-%548 = OpLoad %_struct_205 %393
-OpStore %401 %548
-%549 = OpFunctionCall %ulong %17
-OpStore %419 %549
-%550 = OpLoad %ulong %419
-%551 = OpLoad %ulong %412
-%552 = OpFunctionCall %ulong %18 %550 %551
-OpStore %420 %552
-%553 = OpLoad %_arr_uchar_uint_8 %394
-OpStore %396 %553
-OpBranch %335
-%335 = OpLabel
-%554 = OpLoad %_arr_uchar_uint_8 %396
-OpStore %398 %554
-%555 = OpLoad %ulong %420
-%556 = OpLoad %uchar %495
-%557 = OpFunctionCall %ulong %19 %555 %556
-OpStore %435 %557
-%558 = OpLoad %ulong %435
-OpStore %440 %558
-OpStore %441 %ulong_0
-OpBranch %336
-%336 = OpLabel
-%559 = OpLoad %ulong %441
-%560 = OpULessThan %bool %559 %ulong_8
-OpStore %436 %560
-%561 = OpLoad %bool %436
-OpLoopMerge %338 %383 None
-OpBranchConditional %561 %337 %338
-%338 = OpLabel
-OpBranch %339
-%339 = OpLabel
-%562 = OpLoad %ulong %440
-%563 = OpLoad %uint %413
-%564 = OpFunctionCall %ulong %20 %562 %563
-OpStore %421 %564
-OpBranch %345
-%345 = OpLabel
-%565 = OpLoad %ulong %421
-%566 = OpLoad %uint %496
-%567 = OpFunctionCall %ulong %20 %565 %566
-OpStore %450 %567
-%568 = OpLoad %ulong %450
-%569 = OpLoad %uint %497
-%570 = OpFunctionCall %ulong %20 %568 %569
-OpStore %451 %570
-%571 = OpLoad %ulong %451
-%572 = OpLoad %uint %498
-%573 = OpFunctionCall %ulong %20 %571 %572
-OpStore %452 %573
-OpBranch %346
-%346 = OpLabel
-%574 = OpLoad %ulong %452
-%575 = OpLoad %double %414
-%576 = OpFunctionCall %ulong %22 %574 %575
-OpStore %422 %576
-OpBranch %352
-%352 = OpLabel
-%577 = OpLoad %ulong %422
-%578 = OpLoad %ulong %499
-%579 = OpFunctionCall %ulong %18 %577 %578
-OpStore %461 %579
-%580 = OpLoad %ulong %461
-%581 = OpLoad %ulong %500
-%582 = OpFunctionCall %ulong %18 %580 %581
-OpStore %462 %582
-OpBranch %353
-%353 = OpLabel
-OpBranch %354
-%354 = OpLabel
-%583 = OpLoad %ulong %462
-%584 = OpLoad %double %501
-%585 = OpFunctionCall %ulong %22 %583 %584
-OpStore %463 %585
-%586 = OpLoad %ulong %463
-%587 = OpLoad %double %502
-%588 = OpFunctionCall %ulong %22 %586 %587
-OpStore %464 %588
-OpBranch %355
-%355 = OpLabel
-OpBranch %356
-%356 = OpLabel
-%589 = OpLoad %ulong %464
-%590 = OpLoad %ulong %503
-%591 = OpFunctionCall %ulong %18 %589 %590
-OpStore %465 %591
-%592 = OpLoad %ulong %465
-%593 = OpLoad %double %504
-%594 = OpFunctionCall %ulong %22 %592 %593
-OpStore %466 %594
-OpBranch %357
-%357 = OpLabel
-%595 = OpLoad %ulong %466
-%596 = OpLoad %ulong %415
-%597 = OpFunctionCall %ulong %18 %595 %596
-OpStore %423 %597
-%598 = OpLoad %_struct_205 %400
-OpStore %406 %598
-OpBranch %358
-%358 = OpLabel
-%599 = OpLoad %_struct_205 %406
-OpStore %407 %599
-%600 = OpAccessChain %_ptr_Function_uchar %407 %uint_0
-%601 = OpLoad %uchar %600
-OpStore %467 %601
-%602 = OpLoad %ulong %423
-%603 = OpLoad %uchar %467
-%604 = OpFunctionCall %ulong %19 %602 %603
-OpStore %468 %604
-%605 = OpLoad %ulong %468
-OpStore %473 %605
-OpStore %474 %ulong_0
-OpBranch %359
-%359 = OpLabel
-%606 = OpLoad %ulong %474
-%607 = OpULessThan %bool %606 %ulong_16
-OpStore %469 %607
-%608 = OpLoad %bool %469
-OpLoopMerge %361 %382 None
-OpBranchConditional %608 %360 %361
-%361 = OpLabel
-OpBranch %362
-%362 = OpLabel
-%609 = OpLoad %_arr_uchar_uint_8 %395
-OpStore %397 %609
-OpBranch %363
-%363 = OpLabel
-%610 = OpLoad %_arr_uchar_uint_8 %397
-OpStore %399 %610
-%611 = OpLoad %ulong %473
-%612 = OpLoad %uchar %505
-%613 = OpFunctionCall %ulong %19 %611 %612
-OpStore %475 %613
-%614 = OpLoad %ulong %475
-OpStore %480 %614
-OpStore %481 %ulong_0
-OpBranch %364
-%364 = OpLabel
-%615 = OpLoad %ulong %481
-%616 = OpULessThan %bool %615 %ulong_8
-OpStore %476 %616
-%617 = OpLoad %bool %476
-OpLoopMerge %366 %381 None
-OpBranchConditional %617 %365 %366
-%366 = OpLabel
-OpBranch %367
-%367 = OpLabel
-OpBranch %368
-%368 = OpLabel
-%618 = OpLoad %ulong %480
-%619 = OpLoad %uint %506
-%620 = OpFunctionCall %ulong %20 %618 %619
-OpStore %482 %620
-%621 = OpLoad %ulong %482
-%622 = OpLoad %uint %507
-%623 = OpFunctionCall %ulong %20 %621 %622
-OpStore %483 %623
-%624 = OpLoad %ulong %483
-%625 = OpLoad %uint %508
-%626 = OpFunctionCall %ulong %20 %624 %625
-OpStore %484 %626
-OpBranch %369
-%369 = OpLabel
-OpBranch %370
-%370 = OpLabel
-%627 = OpLoad %ulong %484
-%628 = OpLoad %ulong %509
-%629 = OpFunctionCall %ulong %18 %627 %628
-OpStore %485 %629
-%630 = OpLoad %ulong %485
-%631 = OpLoad %ulong %510
-%632 = OpFunctionCall %ulong %18 %630 %631
-OpStore %486 %632
-OpBranch %371
-%371 = OpLabel
-%633 = OpLoad %_struct_205 %401
-OpStore %408 %633
-OpBranch %372
-%372 = OpLabel
-%634 = OpLoad %_struct_205 %408
-OpStore %409 %634
-%635 = OpAccessChain %_ptr_Function_uchar %409 %uint_0
-%636 = OpLoad %uchar %635
-OpStore %487 %636
-%637 = OpLoad %ulong %486
-%638 = OpLoad %uchar %487
-%639 = OpFunctionCall %ulong %19 %637 %638
-OpStore %488 %639
-%640 = OpLoad %ulong %488
-OpStore %493 %640
-OpStore %494 %ulong_0
-OpBranch %373
-%373 = OpLabel
-%641 = OpLoad %ulong %494
-%642 = OpULessThan %bool %641 %ulong_16
-OpStore %489 %642
-%643 = OpLoad %bool %489
-OpLoopMerge %375 %380 None
-OpBranchConditional %643 %374 %375
-%375 = OpLabel
-OpBranch %376
-%376 = OpLabel
-%644 = OpLoad %ulong %493
-%645 = OpLoad %float %417
-%646 = OpFunctionCall %ulong %21 %644 %645
-OpStore %424 %646
-%647 = OpLoad %ulong %424
-%648 = OpLoad %ulong %418
-%649 = OpFunctionCall %ulong %18 %647 %648
-OpStore %425 %649
-%650 = OpLoad %_struct_205 %400
-OpStore %411 %650
-%651 = OpLoad %_struct_205 %411
-OpStore %410 %651
-%652 = OpAccessChain %_ptr_Function_uchar %410 %uint_0
-%653 = OpLoad %uchar %652
-OpStore %426 %653
-%654 = OpLoad %uchar %426
-%656 = OpIAdd %uchar %654 %uchar_1
-OpStore %427 %656
-%657 = OpLoad %uchar %427
-OpStore %652 %657
-OpStore %434 %ulong_0
-OpBranch %332
-%332 = OpLabel
-%658 = OpLoad %ulong %434
-%659 = OpULessThan %bool %658 %ulong_16
-OpStore %428 %659
-%660 = OpLoad %bool %428
-OpLoopMerge %334 %379 None
-OpBranchConditional %660 %333 %334
-%334 = OpLabel
-%661 = OpLoad %_struct_205 %410
-OpStore %402 %661
-OpBranch %340
-%340 = OpLabel
-%662 = OpLoad %_struct_205 %402
-OpStore %403 %662
-%663 = OpAccessChain %_ptr_Function_uchar %403 %uint_0
-%664 = OpLoad %uchar %663
-OpStore %442 %664
-%665 = OpLoad %ulong %425
-%666 = OpLoad %uchar %442
-%667 = OpFunctionCall %ulong %19 %665 %666
-OpStore %443 %667
-%668 = OpLoad %ulong %443
-OpStore %448 %668
-OpStore %449 %ulong_0
-OpBranch %341
-%341 = OpLabel
-%669 = OpLoad %ulong %449
-%670 = OpULessThan %bool %669 %ulong_16
-OpStore %444 %670
-%671 = OpLoad %bool %444
-OpLoopMerge %343 %378 None
-OpBranchConditional %671 %342 %343
-%343 = OpLabel
-OpBranch %344
-%344 = OpLabel
-%672 = OpLoad %_struct_205 %400
-OpStore %404 %672
-OpBranch %347
-%347 = OpLabel
-%673 = OpLoad %_struct_205 %404
-OpStore %405 %673
-%674 = OpAccessChain %_ptr_Function_uchar %405 %uint_0
-%675 = OpLoad %uchar %674
-OpStore %453 %675
-%676 = OpLoad %ulong %448
-%677 = OpLoad %uchar %453
-%678 = OpFunctionCall %ulong %19 %676 %677
-OpStore %454 %678
-%679 = OpLoad %ulong %454
-OpStore %459 %679
-OpStore %460 %ulong_0
-OpBranch %348
-%348 = OpLabel
-%680 = OpLoad %ulong %460
-%681 = OpULessThan %bool %680 %ulong_16
-OpStore %455 %681
-%682 = OpLoad %bool %455
-OpLoopMerge %350 %377 None
-OpBranchConditional %682 %349 %350
-%350 = OpLabel
-OpBranch %351
-%351 = OpLabel
-%683 = OpLoad %ulong %459
-OpReturnValue %683
-%349 = OpLabel
-%684 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %405 %uint_1
-%685 = OpLoad %ulong %460
-%686 = OpAccessChain %_ptr_Function_uchar %684 %685
-%687 = OpLoad %uchar %686
-OpStore %456 %687
-%688 = OpLoad %ulong %459
-%689 = OpLoad %uchar %456
-%690 = OpFunctionCall %ulong %19 %688 %689
-OpStore %457 %690
-%691 = OpLoad %ulong %460
-%692 = OpIAdd %ulong %691 %ulong_1
-OpStore %458 %692
-%693 = OpLoad %ulong %457
-OpStore %459 %693
-%694 = OpLoad %ulong %458
-OpStore %460 %694
-OpBranch %377
-%342 = OpLabel
-%695 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %403 %uint_1
-%696 = OpLoad %ulong %449
-%697 = OpAccessChain %_ptr_Function_uchar %695 %696
-%698 = OpLoad %uchar %697
-OpStore %445 %698
-%699 = OpLoad %ulong %448
-%700 = OpLoad %uchar %445
-%701 = OpFunctionCall %ulong %19 %699 %700
-OpStore %446 %701
-%702 = OpLoad %ulong %449
-%703 = OpIAdd %ulong %702 %ulong_1
-OpStore %447 %703
-%704 = OpLoad %ulong %446
-OpStore %448 %704
-%705 = OpLoad %ulong %447
-OpStore %449 %705
-OpBranch %378
-%333 = OpLabel
-%706 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %410 %uint_1
-%707 = OpLoad %ulong %434
-%708 = OpAccessChain %_ptr_Function_uchar %706 %707
-%709 = OpLoad %uchar %708
-OpStore %429 %709
-%710 = OpLoad %ulong %434
-%711 = OpUConvert %uchar %710
-OpStore %430 %711
-%712 = OpLoad %uchar %429
-%713 = OpLoad %uchar %430
-%714 = OpIAdd %uchar %712 %713
-OpStore %431 %714
-%715 = OpLoad %uchar %431
-%716 = OpIAdd %uchar %715 %uchar_1
-OpStore %432 %716
-%717 = OpLoad %uchar %432
-OpStore %708 %717
-%718 = OpLoad %ulong %434
-%719 = OpIAdd %ulong %718 %ulong_1
-OpStore %433 %719
-%720 = OpLoad %ulong %433
-OpStore %434 %720
-OpBranch %379
-%374 = OpLabel
-%721 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %409 %uint_1
-%722 = OpLoad %ulong %494
-%723 = OpAccessChain %_ptr_Function_uchar %721 %722
-%724 = OpLoad %uchar %723
-OpStore %490 %724
-%725 = OpLoad %ulong %493
-%726 = OpLoad %uchar %490
-%727 = OpFunctionCall %ulong %19 %725 %726
-OpStore %491 %727
-%728 = OpLoad %ulong %494
-%729 = OpIAdd %ulong %728 %ulong_1
-OpStore %492 %729
-%730 = OpLoad %ulong %491
-OpStore %493 %730
-%731 = OpLoad %ulong %492
-OpStore %494 %731
-OpBranch %380
-%365 = OpLabel
-%732 = OpLoad %ulong %481
-%733 = OpAccessChain %_ptr_Function_uchar %399 %732
-%734 = OpLoad %uchar %733
-OpStore %477 %734
-%735 = OpLoad %ulong %480
-%736 = OpLoad %uchar %477
-%737 = OpFunctionCall %ulong %19 %735 %736
-OpStore %478 %737
-%738 = OpLoad %ulong %481
-%739 = OpIAdd %ulong %738 %ulong_1
-OpStore %479 %739
-%740 = OpLoad %ulong %478
-OpStore %480 %740
-%741 = OpLoad %ulong %479
-OpStore %481 %741
-OpBranch %381
-%360 = OpLabel
-%742 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %407 %uint_1
-%743 = OpLoad %ulong %474
-%744 = OpAccessChain %_ptr_Function_uchar %742 %743
-%745 = OpLoad %uchar %744
-OpStore %470 %745
-%746 = OpLoad %ulong %473
-%747 = OpLoad %uchar %470
-%748 = OpFunctionCall %ulong %19 %746 %747
-OpStore %471 %748
-%749 = OpLoad %ulong %474
-%750 = OpIAdd %ulong %749 %ulong_1
-OpStore %472 %750
-%751 = OpLoad %ulong %471
-OpStore %473 %751
-%752 = OpLoad %ulong %472
-OpStore %474 %752
-OpBranch %382
-%337 = OpLabel
-%753 = OpLoad %ulong %441
-%754 = OpAccessChain %_ptr_Function_uchar %398 %753
-%755 = OpLoad %uchar %754
-OpStore %437 %755
-%756 = OpLoad %ulong %440
-%757 = OpLoad %uchar %437
-%758 = OpFunctionCall %ulong %19 %756 %757
-OpStore %438 %758
-%759 = OpLoad %ulong %441
-%760 = OpIAdd %ulong %759 %ulong_1
-OpStore %439 %760
-%761 = OpLoad %ulong %438
-OpStore %440 %761
-%762 = OpLoad %ulong %439
-OpStore %441 %762
-OpBranch %383
-%377 = OpLabel
-OpBranch %348
-%378 = OpLabel
-OpBranch %341
-%379 = OpLabel
-OpBranch %332
-%380 = OpLabel
-OpBranch %373
-%381 = OpLabel
-OpBranch %364
-%382 = OpLabel
-OpBranch %359
-%383 = OpLabel
-OpBranch %336
+%440 = OpVariable %_ptr_Function_double Function
+%441 = OpVariable %_ptr_Function_double Function
+OpStore %418 %397
+OpStore %417 %398
+%442 = OpAccessChain %_ptr_Function_double %417 %uint_0
+%443 = OpLoad %double %442
+OpStore %440 %443
+%444 = OpAccessChain %_ptr_Function_double %417 %uint_1
+%445 = OpLoad %double %444
+OpStore %441 %445
+OpBranch %400
+%400 = OpLabel
+%446 = OpLoad %double %440
+%447 = OpBitcast %ulong %446
+OpStore %419 %447
+OpBranch %402
+%402 = OpLabel
+%448 = OpLoad %ulong %418
+OpStore %427 %448
+OpStore %428 %ulong_0
+OpBranch %403
+%403 = OpLabel
+%449 = OpLoad %ulong %428
+%450 = OpULessThan %bool %449 %ulong_8
+OpStore %420 %450
+%451 = OpLoad %bool %420
+OpLoopMerge %405 %415 None
+OpBranchConditional %451 %404 %405
+%405 = OpLabel
+OpBranch %406
+%406 = OpLabel
+OpBranch %401
+%401 = OpLabel
+OpBranch %407
+%407 = OpLabel
+%452 = OpLoad %double %441
+%453 = OpBitcast %ulong %452
+OpStore %429 %453
+OpBranch %409
+%409 = OpLabel
+%454 = OpLoad %ulong %427
+OpStore %437 %454
+OpStore %438 %ulong_0
+OpBranch %410
+%410 = OpLabel
+%455 = OpLoad %ulong %438
+%456 = OpULessThan %bool %455 %ulong_8
+OpStore %430 %456
+%457 = OpLoad %bool %430
+OpLoopMerge %412 %414 None
+OpBranchConditional %457 %411 %412
+%412 = OpLabel
+OpBranch %413
+%413 = OpLabel
+OpBranch %408
+%408 = OpLabel
+%458 = OpLoad %ulong %437
+OpReturnValue %458
+%411 = OpLabel
+%459 = OpLoad %ulong %438
+%460 = OpIMul %ulong %459 %ulong_8
+OpStore %431 %460
+%461 = OpLoad %ulong %429
+%462 = OpLoad %ulong %431
+%463 = OpShiftRightLogical %ulong %461 %462
+OpStore %432 %463
+%464 = OpLoad %ulong %432
+%465 = OpBitwiseAnd %ulong %464 %ulong_255
+OpStore %433 %465
+%466 = OpLoad %ulong %437
+%467 = OpLoad %ulong %433
+%468 = OpBitwiseXor %ulong %466 %467
+OpStore %434 %468
+%469 = OpLoad %ulong %434
+%470 = OpIMul %ulong %469 %ulong_1099511628211
+OpStore %435 %470
+%471 = OpLoad %ulong %438
+%472 = OpIAdd %ulong %471 %ulong_1
+OpStore %436 %472
+%473 = OpLoad %ulong %435
+OpStore %437 %473
+%474 = OpLoad %ulong %436
+OpStore %438 %474
+OpBranch %414
+%404 = OpLabel
+%475 = OpLoad %ulong %428
+%476 = OpIMul %ulong %475 %ulong_8
+OpStore %421 %476
+%477 = OpLoad %ulong %419
+%478 = OpLoad %ulong %421
+%479 = OpShiftRightLogical %ulong %477 %478
+OpStore %422 %479
+%480 = OpLoad %ulong %422
+%481 = OpBitwiseAnd %ulong %480 %ulong_255
+OpStore %423 %481
+%482 = OpLoad %ulong %427
+%483 = OpLoad %ulong %423
+%484 = OpBitwiseXor %ulong %482 %483
+OpStore %424 %484
+%485 = OpLoad %ulong %424
+%486 = OpIMul %ulong %485 %ulong_1099511628211
+OpStore %425 %486
+%487 = OpLoad %ulong %428
+%488 = OpIAdd %ulong %487 %ulong_1
+OpStore %426 %488
+%489 = OpLoad %ulong %425
+OpStore %427 %489
+%490 = OpLoad %ulong %426
+OpStore %428 %490
+OpBranch %415
+%414 = OpLabel
+OpBranch %410
+%415 = OpLabel
+OpBranch %403
 OpFunctionEnd
-%10 = OpFunction %_struct_48 None %763
-%764 = OpFunctionParameter %ulong
-%765 = OpLabel
-%770 = OpVariable %_ptr_Function__struct_48 Function
-%771 = OpVariable %_ptr_Function__struct_48 Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_uchar Function
-%774 = OpVariable %_ptr_Function_bool Function
-%775 = OpVariable %_ptr_Function_ulong Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_uchar Function
-%778 = OpVariable %_ptr_Function_uchar Function
-%779 = OpVariable %_ptr_Function_uchar Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_ulong Function
-OpStore %772 %764
-OpStore %770 %782
-%783 = OpLoad %ulong %772
-%784 = OpUConvert %uchar %783
-OpStore %773 %784
-%785 = OpAccessChain %_ptr_Function_uchar %770 %uint_0
-%786 = OpLoad %uchar %773
-OpStore %785 %786
-OpStore %781 %ulong_0
-OpBranch %766
-%766 = OpLabel
-%787 = OpLoad %ulong %781
-%788 = OpULessThan %bool %787 %ulong_8
-OpStore %774 %788
-%789 = OpLoad %bool %774
-OpLoopMerge %768 %769 None
-OpBranchConditional %789 %767 %768
-%768 = OpLabel
-%790 = OpLoad %_struct_48 %770
-OpStore %771 %790
-%791 = OpLoad %_struct_48 %771
-OpReturnValue %791
-%767 = OpLabel
-%792 = OpLoad %ulong %781
-%793 = OpIMul %ulong %792 %ulong_8
-OpStore %775 %793
-%794 = OpLoad %ulong %772
-%795 = OpLoad %ulong %775
-%796 = OpShiftRightLogical %ulong %794 %795
-OpStore %776 %796
-%797 = OpLoad %ulong %776
-%798 = OpUConvert %uchar %797
-OpStore %777 %798
-%799 = OpLoad %ulong %781
-%800 = OpUConvert %uchar %799
-OpStore %778 %800
-%801 = OpLoad %uchar %777
-%802 = OpLoad %uchar %778
-%803 = OpIAdd %uchar %801 %802
-OpStore %779 %803
-%804 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %770 %uint_1
-%805 = OpLoad %ulong %781
-%806 = OpAccessChain %_ptr_Function_uchar %804 %805
-%807 = OpLoad %uchar %779
-OpStore %806 %807
-%808 = OpLoad %ulong %781
-%809 = OpIAdd %ulong %808 %ulong_1
-OpStore %780 %809
-%810 = OpLoad %ulong %780
-OpStore %781 %810
-OpBranch %769
-%769 = OpLabel
-OpBranch %766
+%6 = OpFunction %ulong None %492
+%493 = OpFunctionParameter %ulong
+%494 = OpFunctionParameter %_struct_491
+%495 = OpLabel
+%511 = OpVariable %_ptr_Function__struct_491 Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_bool Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_bool Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_double Function
+OpStore %512 %493
+OpStore %511 %494
+%534 = OpAccessChain %_ptr_Function_ulong %511 %uint_0
+%535 = OpLoad %ulong %534
+OpStore %532 %535
+%536 = OpAccessChain %_ptr_Function_double %511 %uint_1
+%537 = OpLoad %double %536
+OpStore %533 %537
+OpBranch %496
+%496 = OpLabel
+%538 = OpLoad %ulong %512
+OpStore %520 %538
+OpStore %521 %ulong_0
+OpBranch %497
+%497 = OpLabel
+%539 = OpLoad %ulong %521
+%540 = OpULessThan %bool %539 %ulong_8
+OpStore %513 %540
+%541 = OpLoad %bool %513
+OpLoopMerge %499 %509 None
+OpBranchConditional %541 %498 %499
+%499 = OpLabel
+OpBranch %500
+%500 = OpLabel
+OpBranch %501
+%501 = OpLabel
+%542 = OpLoad %double %533
+%543 = OpBitcast %ulong %542
+OpStore %522 %543
+OpBranch %503
+%503 = OpLabel
+%544 = OpLoad %ulong %520
+OpStore %530 %544
+OpStore %531 %ulong_0
+OpBranch %504
+%504 = OpLabel
+%545 = OpLoad %ulong %531
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %523 %546
+%547 = OpLoad %bool %523
+OpLoopMerge %506 %508 None
+OpBranchConditional %547 %505 %506
+%506 = OpLabel
+OpBranch %507
+%507 = OpLabel
+OpBranch %502
+%502 = OpLabel
+%548 = OpLoad %ulong %530
+OpReturnValue %548
+%505 = OpLabel
+%549 = OpLoad %ulong %531
+%550 = OpIMul %ulong %549 %ulong_8
+OpStore %524 %550
+%551 = OpLoad %ulong %522
+%552 = OpLoad %ulong %524
+%553 = OpShiftRightLogical %ulong %551 %552
+OpStore %525 %553
+%554 = OpLoad %ulong %525
+%555 = OpBitwiseAnd %ulong %554 %ulong_255
+OpStore %526 %555
+%556 = OpLoad %ulong %530
+%557 = OpLoad %ulong %526
+%558 = OpBitwiseXor %ulong %556 %557
+OpStore %527 %558
+%559 = OpLoad %ulong %527
+%560 = OpIMul %ulong %559 %ulong_1099511628211
+OpStore %528 %560
+%561 = OpLoad %ulong %531
+%562 = OpIAdd %ulong %561 %ulong_1
+OpStore %529 %562
+%563 = OpLoad %ulong %528
+OpStore %530 %563
+%564 = OpLoad %ulong %529
+OpStore %531 %564
+OpBranch %508
+%498 = OpLabel
+%565 = OpLoad %ulong %521
+%566 = OpIMul %ulong %565 %ulong_8
+OpStore %514 %566
+%567 = OpLoad %ulong %532
+%568 = OpLoad %ulong %514
+%569 = OpShiftRightLogical %ulong %567 %568
+OpStore %515 %569
+%570 = OpLoad %ulong %515
+%571 = OpBitwiseAnd %ulong %570 %ulong_255
+OpStore %516 %571
+%572 = OpLoad %ulong %520
+%573 = OpLoad %ulong %516
+%574 = OpBitwiseXor %ulong %572 %573
+OpStore %517 %574
+%575 = OpLoad %ulong %517
+%576 = OpIMul %ulong %575 %ulong_1099511628211
+OpStore %518 %576
+%577 = OpLoad %ulong %521
+%578 = OpIAdd %ulong %577 %ulong_1
+OpStore %519 %578
+%579 = OpLoad %ulong %518
+OpStore %520 %579
+%580 = OpLoad %ulong %519
+OpStore %521 %580
+OpBranch %509
+%508 = OpLabel
+OpBranch %504
+%509 = OpLabel
+OpBranch %497
 OpFunctionEnd
-%11 = OpFunction %_struct_100 None %811
-%812 = OpFunctionParameter %ulong
-%813 = OpLabel
-%814 = OpVariable %_ptr_Function__struct_100 Function
-%815 = OpVariable %_ptr_Function_ulong Function
-%816 = OpVariable %_ptr_Function_uint Function
-%817 = OpVariable %_ptr_Function_ulong Function
-%818 = OpVariable %_ptr_Function_uint Function
-%819 = OpVariable %_ptr_Function_ulong Function
-%820 = OpVariable %_ptr_Function_uint Function
-OpStore %815 %812
-%821 = OpLoad %ulong %815
-%822 = OpUConvert %uint %821
-OpStore %816 %822
-%823 = OpAccessChain %_ptr_Function_uint %814 %uint_0
-%824 = OpLoad %uint %816
-OpStore %823 %824
-%825 = OpLoad %ulong %815
-%826 = OpShiftRightLogical %ulong %825 %ulong_16
-OpStore %817 %826
-%827 = OpLoad %ulong %817
-%828 = OpUConvert %uint %827
-OpStore %818 %828
-%829 = OpAccessChain %_ptr_Function_uint %814 %uint_1
-%830 = OpLoad %uint %818
-OpStore %829 %830
-%831 = OpLoad %ulong %815
-%833 = OpShiftRightLogical %ulong %831 %ulong_32
-OpStore %819 %833
-%834 = OpLoad %ulong %819
-%835 = OpUConvert %uint %834
-OpStore %820 %835
-%836 = OpAccessChain %_ptr_Function_uint %814 %uint_2
-%837 = OpLoad %uint %820
-OpStore %836 %837
-%838 = OpLoad %_struct_100 %814
-OpReturnValue %838
+%7 = OpFunction %ulong None %584
+%585 = OpFunctionParameter %ulong
+%586 = OpFunctionParameter %_struct_583
+%587 = OpLabel
+%609 = OpVariable %_ptr_Function__struct_583 Function
+%610 = OpVariable %_ptr_Function__struct_583 Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_uchar Function
+%613 = OpVariable %_ptr_Function_bool Function
+%614 = OpVariable %_ptr_Function_uchar Function
+%615 = OpVariable %_ptr_Function_ulong Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+%618 = OpVariable %_ptr_Function_ulong Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_bool Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_ulong Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function_ulong Function
+%627 = OpVariable %_ptr_Function_ulong Function
+%628 = OpVariable %_ptr_Function_ulong Function
+%629 = OpVariable %_ptr_Function_bool Function
+%630 = OpVariable %_ptr_Function_ulong Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_ulong Function
+%633 = OpVariable %_ptr_Function_ulong Function
+%634 = OpVariable %_ptr_Function_ulong Function
+%635 = OpVariable %_ptr_Function_ulong Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function_ulong Function
+OpStore %611 %585
+OpStore %609 %586
+%638 = OpLoad %_struct_583 %609
+OpStore %610 %638
+%639 = OpAccessChain %_ptr_Function_uchar %610 %uint_0
+%640 = OpLoad %uchar %639
+OpStore %612 %640
+OpBranch %591
+%591 = OpLabel
+%641 = OpLoad %uchar %612
+%642 = OpUConvert %ulong %641
+OpStore %618 %642
+OpBranch %595
+%595 = OpLabel
+%643 = OpLoad %ulong %611
+OpStore %627 %643
+OpStore %628 %ulong_0
+OpBranch %596
+%596 = OpLabel
+%644 = OpLoad %ulong %628
+%645 = OpULessThan %bool %644 %ulong_8
+OpStore %620 %645
+%646 = OpLoad %bool %620
+OpLoopMerge %598 %607 None
+OpBranchConditional %646 %597 %598
+%598 = OpLabel
+OpBranch %599
+%599 = OpLabel
+OpBranch %592
+%592 = OpLabel
+%647 = OpLoad %ulong %627
+OpStore %616 %647
+OpStore %617 %ulong_0
+OpBranch %588
+%588 = OpLabel
+%648 = OpLoad %ulong %617
+%650 = OpULessThan %bool %648 %ulong_16
+OpStore %613 %650
+%651 = OpLoad %bool %613
+OpLoopMerge %590 %606 None
+OpBranchConditional %651 %589 %590
+%590 = OpLabel
+%652 = OpLoad %ulong %616
+OpReturnValue %652
+%589 = OpLabel
+%654 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %610 %uint_1
+%655 = OpLoad %ulong %617
+%656 = OpAccessChain %_ptr_Function_uchar %654 %655
+%657 = OpLoad %uchar %656
+OpStore %614 %657
+OpBranch %593
+%593 = OpLabel
+%658 = OpLoad %uchar %614
+%659 = OpUConvert %ulong %658
+OpStore %619 %659
+OpBranch %600
+%600 = OpLabel
+%660 = OpLoad %ulong %616
+OpStore %636 %660
+OpStore %637 %ulong_0
+OpBranch %601
+%601 = OpLabel
+%661 = OpLoad %ulong %637
+%662 = OpULessThan %bool %661 %ulong_8
+OpStore %629 %662
+%663 = OpLoad %bool %629
+OpLoopMerge %603 %605 None
+OpBranchConditional %663 %602 %603
+%603 = OpLabel
+OpBranch %604
+%604 = OpLabel
+OpBranch %594
+%594 = OpLabel
+%664 = OpLoad %ulong %617
+%665 = OpIAdd %ulong %664 %ulong_1
+OpStore %615 %665
+%666 = OpLoad %ulong %636
+OpStore %616 %666
+%667 = OpLoad %ulong %615
+OpStore %617 %667
+OpBranch %606
+%602 = OpLabel
+%668 = OpLoad %ulong %637
+%669 = OpIMul %ulong %668 %ulong_8
+OpStore %630 %669
+%670 = OpLoad %ulong %619
+%671 = OpLoad %ulong %630
+%672 = OpShiftRightLogical %ulong %670 %671
+OpStore %631 %672
+%673 = OpLoad %ulong %631
+%674 = OpBitwiseAnd %ulong %673 %ulong_255
+OpStore %632 %674
+%675 = OpLoad %ulong %636
+%676 = OpLoad %ulong %632
+%677 = OpBitwiseXor %ulong %675 %676
+OpStore %633 %677
+%678 = OpLoad %ulong %633
+%679 = OpIMul %ulong %678 %ulong_1099511628211
+OpStore %634 %679
+%680 = OpLoad %ulong %637
+%681 = OpIAdd %ulong %680 %ulong_1
+OpStore %635 %681
+%682 = OpLoad %ulong %634
+OpStore %636 %682
+%683 = OpLoad %ulong %635
+OpStore %637 %683
+OpBranch %605
+%597 = OpLabel
+%684 = OpLoad %ulong %628
+%685 = OpIMul %ulong %684 %ulong_8
+OpStore %621 %685
+%686 = OpLoad %ulong %618
+%687 = OpLoad %ulong %621
+%688 = OpShiftRightLogical %ulong %686 %687
+OpStore %622 %688
+%689 = OpLoad %ulong %622
+%690 = OpBitwiseAnd %ulong %689 %ulong_255
+OpStore %623 %690
+%691 = OpLoad %ulong %627
+%692 = OpLoad %ulong %623
+%693 = OpBitwiseXor %ulong %691 %692
+OpStore %624 %693
+%694 = OpLoad %ulong %624
+%695 = OpIMul %ulong %694 %ulong_1099511628211
+OpStore %625 %695
+%696 = OpLoad %ulong %628
+%697 = OpIAdd %ulong %696 %ulong_1
+OpStore %626 %697
+%698 = OpLoad %ulong %625
+OpStore %627 %698
+%699 = OpLoad %ulong %626
+OpStore %628 %699
+OpBranch %607
+%605 = OpLabel
+OpBranch %601
+%606 = OpLabel
+OpBranch %588
+%607 = OpLabel
+OpBranch %596
 OpFunctionEnd
-%12 = OpFunction %_struct_132 None %839
-%840 = OpFunctionParameter %ulong
-%841 = OpLabel
-%842 = OpVariable %_ptr_Function__struct_132 Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-OpStore %843 %840
-%846 = OpAccessChain %_ptr_Function_ulong %842 %uint_0
-%847 = OpLoad %ulong %843
-OpStore %846 %847
-%848 = OpLoad %ulong %843
-%850 = OpIMul %ulong %848 %ulong_3
-OpStore %844 %850
-%851 = OpLoad %ulong %844
-%853 = OpIAdd %ulong %851 %ulong_7
-OpStore %845 %853
-%854 = OpAccessChain %_ptr_Function_ulong %842 %uint_1
-%855 = OpLoad %ulong %845
-OpStore %854 %855
-%856 = OpLoad %_struct_132 %842
-OpReturnValue %856
+%8 = OpFunction %ulong None %700
+%701 = OpFunctionParameter %ulong
+%702 = OpLabel
+%721 = OpVariable %_ptr_Function_ulong Function
+%722 = OpVariable %_ptr_Function_ulong Function
+%723 = OpVariable %_ptr_Function_ulong Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_ulong Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_ulong Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_bool Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
+%746 = OpVariable %_ptr_Function_bool Function
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_ulong Function
+%749 = OpVariable %_ptr_Function_ulong Function
+%750 = OpVariable %_ptr_Function_ulong Function
+%751 = OpVariable %_ptr_Function_ulong Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_ulong Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_bool Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+OpStore %721 %701
+OpBranch %703
+%703 = OpLabel
+%764 = OpLoad %ulong %721
+OpStore %744 %764
+OpStore %745 %ulong_0
+OpBranch %704
+%704 = OpLabel
+%765 = OpLoad %ulong %745
+%766 = OpULessThan %bool %765 %ulong_8
+OpStore %737 %766
+%767 = OpLoad %bool %737
+OpLoopMerge %706 %720 None
+OpBranchConditional %767 %705 %706
+%706 = OpLabel
+OpBranch %707
+%707 = OpLabel
+OpBranch %708
+%708 = OpLabel
+%768 = OpLoad %ulong %744
+OpStore %753 %768
+OpStore %754 %ulong_0
+OpBranch %709
+%709 = OpLabel
+%769 = OpLoad %ulong %754
+%770 = OpULessThan %bool %769 %ulong_8
+OpStore %746 %770
+%771 = OpLoad %bool %746
+OpLoopMerge %711 %719 None
+OpBranchConditional %771 %710 %711
+%711 = OpLabel
+OpBranch %712
+%712 = OpLabel
+OpBranch %713
+%713 = OpLabel
+%772 = OpLoad %ulong %753
+OpStore %762 %772
+OpStore %763 %ulong_0
+OpBranch %714
+%714 = OpLabel
+%773 = OpLoad %ulong %763
+%774 = OpULessThan %bool %773 %ulong_8
+OpStore %755 %774
+%775 = OpLoad %bool %755
+OpLoopMerge %716 %718 None
+OpBranchConditional %775 %715 %716
+%716 = OpLabel
+OpBranch %717
+%717 = OpLabel
+%776 = OpLoad %ulong %762
+%777 = OpFunctionCall %ulong %17 %776 %ulong_16
+OpStore %722 %777
+%778 = OpLoad %ulong %722
+%779 = OpFunctionCall %ulong %17 %778 %ulong_16
+OpStore %723 %779
+%780 = OpLoad %ulong %723
+%782 = OpFunctionCall %ulong %17 %780 %ulong_17
+OpStore %724 %782
+%783 = OpLoad %ulong %724
+%784 = OpFunctionCall %ulong %17 %783 %ulong_1
+OpStore %725 %784
+%785 = OpLoad %ulong %725
+%787 = OpFunctionCall %ulong %17 %785 %ulong_4
+OpStore %726 %787
+%788 = OpLoad %ulong %726
+%789 = OpFunctionCall %ulong %17 %788 %ulong_8
+OpStore %727 %789
+%790 = OpLoad %ulong %727
+%791 = OpFunctionCall %ulong %17 %790 %ulong_8
+OpStore %728 %791
+%792 = OpLoad %ulong %728
+%793 = OpFunctionCall %ulong %17 %792 %ulong_8
+OpStore %729 %793
+%794 = OpLoad %ulong %729
+%795 = OpFunctionCall %ulong %17 %794 %ulong_1
+OpStore %730 %795
+%796 = OpLoad %ulong %730
+%797 = OpFunctionCall %ulong %17 %796 %ulong_1
+OpStore %731 %797
+%798 = OpLoad %ulong %731
+%799 = OpFunctionCall %ulong %17 %798 %ulong_8
+OpStore %732 %799
+%800 = OpLoad %ulong %732
+%801 = OpFunctionCall %ulong %17 %800 %ulong_8
+OpStore %733 %801
+%802 = OpLoad %ulong %733
+%803 = OpFunctionCall %ulong %17 %802 %ulong_8
+OpStore %734 %803
+%804 = OpLoad %ulong %734
+%805 = OpFunctionCall %ulong %17 %804 %ulong_8
+OpStore %735 %805
+%806 = OpLoad %ulong %735
+%807 = OpFunctionCall %ulong %17 %806 %ulong_1
+OpStore %736 %807
+%808 = OpLoad %ulong %736
+OpReturnValue %808
+%715 = OpLabel
+%809 = OpLoad %ulong %763
+%810 = OpIMul %ulong %809 %ulong_8
+OpStore %756 %810
+%811 = OpLoad %ulong %756
+%812 = OpShiftRightLogical %ulong %ulong_16 %811
+OpStore %757 %812
+%813 = OpLoad %ulong %757
+%814 = OpBitwiseAnd %ulong %813 %ulong_255
+OpStore %758 %814
+%815 = OpLoad %ulong %762
+%816 = OpLoad %ulong %758
+%817 = OpBitwiseXor %ulong %815 %816
+OpStore %759 %817
+%818 = OpLoad %ulong %759
+%819 = OpIMul %ulong %818 %ulong_1099511628211
+OpStore %760 %819
+%820 = OpLoad %ulong %763
+%821 = OpIAdd %ulong %820 %ulong_1
+OpStore %761 %821
+%822 = OpLoad %ulong %760
+OpStore %762 %822
+%823 = OpLoad %ulong %761
+OpStore %763 %823
+OpBranch %718
+%710 = OpLabel
+%824 = OpLoad %ulong %754
+%825 = OpIMul %ulong %824 %ulong_8
+OpStore %747 %825
+%827 = OpLoad %ulong %747
+%828 = OpShiftRightLogical %ulong %ulong_12 %827
+OpStore %748 %828
+%829 = OpLoad %ulong %748
+%830 = OpBitwiseAnd %ulong %829 %ulong_255
+OpStore %749 %830
+%831 = OpLoad %ulong %753
+%832 = OpLoad %ulong %749
+%833 = OpBitwiseXor %ulong %831 %832
+OpStore %750 %833
+%834 = OpLoad %ulong %750
+%835 = OpIMul %ulong %834 %ulong_1099511628211
+OpStore %751 %835
+%836 = OpLoad %ulong %754
+%837 = OpIAdd %ulong %836 %ulong_1
+OpStore %752 %837
+%838 = OpLoad %ulong %751
+OpStore %753 %838
+%839 = OpLoad %ulong %752
+OpStore %754 %839
+OpBranch %719
+%705 = OpLabel
+%840 = OpLoad %ulong %745
+%841 = OpIMul %ulong %840 %ulong_8
+OpStore %738 %841
+%843 = OpLoad %ulong %738
+%844 = OpShiftRightLogical %ulong %ulong_9 %843
+OpStore %739 %844
+%845 = OpLoad %ulong %739
+%846 = OpBitwiseAnd %ulong %845 %ulong_255
+OpStore %740 %846
+%847 = OpLoad %ulong %744
+%848 = OpLoad %ulong %740
+%849 = OpBitwiseXor %ulong %847 %848
+OpStore %741 %849
+%850 = OpLoad %ulong %741
+%851 = OpIMul %ulong %850 %ulong_1099511628211
+OpStore %742 %851
+%852 = OpLoad %ulong %745
+%853 = OpIAdd %ulong %852 %ulong_1
+OpStore %743 %853
+%854 = OpLoad %ulong %742
+OpStore %744 %854
+%855 = OpLoad %ulong %743
+OpStore %745 %855
+OpBranch %720
+%718 = OpLabel
+OpBranch %714
+%719 = OpLabel
+OpBranch %709
+%720 = OpLabel
+OpBranch %704
 OpFunctionEnd
-%13 = OpFunction %_struct_156 None %857
+%9 = OpFunction %ulong None %857
 %858 = OpFunctionParameter %ulong
-%859 = OpLabel
-%860 = OpVariable %_ptr_Function__struct_156 Function
-%861 = OpVariable %_ptr_Function_ulong Function
-%862 = OpVariable %_ptr_Function_ulong Function
-%863 = OpVariable %_ptr_Function_double Function
-%864 = OpVariable %_ptr_Function_double Function
-%865 = OpVariable %_ptr_Function_ulong Function
-%866 = OpVariable %_ptr_Function_double Function
-%867 = OpVariable %_ptr_Function_double Function
-OpStore %861 %858
-%868 = OpLoad %ulong %861
-%870 = OpBitwiseAnd %ulong %868 %ulong_65535
-OpStore %862 %870
-%871 = OpLoad %ulong %862
-%872 = OpConvertUToF %double %871
-OpStore %863 %872
-%873 = OpLoad %double %863
-%875 = OpFDiv %double %873 %double_8
-OpStore %864 %875
-%876 = OpAccessChain %_ptr_Function_double %860 %uint_0
-%877 = OpLoad %double %864
-OpStore %876 %877
-%878 = OpLoad %ulong %861
-%880 = OpBitwiseAnd %ulong %878 %ulong_4095
-OpStore %865 %880
-%881 = OpLoad %ulong %865
-%882 = OpConvertUToF %double %881
-OpStore %866 %882
-%883 = OpLoad %double %866
-%885 = OpFSub %double %883 %double_2048
-OpStore %867 %885
-%886 = OpAccessChain %_ptr_Function_double %860 %uint_1
-%887 = OpLoad %double %867
-OpStore %886 %887
-%888 = OpLoad %_struct_156 %860
-OpReturnValue %888
-OpFunctionEnd
-%14 = OpFunction %_struct_180 None %889
-%890 = OpFunctionParameter %ulong
+%859 = OpFunctionParameter %_struct_43
+%860 = OpFunctionParameter %uint
+%861 = OpFunctionParameter %_struct_169
+%862 = OpFunctionParameter %double
+%863 = OpFunctionParameter %_struct_309
+%864 = OpFunctionParameter %_struct_395
+%865 = OpFunctionParameter %_struct_491
+%866 = OpFunctionParameter %ulong
+%867 = OpFunctionParameter %_struct_583
+%868 = OpFunctionParameter %_struct_43
+%869 = OpFunctionParameter %_struct_169
+%870 = OpFunctionParameter %_struct_309
+%871 = OpFunctionParameter %_struct_583
+%872 = OpFunctionParameter %float
+%873 = OpFunctionParameter %ulong
+%874 = OpLabel
+%921 = OpVariable %_ptr_Function__struct_43 Function
+%922 = OpVariable %_ptr_Function__struct_169 Function
+%923 = OpVariable %_ptr_Function__struct_309 Function
+%924 = OpVariable %_ptr_Function__struct_395 Function
+%925 = OpVariable %_ptr_Function__struct_491 Function
+%926 = OpVariable %_ptr_Function__struct_583 Function
+%927 = OpVariable %_ptr_Function__struct_43 Function
+%928 = OpVariable %_ptr_Function__struct_169 Function
+%929 = OpVariable %_ptr_Function__struct_309 Function
+%930 = OpVariable %_ptr_Function__struct_583 Function
+%931 = OpVariable %_ptr_Function__struct_43 Function
+%932 = OpVariable %_ptr_Function__struct_169 Function
+%933 = OpVariable %_ptr_Function__struct_309 Function
+%934 = OpVariable %_ptr_Function__struct_583 Function
+%935 = OpVariable %_ptr_Function__struct_43 Function
+%936 = OpVariable %_ptr_Function__struct_169 Function
+%937 = OpVariable %_ptr_Function__struct_309 Function
+%938 = OpVariable %_ptr_Function__struct_583 Function
+%939 = OpVariable %_ptr_Function__struct_583 Function
+%940 = OpVariable %_ptr_Function__struct_583 Function
+%941 = OpVariable %_ptr_Function__struct_43 Function
+%942 = OpVariable %_ptr_Function__struct_169 Function
+%943 = OpVariable %_ptr_Function__struct_309 Function
+%944 = OpVariable %_ptr_Function__struct_583 Function
+%945 = OpVariable %_ptr_Function__struct_43 Function
+%946 = OpVariable %_ptr_Function__struct_169 Function
+%947 = OpVariable %_ptr_Function__struct_309 Function
+%948 = OpVariable %_ptr_Function__struct_583 Function
+%949 = OpVariable %_ptr_Function__struct_583 Function
+%950 = OpVariable %_ptr_Function__struct_583 Function
+%951 = OpVariable %_ptr_Function_ulong Function
+%952 = OpVariable %_ptr_Function_uint Function
+%953 = OpVariable %_ptr_Function_double Function
+%954 = OpVariable %_ptr_Function_ulong Function
+%956 = OpVariable %_ptr_Function_float Function
+%957 = OpVariable %_ptr_Function_ulong Function
+%958 = OpVariable %_ptr_Function_ulong Function
+%959 = OpVariable %_ptr_Function_ulong Function
+%960 = OpVariable %_ptr_Function_ulong Function
+%961 = OpVariable %_ptr_Function_ulong Function
+%962 = OpVariable %_ptr_Function_ulong Function
+%963 = OpVariable %_ptr_Function_ulong Function
+%964 = OpVariable %_ptr_Function_ulong Function
+%965 = OpVariable %_ptr_Function_ulong Function
+%966 = OpVariable %_ptr_Function_ulong Function
+%967 = OpVariable %_ptr_Function_ulong Function
+%968 = OpVariable %_ptr_Function_ulong Function
+%969 = OpVariable %_ptr_Function_uchar Function
+%970 = OpVariable %_ptr_Function_uchar Function
+%971 = OpVariable %_ptr_Function_bool Function
+%972 = OpVariable %_ptr_Function_uchar Function
+%973 = OpVariable %_ptr_Function_uchar Function
+%974 = OpVariable %_ptr_Function_uchar Function
+%975 = OpVariable %_ptr_Function_uchar Function
+%976 = OpVariable %_ptr_Function_ulong Function
+%977 = OpVariable %_ptr_Function_ulong Function
+%978 = OpVariable %_ptr_Function_ulong Function
+%979 = OpVariable %_ptr_Function_ulong Function
+%980 = OpVariable %_ptr_Function_ulong Function
+%981 = OpVariable %_ptr_Function_ulong Function
+%982 = OpVariable %_ptr_Function_ulong Function
+%983 = OpVariable %_ptr_Function_ulong Function
+%984 = OpVariable %_ptr_Function_ulong Function
+%985 = OpVariable %_ptr_Function_bool Function
+%986 = OpVariable %_ptr_Function_ulong Function
+%987 = OpVariable %_ptr_Function_ulong Function
+%988 = OpVariable %_ptr_Function_ulong Function
+%989 = OpVariable %_ptr_Function_ulong Function
+%990 = OpVariable %_ptr_Function_ulong Function
+%991 = OpVariable %_ptr_Function_ulong Function
+%992 = OpVariable %_ptr_Function_ulong Function
+%993 = OpVariable %_ptr_Function_ulong Function
+%994 = OpVariable %_ptr_Function_ulong Function
+%995 = OpVariable %_ptr_Function_bool Function
+%996 = OpVariable %_ptr_Function_ulong Function
+%997 = OpVariable %_ptr_Function_ulong Function
+%998 = OpVariable %_ptr_Function_ulong Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_ulong Function
+%1001 = OpVariable %_ptr_Function_ulong Function
+%1002 = OpVariable %_ptr_Function_ulong Function
+%1003 = OpVariable %_ptr_Function_ulong Function
+%1004 = OpVariable %_ptr_Function_bool Function
+%1005 = OpVariable %_ptr_Function_ulong Function
+%1006 = OpVariable %_ptr_Function_ulong Function
+%1007 = OpVariable %_ptr_Function_ulong Function
+%1008 = OpVariable %_ptr_Function_ulong Function
+%1009 = OpVariable %_ptr_Function_ulong Function
+%1010 = OpVariable %_ptr_Function_ulong Function
+%1011 = OpVariable %_ptr_Function_ulong Function
+%1012 = OpVariable %_ptr_Function_ulong Function
+%1013 = OpVariable %_ptr_Function_ulong Function
+%1014 = OpVariable %_ptr_Function_bool Function
+%1015 = OpVariable %_ptr_Function_ulong Function
+%1016 = OpVariable %_ptr_Function_ulong Function
+%1017 = OpVariable %_ptr_Function_ulong Function
+%1018 = OpVariable %_ptr_Function_ulong Function
+%1019 = OpVariable %_ptr_Function_ulong Function
+%1020 = OpVariable %_ptr_Function_ulong Function
+%1021 = OpVariable %_ptr_Function_ulong Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_uint Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_ulong Function
+%1026 = OpVariable %_ptr_Function_double Function
+%1027 = OpVariable %_ptr_Function_double Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_double Function
+OpStore %951 %858
+OpStore %921 %859
+OpStore %952 %860
+OpStore %922 %861
+OpStore %953 %862
+OpStore %923 %863
+OpStore %924 %864
+OpStore %925 %865
+OpStore %954 %866
+OpStore %926 %867
+OpStore %927 %868
+OpStore %928 %869
+OpStore %929 %870
+OpStore %930 %871
+OpStore %956 %872
+OpStore %957 %873
+%1030 = OpLoad %_struct_43 %921
+OpStore %931 %1030
+%1031 = OpLoad %_struct_169 %922
+OpStore %932 %1031
+%1032 = OpLoad %_struct_309 %923
+OpStore %933 %1032
+%1033 = OpAccessChain %_ptr_Function_double %924 %uint_0
+%1034 = OpLoad %double %1033
+OpStore %1026 %1034
+%1035 = OpAccessChain %_ptr_Function_double %924 %uint_1
+%1036 = OpLoad %double %1035
+OpStore %1027 %1036
+%1037 = OpAccessChain %_ptr_Function_ulong %925 %uint_0
+%1038 = OpLoad %ulong %1037
+OpStore %1028 %1038
+%1039 = OpAccessChain %_ptr_Function_double %925 %uint_1
+%1040 = OpLoad %double %1039
+OpStore %1029 %1040
+%1041 = OpLoad %_struct_583 %926
+OpStore %934 %1041
+%1042 = OpLoad %_struct_43 %927
+OpStore %935 %1042
+%1043 = OpLoad %_struct_169 %928
+OpStore %936 %1043
+%1044 = OpLoad %_struct_309 %929
+OpStore %937 %1044
+%1045 = OpLoad %_struct_583 %930
+OpStore %938 %1045
+OpBranch %878
+%878 = OpLabel
+OpBranch %879
+%879 = OpLabel
+%1047 = OpLoad %ulong %951
+%1048 = OpFunctionCall %ulong %17 %ulong_14695981039346656037 %1047
+OpStore %958 %1048
+%1049 = OpLoad %_struct_43 %931
+OpStore %941 %1049
+%1050 = OpLoad %ulong %958
+%1051 = OpLoad %_struct_43 %941
+%1052 = OpFunctionCall %ulong %2 %1050 %1051
+OpStore %959 %1052
+OpBranch %880
+%880 = OpLabel
+%1053 = OpLoad %uint %952
+%1054 = OpUConvert %ulong %1053
+OpStore %980 %1054
+%1055 = OpLoad %ulong %959
+%1056 = OpLoad %ulong %980
+%1057 = OpFunctionCall %ulong %17 %1055 %1056
+OpStore %981 %1057
+OpBranch %881
+%881 = OpLabel
+%1058 = OpLoad %_struct_169 %932
+OpStore %942 %1058
+%1059 = OpLoad %ulong %981
+%1060 = OpLoad %_struct_169 %942
+%1061 = OpFunctionCall %ulong %3 %1059 %1060
+OpStore %960 %1061
+OpBranch %882
+%882 = OpLabel
+%1062 = OpLoad %double %953
+%1063 = OpBitcast %ulong %1062
+OpStore %982 %1063
+%1064 = OpLoad %ulong %960
+%1065 = OpLoad %ulong %982
+%1066 = OpFunctionCall %ulong %17 %1064 %1065
+OpStore %983 %1066
+OpBranch %883
+%883 = OpLabel
+%1067 = OpLoad %_struct_309 %933
+OpStore %943 %1067
+%1068 = OpLoad %ulong %983
+%1069 = OpLoad %_struct_309 %943
+%1070 = OpFunctionCall %ulong %4 %1068 %1069
+OpStore %961 %1070
+OpBranch %884
+%884 = OpLabel
+OpBranch %885
+%885 = OpLabel
+%1071 = OpLoad %double %1026
+%1072 = OpBitcast %ulong %1071
+OpStore %984 %1072
+OpBranch %887
+%887 = OpLabel
+%1073 = OpLoad %ulong %961
+OpStore %992 %1073
+OpStore %993 %ulong_0
+OpBranch %888
+%888 = OpLabel
+%1074 = OpLoad %ulong %993
+%1075 = OpULessThan %bool %1074 %ulong_8
+OpStore %985 %1075
+%1076 = OpLoad %bool %985
+OpLoopMerge %890 %920 None
+OpBranchConditional %1076 %889 %890
+%890 = OpLabel
+OpBranch %891
 %891 = OpLabel
-%892 = OpVariable %_ptr_Function__struct_180 Function
-%893 = OpVariable %_ptr_Function_ulong Function
-%894 = OpVariable %_ptr_Function_ulong Function
-%895 = OpVariable %_ptr_Function_ulong Function
-%896 = OpVariable %_ptr_Function_double Function
-%897 = OpVariable %_ptr_Function_double Function
-OpStore %893 %890
-%898 = OpLoad %ulong %893
-%900 = OpBitwiseXor %ulong %898 %ulong_305419896
-OpStore %894 %900
-%901 = OpAccessChain %_ptr_Function_ulong %892 %uint_0
-%902 = OpLoad %ulong %894
-OpStore %901 %902
-%903 = OpLoad %ulong %893
-%905 = OpBitwiseAnd %ulong %903 %ulong_262143
-OpStore %895 %905
-%906 = OpLoad %ulong %895
-%907 = OpConvertUToF %double %906
-OpStore %896 %907
-%908 = OpLoad %double %896
-%910 = OpFDiv %double %908 %double_64
-OpStore %897 %910
-%911 = OpAccessChain %_ptr_Function_double %892 %uint_1
-%912 = OpLoad %double %897
-OpStore %911 %912
-%913 = OpLoad %_struct_180 %892
-OpReturnValue %913
-OpFunctionEnd
-%15 = OpFunction %_struct_205 None %914
-%915 = OpFunctionParameter %ulong
-%916 = OpLabel
-%921 = OpVariable %_ptr_Function__struct_205 Function
-%922 = OpVariable %_ptr_Function__struct_205 Function
-%923 = OpVariable %_ptr_Function_ulong Function
-%924 = OpVariable %_ptr_Function_ulong Function
-%925 = OpVariable %_ptr_Function_uchar Function
-%926 = OpVariable %_ptr_Function_bool Function
-%927 = OpVariable %_ptr_Function_ulong Function
-%928 = OpVariable %_ptr_Function_ulong Function
-%929 = OpVariable %_ptr_Function_uchar Function
-%930 = OpVariable %_ptr_Function_uchar Function
-%931 = OpVariable %_ptr_Function_uchar Function
-%932 = OpVariable %_ptr_Function_ulong Function
-%933 = OpVariable %_ptr_Function_ulong Function
-OpStore %923 %915
-OpStore %921 %934
-%935 = OpLoad %ulong %923
-%936 = OpShiftRightLogical %ulong %935 %ulong_7
-OpStore %924 %936
-%937 = OpLoad %ulong %924
-%938 = OpUConvert %uchar %937
-OpStore %925 %938
-%939 = OpAccessChain %_ptr_Function_uchar %921 %uint_0
-%940 = OpLoad %uchar %925
-OpStore %939 %940
-OpStore %933 %ulong_0
+OpBranch %886
+%886 = OpLabel
+OpBranch %892
+%892 = OpLabel
+%1077 = OpLoad %double %1027
+%1078 = OpBitcast %ulong %1077
+OpStore %994 %1078
+OpBranch %894
+%894 = OpLabel
+%1079 = OpLoad %ulong %992
+OpStore %1002 %1079
+OpStore %1003 %ulong_0
+OpBranch %895
+%895 = OpLabel
+%1080 = OpLoad %ulong %1003
+%1081 = OpULessThan %bool %1080 %ulong_8
+OpStore %995 %1081
+%1082 = OpLoad %bool %995
+OpLoopMerge %897 %919 None
+OpBranchConditional %1082 %896 %897
+%897 = OpLabel
+OpBranch %898
+%898 = OpLabel
+OpBranch %893
+%893 = OpLabel
+OpBranch %899
+%899 = OpLabel
+OpBranch %900
+%900 = OpLabel
+OpBranch %901
+%901 = OpLabel
+%1083 = OpLoad %ulong %1002
+OpStore %1011 %1083
+OpStore %1012 %ulong_0
+OpBranch %902
+%902 = OpLabel
+%1084 = OpLoad %ulong %1012
+%1085 = OpULessThan %bool %1084 %ulong_8
+OpStore %1004 %1085
+%1086 = OpLoad %bool %1004
+OpLoopMerge %904 %918 None
+OpBranchConditional %1086 %903 %904
+%904 = OpLabel
+OpBranch %905
+%905 = OpLabel
+OpBranch %906
+%906 = OpLabel
+%1087 = OpLoad %double %1029
+%1088 = OpBitcast %ulong %1087
+OpStore %1013 %1088
+OpBranch %908
+%908 = OpLabel
+%1089 = OpLoad %ulong %1011
+OpStore %1021 %1089
+OpStore %1022 %ulong_0
+OpBranch %909
+%909 = OpLabel
+%1090 = OpLoad %ulong %1022
+%1091 = OpULessThan %bool %1090 %ulong_8
+OpStore %1014 %1091
+%1092 = OpLoad %bool %1014
+OpLoopMerge %911 %917 None
+OpBranchConditional %1092 %910 %911
+%911 = OpLabel
+OpBranch %912
+%912 = OpLabel
+OpBranch %907
+%907 = OpLabel
+OpBranch %913
+%913 = OpLabel
+%1093 = OpLoad %ulong %1021
+%1094 = OpLoad %ulong %954
+%1095 = OpFunctionCall %ulong %17 %1093 %1094
+OpStore %962 %1095
+%1096 = OpLoad %_struct_583 %934
+OpStore %944 %1096
+%1097 = OpLoad %ulong %962
+%1098 = OpLoad %_struct_583 %944
+%1099 = OpFunctionCall %ulong %7 %1097 %1098
+OpStore %963 %1099
+%1100 = OpLoad %_struct_43 %935
+OpStore %945 %1100
+%1101 = OpLoad %ulong %963
+%1102 = OpLoad %_struct_43 %945
+%1103 = OpFunctionCall %ulong %2 %1101 %1102
+OpStore %964 %1103
+%1104 = OpLoad %_struct_169 %936
+OpStore %946 %1104
+%1105 = OpLoad %ulong %964
+%1106 = OpLoad %_struct_169 %946
+%1107 = OpFunctionCall %ulong %3 %1105 %1106
+OpStore %965 %1107
+%1108 = OpLoad %_struct_309 %937
+OpStore %947 %1108
+%1109 = OpLoad %ulong %965
+%1110 = OpLoad %_struct_309 %947
+%1111 = OpFunctionCall %ulong %4 %1109 %1110
+OpStore %966 %1111
+%1112 = OpLoad %_struct_583 %938
+OpStore %948 %1112
+%1113 = OpLoad %ulong %966
+%1114 = OpLoad %_struct_583 %948
+%1115 = OpFunctionCall %ulong %7 %1113 %1114
+OpStore %967 %1115
+OpBranch %914
+%914 = OpLabel
+%1116 = OpLoad %float %956
+%1117 = OpBitcast %uint %1116
+OpStore %1023 %1117
+%1118 = OpLoad %uint %1023
+%1119 = OpUConvert %ulong %1118
+OpStore %1024 %1119
+%1120 = OpLoad %ulong %967
+%1121 = OpLoad %ulong %1024
+%1122 = OpFunctionCall %ulong %17 %1120 %1121
+OpStore %1025 %1122
+OpBranch %915
+%915 = OpLabel
+%1123 = OpLoad %ulong %1025
+%1124 = OpLoad %ulong %957
+%1125 = OpFunctionCall %ulong %17 %1123 %1124
+OpStore %968 %1125
+%1126 = OpLoad %_struct_583 %934
+OpStore %950 %1126
+%1127 = OpLoad %_struct_583 %950
+OpStore %949 %1127
+%1128 = OpAccessChain %_ptr_Function_uchar %949 %uint_0
+%1129 = OpLoad %uchar %1128
+OpStore %969 %1129
+%1130 = OpLoad %uchar %969
+%1132 = OpIAdd %uchar %1130 %uchar_1
+OpStore %970 %1132
+%1133 = OpLoad %uchar %970
+OpStore %1128 %1133
+OpStore %979 %ulong_0
+OpBranch %875
+%875 = OpLabel
+%1134 = OpLoad %ulong %979
+%1135 = OpULessThan %bool %1134 %ulong_16
+OpStore %971 %1135
+%1136 = OpLoad %bool %971
+OpLoopMerge %877 %916 None
+OpBranchConditional %1136 %876 %877
+%877 = OpLabel
+%1137 = OpLoad %_struct_583 %949
+OpStore %939 %1137
+%1138 = OpLoad %ulong %968
+%1139 = OpLoad %_struct_583 %939
+%1140 = OpFunctionCall %ulong %7 %1138 %1139
+OpStore %977 %1140
+%1141 = OpLoad %_struct_583 %934
+OpStore %940 %1141
+%1142 = OpLoad %ulong %977
+%1143 = OpLoad %_struct_583 %940
+%1144 = OpFunctionCall %ulong %7 %1142 %1143
+OpStore %978 %1144
+%1145 = OpLoad %ulong %978
+OpReturnValue %1145
+%876 = OpLabel
+%1146 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %949 %uint_1
+%1147 = OpLoad %ulong %979
+%1148 = OpAccessChain %_ptr_Function_uchar %1146 %1147
+%1149 = OpLoad %uchar %1148
+OpStore %972 %1149
+%1150 = OpLoad %ulong %979
+%1151 = OpUConvert %uchar %1150
+OpStore %973 %1151
+%1152 = OpLoad %uchar %972
+%1153 = OpLoad %uchar %973
+%1154 = OpIAdd %uchar %1152 %1153
+OpStore %974 %1154
+%1155 = OpLoad %uchar %974
+%1156 = OpIAdd %uchar %1155 %uchar_1
+OpStore %975 %1156
+%1157 = OpLoad %uchar %975
+OpStore %1148 %1157
+%1158 = OpLoad %ulong %979
+%1159 = OpIAdd %ulong %1158 %ulong_1
+OpStore %976 %1159
+%1160 = OpLoad %ulong %976
+OpStore %979 %1160
+OpBranch %916
+%910 = OpLabel
+%1161 = OpLoad %ulong %1022
+%1162 = OpIMul %ulong %1161 %ulong_8
+OpStore %1015 %1162
+%1163 = OpLoad %ulong %1013
+%1164 = OpLoad %ulong %1015
+%1165 = OpShiftRightLogical %ulong %1163 %1164
+OpStore %1016 %1165
+%1166 = OpLoad %ulong %1016
+%1167 = OpBitwiseAnd %ulong %1166 %ulong_255
+OpStore %1017 %1167
+%1168 = OpLoad %ulong %1021
+%1169 = OpLoad %ulong %1017
+%1170 = OpBitwiseXor %ulong %1168 %1169
+OpStore %1018 %1170
+%1171 = OpLoad %ulong %1018
+%1172 = OpIMul %ulong %1171 %ulong_1099511628211
+OpStore %1019 %1172
+%1173 = OpLoad %ulong %1022
+%1174 = OpIAdd %ulong %1173 %ulong_1
+OpStore %1020 %1174
+%1175 = OpLoad %ulong %1019
+OpStore %1021 %1175
+%1176 = OpLoad %ulong %1020
+OpStore %1022 %1176
 OpBranch %917
-%917 = OpLabel
-%941 = OpLoad %ulong %933
-%942 = OpULessThan %bool %941 %ulong_16
-OpStore %926 %942
-%943 = OpLoad %bool %926
-OpLoopMerge %919 %920 None
-OpBranchConditional %943 %918 %919
-%919 = OpLabel
-%944 = OpLoad %_struct_205 %921
-OpStore %922 %944
-%945 = OpLoad %_struct_205 %922
-OpReturnValue %945
-%918 = OpLabel
-%946 = OpLoad %ulong %933
-%947 = OpIMul %ulong %946 %ulong_4
-OpStore %927 %947
-%948 = OpLoad %ulong %923
-%949 = OpLoad %ulong %927
-%950 = OpShiftRightLogical %ulong %948 %949
-OpStore %928 %950
-%951 = OpLoad %ulong %928
-%952 = OpUConvert %uchar %951
-OpStore %929 %952
-%953 = OpLoad %ulong %933
-%954 = OpUConvert %uchar %953
-OpStore %930 %954
-%955 = OpLoad %uchar %929
-%956 = OpLoad %uchar %930
-%957 = OpBitwiseXor %uchar %955 %956
-OpStore %931 %957
-%958 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %921 %uint_1
-%959 = OpLoad %ulong %933
-%960 = OpAccessChain %_ptr_Function_uchar %958 %959
-%961 = OpLoad %uchar %931
-OpStore %960 %961
-%962 = OpLoad %ulong %933
-%963 = OpIAdd %ulong %962 %ulong_1
-OpStore %932 %963
-%964 = OpLoad %ulong %932
-OpStore %933 %964
+%903 = OpLabel
+%1177 = OpLoad %ulong %1012
+%1178 = OpIMul %ulong %1177 %ulong_8
+OpStore %1005 %1178
+%1179 = OpLoad %ulong %1028
+%1180 = OpLoad %ulong %1005
+%1181 = OpShiftRightLogical %ulong %1179 %1180
+OpStore %1006 %1181
+%1182 = OpLoad %ulong %1006
+%1183 = OpBitwiseAnd %ulong %1182 %ulong_255
+OpStore %1007 %1183
+%1184 = OpLoad %ulong %1011
+%1185 = OpLoad %ulong %1007
+%1186 = OpBitwiseXor %ulong %1184 %1185
+OpStore %1008 %1186
+%1187 = OpLoad %ulong %1008
+%1188 = OpIMul %ulong %1187 %ulong_1099511628211
+OpStore %1009 %1188
+%1189 = OpLoad %ulong %1012
+%1190 = OpIAdd %ulong %1189 %ulong_1
+OpStore %1010 %1190
+%1191 = OpLoad %ulong %1009
+OpStore %1011 %1191
+%1192 = OpLoad %ulong %1010
+OpStore %1012 %1192
+OpBranch %918
+%896 = OpLabel
+%1193 = OpLoad %ulong %1003
+%1194 = OpIMul %ulong %1193 %ulong_8
+OpStore %996 %1194
+%1195 = OpLoad %ulong %994
+%1196 = OpLoad %ulong %996
+%1197 = OpShiftRightLogical %ulong %1195 %1196
+OpStore %997 %1197
+%1198 = OpLoad %ulong %997
+%1199 = OpBitwiseAnd %ulong %1198 %ulong_255
+OpStore %998 %1199
+%1200 = OpLoad %ulong %1002
+%1201 = OpLoad %ulong %998
+%1202 = OpBitwiseXor %ulong %1200 %1201
+OpStore %999 %1202
+%1203 = OpLoad %ulong %999
+%1204 = OpIMul %ulong %1203 %ulong_1099511628211
+OpStore %1000 %1204
+%1205 = OpLoad %ulong %1003
+%1206 = OpIAdd %ulong %1205 %ulong_1
+OpStore %1001 %1206
+%1207 = OpLoad %ulong %1000
+OpStore %1002 %1207
+%1208 = OpLoad %ulong %1001
+OpStore %1003 %1208
+OpBranch %919
+%889 = OpLabel
+%1209 = OpLoad %ulong %993
+%1210 = OpIMul %ulong %1209 %ulong_8
+OpStore %986 %1210
+%1211 = OpLoad %ulong %984
+%1212 = OpLoad %ulong %986
+%1213 = OpShiftRightLogical %ulong %1211 %1212
+OpStore %987 %1213
+%1214 = OpLoad %ulong %987
+%1215 = OpBitwiseAnd %ulong %1214 %ulong_255
+OpStore %988 %1215
+%1216 = OpLoad %ulong %992
+%1217 = OpLoad %ulong %988
+%1218 = OpBitwiseXor %ulong %1216 %1217
+OpStore %989 %1218
+%1219 = OpLoad %ulong %989
+%1220 = OpIMul %ulong %1219 %ulong_1099511628211
+OpStore %990 %1220
+%1221 = OpLoad %ulong %993
+%1222 = OpIAdd %ulong %1221 %ulong_1
+OpStore %991 %1222
+%1223 = OpLoad %ulong %990
+OpStore %992 %1223
+%1224 = OpLoad %ulong %991
+OpStore %993 %1224
 OpBranch %920
+%916 = OpLabel
+OpBranch %875
+%917 = OpLabel
+OpBranch %909
+%918 = OpLabel
+OpBranch %902
+%919 = OpLabel
+OpBranch %895
 %920 = OpLabel
-OpBranch %917
+OpBranch %888
 OpFunctionEnd
-%16 = OpFunction %ulong None %250
-%965 = OpFunctionParameter %ulong
-%966 = OpLabel
-%1054 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
-%1055 = OpVariable %_ptr_Function__struct_48 Function
-%1056 = OpVariable %_ptr_Function__struct_48 Function
-%1057 = OpVariable %_ptr_Function__struct_48 Function
-%1058 = OpVariable %_ptr_Function__struct_48 Function
-%1059 = OpVariable %_ptr_Function__struct_100 Function
-%1060 = OpVariable %_ptr_Function__struct_100 Function
-%1061 = OpVariable %_ptr_Function__struct_132 Function
-%1062 = OpVariable %_ptr_Function__struct_132 Function
-%1063 = OpVariable %_ptr_Function__struct_156 Function
-%1064 = OpVariable %_ptr_Function__struct_156 Function
-%1065 = OpVariable %_ptr_Function__struct_180 Function
-%1066 = OpVariable %_ptr_Function__struct_180 Function
-%1067 = OpVariable %_ptr_Function__struct_205 Function
-%1068 = OpVariable %_ptr_Function__struct_205 Function
-%1069 = OpVariable %_ptr_Function__struct_205 Function
-%1070 = OpVariable %_ptr_Function__struct_205 Function
-%1071 = OpVariable %_ptr_Function__struct_48 Function
-%1072 = OpVariable %_ptr_Function__struct_48 Function
-%1073 = OpVariable %_ptr_Function__struct_48 Function
-%1074 = OpVariable %_ptr_Function__struct_48 Function
-%1075 = OpVariable %_ptr_Function__struct_100 Function
-%1076 = OpVariable %_ptr_Function__struct_100 Function
-%1077 = OpVariable %_ptr_Function__struct_132 Function
-%1078 = OpVariable %_ptr_Function__struct_132 Function
-%1079 = OpVariable %_ptr_Function__struct_205 Function
-%1080 = OpVariable %_ptr_Function__struct_205 Function
-%1081 = OpVariable %_ptr_Function__struct_205 Function
-%1082 = OpVariable %_ptr_Function__struct_205 Function
-%1083 = OpVariable %_ptr_Function_ulong Function
-%1084 = OpVariable %_ptr_Function_ulong Function
-%1085 = OpVariable %_ptr_Function_bool Function
-%1086 = OpVariable %_ptr_Function_ulong Function
-%1087 = OpVariable %_ptr_Function_bool Function
-%1088 = OpVariable %_ptr_Function_ulong Function
-%1089 = OpVariable %_ptr_Function_ulong Function
-%1090 = OpVariable %_ptr_Function_ulong Function
-%1091 = OpVariable %_ptr_Function_ulong Function
-%1092 = OpVariable %_ptr_Function_ulong Function
-%1093 = OpVariable %_ptr_Function_ulong Function
-%1094 = OpVariable %_ptr_Function_uint Function
-%1095 = OpVariable %_ptr_Function_ulong Function
-%1096 = OpVariable %_ptr_Function_ulong Function
-%1097 = OpVariable %_ptr_Function_ulong Function
-%1098 = OpVariable %_ptr_Function_double Function
-%1099 = OpVariable %_ptr_Function_ulong Function
-%1100 = OpVariable %_ptr_Function_ulong Function
-%1101 = OpVariable %_ptr_Function_ulong Function
-%1102 = OpVariable %_ptr_Function_ulong Function
-%1103 = OpVariable %_ptr_Function_ulong Function
-%1104 = OpVariable %_ptr_Function_ulong Function
-%1105 = OpVariable %_ptr_Function_ulong Function
-%1106 = OpVariable %_ptr_Function_ulong Function
-%1107 = OpVariable %_ptr_Function_ulong Function
-%1108 = OpVariable %_ptr_Function_ulong Function
-%1109 = OpVariable %_ptr_Function_ulong Function
-%1110 = OpVariable %_ptr_Function_ulong Function
-%1111 = OpVariable %_ptr_Function_float Function
-%1112 = OpVariable %_ptr_Function_ulong Function
-%1113 = OpVariable %_ptr_Function_ulong Function
-%1114 = OpVariable %_ptr_Function_ulong Function
-%1115 = OpVariable %_ptr_Function_ulong Function
-%1116 = OpVariable %_ptr_Function_uint Function
-%1117 = OpVariable %_ptr_Function_ulong Function
-%1118 = OpVariable %_ptr_Function_double Function
-%1119 = OpVariable %_ptr_Function_ulong Function
-%1120 = OpVariable %_ptr_Function_ulong Function
-%1121 = OpVariable %_ptr_Function_ulong Function
-%1122 = OpVariable %_ptr_Function_ulong Function
-%1123 = OpVariable %_ptr_Function_ulong Function
-%1124 = OpVariable %_ptr_Function_ulong Function
-%1125 = OpVariable %_ptr_Function_ulong Function
-%1126 = OpVariable %_ptr_Function_float Function
-%1127 = OpVariable %_ptr_Function_ulong Function
-%1128 = OpVariable %_ptr_Function_ulong Function
-%1129 = OpVariable %_ptr_Function_ulong Function
-%1130 = OpVariable %_ptr_Function_ulong Function
-%1131 = OpVariable %_ptr_Function_ulong Function
-%1132 = OpVariable %_ptr_Function_ulong Function
-%1133 = OpVariable %_ptr_Function_ulong Function
-%1134 = OpVariable %_ptr_Function_ulong Function
-%1135 = OpVariable %_ptr_Function_ulong Function
-%1136 = OpVariable %_ptr_Function_ulong Function
-%1137 = OpVariable %_ptr_Function_ulong Function
-%1138 = OpVariable %_ptr_Function_ulong Function
-%1139 = OpVariable %_ptr_Function_ulong Function
-%1140 = OpVariable %_ptr_Function_ulong Function
-%1141 = OpVariable %_ptr_Function_ulong Function
-%1142 = OpVariable %_ptr_Function_ulong Function
-%1143 = OpVariable %_ptr_Function_ulong Function
-%1144 = OpVariable %_ptr_Function_ulong Function
-%1145 = OpVariable %_ptr_Function_ulong Function
-%1146 = OpVariable %_ptr_Function_ulong Function
-%1147 = OpVariable %_ptr_Function_ulong Function
-%1148 = OpVariable %_ptr_Function_ulong Function
-%1149 = OpVariable %_ptr_Function_ulong Function
-%1150 = OpVariable %_ptr_Function_ulong Function
-%1151 = OpVariable %_ptr_Function_ulong Function
-%1152 = OpVariable %_ptr_Function_ulong Function
-%1153 = OpVariable %_ptr_Function_ulong Function
-%1154 = OpVariable %_ptr_Function_ulong Function
-%1155 = OpVariable %_ptr_Function_uchar Function
-%1156 = OpVariable %_ptr_Function_bool Function
-%1157 = OpVariable %_ptr_Function_ulong Function
-%1158 = OpVariable %_ptr_Function_ulong Function
-%1159 = OpVariable %_ptr_Function_uchar Function
-%1160 = OpVariable %_ptr_Function_uchar Function
-%1161 = OpVariable %_ptr_Function_uchar Function
-%1162 = OpVariable %_ptr_Function_ulong Function
-%1163 = OpVariable %_ptr_Function_ulong Function
-%1164 = OpVariable %_ptr_Function_uchar Function
-%1165 = OpVariable %_ptr_Function_bool Function
-%1166 = OpVariable %_ptr_Function_ulong Function
-%1167 = OpVariable %_ptr_Function_ulong Function
-%1168 = OpVariable %_ptr_Function_uchar Function
-%1169 = OpVariable %_ptr_Function_uchar Function
-%1170 = OpVariable %_ptr_Function_uchar Function
-%1171 = OpVariable %_ptr_Function_ulong Function
-%1172 = OpVariable %_ptr_Function_ulong Function
-%1173 = OpVariable %_ptr_Function_uint Function
-%1174 = OpVariable %_ptr_Function_ulong Function
-%1175 = OpVariable %_ptr_Function_uint Function
-%1176 = OpVariable %_ptr_Function_ulong Function
-%1177 = OpVariable %_ptr_Function_uint Function
-%1178 = OpVariable %_ptr_Function_uint Function
-%1179 = OpVariable %_ptr_Function_ulong Function
-%1180 = OpVariable %_ptr_Function_uint Function
-%1181 = OpVariable %_ptr_Function_ulong Function
-%1182 = OpVariable %_ptr_Function_uint Function
-%1183 = OpVariable %_ptr_Function_ulong Function
-%1184 = OpVariable %_ptr_Function_ulong Function
-%1185 = OpVariable %_ptr_Function_ulong Function
-%1186 = OpVariable %_ptr_Function_ulong Function
-%1187 = OpVariable %_ptr_Function_ulong Function
-%1188 = OpVariable %_ptr_Function_double Function
-%1189 = OpVariable %_ptr_Function_double Function
-%1190 = OpVariable %_ptr_Function_ulong Function
-%1191 = OpVariable %_ptr_Function_double Function
-%1192 = OpVariable %_ptr_Function_double Function
-%1193 = OpVariable %_ptr_Function_ulong Function
-%1194 = OpVariable %_ptr_Function_double Function
-%1195 = OpVariable %_ptr_Function_double Function
-%1196 = OpVariable %_ptr_Function_ulong Function
-%1197 = OpVariable %_ptr_Function_double Function
-%1198 = OpVariable %_ptr_Function_double Function
-%1199 = OpVariable %_ptr_Function_ulong Function
-%1200 = OpVariable %_ptr_Function_ulong Function
-%1201 = OpVariable %_ptr_Function_double Function
-%1202 = OpVariable %_ptr_Function_double Function
-%1203 = OpVariable %_ptr_Function_ulong Function
-%1204 = OpVariable %_ptr_Function_ulong Function
-%1205 = OpVariable %_ptr_Function_double Function
-%1206 = OpVariable %_ptr_Function_double Function
-%1207 = OpVariable %_ptr_Function_ulong Function
-%1208 = OpVariable %_ptr_Function_uchar Function
-%1209 = OpVariable %_ptr_Function_bool Function
-%1210 = OpVariable %_ptr_Function_ulong Function
-%1211 = OpVariable %_ptr_Function_ulong Function
-%1212 = OpVariable %_ptr_Function_uchar Function
-%1213 = OpVariable %_ptr_Function_uchar Function
-%1214 = OpVariable %_ptr_Function_uchar Function
-%1215 = OpVariable %_ptr_Function_ulong Function
-%1216 = OpVariable %_ptr_Function_ulong Function
-%1217 = OpVariable %_ptr_Function_ulong Function
-%1218 = OpVariable %_ptr_Function_uchar Function
-%1219 = OpVariable %_ptr_Function_bool Function
-%1220 = OpVariable %_ptr_Function_ulong Function
-%1221 = OpVariable %_ptr_Function_ulong Function
-%1222 = OpVariable %_ptr_Function_uchar Function
-%1223 = OpVariable %_ptr_Function_uchar Function
-%1224 = OpVariable %_ptr_Function_uchar Function
-%1225 = OpVariable %_ptr_Function_ulong Function
-%1226 = OpVariable %_ptr_Function_ulong Function
-%1227 = OpVariable %_ptr_Function_uchar Function
-%1228 = OpVariable %_ptr_Function_bool Function
-%1229 = OpVariable %_ptr_Function_ulong Function
-%1230 = OpVariable %_ptr_Function_ulong Function
-%1231 = OpVariable %_ptr_Function_uchar Function
-%1232 = OpVariable %_ptr_Function_uchar Function
-%1233 = OpVariable %_ptr_Function_uchar Function
+%10 = OpFunction %_struct_43 None %1225
+%1226 = OpFunctionParameter %ulong
+%1227 = OpLabel
+%1232 = OpVariable %_ptr_Function__struct_43 Function
+%1233 = OpVariable %_ptr_Function__struct_43 Function
 %1234 = OpVariable %_ptr_Function_ulong Function
-%1235 = OpVariable %_ptr_Function_ulong Function
-%1236 = OpVariable %_ptr_Function_uchar Function
-%1237 = OpVariable %_ptr_Function_bool Function
+%1235 = OpVariable %_ptr_Function_uchar Function
+%1236 = OpVariable %_ptr_Function_bool Function
+%1237 = OpVariable %_ptr_Function_ulong Function
 %1238 = OpVariable %_ptr_Function_ulong Function
-%1239 = OpVariable %_ptr_Function_ulong Function
+%1239 = OpVariable %_ptr_Function_uchar Function
 %1240 = OpVariable %_ptr_Function_uchar Function
 %1241 = OpVariable %_ptr_Function_uchar Function
-%1242 = OpVariable %_ptr_Function_uchar Function
+%1242 = OpVariable %_ptr_Function_ulong Function
 %1243 = OpVariable %_ptr_Function_ulong Function
-%1244 = OpVariable %_ptr_Function_ulong Function
-%1245 = OpVariable %_ptr_Function_uint Function
-%1246 = OpVariable %_ptr_Function_ulong Function
-%1247 = OpVariable %_ptr_Function_uint Function
-%1248 = OpVariable %_ptr_Function_ulong Function
-%1249 = OpVariable %_ptr_Function_uint Function
-%1250 = OpVariable %_ptr_Function_uint Function
-%1251 = OpVariable %_ptr_Function_ulong Function
-%1252 = OpVariable %_ptr_Function_uint Function
-%1253 = OpVariable %_ptr_Function_ulong Function
-%1254 = OpVariable %_ptr_Function_uint Function
-%1255 = OpVariable %_ptr_Function_ulong Function
-%1256 = OpVariable %_ptr_Function_ulong Function
-%1257 = OpVariable %_ptr_Function_ulong Function
-%1258 = OpVariable %_ptr_Function_ulong Function
-%1259 = OpVariable %_ptr_Function_ulong Function
-%1260 = OpVariable %_ptr_Function_uchar Function
-%1261 = OpVariable %_ptr_Function_bool Function
-%1262 = OpVariable %_ptr_Function_ulong Function
-%1263 = OpVariable %_ptr_Function_ulong Function
-%1264 = OpVariable %_ptr_Function_uchar Function
-%1265 = OpVariable %_ptr_Function_uchar Function
-%1266 = OpVariable %_ptr_Function_uchar Function
-%1267 = OpVariable %_ptr_Function_ulong Function
-%1268 = OpVariable %_ptr_Function_ulong Function
-%1269 = OpVariable %_ptr_Function_ulong Function
-%1270 = OpVariable %_ptr_Function_uchar Function
-%1271 = OpVariable %_ptr_Function_bool Function
-%1272 = OpVariable %_ptr_Function_ulong Function
-%1273 = OpVariable %_ptr_Function_ulong Function
-%1274 = OpVariable %_ptr_Function_uchar Function
-%1275 = OpVariable %_ptr_Function_uchar Function
-%1276 = OpVariable %_ptr_Function_uchar Function
+OpStore %1234 %1226
+OpStore %1232 %1244
+%1245 = OpLoad %ulong %1234
+%1246 = OpUConvert %uchar %1245
+OpStore %1235 %1246
+%1247 = OpAccessChain %_ptr_Function_uchar %1232 %uint_0
+%1248 = OpLoad %uchar %1235
+OpStore %1247 %1248
+OpStore %1243 %ulong_0
+OpBranch %1228
+%1228 = OpLabel
+%1249 = OpLoad %ulong %1243
+%1250 = OpULessThan %bool %1249 %ulong_8
+OpStore %1236 %1250
+%1251 = OpLoad %bool %1236
+OpLoopMerge %1230 %1231 None
+OpBranchConditional %1251 %1229 %1230
+%1230 = OpLabel
+%1252 = OpLoad %_struct_43 %1232
+OpStore %1233 %1252
+%1253 = OpLoad %_struct_43 %1233
+OpReturnValue %1253
+%1229 = OpLabel
+%1254 = OpLoad %ulong %1243
+%1255 = OpIMul %ulong %1254 %ulong_8
+OpStore %1237 %1255
+%1256 = OpLoad %ulong %1234
+%1257 = OpLoad %ulong %1237
+%1258 = OpShiftRightLogical %ulong %1256 %1257
+OpStore %1238 %1258
+%1259 = OpLoad %ulong %1238
+%1260 = OpUConvert %uchar %1259
+OpStore %1239 %1260
+%1261 = OpLoad %ulong %1243
+%1262 = OpUConvert %uchar %1261
+OpStore %1240 %1262
+%1263 = OpLoad %uchar %1239
+%1264 = OpLoad %uchar %1240
+%1265 = OpIAdd %uchar %1263 %1264
+OpStore %1241 %1265
+%1266 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1232 %uint_1
+%1267 = OpLoad %ulong %1243
+%1268 = OpAccessChain %_ptr_Function_uchar %1266 %1267
+%1269 = OpLoad %uchar %1241
+OpStore %1268 %1269
+%1270 = OpLoad %ulong %1243
+%1271 = OpIAdd %ulong %1270 %ulong_1
+OpStore %1242 %1271
+%1272 = OpLoad %ulong %1242
+OpStore %1243 %1272
+OpBranch %1231
+%1231 = OpLabel
+OpBranch %1228
+OpFunctionEnd
+%11 = OpFunction %_struct_169 None %1273
+%1274 = OpFunctionParameter %ulong
+%1275 = OpLabel
+%1276 = OpVariable %_ptr_Function__struct_169 Function
 %1277 = OpVariable %_ptr_Function_ulong Function
-%1278 = OpVariable %_ptr_Function_ulong Function
-OpStore %1083 %965
-%1279 = OpFunctionCall %ulong %17
-OpStore %1084 %1279
-OpBranch %973
-%973 = OpLabel
-%1280 = OpLoad %ulong %1084
-%1281 = OpFunctionCall %ulong %18 %1280 %ulong_9
-OpStore %1134 %1281
-%1282 = OpLoad %ulong %1134
-%1283 = OpFunctionCall %ulong %18 %1282 %ulong_12
-OpStore %1135 %1283
-%1284 = OpLoad %ulong %1135
-%1285 = OpFunctionCall %ulong %18 %1284 %ulong_16
-OpStore %1136 %1285
-%1286 = OpLoad %ulong %1136
-%1287 = OpFunctionCall %ulong %18 %1286 %ulong_16
-OpStore %1137 %1287
-%1288 = OpLoad %ulong %1137
-%1289 = OpFunctionCall %ulong %18 %1288 %ulong_16
-OpStore %1138 %1289
-%1290 = OpLoad %ulong %1138
-%1291 = OpFunctionCall %ulong %18 %1290 %ulong_17
-OpStore %1139 %1291
-%1292 = OpLoad %ulong %1139
-%1293 = OpFunctionCall %ulong %18 %1292 %ulong_1
-OpStore %1140 %1293
-%1294 = OpLoad %ulong %1140
-%1295 = OpFunctionCall %ulong %18 %1294 %ulong_4
-OpStore %1141 %1295
-%1296 = OpLoad %ulong %1141
-%1297 = OpFunctionCall %ulong %18 %1296 %ulong_8
-OpStore %1142 %1297
-%1298 = OpLoad %ulong %1142
-%1299 = OpFunctionCall %ulong %18 %1298 %ulong_8
-OpStore %1143 %1299
-%1300 = OpLoad %ulong %1143
-%1301 = OpFunctionCall %ulong %18 %1300 %ulong_8
-OpStore %1144 %1301
-%1302 = OpLoad %ulong %1144
-%1303 = OpFunctionCall %ulong %18 %1302 %ulong_1
-OpStore %1145 %1303
-%1304 = OpLoad %ulong %1145
-%1305 = OpFunctionCall %ulong %18 %1304 %ulong_1
-OpStore %1146 %1305
-%1306 = OpLoad %ulong %1146
-%1307 = OpFunctionCall %ulong %18 %1306 %ulong_8
-OpStore %1147 %1307
-%1308 = OpLoad %ulong %1147
-%1309 = OpFunctionCall %ulong %18 %1308 %ulong_8
-OpStore %1148 %1309
-%1310 = OpLoad %ulong %1148
-%1311 = OpFunctionCall %ulong %18 %1310 %ulong_8
-OpStore %1149 %1311
-%1312 = OpLoad %ulong %1149
-%1313 = OpFunctionCall %ulong %18 %1312 %ulong_8
-OpStore %1150 %1313
-%1314 = OpLoad %ulong %1150
-%1315 = OpFunctionCall %ulong %18 %1314 %ulong_1
-OpStore %1151 %1315
-OpBranch %974
-%974 = OpLabel
-OpStore %1054 %1316
-OpStore %1131 %ulong_0
-OpBranch %967
-%967 = OpLabel
-%1317 = OpLoad %ulong %1131
-%1318 = OpULessThan %bool %1317 %ulong_12
-OpStore %1085 %1318
-%1319 = OpLoad %bool %1085
-OpLoopMerge %969 %1050 None
-OpBranchConditional %1319 %968 %969
-%969 = OpLabel
-%1320 = OpLoad %ulong %1151
-OpStore %1130 %1320
-OpStore %1132 %ulong_0
-OpStore %1133 %ulong_0
-OpBranch %970
-%970 = OpLabel
-%1321 = OpLoad %ulong %1133
-%1322 = OpULessThan %bool %1321 %ulong_3
-OpStore %1087 %1322
-%1323 = OpLoad %bool %1087
-OpLoopMerge %972 %1049 None
-OpBranchConditional %1323 %971 %972
-%972 = OpLabel
-OpBranch %982
-%982 = OpLabel
-OpStore %1057 %782
-%1324 = OpLoad %ulong %1132
-%1325 = OpUConvert %uchar %1324
-OpStore %1164 %1325
-%1326 = OpAccessChain %_ptr_Function_uchar %1057 %uint_0
-%1327 = OpLoad %uchar %1164
-OpStore %1326 %1327
-OpStore %1172 %ulong_0
-OpBranch %983
-%983 = OpLabel
-%1328 = OpLoad %ulong %1172
-%1329 = OpULessThan %bool %1328 %ulong_8
-OpStore %1165 %1329
-%1330 = OpLoad %bool %1165
-OpLoopMerge %985 %1048 None
-OpBranchConditional %1330 %984 %985
-%985 = OpLabel
-%1331 = OpLoad %_struct_48 %1057
-OpStore %1058 %1331
-OpBranch %986
-%986 = OpLabel
-%1332 = OpLoad %ulong %1132
-%1333 = OpUConvert %uint %1332
-OpStore %1116 %1333
-OpBranch %989
-%989 = OpLabel
-%1334 = OpLoad %ulong %1132
-%1335 = OpUConvert %uint %1334
-OpStore %1178 %1335
-%1336 = OpAccessChain %_ptr_Function_uint %1060 %uint_0
-%1337 = OpLoad %uint %1178
-OpStore %1336 %1337
-%1338 = OpLoad %ulong %1132
-%1339 = OpShiftRightLogical %ulong %1338 %ulong_16
-OpStore %1179 %1339
-%1340 = OpLoad %ulong %1179
-%1341 = OpUConvert %uint %1340
-OpStore %1180 %1341
-%1342 = OpAccessChain %_ptr_Function_uint %1060 %uint_1
-%1343 = OpLoad %uint %1180
-OpStore %1342 %1343
-%1344 = OpLoad %ulong %1132
-%1345 = OpShiftRightLogical %ulong %1344 %ulong_32
-OpStore %1181 %1345
-%1346 = OpLoad %ulong %1181
-%1347 = OpUConvert %uint %1346
-OpStore %1182 %1347
-%1348 = OpAccessChain %_ptr_Function_uint %1060 %uint_2
-%1349 = OpLoad %uint %1182
+%1278 = OpVariable %_ptr_Function_uint Function
+%1279 = OpVariable %_ptr_Function_ulong Function
+%1280 = OpVariable %_ptr_Function_uint Function
+%1281 = OpVariable %_ptr_Function_ulong Function
+%1282 = OpVariable %_ptr_Function_uint Function
+OpStore %1277 %1274
+%1283 = OpLoad %ulong %1277
+%1284 = OpUConvert %uint %1283
+OpStore %1278 %1284
+%1285 = OpAccessChain %_ptr_Function_uint %1276 %uint_0
+%1286 = OpLoad %uint %1278
+OpStore %1285 %1286
+%1287 = OpLoad %ulong %1277
+%1288 = OpShiftRightLogical %ulong %1287 %ulong_16
+OpStore %1279 %1288
+%1289 = OpLoad %ulong %1279
+%1290 = OpUConvert %uint %1289
+OpStore %1280 %1290
+%1291 = OpAccessChain %_ptr_Function_uint %1276 %uint_1
+%1292 = OpLoad %uint %1280
+OpStore %1291 %1292
+%1293 = OpLoad %ulong %1277
+%1295 = OpShiftRightLogical %ulong %1293 %ulong_32
+OpStore %1281 %1295
+%1296 = OpLoad %ulong %1281
+%1297 = OpUConvert %uint %1296
+OpStore %1282 %1297
+%1298 = OpAccessChain %_ptr_Function_uint %1276 %uint_2
+%1299 = OpLoad %uint %1282
+OpStore %1298 %1299
+%1300 = OpLoad %_struct_169 %1276
+OpReturnValue %1300
+OpFunctionEnd
+%12 = OpFunction %_struct_309 None %1301
+%1302 = OpFunctionParameter %ulong
+%1303 = OpLabel
+%1304 = OpVariable %_ptr_Function__struct_309 Function
+%1305 = OpVariable %_ptr_Function_ulong Function
+%1306 = OpVariable %_ptr_Function_ulong Function
+%1307 = OpVariable %_ptr_Function_ulong Function
+OpStore %1305 %1302
+%1308 = OpAccessChain %_ptr_Function_ulong %1304 %uint_0
+%1309 = OpLoad %ulong %1305
+OpStore %1308 %1309
+%1310 = OpLoad %ulong %1305
+%1312 = OpIMul %ulong %1310 %ulong_3
+OpStore %1306 %1312
+%1313 = OpLoad %ulong %1306
+%1315 = OpIAdd %ulong %1313 %ulong_7
+OpStore %1307 %1315
+%1316 = OpAccessChain %_ptr_Function_ulong %1304 %uint_1
+%1317 = OpLoad %ulong %1307
+OpStore %1316 %1317
+%1318 = OpLoad %_struct_309 %1304
+OpReturnValue %1318
+OpFunctionEnd
+%13 = OpFunction %_struct_395 None %1319
+%1320 = OpFunctionParameter %ulong
+%1321 = OpLabel
+%1322 = OpVariable %_ptr_Function__struct_395 Function
+%1323 = OpVariable %_ptr_Function_ulong Function
+%1324 = OpVariable %_ptr_Function_ulong Function
+%1325 = OpVariable %_ptr_Function_double Function
+%1326 = OpVariable %_ptr_Function_double Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_double Function
+%1329 = OpVariable %_ptr_Function_double Function
+OpStore %1323 %1320
+%1330 = OpLoad %ulong %1323
+%1332 = OpBitwiseAnd %ulong %1330 %ulong_65535
+OpStore %1324 %1332
+%1333 = OpLoad %ulong %1324
+%1334 = OpConvertUToF %double %1333
+OpStore %1325 %1334
+%1335 = OpLoad %double %1325
+%1337 = OpFDiv %double %1335 %double_8
+OpStore %1326 %1337
+%1338 = OpAccessChain %_ptr_Function_double %1322 %uint_0
+%1339 = OpLoad %double %1326
+OpStore %1338 %1339
+%1340 = OpLoad %ulong %1323
+%1342 = OpBitwiseAnd %ulong %1340 %ulong_4095
+OpStore %1327 %1342
+%1343 = OpLoad %ulong %1327
+%1344 = OpConvertUToF %double %1343
+OpStore %1328 %1344
+%1345 = OpLoad %double %1328
+%1347 = OpFSub %double %1345 %double_2048
+OpStore %1329 %1347
+%1348 = OpAccessChain %_ptr_Function_double %1322 %uint_1
+%1349 = OpLoad %double %1329
 OpStore %1348 %1349
-OpBranch %990
-%990 = OpLabel
-%1350 = OpLoad %ulong %1132
-%1352 = OpBitwiseAnd %ulong %1350 %ulong_1023
-OpStore %1117 %1352
-%1353 = OpLoad %ulong %1117
-%1354 = OpConvertUToF %double %1353
-OpStore %1118 %1354
-OpBranch %993
-%993 = OpLabel
-%1355 = OpAccessChain %_ptr_Function_ulong %1062 %uint_0
-%1356 = OpLoad %ulong %1132
-OpStore %1355 %1356
-%1357 = OpLoad %ulong %1132
-%1358 = OpIMul %ulong %1357 %ulong_3
-OpStore %1185 %1358
-%1359 = OpLoad %ulong %1185
-%1360 = OpIAdd %ulong %1359 %ulong_7
-OpStore %1186 %1360
-%1361 = OpAccessChain %_ptr_Function_ulong %1062 %uint_1
-%1362 = OpLoad %ulong %1186
-OpStore %1361 %1362
-OpBranch %994
-%994 = OpLabel
-OpBranch %997
-%997 = OpLabel
-%1363 = OpLoad %ulong %1132
-%1364 = OpBitwiseAnd %ulong %1363 %ulong_65535
-OpStore %1193 %1364
-%1365 = OpLoad %ulong %1193
-%1366 = OpConvertUToF %double %1365
-OpStore %1194 %1366
-%1367 = OpLoad %double %1194
-%1368 = OpFDiv %double %1367 %double_8
-OpStore %1195 %1368
-%1369 = OpAccessChain %_ptr_Function_double %1064 %uint_0
-%1370 = OpLoad %double %1195
-OpStore %1369 %1370
-%1371 = OpLoad %ulong %1132
-%1372 = OpBitwiseAnd %ulong %1371 %ulong_4095
-OpStore %1196 %1372
-%1373 = OpLoad %ulong %1196
-%1374 = OpConvertUToF %double %1373
-OpStore %1197 %1374
-%1375 = OpLoad %double %1197
-%1376 = OpFSub %double %1375 %double_2048
-OpStore %1198 %1376
-%1377 = OpAccessChain %_ptr_Function_double %1064 %uint_1
-%1378 = OpLoad %double %1198
-OpStore %1377 %1378
-OpBranch %998
-%998 = OpLabel
-OpBranch %1001
-%1001 = OpLabel
-%1379 = OpLoad %ulong %1132
-%1380 = OpBitwiseXor %ulong %1379 %ulong_305419896
-OpStore %1203 %1380
-%1381 = OpAccessChain %_ptr_Function_ulong %1066 %uint_0
-%1382 = OpLoad %ulong %1203
-OpStore %1381 %1382
-%1383 = OpLoad %ulong %1132
-%1384 = OpBitwiseAnd %ulong %1383 %ulong_262143
-OpStore %1204 %1384
-%1385 = OpLoad %ulong %1204
-%1386 = OpConvertUToF %double %1385
-OpStore %1205 %1386
-%1387 = OpLoad %double %1205
-%1388 = OpFDiv %double %1387 %double_64
-OpStore %1206 %1388
-%1389 = OpAccessChain %_ptr_Function_double %1066 %uint_1
-%1390 = OpLoad %double %1206
-OpStore %1389 %1390
-OpBranch %1002
-%1002 = OpLabel
-%1391 = OpAccessChain %_ptr_Function_ulong %1054 %uint_8
-%1392 = OpLoad %ulong %1391
-OpStore %1119 %1392
-OpBranch %1008
-%1008 = OpLabel
-OpStore %1069 %934
-%1393 = OpLoad %ulong %1132
-%1394 = OpShiftRightLogical %ulong %1393 %ulong_7
-OpStore %1217 %1394
-%1395 = OpLoad %ulong %1217
-%1396 = OpUConvert %uchar %1395
-OpStore %1218 %1396
-%1397 = OpAccessChain %_ptr_Function_uchar %1069 %uint_0
-%1398 = OpLoad %uchar %1218
-OpStore %1397 %1398
-OpStore %1226 %ulong_0
-OpBranch %1009
-%1009 = OpLabel
-%1399 = OpLoad %ulong %1226
-%1400 = OpULessThan %bool %1399 %ulong_16
-OpStore %1219 %1400
-%1401 = OpLoad %bool %1219
-OpLoopMerge %1011 %1046 None
-OpBranchConditional %1401 %1010 %1011
-%1011 = OpLabel
-%1402 = OpLoad %_struct_205 %1069
-OpStore %1070 %1402
-OpBranch %1012
-%1012 = OpLabel
-%1404 = OpAccessChain %_ptr_Function_ulong %1054 %uint_10
-%1405 = OpLoad %ulong %1404
-OpStore %1120 %1405
-OpBranch %1018
-%1018 = OpLabel
-OpStore %1073 %782
-%1406 = OpLoad %ulong %1120
-%1407 = OpUConvert %uchar %1406
-OpStore %1236 %1407
-%1408 = OpAccessChain %_ptr_Function_uchar %1073 %uint_0
-%1409 = OpLoad %uchar %1236
-OpStore %1408 %1409
-OpStore %1244 %ulong_0
-OpBranch %1019
-%1019 = OpLabel
-%1410 = OpLoad %ulong %1244
-%1411 = OpULessThan %bool %1410 %ulong_8
-OpStore %1237 %1411
-%1412 = OpLoad %bool %1237
-OpLoopMerge %1021 %1044 None
-OpBranchConditional %1412 %1020 %1021
-%1021 = OpLabel
-%1413 = OpLoad %_struct_48 %1073
-OpStore %1074 %1413
-OpBranch %1022
-%1022 = OpLabel
-%1415 = OpAccessChain %_ptr_Function_ulong %1054 %uint_11
-%1416 = OpLoad %ulong %1415
-OpStore %1121 %1416
-OpBranch %1025
-%1025 = OpLabel
-%1417 = OpLoad %ulong %1121
-%1418 = OpUConvert %uint %1417
-OpStore %1250 %1418
-%1419 = OpAccessChain %_ptr_Function_uint %1076 %uint_0
-%1420 = OpLoad %uint %1250
-OpStore %1419 %1420
-%1421 = OpLoad %ulong %1121
-%1422 = OpShiftRightLogical %ulong %1421 %ulong_16
-OpStore %1251 %1422
-%1423 = OpLoad %ulong %1251
-%1424 = OpUConvert %uint %1423
-OpStore %1252 %1424
-%1425 = OpAccessChain %_ptr_Function_uint %1076 %uint_1
-%1426 = OpLoad %uint %1252
-OpStore %1425 %1426
-%1427 = OpLoad %ulong %1121
-%1428 = OpShiftRightLogical %ulong %1427 %ulong_32
-OpStore %1253 %1428
-%1429 = OpLoad %ulong %1253
-%1430 = OpUConvert %uint %1429
-OpStore %1254 %1430
-%1431 = OpAccessChain %_ptr_Function_uint %1076 %uint_2
-%1432 = OpLoad %uint %1254
-OpStore %1431 %1432
-OpBranch %1026
-%1026 = OpLabel
-%1433 = OpAccessChain %_ptr_Function_ulong %1054 %uint_0
-%1434 = OpLoad %ulong %1433
-OpStore %1122 %1434
-OpBranch %1029
-%1029 = OpLabel
-%1435 = OpAccessChain %_ptr_Function_ulong %1078 %uint_0
-%1436 = OpLoad %ulong %1122
-OpStore %1435 %1436
-%1437 = OpLoad %ulong %1122
-%1438 = OpIMul %ulong %1437 %ulong_3
-OpStore %1257 %1438
-%1439 = OpLoad %ulong %1257
-%1440 = OpIAdd %ulong %1439 %ulong_7
-OpStore %1258 %1440
-%1441 = OpAccessChain %_ptr_Function_ulong %1078 %uint_1
-%1442 = OpLoad %ulong %1258
-OpStore %1441 %1442
-OpBranch %1030
-%1030 = OpLabel
-%1443 = OpAccessChain %_ptr_Function_ulong %1054 %uint_1
-%1444 = OpLoad %ulong %1443
-OpStore %1123 %1444
-OpBranch %1036
-%1036 = OpLabel
-OpStore %1081 %934
-%1445 = OpLoad %ulong %1123
-%1446 = OpShiftRightLogical %ulong %1445 %ulong_7
-OpStore %1269 %1446
-%1447 = OpLoad %ulong %1269
-%1448 = OpUConvert %uchar %1447
-OpStore %1270 %1448
-%1449 = OpAccessChain %_ptr_Function_uchar %1081 %uint_0
-%1450 = OpLoad %uchar %1270
-OpStore %1449 %1450
-OpStore %1278 %ulong_0
-OpBranch %1037
-%1037 = OpLabel
-%1451 = OpLoad %ulong %1278
-%1452 = OpULessThan %bool %1451 %ulong_16
-OpStore %1271 %1452
-%1453 = OpLoad %bool %1271
-OpLoopMerge %1039 %1042 None
-OpBranchConditional %1453 %1038 %1039
-%1039 = OpLabel
-%1454 = OpLoad %_struct_205 %1081
-OpStore %1082 %1454
-OpBranch %1040
-%1040 = OpLabel
-%1455 = OpAccessChain %_ptr_Function_ulong %1054 %uint_2
-%1456 = OpLoad %ulong %1455
-OpStore %1124 %1456
-%1457 = OpLoad %ulong %1124
-%1459 = OpBitwiseAnd %ulong %1457 %ulong_255
-OpStore %1125 %1459
-%1460 = OpLoad %ulong %1125
-%1461 = OpConvertUToF %float %1460
-OpStore %1126 %1461
-%1463 = OpAccessChain %_ptr_Function_ulong %1054 %uint_4
-%1464 = OpLoad %ulong %1463
-OpStore %1127 %1464
-%1465 = OpLoad %ulong %1132
-%1466 = OpLoad %_struct_48 %1058
-%1467 = OpLoad %uint %1116
-%1468 = OpLoad %_struct_100 %1060
-%1469 = OpLoad %double %1118
-%1470 = OpLoad %_struct_132 %1062
-%1471 = OpLoad %_struct_156 %1064
-%1472 = OpLoad %_struct_180 %1066
-%1473 = OpLoad %ulong %1119
-%1474 = OpLoad %_struct_205 %1070
-%1475 = OpLoad %_struct_48 %1074
-%1476 = OpLoad %_struct_100 %1076
-%1477 = OpLoad %_struct_132 %1078
-%1478 = OpLoad %_struct_205 %1082
-%1479 = OpLoad %float %1126
-%1480 = OpLoad %ulong %1127
-%1481 = OpFunctionCall %ulong %9 %1465 %1466 %1467 %1468 %1469 %1470 %1471 %1472 %1473 %1474 %1475 %1476 %1477 %1478 %1479 %1480
-OpStore %1128 %1481
-%1482 = OpLoad %ulong %1130
-%1483 = OpLoad %ulong %1128
-%1484 = OpFunctionCall %ulong %18 %1482 %1483
-OpStore %1129 %1484
-%1485 = OpLoad %ulong %1129
-OpReturnValue %1485
-%1038 = OpLabel
-%1486 = OpLoad %ulong %1278
-%1487 = OpIMul %ulong %1486 %ulong_4
-OpStore %1272 %1487
-%1488 = OpLoad %ulong %1123
-%1489 = OpLoad %ulong %1272
-%1490 = OpShiftRightLogical %ulong %1488 %1489
-OpStore %1273 %1490
-%1491 = OpLoad %ulong %1273
-%1492 = OpUConvert %uchar %1491
-OpStore %1274 %1492
-%1493 = OpLoad %ulong %1278
-%1494 = OpUConvert %uchar %1493
-OpStore %1275 %1494
-%1495 = OpLoad %uchar %1274
-%1496 = OpLoad %uchar %1275
-%1497 = OpBitwiseXor %uchar %1495 %1496
-OpStore %1276 %1497
-%1498 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1081 %uint_1
-%1499 = OpLoad %ulong %1278
-%1500 = OpAccessChain %_ptr_Function_uchar %1498 %1499
-%1501 = OpLoad %uchar %1276
-OpStore %1500 %1501
-%1502 = OpLoad %ulong %1278
-%1503 = OpIAdd %ulong %1502 %ulong_1
-OpStore %1277 %1503
-%1504 = OpLoad %ulong %1277
-OpStore %1278 %1504
-OpBranch %1042
-%1020 = OpLabel
-%1505 = OpLoad %ulong %1244
-%1506 = OpIMul %ulong %1505 %ulong_8
-OpStore %1238 %1506
-%1507 = OpLoad %ulong %1120
-%1508 = OpLoad %ulong %1238
-%1509 = OpShiftRightLogical %ulong %1507 %1508
-OpStore %1239 %1509
-%1510 = OpLoad %ulong %1239
-%1511 = OpUConvert %uchar %1510
-OpStore %1240 %1511
-%1512 = OpLoad %ulong %1244
-%1513 = OpUConvert %uchar %1512
-OpStore %1241 %1513
-%1514 = OpLoad %uchar %1240
-%1515 = OpLoad %uchar %1241
-%1516 = OpIAdd %uchar %1514 %1515
-OpStore %1242 %1516
-%1517 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1073 %uint_1
-%1518 = OpLoad %ulong %1244
-%1519 = OpAccessChain %_ptr_Function_uchar %1517 %1518
-%1520 = OpLoad %uchar %1242
-OpStore %1519 %1520
-%1521 = OpLoad %ulong %1244
-%1522 = OpIAdd %ulong %1521 %ulong_1
-OpStore %1243 %1522
-%1523 = OpLoad %ulong %1243
-OpStore %1244 %1523
-OpBranch %1044
-%1010 = OpLabel
-%1524 = OpLoad %ulong %1226
-%1525 = OpIMul %ulong %1524 %ulong_4
-OpStore %1220 %1525
-%1526 = OpLoad %ulong %1132
-%1527 = OpLoad %ulong %1220
-%1528 = OpShiftRightLogical %ulong %1526 %1527
-OpStore %1221 %1528
-%1529 = OpLoad %ulong %1221
-%1530 = OpUConvert %uchar %1529
-OpStore %1222 %1530
-%1531 = OpLoad %ulong %1226
-%1532 = OpUConvert %uchar %1531
-OpStore %1223 %1532
-%1533 = OpLoad %uchar %1222
-%1534 = OpLoad %uchar %1223
-%1535 = OpBitwiseXor %uchar %1533 %1534
-OpStore %1224 %1535
-%1536 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1069 %uint_1
-%1537 = OpLoad %ulong %1226
-%1538 = OpAccessChain %_ptr_Function_uchar %1536 %1537
-%1539 = OpLoad %uchar %1224
-OpStore %1538 %1539
-%1540 = OpLoad %ulong %1226
-%1541 = OpIAdd %ulong %1540 %ulong_1
-OpStore %1225 %1541
-%1542 = OpLoad %ulong %1225
-OpStore %1226 %1542
-OpBranch %1046
-%984 = OpLabel
-%1543 = OpLoad %ulong %1172
-%1544 = OpIMul %ulong %1543 %ulong_8
-OpStore %1166 %1544
-%1545 = OpLoad %ulong %1132
-%1546 = OpLoad %ulong %1166
-%1547 = OpShiftRightLogical %ulong %1545 %1546
-OpStore %1167 %1547
-%1548 = OpLoad %ulong %1167
-%1549 = OpUConvert %uchar %1548
-OpStore %1168 %1549
-%1550 = OpLoad %ulong %1172
-%1551 = OpUConvert %uchar %1550
-OpStore %1169 %1551
-%1552 = OpLoad %uchar %1168
-%1553 = OpLoad %uchar %1169
-%1554 = OpIAdd %uchar %1552 %1553
-OpStore %1170 %1554
-%1555 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1057 %uint_1
-%1556 = OpLoad %ulong %1172
-%1557 = OpAccessChain %_ptr_Function_uchar %1555 %1556
-%1558 = OpLoad %uchar %1170
-OpStore %1557 %1558
-%1559 = OpLoad %ulong %1172
-%1560 = OpIAdd %ulong %1559 %ulong_1
-OpStore %1171 %1560
-%1561 = OpLoad %ulong %1171
-OpStore %1172 %1561
-OpBranch %1048
-%971 = OpLabel
-%1562 = OpLoad %ulong %1133
-%1563 = OpIMul %ulong %1562 %ulong_17
-OpStore %1088 %1563
-%1564 = OpLoad %ulong %1088
-%1565 = OpLoad %ulong %1083
-%1566 = OpIAdd %ulong %1564 %1565
-OpStore %1089 %1566
-%1567 = OpAccessChain %_ptr_Function_ulong %1054 %uint_0
-%1568 = OpLoad %ulong %1567
-OpStore %1090 %1568
-%1569 = OpLoad %ulong %1090
-%1570 = OpLoad %ulong %1089
-%1571 = OpIAdd %ulong %1569 %1570
-OpStore %1091 %1571
-%1572 = OpAccessChain %_ptr_Function_ulong %1054 %uint_1
-%1573 = OpLoad %ulong %1572
-OpStore %1092 %1573
-OpBranch %977
-%977 = OpLabel
-OpStore %1055 %782
-%1574 = OpLoad %ulong %1092
-%1575 = OpUConvert %uchar %1574
-OpStore %1155 %1575
-%1576 = OpAccessChain %_ptr_Function_uchar %1055 %uint_0
-%1577 = OpLoad %uchar %1155
-OpStore %1576 %1577
-OpStore %1163 %ulong_0
-OpBranch %978
-%978 = OpLabel
-%1578 = OpLoad %ulong %1163
-%1579 = OpULessThan %bool %1578 %ulong_8
-OpStore %1156 %1579
-%1580 = OpLoad %bool %1156
-OpLoopMerge %980 %1047 None
-OpBranchConditional %1580 %979 %980
-%980 = OpLabel
-%1581 = OpLoad %_struct_48 %1055
-OpStore %1056 %1581
-OpBranch %981
-%981 = OpLabel
-%1582 = OpAccessChain %_ptr_Function_ulong %1054 %uint_2
-%1583 = OpLoad %ulong %1582
-OpStore %1093 %1583
-%1584 = OpLoad %ulong %1093
-%1585 = OpUConvert %uint %1584
-OpStore %1094 %1585
-%1587 = OpAccessChain %_ptr_Function_ulong %1054 %uint_3
-%1588 = OpLoad %ulong %1587
-OpStore %1095 %1588
-OpBranch %987
-%987 = OpLabel
-%1589 = OpLoad %ulong %1095
-%1590 = OpUConvert %uint %1589
-OpStore %1173 %1590
-%1591 = OpAccessChain %_ptr_Function_uint %1059 %uint_0
-%1592 = OpLoad %uint %1173
-OpStore %1591 %1592
-%1593 = OpLoad %ulong %1095
-%1594 = OpShiftRightLogical %ulong %1593 %ulong_16
-OpStore %1174 %1594
-%1595 = OpLoad %ulong %1174
-%1596 = OpUConvert %uint %1595
-OpStore %1175 %1596
-%1597 = OpAccessChain %_ptr_Function_uint %1059 %uint_1
-%1598 = OpLoad %uint %1175
-OpStore %1597 %1598
-%1599 = OpLoad %ulong %1095
-%1600 = OpShiftRightLogical %ulong %1599 %ulong_32
-OpStore %1176 %1600
-%1601 = OpLoad %ulong %1176
-%1602 = OpUConvert %uint %1601
-OpStore %1177 %1602
-%1603 = OpAccessChain %_ptr_Function_uint %1059 %uint_2
-%1604 = OpLoad %uint %1177
-OpStore %1603 %1604
-OpBranch %988
-%988 = OpLabel
-%1605 = OpAccessChain %_ptr_Function_ulong %1054 %uint_4
-%1606 = OpLoad %ulong %1605
-OpStore %1096 %1606
-%1607 = OpLoad %ulong %1096
-%1608 = OpBitwiseAnd %ulong %1607 %ulong_1023
-OpStore %1097 %1608
-%1609 = OpLoad %ulong %1097
-%1610 = OpConvertUToF %double %1609
-OpStore %1098 %1610
-%1612 = OpAccessChain %_ptr_Function_ulong %1054 %uint_5
-%1613 = OpLoad %ulong %1612
-OpStore %1099 %1613
-%1614 = OpLoad %ulong %1099
-%1615 = OpLoad %ulong %1089
-%1616 = OpIAdd %ulong %1614 %1615
-OpStore %1100 %1616
-OpBranch %991
-%991 = OpLabel
-%1617 = OpAccessChain %_ptr_Function_ulong %1061 %uint_0
-%1618 = OpLoad %ulong %1100
-OpStore %1617 %1618
-%1619 = OpLoad %ulong %1100
-%1620 = OpIMul %ulong %1619 %ulong_3
-OpStore %1183 %1620
-%1621 = OpLoad %ulong %1183
-%1622 = OpIAdd %ulong %1621 %ulong_7
-OpStore %1184 %1622
-%1623 = OpAccessChain %_ptr_Function_ulong %1061 %uint_1
-%1624 = OpLoad %ulong %1184
-OpStore %1623 %1624
-OpBranch %992
-%992 = OpLabel
-%1626 = OpAccessChain %_ptr_Function_ulong %1054 %uint_6
-%1627 = OpLoad %ulong %1626
-OpStore %1101 %1627
-OpBranch %995
-%995 = OpLabel
-%1628 = OpLoad %ulong %1101
-%1629 = OpBitwiseAnd %ulong %1628 %ulong_65535
-OpStore %1187 %1629
-%1630 = OpLoad %ulong %1187
-%1631 = OpConvertUToF %double %1630
-OpStore %1188 %1631
-%1632 = OpLoad %double %1188
-%1633 = OpFDiv %double %1632 %double_8
-OpStore %1189 %1633
-%1634 = OpAccessChain %_ptr_Function_double %1063 %uint_0
-%1635 = OpLoad %double %1189
-OpStore %1634 %1635
-%1636 = OpLoad %ulong %1101
-%1637 = OpBitwiseAnd %ulong %1636 %ulong_4095
-OpStore %1190 %1637
-%1638 = OpLoad %ulong %1190
-%1639 = OpConvertUToF %double %1638
-OpStore %1191 %1639
-%1640 = OpLoad %double %1191
-%1641 = OpFSub %double %1640 %double_2048
-OpStore %1192 %1641
-%1642 = OpAccessChain %_ptr_Function_double %1063 %uint_1
-%1643 = OpLoad %double %1192
-OpStore %1642 %1643
-OpBranch %996
-%996 = OpLabel
-%1645 = OpAccessChain %_ptr_Function_ulong %1054 %uint_7
-%1646 = OpLoad %ulong %1645
-OpStore %1102 %1646
-OpBranch %999
-%999 = OpLabel
-%1647 = OpLoad %ulong %1102
-%1648 = OpBitwiseXor %ulong %1647 %ulong_305419896
-OpStore %1199 %1648
-%1649 = OpAccessChain %_ptr_Function_ulong %1065 %uint_0
-%1650 = OpLoad %ulong %1199
-OpStore %1649 %1650
-%1651 = OpLoad %ulong %1102
-%1652 = OpBitwiseAnd %ulong %1651 %ulong_262143
-OpStore %1200 %1652
-%1653 = OpLoad %ulong %1200
-%1654 = OpConvertUToF %double %1653
-OpStore %1201 %1654
-%1655 = OpLoad %double %1201
-%1656 = OpFDiv %double %1655 %double_64
-OpStore %1202 %1656
-%1657 = OpAccessChain %_ptr_Function_double %1065 %uint_1
-%1658 = OpLoad %double %1202
-OpStore %1657 %1658
-OpBranch %1000
-%1000 = OpLabel
-%1659 = OpAccessChain %_ptr_Function_ulong %1054 %uint_8
-%1660 = OpLoad %ulong %1659
-OpStore %1103 %1660
-%1662 = OpAccessChain %_ptr_Function_ulong %1054 %uint_9
-%1663 = OpLoad %ulong %1662
-OpStore %1104 %1663
-OpBranch %1003
-%1003 = OpLabel
-OpStore %1067 %934
-%1664 = OpLoad %ulong %1104
-%1665 = OpShiftRightLogical %ulong %1664 %ulong_7
-OpStore %1207 %1665
-%1666 = OpLoad %ulong %1207
-%1667 = OpUConvert %uchar %1666
-OpStore %1208 %1667
-%1668 = OpAccessChain %_ptr_Function_uchar %1067 %uint_0
-%1669 = OpLoad %uchar %1208
-OpStore %1668 %1669
-OpStore %1216 %ulong_0
-OpBranch %1004
-%1004 = OpLabel
-%1670 = OpLoad %ulong %1216
-%1671 = OpULessThan %bool %1670 %ulong_16
-OpStore %1209 %1671
-%1672 = OpLoad %bool %1209
-OpLoopMerge %1006 %1045 None
-OpBranchConditional %1672 %1005 %1006
-%1006 = OpLabel
-%1673 = OpLoad %_struct_205 %1067
-OpStore %1068 %1673
-OpBranch %1007
-%1007 = OpLabel
-%1674 = OpAccessChain %_ptr_Function_ulong %1054 %uint_10
-%1675 = OpLoad %ulong %1674
-OpStore %1105 %1675
-OpBranch %1013
-%1013 = OpLabel
-OpStore %1071 %782
-%1676 = OpLoad %ulong %1105
-%1677 = OpUConvert %uchar %1676
-OpStore %1227 %1677
-%1678 = OpAccessChain %_ptr_Function_uchar %1071 %uint_0
-%1679 = OpLoad %uchar %1227
-OpStore %1678 %1679
-OpStore %1235 %ulong_0
-OpBranch %1014
-%1014 = OpLabel
-%1680 = OpLoad %ulong %1235
-%1681 = OpULessThan %bool %1680 %ulong_8
-OpStore %1228 %1681
-%1682 = OpLoad %bool %1228
-OpLoopMerge %1016 %1043 None
-OpBranchConditional %1682 %1015 %1016
-%1016 = OpLabel
-%1683 = OpLoad %_struct_48 %1071
-OpStore %1072 %1683
-OpBranch %1017
-%1017 = OpLabel
-%1684 = OpAccessChain %_ptr_Function_ulong %1054 %uint_11
-%1685 = OpLoad %ulong %1684
-OpStore %1106 %1685
-OpBranch %1023
-%1023 = OpLabel
-%1686 = OpLoad %ulong %1106
-%1687 = OpUConvert %uint %1686
-OpStore %1245 %1687
-%1688 = OpAccessChain %_ptr_Function_uint %1075 %uint_0
-%1689 = OpLoad %uint %1245
-OpStore %1688 %1689
-%1690 = OpLoad %ulong %1106
-%1691 = OpShiftRightLogical %ulong %1690 %ulong_16
-OpStore %1246 %1691
-%1692 = OpLoad %ulong %1246
-%1693 = OpUConvert %uint %1692
-OpStore %1247 %1693
-%1694 = OpAccessChain %_ptr_Function_uint %1075 %uint_1
-%1695 = OpLoad %uint %1247
-OpStore %1694 %1695
-%1696 = OpLoad %ulong %1106
-%1697 = OpShiftRightLogical %ulong %1696 %ulong_32
-OpStore %1248 %1697
-%1698 = OpLoad %ulong %1248
-%1699 = OpUConvert %uint %1698
-OpStore %1249 %1699
-%1700 = OpAccessChain %_ptr_Function_uint %1075 %uint_2
-%1701 = OpLoad %uint %1249
-OpStore %1700 %1701
-OpBranch %1024
-%1024 = OpLabel
-%1702 = OpAccessChain %_ptr_Function_ulong %1054 %uint_0
-%1703 = OpLoad %ulong %1702
-OpStore %1107 %1703
-OpBranch %1027
-%1027 = OpLabel
-%1704 = OpAccessChain %_ptr_Function_ulong %1077 %uint_0
-%1705 = OpLoad %ulong %1107
-OpStore %1704 %1705
-%1706 = OpLoad %ulong %1107
-%1707 = OpIMul %ulong %1706 %ulong_3
-OpStore %1255 %1707
-%1708 = OpLoad %ulong %1255
-%1709 = OpIAdd %ulong %1708 %ulong_7
-OpStore %1256 %1709
-%1710 = OpAccessChain %_ptr_Function_ulong %1077 %uint_1
-%1711 = OpLoad %ulong %1256
-OpStore %1710 %1711
-OpBranch %1028
-%1028 = OpLabel
-%1712 = OpAccessChain %_ptr_Function_ulong %1054 %uint_1
-%1713 = OpLoad %ulong %1712
-OpStore %1108 %1713
-OpBranch %1031
-%1031 = OpLabel
-OpStore %1079 %934
-%1714 = OpLoad %ulong %1108
-%1715 = OpShiftRightLogical %ulong %1714 %ulong_7
-OpStore %1259 %1715
-%1716 = OpLoad %ulong %1259
-%1717 = OpUConvert %uchar %1716
-OpStore %1260 %1717
-%1718 = OpAccessChain %_ptr_Function_uchar %1079 %uint_0
-%1719 = OpLoad %uchar %1260
-OpStore %1718 %1719
-OpStore %1268 %ulong_0
-OpBranch %1032
-%1032 = OpLabel
-%1720 = OpLoad %ulong %1268
-%1721 = OpULessThan %bool %1720 %ulong_16
-OpStore %1261 %1721
-%1722 = OpLoad %bool %1261
-OpLoopMerge %1034 %1041 None
-OpBranchConditional %1722 %1033 %1034
-%1034 = OpLabel
-%1723 = OpLoad %_struct_205 %1079
-OpStore %1080 %1723
-OpBranch %1035
-%1035 = OpLabel
-%1724 = OpAccessChain %_ptr_Function_ulong %1054 %uint_2
-%1725 = OpLoad %ulong %1724
-OpStore %1109 %1725
-%1726 = OpLoad %ulong %1109
-%1727 = OpBitwiseAnd %ulong %1726 %ulong_255
-OpStore %1110 %1727
-%1728 = OpLoad %ulong %1110
-%1729 = OpConvertUToF %float %1728
-OpStore %1111 %1729
-%1730 = OpAccessChain %_ptr_Function_ulong %1054 %uint_3
-%1731 = OpLoad %ulong %1730
-OpStore %1112 %1731
-%1732 = OpLoad %ulong %1091
-%1733 = OpLoad %_struct_48 %1056
-%1734 = OpLoad %uint %1094
-%1735 = OpLoad %_struct_100 %1059
-%1736 = OpLoad %double %1098
-%1737 = OpLoad %_struct_132 %1061
-%1738 = OpLoad %_struct_156 %1063
-%1739 = OpLoad %_struct_180 %1065
-%1740 = OpLoad %ulong %1103
-%1741 = OpLoad %_struct_205 %1068
-%1742 = OpLoad %_struct_48 %1072
-%1743 = OpLoad %_struct_100 %1075
-%1744 = OpLoad %_struct_132 %1077
-%1745 = OpLoad %_struct_205 %1080
-%1746 = OpLoad %float %1111
-%1747 = OpLoad %ulong %1112
-%1748 = OpFunctionCall %ulong %9 %1732 %1733 %1734 %1735 %1736 %1737 %1738 %1739 %1740 %1741 %1742 %1743 %1744 %1745 %1746 %1747
-OpStore %1113 %1748
-%1749 = OpLoad %ulong %1130
-%1750 = OpLoad %ulong %1113
-%1751 = OpFunctionCall %ulong %18 %1749 %1750
-OpStore %1114 %1751
-%1752 = OpLoad %ulong %1133
-%1753 = OpIAdd %ulong %1752 %ulong_1
-OpStore %1115 %1753
-%1754 = OpLoad %ulong %1114
-OpStore %1130 %1754
-%1755 = OpLoad %ulong %1113
-OpStore %1132 %1755
-%1756 = OpLoad %ulong %1115
-OpStore %1133 %1756
-OpBranch %1049
-%1033 = OpLabel
-%1757 = OpLoad %ulong %1268
-%1758 = OpIMul %ulong %1757 %ulong_4
-OpStore %1262 %1758
-%1759 = OpLoad %ulong %1108
-%1760 = OpLoad %ulong %1262
-%1761 = OpShiftRightLogical %ulong %1759 %1760
-OpStore %1263 %1761
-%1762 = OpLoad %ulong %1263
-%1763 = OpUConvert %uchar %1762
-OpStore %1264 %1763
-%1764 = OpLoad %ulong %1268
-%1765 = OpUConvert %uchar %1764
-OpStore %1265 %1765
-%1766 = OpLoad %uchar %1264
-%1767 = OpLoad %uchar %1265
-%1768 = OpBitwiseXor %uchar %1766 %1767
-OpStore %1266 %1768
-%1769 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1079 %uint_1
-%1770 = OpLoad %ulong %1268
-%1771 = OpAccessChain %_ptr_Function_uchar %1769 %1770
-%1772 = OpLoad %uchar %1266
-OpStore %1771 %1772
-%1773 = OpLoad %ulong %1268
-%1774 = OpIAdd %ulong %1773 %ulong_1
-OpStore %1267 %1774
-%1775 = OpLoad %ulong %1267
-OpStore %1268 %1775
-OpBranch %1041
-%1015 = OpLabel
-%1776 = OpLoad %ulong %1235
-%1777 = OpIMul %ulong %1776 %ulong_8
-OpStore %1229 %1777
-%1778 = OpLoad %ulong %1105
-%1779 = OpLoad %ulong %1229
-%1780 = OpShiftRightLogical %ulong %1778 %1779
-OpStore %1230 %1780
-%1781 = OpLoad %ulong %1230
-%1782 = OpUConvert %uchar %1781
-OpStore %1231 %1782
-%1783 = OpLoad %ulong %1235
-%1784 = OpUConvert %uchar %1783
-OpStore %1232 %1784
-%1785 = OpLoad %uchar %1231
-%1786 = OpLoad %uchar %1232
-%1787 = OpIAdd %uchar %1785 %1786
-OpStore %1233 %1787
-%1788 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1071 %uint_1
-%1789 = OpLoad %ulong %1235
-%1790 = OpAccessChain %_ptr_Function_uchar %1788 %1789
-%1791 = OpLoad %uchar %1233
-OpStore %1790 %1791
-%1792 = OpLoad %ulong %1235
-%1793 = OpIAdd %ulong %1792 %ulong_1
-OpStore %1234 %1793
-%1794 = OpLoad %ulong %1234
-OpStore %1235 %1794
-OpBranch %1043
-%1005 = OpLabel
-%1795 = OpLoad %ulong %1216
-%1796 = OpIMul %ulong %1795 %ulong_4
-OpStore %1210 %1796
-%1797 = OpLoad %ulong %1104
-%1798 = OpLoad %ulong %1210
-%1799 = OpShiftRightLogical %ulong %1797 %1798
-OpStore %1211 %1799
-%1800 = OpLoad %ulong %1211
-%1801 = OpUConvert %uchar %1800
-OpStore %1212 %1801
-%1802 = OpLoad %ulong %1216
-%1803 = OpUConvert %uchar %1802
-OpStore %1213 %1803
-%1804 = OpLoad %uchar %1212
-%1805 = OpLoad %uchar %1213
-%1806 = OpBitwiseXor %uchar %1804 %1805
-OpStore %1214 %1806
-%1807 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1067 %uint_1
-%1808 = OpLoad %ulong %1216
-%1809 = OpAccessChain %_ptr_Function_uchar %1807 %1808
-%1810 = OpLoad %uchar %1214
-OpStore %1809 %1810
-%1811 = OpLoad %ulong %1216
-%1812 = OpIAdd %ulong %1811 %ulong_1
-OpStore %1215 %1812
-%1813 = OpLoad %ulong %1215
-OpStore %1216 %1813
-OpBranch %1045
-%979 = OpLabel
-%1814 = OpLoad %ulong %1163
-%1815 = OpIMul %ulong %1814 %ulong_8
-OpStore %1157 %1815
-%1816 = OpLoad %ulong %1092
-%1817 = OpLoad %ulong %1157
-%1818 = OpShiftRightLogical %ulong %1816 %1817
-OpStore %1158 %1818
-%1819 = OpLoad %ulong %1158
-%1820 = OpUConvert %uchar %1819
-OpStore %1159 %1820
-%1821 = OpLoad %ulong %1163
-%1822 = OpUConvert %uchar %1821
-OpStore %1160 %1822
-%1823 = OpLoad %uchar %1159
-%1824 = OpLoad %uchar %1160
-%1825 = OpIAdd %uchar %1823 %1824
-OpStore %1161 %1825
-%1826 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1055 %uint_1
-%1827 = OpLoad %ulong %1163
-%1828 = OpAccessChain %_ptr_Function_uchar %1826 %1827
-%1829 = OpLoad %uchar %1161
-OpStore %1828 %1829
-%1830 = OpLoad %ulong %1163
-%1831 = OpIAdd %ulong %1830 %ulong_1
-OpStore %1162 %1831
-%1832 = OpLoad %ulong %1162
-OpStore %1163 %1832
-OpBranch %1047
-%968 = OpLabel
-OpBranch %975
-%975 = OpLabel
-%1833 = OpLoad %ulong %1131
-%1834 = OpIMul %ulong %1833 %ulong_6364136223846793005
-OpStore %1152 %1834
-%1835 = OpLoad %ulong %1152
-%1836 = OpIAdd %ulong %1835 %ulong_1442695040888963407
-OpStore %1153 %1836
-%1837 = OpLoad %ulong %1153
-%1838 = OpLoad %ulong %1083
-%1839 = OpIAdd %ulong %1837 %1838
-OpStore %1154 %1839
-OpBranch %976
-%976 = OpLabel
-%1840 = OpLoad %ulong %1131
-%1841 = OpAccessChain %_ptr_Function_ulong %1054 %1840
-%1842 = OpLoad %ulong %1154
-OpStore %1841 %1842
-%1843 = OpLoad %ulong %1131
-%1844 = OpIAdd %ulong %1843 %ulong_1
-OpStore %1086 %1844
-%1845 = OpLoad %ulong %1086
-OpStore %1131 %1845
-OpBranch %1050
-%1041 = OpLabel
-OpBranch %1032
-%1042 = OpLabel
-OpBranch %1037
-%1043 = OpLabel
-OpBranch %1014
-%1044 = OpLabel
-OpBranch %1019
-%1045 = OpLabel
-OpBranch %1004
-%1046 = OpLabel
-OpBranch %1009
-%1047 = OpLabel
-OpBranch %978
-%1048 = OpLabel
-OpBranch %983
-%1049 = OpLabel
-OpBranch %970
-%1050 = OpLabel
-OpBranch %967
+%1350 = OpLoad %_struct_395 %1322
+OpReturnValue %1350
 OpFunctionEnd
-%17 = OpFunction %ulong None %1846
-%1847 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%14 = OpFunction %_struct_491 None %1351
+%1352 = OpFunctionParameter %ulong
+%1353 = OpLabel
+%1354 = OpVariable %_ptr_Function__struct_491 Function
+%1355 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_ulong Function
+%1357 = OpVariable %_ptr_Function_ulong Function
+%1358 = OpVariable %_ptr_Function_double Function
+%1359 = OpVariable %_ptr_Function_double Function
+OpStore %1355 %1352
+%1360 = OpLoad %ulong %1355
+%1362 = OpBitwiseXor %ulong %1360 %ulong_305419896
+OpStore %1356 %1362
+%1363 = OpAccessChain %_ptr_Function_ulong %1354 %uint_0
+%1364 = OpLoad %ulong %1356
+OpStore %1363 %1364
+%1365 = OpLoad %ulong %1355
+%1367 = OpBitwiseAnd %ulong %1365 %ulong_262143
+OpStore %1357 %1367
+%1368 = OpLoad %ulong %1357
+%1369 = OpConvertUToF %double %1368
+OpStore %1358 %1369
+%1370 = OpLoad %double %1358
+%1372 = OpFDiv %double %1370 %double_64
+OpStore %1359 %1372
+%1373 = OpAccessChain %_ptr_Function_double %1354 %uint_1
+%1374 = OpLoad %double %1359
+OpStore %1373 %1374
+%1375 = OpLoad %_struct_491 %1354
+OpReturnValue %1375
 OpFunctionEnd
-%18 = OpFunction %ulong None %24
-%1849 = OpFunctionParameter %ulong
-%1850 = OpFunctionParameter %ulong
-%1851 = OpLabel
-%1856 = OpVariable %_ptr_Function_ulong Function
-%1857 = OpVariable %_ptr_Function_ulong Function
-%1858 = OpVariable %_ptr_Function_bool Function
-%1859 = OpVariable %_ptr_Function_ulong Function
-%1860 = OpVariable %_ptr_Function_ulong Function
-%1861 = OpVariable %_ptr_Function_ulong Function
-%1862 = OpVariable %_ptr_Function_ulong Function
-%1863 = OpVariable %_ptr_Function_ulong Function
-%1864 = OpVariable %_ptr_Function_ulong Function
-%1865 = OpVariable %_ptr_Function_ulong Function
-%1866 = OpVariable %_ptr_Function_ulong Function
-OpStore %1856 %1849
-OpStore %1857 %1850
-%1867 = OpLoad %ulong %1856
-OpStore %1865 %1867
-OpStore %1866 %ulong_0
-OpBranch %1852
-%1852 = OpLabel
-%1868 = OpLoad %ulong %1866
-%1869 = OpULessThan %bool %1868 %ulong_8
-OpStore %1858 %1869
-%1870 = OpLoad %bool %1858
-OpLoopMerge %1854 %1855 None
-OpBranchConditional %1870 %1853 %1854
-%1854 = OpLabel
-%1871 = OpLoad %ulong %1865
-OpReturnValue %1871
-%1853 = OpLabel
-%1872 = OpLoad %ulong %1866
-%1873 = OpIMul %ulong %1872 %ulong_8
-OpStore %1859 %1873
-%1874 = OpLoad %ulong %1857
-%1875 = OpLoad %ulong %1859
-%1876 = OpShiftRightLogical %ulong %1874 %1875
-OpStore %1860 %1876
-%1877 = OpLoad %ulong %1860
-%1878 = OpBitwiseAnd %ulong %1877 %ulong_255
-OpStore %1861 %1878
-%1879 = OpLoad %ulong %1865
-%1880 = OpLoad %ulong %1861
-%1881 = OpBitwiseXor %ulong %1879 %1880
-OpStore %1862 %1881
-%1882 = OpLoad %ulong %1862
-%1884 = OpIMul %ulong %1882 %ulong_1099511628211
-OpStore %1863 %1884
-%1885 = OpLoad %ulong %1866
-%1886 = OpIAdd %ulong %1885 %ulong_1
-OpStore %1864 %1886
-%1887 = OpLoad %ulong %1863
-OpStore %1865 %1887
-%1888 = OpLoad %ulong %1864
-OpStore %1866 %1888
-OpBranch %1855
-%1855 = OpLabel
-OpBranch %1852
+%15 = OpFunction %_struct_583 None %1376
+%1377 = OpFunctionParameter %ulong
+%1378 = OpLabel
+%1383 = OpVariable %_ptr_Function__struct_583 Function
+%1384 = OpVariable %_ptr_Function__struct_583 Function
+%1385 = OpVariable %_ptr_Function_ulong Function
+%1386 = OpVariable %_ptr_Function_ulong Function
+%1387 = OpVariable %_ptr_Function_uchar Function
+%1388 = OpVariable %_ptr_Function_bool Function
+%1389 = OpVariable %_ptr_Function_ulong Function
+%1390 = OpVariable %_ptr_Function_ulong Function
+%1391 = OpVariable %_ptr_Function_uchar Function
+%1392 = OpVariable %_ptr_Function_uchar Function
+%1393 = OpVariable %_ptr_Function_uchar Function
+%1394 = OpVariable %_ptr_Function_ulong Function
+%1395 = OpVariable %_ptr_Function_ulong Function
+OpStore %1385 %1377
+OpStore %1383 %1396
+%1397 = OpLoad %ulong %1385
+%1398 = OpShiftRightLogical %ulong %1397 %ulong_7
+OpStore %1386 %1398
+%1399 = OpLoad %ulong %1386
+%1400 = OpUConvert %uchar %1399
+OpStore %1387 %1400
+%1401 = OpAccessChain %_ptr_Function_uchar %1383 %uint_0
+%1402 = OpLoad %uchar %1387
+OpStore %1401 %1402
+OpStore %1395 %ulong_0
+OpBranch %1379
+%1379 = OpLabel
+%1403 = OpLoad %ulong %1395
+%1404 = OpULessThan %bool %1403 %ulong_16
+OpStore %1388 %1404
+%1405 = OpLoad %bool %1388
+OpLoopMerge %1381 %1382 None
+OpBranchConditional %1405 %1380 %1381
+%1381 = OpLabel
+%1406 = OpLoad %_struct_583 %1383
+OpStore %1384 %1406
+%1407 = OpLoad %_struct_583 %1384
+OpReturnValue %1407
+%1380 = OpLabel
+%1408 = OpLoad %ulong %1395
+%1409 = OpIMul %ulong %1408 %ulong_4
+OpStore %1389 %1409
+%1410 = OpLoad %ulong %1385
+%1411 = OpLoad %ulong %1389
+%1412 = OpShiftRightLogical %ulong %1410 %1411
+OpStore %1390 %1412
+%1413 = OpLoad %ulong %1390
+%1414 = OpUConvert %uchar %1413
+OpStore %1391 %1414
+%1415 = OpLoad %ulong %1395
+%1416 = OpUConvert %uchar %1415
+OpStore %1392 %1416
+%1417 = OpLoad %uchar %1391
+%1418 = OpLoad %uchar %1392
+%1419 = OpBitwiseXor %uchar %1417 %1418
+OpStore %1393 %1419
+%1420 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1383 %uint_1
+%1421 = OpLoad %ulong %1395
+%1422 = OpAccessChain %_ptr_Function_uchar %1420 %1421
+%1423 = OpLoad %uchar %1393
+OpStore %1422 %1423
+%1424 = OpLoad %ulong %1395
+%1425 = OpIAdd %ulong %1424 %ulong_1
+OpStore %1394 %1425
+%1426 = OpLoad %ulong %1394
+OpStore %1395 %1426
+OpBranch %1382
+%1382 = OpLabel
+OpBranch %1379
 OpFunctionEnd
-%19 = OpFunction %ulong None %1889
-%1890 = OpFunctionParameter %ulong
-%1891 = OpFunctionParameter %uchar
-%1892 = OpLabel
-%1899 = OpVariable %_ptr_Function_ulong Function
-%1900 = OpVariable %_ptr_Function_uchar Function
-%1901 = OpVariable %_ptr_Function_ulong Function
-%1902 = OpVariable %_ptr_Function_bool Function
-%1903 = OpVariable %_ptr_Function_ulong Function
-%1904 = OpVariable %_ptr_Function_ulong Function
-%1905 = OpVariable %_ptr_Function_ulong Function
-%1906 = OpVariable %_ptr_Function_ulong Function
-%1907 = OpVariable %_ptr_Function_ulong Function
-%1908 = OpVariable %_ptr_Function_ulong Function
-%1909 = OpVariable %_ptr_Function_ulong Function
-%1910 = OpVariable %_ptr_Function_ulong Function
-OpStore %1899 %1890
-OpStore %1900 %1891
-%1911 = OpLoad %uchar %1900
-%1912 = OpUConvert %ulong %1911
-OpStore %1901 %1912
-OpBranch %1893
-%1893 = OpLabel
-%1913 = OpLoad %ulong %1899
-OpStore %1909 %1913
-OpStore %1910 %ulong_0
-OpBranch %1894
-%1894 = OpLabel
-%1914 = OpLoad %ulong %1910
-%1915 = OpULessThan %bool %1914 %ulong_8
-OpStore %1902 %1915
-%1916 = OpLoad %bool %1902
-OpLoopMerge %1896 %1898 None
-OpBranchConditional %1916 %1895 %1896
-%1896 = OpLabel
-OpBranch %1897
-%1897 = OpLabel
-%1917 = OpLoad %ulong %1909
-OpReturnValue %1917
-%1895 = OpLabel
-%1918 = OpLoad %ulong %1910
-%1919 = OpIMul %ulong %1918 %ulong_8
-OpStore %1903 %1919
-%1920 = OpLoad %ulong %1901
-%1921 = OpLoad %ulong %1903
-%1922 = OpShiftRightLogical %ulong %1920 %1921
-OpStore %1904 %1922
-%1923 = OpLoad %ulong %1904
-%1924 = OpBitwiseAnd %ulong %1923 %ulong_255
-OpStore %1905 %1924
-%1925 = OpLoad %ulong %1909
-%1926 = OpLoad %ulong %1905
-%1927 = OpBitwiseXor %ulong %1925 %1926
-OpStore %1906 %1927
-%1928 = OpLoad %ulong %1906
-%1929 = OpIMul %ulong %1928 %ulong_1099511628211
-OpStore %1907 %1929
-%1930 = OpLoad %ulong %1910
-%1931 = OpIAdd %ulong %1930 %ulong_1
-OpStore %1908 %1931
-%1932 = OpLoad %ulong %1907
-OpStore %1909 %1932
-%1933 = OpLoad %ulong %1908
-OpStore %1910 %1933
-OpBranch %1898
-%1898 = OpLabel
-OpBranch %1894
+%16 = OpFunction %ulong None %700
+%1427 = OpFunctionParameter %ulong
+%1428 = OpLabel
+%1533 = OpVariable %_ptr_Function__struct_43 Function
+%1534 = OpVariable %_ptr_Function__struct_43 Function
+%1535 = OpVariable %_ptr_Function__struct_43 Function
+%1536 = OpVariable %_ptr_Function__struct_43 Function
+%1540 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
+%1541 = OpVariable %_ptr_Function__struct_169 Function
+%1542 = OpVariable %_ptr_Function__struct_169 Function
+%1543 = OpVariable %_ptr_Function__struct_309 Function
+%1544 = OpVariable %_ptr_Function__struct_309 Function
+%1545 = OpVariable %_ptr_Function__struct_395 Function
+%1546 = OpVariable %_ptr_Function__struct_395 Function
+%1547 = OpVariable %_ptr_Function__struct_491 Function
+%1548 = OpVariable %_ptr_Function__struct_491 Function
+%1549 = OpVariable %_ptr_Function__struct_583 Function
+%1550 = OpVariable %_ptr_Function__struct_583 Function
+%1551 = OpVariable %_ptr_Function__struct_583 Function
+%1552 = OpVariable %_ptr_Function__struct_583 Function
+%1553 = OpVariable %_ptr_Function__struct_43 Function
+%1554 = OpVariable %_ptr_Function__struct_43 Function
+%1555 = OpVariable %_ptr_Function__struct_43 Function
+%1556 = OpVariable %_ptr_Function__struct_43 Function
+%1557 = OpVariable %_ptr_Function__struct_169 Function
+%1558 = OpVariable %_ptr_Function__struct_169 Function
+%1559 = OpVariable %_ptr_Function__struct_309 Function
+%1560 = OpVariable %_ptr_Function__struct_309 Function
+%1561 = OpVariable %_ptr_Function__struct_583 Function
+%1562 = OpVariable %_ptr_Function__struct_583 Function
+%1563 = OpVariable %_ptr_Function__struct_583 Function
+%1564 = OpVariable %_ptr_Function__struct_583 Function
+%1565 = OpVariable %_ptr_Function_ulong Function
+%1566 = OpVariable %_ptr_Function_bool Function
+%1567 = OpVariable %_ptr_Function_ulong Function
+%1568 = OpVariable %_ptr_Function_bool Function
+%1569 = OpVariable %_ptr_Function_ulong Function
+%1570 = OpVariable %_ptr_Function_ulong Function
+%1571 = OpVariable %_ptr_Function_ulong Function
+%1572 = OpVariable %_ptr_Function_ulong Function
+%1573 = OpVariable %_ptr_Function_ulong Function
+%1574 = OpVariable %_ptr_Function_ulong Function
+%1575 = OpVariable %_ptr_Function_uint Function
+%1576 = OpVariable %_ptr_Function_ulong Function
+%1577 = OpVariable %_ptr_Function_ulong Function
+%1578 = OpVariable %_ptr_Function_ulong Function
+%1579 = OpVariable %_ptr_Function_double Function
+%1580 = OpVariable %_ptr_Function_ulong Function
+%1581 = OpVariable %_ptr_Function_ulong Function
+%1582 = OpVariable %_ptr_Function_ulong Function
+%1583 = OpVariable %_ptr_Function_ulong Function
+%1584 = OpVariable %_ptr_Function_ulong Function
+%1585 = OpVariable %_ptr_Function_ulong Function
+%1586 = OpVariable %_ptr_Function_ulong Function
+%1587 = OpVariable %_ptr_Function_ulong Function
+%1588 = OpVariable %_ptr_Function_ulong Function
+%1589 = OpVariable %_ptr_Function_ulong Function
+%1590 = OpVariable %_ptr_Function_ulong Function
+%1591 = OpVariable %_ptr_Function_ulong Function
+%1592 = OpVariable %_ptr_Function_float Function
+%1593 = OpVariable %_ptr_Function_ulong Function
+%1594 = OpVariable %_ptr_Function_ulong Function
+%1595 = OpVariable %_ptr_Function_ulong Function
+%1596 = OpVariable %_ptr_Function_ulong Function
+%1597 = OpVariable %_ptr_Function_uint Function
+%1598 = OpVariable %_ptr_Function_ulong Function
+%1599 = OpVariable %_ptr_Function_double Function
+%1600 = OpVariable %_ptr_Function_ulong Function
+%1601 = OpVariable %_ptr_Function_ulong Function
+%1602 = OpVariable %_ptr_Function_ulong Function
+%1603 = OpVariable %_ptr_Function_ulong Function
+%1604 = OpVariable %_ptr_Function_ulong Function
+%1605 = OpVariable %_ptr_Function_ulong Function
+%1606 = OpVariable %_ptr_Function_ulong Function
+%1607 = OpVariable %_ptr_Function_float Function
+%1608 = OpVariable %_ptr_Function_ulong Function
+%1609 = OpVariable %_ptr_Function_ulong Function
+%1610 = OpVariable %_ptr_Function_ulong Function
+%1611 = OpVariable %_ptr_Function_ulong Function
+%1612 = OpVariable %_ptr_Function_ulong Function
+%1613 = OpVariable %_ptr_Function_ulong Function
+%1614 = OpVariable %_ptr_Function_ulong Function
+%1615 = OpVariable %_ptr_Function_ulong Function
+%1616 = OpVariable %_ptr_Function_ulong Function
+%1617 = OpVariable %_ptr_Function_ulong Function
+%1618 = OpVariable %_ptr_Function_uchar Function
+%1619 = OpVariable %_ptr_Function_bool Function
+%1620 = OpVariable %_ptr_Function_ulong Function
+%1621 = OpVariable %_ptr_Function_ulong Function
+%1622 = OpVariable %_ptr_Function_uchar Function
+%1623 = OpVariable %_ptr_Function_uchar Function
+%1624 = OpVariable %_ptr_Function_uchar Function
+%1625 = OpVariable %_ptr_Function_ulong Function
+%1626 = OpVariable %_ptr_Function_ulong Function
+%1627 = OpVariable %_ptr_Function_uchar Function
+%1628 = OpVariable %_ptr_Function_bool Function
+%1629 = OpVariable %_ptr_Function_ulong Function
+%1630 = OpVariable %_ptr_Function_ulong Function
+%1631 = OpVariable %_ptr_Function_uchar Function
+%1632 = OpVariable %_ptr_Function_uchar Function
+%1633 = OpVariable %_ptr_Function_uchar Function
+%1634 = OpVariable %_ptr_Function_ulong Function
+%1635 = OpVariable %_ptr_Function_ulong Function
+%1636 = OpVariable %_ptr_Function_ulong Function
+%1637 = OpVariable %_ptr_Function_ulong Function
+%1638 = OpVariable %_ptr_Function_ulong Function
+%1639 = OpVariable %_ptr_Function_ulong Function
+%1640 = OpVariable %_ptr_Function_ulong Function
+%1641 = OpVariable %_ptr_Function_ulong Function
+%1642 = OpVariable %_ptr_Function_ulong Function
+%1643 = OpVariable %_ptr_Function_ulong Function
+%1644 = OpVariable %_ptr_Function_ulong Function
+%1645 = OpVariable %_ptr_Function_ulong Function
+%1646 = OpVariable %_ptr_Function_ulong Function
+%1647 = OpVariable %_ptr_Function_ulong Function
+%1648 = OpVariable %_ptr_Function_ulong Function
+%1649 = OpVariable %_ptr_Function_ulong Function
+%1650 = OpVariable %_ptr_Function_ulong Function
+%1651 = OpVariable %_ptr_Function_bool Function
+%1652 = OpVariable %_ptr_Function_ulong Function
+%1653 = OpVariable %_ptr_Function_ulong Function
+%1654 = OpVariable %_ptr_Function_ulong Function
+%1655 = OpVariable %_ptr_Function_ulong Function
+%1656 = OpVariable %_ptr_Function_ulong Function
+%1657 = OpVariable %_ptr_Function_ulong Function
+%1658 = OpVariable %_ptr_Function_ulong Function
+%1659 = OpVariable %_ptr_Function_ulong Function
+%1660 = OpVariable %_ptr_Function_bool Function
+%1661 = OpVariable %_ptr_Function_ulong Function
+%1662 = OpVariable %_ptr_Function_ulong Function
+%1663 = OpVariable %_ptr_Function_ulong Function
+%1664 = OpVariable %_ptr_Function_ulong Function
+%1665 = OpVariable %_ptr_Function_ulong Function
+%1666 = OpVariable %_ptr_Function_ulong Function
+%1667 = OpVariable %_ptr_Function_ulong Function
+%1668 = OpVariable %_ptr_Function_ulong Function
+%1669 = OpVariable %_ptr_Function_bool Function
+%1670 = OpVariable %_ptr_Function_ulong Function
+%1671 = OpVariable %_ptr_Function_ulong Function
+%1672 = OpVariable %_ptr_Function_ulong Function
+%1673 = OpVariable %_ptr_Function_ulong Function
+%1674 = OpVariable %_ptr_Function_ulong Function
+%1675 = OpVariable %_ptr_Function_ulong Function
+%1676 = OpVariable %_ptr_Function_ulong Function
+%1677 = OpVariable %_ptr_Function_ulong Function
+%1678 = OpVariable %_ptr_Function_uint Function
+%1679 = OpVariable %_ptr_Function_ulong Function
+%1680 = OpVariable %_ptr_Function_uint Function
+%1681 = OpVariable %_ptr_Function_ulong Function
+%1682 = OpVariable %_ptr_Function_uint Function
+%1683 = OpVariable %_ptr_Function_uint Function
+%1684 = OpVariable %_ptr_Function_ulong Function
+%1685 = OpVariable %_ptr_Function_uint Function
+%1686 = OpVariable %_ptr_Function_ulong Function
+%1687 = OpVariable %_ptr_Function_uint Function
+%1688 = OpVariable %_ptr_Function_ulong Function
+%1689 = OpVariable %_ptr_Function_ulong Function
+%1690 = OpVariable %_ptr_Function_ulong Function
+%1691 = OpVariable %_ptr_Function_ulong Function
+%1692 = OpVariable %_ptr_Function_ulong Function
+%1693 = OpVariable %_ptr_Function_double Function
+%1694 = OpVariable %_ptr_Function_double Function
+%1695 = OpVariable %_ptr_Function_ulong Function
+%1696 = OpVariable %_ptr_Function_double Function
+%1697 = OpVariable %_ptr_Function_double Function
+%1698 = OpVariable %_ptr_Function_ulong Function
+%1699 = OpVariable %_ptr_Function_double Function
+%1700 = OpVariable %_ptr_Function_double Function
+%1701 = OpVariable %_ptr_Function_ulong Function
+%1702 = OpVariable %_ptr_Function_double Function
+%1703 = OpVariable %_ptr_Function_double Function
+%1704 = OpVariable %_ptr_Function_ulong Function
+%1705 = OpVariable %_ptr_Function_ulong Function
+%1706 = OpVariable %_ptr_Function_double Function
+%1707 = OpVariable %_ptr_Function_double Function
+%1708 = OpVariable %_ptr_Function_ulong Function
+%1709 = OpVariable %_ptr_Function_ulong Function
+%1710 = OpVariable %_ptr_Function_double Function
+%1711 = OpVariable %_ptr_Function_double Function
+%1712 = OpVariable %_ptr_Function_ulong Function
+%1713 = OpVariable %_ptr_Function_uchar Function
+%1714 = OpVariable %_ptr_Function_bool Function
+%1715 = OpVariable %_ptr_Function_ulong Function
+%1716 = OpVariable %_ptr_Function_ulong Function
+%1717 = OpVariable %_ptr_Function_uchar Function
+%1718 = OpVariable %_ptr_Function_uchar Function
+%1719 = OpVariable %_ptr_Function_uchar Function
+%1720 = OpVariable %_ptr_Function_ulong Function
+%1721 = OpVariable %_ptr_Function_ulong Function
+%1722 = OpVariable %_ptr_Function_ulong Function
+%1723 = OpVariable %_ptr_Function_uchar Function
+%1724 = OpVariable %_ptr_Function_bool Function
+%1725 = OpVariable %_ptr_Function_ulong Function
+%1726 = OpVariable %_ptr_Function_ulong Function
+%1727 = OpVariable %_ptr_Function_uchar Function
+%1728 = OpVariable %_ptr_Function_uchar Function
+%1729 = OpVariable %_ptr_Function_uchar Function
+%1730 = OpVariable %_ptr_Function_ulong Function
+%1731 = OpVariable %_ptr_Function_ulong Function
+%1732 = OpVariable %_ptr_Function_uchar Function
+%1733 = OpVariable %_ptr_Function_bool Function
+%1734 = OpVariable %_ptr_Function_ulong Function
+%1735 = OpVariable %_ptr_Function_ulong Function
+%1736 = OpVariable %_ptr_Function_uchar Function
+%1737 = OpVariable %_ptr_Function_uchar Function
+%1738 = OpVariable %_ptr_Function_uchar Function
+%1739 = OpVariable %_ptr_Function_ulong Function
+%1740 = OpVariable %_ptr_Function_ulong Function
+%1741 = OpVariable %_ptr_Function_uchar Function
+%1742 = OpVariable %_ptr_Function_bool Function
+%1743 = OpVariable %_ptr_Function_ulong Function
+%1744 = OpVariable %_ptr_Function_ulong Function
+%1745 = OpVariable %_ptr_Function_uchar Function
+%1746 = OpVariable %_ptr_Function_uchar Function
+%1747 = OpVariable %_ptr_Function_uchar Function
+%1748 = OpVariable %_ptr_Function_ulong Function
+%1749 = OpVariable %_ptr_Function_ulong Function
+%1750 = OpVariable %_ptr_Function_uint Function
+%1751 = OpVariable %_ptr_Function_ulong Function
+%1752 = OpVariable %_ptr_Function_uint Function
+%1753 = OpVariable %_ptr_Function_ulong Function
+%1754 = OpVariable %_ptr_Function_uint Function
+%1755 = OpVariable %_ptr_Function_uint Function
+%1756 = OpVariable %_ptr_Function_ulong Function
+%1757 = OpVariable %_ptr_Function_uint Function
+%1758 = OpVariable %_ptr_Function_ulong Function
+%1759 = OpVariable %_ptr_Function_uint Function
+%1760 = OpVariable %_ptr_Function_ulong Function
+%1761 = OpVariable %_ptr_Function_ulong Function
+%1762 = OpVariable %_ptr_Function_ulong Function
+%1763 = OpVariable %_ptr_Function_ulong Function
+%1764 = OpVariable %_ptr_Function_ulong Function
+%1765 = OpVariable %_ptr_Function_uchar Function
+%1766 = OpVariable %_ptr_Function_bool Function
+%1767 = OpVariable %_ptr_Function_ulong Function
+%1768 = OpVariable %_ptr_Function_ulong Function
+%1769 = OpVariable %_ptr_Function_uchar Function
+%1770 = OpVariable %_ptr_Function_uchar Function
+%1771 = OpVariable %_ptr_Function_uchar Function
+%1772 = OpVariable %_ptr_Function_ulong Function
+%1773 = OpVariable %_ptr_Function_ulong Function
+%1774 = OpVariable %_ptr_Function_ulong Function
+%1775 = OpVariable %_ptr_Function_uchar Function
+%1776 = OpVariable %_ptr_Function_bool Function
+%1777 = OpVariable %_ptr_Function_ulong Function
+%1778 = OpVariable %_ptr_Function_ulong Function
+%1779 = OpVariable %_ptr_Function_uchar Function
+%1780 = OpVariable %_ptr_Function_uchar Function
+%1781 = OpVariable %_ptr_Function_uchar Function
+%1782 = OpVariable %_ptr_Function_ulong Function
+%1783 = OpVariable %_ptr_Function_ulong Function
+OpStore %1565 %1427
+OpBranch %1435
+%1435 = OpLabel
+OpBranch %1436
+%1436 = OpLabel
+OpBranch %1449
+%1449 = OpLabel
+OpBranch %1450
+%1450 = OpLabel
+OpStore %1658 %ulong_14695981039346656037
+OpStore %1659 %ulong_0
+OpBranch %1451
+%1451 = OpLabel
+%1784 = OpLoad %ulong %1659
+%1785 = OpULessThan %bool %1784 %ulong_8
+OpStore %1651 %1785
+%1786 = OpLoad %bool %1651
+OpLoopMerge %1453 %1532 None
+OpBranchConditional %1786 %1452 %1453
+%1453 = OpLabel
+OpBranch %1454
+%1454 = OpLabel
+OpBranch %1455
+%1455 = OpLabel
+%1787 = OpLoad %ulong %1658
+OpStore %1667 %1787
+OpStore %1668 %ulong_0
+OpBranch %1456
+%1456 = OpLabel
+%1788 = OpLoad %ulong %1668
+%1789 = OpULessThan %bool %1788 %ulong_8
+OpStore %1660 %1789
+%1790 = OpLoad %bool %1660
+OpLoopMerge %1458 %1531 None
+OpBranchConditional %1790 %1457 %1458
+%1458 = OpLabel
+OpBranch %1459
+%1459 = OpLabel
+OpBranch %1460
+%1460 = OpLabel
+%1791 = OpLoad %ulong %1667
+OpStore %1676 %1791
+OpStore %1677 %ulong_0
+OpBranch %1461
+%1461 = OpLabel
+%1792 = OpLoad %ulong %1677
+%1793 = OpULessThan %bool %1792 %ulong_8
+OpStore %1669 %1793
+%1794 = OpLoad %bool %1669
+OpLoopMerge %1463 %1530 None
+OpBranchConditional %1794 %1462 %1463
+%1463 = OpLabel
+OpBranch %1464
+%1464 = OpLabel
+%1795 = OpLoad %ulong %1676
+%1796 = OpFunctionCall %ulong %17 %1795 %ulong_16
+OpStore %1636 %1796
+%1797 = OpLoad %ulong %1636
+%1798 = OpFunctionCall %ulong %17 %1797 %ulong_16
+OpStore %1637 %1798
+%1799 = OpLoad %ulong %1637
+%1800 = OpFunctionCall %ulong %17 %1799 %ulong_17
+OpStore %1638 %1800
+%1801 = OpLoad %ulong %1638
+%1802 = OpFunctionCall %ulong %17 %1801 %ulong_1
+OpStore %1639 %1802
+%1803 = OpLoad %ulong %1639
+%1804 = OpFunctionCall %ulong %17 %1803 %ulong_4
+OpStore %1640 %1804
+%1805 = OpLoad %ulong %1640
+%1806 = OpFunctionCall %ulong %17 %1805 %ulong_8
+OpStore %1641 %1806
+%1807 = OpLoad %ulong %1641
+%1808 = OpFunctionCall %ulong %17 %1807 %ulong_8
+OpStore %1642 %1808
+%1809 = OpLoad %ulong %1642
+%1810 = OpFunctionCall %ulong %17 %1809 %ulong_8
+OpStore %1643 %1810
+%1811 = OpLoad %ulong %1643
+%1812 = OpFunctionCall %ulong %17 %1811 %ulong_1
+OpStore %1644 %1812
+%1813 = OpLoad %ulong %1644
+%1814 = OpFunctionCall %ulong %17 %1813 %ulong_1
+OpStore %1645 %1814
+%1815 = OpLoad %ulong %1645
+%1816 = OpFunctionCall %ulong %17 %1815 %ulong_8
+OpStore %1646 %1816
+%1817 = OpLoad %ulong %1646
+%1818 = OpFunctionCall %ulong %17 %1817 %ulong_8
+OpStore %1647 %1818
+%1819 = OpLoad %ulong %1647
+%1820 = OpFunctionCall %ulong %17 %1819 %ulong_8
+OpStore %1648 %1820
+%1821 = OpLoad %ulong %1648
+%1822 = OpFunctionCall %ulong %17 %1821 %ulong_8
+OpStore %1649 %1822
+%1823 = OpLoad %ulong %1649
+%1824 = OpFunctionCall %ulong %17 %1823 %ulong_1
+OpStore %1650 %1824
+OpBranch %1465
+%1465 = OpLabel
+OpStore %1540 %1825
+OpStore %1612 %ulong_0
+OpBranch %1429
+%1429 = OpLabel
+%1826 = OpLoad %ulong %1612
+%1827 = OpULessThan %bool %1826 %ulong_12
+OpStore %1566 %1827
+%1828 = OpLoad %bool %1566
+OpLoopMerge %1431 %1529 None
+OpBranchConditional %1828 %1430 %1431
+%1431 = OpLabel
+%1829 = OpLoad %ulong %1650
+OpStore %1611 %1829
+OpStore %1613 %ulong_0
+OpStore %1614 %ulong_0
+OpBranch %1432
+%1432 = OpLabel
+%1830 = OpLoad %ulong %1614
+%1831 = OpULessThan %bool %1830 %ulong_3
+OpStore %1568 %1831
+%1832 = OpLoad %bool %1568
+OpLoopMerge %1434 %1528 None
+OpBranchConditional %1832 %1433 %1434
+%1434 = OpLabel
+OpBranch %1444
+%1444 = OpLabel
+OpStore %1535 %1244
+%1833 = OpLoad %ulong %1613
+%1834 = OpUConvert %uchar %1833
+OpStore %1627 %1834
+%1835 = OpAccessChain %_ptr_Function_uchar %1535 %uint_0
+%1836 = OpLoad %uchar %1627
+OpStore %1835 %1836
+OpStore %1635 %ulong_0
+OpBranch %1445
+%1445 = OpLabel
+%1837 = OpLoad %ulong %1635
+%1838 = OpULessThan %bool %1837 %ulong_8
+OpStore %1628 %1838
+%1839 = OpLoad %bool %1628
+OpLoopMerge %1447 %1527 None
+OpBranchConditional %1839 %1446 %1447
+%1447 = OpLabel
+%1840 = OpLoad %_struct_43 %1535
+OpStore %1536 %1840
+OpBranch %1448
+%1448 = OpLabel
+%1841 = OpLoad %ulong %1613
+%1842 = OpUConvert %uint %1841
+OpStore %1597 %1842
+OpBranch %1468
+%1468 = OpLabel
+%1843 = OpLoad %ulong %1613
+%1844 = OpUConvert %uint %1843
+OpStore %1683 %1844
+%1845 = OpAccessChain %_ptr_Function_uint %1542 %uint_0
+%1846 = OpLoad %uint %1683
+OpStore %1845 %1846
+%1847 = OpLoad %ulong %1613
+%1848 = OpShiftRightLogical %ulong %1847 %ulong_16
+OpStore %1684 %1848
+%1849 = OpLoad %ulong %1684
+%1850 = OpUConvert %uint %1849
+OpStore %1685 %1850
+%1851 = OpAccessChain %_ptr_Function_uint %1542 %uint_1
+%1852 = OpLoad %uint %1685
+OpStore %1851 %1852
+%1853 = OpLoad %ulong %1613
+%1854 = OpShiftRightLogical %ulong %1853 %ulong_32
+OpStore %1686 %1854
+%1855 = OpLoad %ulong %1686
+%1856 = OpUConvert %uint %1855
+OpStore %1687 %1856
+%1857 = OpAccessChain %_ptr_Function_uint %1542 %uint_2
+%1858 = OpLoad %uint %1687
+OpStore %1857 %1858
+OpBranch %1469
+%1469 = OpLabel
+%1859 = OpLoad %ulong %1613
+%1861 = OpBitwiseAnd %ulong %1859 %ulong_1023
+OpStore %1598 %1861
+%1862 = OpLoad %ulong %1598
+%1863 = OpConvertUToF %double %1862
+OpStore %1599 %1863
+OpBranch %1472
+%1472 = OpLabel
+%1864 = OpAccessChain %_ptr_Function_ulong %1544 %uint_0
+%1865 = OpLoad %ulong %1613
+OpStore %1864 %1865
+%1866 = OpLoad %ulong %1613
+%1867 = OpIMul %ulong %1866 %ulong_3
+OpStore %1690 %1867
+%1868 = OpLoad %ulong %1690
+%1869 = OpIAdd %ulong %1868 %ulong_7
+OpStore %1691 %1869
+%1870 = OpAccessChain %_ptr_Function_ulong %1544 %uint_1
+%1871 = OpLoad %ulong %1691
+OpStore %1870 %1871
+OpBranch %1473
+%1473 = OpLabel
+OpBranch %1476
+%1476 = OpLabel
+%1872 = OpLoad %ulong %1613
+%1873 = OpBitwiseAnd %ulong %1872 %ulong_65535
+OpStore %1698 %1873
+%1874 = OpLoad %ulong %1698
+%1875 = OpConvertUToF %double %1874
+OpStore %1699 %1875
+%1876 = OpLoad %double %1699
+%1877 = OpFDiv %double %1876 %double_8
+OpStore %1700 %1877
+%1878 = OpAccessChain %_ptr_Function_double %1546 %uint_0
+%1879 = OpLoad %double %1700
+OpStore %1878 %1879
+%1880 = OpLoad %ulong %1613
+%1881 = OpBitwiseAnd %ulong %1880 %ulong_4095
+OpStore %1701 %1881
+%1882 = OpLoad %ulong %1701
+%1883 = OpConvertUToF %double %1882
+OpStore %1702 %1883
+%1884 = OpLoad %double %1702
+%1885 = OpFSub %double %1884 %double_2048
+OpStore %1703 %1885
+%1886 = OpAccessChain %_ptr_Function_double %1546 %uint_1
+%1887 = OpLoad %double %1703
+OpStore %1886 %1887
+OpBranch %1477
+%1477 = OpLabel
+OpBranch %1480
+%1480 = OpLabel
+%1888 = OpLoad %ulong %1613
+%1889 = OpBitwiseXor %ulong %1888 %ulong_305419896
+OpStore %1708 %1889
+%1890 = OpAccessChain %_ptr_Function_ulong %1548 %uint_0
+%1891 = OpLoad %ulong %1708
+OpStore %1890 %1891
+%1892 = OpLoad %ulong %1613
+%1893 = OpBitwiseAnd %ulong %1892 %ulong_262143
+OpStore %1709 %1893
+%1894 = OpLoad %ulong %1709
+%1895 = OpConvertUToF %double %1894
+OpStore %1710 %1895
+%1896 = OpLoad %double %1710
+%1897 = OpFDiv %double %1896 %double_64
+OpStore %1711 %1897
+%1898 = OpAccessChain %_ptr_Function_double %1548 %uint_1
+%1899 = OpLoad %double %1711
+OpStore %1898 %1899
+OpBranch %1481
+%1481 = OpLabel
+%1900 = OpAccessChain %_ptr_Function_ulong %1540 %uint_8
+%1901 = OpLoad %ulong %1900
+OpStore %1600 %1901
+OpBranch %1487
+%1487 = OpLabel
+OpStore %1551 %1396
+%1902 = OpLoad %ulong %1613
+%1903 = OpShiftRightLogical %ulong %1902 %ulong_7
+OpStore %1722 %1903
+%1904 = OpLoad %ulong %1722
+%1905 = OpUConvert %uchar %1904
+OpStore %1723 %1905
+%1906 = OpAccessChain %_ptr_Function_uchar %1551 %uint_0
+%1907 = OpLoad %uchar %1723
+OpStore %1906 %1907
+OpStore %1731 %ulong_0
+OpBranch %1488
+%1488 = OpLabel
+%1908 = OpLoad %ulong %1731
+%1909 = OpULessThan %bool %1908 %ulong_16
+OpStore %1724 %1909
+%1910 = OpLoad %bool %1724
+OpLoopMerge %1490 %1525 None
+OpBranchConditional %1910 %1489 %1490
+%1490 = OpLabel
+%1911 = OpLoad %_struct_583 %1551
+OpStore %1552 %1911
+OpBranch %1491
+%1491 = OpLabel
+%1913 = OpAccessChain %_ptr_Function_ulong %1540 %uint_10
+%1914 = OpLoad %ulong %1913
+OpStore %1601 %1914
+OpBranch %1497
+%1497 = OpLabel
+OpStore %1555 %1244
+%1915 = OpLoad %ulong %1601
+%1916 = OpUConvert %uchar %1915
+OpStore %1741 %1916
+%1917 = OpAccessChain %_ptr_Function_uchar %1555 %uint_0
+%1918 = OpLoad %uchar %1741
+OpStore %1917 %1918
+OpStore %1749 %ulong_0
+OpBranch %1498
+%1498 = OpLabel
+%1919 = OpLoad %ulong %1749
+%1920 = OpULessThan %bool %1919 %ulong_8
+OpStore %1742 %1920
+%1921 = OpLoad %bool %1742
+OpLoopMerge %1500 %1523 None
+OpBranchConditional %1921 %1499 %1500
+%1500 = OpLabel
+%1922 = OpLoad %_struct_43 %1555
+OpStore %1556 %1922
+OpBranch %1501
+%1501 = OpLabel
+%1924 = OpAccessChain %_ptr_Function_ulong %1540 %uint_11
+%1925 = OpLoad %ulong %1924
+OpStore %1602 %1925
+OpBranch %1504
+%1504 = OpLabel
+%1926 = OpLoad %ulong %1602
+%1927 = OpUConvert %uint %1926
+OpStore %1755 %1927
+%1928 = OpAccessChain %_ptr_Function_uint %1558 %uint_0
+%1929 = OpLoad %uint %1755
+OpStore %1928 %1929
+%1930 = OpLoad %ulong %1602
+%1931 = OpShiftRightLogical %ulong %1930 %ulong_16
+OpStore %1756 %1931
+%1932 = OpLoad %ulong %1756
+%1933 = OpUConvert %uint %1932
+OpStore %1757 %1933
+%1934 = OpAccessChain %_ptr_Function_uint %1558 %uint_1
+%1935 = OpLoad %uint %1757
+OpStore %1934 %1935
+%1936 = OpLoad %ulong %1602
+%1937 = OpShiftRightLogical %ulong %1936 %ulong_32
+OpStore %1758 %1937
+%1938 = OpLoad %ulong %1758
+%1939 = OpUConvert %uint %1938
+OpStore %1759 %1939
+%1940 = OpAccessChain %_ptr_Function_uint %1558 %uint_2
+%1941 = OpLoad %uint %1759
+OpStore %1940 %1941
+OpBranch %1505
+%1505 = OpLabel
+%1942 = OpAccessChain %_ptr_Function_ulong %1540 %uint_0
+%1943 = OpLoad %ulong %1942
+OpStore %1603 %1943
+OpBranch %1508
+%1508 = OpLabel
+%1944 = OpAccessChain %_ptr_Function_ulong %1560 %uint_0
+%1945 = OpLoad %ulong %1603
+OpStore %1944 %1945
+%1946 = OpLoad %ulong %1603
+%1947 = OpIMul %ulong %1946 %ulong_3
+OpStore %1762 %1947
+%1948 = OpLoad %ulong %1762
+%1949 = OpIAdd %ulong %1948 %ulong_7
+OpStore %1763 %1949
+%1950 = OpAccessChain %_ptr_Function_ulong %1560 %uint_1
+%1951 = OpLoad %ulong %1763
+OpStore %1950 %1951
+OpBranch %1509
+%1509 = OpLabel
+%1952 = OpAccessChain %_ptr_Function_ulong %1540 %uint_1
+%1953 = OpLoad %ulong %1952
+OpStore %1604 %1953
+OpBranch %1515
+%1515 = OpLabel
+OpStore %1563 %1396
+%1954 = OpLoad %ulong %1604
+%1955 = OpShiftRightLogical %ulong %1954 %ulong_7
+OpStore %1774 %1955
+%1956 = OpLoad %ulong %1774
+%1957 = OpUConvert %uchar %1956
+OpStore %1775 %1957
+%1958 = OpAccessChain %_ptr_Function_uchar %1563 %uint_0
+%1959 = OpLoad %uchar %1775
+OpStore %1958 %1959
+OpStore %1783 %ulong_0
+OpBranch %1516
+%1516 = OpLabel
+%1960 = OpLoad %ulong %1783
+%1961 = OpULessThan %bool %1960 %ulong_16
+OpStore %1776 %1961
+%1962 = OpLoad %bool %1776
+OpLoopMerge %1518 %1521 None
+OpBranchConditional %1962 %1517 %1518
+%1518 = OpLabel
+%1963 = OpLoad %_struct_583 %1563
+OpStore %1564 %1963
+OpBranch %1519
+%1519 = OpLabel
+%1964 = OpAccessChain %_ptr_Function_ulong %1540 %uint_2
+%1965 = OpLoad %ulong %1964
+OpStore %1605 %1965
+%1966 = OpLoad %ulong %1605
+%1967 = OpBitwiseAnd %ulong %1966 %ulong_255
+OpStore %1606 %1967
+%1968 = OpLoad %ulong %1606
+%1969 = OpConvertUToF %float %1968
+OpStore %1607 %1969
+%1971 = OpAccessChain %_ptr_Function_ulong %1540 %uint_4
+%1972 = OpLoad %ulong %1971
+OpStore %1608 %1972
+%1973 = OpLoad %ulong %1613
+%1974 = OpLoad %_struct_43 %1536
+%1975 = OpLoad %uint %1597
+%1976 = OpLoad %_struct_169 %1542
+%1977 = OpLoad %double %1599
+%1978 = OpLoad %_struct_309 %1544
+%1979 = OpLoad %_struct_395 %1546
+%1980 = OpLoad %_struct_491 %1548
+%1981 = OpLoad %ulong %1600
+%1982 = OpLoad %_struct_583 %1552
+%1983 = OpLoad %_struct_43 %1556
+%1984 = OpLoad %_struct_169 %1558
+%1985 = OpLoad %_struct_309 %1560
+%1986 = OpLoad %_struct_583 %1564
+%1987 = OpLoad %float %1607
+%1988 = OpLoad %ulong %1608
+%1989 = OpFunctionCall %ulong %9 %1973 %1974 %1975 %1976 %1977 %1978 %1979 %1980 %1981 %1982 %1983 %1984 %1985 %1986 %1987 %1988
+OpStore %1609 %1989
+%1990 = OpLoad %ulong %1611
+%1991 = OpLoad %ulong %1609
+%1992 = OpFunctionCall %ulong %17 %1990 %1991
+OpStore %1610 %1992
+%1993 = OpLoad %ulong %1610
+OpReturnValue %1993
+%1517 = OpLabel
+%1994 = OpLoad %ulong %1783
+%1995 = OpIMul %ulong %1994 %ulong_4
+OpStore %1777 %1995
+%1996 = OpLoad %ulong %1604
+%1997 = OpLoad %ulong %1777
+%1998 = OpShiftRightLogical %ulong %1996 %1997
+OpStore %1778 %1998
+%1999 = OpLoad %ulong %1778
+%2000 = OpUConvert %uchar %1999
+OpStore %1779 %2000
+%2001 = OpLoad %ulong %1783
+%2002 = OpUConvert %uchar %2001
+OpStore %1780 %2002
+%2003 = OpLoad %uchar %1779
+%2004 = OpLoad %uchar %1780
+%2005 = OpBitwiseXor %uchar %2003 %2004
+OpStore %1781 %2005
+%2006 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1563 %uint_1
+%2007 = OpLoad %ulong %1783
+%2008 = OpAccessChain %_ptr_Function_uchar %2006 %2007
+%2009 = OpLoad %uchar %1781
+OpStore %2008 %2009
+%2010 = OpLoad %ulong %1783
+%2011 = OpIAdd %ulong %2010 %ulong_1
+OpStore %1782 %2011
+%2012 = OpLoad %ulong %1782
+OpStore %1783 %2012
+OpBranch %1521
+%1499 = OpLabel
+%2013 = OpLoad %ulong %1749
+%2014 = OpIMul %ulong %2013 %ulong_8
+OpStore %1743 %2014
+%2015 = OpLoad %ulong %1601
+%2016 = OpLoad %ulong %1743
+%2017 = OpShiftRightLogical %ulong %2015 %2016
+OpStore %1744 %2017
+%2018 = OpLoad %ulong %1744
+%2019 = OpUConvert %uchar %2018
+OpStore %1745 %2019
+%2020 = OpLoad %ulong %1749
+%2021 = OpUConvert %uchar %2020
+OpStore %1746 %2021
+%2022 = OpLoad %uchar %1745
+%2023 = OpLoad %uchar %1746
+%2024 = OpIAdd %uchar %2022 %2023
+OpStore %1747 %2024
+%2025 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1555 %uint_1
+%2026 = OpLoad %ulong %1749
+%2027 = OpAccessChain %_ptr_Function_uchar %2025 %2026
+%2028 = OpLoad %uchar %1747
+OpStore %2027 %2028
+%2029 = OpLoad %ulong %1749
+%2030 = OpIAdd %ulong %2029 %ulong_1
+OpStore %1748 %2030
+%2031 = OpLoad %ulong %1748
+OpStore %1749 %2031
+OpBranch %1523
+%1489 = OpLabel
+%2032 = OpLoad %ulong %1731
+%2033 = OpIMul %ulong %2032 %ulong_4
+OpStore %1725 %2033
+%2034 = OpLoad %ulong %1613
+%2035 = OpLoad %ulong %1725
+%2036 = OpShiftRightLogical %ulong %2034 %2035
+OpStore %1726 %2036
+%2037 = OpLoad %ulong %1726
+%2038 = OpUConvert %uchar %2037
+OpStore %1727 %2038
+%2039 = OpLoad %ulong %1731
+%2040 = OpUConvert %uchar %2039
+OpStore %1728 %2040
+%2041 = OpLoad %uchar %1727
+%2042 = OpLoad %uchar %1728
+%2043 = OpBitwiseXor %uchar %2041 %2042
+OpStore %1729 %2043
+%2044 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1551 %uint_1
+%2045 = OpLoad %ulong %1731
+%2046 = OpAccessChain %_ptr_Function_uchar %2044 %2045
+%2047 = OpLoad %uchar %1729
+OpStore %2046 %2047
+%2048 = OpLoad %ulong %1731
+%2049 = OpIAdd %ulong %2048 %ulong_1
+OpStore %1730 %2049
+%2050 = OpLoad %ulong %1730
+OpStore %1731 %2050
+OpBranch %1525
+%1446 = OpLabel
+%2051 = OpLoad %ulong %1635
+%2052 = OpIMul %ulong %2051 %ulong_8
+OpStore %1629 %2052
+%2053 = OpLoad %ulong %1613
+%2054 = OpLoad %ulong %1629
+%2055 = OpShiftRightLogical %ulong %2053 %2054
+OpStore %1630 %2055
+%2056 = OpLoad %ulong %1630
+%2057 = OpUConvert %uchar %2056
+OpStore %1631 %2057
+%2058 = OpLoad %ulong %1635
+%2059 = OpUConvert %uchar %2058
+OpStore %1632 %2059
+%2060 = OpLoad %uchar %1631
+%2061 = OpLoad %uchar %1632
+%2062 = OpIAdd %uchar %2060 %2061
+OpStore %1633 %2062
+%2063 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1535 %uint_1
+%2064 = OpLoad %ulong %1635
+%2065 = OpAccessChain %_ptr_Function_uchar %2063 %2064
+%2066 = OpLoad %uchar %1633
+OpStore %2065 %2066
+%2067 = OpLoad %ulong %1635
+%2068 = OpIAdd %ulong %2067 %ulong_1
+OpStore %1634 %2068
+%2069 = OpLoad %ulong %1634
+OpStore %1635 %2069
+OpBranch %1527
+%1433 = OpLabel
+%2070 = OpLoad %ulong %1614
+%2071 = OpIMul %ulong %2070 %ulong_17
+OpStore %1569 %2071
+%2072 = OpLoad %ulong %1569
+%2073 = OpLoad %ulong %1565
+%2074 = OpIAdd %ulong %2072 %2073
+OpStore %1570 %2074
+%2075 = OpAccessChain %_ptr_Function_ulong %1540 %uint_0
+%2076 = OpLoad %ulong %2075
+OpStore %1571 %2076
+%2077 = OpLoad %ulong %1571
+%2078 = OpLoad %ulong %1570
+%2079 = OpIAdd %ulong %2077 %2078
+OpStore %1572 %2079
+%2080 = OpAccessChain %_ptr_Function_ulong %1540 %uint_1
+%2081 = OpLoad %ulong %2080
+OpStore %1573 %2081
+OpBranch %1439
+%1439 = OpLabel
+OpStore %1533 %1244
+%2082 = OpLoad %ulong %1573
+%2083 = OpUConvert %uchar %2082
+OpStore %1618 %2083
+%2084 = OpAccessChain %_ptr_Function_uchar %1533 %uint_0
+%2085 = OpLoad %uchar %1618
+OpStore %2084 %2085
+OpStore %1626 %ulong_0
+OpBranch %1440
+%1440 = OpLabel
+%2086 = OpLoad %ulong %1626
+%2087 = OpULessThan %bool %2086 %ulong_8
+OpStore %1619 %2087
+%2088 = OpLoad %bool %1619
+OpLoopMerge %1442 %1526 None
+OpBranchConditional %2088 %1441 %1442
+%1442 = OpLabel
+%2089 = OpLoad %_struct_43 %1533
+OpStore %1534 %2089
+OpBranch %1443
+%1443 = OpLabel
+%2090 = OpAccessChain %_ptr_Function_ulong %1540 %uint_2
+%2091 = OpLoad %ulong %2090
+OpStore %1574 %2091
+%2092 = OpLoad %ulong %1574
+%2093 = OpUConvert %uint %2092
+OpStore %1575 %2093
+%2095 = OpAccessChain %_ptr_Function_ulong %1540 %uint_3
+%2096 = OpLoad %ulong %2095
+OpStore %1576 %2096
+OpBranch %1466
+%1466 = OpLabel
+%2097 = OpLoad %ulong %1576
+%2098 = OpUConvert %uint %2097
+OpStore %1678 %2098
+%2099 = OpAccessChain %_ptr_Function_uint %1541 %uint_0
+%2100 = OpLoad %uint %1678
+OpStore %2099 %2100
+%2101 = OpLoad %ulong %1576
+%2102 = OpShiftRightLogical %ulong %2101 %ulong_16
+OpStore %1679 %2102
+%2103 = OpLoad %ulong %1679
+%2104 = OpUConvert %uint %2103
+OpStore %1680 %2104
+%2105 = OpAccessChain %_ptr_Function_uint %1541 %uint_1
+%2106 = OpLoad %uint %1680
+OpStore %2105 %2106
+%2107 = OpLoad %ulong %1576
+%2108 = OpShiftRightLogical %ulong %2107 %ulong_32
+OpStore %1681 %2108
+%2109 = OpLoad %ulong %1681
+%2110 = OpUConvert %uint %2109
+OpStore %1682 %2110
+%2111 = OpAccessChain %_ptr_Function_uint %1541 %uint_2
+%2112 = OpLoad %uint %1682
+OpStore %2111 %2112
+OpBranch %1467
+%1467 = OpLabel
+%2113 = OpAccessChain %_ptr_Function_ulong %1540 %uint_4
+%2114 = OpLoad %ulong %2113
+OpStore %1577 %2114
+%2115 = OpLoad %ulong %1577
+%2116 = OpBitwiseAnd %ulong %2115 %ulong_1023
+OpStore %1578 %2116
+%2117 = OpLoad %ulong %1578
+%2118 = OpConvertUToF %double %2117
+OpStore %1579 %2118
+%2120 = OpAccessChain %_ptr_Function_ulong %1540 %uint_5
+%2121 = OpLoad %ulong %2120
+OpStore %1580 %2121
+%2122 = OpLoad %ulong %1580
+%2123 = OpLoad %ulong %1570
+%2124 = OpIAdd %ulong %2122 %2123
+OpStore %1581 %2124
+OpBranch %1470
+%1470 = OpLabel
+%2125 = OpAccessChain %_ptr_Function_ulong %1543 %uint_0
+%2126 = OpLoad %ulong %1581
+OpStore %2125 %2126
+%2127 = OpLoad %ulong %1581
+%2128 = OpIMul %ulong %2127 %ulong_3
+OpStore %1688 %2128
+%2129 = OpLoad %ulong %1688
+%2130 = OpIAdd %ulong %2129 %ulong_7
+OpStore %1689 %2130
+%2131 = OpAccessChain %_ptr_Function_ulong %1543 %uint_1
+%2132 = OpLoad %ulong %1689
+OpStore %2131 %2132
+OpBranch %1471
+%1471 = OpLabel
+%2134 = OpAccessChain %_ptr_Function_ulong %1540 %uint_6
+%2135 = OpLoad %ulong %2134
+OpStore %1582 %2135
+OpBranch %1474
+%1474 = OpLabel
+%2136 = OpLoad %ulong %1582
+%2137 = OpBitwiseAnd %ulong %2136 %ulong_65535
+OpStore %1692 %2137
+%2138 = OpLoad %ulong %1692
+%2139 = OpConvertUToF %double %2138
+OpStore %1693 %2139
+%2140 = OpLoad %double %1693
+%2141 = OpFDiv %double %2140 %double_8
+OpStore %1694 %2141
+%2142 = OpAccessChain %_ptr_Function_double %1545 %uint_0
+%2143 = OpLoad %double %1694
+OpStore %2142 %2143
+%2144 = OpLoad %ulong %1582
+%2145 = OpBitwiseAnd %ulong %2144 %ulong_4095
+OpStore %1695 %2145
+%2146 = OpLoad %ulong %1695
+%2147 = OpConvertUToF %double %2146
+OpStore %1696 %2147
+%2148 = OpLoad %double %1696
+%2149 = OpFSub %double %2148 %double_2048
+OpStore %1697 %2149
+%2150 = OpAccessChain %_ptr_Function_double %1545 %uint_1
+%2151 = OpLoad %double %1697
+OpStore %2150 %2151
+OpBranch %1475
+%1475 = OpLabel
+%2153 = OpAccessChain %_ptr_Function_ulong %1540 %uint_7
+%2154 = OpLoad %ulong %2153
+OpStore %1583 %2154
+OpBranch %1478
+%1478 = OpLabel
+%2155 = OpLoad %ulong %1583
+%2156 = OpBitwiseXor %ulong %2155 %ulong_305419896
+OpStore %1704 %2156
+%2157 = OpAccessChain %_ptr_Function_ulong %1547 %uint_0
+%2158 = OpLoad %ulong %1704
+OpStore %2157 %2158
+%2159 = OpLoad %ulong %1583
+%2160 = OpBitwiseAnd %ulong %2159 %ulong_262143
+OpStore %1705 %2160
+%2161 = OpLoad %ulong %1705
+%2162 = OpConvertUToF %double %2161
+OpStore %1706 %2162
+%2163 = OpLoad %double %1706
+%2164 = OpFDiv %double %2163 %double_64
+OpStore %1707 %2164
+%2165 = OpAccessChain %_ptr_Function_double %1547 %uint_1
+%2166 = OpLoad %double %1707
+OpStore %2165 %2166
+OpBranch %1479
+%1479 = OpLabel
+%2167 = OpAccessChain %_ptr_Function_ulong %1540 %uint_8
+%2168 = OpLoad %ulong %2167
+OpStore %1584 %2168
+%2170 = OpAccessChain %_ptr_Function_ulong %1540 %uint_9
+%2171 = OpLoad %ulong %2170
+OpStore %1585 %2171
+OpBranch %1482
+%1482 = OpLabel
+OpStore %1549 %1396
+%2172 = OpLoad %ulong %1585
+%2173 = OpShiftRightLogical %ulong %2172 %ulong_7
+OpStore %1712 %2173
+%2174 = OpLoad %ulong %1712
+%2175 = OpUConvert %uchar %2174
+OpStore %1713 %2175
+%2176 = OpAccessChain %_ptr_Function_uchar %1549 %uint_0
+%2177 = OpLoad %uchar %1713
+OpStore %2176 %2177
+OpStore %1721 %ulong_0
+OpBranch %1483
+%1483 = OpLabel
+%2178 = OpLoad %ulong %1721
+%2179 = OpULessThan %bool %2178 %ulong_16
+OpStore %1714 %2179
+%2180 = OpLoad %bool %1714
+OpLoopMerge %1485 %1524 None
+OpBranchConditional %2180 %1484 %1485
+%1485 = OpLabel
+%2181 = OpLoad %_struct_583 %1549
+OpStore %1550 %2181
+OpBranch %1486
+%1486 = OpLabel
+%2182 = OpAccessChain %_ptr_Function_ulong %1540 %uint_10
+%2183 = OpLoad %ulong %2182
+OpStore %1586 %2183
+OpBranch %1492
+%1492 = OpLabel
+OpStore %1553 %1244
+%2184 = OpLoad %ulong %1586
+%2185 = OpUConvert %uchar %2184
+OpStore %1732 %2185
+%2186 = OpAccessChain %_ptr_Function_uchar %1553 %uint_0
+%2187 = OpLoad %uchar %1732
+OpStore %2186 %2187
+OpStore %1740 %ulong_0
+OpBranch %1493
+%1493 = OpLabel
+%2188 = OpLoad %ulong %1740
+%2189 = OpULessThan %bool %2188 %ulong_8
+OpStore %1733 %2189
+%2190 = OpLoad %bool %1733
+OpLoopMerge %1495 %1522 None
+OpBranchConditional %2190 %1494 %1495
+%1495 = OpLabel
+%2191 = OpLoad %_struct_43 %1553
+OpStore %1554 %2191
+OpBranch %1496
+%1496 = OpLabel
+%2192 = OpAccessChain %_ptr_Function_ulong %1540 %uint_11
+%2193 = OpLoad %ulong %2192
+OpStore %1587 %2193
+OpBranch %1502
+%1502 = OpLabel
+%2194 = OpLoad %ulong %1587
+%2195 = OpUConvert %uint %2194
+OpStore %1750 %2195
+%2196 = OpAccessChain %_ptr_Function_uint %1557 %uint_0
+%2197 = OpLoad %uint %1750
+OpStore %2196 %2197
+%2198 = OpLoad %ulong %1587
+%2199 = OpShiftRightLogical %ulong %2198 %ulong_16
+OpStore %1751 %2199
+%2200 = OpLoad %ulong %1751
+%2201 = OpUConvert %uint %2200
+OpStore %1752 %2201
+%2202 = OpAccessChain %_ptr_Function_uint %1557 %uint_1
+%2203 = OpLoad %uint %1752
+OpStore %2202 %2203
+%2204 = OpLoad %ulong %1587
+%2205 = OpShiftRightLogical %ulong %2204 %ulong_32
+OpStore %1753 %2205
+%2206 = OpLoad %ulong %1753
+%2207 = OpUConvert %uint %2206
+OpStore %1754 %2207
+%2208 = OpAccessChain %_ptr_Function_uint %1557 %uint_2
+%2209 = OpLoad %uint %1754
+OpStore %2208 %2209
+OpBranch %1503
+%1503 = OpLabel
+%2210 = OpAccessChain %_ptr_Function_ulong %1540 %uint_0
+%2211 = OpLoad %ulong %2210
+OpStore %1588 %2211
+OpBranch %1506
+%1506 = OpLabel
+%2212 = OpAccessChain %_ptr_Function_ulong %1559 %uint_0
+%2213 = OpLoad %ulong %1588
+OpStore %2212 %2213
+%2214 = OpLoad %ulong %1588
+%2215 = OpIMul %ulong %2214 %ulong_3
+OpStore %1760 %2215
+%2216 = OpLoad %ulong %1760
+%2217 = OpIAdd %ulong %2216 %ulong_7
+OpStore %1761 %2217
+%2218 = OpAccessChain %_ptr_Function_ulong %1559 %uint_1
+%2219 = OpLoad %ulong %1761
+OpStore %2218 %2219
+OpBranch %1507
+%1507 = OpLabel
+%2220 = OpAccessChain %_ptr_Function_ulong %1540 %uint_1
+%2221 = OpLoad %ulong %2220
+OpStore %1589 %2221
+OpBranch %1510
+%1510 = OpLabel
+OpStore %1561 %1396
+%2222 = OpLoad %ulong %1589
+%2223 = OpShiftRightLogical %ulong %2222 %ulong_7
+OpStore %1764 %2223
+%2224 = OpLoad %ulong %1764
+%2225 = OpUConvert %uchar %2224
+OpStore %1765 %2225
+%2226 = OpAccessChain %_ptr_Function_uchar %1561 %uint_0
+%2227 = OpLoad %uchar %1765
+OpStore %2226 %2227
+OpStore %1773 %ulong_0
+OpBranch %1511
+%1511 = OpLabel
+%2228 = OpLoad %ulong %1773
+%2229 = OpULessThan %bool %2228 %ulong_16
+OpStore %1766 %2229
+%2230 = OpLoad %bool %1766
+OpLoopMerge %1513 %1520 None
+OpBranchConditional %2230 %1512 %1513
+%1513 = OpLabel
+%2231 = OpLoad %_struct_583 %1561
+OpStore %1562 %2231
+OpBranch %1514
+%1514 = OpLabel
+%2232 = OpAccessChain %_ptr_Function_ulong %1540 %uint_2
+%2233 = OpLoad %ulong %2232
+OpStore %1590 %2233
+%2234 = OpLoad %ulong %1590
+%2235 = OpBitwiseAnd %ulong %2234 %ulong_255
+OpStore %1591 %2235
+%2236 = OpLoad %ulong %1591
+%2237 = OpConvertUToF %float %2236
+OpStore %1592 %2237
+%2238 = OpAccessChain %_ptr_Function_ulong %1540 %uint_3
+%2239 = OpLoad %ulong %2238
+OpStore %1593 %2239
+%2240 = OpLoad %ulong %1572
+%2241 = OpLoad %_struct_43 %1534
+%2242 = OpLoad %uint %1575
+%2243 = OpLoad %_struct_169 %1541
+%2244 = OpLoad %double %1579
+%2245 = OpLoad %_struct_309 %1543
+%2246 = OpLoad %_struct_395 %1545
+%2247 = OpLoad %_struct_491 %1547
+%2248 = OpLoad %ulong %1584
+%2249 = OpLoad %_struct_583 %1550
+%2250 = OpLoad %_struct_43 %1554
+%2251 = OpLoad %_struct_169 %1557
+%2252 = OpLoad %_struct_309 %1559
+%2253 = OpLoad %_struct_583 %1562
+%2254 = OpLoad %float %1592
+%2255 = OpLoad %ulong %1593
+%2256 = OpFunctionCall %ulong %9 %2240 %2241 %2242 %2243 %2244 %2245 %2246 %2247 %2248 %2249 %2250 %2251 %2252 %2253 %2254 %2255
+OpStore %1594 %2256
+%2257 = OpLoad %ulong %1611
+%2258 = OpLoad %ulong %1594
+%2259 = OpFunctionCall %ulong %17 %2257 %2258
+OpStore %1595 %2259
+%2260 = OpLoad %ulong %1614
+%2261 = OpIAdd %ulong %2260 %ulong_1
+OpStore %1596 %2261
+%2262 = OpLoad %ulong %1595
+OpStore %1611 %2262
+%2263 = OpLoad %ulong %1594
+OpStore %1613 %2263
+%2264 = OpLoad %ulong %1596
+OpStore %1614 %2264
+OpBranch %1528
+%1512 = OpLabel
+%2265 = OpLoad %ulong %1773
+%2266 = OpIMul %ulong %2265 %ulong_4
+OpStore %1767 %2266
+%2267 = OpLoad %ulong %1589
+%2268 = OpLoad %ulong %1767
+%2269 = OpShiftRightLogical %ulong %2267 %2268
+OpStore %1768 %2269
+%2270 = OpLoad %ulong %1768
+%2271 = OpUConvert %uchar %2270
+OpStore %1769 %2271
+%2272 = OpLoad %ulong %1773
+%2273 = OpUConvert %uchar %2272
+OpStore %1770 %2273
+%2274 = OpLoad %uchar %1769
+%2275 = OpLoad %uchar %1770
+%2276 = OpBitwiseXor %uchar %2274 %2275
+OpStore %1771 %2276
+%2277 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1561 %uint_1
+%2278 = OpLoad %ulong %1773
+%2279 = OpAccessChain %_ptr_Function_uchar %2277 %2278
+%2280 = OpLoad %uchar %1771
+OpStore %2279 %2280
+%2281 = OpLoad %ulong %1773
+%2282 = OpIAdd %ulong %2281 %ulong_1
+OpStore %1772 %2282
+%2283 = OpLoad %ulong %1772
+OpStore %1773 %2283
+OpBranch %1520
+%1494 = OpLabel
+%2284 = OpLoad %ulong %1740
+%2285 = OpIMul %ulong %2284 %ulong_8
+OpStore %1734 %2285
+%2286 = OpLoad %ulong %1586
+%2287 = OpLoad %ulong %1734
+%2288 = OpShiftRightLogical %ulong %2286 %2287
+OpStore %1735 %2288
+%2289 = OpLoad %ulong %1735
+%2290 = OpUConvert %uchar %2289
+OpStore %1736 %2290
+%2291 = OpLoad %ulong %1740
+%2292 = OpUConvert %uchar %2291
+OpStore %1737 %2292
+%2293 = OpLoad %uchar %1736
+%2294 = OpLoad %uchar %1737
+%2295 = OpIAdd %uchar %2293 %2294
+OpStore %1738 %2295
+%2296 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1553 %uint_1
+%2297 = OpLoad %ulong %1740
+%2298 = OpAccessChain %_ptr_Function_uchar %2296 %2297
+%2299 = OpLoad %uchar %1738
+OpStore %2298 %2299
+%2300 = OpLoad %ulong %1740
+%2301 = OpIAdd %ulong %2300 %ulong_1
+OpStore %1739 %2301
+%2302 = OpLoad %ulong %1739
+OpStore %1740 %2302
+OpBranch %1522
+%1484 = OpLabel
+%2303 = OpLoad %ulong %1721
+%2304 = OpIMul %ulong %2303 %ulong_4
+OpStore %1715 %2304
+%2305 = OpLoad %ulong %1585
+%2306 = OpLoad %ulong %1715
+%2307 = OpShiftRightLogical %ulong %2305 %2306
+OpStore %1716 %2307
+%2308 = OpLoad %ulong %1716
+%2309 = OpUConvert %uchar %2308
+OpStore %1717 %2309
+%2310 = OpLoad %ulong %1721
+%2311 = OpUConvert %uchar %2310
+OpStore %1718 %2311
+%2312 = OpLoad %uchar %1717
+%2313 = OpLoad %uchar %1718
+%2314 = OpBitwiseXor %uchar %2312 %2313
+OpStore %1719 %2314
+%2315 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %1549 %uint_1
+%2316 = OpLoad %ulong %1721
+%2317 = OpAccessChain %_ptr_Function_uchar %2315 %2316
+%2318 = OpLoad %uchar %1719
+OpStore %2317 %2318
+%2319 = OpLoad %ulong %1721
+%2320 = OpIAdd %ulong %2319 %ulong_1
+OpStore %1720 %2320
+%2321 = OpLoad %ulong %1720
+OpStore %1721 %2321
+OpBranch %1524
+%1441 = OpLabel
+%2322 = OpLoad %ulong %1626
+%2323 = OpIMul %ulong %2322 %ulong_8
+OpStore %1620 %2323
+%2324 = OpLoad %ulong %1573
+%2325 = OpLoad %ulong %1620
+%2326 = OpShiftRightLogical %ulong %2324 %2325
+OpStore %1621 %2326
+%2327 = OpLoad %ulong %1621
+%2328 = OpUConvert %uchar %2327
+OpStore %1622 %2328
+%2329 = OpLoad %ulong %1626
+%2330 = OpUConvert %uchar %2329
+OpStore %1623 %2330
+%2331 = OpLoad %uchar %1622
+%2332 = OpLoad %uchar %1623
+%2333 = OpIAdd %uchar %2331 %2332
+OpStore %1624 %2333
+%2334 = OpAccessChain %_ptr_Function__arr_uchar_uint_8 %1533 %uint_1
+%2335 = OpLoad %ulong %1626
+%2336 = OpAccessChain %_ptr_Function_uchar %2334 %2335
+%2337 = OpLoad %uchar %1624
+OpStore %2336 %2337
+%2338 = OpLoad %ulong %1626
+%2339 = OpIAdd %ulong %2338 %ulong_1
+OpStore %1625 %2339
+%2340 = OpLoad %ulong %1625
+OpStore %1626 %2340
+OpBranch %1526
+%1430 = OpLabel
+OpBranch %1437
+%1437 = OpLabel
+%2341 = OpLoad %ulong %1612
+%2342 = OpIMul %ulong %2341 %ulong_6364136223846793005
+OpStore %1615 %2342
+%2343 = OpLoad %ulong %1615
+%2344 = OpIAdd %ulong %2343 %ulong_1442695040888963407
+OpStore %1616 %2344
+%2345 = OpLoad %ulong %1616
+%2346 = OpLoad %ulong %1565
+%2347 = OpIAdd %ulong %2345 %2346
+OpStore %1617 %2347
+OpBranch %1438
+%1438 = OpLabel
+%2348 = OpLoad %ulong %1612
+%2349 = OpAccessChain %_ptr_Function_ulong %1540 %2348
+%2350 = OpLoad %ulong %1617
+OpStore %2349 %2350
+%2351 = OpLoad %ulong %1612
+%2352 = OpIAdd %ulong %2351 %ulong_1
+OpStore %1567 %2352
+%2353 = OpLoad %ulong %1567
+OpStore %1612 %2353
+OpBranch %1529
+%1462 = OpLabel
+%2354 = OpLoad %ulong %1677
+%2355 = OpIMul %ulong %2354 %ulong_8
+OpStore %1670 %2355
+%2356 = OpLoad %ulong %1670
+%2357 = OpShiftRightLogical %ulong %ulong_16 %2356
+OpStore %1671 %2357
+%2358 = OpLoad %ulong %1671
+%2359 = OpBitwiseAnd %ulong %2358 %ulong_255
+OpStore %1672 %2359
+%2360 = OpLoad %ulong %1676
+%2361 = OpLoad %ulong %1672
+%2362 = OpBitwiseXor %ulong %2360 %2361
+OpStore %1673 %2362
+%2363 = OpLoad %ulong %1673
+%2364 = OpIMul %ulong %2363 %ulong_1099511628211
+OpStore %1674 %2364
+%2365 = OpLoad %ulong %1677
+%2366 = OpIAdd %ulong %2365 %ulong_1
+OpStore %1675 %2366
+%2367 = OpLoad %ulong %1674
+OpStore %1676 %2367
+%2368 = OpLoad %ulong %1675
+OpStore %1677 %2368
+OpBranch %1530
+%1457 = OpLabel
+%2369 = OpLoad %ulong %1668
+%2370 = OpIMul %ulong %2369 %ulong_8
+OpStore %1661 %2370
+%2371 = OpLoad %ulong %1661
+%2372 = OpShiftRightLogical %ulong %ulong_12 %2371
+OpStore %1662 %2372
+%2373 = OpLoad %ulong %1662
+%2374 = OpBitwiseAnd %ulong %2373 %ulong_255
+OpStore %1663 %2374
+%2375 = OpLoad %ulong %1667
+%2376 = OpLoad %ulong %1663
+%2377 = OpBitwiseXor %ulong %2375 %2376
+OpStore %1664 %2377
+%2378 = OpLoad %ulong %1664
+%2379 = OpIMul %ulong %2378 %ulong_1099511628211
+OpStore %1665 %2379
+%2380 = OpLoad %ulong %1668
+%2381 = OpIAdd %ulong %2380 %ulong_1
+OpStore %1666 %2381
+%2382 = OpLoad %ulong %1665
+OpStore %1667 %2382
+%2383 = OpLoad %ulong %1666
+OpStore %1668 %2383
+OpBranch %1531
+%1452 = OpLabel
+%2384 = OpLoad %ulong %1659
+%2385 = OpIMul %ulong %2384 %ulong_8
+OpStore %1652 %2385
+%2386 = OpLoad %ulong %1652
+%2387 = OpShiftRightLogical %ulong %ulong_9 %2386
+OpStore %1653 %2387
+%2388 = OpLoad %ulong %1653
+%2389 = OpBitwiseAnd %ulong %2388 %ulong_255
+OpStore %1654 %2389
+%2390 = OpLoad %ulong %1658
+%2391 = OpLoad %ulong %1654
+%2392 = OpBitwiseXor %ulong %2390 %2391
+OpStore %1655 %2392
+%2393 = OpLoad %ulong %1655
+%2394 = OpIMul %ulong %2393 %ulong_1099511628211
+OpStore %1656 %2394
+%2395 = OpLoad %ulong %1659
+%2396 = OpIAdd %ulong %2395 %ulong_1
+OpStore %1657 %2396
+%2397 = OpLoad %ulong %1656
+OpStore %1658 %2397
+%2398 = OpLoad %ulong %1657
+OpStore %1659 %2398
+OpBranch %1532
+%1520 = OpLabel
+OpBranch %1511
+%1521 = OpLabel
+OpBranch %1516
+%1522 = OpLabel
+OpBranch %1493
+%1523 = OpLabel
+OpBranch %1498
+%1524 = OpLabel
+OpBranch %1483
+%1525 = OpLabel
+OpBranch %1488
+%1526 = OpLabel
+OpBranch %1440
+%1527 = OpLabel
+OpBranch %1445
+%1528 = OpLabel
+OpBranch %1432
+%1529 = OpLabel
+OpBranch %1429
+%1530 = OpLabel
+OpBranch %1461
+%1531 = OpLabel
+OpBranch %1456
+%1532 = OpLabel
+OpBranch %1451
 OpFunctionEnd
-%20 = OpFunction %ulong None %1934
-%1935 = OpFunctionParameter %ulong
-%1936 = OpFunctionParameter %uint
-%1937 = OpLabel
-%1944 = OpVariable %_ptr_Function_ulong Function
-%1945 = OpVariable %_ptr_Function_uint Function
-%1946 = OpVariable %_ptr_Function_ulong Function
-%1947 = OpVariable %_ptr_Function_bool Function
-%1948 = OpVariable %_ptr_Function_ulong Function
-%1949 = OpVariable %_ptr_Function_ulong Function
-%1950 = OpVariable %_ptr_Function_ulong Function
-%1951 = OpVariable %_ptr_Function_ulong Function
-%1952 = OpVariable %_ptr_Function_ulong Function
-%1953 = OpVariable %_ptr_Function_ulong Function
-%1954 = OpVariable %_ptr_Function_ulong Function
-%1955 = OpVariable %_ptr_Function_ulong Function
-OpStore %1944 %1935
-OpStore %1945 %1936
-%1956 = OpLoad %uint %1945
-%1957 = OpUConvert %ulong %1956
-OpStore %1946 %1957
-OpBranch %1938
-%1938 = OpLabel
-%1958 = OpLoad %ulong %1944
-OpStore %1954 %1958
-OpStore %1955 %ulong_0
-OpBranch %1939
-%1939 = OpLabel
-%1959 = OpLoad %ulong %1955
-%1960 = OpULessThan %bool %1959 %ulong_8
-OpStore %1947 %1960
-%1961 = OpLoad %bool %1947
-OpLoopMerge %1941 %1943 None
-OpBranchConditional %1961 %1940 %1941
-%1941 = OpLabel
-OpBranch %1942
-%1942 = OpLabel
-%1962 = OpLoad %ulong %1954
-OpReturnValue %1962
-%1940 = OpLabel
-%1963 = OpLoad %ulong %1955
-%1964 = OpIMul %ulong %1963 %ulong_8
-OpStore %1948 %1964
-%1965 = OpLoad %ulong %1946
-%1966 = OpLoad %ulong %1948
-%1967 = OpShiftRightLogical %ulong %1965 %1966
-OpStore %1949 %1967
-%1968 = OpLoad %ulong %1949
-%1969 = OpBitwiseAnd %ulong %1968 %ulong_255
-OpStore %1950 %1969
-%1970 = OpLoad %ulong %1954
-%1971 = OpLoad %ulong %1950
-%1972 = OpBitwiseXor %ulong %1970 %1971
-OpStore %1951 %1972
-%1973 = OpLoad %ulong %1951
-%1974 = OpIMul %ulong %1973 %ulong_1099511628211
-OpStore %1952 %1974
-%1975 = OpLoad %ulong %1955
-%1976 = OpIAdd %ulong %1975 %ulong_1
-OpStore %1953 %1976
-%1977 = OpLoad %ulong %1952
-OpStore %1954 %1977
-%1978 = OpLoad %ulong %1953
-OpStore %1955 %1978
-OpBranch %1943
-%1943 = OpLabel
-OpBranch %1939
-OpFunctionEnd
-%21 = OpFunction %ulong None %1979
-%1980 = OpFunctionParameter %ulong
-%1981 = OpFunctionParameter %float
-%1982 = OpLabel
-%1989 = OpVariable %_ptr_Function_ulong Function
-%1990 = OpVariable %_ptr_Function_float Function
-%1991 = OpVariable %_ptr_Function_uint Function
-%1992 = OpVariable %_ptr_Function_ulong Function
-%1993 = OpVariable %_ptr_Function_bool Function
-%1994 = OpVariable %_ptr_Function_ulong Function
-%1995 = OpVariable %_ptr_Function_ulong Function
-%1996 = OpVariable %_ptr_Function_ulong Function
-%1997 = OpVariable %_ptr_Function_ulong Function
-%1998 = OpVariable %_ptr_Function_ulong Function
-%1999 = OpVariable %_ptr_Function_ulong Function
-%2000 = OpVariable %_ptr_Function_ulong Function
-%2001 = OpVariable %_ptr_Function_ulong Function
-OpStore %1989 %1980
-OpStore %1990 %1981
-%2002 = OpLoad %float %1990
-%2003 = OpBitcast %uint %2002
-OpStore %1991 %2003
-%2004 = OpLoad %uint %1991
-%2005 = OpUConvert %ulong %2004
-OpStore %1992 %2005
-OpBranch %1983
-%1983 = OpLabel
-%2006 = OpLoad %ulong %1989
-OpStore %2000 %2006
-OpStore %2001 %ulong_0
-OpBranch %1984
-%1984 = OpLabel
-%2007 = OpLoad %ulong %2001
-%2008 = OpULessThan %bool %2007 %ulong_8
-OpStore %1993 %2008
-%2009 = OpLoad %bool %1993
-OpLoopMerge %1986 %1988 None
-OpBranchConditional %2009 %1985 %1986
-%1986 = OpLabel
-OpBranch %1987
-%1987 = OpLabel
-%2010 = OpLoad %ulong %2000
-OpReturnValue %2010
-%1985 = OpLabel
-%2011 = OpLoad %ulong %2001
-%2012 = OpIMul %ulong %2011 %ulong_8
-OpStore %1994 %2012
-%2013 = OpLoad %ulong %1992
-%2014 = OpLoad %ulong %1994
-%2015 = OpShiftRightLogical %ulong %2013 %2014
-OpStore %1995 %2015
-%2016 = OpLoad %ulong %1995
-%2017 = OpBitwiseAnd %ulong %2016 %ulong_255
-OpStore %1996 %2017
-%2018 = OpLoad %ulong %2000
-%2019 = OpLoad %ulong %1996
-%2020 = OpBitwiseXor %ulong %2018 %2019
-OpStore %1997 %2020
-%2021 = OpLoad %ulong %1997
-%2022 = OpIMul %ulong %2021 %ulong_1099511628211
-OpStore %1998 %2022
-%2023 = OpLoad %ulong %2001
-%2024 = OpIAdd %ulong %2023 %ulong_1
-OpStore %1999 %2024
-%2025 = OpLoad %ulong %1998
-OpStore %2000 %2025
-%2026 = OpLoad %ulong %1999
-OpStore %2001 %2026
-OpBranch %1988
-%1988 = OpLabel
-OpBranch %1984
-OpFunctionEnd
-%22 = OpFunction %ulong None %2027
-%2028 = OpFunctionParameter %ulong
-%2029 = OpFunctionParameter %double
-%2030 = OpLabel
-%2037 = OpVariable %_ptr_Function_ulong Function
-%2038 = OpVariable %_ptr_Function_double Function
-%2039 = OpVariable %_ptr_Function_ulong Function
-%2040 = OpVariable %_ptr_Function_bool Function
-%2041 = OpVariable %_ptr_Function_ulong Function
-%2042 = OpVariable %_ptr_Function_ulong Function
-%2043 = OpVariable %_ptr_Function_ulong Function
-%2044 = OpVariable %_ptr_Function_ulong Function
-%2045 = OpVariable %_ptr_Function_ulong Function
-%2046 = OpVariable %_ptr_Function_ulong Function
-%2047 = OpVariable %_ptr_Function_ulong Function
-%2048 = OpVariable %_ptr_Function_ulong Function
-OpStore %2037 %2028
-OpStore %2038 %2029
-%2049 = OpLoad %double %2038
-%2050 = OpBitcast %ulong %2049
-OpStore %2039 %2050
-OpBranch %2031
-%2031 = OpLabel
-%2051 = OpLoad %ulong %2037
-OpStore %2047 %2051
-OpStore %2048 %ulong_0
-OpBranch %2032
-%2032 = OpLabel
-%2052 = OpLoad %ulong %2048
-%2053 = OpULessThan %bool %2052 %ulong_8
-OpStore %2040 %2053
-%2054 = OpLoad %bool %2040
-OpLoopMerge %2034 %2036 None
-OpBranchConditional %2054 %2033 %2034
-%2034 = OpLabel
-OpBranch %2035
-%2035 = OpLabel
-%2055 = OpLoad %ulong %2047
-OpReturnValue %2055
-%2033 = OpLabel
-%2056 = OpLoad %ulong %2048
-%2057 = OpIMul %ulong %2056 %ulong_8
-OpStore %2041 %2057
-%2058 = OpLoad %ulong %2039
-%2059 = OpLoad %ulong %2041
-%2060 = OpShiftRightLogical %ulong %2058 %2059
-OpStore %2042 %2060
-%2061 = OpLoad %ulong %2042
-%2062 = OpBitwiseAnd %ulong %2061 %ulong_255
-OpStore %2043 %2062
-%2063 = OpLoad %ulong %2047
-%2064 = OpLoad %ulong %2043
-%2065 = OpBitwiseXor %ulong %2063 %2064
-OpStore %2044 %2065
-%2066 = OpLoad %ulong %2044
-%2067 = OpIMul %ulong %2066 %ulong_1099511628211
-OpStore %2045 %2067
-%2068 = OpLoad %ulong %2048
-%2069 = OpIAdd %ulong %2068 %ulong_1
-OpStore %2046 %2069
-%2070 = OpLoad %ulong %2045
-OpStore %2047 %2070
-%2071 = OpLoad %ulong %2046
-OpStore %2048 %2071
-OpBranch %2036
-%2036 = OpLabel
-OpBranch %2032
+%17 = OpFunction %ulong None %19
+%2399 = OpFunctionParameter %ulong
+%2400 = OpFunctionParameter %ulong
+%2401 = OpLabel
+%2406 = OpVariable %_ptr_Function_ulong Function
+%2407 = OpVariable %_ptr_Function_ulong Function
+%2408 = OpVariable %_ptr_Function_bool Function
+%2409 = OpVariable %_ptr_Function_ulong Function
+%2410 = OpVariable %_ptr_Function_ulong Function
+%2411 = OpVariable %_ptr_Function_ulong Function
+%2412 = OpVariable %_ptr_Function_ulong Function
+%2413 = OpVariable %_ptr_Function_ulong Function
+%2414 = OpVariable %_ptr_Function_ulong Function
+%2415 = OpVariable %_ptr_Function_ulong Function
+%2416 = OpVariable %_ptr_Function_ulong Function
+OpStore %2406 %2399
+OpStore %2407 %2400
+%2417 = OpLoad %ulong %2406
+OpStore %2415 %2417
+OpStore %2416 %ulong_0
+OpBranch %2402
+%2402 = OpLabel
+%2418 = OpLoad %ulong %2416
+%2419 = OpULessThan %bool %2418 %ulong_8
+OpStore %2408 %2419
+%2420 = OpLoad %bool %2408
+OpLoopMerge %2404 %2405 None
+OpBranchConditional %2420 %2403 %2404
+%2404 = OpLabel
+%2421 = OpLoad %ulong %2415
+OpReturnValue %2421
+%2403 = OpLabel
+%2422 = OpLoad %ulong %2416
+%2423 = OpIMul %ulong %2422 %ulong_8
+OpStore %2409 %2423
+%2424 = OpLoad %ulong %2407
+%2425 = OpLoad %ulong %2409
+%2426 = OpShiftRightLogical %ulong %2424 %2425
+OpStore %2410 %2426
+%2427 = OpLoad %ulong %2410
+%2428 = OpBitwiseAnd %ulong %2427 %ulong_255
+OpStore %2411 %2428
+%2429 = OpLoad %ulong %2415
+%2430 = OpLoad %ulong %2411
+%2431 = OpBitwiseXor %ulong %2429 %2430
+OpStore %2412 %2431
+%2432 = OpLoad %ulong %2412
+%2433 = OpIMul %ulong %2432 %ulong_1099511628211
+OpStore %2413 %2433
+%2434 = OpLoad %ulong %2416
+%2435 = OpIAdd %ulong %2434 %ulong_1
+OpStore %2414 %2435
+%2436 = OpLoad %ulong %2413
+OpStore %2415 %2436
+%2437 = OpLoad %ulong %2414
+OpStore %2416 %2437
+OpBranch %2405
+%2405 = OpLabel
+OpBranch %2402
 OpFunctionEnd

--- a/test/golden/spirv/call/call_rec_large.dis
+++ b/test/golden/spirv/call/call_rec_large.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 2010
+; Bound: 2683
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -27,502 +27,521 @@ OpDecorate %16 LinkageAttributes "corpus.cases.call.call_rec_large.mk48" Export
 OpDecorate %17 LinkageAttributes "corpus.cases.call.call_rec_large.mk48m" Export
 OpDecorate %18 LinkageAttributes "corpus.cases.call.call_rec_large.checksum" Export
 %ulong = OpTypeInt 64 0
-%25 = OpTypeFunction %ulong %ulong %ulong
+%21 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
-%_struct_45 = OpTypeStruct %ulong %ulong %ulong
-%46 = OpTypeFunction %ulong %ulong %_struct_45
-%_ptr_Function__struct_45 = OpTypePointer Function %_struct_45
+%_struct_41 = OpTypeStruct %ulong %ulong %ulong
+%42 = OpTypeFunction %ulong %ulong %_struct_41
+%bool = OpTypeBool
+%_ptr_Function__struct_41 = OpTypePointer Function %_struct_41
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uint = OpTypeInt 32 0
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %double = OpTypeFloat 64
-%_struct_80 = OpTypeStruct %double %double %double
-%81 = OpTypeFunction %ulong %ulong %_struct_80
-%_ptr_Function__struct_80 = OpTypePointer Function %_struct_80
+%_struct_176 = OpTypeStruct %double %double %double
+%177 = OpTypeFunction %ulong %ulong %_struct_176
+%_ptr_Function__struct_176 = OpTypePointer Function %_struct_176
 %_ptr_Function_double = OpTypePointer Function %double
-%_struct_111 = OpTypeStruct %ulong %double %uint %uint
-%112 = OpTypeFunction %ulong %ulong %_struct_111
-%_ptr_Function__struct_111 = OpTypePointer Function %_struct_111
+%_struct_315 = OpTypeStruct %ulong %double %uint %uint
+%316 = OpTypeFunction %ulong %ulong %_struct_315
+%_ptr_Function__struct_315 = OpTypePointer Function %_struct_315
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uint_3 = OpConstant %uint 3
-%_struct_150 = OpTypeStruct %ulong %ulong %ulong %ulong
-%151 = OpTypeFunction %ulong %ulong %_struct_150
-%_ptr_Function__struct_150 = OpTypePointer Function %_struct_150
-%_struct_187 = OpTypeStruct %ulong %ulong
-%_struct_188 = OpTypeStruct %_struct_187 %_struct_187
-%189 = OpTypeFunction %ulong %ulong %_struct_188
-%_ptr_Function__struct_188 = OpTypePointer Function %_struct_188
-%_ptr_Function__struct_187 = OpTypePointer Function %_struct_187
-%_struct_228 = OpTypeStruct %ulong %ulong %ulong %ulong %ulong %ulong
-%229 = OpTypeFunction %ulong %ulong %_struct_228
-%_ptr_Function__struct_228 = OpTypePointer Function %_struct_228
+%_struct_493 = OpTypeStruct %ulong %ulong %ulong %ulong
+%494 = OpTypeFunction %ulong %ulong %_struct_493
+%_ptr_Function__struct_493 = OpTypePointer Function %_struct_493
+%_struct_654 = OpTypeStruct %ulong %ulong
+%_struct_655 = OpTypeStruct %_struct_654 %_struct_654
+%656 = OpTypeFunction %ulong %ulong %_struct_655
+%_ptr_Function__struct_655 = OpTypePointer Function %_struct_655
+%_ptr_Function__struct_654 = OpTypePointer Function %_struct_654
+%_struct_757 = OpTypeStruct %ulong %ulong %ulong %ulong %ulong %ulong
+%758 = OpTypeFunction %ulong %ulong %_struct_757
+%_ptr_Function__struct_757 = OpTypePointer Function %_struct_757
 %uint_4 = OpConstant %uint 4
 %uint_5 = OpConstant %uint 5
-%_struct_281 = OpTypeStruct %ulong %double %uint %uint %double %ulong %ulong
-%282 = OpTypeFunction %ulong %ulong %_struct_281
-%_ptr_Function__struct_281 = OpTypePointer Function %_struct_281
+%_struct_810 = OpTypeStruct %ulong %double %uint %uint %double %ulong %ulong
+%811 = OpTypeFunction %ulong %ulong %_struct_810
+%_ptr_Function__struct_810 = OpTypePointer Function %_struct_810
 %uint_6 = OpConstant %uint 6
-%340 = OpTypeFunction %ulong %ulong
+%889 = OpTypeFunction %ulong %ulong
 %ulong_24 = OpConstant %ulong 24
 %ulong_32 = OpConstant %ulong 32
 %ulong_48 = OpConstant %ulong 48
-%ulong_8 = OpConstant %ulong 8
 %ulong_16 = OpConstant %ulong 16
 %ulong_20 = OpConstant %ulong 20
 %ulong_40 = OpConstant %ulong 40
 %float = OpTypeFloat 32
-%404 = OpTypeFunction %ulong %ulong %_struct_45 %_struct_80 %_struct_111 %uint %_struct_150 %_struct_188 %double %_struct_228 %_struct_281 %_struct_45 %_struct_150 %_struct_228 %float %ulong
+%952 = OpTypeFunction %ulong %ulong %_struct_41 %_struct_176 %_struct_315 %uint %_struct_493 %_struct_655 %double %_struct_757 %_struct_810 %_struct_41 %_struct_493 %_struct_757 %float %ulong
 %_ptr_Function_float = OpTypePointer Function %float
-%ulong_1 = OpConstant %ulong 1
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_4294967295 = OpConstant %ulong 4294967295
-%850 = OpTypeFunction %_struct_45 %ulong
+%1670 = OpTypeFunction %_struct_41 %ulong
 %ulong_3 = OpConstant %ulong 3
 %ulong_305419896 = OpConstant %ulong 305419896
-%873 = OpTypeFunction %_struct_80 %ulong
+%1693 = OpTypeFunction %_struct_176 %ulong
 %ulong_65535 = OpConstant %ulong 65535
 %double_8 = OpConstant %double 8
 %ulong_4095 = OpConstant %ulong 4095
 %double_2048 = OpConstant %double 2048
 %ulong_262143 = OpConstant %ulong 262143
 %double_64 = OpConstant %double 64
-%918 = OpTypeFunction %_struct_111 %ulong
+%1738 = OpTypeFunction %_struct_315 %ulong
 %ulong_32767 = OpConstant %ulong 32767
 %double_4 = OpConstant %double 4
-%952 = OpTypeFunction %_struct_150 %ulong
+%1772 = OpTypeFunction %_struct_493 %ulong
 %ulong_5 = OpConstant %ulong 5
-%976 = OpTypeFunction %_struct_188 %ulong
+%1796 = OpTypeFunction %_struct_655 %ulong
 %ulong_11 = OpConstant %ulong 11
 %ulong_7 = OpConstant %ulong 7
-%1007 = OpTypeFunction %_struct_228 %ulong
+%1827 = OpTypeFunction %_struct_757 %ulong
 %ulong_2 = OpConstant %ulong 2
 %ulong_9 = OpConstant %ulong 9
 %ulong_2863311530 = OpConstant %ulong 2863311530
-%1043 = OpTypeFunction %_struct_281 %ulong
+%1863 = OpTypeFunction %_struct_810 %ulong
 %ulong_8191 = OpConstant %ulong 8191
 %double_2 = OpConstant %double 2
 %ulong_131071 = OpConstant %ulong 131071
 %double_32 = OpConstant %double 32
-%bool = OpTypeBool
 %uint_12 = OpConstant %uint 12
 %_arr_ulong_uint_12 = OpTypeArray %ulong %uint_12
 %_ptr_Function__arr_ulong_uint_12 = OpTypePointer Function %_arr_ulong_uint_12
-%_ptr_Function_bool = OpTypePointer Function %bool
-%1363 = OpConstantNull %_arr_ulong_uint_12
-%ulong_0 = OpConstant %ulong 0
+%2180 = OpConstantNull %_arr_ulong_uint_12
 %ulong_12 = OpConstant %ulong 12
 %ulong_1023 = OpConstant %ulong 1023
 %uint_10 = OpConstant %uint 10
 %uint_11 = OpConstant %uint 11
-%ulong_255 = OpConstant %ulong 255
 %ulong_19 = OpConstant %ulong 19
 %uint_7 = OpConstant %uint 7
 %uint_8 = OpConstant %uint 8
 %uint_9 = OpConstant %uint 9
-%1829 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1872 = OpTypeFunction %ulong %ulong %uint
-%1917 = OpTypeFunction %ulong %ulong %float
-%1965 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %25
-%26 = OpFunctionParameter %ulong
-%27 = OpFunctionParameter %ulong
-%28 = OpLabel
+%1 = OpFunction %ulong None %21
+%22 = OpFunctionParameter %ulong
+%23 = OpFunctionParameter %ulong
+%24 = OpLabel
+%26 = OpVariable %_ptr_Function_ulong Function
+%27 = OpVariable %_ptr_Function_ulong Function
+%28 = OpVariable %_ptr_Function_ulong Function
+%29 = OpVariable %_ptr_Function_ulong Function
 %30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-OpStore %30 %26
-OpStore %31 %27
-%35 = OpLoad %ulong %31
-%37 = OpIMul %ulong %35 %ulong_6364136223846793005
-OpStore %32 %37
-%38 = OpLoad %ulong %32
-%40 = OpIAdd %ulong %38 %ulong_1442695040888963407
-OpStore %33 %40
-%41 = OpLoad %ulong %33
-%42 = OpLoad %ulong %30
-%43 = OpIAdd %ulong %41 %42
-OpStore %34 %43
-%44 = OpLoad %ulong %34
-OpReturnValue %44
+OpStore %26 %22
+OpStore %27 %23
+%31 = OpLoad %ulong %27
+%33 = OpIMul %ulong %31 %ulong_6364136223846793005
+OpStore %28 %33
+%34 = OpLoad %ulong %28
+%36 = OpIAdd %ulong %34 %ulong_1442695040888963407
+OpStore %29 %36
+%37 = OpLoad %ulong %29
+%38 = OpLoad %ulong %26
+%39 = OpIAdd %ulong %37 %38
+OpStore %30 %39
+%40 = OpLoad %ulong %30
+OpReturnValue %40
 OpFunctionEnd
-%2 = OpFunction %ulong None %46
-%47 = OpFunctionParameter %ulong
-%48 = OpFunctionParameter %_struct_45
-%49 = OpLabel
-%51 = OpVariable %_ptr_Function__struct_45 Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-OpStore %52 %47
-OpStore %51 %48
-%61 = OpAccessChain %_ptr_Function_ulong %51 %uint_0
-%62 = OpLoad %ulong %61
-OpStore %56 %62
-%64 = OpAccessChain %_ptr_Function_ulong %51 %uint_1
-%65 = OpLoad %ulong %64
-OpStore %57 %65
-%67 = OpAccessChain %_ptr_Function_ulong %51 %uint_2
-%68 = OpLoad %ulong %67
-OpStore %58 %68
-%69 = OpLoad %ulong %52
-%70 = OpLoad %ulong %56
-%71 = OpFunctionCall %ulong %20 %69 %70
-OpStore %53 %71
-%72 = OpLoad %ulong %53
-%73 = OpLoad %ulong %57
-%74 = OpFunctionCall %ulong %20 %72 %73
-OpStore %54 %74
-%75 = OpLoad %ulong %54
-%76 = OpLoad %ulong %58
-%77 = OpFunctionCall %ulong %20 %75 %76
-OpStore %55 %77
-%78 = OpLoad %ulong %55
-OpReturnValue %78
-OpFunctionEnd
-%3 = OpFunction %ulong None %81
-%82 = OpFunctionParameter %ulong
-%83 = OpFunctionParameter %_struct_80
-%84 = OpLabel
-%86 = OpVariable %_ptr_Function__struct_80 Function
-%87 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %42
+%43 = OpFunctionParameter %ulong
+%44 = OpFunctionParameter %_struct_41
+%45 = OpLabel
+%66 = OpVariable %_ptr_Function__struct_41 Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_bool Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_bool Function
 %88 = OpVariable %_ptr_Function_ulong Function
 %89 = OpVariable %_ptr_Function_ulong Function
 %90 = OpVariable %_ptr_Function_ulong Function
-%92 = OpVariable %_ptr_Function_double Function
-%93 = OpVariable %_ptr_Function_double Function
-%94 = OpVariable %_ptr_Function_double Function
-OpStore %87 %82
-OpStore %86 %83
-%95 = OpAccessChain %_ptr_Function_double %86 %uint_0
-%96 = OpLoad %double %95
-OpStore %92 %96
-%97 = OpAccessChain %_ptr_Function_double %86 %uint_1
-%98 = OpLoad %double %97
-OpStore %93 %98
-%99 = OpAccessChain %_ptr_Function_double %86 %uint_2
-%100 = OpLoad %double %99
-OpStore %94 %100
-%101 = OpLoad %ulong %87
-%102 = OpLoad %double %92
-%103 = OpFunctionCall %ulong %23 %101 %102
-OpStore %88 %103
-%104 = OpLoad %ulong %88
-%105 = OpLoad %double %93
-%106 = OpFunctionCall %ulong %23 %104 %105
-OpStore %89 %106
-%107 = OpLoad %ulong %89
-%108 = OpLoad %double %94
-%109 = OpFunctionCall %ulong %23 %107 %108
-OpStore %90 %109
-%110 = OpLoad %ulong %90
-OpReturnValue %110
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+OpStore %67 %43
+OpStore %66 %44
+%101 = OpAccessChain %_ptr_Function_ulong %66 %uint_0
+%102 = OpLoad %ulong %101
+OpStore %96 %102
+%104 = OpAccessChain %_ptr_Function_ulong %66 %uint_1
+%105 = OpLoad %ulong %104
+OpStore %97 %105
+%107 = OpAccessChain %_ptr_Function_ulong %66 %uint_2
+%108 = OpLoad %ulong %107
+OpStore %98 %108
+OpBranch %46
+%46 = OpLabel
+%109 = OpLoad %ulong %67
+OpStore %76 %109
+OpStore %77 %ulong_0
+OpBranch %47
+%47 = OpLabel
+%111 = OpLoad %ulong %77
+%113 = OpULessThan %bool %111 %ulong_8
+OpStore %69 %113
+%114 = OpLoad %bool %69
+OpLoopMerge %49 %63 None
+OpBranchConditional %114 %48 %49
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+OpBranch %51
+%51 = OpLabel
+%115 = OpLoad %ulong %76
+OpStore %85 %115
+OpStore %86 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%116 = OpLoad %ulong %86
+%117 = OpULessThan %bool %116 %ulong_8
+OpStore %78 %117
+%118 = OpLoad %bool %78
+OpLoopMerge %54 %62 None
+OpBranchConditional %118 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+%119 = OpLoad %ulong %85
+OpStore %94 %119
+OpStore %95 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%120 = OpLoad %ulong %95
+%121 = OpULessThan %bool %120 %ulong_8
+OpStore %87 %121
+%122 = OpLoad %bool %87
+OpLoopMerge %59 %61 None
+OpBranchConditional %122 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+%123 = OpLoad %ulong %94
+OpReturnValue %123
+%58 = OpLabel
+%124 = OpLoad %ulong %95
+%125 = OpIMul %ulong %124 %ulong_8
+OpStore %88 %125
+%126 = OpLoad %ulong %98
+%127 = OpLoad %ulong %88
+%128 = OpShiftRightLogical %ulong %126 %127
+OpStore %89 %128
+%129 = OpLoad %ulong %89
+%131 = OpBitwiseAnd %ulong %129 %ulong_255
+OpStore %90 %131
+%132 = OpLoad %ulong %94
+%133 = OpLoad %ulong %90
+%134 = OpBitwiseXor %ulong %132 %133
+OpStore %91 %134
+%135 = OpLoad %ulong %91
+%137 = OpIMul %ulong %135 %ulong_1099511628211
+OpStore %92 %137
+%138 = OpLoad %ulong %95
+%140 = OpIAdd %ulong %138 %ulong_1
+OpStore %93 %140
+%141 = OpLoad %ulong %92
+OpStore %94 %141
+%142 = OpLoad %ulong %93
+OpStore %95 %142
+OpBranch %61
+%53 = OpLabel
+%143 = OpLoad %ulong %86
+%144 = OpIMul %ulong %143 %ulong_8
+OpStore %79 %144
+%145 = OpLoad %ulong %97
+%146 = OpLoad %ulong %79
+%147 = OpShiftRightLogical %ulong %145 %146
+OpStore %80 %147
+%148 = OpLoad %ulong %80
+%149 = OpBitwiseAnd %ulong %148 %ulong_255
+OpStore %81 %149
+%150 = OpLoad %ulong %85
+%151 = OpLoad %ulong %81
+%152 = OpBitwiseXor %ulong %150 %151
+OpStore %82 %152
+%153 = OpLoad %ulong %82
+%154 = OpIMul %ulong %153 %ulong_1099511628211
+OpStore %83 %154
+%155 = OpLoad %ulong %86
+%156 = OpIAdd %ulong %155 %ulong_1
+OpStore %84 %156
+%157 = OpLoad %ulong %83
+OpStore %85 %157
+%158 = OpLoad %ulong %84
+OpStore %86 %158
+OpBranch %62
+%48 = OpLabel
+%159 = OpLoad %ulong %77
+%160 = OpIMul %ulong %159 %ulong_8
+OpStore %70 %160
+%161 = OpLoad %ulong %96
+%162 = OpLoad %ulong %70
+%163 = OpShiftRightLogical %ulong %161 %162
+OpStore %71 %163
+%164 = OpLoad %ulong %71
+%165 = OpBitwiseAnd %ulong %164 %ulong_255
+OpStore %72 %165
+%166 = OpLoad %ulong %76
+%167 = OpLoad %ulong %72
+%168 = OpBitwiseXor %ulong %166 %167
+OpStore %73 %168
+%169 = OpLoad %ulong %73
+%170 = OpIMul %ulong %169 %ulong_1099511628211
+OpStore %74 %170
+%171 = OpLoad %ulong %77
+%172 = OpIAdd %ulong %171 %ulong_1
+OpStore %75 %172
+%173 = OpLoad %ulong %74
+OpStore %76 %173
+%174 = OpLoad %ulong %75
+OpStore %77 %174
+OpBranch %63
+%61 = OpLabel
+OpBranch %57
+%62 = OpLabel
+OpBranch %52
+%63 = OpLabel
+OpBranch %47
 OpFunctionEnd
-%4 = OpFunction %ulong None %112
-%113 = OpFunctionParameter %ulong
-%114 = OpFunctionParameter %_struct_111
-%115 = OpLabel
-%117 = OpVariable %_ptr_Function__struct_111 Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_double Function
-%126 = OpVariable %_ptr_Function_uint Function
-%127 = OpVariable %_ptr_Function_uint Function
-OpStore %118 %113
-OpStore %117 %114
-%128 = OpAccessChain %_ptr_Function_ulong %117 %uint_0
-%129 = OpLoad %ulong %128
-OpStore %123 %129
-%130 = OpAccessChain %_ptr_Function_double %117 %uint_1
-%131 = OpLoad %double %130
-OpStore %124 %131
-%132 = OpAccessChain %_ptr_Function_uint %117 %uint_2
-%133 = OpLoad %uint %132
-OpStore %126 %133
-%135 = OpAccessChain %_ptr_Function_uint %117 %uint_3
-%136 = OpLoad %uint %135
-OpStore %127 %136
-%137 = OpLoad %ulong %118
-%138 = OpLoad %ulong %123
-%139 = OpFunctionCall %ulong %20 %137 %138
-OpStore %119 %139
-%140 = OpLoad %ulong %119
-%141 = OpLoad %double %124
-%142 = OpFunctionCall %ulong %23 %140 %141
-OpStore %120 %142
-%143 = OpLoad %ulong %120
-%144 = OpLoad %uint %126
-%145 = OpFunctionCall %ulong %21 %143 %144
-OpStore %121 %145
-%146 = OpLoad %ulong %121
-%147 = OpLoad %uint %127
-%148 = OpFunctionCall %ulong %21 %146 %147
-OpStore %122 %148
-%149 = OpLoad %ulong %122
-OpReturnValue %149
-OpFunctionEnd
-%5 = OpFunction %ulong None %151
-%152 = OpFunctionParameter %ulong
-%153 = OpFunctionParameter %_struct_150
-%154 = OpLabel
-%156 = OpVariable %_ptr_Function__struct_150 Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-OpStore %157 %152
-OpStore %156 %153
-%166 = OpAccessChain %_ptr_Function_ulong %156 %uint_0
-%167 = OpLoad %ulong %166
-OpStore %162 %167
-%168 = OpAccessChain %_ptr_Function_ulong %156 %uint_1
-%169 = OpLoad %ulong %168
-OpStore %163 %169
-%170 = OpAccessChain %_ptr_Function_ulong %156 %uint_2
-%171 = OpLoad %ulong %170
-OpStore %164 %171
-%172 = OpAccessChain %_ptr_Function_ulong %156 %uint_3
-%173 = OpLoad %ulong %172
-OpStore %165 %173
-%174 = OpLoad %ulong %157
-%175 = OpLoad %ulong %162
-%176 = OpFunctionCall %ulong %20 %174 %175
-OpStore %158 %176
-%177 = OpLoad %ulong %158
-%178 = OpLoad %ulong %163
-%179 = OpFunctionCall %ulong %20 %177 %178
-OpStore %159 %179
-%180 = OpLoad %ulong %159
-%181 = OpLoad %ulong %164
-%182 = OpFunctionCall %ulong %20 %180 %181
-OpStore %160 %182
-%183 = OpLoad %ulong %160
-%184 = OpLoad %ulong %165
-%185 = OpFunctionCall %ulong %20 %183 %184
-OpStore %161 %185
-%186 = OpLoad %ulong %161
-OpReturnValue %186
-OpFunctionEnd
-%6 = OpFunction %ulong None %189
-%190 = OpFunctionParameter %ulong
-%191 = OpFunctionParameter %_struct_188
-%192 = OpLabel
-%194 = OpVariable %_ptr_Function__struct_188 Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-OpStore %195 %190
-OpStore %194 %191
-%205 = OpAccessChain %_ptr_Function__struct_187 %194 %uint_0
-%206 = OpAccessChain %_ptr_Function_ulong %205 %uint_0
-%207 = OpLoad %ulong %206
-OpStore %200 %207
-%208 = OpAccessChain %_ptr_Function_ulong %205 %uint_1
-%209 = OpLoad %ulong %208
-OpStore %201 %209
-%210 = OpAccessChain %_ptr_Function__struct_187 %194 %uint_1
-%211 = OpAccessChain %_ptr_Function_ulong %210 %uint_0
-%212 = OpLoad %ulong %211
-OpStore %202 %212
-%213 = OpAccessChain %_ptr_Function_ulong %210 %uint_1
-%214 = OpLoad %ulong %213
-OpStore %203 %214
-%215 = OpLoad %ulong %195
-%216 = OpLoad %ulong %200
-%217 = OpFunctionCall %ulong %20 %215 %216
-OpStore %196 %217
-%218 = OpLoad %ulong %196
-%219 = OpLoad %ulong %201
-%220 = OpFunctionCall %ulong %20 %218 %219
-OpStore %197 %220
-%221 = OpLoad %ulong %197
-%222 = OpLoad %ulong %202
-%223 = OpFunctionCall %ulong %20 %221 %222
-OpStore %198 %223
-%224 = OpLoad %ulong %198
-%225 = OpLoad %ulong %203
-%226 = OpFunctionCall %ulong %20 %224 %225
-OpStore %199 %226
-%227 = OpLoad %ulong %199
-OpReturnValue %227
-OpFunctionEnd
-%7 = OpFunction %ulong None %229
-%230 = OpFunctionParameter %ulong
-%231 = OpFunctionParameter %_struct_228
-%232 = OpLabel
-%234 = OpVariable %_ptr_Function__struct_228 Function
+%3 = OpFunction %ulong None %177
+%178 = OpFunctionParameter %ulong
+%179 = OpFunctionParameter %_struct_176
+%180 = OpLabel
+%206 = OpVariable %_ptr_Function__struct_176 Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
 %235 = OpVariable %_ptr_Function_ulong Function
 %236 = OpVariable %_ptr_Function_ulong Function
 %237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_ulong Function
-OpStore %235 %230
-OpStore %234 %231
-%248 = OpAccessChain %_ptr_Function_ulong %234 %uint_0
-%249 = OpLoad %ulong %248
-OpStore %242 %249
-%250 = OpAccessChain %_ptr_Function_ulong %234 %uint_1
-%251 = OpLoad %ulong %250
-OpStore %243 %251
-%252 = OpAccessChain %_ptr_Function_ulong %234 %uint_2
-%253 = OpLoad %ulong %252
-OpStore %244 %253
-%254 = OpAccessChain %_ptr_Function_ulong %234 %uint_3
-%255 = OpLoad %ulong %254
-OpStore %245 %255
-%257 = OpAccessChain %_ptr_Function_ulong %234 %uint_4
-%258 = OpLoad %ulong %257
-OpStore %246 %258
-%260 = OpAccessChain %_ptr_Function_ulong %234 %uint_5
-%261 = OpLoad %ulong %260
-OpStore %247 %261
-%262 = OpLoad %ulong %235
-%263 = OpLoad %ulong %242
-%264 = OpFunctionCall %ulong %20 %262 %263
-OpStore %236 %264
-%265 = OpLoad %ulong %236
-%266 = OpLoad %ulong %243
-%267 = OpFunctionCall %ulong %20 %265 %266
-OpStore %237 %267
-%268 = OpLoad %ulong %237
-%269 = OpLoad %ulong %244
-%270 = OpFunctionCall %ulong %20 %268 %269
-OpStore %238 %270
-%271 = OpLoad %ulong %238
-%272 = OpLoad %ulong %245
-%273 = OpFunctionCall %ulong %20 %271 %272
-OpStore %239 %273
-%274 = OpLoad %ulong %239
-%275 = OpLoad %ulong %246
-%276 = OpFunctionCall %ulong %20 %274 %275
-OpStore %240 %276
-%277 = OpLoad %ulong %240
-%278 = OpLoad %ulong %247
-%279 = OpFunctionCall %ulong %20 %277 %278
-OpStore %241 %279
-%280 = OpLoad %ulong %241
-OpReturnValue %280
+%239 = OpVariable %_ptr_Function_double Function
+%240 = OpVariable %_ptr_Function_double Function
+%241 = OpVariable %_ptr_Function_double Function
+OpStore %207 %178
+OpStore %206 %179
+%242 = OpAccessChain %_ptr_Function_double %206 %uint_0
+%243 = OpLoad %double %242
+OpStore %239 %243
+%244 = OpAccessChain %_ptr_Function_double %206 %uint_1
+%245 = OpLoad %double %244
+OpStore %240 %245
+%246 = OpAccessChain %_ptr_Function_double %206 %uint_2
+%247 = OpLoad %double %246
+OpStore %241 %247
+OpBranch %181
+%181 = OpLabel
+%248 = OpLoad %double %239
+%249 = OpBitcast %ulong %248
+OpStore %208 %249
+OpBranch %183
+%183 = OpLabel
+%250 = OpLoad %ulong %207
+OpStore %216 %250
+OpStore %217 %ulong_0
+OpBranch %184
+%184 = OpLabel
+%251 = OpLoad %ulong %217
+%252 = OpULessThan %bool %251 %ulong_8
+OpStore %209 %252
+%253 = OpLoad %bool %209
+OpLoopMerge %186 %204 None
+OpBranchConditional %253 %185 %186
+%186 = OpLabel
+OpBranch %187
+%187 = OpLabel
+OpBranch %182
+%182 = OpLabel
+OpBranch %188
+%188 = OpLabel
+%254 = OpLoad %double %240
+%255 = OpBitcast %ulong %254
+OpStore %218 %255
+OpBranch %190
+%190 = OpLabel
+%256 = OpLoad %ulong %216
+OpStore %226 %256
+OpStore %227 %ulong_0
+OpBranch %191
+%191 = OpLabel
+%257 = OpLoad %ulong %227
+%258 = OpULessThan %bool %257 %ulong_8
+OpStore %219 %258
+%259 = OpLoad %bool %219
+OpLoopMerge %193 %203 None
+OpBranchConditional %259 %192 %193
+%193 = OpLabel
+OpBranch %194
+%194 = OpLabel
+OpBranch %189
+%189 = OpLabel
+OpBranch %195
+%195 = OpLabel
+%260 = OpLoad %double %241
+%261 = OpBitcast %ulong %260
+OpStore %228 %261
+OpBranch %197
+%197 = OpLabel
+%262 = OpLoad %ulong %226
+OpStore %236 %262
+OpStore %237 %ulong_0
+OpBranch %198
+%198 = OpLabel
+%263 = OpLoad %ulong %237
+%264 = OpULessThan %bool %263 %ulong_8
+OpStore %229 %264
+%265 = OpLoad %bool %229
+OpLoopMerge %200 %202 None
+OpBranchConditional %265 %199 %200
+%200 = OpLabel
+OpBranch %201
+%201 = OpLabel
+OpBranch %196
+%196 = OpLabel
+%266 = OpLoad %ulong %236
+OpReturnValue %266
+%199 = OpLabel
+%267 = OpLoad %ulong %237
+%268 = OpIMul %ulong %267 %ulong_8
+OpStore %230 %268
+%269 = OpLoad %ulong %228
+%270 = OpLoad %ulong %230
+%271 = OpShiftRightLogical %ulong %269 %270
+OpStore %231 %271
+%272 = OpLoad %ulong %231
+%273 = OpBitwiseAnd %ulong %272 %ulong_255
+OpStore %232 %273
+%274 = OpLoad %ulong %236
+%275 = OpLoad %ulong %232
+%276 = OpBitwiseXor %ulong %274 %275
+OpStore %233 %276
+%277 = OpLoad %ulong %233
+%278 = OpIMul %ulong %277 %ulong_1099511628211
+OpStore %234 %278
+%279 = OpLoad %ulong %237
+%280 = OpIAdd %ulong %279 %ulong_1
+OpStore %235 %280
+%281 = OpLoad %ulong %234
+OpStore %236 %281
+%282 = OpLoad %ulong %235
+OpStore %237 %282
+OpBranch %202
+%192 = OpLabel
+%283 = OpLoad %ulong %227
+%284 = OpIMul %ulong %283 %ulong_8
+OpStore %220 %284
+%285 = OpLoad %ulong %218
+%286 = OpLoad %ulong %220
+%287 = OpShiftRightLogical %ulong %285 %286
+OpStore %221 %287
+%288 = OpLoad %ulong %221
+%289 = OpBitwiseAnd %ulong %288 %ulong_255
+OpStore %222 %289
+%290 = OpLoad %ulong %226
+%291 = OpLoad %ulong %222
+%292 = OpBitwiseXor %ulong %290 %291
+OpStore %223 %292
+%293 = OpLoad %ulong %223
+%294 = OpIMul %ulong %293 %ulong_1099511628211
+OpStore %224 %294
+%295 = OpLoad %ulong %227
+%296 = OpIAdd %ulong %295 %ulong_1
+OpStore %225 %296
+%297 = OpLoad %ulong %224
+OpStore %226 %297
+%298 = OpLoad %ulong %225
+OpStore %227 %298
+OpBranch %203
+%185 = OpLabel
+%299 = OpLoad %ulong %217
+%300 = OpIMul %ulong %299 %ulong_8
+OpStore %210 %300
+%301 = OpLoad %ulong %208
+%302 = OpLoad %ulong %210
+%303 = OpShiftRightLogical %ulong %301 %302
+OpStore %211 %303
+%304 = OpLoad %ulong %211
+%305 = OpBitwiseAnd %ulong %304 %ulong_255
+OpStore %212 %305
+%306 = OpLoad %ulong %216
+%307 = OpLoad %ulong %212
+%308 = OpBitwiseXor %ulong %306 %307
+OpStore %213 %308
+%309 = OpLoad %ulong %213
+%310 = OpIMul %ulong %309 %ulong_1099511628211
+OpStore %214 %310
+%311 = OpLoad %ulong %217
+%312 = OpIAdd %ulong %311 %ulong_1
+OpStore %215 %312
+%313 = OpLoad %ulong %214
+OpStore %216 %313
+%314 = OpLoad %ulong %215
+OpStore %217 %314
+OpBranch %204
+%202 = OpLabel
+OpBranch %198
+%203 = OpLabel
+OpBranch %191
+%204 = OpLabel
+OpBranch %184
 OpFunctionEnd
-%8 = OpFunction %ulong None %282
-%283 = OpFunctionParameter %ulong
-%284 = OpFunctionParameter %_struct_281
-%285 = OpLabel
-%287 = OpVariable %_ptr_Function__struct_281 Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_ulong Function
-%297 = OpVariable %_ptr_Function_double Function
-%298 = OpVariable %_ptr_Function_uint Function
-%299 = OpVariable %_ptr_Function_uint Function
-%300 = OpVariable %_ptr_Function_double Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ulong Function
-OpStore %288 %283
-OpStore %287 %284
-%303 = OpAccessChain %_ptr_Function_ulong %287 %uint_0
-%304 = OpLoad %ulong %303
-OpStore %296 %304
-%305 = OpAccessChain %_ptr_Function_double %287 %uint_1
-%306 = OpLoad %double %305
-OpStore %297 %306
-%307 = OpAccessChain %_ptr_Function_uint %287 %uint_2
-%308 = OpLoad %uint %307
-OpStore %298 %308
-%309 = OpAccessChain %_ptr_Function_uint %287 %uint_3
-%310 = OpLoad %uint %309
-OpStore %299 %310
-%311 = OpAccessChain %_ptr_Function_double %287 %uint_4
-%312 = OpLoad %double %311
-OpStore %300 %312
-%313 = OpAccessChain %_ptr_Function_ulong %287 %uint_5
-%314 = OpLoad %ulong %313
-OpStore %301 %314
-%316 = OpAccessChain %_ptr_Function_ulong %287 %uint_6
-%317 = OpLoad %ulong %316
-OpStore %302 %317
-%318 = OpLoad %ulong %288
-%319 = OpLoad %ulong %296
-%320 = OpFunctionCall %ulong %20 %318 %319
-OpStore %289 %320
-%321 = OpLoad %ulong %289
-%322 = OpLoad %double %297
-%323 = OpFunctionCall %ulong %23 %321 %322
-OpStore %290 %323
-%324 = OpLoad %ulong %290
-%325 = OpLoad %uint %298
-%326 = OpFunctionCall %ulong %21 %324 %325
-OpStore %291 %326
-%327 = OpLoad %ulong %291
-%328 = OpLoad %uint %299
-%329 = OpFunctionCall %ulong %21 %327 %328
-OpStore %292 %329
-%330 = OpLoad %ulong %292
-%331 = OpLoad %double %300
-%332 = OpFunctionCall %ulong %23 %330 %331
-OpStore %293 %332
-%333 = OpLoad %ulong %293
-%334 = OpLoad %ulong %301
-%335 = OpFunctionCall %ulong %20 %333 %334
-OpStore %294 %335
-%336 = OpLoad %ulong %294
-%337 = OpLoad %ulong %302
-%338 = OpFunctionCall %ulong %20 %336 %337
-OpStore %295 %338
-%339 = OpLoad %ulong %295
-OpReturnValue %339
-OpFunctionEnd
-%9 = OpFunction %ulong None %340
-%341 = OpFunctionParameter %ulong
-%342 = OpLabel
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_ulong Function
+%4 = OpFunction %ulong None %316
+%317 = OpFunctionParameter %ulong
+%318 = OpFunctionParameter %_struct_315
+%319 = OpLabel
+%351 = OpVariable %_ptr_Function__struct_315 Function
 %352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_bool Function
 %354 = OpVariable %_ptr_Function_ulong Function
 %355 = OpVariable %_ptr_Function_ulong Function
 %356 = OpVariable %_ptr_Function_ulong Function
@@ -530,167 +549,271 @@ OpFunctionEnd
 %358 = OpVariable %_ptr_Function_ulong Function
 %359 = OpVariable %_ptr_Function_ulong Function
 %360 = OpVariable %_ptr_Function_ulong Function
-OpStore %343 %341
-%361 = OpLoad %ulong %343
-%363 = OpFunctionCall %ulong %20 %361 %ulong_24
-OpStore %344 %363
-%364 = OpLoad %ulong %344
-%365 = OpFunctionCall %ulong %20 %364 %ulong_24
-OpStore %345 %365
-%366 = OpLoad %ulong %345
-%367 = OpFunctionCall %ulong %20 %366 %ulong_24
-OpStore %346 %367
-%368 = OpLoad %ulong %346
-%370 = OpFunctionCall %ulong %20 %368 %ulong_32
-OpStore %347 %370
-%371 = OpLoad %ulong %347
-%372 = OpFunctionCall %ulong %20 %371 %ulong_32
-OpStore %348 %372
-%373 = OpLoad %ulong %348
-%375 = OpFunctionCall %ulong %20 %373 %ulong_48
-OpStore %349 %375
-%376 = OpLoad %ulong %349
-%377 = OpFunctionCall %ulong %20 %376 %ulong_48
-OpStore %350 %377
-%378 = OpLoad %ulong %350
-%380 = OpFunctionCall %ulong %20 %378 %ulong_8
-OpStore %351 %380
-%381 = OpLoad %ulong %351
-%382 = OpFunctionCall %ulong %20 %381 %ulong_8
-OpStore %352 %382
-%383 = OpLoad %ulong %352
-%384 = OpFunctionCall %ulong %20 %383 %ulong_8
-OpStore %353 %384
-%385 = OpLoad %ulong %353
-%387 = OpFunctionCall %ulong %20 %385 %ulong_16
-OpStore %354 %387
-%388 = OpLoad %ulong %354
-%389 = OpFunctionCall %ulong %20 %388 %ulong_16
-OpStore %355 %389
-%390 = OpLoad %ulong %355
-%392 = OpFunctionCall %ulong %20 %390 %ulong_20
-OpStore %356 %392
-%393 = OpLoad %ulong %356
-%394 = OpFunctionCall %ulong %20 %393 %ulong_16
-OpStore %357 %394
-%395 = OpLoad %ulong %357
-%397 = OpFunctionCall %ulong %20 %395 %ulong_40
-OpStore %358 %397
-%398 = OpLoad %ulong %358
-%399 = OpFunctionCall %ulong %20 %398 %ulong_24
-OpStore %359 %399
-%400 = OpLoad %ulong %359
-%401 = OpFunctionCall %ulong %20 %400 %ulong_40
-OpStore %360 %401
-%402 = OpLoad %ulong %360
-OpReturnValue %402
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_bool Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_bool Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_bool Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_double Function
+%395 = OpVariable %_ptr_Function_uint Function
+%396 = OpVariable %_ptr_Function_uint Function
+OpStore %352 %317
+OpStore %351 %318
+%397 = OpAccessChain %_ptr_Function_ulong %351 %uint_0
+%398 = OpLoad %ulong %397
+OpStore %392 %398
+%399 = OpAccessChain %_ptr_Function_double %351 %uint_1
+%400 = OpLoad %double %399
+OpStore %393 %400
+%401 = OpAccessChain %_ptr_Function_uint %351 %uint_2
+%402 = OpLoad %uint %401
+OpStore %395 %402
+%404 = OpAccessChain %_ptr_Function_uint %351 %uint_3
+%405 = OpLoad %uint %404
+OpStore %396 %405
+OpBranch %320
+%320 = OpLabel
+%406 = OpLoad %ulong %352
+OpStore %360 %406
+OpStore %361 %ulong_0
+OpBranch %321
+%321 = OpLabel
+%407 = OpLoad %ulong %361
+%408 = OpULessThan %bool %407 %ulong_8
+OpStore %353 %408
+%409 = OpLoad %bool %353
+OpLoopMerge %323 %349 None
+OpBranchConditional %409 %322 %323
+%323 = OpLabel
+OpBranch %324
+%324 = OpLabel
+OpBranch %325
+%325 = OpLabel
+%410 = OpLoad %double %393
+%411 = OpBitcast %ulong %410
+OpStore %362 %411
+OpBranch %327
+%327 = OpLabel
+%412 = OpLoad %ulong %360
+OpStore %370 %412
+OpStore %371 %ulong_0
+OpBranch %328
+%328 = OpLabel
+%413 = OpLoad %ulong %371
+%414 = OpULessThan %bool %413 %ulong_8
+OpStore %363 %414
+%415 = OpLoad %bool %363
+OpLoopMerge %330 %348 None
+OpBranchConditional %415 %329 %330
+%330 = OpLabel
+OpBranch %331
+%331 = OpLabel
+OpBranch %326
+%326 = OpLabel
+OpBranch %332
+%332 = OpLabel
+%416 = OpLoad %uint %395
+%417 = OpUConvert %ulong %416
+OpStore %372 %417
+OpBranch %334
+%334 = OpLabel
+%418 = OpLoad %ulong %370
+OpStore %380 %418
+OpStore %381 %ulong_0
+OpBranch %335
+%335 = OpLabel
+%419 = OpLoad %ulong %381
+%420 = OpULessThan %bool %419 %ulong_8
+OpStore %373 %420
+%421 = OpLoad %bool %373
+OpLoopMerge %337 %347 None
+OpBranchConditional %421 %336 %337
+%337 = OpLabel
+OpBranch %338
+%338 = OpLabel
+OpBranch %333
+%333 = OpLabel
+OpBranch %339
+%339 = OpLabel
+%422 = OpLoad %uint %396
+%423 = OpUConvert %ulong %422
+OpStore %382 %423
+OpBranch %341
+%341 = OpLabel
+%424 = OpLoad %ulong %380
+OpStore %390 %424
+OpStore %391 %ulong_0
+OpBranch %342
+%342 = OpLabel
+%425 = OpLoad %ulong %391
+%426 = OpULessThan %bool %425 %ulong_8
+OpStore %383 %426
+%427 = OpLoad %bool %383
+OpLoopMerge %344 %346 None
+OpBranchConditional %427 %343 %344
+%344 = OpLabel
+OpBranch %345
+%345 = OpLabel
+OpBranch %340
+%340 = OpLabel
+%428 = OpLoad %ulong %390
+OpReturnValue %428
+%343 = OpLabel
+%429 = OpLoad %ulong %391
+%430 = OpIMul %ulong %429 %ulong_8
+OpStore %384 %430
+%431 = OpLoad %ulong %382
+%432 = OpLoad %ulong %384
+%433 = OpShiftRightLogical %ulong %431 %432
+OpStore %385 %433
+%434 = OpLoad %ulong %385
+%435 = OpBitwiseAnd %ulong %434 %ulong_255
+OpStore %386 %435
+%436 = OpLoad %ulong %390
+%437 = OpLoad %ulong %386
+%438 = OpBitwiseXor %ulong %436 %437
+OpStore %387 %438
+%439 = OpLoad %ulong %387
+%440 = OpIMul %ulong %439 %ulong_1099511628211
+OpStore %388 %440
+%441 = OpLoad %ulong %391
+%442 = OpIAdd %ulong %441 %ulong_1
+OpStore %389 %442
+%443 = OpLoad %ulong %388
+OpStore %390 %443
+%444 = OpLoad %ulong %389
+OpStore %391 %444
+OpBranch %346
+%336 = OpLabel
+%445 = OpLoad %ulong %381
+%446 = OpIMul %ulong %445 %ulong_8
+OpStore %374 %446
+%447 = OpLoad %ulong %372
+%448 = OpLoad %ulong %374
+%449 = OpShiftRightLogical %ulong %447 %448
+OpStore %375 %449
+%450 = OpLoad %ulong %375
+%451 = OpBitwiseAnd %ulong %450 %ulong_255
+OpStore %376 %451
+%452 = OpLoad %ulong %380
+%453 = OpLoad %ulong %376
+%454 = OpBitwiseXor %ulong %452 %453
+OpStore %377 %454
+%455 = OpLoad %ulong %377
+%456 = OpIMul %ulong %455 %ulong_1099511628211
+OpStore %378 %456
+%457 = OpLoad %ulong %381
+%458 = OpIAdd %ulong %457 %ulong_1
+OpStore %379 %458
+%459 = OpLoad %ulong %378
+OpStore %380 %459
+%460 = OpLoad %ulong %379
+OpStore %381 %460
+OpBranch %347
+%329 = OpLabel
+%461 = OpLoad %ulong %371
+%462 = OpIMul %ulong %461 %ulong_8
+OpStore %364 %462
+%463 = OpLoad %ulong %362
+%464 = OpLoad %ulong %364
+%465 = OpShiftRightLogical %ulong %463 %464
+OpStore %365 %465
+%466 = OpLoad %ulong %365
+%467 = OpBitwiseAnd %ulong %466 %ulong_255
+OpStore %366 %467
+%468 = OpLoad %ulong %370
+%469 = OpLoad %ulong %366
+%470 = OpBitwiseXor %ulong %468 %469
+OpStore %367 %470
+%471 = OpLoad %ulong %367
+%472 = OpIMul %ulong %471 %ulong_1099511628211
+OpStore %368 %472
+%473 = OpLoad %ulong %371
+%474 = OpIAdd %ulong %473 %ulong_1
+OpStore %369 %474
+%475 = OpLoad %ulong %368
+OpStore %370 %475
+%476 = OpLoad %ulong %369
+OpStore %371 %476
+OpBranch %348
+%322 = OpLabel
+%477 = OpLoad %ulong %361
+%478 = OpIMul %ulong %477 %ulong_8
+OpStore %354 %478
+%479 = OpLoad %ulong %392
+%480 = OpLoad %ulong %354
+%481 = OpShiftRightLogical %ulong %479 %480
+OpStore %355 %481
+%482 = OpLoad %ulong %355
+%483 = OpBitwiseAnd %ulong %482 %ulong_255
+OpStore %356 %483
+%484 = OpLoad %ulong %360
+%485 = OpLoad %ulong %356
+%486 = OpBitwiseXor %ulong %484 %485
+OpStore %357 %486
+%487 = OpLoad %ulong %357
+%488 = OpIMul %ulong %487 %ulong_1099511628211
+OpStore %358 %488
+%489 = OpLoad %ulong %361
+%490 = OpIAdd %ulong %489 %ulong_1
+OpStore %359 %490
+%491 = OpLoad %ulong %358
+OpStore %360 %491
+%492 = OpLoad %ulong %359
+OpStore %361 %492
+OpBranch %349
+%346 = OpLabel
+OpBranch %342
+%347 = OpLabel
+OpBranch %335
+%348 = OpLabel
+OpBranch %328
+%349 = OpLabel
+OpBranch %321
 OpFunctionEnd
-%10 = OpFunction %ulong None %404
-%405 = OpFunctionParameter %ulong
-%406 = OpFunctionParameter %_struct_45
-%407 = OpFunctionParameter %_struct_80
-%408 = OpFunctionParameter %_struct_111
-%409 = OpFunctionParameter %uint
-%410 = OpFunctionParameter %_struct_150
-%411 = OpFunctionParameter %_struct_188
-%412 = OpFunctionParameter %double
-%413 = OpFunctionParameter %_struct_228
-%414 = OpFunctionParameter %_struct_281
-%415 = OpFunctionParameter %_struct_45
-%416 = OpFunctionParameter %_struct_150
-%417 = OpFunctionParameter %_struct_228
-%418 = OpFunctionParameter %float
-%419 = OpFunctionParameter %ulong
-%420 = OpLabel
-%445 = OpVariable %_ptr_Function__struct_45 Function
-%446 = OpVariable %_ptr_Function__struct_80 Function
-%447 = OpVariable %_ptr_Function__struct_111 Function
-%448 = OpVariable %_ptr_Function__struct_150 Function
-%449 = OpVariable %_ptr_Function__struct_188 Function
-%450 = OpVariable %_ptr_Function__struct_228 Function
-%451 = OpVariable %_ptr_Function__struct_281 Function
-%452 = OpVariable %_ptr_Function__struct_45 Function
-%453 = OpVariable %_ptr_Function__struct_150 Function
-%454 = OpVariable %_ptr_Function__struct_228 Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_uint Function
-%457 = OpVariable %_ptr_Function_double Function
-%459 = OpVariable %_ptr_Function_float Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_ulong Function
-%470 = OpVariable %_ptr_Function_ulong Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_ulong Function
-%473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_ulong Function
-%476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_ulong Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_ulong Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_ulong Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_ulong Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_ulong Function
-%497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_ulong Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_ulong Function
-%501 = OpVariable %_ptr_Function_ulong Function
-%502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_ulong Function
+%5 = OpFunction %ulong None %494
+%495 = OpFunctionParameter %ulong
+%496 = OpFunctionParameter %_struct_493
+%497 = OpLabel
+%523 = OpVariable %_ptr_Function__struct_493 Function
 %524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_bool Function
 %526 = OpVariable %_ptr_Function_ulong Function
 %527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_double Function
-%529 = OpVariable %_ptr_Function_double Function
-%530 = OpVariable %_ptr_Function_double Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
 %531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_double Function
-%533 = OpVariable %_ptr_Function_uint Function
-%534 = OpVariable %_ptr_Function_uint Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_bool Function
 %535 = OpVariable %_ptr_Function_ulong Function
 %536 = OpVariable %_ptr_Function_ulong Function
 %537 = OpVariable %_ptr_Function_ulong Function
@@ -699,16 +822,16 @@ OpFunctionEnd
 %540 = OpVariable %_ptr_Function_ulong Function
 %541 = OpVariable %_ptr_Function_ulong Function
 %542 = OpVariable %_ptr_Function_ulong Function
-%543 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_bool Function
 %544 = OpVariable %_ptr_Function_ulong Function
 %545 = OpVariable %_ptr_Function_ulong Function
-%546 = OpVariable %_ptr_Function_double Function
-%547 = OpVariable %_ptr_Function_uint Function
-%548 = OpVariable %_ptr_Function_uint Function
-%549 = OpVariable %_ptr_Function_double Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
 %550 = OpVariable %_ptr_Function_ulong Function
 %551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_bool Function
 %553 = OpVariable %_ptr_Function_ulong Function
 %554 = OpVariable %_ptr_Function_ulong Function
 %555 = OpVariable %_ptr_Function_ulong Function
@@ -721,819 +844,725 @@ OpFunctionEnd
 %562 = OpVariable %_ptr_Function_ulong Function
 %563 = OpVariable %_ptr_Function_ulong Function
 %564 = OpVariable %_ptr_Function_ulong Function
-%565 = OpVariable %_ptr_Function_ulong Function
-%566 = OpVariable %_ptr_Function_ulong Function
-%567 = OpVariable %_ptr_Function_ulong Function
-%568 = OpVariable %_ptr_Function_ulong Function
-OpStore %455 %405
-OpStore %445 %406
-OpStore %446 %407
-OpStore %447 %408
-OpStore %456 %409
-OpStore %448 %410
-OpStore %449 %411
-OpStore %457 %412
-OpStore %450 %413
-OpStore %451 %414
-OpStore %452 %415
-OpStore %453 %416
-OpStore %454 %417
-OpStore %459 %418
-OpStore %460 %419
-%569 = OpAccessChain %_ptr_Function_ulong %445 %uint_0
+OpStore %524 %495
+OpStore %523 %496
+%565 = OpAccessChain %_ptr_Function_ulong %523 %uint_0
+%566 = OpLoad %ulong %565
+OpStore %561 %566
+%567 = OpAccessChain %_ptr_Function_ulong %523 %uint_1
+%568 = OpLoad %ulong %567
+OpStore %562 %568
+%569 = OpAccessChain %_ptr_Function_ulong %523 %uint_2
 %570 = OpLoad %ulong %569
-OpStore %525 %570
-%571 = OpAccessChain %_ptr_Function_ulong %445 %uint_1
+OpStore %563 %570
+%571 = OpAccessChain %_ptr_Function_ulong %523 %uint_3
 %572 = OpLoad %ulong %571
-OpStore %526 %572
-%573 = OpAccessChain %_ptr_Function_ulong %445 %uint_2
-%574 = OpLoad %ulong %573
-OpStore %527 %574
-%575 = OpAccessChain %_ptr_Function_double %446 %uint_0
-%576 = OpLoad %double %575
-OpStore %528 %576
-%577 = OpAccessChain %_ptr_Function_double %446 %uint_1
-%578 = OpLoad %double %577
-OpStore %529 %578
-%579 = OpAccessChain %_ptr_Function_double %446 %uint_2
-%580 = OpLoad %double %579
-OpStore %530 %580
-%581 = OpAccessChain %_ptr_Function_ulong %447 %uint_0
-%582 = OpLoad %ulong %581
-OpStore %531 %582
-%583 = OpAccessChain %_ptr_Function_double %447 %uint_1
-%584 = OpLoad %double %583
-OpStore %532 %584
-%585 = OpAccessChain %_ptr_Function_uint %447 %uint_2
-%586 = OpLoad %uint %585
-OpStore %533 %586
-%587 = OpAccessChain %_ptr_Function_uint %447 %uint_3
-%588 = OpLoad %uint %587
-OpStore %534 %588
-%589 = OpAccessChain %_ptr_Function_ulong %448 %uint_0
-%590 = OpLoad %ulong %589
-OpStore %535 %590
-%591 = OpAccessChain %_ptr_Function_ulong %448 %uint_1
-%592 = OpLoad %ulong %591
-OpStore %536 %592
-%593 = OpAccessChain %_ptr_Function_ulong %448 %uint_2
-%594 = OpLoad %ulong %593
-OpStore %537 %594
-%595 = OpAccessChain %_ptr_Function_ulong %448 %uint_3
-%596 = OpLoad %ulong %595
-OpStore %538 %596
-%597 = OpAccessChain %_ptr_Function__struct_187 %449 %uint_0
-%598 = OpAccessChain %_ptr_Function_ulong %597 %uint_0
-%599 = OpLoad %ulong %598
-OpStore %565 %599
-%600 = OpAccessChain %_ptr_Function_ulong %597 %uint_1
-%601 = OpLoad %ulong %600
-OpStore %566 %601
-%602 = OpAccessChain %_ptr_Function__struct_187 %449 %uint_1
-%603 = OpAccessChain %_ptr_Function_ulong %602 %uint_0
-%604 = OpLoad %ulong %603
-OpStore %567 %604
-%605 = OpAccessChain %_ptr_Function_ulong %602 %uint_1
-%606 = OpLoad %ulong %605
-OpStore %568 %606
-%607 = OpAccessChain %_ptr_Function_ulong %450 %uint_0
-%608 = OpLoad %ulong %607
-OpStore %539 %608
-%609 = OpAccessChain %_ptr_Function_ulong %450 %uint_1
-%610 = OpLoad %ulong %609
-OpStore %540 %610
-%611 = OpAccessChain %_ptr_Function_ulong %450 %uint_2
-%612 = OpLoad %ulong %611
-OpStore %541 %612
-%613 = OpAccessChain %_ptr_Function_ulong %450 %uint_3
-%614 = OpLoad %ulong %613
-OpStore %542 %614
-%615 = OpAccessChain %_ptr_Function_ulong %450 %uint_4
-%616 = OpLoad %ulong %615
-OpStore %543 %616
-%617 = OpAccessChain %_ptr_Function_ulong %450 %uint_5
-%618 = OpLoad %ulong %617
-OpStore %544 %618
-%619 = OpAccessChain %_ptr_Function_ulong %451 %uint_0
-%620 = OpLoad %ulong %619
-OpStore %545 %620
-%621 = OpAccessChain %_ptr_Function_double %451 %uint_1
-%622 = OpLoad %double %621
-OpStore %546 %622
-%623 = OpAccessChain %_ptr_Function_uint %451 %uint_2
-%624 = OpLoad %uint %623
-OpStore %547 %624
-%625 = OpAccessChain %_ptr_Function_uint %451 %uint_3
-%626 = OpLoad %uint %625
-OpStore %548 %626
-%627 = OpAccessChain %_ptr_Function_double %451 %uint_4
-%628 = OpLoad %double %627
-OpStore %549 %628
-%629 = OpAccessChain %_ptr_Function_ulong %451 %uint_5
-%630 = OpLoad %ulong %629
-OpStore %550 %630
-%631 = OpAccessChain %_ptr_Function_ulong %451 %uint_6
-%632 = OpLoad %ulong %631
-OpStore %551 %632
-%633 = OpAccessChain %_ptr_Function_ulong %452 %uint_0
-%634 = OpLoad %ulong %633
-OpStore %552 %634
-%635 = OpAccessChain %_ptr_Function_ulong %452 %uint_1
-%636 = OpLoad %ulong %635
-OpStore %553 %636
-%637 = OpAccessChain %_ptr_Function_ulong %452 %uint_2
-%638 = OpLoad %ulong %637
-OpStore %554 %638
-%639 = OpAccessChain %_ptr_Function_ulong %453 %uint_0
-%640 = OpLoad %ulong %639
-OpStore %555 %640
-%641 = OpAccessChain %_ptr_Function_ulong %453 %uint_1
-%642 = OpLoad %ulong %641
-OpStore %556 %642
-%643 = OpAccessChain %_ptr_Function_ulong %453 %uint_2
-%644 = OpLoad %ulong %643
-OpStore %557 %644
-%645 = OpAccessChain %_ptr_Function_ulong %453 %uint_3
-%646 = OpLoad %ulong %645
-OpStore %558 %646
-%647 = OpAccessChain %_ptr_Function_ulong %454 %uint_0
-%648 = OpLoad %ulong %647
-OpStore %559 %648
-%649 = OpAccessChain %_ptr_Function_ulong %454 %uint_1
-%650 = OpLoad %ulong %649
-OpStore %560 %650
-%651 = OpAccessChain %_ptr_Function_ulong %454 %uint_2
-%652 = OpLoad %ulong %651
-OpStore %561 %652
-%653 = OpAccessChain %_ptr_Function_ulong %454 %uint_3
-%654 = OpLoad %ulong %653
-OpStore %562 %654
-%655 = OpAccessChain %_ptr_Function_ulong %454 %uint_4
-%656 = OpLoad %ulong %655
-OpStore %563 %656
-%657 = OpAccessChain %_ptr_Function_ulong %454 %uint_5
-%658 = OpLoad %ulong %657
-OpStore %564 %658
-%659 = OpFunctionCall %ulong %19
-OpStore %461 %659
-%660 = OpLoad %ulong %461
-%661 = OpLoad %ulong %455
-%662 = OpFunctionCall %ulong %20 %660 %661
-OpStore %462 %662
-OpBranch %421
-%421 = OpLabel
-%663 = OpLoad %ulong %462
-%664 = OpLoad %ulong %525
-%665 = OpFunctionCall %ulong %20 %663 %664
-OpStore %469 %665
-%666 = OpLoad %ulong %469
-%667 = OpLoad %ulong %526
-%668 = OpFunctionCall %ulong %20 %666 %667
-OpStore %470 %668
-%669 = OpLoad %ulong %470
-%670 = OpLoad %ulong %527
-%671 = OpFunctionCall %ulong %20 %669 %670
-OpStore %471 %671
-OpBranch %422
-%422 = OpLabel
-OpBranch %423
-%423 = OpLabel
-%672 = OpLoad %ulong %471
-%673 = OpLoad %double %528
-%674 = OpFunctionCall %ulong %23 %672 %673
-OpStore %472 %674
-%675 = OpLoad %ulong %472
-%676 = OpLoad %double %529
-%677 = OpFunctionCall %ulong %23 %675 %676
-OpStore %473 %677
-%678 = OpLoad %ulong %473
-%679 = OpLoad %double %530
-%680 = OpFunctionCall %ulong %23 %678 %679
-OpStore %474 %680
-OpBranch %424
-%424 = OpLabel
-OpBranch %425
-%425 = OpLabel
-%681 = OpLoad %ulong %474
-%682 = OpLoad %ulong %531
-%683 = OpFunctionCall %ulong %20 %681 %682
-OpStore %475 %683
-%684 = OpLoad %ulong %475
-%685 = OpLoad %double %532
-%686 = OpFunctionCall %ulong %23 %684 %685
-OpStore %476 %686
-%687 = OpLoad %ulong %476
-%688 = OpLoad %uint %533
-%689 = OpFunctionCall %ulong %21 %687 %688
-OpStore %477 %689
-%690 = OpLoad %ulong %477
-%691 = OpLoad %uint %534
-%692 = OpFunctionCall %ulong %21 %690 %691
-OpStore %478 %692
-OpBranch %426
-%426 = OpLabel
-%693 = OpLoad %ulong %478
-%694 = OpLoad %uint %456
-%695 = OpFunctionCall %ulong %21 %693 %694
-OpStore %463 %695
-OpBranch %427
-%427 = OpLabel
-%696 = OpLoad %ulong %463
-%697 = OpLoad %ulong %535
-%698 = OpFunctionCall %ulong %20 %696 %697
-OpStore %479 %698
-%699 = OpLoad %ulong %479
-%700 = OpLoad %ulong %536
-%701 = OpFunctionCall %ulong %20 %699 %700
-OpStore %480 %701
-%702 = OpLoad %ulong %480
-%703 = OpLoad %ulong %537
-%704 = OpFunctionCall %ulong %20 %702 %703
-OpStore %481 %704
-%705 = OpLoad %ulong %481
-%706 = OpLoad %ulong %538
-%707 = OpFunctionCall %ulong %20 %705 %706
-OpStore %482 %707
-OpBranch %428
-%428 = OpLabel
-OpBranch %429
-%429 = OpLabel
-%708 = OpLoad %ulong %482
-%709 = OpLoad %ulong %565
-%710 = OpFunctionCall %ulong %20 %708 %709
-OpStore %483 %710
-%711 = OpLoad %ulong %483
-%712 = OpLoad %ulong %566
-%713 = OpFunctionCall %ulong %20 %711 %712
-OpStore %484 %713
-%714 = OpLoad %ulong %484
-%715 = OpLoad %ulong %567
-%716 = OpFunctionCall %ulong %20 %714 %715
-OpStore %485 %716
-%717 = OpLoad %ulong %485
-%718 = OpLoad %ulong %568
-%719 = OpFunctionCall %ulong %20 %717 %718
-OpStore %486 %719
-OpBranch %430
-%430 = OpLabel
-%720 = OpLoad %ulong %486
-%721 = OpLoad %double %457
-%722 = OpFunctionCall %ulong %23 %720 %721
-OpStore %464 %722
-OpBranch %431
-%431 = OpLabel
-%723 = OpLoad %ulong %464
-%724 = OpLoad %ulong %539
-%725 = OpFunctionCall %ulong %20 %723 %724
-OpStore %487 %725
-%726 = OpLoad %ulong %487
-%727 = OpLoad %ulong %540
-%728 = OpFunctionCall %ulong %20 %726 %727
-OpStore %488 %728
-%729 = OpLoad %ulong %488
-%730 = OpLoad %ulong %541
-%731 = OpFunctionCall %ulong %20 %729 %730
-OpStore %489 %731
-%732 = OpLoad %ulong %489
-%733 = OpLoad %ulong %542
-%734 = OpFunctionCall %ulong %20 %732 %733
-OpStore %490 %734
-%735 = OpLoad %ulong %490
-%736 = OpLoad %ulong %543
-%737 = OpFunctionCall %ulong %20 %735 %736
-OpStore %491 %737
-%738 = OpLoad %ulong %491
-%739 = OpLoad %ulong %544
-%740 = OpFunctionCall %ulong %20 %738 %739
-OpStore %492 %740
-OpBranch %432
-%432 = OpLabel
-OpBranch %433
-%433 = OpLabel
-%741 = OpLoad %ulong %492
-%742 = OpLoad %ulong %545
-%743 = OpFunctionCall %ulong %20 %741 %742
-OpStore %493 %743
-%744 = OpLoad %ulong %493
-%745 = OpLoad %double %546
-%746 = OpFunctionCall %ulong %23 %744 %745
-OpStore %494 %746
-%747 = OpLoad %ulong %494
-%748 = OpLoad %uint %547
-%749 = OpFunctionCall %ulong %21 %747 %748
-OpStore %495 %749
-%750 = OpLoad %ulong %495
-%751 = OpLoad %uint %548
-%752 = OpFunctionCall %ulong %21 %750 %751
-OpStore %496 %752
-%753 = OpLoad %ulong %496
-%754 = OpLoad %double %549
-%755 = OpFunctionCall %ulong %23 %753 %754
-OpStore %497 %755
-%756 = OpLoad %ulong %497
-%757 = OpLoad %ulong %550
-%758 = OpFunctionCall %ulong %20 %756 %757
-OpStore %498 %758
-%759 = OpLoad %ulong %498
-%760 = OpLoad %ulong %551
-%761 = OpFunctionCall %ulong %20 %759 %760
-OpStore %499 %761
-OpBranch %434
-%434 = OpLabel
-OpBranch %435
-%435 = OpLabel
-%762 = OpLoad %ulong %499
-%763 = OpLoad %ulong %552
-%764 = OpFunctionCall %ulong %20 %762 %763
-OpStore %500 %764
-%765 = OpLoad %ulong %500
-%766 = OpLoad %ulong %553
-%767 = OpFunctionCall %ulong %20 %765 %766
-OpStore %501 %767
-%768 = OpLoad %ulong %501
-%769 = OpLoad %ulong %554
-%770 = OpFunctionCall %ulong %20 %768 %769
-OpStore %502 %770
-OpBranch %436
-%436 = OpLabel
-OpBranch %437
-%437 = OpLabel
-%771 = OpLoad %ulong %502
-%772 = OpLoad %ulong %555
-%773 = OpFunctionCall %ulong %20 %771 %772
-OpStore %503 %773
-%774 = OpLoad %ulong %503
-%775 = OpLoad %ulong %556
-%776 = OpFunctionCall %ulong %20 %774 %775
-OpStore %504 %776
-%777 = OpLoad %ulong %504
-%778 = OpLoad %ulong %557
-%779 = OpFunctionCall %ulong %20 %777 %778
-OpStore %505 %779
-%780 = OpLoad %ulong %505
-%781 = OpLoad %ulong %558
-%782 = OpFunctionCall %ulong %20 %780 %781
-OpStore %506 %782
-OpBranch %438
-%438 = OpLabel
-OpBranch %439
-%439 = OpLabel
-%783 = OpLoad %ulong %506
-%784 = OpLoad %ulong %559
-%785 = OpFunctionCall %ulong %20 %783 %784
-OpStore %507 %785
-%786 = OpLoad %ulong %507
-%787 = OpLoad %ulong %560
-%788 = OpFunctionCall %ulong %20 %786 %787
-OpStore %508 %788
-%789 = OpLoad %ulong %508
-%790 = OpLoad %ulong %561
-%791 = OpFunctionCall %ulong %20 %789 %790
-OpStore %509 %791
-%792 = OpLoad %ulong %509
-%793 = OpLoad %ulong %562
-%794 = OpFunctionCall %ulong %20 %792 %793
-OpStore %510 %794
-%795 = OpLoad %ulong %510
-%796 = OpLoad %ulong %563
-%797 = OpFunctionCall %ulong %20 %795 %796
-OpStore %511 %797
-%798 = OpLoad %ulong %511
-%799 = OpLoad %ulong %564
-%800 = OpFunctionCall %ulong %20 %798 %799
-OpStore %512 %800
-OpBranch %440
-%440 = OpLabel
-%801 = OpLoad %ulong %512
-%802 = OpLoad %float %459
-%803 = OpFunctionCall %ulong %22 %801 %802
-OpStore %465 %803
-%804 = OpLoad %ulong %465
-%805 = OpLoad %ulong %460
-%806 = OpFunctionCall %ulong %20 %804 %805
-OpStore %466 %806
-%807 = OpLoad %ulong %539
-%809 = OpIAdd %ulong %807 %ulong_1
-OpStore %467 %809
-%810 = OpLoad %ulong %544
-%812 = OpBitwiseXor %ulong %810 %ulong_4294967295
-OpStore %468 %812
-OpBranch %441
-%441 = OpLabel
-%813 = OpLoad %ulong %466
-%814 = OpLoad %ulong %467
-%815 = OpFunctionCall %ulong %20 %813 %814
-OpStore %513 %815
-%816 = OpLoad %ulong %513
-%817 = OpLoad %ulong %540
-%818 = OpFunctionCall %ulong %20 %816 %817
-OpStore %514 %818
-%819 = OpLoad %ulong %514
-%820 = OpLoad %ulong %541
-%821 = OpFunctionCall %ulong %20 %819 %820
-OpStore %515 %821
-%822 = OpLoad %ulong %515
-%823 = OpLoad %ulong %542
-%824 = OpFunctionCall %ulong %20 %822 %823
-OpStore %516 %824
-%825 = OpLoad %ulong %516
-%826 = OpLoad %ulong %543
-%827 = OpFunctionCall %ulong %20 %825 %826
-OpStore %517 %827
-%828 = OpLoad %ulong %517
-%829 = OpLoad %ulong %468
-%830 = OpFunctionCall %ulong %20 %828 %829
-OpStore %518 %830
-OpBranch %442
-%442 = OpLabel
-OpBranch %443
-%443 = OpLabel
-%831 = OpLoad %ulong %518
-%832 = OpLoad %ulong %539
-%833 = OpFunctionCall %ulong %20 %831 %832
-OpStore %519 %833
-%834 = OpLoad %ulong %519
-%835 = OpLoad %ulong %540
-%836 = OpFunctionCall %ulong %20 %834 %835
-OpStore %520 %836
-%837 = OpLoad %ulong %520
-%838 = OpLoad %ulong %541
-%839 = OpFunctionCall %ulong %20 %837 %838
-OpStore %521 %839
-%840 = OpLoad %ulong %521
-%841 = OpLoad %ulong %542
-%842 = OpFunctionCall %ulong %20 %840 %841
-OpStore %522 %842
-%843 = OpLoad %ulong %522
-%844 = OpLoad %ulong %543
-%845 = OpFunctionCall %ulong %20 %843 %844
-OpStore %523 %845
-%846 = OpLoad %ulong %523
-%847 = OpLoad %ulong %544
-%848 = OpFunctionCall %ulong %20 %846 %847
-OpStore %524 %848
-OpBranch %444
-%444 = OpLabel
-%849 = OpLoad %ulong %524
-OpReturnValue %849
+OpStore %564 %572
+OpBranch %498
+%498 = OpLabel
+%573 = OpLoad %ulong %524
+OpStore %532 %573
+OpStore %533 %ulong_0
+OpBranch %499
+%499 = OpLabel
+%574 = OpLoad %ulong %533
+%575 = OpULessThan %bool %574 %ulong_8
+OpStore %525 %575
+%576 = OpLoad %bool %525
+OpLoopMerge %501 %521 None
+OpBranchConditional %576 %500 %501
+%501 = OpLabel
+OpBranch %502
+%502 = OpLabel
+OpBranch %503
+%503 = OpLabel
+%577 = OpLoad %ulong %532
+OpStore %541 %577
+OpStore %542 %ulong_0
+OpBranch %504
+%504 = OpLabel
+%578 = OpLoad %ulong %542
+%579 = OpULessThan %bool %578 %ulong_8
+OpStore %534 %579
+%580 = OpLoad %bool %534
+OpLoopMerge %506 %520 None
+OpBranchConditional %580 %505 %506
+%506 = OpLabel
+OpBranch %507
+%507 = OpLabel
+OpBranch %508
+%508 = OpLabel
+%581 = OpLoad %ulong %541
+OpStore %550 %581
+OpStore %551 %ulong_0
+OpBranch %509
+%509 = OpLabel
+%582 = OpLoad %ulong %551
+%583 = OpULessThan %bool %582 %ulong_8
+OpStore %543 %583
+%584 = OpLoad %bool %543
+OpLoopMerge %511 %519 None
+OpBranchConditional %584 %510 %511
+%511 = OpLabel
+OpBranch %512
+%512 = OpLabel
+OpBranch %513
+%513 = OpLabel
+%585 = OpLoad %ulong %550
+OpStore %559 %585
+OpStore %560 %ulong_0
+OpBranch %514
+%514 = OpLabel
+%586 = OpLoad %ulong %560
+%587 = OpULessThan %bool %586 %ulong_8
+OpStore %552 %587
+%588 = OpLoad %bool %552
+OpLoopMerge %516 %518 None
+OpBranchConditional %588 %515 %516
+%516 = OpLabel
+OpBranch %517
+%517 = OpLabel
+%589 = OpLoad %ulong %559
+OpReturnValue %589
+%515 = OpLabel
+%590 = OpLoad %ulong %560
+%591 = OpIMul %ulong %590 %ulong_8
+OpStore %553 %591
+%592 = OpLoad %ulong %564
+%593 = OpLoad %ulong %553
+%594 = OpShiftRightLogical %ulong %592 %593
+OpStore %554 %594
+%595 = OpLoad %ulong %554
+%596 = OpBitwiseAnd %ulong %595 %ulong_255
+OpStore %555 %596
+%597 = OpLoad %ulong %559
+%598 = OpLoad %ulong %555
+%599 = OpBitwiseXor %ulong %597 %598
+OpStore %556 %599
+%600 = OpLoad %ulong %556
+%601 = OpIMul %ulong %600 %ulong_1099511628211
+OpStore %557 %601
+%602 = OpLoad %ulong %560
+%603 = OpIAdd %ulong %602 %ulong_1
+OpStore %558 %603
+%604 = OpLoad %ulong %557
+OpStore %559 %604
+%605 = OpLoad %ulong %558
+OpStore %560 %605
+OpBranch %518
+%510 = OpLabel
+%606 = OpLoad %ulong %551
+%607 = OpIMul %ulong %606 %ulong_8
+OpStore %544 %607
+%608 = OpLoad %ulong %563
+%609 = OpLoad %ulong %544
+%610 = OpShiftRightLogical %ulong %608 %609
+OpStore %545 %610
+%611 = OpLoad %ulong %545
+%612 = OpBitwiseAnd %ulong %611 %ulong_255
+OpStore %546 %612
+%613 = OpLoad %ulong %550
+%614 = OpLoad %ulong %546
+%615 = OpBitwiseXor %ulong %613 %614
+OpStore %547 %615
+%616 = OpLoad %ulong %547
+%617 = OpIMul %ulong %616 %ulong_1099511628211
+OpStore %548 %617
+%618 = OpLoad %ulong %551
+%619 = OpIAdd %ulong %618 %ulong_1
+OpStore %549 %619
+%620 = OpLoad %ulong %548
+OpStore %550 %620
+%621 = OpLoad %ulong %549
+OpStore %551 %621
+OpBranch %519
+%505 = OpLabel
+%622 = OpLoad %ulong %542
+%623 = OpIMul %ulong %622 %ulong_8
+OpStore %535 %623
+%624 = OpLoad %ulong %562
+%625 = OpLoad %ulong %535
+%626 = OpShiftRightLogical %ulong %624 %625
+OpStore %536 %626
+%627 = OpLoad %ulong %536
+%628 = OpBitwiseAnd %ulong %627 %ulong_255
+OpStore %537 %628
+%629 = OpLoad %ulong %541
+%630 = OpLoad %ulong %537
+%631 = OpBitwiseXor %ulong %629 %630
+OpStore %538 %631
+%632 = OpLoad %ulong %538
+%633 = OpIMul %ulong %632 %ulong_1099511628211
+OpStore %539 %633
+%634 = OpLoad %ulong %542
+%635 = OpIAdd %ulong %634 %ulong_1
+OpStore %540 %635
+%636 = OpLoad %ulong %539
+OpStore %541 %636
+%637 = OpLoad %ulong %540
+OpStore %542 %637
+OpBranch %520
+%500 = OpLabel
+%638 = OpLoad %ulong %533
+%639 = OpIMul %ulong %638 %ulong_8
+OpStore %526 %639
+%640 = OpLoad %ulong %561
+%641 = OpLoad %ulong %526
+%642 = OpShiftRightLogical %ulong %640 %641
+OpStore %527 %642
+%643 = OpLoad %ulong %527
+%644 = OpBitwiseAnd %ulong %643 %ulong_255
+OpStore %528 %644
+%645 = OpLoad %ulong %532
+%646 = OpLoad %ulong %528
+%647 = OpBitwiseXor %ulong %645 %646
+OpStore %529 %647
+%648 = OpLoad %ulong %529
+%649 = OpIMul %ulong %648 %ulong_1099511628211
+OpStore %530 %649
+%650 = OpLoad %ulong %533
+%651 = OpIAdd %ulong %650 %ulong_1
+OpStore %531 %651
+%652 = OpLoad %ulong %530
+OpStore %532 %652
+%653 = OpLoad %ulong %531
+OpStore %533 %653
+OpBranch %521
+%518 = OpLabel
+OpBranch %514
+%519 = OpLabel
+OpBranch %509
+%520 = OpLabel
+OpBranch %504
+%521 = OpLabel
+OpBranch %499
 OpFunctionEnd
-%11 = OpFunction %_struct_45 None %850
-%851 = OpFunctionParameter %ulong
-%852 = OpLabel
-%853 = OpVariable %_ptr_Function__struct_45 Function
-%854 = OpVariable %_ptr_Function_ulong Function
-%855 = OpVariable %_ptr_Function_ulong Function
-%856 = OpVariable %_ptr_Function_ulong Function
-%857 = OpVariable %_ptr_Function_ulong Function
-OpStore %854 %851
-%858 = OpAccessChain %_ptr_Function_ulong %853 %uint_0
-%859 = OpLoad %ulong %854
-OpStore %858 %859
-%860 = OpLoad %ulong %854
-%862 = OpIMul %ulong %860 %ulong_3
-OpStore %855 %862
-%863 = OpLoad %ulong %855
-%864 = OpIAdd %ulong %863 %ulong_1
-OpStore %856 %864
-%865 = OpAccessChain %_ptr_Function_ulong %853 %uint_1
-%866 = OpLoad %ulong %856
-OpStore %865 %866
-%867 = OpLoad %ulong %854
-%869 = OpBitwiseXor %ulong %867 %ulong_305419896
-OpStore %857 %869
-%870 = OpAccessChain %_ptr_Function_ulong %853 %uint_2
-%871 = OpLoad %ulong %857
-OpStore %870 %871
-%872 = OpLoad %_struct_45 %853
-OpReturnValue %872
+%6 = OpFunction %ulong None %656
+%657 = OpFunctionParameter %ulong
+%658 = OpFunctionParameter %_struct_655
+%659 = OpLabel
+%673 = OpVariable %_ptr_Function__struct_655 Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_ulong Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_bool Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_ulong Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%681 = OpVariable %_ptr_Function_ulong Function
+%682 = OpVariable %_ptr_Function_ulong Function
+%683 = OpVariable %_ptr_Function_ulong Function
+%684 = OpVariable %_ptr_Function_ulong Function
+%685 = OpVariable %_ptr_Function_ulong Function
+%686 = OpVariable %_ptr_Function_bool Function
+%687 = OpVariable %_ptr_Function_ulong Function
+%688 = OpVariable %_ptr_Function_ulong Function
+%689 = OpVariable %_ptr_Function_ulong Function
+%690 = OpVariable %_ptr_Function_ulong Function
+%691 = OpVariable %_ptr_Function_ulong Function
+%692 = OpVariable %_ptr_Function_ulong Function
+%693 = OpVariable %_ptr_Function_ulong Function
+%694 = OpVariable %_ptr_Function_ulong Function
+%695 = OpVariable %_ptr_Function_ulong Function
+%696 = OpVariable %_ptr_Function_ulong Function
+%697 = OpVariable %_ptr_Function_ulong Function
+%698 = OpVariable %_ptr_Function_ulong Function
+OpStore %674 %657
+OpStore %673 %658
+%700 = OpAccessChain %_ptr_Function__struct_654 %673 %uint_0
+%701 = OpAccessChain %_ptr_Function_ulong %700 %uint_0
+%702 = OpLoad %ulong %701
+OpStore %695 %702
+%703 = OpAccessChain %_ptr_Function_ulong %700 %uint_1
+%704 = OpLoad %ulong %703
+OpStore %696 %704
+%705 = OpAccessChain %_ptr_Function__struct_654 %673 %uint_1
+%706 = OpAccessChain %_ptr_Function_ulong %705 %uint_0
+%707 = OpLoad %ulong %706
+OpStore %697 %707
+%708 = OpAccessChain %_ptr_Function_ulong %705 %uint_1
+%709 = OpLoad %ulong %708
+OpStore %698 %709
+OpBranch %660
+%660 = OpLabel
+%710 = OpLoad %ulong %674
+OpStore %684 %710
+OpStore %685 %ulong_0
+OpBranch %661
+%661 = OpLabel
+%711 = OpLoad %ulong %685
+%712 = OpULessThan %bool %711 %ulong_8
+OpStore %677 %712
+%713 = OpLoad %bool %677
+OpLoopMerge %663 %671 None
+OpBranchConditional %713 %662 %663
+%663 = OpLabel
+OpBranch %664
+%664 = OpLabel
+OpBranch %665
+%665 = OpLabel
+%714 = OpLoad %ulong %684
+OpStore %693 %714
+OpStore %694 %ulong_0
+OpBranch %666
+%666 = OpLabel
+%715 = OpLoad %ulong %694
+%716 = OpULessThan %bool %715 %ulong_8
+OpStore %686 %716
+%717 = OpLoad %bool %686
+OpLoopMerge %668 %670 None
+OpBranchConditional %717 %667 %668
+%668 = OpLabel
+OpBranch %669
+%669 = OpLabel
+%718 = OpLoad %ulong %693
+%719 = OpLoad %ulong %697
+%720 = OpFunctionCall %ulong %19 %718 %719
+OpStore %675 %720
+%721 = OpLoad %ulong %675
+%722 = OpLoad %ulong %698
+%723 = OpFunctionCall %ulong %19 %721 %722
+OpStore %676 %723
+%724 = OpLoad %ulong %676
+OpReturnValue %724
+%667 = OpLabel
+%725 = OpLoad %ulong %694
+%726 = OpIMul %ulong %725 %ulong_8
+OpStore %687 %726
+%727 = OpLoad %ulong %696
+%728 = OpLoad %ulong %687
+%729 = OpShiftRightLogical %ulong %727 %728
+OpStore %688 %729
+%730 = OpLoad %ulong %688
+%731 = OpBitwiseAnd %ulong %730 %ulong_255
+OpStore %689 %731
+%732 = OpLoad %ulong %693
+%733 = OpLoad %ulong %689
+%734 = OpBitwiseXor %ulong %732 %733
+OpStore %690 %734
+%735 = OpLoad %ulong %690
+%736 = OpIMul %ulong %735 %ulong_1099511628211
+OpStore %691 %736
+%737 = OpLoad %ulong %694
+%738 = OpIAdd %ulong %737 %ulong_1
+OpStore %692 %738
+%739 = OpLoad %ulong %691
+OpStore %693 %739
+%740 = OpLoad %ulong %692
+OpStore %694 %740
+OpBranch %670
+%662 = OpLabel
+%741 = OpLoad %ulong %685
+%742 = OpIMul %ulong %741 %ulong_8
+OpStore %678 %742
+%743 = OpLoad %ulong %695
+%744 = OpLoad %ulong %678
+%745 = OpShiftRightLogical %ulong %743 %744
+OpStore %679 %745
+%746 = OpLoad %ulong %679
+%747 = OpBitwiseAnd %ulong %746 %ulong_255
+OpStore %680 %747
+%748 = OpLoad %ulong %684
+%749 = OpLoad %ulong %680
+%750 = OpBitwiseXor %ulong %748 %749
+OpStore %681 %750
+%751 = OpLoad %ulong %681
+%752 = OpIMul %ulong %751 %ulong_1099511628211
+OpStore %682 %752
+%753 = OpLoad %ulong %685
+%754 = OpIAdd %ulong %753 %ulong_1
+OpStore %683 %754
+%755 = OpLoad %ulong %682
+OpStore %684 %755
+%756 = OpLoad %ulong %683
+OpStore %685 %756
+OpBranch %671
+%670 = OpLabel
+OpBranch %666
+%671 = OpLabel
+OpBranch %661
 OpFunctionEnd
-%12 = OpFunction %_struct_80 None %873
-%874 = OpFunctionParameter %ulong
-%875 = OpLabel
-%876 = OpVariable %_ptr_Function__struct_80 Function
-%877 = OpVariable %_ptr_Function_ulong Function
-%878 = OpVariable %_ptr_Function_ulong Function
-%879 = OpVariable %_ptr_Function_double Function
-%880 = OpVariable %_ptr_Function_double Function
-%881 = OpVariable %_ptr_Function_ulong Function
-%882 = OpVariable %_ptr_Function_double Function
-%883 = OpVariable %_ptr_Function_double Function
-%884 = OpVariable %_ptr_Function_ulong Function
-%885 = OpVariable %_ptr_Function_double Function
-%886 = OpVariable %_ptr_Function_double Function
-OpStore %877 %874
-%887 = OpLoad %ulong %877
-%889 = OpBitwiseAnd %ulong %887 %ulong_65535
-OpStore %878 %889
-%890 = OpLoad %ulong %878
-%891 = OpConvertUToF %double %890
-OpStore %879 %891
-%892 = OpLoad %double %879
-%894 = OpFDiv %double %892 %double_8
-OpStore %880 %894
-%895 = OpAccessChain %_ptr_Function_double %876 %uint_0
-%896 = OpLoad %double %880
-OpStore %895 %896
-%897 = OpLoad %ulong %877
-%899 = OpBitwiseAnd %ulong %897 %ulong_4095
-OpStore %881 %899
-%900 = OpLoad %ulong %881
-%901 = OpConvertUToF %double %900
-OpStore %882 %901
-%902 = OpLoad %double %882
-%904 = OpFSub %double %902 %double_2048
-OpStore %883 %904
-%905 = OpAccessChain %_ptr_Function_double %876 %uint_1
-%906 = OpLoad %double %883
-OpStore %905 %906
-%907 = OpLoad %ulong %877
-%909 = OpBitwiseAnd %ulong %907 %ulong_262143
-OpStore %884 %909
-%910 = OpLoad %ulong %884
-%911 = OpConvertUToF %double %910
-OpStore %885 %911
-%912 = OpLoad %double %885
-%914 = OpFDiv %double %912 %double_64
-OpStore %886 %914
-%915 = OpAccessChain %_ptr_Function_double %876 %uint_2
-%916 = OpLoad %double %886
-OpStore %915 %916
-%917 = OpLoad %_struct_80 %876
-OpReturnValue %917
+%7 = OpFunction %ulong None %758
+%759 = OpFunctionParameter %ulong
+%760 = OpFunctionParameter %_struct_757
+%761 = OpLabel
+%763 = OpVariable %_ptr_Function__struct_757 Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_ulong Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+OpStore %764 %759
+OpStore %763 %760
+%777 = OpAccessChain %_ptr_Function_ulong %763 %uint_0
+%778 = OpLoad %ulong %777
+OpStore %771 %778
+%779 = OpAccessChain %_ptr_Function_ulong %763 %uint_1
+%780 = OpLoad %ulong %779
+OpStore %772 %780
+%781 = OpAccessChain %_ptr_Function_ulong %763 %uint_2
+%782 = OpLoad %ulong %781
+OpStore %773 %782
+%783 = OpAccessChain %_ptr_Function_ulong %763 %uint_3
+%784 = OpLoad %ulong %783
+OpStore %774 %784
+%786 = OpAccessChain %_ptr_Function_ulong %763 %uint_4
+%787 = OpLoad %ulong %786
+OpStore %775 %787
+%789 = OpAccessChain %_ptr_Function_ulong %763 %uint_5
+%790 = OpLoad %ulong %789
+OpStore %776 %790
+%791 = OpLoad %ulong %764
+%792 = OpLoad %ulong %771
+%793 = OpFunctionCall %ulong %19 %791 %792
+OpStore %765 %793
+%794 = OpLoad %ulong %765
+%795 = OpLoad %ulong %772
+%796 = OpFunctionCall %ulong %19 %794 %795
+OpStore %766 %796
+%797 = OpLoad %ulong %766
+%798 = OpLoad %ulong %773
+%799 = OpFunctionCall %ulong %19 %797 %798
+OpStore %767 %799
+%800 = OpLoad %ulong %767
+%801 = OpLoad %ulong %774
+%802 = OpFunctionCall %ulong %19 %800 %801
+OpStore %768 %802
+%803 = OpLoad %ulong %768
+%804 = OpLoad %ulong %775
+%805 = OpFunctionCall %ulong %19 %803 %804
+OpStore %769 %805
+%806 = OpLoad %ulong %769
+%807 = OpLoad %ulong %776
+%808 = OpFunctionCall %ulong %19 %806 %807
+OpStore %770 %808
+%809 = OpLoad %ulong %770
+OpReturnValue %809
 OpFunctionEnd
-%13 = OpFunction %_struct_111 None %918
-%919 = OpFunctionParameter %ulong
-%920 = OpLabel
-%921 = OpVariable %_ptr_Function__struct_111 Function
-%922 = OpVariable %_ptr_Function_ulong Function
-%923 = OpVariable %_ptr_Function_ulong Function
-%924 = OpVariable %_ptr_Function_double Function
-%925 = OpVariable %_ptr_Function_double Function
-%926 = OpVariable %_ptr_Function_uint Function
-%927 = OpVariable %_ptr_Function_ulong Function
-%928 = OpVariable %_ptr_Function_uint Function
-OpStore %922 %919
-%929 = OpAccessChain %_ptr_Function_ulong %921 %uint_0
-%930 = OpLoad %ulong %922
-OpStore %929 %930
-%931 = OpLoad %ulong %922
-%933 = OpBitwiseAnd %ulong %931 %ulong_32767
-OpStore %923 %933
-%934 = OpLoad %ulong %923
-%935 = OpConvertUToF %double %934
-OpStore %924 %935
-%936 = OpLoad %double %924
-%938 = OpFDiv %double %936 %double_4
-OpStore %925 %938
-%939 = OpAccessChain %_ptr_Function_double %921 %uint_1
-%940 = OpLoad %double %925
-OpStore %939 %940
-%941 = OpLoad %ulong %922
-%942 = OpUConvert %uint %941
-OpStore %926 %942
-%943 = OpAccessChain %_ptr_Function_uint %921 %uint_2
-%944 = OpLoad %uint %926
-OpStore %943 %944
-%945 = OpLoad %ulong %922
-%946 = OpShiftRightLogical %ulong %945 %ulong_32
-OpStore %927 %946
-%947 = OpLoad %ulong %927
-%948 = OpUConvert %uint %947
-OpStore %928 %948
-%949 = OpAccessChain %_ptr_Function_uint %921 %uint_3
-%950 = OpLoad %uint %928
-OpStore %949 %950
-%951 = OpLoad %_struct_111 %921
-OpReturnValue %951
+%8 = OpFunction %ulong None %811
+%812 = OpFunctionParameter %ulong
+%813 = OpFunctionParameter %_struct_810
+%814 = OpLabel
+%824 = OpVariable %_ptr_Function__struct_810 Function
+%825 = OpVariable %_ptr_Function_ulong Function
+%826 = OpVariable %_ptr_Function_ulong Function
+%827 = OpVariable %_ptr_Function_ulong Function
+%828 = OpVariable %_ptr_Function_ulong Function
+%829 = OpVariable %_ptr_Function_ulong Function
+%830 = OpVariable %_ptr_Function_ulong Function
+%831 = OpVariable %_ptr_Function_ulong Function
+%832 = OpVariable %_ptr_Function_ulong Function
+%833 = OpVariable %_ptr_Function_ulong Function
+%834 = OpVariable %_ptr_Function_ulong Function
+%835 = OpVariable %_ptr_Function_ulong Function
+%836 = OpVariable %_ptr_Function_ulong Function
+%837 = OpVariable %_ptr_Function_ulong Function
+%838 = OpVariable %_ptr_Function_double Function
+%839 = OpVariable %_ptr_Function_uint Function
+%840 = OpVariable %_ptr_Function_uint Function
+%841 = OpVariable %_ptr_Function_double Function
+%842 = OpVariable %_ptr_Function_ulong Function
+%843 = OpVariable %_ptr_Function_ulong Function
+OpStore %825 %812
+OpStore %824 %813
+%844 = OpAccessChain %_ptr_Function_ulong %824 %uint_0
+%845 = OpLoad %ulong %844
+OpStore %837 %845
+%846 = OpAccessChain %_ptr_Function_double %824 %uint_1
+%847 = OpLoad %double %846
+OpStore %838 %847
+%848 = OpAccessChain %_ptr_Function_uint %824 %uint_2
+%849 = OpLoad %uint %848
+OpStore %839 %849
+%850 = OpAccessChain %_ptr_Function_uint %824 %uint_3
+%851 = OpLoad %uint %850
+OpStore %840 %851
+%852 = OpAccessChain %_ptr_Function_double %824 %uint_4
+%853 = OpLoad %double %852
+OpStore %841 %853
+%854 = OpAccessChain %_ptr_Function_ulong %824 %uint_5
+%855 = OpLoad %ulong %854
+OpStore %842 %855
+%857 = OpAccessChain %_ptr_Function_ulong %824 %uint_6
+%858 = OpLoad %ulong %857
+OpStore %843 %858
+%859 = OpLoad %ulong %825
+%860 = OpLoad %ulong %837
+%861 = OpFunctionCall %ulong %19 %859 %860
+OpStore %826 %861
+OpBranch %815
+%815 = OpLabel
+%862 = OpLoad %double %838
+%863 = OpBitcast %ulong %862
+OpStore %829 %863
+%864 = OpLoad %ulong %826
+%865 = OpLoad %ulong %829
+%866 = OpFunctionCall %ulong %19 %864 %865
+OpStore %830 %866
+OpBranch %816
+%816 = OpLabel
+OpBranch %817
+%817 = OpLabel
+%867 = OpLoad %uint %839
+%868 = OpUConvert %ulong %867
+OpStore %831 %868
+%869 = OpLoad %ulong %830
+%870 = OpLoad %ulong %831
+%871 = OpFunctionCall %ulong %19 %869 %870
+OpStore %832 %871
+OpBranch %818
+%818 = OpLabel
+OpBranch %819
+%819 = OpLabel
+%872 = OpLoad %uint %840
+%873 = OpUConvert %ulong %872
+OpStore %833 %873
+%874 = OpLoad %ulong %832
+%875 = OpLoad %ulong %833
+%876 = OpFunctionCall %ulong %19 %874 %875
+OpStore %834 %876
+OpBranch %820
+%820 = OpLabel
+OpBranch %821
+%821 = OpLabel
+%877 = OpLoad %double %841
+%878 = OpBitcast %ulong %877
+OpStore %835 %878
+%879 = OpLoad %ulong %834
+%880 = OpLoad %ulong %835
+%881 = OpFunctionCall %ulong %19 %879 %880
+OpStore %836 %881
+OpBranch %822
+%822 = OpLabel
+%882 = OpLoad %ulong %836
+%883 = OpLoad %ulong %842
+%884 = OpFunctionCall %ulong %19 %882 %883
+OpStore %827 %884
+%885 = OpLoad %ulong %827
+%886 = OpLoad %ulong %843
+%887 = OpFunctionCall %ulong %19 %885 %886
+OpStore %828 %887
+%888 = OpLoad %ulong %828
+OpReturnValue %888
 OpFunctionEnd
-%14 = OpFunction %_struct_150 None %952
+%9 = OpFunction %ulong None %889
+%890 = OpFunctionParameter %ulong
+%891 = OpLabel
+%892 = OpVariable %_ptr_Function_ulong Function
+%893 = OpVariable %_ptr_Function_ulong Function
+%894 = OpVariable %_ptr_Function_ulong Function
+%895 = OpVariable %_ptr_Function_ulong Function
+%896 = OpVariable %_ptr_Function_ulong Function
+%897 = OpVariable %_ptr_Function_ulong Function
+%898 = OpVariable %_ptr_Function_ulong Function
+%899 = OpVariable %_ptr_Function_ulong Function
+%900 = OpVariable %_ptr_Function_ulong Function
+%901 = OpVariable %_ptr_Function_ulong Function
+%902 = OpVariable %_ptr_Function_ulong Function
+%903 = OpVariable %_ptr_Function_ulong Function
+%904 = OpVariable %_ptr_Function_ulong Function
+%905 = OpVariable %_ptr_Function_ulong Function
+%906 = OpVariable %_ptr_Function_ulong Function
+%907 = OpVariable %_ptr_Function_ulong Function
+%908 = OpVariable %_ptr_Function_ulong Function
+%909 = OpVariable %_ptr_Function_ulong Function
+OpStore %892 %890
+%910 = OpLoad %ulong %892
+%912 = OpFunctionCall %ulong %19 %910 %ulong_24
+OpStore %893 %912
+%913 = OpLoad %ulong %893
+%914 = OpFunctionCall %ulong %19 %913 %ulong_24
+OpStore %894 %914
+%915 = OpLoad %ulong %894
+%916 = OpFunctionCall %ulong %19 %915 %ulong_24
+OpStore %895 %916
+%917 = OpLoad %ulong %895
+%919 = OpFunctionCall %ulong %19 %917 %ulong_32
+OpStore %896 %919
+%920 = OpLoad %ulong %896
+%921 = OpFunctionCall %ulong %19 %920 %ulong_32
+OpStore %897 %921
+%922 = OpLoad %ulong %897
+%924 = OpFunctionCall %ulong %19 %922 %ulong_48
+OpStore %898 %924
+%925 = OpLoad %ulong %898
+%926 = OpFunctionCall %ulong %19 %925 %ulong_48
+OpStore %899 %926
+%927 = OpLoad %ulong %899
+%928 = OpFunctionCall %ulong %19 %927 %ulong_8
+OpStore %900 %928
+%929 = OpLoad %ulong %900
+%930 = OpFunctionCall %ulong %19 %929 %ulong_8
+OpStore %901 %930
+%931 = OpLoad %ulong %901
+%932 = OpFunctionCall %ulong %19 %931 %ulong_8
+OpStore %902 %932
+%933 = OpLoad %ulong %902
+%935 = OpFunctionCall %ulong %19 %933 %ulong_16
+OpStore %903 %935
+%936 = OpLoad %ulong %903
+%937 = OpFunctionCall %ulong %19 %936 %ulong_16
+OpStore %904 %937
+%938 = OpLoad %ulong %904
+%940 = OpFunctionCall %ulong %19 %938 %ulong_20
+OpStore %905 %940
+%941 = OpLoad %ulong %905
+%942 = OpFunctionCall %ulong %19 %941 %ulong_16
+OpStore %906 %942
+%943 = OpLoad %ulong %906
+%945 = OpFunctionCall %ulong %19 %943 %ulong_40
+OpStore %907 %945
+%946 = OpLoad %ulong %907
+%947 = OpFunctionCall %ulong %19 %946 %ulong_24
+OpStore %908 %947
+%948 = OpLoad %ulong %908
+%949 = OpFunctionCall %ulong %19 %948 %ulong_40
+OpStore %909 %949
+%950 = OpLoad %ulong %909
+OpReturnValue %950
+OpFunctionEnd
+%10 = OpFunction %ulong None %952
 %953 = OpFunctionParameter %ulong
-%954 = OpLabel
-%955 = OpVariable %_ptr_Function__struct_150 Function
-%956 = OpVariable %_ptr_Function_ulong Function
-%957 = OpVariable %_ptr_Function_ulong Function
-%958 = OpVariable %_ptr_Function_ulong Function
-%959 = OpVariable %_ptr_Function_ulong Function
-OpStore %956 %953
-%960 = OpAccessChain %_ptr_Function_ulong %955 %uint_0
-%961 = OpLoad %ulong %956
-OpStore %960 %961
-%962 = OpLoad %ulong %956
-%963 = OpNot %ulong %962
-OpStore %957 %963
-%964 = OpAccessChain %_ptr_Function_ulong %955 %uint_1
-%965 = OpLoad %ulong %957
-OpStore %964 %965
-%966 = OpLoad %ulong %956
-%968 = OpIMul %ulong %966 %ulong_5
-OpStore %958 %968
-%969 = OpAccessChain %_ptr_Function_ulong %955 %uint_2
-%970 = OpLoad %ulong %958
-OpStore %969 %970
-%971 = OpLoad %ulong %956
-%972 = OpShiftRightLogical %ulong %971 %ulong_3
-OpStore %959 %972
-%973 = OpAccessChain %_ptr_Function_ulong %955 %uint_3
-%974 = OpLoad %ulong %959
-OpStore %973 %974
-%975 = OpLoad %_struct_150 %955
-OpReturnValue %975
-OpFunctionEnd
-%15 = OpFunction %_struct_188 None %976
-%977 = OpFunctionParameter %ulong
-%978 = OpLabel
-%979 = OpVariable %_ptr_Function__struct_188 Function
-%980 = OpVariable %_ptr_Function__struct_187 Function
-%981 = OpVariable %_ptr_Function__struct_187 Function
-%982 = OpVariable %_ptr_Function_ulong Function
-%983 = OpVariable %_ptr_Function_ulong Function
-%984 = OpVariable %_ptr_Function_ulong Function
-%985 = OpVariable %_ptr_Function_ulong Function
-OpStore %982 %977
-%986 = OpAccessChain %_ptr_Function_ulong %980 %uint_0
-%987 = OpLoad %ulong %982
-OpStore %986 %987
-%988 = OpLoad %ulong %982
-%990 = OpIAdd %ulong %988 %ulong_11
-OpStore %983 %990
-%991 = OpAccessChain %_ptr_Function_ulong %980 %uint_1
-%992 = OpLoad %ulong %983
-OpStore %991 %992
-%993 = OpAccessChain %_ptr_Function__struct_187 %979 %uint_0
-%994 = OpLoad %_struct_187 %980
-OpStore %993 %994
-%995 = OpLoad %ulong %982
-%997 = OpIMul %ulong %995 %ulong_7
-OpStore %984 %997
-%998 = OpAccessChain %_ptr_Function_ulong %981 %uint_0
-%999 = OpLoad %ulong %984
-OpStore %998 %999
-%1000 = OpLoad %ulong %982
-%1001 = OpNot %ulong %1000
-OpStore %985 %1001
-%1002 = OpAccessChain %_ptr_Function_ulong %981 %uint_1
-%1003 = OpLoad %ulong %985
-OpStore %1002 %1003
-%1004 = OpAccessChain %_ptr_Function__struct_187 %979 %uint_1
-%1005 = OpLoad %_struct_187 %981
-OpStore %1004 %1005
-%1006 = OpLoad %_struct_188 %979
-OpReturnValue %1006
-OpFunctionEnd
-%16 = OpFunction %_struct_228 None %1007
-%1008 = OpFunctionParameter %ulong
-%1009 = OpLabel
-%1010 = OpVariable %_ptr_Function__struct_228 Function
-%1011 = OpVariable %_ptr_Function_ulong Function
-%1012 = OpVariable %_ptr_Function_ulong Function
-%1013 = OpVariable %_ptr_Function_ulong Function
-%1014 = OpVariable %_ptr_Function_ulong Function
-%1015 = OpVariable %_ptr_Function_ulong Function
-%1016 = OpVariable %_ptr_Function_ulong Function
-OpStore %1011 %1008
-%1017 = OpAccessChain %_ptr_Function_ulong %1010 %uint_0
-%1018 = OpLoad %ulong %1011
-OpStore %1017 %1018
-%1019 = OpLoad %ulong %1011
-%1020 = OpIAdd %ulong %1019 %ulong_1
-OpStore %1012 %1020
-%1021 = OpAccessChain %_ptr_Function_ulong %1010 %uint_1
-%1022 = OpLoad %ulong %1012
-OpStore %1021 %1022
-%1023 = OpLoad %ulong %1011
-%1025 = OpIAdd %ulong %1023 %ulong_2
-OpStore %1013 %1025
-%1026 = OpAccessChain %_ptr_Function_ulong %1010 %uint_2
-%1027 = OpLoad %ulong %1013
-OpStore %1026 %1027
-%1028 = OpLoad %ulong %1011
-%1030 = OpIMul %ulong %1028 %ulong_9
-OpStore %1014 %1030
-%1031 = OpAccessChain %_ptr_Function_ulong %1010 %uint_3
-%1032 = OpLoad %ulong %1014
-OpStore %1031 %1032
-%1033 = OpLoad %ulong %1011
-%1034 = OpNot %ulong %1033
-OpStore %1015 %1034
-%1035 = OpAccessChain %_ptr_Function_ulong %1010 %uint_4
-%1036 = OpLoad %ulong %1015
-OpStore %1035 %1036
-%1037 = OpLoad %ulong %1011
-%1039 = OpBitwiseXor %ulong %1037 %ulong_2863311530
-OpStore %1016 %1039
-%1040 = OpAccessChain %_ptr_Function_ulong %1010 %uint_5
-%1041 = OpLoad %ulong %1016
-OpStore %1040 %1041
-%1042 = OpLoad %_struct_228 %1010
-OpReturnValue %1042
-OpFunctionEnd
-%17 = OpFunction %_struct_281 None %1043
-%1044 = OpFunctionParameter %ulong
-%1045 = OpLabel
-%1046 = OpVariable %_ptr_Function__struct_281 Function
-%1047 = OpVariable %_ptr_Function_ulong Function
-%1048 = OpVariable %_ptr_Function_ulong Function
-%1049 = OpVariable %_ptr_Function_double Function
-%1050 = OpVariable %_ptr_Function_double Function
-%1051 = OpVariable %_ptr_Function_uint Function
-%1052 = OpVariable %_ptr_Function_ulong Function
-%1053 = OpVariable %_ptr_Function_uint Function
-%1054 = OpVariable %_ptr_Function_ulong Function
-%1055 = OpVariable %_ptr_Function_double Function
-%1056 = OpVariable %_ptr_Function_double Function
-%1057 = OpVariable %_ptr_Function_ulong Function
-%1058 = OpVariable %_ptr_Function_ulong Function
-OpStore %1047 %1044
-%1059 = OpAccessChain %_ptr_Function_ulong %1046 %uint_0
-%1060 = OpLoad %ulong %1047
-OpStore %1059 %1060
-%1061 = OpLoad %ulong %1047
-%1063 = OpBitwiseAnd %ulong %1061 %ulong_8191
-OpStore %1048 %1063
-%1064 = OpLoad %ulong %1048
-%1065 = OpConvertUToF %double %1064
-OpStore %1049 %1065
-%1066 = OpLoad %double %1049
-%1068 = OpFDiv %double %1066 %double_2
-OpStore %1050 %1068
-%1069 = OpAccessChain %_ptr_Function_double %1046 %uint_1
-%1070 = OpLoad %double %1050
-OpStore %1069 %1070
-%1071 = OpLoad %ulong %1047
-%1072 = OpUConvert %uint %1071
-OpStore %1051 %1072
-%1073 = OpAccessChain %_ptr_Function_uint %1046 %uint_2
-%1074 = OpLoad %uint %1051
-OpStore %1073 %1074
-%1075 = OpLoad %ulong %1047
-%1076 = OpShiftRightLogical %ulong %1075 %ulong_16
-OpStore %1052 %1076
-%1077 = OpLoad %ulong %1052
-%1078 = OpUConvert %uint %1077
-OpStore %1053 %1078
-%1079 = OpAccessChain %_ptr_Function_uint %1046 %uint_3
-%1080 = OpLoad %uint %1053
-OpStore %1079 %1080
-%1081 = OpLoad %ulong %1047
-%1083 = OpBitwiseAnd %ulong %1081 %ulong_131071
-OpStore %1054 %1083
-%1084 = OpLoad %ulong %1054
-%1085 = OpConvertUToF %double %1084
-OpStore %1055 %1085
-%1086 = OpLoad %double %1055
-%1088 = OpFDiv %double %1086 %double_32
-OpStore %1056 %1088
-%1089 = OpAccessChain %_ptr_Function_double %1046 %uint_4
-%1090 = OpLoad %double %1056
-OpStore %1089 %1090
-%1091 = OpLoad %ulong %1047
-%1092 = OpIMul %ulong %1091 %ulong_3
-OpStore %1057 %1092
-%1093 = OpAccessChain %_ptr_Function_ulong %1046 %uint_5
-%1094 = OpLoad %ulong %1057
-OpStore %1093 %1094
-%1095 = OpLoad %ulong %1047
-%1096 = OpNot %ulong %1095
-OpStore %1058 %1096
-%1097 = OpAccessChain %_ptr_Function_ulong %1046 %uint_6
-%1098 = OpLoad %ulong %1058
-OpStore %1097 %1098
-%1099 = OpLoad %_struct_281 %1046
-OpReturnValue %1099
-OpFunctionEnd
-%18 = OpFunction %ulong None %340
-%1100 = OpFunctionParameter %ulong
-%1101 = OpLabel
-%1154 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
-%1155 = OpVariable %_ptr_Function__struct_45 Function
-%1156 = OpVariable %_ptr_Function__struct_45 Function
-%1157 = OpVariable %_ptr_Function__struct_80 Function
-%1158 = OpVariable %_ptr_Function__struct_80 Function
-%1159 = OpVariable %_ptr_Function__struct_111 Function
-%1160 = OpVariable %_ptr_Function__struct_111 Function
-%1161 = OpVariable %_ptr_Function__struct_150 Function
-%1162 = OpVariable %_ptr_Function__struct_150 Function
-%1163 = OpVariable %_ptr_Function__struct_188 Function
-%1164 = OpVariable %_ptr_Function__struct_187 Function
-%1165 = OpVariable %_ptr_Function__struct_187 Function
-%1166 = OpVariable %_ptr_Function__struct_188 Function
-%1167 = OpVariable %_ptr_Function__struct_187 Function
-%1168 = OpVariable %_ptr_Function__struct_187 Function
-%1169 = OpVariable %_ptr_Function__struct_228 Function
-%1170 = OpVariable %_ptr_Function__struct_281 Function
-%1171 = OpVariable %_ptr_Function__struct_228 Function
-%1172 = OpVariable %_ptr_Function__struct_281 Function
-%1173 = OpVariable %_ptr_Function__struct_45 Function
-%1174 = OpVariable %_ptr_Function__struct_45 Function
-%1175 = OpVariable %_ptr_Function__struct_150 Function
-%1176 = OpVariable %_ptr_Function__struct_150 Function
-%1177 = OpVariable %_ptr_Function__struct_228 Function
-%1178 = OpVariable %_ptr_Function__struct_228 Function
+%954 = OpFunctionParameter %_struct_41
+%955 = OpFunctionParameter %_struct_176
+%956 = OpFunctionParameter %_struct_315
+%957 = OpFunctionParameter %uint
+%958 = OpFunctionParameter %_struct_493
+%959 = OpFunctionParameter %_struct_655
+%960 = OpFunctionParameter %double
+%961 = OpFunctionParameter %_struct_757
+%962 = OpFunctionParameter %_struct_810
+%963 = OpFunctionParameter %_struct_41
+%964 = OpFunctionParameter %_struct_493
+%965 = OpFunctionParameter %_struct_757
+%966 = OpFunctionParameter %float
+%967 = OpFunctionParameter %ulong
+%968 = OpLabel
+%1067 = OpVariable %_ptr_Function__struct_41 Function
+%1068 = OpVariable %_ptr_Function__struct_176 Function
+%1069 = OpVariable %_ptr_Function__struct_315 Function
+%1070 = OpVariable %_ptr_Function__struct_493 Function
+%1071 = OpVariable %_ptr_Function__struct_655 Function
+%1072 = OpVariable %_ptr_Function__struct_757 Function
+%1073 = OpVariable %_ptr_Function__struct_810 Function
+%1074 = OpVariable %_ptr_Function__struct_41 Function
+%1075 = OpVariable %_ptr_Function__struct_493 Function
+%1076 = OpVariable %_ptr_Function__struct_757 Function
+%1077 = OpVariable %_ptr_Function__struct_41 Function
+%1078 = OpVariable %_ptr_Function__struct_493 Function
+%1079 = OpVariable %_ptr_Function__struct_41 Function
+%1080 = OpVariable %_ptr_Function__struct_493 Function
+%1081 = OpVariable %_ptr_Function__struct_41 Function
+%1082 = OpVariable %_ptr_Function__struct_493 Function
+%1083 = OpVariable %_ptr_Function__struct_41 Function
+%1084 = OpVariable %_ptr_Function__struct_493 Function
+%1085 = OpVariable %_ptr_Function_ulong Function
+%1086 = OpVariable %_ptr_Function_uint Function
+%1087 = OpVariable %_ptr_Function_double Function
+%1089 = OpVariable %_ptr_Function_float Function
+%1090 = OpVariable %_ptr_Function_ulong Function
+%1091 = OpVariable %_ptr_Function_ulong Function
+%1092 = OpVariable %_ptr_Function_ulong Function
+%1093 = OpVariable %_ptr_Function_ulong Function
+%1094 = OpVariable %_ptr_Function_ulong Function
+%1095 = OpVariable %_ptr_Function_ulong Function
+%1096 = OpVariable %_ptr_Function_ulong Function
+%1097 = OpVariable %_ptr_Function_ulong Function
+%1098 = OpVariable %_ptr_Function_ulong Function
+%1099 = OpVariable %_ptr_Function_ulong Function
+%1100 = OpVariable %_ptr_Function_bool Function
+%1101 = OpVariable %_ptr_Function_ulong Function
+%1102 = OpVariable %_ptr_Function_ulong Function
+%1103 = OpVariable %_ptr_Function_ulong Function
+%1104 = OpVariable %_ptr_Function_ulong Function
+%1105 = OpVariable %_ptr_Function_ulong Function
+%1106 = OpVariable %_ptr_Function_ulong Function
+%1107 = OpVariable %_ptr_Function_ulong Function
+%1108 = OpVariable %_ptr_Function_ulong Function
+%1109 = OpVariable %_ptr_Function_ulong Function
+%1110 = OpVariable %_ptr_Function_bool Function
+%1111 = OpVariable %_ptr_Function_ulong Function
+%1112 = OpVariable %_ptr_Function_ulong Function
+%1113 = OpVariable %_ptr_Function_ulong Function
+%1114 = OpVariable %_ptr_Function_ulong Function
+%1115 = OpVariable %_ptr_Function_ulong Function
+%1116 = OpVariable %_ptr_Function_ulong Function
+%1117 = OpVariable %_ptr_Function_ulong Function
+%1118 = OpVariable %_ptr_Function_ulong Function
+%1119 = OpVariable %_ptr_Function_ulong Function
+%1120 = OpVariable %_ptr_Function_bool Function
+%1121 = OpVariable %_ptr_Function_ulong Function
+%1122 = OpVariable %_ptr_Function_ulong Function
+%1123 = OpVariable %_ptr_Function_ulong Function
+%1124 = OpVariable %_ptr_Function_ulong Function
+%1125 = OpVariable %_ptr_Function_ulong Function
+%1126 = OpVariable %_ptr_Function_ulong Function
+%1127 = OpVariable %_ptr_Function_ulong Function
+%1128 = OpVariable %_ptr_Function_ulong Function
+%1129 = OpVariable %_ptr_Function_bool Function
+%1130 = OpVariable %_ptr_Function_ulong Function
+%1131 = OpVariable %_ptr_Function_ulong Function
+%1132 = OpVariable %_ptr_Function_ulong Function
+%1133 = OpVariable %_ptr_Function_ulong Function
+%1134 = OpVariable %_ptr_Function_ulong Function
+%1135 = OpVariable %_ptr_Function_ulong Function
+%1136 = OpVariable %_ptr_Function_ulong Function
+%1137 = OpVariable %_ptr_Function_ulong Function
+%1138 = OpVariable %_ptr_Function_ulong Function
+%1139 = OpVariable %_ptr_Function_bool Function
+%1140 = OpVariable %_ptr_Function_ulong Function
+%1141 = OpVariable %_ptr_Function_ulong Function
+%1142 = OpVariable %_ptr_Function_ulong Function
+%1143 = OpVariable %_ptr_Function_ulong Function
+%1144 = OpVariable %_ptr_Function_ulong Function
+%1145 = OpVariable %_ptr_Function_ulong Function
+%1146 = OpVariable %_ptr_Function_ulong Function
+%1147 = OpVariable %_ptr_Function_ulong Function
+%1148 = OpVariable %_ptr_Function_ulong Function
+%1149 = OpVariable %_ptr_Function_bool Function
+%1150 = OpVariable %_ptr_Function_ulong Function
+%1151 = OpVariable %_ptr_Function_ulong Function
+%1152 = OpVariable %_ptr_Function_ulong Function
+%1153 = OpVariable %_ptr_Function_ulong Function
+%1154 = OpVariable %_ptr_Function_ulong Function
+%1155 = OpVariable %_ptr_Function_ulong Function
+%1156 = OpVariable %_ptr_Function_ulong Function
+%1157 = OpVariable %_ptr_Function_ulong Function
+%1158 = OpVariable %_ptr_Function_ulong Function
+%1159 = OpVariable %_ptr_Function_bool Function
+%1160 = OpVariable %_ptr_Function_ulong Function
+%1161 = OpVariable %_ptr_Function_ulong Function
+%1162 = OpVariable %_ptr_Function_ulong Function
+%1163 = OpVariable %_ptr_Function_ulong Function
+%1164 = OpVariable %_ptr_Function_ulong Function
+%1165 = OpVariable %_ptr_Function_ulong Function
+%1166 = OpVariable %_ptr_Function_ulong Function
+%1167 = OpVariable %_ptr_Function_ulong Function
+%1168 = OpVariable %_ptr_Function_ulong Function
+%1169 = OpVariable %_ptr_Function_ulong Function
+%1170 = OpVariable %_ptr_Function_ulong Function
+%1171 = OpVariable %_ptr_Function_ulong Function
+%1172 = OpVariable %_ptr_Function_bool Function
+%1173 = OpVariable %_ptr_Function_ulong Function
+%1174 = OpVariable %_ptr_Function_ulong Function
+%1175 = OpVariable %_ptr_Function_ulong Function
+%1176 = OpVariable %_ptr_Function_ulong Function
+%1177 = OpVariable %_ptr_Function_ulong Function
+%1178 = OpVariable %_ptr_Function_ulong Function
 %1179 = OpVariable %_ptr_Function_ulong Function
 %1180 = OpVariable %_ptr_Function_ulong Function
-%1182 = OpVariable %_ptr_Function_bool Function
+%1181 = OpVariable %_ptr_Function_bool Function
+%1182 = OpVariable %_ptr_Function_ulong Function
 %1183 = OpVariable %_ptr_Function_ulong Function
-%1184 = OpVariable %_ptr_Function_bool Function
+%1184 = OpVariable %_ptr_Function_ulong Function
 %1185 = OpVariable %_ptr_Function_ulong Function
 %1186 = OpVariable %_ptr_Function_ulong Function
 %1187 = OpVariable %_ptr_Function_ulong Function
@@ -1542,13 +1571,13 @@ OpFunctionEnd
 %1190 = OpVariable %_ptr_Function_ulong Function
 %1191 = OpVariable %_ptr_Function_ulong Function
 %1192 = OpVariable %_ptr_Function_ulong Function
-%1193 = OpVariable %_ptr_Function_uint Function
+%1193 = OpVariable %_ptr_Function_ulong Function
 %1194 = OpVariable %_ptr_Function_ulong Function
 %1195 = OpVariable %_ptr_Function_ulong Function
 %1196 = OpVariable %_ptr_Function_ulong Function
 %1197 = OpVariable %_ptr_Function_ulong Function
 %1198 = OpVariable %_ptr_Function_ulong Function
-%1199 = OpVariable %_ptr_Function_double Function
+%1199 = OpVariable %_ptr_Function_ulong Function
 %1200 = OpVariable %_ptr_Function_ulong Function
 %1201 = OpVariable %_ptr_Function_ulong Function
 %1202 = OpVariable %_ptr_Function_ulong Function
@@ -1556,20 +1585,20 @@ OpFunctionEnd
 %1204 = OpVariable %_ptr_Function_ulong Function
 %1205 = OpVariable %_ptr_Function_ulong Function
 %1206 = OpVariable %_ptr_Function_ulong Function
-%1207 = OpVariable %_ptr_Function_float Function
+%1207 = OpVariable %_ptr_Function_ulong Function
 %1208 = OpVariable %_ptr_Function_ulong Function
 %1209 = OpVariable %_ptr_Function_ulong Function
 %1210 = OpVariable %_ptr_Function_ulong Function
 %1211 = OpVariable %_ptr_Function_ulong Function
-%1212 = OpVariable %_ptr_Function_uint Function
+%1212 = OpVariable %_ptr_Function_ulong Function
 %1213 = OpVariable %_ptr_Function_ulong Function
-%1214 = OpVariable %_ptr_Function_double Function
-%1215 = OpVariable %_ptr_Function_ulong Function
+%1214 = OpVariable %_ptr_Function_ulong Function
+%1215 = OpVariable %_ptr_Function_uint Function
 %1216 = OpVariable %_ptr_Function_ulong Function
 %1217 = OpVariable %_ptr_Function_ulong Function
 %1218 = OpVariable %_ptr_Function_ulong Function
 %1219 = OpVariable %_ptr_Function_ulong Function
-%1220 = OpVariable %_ptr_Function_float Function
+%1220 = OpVariable %_ptr_Function_ulong Function
 %1221 = OpVariable %_ptr_Function_ulong Function
 %1222 = OpVariable %_ptr_Function_ulong Function
 %1223 = OpVariable %_ptr_Function_ulong Function
@@ -1579,13 +1608,13 @@ OpFunctionEnd
 %1227 = OpVariable %_ptr_Function_ulong Function
 %1228 = OpVariable %_ptr_Function_ulong Function
 %1229 = OpVariable %_ptr_Function_ulong Function
-%1230 = OpVariable %_ptr_Function_ulong Function
-%1231 = OpVariable %_ptr_Function_ulong Function
-%1232 = OpVariable %_ptr_Function_ulong Function
+%1230 = OpVariable %_ptr_Function_double Function
+%1231 = OpVariable %_ptr_Function_double Function
+%1232 = OpVariable %_ptr_Function_double Function
 %1233 = OpVariable %_ptr_Function_ulong Function
-%1234 = OpVariable %_ptr_Function_ulong Function
-%1235 = OpVariable %_ptr_Function_ulong Function
-%1236 = OpVariable %_ptr_Function_ulong Function
+%1234 = OpVariable %_ptr_Function_double Function
+%1235 = OpVariable %_ptr_Function_uint Function
+%1236 = OpVariable %_ptr_Function_uint Function
 %1237 = OpVariable %_ptr_Function_ulong Function
 %1238 = OpVariable %_ptr_Function_ulong Function
 %1239 = OpVariable %_ptr_Function_ulong Function
@@ -1593,10 +1622,10 @@ OpFunctionEnd
 %1241 = OpVariable %_ptr_Function_ulong Function
 %1242 = OpVariable %_ptr_Function_ulong Function
 %1243 = OpVariable %_ptr_Function_ulong Function
-%1244 = OpVariable %_ptr_Function_ulong Function
-%1245 = OpVariable %_ptr_Function_ulong Function
-%1246 = OpVariable %_ptr_Function_ulong Function
-%1247 = OpVariable %_ptr_Function_ulong Function
+%1244 = OpVariable %_ptr_Function_double Function
+%1245 = OpVariable %_ptr_Function_uint Function
+%1246 = OpVariable %_ptr_Function_uint Function
+%1247 = OpVariable %_ptr_Function_double Function
 %1248 = OpVariable %_ptr_Function_ulong Function
 %1249 = OpVariable %_ptr_Function_ulong Function
 %1250 = OpVariable %_ptr_Function_ulong Function
@@ -1604,1172 +1633,2217 @@ OpFunctionEnd
 %1252 = OpVariable %_ptr_Function_ulong Function
 %1253 = OpVariable %_ptr_Function_ulong Function
 %1254 = OpVariable %_ptr_Function_ulong Function
-%1255 = OpVariable %_ptr_Function_double Function
-%1256 = OpVariable %_ptr_Function_double Function
+%1255 = OpVariable %_ptr_Function_ulong Function
+%1256 = OpVariable %_ptr_Function_ulong Function
 %1257 = OpVariable %_ptr_Function_ulong Function
-%1258 = OpVariable %_ptr_Function_double Function
-%1259 = OpVariable %_ptr_Function_double Function
-%1260 = OpVariable %_ptr_Function_ulong Function
-%1261 = OpVariable %_ptr_Function_double Function
-%1262 = OpVariable %_ptr_Function_double Function
-%1263 = OpVariable %_ptr_Function_ulong Function
-%1264 = OpVariable %_ptr_Function_double Function
-%1265 = OpVariable %_ptr_Function_double Function
-%1266 = OpVariable %_ptr_Function_ulong Function
-%1267 = OpVariable %_ptr_Function_double Function
-%1268 = OpVariable %_ptr_Function_double Function
-%1269 = OpVariable %_ptr_Function_ulong Function
-%1270 = OpVariable %_ptr_Function_double Function
-%1271 = OpVariable %_ptr_Function_double Function
-%1272 = OpVariable %_ptr_Function_ulong Function
-%1273 = OpVariable %_ptr_Function_double Function
-%1274 = OpVariable %_ptr_Function_double Function
-%1275 = OpVariable %_ptr_Function_uint Function
-%1276 = OpVariable %_ptr_Function_ulong Function
-%1277 = OpVariable %_ptr_Function_uint Function
-%1278 = OpVariable %_ptr_Function_ulong Function
-%1279 = OpVariable %_ptr_Function_double Function
-%1280 = OpVariable %_ptr_Function_double Function
-%1281 = OpVariable %_ptr_Function_uint Function
-%1282 = OpVariable %_ptr_Function_ulong Function
-%1283 = OpVariable %_ptr_Function_uint Function
-%1284 = OpVariable %_ptr_Function_ulong Function
-%1285 = OpVariable %_ptr_Function_ulong Function
-%1286 = OpVariable %_ptr_Function_ulong Function
-%1287 = OpVariable %_ptr_Function_ulong Function
-%1288 = OpVariable %_ptr_Function_ulong Function
-%1289 = OpVariable %_ptr_Function_ulong Function
-%1290 = OpVariable %_ptr_Function_ulong Function
-%1291 = OpVariable %_ptr_Function_ulong Function
-%1292 = OpVariable %_ptr_Function_ulong Function
-%1293 = OpVariable %_ptr_Function_ulong Function
-%1294 = OpVariable %_ptr_Function_ulong Function
-%1295 = OpVariable %_ptr_Function_ulong Function
-%1296 = OpVariable %_ptr_Function_ulong Function
-%1297 = OpVariable %_ptr_Function_ulong Function
-%1298 = OpVariable %_ptr_Function_ulong Function
-%1299 = OpVariable %_ptr_Function_ulong Function
-%1300 = OpVariable %_ptr_Function_ulong Function
-%1301 = OpVariable %_ptr_Function_ulong Function
-%1302 = OpVariable %_ptr_Function_ulong Function
-%1303 = OpVariable %_ptr_Function_ulong Function
-%1304 = OpVariable %_ptr_Function_ulong Function
-%1305 = OpVariable %_ptr_Function_ulong Function
-%1306 = OpVariable %_ptr_Function_ulong Function
-%1307 = OpVariable %_ptr_Function_ulong Function
-%1308 = OpVariable %_ptr_Function_ulong Function
-%1309 = OpVariable %_ptr_Function_ulong Function
-%1310 = OpVariable %_ptr_Function_ulong Function
-%1311 = OpVariable %_ptr_Function_ulong Function
-%1312 = OpVariable %_ptr_Function_ulong Function
-%1313 = OpVariable %_ptr_Function_ulong Function
-%1314 = OpVariable %_ptr_Function_ulong Function
-%1315 = OpVariable %_ptr_Function_ulong Function
-%1316 = OpVariable %_ptr_Function_ulong Function
-%1317 = OpVariable %_ptr_Function_ulong Function
-%1318 = OpVariable %_ptr_Function_ulong Function
-%1319 = OpVariable %_ptr_Function_ulong Function
-%1320 = OpVariable %_ptr_Function_ulong Function
-%1321 = OpVariable %_ptr_Function_ulong Function
-%1322 = OpVariable %_ptr_Function_ulong Function
-%1323 = OpVariable %_ptr_Function_ulong Function
-%1324 = OpVariable %_ptr_Function_ulong Function
-%1325 = OpVariable %_ptr_Function_ulong Function
-%1326 = OpVariable %_ptr_Function_ulong Function
-%1327 = OpVariable %_ptr_Function_ulong Function
-OpStore %1179 %1100
-%1328 = OpFunctionCall %ulong %19
-OpStore %1180 %1328
-OpBranch %1108
-%1108 = OpLabel
-%1329 = OpLoad %ulong %1180
-%1330 = OpFunctionCall %ulong %20 %1329 %ulong_24
-OpStore %1228 %1330
-%1331 = OpLoad %ulong %1228
-%1332 = OpFunctionCall %ulong %20 %1331 %ulong_24
-OpStore %1229 %1332
-%1333 = OpLoad %ulong %1229
-%1334 = OpFunctionCall %ulong %20 %1333 %ulong_24
-OpStore %1230 %1334
-%1335 = OpLoad %ulong %1230
-%1336 = OpFunctionCall %ulong %20 %1335 %ulong_32
-OpStore %1231 %1336
-%1337 = OpLoad %ulong %1231
-%1338 = OpFunctionCall %ulong %20 %1337 %ulong_32
-OpStore %1232 %1338
-%1339 = OpLoad %ulong %1232
-%1340 = OpFunctionCall %ulong %20 %1339 %ulong_48
-OpStore %1233 %1340
-%1341 = OpLoad %ulong %1233
-%1342 = OpFunctionCall %ulong %20 %1341 %ulong_48
-OpStore %1234 %1342
-%1343 = OpLoad %ulong %1234
-%1344 = OpFunctionCall %ulong %20 %1343 %ulong_8
-OpStore %1235 %1344
-%1345 = OpLoad %ulong %1235
-%1346 = OpFunctionCall %ulong %20 %1345 %ulong_8
-OpStore %1236 %1346
-%1347 = OpLoad %ulong %1236
-%1348 = OpFunctionCall %ulong %20 %1347 %ulong_8
-OpStore %1237 %1348
-%1349 = OpLoad %ulong %1237
-%1350 = OpFunctionCall %ulong %20 %1349 %ulong_16
-OpStore %1238 %1350
-%1351 = OpLoad %ulong %1238
-%1352 = OpFunctionCall %ulong %20 %1351 %ulong_16
-OpStore %1239 %1352
-%1353 = OpLoad %ulong %1239
-%1354 = OpFunctionCall %ulong %20 %1353 %ulong_20
-OpStore %1240 %1354
-%1355 = OpLoad %ulong %1240
-%1356 = OpFunctionCall %ulong %20 %1355 %ulong_16
-OpStore %1241 %1356
-%1357 = OpLoad %ulong %1241
-%1358 = OpFunctionCall %ulong %20 %1357 %ulong_40
-OpStore %1242 %1358
-%1359 = OpLoad %ulong %1242
-%1360 = OpFunctionCall %ulong %20 %1359 %ulong_24
-OpStore %1243 %1360
-%1361 = OpLoad %ulong %1243
-%1362 = OpFunctionCall %ulong %20 %1361 %ulong_40
-OpStore %1244 %1362
-OpBranch %1109
-%1109 = OpLabel
-OpStore %1154 %1363
-OpStore %1225 %ulong_0
-OpBranch %1102
-%1102 = OpLabel
-%1365 = OpLoad %ulong %1225
-%1367 = OpULessThan %bool %1365 %ulong_12
-OpStore %1182 %1367
-%1368 = OpLoad %bool %1182
-OpLoopMerge %1104 %1149 None
-OpBranchConditional %1368 %1103 %1104
-%1104 = OpLabel
-%1369 = OpLoad %ulong %1244
-OpStore %1224 %1369
-OpStore %1226 %ulong_0
-OpStore %1227 %ulong_0
-OpBranch %1105
-%1105 = OpLabel
-%1370 = OpLoad %ulong %1227
-%1371 = OpULessThan %bool %1370 %ulong_3
-OpStore %1184 %1371
-%1372 = OpLoad %bool %1184
-OpLoopMerge %1107 %1148 None
-OpBranchConditional %1372 %1106 %1107
-%1107 = OpLabel
-OpBranch %1114
-%1114 = OpLabel
-%1373 = OpAccessChain %_ptr_Function_ulong %1156 %uint_0
-%1374 = OpLoad %ulong %1226
-OpStore %1373 %1374
-%1375 = OpLoad %ulong %1226
-%1376 = OpIMul %ulong %1375 %ulong_3
-OpStore %1251 %1376
-%1377 = OpLoad %ulong %1251
-%1378 = OpIAdd %ulong %1377 %ulong_1
-OpStore %1252 %1378
-%1379 = OpAccessChain %_ptr_Function_ulong %1156 %uint_1
-%1380 = OpLoad %ulong %1252
-OpStore %1379 %1380
-%1381 = OpLoad %ulong %1226
-%1382 = OpBitwiseXor %ulong %1381 %ulong_305419896
-OpStore %1253 %1382
-%1383 = OpAccessChain %_ptr_Function_ulong %1156 %uint_2
-%1384 = OpLoad %ulong %1253
-OpStore %1383 %1384
-OpBranch %1115
-%1115 = OpLabel
-OpBranch %1118
-%1118 = OpLabel
-%1385 = OpLoad %ulong %1226
-%1386 = OpBitwiseAnd %ulong %1385 %ulong_65535
-OpStore %1263 %1386
-%1387 = OpLoad %ulong %1263
-%1388 = OpConvertUToF %double %1387
-OpStore %1264 %1388
-%1389 = OpLoad %double %1264
-%1390 = OpFDiv %double %1389 %double_8
-OpStore %1265 %1390
-%1391 = OpAccessChain %_ptr_Function_double %1158 %uint_0
-%1392 = OpLoad %double %1265
-OpStore %1391 %1392
-%1393 = OpLoad %ulong %1226
-%1394 = OpBitwiseAnd %ulong %1393 %ulong_4095
-OpStore %1266 %1394
-%1395 = OpLoad %ulong %1266
-%1396 = OpConvertUToF %double %1395
-OpStore %1267 %1396
-%1397 = OpLoad %double %1267
-%1398 = OpFSub %double %1397 %double_2048
-OpStore %1268 %1398
-%1399 = OpAccessChain %_ptr_Function_double %1158 %uint_1
-%1400 = OpLoad %double %1268
-OpStore %1399 %1400
-%1401 = OpLoad %ulong %1226
-%1402 = OpBitwiseAnd %ulong %1401 %ulong_262143
-OpStore %1269 %1402
-%1403 = OpLoad %ulong %1269
-%1404 = OpConvertUToF %double %1403
-OpStore %1270 %1404
-%1405 = OpLoad %double %1270
-%1406 = OpFDiv %double %1405 %double_64
-OpStore %1271 %1406
-%1407 = OpAccessChain %_ptr_Function_double %1158 %uint_2
-%1408 = OpLoad %double %1271
-OpStore %1407 %1408
-OpBranch %1119
-%1119 = OpLabel
-OpBranch %1122
-%1122 = OpLabel
-%1409 = OpAccessChain %_ptr_Function_ulong %1160 %uint_0
-%1410 = OpLoad %ulong %1226
-OpStore %1409 %1410
-%1411 = OpLoad %ulong %1226
-%1412 = OpBitwiseAnd %ulong %1411 %ulong_32767
-OpStore %1278 %1412
-%1413 = OpLoad %ulong %1278
-%1414 = OpConvertUToF %double %1413
-OpStore %1279 %1414
-%1415 = OpLoad %double %1279
-%1416 = OpFDiv %double %1415 %double_4
-OpStore %1280 %1416
-%1417 = OpAccessChain %_ptr_Function_double %1160 %uint_1
-%1418 = OpLoad %double %1280
-OpStore %1417 %1418
-%1419 = OpLoad %ulong %1226
-%1420 = OpUConvert %uint %1419
-OpStore %1281 %1420
-%1421 = OpAccessChain %_ptr_Function_uint %1160 %uint_2
-%1422 = OpLoad %uint %1281
-OpStore %1421 %1422
-%1423 = OpLoad %ulong %1226
-%1424 = OpShiftRightLogical %ulong %1423 %ulong_32
-OpStore %1282 %1424
-%1425 = OpLoad %ulong %1282
-%1426 = OpUConvert %uint %1425
-OpStore %1283 %1426
-%1427 = OpAccessChain %_ptr_Function_uint %1160 %uint_3
-%1428 = OpLoad %uint %1283
-OpStore %1427 %1428
-OpBranch %1123
-%1123 = OpLabel
-%1429 = OpLoad %ulong %1226
-%1430 = OpUConvert %uint %1429
-OpStore %1212 %1430
-OpBranch %1126
-%1126 = OpLabel
-%1431 = OpAccessChain %_ptr_Function_ulong %1162 %uint_0
-%1432 = OpLoad %ulong %1226
-OpStore %1431 %1432
-%1433 = OpLoad %ulong %1226
-%1434 = OpNot %ulong %1433
-OpStore %1287 %1434
-%1435 = OpAccessChain %_ptr_Function_ulong %1162 %uint_1
-%1436 = OpLoad %ulong %1287
-OpStore %1435 %1436
-%1437 = OpLoad %ulong %1226
-%1438 = OpIMul %ulong %1437 %ulong_5
-OpStore %1288 %1438
-%1439 = OpAccessChain %_ptr_Function_ulong %1162 %uint_2
-%1440 = OpLoad %ulong %1288
-OpStore %1439 %1440
-%1441 = OpLoad %ulong %1226
-%1442 = OpShiftRightLogical %ulong %1441 %ulong_3
-OpStore %1289 %1442
-%1443 = OpAccessChain %_ptr_Function_ulong %1162 %uint_3
-%1444 = OpLoad %ulong %1289
-OpStore %1443 %1444
-OpBranch %1127
-%1127 = OpLabel
-OpBranch %1130
-%1130 = OpLabel
-%1445 = OpAccessChain %_ptr_Function_ulong %1167 %uint_0
-%1446 = OpLoad %ulong %1226
-OpStore %1445 %1446
-%1447 = OpLoad %ulong %1226
-%1448 = OpIAdd %ulong %1447 %ulong_11
-OpStore %1293 %1448
-%1449 = OpAccessChain %_ptr_Function_ulong %1167 %uint_1
-%1450 = OpLoad %ulong %1293
-OpStore %1449 %1450
-%1451 = OpAccessChain %_ptr_Function__struct_187 %1166 %uint_0
-%1452 = OpLoad %_struct_187 %1167
-OpStore %1451 %1452
-%1453 = OpLoad %ulong %1226
-%1454 = OpIMul %ulong %1453 %ulong_7
-OpStore %1294 %1454
-%1455 = OpAccessChain %_ptr_Function_ulong %1168 %uint_0
-%1456 = OpLoad %ulong %1294
-OpStore %1455 %1456
-%1457 = OpLoad %ulong %1226
-%1458 = OpNot %ulong %1457
-OpStore %1295 %1458
-%1459 = OpAccessChain %_ptr_Function_ulong %1168 %uint_1
-%1460 = OpLoad %ulong %1295
-OpStore %1459 %1460
-%1461 = OpAccessChain %_ptr_Function__struct_187 %1166 %uint_1
-%1462 = OpLoad %_struct_187 %1168
-OpStore %1461 %1462
-OpBranch %1131
-%1131 = OpLabel
-%1463 = OpLoad %ulong %1226
-%1465 = OpBitwiseAnd %ulong %1463 %ulong_1023
-OpStore %1213 %1465
-%1466 = OpLoad %ulong %1213
-%1467 = OpConvertUToF %double %1466
-OpStore %1214 %1467
-OpBranch %1134
-%1134 = OpLabel
-%1468 = OpAccessChain %_ptr_Function_ulong %1171 %uint_0
-%1469 = OpLoad %ulong %1226
-OpStore %1468 %1469
-%1470 = OpLoad %ulong %1226
-%1471 = OpIAdd %ulong %1470 %ulong_1
-OpStore %1301 %1471
-%1472 = OpAccessChain %_ptr_Function_ulong %1171 %uint_1
-%1473 = OpLoad %ulong %1301
-OpStore %1472 %1473
-%1474 = OpLoad %ulong %1226
-%1475 = OpIAdd %ulong %1474 %ulong_2
-OpStore %1302 %1475
-%1476 = OpAccessChain %_ptr_Function_ulong %1171 %uint_2
-%1477 = OpLoad %ulong %1302
-OpStore %1476 %1477
-%1478 = OpLoad %ulong %1226
-%1479 = OpIMul %ulong %1478 %ulong_9
-OpStore %1303 %1479
-%1480 = OpAccessChain %_ptr_Function_ulong %1171 %uint_3
-%1481 = OpLoad %ulong %1303
-OpStore %1480 %1481
-%1482 = OpLoad %ulong %1226
-%1483 = OpNot %ulong %1482
-OpStore %1304 %1483
-%1484 = OpAccessChain %_ptr_Function_ulong %1171 %uint_4
-%1485 = OpLoad %ulong %1304
-OpStore %1484 %1485
-%1486 = OpLoad %ulong %1226
-%1487 = OpBitwiseXor %ulong %1486 %ulong_2863311530
-OpStore %1305 %1487
-%1488 = OpAccessChain %_ptr_Function_ulong %1171 %uint_5
-%1489 = OpLoad %ulong %1305
-OpStore %1488 %1489
-OpBranch %1135
-%1135 = OpLabel
-%1490 = OpLoad %ulong %1226
-%1491 = OpFunctionCall %_struct_281 %17 %1490
-OpStore %1172 %1491
-%1493 = OpAccessChain %_ptr_Function_ulong %1154 %uint_10
-%1494 = OpLoad %ulong %1493
-OpStore %1215 %1494
-OpBranch %1138
-%1138 = OpLabel
-%1495 = OpAccessChain %_ptr_Function_ulong %1174 %uint_0
-%1496 = OpLoad %ulong %1215
-OpStore %1495 %1496
-%1497 = OpLoad %ulong %1215
-%1498 = OpIMul %ulong %1497 %ulong_3
-OpStore %1309 %1498
-%1499 = OpLoad %ulong %1309
-%1500 = OpIAdd %ulong %1499 %ulong_1
-OpStore %1310 %1500
-%1501 = OpAccessChain %_ptr_Function_ulong %1174 %uint_1
-%1502 = OpLoad %ulong %1310
-OpStore %1501 %1502
-%1503 = OpLoad %ulong %1215
-%1504 = OpBitwiseXor %ulong %1503 %ulong_305419896
-OpStore %1311 %1504
-%1505 = OpAccessChain %_ptr_Function_ulong %1174 %uint_2
-%1506 = OpLoad %ulong %1311
-OpStore %1505 %1506
-OpBranch %1139
-%1139 = OpLabel
-%1508 = OpAccessChain %_ptr_Function_ulong %1154 %uint_11
-%1509 = OpLoad %ulong %1508
-OpStore %1216 %1509
-OpBranch %1142
-%1142 = OpLabel
-%1510 = OpAccessChain %_ptr_Function_ulong %1176 %uint_0
-%1511 = OpLoad %ulong %1216
-OpStore %1510 %1511
-%1512 = OpLoad %ulong %1216
-%1513 = OpNot %ulong %1512
-OpStore %1315 %1513
-%1514 = OpAccessChain %_ptr_Function_ulong %1176 %uint_1
-%1515 = OpLoad %ulong %1315
-OpStore %1514 %1515
-%1516 = OpLoad %ulong %1216
-%1517 = OpIMul %ulong %1516 %ulong_5
-OpStore %1316 %1517
-%1518 = OpAccessChain %_ptr_Function_ulong %1176 %uint_2
-%1519 = OpLoad %ulong %1316
-OpStore %1518 %1519
-%1520 = OpLoad %ulong %1216
-%1521 = OpShiftRightLogical %ulong %1520 %ulong_3
-OpStore %1317 %1521
-%1522 = OpAccessChain %_ptr_Function_ulong %1176 %uint_3
-%1523 = OpLoad %ulong %1317
-OpStore %1522 %1523
-OpBranch %1143
-%1143 = OpLabel
-%1524 = OpAccessChain %_ptr_Function_ulong %1154 %uint_0
-%1525 = OpLoad %ulong %1524
-OpStore %1217 %1525
-OpBranch %1146
-%1146 = OpLabel
-%1526 = OpAccessChain %_ptr_Function_ulong %1178 %uint_0
-%1527 = OpLoad %ulong %1217
-OpStore %1526 %1527
-%1528 = OpLoad %ulong %1217
-%1529 = OpIAdd %ulong %1528 %ulong_1
-OpStore %1323 %1529
-%1530 = OpAccessChain %_ptr_Function_ulong %1178 %uint_1
-%1531 = OpLoad %ulong %1323
-OpStore %1530 %1531
-%1532 = OpLoad %ulong %1217
-%1533 = OpIAdd %ulong %1532 %ulong_2
-OpStore %1324 %1533
-%1534 = OpAccessChain %_ptr_Function_ulong %1178 %uint_2
-%1535 = OpLoad %ulong %1324
-OpStore %1534 %1535
-%1536 = OpLoad %ulong %1217
-%1537 = OpIMul %ulong %1536 %ulong_9
-OpStore %1325 %1537
-%1538 = OpAccessChain %_ptr_Function_ulong %1178 %uint_3
-%1539 = OpLoad %ulong %1325
-OpStore %1538 %1539
-%1540 = OpLoad %ulong %1217
-%1541 = OpNot %ulong %1540
-OpStore %1326 %1541
-%1542 = OpAccessChain %_ptr_Function_ulong %1178 %uint_4
-%1543 = OpLoad %ulong %1326
-OpStore %1542 %1543
-%1544 = OpLoad %ulong %1217
-%1545 = OpBitwiseXor %ulong %1544 %ulong_2863311530
-OpStore %1327 %1545
-%1546 = OpAccessChain %_ptr_Function_ulong %1178 %uint_5
-%1547 = OpLoad %ulong %1327
-OpStore %1546 %1547
-OpBranch %1147
-%1147 = OpLabel
-%1548 = OpAccessChain %_ptr_Function_ulong %1154 %uint_1
-%1549 = OpLoad %ulong %1548
-OpStore %1218 %1549
-%1550 = OpLoad %ulong %1218
-%1552 = OpBitwiseAnd %ulong %1550 %ulong_255
-OpStore %1219 %1552
-%1553 = OpLoad %ulong %1219
-%1554 = OpConvertUToF %float %1553
-OpStore %1220 %1554
-%1555 = OpAccessChain %_ptr_Function_ulong %1154 %uint_3
-%1556 = OpLoad %ulong %1555
-OpStore %1221 %1556
-%1557 = OpLoad %ulong %1226
-%1558 = OpLoad %_struct_45 %1156
-%1559 = OpLoad %_struct_80 %1158
-%1560 = OpLoad %_struct_111 %1160
-%1561 = OpLoad %uint %1212
-%1562 = OpLoad %_struct_150 %1162
-%1563 = OpLoad %_struct_188 %1166
-%1564 = OpLoad %double %1214
-%1565 = OpLoad %_struct_228 %1171
-%1566 = OpLoad %_struct_281 %1172
-%1567 = OpLoad %_struct_45 %1174
-%1568 = OpLoad %_struct_150 %1176
-%1569 = OpLoad %_struct_228 %1178
-%1570 = OpLoad %float %1220
-%1571 = OpLoad %ulong %1221
-%1572 = OpFunctionCall %ulong %10 %1557 %1558 %1559 %1560 %1561 %1562 %1563 %1564 %1565 %1566 %1567 %1568 %1569 %1570 %1571
-OpStore %1222 %1572
-%1573 = OpLoad %ulong %1224
-%1574 = OpLoad %ulong %1222
-%1575 = OpFunctionCall %ulong %20 %1573 %1574
-OpStore %1223 %1575
-%1576 = OpLoad %ulong %1223
-OpReturnValue %1576
-%1106 = OpLabel
-%1577 = OpLoad %ulong %1227
-%1579 = OpIMul %ulong %1577 %ulong_19
-OpStore %1185 %1579
-%1580 = OpLoad %ulong %1185
-%1581 = OpLoad %ulong %1179
-%1582 = OpIAdd %ulong %1580 %1581
-OpStore %1186 %1582
-%1583 = OpAccessChain %_ptr_Function_ulong %1154 %uint_0
-%1584 = OpLoad %ulong %1583
-OpStore %1187 %1584
-%1585 = OpLoad %ulong %1187
-%1586 = OpLoad %ulong %1186
-%1587 = OpIAdd %ulong %1585 %1586
-OpStore %1188 %1587
-%1588 = OpAccessChain %_ptr_Function_ulong %1154 %uint_1
-%1589 = OpLoad %ulong %1588
-OpStore %1189 %1589
-OpBranch %1112
-%1112 = OpLabel
-%1590 = OpAccessChain %_ptr_Function_ulong %1155 %uint_0
-%1591 = OpLoad %ulong %1189
-OpStore %1590 %1591
-%1592 = OpLoad %ulong %1189
-%1593 = OpIMul %ulong %1592 %ulong_3
-OpStore %1248 %1593
-%1594 = OpLoad %ulong %1248
-%1595 = OpIAdd %ulong %1594 %ulong_1
-OpStore %1249 %1595
-%1596 = OpAccessChain %_ptr_Function_ulong %1155 %uint_1
-%1597 = OpLoad %ulong %1249
-OpStore %1596 %1597
-%1598 = OpLoad %ulong %1189
-%1599 = OpBitwiseXor %ulong %1598 %ulong_305419896
-OpStore %1250 %1599
-%1600 = OpAccessChain %_ptr_Function_ulong %1155 %uint_2
-%1601 = OpLoad %ulong %1250
-OpStore %1600 %1601
-OpBranch %1113
-%1113 = OpLabel
-%1602 = OpAccessChain %_ptr_Function_ulong %1154 %uint_2
-%1603 = OpLoad %ulong %1602
-OpStore %1190 %1603
-OpBranch %1116
-%1116 = OpLabel
-%1604 = OpLoad %ulong %1190
-%1605 = OpBitwiseAnd %ulong %1604 %ulong_65535
-OpStore %1254 %1605
-%1606 = OpLoad %ulong %1254
-%1607 = OpConvertUToF %double %1606
-OpStore %1255 %1607
-%1608 = OpLoad %double %1255
-%1609 = OpFDiv %double %1608 %double_8
-OpStore %1256 %1609
-%1610 = OpAccessChain %_ptr_Function_double %1157 %uint_0
-%1611 = OpLoad %double %1256
-OpStore %1610 %1611
-%1612 = OpLoad %ulong %1190
-%1613 = OpBitwiseAnd %ulong %1612 %ulong_4095
-OpStore %1257 %1613
-%1614 = OpLoad %ulong %1257
-%1615 = OpConvertUToF %double %1614
-OpStore %1258 %1615
-%1616 = OpLoad %double %1258
-%1617 = OpFSub %double %1616 %double_2048
-OpStore %1259 %1617
-%1618 = OpAccessChain %_ptr_Function_double %1157 %uint_1
-%1619 = OpLoad %double %1259
-OpStore %1618 %1619
-%1620 = OpLoad %ulong %1190
-%1621 = OpBitwiseAnd %ulong %1620 %ulong_262143
-OpStore %1260 %1621
-%1622 = OpLoad %ulong %1260
-%1623 = OpConvertUToF %double %1622
-OpStore %1261 %1623
-%1624 = OpLoad %double %1261
-%1625 = OpFDiv %double %1624 %double_64
-OpStore %1262 %1625
-%1626 = OpAccessChain %_ptr_Function_double %1157 %uint_2
-%1627 = OpLoad %double %1262
-OpStore %1626 %1627
-OpBranch %1117
-%1117 = OpLabel
-%1628 = OpAccessChain %_ptr_Function_ulong %1154 %uint_3
-%1629 = OpLoad %ulong %1628
-OpStore %1191 %1629
-OpBranch %1120
-%1120 = OpLabel
-%1630 = OpAccessChain %_ptr_Function_ulong %1159 %uint_0
-%1631 = OpLoad %ulong %1191
-OpStore %1630 %1631
-%1632 = OpLoad %ulong %1191
-%1633 = OpBitwiseAnd %ulong %1632 %ulong_32767
-OpStore %1272 %1633
-%1634 = OpLoad %ulong %1272
-%1635 = OpConvertUToF %double %1634
-OpStore %1273 %1635
-%1636 = OpLoad %double %1273
-%1637 = OpFDiv %double %1636 %double_4
-OpStore %1274 %1637
-%1638 = OpAccessChain %_ptr_Function_double %1159 %uint_1
-%1639 = OpLoad %double %1274
-OpStore %1638 %1639
-%1640 = OpLoad %ulong %1191
-%1641 = OpUConvert %uint %1640
-OpStore %1275 %1641
-%1642 = OpAccessChain %_ptr_Function_uint %1159 %uint_2
-%1643 = OpLoad %uint %1275
-OpStore %1642 %1643
-%1644 = OpLoad %ulong %1191
-%1645 = OpShiftRightLogical %ulong %1644 %ulong_32
-OpStore %1276 %1645
-%1646 = OpLoad %ulong %1276
-%1647 = OpUConvert %uint %1646
-OpStore %1277 %1647
-%1648 = OpAccessChain %_ptr_Function_uint %1159 %uint_3
-%1649 = OpLoad %uint %1277
-OpStore %1648 %1649
-OpBranch %1121
-%1121 = OpLabel
-%1650 = OpAccessChain %_ptr_Function_ulong %1154 %uint_4
-%1651 = OpLoad %ulong %1650
-OpStore %1192 %1651
-%1652 = OpLoad %ulong %1192
-%1653 = OpUConvert %uint %1652
-OpStore %1193 %1653
-%1654 = OpAccessChain %_ptr_Function_ulong %1154 %uint_5
-%1655 = OpLoad %ulong %1654
-OpStore %1194 %1655
-%1656 = OpLoad %ulong %1194
-%1657 = OpLoad %ulong %1186
-%1658 = OpIAdd %ulong %1656 %1657
-OpStore %1195 %1658
-OpBranch %1124
-%1124 = OpLabel
-%1659 = OpAccessChain %_ptr_Function_ulong %1161 %uint_0
-%1660 = OpLoad %ulong %1195
-OpStore %1659 %1660
-%1661 = OpLoad %ulong %1195
-%1662 = OpNot %ulong %1661
-OpStore %1284 %1662
-%1663 = OpAccessChain %_ptr_Function_ulong %1161 %uint_1
-%1664 = OpLoad %ulong %1284
-OpStore %1663 %1664
-%1665 = OpLoad %ulong %1195
-%1666 = OpIMul %ulong %1665 %ulong_5
-OpStore %1285 %1666
-%1667 = OpAccessChain %_ptr_Function_ulong %1161 %uint_2
-%1668 = OpLoad %ulong %1285
-OpStore %1667 %1668
-%1669 = OpLoad %ulong %1195
-%1670 = OpShiftRightLogical %ulong %1669 %ulong_3
-OpStore %1286 %1670
-%1671 = OpAccessChain %_ptr_Function_ulong %1161 %uint_3
-%1672 = OpLoad %ulong %1286
-OpStore %1671 %1672
-OpBranch %1125
-%1125 = OpLabel
-%1673 = OpAccessChain %_ptr_Function_ulong %1154 %uint_6
-%1674 = OpLoad %ulong %1673
-OpStore %1196 %1674
-OpBranch %1128
-%1128 = OpLabel
-%1675 = OpAccessChain %_ptr_Function_ulong %1164 %uint_0
-%1676 = OpLoad %ulong %1196
-OpStore %1675 %1676
-%1677 = OpLoad %ulong %1196
-%1678 = OpIAdd %ulong %1677 %ulong_11
-OpStore %1290 %1678
-%1679 = OpAccessChain %_ptr_Function_ulong %1164 %uint_1
-%1680 = OpLoad %ulong %1290
-OpStore %1679 %1680
-%1681 = OpAccessChain %_ptr_Function__struct_187 %1163 %uint_0
-%1682 = OpLoad %_struct_187 %1164
-OpStore %1681 %1682
-%1683 = OpLoad %ulong %1196
-%1684 = OpIMul %ulong %1683 %ulong_7
-OpStore %1291 %1684
-%1685 = OpAccessChain %_ptr_Function_ulong %1165 %uint_0
-%1686 = OpLoad %ulong %1291
+%1258 = OpVariable %_ptr_Function_ulong Function
+%1259 = OpVariable %_ptr_Function_ulong Function
+OpStore %1085 %953
+OpStore %1067 %954
+OpStore %1068 %955
+OpStore %1069 %956
+OpStore %1086 %957
+OpStore %1070 %958
+OpStore %1071 %959
+OpStore %1087 %960
+OpStore %1072 %961
+OpStore %1073 %962
+OpStore %1074 %963
+OpStore %1075 %964
+OpStore %1076 %965
+OpStore %1089 %966
+OpStore %1090 %967
+%1260 = OpLoad %_struct_41 %1067
+OpStore %1077 %1260
+%1261 = OpAccessChain %_ptr_Function_double %1068 %uint_0
+%1262 = OpLoad %double %1261
+OpStore %1230 %1262
+%1263 = OpAccessChain %_ptr_Function_double %1068 %uint_1
+%1264 = OpLoad %double %1263
+OpStore %1231 %1264
+%1265 = OpAccessChain %_ptr_Function_double %1068 %uint_2
+%1266 = OpLoad %double %1265
+OpStore %1232 %1266
+%1267 = OpAccessChain %_ptr_Function_ulong %1069 %uint_0
+%1268 = OpLoad %ulong %1267
+OpStore %1233 %1268
+%1269 = OpAccessChain %_ptr_Function_double %1069 %uint_1
+%1270 = OpLoad %double %1269
+OpStore %1234 %1270
+%1271 = OpAccessChain %_ptr_Function_uint %1069 %uint_2
+%1272 = OpLoad %uint %1271
+OpStore %1235 %1272
+%1273 = OpAccessChain %_ptr_Function_uint %1069 %uint_3
+%1274 = OpLoad %uint %1273
+OpStore %1236 %1274
+%1275 = OpLoad %_struct_493 %1070
+OpStore %1078 %1275
+%1276 = OpAccessChain %_ptr_Function__struct_654 %1071 %uint_0
+%1277 = OpAccessChain %_ptr_Function_ulong %1276 %uint_0
+%1278 = OpLoad %ulong %1277
+OpStore %1256 %1278
+%1279 = OpAccessChain %_ptr_Function_ulong %1276 %uint_1
+%1280 = OpLoad %ulong %1279
+OpStore %1257 %1280
+%1281 = OpAccessChain %_ptr_Function__struct_654 %1071 %uint_1
+%1282 = OpAccessChain %_ptr_Function_ulong %1281 %uint_0
+%1283 = OpLoad %ulong %1282
+OpStore %1258 %1283
+%1284 = OpAccessChain %_ptr_Function_ulong %1281 %uint_1
+%1285 = OpLoad %ulong %1284
+OpStore %1259 %1285
+%1286 = OpAccessChain %_ptr_Function_ulong %1072 %uint_0
+%1287 = OpLoad %ulong %1286
+OpStore %1237 %1287
+%1288 = OpAccessChain %_ptr_Function_ulong %1072 %uint_1
+%1289 = OpLoad %ulong %1288
+OpStore %1238 %1289
+%1290 = OpAccessChain %_ptr_Function_ulong %1072 %uint_2
+%1291 = OpLoad %ulong %1290
+OpStore %1239 %1291
+%1292 = OpAccessChain %_ptr_Function_ulong %1072 %uint_3
+%1293 = OpLoad %ulong %1292
+OpStore %1240 %1293
+%1294 = OpAccessChain %_ptr_Function_ulong %1072 %uint_4
+%1295 = OpLoad %ulong %1294
+OpStore %1241 %1295
+%1296 = OpAccessChain %_ptr_Function_ulong %1072 %uint_5
+%1297 = OpLoad %ulong %1296
+OpStore %1242 %1297
+%1298 = OpAccessChain %_ptr_Function_ulong %1073 %uint_0
+%1299 = OpLoad %ulong %1298
+OpStore %1243 %1299
+%1300 = OpAccessChain %_ptr_Function_double %1073 %uint_1
+%1301 = OpLoad %double %1300
+OpStore %1244 %1301
+%1302 = OpAccessChain %_ptr_Function_uint %1073 %uint_2
+%1303 = OpLoad %uint %1302
+OpStore %1245 %1303
+%1304 = OpAccessChain %_ptr_Function_uint %1073 %uint_3
+%1305 = OpLoad %uint %1304
+OpStore %1246 %1305
+%1306 = OpAccessChain %_ptr_Function_double %1073 %uint_4
+%1307 = OpLoad %double %1306
+OpStore %1247 %1307
+%1308 = OpAccessChain %_ptr_Function_ulong %1073 %uint_5
+%1309 = OpLoad %ulong %1308
+OpStore %1248 %1309
+%1310 = OpAccessChain %_ptr_Function_ulong %1073 %uint_6
+%1311 = OpLoad %ulong %1310
+OpStore %1249 %1311
+%1312 = OpLoad %_struct_41 %1074
+OpStore %1079 %1312
+%1313 = OpLoad %_struct_493 %1075
+OpStore %1080 %1313
+%1314 = OpAccessChain %_ptr_Function_ulong %1076 %uint_0
+%1315 = OpLoad %ulong %1314
+OpStore %1250 %1315
+%1316 = OpAccessChain %_ptr_Function_ulong %1076 %uint_1
+%1317 = OpLoad %ulong %1316
+OpStore %1251 %1317
+%1318 = OpAccessChain %_ptr_Function_ulong %1076 %uint_2
+%1319 = OpLoad %ulong %1318
+OpStore %1252 %1319
+%1320 = OpAccessChain %_ptr_Function_ulong %1076 %uint_3
+%1321 = OpLoad %ulong %1320
+OpStore %1253 %1321
+%1322 = OpAccessChain %_ptr_Function_ulong %1076 %uint_4
+%1323 = OpLoad %ulong %1322
+OpStore %1254 %1323
+%1324 = OpAccessChain %_ptr_Function_ulong %1076 %uint_5
+%1325 = OpLoad %ulong %1324
+OpStore %1255 %1325
+OpBranch %969
+%969 = OpLabel
+OpBranch %970
+%970 = OpLabel
+%1327 = OpLoad %ulong %1085
+%1328 = OpFunctionCall %ulong %19 %ulong_14695981039346656037 %1327
+OpStore %1091 %1328
+%1329 = OpLoad %_struct_41 %1077
+OpStore %1081 %1329
+%1330 = OpLoad %ulong %1091
+%1331 = OpLoad %_struct_41 %1081
+%1332 = OpFunctionCall %ulong %2 %1330 %1331
+OpStore %1092 %1332
+OpBranch %971
+%971 = OpLabel
+OpBranch %972
+%972 = OpLabel
+%1333 = OpLoad %double %1230
+%1334 = OpBitcast %ulong %1333
+OpStore %1099 %1334
+OpBranch %974
+%974 = OpLabel
+%1335 = OpLoad %ulong %1092
+OpStore %1107 %1335
+OpStore %1108 %ulong_0
+OpBranch %975
+%975 = OpLabel
+%1336 = OpLoad %ulong %1108
+%1337 = OpULessThan %bool %1336 %ulong_8
+OpStore %1100 %1337
+%1338 = OpLoad %bool %1100
+OpLoopMerge %977 %1066 None
+OpBranchConditional %1338 %976 %977
+%977 = OpLabel
+OpBranch %978
+%978 = OpLabel
+OpBranch %973
+%973 = OpLabel
+OpBranch %979
+%979 = OpLabel
+%1339 = OpLoad %double %1231
+%1340 = OpBitcast %ulong %1339
+OpStore %1109 %1340
+OpBranch %981
+%981 = OpLabel
+%1341 = OpLoad %ulong %1107
+OpStore %1117 %1341
+OpStore %1118 %ulong_0
+OpBranch %982
+%982 = OpLabel
+%1342 = OpLoad %ulong %1118
+%1343 = OpULessThan %bool %1342 %ulong_8
+OpStore %1110 %1343
+%1344 = OpLoad %bool %1110
+OpLoopMerge %984 %1065 None
+OpBranchConditional %1344 %983 %984
+%984 = OpLabel
+OpBranch %985
+%985 = OpLabel
+OpBranch %980
+%980 = OpLabel
+OpBranch %986
+%986 = OpLabel
+%1345 = OpLoad %double %1232
+%1346 = OpBitcast %ulong %1345
+OpStore %1119 %1346
+OpBranch %988
+%988 = OpLabel
+%1347 = OpLoad %ulong %1117
+OpStore %1127 %1347
+OpStore %1128 %ulong_0
+OpBranch %989
+%989 = OpLabel
+%1348 = OpLoad %ulong %1128
+%1349 = OpULessThan %bool %1348 %ulong_8
+OpStore %1120 %1349
+%1350 = OpLoad %bool %1120
+OpLoopMerge %991 %1064 None
+OpBranchConditional %1350 %990 %991
+%991 = OpLabel
+OpBranch %992
+%992 = OpLabel
+OpBranch %987
+%987 = OpLabel
+OpBranch %993
+%993 = OpLabel
+OpBranch %994
+%994 = OpLabel
+OpBranch %995
+%995 = OpLabel
+%1351 = OpLoad %ulong %1127
+OpStore %1136 %1351
+OpStore %1137 %ulong_0
+OpBranch %996
+%996 = OpLabel
+%1352 = OpLoad %ulong %1137
+%1353 = OpULessThan %bool %1352 %ulong_8
+OpStore %1129 %1353
+%1354 = OpLoad %bool %1129
+OpLoopMerge %998 %1063 None
+OpBranchConditional %1354 %997 %998
+%998 = OpLabel
+OpBranch %999
+%999 = OpLabel
+OpBranch %1000
+%1000 = OpLabel
+%1355 = OpLoad %double %1234
+%1356 = OpBitcast %ulong %1355
+OpStore %1138 %1356
+OpBranch %1002
+%1002 = OpLabel
+%1357 = OpLoad %ulong %1136
+OpStore %1146 %1357
+OpStore %1147 %ulong_0
+OpBranch %1003
+%1003 = OpLabel
+%1358 = OpLoad %ulong %1147
+%1359 = OpULessThan %bool %1358 %ulong_8
+OpStore %1139 %1359
+%1360 = OpLoad %bool %1139
+OpLoopMerge %1005 %1062 None
+OpBranchConditional %1360 %1004 %1005
+%1005 = OpLabel
+OpBranch %1006
+%1006 = OpLabel
+OpBranch %1001
+%1001 = OpLabel
+OpBranch %1007
+%1007 = OpLabel
+%1361 = OpLoad %uint %1235
+%1362 = OpUConvert %ulong %1361
+OpStore %1148 %1362
+OpBranch %1009
+%1009 = OpLabel
+%1363 = OpLoad %ulong %1146
+OpStore %1156 %1363
+OpStore %1157 %ulong_0
+OpBranch %1010
+%1010 = OpLabel
+%1364 = OpLoad %ulong %1157
+%1365 = OpULessThan %bool %1364 %ulong_8
+OpStore %1149 %1365
+%1366 = OpLoad %bool %1149
+OpLoopMerge %1012 %1061 None
+OpBranchConditional %1366 %1011 %1012
+%1012 = OpLabel
+OpBranch %1013
+%1013 = OpLabel
+OpBranch %1008
+%1008 = OpLabel
+OpBranch %1014
+%1014 = OpLabel
+%1367 = OpLoad %uint %1236
+%1368 = OpUConvert %ulong %1367
+OpStore %1158 %1368
+OpBranch %1016
+%1016 = OpLabel
+%1369 = OpLoad %ulong %1156
+OpStore %1166 %1369
+OpStore %1167 %ulong_0
+OpBranch %1017
+%1017 = OpLabel
+%1370 = OpLoad %ulong %1167
+%1371 = OpULessThan %bool %1370 %ulong_8
+OpStore %1159 %1371
+%1372 = OpLoad %bool %1159
+OpLoopMerge %1019 %1060 None
+OpBranchConditional %1372 %1018 %1019
+%1019 = OpLabel
+OpBranch %1020
+%1020 = OpLabel
+OpBranch %1015
+%1015 = OpLabel
+OpBranch %1021
+%1021 = OpLabel
+OpBranch %1022
+%1022 = OpLabel
+%1373 = OpLoad %uint %1086
+%1374 = OpUConvert %ulong %1373
+OpStore %1168 %1374
+%1375 = OpLoad %ulong %1166
+%1376 = OpLoad %ulong %1168
+%1377 = OpFunctionCall %ulong %19 %1375 %1376
+OpStore %1169 %1377
+OpBranch %1023
+%1023 = OpLabel
+%1378 = OpLoad %_struct_493 %1078
+OpStore %1082 %1378
+%1379 = OpLoad %ulong %1169
+%1380 = OpLoad %_struct_493 %1082
+%1381 = OpFunctionCall %ulong %5 %1379 %1380
+OpStore %1093 %1381
+OpBranch %1024
+%1024 = OpLabel
+OpBranch %1025
+%1025 = OpLabel
+%1382 = OpLoad %ulong %1093
+OpStore %1179 %1382
+OpStore %1180 %ulong_0
+OpBranch %1026
+%1026 = OpLabel
+%1383 = OpLoad %ulong %1180
+%1384 = OpULessThan %bool %1383 %ulong_8
+OpStore %1172 %1384
+%1385 = OpLoad %bool %1172
+OpLoopMerge %1028 %1059 None
+OpBranchConditional %1385 %1027 %1028
+%1028 = OpLabel
+OpBranch %1029
+%1029 = OpLabel
+OpBranch %1030
+%1030 = OpLabel
+%1386 = OpLoad %ulong %1179
+OpStore %1188 %1386
+OpStore %1189 %ulong_0
+OpBranch %1031
+%1031 = OpLabel
+%1387 = OpLoad %ulong %1189
+%1388 = OpULessThan %bool %1387 %ulong_8
+OpStore %1181 %1388
+%1389 = OpLoad %bool %1181
+OpLoopMerge %1033 %1058 None
+OpBranchConditional %1389 %1032 %1033
+%1033 = OpLabel
+OpBranch %1034
+%1034 = OpLabel
+%1390 = OpLoad %ulong %1188
+%1391 = OpLoad %ulong %1258
+%1392 = OpFunctionCall %ulong %19 %1390 %1391
+OpStore %1170 %1392
+%1393 = OpLoad %ulong %1170
+%1394 = OpLoad %ulong %1259
+%1395 = OpFunctionCall %ulong %19 %1393 %1394
+OpStore %1171 %1395
+OpBranch %1035
+%1035 = OpLabel
+OpBranch %1036
+%1036 = OpLabel
+%1396 = OpLoad %double %1087
+%1397 = OpBitcast %ulong %1396
+OpStore %1190 %1397
+%1398 = OpLoad %ulong %1171
+%1399 = OpLoad %ulong %1190
+%1400 = OpFunctionCall %ulong %19 %1398 %1399
+OpStore %1191 %1400
+OpBranch %1037
+%1037 = OpLabel
+OpBranch %1038
+%1038 = OpLabel
+%1401 = OpLoad %ulong %1191
+%1402 = OpLoad %ulong %1237
+%1403 = OpFunctionCall %ulong %19 %1401 %1402
+OpStore %1192 %1403
+%1404 = OpLoad %ulong %1192
+%1405 = OpLoad %ulong %1238
+%1406 = OpFunctionCall %ulong %19 %1404 %1405
+OpStore %1193 %1406
+%1407 = OpLoad %ulong %1193
+%1408 = OpLoad %ulong %1239
+%1409 = OpFunctionCall %ulong %19 %1407 %1408
+OpStore %1194 %1409
+%1410 = OpLoad %ulong %1194
+%1411 = OpLoad %ulong %1240
+%1412 = OpFunctionCall %ulong %19 %1410 %1411
+OpStore %1195 %1412
+%1413 = OpLoad %ulong %1195
+%1414 = OpLoad %ulong %1241
+%1415 = OpFunctionCall %ulong %19 %1413 %1414
+OpStore %1196 %1415
+%1416 = OpLoad %ulong %1196
+%1417 = OpLoad %ulong %1242
+%1418 = OpFunctionCall %ulong %19 %1416 %1417
+OpStore %1197 %1418
+OpBranch %1039
+%1039 = OpLabel
+OpBranch %1040
+%1040 = OpLabel
+%1419 = OpLoad %ulong %1197
+%1420 = OpLoad %ulong %1243
+%1421 = OpFunctionCall %ulong %19 %1419 %1420
+OpStore %1198 %1421
+OpBranch %1041
+%1041 = OpLabel
+%1422 = OpLoad %double %1244
+%1423 = OpBitcast %ulong %1422
+OpStore %1201 %1423
+%1424 = OpLoad %ulong %1198
+%1425 = OpLoad %ulong %1201
+%1426 = OpFunctionCall %ulong %19 %1424 %1425
+OpStore %1202 %1426
+OpBranch %1042
+%1042 = OpLabel
+OpBranch %1043
+%1043 = OpLabel
+%1427 = OpLoad %uint %1245
+%1428 = OpUConvert %ulong %1427
+OpStore %1203 %1428
+%1429 = OpLoad %ulong %1202
+%1430 = OpLoad %ulong %1203
+%1431 = OpFunctionCall %ulong %19 %1429 %1430
+OpStore %1204 %1431
+OpBranch %1044
+%1044 = OpLabel
+OpBranch %1045
+%1045 = OpLabel
+%1432 = OpLoad %uint %1246
+%1433 = OpUConvert %ulong %1432
+OpStore %1205 %1433
+%1434 = OpLoad %ulong %1204
+%1435 = OpLoad %ulong %1205
+%1436 = OpFunctionCall %ulong %19 %1434 %1435
+OpStore %1206 %1436
+OpBranch %1046
+%1046 = OpLabel
+OpBranch %1047
+%1047 = OpLabel
+%1437 = OpLoad %double %1247
+%1438 = OpBitcast %ulong %1437
+OpStore %1207 %1438
+%1439 = OpLoad %ulong %1206
+%1440 = OpLoad %ulong %1207
+%1441 = OpFunctionCall %ulong %19 %1439 %1440
+OpStore %1208 %1441
+OpBranch %1048
+%1048 = OpLabel
+%1442 = OpLoad %ulong %1208
+%1443 = OpLoad %ulong %1248
+%1444 = OpFunctionCall %ulong %19 %1442 %1443
+OpStore %1199 %1444
+%1445 = OpLoad %ulong %1199
+%1446 = OpLoad %ulong %1249
+%1447 = OpFunctionCall %ulong %19 %1445 %1446
+OpStore %1200 %1447
+OpBranch %1049
+%1049 = OpLabel
+%1448 = OpLoad %_struct_41 %1079
+OpStore %1083 %1448
+%1449 = OpLoad %ulong %1200
+%1450 = OpLoad %_struct_41 %1083
+%1451 = OpFunctionCall %ulong %2 %1449 %1450
+OpStore %1094 %1451
+%1452 = OpLoad %_struct_493 %1080
+OpStore %1084 %1452
+%1453 = OpLoad %ulong %1094
+%1454 = OpLoad %_struct_493 %1084
+%1455 = OpFunctionCall %ulong %5 %1453 %1454
+OpStore %1095 %1455
+OpBranch %1050
+%1050 = OpLabel
+%1456 = OpLoad %ulong %1095
+%1457 = OpLoad %ulong %1250
+%1458 = OpFunctionCall %ulong %19 %1456 %1457
+OpStore %1209 %1458
+%1459 = OpLoad %ulong %1209
+%1460 = OpLoad %ulong %1251
+%1461 = OpFunctionCall %ulong %19 %1459 %1460
+OpStore %1210 %1461
+%1462 = OpLoad %ulong %1210
+%1463 = OpLoad %ulong %1252
+%1464 = OpFunctionCall %ulong %19 %1462 %1463
+OpStore %1211 %1464
+%1465 = OpLoad %ulong %1211
+%1466 = OpLoad %ulong %1253
+%1467 = OpFunctionCall %ulong %19 %1465 %1466
+OpStore %1212 %1467
+%1468 = OpLoad %ulong %1212
+%1469 = OpLoad %ulong %1254
+%1470 = OpFunctionCall %ulong %19 %1468 %1469
+OpStore %1213 %1470
+%1471 = OpLoad %ulong %1213
+%1472 = OpLoad %ulong %1255
+%1473 = OpFunctionCall %ulong %19 %1471 %1472
+OpStore %1214 %1473
+OpBranch %1051
+%1051 = OpLabel
+OpBranch %1052
+%1052 = OpLabel
+%1474 = OpLoad %float %1089
+%1475 = OpBitcast %uint %1474
+OpStore %1215 %1475
+%1476 = OpLoad %uint %1215
+%1477 = OpUConvert %ulong %1476
+OpStore %1216 %1477
+%1478 = OpLoad %ulong %1214
+%1479 = OpLoad %ulong %1216
+%1480 = OpFunctionCall %ulong %19 %1478 %1479
+OpStore %1217 %1480
+OpBranch %1053
+%1053 = OpLabel
+%1481 = OpLoad %ulong %1217
+%1482 = OpLoad %ulong %1090
+%1483 = OpFunctionCall %ulong %19 %1481 %1482
+OpStore %1096 %1483
+%1484 = OpLoad %ulong %1237
+%1485 = OpIAdd %ulong %1484 %ulong_1
+OpStore %1097 %1485
+%1486 = OpLoad %ulong %1242
+%1488 = OpBitwiseXor %ulong %1486 %ulong_4294967295
+OpStore %1098 %1488
+OpBranch %1054
+%1054 = OpLabel
+%1489 = OpLoad %ulong %1096
+%1490 = OpLoad %ulong %1097
+%1491 = OpFunctionCall %ulong %19 %1489 %1490
+OpStore %1218 %1491
+%1492 = OpLoad %ulong %1218
+%1493 = OpLoad %ulong %1238
+%1494 = OpFunctionCall %ulong %19 %1492 %1493
+OpStore %1219 %1494
+%1495 = OpLoad %ulong %1219
+%1496 = OpLoad %ulong %1239
+%1497 = OpFunctionCall %ulong %19 %1495 %1496
+OpStore %1220 %1497
+%1498 = OpLoad %ulong %1220
+%1499 = OpLoad %ulong %1240
+%1500 = OpFunctionCall %ulong %19 %1498 %1499
+OpStore %1221 %1500
+%1501 = OpLoad %ulong %1221
+%1502 = OpLoad %ulong %1241
+%1503 = OpFunctionCall %ulong %19 %1501 %1502
+OpStore %1222 %1503
+%1504 = OpLoad %ulong %1222
+%1505 = OpLoad %ulong %1098
+%1506 = OpFunctionCall %ulong %19 %1504 %1505
+OpStore %1223 %1506
+OpBranch %1055
+%1055 = OpLabel
+OpBranch %1056
+%1056 = OpLabel
+%1507 = OpLoad %ulong %1223
+%1508 = OpLoad %ulong %1237
+%1509 = OpFunctionCall %ulong %19 %1507 %1508
+OpStore %1224 %1509
+%1510 = OpLoad %ulong %1224
+%1511 = OpLoad %ulong %1238
+%1512 = OpFunctionCall %ulong %19 %1510 %1511
+OpStore %1225 %1512
+%1513 = OpLoad %ulong %1225
+%1514 = OpLoad %ulong %1239
+%1515 = OpFunctionCall %ulong %19 %1513 %1514
+OpStore %1226 %1515
+%1516 = OpLoad %ulong %1226
+%1517 = OpLoad %ulong %1240
+%1518 = OpFunctionCall %ulong %19 %1516 %1517
+OpStore %1227 %1518
+%1519 = OpLoad %ulong %1227
+%1520 = OpLoad %ulong %1241
+%1521 = OpFunctionCall %ulong %19 %1519 %1520
+OpStore %1228 %1521
+%1522 = OpLoad %ulong %1228
+%1523 = OpLoad %ulong %1242
+%1524 = OpFunctionCall %ulong %19 %1522 %1523
+OpStore %1229 %1524
+OpBranch %1057
+%1057 = OpLabel
+%1525 = OpLoad %ulong %1229
+OpReturnValue %1525
+%1032 = OpLabel
+%1526 = OpLoad %ulong %1189
+%1527 = OpIMul %ulong %1526 %ulong_8
+OpStore %1182 %1527
+%1528 = OpLoad %ulong %1257
+%1529 = OpLoad %ulong %1182
+%1530 = OpShiftRightLogical %ulong %1528 %1529
+OpStore %1183 %1530
+%1531 = OpLoad %ulong %1183
+%1532 = OpBitwiseAnd %ulong %1531 %ulong_255
+OpStore %1184 %1532
+%1533 = OpLoad %ulong %1188
+%1534 = OpLoad %ulong %1184
+%1535 = OpBitwiseXor %ulong %1533 %1534
+OpStore %1185 %1535
+%1536 = OpLoad %ulong %1185
+%1537 = OpIMul %ulong %1536 %ulong_1099511628211
+OpStore %1186 %1537
+%1538 = OpLoad %ulong %1189
+%1539 = OpIAdd %ulong %1538 %ulong_1
+OpStore %1187 %1539
+%1540 = OpLoad %ulong %1186
+OpStore %1188 %1540
+%1541 = OpLoad %ulong %1187
+OpStore %1189 %1541
+OpBranch %1058
+%1027 = OpLabel
+%1542 = OpLoad %ulong %1180
+%1543 = OpIMul %ulong %1542 %ulong_8
+OpStore %1173 %1543
+%1544 = OpLoad %ulong %1256
+%1545 = OpLoad %ulong %1173
+%1546 = OpShiftRightLogical %ulong %1544 %1545
+OpStore %1174 %1546
+%1547 = OpLoad %ulong %1174
+%1548 = OpBitwiseAnd %ulong %1547 %ulong_255
+OpStore %1175 %1548
+%1549 = OpLoad %ulong %1179
+%1550 = OpLoad %ulong %1175
+%1551 = OpBitwiseXor %ulong %1549 %1550
+OpStore %1176 %1551
+%1552 = OpLoad %ulong %1176
+%1553 = OpIMul %ulong %1552 %ulong_1099511628211
+OpStore %1177 %1553
+%1554 = OpLoad %ulong %1180
+%1555 = OpIAdd %ulong %1554 %ulong_1
+OpStore %1178 %1555
+%1556 = OpLoad %ulong %1177
+OpStore %1179 %1556
+%1557 = OpLoad %ulong %1178
+OpStore %1180 %1557
+OpBranch %1059
+%1018 = OpLabel
+%1558 = OpLoad %ulong %1167
+%1559 = OpIMul %ulong %1558 %ulong_8
+OpStore %1160 %1559
+%1560 = OpLoad %ulong %1158
+%1561 = OpLoad %ulong %1160
+%1562 = OpShiftRightLogical %ulong %1560 %1561
+OpStore %1161 %1562
+%1563 = OpLoad %ulong %1161
+%1564 = OpBitwiseAnd %ulong %1563 %ulong_255
+OpStore %1162 %1564
+%1565 = OpLoad %ulong %1166
+%1566 = OpLoad %ulong %1162
+%1567 = OpBitwiseXor %ulong %1565 %1566
+OpStore %1163 %1567
+%1568 = OpLoad %ulong %1163
+%1569 = OpIMul %ulong %1568 %ulong_1099511628211
+OpStore %1164 %1569
+%1570 = OpLoad %ulong %1167
+%1571 = OpIAdd %ulong %1570 %ulong_1
+OpStore %1165 %1571
+%1572 = OpLoad %ulong %1164
+OpStore %1166 %1572
+%1573 = OpLoad %ulong %1165
+OpStore %1167 %1573
+OpBranch %1060
+%1011 = OpLabel
+%1574 = OpLoad %ulong %1157
+%1575 = OpIMul %ulong %1574 %ulong_8
+OpStore %1150 %1575
+%1576 = OpLoad %ulong %1148
+%1577 = OpLoad %ulong %1150
+%1578 = OpShiftRightLogical %ulong %1576 %1577
+OpStore %1151 %1578
+%1579 = OpLoad %ulong %1151
+%1580 = OpBitwiseAnd %ulong %1579 %ulong_255
+OpStore %1152 %1580
+%1581 = OpLoad %ulong %1156
+%1582 = OpLoad %ulong %1152
+%1583 = OpBitwiseXor %ulong %1581 %1582
+OpStore %1153 %1583
+%1584 = OpLoad %ulong %1153
+%1585 = OpIMul %ulong %1584 %ulong_1099511628211
+OpStore %1154 %1585
+%1586 = OpLoad %ulong %1157
+%1587 = OpIAdd %ulong %1586 %ulong_1
+OpStore %1155 %1587
+%1588 = OpLoad %ulong %1154
+OpStore %1156 %1588
+%1589 = OpLoad %ulong %1155
+OpStore %1157 %1589
+OpBranch %1061
+%1004 = OpLabel
+%1590 = OpLoad %ulong %1147
+%1591 = OpIMul %ulong %1590 %ulong_8
+OpStore %1140 %1591
+%1592 = OpLoad %ulong %1138
+%1593 = OpLoad %ulong %1140
+%1594 = OpShiftRightLogical %ulong %1592 %1593
+OpStore %1141 %1594
+%1595 = OpLoad %ulong %1141
+%1596 = OpBitwiseAnd %ulong %1595 %ulong_255
+OpStore %1142 %1596
+%1597 = OpLoad %ulong %1146
+%1598 = OpLoad %ulong %1142
+%1599 = OpBitwiseXor %ulong %1597 %1598
+OpStore %1143 %1599
+%1600 = OpLoad %ulong %1143
+%1601 = OpIMul %ulong %1600 %ulong_1099511628211
+OpStore %1144 %1601
+%1602 = OpLoad %ulong %1147
+%1603 = OpIAdd %ulong %1602 %ulong_1
+OpStore %1145 %1603
+%1604 = OpLoad %ulong %1144
+OpStore %1146 %1604
+%1605 = OpLoad %ulong %1145
+OpStore %1147 %1605
+OpBranch %1062
+%997 = OpLabel
+%1606 = OpLoad %ulong %1137
+%1607 = OpIMul %ulong %1606 %ulong_8
+OpStore %1130 %1607
+%1608 = OpLoad %ulong %1233
+%1609 = OpLoad %ulong %1130
+%1610 = OpShiftRightLogical %ulong %1608 %1609
+OpStore %1131 %1610
+%1611 = OpLoad %ulong %1131
+%1612 = OpBitwiseAnd %ulong %1611 %ulong_255
+OpStore %1132 %1612
+%1613 = OpLoad %ulong %1136
+%1614 = OpLoad %ulong %1132
+%1615 = OpBitwiseXor %ulong %1613 %1614
+OpStore %1133 %1615
+%1616 = OpLoad %ulong %1133
+%1617 = OpIMul %ulong %1616 %ulong_1099511628211
+OpStore %1134 %1617
+%1618 = OpLoad %ulong %1137
+%1619 = OpIAdd %ulong %1618 %ulong_1
+OpStore %1135 %1619
+%1620 = OpLoad %ulong %1134
+OpStore %1136 %1620
+%1621 = OpLoad %ulong %1135
+OpStore %1137 %1621
+OpBranch %1063
+%990 = OpLabel
+%1622 = OpLoad %ulong %1128
+%1623 = OpIMul %ulong %1622 %ulong_8
+OpStore %1121 %1623
+%1624 = OpLoad %ulong %1119
+%1625 = OpLoad %ulong %1121
+%1626 = OpShiftRightLogical %ulong %1624 %1625
+OpStore %1122 %1626
+%1627 = OpLoad %ulong %1122
+%1628 = OpBitwiseAnd %ulong %1627 %ulong_255
+OpStore %1123 %1628
+%1629 = OpLoad %ulong %1127
+%1630 = OpLoad %ulong %1123
+%1631 = OpBitwiseXor %ulong %1629 %1630
+OpStore %1124 %1631
+%1632 = OpLoad %ulong %1124
+%1633 = OpIMul %ulong %1632 %ulong_1099511628211
+OpStore %1125 %1633
+%1634 = OpLoad %ulong %1128
+%1635 = OpIAdd %ulong %1634 %ulong_1
+OpStore %1126 %1635
+%1636 = OpLoad %ulong %1125
+OpStore %1127 %1636
+%1637 = OpLoad %ulong %1126
+OpStore %1128 %1637
+OpBranch %1064
+%983 = OpLabel
+%1638 = OpLoad %ulong %1118
+%1639 = OpIMul %ulong %1638 %ulong_8
+OpStore %1111 %1639
+%1640 = OpLoad %ulong %1109
+%1641 = OpLoad %ulong %1111
+%1642 = OpShiftRightLogical %ulong %1640 %1641
+OpStore %1112 %1642
+%1643 = OpLoad %ulong %1112
+%1644 = OpBitwiseAnd %ulong %1643 %ulong_255
+OpStore %1113 %1644
+%1645 = OpLoad %ulong %1117
+%1646 = OpLoad %ulong %1113
+%1647 = OpBitwiseXor %ulong %1645 %1646
+OpStore %1114 %1647
+%1648 = OpLoad %ulong %1114
+%1649 = OpIMul %ulong %1648 %ulong_1099511628211
+OpStore %1115 %1649
+%1650 = OpLoad %ulong %1118
+%1651 = OpIAdd %ulong %1650 %ulong_1
+OpStore %1116 %1651
+%1652 = OpLoad %ulong %1115
+OpStore %1117 %1652
+%1653 = OpLoad %ulong %1116
+OpStore %1118 %1653
+OpBranch %1065
+%976 = OpLabel
+%1654 = OpLoad %ulong %1108
+%1655 = OpIMul %ulong %1654 %ulong_8
+OpStore %1101 %1655
+%1656 = OpLoad %ulong %1099
+%1657 = OpLoad %ulong %1101
+%1658 = OpShiftRightLogical %ulong %1656 %1657
+OpStore %1102 %1658
+%1659 = OpLoad %ulong %1102
+%1660 = OpBitwiseAnd %ulong %1659 %ulong_255
+OpStore %1103 %1660
+%1661 = OpLoad %ulong %1107
+%1662 = OpLoad %ulong %1103
+%1663 = OpBitwiseXor %ulong %1661 %1662
+OpStore %1104 %1663
+%1664 = OpLoad %ulong %1104
+%1665 = OpIMul %ulong %1664 %ulong_1099511628211
+OpStore %1105 %1665
+%1666 = OpLoad %ulong %1108
+%1667 = OpIAdd %ulong %1666 %ulong_1
+OpStore %1106 %1667
+%1668 = OpLoad %ulong %1105
+OpStore %1107 %1668
+%1669 = OpLoad %ulong %1106
+OpStore %1108 %1669
+OpBranch %1066
+%1058 = OpLabel
+OpBranch %1031
+%1059 = OpLabel
+OpBranch %1026
+%1060 = OpLabel
+OpBranch %1017
+%1061 = OpLabel
+OpBranch %1010
+%1062 = OpLabel
+OpBranch %1003
+%1063 = OpLabel
+OpBranch %996
+%1064 = OpLabel
+OpBranch %989
+%1065 = OpLabel
+OpBranch %982
+%1066 = OpLabel
+OpBranch %975
+OpFunctionEnd
+%11 = OpFunction %_struct_41 None %1670
+%1671 = OpFunctionParameter %ulong
+%1672 = OpLabel
+%1673 = OpVariable %_ptr_Function__struct_41 Function
+%1674 = OpVariable %_ptr_Function_ulong Function
+%1675 = OpVariable %_ptr_Function_ulong Function
+%1676 = OpVariable %_ptr_Function_ulong Function
+%1677 = OpVariable %_ptr_Function_ulong Function
+OpStore %1674 %1671
+%1678 = OpAccessChain %_ptr_Function_ulong %1673 %uint_0
+%1679 = OpLoad %ulong %1674
+OpStore %1678 %1679
+%1680 = OpLoad %ulong %1674
+%1682 = OpIMul %ulong %1680 %ulong_3
+OpStore %1675 %1682
+%1683 = OpLoad %ulong %1675
+%1684 = OpIAdd %ulong %1683 %ulong_1
+OpStore %1676 %1684
+%1685 = OpAccessChain %_ptr_Function_ulong %1673 %uint_1
+%1686 = OpLoad %ulong %1676
 OpStore %1685 %1686
-%1687 = OpLoad %ulong %1196
-%1688 = OpNot %ulong %1687
-OpStore %1292 %1688
-%1689 = OpAccessChain %_ptr_Function_ulong %1165 %uint_1
-%1690 = OpLoad %ulong %1292
-OpStore %1689 %1690
-%1691 = OpAccessChain %_ptr_Function__struct_187 %1163 %uint_1
-%1692 = OpLoad %_struct_187 %1165
-OpStore %1691 %1692
-OpBranch %1129
-%1129 = OpLabel
-%1694 = OpAccessChain %_ptr_Function_ulong %1154 %uint_7
-%1695 = OpLoad %ulong %1694
-OpStore %1197 %1695
-%1696 = OpLoad %ulong %1197
-%1697 = OpBitwiseAnd %ulong %1696 %ulong_1023
-OpStore %1198 %1697
-%1698 = OpLoad %ulong %1198
-%1699 = OpConvertUToF %double %1698
-OpStore %1199 %1699
-%1701 = OpAccessChain %_ptr_Function_ulong %1154 %uint_8
-%1702 = OpLoad %ulong %1701
-OpStore %1200 %1702
-OpBranch %1132
-%1132 = OpLabel
-%1703 = OpAccessChain %_ptr_Function_ulong %1169 %uint_0
-%1704 = OpLoad %ulong %1200
-OpStore %1703 %1704
-%1705 = OpLoad %ulong %1200
-%1706 = OpIAdd %ulong %1705 %ulong_1
-OpStore %1296 %1706
-%1707 = OpAccessChain %_ptr_Function_ulong %1169 %uint_1
-%1708 = OpLoad %ulong %1296
-OpStore %1707 %1708
-%1709 = OpLoad %ulong %1200
-%1710 = OpIAdd %ulong %1709 %ulong_2
-OpStore %1297 %1710
-%1711 = OpAccessChain %_ptr_Function_ulong %1169 %uint_2
-%1712 = OpLoad %ulong %1297
-OpStore %1711 %1712
-%1713 = OpLoad %ulong %1200
-%1714 = OpIMul %ulong %1713 %ulong_9
-OpStore %1298 %1714
-%1715 = OpAccessChain %_ptr_Function_ulong %1169 %uint_3
-%1716 = OpLoad %ulong %1298
+%1687 = OpLoad %ulong %1674
+%1689 = OpBitwiseXor %ulong %1687 %ulong_305419896
+OpStore %1677 %1689
+%1690 = OpAccessChain %_ptr_Function_ulong %1673 %uint_2
+%1691 = OpLoad %ulong %1677
+OpStore %1690 %1691
+%1692 = OpLoad %_struct_41 %1673
+OpReturnValue %1692
+OpFunctionEnd
+%12 = OpFunction %_struct_176 None %1693
+%1694 = OpFunctionParameter %ulong
+%1695 = OpLabel
+%1696 = OpVariable %_ptr_Function__struct_176 Function
+%1697 = OpVariable %_ptr_Function_ulong Function
+%1698 = OpVariable %_ptr_Function_ulong Function
+%1699 = OpVariable %_ptr_Function_double Function
+%1700 = OpVariable %_ptr_Function_double Function
+%1701 = OpVariable %_ptr_Function_ulong Function
+%1702 = OpVariable %_ptr_Function_double Function
+%1703 = OpVariable %_ptr_Function_double Function
+%1704 = OpVariable %_ptr_Function_ulong Function
+%1705 = OpVariable %_ptr_Function_double Function
+%1706 = OpVariable %_ptr_Function_double Function
+OpStore %1697 %1694
+%1707 = OpLoad %ulong %1697
+%1709 = OpBitwiseAnd %ulong %1707 %ulong_65535
+OpStore %1698 %1709
+%1710 = OpLoad %ulong %1698
+%1711 = OpConvertUToF %double %1710
+OpStore %1699 %1711
+%1712 = OpLoad %double %1699
+%1714 = OpFDiv %double %1712 %double_8
+OpStore %1700 %1714
+%1715 = OpAccessChain %_ptr_Function_double %1696 %uint_0
+%1716 = OpLoad %double %1700
 OpStore %1715 %1716
-%1717 = OpLoad %ulong %1200
-%1718 = OpNot %ulong %1717
-OpStore %1299 %1718
-%1719 = OpAccessChain %_ptr_Function_ulong %1169 %uint_4
-%1720 = OpLoad %ulong %1299
-OpStore %1719 %1720
-%1721 = OpLoad %ulong %1200
-%1722 = OpBitwiseXor %ulong %1721 %ulong_2863311530
-OpStore %1300 %1722
-%1723 = OpAccessChain %_ptr_Function_ulong %1169 %uint_5
-%1724 = OpLoad %ulong %1300
-OpStore %1723 %1724
-OpBranch %1133
-%1133 = OpLabel
-%1726 = OpAccessChain %_ptr_Function_ulong %1154 %uint_9
-%1727 = OpLoad %ulong %1726
-OpStore %1201 %1727
-%1728 = OpLoad %ulong %1201
-%1729 = OpFunctionCall %_struct_281 %17 %1728
-OpStore %1170 %1729
-%1730 = OpAccessChain %_ptr_Function_ulong %1154 %uint_10
-%1731 = OpLoad %ulong %1730
-OpStore %1202 %1731
-OpBranch %1136
-%1136 = OpLabel
-%1732 = OpAccessChain %_ptr_Function_ulong %1173 %uint_0
-%1733 = OpLoad %ulong %1202
-OpStore %1732 %1733
-%1734 = OpLoad %ulong %1202
-%1735 = OpIMul %ulong %1734 %ulong_3
-OpStore %1306 %1735
-%1736 = OpLoad %ulong %1306
-%1737 = OpIAdd %ulong %1736 %ulong_1
-OpStore %1307 %1737
-%1738 = OpAccessChain %_ptr_Function_ulong %1173 %uint_1
-%1739 = OpLoad %ulong %1307
-OpStore %1738 %1739
-%1740 = OpLoad %ulong %1202
-%1741 = OpBitwiseXor %ulong %1740 %ulong_305419896
-OpStore %1308 %1741
-%1742 = OpAccessChain %_ptr_Function_ulong %1173 %uint_2
-%1743 = OpLoad %ulong %1308
-OpStore %1742 %1743
-OpBranch %1137
-%1137 = OpLabel
-%1744 = OpAccessChain %_ptr_Function_ulong %1154 %uint_11
-%1745 = OpLoad %ulong %1744
-OpStore %1203 %1745
-OpBranch %1140
-%1140 = OpLabel
-%1746 = OpAccessChain %_ptr_Function_ulong %1175 %uint_0
-%1747 = OpLoad %ulong %1203
-OpStore %1746 %1747
-%1748 = OpLoad %ulong %1203
-%1749 = OpNot %ulong %1748
-OpStore %1312 %1749
-%1750 = OpAccessChain %_ptr_Function_ulong %1175 %uint_1
-%1751 = OpLoad %ulong %1312
-OpStore %1750 %1751
-%1752 = OpLoad %ulong %1203
-%1753 = OpIMul %ulong %1752 %ulong_5
-OpStore %1313 %1753
-%1754 = OpAccessChain %_ptr_Function_ulong %1175 %uint_2
-%1755 = OpLoad %ulong %1313
-OpStore %1754 %1755
-%1756 = OpLoad %ulong %1203
-%1757 = OpShiftRightLogical %ulong %1756 %ulong_3
-OpStore %1314 %1757
-%1758 = OpAccessChain %_ptr_Function_ulong %1175 %uint_3
-%1759 = OpLoad %ulong %1314
-OpStore %1758 %1759
-OpBranch %1141
-%1141 = OpLabel
-%1760 = OpAccessChain %_ptr_Function_ulong %1154 %uint_0
-%1761 = OpLoad %ulong %1760
-OpStore %1204 %1761
-OpBranch %1144
-%1144 = OpLabel
-%1762 = OpAccessChain %_ptr_Function_ulong %1177 %uint_0
-%1763 = OpLoad %ulong %1204
-OpStore %1762 %1763
-%1764 = OpLoad %ulong %1204
-%1765 = OpIAdd %ulong %1764 %ulong_1
-OpStore %1318 %1765
-%1766 = OpAccessChain %_ptr_Function_ulong %1177 %uint_1
-%1767 = OpLoad %ulong %1318
-OpStore %1766 %1767
-%1768 = OpLoad %ulong %1204
-%1769 = OpIAdd %ulong %1768 %ulong_2
-OpStore %1319 %1769
-%1770 = OpAccessChain %_ptr_Function_ulong %1177 %uint_2
-%1771 = OpLoad %ulong %1319
-OpStore %1770 %1771
-%1772 = OpLoad %ulong %1204
-%1773 = OpIMul %ulong %1772 %ulong_9
-OpStore %1320 %1773
-%1774 = OpAccessChain %_ptr_Function_ulong %1177 %uint_3
-%1775 = OpLoad %ulong %1320
-OpStore %1774 %1775
-%1776 = OpLoad %ulong %1204
-%1777 = OpNot %ulong %1776
-OpStore %1321 %1777
-%1778 = OpAccessChain %_ptr_Function_ulong %1177 %uint_4
-%1779 = OpLoad %ulong %1321
-OpStore %1778 %1779
-%1780 = OpLoad %ulong %1204
-%1781 = OpBitwiseXor %ulong %1780 %ulong_2863311530
-OpStore %1322 %1781
-%1782 = OpAccessChain %_ptr_Function_ulong %1177 %uint_5
-%1783 = OpLoad %ulong %1322
-OpStore %1782 %1783
-OpBranch %1145
-%1145 = OpLabel
-%1784 = OpAccessChain %_ptr_Function_ulong %1154 %uint_1
-%1785 = OpLoad %ulong %1784
-OpStore %1205 %1785
-%1786 = OpLoad %ulong %1205
-%1787 = OpBitwiseAnd %ulong %1786 %ulong_255
-OpStore %1206 %1787
-%1788 = OpLoad %ulong %1206
-%1789 = OpConvertUToF %float %1788
-OpStore %1207 %1789
-%1790 = OpAccessChain %_ptr_Function_ulong %1154 %uint_2
-%1791 = OpLoad %ulong %1790
-OpStore %1208 %1791
-%1792 = OpLoad %ulong %1188
-%1793 = OpLoad %_struct_45 %1155
-%1794 = OpLoad %_struct_80 %1157
-%1795 = OpLoad %_struct_111 %1159
-%1796 = OpLoad %uint %1193
-%1797 = OpLoad %_struct_150 %1161
-%1798 = OpLoad %_struct_188 %1163
-%1799 = OpLoad %double %1199
-%1800 = OpLoad %_struct_228 %1169
-%1801 = OpLoad %_struct_281 %1170
-%1802 = OpLoad %_struct_45 %1173
-%1803 = OpLoad %_struct_150 %1175
-%1804 = OpLoad %_struct_228 %1177
-%1805 = OpLoad %float %1207
-%1806 = OpLoad %ulong %1208
-%1807 = OpFunctionCall %ulong %10 %1792 %1793 %1794 %1795 %1796 %1797 %1798 %1799 %1800 %1801 %1802 %1803 %1804 %1805 %1806
-OpStore %1209 %1807
-%1808 = OpLoad %ulong %1224
-%1809 = OpLoad %ulong %1209
-%1810 = OpFunctionCall %ulong %20 %1808 %1809
-OpStore %1210 %1810
-%1811 = OpLoad %ulong %1227
-%1812 = OpIAdd %ulong %1811 %ulong_1
-OpStore %1211 %1812
-%1813 = OpLoad %ulong %1210
-OpStore %1224 %1813
-%1814 = OpLoad %ulong %1209
-OpStore %1226 %1814
-%1815 = OpLoad %ulong %1211
-OpStore %1227 %1815
-OpBranch %1148
-%1103 = OpLabel
-OpBranch %1110
-%1110 = OpLabel
-%1816 = OpLoad %ulong %1225
-%1817 = OpIMul %ulong %1816 %ulong_6364136223846793005
-OpStore %1245 %1817
-%1818 = OpLoad %ulong %1245
-%1819 = OpIAdd %ulong %1818 %ulong_1442695040888963407
-OpStore %1246 %1819
-%1820 = OpLoad %ulong %1246
-%1821 = OpLoad %ulong %1179
-%1822 = OpIAdd %ulong %1820 %1821
-OpStore %1247 %1822
-OpBranch %1111
-%1111 = OpLabel
-%1823 = OpLoad %ulong %1225
-%1824 = OpAccessChain %_ptr_Function_ulong %1154 %1823
-%1825 = OpLoad %ulong %1247
+%1717 = OpLoad %ulong %1697
+%1719 = OpBitwiseAnd %ulong %1717 %ulong_4095
+OpStore %1701 %1719
+%1720 = OpLoad %ulong %1701
+%1721 = OpConvertUToF %double %1720
+OpStore %1702 %1721
+%1722 = OpLoad %double %1702
+%1724 = OpFSub %double %1722 %double_2048
+OpStore %1703 %1724
+%1725 = OpAccessChain %_ptr_Function_double %1696 %uint_1
+%1726 = OpLoad %double %1703
+OpStore %1725 %1726
+%1727 = OpLoad %ulong %1697
+%1729 = OpBitwiseAnd %ulong %1727 %ulong_262143
+OpStore %1704 %1729
+%1730 = OpLoad %ulong %1704
+%1731 = OpConvertUToF %double %1730
+OpStore %1705 %1731
+%1732 = OpLoad %double %1705
+%1734 = OpFDiv %double %1732 %double_64
+OpStore %1706 %1734
+%1735 = OpAccessChain %_ptr_Function_double %1696 %uint_2
+%1736 = OpLoad %double %1706
+OpStore %1735 %1736
+%1737 = OpLoad %_struct_176 %1696
+OpReturnValue %1737
+OpFunctionEnd
+%13 = OpFunction %_struct_315 None %1738
+%1739 = OpFunctionParameter %ulong
+%1740 = OpLabel
+%1741 = OpVariable %_ptr_Function__struct_315 Function
+%1742 = OpVariable %_ptr_Function_ulong Function
+%1743 = OpVariable %_ptr_Function_ulong Function
+%1744 = OpVariable %_ptr_Function_double Function
+%1745 = OpVariable %_ptr_Function_double Function
+%1746 = OpVariable %_ptr_Function_uint Function
+%1747 = OpVariable %_ptr_Function_ulong Function
+%1748 = OpVariable %_ptr_Function_uint Function
+OpStore %1742 %1739
+%1749 = OpAccessChain %_ptr_Function_ulong %1741 %uint_0
+%1750 = OpLoad %ulong %1742
+OpStore %1749 %1750
+%1751 = OpLoad %ulong %1742
+%1753 = OpBitwiseAnd %ulong %1751 %ulong_32767
+OpStore %1743 %1753
+%1754 = OpLoad %ulong %1743
+%1755 = OpConvertUToF %double %1754
+OpStore %1744 %1755
+%1756 = OpLoad %double %1744
+%1758 = OpFDiv %double %1756 %double_4
+OpStore %1745 %1758
+%1759 = OpAccessChain %_ptr_Function_double %1741 %uint_1
+%1760 = OpLoad %double %1745
+OpStore %1759 %1760
+%1761 = OpLoad %ulong %1742
+%1762 = OpUConvert %uint %1761
+OpStore %1746 %1762
+%1763 = OpAccessChain %_ptr_Function_uint %1741 %uint_2
+%1764 = OpLoad %uint %1746
+OpStore %1763 %1764
+%1765 = OpLoad %ulong %1742
+%1766 = OpShiftRightLogical %ulong %1765 %ulong_32
+OpStore %1747 %1766
+%1767 = OpLoad %ulong %1747
+%1768 = OpUConvert %uint %1767
+OpStore %1748 %1768
+%1769 = OpAccessChain %_ptr_Function_uint %1741 %uint_3
+%1770 = OpLoad %uint %1748
+OpStore %1769 %1770
+%1771 = OpLoad %_struct_315 %1741
+OpReturnValue %1771
+OpFunctionEnd
+%14 = OpFunction %_struct_493 None %1772
+%1773 = OpFunctionParameter %ulong
+%1774 = OpLabel
+%1775 = OpVariable %_ptr_Function__struct_493 Function
+%1776 = OpVariable %_ptr_Function_ulong Function
+%1777 = OpVariable %_ptr_Function_ulong Function
+%1778 = OpVariable %_ptr_Function_ulong Function
+%1779 = OpVariable %_ptr_Function_ulong Function
+OpStore %1776 %1773
+%1780 = OpAccessChain %_ptr_Function_ulong %1775 %uint_0
+%1781 = OpLoad %ulong %1776
+OpStore %1780 %1781
+%1782 = OpLoad %ulong %1776
+%1783 = OpNot %ulong %1782
+OpStore %1777 %1783
+%1784 = OpAccessChain %_ptr_Function_ulong %1775 %uint_1
+%1785 = OpLoad %ulong %1777
+OpStore %1784 %1785
+%1786 = OpLoad %ulong %1776
+%1788 = OpIMul %ulong %1786 %ulong_5
+OpStore %1778 %1788
+%1789 = OpAccessChain %_ptr_Function_ulong %1775 %uint_2
+%1790 = OpLoad %ulong %1778
+OpStore %1789 %1790
+%1791 = OpLoad %ulong %1776
+%1792 = OpShiftRightLogical %ulong %1791 %ulong_3
+OpStore %1779 %1792
+%1793 = OpAccessChain %_ptr_Function_ulong %1775 %uint_3
+%1794 = OpLoad %ulong %1779
+OpStore %1793 %1794
+%1795 = OpLoad %_struct_493 %1775
+OpReturnValue %1795
+OpFunctionEnd
+%15 = OpFunction %_struct_655 None %1796
+%1797 = OpFunctionParameter %ulong
+%1798 = OpLabel
+%1799 = OpVariable %_ptr_Function__struct_655 Function
+%1800 = OpVariable %_ptr_Function__struct_654 Function
+%1801 = OpVariable %_ptr_Function__struct_654 Function
+%1802 = OpVariable %_ptr_Function_ulong Function
+%1803 = OpVariable %_ptr_Function_ulong Function
+%1804 = OpVariable %_ptr_Function_ulong Function
+%1805 = OpVariable %_ptr_Function_ulong Function
+OpStore %1802 %1797
+%1806 = OpAccessChain %_ptr_Function_ulong %1800 %uint_0
+%1807 = OpLoad %ulong %1802
+OpStore %1806 %1807
+%1808 = OpLoad %ulong %1802
+%1810 = OpIAdd %ulong %1808 %ulong_11
+OpStore %1803 %1810
+%1811 = OpAccessChain %_ptr_Function_ulong %1800 %uint_1
+%1812 = OpLoad %ulong %1803
+OpStore %1811 %1812
+%1813 = OpAccessChain %_ptr_Function__struct_654 %1799 %uint_0
+%1814 = OpLoad %_struct_654 %1800
+OpStore %1813 %1814
+%1815 = OpLoad %ulong %1802
+%1817 = OpIMul %ulong %1815 %ulong_7
+OpStore %1804 %1817
+%1818 = OpAccessChain %_ptr_Function_ulong %1801 %uint_0
+%1819 = OpLoad %ulong %1804
+OpStore %1818 %1819
+%1820 = OpLoad %ulong %1802
+%1821 = OpNot %ulong %1820
+OpStore %1805 %1821
+%1822 = OpAccessChain %_ptr_Function_ulong %1801 %uint_1
+%1823 = OpLoad %ulong %1805
+OpStore %1822 %1823
+%1824 = OpAccessChain %_ptr_Function__struct_654 %1799 %uint_1
+%1825 = OpLoad %_struct_654 %1801
 OpStore %1824 %1825
-%1826 = OpLoad %ulong %1225
-%1827 = OpIAdd %ulong %1826 %ulong_1
-OpStore %1183 %1827
-%1828 = OpLoad %ulong %1183
-OpStore %1225 %1828
-OpBranch %1149
-%1148 = OpLabel
-OpBranch %1105
-%1149 = OpLabel
-OpBranch %1102
+%1826 = OpLoad %_struct_655 %1799
+OpReturnValue %1826
 OpFunctionEnd
-%19 = OpFunction %ulong None %1829
-%1830 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%16 = OpFunction %_struct_757 None %1827
+%1828 = OpFunctionParameter %ulong
+%1829 = OpLabel
+%1830 = OpVariable %_ptr_Function__struct_757 Function
+%1831 = OpVariable %_ptr_Function_ulong Function
+%1832 = OpVariable %_ptr_Function_ulong Function
+%1833 = OpVariable %_ptr_Function_ulong Function
+%1834 = OpVariable %_ptr_Function_ulong Function
+%1835 = OpVariable %_ptr_Function_ulong Function
+%1836 = OpVariable %_ptr_Function_ulong Function
+OpStore %1831 %1828
+%1837 = OpAccessChain %_ptr_Function_ulong %1830 %uint_0
+%1838 = OpLoad %ulong %1831
+OpStore %1837 %1838
+%1839 = OpLoad %ulong %1831
+%1840 = OpIAdd %ulong %1839 %ulong_1
+OpStore %1832 %1840
+%1841 = OpAccessChain %_ptr_Function_ulong %1830 %uint_1
+%1842 = OpLoad %ulong %1832
+OpStore %1841 %1842
+%1843 = OpLoad %ulong %1831
+%1845 = OpIAdd %ulong %1843 %ulong_2
+OpStore %1833 %1845
+%1846 = OpAccessChain %_ptr_Function_ulong %1830 %uint_2
+%1847 = OpLoad %ulong %1833
+OpStore %1846 %1847
+%1848 = OpLoad %ulong %1831
+%1850 = OpIMul %ulong %1848 %ulong_9
+OpStore %1834 %1850
+%1851 = OpAccessChain %_ptr_Function_ulong %1830 %uint_3
+%1852 = OpLoad %ulong %1834
+OpStore %1851 %1852
+%1853 = OpLoad %ulong %1831
+%1854 = OpNot %ulong %1853
+OpStore %1835 %1854
+%1855 = OpAccessChain %_ptr_Function_ulong %1830 %uint_4
+%1856 = OpLoad %ulong %1835
+OpStore %1855 %1856
+%1857 = OpLoad %ulong %1831
+%1859 = OpBitwiseXor %ulong %1857 %ulong_2863311530
+OpStore %1836 %1859
+%1860 = OpAccessChain %_ptr_Function_ulong %1830 %uint_5
+%1861 = OpLoad %ulong %1836
+OpStore %1860 %1861
+%1862 = OpLoad %_struct_757 %1830
+OpReturnValue %1862
 OpFunctionEnd
-%20 = OpFunction %ulong None %25
-%1832 = OpFunctionParameter %ulong
-%1833 = OpFunctionParameter %ulong
-%1834 = OpLabel
-%1839 = OpVariable %_ptr_Function_ulong Function
-%1840 = OpVariable %_ptr_Function_ulong Function
-%1841 = OpVariable %_ptr_Function_bool Function
-%1842 = OpVariable %_ptr_Function_ulong Function
-%1843 = OpVariable %_ptr_Function_ulong Function
-%1844 = OpVariable %_ptr_Function_ulong Function
-%1845 = OpVariable %_ptr_Function_ulong Function
-%1846 = OpVariable %_ptr_Function_ulong Function
-%1847 = OpVariable %_ptr_Function_ulong Function
-%1848 = OpVariable %_ptr_Function_ulong Function
-%1849 = OpVariable %_ptr_Function_ulong Function
-OpStore %1839 %1832
-OpStore %1840 %1833
-%1850 = OpLoad %ulong %1839
-OpStore %1848 %1850
-OpStore %1849 %ulong_0
-OpBranch %1835
-%1835 = OpLabel
-%1851 = OpLoad %ulong %1849
-%1852 = OpULessThan %bool %1851 %ulong_8
-OpStore %1841 %1852
-%1853 = OpLoad %bool %1841
-OpLoopMerge %1837 %1838 None
-OpBranchConditional %1853 %1836 %1837
-%1837 = OpLabel
-%1854 = OpLoad %ulong %1848
-OpReturnValue %1854
-%1836 = OpLabel
-%1855 = OpLoad %ulong %1849
-%1856 = OpIMul %ulong %1855 %ulong_8
-OpStore %1842 %1856
-%1857 = OpLoad %ulong %1840
-%1858 = OpLoad %ulong %1842
-%1859 = OpShiftRightLogical %ulong %1857 %1858
-OpStore %1843 %1859
-%1860 = OpLoad %ulong %1843
-%1861 = OpBitwiseAnd %ulong %1860 %ulong_255
-OpStore %1844 %1861
-%1862 = OpLoad %ulong %1848
-%1863 = OpLoad %ulong %1844
-%1864 = OpBitwiseXor %ulong %1862 %1863
-OpStore %1845 %1864
-%1865 = OpLoad %ulong %1845
-%1867 = OpIMul %ulong %1865 %ulong_1099511628211
-OpStore %1846 %1867
-%1868 = OpLoad %ulong %1849
-%1869 = OpIAdd %ulong %1868 %ulong_1
-OpStore %1847 %1869
-%1870 = OpLoad %ulong %1846
-OpStore %1848 %1870
-%1871 = OpLoad %ulong %1847
-OpStore %1849 %1871
-OpBranch %1838
-%1838 = OpLabel
-OpBranch %1835
+%17 = OpFunction %_struct_810 None %1863
+%1864 = OpFunctionParameter %ulong
+%1865 = OpLabel
+%1866 = OpVariable %_ptr_Function__struct_810 Function
+%1867 = OpVariable %_ptr_Function_ulong Function
+%1868 = OpVariable %_ptr_Function_ulong Function
+%1869 = OpVariable %_ptr_Function_double Function
+%1870 = OpVariable %_ptr_Function_double Function
+%1871 = OpVariable %_ptr_Function_uint Function
+%1872 = OpVariable %_ptr_Function_ulong Function
+%1873 = OpVariable %_ptr_Function_uint Function
+%1874 = OpVariable %_ptr_Function_ulong Function
+%1875 = OpVariable %_ptr_Function_double Function
+%1876 = OpVariable %_ptr_Function_double Function
+%1877 = OpVariable %_ptr_Function_ulong Function
+%1878 = OpVariable %_ptr_Function_ulong Function
+OpStore %1867 %1864
+%1879 = OpAccessChain %_ptr_Function_ulong %1866 %uint_0
+%1880 = OpLoad %ulong %1867
+OpStore %1879 %1880
+%1881 = OpLoad %ulong %1867
+%1883 = OpBitwiseAnd %ulong %1881 %ulong_8191
+OpStore %1868 %1883
+%1884 = OpLoad %ulong %1868
+%1885 = OpConvertUToF %double %1884
+OpStore %1869 %1885
+%1886 = OpLoad %double %1869
+%1888 = OpFDiv %double %1886 %double_2
+OpStore %1870 %1888
+%1889 = OpAccessChain %_ptr_Function_double %1866 %uint_1
+%1890 = OpLoad %double %1870
+OpStore %1889 %1890
+%1891 = OpLoad %ulong %1867
+%1892 = OpUConvert %uint %1891
+OpStore %1871 %1892
+%1893 = OpAccessChain %_ptr_Function_uint %1866 %uint_2
+%1894 = OpLoad %uint %1871
+OpStore %1893 %1894
+%1895 = OpLoad %ulong %1867
+%1896 = OpShiftRightLogical %ulong %1895 %ulong_16
+OpStore %1872 %1896
+%1897 = OpLoad %ulong %1872
+%1898 = OpUConvert %uint %1897
+OpStore %1873 %1898
+%1899 = OpAccessChain %_ptr_Function_uint %1866 %uint_3
+%1900 = OpLoad %uint %1873
+OpStore %1899 %1900
+%1901 = OpLoad %ulong %1867
+%1903 = OpBitwiseAnd %ulong %1901 %ulong_131071
+OpStore %1874 %1903
+%1904 = OpLoad %ulong %1874
+%1905 = OpConvertUToF %double %1904
+OpStore %1875 %1905
+%1906 = OpLoad %double %1875
+%1908 = OpFDiv %double %1906 %double_32
+OpStore %1876 %1908
+%1909 = OpAccessChain %_ptr_Function_double %1866 %uint_4
+%1910 = OpLoad %double %1876
+OpStore %1909 %1910
+%1911 = OpLoad %ulong %1867
+%1912 = OpIMul %ulong %1911 %ulong_3
+OpStore %1877 %1912
+%1913 = OpAccessChain %_ptr_Function_ulong %1866 %uint_5
+%1914 = OpLoad %ulong %1877
+OpStore %1913 %1914
+%1915 = OpLoad %ulong %1867
+%1916 = OpNot %ulong %1915
+OpStore %1878 %1916
+%1917 = OpAccessChain %_ptr_Function_ulong %1866 %uint_6
+%1918 = OpLoad %ulong %1878
+OpStore %1917 %1918
+%1919 = OpLoad %_struct_810 %1866
+OpReturnValue %1919
 OpFunctionEnd
-%21 = OpFunction %ulong None %1872
-%1873 = OpFunctionParameter %ulong
-%1874 = OpFunctionParameter %uint
-%1875 = OpLabel
-%1882 = OpVariable %_ptr_Function_ulong Function
-%1883 = OpVariable %_ptr_Function_uint Function
-%1884 = OpVariable %_ptr_Function_ulong Function
-%1885 = OpVariable %_ptr_Function_bool Function
-%1886 = OpVariable %_ptr_Function_ulong Function
-%1887 = OpVariable %_ptr_Function_ulong Function
-%1888 = OpVariable %_ptr_Function_ulong Function
-%1889 = OpVariable %_ptr_Function_ulong Function
-%1890 = OpVariable %_ptr_Function_ulong Function
-%1891 = OpVariable %_ptr_Function_ulong Function
-%1892 = OpVariable %_ptr_Function_ulong Function
-%1893 = OpVariable %_ptr_Function_ulong Function
-OpStore %1882 %1873
-OpStore %1883 %1874
-%1894 = OpLoad %uint %1883
-%1895 = OpUConvert %ulong %1894
-OpStore %1884 %1895
-OpBranch %1876
-%1876 = OpLabel
-%1896 = OpLoad %ulong %1882
-OpStore %1892 %1896
-OpStore %1893 %ulong_0
-OpBranch %1877
-%1877 = OpLabel
-%1897 = OpLoad %ulong %1893
-%1898 = OpULessThan %bool %1897 %ulong_8
-OpStore %1885 %1898
-%1899 = OpLoad %bool %1885
-OpLoopMerge %1879 %1881 None
-OpBranchConditional %1899 %1878 %1879
-%1879 = OpLabel
-OpBranch %1880
-%1880 = OpLabel
-%1900 = OpLoad %ulong %1892
-OpReturnValue %1900
-%1878 = OpLabel
-%1901 = OpLoad %ulong %1893
-%1902 = OpIMul %ulong %1901 %ulong_8
-OpStore %1886 %1902
-%1903 = OpLoad %ulong %1884
-%1904 = OpLoad %ulong %1886
-%1905 = OpShiftRightLogical %ulong %1903 %1904
-OpStore %1887 %1905
-%1906 = OpLoad %ulong %1887
-%1907 = OpBitwiseAnd %ulong %1906 %ulong_255
-OpStore %1888 %1907
-%1908 = OpLoad %ulong %1892
-%1909 = OpLoad %ulong %1888
-%1910 = OpBitwiseXor %ulong %1908 %1909
-OpStore %1889 %1910
-%1911 = OpLoad %ulong %1889
-%1912 = OpIMul %ulong %1911 %ulong_1099511628211
-OpStore %1890 %1912
-%1913 = OpLoad %ulong %1893
-%1914 = OpIAdd %ulong %1913 %ulong_1
-OpStore %1891 %1914
-%1915 = OpLoad %ulong %1890
-OpStore %1892 %1915
-%1916 = OpLoad %ulong %1891
-OpStore %1893 %1916
-OpBranch %1881
-%1881 = OpLabel
-OpBranch %1877
-OpFunctionEnd
-%22 = OpFunction %ulong None %1917
-%1918 = OpFunctionParameter %ulong
-%1919 = OpFunctionParameter %float
-%1920 = OpLabel
-%1927 = OpVariable %_ptr_Function_ulong Function
-%1928 = OpVariable %_ptr_Function_float Function
-%1929 = OpVariable %_ptr_Function_uint Function
-%1930 = OpVariable %_ptr_Function_ulong Function
-%1931 = OpVariable %_ptr_Function_bool Function
-%1932 = OpVariable %_ptr_Function_ulong Function
-%1933 = OpVariable %_ptr_Function_ulong Function
-%1934 = OpVariable %_ptr_Function_ulong Function
-%1935 = OpVariable %_ptr_Function_ulong Function
-%1936 = OpVariable %_ptr_Function_ulong Function
-%1937 = OpVariable %_ptr_Function_ulong Function
-%1938 = OpVariable %_ptr_Function_ulong Function
-%1939 = OpVariable %_ptr_Function_ulong Function
-OpStore %1927 %1918
-OpStore %1928 %1919
-%1940 = OpLoad %float %1928
-%1941 = OpBitcast %uint %1940
-OpStore %1929 %1941
-%1942 = OpLoad %uint %1929
-%1943 = OpUConvert %ulong %1942
-OpStore %1930 %1943
-OpBranch %1921
+%18 = OpFunction %ulong None %889
+%1920 = OpFunctionParameter %ulong
 %1921 = OpLabel
-%1944 = OpLoad %ulong %1927
-OpStore %1938 %1944
-OpStore %1939 %ulong_0
+%1972 = OpVariable %_ptr_Function__struct_41 Function
+%1973 = OpVariable %_ptr_Function__struct_41 Function
+%1977 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
+%1978 = OpVariable %_ptr_Function__struct_176 Function
+%1979 = OpVariable %_ptr_Function__struct_176 Function
+%1980 = OpVariable %_ptr_Function__struct_315 Function
+%1981 = OpVariable %_ptr_Function__struct_315 Function
+%1982 = OpVariable %_ptr_Function__struct_493 Function
+%1983 = OpVariable %_ptr_Function__struct_493 Function
+%1984 = OpVariable %_ptr_Function__struct_655 Function
+%1985 = OpVariable %_ptr_Function__struct_654 Function
+%1986 = OpVariable %_ptr_Function__struct_654 Function
+%1987 = OpVariable %_ptr_Function__struct_655 Function
+%1988 = OpVariable %_ptr_Function__struct_654 Function
+%1989 = OpVariable %_ptr_Function__struct_654 Function
+%1990 = OpVariable %_ptr_Function__struct_757 Function
+%1991 = OpVariable %_ptr_Function__struct_810 Function
+%1992 = OpVariable %_ptr_Function__struct_757 Function
+%1993 = OpVariable %_ptr_Function__struct_810 Function
+%1994 = OpVariable %_ptr_Function__struct_41 Function
+%1995 = OpVariable %_ptr_Function__struct_41 Function
+%1996 = OpVariable %_ptr_Function__struct_493 Function
+%1997 = OpVariable %_ptr_Function__struct_493 Function
+%1998 = OpVariable %_ptr_Function__struct_757 Function
+%1999 = OpVariable %_ptr_Function__struct_757 Function
+%2000 = OpVariable %_ptr_Function_ulong Function
+%2001 = OpVariable %_ptr_Function_bool Function
+%2002 = OpVariable %_ptr_Function_ulong Function
+%2003 = OpVariable %_ptr_Function_bool Function
+%2004 = OpVariable %_ptr_Function_ulong Function
+%2005 = OpVariable %_ptr_Function_ulong Function
+%2006 = OpVariable %_ptr_Function_ulong Function
+%2007 = OpVariable %_ptr_Function_ulong Function
+%2008 = OpVariable %_ptr_Function_ulong Function
+%2009 = OpVariable %_ptr_Function_ulong Function
+%2010 = OpVariable %_ptr_Function_ulong Function
+%2011 = OpVariable %_ptr_Function_ulong Function
+%2012 = OpVariable %_ptr_Function_uint Function
+%2013 = OpVariable %_ptr_Function_ulong Function
+%2014 = OpVariable %_ptr_Function_ulong Function
+%2015 = OpVariable %_ptr_Function_ulong Function
+%2016 = OpVariable %_ptr_Function_ulong Function
+%2017 = OpVariable %_ptr_Function_ulong Function
+%2018 = OpVariable %_ptr_Function_double Function
+%2019 = OpVariable %_ptr_Function_ulong Function
+%2020 = OpVariable %_ptr_Function_ulong Function
+%2021 = OpVariable %_ptr_Function_ulong Function
+%2022 = OpVariable %_ptr_Function_ulong Function
+%2023 = OpVariable %_ptr_Function_ulong Function
+%2024 = OpVariable %_ptr_Function_ulong Function
+%2025 = OpVariable %_ptr_Function_ulong Function
+%2026 = OpVariable %_ptr_Function_float Function
+%2027 = OpVariable %_ptr_Function_ulong Function
+%2028 = OpVariable %_ptr_Function_ulong Function
+%2029 = OpVariable %_ptr_Function_ulong Function
+%2030 = OpVariable %_ptr_Function_ulong Function
+%2031 = OpVariable %_ptr_Function_uint Function
+%2032 = OpVariable %_ptr_Function_ulong Function
+%2033 = OpVariable %_ptr_Function_double Function
+%2034 = OpVariable %_ptr_Function_ulong Function
+%2035 = OpVariable %_ptr_Function_ulong Function
+%2036 = OpVariable %_ptr_Function_ulong Function
+%2037 = OpVariable %_ptr_Function_ulong Function
+%2038 = OpVariable %_ptr_Function_ulong Function
+%2039 = OpVariable %_ptr_Function_float Function
+%2040 = OpVariable %_ptr_Function_ulong Function
+%2041 = OpVariable %_ptr_Function_ulong Function
+%2042 = OpVariable %_ptr_Function_ulong Function
+%2043 = OpVariable %_ptr_Function_ulong Function
+%2044 = OpVariable %_ptr_Function_ulong Function
+%2045 = OpVariable %_ptr_Function_ulong Function
+%2046 = OpVariable %_ptr_Function_ulong Function
+%2047 = OpVariable %_ptr_Function_ulong Function
+%2048 = OpVariable %_ptr_Function_ulong Function
+%2049 = OpVariable %_ptr_Function_ulong Function
+%2050 = OpVariable %_ptr_Function_ulong Function
+%2051 = OpVariable %_ptr_Function_ulong Function
+%2052 = OpVariable %_ptr_Function_ulong Function
+%2053 = OpVariable %_ptr_Function_ulong Function
+%2054 = OpVariable %_ptr_Function_ulong Function
+%2055 = OpVariable %_ptr_Function_ulong Function
+%2056 = OpVariable %_ptr_Function_ulong Function
+%2057 = OpVariable %_ptr_Function_ulong Function
+%2058 = OpVariable %_ptr_Function_ulong Function
+%2059 = OpVariable %_ptr_Function_ulong Function
+%2060 = OpVariable %_ptr_Function_ulong Function
+%2061 = OpVariable %_ptr_Function_ulong Function
+%2062 = OpVariable %_ptr_Function_ulong Function
+%2063 = OpVariable %_ptr_Function_ulong Function
+%2064 = OpVariable %_ptr_Function_ulong Function
+%2065 = OpVariable %_ptr_Function_ulong Function
+%2066 = OpVariable %_ptr_Function_ulong Function
+%2067 = OpVariable %_ptr_Function_ulong Function
+%2068 = OpVariable %_ptr_Function_ulong Function
+%2069 = OpVariable %_ptr_Function_ulong Function
+%2070 = OpVariable %_ptr_Function_ulong Function
+%2071 = OpVariable %_ptr_Function_ulong Function
+%2072 = OpVariable %_ptr_Function_ulong Function
+%2073 = OpVariable %_ptr_Function_ulong Function
+%2074 = OpVariable %_ptr_Function_double Function
+%2075 = OpVariable %_ptr_Function_double Function
+%2076 = OpVariable %_ptr_Function_ulong Function
+%2077 = OpVariable %_ptr_Function_double Function
+%2078 = OpVariable %_ptr_Function_double Function
+%2079 = OpVariable %_ptr_Function_ulong Function
+%2080 = OpVariable %_ptr_Function_double Function
+%2081 = OpVariable %_ptr_Function_double Function
+%2082 = OpVariable %_ptr_Function_ulong Function
+%2083 = OpVariable %_ptr_Function_double Function
+%2084 = OpVariable %_ptr_Function_double Function
+%2085 = OpVariable %_ptr_Function_ulong Function
+%2086 = OpVariable %_ptr_Function_double Function
+%2087 = OpVariable %_ptr_Function_double Function
+%2088 = OpVariable %_ptr_Function_ulong Function
+%2089 = OpVariable %_ptr_Function_double Function
+%2090 = OpVariable %_ptr_Function_double Function
+%2091 = OpVariable %_ptr_Function_ulong Function
+%2092 = OpVariable %_ptr_Function_double Function
+%2093 = OpVariable %_ptr_Function_double Function
+%2094 = OpVariable %_ptr_Function_uint Function
+%2095 = OpVariable %_ptr_Function_ulong Function
+%2096 = OpVariable %_ptr_Function_uint Function
+%2097 = OpVariable %_ptr_Function_ulong Function
+%2098 = OpVariable %_ptr_Function_double Function
+%2099 = OpVariable %_ptr_Function_double Function
+%2100 = OpVariable %_ptr_Function_uint Function
+%2101 = OpVariable %_ptr_Function_ulong Function
+%2102 = OpVariable %_ptr_Function_uint Function
+%2103 = OpVariable %_ptr_Function_ulong Function
+%2104 = OpVariable %_ptr_Function_ulong Function
+%2105 = OpVariable %_ptr_Function_ulong Function
+%2106 = OpVariable %_ptr_Function_ulong Function
+%2107 = OpVariable %_ptr_Function_ulong Function
+%2108 = OpVariable %_ptr_Function_ulong Function
+%2109 = OpVariable %_ptr_Function_ulong Function
+%2110 = OpVariable %_ptr_Function_ulong Function
+%2111 = OpVariable %_ptr_Function_ulong Function
+%2112 = OpVariable %_ptr_Function_ulong Function
+%2113 = OpVariable %_ptr_Function_ulong Function
+%2114 = OpVariable %_ptr_Function_ulong Function
+%2115 = OpVariable %_ptr_Function_ulong Function
+%2116 = OpVariable %_ptr_Function_ulong Function
+%2117 = OpVariable %_ptr_Function_ulong Function
+%2118 = OpVariable %_ptr_Function_ulong Function
+%2119 = OpVariable %_ptr_Function_ulong Function
+%2120 = OpVariable %_ptr_Function_ulong Function
+%2121 = OpVariable %_ptr_Function_ulong Function
+%2122 = OpVariable %_ptr_Function_ulong Function
+%2123 = OpVariable %_ptr_Function_ulong Function
+%2124 = OpVariable %_ptr_Function_ulong Function
+%2125 = OpVariable %_ptr_Function_ulong Function
+%2126 = OpVariable %_ptr_Function_ulong Function
+%2127 = OpVariable %_ptr_Function_ulong Function
+%2128 = OpVariable %_ptr_Function_ulong Function
+%2129 = OpVariable %_ptr_Function_ulong Function
+%2130 = OpVariable %_ptr_Function_ulong Function
+%2131 = OpVariable %_ptr_Function_ulong Function
+%2132 = OpVariable %_ptr_Function_ulong Function
+%2133 = OpVariable %_ptr_Function_ulong Function
+%2134 = OpVariable %_ptr_Function_ulong Function
+%2135 = OpVariable %_ptr_Function_ulong Function
+%2136 = OpVariable %_ptr_Function_ulong Function
+%2137 = OpVariable %_ptr_Function_ulong Function
+%2138 = OpVariable %_ptr_Function_ulong Function
+%2139 = OpVariable %_ptr_Function_ulong Function
+%2140 = OpVariable %_ptr_Function_ulong Function
+%2141 = OpVariable %_ptr_Function_ulong Function
+%2142 = OpVariable %_ptr_Function_ulong Function
+%2143 = OpVariable %_ptr_Function_ulong Function
+%2144 = OpVariable %_ptr_Function_ulong Function
+%2145 = OpVariable %_ptr_Function_ulong Function
+%2146 = OpVariable %_ptr_Function_ulong Function
+OpStore %2000 %1920
+OpBranch %1928
+%1928 = OpLabel
+OpBranch %1929
+%1929 = OpLabel
+OpBranch %1936
+%1936 = OpLabel
+%2147 = OpFunctionCall %ulong %19 %ulong_14695981039346656037 %ulong_24
+OpStore %2056 %2147
+%2148 = OpLoad %ulong %2056
+%2149 = OpFunctionCall %ulong %19 %2148 %ulong_24
+OpStore %2057 %2149
+%2150 = OpLoad %ulong %2057
+%2151 = OpFunctionCall %ulong %19 %2150 %ulong_24
+OpStore %2058 %2151
+%2152 = OpLoad %ulong %2058
+%2153 = OpFunctionCall %ulong %19 %2152 %ulong_32
+OpStore %2059 %2153
+%2154 = OpLoad %ulong %2059
+%2155 = OpFunctionCall %ulong %19 %2154 %ulong_32
+OpStore %2060 %2155
+%2156 = OpLoad %ulong %2060
+%2157 = OpFunctionCall %ulong %19 %2156 %ulong_48
+OpStore %2061 %2157
+%2158 = OpLoad %ulong %2061
+%2159 = OpFunctionCall %ulong %19 %2158 %ulong_48
+OpStore %2062 %2159
+%2160 = OpLoad %ulong %2062
+%2161 = OpFunctionCall %ulong %19 %2160 %ulong_8
+OpStore %2063 %2161
+%2162 = OpLoad %ulong %2063
+%2163 = OpFunctionCall %ulong %19 %2162 %ulong_8
+OpStore %2064 %2163
+%2164 = OpLoad %ulong %2064
+%2165 = OpFunctionCall %ulong %19 %2164 %ulong_8
+OpStore %2065 %2165
+%2166 = OpLoad %ulong %2065
+%2167 = OpFunctionCall %ulong %19 %2166 %ulong_16
+OpStore %2066 %2167
+%2168 = OpLoad %ulong %2066
+%2169 = OpFunctionCall %ulong %19 %2168 %ulong_16
+OpStore %2067 %2169
+%2170 = OpLoad %ulong %2067
+%2171 = OpFunctionCall %ulong %19 %2170 %ulong_20
+OpStore %2068 %2171
+%2172 = OpLoad %ulong %2068
+%2173 = OpFunctionCall %ulong %19 %2172 %ulong_16
+OpStore %2069 %2173
+%2174 = OpLoad %ulong %2069
+%2175 = OpFunctionCall %ulong %19 %2174 %ulong_40
+OpStore %2070 %2175
+%2176 = OpLoad %ulong %2070
+%2177 = OpFunctionCall %ulong %19 %2176 %ulong_24
+OpStore %2071 %2177
+%2178 = OpLoad %ulong %2071
+%2179 = OpFunctionCall %ulong %19 %2178 %ulong_40
+OpStore %2072 %2179
+OpBranch %1937
+%1937 = OpLabel
+OpStore %1977 %2180
+OpStore %2044 %ulong_0
 OpBranch %1922
 %1922 = OpLabel
-%1945 = OpLoad %ulong %1939
-%1946 = OpULessThan %bool %1945 %ulong_8
-OpStore %1931 %1946
-%1947 = OpLoad %bool %1931
-OpLoopMerge %1924 %1926 None
-OpBranchConditional %1947 %1923 %1924
+%2181 = OpLoad %ulong %2044
+%2183 = OpULessThan %bool %2181 %ulong_12
+OpStore %2001 %2183
+%2184 = OpLoad %bool %2001
+OpLoopMerge %1924 %1971 None
+OpBranchConditional %2184 %1923 %1924
 %1924 = OpLabel
+%2185 = OpLoad %ulong %2072
+OpStore %2043 %2185
+OpStore %2045 %ulong_0
+OpStore %2046 %ulong_0
 OpBranch %1925
 %1925 = OpLabel
-%1948 = OpLoad %ulong %1938
-OpReturnValue %1948
-%1923 = OpLabel
-%1949 = OpLoad %ulong %1939
-%1950 = OpIMul %ulong %1949 %ulong_8
-OpStore %1932 %1950
-%1951 = OpLoad %ulong %1930
-%1952 = OpLoad %ulong %1932
-%1953 = OpShiftRightLogical %ulong %1951 %1952
-OpStore %1933 %1953
-%1954 = OpLoad %ulong %1933
-%1955 = OpBitwiseAnd %ulong %1954 %ulong_255
-OpStore %1934 %1955
-%1956 = OpLoad %ulong %1938
-%1957 = OpLoad %ulong %1934
-%1958 = OpBitwiseXor %ulong %1956 %1957
-OpStore %1935 %1958
-%1959 = OpLoad %ulong %1935
-%1960 = OpIMul %ulong %1959 %ulong_1099511628211
-OpStore %1936 %1960
-%1961 = OpLoad %ulong %1939
-%1962 = OpIAdd %ulong %1961 %ulong_1
-OpStore %1937 %1962
-%1963 = OpLoad %ulong %1936
-OpStore %1938 %1963
-%1964 = OpLoad %ulong %1937
-OpStore %1939 %1964
-OpBranch %1926
-%1926 = OpLabel
-OpBranch %1922
-OpFunctionEnd
-%23 = OpFunction %ulong None %1965
-%1966 = OpFunctionParameter %ulong
-%1967 = OpFunctionParameter %double
+%2186 = OpLoad %ulong %2046
+%2187 = OpULessThan %bool %2186 %ulong_3
+OpStore %2003 %2187
+%2188 = OpLoad %bool %2003
+OpLoopMerge %1927 %1970 None
+OpBranchConditional %2188 %1926 %1927
+%1927 = OpLabel
+OpBranch %1934
+%1934 = OpLabel
+%2189 = OpAccessChain %_ptr_Function_ulong %1973 %uint_0
+%2190 = OpLoad %ulong %2045
+OpStore %2189 %2190
+%2191 = OpLoad %ulong %2045
+%2192 = OpIMul %ulong %2191 %ulong_3
+OpStore %2053 %2192
+%2193 = OpLoad %ulong %2053
+%2194 = OpIAdd %ulong %2193 %ulong_1
+OpStore %2054 %2194
+%2195 = OpAccessChain %_ptr_Function_ulong %1973 %uint_1
+%2196 = OpLoad %ulong %2054
+OpStore %2195 %2196
+%2197 = OpLoad %ulong %2045
+%2198 = OpBitwiseXor %ulong %2197 %ulong_305419896
+OpStore %2055 %2198
+%2199 = OpAccessChain %_ptr_Function_ulong %1973 %uint_2
+%2200 = OpLoad %ulong %2055
+OpStore %2199 %2200
+OpBranch %1935
+%1935 = OpLabel
+OpBranch %1940
+%1940 = OpLabel
+%2201 = OpLoad %ulong %2045
+%2202 = OpBitwiseAnd %ulong %2201 %ulong_65535
+OpStore %2082 %2202
+%2203 = OpLoad %ulong %2082
+%2204 = OpConvertUToF %double %2203
+OpStore %2083 %2204
+%2205 = OpLoad %double %2083
+%2206 = OpFDiv %double %2205 %double_8
+OpStore %2084 %2206
+%2207 = OpAccessChain %_ptr_Function_double %1979 %uint_0
+%2208 = OpLoad %double %2084
+OpStore %2207 %2208
+%2209 = OpLoad %ulong %2045
+%2210 = OpBitwiseAnd %ulong %2209 %ulong_4095
+OpStore %2085 %2210
+%2211 = OpLoad %ulong %2085
+%2212 = OpConvertUToF %double %2211
+OpStore %2086 %2212
+%2213 = OpLoad %double %2086
+%2214 = OpFSub %double %2213 %double_2048
+OpStore %2087 %2214
+%2215 = OpAccessChain %_ptr_Function_double %1979 %uint_1
+%2216 = OpLoad %double %2087
+OpStore %2215 %2216
+%2217 = OpLoad %ulong %2045
+%2218 = OpBitwiseAnd %ulong %2217 %ulong_262143
+OpStore %2088 %2218
+%2219 = OpLoad %ulong %2088
+%2220 = OpConvertUToF %double %2219
+OpStore %2089 %2220
+%2221 = OpLoad %double %2089
+%2222 = OpFDiv %double %2221 %double_64
+OpStore %2090 %2222
+%2223 = OpAccessChain %_ptr_Function_double %1979 %uint_2
+%2224 = OpLoad %double %2090
+OpStore %2223 %2224
+OpBranch %1941
+%1941 = OpLabel
+OpBranch %1944
+%1944 = OpLabel
+%2225 = OpAccessChain %_ptr_Function_ulong %1981 %uint_0
+%2226 = OpLoad %ulong %2045
+OpStore %2225 %2226
+%2227 = OpLoad %ulong %2045
+%2228 = OpBitwiseAnd %ulong %2227 %ulong_32767
+OpStore %2097 %2228
+%2229 = OpLoad %ulong %2097
+%2230 = OpConvertUToF %double %2229
+OpStore %2098 %2230
+%2231 = OpLoad %double %2098
+%2232 = OpFDiv %double %2231 %double_4
+OpStore %2099 %2232
+%2233 = OpAccessChain %_ptr_Function_double %1981 %uint_1
+%2234 = OpLoad %double %2099
+OpStore %2233 %2234
+%2235 = OpLoad %ulong %2045
+%2236 = OpUConvert %uint %2235
+OpStore %2100 %2236
+%2237 = OpAccessChain %_ptr_Function_uint %1981 %uint_2
+%2238 = OpLoad %uint %2100
+OpStore %2237 %2238
+%2239 = OpLoad %ulong %2045
+%2240 = OpShiftRightLogical %ulong %2239 %ulong_32
+OpStore %2101 %2240
+%2241 = OpLoad %ulong %2101
+%2242 = OpUConvert %uint %2241
+OpStore %2102 %2242
+%2243 = OpAccessChain %_ptr_Function_uint %1981 %uint_3
+%2244 = OpLoad %uint %2102
+OpStore %2243 %2244
+OpBranch %1945
+%1945 = OpLabel
+%2245 = OpLoad %ulong %2045
+%2246 = OpUConvert %uint %2245
+OpStore %2031 %2246
+OpBranch %1948
+%1948 = OpLabel
+%2247 = OpAccessChain %_ptr_Function_ulong %1983 %uint_0
+%2248 = OpLoad %ulong %2045
+OpStore %2247 %2248
+%2249 = OpLoad %ulong %2045
+%2250 = OpNot %ulong %2249
+OpStore %2106 %2250
+%2251 = OpAccessChain %_ptr_Function_ulong %1983 %uint_1
+%2252 = OpLoad %ulong %2106
+OpStore %2251 %2252
+%2253 = OpLoad %ulong %2045
+%2254 = OpIMul %ulong %2253 %ulong_5
+OpStore %2107 %2254
+%2255 = OpAccessChain %_ptr_Function_ulong %1983 %uint_2
+%2256 = OpLoad %ulong %2107
+OpStore %2255 %2256
+%2257 = OpLoad %ulong %2045
+%2258 = OpShiftRightLogical %ulong %2257 %ulong_3
+OpStore %2108 %2258
+%2259 = OpAccessChain %_ptr_Function_ulong %1983 %uint_3
+%2260 = OpLoad %ulong %2108
+OpStore %2259 %2260
+OpBranch %1949
+%1949 = OpLabel
+OpBranch %1952
+%1952 = OpLabel
+%2261 = OpAccessChain %_ptr_Function_ulong %1988 %uint_0
+%2262 = OpLoad %ulong %2045
+OpStore %2261 %2262
+%2263 = OpLoad %ulong %2045
+%2264 = OpIAdd %ulong %2263 %ulong_11
+OpStore %2112 %2264
+%2265 = OpAccessChain %_ptr_Function_ulong %1988 %uint_1
+%2266 = OpLoad %ulong %2112
+OpStore %2265 %2266
+%2267 = OpAccessChain %_ptr_Function__struct_654 %1987 %uint_0
+%2268 = OpLoad %_struct_654 %1988
+OpStore %2267 %2268
+%2269 = OpLoad %ulong %2045
+%2270 = OpIMul %ulong %2269 %ulong_7
+OpStore %2113 %2270
+%2271 = OpAccessChain %_ptr_Function_ulong %1989 %uint_0
+%2272 = OpLoad %ulong %2113
+OpStore %2271 %2272
+%2273 = OpLoad %ulong %2045
+%2274 = OpNot %ulong %2273
+OpStore %2114 %2274
+%2275 = OpAccessChain %_ptr_Function_ulong %1989 %uint_1
+%2276 = OpLoad %ulong %2114
+OpStore %2275 %2276
+%2277 = OpAccessChain %_ptr_Function__struct_654 %1987 %uint_1
+%2278 = OpLoad %_struct_654 %1989
+OpStore %2277 %2278
+OpBranch %1953
+%1953 = OpLabel
+%2279 = OpLoad %ulong %2045
+%2281 = OpBitwiseAnd %ulong %2279 %ulong_1023
+OpStore %2032 %2281
+%2282 = OpLoad %ulong %2032
+%2283 = OpConvertUToF %double %2282
+OpStore %2033 %2283
+OpBranch %1956
+%1956 = OpLabel
+%2284 = OpAccessChain %_ptr_Function_ulong %1992 %uint_0
+%2285 = OpLoad %ulong %2045
+OpStore %2284 %2285
+%2286 = OpLoad %ulong %2045
+%2287 = OpIAdd %ulong %2286 %ulong_1
+OpStore %2120 %2287
+%2288 = OpAccessChain %_ptr_Function_ulong %1992 %uint_1
+%2289 = OpLoad %ulong %2120
+OpStore %2288 %2289
+%2290 = OpLoad %ulong %2045
+%2291 = OpIAdd %ulong %2290 %ulong_2
+OpStore %2121 %2291
+%2292 = OpAccessChain %_ptr_Function_ulong %1992 %uint_2
+%2293 = OpLoad %ulong %2121
+OpStore %2292 %2293
+%2294 = OpLoad %ulong %2045
+%2295 = OpIMul %ulong %2294 %ulong_9
+OpStore %2122 %2295
+%2296 = OpAccessChain %_ptr_Function_ulong %1992 %uint_3
+%2297 = OpLoad %ulong %2122
+OpStore %2296 %2297
+%2298 = OpLoad %ulong %2045
+%2299 = OpNot %ulong %2298
+OpStore %2123 %2299
+%2300 = OpAccessChain %_ptr_Function_ulong %1992 %uint_4
+%2301 = OpLoad %ulong %2123
+OpStore %2300 %2301
+%2302 = OpLoad %ulong %2045
+%2303 = OpBitwiseXor %ulong %2302 %ulong_2863311530
+OpStore %2124 %2303
+%2304 = OpAccessChain %_ptr_Function_ulong %1992 %uint_5
+%2305 = OpLoad %ulong %2124
+OpStore %2304 %2305
+OpBranch %1957
+%1957 = OpLabel
+%2306 = OpLoad %ulong %2045
+%2307 = OpFunctionCall %_struct_810 %17 %2306
+OpStore %1993 %2307
+%2309 = OpAccessChain %_ptr_Function_ulong %1977 %uint_10
+%2310 = OpLoad %ulong %2309
+OpStore %2034 %2310
+OpBranch %1960
+%1960 = OpLabel
+%2311 = OpAccessChain %_ptr_Function_ulong %1995 %uint_0
+%2312 = OpLoad %ulong %2034
+OpStore %2311 %2312
+%2313 = OpLoad %ulong %2034
+%2314 = OpIMul %ulong %2313 %ulong_3
+OpStore %2128 %2314
+%2315 = OpLoad %ulong %2128
+%2316 = OpIAdd %ulong %2315 %ulong_1
+OpStore %2129 %2316
+%2317 = OpAccessChain %_ptr_Function_ulong %1995 %uint_1
+%2318 = OpLoad %ulong %2129
+OpStore %2317 %2318
+%2319 = OpLoad %ulong %2034
+%2320 = OpBitwiseXor %ulong %2319 %ulong_305419896
+OpStore %2130 %2320
+%2321 = OpAccessChain %_ptr_Function_ulong %1995 %uint_2
+%2322 = OpLoad %ulong %2130
+OpStore %2321 %2322
+OpBranch %1961
+%1961 = OpLabel
+%2324 = OpAccessChain %_ptr_Function_ulong %1977 %uint_11
+%2325 = OpLoad %ulong %2324
+OpStore %2035 %2325
+OpBranch %1964
+%1964 = OpLabel
+%2326 = OpAccessChain %_ptr_Function_ulong %1997 %uint_0
+%2327 = OpLoad %ulong %2035
+OpStore %2326 %2327
+%2328 = OpLoad %ulong %2035
+%2329 = OpNot %ulong %2328
+OpStore %2134 %2329
+%2330 = OpAccessChain %_ptr_Function_ulong %1997 %uint_1
+%2331 = OpLoad %ulong %2134
+OpStore %2330 %2331
+%2332 = OpLoad %ulong %2035
+%2333 = OpIMul %ulong %2332 %ulong_5
+OpStore %2135 %2333
+%2334 = OpAccessChain %_ptr_Function_ulong %1997 %uint_2
+%2335 = OpLoad %ulong %2135
+OpStore %2334 %2335
+%2336 = OpLoad %ulong %2035
+%2337 = OpShiftRightLogical %ulong %2336 %ulong_3
+OpStore %2136 %2337
+%2338 = OpAccessChain %_ptr_Function_ulong %1997 %uint_3
+%2339 = OpLoad %ulong %2136
+OpStore %2338 %2339
+OpBranch %1965
+%1965 = OpLabel
+%2340 = OpAccessChain %_ptr_Function_ulong %1977 %uint_0
+%2341 = OpLoad %ulong %2340
+OpStore %2036 %2341
+OpBranch %1968
 %1968 = OpLabel
-%1975 = OpVariable %_ptr_Function_ulong Function
-%1976 = OpVariable %_ptr_Function_double Function
-%1977 = OpVariable %_ptr_Function_ulong Function
-%1978 = OpVariable %_ptr_Function_bool Function
-%1979 = OpVariable %_ptr_Function_ulong Function
-%1980 = OpVariable %_ptr_Function_ulong Function
-%1981 = OpVariable %_ptr_Function_ulong Function
-%1982 = OpVariable %_ptr_Function_ulong Function
-%1983 = OpVariable %_ptr_Function_ulong Function
-%1984 = OpVariable %_ptr_Function_ulong Function
-%1985 = OpVariable %_ptr_Function_ulong Function
-%1986 = OpVariable %_ptr_Function_ulong Function
-OpStore %1975 %1966
-OpStore %1976 %1967
-%1987 = OpLoad %double %1976
-%1988 = OpBitcast %ulong %1987
-OpStore %1977 %1988
+%2342 = OpAccessChain %_ptr_Function_ulong %1999 %uint_0
+%2343 = OpLoad %ulong %2036
+OpStore %2342 %2343
+%2344 = OpLoad %ulong %2036
+%2345 = OpIAdd %ulong %2344 %ulong_1
+OpStore %2142 %2345
+%2346 = OpAccessChain %_ptr_Function_ulong %1999 %uint_1
+%2347 = OpLoad %ulong %2142
+OpStore %2346 %2347
+%2348 = OpLoad %ulong %2036
+%2349 = OpIAdd %ulong %2348 %ulong_2
+OpStore %2143 %2349
+%2350 = OpAccessChain %_ptr_Function_ulong %1999 %uint_2
+%2351 = OpLoad %ulong %2143
+OpStore %2350 %2351
+%2352 = OpLoad %ulong %2036
+%2353 = OpIMul %ulong %2352 %ulong_9
+OpStore %2144 %2353
+%2354 = OpAccessChain %_ptr_Function_ulong %1999 %uint_3
+%2355 = OpLoad %ulong %2144
+OpStore %2354 %2355
+%2356 = OpLoad %ulong %2036
+%2357 = OpNot %ulong %2356
+OpStore %2145 %2357
+%2358 = OpAccessChain %_ptr_Function_ulong %1999 %uint_4
+%2359 = OpLoad %ulong %2145
+OpStore %2358 %2359
+%2360 = OpLoad %ulong %2036
+%2361 = OpBitwiseXor %ulong %2360 %ulong_2863311530
+OpStore %2146 %2361
+%2362 = OpAccessChain %_ptr_Function_ulong %1999 %uint_5
+%2363 = OpLoad %ulong %2146
+OpStore %2362 %2363
 OpBranch %1969
 %1969 = OpLabel
-%1989 = OpLoad %ulong %1975
-OpStore %1985 %1989
-OpStore %1986 %ulong_0
+%2364 = OpAccessChain %_ptr_Function_ulong %1977 %uint_1
+%2365 = OpLoad %ulong %2364
+OpStore %2037 %2365
+%2366 = OpLoad %ulong %2037
+%2367 = OpBitwiseAnd %ulong %2366 %ulong_255
+OpStore %2038 %2367
+%2368 = OpLoad %ulong %2038
+%2369 = OpConvertUToF %float %2368
+OpStore %2039 %2369
+%2370 = OpAccessChain %_ptr_Function_ulong %1977 %uint_3
+%2371 = OpLoad %ulong %2370
+OpStore %2040 %2371
+%2372 = OpLoad %ulong %2045
+%2373 = OpLoad %_struct_41 %1973
+%2374 = OpLoad %_struct_176 %1979
+%2375 = OpLoad %_struct_315 %1981
+%2376 = OpLoad %uint %2031
+%2377 = OpLoad %_struct_493 %1983
+%2378 = OpLoad %_struct_655 %1987
+%2379 = OpLoad %double %2033
+%2380 = OpLoad %_struct_757 %1992
+%2381 = OpLoad %_struct_810 %1993
+%2382 = OpLoad %_struct_41 %1995
+%2383 = OpLoad %_struct_493 %1997
+%2384 = OpLoad %_struct_757 %1999
+%2385 = OpLoad %float %2039
+%2386 = OpLoad %ulong %2040
+%2387 = OpFunctionCall %ulong %10 %2372 %2373 %2374 %2375 %2376 %2377 %2378 %2379 %2380 %2381 %2382 %2383 %2384 %2385 %2386
+OpStore %2041 %2387
+%2388 = OpLoad %ulong %2043
+%2389 = OpLoad %ulong %2041
+%2390 = OpFunctionCall %ulong %19 %2388 %2389
+OpStore %2042 %2390
+%2391 = OpLoad %ulong %2042
+OpReturnValue %2391
+%1926 = OpLabel
+%2392 = OpLoad %ulong %2046
+%2394 = OpIMul %ulong %2392 %ulong_19
+OpStore %2004 %2394
+%2395 = OpLoad %ulong %2004
+%2396 = OpLoad %ulong %2000
+%2397 = OpIAdd %ulong %2395 %2396
+OpStore %2005 %2397
+%2398 = OpAccessChain %_ptr_Function_ulong %1977 %uint_0
+%2399 = OpLoad %ulong %2398
+OpStore %2006 %2399
+%2400 = OpLoad %ulong %2006
+%2401 = OpLoad %ulong %2005
+%2402 = OpIAdd %ulong %2400 %2401
+OpStore %2007 %2402
+%2403 = OpAccessChain %_ptr_Function_ulong %1977 %uint_1
+%2404 = OpLoad %ulong %2403
+OpStore %2008 %2404
+OpBranch %1932
+%1932 = OpLabel
+%2405 = OpAccessChain %_ptr_Function_ulong %1972 %uint_0
+%2406 = OpLoad %ulong %2008
+OpStore %2405 %2406
+%2407 = OpLoad %ulong %2008
+%2408 = OpIMul %ulong %2407 %ulong_3
+OpStore %2050 %2408
+%2409 = OpLoad %ulong %2050
+%2410 = OpIAdd %ulong %2409 %ulong_1
+OpStore %2051 %2410
+%2411 = OpAccessChain %_ptr_Function_ulong %1972 %uint_1
+%2412 = OpLoad %ulong %2051
+OpStore %2411 %2412
+%2413 = OpLoad %ulong %2008
+%2414 = OpBitwiseXor %ulong %2413 %ulong_305419896
+OpStore %2052 %2414
+%2415 = OpAccessChain %_ptr_Function_ulong %1972 %uint_2
+%2416 = OpLoad %ulong %2052
+OpStore %2415 %2416
+OpBranch %1933
+%1933 = OpLabel
+%2417 = OpAccessChain %_ptr_Function_ulong %1977 %uint_2
+%2418 = OpLoad %ulong %2417
+OpStore %2009 %2418
+OpBranch %1938
+%1938 = OpLabel
+%2419 = OpLoad %ulong %2009
+%2420 = OpBitwiseAnd %ulong %2419 %ulong_65535
+OpStore %2073 %2420
+%2421 = OpLoad %ulong %2073
+%2422 = OpConvertUToF %double %2421
+OpStore %2074 %2422
+%2423 = OpLoad %double %2074
+%2424 = OpFDiv %double %2423 %double_8
+OpStore %2075 %2424
+%2425 = OpAccessChain %_ptr_Function_double %1978 %uint_0
+%2426 = OpLoad %double %2075
+OpStore %2425 %2426
+%2427 = OpLoad %ulong %2009
+%2428 = OpBitwiseAnd %ulong %2427 %ulong_4095
+OpStore %2076 %2428
+%2429 = OpLoad %ulong %2076
+%2430 = OpConvertUToF %double %2429
+OpStore %2077 %2430
+%2431 = OpLoad %double %2077
+%2432 = OpFSub %double %2431 %double_2048
+OpStore %2078 %2432
+%2433 = OpAccessChain %_ptr_Function_double %1978 %uint_1
+%2434 = OpLoad %double %2078
+OpStore %2433 %2434
+%2435 = OpLoad %ulong %2009
+%2436 = OpBitwiseAnd %ulong %2435 %ulong_262143
+OpStore %2079 %2436
+%2437 = OpLoad %ulong %2079
+%2438 = OpConvertUToF %double %2437
+OpStore %2080 %2438
+%2439 = OpLoad %double %2080
+%2440 = OpFDiv %double %2439 %double_64
+OpStore %2081 %2440
+%2441 = OpAccessChain %_ptr_Function_double %1978 %uint_2
+%2442 = OpLoad %double %2081
+OpStore %2441 %2442
+OpBranch %1939
+%1939 = OpLabel
+%2443 = OpAccessChain %_ptr_Function_ulong %1977 %uint_3
+%2444 = OpLoad %ulong %2443
+OpStore %2010 %2444
+OpBranch %1942
+%1942 = OpLabel
+%2445 = OpAccessChain %_ptr_Function_ulong %1980 %uint_0
+%2446 = OpLoad %ulong %2010
+OpStore %2445 %2446
+%2447 = OpLoad %ulong %2010
+%2448 = OpBitwiseAnd %ulong %2447 %ulong_32767
+OpStore %2091 %2448
+%2449 = OpLoad %ulong %2091
+%2450 = OpConvertUToF %double %2449
+OpStore %2092 %2450
+%2451 = OpLoad %double %2092
+%2452 = OpFDiv %double %2451 %double_4
+OpStore %2093 %2452
+%2453 = OpAccessChain %_ptr_Function_double %1980 %uint_1
+%2454 = OpLoad %double %2093
+OpStore %2453 %2454
+%2455 = OpLoad %ulong %2010
+%2456 = OpUConvert %uint %2455
+OpStore %2094 %2456
+%2457 = OpAccessChain %_ptr_Function_uint %1980 %uint_2
+%2458 = OpLoad %uint %2094
+OpStore %2457 %2458
+%2459 = OpLoad %ulong %2010
+%2460 = OpShiftRightLogical %ulong %2459 %ulong_32
+OpStore %2095 %2460
+%2461 = OpLoad %ulong %2095
+%2462 = OpUConvert %uint %2461
+OpStore %2096 %2462
+%2463 = OpAccessChain %_ptr_Function_uint %1980 %uint_3
+%2464 = OpLoad %uint %2096
+OpStore %2463 %2464
+OpBranch %1943
+%1943 = OpLabel
+%2465 = OpAccessChain %_ptr_Function_ulong %1977 %uint_4
+%2466 = OpLoad %ulong %2465
+OpStore %2011 %2466
+%2467 = OpLoad %ulong %2011
+%2468 = OpUConvert %uint %2467
+OpStore %2012 %2468
+%2469 = OpAccessChain %_ptr_Function_ulong %1977 %uint_5
+%2470 = OpLoad %ulong %2469
+OpStore %2013 %2470
+%2471 = OpLoad %ulong %2013
+%2472 = OpLoad %ulong %2005
+%2473 = OpIAdd %ulong %2471 %2472
+OpStore %2014 %2473
+OpBranch %1946
+%1946 = OpLabel
+%2474 = OpAccessChain %_ptr_Function_ulong %1982 %uint_0
+%2475 = OpLoad %ulong %2014
+OpStore %2474 %2475
+%2476 = OpLoad %ulong %2014
+%2477 = OpNot %ulong %2476
+OpStore %2103 %2477
+%2478 = OpAccessChain %_ptr_Function_ulong %1982 %uint_1
+%2479 = OpLoad %ulong %2103
+OpStore %2478 %2479
+%2480 = OpLoad %ulong %2014
+%2481 = OpIMul %ulong %2480 %ulong_5
+OpStore %2104 %2481
+%2482 = OpAccessChain %_ptr_Function_ulong %1982 %uint_2
+%2483 = OpLoad %ulong %2104
+OpStore %2482 %2483
+%2484 = OpLoad %ulong %2014
+%2485 = OpShiftRightLogical %ulong %2484 %ulong_3
+OpStore %2105 %2485
+%2486 = OpAccessChain %_ptr_Function_ulong %1982 %uint_3
+%2487 = OpLoad %ulong %2105
+OpStore %2486 %2487
+OpBranch %1947
+%1947 = OpLabel
+%2488 = OpAccessChain %_ptr_Function_ulong %1977 %uint_6
+%2489 = OpLoad %ulong %2488
+OpStore %2015 %2489
+OpBranch %1950
+%1950 = OpLabel
+%2490 = OpAccessChain %_ptr_Function_ulong %1985 %uint_0
+%2491 = OpLoad %ulong %2015
+OpStore %2490 %2491
+%2492 = OpLoad %ulong %2015
+%2493 = OpIAdd %ulong %2492 %ulong_11
+OpStore %2109 %2493
+%2494 = OpAccessChain %_ptr_Function_ulong %1985 %uint_1
+%2495 = OpLoad %ulong %2109
+OpStore %2494 %2495
+%2496 = OpAccessChain %_ptr_Function__struct_654 %1984 %uint_0
+%2497 = OpLoad %_struct_654 %1985
+OpStore %2496 %2497
+%2498 = OpLoad %ulong %2015
+%2499 = OpIMul %ulong %2498 %ulong_7
+OpStore %2110 %2499
+%2500 = OpAccessChain %_ptr_Function_ulong %1986 %uint_0
+%2501 = OpLoad %ulong %2110
+OpStore %2500 %2501
+%2502 = OpLoad %ulong %2015
+%2503 = OpNot %ulong %2502
+OpStore %2111 %2503
+%2504 = OpAccessChain %_ptr_Function_ulong %1986 %uint_1
+%2505 = OpLoad %ulong %2111
+OpStore %2504 %2505
+%2506 = OpAccessChain %_ptr_Function__struct_654 %1984 %uint_1
+%2507 = OpLoad %_struct_654 %1986
+OpStore %2506 %2507
+OpBranch %1951
+%1951 = OpLabel
+%2509 = OpAccessChain %_ptr_Function_ulong %1977 %uint_7
+%2510 = OpLoad %ulong %2509
+OpStore %2016 %2510
+%2511 = OpLoad %ulong %2016
+%2512 = OpBitwiseAnd %ulong %2511 %ulong_1023
+OpStore %2017 %2512
+%2513 = OpLoad %ulong %2017
+%2514 = OpConvertUToF %double %2513
+OpStore %2018 %2514
+%2516 = OpAccessChain %_ptr_Function_ulong %1977 %uint_8
+%2517 = OpLoad %ulong %2516
+OpStore %2019 %2517
+OpBranch %1954
+%1954 = OpLabel
+%2518 = OpAccessChain %_ptr_Function_ulong %1990 %uint_0
+%2519 = OpLoad %ulong %2019
+OpStore %2518 %2519
+%2520 = OpLoad %ulong %2019
+%2521 = OpIAdd %ulong %2520 %ulong_1
+OpStore %2115 %2521
+%2522 = OpAccessChain %_ptr_Function_ulong %1990 %uint_1
+%2523 = OpLoad %ulong %2115
+OpStore %2522 %2523
+%2524 = OpLoad %ulong %2019
+%2525 = OpIAdd %ulong %2524 %ulong_2
+OpStore %2116 %2525
+%2526 = OpAccessChain %_ptr_Function_ulong %1990 %uint_2
+%2527 = OpLoad %ulong %2116
+OpStore %2526 %2527
+%2528 = OpLoad %ulong %2019
+%2529 = OpIMul %ulong %2528 %ulong_9
+OpStore %2117 %2529
+%2530 = OpAccessChain %_ptr_Function_ulong %1990 %uint_3
+%2531 = OpLoad %ulong %2117
+OpStore %2530 %2531
+%2532 = OpLoad %ulong %2019
+%2533 = OpNot %ulong %2532
+OpStore %2118 %2533
+%2534 = OpAccessChain %_ptr_Function_ulong %1990 %uint_4
+%2535 = OpLoad %ulong %2118
+OpStore %2534 %2535
+%2536 = OpLoad %ulong %2019
+%2537 = OpBitwiseXor %ulong %2536 %ulong_2863311530
+OpStore %2119 %2537
+%2538 = OpAccessChain %_ptr_Function_ulong %1990 %uint_5
+%2539 = OpLoad %ulong %2119
+OpStore %2538 %2539
+OpBranch %1955
+%1955 = OpLabel
+%2541 = OpAccessChain %_ptr_Function_ulong %1977 %uint_9
+%2542 = OpLoad %ulong %2541
+OpStore %2020 %2542
+%2543 = OpLoad %ulong %2020
+%2544 = OpFunctionCall %_struct_810 %17 %2543
+OpStore %1991 %2544
+%2545 = OpAccessChain %_ptr_Function_ulong %1977 %uint_10
+%2546 = OpLoad %ulong %2545
+OpStore %2021 %2546
+OpBranch %1958
+%1958 = OpLabel
+%2547 = OpAccessChain %_ptr_Function_ulong %1994 %uint_0
+%2548 = OpLoad %ulong %2021
+OpStore %2547 %2548
+%2549 = OpLoad %ulong %2021
+%2550 = OpIMul %ulong %2549 %ulong_3
+OpStore %2125 %2550
+%2551 = OpLoad %ulong %2125
+%2552 = OpIAdd %ulong %2551 %ulong_1
+OpStore %2126 %2552
+%2553 = OpAccessChain %_ptr_Function_ulong %1994 %uint_1
+%2554 = OpLoad %ulong %2126
+OpStore %2553 %2554
+%2555 = OpLoad %ulong %2021
+%2556 = OpBitwiseXor %ulong %2555 %ulong_305419896
+OpStore %2127 %2556
+%2557 = OpAccessChain %_ptr_Function_ulong %1994 %uint_2
+%2558 = OpLoad %ulong %2127
+OpStore %2557 %2558
+OpBranch %1959
+%1959 = OpLabel
+%2559 = OpAccessChain %_ptr_Function_ulong %1977 %uint_11
+%2560 = OpLoad %ulong %2559
+OpStore %2022 %2560
+OpBranch %1962
+%1962 = OpLabel
+%2561 = OpAccessChain %_ptr_Function_ulong %1996 %uint_0
+%2562 = OpLoad %ulong %2022
+OpStore %2561 %2562
+%2563 = OpLoad %ulong %2022
+%2564 = OpNot %ulong %2563
+OpStore %2131 %2564
+%2565 = OpAccessChain %_ptr_Function_ulong %1996 %uint_1
+%2566 = OpLoad %ulong %2131
+OpStore %2565 %2566
+%2567 = OpLoad %ulong %2022
+%2568 = OpIMul %ulong %2567 %ulong_5
+OpStore %2132 %2568
+%2569 = OpAccessChain %_ptr_Function_ulong %1996 %uint_2
+%2570 = OpLoad %ulong %2132
+OpStore %2569 %2570
+%2571 = OpLoad %ulong %2022
+%2572 = OpShiftRightLogical %ulong %2571 %ulong_3
+OpStore %2133 %2572
+%2573 = OpAccessChain %_ptr_Function_ulong %1996 %uint_3
+%2574 = OpLoad %ulong %2133
+OpStore %2573 %2574
+OpBranch %1963
+%1963 = OpLabel
+%2575 = OpAccessChain %_ptr_Function_ulong %1977 %uint_0
+%2576 = OpLoad %ulong %2575
+OpStore %2023 %2576
+OpBranch %1966
+%1966 = OpLabel
+%2577 = OpAccessChain %_ptr_Function_ulong %1998 %uint_0
+%2578 = OpLoad %ulong %2023
+OpStore %2577 %2578
+%2579 = OpLoad %ulong %2023
+%2580 = OpIAdd %ulong %2579 %ulong_1
+OpStore %2137 %2580
+%2581 = OpAccessChain %_ptr_Function_ulong %1998 %uint_1
+%2582 = OpLoad %ulong %2137
+OpStore %2581 %2582
+%2583 = OpLoad %ulong %2023
+%2584 = OpIAdd %ulong %2583 %ulong_2
+OpStore %2138 %2584
+%2585 = OpAccessChain %_ptr_Function_ulong %1998 %uint_2
+%2586 = OpLoad %ulong %2138
+OpStore %2585 %2586
+%2587 = OpLoad %ulong %2023
+%2588 = OpIMul %ulong %2587 %ulong_9
+OpStore %2139 %2588
+%2589 = OpAccessChain %_ptr_Function_ulong %1998 %uint_3
+%2590 = OpLoad %ulong %2139
+OpStore %2589 %2590
+%2591 = OpLoad %ulong %2023
+%2592 = OpNot %ulong %2591
+OpStore %2140 %2592
+%2593 = OpAccessChain %_ptr_Function_ulong %1998 %uint_4
+%2594 = OpLoad %ulong %2140
+OpStore %2593 %2594
+%2595 = OpLoad %ulong %2023
+%2596 = OpBitwiseXor %ulong %2595 %ulong_2863311530
+OpStore %2141 %2596
+%2597 = OpAccessChain %_ptr_Function_ulong %1998 %uint_5
+%2598 = OpLoad %ulong %2141
+OpStore %2597 %2598
+OpBranch %1967
+%1967 = OpLabel
+%2599 = OpAccessChain %_ptr_Function_ulong %1977 %uint_1
+%2600 = OpLoad %ulong %2599
+OpStore %2024 %2600
+%2601 = OpLoad %ulong %2024
+%2602 = OpBitwiseAnd %ulong %2601 %ulong_255
+OpStore %2025 %2602
+%2603 = OpLoad %ulong %2025
+%2604 = OpConvertUToF %float %2603
+OpStore %2026 %2604
+%2605 = OpAccessChain %_ptr_Function_ulong %1977 %uint_2
+%2606 = OpLoad %ulong %2605
+OpStore %2027 %2606
+%2607 = OpLoad %ulong %2007
+%2608 = OpLoad %_struct_41 %1972
+%2609 = OpLoad %_struct_176 %1978
+%2610 = OpLoad %_struct_315 %1980
+%2611 = OpLoad %uint %2012
+%2612 = OpLoad %_struct_493 %1982
+%2613 = OpLoad %_struct_655 %1984
+%2614 = OpLoad %double %2018
+%2615 = OpLoad %_struct_757 %1990
+%2616 = OpLoad %_struct_810 %1991
+%2617 = OpLoad %_struct_41 %1994
+%2618 = OpLoad %_struct_493 %1996
+%2619 = OpLoad %_struct_757 %1998
+%2620 = OpLoad %float %2026
+%2621 = OpLoad %ulong %2027
+%2622 = OpFunctionCall %ulong %10 %2607 %2608 %2609 %2610 %2611 %2612 %2613 %2614 %2615 %2616 %2617 %2618 %2619 %2620 %2621
+OpStore %2028 %2622
+%2623 = OpLoad %ulong %2043
+%2624 = OpLoad %ulong %2028
+%2625 = OpFunctionCall %ulong %19 %2623 %2624
+OpStore %2029 %2625
+%2626 = OpLoad %ulong %2046
+%2627 = OpIAdd %ulong %2626 %ulong_1
+OpStore %2030 %2627
+%2628 = OpLoad %ulong %2029
+OpStore %2043 %2628
+%2629 = OpLoad %ulong %2028
+OpStore %2045 %2629
+%2630 = OpLoad %ulong %2030
+OpStore %2046 %2630
 OpBranch %1970
+%1923 = OpLabel
+OpBranch %1930
+%1930 = OpLabel
+%2631 = OpLoad %ulong %2044
+%2632 = OpIMul %ulong %2631 %ulong_6364136223846793005
+OpStore %2047 %2632
+%2633 = OpLoad %ulong %2047
+%2634 = OpIAdd %ulong %2633 %ulong_1442695040888963407
+OpStore %2048 %2634
+%2635 = OpLoad %ulong %2048
+%2636 = OpLoad %ulong %2000
+%2637 = OpIAdd %ulong %2635 %2636
+OpStore %2049 %2637
+OpBranch %1931
+%1931 = OpLabel
+%2638 = OpLoad %ulong %2044
+%2639 = OpAccessChain %_ptr_Function_ulong %1977 %2638
+%2640 = OpLoad %ulong %2049
+OpStore %2639 %2640
+%2641 = OpLoad %ulong %2044
+%2642 = OpIAdd %ulong %2641 %ulong_1
+OpStore %2002 %2642
+%2643 = OpLoad %ulong %2002
+OpStore %2044 %2643
+OpBranch %1971
 %1970 = OpLabel
-%1990 = OpLoad %ulong %1986
-%1991 = OpULessThan %bool %1990 %ulong_8
-OpStore %1978 %1991
-%1992 = OpLoad %bool %1978
-OpLoopMerge %1972 %1974 None
-OpBranchConditional %1992 %1971 %1972
-%1972 = OpLabel
-OpBranch %1973
-%1973 = OpLabel
-%1993 = OpLoad %ulong %1985
-OpReturnValue %1993
+OpBranch %1925
 %1971 = OpLabel
-%1994 = OpLoad %ulong %1986
-%1995 = OpIMul %ulong %1994 %ulong_8
-OpStore %1979 %1995
-%1996 = OpLoad %ulong %1977
-%1997 = OpLoad %ulong %1979
-%1998 = OpShiftRightLogical %ulong %1996 %1997
-OpStore %1980 %1998
-%1999 = OpLoad %ulong %1980
-%2000 = OpBitwiseAnd %ulong %1999 %ulong_255
-OpStore %1981 %2000
-%2001 = OpLoad %ulong %1985
-%2002 = OpLoad %ulong %1981
-%2003 = OpBitwiseXor %ulong %2001 %2002
-OpStore %1982 %2003
-%2004 = OpLoad %ulong %1982
-%2005 = OpIMul %ulong %2004 %ulong_1099511628211
-OpStore %1983 %2005
-%2006 = OpLoad %ulong %1986
-%2007 = OpIAdd %ulong %2006 %ulong_1
-OpStore %1984 %2007
-%2008 = OpLoad %ulong %1983
-OpStore %1985 %2008
-%2009 = OpLoad %ulong %1984
-OpStore %1986 %2009
-OpBranch %1974
-%1974 = OpLabel
-OpBranch %1970
+OpBranch %1922
+OpFunctionEnd
+%19 = OpFunction %ulong None %21
+%2644 = OpFunctionParameter %ulong
+%2645 = OpFunctionParameter %ulong
+%2646 = OpLabel
+%2651 = OpVariable %_ptr_Function_ulong Function
+%2652 = OpVariable %_ptr_Function_ulong Function
+%2653 = OpVariable %_ptr_Function_bool Function
+%2654 = OpVariable %_ptr_Function_ulong Function
+%2655 = OpVariable %_ptr_Function_ulong Function
+%2656 = OpVariable %_ptr_Function_ulong Function
+%2657 = OpVariable %_ptr_Function_ulong Function
+%2658 = OpVariable %_ptr_Function_ulong Function
+%2659 = OpVariable %_ptr_Function_ulong Function
+%2660 = OpVariable %_ptr_Function_ulong Function
+%2661 = OpVariable %_ptr_Function_ulong Function
+OpStore %2651 %2644
+OpStore %2652 %2645
+%2662 = OpLoad %ulong %2651
+OpStore %2660 %2662
+OpStore %2661 %ulong_0
+OpBranch %2647
+%2647 = OpLabel
+%2663 = OpLoad %ulong %2661
+%2664 = OpULessThan %bool %2663 %ulong_8
+OpStore %2653 %2664
+%2665 = OpLoad %bool %2653
+OpLoopMerge %2649 %2650 None
+OpBranchConditional %2665 %2648 %2649
+%2649 = OpLabel
+%2666 = OpLoad %ulong %2660
+OpReturnValue %2666
+%2648 = OpLabel
+%2667 = OpLoad %ulong %2661
+%2668 = OpIMul %ulong %2667 %ulong_8
+OpStore %2654 %2668
+%2669 = OpLoad %ulong %2652
+%2670 = OpLoad %ulong %2654
+%2671 = OpShiftRightLogical %ulong %2669 %2670
+OpStore %2655 %2671
+%2672 = OpLoad %ulong %2655
+%2673 = OpBitwiseAnd %ulong %2672 %ulong_255
+OpStore %2656 %2673
+%2674 = OpLoad %ulong %2660
+%2675 = OpLoad %ulong %2656
+%2676 = OpBitwiseXor %ulong %2674 %2675
+OpStore %2657 %2676
+%2677 = OpLoad %ulong %2657
+%2678 = OpIMul %ulong %2677 %ulong_1099511628211
+OpStore %2658 %2678
+%2679 = OpLoad %ulong %2661
+%2680 = OpIAdd %ulong %2679 %ulong_1
+OpStore %2659 %2680
+%2681 = OpLoad %ulong %2658
+OpStore %2660 %2681
+%2682 = OpLoad %ulong %2659
+OpStore %2661 %2682
+OpBranch %2650
+%2650 = OpLabel
+OpBranch %2647
 OpFunctionEnd

--- a/test/golden/spirv/call/call_rec_small.dis
+++ b/test/golden/spirv/call/call_rec_small.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1349
+; Bound: 1883
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -23,58 +23,61 @@ OpDecorate %10 LinkageAttributes "corpus.cases.call.call_rec_small.mk4" Export
 OpDecorate %11 LinkageAttributes "corpus.cases.call.call_rec_small.mk8" Export
 OpDecorate %12 LinkageAttributes "corpus.cases.call.call_rec_small.checksum" Export
 %ulong = OpTypeInt 64 0
-%21 = OpTypeFunction %ulong %ulong %ulong
+%15 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %uchar = OpTypeInt 8 0
-%_struct_42 = OpTypeStruct %uchar
-%43 = OpTypeFunction %ulong %ulong %_struct_42
-%_ptr_Function__struct_42 = OpTypePointer Function %_struct_42
+%_struct_36 = OpTypeStruct %uchar
+%37 = OpTypeFunction %ulong %ulong %_struct_36
+%bool = OpTypeBool
+%_ptr_Function__struct_36 = OpTypePointer Function %_struct_36
+%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %uint = OpTypeInt 32 0
 %uint_0 = OpConstant %uint 0
-%_struct_61 = OpTypeStruct %uchar %uchar
-%62 = OpTypeFunction %ulong %ulong %_struct_61
-%_ptr_Function__struct_61 = OpTypePointer Function %_struct_61
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%_struct_98 = OpTypeStruct %uchar %uchar
+%99 = OpTypeFunction %ulong %ulong %_struct_98
+%_ptr_Function__struct_98 = OpTypePointer Function %_struct_98
 %uint_1 = OpConstant %uint 1
 %ushort = OpTypeInt 16 0
-%_struct_86 = OpTypeStruct %uchar %uchar %ushort
-%87 = OpTypeFunction %ulong %ulong %_struct_86
-%_ptr_Function__struct_86 = OpTypePointer Function %_struct_86
+%_struct_195 = OpTypeStruct %uchar %uchar %ushort
+%196 = OpTypeFunction %ulong %ulong %_struct_195
+%_ptr_Function__struct_195 = OpTypePointer Function %_struct_195
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %uint_2 = OpConstant %uint 2
-%_struct_118 = OpTypeStruct %uint %ushort %uchar
-%119 = OpTypeFunction %ulong %ulong %_struct_118
-%_ptr_Function__struct_118 = OpTypePointer Function %_struct_118
+%_struct_335 = OpTypeStruct %uint %ushort %uchar
+%336 = OpTypeFunction %ulong %ulong %_struct_335
+%_ptr_Function__struct_335 = OpTypePointer Function %_struct_335
 %_ptr_Function_uint = OpTypePointer Function %uint
-%149 = OpTypeFunction %ulong %ulong
-%ulong_1 = OpConstant %ulong 1
-%ulong_2 = OpConstant %ulong 2
+%474 = OpTypeFunction %ulong %ulong
 %ulong_4 = OpConstant %ulong 4
-%ulong_8 = OpConstant %ulong 8
+%ulong_2 = OpConstant %ulong 2
 %ulong_6 = OpConstant %ulong 6
 %double = OpTypeFloat 64
 %float = OpTypeFloat 32
-%200 = OpTypeFunction %ulong %ulong %_struct_42 %uint %_struct_61 %double %_struct_86 %ulong %_struct_118 %_struct_42 %_struct_61 %_struct_86 %_struct_118 %float %ulong
+%740 = OpTypeFunction %ulong %ulong %_struct_36 %uint %_struct_98 %double %_struct_195 %ulong %_struct_335 %_struct_36 %_struct_98 %_struct_195 %_struct_335 %float %ulong
 %_ptr_Function_double = OpTypePointer Function %double
 %_ptr_Function_float = OpTypePointer Function %float
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ushort_2 = OpConstant %ushort 2
 %uchar_3 = OpConstant %uchar 3
-%440 = OpTypeFunction %_struct_42 %ulong
-%451 = OpTypeFunction %_struct_61 %ulong
-%470 = OpTypeFunction %_struct_86 %ulong
+%994 = OpTypeFunction %_struct_36 %ulong
+%1005 = OpTypeFunction %_struct_98 %ulong
+%1024 = OpTypeFunction %_struct_195 %ulong
 %ulong_16 = OpConstant %ulong 16
-%498 = OpTypeFunction %_struct_118 %ulong
+%1052 = OpTypeFunction %_struct_335 %ulong
 %ulong_32 = OpConstant %ulong 32
 %ulong_48 = OpConstant %ulong 48
-%bool = OpTypeBool
 %uint_12 = OpConstant %uint 12
 %_arr_ulong_uint_12 = OpTypeArray %ulong %uint_12
 %_ptr_Function__arr_ulong_uint_12 = OpTypePointer Function %_arr_ulong_uint_12
-%_ptr_Function_bool = OpTypePointer Function %bool
-%743 = OpConstantNull %_arr_ulong_uint_12
-%ulong_0 = OpConstant %ulong 0
+%1406 = OpConstantNull %_arr_ulong_uint_12
 %ulong_12 = OpConstant %ulong 12
 %ulong_3 = OpConstant %ulong 3
 %ulong_1023 = OpConstant %ulong 1023
@@ -83,1819 +86,2678 @@ OpDecorate %12 LinkageAttributes "corpus.cases.call.call_rec_small.checksum" Exp
 %uint_9 = OpConstant %uint 9
 %uint_10 = OpConstant %uint 10
 %uint_11 = OpConstant %uint 11
-%ulong_255 = OpConstant %ulong 255
 %ulong_13 = OpConstant %ulong 13
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
 %uint_5 = OpConstant %uint 5
 %uint_7 = OpConstant %uint 7
-%1078 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1121 = OpTypeFunction %ulong %ulong %uchar
-%1166 = OpTypeFunction %ulong %ulong %ushort
-%1211 = OpTypeFunction %ulong %ulong %uint
-%1256 = OpTypeFunction %ulong %ulong %float
-%1304 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %21
-%22 = OpFunctionParameter %ulong
-%23 = OpFunctionParameter %ulong
-%24 = OpLabel
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-OpStore %26 %22
-OpStore %27 %23
-%31 = OpLoad %ulong %27
-%33 = OpIMul %ulong %31 %ulong_6364136223846793005
-OpStore %28 %33
-%34 = OpLoad %ulong %28
-%36 = OpIAdd %ulong %34 %ulong_1442695040888963407
-OpStore %29 %36
-%37 = OpLoad %ulong %29
-%38 = OpLoad %ulong %26
-%39 = OpIAdd %ulong %37 %38
-OpStore %30 %39
-%40 = OpLoad %ulong %30
-OpReturnValue %40
+%1 = OpFunction %ulong None %15
+%16 = OpFunctionParameter %ulong
+%17 = OpFunctionParameter %ulong
+%18 = OpLabel
+%20 = OpVariable %_ptr_Function_ulong Function
+%21 = OpVariable %_ptr_Function_ulong Function
+%22 = OpVariable %_ptr_Function_ulong Function
+%23 = OpVariable %_ptr_Function_ulong Function
+%24 = OpVariable %_ptr_Function_ulong Function
+OpStore %20 %16
+OpStore %21 %17
+%25 = OpLoad %ulong %21
+%27 = OpIMul %ulong %25 %ulong_6364136223846793005
+OpStore %22 %27
+%28 = OpLoad %ulong %22
+%30 = OpIAdd %ulong %28 %ulong_1442695040888963407
+OpStore %23 %30
+%31 = OpLoad %ulong %23
+%32 = OpLoad %ulong %20
+%33 = OpIAdd %ulong %31 %32
+OpStore %24 %33
+%34 = OpLoad %ulong %24
+OpReturnValue %34
 OpFunctionEnd
-%2 = OpFunction %ulong None %43
-%44 = OpFunctionParameter %ulong
-%45 = OpFunctionParameter %_struct_42
+%2 = OpFunction %ulong None %37
+%38 = OpFunctionParameter %ulong
+%39 = OpFunctionParameter %_struct_36
+%40 = OpLabel
+%51 = OpVariable %_ptr_Function__struct_36 Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_bool Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_uchar Function
+OpStore %52 %38
+OpStore %51 %39
+%68 = OpAccessChain %_ptr_Function_uchar %51 %uint_0
+%69 = OpLoad %uchar %68
+OpStore %65 %69
+OpBranch %41
+%41 = OpLabel
+%70 = OpLoad %uchar %65
+%71 = OpUConvert %ulong %70
+OpStore %53 %71
+OpBranch %43
+%43 = OpLabel
+%72 = OpLoad %ulong %52
+OpStore %62 %72
+OpStore %63 %ulong_0
+OpBranch %44
+%44 = OpLabel
+%74 = OpLoad %ulong %63
+%76 = OpULessThan %bool %74 %ulong_8
+OpStore %55 %76
+%77 = OpLoad %bool %55
+OpLoopMerge %46 %48 None
+OpBranchConditional %77 %45 %46
 %46 = OpLabel
-%48 = OpVariable %_ptr_Function__struct_42 Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_uchar Function
-OpStore %49 %44
-OpStore %48 %45
-%55 = OpAccessChain %_ptr_Function_uchar %48 %uint_0
-%56 = OpLoad %uchar %55
-OpStore %52 %56
-%57 = OpLoad %ulong %49
-%58 = OpLoad %uchar %52
-%59 = OpFunctionCall %ulong %15 %57 %58
-OpStore %50 %59
-%60 = OpLoad %ulong %50
-OpReturnValue %60
+OpBranch %47
+%47 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%78 = OpLoad %ulong %62
+OpReturnValue %78
+%45 = OpLabel
+%79 = OpLoad %ulong %63
+%80 = OpIMul %ulong %79 %ulong_8
+OpStore %56 %80
+%81 = OpLoad %ulong %53
+%82 = OpLoad %ulong %56
+%83 = OpShiftRightLogical %ulong %81 %82
+OpStore %57 %83
+%84 = OpLoad %ulong %57
+%86 = OpBitwiseAnd %ulong %84 %ulong_255
+OpStore %58 %86
+%87 = OpLoad %ulong %62
+%88 = OpLoad %ulong %58
+%89 = OpBitwiseXor %ulong %87 %88
+OpStore %59 %89
+%90 = OpLoad %ulong %59
+%92 = OpIMul %ulong %90 %ulong_1099511628211
+OpStore %60 %92
+%93 = OpLoad %ulong %63
+%95 = OpIAdd %ulong %93 %ulong_1
+OpStore %61 %95
+%96 = OpLoad %ulong %60
+OpStore %62 %96
+%97 = OpLoad %ulong %61
+OpStore %63 %97
+OpBranch %48
+%48 = OpLabel
+OpBranch %44
 OpFunctionEnd
-%3 = OpFunction %ulong None %62
-%63 = OpFunctionParameter %ulong
-%64 = OpFunctionParameter %_struct_61
-%65 = OpLabel
-%67 = OpVariable %_ptr_Function__struct_61 Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_uchar Function
-%72 = OpVariable %_ptr_Function_uchar Function
-OpStore %68 %63
-OpStore %67 %64
-%73 = OpAccessChain %_ptr_Function_uchar %67 %uint_0
-%74 = OpLoad %uchar %73
-OpStore %71 %74
-%76 = OpAccessChain %_ptr_Function_uchar %67 %uint_1
-%77 = OpLoad %uchar %76
-OpStore %72 %77
-%78 = OpLoad %ulong %68
-%79 = OpLoad %uchar %71
-%80 = OpFunctionCall %ulong %15 %78 %79
-OpStore %69 %80
-%81 = OpLoad %ulong %69
-%82 = OpLoad %uchar %72
-%83 = OpFunctionCall %ulong %15 %81 %82
-OpStore %70 %83
-%84 = OpLoad %ulong %70
-OpReturnValue %84
-OpFunctionEnd
-%4 = OpFunction %ulong None %87
-%88 = OpFunctionParameter %ulong
-%89 = OpFunctionParameter %_struct_86
-%90 = OpLabel
-%92 = OpVariable %_ptr_Function__struct_86 Function
-%93 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_ulong Function
-%95 = OpVariable %_ptr_Function_ulong Function
-%96 = OpVariable %_ptr_Function_ulong Function
-%97 = OpVariable %_ptr_Function_uchar Function
-%98 = OpVariable %_ptr_Function_uchar Function
-%100 = OpVariable %_ptr_Function_ushort Function
-OpStore %93 %88
-OpStore %92 %89
-%101 = OpAccessChain %_ptr_Function_uchar %92 %uint_0
-%102 = OpLoad %uchar %101
-OpStore %97 %102
-%103 = OpAccessChain %_ptr_Function_uchar %92 %uint_1
-%104 = OpLoad %uchar %103
-OpStore %98 %104
-%106 = OpAccessChain %_ptr_Function_ushort %92 %uint_2
-%107 = OpLoad %ushort %106
-OpStore %100 %107
-%108 = OpLoad %ulong %93
-%109 = OpLoad %uchar %97
-%110 = OpFunctionCall %ulong %15 %108 %109
-OpStore %94 %110
-%111 = OpLoad %ulong %94
-%112 = OpLoad %uchar %98
-%113 = OpFunctionCall %ulong %15 %111 %112
-OpStore %95 %113
-%114 = OpLoad %ulong %95
-%115 = OpLoad %ushort %100
-%116 = OpFunctionCall %ulong %16 %114 %115
-OpStore %96 %116
-%117 = OpLoad %ulong %96
-OpReturnValue %117
-OpFunctionEnd
-%5 = OpFunction %ulong None %119
-%120 = OpFunctionParameter %ulong
-%121 = OpFunctionParameter %_struct_118
-%122 = OpLabel
-%124 = OpVariable %_ptr_Function__struct_118 Function
+%3 = OpFunction %ulong None %99
+%100 = OpFunctionParameter %ulong
+%101 = OpFunctionParameter %_struct_98
+%102 = OpLabel
+%120 = OpVariable %_ptr_Function__struct_98 Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_bool Function
+%124 = OpVariable %_ptr_Function_ulong Function
 %125 = OpVariable %_ptr_Function_ulong Function
 %126 = OpVariable %_ptr_Function_ulong Function
 %127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_uint Function
-%131 = OpVariable %_ptr_Function_ushort Function
-%132 = OpVariable %_ptr_Function_uchar Function
-OpStore %125 %120
-OpStore %124 %121
-%133 = OpAccessChain %_ptr_Function_uint %124 %uint_0
-%134 = OpLoad %uint %133
-OpStore %130 %134
-%135 = OpAccessChain %_ptr_Function_ushort %124 %uint_1
-%136 = OpLoad %ushort %135
-OpStore %131 %136
-%137 = OpAccessChain %_ptr_Function_uchar %124 %uint_2
-%138 = OpLoad %uchar %137
-OpStore %132 %138
-%139 = OpLoad %ulong %125
-%140 = OpLoad %uint %130
-%141 = OpFunctionCall %ulong %17 %139 %140
-OpStore %126 %141
-%142 = OpLoad %ulong %126
-%143 = OpLoad %ushort %131
-%144 = OpFunctionCall %ulong %16 %142 %143
-OpStore %127 %144
-%145 = OpLoad %ulong %127
-%146 = OpLoad %uchar %132
-%147 = OpFunctionCall %ulong %15 %145 %146
-OpStore %128 %147
-%148 = OpLoad %ulong %128
-OpReturnValue %148
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_bool Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_uchar Function
+%143 = OpVariable %_ptr_Function_uchar Function
+OpStore %121 %100
+OpStore %120 %101
+%144 = OpAccessChain %_ptr_Function_uchar %120 %uint_0
+%145 = OpLoad %uchar %144
+OpStore %142 %145
+%147 = OpAccessChain %_ptr_Function_uchar %120 %uint_1
+%148 = OpLoad %uchar %147
+OpStore %143 %148
+OpBranch %103
+%103 = OpLabel
+%149 = OpLoad %uchar %142
+%150 = OpUConvert %ulong %149
+OpStore %122 %150
+OpBranch %105
+%105 = OpLabel
+%151 = OpLoad %ulong %121
+OpStore %130 %151
+OpStore %131 %ulong_0
+OpBranch %106
+%106 = OpLabel
+%152 = OpLoad %ulong %131
+%153 = OpULessThan %bool %152 %ulong_8
+OpStore %123 %153
+%154 = OpLoad %bool %123
+OpLoopMerge %108 %118 None
+OpBranchConditional %154 %107 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %104
+%104 = OpLabel
+OpBranch %110
+%110 = OpLabel
+%155 = OpLoad %uchar %143
+%156 = OpUConvert %ulong %155
+OpStore %132 %156
+OpBranch %112
+%112 = OpLabel
+%157 = OpLoad %ulong %130
+OpStore %140 %157
+OpStore %141 %ulong_0
+OpBranch %113
+%113 = OpLabel
+%158 = OpLoad %ulong %141
+%159 = OpULessThan %bool %158 %ulong_8
+OpStore %133 %159
+%160 = OpLoad %bool %133
+OpLoopMerge %115 %117 None
+OpBranchConditional %160 %114 %115
+%115 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%161 = OpLoad %ulong %140
+OpReturnValue %161
+%114 = OpLabel
+%162 = OpLoad %ulong %141
+%163 = OpIMul %ulong %162 %ulong_8
+OpStore %134 %163
+%164 = OpLoad %ulong %132
+%165 = OpLoad %ulong %134
+%166 = OpShiftRightLogical %ulong %164 %165
+OpStore %135 %166
+%167 = OpLoad %ulong %135
+%168 = OpBitwiseAnd %ulong %167 %ulong_255
+OpStore %136 %168
+%169 = OpLoad %ulong %140
+%170 = OpLoad %ulong %136
+%171 = OpBitwiseXor %ulong %169 %170
+OpStore %137 %171
+%172 = OpLoad %ulong %137
+%173 = OpIMul %ulong %172 %ulong_1099511628211
+OpStore %138 %173
+%174 = OpLoad %ulong %141
+%175 = OpIAdd %ulong %174 %ulong_1
+OpStore %139 %175
+%176 = OpLoad %ulong %138
+OpStore %140 %176
+%177 = OpLoad %ulong %139
+OpStore %141 %177
+OpBranch %117
+%107 = OpLabel
+%178 = OpLoad %ulong %131
+%179 = OpIMul %ulong %178 %ulong_8
+OpStore %124 %179
+%180 = OpLoad %ulong %122
+%181 = OpLoad %ulong %124
+%182 = OpShiftRightLogical %ulong %180 %181
+OpStore %125 %182
+%183 = OpLoad %ulong %125
+%184 = OpBitwiseAnd %ulong %183 %ulong_255
+OpStore %126 %184
+%185 = OpLoad %ulong %130
+%186 = OpLoad %ulong %126
+%187 = OpBitwiseXor %ulong %185 %186
+OpStore %127 %187
+%188 = OpLoad %ulong %127
+%189 = OpIMul %ulong %188 %ulong_1099511628211
+OpStore %128 %189
+%190 = OpLoad %ulong %131
+%191 = OpIAdd %ulong %190 %ulong_1
+OpStore %129 %191
+%192 = OpLoad %ulong %128
+OpStore %130 %192
+%193 = OpLoad %ulong %129
+OpStore %131 %193
+OpBranch %118
+%117 = OpLabel
+OpBranch %113
+%118 = OpLabel
+OpBranch %106
 OpFunctionEnd
-%6 = OpFunction %ulong None %149
-%150 = OpFunctionParameter %ulong
-%151 = OpLabel
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-OpStore %152 %150
-%166 = OpLoad %ulong %152
-%168 = OpFunctionCall %ulong %14 %166 %ulong_1
-OpStore %153 %168
-%169 = OpLoad %ulong %153
-%171 = OpFunctionCall %ulong %14 %169 %ulong_2
-OpStore %154 %171
-%172 = OpLoad %ulong %154
-%174 = OpFunctionCall %ulong %14 %172 %ulong_4
-OpStore %155 %174
-%175 = OpLoad %ulong %155
-%177 = OpFunctionCall %ulong %14 %175 %ulong_8
-OpStore %156 %177
-%178 = OpLoad %ulong %156
-%179 = OpFunctionCall %ulong %14 %178 %ulong_1
-OpStore %157 %179
-%180 = OpLoad %ulong %157
-%181 = OpFunctionCall %ulong %14 %180 %ulong_1
-OpStore %158 %181
-%182 = OpLoad %ulong %158
-%183 = OpFunctionCall %ulong %14 %182 %ulong_2
-OpStore %159 %183
-%184 = OpLoad %ulong %159
-%185 = OpFunctionCall %ulong %14 %184 %ulong_4
-OpStore %160 %185
-%186 = OpLoad %ulong %160
-%187 = OpFunctionCall %ulong %14 %186 %ulong_1
-OpStore %161 %187
-%188 = OpLoad %ulong %161
-%189 = OpFunctionCall %ulong %14 %188 %ulong_1
-OpStore %162 %189
-%190 = OpLoad %ulong %162
-%191 = OpFunctionCall %ulong %14 %190 %ulong_2
-OpStore %163 %191
-%192 = OpLoad %ulong %163
-%193 = OpFunctionCall %ulong %14 %192 %ulong_4
-OpStore %164 %193
-%194 = OpLoad %ulong %164
-%196 = OpFunctionCall %ulong %14 %194 %ulong_6
-OpStore %165 %196
-%197 = OpLoad %ulong %165
-OpReturnValue %197
-OpFunctionEnd
-%7 = OpFunction %ulong None %200
-%201 = OpFunctionParameter %ulong
-%202 = OpFunctionParameter %_struct_42
-%203 = OpFunctionParameter %uint
-%204 = OpFunctionParameter %_struct_61
-%205 = OpFunctionParameter %double
-%206 = OpFunctionParameter %_struct_86
-%207 = OpFunctionParameter %ulong
-%208 = OpFunctionParameter %_struct_118
-%209 = OpFunctionParameter %_struct_42
-%210 = OpFunctionParameter %_struct_61
-%211 = OpFunctionParameter %_struct_86
-%212 = OpFunctionParameter %_struct_118
-%213 = OpFunctionParameter %float
-%214 = OpFunctionParameter %ulong
-%215 = OpLabel
-%236 = OpVariable %_ptr_Function__struct_42 Function
-%237 = OpVariable %_ptr_Function__struct_61 Function
-%238 = OpVariable %_ptr_Function__struct_86 Function
-%239 = OpVariable %_ptr_Function__struct_118 Function
-%240 = OpVariable %_ptr_Function__struct_42 Function
-%241 = OpVariable %_ptr_Function__struct_61 Function
-%242 = OpVariable %_ptr_Function__struct_86 Function
-%243 = OpVariable %_ptr_Function__struct_118 Function
+%4 = OpFunction %ulong None %196
+%197 = OpFunctionParameter %ulong
+%198 = OpFunctionParameter %_struct_195
+%199 = OpLabel
+%225 = OpVariable %_ptr_Function__struct_195 Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_bool Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_bool Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
 %244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_uint Function
-%247 = OpVariable %_ptr_Function_double Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_float Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_bool Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
 %251 = OpVariable %_ptr_Function_ulong Function
 %252 = OpVariable %_ptr_Function_ulong Function
 %253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
 %255 = OpVariable %_ptr_Function_ulong Function
 %256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_uint Function
+%257 = OpVariable %_ptr_Function_uchar Function
+%258 = OpVariable %_ptr_Function_uchar Function
 %260 = OpVariable %_ptr_Function_ushort Function
-%261 = OpVariable %_ptr_Function_uchar Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_uchar Function
-%287 = OpVariable %_ptr_Function_uchar Function
-%288 = OpVariable %_ptr_Function_uchar Function
-%289 = OpVariable %_ptr_Function_uchar Function
-%290 = OpVariable %_ptr_Function_uchar Function
-%291 = OpVariable %_ptr_Function_ushort Function
-%292 = OpVariable %_ptr_Function_uint Function
-%293 = OpVariable %_ptr_Function_ushort Function
-%294 = OpVariable %_ptr_Function_uchar Function
-%295 = OpVariable %_ptr_Function_uchar Function
-%296 = OpVariable %_ptr_Function_uchar Function
-%297 = OpVariable %_ptr_Function_uchar Function
-%298 = OpVariable %_ptr_Function_uchar Function
-%299 = OpVariable %_ptr_Function_uchar Function
-%300 = OpVariable %_ptr_Function_ushort Function
-%301 = OpVariable %_ptr_Function_uint Function
-%302 = OpVariable %_ptr_Function_ushort Function
-%303 = OpVariable %_ptr_Function_uchar Function
-OpStore %244 %201
-OpStore %236 %202
-OpStore %245 %203
-OpStore %237 %204
-OpStore %247 %205
-OpStore %238 %206
-OpStore %248 %207
-OpStore %239 %208
-OpStore %240 %209
-OpStore %241 %210
-OpStore %242 %211
-OpStore %243 %212
-OpStore %250 %213
-OpStore %251 %214
-%304 = OpAccessChain %_ptr_Function_uchar %236 %uint_0
-%305 = OpLoad %uchar %304
-OpStore %286 %305
-%306 = OpAccessChain %_ptr_Function_uchar %237 %uint_0
-%307 = OpLoad %uchar %306
-OpStore %287 %307
-%308 = OpAccessChain %_ptr_Function_uchar %237 %uint_1
-%309 = OpLoad %uchar %308
-OpStore %288 %309
-%310 = OpAccessChain %_ptr_Function_uchar %238 %uint_0
-%311 = OpLoad %uchar %310
-OpStore %289 %311
-%312 = OpAccessChain %_ptr_Function_uchar %238 %uint_1
-%313 = OpLoad %uchar %312
-OpStore %290 %313
-%314 = OpAccessChain %_ptr_Function_ushort %238 %uint_2
-%315 = OpLoad %ushort %314
-OpStore %291 %315
-%316 = OpAccessChain %_ptr_Function_uint %239 %uint_0
-%317 = OpLoad %uint %316
-OpStore %292 %317
-%318 = OpAccessChain %_ptr_Function_ushort %239 %uint_1
-%319 = OpLoad %ushort %318
-OpStore %293 %319
-%320 = OpAccessChain %_ptr_Function_uchar %239 %uint_2
-%321 = OpLoad %uchar %320
-OpStore %294 %321
-%322 = OpAccessChain %_ptr_Function_uchar %240 %uint_0
-%323 = OpLoad %uchar %322
-OpStore %295 %323
-%324 = OpAccessChain %_ptr_Function_uchar %241 %uint_0
-%325 = OpLoad %uchar %324
-OpStore %296 %325
-%326 = OpAccessChain %_ptr_Function_uchar %241 %uint_1
-%327 = OpLoad %uchar %326
-OpStore %297 %327
-%328 = OpAccessChain %_ptr_Function_uchar %242 %uint_0
-%329 = OpLoad %uchar %328
-OpStore %298 %329
-%330 = OpAccessChain %_ptr_Function_uchar %242 %uint_1
-%331 = OpLoad %uchar %330
-OpStore %299 %331
-%332 = OpAccessChain %_ptr_Function_ushort %242 %uint_2
-%333 = OpLoad %ushort %332
-OpStore %300 %333
-%334 = OpAccessChain %_ptr_Function_uint %243 %uint_0
-%335 = OpLoad %uint %334
-OpStore %301 %335
-%336 = OpAccessChain %_ptr_Function_ushort %243 %uint_1
-%337 = OpLoad %ushort %336
-OpStore %302 %337
-%338 = OpAccessChain %_ptr_Function_uchar %243 %uint_2
-%339 = OpLoad %uchar %338
-OpStore %303 %339
-%340 = OpFunctionCall %ulong %13
-OpStore %252 %340
-%341 = OpLoad %ulong %252
-%342 = OpLoad %ulong %244
-%343 = OpFunctionCall %ulong %14 %341 %342
-OpStore %253 %343
+OpStore %226 %197
+OpStore %225 %198
+%261 = OpAccessChain %_ptr_Function_uchar %225 %uint_0
+%262 = OpLoad %uchar %261
+OpStore %257 %262
+%263 = OpAccessChain %_ptr_Function_uchar %225 %uint_1
+%264 = OpLoad %uchar %263
+OpStore %258 %264
+%266 = OpAccessChain %_ptr_Function_ushort %225 %uint_2
+%267 = OpLoad %ushort %266
+OpStore %260 %267
+OpBranch %200
+%200 = OpLabel
+%268 = OpLoad %uchar %257
+%269 = OpUConvert %ulong %268
+OpStore %227 %269
+OpBranch %202
+%202 = OpLabel
+%270 = OpLoad %ulong %226
+OpStore %235 %270
+OpStore %236 %ulong_0
+OpBranch %203
+%203 = OpLabel
+%271 = OpLoad %ulong %236
+%272 = OpULessThan %bool %271 %ulong_8
+OpStore %228 %272
+%273 = OpLoad %bool %228
+OpLoopMerge %205 %223 None
+OpBranchConditional %273 %204 %205
+%205 = OpLabel
+OpBranch %206
+%206 = OpLabel
+OpBranch %201
+%201 = OpLabel
+OpBranch %207
+%207 = OpLabel
+%274 = OpLoad %uchar %258
+%275 = OpUConvert %ulong %274
+OpStore %237 %275
+OpBranch %209
+%209 = OpLabel
+%276 = OpLoad %ulong %235
+OpStore %245 %276
+OpStore %246 %ulong_0
+OpBranch %210
+%210 = OpLabel
+%277 = OpLoad %ulong %246
+%278 = OpULessThan %bool %277 %ulong_8
+OpStore %238 %278
+%279 = OpLoad %bool %238
+OpLoopMerge %212 %222 None
+OpBranchConditional %279 %211 %212
+%212 = OpLabel
+OpBranch %213
+%213 = OpLabel
+OpBranch %208
+%208 = OpLabel
+OpBranch %214
+%214 = OpLabel
+%280 = OpLoad %ushort %260
+%281 = OpUConvert %ulong %280
+OpStore %247 %281
 OpBranch %216
 %216 = OpLabel
-%344 = OpLoad %ulong %253
-%345 = OpLoad %uchar %286
-%346 = OpFunctionCall %ulong %15 %344 %345
-OpStore %262 %346
+%282 = OpLoad %ulong %245
+OpStore %255 %282
+OpStore %256 %ulong_0
 OpBranch %217
 %217 = OpLabel
-%347 = OpLoad %ulong %262
-%348 = OpLoad %uint %245
-%349 = OpFunctionCall %ulong %17 %347 %348
-OpStore %254 %349
-OpBranch %218
-%218 = OpLabel
-%350 = OpLoad %ulong %254
-%351 = OpLoad %uchar %287
-%352 = OpFunctionCall %ulong %15 %350 %351
-OpStore %263 %352
-%353 = OpLoad %ulong %263
-%354 = OpLoad %uchar %288
-%355 = OpFunctionCall %ulong %15 %353 %354
-OpStore %264 %355
-OpBranch %219
+%283 = OpLoad %ulong %256
+%284 = OpULessThan %bool %283 %ulong_8
+OpStore %248 %284
+%285 = OpLoad %bool %248
+OpLoopMerge %219 %221 None
+OpBranchConditional %285 %218 %219
 %219 = OpLabel
-%356 = OpLoad %ulong %264
-%357 = OpLoad %double %247
-%358 = OpFunctionCall %ulong %19 %356 %357
-OpStore %255 %358
 OpBranch %220
 %220 = OpLabel
-%359 = OpLoad %ulong %255
-%360 = OpLoad %uchar %289
-%361 = OpFunctionCall %ulong %15 %359 %360
-OpStore %265 %361
-%362 = OpLoad %ulong %265
-%363 = OpLoad %uchar %290
-%364 = OpFunctionCall %ulong %15 %362 %363
-OpStore %266 %364
-%365 = OpLoad %ulong %266
-%366 = OpLoad %ushort %291
-%367 = OpFunctionCall %ulong %16 %365 %366
-OpStore %267 %367
+OpBranch %215
+%215 = OpLabel
+%286 = OpLoad %ulong %255
+OpReturnValue %286
+%218 = OpLabel
+%287 = OpLoad %ulong %256
+%288 = OpIMul %ulong %287 %ulong_8
+OpStore %249 %288
+%289 = OpLoad %ulong %247
+%290 = OpLoad %ulong %249
+%291 = OpShiftRightLogical %ulong %289 %290
+OpStore %250 %291
+%292 = OpLoad %ulong %250
+%293 = OpBitwiseAnd %ulong %292 %ulong_255
+OpStore %251 %293
+%294 = OpLoad %ulong %255
+%295 = OpLoad %ulong %251
+%296 = OpBitwiseXor %ulong %294 %295
+OpStore %252 %296
+%297 = OpLoad %ulong %252
+%298 = OpIMul %ulong %297 %ulong_1099511628211
+OpStore %253 %298
+%299 = OpLoad %ulong %256
+%300 = OpIAdd %ulong %299 %ulong_1
+OpStore %254 %300
+%301 = OpLoad %ulong %253
+OpStore %255 %301
+%302 = OpLoad %ulong %254
+OpStore %256 %302
 OpBranch %221
-%221 = OpLabel
-%368 = OpLoad %ulong %267
-%369 = OpLoad %ulong %248
-%370 = OpFunctionCall %ulong %14 %368 %369
-OpStore %256 %370
+%211 = OpLabel
+%303 = OpLoad %ulong %246
+%304 = OpIMul %ulong %303 %ulong_8
+OpStore %239 %304
+%305 = OpLoad %ulong %237
+%306 = OpLoad %ulong %239
+%307 = OpShiftRightLogical %ulong %305 %306
+OpStore %240 %307
+%308 = OpLoad %ulong %240
+%309 = OpBitwiseAnd %ulong %308 %ulong_255
+OpStore %241 %309
+%310 = OpLoad %ulong %245
+%311 = OpLoad %ulong %241
+%312 = OpBitwiseXor %ulong %310 %311
+OpStore %242 %312
+%313 = OpLoad %ulong %242
+%314 = OpIMul %ulong %313 %ulong_1099511628211
+OpStore %243 %314
+%315 = OpLoad %ulong %246
+%316 = OpIAdd %ulong %315 %ulong_1
+OpStore %244 %316
+%317 = OpLoad %ulong %243
+OpStore %245 %317
+%318 = OpLoad %ulong %244
+OpStore %246 %318
 OpBranch %222
-%222 = OpLabel
-%371 = OpLoad %ulong %256
-%372 = OpLoad %uint %292
-%373 = OpFunctionCall %ulong %17 %371 %372
-OpStore %268 %373
-%374 = OpLoad %ulong %268
-%375 = OpLoad %ushort %293
-%376 = OpFunctionCall %ulong %16 %374 %375
-OpStore %269 %376
-%377 = OpLoad %ulong %269
-%378 = OpLoad %uchar %294
-%379 = OpFunctionCall %ulong %15 %377 %378
-OpStore %270 %379
+%204 = OpLabel
+%319 = OpLoad %ulong %236
+%320 = OpIMul %ulong %319 %ulong_8
+OpStore %229 %320
+%321 = OpLoad %ulong %227
+%322 = OpLoad %ulong %229
+%323 = OpShiftRightLogical %ulong %321 %322
+OpStore %230 %323
+%324 = OpLoad %ulong %230
+%325 = OpBitwiseAnd %ulong %324 %ulong_255
+OpStore %231 %325
+%326 = OpLoad %ulong %235
+%327 = OpLoad %ulong %231
+%328 = OpBitwiseXor %ulong %326 %327
+OpStore %232 %328
+%329 = OpLoad %ulong %232
+%330 = OpIMul %ulong %329 %ulong_1099511628211
+OpStore %233 %330
+%331 = OpLoad %ulong %236
+%332 = OpIAdd %ulong %331 %ulong_1
+OpStore %234 %332
+%333 = OpLoad %ulong %233
+OpStore %235 %333
+%334 = OpLoad %ulong %234
+OpStore %236 %334
 OpBranch %223
+%221 = OpLabel
+OpBranch %217
+%222 = OpLabel
+OpBranch %210
 %223 = OpLabel
-OpBranch %224
-%224 = OpLabel
-%380 = OpLoad %ulong %270
-%381 = OpLoad %uchar %295
-%382 = OpFunctionCall %ulong %15 %380 %381
-OpStore %271 %382
-OpBranch %225
-%225 = OpLabel
-OpBranch %226
-%226 = OpLabel
-%383 = OpLoad %ulong %271
-%384 = OpLoad %uchar %296
-%385 = OpFunctionCall %ulong %15 %383 %384
-OpStore %272 %385
-%386 = OpLoad %ulong %272
-%387 = OpLoad %uchar %297
-%388 = OpFunctionCall %ulong %15 %386 %387
-OpStore %273 %388
-OpBranch %227
-%227 = OpLabel
-OpBranch %228
-%228 = OpLabel
-%389 = OpLoad %ulong %273
-%390 = OpLoad %uchar %298
-%391 = OpFunctionCall %ulong %15 %389 %390
-OpStore %274 %391
-%392 = OpLoad %ulong %274
-%393 = OpLoad %uchar %299
-%394 = OpFunctionCall %ulong %15 %392 %393
-OpStore %275 %394
-%395 = OpLoad %ulong %275
-%396 = OpLoad %ushort %300
-%397 = OpFunctionCall %ulong %16 %395 %396
-OpStore %276 %397
-OpBranch %229
-%229 = OpLabel
-OpBranch %230
-%230 = OpLabel
-%398 = OpLoad %ulong %276
-%399 = OpLoad %uint %301
-%400 = OpFunctionCall %ulong %17 %398 %399
-OpStore %277 %400
-%401 = OpLoad %ulong %277
-%402 = OpLoad %ushort %302
-%403 = OpFunctionCall %ulong %16 %401 %402
-OpStore %278 %403
-%404 = OpLoad %ulong %278
-%405 = OpLoad %uchar %303
-%406 = OpFunctionCall %ulong %15 %404 %405
-OpStore %279 %406
-OpBranch %231
-%231 = OpLabel
-%407 = OpLoad %ulong %279
-%408 = OpLoad %float %250
-%409 = OpFunctionCall %ulong %18 %407 %408
-OpStore %257 %409
-%410 = OpLoad %ulong %257
-%411 = OpLoad %ulong %251
-%412 = OpFunctionCall %ulong %14 %410 %411
-OpStore %258 %412
-%413 = OpLoad %uint %292
-%414 = OpIAdd %uint %413 %uint_1
-OpStore %259 %414
-%415 = OpLoad %ushort %293
-%417 = OpIAdd %ushort %415 %ushort_2
-OpStore %260 %417
-%418 = OpLoad %uchar %294
-%420 = OpIAdd %uchar %418 %uchar_3
-OpStore %261 %420
-OpBranch %232
-%232 = OpLabel
-%421 = OpLoad %ulong %258
-%422 = OpLoad %uint %259
-%423 = OpFunctionCall %ulong %17 %421 %422
-OpStore %280 %423
-%424 = OpLoad %ulong %280
-%425 = OpLoad %ushort %260
-%426 = OpFunctionCall %ulong %16 %424 %425
-OpStore %281 %426
-%427 = OpLoad %ulong %281
-%428 = OpLoad %uchar %261
-%429 = OpFunctionCall %ulong %15 %427 %428
-OpStore %282 %429
-OpBranch %233
-%233 = OpLabel
-OpBranch %234
-%234 = OpLabel
-%430 = OpLoad %ulong %282
-%431 = OpLoad %uint %292
-%432 = OpFunctionCall %ulong %17 %430 %431
-OpStore %283 %432
-%433 = OpLoad %ulong %283
-%434 = OpLoad %ushort %293
-%435 = OpFunctionCall %ulong %16 %433 %434
-OpStore %284 %435
-%436 = OpLoad %ulong %284
-%437 = OpLoad %uchar %294
-%438 = OpFunctionCall %ulong %15 %436 %437
-OpStore %285 %438
-OpBranch %235
-%235 = OpLabel
-%439 = OpLoad %ulong %285
-OpReturnValue %439
+OpBranch %203
 OpFunctionEnd
-%8 = OpFunction %_struct_42 None %440
-%441 = OpFunctionParameter %ulong
-%442 = OpLabel
-%443 = OpVariable %_ptr_Function__struct_42 Function
-%444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_uchar Function
-OpStore %444 %441
-%446 = OpLoad %ulong %444
-%447 = OpUConvert %uchar %446
-OpStore %445 %447
-%448 = OpAccessChain %_ptr_Function_uchar %443 %uint_0
-%449 = OpLoad %uchar %445
-OpStore %448 %449
-%450 = OpLoad %_struct_42 %443
-OpReturnValue %450
+%5 = OpFunction %ulong None %336
+%337 = OpFunctionParameter %ulong
+%338 = OpFunctionParameter %_struct_335
+%339 = OpLabel
+%365 = OpVariable %_ptr_Function__struct_335 Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_bool Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_bool Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_bool Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_uint Function
+%399 = OpVariable %_ptr_Function_ushort Function
+%400 = OpVariable %_ptr_Function_uchar Function
+OpStore %366 %337
+OpStore %365 %338
+%401 = OpAccessChain %_ptr_Function_uint %365 %uint_0
+%402 = OpLoad %uint %401
+OpStore %398 %402
+%403 = OpAccessChain %_ptr_Function_ushort %365 %uint_1
+%404 = OpLoad %ushort %403
+OpStore %399 %404
+%405 = OpAccessChain %_ptr_Function_uchar %365 %uint_2
+%406 = OpLoad %uchar %405
+OpStore %400 %406
+OpBranch %340
+%340 = OpLabel
+%407 = OpLoad %uint %398
+%408 = OpUConvert %ulong %407
+OpStore %367 %408
+OpBranch %342
+%342 = OpLabel
+%409 = OpLoad %ulong %366
+OpStore %375 %409
+OpStore %376 %ulong_0
+OpBranch %343
+%343 = OpLabel
+%410 = OpLoad %ulong %376
+%411 = OpULessThan %bool %410 %ulong_8
+OpStore %368 %411
+%412 = OpLoad %bool %368
+OpLoopMerge %345 %363 None
+OpBranchConditional %412 %344 %345
+%345 = OpLabel
+OpBranch %346
+%346 = OpLabel
+OpBranch %341
+%341 = OpLabel
+OpBranch %347
+%347 = OpLabel
+%413 = OpLoad %ushort %399
+%414 = OpUConvert %ulong %413
+OpStore %377 %414
+OpBranch %349
+%349 = OpLabel
+%415 = OpLoad %ulong %375
+OpStore %385 %415
+OpStore %386 %ulong_0
+OpBranch %350
+%350 = OpLabel
+%416 = OpLoad %ulong %386
+%417 = OpULessThan %bool %416 %ulong_8
+OpStore %378 %417
+%418 = OpLoad %bool %378
+OpLoopMerge %352 %362 None
+OpBranchConditional %418 %351 %352
+%352 = OpLabel
+OpBranch %353
+%353 = OpLabel
+OpBranch %348
+%348 = OpLabel
+OpBranch %354
+%354 = OpLabel
+%419 = OpLoad %uchar %400
+%420 = OpUConvert %ulong %419
+OpStore %387 %420
+OpBranch %356
+%356 = OpLabel
+%421 = OpLoad %ulong %385
+OpStore %395 %421
+OpStore %396 %ulong_0
+OpBranch %357
+%357 = OpLabel
+%422 = OpLoad %ulong %396
+%423 = OpULessThan %bool %422 %ulong_8
+OpStore %388 %423
+%424 = OpLoad %bool %388
+OpLoopMerge %359 %361 None
+OpBranchConditional %424 %358 %359
+%359 = OpLabel
+OpBranch %360
+%360 = OpLabel
+OpBranch %355
+%355 = OpLabel
+%425 = OpLoad %ulong %395
+OpReturnValue %425
+%358 = OpLabel
+%426 = OpLoad %ulong %396
+%427 = OpIMul %ulong %426 %ulong_8
+OpStore %389 %427
+%428 = OpLoad %ulong %387
+%429 = OpLoad %ulong %389
+%430 = OpShiftRightLogical %ulong %428 %429
+OpStore %390 %430
+%431 = OpLoad %ulong %390
+%432 = OpBitwiseAnd %ulong %431 %ulong_255
+OpStore %391 %432
+%433 = OpLoad %ulong %395
+%434 = OpLoad %ulong %391
+%435 = OpBitwiseXor %ulong %433 %434
+OpStore %392 %435
+%436 = OpLoad %ulong %392
+%437 = OpIMul %ulong %436 %ulong_1099511628211
+OpStore %393 %437
+%438 = OpLoad %ulong %396
+%439 = OpIAdd %ulong %438 %ulong_1
+OpStore %394 %439
+%440 = OpLoad %ulong %393
+OpStore %395 %440
+%441 = OpLoad %ulong %394
+OpStore %396 %441
+OpBranch %361
+%351 = OpLabel
+%442 = OpLoad %ulong %386
+%443 = OpIMul %ulong %442 %ulong_8
+OpStore %379 %443
+%444 = OpLoad %ulong %377
+%445 = OpLoad %ulong %379
+%446 = OpShiftRightLogical %ulong %444 %445
+OpStore %380 %446
+%447 = OpLoad %ulong %380
+%448 = OpBitwiseAnd %ulong %447 %ulong_255
+OpStore %381 %448
+%449 = OpLoad %ulong %385
+%450 = OpLoad %ulong %381
+%451 = OpBitwiseXor %ulong %449 %450
+OpStore %382 %451
+%452 = OpLoad %ulong %382
+%453 = OpIMul %ulong %452 %ulong_1099511628211
+OpStore %383 %453
+%454 = OpLoad %ulong %386
+%455 = OpIAdd %ulong %454 %ulong_1
+OpStore %384 %455
+%456 = OpLoad %ulong %383
+OpStore %385 %456
+%457 = OpLoad %ulong %384
+OpStore %386 %457
+OpBranch %362
+%344 = OpLabel
+%458 = OpLoad %ulong %376
+%459 = OpIMul %ulong %458 %ulong_8
+OpStore %369 %459
+%460 = OpLoad %ulong %367
+%461 = OpLoad %ulong %369
+%462 = OpShiftRightLogical %ulong %460 %461
+OpStore %370 %462
+%463 = OpLoad %ulong %370
+%464 = OpBitwiseAnd %ulong %463 %ulong_255
+OpStore %371 %464
+%465 = OpLoad %ulong %375
+%466 = OpLoad %ulong %371
+%467 = OpBitwiseXor %ulong %465 %466
+OpStore %372 %467
+%468 = OpLoad %ulong %372
+%469 = OpIMul %ulong %468 %ulong_1099511628211
+OpStore %373 %469
+%470 = OpLoad %ulong %376
+%471 = OpIAdd %ulong %470 %ulong_1
+OpStore %374 %471
+%472 = OpLoad %ulong %373
+OpStore %375 %472
+%473 = OpLoad %ulong %374
+OpStore %376 %473
+OpBranch %363
+%361 = OpLabel
+OpBranch %357
+%362 = OpLabel
+OpBranch %350
+%363 = OpLabel
+OpBranch %343
 OpFunctionEnd
-%9 = OpFunction %_struct_61 None %451
-%452 = OpFunctionParameter %ulong
-%453 = OpLabel
-%454 = OpVariable %_ptr_Function__struct_61 Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_uchar Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_uchar Function
-OpStore %455 %452
-%459 = OpLoad %ulong %455
-%460 = OpUConvert %uchar %459
-OpStore %456 %460
-%461 = OpAccessChain %_ptr_Function_uchar %454 %uint_0
-%462 = OpLoad %uchar %456
-OpStore %461 %462
-%463 = OpLoad %ulong %455
-%464 = OpShiftRightLogical %ulong %463 %ulong_8
-OpStore %457 %464
-%465 = OpLoad %ulong %457
-%466 = OpUConvert %uchar %465
-OpStore %458 %466
-%467 = OpAccessChain %_ptr_Function_uchar %454 %uint_1
-%468 = OpLoad %uchar %458
-OpStore %467 %468
-%469 = OpLoad %_struct_61 %454
-OpReturnValue %469
-OpFunctionEnd
-%10 = OpFunction %_struct_86 None %470
-%471 = OpFunctionParameter %ulong
-%472 = OpLabel
-%473 = OpVariable %_ptr_Function__struct_86 Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_uchar Function
-%476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_uchar Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_ushort Function
-OpStore %474 %471
-%480 = OpLoad %ulong %474
-%481 = OpUConvert %uchar %480
-OpStore %475 %481
-%482 = OpAccessChain %_ptr_Function_uchar %473 %uint_0
-%483 = OpLoad %uchar %475
-OpStore %482 %483
-%484 = OpLoad %ulong %474
-%485 = OpShiftRightLogical %ulong %484 %ulong_8
-OpStore %476 %485
-%486 = OpLoad %ulong %476
-%487 = OpUConvert %uchar %486
-OpStore %477 %487
-%488 = OpAccessChain %_ptr_Function_uchar %473 %uint_1
-%489 = OpLoad %uchar %477
-OpStore %488 %489
-%490 = OpLoad %ulong %474
-%492 = OpShiftRightLogical %ulong %490 %ulong_16
-OpStore %478 %492
-%493 = OpLoad %ulong %478
-%494 = OpUConvert %ushort %493
-OpStore %479 %494
-%495 = OpAccessChain %_ptr_Function_ushort %473 %uint_2
-%496 = OpLoad %ushort %479
-OpStore %495 %496
-%497 = OpLoad %_struct_86 %473
-OpReturnValue %497
-OpFunctionEnd
-%11 = OpFunction %_struct_118 None %498
-%499 = OpFunctionParameter %ulong
+%6 = OpFunction %ulong None %474
+%475 = OpFunctionParameter %ulong
+%476 = OpLabel
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_bool Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_bool Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_bool Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_bool Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_ulong Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_bool Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_bool Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_bool Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_ulong Function
+%588 = OpVariable %_ptr_Function_ulong Function
+OpStore %519 %475
+OpBranch %477
+%477 = OpLabel
+%589 = OpLoad %ulong %519
+OpStore %533 %589
+OpStore %534 %ulong_0
+OpBranch %478
+%478 = OpLabel
+%590 = OpLoad %ulong %534
+%591 = OpULessThan %bool %590 %ulong_8
+OpStore %526 %591
+%592 = OpLoad %bool %526
+OpLoopMerge %480 %518 None
+OpBranchConditional %592 %479 %480
+%480 = OpLabel
+OpBranch %481
+%481 = OpLabel
+OpBranch %482
+%482 = OpLabel
+%593 = OpLoad %ulong %533
+OpStore %542 %593
+OpStore %543 %ulong_0
+OpBranch %483
+%483 = OpLabel
+%594 = OpLoad %ulong %543
+%595 = OpULessThan %bool %594 %ulong_8
+OpStore %535 %595
+%596 = OpLoad %bool %535
+OpLoopMerge %485 %517 None
+OpBranchConditional %596 %484 %485
+%485 = OpLabel
+OpBranch %486
+%486 = OpLabel
+OpBranch %487
+%487 = OpLabel
+%597 = OpLoad %ulong %542
+OpStore %551 %597
+OpStore %552 %ulong_0
+OpBranch %488
+%488 = OpLabel
+%598 = OpLoad %ulong %552
+%599 = OpULessThan %bool %598 %ulong_8
+OpStore %544 %599
+%600 = OpLoad %bool %544
+OpLoopMerge %490 %516 None
+OpBranchConditional %600 %489 %490
+%490 = OpLabel
+OpBranch %491
+%491 = OpLabel
+OpBranch %492
+%492 = OpLabel
+%601 = OpLoad %ulong %551
+OpStore %560 %601
+OpStore %561 %ulong_0
+OpBranch %493
+%493 = OpLabel
+%602 = OpLoad %ulong %561
+%603 = OpULessThan %bool %602 %ulong_8
+OpStore %553 %603
+%604 = OpLoad %bool %553
+OpLoopMerge %495 %515 None
+OpBranchConditional %604 %494 %495
+%495 = OpLabel
+OpBranch %496
+%496 = OpLabel
+OpBranch %497
+%497 = OpLabel
+%605 = OpLoad %ulong %560
+OpStore %569 %605
+OpStore %570 %ulong_0
+OpBranch %498
+%498 = OpLabel
+%606 = OpLoad %ulong %570
+%607 = OpULessThan %bool %606 %ulong_8
+OpStore %562 %607
+%608 = OpLoad %bool %562
+OpLoopMerge %500 %514 None
+OpBranchConditional %608 %499 %500
 %500 = OpLabel
-%501 = OpVariable %_ptr_Function__struct_118 Function
-%502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_uint Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ushort Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_uchar Function
-OpStore %502 %499
-%508 = OpLoad %ulong %502
-%509 = OpUConvert %uint %508
-OpStore %503 %509
-%510 = OpAccessChain %_ptr_Function_uint %501 %uint_0
-%511 = OpLoad %uint %503
-OpStore %510 %511
-%512 = OpLoad %ulong %502
-%514 = OpShiftRightLogical %ulong %512 %ulong_32
-OpStore %504 %514
-%515 = OpLoad %ulong %504
-%516 = OpUConvert %ushort %515
-OpStore %505 %516
-%517 = OpAccessChain %_ptr_Function_ushort %501 %uint_1
-%518 = OpLoad %ushort %505
-OpStore %517 %518
-%519 = OpLoad %ulong %502
-%521 = OpShiftRightLogical %ulong %519 %ulong_48
-OpStore %506 %521
-%522 = OpLoad %ulong %506
-%523 = OpUConvert %uchar %522
-OpStore %507 %523
-%524 = OpAccessChain %_ptr_Function_uchar %501 %uint_2
-%525 = OpLoad %uchar %507
-OpStore %524 %525
-%526 = OpLoad %_struct_118 %501
-OpReturnValue %526
+OpBranch %501
+%501 = OpLabel
+OpBranch %502
+%502 = OpLabel
+%609 = OpLoad %ulong %569
+OpStore %578 %609
+OpStore %579 %ulong_0
+OpBranch %503
+%503 = OpLabel
+%610 = OpLoad %ulong %579
+%611 = OpULessThan %bool %610 %ulong_8
+OpStore %571 %611
+%612 = OpLoad %bool %571
+OpLoopMerge %505 %513 None
+OpBranchConditional %612 %504 %505
+%505 = OpLabel
+OpBranch %506
+%506 = OpLabel
+OpBranch %507
+%507 = OpLabel
+%613 = OpLoad %ulong %578
+OpStore %587 %613
+OpStore %588 %ulong_0
+OpBranch %508
+%508 = OpLabel
+%614 = OpLoad %ulong %588
+%615 = OpULessThan %bool %614 %ulong_8
+OpStore %580 %615
+%616 = OpLoad %bool %580
+OpLoopMerge %510 %512 None
+OpBranchConditional %616 %509 %510
+%510 = OpLabel
+OpBranch %511
+%511 = OpLabel
+%617 = OpLoad %ulong %587
+%619 = OpFunctionCall %ulong %13 %617 %ulong_4
+OpStore %520 %619
+%620 = OpLoad %ulong %520
+%621 = OpFunctionCall %ulong %13 %620 %ulong_1
+OpStore %521 %621
+%622 = OpLoad %ulong %521
+%623 = OpFunctionCall %ulong %13 %622 %ulong_1
+OpStore %522 %623
+%624 = OpLoad %ulong %522
+%626 = OpFunctionCall %ulong %13 %624 %ulong_2
+OpStore %523 %626
+%627 = OpLoad %ulong %523
+%628 = OpFunctionCall %ulong %13 %627 %ulong_4
+OpStore %524 %628
+%629 = OpLoad %ulong %524
+%631 = OpFunctionCall %ulong %13 %629 %ulong_6
+OpStore %525 %631
+%632 = OpLoad %ulong %525
+OpReturnValue %632
+%509 = OpLabel
+%633 = OpLoad %ulong %588
+%634 = OpIMul %ulong %633 %ulong_8
+OpStore %581 %634
+%635 = OpLoad %ulong %581
+%636 = OpShiftRightLogical %ulong %ulong_2 %635
+OpStore %582 %636
+%637 = OpLoad %ulong %582
+%638 = OpBitwiseAnd %ulong %637 %ulong_255
+OpStore %583 %638
+%639 = OpLoad %ulong %587
+%640 = OpLoad %ulong %583
+%641 = OpBitwiseXor %ulong %639 %640
+OpStore %584 %641
+%642 = OpLoad %ulong %584
+%643 = OpIMul %ulong %642 %ulong_1099511628211
+OpStore %585 %643
+%644 = OpLoad %ulong %588
+%645 = OpIAdd %ulong %644 %ulong_1
+OpStore %586 %645
+%646 = OpLoad %ulong %585
+OpStore %587 %646
+%647 = OpLoad %ulong %586
+OpStore %588 %647
+OpBranch %512
+%504 = OpLabel
+%648 = OpLoad %ulong %579
+%649 = OpIMul %ulong %648 %ulong_8
+OpStore %572 %649
+%650 = OpLoad %ulong %572
+%651 = OpShiftRightLogical %ulong %ulong_1 %650
+OpStore %573 %651
+%652 = OpLoad %ulong %573
+%653 = OpBitwiseAnd %ulong %652 %ulong_255
+OpStore %574 %653
+%654 = OpLoad %ulong %578
+%655 = OpLoad %ulong %574
+%656 = OpBitwiseXor %ulong %654 %655
+OpStore %575 %656
+%657 = OpLoad %ulong %575
+%658 = OpIMul %ulong %657 %ulong_1099511628211
+OpStore %576 %658
+%659 = OpLoad %ulong %579
+%660 = OpIAdd %ulong %659 %ulong_1
+OpStore %577 %660
+%661 = OpLoad %ulong %576
+OpStore %578 %661
+%662 = OpLoad %ulong %577
+OpStore %579 %662
+OpBranch %513
+%499 = OpLabel
+%663 = OpLoad %ulong %570
+%664 = OpIMul %ulong %663 %ulong_8
+OpStore %563 %664
+%665 = OpLoad %ulong %563
+%666 = OpShiftRightLogical %ulong %ulong_1 %665
+OpStore %564 %666
+%667 = OpLoad %ulong %564
+%668 = OpBitwiseAnd %ulong %667 %ulong_255
+OpStore %565 %668
+%669 = OpLoad %ulong %569
+%670 = OpLoad %ulong %565
+%671 = OpBitwiseXor %ulong %669 %670
+OpStore %566 %671
+%672 = OpLoad %ulong %566
+%673 = OpIMul %ulong %672 %ulong_1099511628211
+OpStore %567 %673
+%674 = OpLoad %ulong %570
+%675 = OpIAdd %ulong %674 %ulong_1
+OpStore %568 %675
+%676 = OpLoad %ulong %567
+OpStore %569 %676
+%677 = OpLoad %ulong %568
+OpStore %570 %677
+OpBranch %514
+%494 = OpLabel
+%678 = OpLoad %ulong %561
+%679 = OpIMul %ulong %678 %ulong_8
+OpStore %554 %679
+%680 = OpLoad %ulong %554
+%681 = OpShiftRightLogical %ulong %ulong_8 %680
+OpStore %555 %681
+%682 = OpLoad %ulong %555
+%683 = OpBitwiseAnd %ulong %682 %ulong_255
+OpStore %556 %683
+%684 = OpLoad %ulong %560
+%685 = OpLoad %ulong %556
+%686 = OpBitwiseXor %ulong %684 %685
+OpStore %557 %686
+%687 = OpLoad %ulong %557
+%688 = OpIMul %ulong %687 %ulong_1099511628211
+OpStore %558 %688
+%689 = OpLoad %ulong %561
+%690 = OpIAdd %ulong %689 %ulong_1
+OpStore %559 %690
+%691 = OpLoad %ulong %558
+OpStore %560 %691
+%692 = OpLoad %ulong %559
+OpStore %561 %692
+OpBranch %515
+%489 = OpLabel
+%693 = OpLoad %ulong %552
+%694 = OpIMul %ulong %693 %ulong_8
+OpStore %545 %694
+%695 = OpLoad %ulong %545
+%696 = OpShiftRightLogical %ulong %ulong_4 %695
+OpStore %546 %696
+%697 = OpLoad %ulong %546
+%698 = OpBitwiseAnd %ulong %697 %ulong_255
+OpStore %547 %698
+%699 = OpLoad %ulong %551
+%700 = OpLoad %ulong %547
+%701 = OpBitwiseXor %ulong %699 %700
+OpStore %548 %701
+%702 = OpLoad %ulong %548
+%703 = OpIMul %ulong %702 %ulong_1099511628211
+OpStore %549 %703
+%704 = OpLoad %ulong %552
+%705 = OpIAdd %ulong %704 %ulong_1
+OpStore %550 %705
+%706 = OpLoad %ulong %549
+OpStore %551 %706
+%707 = OpLoad %ulong %550
+OpStore %552 %707
+OpBranch %516
+%484 = OpLabel
+%708 = OpLoad %ulong %543
+%709 = OpIMul %ulong %708 %ulong_8
+OpStore %536 %709
+%710 = OpLoad %ulong %536
+%711 = OpShiftRightLogical %ulong %ulong_2 %710
+OpStore %537 %711
+%712 = OpLoad %ulong %537
+%713 = OpBitwiseAnd %ulong %712 %ulong_255
+OpStore %538 %713
+%714 = OpLoad %ulong %542
+%715 = OpLoad %ulong %538
+%716 = OpBitwiseXor %ulong %714 %715
+OpStore %539 %716
+%717 = OpLoad %ulong %539
+%718 = OpIMul %ulong %717 %ulong_1099511628211
+OpStore %540 %718
+%719 = OpLoad %ulong %543
+%720 = OpIAdd %ulong %719 %ulong_1
+OpStore %541 %720
+%721 = OpLoad %ulong %540
+OpStore %542 %721
+%722 = OpLoad %ulong %541
+OpStore %543 %722
+OpBranch %517
+%479 = OpLabel
+%723 = OpLoad %ulong %534
+%724 = OpIMul %ulong %723 %ulong_8
+OpStore %527 %724
+%725 = OpLoad %ulong %527
+%726 = OpShiftRightLogical %ulong %ulong_1 %725
+OpStore %528 %726
+%727 = OpLoad %ulong %528
+%728 = OpBitwiseAnd %ulong %727 %ulong_255
+OpStore %529 %728
+%729 = OpLoad %ulong %533
+%730 = OpLoad %ulong %529
+%731 = OpBitwiseXor %ulong %729 %730
+OpStore %530 %731
+%732 = OpLoad %ulong %530
+%733 = OpIMul %ulong %732 %ulong_1099511628211
+OpStore %531 %733
+%734 = OpLoad %ulong %534
+%735 = OpIAdd %ulong %734 %ulong_1
+OpStore %532 %735
+%736 = OpLoad %ulong %531
+OpStore %533 %736
+%737 = OpLoad %ulong %532
+OpStore %534 %737
+OpBranch %518
+%512 = OpLabel
+OpBranch %508
+%513 = OpLabel
+OpBranch %503
+%514 = OpLabel
+OpBranch %498
+%515 = OpLabel
+OpBranch %493
+%516 = OpLabel
+OpBranch %488
+%517 = OpLabel
+OpBranch %483
+%518 = OpLabel
+OpBranch %478
 OpFunctionEnd
-%12 = OpFunction %ulong None %149
-%527 = OpFunctionParameter %ulong
-%528 = OpLabel
-%577 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
-%578 = OpVariable %_ptr_Function__struct_42 Function
-%579 = OpVariable %_ptr_Function__struct_42 Function
-%580 = OpVariable %_ptr_Function__struct_61 Function
-%581 = OpVariable %_ptr_Function__struct_61 Function
-%582 = OpVariable %_ptr_Function__struct_86 Function
-%583 = OpVariable %_ptr_Function__struct_86 Function
-%584 = OpVariable %_ptr_Function__struct_118 Function
-%585 = OpVariable %_ptr_Function__struct_118 Function
-%586 = OpVariable %_ptr_Function__struct_42 Function
-%587 = OpVariable %_ptr_Function__struct_42 Function
-%588 = OpVariable %_ptr_Function__struct_61 Function
-%589 = OpVariable %_ptr_Function__struct_61 Function
-%590 = OpVariable %_ptr_Function__struct_86 Function
-%591 = OpVariable %_ptr_Function__struct_86 Function
-%592 = OpVariable %_ptr_Function__struct_118 Function
-%593 = OpVariable %_ptr_Function__struct_118 Function
-%594 = OpVariable %_ptr_Function_ulong Function
-%595 = OpVariable %_ptr_Function_ulong Function
-%597 = OpVariable %_ptr_Function_bool Function
-%598 = OpVariable %_ptr_Function_ulong Function
-%599 = OpVariable %_ptr_Function_bool Function
-%600 = OpVariable %_ptr_Function_ulong Function
-%601 = OpVariable %_ptr_Function_ulong Function
-%602 = OpVariable %_ptr_Function_ulong Function
-%603 = OpVariable %_ptr_Function_ulong Function
-%604 = OpVariable %_ptr_Function_ulong Function
-%605 = OpVariable %_ptr_Function_ulong Function
-%606 = OpVariable %_ptr_Function_uint Function
-%607 = OpVariable %_ptr_Function_ulong Function
-%608 = OpVariable %_ptr_Function_ulong Function
-%609 = OpVariable %_ptr_Function_ulong Function
-%610 = OpVariable %_ptr_Function_double Function
-%611 = OpVariable %_ptr_Function_ulong Function
-%612 = OpVariable %_ptr_Function_ulong Function
-%613 = OpVariable %_ptr_Function_ulong Function
-%614 = OpVariable %_ptr_Function_ulong Function
-%615 = OpVariable %_ptr_Function_ulong Function
-%616 = OpVariable %_ptr_Function_ulong Function
-%617 = OpVariable %_ptr_Function_ulong Function
-%618 = OpVariable %_ptr_Function_ulong Function
-%619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_ulong Function
-%621 = OpVariable %_ptr_Function_float Function
-%622 = OpVariable %_ptr_Function_ulong Function
-%623 = OpVariable %_ptr_Function_ulong Function
-%624 = OpVariable %_ptr_Function_ulong Function
-%625 = OpVariable %_ptr_Function_ulong Function
-%626 = OpVariable %_ptr_Function_uint Function
-%627 = OpVariable %_ptr_Function_ulong Function
-%628 = OpVariable %_ptr_Function_double Function
-%629 = OpVariable %_ptr_Function_ulong Function
-%630 = OpVariable %_ptr_Function_ulong Function
-%631 = OpVariable %_ptr_Function_ulong Function
-%632 = OpVariable %_ptr_Function_ulong Function
-%633 = OpVariable %_ptr_Function_ulong Function
-%634 = OpVariable %_ptr_Function_ulong Function
-%635 = OpVariable %_ptr_Function_ulong Function
-%636 = OpVariable %_ptr_Function_float Function
-%637 = OpVariable %_ptr_Function_ulong Function
-%638 = OpVariable %_ptr_Function_ulong Function
-%639 = OpVariable %_ptr_Function_ulong Function
-%640 = OpVariable %_ptr_Function_ulong Function
-%641 = OpVariable %_ptr_Function_ulong Function
-%642 = OpVariable %_ptr_Function_ulong Function
-%643 = OpVariable %_ptr_Function_ulong Function
-%644 = OpVariable %_ptr_Function_ulong Function
-%645 = OpVariable %_ptr_Function_ulong Function
-%646 = OpVariable %_ptr_Function_ulong Function
-%647 = OpVariable %_ptr_Function_ulong Function
-%648 = OpVariable %_ptr_Function_ulong Function
-%649 = OpVariable %_ptr_Function_ulong Function
-%650 = OpVariable %_ptr_Function_ulong Function
-%651 = OpVariable %_ptr_Function_ulong Function
-%652 = OpVariable %_ptr_Function_ulong Function
-%653 = OpVariable %_ptr_Function_ulong Function
-%654 = OpVariable %_ptr_Function_ulong Function
-%655 = OpVariable %_ptr_Function_ulong Function
-%656 = OpVariable %_ptr_Function_ulong Function
-%657 = OpVariable %_ptr_Function_ulong Function
-%658 = OpVariable %_ptr_Function_ulong Function
-%659 = OpVariable %_ptr_Function_ulong Function
-%660 = OpVariable %_ptr_Function_uchar Function
-%661 = OpVariable %_ptr_Function_uchar Function
-%662 = OpVariable %_ptr_Function_uchar Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_uchar Function
-%665 = OpVariable %_ptr_Function_uchar Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_uchar Function
-%668 = OpVariable %_ptr_Function_uchar Function
-%669 = OpVariable %_ptr_Function_ulong Function
-%670 = OpVariable %_ptr_Function_uchar Function
-%671 = OpVariable %_ptr_Function_ulong Function
-%672 = OpVariable %_ptr_Function_ushort Function
-%673 = OpVariable %_ptr_Function_uchar Function
-%674 = OpVariable %_ptr_Function_ulong Function
-%675 = OpVariable %_ptr_Function_uchar Function
-%676 = OpVariable %_ptr_Function_ulong Function
-%677 = OpVariable %_ptr_Function_ushort Function
-%678 = OpVariable %_ptr_Function_uint Function
-%679 = OpVariable %_ptr_Function_ulong Function
-%680 = OpVariable %_ptr_Function_ushort Function
-%681 = OpVariable %_ptr_Function_ulong Function
-%682 = OpVariable %_ptr_Function_uchar Function
-%683 = OpVariable %_ptr_Function_uint Function
-%684 = OpVariable %_ptr_Function_ulong Function
-%685 = OpVariable %_ptr_Function_ushort Function
-%686 = OpVariable %_ptr_Function_ulong Function
-%687 = OpVariable %_ptr_Function_uchar Function
-%688 = OpVariable %_ptr_Function_uchar Function
-%689 = OpVariable %_ptr_Function_uchar Function
-%690 = OpVariable %_ptr_Function_uchar Function
-%691 = OpVariable %_ptr_Function_ulong Function
-%692 = OpVariable %_ptr_Function_uchar Function
-%693 = OpVariable %_ptr_Function_uchar Function
-%694 = OpVariable %_ptr_Function_ulong Function
-%695 = OpVariable %_ptr_Function_uchar Function
-%696 = OpVariable %_ptr_Function_uchar Function
-%697 = OpVariable %_ptr_Function_ulong Function
-%698 = OpVariable %_ptr_Function_uchar Function
-%699 = OpVariable %_ptr_Function_ulong Function
-%700 = OpVariable %_ptr_Function_ushort Function
-%701 = OpVariable %_ptr_Function_uchar Function
-%702 = OpVariable %_ptr_Function_ulong Function
-%703 = OpVariable %_ptr_Function_uchar Function
-%704 = OpVariable %_ptr_Function_ulong Function
-%705 = OpVariable %_ptr_Function_ushort Function
-%706 = OpVariable %_ptr_Function_uint Function
-%707 = OpVariable %_ptr_Function_ulong Function
-%708 = OpVariable %_ptr_Function_ushort Function
-%709 = OpVariable %_ptr_Function_ulong Function
-%710 = OpVariable %_ptr_Function_uchar Function
-%711 = OpVariable %_ptr_Function_uint Function
-%712 = OpVariable %_ptr_Function_ulong Function
-%713 = OpVariable %_ptr_Function_ushort Function
-%714 = OpVariable %_ptr_Function_ulong Function
-%715 = OpVariable %_ptr_Function_uchar Function
-OpStore %594 %527
-%716 = OpFunctionCall %ulong %13
-OpStore %595 %716
-OpBranch %535
-%535 = OpLabel
-%717 = OpLoad %ulong %595
-%718 = OpFunctionCall %ulong %14 %717 %ulong_1
-OpStore %644 %718
-%719 = OpLoad %ulong %644
-%720 = OpFunctionCall %ulong %14 %719 %ulong_2
-OpStore %645 %720
-%721 = OpLoad %ulong %645
-%722 = OpFunctionCall %ulong %14 %721 %ulong_4
-OpStore %646 %722
-%723 = OpLoad %ulong %646
-%724 = OpFunctionCall %ulong %14 %723 %ulong_8
-OpStore %647 %724
-%725 = OpLoad %ulong %647
-%726 = OpFunctionCall %ulong %14 %725 %ulong_1
-OpStore %648 %726
-%727 = OpLoad %ulong %648
-%728 = OpFunctionCall %ulong %14 %727 %ulong_1
-OpStore %649 %728
-%729 = OpLoad %ulong %649
-%730 = OpFunctionCall %ulong %14 %729 %ulong_2
-OpStore %650 %730
-%731 = OpLoad %ulong %650
-%732 = OpFunctionCall %ulong %14 %731 %ulong_4
-OpStore %651 %732
-%733 = OpLoad %ulong %651
-%734 = OpFunctionCall %ulong %14 %733 %ulong_1
-OpStore %652 %734
-%735 = OpLoad %ulong %652
-%736 = OpFunctionCall %ulong %14 %735 %ulong_1
-OpStore %653 %736
-%737 = OpLoad %ulong %653
-%738 = OpFunctionCall %ulong %14 %737 %ulong_2
-OpStore %654 %738
-%739 = OpLoad %ulong %654
-%740 = OpFunctionCall %ulong %14 %739 %ulong_4
-OpStore %655 %740
-%741 = OpLoad %ulong %655
-%742 = OpFunctionCall %ulong %14 %741 %ulong_6
-OpStore %656 %742
-OpBranch %536
-%536 = OpLabel
-OpStore %577 %743
-OpStore %641 %ulong_0
-OpBranch %529
-%529 = OpLabel
-%745 = OpLoad %ulong %641
-%747 = OpULessThan %bool %745 %ulong_12
-OpStore %597 %747
-%748 = OpLoad %bool %597
-OpLoopMerge %531 %572 None
-OpBranchConditional %748 %530 %531
-%531 = OpLabel
-%749 = OpLoad %ulong %656
-OpStore %640 %749
-OpStore %642 %ulong_0
-OpStore %643 %ulong_0
-OpBranch %532
-%532 = OpLabel
-%750 = OpLoad %ulong %643
-%752 = OpULessThan %bool %750 %ulong_3
-OpStore %599 %752
-%753 = OpLoad %bool %599
-OpLoopMerge %534 %571 None
-OpBranchConditional %753 %533 %534
-%534 = OpLabel
-OpBranch %541
-%541 = OpLabel
-%754 = OpLoad %ulong %642
-%755 = OpUConvert %uchar %754
-OpStore %661 %755
-%756 = OpAccessChain %_ptr_Function_uchar %579 %uint_0
-%757 = OpLoad %uchar %661
-OpStore %756 %757
-OpBranch %542
-%542 = OpLabel
-%758 = OpLoad %ulong %642
-%759 = OpUConvert %uint %758
-OpStore %626 %759
-OpBranch %545
-%545 = OpLabel
-%760 = OpLoad %ulong %642
-%761 = OpUConvert %uchar %760
-OpStore %665 %761
-%762 = OpAccessChain %_ptr_Function_uchar %581 %uint_0
-%763 = OpLoad %uchar %665
-OpStore %762 %763
-%764 = OpLoad %ulong %642
-%765 = OpShiftRightLogical %ulong %764 %ulong_8
-OpStore %666 %765
-%766 = OpLoad %ulong %666
-%767 = OpUConvert %uchar %766
-OpStore %667 %767
-%768 = OpAccessChain %_ptr_Function_uchar %581 %uint_1
-%769 = OpLoad %uchar %667
-OpStore %768 %769
-OpBranch %546
-%546 = OpLabel
-%770 = OpLoad %ulong %642
-%772 = OpBitwiseAnd %ulong %770 %ulong_1023
-OpStore %627 %772
-%773 = OpLoad %ulong %627
-%774 = OpConvertUToF %double %773
-OpStore %628 %774
-OpBranch %549
-%549 = OpLabel
-%775 = OpLoad %ulong %642
-%776 = OpUConvert %uchar %775
-OpStore %673 %776
-%777 = OpAccessChain %_ptr_Function_uchar %583 %uint_0
-%778 = OpLoad %uchar %673
-OpStore %777 %778
-%779 = OpLoad %ulong %642
-%780 = OpShiftRightLogical %ulong %779 %ulong_8
-OpStore %674 %780
-%781 = OpLoad %ulong %674
-%782 = OpUConvert %uchar %781
-OpStore %675 %782
-%783 = OpAccessChain %_ptr_Function_uchar %583 %uint_1
-%784 = OpLoad %uchar %675
-OpStore %783 %784
-%785 = OpLoad %ulong %642
-%786 = OpShiftRightLogical %ulong %785 %ulong_16
-OpStore %676 %786
-%787 = OpLoad %ulong %676
-%788 = OpUConvert %ushort %787
-OpStore %677 %788
-%789 = OpAccessChain %_ptr_Function_ushort %583 %uint_2
-%790 = OpLoad %ushort %677
-OpStore %789 %790
-OpBranch %550
-%550 = OpLabel
-%792 = OpAccessChain %_ptr_Function_ulong %577 %uint_6
-%793 = OpLoad %ulong %792
-OpStore %629 %793
-OpBranch %553
-%553 = OpLabel
-%794 = OpLoad %ulong %642
-%795 = OpUConvert %uint %794
-OpStore %683 %795
-%796 = OpAccessChain %_ptr_Function_uint %585 %uint_0
-%797 = OpLoad %uint %683
-OpStore %796 %797
-%798 = OpLoad %ulong %642
-%799 = OpShiftRightLogical %ulong %798 %ulong_32
-OpStore %684 %799
-%800 = OpLoad %ulong %684
-%801 = OpUConvert %ushort %800
-OpStore %685 %801
-%802 = OpAccessChain %_ptr_Function_ushort %585 %uint_1
-%803 = OpLoad %ushort %685
-OpStore %802 %803
-%804 = OpLoad %ulong %642
-%805 = OpShiftRightLogical %ulong %804 %ulong_48
-OpStore %686 %805
-%806 = OpLoad %ulong %686
-%807 = OpUConvert %uchar %806
-OpStore %687 %807
-%808 = OpAccessChain %_ptr_Function_uchar %585 %uint_2
-%809 = OpLoad %uchar %687
-OpStore %808 %809
-OpBranch %554
-%554 = OpLabel
-%811 = OpAccessChain %_ptr_Function_ulong %577 %uint_8
-%812 = OpLoad %ulong %811
-OpStore %630 %812
-OpBranch %557
-%557 = OpLabel
-%813 = OpLoad %ulong %630
-%814 = OpUConvert %uchar %813
-OpStore %689 %814
-%815 = OpAccessChain %_ptr_Function_uchar %587 %uint_0
-%816 = OpLoad %uchar %689
-OpStore %815 %816
-OpBranch %558
-%558 = OpLabel
-%818 = OpAccessChain %_ptr_Function_ulong %577 %uint_9
-%819 = OpLoad %ulong %818
-OpStore %631 %819
-OpBranch %561
-%561 = OpLabel
-%820 = OpLoad %ulong %631
-%821 = OpUConvert %uchar %820
-OpStore %693 %821
-%822 = OpAccessChain %_ptr_Function_uchar %589 %uint_0
-%823 = OpLoad %uchar %693
-OpStore %822 %823
-%824 = OpLoad %ulong %631
-%825 = OpShiftRightLogical %ulong %824 %ulong_8
-OpStore %694 %825
-%826 = OpLoad %ulong %694
-%827 = OpUConvert %uchar %826
-OpStore %695 %827
-%828 = OpAccessChain %_ptr_Function_uchar %589 %uint_1
-%829 = OpLoad %uchar %695
-OpStore %828 %829
-OpBranch %562
-%562 = OpLabel
-%831 = OpAccessChain %_ptr_Function_ulong %577 %uint_10
-%832 = OpLoad %ulong %831
-OpStore %632 %832
-OpBranch %565
-%565 = OpLabel
-%833 = OpLoad %ulong %632
-%834 = OpUConvert %uchar %833
-OpStore %701 %834
-%835 = OpAccessChain %_ptr_Function_uchar %591 %uint_0
-%836 = OpLoad %uchar %701
-OpStore %835 %836
-%837 = OpLoad %ulong %632
-%838 = OpShiftRightLogical %ulong %837 %ulong_8
-OpStore %702 %838
-%839 = OpLoad %ulong %702
-%840 = OpUConvert %uchar %839
-OpStore %703 %840
-%841 = OpAccessChain %_ptr_Function_uchar %591 %uint_1
-%842 = OpLoad %uchar %703
-OpStore %841 %842
-%843 = OpLoad %ulong %632
-%844 = OpShiftRightLogical %ulong %843 %ulong_16
-OpStore %704 %844
-%845 = OpLoad %ulong %704
-%846 = OpUConvert %ushort %845
-OpStore %705 %846
-%847 = OpAccessChain %_ptr_Function_ushort %591 %uint_2
-%848 = OpLoad %ushort %705
-OpStore %847 %848
-OpBranch %566
-%566 = OpLabel
-%850 = OpAccessChain %_ptr_Function_ulong %577 %uint_11
-%851 = OpLoad %ulong %850
-OpStore %633 %851
-OpBranch %569
-%569 = OpLabel
-%852 = OpLoad %ulong %633
-%853 = OpUConvert %uint %852
-OpStore %711 %853
-%854 = OpAccessChain %_ptr_Function_uint %593 %uint_0
-%855 = OpLoad %uint %711
-OpStore %854 %855
-%856 = OpLoad %ulong %633
-%857 = OpShiftRightLogical %ulong %856 %ulong_32
-OpStore %712 %857
-%858 = OpLoad %ulong %712
-%859 = OpUConvert %ushort %858
-OpStore %713 %859
-%860 = OpAccessChain %_ptr_Function_ushort %593 %uint_1
-%861 = OpLoad %ushort %713
-OpStore %860 %861
-%862 = OpLoad %ulong %633
-%863 = OpShiftRightLogical %ulong %862 %ulong_48
-OpStore %714 %863
-%864 = OpLoad %ulong %714
-%865 = OpUConvert %uchar %864
-OpStore %715 %865
-%866 = OpAccessChain %_ptr_Function_uchar %593 %uint_2
-%867 = OpLoad %uchar %715
-OpStore %866 %867
-OpBranch %570
-%570 = OpLabel
-%868 = OpAccessChain %_ptr_Function_ulong %577 %uint_0
-%869 = OpLoad %ulong %868
-OpStore %634 %869
-%870 = OpLoad %ulong %634
-%872 = OpBitwiseAnd %ulong %870 %ulong_255
-OpStore %635 %872
-%873 = OpLoad %ulong %635
-%874 = OpConvertUToF %float %873
-OpStore %636 %874
-%875 = OpAccessChain %_ptr_Function_ulong %577 %uint_2
-%876 = OpLoad %ulong %875
-OpStore %637 %876
-%877 = OpLoad %ulong %642
-%878 = OpLoad %_struct_42 %579
-%879 = OpLoad %uint %626
-%880 = OpLoad %_struct_61 %581
-%881 = OpLoad %double %628
-%882 = OpLoad %_struct_86 %583
-%883 = OpLoad %ulong %629
-%884 = OpLoad %_struct_118 %585
-%885 = OpLoad %_struct_42 %587
-%886 = OpLoad %_struct_61 %589
-%887 = OpLoad %_struct_86 %591
-%888 = OpLoad %_struct_118 %593
-%889 = OpLoad %float %636
-%890 = OpLoad %ulong %637
-%891 = OpFunctionCall %ulong %7 %877 %878 %879 %880 %881 %882 %883 %884 %885 %886 %887 %888 %889 %890
-OpStore %638 %891
-%892 = OpLoad %ulong %640
-%893 = OpLoad %ulong %638
-%894 = OpFunctionCall %ulong %14 %892 %893
-OpStore %639 %894
-%895 = OpLoad %ulong %639
-OpReturnValue %895
-%533 = OpLabel
-%896 = OpLoad %ulong %643
-%898 = OpIMul %ulong %896 %ulong_13
-OpStore %600 %898
-%899 = OpLoad %ulong %600
-%900 = OpLoad %ulong %594
-%901 = OpIAdd %ulong %899 %900
-OpStore %601 %901
-%902 = OpAccessChain %_ptr_Function_ulong %577 %uint_0
-%903 = OpLoad %ulong %902
-OpStore %602 %903
-%904 = OpLoad %ulong %602
-%905 = OpLoad %ulong %601
-%906 = OpIAdd %ulong %904 %905
-OpStore %603 %906
-%907 = OpAccessChain %_ptr_Function_ulong %577 %uint_1
-%908 = OpLoad %ulong %907
-OpStore %604 %908
-OpBranch %539
-%539 = OpLabel
-%909 = OpLoad %ulong %604
-%910 = OpUConvert %uchar %909
-OpStore %660 %910
-%911 = OpAccessChain %_ptr_Function_uchar %578 %uint_0
-%912 = OpLoad %uchar %660
-OpStore %911 %912
-OpBranch %540
-%540 = OpLabel
-%913 = OpAccessChain %_ptr_Function_ulong %577 %uint_2
-%914 = OpLoad %ulong %913
-OpStore %605 %914
-%915 = OpLoad %ulong %605
-%916 = OpUConvert %uint %915
-OpStore %606 %916
-%918 = OpAccessChain %_ptr_Function_ulong %577 %uint_3
-%919 = OpLoad %ulong %918
-OpStore %607 %919
-OpBranch %543
-%543 = OpLabel
-%920 = OpLoad %ulong %607
-%921 = OpUConvert %uchar %920
-OpStore %662 %921
-%922 = OpAccessChain %_ptr_Function_uchar %580 %uint_0
-%923 = OpLoad %uchar %662
-OpStore %922 %923
-%924 = OpLoad %ulong %607
-%925 = OpShiftRightLogical %ulong %924 %ulong_8
-OpStore %663 %925
-%926 = OpLoad %ulong %663
-%927 = OpUConvert %uchar %926
-OpStore %664 %927
-%928 = OpAccessChain %_ptr_Function_uchar %580 %uint_1
-%929 = OpLoad %uchar %664
-OpStore %928 %929
-OpBranch %544
-%544 = OpLabel
-%931 = OpAccessChain %_ptr_Function_ulong %577 %uint_4
-%932 = OpLoad %ulong %931
-OpStore %608 %932
-%933 = OpLoad %ulong %608
-%934 = OpBitwiseAnd %ulong %933 %ulong_1023
-OpStore %609 %934
-%935 = OpLoad %ulong %609
-%936 = OpConvertUToF %double %935
-OpStore %610 %936
-%938 = OpAccessChain %_ptr_Function_ulong %577 %uint_5
-%939 = OpLoad %ulong %938
-OpStore %611 %939
-OpBranch %547
-%547 = OpLabel
-%940 = OpLoad %ulong %611
-%941 = OpUConvert %uchar %940
-OpStore %668 %941
-%942 = OpAccessChain %_ptr_Function_uchar %582 %uint_0
-%943 = OpLoad %uchar %668
-OpStore %942 %943
-%944 = OpLoad %ulong %611
-%945 = OpShiftRightLogical %ulong %944 %ulong_8
-OpStore %669 %945
-%946 = OpLoad %ulong %669
-%947 = OpUConvert %uchar %946
-OpStore %670 %947
-%948 = OpAccessChain %_ptr_Function_uchar %582 %uint_1
-%949 = OpLoad %uchar %670
-OpStore %948 %949
-%950 = OpLoad %ulong %611
-%951 = OpShiftRightLogical %ulong %950 %ulong_16
-OpStore %671 %951
-%952 = OpLoad %ulong %671
-%953 = OpUConvert %ushort %952
-OpStore %672 %953
-%954 = OpAccessChain %_ptr_Function_ushort %582 %uint_2
-%955 = OpLoad %ushort %672
-OpStore %954 %955
-OpBranch %548
-%548 = OpLabel
-%956 = OpAccessChain %_ptr_Function_ulong %577 %uint_6
-%957 = OpLoad %ulong %956
-OpStore %612 %957
-%959 = OpAccessChain %_ptr_Function_ulong %577 %uint_7
-%960 = OpLoad %ulong %959
-OpStore %613 %960
-%961 = OpLoad %ulong %613
-%962 = OpLoad %ulong %601
-%963 = OpIAdd %ulong %961 %962
-OpStore %614 %963
-OpBranch %551
-%551 = OpLabel
-%964 = OpLoad %ulong %614
-%965 = OpUConvert %uint %964
-OpStore %678 %965
-%966 = OpAccessChain %_ptr_Function_uint %584 %uint_0
-%967 = OpLoad %uint %678
-OpStore %966 %967
-%968 = OpLoad %ulong %614
-%969 = OpShiftRightLogical %ulong %968 %ulong_32
-OpStore %679 %969
-%970 = OpLoad %ulong %679
-%971 = OpUConvert %ushort %970
-OpStore %680 %971
-%972 = OpAccessChain %_ptr_Function_ushort %584 %uint_1
-%973 = OpLoad %ushort %680
-OpStore %972 %973
-%974 = OpLoad %ulong %614
-%975 = OpShiftRightLogical %ulong %974 %ulong_48
-OpStore %681 %975
-%976 = OpLoad %ulong %681
-%977 = OpUConvert %uchar %976
-OpStore %682 %977
-%978 = OpAccessChain %_ptr_Function_uchar %584 %uint_2
-%979 = OpLoad %uchar %682
-OpStore %978 %979
-OpBranch %552
-%552 = OpLabel
-%980 = OpAccessChain %_ptr_Function_ulong %577 %uint_8
-%981 = OpLoad %ulong %980
-OpStore %615 %981
-OpBranch %555
-%555 = OpLabel
-%982 = OpLoad %ulong %615
-%983 = OpUConvert %uchar %982
-OpStore %688 %983
-%984 = OpAccessChain %_ptr_Function_uchar %586 %uint_0
-%985 = OpLoad %uchar %688
-OpStore %984 %985
-OpBranch %556
-%556 = OpLabel
-%986 = OpAccessChain %_ptr_Function_ulong %577 %uint_9
-%987 = OpLoad %ulong %986
-OpStore %616 %987
-OpBranch %559
-%559 = OpLabel
-%988 = OpLoad %ulong %616
-%989 = OpUConvert %uchar %988
-OpStore %690 %989
-%990 = OpAccessChain %_ptr_Function_uchar %588 %uint_0
-%991 = OpLoad %uchar %690
-OpStore %990 %991
-%992 = OpLoad %ulong %616
-%993 = OpShiftRightLogical %ulong %992 %ulong_8
-OpStore %691 %993
-%994 = OpLoad %ulong %691
-%995 = OpUConvert %uchar %994
-OpStore %692 %995
-%996 = OpAccessChain %_ptr_Function_uchar %588 %uint_1
-%997 = OpLoad %uchar %692
-OpStore %996 %997
-OpBranch %560
-%560 = OpLabel
-%998 = OpAccessChain %_ptr_Function_ulong %577 %uint_10
-%999 = OpLoad %ulong %998
-OpStore %617 %999
-OpBranch %563
-%563 = OpLabel
-%1000 = OpLoad %ulong %617
+%7 = OpFunction %ulong None %740
+%741 = OpFunctionParameter %ulong
+%742 = OpFunctionParameter %_struct_36
+%743 = OpFunctionParameter %uint
+%744 = OpFunctionParameter %_struct_98
+%745 = OpFunctionParameter %double
+%746 = OpFunctionParameter %_struct_195
+%747 = OpFunctionParameter %ulong
+%748 = OpFunctionParameter %_struct_335
+%749 = OpFunctionParameter %_struct_36
+%750 = OpFunctionParameter %_struct_98
+%751 = OpFunctionParameter %_struct_195
+%752 = OpFunctionParameter %_struct_335
+%753 = OpFunctionParameter %float
+%754 = OpFunctionParameter %ulong
+%755 = OpLabel
+%784 = OpVariable %_ptr_Function__struct_36 Function
+%785 = OpVariable %_ptr_Function__struct_98 Function
+%786 = OpVariable %_ptr_Function__struct_195 Function
+%787 = OpVariable %_ptr_Function__struct_335 Function
+%788 = OpVariable %_ptr_Function__struct_36 Function
+%789 = OpVariable %_ptr_Function__struct_98 Function
+%790 = OpVariable %_ptr_Function__struct_195 Function
+%791 = OpVariable %_ptr_Function__struct_335 Function
+%792 = OpVariable %_ptr_Function__struct_98 Function
+%793 = OpVariable %_ptr_Function__struct_195 Function
+%794 = OpVariable %_ptr_Function__struct_335 Function
+%795 = OpVariable %_ptr_Function__struct_98 Function
+%796 = OpVariable %_ptr_Function__struct_195 Function
+%797 = OpVariable %_ptr_Function__struct_335 Function
+%798 = OpVariable %_ptr_Function__struct_98 Function
+%799 = OpVariable %_ptr_Function__struct_195 Function
+%800 = OpVariable %_ptr_Function__struct_335 Function
+%801 = OpVariable %_ptr_Function__struct_98 Function
+%802 = OpVariable %_ptr_Function__struct_195 Function
+%803 = OpVariable %_ptr_Function__struct_335 Function
+%804 = OpVariable %_ptr_Function__struct_335 Function
+%805 = OpVariable %_ptr_Function__struct_335 Function
+%806 = OpVariable %_ptr_Function__struct_335 Function
+%807 = OpVariable %_ptr_Function__struct_335 Function
+%808 = OpVariable %_ptr_Function_ulong Function
+%809 = OpVariable %_ptr_Function_uint Function
+%811 = OpVariable %_ptr_Function_double Function
+%812 = OpVariable %_ptr_Function_ulong Function
+%814 = OpVariable %_ptr_Function_float Function
+%815 = OpVariable %_ptr_Function_ulong Function
+%816 = OpVariable %_ptr_Function_ulong Function
+%817 = OpVariable %_ptr_Function_ulong Function
+%818 = OpVariable %_ptr_Function_ulong Function
+%819 = OpVariable %_ptr_Function_ulong Function
+%820 = OpVariable %_ptr_Function_ulong Function
+%821 = OpVariable %_ptr_Function_ulong Function
+%822 = OpVariable %_ptr_Function_ulong Function
+%823 = OpVariable %_ptr_Function_ulong Function
+%824 = OpVariable %_ptr_Function_ulong Function
+%825 = OpVariable %_ptr_Function_uint Function
+%826 = OpVariable %_ptr_Function_uint Function
+%827 = OpVariable %_ptr_Function_ushort Function
+%828 = OpVariable %_ptr_Function_ushort Function
+%829 = OpVariable %_ptr_Function_uchar Function
+%830 = OpVariable %_ptr_Function_uchar Function
+%831 = OpVariable %_ptr_Function_ulong Function
+%832 = OpVariable %_ptr_Function_ulong Function
+%833 = OpVariable %_ptr_Function_ulong Function
+%834 = OpVariable %_ptr_Function_bool Function
+%835 = OpVariable %_ptr_Function_ulong Function
+%836 = OpVariable %_ptr_Function_ulong Function
+%837 = OpVariable %_ptr_Function_ulong Function
+%838 = OpVariable %_ptr_Function_ulong Function
+%839 = OpVariable %_ptr_Function_ulong Function
+%840 = OpVariable %_ptr_Function_ulong Function
+%841 = OpVariable %_ptr_Function_ulong Function
+%842 = OpVariable %_ptr_Function_ulong Function
+%843 = OpVariable %_ptr_Function_ulong Function
+%844 = OpVariable %_ptr_Function_ulong Function
+%845 = OpVariable %_ptr_Function_ulong Function
+%846 = OpVariable %_ptr_Function_ulong Function
+%847 = OpVariable %_ptr_Function_ulong Function
+%848 = OpVariable %_ptr_Function_bool Function
+%849 = OpVariable %_ptr_Function_ulong Function
+%850 = OpVariable %_ptr_Function_ulong Function
+%851 = OpVariable %_ptr_Function_ulong Function
+%852 = OpVariable %_ptr_Function_ulong Function
+%853 = OpVariable %_ptr_Function_ulong Function
+%854 = OpVariable %_ptr_Function_ulong Function
+%855 = OpVariable %_ptr_Function_ulong Function
+%856 = OpVariable %_ptr_Function_ulong Function
+%857 = OpVariable %_ptr_Function_uint Function
+%858 = OpVariable %_ptr_Function_ulong Function
+%859 = OpVariable %_ptr_Function_ulong Function
+%860 = OpVariable %_ptr_Function_uchar Function
+%861 = OpVariable %_ptr_Function_uchar Function
+OpStore %808 %741
+OpStore %784 %742
+OpStore %809 %743
+OpStore %785 %744
+OpStore %811 %745
+OpStore %786 %746
+OpStore %812 %747
+OpStore %787 %748
+OpStore %788 %749
+OpStore %789 %750
+OpStore %790 %751
+OpStore %791 %752
+OpStore %814 %753
+OpStore %815 %754
+%862 = OpAccessChain %_ptr_Function_uchar %784 %uint_0
+%863 = OpLoad %uchar %862
+OpStore %860 %863
+%864 = OpLoad %_struct_98 %785
+OpStore %792 %864
+%865 = OpLoad %_struct_195 %786
+OpStore %793 %865
+%866 = OpLoad %_struct_335 %787
+OpStore %794 %866
+%867 = OpAccessChain %_ptr_Function_uchar %788 %uint_0
+%868 = OpLoad %uchar %867
+OpStore %861 %868
+%869 = OpLoad %_struct_98 %789
+OpStore %795 %869
+%870 = OpLoad %_struct_195 %790
+OpStore %796 %870
+%871 = OpLoad %_struct_335 %791
+OpStore %797 %871
+OpBranch %756
+%756 = OpLabel
+OpBranch %757
+%757 = OpLabel
+%873 = OpLoad %ulong %808
+%874 = OpFunctionCall %ulong %13 %ulong_14695981039346656037 %873
+OpStore %816 %874
+OpBranch %758
+%758 = OpLabel
+OpBranch %759
+%759 = OpLabel
+%875 = OpLoad %uchar %860
+%876 = OpUConvert %ulong %875
+OpStore %833 %876
+OpBranch %761
+%761 = OpLabel
+%877 = OpLoad %ulong %816
+OpStore %841 %877
+OpStore %842 %ulong_0
+OpBranch %762
+%762 = OpLabel
+%878 = OpLoad %ulong %842
+%879 = OpULessThan %bool %878 %ulong_8
+OpStore %834 %879
+%880 = OpLoad %bool %834
+OpLoopMerge %764 %783 None
+OpBranchConditional %880 %763 %764
+%764 = OpLabel
+OpBranch %765
+%765 = OpLabel
+OpBranch %760
+%760 = OpLabel
+OpBranch %766
+%766 = OpLabel
+OpBranch %767
+%767 = OpLabel
+%881 = OpLoad %uint %809
+%882 = OpUConvert %ulong %881
+OpStore %843 %882
+%883 = OpLoad %ulong %841
+%884 = OpLoad %ulong %843
+%885 = OpFunctionCall %ulong %13 %883 %884
+OpStore %844 %885
+OpBranch %768
+%768 = OpLabel
+%886 = OpLoad %_struct_98 %792
+OpStore %798 %886
+%887 = OpLoad %ulong %844
+%888 = OpLoad %_struct_98 %798
+%889 = OpFunctionCall %ulong %3 %887 %888
+OpStore %817 %889
+OpBranch %769
+%769 = OpLabel
+%890 = OpLoad %double %811
+%891 = OpBitcast %ulong %890
+OpStore %845 %891
+%892 = OpLoad %ulong %817
+%893 = OpLoad %ulong %845
+%894 = OpFunctionCall %ulong %13 %892 %893
+OpStore %846 %894
+OpBranch %770
+%770 = OpLabel
+%895 = OpLoad %_struct_195 %793
+OpStore %799 %895
+%896 = OpLoad %ulong %846
+%897 = OpLoad %_struct_195 %799
+%898 = OpFunctionCall %ulong %4 %896 %897
+OpStore %818 %898
+%899 = OpLoad %ulong %818
+%900 = OpLoad %ulong %812
+%901 = OpFunctionCall %ulong %13 %899 %900
+OpStore %819 %901
+%902 = OpLoad %_struct_335 %794
+OpStore %800 %902
+%903 = OpLoad %ulong %819
+%904 = OpLoad %_struct_335 %800
+%905 = OpFunctionCall %ulong %5 %903 %904
+OpStore %820 %905
+OpBranch %771
+%771 = OpLabel
+OpBranch %772
+%772 = OpLabel
+%906 = OpLoad %uchar %861
+%907 = OpUConvert %ulong %906
+OpStore %847 %907
+OpBranch %774
+%774 = OpLabel
+%908 = OpLoad %ulong %820
+OpStore %855 %908
+OpStore %856 %ulong_0
+OpBranch %775
+%775 = OpLabel
+%909 = OpLoad %ulong %856
+%910 = OpULessThan %bool %909 %ulong_8
+OpStore %848 %910
+%911 = OpLoad %bool %848
+OpLoopMerge %777 %782 None
+OpBranchConditional %911 %776 %777
+%777 = OpLabel
+OpBranch %778
+%778 = OpLabel
+OpBranch %773
+%773 = OpLabel
+OpBranch %779
+%779 = OpLabel
+%912 = OpLoad %_struct_98 %795
+OpStore %801 %912
+%913 = OpLoad %ulong %855
+%914 = OpLoad %_struct_98 %801
+%915 = OpFunctionCall %ulong %3 %913 %914
+OpStore %821 %915
+%916 = OpLoad %_struct_195 %796
+OpStore %802 %916
+%917 = OpLoad %ulong %821
+%918 = OpLoad %_struct_195 %802
+%919 = OpFunctionCall %ulong %4 %917 %918
+OpStore %822 %919
+%920 = OpLoad %_struct_335 %797
+OpStore %803 %920
+%921 = OpLoad %ulong %822
+%922 = OpLoad %_struct_335 %803
+%923 = OpFunctionCall %ulong %5 %921 %922
+OpStore %823 %923
+OpBranch %780
+%780 = OpLabel
+%924 = OpLoad %float %814
+%925 = OpBitcast %uint %924
+OpStore %857 %925
+%926 = OpLoad %uint %857
+%927 = OpUConvert %ulong %926
+OpStore %858 %927
+%928 = OpLoad %ulong %823
+%929 = OpLoad %ulong %858
+%930 = OpFunctionCall %ulong %13 %928 %929
+OpStore %859 %930
+OpBranch %781
+%781 = OpLabel
+%931 = OpLoad %ulong %859
+%932 = OpLoad %ulong %815
+%933 = OpFunctionCall %ulong %13 %931 %932
+OpStore %824 %933
+%934 = OpLoad %_struct_335 %794
+OpStore %805 %934
+%935 = OpLoad %_struct_335 %805
+OpStore %804 %935
+%936 = OpAccessChain %_ptr_Function_uint %804 %uint_0
+%937 = OpLoad %uint %936
+OpStore %825 %937
+%938 = OpLoad %uint %825
+%939 = OpIAdd %uint %938 %uint_1
+OpStore %826 %939
+%940 = OpLoad %uint %826
+OpStore %936 %940
+%941 = OpAccessChain %_ptr_Function_ushort %804 %uint_1
+%942 = OpLoad %ushort %941
+OpStore %827 %942
+%943 = OpLoad %ushort %827
+%945 = OpIAdd %ushort %943 %ushort_2
+OpStore %828 %945
+%946 = OpLoad %ushort %828
+OpStore %941 %946
+%947 = OpAccessChain %_ptr_Function_uchar %804 %uint_2
+%948 = OpLoad %uchar %947
+OpStore %829 %948
+%949 = OpLoad %uchar %829
+%951 = OpIAdd %uchar %949 %uchar_3
+OpStore %830 %951
+%952 = OpLoad %uchar %830
+OpStore %947 %952
+%953 = OpLoad %_struct_335 %804
+OpStore %806 %953
+%954 = OpLoad %ulong %824
+%955 = OpLoad %_struct_335 %806
+%956 = OpFunctionCall %ulong %5 %954 %955
+OpStore %831 %956
+%957 = OpLoad %_struct_335 %794
+OpStore %807 %957
+%958 = OpLoad %ulong %831
+%959 = OpLoad %_struct_335 %807
+%960 = OpFunctionCall %ulong %5 %958 %959
+OpStore %832 %960
+%961 = OpLoad %ulong %832
+OpReturnValue %961
+%776 = OpLabel
+%962 = OpLoad %ulong %856
+%963 = OpIMul %ulong %962 %ulong_8
+OpStore %849 %963
+%964 = OpLoad %ulong %847
+%965 = OpLoad %ulong %849
+%966 = OpShiftRightLogical %ulong %964 %965
+OpStore %850 %966
+%967 = OpLoad %ulong %850
+%968 = OpBitwiseAnd %ulong %967 %ulong_255
+OpStore %851 %968
+%969 = OpLoad %ulong %855
+%970 = OpLoad %ulong %851
+%971 = OpBitwiseXor %ulong %969 %970
+OpStore %852 %971
+%972 = OpLoad %ulong %852
+%973 = OpIMul %ulong %972 %ulong_1099511628211
+OpStore %853 %973
+%974 = OpLoad %ulong %856
+%975 = OpIAdd %ulong %974 %ulong_1
+OpStore %854 %975
+%976 = OpLoad %ulong %853
+OpStore %855 %976
+%977 = OpLoad %ulong %854
+OpStore %856 %977
+OpBranch %782
+%763 = OpLabel
+%978 = OpLoad %ulong %842
+%979 = OpIMul %ulong %978 %ulong_8
+OpStore %835 %979
+%980 = OpLoad %ulong %833
+%981 = OpLoad %ulong %835
+%982 = OpShiftRightLogical %ulong %980 %981
+OpStore %836 %982
+%983 = OpLoad %ulong %836
+%984 = OpBitwiseAnd %ulong %983 %ulong_255
+OpStore %837 %984
+%985 = OpLoad %ulong %841
+%986 = OpLoad %ulong %837
+%987 = OpBitwiseXor %ulong %985 %986
+OpStore %838 %987
+%988 = OpLoad %ulong %838
+%989 = OpIMul %ulong %988 %ulong_1099511628211
+OpStore %839 %989
+%990 = OpLoad %ulong %842
+%991 = OpIAdd %ulong %990 %ulong_1
+OpStore %840 %991
+%992 = OpLoad %ulong %839
+OpStore %841 %992
+%993 = OpLoad %ulong %840
+OpStore %842 %993
+OpBranch %783
+%782 = OpLabel
+OpBranch %775
+%783 = OpLabel
+OpBranch %762
+OpFunctionEnd
+%8 = OpFunction %_struct_36 None %994
+%995 = OpFunctionParameter %ulong
+%996 = OpLabel
+%997 = OpVariable %_ptr_Function__struct_36 Function
+%998 = OpVariable %_ptr_Function_ulong Function
+%999 = OpVariable %_ptr_Function_uchar Function
+OpStore %998 %995
+%1000 = OpLoad %ulong %998
 %1001 = OpUConvert %uchar %1000
-OpStore %696 %1001
-%1002 = OpAccessChain %_ptr_Function_uchar %590 %uint_0
-%1003 = OpLoad %uchar %696
+OpStore %999 %1001
+%1002 = OpAccessChain %_ptr_Function_uchar %997 %uint_0
+%1003 = OpLoad %uchar %999
 OpStore %1002 %1003
-%1004 = OpLoad %ulong %617
-%1005 = OpShiftRightLogical %ulong %1004 %ulong_8
-OpStore %697 %1005
-%1006 = OpLoad %ulong %697
-%1007 = OpUConvert %uchar %1006
-OpStore %698 %1007
-%1008 = OpAccessChain %_ptr_Function_uchar %590 %uint_1
-%1009 = OpLoad %uchar %698
-OpStore %1008 %1009
-%1010 = OpLoad %ulong %617
-%1011 = OpShiftRightLogical %ulong %1010 %ulong_16
-OpStore %699 %1011
-%1012 = OpLoad %ulong %699
-%1013 = OpUConvert %ushort %1012
-OpStore %700 %1013
-%1014 = OpAccessChain %_ptr_Function_ushort %590 %uint_2
-%1015 = OpLoad %ushort %700
-OpStore %1014 %1015
-OpBranch %564
-%564 = OpLabel
-%1016 = OpAccessChain %_ptr_Function_ulong %577 %uint_11
-%1017 = OpLoad %ulong %1016
-OpStore %618 %1017
-OpBranch %567
-%567 = OpLabel
-%1018 = OpLoad %ulong %618
-%1019 = OpUConvert %uint %1018
-OpStore %706 %1019
-%1020 = OpAccessChain %_ptr_Function_uint %592 %uint_0
-%1021 = OpLoad %uint %706
-OpStore %1020 %1021
-%1022 = OpLoad %ulong %618
-%1023 = OpShiftRightLogical %ulong %1022 %ulong_32
-OpStore %707 %1023
-%1024 = OpLoad %ulong %707
-%1025 = OpUConvert %ushort %1024
-OpStore %708 %1025
-%1026 = OpAccessChain %_ptr_Function_ushort %592 %uint_1
-%1027 = OpLoad %ushort %708
-OpStore %1026 %1027
-%1028 = OpLoad %ulong %618
-%1029 = OpShiftRightLogical %ulong %1028 %ulong_48
-OpStore %709 %1029
-%1030 = OpLoad %ulong %709
-%1031 = OpUConvert %uchar %1030
-OpStore %710 %1031
-%1032 = OpAccessChain %_ptr_Function_uchar %592 %uint_2
-%1033 = OpLoad %uchar %710
-OpStore %1032 %1033
-OpBranch %568
-%568 = OpLabel
-%1034 = OpAccessChain %_ptr_Function_ulong %577 %uint_0
-%1035 = OpLoad %ulong %1034
-OpStore %619 %1035
-%1036 = OpLoad %ulong %619
-%1037 = OpBitwiseAnd %ulong %1036 %ulong_255
-OpStore %620 %1037
-%1038 = OpLoad %ulong %620
-%1039 = OpConvertUToF %float %1038
-OpStore %621 %1039
-%1040 = OpAccessChain %_ptr_Function_ulong %577 %uint_1
-%1041 = OpLoad %ulong %1040
-OpStore %622 %1041
-%1042 = OpLoad %ulong %603
-%1043 = OpLoad %_struct_42 %578
-%1044 = OpLoad %uint %606
-%1045 = OpLoad %_struct_61 %580
-%1046 = OpLoad %double %610
-%1047 = OpLoad %_struct_86 %582
-%1048 = OpLoad %ulong %612
-%1049 = OpLoad %_struct_118 %584
-%1050 = OpLoad %_struct_42 %586
-%1051 = OpLoad %_struct_61 %588
-%1052 = OpLoad %_struct_86 %590
-%1053 = OpLoad %_struct_118 %592
-%1054 = OpLoad %float %621
-%1055 = OpLoad %ulong %622
-%1056 = OpFunctionCall %ulong %7 %1042 %1043 %1044 %1045 %1046 %1047 %1048 %1049 %1050 %1051 %1052 %1053 %1054 %1055
-OpStore %623 %1056
-%1057 = OpLoad %ulong %640
-%1058 = OpLoad %ulong %623
-%1059 = OpFunctionCall %ulong %14 %1057 %1058
-OpStore %624 %1059
-%1060 = OpLoad %ulong %643
-%1061 = OpIAdd %ulong %1060 %ulong_1
-OpStore %625 %1061
-%1062 = OpLoad %ulong %624
-OpStore %640 %1062
-%1063 = OpLoad %ulong %623
-OpStore %642 %1063
-%1064 = OpLoad %ulong %625
-OpStore %643 %1064
-OpBranch %571
-%530 = OpLabel
-OpBranch %537
-%537 = OpLabel
-%1065 = OpLoad %ulong %641
-%1066 = OpIMul %ulong %1065 %ulong_6364136223846793005
-OpStore %657 %1066
-%1067 = OpLoad %ulong %657
-%1068 = OpIAdd %ulong %1067 %ulong_1442695040888963407
-OpStore %658 %1068
-%1069 = OpLoad %ulong %658
-%1070 = OpLoad %ulong %594
-%1071 = OpIAdd %ulong %1069 %1070
-OpStore %659 %1071
-OpBranch %538
-%538 = OpLabel
-%1072 = OpLoad %ulong %641
-%1073 = OpAccessChain %_ptr_Function_ulong %577 %1072
-%1074 = OpLoad %ulong %659
-OpStore %1073 %1074
-%1075 = OpLoad %ulong %641
-%1076 = OpIAdd %ulong %1075 %ulong_1
-OpStore %598 %1076
-%1077 = OpLoad %ulong %598
-OpStore %641 %1077
-OpBranch %572
-%571 = OpLabel
-OpBranch %532
-%572 = OpLabel
-OpBranch %529
+%1004 = OpLoad %_struct_36 %997
+OpReturnValue %1004
 OpFunctionEnd
-%13 = OpFunction %ulong None %1078
-%1079 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%9 = OpFunction %_struct_98 None %1005
+%1006 = OpFunctionParameter %ulong
+%1007 = OpLabel
+%1008 = OpVariable %_ptr_Function__struct_98 Function
+%1009 = OpVariable %_ptr_Function_ulong Function
+%1010 = OpVariable %_ptr_Function_uchar Function
+%1011 = OpVariable %_ptr_Function_ulong Function
+%1012 = OpVariable %_ptr_Function_uchar Function
+OpStore %1009 %1006
+%1013 = OpLoad %ulong %1009
+%1014 = OpUConvert %uchar %1013
+OpStore %1010 %1014
+%1015 = OpAccessChain %_ptr_Function_uchar %1008 %uint_0
+%1016 = OpLoad %uchar %1010
+OpStore %1015 %1016
+%1017 = OpLoad %ulong %1009
+%1018 = OpShiftRightLogical %ulong %1017 %ulong_8
+OpStore %1011 %1018
+%1019 = OpLoad %ulong %1011
+%1020 = OpUConvert %uchar %1019
+OpStore %1012 %1020
+%1021 = OpAccessChain %_ptr_Function_uchar %1008 %uint_1
+%1022 = OpLoad %uchar %1012
+OpStore %1021 %1022
+%1023 = OpLoad %_struct_98 %1008
+OpReturnValue %1023
 OpFunctionEnd
-%14 = OpFunction %ulong None %21
+%10 = OpFunction %_struct_195 None %1024
+%1025 = OpFunctionParameter %ulong
+%1026 = OpLabel
+%1027 = OpVariable %_ptr_Function__struct_195 Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_uchar Function
+%1030 = OpVariable %_ptr_Function_ulong Function
+%1031 = OpVariable %_ptr_Function_uchar Function
+%1032 = OpVariable %_ptr_Function_ulong Function
+%1033 = OpVariable %_ptr_Function_ushort Function
+OpStore %1028 %1025
+%1034 = OpLoad %ulong %1028
+%1035 = OpUConvert %uchar %1034
+OpStore %1029 %1035
+%1036 = OpAccessChain %_ptr_Function_uchar %1027 %uint_0
+%1037 = OpLoad %uchar %1029
+OpStore %1036 %1037
+%1038 = OpLoad %ulong %1028
+%1039 = OpShiftRightLogical %ulong %1038 %ulong_8
+OpStore %1030 %1039
+%1040 = OpLoad %ulong %1030
+%1041 = OpUConvert %uchar %1040
+OpStore %1031 %1041
+%1042 = OpAccessChain %_ptr_Function_uchar %1027 %uint_1
+%1043 = OpLoad %uchar %1031
+OpStore %1042 %1043
+%1044 = OpLoad %ulong %1028
+%1046 = OpShiftRightLogical %ulong %1044 %ulong_16
+OpStore %1032 %1046
+%1047 = OpLoad %ulong %1032
+%1048 = OpUConvert %ushort %1047
+OpStore %1033 %1048
+%1049 = OpAccessChain %_ptr_Function_ushort %1027 %uint_2
+%1050 = OpLoad %ushort %1033
+OpStore %1049 %1050
+%1051 = OpLoad %_struct_195 %1027
+OpReturnValue %1051
+OpFunctionEnd
+%11 = OpFunction %_struct_335 None %1052
+%1053 = OpFunctionParameter %ulong
+%1054 = OpLabel
+%1055 = OpVariable %_ptr_Function__struct_335 Function
+%1056 = OpVariable %_ptr_Function_ulong Function
+%1057 = OpVariable %_ptr_Function_uint Function
+%1058 = OpVariable %_ptr_Function_ulong Function
+%1059 = OpVariable %_ptr_Function_ushort Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_uchar Function
+OpStore %1056 %1053
+%1062 = OpLoad %ulong %1056
+%1063 = OpUConvert %uint %1062
+OpStore %1057 %1063
+%1064 = OpAccessChain %_ptr_Function_uint %1055 %uint_0
+%1065 = OpLoad %uint %1057
+OpStore %1064 %1065
+%1066 = OpLoad %ulong %1056
+%1068 = OpShiftRightLogical %ulong %1066 %ulong_32
+OpStore %1058 %1068
+%1069 = OpLoad %ulong %1058
+%1070 = OpUConvert %ushort %1069
+OpStore %1059 %1070
+%1071 = OpAccessChain %_ptr_Function_ushort %1055 %uint_1
+%1072 = OpLoad %ushort %1059
+OpStore %1071 %1072
+%1073 = OpLoad %ulong %1056
+%1075 = OpShiftRightLogical %ulong %1073 %ulong_48
+OpStore %1060 %1075
+%1076 = OpLoad %ulong %1060
+%1077 = OpUConvert %uchar %1076
+OpStore %1061 %1077
+%1078 = OpAccessChain %_ptr_Function_uchar %1055 %uint_2
+%1079 = OpLoad %uchar %1061
+OpStore %1078 %1079
+%1080 = OpLoad %_struct_335 %1055
+OpReturnValue %1080
+OpFunctionEnd
+%12 = OpFunction %ulong None %474
 %1081 = OpFunctionParameter %ulong
-%1082 = OpFunctionParameter %ulong
-%1083 = OpLabel
-%1088 = OpVariable %_ptr_Function_ulong Function
-%1089 = OpVariable %_ptr_Function_ulong Function
-%1090 = OpVariable %_ptr_Function_bool Function
-%1091 = OpVariable %_ptr_Function_ulong Function
-%1092 = OpVariable %_ptr_Function_ulong Function
-%1093 = OpVariable %_ptr_Function_ulong Function
-%1094 = OpVariable %_ptr_Function_ulong Function
-%1095 = OpVariable %_ptr_Function_ulong Function
-%1096 = OpVariable %_ptr_Function_ulong Function
-%1097 = OpVariable %_ptr_Function_ulong Function
-%1098 = OpVariable %_ptr_Function_ulong Function
-OpStore %1088 %1081
-OpStore %1089 %1082
-%1099 = OpLoad %ulong %1088
-OpStore %1097 %1099
-OpStore %1098 %ulong_0
-OpBranch %1084
-%1084 = OpLabel
-%1100 = OpLoad %ulong %1098
-%1101 = OpULessThan %bool %1100 %ulong_8
-OpStore %1090 %1101
-%1102 = OpLoad %bool %1090
-OpLoopMerge %1086 %1087 None
-OpBranchConditional %1102 %1085 %1086
-%1086 = OpLabel
-%1103 = OpLoad %ulong %1097
-OpReturnValue %1103
-%1085 = OpLabel
-%1104 = OpLoad %ulong %1098
-%1105 = OpIMul %ulong %1104 %ulong_8
-OpStore %1091 %1105
-%1106 = OpLoad %ulong %1089
-%1107 = OpLoad %ulong %1091
-%1108 = OpShiftRightLogical %ulong %1106 %1107
-OpStore %1092 %1108
-%1109 = OpLoad %ulong %1092
-%1110 = OpBitwiseAnd %ulong %1109 %ulong_255
-OpStore %1093 %1110
-%1111 = OpLoad %ulong %1097
-%1112 = OpLoad %ulong %1093
-%1113 = OpBitwiseXor %ulong %1111 %1112
-OpStore %1094 %1113
-%1114 = OpLoad %ulong %1094
-%1116 = OpIMul %ulong %1114 %ulong_1099511628211
-OpStore %1095 %1116
-%1117 = OpLoad %ulong %1098
-%1118 = OpIAdd %ulong %1117 %ulong_1
-OpStore %1096 %1118
-%1119 = OpLoad %ulong %1095
-OpStore %1097 %1119
-%1120 = OpLoad %ulong %1096
-OpStore %1098 %1120
-OpBranch %1087
-%1087 = OpLabel
-OpBranch %1084
-OpFunctionEnd
-%15 = OpFunction %ulong None %1121
-%1122 = OpFunctionParameter %ulong
-%1123 = OpFunctionParameter %uchar
-%1124 = OpLabel
-%1131 = OpVariable %_ptr_Function_ulong Function
-%1132 = OpVariable %_ptr_Function_uchar Function
-%1133 = OpVariable %_ptr_Function_ulong Function
-%1134 = OpVariable %_ptr_Function_bool Function
-%1135 = OpVariable %_ptr_Function_ulong Function
-%1136 = OpVariable %_ptr_Function_ulong Function
-%1137 = OpVariable %_ptr_Function_ulong Function
-%1138 = OpVariable %_ptr_Function_ulong Function
-%1139 = OpVariable %_ptr_Function_ulong Function
-%1140 = OpVariable %_ptr_Function_ulong Function
-%1141 = OpVariable %_ptr_Function_ulong Function
-%1142 = OpVariable %_ptr_Function_ulong Function
-OpStore %1131 %1122
-OpStore %1132 %1123
-%1143 = OpLoad %uchar %1132
-%1144 = OpUConvert %ulong %1143
-OpStore %1133 %1144
-OpBranch %1125
-%1125 = OpLabel
-%1145 = OpLoad %ulong %1131
-OpStore %1141 %1145
-OpStore %1142 %ulong_0
-OpBranch %1126
-%1126 = OpLabel
-%1146 = OpLoad %ulong %1142
-%1147 = OpULessThan %bool %1146 %ulong_8
-OpStore %1134 %1147
-%1148 = OpLoad %bool %1134
-OpLoopMerge %1128 %1130 None
-OpBranchConditional %1148 %1127 %1128
-%1128 = OpLabel
-OpBranch %1129
-%1129 = OpLabel
-%1149 = OpLoad %ulong %1141
-OpReturnValue %1149
-%1127 = OpLabel
-%1150 = OpLoad %ulong %1142
-%1151 = OpIMul %ulong %1150 %ulong_8
-OpStore %1135 %1151
-%1152 = OpLoad %ulong %1133
-%1153 = OpLoad %ulong %1135
-%1154 = OpShiftRightLogical %ulong %1152 %1153
-OpStore %1136 %1154
-%1155 = OpLoad %ulong %1136
-%1156 = OpBitwiseAnd %ulong %1155 %ulong_255
-OpStore %1137 %1156
-%1157 = OpLoad %ulong %1141
-%1158 = OpLoad %ulong %1137
-%1159 = OpBitwiseXor %ulong %1157 %1158
-OpStore %1138 %1159
-%1160 = OpLoad %ulong %1138
-%1161 = OpIMul %ulong %1160 %ulong_1099511628211
-OpStore %1139 %1161
-%1162 = OpLoad %ulong %1142
-%1163 = OpIAdd %ulong %1162 %ulong_1
-OpStore %1140 %1163
-%1164 = OpLoad %ulong %1139
-OpStore %1141 %1164
-%1165 = OpLoad %ulong %1140
-OpStore %1142 %1165
-OpBranch %1130
-%1130 = OpLabel
-OpBranch %1126
-OpFunctionEnd
-%16 = OpFunction %ulong None %1166
-%1167 = OpFunctionParameter %ulong
-%1168 = OpFunctionParameter %ushort
-%1169 = OpLabel
-%1176 = OpVariable %_ptr_Function_ulong Function
-%1177 = OpVariable %_ptr_Function_ushort Function
-%1178 = OpVariable %_ptr_Function_ulong Function
-%1179 = OpVariable %_ptr_Function_bool Function
-%1180 = OpVariable %_ptr_Function_ulong Function
-%1181 = OpVariable %_ptr_Function_ulong Function
-%1182 = OpVariable %_ptr_Function_ulong Function
-%1183 = OpVariable %_ptr_Function_ulong Function
-%1184 = OpVariable %_ptr_Function_ulong Function
-%1185 = OpVariable %_ptr_Function_ulong Function
-%1186 = OpVariable %_ptr_Function_ulong Function
-%1187 = OpVariable %_ptr_Function_ulong Function
-OpStore %1176 %1167
-OpStore %1177 %1168
-%1188 = OpLoad %ushort %1177
-%1189 = OpUConvert %ulong %1188
-OpStore %1178 %1189
-OpBranch %1170
-%1170 = OpLabel
-%1190 = OpLoad %ulong %1176
-OpStore %1186 %1190
-OpStore %1187 %ulong_0
-OpBranch %1171
-%1171 = OpLabel
-%1191 = OpLoad %ulong %1187
-%1192 = OpULessThan %bool %1191 %ulong_8
-OpStore %1179 %1192
-%1193 = OpLoad %bool %1179
-OpLoopMerge %1173 %1175 None
-OpBranchConditional %1193 %1172 %1173
-%1173 = OpLabel
-OpBranch %1174
-%1174 = OpLabel
-%1194 = OpLoad %ulong %1186
-OpReturnValue %1194
-%1172 = OpLabel
-%1195 = OpLoad %ulong %1187
-%1196 = OpIMul %ulong %1195 %ulong_8
-OpStore %1180 %1196
-%1197 = OpLoad %ulong %1178
-%1198 = OpLoad %ulong %1180
-%1199 = OpShiftRightLogical %ulong %1197 %1198
-OpStore %1181 %1199
-%1200 = OpLoad %ulong %1181
-%1201 = OpBitwiseAnd %ulong %1200 %ulong_255
-OpStore %1182 %1201
-%1202 = OpLoad %ulong %1186
-%1203 = OpLoad %ulong %1182
-%1204 = OpBitwiseXor %ulong %1202 %1203
-OpStore %1183 %1204
-%1205 = OpLoad %ulong %1183
-%1206 = OpIMul %ulong %1205 %ulong_1099511628211
-OpStore %1184 %1206
-%1207 = OpLoad %ulong %1187
-%1208 = OpIAdd %ulong %1207 %ulong_1
-OpStore %1185 %1208
-%1209 = OpLoad %ulong %1184
-OpStore %1186 %1209
-%1210 = OpLoad %ulong %1185
-OpStore %1187 %1210
-OpBranch %1175
-%1175 = OpLabel
-OpBranch %1171
-OpFunctionEnd
-%17 = OpFunction %ulong None %1211
-%1212 = OpFunctionParameter %ulong
-%1213 = OpFunctionParameter %uint
-%1214 = OpLabel
-%1221 = OpVariable %_ptr_Function_ulong Function
-%1222 = OpVariable %_ptr_Function_uint Function
-%1223 = OpVariable %_ptr_Function_ulong Function
-%1224 = OpVariable %_ptr_Function_bool Function
+%1082 = OpLabel
+%1171 = OpVariable %_ptr_Function__struct_36 Function
+%1172 = OpVariable %_ptr_Function__struct_36 Function
+%1176 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
+%1177 = OpVariable %_ptr_Function__struct_98 Function
+%1178 = OpVariable %_ptr_Function__struct_98 Function
+%1179 = OpVariable %_ptr_Function__struct_195 Function
+%1180 = OpVariable %_ptr_Function__struct_195 Function
+%1181 = OpVariable %_ptr_Function__struct_335 Function
+%1182 = OpVariable %_ptr_Function__struct_335 Function
+%1183 = OpVariable %_ptr_Function__struct_36 Function
+%1184 = OpVariable %_ptr_Function__struct_36 Function
+%1185 = OpVariable %_ptr_Function__struct_98 Function
+%1186 = OpVariable %_ptr_Function__struct_98 Function
+%1187 = OpVariable %_ptr_Function__struct_195 Function
+%1188 = OpVariable %_ptr_Function__struct_195 Function
+%1189 = OpVariable %_ptr_Function__struct_335 Function
+%1190 = OpVariable %_ptr_Function__struct_335 Function
+%1191 = OpVariable %_ptr_Function_ulong Function
+%1192 = OpVariable %_ptr_Function_bool Function
+%1193 = OpVariable %_ptr_Function_ulong Function
+%1194 = OpVariable %_ptr_Function_bool Function
+%1195 = OpVariable %_ptr_Function_ulong Function
+%1196 = OpVariable %_ptr_Function_ulong Function
+%1197 = OpVariable %_ptr_Function_ulong Function
+%1198 = OpVariable %_ptr_Function_ulong Function
+%1199 = OpVariable %_ptr_Function_ulong Function
+%1200 = OpVariable %_ptr_Function_ulong Function
+%1201 = OpVariable %_ptr_Function_uint Function
+%1202 = OpVariable %_ptr_Function_ulong Function
+%1203 = OpVariable %_ptr_Function_ulong Function
+%1204 = OpVariable %_ptr_Function_ulong Function
+%1205 = OpVariable %_ptr_Function_double Function
+%1206 = OpVariable %_ptr_Function_ulong Function
+%1207 = OpVariable %_ptr_Function_ulong Function
+%1208 = OpVariable %_ptr_Function_ulong Function
+%1209 = OpVariable %_ptr_Function_ulong Function
+%1210 = OpVariable %_ptr_Function_ulong Function
+%1211 = OpVariable %_ptr_Function_ulong Function
+%1212 = OpVariable %_ptr_Function_ulong Function
+%1213 = OpVariable %_ptr_Function_ulong Function
+%1214 = OpVariable %_ptr_Function_ulong Function
+%1215 = OpVariable %_ptr_Function_ulong Function
+%1216 = OpVariable %_ptr_Function_float Function
+%1217 = OpVariable %_ptr_Function_ulong Function
+%1218 = OpVariable %_ptr_Function_ulong Function
+%1219 = OpVariable %_ptr_Function_ulong Function
+%1220 = OpVariable %_ptr_Function_ulong Function
+%1221 = OpVariable %_ptr_Function_uint Function
+%1222 = OpVariable %_ptr_Function_ulong Function
+%1223 = OpVariable %_ptr_Function_double Function
+%1224 = OpVariable %_ptr_Function_ulong Function
 %1225 = OpVariable %_ptr_Function_ulong Function
 %1226 = OpVariable %_ptr_Function_ulong Function
 %1227 = OpVariable %_ptr_Function_ulong Function
 %1228 = OpVariable %_ptr_Function_ulong Function
 %1229 = OpVariable %_ptr_Function_ulong Function
 %1230 = OpVariable %_ptr_Function_ulong Function
-%1231 = OpVariable %_ptr_Function_ulong Function
+%1231 = OpVariable %_ptr_Function_float Function
 %1232 = OpVariable %_ptr_Function_ulong Function
-OpStore %1221 %1212
-OpStore %1222 %1213
-%1233 = OpLoad %uint %1222
-%1234 = OpUConvert %ulong %1233
-OpStore %1223 %1234
-OpBranch %1215
-%1215 = OpLabel
-%1235 = OpLoad %ulong %1221
-OpStore %1231 %1235
-OpStore %1232 %ulong_0
-OpBranch %1216
-%1216 = OpLabel
-%1236 = OpLoad %ulong %1232
-%1237 = OpULessThan %bool %1236 %ulong_8
-OpStore %1224 %1237
-%1238 = OpLoad %bool %1224
-OpLoopMerge %1218 %1220 None
-OpBranchConditional %1238 %1217 %1218
-%1218 = OpLabel
-OpBranch %1219
-%1219 = OpLabel
-%1239 = OpLoad %ulong %1231
-OpReturnValue %1239
-%1217 = OpLabel
-%1240 = OpLoad %ulong %1232
-%1241 = OpIMul %ulong %1240 %ulong_8
-OpStore %1225 %1241
-%1242 = OpLoad %ulong %1223
-%1243 = OpLoad %ulong %1225
-%1244 = OpShiftRightLogical %ulong %1242 %1243
-OpStore %1226 %1244
-%1245 = OpLoad %ulong %1226
-%1246 = OpBitwiseAnd %ulong %1245 %ulong_255
-OpStore %1227 %1246
-%1247 = OpLoad %ulong %1231
-%1248 = OpLoad %ulong %1227
-%1249 = OpBitwiseXor %ulong %1247 %1248
-OpStore %1228 %1249
-%1250 = OpLoad %ulong %1228
-%1251 = OpIMul %ulong %1250 %ulong_1099511628211
-OpStore %1229 %1251
-%1252 = OpLoad %ulong %1232
-%1253 = OpIAdd %ulong %1252 %ulong_1
-OpStore %1230 %1253
-%1254 = OpLoad %ulong %1229
-OpStore %1231 %1254
-%1255 = OpLoad %ulong %1230
-OpStore %1232 %1255
-OpBranch %1220
-%1220 = OpLabel
-OpBranch %1216
-OpFunctionEnd
-%18 = OpFunction %ulong None %1256
-%1257 = OpFunctionParameter %ulong
-%1258 = OpFunctionParameter %float
-%1259 = OpLabel
+%1233 = OpVariable %_ptr_Function_ulong Function
+%1234 = OpVariable %_ptr_Function_ulong Function
+%1235 = OpVariable %_ptr_Function_ulong Function
+%1236 = OpVariable %_ptr_Function_ulong Function
+%1237 = OpVariable %_ptr_Function_ulong Function
+%1238 = OpVariable %_ptr_Function_ulong Function
+%1239 = OpVariable %_ptr_Function_ulong Function
+%1240 = OpVariable %_ptr_Function_ulong Function
+%1241 = OpVariable %_ptr_Function_ulong Function
+%1242 = OpVariable %_ptr_Function_uchar Function
+%1243 = OpVariable %_ptr_Function_uchar Function
+%1244 = OpVariable %_ptr_Function_ulong Function
+%1245 = OpVariable %_ptr_Function_ulong Function
+%1246 = OpVariable %_ptr_Function_ulong Function
+%1247 = OpVariable %_ptr_Function_ulong Function
+%1248 = OpVariable %_ptr_Function_ulong Function
+%1249 = OpVariable %_ptr_Function_ulong Function
+%1250 = OpVariable %_ptr_Function_bool Function
+%1251 = OpVariable %_ptr_Function_ulong Function
+%1252 = OpVariable %_ptr_Function_ulong Function
+%1253 = OpVariable %_ptr_Function_ulong Function
+%1254 = OpVariable %_ptr_Function_ulong Function
+%1255 = OpVariable %_ptr_Function_ulong Function
+%1256 = OpVariable %_ptr_Function_ulong Function
+%1257 = OpVariable %_ptr_Function_ulong Function
+%1258 = OpVariable %_ptr_Function_ulong Function
+%1259 = OpVariable %_ptr_Function_bool Function
+%1260 = OpVariable %_ptr_Function_ulong Function
+%1261 = OpVariable %_ptr_Function_ulong Function
+%1262 = OpVariable %_ptr_Function_ulong Function
+%1263 = OpVariable %_ptr_Function_ulong Function
+%1264 = OpVariable %_ptr_Function_ulong Function
+%1265 = OpVariable %_ptr_Function_ulong Function
 %1266 = OpVariable %_ptr_Function_ulong Function
-%1267 = OpVariable %_ptr_Function_float Function
-%1268 = OpVariable %_ptr_Function_uint Function
+%1267 = OpVariable %_ptr_Function_ulong Function
+%1268 = OpVariable %_ptr_Function_bool Function
 %1269 = OpVariable %_ptr_Function_ulong Function
-%1270 = OpVariable %_ptr_Function_bool Function
+%1270 = OpVariable %_ptr_Function_ulong Function
 %1271 = OpVariable %_ptr_Function_ulong Function
 %1272 = OpVariable %_ptr_Function_ulong Function
 %1273 = OpVariable %_ptr_Function_ulong Function
 %1274 = OpVariable %_ptr_Function_ulong Function
 %1275 = OpVariable %_ptr_Function_ulong Function
 %1276 = OpVariable %_ptr_Function_ulong Function
-%1277 = OpVariable %_ptr_Function_ulong Function
+%1277 = OpVariable %_ptr_Function_bool Function
 %1278 = OpVariable %_ptr_Function_ulong Function
-OpStore %1266 %1257
-OpStore %1267 %1258
-%1279 = OpLoad %float %1267
-%1280 = OpBitcast %uint %1279
-OpStore %1268 %1280
-%1281 = OpLoad %uint %1268
-%1282 = OpUConvert %ulong %1281
-OpStore %1269 %1282
-OpBranch %1260
-%1260 = OpLabel
-%1283 = OpLoad %ulong %1266
-OpStore %1277 %1283
-OpStore %1278 %ulong_0
-OpBranch %1261
-%1261 = OpLabel
-%1284 = OpLoad %ulong %1278
-%1285 = OpULessThan %bool %1284 %ulong_8
-OpStore %1270 %1285
-%1286 = OpLoad %bool %1270
-OpLoopMerge %1263 %1265 None
-OpBranchConditional %1286 %1262 %1263
-%1263 = OpLabel
-OpBranch %1264
-%1264 = OpLabel
-%1287 = OpLoad %ulong %1277
-OpReturnValue %1287
-%1262 = OpLabel
-%1288 = OpLoad %ulong %1278
-%1289 = OpIMul %ulong %1288 %ulong_8
-OpStore %1271 %1289
-%1290 = OpLoad %ulong %1269
-%1291 = OpLoad %ulong %1271
-%1292 = OpShiftRightLogical %ulong %1290 %1291
-OpStore %1272 %1292
-%1293 = OpLoad %ulong %1272
-%1294 = OpBitwiseAnd %ulong %1293 %ulong_255
-OpStore %1273 %1294
-%1295 = OpLoad %ulong %1277
-%1296 = OpLoad %ulong %1273
-%1297 = OpBitwiseXor %ulong %1295 %1296
-OpStore %1274 %1297
-%1298 = OpLoad %ulong %1274
-%1299 = OpIMul %ulong %1298 %ulong_1099511628211
-OpStore %1275 %1299
-%1300 = OpLoad %ulong %1278
-%1301 = OpIAdd %ulong %1300 %ulong_1
-OpStore %1276 %1301
-%1302 = OpLoad %ulong %1275
-OpStore %1277 %1302
-%1303 = OpLoad %ulong %1276
-OpStore %1278 %1303
-OpBranch %1265
-%1265 = OpLabel
-OpBranch %1261
-OpFunctionEnd
-%19 = OpFunction %ulong None %1304
-%1305 = OpFunctionParameter %ulong
-%1306 = OpFunctionParameter %double
-%1307 = OpLabel
+%1279 = OpVariable %_ptr_Function_ulong Function
+%1280 = OpVariable %_ptr_Function_ulong Function
+%1281 = OpVariable %_ptr_Function_ulong Function
+%1282 = OpVariable %_ptr_Function_ulong Function
+%1283 = OpVariable %_ptr_Function_ulong Function
+%1284 = OpVariable %_ptr_Function_ulong Function
+%1285 = OpVariable %_ptr_Function_ulong Function
+%1286 = OpVariable %_ptr_Function_bool Function
+%1287 = OpVariable %_ptr_Function_ulong Function
+%1288 = OpVariable %_ptr_Function_ulong Function
+%1289 = OpVariable %_ptr_Function_ulong Function
+%1290 = OpVariable %_ptr_Function_ulong Function
+%1291 = OpVariable %_ptr_Function_ulong Function
+%1292 = OpVariable %_ptr_Function_ulong Function
+%1293 = OpVariable %_ptr_Function_ulong Function
+%1294 = OpVariable %_ptr_Function_ulong Function
+%1295 = OpVariable %_ptr_Function_bool Function
+%1296 = OpVariable %_ptr_Function_ulong Function
+%1297 = OpVariable %_ptr_Function_ulong Function
+%1298 = OpVariable %_ptr_Function_ulong Function
+%1299 = OpVariable %_ptr_Function_ulong Function
+%1300 = OpVariable %_ptr_Function_ulong Function
+%1301 = OpVariable %_ptr_Function_ulong Function
+%1302 = OpVariable %_ptr_Function_ulong Function
+%1303 = OpVariable %_ptr_Function_ulong Function
+%1304 = OpVariable %_ptr_Function_bool Function
+%1305 = OpVariable %_ptr_Function_ulong Function
+%1306 = OpVariable %_ptr_Function_ulong Function
+%1307 = OpVariable %_ptr_Function_ulong Function
+%1308 = OpVariable %_ptr_Function_ulong Function
+%1309 = OpVariable %_ptr_Function_ulong Function
+%1310 = OpVariable %_ptr_Function_ulong Function
+%1311 = OpVariable %_ptr_Function_ulong Function
+%1312 = OpVariable %_ptr_Function_ulong Function
+%1313 = OpVariable %_ptr_Function_uchar Function
 %1314 = OpVariable %_ptr_Function_ulong Function
-%1315 = OpVariable %_ptr_Function_double Function
-%1316 = OpVariable %_ptr_Function_ulong Function
-%1317 = OpVariable %_ptr_Function_bool Function
-%1318 = OpVariable %_ptr_Function_ulong Function
-%1319 = OpVariable %_ptr_Function_ulong Function
+%1315 = OpVariable %_ptr_Function_uchar Function
+%1316 = OpVariable %_ptr_Function_uchar Function
+%1317 = OpVariable %_ptr_Function_ulong Function
+%1318 = OpVariable %_ptr_Function_uchar Function
+%1319 = OpVariable %_ptr_Function_uchar Function
 %1320 = OpVariable %_ptr_Function_ulong Function
-%1321 = OpVariable %_ptr_Function_ulong Function
+%1321 = OpVariable %_ptr_Function_uchar Function
 %1322 = OpVariable %_ptr_Function_ulong Function
-%1323 = OpVariable %_ptr_Function_ulong Function
-%1324 = OpVariable %_ptr_Function_ulong Function
+%1323 = OpVariable %_ptr_Function_ushort Function
+%1324 = OpVariable %_ptr_Function_uchar Function
 %1325 = OpVariable %_ptr_Function_ulong Function
-OpStore %1314 %1305
-OpStore %1315 %1306
-%1326 = OpLoad %double %1315
-%1327 = OpBitcast %ulong %1326
-OpStore %1316 %1327
-OpBranch %1308
-%1308 = OpLabel
-%1328 = OpLoad %ulong %1314
-OpStore %1324 %1328
-OpStore %1325 %ulong_0
-OpBranch %1309
-%1309 = OpLabel
-%1329 = OpLoad %ulong %1325
-%1330 = OpULessThan %bool %1329 %ulong_8
-OpStore %1317 %1330
-%1331 = OpLoad %bool %1317
-OpLoopMerge %1311 %1313 None
-OpBranchConditional %1331 %1310 %1311
-%1311 = OpLabel
-OpBranch %1312
-%1312 = OpLabel
-%1332 = OpLoad %ulong %1324
-OpReturnValue %1332
-%1310 = OpLabel
-%1333 = OpLoad %ulong %1325
-%1334 = OpIMul %ulong %1333 %ulong_8
-OpStore %1318 %1334
-%1335 = OpLoad %ulong %1316
-%1336 = OpLoad %ulong %1318
-%1337 = OpShiftRightLogical %ulong %1335 %1336
-OpStore %1319 %1337
-%1338 = OpLoad %ulong %1319
-%1339 = OpBitwiseAnd %ulong %1338 %ulong_255
-OpStore %1320 %1339
-%1340 = OpLoad %ulong %1324
-%1341 = OpLoad %ulong %1320
-%1342 = OpBitwiseXor %ulong %1340 %1341
-OpStore %1321 %1342
-%1343 = OpLoad %ulong %1321
-%1344 = OpIMul %ulong %1343 %ulong_1099511628211
-OpStore %1322 %1344
-%1345 = OpLoad %ulong %1325
-%1346 = OpIAdd %ulong %1345 %ulong_1
-OpStore %1323 %1346
-%1347 = OpLoad %ulong %1322
-OpStore %1324 %1347
-%1348 = OpLoad %ulong %1323
-OpStore %1325 %1348
-OpBranch %1313
-%1313 = OpLabel
-OpBranch %1309
+%1326 = OpVariable %_ptr_Function_uchar Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_ushort Function
+%1329 = OpVariable %_ptr_Function_uint Function
+%1330 = OpVariable %_ptr_Function_ulong Function
+%1331 = OpVariable %_ptr_Function_ushort Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_uchar Function
+%1334 = OpVariable %_ptr_Function_uint Function
+%1335 = OpVariable %_ptr_Function_ulong Function
+%1336 = OpVariable %_ptr_Function_ushort Function
+%1337 = OpVariable %_ptr_Function_ulong Function
+%1338 = OpVariable %_ptr_Function_uchar Function
+%1339 = OpVariable %_ptr_Function_uchar Function
+%1340 = OpVariable %_ptr_Function_uchar Function
+%1341 = OpVariable %_ptr_Function_uchar Function
+%1342 = OpVariable %_ptr_Function_ulong Function
+%1343 = OpVariable %_ptr_Function_uchar Function
+%1344 = OpVariable %_ptr_Function_uchar Function
+%1345 = OpVariable %_ptr_Function_ulong Function
+%1346 = OpVariable %_ptr_Function_uchar Function
+%1347 = OpVariable %_ptr_Function_uchar Function
+%1348 = OpVariable %_ptr_Function_ulong Function
+%1349 = OpVariable %_ptr_Function_uchar Function
+%1350 = OpVariable %_ptr_Function_ulong Function
+%1351 = OpVariable %_ptr_Function_ushort Function
+%1352 = OpVariable %_ptr_Function_uchar Function
+%1353 = OpVariable %_ptr_Function_ulong Function
+%1354 = OpVariable %_ptr_Function_uchar Function
+%1355 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_ushort Function
+%1357 = OpVariable %_ptr_Function_uint Function
+%1358 = OpVariable %_ptr_Function_ulong Function
+%1359 = OpVariable %_ptr_Function_ushort Function
+%1360 = OpVariable %_ptr_Function_ulong Function
+%1361 = OpVariable %_ptr_Function_uchar Function
+%1362 = OpVariable %_ptr_Function_uint Function
+%1363 = OpVariable %_ptr_Function_ulong Function
+%1364 = OpVariable %_ptr_Function_ushort Function
+%1365 = OpVariable %_ptr_Function_ulong Function
+%1366 = OpVariable %_ptr_Function_uchar Function
+OpStore %1191 %1081
+OpBranch %1089
+%1089 = OpLabel
+OpBranch %1090
+%1090 = OpLabel
+OpBranch %1097
+%1097 = OpLabel
+OpBranch %1098
+%1098 = OpLabel
+OpStore %1257 %ulong_14695981039346656037
+OpStore %1258 %ulong_0
+OpBranch %1099
+%1099 = OpLabel
+%1367 = OpLoad %ulong %1258
+%1368 = OpULessThan %bool %1367 %ulong_8
+OpStore %1250 %1368
+%1369 = OpLoad %bool %1250
+OpLoopMerge %1101 %1170 None
+OpBranchConditional %1369 %1100 %1101
+%1101 = OpLabel
+OpBranch %1102
+%1102 = OpLabel
+OpBranch %1103
+%1103 = OpLabel
+%1370 = OpLoad %ulong %1257
+OpStore %1266 %1370
+OpStore %1267 %ulong_0
+OpBranch %1104
+%1104 = OpLabel
+%1371 = OpLoad %ulong %1267
+%1372 = OpULessThan %bool %1371 %ulong_8
+OpStore %1259 %1372
+%1373 = OpLoad %bool %1259
+OpLoopMerge %1106 %1169 None
+OpBranchConditional %1373 %1105 %1106
+%1106 = OpLabel
+OpBranch %1107
+%1107 = OpLabel
+OpBranch %1108
+%1108 = OpLabel
+%1374 = OpLoad %ulong %1266
+OpStore %1275 %1374
+OpStore %1276 %ulong_0
+OpBranch %1109
+%1109 = OpLabel
+%1375 = OpLoad %ulong %1276
+%1376 = OpULessThan %bool %1375 %ulong_8
+OpStore %1268 %1376
+%1377 = OpLoad %bool %1268
+OpLoopMerge %1111 %1168 None
+OpBranchConditional %1377 %1110 %1111
+%1111 = OpLabel
+OpBranch %1112
+%1112 = OpLabel
+OpBranch %1113
+%1113 = OpLabel
+%1378 = OpLoad %ulong %1275
+OpStore %1284 %1378
+OpStore %1285 %ulong_0
+OpBranch %1114
+%1114 = OpLabel
+%1379 = OpLoad %ulong %1285
+%1380 = OpULessThan %bool %1379 %ulong_8
+OpStore %1277 %1380
+%1381 = OpLoad %bool %1277
+OpLoopMerge %1116 %1167 None
+OpBranchConditional %1381 %1115 %1116
+%1116 = OpLabel
+OpBranch %1117
+%1117 = OpLabel
+OpBranch %1118
+%1118 = OpLabel
+%1382 = OpLoad %ulong %1284
+OpStore %1293 %1382
+OpStore %1294 %ulong_0
+OpBranch %1119
+%1119 = OpLabel
+%1383 = OpLoad %ulong %1294
+%1384 = OpULessThan %bool %1383 %ulong_8
+OpStore %1286 %1384
+%1385 = OpLoad %bool %1286
+OpLoopMerge %1121 %1166 None
+OpBranchConditional %1385 %1120 %1121
+%1121 = OpLabel
+OpBranch %1122
+%1122 = OpLabel
+OpBranch %1123
+%1123 = OpLabel
+%1386 = OpLoad %ulong %1293
+OpStore %1302 %1386
+OpStore %1303 %ulong_0
+OpBranch %1124
+%1124 = OpLabel
+%1387 = OpLoad %ulong %1303
+%1388 = OpULessThan %bool %1387 %ulong_8
+OpStore %1295 %1388
+%1389 = OpLoad %bool %1295
+OpLoopMerge %1126 %1165 None
+OpBranchConditional %1389 %1125 %1126
+%1126 = OpLabel
+OpBranch %1127
+%1127 = OpLabel
+OpBranch %1128
+%1128 = OpLabel
+%1390 = OpLoad %ulong %1302
+OpStore %1311 %1390
+OpStore %1312 %ulong_0
+OpBranch %1129
+%1129 = OpLabel
+%1391 = OpLoad %ulong %1312
+%1392 = OpULessThan %bool %1391 %ulong_8
+OpStore %1304 %1392
+%1393 = OpLoad %bool %1304
+OpLoopMerge %1131 %1164 None
+OpBranchConditional %1393 %1130 %1131
+%1131 = OpLabel
+OpBranch %1132
+%1132 = OpLabel
+%1394 = OpLoad %ulong %1311
+%1395 = OpFunctionCall %ulong %13 %1394 %ulong_4
+OpStore %1244 %1395
+%1396 = OpLoad %ulong %1244
+%1397 = OpFunctionCall %ulong %13 %1396 %ulong_1
+OpStore %1245 %1397
+%1398 = OpLoad %ulong %1245
+%1399 = OpFunctionCall %ulong %13 %1398 %ulong_1
+OpStore %1246 %1399
+%1400 = OpLoad %ulong %1246
+%1401 = OpFunctionCall %ulong %13 %1400 %ulong_2
+OpStore %1247 %1401
+%1402 = OpLoad %ulong %1247
+%1403 = OpFunctionCall %ulong %13 %1402 %ulong_4
+OpStore %1248 %1403
+%1404 = OpLoad %ulong %1248
+%1405 = OpFunctionCall %ulong %13 %1404 %ulong_6
+OpStore %1249 %1405
+OpBranch %1133
+%1133 = OpLabel
+OpStore %1176 %1406
+OpStore %1236 %ulong_0
+OpBranch %1083
+%1083 = OpLabel
+%1407 = OpLoad %ulong %1236
+%1409 = OpULessThan %bool %1407 %ulong_12
+OpStore %1192 %1409
+%1410 = OpLoad %bool %1192
+OpLoopMerge %1085 %1163 None
+OpBranchConditional %1410 %1084 %1085
+%1085 = OpLabel
+%1411 = OpLoad %ulong %1249
+OpStore %1235 %1411
+OpStore %1237 %ulong_0
+OpStore %1238 %ulong_0
+OpBranch %1086
+%1086 = OpLabel
+%1412 = OpLoad %ulong %1238
+%1414 = OpULessThan %bool %1412 %ulong_3
+OpStore %1194 %1414
+%1415 = OpLoad %bool %1194
+OpLoopMerge %1088 %1162 None
+OpBranchConditional %1415 %1087 %1088
+%1088 = OpLabel
+OpBranch %1095
+%1095 = OpLabel
+%1416 = OpLoad %ulong %1237
+%1417 = OpUConvert %uchar %1416
+OpStore %1243 %1417
+%1418 = OpAccessChain %_ptr_Function_uchar %1172 %uint_0
+%1419 = OpLoad %uchar %1243
+OpStore %1418 %1419
+OpBranch %1096
+%1096 = OpLabel
+%1420 = OpLoad %ulong %1237
+%1421 = OpUConvert %uint %1420
+OpStore %1221 %1421
+OpBranch %1136
+%1136 = OpLabel
+%1422 = OpLoad %ulong %1237
+%1423 = OpUConvert %uchar %1422
+OpStore %1316 %1423
+%1424 = OpAccessChain %_ptr_Function_uchar %1178 %uint_0
+%1425 = OpLoad %uchar %1316
+OpStore %1424 %1425
+%1426 = OpLoad %ulong %1237
+%1427 = OpShiftRightLogical %ulong %1426 %ulong_8
+OpStore %1317 %1427
+%1428 = OpLoad %ulong %1317
+%1429 = OpUConvert %uchar %1428
+OpStore %1318 %1429
+%1430 = OpAccessChain %_ptr_Function_uchar %1178 %uint_1
+%1431 = OpLoad %uchar %1318
+OpStore %1430 %1431
+OpBranch %1137
+%1137 = OpLabel
+%1432 = OpLoad %ulong %1237
+%1434 = OpBitwiseAnd %ulong %1432 %ulong_1023
+OpStore %1222 %1434
+%1435 = OpLoad %ulong %1222
+%1436 = OpConvertUToF %double %1435
+OpStore %1223 %1436
+OpBranch %1140
+%1140 = OpLabel
+%1437 = OpLoad %ulong %1237
+%1438 = OpUConvert %uchar %1437
+OpStore %1324 %1438
+%1439 = OpAccessChain %_ptr_Function_uchar %1180 %uint_0
+%1440 = OpLoad %uchar %1324
+OpStore %1439 %1440
+%1441 = OpLoad %ulong %1237
+%1442 = OpShiftRightLogical %ulong %1441 %ulong_8
+OpStore %1325 %1442
+%1443 = OpLoad %ulong %1325
+%1444 = OpUConvert %uchar %1443
+OpStore %1326 %1444
+%1445 = OpAccessChain %_ptr_Function_uchar %1180 %uint_1
+%1446 = OpLoad %uchar %1326
+OpStore %1445 %1446
+%1447 = OpLoad %ulong %1237
+%1448 = OpShiftRightLogical %ulong %1447 %ulong_16
+OpStore %1327 %1448
+%1449 = OpLoad %ulong %1327
+%1450 = OpUConvert %ushort %1449
+OpStore %1328 %1450
+%1451 = OpAccessChain %_ptr_Function_ushort %1180 %uint_2
+%1452 = OpLoad %ushort %1328
+OpStore %1451 %1452
+OpBranch %1141
+%1141 = OpLabel
+%1454 = OpAccessChain %_ptr_Function_ulong %1176 %uint_6
+%1455 = OpLoad %ulong %1454
+OpStore %1224 %1455
+OpBranch %1144
+%1144 = OpLabel
+%1456 = OpLoad %ulong %1237
+%1457 = OpUConvert %uint %1456
+OpStore %1334 %1457
+%1458 = OpAccessChain %_ptr_Function_uint %1182 %uint_0
+%1459 = OpLoad %uint %1334
+OpStore %1458 %1459
+%1460 = OpLoad %ulong %1237
+%1461 = OpShiftRightLogical %ulong %1460 %ulong_32
+OpStore %1335 %1461
+%1462 = OpLoad %ulong %1335
+%1463 = OpUConvert %ushort %1462
+OpStore %1336 %1463
+%1464 = OpAccessChain %_ptr_Function_ushort %1182 %uint_1
+%1465 = OpLoad %ushort %1336
+OpStore %1464 %1465
+%1466 = OpLoad %ulong %1237
+%1467 = OpShiftRightLogical %ulong %1466 %ulong_48
+OpStore %1337 %1467
+%1468 = OpLoad %ulong %1337
+%1469 = OpUConvert %uchar %1468
+OpStore %1338 %1469
+%1470 = OpAccessChain %_ptr_Function_uchar %1182 %uint_2
+%1471 = OpLoad %uchar %1338
+OpStore %1470 %1471
+OpBranch %1145
+%1145 = OpLabel
+%1473 = OpAccessChain %_ptr_Function_ulong %1176 %uint_8
+%1474 = OpLoad %ulong %1473
+OpStore %1225 %1474
+OpBranch %1148
+%1148 = OpLabel
+%1475 = OpLoad %ulong %1225
+%1476 = OpUConvert %uchar %1475
+OpStore %1340 %1476
+%1477 = OpAccessChain %_ptr_Function_uchar %1184 %uint_0
+%1478 = OpLoad %uchar %1340
+OpStore %1477 %1478
+OpBranch %1149
+%1149 = OpLabel
+%1480 = OpAccessChain %_ptr_Function_ulong %1176 %uint_9
+%1481 = OpLoad %ulong %1480
+OpStore %1226 %1481
+OpBranch %1152
+%1152 = OpLabel
+%1482 = OpLoad %ulong %1226
+%1483 = OpUConvert %uchar %1482
+OpStore %1344 %1483
+%1484 = OpAccessChain %_ptr_Function_uchar %1186 %uint_0
+%1485 = OpLoad %uchar %1344
+OpStore %1484 %1485
+%1486 = OpLoad %ulong %1226
+%1487 = OpShiftRightLogical %ulong %1486 %ulong_8
+OpStore %1345 %1487
+%1488 = OpLoad %ulong %1345
+%1489 = OpUConvert %uchar %1488
+OpStore %1346 %1489
+%1490 = OpAccessChain %_ptr_Function_uchar %1186 %uint_1
+%1491 = OpLoad %uchar %1346
+OpStore %1490 %1491
+OpBranch %1153
+%1153 = OpLabel
+%1493 = OpAccessChain %_ptr_Function_ulong %1176 %uint_10
+%1494 = OpLoad %ulong %1493
+OpStore %1227 %1494
+OpBranch %1156
+%1156 = OpLabel
+%1495 = OpLoad %ulong %1227
+%1496 = OpUConvert %uchar %1495
+OpStore %1352 %1496
+%1497 = OpAccessChain %_ptr_Function_uchar %1188 %uint_0
+%1498 = OpLoad %uchar %1352
+OpStore %1497 %1498
+%1499 = OpLoad %ulong %1227
+%1500 = OpShiftRightLogical %ulong %1499 %ulong_8
+OpStore %1353 %1500
+%1501 = OpLoad %ulong %1353
+%1502 = OpUConvert %uchar %1501
+OpStore %1354 %1502
+%1503 = OpAccessChain %_ptr_Function_uchar %1188 %uint_1
+%1504 = OpLoad %uchar %1354
+OpStore %1503 %1504
+%1505 = OpLoad %ulong %1227
+%1506 = OpShiftRightLogical %ulong %1505 %ulong_16
+OpStore %1355 %1506
+%1507 = OpLoad %ulong %1355
+%1508 = OpUConvert %ushort %1507
+OpStore %1356 %1508
+%1509 = OpAccessChain %_ptr_Function_ushort %1188 %uint_2
+%1510 = OpLoad %ushort %1356
+OpStore %1509 %1510
+OpBranch %1157
+%1157 = OpLabel
+%1512 = OpAccessChain %_ptr_Function_ulong %1176 %uint_11
+%1513 = OpLoad %ulong %1512
+OpStore %1228 %1513
+OpBranch %1160
+%1160 = OpLabel
+%1514 = OpLoad %ulong %1228
+%1515 = OpUConvert %uint %1514
+OpStore %1362 %1515
+%1516 = OpAccessChain %_ptr_Function_uint %1190 %uint_0
+%1517 = OpLoad %uint %1362
+OpStore %1516 %1517
+%1518 = OpLoad %ulong %1228
+%1519 = OpShiftRightLogical %ulong %1518 %ulong_32
+OpStore %1363 %1519
+%1520 = OpLoad %ulong %1363
+%1521 = OpUConvert %ushort %1520
+OpStore %1364 %1521
+%1522 = OpAccessChain %_ptr_Function_ushort %1190 %uint_1
+%1523 = OpLoad %ushort %1364
+OpStore %1522 %1523
+%1524 = OpLoad %ulong %1228
+%1525 = OpShiftRightLogical %ulong %1524 %ulong_48
+OpStore %1365 %1525
+%1526 = OpLoad %ulong %1365
+%1527 = OpUConvert %uchar %1526
+OpStore %1366 %1527
+%1528 = OpAccessChain %_ptr_Function_uchar %1190 %uint_2
+%1529 = OpLoad %uchar %1366
+OpStore %1528 %1529
+OpBranch %1161
+%1161 = OpLabel
+%1530 = OpAccessChain %_ptr_Function_ulong %1176 %uint_0
+%1531 = OpLoad %ulong %1530
+OpStore %1229 %1531
+%1532 = OpLoad %ulong %1229
+%1533 = OpBitwiseAnd %ulong %1532 %ulong_255
+OpStore %1230 %1533
+%1534 = OpLoad %ulong %1230
+%1535 = OpConvertUToF %float %1534
+OpStore %1231 %1535
+%1536 = OpAccessChain %_ptr_Function_ulong %1176 %uint_2
+%1537 = OpLoad %ulong %1536
+OpStore %1232 %1537
+%1538 = OpLoad %ulong %1237
+%1539 = OpLoad %_struct_36 %1172
+%1540 = OpLoad %uint %1221
+%1541 = OpLoad %_struct_98 %1178
+%1542 = OpLoad %double %1223
+%1543 = OpLoad %_struct_195 %1180
+%1544 = OpLoad %ulong %1224
+%1545 = OpLoad %_struct_335 %1182
+%1546 = OpLoad %_struct_36 %1184
+%1547 = OpLoad %_struct_98 %1186
+%1548 = OpLoad %_struct_195 %1188
+%1549 = OpLoad %_struct_335 %1190
+%1550 = OpLoad %float %1231
+%1551 = OpLoad %ulong %1232
+%1552 = OpFunctionCall %ulong %7 %1538 %1539 %1540 %1541 %1542 %1543 %1544 %1545 %1546 %1547 %1548 %1549 %1550 %1551
+OpStore %1233 %1552
+%1553 = OpLoad %ulong %1235
+%1554 = OpLoad %ulong %1233
+%1555 = OpFunctionCall %ulong %13 %1553 %1554
+OpStore %1234 %1555
+%1556 = OpLoad %ulong %1234
+OpReturnValue %1556
+%1087 = OpLabel
+%1557 = OpLoad %ulong %1238
+%1559 = OpIMul %ulong %1557 %ulong_13
+OpStore %1195 %1559
+%1560 = OpLoad %ulong %1195
+%1561 = OpLoad %ulong %1191
+%1562 = OpIAdd %ulong %1560 %1561
+OpStore %1196 %1562
+%1563 = OpAccessChain %_ptr_Function_ulong %1176 %uint_0
+%1564 = OpLoad %ulong %1563
+OpStore %1197 %1564
+%1565 = OpLoad %ulong %1197
+%1566 = OpLoad %ulong %1196
+%1567 = OpIAdd %ulong %1565 %1566
+OpStore %1198 %1567
+%1568 = OpAccessChain %_ptr_Function_ulong %1176 %uint_1
+%1569 = OpLoad %ulong %1568
+OpStore %1199 %1569
+OpBranch %1093
+%1093 = OpLabel
+%1570 = OpLoad %ulong %1199
+%1571 = OpUConvert %uchar %1570
+OpStore %1242 %1571
+%1572 = OpAccessChain %_ptr_Function_uchar %1171 %uint_0
+%1573 = OpLoad %uchar %1242
+OpStore %1572 %1573
+OpBranch %1094
+%1094 = OpLabel
+%1574 = OpAccessChain %_ptr_Function_ulong %1176 %uint_2
+%1575 = OpLoad %ulong %1574
+OpStore %1200 %1575
+%1576 = OpLoad %ulong %1200
+%1577 = OpUConvert %uint %1576
+OpStore %1201 %1577
+%1579 = OpAccessChain %_ptr_Function_ulong %1176 %uint_3
+%1580 = OpLoad %ulong %1579
+OpStore %1202 %1580
+OpBranch %1134
+%1134 = OpLabel
+%1581 = OpLoad %ulong %1202
+%1582 = OpUConvert %uchar %1581
+OpStore %1313 %1582
+%1583 = OpAccessChain %_ptr_Function_uchar %1177 %uint_0
+%1584 = OpLoad %uchar %1313
+OpStore %1583 %1584
+%1585 = OpLoad %ulong %1202
+%1586 = OpShiftRightLogical %ulong %1585 %ulong_8
+OpStore %1314 %1586
+%1587 = OpLoad %ulong %1314
+%1588 = OpUConvert %uchar %1587
+OpStore %1315 %1588
+%1589 = OpAccessChain %_ptr_Function_uchar %1177 %uint_1
+%1590 = OpLoad %uchar %1315
+OpStore %1589 %1590
+OpBranch %1135
+%1135 = OpLabel
+%1592 = OpAccessChain %_ptr_Function_ulong %1176 %uint_4
+%1593 = OpLoad %ulong %1592
+OpStore %1203 %1593
+%1594 = OpLoad %ulong %1203
+%1595 = OpBitwiseAnd %ulong %1594 %ulong_1023
+OpStore %1204 %1595
+%1596 = OpLoad %ulong %1204
+%1597 = OpConvertUToF %double %1596
+OpStore %1205 %1597
+%1599 = OpAccessChain %_ptr_Function_ulong %1176 %uint_5
+%1600 = OpLoad %ulong %1599
+OpStore %1206 %1600
+OpBranch %1138
+%1138 = OpLabel
+%1601 = OpLoad %ulong %1206
+%1602 = OpUConvert %uchar %1601
+OpStore %1319 %1602
+%1603 = OpAccessChain %_ptr_Function_uchar %1179 %uint_0
+%1604 = OpLoad %uchar %1319
+OpStore %1603 %1604
+%1605 = OpLoad %ulong %1206
+%1606 = OpShiftRightLogical %ulong %1605 %ulong_8
+OpStore %1320 %1606
+%1607 = OpLoad %ulong %1320
+%1608 = OpUConvert %uchar %1607
+OpStore %1321 %1608
+%1609 = OpAccessChain %_ptr_Function_uchar %1179 %uint_1
+%1610 = OpLoad %uchar %1321
+OpStore %1609 %1610
+%1611 = OpLoad %ulong %1206
+%1612 = OpShiftRightLogical %ulong %1611 %ulong_16
+OpStore %1322 %1612
+%1613 = OpLoad %ulong %1322
+%1614 = OpUConvert %ushort %1613
+OpStore %1323 %1614
+%1615 = OpAccessChain %_ptr_Function_ushort %1179 %uint_2
+%1616 = OpLoad %ushort %1323
+OpStore %1615 %1616
+OpBranch %1139
+%1139 = OpLabel
+%1617 = OpAccessChain %_ptr_Function_ulong %1176 %uint_6
+%1618 = OpLoad %ulong %1617
+OpStore %1207 %1618
+%1620 = OpAccessChain %_ptr_Function_ulong %1176 %uint_7
+%1621 = OpLoad %ulong %1620
+OpStore %1208 %1621
+%1622 = OpLoad %ulong %1208
+%1623 = OpLoad %ulong %1196
+%1624 = OpIAdd %ulong %1622 %1623
+OpStore %1209 %1624
+OpBranch %1142
+%1142 = OpLabel
+%1625 = OpLoad %ulong %1209
+%1626 = OpUConvert %uint %1625
+OpStore %1329 %1626
+%1627 = OpAccessChain %_ptr_Function_uint %1181 %uint_0
+%1628 = OpLoad %uint %1329
+OpStore %1627 %1628
+%1629 = OpLoad %ulong %1209
+%1630 = OpShiftRightLogical %ulong %1629 %ulong_32
+OpStore %1330 %1630
+%1631 = OpLoad %ulong %1330
+%1632 = OpUConvert %ushort %1631
+OpStore %1331 %1632
+%1633 = OpAccessChain %_ptr_Function_ushort %1181 %uint_1
+%1634 = OpLoad %ushort %1331
+OpStore %1633 %1634
+%1635 = OpLoad %ulong %1209
+%1636 = OpShiftRightLogical %ulong %1635 %ulong_48
+OpStore %1332 %1636
+%1637 = OpLoad %ulong %1332
+%1638 = OpUConvert %uchar %1637
+OpStore %1333 %1638
+%1639 = OpAccessChain %_ptr_Function_uchar %1181 %uint_2
+%1640 = OpLoad %uchar %1333
+OpStore %1639 %1640
+OpBranch %1143
+%1143 = OpLabel
+%1641 = OpAccessChain %_ptr_Function_ulong %1176 %uint_8
+%1642 = OpLoad %ulong %1641
+OpStore %1210 %1642
+OpBranch %1146
+%1146 = OpLabel
+%1643 = OpLoad %ulong %1210
+%1644 = OpUConvert %uchar %1643
+OpStore %1339 %1644
+%1645 = OpAccessChain %_ptr_Function_uchar %1183 %uint_0
+%1646 = OpLoad %uchar %1339
+OpStore %1645 %1646
+OpBranch %1147
+%1147 = OpLabel
+%1647 = OpAccessChain %_ptr_Function_ulong %1176 %uint_9
+%1648 = OpLoad %ulong %1647
+OpStore %1211 %1648
+OpBranch %1150
+%1150 = OpLabel
+%1649 = OpLoad %ulong %1211
+%1650 = OpUConvert %uchar %1649
+OpStore %1341 %1650
+%1651 = OpAccessChain %_ptr_Function_uchar %1185 %uint_0
+%1652 = OpLoad %uchar %1341
+OpStore %1651 %1652
+%1653 = OpLoad %ulong %1211
+%1654 = OpShiftRightLogical %ulong %1653 %ulong_8
+OpStore %1342 %1654
+%1655 = OpLoad %ulong %1342
+%1656 = OpUConvert %uchar %1655
+OpStore %1343 %1656
+%1657 = OpAccessChain %_ptr_Function_uchar %1185 %uint_1
+%1658 = OpLoad %uchar %1343
+OpStore %1657 %1658
+OpBranch %1151
+%1151 = OpLabel
+%1659 = OpAccessChain %_ptr_Function_ulong %1176 %uint_10
+%1660 = OpLoad %ulong %1659
+OpStore %1212 %1660
+OpBranch %1154
+%1154 = OpLabel
+%1661 = OpLoad %ulong %1212
+%1662 = OpUConvert %uchar %1661
+OpStore %1347 %1662
+%1663 = OpAccessChain %_ptr_Function_uchar %1187 %uint_0
+%1664 = OpLoad %uchar %1347
+OpStore %1663 %1664
+%1665 = OpLoad %ulong %1212
+%1666 = OpShiftRightLogical %ulong %1665 %ulong_8
+OpStore %1348 %1666
+%1667 = OpLoad %ulong %1348
+%1668 = OpUConvert %uchar %1667
+OpStore %1349 %1668
+%1669 = OpAccessChain %_ptr_Function_uchar %1187 %uint_1
+%1670 = OpLoad %uchar %1349
+OpStore %1669 %1670
+%1671 = OpLoad %ulong %1212
+%1672 = OpShiftRightLogical %ulong %1671 %ulong_16
+OpStore %1350 %1672
+%1673 = OpLoad %ulong %1350
+%1674 = OpUConvert %ushort %1673
+OpStore %1351 %1674
+%1675 = OpAccessChain %_ptr_Function_ushort %1187 %uint_2
+%1676 = OpLoad %ushort %1351
+OpStore %1675 %1676
+OpBranch %1155
+%1155 = OpLabel
+%1677 = OpAccessChain %_ptr_Function_ulong %1176 %uint_11
+%1678 = OpLoad %ulong %1677
+OpStore %1213 %1678
+OpBranch %1158
+%1158 = OpLabel
+%1679 = OpLoad %ulong %1213
+%1680 = OpUConvert %uint %1679
+OpStore %1357 %1680
+%1681 = OpAccessChain %_ptr_Function_uint %1189 %uint_0
+%1682 = OpLoad %uint %1357
+OpStore %1681 %1682
+%1683 = OpLoad %ulong %1213
+%1684 = OpShiftRightLogical %ulong %1683 %ulong_32
+OpStore %1358 %1684
+%1685 = OpLoad %ulong %1358
+%1686 = OpUConvert %ushort %1685
+OpStore %1359 %1686
+%1687 = OpAccessChain %_ptr_Function_ushort %1189 %uint_1
+%1688 = OpLoad %ushort %1359
+OpStore %1687 %1688
+%1689 = OpLoad %ulong %1213
+%1690 = OpShiftRightLogical %ulong %1689 %ulong_48
+OpStore %1360 %1690
+%1691 = OpLoad %ulong %1360
+%1692 = OpUConvert %uchar %1691
+OpStore %1361 %1692
+%1693 = OpAccessChain %_ptr_Function_uchar %1189 %uint_2
+%1694 = OpLoad %uchar %1361
+OpStore %1693 %1694
+OpBranch %1159
+%1159 = OpLabel
+%1695 = OpAccessChain %_ptr_Function_ulong %1176 %uint_0
+%1696 = OpLoad %ulong %1695
+OpStore %1214 %1696
+%1697 = OpLoad %ulong %1214
+%1698 = OpBitwiseAnd %ulong %1697 %ulong_255
+OpStore %1215 %1698
+%1699 = OpLoad %ulong %1215
+%1700 = OpConvertUToF %float %1699
+OpStore %1216 %1700
+%1701 = OpAccessChain %_ptr_Function_ulong %1176 %uint_1
+%1702 = OpLoad %ulong %1701
+OpStore %1217 %1702
+%1703 = OpLoad %ulong %1198
+%1704 = OpLoad %_struct_36 %1171
+%1705 = OpLoad %uint %1201
+%1706 = OpLoad %_struct_98 %1177
+%1707 = OpLoad %double %1205
+%1708 = OpLoad %_struct_195 %1179
+%1709 = OpLoad %ulong %1207
+%1710 = OpLoad %_struct_335 %1181
+%1711 = OpLoad %_struct_36 %1183
+%1712 = OpLoad %_struct_98 %1185
+%1713 = OpLoad %_struct_195 %1187
+%1714 = OpLoad %_struct_335 %1189
+%1715 = OpLoad %float %1216
+%1716 = OpLoad %ulong %1217
+%1717 = OpFunctionCall %ulong %7 %1703 %1704 %1705 %1706 %1707 %1708 %1709 %1710 %1711 %1712 %1713 %1714 %1715 %1716
+OpStore %1218 %1717
+%1718 = OpLoad %ulong %1235
+%1719 = OpLoad %ulong %1218
+%1720 = OpFunctionCall %ulong %13 %1718 %1719
+OpStore %1219 %1720
+%1721 = OpLoad %ulong %1238
+%1722 = OpIAdd %ulong %1721 %ulong_1
+OpStore %1220 %1722
+%1723 = OpLoad %ulong %1219
+OpStore %1235 %1723
+%1724 = OpLoad %ulong %1218
+OpStore %1237 %1724
+%1725 = OpLoad %ulong %1220
+OpStore %1238 %1725
+OpBranch %1162
+%1084 = OpLabel
+OpBranch %1091
+%1091 = OpLabel
+%1726 = OpLoad %ulong %1236
+%1727 = OpIMul %ulong %1726 %ulong_6364136223846793005
+OpStore %1239 %1727
+%1728 = OpLoad %ulong %1239
+%1729 = OpIAdd %ulong %1728 %ulong_1442695040888963407
+OpStore %1240 %1729
+%1730 = OpLoad %ulong %1240
+%1731 = OpLoad %ulong %1191
+%1732 = OpIAdd %ulong %1730 %1731
+OpStore %1241 %1732
+OpBranch %1092
+%1092 = OpLabel
+%1733 = OpLoad %ulong %1236
+%1734 = OpAccessChain %_ptr_Function_ulong %1176 %1733
+%1735 = OpLoad %ulong %1241
+OpStore %1734 %1735
+%1736 = OpLoad %ulong %1236
+%1737 = OpIAdd %ulong %1736 %ulong_1
+OpStore %1193 %1737
+%1738 = OpLoad %ulong %1193
+OpStore %1236 %1738
+OpBranch %1163
+%1130 = OpLabel
+%1739 = OpLoad %ulong %1312
+%1740 = OpIMul %ulong %1739 %ulong_8
+OpStore %1305 %1740
+%1741 = OpLoad %ulong %1305
+%1742 = OpShiftRightLogical %ulong %ulong_2 %1741
+OpStore %1306 %1742
+%1743 = OpLoad %ulong %1306
+%1744 = OpBitwiseAnd %ulong %1743 %ulong_255
+OpStore %1307 %1744
+%1745 = OpLoad %ulong %1311
+%1746 = OpLoad %ulong %1307
+%1747 = OpBitwiseXor %ulong %1745 %1746
+OpStore %1308 %1747
+%1748 = OpLoad %ulong %1308
+%1749 = OpIMul %ulong %1748 %ulong_1099511628211
+OpStore %1309 %1749
+%1750 = OpLoad %ulong %1312
+%1751 = OpIAdd %ulong %1750 %ulong_1
+OpStore %1310 %1751
+%1752 = OpLoad %ulong %1309
+OpStore %1311 %1752
+%1753 = OpLoad %ulong %1310
+OpStore %1312 %1753
+OpBranch %1164
+%1125 = OpLabel
+%1754 = OpLoad %ulong %1303
+%1755 = OpIMul %ulong %1754 %ulong_8
+OpStore %1296 %1755
+%1756 = OpLoad %ulong %1296
+%1757 = OpShiftRightLogical %ulong %ulong_1 %1756
+OpStore %1297 %1757
+%1758 = OpLoad %ulong %1297
+%1759 = OpBitwiseAnd %ulong %1758 %ulong_255
+OpStore %1298 %1759
+%1760 = OpLoad %ulong %1302
+%1761 = OpLoad %ulong %1298
+%1762 = OpBitwiseXor %ulong %1760 %1761
+OpStore %1299 %1762
+%1763 = OpLoad %ulong %1299
+%1764 = OpIMul %ulong %1763 %ulong_1099511628211
+OpStore %1300 %1764
+%1765 = OpLoad %ulong %1303
+%1766 = OpIAdd %ulong %1765 %ulong_1
+OpStore %1301 %1766
+%1767 = OpLoad %ulong %1300
+OpStore %1302 %1767
+%1768 = OpLoad %ulong %1301
+OpStore %1303 %1768
+OpBranch %1165
+%1120 = OpLabel
+%1769 = OpLoad %ulong %1294
+%1770 = OpIMul %ulong %1769 %ulong_8
+OpStore %1287 %1770
+%1771 = OpLoad %ulong %1287
+%1772 = OpShiftRightLogical %ulong %ulong_1 %1771
+OpStore %1288 %1772
+%1773 = OpLoad %ulong %1288
+%1774 = OpBitwiseAnd %ulong %1773 %ulong_255
+OpStore %1289 %1774
+%1775 = OpLoad %ulong %1293
+%1776 = OpLoad %ulong %1289
+%1777 = OpBitwiseXor %ulong %1775 %1776
+OpStore %1290 %1777
+%1778 = OpLoad %ulong %1290
+%1779 = OpIMul %ulong %1778 %ulong_1099511628211
+OpStore %1291 %1779
+%1780 = OpLoad %ulong %1294
+%1781 = OpIAdd %ulong %1780 %ulong_1
+OpStore %1292 %1781
+%1782 = OpLoad %ulong %1291
+OpStore %1293 %1782
+%1783 = OpLoad %ulong %1292
+OpStore %1294 %1783
+OpBranch %1166
+%1115 = OpLabel
+%1784 = OpLoad %ulong %1285
+%1785 = OpIMul %ulong %1784 %ulong_8
+OpStore %1278 %1785
+%1786 = OpLoad %ulong %1278
+%1787 = OpShiftRightLogical %ulong %ulong_8 %1786
+OpStore %1279 %1787
+%1788 = OpLoad %ulong %1279
+%1789 = OpBitwiseAnd %ulong %1788 %ulong_255
+OpStore %1280 %1789
+%1790 = OpLoad %ulong %1284
+%1791 = OpLoad %ulong %1280
+%1792 = OpBitwiseXor %ulong %1790 %1791
+OpStore %1281 %1792
+%1793 = OpLoad %ulong %1281
+%1794 = OpIMul %ulong %1793 %ulong_1099511628211
+OpStore %1282 %1794
+%1795 = OpLoad %ulong %1285
+%1796 = OpIAdd %ulong %1795 %ulong_1
+OpStore %1283 %1796
+%1797 = OpLoad %ulong %1282
+OpStore %1284 %1797
+%1798 = OpLoad %ulong %1283
+OpStore %1285 %1798
+OpBranch %1167
+%1110 = OpLabel
+%1799 = OpLoad %ulong %1276
+%1800 = OpIMul %ulong %1799 %ulong_8
+OpStore %1269 %1800
+%1801 = OpLoad %ulong %1269
+%1802 = OpShiftRightLogical %ulong %ulong_4 %1801
+OpStore %1270 %1802
+%1803 = OpLoad %ulong %1270
+%1804 = OpBitwiseAnd %ulong %1803 %ulong_255
+OpStore %1271 %1804
+%1805 = OpLoad %ulong %1275
+%1806 = OpLoad %ulong %1271
+%1807 = OpBitwiseXor %ulong %1805 %1806
+OpStore %1272 %1807
+%1808 = OpLoad %ulong %1272
+%1809 = OpIMul %ulong %1808 %ulong_1099511628211
+OpStore %1273 %1809
+%1810 = OpLoad %ulong %1276
+%1811 = OpIAdd %ulong %1810 %ulong_1
+OpStore %1274 %1811
+%1812 = OpLoad %ulong %1273
+OpStore %1275 %1812
+%1813 = OpLoad %ulong %1274
+OpStore %1276 %1813
+OpBranch %1168
+%1105 = OpLabel
+%1814 = OpLoad %ulong %1267
+%1815 = OpIMul %ulong %1814 %ulong_8
+OpStore %1260 %1815
+%1816 = OpLoad %ulong %1260
+%1817 = OpShiftRightLogical %ulong %ulong_2 %1816
+OpStore %1261 %1817
+%1818 = OpLoad %ulong %1261
+%1819 = OpBitwiseAnd %ulong %1818 %ulong_255
+OpStore %1262 %1819
+%1820 = OpLoad %ulong %1266
+%1821 = OpLoad %ulong %1262
+%1822 = OpBitwiseXor %ulong %1820 %1821
+OpStore %1263 %1822
+%1823 = OpLoad %ulong %1263
+%1824 = OpIMul %ulong %1823 %ulong_1099511628211
+OpStore %1264 %1824
+%1825 = OpLoad %ulong %1267
+%1826 = OpIAdd %ulong %1825 %ulong_1
+OpStore %1265 %1826
+%1827 = OpLoad %ulong %1264
+OpStore %1266 %1827
+%1828 = OpLoad %ulong %1265
+OpStore %1267 %1828
+OpBranch %1169
+%1100 = OpLabel
+%1829 = OpLoad %ulong %1258
+%1830 = OpIMul %ulong %1829 %ulong_8
+OpStore %1251 %1830
+%1831 = OpLoad %ulong %1251
+%1832 = OpShiftRightLogical %ulong %ulong_1 %1831
+OpStore %1252 %1832
+%1833 = OpLoad %ulong %1252
+%1834 = OpBitwiseAnd %ulong %1833 %ulong_255
+OpStore %1253 %1834
+%1835 = OpLoad %ulong %1257
+%1836 = OpLoad %ulong %1253
+%1837 = OpBitwiseXor %ulong %1835 %1836
+OpStore %1254 %1837
+%1838 = OpLoad %ulong %1254
+%1839 = OpIMul %ulong %1838 %ulong_1099511628211
+OpStore %1255 %1839
+%1840 = OpLoad %ulong %1258
+%1841 = OpIAdd %ulong %1840 %ulong_1
+OpStore %1256 %1841
+%1842 = OpLoad %ulong %1255
+OpStore %1257 %1842
+%1843 = OpLoad %ulong %1256
+OpStore %1258 %1843
+OpBranch %1170
+%1162 = OpLabel
+OpBranch %1086
+%1163 = OpLabel
+OpBranch %1083
+%1164 = OpLabel
+OpBranch %1129
+%1165 = OpLabel
+OpBranch %1124
+%1166 = OpLabel
+OpBranch %1119
+%1167 = OpLabel
+OpBranch %1114
+%1168 = OpLabel
+OpBranch %1109
+%1169 = OpLabel
+OpBranch %1104
+%1170 = OpLabel
+OpBranch %1099
+OpFunctionEnd
+%13 = OpFunction %ulong None %15
+%1844 = OpFunctionParameter %ulong
+%1845 = OpFunctionParameter %ulong
+%1846 = OpLabel
+%1851 = OpVariable %_ptr_Function_ulong Function
+%1852 = OpVariable %_ptr_Function_ulong Function
+%1853 = OpVariable %_ptr_Function_bool Function
+%1854 = OpVariable %_ptr_Function_ulong Function
+%1855 = OpVariable %_ptr_Function_ulong Function
+%1856 = OpVariable %_ptr_Function_ulong Function
+%1857 = OpVariable %_ptr_Function_ulong Function
+%1858 = OpVariable %_ptr_Function_ulong Function
+%1859 = OpVariable %_ptr_Function_ulong Function
+%1860 = OpVariable %_ptr_Function_ulong Function
+%1861 = OpVariable %_ptr_Function_ulong Function
+OpStore %1851 %1844
+OpStore %1852 %1845
+%1862 = OpLoad %ulong %1851
+OpStore %1860 %1862
+OpStore %1861 %ulong_0
+OpBranch %1847
+%1847 = OpLabel
+%1863 = OpLoad %ulong %1861
+%1864 = OpULessThan %bool %1863 %ulong_8
+OpStore %1853 %1864
+%1865 = OpLoad %bool %1853
+OpLoopMerge %1849 %1850 None
+OpBranchConditional %1865 %1848 %1849
+%1849 = OpLabel
+%1866 = OpLoad %ulong %1860
+OpReturnValue %1866
+%1848 = OpLabel
+%1867 = OpLoad %ulong %1861
+%1868 = OpIMul %ulong %1867 %ulong_8
+OpStore %1854 %1868
+%1869 = OpLoad %ulong %1852
+%1870 = OpLoad %ulong %1854
+%1871 = OpShiftRightLogical %ulong %1869 %1870
+OpStore %1855 %1871
+%1872 = OpLoad %ulong %1855
+%1873 = OpBitwiseAnd %ulong %1872 %ulong_255
+OpStore %1856 %1873
+%1874 = OpLoad %ulong %1860
+%1875 = OpLoad %ulong %1856
+%1876 = OpBitwiseXor %ulong %1874 %1875
+OpStore %1857 %1876
+%1877 = OpLoad %ulong %1857
+%1878 = OpIMul %ulong %1877 %ulong_1099511628211
+OpStore %1858 %1878
+%1879 = OpLoad %ulong %1861
+%1880 = OpIAdd %ulong %1879 %ulong_1
+OpStore %1859 %1880
+%1881 = OpLoad %ulong %1858
+OpStore %1860 %1881
+%1882 = OpLoad %ulong %1859
+OpStore %1861 %1882
+OpBranch %1850
+%1850 = OpLabel
+OpBranch %1847
 OpFunctionEnd

--- a/test/golden/spirv/call/call_ret_large.dis
+++ b/test/golden/spirv/call/call_ret_large.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 2146
+; Bound: 2926
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -31,440 +31,467 @@ OpDecorate %20 LinkageAttributes "corpus.cases.call.call_ret_large.nest_of" Expo
 OpDecorate %21 LinkageAttributes "corpus.cases.call.call_ret_large.take_two" Export
 OpDecorate %22 LinkageAttributes "corpus.cases.call.call_ret_large.checksum" Export
 %ulong = OpTypeInt 64 0
-%28 = OpTypeFunction %ulong %ulong %ulong
+%25 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %uint = OpTypeInt 32 0
-%_struct_49 = OpTypeStruct %uint %uint %uint %uint %uint
-%50 = OpTypeFunction %ulong %ulong %_struct_49
-%_ptr_Function__struct_49 = OpTypePointer Function %_struct_49
+%_struct_46 = OpTypeStruct %uint %uint %uint %uint %uint
+%47 = OpTypeFunction %ulong %ulong %_struct_46
+%bool = OpTypeBool
+%_ptr_Function__struct_46 = OpTypePointer Function %_struct_46
+%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
-%_struct_99 = OpTypeStruct %ulong %ulong %ulong
-%100 = OpTypeFunction %ulong %ulong %_struct_99
-%_ptr_Function__struct_99 = OpTypePointer Function %_struct_99
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%_struct_283 = OpTypeStruct %ulong %ulong %ulong
+%284 = OpTypeFunction %ulong %ulong %_struct_283
+%_ptr_Function__struct_283 = OpTypePointer Function %_struct_283
 %double = OpTypeFloat 64
-%_struct_130 = OpTypeStruct %double %double %double
-%131 = OpTypeFunction %ulong %ulong %_struct_130
-%_ptr_Function__struct_130 = OpTypePointer Function %_struct_130
+%_struct_407 = OpTypeStruct %double %double %double
+%408 = OpTypeFunction %ulong %ulong %_struct_407
+%_ptr_Function__struct_407 = OpTypePointer Function %_struct_407
 %_ptr_Function_double = OpTypePointer Function %double
-%_struct_161 = OpTypeStruct %ulong %ulong %ulong %ulong
-%162 = OpTypeFunction %ulong %ulong %_struct_161
-%_ptr_Function__struct_161 = OpTypePointer Function %_struct_161
-%_struct_198 = OpTypeStruct %ulong %double %uint %uint %double %ulong
-%199 = OpTypeFunction %ulong %ulong %_struct_198
-%_ptr_Function__struct_198 = OpTypePointer Function %_struct_198
+%_struct_546 = OpTypeStruct %ulong %ulong %ulong %ulong
+%547 = OpTypeFunction %ulong %ulong %_struct_546
+%_ptr_Function__struct_546 = OpTypePointer Function %_struct_546
+%_struct_707 = OpTypeStruct %ulong %double %uint %uint %double %ulong
+%708 = OpTypeFunction %ulong %ulong %_struct_707
+%_ptr_Function__struct_707 = OpTypePointer Function %_struct_707
 %uint_5 = OpConstant %uint 5
-%_struct_250 = OpTypeStruct %ulong %ulong %ulong %ulong %ulong %ulong
-%251 = OpTypeFunction %ulong %ulong %_struct_250
-%_ptr_Function__struct_250 = OpTypePointer Function %_struct_250
-%_struct_301 = OpTypeStruct %ulong %ulong
-%_struct_302 = OpTypeStruct %uint %_struct_99 %_struct_301
-%303 = OpTypeFunction %ulong %ulong %_struct_302
-%_ptr_Function__struct_302 = OpTypePointer Function %_struct_302
-%_ptr_Function__struct_301 = OpTypePointer Function %_struct_301
-%358 = OpTypeFunction %ulong %ulong
+%_struct_810 = OpTypeStruct %ulong %ulong %ulong %ulong %ulong %ulong
+%811 = OpTypeFunction %ulong %ulong %_struct_810
+%_ptr_Function__struct_810 = OpTypePointer Function %_struct_810
+%_struct_861 = OpTypeStruct %ulong %ulong
+%_struct_862 = OpTypeStruct %uint %_struct_283 %_struct_861
+%863 = OpTypeFunction %ulong %ulong %_struct_862
+%_ptr_Function__struct_862 = OpTypePointer Function %_struct_862
+%_ptr_Function__struct_861 = OpTypePointer Function %_struct_861
+%908 = OpTypeFunction %ulong %ulong
 %ulong_20 = OpConstant %ulong 20
 %ulong_24 = OpConstant %ulong 24
 %ulong_32 = OpConstant %ulong 32
 %ulong_40 = OpConstant %ulong 40
 %ulong_48 = OpConstant %ulong 48
-%ulong_8 = OpConstant %ulong 8
-%396 = OpTypeFunction %_struct_49 %ulong
+%945 = OpTypeFunction %_struct_46 %ulong
 %ulong_16 = OpConstant %ulong 16
-%440 = OpTypeFunction %_struct_99 %ulong
+%989 = OpTypeFunction %_struct_283 %ulong
 %ulong_3 = OpConstant %ulong 3
-%ulong_1 = OpConstant %ulong 1
-%463 = OpTypeFunction %_struct_130 %ulong
+%1011 = OpTypeFunction %_struct_407 %ulong
 %ulong_65535 = OpConstant %ulong 65535
 %double_8 = OpConstant %double 8
 %ulong_4095 = OpConstant %ulong 4095
 %double_2048 = OpConstant %double 2048
 %ulong_262143 = OpConstant %ulong 262143
 %double_64 = OpConstant %double 64
-%508 = OpTypeFunction %_struct_161 %ulong
+%1056 = OpTypeFunction %_struct_546 %ulong
 %ulong_5 = OpConstant %ulong 5
-%532 = OpTypeFunction %_struct_198 %ulong
+%1080 = OpTypeFunction %_struct_707 %ulong
 %ulong_8191 = OpConstant %ulong 8191
 %double_2 = OpConstant %double 2
 %ulong_131071 = OpConstant %ulong 131071
 %double_32 = OpConstant %double 32
 %ulong_7 = OpConstant %ulong 7
-%585 = OpTypeFunction %_struct_250 %ulong
+%1133 = OpTypeFunction %_struct_810 %ulong
 %ulong_2 = OpConstant %ulong 2
 %ulong_9 = OpConstant %ulong 9
 %ulong_2863311530 = OpConstant %ulong 2863311530
-%621 = OpTypeFunction %_struct_99 %_struct_99 %ulong
-%656 = OpTypeFunction %_struct_250 %_struct_250 %ulong
-%718 = OpTypeFunction %_struct_250 %_struct_99
-%757 = OpTypeFunction %_struct_99 %_struct_250
-%799 = OpTypeFunction %_struct_302 %ulong
+%1169 = OpTypeFunction %_struct_283 %_struct_283 %ulong
+%1204 = OpTypeFunction %_struct_810 %_struct_810 %ulong
+%1266 = OpTypeFunction %_struct_810 %_struct_283
+%1305 = OpTypeFunction %_struct_283 %_struct_810
+%1347 = OpTypeFunction %_struct_862 %ulong
 %ulong_11 = OpConstant %ulong 11
-%844 = OpTypeFunction %ulong %_struct_250 %_struct_99 %ulong
-%bool = OpTypeBool
+%1392 = OpTypeFunction %ulong %_struct_810 %_struct_283 %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_6 = OpConstant %uint 6
-%_arr__struct_161_uint_6 = OpTypeArray %_struct_161 %uint_6
-%_ptr_Function__arr__struct_161_uint_6 = OpTypePointer Function %_arr__struct_161_uint_6
+%_arr__struct_546_uint_6 = OpTypeArray %_struct_546 %uint_6
+%_ptr_Function__arr__struct_546_uint_6 = OpTypePointer Function %_arr__struct_546_uint_6
 %uint_8 = OpConstant %uint 8
 %_arr_ulong_uint_8 = OpTypeArray %ulong %uint_8
 %_ptr_Function__arr_ulong_uint_8 = OpTypePointer Function %_arr_ulong_uint_8
-%_ptr_Function_bool = OpTypePointer Function %bool
-%1327 = OpConstantNull %_arr_ulong_uint_8
-%ulong_0 = OpConstant %ulong 0
-%1380 = OpConstantNull %_arr__struct_161_uint_6
+%2016 = OpConstantNull %_arr_ulong_uint_8
+%2072 = OpConstantNull %_arr__struct_546_uint_6
 %ulong_6 = OpConstant %ulong 6
-%1389 = OpConstantNull %_struct_302
+%2081 = OpConstantNull %_struct_862
 %uint_305419896 = OpConstant %uint 305419896
 %ulong_4 = OpConstant %ulong 4
-%2012 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%2056 = OpTypeFunction %ulong %ulong %uint
-%2101 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %28
-%29 = OpFunctionParameter %ulong
-%30 = OpFunctionParameter %ulong
-%31 = OpLabel
+%1 = OpFunction %ulong None %25
+%26 = OpFunctionParameter %ulong
+%27 = OpFunctionParameter %ulong
+%28 = OpLabel
+%30 = OpVariable %_ptr_Function_ulong Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%32 = OpVariable %_ptr_Function_ulong Function
 %33 = OpVariable %_ptr_Function_ulong Function
 %34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-OpStore %33 %29
-OpStore %34 %30
-%38 = OpLoad %ulong %34
-%40 = OpIMul %ulong %38 %ulong_6364136223846793005
-OpStore %35 %40
-%41 = OpLoad %ulong %35
-%43 = OpIAdd %ulong %41 %ulong_1442695040888963407
-OpStore %36 %43
-%44 = OpLoad %ulong %36
-%45 = OpLoad %ulong %33
-%46 = OpIAdd %ulong %44 %45
-OpStore %37 %46
-%47 = OpLoad %ulong %37
-OpReturnValue %47
+OpStore %30 %26
+OpStore %31 %27
+%35 = OpLoad %ulong %31
+%37 = OpIMul %ulong %35 %ulong_6364136223846793005
+OpStore %32 %37
+%38 = OpLoad %ulong %32
+%40 = OpIAdd %ulong %38 %ulong_1442695040888963407
+OpStore %33 %40
+%41 = OpLoad %ulong %33
+%42 = OpLoad %ulong %30
+%43 = OpIAdd %ulong %41 %42
+OpStore %34 %43
+%44 = OpLoad %ulong %34
+OpReturnValue %44
 OpFunctionEnd
-%2 = OpFunction %ulong None %50
-%51 = OpFunctionParameter %ulong
-%52 = OpFunctionParameter %_struct_49
-%53 = OpLabel
-%55 = OpVariable %_ptr_Function__struct_49 Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-%65 = OpVariable %_ptr_Function_uint Function
-%66 = OpVariable %_ptr_Function_uint Function
-%67 = OpVariable %_ptr_Function_uint Function
-OpStore %56 %51
-OpStore %55 %52
-%69 = OpAccessChain %_ptr_Function_uint %55 %uint_0
-%70 = OpLoad %uint %69
-OpStore %63 %70
-%72 = OpAccessChain %_ptr_Function_uint %55 %uint_1
-%73 = OpLoad %uint %72
-OpStore %64 %73
-%75 = OpAccessChain %_ptr_Function_uint %55 %uint_2
-%76 = OpLoad %uint %75
-OpStore %65 %76
-%78 = OpAccessChain %_ptr_Function_uint %55 %uint_3
-%79 = OpLoad %uint %78
-OpStore %66 %79
-%81 = OpAccessChain %_ptr_Function_uint %55 %uint_4
-%82 = OpLoad %uint %81
-OpStore %67 %82
-%83 = OpLoad %ulong %56
-%84 = OpLoad %uint %63
-%85 = OpFunctionCall %ulong %25 %83 %84
-OpStore %57 %85
-%86 = OpLoad %ulong %57
-%87 = OpLoad %uint %64
-%88 = OpFunctionCall %ulong %25 %86 %87
-OpStore %58 %88
-%89 = OpLoad %ulong %58
-%90 = OpLoad %uint %65
-%91 = OpFunctionCall %ulong %25 %89 %90
-OpStore %59 %91
-%92 = OpLoad %ulong %59
-%93 = OpLoad %uint %66
-%94 = OpFunctionCall %ulong %25 %92 %93
-OpStore %60 %94
-%95 = OpLoad %ulong %60
-%96 = OpLoad %uint %67
-%97 = OpFunctionCall %ulong %25 %95 %96
-OpStore %61 %97
-%98 = OpLoad %ulong %61
-OpReturnValue %98
-OpFunctionEnd
-%3 = OpFunction %ulong None %100
-%101 = OpFunctionParameter %ulong
-%102 = OpFunctionParameter %_struct_99
-%103 = OpLabel
-%105 = OpVariable %_ptr_Function__struct_99 Function
+%2 = OpFunction %ulong None %47
+%48 = OpFunctionParameter %ulong
+%49 = OpFunctionParameter %_struct_46
+%50 = OpLabel
+%93 = OpVariable %_ptr_Function__struct_46 Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_bool Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
 %106 = OpVariable %_ptr_Function_ulong Function
-%107 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_bool Function
 %108 = OpVariable %_ptr_Function_ulong Function
 %109 = OpVariable %_ptr_Function_ulong Function
 %110 = OpVariable %_ptr_Function_ulong Function
 %111 = OpVariable %_ptr_Function_ulong Function
 %112 = OpVariable %_ptr_Function_ulong Function
-OpStore %106 %101
-OpStore %105 %102
-%113 = OpAccessChain %_ptr_Function_ulong %105 %uint_0
-%114 = OpLoad %ulong %113
-OpStore %110 %114
-%115 = OpAccessChain %_ptr_Function_ulong %105 %uint_1
-%116 = OpLoad %ulong %115
-OpStore %111 %116
-%117 = OpAccessChain %_ptr_Function_ulong %105 %uint_2
-%118 = OpLoad %ulong %117
-OpStore %112 %118
-%119 = OpLoad %ulong %106
-%120 = OpLoad %ulong %110
-%121 = OpFunctionCall %ulong %24 %119 %120
-OpStore %107 %121
-%122 = OpLoad %ulong %107
-%123 = OpLoad %ulong %111
-%124 = OpFunctionCall %ulong %24 %122 %123
-OpStore %108 %124
-%125 = OpLoad %ulong %108
-%126 = OpLoad %ulong %112
-%127 = OpFunctionCall %ulong %24 %125 %126
-OpStore %109 %127
-%128 = OpLoad %ulong %109
-OpReturnValue %128
-OpFunctionEnd
-%4 = OpFunction %ulong None %131
-%132 = OpFunctionParameter %ulong
-%133 = OpFunctionParameter %_struct_130
-%134 = OpLabel
-%136 = OpVariable %_ptr_Function__struct_130 Function
-%137 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_bool Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_bool Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_bool Function
 %138 = OpVariable %_ptr_Function_ulong Function
 %139 = OpVariable %_ptr_Function_ulong Function
 %140 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_double Function
-%143 = OpVariable %_ptr_Function_double Function
-%144 = OpVariable %_ptr_Function_double Function
-OpStore %137 %132
-OpStore %136 %133
-%145 = OpAccessChain %_ptr_Function_double %136 %uint_0
-%146 = OpLoad %double %145
-OpStore %142 %146
-%147 = OpAccessChain %_ptr_Function_double %136 %uint_1
-%148 = OpLoad %double %147
-OpStore %143 %148
-%149 = OpAccessChain %_ptr_Function_double %136 %uint_2
-%150 = OpLoad %double %149
-OpStore %144 %150
-%151 = OpLoad %ulong %137
-%152 = OpLoad %double %142
-%153 = OpFunctionCall %ulong %26 %151 %152
-OpStore %138 %153
-%154 = OpLoad %ulong %138
-%155 = OpLoad %double %143
-%156 = OpFunctionCall %ulong %26 %154 %155
-OpStore %139 %156
-%157 = OpLoad %ulong %139
-%158 = OpLoad %double %144
-%159 = OpFunctionCall %ulong %26 %157 %158
-OpStore %140 %159
-%160 = OpLoad %ulong %140
-OpReturnValue %160
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_uint Function
+%149 = OpVariable %_ptr_Function_uint Function
+%150 = OpVariable %_ptr_Function_uint Function
+%151 = OpVariable %_ptr_Function_uint Function
+OpStore %94 %48
+OpStore %93 %49
+%153 = OpAccessChain %_ptr_Function_uint %93 %uint_0
+%154 = OpLoad %uint %153
+OpStore %147 %154
+%156 = OpAccessChain %_ptr_Function_uint %93 %uint_1
+%157 = OpLoad %uint %156
+OpStore %148 %157
+%159 = OpAccessChain %_ptr_Function_uint %93 %uint_2
+%160 = OpLoad %uint %159
+OpStore %149 %160
+%162 = OpAccessChain %_ptr_Function_uint %93 %uint_3
+%163 = OpLoad %uint %162
+OpStore %150 %163
+%165 = OpAccessChain %_ptr_Function_uint %93 %uint_4
+%166 = OpLoad %uint %165
+OpStore %151 %166
+OpBranch %51
+%51 = OpLabel
+%167 = OpLoad %uint %147
+%168 = OpUConvert %ulong %167
+OpStore %95 %168
+OpBranch %53
+%53 = OpLabel
+%169 = OpLoad %ulong %94
+OpStore %104 %169
+OpStore %105 %ulong_0
+OpBranch %54
+%54 = OpLabel
+%171 = OpLoad %ulong %105
+%173 = OpULessThan %bool %171 %ulong_8
+OpStore %97 %173
+%174 = OpLoad %bool %97
+OpLoopMerge %56 %90 None
+OpBranchConditional %174 %55 %56
+%56 = OpLabel
+OpBranch %57
+%57 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%175 = OpLoad %uint %148
+%176 = OpUConvert %ulong %175
+OpStore %106 %176
+OpBranch %60
+%60 = OpLabel
+%177 = OpLoad %ulong %104
+OpStore %114 %177
+OpStore %115 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%178 = OpLoad %ulong %115
+%179 = OpULessThan %bool %178 %ulong_8
+OpStore %107 %179
+%180 = OpLoad %bool %107
+OpLoopMerge %63 %89 None
+OpBranchConditional %180 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %65
+%65 = OpLabel
+%181 = OpLoad %uint %149
+%182 = OpUConvert %ulong %181
+OpStore %116 %182
+OpBranch %67
+%67 = OpLabel
+%183 = OpLoad %ulong %114
+OpStore %124 %183
+OpStore %125 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%184 = OpLoad %ulong %125
+%185 = OpULessThan %bool %184 %ulong_8
+OpStore %117 %185
+%186 = OpLoad %bool %117
+OpLoopMerge %70 %88 None
+OpBranchConditional %186 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%187 = OpLoad %uint %150
+%188 = OpUConvert %ulong %187
+OpStore %126 %188
+OpBranch %74
+%74 = OpLabel
+%189 = OpLoad %ulong %124
+OpStore %134 %189
+OpStore %135 %ulong_0
+OpBranch %75
+%75 = OpLabel
+%190 = OpLoad %ulong %135
+%191 = OpULessThan %bool %190 %ulong_8
+OpStore %127 %191
+%192 = OpLoad %bool %127
+OpLoopMerge %77 %87 None
+OpBranchConditional %192 %76 %77
+%77 = OpLabel
+OpBranch %78
+%78 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%193 = OpLoad %uint %151
+%194 = OpUConvert %ulong %193
+OpStore %136 %194
+OpBranch %81
+%81 = OpLabel
+%195 = OpLoad %ulong %134
+OpStore %144 %195
+OpStore %145 %ulong_0
+OpBranch %82
+%82 = OpLabel
+%196 = OpLoad %ulong %145
+%197 = OpULessThan %bool %196 %ulong_8
+OpStore %137 %197
+%198 = OpLoad %bool %137
+OpLoopMerge %84 %86 None
+OpBranchConditional %198 %83 %84
+%84 = OpLabel
+OpBranch %85
+%85 = OpLabel
+OpBranch %80
+%80 = OpLabel
+%199 = OpLoad %ulong %144
+OpReturnValue %199
+%83 = OpLabel
+%200 = OpLoad %ulong %145
+%201 = OpIMul %ulong %200 %ulong_8
+OpStore %138 %201
+%202 = OpLoad %ulong %136
+%203 = OpLoad %ulong %138
+%204 = OpShiftRightLogical %ulong %202 %203
+OpStore %139 %204
+%205 = OpLoad %ulong %139
+%207 = OpBitwiseAnd %ulong %205 %ulong_255
+OpStore %140 %207
+%208 = OpLoad %ulong %144
+%209 = OpLoad %ulong %140
+%210 = OpBitwiseXor %ulong %208 %209
+OpStore %141 %210
+%211 = OpLoad %ulong %141
+%213 = OpIMul %ulong %211 %ulong_1099511628211
+OpStore %142 %213
+%214 = OpLoad %ulong %145
+%216 = OpIAdd %ulong %214 %ulong_1
+OpStore %143 %216
+%217 = OpLoad %ulong %142
+OpStore %144 %217
+%218 = OpLoad %ulong %143
+OpStore %145 %218
+OpBranch %86
+%76 = OpLabel
+%219 = OpLoad %ulong %135
+%220 = OpIMul %ulong %219 %ulong_8
+OpStore %128 %220
+%221 = OpLoad %ulong %126
+%222 = OpLoad %ulong %128
+%223 = OpShiftRightLogical %ulong %221 %222
+OpStore %129 %223
+%224 = OpLoad %ulong %129
+%225 = OpBitwiseAnd %ulong %224 %ulong_255
+OpStore %130 %225
+%226 = OpLoad %ulong %134
+%227 = OpLoad %ulong %130
+%228 = OpBitwiseXor %ulong %226 %227
+OpStore %131 %228
+%229 = OpLoad %ulong %131
+%230 = OpIMul %ulong %229 %ulong_1099511628211
+OpStore %132 %230
+%231 = OpLoad %ulong %135
+%232 = OpIAdd %ulong %231 %ulong_1
+OpStore %133 %232
+%233 = OpLoad %ulong %132
+OpStore %134 %233
+%234 = OpLoad %ulong %133
+OpStore %135 %234
+OpBranch %87
+%69 = OpLabel
+%235 = OpLoad %ulong %125
+%236 = OpIMul %ulong %235 %ulong_8
+OpStore %118 %236
+%237 = OpLoad %ulong %116
+%238 = OpLoad %ulong %118
+%239 = OpShiftRightLogical %ulong %237 %238
+OpStore %119 %239
+%240 = OpLoad %ulong %119
+%241 = OpBitwiseAnd %ulong %240 %ulong_255
+OpStore %120 %241
+%242 = OpLoad %ulong %124
+%243 = OpLoad %ulong %120
+%244 = OpBitwiseXor %ulong %242 %243
+OpStore %121 %244
+%245 = OpLoad %ulong %121
+%246 = OpIMul %ulong %245 %ulong_1099511628211
+OpStore %122 %246
+%247 = OpLoad %ulong %125
+%248 = OpIAdd %ulong %247 %ulong_1
+OpStore %123 %248
+%249 = OpLoad %ulong %122
+OpStore %124 %249
+%250 = OpLoad %ulong %123
+OpStore %125 %250
+OpBranch %88
+%62 = OpLabel
+%251 = OpLoad %ulong %115
+%252 = OpIMul %ulong %251 %ulong_8
+OpStore %108 %252
+%253 = OpLoad %ulong %106
+%254 = OpLoad %ulong %108
+%255 = OpShiftRightLogical %ulong %253 %254
+OpStore %109 %255
+%256 = OpLoad %ulong %109
+%257 = OpBitwiseAnd %ulong %256 %ulong_255
+OpStore %110 %257
+%258 = OpLoad %ulong %114
+%259 = OpLoad %ulong %110
+%260 = OpBitwiseXor %ulong %258 %259
+OpStore %111 %260
+%261 = OpLoad %ulong %111
+%262 = OpIMul %ulong %261 %ulong_1099511628211
+OpStore %112 %262
+%263 = OpLoad %ulong %115
+%264 = OpIAdd %ulong %263 %ulong_1
+OpStore %113 %264
+%265 = OpLoad %ulong %112
+OpStore %114 %265
+%266 = OpLoad %ulong %113
+OpStore %115 %266
+OpBranch %89
+%55 = OpLabel
+%267 = OpLoad %ulong %105
+%268 = OpIMul %ulong %267 %ulong_8
+OpStore %98 %268
+%269 = OpLoad %ulong %95
+%270 = OpLoad %ulong %98
+%271 = OpShiftRightLogical %ulong %269 %270
+OpStore %99 %271
+%272 = OpLoad %ulong %99
+%273 = OpBitwiseAnd %ulong %272 %ulong_255
+OpStore %100 %273
+%274 = OpLoad %ulong %104
+%275 = OpLoad %ulong %100
+%276 = OpBitwiseXor %ulong %274 %275
+OpStore %101 %276
+%277 = OpLoad %ulong %101
+%278 = OpIMul %ulong %277 %ulong_1099511628211
+OpStore %102 %278
+%279 = OpLoad %ulong %105
+%280 = OpIAdd %ulong %279 %ulong_1
+OpStore %103 %280
+%281 = OpLoad %ulong %102
+OpStore %104 %281
+%282 = OpLoad %ulong %103
+OpStore %105 %282
+OpBranch %90
+%86 = OpLabel
+OpBranch %82
+%87 = OpLabel
+OpBranch %75
+%88 = OpLabel
+OpBranch %68
+%89 = OpLabel
+OpBranch %61
+%90 = OpLabel
+OpBranch %54
 OpFunctionEnd
-%5 = OpFunction %ulong None %162
-%163 = OpFunctionParameter %ulong
-%164 = OpFunctionParameter %_struct_161
-%165 = OpLabel
-%167 = OpVariable %_ptr_Function__struct_161 Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-OpStore %168 %163
-OpStore %167 %164
-%177 = OpAccessChain %_ptr_Function_ulong %167 %uint_0
-%178 = OpLoad %ulong %177
-OpStore %173 %178
-%179 = OpAccessChain %_ptr_Function_ulong %167 %uint_1
-%180 = OpLoad %ulong %179
-OpStore %174 %180
-%181 = OpAccessChain %_ptr_Function_ulong %167 %uint_2
-%182 = OpLoad %ulong %181
-OpStore %175 %182
-%183 = OpAccessChain %_ptr_Function_ulong %167 %uint_3
-%184 = OpLoad %ulong %183
-OpStore %176 %184
-%185 = OpLoad %ulong %168
-%186 = OpLoad %ulong %173
-%187 = OpFunctionCall %ulong %24 %185 %186
-OpStore %169 %187
-%188 = OpLoad %ulong %169
-%189 = OpLoad %ulong %174
-%190 = OpFunctionCall %ulong %24 %188 %189
-OpStore %170 %190
-%191 = OpLoad %ulong %170
-%192 = OpLoad %ulong %175
-%193 = OpFunctionCall %ulong %24 %191 %192
-OpStore %171 %193
-%194 = OpLoad %ulong %171
-%195 = OpLoad %ulong %176
-%196 = OpFunctionCall %ulong %24 %194 %195
-OpStore %172 %196
-%197 = OpLoad %ulong %172
-OpReturnValue %197
-OpFunctionEnd
-%6 = OpFunction %ulong None %199
-%200 = OpFunctionParameter %ulong
-%201 = OpFunctionParameter %_struct_198
-%202 = OpLabel
-%204 = OpVariable %_ptr_Function__struct_198 Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_double Function
-%214 = OpVariable %_ptr_Function_uint Function
-%215 = OpVariable %_ptr_Function_uint Function
-%216 = OpVariable %_ptr_Function_double Function
-%217 = OpVariable %_ptr_Function_ulong Function
-OpStore %205 %200
-OpStore %204 %201
-%218 = OpAccessChain %_ptr_Function_ulong %204 %uint_0
-%219 = OpLoad %ulong %218
-OpStore %212 %219
-%220 = OpAccessChain %_ptr_Function_double %204 %uint_1
-%221 = OpLoad %double %220
-OpStore %213 %221
-%222 = OpAccessChain %_ptr_Function_uint %204 %uint_2
-%223 = OpLoad %uint %222
-OpStore %214 %223
-%224 = OpAccessChain %_ptr_Function_uint %204 %uint_3
-%225 = OpLoad %uint %224
-OpStore %215 %225
-%226 = OpAccessChain %_ptr_Function_double %204 %uint_4
-%227 = OpLoad %double %226
-OpStore %216 %227
-%229 = OpAccessChain %_ptr_Function_ulong %204 %uint_5
-%230 = OpLoad %ulong %229
-OpStore %217 %230
-%231 = OpLoad %ulong %205
-%232 = OpLoad %ulong %212
-%233 = OpFunctionCall %ulong %24 %231 %232
-OpStore %206 %233
-%234 = OpLoad %ulong %206
-%235 = OpLoad %double %213
-%236 = OpFunctionCall %ulong %26 %234 %235
-OpStore %207 %236
-%237 = OpLoad %ulong %207
-%238 = OpLoad %uint %214
-%239 = OpFunctionCall %ulong %25 %237 %238
-OpStore %208 %239
-%240 = OpLoad %ulong %208
-%241 = OpLoad %uint %215
-%242 = OpFunctionCall %ulong %25 %240 %241
-OpStore %209 %242
-%243 = OpLoad %ulong %209
-%244 = OpLoad %double %216
-%245 = OpFunctionCall %ulong %26 %243 %244
-OpStore %210 %245
-%246 = OpLoad %ulong %210
-%247 = OpLoad %ulong %217
-%248 = OpFunctionCall %ulong %24 %246 %247
-OpStore %211 %248
-%249 = OpLoad %ulong %211
-OpReturnValue %249
-OpFunctionEnd
-%7 = OpFunction %ulong None %251
-%252 = OpFunctionParameter %ulong
-%253 = OpFunctionParameter %_struct_250
-%254 = OpLabel
-%256 = OpVariable %_ptr_Function__struct_250 Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
-OpStore %257 %252
-OpStore %256 %253
-%270 = OpAccessChain %_ptr_Function_ulong %256 %uint_0
-%271 = OpLoad %ulong %270
-OpStore %264 %271
-%272 = OpAccessChain %_ptr_Function_ulong %256 %uint_1
-%273 = OpLoad %ulong %272
-OpStore %265 %273
-%274 = OpAccessChain %_ptr_Function_ulong %256 %uint_2
-%275 = OpLoad %ulong %274
-OpStore %266 %275
-%276 = OpAccessChain %_ptr_Function_ulong %256 %uint_3
-%277 = OpLoad %ulong %276
-OpStore %267 %277
-%278 = OpAccessChain %_ptr_Function_ulong %256 %uint_4
-%279 = OpLoad %ulong %278
-OpStore %268 %279
-%280 = OpAccessChain %_ptr_Function_ulong %256 %uint_5
-%281 = OpLoad %ulong %280
-OpStore %269 %281
-%282 = OpLoad %ulong %257
-%283 = OpLoad %ulong %264
-%284 = OpFunctionCall %ulong %24 %282 %283
-OpStore %258 %284
-%285 = OpLoad %ulong %258
-%286 = OpLoad %ulong %265
-%287 = OpFunctionCall %ulong %24 %285 %286
-OpStore %259 %287
-%288 = OpLoad %ulong %259
-%289 = OpLoad %ulong %266
-%290 = OpFunctionCall %ulong %24 %288 %289
-OpStore %260 %290
-%291 = OpLoad %ulong %260
-%292 = OpLoad %ulong %267
-%293 = OpFunctionCall %ulong %24 %291 %292
-OpStore %261 %293
-%294 = OpLoad %ulong %261
-%295 = OpLoad %ulong %268
-%296 = OpFunctionCall %ulong %24 %294 %295
-OpStore %262 %296
-%297 = OpLoad %ulong %262
-%298 = OpLoad %ulong %269
-%299 = OpFunctionCall %ulong %24 %297 %298
-OpStore %263 %299
-%300 = OpLoad %ulong %263
-OpReturnValue %300
-OpFunctionEnd
-%8 = OpFunction %ulong None %303
-%304 = OpFunctionParameter %ulong
-%305 = OpFunctionParameter %_struct_302
-%306 = OpLabel
-%310 = OpVariable %_ptr_Function__struct_302 Function
+%3 = OpFunction %ulong None %284
+%285 = OpFunctionParameter %ulong
+%286 = OpFunctionParameter %_struct_283
+%287 = OpLabel
+%307 = OpVariable %_ptr_Function__struct_283 Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_ulong Function
 %311 = OpVariable %_ptr_Function_ulong Function
 %312 = OpVariable %_ptr_Function_ulong Function
 %313 = OpVariable %_ptr_Function_ulong Function
@@ -472,957 +499,1228 @@ OpFunctionEnd
 %315 = OpVariable %_ptr_Function_ulong Function
 %316 = OpVariable %_ptr_Function_ulong Function
 %317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_uint Function
+%318 = OpVariable %_ptr_Function_bool Function
 %319 = OpVariable %_ptr_Function_ulong Function
 %320 = OpVariable %_ptr_Function_ulong Function
 %321 = OpVariable %_ptr_Function_ulong Function
 %322 = OpVariable %_ptr_Function_ulong Function
 %323 = OpVariable %_ptr_Function_ulong Function
-OpStore %311 %304
-OpStore %310 %305
-%324 = OpAccessChain %_ptr_Function_uint %310 %uint_0
-%325 = OpLoad %uint %324
-OpStore %318 %325
-%326 = OpAccessChain %_ptr_Function__struct_99 %310 %uint_1
-%327 = OpAccessChain %_ptr_Function_ulong %326 %uint_0
-%328 = OpLoad %ulong %327
-OpStore %319 %328
-%329 = OpAccessChain %_ptr_Function_ulong %326 %uint_1
-%330 = OpLoad %ulong %329
-OpStore %320 %330
-%331 = OpAccessChain %_ptr_Function_ulong %326 %uint_2
-%332 = OpLoad %ulong %331
-OpStore %321 %332
-%334 = OpAccessChain %_ptr_Function__struct_301 %310 %uint_2
-%335 = OpAccessChain %_ptr_Function_ulong %334 %uint_0
-%336 = OpLoad %ulong %335
-OpStore %322 %336
-%337 = OpAccessChain %_ptr_Function_ulong %334 %uint_1
-%338 = OpLoad %ulong %337
-OpStore %323 %338
-%339 = OpLoad %ulong %311
-%340 = OpLoad %uint %318
-%341 = OpFunctionCall %ulong %25 %339 %340
-OpStore %312 %341
-OpBranch %307
-%307 = OpLabel
-%342 = OpLoad %ulong %312
-%343 = OpLoad %ulong %319
-%344 = OpFunctionCall %ulong %24 %342 %343
-OpStore %315 %344
-%345 = OpLoad %ulong %315
-%346 = OpLoad %ulong %320
-%347 = OpFunctionCall %ulong %24 %345 %346
-OpStore %316 %347
-%348 = OpLoad %ulong %316
-%349 = OpLoad %ulong %321
-%350 = OpFunctionCall %ulong %24 %348 %349
-OpStore %317 %350
-OpBranch %308
-%308 = OpLabel
-%351 = OpLoad %ulong %317
-%352 = OpLoad %ulong %322
-%353 = OpFunctionCall %ulong %24 %351 %352
-OpStore %313 %353
-%354 = OpLoad %ulong %313
-%355 = OpLoad %ulong %323
-%356 = OpFunctionCall %ulong %24 %354 %355
-OpStore %314 %356
-%357 = OpLoad %ulong %314
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_bool Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+OpStore %308 %285
+OpStore %307 %286
+%339 = OpAccessChain %_ptr_Function_ulong %307 %uint_0
+%340 = OpLoad %ulong %339
+OpStore %336 %340
+%341 = OpAccessChain %_ptr_Function_ulong %307 %uint_1
+%342 = OpLoad %ulong %341
+OpStore %337 %342
+%343 = OpAccessChain %_ptr_Function_ulong %307 %uint_2
+%344 = OpLoad %ulong %343
+OpStore %338 %344
+OpBranch %288
+%288 = OpLabel
+%345 = OpLoad %ulong %308
+OpStore %316 %345
+OpStore %317 %ulong_0
+OpBranch %289
+%289 = OpLabel
+%346 = OpLoad %ulong %317
+%347 = OpULessThan %bool %346 %ulong_8
+OpStore %309 %347
+%348 = OpLoad %bool %309
+OpLoopMerge %291 %305 None
+OpBranchConditional %348 %290 %291
+%291 = OpLabel
+OpBranch %292
+%292 = OpLabel
+OpBranch %293
+%293 = OpLabel
+%349 = OpLoad %ulong %316
+OpStore %325 %349
+OpStore %326 %ulong_0
+OpBranch %294
+%294 = OpLabel
+%350 = OpLoad %ulong %326
+%351 = OpULessThan %bool %350 %ulong_8
+OpStore %318 %351
+%352 = OpLoad %bool %318
+OpLoopMerge %296 %304 None
+OpBranchConditional %352 %295 %296
+%296 = OpLabel
+OpBranch %297
+%297 = OpLabel
+OpBranch %298
+%298 = OpLabel
+%353 = OpLoad %ulong %325
+OpStore %334 %353
+OpStore %335 %ulong_0
+OpBranch %299
+%299 = OpLabel
+%354 = OpLoad %ulong %335
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %327 %355
+%356 = OpLoad %bool %327
+OpLoopMerge %301 %303 None
+OpBranchConditional %356 %300 %301
+%301 = OpLabel
+OpBranch %302
+%302 = OpLabel
+%357 = OpLoad %ulong %334
 OpReturnValue %357
+%300 = OpLabel
+%358 = OpLoad %ulong %335
+%359 = OpIMul %ulong %358 %ulong_8
+OpStore %328 %359
+%360 = OpLoad %ulong %338
+%361 = OpLoad %ulong %328
+%362 = OpShiftRightLogical %ulong %360 %361
+OpStore %329 %362
+%363 = OpLoad %ulong %329
+%364 = OpBitwiseAnd %ulong %363 %ulong_255
+OpStore %330 %364
+%365 = OpLoad %ulong %334
+%366 = OpLoad %ulong %330
+%367 = OpBitwiseXor %ulong %365 %366
+OpStore %331 %367
+%368 = OpLoad %ulong %331
+%369 = OpIMul %ulong %368 %ulong_1099511628211
+OpStore %332 %369
+%370 = OpLoad %ulong %335
+%371 = OpIAdd %ulong %370 %ulong_1
+OpStore %333 %371
+%372 = OpLoad %ulong %332
+OpStore %334 %372
+%373 = OpLoad %ulong %333
+OpStore %335 %373
+OpBranch %303
+%295 = OpLabel
+%374 = OpLoad %ulong %326
+%375 = OpIMul %ulong %374 %ulong_8
+OpStore %319 %375
+%376 = OpLoad %ulong %337
+%377 = OpLoad %ulong %319
+%378 = OpShiftRightLogical %ulong %376 %377
+OpStore %320 %378
+%379 = OpLoad %ulong %320
+%380 = OpBitwiseAnd %ulong %379 %ulong_255
+OpStore %321 %380
+%381 = OpLoad %ulong %325
+%382 = OpLoad %ulong %321
+%383 = OpBitwiseXor %ulong %381 %382
+OpStore %322 %383
+%384 = OpLoad %ulong %322
+%385 = OpIMul %ulong %384 %ulong_1099511628211
+OpStore %323 %385
+%386 = OpLoad %ulong %326
+%387 = OpIAdd %ulong %386 %ulong_1
+OpStore %324 %387
+%388 = OpLoad %ulong %323
+OpStore %325 %388
+%389 = OpLoad %ulong %324
+OpStore %326 %389
+OpBranch %304
+%290 = OpLabel
+%390 = OpLoad %ulong %317
+%391 = OpIMul %ulong %390 %ulong_8
+OpStore %310 %391
+%392 = OpLoad %ulong %336
+%393 = OpLoad %ulong %310
+%394 = OpShiftRightLogical %ulong %392 %393
+OpStore %311 %394
+%395 = OpLoad %ulong %311
+%396 = OpBitwiseAnd %ulong %395 %ulong_255
+OpStore %312 %396
+%397 = OpLoad %ulong %316
+%398 = OpLoad %ulong %312
+%399 = OpBitwiseXor %ulong %397 %398
+OpStore %313 %399
+%400 = OpLoad %ulong %313
+%401 = OpIMul %ulong %400 %ulong_1099511628211
+OpStore %314 %401
+%402 = OpLoad %ulong %317
+%403 = OpIAdd %ulong %402 %ulong_1
+OpStore %315 %403
+%404 = OpLoad %ulong %314
+OpStore %316 %404
+%405 = OpLoad %ulong %315
+OpStore %317 %405
+OpBranch %305
+%303 = OpLabel
+OpBranch %299
+%304 = OpLabel
+OpBranch %294
+%305 = OpLabel
+OpBranch %289
 OpFunctionEnd
-%9 = OpFunction %ulong None %358
-%359 = OpFunctionParameter %ulong
-%360 = OpLabel
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_ulong Function
-%368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_ulong Function
-%370 = OpVariable %_ptr_Function_ulong Function
-OpStore %361 %359
-%371 = OpLoad %ulong %361
-%373 = OpFunctionCall %ulong %24 %371 %ulong_20
-OpStore %362 %373
-%374 = OpLoad %ulong %362
-%376 = OpFunctionCall %ulong %24 %374 %ulong_24
-OpStore %363 %376
-%377 = OpLoad %ulong %363
-%378 = OpFunctionCall %ulong %24 %377 %ulong_24
-OpStore %364 %378
-%379 = OpLoad %ulong %364
-%381 = OpFunctionCall %ulong %24 %379 %ulong_32
-OpStore %365 %381
-%382 = OpLoad %ulong %365
-%384 = OpFunctionCall %ulong %24 %382 %ulong_40
-OpStore %366 %384
-%385 = OpLoad %ulong %366
-%387 = OpFunctionCall %ulong %24 %385 %ulong_48
-OpStore %367 %387
-%388 = OpLoad %ulong %367
-%389 = OpFunctionCall %ulong %24 %388 %ulong_48
-OpStore %368 %389
-%390 = OpLoad %ulong %368
-%392 = OpFunctionCall %ulong %24 %390 %ulong_8
-OpStore %369 %392
-%393 = OpLoad %ulong %369
-%394 = OpFunctionCall %ulong %24 %393 %ulong_32
-OpStore %370 %394
-%395 = OpLoad %ulong %370
-OpReturnValue %395
-OpFunctionEnd
-%10 = OpFunction %_struct_49 None %396
-%397 = OpFunctionParameter %ulong
-%398 = OpLabel
-%399 = OpVariable %_ptr_Function__struct_49 Function
-%400 = OpVariable %_ptr_Function_ulong Function
-%401 = OpVariable %_ptr_Function_uint Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_uint Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_uint Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_uint Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_uint Function
-OpStore %400 %397
-%410 = OpLoad %ulong %400
-%411 = OpUConvert %uint %410
-OpStore %401 %411
-%412 = OpAccessChain %_ptr_Function_uint %399 %uint_0
-%413 = OpLoad %uint %401
-OpStore %412 %413
-%414 = OpLoad %ulong %400
-%415 = OpShiftRightLogical %ulong %414 %ulong_8
-OpStore %402 %415
-%416 = OpLoad %ulong %402
-%417 = OpUConvert %uint %416
-OpStore %403 %417
-%418 = OpAccessChain %_ptr_Function_uint %399 %uint_1
-%419 = OpLoad %uint %403
-OpStore %418 %419
-%420 = OpLoad %ulong %400
-%422 = OpShiftRightLogical %ulong %420 %ulong_16
-OpStore %404 %422
-%423 = OpLoad %ulong %404
-%424 = OpUConvert %uint %423
-OpStore %405 %424
-%425 = OpAccessChain %_ptr_Function_uint %399 %uint_2
-%426 = OpLoad %uint %405
-OpStore %425 %426
-%427 = OpLoad %ulong %400
-%428 = OpShiftRightLogical %ulong %427 %ulong_24
-OpStore %406 %428
-%429 = OpLoad %ulong %406
-%430 = OpUConvert %uint %429
-OpStore %407 %430
-%431 = OpAccessChain %_ptr_Function_uint %399 %uint_3
-%432 = OpLoad %uint %407
-OpStore %431 %432
-%433 = OpLoad %ulong %400
-%434 = OpShiftRightLogical %ulong %433 %ulong_32
-OpStore %408 %434
-%435 = OpLoad %ulong %408
-%436 = OpUConvert %uint %435
-OpStore %409 %436
-%437 = OpAccessChain %_ptr_Function_uint %399 %uint_4
-%438 = OpLoad %uint %409
-OpStore %437 %438
-%439 = OpLoad %_struct_49 %399
-OpReturnValue %439
-OpFunctionEnd
-%11 = OpFunction %_struct_99 None %440
-%441 = OpFunctionParameter %ulong
-%442 = OpLabel
-%443 = OpVariable %_ptr_Function__struct_99 Function
+%4 = OpFunction %ulong None %408
+%409 = OpFunctionParameter %ulong
+%410 = OpFunctionParameter %_struct_407
+%411 = OpLabel
+%437 = OpVariable %_ptr_Function__struct_407 Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_bool Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
 %444 = OpVariable %_ptr_Function_ulong Function
 %445 = OpVariable %_ptr_Function_ulong Function
 %446 = OpVariable %_ptr_Function_ulong Function
 %447 = OpVariable %_ptr_Function_ulong Function
-OpStore %444 %441
-%448 = OpAccessChain %_ptr_Function_ulong %443 %uint_0
-%449 = OpLoad %ulong %444
-OpStore %448 %449
-%450 = OpLoad %ulong %444
-%451 = OpNot %ulong %450
-OpStore %445 %451
-%452 = OpAccessChain %_ptr_Function_ulong %443 %uint_1
-%453 = OpLoad %ulong %445
-OpStore %452 %453
-%454 = OpLoad %ulong %444
-%456 = OpIMul %ulong %454 %ulong_3
-OpStore %446 %456
-%457 = OpLoad %ulong %446
-%459 = OpIAdd %ulong %457 %ulong_1
-OpStore %447 %459
-%460 = OpAccessChain %_ptr_Function_ulong %443 %uint_2
-%461 = OpLoad %ulong %447
-OpStore %460 %461
-%462 = OpLoad %_struct_99 %443
-OpReturnValue %462
-OpFunctionEnd
-%12 = OpFunction %_struct_130 None %463
-%464 = OpFunctionParameter %ulong
-%465 = OpLabel
-%466 = OpVariable %_ptr_Function__struct_130 Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_bool Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_bool Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
 %467 = OpVariable %_ptr_Function_ulong Function
 %468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_double Function
 %470 = OpVariable %_ptr_Function_double Function
-%471 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_double Function
 %472 = OpVariable %_ptr_Function_double Function
-%473 = OpVariable %_ptr_Function_double Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_double Function
-%476 = OpVariable %_ptr_Function_double Function
-OpStore %467 %464
-%477 = OpLoad %ulong %467
-%479 = OpBitwiseAnd %ulong %477 %ulong_65535
-OpStore %468 %479
-%480 = OpLoad %ulong %468
-%481 = OpConvertUToF %double %480
-OpStore %469 %481
-%482 = OpLoad %double %469
-%484 = OpFDiv %double %482 %double_8
-OpStore %470 %484
-%485 = OpAccessChain %_ptr_Function_double %466 %uint_0
-%486 = OpLoad %double %470
-OpStore %485 %486
-%487 = OpLoad %ulong %467
-%489 = OpBitwiseAnd %ulong %487 %ulong_4095
-OpStore %471 %489
-%490 = OpLoad %ulong %471
-%491 = OpConvertUToF %double %490
-OpStore %472 %491
-%492 = OpLoad %double %472
-%494 = OpFSub %double %492 %double_2048
-OpStore %473 %494
-%495 = OpAccessChain %_ptr_Function_double %466 %uint_1
-%496 = OpLoad %double %473
-OpStore %495 %496
+OpStore %438 %409
+OpStore %437 %410
+%473 = OpAccessChain %_ptr_Function_double %437 %uint_0
+%474 = OpLoad %double %473
+OpStore %470 %474
+%475 = OpAccessChain %_ptr_Function_double %437 %uint_1
+%476 = OpLoad %double %475
+OpStore %471 %476
+%477 = OpAccessChain %_ptr_Function_double %437 %uint_2
+%478 = OpLoad %double %477
+OpStore %472 %478
+OpBranch %412
+%412 = OpLabel
+%479 = OpLoad %double %470
+%480 = OpBitcast %ulong %479
+OpStore %439 %480
+OpBranch %414
+%414 = OpLabel
+%481 = OpLoad %ulong %438
+OpStore %447 %481
+OpStore %448 %ulong_0
+OpBranch %415
+%415 = OpLabel
+%482 = OpLoad %ulong %448
+%483 = OpULessThan %bool %482 %ulong_8
+OpStore %440 %483
+%484 = OpLoad %bool %440
+OpLoopMerge %417 %435 None
+OpBranchConditional %484 %416 %417
+%417 = OpLabel
+OpBranch %418
+%418 = OpLabel
+OpBranch %413
+%413 = OpLabel
+OpBranch %419
+%419 = OpLabel
+%485 = OpLoad %double %471
+%486 = OpBitcast %ulong %485
+OpStore %449 %486
+OpBranch %421
+%421 = OpLabel
+%487 = OpLoad %ulong %447
+OpStore %457 %487
+OpStore %458 %ulong_0
+OpBranch %422
+%422 = OpLabel
+%488 = OpLoad %ulong %458
+%489 = OpULessThan %bool %488 %ulong_8
+OpStore %450 %489
+%490 = OpLoad %bool %450
+OpLoopMerge %424 %434 None
+OpBranchConditional %490 %423 %424
+%424 = OpLabel
+OpBranch %425
+%425 = OpLabel
+OpBranch %420
+%420 = OpLabel
+OpBranch %426
+%426 = OpLabel
+%491 = OpLoad %double %472
+%492 = OpBitcast %ulong %491
+OpStore %459 %492
+OpBranch %428
+%428 = OpLabel
+%493 = OpLoad %ulong %457
+OpStore %467 %493
+OpStore %468 %ulong_0
+OpBranch %429
+%429 = OpLabel
+%494 = OpLoad %ulong %468
+%495 = OpULessThan %bool %494 %ulong_8
+OpStore %460 %495
+%496 = OpLoad %bool %460
+OpLoopMerge %431 %433 None
+OpBranchConditional %496 %430 %431
+%431 = OpLabel
+OpBranch %432
+%432 = OpLabel
+OpBranch %427
+%427 = OpLabel
 %497 = OpLoad %ulong %467
-%499 = OpBitwiseAnd %ulong %497 %ulong_262143
-OpStore %474 %499
-%500 = OpLoad %ulong %474
-%501 = OpConvertUToF %double %500
-OpStore %475 %501
-%502 = OpLoad %double %475
-%504 = OpFDiv %double %502 %double_64
-OpStore %476 %504
-%505 = OpAccessChain %_ptr_Function_double %466 %uint_2
-%506 = OpLoad %double %476
-OpStore %505 %506
-%507 = OpLoad %_struct_130 %466
-OpReturnValue %507
+OpReturnValue %497
+%430 = OpLabel
+%498 = OpLoad %ulong %468
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %461 %499
+%500 = OpLoad %ulong %459
+%501 = OpLoad %ulong %461
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %462 %502
+%503 = OpLoad %ulong %462
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %463 %504
+%505 = OpLoad %ulong %467
+%506 = OpLoad %ulong %463
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %464 %507
+%508 = OpLoad %ulong %464
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %465 %509
+%510 = OpLoad %ulong %468
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %466 %511
+%512 = OpLoad %ulong %465
+OpStore %467 %512
+%513 = OpLoad %ulong %466
+OpStore %468 %513
+OpBranch %433
+%423 = OpLabel
+%514 = OpLoad %ulong %458
+%515 = OpIMul %ulong %514 %ulong_8
+OpStore %451 %515
+%516 = OpLoad %ulong %449
+%517 = OpLoad %ulong %451
+%518 = OpShiftRightLogical %ulong %516 %517
+OpStore %452 %518
+%519 = OpLoad %ulong %452
+%520 = OpBitwiseAnd %ulong %519 %ulong_255
+OpStore %453 %520
+%521 = OpLoad %ulong %457
+%522 = OpLoad %ulong %453
+%523 = OpBitwiseXor %ulong %521 %522
+OpStore %454 %523
+%524 = OpLoad %ulong %454
+%525 = OpIMul %ulong %524 %ulong_1099511628211
+OpStore %455 %525
+%526 = OpLoad %ulong %458
+%527 = OpIAdd %ulong %526 %ulong_1
+OpStore %456 %527
+%528 = OpLoad %ulong %455
+OpStore %457 %528
+%529 = OpLoad %ulong %456
+OpStore %458 %529
+OpBranch %434
+%416 = OpLabel
+%530 = OpLoad %ulong %448
+%531 = OpIMul %ulong %530 %ulong_8
+OpStore %441 %531
+%532 = OpLoad %ulong %439
+%533 = OpLoad %ulong %441
+%534 = OpShiftRightLogical %ulong %532 %533
+OpStore %442 %534
+%535 = OpLoad %ulong %442
+%536 = OpBitwiseAnd %ulong %535 %ulong_255
+OpStore %443 %536
+%537 = OpLoad %ulong %447
+%538 = OpLoad %ulong %443
+%539 = OpBitwiseXor %ulong %537 %538
+OpStore %444 %539
+%540 = OpLoad %ulong %444
+%541 = OpIMul %ulong %540 %ulong_1099511628211
+OpStore %445 %541
+%542 = OpLoad %ulong %448
+%543 = OpIAdd %ulong %542 %ulong_1
+OpStore %446 %543
+%544 = OpLoad %ulong %445
+OpStore %447 %544
+%545 = OpLoad %ulong %446
+OpStore %448 %545
+OpBranch %435
+%433 = OpLabel
+OpBranch %429
+%434 = OpLabel
+OpBranch %422
+%435 = OpLabel
+OpBranch %415
 OpFunctionEnd
-%13 = OpFunction %_struct_161 None %508
-%509 = OpFunctionParameter %ulong
-%510 = OpLabel
-%511 = OpVariable %_ptr_Function__struct_161 Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-OpStore %512 %509
-%516 = OpAccessChain %_ptr_Function_ulong %511 %uint_0
-%517 = OpLoad %ulong %512
-OpStore %516 %517
-%518 = OpLoad %ulong %512
-%519 = OpIAdd %ulong %518 %ulong_1
-OpStore %513 %519
-%520 = OpAccessChain %_ptr_Function_ulong %511 %uint_1
-%521 = OpLoad %ulong %513
-OpStore %520 %521
-%522 = OpLoad %ulong %512
-%524 = OpIMul %ulong %522 %ulong_5
-OpStore %514 %524
-%525 = OpAccessChain %_ptr_Function_ulong %511 %uint_2
-%526 = OpLoad %ulong %514
-OpStore %525 %526
-%527 = OpLoad %ulong %512
-%528 = OpNot %ulong %527
-OpStore %515 %528
-%529 = OpAccessChain %_ptr_Function_ulong %511 %uint_3
-%530 = OpLoad %ulong %515
-OpStore %529 %530
-%531 = OpLoad %_struct_161 %511
-OpReturnValue %531
-OpFunctionEnd
-%14 = OpFunction %_struct_198 None %532
-%533 = OpFunctionParameter %ulong
-%534 = OpLabel
-%535 = OpVariable %_ptr_Function__struct_198 Function
-%536 = OpVariable %_ptr_Function_ulong Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_double Function
-%539 = OpVariable %_ptr_Function_double Function
-%540 = OpVariable %_ptr_Function_uint Function
-%541 = OpVariable %_ptr_Function_ulong Function
-%542 = OpVariable %_ptr_Function_uint Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_double Function
-%545 = OpVariable %_ptr_Function_double Function
-%546 = OpVariable %_ptr_Function_ulong Function
-OpStore %536 %533
-%547 = OpAccessChain %_ptr_Function_ulong %535 %uint_0
-%548 = OpLoad %ulong %536
-OpStore %547 %548
-%549 = OpLoad %ulong %536
-%551 = OpBitwiseAnd %ulong %549 %ulong_8191
-OpStore %537 %551
-%552 = OpLoad %ulong %537
-%553 = OpConvertUToF %double %552
-OpStore %538 %553
-%554 = OpLoad %double %538
-%556 = OpFDiv %double %554 %double_2
-OpStore %539 %556
-%557 = OpAccessChain %_ptr_Function_double %535 %uint_1
-%558 = OpLoad %double %539
-OpStore %557 %558
-%559 = OpLoad %ulong %536
-%560 = OpUConvert %uint %559
-OpStore %540 %560
-%561 = OpAccessChain %_ptr_Function_uint %535 %uint_2
-%562 = OpLoad %uint %540
-OpStore %561 %562
-%563 = OpLoad %ulong %536
-%564 = OpShiftRightLogical %ulong %563 %ulong_16
-OpStore %541 %564
-%565 = OpLoad %ulong %541
-%566 = OpUConvert %uint %565
-OpStore %542 %566
-%567 = OpAccessChain %_ptr_Function_uint %535 %uint_3
-%568 = OpLoad %uint %542
-OpStore %567 %568
-%569 = OpLoad %ulong %536
-%571 = OpBitwiseAnd %ulong %569 %ulong_131071
-OpStore %543 %571
-%572 = OpLoad %ulong %543
-%573 = OpConvertUToF %double %572
-OpStore %544 %573
-%574 = OpLoad %double %544
-%576 = OpFDiv %double %574 %double_32
-OpStore %545 %576
-%577 = OpAccessChain %_ptr_Function_double %535 %uint_4
-%578 = OpLoad %double %545
-OpStore %577 %578
-%579 = OpLoad %ulong %536
-%581 = OpIMul %ulong %579 %ulong_7
-OpStore %546 %581
-%582 = OpAccessChain %_ptr_Function_ulong %535 %uint_5
-%583 = OpLoad %ulong %546
-OpStore %582 %583
-%584 = OpLoad %_struct_198 %535
-OpReturnValue %584
-OpFunctionEnd
-%15 = OpFunction %_struct_250 None %585
-%586 = OpFunctionParameter %ulong
-%587 = OpLabel
-%588 = OpVariable %_ptr_Function__struct_250 Function
+%5 = OpFunction %ulong None %547
+%548 = OpFunctionParameter %ulong
+%549 = OpFunctionParameter %_struct_546
+%550 = OpLabel
+%576 = OpVariable %_ptr_Function__struct_546 Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_bool Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_bool Function
+%588 = OpVariable %_ptr_Function_ulong Function
 %589 = OpVariable %_ptr_Function_ulong Function
 %590 = OpVariable %_ptr_Function_ulong Function
 %591 = OpVariable %_ptr_Function_ulong Function
 %592 = OpVariable %_ptr_Function_ulong Function
 %593 = OpVariable %_ptr_Function_ulong Function
 %594 = OpVariable %_ptr_Function_ulong Function
-OpStore %589 %586
-%595 = OpAccessChain %_ptr_Function_ulong %588 %uint_0
-%596 = OpLoad %ulong %589
-OpStore %595 %596
-%597 = OpLoad %ulong %589
-%598 = OpIAdd %ulong %597 %ulong_1
-OpStore %590 %598
-%599 = OpAccessChain %_ptr_Function_ulong %588 %uint_1
-%600 = OpLoad %ulong %590
-OpStore %599 %600
-%601 = OpLoad %ulong %589
-%603 = OpIAdd %ulong %601 %ulong_2
-OpStore %591 %603
-%604 = OpAccessChain %_ptr_Function_ulong %588 %uint_2
-%605 = OpLoad %ulong %591
-OpStore %604 %605
-%606 = OpLoad %ulong %589
-%608 = OpIMul %ulong %606 %ulong_9
-OpStore %592 %608
-%609 = OpAccessChain %_ptr_Function_ulong %588 %uint_3
-%610 = OpLoad %ulong %592
-OpStore %609 %610
-%611 = OpLoad %ulong %589
-%612 = OpNot %ulong %611
-OpStore %593 %612
-%613 = OpAccessChain %_ptr_Function_ulong %588 %uint_4
-%614 = OpLoad %ulong %593
-OpStore %613 %614
-%615 = OpLoad %ulong %589
-%617 = OpBitwiseXor %ulong %615 %ulong_2863311530
-OpStore %594 %617
-%618 = OpAccessChain %_ptr_Function_ulong %588 %uint_5
-%619 = OpLoad %ulong %594
-OpStore %618 %619
-%620 = OpLoad %_struct_250 %588
-OpReturnValue %620
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_bool Function
+%597 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_ulong Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_bool Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_ulong Function
+%610 = OpVariable %_ptr_Function_ulong Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_ulong Function
+%613 = OpVariable %_ptr_Function_ulong Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_ulong Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+OpStore %577 %548
+OpStore %576 %549
+%618 = OpAccessChain %_ptr_Function_ulong %576 %uint_0
+%619 = OpLoad %ulong %618
+OpStore %614 %619
+%620 = OpAccessChain %_ptr_Function_ulong %576 %uint_1
+%621 = OpLoad %ulong %620
+OpStore %615 %621
+%622 = OpAccessChain %_ptr_Function_ulong %576 %uint_2
+%623 = OpLoad %ulong %622
+OpStore %616 %623
+%624 = OpAccessChain %_ptr_Function_ulong %576 %uint_3
+%625 = OpLoad %ulong %624
+OpStore %617 %625
+OpBranch %551
+%551 = OpLabel
+%626 = OpLoad %ulong %577
+OpStore %585 %626
+OpStore %586 %ulong_0
+OpBranch %552
+%552 = OpLabel
+%627 = OpLoad %ulong %586
+%628 = OpULessThan %bool %627 %ulong_8
+OpStore %578 %628
+%629 = OpLoad %bool %578
+OpLoopMerge %554 %574 None
+OpBranchConditional %629 %553 %554
+%554 = OpLabel
+OpBranch %555
+%555 = OpLabel
+OpBranch %556
+%556 = OpLabel
+%630 = OpLoad %ulong %585
+OpStore %594 %630
+OpStore %595 %ulong_0
+OpBranch %557
+%557 = OpLabel
+%631 = OpLoad %ulong %595
+%632 = OpULessThan %bool %631 %ulong_8
+OpStore %587 %632
+%633 = OpLoad %bool %587
+OpLoopMerge %559 %573 None
+OpBranchConditional %633 %558 %559
+%559 = OpLabel
+OpBranch %560
+%560 = OpLabel
+OpBranch %561
+%561 = OpLabel
+%634 = OpLoad %ulong %594
+OpStore %603 %634
+OpStore %604 %ulong_0
+OpBranch %562
+%562 = OpLabel
+%635 = OpLoad %ulong %604
+%636 = OpULessThan %bool %635 %ulong_8
+OpStore %596 %636
+%637 = OpLoad %bool %596
+OpLoopMerge %564 %572 None
+OpBranchConditional %637 %563 %564
+%564 = OpLabel
+OpBranch %565
+%565 = OpLabel
+OpBranch %566
+%566 = OpLabel
+%638 = OpLoad %ulong %603
+OpStore %612 %638
+OpStore %613 %ulong_0
+OpBranch %567
+%567 = OpLabel
+%639 = OpLoad %ulong %613
+%640 = OpULessThan %bool %639 %ulong_8
+OpStore %605 %640
+%641 = OpLoad %bool %605
+OpLoopMerge %569 %571 None
+OpBranchConditional %641 %568 %569
+%569 = OpLabel
+OpBranch %570
+%570 = OpLabel
+%642 = OpLoad %ulong %612
+OpReturnValue %642
+%568 = OpLabel
+%643 = OpLoad %ulong %613
+%644 = OpIMul %ulong %643 %ulong_8
+OpStore %606 %644
+%645 = OpLoad %ulong %617
+%646 = OpLoad %ulong %606
+%647 = OpShiftRightLogical %ulong %645 %646
+OpStore %607 %647
+%648 = OpLoad %ulong %607
+%649 = OpBitwiseAnd %ulong %648 %ulong_255
+OpStore %608 %649
+%650 = OpLoad %ulong %612
+%651 = OpLoad %ulong %608
+%652 = OpBitwiseXor %ulong %650 %651
+OpStore %609 %652
+%653 = OpLoad %ulong %609
+%654 = OpIMul %ulong %653 %ulong_1099511628211
+OpStore %610 %654
+%655 = OpLoad %ulong %613
+%656 = OpIAdd %ulong %655 %ulong_1
+OpStore %611 %656
+%657 = OpLoad %ulong %610
+OpStore %612 %657
+%658 = OpLoad %ulong %611
+OpStore %613 %658
+OpBranch %571
+%563 = OpLabel
+%659 = OpLoad %ulong %604
+%660 = OpIMul %ulong %659 %ulong_8
+OpStore %597 %660
+%661 = OpLoad %ulong %616
+%662 = OpLoad %ulong %597
+%663 = OpShiftRightLogical %ulong %661 %662
+OpStore %598 %663
+%664 = OpLoad %ulong %598
+%665 = OpBitwiseAnd %ulong %664 %ulong_255
+OpStore %599 %665
+%666 = OpLoad %ulong %603
+%667 = OpLoad %ulong %599
+%668 = OpBitwiseXor %ulong %666 %667
+OpStore %600 %668
+%669 = OpLoad %ulong %600
+%670 = OpIMul %ulong %669 %ulong_1099511628211
+OpStore %601 %670
+%671 = OpLoad %ulong %604
+%672 = OpIAdd %ulong %671 %ulong_1
+OpStore %602 %672
+%673 = OpLoad %ulong %601
+OpStore %603 %673
+%674 = OpLoad %ulong %602
+OpStore %604 %674
+OpBranch %572
+%558 = OpLabel
+%675 = OpLoad %ulong %595
+%676 = OpIMul %ulong %675 %ulong_8
+OpStore %588 %676
+%677 = OpLoad %ulong %615
+%678 = OpLoad %ulong %588
+%679 = OpShiftRightLogical %ulong %677 %678
+OpStore %589 %679
+%680 = OpLoad %ulong %589
+%681 = OpBitwiseAnd %ulong %680 %ulong_255
+OpStore %590 %681
+%682 = OpLoad %ulong %594
+%683 = OpLoad %ulong %590
+%684 = OpBitwiseXor %ulong %682 %683
+OpStore %591 %684
+%685 = OpLoad %ulong %591
+%686 = OpIMul %ulong %685 %ulong_1099511628211
+OpStore %592 %686
+%687 = OpLoad %ulong %595
+%688 = OpIAdd %ulong %687 %ulong_1
+OpStore %593 %688
+%689 = OpLoad %ulong %592
+OpStore %594 %689
+%690 = OpLoad %ulong %593
+OpStore %595 %690
+OpBranch %573
+%553 = OpLabel
+%691 = OpLoad %ulong %586
+%692 = OpIMul %ulong %691 %ulong_8
+OpStore %579 %692
+%693 = OpLoad %ulong %614
+%694 = OpLoad %ulong %579
+%695 = OpShiftRightLogical %ulong %693 %694
+OpStore %580 %695
+%696 = OpLoad %ulong %580
+%697 = OpBitwiseAnd %ulong %696 %ulong_255
+OpStore %581 %697
+%698 = OpLoad %ulong %585
+%699 = OpLoad %ulong %581
+%700 = OpBitwiseXor %ulong %698 %699
+OpStore %582 %700
+%701 = OpLoad %ulong %582
+%702 = OpIMul %ulong %701 %ulong_1099511628211
+OpStore %583 %702
+%703 = OpLoad %ulong %586
+%704 = OpIAdd %ulong %703 %ulong_1
+OpStore %584 %704
+%705 = OpLoad %ulong %583
+OpStore %585 %705
+%706 = OpLoad %ulong %584
+OpStore %586 %706
+OpBranch %574
+%571 = OpLabel
+OpBranch %567
+%572 = OpLabel
+OpBranch %562
+%573 = OpLabel
+OpBranch %557
+%574 = OpLabel
+OpBranch %552
 OpFunctionEnd
-%16 = OpFunction %_struct_99 None %621
-%622 = OpFunctionParameter %_struct_99
-%623 = OpFunctionParameter %ulong
-%624 = OpLabel
-%625 = OpVariable %_ptr_Function__struct_99 Function
-%626 = OpVariable %_ptr_Function__struct_99 Function
-%627 = OpVariable %_ptr_Function_ulong Function
-%628 = OpVariable %_ptr_Function_ulong Function
-%629 = OpVariable %_ptr_Function_ulong Function
-%630 = OpVariable %_ptr_Function_ulong Function
-%631 = OpVariable %_ptr_Function_ulong Function
-%632 = OpVariable %_ptr_Function_ulong Function
-%633 = OpVariable %_ptr_Function_ulong Function
-OpStore %625 %622
-OpStore %627 %623
-%634 = OpAccessChain %_ptr_Function_ulong %625 %uint_0
-%635 = OpLoad %ulong %634
-OpStore %631 %635
-%636 = OpAccessChain %_ptr_Function_ulong %625 %uint_1
-%637 = OpLoad %ulong %636
-OpStore %632 %637
-%638 = OpAccessChain %_ptr_Function_ulong %625 %uint_2
-%639 = OpLoad %ulong %638
-OpStore %633 %639
-%640 = OpLoad %ulong %631
-%641 = OpLoad %ulong %627
-%642 = OpIAdd %ulong %640 %641
-OpStore %628 %642
-%643 = OpAccessChain %_ptr_Function_ulong %626 %uint_0
-%644 = OpLoad %ulong %628
-OpStore %643 %644
-%645 = OpLoad %ulong %632
-%646 = OpLoad %ulong %627
-%647 = OpBitwiseXor %ulong %645 %646
-OpStore %629 %647
-%648 = OpAccessChain %_ptr_Function_ulong %626 %uint_1
-%649 = OpLoad %ulong %629
-OpStore %648 %649
-%650 = OpLoad %ulong %633
-%651 = OpLoad %ulong %631
-%652 = OpIAdd %ulong %650 %651
-OpStore %630 %652
-%653 = OpAccessChain %_ptr_Function_ulong %626 %uint_2
-%654 = OpLoad %ulong %630
-OpStore %653 %654
-%655 = OpLoad %_struct_99 %626
-OpReturnValue %655
-OpFunctionEnd
-%17 = OpFunction %_struct_250 None %656
-%657 = OpFunctionParameter %_struct_250
-%658 = OpFunctionParameter %ulong
-%659 = OpLabel
-%660 = OpVariable %_ptr_Function__struct_250 Function
-%661 = OpVariable %_ptr_Function__struct_250 Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_ulong Function
-%668 = OpVariable %_ptr_Function_ulong Function
-%669 = OpVariable %_ptr_Function_ulong Function
-%670 = OpVariable %_ptr_Function_ulong Function
-%671 = OpVariable %_ptr_Function_ulong Function
-%672 = OpVariable %_ptr_Function_ulong Function
-%673 = OpVariable %_ptr_Function_ulong Function
-%674 = OpVariable %_ptr_Function_ulong Function
-OpStore %660 %657
-OpStore %662 %658
-%675 = OpAccessChain %_ptr_Function_ulong %660 %uint_0
-%676 = OpLoad %ulong %675
-OpStore %669 %676
-%677 = OpAccessChain %_ptr_Function_ulong %660 %uint_1
-%678 = OpLoad %ulong %677
-OpStore %670 %678
-%679 = OpAccessChain %_ptr_Function_ulong %660 %uint_2
-%680 = OpLoad %ulong %679
-OpStore %671 %680
-%681 = OpAccessChain %_ptr_Function_ulong %660 %uint_3
-%682 = OpLoad %ulong %681
-OpStore %672 %682
-%683 = OpAccessChain %_ptr_Function_ulong %660 %uint_4
-%684 = OpLoad %ulong %683
-OpStore %673 %684
-%685 = OpAccessChain %_ptr_Function_ulong %660 %uint_5
-%686 = OpLoad %ulong %685
-OpStore %674 %686
-%687 = OpLoad %ulong %669
-%688 = OpLoad %ulong %662
-%689 = OpIAdd %ulong %687 %688
-OpStore %663 %689
-%690 = OpAccessChain %_ptr_Function_ulong %661 %uint_0
-%691 = OpLoad %ulong %663
-OpStore %690 %691
-%692 = OpLoad %ulong %670
-%693 = OpLoad %ulong %662
-%694 = OpBitwiseXor %ulong %692 %693
-OpStore %664 %694
-%695 = OpAccessChain %_ptr_Function_ulong %661 %uint_1
-%696 = OpLoad %ulong %664
-OpStore %695 %696
-%697 = OpLoad %ulong %671
-%698 = OpLoad %ulong %669
-%699 = OpIAdd %ulong %697 %698
-OpStore %665 %699
-%700 = OpAccessChain %_ptr_Function_ulong %661 %uint_2
-%701 = OpLoad %ulong %665
-OpStore %700 %701
-%702 = OpLoad %ulong %672
-%703 = OpLoad %ulong %670
-%704 = OpIAdd %ulong %702 %703
-OpStore %666 %704
-%705 = OpAccessChain %_ptr_Function_ulong %661 %uint_3
-%706 = OpLoad %ulong %666
-OpStore %705 %706
-%707 = OpLoad %ulong %673
-%708 = OpLoad %ulong %671
-%709 = OpBitwiseXor %ulong %707 %708
-OpStore %667 %709
-%710 = OpAccessChain %_ptr_Function_ulong %661 %uint_4
-%711 = OpLoad %ulong %667
-OpStore %710 %711
-%712 = OpLoad %ulong %674
-%713 = OpLoad %ulong %662
-%714 = OpIAdd %ulong %712 %713
-OpStore %668 %714
-%715 = OpAccessChain %_ptr_Function_ulong %661 %uint_5
-%716 = OpLoad %ulong %668
-OpStore %715 %716
-%717 = OpLoad %_struct_250 %661
-OpReturnValue %717
-OpFunctionEnd
-%18 = OpFunction %_struct_250 None %718
-%719 = OpFunctionParameter %_struct_99
-%720 = OpLabel
-%721 = OpVariable %_ptr_Function__struct_99 Function
-%722 = OpVariable %_ptr_Function__struct_250 Function
-%723 = OpVariable %_ptr_Function_ulong Function
-%724 = OpVariable %_ptr_Function_ulong Function
-%725 = OpVariable %_ptr_Function_ulong Function
-%726 = OpVariable %_ptr_Function_ulong Function
-%727 = OpVariable %_ptr_Function_ulong Function
+%6 = OpFunction %ulong None %708
+%709 = OpFunctionParameter %ulong
+%710 = OpFunctionParameter %_struct_707
+%711 = OpLabel
+%727 = OpVariable %_ptr_Function__struct_707 Function
 %728 = OpVariable %_ptr_Function_ulong Function
-OpStore %721 %719
-%729 = OpAccessChain %_ptr_Function_ulong %721 %uint_0
-%730 = OpLoad %ulong %729
-OpStore %726 %730
-%731 = OpAccessChain %_ptr_Function_ulong %721 %uint_1
-%732 = OpLoad %ulong %731
-OpStore %727 %732
-%733 = OpAccessChain %_ptr_Function_ulong %721 %uint_2
-%734 = OpLoad %ulong %733
-OpStore %728 %734
-%735 = OpAccessChain %_ptr_Function_ulong %722 %uint_0
-%736 = OpLoad %ulong %726
-OpStore %735 %736
-%737 = OpAccessChain %_ptr_Function_ulong %722 %uint_1
-%738 = OpLoad %ulong %727
-OpStore %737 %738
-%739 = OpAccessChain %_ptr_Function_ulong %722 %uint_2
-%740 = OpLoad %ulong %728
-OpStore %739 %740
-%741 = OpLoad %ulong %726
-%742 = OpLoad %ulong %727
-%743 = OpBitwiseXor %ulong %741 %742
-OpStore %723 %743
-%744 = OpAccessChain %_ptr_Function_ulong %722 %uint_3
-%745 = OpLoad %ulong %723
-OpStore %744 %745
-%746 = OpLoad %ulong %727
-%747 = OpLoad %ulong %728
-%748 = OpBitwiseXor %ulong %746 %747
-OpStore %724 %748
-%749 = OpAccessChain %_ptr_Function_ulong %722 %uint_4
-%750 = OpLoad %ulong %724
-OpStore %749 %750
-%751 = OpLoad %ulong %728
-%752 = OpLoad %ulong %726
-%753 = OpBitwiseXor %ulong %751 %752
-OpStore %725 %753
-%754 = OpAccessChain %_ptr_Function_ulong %722 %uint_5
-%755 = OpLoad %ulong %725
-OpStore %754 %755
-%756 = OpLoad %_struct_250 %722
-OpReturnValue %756
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_bool Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_ulong Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_double Function
+%749 = OpVariable %_ptr_Function_uint Function
+%750 = OpVariable %_ptr_Function_uint Function
+%751 = OpVariable %_ptr_Function_double Function
+%752 = OpVariable %_ptr_Function_ulong Function
+OpStore %728 %709
+OpStore %727 %710
+%753 = OpAccessChain %_ptr_Function_ulong %727 %uint_0
+%754 = OpLoad %ulong %753
+OpStore %747 %754
+%755 = OpAccessChain %_ptr_Function_double %727 %uint_1
+%756 = OpLoad %double %755
+OpStore %748 %756
+%757 = OpAccessChain %_ptr_Function_uint %727 %uint_2
+%758 = OpLoad %uint %757
+OpStore %749 %758
+%759 = OpAccessChain %_ptr_Function_uint %727 %uint_3
+%760 = OpLoad %uint %759
+OpStore %750 %760
+%761 = OpAccessChain %_ptr_Function_double %727 %uint_4
+%762 = OpLoad %double %761
+OpStore %751 %762
+%764 = OpAccessChain %_ptr_Function_ulong %727 %uint_5
+%765 = OpLoad %ulong %764
+OpStore %752 %765
+OpBranch %712
+%712 = OpLabel
+%766 = OpLoad %ulong %728
+OpStore %737 %766
+OpStore %738 %ulong_0
+OpBranch %713
+%713 = OpLabel
+%767 = OpLoad %ulong %738
+%768 = OpULessThan %bool %767 %ulong_8
+OpStore %730 %768
+%769 = OpLoad %bool %730
+OpLoopMerge %715 %725 None
+OpBranchConditional %769 %714 %715
+%715 = OpLabel
+OpBranch %716
+%716 = OpLabel
+OpBranch %717
+%717 = OpLabel
+%770 = OpLoad %double %748
+%771 = OpBitcast %ulong %770
+OpStore %739 %771
+%772 = OpLoad %ulong %737
+%773 = OpLoad %ulong %739
+%774 = OpFunctionCall %ulong %23 %772 %773
+OpStore %740 %774
+OpBranch %718
+%718 = OpLabel
+OpBranch %719
+%719 = OpLabel
+%775 = OpLoad %uint %749
+%776 = OpUConvert %ulong %775
+OpStore %741 %776
+%777 = OpLoad %ulong %740
+%778 = OpLoad %ulong %741
+%779 = OpFunctionCall %ulong %23 %777 %778
+OpStore %742 %779
+OpBranch %720
+%720 = OpLabel
+OpBranch %721
+%721 = OpLabel
+%780 = OpLoad %uint %750
+%781 = OpUConvert %ulong %780
+OpStore %743 %781
+%782 = OpLoad %ulong %742
+%783 = OpLoad %ulong %743
+%784 = OpFunctionCall %ulong %23 %782 %783
+OpStore %744 %784
+OpBranch %722
+%722 = OpLabel
+OpBranch %723
+%723 = OpLabel
+%785 = OpLoad %double %751
+%786 = OpBitcast %ulong %785
+OpStore %745 %786
+%787 = OpLoad %ulong %744
+%788 = OpLoad %ulong %745
+%789 = OpFunctionCall %ulong %23 %787 %788
+OpStore %746 %789
+OpBranch %724
+%724 = OpLabel
+%790 = OpLoad %ulong %746
+%791 = OpLoad %ulong %752
+%792 = OpFunctionCall %ulong %23 %790 %791
+OpStore %729 %792
+%793 = OpLoad %ulong %729
+OpReturnValue %793
+%714 = OpLabel
+%794 = OpLoad %ulong %738
+%795 = OpIMul %ulong %794 %ulong_8
+OpStore %731 %795
+%796 = OpLoad %ulong %747
+%797 = OpLoad %ulong %731
+%798 = OpShiftRightLogical %ulong %796 %797
+OpStore %732 %798
+%799 = OpLoad %ulong %732
+%800 = OpBitwiseAnd %ulong %799 %ulong_255
+OpStore %733 %800
+%801 = OpLoad %ulong %737
+%802 = OpLoad %ulong %733
+%803 = OpBitwiseXor %ulong %801 %802
+OpStore %734 %803
+%804 = OpLoad %ulong %734
+%805 = OpIMul %ulong %804 %ulong_1099511628211
+OpStore %735 %805
+%806 = OpLoad %ulong %738
+%807 = OpIAdd %ulong %806 %ulong_1
+OpStore %736 %807
+%808 = OpLoad %ulong %735
+OpStore %737 %808
+%809 = OpLoad %ulong %736
+OpStore %738 %809
+OpBranch %725
+%725 = OpLabel
+OpBranch %713
 OpFunctionEnd
-%19 = OpFunction %_struct_99 None %757
-%758 = OpFunctionParameter %_struct_250
-%759 = OpLabel
-%760 = OpVariable %_ptr_Function__struct_250 Function
-%761 = OpVariable %_ptr_Function__struct_99 Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_ulong Function
-%764 = OpVariable %_ptr_Function_ulong Function
-%765 = OpVariable %_ptr_Function_ulong Function
-%766 = OpVariable %_ptr_Function_ulong Function
-%767 = OpVariable %_ptr_Function_ulong Function
-%768 = OpVariable %_ptr_Function_ulong Function
-%769 = OpVariable %_ptr_Function_ulong Function
-%770 = OpVariable %_ptr_Function_ulong Function
-OpStore %760 %758
-%771 = OpAccessChain %_ptr_Function_ulong %760 %uint_0
-%772 = OpLoad %ulong %771
-OpStore %765 %772
-%773 = OpAccessChain %_ptr_Function_ulong %760 %uint_1
-%774 = OpLoad %ulong %773
-OpStore %766 %774
-%775 = OpAccessChain %_ptr_Function_ulong %760 %uint_2
-%776 = OpLoad %ulong %775
-OpStore %767 %776
-%777 = OpAccessChain %_ptr_Function_ulong %760 %uint_3
-%778 = OpLoad %ulong %777
-OpStore %768 %778
-%779 = OpAccessChain %_ptr_Function_ulong %760 %uint_4
-%780 = OpLoad %ulong %779
-OpStore %769 %780
-%781 = OpAccessChain %_ptr_Function_ulong %760 %uint_5
-%782 = OpLoad %ulong %781
-OpStore %770 %782
-%783 = OpLoad %ulong %765
-%784 = OpLoad %ulong %768
-%785 = OpBitwiseXor %ulong %783 %784
-OpStore %762 %785
-%786 = OpAccessChain %_ptr_Function_ulong %761 %uint_0
-%787 = OpLoad %ulong %762
-OpStore %786 %787
-%788 = OpLoad %ulong %766
-%789 = OpLoad %ulong %769
-%790 = OpBitwiseXor %ulong %788 %789
-OpStore %763 %790
-%791 = OpAccessChain %_ptr_Function_ulong %761 %uint_1
-%792 = OpLoad %ulong %763
-OpStore %791 %792
-%793 = OpLoad %ulong %767
-%794 = OpLoad %ulong %770
-%795 = OpBitwiseXor %ulong %793 %794
-OpStore %764 %795
-%796 = OpAccessChain %_ptr_Function_ulong %761 %uint_2
-%797 = OpLoad %ulong %764
-OpStore %796 %797
-%798 = OpLoad %_struct_99 %761
-OpReturnValue %798
+%7 = OpFunction %ulong None %811
+%812 = OpFunctionParameter %ulong
+%813 = OpFunctionParameter %_struct_810
+%814 = OpLabel
+%816 = OpVariable %_ptr_Function__struct_810 Function
+%817 = OpVariable %_ptr_Function_ulong Function
+%818 = OpVariable %_ptr_Function_ulong Function
+%819 = OpVariable %_ptr_Function_ulong Function
+%820 = OpVariable %_ptr_Function_ulong Function
+%821 = OpVariable %_ptr_Function_ulong Function
+%822 = OpVariable %_ptr_Function_ulong Function
+%823 = OpVariable %_ptr_Function_ulong Function
+%824 = OpVariable %_ptr_Function_ulong Function
+%825 = OpVariable %_ptr_Function_ulong Function
+%826 = OpVariable %_ptr_Function_ulong Function
+%827 = OpVariable %_ptr_Function_ulong Function
+%828 = OpVariable %_ptr_Function_ulong Function
+%829 = OpVariable %_ptr_Function_ulong Function
+OpStore %817 %812
+OpStore %816 %813
+%830 = OpAccessChain %_ptr_Function_ulong %816 %uint_0
+%831 = OpLoad %ulong %830
+OpStore %824 %831
+%832 = OpAccessChain %_ptr_Function_ulong %816 %uint_1
+%833 = OpLoad %ulong %832
+OpStore %825 %833
+%834 = OpAccessChain %_ptr_Function_ulong %816 %uint_2
+%835 = OpLoad %ulong %834
+OpStore %826 %835
+%836 = OpAccessChain %_ptr_Function_ulong %816 %uint_3
+%837 = OpLoad %ulong %836
+OpStore %827 %837
+%838 = OpAccessChain %_ptr_Function_ulong %816 %uint_4
+%839 = OpLoad %ulong %838
+OpStore %828 %839
+%840 = OpAccessChain %_ptr_Function_ulong %816 %uint_5
+%841 = OpLoad %ulong %840
+OpStore %829 %841
+%842 = OpLoad %ulong %817
+%843 = OpLoad %ulong %824
+%844 = OpFunctionCall %ulong %23 %842 %843
+OpStore %818 %844
+%845 = OpLoad %ulong %818
+%846 = OpLoad %ulong %825
+%847 = OpFunctionCall %ulong %23 %845 %846
+OpStore %819 %847
+%848 = OpLoad %ulong %819
+%849 = OpLoad %ulong %826
+%850 = OpFunctionCall %ulong %23 %848 %849
+OpStore %820 %850
+%851 = OpLoad %ulong %820
+%852 = OpLoad %ulong %827
+%853 = OpFunctionCall %ulong %23 %851 %852
+OpStore %821 %853
+%854 = OpLoad %ulong %821
+%855 = OpLoad %ulong %828
+%856 = OpFunctionCall %ulong %23 %854 %855
+OpStore %822 %856
+%857 = OpLoad %ulong %822
+%858 = OpLoad %ulong %829
+%859 = OpFunctionCall %ulong %23 %857 %858
+OpStore %823 %859
+%860 = OpLoad %ulong %823
+OpReturnValue %860
 OpFunctionEnd
-%20 = OpFunction %_struct_302 None %799
-%800 = OpFunctionParameter %ulong
-%801 = OpLabel
-%804 = OpVariable %_ptr_Function__struct_302 Function
-%805 = OpVariable %_ptr_Function__struct_99 Function
-%806 = OpVariable %_ptr_Function__struct_301 Function
-%807 = OpVariable %_ptr_Function_ulong Function
-%808 = OpVariable %_ptr_Function_uint Function
-%809 = OpVariable %_ptr_Function_ulong Function
-%810 = OpVariable %_ptr_Function_ulong Function
-%811 = OpVariable %_ptr_Function_ulong Function
-%812 = OpVariable %_ptr_Function_ulong Function
-%813 = OpVariable %_ptr_Function_ulong Function
-OpStore %807 %800
-%814 = OpLoad %ulong %807
-%815 = OpUConvert %uint %814
-OpStore %808 %815
-%816 = OpAccessChain %_ptr_Function_uint %804 %uint_0
-%817 = OpLoad %uint %808
-OpStore %816 %817
-OpBranch %802
-%802 = OpLabel
-%818 = OpAccessChain %_ptr_Function_ulong %805 %uint_0
-%819 = OpLoad %ulong %807
-OpStore %818 %819
-%820 = OpLoad %ulong %807
-%821 = OpNot %ulong %820
-OpStore %811 %821
-%822 = OpAccessChain %_ptr_Function_ulong %805 %uint_1
-%823 = OpLoad %ulong %811
-OpStore %822 %823
-%824 = OpLoad %ulong %807
-%825 = OpIMul %ulong %824 %ulong_3
-OpStore %812 %825
-%826 = OpLoad %ulong %812
-%827 = OpIAdd %ulong %826 %ulong_1
-OpStore %813 %827
-%828 = OpAccessChain %_ptr_Function_ulong %805 %uint_2
-%829 = OpLoad %ulong %813
-OpStore %828 %829
-OpBranch %803
-%803 = OpLabel
-%830 = OpAccessChain %_ptr_Function__struct_99 %804 %uint_1
-%831 = OpLoad %_struct_99 %805
-OpStore %830 %831
-%832 = OpLoad %ulong %807
-%834 = OpIMul %ulong %832 %ulong_11
-OpStore %809 %834
-%835 = OpAccessChain %_ptr_Function_ulong %806 %uint_0
-%836 = OpLoad %ulong %809
-OpStore %835 %836
-%837 = OpLoad %ulong %807
-%838 = OpNot %ulong %837
-OpStore %810 %838
-%839 = OpAccessChain %_ptr_Function_ulong %806 %uint_1
-%840 = OpLoad %ulong %810
-OpStore %839 %840
-%841 = OpAccessChain %_ptr_Function__struct_301 %804 %uint_2
-%842 = OpLoad %_struct_301 %806
-OpStore %841 %842
-%843 = OpLoad %_struct_302 %804
-OpReturnValue %843
-OpFunctionEnd
-%21 = OpFunction %ulong None %844
-%845 = OpFunctionParameter %_struct_250
-%846 = OpFunctionParameter %_struct_99
-%847 = OpFunctionParameter %ulong
-%848 = OpLabel
-%853 = OpVariable %_ptr_Function__struct_250 Function
-%854 = OpVariable %_ptr_Function__struct_99 Function
-%855 = OpVariable %_ptr_Function_ulong Function
-%856 = OpVariable %_ptr_Function_ulong Function
-%857 = OpVariable %_ptr_Function_ulong Function
-%858 = OpVariable %_ptr_Function_ulong Function
-%859 = OpVariable %_ptr_Function_ulong Function
-%860 = OpVariable %_ptr_Function_ulong Function
-%861 = OpVariable %_ptr_Function_ulong Function
-%862 = OpVariable %_ptr_Function_ulong Function
-%863 = OpVariable %_ptr_Function_ulong Function
-%864 = OpVariable %_ptr_Function_ulong Function
-%865 = OpVariable %_ptr_Function_ulong Function
-%866 = OpVariable %_ptr_Function_ulong Function
-%867 = OpVariable %_ptr_Function_ulong Function
-%868 = OpVariable %_ptr_Function_ulong Function
-%869 = OpVariable %_ptr_Function_ulong Function
-%870 = OpVariable %_ptr_Function_ulong Function
-%871 = OpVariable %_ptr_Function_ulong Function
-%872 = OpVariable %_ptr_Function_ulong Function
+%8 = OpFunction %ulong None %863
+%864 = OpFunctionParameter %ulong
+%865 = OpFunctionParameter %_struct_862
+%866 = OpLabel
+%870 = OpVariable %_ptr_Function__struct_862 Function
+%871 = OpVariable %_ptr_Function__struct_862 Function
+%872 = OpVariable %_ptr_Function__struct_283 Function
 %873 = OpVariable %_ptr_Function_ulong Function
-%874 = OpVariable %_ptr_Function_ulong Function
+%874 = OpVariable %_ptr_Function_uint Function
 %875 = OpVariable %_ptr_Function_ulong Function
-OpStore %853 %845
-OpStore %854 %846
-OpStore %855 %847
-%876 = OpAccessChain %_ptr_Function_ulong %853 %uint_0
-%877 = OpLoad %ulong %876
-OpStore %867 %877
-%878 = OpAccessChain %_ptr_Function_ulong %853 %uint_1
-%879 = OpLoad %ulong %878
-OpStore %868 %879
-%880 = OpAccessChain %_ptr_Function_ulong %853 %uint_2
-%881 = OpLoad %ulong %880
-OpStore %869 %881
-%882 = OpAccessChain %_ptr_Function_ulong %853 %uint_3
-%883 = OpLoad %ulong %882
-OpStore %870 %883
-%884 = OpAccessChain %_ptr_Function_ulong %853 %uint_4
-%885 = OpLoad %ulong %884
-OpStore %871 %885
-%886 = OpAccessChain %_ptr_Function_ulong %853 %uint_5
-%887 = OpLoad %ulong %886
-OpStore %872 %887
-%888 = OpAccessChain %_ptr_Function_ulong %854 %uint_0
-%889 = OpLoad %ulong %888
-OpStore %873 %889
-%890 = OpAccessChain %_ptr_Function_ulong %854 %uint_1
-%891 = OpLoad %ulong %890
-OpStore %874 %891
-%892 = OpAccessChain %_ptr_Function_ulong %854 %uint_2
-%893 = OpLoad %ulong %892
-OpStore %875 %893
-%894 = OpFunctionCall %ulong %23
-OpStore %856 %894
-OpBranch %849
-%849 = OpLabel
-%895 = OpLoad %ulong %856
-%896 = OpLoad %ulong %867
-%897 = OpFunctionCall %ulong %24 %895 %896
-OpStore %858 %897
-%898 = OpLoad %ulong %858
-%899 = OpLoad %ulong %868
-%900 = OpFunctionCall %ulong %24 %898 %899
-OpStore %859 %900
-%901 = OpLoad %ulong %859
-%902 = OpLoad %ulong %869
-%903 = OpFunctionCall %ulong %24 %901 %902
-OpStore %860 %903
-%904 = OpLoad %ulong %860
-%905 = OpLoad %ulong %870
-%906 = OpFunctionCall %ulong %24 %904 %905
-OpStore %861 %906
-%907 = OpLoad %ulong %861
-%908 = OpLoad %ulong %871
-%909 = OpFunctionCall %ulong %24 %907 %908
-OpStore %862 %909
-%910 = OpLoad %ulong %862
-%911 = OpLoad %ulong %872
-%912 = OpFunctionCall %ulong %24 %910 %911
-OpStore %863 %912
-OpBranch %850
-%850 = OpLabel
-OpBranch %851
-%851 = OpLabel
-%913 = OpLoad %ulong %863
-%914 = OpLoad %ulong %873
-%915 = OpFunctionCall %ulong %24 %913 %914
-OpStore %864 %915
-%916 = OpLoad %ulong %864
-%917 = OpLoad %ulong %874
-%918 = OpFunctionCall %ulong %24 %916 %917
-OpStore %865 %918
-%919 = OpLoad %ulong %865
-%920 = OpLoad %ulong %875
-%921 = OpFunctionCall %ulong %24 %919 %920
-OpStore %866 %921
-OpBranch %852
-%852 = OpLabel
-%922 = OpLoad %ulong %866
-%923 = OpLoad %ulong %855
-%924 = OpFunctionCall %ulong %24 %922 %923
-OpStore %857 %924
-%925 = OpLoad %ulong %857
-OpReturnValue %925
+%876 = OpVariable %_ptr_Function_ulong Function
+%877 = OpVariable %_ptr_Function_ulong Function
+%878 = OpVariable %_ptr_Function_ulong Function
+%879 = OpVariable %_ptr_Function_ulong Function
+%880 = OpVariable %_ptr_Function_ulong Function
+%881 = OpVariable %_ptr_Function_ulong Function
+OpStore %873 %864
+OpStore %870 %865
+%882 = OpLoad %_struct_862 %870
+OpStore %871 %882
+%883 = OpAccessChain %_ptr_Function_uint %871 %uint_0
+%884 = OpLoad %uint %883
+OpStore %874 %884
+OpBranch %867
+%867 = OpLabel
+%885 = OpLoad %uint %874
+%886 = OpUConvert %ulong %885
+OpStore %880 %886
+%887 = OpLoad %ulong %873
+%888 = OpLoad %ulong %880
+%889 = OpFunctionCall %ulong %23 %887 %888
+OpStore %881 %889
+OpBranch %868
+%868 = OpLabel
+%890 = OpAccessChain %_ptr_Function__struct_283 %871 %uint_1
+%891 = OpLoad %_struct_283 %890
+OpStore %872 %891
+%892 = OpLoad %ulong %881
+%893 = OpLoad %_struct_283 %872
+%894 = OpFunctionCall %ulong %3 %892 %893
+OpStore %875 %894
+%896 = OpAccessChain %_ptr_Function__struct_861 %871 %uint_2
+%897 = OpAccessChain %_ptr_Function_ulong %896 %uint_0
+%898 = OpLoad %ulong %897
+OpStore %876 %898
+%899 = OpLoad %ulong %875
+%900 = OpLoad %ulong %876
+%901 = OpFunctionCall %ulong %23 %899 %900
+OpStore %877 %901
+%902 = OpAccessChain %_ptr_Function_ulong %896 %uint_1
+%903 = OpLoad %ulong %902
+OpStore %878 %903
+%904 = OpLoad %ulong %877
+%905 = OpLoad %ulong %878
+%906 = OpFunctionCall %ulong %23 %904 %905
+OpStore %879 %906
+%907 = OpLoad %ulong %879
+OpReturnValue %907
 OpFunctionEnd
-%22 = OpFunction %ulong None %358
-%926 = OpFunctionParameter %ulong
-%927 = OpLabel
-%1031 = OpVariable %_ptr_Function__struct_250 Function
-%1032 = OpVariable %_ptr_Function__struct_250 Function
-%1033 = OpVariable %_ptr_Function__struct_250 Function
-%1037 = OpVariable %_ptr_Function__arr__struct_161_uint_6 Function
-%1038 = OpVariable %_ptr_Function__struct_302 Function
-%1042 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
-%1043 = OpVariable %_ptr_Function__struct_250 Function
-%1044 = OpVariable %_ptr_Function__struct_161 Function
-%1045 = OpVariable %_ptr_Function__struct_99 Function
-%1046 = OpVariable %_ptr_Function__struct_250 Function
-%1047 = OpVariable %_ptr_Function__struct_99 Function
-%1048 = OpVariable %_ptr_Function__struct_301 Function
-%1049 = OpVariable %_ptr_Function__struct_302 Function
-%1050 = OpVariable %_ptr_Function__struct_250 Function
-%1051 = OpVariable %_ptr_Function__struct_99 Function
-%1052 = OpVariable %_ptr_Function__struct_250 Function
-%1053 = OpVariable %_ptr_Function__struct_99 Function
-%1054 = OpVariable %_ptr_Function__struct_250 Function
-%1055 = OpVariable %_ptr_Function__struct_99 Function
-%1056 = OpVariable %_ptr_Function__struct_250 Function
-%1057 = OpVariable %_ptr_Function__struct_99 Function
-%1058 = OpVariable %_ptr_Function__struct_250 Function
-%1059 = OpVariable %_ptr_Function__struct_250 Function
-%1060 = OpVariable %_ptr_Function__struct_99 Function
-%1061 = OpVariable %_ptr_Function__struct_302 Function
-%1062 = OpVariable %_ptr_Function__struct_99 Function
-%1063 = OpVariable %_ptr_Function__struct_301 Function
-%1064 = OpVariable %_ptr_Function_ulong Function
-%1065 = OpVariable %_ptr_Function_ulong Function
-%1067 = OpVariable %_ptr_Function_bool Function
-%1068 = OpVariable %_ptr_Function_ulong Function
-%1069 = OpVariable %_ptr_Function_bool Function
-%1070 = OpVariable %_ptr_Function_ulong Function
-%1071 = OpVariable %_ptr_Function_ulong Function
-%1072 = OpVariable %_ptr_Function_ulong Function
-%1073 = OpVariable %_ptr_Function_ulong Function
-%1074 = OpVariable %_ptr_Function_ulong Function
-%1075 = OpVariable %_ptr_Function_bool Function
-%1076 = OpVariable %_ptr_Function_ulong Function
-%1077 = OpVariable %_ptr_Function_ulong Function
-%1078 = OpVariable %_ptr_Function_ulong Function
-%1079 = OpVariable %_ptr_Function_bool Function
-%1080 = OpVariable %_ptr_Function_ulong Function
-%1081 = OpVariable %_ptr_Function_ulong Function
-%1082 = OpVariable %_ptr_Function_bool Function
-%1083 = OpVariable %_ptr_Function_ulong Function
+%9 = OpFunction %ulong None %908
+%909 = OpFunctionParameter %ulong
+%910 = OpLabel
+%911 = OpVariable %_ptr_Function_ulong Function
+%912 = OpVariable %_ptr_Function_ulong Function
+%913 = OpVariable %_ptr_Function_ulong Function
+%914 = OpVariable %_ptr_Function_ulong Function
+%915 = OpVariable %_ptr_Function_ulong Function
+%916 = OpVariable %_ptr_Function_ulong Function
+%917 = OpVariable %_ptr_Function_ulong Function
+%918 = OpVariable %_ptr_Function_ulong Function
+%919 = OpVariable %_ptr_Function_ulong Function
+%920 = OpVariable %_ptr_Function_ulong Function
+OpStore %911 %909
+%921 = OpLoad %ulong %911
+%923 = OpFunctionCall %ulong %23 %921 %ulong_20
+OpStore %912 %923
+%924 = OpLoad %ulong %912
+%926 = OpFunctionCall %ulong %23 %924 %ulong_24
+OpStore %913 %926
+%927 = OpLoad %ulong %913
+%928 = OpFunctionCall %ulong %23 %927 %ulong_24
+OpStore %914 %928
+%929 = OpLoad %ulong %914
+%931 = OpFunctionCall %ulong %23 %929 %ulong_32
+OpStore %915 %931
+%932 = OpLoad %ulong %915
+%934 = OpFunctionCall %ulong %23 %932 %ulong_40
+OpStore %916 %934
+%935 = OpLoad %ulong %916
+%937 = OpFunctionCall %ulong %23 %935 %ulong_48
+OpStore %917 %937
+%938 = OpLoad %ulong %917
+%939 = OpFunctionCall %ulong %23 %938 %ulong_48
+OpStore %918 %939
+%940 = OpLoad %ulong %918
+%941 = OpFunctionCall %ulong %23 %940 %ulong_8
+OpStore %919 %941
+%942 = OpLoad %ulong %919
+%943 = OpFunctionCall %ulong %23 %942 %ulong_32
+OpStore %920 %943
+%944 = OpLoad %ulong %920
+OpReturnValue %944
+OpFunctionEnd
+%10 = OpFunction %_struct_46 None %945
+%946 = OpFunctionParameter %ulong
+%947 = OpLabel
+%948 = OpVariable %_ptr_Function__struct_46 Function
+%949 = OpVariable %_ptr_Function_ulong Function
+%950 = OpVariable %_ptr_Function_uint Function
+%951 = OpVariable %_ptr_Function_ulong Function
+%952 = OpVariable %_ptr_Function_uint Function
+%953 = OpVariable %_ptr_Function_ulong Function
+%954 = OpVariable %_ptr_Function_uint Function
+%955 = OpVariable %_ptr_Function_ulong Function
+%956 = OpVariable %_ptr_Function_uint Function
+%957 = OpVariable %_ptr_Function_ulong Function
+%958 = OpVariable %_ptr_Function_uint Function
+OpStore %949 %946
+%959 = OpLoad %ulong %949
+%960 = OpUConvert %uint %959
+OpStore %950 %960
+%961 = OpAccessChain %_ptr_Function_uint %948 %uint_0
+%962 = OpLoad %uint %950
+OpStore %961 %962
+%963 = OpLoad %ulong %949
+%964 = OpShiftRightLogical %ulong %963 %ulong_8
+OpStore %951 %964
+%965 = OpLoad %ulong %951
+%966 = OpUConvert %uint %965
+OpStore %952 %966
+%967 = OpAccessChain %_ptr_Function_uint %948 %uint_1
+%968 = OpLoad %uint %952
+OpStore %967 %968
+%969 = OpLoad %ulong %949
+%971 = OpShiftRightLogical %ulong %969 %ulong_16
+OpStore %953 %971
+%972 = OpLoad %ulong %953
+%973 = OpUConvert %uint %972
+OpStore %954 %973
+%974 = OpAccessChain %_ptr_Function_uint %948 %uint_2
+%975 = OpLoad %uint %954
+OpStore %974 %975
+%976 = OpLoad %ulong %949
+%977 = OpShiftRightLogical %ulong %976 %ulong_24
+OpStore %955 %977
+%978 = OpLoad %ulong %955
+%979 = OpUConvert %uint %978
+OpStore %956 %979
+%980 = OpAccessChain %_ptr_Function_uint %948 %uint_3
+%981 = OpLoad %uint %956
+OpStore %980 %981
+%982 = OpLoad %ulong %949
+%983 = OpShiftRightLogical %ulong %982 %ulong_32
+OpStore %957 %983
+%984 = OpLoad %ulong %957
+%985 = OpUConvert %uint %984
+OpStore %958 %985
+%986 = OpAccessChain %_ptr_Function_uint %948 %uint_4
+%987 = OpLoad %uint %958
+OpStore %986 %987
+%988 = OpLoad %_struct_46 %948
+OpReturnValue %988
+OpFunctionEnd
+%11 = OpFunction %_struct_283 None %989
+%990 = OpFunctionParameter %ulong
+%991 = OpLabel
+%992 = OpVariable %_ptr_Function__struct_283 Function
+%993 = OpVariable %_ptr_Function_ulong Function
+%994 = OpVariable %_ptr_Function_ulong Function
+%995 = OpVariable %_ptr_Function_ulong Function
+%996 = OpVariable %_ptr_Function_ulong Function
+OpStore %993 %990
+%997 = OpAccessChain %_ptr_Function_ulong %992 %uint_0
+%998 = OpLoad %ulong %993
+OpStore %997 %998
+%999 = OpLoad %ulong %993
+%1000 = OpNot %ulong %999
+OpStore %994 %1000
+%1001 = OpAccessChain %_ptr_Function_ulong %992 %uint_1
+%1002 = OpLoad %ulong %994
+OpStore %1001 %1002
+%1003 = OpLoad %ulong %993
+%1005 = OpIMul %ulong %1003 %ulong_3
+OpStore %995 %1005
+%1006 = OpLoad %ulong %995
+%1007 = OpIAdd %ulong %1006 %ulong_1
+OpStore %996 %1007
+%1008 = OpAccessChain %_ptr_Function_ulong %992 %uint_2
+%1009 = OpLoad %ulong %996
+OpStore %1008 %1009
+%1010 = OpLoad %_struct_283 %992
+OpReturnValue %1010
+OpFunctionEnd
+%12 = OpFunction %_struct_407 None %1011
+%1012 = OpFunctionParameter %ulong
+%1013 = OpLabel
+%1014 = OpVariable %_ptr_Function__struct_407 Function
+%1015 = OpVariable %_ptr_Function_ulong Function
+%1016 = OpVariable %_ptr_Function_ulong Function
+%1017 = OpVariable %_ptr_Function_double Function
+%1018 = OpVariable %_ptr_Function_double Function
+%1019 = OpVariable %_ptr_Function_ulong Function
+%1020 = OpVariable %_ptr_Function_double Function
+%1021 = OpVariable %_ptr_Function_double Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_double Function
+%1024 = OpVariable %_ptr_Function_double Function
+OpStore %1015 %1012
+%1025 = OpLoad %ulong %1015
+%1027 = OpBitwiseAnd %ulong %1025 %ulong_65535
+OpStore %1016 %1027
+%1028 = OpLoad %ulong %1016
+%1029 = OpConvertUToF %double %1028
+OpStore %1017 %1029
+%1030 = OpLoad %double %1017
+%1032 = OpFDiv %double %1030 %double_8
+OpStore %1018 %1032
+%1033 = OpAccessChain %_ptr_Function_double %1014 %uint_0
+%1034 = OpLoad %double %1018
+OpStore %1033 %1034
+%1035 = OpLoad %ulong %1015
+%1037 = OpBitwiseAnd %ulong %1035 %ulong_4095
+OpStore %1019 %1037
+%1038 = OpLoad %ulong %1019
+%1039 = OpConvertUToF %double %1038
+OpStore %1020 %1039
+%1040 = OpLoad %double %1020
+%1042 = OpFSub %double %1040 %double_2048
+OpStore %1021 %1042
+%1043 = OpAccessChain %_ptr_Function_double %1014 %uint_1
+%1044 = OpLoad %double %1021
+OpStore %1043 %1044
+%1045 = OpLoad %ulong %1015
+%1047 = OpBitwiseAnd %ulong %1045 %ulong_262143
+OpStore %1022 %1047
+%1048 = OpLoad %ulong %1022
+%1049 = OpConvertUToF %double %1048
+OpStore %1023 %1049
+%1050 = OpLoad %double %1023
+%1052 = OpFDiv %double %1050 %double_64
+OpStore %1024 %1052
+%1053 = OpAccessChain %_ptr_Function_double %1014 %uint_2
+%1054 = OpLoad %double %1024
+OpStore %1053 %1054
+%1055 = OpLoad %_struct_407 %1014
+OpReturnValue %1055
+OpFunctionEnd
+%13 = OpFunction %_struct_546 None %1056
+%1057 = OpFunctionParameter %ulong
+%1058 = OpLabel
+%1059 = OpVariable %_ptr_Function__struct_546 Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_ulong Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_ulong Function
+OpStore %1060 %1057
+%1064 = OpAccessChain %_ptr_Function_ulong %1059 %uint_0
+%1065 = OpLoad %ulong %1060
+OpStore %1064 %1065
+%1066 = OpLoad %ulong %1060
+%1067 = OpIAdd %ulong %1066 %ulong_1
+OpStore %1061 %1067
+%1068 = OpAccessChain %_ptr_Function_ulong %1059 %uint_1
+%1069 = OpLoad %ulong %1061
+OpStore %1068 %1069
+%1070 = OpLoad %ulong %1060
+%1072 = OpIMul %ulong %1070 %ulong_5
+OpStore %1062 %1072
+%1073 = OpAccessChain %_ptr_Function_ulong %1059 %uint_2
+%1074 = OpLoad %ulong %1062
+OpStore %1073 %1074
+%1075 = OpLoad %ulong %1060
+%1076 = OpNot %ulong %1075
+OpStore %1063 %1076
+%1077 = OpAccessChain %_ptr_Function_ulong %1059 %uint_3
+%1078 = OpLoad %ulong %1063
+OpStore %1077 %1078
+%1079 = OpLoad %_struct_546 %1059
+OpReturnValue %1079
+OpFunctionEnd
+%14 = OpFunction %_struct_707 None %1080
+%1081 = OpFunctionParameter %ulong
+%1082 = OpLabel
+%1083 = OpVariable %_ptr_Function__struct_707 Function
 %1084 = OpVariable %_ptr_Function_ulong Function
 %1085 = OpVariable %_ptr_Function_ulong Function
-%1086 = OpVariable %_ptr_Function_bool Function
-%1087 = OpVariable %_ptr_Function_ulong Function
-%1088 = OpVariable %_ptr_Function_ulong Function
+%1086 = OpVariable %_ptr_Function_double Function
+%1087 = OpVariable %_ptr_Function_double Function
+%1088 = OpVariable %_ptr_Function_uint Function
 %1089 = OpVariable %_ptr_Function_ulong Function
-%1090 = OpVariable %_ptr_Function_ulong Function
+%1090 = OpVariable %_ptr_Function_uint Function
 %1091 = OpVariable %_ptr_Function_ulong Function
-%1092 = OpVariable %_ptr_Function_ulong Function
-%1093 = OpVariable %_ptr_Function_bool Function
+%1092 = OpVariable %_ptr_Function_double Function
+%1093 = OpVariable %_ptr_Function_double Function
 %1094 = OpVariable %_ptr_Function_ulong Function
-%1095 = OpVariable %_ptr_Function_ulong Function
-%1096 = OpVariable %_ptr_Function_ulong Function
-%1097 = OpVariable %_ptr_Function_ulong Function
-%1098 = OpVariable %_ptr_Function_ulong Function
-%1099 = OpVariable %_ptr_Function_ulong Function
-%1100 = OpVariable %_ptr_Function_ulong Function
-%1101 = OpVariable %_ptr_Function_ulong Function
-%1102 = OpVariable %_ptr_Function_ulong Function
-%1103 = OpVariable %_ptr_Function_ulong Function
-%1104 = OpVariable %_ptr_Function_ulong Function
-%1105 = OpVariable %_ptr_Function_ulong Function
-%1106 = OpVariable %_ptr_Function_ulong Function
-%1107 = OpVariable %_ptr_Function_ulong Function
-%1108 = OpVariable %_ptr_Function_ulong Function
-%1109 = OpVariable %_ptr_Function_ulong Function
-%1110 = OpVariable %_ptr_Function_ulong Function
-%1111 = OpVariable %_ptr_Function_ulong Function
-%1112 = OpVariable %_ptr_Function_ulong Function
-%1113 = OpVariable %_ptr_Function_ulong Function
-%1114 = OpVariable %_ptr_Function_ulong Function
-%1115 = OpVariable %_ptr_Function_ulong Function
-%1116 = OpVariable %_ptr_Function_ulong Function
-%1117 = OpVariable %_ptr_Function_ulong Function
-%1118 = OpVariable %_ptr_Function_ulong Function
-%1119 = OpVariable %_ptr_Function_ulong Function
-%1120 = OpVariable %_ptr_Function_ulong Function
-%1121 = OpVariable %_ptr_Function_ulong Function
-%1122 = OpVariable %_ptr_Function_uint Function
-%1123 = OpVariable %_ptr_Function_ulong Function
-%1124 = OpVariable %_ptr_Function_uint Function
-%1125 = OpVariable %_ptr_Function_ulong Function
-%1126 = OpVariable %_ptr_Function_uint Function
-%1127 = OpVariable %_ptr_Function_ulong Function
-%1128 = OpVariable %_ptr_Function_uint Function
-%1129 = OpVariable %_ptr_Function_ulong Function
-%1130 = OpVariable %_ptr_Function_uint Function
-%1131 = OpVariable %_ptr_Function_ulong Function
-%1132 = OpVariable %_ptr_Function_ulong Function
-%1133 = OpVariable %_ptr_Function_ulong Function
-%1134 = OpVariable %_ptr_Function_ulong Function
-%1135 = OpVariable %_ptr_Function_ulong Function
-%1136 = OpVariable %_ptr_Function_ulong Function
+OpStore %1084 %1081
+%1095 = OpAccessChain %_ptr_Function_ulong %1083 %uint_0
+%1096 = OpLoad %ulong %1084
+OpStore %1095 %1096
+%1097 = OpLoad %ulong %1084
+%1099 = OpBitwiseAnd %ulong %1097 %ulong_8191
+OpStore %1085 %1099
+%1100 = OpLoad %ulong %1085
+%1101 = OpConvertUToF %double %1100
+OpStore %1086 %1101
+%1102 = OpLoad %double %1086
+%1104 = OpFDiv %double %1102 %double_2
+OpStore %1087 %1104
+%1105 = OpAccessChain %_ptr_Function_double %1083 %uint_1
+%1106 = OpLoad %double %1087
+OpStore %1105 %1106
+%1107 = OpLoad %ulong %1084
+%1108 = OpUConvert %uint %1107
+OpStore %1088 %1108
+%1109 = OpAccessChain %_ptr_Function_uint %1083 %uint_2
+%1110 = OpLoad %uint %1088
+OpStore %1109 %1110
+%1111 = OpLoad %ulong %1084
+%1112 = OpShiftRightLogical %ulong %1111 %ulong_16
+OpStore %1089 %1112
+%1113 = OpLoad %ulong %1089
+%1114 = OpUConvert %uint %1113
+OpStore %1090 %1114
+%1115 = OpAccessChain %_ptr_Function_uint %1083 %uint_3
+%1116 = OpLoad %uint %1090
+OpStore %1115 %1116
+%1117 = OpLoad %ulong %1084
+%1119 = OpBitwiseAnd %ulong %1117 %ulong_131071
+OpStore %1091 %1119
+%1120 = OpLoad %ulong %1091
+%1121 = OpConvertUToF %double %1120
+OpStore %1092 %1121
+%1122 = OpLoad %double %1092
+%1124 = OpFDiv %double %1122 %double_32
+OpStore %1093 %1124
+%1125 = OpAccessChain %_ptr_Function_double %1083 %uint_4
+%1126 = OpLoad %double %1093
+OpStore %1125 %1126
+%1127 = OpLoad %ulong %1084
+%1129 = OpIMul %ulong %1127 %ulong_7
+OpStore %1094 %1129
+%1130 = OpAccessChain %_ptr_Function_ulong %1083 %uint_5
+%1131 = OpLoad %ulong %1094
+OpStore %1130 %1131
+%1132 = OpLoad %_struct_707 %1083
+OpReturnValue %1132
+OpFunctionEnd
+%15 = OpFunction %_struct_810 None %1133
+%1134 = OpFunctionParameter %ulong
+%1135 = OpLabel
+%1136 = OpVariable %_ptr_Function__struct_810 Function
 %1137 = OpVariable %_ptr_Function_ulong Function
 %1138 = OpVariable %_ptr_Function_ulong Function
 %1139 = OpVariable %_ptr_Function_ulong Function
 %1140 = OpVariable %_ptr_Function_ulong Function
 %1141 = OpVariable %_ptr_Function_ulong Function
 %1142 = OpVariable %_ptr_Function_ulong Function
-%1143 = OpVariable %_ptr_Function_ulong Function
-%1144 = OpVariable %_ptr_Function_ulong Function
-%1145 = OpVariable %_ptr_Function_ulong Function
-%1146 = OpVariable %_ptr_Function_ulong Function
-%1147 = OpVariable %_ptr_Function_ulong Function
-%1148 = OpVariable %_ptr_Function_ulong Function
-%1149 = OpVariable %_ptr_Function_ulong Function
-%1150 = OpVariable %_ptr_Function_ulong Function
-%1151 = OpVariable %_ptr_Function_ulong Function
-%1152 = OpVariable %_ptr_Function_ulong Function
-%1153 = OpVariable %_ptr_Function_ulong Function
-%1154 = OpVariable %_ptr_Function_ulong Function
-%1155 = OpVariable %_ptr_Function_ulong Function
-%1156 = OpVariable %_ptr_Function_ulong Function
-%1157 = OpVariable %_ptr_Function_ulong Function
-%1158 = OpVariable %_ptr_Function_ulong Function
-%1159 = OpVariable %_ptr_Function_ulong Function
-%1160 = OpVariable %_ptr_Function_ulong Function
-%1161 = OpVariable %_ptr_Function_ulong Function
-%1162 = OpVariable %_ptr_Function_ulong Function
-%1163 = OpVariable %_ptr_Function_ulong Function
-%1164 = OpVariable %_ptr_Function_ulong Function
-%1165 = OpVariable %_ptr_Function_ulong Function
-%1166 = OpVariable %_ptr_Function_ulong Function
-%1167 = OpVariable %_ptr_Function_ulong Function
-%1168 = OpVariable %_ptr_Function_ulong Function
-%1169 = OpVariable %_ptr_Function_ulong Function
-%1170 = OpVariable %_ptr_Function_ulong Function
-%1171 = OpVariable %_ptr_Function_ulong Function
-%1172 = OpVariable %_ptr_Function_ulong Function
-%1173 = OpVariable %_ptr_Function_ulong Function
-%1174 = OpVariable %_ptr_Function_ulong Function
+OpStore %1137 %1134
+%1143 = OpAccessChain %_ptr_Function_ulong %1136 %uint_0
+%1144 = OpLoad %ulong %1137
+OpStore %1143 %1144
+%1145 = OpLoad %ulong %1137
+%1146 = OpIAdd %ulong %1145 %ulong_1
+OpStore %1138 %1146
+%1147 = OpAccessChain %_ptr_Function_ulong %1136 %uint_1
+%1148 = OpLoad %ulong %1138
+OpStore %1147 %1148
+%1149 = OpLoad %ulong %1137
+%1151 = OpIAdd %ulong %1149 %ulong_2
+OpStore %1139 %1151
+%1152 = OpAccessChain %_ptr_Function_ulong %1136 %uint_2
+%1153 = OpLoad %ulong %1139
+OpStore %1152 %1153
+%1154 = OpLoad %ulong %1137
+%1156 = OpIMul %ulong %1154 %ulong_9
+OpStore %1140 %1156
+%1157 = OpAccessChain %_ptr_Function_ulong %1136 %uint_3
+%1158 = OpLoad %ulong %1140
+OpStore %1157 %1158
+%1159 = OpLoad %ulong %1137
+%1160 = OpNot %ulong %1159
+OpStore %1141 %1160
+%1161 = OpAccessChain %_ptr_Function_ulong %1136 %uint_4
+%1162 = OpLoad %ulong %1141
+OpStore %1161 %1162
+%1163 = OpLoad %ulong %1137
+%1165 = OpBitwiseXor %ulong %1163 %ulong_2863311530
+OpStore %1142 %1165
+%1166 = OpAccessChain %_ptr_Function_ulong %1136 %uint_5
+%1167 = OpLoad %ulong %1142
+OpStore %1166 %1167
+%1168 = OpLoad %_struct_810 %1136
+OpReturnValue %1168
+OpFunctionEnd
+%16 = OpFunction %_struct_283 None %1169
+%1170 = OpFunctionParameter %_struct_283
+%1171 = OpFunctionParameter %ulong
+%1172 = OpLabel
+%1173 = OpVariable %_ptr_Function__struct_283 Function
+%1174 = OpVariable %_ptr_Function__struct_283 Function
 %1175 = OpVariable %_ptr_Function_ulong Function
 %1176 = OpVariable %_ptr_Function_ulong Function
 %1177 = OpVariable %_ptr_Function_ulong Function
@@ -1430,34 +1728,47 @@ OpFunctionEnd
 %1179 = OpVariable %_ptr_Function_ulong Function
 %1180 = OpVariable %_ptr_Function_ulong Function
 %1181 = OpVariable %_ptr_Function_ulong Function
-%1182 = OpVariable %_ptr_Function_ulong Function
-%1183 = OpVariable %_ptr_Function_ulong Function
-%1184 = OpVariable %_ptr_Function_ulong Function
-%1185 = OpVariable %_ptr_Function_ulong Function
-%1186 = OpVariable %_ptr_Function_ulong Function
-%1187 = OpVariable %_ptr_Function_ulong Function
-%1188 = OpVariable %_ptr_Function_ulong Function
-%1189 = OpVariable %_ptr_Function_ulong Function
-%1190 = OpVariable %_ptr_Function_ulong Function
-%1191 = OpVariable %_ptr_Function_ulong Function
-%1192 = OpVariable %_ptr_Function_ulong Function
-%1193 = OpVariable %_ptr_Function_ulong Function
-%1194 = OpVariable %_ptr_Function_ulong Function
-%1195 = OpVariable %_ptr_Function_ulong Function
-%1196 = OpVariable %_ptr_Function_ulong Function
-%1197 = OpVariable %_ptr_Function_ulong Function
-%1198 = OpVariable %_ptr_Function_ulong Function
-%1199 = OpVariable %_ptr_Function_ulong Function
-%1200 = OpVariable %_ptr_Function_double Function
-%1201 = OpVariable %_ptr_Function_double Function
-%1202 = OpVariable %_ptr_Function_ulong Function
-%1203 = OpVariable %_ptr_Function_double Function
-%1204 = OpVariable %_ptr_Function_double Function
-%1205 = OpVariable %_ptr_Function_ulong Function
-%1206 = OpVariable %_ptr_Function_double Function
-%1207 = OpVariable %_ptr_Function_double Function
-%1208 = OpVariable %_ptr_Function_ulong Function
-%1209 = OpVariable %_ptr_Function_ulong Function
+OpStore %1173 %1170
+OpStore %1175 %1171
+%1182 = OpAccessChain %_ptr_Function_ulong %1173 %uint_0
+%1183 = OpLoad %ulong %1182
+OpStore %1179 %1183
+%1184 = OpAccessChain %_ptr_Function_ulong %1173 %uint_1
+%1185 = OpLoad %ulong %1184
+OpStore %1180 %1185
+%1186 = OpAccessChain %_ptr_Function_ulong %1173 %uint_2
+%1187 = OpLoad %ulong %1186
+OpStore %1181 %1187
+%1188 = OpLoad %ulong %1179
+%1189 = OpLoad %ulong %1175
+%1190 = OpIAdd %ulong %1188 %1189
+OpStore %1176 %1190
+%1191 = OpAccessChain %_ptr_Function_ulong %1174 %uint_0
+%1192 = OpLoad %ulong %1176
+OpStore %1191 %1192
+%1193 = OpLoad %ulong %1180
+%1194 = OpLoad %ulong %1175
+%1195 = OpBitwiseXor %ulong %1193 %1194
+OpStore %1177 %1195
+%1196 = OpAccessChain %_ptr_Function_ulong %1174 %uint_1
+%1197 = OpLoad %ulong %1177
+OpStore %1196 %1197
+%1198 = OpLoad %ulong %1181
+%1199 = OpLoad %ulong %1179
+%1200 = OpIAdd %ulong %1198 %1199
+OpStore %1178 %1200
+%1201 = OpAccessChain %_ptr_Function_ulong %1174 %uint_2
+%1202 = OpLoad %ulong %1178
+OpStore %1201 %1202
+%1203 = OpLoad %_struct_283 %1174
+OpReturnValue %1203
+OpFunctionEnd
+%17 = OpFunction %_struct_810 None %1204
+%1205 = OpFunctionParameter %_struct_810
+%1206 = OpFunctionParameter %ulong
+%1207 = OpLabel
+%1208 = OpVariable %_ptr_Function__struct_810 Function
+%1209 = OpVariable %_ptr_Function__struct_810 Function
 %1210 = OpVariable %_ptr_Function_ulong Function
 %1211 = OpVariable %_ptr_Function_ulong Function
 %1212 = OpVariable %_ptr_Function_ulong Function
@@ -1471,1524 +1782,2443 @@ OpFunctionEnd
 %1220 = OpVariable %_ptr_Function_ulong Function
 %1221 = OpVariable %_ptr_Function_ulong Function
 %1222 = OpVariable %_ptr_Function_ulong Function
-%1223 = OpVariable %_ptr_Function_ulong Function
-%1224 = OpVariable %_ptr_Function_ulong Function
-%1225 = OpVariable %_ptr_Function_ulong Function
-%1226 = OpVariable %_ptr_Function_ulong Function
-%1227 = OpVariable %_ptr_Function_ulong Function
-%1228 = OpVariable %_ptr_Function_ulong Function
-%1229 = OpVariable %_ptr_Function_ulong Function
-%1230 = OpVariable %_ptr_Function_ulong Function
-%1231 = OpVariable %_ptr_Function_ulong Function
-%1232 = OpVariable %_ptr_Function_ulong Function
-%1233 = OpVariable %_ptr_Function_ulong Function
-%1234 = OpVariable %_ptr_Function_ulong Function
-%1235 = OpVariable %_ptr_Function_ulong Function
-%1236 = OpVariable %_ptr_Function_double Function
-%1237 = OpVariable %_ptr_Function_double Function
-%1238 = OpVariable %_ptr_Function_uint Function
-%1239 = OpVariable %_ptr_Function_ulong Function
-%1240 = OpVariable %_ptr_Function_uint Function
-%1241 = OpVariable %_ptr_Function_ulong Function
-%1242 = OpVariable %_ptr_Function_double Function
-%1243 = OpVariable %_ptr_Function_double Function
-%1244 = OpVariable %_ptr_Function_ulong Function
-%1245 = OpVariable %_ptr_Function_ulong Function
-%1246 = OpVariable %_ptr_Function_ulong Function
-%1247 = OpVariable %_ptr_Function_ulong Function
-%1248 = OpVariable %_ptr_Function_ulong Function
-%1249 = OpVariable %_ptr_Function_ulong Function
-%1250 = OpVariable %_ptr_Function_ulong Function
-%1251 = OpVariable %_ptr_Function_ulong Function
-%1252 = OpVariable %_ptr_Function_ulong Function
-%1253 = OpVariable %_ptr_Function_ulong Function
-%1254 = OpVariable %_ptr_Function_ulong Function
-%1255 = OpVariable %_ptr_Function_ulong Function
-%1256 = OpVariable %_ptr_Function_ulong Function
-%1257 = OpVariable %_ptr_Function_ulong Function
-%1258 = OpVariable %_ptr_Function_ulong Function
-%1259 = OpVariable %_ptr_Function_ulong Function
-%1260 = OpVariable %_ptr_Function_ulong Function
-%1261 = OpVariable %_ptr_Function_ulong Function
-%1262 = OpVariable %_ptr_Function_ulong Function
-%1263 = OpVariable %_ptr_Function_ulong Function
-%1264 = OpVariable %_ptr_Function_ulong Function
-%1265 = OpVariable %_ptr_Function_ulong Function
-%1266 = OpVariable %_ptr_Function_ulong Function
-%1267 = OpVariable %_ptr_Function_ulong Function
-%1268 = OpVariable %_ptr_Function_uint Function
-%1269 = OpVariable %_ptr_Function_ulong Function
-%1270 = OpVariable %_ptr_Function_ulong Function
+OpStore %1208 %1205
+OpStore %1210 %1206
+%1223 = OpAccessChain %_ptr_Function_ulong %1208 %uint_0
+%1224 = OpLoad %ulong %1223
+OpStore %1217 %1224
+%1225 = OpAccessChain %_ptr_Function_ulong %1208 %uint_1
+%1226 = OpLoad %ulong %1225
+OpStore %1218 %1226
+%1227 = OpAccessChain %_ptr_Function_ulong %1208 %uint_2
+%1228 = OpLoad %ulong %1227
+OpStore %1219 %1228
+%1229 = OpAccessChain %_ptr_Function_ulong %1208 %uint_3
+%1230 = OpLoad %ulong %1229
+OpStore %1220 %1230
+%1231 = OpAccessChain %_ptr_Function_ulong %1208 %uint_4
+%1232 = OpLoad %ulong %1231
+OpStore %1221 %1232
+%1233 = OpAccessChain %_ptr_Function_ulong %1208 %uint_5
+%1234 = OpLoad %ulong %1233
+OpStore %1222 %1234
+%1235 = OpLoad %ulong %1217
+%1236 = OpLoad %ulong %1210
+%1237 = OpIAdd %ulong %1235 %1236
+OpStore %1211 %1237
+%1238 = OpAccessChain %_ptr_Function_ulong %1209 %uint_0
+%1239 = OpLoad %ulong %1211
+OpStore %1238 %1239
+%1240 = OpLoad %ulong %1218
+%1241 = OpLoad %ulong %1210
+%1242 = OpBitwiseXor %ulong %1240 %1241
+OpStore %1212 %1242
+%1243 = OpAccessChain %_ptr_Function_ulong %1209 %uint_1
+%1244 = OpLoad %ulong %1212
+OpStore %1243 %1244
+%1245 = OpLoad %ulong %1219
+%1246 = OpLoad %ulong %1217
+%1247 = OpIAdd %ulong %1245 %1246
+OpStore %1213 %1247
+%1248 = OpAccessChain %_ptr_Function_ulong %1209 %uint_2
+%1249 = OpLoad %ulong %1213
+OpStore %1248 %1249
+%1250 = OpLoad %ulong %1220
+%1251 = OpLoad %ulong %1218
+%1252 = OpIAdd %ulong %1250 %1251
+OpStore %1214 %1252
+%1253 = OpAccessChain %_ptr_Function_ulong %1209 %uint_3
+%1254 = OpLoad %ulong %1214
+OpStore %1253 %1254
+%1255 = OpLoad %ulong %1221
+%1256 = OpLoad %ulong %1219
+%1257 = OpBitwiseXor %ulong %1255 %1256
+OpStore %1215 %1257
+%1258 = OpAccessChain %_ptr_Function_ulong %1209 %uint_4
+%1259 = OpLoad %ulong %1215
+OpStore %1258 %1259
+%1260 = OpLoad %ulong %1222
+%1261 = OpLoad %ulong %1210
+%1262 = OpIAdd %ulong %1260 %1261
+OpStore %1216 %1262
+%1263 = OpAccessChain %_ptr_Function_ulong %1209 %uint_5
+%1264 = OpLoad %ulong %1216
+OpStore %1263 %1264
+%1265 = OpLoad %_struct_810 %1209
+OpReturnValue %1265
+OpFunctionEnd
+%18 = OpFunction %_struct_810 None %1266
+%1267 = OpFunctionParameter %_struct_283
+%1268 = OpLabel
+%1269 = OpVariable %_ptr_Function__struct_283 Function
+%1270 = OpVariable %_ptr_Function__struct_810 Function
 %1271 = OpVariable %_ptr_Function_ulong Function
 %1272 = OpVariable %_ptr_Function_ulong Function
 %1273 = OpVariable %_ptr_Function_ulong Function
 %1274 = OpVariable %_ptr_Function_ulong Function
 %1275 = OpVariable %_ptr_Function_ulong Function
 %1276 = OpVariable %_ptr_Function_ulong Function
-%1277 = OpVariable %_ptr_Function_ulong Function
-%1278 = OpVariable %_ptr_Function_ulong Function
-%1279 = OpVariable %_ptr_Function_ulong Function
-%1280 = OpVariable %_ptr_Function_ulong Function
-%1281 = OpVariable %_ptr_Function_ulong Function
-%1282 = OpVariable %_ptr_Function_ulong Function
-%1283 = OpVariable %_ptr_Function_ulong Function
-%1284 = OpVariable %_ptr_Function_ulong Function
-%1285 = OpVariable %_ptr_Function_ulong Function
-%1286 = OpVariable %_ptr_Function_ulong Function
-%1287 = OpVariable %_ptr_Function_ulong Function
-%1288 = OpVariable %_ptr_Function_ulong Function
-%1289 = OpVariable %_ptr_Function_ulong Function
-%1290 = OpVariable %_ptr_Function_ulong Function
-%1291 = OpVariable %_ptr_Function_ulong Function
-%1292 = OpVariable %_ptr_Function_ulong Function
-%1293 = OpVariable %_ptr_Function_ulong Function
-%1294 = OpVariable %_ptr_Function_ulong Function
-%1295 = OpVariable %_ptr_Function_ulong Function
-%1296 = OpVariable %_ptr_Function_ulong Function
-%1297 = OpVariable %_ptr_Function_ulong Function
-%1298 = OpVariable %_ptr_Function_ulong Function
-%1299 = OpVariable %_ptr_Function_ulong Function
-%1300 = OpVariable %_ptr_Function_ulong Function
-%1301 = OpVariable %_ptr_Function_ulong Function
-%1302 = OpVariable %_ptr_Function_ulong Function
-%1303 = OpVariable %_ptr_Function_ulong Function
-%1304 = OpVariable %_ptr_Function_ulong Function
-%1305 = OpVariable %_ptr_Function_ulong Function
-%1306 = OpVariable %_ptr_Function_ulong Function
-%1307 = OpVariable %_ptr_Function_ulong Function
-OpStore %1064 %926
-%1308 = OpFunctionCall %ulong %23
-OpStore %1065 %1308
-OpBranch %949
-%949 = OpLabel
-%1309 = OpLoad %ulong %1065
-%1310 = OpFunctionCall %ulong %24 %1309 %ulong_20
-OpStore %1110 %1310
-%1311 = OpLoad %ulong %1110
-%1312 = OpFunctionCall %ulong %24 %1311 %ulong_24
-OpStore %1111 %1312
-%1313 = OpLoad %ulong %1111
-%1314 = OpFunctionCall %ulong %24 %1313 %ulong_24
-OpStore %1112 %1314
-%1315 = OpLoad %ulong %1112
-%1316 = OpFunctionCall %ulong %24 %1315 %ulong_32
-OpStore %1113 %1316
-%1317 = OpLoad %ulong %1113
-%1318 = OpFunctionCall %ulong %24 %1317 %ulong_40
-OpStore %1114 %1318
-%1319 = OpLoad %ulong %1114
-%1320 = OpFunctionCall %ulong %24 %1319 %ulong_48
-OpStore %1115 %1320
-%1321 = OpLoad %ulong %1115
-%1322 = OpFunctionCall %ulong %24 %1321 %ulong_48
-OpStore %1116 %1322
-%1323 = OpLoad %ulong %1116
-%1324 = OpFunctionCall %ulong %24 %1323 %ulong_8
-OpStore %1117 %1324
-%1325 = OpLoad %ulong %1117
-%1326 = OpFunctionCall %ulong %24 %1325 %ulong_32
-OpStore %1118 %1326
-OpBranch %950
-%950 = OpLabel
-OpStore %1042 %1327
-OpStore %1103 %ulong_0
-OpBranch %928
-%928 = OpLabel
-%1329 = OpLoad %ulong %1103
-%1330 = OpULessThan %bool %1329 %ulong_8
-OpStore %1067 %1330
-%1331 = OpLoad %bool %1067
-OpLoopMerge %930 %1029 None
-OpBranchConditional %1331 %929 %930
-%930 = OpLabel
-%1332 = OpLoad %ulong %1118
-OpStore %1102 %1332
-OpStore %1109 %ulong_0
-OpBranch %931
-%931 = OpLabel
-%1333 = OpLoad %ulong %1109
-%1334 = OpULessThan %bool %1333 %ulong_8
-OpStore %1069 %1334
-%1335 = OpLoad %bool %1069
-OpLoopMerge %933 %1028 None
-OpBranchConditional %1335 %932 %933
-%933 = OpLabel
-%1336 = OpLoad %ulong %1064
-%1337 = OpIAdd %ulong %1336 %ulong_1
-OpStore %1074 %1337
-OpBranch %955
-%955 = OpLabel
-%1338 = OpLoad %ulong %1074
-%1339 = OpNot %ulong %1338
-OpStore %1131 %1339
-%1340 = OpLoad %ulong %1074
-%1341 = OpIMul %ulong %1340 %ulong_3
-OpStore %1132 %1341
-%1342 = OpLoad %ulong %1132
-%1343 = OpIAdd %ulong %1342 %ulong_1
-OpStore %1133 %1343
-OpBranch %956
-%956 = OpLabel
-%1344 = OpLoad %ulong %1102
-OpStore %1101 %1344
-OpStore %1108 %ulong_0
-%1345 = OpLoad %ulong %1074
-OpStore %1305 %1345
-%1346 = OpLoad %ulong %1131
-OpStore %1306 %1346
-%1347 = OpLoad %ulong %1133
-OpStore %1307 %1347
-OpBranch %934
-%934 = OpLabel
-%1348 = OpLoad %ulong %1108
-%1349 = OpULessThan %bool %1348 %ulong_8
-OpStore %1075 %1349
-%1350 = OpLoad %bool %1075
-OpLoopMerge %936 %1027 None
-OpBranchConditional %1350 %935 %936
-%936 = OpLabel
-%1351 = OpLoad %ulong %1064
-%1352 = OpIAdd %ulong %1351 %ulong_2
-OpStore %1078 %1352
-OpBranch %959
-%959 = OpLabel
-%1353 = OpAccessChain %_ptr_Function_ulong %1043 %uint_0
-%1354 = OpLoad %ulong %1078
-OpStore %1353 %1354
-%1355 = OpLoad %ulong %1078
-%1356 = OpIAdd %ulong %1355 %ulong_1
-OpStore %1137 %1356
-%1357 = OpAccessChain %_ptr_Function_ulong %1043 %uint_1
-%1358 = OpLoad %ulong %1137
-OpStore %1357 %1358
-%1359 = OpLoad %ulong %1078
-%1360 = OpIAdd %ulong %1359 %ulong_2
-OpStore %1138 %1360
-%1361 = OpAccessChain %_ptr_Function_ulong %1043 %uint_2
-%1362 = OpLoad %ulong %1138
-OpStore %1361 %1362
-%1363 = OpLoad %ulong %1078
-%1364 = OpIMul %ulong %1363 %ulong_9
-OpStore %1139 %1364
-%1365 = OpAccessChain %_ptr_Function_ulong %1043 %uint_3
-%1366 = OpLoad %ulong %1139
-OpStore %1365 %1366
-%1367 = OpLoad %ulong %1078
-%1368 = OpNot %ulong %1367
-OpStore %1140 %1368
-%1369 = OpAccessChain %_ptr_Function_ulong %1043 %uint_4
-%1370 = OpLoad %ulong %1140
-OpStore %1369 %1370
-%1371 = OpLoad %ulong %1078
-%1372 = OpBitwiseXor %ulong %1371 %ulong_2863311530
-OpStore %1141 %1372
-%1373 = OpAccessChain %_ptr_Function_ulong %1043 %uint_5
-%1374 = OpLoad %ulong %1141
-OpStore %1373 %1374
-OpBranch %960
-%960 = OpLabel
-%1375 = OpLoad %_struct_250 %1043
-OpStore %1031 %1375
-%1376 = OpLoad %ulong %1101
-OpStore %1100 %1376
-OpStore %1107 %ulong_0
-OpBranch %937
-%937 = OpLabel
-%1377 = OpLoad %ulong %1107
-%1378 = OpULessThan %bool %1377 %ulong_8
-OpStore %1079 %1378
-%1379 = OpLoad %bool %1079
-OpLoopMerge %939 %1026 None
-OpBranchConditional %1379 %938 %939
-%939 = OpLabel
-OpStore %1037 %1380
-OpStore %1106 %ulong_0
-OpBranch %940
-%940 = OpLabel
-%1381 = OpLoad %ulong %1106
-%1383 = OpULessThan %bool %1381 %ulong_6
-OpStore %1082 %1383
-%1384 = OpLoad %bool %1082
-OpLoopMerge %942 %1025 None
-OpBranchConditional %1384 %941 %942
-%942 = OpLabel
-%1385 = OpLoad %ulong %1100
-OpStore %1099 %1385
-OpStore %1105 %ulong_0
-OpBranch %943
-%943 = OpLabel
-%1386 = OpLoad %ulong %1105
-%1387 = OpULessThan %bool %1386 %ulong_6
-OpStore %1086 %1387
-%1388 = OpLoad %bool %1086
-OpLoopMerge %945 %1024 None
-OpBranchConditional %1388 %944 %945
-%945 = OpLabel
-OpStore %1038 %1389
-%1390 = OpAccessChain %_ptr_Function_uint %1038 %uint_0
-OpStore %1390 %uint_305419896
-%1392 = OpLoad %ulong %1064
-%1393 = OpIAdd %ulong %1392 %ulong_3
-OpStore %1088 %1393
-OpBranch %967
-%967 = OpLabel
-%1394 = OpLoad %ulong %1088
-%1395 = OpNot %ulong %1394
-OpStore %1155 %1395
-%1396 = OpLoad %ulong %1088
-%1397 = OpIMul %ulong %1396 %ulong_3
-OpStore %1156 %1397
-%1398 = OpLoad %ulong %1156
-%1399 = OpIAdd %ulong %1398 %ulong_1
-OpStore %1157 %1399
-OpBranch %968
-%968 = OpLabel
-%1400 = OpAccessChain %_ptr_Function_ulong %1042 %uint_0
-%1401 = OpLoad %ulong %1400
-OpStore %1089 %1401
-OpBranch %975
-%975 = OpLabel
-%1402 = OpLoad %ulong %1088
-%1403 = OpLoad %ulong %1089
-%1404 = OpIAdd %ulong %1402 %1403
-OpStore %1169 %1404
-%1405 = OpAccessChain %_ptr_Function_ulong %1047 %uint_0
-%1406 = OpLoad %ulong %1169
-OpStore %1405 %1406
-%1407 = OpLoad %ulong %1155
-%1408 = OpLoad %ulong %1089
-%1409 = OpBitwiseXor %ulong %1407 %1408
-OpStore %1170 %1409
-%1410 = OpAccessChain %_ptr_Function_ulong %1047 %uint_1
-%1411 = OpLoad %ulong %1170
-OpStore %1410 %1411
-%1412 = OpLoad %ulong %1157
-%1413 = OpLoad %ulong %1088
-%1414 = OpIAdd %ulong %1412 %1413
-OpStore %1171 %1414
-%1415 = OpAccessChain %_ptr_Function_ulong %1047 %uint_2
-%1416 = OpLoad %ulong %1171
-OpStore %1415 %1416
-OpBranch %976
-%976 = OpLabel
-%1417 = OpAccessChain %_ptr_Function__struct_99 %1038 %uint_1
-%1418 = OpLoad %_struct_99 %1047
-OpStore %1417 %1418
-%1419 = OpAccessChain %_ptr_Function_ulong %1042 %uint_1
-%1420 = OpLoad %ulong %1419
-OpStore %1090 %1420
-%1421 = OpAccessChain %_ptr_Function_ulong %1048 %uint_0
-%1422 = OpLoad %ulong %1090
-OpStore %1421 %1422
-%1423 = OpAccessChain %_ptr_Function_ulong %1042 %uint_2
-%1424 = OpLoad %ulong %1423
-OpStore %1091 %1424
-%1425 = OpAccessChain %_ptr_Function_ulong %1048 %uint_1
-%1426 = OpLoad %ulong %1091
-OpStore %1425 %1426
-%1427 = OpAccessChain %_ptr_Function__struct_301 %1038 %uint_2
-%1428 = OpLoad %_struct_301 %1048
-OpStore %1427 %1428
-%1429 = OpLoad %_struct_302 %1038
-OpStore %1049 %1429
-%1430 = OpLoad %ulong %1099
-%1431 = OpLoad %_struct_302 %1049
-%1432 = OpFunctionCall %ulong %8 %1430 %1431
-OpStore %1092 %1432
-%1433 = OpLoad %ulong %1092
-OpStore %1098 %1433
-OpStore %1104 %ulong_0
-OpBranch %946
-%946 = OpLabel
-%1434 = OpLoad %ulong %1104
-%1436 = OpULessThan %bool %1434 %ulong_4
-OpStore %1093 %1436
-%1437 = OpLoad %bool %1093
-OpLoopMerge %948 %1023 None
-OpBranchConditional %1437 %947 %948
-%948 = OpLabel
-%1438 = OpLoad %ulong %1098
-OpReturnValue %1438
-%947 = OpLabel
-%1439 = OpLoad %ulong %1104
-%1440 = OpAccessChain %_ptr_Function_ulong %1042 %1439
-%1441 = OpLoad %ulong %1440
-OpStore %1094 %1441
-%1442 = OpLoad %ulong %1094
-%1443 = OpLoad %ulong %1064
-%1444 = OpIAdd %ulong %1442 %1443
-OpStore %1095 %1444
-OpBranch %969
-%969 = OpLabel
-%1445 = OpAccessChain %_ptr_Function_ulong %1045 %uint_0
-%1446 = OpLoad %ulong %1095
-OpStore %1445 %1446
-%1447 = OpLoad %ulong %1095
-%1448 = OpNot %ulong %1447
-OpStore %1158 %1448
-%1449 = OpAccessChain %_ptr_Function_ulong %1045 %uint_1
-%1450 = OpLoad %ulong %1158
-OpStore %1449 %1450
-%1451 = OpLoad %ulong %1095
-%1452 = OpIMul %ulong %1451 %ulong_3
-OpStore %1159 %1452
-%1453 = OpLoad %ulong %1159
-%1454 = OpIAdd %ulong %1453 %ulong_1
-OpStore %1160 %1454
-%1455 = OpAccessChain %_ptr_Function_ulong %1045 %uint_2
-%1456 = OpLoad %ulong %1160
-OpStore %1455 %1456
-OpBranch %970
-%970 = OpLabel
-%1457 = OpLoad %_struct_99 %1045
-%1458 = OpFunctionCall %_struct_250 %18 %1457
-OpStore %1046 %1458
-OpBranch %977
-%977 = OpLabel
-%1459 = OpAccessChain %_ptr_Function_ulong %1050 %uint_0
-%1460 = OpLoad %ulong %1095
-OpStore %1459 %1460
-%1461 = OpLoad %ulong %1095
-%1462 = OpIAdd %ulong %1461 %ulong_1
-OpStore %1172 %1462
-%1463 = OpAccessChain %_ptr_Function_ulong %1050 %uint_1
-%1464 = OpLoad %ulong %1172
-OpStore %1463 %1464
-%1465 = OpLoad %ulong %1095
-%1466 = OpIAdd %ulong %1465 %ulong_2
-OpStore %1173 %1466
-%1467 = OpAccessChain %_ptr_Function_ulong %1050 %uint_2
-%1468 = OpLoad %ulong %1173
-OpStore %1467 %1468
-%1469 = OpLoad %ulong %1095
-%1470 = OpIMul %ulong %1469 %ulong_9
-OpStore %1174 %1470
-%1471 = OpAccessChain %_ptr_Function_ulong %1050 %uint_3
-%1472 = OpLoad %ulong %1174
-OpStore %1471 %1472
-%1473 = OpLoad %ulong %1095
-%1474 = OpNot %ulong %1473
-OpStore %1175 %1474
-%1475 = OpAccessChain %_ptr_Function_ulong %1050 %uint_4
-%1476 = OpLoad %ulong %1175
-OpStore %1475 %1476
-%1477 = OpLoad %ulong %1095
-%1478 = OpBitwiseXor %ulong %1477 %ulong_2863311530
-OpStore %1176 %1478
-%1479 = OpAccessChain %_ptr_Function_ulong %1050 %uint_5
-%1480 = OpLoad %ulong %1176
-OpStore %1479 %1480
-OpBranch %978
-%978 = OpLabel
-%1481 = OpLoad %_struct_250 %1050
-%1482 = OpFunctionCall %_struct_99 %19 %1481
-OpStore %1051 %1482
-OpBranch %981
-%981 = OpLabel
-%1483 = OpAccessChain %_ptr_Function_ulong %1046 %uint_0
-%1484 = OpLoad %ulong %1483
-OpStore %1284 %1484
-%1485 = OpAccessChain %_ptr_Function_ulong %1046 %uint_1
-%1486 = OpLoad %ulong %1485
-OpStore %1285 %1486
-%1487 = OpAccessChain %_ptr_Function_ulong %1046 %uint_2
-%1488 = OpLoad %ulong %1487
-OpStore %1286 %1488
-%1489 = OpAccessChain %_ptr_Function_ulong %1046 %uint_3
-%1490 = OpLoad %ulong %1489
-OpStore %1287 %1490
-%1491 = OpAccessChain %_ptr_Function_ulong %1046 %uint_4
-%1492 = OpLoad %ulong %1491
-OpStore %1288 %1492
-%1493 = OpAccessChain %_ptr_Function_ulong %1046 %uint_5
-%1494 = OpLoad %ulong %1493
-OpStore %1289 %1494
-%1495 = OpAccessChain %_ptr_Function_ulong %1051 %uint_0
-%1496 = OpLoad %ulong %1495
-OpStore %1290 %1496
-%1497 = OpAccessChain %_ptr_Function_ulong %1051 %uint_1
-%1498 = OpLoad %ulong %1497
-OpStore %1291 %1498
-%1499 = OpAccessChain %_ptr_Function_ulong %1051 %uint_2
-%1500 = OpLoad %ulong %1499
-OpStore %1292 %1500
-%1501 = OpFunctionCall %ulong %23
-OpStore %1180 %1501
-OpBranch %982
-%982 = OpLabel
-%1502 = OpLoad %ulong %1180
-%1503 = OpLoad %ulong %1284
-%1504 = OpFunctionCall %ulong %24 %1502 %1503
-OpStore %1182 %1504
-%1505 = OpLoad %ulong %1182
-%1506 = OpLoad %ulong %1285
-%1507 = OpFunctionCall %ulong %24 %1505 %1506
-OpStore %1183 %1507
-%1508 = OpLoad %ulong %1183
-%1509 = OpLoad %ulong %1286
-%1510 = OpFunctionCall %ulong %24 %1508 %1509
-OpStore %1184 %1510
-%1511 = OpLoad %ulong %1184
-%1512 = OpLoad %ulong %1287
-%1513 = OpFunctionCall %ulong %24 %1511 %1512
-OpStore %1185 %1513
-%1514 = OpLoad %ulong %1185
-%1515 = OpLoad %ulong %1288
-%1516 = OpFunctionCall %ulong %24 %1514 %1515
-OpStore %1186 %1516
-%1517 = OpLoad %ulong %1186
-%1518 = OpLoad %ulong %1289
-%1519 = OpFunctionCall %ulong %24 %1517 %1518
-OpStore %1187 %1519
-OpBranch %983
-%983 = OpLabel
-OpBranch %984
-%984 = OpLabel
-%1520 = OpLoad %ulong %1187
-%1521 = OpLoad %ulong %1290
-%1522 = OpFunctionCall %ulong %24 %1520 %1521
-OpStore %1188 %1522
-%1523 = OpLoad %ulong %1188
-%1524 = OpLoad %ulong %1291
-%1525 = OpFunctionCall %ulong %24 %1523 %1524
-OpStore %1189 %1525
-%1526 = OpLoad %ulong %1189
-%1527 = OpLoad %ulong %1292
-%1528 = OpFunctionCall %ulong %24 %1526 %1527
-OpStore %1190 %1528
-OpBranch %985
-%985 = OpLabel
-%1529 = OpLoad %ulong %1190
-%1530 = OpLoad %ulong %1095
-%1531 = OpFunctionCall %ulong %24 %1529 %1530
-OpStore %1181 %1531
-OpBranch %986
-%986 = OpLabel
-%1532 = OpLoad %ulong %1098
-%1533 = OpLoad %ulong %1181
-%1534 = OpFunctionCall %ulong %24 %1532 %1533
-OpStore %1096 %1534
-OpBranch %989
-%989 = OpLabel
-%1535 = OpAccessChain %_ptr_Function_ulong %1052 %uint_0
-%1536 = OpLoad %ulong %1095
-OpStore %1535 %1536
-%1537 = OpLoad %ulong %1095
-%1538 = OpIAdd %ulong %1537 %ulong_1
-OpStore %1194 %1538
-%1539 = OpAccessChain %_ptr_Function_ulong %1052 %uint_1
-%1540 = OpLoad %ulong %1194
-OpStore %1539 %1540
-%1541 = OpLoad %ulong %1095
-%1542 = OpIAdd %ulong %1541 %ulong_2
-OpStore %1195 %1542
-%1543 = OpAccessChain %_ptr_Function_ulong %1052 %uint_2
-%1544 = OpLoad %ulong %1195
-OpStore %1543 %1544
-%1545 = OpLoad %ulong %1095
-%1546 = OpIMul %ulong %1545 %ulong_9
-OpStore %1196 %1546
-%1547 = OpAccessChain %_ptr_Function_ulong %1052 %uint_3
-%1548 = OpLoad %ulong %1196
-OpStore %1547 %1548
-%1549 = OpLoad %ulong %1095
-%1550 = OpNot %ulong %1549
-OpStore %1197 %1550
-%1551 = OpAccessChain %_ptr_Function_ulong %1052 %uint_4
-%1552 = OpLoad %ulong %1197
-OpStore %1551 %1552
-%1553 = OpLoad %ulong %1095
-%1554 = OpBitwiseXor %ulong %1553 %ulong_2863311530
-OpStore %1198 %1554
-%1555 = OpAccessChain %_ptr_Function_ulong %1052 %uint_5
-%1556 = OpLoad %ulong %1198
-OpStore %1555 %1556
-OpBranch %990
-%990 = OpLabel
-%1557 = OpLoad %_struct_250 %1052
-%1558 = OpFunctionCall %_struct_99 %19 %1557
-OpStore %1053 %1558
-%1559 = OpLoad %_struct_99 %1053
-%1560 = OpFunctionCall %_struct_250 %18 %1559
-OpStore %1054 %1560
-OpBranch %993
-%993 = OpLabel
-%1561 = OpAccessChain %_ptr_Function_ulong %1054 %uint_0
-%1562 = OpLoad %ulong %1561
-OpStore %1293 %1562
-%1563 = OpAccessChain %_ptr_Function_ulong %1054 %uint_1
-%1564 = OpLoad %ulong %1563
-OpStore %1294 %1564
-%1565 = OpAccessChain %_ptr_Function_ulong %1054 %uint_2
-%1566 = OpLoad %ulong %1565
-OpStore %1295 %1566
-%1567 = OpAccessChain %_ptr_Function_ulong %1054 %uint_3
-%1568 = OpLoad %ulong %1567
-OpStore %1296 %1568
-%1569 = OpAccessChain %_ptr_Function_ulong %1054 %uint_4
-%1570 = OpLoad %ulong %1569
-OpStore %1297 %1570
-%1571 = OpAccessChain %_ptr_Function_ulong %1054 %uint_5
-%1572 = OpLoad %ulong %1571
-OpStore %1298 %1572
-%1573 = OpLoad %ulong %1096
-%1574 = OpLoad %ulong %1293
-%1575 = OpFunctionCall %ulong %24 %1573 %1574
-OpStore %1208 %1575
-%1576 = OpLoad %ulong %1208
-%1577 = OpLoad %ulong %1294
-%1578 = OpFunctionCall %ulong %24 %1576 %1577
-OpStore %1209 %1578
-%1579 = OpLoad %ulong %1209
-%1580 = OpLoad %ulong %1295
-%1581 = OpFunctionCall %ulong %24 %1579 %1580
-OpStore %1210 %1581
-%1582 = OpLoad %ulong %1210
-%1583 = OpLoad %ulong %1296
-%1584 = OpFunctionCall %ulong %24 %1582 %1583
-OpStore %1211 %1584
-%1585 = OpLoad %ulong %1211
-%1586 = OpLoad %ulong %1297
-%1587 = OpFunctionCall %ulong %24 %1585 %1586
-OpStore %1212 %1587
-%1588 = OpLoad %ulong %1212
-%1589 = OpLoad %ulong %1298
-%1590 = OpFunctionCall %ulong %24 %1588 %1589
-OpStore %1213 %1590
-OpBranch %994
-%994 = OpLabel
-OpBranch %997
-%997 = OpLabel
-%1591 = OpAccessChain %_ptr_Function_ulong %1055 %uint_0
-%1592 = OpLoad %ulong %1095
-OpStore %1591 %1592
-%1593 = OpLoad %ulong %1095
-%1594 = OpNot %ulong %1593
-OpStore %1217 %1594
-%1595 = OpAccessChain %_ptr_Function_ulong %1055 %uint_1
-%1596 = OpLoad %ulong %1217
-OpStore %1595 %1596
-%1597 = OpLoad %ulong %1095
-%1598 = OpIMul %ulong %1597 %ulong_3
-OpStore %1218 %1598
-%1599 = OpLoad %ulong %1218
-%1600 = OpIAdd %ulong %1599 %ulong_1
-OpStore %1219 %1600
-%1601 = OpAccessChain %_ptr_Function_ulong %1055 %uint_2
-%1602 = OpLoad %ulong %1219
-OpStore %1601 %1602
-OpBranch %998
-%998 = OpLabel
-%1603 = OpLoad %_struct_99 %1055
-%1604 = OpFunctionCall %_struct_250 %18 %1603
-OpStore %1056 %1604
-%1605 = OpLoad %_struct_250 %1056
-%1606 = OpFunctionCall %_struct_99 %19 %1605
-OpStore %1057 %1606
-OpBranch %1001
-%1001 = OpLabel
-%1607 = OpAccessChain %_ptr_Function_ulong %1057 %uint_0
-%1608 = OpLoad %ulong %1607
-OpStore %1299 %1608
-%1609 = OpAccessChain %_ptr_Function_ulong %1057 %uint_1
-%1610 = OpLoad %ulong %1609
-OpStore %1300 %1610
-%1611 = OpAccessChain %_ptr_Function_ulong %1057 %uint_2
-%1612 = OpLoad %ulong %1611
-OpStore %1301 %1612
-%1613 = OpLoad %ulong %1213
-%1614 = OpLoad %ulong %1299
-%1615 = OpFunctionCall %ulong %24 %1613 %1614
-OpStore %1223 %1615
-%1616 = OpLoad %ulong %1223
-%1617 = OpLoad %ulong %1300
-%1618 = OpFunctionCall %ulong %24 %1616 %1617
-OpStore %1224 %1618
-%1619 = OpLoad %ulong %1224
-%1620 = OpLoad %ulong %1301
-%1621 = OpFunctionCall %ulong %24 %1619 %1620
-OpStore %1225 %1621
-OpBranch %1002
-%1002 = OpLabel
-OpBranch %1005
-%1005 = OpLabel
-%1622 = OpAccessChain %_ptr_Function_ulong %1058 %uint_0
-%1623 = OpLoad %ulong %1095
-OpStore %1622 %1623
-%1624 = OpLoad %ulong %1095
-%1625 = OpIAdd %ulong %1624 %ulong_1
-OpStore %1230 %1625
-%1626 = OpAccessChain %_ptr_Function_ulong %1058 %uint_1
-%1627 = OpLoad %ulong %1230
-OpStore %1626 %1627
-%1628 = OpLoad %ulong %1095
-%1629 = OpIAdd %ulong %1628 %ulong_2
-OpStore %1231 %1629
-%1630 = OpAccessChain %_ptr_Function_ulong %1058 %uint_2
-%1631 = OpLoad %ulong %1231
-OpStore %1630 %1631
-%1632 = OpLoad %ulong %1095
-%1633 = OpIMul %ulong %1632 %ulong_9
-OpStore %1232 %1633
-%1634 = OpAccessChain %_ptr_Function_ulong %1058 %uint_3
-%1635 = OpLoad %ulong %1232
-OpStore %1634 %1635
-%1636 = OpLoad %ulong %1095
-%1637 = OpNot %ulong %1636
-OpStore %1233 %1637
-%1638 = OpAccessChain %_ptr_Function_ulong %1058 %uint_4
-%1639 = OpLoad %ulong %1233
-OpStore %1638 %1639
-%1640 = OpLoad %ulong %1095
-%1641 = OpBitwiseXor %ulong %1640 %ulong_2863311530
-OpStore %1234 %1641
-%1642 = OpAccessChain %_ptr_Function_ulong %1058 %uint_5
-%1643 = OpLoad %ulong %1234
-OpStore %1642 %1643
-OpBranch %1006
-%1006 = OpLabel
-%1644 = OpLoad %_struct_250 %1058
-%1645 = OpLoad %ulong %1095
-%1646 = OpFunctionCall %_struct_250 %17 %1644 %1645
-OpStore %1059 %1646
-%1647 = OpLoad %_struct_250 %1059
-%1648 = OpFunctionCall %_struct_99 %19 %1647
-OpStore %1060 %1648
-OpBranch %1009
-%1009 = OpLabel
-%1649 = OpAccessChain %_ptr_Function_ulong %1060 %uint_0
-%1650 = OpLoad %ulong %1649
-OpStore %1302 %1650
-%1651 = OpAccessChain %_ptr_Function_ulong %1060 %uint_1
-%1652 = OpLoad %ulong %1651
-OpStore %1303 %1652
-%1653 = OpAccessChain %_ptr_Function_ulong %1060 %uint_2
-%1654 = OpLoad %ulong %1653
-OpStore %1304 %1654
-%1655 = OpLoad %ulong %1302
-%1656 = OpLoad %ulong %1095
-%1657 = OpIAdd %ulong %1655 %1656
-OpStore %1245 %1657
-%1658 = OpLoad %ulong %1303
-%1659 = OpLoad %ulong %1095
-%1660 = OpBitwiseXor %ulong %1658 %1659
-OpStore %1246 %1660
-%1661 = OpLoad %ulong %1304
-%1662 = OpLoad %ulong %1302
-%1663 = OpIAdd %ulong %1661 %1662
-OpStore %1247 %1663
-OpBranch %1010
-%1010 = OpLabel
-OpBranch %1013
-%1013 = OpLabel
-%1664 = OpLoad %ulong %1225
-%1665 = OpLoad %ulong %1245
-%1666 = OpFunctionCall %ulong %24 %1664 %1665
-OpStore %1254 %1666
-%1667 = OpLoad %ulong %1254
-%1668 = OpLoad %ulong %1246
-%1669 = OpFunctionCall %ulong %24 %1667 %1668
-OpStore %1255 %1669
-%1670 = OpLoad %ulong %1255
-%1671 = OpLoad %ulong %1247
-%1672 = OpFunctionCall %ulong %24 %1670 %1671
-OpStore %1256 %1672
-OpBranch %1014
-%1014 = OpLabel
-%1673 = OpLoad %ulong %1104
-%1674 = OpIAdd %ulong %1673 %ulong_1
-OpStore %1097 %1674
-%1675 = OpLoad %ulong %1256
-OpStore %1098 %1675
-%1676 = OpLoad %ulong %1097
-OpStore %1104 %1676
-OpBranch %1023
-%944 = OpLabel
-%1677 = OpLoad %ulong %1105
-%1678 = OpAccessChain %_ptr_Function__struct_161 %1037 %1677
-%1679 = OpAccessChain %_ptr_Function_ulong %1678 %uint_0
-%1680 = OpLoad %ulong %1679
-OpStore %1280 %1680
-%1681 = OpAccessChain %_ptr_Function_ulong %1678 %uint_1
-%1682 = OpLoad %ulong %1681
-OpStore %1281 %1682
-%1683 = OpAccessChain %_ptr_Function_ulong %1678 %uint_2
-%1684 = OpLoad %ulong %1683
-OpStore %1282 %1684
-%1685 = OpAccessChain %_ptr_Function_ulong %1678 %uint_3
-%1686 = OpLoad %ulong %1685
-OpStore %1283 %1686
-OpBranch %965
-%965 = OpLabel
-%1687 = OpLoad %ulong %1099
-%1688 = OpLoad %ulong %1280
-%1689 = OpFunctionCall %ulong %24 %1687 %1688
-OpStore %1151 %1689
-%1690 = OpLoad %ulong %1151
-%1691 = OpLoad %ulong %1281
-%1692 = OpFunctionCall %ulong %24 %1690 %1691
-OpStore %1152 %1692
-%1693 = OpLoad %ulong %1152
-%1694 = OpLoad %ulong %1282
-%1695 = OpFunctionCall %ulong %24 %1693 %1694
-OpStore %1153 %1695
-%1696 = OpLoad %ulong %1153
-%1697 = OpLoad %ulong %1283
-%1698 = OpFunctionCall %ulong %24 %1696 %1697
-OpStore %1154 %1698
-OpBranch %966
-%966 = OpLabel
-%1699 = OpLoad %ulong %1105
-%1700 = OpIAdd %ulong %1699 %ulong_1
-OpStore %1087 %1700
-%1701 = OpLoad %ulong %1154
-OpStore %1099 %1701
-%1702 = OpLoad %ulong %1087
-OpStore %1105 %1702
-OpBranch %1024
-%941 = OpLabel
-%1703 = OpLoad %ulong %1106
-%1704 = OpAccessChain %_ptr_Function_ulong %1042 %1703
-%1705 = OpLoad %ulong %1704
-OpStore %1083 %1705
-%1706 = OpLoad %ulong %1083
-%1707 = OpLoad %ulong %1064
-%1708 = OpIAdd %ulong %1706 %1707
-OpStore %1084 %1708
-OpBranch %963
-%963 = OpLabel
-%1709 = OpAccessChain %_ptr_Function_ulong %1044 %uint_0
-%1710 = OpLoad %ulong %1084
-OpStore %1709 %1710
-%1711 = OpLoad %ulong %1084
-%1712 = OpIAdd %ulong %1711 %ulong_1
-OpStore %1148 %1712
-%1713 = OpAccessChain %_ptr_Function_ulong %1044 %uint_1
-%1714 = OpLoad %ulong %1148
-OpStore %1713 %1714
-%1715 = OpLoad %ulong %1084
-%1716 = OpIMul %ulong %1715 %ulong_5
-OpStore %1149 %1716
-%1717 = OpAccessChain %_ptr_Function_ulong %1044 %uint_2
-%1718 = OpLoad %ulong %1149
-OpStore %1717 %1718
-%1719 = OpLoad %ulong %1084
-%1720 = OpNot %ulong %1719
-OpStore %1150 %1720
-%1721 = OpAccessChain %_ptr_Function_ulong %1044 %uint_3
-%1722 = OpLoad %ulong %1150
-OpStore %1721 %1722
-OpBranch %964
-%964 = OpLabel
-%1723 = OpLoad %ulong %1106
-%1724 = OpAccessChain %_ptr_Function__struct_161 %1037 %1723
-%1725 = OpLoad %_struct_161 %1044
-OpStore %1724 %1725
-%1726 = OpLoad %ulong %1106
-%1727 = OpIAdd %ulong %1726 %ulong_1
-OpStore %1085 %1727
-%1728 = OpLoad %ulong %1085
-OpStore %1106 %1728
-OpBranch %1025
-%938 = OpLabel
-%1729 = OpLoad %_struct_250 %1031
-OpStore %1032 %1729
-%1730 = OpLoad %ulong %1107
-%1731 = OpAccessChain %_ptr_Function_ulong %1042 %1730
-%1732 = OpLoad %ulong %1731
-OpStore %1080 %1732
-%1733 = OpLoad %_struct_250 %1032
-%1734 = OpLoad %ulong %1080
-%1735 = OpFunctionCall %_struct_250 %17 %1733 %1734
-OpStore %1033 %1735
-%1736 = OpLoad %_struct_250 %1033
-OpStore %1031 %1736
-%1737 = OpAccessChain %_ptr_Function_ulong %1031 %uint_0
-%1738 = OpLoad %ulong %1737
-OpStore %1274 %1738
-%1739 = OpAccessChain %_ptr_Function_ulong %1031 %uint_1
-%1740 = OpLoad %ulong %1739
-OpStore %1275 %1740
-%1741 = OpAccessChain %_ptr_Function_ulong %1031 %uint_2
-%1742 = OpLoad %ulong %1741
-OpStore %1276 %1742
-%1743 = OpAccessChain %_ptr_Function_ulong %1031 %uint_3
-%1744 = OpLoad %ulong %1743
-OpStore %1277 %1744
-%1745 = OpAccessChain %_ptr_Function_ulong %1031 %uint_4
-%1746 = OpLoad %ulong %1745
-OpStore %1278 %1746
-%1747 = OpAccessChain %_ptr_Function_ulong %1031 %uint_5
-%1748 = OpLoad %ulong %1747
-OpStore %1279 %1748
-OpBranch %961
-%961 = OpLabel
-%1749 = OpLoad %ulong %1100
-%1750 = OpLoad %ulong %1274
-%1751 = OpFunctionCall %ulong %24 %1749 %1750
-OpStore %1142 %1751
-%1752 = OpLoad %ulong %1142
-%1753 = OpLoad %ulong %1275
-%1754 = OpFunctionCall %ulong %24 %1752 %1753
-OpStore %1143 %1754
-%1755 = OpLoad %ulong %1143
-%1756 = OpLoad %ulong %1276
-%1757 = OpFunctionCall %ulong %24 %1755 %1756
-OpStore %1144 %1757
-%1758 = OpLoad %ulong %1144
-%1759 = OpLoad %ulong %1277
-%1760 = OpFunctionCall %ulong %24 %1758 %1759
-OpStore %1145 %1760
-%1761 = OpLoad %ulong %1145
-%1762 = OpLoad %ulong %1278
-%1763 = OpFunctionCall %ulong %24 %1761 %1762
-OpStore %1146 %1763
-%1764 = OpLoad %ulong %1146
-%1765 = OpLoad %ulong %1279
-%1766 = OpFunctionCall %ulong %24 %1764 %1765
-OpStore %1147 %1766
-OpBranch %962
-%962 = OpLabel
-%1767 = OpLoad %ulong %1107
-%1768 = OpIAdd %ulong %1767 %ulong_1
-OpStore %1081 %1768
-%1769 = OpLoad %ulong %1147
-OpStore %1100 %1769
-%1770 = OpLoad %ulong %1081
-OpStore %1107 %1770
-OpBranch %1026
-%935 = OpLabel
-%1771 = OpLoad %ulong %1108
-%1772 = OpAccessChain %_ptr_Function_ulong %1042 %1771
-%1773 = OpLoad %ulong %1772
-OpStore %1076 %1773
-OpBranch %957
-%957 = OpLabel
-%1774 = OpLoad %ulong %1305
-%1775 = OpLoad %ulong %1076
-%1776 = OpIAdd %ulong %1774 %1775
-OpStore %1134 %1776
-%1777 = OpLoad %ulong %1306
-%1778 = OpLoad %ulong %1076
-%1779 = OpBitwiseXor %ulong %1777 %1778
-OpStore %1135 %1779
-%1780 = OpLoad %ulong %1307
-%1781 = OpLoad %ulong %1305
-%1782 = OpIAdd %ulong %1780 %1781
-OpStore %1136 %1782
-OpBranch %958
-%958 = OpLabel
-OpBranch %973
-%973 = OpLabel
-%1783 = OpLoad %ulong %1101
-%1784 = OpLoad %ulong %1134
-%1785 = OpFunctionCall %ulong %24 %1783 %1784
-OpStore %1166 %1785
-%1786 = OpLoad %ulong %1166
-%1787 = OpLoad %ulong %1135
-%1788 = OpFunctionCall %ulong %24 %1786 %1787
-OpStore %1167 %1788
-%1789 = OpLoad %ulong %1167
-%1790 = OpLoad %ulong %1136
-%1791 = OpFunctionCall %ulong %24 %1789 %1790
-OpStore %1168 %1791
-OpBranch %974
-%974 = OpLabel
-%1792 = OpLoad %ulong %1108
-%1793 = OpIAdd %ulong %1792 %ulong_1
-OpStore %1077 %1793
-%1794 = OpLoad %ulong %1168
-OpStore %1101 %1794
-%1795 = OpLoad %ulong %1077
-OpStore %1108 %1795
-%1796 = OpLoad %ulong %1134
-OpStore %1305 %1796
-%1797 = OpLoad %ulong %1135
-OpStore %1306 %1797
-%1798 = OpLoad %ulong %1136
-OpStore %1307 %1798
-OpBranch %1027
-%932 = OpLabel
-%1799 = OpLoad %ulong %1109
-%1800 = OpAccessChain %_ptr_Function_ulong %1042 %1799
-%1801 = OpLoad %ulong %1800
-OpStore %1070 %1801
-%1802 = OpLoad %ulong %1070
-%1803 = OpLoad %ulong %1064
-%1804 = OpIAdd %ulong %1802 %1803
-OpStore %1071 %1804
-OpBranch %953
-%953 = OpLabel
-%1805 = OpLoad %ulong %1071
-%1806 = OpUConvert %uint %1805
-OpStore %1122 %1806
-%1807 = OpLoad %ulong %1071
-%1808 = OpShiftRightLogical %ulong %1807 %ulong_8
-OpStore %1123 %1808
-%1809 = OpLoad %ulong %1123
-%1810 = OpUConvert %uint %1809
-OpStore %1124 %1810
-%1811 = OpLoad %ulong %1071
-%1812 = OpShiftRightLogical %ulong %1811 %ulong_16
-OpStore %1125 %1812
-%1813 = OpLoad %ulong %1125
-%1814 = OpUConvert %uint %1813
-OpStore %1126 %1814
-%1815 = OpLoad %ulong %1071
-%1816 = OpShiftRightLogical %ulong %1815 %ulong_24
-OpStore %1127 %1816
-%1817 = OpLoad %ulong %1127
-%1818 = OpUConvert %uint %1817
-OpStore %1128 %1818
-%1819 = OpLoad %ulong %1071
-%1820 = OpShiftRightLogical %ulong %1819 %ulong_32
-OpStore %1129 %1820
-%1821 = OpLoad %ulong %1129
-%1822 = OpUConvert %uint %1821
-OpStore %1130 %1822
-OpBranch %954
-%954 = OpLabel
-OpBranch %971
-%971 = OpLabel
-%1823 = OpLoad %ulong %1102
-%1824 = OpLoad %uint %1122
-%1825 = OpFunctionCall %ulong %25 %1823 %1824
-OpStore %1161 %1825
-%1826 = OpLoad %ulong %1161
-%1827 = OpLoad %uint %1124
-%1828 = OpFunctionCall %ulong %25 %1826 %1827
-OpStore %1162 %1828
-%1829 = OpLoad %ulong %1162
-%1830 = OpLoad %uint %1126
-%1831 = OpFunctionCall %ulong %25 %1829 %1830
-OpStore %1163 %1831
-%1832 = OpLoad %ulong %1163
-%1833 = OpLoad %uint %1128
-%1834 = OpFunctionCall %ulong %25 %1832 %1833
-OpStore %1164 %1834
-%1835 = OpLoad %ulong %1164
-%1836 = OpLoad %uint %1130
-%1837 = OpFunctionCall %ulong %25 %1835 %1836
-OpStore %1165 %1837
-OpBranch %972
-%972 = OpLabel
-OpBranch %979
-%979 = OpLabel
-%1838 = OpLoad %ulong %1071
-%1839 = OpNot %ulong %1838
-OpStore %1177 %1839
-%1840 = OpLoad %ulong %1071
-%1841 = OpIMul %ulong %1840 %ulong_3
-OpStore %1178 %1841
-%1842 = OpLoad %ulong %1178
-%1843 = OpIAdd %ulong %1842 %ulong_1
-OpStore %1179 %1843
-OpBranch %980
-%980 = OpLabel
-OpBranch %987
-%987 = OpLabel
-%1844 = OpLoad %ulong %1165
-%1845 = OpLoad %ulong %1071
-%1846 = OpFunctionCall %ulong %24 %1844 %1845
-OpStore %1191 %1846
-%1847 = OpLoad %ulong %1191
-%1848 = OpLoad %ulong %1177
-%1849 = OpFunctionCall %ulong %24 %1847 %1848
-OpStore %1192 %1849
-%1850 = OpLoad %ulong %1192
-%1851 = OpLoad %ulong %1179
-%1852 = OpFunctionCall %ulong %24 %1850 %1851
-OpStore %1193 %1852
-OpBranch %988
-%988 = OpLabel
-OpBranch %991
-%991 = OpLabel
-%1853 = OpLoad %ulong %1071
-%1854 = OpBitwiseAnd %ulong %1853 %ulong_65535
-OpStore %1199 %1854
-%1855 = OpLoad %ulong %1199
-%1856 = OpConvertUToF %double %1855
-OpStore %1200 %1856
-%1857 = OpLoad %double %1200
-%1858 = OpFDiv %double %1857 %double_8
-OpStore %1201 %1858
-%1859 = OpLoad %ulong %1071
-%1860 = OpBitwiseAnd %ulong %1859 %ulong_4095
-OpStore %1202 %1860
-%1861 = OpLoad %ulong %1202
-%1862 = OpConvertUToF %double %1861
-OpStore %1203 %1862
-%1863 = OpLoad %double %1203
-%1864 = OpFSub %double %1863 %double_2048
-OpStore %1204 %1864
-%1865 = OpLoad %ulong %1071
-%1866 = OpBitwiseAnd %ulong %1865 %ulong_262143
-OpStore %1205 %1866
-%1867 = OpLoad %ulong %1205
-%1868 = OpConvertUToF %double %1867
-OpStore %1206 %1868
-%1869 = OpLoad %double %1206
-%1870 = OpFDiv %double %1869 %double_64
-OpStore %1207 %1870
-OpBranch %992
-%992 = OpLabel
-OpBranch %995
-%995 = OpLabel
-%1871 = OpLoad %ulong %1193
-%1872 = OpLoad %double %1201
-%1873 = OpFunctionCall %ulong %26 %1871 %1872
-OpStore %1214 %1873
-%1874 = OpLoad %ulong %1214
-%1875 = OpLoad %double %1204
-%1876 = OpFunctionCall %ulong %26 %1874 %1875
-OpStore %1215 %1876
-%1877 = OpLoad %ulong %1215
-%1878 = OpLoad %double %1207
-%1879 = OpFunctionCall %ulong %26 %1877 %1878
-OpStore %1216 %1879
-OpBranch %996
-%996 = OpLabel
-OpBranch %999
-%999 = OpLabel
-%1880 = OpLoad %ulong %1071
-%1881 = OpIAdd %ulong %1880 %ulong_1
-OpStore %1220 %1881
-%1882 = OpLoad %ulong %1071
-%1883 = OpIMul %ulong %1882 %ulong_5
-OpStore %1221 %1883
-%1884 = OpLoad %ulong %1071
-%1885 = OpNot %ulong %1884
-OpStore %1222 %1885
-OpBranch %1000
-%1000 = OpLabel
-OpBranch %1003
-%1003 = OpLabel
-%1886 = OpLoad %ulong %1216
-%1887 = OpLoad %ulong %1071
-%1888 = OpFunctionCall %ulong %24 %1886 %1887
-OpStore %1226 %1888
-%1889 = OpLoad %ulong %1226
-%1890 = OpLoad %ulong %1220
-%1891 = OpFunctionCall %ulong %24 %1889 %1890
-OpStore %1227 %1891
-%1892 = OpLoad %ulong %1227
-%1893 = OpLoad %ulong %1221
-%1894 = OpFunctionCall %ulong %24 %1892 %1893
-OpStore %1228 %1894
-%1895 = OpLoad %ulong %1228
-%1896 = OpLoad %ulong %1222
-%1897 = OpFunctionCall %ulong %24 %1895 %1896
-OpStore %1229 %1897
-OpBranch %1004
-%1004 = OpLabel
-OpBranch %1007
-%1007 = OpLabel
-%1898 = OpLoad %ulong %1071
-%1899 = OpBitwiseAnd %ulong %1898 %ulong_8191
-OpStore %1235 %1899
-%1900 = OpLoad %ulong %1235
-%1901 = OpConvertUToF %double %1900
-OpStore %1236 %1901
-%1902 = OpLoad %double %1236
-%1903 = OpFDiv %double %1902 %double_2
-OpStore %1237 %1903
-%1904 = OpLoad %ulong %1071
-%1905 = OpUConvert %uint %1904
-OpStore %1238 %1905
-%1906 = OpLoad %ulong %1071
-%1907 = OpShiftRightLogical %ulong %1906 %ulong_16
-OpStore %1239 %1907
-%1908 = OpLoad %ulong %1239
-%1909 = OpUConvert %uint %1908
-OpStore %1240 %1909
-%1910 = OpLoad %ulong %1071
-%1911 = OpBitwiseAnd %ulong %1910 %ulong_131071
-OpStore %1241 %1911
-%1912 = OpLoad %ulong %1241
-%1913 = OpConvertUToF %double %1912
-OpStore %1242 %1913
-%1914 = OpLoad %double %1242
-%1915 = OpFDiv %double %1914 %double_32
-OpStore %1243 %1915
-%1916 = OpLoad %ulong %1071
-%1917 = OpIMul %ulong %1916 %ulong_7
-OpStore %1244 %1917
-OpBranch %1008
-%1008 = OpLabel
-OpBranch %1011
-%1011 = OpLabel
-%1918 = OpLoad %ulong %1229
-%1919 = OpLoad %ulong %1071
-%1920 = OpFunctionCall %ulong %24 %1918 %1919
-OpStore %1248 %1920
-%1921 = OpLoad %ulong %1248
-%1922 = OpLoad %double %1237
-%1923 = OpFunctionCall %ulong %26 %1921 %1922
-OpStore %1249 %1923
-%1924 = OpLoad %ulong %1249
-%1925 = OpLoad %uint %1238
-%1926 = OpFunctionCall %ulong %25 %1924 %1925
-OpStore %1250 %1926
-%1927 = OpLoad %ulong %1250
-%1928 = OpLoad %uint %1240
-%1929 = OpFunctionCall %ulong %25 %1927 %1928
-OpStore %1251 %1929
-%1930 = OpLoad %ulong %1251
-%1931 = OpLoad %double %1243
-%1932 = OpFunctionCall %ulong %26 %1930 %1931
-OpStore %1252 %1932
-%1933 = OpLoad %ulong %1252
-%1934 = OpLoad %ulong %1244
-%1935 = OpFunctionCall %ulong %24 %1933 %1934
-OpStore %1253 %1935
-OpBranch %1012
-%1012 = OpLabel
-OpBranch %1015
-%1015 = OpLabel
-%1936 = OpLoad %ulong %1071
-%1937 = OpIAdd %ulong %1936 %ulong_1
-OpStore %1257 %1937
-%1938 = OpLoad %ulong %1071
-%1939 = OpIAdd %ulong %1938 %ulong_2
-OpStore %1258 %1939
-%1940 = OpLoad %ulong %1071
-%1941 = OpIMul %ulong %1940 %ulong_9
-OpStore %1259 %1941
-%1942 = OpLoad %ulong %1071
-%1943 = OpNot %ulong %1942
-OpStore %1260 %1943
-%1944 = OpLoad %ulong %1071
-%1945 = OpBitwiseXor %ulong %1944 %ulong_2863311530
-OpStore %1261 %1945
-OpBranch %1016
-%1016 = OpLabel
-OpBranch %1017
-%1017 = OpLabel
-%1946 = OpLoad %ulong %1253
-%1947 = OpLoad %ulong %1071
-%1948 = OpFunctionCall %ulong %24 %1946 %1947
-OpStore %1262 %1948
-%1949 = OpLoad %ulong %1262
-%1950 = OpLoad %ulong %1257
-%1951 = OpFunctionCall %ulong %24 %1949 %1950
-OpStore %1263 %1951
-%1952 = OpLoad %ulong %1263
-%1953 = OpLoad %ulong %1258
-%1954 = OpFunctionCall %ulong %24 %1952 %1953
-OpStore %1264 %1954
-%1955 = OpLoad %ulong %1264
-%1956 = OpLoad %ulong %1259
-%1957 = OpFunctionCall %ulong %24 %1955 %1956
-OpStore %1265 %1957
-%1958 = OpLoad %ulong %1265
-%1959 = OpLoad %ulong %1260
-%1960 = OpFunctionCall %ulong %24 %1958 %1959
-OpStore %1266 %1960
-%1961 = OpLoad %ulong %1266
-%1962 = OpLoad %ulong %1261
-%1963 = OpFunctionCall %ulong %24 %1961 %1962
-OpStore %1267 %1963
-OpBranch %1018
-%1018 = OpLabel
-OpBranch %1019
-%1019 = OpLabel
-%1964 = OpLoad %ulong %1071
-%1965 = OpUConvert %uint %1964
-OpStore %1268 %1965
-%1966 = OpAccessChain %_ptr_Function_uint %1061 %uint_0
-%1967 = OpLoad %uint %1268
-OpStore %1966 %1967
-OpBranch %1020
-%1020 = OpLabel
-%1968 = OpAccessChain %_ptr_Function_ulong %1062 %uint_0
-%1969 = OpLoad %ulong %1071
-OpStore %1968 %1969
-%1970 = OpLoad %ulong %1071
-%1971 = OpNot %ulong %1970
-OpStore %1271 %1971
-%1972 = OpAccessChain %_ptr_Function_ulong %1062 %uint_1
-%1973 = OpLoad %ulong %1271
-OpStore %1972 %1973
-%1974 = OpLoad %ulong %1071
-%1975 = OpIMul %ulong %1974 %ulong_3
-OpStore %1272 %1975
-%1976 = OpLoad %ulong %1272
-%1977 = OpIAdd %ulong %1976 %ulong_1
-OpStore %1273 %1977
-%1978 = OpAccessChain %_ptr_Function_ulong %1062 %uint_2
-%1979 = OpLoad %ulong %1273
-OpStore %1978 %1979
-OpBranch %1021
-%1021 = OpLabel
-%1980 = OpAccessChain %_ptr_Function__struct_99 %1061 %uint_1
-%1981 = OpLoad %_struct_99 %1062
-OpStore %1980 %1981
-%1982 = OpLoad %ulong %1071
-%1983 = OpIMul %ulong %1982 %ulong_11
-OpStore %1269 %1983
-%1984 = OpAccessChain %_ptr_Function_ulong %1063 %uint_0
-%1985 = OpLoad %ulong %1269
-OpStore %1984 %1985
-%1986 = OpLoad %ulong %1071
-%1987 = OpNot %ulong %1986
-OpStore %1270 %1987
-%1988 = OpAccessChain %_ptr_Function_ulong %1063 %uint_1
-%1989 = OpLoad %ulong %1270
-OpStore %1988 %1989
-%1990 = OpAccessChain %_ptr_Function__struct_301 %1061 %uint_2
-%1991 = OpLoad %_struct_301 %1063
-OpStore %1990 %1991
-OpBranch %1022
-%1022 = OpLabel
-%1992 = OpLoad %ulong %1267
-%1993 = OpLoad %_struct_302 %1061
-%1994 = OpFunctionCall %ulong %8 %1992 %1993
-OpStore %1072 %1994
-%1995 = OpLoad %ulong %1109
-%1996 = OpIAdd %ulong %1995 %ulong_1
-OpStore %1073 %1996
-%1997 = OpLoad %ulong %1072
-OpStore %1102 %1997
-%1998 = OpLoad %ulong %1073
-OpStore %1109 %1998
-OpBranch %1028
-%929 = OpLabel
-OpBranch %951
-%951 = OpLabel
-%1999 = OpLoad %ulong %1103
-%2000 = OpIMul %ulong %1999 %ulong_6364136223846793005
-OpStore %1119 %2000
-%2001 = OpLoad %ulong %1119
-%2002 = OpIAdd %ulong %2001 %ulong_1442695040888963407
-OpStore %1120 %2002
-%2003 = OpLoad %ulong %1120
-%2004 = OpLoad %ulong %1064
-%2005 = OpIAdd %ulong %2003 %2004
-OpStore %1121 %2005
-OpBranch %952
-%952 = OpLabel
-%2006 = OpLoad %ulong %1103
-%2007 = OpAccessChain %_ptr_Function_ulong %1042 %2006
-%2008 = OpLoad %ulong %1121
-OpStore %2007 %2008
-%2009 = OpLoad %ulong %1103
-%2010 = OpIAdd %ulong %2009 %ulong_1
-OpStore %1068 %2010
-%2011 = OpLoad %ulong %1068
-OpStore %1103 %2011
-OpBranch %1029
-%1023 = OpLabel
-OpBranch %946
-%1024 = OpLabel
-OpBranch %943
-%1025 = OpLabel
-OpBranch %940
-%1026 = OpLabel
-OpBranch %937
-%1027 = OpLabel
-OpBranch %934
-%1028 = OpLabel
-OpBranch %931
-%1029 = OpLabel
-OpBranch %928
+OpStore %1269 %1267
+%1277 = OpAccessChain %_ptr_Function_ulong %1269 %uint_0
+%1278 = OpLoad %ulong %1277
+OpStore %1274 %1278
+%1279 = OpAccessChain %_ptr_Function_ulong %1269 %uint_1
+%1280 = OpLoad %ulong %1279
+OpStore %1275 %1280
+%1281 = OpAccessChain %_ptr_Function_ulong %1269 %uint_2
+%1282 = OpLoad %ulong %1281
+OpStore %1276 %1282
+%1283 = OpAccessChain %_ptr_Function_ulong %1270 %uint_0
+%1284 = OpLoad %ulong %1274
+OpStore %1283 %1284
+%1285 = OpAccessChain %_ptr_Function_ulong %1270 %uint_1
+%1286 = OpLoad %ulong %1275
+OpStore %1285 %1286
+%1287 = OpAccessChain %_ptr_Function_ulong %1270 %uint_2
+%1288 = OpLoad %ulong %1276
+OpStore %1287 %1288
+%1289 = OpLoad %ulong %1274
+%1290 = OpLoad %ulong %1275
+%1291 = OpBitwiseXor %ulong %1289 %1290
+OpStore %1271 %1291
+%1292 = OpAccessChain %_ptr_Function_ulong %1270 %uint_3
+%1293 = OpLoad %ulong %1271
+OpStore %1292 %1293
+%1294 = OpLoad %ulong %1275
+%1295 = OpLoad %ulong %1276
+%1296 = OpBitwiseXor %ulong %1294 %1295
+OpStore %1272 %1296
+%1297 = OpAccessChain %_ptr_Function_ulong %1270 %uint_4
+%1298 = OpLoad %ulong %1272
+OpStore %1297 %1298
+%1299 = OpLoad %ulong %1276
+%1300 = OpLoad %ulong %1274
+%1301 = OpBitwiseXor %ulong %1299 %1300
+OpStore %1273 %1301
+%1302 = OpAccessChain %_ptr_Function_ulong %1270 %uint_5
+%1303 = OpLoad %ulong %1273
+OpStore %1302 %1303
+%1304 = OpLoad %_struct_810 %1270
+OpReturnValue %1304
 OpFunctionEnd
-%23 = OpFunction %ulong None %2012
-%2013 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%19 = OpFunction %_struct_283 None %1305
+%1306 = OpFunctionParameter %_struct_810
+%1307 = OpLabel
+%1308 = OpVariable %_ptr_Function__struct_810 Function
+%1309 = OpVariable %_ptr_Function__struct_283 Function
+%1310 = OpVariable %_ptr_Function_ulong Function
+%1311 = OpVariable %_ptr_Function_ulong Function
+%1312 = OpVariable %_ptr_Function_ulong Function
+%1313 = OpVariable %_ptr_Function_ulong Function
+%1314 = OpVariable %_ptr_Function_ulong Function
+%1315 = OpVariable %_ptr_Function_ulong Function
+%1316 = OpVariable %_ptr_Function_ulong Function
+%1317 = OpVariable %_ptr_Function_ulong Function
+%1318 = OpVariable %_ptr_Function_ulong Function
+OpStore %1308 %1306
+%1319 = OpAccessChain %_ptr_Function_ulong %1308 %uint_0
+%1320 = OpLoad %ulong %1319
+OpStore %1313 %1320
+%1321 = OpAccessChain %_ptr_Function_ulong %1308 %uint_1
+%1322 = OpLoad %ulong %1321
+OpStore %1314 %1322
+%1323 = OpAccessChain %_ptr_Function_ulong %1308 %uint_2
+%1324 = OpLoad %ulong %1323
+OpStore %1315 %1324
+%1325 = OpAccessChain %_ptr_Function_ulong %1308 %uint_3
+%1326 = OpLoad %ulong %1325
+OpStore %1316 %1326
+%1327 = OpAccessChain %_ptr_Function_ulong %1308 %uint_4
+%1328 = OpLoad %ulong %1327
+OpStore %1317 %1328
+%1329 = OpAccessChain %_ptr_Function_ulong %1308 %uint_5
+%1330 = OpLoad %ulong %1329
+OpStore %1318 %1330
+%1331 = OpLoad %ulong %1313
+%1332 = OpLoad %ulong %1316
+%1333 = OpBitwiseXor %ulong %1331 %1332
+OpStore %1310 %1333
+%1334 = OpAccessChain %_ptr_Function_ulong %1309 %uint_0
+%1335 = OpLoad %ulong %1310
+OpStore %1334 %1335
+%1336 = OpLoad %ulong %1314
+%1337 = OpLoad %ulong %1317
+%1338 = OpBitwiseXor %ulong %1336 %1337
+OpStore %1311 %1338
+%1339 = OpAccessChain %_ptr_Function_ulong %1309 %uint_1
+%1340 = OpLoad %ulong %1311
+OpStore %1339 %1340
+%1341 = OpLoad %ulong %1315
+%1342 = OpLoad %ulong %1318
+%1343 = OpBitwiseXor %ulong %1341 %1342
+OpStore %1312 %1343
+%1344 = OpAccessChain %_ptr_Function_ulong %1309 %uint_2
+%1345 = OpLoad %ulong %1312
+OpStore %1344 %1345
+%1346 = OpLoad %_struct_283 %1309
+OpReturnValue %1346
 OpFunctionEnd
-%24 = OpFunction %ulong None %28
-%2015 = OpFunctionParameter %ulong
-%2016 = OpFunctionParameter %ulong
-%2017 = OpLabel
-%2022 = OpVariable %_ptr_Function_ulong Function
-%2023 = OpVariable %_ptr_Function_ulong Function
-%2024 = OpVariable %_ptr_Function_bool Function
-%2025 = OpVariable %_ptr_Function_ulong Function
-%2026 = OpVariable %_ptr_Function_ulong Function
-%2027 = OpVariable %_ptr_Function_ulong Function
-%2028 = OpVariable %_ptr_Function_ulong Function
-%2029 = OpVariable %_ptr_Function_ulong Function
-%2030 = OpVariable %_ptr_Function_ulong Function
-%2031 = OpVariable %_ptr_Function_ulong Function
-%2032 = OpVariable %_ptr_Function_ulong Function
-OpStore %2022 %2015
-OpStore %2023 %2016
-%2033 = OpLoad %ulong %2022
-OpStore %2031 %2033
-OpStore %2032 %ulong_0
-OpBranch %2018
-%2018 = OpLabel
-%2034 = OpLoad %ulong %2032
-%2035 = OpULessThan %bool %2034 %ulong_8
-OpStore %2024 %2035
-%2036 = OpLoad %bool %2024
-OpLoopMerge %2020 %2021 None
-OpBranchConditional %2036 %2019 %2020
-%2020 = OpLabel
-%2037 = OpLoad %ulong %2031
-OpReturnValue %2037
-%2019 = OpLabel
-%2038 = OpLoad %ulong %2032
-%2039 = OpIMul %ulong %2038 %ulong_8
-OpStore %2025 %2039
-%2040 = OpLoad %ulong %2023
-%2041 = OpLoad %ulong %2025
-%2042 = OpShiftRightLogical %ulong %2040 %2041
-OpStore %2026 %2042
-%2043 = OpLoad %ulong %2026
-%2045 = OpBitwiseAnd %ulong %2043 %ulong_255
-OpStore %2027 %2045
-%2046 = OpLoad %ulong %2031
-%2047 = OpLoad %ulong %2027
-%2048 = OpBitwiseXor %ulong %2046 %2047
-OpStore %2028 %2048
-%2049 = OpLoad %ulong %2028
-%2051 = OpIMul %ulong %2049 %ulong_1099511628211
-OpStore %2029 %2051
-%2052 = OpLoad %ulong %2032
-%2053 = OpIAdd %ulong %2052 %ulong_1
-OpStore %2030 %2053
-%2054 = OpLoad %ulong %2029
-OpStore %2031 %2054
-%2055 = OpLoad %ulong %2030
-OpStore %2032 %2055
-OpBranch %2021
-%2021 = OpLabel
-OpBranch %2018
+%20 = OpFunction %_struct_862 None %1347
+%1348 = OpFunctionParameter %ulong
+%1349 = OpLabel
+%1352 = OpVariable %_ptr_Function__struct_862 Function
+%1353 = OpVariable %_ptr_Function__struct_283 Function
+%1354 = OpVariable %_ptr_Function__struct_861 Function
+%1355 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_uint Function
+%1357 = OpVariable %_ptr_Function_ulong Function
+%1358 = OpVariable %_ptr_Function_ulong Function
+%1359 = OpVariable %_ptr_Function_ulong Function
+%1360 = OpVariable %_ptr_Function_ulong Function
+%1361 = OpVariable %_ptr_Function_ulong Function
+OpStore %1355 %1348
+%1362 = OpLoad %ulong %1355
+%1363 = OpUConvert %uint %1362
+OpStore %1356 %1363
+%1364 = OpAccessChain %_ptr_Function_uint %1352 %uint_0
+%1365 = OpLoad %uint %1356
+OpStore %1364 %1365
+OpBranch %1350
+%1350 = OpLabel
+%1366 = OpAccessChain %_ptr_Function_ulong %1353 %uint_0
+%1367 = OpLoad %ulong %1355
+OpStore %1366 %1367
+%1368 = OpLoad %ulong %1355
+%1369 = OpNot %ulong %1368
+OpStore %1359 %1369
+%1370 = OpAccessChain %_ptr_Function_ulong %1353 %uint_1
+%1371 = OpLoad %ulong %1359
+OpStore %1370 %1371
+%1372 = OpLoad %ulong %1355
+%1373 = OpIMul %ulong %1372 %ulong_3
+OpStore %1360 %1373
+%1374 = OpLoad %ulong %1360
+%1375 = OpIAdd %ulong %1374 %ulong_1
+OpStore %1361 %1375
+%1376 = OpAccessChain %_ptr_Function_ulong %1353 %uint_2
+%1377 = OpLoad %ulong %1361
+OpStore %1376 %1377
+OpBranch %1351
+%1351 = OpLabel
+%1378 = OpAccessChain %_ptr_Function__struct_283 %1352 %uint_1
+%1379 = OpLoad %_struct_283 %1353
+OpStore %1378 %1379
+%1380 = OpLoad %ulong %1355
+%1382 = OpIMul %ulong %1380 %ulong_11
+OpStore %1357 %1382
+%1383 = OpAccessChain %_ptr_Function_ulong %1354 %uint_0
+%1384 = OpLoad %ulong %1357
+OpStore %1383 %1384
+%1385 = OpLoad %ulong %1355
+%1386 = OpNot %ulong %1385
+OpStore %1358 %1386
+%1387 = OpAccessChain %_ptr_Function_ulong %1354 %uint_1
+%1388 = OpLoad %ulong %1358
+OpStore %1387 %1388
+%1389 = OpAccessChain %_ptr_Function__struct_861 %1352 %uint_2
+%1390 = OpLoad %_struct_861 %1354
+OpStore %1389 %1390
+%1391 = OpLoad %_struct_862 %1352
+OpReturnValue %1391
 OpFunctionEnd
-%25 = OpFunction %ulong None %2056
-%2057 = OpFunctionParameter %ulong
-%2058 = OpFunctionParameter %uint
-%2059 = OpLabel
-%2066 = OpVariable %_ptr_Function_ulong Function
-%2067 = OpVariable %_ptr_Function_uint Function
-%2068 = OpVariable %_ptr_Function_ulong Function
-%2069 = OpVariable %_ptr_Function_bool Function
-%2070 = OpVariable %_ptr_Function_ulong Function
-%2071 = OpVariable %_ptr_Function_ulong Function
-%2072 = OpVariable %_ptr_Function_ulong Function
-%2073 = OpVariable %_ptr_Function_ulong Function
-%2074 = OpVariable %_ptr_Function_ulong Function
-%2075 = OpVariable %_ptr_Function_ulong Function
-%2076 = OpVariable %_ptr_Function_ulong Function
-%2077 = OpVariable %_ptr_Function_ulong Function
-OpStore %2066 %2057
-OpStore %2067 %2058
-%2078 = OpLoad %uint %2067
-%2079 = OpUConvert %ulong %2078
-OpStore %2068 %2079
-OpBranch %2060
-%2060 = OpLabel
-%2080 = OpLoad %ulong %2066
-OpStore %2076 %2080
-OpStore %2077 %ulong_0
-OpBranch %2061
-%2061 = OpLabel
-%2081 = OpLoad %ulong %2077
-%2082 = OpULessThan %bool %2081 %ulong_8
-OpStore %2069 %2082
-%2083 = OpLoad %bool %2069
-OpLoopMerge %2063 %2065 None
-OpBranchConditional %2083 %2062 %2063
-%2063 = OpLabel
-OpBranch %2064
-%2064 = OpLabel
-%2084 = OpLoad %ulong %2076
-OpReturnValue %2084
-%2062 = OpLabel
-%2085 = OpLoad %ulong %2077
-%2086 = OpIMul %ulong %2085 %ulong_8
-OpStore %2070 %2086
-%2087 = OpLoad %ulong %2068
-%2088 = OpLoad %ulong %2070
-%2089 = OpShiftRightLogical %ulong %2087 %2088
-OpStore %2071 %2089
-%2090 = OpLoad %ulong %2071
-%2091 = OpBitwiseAnd %ulong %2090 %ulong_255
-OpStore %2072 %2091
-%2092 = OpLoad %ulong %2076
-%2093 = OpLoad %ulong %2072
-%2094 = OpBitwiseXor %ulong %2092 %2093
-OpStore %2073 %2094
-%2095 = OpLoad %ulong %2073
-%2096 = OpIMul %ulong %2095 %ulong_1099511628211
-OpStore %2074 %2096
-%2097 = OpLoad %ulong %2077
-%2098 = OpIAdd %ulong %2097 %ulong_1
-OpStore %2075 %2098
-%2099 = OpLoad %ulong %2074
-OpStore %2076 %2099
-%2100 = OpLoad %ulong %2075
-OpStore %2077 %2100
-OpBranch %2065
-%2065 = OpLabel
-OpBranch %2061
+%21 = OpFunction %ulong None %1392
+%1393 = OpFunctionParameter %_struct_810
+%1394 = OpFunctionParameter %_struct_283
+%1395 = OpFunctionParameter %ulong
+%1396 = OpLabel
+%1401 = OpVariable %_ptr_Function__struct_810 Function
+%1402 = OpVariable %_ptr_Function__struct_283 Function
+%1403 = OpVariable %_ptr_Function__struct_283 Function
+%1404 = OpVariable %_ptr_Function__struct_283 Function
+%1405 = OpVariable %_ptr_Function_ulong Function
+%1406 = OpVariable %_ptr_Function_ulong Function
+%1407 = OpVariable %_ptr_Function_ulong Function
+%1408 = OpVariable %_ptr_Function_ulong Function
+%1409 = OpVariable %_ptr_Function_ulong Function
+%1410 = OpVariable %_ptr_Function_ulong Function
+%1411 = OpVariable %_ptr_Function_ulong Function
+%1412 = OpVariable %_ptr_Function_ulong Function
+%1413 = OpVariable %_ptr_Function_ulong Function
+%1414 = OpVariable %_ptr_Function_ulong Function
+%1415 = OpVariable %_ptr_Function_ulong Function
+%1416 = OpVariable %_ptr_Function_ulong Function
+%1417 = OpVariable %_ptr_Function_ulong Function
+%1418 = OpVariable %_ptr_Function_ulong Function
+%1419 = OpVariable %_ptr_Function_ulong Function
+OpStore %1401 %1393
+OpStore %1402 %1394
+OpStore %1405 %1395
+%1420 = OpAccessChain %_ptr_Function_ulong %1401 %uint_0
+%1421 = OpLoad %ulong %1420
+OpStore %1414 %1421
+%1422 = OpAccessChain %_ptr_Function_ulong %1401 %uint_1
+%1423 = OpLoad %ulong %1422
+OpStore %1415 %1423
+%1424 = OpAccessChain %_ptr_Function_ulong %1401 %uint_2
+%1425 = OpLoad %ulong %1424
+OpStore %1416 %1425
+%1426 = OpAccessChain %_ptr_Function_ulong %1401 %uint_3
+%1427 = OpLoad %ulong %1426
+OpStore %1417 %1427
+%1428 = OpAccessChain %_ptr_Function_ulong %1401 %uint_4
+%1429 = OpLoad %ulong %1428
+OpStore %1418 %1429
+%1430 = OpAccessChain %_ptr_Function_ulong %1401 %uint_5
+%1431 = OpLoad %ulong %1430
+OpStore %1419 %1431
+%1432 = OpLoad %_struct_283 %1402
+OpStore %1403 %1432
+OpBranch %1397
+%1397 = OpLabel
+OpBranch %1398
+%1398 = OpLabel
+OpBranch %1399
+%1399 = OpLabel
+%1434 = OpLoad %ulong %1414
+%1435 = OpFunctionCall %ulong %23 %ulong_14695981039346656037 %1434
+OpStore %1408 %1435
+%1436 = OpLoad %ulong %1408
+%1437 = OpLoad %ulong %1415
+%1438 = OpFunctionCall %ulong %23 %1436 %1437
+OpStore %1409 %1438
+%1439 = OpLoad %ulong %1409
+%1440 = OpLoad %ulong %1416
+%1441 = OpFunctionCall %ulong %23 %1439 %1440
+OpStore %1410 %1441
+%1442 = OpLoad %ulong %1410
+%1443 = OpLoad %ulong %1417
+%1444 = OpFunctionCall %ulong %23 %1442 %1443
+OpStore %1411 %1444
+%1445 = OpLoad %ulong %1411
+%1446 = OpLoad %ulong %1418
+%1447 = OpFunctionCall %ulong %23 %1445 %1446
+OpStore %1412 %1447
+%1448 = OpLoad %ulong %1412
+%1449 = OpLoad %ulong %1419
+%1450 = OpFunctionCall %ulong %23 %1448 %1449
+OpStore %1413 %1450
+OpBranch %1400
+%1400 = OpLabel
+%1451 = OpLoad %_struct_283 %1403
+OpStore %1404 %1451
+%1452 = OpLoad %ulong %1413
+%1453 = OpLoad %_struct_283 %1404
+%1454 = OpFunctionCall %ulong %3 %1452 %1453
+OpStore %1406 %1454
+%1455 = OpLoad %ulong %1406
+%1456 = OpLoad %ulong %1405
+%1457 = OpFunctionCall %ulong %23 %1455 %1456
+OpStore %1407 %1457
+%1458 = OpLoad %ulong %1407
+OpReturnValue %1458
 OpFunctionEnd
-%26 = OpFunction %ulong None %2101
-%2102 = OpFunctionParameter %ulong
-%2103 = OpFunctionParameter %double
-%2104 = OpLabel
-%2111 = OpVariable %_ptr_Function_ulong Function
-%2112 = OpVariable %_ptr_Function_double Function
-%2113 = OpVariable %_ptr_Function_ulong Function
-%2114 = OpVariable %_ptr_Function_bool Function
-%2115 = OpVariable %_ptr_Function_ulong Function
-%2116 = OpVariable %_ptr_Function_ulong Function
-%2117 = OpVariable %_ptr_Function_ulong Function
-%2118 = OpVariable %_ptr_Function_ulong Function
-%2119 = OpVariable %_ptr_Function_ulong Function
-%2120 = OpVariable %_ptr_Function_ulong Function
-%2121 = OpVariable %_ptr_Function_ulong Function
-%2122 = OpVariable %_ptr_Function_ulong Function
-OpStore %2111 %2102
-OpStore %2112 %2103
-%2123 = OpLoad %double %2112
-%2124 = OpBitcast %ulong %2123
-OpStore %2113 %2124
-OpBranch %2105
-%2105 = OpLabel
-%2125 = OpLoad %ulong %2111
-OpStore %2121 %2125
-OpStore %2122 %ulong_0
-OpBranch %2106
-%2106 = OpLabel
-%2126 = OpLoad %ulong %2122
-%2127 = OpULessThan %bool %2126 %ulong_8
-OpStore %2114 %2127
-%2128 = OpLoad %bool %2114
-OpLoopMerge %2108 %2110 None
-OpBranchConditional %2128 %2107 %2108
-%2108 = OpLabel
-OpBranch %2109
-%2109 = OpLabel
-%2129 = OpLoad %ulong %2121
-OpReturnValue %2129
-%2107 = OpLabel
-%2130 = OpLoad %ulong %2122
-%2131 = OpIMul %ulong %2130 %ulong_8
-OpStore %2115 %2131
-%2132 = OpLoad %ulong %2113
-%2133 = OpLoad %ulong %2115
-%2134 = OpShiftRightLogical %ulong %2132 %2133
-OpStore %2116 %2134
-%2135 = OpLoad %ulong %2116
-%2136 = OpBitwiseAnd %ulong %2135 %ulong_255
-OpStore %2117 %2136
-%2137 = OpLoad %ulong %2121
-%2138 = OpLoad %ulong %2117
-%2139 = OpBitwiseXor %ulong %2137 %2138
-OpStore %2118 %2139
-%2140 = OpLoad %ulong %2118
-%2141 = OpIMul %ulong %2140 %ulong_1099511628211
-OpStore %2119 %2141
-%2142 = OpLoad %ulong %2122
-%2143 = OpIAdd %ulong %2142 %ulong_1
-OpStore %2120 %2143
-%2144 = OpLoad %ulong %2119
-OpStore %2121 %2144
-%2145 = OpLoad %ulong %2120
-OpStore %2122 %2145
-OpBranch %2110
-%2110 = OpLabel
-OpBranch %2106
+%22 = OpFunction %ulong None %908
+%1459 = OpFunctionParameter %ulong
+%1460 = OpLabel
+%1639 = OpVariable %_ptr_Function__struct_283 Function
+%1640 = OpVariable %_ptr_Function__struct_810 Function
+%1641 = OpVariable %_ptr_Function__struct_810 Function
+%1642 = OpVariable %_ptr_Function__struct_810 Function
+%1646 = OpVariable %_ptr_Function__arr__struct_546_uint_6 Function
+%1647 = OpVariable %_ptr_Function__struct_546 Function
+%1648 = OpVariable %_ptr_Function__struct_862 Function
+%1649 = OpVariable %_ptr_Function__struct_283 Function
+%1650 = OpVariable %_ptr_Function__struct_283 Function
+%1651 = OpVariable %_ptr_Function__struct_283 Function
+%1652 = OpVariable %_ptr_Function__struct_810 Function
+%1653 = OpVariable %_ptr_Function__struct_546 Function
+%1654 = OpVariable %_ptr_Function__struct_283 Function
+%1655 = OpVariable %_ptr_Function__struct_810 Function
+%1659 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
+%1660 = OpVariable %_ptr_Function__struct_283 Function
+%1661 = OpVariable %_ptr_Function__struct_861 Function
+%1662 = OpVariable %_ptr_Function__struct_862 Function
+%1663 = OpVariable %_ptr_Function__struct_810 Function
+%1664 = OpVariable %_ptr_Function__struct_283 Function
+%1665 = OpVariable %_ptr_Function__struct_283 Function
+%1666 = OpVariable %_ptr_Function__struct_862 Function
+%1667 = OpVariable %_ptr_Function__struct_283 Function
+%1668 = OpVariable %_ptr_Function__struct_283 Function
+%1669 = OpVariable %_ptr_Function__struct_283 Function
+%1670 = OpVariable %_ptr_Function__struct_810 Function
+%1671 = OpVariable %_ptr_Function__struct_283 Function
+%1672 = OpVariable %_ptr_Function__struct_810 Function
+%1673 = OpVariable %_ptr_Function__struct_546 Function
+%1674 = OpVariable %_ptr_Function__struct_283 Function
+%1675 = OpVariable %_ptr_Function__struct_810 Function
+%1676 = OpVariable %_ptr_Function__struct_283 Function
+%1677 = OpVariable %_ptr_Function__struct_810 Function
+%1678 = OpVariable %_ptr_Function__struct_810 Function
+%1679 = OpVariable %_ptr_Function__struct_283 Function
+%1680 = OpVariable %_ptr_Function__struct_283 Function
+%1681 = OpVariable %_ptr_Function__struct_862 Function
+%1682 = OpVariable %_ptr_Function__struct_283 Function
+%1683 = OpVariable %_ptr_Function__struct_861 Function
+%1684 = OpVariable %_ptr_Function__struct_862 Function
+%1685 = OpVariable %_ptr_Function__struct_283 Function
+%1686 = OpVariable %_ptr_Function_ulong Function
+%1687 = OpVariable %_ptr_Function_bool Function
+%1688 = OpVariable %_ptr_Function_ulong Function
+%1689 = OpVariable %_ptr_Function_bool Function
+%1690 = OpVariable %_ptr_Function_ulong Function
+%1691 = OpVariable %_ptr_Function_ulong Function
+%1692 = OpVariable %_ptr_Function_ulong Function
+%1693 = OpVariable %_ptr_Function_ulong Function
+%1694 = OpVariable %_ptr_Function_ulong Function
+%1695 = OpVariable %_ptr_Function_ulong Function
+%1696 = OpVariable %_ptr_Function_bool Function
+%1697 = OpVariable %_ptr_Function_ulong Function
+%1698 = OpVariable %_ptr_Function_ulong Function
+%1699 = OpVariable %_ptr_Function_ulong Function
+%1700 = OpVariable %_ptr_Function_ulong Function
+%1701 = OpVariable %_ptr_Function_bool Function
+%1702 = OpVariable %_ptr_Function_ulong Function
+%1703 = OpVariable %_ptr_Function_ulong Function
+%1704 = OpVariable %_ptr_Function_bool Function
+%1705 = OpVariable %_ptr_Function_ulong Function
+%1706 = OpVariable %_ptr_Function_ulong Function
+%1707 = OpVariable %_ptr_Function_ulong Function
+%1708 = OpVariable %_ptr_Function_bool Function
+%1709 = OpVariable %_ptr_Function_ulong Function
+%1710 = OpVariable %_ptr_Function_ulong Function
+%1711 = OpVariable %_ptr_Function_ulong Function
+%1712 = OpVariable %_ptr_Function_ulong Function
+%1713 = OpVariable %_ptr_Function_ulong Function
+%1714 = OpVariable %_ptr_Function_ulong Function
+%1715 = OpVariable %_ptr_Function_bool Function
+%1716 = OpVariable %_ptr_Function_ulong Function
+%1717 = OpVariable %_ptr_Function_ulong Function
+%1718 = OpVariable %_ptr_Function_ulong Function
+%1719 = OpVariable %_ptr_Function_ulong Function
+%1720 = OpVariable %_ptr_Function_ulong Function
+%1721 = OpVariable %_ptr_Function_ulong Function
+%1722 = OpVariable %_ptr_Function_ulong Function
+%1723 = OpVariable %_ptr_Function_ulong Function
+%1724 = OpVariable %_ptr_Function_ulong Function
+%1725 = OpVariable %_ptr_Function_ulong Function
+%1726 = OpVariable %_ptr_Function_ulong Function
+%1727 = OpVariable %_ptr_Function_ulong Function
+%1728 = OpVariable %_ptr_Function_ulong Function
+%1729 = OpVariable %_ptr_Function_ulong Function
+%1730 = OpVariable %_ptr_Function_ulong Function
+%1731 = OpVariable %_ptr_Function_ulong Function
+%1732 = OpVariable %_ptr_Function_ulong Function
+%1733 = OpVariable %_ptr_Function_ulong Function
+%1734 = OpVariable %_ptr_Function_ulong Function
+%1735 = OpVariable %_ptr_Function_ulong Function
+%1736 = OpVariable %_ptr_Function_ulong Function
+%1737 = OpVariable %_ptr_Function_uint Function
+%1738 = OpVariable %_ptr_Function_ulong Function
+%1739 = OpVariable %_ptr_Function_uint Function
+%1740 = OpVariable %_ptr_Function_ulong Function
+%1741 = OpVariable %_ptr_Function_uint Function
+%1742 = OpVariable %_ptr_Function_ulong Function
+%1743 = OpVariable %_ptr_Function_uint Function
+%1744 = OpVariable %_ptr_Function_ulong Function
+%1745 = OpVariable %_ptr_Function_uint Function
+%1746 = OpVariable %_ptr_Function_ulong Function
+%1747 = OpVariable %_ptr_Function_ulong Function
+%1748 = OpVariable %_ptr_Function_ulong Function
+%1749 = OpVariable %_ptr_Function_ulong Function
+%1750 = OpVariable %_ptr_Function_ulong Function
+%1751 = OpVariable %_ptr_Function_ulong Function
+%1752 = OpVariable %_ptr_Function_ulong Function
+%1753 = OpVariable %_ptr_Function_ulong Function
+%1754 = OpVariable %_ptr_Function_ulong Function
+%1755 = OpVariable %_ptr_Function_ulong Function
+%1756 = OpVariable %_ptr_Function_ulong Function
+%1757 = OpVariable %_ptr_Function_ulong Function
+%1758 = OpVariable %_ptr_Function_ulong Function
+%1759 = OpVariable %_ptr_Function_ulong Function
+%1760 = OpVariable %_ptr_Function_ulong Function
+%1761 = OpVariable %_ptr_Function_ulong Function
+%1762 = OpVariable %_ptr_Function_ulong Function
+%1763 = OpVariable %_ptr_Function_ulong Function
+%1764 = OpVariable %_ptr_Function_ulong Function
+%1765 = OpVariable %_ptr_Function_ulong Function
+%1766 = OpVariable %_ptr_Function_ulong Function
+%1767 = OpVariable %_ptr_Function_ulong Function
+%1768 = OpVariable %_ptr_Function_ulong Function
+%1769 = OpVariable %_ptr_Function_ulong Function
+%1770 = OpVariable %_ptr_Function_ulong Function
+%1771 = OpVariable %_ptr_Function_ulong Function
+%1772 = OpVariable %_ptr_Function_ulong Function
+%1773 = OpVariable %_ptr_Function_ulong Function
+%1774 = OpVariable %_ptr_Function_ulong Function
+%1775 = OpVariable %_ptr_Function_ulong Function
+%1776 = OpVariable %_ptr_Function_ulong Function
+%1777 = OpVariable %_ptr_Function_ulong Function
+%1778 = OpVariable %_ptr_Function_ulong Function
+%1779 = OpVariable %_ptr_Function_ulong Function
+%1780 = OpVariable %_ptr_Function_ulong Function
+%1781 = OpVariable %_ptr_Function_ulong Function
+%1782 = OpVariable %_ptr_Function_bool Function
+%1783 = OpVariable %_ptr_Function_ulong Function
+%1784 = OpVariable %_ptr_Function_ulong Function
+%1785 = OpVariable %_ptr_Function_ulong Function
+%1786 = OpVariable %_ptr_Function_ulong Function
+%1787 = OpVariable %_ptr_Function_ulong Function
+%1788 = OpVariable %_ptr_Function_ulong Function
+%1789 = OpVariable %_ptr_Function_ulong Function
+%1790 = OpVariable %_ptr_Function_ulong Function
+%1791 = OpVariable %_ptr_Function_ulong Function
+%1792 = OpVariable %_ptr_Function_bool Function
+%1793 = OpVariable %_ptr_Function_ulong Function
+%1794 = OpVariable %_ptr_Function_ulong Function
+%1795 = OpVariable %_ptr_Function_ulong Function
+%1796 = OpVariable %_ptr_Function_ulong Function
+%1797 = OpVariable %_ptr_Function_ulong Function
+%1798 = OpVariable %_ptr_Function_ulong Function
+%1799 = OpVariable %_ptr_Function_ulong Function
+%1800 = OpVariable %_ptr_Function_ulong Function
+%1801 = OpVariable %_ptr_Function_ulong Function
+%1802 = OpVariable %_ptr_Function_bool Function
+%1803 = OpVariable %_ptr_Function_ulong Function
+%1804 = OpVariable %_ptr_Function_ulong Function
+%1805 = OpVariable %_ptr_Function_ulong Function
+%1806 = OpVariable %_ptr_Function_ulong Function
+%1807 = OpVariable %_ptr_Function_ulong Function
+%1808 = OpVariable %_ptr_Function_ulong Function
+%1809 = OpVariable %_ptr_Function_ulong Function
+%1810 = OpVariable %_ptr_Function_ulong Function
+%1811 = OpVariable %_ptr_Function_ulong Function
+%1812 = OpVariable %_ptr_Function_bool Function
+%1813 = OpVariable %_ptr_Function_ulong Function
+%1814 = OpVariable %_ptr_Function_ulong Function
+%1815 = OpVariable %_ptr_Function_ulong Function
+%1816 = OpVariable %_ptr_Function_ulong Function
+%1817 = OpVariable %_ptr_Function_ulong Function
+%1818 = OpVariable %_ptr_Function_ulong Function
+%1819 = OpVariable %_ptr_Function_ulong Function
+%1820 = OpVariable %_ptr_Function_ulong Function
+%1821 = OpVariable %_ptr_Function_ulong Function
+%1822 = OpVariable %_ptr_Function_bool Function
+%1823 = OpVariable %_ptr_Function_ulong Function
+%1824 = OpVariable %_ptr_Function_ulong Function
+%1825 = OpVariable %_ptr_Function_ulong Function
+%1826 = OpVariable %_ptr_Function_ulong Function
+%1827 = OpVariable %_ptr_Function_ulong Function
+%1828 = OpVariable %_ptr_Function_ulong Function
+%1829 = OpVariable %_ptr_Function_ulong Function
+%1830 = OpVariable %_ptr_Function_ulong Function
+%1831 = OpVariable %_ptr_Function_ulong Function
+%1832 = OpVariable %_ptr_Function_ulong Function
+%1833 = OpVariable %_ptr_Function_ulong Function
+%1834 = OpVariable %_ptr_Function_ulong Function
+%1835 = OpVariable %_ptr_Function_ulong Function
+%1836 = OpVariable %_ptr_Function_ulong Function
+%1837 = OpVariable %_ptr_Function_ulong Function
+%1838 = OpVariable %_ptr_Function_ulong Function
+%1839 = OpVariable %_ptr_Function_ulong Function
+%1840 = OpVariable %_ptr_Function_ulong Function
+%1841 = OpVariable %_ptr_Function_ulong Function
+%1842 = OpVariable %_ptr_Function_uint Function
+%1843 = OpVariable %_ptr_Function_ulong Function
+%1844 = OpVariable %_ptr_Function_ulong Function
+%1845 = OpVariable %_ptr_Function_ulong Function
+%1846 = OpVariable %_ptr_Function_ulong Function
+%1847 = OpVariable %_ptr_Function_ulong Function
+%1848 = OpVariable %_ptr_Function_ulong Function
+%1849 = OpVariable %_ptr_Function_ulong Function
+%1850 = OpVariable %_ptr_Function_ulong Function
+%1851 = OpVariable %_ptr_Function_ulong Function
+%1852 = OpVariable %_ptr_Function_ulong Function
+%1853 = OpVariable %_ptr_Function_ulong Function
+%1854 = OpVariable %_ptr_Function_ulong Function
+%1855 = OpVariable %_ptr_Function_ulong Function
+%1856 = OpVariable %_ptr_Function_ulong Function
+%1857 = OpVariable %_ptr_Function_ulong Function
+%1858 = OpVariable %_ptr_Function_ulong Function
+%1859 = OpVariable %_ptr_Function_double Function
+%1860 = OpVariable %_ptr_Function_double Function
+%1861 = OpVariable %_ptr_Function_ulong Function
+%1862 = OpVariable %_ptr_Function_double Function
+%1863 = OpVariable %_ptr_Function_double Function
+%1864 = OpVariable %_ptr_Function_ulong Function
+%1865 = OpVariable %_ptr_Function_double Function
+%1866 = OpVariable %_ptr_Function_double Function
+%1867 = OpVariable %_ptr_Function_ulong Function
+%1868 = OpVariable %_ptr_Function_ulong Function
+%1869 = OpVariable %_ptr_Function_ulong Function
+%1870 = OpVariable %_ptr_Function_ulong Function
+%1871 = OpVariable %_ptr_Function_ulong Function
+%1872 = OpVariable %_ptr_Function_ulong Function
+%1873 = OpVariable %_ptr_Function_bool Function
+%1874 = OpVariable %_ptr_Function_ulong Function
+%1875 = OpVariable %_ptr_Function_ulong Function
+%1876 = OpVariable %_ptr_Function_ulong Function
+%1877 = OpVariable %_ptr_Function_ulong Function
+%1878 = OpVariable %_ptr_Function_ulong Function
+%1879 = OpVariable %_ptr_Function_ulong Function
+%1880 = OpVariable %_ptr_Function_ulong Function
+%1881 = OpVariable %_ptr_Function_ulong Function
+%1882 = OpVariable %_ptr_Function_ulong Function
+%1883 = OpVariable %_ptr_Function_bool Function
+%1884 = OpVariable %_ptr_Function_ulong Function
+%1885 = OpVariable %_ptr_Function_ulong Function
+%1886 = OpVariable %_ptr_Function_ulong Function
+%1887 = OpVariable %_ptr_Function_ulong Function
+%1888 = OpVariable %_ptr_Function_ulong Function
+%1889 = OpVariable %_ptr_Function_ulong Function
+%1890 = OpVariable %_ptr_Function_ulong Function
+%1891 = OpVariable %_ptr_Function_ulong Function
+%1892 = OpVariable %_ptr_Function_ulong Function
+%1893 = OpVariable %_ptr_Function_bool Function
+%1894 = OpVariable %_ptr_Function_ulong Function
+%1895 = OpVariable %_ptr_Function_ulong Function
+%1896 = OpVariable %_ptr_Function_ulong Function
+%1897 = OpVariable %_ptr_Function_ulong Function
+%1898 = OpVariable %_ptr_Function_ulong Function
+%1899 = OpVariable %_ptr_Function_ulong Function
+%1900 = OpVariable %_ptr_Function_ulong Function
+%1901 = OpVariable %_ptr_Function_ulong Function
+%1902 = OpVariable %_ptr_Function_ulong Function
+%1903 = OpVariable %_ptr_Function_ulong Function
+%1904 = OpVariable %_ptr_Function_ulong Function
+%1905 = OpVariable %_ptr_Function_ulong Function
+%1906 = OpVariable %_ptr_Function_ulong Function
+%1907 = OpVariable %_ptr_Function_ulong Function
+%1908 = OpVariable %_ptr_Function_ulong Function
+%1909 = OpVariable %_ptr_Function_ulong Function
+%1910 = OpVariable %_ptr_Function_ulong Function
+%1911 = OpVariable %_ptr_Function_ulong Function
+%1912 = OpVariable %_ptr_Function_ulong Function
+%1913 = OpVariable %_ptr_Function_ulong Function
+%1914 = OpVariable %_ptr_Function_ulong Function
+%1915 = OpVariable %_ptr_Function_double Function
+%1916 = OpVariable %_ptr_Function_double Function
+%1917 = OpVariable %_ptr_Function_uint Function
+%1918 = OpVariable %_ptr_Function_ulong Function
+%1919 = OpVariable %_ptr_Function_uint Function
+%1920 = OpVariable %_ptr_Function_ulong Function
+%1921 = OpVariable %_ptr_Function_double Function
+%1922 = OpVariable %_ptr_Function_double Function
+%1923 = OpVariable %_ptr_Function_ulong Function
+%1924 = OpVariable %_ptr_Function_ulong Function
+%1925 = OpVariable %_ptr_Function_ulong Function
+%1926 = OpVariable %_ptr_Function_ulong Function
+%1927 = OpVariable %_ptr_Function_ulong Function
+%1928 = OpVariable %_ptr_Function_ulong Function
+%1929 = OpVariable %_ptr_Function_ulong Function
+%1930 = OpVariable %_ptr_Function_bool Function
+%1931 = OpVariable %_ptr_Function_ulong Function
+%1932 = OpVariable %_ptr_Function_ulong Function
+%1933 = OpVariable %_ptr_Function_ulong Function
+%1934 = OpVariable %_ptr_Function_ulong Function
+%1935 = OpVariable %_ptr_Function_ulong Function
+%1936 = OpVariable %_ptr_Function_ulong Function
+%1937 = OpVariable %_ptr_Function_ulong Function
+%1938 = OpVariable %_ptr_Function_ulong Function
+%1939 = OpVariable %_ptr_Function_ulong Function
+%1940 = OpVariable %_ptr_Function_ulong Function
+%1941 = OpVariable %_ptr_Function_ulong Function
+%1942 = OpVariable %_ptr_Function_ulong Function
+%1943 = OpVariable %_ptr_Function_ulong Function
+%1944 = OpVariable %_ptr_Function_ulong Function
+%1945 = OpVariable %_ptr_Function_ulong Function
+%1946 = OpVariable %_ptr_Function_ulong Function
+%1947 = OpVariable %_ptr_Function_ulong Function
+%1948 = OpVariable %_ptr_Function_ulong Function
+%1949 = OpVariable %_ptr_Function_ulong Function
+%1950 = OpVariable %_ptr_Function_ulong Function
+%1951 = OpVariable %_ptr_Function_ulong Function
+%1952 = OpVariable %_ptr_Function_ulong Function
+%1953 = OpVariable %_ptr_Function_ulong Function
+%1954 = OpVariable %_ptr_Function_ulong Function
+%1955 = OpVariable %_ptr_Function_ulong Function
+%1956 = OpVariable %_ptr_Function_ulong Function
+%1957 = OpVariable %_ptr_Function_ulong Function
+%1958 = OpVariable %_ptr_Function_ulong Function
+%1959 = OpVariable %_ptr_Function_ulong Function
+%1960 = OpVariable %_ptr_Function_ulong Function
+%1961 = OpVariable %_ptr_Function_uint Function
+%1962 = OpVariable %_ptr_Function_ulong Function
+%1963 = OpVariable %_ptr_Function_ulong Function
+%1964 = OpVariable %_ptr_Function_ulong Function
+%1965 = OpVariable %_ptr_Function_ulong Function
+%1966 = OpVariable %_ptr_Function_ulong Function
+%1967 = OpVariable %_ptr_Function_uint Function
+%1968 = OpVariable %_ptr_Function_ulong Function
+%1969 = OpVariable %_ptr_Function_ulong Function
+%1970 = OpVariable %_ptr_Function_ulong Function
+%1971 = OpVariable %_ptr_Function_ulong Function
+%1972 = OpVariable %_ptr_Function_ulong Function
+%1973 = OpVariable %_ptr_Function_ulong Function
+%1974 = OpVariable %_ptr_Function_ulong Function
+%1975 = OpVariable %_ptr_Function_ulong Function
+%1976 = OpVariable %_ptr_Function_ulong Function
+%1977 = OpVariable %_ptr_Function_ulong Function
+%1978 = OpVariable %_ptr_Function_ulong Function
+%1979 = OpVariable %_ptr_Function_ulong Function
+%1980 = OpVariable %_ptr_Function_ulong Function
+%1981 = OpVariable %_ptr_Function_ulong Function
+%1982 = OpVariable %_ptr_Function_ulong Function
+%1983 = OpVariable %_ptr_Function_ulong Function
+%1984 = OpVariable %_ptr_Function_ulong Function
+%1985 = OpVariable %_ptr_Function_ulong Function
+%1986 = OpVariable %_ptr_Function_ulong Function
+%1987 = OpVariable %_ptr_Function_ulong Function
+%1988 = OpVariable %_ptr_Function_ulong Function
+%1989 = OpVariable %_ptr_Function_ulong Function
+%1990 = OpVariable %_ptr_Function_ulong Function
+%1991 = OpVariable %_ptr_Function_ulong Function
+%1992 = OpVariable %_ptr_Function_ulong Function
+%1993 = OpVariable %_ptr_Function_ulong Function
+%1994 = OpVariable %_ptr_Function_ulong Function
+%1995 = OpVariable %_ptr_Function_ulong Function
+%1996 = OpVariable %_ptr_Function_ulong Function
+%1997 = OpVariable %_ptr_Function_ulong Function
+%1998 = OpVariable %_ptr_Function_ulong Function
+OpStore %1686 %1459
+OpBranch %1482
+%1482 = OpLabel
+OpBranch %1483
+%1483 = OpLabel
+OpBranch %1502
+%1502 = OpLabel
+%1999 = OpFunctionCall %ulong %23 %ulong_14695981039346656037 %ulong_20
+OpStore %1772 %1999
+%2000 = OpLoad %ulong %1772
+%2001 = OpFunctionCall %ulong %23 %2000 %ulong_24
+OpStore %1773 %2001
+%2002 = OpLoad %ulong %1773
+%2003 = OpFunctionCall %ulong %23 %2002 %ulong_24
+OpStore %1774 %2003
+%2004 = OpLoad %ulong %1774
+%2005 = OpFunctionCall %ulong %23 %2004 %ulong_32
+OpStore %1775 %2005
+%2006 = OpLoad %ulong %1775
+%2007 = OpFunctionCall %ulong %23 %2006 %ulong_40
+OpStore %1776 %2007
+%2008 = OpLoad %ulong %1776
+%2009 = OpFunctionCall %ulong %23 %2008 %ulong_48
+OpStore %1777 %2009
+%2010 = OpLoad %ulong %1777
+%2011 = OpFunctionCall %ulong %23 %2010 %ulong_48
+OpStore %1778 %2011
+%2012 = OpLoad %ulong %1778
+%2013 = OpFunctionCall %ulong %23 %2012 %ulong_8
+OpStore %1779 %2013
+%2014 = OpLoad %ulong %1779
+%2015 = OpFunctionCall %ulong %23 %2014 %ulong_32
+OpStore %1780 %2015
+OpBranch %1503
+%1503 = OpLabel
+OpStore %1659 %2016
+OpStore %1727 %ulong_0
+OpBranch %1461
+%1461 = OpLabel
+%2017 = OpLoad %ulong %1727
+%2018 = OpULessThan %bool %2017 %ulong_8
+OpStore %1687 %2018
+%2019 = OpLoad %bool %1687
+OpLoopMerge %1463 %1638 None
+OpBranchConditional %2019 %1462 %1463
+%1463 = OpLabel
+%2020 = OpLoad %ulong %1780
+OpStore %1726 %2020
+OpStore %1733 %ulong_0
+OpBranch %1464
+%1464 = OpLabel
+%2021 = OpLoad %ulong %1733
+%2022 = OpULessThan %bool %2021 %ulong_8
+OpStore %1689 %2022
+%2023 = OpLoad %bool %1689
+OpLoopMerge %1466 %1637 None
+OpBranchConditional %2023 %1465 %1466
+%1466 = OpLabel
+%2024 = OpLoad %ulong %1686
+%2025 = OpIAdd %ulong %2024 %ulong_1
+OpStore %1695 %2025
+OpBranch %1488
+%1488 = OpLabel
+%2026 = OpAccessChain %_ptr_Function_ulong %1649 %uint_0
+%2027 = OpLoad %ulong %1695
+OpStore %2026 %2027
+%2028 = OpLoad %ulong %1695
+%2029 = OpNot %ulong %2028
+OpStore %1746 %2029
+%2030 = OpAccessChain %_ptr_Function_ulong %1649 %uint_1
+%2031 = OpLoad %ulong %1746
+OpStore %2030 %2031
+%2032 = OpLoad %ulong %1695
+%2033 = OpIMul %ulong %2032 %ulong_3
+OpStore %1747 %2033
+%2034 = OpLoad %ulong %1747
+%2035 = OpIAdd %ulong %2034 %ulong_1
+OpStore %1748 %2035
+%2036 = OpAccessChain %_ptr_Function_ulong %1649 %uint_2
+%2037 = OpLoad %ulong %1748
+OpStore %2036 %2037
+OpBranch %1489
+%1489 = OpLabel
+%2038 = OpLoad %_struct_283 %1649
+OpStore %1639 %2038
+%2039 = OpLoad %ulong %1726
+OpStore %1725 %2039
+OpStore %1732 %ulong_0
+OpBranch %1467
+%1467 = OpLabel
+%2040 = OpLoad %ulong %1732
+%2041 = OpULessThan %bool %2040 %ulong_8
+OpStore %1696 %2041
+%2042 = OpLoad %bool %1696
+OpLoopMerge %1469 %1636 None
+OpBranchConditional %2042 %1468 %1469
+%1469 = OpLabel
+%2043 = OpLoad %ulong %1686
+%2044 = OpIAdd %ulong %2043 %ulong_2
+OpStore %1700 %2044
+OpBranch %1492
+%1492 = OpLabel
+%2045 = OpAccessChain %_ptr_Function_ulong %1652 %uint_0
+%2046 = OpLoad %ulong %1700
+OpStore %2045 %2046
+%2047 = OpLoad %ulong %1700
+%2048 = OpIAdd %ulong %2047 %ulong_1
+OpStore %1752 %2048
+%2049 = OpAccessChain %_ptr_Function_ulong %1652 %uint_1
+%2050 = OpLoad %ulong %1752
+OpStore %2049 %2050
+%2051 = OpLoad %ulong %1700
+%2052 = OpIAdd %ulong %2051 %ulong_2
+OpStore %1753 %2052
+%2053 = OpAccessChain %_ptr_Function_ulong %1652 %uint_2
+%2054 = OpLoad %ulong %1753
+OpStore %2053 %2054
+%2055 = OpLoad %ulong %1700
+%2056 = OpIMul %ulong %2055 %ulong_9
+OpStore %1754 %2056
+%2057 = OpAccessChain %_ptr_Function_ulong %1652 %uint_3
+%2058 = OpLoad %ulong %1754
+OpStore %2057 %2058
+%2059 = OpLoad %ulong %1700
+%2060 = OpNot %ulong %2059
+OpStore %1755 %2060
+%2061 = OpAccessChain %_ptr_Function_ulong %1652 %uint_4
+%2062 = OpLoad %ulong %1755
+OpStore %2061 %2062
+%2063 = OpLoad %ulong %1700
+%2064 = OpBitwiseXor %ulong %2063 %ulong_2863311530
+OpStore %1756 %2064
+%2065 = OpAccessChain %_ptr_Function_ulong %1652 %uint_5
+%2066 = OpLoad %ulong %1756
+OpStore %2065 %2066
+OpBranch %1493
+%1493 = OpLabel
+%2067 = OpLoad %_struct_810 %1652
+OpStore %1640 %2067
+%2068 = OpLoad %ulong %1725
+OpStore %1724 %2068
+OpStore %1731 %ulong_0
+OpBranch %1470
+%1470 = OpLabel
+%2069 = OpLoad %ulong %1731
+%2070 = OpULessThan %bool %2069 %ulong_8
+OpStore %1701 %2070
+%2071 = OpLoad %bool %1701
+OpLoopMerge %1472 %1634 None
+OpBranchConditional %2071 %1471 %1472
+%1472 = OpLabel
+OpStore %1646 %2072
+OpStore %1730 %ulong_0
+OpBranch %1473
+%1473 = OpLabel
+%2073 = OpLoad %ulong %1730
+%2075 = OpULessThan %bool %2073 %ulong_6
+OpStore %1704 %2075
+%2076 = OpLoad %bool %1704
+OpLoopMerge %1475 %1633 None
+OpBranchConditional %2076 %1474 %1475
+%1475 = OpLabel
+%2077 = OpLoad %ulong %1724
+OpStore %1723 %2077
+OpStore %1729 %ulong_0
+OpBranch %1476
+%1476 = OpLabel
+%2078 = OpLoad %ulong %1729
+%2079 = OpULessThan %bool %2078 %ulong_6
+OpStore %1708 %2079
+%2080 = OpLoad %bool %1708
+OpLoopMerge %1478 %1632 None
+OpBranchConditional %2080 %1477 %1478
+%1478 = OpLabel
+OpStore %1648 %2081
+%2082 = OpAccessChain %_ptr_Function_uint %1648 %uint_0
+OpStore %2082 %uint_305419896
+%2084 = OpLoad %ulong %1686
+%2085 = OpIAdd %ulong %2084 %ulong_3
+OpStore %1711 %2085
+OpBranch %1498
+%1498 = OpLabel
+%2086 = OpLoad %ulong %1711
+%2087 = OpNot %ulong %2086
+OpStore %1766 %2087
+%2088 = OpLoad %ulong %1711
+%2089 = OpIMul %ulong %2088 %ulong_3
+OpStore %1767 %2089
+%2090 = OpLoad %ulong %1767
+%2091 = OpIAdd %ulong %2090 %ulong_1
+OpStore %1768 %2091
+OpBranch %1499
+%1499 = OpLabel
+%2092 = OpAccessChain %_ptr_Function_ulong %1659 %uint_0
+%2093 = OpLoad %ulong %2092
+OpStore %1712 %2093
+OpBranch %1541
+%1541 = OpLabel
+%2094 = OpLoad %ulong %1711
+%2095 = OpLoad %ulong %1712
+%2096 = OpIAdd %ulong %2094 %2095
+OpStore %1831 %2096
+%2097 = OpAccessChain %_ptr_Function_ulong %1660 %uint_0
+%2098 = OpLoad %ulong %1831
+OpStore %2097 %2098
+%2099 = OpLoad %ulong %1766
+%2100 = OpLoad %ulong %1712
+%2101 = OpBitwiseXor %ulong %2099 %2100
+OpStore %1832 %2101
+%2102 = OpAccessChain %_ptr_Function_ulong %1660 %uint_1
+%2103 = OpLoad %ulong %1832
+OpStore %2102 %2103
+%2104 = OpLoad %ulong %1768
+%2105 = OpLoad %ulong %1711
+%2106 = OpIAdd %ulong %2104 %2105
+OpStore %1833 %2106
+%2107 = OpAccessChain %_ptr_Function_ulong %1660 %uint_2
+%2108 = OpLoad %ulong %1833
+OpStore %2107 %2108
+OpBranch %1542
+%1542 = OpLabel
+%2109 = OpAccessChain %_ptr_Function__struct_283 %1648 %uint_1
+%2110 = OpLoad %_struct_283 %1660
+OpStore %2109 %2110
+%2111 = OpAccessChain %_ptr_Function_ulong %1659 %uint_1
+%2112 = OpLoad %ulong %2111
+OpStore %1713 %2112
+%2113 = OpAccessChain %_ptr_Function_ulong %1661 %uint_0
+%2114 = OpLoad %ulong %1713
+OpStore %2113 %2114
+%2115 = OpAccessChain %_ptr_Function_ulong %1659 %uint_2
+%2116 = OpLoad %ulong %2115
+OpStore %1714 %2116
+%2117 = OpAccessChain %_ptr_Function_ulong %1661 %uint_1
+%2118 = OpLoad %ulong %1714
+OpStore %2117 %2118
+%2119 = OpAccessChain %_ptr_Function__struct_861 %1648 %uint_2
+%2120 = OpLoad %_struct_861 %1661
+OpStore %2119 %2120
+%2121 = OpLoad %_struct_862 %1648
+OpStore %1662 %2121
+OpBranch %1547
+%1547 = OpLabel
+%2122 = OpLoad %_struct_862 %1662
+OpStore %1666 %2122
+%2123 = OpAccessChain %_ptr_Function_uint %1666 %uint_0
+%2124 = OpLoad %uint %2123
+OpStore %1842 %2124
+OpBranch %1548
+%1548 = OpLabel
+%2125 = OpLoad %uint %1842
+%2126 = OpUConvert %ulong %2125
+OpStore %1848 %2126
+%2127 = OpLoad %ulong %1723
+%2128 = OpLoad %ulong %1848
+%2129 = OpFunctionCall %ulong %23 %2127 %2128
+OpStore %1849 %2129
+OpBranch %1549
+%1549 = OpLabel
+%2130 = OpAccessChain %_ptr_Function__struct_283 %1666 %uint_1
+%2131 = OpLoad %_struct_283 %2130
+OpStore %1667 %2131
+%2132 = OpLoad %ulong %1849
+%2133 = OpLoad %_struct_283 %1667
+%2134 = OpFunctionCall %ulong %3 %2132 %2133
+OpStore %1843 %2134
+%2135 = OpAccessChain %_ptr_Function__struct_861 %1666 %uint_2
+%2136 = OpAccessChain %_ptr_Function_ulong %2135 %uint_0
+%2137 = OpLoad %ulong %2136
+OpStore %1844 %2137
+%2138 = OpLoad %ulong %1843
+%2139 = OpLoad %ulong %1844
+%2140 = OpFunctionCall %ulong %23 %2138 %2139
+OpStore %1845 %2140
+%2141 = OpAccessChain %_ptr_Function_ulong %2135 %uint_1
+%2142 = OpLoad %ulong %2141
+OpStore %1846 %2142
+%2143 = OpLoad %ulong %1845
+%2144 = OpLoad %ulong %1846
+%2145 = OpFunctionCall %ulong %23 %2143 %2144
+OpStore %1847 %2145
+OpBranch %1550
+%1550 = OpLabel
+%2146 = OpLoad %ulong %1847
+OpStore %1722 %2146
+OpStore %1728 %ulong_0
+OpBranch %1479
+%1479 = OpLabel
+%2147 = OpLoad %ulong %1728
+%2149 = OpULessThan %bool %2147 %ulong_4
+OpStore %1715 %2149
+%2150 = OpLoad %bool %1715
+OpLoopMerge %1481 %1629 None
+OpBranchConditional %2150 %1480 %1481
+%1481 = OpLabel
+%2151 = OpLoad %ulong %1722
+OpReturnValue %2151
+%1480 = OpLabel
+%2152 = OpLoad %ulong %1728
+%2153 = OpAccessChain %_ptr_Function_ulong %1659 %2152
+%2154 = OpLoad %ulong %2153
+OpStore %1716 %2154
+%2155 = OpLoad %ulong %1716
+%2156 = OpLoad %ulong %1686
+%2157 = OpIAdd %ulong %2155 %2156
+OpStore %1717 %2157
+OpBranch %1500
+%1500 = OpLabel
+%2158 = OpAccessChain %_ptr_Function_ulong %1654 %uint_0
+%2159 = OpLoad %ulong %1717
+OpStore %2158 %2159
+%2160 = OpLoad %ulong %1717
+%2161 = OpNot %ulong %2160
+OpStore %1769 %2161
+%2162 = OpAccessChain %_ptr_Function_ulong %1654 %uint_1
+%2163 = OpLoad %ulong %1769
+OpStore %2162 %2163
+%2164 = OpLoad %ulong %1717
+%2165 = OpIMul %ulong %2164 %ulong_3
+OpStore %1770 %2165
+%2166 = OpLoad %ulong %1770
+%2167 = OpIAdd %ulong %2166 %ulong_1
+OpStore %1771 %2167
+%2168 = OpAccessChain %_ptr_Function_ulong %1654 %uint_2
+%2169 = OpLoad %ulong %1771
+OpStore %2168 %2169
+OpBranch %1501
+%1501 = OpLabel
+%2170 = OpLoad %_struct_283 %1654
+%2171 = OpFunctionCall %_struct_810 %18 %2170
+OpStore %1655 %2171
+OpBranch %1543
+%1543 = OpLabel
+%2172 = OpAccessChain %_ptr_Function_ulong %1663 %uint_0
+%2173 = OpLoad %ulong %1717
+OpStore %2172 %2173
+%2174 = OpLoad %ulong %1717
+%2175 = OpIAdd %ulong %2174 %ulong_1
+OpStore %1834 %2175
+%2176 = OpAccessChain %_ptr_Function_ulong %1663 %uint_1
+%2177 = OpLoad %ulong %1834
+OpStore %2176 %2177
+%2178 = OpLoad %ulong %1717
+%2179 = OpIAdd %ulong %2178 %ulong_2
+OpStore %1835 %2179
+%2180 = OpAccessChain %_ptr_Function_ulong %1663 %uint_2
+%2181 = OpLoad %ulong %1835
+OpStore %2180 %2181
+%2182 = OpLoad %ulong %1717
+%2183 = OpIMul %ulong %2182 %ulong_9
+OpStore %1836 %2183
+%2184 = OpAccessChain %_ptr_Function_ulong %1663 %uint_3
+%2185 = OpLoad %ulong %1836
+OpStore %2184 %2185
+%2186 = OpLoad %ulong %1717
+%2187 = OpNot %ulong %2186
+OpStore %1837 %2187
+%2188 = OpAccessChain %_ptr_Function_ulong %1663 %uint_4
+%2189 = OpLoad %ulong %1837
+OpStore %2188 %2189
+%2190 = OpLoad %ulong %1717
+%2191 = OpBitwiseXor %ulong %2190 %ulong_2863311530
+OpStore %1838 %2191
+%2192 = OpAccessChain %_ptr_Function_ulong %1663 %uint_5
+%2193 = OpLoad %ulong %1838
+OpStore %2192 %2193
+OpBranch %1544
+%1544 = OpLabel
+%2194 = OpLoad %_struct_810 %1663
+%2195 = OpFunctionCall %_struct_283 %19 %2194
+OpStore %1664 %2195
+OpBranch %1551
+%1551 = OpLabel
+%2196 = OpAccessChain %_ptr_Function_ulong %1655 %uint_0
+%2197 = OpLoad %ulong %2196
+OpStore %1984 %2197
+%2198 = OpAccessChain %_ptr_Function_ulong %1655 %uint_1
+%2199 = OpLoad %ulong %2198
+OpStore %1985 %2199
+%2200 = OpAccessChain %_ptr_Function_ulong %1655 %uint_2
+%2201 = OpLoad %ulong %2200
+OpStore %1986 %2201
+%2202 = OpAccessChain %_ptr_Function_ulong %1655 %uint_3
+%2203 = OpLoad %ulong %2202
+OpStore %1987 %2203
+%2204 = OpAccessChain %_ptr_Function_ulong %1655 %uint_4
+%2205 = OpLoad %ulong %2204
+OpStore %1988 %2205
+%2206 = OpAccessChain %_ptr_Function_ulong %1655 %uint_5
+%2207 = OpLoad %ulong %2206
+OpStore %1989 %2207
+%2208 = OpLoad %_struct_283 %1664
+OpStore %1668 %2208
+OpBranch %1552
+%1552 = OpLabel
+OpBranch %1553
+%1553 = OpLabel
+OpBranch %1554
+%1554 = OpLabel
+%2209 = OpLoad %ulong %1984
+%2210 = OpFunctionCall %ulong %23 %ulong_14695981039346656037 %2209
+OpStore %1852 %2210
+%2211 = OpLoad %ulong %1852
+%2212 = OpLoad %ulong %1985
+%2213 = OpFunctionCall %ulong %23 %2211 %2212
+OpStore %1853 %2213
+%2214 = OpLoad %ulong %1853
+%2215 = OpLoad %ulong %1986
+%2216 = OpFunctionCall %ulong %23 %2214 %2215
+OpStore %1854 %2216
+%2217 = OpLoad %ulong %1854
+%2218 = OpLoad %ulong %1987
+%2219 = OpFunctionCall %ulong %23 %2217 %2218
+OpStore %1855 %2219
+%2220 = OpLoad %ulong %1855
+%2221 = OpLoad %ulong %1988
+%2222 = OpFunctionCall %ulong %23 %2220 %2221
+OpStore %1856 %2222
+%2223 = OpLoad %ulong %1856
+%2224 = OpLoad %ulong %1989
+%2225 = OpFunctionCall %ulong %23 %2223 %2224
+OpStore %1857 %2225
+OpBranch %1555
+%1555 = OpLabel
+%2226 = OpLoad %_struct_283 %1668
+OpStore %1669 %2226
+%2227 = OpLoad %ulong %1857
+%2228 = OpLoad %_struct_283 %1669
+%2229 = OpFunctionCall %ulong %3 %2227 %2228
+OpStore %1850 %2229
+%2230 = OpLoad %ulong %1850
+%2231 = OpLoad %ulong %1717
+%2232 = OpFunctionCall %ulong %23 %2230 %2231
+OpStore %1851 %2232
+OpBranch %1556
+%1556 = OpLabel
+%2233 = OpLoad %ulong %1722
+%2234 = OpLoad %ulong %1851
+%2235 = OpFunctionCall %ulong %23 %2233 %2234
+OpStore %1718 %2235
+OpBranch %1559
+%1559 = OpLabel
+%2236 = OpAccessChain %_ptr_Function_ulong %1670 %uint_0
+%2237 = OpLoad %ulong %1717
+OpStore %2236 %2237
+%2238 = OpLoad %ulong %1717
+%2239 = OpIAdd %ulong %2238 %ulong_1
+OpStore %1867 %2239
+%2240 = OpAccessChain %_ptr_Function_ulong %1670 %uint_1
+%2241 = OpLoad %ulong %1867
+OpStore %2240 %2241
+%2242 = OpLoad %ulong %1717
+%2243 = OpIAdd %ulong %2242 %ulong_2
+OpStore %1868 %2243
+%2244 = OpAccessChain %_ptr_Function_ulong %1670 %uint_2
+%2245 = OpLoad %ulong %1868
+OpStore %2244 %2245
+%2246 = OpLoad %ulong %1717
+%2247 = OpIMul %ulong %2246 %ulong_9
+OpStore %1869 %2247
+%2248 = OpAccessChain %_ptr_Function_ulong %1670 %uint_3
+%2249 = OpLoad %ulong %1869
+OpStore %2248 %2249
+%2250 = OpLoad %ulong %1717
+%2251 = OpNot %ulong %2250
+OpStore %1870 %2251
+%2252 = OpAccessChain %_ptr_Function_ulong %1670 %uint_4
+%2253 = OpLoad %ulong %1870
+OpStore %2252 %2253
+%2254 = OpLoad %ulong %1717
+%2255 = OpBitwiseXor %ulong %2254 %ulong_2863311530
+OpStore %1871 %2255
+%2256 = OpAccessChain %_ptr_Function_ulong %1670 %uint_5
+%2257 = OpLoad %ulong %1871
+OpStore %2256 %2257
+OpBranch %1560
+%1560 = OpLabel
+%2258 = OpLoad %_struct_810 %1670
+%2259 = OpFunctionCall %_struct_283 %19 %2258
+OpStore %1671 %2259
+%2260 = OpLoad %_struct_283 %1671
+%2261 = OpFunctionCall %_struct_810 %18 %2260
+OpStore %1672 %2261
+OpBranch %1584
+%1584 = OpLabel
+%2262 = OpAccessChain %_ptr_Function_ulong %1672 %uint_0
+%2263 = OpLoad %ulong %2262
+OpStore %1990 %2263
+%2264 = OpAccessChain %_ptr_Function_ulong %1672 %uint_1
+%2265 = OpLoad %ulong %2264
+OpStore %1991 %2265
+%2266 = OpAccessChain %_ptr_Function_ulong %1672 %uint_2
+%2267 = OpLoad %ulong %2266
+OpStore %1992 %2267
+%2268 = OpAccessChain %_ptr_Function_ulong %1672 %uint_3
+%2269 = OpLoad %ulong %2268
+OpStore %1993 %2269
+%2270 = OpAccessChain %_ptr_Function_ulong %1672 %uint_4
+%2271 = OpLoad %ulong %2270
+OpStore %1994 %2271
+%2272 = OpAccessChain %_ptr_Function_ulong %1672 %uint_5
+%2273 = OpLoad %ulong %2272
+OpStore %1995 %2273
+%2274 = OpLoad %ulong %1718
+%2275 = OpLoad %ulong %1990
+%2276 = OpFunctionCall %ulong %23 %2274 %2275
+OpStore %1902 %2276
+%2277 = OpLoad %ulong %1902
+%2278 = OpLoad %ulong %1991
+%2279 = OpFunctionCall %ulong %23 %2277 %2278
+OpStore %1903 %2279
+%2280 = OpLoad %ulong %1903
+%2281 = OpLoad %ulong %1992
+%2282 = OpFunctionCall %ulong %23 %2280 %2281
+OpStore %1904 %2282
+%2283 = OpLoad %ulong %1904
+%2284 = OpLoad %ulong %1993
+%2285 = OpFunctionCall %ulong %23 %2283 %2284
+OpStore %1905 %2285
+%2286 = OpLoad %ulong %1905
+%2287 = OpLoad %ulong %1994
+%2288 = OpFunctionCall %ulong %23 %2286 %2287
+OpStore %1906 %2288
+%2289 = OpLoad %ulong %1906
+%2290 = OpLoad %ulong %1995
+%2291 = OpFunctionCall %ulong %23 %2289 %2290
+OpStore %1907 %2291
+OpBranch %1585
+%1585 = OpLabel
+OpBranch %1588
+%1588 = OpLabel
+%2292 = OpAccessChain %_ptr_Function_ulong %1674 %uint_0
+%2293 = OpLoad %ulong %1717
+OpStore %2292 %2293
+%2294 = OpLoad %ulong %1717
+%2295 = OpNot %ulong %2294
+OpStore %1911 %2295
+%2296 = OpAccessChain %_ptr_Function_ulong %1674 %uint_1
+%2297 = OpLoad %ulong %1911
+OpStore %2296 %2297
+%2298 = OpLoad %ulong %1717
+%2299 = OpIMul %ulong %2298 %ulong_3
+OpStore %1912 %2299
+%2300 = OpLoad %ulong %1912
+%2301 = OpIAdd %ulong %2300 %ulong_1
+OpStore %1913 %2301
+%2302 = OpAccessChain %_ptr_Function_ulong %1674 %uint_2
+%2303 = OpLoad %ulong %1913
+OpStore %2302 %2303
+OpBranch %1589
+%1589 = OpLabel
+%2304 = OpLoad %_struct_283 %1674
+%2305 = OpFunctionCall %_struct_810 %18 %2304
+OpStore %1675 %2305
+%2306 = OpLoad %_struct_810 %1675
+%2307 = OpFunctionCall %_struct_283 %19 %2306
+OpStore %1676 %2307
+%2308 = OpLoad %ulong %1907
+%2309 = OpLoad %_struct_283 %1676
+%2310 = OpFunctionCall %ulong %3 %2308 %2309
+OpStore %1719 %2310
+OpBranch %1592
+%1592 = OpLabel
+%2311 = OpAccessChain %_ptr_Function_ulong %1677 %uint_0
+%2312 = OpLoad %ulong %1717
+OpStore %2311 %2312
+%2313 = OpLoad %ulong %1717
+%2314 = OpIAdd %ulong %2313 %ulong_1
+OpStore %1924 %2314
+%2315 = OpAccessChain %_ptr_Function_ulong %1677 %uint_1
+%2316 = OpLoad %ulong %1924
+OpStore %2315 %2316
+%2317 = OpLoad %ulong %1717
+%2318 = OpIAdd %ulong %2317 %ulong_2
+OpStore %1925 %2318
+%2319 = OpAccessChain %_ptr_Function_ulong %1677 %uint_2
+%2320 = OpLoad %ulong %1925
+OpStore %2319 %2320
+%2321 = OpLoad %ulong %1717
+%2322 = OpIMul %ulong %2321 %ulong_9
+OpStore %1926 %2322
+%2323 = OpAccessChain %_ptr_Function_ulong %1677 %uint_3
+%2324 = OpLoad %ulong %1926
+OpStore %2323 %2324
+%2325 = OpLoad %ulong %1717
+%2326 = OpNot %ulong %2325
+OpStore %1927 %2326
+%2327 = OpAccessChain %_ptr_Function_ulong %1677 %uint_4
+%2328 = OpLoad %ulong %1927
+OpStore %2327 %2328
+%2329 = OpLoad %ulong %1717
+%2330 = OpBitwiseXor %ulong %2329 %ulong_2863311530
+OpStore %1928 %2330
+%2331 = OpAccessChain %_ptr_Function_ulong %1677 %uint_5
+%2332 = OpLoad %ulong %1928
+OpStore %2331 %2332
+OpBranch %1593
+%1593 = OpLabel
+%2333 = OpLoad %_struct_810 %1677
+%2334 = OpLoad %ulong %1717
+%2335 = OpFunctionCall %_struct_810 %17 %2333 %2334
+OpStore %1678 %2335
+%2336 = OpLoad %_struct_810 %1678
+%2337 = OpFunctionCall %_struct_283 %19 %2336
+OpStore %1679 %2337
+OpBranch %1609
+%1609 = OpLabel
+%2338 = OpAccessChain %_ptr_Function_ulong %1679 %uint_0
+%2339 = OpLoad %ulong %2338
+OpStore %1996 %2339
+%2340 = OpAccessChain %_ptr_Function_ulong %1679 %uint_1
+%2341 = OpLoad %ulong %2340
+OpStore %1997 %2341
+%2342 = OpAccessChain %_ptr_Function_ulong %1679 %uint_2
+%2343 = OpLoad %ulong %2342
+OpStore %1998 %2343
+%2344 = OpLoad %ulong %1996
+%2345 = OpLoad %ulong %1717
+%2346 = OpIAdd %ulong %2344 %2345
+OpStore %1947 %2346
+%2347 = OpAccessChain %_ptr_Function_ulong %1680 %uint_0
+%2348 = OpLoad %ulong %1947
+OpStore %2347 %2348
+%2349 = OpLoad %ulong %1997
+%2350 = OpLoad %ulong %1717
+%2351 = OpBitwiseXor %ulong %2349 %2350
+OpStore %1948 %2351
+%2352 = OpAccessChain %_ptr_Function_ulong %1680 %uint_1
+%2353 = OpLoad %ulong %1948
+OpStore %2352 %2353
+%2354 = OpLoad %ulong %1998
+%2355 = OpLoad %ulong %1996
+%2356 = OpIAdd %ulong %2354 %2355
+OpStore %1949 %2356
+%2357 = OpAccessChain %_ptr_Function_ulong %1680 %uint_2
+%2358 = OpLoad %ulong %1949
+OpStore %2357 %2358
+OpBranch %1610
+%1610 = OpLabel
+%2359 = OpLoad %ulong %1719
+%2360 = OpLoad %_struct_283 %1680
+%2361 = OpFunctionCall %ulong %3 %2359 %2360
+OpStore %1720 %2361
+%2362 = OpLoad %ulong %1728
+%2363 = OpIAdd %ulong %2362 %ulong_1
+OpStore %1721 %2363
+%2364 = OpLoad %ulong %1720
+OpStore %1722 %2364
+%2365 = OpLoad %ulong %1721
+OpStore %1728 %2365
+OpBranch %1629
+%1477 = OpLabel
+%2366 = OpLoad %ulong %1729
+%2367 = OpAccessChain %_ptr_Function__struct_546 %1646 %2366
+%2368 = OpLoad %_struct_546 %2367
+OpStore %1647 %2368
+%2369 = OpLoad %ulong %1723
+%2370 = OpLoad %_struct_546 %1647
+%2371 = OpFunctionCall %ulong %5 %2369 %2370
+OpStore %1709 %2371
+%2372 = OpLoad %ulong %1729
+%2373 = OpIAdd %ulong %2372 %ulong_1
+OpStore %1710 %2373
+%2374 = OpLoad %ulong %1709
+OpStore %1723 %2374
+%2375 = OpLoad %ulong %1710
+OpStore %1729 %2375
+OpBranch %1632
+%1474 = OpLabel
+%2376 = OpLoad %ulong %1730
+%2377 = OpAccessChain %_ptr_Function_ulong %1659 %2376
+%2378 = OpLoad %ulong %2377
+OpStore %1705 %2378
+%2379 = OpLoad %ulong %1705
+%2380 = OpLoad %ulong %1686
+%2381 = OpIAdd %ulong %2379 %2380
+OpStore %1706 %2381
+OpBranch %1496
+%1496 = OpLabel
+%2382 = OpAccessChain %_ptr_Function_ulong %1653 %uint_0
+%2383 = OpLoad %ulong %1706
+OpStore %2382 %2383
+%2384 = OpLoad %ulong %1706
+%2385 = OpIAdd %ulong %2384 %ulong_1
+OpStore %1763 %2385
+%2386 = OpAccessChain %_ptr_Function_ulong %1653 %uint_1
+%2387 = OpLoad %ulong %1763
+OpStore %2386 %2387
+%2388 = OpLoad %ulong %1706
+%2389 = OpIMul %ulong %2388 %ulong_5
+OpStore %1764 %2389
+%2390 = OpAccessChain %_ptr_Function_ulong %1653 %uint_2
+%2391 = OpLoad %ulong %1764
+OpStore %2390 %2391
+%2392 = OpLoad %ulong %1706
+%2393 = OpNot %ulong %2392
+OpStore %1765 %2393
+%2394 = OpAccessChain %_ptr_Function_ulong %1653 %uint_3
+%2395 = OpLoad %ulong %1765
+OpStore %2394 %2395
+OpBranch %1497
+%1497 = OpLabel
+%2396 = OpLoad %ulong %1730
+%2397 = OpAccessChain %_ptr_Function__struct_546 %1646 %2396
+%2398 = OpLoad %_struct_546 %1653
+OpStore %2397 %2398
+%2399 = OpLoad %ulong %1730
+%2400 = OpIAdd %ulong %2399 %ulong_1
+OpStore %1707 %2400
+%2401 = OpLoad %ulong %1707
+OpStore %1730 %2401
+OpBranch %1633
+%1471 = OpLabel
+%2402 = OpLoad %_struct_810 %1640
+OpStore %1641 %2402
+%2403 = OpLoad %ulong %1731
+%2404 = OpAccessChain %_ptr_Function_ulong %1659 %2403
+%2405 = OpLoad %ulong %2404
+OpStore %1702 %2405
+%2406 = OpLoad %_struct_810 %1641
+%2407 = OpLoad %ulong %1702
+%2408 = OpFunctionCall %_struct_810 %17 %2406 %2407
+OpStore %1642 %2408
+%2409 = OpLoad %_struct_810 %1642
+OpStore %1640 %2409
+%2410 = OpAccessChain %_ptr_Function_ulong %1640 %uint_0
+%2411 = OpLoad %ulong %2410
+OpStore %1978 %2411
+%2412 = OpAccessChain %_ptr_Function_ulong %1640 %uint_1
+%2413 = OpLoad %ulong %2412
+OpStore %1979 %2413
+%2414 = OpAccessChain %_ptr_Function_ulong %1640 %uint_2
+%2415 = OpLoad %ulong %2414
+OpStore %1980 %2415
+%2416 = OpAccessChain %_ptr_Function_ulong %1640 %uint_3
+%2417 = OpLoad %ulong %2416
+OpStore %1981 %2417
+%2418 = OpAccessChain %_ptr_Function_ulong %1640 %uint_4
+%2419 = OpLoad %ulong %2418
+OpStore %1982 %2419
+%2420 = OpAccessChain %_ptr_Function_ulong %1640 %uint_5
+%2421 = OpLoad %ulong %2420
+OpStore %1983 %2421
+OpBranch %1494
+%1494 = OpLabel
+%2422 = OpLoad %ulong %1724
+%2423 = OpLoad %ulong %1978
+%2424 = OpFunctionCall %ulong %23 %2422 %2423
+OpStore %1757 %2424
+%2425 = OpLoad %ulong %1757
+%2426 = OpLoad %ulong %1979
+%2427 = OpFunctionCall %ulong %23 %2425 %2426
+OpStore %1758 %2427
+%2428 = OpLoad %ulong %1758
+%2429 = OpLoad %ulong %1980
+%2430 = OpFunctionCall %ulong %23 %2428 %2429
+OpStore %1759 %2430
+%2431 = OpLoad %ulong %1759
+%2432 = OpLoad %ulong %1981
+%2433 = OpFunctionCall %ulong %23 %2431 %2432
+OpStore %1760 %2433
+%2434 = OpLoad %ulong %1760
+%2435 = OpLoad %ulong %1982
+%2436 = OpFunctionCall %ulong %23 %2434 %2435
+OpStore %1761 %2436
+%2437 = OpLoad %ulong %1761
+%2438 = OpLoad %ulong %1983
+%2439 = OpFunctionCall %ulong %23 %2437 %2438
+OpStore %1762 %2439
+OpBranch %1495
+%1495 = OpLabel
+%2440 = OpLoad %ulong %1731
+%2441 = OpIAdd %ulong %2440 %ulong_1
+OpStore %1703 %2441
+%2442 = OpLoad %ulong %1762
+OpStore %1724 %2442
+%2443 = OpLoad %ulong %1703
+OpStore %1731 %2443
+OpBranch %1634
+%1468 = OpLabel
+%2444 = OpAccessChain %_ptr_Function_ulong %1639 %uint_0
+%2445 = OpLoad %ulong %2444
+OpStore %1975 %2445
+%2446 = OpAccessChain %_ptr_Function_ulong %1639 %uint_1
+%2447 = OpLoad %ulong %2446
+OpStore %1976 %2447
+%2448 = OpAccessChain %_ptr_Function_ulong %1639 %uint_2
+%2449 = OpLoad %ulong %2448
+OpStore %1977 %2449
+%2450 = OpLoad %ulong %1732
+%2451 = OpAccessChain %_ptr_Function_ulong %1659 %2450
+%2452 = OpLoad %ulong %2451
+OpStore %1697 %2452
+OpBranch %1490
+%1490 = OpLabel
+%2453 = OpLoad %ulong %1975
+%2454 = OpLoad %ulong %1697
+%2455 = OpIAdd %ulong %2453 %2454
+OpStore %1749 %2455
+%2456 = OpAccessChain %_ptr_Function_ulong %1650 %uint_0
+%2457 = OpLoad %ulong %1749
+OpStore %2456 %2457
+%2458 = OpLoad %ulong %1976
+%2459 = OpLoad %ulong %1697
+%2460 = OpBitwiseXor %ulong %2458 %2459
+OpStore %1750 %2460
+%2461 = OpAccessChain %_ptr_Function_ulong %1650 %uint_1
+%2462 = OpLoad %ulong %1750
+OpStore %2461 %2462
+%2463 = OpLoad %ulong %1977
+%2464 = OpLoad %ulong %1975
+%2465 = OpIAdd %ulong %2463 %2464
+OpStore %1751 %2465
+%2466 = OpAccessChain %_ptr_Function_ulong %1650 %uint_2
+%2467 = OpLoad %ulong %1751
+OpStore %2466 %2467
+OpBranch %1491
+%1491 = OpLabel
+%2468 = OpLoad %_struct_283 %1650
+OpStore %1639 %2468
+%2469 = OpLoad %_struct_283 %1639
+OpStore %1651 %2469
+%2470 = OpLoad %ulong %1725
+%2471 = OpLoad %_struct_283 %1651
+%2472 = OpFunctionCall %ulong %3 %2470 %2471
+OpStore %1698 %2472
+%2473 = OpLoad %ulong %1732
+%2474 = OpIAdd %ulong %2473 %ulong_1
+OpStore %1699 %2474
+%2475 = OpLoad %ulong %1698
+OpStore %1725 %2475
+%2476 = OpLoad %ulong %1699
+OpStore %1732 %2476
+OpBranch %1636
+%1465 = OpLabel
+%2477 = OpLoad %ulong %1733
+%2478 = OpAccessChain %_ptr_Function_ulong %1659 %2477
+%2479 = OpLoad %ulong %2478
+OpStore %1690 %2479
+%2480 = OpLoad %ulong %1690
+%2481 = OpLoad %ulong %1686
+%2482 = OpIAdd %ulong %2480 %2481
+OpStore %1691 %2482
+OpBranch %1486
+%1486 = OpLabel
+%2483 = OpLoad %ulong %1691
+%2484 = OpUConvert %uint %2483
+OpStore %1737 %2484
+%2485 = OpLoad %ulong %1691
+%2486 = OpShiftRightLogical %ulong %2485 %ulong_8
+OpStore %1738 %2486
+%2487 = OpLoad %ulong %1738
+%2488 = OpUConvert %uint %2487
+OpStore %1739 %2488
+%2489 = OpLoad %ulong %1691
+%2490 = OpShiftRightLogical %ulong %2489 %ulong_16
+OpStore %1740 %2490
+%2491 = OpLoad %ulong %1740
+%2492 = OpUConvert %uint %2491
+OpStore %1741 %2492
+%2493 = OpLoad %ulong %1691
+%2494 = OpShiftRightLogical %ulong %2493 %ulong_24
+OpStore %1742 %2494
+%2495 = OpLoad %ulong %1742
+%2496 = OpUConvert %uint %2495
+OpStore %1743 %2496
+%2497 = OpLoad %ulong %1691
+%2498 = OpShiftRightLogical %ulong %2497 %ulong_32
+OpStore %1744 %2498
+%2499 = OpLoad %ulong %1744
+%2500 = OpUConvert %uint %2499
+OpStore %1745 %2500
+OpBranch %1487
+%1487 = OpLabel
+OpBranch %1504
+%1504 = OpLabel
+OpBranch %1505
+%1505 = OpLabel
+%2501 = OpLoad %uint %1737
+%2502 = OpUConvert %ulong %2501
+OpStore %1781 %2502
+OpBranch %1507
+%1507 = OpLabel
+%2503 = OpLoad %ulong %1726
+OpStore %1789 %2503
+OpStore %1790 %ulong_0
+OpBranch %1508
+%1508 = OpLabel
+%2504 = OpLoad %ulong %1790
+%2505 = OpULessThan %bool %2504 %ulong_8
+OpStore %1782 %2505
+%2506 = OpLoad %bool %1782
+OpLoopMerge %1510 %1635 None
+OpBranchConditional %2506 %1509 %1510
+%1510 = OpLabel
+OpBranch %1511
+%1511 = OpLabel
+OpBranch %1506
+%1506 = OpLabel
+OpBranch %1512
+%1512 = OpLabel
+%2507 = OpLoad %uint %1739
+%2508 = OpUConvert %ulong %2507
+OpStore %1791 %2508
+OpBranch %1514
+%1514 = OpLabel
+%2509 = OpLoad %ulong %1789
+OpStore %1799 %2509
+OpStore %1800 %ulong_0
+OpBranch %1515
+%1515 = OpLabel
+%2510 = OpLoad %ulong %1800
+%2511 = OpULessThan %bool %2510 %ulong_8
+OpStore %1792 %2511
+%2512 = OpLoad %bool %1792
+OpLoopMerge %1517 %1631 None
+OpBranchConditional %2512 %1516 %1517
+%1517 = OpLabel
+OpBranch %1518
+%1518 = OpLabel
+OpBranch %1513
+%1513 = OpLabel
+OpBranch %1519
+%1519 = OpLabel
+%2513 = OpLoad %uint %1741
+%2514 = OpUConvert %ulong %2513
+OpStore %1801 %2514
+OpBranch %1521
+%1521 = OpLabel
+%2515 = OpLoad %ulong %1799
+OpStore %1809 %2515
+OpStore %1810 %ulong_0
+OpBranch %1522
+%1522 = OpLabel
+%2516 = OpLoad %ulong %1810
+%2517 = OpULessThan %bool %2516 %ulong_8
+OpStore %1802 %2517
+%2518 = OpLoad %bool %1802
+OpLoopMerge %1524 %1630 None
+OpBranchConditional %2518 %1523 %1524
+%1524 = OpLabel
+OpBranch %1525
+%1525 = OpLabel
+OpBranch %1520
+%1520 = OpLabel
+OpBranch %1526
+%1526 = OpLabel
+%2519 = OpLoad %uint %1743
+%2520 = OpUConvert %ulong %2519
+OpStore %1811 %2520
+OpBranch %1528
+%1528 = OpLabel
+%2521 = OpLoad %ulong %1809
+OpStore %1819 %2521
+OpStore %1820 %ulong_0
+OpBranch %1529
+%1529 = OpLabel
+%2522 = OpLoad %ulong %1820
+%2523 = OpULessThan %bool %2522 %ulong_8
+OpStore %1812 %2523
+%2524 = OpLoad %bool %1812
+OpLoopMerge %1531 %1628 None
+OpBranchConditional %2524 %1530 %1531
+%1531 = OpLabel
+OpBranch %1532
+%1532 = OpLabel
+OpBranch %1527
+%1527 = OpLabel
+OpBranch %1533
+%1533 = OpLabel
+%2525 = OpLoad %uint %1745
+%2526 = OpUConvert %ulong %2525
+OpStore %1821 %2526
+OpBranch %1535
+%1535 = OpLabel
+%2527 = OpLoad %ulong %1819
+OpStore %1829 %2527
+OpStore %1830 %ulong_0
+OpBranch %1536
+%1536 = OpLabel
+%2528 = OpLoad %ulong %1830
+%2529 = OpULessThan %bool %2528 %ulong_8
+OpStore %1822 %2529
+%2530 = OpLoad %bool %1822
+OpLoopMerge %1538 %1627 None
+OpBranchConditional %2530 %1537 %1538
+%1538 = OpLabel
+OpBranch %1539
+%1539 = OpLabel
+OpBranch %1534
+%1534 = OpLabel
+OpBranch %1540
+%1540 = OpLabel
+OpBranch %1545
+%1545 = OpLabel
+%2531 = OpAccessChain %_ptr_Function_ulong %1665 %uint_0
+%2532 = OpLoad %ulong %1691
+OpStore %2531 %2532
+%2533 = OpLoad %ulong %1691
+%2534 = OpNot %ulong %2533
+OpStore %1839 %2534
+%2535 = OpAccessChain %_ptr_Function_ulong %1665 %uint_1
+%2536 = OpLoad %ulong %1839
+OpStore %2535 %2536
+%2537 = OpLoad %ulong %1691
+%2538 = OpIMul %ulong %2537 %ulong_3
+OpStore %1840 %2538
+%2539 = OpLoad %ulong %1840
+%2540 = OpIAdd %ulong %2539 %ulong_1
+OpStore %1841 %2540
+%2541 = OpAccessChain %_ptr_Function_ulong %1665 %uint_2
+%2542 = OpLoad %ulong %1841
+OpStore %2541 %2542
+OpBranch %1546
+%1546 = OpLabel
+%2543 = OpLoad %ulong %1829
+%2544 = OpLoad %_struct_283 %1665
+%2545 = OpFunctionCall %ulong %3 %2543 %2544
+OpStore %1692 %2545
+OpBranch %1557
+%1557 = OpLabel
+%2546 = OpLoad %ulong %1691
+%2547 = OpBitwiseAnd %ulong %2546 %ulong_65535
+OpStore %1858 %2547
+%2548 = OpLoad %ulong %1858
+%2549 = OpConvertUToF %double %2548
+OpStore %1859 %2549
+%2550 = OpLoad %double %1859
+%2551 = OpFDiv %double %2550 %double_8
+OpStore %1860 %2551
+%2552 = OpLoad %ulong %1691
+%2553 = OpBitwiseAnd %ulong %2552 %ulong_4095
+OpStore %1861 %2553
+%2554 = OpLoad %ulong %1861
+%2555 = OpConvertUToF %double %2554
+OpStore %1862 %2555
+%2556 = OpLoad %double %1862
+%2557 = OpFSub %double %2556 %double_2048
+OpStore %1863 %2557
+%2558 = OpLoad %ulong %1691
+%2559 = OpBitwiseAnd %ulong %2558 %ulong_262143
+OpStore %1864 %2559
+%2560 = OpLoad %ulong %1864
+%2561 = OpConvertUToF %double %2560
+OpStore %1865 %2561
+%2562 = OpLoad %double %1865
+%2563 = OpFDiv %double %2562 %double_64
+OpStore %1866 %2563
+OpBranch %1558
+%1558 = OpLabel
+OpBranch %1561
+%1561 = OpLabel
+OpBranch %1562
+%1562 = OpLabel
+%2564 = OpLoad %double %1860
+%2565 = OpBitcast %ulong %2564
+OpStore %1872 %2565
+OpBranch %1564
+%1564 = OpLabel
+%2566 = OpLoad %ulong %1692
+OpStore %1880 %2566
+OpStore %1881 %ulong_0
+OpBranch %1565
+%1565 = OpLabel
+%2567 = OpLoad %ulong %1881
+%2568 = OpULessThan %bool %2567 %ulong_8
+OpStore %1873 %2568
+%2569 = OpLoad %bool %1873
+OpLoopMerge %1567 %1626 None
+OpBranchConditional %2569 %1566 %1567
+%1567 = OpLabel
+OpBranch %1568
+%1568 = OpLabel
+OpBranch %1563
+%1563 = OpLabel
+OpBranch %1569
+%1569 = OpLabel
+%2570 = OpLoad %double %1863
+%2571 = OpBitcast %ulong %2570
+OpStore %1882 %2571
+OpBranch %1571
+%1571 = OpLabel
+%2572 = OpLoad %ulong %1880
+OpStore %1890 %2572
+OpStore %1891 %ulong_0
+OpBranch %1572
+%1572 = OpLabel
+%2573 = OpLoad %ulong %1891
+%2574 = OpULessThan %bool %2573 %ulong_8
+OpStore %1883 %2574
+%2575 = OpLoad %bool %1883
+OpLoopMerge %1574 %1625 None
+OpBranchConditional %2575 %1573 %1574
+%1574 = OpLabel
+OpBranch %1575
+%1575 = OpLabel
+OpBranch %1570
+%1570 = OpLabel
+OpBranch %1576
+%1576 = OpLabel
+%2576 = OpLoad %double %1866
+%2577 = OpBitcast %ulong %2576
+OpStore %1892 %2577
+OpBranch %1578
+%1578 = OpLabel
+%2578 = OpLoad %ulong %1890
+OpStore %1900 %2578
+OpStore %1901 %ulong_0
+OpBranch %1579
+%1579 = OpLabel
+%2579 = OpLoad %ulong %1901
+%2580 = OpULessThan %bool %2579 %ulong_8
+OpStore %1893 %2580
+%2581 = OpLoad %bool %1893
+OpLoopMerge %1581 %1624 None
+OpBranchConditional %2581 %1580 %1581
+%1581 = OpLabel
+OpBranch %1582
+%1582 = OpLabel
+OpBranch %1577
+%1577 = OpLabel
+OpBranch %1583
+%1583 = OpLabel
+OpBranch %1586
+%1586 = OpLabel
+%2582 = OpAccessChain %_ptr_Function_ulong %1673 %uint_0
+%2583 = OpLoad %ulong %1691
+OpStore %2582 %2583
+%2584 = OpLoad %ulong %1691
+%2585 = OpIAdd %ulong %2584 %ulong_1
+OpStore %1908 %2585
+%2586 = OpAccessChain %_ptr_Function_ulong %1673 %uint_1
+%2587 = OpLoad %ulong %1908
+OpStore %2586 %2587
+%2588 = OpLoad %ulong %1691
+%2589 = OpIMul %ulong %2588 %ulong_5
+OpStore %1909 %2589
+%2590 = OpAccessChain %_ptr_Function_ulong %1673 %uint_2
+%2591 = OpLoad %ulong %1909
+OpStore %2590 %2591
+%2592 = OpLoad %ulong %1691
+%2593 = OpNot %ulong %2592
+OpStore %1910 %2593
+%2594 = OpAccessChain %_ptr_Function_ulong %1673 %uint_3
+%2595 = OpLoad %ulong %1910
+OpStore %2594 %2595
+OpBranch %1587
+%1587 = OpLabel
+%2596 = OpLoad %ulong %1900
+%2597 = OpLoad %_struct_546 %1673
+%2598 = OpFunctionCall %ulong %5 %2596 %2597
+OpStore %1693 %2598
+OpBranch %1590
+%1590 = OpLabel
+%2599 = OpLoad %ulong %1691
+%2600 = OpBitwiseAnd %ulong %2599 %ulong_8191
+OpStore %1914 %2600
+%2601 = OpLoad %ulong %1914
+%2602 = OpConvertUToF %double %2601
+OpStore %1915 %2602
+%2603 = OpLoad %double %1915
+%2604 = OpFDiv %double %2603 %double_2
+OpStore %1916 %2604
+%2605 = OpLoad %ulong %1691
+%2606 = OpUConvert %uint %2605
+OpStore %1917 %2606
+%2607 = OpLoad %ulong %1691
+%2608 = OpShiftRightLogical %ulong %2607 %ulong_16
+OpStore %1918 %2608
+%2609 = OpLoad %ulong %1918
+%2610 = OpUConvert %uint %2609
+OpStore %1919 %2610
+%2611 = OpLoad %ulong %1691
+%2612 = OpBitwiseAnd %ulong %2611 %ulong_131071
+OpStore %1920 %2612
+%2613 = OpLoad %ulong %1920
+%2614 = OpConvertUToF %double %2613
+OpStore %1921 %2614
+%2615 = OpLoad %double %1921
+%2616 = OpFDiv %double %2615 %double_32
+OpStore %1922 %2616
+%2617 = OpLoad %ulong %1691
+%2618 = OpIMul %ulong %2617 %ulong_7
+OpStore %1923 %2618
+OpBranch %1591
+%1591 = OpLabel
+OpBranch %1594
+%1594 = OpLabel
+OpBranch %1595
+%1595 = OpLabel
+%2619 = OpLoad %ulong %1693
+OpStore %1937 %2619
+OpStore %1938 %ulong_0
+OpBranch %1596
+%1596 = OpLabel
+%2620 = OpLoad %ulong %1938
+%2621 = OpULessThan %bool %2620 %ulong_8
+OpStore %1930 %2621
+%2622 = OpLoad %bool %1930
+OpLoopMerge %1598 %1623 None
+OpBranchConditional %2622 %1597 %1598
+%1598 = OpLabel
+OpBranch %1599
+%1599 = OpLabel
+OpBranch %1600
+%1600 = OpLabel
+%2623 = OpLoad %double %1916
+%2624 = OpBitcast %ulong %2623
+OpStore %1939 %2624
+%2625 = OpLoad %ulong %1937
+%2626 = OpLoad %ulong %1939
+%2627 = OpFunctionCall %ulong %23 %2625 %2626
+OpStore %1940 %2627
+OpBranch %1601
+%1601 = OpLabel
+OpBranch %1602
+%1602 = OpLabel
+%2628 = OpLoad %uint %1917
+%2629 = OpUConvert %ulong %2628
+OpStore %1941 %2629
+%2630 = OpLoad %ulong %1940
+%2631 = OpLoad %ulong %1941
+%2632 = OpFunctionCall %ulong %23 %2630 %2631
+OpStore %1942 %2632
+OpBranch %1603
+%1603 = OpLabel
+OpBranch %1604
+%1604 = OpLabel
+%2633 = OpLoad %uint %1919
+%2634 = OpUConvert %ulong %2633
+OpStore %1943 %2634
+%2635 = OpLoad %ulong %1942
+%2636 = OpLoad %ulong %1943
+%2637 = OpFunctionCall %ulong %23 %2635 %2636
+OpStore %1944 %2637
+OpBranch %1605
+%1605 = OpLabel
+OpBranch %1606
+%1606 = OpLabel
+%2638 = OpLoad %double %1922
+%2639 = OpBitcast %ulong %2638
+OpStore %1945 %2639
+%2640 = OpLoad %ulong %1944
+%2641 = OpLoad %ulong %1945
+%2642 = OpFunctionCall %ulong %23 %2640 %2641
+OpStore %1946 %2642
+OpBranch %1607
+%1607 = OpLabel
+%2643 = OpLoad %ulong %1946
+%2644 = OpLoad %ulong %1923
+%2645 = OpFunctionCall %ulong %23 %2643 %2644
+OpStore %1929 %2645
+OpBranch %1608
+%1608 = OpLabel
+OpBranch %1611
+%1611 = OpLabel
+%2646 = OpLoad %ulong %1691
+%2647 = OpIAdd %ulong %2646 %ulong_1
+OpStore %1950 %2647
+%2648 = OpLoad %ulong %1691
+%2649 = OpIAdd %ulong %2648 %ulong_2
+OpStore %1951 %2649
+%2650 = OpLoad %ulong %1691
+%2651 = OpIMul %ulong %2650 %ulong_9
+OpStore %1952 %2651
+%2652 = OpLoad %ulong %1691
+%2653 = OpNot %ulong %2652
+OpStore %1953 %2653
+%2654 = OpLoad %ulong %1691
+%2655 = OpBitwiseXor %ulong %2654 %ulong_2863311530
+OpStore %1954 %2655
+OpBranch %1612
+%1612 = OpLabel
+OpBranch %1613
+%1613 = OpLabel
+%2656 = OpLoad %ulong %1929
+%2657 = OpLoad %ulong %1691
+%2658 = OpFunctionCall %ulong %23 %2656 %2657
+OpStore %1955 %2658
+%2659 = OpLoad %ulong %1955
+%2660 = OpLoad %ulong %1950
+%2661 = OpFunctionCall %ulong %23 %2659 %2660
+OpStore %1956 %2661
+%2662 = OpLoad %ulong %1956
+%2663 = OpLoad %ulong %1951
+%2664 = OpFunctionCall %ulong %23 %2662 %2663
+OpStore %1957 %2664
+%2665 = OpLoad %ulong %1957
+%2666 = OpLoad %ulong %1952
+%2667 = OpFunctionCall %ulong %23 %2665 %2666
+OpStore %1958 %2667
+%2668 = OpLoad %ulong %1958
+%2669 = OpLoad %ulong %1953
+%2670 = OpFunctionCall %ulong %23 %2668 %2669
+OpStore %1959 %2670
+%2671 = OpLoad %ulong %1959
+%2672 = OpLoad %ulong %1954
+%2673 = OpFunctionCall %ulong %23 %2671 %2672
+OpStore %1960 %2673
+OpBranch %1614
+%1614 = OpLabel
+OpBranch %1615
+%1615 = OpLabel
+%2674 = OpLoad %ulong %1691
+%2675 = OpUConvert %uint %2674
+OpStore %1961 %2675
+%2676 = OpAccessChain %_ptr_Function_uint %1681 %uint_0
+%2677 = OpLoad %uint %1961
+OpStore %2676 %2677
+OpBranch %1616
+%1616 = OpLabel
+%2678 = OpAccessChain %_ptr_Function_ulong %1682 %uint_0
+%2679 = OpLoad %ulong %1691
+OpStore %2678 %2679
+%2680 = OpLoad %ulong %1691
+%2681 = OpNot %ulong %2680
+OpStore %1964 %2681
+%2682 = OpAccessChain %_ptr_Function_ulong %1682 %uint_1
+%2683 = OpLoad %ulong %1964
+OpStore %2682 %2683
+%2684 = OpLoad %ulong %1691
+%2685 = OpIMul %ulong %2684 %ulong_3
+OpStore %1965 %2685
+%2686 = OpLoad %ulong %1965
+%2687 = OpIAdd %ulong %2686 %ulong_1
+OpStore %1966 %2687
+%2688 = OpAccessChain %_ptr_Function_ulong %1682 %uint_2
+%2689 = OpLoad %ulong %1966
+OpStore %2688 %2689
+OpBranch %1617
+%1617 = OpLabel
+%2690 = OpAccessChain %_ptr_Function__struct_283 %1681 %uint_1
+%2691 = OpLoad %_struct_283 %1682
+OpStore %2690 %2691
+%2692 = OpLoad %ulong %1691
+%2693 = OpIMul %ulong %2692 %ulong_11
+OpStore %1962 %2693
+%2694 = OpAccessChain %_ptr_Function_ulong %1683 %uint_0
+%2695 = OpLoad %ulong %1962
+OpStore %2694 %2695
+%2696 = OpLoad %ulong %1691
+%2697 = OpNot %ulong %2696
+OpStore %1963 %2697
+%2698 = OpAccessChain %_ptr_Function_ulong %1683 %uint_1
+%2699 = OpLoad %ulong %1963
+OpStore %2698 %2699
+%2700 = OpAccessChain %_ptr_Function__struct_861 %1681 %uint_2
+%2701 = OpLoad %_struct_861 %1683
+OpStore %2700 %2701
+OpBranch %1618
+%1618 = OpLabel
+OpBranch %1619
+%1619 = OpLabel
+%2702 = OpLoad %_struct_862 %1681
+OpStore %1684 %2702
+%2703 = OpAccessChain %_ptr_Function_uint %1684 %uint_0
+%2704 = OpLoad %uint %2703
+OpStore %1967 %2704
+OpBranch %1620
+%1620 = OpLabel
+%2705 = OpLoad %uint %1967
+%2706 = OpUConvert %ulong %2705
+OpStore %1973 %2706
+%2707 = OpLoad %ulong %1960
+%2708 = OpLoad %ulong %1973
+%2709 = OpFunctionCall %ulong %23 %2707 %2708
+OpStore %1974 %2709
+OpBranch %1621
+%1621 = OpLabel
+%2710 = OpAccessChain %_ptr_Function__struct_283 %1684 %uint_1
+%2711 = OpLoad %_struct_283 %2710
+OpStore %1685 %2711
+%2712 = OpLoad %ulong %1974
+%2713 = OpLoad %_struct_283 %1685
+%2714 = OpFunctionCall %ulong %3 %2712 %2713
+OpStore %1968 %2714
+%2715 = OpAccessChain %_ptr_Function__struct_861 %1684 %uint_2
+%2716 = OpAccessChain %_ptr_Function_ulong %2715 %uint_0
+%2717 = OpLoad %ulong %2716
+OpStore %1969 %2717
+%2718 = OpLoad %ulong %1968
+%2719 = OpLoad %ulong %1969
+%2720 = OpFunctionCall %ulong %23 %2718 %2719
+OpStore %1970 %2720
+%2721 = OpAccessChain %_ptr_Function_ulong %2715 %uint_1
+%2722 = OpLoad %ulong %2721
+OpStore %1971 %2722
+%2723 = OpLoad %ulong %1970
+%2724 = OpLoad %ulong %1971
+%2725 = OpFunctionCall %ulong %23 %2723 %2724
+OpStore %1972 %2725
+OpBranch %1622
+%1622 = OpLabel
+%2726 = OpLoad %ulong %1733
+%2727 = OpIAdd %ulong %2726 %ulong_1
+OpStore %1694 %2727
+%2728 = OpLoad %ulong %1972
+OpStore %1726 %2728
+%2729 = OpLoad %ulong %1694
+OpStore %1733 %2729
+OpBranch %1637
+%1597 = OpLabel
+%2730 = OpLoad %ulong %1938
+%2731 = OpIMul %ulong %2730 %ulong_8
+OpStore %1931 %2731
+%2732 = OpLoad %ulong %1691
+%2733 = OpLoad %ulong %1931
+%2734 = OpShiftRightLogical %ulong %2732 %2733
+OpStore %1932 %2734
+%2735 = OpLoad %ulong %1932
+%2736 = OpBitwiseAnd %ulong %2735 %ulong_255
+OpStore %1933 %2736
+%2737 = OpLoad %ulong %1937
+%2738 = OpLoad %ulong %1933
+%2739 = OpBitwiseXor %ulong %2737 %2738
+OpStore %1934 %2739
+%2740 = OpLoad %ulong %1934
+%2741 = OpIMul %ulong %2740 %ulong_1099511628211
+OpStore %1935 %2741
+%2742 = OpLoad %ulong %1938
+%2743 = OpIAdd %ulong %2742 %ulong_1
+OpStore %1936 %2743
+%2744 = OpLoad %ulong %1935
+OpStore %1937 %2744
+%2745 = OpLoad %ulong %1936
+OpStore %1938 %2745
+OpBranch %1623
+%1580 = OpLabel
+%2746 = OpLoad %ulong %1901
+%2747 = OpIMul %ulong %2746 %ulong_8
+OpStore %1894 %2747
+%2748 = OpLoad %ulong %1892
+%2749 = OpLoad %ulong %1894
+%2750 = OpShiftRightLogical %ulong %2748 %2749
+OpStore %1895 %2750
+%2751 = OpLoad %ulong %1895
+%2752 = OpBitwiseAnd %ulong %2751 %ulong_255
+OpStore %1896 %2752
+%2753 = OpLoad %ulong %1900
+%2754 = OpLoad %ulong %1896
+%2755 = OpBitwiseXor %ulong %2753 %2754
+OpStore %1897 %2755
+%2756 = OpLoad %ulong %1897
+%2757 = OpIMul %ulong %2756 %ulong_1099511628211
+OpStore %1898 %2757
+%2758 = OpLoad %ulong %1901
+%2759 = OpIAdd %ulong %2758 %ulong_1
+OpStore %1899 %2759
+%2760 = OpLoad %ulong %1898
+OpStore %1900 %2760
+%2761 = OpLoad %ulong %1899
+OpStore %1901 %2761
+OpBranch %1624
+%1573 = OpLabel
+%2762 = OpLoad %ulong %1891
+%2763 = OpIMul %ulong %2762 %ulong_8
+OpStore %1884 %2763
+%2764 = OpLoad %ulong %1882
+%2765 = OpLoad %ulong %1884
+%2766 = OpShiftRightLogical %ulong %2764 %2765
+OpStore %1885 %2766
+%2767 = OpLoad %ulong %1885
+%2768 = OpBitwiseAnd %ulong %2767 %ulong_255
+OpStore %1886 %2768
+%2769 = OpLoad %ulong %1890
+%2770 = OpLoad %ulong %1886
+%2771 = OpBitwiseXor %ulong %2769 %2770
+OpStore %1887 %2771
+%2772 = OpLoad %ulong %1887
+%2773 = OpIMul %ulong %2772 %ulong_1099511628211
+OpStore %1888 %2773
+%2774 = OpLoad %ulong %1891
+%2775 = OpIAdd %ulong %2774 %ulong_1
+OpStore %1889 %2775
+%2776 = OpLoad %ulong %1888
+OpStore %1890 %2776
+%2777 = OpLoad %ulong %1889
+OpStore %1891 %2777
+OpBranch %1625
+%1566 = OpLabel
+%2778 = OpLoad %ulong %1881
+%2779 = OpIMul %ulong %2778 %ulong_8
+OpStore %1874 %2779
+%2780 = OpLoad %ulong %1872
+%2781 = OpLoad %ulong %1874
+%2782 = OpShiftRightLogical %ulong %2780 %2781
+OpStore %1875 %2782
+%2783 = OpLoad %ulong %1875
+%2784 = OpBitwiseAnd %ulong %2783 %ulong_255
+OpStore %1876 %2784
+%2785 = OpLoad %ulong %1880
+%2786 = OpLoad %ulong %1876
+%2787 = OpBitwiseXor %ulong %2785 %2786
+OpStore %1877 %2787
+%2788 = OpLoad %ulong %1877
+%2789 = OpIMul %ulong %2788 %ulong_1099511628211
+OpStore %1878 %2789
+%2790 = OpLoad %ulong %1881
+%2791 = OpIAdd %ulong %2790 %ulong_1
+OpStore %1879 %2791
+%2792 = OpLoad %ulong %1878
+OpStore %1880 %2792
+%2793 = OpLoad %ulong %1879
+OpStore %1881 %2793
+OpBranch %1626
+%1537 = OpLabel
+%2794 = OpLoad %ulong %1830
+%2795 = OpIMul %ulong %2794 %ulong_8
+OpStore %1823 %2795
+%2796 = OpLoad %ulong %1821
+%2797 = OpLoad %ulong %1823
+%2798 = OpShiftRightLogical %ulong %2796 %2797
+OpStore %1824 %2798
+%2799 = OpLoad %ulong %1824
+%2800 = OpBitwiseAnd %ulong %2799 %ulong_255
+OpStore %1825 %2800
+%2801 = OpLoad %ulong %1829
+%2802 = OpLoad %ulong %1825
+%2803 = OpBitwiseXor %ulong %2801 %2802
+OpStore %1826 %2803
+%2804 = OpLoad %ulong %1826
+%2805 = OpIMul %ulong %2804 %ulong_1099511628211
+OpStore %1827 %2805
+%2806 = OpLoad %ulong %1830
+%2807 = OpIAdd %ulong %2806 %ulong_1
+OpStore %1828 %2807
+%2808 = OpLoad %ulong %1827
+OpStore %1829 %2808
+%2809 = OpLoad %ulong %1828
+OpStore %1830 %2809
+OpBranch %1627
+%1530 = OpLabel
+%2810 = OpLoad %ulong %1820
+%2811 = OpIMul %ulong %2810 %ulong_8
+OpStore %1813 %2811
+%2812 = OpLoad %ulong %1811
+%2813 = OpLoad %ulong %1813
+%2814 = OpShiftRightLogical %ulong %2812 %2813
+OpStore %1814 %2814
+%2815 = OpLoad %ulong %1814
+%2816 = OpBitwiseAnd %ulong %2815 %ulong_255
+OpStore %1815 %2816
+%2817 = OpLoad %ulong %1819
+%2818 = OpLoad %ulong %1815
+%2819 = OpBitwiseXor %ulong %2817 %2818
+OpStore %1816 %2819
+%2820 = OpLoad %ulong %1816
+%2821 = OpIMul %ulong %2820 %ulong_1099511628211
+OpStore %1817 %2821
+%2822 = OpLoad %ulong %1820
+%2823 = OpIAdd %ulong %2822 %ulong_1
+OpStore %1818 %2823
+%2824 = OpLoad %ulong %1817
+OpStore %1819 %2824
+%2825 = OpLoad %ulong %1818
+OpStore %1820 %2825
+OpBranch %1628
+%1523 = OpLabel
+%2826 = OpLoad %ulong %1810
+%2827 = OpIMul %ulong %2826 %ulong_8
+OpStore %1803 %2827
+%2828 = OpLoad %ulong %1801
+%2829 = OpLoad %ulong %1803
+%2830 = OpShiftRightLogical %ulong %2828 %2829
+OpStore %1804 %2830
+%2831 = OpLoad %ulong %1804
+%2832 = OpBitwiseAnd %ulong %2831 %ulong_255
+OpStore %1805 %2832
+%2833 = OpLoad %ulong %1809
+%2834 = OpLoad %ulong %1805
+%2835 = OpBitwiseXor %ulong %2833 %2834
+OpStore %1806 %2835
+%2836 = OpLoad %ulong %1806
+%2837 = OpIMul %ulong %2836 %ulong_1099511628211
+OpStore %1807 %2837
+%2838 = OpLoad %ulong %1810
+%2839 = OpIAdd %ulong %2838 %ulong_1
+OpStore %1808 %2839
+%2840 = OpLoad %ulong %1807
+OpStore %1809 %2840
+%2841 = OpLoad %ulong %1808
+OpStore %1810 %2841
+OpBranch %1630
+%1516 = OpLabel
+%2842 = OpLoad %ulong %1800
+%2843 = OpIMul %ulong %2842 %ulong_8
+OpStore %1793 %2843
+%2844 = OpLoad %ulong %1791
+%2845 = OpLoad %ulong %1793
+%2846 = OpShiftRightLogical %ulong %2844 %2845
+OpStore %1794 %2846
+%2847 = OpLoad %ulong %1794
+%2848 = OpBitwiseAnd %ulong %2847 %ulong_255
+OpStore %1795 %2848
+%2849 = OpLoad %ulong %1799
+%2850 = OpLoad %ulong %1795
+%2851 = OpBitwiseXor %ulong %2849 %2850
+OpStore %1796 %2851
+%2852 = OpLoad %ulong %1796
+%2853 = OpIMul %ulong %2852 %ulong_1099511628211
+OpStore %1797 %2853
+%2854 = OpLoad %ulong %1800
+%2855 = OpIAdd %ulong %2854 %ulong_1
+OpStore %1798 %2855
+%2856 = OpLoad %ulong %1797
+OpStore %1799 %2856
+%2857 = OpLoad %ulong %1798
+OpStore %1800 %2857
+OpBranch %1631
+%1509 = OpLabel
+%2858 = OpLoad %ulong %1790
+%2859 = OpIMul %ulong %2858 %ulong_8
+OpStore %1783 %2859
+%2860 = OpLoad %ulong %1781
+%2861 = OpLoad %ulong %1783
+%2862 = OpShiftRightLogical %ulong %2860 %2861
+OpStore %1784 %2862
+%2863 = OpLoad %ulong %1784
+%2864 = OpBitwiseAnd %ulong %2863 %ulong_255
+OpStore %1785 %2864
+%2865 = OpLoad %ulong %1789
+%2866 = OpLoad %ulong %1785
+%2867 = OpBitwiseXor %ulong %2865 %2866
+OpStore %1786 %2867
+%2868 = OpLoad %ulong %1786
+%2869 = OpIMul %ulong %2868 %ulong_1099511628211
+OpStore %1787 %2869
+%2870 = OpLoad %ulong %1790
+%2871 = OpIAdd %ulong %2870 %ulong_1
+OpStore %1788 %2871
+%2872 = OpLoad %ulong %1787
+OpStore %1789 %2872
+%2873 = OpLoad %ulong %1788
+OpStore %1790 %2873
+OpBranch %1635
+%1462 = OpLabel
+OpBranch %1484
+%1484 = OpLabel
+%2874 = OpLoad %ulong %1727
+%2875 = OpIMul %ulong %2874 %ulong_6364136223846793005
+OpStore %1734 %2875
+%2876 = OpLoad %ulong %1734
+%2877 = OpIAdd %ulong %2876 %ulong_1442695040888963407
+OpStore %1735 %2877
+%2878 = OpLoad %ulong %1735
+%2879 = OpLoad %ulong %1686
+%2880 = OpIAdd %ulong %2878 %2879
+OpStore %1736 %2880
+OpBranch %1485
+%1485 = OpLabel
+%2881 = OpLoad %ulong %1727
+%2882 = OpAccessChain %_ptr_Function_ulong %1659 %2881
+%2883 = OpLoad %ulong %1736
+OpStore %2882 %2883
+%2884 = OpLoad %ulong %1727
+%2885 = OpIAdd %ulong %2884 %ulong_1
+OpStore %1688 %2885
+%2886 = OpLoad %ulong %1688
+OpStore %1727 %2886
+OpBranch %1638
+%1623 = OpLabel
+OpBranch %1596
+%1624 = OpLabel
+OpBranch %1579
+%1625 = OpLabel
+OpBranch %1572
+%1626 = OpLabel
+OpBranch %1565
+%1627 = OpLabel
+OpBranch %1536
+%1628 = OpLabel
+OpBranch %1529
+%1629 = OpLabel
+OpBranch %1479
+%1630 = OpLabel
+OpBranch %1522
+%1631 = OpLabel
+OpBranch %1515
+%1632 = OpLabel
+OpBranch %1476
+%1633 = OpLabel
+OpBranch %1473
+%1634 = OpLabel
+OpBranch %1470
+%1635 = OpLabel
+OpBranch %1508
+%1636 = OpLabel
+OpBranch %1467
+%1637 = OpLabel
+OpBranch %1464
+%1638 = OpLabel
+OpBranch %1461
+OpFunctionEnd
+%23 = OpFunction %ulong None %25
+%2887 = OpFunctionParameter %ulong
+%2888 = OpFunctionParameter %ulong
+%2889 = OpLabel
+%2894 = OpVariable %_ptr_Function_ulong Function
+%2895 = OpVariable %_ptr_Function_ulong Function
+%2896 = OpVariable %_ptr_Function_bool Function
+%2897 = OpVariable %_ptr_Function_ulong Function
+%2898 = OpVariable %_ptr_Function_ulong Function
+%2899 = OpVariable %_ptr_Function_ulong Function
+%2900 = OpVariable %_ptr_Function_ulong Function
+%2901 = OpVariable %_ptr_Function_ulong Function
+%2902 = OpVariable %_ptr_Function_ulong Function
+%2903 = OpVariable %_ptr_Function_ulong Function
+%2904 = OpVariable %_ptr_Function_ulong Function
+OpStore %2894 %2887
+OpStore %2895 %2888
+%2905 = OpLoad %ulong %2894
+OpStore %2903 %2905
+OpStore %2904 %ulong_0
+OpBranch %2890
+%2890 = OpLabel
+%2906 = OpLoad %ulong %2904
+%2907 = OpULessThan %bool %2906 %ulong_8
+OpStore %2896 %2907
+%2908 = OpLoad %bool %2896
+OpLoopMerge %2892 %2893 None
+OpBranchConditional %2908 %2891 %2892
+%2892 = OpLabel
+%2909 = OpLoad %ulong %2903
+OpReturnValue %2909
+%2891 = OpLabel
+%2910 = OpLoad %ulong %2904
+%2911 = OpIMul %ulong %2910 %ulong_8
+OpStore %2897 %2911
+%2912 = OpLoad %ulong %2895
+%2913 = OpLoad %ulong %2897
+%2914 = OpShiftRightLogical %ulong %2912 %2913
+OpStore %2898 %2914
+%2915 = OpLoad %ulong %2898
+%2916 = OpBitwiseAnd %ulong %2915 %ulong_255
+OpStore %2899 %2916
+%2917 = OpLoad %ulong %2903
+%2918 = OpLoad %ulong %2899
+%2919 = OpBitwiseXor %ulong %2917 %2918
+OpStore %2900 %2919
+%2920 = OpLoad %ulong %2900
+%2921 = OpIMul %ulong %2920 %ulong_1099511628211
+OpStore %2901 %2921
+%2922 = OpLoad %ulong %2904
+%2923 = OpIAdd %ulong %2922 %ulong_1
+OpStore %2902 %2923
+%2924 = OpLoad %ulong %2901
+OpStore %2903 %2924
+%2925 = OpLoad %ulong %2902
+OpStore %2904 %2925
+OpBranch %2893
+%2893 = OpLabel
+OpBranch %2890
 OpFunctionEnd

--- a/test/golden/spirv/call/call_ret_small.dis
+++ b/test/golden/spirv/call/call_ret_small.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1521
+; Bound: 1878
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -32,684 +32,698 @@ OpDecorate %19 LinkageAttributes "corpus.cases.call.call_ret_small.layout" Expor
 OpDecorate %20 LinkageAttributes "corpus.cases.call.call_ret_small.regain" Export
 OpDecorate %21 LinkageAttributes "corpus.cases.call.call_ret_small.checksum" Export
 %ulong = OpTypeInt 64 0
-%30 = OpTypeFunction %ulong %ulong %ulong
+%24 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
 %uchar = OpTypeInt 8 0
-%_struct_51 = OpTypeStruct %uchar
-%52 = OpTypeFunction %_struct_51 %ulong
-%_ptr_Function__struct_51 = OpTypePointer Function %_struct_51
+%_struct_45 = OpTypeStruct %uchar
+%46 = OpTypeFunction %_struct_45 %ulong
+%_ptr_Function__struct_45 = OpTypePointer Function %_struct_45
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %uint = OpTypeInt 32 0
 %uint_0 = OpConstant %uint 0
 %ushort = OpTypeInt 16 0
-%_struct_68 = OpTypeStruct %ushort
-%69 = OpTypeFunction %_struct_68 %ulong
-%_ptr_Function__struct_68 = OpTypePointer Function %_struct_68
+%_struct_62 = OpTypeStruct %ushort
+%63 = OpTypeFunction %_struct_62 %ulong
+%_ptr_Function__struct_62 = OpTypePointer Function %_struct_62
 %_ptr_Function_ushort = OpTypePointer Function %ushort
-%_struct_82 = OpTypeStruct %uint
-%83 = OpTypeFunction %_struct_82 %ulong
-%_ptr_Function__struct_82 = OpTypePointer Function %_struct_82
+%_struct_76 = OpTypeStruct %uint
+%77 = OpTypeFunction %_struct_76 %ulong
+%_ptr_Function__struct_76 = OpTypePointer Function %_struct_76
 %_ptr_Function_uint = OpTypePointer Function %uint
-%_struct_96 = OpTypeStruct %uint %uint
-%97 = OpTypeFunction %_struct_96 %ulong
-%_ptr_Function__struct_96 = OpTypePointer Function %_struct_96
+%_struct_90 = OpTypeStruct %uint %uint
+%91 = OpTypeFunction %_struct_90 %ulong
+%_ptr_Function__struct_90 = OpTypePointer Function %_struct_90
 %ulong_32 = OpConstant %ulong 32
 %uint_1 = OpConstant %uint 1
 %float = OpTypeFloat 32
-%_struct_120 = OpTypeStruct %float %float
-%121 = OpTypeFunction %_struct_120 %ulong
-%_ptr_Function__struct_120 = OpTypePointer Function %_struct_120
+%_struct_114 = OpTypeStruct %float %float
+%115 = OpTypeFunction %_struct_114 %ulong
+%_ptr_Function__struct_114 = OpTypePointer Function %_struct_114
 %_ptr_Function_float = OpTypePointer Function %float
 %ulong_4095 = OpConstant %ulong 4095
 %float_8 = OpConstant %float 8
 %ulong_255 = OpConstant %ulong 255
 %float_128 = OpConstant %float 128
-%_struct_155 = OpTypeStruct %uint %uint %uint
-%156 = OpTypeFunction %_struct_155 %ulong
-%_ptr_Function__struct_155 = OpTypePointer Function %_struct_155
+%_struct_149 = OpTypeStruct %uint %uint %uint
+%150 = OpTypeFunction %_struct_149 %ulong
+%_ptr_Function__struct_149 = OpTypePointer Function %_struct_149
 %ulong_16 = OpConstant %ulong 16
 %uint_2 = OpConstant %uint 2
-%_struct_186 = OpTypeStruct %ulong %ulong
-%187 = OpTypeFunction %_struct_186 %ulong
-%_ptr_Function__struct_186 = OpTypePointer Function %_struct_186
+%_struct_180 = OpTypeStruct %ulong %ulong
+%181 = OpTypeFunction %_struct_180 %ulong
+%_ptr_Function__struct_180 = OpTypePointer Function %_struct_180
 %double = OpTypeFloat 64
-%_struct_202 = OpTypeStruct %double %double
-%203 = OpTypeFunction %_struct_202 %ulong
-%_ptr_Function__struct_202 = OpTypePointer Function %_struct_202
+%_struct_196 = OpTypeStruct %double %double
+%197 = OpTypeFunction %_struct_196 %ulong
+%_ptr_Function__struct_196 = OpTypePointer Function %_struct_196
 %_ptr_Function_double = OpTypePointer Function %double
 %ulong_65535 = OpConstant %ulong 65535
 %double_8 = OpConstant %double 8
 %ulong_262143 = OpConstant %ulong 262143
 %double_64 = OpConstant %double 64
-%_struct_237 = OpTypeStruct %ulong %double
-%238 = OpTypeFunction %_struct_237 %ulong
-%_ptr_Function__struct_237 = OpTypePointer Function %_struct_237
+%_struct_231 = OpTypeStruct %ulong %double
+%232 = OpTypeFunction %_struct_231 %ulong
+%_ptr_Function__struct_231 = OpTypePointer Function %_struct_231
 %ulong_3 = OpConstant %ulong 3
 %ulong_1 = OpConstant %ulong 1
 %ulong_32767 = OpConstant %ulong 32767
 %double_4 = OpConstant %double 4
-%_struct_268 = OpTypeStruct %double %ulong
-%269 = OpTypeFunction %_struct_268 %ulong
-%_ptr_Function__struct_268 = OpTypePointer Function %_struct_268
+%_struct_262 = OpTypeStruct %double %ulong
+%263 = OpTypeFunction %_struct_262 %ulong
+%_ptr_Function__struct_262 = OpTypePointer Function %_struct_262
 %ulong_8191 = OpConstant %ulong 8191
 %double_2 = OpConstant %double 2
 %ulong_305419896 = OpConstant %ulong 305419896
-%295 = OpTypeFunction %ulong %ulong %_struct_96
-%316 = OpTypeFunction %ulong %ulong %_struct_120
-%337 = OpTypeFunction %ulong %ulong %_struct_155
-%365 = OpTypeFunction %ulong %ulong %_struct_186
-%386 = OpTypeFunction %ulong %ulong %_struct_202
-%407 = OpTypeFunction %ulong %ulong %_struct_237
-%428 = OpTypeFunction %ulong %ulong %_struct_268
-%449 = OpTypeFunction %ulong %ulong
+%289 = OpTypeFunction %ulong %ulong %_struct_90
+%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%387 = OpTypeFunction %ulong %ulong %_struct_114
+%486 = OpTypeFunction %ulong %ulong %_struct_149
+%622 = OpTypeFunction %ulong %ulong %_struct_180
+%705 = OpTypeFunction %ulong %ulong %_struct_196
+%798 = OpTypeFunction %ulong %ulong %_struct_231
+%886 = OpTypeFunction %ulong %ulong %_struct_262
+%974 = OpTypeFunction %ulong %ulong
 %ulong_2 = OpConstant %ulong 2
 %ulong_4 = OpConstant %ulong 4
-%ulong_8 = OpConstant %ulong 8
 %ulong_12 = OpConstant %ulong 12
-%488 = OpTypeFunction %ulong %_struct_186 %_struct_202 %_struct_237 %_struct_155 %_struct_96 %_struct_120
-%bool = OpTypeBool
+%1043 = OpTypeFunction %ulong %_struct_180 %_struct_196 %_struct_231 %_struct_149 %_struct_90 %_struct_114
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_6 = OpConstant %uint 6
-%_arr__struct_155_uint_6 = OpTypeArray %_struct_155 %uint_6
-%_ptr_Function__arr__struct_155_uint_6 = OpTypePointer Function %_arr__struct_155_uint_6
-%_arr__struct_237_uint_6 = OpTypeArray %_struct_237 %uint_6
-%_ptr_Function__arr__struct_237_uint_6 = OpTypePointer Function %_arr__struct_237_uint_6
+%_arr__struct_149_uint_6 = OpTypeArray %_struct_149 %uint_6
+%_ptr_Function__arr__struct_149_uint_6 = OpTypePointer Function %_arr__struct_149_uint_6
+%_arr__struct_231_uint_6 = OpTypeArray %_struct_231 %uint_6
+%_ptr_Function__arr__struct_231_uint_6 = OpTypePointer Function %_arr__struct_231_uint_6
 %uint_8 = OpConstant %uint 8
 %_arr_ulong_uint_8 = OpTypeArray %ulong %uint_8
 %_ptr_Function__arr_ulong_uint_8 = OpTypePointer Function %_arr_ulong_uint_8
-%_ptr_Function_bool = OpTypePointer Function %bool
-%892 = OpConstantNull %_arr_ulong_uint_8
-%ulong_0 = OpConstant %ulong 0
-%901 = OpConstantNull %_arr__struct_155_uint_6
-%902 = OpConstantNull %_arr__struct_237_uint_6
+%1422 = OpConstantNull %_arr_ulong_uint_8
+%1430 = OpConstantNull %_arr__struct_149_uint_6
+%1431 = OpConstantNull %_arr__struct_231_uint_6
 %ulong_6 = OpConstant %ulong 6
-%1250 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1293 = OpTypeFunction %ulong %ulong %uchar
-%1338 = OpTypeFunction %ulong %ulong %ushort
-%1383 = OpTypeFunction %ulong %ulong %uint
-%1428 = OpTypeFunction %ulong %ulong %float
-%1476 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %30
-%31 = OpFunctionParameter %ulong
-%32 = OpFunctionParameter %ulong
-%33 = OpLabel
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-OpStore %35 %31
-OpStore %36 %32
-%40 = OpLoad %ulong %36
-%42 = OpIMul %ulong %40 %ulong_6364136223846793005
-OpStore %37 %42
-%43 = OpLoad %ulong %37
-%45 = OpIAdd %ulong %43 %ulong_1442695040888963407
-OpStore %38 %45
-%46 = OpLoad %ulong %38
-%47 = OpLoad %ulong %35
-%48 = OpIAdd %ulong %46 %47
-OpStore %39 %48
-%49 = OpLoad %ulong %39
-OpReturnValue %49
+%1 = OpFunction %ulong None %24
+%25 = OpFunctionParameter %ulong
+%26 = OpFunctionParameter %ulong
+%27 = OpLabel
+%29 = OpVariable %_ptr_Function_ulong Function
+%30 = OpVariable %_ptr_Function_ulong Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%32 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_ulong Function
+OpStore %29 %25
+OpStore %30 %26
+%34 = OpLoad %ulong %30
+%36 = OpIMul %ulong %34 %ulong_6364136223846793005
+OpStore %31 %36
+%37 = OpLoad %ulong %31
+%39 = OpIAdd %ulong %37 %ulong_1442695040888963407
+OpStore %32 %39
+%40 = OpLoad %ulong %32
+%41 = OpLoad %ulong %29
+%42 = OpIAdd %ulong %40 %41
+OpStore %33 %42
+%43 = OpLoad %ulong %33
+OpReturnValue %43
 OpFunctionEnd
-%2 = OpFunction %_struct_51 None %52
-%53 = OpFunctionParameter %ulong
-%54 = OpLabel
-%56 = OpVariable %_ptr_Function__struct_51 Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_uchar Function
-OpStore %57 %53
-%60 = OpLoad %ulong %57
-%61 = OpUConvert %uchar %60
-OpStore %59 %61
-%64 = OpAccessChain %_ptr_Function_uchar %56 %uint_0
-%65 = OpLoad %uchar %59
-OpStore %64 %65
-%66 = OpLoad %_struct_51 %56
-OpReturnValue %66
+%2 = OpFunction %_struct_45 None %46
+%47 = OpFunctionParameter %ulong
+%48 = OpLabel
+%50 = OpVariable %_ptr_Function__struct_45 Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_uchar Function
+OpStore %51 %47
+%54 = OpLoad %ulong %51
+%55 = OpUConvert %uchar %54
+OpStore %53 %55
+%58 = OpAccessChain %_ptr_Function_uchar %50 %uint_0
+%59 = OpLoad %uchar %53
+OpStore %58 %59
+%60 = OpLoad %_struct_45 %50
+OpReturnValue %60
 OpFunctionEnd
-%3 = OpFunction %_struct_68 None %69
-%70 = OpFunctionParameter %ulong
-%71 = OpLabel
-%73 = OpVariable %_ptr_Function__struct_68 Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ushort Function
-OpStore %74 %70
-%77 = OpLoad %ulong %74
-%78 = OpUConvert %ushort %77
-OpStore %76 %78
-%79 = OpAccessChain %_ptr_Function_ushort %73 %uint_0
-%80 = OpLoad %ushort %76
-OpStore %79 %80
-%81 = OpLoad %_struct_68 %73
-OpReturnValue %81
+%3 = OpFunction %_struct_62 None %63
+%64 = OpFunctionParameter %ulong
+%65 = OpLabel
+%67 = OpVariable %_ptr_Function__struct_62 Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ushort Function
+OpStore %68 %64
+%71 = OpLoad %ulong %68
+%72 = OpUConvert %ushort %71
+OpStore %70 %72
+%73 = OpAccessChain %_ptr_Function_ushort %67 %uint_0
+%74 = OpLoad %ushort %70
+OpStore %73 %74
+%75 = OpLoad %_struct_62 %67
+OpReturnValue %75
 OpFunctionEnd
-%4 = OpFunction %_struct_82 None %83
-%84 = OpFunctionParameter %ulong
-%85 = OpLabel
-%87 = OpVariable %_ptr_Function__struct_82 Function
-%88 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_uint Function
-OpStore %88 %84
-%91 = OpLoad %ulong %88
-%92 = OpUConvert %uint %91
-OpStore %90 %92
-%93 = OpAccessChain %_ptr_Function_uint %87 %uint_0
-%94 = OpLoad %uint %90
-OpStore %93 %94
-%95 = OpLoad %_struct_82 %87
-OpReturnValue %95
+%4 = OpFunction %_struct_76 None %77
+%78 = OpFunctionParameter %ulong
+%79 = OpLabel
+%81 = OpVariable %_ptr_Function__struct_76 Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_uint Function
+OpStore %82 %78
+%85 = OpLoad %ulong %82
+%86 = OpUConvert %uint %85
+OpStore %84 %86
+%87 = OpAccessChain %_ptr_Function_uint %81 %uint_0
+%88 = OpLoad %uint %84
+OpStore %87 %88
+%89 = OpLoad %_struct_76 %81
+OpReturnValue %89
 OpFunctionEnd
-%5 = OpFunction %_struct_96 None %97
-%98 = OpFunctionParameter %ulong
-%99 = OpLabel
-%101 = OpVariable %_ptr_Function__struct_96 Function
-%102 = OpVariable %_ptr_Function_ulong Function
-%103 = OpVariable %_ptr_Function_uint Function
-%104 = OpVariable %_ptr_Function_ulong Function
-%105 = OpVariable %_ptr_Function_uint Function
-OpStore %102 %98
-%106 = OpLoad %ulong %102
-%107 = OpUConvert %uint %106
-OpStore %103 %107
-%108 = OpAccessChain %_ptr_Function_uint %101 %uint_0
-%109 = OpLoad %uint %103
-OpStore %108 %109
-%110 = OpLoad %ulong %102
-%112 = OpShiftRightLogical %ulong %110 %ulong_32
-OpStore %104 %112
-%113 = OpLoad %ulong %104
-%114 = OpUConvert %uint %113
-OpStore %105 %114
-%116 = OpAccessChain %_ptr_Function_uint %101 %uint_1
-%117 = OpLoad %uint %105
-OpStore %116 %117
-%118 = OpLoad %_struct_96 %101
-OpReturnValue %118
+%5 = OpFunction %_struct_90 None %91
+%92 = OpFunctionParameter %ulong
+%93 = OpLabel
+%95 = OpVariable %_ptr_Function__struct_90 Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_uint Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_uint Function
+OpStore %96 %92
+%100 = OpLoad %ulong %96
+%101 = OpUConvert %uint %100
+OpStore %97 %101
+%102 = OpAccessChain %_ptr_Function_uint %95 %uint_0
+%103 = OpLoad %uint %97
+OpStore %102 %103
+%104 = OpLoad %ulong %96
+%106 = OpShiftRightLogical %ulong %104 %ulong_32
+OpStore %98 %106
+%107 = OpLoad %ulong %98
+%108 = OpUConvert %uint %107
+OpStore %99 %108
+%110 = OpAccessChain %_ptr_Function_uint %95 %uint_1
+%111 = OpLoad %uint %99
+OpStore %110 %111
+%112 = OpLoad %_struct_90 %95
+OpReturnValue %112
 OpFunctionEnd
-%6 = OpFunction %_struct_120 None %121
-%122 = OpFunctionParameter %ulong
-%123 = OpLabel
-%125 = OpVariable %_ptr_Function__struct_120 Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_float Function
-%130 = OpVariable %_ptr_Function_float Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_float Function
-%133 = OpVariable %_ptr_Function_float Function
-OpStore %126 %122
-%134 = OpLoad %ulong %126
-%136 = OpBitwiseAnd %ulong %134 %ulong_4095
-OpStore %127 %136
-%137 = OpLoad %ulong %127
-%138 = OpConvertUToF %float %137
-OpStore %129 %138
-%139 = OpLoad %float %129
-%141 = OpFDiv %float %139 %float_8
-OpStore %130 %141
-%142 = OpAccessChain %_ptr_Function_float %125 %uint_0
-%143 = OpLoad %float %130
-OpStore %142 %143
-%144 = OpLoad %ulong %126
-%146 = OpBitwiseAnd %ulong %144 %ulong_255
-OpStore %131 %146
-%147 = OpLoad %ulong %131
-%148 = OpConvertUToF %float %147
-OpStore %132 %148
-%149 = OpLoad %float %132
-%151 = OpFSub %float %149 %float_128
-OpStore %133 %151
-%152 = OpAccessChain %_ptr_Function_float %125 %uint_1
-%153 = OpLoad %float %133
-OpStore %152 %153
-%154 = OpLoad %_struct_120 %125
-OpReturnValue %154
+%6 = OpFunction %_struct_114 None %115
+%116 = OpFunctionParameter %ulong
+%117 = OpLabel
+%119 = OpVariable %_ptr_Function__struct_114 Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_float Function
+%124 = OpVariable %_ptr_Function_float Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_float Function
+%127 = OpVariable %_ptr_Function_float Function
+OpStore %120 %116
+%128 = OpLoad %ulong %120
+%130 = OpBitwiseAnd %ulong %128 %ulong_4095
+OpStore %121 %130
+%131 = OpLoad %ulong %121
+%132 = OpConvertUToF %float %131
+OpStore %123 %132
+%133 = OpLoad %float %123
+%135 = OpFDiv %float %133 %float_8
+OpStore %124 %135
+%136 = OpAccessChain %_ptr_Function_float %119 %uint_0
+%137 = OpLoad %float %124
+OpStore %136 %137
+%138 = OpLoad %ulong %120
+%140 = OpBitwiseAnd %ulong %138 %ulong_255
+OpStore %125 %140
+%141 = OpLoad %ulong %125
+%142 = OpConvertUToF %float %141
+OpStore %126 %142
+%143 = OpLoad %float %126
+%145 = OpFSub %float %143 %float_128
+OpStore %127 %145
+%146 = OpAccessChain %_ptr_Function_float %119 %uint_1
+%147 = OpLoad %float %127
+OpStore %146 %147
+%148 = OpLoad %_struct_114 %119
+OpReturnValue %148
 OpFunctionEnd
-%7 = OpFunction %_struct_155 None %156
-%157 = OpFunctionParameter %ulong
-%158 = OpLabel
-%160 = OpVariable %_ptr_Function__struct_155 Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_uint Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_uint Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_uint Function
-OpStore %161 %157
-%167 = OpLoad %ulong %161
-%168 = OpUConvert %uint %167
-OpStore %162 %168
-%169 = OpAccessChain %_ptr_Function_uint %160 %uint_0
-%170 = OpLoad %uint %162
-OpStore %169 %170
-%171 = OpLoad %ulong %161
-%173 = OpShiftRightLogical %ulong %171 %ulong_16
-OpStore %163 %173
-%174 = OpLoad %ulong %163
+%7 = OpFunction %_struct_149 None %150
+%151 = OpFunctionParameter %ulong
+%152 = OpLabel
+%154 = OpVariable %_ptr_Function__struct_149 Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_uint Function
+OpStore %155 %151
+%161 = OpLoad %ulong %155
+%162 = OpUConvert %uint %161
+OpStore %156 %162
+%163 = OpAccessChain %_ptr_Function_uint %154 %uint_0
+%164 = OpLoad %uint %156
+OpStore %163 %164
+%165 = OpLoad %ulong %155
+%167 = OpShiftRightLogical %ulong %165 %ulong_16
+OpStore %157 %167
+%168 = OpLoad %ulong %157
+%169 = OpUConvert %uint %168
+OpStore %158 %169
+%170 = OpAccessChain %_ptr_Function_uint %154 %uint_1
+%171 = OpLoad %uint %158
+OpStore %170 %171
+%172 = OpLoad %ulong %155
+%173 = OpShiftRightLogical %ulong %172 %ulong_32
+OpStore %159 %173
+%174 = OpLoad %ulong %159
 %175 = OpUConvert %uint %174
-OpStore %164 %175
-%176 = OpAccessChain %_ptr_Function_uint %160 %uint_1
-%177 = OpLoad %uint %164
-OpStore %176 %177
-%178 = OpLoad %ulong %161
-%179 = OpShiftRightLogical %ulong %178 %ulong_32
-OpStore %165 %179
-%180 = OpLoad %ulong %165
-%181 = OpUConvert %uint %180
-OpStore %166 %181
-%183 = OpAccessChain %_ptr_Function_uint %160 %uint_2
-%184 = OpLoad %uint %166
-OpStore %183 %184
-%185 = OpLoad %_struct_155 %160
-OpReturnValue %185
+OpStore %160 %175
+%177 = OpAccessChain %_ptr_Function_uint %154 %uint_2
+%178 = OpLoad %uint %160
+OpStore %177 %178
+%179 = OpLoad %_struct_149 %154
+OpReturnValue %179
 OpFunctionEnd
-%8 = OpFunction %_struct_186 None %187
-%188 = OpFunctionParameter %ulong
-%189 = OpLabel
-%191 = OpVariable %_ptr_Function__struct_186 Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-OpStore %192 %188
-%194 = OpAccessChain %_ptr_Function_ulong %191 %uint_0
-%195 = OpLoad %ulong %192
-OpStore %194 %195
-%196 = OpLoad %ulong %192
-%197 = OpNot %ulong %196
-OpStore %193 %197
-%198 = OpAccessChain %_ptr_Function_ulong %191 %uint_1
-%199 = OpLoad %ulong %193
-OpStore %198 %199
-%200 = OpLoad %_struct_186 %191
-OpReturnValue %200
+%8 = OpFunction %_struct_180 None %181
+%182 = OpFunctionParameter %ulong
+%183 = OpLabel
+%185 = OpVariable %_ptr_Function__struct_180 Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+OpStore %186 %182
+%188 = OpAccessChain %_ptr_Function_ulong %185 %uint_0
+%189 = OpLoad %ulong %186
+OpStore %188 %189
+%190 = OpLoad %ulong %186
+%191 = OpNot %ulong %190
+OpStore %187 %191
+%192 = OpAccessChain %_ptr_Function_ulong %185 %uint_1
+%193 = OpLoad %ulong %187
+OpStore %192 %193
+%194 = OpLoad %_struct_180 %185
+OpReturnValue %194
 OpFunctionEnd
-%9 = OpFunction %_struct_202 None %203
-%204 = OpFunctionParameter %ulong
-%205 = OpLabel
-%207 = OpVariable %_ptr_Function__struct_202 Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_double Function
-%212 = OpVariable %_ptr_Function_double Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_double Function
-%215 = OpVariable %_ptr_Function_double Function
-OpStore %208 %204
-%216 = OpLoad %ulong %208
-%218 = OpBitwiseAnd %ulong %216 %ulong_65535
-OpStore %209 %218
-%219 = OpLoad %ulong %209
-%220 = OpConvertUToF %double %219
-OpStore %211 %220
-%221 = OpLoad %double %211
-%223 = OpFDiv %double %221 %double_8
-OpStore %212 %223
-%224 = OpAccessChain %_ptr_Function_double %207 %uint_0
-%225 = OpLoad %double %212
-OpStore %224 %225
-%226 = OpLoad %ulong %208
-%228 = OpBitwiseAnd %ulong %226 %ulong_262143
-OpStore %213 %228
-%229 = OpLoad %ulong %213
-%230 = OpConvertUToF %double %229
-OpStore %214 %230
-%231 = OpLoad %double %214
-%233 = OpFDiv %double %231 %double_64
-OpStore %215 %233
-%234 = OpAccessChain %_ptr_Function_double %207 %uint_1
-%235 = OpLoad %double %215
-OpStore %234 %235
-%236 = OpLoad %_struct_202 %207
-OpReturnValue %236
+%9 = OpFunction %_struct_196 None %197
+%198 = OpFunctionParameter %ulong
+%199 = OpLabel
+%201 = OpVariable %_ptr_Function__struct_196 Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_double Function
+%206 = OpVariable %_ptr_Function_double Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_double Function
+%209 = OpVariable %_ptr_Function_double Function
+OpStore %202 %198
+%210 = OpLoad %ulong %202
+%212 = OpBitwiseAnd %ulong %210 %ulong_65535
+OpStore %203 %212
+%213 = OpLoad %ulong %203
+%214 = OpConvertUToF %double %213
+OpStore %205 %214
+%215 = OpLoad %double %205
+%217 = OpFDiv %double %215 %double_8
+OpStore %206 %217
+%218 = OpAccessChain %_ptr_Function_double %201 %uint_0
+%219 = OpLoad %double %206
+OpStore %218 %219
+%220 = OpLoad %ulong %202
+%222 = OpBitwiseAnd %ulong %220 %ulong_262143
+OpStore %207 %222
+%223 = OpLoad %ulong %207
+%224 = OpConvertUToF %double %223
+OpStore %208 %224
+%225 = OpLoad %double %208
+%227 = OpFDiv %double %225 %double_64
+OpStore %209 %227
+%228 = OpAccessChain %_ptr_Function_double %201 %uint_1
+%229 = OpLoad %double %209
+OpStore %228 %229
+%230 = OpLoad %_struct_196 %201
+OpReturnValue %230
 OpFunctionEnd
-%10 = OpFunction %_struct_237 None %238
-%239 = OpFunctionParameter %ulong
-%240 = OpLabel
-%242 = OpVariable %_ptr_Function__struct_237 Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_double Function
-%248 = OpVariable %_ptr_Function_double Function
-OpStore %243 %239
-%249 = OpLoad %ulong %243
-%251 = OpIMul %ulong %249 %ulong_3
-OpStore %244 %251
-%252 = OpLoad %ulong %244
-%254 = OpIAdd %ulong %252 %ulong_1
-OpStore %245 %254
-%255 = OpAccessChain %_ptr_Function_ulong %242 %uint_0
-%256 = OpLoad %ulong %245
-OpStore %255 %256
-%257 = OpLoad %ulong %243
-%259 = OpBitwiseAnd %ulong %257 %ulong_32767
-OpStore %246 %259
-%260 = OpLoad %ulong %246
-%261 = OpConvertUToF %double %260
-OpStore %247 %261
-%262 = OpLoad %double %247
-%264 = OpFDiv %double %262 %double_4
-OpStore %248 %264
-%265 = OpAccessChain %_ptr_Function_double %242 %uint_1
-%266 = OpLoad %double %248
-OpStore %265 %266
-%267 = OpLoad %_struct_237 %242
-OpReturnValue %267
+%10 = OpFunction %_struct_231 None %232
+%233 = OpFunctionParameter %ulong
+%234 = OpLabel
+%236 = OpVariable %_ptr_Function__struct_231 Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_double Function
+%242 = OpVariable %_ptr_Function_double Function
+OpStore %237 %233
+%243 = OpLoad %ulong %237
+%245 = OpIMul %ulong %243 %ulong_3
+OpStore %238 %245
+%246 = OpLoad %ulong %238
+%248 = OpIAdd %ulong %246 %ulong_1
+OpStore %239 %248
+%249 = OpAccessChain %_ptr_Function_ulong %236 %uint_0
+%250 = OpLoad %ulong %239
+OpStore %249 %250
+%251 = OpLoad %ulong %237
+%253 = OpBitwiseAnd %ulong %251 %ulong_32767
+OpStore %240 %253
+%254 = OpLoad %ulong %240
+%255 = OpConvertUToF %double %254
+OpStore %241 %255
+%256 = OpLoad %double %241
+%258 = OpFDiv %double %256 %double_4
+OpStore %242 %258
+%259 = OpAccessChain %_ptr_Function_double %236 %uint_1
+%260 = OpLoad %double %242
+OpStore %259 %260
+%261 = OpLoad %_struct_231 %236
+OpReturnValue %261
 OpFunctionEnd
-%11 = OpFunction %_struct_268 None %269
-%270 = OpFunctionParameter %ulong
-%271 = OpLabel
-%273 = OpVariable %_ptr_Function__struct_268 Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_double Function
-%277 = OpVariable %_ptr_Function_double Function
-%278 = OpVariable %_ptr_Function_ulong Function
-OpStore %274 %270
-%279 = OpLoad %ulong %274
-%281 = OpBitwiseAnd %ulong %279 %ulong_8191
-OpStore %275 %281
-%282 = OpLoad %ulong %275
-%283 = OpConvertUToF %double %282
-OpStore %276 %283
-%284 = OpLoad %double %276
-%286 = OpFDiv %double %284 %double_2
-OpStore %277 %286
-%287 = OpAccessChain %_ptr_Function_double %273 %uint_0
-%288 = OpLoad %double %277
-OpStore %287 %288
-%289 = OpLoad %ulong %274
-%291 = OpBitwiseXor %ulong %289 %ulong_305419896
-OpStore %278 %291
-%292 = OpAccessChain %_ptr_Function_ulong %273 %uint_1
-%293 = OpLoad %ulong %278
-OpStore %292 %293
-%294 = OpLoad %_struct_268 %273
-OpReturnValue %294
+%11 = OpFunction %_struct_262 None %263
+%264 = OpFunctionParameter %ulong
+%265 = OpLabel
+%267 = OpVariable %_ptr_Function__struct_262 Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_double Function
+%271 = OpVariable %_ptr_Function_double Function
+%272 = OpVariable %_ptr_Function_ulong Function
+OpStore %268 %264
+%273 = OpLoad %ulong %268
+%275 = OpBitwiseAnd %ulong %273 %ulong_8191
+OpStore %269 %275
+%276 = OpLoad %ulong %269
+%277 = OpConvertUToF %double %276
+OpStore %270 %277
+%278 = OpLoad %double %270
+%280 = OpFDiv %double %278 %double_2
+OpStore %271 %280
+%281 = OpAccessChain %_ptr_Function_double %267 %uint_0
+%282 = OpLoad %double %271
+OpStore %281 %282
+%283 = OpLoad %ulong %268
+%285 = OpBitwiseXor %ulong %283 %ulong_305419896
+OpStore %272 %285
+%286 = OpAccessChain %_ptr_Function_ulong %267 %uint_1
+%287 = OpLoad %ulong %272
+OpStore %286 %287
+%288 = OpLoad %_struct_262 %267
+OpReturnValue %288
 OpFunctionEnd
-%12 = OpFunction %ulong None %295
-%296 = OpFunctionParameter %ulong
-%297 = OpFunctionParameter %_struct_96
-%298 = OpLabel
-%299 = OpVariable %_ptr_Function__struct_96 Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_uint Function
-%304 = OpVariable %_ptr_Function_uint Function
-OpStore %300 %296
-OpStore %299 %297
-%305 = OpAccessChain %_ptr_Function_uint %299 %uint_0
-%306 = OpLoad %uint %305
-OpStore %303 %306
-%307 = OpAccessChain %_ptr_Function_uint %299 %uint_1
-%308 = OpLoad %uint %307
-OpStore %304 %308
-%309 = OpLoad %ulong %300
-%310 = OpLoad %uint %303
-%311 = OpFunctionCall %ulong %26 %309 %310
-OpStore %301 %311
-%312 = OpLoad %ulong %301
-%313 = OpLoad %uint %304
-%314 = OpFunctionCall %ulong %26 %312 %313
-OpStore %302 %314
-%315 = OpLoad %ulong %302
-OpReturnValue %315
-OpFunctionEnd
-%13 = OpFunction %ulong None %316
-%317 = OpFunctionParameter %ulong
-%318 = OpFunctionParameter %_struct_120
-%319 = OpLabel
-%320 = OpVariable %_ptr_Function__struct_120 Function
+%12 = OpFunction %ulong None %289
+%290 = OpFunctionParameter %ulong
+%291 = OpFunctionParameter %_struct_90
+%292 = OpLabel
+%310 = OpVariable %_ptr_Function__struct_90 Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
 %321 = OpVariable %_ptr_Function_ulong Function
 %322 = OpVariable %_ptr_Function_ulong Function
 %323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_float Function
-%325 = OpVariable %_ptr_Function_float Function
-OpStore %321 %317
-OpStore %320 %318
-%326 = OpAccessChain %_ptr_Function_float %320 %uint_0
-%327 = OpLoad %float %326
-OpStore %324 %327
-%328 = OpAccessChain %_ptr_Function_float %320 %uint_1
-%329 = OpLoad %float %328
-OpStore %325 %329
-%330 = OpLoad %ulong %321
-%331 = OpLoad %float %324
-%332 = OpFunctionCall %ulong %27 %330 %331
-OpStore %322 %332
-%333 = OpLoad %ulong %322
-%334 = OpLoad %float %325
-%335 = OpFunctionCall %ulong %27 %333 %334
-OpStore %323 %335
-%336 = OpLoad %ulong %323
-OpReturnValue %336
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_uint Function
+%334 = OpVariable %_ptr_Function_uint Function
+OpStore %311 %290
+OpStore %310 %291
+%335 = OpAccessChain %_ptr_Function_uint %310 %uint_0
+%336 = OpLoad %uint %335
+OpStore %333 %336
+%337 = OpAccessChain %_ptr_Function_uint %310 %uint_1
+%338 = OpLoad %uint %337
+OpStore %334 %338
+OpBranch %293
+%293 = OpLabel
+%339 = OpLoad %uint %333
+%340 = OpUConvert %ulong %339
+OpStore %312 %340
+OpBranch %295
+%295 = OpLabel
+%341 = OpLoad %ulong %311
+OpStore %321 %341
+OpStore %322 %ulong_0
+OpBranch %296
+%296 = OpLabel
+%343 = OpLoad %ulong %322
+%345 = OpULessThan %bool %343 %ulong_8
+OpStore %314 %345
+%346 = OpLoad %bool %314
+OpLoopMerge %298 %308 None
+OpBranchConditional %346 %297 %298
+%298 = OpLabel
+OpBranch %299
+%299 = OpLabel
+OpBranch %294
+%294 = OpLabel
+OpBranch %300
+%300 = OpLabel
+%347 = OpLoad %uint %334
+%348 = OpUConvert %ulong %347
+OpStore %323 %348
+OpBranch %302
+%302 = OpLabel
+%349 = OpLoad %ulong %321
+OpStore %331 %349
+OpStore %332 %ulong_0
+OpBranch %303
+%303 = OpLabel
+%350 = OpLoad %ulong %332
+%351 = OpULessThan %bool %350 %ulong_8
+OpStore %324 %351
+%352 = OpLoad %bool %324
+OpLoopMerge %305 %307 None
+OpBranchConditional %352 %304 %305
+%305 = OpLabel
+OpBranch %306
+%306 = OpLabel
+OpBranch %301
+%301 = OpLabel
+%353 = OpLoad %ulong %331
+OpReturnValue %353
+%304 = OpLabel
+%354 = OpLoad %ulong %332
+%355 = OpIMul %ulong %354 %ulong_8
+OpStore %325 %355
+%356 = OpLoad %ulong %323
+%357 = OpLoad %ulong %325
+%358 = OpShiftRightLogical %ulong %356 %357
+OpStore %326 %358
+%359 = OpLoad %ulong %326
+%360 = OpBitwiseAnd %ulong %359 %ulong_255
+OpStore %327 %360
+%361 = OpLoad %ulong %331
+%362 = OpLoad %ulong %327
+%363 = OpBitwiseXor %ulong %361 %362
+OpStore %328 %363
+%364 = OpLoad %ulong %328
+%366 = OpIMul %ulong %364 %ulong_1099511628211
+OpStore %329 %366
+%367 = OpLoad %ulong %332
+%368 = OpIAdd %ulong %367 %ulong_1
+OpStore %330 %368
+%369 = OpLoad %ulong %329
+OpStore %331 %369
+%370 = OpLoad %ulong %330
+OpStore %332 %370
+OpBranch %307
+%297 = OpLabel
+%371 = OpLoad %ulong %322
+%372 = OpIMul %ulong %371 %ulong_8
+OpStore %315 %372
+%373 = OpLoad %ulong %312
+%374 = OpLoad %ulong %315
+%375 = OpShiftRightLogical %ulong %373 %374
+OpStore %316 %375
+%376 = OpLoad %ulong %316
+%377 = OpBitwiseAnd %ulong %376 %ulong_255
+OpStore %317 %377
+%378 = OpLoad %ulong %321
+%379 = OpLoad %ulong %317
+%380 = OpBitwiseXor %ulong %378 %379
+OpStore %318 %380
+%381 = OpLoad %ulong %318
+%382 = OpIMul %ulong %381 %ulong_1099511628211
+OpStore %319 %382
+%383 = OpLoad %ulong %322
+%384 = OpIAdd %ulong %383 %ulong_1
+OpStore %320 %384
+%385 = OpLoad %ulong %319
+OpStore %321 %385
+%386 = OpLoad %ulong %320
+OpStore %322 %386
+OpBranch %308
+%307 = OpLabel
+OpBranch %303
+%308 = OpLabel
+OpBranch %296
 OpFunctionEnd
-%14 = OpFunction %ulong None %337
-%338 = OpFunctionParameter %ulong
-%339 = OpFunctionParameter %_struct_155
-%340 = OpLabel
-%341 = OpVariable %_ptr_Function__struct_155 Function
-%342 = OpVariable %_ptr_Function_ulong Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_uint Function
-%347 = OpVariable %_ptr_Function_uint Function
-%348 = OpVariable %_ptr_Function_uint Function
-OpStore %342 %338
-OpStore %341 %339
-%349 = OpAccessChain %_ptr_Function_uint %341 %uint_0
-%350 = OpLoad %uint %349
-OpStore %346 %350
-%351 = OpAccessChain %_ptr_Function_uint %341 %uint_1
-%352 = OpLoad %uint %351
-OpStore %347 %352
-%353 = OpAccessChain %_ptr_Function_uint %341 %uint_2
-%354 = OpLoad %uint %353
-OpStore %348 %354
-%355 = OpLoad %ulong %342
-%356 = OpLoad %uint %346
-%357 = OpFunctionCall %ulong %26 %355 %356
-OpStore %343 %357
-%358 = OpLoad %ulong %343
-%359 = OpLoad %uint %347
-%360 = OpFunctionCall %ulong %26 %358 %359
-OpStore %344 %360
-%361 = OpLoad %ulong %344
-%362 = OpLoad %uint %348
-%363 = OpFunctionCall %ulong %26 %361 %362
-OpStore %345 %363
-%364 = OpLoad %ulong %345
-OpReturnValue %364
-OpFunctionEnd
-%15 = OpFunction %ulong None %365
-%366 = OpFunctionParameter %ulong
-%367 = OpFunctionParameter %_struct_186
-%368 = OpLabel
-%369 = OpVariable %_ptr_Function__struct_186 Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_ulong Function
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_ulong Function
-OpStore %370 %366
-OpStore %369 %367
-%375 = OpAccessChain %_ptr_Function_ulong %369 %uint_0
-%376 = OpLoad %ulong %375
-OpStore %373 %376
-%377 = OpAccessChain %_ptr_Function_ulong %369 %uint_1
-%378 = OpLoad %ulong %377
-OpStore %374 %378
-%379 = OpLoad %ulong %370
-%380 = OpLoad %ulong %373
-%381 = OpFunctionCall %ulong %23 %379 %380
-OpStore %371 %381
-%382 = OpLoad %ulong %371
-%383 = OpLoad %ulong %374
-%384 = OpFunctionCall %ulong %23 %382 %383
-OpStore %372 %384
-%385 = OpLoad %ulong %372
-OpReturnValue %385
-OpFunctionEnd
-%16 = OpFunction %ulong None %386
-%387 = OpFunctionParameter %ulong
-%388 = OpFunctionParameter %_struct_202
-%389 = OpLabel
-%390 = OpVariable %_ptr_Function__struct_202 Function
-%391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_double Function
-%395 = OpVariable %_ptr_Function_double Function
-OpStore %391 %387
-OpStore %390 %388
-%396 = OpAccessChain %_ptr_Function_double %390 %uint_0
-%397 = OpLoad %double %396
-OpStore %394 %397
-%398 = OpAccessChain %_ptr_Function_double %390 %uint_1
-%399 = OpLoad %double %398
-OpStore %395 %399
-%400 = OpLoad %ulong %391
-%401 = OpLoad %double %394
-%402 = OpFunctionCall %ulong %28 %400 %401
-OpStore %392 %402
-%403 = OpLoad %ulong %392
-%404 = OpLoad %double %395
-%405 = OpFunctionCall %ulong %28 %403 %404
-OpStore %393 %405
-%406 = OpLoad %ulong %393
-OpReturnValue %406
-OpFunctionEnd
-%17 = OpFunction %ulong None %407
-%408 = OpFunctionParameter %ulong
-%409 = OpFunctionParameter %_struct_237
-%410 = OpLabel
-%411 = OpVariable %_ptr_Function__struct_237 Function
+%13 = OpFunction %ulong None %387
+%388 = OpFunctionParameter %ulong
+%389 = OpFunctionParameter %_struct_114
+%390 = OpLabel
+%407 = OpVariable %_ptr_Function__struct_114 Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_uint Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_bool Function
 %412 = OpVariable %_ptr_Function_ulong Function
 %413 = OpVariable %_ptr_Function_ulong Function
 %414 = OpVariable %_ptr_Function_ulong Function
 %415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_double Function
-OpStore %412 %408
-OpStore %411 %409
-%417 = OpAccessChain %_ptr_Function_ulong %411 %uint_0
-%418 = OpLoad %ulong %417
-OpStore %415 %418
-%419 = OpAccessChain %_ptr_Function_double %411 %uint_1
-%420 = OpLoad %double %419
-OpStore %416 %420
-%421 = OpLoad %ulong %412
-%422 = OpLoad %ulong %415
-%423 = OpFunctionCall %ulong %23 %421 %422
-OpStore %413 %423
-%424 = OpLoad %ulong %413
-%425 = OpLoad %double %416
-%426 = OpFunctionCall %ulong %28 %424 %425
-OpStore %414 %426
-%427 = OpLoad %ulong %414
-OpReturnValue %427
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_uint Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_bool Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_float Function
+%432 = OpVariable %_ptr_Function_float Function
+OpStore %408 %388
+OpStore %407 %389
+%433 = OpAccessChain %_ptr_Function_float %407 %uint_0
+%434 = OpLoad %float %433
+OpStore %431 %434
+%435 = OpAccessChain %_ptr_Function_float %407 %uint_1
+%436 = OpLoad %float %435
+OpStore %432 %436
+OpBranch %391
+%391 = OpLabel
+%437 = OpLoad %float %431
+%438 = OpBitcast %uint %437
+OpStore %409 %438
+%439 = OpLoad %uint %409
+%440 = OpUConvert %ulong %439
+OpStore %410 %440
+OpBranch %393
+%393 = OpLabel
+%441 = OpLoad %ulong %408
+OpStore %418 %441
+OpStore %419 %ulong_0
+OpBranch %394
+%394 = OpLabel
+%442 = OpLoad %ulong %419
+%443 = OpULessThan %bool %442 %ulong_8
+OpStore %411 %443
+%444 = OpLoad %bool %411
+OpLoopMerge %396 %406 None
+OpBranchConditional %444 %395 %396
+%396 = OpLabel
+OpBranch %397
+%397 = OpLabel
+OpBranch %392
+%392 = OpLabel
+OpBranch %398
+%398 = OpLabel
+%445 = OpLoad %float %432
+%446 = OpBitcast %uint %445
+OpStore %420 %446
+%447 = OpLoad %uint %420
+%448 = OpUConvert %ulong %447
+OpStore %421 %448
+OpBranch %400
+%400 = OpLabel
+%449 = OpLoad %ulong %418
+OpStore %429 %449
+OpStore %430 %ulong_0
+OpBranch %401
+%401 = OpLabel
+%450 = OpLoad %ulong %430
+%451 = OpULessThan %bool %450 %ulong_8
+OpStore %422 %451
+%452 = OpLoad %bool %422
+OpLoopMerge %403 %405 None
+OpBranchConditional %452 %402 %403
+%403 = OpLabel
+OpBranch %404
+%404 = OpLabel
+OpBranch %399
+%399 = OpLabel
+%453 = OpLoad %ulong %429
+OpReturnValue %453
+%402 = OpLabel
+%454 = OpLoad %ulong %430
+%455 = OpIMul %ulong %454 %ulong_8
+OpStore %423 %455
+%456 = OpLoad %ulong %421
+%457 = OpLoad %ulong %423
+%458 = OpShiftRightLogical %ulong %456 %457
+OpStore %424 %458
+%459 = OpLoad %ulong %424
+%460 = OpBitwiseAnd %ulong %459 %ulong_255
+OpStore %425 %460
+%461 = OpLoad %ulong %429
+%462 = OpLoad %ulong %425
+%463 = OpBitwiseXor %ulong %461 %462
+OpStore %426 %463
+%464 = OpLoad %ulong %426
+%465 = OpIMul %ulong %464 %ulong_1099511628211
+OpStore %427 %465
+%466 = OpLoad %ulong %430
+%467 = OpIAdd %ulong %466 %ulong_1
+OpStore %428 %467
+%468 = OpLoad %ulong %427
+OpStore %429 %468
+%469 = OpLoad %ulong %428
+OpStore %430 %469
+OpBranch %405
+%395 = OpLabel
+%470 = OpLoad %ulong %419
+%471 = OpIMul %ulong %470 %ulong_8
+OpStore %412 %471
+%472 = OpLoad %ulong %410
+%473 = OpLoad %ulong %412
+%474 = OpShiftRightLogical %ulong %472 %473
+OpStore %413 %474
+%475 = OpLoad %ulong %413
+%476 = OpBitwiseAnd %ulong %475 %ulong_255
+OpStore %414 %476
+%477 = OpLoad %ulong %418
+%478 = OpLoad %ulong %414
+%479 = OpBitwiseXor %ulong %477 %478
+OpStore %415 %479
+%480 = OpLoad %ulong %415
+%481 = OpIMul %ulong %480 %ulong_1099511628211
+OpStore %416 %481
+%482 = OpLoad %ulong %419
+%483 = OpIAdd %ulong %482 %ulong_1
+OpStore %417 %483
+%484 = OpLoad %ulong %416
+OpStore %418 %484
+%485 = OpLoad %ulong %417
+OpStore %419 %485
+OpBranch %406
+%405 = OpLabel
+OpBranch %401
+%406 = OpLabel
+OpBranch %394
 OpFunctionEnd
-%18 = OpFunction %ulong None %428
-%429 = OpFunctionParameter %ulong
-%430 = OpFunctionParameter %_struct_268
-%431 = OpLabel
-%432 = OpVariable %_ptr_Function__struct_268 Function
-%433 = OpVariable %_ptr_Function_ulong Function
-%434 = OpVariable %_ptr_Function_ulong Function
-%435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_double Function
-%437 = OpVariable %_ptr_Function_ulong Function
-OpStore %433 %429
-OpStore %432 %430
-%438 = OpAccessChain %_ptr_Function_double %432 %uint_0
-%439 = OpLoad %double %438
-OpStore %436 %439
-%440 = OpAccessChain %_ptr_Function_ulong %432 %uint_1
-%441 = OpLoad %ulong %440
-OpStore %437 %441
-%442 = OpLoad %ulong %433
-%443 = OpLoad %double %436
-%444 = OpFunctionCall %ulong %28 %442 %443
-OpStore %434 %444
-%445 = OpLoad %ulong %434
-%446 = OpLoad %ulong %437
-%447 = OpFunctionCall %ulong %23 %445 %446
-OpStore %435 %447
-%448 = OpLoad %ulong %435
-OpReturnValue %448
-OpFunctionEnd
-%19 = OpFunction %ulong None %449
-%450 = OpFunctionParameter %ulong
-%451 = OpLabel
-%452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_ulong Function
-%454 = OpVariable %_ptr_Function_ulong Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-OpStore %452 %450
-%463 = OpLoad %ulong %452
-%464 = OpFunctionCall %ulong %23 %463 %ulong_1
-OpStore %453 %464
-%465 = OpLoad %ulong %453
-%467 = OpFunctionCall %ulong %23 %465 %ulong_2
-OpStore %454 %467
-%468 = OpLoad %ulong %454
-%470 = OpFunctionCall %ulong %23 %468 %ulong_4
-OpStore %455 %470
-%471 = OpLoad %ulong %455
-%473 = OpFunctionCall %ulong %23 %471 %ulong_8
-OpStore %456 %473
-%474 = OpLoad %ulong %456
-%475 = OpFunctionCall %ulong %23 %474 %ulong_8
-OpStore %457 %475
-%476 = OpLoad %ulong %457
-%478 = OpFunctionCall %ulong %23 %476 %ulong_12
-OpStore %458 %478
-%479 = OpLoad %ulong %458
-%480 = OpFunctionCall %ulong %23 %479 %ulong_16
-OpStore %459 %480
-%481 = OpLoad %ulong %459
-%482 = OpFunctionCall %ulong %23 %481 %ulong_16
-OpStore %460 %482
-%483 = OpLoad %ulong %460
-%484 = OpFunctionCall %ulong %23 %483 %ulong_16
-OpStore %461 %484
-%485 = OpLoad %ulong %461
-%486 = OpFunctionCall %ulong %23 %485 %ulong_16
-OpStore %462 %486
-%487 = OpLoad %ulong %462
-OpReturnValue %487
-OpFunctionEnd
-%20 = OpFunction %ulong None %488
-%489 = OpFunctionParameter %_struct_186
-%490 = OpFunctionParameter %_struct_202
-%491 = OpFunctionParameter %_struct_237
-%492 = OpFunctionParameter %_struct_155
-%493 = OpFunctionParameter %_struct_96
-%494 = OpFunctionParameter %_struct_120
-%495 = OpLabel
-%508 = OpVariable %_ptr_Function__struct_186 Function
-%509 = OpVariable %_ptr_Function__struct_202 Function
-%510 = OpVariable %_ptr_Function__struct_237 Function
-%511 = OpVariable %_ptr_Function__struct_155 Function
-%512 = OpVariable %_ptr_Function__struct_96 Function
-%513 = OpVariable %_ptr_Function__struct_120 Function
-%514 = OpVariable %_ptr_Function_ulong Function
+%14 = OpFunction %ulong None %486
+%487 = OpFunctionParameter %ulong
+%488 = OpFunctionParameter %_struct_149
+%489 = OpLabel
+%514 = OpVariable %_ptr_Function__struct_149 Function
 %515 = OpVariable %_ptr_Function_ulong Function
 %516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_bool Function
 %518 = OpVariable %_ptr_Function_ulong Function
 %519 = OpVariable %_ptr_Function_ulong Function
 %520 = OpVariable %_ptr_Function_ulong Function
@@ -719,163 +733,325 @@ OpFunctionEnd
 %524 = OpVariable %_ptr_Function_ulong Function
 %525 = OpVariable %_ptr_Function_ulong Function
 %526 = OpVariable %_ptr_Function_ulong Function
-%527 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_bool Function
 %528 = OpVariable %_ptr_Function_ulong Function
 %529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_double Function
-%531 = OpVariable %_ptr_Function_double Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
 %532 = OpVariable %_ptr_Function_ulong Function
-%533 = OpVariable %_ptr_Function_double Function
-%534 = OpVariable %_ptr_Function_uint Function
-%535 = OpVariable %_ptr_Function_uint Function
-%536 = OpVariable %_ptr_Function_uint Function
-%537 = OpVariable %_ptr_Function_uint Function
-%538 = OpVariable %_ptr_Function_uint Function
-%539 = OpVariable %_ptr_Function_float Function
-%540 = OpVariable %_ptr_Function_float Function
-OpStore %508 %489
-OpStore %509 %490
-OpStore %510 %491
-OpStore %511 %492
-OpStore %512 %493
-OpStore %513 %494
-%541 = OpAccessChain %_ptr_Function_ulong %508 %uint_0
-%542 = OpLoad %ulong %541
-OpStore %528 %542
-%543 = OpAccessChain %_ptr_Function_ulong %508 %uint_1
-%544 = OpLoad %ulong %543
-OpStore %529 %544
-%545 = OpAccessChain %_ptr_Function_double %509 %uint_0
-%546 = OpLoad %double %545
-OpStore %530 %546
-%547 = OpAccessChain %_ptr_Function_double %509 %uint_1
-%548 = OpLoad %double %547
-OpStore %531 %548
-%549 = OpAccessChain %_ptr_Function_ulong %510 %uint_0
-%550 = OpLoad %ulong %549
-OpStore %532 %550
-%551 = OpAccessChain %_ptr_Function_double %510 %uint_1
-%552 = OpLoad %double %551
-OpStore %533 %552
-%553 = OpAccessChain %_ptr_Function_uint %511 %uint_0
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_bool Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_uint Function
+%547 = OpVariable %_ptr_Function_uint Function
+%548 = OpVariable %_ptr_Function_uint Function
+OpStore %515 %487
+OpStore %514 %488
+%549 = OpAccessChain %_ptr_Function_uint %514 %uint_0
+%550 = OpLoad %uint %549
+OpStore %546 %550
+%551 = OpAccessChain %_ptr_Function_uint %514 %uint_1
+%552 = OpLoad %uint %551
+OpStore %547 %552
+%553 = OpAccessChain %_ptr_Function_uint %514 %uint_2
 %554 = OpLoad %uint %553
-OpStore %534 %554
-%555 = OpAccessChain %_ptr_Function_uint %511 %uint_1
-%556 = OpLoad %uint %555
-OpStore %535 %556
-%557 = OpAccessChain %_ptr_Function_uint %511 %uint_2
-%558 = OpLoad %uint %557
-OpStore %536 %558
-%559 = OpAccessChain %_ptr_Function_uint %512 %uint_0
-%560 = OpLoad %uint %559
-OpStore %537 %560
-%561 = OpAccessChain %_ptr_Function_uint %512 %uint_1
-%562 = OpLoad %uint %561
-OpStore %538 %562
-%563 = OpAccessChain %_ptr_Function_float %513 %uint_0
-%564 = OpLoad %float %563
-OpStore %539 %564
-%565 = OpAccessChain %_ptr_Function_float %513 %uint_1
-%566 = OpLoad %float %565
-OpStore %540 %566
-%567 = OpFunctionCall %ulong %22
-OpStore %514 %567
+OpStore %548 %554
+OpBranch %490
+%490 = OpLabel
+%555 = OpLoad %uint %546
+%556 = OpUConvert %ulong %555
+OpStore %516 %556
+OpBranch %492
+%492 = OpLabel
+%557 = OpLoad %ulong %515
+OpStore %524 %557
+OpStore %525 %ulong_0
+OpBranch %493
+%493 = OpLabel
+%558 = OpLoad %ulong %525
+%559 = OpULessThan %bool %558 %ulong_8
+OpStore %517 %559
+%560 = OpLoad %bool %517
+OpLoopMerge %495 %513 None
+OpBranchConditional %560 %494 %495
+%495 = OpLabel
 OpBranch %496
 %496 = OpLabel
-%568 = OpLoad %ulong %514
-%569 = OpLoad %ulong %528
-%570 = OpFunctionCall %ulong %23 %568 %569
-OpStore %515 %570
-%571 = OpLoad %ulong %515
-%572 = OpLoad %ulong %529
-%573 = OpFunctionCall %ulong %23 %571 %572
-OpStore %516 %573
+OpBranch %491
+%491 = OpLabel
 OpBranch %497
 %497 = OpLabel
-OpBranch %498
-%498 = OpLabel
-%574 = OpLoad %ulong %516
-%575 = OpLoad %double %530
-%576 = OpFunctionCall %ulong %28 %574 %575
-OpStore %517 %576
-%577 = OpLoad %ulong %517
-%578 = OpLoad %double %531
-%579 = OpFunctionCall %ulong %28 %577 %578
-OpStore %518 %579
+%561 = OpLoad %uint %547
+%562 = OpUConvert %ulong %561
+OpStore %526 %562
 OpBranch %499
 %499 = OpLabel
+%563 = OpLoad %ulong %524
+OpStore %534 %563
+OpStore %535 %ulong_0
 OpBranch %500
 %500 = OpLabel
-%580 = OpLoad %ulong %518
-%581 = OpLoad %ulong %532
-%582 = OpFunctionCall %ulong %23 %580 %581
-OpStore %519 %582
-%583 = OpLoad %ulong %519
-%584 = OpLoad %double %533
-%585 = OpFunctionCall %ulong %28 %583 %584
-OpStore %520 %585
-OpBranch %501
-%501 = OpLabel
-OpBranch %502
+%564 = OpLoad %ulong %535
+%565 = OpULessThan %bool %564 %ulong_8
+OpStore %527 %565
+%566 = OpLoad %bool %527
+OpLoopMerge %502 %512 None
+OpBranchConditional %566 %501 %502
 %502 = OpLabel
-%586 = OpLoad %ulong %520
-%587 = OpLoad %uint %534
-%588 = OpFunctionCall %ulong %26 %586 %587
-OpStore %521 %588
-%589 = OpLoad %ulong %521
-%590 = OpLoad %uint %535
-%591 = OpFunctionCall %ulong %26 %589 %590
-OpStore %522 %591
-%592 = OpLoad %ulong %522
-%593 = OpLoad %uint %536
-%594 = OpFunctionCall %ulong %26 %592 %593
-OpStore %523 %594
 OpBranch %503
 %503 = OpLabel
+OpBranch %498
+%498 = OpLabel
 OpBranch %504
 %504 = OpLabel
-%595 = OpLoad %ulong %523
-%596 = OpLoad %uint %537
-%597 = OpFunctionCall %ulong %26 %595 %596
-OpStore %524 %597
-%598 = OpLoad %ulong %524
-%599 = OpLoad %uint %538
-%600 = OpFunctionCall %ulong %26 %598 %599
-OpStore %525 %600
-OpBranch %505
-%505 = OpLabel
+%567 = OpLoad %uint %548
+%568 = OpUConvert %ulong %567
+OpStore %536 %568
 OpBranch %506
 %506 = OpLabel
-%601 = OpLoad %ulong %525
-%602 = OpLoad %float %539
-%603 = OpFunctionCall %ulong %27 %601 %602
-OpStore %526 %603
-%604 = OpLoad %ulong %526
-%605 = OpLoad %float %540
-%606 = OpFunctionCall %ulong %27 %604 %605
-OpStore %527 %606
+%569 = OpLoad %ulong %534
+OpStore %544 %569
+OpStore %545 %ulong_0
 OpBranch %507
 %507 = OpLabel
-%607 = OpLoad %ulong %527
-OpReturnValue %607
+%570 = OpLoad %ulong %545
+%571 = OpULessThan %bool %570 %ulong_8
+OpStore %537 %571
+%572 = OpLoad %bool %537
+OpLoopMerge %509 %511 None
+OpBranchConditional %572 %508 %509
+%509 = OpLabel
+OpBranch %510
+%510 = OpLabel
+OpBranch %505
+%505 = OpLabel
+%573 = OpLoad %ulong %544
+OpReturnValue %573
+%508 = OpLabel
+%574 = OpLoad %ulong %545
+%575 = OpIMul %ulong %574 %ulong_8
+OpStore %538 %575
+%576 = OpLoad %ulong %536
+%577 = OpLoad %ulong %538
+%578 = OpShiftRightLogical %ulong %576 %577
+OpStore %539 %578
+%579 = OpLoad %ulong %539
+%580 = OpBitwiseAnd %ulong %579 %ulong_255
+OpStore %540 %580
+%581 = OpLoad %ulong %544
+%582 = OpLoad %ulong %540
+%583 = OpBitwiseXor %ulong %581 %582
+OpStore %541 %583
+%584 = OpLoad %ulong %541
+%585 = OpIMul %ulong %584 %ulong_1099511628211
+OpStore %542 %585
+%586 = OpLoad %ulong %545
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %543 %587
+%588 = OpLoad %ulong %542
+OpStore %544 %588
+%589 = OpLoad %ulong %543
+OpStore %545 %589
+OpBranch %511
+%501 = OpLabel
+%590 = OpLoad %ulong %535
+%591 = OpIMul %ulong %590 %ulong_8
+OpStore %528 %591
+%592 = OpLoad %ulong %526
+%593 = OpLoad %ulong %528
+%594 = OpShiftRightLogical %ulong %592 %593
+OpStore %529 %594
+%595 = OpLoad %ulong %529
+%596 = OpBitwiseAnd %ulong %595 %ulong_255
+OpStore %530 %596
+%597 = OpLoad %ulong %534
+%598 = OpLoad %ulong %530
+%599 = OpBitwiseXor %ulong %597 %598
+OpStore %531 %599
+%600 = OpLoad %ulong %531
+%601 = OpIMul %ulong %600 %ulong_1099511628211
+OpStore %532 %601
+%602 = OpLoad %ulong %535
+%603 = OpIAdd %ulong %602 %ulong_1
+OpStore %533 %603
+%604 = OpLoad %ulong %532
+OpStore %534 %604
+%605 = OpLoad %ulong %533
+OpStore %535 %605
+OpBranch %512
+%494 = OpLabel
+%606 = OpLoad %ulong %525
+%607 = OpIMul %ulong %606 %ulong_8
+OpStore %518 %607
+%608 = OpLoad %ulong %516
+%609 = OpLoad %ulong %518
+%610 = OpShiftRightLogical %ulong %608 %609
+OpStore %519 %610
+%611 = OpLoad %ulong %519
+%612 = OpBitwiseAnd %ulong %611 %ulong_255
+OpStore %520 %612
+%613 = OpLoad %ulong %524
+%614 = OpLoad %ulong %520
+%615 = OpBitwiseXor %ulong %613 %614
+OpStore %521 %615
+%616 = OpLoad %ulong %521
+%617 = OpIMul %ulong %616 %ulong_1099511628211
+OpStore %522 %617
+%618 = OpLoad %ulong %525
+%619 = OpIAdd %ulong %618 %ulong_1
+OpStore %523 %619
+%620 = OpLoad %ulong %522
+OpStore %524 %620
+%621 = OpLoad %ulong %523
+OpStore %525 %621
+OpBranch %513
+%511 = OpLabel
+OpBranch %507
+%512 = OpLabel
+OpBranch %500
+%513 = OpLabel
+OpBranch %493
 OpFunctionEnd
-%21 = OpFunction %ulong None %449
-%608 = OpFunctionParameter %ulong
-%609 = OpLabel
-%706 = OpVariable %_ptr_Function__arr__struct_155_uint_6 Function
-%709 = OpVariable %_ptr_Function__arr__struct_237_uint_6 Function
-%713 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
-%714 = OpVariable %_ptr_Function__struct_155 Function
-%715 = OpVariable %_ptr_Function__struct_237 Function
-%716 = OpVariable %_ptr_Function_ulong Function
-%717 = OpVariable %_ptr_Function_ulong Function
-%719 = OpVariable %_ptr_Function_bool Function
-%720 = OpVariable %_ptr_Function_ulong Function
-%721 = OpVariable %_ptr_Function_bool Function
-%722 = OpVariable %_ptr_Function_ulong Function
-%723 = OpVariable %_ptr_Function_ulong Function
-%724 = OpVariable %_ptr_Function_ulong Function
-%725 = OpVariable %_ptr_Function_ulong Function
+%15 = OpFunction %ulong None %622
+%623 = OpFunctionParameter %ulong
+%624 = OpFunctionParameter %_struct_180
+%625 = OpLabel
+%638 = OpVariable %_ptr_Function__struct_180 Function
+%639 = OpVariable %_ptr_Function_ulong Function
+%640 = OpVariable %_ptr_Function_bool Function
+%641 = OpVariable %_ptr_Function_ulong Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_ulong Function
+%644 = OpVariable %_ptr_Function_ulong Function
+%645 = OpVariable %_ptr_Function_ulong Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_ulong Function
+%648 = OpVariable %_ptr_Function_ulong Function
+%649 = OpVariable %_ptr_Function_bool Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_ulong Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_ulong Function
+OpStore %639 %623
+OpStore %638 %624
+%660 = OpAccessChain %_ptr_Function_ulong %638 %uint_0
+%661 = OpLoad %ulong %660
+OpStore %658 %661
+%662 = OpAccessChain %_ptr_Function_ulong %638 %uint_1
+%663 = OpLoad %ulong %662
+OpStore %659 %663
+OpBranch %626
+%626 = OpLabel
+%664 = OpLoad %ulong %639
+OpStore %647 %664
+OpStore %648 %ulong_0
+OpBranch %627
+%627 = OpLabel
+%665 = OpLoad %ulong %648
+%666 = OpULessThan %bool %665 %ulong_8
+OpStore %640 %666
+%667 = OpLoad %bool %640
+OpLoopMerge %629 %637 None
+OpBranchConditional %667 %628 %629
+%629 = OpLabel
+OpBranch %630
+%630 = OpLabel
+OpBranch %631
+%631 = OpLabel
+%668 = OpLoad %ulong %647
+OpStore %656 %668
+OpStore %657 %ulong_0
+OpBranch %632
+%632 = OpLabel
+%669 = OpLoad %ulong %657
+%670 = OpULessThan %bool %669 %ulong_8
+OpStore %649 %670
+%671 = OpLoad %bool %649
+OpLoopMerge %634 %636 None
+OpBranchConditional %671 %633 %634
+%634 = OpLabel
+OpBranch %635
+%635 = OpLabel
+%672 = OpLoad %ulong %656
+OpReturnValue %672
+%633 = OpLabel
+%673 = OpLoad %ulong %657
+%674 = OpIMul %ulong %673 %ulong_8
+OpStore %650 %674
+%675 = OpLoad %ulong %659
+%676 = OpLoad %ulong %650
+%677 = OpShiftRightLogical %ulong %675 %676
+OpStore %651 %677
+%678 = OpLoad %ulong %651
+%679 = OpBitwiseAnd %ulong %678 %ulong_255
+OpStore %652 %679
+%680 = OpLoad %ulong %656
+%681 = OpLoad %ulong %652
+%682 = OpBitwiseXor %ulong %680 %681
+OpStore %653 %682
+%683 = OpLoad %ulong %653
+%684 = OpIMul %ulong %683 %ulong_1099511628211
+OpStore %654 %684
+%685 = OpLoad %ulong %657
+%686 = OpIAdd %ulong %685 %ulong_1
+OpStore %655 %686
+%687 = OpLoad %ulong %654
+OpStore %656 %687
+%688 = OpLoad %ulong %655
+OpStore %657 %688
+OpBranch %636
+%628 = OpLabel
+%689 = OpLoad %ulong %648
+%690 = OpIMul %ulong %689 %ulong_8
+OpStore %641 %690
+%691 = OpLoad %ulong %658
+%692 = OpLoad %ulong %641
+%693 = OpShiftRightLogical %ulong %691 %692
+OpStore %642 %693
+%694 = OpLoad %ulong %642
+%695 = OpBitwiseAnd %ulong %694 %ulong_255
+OpStore %643 %695
+%696 = OpLoad %ulong %647
+%697 = OpLoad %ulong %643
+%698 = OpBitwiseXor %ulong %696 %697
+OpStore %644 %698
+%699 = OpLoad %ulong %644
+%700 = OpIMul %ulong %699 %ulong_1099511628211
+OpStore %645 %700
+%701 = OpLoad %ulong %648
+%702 = OpIAdd %ulong %701 %ulong_1
+OpStore %646 %702
+%703 = OpLoad %ulong %645
+OpStore %647 %703
+%704 = OpLoad %ulong %646
+OpStore %648 %704
+OpBranch %637
+%636 = OpLabel
+OpBranch %632
+%637 = OpLabel
+OpBranch %627
+OpFunctionEnd
+%16 = OpFunction %ulong None %705
+%706 = OpFunctionParameter %ulong
+%707 = OpFunctionParameter %_struct_196
+%708 = OpLabel
+%725 = OpVariable %_ptr_Function__struct_196 Function
 %726 = OpVariable %_ptr_Function_ulong Function
 %727 = OpVariable %_ptr_Function_ulong Function
 %728 = OpVariable %_ptr_Function_bool Function
@@ -885,10 +1061,10 @@ OpFunctionEnd
 %732 = OpVariable %_ptr_Function_ulong Function
 %733 = OpVariable %_ptr_Function_ulong Function
 %734 = OpVariable %_ptr_Function_ulong Function
-%735 = OpVariable %_ptr_Function_bool Function
+%735 = OpVariable %_ptr_Function_ulong Function
 %736 = OpVariable %_ptr_Function_ulong Function
-%737 = OpVariable %_ptr_Function_bool Function
-%738 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_bool Function
 %739 = OpVariable %_ptr_Function_ulong Function
 %740 = OpVariable %_ptr_Function_ulong Function
 %741 = OpVariable %_ptr_Function_ulong Function
@@ -897,78 +1073,128 @@ OpFunctionEnd
 %744 = OpVariable %_ptr_Function_ulong Function
 %745 = OpVariable %_ptr_Function_ulong Function
 %746 = OpVariable %_ptr_Function_ulong Function
-%747 = OpVariable %_ptr_Function_ulong Function
-%748 = OpVariable %_ptr_Function_ulong Function
-%749 = OpVariable %_ptr_Function_ulong Function
-%750 = OpVariable %_ptr_Function_ulong Function
-%751 = OpVariable %_ptr_Function_ulong Function
-%752 = OpVariable %_ptr_Function_ulong Function
-%753 = OpVariable %_ptr_Function_ulong Function
-%754 = OpVariable %_ptr_Function_ulong Function
-%755 = OpVariable %_ptr_Function_ulong Function
-%756 = OpVariable %_ptr_Function_ulong Function
-%757 = OpVariable %_ptr_Function_ulong Function
-%758 = OpVariable %_ptr_Function_ulong Function
-%759 = OpVariable %_ptr_Function_ulong Function
-%760 = OpVariable %_ptr_Function_ulong Function
-%761 = OpVariable %_ptr_Function_ulong Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_uchar Function
-%764 = OpVariable %_ptr_Function_uint Function
-%765 = OpVariable %_ptr_Function_ulong Function
-%766 = OpVariable %_ptr_Function_uint Function
-%767 = OpVariable %_ptr_Function_ulong Function
-%768 = OpVariable %_ptr_Function_uint Function
-%769 = OpVariable %_ptr_Function_ulong Function
-%770 = OpVariable %_ptr_Function_ulong Function
-%771 = OpVariable %_ptr_Function_ulong Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_ushort Function
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_ulong Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_double Function
-%778 = OpVariable %_ptr_Function_double Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_ulong Function
-%782 = OpVariable %_ptr_Function_double Function
-%783 = OpVariable %_ptr_Function_double Function
-%784 = OpVariable %_ptr_Function_ulong Function
-%785 = OpVariable %_ptr_Function_double Function
-%786 = OpVariable %_ptr_Function_double Function
-%787 = OpVariable %_ptr_Function_uint Function
-%788 = OpVariable %_ptr_Function_ulong Function
-%789 = OpVariable %_ptr_Function_ulong Function
-%790 = OpVariable %_ptr_Function_ulong Function
-%791 = OpVariable %_ptr_Function_double Function
-%792 = OpVariable %_ptr_Function_double Function
-%793 = OpVariable %_ptr_Function_uint Function
-%794 = OpVariable %_ptr_Function_ulong Function
-%795 = OpVariable %_ptr_Function_uint Function
-%796 = OpVariable %_ptr_Function_uint Function
-%797 = OpVariable %_ptr_Function_ulong Function
-%798 = OpVariable %_ptr_Function_uint Function
-%799 = OpVariable %_ptr_Function_ulong Function
-%800 = OpVariable %_ptr_Function_uint Function
-%801 = OpVariable %_ptr_Function_ulong Function
-%802 = OpVariable %_ptr_Function_ulong Function
-%803 = OpVariable %_ptr_Function_uint Function
-%804 = OpVariable %_ptr_Function_ulong Function
-%805 = OpVariable %_ptr_Function_uint Function
-%806 = OpVariable %_ptr_Function_ulong Function
-%807 = OpVariable %_ptr_Function_float Function
-%808 = OpVariable %_ptr_Function_float Function
-%809 = OpVariable %_ptr_Function_ulong Function
-%810 = OpVariable %_ptr_Function_float Function
-%811 = OpVariable %_ptr_Function_float Function
-%812 = OpVariable %_ptr_Function_ulong Function
-%813 = OpVariable %_ptr_Function_float Function
-%814 = OpVariable %_ptr_Function_float Function
-%815 = OpVariable %_ptr_Function_ulong Function
-%816 = OpVariable %_ptr_Function_float Function
-%817 = OpVariable %_ptr_Function_float Function
-%818 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_double Function
+%748 = OpVariable %_ptr_Function_double Function
+OpStore %726 %706
+OpStore %725 %707
+%749 = OpAccessChain %_ptr_Function_double %725 %uint_0
+%750 = OpLoad %double %749
+OpStore %747 %750
+%751 = OpAccessChain %_ptr_Function_double %725 %uint_1
+%752 = OpLoad %double %751
+OpStore %748 %752
+OpBranch %709
+%709 = OpLabel
+%753 = OpLoad %double %747
+%754 = OpBitcast %ulong %753
+OpStore %727 %754
+OpBranch %711
+%711 = OpLabel
+%755 = OpLoad %ulong %726
+OpStore %735 %755
+OpStore %736 %ulong_0
+OpBranch %712
+%712 = OpLabel
+%756 = OpLoad %ulong %736
+%757 = OpULessThan %bool %756 %ulong_8
+OpStore %728 %757
+%758 = OpLoad %bool %728
+OpLoopMerge %714 %724 None
+OpBranchConditional %758 %713 %714
+%714 = OpLabel
+OpBranch %715
+%715 = OpLabel
+OpBranch %710
+%710 = OpLabel
+OpBranch %716
+%716 = OpLabel
+%759 = OpLoad %double %748
+%760 = OpBitcast %ulong %759
+OpStore %737 %760
+OpBranch %718
+%718 = OpLabel
+%761 = OpLoad %ulong %735
+OpStore %745 %761
+OpStore %746 %ulong_0
+OpBranch %719
+%719 = OpLabel
+%762 = OpLoad %ulong %746
+%763 = OpULessThan %bool %762 %ulong_8
+OpStore %738 %763
+%764 = OpLoad %bool %738
+OpLoopMerge %721 %723 None
+OpBranchConditional %764 %720 %721
+%721 = OpLabel
+OpBranch %722
+%722 = OpLabel
+OpBranch %717
+%717 = OpLabel
+%765 = OpLoad %ulong %745
+OpReturnValue %765
+%720 = OpLabel
+%766 = OpLoad %ulong %746
+%767 = OpIMul %ulong %766 %ulong_8
+OpStore %739 %767
+%768 = OpLoad %ulong %737
+%769 = OpLoad %ulong %739
+%770 = OpShiftRightLogical %ulong %768 %769
+OpStore %740 %770
+%771 = OpLoad %ulong %740
+%772 = OpBitwiseAnd %ulong %771 %ulong_255
+OpStore %741 %772
+%773 = OpLoad %ulong %745
+%774 = OpLoad %ulong %741
+%775 = OpBitwiseXor %ulong %773 %774
+OpStore %742 %775
+%776 = OpLoad %ulong %742
+%777 = OpIMul %ulong %776 %ulong_1099511628211
+OpStore %743 %777
+%778 = OpLoad %ulong %746
+%779 = OpIAdd %ulong %778 %ulong_1
+OpStore %744 %779
+%780 = OpLoad %ulong %743
+OpStore %745 %780
+%781 = OpLoad %ulong %744
+OpStore %746 %781
+OpBranch %723
+%713 = OpLabel
+%782 = OpLoad %ulong %736
+%783 = OpIMul %ulong %782 %ulong_8
+OpStore %729 %783
+%784 = OpLoad %ulong %727
+%785 = OpLoad %ulong %729
+%786 = OpShiftRightLogical %ulong %784 %785
+OpStore %730 %786
+%787 = OpLoad %ulong %730
+%788 = OpBitwiseAnd %ulong %787 %ulong_255
+OpStore %731 %788
+%789 = OpLoad %ulong %735
+%790 = OpLoad %ulong %731
+%791 = OpBitwiseXor %ulong %789 %790
+OpStore %732 %791
+%792 = OpLoad %ulong %732
+%793 = OpIMul %ulong %792 %ulong_1099511628211
+OpStore %733 %793
+%794 = OpLoad %ulong %736
+%795 = OpIAdd %ulong %794 %ulong_1
+OpStore %734 %795
+%796 = OpLoad %ulong %733
+OpStore %735 %796
+%797 = OpLoad %ulong %734
+OpStore %736 %797
+OpBranch %724
+%723 = OpLabel
+OpBranch %719
+%724 = OpLabel
+OpBranch %712
+OpFunctionEnd
+%17 = OpFunction %ulong None %798
+%799 = OpFunctionParameter %ulong
+%800 = OpFunctionParameter %_struct_231
+%801 = OpLabel
+%816 = OpVariable %_ptr_Function__struct_231 Function
+%817 = OpVariable %_ptr_Function_ulong Function
+%818 = OpVariable %_ptr_Function_bool Function
 %819 = OpVariable %_ptr_Function_ulong Function
 %820 = OpVariable %_ptr_Function_ulong Function
 %821 = OpVariable %_ptr_Function_ulong Function
@@ -978,1192 +1204,1548 @@ OpFunctionEnd
 %825 = OpVariable %_ptr_Function_ulong Function
 %826 = OpVariable %_ptr_Function_ulong Function
 %827 = OpVariable %_ptr_Function_ulong Function
-%828 = OpVariable %_ptr_Function_ulong Function
+%828 = OpVariable %_ptr_Function_bool Function
 %829 = OpVariable %_ptr_Function_ulong Function
 %830 = OpVariable %_ptr_Function_ulong Function
 %831 = OpVariable %_ptr_Function_ulong Function
 %832 = OpVariable %_ptr_Function_ulong Function
 %833 = OpVariable %_ptr_Function_ulong Function
-%834 = OpVariable %_ptr_Function_uint Function
+%834 = OpVariable %_ptr_Function_ulong Function
 %835 = OpVariable %_ptr_Function_ulong Function
-%836 = OpVariable %_ptr_Function_uint Function
+%836 = OpVariable %_ptr_Function_ulong Function
 %837 = OpVariable %_ptr_Function_ulong Function
-%838 = OpVariable %_ptr_Function_uint Function
-%839 = OpVariable %_ptr_Function_ulong Function
-%840 = OpVariable %_ptr_Function_ulong Function
-%841 = OpVariable %_ptr_Function_ulong Function
-%842 = OpVariable %_ptr_Function_ulong Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_double Function
-%847 = OpVariable %_ptr_Function_double Function
-%848 = OpVariable %_ptr_Function_ulong Function
-%849 = OpVariable %_ptr_Function_double Function
-%850 = OpVariable %_ptr_Function_double Function
-%851 = OpVariable %_ptr_Function_ulong Function
-%852 = OpVariable %_ptr_Function_ulong Function
-%853 = OpVariable %_ptr_Function_ulong Function
-%854 = OpVariable %_ptr_Function_ulong Function
-%855 = OpVariable %_ptr_Function_ulong Function
-%856 = OpVariable %_ptr_Function_double Function
-%857 = OpVariable %_ptr_Function_double Function
-%858 = OpVariable %_ptr_Function_ulong Function
-%859 = OpVariable %_ptr_Function_ulong Function
-%860 = OpVariable %_ptr_Function_ulong Function
-%861 = OpVariable %_ptr_Function_double Function
-%862 = OpVariable %_ptr_Function_double Function
-%863 = OpVariable %_ptr_Function_ulong Function
-%864 = OpVariable %_ptr_Function_ulong Function
-%865 = OpVariable %_ptr_Function_ulong Function
-%866 = OpVariable %_ptr_Function_uint Function
-%867 = OpVariable %_ptr_Function_uint Function
-%868 = OpVariable %_ptr_Function_uint Function
-%869 = OpVariable %_ptr_Function_ulong Function
-%870 = OpVariable %_ptr_Function_double Function
-OpStore %716 %608
-%871 = OpFunctionCall %ulong %22
-OpStore %717 %871
-OpBranch %625
-%625 = OpLabel
-%872 = OpLoad %ulong %717
-%873 = OpFunctionCall %ulong %23 %872 %ulong_1
-OpStore %750 %873
-%874 = OpLoad %ulong %750
-%875 = OpFunctionCall %ulong %23 %874 %ulong_2
-OpStore %751 %875
-%876 = OpLoad %ulong %751
-%877 = OpFunctionCall %ulong %23 %876 %ulong_4
-OpStore %752 %877
-%878 = OpLoad %ulong %752
-%879 = OpFunctionCall %ulong %23 %878 %ulong_8
-OpStore %753 %879
-%880 = OpLoad %ulong %753
-%881 = OpFunctionCall %ulong %23 %880 %ulong_8
-OpStore %754 %881
-%882 = OpLoad %ulong %754
-%883 = OpFunctionCall %ulong %23 %882 %ulong_12
-OpStore %755 %883
-%884 = OpLoad %ulong %755
-%885 = OpFunctionCall %ulong %23 %884 %ulong_16
-OpStore %756 %885
-%886 = OpLoad %ulong %756
-%887 = OpFunctionCall %ulong %23 %886 %ulong_16
-OpStore %757 %887
-%888 = OpLoad %ulong %757
-%889 = OpFunctionCall %ulong %23 %888 %ulong_16
-OpStore %758 %889
-%890 = OpLoad %ulong %758
-%891 = OpFunctionCall %ulong %23 %890 %ulong_16
-OpStore %759 %891
-OpBranch %626
-%626 = OpLabel
-OpStore %713 %892
-OpStore %745 %ulong_0
-OpBranch %610
-%610 = OpLabel
-%894 = OpLoad %ulong %745
-%895 = OpULessThan %bool %894 %ulong_8
-OpStore %719 %895
-%896 = OpLoad %bool %719
-OpLoopMerge %612 %701 None
-OpBranchConditional %896 %611 %612
-%612 = OpLabel
-%897 = OpLoad %ulong %759
-OpStore %744 %897
-OpStore %749 %ulong_0
-OpBranch %613
-%613 = OpLabel
-%898 = OpLoad %ulong %749
-%899 = OpULessThan %bool %898 %ulong_8
-OpStore %721 %899
-%900 = OpLoad %bool %721
-OpLoopMerge %615 %700 None
-OpBranchConditional %900 %614 %615
-%615 = OpLabel
-OpStore %706 %901
-OpStore %709 %902
-OpStore %748 %ulong_0
-OpBranch %616
-%616 = OpLabel
-%903 = OpLoad %ulong %748
-%905 = OpULessThan %bool %903 %ulong_6
-OpStore %728 %905
-%906 = OpLoad %bool %728
-OpLoopMerge %618 %699 None
-OpBranchConditional %906 %617 %618
-%618 = OpLabel
-%907 = OpLoad %ulong %744
-OpStore %743 %907
-OpStore %747 %ulong_0
-OpBranch %619
-%619 = OpLabel
-%908 = OpLoad %ulong %747
-%909 = OpULessThan %bool %908 %ulong_6
-OpStore %735 %909
-%910 = OpLoad %bool %735
-OpLoopMerge %621 %698 None
-OpBranchConditional %910 %620 %621
-%621 = OpLabel
-%911 = OpLoad %ulong %743
-OpStore %742 %911
-OpStore %746 %ulong_0
-OpBranch %622
-%622 = OpLabel
-%912 = OpLoad %ulong %746
-%913 = OpULessThan %bool %912 %ulong_4
-OpStore %737 %913
-%914 = OpLoad %bool %737
-OpLoopMerge %624 %697 None
-OpBranchConditional %914 %623 %624
-%624 = OpLabel
-%915 = OpLoad %ulong %742
-OpReturnValue %915
-%623 = OpLabel
-%916 = OpLoad %ulong %746
-%917 = OpAccessChain %_ptr_Function_ulong %713 %916
-%918 = OpLoad %ulong %917
-OpStore %738 %918
-%919 = OpLoad %ulong %738
-%920 = OpLoad %ulong %716
-%921 = OpIAdd %ulong %919 %920
-OpStore %739 %921
-OpBranch %635
-%635 = OpLabel
-%922 = OpLoad %ulong %739
-%923 = OpNot %ulong %922
-OpStore %772 %923
-OpBranch %636
-%636 = OpLabel
-OpBranch %643
-%643 = OpLabel
-%924 = OpLoad %ulong %739
-%925 = OpBitwiseAnd %ulong %924 %ulong_65535
-OpStore %781 %925
-%926 = OpLoad %ulong %781
-%927 = OpConvertUToF %double %926
-OpStore %782 %927
-%928 = OpLoad %double %782
-%929 = OpFDiv %double %928 %double_8
-OpStore %783 %929
-%930 = OpLoad %ulong %739
-%931 = OpBitwiseAnd %ulong %930 %ulong_262143
-OpStore %784 %931
-%932 = OpLoad %ulong %784
-%933 = OpConvertUToF %double %932
-OpStore %785 %933
-%934 = OpLoad %double %785
-%935 = OpFDiv %double %934 %double_64
-OpStore %786 %935
-OpBranch %644
-%644 = OpLabel
-OpBranch %647
-%647 = OpLabel
-%936 = OpLoad %ulong %739
-%937 = OpIMul %ulong %936 %ulong_3
-OpStore %788 %937
-%938 = OpLoad %ulong %788
-%939 = OpIAdd %ulong %938 %ulong_1
-OpStore %789 %939
-%940 = OpLoad %ulong %739
-%941 = OpBitwiseAnd %ulong %940 %ulong_32767
-OpStore %790 %941
-%942 = OpLoad %ulong %790
-%943 = OpConvertUToF %double %942
-OpStore %791 %943
-%944 = OpLoad %double %791
-%945 = OpFDiv %double %944 %double_4
-OpStore %792 %945
-OpBranch %648
-%648 = OpLabel
-OpBranch %651
-%651 = OpLabel
-%946 = OpLoad %ulong %739
-%947 = OpUConvert %uint %946
-OpStore %796 %947
-%948 = OpLoad %ulong %739
-%949 = OpShiftRightLogical %ulong %948 %ulong_16
-OpStore %797 %949
-%950 = OpLoad %ulong %797
-%951 = OpUConvert %uint %950
-OpStore %798 %951
-%952 = OpLoad %ulong %739
-%953 = OpShiftRightLogical %ulong %952 %ulong_32
-OpStore %799 %953
-%954 = OpLoad %ulong %799
-%955 = OpUConvert %uint %954
-OpStore %800 %955
-OpBranch %652
-%652 = OpLabel
-OpBranch %655
-%655 = OpLabel
-%956 = OpLoad %ulong %739
-%957 = OpUConvert %uint %956
-OpStore %803 %957
-%958 = OpLoad %ulong %739
-%959 = OpShiftRightLogical %ulong %958 %ulong_32
-OpStore %804 %959
-%960 = OpLoad %ulong %804
-%961 = OpUConvert %uint %960
-OpStore %805 %961
-OpBranch %656
-%656 = OpLabel
-OpBranch %659
-%659 = OpLabel
-%962 = OpLoad %ulong %739
-%963 = OpBitwiseAnd %ulong %962 %ulong_4095
-OpStore %812 %963
-%964 = OpLoad %ulong %812
-%965 = OpConvertUToF %float %964
-OpStore %813 %965
-%966 = OpLoad %float %813
-%967 = OpFDiv %float %966 %float_8
-OpStore %814 %967
-%968 = OpLoad %ulong %739
-%969 = OpBitwiseAnd %ulong %968 %ulong_255
-OpStore %815 %969
-%970 = OpLoad %ulong %815
-%971 = OpConvertUToF %float %970
-OpStore %816 %971
-%972 = OpLoad %float %816
-%973 = OpFSub %float %972 %float_128
-OpStore %817 %973
-OpBranch %660
-%660 = OpLabel
-OpBranch %663
-%663 = OpLabel
-%974 = OpFunctionCall %ulong %22
-OpStore %820 %974
-OpBranch %664
-%664 = OpLabel
-%975 = OpLoad %ulong %820
-%976 = OpLoad %ulong %739
-%977 = OpFunctionCall %ulong %23 %975 %976
-OpStore %821 %977
-%978 = OpLoad %ulong %821
-%979 = OpLoad %ulong %772
-%980 = OpFunctionCall %ulong %23 %978 %979
-OpStore %822 %980
-OpBranch %665
-%665 = OpLabel
-OpBranch %666
-%666 = OpLabel
-%981 = OpLoad %ulong %822
-%982 = OpLoad %double %783
-%983 = OpFunctionCall %ulong %28 %981 %982
-OpStore %823 %983
-%984 = OpLoad %ulong %823
-%985 = OpLoad %double %786
-%986 = OpFunctionCall %ulong %28 %984 %985
-OpStore %824 %986
-OpBranch %667
-%667 = OpLabel
-OpBranch %668
-%668 = OpLabel
-%987 = OpLoad %ulong %824
-%988 = OpLoad %ulong %789
-%989 = OpFunctionCall %ulong %23 %987 %988
-OpStore %825 %989
-%990 = OpLoad %ulong %825
-%991 = OpLoad %double %792
-%992 = OpFunctionCall %ulong %28 %990 %991
-OpStore %826 %992
-OpBranch %669
-%669 = OpLabel
-OpBranch %670
-%670 = OpLabel
-%993 = OpLoad %ulong %826
-%994 = OpLoad %uint %796
-%995 = OpFunctionCall %ulong %26 %993 %994
-OpStore %827 %995
-%996 = OpLoad %ulong %827
-%997 = OpLoad %uint %798
-%998 = OpFunctionCall %ulong %26 %996 %997
-OpStore %828 %998
-%999 = OpLoad %ulong %828
-%1000 = OpLoad %uint %800
-%1001 = OpFunctionCall %ulong %26 %999 %1000
-OpStore %829 %1001
-OpBranch %671
-%671 = OpLabel
-OpBranch %672
-%672 = OpLabel
-%1002 = OpLoad %ulong %829
-%1003 = OpLoad %uint %803
-%1004 = OpFunctionCall %ulong %26 %1002 %1003
-OpStore %830 %1004
-%1005 = OpLoad %ulong %830
-%1006 = OpLoad %uint %805
-%1007 = OpFunctionCall %ulong %26 %1005 %1006
-OpStore %831 %1007
-OpBranch %673
-%673 = OpLabel
-OpBranch %674
-%674 = OpLabel
-%1008 = OpLoad %ulong %831
-%1009 = OpLoad %float %814
-%1010 = OpFunctionCall %ulong %27 %1008 %1009
-OpStore %832 %1010
-%1011 = OpLoad %ulong %832
-%1012 = OpLoad %float %817
-%1013 = OpFunctionCall %ulong %27 %1011 %1012
-OpStore %833 %1013
-OpBranch %675
-%675 = OpLabel
-OpBranch %676
-%676 = OpLabel
-%1014 = OpLoad %ulong %742
-%1015 = OpLoad %ulong %833
-%1016 = OpFunctionCall %ulong %23 %1014 %1015
-OpStore %740 %1016
-%1017 = OpLoad %ulong %746
-%1018 = OpIAdd %ulong %1017 %ulong_1
-OpStore %741 %1018
-%1019 = OpLoad %ulong %740
-OpStore %742 %1019
-%1020 = OpLoad %ulong %741
-OpStore %746 %1020
-OpBranch %697
-%620 = OpLabel
-%1021 = OpLoad %ulong %747
-%1022 = OpAccessChain %_ptr_Function__struct_155 %706 %1021
-%1023 = OpAccessChain %_ptr_Function_uint %1022 %uint_0
-%1024 = OpLoad %uint %1023
-OpStore %866 %1024
-%1025 = OpAccessChain %_ptr_Function_uint %1022 %uint_1
-%1026 = OpLoad %uint %1025
-OpStore %867 %1026
-%1027 = OpAccessChain %_ptr_Function_uint %1022 %uint_2
-%1028 = OpLoad %uint %1027
-OpStore %868 %1028
-OpBranch %633
-%633 = OpLabel
-%1029 = OpLoad %ulong %743
-%1030 = OpLoad %uint %866
-%1031 = OpFunctionCall %ulong %26 %1029 %1030
-OpStore %769 %1031
-%1032 = OpLoad %ulong %769
-%1033 = OpLoad %uint %867
-%1034 = OpFunctionCall %ulong %26 %1032 %1033
-OpStore %770 %1034
-%1035 = OpLoad %ulong %770
-%1036 = OpLoad %uint %868
-%1037 = OpFunctionCall %ulong %26 %1035 %1036
-OpStore %771 %1037
-OpBranch %634
-%634 = OpLabel
-%1038 = OpLoad %ulong %747
-%1039 = OpAccessChain %_ptr_Function__struct_237 %709 %1038
-%1040 = OpAccessChain %_ptr_Function_ulong %1039 %uint_0
-%1041 = OpLoad %ulong %1040
-OpStore %869 %1041
-%1042 = OpAccessChain %_ptr_Function_double %1039 %uint_1
-%1043 = OpLoad %double %1042
-OpStore %870 %1043
-OpBranch %641
-%641 = OpLabel
-%1044 = OpLoad %ulong %771
-%1045 = OpLoad %ulong %869
-%1046 = OpFunctionCall %ulong %23 %1044 %1045
-OpStore %779 %1046
-%1047 = OpLoad %ulong %779
-%1048 = OpLoad %double %870
-%1049 = OpFunctionCall %ulong %28 %1047 %1048
-OpStore %780 %1049
-OpBranch %642
-%642 = OpLabel
-%1050 = OpLoad %ulong %747
-%1051 = OpIAdd %ulong %1050 %ulong_1
-OpStore %736 %1051
-%1052 = OpLoad %ulong %780
-OpStore %743 %1052
-%1053 = OpLoad %ulong %736
-OpStore %747 %1053
-OpBranch %698
-%617 = OpLabel
-%1054 = OpLoad %ulong %748
-%1055 = OpAccessChain %_ptr_Function_ulong %713 %1054
-%1056 = OpLoad %ulong %1055
-OpStore %729 %1056
-%1057 = OpLoad %ulong %729
-%1058 = OpLoad %ulong %716
-%1059 = OpIAdd %ulong %1057 %1058
-OpStore %730 %1059
-OpBranch %631
-%631 = OpLabel
-%1060 = OpLoad %ulong %730
-%1061 = OpUConvert %uint %1060
-OpStore %764 %1061
-%1062 = OpAccessChain %_ptr_Function_uint %714 %uint_0
-%1063 = OpLoad %uint %764
-OpStore %1062 %1063
-%1064 = OpLoad %ulong %730
-%1065 = OpShiftRightLogical %ulong %1064 %ulong_16
-OpStore %765 %1065
-%1066 = OpLoad %ulong %765
-%1067 = OpUConvert %uint %1066
-OpStore %766 %1067
-%1068 = OpAccessChain %_ptr_Function_uint %714 %uint_1
-%1069 = OpLoad %uint %766
-OpStore %1068 %1069
-%1070 = OpLoad %ulong %730
-%1071 = OpShiftRightLogical %ulong %1070 %ulong_32
-OpStore %767 %1071
-%1072 = OpLoad %ulong %767
-%1073 = OpUConvert %uint %1072
-OpStore %768 %1073
-%1074 = OpAccessChain %_ptr_Function_uint %714 %uint_2
-%1075 = OpLoad %uint %768
-OpStore %1074 %1075
-OpBranch %632
-%632 = OpLabel
-%1076 = OpLoad %ulong %748
-%1077 = OpAccessChain %_ptr_Function__struct_155 %706 %1076
-%1078 = OpLoad %_struct_155 %714
-OpStore %1077 %1078
-%1079 = OpLoad %ulong %748
-%1080 = OpAccessChain %_ptr_Function_ulong %713 %1079
-%1081 = OpLoad %ulong %1080
-OpStore %731 %1081
-%1082 = OpLoad %ulong %731
-%1083 = OpIMul %ulong %1082 %ulong_3
-OpStore %732 %1083
-%1084 = OpLoad %ulong %732
-%1085 = OpLoad %ulong %716
-%1086 = OpIAdd %ulong %1084 %1085
-OpStore %733 %1086
-OpBranch %639
-%639 = OpLabel
-%1087 = OpLoad %ulong %733
-%1088 = OpIMul %ulong %1087 %ulong_3
-OpStore %774 %1088
-%1089 = OpLoad %ulong %774
-%1090 = OpIAdd %ulong %1089 %ulong_1
-OpStore %775 %1090
-%1091 = OpAccessChain %_ptr_Function_ulong %715 %uint_0
-%1092 = OpLoad %ulong %775
-OpStore %1091 %1092
-%1093 = OpLoad %ulong %733
-%1094 = OpBitwiseAnd %ulong %1093 %ulong_32767
-OpStore %776 %1094
-%1095 = OpLoad %ulong %776
-%1096 = OpConvertUToF %double %1095
-OpStore %777 %1096
-%1097 = OpLoad %double %777
-%1098 = OpFDiv %double %1097 %double_4
-OpStore %778 %1098
-%1099 = OpAccessChain %_ptr_Function_double %715 %uint_1
-%1100 = OpLoad %double %778
-OpStore %1099 %1100
-OpBranch %640
-%640 = OpLabel
-%1101 = OpLoad %ulong %748
-%1102 = OpAccessChain %_ptr_Function__struct_237 %709 %1101
-%1103 = OpLoad %_struct_237 %715
-OpStore %1102 %1103
-%1104 = OpLoad %ulong %748
-%1105 = OpIAdd %ulong %1104 %ulong_1
-OpStore %734 %1105
-%1106 = OpLoad %ulong %734
-OpStore %748 %1106
-OpBranch %699
-%614 = OpLabel
-%1107 = OpLoad %ulong %749
-%1108 = OpAccessChain %_ptr_Function_ulong %713 %1107
-%1109 = OpLoad %ulong %1108
-OpStore %722 %1109
-%1110 = OpLoad %ulong %722
-%1111 = OpLoad %ulong %716
-%1112 = OpIAdd %ulong %1110 %1111
-OpStore %723 %1112
-OpBranch %629
-%629 = OpLabel
-%1113 = OpLoad %ulong %723
-%1114 = OpUConvert %uchar %1113
-OpStore %763 %1114
-OpBranch %630
-%630 = OpLabel
-%1115 = OpLoad %ulong %744
-%1116 = OpLoad %uchar %763
-%1117 = OpFunctionCall %ulong %24 %1115 %1116
-OpStore %724 %1117
-OpBranch %637
-%637 = OpLabel
-%1118 = OpLoad %ulong %723
-%1119 = OpUConvert %ushort %1118
-OpStore %773 %1119
-OpBranch %638
-%638 = OpLabel
-%1120 = OpLoad %ulong %724
-%1121 = OpLoad %ushort %773
-%1122 = OpFunctionCall %ulong %25 %1120 %1121
-OpStore %725 %1122
-OpBranch %645
-%645 = OpLabel
-%1123 = OpLoad %ulong %723
-%1124 = OpUConvert %uint %1123
-OpStore %787 %1124
-OpBranch %646
-%646 = OpLabel
-%1125 = OpLoad %ulong %725
-%1126 = OpLoad %uint %787
-%1127 = OpFunctionCall %ulong %26 %1125 %1126
-OpStore %726 %1127
-OpBranch %649
-%649 = OpLabel
-%1128 = OpLoad %ulong %723
-%1129 = OpUConvert %uint %1128
-OpStore %793 %1129
-%1130 = OpLoad %ulong %723
-%1131 = OpShiftRightLogical %ulong %1130 %ulong_32
-OpStore %794 %1131
-%1132 = OpLoad %ulong %794
-%1133 = OpUConvert %uint %1132
-OpStore %795 %1133
-OpBranch %650
-%650 = OpLabel
-OpBranch %653
-%653 = OpLabel
-%1134 = OpLoad %ulong %726
-%1135 = OpLoad %uint %793
-%1136 = OpFunctionCall %ulong %26 %1134 %1135
-OpStore %801 %1136
-%1137 = OpLoad %ulong %801
-%1138 = OpLoad %uint %795
-%1139 = OpFunctionCall %ulong %26 %1137 %1138
-OpStore %802 %1139
-OpBranch %654
-%654 = OpLabel
-OpBranch %657
-%657 = OpLabel
-%1140 = OpLoad %ulong %723
-%1141 = OpBitwiseAnd %ulong %1140 %ulong_4095
-OpStore %806 %1141
-%1142 = OpLoad %ulong %806
-%1143 = OpConvertUToF %float %1142
-OpStore %807 %1143
-%1144 = OpLoad %float %807
-%1145 = OpFDiv %float %1144 %float_8
-OpStore %808 %1145
-%1146 = OpLoad %ulong %723
-%1147 = OpBitwiseAnd %ulong %1146 %ulong_255
-OpStore %809 %1147
-%1148 = OpLoad %ulong %809
-%1149 = OpConvertUToF %float %1148
-OpStore %810 %1149
-%1150 = OpLoad %float %810
-%1151 = OpFSub %float %1150 %float_128
-OpStore %811 %1151
-OpBranch %658
-%658 = OpLabel
-OpBranch %661
-%661 = OpLabel
-%1152 = OpLoad %ulong %802
-%1153 = OpLoad %float %808
-%1154 = OpFunctionCall %ulong %27 %1152 %1153
-OpStore %818 %1154
-%1155 = OpLoad %ulong %818
-%1156 = OpLoad %float %811
-%1157 = OpFunctionCall %ulong %27 %1155 %1156
-OpStore %819 %1157
-OpBranch %662
-%662 = OpLabel
-OpBranch %677
-%677 = OpLabel
-%1158 = OpLoad %ulong %723
-%1159 = OpUConvert %uint %1158
-OpStore %834 %1159
-%1160 = OpLoad %ulong %723
-%1161 = OpShiftRightLogical %ulong %1160 %ulong_16
-OpStore %835 %1161
-%1162 = OpLoad %ulong %835
-%1163 = OpUConvert %uint %1162
-OpStore %836 %1163
-%1164 = OpLoad %ulong %723
-%1165 = OpShiftRightLogical %ulong %1164 %ulong_32
-OpStore %837 %1165
-%1166 = OpLoad %ulong %837
-%1167 = OpUConvert %uint %1166
-OpStore %838 %1167
-OpBranch %678
-%678 = OpLabel
-OpBranch %679
-%679 = OpLabel
-%1168 = OpLoad %ulong %819
-%1169 = OpLoad %uint %834
-%1170 = OpFunctionCall %ulong %26 %1168 %1169
-OpStore %839 %1170
-%1171 = OpLoad %ulong %839
-%1172 = OpLoad %uint %836
-%1173 = OpFunctionCall %ulong %26 %1171 %1172
-OpStore %840 %1173
-%1174 = OpLoad %ulong %840
-%1175 = OpLoad %uint %838
-%1176 = OpFunctionCall %ulong %26 %1174 %1175
-OpStore %841 %1176
-OpBranch %680
-%680 = OpLabel
-OpBranch %681
-%681 = OpLabel
-%1177 = OpLoad %ulong %723
-%1178 = OpNot %ulong %1177
-OpStore %842 %1178
-OpBranch %682
-%682 = OpLabel
-OpBranch %683
-%683 = OpLabel
-%1179 = OpLoad %ulong %841
-%1180 = OpLoad %ulong %723
-%1181 = OpFunctionCall %ulong %23 %1179 %1180
-OpStore %843 %1181
-%1182 = OpLoad %ulong %843
-%1183 = OpLoad %ulong %842
-%1184 = OpFunctionCall %ulong %23 %1182 %1183
-OpStore %844 %1184
-OpBranch %684
-%684 = OpLabel
-OpBranch %685
-%685 = OpLabel
-%1185 = OpLoad %ulong %723
-%1186 = OpBitwiseAnd %ulong %1185 %ulong_65535
-OpStore %845 %1186
-%1187 = OpLoad %ulong %845
-%1188 = OpConvertUToF %double %1187
-OpStore %846 %1188
-%1189 = OpLoad %double %846
-%1190 = OpFDiv %double %1189 %double_8
-OpStore %847 %1190
-%1191 = OpLoad %ulong %723
-%1192 = OpBitwiseAnd %ulong %1191 %ulong_262143
-OpStore %848 %1192
-%1193 = OpLoad %ulong %848
-%1194 = OpConvertUToF %double %1193
-OpStore %849 %1194
-%1195 = OpLoad %double %849
-%1196 = OpFDiv %double %1195 %double_64
-OpStore %850 %1196
-OpBranch %686
-%686 = OpLabel
-OpBranch %687
-%687 = OpLabel
-%1197 = OpLoad %ulong %844
-%1198 = OpLoad %double %847
-%1199 = OpFunctionCall %ulong %28 %1197 %1198
-OpStore %851 %1199
-%1200 = OpLoad %ulong %851
-%1201 = OpLoad %double %850
-%1202 = OpFunctionCall %ulong %28 %1200 %1201
-OpStore %852 %1202
-OpBranch %688
-%688 = OpLabel
-OpBranch %689
-%689 = OpLabel
-%1203 = OpLoad %ulong %723
-%1204 = OpIMul %ulong %1203 %ulong_3
-OpStore %853 %1204
-%1205 = OpLoad %ulong %853
-%1206 = OpIAdd %ulong %1205 %ulong_1
-OpStore %854 %1206
-%1207 = OpLoad %ulong %723
-%1208 = OpBitwiseAnd %ulong %1207 %ulong_32767
-OpStore %855 %1208
-%1209 = OpLoad %ulong %855
-%1210 = OpConvertUToF %double %1209
-OpStore %856 %1210
-%1211 = OpLoad %double %856
-%1212 = OpFDiv %double %1211 %double_4
-OpStore %857 %1212
-OpBranch %690
-%690 = OpLabel
-OpBranch %691
-%691 = OpLabel
-%1213 = OpLoad %ulong %852
-%1214 = OpLoad %ulong %854
-%1215 = OpFunctionCall %ulong %23 %1213 %1214
-OpStore %858 %1215
-%1216 = OpLoad %ulong %858
-%1217 = OpLoad %double %857
-%1218 = OpFunctionCall %ulong %28 %1216 %1217
-OpStore %859 %1218
-OpBranch %692
-%692 = OpLabel
-OpBranch %693
-%693 = OpLabel
-%1219 = OpLoad %ulong %723
-%1220 = OpBitwiseAnd %ulong %1219 %ulong_8191
-OpStore %860 %1220
-%1221 = OpLoad %ulong %860
-%1222 = OpConvertUToF %double %1221
-OpStore %861 %1222
-%1223 = OpLoad %double %861
-%1224 = OpFDiv %double %1223 %double_2
-OpStore %862 %1224
-%1225 = OpLoad %ulong %723
-%1226 = OpBitwiseXor %ulong %1225 %ulong_305419896
-OpStore %863 %1226
-OpBranch %694
-%694 = OpLabel
-OpBranch %695
-%695 = OpLabel
-%1227 = OpLoad %ulong %859
-%1228 = OpLoad %double %862
-%1229 = OpFunctionCall %ulong %28 %1227 %1228
-OpStore %864 %1229
-%1230 = OpLoad %ulong %864
-%1231 = OpLoad %ulong %863
-%1232 = OpFunctionCall %ulong %23 %1230 %1231
-OpStore %865 %1232
-OpBranch %696
-%696 = OpLabel
-%1233 = OpLoad %ulong %749
-%1234 = OpIAdd %ulong %1233 %ulong_1
-OpStore %727 %1234
-%1235 = OpLoad %ulong %865
-OpStore %744 %1235
-%1236 = OpLoad %ulong %727
-OpStore %749 %1236
-OpBranch %700
-%611 = OpLabel
-OpBranch %627
-%627 = OpLabel
-%1237 = OpLoad %ulong %745
-%1238 = OpIMul %ulong %1237 %ulong_6364136223846793005
-OpStore %760 %1238
-%1239 = OpLoad %ulong %760
-%1240 = OpIAdd %ulong %1239 %ulong_1442695040888963407
-OpStore %761 %1240
-%1241 = OpLoad %ulong %761
-%1242 = OpLoad %ulong %716
-%1243 = OpIAdd %ulong %1241 %1242
-OpStore %762 %1243
-OpBranch %628
-%628 = OpLabel
-%1244 = OpLoad %ulong %745
-%1245 = OpAccessChain %_ptr_Function_ulong %713 %1244
-%1246 = OpLoad %ulong %762
-OpStore %1245 %1246
-%1247 = OpLoad %ulong %745
-%1248 = OpIAdd %ulong %1247 %ulong_1
-OpStore %720 %1248
-%1249 = OpLoad %ulong %720
-OpStore %745 %1249
-OpBranch %701
-%697 = OpLabel
-OpBranch %622
-%698 = OpLabel
-OpBranch %619
-%699 = OpLabel
-OpBranch %616
-%700 = OpLabel
-OpBranch %613
-%701 = OpLabel
-OpBranch %610
+%838 = OpVariable %_ptr_Function_double Function
+OpStore %817 %799
+OpStore %816 %800
+%839 = OpAccessChain %_ptr_Function_ulong %816 %uint_0
+%840 = OpLoad %ulong %839
+OpStore %837 %840
+%841 = OpAccessChain %_ptr_Function_double %816 %uint_1
+%842 = OpLoad %double %841
+OpStore %838 %842
+OpBranch %802
+%802 = OpLabel
+%843 = OpLoad %ulong %817
+OpStore %825 %843
+OpStore %826 %ulong_0
+OpBranch %803
+%803 = OpLabel
+%844 = OpLoad %ulong %826
+%845 = OpULessThan %bool %844 %ulong_8
+OpStore %818 %845
+%846 = OpLoad %bool %818
+OpLoopMerge %805 %815 None
+OpBranchConditional %846 %804 %805
+%805 = OpLabel
+OpBranch %806
+%806 = OpLabel
+OpBranch %807
+%807 = OpLabel
+%847 = OpLoad %double %838
+%848 = OpBitcast %ulong %847
+OpStore %827 %848
+OpBranch %809
+%809 = OpLabel
+%849 = OpLoad %ulong %825
+OpStore %835 %849
+OpStore %836 %ulong_0
+OpBranch %810
+%810 = OpLabel
+%850 = OpLoad %ulong %836
+%851 = OpULessThan %bool %850 %ulong_8
+OpStore %828 %851
+%852 = OpLoad %bool %828
+OpLoopMerge %812 %814 None
+OpBranchConditional %852 %811 %812
+%812 = OpLabel
+OpBranch %813
+%813 = OpLabel
+OpBranch %808
+%808 = OpLabel
+%853 = OpLoad %ulong %835
+OpReturnValue %853
+%811 = OpLabel
+%854 = OpLoad %ulong %836
+%855 = OpIMul %ulong %854 %ulong_8
+OpStore %829 %855
+%856 = OpLoad %ulong %827
+%857 = OpLoad %ulong %829
+%858 = OpShiftRightLogical %ulong %856 %857
+OpStore %830 %858
+%859 = OpLoad %ulong %830
+%860 = OpBitwiseAnd %ulong %859 %ulong_255
+OpStore %831 %860
+%861 = OpLoad %ulong %835
+%862 = OpLoad %ulong %831
+%863 = OpBitwiseXor %ulong %861 %862
+OpStore %832 %863
+%864 = OpLoad %ulong %832
+%865 = OpIMul %ulong %864 %ulong_1099511628211
+OpStore %833 %865
+%866 = OpLoad %ulong %836
+%867 = OpIAdd %ulong %866 %ulong_1
+OpStore %834 %867
+%868 = OpLoad %ulong %833
+OpStore %835 %868
+%869 = OpLoad %ulong %834
+OpStore %836 %869
+OpBranch %814
+%804 = OpLabel
+%870 = OpLoad %ulong %826
+%871 = OpIMul %ulong %870 %ulong_8
+OpStore %819 %871
+%872 = OpLoad %ulong %837
+%873 = OpLoad %ulong %819
+%874 = OpShiftRightLogical %ulong %872 %873
+OpStore %820 %874
+%875 = OpLoad %ulong %820
+%876 = OpBitwiseAnd %ulong %875 %ulong_255
+OpStore %821 %876
+%877 = OpLoad %ulong %825
+%878 = OpLoad %ulong %821
+%879 = OpBitwiseXor %ulong %877 %878
+OpStore %822 %879
+%880 = OpLoad %ulong %822
+%881 = OpIMul %ulong %880 %ulong_1099511628211
+OpStore %823 %881
+%882 = OpLoad %ulong %826
+%883 = OpIAdd %ulong %882 %ulong_1
+OpStore %824 %883
+%884 = OpLoad %ulong %823
+OpStore %825 %884
+%885 = OpLoad %ulong %824
+OpStore %826 %885
+OpBranch %815
+%814 = OpLabel
+OpBranch %810
+%815 = OpLabel
+OpBranch %803
 OpFunctionEnd
-%22 = OpFunction %ulong None %1250
-%1251 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%18 = OpFunction %ulong None %886
+%887 = OpFunctionParameter %ulong
+%888 = OpFunctionParameter %_struct_262
+%889 = OpLabel
+%904 = OpVariable %_ptr_Function__struct_262 Function
+%905 = OpVariable %_ptr_Function_ulong Function
+%906 = OpVariable %_ptr_Function_ulong Function
+%907 = OpVariable %_ptr_Function_bool Function
+%908 = OpVariable %_ptr_Function_ulong Function
+%909 = OpVariable %_ptr_Function_ulong Function
+%910 = OpVariable %_ptr_Function_ulong Function
+%911 = OpVariable %_ptr_Function_ulong Function
+%912 = OpVariable %_ptr_Function_ulong Function
+%913 = OpVariable %_ptr_Function_ulong Function
+%914 = OpVariable %_ptr_Function_ulong Function
+%915 = OpVariable %_ptr_Function_ulong Function
+%916 = OpVariable %_ptr_Function_bool Function
+%917 = OpVariable %_ptr_Function_ulong Function
+%918 = OpVariable %_ptr_Function_ulong Function
+%919 = OpVariable %_ptr_Function_ulong Function
+%920 = OpVariable %_ptr_Function_ulong Function
+%921 = OpVariable %_ptr_Function_ulong Function
+%922 = OpVariable %_ptr_Function_ulong Function
+%923 = OpVariable %_ptr_Function_ulong Function
+%924 = OpVariable %_ptr_Function_ulong Function
+%925 = OpVariable %_ptr_Function_double Function
+%926 = OpVariable %_ptr_Function_ulong Function
+OpStore %905 %887
+OpStore %904 %888
+%927 = OpAccessChain %_ptr_Function_double %904 %uint_0
+%928 = OpLoad %double %927
+OpStore %925 %928
+%929 = OpAccessChain %_ptr_Function_ulong %904 %uint_1
+%930 = OpLoad %ulong %929
+OpStore %926 %930
+OpBranch %890
+%890 = OpLabel
+%931 = OpLoad %double %925
+%932 = OpBitcast %ulong %931
+OpStore %906 %932
+OpBranch %892
+%892 = OpLabel
+%933 = OpLoad %ulong %905
+OpStore %914 %933
+OpStore %915 %ulong_0
+OpBranch %893
+%893 = OpLabel
+%934 = OpLoad %ulong %915
+%935 = OpULessThan %bool %934 %ulong_8
+OpStore %907 %935
+%936 = OpLoad %bool %907
+OpLoopMerge %895 %903 None
+OpBranchConditional %936 %894 %895
+%895 = OpLabel
+OpBranch %896
+%896 = OpLabel
+OpBranch %891
+%891 = OpLabel
+OpBranch %897
+%897 = OpLabel
+%937 = OpLoad %ulong %914
+OpStore %923 %937
+OpStore %924 %ulong_0
+OpBranch %898
+%898 = OpLabel
+%938 = OpLoad %ulong %924
+%939 = OpULessThan %bool %938 %ulong_8
+OpStore %916 %939
+%940 = OpLoad %bool %916
+OpLoopMerge %900 %902 None
+OpBranchConditional %940 %899 %900
+%900 = OpLabel
+OpBranch %901
+%901 = OpLabel
+%941 = OpLoad %ulong %923
+OpReturnValue %941
+%899 = OpLabel
+%942 = OpLoad %ulong %924
+%943 = OpIMul %ulong %942 %ulong_8
+OpStore %917 %943
+%944 = OpLoad %ulong %926
+%945 = OpLoad %ulong %917
+%946 = OpShiftRightLogical %ulong %944 %945
+OpStore %918 %946
+%947 = OpLoad %ulong %918
+%948 = OpBitwiseAnd %ulong %947 %ulong_255
+OpStore %919 %948
+%949 = OpLoad %ulong %923
+%950 = OpLoad %ulong %919
+%951 = OpBitwiseXor %ulong %949 %950
+OpStore %920 %951
+%952 = OpLoad %ulong %920
+%953 = OpIMul %ulong %952 %ulong_1099511628211
+OpStore %921 %953
+%954 = OpLoad %ulong %924
+%955 = OpIAdd %ulong %954 %ulong_1
+OpStore %922 %955
+%956 = OpLoad %ulong %921
+OpStore %923 %956
+%957 = OpLoad %ulong %922
+OpStore %924 %957
+OpBranch %902
+%894 = OpLabel
+%958 = OpLoad %ulong %915
+%959 = OpIMul %ulong %958 %ulong_8
+OpStore %908 %959
+%960 = OpLoad %ulong %906
+%961 = OpLoad %ulong %908
+%962 = OpShiftRightLogical %ulong %960 %961
+OpStore %909 %962
+%963 = OpLoad %ulong %909
+%964 = OpBitwiseAnd %ulong %963 %ulong_255
+OpStore %910 %964
+%965 = OpLoad %ulong %914
+%966 = OpLoad %ulong %910
+%967 = OpBitwiseXor %ulong %965 %966
+OpStore %911 %967
+%968 = OpLoad %ulong %911
+%969 = OpIMul %ulong %968 %ulong_1099511628211
+OpStore %912 %969
+%970 = OpLoad %ulong %915
+%971 = OpIAdd %ulong %970 %ulong_1
+OpStore %913 %971
+%972 = OpLoad %ulong %912
+OpStore %914 %972
+%973 = OpLoad %ulong %913
+OpStore %915 %973
+OpBranch %903
+%902 = OpLabel
+OpBranch %898
+%903 = OpLabel
+OpBranch %893
 OpFunctionEnd
-%23 = OpFunction %ulong None %30
-%1253 = OpFunctionParameter %ulong
-%1254 = OpFunctionParameter %ulong
-%1255 = OpLabel
+%19 = OpFunction %ulong None %974
+%975 = OpFunctionParameter %ulong
+%976 = OpLabel
+%983 = OpVariable %_ptr_Function_ulong Function
+%984 = OpVariable %_ptr_Function_ulong Function
+%985 = OpVariable %_ptr_Function_ulong Function
+%986 = OpVariable %_ptr_Function_ulong Function
+%987 = OpVariable %_ptr_Function_ulong Function
+%988 = OpVariable %_ptr_Function_ulong Function
+%989 = OpVariable %_ptr_Function_ulong Function
+%990 = OpVariable %_ptr_Function_ulong Function
+%991 = OpVariable %_ptr_Function_ulong Function
+%992 = OpVariable %_ptr_Function_ulong Function
+%993 = OpVariable %_ptr_Function_bool Function
+%994 = OpVariable %_ptr_Function_ulong Function
+%995 = OpVariable %_ptr_Function_ulong Function
+%996 = OpVariable %_ptr_Function_ulong Function
+%997 = OpVariable %_ptr_Function_ulong Function
+%998 = OpVariable %_ptr_Function_ulong Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_ulong Function
+%1001 = OpVariable %_ptr_Function_ulong Function
+OpStore %983 %975
+OpBranch %977
+%977 = OpLabel
+%1002 = OpLoad %ulong %983
+OpStore %1000 %1002
+OpStore %1001 %ulong_0
+OpBranch %978
+%978 = OpLabel
+%1003 = OpLoad %ulong %1001
+%1004 = OpULessThan %bool %1003 %ulong_8
+OpStore %993 %1004
+%1005 = OpLoad %bool %993
+OpLoopMerge %980 %982 None
+OpBranchConditional %1005 %979 %980
+%980 = OpLabel
+OpBranch %981
+%981 = OpLabel
+%1006 = OpLoad %ulong %1000
+%1008 = OpFunctionCall %ulong %22 %1006 %ulong_2
+OpStore %984 %1008
+%1009 = OpLoad %ulong %984
+%1011 = OpFunctionCall %ulong %22 %1009 %ulong_4
+OpStore %985 %1011
+%1012 = OpLoad %ulong %985
+%1013 = OpFunctionCall %ulong %22 %1012 %ulong_8
+OpStore %986 %1013
+%1014 = OpLoad %ulong %986
+%1015 = OpFunctionCall %ulong %22 %1014 %ulong_8
+OpStore %987 %1015
+%1016 = OpLoad %ulong %987
+%1018 = OpFunctionCall %ulong %22 %1016 %ulong_12
+OpStore %988 %1018
+%1019 = OpLoad %ulong %988
+%1020 = OpFunctionCall %ulong %22 %1019 %ulong_16
+OpStore %989 %1020
+%1021 = OpLoad %ulong %989
+%1022 = OpFunctionCall %ulong %22 %1021 %ulong_16
+OpStore %990 %1022
+%1023 = OpLoad %ulong %990
+%1024 = OpFunctionCall %ulong %22 %1023 %ulong_16
+OpStore %991 %1024
+%1025 = OpLoad %ulong %991
+%1026 = OpFunctionCall %ulong %22 %1025 %ulong_16
+OpStore %992 %1026
+%1027 = OpLoad %ulong %992
+OpReturnValue %1027
+%979 = OpLabel
+%1028 = OpLoad %ulong %1001
+%1029 = OpIMul %ulong %1028 %ulong_8
+OpStore %994 %1029
+%1030 = OpLoad %ulong %994
+%1031 = OpShiftRightLogical %ulong %ulong_1 %1030
+OpStore %995 %1031
+%1032 = OpLoad %ulong %995
+%1033 = OpBitwiseAnd %ulong %1032 %ulong_255
+OpStore %996 %1033
+%1034 = OpLoad %ulong %1000
+%1035 = OpLoad %ulong %996
+%1036 = OpBitwiseXor %ulong %1034 %1035
+OpStore %997 %1036
+%1037 = OpLoad %ulong %997
+%1038 = OpIMul %ulong %1037 %ulong_1099511628211
+OpStore %998 %1038
+%1039 = OpLoad %ulong %1001
+%1040 = OpIAdd %ulong %1039 %ulong_1
+OpStore %999 %1040
+%1041 = OpLoad %ulong %998
+OpStore %1000 %1041
+%1042 = OpLoad %ulong %999
+OpStore %1001 %1042
+OpBranch %982
+%982 = OpLabel
+OpBranch %978
+OpFunctionEnd
+%20 = OpFunction %ulong None %1043
+%1044 = OpFunctionParameter %_struct_180
+%1045 = OpFunctionParameter %_struct_196
+%1046 = OpFunctionParameter %_struct_231
+%1047 = OpFunctionParameter %_struct_149
+%1048 = OpFunctionParameter %_struct_90
+%1049 = OpFunctionParameter %_struct_114
+%1050 = OpLabel
+%1053 = OpVariable %_ptr_Function__struct_180 Function
+%1054 = OpVariable %_ptr_Function__struct_196 Function
+%1055 = OpVariable %_ptr_Function__struct_231 Function
+%1056 = OpVariable %_ptr_Function__struct_149 Function
+%1057 = OpVariable %_ptr_Function__struct_90 Function
+%1058 = OpVariable %_ptr_Function__struct_114 Function
+%1059 = OpVariable %_ptr_Function__struct_180 Function
+%1060 = OpVariable %_ptr_Function__struct_196 Function
+%1061 = OpVariable %_ptr_Function__struct_231 Function
+%1062 = OpVariable %_ptr_Function__struct_149 Function
+%1063 = OpVariable %_ptr_Function__struct_90 Function
+%1064 = OpVariable %_ptr_Function__struct_114 Function
+%1065 = OpVariable %_ptr_Function__struct_180 Function
+%1066 = OpVariable %_ptr_Function__struct_196 Function
+%1067 = OpVariable %_ptr_Function__struct_231 Function
+%1068 = OpVariable %_ptr_Function__struct_149 Function
+%1069 = OpVariable %_ptr_Function__struct_90 Function
+%1070 = OpVariable %_ptr_Function__struct_114 Function
+%1071 = OpVariable %_ptr_Function_ulong Function
+%1072 = OpVariable %_ptr_Function_ulong Function
+%1073 = OpVariable %_ptr_Function_ulong Function
+%1074 = OpVariable %_ptr_Function_ulong Function
+%1075 = OpVariable %_ptr_Function_ulong Function
+%1076 = OpVariable %_ptr_Function_ulong Function
+OpStore %1053 %1044
+OpStore %1054 %1045
+OpStore %1055 %1046
+OpStore %1056 %1047
+OpStore %1057 %1048
+OpStore %1058 %1049
+%1077 = OpLoad %_struct_180 %1053
+OpStore %1059 %1077
+%1078 = OpLoad %_struct_196 %1054
+OpStore %1060 %1078
+%1079 = OpLoad %_struct_231 %1055
+OpStore %1061 %1079
+%1080 = OpLoad %_struct_149 %1056
+OpStore %1062 %1080
+%1081 = OpLoad %_struct_90 %1057
+OpStore %1063 %1081
+%1082 = OpLoad %_struct_114 %1058
+OpStore %1064 %1082
+OpBranch %1051
+%1051 = OpLabel
+OpBranch %1052
+%1052 = OpLabel
+%1083 = OpLoad %_struct_180 %1059
+OpStore %1065 %1083
+%1085 = OpLoad %_struct_180 %1065
+%1086 = OpFunctionCall %ulong %15 %ulong_14695981039346656037 %1085
+OpStore %1071 %1086
+%1087 = OpLoad %_struct_196 %1060
+OpStore %1066 %1087
+%1088 = OpLoad %ulong %1071
+%1089 = OpLoad %_struct_196 %1066
+%1090 = OpFunctionCall %ulong %16 %1088 %1089
+OpStore %1072 %1090
+%1091 = OpLoad %_struct_231 %1061
+OpStore %1067 %1091
+%1092 = OpLoad %ulong %1072
+%1093 = OpLoad %_struct_231 %1067
+%1094 = OpFunctionCall %ulong %17 %1092 %1093
+OpStore %1073 %1094
+%1095 = OpLoad %_struct_149 %1062
+OpStore %1068 %1095
+%1096 = OpLoad %ulong %1073
+%1097 = OpLoad %_struct_149 %1068
+%1098 = OpFunctionCall %ulong %14 %1096 %1097
+OpStore %1074 %1098
+%1099 = OpLoad %_struct_90 %1063
+OpStore %1069 %1099
+%1100 = OpLoad %ulong %1074
+%1101 = OpLoad %_struct_90 %1069
+%1102 = OpFunctionCall %ulong %12 %1100 %1101
+OpStore %1075 %1102
+%1103 = OpLoad %_struct_114 %1064
+OpStore %1070 %1103
+%1104 = OpLoad %ulong %1075
+%1105 = OpLoad %_struct_114 %1070
+%1106 = OpFunctionCall %ulong %13 %1104 %1105
+OpStore %1076 %1106
+%1107 = OpLoad %ulong %1076
+OpReturnValue %1107
+OpFunctionEnd
+%21 = OpFunction %ulong None %974
+%1108 = OpFunctionParameter %ulong
+%1109 = OpLabel
+%1207 = OpVariable %_ptr_Function__arr__struct_149_uint_6 Function
+%1210 = OpVariable %_ptr_Function__arr__struct_231_uint_6 Function
+%1211 = OpVariable %_ptr_Function__struct_149 Function
+%1212 = OpVariable %_ptr_Function__struct_231 Function
+%1213 = OpVariable %_ptr_Function__struct_149 Function
+%1214 = OpVariable %_ptr_Function__struct_180 Function
+%1218 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
+%1219 = OpVariable %_ptr_Function__struct_231 Function
+%1220 = OpVariable %_ptr_Function__struct_196 Function
+%1221 = OpVariable %_ptr_Function__struct_231 Function
+%1222 = OpVariable %_ptr_Function__struct_149 Function
+%1223 = OpVariable %_ptr_Function__struct_90 Function
+%1224 = OpVariable %_ptr_Function__struct_114 Function
+%1225 = OpVariable %_ptr_Function__struct_90 Function
+%1226 = OpVariable %_ptr_Function__struct_180 Function
+%1227 = OpVariable %_ptr_Function__struct_196 Function
+%1228 = OpVariable %_ptr_Function__struct_231 Function
+%1229 = OpVariable %_ptr_Function__struct_149 Function
+%1230 = OpVariable %_ptr_Function__struct_90 Function
+%1231 = OpVariable %_ptr_Function__struct_114 Function
+%1232 = OpVariable %_ptr_Function__struct_180 Function
+%1233 = OpVariable %_ptr_Function__struct_196 Function
+%1234 = OpVariable %_ptr_Function__struct_231 Function
+%1235 = OpVariable %_ptr_Function__struct_149 Function
+%1236 = OpVariable %_ptr_Function__struct_90 Function
+%1237 = OpVariable %_ptr_Function__struct_114 Function
+%1238 = OpVariable %_ptr_Function__struct_114 Function
+%1239 = OpVariable %_ptr_Function__struct_149 Function
+%1240 = OpVariable %_ptr_Function__struct_180 Function
+%1241 = OpVariable %_ptr_Function__struct_196 Function
+%1242 = OpVariable %_ptr_Function__struct_231 Function
+%1243 = OpVariable %_ptr_Function_ulong Function
+%1244 = OpVariable %_ptr_Function_bool Function
+%1245 = OpVariable %_ptr_Function_ulong Function
+%1246 = OpVariable %_ptr_Function_bool Function
+%1247 = OpVariable %_ptr_Function_ulong Function
+%1248 = OpVariable %_ptr_Function_ulong Function
+%1249 = OpVariable %_ptr_Function_ulong Function
+%1250 = OpVariable %_ptr_Function_ulong Function
+%1251 = OpVariable %_ptr_Function_ulong Function
+%1252 = OpVariable %_ptr_Function_ulong Function
+%1253 = OpVariable %_ptr_Function_ulong Function
+%1254 = OpVariable %_ptr_Function_ulong Function
+%1255 = OpVariable %_ptr_Function_ulong Function
+%1256 = OpVariable %_ptr_Function_bool Function
+%1257 = OpVariable %_ptr_Function_ulong Function
+%1258 = OpVariable %_ptr_Function_ulong Function
+%1259 = OpVariable %_ptr_Function_ulong Function
 %1260 = OpVariable %_ptr_Function_ulong Function
 %1261 = OpVariable %_ptr_Function_ulong Function
-%1262 = OpVariable %_ptr_Function_bool Function
-%1263 = OpVariable %_ptr_Function_ulong Function
+%1262 = OpVariable %_ptr_Function_ulong Function
+%1263 = OpVariable %_ptr_Function_bool Function
 %1264 = OpVariable %_ptr_Function_ulong Function
 %1265 = OpVariable %_ptr_Function_ulong Function
 %1266 = OpVariable %_ptr_Function_ulong Function
-%1267 = OpVariable %_ptr_Function_ulong Function
+%1267 = OpVariable %_ptr_Function_bool Function
 %1268 = OpVariable %_ptr_Function_ulong Function
 %1269 = OpVariable %_ptr_Function_ulong Function
 %1270 = OpVariable %_ptr_Function_ulong Function
-OpStore %1260 %1253
-OpStore %1261 %1254
-%1271 = OpLoad %ulong %1260
-OpStore %1269 %1271
-OpStore %1270 %ulong_0
-OpBranch %1256
-%1256 = OpLabel
-%1272 = OpLoad %ulong %1270
-%1273 = OpULessThan %bool %1272 %ulong_8
-OpStore %1262 %1273
-%1274 = OpLoad %bool %1262
-OpLoopMerge %1258 %1259 None
-OpBranchConditional %1274 %1257 %1258
-%1258 = OpLabel
-%1275 = OpLoad %ulong %1269
-OpReturnValue %1275
-%1257 = OpLabel
-%1276 = OpLoad %ulong %1270
-%1277 = OpIMul %ulong %1276 %ulong_8
-OpStore %1263 %1277
-%1278 = OpLoad %ulong %1261
-%1279 = OpLoad %ulong %1263
-%1280 = OpShiftRightLogical %ulong %1278 %1279
-OpStore %1264 %1280
-%1281 = OpLoad %ulong %1264
-%1282 = OpBitwiseAnd %ulong %1281 %ulong_255
-OpStore %1265 %1282
-%1283 = OpLoad %ulong %1269
-%1284 = OpLoad %ulong %1265
-%1285 = OpBitwiseXor %ulong %1283 %1284
-OpStore %1266 %1285
-%1286 = OpLoad %ulong %1266
-%1288 = OpIMul %ulong %1286 %ulong_1099511628211
-OpStore %1267 %1288
-%1289 = OpLoad %ulong %1270
-%1290 = OpIAdd %ulong %1289 %ulong_1
-OpStore %1268 %1290
-%1291 = OpLoad %ulong %1267
-OpStore %1269 %1291
-%1292 = OpLoad %ulong %1268
-OpStore %1270 %1292
-OpBranch %1259
-%1259 = OpLabel
-OpBranch %1256
-OpFunctionEnd
-%24 = OpFunction %ulong None %1293
-%1294 = OpFunctionParameter %ulong
-%1295 = OpFunctionParameter %uchar
-%1296 = OpLabel
+%1271 = OpVariable %_ptr_Function_ulong Function
+%1272 = OpVariable %_ptr_Function_ulong Function
+%1273 = OpVariable %_ptr_Function_ulong Function
+%1274 = OpVariable %_ptr_Function_ulong Function
+%1275 = OpVariable %_ptr_Function_ulong Function
+%1276 = OpVariable %_ptr_Function_ulong Function
+%1277 = OpVariable %_ptr_Function_ulong Function
+%1278 = OpVariable %_ptr_Function_ulong Function
+%1279 = OpVariable %_ptr_Function_ulong Function
+%1280 = OpVariable %_ptr_Function_ulong Function
+%1281 = OpVariable %_ptr_Function_ulong Function
+%1282 = OpVariable %_ptr_Function_ulong Function
+%1283 = OpVariable %_ptr_Function_uchar Function
+%1284 = OpVariable %_ptr_Function_uint Function
+%1285 = OpVariable %_ptr_Function_ulong Function
+%1286 = OpVariable %_ptr_Function_uint Function
+%1287 = OpVariable %_ptr_Function_ulong Function
+%1288 = OpVariable %_ptr_Function_uint Function
+%1289 = OpVariable %_ptr_Function_ulong Function
+%1290 = OpVariable %_ptr_Function_ulong Function
+%1291 = OpVariable %_ptr_Function_ulong Function
+%1292 = OpVariable %_ptr_Function_ulong Function
+%1293 = OpVariable %_ptr_Function_ulong Function
+%1294 = OpVariable %_ptr_Function_ulong Function
+%1295 = OpVariable %_ptr_Function_ulong Function
+%1296 = OpVariable %_ptr_Function_ulong Function
+%1297 = OpVariable %_ptr_Function_ulong Function
+%1298 = OpVariable %_ptr_Function_ulong Function
+%1299 = OpVariable %_ptr_Function_bool Function
+%1300 = OpVariable %_ptr_Function_ulong Function
+%1301 = OpVariable %_ptr_Function_ulong Function
+%1302 = OpVariable %_ptr_Function_ulong Function
 %1303 = OpVariable %_ptr_Function_ulong Function
-%1304 = OpVariable %_ptr_Function_uchar Function
+%1304 = OpVariable %_ptr_Function_ulong Function
 %1305 = OpVariable %_ptr_Function_ulong Function
-%1306 = OpVariable %_ptr_Function_bool Function
+%1306 = OpVariable %_ptr_Function_ulong Function
 %1307 = OpVariable %_ptr_Function_ulong Function
 %1308 = OpVariable %_ptr_Function_ulong Function
 %1309 = OpVariable %_ptr_Function_ulong Function
 %1310 = OpVariable %_ptr_Function_ulong Function
 %1311 = OpVariable %_ptr_Function_ulong Function
 %1312 = OpVariable %_ptr_Function_ulong Function
-%1313 = OpVariable %_ptr_Function_ulong Function
-%1314 = OpVariable %_ptr_Function_ulong Function
-OpStore %1303 %1294
-OpStore %1304 %1295
-%1315 = OpLoad %uchar %1304
-%1316 = OpUConvert %ulong %1315
-OpStore %1305 %1316
-OpBranch %1297
-%1297 = OpLabel
-%1317 = OpLoad %ulong %1303
-OpStore %1313 %1317
-OpStore %1314 %ulong_0
-OpBranch %1298
-%1298 = OpLabel
-%1318 = OpLoad %ulong %1314
-%1319 = OpULessThan %bool %1318 %ulong_8
-OpStore %1306 %1319
-%1320 = OpLoad %bool %1306
-OpLoopMerge %1300 %1302 None
-OpBranchConditional %1320 %1299 %1300
-%1300 = OpLabel
-OpBranch %1301
-%1301 = OpLabel
-%1321 = OpLoad %ulong %1313
-OpReturnValue %1321
-%1299 = OpLabel
-%1322 = OpLoad %ulong %1314
-%1323 = OpIMul %ulong %1322 %ulong_8
-OpStore %1307 %1323
-%1324 = OpLoad %ulong %1305
-%1325 = OpLoad %ulong %1307
-%1326 = OpShiftRightLogical %ulong %1324 %1325
-OpStore %1308 %1326
-%1327 = OpLoad %ulong %1308
-%1328 = OpBitwiseAnd %ulong %1327 %ulong_255
-OpStore %1309 %1328
-%1329 = OpLoad %ulong %1313
-%1330 = OpLoad %ulong %1309
-%1331 = OpBitwiseXor %ulong %1329 %1330
-OpStore %1310 %1331
-%1332 = OpLoad %ulong %1310
-%1333 = OpIMul %ulong %1332 %ulong_1099511628211
-OpStore %1311 %1333
-%1334 = OpLoad %ulong %1314
-%1335 = OpIAdd %ulong %1334 %ulong_1
-OpStore %1312 %1335
-%1336 = OpLoad %ulong %1311
-OpStore %1313 %1336
-%1337 = OpLoad %ulong %1312
-OpStore %1314 %1337
-OpBranch %1302
-%1302 = OpLabel
-OpBranch %1298
-OpFunctionEnd
-%25 = OpFunction %ulong None %1338
-%1339 = OpFunctionParameter %ulong
-%1340 = OpFunctionParameter %ushort
-%1341 = OpLabel
-%1348 = OpVariable %_ptr_Function_ulong Function
-%1349 = OpVariable %_ptr_Function_ushort Function
+%1313 = OpVariable %_ptr_Function_double Function
+%1314 = OpVariable %_ptr_Function_double Function
+%1315 = OpVariable %_ptr_Function_ulong Function
+%1316 = OpVariable %_ptr_Function_double Function
+%1317 = OpVariable %_ptr_Function_double Function
+%1318 = OpVariable %_ptr_Function_ulong Function
+%1319 = OpVariable %_ptr_Function_double Function
+%1320 = OpVariable %_ptr_Function_double Function
+%1321 = OpVariable %_ptr_Function_ushort Function
+%1322 = OpVariable %_ptr_Function_ulong Function
+%1323 = OpVariable %_ptr_Function_ulong Function
+%1324 = OpVariable %_ptr_Function_ulong Function
+%1325 = OpVariable %_ptr_Function_double Function
+%1326 = OpVariable %_ptr_Function_double Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_ulong Function
+%1329 = OpVariable %_ptr_Function_uint Function
+%1330 = OpVariable %_ptr_Function_ulong Function
+%1331 = OpVariable %_ptr_Function_uint Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_uint Function
+%1334 = OpVariable %_ptr_Function_uint Function
+%1335 = OpVariable %_ptr_Function_uint Function
+%1336 = OpVariable %_ptr_Function_ulong Function
+%1337 = OpVariable %_ptr_Function_uint Function
+%1338 = OpVariable %_ptr_Function_ulong Function
+%1339 = OpVariable %_ptr_Function_ulong Function
+%1340 = OpVariable %_ptr_Function_ulong Function
+%1341 = OpVariable %_ptr_Function_float Function
+%1342 = OpVariable %_ptr_Function_float Function
+%1343 = OpVariable %_ptr_Function_ulong Function
+%1344 = OpVariable %_ptr_Function_float Function
+%1345 = OpVariable %_ptr_Function_float Function
+%1346 = OpVariable %_ptr_Function_uint Function
+%1347 = OpVariable %_ptr_Function_ulong Function
+%1348 = OpVariable %_ptr_Function_uint Function
+%1349 = OpVariable %_ptr_Function_ulong Function
 %1350 = OpVariable %_ptr_Function_ulong Function
-%1351 = OpVariable %_ptr_Function_bool Function
+%1351 = OpVariable %_ptr_Function_ulong Function
 %1352 = OpVariable %_ptr_Function_ulong Function
 %1353 = OpVariable %_ptr_Function_ulong Function
 %1354 = OpVariable %_ptr_Function_ulong Function
 %1355 = OpVariable %_ptr_Function_ulong Function
-%1356 = OpVariable %_ptr_Function_ulong Function
-%1357 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_float Function
+%1357 = OpVariable %_ptr_Function_float Function
 %1358 = OpVariable %_ptr_Function_ulong Function
-%1359 = OpVariable %_ptr_Function_ulong Function
-OpStore %1348 %1339
-OpStore %1349 %1340
-%1360 = OpLoad %ushort %1349
-%1361 = OpUConvert %ulong %1360
-OpStore %1350 %1361
-OpBranch %1342
-%1342 = OpLabel
-%1362 = OpLoad %ulong %1348
-OpStore %1358 %1362
-OpStore %1359 %ulong_0
-OpBranch %1343
-%1343 = OpLabel
-%1363 = OpLoad %ulong %1359
-%1364 = OpULessThan %bool %1363 %ulong_8
-OpStore %1351 %1364
-%1365 = OpLoad %bool %1351
-OpLoopMerge %1345 %1347 None
-OpBranchConditional %1365 %1344 %1345
-%1345 = OpLabel
-OpBranch %1346
-%1346 = OpLabel
-%1366 = OpLoad %ulong %1358
-OpReturnValue %1366
-%1344 = OpLabel
-%1367 = OpLoad %ulong %1359
-%1368 = OpIMul %ulong %1367 %ulong_8
-OpStore %1352 %1368
-%1369 = OpLoad %ulong %1350
-%1370 = OpLoad %ulong %1352
-%1371 = OpShiftRightLogical %ulong %1369 %1370
-OpStore %1353 %1371
-%1372 = OpLoad %ulong %1353
-%1373 = OpBitwiseAnd %ulong %1372 %ulong_255
-OpStore %1354 %1373
-%1374 = OpLoad %ulong %1358
-%1375 = OpLoad %ulong %1354
-%1376 = OpBitwiseXor %ulong %1374 %1375
-OpStore %1355 %1376
-%1377 = OpLoad %ulong %1355
-%1378 = OpIMul %ulong %1377 %ulong_1099511628211
-OpStore %1356 %1378
-%1379 = OpLoad %ulong %1359
-%1380 = OpIAdd %ulong %1379 %ulong_1
-OpStore %1357 %1380
-%1381 = OpLoad %ulong %1356
-OpStore %1358 %1381
-%1382 = OpLoad %ulong %1357
-OpStore %1359 %1382
-OpBranch %1347
-%1347 = OpLabel
-OpBranch %1343
-OpFunctionEnd
-%26 = OpFunction %ulong None %1383
-%1384 = OpFunctionParameter %ulong
-%1385 = OpFunctionParameter %uint
-%1386 = OpLabel
+%1359 = OpVariable %_ptr_Function_float Function
+%1360 = OpVariable %_ptr_Function_float Function
+%1361 = OpVariable %_ptr_Function_uint Function
+%1362 = OpVariable %_ptr_Function_ulong Function
+%1363 = OpVariable %_ptr_Function_uint Function
+%1364 = OpVariable %_ptr_Function_ulong Function
+%1365 = OpVariable %_ptr_Function_uint Function
+%1366 = OpVariable %_ptr_Function_ulong Function
+%1367 = OpVariable %_ptr_Function_ulong Function
+%1368 = OpVariable %_ptr_Function_double Function
+%1369 = OpVariable %_ptr_Function_double Function
+%1370 = OpVariable %_ptr_Function_ulong Function
+%1371 = OpVariable %_ptr_Function_double Function
+%1372 = OpVariable %_ptr_Function_double Function
+%1373 = OpVariable %_ptr_Function_ulong Function
+%1374 = OpVariable %_ptr_Function_ulong Function
+%1375 = OpVariable %_ptr_Function_ulong Function
+%1376 = OpVariable %_ptr_Function_double Function
+%1377 = OpVariable %_ptr_Function_double Function
+%1378 = OpVariable %_ptr_Function_ulong Function
+%1379 = OpVariable %_ptr_Function_double Function
+%1380 = OpVariable %_ptr_Function_double Function
+%1381 = OpVariable %_ptr_Function_ulong Function
+%1382 = OpVariable %_ptr_Function_ulong Function
+%1383 = OpVariable %_ptr_Function_bool Function
+%1384 = OpVariable %_ptr_Function_ulong Function
+%1385 = OpVariable %_ptr_Function_ulong Function
+%1386 = OpVariable %_ptr_Function_ulong Function
+%1387 = OpVariable %_ptr_Function_ulong Function
+%1388 = OpVariable %_ptr_Function_ulong Function
+%1389 = OpVariable %_ptr_Function_ulong Function
+%1390 = OpVariable %_ptr_Function_ulong Function
+%1391 = OpVariable %_ptr_Function_ulong Function
+%1392 = OpVariable %_ptr_Function_bool Function
 %1393 = OpVariable %_ptr_Function_ulong Function
-%1394 = OpVariable %_ptr_Function_uint Function
+%1394 = OpVariable %_ptr_Function_ulong Function
 %1395 = OpVariable %_ptr_Function_ulong Function
-%1396 = OpVariable %_ptr_Function_bool Function
+%1396 = OpVariable %_ptr_Function_ulong Function
 %1397 = OpVariable %_ptr_Function_ulong Function
 %1398 = OpVariable %_ptr_Function_ulong Function
 %1399 = OpVariable %_ptr_Function_ulong Function
 %1400 = OpVariable %_ptr_Function_ulong Function
-%1401 = OpVariable %_ptr_Function_ulong Function
-%1402 = OpVariable %_ptr_Function_ulong Function
-%1403 = OpVariable %_ptr_Function_ulong Function
-%1404 = OpVariable %_ptr_Function_ulong Function
-OpStore %1393 %1384
-OpStore %1394 %1385
-%1405 = OpLoad %uint %1394
-%1406 = OpUConvert %ulong %1405
-OpStore %1395 %1406
-OpBranch %1387
-%1387 = OpLabel
-%1407 = OpLoad %ulong %1393
-OpStore %1403 %1407
-OpStore %1404 %ulong_0
-OpBranch %1388
-%1388 = OpLabel
-%1408 = OpLoad %ulong %1404
-%1409 = OpULessThan %bool %1408 %ulong_8
-OpStore %1396 %1409
-%1410 = OpLoad %bool %1396
-OpLoopMerge %1390 %1392 None
-OpBranchConditional %1410 %1389 %1390
-%1390 = OpLabel
-OpBranch %1391
-%1391 = OpLabel
-%1411 = OpLoad %ulong %1403
-OpReturnValue %1411
-%1389 = OpLabel
-%1412 = OpLoad %ulong %1404
-%1413 = OpIMul %ulong %1412 %ulong_8
-OpStore %1397 %1413
-%1414 = OpLoad %ulong %1395
-%1415 = OpLoad %ulong %1397
-%1416 = OpShiftRightLogical %ulong %1414 %1415
-OpStore %1398 %1416
-%1417 = OpLoad %ulong %1398
-%1418 = OpBitwiseAnd %ulong %1417 %ulong_255
-OpStore %1399 %1418
-%1419 = OpLoad %ulong %1403
-%1420 = OpLoad %ulong %1399
-%1421 = OpBitwiseXor %ulong %1419 %1420
-OpStore %1400 %1421
-%1422 = OpLoad %ulong %1400
-%1423 = OpIMul %ulong %1422 %ulong_1099511628211
-OpStore %1401 %1423
-%1424 = OpLoad %ulong %1404
-%1425 = OpIAdd %ulong %1424 %ulong_1
-OpStore %1402 %1425
-%1426 = OpLoad %ulong %1401
-OpStore %1403 %1426
-%1427 = OpLoad %ulong %1402
-OpStore %1404 %1427
-OpBranch %1392
-%1392 = OpLabel
-OpBranch %1388
+OpStore %1243 %1108
+OpBranch %1125
+%1125 = OpLabel
+OpBranch %1126
+%1126 = OpLabel
+OpBranch %1135
+%1135 = OpLabel
+OpBranch %1136
+%1136 = OpLabel
+OpStore %1306 %ulong_14695981039346656037
+OpStore %1307 %ulong_0
+OpBranch %1137
+%1137 = OpLabel
+%1401 = OpLoad %ulong %1307
+%1402 = OpULessThan %bool %1401 %ulong_8
+OpStore %1299 %1402
+%1403 = OpLoad %bool %1299
+OpLoopMerge %1139 %1203 None
+OpBranchConditional %1403 %1138 %1139
+%1139 = OpLabel
+OpBranch %1140
+%1140 = OpLabel
+%1404 = OpLoad %ulong %1306
+%1405 = OpFunctionCall %ulong %22 %1404 %ulong_2
+OpStore %1290 %1405
+%1406 = OpLoad %ulong %1290
+%1407 = OpFunctionCall %ulong %22 %1406 %ulong_4
+OpStore %1291 %1407
+%1408 = OpLoad %ulong %1291
+%1409 = OpFunctionCall %ulong %22 %1408 %ulong_8
+OpStore %1292 %1409
+%1410 = OpLoad %ulong %1292
+%1411 = OpFunctionCall %ulong %22 %1410 %ulong_8
+OpStore %1293 %1411
+%1412 = OpLoad %ulong %1293
+%1413 = OpFunctionCall %ulong %22 %1412 %ulong_12
+OpStore %1294 %1413
+%1414 = OpLoad %ulong %1294
+%1415 = OpFunctionCall %ulong %22 %1414 %ulong_16
+OpStore %1295 %1415
+%1416 = OpLoad %ulong %1295
+%1417 = OpFunctionCall %ulong %22 %1416 %ulong_16
+OpStore %1296 %1417
+%1418 = OpLoad %ulong %1296
+%1419 = OpFunctionCall %ulong %22 %1418 %ulong_16
+OpStore %1297 %1419
+%1420 = OpLoad %ulong %1297
+%1421 = OpFunctionCall %ulong %22 %1420 %ulong_16
+OpStore %1298 %1421
+OpBranch %1141
+%1141 = OpLabel
+OpStore %1218 %1422
+OpStore %1275 %ulong_0
+OpBranch %1110
+%1110 = OpLabel
+%1423 = OpLoad %ulong %1275
+%1424 = OpULessThan %bool %1423 %ulong_8
+OpStore %1244 %1424
+%1425 = OpLoad %bool %1244
+OpLoopMerge %1112 %1202 None
+OpBranchConditional %1425 %1111 %1112
+%1112 = OpLabel
+%1426 = OpLoad %ulong %1298
+OpStore %1274 %1426
+OpStore %1279 %ulong_0
+OpBranch %1113
+%1113 = OpLabel
+%1427 = OpLoad %ulong %1279
+%1428 = OpULessThan %bool %1427 %ulong_8
+OpStore %1246 %1428
+%1429 = OpLoad %bool %1246
+OpLoopMerge %1115 %1201 None
+OpBranchConditional %1429 %1114 %1115
+%1115 = OpLabel
+OpStore %1207 %1430
+OpStore %1210 %1431
+OpStore %1278 %ulong_0
+OpBranch %1116
+%1116 = OpLabel
+%1432 = OpLoad %ulong %1278
+%1434 = OpULessThan %bool %1432 %ulong_6
+OpStore %1256 %1434
+%1435 = OpLoad %bool %1256
+OpLoopMerge %1118 %1200 None
+OpBranchConditional %1435 %1117 %1118
+%1118 = OpLabel
+%1436 = OpLoad %ulong %1274
+OpStore %1273 %1436
+OpStore %1277 %ulong_0
+OpBranch %1119
+%1119 = OpLabel
+%1437 = OpLoad %ulong %1277
+%1438 = OpULessThan %bool %1437 %ulong_6
+OpStore %1263 %1438
+%1439 = OpLoad %bool %1263
+OpLoopMerge %1121 %1199 None
+OpBranchConditional %1439 %1120 %1121
+%1121 = OpLabel
+%1440 = OpLoad %ulong %1273
+OpStore %1272 %1440
+OpStore %1276 %ulong_0
+OpBranch %1122
+%1122 = OpLabel
+%1441 = OpLoad %ulong %1276
+%1442 = OpULessThan %bool %1441 %ulong_4
+OpStore %1267 %1442
+%1443 = OpLoad %bool %1267
+OpLoopMerge %1124 %1198 None
+OpBranchConditional %1443 %1123 %1124
+%1124 = OpLabel
+%1444 = OpLoad %ulong %1272
+OpReturnValue %1444
+%1123 = OpLabel
+%1445 = OpLoad %ulong %1276
+%1446 = OpAccessChain %_ptr_Function_ulong %1218 %1445
+%1447 = OpLoad %ulong %1446
+OpStore %1268 %1447
+%1448 = OpLoad %ulong %1268
+%1449 = OpLoad %ulong %1243
+%1450 = OpIAdd %ulong %1448 %1449
+OpStore %1269 %1450
+OpBranch %1133
+%1133 = OpLabel
+%1451 = OpAccessChain %_ptr_Function_ulong %1214 %uint_0
+%1452 = OpLoad %ulong %1269
+OpStore %1451 %1452
+%1453 = OpLoad %ulong %1269
+%1454 = OpNot %ulong %1453
+OpStore %1289 %1454
+%1455 = OpAccessChain %_ptr_Function_ulong %1214 %uint_1
+%1456 = OpLoad %ulong %1289
+OpStore %1455 %1456
+OpBranch %1134
+%1134 = OpLabel
+OpBranch %1146
+%1146 = OpLabel
+%1457 = OpLoad %ulong %1269
+%1458 = OpBitwiseAnd %ulong %1457 %ulong_65535
+OpStore %1315 %1458
+%1459 = OpLoad %ulong %1315
+%1460 = OpConvertUToF %double %1459
+OpStore %1316 %1460
+%1461 = OpLoad %double %1316
+%1462 = OpFDiv %double %1461 %double_8
+OpStore %1317 %1462
+%1463 = OpAccessChain %_ptr_Function_double %1220 %uint_0
+%1464 = OpLoad %double %1317
+OpStore %1463 %1464
+%1465 = OpLoad %ulong %1269
+%1466 = OpBitwiseAnd %ulong %1465 %ulong_262143
+OpStore %1318 %1466
+%1467 = OpLoad %ulong %1318
+%1468 = OpConvertUToF %double %1467
+OpStore %1319 %1468
+%1469 = OpLoad %double %1319
+%1470 = OpFDiv %double %1469 %double_64
+OpStore %1320 %1470
+%1471 = OpAccessChain %_ptr_Function_double %1220 %uint_1
+%1472 = OpLoad %double %1320
+OpStore %1471 %1472
+OpBranch %1147
+%1147 = OpLabel
+OpBranch %1150
+%1150 = OpLabel
+%1473 = OpLoad %ulong %1269
+%1474 = OpIMul %ulong %1473 %ulong_3
+OpStore %1322 %1474
+%1475 = OpLoad %ulong %1322
+%1476 = OpIAdd %ulong %1475 %ulong_1
+OpStore %1323 %1476
+%1477 = OpAccessChain %_ptr_Function_ulong %1221 %uint_0
+%1478 = OpLoad %ulong %1323
+OpStore %1477 %1478
+%1479 = OpLoad %ulong %1269
+%1480 = OpBitwiseAnd %ulong %1479 %ulong_32767
+OpStore %1324 %1480
+%1481 = OpLoad %ulong %1324
+%1482 = OpConvertUToF %double %1481
+OpStore %1325 %1482
+%1483 = OpLoad %double %1325
+%1484 = OpFDiv %double %1483 %double_4
+OpStore %1326 %1484
+%1485 = OpAccessChain %_ptr_Function_double %1221 %uint_1
+%1486 = OpLoad %double %1326
+OpStore %1485 %1486
+OpBranch %1151
+%1151 = OpLabel
+OpBranch %1154
+%1154 = OpLabel
+%1487 = OpLoad %ulong %1269
+%1488 = OpUConvert %uint %1487
+OpStore %1329 %1488
+%1489 = OpAccessChain %_ptr_Function_uint %1222 %uint_0
+%1490 = OpLoad %uint %1329
+OpStore %1489 %1490
+%1491 = OpLoad %ulong %1269
+%1492 = OpShiftRightLogical %ulong %1491 %ulong_16
+OpStore %1330 %1492
+%1493 = OpLoad %ulong %1330
+%1494 = OpUConvert %uint %1493
+OpStore %1331 %1494
+%1495 = OpAccessChain %_ptr_Function_uint %1222 %uint_1
+%1496 = OpLoad %uint %1331
+OpStore %1495 %1496
+%1497 = OpLoad %ulong %1269
+%1498 = OpShiftRightLogical %ulong %1497 %ulong_32
+OpStore %1332 %1498
+%1499 = OpLoad %ulong %1332
+%1500 = OpUConvert %uint %1499
+OpStore %1333 %1500
+%1501 = OpAccessChain %_ptr_Function_uint %1222 %uint_2
+%1502 = OpLoad %uint %1333
+OpStore %1501 %1502
+OpBranch %1155
+%1155 = OpLabel
+OpBranch %1158
+%1158 = OpLabel
+%1503 = OpLoad %ulong %1269
+%1504 = OpUConvert %uint %1503
+OpStore %1335 %1504
+%1505 = OpAccessChain %_ptr_Function_uint %1223 %uint_0
+%1506 = OpLoad %uint %1335
+OpStore %1505 %1506
+%1507 = OpLoad %ulong %1269
+%1508 = OpShiftRightLogical %ulong %1507 %ulong_32
+OpStore %1336 %1508
+%1509 = OpLoad %ulong %1336
+%1510 = OpUConvert %uint %1509
+OpStore %1337 %1510
+%1511 = OpAccessChain %_ptr_Function_uint %1223 %uint_1
+%1512 = OpLoad %uint %1337
+OpStore %1511 %1512
+OpBranch %1159
+%1159 = OpLabel
+OpBranch %1162
+%1162 = OpLabel
+%1513 = OpLoad %ulong %1269
+%1514 = OpBitwiseAnd %ulong %1513 %ulong_4095
+OpStore %1340 %1514
+%1515 = OpLoad %ulong %1340
+%1516 = OpConvertUToF %float %1515
+OpStore %1341 %1516
+%1517 = OpLoad %float %1341
+%1518 = OpFDiv %float %1517 %float_8
+OpStore %1342 %1518
+%1519 = OpAccessChain %_ptr_Function_float %1224 %uint_0
+%1520 = OpLoad %float %1342
+OpStore %1519 %1520
+%1521 = OpLoad %ulong %1269
+%1522 = OpBitwiseAnd %ulong %1521 %ulong_255
+OpStore %1343 %1522
+%1523 = OpLoad %ulong %1343
+%1524 = OpConvertUToF %float %1523
+OpStore %1344 %1524
+%1525 = OpLoad %float %1344
+%1526 = OpFSub %float %1525 %float_128
+OpStore %1345 %1526
+%1527 = OpAccessChain %_ptr_Function_float %1224 %uint_1
+%1528 = OpLoad %float %1345
+OpStore %1527 %1528
+OpBranch %1163
+%1163 = OpLabel
+OpBranch %1166
+%1166 = OpLabel
+%1529 = OpLoad %_struct_180 %1214
+OpStore %1226 %1529
+%1530 = OpLoad %_struct_196 %1220
+OpStore %1227 %1530
+%1531 = OpLoad %_struct_231 %1221
+OpStore %1228 %1531
+%1532 = OpLoad %_struct_149 %1222
+OpStore %1229 %1532
+%1533 = OpLoad %_struct_90 %1223
+OpStore %1230 %1533
+%1534 = OpLoad %_struct_114 %1224
+OpStore %1231 %1534
+OpBranch %1167
+%1167 = OpLabel
+OpBranch %1168
+%1168 = OpLabel
+%1535 = OpLoad %_struct_180 %1226
+OpStore %1232 %1535
+%1536 = OpLoad %_struct_180 %1232
+%1537 = OpFunctionCall %ulong %15 %ulong_14695981039346656037 %1536
+OpStore %1349 %1537
+%1538 = OpLoad %_struct_196 %1227
+OpStore %1233 %1538
+%1539 = OpLoad %ulong %1349
+%1540 = OpLoad %_struct_196 %1233
+%1541 = OpFunctionCall %ulong %16 %1539 %1540
+OpStore %1350 %1541
+%1542 = OpLoad %_struct_231 %1228
+OpStore %1234 %1542
+%1543 = OpLoad %ulong %1350
+%1544 = OpLoad %_struct_231 %1234
+%1545 = OpFunctionCall %ulong %17 %1543 %1544
+OpStore %1351 %1545
+%1546 = OpLoad %_struct_149 %1229
+OpStore %1235 %1546
+%1547 = OpLoad %ulong %1351
+%1548 = OpLoad %_struct_149 %1235
+%1549 = OpFunctionCall %ulong %14 %1547 %1548
+OpStore %1352 %1549
+%1550 = OpLoad %_struct_90 %1230
+OpStore %1236 %1550
+%1551 = OpLoad %ulong %1352
+%1552 = OpLoad %_struct_90 %1236
+%1553 = OpFunctionCall %ulong %12 %1551 %1552
+OpStore %1353 %1553
+%1554 = OpLoad %_struct_114 %1231
+OpStore %1237 %1554
+%1555 = OpLoad %ulong %1353
+%1556 = OpLoad %_struct_114 %1237
+%1557 = OpFunctionCall %ulong %13 %1555 %1556
+OpStore %1354 %1557
+OpBranch %1169
+%1169 = OpLabel
+%1558 = OpLoad %ulong %1272
+%1559 = OpLoad %ulong %1354
+%1560 = OpFunctionCall %ulong %22 %1558 %1559
+OpStore %1270 %1560
+%1561 = OpLoad %ulong %1276
+%1562 = OpIAdd %ulong %1561 %ulong_1
+OpStore %1271 %1562
+%1563 = OpLoad %ulong %1270
+OpStore %1272 %1563
+%1564 = OpLoad %ulong %1271
+OpStore %1276 %1564
+OpBranch %1198
+%1120 = OpLabel
+%1565 = OpLoad %ulong %1277
+%1566 = OpAccessChain %_ptr_Function__struct_149 %1207 %1565
+%1567 = OpLoad %_struct_149 %1566
+OpStore %1211 %1567
+%1568 = OpLoad %ulong %1273
+%1569 = OpLoad %_struct_149 %1211
+%1570 = OpFunctionCall %ulong %14 %1568 %1569
+OpStore %1264 %1570
+%1571 = OpLoad %ulong %1277
+%1572 = OpAccessChain %_ptr_Function__struct_231 %1210 %1571
+%1573 = OpLoad %_struct_231 %1572
+OpStore %1212 %1573
+%1574 = OpLoad %ulong %1264
+%1575 = OpLoad %_struct_231 %1212
+%1576 = OpFunctionCall %ulong %17 %1574 %1575
+OpStore %1265 %1576
+%1577 = OpLoad %ulong %1277
+%1578 = OpIAdd %ulong %1577 %ulong_1
+OpStore %1266 %1578
+%1579 = OpLoad %ulong %1265
+OpStore %1273 %1579
+%1580 = OpLoad %ulong %1266
+OpStore %1277 %1580
+OpBranch %1199
+%1117 = OpLabel
+%1581 = OpLoad %ulong %1278
+%1582 = OpAccessChain %_ptr_Function_ulong %1218 %1581
+%1583 = OpLoad %ulong %1582
+OpStore %1257 %1583
+%1584 = OpLoad %ulong %1257
+%1585 = OpLoad %ulong %1243
+%1586 = OpIAdd %ulong %1584 %1585
+OpStore %1258 %1586
+OpBranch %1131
+%1131 = OpLabel
+%1587 = OpLoad %ulong %1258
+%1588 = OpUConvert %uint %1587
+OpStore %1284 %1588
+%1589 = OpAccessChain %_ptr_Function_uint %1213 %uint_0
+%1590 = OpLoad %uint %1284
+OpStore %1589 %1590
+%1591 = OpLoad %ulong %1258
+%1592 = OpShiftRightLogical %ulong %1591 %ulong_16
+OpStore %1285 %1592
+%1593 = OpLoad %ulong %1285
+%1594 = OpUConvert %uint %1593
+OpStore %1286 %1594
+%1595 = OpAccessChain %_ptr_Function_uint %1213 %uint_1
+%1596 = OpLoad %uint %1286
+OpStore %1595 %1596
+%1597 = OpLoad %ulong %1258
+%1598 = OpShiftRightLogical %ulong %1597 %ulong_32
+OpStore %1287 %1598
+%1599 = OpLoad %ulong %1287
+%1600 = OpUConvert %uint %1599
+OpStore %1288 %1600
+%1601 = OpAccessChain %_ptr_Function_uint %1213 %uint_2
+%1602 = OpLoad %uint %1288
+OpStore %1601 %1602
+OpBranch %1132
+%1132 = OpLabel
+%1603 = OpLoad %ulong %1278
+%1604 = OpAccessChain %_ptr_Function__struct_149 %1207 %1603
+%1605 = OpLoad %_struct_149 %1213
+OpStore %1604 %1605
+%1606 = OpLoad %ulong %1278
+%1607 = OpAccessChain %_ptr_Function_ulong %1218 %1606
+%1608 = OpLoad %ulong %1607
+OpStore %1259 %1608
+%1609 = OpLoad %ulong %1259
+%1610 = OpIMul %ulong %1609 %ulong_3
+OpStore %1260 %1610
+%1611 = OpLoad %ulong %1260
+%1612 = OpLoad %ulong %1243
+%1613 = OpIAdd %ulong %1611 %1612
+OpStore %1261 %1613
+OpBranch %1144
+%1144 = OpLabel
+%1614 = OpLoad %ulong %1261
+%1615 = OpIMul %ulong %1614 %ulong_3
+OpStore %1310 %1615
+%1616 = OpLoad %ulong %1310
+%1617 = OpIAdd %ulong %1616 %ulong_1
+OpStore %1311 %1617
+%1618 = OpAccessChain %_ptr_Function_ulong %1219 %uint_0
+%1619 = OpLoad %ulong %1311
+OpStore %1618 %1619
+%1620 = OpLoad %ulong %1261
+%1621 = OpBitwiseAnd %ulong %1620 %ulong_32767
+OpStore %1312 %1621
+%1622 = OpLoad %ulong %1312
+%1623 = OpConvertUToF %double %1622
+OpStore %1313 %1623
+%1624 = OpLoad %double %1313
+%1625 = OpFDiv %double %1624 %double_4
+OpStore %1314 %1625
+%1626 = OpAccessChain %_ptr_Function_double %1219 %uint_1
+%1627 = OpLoad %double %1314
+OpStore %1626 %1627
+OpBranch %1145
+%1145 = OpLabel
+%1628 = OpLoad %ulong %1278
+%1629 = OpAccessChain %_ptr_Function__struct_231 %1210 %1628
+%1630 = OpLoad %_struct_231 %1219
+OpStore %1629 %1630
+%1631 = OpLoad %ulong %1278
+%1632 = OpIAdd %ulong %1631 %ulong_1
+OpStore %1262 %1632
+%1633 = OpLoad %ulong %1262
+OpStore %1278 %1633
+OpBranch %1200
+%1114 = OpLabel
+%1634 = OpLoad %ulong %1279
+%1635 = OpAccessChain %_ptr_Function_ulong %1218 %1634
+%1636 = OpLoad %ulong %1635
+OpStore %1247 %1636
+%1637 = OpLoad %ulong %1247
+%1638 = OpLoad %ulong %1243
+%1639 = OpIAdd %ulong %1637 %1638
+OpStore %1248 %1639
+OpBranch %1129
+%1129 = OpLabel
+%1640 = OpLoad %ulong %1248
+%1641 = OpUConvert %uchar %1640
+OpStore %1283 %1641
+OpBranch %1130
+%1130 = OpLabel
+OpBranch %1142
+%1142 = OpLabel
+%1642 = OpLoad %uchar %1283
+%1643 = OpUConvert %ulong %1642
+OpStore %1308 %1643
+%1644 = OpLoad %ulong %1274
+%1645 = OpLoad %ulong %1308
+%1646 = OpFunctionCall %ulong %22 %1644 %1645
+OpStore %1309 %1646
+OpBranch %1143
+%1143 = OpLabel
+OpBranch %1148
+%1148 = OpLabel
+%1647 = OpLoad %ulong %1248
+%1648 = OpUConvert %ushort %1647
+OpStore %1321 %1648
+OpBranch %1149
+%1149 = OpLabel
+OpBranch %1152
+%1152 = OpLabel
+%1649 = OpLoad %ushort %1321
+%1650 = OpUConvert %ulong %1649
+OpStore %1327 %1650
+%1651 = OpLoad %ulong %1309
+%1652 = OpLoad %ulong %1327
+%1653 = OpFunctionCall %ulong %22 %1651 %1652
+OpStore %1328 %1653
+OpBranch %1153
+%1153 = OpLabel
+OpBranch %1156
+%1156 = OpLabel
+%1654 = OpLoad %ulong %1248
+%1655 = OpUConvert %uint %1654
+OpStore %1334 %1655
+OpBranch %1157
+%1157 = OpLabel
+OpBranch %1160
+%1160 = OpLabel
+%1656 = OpLoad %uint %1334
+%1657 = OpUConvert %ulong %1656
+OpStore %1338 %1657
+%1658 = OpLoad %ulong %1328
+%1659 = OpLoad %ulong %1338
+%1660 = OpFunctionCall %ulong %22 %1658 %1659
+OpStore %1339 %1660
+OpBranch %1161
+%1161 = OpLabel
+OpBranch %1164
+%1164 = OpLabel
+%1661 = OpLoad %ulong %1248
+%1662 = OpUConvert %uint %1661
+OpStore %1346 %1662
+%1663 = OpAccessChain %_ptr_Function_uint %1225 %uint_0
+%1664 = OpLoad %uint %1346
+OpStore %1663 %1664
+%1665 = OpLoad %ulong %1248
+%1666 = OpShiftRightLogical %ulong %1665 %ulong_32
+OpStore %1347 %1666
+%1667 = OpLoad %ulong %1347
+%1668 = OpUConvert %uint %1667
+OpStore %1348 %1668
+%1669 = OpAccessChain %_ptr_Function_uint %1225 %uint_1
+%1670 = OpLoad %uint %1348
+OpStore %1669 %1670
+OpBranch %1165
+%1165 = OpLabel
+%1671 = OpLoad %ulong %1339
+%1672 = OpLoad %_struct_90 %1225
+%1673 = OpFunctionCall %ulong %12 %1671 %1672
+OpStore %1249 %1673
+OpBranch %1170
+%1170 = OpLabel
+%1674 = OpLoad %ulong %1248
+%1675 = OpBitwiseAnd %ulong %1674 %ulong_4095
+OpStore %1355 %1675
+%1676 = OpLoad %ulong %1355
+%1677 = OpConvertUToF %float %1676
+OpStore %1356 %1677
+%1678 = OpLoad %float %1356
+%1679 = OpFDiv %float %1678 %float_8
+OpStore %1357 %1679
+%1680 = OpAccessChain %_ptr_Function_float %1238 %uint_0
+%1681 = OpLoad %float %1357
+OpStore %1680 %1681
+%1682 = OpLoad %ulong %1248
+%1683 = OpBitwiseAnd %ulong %1682 %ulong_255
+OpStore %1358 %1683
+%1684 = OpLoad %ulong %1358
+%1685 = OpConvertUToF %float %1684
+OpStore %1359 %1685
+%1686 = OpLoad %float %1359
+%1687 = OpFSub %float %1686 %float_128
+OpStore %1360 %1687
+%1688 = OpAccessChain %_ptr_Function_float %1238 %uint_1
+%1689 = OpLoad %float %1360
+OpStore %1688 %1689
+OpBranch %1171
+%1171 = OpLabel
+%1690 = OpLoad %ulong %1249
+%1691 = OpLoad %_struct_114 %1238
+%1692 = OpFunctionCall %ulong %13 %1690 %1691
+OpStore %1250 %1692
+OpBranch %1172
+%1172 = OpLabel
+%1693 = OpLoad %ulong %1248
+%1694 = OpUConvert %uint %1693
+OpStore %1361 %1694
+%1695 = OpAccessChain %_ptr_Function_uint %1239 %uint_0
+%1696 = OpLoad %uint %1361
+OpStore %1695 %1696
+%1697 = OpLoad %ulong %1248
+%1698 = OpShiftRightLogical %ulong %1697 %ulong_16
+OpStore %1362 %1698
+%1699 = OpLoad %ulong %1362
+%1700 = OpUConvert %uint %1699
+OpStore %1363 %1700
+%1701 = OpAccessChain %_ptr_Function_uint %1239 %uint_1
+%1702 = OpLoad %uint %1363
+OpStore %1701 %1702
+%1703 = OpLoad %ulong %1248
+%1704 = OpShiftRightLogical %ulong %1703 %ulong_32
+OpStore %1364 %1704
+%1705 = OpLoad %ulong %1364
+%1706 = OpUConvert %uint %1705
+OpStore %1365 %1706
+%1707 = OpAccessChain %_ptr_Function_uint %1239 %uint_2
+%1708 = OpLoad %uint %1365
+OpStore %1707 %1708
+OpBranch %1173
+%1173 = OpLabel
+%1709 = OpLoad %ulong %1250
+%1710 = OpLoad %_struct_149 %1239
+%1711 = OpFunctionCall %ulong %14 %1709 %1710
+OpStore %1251 %1711
+OpBranch %1174
+%1174 = OpLabel
+%1712 = OpAccessChain %_ptr_Function_ulong %1240 %uint_0
+%1713 = OpLoad %ulong %1248
+OpStore %1712 %1713
+%1714 = OpLoad %ulong %1248
+%1715 = OpNot %ulong %1714
+OpStore %1366 %1715
+%1716 = OpAccessChain %_ptr_Function_ulong %1240 %uint_1
+%1717 = OpLoad %ulong %1366
+OpStore %1716 %1717
+OpBranch %1175
+%1175 = OpLabel
+%1718 = OpLoad %ulong %1251
+%1719 = OpLoad %_struct_180 %1240
+%1720 = OpFunctionCall %ulong %15 %1718 %1719
+OpStore %1252 %1720
+OpBranch %1176
+%1176 = OpLabel
+%1721 = OpLoad %ulong %1248
+%1722 = OpBitwiseAnd %ulong %1721 %ulong_65535
+OpStore %1367 %1722
+%1723 = OpLoad %ulong %1367
+%1724 = OpConvertUToF %double %1723
+OpStore %1368 %1724
+%1725 = OpLoad %double %1368
+%1726 = OpFDiv %double %1725 %double_8
+OpStore %1369 %1726
+%1727 = OpAccessChain %_ptr_Function_double %1241 %uint_0
+%1728 = OpLoad %double %1369
+OpStore %1727 %1728
+%1729 = OpLoad %ulong %1248
+%1730 = OpBitwiseAnd %ulong %1729 %ulong_262143
+OpStore %1370 %1730
+%1731 = OpLoad %ulong %1370
+%1732 = OpConvertUToF %double %1731
+OpStore %1371 %1732
+%1733 = OpLoad %double %1371
+%1734 = OpFDiv %double %1733 %double_64
+OpStore %1372 %1734
+%1735 = OpAccessChain %_ptr_Function_double %1241 %uint_1
+%1736 = OpLoad %double %1372
+OpStore %1735 %1736
+OpBranch %1177
+%1177 = OpLabel
+%1737 = OpLoad %ulong %1252
+%1738 = OpLoad %_struct_196 %1241
+%1739 = OpFunctionCall %ulong %16 %1737 %1738
+OpStore %1253 %1739
+OpBranch %1178
+%1178 = OpLabel
+%1740 = OpLoad %ulong %1248
+%1741 = OpIMul %ulong %1740 %ulong_3
+OpStore %1373 %1741
+%1742 = OpLoad %ulong %1373
+%1743 = OpIAdd %ulong %1742 %ulong_1
+OpStore %1374 %1743
+%1744 = OpAccessChain %_ptr_Function_ulong %1242 %uint_0
+%1745 = OpLoad %ulong %1374
+OpStore %1744 %1745
+%1746 = OpLoad %ulong %1248
+%1747 = OpBitwiseAnd %ulong %1746 %ulong_32767
+OpStore %1375 %1747
+%1748 = OpLoad %ulong %1375
+%1749 = OpConvertUToF %double %1748
+OpStore %1376 %1749
+%1750 = OpLoad %double %1376
+%1751 = OpFDiv %double %1750 %double_4
+OpStore %1377 %1751
+%1752 = OpAccessChain %_ptr_Function_double %1242 %uint_1
+%1753 = OpLoad %double %1377
+OpStore %1752 %1753
+OpBranch %1179
+%1179 = OpLabel
+%1754 = OpLoad %ulong %1253
+%1755 = OpLoad %_struct_231 %1242
+%1756 = OpFunctionCall %ulong %17 %1754 %1755
+OpStore %1254 %1756
+OpBranch %1180
+%1180 = OpLabel
+%1757 = OpLoad %ulong %1248
+%1758 = OpBitwiseAnd %ulong %1757 %ulong_8191
+OpStore %1378 %1758
+%1759 = OpLoad %ulong %1378
+%1760 = OpConvertUToF %double %1759
+OpStore %1379 %1760
+%1761 = OpLoad %double %1379
+%1762 = OpFDiv %double %1761 %double_2
+OpStore %1380 %1762
+%1763 = OpLoad %ulong %1248
+%1764 = OpBitwiseXor %ulong %1763 %ulong_305419896
+OpStore %1381 %1764
+OpBranch %1181
+%1181 = OpLabel
+OpBranch %1182
+%1182 = OpLabel
+OpBranch %1183
+%1183 = OpLabel
+%1765 = OpLoad %double %1380
+%1766 = OpBitcast %ulong %1765
+OpStore %1382 %1766
+OpBranch %1185
+%1185 = OpLabel
+%1767 = OpLoad %ulong %1254
+OpStore %1390 %1767
+OpStore %1391 %ulong_0
+OpBranch %1186
+%1186 = OpLabel
+%1768 = OpLoad %ulong %1391
+%1769 = OpULessThan %bool %1768 %ulong_8
+OpStore %1383 %1769
+%1770 = OpLoad %bool %1383
+OpLoopMerge %1188 %1197 None
+OpBranchConditional %1770 %1187 %1188
+%1188 = OpLabel
+OpBranch %1189
+%1189 = OpLabel
+OpBranch %1184
+%1184 = OpLabel
+OpBranch %1190
+%1190 = OpLabel
+%1771 = OpLoad %ulong %1390
+OpStore %1399 %1771
+OpStore %1400 %ulong_0
+OpBranch %1191
+%1191 = OpLabel
+%1772 = OpLoad %ulong %1400
+%1773 = OpULessThan %bool %1772 %ulong_8
+OpStore %1392 %1773
+%1774 = OpLoad %bool %1392
+OpLoopMerge %1193 %1196 None
+OpBranchConditional %1774 %1192 %1193
+%1193 = OpLabel
+OpBranch %1194
+%1194 = OpLabel
+OpBranch %1195
+%1195 = OpLabel
+%1775 = OpLoad %ulong %1279
+%1776 = OpIAdd %ulong %1775 %ulong_1
+OpStore %1255 %1776
+%1777 = OpLoad %ulong %1399
+OpStore %1274 %1777
+%1778 = OpLoad %ulong %1255
+OpStore %1279 %1778
+OpBranch %1201
+%1192 = OpLabel
+%1779 = OpLoad %ulong %1400
+%1780 = OpIMul %ulong %1779 %ulong_8
+OpStore %1393 %1780
+%1781 = OpLoad %ulong %1381
+%1782 = OpLoad %ulong %1393
+%1783 = OpShiftRightLogical %ulong %1781 %1782
+OpStore %1394 %1783
+%1784 = OpLoad %ulong %1394
+%1785 = OpBitwiseAnd %ulong %1784 %ulong_255
+OpStore %1395 %1785
+%1786 = OpLoad %ulong %1399
+%1787 = OpLoad %ulong %1395
+%1788 = OpBitwiseXor %ulong %1786 %1787
+OpStore %1396 %1788
+%1789 = OpLoad %ulong %1396
+%1790 = OpIMul %ulong %1789 %ulong_1099511628211
+OpStore %1397 %1790
+%1791 = OpLoad %ulong %1400
+%1792 = OpIAdd %ulong %1791 %ulong_1
+OpStore %1398 %1792
+%1793 = OpLoad %ulong %1397
+OpStore %1399 %1793
+%1794 = OpLoad %ulong %1398
+OpStore %1400 %1794
+OpBranch %1196
+%1187 = OpLabel
+%1795 = OpLoad %ulong %1391
+%1796 = OpIMul %ulong %1795 %ulong_8
+OpStore %1384 %1796
+%1797 = OpLoad %ulong %1382
+%1798 = OpLoad %ulong %1384
+%1799 = OpShiftRightLogical %ulong %1797 %1798
+OpStore %1385 %1799
+%1800 = OpLoad %ulong %1385
+%1801 = OpBitwiseAnd %ulong %1800 %ulong_255
+OpStore %1386 %1801
+%1802 = OpLoad %ulong %1390
+%1803 = OpLoad %ulong %1386
+%1804 = OpBitwiseXor %ulong %1802 %1803
+OpStore %1387 %1804
+%1805 = OpLoad %ulong %1387
+%1806 = OpIMul %ulong %1805 %ulong_1099511628211
+OpStore %1388 %1806
+%1807 = OpLoad %ulong %1391
+%1808 = OpIAdd %ulong %1807 %ulong_1
+OpStore %1389 %1808
+%1809 = OpLoad %ulong %1388
+OpStore %1390 %1809
+%1810 = OpLoad %ulong %1389
+OpStore %1391 %1810
+OpBranch %1197
+%1111 = OpLabel
+OpBranch %1127
+%1127 = OpLabel
+%1811 = OpLoad %ulong %1275
+%1812 = OpIMul %ulong %1811 %ulong_6364136223846793005
+OpStore %1280 %1812
+%1813 = OpLoad %ulong %1280
+%1814 = OpIAdd %ulong %1813 %ulong_1442695040888963407
+OpStore %1281 %1814
+%1815 = OpLoad %ulong %1281
+%1816 = OpLoad %ulong %1243
+%1817 = OpIAdd %ulong %1815 %1816
+OpStore %1282 %1817
+OpBranch %1128
+%1128 = OpLabel
+%1818 = OpLoad %ulong %1275
+%1819 = OpAccessChain %_ptr_Function_ulong %1218 %1818
+%1820 = OpLoad %ulong %1282
+OpStore %1819 %1820
+%1821 = OpLoad %ulong %1275
+%1822 = OpIAdd %ulong %1821 %ulong_1
+OpStore %1245 %1822
+%1823 = OpLoad %ulong %1245
+OpStore %1275 %1823
+OpBranch %1202
+%1138 = OpLabel
+%1824 = OpLoad %ulong %1307
+%1825 = OpIMul %ulong %1824 %ulong_8
+OpStore %1300 %1825
+%1826 = OpLoad %ulong %1300
+%1827 = OpShiftRightLogical %ulong %ulong_1 %1826
+OpStore %1301 %1827
+%1828 = OpLoad %ulong %1301
+%1829 = OpBitwiseAnd %ulong %1828 %ulong_255
+OpStore %1302 %1829
+%1830 = OpLoad %ulong %1306
+%1831 = OpLoad %ulong %1302
+%1832 = OpBitwiseXor %ulong %1830 %1831
+OpStore %1303 %1832
+%1833 = OpLoad %ulong %1303
+%1834 = OpIMul %ulong %1833 %ulong_1099511628211
+OpStore %1304 %1834
+%1835 = OpLoad %ulong %1307
+%1836 = OpIAdd %ulong %1835 %ulong_1
+OpStore %1305 %1836
+%1837 = OpLoad %ulong %1304
+OpStore %1306 %1837
+%1838 = OpLoad %ulong %1305
+OpStore %1307 %1838
+OpBranch %1203
+%1196 = OpLabel
+OpBranch %1191
+%1197 = OpLabel
+OpBranch %1186
+%1198 = OpLabel
+OpBranch %1122
+%1199 = OpLabel
+OpBranch %1119
+%1200 = OpLabel
+OpBranch %1116
+%1201 = OpLabel
+OpBranch %1113
+%1202 = OpLabel
+OpBranch %1110
+%1203 = OpLabel
+OpBranch %1137
 OpFunctionEnd
-%27 = OpFunction %ulong None %1428
-%1429 = OpFunctionParameter %ulong
-%1430 = OpFunctionParameter %float
-%1431 = OpLabel
-%1438 = OpVariable %_ptr_Function_ulong Function
-%1439 = OpVariable %_ptr_Function_float Function
-%1440 = OpVariable %_ptr_Function_uint Function
-%1441 = OpVariable %_ptr_Function_ulong Function
-%1442 = OpVariable %_ptr_Function_bool Function
-%1443 = OpVariable %_ptr_Function_ulong Function
-%1444 = OpVariable %_ptr_Function_ulong Function
-%1445 = OpVariable %_ptr_Function_ulong Function
-%1446 = OpVariable %_ptr_Function_ulong Function
-%1447 = OpVariable %_ptr_Function_ulong Function
-%1448 = OpVariable %_ptr_Function_ulong Function
-%1449 = OpVariable %_ptr_Function_ulong Function
-%1450 = OpVariable %_ptr_Function_ulong Function
-OpStore %1438 %1429
-OpStore %1439 %1430
-%1451 = OpLoad %float %1439
-%1452 = OpBitcast %uint %1451
-OpStore %1440 %1452
-%1453 = OpLoad %uint %1440
-%1454 = OpUConvert %ulong %1453
-OpStore %1441 %1454
-OpBranch %1432
-%1432 = OpLabel
-%1455 = OpLoad %ulong %1438
-OpStore %1449 %1455
-OpStore %1450 %ulong_0
-OpBranch %1433
-%1433 = OpLabel
-%1456 = OpLoad %ulong %1450
-%1457 = OpULessThan %bool %1456 %ulong_8
-OpStore %1442 %1457
-%1458 = OpLoad %bool %1442
-OpLoopMerge %1435 %1437 None
-OpBranchConditional %1458 %1434 %1435
-%1435 = OpLabel
-OpBranch %1436
-%1436 = OpLabel
-%1459 = OpLoad %ulong %1449
-OpReturnValue %1459
-%1434 = OpLabel
-%1460 = OpLoad %ulong %1450
-%1461 = OpIMul %ulong %1460 %ulong_8
-OpStore %1443 %1461
-%1462 = OpLoad %ulong %1441
-%1463 = OpLoad %ulong %1443
-%1464 = OpShiftRightLogical %ulong %1462 %1463
-OpStore %1444 %1464
-%1465 = OpLoad %ulong %1444
-%1466 = OpBitwiseAnd %ulong %1465 %ulong_255
-OpStore %1445 %1466
-%1467 = OpLoad %ulong %1449
-%1468 = OpLoad %ulong %1445
-%1469 = OpBitwiseXor %ulong %1467 %1468
-OpStore %1446 %1469
-%1470 = OpLoad %ulong %1446
-%1471 = OpIMul %ulong %1470 %ulong_1099511628211
-OpStore %1447 %1471
-%1472 = OpLoad %ulong %1450
-%1473 = OpIAdd %ulong %1472 %ulong_1
-OpStore %1448 %1473
-%1474 = OpLoad %ulong %1447
-OpStore %1449 %1474
-%1475 = OpLoad %ulong %1448
-OpStore %1450 %1475
-OpBranch %1437
-%1437 = OpLabel
-OpBranch %1433
-OpFunctionEnd
-%28 = OpFunction %ulong None %1476
-%1477 = OpFunctionParameter %ulong
-%1478 = OpFunctionParameter %double
-%1479 = OpLabel
-%1486 = OpVariable %_ptr_Function_ulong Function
-%1487 = OpVariable %_ptr_Function_double Function
-%1488 = OpVariable %_ptr_Function_ulong Function
-%1489 = OpVariable %_ptr_Function_bool Function
-%1490 = OpVariable %_ptr_Function_ulong Function
-%1491 = OpVariable %_ptr_Function_ulong Function
-%1492 = OpVariable %_ptr_Function_ulong Function
-%1493 = OpVariable %_ptr_Function_ulong Function
-%1494 = OpVariable %_ptr_Function_ulong Function
-%1495 = OpVariable %_ptr_Function_ulong Function
-%1496 = OpVariable %_ptr_Function_ulong Function
-%1497 = OpVariable %_ptr_Function_ulong Function
-OpStore %1486 %1477
-OpStore %1487 %1478
-%1498 = OpLoad %double %1487
-%1499 = OpBitcast %ulong %1498
-OpStore %1488 %1499
-OpBranch %1480
-%1480 = OpLabel
-%1500 = OpLoad %ulong %1486
-OpStore %1496 %1500
-OpStore %1497 %ulong_0
-OpBranch %1481
-%1481 = OpLabel
-%1501 = OpLoad %ulong %1497
-%1502 = OpULessThan %bool %1501 %ulong_8
-OpStore %1489 %1502
-%1503 = OpLoad %bool %1489
-OpLoopMerge %1483 %1485 None
-OpBranchConditional %1503 %1482 %1483
-%1483 = OpLabel
-OpBranch %1484
-%1484 = OpLabel
-%1504 = OpLoad %ulong %1496
-OpReturnValue %1504
-%1482 = OpLabel
-%1505 = OpLoad %ulong %1497
-%1506 = OpIMul %ulong %1505 %ulong_8
-OpStore %1490 %1506
-%1507 = OpLoad %ulong %1488
-%1508 = OpLoad %ulong %1490
-%1509 = OpShiftRightLogical %ulong %1507 %1508
-OpStore %1491 %1509
-%1510 = OpLoad %ulong %1491
-%1511 = OpBitwiseAnd %ulong %1510 %ulong_255
-OpStore %1492 %1511
-%1512 = OpLoad %ulong %1496
-%1513 = OpLoad %ulong %1492
-%1514 = OpBitwiseXor %ulong %1512 %1513
-OpStore %1493 %1514
-%1515 = OpLoad %ulong %1493
-%1516 = OpIMul %ulong %1515 %ulong_1099511628211
-OpStore %1494 %1516
-%1517 = OpLoad %ulong %1497
-%1518 = OpIAdd %ulong %1517 %ulong_1
-OpStore %1495 %1518
-%1519 = OpLoad %ulong %1494
-OpStore %1496 %1519
-%1520 = OpLoad %ulong %1495
-OpStore %1497 %1520
-OpBranch %1485
-%1485 = OpLabel
-OpBranch %1481
+%22 = OpFunction %ulong None %24
+%1839 = OpFunctionParameter %ulong
+%1840 = OpFunctionParameter %ulong
+%1841 = OpLabel
+%1846 = OpVariable %_ptr_Function_ulong Function
+%1847 = OpVariable %_ptr_Function_ulong Function
+%1848 = OpVariable %_ptr_Function_bool Function
+%1849 = OpVariable %_ptr_Function_ulong Function
+%1850 = OpVariable %_ptr_Function_ulong Function
+%1851 = OpVariable %_ptr_Function_ulong Function
+%1852 = OpVariable %_ptr_Function_ulong Function
+%1853 = OpVariable %_ptr_Function_ulong Function
+%1854 = OpVariable %_ptr_Function_ulong Function
+%1855 = OpVariable %_ptr_Function_ulong Function
+%1856 = OpVariable %_ptr_Function_ulong Function
+OpStore %1846 %1839
+OpStore %1847 %1840
+%1857 = OpLoad %ulong %1846
+OpStore %1855 %1857
+OpStore %1856 %ulong_0
+OpBranch %1842
+%1842 = OpLabel
+%1858 = OpLoad %ulong %1856
+%1859 = OpULessThan %bool %1858 %ulong_8
+OpStore %1848 %1859
+%1860 = OpLoad %bool %1848
+OpLoopMerge %1844 %1845 None
+OpBranchConditional %1860 %1843 %1844
+%1844 = OpLabel
+%1861 = OpLoad %ulong %1855
+OpReturnValue %1861
+%1843 = OpLabel
+%1862 = OpLoad %ulong %1856
+%1863 = OpIMul %ulong %1862 %ulong_8
+OpStore %1849 %1863
+%1864 = OpLoad %ulong %1847
+%1865 = OpLoad %ulong %1849
+%1866 = OpShiftRightLogical %ulong %1864 %1865
+OpStore %1850 %1866
+%1867 = OpLoad %ulong %1850
+%1868 = OpBitwiseAnd %ulong %1867 %ulong_255
+OpStore %1851 %1868
+%1869 = OpLoad %ulong %1855
+%1870 = OpLoad %ulong %1851
+%1871 = OpBitwiseXor %ulong %1869 %1870
+OpStore %1852 %1871
+%1872 = OpLoad %ulong %1852
+%1873 = OpIMul %ulong %1872 %ulong_1099511628211
+OpStore %1853 %1873
+%1874 = OpLoad %ulong %1856
+%1875 = OpIAdd %ulong %1874 %ulong_1
+OpStore %1854 %1875
+%1876 = OpLoad %ulong %1853
+OpStore %1855 %1876
+%1877 = OpLoad %ulong %1854
+OpStore %1856 %1877
+OpBranch %1845
+%1845 = OpLabel
+OpBranch %1842
 OpFunctionEnd

--- a/test/golden/spirv/call/call_variadic.dis
+++ b/test/golden/spirv/call/call_variadic.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1520
+; Bound: 2051
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -31,11 +31,11 @@ OpDecorate %18 LinkageAttributes "corpus.cases.call.call_variadic.fold_pack$pack
 OpDecorate %19 LinkageAttributes "corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64" Export
 OpDecorate %20 LinkageAttributes "corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64" Export
 %ulong = OpTypeInt 64 0
-%26 = OpTypeFunction %ulong %ulong %ulong
+%23 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
-%46 = OpTypeFunction %ulong %ulong
+%43 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
@@ -51,9 +51,11 @@ OpDecorate %20 LinkageAttributes "corpus.cases.call.call_variadic.fold_pack$pack
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_double = OpTypePointer Function %double
-%287 = OpConstantNull %_arr_ulong_uint_12
+%535 = OpConstantNull %_arr_ulong_uint_12
 %ulong_0 = OpConstant %ulong 0
 %ulong_12 = OpConstant %ulong 12
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_8 = OpConstant %ulong 8
 %ulong_4 = OpConstant %ulong 4
 %ulong_7 = OpConstant %ulong 7
 %ulong_3 = OpConstant %ulong 3
@@ -72,7 +74,6 @@ OpDecorate %20 LinkageAttributes "corpus.cases.call.call_variadic.fold_pack$pack
 %double_256 = OpConstant %double 256
 %ulong_8191 = OpConstant %ulong 8191
 %double_2 = OpConstant %double 2
-%ulong_8 = OpConstant %ulong 8
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
@@ -88,200 +89,80 @@ OpDecorate %20 LinkageAttributes "corpus.cases.call.call_variadic.fold_pack$pack
 %ulong_5 = OpConstant %ulong 5
 %ulong_6 = OpConstant %ulong 6
 %ulong_1 = OpConstant %ulong 1
-%747 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong %uchar %ushort %uint %ulong
-%821 = OpTypeFunction %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong
-%901 = OpTypeFunction %ulong %ulong %float %double %float %double
-%933 = OpTypeFunction %ulong %ulong %ulong %float %uint %double %ushort %ulong
-%983 = OpTypeFunction %ulong %ulong %ulong %uchar %uint %ulong %ushort
-%1046 = OpTypeFunction %ulong %ulong %ulong %float %ulong %double
-%1082 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong
-%1169 = OpTypeFunction %ulong %ulong %ulong %float %double
-%1279 = OpTypeFunction %ulong %ulong %float
-%1385 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1475 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %26
-%27 = OpFunctionParameter %ulong
-%28 = OpFunctionParameter %ulong
-%29 = OpLabel
+%1275 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong %uchar %ushort %uint %ulong
+%1349 = OpTypeFunction %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong %ulong
+%1429 = OpTypeFunction %ulong %ulong %float %double %float %double
+%1487 = OpTypeFunction %ulong %ulong %ulong %float %uint %double %ushort %ulong
+%1550 = OpTypeFunction %ulong %ulong %ulong %uchar %uint %ulong %ushort
+%1613 = OpTypeFunction %ulong %ulong %ulong %float %ulong %double
+%1662 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong
+%1749 = OpTypeFunction %ulong %ulong %ulong %float %double
+%1872 = OpTypeFunction %ulong %ulong %float
+%1 = OpFunction %ulong None %23
+%24 = OpFunctionParameter %ulong
+%25 = OpFunctionParameter %ulong
+%26 = OpLabel
+%28 = OpVariable %_ptr_Function_ulong Function
+%29 = OpVariable %_ptr_Function_ulong Function
+%30 = OpVariable %_ptr_Function_ulong Function
 %31 = OpVariable %_ptr_Function_ulong Function
 %32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-OpStore %31 %27
-OpStore %32 %28
-%36 = OpLoad %ulong %32
-%38 = OpIMul %ulong %36 %ulong_6364136223846793005
-OpStore %33 %38
-%39 = OpLoad %ulong %33
-%41 = OpIAdd %ulong %39 %ulong_1442695040888963407
-OpStore %34 %41
-%42 = OpLoad %ulong %34
-%43 = OpLoad %ulong %31
-%44 = OpIAdd %ulong %42 %43
-OpStore %35 %44
-%45 = OpLoad %ulong %35
-OpReturnValue %45
+OpStore %28 %24
+OpStore %29 %25
+%33 = OpLoad %ulong %29
+%35 = OpIMul %ulong %33 %ulong_6364136223846793005
+OpStore %30 %35
+%36 = OpLoad %ulong %30
+%38 = OpIAdd %ulong %36 %ulong_1442695040888963407
+OpStore %31 %38
+%39 = OpLoad %ulong %31
+%40 = OpLoad %ulong %28
+%41 = OpIAdd %ulong %39 %40
+OpStore %32 %41
+%42 = OpLoad %ulong %32
+OpReturnValue %42
 OpFunctionEnd
-%2 = OpFunction %ulong None %46
-%47 = OpFunctionParameter %ulong
-%48 = OpLabel
-%116 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_bool Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_bool Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_uchar Function
-%128 = OpVariable %_ptr_Function_ushort Function
-%130 = OpVariable %_ptr_Function_uint Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_uchar Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_ushort Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_uint Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_float Function
-%140 = OpVariable %_ptr_Function_float Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_float Function
-%143 = OpVariable %_ptr_Function_float Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_float Function
-%146 = OpVariable %_ptr_Function_float Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_float Function
-%149 = OpVariable %_ptr_Function_float Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_double Function
-%153 = OpVariable %_ptr_Function_double Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_double Function
-%156 = OpVariable %_ptr_Function_double Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_double Function
-%159 = OpVariable %_ptr_Function_double Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %43
+%44 = OpFunctionParameter %ulong
+%45 = OpLabel
+%233 = OpVariable %_ptr_Function__arr_ulong_uint_12 Function
 %234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
 %237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_bool Function
 %239 = OpVariable %_ptr_Function_ulong Function
 %240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_uchar Function
+%244 = OpVariable %_ptr_Function_ushort Function
+%246 = OpVariable %_ptr_Function_uint Function
 %247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_uchar Function
 %249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ushort Function
 %251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_uint Function
 %253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_float Function
+%256 = OpVariable %_ptr_Function_float Function
 %257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_float Function
+%259 = OpVariable %_ptr_Function_float Function
 %260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_float Function
+%262 = OpVariable %_ptr_Function_float Function
 %263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_float Function
+%265 = OpVariable %_ptr_Function_float Function
 %266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_double Function
+%269 = OpVariable %_ptr_Function_double Function
 %270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_double Function
+%272 = OpVariable %_ptr_Function_double Function
 %273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_double Function
+%275 = OpVariable %_ptr_Function_double Function
 %276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
@@ -292,1503 +173,1713 @@ OpFunctionEnd
 %283 = OpVariable %_ptr_Function_ulong Function
 %284 = OpVariable %_ptr_Function_ulong Function
 %285 = OpVariable %_ptr_Function_ulong Function
-OpStore %117 %47
-%286 = OpFunctionCall %ulong %21
-OpStore %118 %286
-OpStore %116 %287
-OpStore %179 %ulong_0
-OpBranch %49
-%49 = OpLabel
-%289 = OpLoad %ulong %179
-%291 = OpULessThan %bool %289 %ulong_12
-OpStore %120 %291
-%292 = OpLoad %bool %120
-OpLoopMerge %51 %106 None
-OpBranchConditional %292 %50 %51
-%51 = OpLabel
-OpBranch %57
-%57 = OpLabel
-%293 = OpLoad %ulong %118
-%294 = OpFunctionCall %ulong %22 %293 %ulong_0
-OpStore %184 %294
-OpBranch %58
-%58 = OpLabel
-OpBranch %61
-%61 = OpLabel
-OpBranch %65
-%65 = OpLabel
-%295 = OpLoad %ulong %184
-%296 = OpFunctionCall %ulong %22 %295 %ulong_0
-OpStore %213 %296
-OpBranch %66
-%66 = OpLabel
-OpBranch %62
-%62 = OpLabel
-OpBranch %67
-%67 = OpLabel
-OpBranch %71
-%71 = OpLabel
-OpBranch %75
-%75 = OpLabel
-%297 = OpLoad %ulong %213
-%298 = OpFunctionCall %ulong %22 %297 %ulong_0
-OpStore %228 %298
-OpBranch %76
-%76 = OpLabel
-OpBranch %72
-%72 = OpLabel
-OpBranch %68
-%68 = OpLabel
-%299 = OpLoad %ulong %228
-OpStore %178 %299
-OpStore %180 %ulong_0
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_bool Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_bool Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_bool Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_bool Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_bool Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_bool Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_bool Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_uint Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_bool Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_bool Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_bool Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_bool Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_bool Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_bool Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_bool Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_bool Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_uint Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_uint Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_bool Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_ulong Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_uint Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_uint Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_uint Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+OpStore %234 %44
 OpBranch %52
 %52 = OpLabel
-%300 = OpLoad %ulong %180
-%302 = OpULessThan %bool %300 %ulong_4
-OpStore %122 %302
-%303 = OpLoad %bool %122
-OpLoopMerge %54 %105 None
-OpBranchConditional %303 %53 %54
-%54 = OpLabel
-%304 = OpLoad %ulong %178
-OpReturnValue %304
+OpBranch %53
 %53 = OpLabel
-%305 = OpLoad %ulong %180
-%306 = OpAccessChain %_ptr_Function_ulong %116 %305
-%307 = OpLoad %ulong %306
-OpStore %123 %307
-%308 = OpLoad %ulong %123
-%309 = OpLoad %ulong %117
-%310 = OpIAdd %ulong %308 %309
-OpStore %124 %310
-%311 = OpLoad %ulong %124
-%312 = OpUConvert %uchar %311
-OpStore %126 %312
-%313 = OpLoad %ulong %124
-%314 = OpUConvert %ushort %313
-OpStore %128 %314
-%315 = OpLoad %ulong %124
-%316 = OpUConvert %uint %315
-OpStore %130 %316
-%317 = OpLoad %ulong %124
-%319 = OpShiftRightLogical %ulong %317 %ulong_7
-OpStore %131 %319
-%320 = OpLoad %ulong %131
-%321 = OpUConvert %uchar %320
-OpStore %132 %321
-%322 = OpLoad %ulong %124
-%324 = OpShiftRightLogical %ulong %322 %ulong_3
-OpStore %133 %324
-%325 = OpLoad %ulong %133
-%326 = OpUConvert %ushort %325
-OpStore %134 %326
-%327 = OpLoad %ulong %124
-%329 = OpShiftRightLogical %ulong %327 %ulong_11
-OpStore %135 %329
-%330 = OpLoad %ulong %135
-%331 = OpUConvert %uint %330
-OpStore %136 %331
-%332 = OpLoad %ulong %124
-%334 = OpBitwiseAnd %ulong %332 %ulong_4095
-OpStore %137 %334
-%335 = OpLoad %ulong %137
-%336 = OpConvertUToF %float %335
-OpStore %139 %336
-%337 = OpLoad %float %139
-%339 = OpFDiv %float %337 %float_8
-OpStore %140 %339
-%340 = OpLoad %ulong %124
-%342 = OpBitwiseAnd %ulong %340 %ulong_255
-OpStore %141 %342
-%343 = OpLoad %ulong %141
-%344 = OpConvertUToF %float %343
-OpStore %142 %344
-%345 = OpLoad %float %142
-%347 = OpFSub %float %345 %float_128
-OpStore %143 %347
-%348 = OpLoad %ulong %124
-%350 = OpBitwiseAnd %ulong %348 %ulong_1023
-OpStore %144 %350
-%351 = OpLoad %ulong %144
-%352 = OpConvertUToF %float %351
-OpStore %145 %352
-%353 = OpLoad %float %145
-%355 = OpFDiv %float %353 %float_4
-OpStore %146 %355
-%356 = OpLoad %ulong %124
-%358 = OpBitwiseAnd %ulong %356 %ulong_511
-OpStore %147 %358
-%359 = OpLoad %ulong %147
-%360 = OpConvertUToF %float %359
-OpStore %148 %360
-%361 = OpLoad %float %148
-%363 = OpFDiv %float %361 %float_2
-OpStore %149 %363
-%364 = OpLoad %ulong %124
-%366 = OpBitwiseAnd %ulong %364 %ulong_65535
-OpStore %150 %366
-%367 = OpLoad %ulong %150
-%368 = OpConvertUToF %double %367
-OpStore %152 %368
-%369 = OpLoad %double %152
-%371 = OpFDiv %double %369 %double_64
-OpStore %153 %371
-%372 = OpLoad %ulong %124
-%374 = OpBitwiseAnd %ulong %372 %ulong_262143
-OpStore %154 %374
-%375 = OpLoad %ulong %154
-%376 = OpConvertUToF %double %375
-OpStore %155 %376
-%377 = OpLoad %double %155
-%379 = OpFDiv %double %377 %double_256
-OpStore %156 %379
-%380 = OpLoad %ulong %124
-%382 = OpBitwiseAnd %ulong %380 %ulong_8191
-OpStore %157 %382
-%383 = OpLoad %ulong %157
-%384 = OpConvertUToF %double %383
-OpStore %158 %384
-%385 = OpLoad %double %158
-%387 = OpFDiv %double %385 %double_2
-OpStore %159 %387
-%388 = OpLoad %ulong %124
-%389 = OpIMul %ulong %388 %ulong_3
-OpStore %160 %389
-OpBranch %59
-%59 = OpLabel
-%390 = OpLoad %uchar %126
-%391 = OpUConvert %ulong %390
-OpStore %185 %391
-%392 = OpLoad %ulong %178
-%393 = OpLoad %ulong %185
-%394 = OpFunctionCall %ulong %22 %392 %393
-OpStore %186 %394
-%395 = OpLoad %ushort %128
-%396 = OpSConvert %ulong %395
-OpStore %187 %396
-%397 = OpLoad %ulong %186
-%398 = OpLoad %ulong %187
-%399 = OpFunctionCall %ulong %22 %397 %398
-OpStore %188 %399
-%400 = OpLoad %uint %130
-%401 = OpUConvert %ulong %400
-OpStore %189 %401
-%402 = OpLoad %ulong %188
-%403 = OpLoad %ulong %189
-%404 = OpFunctionCall %ulong %22 %402 %403
-OpStore %190 %404
-%405 = OpLoad %ulong %190
-%406 = OpLoad %ulong %124
-%407 = OpFunctionCall %ulong %22 %405 %406
-OpStore %191 %407
-%408 = OpLoad %uchar %132
-%409 = OpUConvert %ulong %408
-OpStore %192 %409
-%410 = OpLoad %ulong %191
-%411 = OpLoad %ulong %192
-%412 = OpFunctionCall %ulong %22 %410 %411
-OpStore %193 %412
-%413 = OpLoad %ushort %134
-%414 = OpUConvert %ulong %413
-OpStore %194 %414
-%415 = OpLoad %ulong %193
-%416 = OpLoad %ulong %194
-%417 = OpFunctionCall %ulong %22 %415 %416
-OpStore %195 %417
-%418 = OpLoad %uint %136
-%419 = OpSConvert %ulong %418
-OpStore %196 %419
-%420 = OpLoad %ulong %195
-%421 = OpLoad %ulong %196
-%422 = OpFunctionCall %ulong %22 %420 %421
-OpStore %197 %422
-%423 = OpLoad %ulong %197
-%424 = OpLoad %ulong %160
-%425 = OpFunctionCall %ulong %22 %423 %424
-OpStore %198 %425
-%426 = OpLoad %ulong %198
-%428 = OpFunctionCall %ulong %22 %426 %ulong_8
-OpStore %199 %428
-OpBranch %60
-%60 = OpLabel
-%430 = OpAccessChain %_ptr_Function_ulong %116 %uint_0
-%431 = OpLoad %ulong %430
-OpStore %161 %431
-%432 = OpLoad %ulong %161
-%433 = OpLoad %ulong %124
-%434 = OpIAdd %ulong %432 %433
-OpStore %162 %434
-%436 = OpAccessChain %_ptr_Function_ulong %116 %uint_1
-%437 = OpLoad %ulong %436
-OpStore %163 %437
-%439 = OpAccessChain %_ptr_Function_ulong %116 %uint_2
-%440 = OpLoad %ulong %439
-OpStore %164 %440
-%442 = OpAccessChain %_ptr_Function_ulong %116 %uint_3
-%443 = OpLoad %ulong %442
-OpStore %165 %443
-%445 = OpAccessChain %_ptr_Function_ulong %116 %uint_4
-%446 = OpLoad %ulong %445
-OpStore %166 %446
-%448 = OpAccessChain %_ptr_Function_ulong %116 %uint_5
-%449 = OpLoad %ulong %448
-OpStore %167 %449
-%451 = OpAccessChain %_ptr_Function_ulong %116 %uint_6
-%452 = OpLoad %ulong %451
-OpStore %168 %452
-%454 = OpAccessChain %_ptr_Function_ulong %116 %uint_7
-%455 = OpLoad %ulong %454
-OpStore %169 %455
-%457 = OpAccessChain %_ptr_Function_ulong %116 %uint_8
-%458 = OpLoad %ulong %457
-OpStore %170 %458
-%460 = OpAccessChain %_ptr_Function_ulong %116 %uint_9
-%461 = OpLoad %ulong %460
-OpStore %171 %461
-%463 = OpAccessChain %_ptr_Function_ulong %116 %uint_10
-%464 = OpLoad %ulong %463
-OpStore %172 %464
-%466 = OpAccessChain %_ptr_Function_ulong %116 %uint_11
-%467 = OpLoad %ulong %466
-OpStore %173 %467
-OpBranch %63
-%63 = OpLabel
-%468 = OpLoad %ulong %199
-%469 = OpLoad %ulong %162
-%470 = OpFunctionCall %ulong %22 %468 %469
-OpStore %200 %470
-%471 = OpLoad %ulong %200
-%472 = OpLoad %ulong %163
-%473 = OpFunctionCall %ulong %22 %471 %472
-OpStore %201 %473
-%474 = OpLoad %ulong %201
-%475 = OpLoad %ulong %164
-%476 = OpFunctionCall %ulong %22 %474 %475
-OpStore %202 %476
-%477 = OpLoad %ulong %202
-%478 = OpLoad %ulong %165
-%479 = OpFunctionCall %ulong %22 %477 %478
-OpStore %203 %479
-%480 = OpLoad %ulong %203
-%481 = OpLoad %ulong %166
-%482 = OpFunctionCall %ulong %22 %480 %481
-OpStore %204 %482
-%483 = OpLoad %ulong %204
-%484 = OpLoad %ulong %167
-%485 = OpFunctionCall %ulong %22 %483 %484
-OpStore %205 %485
-%486 = OpLoad %ulong %205
-%487 = OpLoad %ulong %168
-%488 = OpFunctionCall %ulong %22 %486 %487
-OpStore %206 %488
-%489 = OpLoad %ulong %206
-%490 = OpLoad %ulong %169
-%491 = OpFunctionCall %ulong %22 %489 %490
-OpStore %207 %491
-%492 = OpLoad %ulong %207
-%493 = OpLoad %ulong %170
-%494 = OpFunctionCall %ulong %22 %492 %493
-OpStore %208 %494
-%495 = OpLoad %ulong %208
-%496 = OpLoad %ulong %171
-%497 = OpFunctionCall %ulong %22 %495 %496
-OpStore %209 %497
-%498 = OpLoad %ulong %209
-%499 = OpLoad %ulong %172
-%500 = OpFunctionCall %ulong %22 %498 %499
-OpStore %210 %500
-%501 = OpLoad %ulong %210
-%502 = OpLoad %ulong %173
-%503 = OpFunctionCall %ulong %22 %501 %502
-OpStore %211 %503
-%504 = OpLoad %ulong %211
-%505 = OpFunctionCall %ulong %22 %504 %ulong_12
-OpStore %212 %505
-OpBranch %64
-%64 = OpLabel
-OpBranch %69
-%69 = OpLabel
-%506 = OpLoad %ulong %212
-%507 = OpLoad %float %140
-%508 = OpFunctionCall %ulong %23 %506 %507
-OpStore %214 %508
-%509 = OpLoad %ulong %214
-%510 = OpLoad %double %153
-%511 = OpFunctionCall %ulong %24 %509 %510
-OpStore %215 %511
-%512 = OpLoad %ulong %215
-%513 = OpLoad %float %143
-%514 = OpFunctionCall %ulong %23 %512 %513
-OpStore %216 %514
-%515 = OpLoad %ulong %216
-%516 = OpLoad %double %156
-%517 = OpFunctionCall %ulong %24 %515 %516
-OpStore %217 %517
-%518 = OpLoad %ulong %217
-%519 = OpFunctionCall %ulong %22 %518 %ulong_4
-OpStore %218 %519
-OpBranch %70
-%70 = OpLabel
-%520 = OpLoad %ulong %124
-%522 = OpIMul %ulong %520 %ulong_5
-OpStore %174 %522
-OpBranch %73
-%73 = OpLabel
-%523 = OpLoad %ulong %218
-%524 = OpLoad %ulong %124
-%525 = OpFunctionCall %ulong %22 %523 %524
-OpStore %219 %525
-%526 = OpLoad %ulong %219
-%527 = OpLoad %float %140
-%528 = OpFunctionCall %ulong %23 %526 %527
-OpStore %220 %528
-%529 = OpLoad %uint %130
-%530 = OpUConvert %ulong %529
-OpStore %221 %530
-%531 = OpLoad %ulong %220
-%532 = OpLoad %ulong %221
-%533 = OpFunctionCall %ulong %22 %531 %532
-OpStore %222 %533
-%534 = OpLoad %ulong %222
-%535 = OpLoad %double %153
-%536 = OpFunctionCall %ulong %24 %534 %535
-OpStore %223 %536
-%537 = OpLoad %ushort %128
-%538 = OpSConvert %ulong %537
-OpStore %224 %538
-%539 = OpLoad %ulong %223
-%540 = OpLoad %ulong %224
-%541 = OpFunctionCall %ulong %22 %539 %540
-OpStore %225 %541
-%542 = OpLoad %ulong %225
-%543 = OpLoad %ulong %174
-%544 = OpFunctionCall %ulong %22 %542 %543
-OpStore %226 %544
-%545 = OpLoad %ulong %226
-%547 = OpFunctionCall %ulong %22 %545 %ulong_6
-OpStore %227 %547
-OpBranch %74
-%74 = OpLabel
-%548 = OpLoad %ulong %124
-%549 = OpIMul %ulong %548 %ulong_7
-OpStore %175 %549
-OpBranch %77
-%77 = OpLabel
-%550 = OpLoad %ulong %227
-%551 = OpLoad %ulong %124
-%552 = OpFunctionCall %ulong %22 %550 %551
-OpStore %229 %552
-%553 = OpLoad %uchar %126
-%554 = OpUConvert %ulong %553
-OpStore %230 %554
-%555 = OpLoad %ulong %230
-%556 = OpLoad %ulong %124
-%557 = OpIAdd %ulong %555 %556
-OpStore %231 %557
-%558 = OpLoad %ulong %229
-%559 = OpLoad %ulong %231
-%560 = OpFunctionCall %ulong %22 %558 %559
-OpStore %232 %560
-%561 = OpLoad %uint %130
-%562 = OpUConvert %ulong %561
-OpStore %233 %562
-%563 = OpLoad %ulong %233
-%564 = OpLoad %ulong %124
-%565 = OpIAdd %ulong %563 %564
-OpStore %234 %565
-%566 = OpLoad %ulong %232
-%567 = OpLoad %ulong %234
-%568 = OpFunctionCall %ulong %22 %566 %567
-OpStore %235 %568
-%569 = OpLoad %ulong %175
-%570 = OpLoad %ulong %124
-%571 = OpIAdd %ulong %569 %570
-OpStore %236 %571
-%572 = OpLoad %ulong %235
-%573 = OpLoad %ulong %236
-%574 = OpFunctionCall %ulong %22 %572 %573
-OpStore %237 %574
-%575 = OpLoad %ushort %134
-%576 = OpUConvert %ulong %575
-OpStore %238 %576
-%577 = OpLoad %ulong %238
-%578 = OpLoad %ulong %124
-%579 = OpIAdd %ulong %577 %578
-OpStore %239 %579
-%580 = OpLoad %ulong %237
-%581 = OpLoad %ulong %239
-%582 = OpFunctionCall %ulong %22 %580 %581
-OpStore %240 %582
-%583 = OpLoad %ulong %240
-%584 = OpFunctionCall %ulong %22 %583 %ulong_4
-OpStore %241 %584
-OpBranch %78
-%78 = OpLabel
-OpBranch %79
-%79 = OpLabel
-%585 = OpLoad %ulong %241
-%586 = OpLoad %ulong %124
-%587 = OpFunctionCall %ulong %22 %585 %586
-OpStore %242 %587
-%588 = OpLoad %ulong %242
-%589 = OpLoad %float %146
-%590 = OpFunctionCall %ulong %23 %588 %589
-OpStore %243 %590
-%591 = OpLoad %ulong %124
-%592 = OpLoad %ulong %124
-%593 = OpIAdd %ulong %591 %592
-OpStore %244 %593
-%594 = OpLoad %ulong %243
-%595 = OpLoad %ulong %244
-%596 = OpFunctionCall %ulong %22 %594 %595
-OpStore %245 %596
-%597 = OpLoad %ulong %245
-%598 = OpLoad %double %159
-%599 = OpFunctionCall %ulong %24 %597 %598
-OpStore %246 %599
-%600 = OpLoad %ulong %246
-%601 = OpFunctionCall %ulong %22 %600 %ulong_3
-OpStore %247 %601
-OpBranch %80
-%80 = OpLabel
-OpBranch %81
-%81 = OpLabel
-OpBranch %83
-%83 = OpLabel
-%602 = OpLoad %uchar %126
-%603 = OpUConvert %ulong %602
-OpStore %248 %603
-%604 = OpLoad %ulong %247
-%605 = OpLoad %ulong %248
-%606 = OpFunctionCall %ulong %22 %604 %605
-OpStore %249 %606
-%607 = OpLoad %ushort %128
-%608 = OpSConvert %ulong %607
-OpStore %250 %608
-%609 = OpLoad %ulong %249
-%610 = OpLoad %ulong %250
-%611 = OpFunctionCall %ulong %22 %609 %610
-OpStore %251 %611
-%612 = OpLoad %uint %130
-%613 = OpUConvert %ulong %612
-OpStore %252 %613
-%614 = OpLoad %ulong %251
-%615 = OpLoad %ulong %252
-%616 = OpFunctionCall %ulong %22 %614 %615
-OpStore %253 %616
-%617 = OpLoad %ulong %253
-%618 = OpLoad %ulong %124
-%619 = OpFunctionCall %ulong %22 %617 %618
-OpStore %254 %619
-%620 = OpLoad %ulong %254
-%621 = OpFunctionCall %ulong %22 %620 %ulong_4
-OpStore %255 %621
-OpBranch %84
-%84 = OpLabel
-OpBranch %82
-%82 = OpLabel
-OpBranch %85
-%85 = OpLabel
-OpBranch %87
-%87 = OpLabel
-OpBranch %91
-%91 = OpLabel
-%622 = OpLoad %uchar %126
-%623 = OpUConvert %ulong %622
-OpStore %256 %623
-%624 = OpLoad %ulong %255
-%625 = OpLoad %ulong %256
-%626 = OpFunctionCall %ulong %22 %624 %625
-OpStore %257 %626
-%627 = OpLoad %ushort %128
-%628 = OpSConvert %ulong %627
-OpStore %258 %628
-%629 = OpLoad %ulong %257
-%630 = OpLoad %ulong %258
-%631 = OpFunctionCall %ulong %22 %629 %630
-OpStore %259 %631
-%632 = OpLoad %uint %130
-%633 = OpUConvert %ulong %632
-OpStore %260 %633
-%634 = OpLoad %ulong %259
-%635 = OpLoad %ulong %260
-%636 = OpFunctionCall %ulong %22 %634 %635
-OpStore %261 %636
-%637 = OpLoad %ulong %261
-%638 = OpLoad %ulong %124
-%639 = OpFunctionCall %ulong %22 %637 %638
-OpStore %262 %639
-%640 = OpLoad %ulong %262
-%641 = OpFunctionCall %ulong %22 %640 %ulong_4
-OpStore %263 %641
-OpBranch %92
-%92 = OpLabel
-OpBranch %88
-%88 = OpLabel
-OpBranch %86
-%86 = OpLabel
-OpBranch %89
-%89 = OpLabel
-OpBranch %93
-%93 = OpLabel
-OpBranch %97
-%97 = OpLabel
-%642 = OpLoad %ulong %263
-%643 = OpLoad %ulong %124
-%644 = OpFunctionCall %ulong %22 %642 %643
-OpStore %265 %644
-%645 = OpLoad %ulong %265
-%646 = OpLoad %float %140
-%647 = OpFunctionCall %ulong %23 %645 %646
-OpStore %266 %647
-%648 = OpLoad %ulong %266
-%649 = OpLoad %double %153
-%650 = OpFunctionCall %ulong %24 %648 %649
-OpStore %267 %650
-%651 = OpLoad %ulong %267
-%652 = OpFunctionCall %ulong %22 %651 %ulong_3
-OpStore %268 %652
-OpBranch %98
-%98 = OpLabel
-OpBranch %94
-%94 = OpLabel
-OpBranch %90
-%90 = OpLabel
-%653 = OpLoad %ulong %124
-%654 = OpIMul %ulong %653 %ulong_7
-OpStore %176 %654
-OpBranch %95
-%95 = OpLabel
-%655 = OpLoad %ulong %124
-%656 = OpIMul %ulong %655 %ulong_3
-OpStore %264 %656
-OpBranch %99
-%99 = OpLabel
-%657 = OpLoad %ulong %268
-%658 = OpLoad %ulong %264
-%659 = OpFunctionCall %ulong %22 %657 %658
-OpStore %269 %659
-%660 = OpLoad %uchar %126
-%661 = OpUConvert %ulong %660
-OpStore %270 %661
-%662 = OpLoad %ulong %270
-%663 = OpLoad %ulong %264
-%664 = OpIAdd %ulong %662 %663
-OpStore %271 %664
-%665 = OpLoad %ulong %269
-%666 = OpLoad %ulong %271
-%667 = OpFunctionCall %ulong %22 %665 %666
-OpStore %272 %667
-%668 = OpLoad %uint %130
-%669 = OpUConvert %ulong %668
-OpStore %273 %669
-%670 = OpLoad %ulong %273
-%671 = OpLoad %ulong %264
-%672 = OpIAdd %ulong %670 %671
-OpStore %274 %672
-%673 = OpLoad %ulong %272
-%674 = OpLoad %ulong %274
-%675 = OpFunctionCall %ulong %22 %673 %674
-OpStore %275 %675
-%676 = OpLoad %ulong %176
-%677 = OpLoad %ulong %264
-%678 = OpIAdd %ulong %676 %677
-OpStore %276 %678
-%679 = OpLoad %ulong %275
-%680 = OpLoad %ulong %276
-%681 = OpFunctionCall %ulong %22 %679 %680
-OpStore %277 %681
-%682 = OpLoad %ushort %134
-%683 = OpUConvert %ulong %682
-OpStore %278 %683
-%684 = OpLoad %ulong %278
-%685 = OpLoad %ulong %264
-%686 = OpIAdd %ulong %684 %685
-OpStore %279 %686
-%687 = OpLoad %ulong %277
-%688 = OpLoad %ulong %279
-%689 = OpFunctionCall %ulong %22 %687 %688
-OpStore %280 %689
-%690 = OpLoad %ulong %280
-%691 = OpFunctionCall %ulong %22 %690 %ulong_4
-OpStore %281 %691
-OpBranch %100
-%100 = OpLabel
-OpBranch %96
-%96 = OpLabel
-OpBranch %101
-%101 = OpLabel
-%692 = OpLoad %ulong %281
-%693 = OpLoad %ulong %124
-%694 = OpFunctionCall %ulong %22 %692 %693
-OpStore %282 %694
-%695 = OpLoad %ulong %282
-%697 = OpFunctionCall %ulong %22 %695 %ulong_1
-OpStore %283 %697
-OpBranch %102
-%102 = OpLabel
-OpBranch %103
-%103 = OpLabel
-%698 = OpLoad %ulong %283
-%699 = OpLoad %float %149
-%700 = OpFunctionCall %ulong %23 %698 %699
-OpStore %284 %700
-%701 = OpLoad %ulong %284
-%702 = OpFunctionCall %ulong %22 %701 %ulong_1
-OpStore %285 %702
-OpBranch %104
-%104 = OpLabel
-%703 = OpLoad %ulong %180
-%704 = OpIAdd %ulong %703 %ulong_1
-OpStore %177 %704
-%705 = OpLoad %ulong %285
-OpStore %178 %705
-%706 = OpLoad %ulong %177
-OpStore %180 %706
-OpBranch %105
-%50 = OpLabel
-OpBranch %55
-%55 = OpLabel
-%707 = OpLoad %ulong %179
-%708 = OpIMul %ulong %707 %ulong_6364136223846793005
-OpStore %181 %708
-%709 = OpLoad %ulong %181
-%710 = OpIAdd %ulong %709 %ulong_1442695040888963407
-OpStore %182 %710
-%711 = OpLoad %ulong %182
-%712 = OpLoad %ulong %117
-%713 = OpIAdd %ulong %711 %712
-OpStore %183 %713
+OpStore %233 %535
+OpStore %295 %ulong_0
+OpBranch %46
+%46 = OpLabel
+%537 = OpLoad %ulong %295
+%539 = OpULessThan %bool %537 %ulong_12
+OpStore %236 %539
+%540 = OpLoad %bool %236
+OpLoopMerge %48 %223 None
+OpBranchConditional %540 %47 %48
+%48 = OpLabel
 OpBranch %56
 %56 = OpLabel
-%714 = OpLoad %ulong %179
-%715 = OpAccessChain %_ptr_Function_ulong %116 %714
-%716 = OpLoad %ulong %183
-OpStore %715 %716
-%717 = OpLoad %ulong %179
-%718 = OpIAdd %ulong %717 %ulong_1
-OpStore %121 %718
-%719 = OpLoad %ulong %121
-OpStore %179 %719
-OpBranch %106
-%105 = OpLabel
-OpBranch %52
-%106 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpStore %313 %ulong_14695981039346656037
+OpStore %314 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%542 = OpLoad %ulong %314
+%544 = OpULessThan %bool %542 %ulong_8
+OpStore %310 %544
+%545 = OpLoad %bool %310
+OpLoopMerge %63 %222 None
+OpBranchConditional %545 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+OpBranch %57
+%57 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpBranch %90
+%90 = OpLabel
+%546 = OpLoad %ulong %313
+OpStore %355 %546
+OpStore %356 %ulong_0
+OpBranch %91
+%91 = OpLabel
+%547 = OpLoad %ulong %356
+%548 = OpULessThan %bool %547 %ulong_8
+OpStore %352 %548
+%549 = OpLoad %bool %352
+OpLoopMerge %93 %221 None
+OpBranchConditional %549 %92 %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+OpBranch %75
+%75 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %95
+%95 = OpLabel
+OpBranch %111
+%111 = OpLabel
+OpBranch %137
+%137 = OpLabel
+%550 = OpLoad %ulong %355
+OpStore %435 %550
+OpStore %436 %ulong_0
+OpBranch %138
+%138 = OpLabel
+%551 = OpLoad %ulong %436
+%552 = OpULessThan %bool %551 %ulong_8
+OpStore %432 %552
+%553 = OpLoad %bool %432
+OpLoopMerge %140 %220 None
+OpBranchConditional %553 %139 %140
+%140 = OpLabel
+OpBranch %141
+%141 = OpLabel
+OpBranch %112
+%112 = OpLabel
+OpBranch %96
+%96 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%554 = OpLoad %ulong %435
+OpStore %294 %554
+OpStore %296 %ulong_0
 OpBranch %49
+%49 = OpLabel
+%555 = OpLoad %ulong %296
+%557 = OpULessThan %bool %555 %ulong_4
+OpStore %238 %557
+%558 = OpLoad %bool %238
+OpLoopMerge %51 %219 None
+OpBranchConditional %558 %50 %51
+%51 = OpLabel
+%559 = OpLoad %ulong %294
+OpReturnValue %559
+%50 = OpLabel
+%560 = OpLoad %ulong %296
+%561 = OpAccessChain %_ptr_Function_ulong %233 %560
+%562 = OpLoad %ulong %561
+OpStore %239 %562
+%563 = OpLoad %ulong %239
+%564 = OpLoad %ulong %234
+%565 = OpIAdd %ulong %563 %564
+OpStore %240 %565
+%566 = OpLoad %ulong %240
+%567 = OpUConvert %uchar %566
+OpStore %242 %567
+%568 = OpLoad %ulong %240
+%569 = OpUConvert %ushort %568
+OpStore %244 %569
+%570 = OpLoad %ulong %240
+%571 = OpUConvert %uint %570
+OpStore %246 %571
+%572 = OpLoad %ulong %240
+%574 = OpShiftRightLogical %ulong %572 %ulong_7
+OpStore %247 %574
+%575 = OpLoad %ulong %247
+%576 = OpUConvert %uchar %575
+OpStore %248 %576
+%577 = OpLoad %ulong %240
+%579 = OpShiftRightLogical %ulong %577 %ulong_3
+OpStore %249 %579
+%580 = OpLoad %ulong %249
+%581 = OpUConvert %ushort %580
+OpStore %250 %581
+%582 = OpLoad %ulong %240
+%584 = OpShiftRightLogical %ulong %582 %ulong_11
+OpStore %251 %584
+%585 = OpLoad %ulong %251
+%586 = OpUConvert %uint %585
+OpStore %252 %586
+%587 = OpLoad %ulong %240
+%589 = OpBitwiseAnd %ulong %587 %ulong_4095
+OpStore %253 %589
+%590 = OpLoad %ulong %253
+%591 = OpConvertUToF %float %590
+OpStore %255 %591
+%592 = OpLoad %float %255
+%594 = OpFDiv %float %592 %float_8
+OpStore %256 %594
+%595 = OpLoad %ulong %240
+%597 = OpBitwiseAnd %ulong %595 %ulong_255
+OpStore %257 %597
+%598 = OpLoad %ulong %257
+%599 = OpConvertUToF %float %598
+OpStore %258 %599
+%600 = OpLoad %float %258
+%602 = OpFSub %float %600 %float_128
+OpStore %259 %602
+%603 = OpLoad %ulong %240
+%605 = OpBitwiseAnd %ulong %603 %ulong_1023
+OpStore %260 %605
+%606 = OpLoad %ulong %260
+%607 = OpConvertUToF %float %606
+OpStore %261 %607
+%608 = OpLoad %float %261
+%610 = OpFDiv %float %608 %float_4
+OpStore %262 %610
+%611 = OpLoad %ulong %240
+%613 = OpBitwiseAnd %ulong %611 %ulong_511
+OpStore %263 %613
+%614 = OpLoad %ulong %263
+%615 = OpConvertUToF %float %614
+OpStore %264 %615
+%616 = OpLoad %float %264
+%618 = OpFDiv %float %616 %float_2
+OpStore %265 %618
+%619 = OpLoad %ulong %240
+%621 = OpBitwiseAnd %ulong %619 %ulong_65535
+OpStore %266 %621
+%622 = OpLoad %ulong %266
+%623 = OpConvertUToF %double %622
+OpStore %268 %623
+%624 = OpLoad %double %268
+%626 = OpFDiv %double %624 %double_64
+OpStore %269 %626
+%627 = OpLoad %ulong %240
+%629 = OpBitwiseAnd %ulong %627 %ulong_262143
+OpStore %270 %629
+%630 = OpLoad %ulong %270
+%631 = OpConvertUToF %double %630
+OpStore %271 %631
+%632 = OpLoad %double %271
+%634 = OpFDiv %double %632 %double_256
+OpStore %272 %634
+%635 = OpLoad %ulong %240
+%637 = OpBitwiseAnd %ulong %635 %ulong_8191
+OpStore %273 %637
+%638 = OpLoad %ulong %273
+%639 = OpConvertUToF %double %638
+OpStore %274 %639
+%640 = OpLoad %double %274
+%642 = OpFDiv %double %640 %double_2
+OpStore %275 %642
+%643 = OpLoad %ulong %240
+%644 = OpIMul %ulong %643 %ulong_3
+OpStore %276 %644
+OpBranch %58
+%58 = OpLabel
+%645 = OpLoad %uchar %242
+%646 = OpUConvert %ulong %645
+OpStore %300 %646
+OpBranch %67
+%67 = OpLabel
+%647 = OpLoad %ulong %294
+OpStore %322 %647
+OpStore %323 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%648 = OpLoad %ulong %323
+%649 = OpULessThan %bool %648 %ulong_8
+OpStore %315 %649
+%650 = OpLoad %bool %315
+OpLoopMerge %70 %218 None
+OpBranchConditional %650 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%651 = OpLoad %ushort %244
+%652 = OpSConvert %ulong %651
+OpStore %301 %652
+OpBranch %78
+%78 = OpLabel
+%653 = OpLoad %ulong %322
+OpStore %340 %653
+OpStore %341 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%654 = OpLoad %ulong %341
+%655 = OpULessThan %bool %654 %ulong_8
+OpStore %333 %655
+%656 = OpLoad %bool %333
+OpLoopMerge %81 %217 None
+OpBranchConditional %656 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+%657 = OpLoad %uint %246
+%658 = OpUConvert %ulong %657
+OpStore %302 %658
+OpBranch %97
+%97 = OpLabel
+%659 = OpLoad %ulong %340
+OpStore %364 %659
+OpStore %365 %ulong_0
+OpBranch %98
+%98 = OpLabel
+%660 = OpLoad %ulong %365
+%661 = OpULessThan %bool %660 %ulong_8
+OpStore %357 %661
+%662 = OpLoad %bool %357
+OpLoopMerge %100 %216 None
+OpBranchConditional %662 %99 %100
+%100 = OpLabel
+OpBranch %101
+%101 = OpLabel
+OpBranch %113
+%113 = OpLabel
+%663 = OpLoad %ulong %364
+OpStore %390 %663
+OpStore %391 %ulong_0
+OpBranch %114
+%114 = OpLabel
+%664 = OpLoad %ulong %391
+%665 = OpULessThan %bool %664 %ulong_8
+OpStore %383 %665
+%666 = OpLoad %bool %383
+OpLoopMerge %116 %215 None
+OpBranchConditional %666 %115 %116
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
+%667 = OpLoad %uchar %248
+%668 = OpUConvert %ulong %667
+OpStore %303 %668
+OpBranch %142
+%142 = OpLabel
+%669 = OpLoad %ulong %390
+OpStore %444 %669
+OpStore %445 %ulong_0
+OpBranch %143
+%143 = OpLabel
+%670 = OpLoad %ulong %445
+%671 = OpULessThan %bool %670 %ulong_8
+OpStore %437 %671
+%672 = OpLoad %bool %437
+OpLoopMerge %145 %214 None
+OpBranchConditional %672 %144 %145
+%145 = OpLabel
+OpBranch %146
+%146 = OpLabel
+%673 = OpLoad %ushort %250
+%674 = OpUConvert %ulong %673
+OpStore %304 %674
+%675 = OpLoad %ulong %444
+%676 = OpLoad %ulong %304
+%677 = OpFunctionCall %ulong %21 %675 %676
+OpStore %305 %677
+%678 = OpLoad %uint %252
+%679 = OpSConvert %ulong %678
+OpStore %306 %679
+%680 = OpLoad %ulong %305
+%681 = OpLoad %ulong %306
+%682 = OpFunctionCall %ulong %21 %680 %681
+OpStore %307 %682
+%683 = OpLoad %ulong %307
+%684 = OpLoad %ulong %276
+%685 = OpFunctionCall %ulong %21 %683 %684
+OpStore %308 %685
+%686 = OpLoad %ulong %308
+%687 = OpFunctionCall %ulong %21 %686 %ulong_8
+OpStore %309 %687
+OpBranch %59
+%59 = OpLabel
+%689 = OpAccessChain %_ptr_Function_ulong %233 %uint_0
+%690 = OpLoad %ulong %689
+OpStore %277 %690
+%691 = OpLoad %ulong %277
+%692 = OpLoad %ulong %240
+%693 = OpIAdd %ulong %691 %692
+OpStore %278 %693
+%695 = OpAccessChain %_ptr_Function_ulong %233 %uint_1
+%696 = OpLoad %ulong %695
+OpStore %279 %696
+%698 = OpAccessChain %_ptr_Function_ulong %233 %uint_2
+%699 = OpLoad %ulong %698
+OpStore %280 %699
+%701 = OpAccessChain %_ptr_Function_ulong %233 %uint_3
+%702 = OpLoad %ulong %701
+OpStore %281 %702
+%704 = OpAccessChain %_ptr_Function_ulong %233 %uint_4
+%705 = OpLoad %ulong %704
+OpStore %282 %705
+%707 = OpAccessChain %_ptr_Function_ulong %233 %uint_5
+%708 = OpLoad %ulong %707
+OpStore %283 %708
+%710 = OpAccessChain %_ptr_Function_ulong %233 %uint_6
+%711 = OpLoad %ulong %710
+OpStore %284 %711
+%713 = OpAccessChain %_ptr_Function_ulong %233 %uint_7
+%714 = OpLoad %ulong %713
+OpStore %285 %714
+%716 = OpAccessChain %_ptr_Function_ulong %233 %uint_8
+%717 = OpLoad %ulong %716
+OpStore %286 %717
+%719 = OpAccessChain %_ptr_Function_ulong %233 %uint_9
+%720 = OpLoad %ulong %719
+OpStore %287 %720
+%722 = OpAccessChain %_ptr_Function_ulong %233 %uint_10
+%723 = OpLoad %ulong %722
+OpStore %288 %723
+%725 = OpAccessChain %_ptr_Function_ulong %233 %uint_11
+%726 = OpLoad %ulong %725
+OpStore %289 %726
+OpBranch %72
+%72 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%727 = OpLoad %ulong %309
+OpStore %349 %727
+OpStore %350 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%728 = OpLoad %ulong %350
+%729 = OpULessThan %bool %728 %ulong_8
+OpStore %342 %729
+%730 = OpLoad %bool %342
+OpLoopMerge %86 %213 None
+OpBranchConditional %730 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%731 = OpLoad %ulong %349
+OpStore %373 %731
+OpStore %374 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%732 = OpLoad %ulong %374
+%733 = OpULessThan %bool %732 %ulong_8
+OpStore %366 %733
+%734 = OpLoad %bool %366
+OpLoopMerge %105 %212 None
+OpBranchConditional %734 %104 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+OpBranch %118
+%118 = OpLabel
+%735 = OpLoad %ulong %373
+OpStore %399 %735
+OpStore %400 %ulong_0
+OpBranch %119
+%119 = OpLabel
+%736 = OpLoad %ulong %400
+%737 = OpULessThan %bool %736 %ulong_8
+OpStore %392 %737
+%738 = OpLoad %bool %392
+OpLoopMerge %121 %211 None
+OpBranchConditional %738 %120 %121
+%121 = OpLabel
+OpBranch %122
+%122 = OpLabel
+OpBranch %147
+%147 = OpLabel
+%739 = OpLoad %ulong %399
+OpStore %453 %739
+OpStore %454 %ulong_0
+OpBranch %148
+%148 = OpLabel
+%740 = OpLoad %ulong %454
+%741 = OpULessThan %bool %740 %ulong_8
+OpStore %446 %741
+%742 = OpLoad %bool %446
+OpLoopMerge %150 %210 None
+OpBranchConditional %742 %149 %150
+%150 = OpLabel
+OpBranch %151
+%151 = OpLabel
+%743 = OpLoad %ulong %453
+%744 = OpLoad %ulong %282
+%745 = OpFunctionCall %ulong %21 %743 %744
+OpStore %324 %745
+%746 = OpLoad %ulong %324
+%747 = OpLoad %ulong %283
+%748 = OpFunctionCall %ulong %21 %746 %747
+OpStore %325 %748
+%749 = OpLoad %ulong %325
+%750 = OpLoad %ulong %284
+%751 = OpFunctionCall %ulong %21 %749 %750
+OpStore %326 %751
+%752 = OpLoad %ulong %326
+%753 = OpLoad %ulong %285
+%754 = OpFunctionCall %ulong %21 %752 %753
+OpStore %327 %754
+%755 = OpLoad %ulong %327
+%756 = OpLoad %ulong %286
+%757 = OpFunctionCall %ulong %21 %755 %756
+OpStore %328 %757
+%758 = OpLoad %ulong %328
+%759 = OpLoad %ulong %287
+%760 = OpFunctionCall %ulong %21 %758 %759
+OpStore %329 %760
+%761 = OpLoad %ulong %329
+%762 = OpLoad %ulong %288
+%763 = OpFunctionCall %ulong %21 %761 %762
+OpStore %330 %763
+%764 = OpLoad %ulong %330
+%765 = OpLoad %ulong %289
+%766 = OpFunctionCall %ulong %21 %764 %765
+OpStore %331 %766
+%767 = OpLoad %ulong %331
+%768 = OpFunctionCall %ulong %21 %767 %ulong_12
+OpStore %332 %768
+OpBranch %73
+%73 = OpLabel
+OpBranch %88
+%88 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%769 = OpLoad %float %256
+%770 = OpBitcast %uint %769
+OpStore %375 %770
+%771 = OpLoad %uint %375
+%772 = OpUConvert %ulong %771
+OpStore %376 %772
+OpBranch %123
+%123 = OpLabel
+%773 = OpLoad %ulong %332
+OpStore %408 %773
+OpStore %409 %ulong_0
+OpBranch %124
+%124 = OpLabel
+%774 = OpLoad %ulong %409
+%775 = OpULessThan %bool %774 %ulong_8
+OpStore %401 %775
+%776 = OpLoad %bool %401
+OpLoopMerge %126 %209 None
+OpBranchConditional %776 %125 %126
+%126 = OpLabel
+OpBranch %127
+%127 = OpLabel
+OpBranch %108
+%108 = OpLabel
+OpBranch %128
+%128 = OpLabel
+%777 = OpLoad %double %269
+%778 = OpBitcast %ulong %777
+OpStore %410 %778
+OpBranch %152
+%152 = OpLabel
+%779 = OpLoad %ulong %408
+OpStore %462 %779
+OpStore %463 %ulong_0
+OpBranch %153
+%153 = OpLabel
+%780 = OpLoad %ulong %463
+%781 = OpULessThan %bool %780 %ulong_8
+OpStore %455 %781
+%782 = OpLoad %bool %455
+OpLoopMerge %155 %208 None
+OpBranchConditional %782 %154 %155
+%155 = OpLabel
+OpBranch %156
+%156 = OpLabel
+OpBranch %129
+%129 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%783 = OpLoad %float %259
+%784 = OpBitcast %uint %783
+OpStore %464 %784
+%785 = OpLoad %uint %464
+%786 = OpUConvert %ulong %785
+OpStore %465 %786
+%787 = OpLoad %ulong %462
+%788 = OpLoad %ulong %465
+%789 = OpFunctionCall %ulong %21 %787 %788
+OpStore %466 %789
+OpBranch %158
+%158 = OpLabel
+OpBranch %168
+%168 = OpLabel
+%790 = OpLoad %double %272
+%791 = OpBitcast %ulong %790
+OpStore %483 %791
+%792 = OpLoad %ulong %466
+%793 = OpLoad %ulong %483
+%794 = OpFunctionCall %ulong %21 %792 %793
+OpStore %484 %794
+OpBranch %169
+%169 = OpLabel
+%795 = OpLoad %ulong %484
+%796 = OpFunctionCall %ulong %21 %795 %ulong_4
+OpStore %351 %796
+OpBranch %89
+%89 = OpLabel
+%797 = OpLoad %ulong %240
+%799 = OpIMul %ulong %797 %ulong_5
+OpStore %290 %799
+OpBranch %109
+%109 = OpLabel
+OpBranch %130
+%130 = OpLabel
+%800 = OpLoad %ulong %351
+OpStore %418 %800
+OpStore %419 %ulong_0
+OpBranch %131
+%131 = OpLabel
+%801 = OpLoad %ulong %419
+%802 = OpULessThan %bool %801 %ulong_8
+OpStore %411 %802
+%803 = OpLoad %bool %411
+OpLoopMerge %133 %207 None
+OpBranchConditional %803 %132 %133
+%133 = OpLabel
+OpBranch %134
+%134 = OpLabel
+OpBranch %159
+%159 = OpLabel
+%804 = OpLoad %float %256
+%805 = OpBitcast %uint %804
+OpStore %467 %805
+%806 = OpLoad %uint %467
+%807 = OpUConvert %ulong %806
+OpStore %468 %807
+%808 = OpLoad %ulong %418
+%809 = OpLoad %ulong %468
+%810 = OpFunctionCall %ulong %21 %808 %809
+OpStore %469 %810
+OpBranch %160
+%160 = OpLabel
+%811 = OpLoad %uint %246
+%812 = OpUConvert %ulong %811
+OpStore %377 %812
+%813 = OpLoad %ulong %469
+%814 = OpLoad %ulong %377
+%815 = OpFunctionCall %ulong %21 %813 %814
+OpStore %378 %815
+OpBranch %170
+%170 = OpLabel
+%816 = OpLoad %double %269
+%817 = OpBitcast %ulong %816
+OpStore %485 %817
+%818 = OpLoad %ulong %378
+%819 = OpLoad %ulong %485
+%820 = OpFunctionCall %ulong %21 %818 %819
+OpStore %486 %820
+OpBranch %171
+%171 = OpLabel
+%821 = OpLoad %ushort %244
+%822 = OpSConvert %ulong %821
+OpStore %379 %822
+%823 = OpLoad %ulong %486
+%824 = OpLoad %ulong %379
+%825 = OpFunctionCall %ulong %21 %823 %824
+OpStore %380 %825
+%826 = OpLoad %ulong %380
+%827 = OpLoad %ulong %290
+%828 = OpFunctionCall %ulong %21 %826 %827
+OpStore %381 %828
+%829 = OpLoad %ulong %381
+%831 = OpFunctionCall %ulong %21 %829 %ulong_6
+OpStore %382 %831
+OpBranch %110
+%110 = OpLabel
+%832 = OpLoad %ulong %240
+%833 = OpIMul %ulong %832 %ulong_7
+OpStore %291 %833
+OpBranch %135
+%135 = OpLabel
+OpBranch %161
+%161 = OpLabel
+%834 = OpLoad %ulong %382
+OpStore %477 %834
+OpStore %478 %ulong_0
+OpBranch %162
+%162 = OpLabel
+%835 = OpLoad %ulong %478
+%836 = OpULessThan %bool %835 %ulong_8
+OpStore %470 %836
+%837 = OpLoad %bool %470
+OpLoopMerge %164 %206 None
+OpBranchConditional %837 %163 %164
+%164 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%838 = OpLoad %uchar %242
+%839 = OpUConvert %ulong %838
+OpStore %420 %839
+%840 = OpLoad %ulong %420
+%841 = OpLoad %ulong %240
+%842 = OpIAdd %ulong %840 %841
+OpStore %421 %842
+%843 = OpLoad %ulong %477
+%844 = OpLoad %ulong %421
+%845 = OpFunctionCall %ulong %21 %843 %844
+OpStore %422 %845
+%846 = OpLoad %uint %246
+%847 = OpUConvert %ulong %846
+OpStore %423 %847
+%848 = OpLoad %ulong %423
+%849 = OpLoad %ulong %240
+%850 = OpIAdd %ulong %848 %849
+OpStore %424 %850
+%851 = OpLoad %ulong %422
+%852 = OpLoad %ulong %424
+%853 = OpFunctionCall %ulong %21 %851 %852
+OpStore %425 %853
+%854 = OpLoad %ulong %291
+%855 = OpLoad %ulong %240
+%856 = OpIAdd %ulong %854 %855
+OpStore %426 %856
+%857 = OpLoad %ulong %425
+%858 = OpLoad %ulong %426
+%859 = OpFunctionCall %ulong %21 %857 %858
+OpStore %427 %859
+%860 = OpLoad %ushort %250
+%861 = OpUConvert %ulong %860
+OpStore %428 %861
+%862 = OpLoad %ulong %428
+%863 = OpLoad %ulong %240
+%864 = OpIAdd %ulong %862 %863
+OpStore %429 %864
+%865 = OpLoad %ulong %427
+%866 = OpLoad %ulong %429
+%867 = OpFunctionCall %ulong %21 %865 %866
+OpStore %430 %867
+%868 = OpLoad %ulong %430
+%869 = OpFunctionCall %ulong %21 %868 %ulong_4
+OpStore %431 %869
+OpBranch %136
+%136 = OpLabel
+OpBranch %166
+%166 = OpLabel
+%870 = OpLoad %ulong %431
+%871 = OpLoad %ulong %240
+%872 = OpFunctionCall %ulong %21 %870 %871
+OpStore %479 %872
+OpBranch %172
+%172 = OpLabel
+%873 = OpLoad %float %262
+%874 = OpBitcast %uint %873
+OpStore %487 %874
+%875 = OpLoad %uint %487
+%876 = OpUConvert %ulong %875
+OpStore %488 %876
+%877 = OpLoad %ulong %479
+%878 = OpLoad %ulong %488
+%879 = OpFunctionCall %ulong %21 %877 %878
+OpStore %489 %879
+OpBranch %173
+%173 = OpLabel
+%880 = OpLoad %ulong %240
+%881 = OpLoad %ulong %240
+%882 = OpIAdd %ulong %880 %881
+OpStore %480 %882
+%883 = OpLoad %ulong %489
+%884 = OpLoad %ulong %480
+%885 = OpFunctionCall %ulong %21 %883 %884
+OpStore %481 %885
+OpBranch %176
+%176 = OpLabel
+%886 = OpLoad %double %275
+%887 = OpBitcast %ulong %886
+OpStore %490 %887
+%888 = OpLoad %ulong %481
+%889 = OpLoad %ulong %490
+%890 = OpFunctionCall %ulong %21 %888 %889
+OpStore %491 %890
+OpBranch %177
+%177 = OpLabel
+%891 = OpLoad %ulong %491
+%892 = OpFunctionCall %ulong %21 %891 %ulong_3
+OpStore %482 %892
+OpBranch %167
+%167 = OpLabel
+OpBranch %174
+%174 = OpLabel
+OpBranch %178
+%178 = OpLabel
+%893 = OpLoad %uchar %242
+%894 = OpUConvert %ulong %893
+OpStore %492 %894
+%895 = OpLoad %ulong %482
+%896 = OpLoad %ulong %492
+%897 = OpFunctionCall %ulong %21 %895 %896
+OpStore %493 %897
+%898 = OpLoad %ushort %244
+%899 = OpSConvert %ulong %898
+OpStore %494 %899
+%900 = OpLoad %ulong %493
+%901 = OpLoad %ulong %494
+%902 = OpFunctionCall %ulong %21 %900 %901
+OpStore %495 %902
+%903 = OpLoad %uint %246
+%904 = OpUConvert %ulong %903
+OpStore %496 %904
+%905 = OpLoad %ulong %495
+%906 = OpLoad %ulong %496
+%907 = OpFunctionCall %ulong %21 %905 %906
+OpStore %497 %907
+%908 = OpLoad %ulong %497
+%909 = OpLoad %ulong %240
+%910 = OpFunctionCall %ulong %21 %908 %909
+OpStore %498 %910
+%911 = OpLoad %ulong %498
+%912 = OpFunctionCall %ulong %21 %911 %ulong_4
+OpStore %499 %912
+OpBranch %179
+%179 = OpLabel
+OpBranch %175
+%175 = OpLabel
+OpBranch %180
+%180 = OpLabel
+OpBranch %182
+%182 = OpLabel
+OpBranch %186
+%186 = OpLabel
+%913 = OpLoad %uchar %242
+%914 = OpUConvert %ulong %913
+OpStore %500 %914
+%915 = OpLoad %ulong %499
+%916 = OpLoad %ulong %500
+%917 = OpFunctionCall %ulong %21 %915 %916
+OpStore %501 %917
+%918 = OpLoad %ushort %244
+%919 = OpSConvert %ulong %918
+OpStore %502 %919
+%920 = OpLoad %ulong %501
+%921 = OpLoad %ulong %502
+%922 = OpFunctionCall %ulong %21 %920 %921
+OpStore %503 %922
+%923 = OpLoad %uint %246
+%924 = OpUConvert %ulong %923
+OpStore %504 %924
+%925 = OpLoad %ulong %503
+%926 = OpLoad %ulong %504
+%927 = OpFunctionCall %ulong %21 %925 %926
+OpStore %505 %927
+%928 = OpLoad %ulong %505
+%929 = OpLoad %ulong %240
+%930 = OpFunctionCall %ulong %21 %928 %929
+OpStore %506 %930
+%931 = OpLoad %ulong %506
+%932 = OpFunctionCall %ulong %21 %931 %ulong_4
+OpStore %507 %932
+OpBranch %187
+%187 = OpLabel
+OpBranch %183
+%183 = OpLabel
+OpBranch %181
+%181 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %188
+%188 = OpLabel
+OpBranch %192
+%192 = OpLabel
+%933 = OpLoad %ulong %507
+%934 = OpLoad %ulong %240
+%935 = OpFunctionCall %ulong %21 %933 %934
+OpStore %509 %935
+OpBranch %198
+%198 = OpLabel
+%936 = OpLoad %float %256
+%937 = OpBitcast %uint %936
+OpStore %526 %937
+%938 = OpLoad %uint %526
+%939 = OpUConvert %ulong %938
+OpStore %527 %939
+%940 = OpLoad %ulong %509
+%941 = OpLoad %ulong %527
+%942 = OpFunctionCall %ulong %21 %940 %941
+OpStore %528 %942
+OpBranch %199
+%199 = OpLabel
+OpBranch %202
+%202 = OpLabel
+%943 = OpLoad %double %269
+%944 = OpBitcast %ulong %943
+OpStore %530 %944
+%945 = OpLoad %ulong %528
+%946 = OpLoad %ulong %530
+%947 = OpFunctionCall %ulong %21 %945 %946
+OpStore %531 %947
+OpBranch %203
+%203 = OpLabel
+%948 = OpLoad %ulong %531
+%949 = OpFunctionCall %ulong %21 %948 %ulong_3
+OpStore %510 %949
+OpBranch %193
+%193 = OpLabel
+OpBranch %189
+%189 = OpLabel
+OpBranch %185
+%185 = OpLabel
+%950 = OpLoad %ulong %240
+%951 = OpIMul %ulong %950 %ulong_7
+OpStore %292 %951
+OpBranch %190
+%190 = OpLabel
+%952 = OpLoad %ulong %240
+%953 = OpIMul %ulong %952 %ulong_3
+OpStore %508 %953
+OpBranch %194
+%194 = OpLabel
+%954 = OpLoad %ulong %510
+%955 = OpLoad %ulong %508
+%956 = OpFunctionCall %ulong %21 %954 %955
+OpStore %511 %956
+%957 = OpLoad %uchar %242
+%958 = OpUConvert %ulong %957
+OpStore %512 %958
+%959 = OpLoad %ulong %512
+%960 = OpLoad %ulong %508
+%961 = OpIAdd %ulong %959 %960
+OpStore %513 %961
+%962 = OpLoad %ulong %511
+%963 = OpLoad %ulong %513
+%964 = OpFunctionCall %ulong %21 %962 %963
+OpStore %514 %964
+%965 = OpLoad %uint %246
+%966 = OpUConvert %ulong %965
+OpStore %515 %966
+%967 = OpLoad %ulong %515
+%968 = OpLoad %ulong %508
+%969 = OpIAdd %ulong %967 %968
+OpStore %516 %969
+%970 = OpLoad %ulong %514
+%971 = OpLoad %ulong %516
+%972 = OpFunctionCall %ulong %21 %970 %971
+OpStore %517 %972
+%973 = OpLoad %ulong %292
+%974 = OpLoad %ulong %508
+%975 = OpIAdd %ulong %973 %974
+OpStore %518 %975
+%976 = OpLoad %ulong %517
+%977 = OpLoad %ulong %518
+%978 = OpFunctionCall %ulong %21 %976 %977
+OpStore %519 %978
+%979 = OpLoad %ushort %250
+%980 = OpUConvert %ulong %979
+OpStore %520 %980
+%981 = OpLoad %ulong %520
+%982 = OpLoad %ulong %508
+%983 = OpIAdd %ulong %981 %982
+OpStore %521 %983
+%984 = OpLoad %ulong %519
+%985 = OpLoad %ulong %521
+%986 = OpFunctionCall %ulong %21 %984 %985
+OpStore %522 %986
+%987 = OpLoad %ulong %522
+%988 = OpFunctionCall %ulong %21 %987 %ulong_4
+OpStore %523 %988
+OpBranch %195
+%195 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %196
+%196 = OpLabel
+%989 = OpLoad %ulong %523
+%990 = OpLoad %ulong %240
+%991 = OpFunctionCall %ulong %21 %989 %990
+OpStore %524 %991
+%992 = OpLoad %ulong %524
+%994 = OpFunctionCall %ulong %21 %992 %ulong_1
+OpStore %525 %994
+OpBranch %197
+%197 = OpLabel
+OpBranch %200
+%200 = OpLabel
+OpBranch %204
+%204 = OpLabel
+%995 = OpLoad %float %265
+%996 = OpBitcast %uint %995
+OpStore %532 %996
+%997 = OpLoad %uint %532
+%998 = OpUConvert %ulong %997
+OpStore %533 %998
+%999 = OpLoad %ulong %525
+%1000 = OpLoad %ulong %533
+%1001 = OpFunctionCall %ulong %21 %999 %1000
+OpStore %534 %1001
+OpBranch %205
+%205 = OpLabel
+%1002 = OpLoad %ulong %534
+%1003 = OpFunctionCall %ulong %21 %1002 %ulong_1
+OpStore %529 %1003
+OpBranch %201
+%201 = OpLabel
+%1004 = OpLoad %ulong %296
+%1005 = OpIAdd %ulong %1004 %ulong_1
+OpStore %293 %1005
+%1006 = OpLoad %ulong %529
+OpStore %294 %1006
+%1007 = OpLoad %ulong %293
+OpStore %296 %1007
+OpBranch %219
+%163 = OpLabel
+%1008 = OpLoad %ulong %478
+%1009 = OpIMul %ulong %1008 %ulong_8
+OpStore %471 %1009
+%1010 = OpLoad %ulong %240
+%1011 = OpLoad %ulong %471
+%1012 = OpShiftRightLogical %ulong %1010 %1011
+OpStore %472 %1012
+%1013 = OpLoad %ulong %472
+%1014 = OpBitwiseAnd %ulong %1013 %ulong_255
+OpStore %473 %1014
+%1015 = OpLoad %ulong %477
+%1016 = OpLoad %ulong %473
+%1017 = OpBitwiseXor %ulong %1015 %1016
+OpStore %474 %1017
+%1018 = OpLoad %ulong %474
+%1020 = OpIMul %ulong %1018 %ulong_1099511628211
+OpStore %475 %1020
+%1021 = OpLoad %ulong %478
+%1022 = OpIAdd %ulong %1021 %ulong_1
+OpStore %476 %1022
+%1023 = OpLoad %ulong %475
+OpStore %477 %1023
+%1024 = OpLoad %ulong %476
+OpStore %478 %1024
+OpBranch %206
+%132 = OpLabel
+%1025 = OpLoad %ulong %419
+%1026 = OpIMul %ulong %1025 %ulong_8
+OpStore %412 %1026
+%1027 = OpLoad %ulong %240
+%1028 = OpLoad %ulong %412
+%1029 = OpShiftRightLogical %ulong %1027 %1028
+OpStore %413 %1029
+%1030 = OpLoad %ulong %413
+%1031 = OpBitwiseAnd %ulong %1030 %ulong_255
+OpStore %414 %1031
+%1032 = OpLoad %ulong %418
+%1033 = OpLoad %ulong %414
+%1034 = OpBitwiseXor %ulong %1032 %1033
+OpStore %415 %1034
+%1035 = OpLoad %ulong %415
+%1036 = OpIMul %ulong %1035 %ulong_1099511628211
+OpStore %416 %1036
+%1037 = OpLoad %ulong %419
+%1038 = OpIAdd %ulong %1037 %ulong_1
+OpStore %417 %1038
+%1039 = OpLoad %ulong %416
+OpStore %418 %1039
+%1040 = OpLoad %ulong %417
+OpStore %419 %1040
+OpBranch %207
+%154 = OpLabel
+%1041 = OpLoad %ulong %463
+%1042 = OpIMul %ulong %1041 %ulong_8
+OpStore %456 %1042
+%1043 = OpLoad %ulong %410
+%1044 = OpLoad %ulong %456
+%1045 = OpShiftRightLogical %ulong %1043 %1044
+OpStore %457 %1045
+%1046 = OpLoad %ulong %457
+%1047 = OpBitwiseAnd %ulong %1046 %ulong_255
+OpStore %458 %1047
+%1048 = OpLoad %ulong %462
+%1049 = OpLoad %ulong %458
+%1050 = OpBitwiseXor %ulong %1048 %1049
+OpStore %459 %1050
+%1051 = OpLoad %ulong %459
+%1052 = OpIMul %ulong %1051 %ulong_1099511628211
+OpStore %460 %1052
+%1053 = OpLoad %ulong %463
+%1054 = OpIAdd %ulong %1053 %ulong_1
+OpStore %461 %1054
+%1055 = OpLoad %ulong %460
+OpStore %462 %1055
+%1056 = OpLoad %ulong %461
+OpStore %463 %1056
+OpBranch %208
+%125 = OpLabel
+%1057 = OpLoad %ulong %409
+%1058 = OpIMul %ulong %1057 %ulong_8
+OpStore %402 %1058
+%1059 = OpLoad %ulong %376
+%1060 = OpLoad %ulong %402
+%1061 = OpShiftRightLogical %ulong %1059 %1060
+OpStore %403 %1061
+%1062 = OpLoad %ulong %403
+%1063 = OpBitwiseAnd %ulong %1062 %ulong_255
+OpStore %404 %1063
+%1064 = OpLoad %ulong %408
+%1065 = OpLoad %ulong %404
+%1066 = OpBitwiseXor %ulong %1064 %1065
+OpStore %405 %1066
+%1067 = OpLoad %ulong %405
+%1068 = OpIMul %ulong %1067 %ulong_1099511628211
+OpStore %406 %1068
+%1069 = OpLoad %ulong %409
+%1070 = OpIAdd %ulong %1069 %ulong_1
+OpStore %407 %1070
+%1071 = OpLoad %ulong %406
+OpStore %408 %1071
+%1072 = OpLoad %ulong %407
+OpStore %409 %1072
+OpBranch %209
+%149 = OpLabel
+%1073 = OpLoad %ulong %454
+%1074 = OpIMul %ulong %1073 %ulong_8
+OpStore %447 %1074
+%1075 = OpLoad %ulong %281
+%1076 = OpLoad %ulong %447
+%1077 = OpShiftRightLogical %ulong %1075 %1076
+OpStore %448 %1077
+%1078 = OpLoad %ulong %448
+%1079 = OpBitwiseAnd %ulong %1078 %ulong_255
+OpStore %449 %1079
+%1080 = OpLoad %ulong %453
+%1081 = OpLoad %ulong %449
+%1082 = OpBitwiseXor %ulong %1080 %1081
+OpStore %450 %1082
+%1083 = OpLoad %ulong %450
+%1084 = OpIMul %ulong %1083 %ulong_1099511628211
+OpStore %451 %1084
+%1085 = OpLoad %ulong %454
+%1086 = OpIAdd %ulong %1085 %ulong_1
+OpStore %452 %1086
+%1087 = OpLoad %ulong %451
+OpStore %453 %1087
+%1088 = OpLoad %ulong %452
+OpStore %454 %1088
+OpBranch %210
+%120 = OpLabel
+%1089 = OpLoad %ulong %400
+%1090 = OpIMul %ulong %1089 %ulong_8
+OpStore %393 %1090
+%1091 = OpLoad %ulong %280
+%1092 = OpLoad %ulong %393
+%1093 = OpShiftRightLogical %ulong %1091 %1092
+OpStore %394 %1093
+%1094 = OpLoad %ulong %394
+%1095 = OpBitwiseAnd %ulong %1094 %ulong_255
+OpStore %395 %1095
+%1096 = OpLoad %ulong %399
+%1097 = OpLoad %ulong %395
+%1098 = OpBitwiseXor %ulong %1096 %1097
+OpStore %396 %1098
+%1099 = OpLoad %ulong %396
+%1100 = OpIMul %ulong %1099 %ulong_1099511628211
+OpStore %397 %1100
+%1101 = OpLoad %ulong %400
+%1102 = OpIAdd %ulong %1101 %ulong_1
+OpStore %398 %1102
+%1103 = OpLoad %ulong %397
+OpStore %399 %1103
+%1104 = OpLoad %ulong %398
+OpStore %400 %1104
+OpBranch %211
+%104 = OpLabel
+%1105 = OpLoad %ulong %374
+%1106 = OpIMul %ulong %1105 %ulong_8
+OpStore %367 %1106
+%1107 = OpLoad %ulong %279
+%1108 = OpLoad %ulong %367
+%1109 = OpShiftRightLogical %ulong %1107 %1108
+OpStore %368 %1109
+%1110 = OpLoad %ulong %368
+%1111 = OpBitwiseAnd %ulong %1110 %ulong_255
+OpStore %369 %1111
+%1112 = OpLoad %ulong %373
+%1113 = OpLoad %ulong %369
+%1114 = OpBitwiseXor %ulong %1112 %1113
+OpStore %370 %1114
+%1115 = OpLoad %ulong %370
+%1116 = OpIMul %ulong %1115 %ulong_1099511628211
+OpStore %371 %1116
+%1117 = OpLoad %ulong %374
+%1118 = OpIAdd %ulong %1117 %ulong_1
+OpStore %372 %1118
+%1119 = OpLoad %ulong %371
+OpStore %373 %1119
+%1120 = OpLoad %ulong %372
+OpStore %374 %1120
+OpBranch %212
+%85 = OpLabel
+%1121 = OpLoad %ulong %350
+%1122 = OpIMul %ulong %1121 %ulong_8
+OpStore %343 %1122
+%1123 = OpLoad %ulong %278
+%1124 = OpLoad %ulong %343
+%1125 = OpShiftRightLogical %ulong %1123 %1124
+OpStore %344 %1125
+%1126 = OpLoad %ulong %344
+%1127 = OpBitwiseAnd %ulong %1126 %ulong_255
+OpStore %345 %1127
+%1128 = OpLoad %ulong %349
+%1129 = OpLoad %ulong %345
+%1130 = OpBitwiseXor %ulong %1128 %1129
+OpStore %346 %1130
+%1131 = OpLoad %ulong %346
+%1132 = OpIMul %ulong %1131 %ulong_1099511628211
+OpStore %347 %1132
+%1133 = OpLoad %ulong %350
+%1134 = OpIAdd %ulong %1133 %ulong_1
+OpStore %348 %1134
+%1135 = OpLoad %ulong %347
+OpStore %349 %1135
+%1136 = OpLoad %ulong %348
+OpStore %350 %1136
+OpBranch %213
+%144 = OpLabel
+%1137 = OpLoad %ulong %445
+%1138 = OpIMul %ulong %1137 %ulong_8
+OpStore %438 %1138
+%1139 = OpLoad %ulong %303
+%1140 = OpLoad %ulong %438
+%1141 = OpShiftRightLogical %ulong %1139 %1140
+OpStore %439 %1141
+%1142 = OpLoad %ulong %439
+%1143 = OpBitwiseAnd %ulong %1142 %ulong_255
+OpStore %440 %1143
+%1144 = OpLoad %ulong %444
+%1145 = OpLoad %ulong %440
+%1146 = OpBitwiseXor %ulong %1144 %1145
+OpStore %441 %1146
+%1147 = OpLoad %ulong %441
+%1148 = OpIMul %ulong %1147 %ulong_1099511628211
+OpStore %442 %1148
+%1149 = OpLoad %ulong %445
+%1150 = OpIAdd %ulong %1149 %ulong_1
+OpStore %443 %1150
+%1151 = OpLoad %ulong %442
+OpStore %444 %1151
+%1152 = OpLoad %ulong %443
+OpStore %445 %1152
+OpBranch %214
+%115 = OpLabel
+%1153 = OpLoad %ulong %391
+%1154 = OpIMul %ulong %1153 %ulong_8
+OpStore %384 %1154
+%1155 = OpLoad %ulong %240
+%1156 = OpLoad %ulong %384
+%1157 = OpShiftRightLogical %ulong %1155 %1156
+OpStore %385 %1157
+%1158 = OpLoad %ulong %385
+%1159 = OpBitwiseAnd %ulong %1158 %ulong_255
+OpStore %386 %1159
+%1160 = OpLoad %ulong %390
+%1161 = OpLoad %ulong %386
+%1162 = OpBitwiseXor %ulong %1160 %1161
+OpStore %387 %1162
+%1163 = OpLoad %ulong %387
+%1164 = OpIMul %ulong %1163 %ulong_1099511628211
+OpStore %388 %1164
+%1165 = OpLoad %ulong %391
+%1166 = OpIAdd %ulong %1165 %ulong_1
+OpStore %389 %1166
+%1167 = OpLoad %ulong %388
+OpStore %390 %1167
+%1168 = OpLoad %ulong %389
+OpStore %391 %1168
+OpBranch %215
+%99 = OpLabel
+%1169 = OpLoad %ulong %365
+%1170 = OpIMul %ulong %1169 %ulong_8
+OpStore %358 %1170
+%1171 = OpLoad %ulong %302
+%1172 = OpLoad %ulong %358
+%1173 = OpShiftRightLogical %ulong %1171 %1172
+OpStore %359 %1173
+%1174 = OpLoad %ulong %359
+%1175 = OpBitwiseAnd %ulong %1174 %ulong_255
+OpStore %360 %1175
+%1176 = OpLoad %ulong %364
+%1177 = OpLoad %ulong %360
+%1178 = OpBitwiseXor %ulong %1176 %1177
+OpStore %361 %1178
+%1179 = OpLoad %ulong %361
+%1180 = OpIMul %ulong %1179 %ulong_1099511628211
+OpStore %362 %1180
+%1181 = OpLoad %ulong %365
+%1182 = OpIAdd %ulong %1181 %ulong_1
+OpStore %363 %1182
+%1183 = OpLoad %ulong %362
+OpStore %364 %1183
+%1184 = OpLoad %ulong %363
+OpStore %365 %1184
+OpBranch %216
+%80 = OpLabel
+%1185 = OpLoad %ulong %341
+%1186 = OpIMul %ulong %1185 %ulong_8
+OpStore %334 %1186
+%1187 = OpLoad %ulong %301
+%1188 = OpLoad %ulong %334
+%1189 = OpShiftRightLogical %ulong %1187 %1188
+OpStore %335 %1189
+%1190 = OpLoad %ulong %335
+%1191 = OpBitwiseAnd %ulong %1190 %ulong_255
+OpStore %336 %1191
+%1192 = OpLoad %ulong %340
+%1193 = OpLoad %ulong %336
+%1194 = OpBitwiseXor %ulong %1192 %1193
+OpStore %337 %1194
+%1195 = OpLoad %ulong %337
+%1196 = OpIMul %ulong %1195 %ulong_1099511628211
+OpStore %338 %1196
+%1197 = OpLoad %ulong %341
+%1198 = OpIAdd %ulong %1197 %ulong_1
+OpStore %339 %1198
+%1199 = OpLoad %ulong %338
+OpStore %340 %1199
+%1200 = OpLoad %ulong %339
+OpStore %341 %1200
+OpBranch %217
+%69 = OpLabel
+%1201 = OpLoad %ulong %323
+%1202 = OpIMul %ulong %1201 %ulong_8
+OpStore %316 %1202
+%1203 = OpLoad %ulong %300
+%1204 = OpLoad %ulong %316
+%1205 = OpShiftRightLogical %ulong %1203 %1204
+OpStore %317 %1205
+%1206 = OpLoad %ulong %317
+%1207 = OpBitwiseAnd %ulong %1206 %ulong_255
+OpStore %318 %1207
+%1208 = OpLoad %ulong %322
+%1209 = OpLoad %ulong %318
+%1210 = OpBitwiseXor %ulong %1208 %1209
+OpStore %319 %1210
+%1211 = OpLoad %ulong %319
+%1212 = OpIMul %ulong %1211 %ulong_1099511628211
+OpStore %320 %1212
+%1213 = OpLoad %ulong %323
+%1214 = OpIAdd %ulong %1213 %ulong_1
+OpStore %321 %1214
+%1215 = OpLoad %ulong %320
+OpStore %322 %1215
+%1216 = OpLoad %ulong %321
+OpStore %323 %1216
+OpBranch %218
+%139 = OpLabel
+%1217 = OpLoad %ulong %435
+%1218 = OpIMul %ulong %1217 %ulong_1099511628211
+OpStore %433 %1218
+%1219 = OpLoad %ulong %436
+%1220 = OpIAdd %ulong %1219 %ulong_1
+OpStore %434 %1220
+%1221 = OpLoad %ulong %433
+OpStore %435 %1221
+%1222 = OpLoad %ulong %434
+OpStore %436 %1222
+OpBranch %220
+%92 = OpLabel
+%1223 = OpLoad %ulong %355
+%1224 = OpIMul %ulong %1223 %ulong_1099511628211
+OpStore %353 %1224
+%1225 = OpLoad %ulong %356
+%1226 = OpIAdd %ulong %1225 %ulong_1
+OpStore %354 %1226
+%1227 = OpLoad %ulong %353
+OpStore %355 %1227
+%1228 = OpLoad %ulong %354
+OpStore %356 %1228
+OpBranch %221
+%62 = OpLabel
+%1229 = OpLoad %ulong %313
+%1230 = OpIMul %ulong %1229 %ulong_1099511628211
+OpStore %311 %1230
+%1231 = OpLoad %ulong %314
+%1232 = OpIAdd %ulong %1231 %ulong_1
+OpStore %312 %1232
+%1233 = OpLoad %ulong %311
+OpStore %313 %1233
+%1234 = OpLoad %ulong %312
+OpStore %314 %1234
+OpBranch %222
+%47 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%1235 = OpLoad %ulong %295
+%1236 = OpIMul %ulong %1235 %ulong_6364136223846793005
+OpStore %297 %1236
+%1237 = OpLoad %ulong %297
+%1238 = OpIAdd %ulong %1237 %ulong_1442695040888963407
+OpStore %298 %1238
+%1239 = OpLoad %ulong %298
+%1240 = OpLoad %ulong %234
+%1241 = OpIAdd %ulong %1239 %1240
+OpStore %299 %1241
+OpBranch %55
+%55 = OpLabel
+%1242 = OpLoad %ulong %295
+%1243 = OpAccessChain %_ptr_Function_ulong %233 %1242
+%1244 = OpLoad %ulong %299
+OpStore %1243 %1244
+%1245 = OpLoad %ulong %295
+%1246 = OpIAdd %ulong %1245 %ulong_1
+OpStore %237 %1246
+%1247 = OpLoad %ulong %237
+OpStore %295 %1247
+OpBranch %223
+%206 = OpLabel
+OpBranch %162
+%207 = OpLabel
+OpBranch %131
+%208 = OpLabel
+OpBranch %153
+%209 = OpLabel
+OpBranch %124
+%210 = OpLabel
+OpBranch %148
+%211 = OpLabel
+OpBranch %119
+%212 = OpLabel
+OpBranch %103
+%213 = OpLabel
+OpBranch %84
+%214 = OpLabel
+OpBranch %143
+%215 = OpLabel
+OpBranch %114
+%216 = OpLabel
+OpBranch %98
+%217 = OpLabel
+OpBranch %79
+%218 = OpLabel
+OpBranch %68
+%219 = OpLabel
+OpBranch %49
+%220 = OpLabel
+OpBranch %138
+%221 = OpLabel
+OpBranch %91
+%222 = OpLabel
+OpBranch %61
+%223 = OpLabel
+OpBranch %46
 OpFunctionEnd
-%3 = OpFunction %ulong None %46
-%720 = OpFunctionParameter %ulong
-%721 = OpLabel
-%722 = OpVariable %_ptr_Function_ulong Function
-%723 = OpVariable %_ptr_Function_ulong Function
-OpStore %722 %720
-%724 = OpLoad %ulong %722
-%725 = OpFunctionCall %ulong %22 %724 %ulong_0
-OpStore %723 %725
-%726 = OpLoad %ulong %723
-OpReturnValue %726
+%3 = OpFunction %ulong None %43
+%1248 = OpFunctionParameter %ulong
+%1249 = OpLabel
+%1250 = OpVariable %_ptr_Function_ulong Function
+%1251 = OpVariable %_ptr_Function_ulong Function
+OpStore %1250 %1248
+%1252 = OpLoad %ulong %1250
+%1253 = OpFunctionCall %ulong %21 %1252 %ulong_0
+OpStore %1251 %1253
+%1254 = OpLoad %ulong %1251
+OpReturnValue %1254
 OpFunctionEnd
-%4 = OpFunction %ulong None %46
-%727 = OpFunctionParameter %ulong
-%728 = OpLabel
-%731 = OpVariable %_ptr_Function_ulong Function
-%732 = OpVariable %_ptr_Function_ulong Function
-OpStore %731 %727
-OpBranch %729
-%729 = OpLabel
-%733 = OpLoad %ulong %731
-%734 = OpFunctionCall %ulong %22 %733 %ulong_0
-OpStore %732 %734
-OpBranch %730
-%730 = OpLabel
-%735 = OpLoad %ulong %732
-OpReturnValue %735
+%4 = OpFunction %ulong None %43
+%1255 = OpFunctionParameter %ulong
+%1256 = OpLabel
+%1259 = OpVariable %_ptr_Function_ulong Function
+%1260 = OpVariable %_ptr_Function_ulong Function
+OpStore %1259 %1255
+OpBranch %1257
+%1257 = OpLabel
+%1261 = OpLoad %ulong %1259
+%1262 = OpFunctionCall %ulong %21 %1261 %ulong_0
+OpStore %1260 %1262
+OpBranch %1258
+%1258 = OpLabel
+%1263 = OpLoad %ulong %1260
+OpReturnValue %1263
 OpFunctionEnd
-%5 = OpFunction %ulong None %46
-%736 = OpFunctionParameter %ulong
-%737 = OpLabel
-%742 = OpVariable %_ptr_Function_ulong Function
-%743 = OpVariable %_ptr_Function_ulong Function
-OpStore %742 %736
-OpBranch %738
-%738 = OpLabel
-OpBranch %739
-%739 = OpLabel
-%744 = OpLoad %ulong %742
-%745 = OpFunctionCall %ulong %22 %744 %ulong_0
-OpStore %743 %745
-OpBranch %740
-%740 = OpLabel
-OpBranch %741
-%741 = OpLabel
-%746 = OpLoad %ulong %743
-OpReturnValue %746
-OpFunctionEnd
-%6 = OpFunction %ulong None %747
-%748 = OpFunctionParameter %ulong
-%749 = OpFunctionParameter %uchar
-%750 = OpFunctionParameter %ushort
-%751 = OpFunctionParameter %uint
-%752 = OpFunctionParameter %ulong
-%753 = OpFunctionParameter %uchar
-%754 = OpFunctionParameter %ushort
-%755 = OpFunctionParameter %uint
-%756 = OpFunctionParameter %ulong
-%757 = OpLabel
-%758 = OpVariable %_ptr_Function_ulong Function
-%759 = OpVariable %_ptr_Function_uchar Function
-%760 = OpVariable %_ptr_Function_ushort Function
-%761 = OpVariable %_ptr_Function_uint Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_uchar Function
-%764 = OpVariable %_ptr_Function_ushort Function
-%765 = OpVariable %_ptr_Function_uint Function
-%766 = OpVariable %_ptr_Function_ulong Function
-%767 = OpVariable %_ptr_Function_ulong Function
-%768 = OpVariable %_ptr_Function_ulong Function
-%769 = OpVariable %_ptr_Function_ulong Function
-%770 = OpVariable %_ptr_Function_ulong Function
-%771 = OpVariable %_ptr_Function_ulong Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_ulong Function
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_ulong Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_ulong Function
-%778 = OpVariable %_ptr_Function_ulong Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_ulong Function
-OpStore %758 %748
-OpStore %759 %749
-OpStore %760 %750
-OpStore %761 %751
-OpStore %762 %752
-OpStore %763 %753
-OpStore %764 %754
-OpStore %765 %755
-OpStore %766 %756
-%782 = OpLoad %uchar %759
-%783 = OpUConvert %ulong %782
-OpStore %767 %783
-%784 = OpLoad %ulong %758
-%785 = OpLoad %ulong %767
-%786 = OpFunctionCall %ulong %22 %784 %785
-OpStore %768 %786
-%787 = OpLoad %ushort %760
-%788 = OpSConvert %ulong %787
-OpStore %769 %788
-%789 = OpLoad %ulong %768
-%790 = OpLoad %ulong %769
-%791 = OpFunctionCall %ulong %22 %789 %790
-OpStore %770 %791
-%792 = OpLoad %uint %761
-%793 = OpUConvert %ulong %792
-OpStore %771 %793
-%794 = OpLoad %ulong %770
-%795 = OpLoad %ulong %771
-%796 = OpFunctionCall %ulong %22 %794 %795
-OpStore %772 %796
-%797 = OpLoad %ulong %772
-%798 = OpLoad %ulong %762
-%799 = OpFunctionCall %ulong %22 %797 %798
-OpStore %773 %799
-%800 = OpLoad %uchar %763
-%801 = OpUConvert %ulong %800
-OpStore %774 %801
-%802 = OpLoad %ulong %773
-%803 = OpLoad %ulong %774
-%804 = OpFunctionCall %ulong %22 %802 %803
-OpStore %775 %804
-%805 = OpLoad %ushort %764
-%806 = OpUConvert %ulong %805
-OpStore %776 %806
-%807 = OpLoad %ulong %775
-%808 = OpLoad %ulong %776
-%809 = OpFunctionCall %ulong %22 %807 %808
-OpStore %777 %809
-%810 = OpLoad %uint %765
-%811 = OpSConvert %ulong %810
-OpStore %778 %811
-%812 = OpLoad %ulong %777
-%813 = OpLoad %ulong %778
-%814 = OpFunctionCall %ulong %22 %812 %813
-OpStore %779 %814
-%815 = OpLoad %ulong %779
-%816 = OpLoad %ulong %766
-%817 = OpFunctionCall %ulong %22 %815 %816
-OpStore %780 %817
-%818 = OpLoad %ulong %780
-%819 = OpFunctionCall %ulong %22 %818 %ulong_8
-OpStore %781 %819
-%820 = OpLoad %ulong %781
-OpReturnValue %820
-OpFunctionEnd
-%7 = OpFunction %ulong None %821
-%822 = OpFunctionParameter %ulong
-%823 = OpFunctionParameter %ulong
-%824 = OpFunctionParameter %ulong
-%825 = OpFunctionParameter %ulong
-%826 = OpFunctionParameter %ulong
-%827 = OpFunctionParameter %ulong
-%828 = OpFunctionParameter %ulong
-%829 = OpFunctionParameter %ulong
-%830 = OpFunctionParameter %ulong
-%831 = OpFunctionParameter %ulong
-%832 = OpFunctionParameter %ulong
-%833 = OpFunctionParameter %ulong
-%834 = OpFunctionParameter %ulong
-%835 = OpLabel
-%836 = OpVariable %_ptr_Function_ulong Function
-%837 = OpVariable %_ptr_Function_ulong Function
-%838 = OpVariable %_ptr_Function_ulong Function
-%839 = OpVariable %_ptr_Function_ulong Function
-%840 = OpVariable %_ptr_Function_ulong Function
-%841 = OpVariable %_ptr_Function_ulong Function
-%842 = OpVariable %_ptr_Function_ulong Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_ulong Function
-%847 = OpVariable %_ptr_Function_ulong Function
-%848 = OpVariable %_ptr_Function_ulong Function
-%849 = OpVariable %_ptr_Function_ulong Function
-%850 = OpVariable %_ptr_Function_ulong Function
-%851 = OpVariable %_ptr_Function_ulong Function
-%852 = OpVariable %_ptr_Function_ulong Function
-%853 = OpVariable %_ptr_Function_ulong Function
-%854 = OpVariable %_ptr_Function_ulong Function
-%855 = OpVariable %_ptr_Function_ulong Function
-%856 = OpVariable %_ptr_Function_ulong Function
-%857 = OpVariable %_ptr_Function_ulong Function
-%858 = OpVariable %_ptr_Function_ulong Function
-%859 = OpVariable %_ptr_Function_ulong Function
-%860 = OpVariable %_ptr_Function_ulong Function
-%861 = OpVariable %_ptr_Function_ulong Function
-OpStore %836 %822
-OpStore %837 %823
-OpStore %838 %824
-OpStore %839 %825
-OpStore %840 %826
-OpStore %841 %827
-OpStore %842 %828
-OpStore %843 %829
-OpStore %844 %830
-OpStore %845 %831
-OpStore %846 %832
-OpStore %847 %833
-OpStore %848 %834
-%862 = OpLoad %ulong %836
-%863 = OpLoad %ulong %837
-%864 = OpFunctionCall %ulong %22 %862 %863
-OpStore %849 %864
-%865 = OpLoad %ulong %849
-%866 = OpLoad %ulong %838
-%867 = OpFunctionCall %ulong %22 %865 %866
-OpStore %850 %867
-%868 = OpLoad %ulong %850
-%869 = OpLoad %ulong %839
-%870 = OpFunctionCall %ulong %22 %868 %869
-OpStore %851 %870
-%871 = OpLoad %ulong %851
-%872 = OpLoad %ulong %840
-%873 = OpFunctionCall %ulong %22 %871 %872
-OpStore %852 %873
-%874 = OpLoad %ulong %852
-%875 = OpLoad %ulong %841
-%876 = OpFunctionCall %ulong %22 %874 %875
-OpStore %853 %876
-%877 = OpLoad %ulong %853
-%878 = OpLoad %ulong %842
-%879 = OpFunctionCall %ulong %22 %877 %878
-OpStore %854 %879
-%880 = OpLoad %ulong %854
-%881 = OpLoad %ulong %843
-%882 = OpFunctionCall %ulong %22 %880 %881
-OpStore %855 %882
-%883 = OpLoad %ulong %855
-%884 = OpLoad %ulong %844
-%885 = OpFunctionCall %ulong %22 %883 %884
-OpStore %856 %885
-%886 = OpLoad %ulong %856
-%887 = OpLoad %ulong %845
-%888 = OpFunctionCall %ulong %22 %886 %887
-OpStore %857 %888
-%889 = OpLoad %ulong %857
-%890 = OpLoad %ulong %846
-%891 = OpFunctionCall %ulong %22 %889 %890
-OpStore %858 %891
-%892 = OpLoad %ulong %858
-%893 = OpLoad %ulong %847
-%894 = OpFunctionCall %ulong %22 %892 %893
-OpStore %859 %894
-%895 = OpLoad %ulong %859
-%896 = OpLoad %ulong %848
-%897 = OpFunctionCall %ulong %22 %895 %896
-OpStore %860 %897
-%898 = OpLoad %ulong %860
-%899 = OpFunctionCall %ulong %22 %898 %ulong_12
-OpStore %861 %899
-%900 = OpLoad %ulong %861
-OpReturnValue %900
-OpFunctionEnd
-%8 = OpFunction %ulong None %901
-%902 = OpFunctionParameter %ulong
-%903 = OpFunctionParameter %float
-%904 = OpFunctionParameter %double
-%905 = OpFunctionParameter %float
-%906 = OpFunctionParameter %double
-%907 = OpLabel
-%908 = OpVariable %_ptr_Function_ulong Function
-%909 = OpVariable %_ptr_Function_float Function
-%910 = OpVariable %_ptr_Function_double Function
-%911 = OpVariable %_ptr_Function_float Function
-%912 = OpVariable %_ptr_Function_double Function
-%913 = OpVariable %_ptr_Function_ulong Function
-%914 = OpVariable %_ptr_Function_ulong Function
-%915 = OpVariable %_ptr_Function_ulong Function
-%916 = OpVariable %_ptr_Function_ulong Function
-%917 = OpVariable %_ptr_Function_ulong Function
-OpStore %908 %902
-OpStore %909 %903
-OpStore %910 %904
-OpStore %911 %905
-OpStore %912 %906
-%918 = OpLoad %ulong %908
-%919 = OpLoad %float %909
-%920 = OpFunctionCall %ulong %23 %918 %919
-OpStore %913 %920
-%921 = OpLoad %ulong %913
-%922 = OpLoad %double %910
-%923 = OpFunctionCall %ulong %24 %921 %922
-OpStore %914 %923
-%924 = OpLoad %ulong %914
-%925 = OpLoad %float %911
-%926 = OpFunctionCall %ulong %23 %924 %925
-OpStore %915 %926
-%927 = OpLoad %ulong %915
-%928 = OpLoad %double %912
-%929 = OpFunctionCall %ulong %24 %927 %928
-OpStore %916 %929
-%930 = OpLoad %ulong %916
-%931 = OpFunctionCall %ulong %22 %930 %ulong_4
-OpStore %917 %931
-%932 = OpLoad %ulong %917
-OpReturnValue %932
-OpFunctionEnd
-%9 = OpFunction %ulong None %933
-%934 = OpFunctionParameter %ulong
-%935 = OpFunctionParameter %ulong
-%936 = OpFunctionParameter %float
-%937 = OpFunctionParameter %uint
-%938 = OpFunctionParameter %double
-%939 = OpFunctionParameter %ushort
-%940 = OpFunctionParameter %ulong
-%941 = OpLabel
-%942 = OpVariable %_ptr_Function_ulong Function
-%943 = OpVariable %_ptr_Function_ulong Function
-%944 = OpVariable %_ptr_Function_float Function
-%945 = OpVariable %_ptr_Function_uint Function
-%946 = OpVariable %_ptr_Function_double Function
-%947 = OpVariable %_ptr_Function_ushort Function
-%948 = OpVariable %_ptr_Function_ulong Function
-%949 = OpVariable %_ptr_Function_ulong Function
-%950 = OpVariable %_ptr_Function_ulong Function
-%951 = OpVariable %_ptr_Function_ulong Function
-%952 = OpVariable %_ptr_Function_ulong Function
-%953 = OpVariable %_ptr_Function_ulong Function
-%954 = OpVariable %_ptr_Function_ulong Function
-%955 = OpVariable %_ptr_Function_ulong Function
-%956 = OpVariable %_ptr_Function_ulong Function
-%957 = OpVariable %_ptr_Function_ulong Function
-OpStore %942 %934
-OpStore %943 %935
-OpStore %944 %936
-OpStore %945 %937
-OpStore %946 %938
-OpStore %947 %939
-OpStore %948 %940
-%958 = OpLoad %ulong %942
-%959 = OpLoad %ulong %943
-%960 = OpFunctionCall %ulong %22 %958 %959
-OpStore %949 %960
-%961 = OpLoad %ulong %949
-%962 = OpLoad %float %944
-%963 = OpFunctionCall %ulong %23 %961 %962
-OpStore %950 %963
-%964 = OpLoad %uint %945
-%965 = OpUConvert %ulong %964
-OpStore %951 %965
-%966 = OpLoad %ulong %950
-%967 = OpLoad %ulong %951
-%968 = OpFunctionCall %ulong %22 %966 %967
-OpStore %952 %968
-%969 = OpLoad %ulong %952
-%970 = OpLoad %double %946
-%971 = OpFunctionCall %ulong %24 %969 %970
-OpStore %953 %971
-%972 = OpLoad %ushort %947
-%973 = OpSConvert %ulong %972
-OpStore %954 %973
-%974 = OpLoad %ulong %953
-%975 = OpLoad %ulong %954
-%976 = OpFunctionCall %ulong %22 %974 %975
-OpStore %955 %976
-%977 = OpLoad %ulong %955
-%978 = OpLoad %ulong %948
-%979 = OpFunctionCall %ulong %22 %977 %978
-OpStore %956 %979
-%980 = OpLoad %ulong %956
-%981 = OpFunctionCall %ulong %22 %980 %ulong_6
-OpStore %957 %981
-%982 = OpLoad %ulong %957
-OpReturnValue %982
-OpFunctionEnd
-%10 = OpFunction %ulong None %983
-%984 = OpFunctionParameter %ulong
-%985 = OpFunctionParameter %ulong
-%986 = OpFunctionParameter %uchar
-%987 = OpFunctionParameter %uint
-%988 = OpFunctionParameter %ulong
-%989 = OpFunctionParameter %ushort
-%990 = OpLabel
-%991 = OpVariable %_ptr_Function_ulong Function
-%992 = OpVariable %_ptr_Function_ulong Function
-%993 = OpVariable %_ptr_Function_uchar Function
-%994 = OpVariable %_ptr_Function_uint Function
-%995 = OpVariable %_ptr_Function_ulong Function
-%996 = OpVariable %_ptr_Function_ushort Function
-%997 = OpVariable %_ptr_Function_ulong Function
-%998 = OpVariable %_ptr_Function_ulong Function
-%999 = OpVariable %_ptr_Function_ulong Function
-%1000 = OpVariable %_ptr_Function_ulong Function
-%1001 = OpVariable %_ptr_Function_ulong Function
-%1002 = OpVariable %_ptr_Function_ulong Function
-%1003 = OpVariable %_ptr_Function_ulong Function
-%1004 = OpVariable %_ptr_Function_ulong Function
-%1005 = OpVariable %_ptr_Function_ulong Function
-%1006 = OpVariable %_ptr_Function_ulong Function
-%1007 = OpVariable %_ptr_Function_ulong Function
-%1008 = OpVariable %_ptr_Function_ulong Function
-%1009 = OpVariable %_ptr_Function_ulong Function
-OpStore %991 %984
-OpStore %992 %985
-OpStore %993 %986
-OpStore %994 %987
-OpStore %995 %988
-OpStore %996 %989
-%1010 = OpLoad %ulong %991
-%1011 = OpLoad %ulong %992
-%1012 = OpFunctionCall %ulong %22 %1010 %1011
-OpStore %997 %1012
-%1013 = OpLoad %uchar %993
-%1014 = OpUConvert %ulong %1013
-OpStore %998 %1014
-%1015 = OpLoad %ulong %998
-%1016 = OpLoad %ulong %992
-%1017 = OpIAdd %ulong %1015 %1016
-OpStore %999 %1017
-%1018 = OpLoad %ulong %997
-%1019 = OpLoad %ulong %999
-%1020 = OpFunctionCall %ulong %22 %1018 %1019
-OpStore %1000 %1020
-%1021 = OpLoad %uint %994
-%1022 = OpUConvert %ulong %1021
-OpStore %1001 %1022
-%1023 = OpLoad %ulong %1001
-%1024 = OpLoad %ulong %992
-%1025 = OpIAdd %ulong %1023 %1024
-OpStore %1002 %1025
-%1026 = OpLoad %ulong %1000
-%1027 = OpLoad %ulong %1002
-%1028 = OpFunctionCall %ulong %22 %1026 %1027
-OpStore %1003 %1028
-%1029 = OpLoad %ulong %995
-%1030 = OpLoad %ulong %992
-%1031 = OpIAdd %ulong %1029 %1030
-OpStore %1004 %1031
-%1032 = OpLoad %ulong %1003
-%1033 = OpLoad %ulong %1004
-%1034 = OpFunctionCall %ulong %22 %1032 %1033
-OpStore %1005 %1034
-%1035 = OpLoad %ushort %996
-%1036 = OpUConvert %ulong %1035
-OpStore %1006 %1036
-%1037 = OpLoad %ulong %1006
-%1038 = OpLoad %ulong %992
-%1039 = OpIAdd %ulong %1037 %1038
-OpStore %1007 %1039
-%1040 = OpLoad %ulong %1005
-%1041 = OpLoad %ulong %1007
-%1042 = OpFunctionCall %ulong %22 %1040 %1041
-OpStore %1008 %1042
-%1043 = OpLoad %ulong %1008
-%1044 = OpFunctionCall %ulong %22 %1043 %ulong_4
-OpStore %1009 %1044
-%1045 = OpLoad %ulong %1009
-OpReturnValue %1045
-OpFunctionEnd
-%11 = OpFunction %ulong None %1046
-%1047 = OpFunctionParameter %ulong
-%1048 = OpFunctionParameter %ulong
-%1049 = OpFunctionParameter %float
-%1050 = OpFunctionParameter %ulong
-%1051 = OpFunctionParameter %double
-%1052 = OpLabel
-%1053 = OpVariable %_ptr_Function_ulong Function
-%1054 = OpVariable %_ptr_Function_ulong Function
-%1055 = OpVariable %_ptr_Function_float Function
-%1056 = OpVariable %_ptr_Function_ulong Function
-%1057 = OpVariable %_ptr_Function_double Function
-%1058 = OpVariable %_ptr_Function_ulong Function
-%1059 = OpVariable %_ptr_Function_ulong Function
-%1060 = OpVariable %_ptr_Function_ulong Function
-%1061 = OpVariable %_ptr_Function_ulong Function
-%1062 = OpVariable %_ptr_Function_ulong Function
-%1063 = OpVariable %_ptr_Function_ulong Function
-OpStore %1053 %1047
-OpStore %1054 %1048
-OpStore %1055 %1049
-OpStore %1056 %1050
-OpStore %1057 %1051
-%1064 = OpLoad %ulong %1053
-%1065 = OpLoad %ulong %1054
-%1066 = OpFunctionCall %ulong %22 %1064 %1065
-OpStore %1058 %1066
-%1067 = OpLoad %ulong %1058
-%1068 = OpLoad %float %1055
-%1069 = OpFunctionCall %ulong %23 %1067 %1068
-OpStore %1059 %1069
-%1070 = OpLoad %ulong %1056
-%1071 = OpLoad %ulong %1054
-%1072 = OpIAdd %ulong %1070 %1071
-OpStore %1060 %1072
-%1073 = OpLoad %ulong %1059
-%1074 = OpLoad %ulong %1060
-%1075 = OpFunctionCall %ulong %22 %1073 %1074
-OpStore %1061 %1075
-%1076 = OpLoad %ulong %1061
-%1077 = OpLoad %double %1057
-%1078 = OpFunctionCall %ulong %24 %1076 %1077
-OpStore %1062 %1078
-%1079 = OpLoad %ulong %1062
-%1080 = OpFunctionCall %ulong %22 %1079 %ulong_3
-OpStore %1063 %1080
-%1081 = OpLoad %ulong %1063
-OpReturnValue %1081
-OpFunctionEnd
-%12 = OpFunction %ulong None %1082
-%1083 = OpFunctionParameter %ulong
-%1084 = OpFunctionParameter %uchar
-%1085 = OpFunctionParameter %ushort
-%1086 = OpFunctionParameter %uint
-%1087 = OpFunctionParameter %ulong
-%1088 = OpLabel
-%1091 = OpVariable %_ptr_Function_ulong Function
-%1092 = OpVariable %_ptr_Function_uchar Function
-%1093 = OpVariable %_ptr_Function_ushort Function
-%1094 = OpVariable %_ptr_Function_uint Function
-%1095 = OpVariable %_ptr_Function_ulong Function
-%1096 = OpVariable %_ptr_Function_ulong Function
-%1097 = OpVariable %_ptr_Function_ulong Function
-%1098 = OpVariable %_ptr_Function_ulong Function
-%1099 = OpVariable %_ptr_Function_ulong Function
-%1100 = OpVariable %_ptr_Function_ulong Function
-%1101 = OpVariable %_ptr_Function_ulong Function
-%1102 = OpVariable %_ptr_Function_ulong Function
-%1103 = OpVariable %_ptr_Function_ulong Function
-OpStore %1091 %1083
-OpStore %1092 %1084
-OpStore %1093 %1085
-OpStore %1094 %1086
-OpStore %1095 %1087
-OpBranch %1089
-%1089 = OpLabel
-%1104 = OpLoad %uchar %1092
-%1105 = OpUConvert %ulong %1104
-OpStore %1096 %1105
-%1106 = OpLoad %ulong %1091
-%1107 = OpLoad %ulong %1096
-%1108 = OpFunctionCall %ulong %22 %1106 %1107
-OpStore %1097 %1108
-%1109 = OpLoad %ushort %1093
-%1110 = OpSConvert %ulong %1109
-OpStore %1098 %1110
-%1111 = OpLoad %ulong %1097
-%1112 = OpLoad %ulong %1098
-%1113 = OpFunctionCall %ulong %22 %1111 %1112
-OpStore %1099 %1113
-%1114 = OpLoad %uint %1094
-%1115 = OpUConvert %ulong %1114
-OpStore %1100 %1115
-%1116 = OpLoad %ulong %1099
-%1117 = OpLoad %ulong %1100
-%1118 = OpFunctionCall %ulong %22 %1116 %1117
-OpStore %1101 %1118
-%1119 = OpLoad %ulong %1101
-%1120 = OpLoad %ulong %1095
-%1121 = OpFunctionCall %ulong %22 %1119 %1120
-OpStore %1102 %1121
-%1122 = OpLoad %ulong %1102
-%1123 = OpFunctionCall %ulong %22 %1122 %ulong_4
-OpStore %1103 %1123
-OpBranch %1090
-%1090 = OpLabel
-%1124 = OpLoad %ulong %1103
-OpReturnValue %1124
-OpFunctionEnd
-%13 = OpFunction %ulong None %1082
-%1125 = OpFunctionParameter %ulong
-%1126 = OpFunctionParameter %uchar
-%1127 = OpFunctionParameter %ushort
-%1128 = OpFunctionParameter %uint
-%1129 = OpFunctionParameter %ulong
-%1130 = OpLabel
-%1135 = OpVariable %_ptr_Function_ulong Function
-%1136 = OpVariable %_ptr_Function_uchar Function
-%1137 = OpVariable %_ptr_Function_ushort Function
-%1138 = OpVariable %_ptr_Function_uint Function
-%1139 = OpVariable %_ptr_Function_ulong Function
-%1140 = OpVariable %_ptr_Function_ulong Function
-%1141 = OpVariable %_ptr_Function_ulong Function
-%1142 = OpVariable %_ptr_Function_ulong Function
-%1143 = OpVariable %_ptr_Function_ulong Function
-%1144 = OpVariable %_ptr_Function_ulong Function
-%1145 = OpVariable %_ptr_Function_ulong Function
-%1146 = OpVariable %_ptr_Function_ulong Function
-%1147 = OpVariable %_ptr_Function_ulong Function
-OpStore %1135 %1125
-OpStore %1136 %1126
-OpStore %1137 %1127
-OpStore %1138 %1128
-OpStore %1139 %1129
-OpBranch %1131
-%1131 = OpLabel
-OpBranch %1132
-%1132 = OpLabel
-%1148 = OpLoad %uchar %1136
-%1149 = OpUConvert %ulong %1148
-OpStore %1140 %1149
-%1150 = OpLoad %ulong %1135
-%1151 = OpLoad %ulong %1140
-%1152 = OpFunctionCall %ulong %22 %1150 %1151
-OpStore %1141 %1152
-%1153 = OpLoad %ushort %1137
-%1154 = OpSConvert %ulong %1153
-OpStore %1142 %1154
-%1155 = OpLoad %ulong %1141
-%1156 = OpLoad %ulong %1142
-%1157 = OpFunctionCall %ulong %22 %1155 %1156
-OpStore %1143 %1157
-%1158 = OpLoad %uint %1138
-%1159 = OpUConvert %ulong %1158
-OpStore %1144 %1159
-%1160 = OpLoad %ulong %1143
-%1161 = OpLoad %ulong %1144
-%1162 = OpFunctionCall %ulong %22 %1160 %1161
-OpStore %1145 %1162
-%1163 = OpLoad %ulong %1145
-%1164 = OpLoad %ulong %1139
-%1165 = OpFunctionCall %ulong %22 %1163 %1164
-OpStore %1146 %1165
-%1166 = OpLoad %ulong %1146
-%1167 = OpFunctionCall %ulong %22 %1166 %ulong_4
-OpStore %1147 %1167
-OpBranch %1133
-%1133 = OpLabel
-OpBranch %1134
-%1134 = OpLabel
-%1168 = OpLoad %ulong %1147
-OpReturnValue %1168
-OpFunctionEnd
-%14 = OpFunction %ulong None %1169
-%1170 = OpFunctionParameter %ulong
-%1171 = OpFunctionParameter %ulong
-%1172 = OpFunctionParameter %float
-%1173 = OpFunctionParameter %double
-%1174 = OpLabel
-%1179 = OpVariable %_ptr_Function_ulong Function
-%1180 = OpVariable %_ptr_Function_ulong Function
-%1181 = OpVariable %_ptr_Function_float Function
-%1182 = OpVariable %_ptr_Function_double Function
-%1183 = OpVariable %_ptr_Function_ulong Function
-%1184 = OpVariable %_ptr_Function_ulong Function
-%1185 = OpVariable %_ptr_Function_ulong Function
-%1186 = OpVariable %_ptr_Function_ulong Function
-OpStore %1179 %1170
-OpStore %1180 %1171
-OpStore %1181 %1172
-OpStore %1182 %1173
-OpBranch %1175
-%1175 = OpLabel
-OpBranch %1177
-%1177 = OpLabel
-%1187 = OpLoad %ulong %1179
-%1188 = OpLoad %ulong %1180
-%1189 = OpFunctionCall %ulong %22 %1187 %1188
-OpStore %1183 %1189
-%1190 = OpLoad %ulong %1183
-%1191 = OpLoad %float %1181
-%1192 = OpFunctionCall %ulong %23 %1190 %1191
-OpStore %1184 %1192
-%1193 = OpLoad %ulong %1184
-%1194 = OpLoad %double %1182
-%1195 = OpFunctionCall %ulong %24 %1193 %1194
-OpStore %1185 %1195
-%1196 = OpLoad %ulong %1185
-%1197 = OpFunctionCall %ulong %22 %1196 %ulong_3
-OpStore %1186 %1197
-OpBranch %1178
-%1178 = OpLabel
-OpBranch %1176
-%1176 = OpLabel
-%1198 = OpLoad %ulong %1186
-OpReturnValue %1198
-OpFunctionEnd
-%15 = OpFunction %ulong None %983
-%1199 = OpFunctionParameter %ulong
-%1200 = OpFunctionParameter %ulong
-%1201 = OpFunctionParameter %uchar
-%1202 = OpFunctionParameter %uint
-%1203 = OpFunctionParameter %ulong
-%1204 = OpFunctionParameter %ushort
-%1205 = OpLabel
-%1208 = OpVariable %_ptr_Function_ulong Function
-%1209 = OpVariable %_ptr_Function_ulong Function
-%1210 = OpVariable %_ptr_Function_uchar Function
-%1211 = OpVariable %_ptr_Function_uint Function
-%1212 = OpVariable %_ptr_Function_ulong Function
-%1213 = OpVariable %_ptr_Function_ushort Function
-%1214 = OpVariable %_ptr_Function_ulong Function
-%1215 = OpVariable %_ptr_Function_ulong Function
-%1216 = OpVariable %_ptr_Function_ulong Function
-%1217 = OpVariable %_ptr_Function_ulong Function
-%1218 = OpVariable %_ptr_Function_ulong Function
-%1219 = OpVariable %_ptr_Function_ulong Function
-%1220 = OpVariable %_ptr_Function_ulong Function
-%1221 = OpVariable %_ptr_Function_ulong Function
-%1222 = OpVariable %_ptr_Function_ulong Function
-%1223 = OpVariable %_ptr_Function_ulong Function
-%1224 = OpVariable %_ptr_Function_ulong Function
-%1225 = OpVariable %_ptr_Function_ulong Function
-%1226 = OpVariable %_ptr_Function_ulong Function
-%1227 = OpVariable %_ptr_Function_ulong Function
-OpStore %1208 %1199
-OpStore %1209 %1200
-OpStore %1210 %1201
-OpStore %1211 %1202
-OpStore %1212 %1203
-OpStore %1213 %1204
-%1228 = OpLoad %ulong %1209
-%1229 = OpIMul %ulong %1228 %ulong_3
-OpStore %1214 %1229
-OpBranch %1206
-%1206 = OpLabel
-%1230 = OpLoad %ulong %1208
-%1231 = OpLoad %ulong %1214
-%1232 = OpFunctionCall %ulong %22 %1230 %1231
-OpStore %1215 %1232
-%1233 = OpLoad %uchar %1210
-%1234 = OpUConvert %ulong %1233
-OpStore %1216 %1234
-%1235 = OpLoad %ulong %1216
-%1236 = OpLoad %ulong %1214
-%1237 = OpIAdd %ulong %1235 %1236
-OpStore %1217 %1237
-%1238 = OpLoad %ulong %1215
-%1239 = OpLoad %ulong %1217
-%1240 = OpFunctionCall %ulong %22 %1238 %1239
-OpStore %1218 %1240
-%1241 = OpLoad %uint %1211
-%1242 = OpUConvert %ulong %1241
-OpStore %1219 %1242
-%1243 = OpLoad %ulong %1219
-%1244 = OpLoad %ulong %1214
-%1245 = OpIAdd %ulong %1243 %1244
-OpStore %1220 %1245
-%1246 = OpLoad %ulong %1218
-%1247 = OpLoad %ulong %1220
-%1248 = OpFunctionCall %ulong %22 %1246 %1247
-OpStore %1221 %1248
-%1249 = OpLoad %ulong %1212
-%1250 = OpLoad %ulong %1214
-%1251 = OpIAdd %ulong %1249 %1250
-OpStore %1222 %1251
-%1252 = OpLoad %ulong %1221
-%1253 = OpLoad %ulong %1222
-%1254 = OpFunctionCall %ulong %22 %1252 %1253
-OpStore %1223 %1254
-%1255 = OpLoad %ushort %1213
-%1256 = OpUConvert %ulong %1255
-OpStore %1224 %1256
-%1257 = OpLoad %ulong %1224
-%1258 = OpLoad %ulong %1214
-%1259 = OpIAdd %ulong %1257 %1258
-OpStore %1225 %1259
-%1260 = OpLoad %ulong %1223
-%1261 = OpLoad %ulong %1225
-%1262 = OpFunctionCall %ulong %22 %1260 %1261
-OpStore %1226 %1262
-%1263 = OpLoad %ulong %1226
-%1264 = OpFunctionCall %ulong %22 %1263 %ulong_4
-OpStore %1227 %1264
-OpBranch %1207
-%1207 = OpLabel
-%1265 = OpLoad %ulong %1227
-OpReturnValue %1265
-OpFunctionEnd
-%16 = OpFunction %ulong None %26
-%1266 = OpFunctionParameter %ulong
-%1267 = OpFunctionParameter %ulong
-%1268 = OpLabel
-%1269 = OpVariable %_ptr_Function_ulong Function
+%5 = OpFunction %ulong None %43
+%1264 = OpFunctionParameter %ulong
+%1265 = OpLabel
 %1270 = OpVariable %_ptr_Function_ulong Function
 %1271 = OpVariable %_ptr_Function_ulong Function
-%1272 = OpVariable %_ptr_Function_ulong Function
-OpStore %1269 %1266
-OpStore %1270 %1267
-%1273 = OpLoad %ulong %1269
-%1274 = OpLoad %ulong %1270
-%1275 = OpFunctionCall %ulong %22 %1273 %1274
-OpStore %1271 %1275
-%1276 = OpLoad %ulong %1271
-%1277 = OpFunctionCall %ulong %22 %1276 %ulong_1
-OpStore %1272 %1277
-%1278 = OpLoad %ulong %1272
-OpReturnValue %1278
+OpStore %1270 %1264
+OpBranch %1266
+%1266 = OpLabel
+OpBranch %1267
+%1267 = OpLabel
+%1272 = OpLoad %ulong %1270
+%1273 = OpFunctionCall %ulong %21 %1272 %ulong_0
+OpStore %1271 %1273
+OpBranch %1268
+%1268 = OpLabel
+OpBranch %1269
+%1269 = OpLabel
+%1274 = OpLoad %ulong %1271
+OpReturnValue %1274
 OpFunctionEnd
-%17 = OpFunction %ulong None %1279
+%6 = OpFunction %ulong None %1275
+%1276 = OpFunctionParameter %ulong
+%1277 = OpFunctionParameter %uchar
+%1278 = OpFunctionParameter %ushort
+%1279 = OpFunctionParameter %uint
 %1280 = OpFunctionParameter %ulong
-%1281 = OpFunctionParameter %float
-%1282 = OpLabel
-%1283 = OpVariable %_ptr_Function_ulong Function
-%1284 = OpVariable %_ptr_Function_float Function
-%1285 = OpVariable %_ptr_Function_ulong Function
+%1281 = OpFunctionParameter %uchar
+%1282 = OpFunctionParameter %ushort
+%1283 = OpFunctionParameter %uint
+%1284 = OpFunctionParameter %ulong
+%1285 = OpLabel
 %1286 = OpVariable %_ptr_Function_ulong Function
-OpStore %1283 %1280
-OpStore %1284 %1281
-%1287 = OpLoad %ulong %1283
-%1288 = OpLoad %float %1284
-%1289 = OpFunctionCall %ulong %23 %1287 %1288
-OpStore %1285 %1289
-%1290 = OpLoad %ulong %1285
-%1291 = OpFunctionCall %ulong %22 %1290 %ulong_1
-OpStore %1286 %1291
-%1292 = OpLoad %ulong %1286
-OpReturnValue %1292
-OpFunctionEnd
-%18 = OpFunction %ulong None %1082
-%1293 = OpFunctionParameter %ulong
-%1294 = OpFunctionParameter %uchar
-%1295 = OpFunctionParameter %ushort
-%1296 = OpFunctionParameter %uint
-%1297 = OpFunctionParameter %ulong
-%1298 = OpLabel
+%1287 = OpVariable %_ptr_Function_uchar Function
+%1288 = OpVariable %_ptr_Function_ushort Function
+%1289 = OpVariable %_ptr_Function_uint Function
+%1290 = OpVariable %_ptr_Function_ulong Function
+%1291 = OpVariable %_ptr_Function_uchar Function
+%1292 = OpVariable %_ptr_Function_ushort Function
+%1293 = OpVariable %_ptr_Function_uint Function
+%1294 = OpVariable %_ptr_Function_ulong Function
+%1295 = OpVariable %_ptr_Function_ulong Function
+%1296 = OpVariable %_ptr_Function_ulong Function
+%1297 = OpVariable %_ptr_Function_ulong Function
+%1298 = OpVariable %_ptr_Function_ulong Function
 %1299 = OpVariable %_ptr_Function_ulong Function
-%1300 = OpVariable %_ptr_Function_uchar Function
-%1301 = OpVariable %_ptr_Function_ushort Function
-%1302 = OpVariable %_ptr_Function_uint Function
+%1300 = OpVariable %_ptr_Function_ulong Function
+%1301 = OpVariable %_ptr_Function_ulong Function
+%1302 = OpVariable %_ptr_Function_ulong Function
 %1303 = OpVariable %_ptr_Function_ulong Function
 %1304 = OpVariable %_ptr_Function_ulong Function
 %1305 = OpVariable %_ptr_Function_ulong Function
@@ -1796,321 +1887,1065 @@ OpFunctionEnd
 %1307 = OpVariable %_ptr_Function_ulong Function
 %1308 = OpVariable %_ptr_Function_ulong Function
 %1309 = OpVariable %_ptr_Function_ulong Function
-%1310 = OpVariable %_ptr_Function_ulong Function
-%1311 = OpVariable %_ptr_Function_ulong Function
-OpStore %1299 %1293
-OpStore %1300 %1294
-OpStore %1301 %1295
-OpStore %1302 %1296
-OpStore %1303 %1297
-%1312 = OpLoad %uchar %1300
-%1313 = OpUConvert %ulong %1312
-OpStore %1304 %1313
-%1314 = OpLoad %ulong %1299
-%1315 = OpLoad %ulong %1304
-%1316 = OpFunctionCall %ulong %22 %1314 %1315
-OpStore %1305 %1316
-%1317 = OpLoad %ushort %1301
-%1318 = OpSConvert %ulong %1317
-OpStore %1306 %1318
-%1319 = OpLoad %ulong %1305
-%1320 = OpLoad %ulong %1306
-%1321 = OpFunctionCall %ulong %22 %1319 %1320
-OpStore %1307 %1321
-%1322 = OpLoad %uint %1302
-%1323 = OpUConvert %ulong %1322
-OpStore %1308 %1323
-%1324 = OpLoad %ulong %1307
-%1325 = OpLoad %ulong %1308
-%1326 = OpFunctionCall %ulong %22 %1324 %1325
-OpStore %1309 %1326
-%1327 = OpLoad %ulong %1309
-%1328 = OpLoad %ulong %1303
-%1329 = OpFunctionCall %ulong %22 %1327 %1328
-OpStore %1310 %1329
-%1330 = OpLoad %ulong %1310
-%1331 = OpFunctionCall %ulong %22 %1330 %ulong_4
-OpStore %1311 %1331
-%1332 = OpLoad %ulong %1311
-OpReturnValue %1332
+OpStore %1286 %1276
+OpStore %1287 %1277
+OpStore %1288 %1278
+OpStore %1289 %1279
+OpStore %1290 %1280
+OpStore %1291 %1281
+OpStore %1292 %1282
+OpStore %1293 %1283
+OpStore %1294 %1284
+%1310 = OpLoad %uchar %1287
+%1311 = OpUConvert %ulong %1310
+OpStore %1295 %1311
+%1312 = OpLoad %ulong %1286
+%1313 = OpLoad %ulong %1295
+%1314 = OpFunctionCall %ulong %21 %1312 %1313
+OpStore %1296 %1314
+%1315 = OpLoad %ushort %1288
+%1316 = OpSConvert %ulong %1315
+OpStore %1297 %1316
+%1317 = OpLoad %ulong %1296
+%1318 = OpLoad %ulong %1297
+%1319 = OpFunctionCall %ulong %21 %1317 %1318
+OpStore %1298 %1319
+%1320 = OpLoad %uint %1289
+%1321 = OpUConvert %ulong %1320
+OpStore %1299 %1321
+%1322 = OpLoad %ulong %1298
+%1323 = OpLoad %ulong %1299
+%1324 = OpFunctionCall %ulong %21 %1322 %1323
+OpStore %1300 %1324
+%1325 = OpLoad %ulong %1300
+%1326 = OpLoad %ulong %1290
+%1327 = OpFunctionCall %ulong %21 %1325 %1326
+OpStore %1301 %1327
+%1328 = OpLoad %uchar %1291
+%1329 = OpUConvert %ulong %1328
+OpStore %1302 %1329
+%1330 = OpLoad %ulong %1301
+%1331 = OpLoad %ulong %1302
+%1332 = OpFunctionCall %ulong %21 %1330 %1331
+OpStore %1303 %1332
+%1333 = OpLoad %ushort %1292
+%1334 = OpUConvert %ulong %1333
+OpStore %1304 %1334
+%1335 = OpLoad %ulong %1303
+%1336 = OpLoad %ulong %1304
+%1337 = OpFunctionCall %ulong %21 %1335 %1336
+OpStore %1305 %1337
+%1338 = OpLoad %uint %1293
+%1339 = OpSConvert %ulong %1338
+OpStore %1306 %1339
+%1340 = OpLoad %ulong %1305
+%1341 = OpLoad %ulong %1306
+%1342 = OpFunctionCall %ulong %21 %1340 %1341
+OpStore %1307 %1342
+%1343 = OpLoad %ulong %1307
+%1344 = OpLoad %ulong %1294
+%1345 = OpFunctionCall %ulong %21 %1343 %1344
+OpStore %1308 %1345
+%1346 = OpLoad %ulong %1308
+%1347 = OpFunctionCall %ulong %21 %1346 %ulong_8
+OpStore %1309 %1347
+%1348 = OpLoad %ulong %1309
+OpReturnValue %1348
 OpFunctionEnd
-%19 = OpFunction %ulong None %1169
-%1333 = OpFunctionParameter %ulong
-%1334 = OpFunctionParameter %ulong
-%1335 = OpFunctionParameter %float
-%1336 = OpFunctionParameter %double
-%1337 = OpLabel
-%1340 = OpVariable %_ptr_Function_ulong Function
-%1341 = OpVariable %_ptr_Function_ulong Function
-%1342 = OpVariable %_ptr_Function_float Function
-%1343 = OpVariable %_ptr_Function_double Function
-%1344 = OpVariable %_ptr_Function_ulong Function
-%1345 = OpVariable %_ptr_Function_ulong Function
-%1346 = OpVariable %_ptr_Function_ulong Function
-%1347 = OpVariable %_ptr_Function_ulong Function
-OpStore %1340 %1333
-OpStore %1341 %1334
-OpStore %1342 %1335
-OpStore %1343 %1336
-OpBranch %1338
-%1338 = OpLabel
-%1348 = OpLoad %ulong %1340
-%1349 = OpLoad %ulong %1341
-%1350 = OpFunctionCall %ulong %22 %1348 %1349
-OpStore %1344 %1350
-%1351 = OpLoad %ulong %1344
-%1352 = OpLoad %float %1342
-%1353 = OpFunctionCall %ulong %23 %1351 %1352
-OpStore %1345 %1353
-%1354 = OpLoad %ulong %1345
-%1355 = OpLoad %double %1343
-%1356 = OpFunctionCall %ulong %24 %1354 %1355
-OpStore %1346 %1356
-%1357 = OpLoad %ulong %1346
-%1358 = OpFunctionCall %ulong %22 %1357 %ulong_3
-OpStore %1347 %1358
-OpBranch %1339
-%1339 = OpLabel
-%1359 = OpLoad %ulong %1347
-OpReturnValue %1359
-OpFunctionEnd
-%20 = OpFunction %ulong None %1169
+%7 = OpFunction %ulong None %1349
+%1350 = OpFunctionParameter %ulong
+%1351 = OpFunctionParameter %ulong
+%1352 = OpFunctionParameter %ulong
+%1353 = OpFunctionParameter %ulong
+%1354 = OpFunctionParameter %ulong
+%1355 = OpFunctionParameter %ulong
+%1356 = OpFunctionParameter %ulong
+%1357 = OpFunctionParameter %ulong
+%1358 = OpFunctionParameter %ulong
+%1359 = OpFunctionParameter %ulong
 %1360 = OpFunctionParameter %ulong
 %1361 = OpFunctionParameter %ulong
-%1362 = OpFunctionParameter %float
-%1363 = OpFunctionParameter %double
-%1364 = OpLabel
+%1362 = OpFunctionParameter %ulong
+%1363 = OpLabel
+%1364 = OpVariable %_ptr_Function_ulong Function
 %1365 = OpVariable %_ptr_Function_ulong Function
 %1366 = OpVariable %_ptr_Function_ulong Function
-%1367 = OpVariable %_ptr_Function_float Function
-%1368 = OpVariable %_ptr_Function_double Function
+%1367 = OpVariable %_ptr_Function_ulong Function
+%1368 = OpVariable %_ptr_Function_ulong Function
 %1369 = OpVariable %_ptr_Function_ulong Function
 %1370 = OpVariable %_ptr_Function_ulong Function
 %1371 = OpVariable %_ptr_Function_ulong Function
 %1372 = OpVariable %_ptr_Function_ulong Function
-OpStore %1365 %1360
-OpStore %1366 %1361
-OpStore %1367 %1362
-OpStore %1368 %1363
-%1373 = OpLoad %ulong %1365
-%1374 = OpLoad %ulong %1366
-%1375 = OpFunctionCall %ulong %22 %1373 %1374
-OpStore %1369 %1375
-%1376 = OpLoad %ulong %1369
-%1377 = OpLoad %float %1367
-%1378 = OpFunctionCall %ulong %23 %1376 %1377
-OpStore %1370 %1378
-%1379 = OpLoad %ulong %1370
-%1380 = OpLoad %double %1368
-%1381 = OpFunctionCall %ulong %24 %1379 %1380
-OpStore %1371 %1381
-%1382 = OpLoad %ulong %1371
-%1383 = OpFunctionCall %ulong %22 %1382 %ulong_3
-OpStore %1372 %1383
-%1384 = OpLoad %ulong %1372
-OpReturnValue %1384
+%1373 = OpVariable %_ptr_Function_ulong Function
+%1374 = OpVariable %_ptr_Function_ulong Function
+%1375 = OpVariable %_ptr_Function_ulong Function
+%1376 = OpVariable %_ptr_Function_ulong Function
+%1377 = OpVariable %_ptr_Function_ulong Function
+%1378 = OpVariable %_ptr_Function_ulong Function
+%1379 = OpVariable %_ptr_Function_ulong Function
+%1380 = OpVariable %_ptr_Function_ulong Function
+%1381 = OpVariable %_ptr_Function_ulong Function
+%1382 = OpVariable %_ptr_Function_ulong Function
+%1383 = OpVariable %_ptr_Function_ulong Function
+%1384 = OpVariable %_ptr_Function_ulong Function
+%1385 = OpVariable %_ptr_Function_ulong Function
+%1386 = OpVariable %_ptr_Function_ulong Function
+%1387 = OpVariable %_ptr_Function_ulong Function
+%1388 = OpVariable %_ptr_Function_ulong Function
+%1389 = OpVariable %_ptr_Function_ulong Function
+OpStore %1364 %1350
+OpStore %1365 %1351
+OpStore %1366 %1352
+OpStore %1367 %1353
+OpStore %1368 %1354
+OpStore %1369 %1355
+OpStore %1370 %1356
+OpStore %1371 %1357
+OpStore %1372 %1358
+OpStore %1373 %1359
+OpStore %1374 %1360
+OpStore %1375 %1361
+OpStore %1376 %1362
+%1390 = OpLoad %ulong %1364
+%1391 = OpLoad %ulong %1365
+%1392 = OpFunctionCall %ulong %21 %1390 %1391
+OpStore %1377 %1392
+%1393 = OpLoad %ulong %1377
+%1394 = OpLoad %ulong %1366
+%1395 = OpFunctionCall %ulong %21 %1393 %1394
+OpStore %1378 %1395
+%1396 = OpLoad %ulong %1378
+%1397 = OpLoad %ulong %1367
+%1398 = OpFunctionCall %ulong %21 %1396 %1397
+OpStore %1379 %1398
+%1399 = OpLoad %ulong %1379
+%1400 = OpLoad %ulong %1368
+%1401 = OpFunctionCall %ulong %21 %1399 %1400
+OpStore %1380 %1401
+%1402 = OpLoad %ulong %1380
+%1403 = OpLoad %ulong %1369
+%1404 = OpFunctionCall %ulong %21 %1402 %1403
+OpStore %1381 %1404
+%1405 = OpLoad %ulong %1381
+%1406 = OpLoad %ulong %1370
+%1407 = OpFunctionCall %ulong %21 %1405 %1406
+OpStore %1382 %1407
+%1408 = OpLoad %ulong %1382
+%1409 = OpLoad %ulong %1371
+%1410 = OpFunctionCall %ulong %21 %1408 %1409
+OpStore %1383 %1410
+%1411 = OpLoad %ulong %1383
+%1412 = OpLoad %ulong %1372
+%1413 = OpFunctionCall %ulong %21 %1411 %1412
+OpStore %1384 %1413
+%1414 = OpLoad %ulong %1384
+%1415 = OpLoad %ulong %1373
+%1416 = OpFunctionCall %ulong %21 %1414 %1415
+OpStore %1385 %1416
+%1417 = OpLoad %ulong %1385
+%1418 = OpLoad %ulong %1374
+%1419 = OpFunctionCall %ulong %21 %1417 %1418
+OpStore %1386 %1419
+%1420 = OpLoad %ulong %1386
+%1421 = OpLoad %ulong %1375
+%1422 = OpFunctionCall %ulong %21 %1420 %1421
+OpStore %1387 %1422
+%1423 = OpLoad %ulong %1387
+%1424 = OpLoad %ulong %1376
+%1425 = OpFunctionCall %ulong %21 %1423 %1424
+OpStore %1388 %1425
+%1426 = OpLoad %ulong %1388
+%1427 = OpFunctionCall %ulong %21 %1426 %ulong_12
+OpStore %1389 %1427
+%1428 = OpLoad %ulong %1389
+OpReturnValue %1428
 OpFunctionEnd
-%21 = OpFunction %ulong None %1385
-%1386 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%22 = OpFunction %ulong None %26
-%1388 = OpFunctionParameter %ulong
-%1389 = OpFunctionParameter %ulong
-%1390 = OpLabel
-%1395 = OpVariable %_ptr_Function_ulong Function
-%1396 = OpVariable %_ptr_Function_ulong Function
-%1397 = OpVariable %_ptr_Function_bool Function
-%1398 = OpVariable %_ptr_Function_ulong Function
-%1399 = OpVariable %_ptr_Function_ulong Function
-%1400 = OpVariable %_ptr_Function_ulong Function
-%1401 = OpVariable %_ptr_Function_ulong Function
-%1402 = OpVariable %_ptr_Function_ulong Function
-%1403 = OpVariable %_ptr_Function_ulong Function
-%1404 = OpVariable %_ptr_Function_ulong Function
-%1405 = OpVariable %_ptr_Function_ulong Function
-OpStore %1395 %1388
-OpStore %1396 %1389
-%1406 = OpLoad %ulong %1395
-OpStore %1404 %1406
-OpStore %1405 %ulong_0
-OpBranch %1391
-%1391 = OpLabel
-%1407 = OpLoad %ulong %1405
-%1408 = OpULessThan %bool %1407 %ulong_8
-OpStore %1397 %1408
-%1409 = OpLoad %bool %1397
-OpLoopMerge %1393 %1394 None
-OpBranchConditional %1409 %1392 %1393
-%1393 = OpLabel
-%1410 = OpLoad %ulong %1404
-OpReturnValue %1410
-%1392 = OpLabel
-%1411 = OpLoad %ulong %1405
-%1412 = OpIMul %ulong %1411 %ulong_8
-OpStore %1398 %1412
-%1413 = OpLoad %ulong %1396
-%1414 = OpLoad %ulong %1398
-%1415 = OpShiftRightLogical %ulong %1413 %1414
-OpStore %1399 %1415
-%1416 = OpLoad %ulong %1399
-%1417 = OpBitwiseAnd %ulong %1416 %ulong_255
-OpStore %1400 %1417
-%1418 = OpLoad %ulong %1404
-%1419 = OpLoad %ulong %1400
-%1420 = OpBitwiseXor %ulong %1418 %1419
-OpStore %1401 %1420
-%1421 = OpLoad %ulong %1401
-%1423 = OpIMul %ulong %1421 %ulong_1099511628211
-OpStore %1402 %1423
-%1424 = OpLoad %ulong %1405
-%1425 = OpIAdd %ulong %1424 %ulong_1
-OpStore %1403 %1425
-%1426 = OpLoad %ulong %1402
-OpStore %1404 %1426
-%1427 = OpLoad %ulong %1403
-OpStore %1405 %1427
-OpBranch %1394
-%1394 = OpLabel
-OpBranch %1391
-OpFunctionEnd
-%23 = OpFunction %ulong None %1279
-%1428 = OpFunctionParameter %ulong
-%1429 = OpFunctionParameter %float
-%1430 = OpLabel
-%1437 = OpVariable %_ptr_Function_ulong Function
-%1438 = OpVariable %_ptr_Function_float Function
-%1439 = OpVariable %_ptr_Function_uint Function
-%1440 = OpVariable %_ptr_Function_ulong Function
-%1441 = OpVariable %_ptr_Function_bool Function
-%1442 = OpVariable %_ptr_Function_ulong Function
-%1443 = OpVariable %_ptr_Function_ulong Function
-%1444 = OpVariable %_ptr_Function_ulong Function
-%1445 = OpVariable %_ptr_Function_ulong Function
-%1446 = OpVariable %_ptr_Function_ulong Function
-%1447 = OpVariable %_ptr_Function_ulong Function
-%1448 = OpVariable %_ptr_Function_ulong Function
-%1449 = OpVariable %_ptr_Function_ulong Function
-OpStore %1437 %1428
-OpStore %1438 %1429
-%1450 = OpLoad %float %1438
-%1451 = OpBitcast %uint %1450
-OpStore %1439 %1451
-%1452 = OpLoad %uint %1439
-%1453 = OpUConvert %ulong %1452
-OpStore %1440 %1453
-OpBranch %1431
-%1431 = OpLabel
-%1454 = OpLoad %ulong %1437
-OpStore %1448 %1454
-OpStore %1449 %ulong_0
-OpBranch %1432
-%1432 = OpLabel
-%1455 = OpLoad %ulong %1449
-%1456 = OpULessThan %bool %1455 %ulong_8
-OpStore %1441 %1456
-%1457 = OpLoad %bool %1441
-OpLoopMerge %1434 %1436 None
-OpBranchConditional %1457 %1433 %1434
-%1434 = OpLabel
-OpBranch %1435
+%8 = OpFunction %ulong None %1429
+%1430 = OpFunctionParameter %ulong
+%1431 = OpFunctionParameter %float
+%1432 = OpFunctionParameter %double
+%1433 = OpFunctionParameter %float
+%1434 = OpFunctionParameter %double
 %1435 = OpLabel
-%1458 = OpLoad %ulong %1448
-OpReturnValue %1458
-%1433 = OpLabel
-%1459 = OpLoad %ulong %1449
-%1460 = OpIMul %ulong %1459 %ulong_8
-OpStore %1442 %1460
-%1461 = OpLoad %ulong %1440
-%1462 = OpLoad %ulong %1442
-%1463 = OpShiftRightLogical %ulong %1461 %1462
-OpStore %1443 %1463
-%1464 = OpLoad %ulong %1443
-%1465 = OpBitwiseAnd %ulong %1464 %ulong_255
-OpStore %1444 %1465
-%1466 = OpLoad %ulong %1448
-%1467 = OpLoad %ulong %1444
-%1468 = OpBitwiseXor %ulong %1466 %1467
-OpStore %1445 %1468
-%1469 = OpLoad %ulong %1445
-%1470 = OpIMul %ulong %1469 %ulong_1099511628211
-OpStore %1446 %1470
-%1471 = OpLoad %ulong %1449
-%1472 = OpIAdd %ulong %1471 %ulong_1
-OpStore %1447 %1472
-%1473 = OpLoad %ulong %1446
-OpStore %1448 %1473
-%1474 = OpLoad %ulong %1447
-OpStore %1449 %1474
+%1444 = OpVariable %_ptr_Function_ulong Function
+%1445 = OpVariable %_ptr_Function_float Function
+%1446 = OpVariable %_ptr_Function_double Function
+%1447 = OpVariable %_ptr_Function_float Function
+%1448 = OpVariable %_ptr_Function_double Function
+%1449 = OpVariable %_ptr_Function_ulong Function
+%1450 = OpVariable %_ptr_Function_uint Function
+%1451 = OpVariable %_ptr_Function_ulong Function
+%1452 = OpVariable %_ptr_Function_ulong Function
+%1453 = OpVariable %_ptr_Function_ulong Function
+%1454 = OpVariable %_ptr_Function_ulong Function
+%1455 = OpVariable %_ptr_Function_uint Function
+%1456 = OpVariable %_ptr_Function_ulong Function
+%1457 = OpVariable %_ptr_Function_ulong Function
+%1458 = OpVariable %_ptr_Function_ulong Function
+%1459 = OpVariable %_ptr_Function_ulong Function
+OpStore %1444 %1430
+OpStore %1445 %1431
+OpStore %1446 %1432
+OpStore %1447 %1433
+OpStore %1448 %1434
 OpBranch %1436
 %1436 = OpLabel
-OpBranch %1432
+%1460 = OpLoad %float %1445
+%1461 = OpBitcast %uint %1460
+OpStore %1450 %1461
+%1462 = OpLoad %uint %1450
+%1463 = OpUConvert %ulong %1462
+OpStore %1451 %1463
+%1464 = OpLoad %ulong %1444
+%1465 = OpLoad %ulong %1451
+%1466 = OpFunctionCall %ulong %21 %1464 %1465
+OpStore %1452 %1466
+OpBranch %1437
+%1437 = OpLabel
+OpBranch %1438
+%1438 = OpLabel
+%1467 = OpLoad %double %1446
+%1468 = OpBitcast %ulong %1467
+OpStore %1453 %1468
+%1469 = OpLoad %ulong %1452
+%1470 = OpLoad %ulong %1453
+%1471 = OpFunctionCall %ulong %21 %1469 %1470
+OpStore %1454 %1471
+OpBranch %1439
+%1439 = OpLabel
+OpBranch %1440
+%1440 = OpLabel
+%1472 = OpLoad %float %1447
+%1473 = OpBitcast %uint %1472
+OpStore %1455 %1473
+%1474 = OpLoad %uint %1455
+%1475 = OpUConvert %ulong %1474
+OpStore %1456 %1475
+%1476 = OpLoad %ulong %1454
+%1477 = OpLoad %ulong %1456
+%1478 = OpFunctionCall %ulong %21 %1476 %1477
+OpStore %1457 %1478
+OpBranch %1441
+%1441 = OpLabel
+OpBranch %1442
+%1442 = OpLabel
+%1479 = OpLoad %double %1448
+%1480 = OpBitcast %ulong %1479
+OpStore %1458 %1480
+%1481 = OpLoad %ulong %1457
+%1482 = OpLoad %ulong %1458
+%1483 = OpFunctionCall %ulong %21 %1481 %1482
+OpStore %1459 %1483
+OpBranch %1443
+%1443 = OpLabel
+%1484 = OpLoad %ulong %1459
+%1485 = OpFunctionCall %ulong %21 %1484 %ulong_4
+OpStore %1449 %1485
+%1486 = OpLoad %ulong %1449
+OpReturnValue %1486
 OpFunctionEnd
-%24 = OpFunction %ulong None %1475
-%1476 = OpFunctionParameter %ulong
-%1477 = OpFunctionParameter %double
-%1478 = OpLabel
-%1485 = OpVariable %_ptr_Function_ulong Function
-%1486 = OpVariable %_ptr_Function_double Function
-%1487 = OpVariable %_ptr_Function_ulong Function
-%1488 = OpVariable %_ptr_Function_bool Function
-%1489 = OpVariable %_ptr_Function_ulong Function
-%1490 = OpVariable %_ptr_Function_ulong Function
-%1491 = OpVariable %_ptr_Function_ulong Function
-%1492 = OpVariable %_ptr_Function_ulong Function
-%1493 = OpVariable %_ptr_Function_ulong Function
-%1494 = OpVariable %_ptr_Function_ulong Function
-%1495 = OpVariable %_ptr_Function_ulong Function
-%1496 = OpVariable %_ptr_Function_ulong Function
-OpStore %1485 %1476
-OpStore %1486 %1477
-%1497 = OpLoad %double %1486
-%1498 = OpBitcast %ulong %1497
-OpStore %1487 %1498
-OpBranch %1479
-%1479 = OpLabel
-%1499 = OpLoad %ulong %1485
-OpStore %1495 %1499
-OpStore %1496 %ulong_0
-OpBranch %1480
-%1480 = OpLabel
-%1500 = OpLoad %ulong %1496
-%1501 = OpULessThan %bool %1500 %ulong_8
-OpStore %1488 %1501
-%1502 = OpLoad %bool %1488
-OpLoopMerge %1482 %1484 None
-OpBranchConditional %1502 %1481 %1482
-%1482 = OpLabel
-OpBranch %1483
-%1483 = OpLabel
-%1503 = OpLoad %ulong %1495
-OpReturnValue %1503
-%1481 = OpLabel
-%1504 = OpLoad %ulong %1496
-%1505 = OpIMul %ulong %1504 %ulong_8
-OpStore %1489 %1505
-%1506 = OpLoad %ulong %1487
-%1507 = OpLoad %ulong %1489
-%1508 = OpShiftRightLogical %ulong %1506 %1507
-OpStore %1490 %1508
-%1509 = OpLoad %ulong %1490
-%1510 = OpBitwiseAnd %ulong %1509 %ulong_255
-OpStore %1491 %1510
-%1511 = OpLoad %ulong %1495
-%1512 = OpLoad %ulong %1491
-%1513 = OpBitwiseXor %ulong %1511 %1512
-OpStore %1492 %1513
-%1514 = OpLoad %ulong %1492
-%1515 = OpIMul %ulong %1514 %ulong_1099511628211
-OpStore %1493 %1515
-%1516 = OpLoad %ulong %1496
-%1517 = OpIAdd %ulong %1516 %ulong_1
-OpStore %1494 %1517
-%1518 = OpLoad %ulong %1493
-OpStore %1495 %1518
-%1519 = OpLoad %ulong %1494
-OpStore %1496 %1519
-OpBranch %1484
-%1484 = OpLabel
-OpBranch %1480
+%9 = OpFunction %ulong None %1487
+%1488 = OpFunctionParameter %ulong
+%1489 = OpFunctionParameter %ulong
+%1490 = OpFunctionParameter %float
+%1491 = OpFunctionParameter %uint
+%1492 = OpFunctionParameter %double
+%1493 = OpFunctionParameter %ushort
+%1494 = OpFunctionParameter %ulong
+%1495 = OpLabel
+%1500 = OpVariable %_ptr_Function_ulong Function
+%1501 = OpVariable %_ptr_Function_ulong Function
+%1502 = OpVariable %_ptr_Function_float Function
+%1503 = OpVariable %_ptr_Function_uint Function
+%1504 = OpVariable %_ptr_Function_double Function
+%1505 = OpVariable %_ptr_Function_ushort Function
+%1506 = OpVariable %_ptr_Function_ulong Function
+%1507 = OpVariable %_ptr_Function_ulong Function
+%1508 = OpVariable %_ptr_Function_ulong Function
+%1509 = OpVariable %_ptr_Function_ulong Function
+%1510 = OpVariable %_ptr_Function_ulong Function
+%1511 = OpVariable %_ptr_Function_ulong Function
+%1512 = OpVariable %_ptr_Function_ulong Function
+%1513 = OpVariable %_ptr_Function_ulong Function
+%1514 = OpVariable %_ptr_Function_uint Function
+%1515 = OpVariable %_ptr_Function_ulong Function
+%1516 = OpVariable %_ptr_Function_ulong Function
+%1517 = OpVariable %_ptr_Function_ulong Function
+%1518 = OpVariable %_ptr_Function_ulong Function
+OpStore %1500 %1488
+OpStore %1501 %1489
+OpStore %1502 %1490
+OpStore %1503 %1491
+OpStore %1504 %1492
+OpStore %1505 %1493
+OpStore %1506 %1494
+%1519 = OpLoad %ulong %1500
+%1520 = OpLoad %ulong %1501
+%1521 = OpFunctionCall %ulong %21 %1519 %1520
+OpStore %1507 %1521
+OpBranch %1496
+%1496 = OpLabel
+%1522 = OpLoad %float %1502
+%1523 = OpBitcast %uint %1522
+OpStore %1514 %1523
+%1524 = OpLoad %uint %1514
+%1525 = OpUConvert %ulong %1524
+OpStore %1515 %1525
+%1526 = OpLoad %ulong %1507
+%1527 = OpLoad %ulong %1515
+%1528 = OpFunctionCall %ulong %21 %1526 %1527
+OpStore %1516 %1528
+OpBranch %1497
+%1497 = OpLabel
+%1529 = OpLoad %uint %1503
+%1530 = OpUConvert %ulong %1529
+OpStore %1508 %1530
+%1531 = OpLoad %ulong %1516
+%1532 = OpLoad %ulong %1508
+%1533 = OpFunctionCall %ulong %21 %1531 %1532
+OpStore %1509 %1533
+OpBranch %1498
+%1498 = OpLabel
+%1534 = OpLoad %double %1504
+%1535 = OpBitcast %ulong %1534
+OpStore %1517 %1535
+%1536 = OpLoad %ulong %1509
+%1537 = OpLoad %ulong %1517
+%1538 = OpFunctionCall %ulong %21 %1536 %1537
+OpStore %1518 %1538
+OpBranch %1499
+%1499 = OpLabel
+%1539 = OpLoad %ushort %1505
+%1540 = OpSConvert %ulong %1539
+OpStore %1510 %1540
+%1541 = OpLoad %ulong %1518
+%1542 = OpLoad %ulong %1510
+%1543 = OpFunctionCall %ulong %21 %1541 %1542
+OpStore %1511 %1543
+%1544 = OpLoad %ulong %1511
+%1545 = OpLoad %ulong %1506
+%1546 = OpFunctionCall %ulong %21 %1544 %1545
+OpStore %1512 %1546
+%1547 = OpLoad %ulong %1512
+%1548 = OpFunctionCall %ulong %21 %1547 %ulong_6
+OpStore %1513 %1548
+%1549 = OpLoad %ulong %1513
+OpReturnValue %1549
+OpFunctionEnd
+%10 = OpFunction %ulong None %1550
+%1551 = OpFunctionParameter %ulong
+%1552 = OpFunctionParameter %ulong
+%1553 = OpFunctionParameter %uchar
+%1554 = OpFunctionParameter %uint
+%1555 = OpFunctionParameter %ulong
+%1556 = OpFunctionParameter %ushort
+%1557 = OpLabel
+%1558 = OpVariable %_ptr_Function_ulong Function
+%1559 = OpVariable %_ptr_Function_ulong Function
+%1560 = OpVariable %_ptr_Function_uchar Function
+%1561 = OpVariable %_ptr_Function_uint Function
+%1562 = OpVariable %_ptr_Function_ulong Function
+%1563 = OpVariable %_ptr_Function_ushort Function
+%1564 = OpVariable %_ptr_Function_ulong Function
+%1565 = OpVariable %_ptr_Function_ulong Function
+%1566 = OpVariable %_ptr_Function_ulong Function
+%1567 = OpVariable %_ptr_Function_ulong Function
+%1568 = OpVariable %_ptr_Function_ulong Function
+%1569 = OpVariable %_ptr_Function_ulong Function
+%1570 = OpVariable %_ptr_Function_ulong Function
+%1571 = OpVariable %_ptr_Function_ulong Function
+%1572 = OpVariable %_ptr_Function_ulong Function
+%1573 = OpVariable %_ptr_Function_ulong Function
+%1574 = OpVariable %_ptr_Function_ulong Function
+%1575 = OpVariable %_ptr_Function_ulong Function
+%1576 = OpVariable %_ptr_Function_ulong Function
+OpStore %1558 %1551
+OpStore %1559 %1552
+OpStore %1560 %1553
+OpStore %1561 %1554
+OpStore %1562 %1555
+OpStore %1563 %1556
+%1577 = OpLoad %ulong %1558
+%1578 = OpLoad %ulong %1559
+%1579 = OpFunctionCall %ulong %21 %1577 %1578
+OpStore %1564 %1579
+%1580 = OpLoad %uchar %1560
+%1581 = OpUConvert %ulong %1580
+OpStore %1565 %1581
+%1582 = OpLoad %ulong %1565
+%1583 = OpLoad %ulong %1559
+%1584 = OpIAdd %ulong %1582 %1583
+OpStore %1566 %1584
+%1585 = OpLoad %ulong %1564
+%1586 = OpLoad %ulong %1566
+%1587 = OpFunctionCall %ulong %21 %1585 %1586
+OpStore %1567 %1587
+%1588 = OpLoad %uint %1561
+%1589 = OpUConvert %ulong %1588
+OpStore %1568 %1589
+%1590 = OpLoad %ulong %1568
+%1591 = OpLoad %ulong %1559
+%1592 = OpIAdd %ulong %1590 %1591
+OpStore %1569 %1592
+%1593 = OpLoad %ulong %1567
+%1594 = OpLoad %ulong %1569
+%1595 = OpFunctionCall %ulong %21 %1593 %1594
+OpStore %1570 %1595
+%1596 = OpLoad %ulong %1562
+%1597 = OpLoad %ulong %1559
+%1598 = OpIAdd %ulong %1596 %1597
+OpStore %1571 %1598
+%1599 = OpLoad %ulong %1570
+%1600 = OpLoad %ulong %1571
+%1601 = OpFunctionCall %ulong %21 %1599 %1600
+OpStore %1572 %1601
+%1602 = OpLoad %ushort %1563
+%1603 = OpUConvert %ulong %1602
+OpStore %1573 %1603
+%1604 = OpLoad %ulong %1573
+%1605 = OpLoad %ulong %1559
+%1606 = OpIAdd %ulong %1604 %1605
+OpStore %1574 %1606
+%1607 = OpLoad %ulong %1572
+%1608 = OpLoad %ulong %1574
+%1609 = OpFunctionCall %ulong %21 %1607 %1608
+OpStore %1575 %1609
+%1610 = OpLoad %ulong %1575
+%1611 = OpFunctionCall %ulong %21 %1610 %ulong_4
+OpStore %1576 %1611
+%1612 = OpLoad %ulong %1576
+OpReturnValue %1612
+OpFunctionEnd
+%11 = OpFunction %ulong None %1613
+%1614 = OpFunctionParameter %ulong
+%1615 = OpFunctionParameter %ulong
+%1616 = OpFunctionParameter %float
+%1617 = OpFunctionParameter %ulong
+%1618 = OpFunctionParameter %double
+%1619 = OpLabel
+%1624 = OpVariable %_ptr_Function_ulong Function
+%1625 = OpVariable %_ptr_Function_ulong Function
+%1626 = OpVariable %_ptr_Function_float Function
+%1627 = OpVariable %_ptr_Function_ulong Function
+%1628 = OpVariable %_ptr_Function_double Function
+%1629 = OpVariable %_ptr_Function_ulong Function
+%1630 = OpVariable %_ptr_Function_ulong Function
+%1631 = OpVariable %_ptr_Function_ulong Function
+%1632 = OpVariable %_ptr_Function_ulong Function
+%1633 = OpVariable %_ptr_Function_uint Function
+%1634 = OpVariable %_ptr_Function_ulong Function
+%1635 = OpVariable %_ptr_Function_ulong Function
+%1636 = OpVariable %_ptr_Function_ulong Function
+%1637 = OpVariable %_ptr_Function_ulong Function
+OpStore %1624 %1614
+OpStore %1625 %1615
+OpStore %1626 %1616
+OpStore %1627 %1617
+OpStore %1628 %1618
+%1638 = OpLoad %ulong %1624
+%1639 = OpLoad %ulong %1625
+%1640 = OpFunctionCall %ulong %21 %1638 %1639
+OpStore %1629 %1640
+OpBranch %1620
+%1620 = OpLabel
+%1641 = OpLoad %float %1626
+%1642 = OpBitcast %uint %1641
+OpStore %1633 %1642
+%1643 = OpLoad %uint %1633
+%1644 = OpUConvert %ulong %1643
+OpStore %1634 %1644
+%1645 = OpLoad %ulong %1629
+%1646 = OpLoad %ulong %1634
+%1647 = OpFunctionCall %ulong %21 %1645 %1646
+OpStore %1635 %1647
+OpBranch %1621
+%1621 = OpLabel
+%1648 = OpLoad %ulong %1627
+%1649 = OpLoad %ulong %1625
+%1650 = OpIAdd %ulong %1648 %1649
+OpStore %1630 %1650
+%1651 = OpLoad %ulong %1635
+%1652 = OpLoad %ulong %1630
+%1653 = OpFunctionCall %ulong %21 %1651 %1652
+OpStore %1631 %1653
+OpBranch %1622
+%1622 = OpLabel
+%1654 = OpLoad %double %1628
+%1655 = OpBitcast %ulong %1654
+OpStore %1636 %1655
+%1656 = OpLoad %ulong %1631
+%1657 = OpLoad %ulong %1636
+%1658 = OpFunctionCall %ulong %21 %1656 %1657
+OpStore %1637 %1658
+OpBranch %1623
+%1623 = OpLabel
+%1659 = OpLoad %ulong %1637
+%1660 = OpFunctionCall %ulong %21 %1659 %ulong_3
+OpStore %1632 %1660
+%1661 = OpLoad %ulong %1632
+OpReturnValue %1661
+OpFunctionEnd
+%12 = OpFunction %ulong None %1662
+%1663 = OpFunctionParameter %ulong
+%1664 = OpFunctionParameter %uchar
+%1665 = OpFunctionParameter %ushort
+%1666 = OpFunctionParameter %uint
+%1667 = OpFunctionParameter %ulong
+%1668 = OpLabel
+%1671 = OpVariable %_ptr_Function_ulong Function
+%1672 = OpVariable %_ptr_Function_uchar Function
+%1673 = OpVariable %_ptr_Function_ushort Function
+%1674 = OpVariable %_ptr_Function_uint Function
+%1675 = OpVariable %_ptr_Function_ulong Function
+%1676 = OpVariable %_ptr_Function_ulong Function
+%1677 = OpVariable %_ptr_Function_ulong Function
+%1678 = OpVariable %_ptr_Function_ulong Function
+%1679 = OpVariable %_ptr_Function_ulong Function
+%1680 = OpVariable %_ptr_Function_ulong Function
+%1681 = OpVariable %_ptr_Function_ulong Function
+%1682 = OpVariable %_ptr_Function_ulong Function
+%1683 = OpVariable %_ptr_Function_ulong Function
+OpStore %1671 %1663
+OpStore %1672 %1664
+OpStore %1673 %1665
+OpStore %1674 %1666
+OpStore %1675 %1667
+OpBranch %1669
+%1669 = OpLabel
+%1684 = OpLoad %uchar %1672
+%1685 = OpUConvert %ulong %1684
+OpStore %1676 %1685
+%1686 = OpLoad %ulong %1671
+%1687 = OpLoad %ulong %1676
+%1688 = OpFunctionCall %ulong %21 %1686 %1687
+OpStore %1677 %1688
+%1689 = OpLoad %ushort %1673
+%1690 = OpSConvert %ulong %1689
+OpStore %1678 %1690
+%1691 = OpLoad %ulong %1677
+%1692 = OpLoad %ulong %1678
+%1693 = OpFunctionCall %ulong %21 %1691 %1692
+OpStore %1679 %1693
+%1694 = OpLoad %uint %1674
+%1695 = OpUConvert %ulong %1694
+OpStore %1680 %1695
+%1696 = OpLoad %ulong %1679
+%1697 = OpLoad %ulong %1680
+%1698 = OpFunctionCall %ulong %21 %1696 %1697
+OpStore %1681 %1698
+%1699 = OpLoad %ulong %1681
+%1700 = OpLoad %ulong %1675
+%1701 = OpFunctionCall %ulong %21 %1699 %1700
+OpStore %1682 %1701
+%1702 = OpLoad %ulong %1682
+%1703 = OpFunctionCall %ulong %21 %1702 %ulong_4
+OpStore %1683 %1703
+OpBranch %1670
+%1670 = OpLabel
+%1704 = OpLoad %ulong %1683
+OpReturnValue %1704
+OpFunctionEnd
+%13 = OpFunction %ulong None %1662
+%1705 = OpFunctionParameter %ulong
+%1706 = OpFunctionParameter %uchar
+%1707 = OpFunctionParameter %ushort
+%1708 = OpFunctionParameter %uint
+%1709 = OpFunctionParameter %ulong
+%1710 = OpLabel
+%1715 = OpVariable %_ptr_Function_ulong Function
+%1716 = OpVariable %_ptr_Function_uchar Function
+%1717 = OpVariable %_ptr_Function_ushort Function
+%1718 = OpVariable %_ptr_Function_uint Function
+%1719 = OpVariable %_ptr_Function_ulong Function
+%1720 = OpVariable %_ptr_Function_ulong Function
+%1721 = OpVariable %_ptr_Function_ulong Function
+%1722 = OpVariable %_ptr_Function_ulong Function
+%1723 = OpVariable %_ptr_Function_ulong Function
+%1724 = OpVariable %_ptr_Function_ulong Function
+%1725 = OpVariable %_ptr_Function_ulong Function
+%1726 = OpVariable %_ptr_Function_ulong Function
+%1727 = OpVariable %_ptr_Function_ulong Function
+OpStore %1715 %1705
+OpStore %1716 %1706
+OpStore %1717 %1707
+OpStore %1718 %1708
+OpStore %1719 %1709
+OpBranch %1711
+%1711 = OpLabel
+OpBranch %1712
+%1712 = OpLabel
+%1728 = OpLoad %uchar %1716
+%1729 = OpUConvert %ulong %1728
+OpStore %1720 %1729
+%1730 = OpLoad %ulong %1715
+%1731 = OpLoad %ulong %1720
+%1732 = OpFunctionCall %ulong %21 %1730 %1731
+OpStore %1721 %1732
+%1733 = OpLoad %ushort %1717
+%1734 = OpSConvert %ulong %1733
+OpStore %1722 %1734
+%1735 = OpLoad %ulong %1721
+%1736 = OpLoad %ulong %1722
+%1737 = OpFunctionCall %ulong %21 %1735 %1736
+OpStore %1723 %1737
+%1738 = OpLoad %uint %1718
+%1739 = OpUConvert %ulong %1738
+OpStore %1724 %1739
+%1740 = OpLoad %ulong %1723
+%1741 = OpLoad %ulong %1724
+%1742 = OpFunctionCall %ulong %21 %1740 %1741
+OpStore %1725 %1742
+%1743 = OpLoad %ulong %1725
+%1744 = OpLoad %ulong %1719
+%1745 = OpFunctionCall %ulong %21 %1743 %1744
+OpStore %1726 %1745
+%1746 = OpLoad %ulong %1726
+%1747 = OpFunctionCall %ulong %21 %1746 %ulong_4
+OpStore %1727 %1747
+OpBranch %1713
+%1713 = OpLabel
+OpBranch %1714
+%1714 = OpLabel
+%1748 = OpLoad %ulong %1727
+OpReturnValue %1748
+OpFunctionEnd
+%14 = OpFunction %ulong None %1749
+%1750 = OpFunctionParameter %ulong
+%1751 = OpFunctionParameter %ulong
+%1752 = OpFunctionParameter %float
+%1753 = OpFunctionParameter %double
+%1754 = OpLabel
+%1763 = OpVariable %_ptr_Function_ulong Function
+%1764 = OpVariable %_ptr_Function_ulong Function
+%1765 = OpVariable %_ptr_Function_float Function
+%1766 = OpVariable %_ptr_Function_double Function
+%1767 = OpVariable %_ptr_Function_ulong Function
+%1768 = OpVariable %_ptr_Function_ulong Function
+%1769 = OpVariable %_ptr_Function_uint Function
+%1770 = OpVariable %_ptr_Function_ulong Function
+%1771 = OpVariable %_ptr_Function_ulong Function
+%1772 = OpVariable %_ptr_Function_ulong Function
+%1773 = OpVariable %_ptr_Function_ulong Function
+OpStore %1763 %1750
+OpStore %1764 %1751
+OpStore %1765 %1752
+OpStore %1766 %1753
+OpBranch %1755
+%1755 = OpLabel
+OpBranch %1757
+%1757 = OpLabel
+%1774 = OpLoad %ulong %1763
+%1775 = OpLoad %ulong %1764
+%1776 = OpFunctionCall %ulong %21 %1774 %1775
+OpStore %1767 %1776
+OpBranch %1759
+%1759 = OpLabel
+%1777 = OpLoad %float %1765
+%1778 = OpBitcast %uint %1777
+OpStore %1769 %1778
+%1779 = OpLoad %uint %1769
+%1780 = OpUConvert %ulong %1779
+OpStore %1770 %1780
+%1781 = OpLoad %ulong %1767
+%1782 = OpLoad %ulong %1770
+%1783 = OpFunctionCall %ulong %21 %1781 %1782
+OpStore %1771 %1783
+OpBranch %1760
+%1760 = OpLabel
+OpBranch %1761
+%1761 = OpLabel
+%1784 = OpLoad %double %1766
+%1785 = OpBitcast %ulong %1784
+OpStore %1772 %1785
+%1786 = OpLoad %ulong %1771
+%1787 = OpLoad %ulong %1772
+%1788 = OpFunctionCall %ulong %21 %1786 %1787
+OpStore %1773 %1788
+OpBranch %1762
+%1762 = OpLabel
+%1789 = OpLoad %ulong %1773
+%1790 = OpFunctionCall %ulong %21 %1789 %ulong_3
+OpStore %1768 %1790
+OpBranch %1758
+%1758 = OpLabel
+OpBranch %1756
+%1756 = OpLabel
+%1791 = OpLoad %ulong %1768
+OpReturnValue %1791
+OpFunctionEnd
+%15 = OpFunction %ulong None %1550
+%1792 = OpFunctionParameter %ulong
+%1793 = OpFunctionParameter %ulong
+%1794 = OpFunctionParameter %uchar
+%1795 = OpFunctionParameter %uint
+%1796 = OpFunctionParameter %ulong
+%1797 = OpFunctionParameter %ushort
+%1798 = OpLabel
+%1801 = OpVariable %_ptr_Function_ulong Function
+%1802 = OpVariable %_ptr_Function_ulong Function
+%1803 = OpVariable %_ptr_Function_uchar Function
+%1804 = OpVariable %_ptr_Function_uint Function
+%1805 = OpVariable %_ptr_Function_ulong Function
+%1806 = OpVariable %_ptr_Function_ushort Function
+%1807 = OpVariable %_ptr_Function_ulong Function
+%1808 = OpVariable %_ptr_Function_ulong Function
+%1809 = OpVariable %_ptr_Function_ulong Function
+%1810 = OpVariable %_ptr_Function_ulong Function
+%1811 = OpVariable %_ptr_Function_ulong Function
+%1812 = OpVariable %_ptr_Function_ulong Function
+%1813 = OpVariable %_ptr_Function_ulong Function
+%1814 = OpVariable %_ptr_Function_ulong Function
+%1815 = OpVariable %_ptr_Function_ulong Function
+%1816 = OpVariable %_ptr_Function_ulong Function
+%1817 = OpVariable %_ptr_Function_ulong Function
+%1818 = OpVariable %_ptr_Function_ulong Function
+%1819 = OpVariable %_ptr_Function_ulong Function
+%1820 = OpVariable %_ptr_Function_ulong Function
+OpStore %1801 %1792
+OpStore %1802 %1793
+OpStore %1803 %1794
+OpStore %1804 %1795
+OpStore %1805 %1796
+OpStore %1806 %1797
+%1821 = OpLoad %ulong %1802
+%1822 = OpIMul %ulong %1821 %ulong_3
+OpStore %1807 %1822
+OpBranch %1799
+%1799 = OpLabel
+%1823 = OpLoad %ulong %1801
+%1824 = OpLoad %ulong %1807
+%1825 = OpFunctionCall %ulong %21 %1823 %1824
+OpStore %1808 %1825
+%1826 = OpLoad %uchar %1803
+%1827 = OpUConvert %ulong %1826
+OpStore %1809 %1827
+%1828 = OpLoad %ulong %1809
+%1829 = OpLoad %ulong %1807
+%1830 = OpIAdd %ulong %1828 %1829
+OpStore %1810 %1830
+%1831 = OpLoad %ulong %1808
+%1832 = OpLoad %ulong %1810
+%1833 = OpFunctionCall %ulong %21 %1831 %1832
+OpStore %1811 %1833
+%1834 = OpLoad %uint %1804
+%1835 = OpUConvert %ulong %1834
+OpStore %1812 %1835
+%1836 = OpLoad %ulong %1812
+%1837 = OpLoad %ulong %1807
+%1838 = OpIAdd %ulong %1836 %1837
+OpStore %1813 %1838
+%1839 = OpLoad %ulong %1811
+%1840 = OpLoad %ulong %1813
+%1841 = OpFunctionCall %ulong %21 %1839 %1840
+OpStore %1814 %1841
+%1842 = OpLoad %ulong %1805
+%1843 = OpLoad %ulong %1807
+%1844 = OpIAdd %ulong %1842 %1843
+OpStore %1815 %1844
+%1845 = OpLoad %ulong %1814
+%1846 = OpLoad %ulong %1815
+%1847 = OpFunctionCall %ulong %21 %1845 %1846
+OpStore %1816 %1847
+%1848 = OpLoad %ushort %1806
+%1849 = OpUConvert %ulong %1848
+OpStore %1817 %1849
+%1850 = OpLoad %ulong %1817
+%1851 = OpLoad %ulong %1807
+%1852 = OpIAdd %ulong %1850 %1851
+OpStore %1818 %1852
+%1853 = OpLoad %ulong %1816
+%1854 = OpLoad %ulong %1818
+%1855 = OpFunctionCall %ulong %21 %1853 %1854
+OpStore %1819 %1855
+%1856 = OpLoad %ulong %1819
+%1857 = OpFunctionCall %ulong %21 %1856 %ulong_4
+OpStore %1820 %1857
+OpBranch %1800
+%1800 = OpLabel
+%1858 = OpLoad %ulong %1820
+OpReturnValue %1858
+OpFunctionEnd
+%16 = OpFunction %ulong None %23
+%1859 = OpFunctionParameter %ulong
+%1860 = OpFunctionParameter %ulong
+%1861 = OpLabel
+%1862 = OpVariable %_ptr_Function_ulong Function
+%1863 = OpVariable %_ptr_Function_ulong Function
+%1864 = OpVariable %_ptr_Function_ulong Function
+%1865 = OpVariable %_ptr_Function_ulong Function
+OpStore %1862 %1859
+OpStore %1863 %1860
+%1866 = OpLoad %ulong %1862
+%1867 = OpLoad %ulong %1863
+%1868 = OpFunctionCall %ulong %21 %1866 %1867
+OpStore %1864 %1868
+%1869 = OpLoad %ulong %1864
+%1870 = OpFunctionCall %ulong %21 %1869 %ulong_1
+OpStore %1865 %1870
+%1871 = OpLoad %ulong %1865
+OpReturnValue %1871
+OpFunctionEnd
+%17 = OpFunction %ulong None %1872
+%1873 = OpFunctionParameter %ulong
+%1874 = OpFunctionParameter %float
+%1875 = OpLabel
+%1878 = OpVariable %_ptr_Function_ulong Function
+%1879 = OpVariable %_ptr_Function_float Function
+%1880 = OpVariable %_ptr_Function_ulong Function
+%1881 = OpVariable %_ptr_Function_uint Function
+%1882 = OpVariable %_ptr_Function_ulong Function
+%1883 = OpVariable %_ptr_Function_ulong Function
+OpStore %1878 %1873
+OpStore %1879 %1874
+OpBranch %1876
+%1876 = OpLabel
+%1884 = OpLoad %float %1879
+%1885 = OpBitcast %uint %1884
+OpStore %1881 %1885
+%1886 = OpLoad %uint %1881
+%1887 = OpUConvert %ulong %1886
+OpStore %1882 %1887
+%1888 = OpLoad %ulong %1878
+%1889 = OpLoad %ulong %1882
+%1890 = OpFunctionCall %ulong %21 %1888 %1889
+OpStore %1883 %1890
+OpBranch %1877
+%1877 = OpLabel
+%1891 = OpLoad %ulong %1883
+%1892 = OpFunctionCall %ulong %21 %1891 %ulong_1
+OpStore %1880 %1892
+%1893 = OpLoad %ulong %1880
+OpReturnValue %1893
+OpFunctionEnd
+%18 = OpFunction %ulong None %1662
+%1894 = OpFunctionParameter %ulong
+%1895 = OpFunctionParameter %uchar
+%1896 = OpFunctionParameter %ushort
+%1897 = OpFunctionParameter %uint
+%1898 = OpFunctionParameter %ulong
+%1899 = OpLabel
+%1900 = OpVariable %_ptr_Function_ulong Function
+%1901 = OpVariable %_ptr_Function_uchar Function
+%1902 = OpVariable %_ptr_Function_ushort Function
+%1903 = OpVariable %_ptr_Function_uint Function
+%1904 = OpVariable %_ptr_Function_ulong Function
+%1905 = OpVariable %_ptr_Function_ulong Function
+%1906 = OpVariable %_ptr_Function_ulong Function
+%1907 = OpVariable %_ptr_Function_ulong Function
+%1908 = OpVariable %_ptr_Function_ulong Function
+%1909 = OpVariable %_ptr_Function_ulong Function
+%1910 = OpVariable %_ptr_Function_ulong Function
+%1911 = OpVariable %_ptr_Function_ulong Function
+%1912 = OpVariable %_ptr_Function_ulong Function
+OpStore %1900 %1894
+OpStore %1901 %1895
+OpStore %1902 %1896
+OpStore %1903 %1897
+OpStore %1904 %1898
+%1913 = OpLoad %uchar %1901
+%1914 = OpUConvert %ulong %1913
+OpStore %1905 %1914
+%1915 = OpLoad %ulong %1900
+%1916 = OpLoad %ulong %1905
+%1917 = OpFunctionCall %ulong %21 %1915 %1916
+OpStore %1906 %1917
+%1918 = OpLoad %ushort %1902
+%1919 = OpSConvert %ulong %1918
+OpStore %1907 %1919
+%1920 = OpLoad %ulong %1906
+%1921 = OpLoad %ulong %1907
+%1922 = OpFunctionCall %ulong %21 %1920 %1921
+OpStore %1908 %1922
+%1923 = OpLoad %uint %1903
+%1924 = OpUConvert %ulong %1923
+OpStore %1909 %1924
+%1925 = OpLoad %ulong %1908
+%1926 = OpLoad %ulong %1909
+%1927 = OpFunctionCall %ulong %21 %1925 %1926
+OpStore %1910 %1927
+%1928 = OpLoad %ulong %1910
+%1929 = OpLoad %ulong %1904
+%1930 = OpFunctionCall %ulong %21 %1928 %1929
+OpStore %1911 %1930
+%1931 = OpLoad %ulong %1911
+%1932 = OpFunctionCall %ulong %21 %1931 %ulong_4
+OpStore %1912 %1932
+%1933 = OpLoad %ulong %1912
+OpReturnValue %1933
+OpFunctionEnd
+%19 = OpFunction %ulong None %1749
+%1934 = OpFunctionParameter %ulong
+%1935 = OpFunctionParameter %ulong
+%1936 = OpFunctionParameter %float
+%1937 = OpFunctionParameter %double
+%1938 = OpLabel
+%1945 = OpVariable %_ptr_Function_ulong Function
+%1946 = OpVariable %_ptr_Function_ulong Function
+%1947 = OpVariable %_ptr_Function_float Function
+%1948 = OpVariable %_ptr_Function_double Function
+%1949 = OpVariable %_ptr_Function_ulong Function
+%1950 = OpVariable %_ptr_Function_ulong Function
+%1951 = OpVariable %_ptr_Function_uint Function
+%1952 = OpVariable %_ptr_Function_ulong Function
+%1953 = OpVariable %_ptr_Function_ulong Function
+%1954 = OpVariable %_ptr_Function_ulong Function
+%1955 = OpVariable %_ptr_Function_ulong Function
+OpStore %1945 %1934
+OpStore %1946 %1935
+OpStore %1947 %1936
+OpStore %1948 %1937
+OpBranch %1939
+%1939 = OpLabel
+%1956 = OpLoad %ulong %1945
+%1957 = OpLoad %ulong %1946
+%1958 = OpFunctionCall %ulong %21 %1956 %1957
+OpStore %1949 %1958
+OpBranch %1941
+%1941 = OpLabel
+%1959 = OpLoad %float %1947
+%1960 = OpBitcast %uint %1959
+OpStore %1951 %1960
+%1961 = OpLoad %uint %1951
+%1962 = OpUConvert %ulong %1961
+OpStore %1952 %1962
+%1963 = OpLoad %ulong %1949
+%1964 = OpLoad %ulong %1952
+%1965 = OpFunctionCall %ulong %21 %1963 %1964
+OpStore %1953 %1965
+OpBranch %1942
+%1942 = OpLabel
+OpBranch %1943
+%1943 = OpLabel
+%1966 = OpLoad %double %1948
+%1967 = OpBitcast %ulong %1966
+OpStore %1954 %1967
+%1968 = OpLoad %ulong %1953
+%1969 = OpLoad %ulong %1954
+%1970 = OpFunctionCall %ulong %21 %1968 %1969
+OpStore %1955 %1970
+OpBranch %1944
+%1944 = OpLabel
+%1971 = OpLoad %ulong %1955
+%1972 = OpFunctionCall %ulong %21 %1971 %ulong_3
+OpStore %1950 %1972
+OpBranch %1940
+%1940 = OpLabel
+%1973 = OpLoad %ulong %1950
+OpReturnValue %1973
+OpFunctionEnd
+%20 = OpFunction %ulong None %1749
+%1974 = OpFunctionParameter %ulong
+%1975 = OpFunctionParameter %ulong
+%1976 = OpFunctionParameter %float
+%1977 = OpFunctionParameter %double
+%1978 = OpLabel
+%1983 = OpVariable %_ptr_Function_ulong Function
+%1984 = OpVariable %_ptr_Function_ulong Function
+%1985 = OpVariable %_ptr_Function_float Function
+%1986 = OpVariable %_ptr_Function_double Function
+%1987 = OpVariable %_ptr_Function_ulong Function
+%1988 = OpVariable %_ptr_Function_ulong Function
+%1989 = OpVariable %_ptr_Function_uint Function
+%1990 = OpVariable %_ptr_Function_ulong Function
+%1991 = OpVariable %_ptr_Function_ulong Function
+%1992 = OpVariable %_ptr_Function_ulong Function
+%1993 = OpVariable %_ptr_Function_ulong Function
+OpStore %1983 %1974
+OpStore %1984 %1975
+OpStore %1985 %1976
+OpStore %1986 %1977
+%1994 = OpLoad %ulong %1983
+%1995 = OpLoad %ulong %1984
+%1996 = OpFunctionCall %ulong %21 %1994 %1995
+OpStore %1987 %1996
+OpBranch %1979
+%1979 = OpLabel
+%1997 = OpLoad %float %1985
+%1998 = OpBitcast %uint %1997
+OpStore %1989 %1998
+%1999 = OpLoad %uint %1989
+%2000 = OpUConvert %ulong %1999
+OpStore %1990 %2000
+%2001 = OpLoad %ulong %1987
+%2002 = OpLoad %ulong %1990
+%2003 = OpFunctionCall %ulong %21 %2001 %2002
+OpStore %1991 %2003
+OpBranch %1980
+%1980 = OpLabel
+OpBranch %1981
+%1981 = OpLabel
+%2004 = OpLoad %double %1986
+%2005 = OpBitcast %ulong %2004
+OpStore %1992 %2005
+%2006 = OpLoad %ulong %1991
+%2007 = OpLoad %ulong %1992
+%2008 = OpFunctionCall %ulong %21 %2006 %2007
+OpStore %1993 %2008
+OpBranch %1982
+%1982 = OpLabel
+%2009 = OpLoad %ulong %1993
+%2010 = OpFunctionCall %ulong %21 %2009 %ulong_3
+OpStore %1988 %2010
+%2011 = OpLoad %ulong %1988
+OpReturnValue %2011
+OpFunctionEnd
+%21 = OpFunction %ulong None %23
+%2012 = OpFunctionParameter %ulong
+%2013 = OpFunctionParameter %ulong
+%2014 = OpLabel
+%2019 = OpVariable %_ptr_Function_ulong Function
+%2020 = OpVariable %_ptr_Function_ulong Function
+%2021 = OpVariable %_ptr_Function_bool Function
+%2022 = OpVariable %_ptr_Function_ulong Function
+%2023 = OpVariable %_ptr_Function_ulong Function
+%2024 = OpVariable %_ptr_Function_ulong Function
+%2025 = OpVariable %_ptr_Function_ulong Function
+%2026 = OpVariable %_ptr_Function_ulong Function
+%2027 = OpVariable %_ptr_Function_ulong Function
+%2028 = OpVariable %_ptr_Function_ulong Function
+%2029 = OpVariable %_ptr_Function_ulong Function
+OpStore %2019 %2012
+OpStore %2020 %2013
+%2030 = OpLoad %ulong %2019
+OpStore %2028 %2030
+OpStore %2029 %ulong_0
+OpBranch %2015
+%2015 = OpLabel
+%2031 = OpLoad %ulong %2029
+%2032 = OpULessThan %bool %2031 %ulong_8
+OpStore %2021 %2032
+%2033 = OpLoad %bool %2021
+OpLoopMerge %2017 %2018 None
+OpBranchConditional %2033 %2016 %2017
+%2017 = OpLabel
+%2034 = OpLoad %ulong %2028
+OpReturnValue %2034
+%2016 = OpLabel
+%2035 = OpLoad %ulong %2029
+%2036 = OpIMul %ulong %2035 %ulong_8
+OpStore %2022 %2036
+%2037 = OpLoad %ulong %2020
+%2038 = OpLoad %ulong %2022
+%2039 = OpShiftRightLogical %ulong %2037 %2038
+OpStore %2023 %2039
+%2040 = OpLoad %ulong %2023
+%2041 = OpBitwiseAnd %ulong %2040 %ulong_255
+OpStore %2024 %2041
+%2042 = OpLoad %ulong %2028
+%2043 = OpLoad %ulong %2024
+%2044 = OpBitwiseXor %ulong %2042 %2043
+OpStore %2025 %2044
+%2045 = OpLoad %ulong %2025
+%2046 = OpIMul %ulong %2045 %ulong_1099511628211
+OpStore %2026 %2046
+%2047 = OpLoad %ulong %2029
+%2048 = OpIAdd %ulong %2047 %ulong_1
+OpStore %2027 %2048
+%2049 = OpLoad %ulong %2026
+OpStore %2028 %2049
+%2050 = OpLoad %ulong %2027
+OpStore %2029 %2050
+OpBranch %2018
+%2018 = OpLabel
+OpBranch %2015
 OpFunctionEnd

--- a/test/golden/spirv/cmp/branch_nest.dis
+++ b/test/golden/spirv/cmp/branch_nest.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 305
+; Bound: 327
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,12 +9,13 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.branch_nest.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_20 = OpConstant %uint 20
 %uint_4 = OpConstant %uint 4
@@ -49,58 +50,39 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.branch_nest.checksum" Export
 %uint_102 = OpConstant %uint 102
 %uint_101 = OpConstant %uint 101
 %uint_100 = OpConstant %uint 100
-%252 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%255 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_uint Function
-%77 = OpVariable %_ptr_Function_bool Function
-%78 = OpVariable %_ptr_Function_uint Function
-%79 = OpVariable %_ptr_Function_bool Function
-%80 = OpVariable %_ptr_Function_bool Function
-%81 = OpVariable %_ptr_Function_bool Function
-%82 = OpVariable %_ptr_Function_bool Function
-%83 = OpVariable %_ptr_Function_bool Function
-%84 = OpVariable %_ptr_Function_bool Function
-%85 = OpVariable %_ptr_Function_bool Function
-%86 = OpVariable %_ptr_Function_bool Function
-%87 = OpVariable %_ptr_Function_bool Function
-%88 = OpVariable %_ptr_Function_bool Function
-%89 = OpVariable %_ptr_Function_bool Function
-%90 = OpVariable %_ptr_Function_bool Function
-%91 = OpVariable %_ptr_Function_bool Function
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%88 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_uint Function
 %92 = OpVariable %_ptr_Function_bool Function
-%93 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_uint Function
 %94 = OpVariable %_ptr_Function_bool Function
 %95 = OpVariable %_ptr_Function_bool Function
 %96 = OpVariable %_ptr_Function_bool Function
 %97 = OpVariable %_ptr_Function_bool Function
-%98 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_uint Function
-%101 = OpVariable %_ptr_Function_ulong Function
-%102 = OpVariable %_ptr_Function_uint Function
-%103 = OpVariable %_ptr_Function_uint Function
-%104 = OpVariable %_ptr_Function_uint Function
-%105 = OpVariable %_ptr_Function_uint Function
-%106 = OpVariable %_ptr_Function_uint Function
-%107 = OpVariable %_ptr_Function_uint Function
-%108 = OpVariable %_ptr_Function_uint Function
-%109 = OpVariable %_ptr_Function_uint Function
-%110 = OpVariable %_ptr_Function_uint Function
-%111 = OpVariable %_ptr_Function_uint Function
-%112 = OpVariable %_ptr_Function_uint Function
+%98 = OpVariable %_ptr_Function_bool Function
+%99 = OpVariable %_ptr_Function_bool Function
+%100 = OpVariable %_ptr_Function_bool Function
+%101 = OpVariable %_ptr_Function_bool Function
+%102 = OpVariable %_ptr_Function_bool Function
+%103 = OpVariable %_ptr_Function_bool Function
+%104 = OpVariable %_ptr_Function_bool Function
+%105 = OpVariable %_ptr_Function_bool Function
+%106 = OpVariable %_ptr_Function_bool Function
+%107 = OpVariable %_ptr_Function_bool Function
+%108 = OpVariable %_ptr_Function_bool Function
+%109 = OpVariable %_ptr_Function_bool Function
+%110 = OpVariable %_ptr_Function_bool Function
+%111 = OpVariable %_ptr_Function_bool Function
+%112 = OpVariable %_ptr_Function_bool Function
 %113 = OpVariable %_ptr_Function_uint Function
-%114 = OpVariable %_ptr_Function_uint Function
+%114 = OpVariable %_ptr_Function_ulong Function
 %115 = OpVariable %_ptr_Function_uint Function
 %116 = OpVariable %_ptr_Function_uint Function
 %117 = OpVariable %_ptr_Function_uint Function
@@ -108,384 +90,440 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.branch_nest.checksum" Export
 %119 = OpVariable %_ptr_Function_uint Function
 %120 = OpVariable %_ptr_Function_uint Function
 %121 = OpVariable %_ptr_Function_uint Function
-OpStore %72 %6
-%122 = OpFunctionCall %ulong %2
-OpStore %73 %122
-%123 = OpLoad %ulong %72
-%124 = OpUConvert %uint %123
-OpStore %75 %124
-%125 = OpLoad %ulong %73
-OpStore %101 %125
-OpStore %102 %uint_0
-OpBranch %8
-%8 = OpLabel
-%127 = OpLoad %uint %102
-%129 = OpULessThan %bool %127 %uint_20
-OpStore %77 %129
-%130 = OpLoad %bool %77
-OpLoopMerge %10 %68 None
-OpBranchConditional %130 %9 %10
-%10 = OpLabel
-%131 = OpLoad %ulong %101
-OpReturnValue %131
-%9 = OpLabel
-%132 = OpLoad %uint %102
-%133 = OpLoad %uint %75
-%134 = OpIAdd %uint %132 %133
-OpStore %78 %134
-%135 = OpLoad %uint %78
-%137 = OpULessThan %bool %135 %uint_4
-OpStore %79 %137
-%138 = OpLoad %bool %79
-OpSelectionMerge %13 None
-OpBranchConditional %138 %11 %12
-%12 = OpLabel
-%139 = OpLoad %uint %78
-%141 = OpULessThan %bool %139 %uint_8
-OpStore %83 %141
-%142 = OpLoad %bool %83
-OpSelectionMerge %25 None
-OpBranchConditional %142 %23 %24
-%24 = OpLabel
-%143 = OpLoad %uint %78
-%145 = OpULessThan %bool %143 %uint_12
-OpStore %87 %145
-%146 = OpLoad %bool %87
-OpSelectionMerge %37 None
-OpBranchConditional %146 %35 %36
-%36 = OpLabel
-%147 = OpLoad %uint %78
-%149 = OpULessThan %bool %147 %uint_16
-OpStore %91 %149
-%150 = OpLoad %bool %91
-OpSelectionMerge %49 None
-OpBranchConditional %150 %47 %48
-%48 = OpLabel
-%151 = OpLoad %uint %78
-%152 = OpIEqual %bool %151 %uint_16
-OpStore %95 %152
-%153 = OpLoad %bool %95
-OpSelectionMerge %61 None
-OpBranchConditional %153 %59 %60
-%60 = OpLabel
-%154 = OpLoad %uint %78
-%156 = OpIEqual %bool %154 %uint_17
-OpStore %96 %156
-%157 = OpLoad %bool %96
-OpSelectionMerge %64 None
-OpBranchConditional %157 %62 %63
-%63 = OpLabel
-%158 = OpLoad %uint %78
-%160 = OpIEqual %bool %158 %uint_18
-OpStore %97 %160
-%161 = OpLoad %bool %97
-OpSelectionMerge %67 None
-OpBranchConditional %161 %65 %66
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_uint Function
+%127 = OpVariable %_ptr_Function_uint Function
+%128 = OpVariable %_ptr_Function_uint Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_uint Function
+%132 = OpVariable %_ptr_Function_uint Function
+%133 = OpVariable %_ptr_Function_uint Function
+%134 = OpVariable %_ptr_Function_uint Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_bool Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_bool Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+OpStore %88 %4
+OpBranch %66
 %66 = OpLabel
-OpStore %103 %uint_503
-OpBranch %67
-%65 = OpLabel
-OpStore %103 %uint_502
 OpBranch %67
 %67 = OpLabel
-%164 = OpLoad %uint %103
-OpStore %104 %164
-OpBranch %64
-%62 = OpLabel
-OpStore %104 %uint_501
-OpBranch %64
-%64 = OpLabel
-%166 = OpLoad %uint %104
-OpStore %105 %166
-OpBranch %61
-%59 = OpLabel
-OpStore %105 %uint_500
-OpBranch %61
-%61 = OpLabel
-%168 = OpLoad %uint %105
-OpStore %106 %168
-OpBranch %49
-%47 = OpLabel
-%169 = OpLoad %uint %78
-%171 = OpULessThan %bool %169 %uint_14
-OpStore %92 %171
-%172 = OpLoad %bool %92
-OpSelectionMerge %52 None
-OpBranchConditional %172 %50 %51
-%51 = OpLabel
-%173 = OpLoad %uint %78
-%174 = OpIEqual %bool %173 %uint_14
-OpStore %94 %174
-%175 = OpLoad %bool %94
-OpSelectionMerge %58 None
-OpBranchConditional %175 %56 %57
-%57 = OpLabel
-OpStore %110 %uint_403
-OpBranch %58
-%56 = OpLabel
-OpStore %110 %uint_402
-OpBranch %58
-%58 = OpLabel
-%178 = OpLoad %uint %110
-OpStore %111 %178
-OpBranch %52
-%50 = OpLabel
-%179 = OpLoad %uint %78
-%180 = OpIEqual %bool %179 %uint_12
-OpStore %93 %180
-%181 = OpLoad %bool %93
-OpSelectionMerge %55 None
-OpBranchConditional %181 %53 %54
-%54 = OpLabel
-OpStore %112 %uint_401
-OpBranch %55
-%53 = OpLabel
-OpStore %112 %uint_400
-OpBranch %55
-%55 = OpLabel
-%184 = OpLoad %uint %112
-OpStore %111 %184
-OpBranch %52
-%52 = OpLabel
-%185 = OpLoad %uint %111
-OpStore %106 %185
-OpBranch %49
-%49 = OpLabel
-%186 = OpLoad %uint %106
-OpStore %107 %186
-OpBranch %37
-%35 = OpLabel
-%187 = OpLoad %uint %78
-%188 = OpIEqual %bool %187 %uint_8
-OpStore %88 %188
-%189 = OpLoad %bool %88
-OpSelectionMerge %40 None
-OpBranchConditional %189 %38 %39
-%39 = OpLabel
-%190 = OpLoad %uint %78
-%192 = OpIEqual %bool %190 %uint_9
-OpStore %89 %192
-%193 = OpLoad %bool %89
-OpSelectionMerge %43 None
-OpBranchConditional %193 %41 %42
-%42 = OpLabel
-%194 = OpLoad %uint %78
-%196 = OpIEqual %bool %194 %uint_10
-OpStore %90 %196
-%197 = OpLoad %bool %90
-OpSelectionMerge %46 None
-OpBranchConditional %197 %44 %45
-%45 = OpLabel
-OpStore %113 %uint_303
-OpBranch %46
-%44 = OpLabel
-OpStore %113 %uint_302
-OpBranch %46
-%46 = OpLabel
-%200 = OpLoad %uint %113
-OpStore %114 %200
-OpBranch %43
-%41 = OpLabel
-OpStore %114 %uint_301
-OpBranch %43
-%43 = OpLabel
-%202 = OpLoad %uint %114
-OpStore %115 %202
-OpBranch %40
-%38 = OpLabel
-OpStore %115 %uint_300
-OpBranch %40
-%40 = OpLabel
-%204 = OpLoad %uint %115
-OpStore %107 %204
-OpBranch %37
-%37 = OpLabel
-%205 = OpLoad %uint %107
-OpStore %108 %205
-OpBranch %25
-%23 = OpLabel
-%206 = OpLoad %uint %78
-%208 = OpULessThan %bool %206 %uint_6
-OpStore %84 %208
-%209 = OpLoad %bool %84
-OpSelectionMerge %28 None
-OpBranchConditional %209 %26 %27
-%27 = OpLabel
-%210 = OpLoad %uint %78
-%211 = OpIEqual %bool %210 %uint_6
-OpStore %86 %211
-%212 = OpLoad %bool %86
-OpSelectionMerge %34 None
-OpBranchConditional %212 %32 %33
-%33 = OpLabel
-OpStore %116 %uint_203
-OpBranch %34
-%32 = OpLabel
-OpStore %116 %uint_202
-OpBranch %34
-%34 = OpLabel
-%215 = OpLoad %uint %116
-OpStore %117 %215
-OpBranch %28
-%26 = OpLabel
-%216 = OpLoad %uint %78
-%217 = OpIEqual %bool %216 %uint_4
-OpStore %85 %217
-%218 = OpLoad %bool %85
-OpSelectionMerge %31 None
-OpBranchConditional %218 %29 %30
-%30 = OpLabel
-OpStore %118 %uint_201
-OpBranch %31
-%29 = OpLabel
-OpStore %118 %uint_200
-OpBranch %31
-%31 = OpLabel
-%221 = OpLoad %uint %118
-OpStore %117 %221
-OpBranch %28
-%28 = OpLabel
-%222 = OpLoad %uint %117
-OpStore %108 %222
-OpBranch %25
-%25 = OpLabel
-%223 = OpLoad %uint %108
-OpStore %109 %223
-OpBranch %13
-%11 = OpLabel
-%224 = OpLoad %uint %78
-%225 = OpIEqual %bool %224 %uint_0
-OpStore %80 %225
-%226 = OpLoad %bool %80
-OpSelectionMerge %16 None
-OpBranchConditional %226 %14 %15
-%15 = OpLabel
-%227 = OpLoad %uint %78
-%229 = OpIEqual %bool %227 %uint_1
-OpStore %81 %229
-%230 = OpLoad %bool %81
-OpSelectionMerge %19 None
-OpBranchConditional %230 %17 %18
-%18 = OpLabel
-%231 = OpLoad %uint %78
-%233 = OpIEqual %bool %231 %uint_2
-OpStore %82 %233
-%234 = OpLoad %bool %82
-OpSelectionMerge %22 None
-OpBranchConditional %234 %20 %21
-%21 = OpLabel
-OpStore %119 %uint_103
-OpBranch %22
-%20 = OpLabel
-OpStore %119 %uint_102
-OpBranch %22
+%155 = OpLoad %ulong %88
+%156 = OpUConvert %uint %155
+OpStore %90 %156
+OpStore %114 %ulong_14695981039346656037
+OpStore %115 %uint_0
+OpBranch %6
+%6 = OpLabel
+%159 = OpLoad %uint %115
+%161 = OpULessThan %bool %159 %uint_20
+OpStore %92 %161
+%162 = OpLoad %bool %92
+OpLoopMerge %8 %84 None
+OpBranchConditional %162 %7 %8
+%8 = OpLabel
+%163 = OpLoad %ulong %114
+OpReturnValue %163
+%7 = OpLabel
+%164 = OpLoad %uint %115
+%165 = OpLoad %uint %90
+%166 = OpIAdd %uint %164 %165
+OpStore %93 %166
+%167 = OpLoad %uint %93
+%169 = OpULessThan %bool %167 %uint_4
+OpStore %94 %169
+%170 = OpLoad %bool %94
+OpSelectionMerge %11 None
+OpBranchConditional %170 %9 %10
+%10 = OpLabel
+%171 = OpLoad %uint %93
+%173 = OpULessThan %bool %171 %uint_8
+OpStore %98 %173
+%174 = OpLoad %bool %98
+OpSelectionMerge %23 None
+OpBranchConditional %174 %21 %22
 %22 = OpLabel
-%237 = OpLoad %uint %119
-OpStore %120 %237
-OpBranch %19
-%17 = OpLabel
-OpStore %120 %uint_101
-OpBranch %19
-%19 = OpLabel
-%239 = OpLoad %uint %120
-OpStore %121 %239
-OpBranch %16
-%14 = OpLabel
-OpStore %121 %uint_100
-OpBranch %16
-%16 = OpLabel
-%241 = OpLoad %uint %121
-OpStore %109 %241
-OpBranch %13
-%13 = OpLabel
-%242 = OpLoad %ulong %101
-%243 = OpLoad %uint %109
-%244 = OpFunctionCall %ulong %3 %242 %243
-OpStore %98 %244
-%245 = OpLoad %ulong %98
-%246 = OpLoad %uint %78
-%247 = OpFunctionCall %ulong %3 %245 %246
-OpStore %99 %247
-%248 = OpLoad %uint %102
-%249 = OpIAdd %uint %248 %uint_1
+%175 = OpLoad %uint %93
+%177 = OpULessThan %bool %175 %uint_12
+OpStore %102 %177
+%178 = OpLoad %bool %102
+OpSelectionMerge %35 None
+OpBranchConditional %178 %33 %34
+%34 = OpLabel
+%179 = OpLoad %uint %93
+%181 = OpULessThan %bool %179 %uint_16
+OpStore %106 %181
+%182 = OpLoad %bool %106
+OpSelectionMerge %47 None
+OpBranchConditional %182 %45 %46
+%46 = OpLabel
+%183 = OpLoad %uint %93
+%184 = OpIEqual %bool %183 %uint_16
+OpStore %110 %184
+%185 = OpLoad %bool %110
+OpSelectionMerge %59 None
+OpBranchConditional %185 %57 %58
+%58 = OpLabel
+%186 = OpLoad %uint %93
+%188 = OpIEqual %bool %186 %uint_17
+OpStore %111 %188
+%189 = OpLoad %bool %111
+OpSelectionMerge %62 None
+OpBranchConditional %189 %60 %61
+%61 = OpLabel
+%190 = OpLoad %uint %93
+%192 = OpIEqual %bool %190 %uint_18
+OpStore %112 %192
+%193 = OpLoad %bool %112
+OpSelectionMerge %65 None
+OpBranchConditional %193 %63 %64
+%64 = OpLabel
+OpStore %116 %uint_503
+OpBranch %65
+%63 = OpLabel
+OpStore %116 %uint_502
+OpBranch %65
+%65 = OpLabel
+%196 = OpLoad %uint %116
+OpStore %117 %196
+OpBranch %62
+%60 = OpLabel
+OpStore %117 %uint_501
+OpBranch %62
+%62 = OpLabel
+%198 = OpLoad %uint %117
+OpStore %118 %198
+OpBranch %59
+%57 = OpLabel
+OpStore %118 %uint_500
+OpBranch %59
+%59 = OpLabel
+%200 = OpLoad %uint %118
+OpStore %119 %200
+OpBranch %47
+%45 = OpLabel
+%201 = OpLoad %uint %93
+%203 = OpULessThan %bool %201 %uint_14
+OpStore %107 %203
+%204 = OpLoad %bool %107
+OpSelectionMerge %50 None
+OpBranchConditional %204 %48 %49
+%49 = OpLabel
+%205 = OpLoad %uint %93
+%206 = OpIEqual %bool %205 %uint_14
+OpStore %109 %206
+%207 = OpLoad %bool %109
+OpSelectionMerge %56 None
+OpBranchConditional %207 %54 %55
+%55 = OpLabel
+OpStore %123 %uint_403
+OpBranch %56
+%54 = OpLabel
+OpStore %123 %uint_402
+OpBranch %56
+%56 = OpLabel
+%210 = OpLoad %uint %123
+OpStore %124 %210
+OpBranch %50
+%48 = OpLabel
+%211 = OpLoad %uint %93
+%212 = OpIEqual %bool %211 %uint_12
+OpStore %108 %212
+%213 = OpLoad %bool %108
+OpSelectionMerge %53 None
+OpBranchConditional %213 %51 %52
+%52 = OpLabel
+OpStore %125 %uint_401
+OpBranch %53
+%51 = OpLabel
+OpStore %125 %uint_400
+OpBranch %53
+%53 = OpLabel
+%216 = OpLoad %uint %125
+OpStore %124 %216
+OpBranch %50
+%50 = OpLabel
+%217 = OpLoad %uint %124
+OpStore %119 %217
+OpBranch %47
+%47 = OpLabel
+%218 = OpLoad %uint %119
+OpStore %120 %218
+OpBranch %35
+%33 = OpLabel
+%219 = OpLoad %uint %93
+%220 = OpIEqual %bool %219 %uint_8
+OpStore %103 %220
+%221 = OpLoad %bool %103
+OpSelectionMerge %38 None
+OpBranchConditional %221 %36 %37
+%37 = OpLabel
+%222 = OpLoad %uint %93
+%224 = OpIEqual %bool %222 %uint_9
+OpStore %104 %224
+%225 = OpLoad %bool %104
+OpSelectionMerge %41 None
+OpBranchConditional %225 %39 %40
+%40 = OpLabel
+%226 = OpLoad %uint %93
+%228 = OpIEqual %bool %226 %uint_10
+OpStore %105 %228
+%229 = OpLoad %bool %105
+OpSelectionMerge %44 None
+OpBranchConditional %229 %42 %43
+%43 = OpLabel
+OpStore %126 %uint_303
+OpBranch %44
+%42 = OpLabel
+OpStore %126 %uint_302
+OpBranch %44
+%44 = OpLabel
+%232 = OpLoad %uint %126
+OpStore %127 %232
+OpBranch %41
+%39 = OpLabel
+OpStore %127 %uint_301
+OpBranch %41
+%41 = OpLabel
+%234 = OpLoad %uint %127
+OpStore %128 %234
+OpBranch %38
+%36 = OpLabel
+OpStore %128 %uint_300
+OpBranch %38
+%38 = OpLabel
+%236 = OpLoad %uint %128
+OpStore %120 %236
+OpBranch %35
+%35 = OpLabel
+%237 = OpLoad %uint %120
+OpStore %121 %237
+OpBranch %23
+%21 = OpLabel
+%238 = OpLoad %uint %93
+%240 = OpULessThan %bool %238 %uint_6
+OpStore %99 %240
+%241 = OpLoad %bool %99
+OpSelectionMerge %26 None
+OpBranchConditional %241 %24 %25
+%25 = OpLabel
+%242 = OpLoad %uint %93
+%243 = OpIEqual %bool %242 %uint_6
+OpStore %101 %243
+%244 = OpLoad %bool %101
+OpSelectionMerge %32 None
+OpBranchConditional %244 %30 %31
+%31 = OpLabel
+OpStore %129 %uint_203
+OpBranch %32
+%30 = OpLabel
+OpStore %129 %uint_202
+OpBranch %32
+%32 = OpLabel
+%247 = OpLoad %uint %129
+OpStore %130 %247
+OpBranch %26
+%24 = OpLabel
+%248 = OpLoad %uint %93
+%249 = OpIEqual %bool %248 %uint_4
 OpStore %100 %249
-%250 = OpLoad %ulong %99
-OpStore %101 %250
-%251 = OpLoad %uint %100
-OpStore %102 %251
+%250 = OpLoad %bool %100
+OpSelectionMerge %29 None
+OpBranchConditional %250 %27 %28
+%28 = OpLabel
+OpStore %131 %uint_201
+OpBranch %29
+%27 = OpLabel
+OpStore %131 %uint_200
+OpBranch %29
+%29 = OpLabel
+%253 = OpLoad %uint %131
+OpStore %130 %253
+OpBranch %26
+%26 = OpLabel
+%254 = OpLoad %uint %130
+OpStore %121 %254
+OpBranch %23
+%23 = OpLabel
+%255 = OpLoad %uint %121
+OpStore %122 %255
+OpBranch %11
+%9 = OpLabel
+%256 = OpLoad %uint %93
+%257 = OpIEqual %bool %256 %uint_0
+OpStore %95 %257
+%258 = OpLoad %bool %95
+OpSelectionMerge %14 None
+OpBranchConditional %258 %12 %13
+%13 = OpLabel
+%259 = OpLoad %uint %93
+%261 = OpIEqual %bool %259 %uint_1
+OpStore %96 %261
+%262 = OpLoad %bool %96
+OpSelectionMerge %17 None
+OpBranchConditional %262 %15 %16
+%16 = OpLabel
+%263 = OpLoad %uint %93
+%265 = OpIEqual %bool %263 %uint_2
+OpStore %97 %265
+%266 = OpLoad %bool %97
+OpSelectionMerge %20 None
+OpBranchConditional %266 %18 %19
+%19 = OpLabel
+OpStore %132 %uint_103
+OpBranch %20
+%18 = OpLabel
+OpStore %132 %uint_102
+OpBranch %20
+%20 = OpLabel
+%269 = OpLoad %uint %132
+OpStore %133 %269
+OpBranch %17
+%15 = OpLabel
+OpStore %133 %uint_101
+OpBranch %17
+%17 = OpLabel
+%271 = OpLoad %uint %133
+OpStore %134 %271
+OpBranch %14
+%12 = OpLabel
+OpStore %134 %uint_100
+OpBranch %14
+%14 = OpLabel
+%273 = OpLoad %uint %134
+OpStore %122 %273
+OpBranch %11
+%11 = OpLabel
 OpBranch %68
 %68 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %252
-%253 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %255
-%256 = OpFunctionParameter %ulong
-%257 = OpFunctionParameter %uint
-%258 = OpLabel
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_uint Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_bool Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_ulong Function
-OpStore %265 %256
-OpStore %266 %257
-%277 = OpLoad %uint %266
-%278 = OpUConvert %ulong %277
-OpStore %267 %278
-OpBranch %259
-%259 = OpLabel
-%279 = OpLoad %ulong %265
-OpStore %275 %279
-OpStore %276 %ulong_0
-OpBranch %260
-%260 = OpLabel
-%281 = OpLoad %ulong %276
-%283 = OpULessThan %bool %281 %ulong_8
-OpStore %268 %283
-%284 = OpLoad %bool %268
-OpLoopMerge %262 %264 None
-OpBranchConditional %284 %261 %262
-%262 = OpLabel
-OpBranch %263
-%263 = OpLabel
-%285 = OpLoad %ulong %275
-OpReturnValue %285
-%261 = OpLabel
-%286 = OpLoad %ulong %276
-%287 = OpIMul %ulong %286 %ulong_8
-OpStore %269 %287
-%288 = OpLoad %ulong %267
-%289 = OpLoad %ulong %269
-%290 = OpShiftRightLogical %ulong %288 %289
-OpStore %270 %290
-%291 = OpLoad %ulong %270
-%293 = OpBitwiseAnd %ulong %291 %ulong_255
-OpStore %271 %293
-%294 = OpLoad %ulong %275
-%295 = OpLoad %ulong %271
-%296 = OpBitwiseXor %ulong %294 %295
-OpStore %272 %296
-%297 = OpLoad %ulong %272
-%299 = OpIMul %ulong %297 %ulong_1099511628211
-OpStore %273 %299
-%300 = OpLoad %ulong %276
-%302 = OpIAdd %ulong %300 %ulong_1
-OpStore %274 %302
-%303 = OpLoad %ulong %273
-OpStore %275 %303
-%304 = OpLoad %ulong %274
-OpStore %276 %304
-OpBranch %264
-%264 = OpLabel
-OpBranch %260
+%274 = OpLoad %uint %122
+%275 = OpUConvert %ulong %274
+OpStore %135 %275
+OpBranch %70
+%70 = OpLabel
+%276 = OpLoad %ulong %114
+OpStore %143 %276
+OpStore %144 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%278 = OpLoad %ulong %144
+%280 = OpULessThan %bool %278 %ulong_8
+OpStore %136 %280
+%281 = OpLoad %bool %136
+OpLoopMerge %73 %83 None
+OpBranchConditional %281 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%282 = OpLoad %uint %93
+%283 = OpUConvert %ulong %282
+OpStore %145 %283
+OpBranch %77
+%77 = OpLabel
+%284 = OpLoad %ulong %143
+OpStore %153 %284
+OpStore %154 %ulong_0
+OpBranch %78
+%78 = OpLabel
+%285 = OpLoad %ulong %154
+%286 = OpULessThan %bool %285 %ulong_8
+OpStore %146 %286
+%287 = OpLoad %bool %146
+OpLoopMerge %80 %82 None
+OpBranchConditional %287 %79 %80
+%80 = OpLabel
+OpBranch %81
+%81 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%288 = OpLoad %uint %115
+%289 = OpIAdd %uint %288 %uint_1
+OpStore %113 %289
+%290 = OpLoad %ulong %153
+OpStore %114 %290
+%291 = OpLoad %uint %113
+OpStore %115 %291
+OpBranch %84
+%79 = OpLabel
+%292 = OpLoad %ulong %154
+%293 = OpIMul %ulong %292 %ulong_8
+OpStore %147 %293
+%294 = OpLoad %ulong %145
+%295 = OpLoad %ulong %147
+%296 = OpShiftRightLogical %ulong %294 %295
+OpStore %148 %296
+%297 = OpLoad %ulong %148
+%299 = OpBitwiseAnd %ulong %297 %ulong_255
+OpStore %149 %299
+%300 = OpLoad %ulong %153
+%301 = OpLoad %ulong %149
+%302 = OpBitwiseXor %ulong %300 %301
+OpStore %150 %302
+%303 = OpLoad %ulong %150
+%305 = OpIMul %ulong %303 %ulong_1099511628211
+OpStore %151 %305
+%306 = OpLoad %ulong %154
+%308 = OpIAdd %ulong %306 %ulong_1
+OpStore %152 %308
+%309 = OpLoad %ulong %151
+OpStore %153 %309
+%310 = OpLoad %ulong %152
+OpStore %154 %310
+OpBranch %82
+%72 = OpLabel
+%311 = OpLoad %ulong %144
+%312 = OpIMul %ulong %311 %ulong_8
+OpStore %137 %312
+%313 = OpLoad %ulong %135
+%314 = OpLoad %ulong %137
+%315 = OpShiftRightLogical %ulong %313 %314
+OpStore %138 %315
+%316 = OpLoad %ulong %138
+%317 = OpBitwiseAnd %ulong %316 %ulong_255
+OpStore %139 %317
+%318 = OpLoad %ulong %143
+%319 = OpLoad %ulong %139
+%320 = OpBitwiseXor %ulong %318 %319
+OpStore %140 %320
+%321 = OpLoad %ulong %140
+%322 = OpIMul %ulong %321 %ulong_1099511628211
+OpStore %141 %322
+%323 = OpLoad %ulong %144
+%324 = OpIAdd %ulong %323 %ulong_1
+OpStore %142 %324
+%325 = OpLoad %ulong %141
+OpStore %143 %325
+%326 = OpLoad %ulong %142
+OpStore %144 %326
+OpBranch %83
+%82 = OpLabel
+OpBranch %78
+%83 = OpLabel
+OpBranch %71
+%84 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/cmp/cmp_i32.dis
+++ b/test/golden/spirv/cmp/cmp_i32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 193
+; Bound: 358
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,9 +10,9 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_i32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %uint_7 = OpConstant %uint 7
 %_arr_uint_uint_7 = OpTypeArray %uint %uint_7
 %_ptr_Function__arr_uint_uint_7 = OpTypePointer Function %_arr_uint_uint_7
@@ -29,247 +29,508 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_i32.checksum" Export
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_7 = OpConstant %ulong 7
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
-%ulong_1 = OpConstant %ulong 1
-%141 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%144 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
 %ulong_8 = OpConstant %ulong 8
+%ulong_1 = OpConstant %ulong 1
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%17 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%18 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%19 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%20 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_bool Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_bool Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_bool Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_bool Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_bool Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-OpStore %22 %6
-%46 = OpFunctionCall %ulong %2
-OpStore %23 %46
-%47 = OpLoad %ulong %22
-%48 = OpUConvert %uint %47
-OpStore %25 %48
-%50 = OpAccessChain %_ptr_Function_uint %18 %uint_0
-OpStore %50 %uint_0
-%52 = OpAccessChain %_ptr_Function_uint %18 %uint_1
-OpStore %52 %uint_0
-%54 = OpAccessChain %_ptr_Function_uint %18 %uint_2
-OpStore %54 %uint_4294967295
-%57 = OpAccessChain %_ptr_Function_uint %18 %uint_3
-OpStore %57 %uint_2147483647
-%60 = OpAccessChain %_ptr_Function_uint %18 %uint_4
-OpStore %60 %uint_2147483648
-%63 = OpAccessChain %_ptr_Function_uint %18 %uint_5
-OpStore %63 %uint_4294967295
-%65 = OpAccessChain %_ptr_Function_uint %18 %uint_6
-OpStore %65 %uint_2147483648
-%66 = OpLoad %_arr_uint_uint_7 %18
-OpStore %17 %66
-%67 = OpAccessChain %_ptr_Function_uint %20 %uint_0
-OpStore %67 %uint_0
-%68 = OpAccessChain %_ptr_Function_uint %20 %uint_1
-OpStore %68 %uint_4294967295
-%69 = OpAccessChain %_ptr_Function_uint %20 %uint_2
-OpStore %69 %uint_0
-%70 = OpAccessChain %_ptr_Function_uint %20 %uint_3
-OpStore %70 %uint_2147483648
-%71 = OpAccessChain %_ptr_Function_uint %20 %uint_4
-OpStore %71 %uint_2147483647
-%72 = OpAccessChain %_ptr_Function_uint %20 %uint_5
-OpStore %72 %uint_4294967295
-%73 = OpAccessChain %_ptr_Function_uint %20 %uint_6
-OpStore %73 %uint_2147483648
-%74 = OpLoad %_arr_uint_uint_7 %20
-OpStore %19 %74
-%75 = OpLoad %ulong %23
-OpStore %44 %75
-OpStore %45 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%77 = OpLoad %ulong %45
-%79 = OpULessThan %bool %77 %ulong_7
-OpStore %27 %79
-%80 = OpLoad %bool %27
-OpLoopMerge %10 %11 None
-OpBranchConditional %80 %9 %10
-%10 = OpLabel
-%81 = OpLoad %ulong %44
-OpReturnValue %81
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%65 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%66 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%67 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%68 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_uint Function
+%74 = OpVariable %_ptr_Function_bool Function
+%75 = OpVariable %_ptr_Function_uint Function
+%76 = OpVariable %_ptr_Function_uint Function
+%77 = OpVariable %_ptr_Function_uint Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_bool Function
+%80 = OpVariable %_ptr_Function_bool Function
+%81 = OpVariable %_ptr_Function_bool Function
+%82 = OpVariable %_ptr_Function_bool Function
+%83 = OpVariable %_ptr_Function_bool Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_bool Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_bool Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_bool Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_bool Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_bool Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+OpStore %70 %4
+OpBranch %9
 %9 = OpLabel
-%82 = OpLoad %ulong %45
-%83 = OpAccessChain %_ptr_Function_uint %17 %82
-%84 = OpLoad %uint %83
-OpStore %28 %84
-%85 = OpLoad %uint %28
-%86 = OpLoad %uint %25
-%87 = OpIAdd %uint %85 %86
-OpStore %29 %87
-%88 = OpLoad %ulong %45
-%89 = OpAccessChain %_ptr_Function_uint %19 %88
-%90 = OpLoad %uint %89
-OpStore %30 %90
-%91 = OpLoad %uint %29
-%92 = OpLoad %uint %30
-%93 = OpIEqual %bool %91 %92
-OpStore %31 %93
-%95 = OpLoad %ulong %44
-%96 = OpLoad %bool %31
-%99 = OpSelect %uchar %96 %uchar_1 %uchar_0
-%100 = OpFunctionCall %ulong %3 %95 %99
-OpStore %32 %100
-%101 = OpLoad %uint %29
-%102 = OpLoad %uint %30
-%103 = OpINotEqual %bool %101 %102
-OpStore %33 %103
-%104 = OpLoad %ulong %32
-%105 = OpLoad %bool %33
-%106 = OpSelect %uchar %105 %uchar_1 %uchar_0
-%107 = OpFunctionCall %ulong %3 %104 %106
-OpStore %34 %107
-%108 = OpLoad %uint %29
-%109 = OpLoad %uint %30
-%110 = OpSLessThan %bool %108 %109
-OpStore %35 %110
-%111 = OpLoad %ulong %34
-%112 = OpLoad %bool %35
-%113 = OpSelect %uchar %112 %uchar_1 %uchar_0
-%114 = OpFunctionCall %ulong %3 %111 %113
-OpStore %36 %114
-%115 = OpLoad %uint %30
-%116 = OpLoad %uint %29
-%117 = OpSLessThan %bool %115 %116
-OpStore %37 %117
-%118 = OpLoad %ulong %36
-%119 = OpLoad %bool %37
-%120 = OpSelect %uchar %119 %uchar_1 %uchar_0
-%121 = OpFunctionCall %ulong %3 %118 %120
-OpStore %38 %121
-%122 = OpLoad %uint %29
-%123 = OpLoad %uint %30
-%124 = OpSLessThanEqual %bool %122 %123
-OpStore %39 %124
-%125 = OpLoad %ulong %38
-%126 = OpLoad %bool %39
-%127 = OpSelect %uchar %126 %uchar_1 %uchar_0
-%128 = OpFunctionCall %ulong %3 %125 %127
-OpStore %40 %128
-%129 = OpLoad %uint %30
-%130 = OpLoad %uint %29
-%131 = OpSLessThanEqual %bool %129 %130
-OpStore %41 %131
-%132 = OpLoad %ulong %40
-%133 = OpLoad %bool %41
-%134 = OpSelect %uchar %133 %uchar_1 %uchar_0
-%135 = OpFunctionCall %ulong %3 %132 %134
-OpStore %42 %135
-%136 = OpLoad %ulong %45
-%138 = OpIAdd %ulong %136 %ulong_1
-OpStore %43 %138
-%139 = OpLoad %ulong %42
-OpStore %44 %139
-%140 = OpLoad %ulong %43
-OpStore %45 %140
+OpBranch %10
+%10 = OpLabel
+%147 = OpLoad %ulong %70
+%148 = OpUConvert %uint %147
+OpStore %72 %148
+%150 = OpAccessChain %_ptr_Function_uint %66 %uint_0
+OpStore %150 %uint_0
+%152 = OpAccessChain %_ptr_Function_uint %66 %uint_1
+OpStore %152 %uint_0
+%154 = OpAccessChain %_ptr_Function_uint %66 %uint_2
+OpStore %154 %uint_4294967295
+%157 = OpAccessChain %_ptr_Function_uint %66 %uint_3
+OpStore %157 %uint_2147483647
+%160 = OpAccessChain %_ptr_Function_uint %66 %uint_4
+OpStore %160 %uint_2147483648
+%163 = OpAccessChain %_ptr_Function_uint %66 %uint_5
+OpStore %163 %uint_4294967295
+%165 = OpAccessChain %_ptr_Function_uint %66 %uint_6
+OpStore %165 %uint_2147483648
+%166 = OpLoad %_arr_uint_uint_7 %66
+OpStore %65 %166
+%167 = OpAccessChain %_ptr_Function_uint %68 %uint_0
+OpStore %167 %uint_0
+%168 = OpAccessChain %_ptr_Function_uint %68 %uint_1
+OpStore %168 %uint_4294967295
+%169 = OpAccessChain %_ptr_Function_uint %68 %uint_2
+OpStore %169 %uint_0
+%170 = OpAccessChain %_ptr_Function_uint %68 %uint_3
+OpStore %170 %uint_2147483648
+%171 = OpAccessChain %_ptr_Function_uint %68 %uint_4
+OpStore %171 %uint_2147483647
+%172 = OpAccessChain %_ptr_Function_uint %68 %uint_5
+OpStore %172 %uint_4294967295
+%173 = OpAccessChain %_ptr_Function_uint %68 %uint_6
+OpStore %173 %uint_2147483648
+%174 = OpLoad %_arr_uint_uint_7 %68
+OpStore %67 %174
+OpStore %85 %ulong_14695981039346656037
+OpStore %86 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%177 = OpLoad %ulong %86
+%179 = OpULessThan %bool %177 %ulong_7
+OpStore %74 %179
+%180 = OpLoad %bool %74
+OpLoopMerge %8 %59 None
+OpBranchConditional %180 %7 %8
+%8 = OpLabel
+%181 = OpLoad %ulong %85
+OpReturnValue %181
+%7 = OpLabel
+%182 = OpLoad %ulong %86
+%183 = OpAccessChain %_ptr_Function_uint %65 %182
+%184 = OpLoad %uint %183
+OpStore %75 %184
+%185 = OpLoad %uint %75
+%186 = OpLoad %uint %72
+%187 = OpIAdd %uint %185 %186
+OpStore %76 %187
+%188 = OpLoad %ulong %86
+%189 = OpAccessChain %_ptr_Function_uint %67 %188
+%190 = OpLoad %uint %189
+OpStore %77 %190
+%191 = OpLoad %uint %76
+%192 = OpLoad %uint %77
+%193 = OpIEqual %bool %191 %192
+OpStore %78 %193
 OpBranch %11
 %11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %141
-%142 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %144
-%145 = OpFunctionParameter %ulong
-%146 = OpFunctionParameter %uchar
-%147 = OpLabel
-%154 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_uchar Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_bool Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-OpStore %154 %145
-OpStore %156 %146
-%167 = OpLoad %uchar %156
-%168 = OpUConvert %ulong %167
-OpStore %157 %168
-OpBranch %148
-%148 = OpLabel
-%169 = OpLoad %ulong %154
-OpStore %165 %169
-OpStore %166 %ulong_0
-OpBranch %149
-%149 = OpLabel
-%170 = OpLoad %ulong %166
-%172 = OpULessThan %bool %170 %ulong_8
-OpStore %158 %172
-%173 = OpLoad %bool %158
-OpLoopMerge %151 %153 None
-OpBranchConditional %173 %150 %151
-%151 = OpLabel
-OpBranch %152
-%152 = OpLabel
-%174 = OpLoad %ulong %165
-OpReturnValue %174
-%150 = OpLabel
-%175 = OpLoad %ulong %166
-%176 = OpIMul %ulong %175 %ulong_8
-OpStore %159 %176
-%177 = OpLoad %ulong %157
-%178 = OpLoad %ulong %159
-%179 = OpShiftRightLogical %ulong %177 %178
-OpStore %160 %179
-%180 = OpLoad %ulong %160
-%182 = OpBitwiseAnd %ulong %180 %ulong_255
-OpStore %161 %182
-%183 = OpLoad %ulong %165
-%184 = OpLoad %ulong %161
-%185 = OpBitwiseXor %ulong %183 %184
-OpStore %162 %185
-%186 = OpLoad %ulong %162
-%188 = OpIMul %ulong %186 %ulong_1099511628211
-OpStore %163 %188
-%189 = OpLoad %ulong %166
-%190 = OpIAdd %ulong %189 %ulong_1
-OpStore %164 %190
-%191 = OpLoad %ulong %163
-OpStore %165 %191
-%192 = OpLoad %ulong %164
-OpStore %166 %192
-OpBranch %153
-%153 = OpLabel
-OpBranch %149
+%195 = OpLoad %bool %78
+%198 = OpSelect %uchar %195 %uchar_1 %uchar_0
+%199 = OpUConvert %ulong %198
+OpStore %87 %199
+OpBranch %13
+%13 = OpLabel
+%200 = OpLoad %ulong %85
+OpStore %95 %200
+OpStore %96 %ulong_0
+OpBranch %14
+%14 = OpLabel
+%201 = OpLoad %ulong %96
+%203 = OpULessThan %bool %201 %ulong_8
+OpStore %88 %203
+%204 = OpLoad %bool %88
+OpLoopMerge %16 %58 None
+OpBranchConditional %204 %15 %16
+%16 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%205 = OpLoad %uint %76
+%206 = OpLoad %uint %77
+%207 = OpINotEqual %bool %205 %206
+OpStore %79 %207
+OpBranch %18
+%18 = OpLabel
+%208 = OpLoad %bool %79
+%209 = OpSelect %uchar %208 %uchar_1 %uchar_0
+%210 = OpUConvert %ulong %209
+OpStore %97 %210
+OpBranch %20
+%20 = OpLabel
+%211 = OpLoad %ulong %95
+OpStore %105 %211
+OpStore %106 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%212 = OpLoad %ulong %106
+%213 = OpULessThan %bool %212 %ulong_8
+OpStore %98 %213
+%214 = OpLoad %bool %98
+OpLoopMerge %23 %57 None
+OpBranchConditional %214 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%215 = OpLoad %uint %76
+%216 = OpLoad %uint %77
+%217 = OpSLessThan %bool %215 %216
+OpStore %80 %217
+OpBranch %25
+%25 = OpLabel
+%218 = OpLoad %bool %80
+%219 = OpSelect %uchar %218 %uchar_1 %uchar_0
+%220 = OpUConvert %ulong %219
+OpStore %107 %220
+OpBranch %27
+%27 = OpLabel
+%221 = OpLoad %ulong %105
+OpStore %115 %221
+OpStore %116 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%222 = OpLoad %ulong %116
+%223 = OpULessThan %bool %222 %ulong_8
+OpStore %108 %223
+%224 = OpLoad %bool %108
+OpLoopMerge %30 %56 None
+OpBranchConditional %224 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%225 = OpLoad %uint %77
+%226 = OpLoad %uint %76
+%227 = OpSLessThan %bool %225 %226
+OpStore %81 %227
+OpBranch %32
+%32 = OpLabel
+%228 = OpLoad %bool %81
+%229 = OpSelect %uchar %228 %uchar_1 %uchar_0
+%230 = OpUConvert %ulong %229
+OpStore %117 %230
+OpBranch %34
+%34 = OpLabel
+%231 = OpLoad %ulong %115
+OpStore %125 %231
+OpStore %126 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%232 = OpLoad %ulong %126
+%233 = OpULessThan %bool %232 %ulong_8
+OpStore %118 %233
+%234 = OpLoad %bool %118
+OpLoopMerge %37 %55 None
+OpBranchConditional %234 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%235 = OpLoad %uint %76
+%236 = OpLoad %uint %77
+%237 = OpSLessThanEqual %bool %235 %236
+OpStore %82 %237
+OpBranch %39
+%39 = OpLabel
+%238 = OpLoad %bool %82
+%239 = OpSelect %uchar %238 %uchar_1 %uchar_0
+%240 = OpUConvert %ulong %239
+OpStore %127 %240
+OpBranch %41
+%41 = OpLabel
+%241 = OpLoad %ulong %125
+OpStore %135 %241
+OpStore %136 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%242 = OpLoad %ulong %136
+%243 = OpULessThan %bool %242 %ulong_8
+OpStore %128 %243
+%244 = OpLoad %bool %128
+OpLoopMerge %44 %54 None
+OpBranchConditional %244 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%245 = OpLoad %uint %77
+%246 = OpLoad %uint %76
+%247 = OpSLessThanEqual %bool %245 %246
+OpStore %83 %247
+OpBranch %46
+%46 = OpLabel
+%248 = OpLoad %bool %83
+%249 = OpSelect %uchar %248 %uchar_1 %uchar_0
+%250 = OpUConvert %ulong %249
+OpStore %137 %250
+OpBranch %48
+%48 = OpLabel
+%251 = OpLoad %ulong %135
+OpStore %145 %251
+OpStore %146 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%252 = OpLoad %ulong %146
+%253 = OpULessThan %bool %252 %ulong_8
+OpStore %138 %253
+%254 = OpLoad %bool %138
+OpLoopMerge %51 %53 None
+OpBranchConditional %254 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%255 = OpLoad %ulong %86
+%257 = OpIAdd %ulong %255 %ulong_1
+OpStore %84 %257
+%258 = OpLoad %ulong %145
+OpStore %85 %258
+%259 = OpLoad %ulong %84
+OpStore %86 %259
+OpBranch %59
+%50 = OpLabel
+%260 = OpLoad %ulong %146
+%261 = OpIMul %ulong %260 %ulong_8
+OpStore %139 %261
+%262 = OpLoad %ulong %137
+%263 = OpLoad %ulong %139
+%264 = OpShiftRightLogical %ulong %262 %263
+OpStore %140 %264
+%265 = OpLoad %ulong %140
+%267 = OpBitwiseAnd %ulong %265 %ulong_255
+OpStore %141 %267
+%268 = OpLoad %ulong %145
+%269 = OpLoad %ulong %141
+%270 = OpBitwiseXor %ulong %268 %269
+OpStore %142 %270
+%271 = OpLoad %ulong %142
+%273 = OpIMul %ulong %271 %ulong_1099511628211
+OpStore %143 %273
+%274 = OpLoad %ulong %146
+%275 = OpIAdd %ulong %274 %ulong_1
+OpStore %144 %275
+%276 = OpLoad %ulong %143
+OpStore %145 %276
+%277 = OpLoad %ulong %144
+OpStore %146 %277
+OpBranch %53
+%43 = OpLabel
+%278 = OpLoad %ulong %136
+%279 = OpIMul %ulong %278 %ulong_8
+OpStore %129 %279
+%280 = OpLoad %ulong %127
+%281 = OpLoad %ulong %129
+%282 = OpShiftRightLogical %ulong %280 %281
+OpStore %130 %282
+%283 = OpLoad %ulong %130
+%284 = OpBitwiseAnd %ulong %283 %ulong_255
+OpStore %131 %284
+%285 = OpLoad %ulong %135
+%286 = OpLoad %ulong %131
+%287 = OpBitwiseXor %ulong %285 %286
+OpStore %132 %287
+%288 = OpLoad %ulong %132
+%289 = OpIMul %ulong %288 %ulong_1099511628211
+OpStore %133 %289
+%290 = OpLoad %ulong %136
+%291 = OpIAdd %ulong %290 %ulong_1
+OpStore %134 %291
+%292 = OpLoad %ulong %133
+OpStore %135 %292
+%293 = OpLoad %ulong %134
+OpStore %136 %293
+OpBranch %54
+%36 = OpLabel
+%294 = OpLoad %ulong %126
+%295 = OpIMul %ulong %294 %ulong_8
+OpStore %119 %295
+%296 = OpLoad %ulong %117
+%297 = OpLoad %ulong %119
+%298 = OpShiftRightLogical %ulong %296 %297
+OpStore %120 %298
+%299 = OpLoad %ulong %120
+%300 = OpBitwiseAnd %ulong %299 %ulong_255
+OpStore %121 %300
+%301 = OpLoad %ulong %125
+%302 = OpLoad %ulong %121
+%303 = OpBitwiseXor %ulong %301 %302
+OpStore %122 %303
+%304 = OpLoad %ulong %122
+%305 = OpIMul %ulong %304 %ulong_1099511628211
+OpStore %123 %305
+%306 = OpLoad %ulong %126
+%307 = OpIAdd %ulong %306 %ulong_1
+OpStore %124 %307
+%308 = OpLoad %ulong %123
+OpStore %125 %308
+%309 = OpLoad %ulong %124
+OpStore %126 %309
+OpBranch %55
+%29 = OpLabel
+%310 = OpLoad %ulong %116
+%311 = OpIMul %ulong %310 %ulong_8
+OpStore %109 %311
+%312 = OpLoad %ulong %107
+%313 = OpLoad %ulong %109
+%314 = OpShiftRightLogical %ulong %312 %313
+OpStore %110 %314
+%315 = OpLoad %ulong %110
+%316 = OpBitwiseAnd %ulong %315 %ulong_255
+OpStore %111 %316
+%317 = OpLoad %ulong %115
+%318 = OpLoad %ulong %111
+%319 = OpBitwiseXor %ulong %317 %318
+OpStore %112 %319
+%320 = OpLoad %ulong %112
+%321 = OpIMul %ulong %320 %ulong_1099511628211
+OpStore %113 %321
+%322 = OpLoad %ulong %116
+%323 = OpIAdd %ulong %322 %ulong_1
+OpStore %114 %323
+%324 = OpLoad %ulong %113
+OpStore %115 %324
+%325 = OpLoad %ulong %114
+OpStore %116 %325
+OpBranch %56
+%22 = OpLabel
+%326 = OpLoad %ulong %106
+%327 = OpIMul %ulong %326 %ulong_8
+OpStore %99 %327
+%328 = OpLoad %ulong %97
+%329 = OpLoad %ulong %99
+%330 = OpShiftRightLogical %ulong %328 %329
+OpStore %100 %330
+%331 = OpLoad %ulong %100
+%332 = OpBitwiseAnd %ulong %331 %ulong_255
+OpStore %101 %332
+%333 = OpLoad %ulong %105
+%334 = OpLoad %ulong %101
+%335 = OpBitwiseXor %ulong %333 %334
+OpStore %102 %335
+%336 = OpLoad %ulong %102
+%337 = OpIMul %ulong %336 %ulong_1099511628211
+OpStore %103 %337
+%338 = OpLoad %ulong %106
+%339 = OpIAdd %ulong %338 %ulong_1
+OpStore %104 %339
+%340 = OpLoad %ulong %103
+OpStore %105 %340
+%341 = OpLoad %ulong %104
+OpStore %106 %341
+OpBranch %57
+%15 = OpLabel
+%342 = OpLoad %ulong %96
+%343 = OpIMul %ulong %342 %ulong_8
+OpStore %89 %343
+%344 = OpLoad %ulong %87
+%345 = OpLoad %ulong %89
+%346 = OpShiftRightLogical %ulong %344 %345
+OpStore %90 %346
+%347 = OpLoad %ulong %90
+%348 = OpBitwiseAnd %ulong %347 %ulong_255
+OpStore %91 %348
+%349 = OpLoad %ulong %95
+%350 = OpLoad %ulong %91
+%351 = OpBitwiseXor %ulong %349 %350
+OpStore %92 %351
+%352 = OpLoad %ulong %92
+%353 = OpIMul %ulong %352 %ulong_1099511628211
+OpStore %93 %353
+%354 = OpLoad %ulong %96
+%355 = OpIAdd %ulong %354 %ulong_1
+OpStore %94 %355
+%356 = OpLoad %ulong %93
+OpStore %95 %356
+%357 = OpLoad %ulong %94
+OpStore %96 %357
+OpBranch %58
+%53 = OpLabel
+OpBranch %49
+%54 = OpLabel
+OpBranch %42
+%55 = OpLabel
+OpBranch %35
+%56 = OpLabel
+OpBranch %28
+%57 = OpLabel
+OpBranch %21
+%58 = OpLabel
+OpBranch %14
+%59 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/cmp/cmp_i64.dis
+++ b/test/golden/spirv/cmp/cmp_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 189
+; Bound: 354
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,7 +10,7 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_i64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %uint_7 = OpConstant %uint 7
@@ -29,242 +29,503 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_i64.checksum" Export
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_7 = OpConstant %ulong 7
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
-%ulong_1 = OpConstant %ulong 1
-%137 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%140 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
 %ulong_8 = OpConstant %ulong 8
+%ulong_1 = OpConstant %ulong 1
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%17 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%18 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%19 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%20 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_bool Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_bool Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_bool Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_bool Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-OpStore %22 %6
-%44 = OpFunctionCall %ulong %2
-OpStore %23 %44
-%46 = OpAccessChain %_ptr_Function_ulong %18 %uint_0
-OpStore %46 %ulong_0
-%49 = OpAccessChain %_ptr_Function_ulong %18 %uint_1
-OpStore %49 %ulong_0
-%51 = OpAccessChain %_ptr_Function_ulong %18 %uint_2
-OpStore %51 %ulong_18446744073709551615
-%54 = OpAccessChain %_ptr_Function_ulong %18 %uint_3
-OpStore %54 %ulong_9223372036854775807
-%57 = OpAccessChain %_ptr_Function_ulong %18 %uint_4
-OpStore %57 %ulong_9223372036854775808
-%60 = OpAccessChain %_ptr_Function_ulong %18 %uint_5
-OpStore %60 %ulong_18446744073709551615
-%62 = OpAccessChain %_ptr_Function_ulong %18 %uint_6
-OpStore %62 %ulong_9223372036854775808
-%63 = OpLoad %_arr_ulong_uint_7 %18
-OpStore %17 %63
-%64 = OpAccessChain %_ptr_Function_ulong %20 %uint_0
-OpStore %64 %ulong_0
-%65 = OpAccessChain %_ptr_Function_ulong %20 %uint_1
-OpStore %65 %ulong_18446744073709551615
-%66 = OpAccessChain %_ptr_Function_ulong %20 %uint_2
-OpStore %66 %ulong_0
-%67 = OpAccessChain %_ptr_Function_ulong %20 %uint_3
-OpStore %67 %ulong_9223372036854775808
-%68 = OpAccessChain %_ptr_Function_ulong %20 %uint_4
-OpStore %68 %ulong_9223372036854775807
-%69 = OpAccessChain %_ptr_Function_ulong %20 %uint_5
-OpStore %69 %ulong_18446744073709551615
-%70 = OpAccessChain %_ptr_Function_ulong %20 %uint_6
-OpStore %70 %ulong_9223372036854775808
-%71 = OpLoad %_arr_ulong_uint_7 %20
-OpStore %19 %71
-%72 = OpLoad %ulong %23
-OpStore %42 %72
-OpStore %43 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%73 = OpLoad %ulong %43
-%75 = OpULessThan %bool %73 %ulong_7
-OpStore %25 %75
-%76 = OpLoad %bool %25
-OpLoopMerge %10 %11 None
-OpBranchConditional %76 %9 %10
-%10 = OpLabel
-%77 = OpLoad %ulong %42
-OpReturnValue %77
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%65 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%66 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%67 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%68 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_bool Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_bool Function
+%77 = OpVariable %_ptr_Function_bool Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_bool Function
+%80 = OpVariable %_ptr_Function_bool Function
+%81 = OpVariable %_ptr_Function_bool Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_bool Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_bool Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_bool Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_bool Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_bool Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_bool Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+OpStore %70 %4
+OpBranch %9
 %9 = OpLabel
-%78 = OpLoad %ulong %43
-%79 = OpAccessChain %_ptr_Function_ulong %17 %78
-%80 = OpLoad %ulong %79
-OpStore %26 %80
-%81 = OpLoad %ulong %26
-%82 = OpLoad %ulong %22
-%83 = OpIAdd %ulong %81 %82
-OpStore %27 %83
-%84 = OpLoad %ulong %43
-%85 = OpAccessChain %_ptr_Function_ulong %19 %84
-%86 = OpLoad %ulong %85
-OpStore %28 %86
-%87 = OpLoad %ulong %27
-%88 = OpLoad %ulong %28
-%89 = OpIEqual %bool %87 %88
-OpStore %29 %89
-%91 = OpLoad %ulong %42
-%92 = OpLoad %bool %29
-%95 = OpSelect %uchar %92 %uchar_1 %uchar_0
-%96 = OpFunctionCall %ulong %3 %91 %95
-OpStore %30 %96
-%97 = OpLoad %ulong %27
-%98 = OpLoad %ulong %28
-%99 = OpINotEqual %bool %97 %98
-OpStore %31 %99
-%100 = OpLoad %ulong %30
-%101 = OpLoad %bool %31
-%102 = OpSelect %uchar %101 %uchar_1 %uchar_0
-%103 = OpFunctionCall %ulong %3 %100 %102
-OpStore %32 %103
-%104 = OpLoad %ulong %27
-%105 = OpLoad %ulong %28
-%106 = OpSLessThan %bool %104 %105
-OpStore %33 %106
-%107 = OpLoad %ulong %32
-%108 = OpLoad %bool %33
-%109 = OpSelect %uchar %108 %uchar_1 %uchar_0
-%110 = OpFunctionCall %ulong %3 %107 %109
-OpStore %34 %110
-%111 = OpLoad %ulong %28
-%112 = OpLoad %ulong %27
-%113 = OpSLessThan %bool %111 %112
-OpStore %35 %113
-%114 = OpLoad %ulong %34
-%115 = OpLoad %bool %35
-%116 = OpSelect %uchar %115 %uchar_1 %uchar_0
-%117 = OpFunctionCall %ulong %3 %114 %116
-OpStore %36 %117
-%118 = OpLoad %ulong %27
-%119 = OpLoad %ulong %28
-%120 = OpSLessThanEqual %bool %118 %119
-OpStore %37 %120
-%121 = OpLoad %ulong %36
-%122 = OpLoad %bool %37
-%123 = OpSelect %uchar %122 %uchar_1 %uchar_0
-%124 = OpFunctionCall %ulong %3 %121 %123
-OpStore %38 %124
-%125 = OpLoad %ulong %28
-%126 = OpLoad %ulong %27
-%127 = OpSLessThanEqual %bool %125 %126
-OpStore %39 %127
-%128 = OpLoad %ulong %38
-%129 = OpLoad %bool %39
-%130 = OpSelect %uchar %129 %uchar_1 %uchar_0
-%131 = OpFunctionCall %ulong %3 %128 %130
-OpStore %40 %131
-%132 = OpLoad %ulong %43
-%134 = OpIAdd %ulong %132 %ulong_1
-OpStore %41 %134
-%135 = OpLoad %ulong %40
-OpStore %42 %135
-%136 = OpLoad %ulong %41
-OpStore %43 %136
+OpBranch %10
+%10 = OpLabel
+%146 = OpAccessChain %_ptr_Function_ulong %66 %uint_0
+OpStore %146 %ulong_0
+%149 = OpAccessChain %_ptr_Function_ulong %66 %uint_1
+OpStore %149 %ulong_0
+%151 = OpAccessChain %_ptr_Function_ulong %66 %uint_2
+OpStore %151 %ulong_18446744073709551615
+%154 = OpAccessChain %_ptr_Function_ulong %66 %uint_3
+OpStore %154 %ulong_9223372036854775807
+%157 = OpAccessChain %_ptr_Function_ulong %66 %uint_4
+OpStore %157 %ulong_9223372036854775808
+%160 = OpAccessChain %_ptr_Function_ulong %66 %uint_5
+OpStore %160 %ulong_18446744073709551615
+%162 = OpAccessChain %_ptr_Function_ulong %66 %uint_6
+OpStore %162 %ulong_9223372036854775808
+%163 = OpLoad %_arr_ulong_uint_7 %66
+OpStore %65 %163
+%164 = OpAccessChain %_ptr_Function_ulong %68 %uint_0
+OpStore %164 %ulong_0
+%165 = OpAccessChain %_ptr_Function_ulong %68 %uint_1
+OpStore %165 %ulong_18446744073709551615
+%166 = OpAccessChain %_ptr_Function_ulong %68 %uint_2
+OpStore %166 %ulong_0
+%167 = OpAccessChain %_ptr_Function_ulong %68 %uint_3
+OpStore %167 %ulong_9223372036854775808
+%168 = OpAccessChain %_ptr_Function_ulong %68 %uint_4
+OpStore %168 %ulong_9223372036854775807
+%169 = OpAccessChain %_ptr_Function_ulong %68 %uint_5
+OpStore %169 %ulong_18446744073709551615
+%170 = OpAccessChain %_ptr_Function_ulong %68 %uint_6
+OpStore %170 %ulong_9223372036854775808
+%171 = OpLoad %_arr_ulong_uint_7 %68
+OpStore %67 %171
+OpStore %83 %ulong_14695981039346656037
+OpStore %84 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%173 = OpLoad %ulong %84
+%175 = OpULessThan %bool %173 %ulong_7
+OpStore %72 %175
+%176 = OpLoad %bool %72
+OpLoopMerge %8 %59 None
+OpBranchConditional %176 %7 %8
+%8 = OpLabel
+%177 = OpLoad %ulong %83
+OpReturnValue %177
+%7 = OpLabel
+%178 = OpLoad %ulong %84
+%179 = OpAccessChain %_ptr_Function_ulong %65 %178
+%180 = OpLoad %ulong %179
+OpStore %73 %180
+%181 = OpLoad %ulong %73
+%182 = OpLoad %ulong %70
+%183 = OpIAdd %ulong %181 %182
+OpStore %74 %183
+%184 = OpLoad %ulong %84
+%185 = OpAccessChain %_ptr_Function_ulong %67 %184
+%186 = OpLoad %ulong %185
+OpStore %75 %186
+%187 = OpLoad %ulong %74
+%188 = OpLoad %ulong %75
+%189 = OpIEqual %bool %187 %188
+OpStore %76 %189
 OpBranch %11
 %11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %137
-%138 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %140
-%141 = OpFunctionParameter %ulong
-%142 = OpFunctionParameter %uchar
-%143 = OpLabel
-%150 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_uchar Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-OpStore %150 %141
-OpStore %152 %142
-%163 = OpLoad %uchar %152
-%164 = OpUConvert %ulong %163
-OpStore %153 %164
-OpBranch %144
-%144 = OpLabel
-%165 = OpLoad %ulong %150
-OpStore %161 %165
-OpStore %162 %ulong_0
-OpBranch %145
-%145 = OpLabel
-%166 = OpLoad %ulong %162
-%168 = OpULessThan %bool %166 %ulong_8
-OpStore %154 %168
-%169 = OpLoad %bool %154
-OpLoopMerge %147 %149 None
-OpBranchConditional %169 %146 %147
-%147 = OpLabel
-OpBranch %148
-%148 = OpLabel
-%170 = OpLoad %ulong %161
-OpReturnValue %170
-%146 = OpLabel
-%171 = OpLoad %ulong %162
-%172 = OpIMul %ulong %171 %ulong_8
-OpStore %155 %172
-%173 = OpLoad %ulong %153
-%174 = OpLoad %ulong %155
-%175 = OpShiftRightLogical %ulong %173 %174
-OpStore %156 %175
-%176 = OpLoad %ulong %156
-%178 = OpBitwiseAnd %ulong %176 %ulong_255
-OpStore %157 %178
-%179 = OpLoad %ulong %161
-%180 = OpLoad %ulong %157
-%181 = OpBitwiseXor %ulong %179 %180
-OpStore %158 %181
-%182 = OpLoad %ulong %158
-%184 = OpIMul %ulong %182 %ulong_1099511628211
-OpStore %159 %184
-%185 = OpLoad %ulong %162
-%186 = OpIAdd %ulong %185 %ulong_1
-OpStore %160 %186
-%187 = OpLoad %ulong %159
-OpStore %161 %187
-%188 = OpLoad %ulong %160
-OpStore %162 %188
-OpBranch %149
-%149 = OpLabel
-OpBranch %145
+%191 = OpLoad %bool %76
+%194 = OpSelect %uchar %191 %uchar_1 %uchar_0
+%195 = OpUConvert %ulong %194
+OpStore %85 %195
+OpBranch %13
+%13 = OpLabel
+%196 = OpLoad %ulong %83
+OpStore %93 %196
+OpStore %94 %ulong_0
+OpBranch %14
+%14 = OpLabel
+%197 = OpLoad %ulong %94
+%199 = OpULessThan %bool %197 %ulong_8
+OpStore %86 %199
+%200 = OpLoad %bool %86
+OpLoopMerge %16 %58 None
+OpBranchConditional %200 %15 %16
+%16 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%201 = OpLoad %ulong %74
+%202 = OpLoad %ulong %75
+%203 = OpINotEqual %bool %201 %202
+OpStore %77 %203
+OpBranch %18
+%18 = OpLabel
+%204 = OpLoad %bool %77
+%205 = OpSelect %uchar %204 %uchar_1 %uchar_0
+%206 = OpUConvert %ulong %205
+OpStore %95 %206
+OpBranch %20
+%20 = OpLabel
+%207 = OpLoad %ulong %93
+OpStore %103 %207
+OpStore %104 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%208 = OpLoad %ulong %104
+%209 = OpULessThan %bool %208 %ulong_8
+OpStore %96 %209
+%210 = OpLoad %bool %96
+OpLoopMerge %23 %57 None
+OpBranchConditional %210 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%211 = OpLoad %ulong %74
+%212 = OpLoad %ulong %75
+%213 = OpSLessThan %bool %211 %212
+OpStore %78 %213
+OpBranch %25
+%25 = OpLabel
+%214 = OpLoad %bool %78
+%215 = OpSelect %uchar %214 %uchar_1 %uchar_0
+%216 = OpUConvert %ulong %215
+OpStore %105 %216
+OpBranch %27
+%27 = OpLabel
+%217 = OpLoad %ulong %103
+OpStore %113 %217
+OpStore %114 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%218 = OpLoad %ulong %114
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %106 %219
+%220 = OpLoad %bool %106
+OpLoopMerge %30 %56 None
+OpBranchConditional %220 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%221 = OpLoad %ulong %75
+%222 = OpLoad %ulong %74
+%223 = OpSLessThan %bool %221 %222
+OpStore %79 %223
+OpBranch %32
+%32 = OpLabel
+%224 = OpLoad %bool %79
+%225 = OpSelect %uchar %224 %uchar_1 %uchar_0
+%226 = OpUConvert %ulong %225
+OpStore %115 %226
+OpBranch %34
+%34 = OpLabel
+%227 = OpLoad %ulong %113
+OpStore %123 %227
+OpStore %124 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%228 = OpLoad %ulong %124
+%229 = OpULessThan %bool %228 %ulong_8
+OpStore %116 %229
+%230 = OpLoad %bool %116
+OpLoopMerge %37 %55 None
+OpBranchConditional %230 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%231 = OpLoad %ulong %74
+%232 = OpLoad %ulong %75
+%233 = OpSLessThanEqual %bool %231 %232
+OpStore %80 %233
+OpBranch %39
+%39 = OpLabel
+%234 = OpLoad %bool %80
+%235 = OpSelect %uchar %234 %uchar_1 %uchar_0
+%236 = OpUConvert %ulong %235
+OpStore %125 %236
+OpBranch %41
+%41 = OpLabel
+%237 = OpLoad %ulong %123
+OpStore %133 %237
+OpStore %134 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%238 = OpLoad %ulong %134
+%239 = OpULessThan %bool %238 %ulong_8
+OpStore %126 %239
+%240 = OpLoad %bool %126
+OpLoopMerge %44 %54 None
+OpBranchConditional %240 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%241 = OpLoad %ulong %75
+%242 = OpLoad %ulong %74
+%243 = OpSLessThanEqual %bool %241 %242
+OpStore %81 %243
+OpBranch %46
+%46 = OpLabel
+%244 = OpLoad %bool %81
+%245 = OpSelect %uchar %244 %uchar_1 %uchar_0
+%246 = OpUConvert %ulong %245
+OpStore %135 %246
+OpBranch %48
+%48 = OpLabel
+%247 = OpLoad %ulong %133
+OpStore %143 %247
+OpStore %144 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%248 = OpLoad %ulong %144
+%249 = OpULessThan %bool %248 %ulong_8
+OpStore %136 %249
+%250 = OpLoad %bool %136
+OpLoopMerge %51 %53 None
+OpBranchConditional %250 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%251 = OpLoad %ulong %84
+%253 = OpIAdd %ulong %251 %ulong_1
+OpStore %82 %253
+%254 = OpLoad %ulong %143
+OpStore %83 %254
+%255 = OpLoad %ulong %82
+OpStore %84 %255
+OpBranch %59
+%50 = OpLabel
+%256 = OpLoad %ulong %144
+%257 = OpIMul %ulong %256 %ulong_8
+OpStore %137 %257
+%258 = OpLoad %ulong %135
+%259 = OpLoad %ulong %137
+%260 = OpShiftRightLogical %ulong %258 %259
+OpStore %138 %260
+%261 = OpLoad %ulong %138
+%263 = OpBitwiseAnd %ulong %261 %ulong_255
+OpStore %139 %263
+%264 = OpLoad %ulong %143
+%265 = OpLoad %ulong %139
+%266 = OpBitwiseXor %ulong %264 %265
+OpStore %140 %266
+%267 = OpLoad %ulong %140
+%269 = OpIMul %ulong %267 %ulong_1099511628211
+OpStore %141 %269
+%270 = OpLoad %ulong %144
+%271 = OpIAdd %ulong %270 %ulong_1
+OpStore %142 %271
+%272 = OpLoad %ulong %141
+OpStore %143 %272
+%273 = OpLoad %ulong %142
+OpStore %144 %273
+OpBranch %53
+%43 = OpLabel
+%274 = OpLoad %ulong %134
+%275 = OpIMul %ulong %274 %ulong_8
+OpStore %127 %275
+%276 = OpLoad %ulong %125
+%277 = OpLoad %ulong %127
+%278 = OpShiftRightLogical %ulong %276 %277
+OpStore %128 %278
+%279 = OpLoad %ulong %128
+%280 = OpBitwiseAnd %ulong %279 %ulong_255
+OpStore %129 %280
+%281 = OpLoad %ulong %133
+%282 = OpLoad %ulong %129
+%283 = OpBitwiseXor %ulong %281 %282
+OpStore %130 %283
+%284 = OpLoad %ulong %130
+%285 = OpIMul %ulong %284 %ulong_1099511628211
+OpStore %131 %285
+%286 = OpLoad %ulong %134
+%287 = OpIAdd %ulong %286 %ulong_1
+OpStore %132 %287
+%288 = OpLoad %ulong %131
+OpStore %133 %288
+%289 = OpLoad %ulong %132
+OpStore %134 %289
+OpBranch %54
+%36 = OpLabel
+%290 = OpLoad %ulong %124
+%291 = OpIMul %ulong %290 %ulong_8
+OpStore %117 %291
+%292 = OpLoad %ulong %115
+%293 = OpLoad %ulong %117
+%294 = OpShiftRightLogical %ulong %292 %293
+OpStore %118 %294
+%295 = OpLoad %ulong %118
+%296 = OpBitwiseAnd %ulong %295 %ulong_255
+OpStore %119 %296
+%297 = OpLoad %ulong %123
+%298 = OpLoad %ulong %119
+%299 = OpBitwiseXor %ulong %297 %298
+OpStore %120 %299
+%300 = OpLoad %ulong %120
+%301 = OpIMul %ulong %300 %ulong_1099511628211
+OpStore %121 %301
+%302 = OpLoad %ulong %124
+%303 = OpIAdd %ulong %302 %ulong_1
+OpStore %122 %303
+%304 = OpLoad %ulong %121
+OpStore %123 %304
+%305 = OpLoad %ulong %122
+OpStore %124 %305
+OpBranch %55
+%29 = OpLabel
+%306 = OpLoad %ulong %114
+%307 = OpIMul %ulong %306 %ulong_8
+OpStore %107 %307
+%308 = OpLoad %ulong %105
+%309 = OpLoad %ulong %107
+%310 = OpShiftRightLogical %ulong %308 %309
+OpStore %108 %310
+%311 = OpLoad %ulong %108
+%312 = OpBitwiseAnd %ulong %311 %ulong_255
+OpStore %109 %312
+%313 = OpLoad %ulong %113
+%314 = OpLoad %ulong %109
+%315 = OpBitwiseXor %ulong %313 %314
+OpStore %110 %315
+%316 = OpLoad %ulong %110
+%317 = OpIMul %ulong %316 %ulong_1099511628211
+OpStore %111 %317
+%318 = OpLoad %ulong %114
+%319 = OpIAdd %ulong %318 %ulong_1
+OpStore %112 %319
+%320 = OpLoad %ulong %111
+OpStore %113 %320
+%321 = OpLoad %ulong %112
+OpStore %114 %321
+OpBranch %56
+%22 = OpLabel
+%322 = OpLoad %ulong %104
+%323 = OpIMul %ulong %322 %ulong_8
+OpStore %97 %323
+%324 = OpLoad %ulong %95
+%325 = OpLoad %ulong %97
+%326 = OpShiftRightLogical %ulong %324 %325
+OpStore %98 %326
+%327 = OpLoad %ulong %98
+%328 = OpBitwiseAnd %ulong %327 %ulong_255
+OpStore %99 %328
+%329 = OpLoad %ulong %103
+%330 = OpLoad %ulong %99
+%331 = OpBitwiseXor %ulong %329 %330
+OpStore %100 %331
+%332 = OpLoad %ulong %100
+%333 = OpIMul %ulong %332 %ulong_1099511628211
+OpStore %101 %333
+%334 = OpLoad %ulong %104
+%335 = OpIAdd %ulong %334 %ulong_1
+OpStore %102 %335
+%336 = OpLoad %ulong %101
+OpStore %103 %336
+%337 = OpLoad %ulong %102
+OpStore %104 %337
+OpBranch %57
+%15 = OpLabel
+%338 = OpLoad %ulong %94
+%339 = OpIMul %ulong %338 %ulong_8
+OpStore %87 %339
+%340 = OpLoad %ulong %85
+%341 = OpLoad %ulong %87
+%342 = OpShiftRightLogical %ulong %340 %341
+OpStore %88 %342
+%343 = OpLoad %ulong %88
+%344 = OpBitwiseAnd %ulong %343 %ulong_255
+OpStore %89 %344
+%345 = OpLoad %ulong %93
+%346 = OpLoad %ulong %89
+%347 = OpBitwiseXor %ulong %345 %346
+OpStore %90 %347
+%348 = OpLoad %ulong %90
+%349 = OpIMul %ulong %348 %ulong_1099511628211
+OpStore %91 %349
+%350 = OpLoad %ulong %94
+%351 = OpIAdd %ulong %350 %ulong_1
+OpStore %92 %351
+%352 = OpLoad %ulong %91
+OpStore %93 %352
+%353 = OpLoad %ulong %92
+OpStore %94 %353
+OpBranch %58
+%53 = OpLabel
+OpBranch %49
+%54 = OpLabel
+OpBranch %42
+%55 = OpLabel
+OpBranch %35
+%56 = OpLabel
+OpBranch %28
+%57 = OpLabel
+OpBranch %21
+%58 = OpLabel
+OpBranch %14
+%59 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/cmp/cmp_u32.dis
+++ b/test/golden/spirv/cmp/cmp_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 193
+; Bound: 358
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,9 +10,9 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %uint_7 = OpConstant %uint 7
 %_arr_uint_uint_7 = OpTypeArray %uint %uint_7
 %_ptr_Function__arr_uint_uint_7 = OpTypePointer Function %_arr_uint_uint_7
@@ -29,247 +29,508 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_u32.checksum" Export
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_7 = OpConstant %ulong 7
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
-%ulong_1 = OpConstant %ulong 1
-%141 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%144 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
 %ulong_8 = OpConstant %ulong 8
+%ulong_1 = OpConstant %ulong 1
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%17 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%18 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%19 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%20 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_bool Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_bool Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_bool Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_bool Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_bool Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-OpStore %22 %6
-%46 = OpFunctionCall %ulong %2
-OpStore %23 %46
-%47 = OpLoad %ulong %22
-%48 = OpUConvert %uint %47
-OpStore %25 %48
-%50 = OpAccessChain %_ptr_Function_uint %18 %uint_0
-OpStore %50 %uint_0
-%52 = OpAccessChain %_ptr_Function_uint %18 %uint_1
-OpStore %52 %uint_0
-%54 = OpAccessChain %_ptr_Function_uint %18 %uint_2
-OpStore %54 %uint_4294967295
-%57 = OpAccessChain %_ptr_Function_uint %18 %uint_3
-OpStore %57 %uint_2147483647
-%60 = OpAccessChain %_ptr_Function_uint %18 %uint_4
-OpStore %60 %uint_2147483648
-%63 = OpAccessChain %_ptr_Function_uint %18 %uint_5
-OpStore %63 %uint_4294967295
-%65 = OpAccessChain %_ptr_Function_uint %18 %uint_6
-OpStore %65 %uint_2147483648
-%66 = OpLoad %_arr_uint_uint_7 %18
-OpStore %17 %66
-%67 = OpAccessChain %_ptr_Function_uint %20 %uint_0
-OpStore %67 %uint_0
-%68 = OpAccessChain %_ptr_Function_uint %20 %uint_1
-OpStore %68 %uint_4294967295
-%69 = OpAccessChain %_ptr_Function_uint %20 %uint_2
-OpStore %69 %uint_0
-%70 = OpAccessChain %_ptr_Function_uint %20 %uint_3
-OpStore %70 %uint_2147483648
-%71 = OpAccessChain %_ptr_Function_uint %20 %uint_4
-OpStore %71 %uint_2147483647
-%72 = OpAccessChain %_ptr_Function_uint %20 %uint_5
-OpStore %72 %uint_4294967295
-%73 = OpAccessChain %_ptr_Function_uint %20 %uint_6
-OpStore %73 %uint_2147483648
-%74 = OpLoad %_arr_uint_uint_7 %20
-OpStore %19 %74
-%75 = OpLoad %ulong %23
-OpStore %44 %75
-OpStore %45 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%77 = OpLoad %ulong %45
-%79 = OpULessThan %bool %77 %ulong_7
-OpStore %27 %79
-%80 = OpLoad %bool %27
-OpLoopMerge %10 %11 None
-OpBranchConditional %80 %9 %10
-%10 = OpLabel
-%81 = OpLoad %ulong %44
-OpReturnValue %81
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%65 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%66 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%67 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%68 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_uint Function
+%74 = OpVariable %_ptr_Function_bool Function
+%75 = OpVariable %_ptr_Function_uint Function
+%76 = OpVariable %_ptr_Function_uint Function
+%77 = OpVariable %_ptr_Function_uint Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_bool Function
+%80 = OpVariable %_ptr_Function_bool Function
+%81 = OpVariable %_ptr_Function_bool Function
+%82 = OpVariable %_ptr_Function_bool Function
+%83 = OpVariable %_ptr_Function_bool Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_bool Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_bool Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_bool Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_bool Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_bool Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+OpStore %70 %4
+OpBranch %9
 %9 = OpLabel
-%82 = OpLoad %ulong %45
-%83 = OpAccessChain %_ptr_Function_uint %17 %82
-%84 = OpLoad %uint %83
-OpStore %28 %84
-%85 = OpLoad %uint %28
-%86 = OpLoad %uint %25
-%87 = OpIAdd %uint %85 %86
-OpStore %29 %87
-%88 = OpLoad %ulong %45
-%89 = OpAccessChain %_ptr_Function_uint %19 %88
-%90 = OpLoad %uint %89
-OpStore %30 %90
-%91 = OpLoad %uint %29
-%92 = OpLoad %uint %30
-%93 = OpIEqual %bool %91 %92
-OpStore %31 %93
-%95 = OpLoad %ulong %44
-%96 = OpLoad %bool %31
-%99 = OpSelect %uchar %96 %uchar_1 %uchar_0
-%100 = OpFunctionCall %ulong %3 %95 %99
-OpStore %32 %100
-%101 = OpLoad %uint %29
-%102 = OpLoad %uint %30
-%103 = OpINotEqual %bool %101 %102
-OpStore %33 %103
-%104 = OpLoad %ulong %32
-%105 = OpLoad %bool %33
-%106 = OpSelect %uchar %105 %uchar_1 %uchar_0
-%107 = OpFunctionCall %ulong %3 %104 %106
-OpStore %34 %107
-%108 = OpLoad %uint %29
-%109 = OpLoad %uint %30
-%110 = OpULessThan %bool %108 %109
-OpStore %35 %110
-%111 = OpLoad %ulong %34
-%112 = OpLoad %bool %35
-%113 = OpSelect %uchar %112 %uchar_1 %uchar_0
-%114 = OpFunctionCall %ulong %3 %111 %113
-OpStore %36 %114
-%115 = OpLoad %uint %30
-%116 = OpLoad %uint %29
-%117 = OpULessThan %bool %115 %116
-OpStore %37 %117
-%118 = OpLoad %ulong %36
-%119 = OpLoad %bool %37
-%120 = OpSelect %uchar %119 %uchar_1 %uchar_0
-%121 = OpFunctionCall %ulong %3 %118 %120
-OpStore %38 %121
-%122 = OpLoad %uint %29
-%123 = OpLoad %uint %30
-%124 = OpULessThanEqual %bool %122 %123
-OpStore %39 %124
-%125 = OpLoad %ulong %38
-%126 = OpLoad %bool %39
-%127 = OpSelect %uchar %126 %uchar_1 %uchar_0
-%128 = OpFunctionCall %ulong %3 %125 %127
-OpStore %40 %128
-%129 = OpLoad %uint %30
-%130 = OpLoad %uint %29
-%131 = OpULessThanEqual %bool %129 %130
-OpStore %41 %131
-%132 = OpLoad %ulong %40
-%133 = OpLoad %bool %41
-%134 = OpSelect %uchar %133 %uchar_1 %uchar_0
-%135 = OpFunctionCall %ulong %3 %132 %134
-OpStore %42 %135
-%136 = OpLoad %ulong %45
-%138 = OpIAdd %ulong %136 %ulong_1
-OpStore %43 %138
-%139 = OpLoad %ulong %42
-OpStore %44 %139
-%140 = OpLoad %ulong %43
-OpStore %45 %140
+OpBranch %10
+%10 = OpLabel
+%147 = OpLoad %ulong %70
+%148 = OpUConvert %uint %147
+OpStore %72 %148
+%150 = OpAccessChain %_ptr_Function_uint %66 %uint_0
+OpStore %150 %uint_0
+%152 = OpAccessChain %_ptr_Function_uint %66 %uint_1
+OpStore %152 %uint_0
+%154 = OpAccessChain %_ptr_Function_uint %66 %uint_2
+OpStore %154 %uint_4294967295
+%157 = OpAccessChain %_ptr_Function_uint %66 %uint_3
+OpStore %157 %uint_2147483647
+%160 = OpAccessChain %_ptr_Function_uint %66 %uint_4
+OpStore %160 %uint_2147483648
+%163 = OpAccessChain %_ptr_Function_uint %66 %uint_5
+OpStore %163 %uint_4294967295
+%165 = OpAccessChain %_ptr_Function_uint %66 %uint_6
+OpStore %165 %uint_2147483648
+%166 = OpLoad %_arr_uint_uint_7 %66
+OpStore %65 %166
+%167 = OpAccessChain %_ptr_Function_uint %68 %uint_0
+OpStore %167 %uint_0
+%168 = OpAccessChain %_ptr_Function_uint %68 %uint_1
+OpStore %168 %uint_4294967295
+%169 = OpAccessChain %_ptr_Function_uint %68 %uint_2
+OpStore %169 %uint_0
+%170 = OpAccessChain %_ptr_Function_uint %68 %uint_3
+OpStore %170 %uint_2147483648
+%171 = OpAccessChain %_ptr_Function_uint %68 %uint_4
+OpStore %171 %uint_2147483647
+%172 = OpAccessChain %_ptr_Function_uint %68 %uint_5
+OpStore %172 %uint_4294967295
+%173 = OpAccessChain %_ptr_Function_uint %68 %uint_6
+OpStore %173 %uint_2147483648
+%174 = OpLoad %_arr_uint_uint_7 %68
+OpStore %67 %174
+OpStore %85 %ulong_14695981039346656037
+OpStore %86 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%177 = OpLoad %ulong %86
+%179 = OpULessThan %bool %177 %ulong_7
+OpStore %74 %179
+%180 = OpLoad %bool %74
+OpLoopMerge %8 %59 None
+OpBranchConditional %180 %7 %8
+%8 = OpLabel
+%181 = OpLoad %ulong %85
+OpReturnValue %181
+%7 = OpLabel
+%182 = OpLoad %ulong %86
+%183 = OpAccessChain %_ptr_Function_uint %65 %182
+%184 = OpLoad %uint %183
+OpStore %75 %184
+%185 = OpLoad %uint %75
+%186 = OpLoad %uint %72
+%187 = OpIAdd %uint %185 %186
+OpStore %76 %187
+%188 = OpLoad %ulong %86
+%189 = OpAccessChain %_ptr_Function_uint %67 %188
+%190 = OpLoad %uint %189
+OpStore %77 %190
+%191 = OpLoad %uint %76
+%192 = OpLoad %uint %77
+%193 = OpIEqual %bool %191 %192
+OpStore %78 %193
 OpBranch %11
 %11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %141
-%142 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %144
-%145 = OpFunctionParameter %ulong
-%146 = OpFunctionParameter %uchar
-%147 = OpLabel
-%154 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_uchar Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_bool Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-OpStore %154 %145
-OpStore %156 %146
-%167 = OpLoad %uchar %156
-%168 = OpUConvert %ulong %167
-OpStore %157 %168
-OpBranch %148
-%148 = OpLabel
-%169 = OpLoad %ulong %154
-OpStore %165 %169
-OpStore %166 %ulong_0
-OpBranch %149
-%149 = OpLabel
-%170 = OpLoad %ulong %166
-%172 = OpULessThan %bool %170 %ulong_8
-OpStore %158 %172
-%173 = OpLoad %bool %158
-OpLoopMerge %151 %153 None
-OpBranchConditional %173 %150 %151
-%151 = OpLabel
-OpBranch %152
-%152 = OpLabel
-%174 = OpLoad %ulong %165
-OpReturnValue %174
-%150 = OpLabel
-%175 = OpLoad %ulong %166
-%176 = OpIMul %ulong %175 %ulong_8
-OpStore %159 %176
-%177 = OpLoad %ulong %157
-%178 = OpLoad %ulong %159
-%179 = OpShiftRightLogical %ulong %177 %178
-OpStore %160 %179
-%180 = OpLoad %ulong %160
-%182 = OpBitwiseAnd %ulong %180 %ulong_255
-OpStore %161 %182
-%183 = OpLoad %ulong %165
-%184 = OpLoad %ulong %161
-%185 = OpBitwiseXor %ulong %183 %184
-OpStore %162 %185
-%186 = OpLoad %ulong %162
-%188 = OpIMul %ulong %186 %ulong_1099511628211
-OpStore %163 %188
-%189 = OpLoad %ulong %166
-%190 = OpIAdd %ulong %189 %ulong_1
-OpStore %164 %190
-%191 = OpLoad %ulong %163
-OpStore %165 %191
-%192 = OpLoad %ulong %164
-OpStore %166 %192
-OpBranch %153
-%153 = OpLabel
-OpBranch %149
+%195 = OpLoad %bool %78
+%198 = OpSelect %uchar %195 %uchar_1 %uchar_0
+%199 = OpUConvert %ulong %198
+OpStore %87 %199
+OpBranch %13
+%13 = OpLabel
+%200 = OpLoad %ulong %85
+OpStore %95 %200
+OpStore %96 %ulong_0
+OpBranch %14
+%14 = OpLabel
+%201 = OpLoad %ulong %96
+%203 = OpULessThan %bool %201 %ulong_8
+OpStore %88 %203
+%204 = OpLoad %bool %88
+OpLoopMerge %16 %58 None
+OpBranchConditional %204 %15 %16
+%16 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%205 = OpLoad %uint %76
+%206 = OpLoad %uint %77
+%207 = OpINotEqual %bool %205 %206
+OpStore %79 %207
+OpBranch %18
+%18 = OpLabel
+%208 = OpLoad %bool %79
+%209 = OpSelect %uchar %208 %uchar_1 %uchar_0
+%210 = OpUConvert %ulong %209
+OpStore %97 %210
+OpBranch %20
+%20 = OpLabel
+%211 = OpLoad %ulong %95
+OpStore %105 %211
+OpStore %106 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%212 = OpLoad %ulong %106
+%213 = OpULessThan %bool %212 %ulong_8
+OpStore %98 %213
+%214 = OpLoad %bool %98
+OpLoopMerge %23 %57 None
+OpBranchConditional %214 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%215 = OpLoad %uint %76
+%216 = OpLoad %uint %77
+%217 = OpULessThan %bool %215 %216
+OpStore %80 %217
+OpBranch %25
+%25 = OpLabel
+%218 = OpLoad %bool %80
+%219 = OpSelect %uchar %218 %uchar_1 %uchar_0
+%220 = OpUConvert %ulong %219
+OpStore %107 %220
+OpBranch %27
+%27 = OpLabel
+%221 = OpLoad %ulong %105
+OpStore %115 %221
+OpStore %116 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%222 = OpLoad %ulong %116
+%223 = OpULessThan %bool %222 %ulong_8
+OpStore %108 %223
+%224 = OpLoad %bool %108
+OpLoopMerge %30 %56 None
+OpBranchConditional %224 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%225 = OpLoad %uint %77
+%226 = OpLoad %uint %76
+%227 = OpULessThan %bool %225 %226
+OpStore %81 %227
+OpBranch %32
+%32 = OpLabel
+%228 = OpLoad %bool %81
+%229 = OpSelect %uchar %228 %uchar_1 %uchar_0
+%230 = OpUConvert %ulong %229
+OpStore %117 %230
+OpBranch %34
+%34 = OpLabel
+%231 = OpLoad %ulong %115
+OpStore %125 %231
+OpStore %126 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%232 = OpLoad %ulong %126
+%233 = OpULessThan %bool %232 %ulong_8
+OpStore %118 %233
+%234 = OpLoad %bool %118
+OpLoopMerge %37 %55 None
+OpBranchConditional %234 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%235 = OpLoad %uint %76
+%236 = OpLoad %uint %77
+%237 = OpULessThanEqual %bool %235 %236
+OpStore %82 %237
+OpBranch %39
+%39 = OpLabel
+%238 = OpLoad %bool %82
+%239 = OpSelect %uchar %238 %uchar_1 %uchar_0
+%240 = OpUConvert %ulong %239
+OpStore %127 %240
+OpBranch %41
+%41 = OpLabel
+%241 = OpLoad %ulong %125
+OpStore %135 %241
+OpStore %136 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%242 = OpLoad %ulong %136
+%243 = OpULessThan %bool %242 %ulong_8
+OpStore %128 %243
+%244 = OpLoad %bool %128
+OpLoopMerge %44 %54 None
+OpBranchConditional %244 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%245 = OpLoad %uint %77
+%246 = OpLoad %uint %76
+%247 = OpULessThanEqual %bool %245 %246
+OpStore %83 %247
+OpBranch %46
+%46 = OpLabel
+%248 = OpLoad %bool %83
+%249 = OpSelect %uchar %248 %uchar_1 %uchar_0
+%250 = OpUConvert %ulong %249
+OpStore %137 %250
+OpBranch %48
+%48 = OpLabel
+%251 = OpLoad %ulong %135
+OpStore %145 %251
+OpStore %146 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%252 = OpLoad %ulong %146
+%253 = OpULessThan %bool %252 %ulong_8
+OpStore %138 %253
+%254 = OpLoad %bool %138
+OpLoopMerge %51 %53 None
+OpBranchConditional %254 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%255 = OpLoad %ulong %86
+%257 = OpIAdd %ulong %255 %ulong_1
+OpStore %84 %257
+%258 = OpLoad %ulong %145
+OpStore %85 %258
+%259 = OpLoad %ulong %84
+OpStore %86 %259
+OpBranch %59
+%50 = OpLabel
+%260 = OpLoad %ulong %146
+%261 = OpIMul %ulong %260 %ulong_8
+OpStore %139 %261
+%262 = OpLoad %ulong %137
+%263 = OpLoad %ulong %139
+%264 = OpShiftRightLogical %ulong %262 %263
+OpStore %140 %264
+%265 = OpLoad %ulong %140
+%267 = OpBitwiseAnd %ulong %265 %ulong_255
+OpStore %141 %267
+%268 = OpLoad %ulong %145
+%269 = OpLoad %ulong %141
+%270 = OpBitwiseXor %ulong %268 %269
+OpStore %142 %270
+%271 = OpLoad %ulong %142
+%273 = OpIMul %ulong %271 %ulong_1099511628211
+OpStore %143 %273
+%274 = OpLoad %ulong %146
+%275 = OpIAdd %ulong %274 %ulong_1
+OpStore %144 %275
+%276 = OpLoad %ulong %143
+OpStore %145 %276
+%277 = OpLoad %ulong %144
+OpStore %146 %277
+OpBranch %53
+%43 = OpLabel
+%278 = OpLoad %ulong %136
+%279 = OpIMul %ulong %278 %ulong_8
+OpStore %129 %279
+%280 = OpLoad %ulong %127
+%281 = OpLoad %ulong %129
+%282 = OpShiftRightLogical %ulong %280 %281
+OpStore %130 %282
+%283 = OpLoad %ulong %130
+%284 = OpBitwiseAnd %ulong %283 %ulong_255
+OpStore %131 %284
+%285 = OpLoad %ulong %135
+%286 = OpLoad %ulong %131
+%287 = OpBitwiseXor %ulong %285 %286
+OpStore %132 %287
+%288 = OpLoad %ulong %132
+%289 = OpIMul %ulong %288 %ulong_1099511628211
+OpStore %133 %289
+%290 = OpLoad %ulong %136
+%291 = OpIAdd %ulong %290 %ulong_1
+OpStore %134 %291
+%292 = OpLoad %ulong %133
+OpStore %135 %292
+%293 = OpLoad %ulong %134
+OpStore %136 %293
+OpBranch %54
+%36 = OpLabel
+%294 = OpLoad %ulong %126
+%295 = OpIMul %ulong %294 %ulong_8
+OpStore %119 %295
+%296 = OpLoad %ulong %117
+%297 = OpLoad %ulong %119
+%298 = OpShiftRightLogical %ulong %296 %297
+OpStore %120 %298
+%299 = OpLoad %ulong %120
+%300 = OpBitwiseAnd %ulong %299 %ulong_255
+OpStore %121 %300
+%301 = OpLoad %ulong %125
+%302 = OpLoad %ulong %121
+%303 = OpBitwiseXor %ulong %301 %302
+OpStore %122 %303
+%304 = OpLoad %ulong %122
+%305 = OpIMul %ulong %304 %ulong_1099511628211
+OpStore %123 %305
+%306 = OpLoad %ulong %126
+%307 = OpIAdd %ulong %306 %ulong_1
+OpStore %124 %307
+%308 = OpLoad %ulong %123
+OpStore %125 %308
+%309 = OpLoad %ulong %124
+OpStore %126 %309
+OpBranch %55
+%29 = OpLabel
+%310 = OpLoad %ulong %116
+%311 = OpIMul %ulong %310 %ulong_8
+OpStore %109 %311
+%312 = OpLoad %ulong %107
+%313 = OpLoad %ulong %109
+%314 = OpShiftRightLogical %ulong %312 %313
+OpStore %110 %314
+%315 = OpLoad %ulong %110
+%316 = OpBitwiseAnd %ulong %315 %ulong_255
+OpStore %111 %316
+%317 = OpLoad %ulong %115
+%318 = OpLoad %ulong %111
+%319 = OpBitwiseXor %ulong %317 %318
+OpStore %112 %319
+%320 = OpLoad %ulong %112
+%321 = OpIMul %ulong %320 %ulong_1099511628211
+OpStore %113 %321
+%322 = OpLoad %ulong %116
+%323 = OpIAdd %ulong %322 %ulong_1
+OpStore %114 %323
+%324 = OpLoad %ulong %113
+OpStore %115 %324
+%325 = OpLoad %ulong %114
+OpStore %116 %325
+OpBranch %56
+%22 = OpLabel
+%326 = OpLoad %ulong %106
+%327 = OpIMul %ulong %326 %ulong_8
+OpStore %99 %327
+%328 = OpLoad %ulong %97
+%329 = OpLoad %ulong %99
+%330 = OpShiftRightLogical %ulong %328 %329
+OpStore %100 %330
+%331 = OpLoad %ulong %100
+%332 = OpBitwiseAnd %ulong %331 %ulong_255
+OpStore %101 %332
+%333 = OpLoad %ulong %105
+%334 = OpLoad %ulong %101
+%335 = OpBitwiseXor %ulong %333 %334
+OpStore %102 %335
+%336 = OpLoad %ulong %102
+%337 = OpIMul %ulong %336 %ulong_1099511628211
+OpStore %103 %337
+%338 = OpLoad %ulong %106
+%339 = OpIAdd %ulong %338 %ulong_1
+OpStore %104 %339
+%340 = OpLoad %ulong %103
+OpStore %105 %340
+%341 = OpLoad %ulong %104
+OpStore %106 %341
+OpBranch %57
+%15 = OpLabel
+%342 = OpLoad %ulong %96
+%343 = OpIMul %ulong %342 %ulong_8
+OpStore %89 %343
+%344 = OpLoad %ulong %87
+%345 = OpLoad %ulong %89
+%346 = OpShiftRightLogical %ulong %344 %345
+OpStore %90 %346
+%347 = OpLoad %ulong %90
+%348 = OpBitwiseAnd %ulong %347 %ulong_255
+OpStore %91 %348
+%349 = OpLoad %ulong %95
+%350 = OpLoad %ulong %91
+%351 = OpBitwiseXor %ulong %349 %350
+OpStore %92 %351
+%352 = OpLoad %ulong %92
+%353 = OpIMul %ulong %352 %ulong_1099511628211
+OpStore %93 %353
+%354 = OpLoad %ulong %96
+%355 = OpIAdd %ulong %354 %ulong_1
+OpStore %94 %355
+%356 = OpLoad %ulong %93
+OpStore %95 %356
+%357 = OpLoad %ulong %94
+OpStore %96 %357
+OpBranch %58
+%53 = OpLabel
+OpBranch %49
+%54 = OpLabel
+OpBranch %42
+%55 = OpLabel
+OpBranch %35
+%56 = OpLabel
+OpBranch %28
+%57 = OpLabel
+OpBranch %21
+%58 = OpLabel
+OpBranch %14
+%59 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/cmp/cmp_u64.dis
+++ b/test/golden/spirv/cmp/cmp_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 189
+; Bound: 354
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,7 +10,7 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %uint_7 = OpConstant %uint 7
@@ -29,242 +29,503 @@ OpDecorate %1 LinkageAttributes "corpus.cases.cmp.cmp_u64.checksum" Export
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_7 = OpConstant %ulong 7
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
-%ulong_1 = OpConstant %ulong 1
-%137 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%140 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
 %ulong_8 = OpConstant %ulong 8
+%ulong_1 = OpConstant %ulong 1
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%17 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%18 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%19 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%20 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_bool Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_bool Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_bool Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_bool Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-OpStore %22 %6
-%44 = OpFunctionCall %ulong %2
-OpStore %23 %44
-%46 = OpAccessChain %_ptr_Function_ulong %18 %uint_0
-OpStore %46 %ulong_0
-%49 = OpAccessChain %_ptr_Function_ulong %18 %uint_1
-OpStore %49 %ulong_0
-%51 = OpAccessChain %_ptr_Function_ulong %18 %uint_2
-OpStore %51 %ulong_18446744073709551615
-%54 = OpAccessChain %_ptr_Function_ulong %18 %uint_3
-OpStore %54 %ulong_9223372036854775807
-%57 = OpAccessChain %_ptr_Function_ulong %18 %uint_4
-OpStore %57 %ulong_9223372036854775808
-%60 = OpAccessChain %_ptr_Function_ulong %18 %uint_5
-OpStore %60 %ulong_18446744073709551615
-%62 = OpAccessChain %_ptr_Function_ulong %18 %uint_6
-OpStore %62 %ulong_9223372036854775808
-%63 = OpLoad %_arr_ulong_uint_7 %18
-OpStore %17 %63
-%64 = OpAccessChain %_ptr_Function_ulong %20 %uint_0
-OpStore %64 %ulong_0
-%65 = OpAccessChain %_ptr_Function_ulong %20 %uint_1
-OpStore %65 %ulong_18446744073709551615
-%66 = OpAccessChain %_ptr_Function_ulong %20 %uint_2
-OpStore %66 %ulong_0
-%67 = OpAccessChain %_ptr_Function_ulong %20 %uint_3
-OpStore %67 %ulong_9223372036854775808
-%68 = OpAccessChain %_ptr_Function_ulong %20 %uint_4
-OpStore %68 %ulong_9223372036854775807
-%69 = OpAccessChain %_ptr_Function_ulong %20 %uint_5
-OpStore %69 %ulong_18446744073709551615
-%70 = OpAccessChain %_ptr_Function_ulong %20 %uint_6
-OpStore %70 %ulong_9223372036854775808
-%71 = OpLoad %_arr_ulong_uint_7 %20
-OpStore %19 %71
-%72 = OpLoad %ulong %23
-OpStore %42 %72
-OpStore %43 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%73 = OpLoad %ulong %43
-%75 = OpULessThan %bool %73 %ulong_7
-OpStore %25 %75
-%76 = OpLoad %bool %25
-OpLoopMerge %10 %11 None
-OpBranchConditional %76 %9 %10
-%10 = OpLabel
-%77 = OpLoad %ulong %42
-OpReturnValue %77
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%65 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%66 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%67 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%68 = OpVariable %_ptr_Function__arr_ulong_uint_7 Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_bool Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_bool Function
+%77 = OpVariable %_ptr_Function_bool Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_bool Function
+%80 = OpVariable %_ptr_Function_bool Function
+%81 = OpVariable %_ptr_Function_bool Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_bool Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_bool Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_bool Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_bool Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_bool Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_bool Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+OpStore %70 %4
+OpBranch %9
 %9 = OpLabel
-%78 = OpLoad %ulong %43
-%79 = OpAccessChain %_ptr_Function_ulong %17 %78
-%80 = OpLoad %ulong %79
-OpStore %26 %80
-%81 = OpLoad %ulong %26
-%82 = OpLoad %ulong %22
-%83 = OpIAdd %ulong %81 %82
-OpStore %27 %83
-%84 = OpLoad %ulong %43
-%85 = OpAccessChain %_ptr_Function_ulong %19 %84
-%86 = OpLoad %ulong %85
-OpStore %28 %86
-%87 = OpLoad %ulong %27
-%88 = OpLoad %ulong %28
-%89 = OpIEqual %bool %87 %88
-OpStore %29 %89
-%91 = OpLoad %ulong %42
-%92 = OpLoad %bool %29
-%95 = OpSelect %uchar %92 %uchar_1 %uchar_0
-%96 = OpFunctionCall %ulong %3 %91 %95
-OpStore %30 %96
-%97 = OpLoad %ulong %27
-%98 = OpLoad %ulong %28
-%99 = OpINotEqual %bool %97 %98
-OpStore %31 %99
-%100 = OpLoad %ulong %30
-%101 = OpLoad %bool %31
-%102 = OpSelect %uchar %101 %uchar_1 %uchar_0
-%103 = OpFunctionCall %ulong %3 %100 %102
-OpStore %32 %103
-%104 = OpLoad %ulong %27
-%105 = OpLoad %ulong %28
-%106 = OpULessThan %bool %104 %105
-OpStore %33 %106
-%107 = OpLoad %ulong %32
-%108 = OpLoad %bool %33
-%109 = OpSelect %uchar %108 %uchar_1 %uchar_0
-%110 = OpFunctionCall %ulong %3 %107 %109
-OpStore %34 %110
-%111 = OpLoad %ulong %28
-%112 = OpLoad %ulong %27
-%113 = OpULessThan %bool %111 %112
-OpStore %35 %113
-%114 = OpLoad %ulong %34
-%115 = OpLoad %bool %35
-%116 = OpSelect %uchar %115 %uchar_1 %uchar_0
-%117 = OpFunctionCall %ulong %3 %114 %116
-OpStore %36 %117
-%118 = OpLoad %ulong %27
-%119 = OpLoad %ulong %28
-%120 = OpULessThanEqual %bool %118 %119
-OpStore %37 %120
-%121 = OpLoad %ulong %36
-%122 = OpLoad %bool %37
-%123 = OpSelect %uchar %122 %uchar_1 %uchar_0
-%124 = OpFunctionCall %ulong %3 %121 %123
-OpStore %38 %124
-%125 = OpLoad %ulong %28
-%126 = OpLoad %ulong %27
-%127 = OpULessThanEqual %bool %125 %126
-OpStore %39 %127
-%128 = OpLoad %ulong %38
-%129 = OpLoad %bool %39
-%130 = OpSelect %uchar %129 %uchar_1 %uchar_0
-%131 = OpFunctionCall %ulong %3 %128 %130
-OpStore %40 %131
-%132 = OpLoad %ulong %43
-%134 = OpIAdd %ulong %132 %ulong_1
-OpStore %41 %134
-%135 = OpLoad %ulong %40
-OpStore %42 %135
-%136 = OpLoad %ulong %41
-OpStore %43 %136
+OpBranch %10
+%10 = OpLabel
+%146 = OpAccessChain %_ptr_Function_ulong %66 %uint_0
+OpStore %146 %ulong_0
+%149 = OpAccessChain %_ptr_Function_ulong %66 %uint_1
+OpStore %149 %ulong_0
+%151 = OpAccessChain %_ptr_Function_ulong %66 %uint_2
+OpStore %151 %ulong_18446744073709551615
+%154 = OpAccessChain %_ptr_Function_ulong %66 %uint_3
+OpStore %154 %ulong_9223372036854775807
+%157 = OpAccessChain %_ptr_Function_ulong %66 %uint_4
+OpStore %157 %ulong_9223372036854775808
+%160 = OpAccessChain %_ptr_Function_ulong %66 %uint_5
+OpStore %160 %ulong_18446744073709551615
+%162 = OpAccessChain %_ptr_Function_ulong %66 %uint_6
+OpStore %162 %ulong_9223372036854775808
+%163 = OpLoad %_arr_ulong_uint_7 %66
+OpStore %65 %163
+%164 = OpAccessChain %_ptr_Function_ulong %68 %uint_0
+OpStore %164 %ulong_0
+%165 = OpAccessChain %_ptr_Function_ulong %68 %uint_1
+OpStore %165 %ulong_18446744073709551615
+%166 = OpAccessChain %_ptr_Function_ulong %68 %uint_2
+OpStore %166 %ulong_0
+%167 = OpAccessChain %_ptr_Function_ulong %68 %uint_3
+OpStore %167 %ulong_9223372036854775808
+%168 = OpAccessChain %_ptr_Function_ulong %68 %uint_4
+OpStore %168 %ulong_9223372036854775807
+%169 = OpAccessChain %_ptr_Function_ulong %68 %uint_5
+OpStore %169 %ulong_18446744073709551615
+%170 = OpAccessChain %_ptr_Function_ulong %68 %uint_6
+OpStore %170 %ulong_9223372036854775808
+%171 = OpLoad %_arr_ulong_uint_7 %68
+OpStore %67 %171
+OpStore %83 %ulong_14695981039346656037
+OpStore %84 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%173 = OpLoad %ulong %84
+%175 = OpULessThan %bool %173 %ulong_7
+OpStore %72 %175
+%176 = OpLoad %bool %72
+OpLoopMerge %8 %59 None
+OpBranchConditional %176 %7 %8
+%8 = OpLabel
+%177 = OpLoad %ulong %83
+OpReturnValue %177
+%7 = OpLabel
+%178 = OpLoad %ulong %84
+%179 = OpAccessChain %_ptr_Function_ulong %65 %178
+%180 = OpLoad %ulong %179
+OpStore %73 %180
+%181 = OpLoad %ulong %73
+%182 = OpLoad %ulong %70
+%183 = OpIAdd %ulong %181 %182
+OpStore %74 %183
+%184 = OpLoad %ulong %84
+%185 = OpAccessChain %_ptr_Function_ulong %67 %184
+%186 = OpLoad %ulong %185
+OpStore %75 %186
+%187 = OpLoad %ulong %74
+%188 = OpLoad %ulong %75
+%189 = OpIEqual %bool %187 %188
+OpStore %76 %189
 OpBranch %11
 %11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %137
-%138 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %140
-%141 = OpFunctionParameter %ulong
-%142 = OpFunctionParameter %uchar
-%143 = OpLabel
-%150 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_uchar Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-OpStore %150 %141
-OpStore %152 %142
-%163 = OpLoad %uchar %152
-%164 = OpUConvert %ulong %163
-OpStore %153 %164
-OpBranch %144
-%144 = OpLabel
-%165 = OpLoad %ulong %150
-OpStore %161 %165
-OpStore %162 %ulong_0
-OpBranch %145
-%145 = OpLabel
-%166 = OpLoad %ulong %162
-%168 = OpULessThan %bool %166 %ulong_8
-OpStore %154 %168
-%169 = OpLoad %bool %154
-OpLoopMerge %147 %149 None
-OpBranchConditional %169 %146 %147
-%147 = OpLabel
-OpBranch %148
-%148 = OpLabel
-%170 = OpLoad %ulong %161
-OpReturnValue %170
-%146 = OpLabel
-%171 = OpLoad %ulong %162
-%172 = OpIMul %ulong %171 %ulong_8
-OpStore %155 %172
-%173 = OpLoad %ulong %153
-%174 = OpLoad %ulong %155
-%175 = OpShiftRightLogical %ulong %173 %174
-OpStore %156 %175
-%176 = OpLoad %ulong %156
-%178 = OpBitwiseAnd %ulong %176 %ulong_255
-OpStore %157 %178
-%179 = OpLoad %ulong %161
-%180 = OpLoad %ulong %157
-%181 = OpBitwiseXor %ulong %179 %180
-OpStore %158 %181
-%182 = OpLoad %ulong %158
-%184 = OpIMul %ulong %182 %ulong_1099511628211
-OpStore %159 %184
-%185 = OpLoad %ulong %162
-%186 = OpIAdd %ulong %185 %ulong_1
-OpStore %160 %186
-%187 = OpLoad %ulong %159
-OpStore %161 %187
-%188 = OpLoad %ulong %160
-OpStore %162 %188
-OpBranch %149
-%149 = OpLabel
-OpBranch %145
+%191 = OpLoad %bool %76
+%194 = OpSelect %uchar %191 %uchar_1 %uchar_0
+%195 = OpUConvert %ulong %194
+OpStore %85 %195
+OpBranch %13
+%13 = OpLabel
+%196 = OpLoad %ulong %83
+OpStore %93 %196
+OpStore %94 %ulong_0
+OpBranch %14
+%14 = OpLabel
+%197 = OpLoad %ulong %94
+%199 = OpULessThan %bool %197 %ulong_8
+OpStore %86 %199
+%200 = OpLoad %bool %86
+OpLoopMerge %16 %58 None
+OpBranchConditional %200 %15 %16
+%16 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%201 = OpLoad %ulong %74
+%202 = OpLoad %ulong %75
+%203 = OpINotEqual %bool %201 %202
+OpStore %77 %203
+OpBranch %18
+%18 = OpLabel
+%204 = OpLoad %bool %77
+%205 = OpSelect %uchar %204 %uchar_1 %uchar_0
+%206 = OpUConvert %ulong %205
+OpStore %95 %206
+OpBranch %20
+%20 = OpLabel
+%207 = OpLoad %ulong %93
+OpStore %103 %207
+OpStore %104 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%208 = OpLoad %ulong %104
+%209 = OpULessThan %bool %208 %ulong_8
+OpStore %96 %209
+%210 = OpLoad %bool %96
+OpLoopMerge %23 %57 None
+OpBranchConditional %210 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%211 = OpLoad %ulong %74
+%212 = OpLoad %ulong %75
+%213 = OpULessThan %bool %211 %212
+OpStore %78 %213
+OpBranch %25
+%25 = OpLabel
+%214 = OpLoad %bool %78
+%215 = OpSelect %uchar %214 %uchar_1 %uchar_0
+%216 = OpUConvert %ulong %215
+OpStore %105 %216
+OpBranch %27
+%27 = OpLabel
+%217 = OpLoad %ulong %103
+OpStore %113 %217
+OpStore %114 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%218 = OpLoad %ulong %114
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %106 %219
+%220 = OpLoad %bool %106
+OpLoopMerge %30 %56 None
+OpBranchConditional %220 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%221 = OpLoad %ulong %75
+%222 = OpLoad %ulong %74
+%223 = OpULessThan %bool %221 %222
+OpStore %79 %223
+OpBranch %32
+%32 = OpLabel
+%224 = OpLoad %bool %79
+%225 = OpSelect %uchar %224 %uchar_1 %uchar_0
+%226 = OpUConvert %ulong %225
+OpStore %115 %226
+OpBranch %34
+%34 = OpLabel
+%227 = OpLoad %ulong %113
+OpStore %123 %227
+OpStore %124 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%228 = OpLoad %ulong %124
+%229 = OpULessThan %bool %228 %ulong_8
+OpStore %116 %229
+%230 = OpLoad %bool %116
+OpLoopMerge %37 %55 None
+OpBranchConditional %230 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%231 = OpLoad %ulong %74
+%232 = OpLoad %ulong %75
+%233 = OpULessThanEqual %bool %231 %232
+OpStore %80 %233
+OpBranch %39
+%39 = OpLabel
+%234 = OpLoad %bool %80
+%235 = OpSelect %uchar %234 %uchar_1 %uchar_0
+%236 = OpUConvert %ulong %235
+OpStore %125 %236
+OpBranch %41
+%41 = OpLabel
+%237 = OpLoad %ulong %123
+OpStore %133 %237
+OpStore %134 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%238 = OpLoad %ulong %134
+%239 = OpULessThan %bool %238 %ulong_8
+OpStore %126 %239
+%240 = OpLoad %bool %126
+OpLoopMerge %44 %54 None
+OpBranchConditional %240 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%241 = OpLoad %ulong %75
+%242 = OpLoad %ulong %74
+%243 = OpULessThanEqual %bool %241 %242
+OpStore %81 %243
+OpBranch %46
+%46 = OpLabel
+%244 = OpLoad %bool %81
+%245 = OpSelect %uchar %244 %uchar_1 %uchar_0
+%246 = OpUConvert %ulong %245
+OpStore %135 %246
+OpBranch %48
+%48 = OpLabel
+%247 = OpLoad %ulong %133
+OpStore %143 %247
+OpStore %144 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%248 = OpLoad %ulong %144
+%249 = OpULessThan %bool %248 %ulong_8
+OpStore %136 %249
+%250 = OpLoad %bool %136
+OpLoopMerge %51 %53 None
+OpBranchConditional %250 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%251 = OpLoad %ulong %84
+%253 = OpIAdd %ulong %251 %ulong_1
+OpStore %82 %253
+%254 = OpLoad %ulong %143
+OpStore %83 %254
+%255 = OpLoad %ulong %82
+OpStore %84 %255
+OpBranch %59
+%50 = OpLabel
+%256 = OpLoad %ulong %144
+%257 = OpIMul %ulong %256 %ulong_8
+OpStore %137 %257
+%258 = OpLoad %ulong %135
+%259 = OpLoad %ulong %137
+%260 = OpShiftRightLogical %ulong %258 %259
+OpStore %138 %260
+%261 = OpLoad %ulong %138
+%263 = OpBitwiseAnd %ulong %261 %ulong_255
+OpStore %139 %263
+%264 = OpLoad %ulong %143
+%265 = OpLoad %ulong %139
+%266 = OpBitwiseXor %ulong %264 %265
+OpStore %140 %266
+%267 = OpLoad %ulong %140
+%269 = OpIMul %ulong %267 %ulong_1099511628211
+OpStore %141 %269
+%270 = OpLoad %ulong %144
+%271 = OpIAdd %ulong %270 %ulong_1
+OpStore %142 %271
+%272 = OpLoad %ulong %141
+OpStore %143 %272
+%273 = OpLoad %ulong %142
+OpStore %144 %273
+OpBranch %53
+%43 = OpLabel
+%274 = OpLoad %ulong %134
+%275 = OpIMul %ulong %274 %ulong_8
+OpStore %127 %275
+%276 = OpLoad %ulong %125
+%277 = OpLoad %ulong %127
+%278 = OpShiftRightLogical %ulong %276 %277
+OpStore %128 %278
+%279 = OpLoad %ulong %128
+%280 = OpBitwiseAnd %ulong %279 %ulong_255
+OpStore %129 %280
+%281 = OpLoad %ulong %133
+%282 = OpLoad %ulong %129
+%283 = OpBitwiseXor %ulong %281 %282
+OpStore %130 %283
+%284 = OpLoad %ulong %130
+%285 = OpIMul %ulong %284 %ulong_1099511628211
+OpStore %131 %285
+%286 = OpLoad %ulong %134
+%287 = OpIAdd %ulong %286 %ulong_1
+OpStore %132 %287
+%288 = OpLoad %ulong %131
+OpStore %133 %288
+%289 = OpLoad %ulong %132
+OpStore %134 %289
+OpBranch %54
+%36 = OpLabel
+%290 = OpLoad %ulong %124
+%291 = OpIMul %ulong %290 %ulong_8
+OpStore %117 %291
+%292 = OpLoad %ulong %115
+%293 = OpLoad %ulong %117
+%294 = OpShiftRightLogical %ulong %292 %293
+OpStore %118 %294
+%295 = OpLoad %ulong %118
+%296 = OpBitwiseAnd %ulong %295 %ulong_255
+OpStore %119 %296
+%297 = OpLoad %ulong %123
+%298 = OpLoad %ulong %119
+%299 = OpBitwiseXor %ulong %297 %298
+OpStore %120 %299
+%300 = OpLoad %ulong %120
+%301 = OpIMul %ulong %300 %ulong_1099511628211
+OpStore %121 %301
+%302 = OpLoad %ulong %124
+%303 = OpIAdd %ulong %302 %ulong_1
+OpStore %122 %303
+%304 = OpLoad %ulong %121
+OpStore %123 %304
+%305 = OpLoad %ulong %122
+OpStore %124 %305
+OpBranch %55
+%29 = OpLabel
+%306 = OpLoad %ulong %114
+%307 = OpIMul %ulong %306 %ulong_8
+OpStore %107 %307
+%308 = OpLoad %ulong %105
+%309 = OpLoad %ulong %107
+%310 = OpShiftRightLogical %ulong %308 %309
+OpStore %108 %310
+%311 = OpLoad %ulong %108
+%312 = OpBitwiseAnd %ulong %311 %ulong_255
+OpStore %109 %312
+%313 = OpLoad %ulong %113
+%314 = OpLoad %ulong %109
+%315 = OpBitwiseXor %ulong %313 %314
+OpStore %110 %315
+%316 = OpLoad %ulong %110
+%317 = OpIMul %ulong %316 %ulong_1099511628211
+OpStore %111 %317
+%318 = OpLoad %ulong %114
+%319 = OpIAdd %ulong %318 %ulong_1
+OpStore %112 %319
+%320 = OpLoad %ulong %111
+OpStore %113 %320
+%321 = OpLoad %ulong %112
+OpStore %114 %321
+OpBranch %56
+%22 = OpLabel
+%322 = OpLoad %ulong %104
+%323 = OpIMul %ulong %322 %ulong_8
+OpStore %97 %323
+%324 = OpLoad %ulong %95
+%325 = OpLoad %ulong %97
+%326 = OpShiftRightLogical %ulong %324 %325
+OpStore %98 %326
+%327 = OpLoad %ulong %98
+%328 = OpBitwiseAnd %ulong %327 %ulong_255
+OpStore %99 %328
+%329 = OpLoad %ulong %103
+%330 = OpLoad %ulong %99
+%331 = OpBitwiseXor %ulong %329 %330
+OpStore %100 %331
+%332 = OpLoad %ulong %100
+%333 = OpIMul %ulong %332 %ulong_1099511628211
+OpStore %101 %333
+%334 = OpLoad %ulong %104
+%335 = OpIAdd %ulong %334 %ulong_1
+OpStore %102 %335
+%336 = OpLoad %ulong %101
+OpStore %103 %336
+%337 = OpLoad %ulong %102
+OpStore %104 %337
+OpBranch %57
+%15 = OpLabel
+%338 = OpLoad %ulong %94
+%339 = OpIMul %ulong %338 %ulong_8
+OpStore %87 %339
+%340 = OpLoad %ulong %85
+%341 = OpLoad %ulong %87
+%342 = OpShiftRightLogical %ulong %340 %341
+OpStore %88 %342
+%343 = OpLoad %ulong %88
+%344 = OpBitwiseAnd %ulong %343 %ulong_255
+OpStore %89 %344
+%345 = OpLoad %ulong %93
+%346 = OpLoad %ulong %89
+%347 = OpBitwiseXor %ulong %345 %346
+OpStore %90 %347
+%348 = OpLoad %ulong %90
+%349 = OpIMul %ulong %348 %ulong_1099511628211
+OpStore %91 %349
+%350 = OpLoad %ulong %94
+%351 = OpIAdd %ulong %350 %ulong_1
+OpStore %92 %351
+%352 = OpLoad %ulong %91
+OpStore %93 %352
+%353 = OpLoad %ulong %92
+OpStore %94 %353
+OpBranch %58
+%53 = OpLabel
+OpBranch %49
+%54 = OpLabel
+OpBranch %42
+%55 = OpLabel
+OpBranch %35
+%56 = OpLabel
+OpBranch %28
+%57 = OpLabel
+OpBranch %21
+%58 = OpLabel
+OpBranch %14
+%59 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/cmp/loop_shapes.dis
+++ b/test/golden/spirv/cmp/loop_shapes.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 269
+; Bound: 399
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,406 +9,612 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.cmp.loop_shapes.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_16 = OpConstant %uint 16
 %uint_98 = OpConstant %uint 98
 %uint_6 = OpConstant %uint 6
 %uint_9 = OpConstant %uint 9
 %uint_1000000 = OpConstant %uint 1000000
-%uint_1 = OpConstant %uint 1
-%uint_20 = OpConstant %uint 20
-%uint_3 = OpConstant %uint 3
-%uint_7 = OpConstant %uint 7
-%216 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%219 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
+%uint_1 = OpConstant %uint 1
+%uint_20 = OpConstant %uint 20
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uint Function
-%50 = OpVariable %_ptr_Function_bool Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uint Function
-%56 = OpVariable %_ptr_Function_uint Function
-%57 = OpVariable %_ptr_Function_bool Function
-%58 = OpVariable %_ptr_Function_uint Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_bool Function
-%61 = OpVariable %_ptr_Function_bool Function
-%62 = OpVariable %_ptr_Function_bool Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-%65 = OpVariable %_ptr_Function_uint Function
-%66 = OpVariable %_ptr_Function_uint Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_uint Function
-%69 = OpVariable %_ptr_Function_uint Function
-%70 = OpVariable %_ptr_Function_bool Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_uint Function
-%73 = OpVariable %_ptr_Function_bool Function
-%74 = OpVariable %_ptr_Function_uint Function
-%75 = OpVariable %_ptr_Function_uint Function
-%76 = OpVariable %_ptr_Function_bool Function
-%77 = OpVariable %_ptr_Function_uint Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_uint Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
+%uint_3 = OpConstant %uint 3
+%uint_7 = OpConstant %uint 7
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
 %85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
 %87 = OpVariable %_ptr_Function_uint Function
-%88 = OpVariable %_ptr_Function_uint Function
-%89 = OpVariable %_ptr_Function_uint Function
+%89 = OpVariable %_ptr_Function_bool Function
 %90 = OpVariable %_ptr_Function_uint Function
 %91 = OpVariable %_ptr_Function_uint Function
 %92 = OpVariable %_ptr_Function_uint Function
 %93 = OpVariable %_ptr_Function_uint Function
 %94 = OpVariable %_ptr_Function_uint Function
-%95 = OpVariable %_ptr_Function_uint Function
-OpStore %45 %6
-%96 = OpFunctionCall %ulong %2
-OpStore %46 %96
-%97 = OpLoad %ulong %45
-%98 = OpUConvert %uint %97
-OpStore %48 %98
-%99 = OpLoad %ulong %46
-OpStore %86 %99
-OpStore %87 %uint_0
-%101 = OpLoad %uint %48
-OpStore %88 %101
-OpBranch %8
+%95 = OpVariable %_ptr_Function_bool Function
+%96 = OpVariable %_ptr_Function_uint Function
+%97 = OpVariable %_ptr_Function_bool Function
+%98 = OpVariable %_ptr_Function_bool Function
+%99 = OpVariable %_ptr_Function_bool Function
+%100 = OpVariable %_ptr_Function_uint Function
+%101 = OpVariable %_ptr_Function_uint Function
+%102 = OpVariable %_ptr_Function_uint Function
+%103 = OpVariable %_ptr_Function_uint Function
+%104 = OpVariable %_ptr_Function_uint Function
+%105 = OpVariable %_ptr_Function_uint Function
+%106 = OpVariable %_ptr_Function_bool Function
+%107 = OpVariable %_ptr_Function_uint Function
+%108 = OpVariable %_ptr_Function_bool Function
+%109 = OpVariable %_ptr_Function_uint Function
+%110 = OpVariable %_ptr_Function_uint Function
+%111 = OpVariable %_ptr_Function_bool Function
+%112 = OpVariable %_ptr_Function_uint Function
+%113 = OpVariable %_ptr_Function_uint Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_uint Function
+%127 = OpVariable %_ptr_Function_uint Function
+%128 = OpVariable %_ptr_Function_uint Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_bool Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_bool Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_bool Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+OpStore %85 %4
+OpBranch %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%180 = OpLoad %ulong %85
+%181 = OpUConvert %uint %180
+OpStore %87 %181
+OpStore %120 %ulong_14695981039346656037
+OpStore %121 %uint_0
+%184 = OpLoad %uint %87
+OpStore %122 %184
+OpBranch %6
+%6 = OpLabel
+%185 = OpLoad %uint %121
+%187 = OpULessThan %bool %185 %uint_16
+OpStore %89 %187
+%188 = OpLoad %bool %89
+OpLoopMerge %8 %79 None
+OpBranchConditional %188 %7 %8
 %8 = OpLabel
-%102 = OpLoad %uint %87
-%104 = OpULessThan %bool %102 %uint_16
-OpStore %50 %104
-%105 = OpLoad %bool %50
-OpLoopMerge %10 %39 None
-OpBranchConditional %105 %9 %10
-%10 = OpLabel
-%107 = OpLoad %uint %48
-%108 = OpIAdd %uint %uint_98 %107
-OpStore %56 %108
-%109 = OpLoad %ulong %86
-OpStore %85 %109
-%110 = OpLoad %uint %56
-OpStore %89 %110
-OpBranch %11
+%190 = OpLoad %uint %87
+%191 = OpIAdd %uint %uint_98 %190
+OpStore %94 %191
+%192 = OpLoad %ulong %120
+OpStore %119 %192
+%193 = OpLoad %uint %94
+OpStore %123 %193
+OpBranch %9
+%9 = OpLabel
+%194 = OpLoad %uint %123
+%195 = OpULessThan %bool %uint_0 %194
+OpStore %95 %195
+%196 = OpLoad %bool %95
+OpLoopMerge %11 %78 None
+OpBranchConditional %196 %10 %11
 %11 = OpLabel
-%111 = OpLoad %uint %89
-%112 = OpULessThan %bool %uint_0 %111
-OpStore %57 %112
-%113 = OpLoad %bool %57
-OpLoopMerge %13 %38 None
-OpBranchConditional %113 %12 %13
-%13 = OpLabel
-%114 = OpLoad %ulong %85
-OpStore %84 %114
-OpStore %90 %uint_0
-OpBranch %14
+%197 = OpLoad %ulong %119
+OpStore %118 %197
+OpStore %124 %uint_0
+OpBranch %12
+%12 = OpLabel
+%198 = OpLoad %uint %124
+%200 = OpULessThan %bool %198 %uint_6
+OpStore %97 %200
+%201 = OpLoad %bool %97
+OpLoopMerge %14 %76 None
+OpBranchConditional %201 %13 %14
 %14 = OpLabel
-%115 = OpLoad %uint %90
-%117 = OpULessThan %bool %115 %uint_6
-OpStore %60 %117
-%118 = OpLoad %bool %60
-OpLoopMerge %16 %37 None
-OpBranchConditional %118 %15 %16
-%16 = OpLabel
-%120 = OpLoad %uint %48
-%121 = OpIAdd %uint %uint_9 %120
-OpStore %72 %121
-%122 = OpLoad %ulong %84
-OpStore %81 %122
-%123 = OpLoad %uint %48
-OpStore %92 %123
+%203 = OpLoad %uint %87
+%204 = OpIAdd %uint %uint_9 %203
+OpStore %107 %204
+%205 = OpLoad %ulong %118
+OpStore %115 %205
+%206 = OpLoad %uint %87
+OpStore %126 %206
+OpBranch %21
+%21 = OpLabel
+%207 = OpLoad %uint %126
+%209 = OpULessThan %bool %207 %uint_1000000
+OpStore %106 %209
+OpLoopMerge %23 %73 None
+OpBranch %74
+%74 = OpLabel
+%210 = OpLoad %bool %106
+OpSelectionMerge %22 None
+OpBranchConditional %210 %22 %67
+%67 = OpLabel
+%211 = OpLoad %ulong %115
+OpStore %116 %211
+OpBranch %23
+%22 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%212 = OpLoad %uint %126
+%213 = OpUConvert %ulong %212
+OpStore %133 %213
+OpBranch %57
+%57 = OpLabel
+%214 = OpLoad %ulong %115
+OpStore %169 %214
+OpStore %170 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%216 = OpLoad %ulong %170
+%218 = OpULessThan %bool %216 %ulong_8
+OpStore %162 %218
+%219 = OpLoad %bool %162
+OpLoopMerge %60 %70 None
+OpBranchConditional %219 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %39
+%39 = OpLabel
+%220 = OpLoad %uint %126
+%221 = OpLoad %uint %107
+%222 = OpIEqual %bool %220 %221
+OpStore %108 %222
+%223 = OpLoad %bool %108
+OpSelectionMerge %81 None
+OpBranchConditional %223 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%224 = OpLoad %uint %126
+%226 = OpIAdd %uint %224 %uint_1
+OpStore %109 %226
+%227 = OpLoad %ulong %169
+OpStore %115 %227
+%228 = OpLoad %uint %109
+OpStore %126 %228
+OpBranch %73
+%24 = OpLabel
+%229 = OpLoad %ulong %169
+OpStore %116 %229
 OpBranch %23
 %23 = OpLabel
-%124 = OpLoad %uint %92
-%126 = OpULessThan %bool %124 %uint_1000000
-OpStore %70 %126
-OpLoopMerge %25 %35 None
+%230 = OpLoad %uint %87
+%231 = OpIAdd %uint %uint_1 %230
+OpStore %110 %231
+%232 = OpLoad %ulong %116
+OpStore %114 %232
+%233 = OpLoad %uint %110
+OpStore %127 %233
+OpStore %128 %uint_1
+OpStore %129 %uint_0
+OpBranch %27
+%27 = OpLabel
+%234 = OpLoad %uint %129
+%236 = OpULessThan %bool %234 %uint_20
+OpStore %111 %236
+%237 = OpLoad %bool %111
+OpLoopMerge %29 %71 None
+OpBranchConditional %237 %28 %29
+%29 = OpLabel
+%238 = OpLoad %ulong %114
+OpReturnValue %238
+%28 = OpLabel
+%239 = OpLoad %uint %127
+%240 = OpLoad %uint %128
+%241 = OpIAdd %uint %239 %240
+OpStore %112 %241
+OpBranch %40
+%40 = OpLabel
+%242 = OpLoad %uint %112
+%243 = OpUConvert %ulong %242
+OpStore %134 %243
+OpBranch %62
+%62 = OpLabel
+%244 = OpLoad %ulong %114
+OpStore %178 %244
+OpStore %179 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%245 = OpLoad %ulong %179
+%246 = OpULessThan %bool %245 %ulong_8
+OpStore %171 %246
+%247 = OpLoad %bool %171
+OpLoopMerge %65 %69 None
+OpBranchConditional %247 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%248 = OpLoad %uint %129
+%249 = OpIAdd %uint %248 %uint_1
+OpStore %113 %249
+%250 = OpLoad %ulong %178
+OpStore %114 %250
+%251 = OpLoad %uint %128
+OpStore %127 %251
+%252 = OpLoad %uint %112
+OpStore %128 %252
+%253 = OpLoad %uint %113
+OpStore %129 %253
+OpBranch %71
+%64 = OpLabel
+%254 = OpLoad %ulong %179
+%255 = OpIMul %ulong %254 %ulong_8
+OpStore %172 %255
+%256 = OpLoad %ulong %134
+%257 = OpLoad %ulong %172
+%258 = OpShiftRightLogical %ulong %256 %257
+OpStore %173 %258
+%259 = OpLoad %ulong %173
+%261 = OpBitwiseAnd %ulong %259 %ulong_255
+OpStore %174 %261
+%262 = OpLoad %ulong %178
+%263 = OpLoad %ulong %174
+%264 = OpBitwiseXor %ulong %262 %263
+OpStore %175 %264
+%265 = OpLoad %ulong %175
+%267 = OpIMul %ulong %265 %ulong_1099511628211
+OpStore %176 %267
+%268 = OpLoad %ulong %179
+%270 = OpIAdd %ulong %268 %ulong_1
+OpStore %177 %270
+%271 = OpLoad %ulong %176
+OpStore %178 %271
+%272 = OpLoad %ulong %177
+OpStore %179 %272
+OpBranch %69
+%59 = OpLabel
+%273 = OpLoad %ulong %170
+%274 = OpIMul %ulong %273 %ulong_8
+OpStore %163 %274
+%275 = OpLoad %ulong %133
+%276 = OpLoad %ulong %163
+%277 = OpShiftRightLogical %ulong %275 %276
+OpStore %164 %277
+%278 = OpLoad %ulong %164
+%279 = OpBitwiseAnd %ulong %278 %ulong_255
+OpStore %165 %279
+%280 = OpLoad %ulong %169
+%281 = OpLoad %ulong %165
+%282 = OpBitwiseXor %ulong %280 %281
+OpStore %166 %282
+%283 = OpLoad %ulong %166
+%284 = OpIMul %ulong %283 %ulong_1099511628211
+OpStore %167 %284
+%285 = OpLoad %ulong %170
+%286 = OpIAdd %ulong %285 %ulong_1
+OpStore %168 %286
+%287 = OpLoad %ulong %167
+OpStore %169 %287
+%288 = OpLoad %ulong %168
+OpStore %170 %288
+OpBranch %70
+%13 = OpLabel
+%289 = OpLoad %uint %124
+%290 = OpIMul %uint %289 %uint_6
+OpStore %101 %290
+%291 = OpLoad %ulong %118
+OpStore %117 %291
+OpStore %125 %uint_0
+OpBranch %15
+%15 = OpLabel
+%292 = OpLoad %uint %125
+%293 = OpULessThan %bool %292 %uint_6
+OpStore %98 %293
+%294 = OpLoad %bool %98
+OpLoopMerge %17 %72 None
+OpBranchConditional %294 %16 %17
+%17 = OpLabel
+%295 = OpLoad %uint %124
+%296 = OpIAdd %uint %295 %uint_1
+OpStore %105 %296
+%297 = OpLoad %ulong %117
+OpStore %118 %297
+%298 = OpLoad %uint %105
+OpStore %124 %298
+OpBranch %76
+%16 = OpLabel
+%299 = OpLoad %uint %125
+%301 = OpIEqual %bool %299 %uint_3
+OpStore %99 %301
+%302 = OpLoad %bool %99
+OpSelectionMerge %80 None
+OpBranchConditional %302 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%303 = OpLoad %uint %101
+%304 = OpLoad %uint %125
+%305 = OpIAdd %uint %303 %304
+OpStore %102 %305
+%306 = OpLoad %uint %102
+%307 = OpLoad %uint %87
+%308 = OpIAdd %uint %306 %307
+OpStore %103 %308
 OpBranch %36
 %36 = OpLabel
-%127 = OpLoad %bool %70
-OpSelectionMerge %24 None
-OpBranchConditional %127 %24 %32
-%32 = OpLabel
-%128 = OpLoad %ulong %81
-OpStore %82 %128
-OpBranch %25
-%24 = OpLabel
-%129 = OpLoad %ulong %81
-%130 = OpLoad %uint %92
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %71 %131
-%132 = OpLoad %uint %92
-%133 = OpLoad %uint %72
-%134 = OpIEqual %bool %132 %133
-OpStore %73 %134
-%135 = OpLoad %bool %73
-OpSelectionMerge %41 None
-OpBranchConditional %135 %26 %27
-%27 = OpLabel
-OpBranch %28
-%28 = OpLabel
-%136 = OpLoad %uint %92
-%138 = OpIAdd %uint %136 %uint_1
-OpStore %74 %138
-%139 = OpLoad %ulong %71
-OpStore %81 %139
-%140 = OpLoad %uint %74
-OpStore %92 %140
-OpBranch %35
-%26 = OpLabel
-%141 = OpLoad %ulong %71
-OpStore %82 %141
-OpBranch %25
-%25 = OpLabel
-%142 = OpLoad %uint %48
-%143 = OpIAdd %uint %uint_1 %142
-OpStore %75 %143
-%144 = OpLoad %ulong %82
-OpStore %80 %144
-%145 = OpLoad %uint %75
-OpStore %93 %145
-OpStore %94 %uint_1
-OpStore %95 %uint_0
-OpBranch %29
-%29 = OpLabel
-%146 = OpLoad %uint %95
-%148 = OpULessThan %bool %146 %uint_20
-OpStore %76 %148
-%149 = OpLoad %bool %76
-OpLoopMerge %31 %33 None
-OpBranchConditional %149 %30 %31
-%31 = OpLabel
-%150 = OpLoad %ulong %80
-OpReturnValue %150
-%30 = OpLabel
-%151 = OpLoad %uint %93
-%152 = OpLoad %uint %94
-%153 = OpIAdd %uint %151 %152
-OpStore %77 %153
-%154 = OpLoad %ulong %80
-%155 = OpLoad %uint %77
-%156 = OpFunctionCall %ulong %3 %154 %155
-OpStore %78 %156
-%157 = OpLoad %uint %95
-%158 = OpIAdd %uint %157 %uint_1
-OpStore %79 %158
-%159 = OpLoad %ulong %78
-OpStore %80 %159
-%160 = OpLoad %uint %94
-OpStore %93 %160
-%161 = OpLoad %uint %77
-OpStore %94 %161
-%162 = OpLoad %uint %79
-OpStore %95 %162
-OpBranch %33
-%15 = OpLabel
-%163 = OpLoad %uint %90
-%164 = OpIMul %uint %163 %uint_6
-OpStore %64 %164
-%165 = OpLoad %ulong %84
-OpStore %83 %165
-OpStore %91 %uint_0
-OpBranch %17
-%17 = OpLabel
-%166 = OpLoad %uint %91
-%167 = OpULessThan %bool %166 %uint_6
-OpStore %61 %167
-%168 = OpLoad %bool %61
-OpLoopMerge %19 %34 None
-OpBranchConditional %168 %18 %19
-%19 = OpLabel
-%169 = OpLoad %uint %90
-%170 = OpIAdd %uint %169 %uint_1
-OpStore %69 %170
-%171 = OpLoad %ulong %83
-OpStore %84 %171
-%172 = OpLoad %uint %69
-OpStore %90 %172
+%309 = OpLoad %uint %103
+%310 = OpUConvert %ulong %309
+OpStore %132 %310
+OpBranch %52
+%52 = OpLabel
+%311 = OpLoad %ulong %117
+OpStore %160 %311
+OpStore %161 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%312 = OpLoad %ulong %161
+%313 = OpULessThan %bool %312 %ulong_8
+OpStore %153 %313
+%314 = OpLoad %bool %153
+OpLoopMerge %55 %68 None
+OpBranchConditional %314 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
 OpBranch %37
-%18 = OpLabel
-%173 = OpLoad %uint %91
-%175 = OpIEqual %bool %173 %uint_3
-OpStore %62 %175
-%176 = OpLoad %bool %62
-OpSelectionMerge %40 None
-OpBranchConditional %176 %20 %21
-%21 = OpLabel
-OpBranch %22
-%22 = OpLabel
-%177 = OpLoad %uint %64
-%178 = OpLoad %uint %91
-%179 = OpIAdd %uint %177 %178
-OpStore %65 %179
-%180 = OpLoad %uint %65
-%181 = OpLoad %uint %48
-%182 = OpIAdd %uint %180 %181
-OpStore %66 %182
-%183 = OpLoad %ulong %83
-%184 = OpLoad %uint %66
-%185 = OpFunctionCall %ulong %3 %183 %184
-OpStore %67 %185
-%186 = OpLoad %uint %91
-%187 = OpIAdd %uint %186 %uint_1
-OpStore %68 %187
-%188 = OpLoad %ulong %67
-OpStore %83 %188
-%189 = OpLoad %uint %68
-OpStore %91 %189
-OpBranch %34
-%20 = OpLabel
-%190 = OpLoad %uint %91
-%191 = OpIAdd %uint %190 %uint_1
-OpStore %63 %191
-%192 = OpLoad %uint %63
-OpStore %91 %192
-OpBranch %34
-%12 = OpLabel
-%193 = OpLoad %uint %89
-%195 = OpISub %uint %193 %uint_7
-OpStore %58 %195
-%196 = OpLoad %ulong %85
-%197 = OpLoad %uint %58
-%198 = OpFunctionCall %ulong %3 %196 %197
-OpStore %59 %198
-%199 = OpLoad %ulong %59
-OpStore %85 %199
-%200 = OpLoad %uint %58
-OpStore %89 %200
-OpBranch %38
-%9 = OpLabel
-%201 = OpLoad %uint %87
-%202 = OpIMul %uint %201 %uint_3
-OpStore %51 %202
-%203 = OpLoad %uint %88
-%204 = OpLoad %uint %51
-%205 = OpIAdd %uint %203 %204
-OpStore %52 %205
-%206 = OpLoad %uint %52
-%207 = OpIAdd %uint %206 %uint_1
-OpStore %53 %207
-%208 = OpLoad %ulong %86
-%209 = OpLoad %uint %53
-%210 = OpFunctionCall %ulong %3 %208 %209
-OpStore %54 %210
-%211 = OpLoad %uint %87
-%212 = OpIAdd %uint %211 %uint_1
-OpStore %55 %212
-%213 = OpLoad %ulong %54
-OpStore %86 %213
-%214 = OpLoad %uint %55
-OpStore %87 %214
-%215 = OpLoad %uint %53
-OpStore %88 %215
-OpBranch %39
-%33 = OpLabel
-OpBranch %29
-%34 = OpLabel
-OpBranch %17
-%35 = OpLabel
-OpBranch %23
 %37 = OpLabel
-OpBranch %14
-%38 = OpLabel
-OpBranch %11
-%39 = OpLabel
-OpBranch %8
-%40 = OpLabel
+%315 = OpLoad %uint %125
+%316 = OpIAdd %uint %315 %uint_1
+OpStore %104 %316
+%317 = OpLoad %ulong %160
+OpStore %117 %317
+%318 = OpLoad %uint %104
+OpStore %125 %318
+OpBranch %72
+%54 = OpLabel
+%319 = OpLoad %ulong %161
+%320 = OpIMul %ulong %319 %ulong_8
+OpStore %154 %320
+%321 = OpLoad %ulong %132
+%322 = OpLoad %ulong %154
+%323 = OpShiftRightLogical %ulong %321 %322
+OpStore %155 %323
+%324 = OpLoad %ulong %155
+%325 = OpBitwiseAnd %ulong %324 %ulong_255
+OpStore %156 %325
+%326 = OpLoad %ulong %160
+%327 = OpLoad %ulong %156
+%328 = OpBitwiseXor %ulong %326 %327
+OpStore %157 %328
+%329 = OpLoad %ulong %157
+%330 = OpIMul %ulong %329 %ulong_1099511628211
+OpStore %158 %330
+%331 = OpLoad %ulong %161
+%332 = OpIAdd %ulong %331 %ulong_1
+OpStore %159 %332
+%333 = OpLoad %ulong %158
+OpStore %160 %333
+%334 = OpLoad %ulong %159
+OpStore %161 %334
+OpBranch %68
+%18 = OpLabel
+%335 = OpLoad %uint %125
+%336 = OpIAdd %uint %335 %uint_1
+OpStore %100 %336
+%337 = OpLoad %uint %100
+OpStore %125 %337
+OpBranch %72
+%10 = OpLabel
+%338 = OpLoad %uint %123
+%340 = OpISub %uint %338 %uint_7
+OpStore %96 %340
+OpBranch %34
+%34 = OpLabel
+%341 = OpLoad %uint %96
+%342 = OpUConvert %ulong %341
+OpStore %131 %342
+OpBranch %47
+%47 = OpLabel
+%343 = OpLoad %ulong %119
+OpStore %151 %343
+OpStore %152 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%344 = OpLoad %ulong %152
+%345 = OpULessThan %bool %344 %ulong_8
+OpStore %144 %345
+%346 = OpLoad %bool %144
+OpLoopMerge %50 %75 None
+OpBranchConditional %346 %49 %50
+%50 = OpLabel
+OpBranch %51
+%51 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%347 = OpLoad %ulong %151
+OpStore %119 %347
+%348 = OpLoad %uint %96
+OpStore %123 %348
+OpBranch %78
+%49 = OpLabel
+%349 = OpLoad %ulong %152
+%350 = OpIMul %ulong %349 %ulong_8
+OpStore %145 %350
+%351 = OpLoad %ulong %131
+%352 = OpLoad %ulong %145
+%353 = OpShiftRightLogical %ulong %351 %352
+OpStore %146 %353
+%354 = OpLoad %ulong %146
+%355 = OpBitwiseAnd %ulong %354 %ulong_255
+OpStore %147 %355
+%356 = OpLoad %ulong %151
+%357 = OpLoad %ulong %147
+%358 = OpBitwiseXor %ulong %356 %357
+OpStore %148 %358
+%359 = OpLoad %ulong %148
+%360 = OpIMul %ulong %359 %ulong_1099511628211
+OpStore %149 %360
+%361 = OpLoad %ulong %152
+%362 = OpIAdd %ulong %361 %ulong_1
+OpStore %150 %362
+%363 = OpLoad %ulong %149
+OpStore %151 %363
+%364 = OpLoad %ulong %150
+OpStore %152 %364
+OpBranch %75
+%7 = OpLabel
+%365 = OpLoad %uint %121
+%366 = OpIMul %uint %365 %uint_3
+OpStore %90 %366
+%367 = OpLoad %uint %122
+%368 = OpLoad %uint %90
+%369 = OpIAdd %uint %367 %368
+OpStore %91 %369
+%370 = OpLoad %uint %91
+%371 = OpIAdd %uint %370 %uint_1
+OpStore %92 %371
+OpBranch %32
+%32 = OpLabel
+%372 = OpLoad %uint %92
+%373 = OpUConvert %ulong %372
+OpStore %130 %373
+OpBranch %42
+%42 = OpLabel
+%374 = OpLoad %ulong %120
+OpStore %142 %374
+OpStore %143 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%375 = OpLoad %ulong %143
+%376 = OpULessThan %bool %375 %ulong_8
+OpStore %135 %376
+%377 = OpLoad %bool %135
+OpLoopMerge %45 %77 None
+OpBranchConditional %377 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%378 = OpLoad %uint %121
+%379 = OpIAdd %uint %378 %uint_1
+OpStore %93 %379
+%380 = OpLoad %ulong %142
+OpStore %120 %380
+%381 = OpLoad %uint %93
+OpStore %121 %381
+%382 = OpLoad %uint %92
+OpStore %122 %382
+OpBranch %79
+%44 = OpLabel
+%383 = OpLoad %ulong %143
+%384 = OpIMul %ulong %383 %ulong_8
+OpStore %136 %384
+%385 = OpLoad %ulong %130
+%386 = OpLoad %ulong %136
+%387 = OpShiftRightLogical %ulong %385 %386
+OpStore %137 %387
+%388 = OpLoad %ulong %137
+%389 = OpBitwiseAnd %ulong %388 %ulong_255
+OpStore %138 %389
+%390 = OpLoad %ulong %142
+%391 = OpLoad %ulong %138
+%392 = OpBitwiseXor %ulong %390 %391
+OpStore %139 %392
+%393 = OpLoad %ulong %139
+%394 = OpIMul %ulong %393 %ulong_1099511628211
+OpStore %140 %394
+%395 = OpLoad %ulong %143
+%396 = OpIAdd %ulong %395 %ulong_1
+OpStore %141 %396
+%397 = OpLoad %ulong %140
+OpStore %142 %397
+%398 = OpLoad %ulong %141
+OpStore %143 %398
+OpBranch %77
+%68 = OpLabel
+OpBranch %53
+%69 = OpLabel
+OpBranch %63
+%70 = OpLabel
+OpBranch %58
+%71 = OpLabel
+OpBranch %27
+%72 = OpLabel
+OpBranch %15
+%73 = OpLabel
+OpBranch %21
+%75 = OpLabel
+OpBranch %48
+%76 = OpLabel
+OpBranch %12
+%77 = OpLabel
+OpBranch %43
+%78 = OpLabel
+OpBranch %9
+%79 = OpLabel
+OpBranch %6
+%80 = OpLabel
 OpUnreachable
-%41 = OpLabel
+%81 = OpLabel
 OpUnreachable
-OpFunctionEnd
-%2 = OpFunction %ulong None %216
-%217 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %219
-%220 = OpFunctionParameter %ulong
-%221 = OpFunctionParameter %uint
-%222 = OpLabel
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_uint Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_bool Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_ulong Function
-OpStore %229 %220
-OpStore %230 %221
-%241 = OpLoad %uint %230
-%242 = OpUConvert %ulong %241
-OpStore %231 %242
-OpBranch %223
-%223 = OpLabel
-%243 = OpLoad %ulong %229
-OpStore %239 %243
-OpStore %240 %ulong_0
-OpBranch %224
-%224 = OpLabel
-%245 = OpLoad %ulong %240
-%247 = OpULessThan %bool %245 %ulong_8
-OpStore %232 %247
-%248 = OpLoad %bool %232
-OpLoopMerge %226 %228 None
-OpBranchConditional %248 %225 %226
-%226 = OpLabel
-OpBranch %227
-%227 = OpLabel
-%249 = OpLoad %ulong %239
-OpReturnValue %249
-%225 = OpLabel
-%250 = OpLoad %ulong %240
-%251 = OpIMul %ulong %250 %ulong_8
-OpStore %233 %251
-%252 = OpLoad %ulong %231
-%253 = OpLoad %ulong %233
-%254 = OpShiftRightLogical %ulong %252 %253
-OpStore %234 %254
-%255 = OpLoad %ulong %234
-%257 = OpBitwiseAnd %ulong %255 %ulong_255
-OpStore %235 %257
-%258 = OpLoad %ulong %239
-%259 = OpLoad %ulong %235
-%260 = OpBitwiseXor %ulong %258 %259
-OpStore %236 %260
-%261 = OpLoad %ulong %236
-%263 = OpIMul %ulong %261 %ulong_1099511628211
-OpStore %237 %263
-%264 = OpLoad %ulong %240
-%266 = OpIAdd %ulong %264 %ulong_1
-OpStore %238 %266
-%267 = OpLoad %ulong %237
-OpStore %239 %267
-%268 = OpLoad %ulong %238
-OpStore %240 %268
-OpBranch %228
-%228 = OpLabel
-OpBranch %224
 OpFunctionEnd

--- a/test/golden/spirv/comptime/ct_runtime_agree.dis
+++ b/test/golden/spirv/comptime/ct_runtime_agree.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 899
+; Bound: 1400
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,7 +15,7 @@ OpDecorate %3 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$0"
 OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1" Export
 %ulong = OpTypeInt 64 0
 %uchar = OpTypeInt 8 0
-%11 = OpTypeFunction %ulong %uchar %ulong
+%8 = OpTypeFunction %ulong %uchar %ulong
 %bool = OpTypeBool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ulong = OpTypePointer Function %ulong
@@ -28,7 +28,7 @@ OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1"
 %ulong_12345 = OpConstant %ulong 12345
 %ulong_29 = OpConstant %ulong 29
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%72 = OpTypeFunction %ulong %ulong
+%69 = OpTypeFunction %ulong %ulong
 %double = OpTypeFloat 64
 %float = OpTypeFloat 32
 %uint = OpTypeInt 32 0
@@ -37,6 +37,7 @@ OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1"
 %_ptr_Function__arr_ulong_uint_6 = OpTypePointer Function %_arr_ulong_uint_6
 %_ptr_Function_double = OpTypePointer Function %double
 %_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_uint = OpTypePointer Function %uint
 %ulong_305419896 = OpConstant %ulong 305419896
 %ulong_3 = OpConstant %ulong 3
 %ulong_7 = OpConstant %ulong 7
@@ -44,8 +45,8 @@ OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1"
 %ulong_64677154575 = OpConstant %ulong 64677154575
 %ulong_4294967295 = OpConstant %ulong 4294967295
 %ulong_2654435761 = OpConstant %ulong 2654435761
-%ulong_916259695 = OpConstant %ulong 916259695
-%ulong_7544905068303 = OpConstant %ulong 7544905068303
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_8 = OpConstant %ulong 8
 %ulong_7495090973393 = OpConstant %ulong 7495090973393
 %ulong_373041873 = OpConstant %ulong 373041873
 %ulong_990215688041620353 = OpConstant %ulong 990215688041620353
@@ -56,25 +57,25 @@ OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1"
 %double_7 = OpConstant %double 7
 %double_2 = OpConstant %double 2
 %double_1_1000000000000001 = OpConstant %double 1.1000000000000001
-%double_0_33333333333333331 = OpConstant %double 0.33333333333333331
-%double_0_33333333333333304 = OpConstant %double 0.33333333333333304
-%double_0_30303030303030276 = OpConstant %double 0.30303030303030276
-%double_0_42516069788797045 = OpConstant %double 0.42516069788797045
+%ulong_4599676419421066581 = OpConstant %ulong 4599676419421066581
+%ulong_4599676419421066576 = OpConstant %ulong 4599676419421066576
+%ulong_4599130528557142880 = OpConstant %ulong 4599130528557142880
+%ulong_4601330634160229295 = OpConstant %ulong 4601330634160229295
 %float_1 = OpConstant %float 1
 %float_3 = OpConstant %float 3
 %float_7 = OpConstant %float 7
 %float_2 = OpConstant %float 2
 %float_1_10000002 = OpConstant %float 1.10000002
-%float_0_333333343 = OpConstant %float 0.333333343
-%float_0_333333492 = OpConstant %float 0.333333492
-%float_0_303030431 = OpConstant %float 0.303030431
-%float_0_425160795 = OpConstant %float 0.425160795
+%uint_1051372203 = OpConstant %uint 1051372203
+%uint_1051372208 = OpConstant %uint 1051372208
+%uint_1050355406 = OpConstant %uint 1050355406
+%uint_1054453421 = OpConstant %uint 1054453421
 %ulong_5445325986 = OpConstant %ulong 5445325986
 %ulong_21862106997 = OpConstant %ulong 21862106997
 %ulong_52920935978 = OpConstant %ulong 52920935978
 %ulong_135205673541 = OpConstant %ulong 135205673541
 %ulong_247317407946 = OpConstant %ulong 247317407946
-%484 = OpConstantNull %_arr_ulong_uint_6
+%818 = OpConstantNull %_arr_ulong_uint_6
 %ulong_1 = OpConstant %ulong 1
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
@@ -86,222 +87,93 @@ OpDecorate %4 LinkageAttributes "corpus.cases.comptime.ct_runtime_agree.apply$1"
 %ulong_63 = OpConstant %ulong 63
 %uint_5 = OpConstant %uint 5
 %ulong_6 = OpConstant %ulong 6
-%ulong_11 = OpConstant %ulong 11
 %ulong_22 = OpConstant %ulong 22
-%ulong_33 = OpConstant %ulong 33
+%ulong_255 = OpConstant %ulong 255
 %ulong_65535 = OpConstant %ulong 65535
 %ulong_44 = OpConstant %ulong 44
-%760 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%763 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%805 = OpTypeFunction %ulong %ulong %float
-%_ptr_Function_uint = OpTypePointer Function %uint
-%854 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %uchar
-%13 = OpFunctionParameter %ulong
-%14 = OpLabel
-%23 = OpVariable %_ptr_Function_uchar Function
+%ulong_33 = OpConstant %ulong 33
+%ulong_11 = OpConstant %ulong 11
+%ulong_7544905068303 = OpConstant %ulong 7544905068303
+%ulong_916259695 = OpConstant %ulong 916259695
+%1360 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %uchar
+%10 = OpFunctionParameter %ulong
+%11 = OpLabel
+%20 = OpVariable %_ptr_Function_uchar Function
+%22 = OpVariable %_ptr_Function_ulong Function
+%24 = OpVariable %_ptr_Function_bool Function
 %25 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_bool Function
-%28 = OpVariable %_ptr_Function_ulong Function
+%26 = OpVariable %_ptr_Function_ulong Function
+%27 = OpVariable %_ptr_Function_ulong Function
+%28 = OpVariable %_ptr_Function_bool Function
 %29 = OpVariable %_ptr_Function_ulong Function
 %30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_bool Function
+%31 = OpVariable %_ptr_Function_ulong Function
 %32 = OpVariable %_ptr_Function_ulong Function
 %33 = OpVariable %_ptr_Function_ulong Function
 %34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-OpStore %23 %12
-OpStore %25 %13
-%38 = OpLoad %uchar %23
-%40 = OpIEqual %bool %38 %uchar_0
-OpStore %27 %40
-%41 = OpLoad %bool %27
+OpStore %20 %9
+OpStore %22 %10
+%35 = OpLoad %uchar %20
+%37 = OpIEqual %bool %35 %uchar_0
+OpStore %24 %37
+%38 = OpLoad %bool %24
+OpSelectionMerge %14 None
+OpBranchConditional %38 %12 %13
+%13 = OpLabel
+%39 = OpLoad %uchar %20
+%41 = OpIEqual %bool %39 %uchar_1
+OpStore %28 %41
+%42 = OpLoad %bool %28
 OpSelectionMerge %17 None
-OpBranchConditional %41 %15 %16
+OpBranchConditional %42 %15 %16
 %16 = OpLabel
-%42 = OpLoad %uchar %23
-%44 = OpIEqual %bool %42 %uchar_1
-OpStore %31 %44
-%45 = OpLoad %bool %31
-OpSelectionMerge %20 None
-OpBranchConditional %45 %18 %19
-%19 = OpLabel
-OpStore %36 %ulong_0
-OpBranch %20
-%18 = OpLabel
-%47 = OpLoad %ulong %25
-%49 = OpShiftLeftLogical %ulong %47 %ulong_17
-OpStore %32 %49
-%50 = OpLoad %ulong %25
-%52 = OpShiftRightLogical %ulong %50 %ulong_47
-OpStore %33 %52
-%53 = OpLoad %ulong %32
-%54 = OpLoad %ulong %33
-%55 = OpBitwiseOr %ulong %53 %54
-OpStore %34 %55
-%56 = OpLoad %ulong %34
-%58 = OpIAdd %ulong %56 %ulong_12345
-OpStore %35 %58
-%59 = OpLoad %ulong %35
-OpStore %36 %59
-OpBranch %20
-%20 = OpLabel
-%60 = OpLoad %ulong %36
-OpStore %37 %60
+OpStore %33 %ulong_0
 OpBranch %17
 %15 = OpLabel
-%61 = OpLoad %ulong %25
-%63 = OpShiftRightLogical %ulong %61 %ulong_29
-OpStore %28 %63
-%64 = OpLoad %ulong %25
-%65 = OpLoad %ulong %28
-%66 = OpBitwiseXor %ulong %64 %65
-OpStore %29 %66
-%67 = OpLoad %ulong %29
-%69 = OpIMul %ulong %67 %ulong_1099511628211
-OpStore %30 %69
-%70 = OpLoad %ulong %30
-OpStore %37 %70
+%44 = OpLoad %ulong %22
+%46 = OpShiftLeftLogical %ulong %44 %ulong_17
+OpStore %29 %46
+%47 = OpLoad %ulong %22
+%49 = OpShiftRightLogical %ulong %47 %ulong_47
+OpStore %30 %49
+%50 = OpLoad %ulong %29
+%51 = OpLoad %ulong %30
+%52 = OpBitwiseOr %ulong %50 %51
+OpStore %31 %52
+%53 = OpLoad %ulong %31
+%55 = OpIAdd %ulong %53 %ulong_12345
+OpStore %32 %55
+%56 = OpLoad %ulong %32
+OpStore %33 %56
 OpBranch %17
 %17 = OpLabel
-%71 = OpLoad %ulong %37
-OpReturnValue %71
+%57 = OpLoad %ulong %33
+OpStore %34 %57
+OpBranch %14
+%12 = OpLabel
+%58 = OpLoad %ulong %22
+%60 = OpShiftRightLogical %ulong %58 %ulong_29
+OpStore %25 %60
+%61 = OpLoad %ulong %22
+%62 = OpLoad %ulong %25
+%63 = OpBitwiseXor %ulong %61 %62
+OpStore %26 %63
+%64 = OpLoad %ulong %26
+%66 = OpIMul %ulong %64 %ulong_1099511628211
+OpStore %27 %66
+%67 = OpLoad %ulong %27
+OpStore %34 %67
+OpBranch %14
+%14 = OpLabel
+%68 = OpLoad %ulong %34
+OpReturnValue %68
 OpFunctionEnd
-%2 = OpFunction %ulong None %72
-%73 = OpFunctionParameter %ulong
-%74 = OpLabel
-%131 = OpVariable %_ptr_Function__arr_ulong_uint_6 Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_ulong Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_double Function
-%163 = OpVariable %_ptr_Function_double Function
-%164 = OpVariable %_ptr_Function_double Function
-%165 = OpVariable %_ptr_Function_double Function
-%166 = OpVariable %_ptr_Function_double Function
-%167 = OpVariable %_ptr_Function_double Function
-%168 = OpVariable %_ptr_Function_double Function
-%169 = OpVariable %_ptr_Function_double Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_float Function
-%181 = OpVariable %_ptr_Function_float Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_bool Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_bool Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_bool Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_uchar Function
-%222 = OpVariable %_ptr_Function_uchar Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_bool Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_bool Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_bool Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_bool Function
+%2 = OpFunction %ulong None %69
+%70 = OpFunctionParameter %ulong
+%71 = OpLabel
+%258 = OpVariable %_ptr_Function__arr_ulong_uint_6 Function
 %259 = OpVariable %_ptr_Function_ulong Function
 %260 = OpVariable %_ptr_Function_ulong Function
 %261 = OpVariable %_ptr_Function_ulong Function
@@ -311,11 +183,11 @@ OpFunctionEnd
 %265 = OpVariable %_ptr_Function_ulong Function
 %266 = OpVariable %_ptr_Function_ulong Function
 %267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_bool Function
+%268 = OpVariable %_ptr_Function_ulong Function
 %269 = OpVariable %_ptr_Function_ulong Function
 %270 = OpVariable %_ptr_Function_ulong Function
 %271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_bool Function
+%272 = OpVariable %_ptr_Function_ulong Function
 %273 = OpVariable %_ptr_Function_ulong Function
 %274 = OpVariable %_ptr_Function_ulong Function
 %275 = OpVariable %_ptr_Function_ulong Function
@@ -324,940 +196,1849 @@ OpFunctionEnd
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
 %280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_bool Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_bool Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_ulong Function
-OpStore %132 %73
-%294 = OpFunctionCall %ulong %5
-OpStore %133 %294
-%296 = OpLoad %ulong %132
-%297 = OpIAdd %ulong %ulong_305419896 %296
-OpStore %134 %297
-%298 = OpLoad %ulong %134
-%300 = OpIMul %ulong %298 %ulong_3
-OpStore %135 %300
-%301 = OpLoad %ulong %135
-%303 = OpIAdd %ulong %301 %ulong_7
-OpStore %136 %303
-%304 = OpLoad %ulong %136
-%306 = OpShiftLeftLogical %ulong %304 %ulong_13
-OpStore %137 %306
-%307 = OpLoad %ulong %137
-%309 = OpBitwiseXor %ulong %307 %ulong_64677154575
-OpStore %138 %309
-%310 = OpLoad %ulong %138
-%311 = OpShiftRightLogical %ulong %310 %ulong_7
-OpStore %139 %311
-%312 = OpLoad %ulong %138
-%313 = OpLoad %ulong %139
-%314 = OpBitwiseXor %ulong %312 %313
-OpStore %140 %314
-%315 = OpLoad %ulong %140
-%317 = OpBitwiseAnd %ulong %315 %ulong_4294967295
-OpStore %141 %317
-%318 = OpLoad %ulong %141
-%320 = OpIMul %ulong %318 %ulong_2654435761
-OpStore %142 %320
-%321 = OpLoad %ulong %142
-%322 = OpShiftRightLogical %ulong %321 %ulong_17
-OpStore %143 %322
-%323 = OpLoad %ulong %143
-%324 = OpLoad %ulong %141
-%325 = OpIAdd %ulong %323 %324
-OpStore %144 %325
-%326 = OpLoad %ulong %133
-%327 = OpFunctionCall %ulong %6 %326 %ulong_305419896
-OpStore %145 %327
-%328 = OpLoad %ulong %145
-%329 = OpLoad %ulong %134
-%330 = OpFunctionCall %ulong %6 %328 %329
-OpStore %146 %330
-%331 = OpLoad %ulong %146
-%333 = OpFunctionCall %ulong %6 %331 %ulong_916259695
-OpStore %147 %333
-%334 = OpLoad %ulong %147
-%335 = OpLoad %ulong %136
-%336 = OpFunctionCall %ulong %6 %334 %335
-OpStore %148 %336
-%337 = OpLoad %ulong %148
-%339 = OpFunctionCall %ulong %6 %337 %ulong_7544905068303
-OpStore %149 %339
-%340 = OpLoad %ulong %149
-%341 = OpLoad %ulong %138
-%342 = OpFunctionCall %ulong %6 %340 %341
-OpStore %150 %342
-%343 = OpLoad %ulong %150
-%345 = OpFunctionCall %ulong %6 %343 %ulong_7495090973393
-OpStore %151 %345
-%346 = OpLoad %ulong %151
-%347 = OpLoad %ulong %140
-%348 = OpFunctionCall %ulong %6 %346 %347
-OpStore %152 %348
-%349 = OpLoad %ulong %152
-%351 = OpFunctionCall %ulong %6 %349 %ulong_373041873
-OpStore %153 %351
-%352 = OpLoad %ulong %153
-%353 = OpLoad %ulong %141
-%354 = OpFunctionCall %ulong %6 %352 %353
-OpStore %154 %354
-%355 = OpLoad %ulong %154
-%357 = OpFunctionCall %ulong %6 %355 %ulong_990215688041620353
-OpStore %155 %357
-%358 = OpLoad %ulong %155
-%359 = OpLoad %ulong %142
-%360 = OpFunctionCall %ulong %6 %358 %359
-OpStore %156 %360
-%361 = OpLoad %ulong %156
-%363 = OpFunctionCall %ulong %6 %361 %ulong_7554746155102
-OpStore %157 %363
-%364 = OpLoad %ulong %157
-%365 = OpLoad %ulong %143
-%366 = OpFunctionCall %ulong %6 %364 %365
-OpStore %158 %366
-%367 = OpLoad %ulong %158
-%369 = OpFunctionCall %ulong %6 %367 %ulong_7555119196975
-OpStore %159 %369
-%370 = OpLoad %ulong %159
-%371 = OpLoad %ulong %144
-%372 = OpFunctionCall %ulong %6 %370 %371
-OpStore %160 %372
-%373 = OpLoad %ulong %132
-%374 = OpConvertUToF %double %373
-OpStore %162 %374
-%376 = OpLoad %double %162
-%377 = OpFAdd %double %double_1 %376
-OpStore %163 %377
-%378 = OpLoad %double %163
-%380 = OpFDiv %double %378 %double_3
-OpStore %164 %380
-%381 = OpLoad %double %164
-%383 = OpFMul %double %381 %double_7
-OpStore %165 %383
-%384 = OpLoad %double %165
-%386 = OpFSub %double %384 %double_2
-OpStore %166 %386
-%387 = OpLoad %double %166
-%389 = OpFDiv %double %387 %double_1_1000000000000001
-OpStore %167 %389
-%390 = OpLoad %double %167
-%391 = OpLoad %double %167
-%392 = OpFMul %double %390 %391
-OpStore %168 %392
-%393 = OpLoad %double %168
-%394 = OpLoad %double %164
-%395 = OpFAdd %double %393 %394
-OpStore %169 %395
-%396 = OpLoad %ulong %160
-%398 = OpFunctionCall %ulong %8 %396 %double_0_33333333333333331
-OpStore %170 %398
-%399 = OpLoad %ulong %170
-%400 = OpLoad %double %164
-%401 = OpFunctionCall %ulong %8 %399 %400
-OpStore %171 %401
-%402 = OpLoad %ulong %171
-%404 = OpFunctionCall %ulong %8 %402 %double_0_33333333333333304
-OpStore %172 %404
-%405 = OpLoad %ulong %172
-%406 = OpLoad %double %166
-%407 = OpFunctionCall %ulong %8 %405 %406
-OpStore %173 %407
-%408 = OpLoad %ulong %173
-%410 = OpFunctionCall %ulong %8 %408 %double_0_30303030303030276
-OpStore %174 %410
-%411 = OpLoad %ulong %174
-%412 = OpLoad %double %167
-%413 = OpFunctionCall %ulong %8 %411 %412
-OpStore %175 %413
-%414 = OpLoad %ulong %175
-%416 = OpFunctionCall %ulong %8 %414 %double_0_42516069788797045
-OpStore %176 %416
-%417 = OpLoad %ulong %176
-%418 = OpLoad %double %169
-%419 = OpFunctionCall %ulong %8 %417 %418
-OpStore %177 %419
-%420 = OpLoad %ulong %132
-%421 = OpConvertUToF %float %420
-OpStore %179 %421
-%423 = OpLoad %float %179
-%424 = OpFAdd %float %float_1 %423
-OpStore %180 %424
-%425 = OpLoad %float %180
-%427 = OpFDiv %float %425 %float_3
-OpStore %181 %427
-%428 = OpLoad %float %181
-%430 = OpFMul %float %428 %float_7
-OpStore %182 %430
-%431 = OpLoad %float %182
-%433 = OpFSub %float %431 %float_2
-OpStore %183 %433
-%434 = OpLoad %float %183
-%436 = OpFDiv %float %434 %float_1_10000002
-OpStore %184 %436
-%437 = OpLoad %float %184
-%438 = OpLoad %float %184
-%439 = OpFMul %float %437 %438
-OpStore %185 %439
-%440 = OpLoad %float %185
-%441 = OpLoad %float %181
-%442 = OpFAdd %float %440 %441
-OpStore %186 %442
-%443 = OpLoad %ulong %177
-%445 = OpFunctionCall %ulong %7 %443 %float_0_333333343
-OpStore %187 %445
-%446 = OpLoad %ulong %187
-%447 = OpLoad %float %181
-%448 = OpFunctionCall %ulong %7 %446 %447
-OpStore %188 %448
-%449 = OpLoad %ulong %188
-%451 = OpFunctionCall %ulong %7 %449 %float_0_333333492
-OpStore %189 %451
-%452 = OpLoad %ulong %189
-%453 = OpLoad %float %183
-%454 = OpFunctionCall %ulong %7 %452 %453
-OpStore %190 %454
-%455 = OpLoad %ulong %190
-%457 = OpFunctionCall %ulong %7 %455 %float_0_303030431
-OpStore %191 %457
-%458 = OpLoad %ulong %191
-%459 = OpLoad %float %184
-%460 = OpFunctionCall %ulong %7 %458 %459
-OpStore %192 %460
-%461 = OpLoad %ulong %192
-%463 = OpFunctionCall %ulong %7 %461 %float_0_425160795
-OpStore %193 %463
-%464 = OpLoad %ulong %193
-%465 = OpLoad %float %186
-%466 = OpFunctionCall %ulong %7 %464 %465
-OpStore %194 %466
-%467 = OpLoad %ulong %194
-%468 = OpFunctionCall %ulong %6 %467 %ulong_2654435761
-OpStore %195 %468
-%469 = OpLoad %ulong %195
-%471 = OpFunctionCall %ulong %6 %469 %ulong_5445325986
-OpStore %196 %471
-%472 = OpLoad %ulong %196
-%474 = OpFunctionCall %ulong %6 %472 %ulong_21862106997
-OpStore %197 %474
-%475 = OpLoad %ulong %197
-%477 = OpFunctionCall %ulong %6 %475 %ulong_52920935978
-OpStore %198 %477
-%478 = OpLoad %ulong %198
-%480 = OpFunctionCall %ulong %6 %478 %ulong_135205673541
-OpStore %199 %480
-%481 = OpLoad %ulong %199
-%483 = OpFunctionCall %ulong %6 %481 %ulong_247317407946
-OpStore %200 %483
-OpStore %131 %484
-%486 = OpLoad %ulong %132
-%487 = OpIAdd %ulong %ulong_1 %486
-OpStore %201 %487
-%489 = OpAccessChain %_ptr_Function_ulong %131 %uint_0
-%490 = OpLoad %ulong %201
-OpStore %489 %490
-%491 = OpLoad %ulong %132
-%492 = OpIAdd %ulong %ulong_3 %491
-OpStore %202 %492
-%494 = OpAccessChain %_ptr_Function_ulong %131 %uint_1
-%495 = OpLoad %ulong %202
-OpStore %494 %495
-%496 = OpLoad %ulong %132
-%497 = OpIAdd %ulong %ulong_7 %496
-OpStore %203 %497
-%499 = OpAccessChain %_ptr_Function_ulong %131 %uint_2
-%500 = OpLoad %ulong %203
-OpStore %499 %500
-%502 = OpLoad %ulong %132
-%503 = OpIAdd %ulong %ulong_15 %502
-OpStore %204 %503
-%505 = OpAccessChain %_ptr_Function_ulong %131 %uint_3
-%506 = OpLoad %ulong %204
-OpStore %505 %506
-%508 = OpLoad %ulong %132
-%509 = OpIAdd %ulong %ulong_31 %508
-OpStore %205 %509
-%511 = OpAccessChain %_ptr_Function_ulong %131 %uint_4
-%512 = OpLoad %ulong %205
-OpStore %511 %512
-%514 = OpLoad %ulong %132
-%515 = OpIAdd %ulong %ulong_63 %514
-OpStore %206 %515
-%517 = OpAccessChain %_ptr_Function_ulong %131 %uint_5
-%518 = OpLoad %ulong %206
-OpStore %517 %518
-%519 = OpLoad %ulong %200
-OpStore %233 %519
-OpStore %234 %ulong_0
-OpStore %235 %ulong_0
-OpBranch %75
-%75 = OpLabel
-%520 = OpLoad %ulong %235
-%522 = OpULessThan %bool %520 %ulong_6
-OpStore %207 %522
-%523 = OpLoad %bool %207
-OpLoopMerge %77 %124 None
-OpBranchConditional %523 %76 %77
-%77 = OpLabel
-%524 = OpLoad %ulong %233
-%526 = OpFunctionCall %ulong %6 %524 %ulong_11
-OpStore %213 %526
-%527 = OpLoad %ulong %144
-%528 = OpLoad %ulong %142
-%529 = OpULessThan %bool %527 %528
-OpStore %214 %529
-%530 = OpLoad %bool %214
-OpSelectionMerge %80 None
-OpBranchConditional %530 %78 %79
-%79 = OpLabel
-%531 = OpLoad %ulong %213
-%533 = OpFunctionCall %ulong %6 %531 %ulong_22
-OpStore %216 %533
-%534 = OpLoad %ulong %216
-OpStore %232 %534
-OpBranch %80
-%78 = OpLabel
-%535 = OpLoad %ulong %213
-%536 = OpFunctionCall %ulong %6 %535 %ulong_11
-OpStore %215 %536
-%537 = OpLoad %ulong %215
-OpStore %232 %537
-OpBranch %80
-%80 = OpLabel
-%538 = OpLoad %ulong %232
-%540 = OpFunctionCall %ulong %6 %538 %ulong_33
-OpStore %217 %540
-%542 = OpLoad %ulong %141
-%543 = OpULessThan %bool %ulong_65535 %542
-OpStore %218 %543
-%544 = OpLoad %bool %218
-OpSelectionMerge %83 None
-OpBranchConditional %544 %81 %82
-%82 = OpLabel
-%545 = OpLoad %ulong %217
-%547 = OpFunctionCall %ulong %6 %545 %ulong_44
-OpStore %220 %547
-%548 = OpLoad %ulong %220
-OpStore %231 %548
-OpBranch %83
+%282 = OpVariable %_ptr_Function_double Function
+%283 = OpVariable %_ptr_Function_double Function
+%284 = OpVariable %_ptr_Function_double Function
+%285 = OpVariable %_ptr_Function_double Function
+%286 = OpVariable %_ptr_Function_double Function
+%287 = OpVariable %_ptr_Function_double Function
+%288 = OpVariable %_ptr_Function_double Function
+%289 = OpVariable %_ptr_Function_double Function
+%291 = OpVariable %_ptr_Function_float Function
+%292 = OpVariable %_ptr_Function_float Function
+%293 = OpVariable %_ptr_Function_float Function
+%294 = OpVariable %_ptr_Function_float Function
+%295 = OpVariable %_ptr_Function_float Function
+%296 = OpVariable %_ptr_Function_float Function
+%297 = OpVariable %_ptr_Function_float Function
+%298 = OpVariable %_ptr_Function_float Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_bool Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_bool Function
+%317 = OpVariable %_ptr_Function_bool Function
+%318 = OpVariable %_ptr_Function_uchar Function
+%319 = OpVariable %_ptr_Function_uchar Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_bool Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_bool Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_bool Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_bool Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_bool Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_bool Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_bool Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_bool Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_bool Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_bool Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_bool Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_bool Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_bool Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_bool Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_bool Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_bool Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_bool Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_bool Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_bool Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_bool Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_bool Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_bool Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_bool Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_uint Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_uint Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_uint Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_uint Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_uint Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_uint Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_uint Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_uint Function
+%571 = OpVariable %_ptr_Function_ulong Function
+%572 = OpVariable %_ptr_Function_ulong Function
+OpStore %259 %70
+OpBranch %81
 %81 = OpLabel
-%549 = OpLoad %ulong %217
-%550 = OpFunctionCall %ulong %6 %549 %ulong_33
-OpStore %219 %550
-%551 = OpLoad %ulong %219
-OpStore %231 %551
-OpBranch %83
-%83 = OpLabel
-%552 = OpLoad %ulong %132
-%553 = OpUConvert %uchar %552
-OpStore %221 %553
-%554 = OpLoad %uchar %221
-%555 = OpIAdd %uchar %uchar_1 %554
-OpStore %222 %555
-OpBranch %84
-%84 = OpLabel
-%556 = OpLoad %ulong %144
-%557 = OpShiftRightLogical %ulong %556 %ulong_29
-OpStore %236 %557
-%558 = OpLoad %ulong %144
-%559 = OpLoad %ulong %236
-%560 = OpBitwiseXor %ulong %558 %559
-OpStore %237 %560
-%561 = OpLoad %ulong %237
-%562 = OpIMul %ulong %561 %ulong_1099511628211
-OpStore %238 %562
-OpBranch %85
-%85 = OpLabel
-%563 = OpLoad %ulong %231
-%564 = OpLoad %ulong %238
-%565 = OpFunctionCall %ulong %6 %563 %564
-OpStore %223 %565
-OpBranch %86
-%86 = OpLabel
-%566 = OpLoad %uchar %221
-%567 = OpIEqual %bool %566 %uchar_0
-OpStore %239 %567
-%568 = OpLoad %bool %239
-OpSelectionMerge %89 None
-OpBranchConditional %568 %87 %88
-%88 = OpLabel
-%569 = OpLoad %uchar %221
-%570 = OpIEqual %bool %569 %uchar_1
-OpStore %243 %570
-%571 = OpLoad %bool %243
-OpSelectionMerge %92 None
-OpBranchConditional %571 %90 %91
-%91 = OpLabel
-OpStore %248 %ulong_0
-OpBranch %92
-%90 = OpLabel
-%572 = OpLoad %ulong %144
-%573 = OpShiftLeftLogical %ulong %572 %ulong_17
-OpStore %244 %573
-%574 = OpLoad %ulong %144
-%575 = OpShiftRightLogical %ulong %574 %ulong_47
-OpStore %245 %575
-%576 = OpLoad %ulong %244
-%577 = OpLoad %ulong %245
-%578 = OpBitwiseOr %ulong %576 %577
-OpStore %246 %578
-%579 = OpLoad %ulong %246
-%580 = OpIAdd %ulong %579 %ulong_12345
-OpStore %247 %580
-%581 = OpLoad %ulong %247
-OpStore %248 %581
-OpBranch %92
-%92 = OpLabel
-%582 = OpLoad %ulong %248
-OpStore %249 %582
-OpBranch %89
-%87 = OpLabel
-%583 = OpLoad %ulong %144
-%584 = OpShiftRightLogical %ulong %583 %ulong_29
-OpStore %240 %584
-%585 = OpLoad %ulong %144
-%586 = OpLoad %ulong %240
-%587 = OpBitwiseXor %ulong %585 %586
-OpStore %241 %587
-%588 = OpLoad %ulong %241
-%589 = OpIMul %ulong %588 %ulong_1099511628211
-OpStore %242 %589
-%590 = OpLoad %ulong %242
-OpStore %249 %590
-OpBranch %89
-%89 = OpLabel
-OpBranch %93
-%93 = OpLabel
-%591 = OpLoad %ulong %223
-%592 = OpLoad %ulong %249
-%593 = OpFunctionCall %ulong %6 %591 %592
-OpStore %224 %593
-OpBranch %94
-%94 = OpLabel
-%594 = OpLoad %ulong %144
-%595 = OpShiftLeftLogical %ulong %594 %ulong_17
-OpStore %250 %595
-%596 = OpLoad %ulong %144
-%597 = OpShiftRightLogical %ulong %596 %ulong_47
-OpStore %251 %597
-%598 = OpLoad %ulong %250
-%599 = OpLoad %ulong %251
-%600 = OpBitwiseOr %ulong %598 %599
-OpStore %252 %600
-%601 = OpLoad %ulong %252
-%602 = OpIAdd %ulong %601 %ulong_12345
-OpStore %253 %602
-OpBranch %95
-%95 = OpLabel
-%603 = OpLoad %ulong %224
-%604 = OpLoad %ulong %253
-%605 = OpFunctionCall %ulong %6 %603 %604
-OpStore %225 %605
-OpBranch %96
-%96 = OpLabel
-%606 = OpLoad %uchar %222
-%607 = OpIEqual %bool %606 %uchar_0
-OpStore %254 %607
-%608 = OpLoad %bool %254
-OpSelectionMerge %99 None
-OpBranchConditional %608 %97 %98
-%98 = OpLabel
-%609 = OpLoad %uchar %222
-%610 = OpIEqual %bool %609 %uchar_1
-OpStore %258 %610
-%611 = OpLoad %bool %258
-OpSelectionMerge %102 None
-OpBranchConditional %611 %100 %101
-%101 = OpLabel
-OpStore %263 %ulong_0
-OpBranch %102
-%100 = OpLabel
-%612 = OpLoad %ulong %144
-%613 = OpShiftLeftLogical %ulong %612 %ulong_17
-OpStore %259 %613
-%614 = OpLoad %ulong %144
-%615 = OpShiftRightLogical %ulong %614 %ulong_47
-OpStore %260 %615
-%616 = OpLoad %ulong %259
-%617 = OpLoad %ulong %260
-%618 = OpBitwiseOr %ulong %616 %617
-OpStore %261 %618
-%619 = OpLoad %ulong %261
-%620 = OpIAdd %ulong %619 %ulong_12345
-OpStore %262 %620
-%621 = OpLoad %ulong %262
-OpStore %263 %621
-OpBranch %102
-%102 = OpLabel
-%622 = OpLoad %ulong %263
-OpStore %264 %622
-OpBranch %99
-%97 = OpLabel
-%623 = OpLoad %ulong %144
-%624 = OpShiftRightLogical %ulong %623 %ulong_29
-OpStore %255 %624
-%625 = OpLoad %ulong %144
-%626 = OpLoad %ulong %255
-%627 = OpBitwiseXor %ulong %625 %626
-OpStore %256 %627
-%628 = OpLoad %ulong %256
-%629 = OpIMul %ulong %628 %ulong_1099511628211
-OpStore %257 %629
-%630 = OpLoad %ulong %257
-OpStore %264 %630
-OpBranch %99
-%99 = OpLabel
-OpBranch %103
-%103 = OpLabel
-%631 = OpLoad %ulong %225
-%632 = OpLoad %ulong %264
-%633 = OpFunctionCall %ulong %6 %631 %632
-OpStore %226 %633
-OpBranch %104
-%104 = OpLabel
-%634 = OpLoad %ulong %141
-%635 = OpShiftRightLogical %ulong %634 %ulong_29
-OpStore %265 %635
-%636 = OpLoad %ulong %141
-%637 = OpLoad %ulong %265
-%638 = OpBitwiseXor %ulong %636 %637
-OpStore %266 %638
-%639 = OpLoad %ulong %266
-%640 = OpIMul %ulong %639 %ulong_1099511628211
-OpStore %267 %640
-OpBranch %105
-%105 = OpLabel
-%641 = OpLoad %ulong %226
-%642 = OpLoad %ulong %267
-%643 = OpFunctionCall %ulong %6 %641 %642
-OpStore %227 %643
-OpBranch %106
-%106 = OpLabel
-%644 = OpLoad %uchar %221
-%645 = OpIEqual %bool %644 %uchar_0
-OpStore %268 %645
-%646 = OpLoad %bool %268
-OpSelectionMerge %109 None
-OpBranchConditional %646 %107 %108
-%108 = OpLabel
-%647 = OpLoad %uchar %221
-%648 = OpIEqual %bool %647 %uchar_1
-OpStore %272 %648
-%649 = OpLoad %bool %272
-OpSelectionMerge %112 None
-OpBranchConditional %649 %110 %111
-%111 = OpLabel
-OpStore %277 %ulong_0
-OpBranch %112
-%110 = OpLabel
-%650 = OpLoad %ulong %141
-%651 = OpShiftLeftLogical %ulong %650 %ulong_17
-OpStore %273 %651
-%652 = OpLoad %ulong %141
-%653 = OpShiftRightLogical %ulong %652 %ulong_47
-OpStore %274 %653
-%654 = OpLoad %ulong %273
-%655 = OpLoad %ulong %274
-%656 = OpBitwiseOr %ulong %654 %655
-OpStore %275 %656
-%657 = OpLoad %ulong %275
-%658 = OpIAdd %ulong %657 %ulong_12345
-OpStore %276 %658
-%659 = OpLoad %ulong %276
-OpStore %277 %659
-OpBranch %112
-%112 = OpLabel
-%660 = OpLoad %ulong %277
-OpStore %278 %660
-OpBranch %109
-%107 = OpLabel
-%661 = OpLoad %ulong %141
-%662 = OpShiftRightLogical %ulong %661 %ulong_29
-OpStore %269 %662
-%663 = OpLoad %ulong %141
-%664 = OpLoad %ulong %269
-%665 = OpBitwiseXor %ulong %663 %664
-OpStore %270 %665
-%666 = OpLoad %ulong %270
-%667 = OpIMul %ulong %666 %ulong_1099511628211
-OpStore %271 %667
-%668 = OpLoad %ulong %271
-OpStore %278 %668
-OpBranch %109
-%109 = OpLabel
-OpBranch %113
-%113 = OpLabel
-%669 = OpLoad %ulong %227
-%670 = OpLoad %ulong %278
-%671 = OpFunctionCall %ulong %6 %669 %670
-OpStore %228 %671
-OpBranch %114
-%114 = OpLabel
-%672 = OpLoad %ulong %141
-%673 = OpShiftLeftLogical %ulong %672 %ulong_17
-OpStore %279 %673
-%674 = OpLoad %ulong %141
-%675 = OpShiftRightLogical %ulong %674 %ulong_47
-OpStore %280 %675
-%676 = OpLoad %ulong %279
-%677 = OpLoad %ulong %280
-%678 = OpBitwiseOr %ulong %676 %677
-OpStore %281 %678
-%679 = OpLoad %ulong %281
-%680 = OpIAdd %ulong %679 %ulong_12345
-OpStore %282 %680
-OpBranch %115
-%115 = OpLabel
-%681 = OpLoad %ulong %228
-%682 = OpLoad %ulong %282
-%683 = OpFunctionCall %ulong %6 %681 %682
-OpStore %229 %683
-OpBranch %116
-%116 = OpLabel
-%684 = OpLoad %uchar %222
-%685 = OpIEqual %bool %684 %uchar_0
-OpStore %283 %685
-%686 = OpLoad %bool %283
-OpSelectionMerge %119 None
-OpBranchConditional %686 %117 %118
-%118 = OpLabel
-%687 = OpLoad %uchar %222
-%688 = OpIEqual %bool %687 %uchar_1
-OpStore %287 %688
-%689 = OpLoad %bool %287
-OpSelectionMerge %122 None
-OpBranchConditional %689 %120 %121
-%121 = OpLabel
-OpStore %292 %ulong_0
-OpBranch %122
+OpBranch %82
+%82 = OpLabel
+%574 = OpLoad %ulong %259
+%575 = OpIAdd %ulong %ulong_305419896 %574
+OpStore %260 %575
+%576 = OpLoad %ulong %260
+%578 = OpIMul %ulong %576 %ulong_3
+OpStore %261 %578
+%579 = OpLoad %ulong %261
+%581 = OpIAdd %ulong %579 %ulong_7
+OpStore %262 %581
+%582 = OpLoad %ulong %262
+%584 = OpShiftLeftLogical %ulong %582 %ulong_13
+OpStore %263 %584
+%585 = OpLoad %ulong %263
+%587 = OpBitwiseXor %ulong %585 %ulong_64677154575
+OpStore %264 %587
+%588 = OpLoad %ulong %264
+%589 = OpShiftRightLogical %ulong %588 %ulong_7
+OpStore %265 %589
+%590 = OpLoad %ulong %264
+%591 = OpLoad %ulong %265
+%592 = OpBitwiseXor %ulong %590 %591
+OpStore %266 %592
+%593 = OpLoad %ulong %266
+%595 = OpBitwiseAnd %ulong %593 %ulong_4294967295
+OpStore %267 %595
+%596 = OpLoad %ulong %267
+%598 = OpIMul %ulong %596 %ulong_2654435761
+OpStore %268 %598
+%599 = OpLoad %ulong %268
+%600 = OpShiftRightLogical %ulong %599 %ulong_17
+OpStore %269 %600
+%601 = OpLoad %ulong %269
+%602 = OpLoad %ulong %267
+%603 = OpIAdd %ulong %601 %602
+OpStore %270 %603
+OpBranch %120
 %120 = OpLabel
-%690 = OpLoad %ulong %141
-%691 = OpShiftLeftLogical %ulong %690 %ulong_17
-OpStore %288 %691
-%692 = OpLoad %ulong %141
-%693 = OpShiftRightLogical %ulong %692 %ulong_47
-OpStore %289 %693
-%694 = OpLoad %ulong %288
-%695 = OpLoad %ulong %289
-%696 = OpBitwiseOr %ulong %694 %695
-OpStore %290 %696
-%697 = OpLoad %ulong %290
-%698 = OpIAdd %ulong %697 %ulong_12345
-OpStore %291 %698
-%699 = OpLoad %ulong %291
-OpStore %292 %699
-OpBranch %122
-%122 = OpLabel
-%700 = OpLoad %ulong %292
-OpStore %293 %700
-OpBranch %119
-%117 = OpLabel
-%701 = OpLoad %ulong %141
-%702 = OpShiftRightLogical %ulong %701 %ulong_29
-OpStore %284 %702
-%703 = OpLoad %ulong %141
-%704 = OpLoad %ulong %284
-%705 = OpBitwiseXor %ulong %703 %704
-OpStore %285 %705
-%706 = OpLoad %ulong %285
-%707 = OpIMul %ulong %706 %ulong_1099511628211
-OpStore %286 %707
-%708 = OpLoad %ulong %286
-OpStore %293 %708
-OpBranch %119
-%119 = OpLabel
-OpBranch %123
+OpStore %403 %ulong_14695981039346656037
+OpStore %404 %ulong_0
+OpBranch %121
+%121 = OpLabel
+%605 = OpLoad %ulong %404
+%607 = OpULessThan %bool %605 %ulong_8
+OpStore %396 %607
+%608 = OpLoad %bool %396
+OpLoopMerge %123 %251 None
+OpBranchConditional %608 %122 %123
 %123 = OpLabel
-%709 = OpLoad %ulong %229
-%710 = OpLoad %ulong %293
-%711 = OpFunctionCall %ulong %6 %709 %710
-OpStore %230 %711
-%712 = OpLoad %ulong %230
-OpReturnValue %712
-%76 = OpLabel
-%713 = OpLoad %ulong %235
-%714 = OpAccessChain %_ptr_Function_ulong %131 %713
-%715 = OpLoad %ulong %714
-OpStore %208 %715
-%716 = OpLoad %ulong %208
-%717 = OpIMul %ulong %716 %ulong_2654435761
-OpStore %209 %717
-%718 = OpLoad %ulong %234
-%719 = OpLoad %ulong %209
-%720 = OpBitwiseXor %ulong %718 %719
-OpStore %210 %720
-%721 = OpLoad %ulong %233
-%722 = OpLoad %ulong %210
-%723 = OpFunctionCall %ulong %6 %721 %722
-OpStore %211 %723
-%724 = OpLoad %ulong %235
-%725 = OpIAdd %ulong %724 %ulong_1
-OpStore %212 %725
-%726 = OpLoad %ulong %211
-OpStore %233 %726
-%727 = OpLoad %ulong %210
-OpStore %234 %727
-%728 = OpLoad %ulong %212
-OpStore %235 %728
 OpBranch %124
 %124 = OpLabel
-OpBranch %75
+OpBranch %130
+%130 = OpLabel
+%609 = OpLoad %ulong %403
+OpStore %421 %609
+OpStore %422 %ulong_0
+OpBranch %131
+%131 = OpLabel
+%610 = OpLoad %ulong %422
+%611 = OpULessThan %bool %610 %ulong_8
+OpStore %414 %611
+%612 = OpLoad %bool %414
+OpLoopMerge %133 %250 None
+OpBranchConditional %612 %132 %133
+%133 = OpLabel
+OpBranch %134
+%134 = OpLabel
+OpBranch %143
+%143 = OpLabel
+%613 = OpLoad %ulong %421
+OpStore %441 %613
+OpStore %442 %ulong_0
+OpBranch %144
+%144 = OpLabel
+%614 = OpLoad %ulong %442
+%615 = OpULessThan %bool %614 %ulong_8
+OpStore %434 %615
+%616 = OpLoad %bool %434
+OpLoopMerge %146 %249 None
+OpBranchConditional %616 %145 %146
+%146 = OpLabel
+OpBranch %147
+%147 = OpLabel
+OpBranch %153
+%153 = OpLabel
+%617 = OpLoad %ulong %441
+OpStore %459 %617
+OpStore %460 %ulong_0
+OpBranch %154
+%154 = OpLabel
+%618 = OpLoad %ulong %460
+%619 = OpULessThan %bool %618 %ulong_8
+OpStore %452 %619
+%620 = OpLoad %bool %452
+OpLoopMerge %156 %248 None
+OpBranchConditional %620 %155 %156
+%156 = OpLabel
+OpBranch %157
+%157 = OpLabel
+OpBranch %160
+%160 = OpLabel
+%621 = OpLoad %ulong %459
+OpStore %472 %621
+OpStore %473 %ulong_0
+OpBranch %161
+%161 = OpLabel
+%622 = OpLoad %ulong %473
+%623 = OpULessThan %bool %622 %ulong_8
+OpStore %465 %623
+%624 = OpLoad %bool %465
+OpLoopMerge %163 %247 None
+OpBranchConditional %624 %162 %163
+%163 = OpLabel
+OpBranch %164
+%164 = OpLabel
+OpBranch %170
+%170 = OpLabel
+%625 = OpLoad %ulong %472
+OpStore %490 %625
+OpStore %491 %ulong_0
+OpBranch %171
+%171 = OpLabel
+%626 = OpLoad %ulong %491
+%627 = OpULessThan %bool %626 %ulong_8
+OpStore %483 %627
+%628 = OpLoad %bool %483
+OpLoopMerge %173 %246 None
+OpBranchConditional %628 %172 %173
+%173 = OpLabel
+OpBranch %174
+%174 = OpLabel
+%629 = OpLoad %ulong %490
+%631 = OpFunctionCall %ulong %5 %629 %ulong_7495090973393
+OpStore %271 %631
+%632 = OpLoad %ulong %271
+%633 = OpLoad %ulong %266
+%634 = OpFunctionCall %ulong %5 %632 %633
+OpStore %272 %634
+%635 = OpLoad %ulong %272
+%637 = OpFunctionCall %ulong %5 %635 %ulong_373041873
+OpStore %273 %637
+%638 = OpLoad %ulong %273
+%639 = OpLoad %ulong %267
+%640 = OpFunctionCall %ulong %5 %638 %639
+OpStore %274 %640
+%641 = OpLoad %ulong %274
+%643 = OpFunctionCall %ulong %5 %641 %ulong_990215688041620353
+OpStore %275 %643
+%644 = OpLoad %ulong %275
+%645 = OpLoad %ulong %268
+%646 = OpFunctionCall %ulong %5 %644 %645
+OpStore %276 %646
+%647 = OpLoad %ulong %276
+%649 = OpFunctionCall %ulong %5 %647 %ulong_7554746155102
+OpStore %277 %649
+%650 = OpLoad %ulong %277
+%651 = OpLoad %ulong %269
+%652 = OpFunctionCall %ulong %5 %650 %651
+OpStore %278 %652
+%653 = OpLoad %ulong %278
+%655 = OpFunctionCall %ulong %5 %653 %ulong_7555119196975
+OpStore %279 %655
+%656 = OpLoad %ulong %279
+%657 = OpLoad %ulong %270
+%658 = OpFunctionCall %ulong %5 %656 %657
+OpStore %280 %658
+%659 = OpLoad %ulong %259
+%660 = OpConvertUToF %double %659
+OpStore %282 %660
+%662 = OpLoad %double %282
+%663 = OpFAdd %double %double_1 %662
+OpStore %283 %663
+%664 = OpLoad %double %283
+%666 = OpFDiv %double %664 %double_3
+OpStore %284 %666
+%667 = OpLoad %double %284
+%669 = OpFMul %double %667 %double_7
+OpStore %285 %669
+%670 = OpLoad %double %285
+%672 = OpFSub %double %670 %double_2
+OpStore %286 %672
+%673 = OpLoad %double %286
+%675 = OpFDiv %double %673 %double_1_1000000000000001
+OpStore %287 %675
+%676 = OpLoad %double %287
+%677 = OpLoad %double %287
+%678 = OpFMul %double %676 %677
+OpStore %288 %678
+%679 = OpLoad %double %288
+%680 = OpLoad %double %284
+%681 = OpFAdd %double %679 %680
+OpStore %289 %681
+OpBranch %183
+%183 = OpLabel
+%683 = OpBitcast %ulong %ulong_4599676419421066581
+OpStore %503 %683
+%684 = OpLoad %ulong %280
+%685 = OpLoad %ulong %503
+%686 = OpFunctionCall %ulong %5 %684 %685
+OpStore %504 %686
+OpBranch %184
+%184 = OpLabel
+OpBranch %187
+%187 = OpLabel
+%687 = OpLoad %double %284
+%688 = OpBitcast %ulong %687
+OpStore %508 %688
+%689 = OpLoad %ulong %504
+%690 = OpLoad %ulong %508
+%691 = OpFunctionCall %ulong %5 %689 %690
+OpStore %509 %691
+OpBranch %188
+%188 = OpLabel
+OpBranch %197
+%197 = OpLabel
+%693 = OpBitcast %ulong %ulong_4599676419421066576
+OpStore %521 %693
+%694 = OpLoad %ulong %509
+%695 = OpLoad %ulong %521
+%696 = OpFunctionCall %ulong %5 %694 %695
+OpStore %522 %696
+OpBranch %198
+%198 = OpLabel
+OpBranch %201
+%201 = OpLabel
+%697 = OpLoad %double %286
+%698 = OpBitcast %ulong %697
+OpStore %527 %698
+%699 = OpLoad %ulong %522
+%700 = OpLoad %ulong %527
+%701 = OpFunctionCall %ulong %5 %699 %700
+OpStore %528 %701
+OpBranch %202
+%202 = OpLabel
+OpBranch %211
+%211 = OpLabel
+%703 = OpBitcast %ulong %ulong_4599130528557142880
+OpStore %540 %703
+%704 = OpLoad %ulong %528
+%705 = OpLoad %ulong %540
+%706 = OpFunctionCall %ulong %5 %704 %705
+OpStore %541 %706
+OpBranch %212
+%212 = OpLabel
+OpBranch %213
+%213 = OpLabel
+%707 = OpLoad %double %287
+%708 = OpBitcast %ulong %707
+OpStore %542 %708
+%709 = OpLoad %ulong %541
+%710 = OpLoad %ulong %542
+%711 = OpFunctionCall %ulong %5 %709 %710
+OpStore %543 %711
+OpBranch %214
+%214 = OpLabel
+OpBranch %215
+%215 = OpLabel
+%713 = OpBitcast %ulong %ulong_4601330634160229295
+OpStore %544 %713
+%714 = OpLoad %ulong %543
+%715 = OpLoad %ulong %544
+%716 = OpFunctionCall %ulong %5 %714 %715
+OpStore %545 %716
+OpBranch %216
+%216 = OpLabel
+OpBranch %217
+%217 = OpLabel
+%717 = OpLoad %double %289
+%718 = OpBitcast %ulong %717
+OpStore %546 %718
+%719 = OpLoad %ulong %545
+%720 = OpLoad %ulong %546
+%721 = OpFunctionCall %ulong %5 %719 %720
+OpStore %547 %721
+OpBranch %218
+%218 = OpLabel
+%722 = OpLoad %ulong %259
+%723 = OpConvertUToF %float %722
+OpStore %291 %723
+%725 = OpLoad %float %291
+%726 = OpFAdd %float %float_1 %725
+OpStore %292 %726
+%727 = OpLoad %float %292
+%729 = OpFDiv %float %727 %float_3
+OpStore %293 %729
+%730 = OpLoad %float %293
+%732 = OpFMul %float %730 %float_7
+OpStore %294 %732
+%733 = OpLoad %float %294
+%735 = OpFSub %float %733 %float_2
+OpStore %295 %735
+%736 = OpLoad %float %295
+%738 = OpFDiv %float %736 %float_1_10000002
+OpStore %296 %738
+%739 = OpLoad %float %296
+%740 = OpLoad %float %296
+%741 = OpFMul %float %739 %740
+OpStore %297 %741
+%742 = OpLoad %float %297
+%743 = OpLoad %float %293
+%744 = OpFAdd %float %742 %743
+OpStore %298 %744
+OpBranch %219
+%219 = OpLabel
+%746 = OpBitcast %uint %uint_1051372203
+OpStore %549 %746
+%747 = OpLoad %uint %549
+%748 = OpUConvert %ulong %747
+OpStore %550 %748
+%749 = OpLoad %ulong %547
+%750 = OpLoad %ulong %550
+%751 = OpFunctionCall %ulong %5 %749 %750
+OpStore %551 %751
+OpBranch %220
+%220 = OpLabel
+OpBranch %221
+%221 = OpLabel
+%752 = OpLoad %float %293
+%753 = OpBitcast %uint %752
+OpStore %552 %753
+%754 = OpLoad %uint %552
+%755 = OpUConvert %ulong %754
+OpStore %553 %755
+%756 = OpLoad %ulong %551
+%757 = OpLoad %ulong %553
+%758 = OpFunctionCall %ulong %5 %756 %757
+OpStore %554 %758
+OpBranch %222
+%222 = OpLabel
+OpBranch %223
+%223 = OpLabel
+%760 = OpBitcast %uint %uint_1051372208
+OpStore %555 %760
+%761 = OpLoad %uint %555
+%762 = OpUConvert %ulong %761
+OpStore %556 %762
+%763 = OpLoad %ulong %554
+%764 = OpLoad %ulong %556
+%765 = OpFunctionCall %ulong %5 %763 %764
+OpStore %557 %765
+OpBranch %224
+%224 = OpLabel
+OpBranch %225
+%225 = OpLabel
+%766 = OpLoad %float %295
+%767 = OpBitcast %uint %766
+OpStore %558 %767
+%768 = OpLoad %uint %558
+%769 = OpUConvert %ulong %768
+OpStore %559 %769
+%770 = OpLoad %ulong %557
+%771 = OpLoad %ulong %559
+%772 = OpFunctionCall %ulong %5 %770 %771
+OpStore %560 %772
+OpBranch %226
+%226 = OpLabel
+OpBranch %227
+%227 = OpLabel
+%774 = OpBitcast %uint %uint_1050355406
+OpStore %561 %774
+%775 = OpLoad %uint %561
+%776 = OpUConvert %ulong %775
+OpStore %562 %776
+%777 = OpLoad %ulong %560
+%778 = OpLoad %ulong %562
+%779 = OpFunctionCall %ulong %5 %777 %778
+OpStore %563 %779
+OpBranch %228
+%228 = OpLabel
+OpBranch %229
+%229 = OpLabel
+%780 = OpLoad %float %296
+%781 = OpBitcast %uint %780
+OpStore %564 %781
+%782 = OpLoad %uint %564
+%783 = OpUConvert %ulong %782
+OpStore %565 %783
+%784 = OpLoad %ulong %563
+%785 = OpLoad %ulong %565
+%786 = OpFunctionCall %ulong %5 %784 %785
+OpStore %566 %786
+OpBranch %230
+%230 = OpLabel
+OpBranch %231
+%231 = OpLabel
+%788 = OpBitcast %uint %uint_1054453421
+OpStore %567 %788
+%789 = OpLoad %uint %567
+%790 = OpUConvert %ulong %789
+OpStore %568 %790
+%791 = OpLoad %ulong %566
+%792 = OpLoad %ulong %568
+%793 = OpFunctionCall %ulong %5 %791 %792
+OpStore %569 %793
+OpBranch %232
+%232 = OpLabel
+OpBranch %233
+%233 = OpLabel
+%794 = OpLoad %float %298
+%795 = OpBitcast %uint %794
+OpStore %570 %795
+%796 = OpLoad %uint %570
+%797 = OpUConvert %ulong %796
+OpStore %571 %797
+%798 = OpLoad %ulong %569
+%799 = OpLoad %ulong %571
+%800 = OpFunctionCall %ulong %5 %798 %799
+OpStore %572 %800
+OpBranch %234
+%234 = OpLabel
+%801 = OpLoad %ulong %572
+%802 = OpFunctionCall %ulong %5 %801 %ulong_2654435761
+OpStore %299 %802
+%803 = OpLoad %ulong %299
+%805 = OpFunctionCall %ulong %5 %803 %ulong_5445325986
+OpStore %300 %805
+%806 = OpLoad %ulong %300
+%808 = OpFunctionCall %ulong %5 %806 %ulong_21862106997
+OpStore %301 %808
+%809 = OpLoad %ulong %301
+%811 = OpFunctionCall %ulong %5 %809 %ulong_52920935978
+OpStore %302 %811
+%812 = OpLoad %ulong %302
+%814 = OpFunctionCall %ulong %5 %812 %ulong_135205673541
+OpStore %303 %814
+%815 = OpLoad %ulong %303
+%817 = OpFunctionCall %ulong %5 %815 %ulong_247317407946
+OpStore %304 %817
+OpStore %258 %818
+%820 = OpLoad %ulong %259
+%821 = OpIAdd %ulong %ulong_1 %820
+OpStore %305 %821
+%823 = OpAccessChain %_ptr_Function_ulong %258 %uint_0
+%824 = OpLoad %ulong %305
+OpStore %823 %824
+%825 = OpLoad %ulong %259
+%826 = OpIAdd %ulong %ulong_3 %825
+OpStore %306 %826
+%828 = OpAccessChain %_ptr_Function_ulong %258 %uint_1
+%829 = OpLoad %ulong %306
+OpStore %828 %829
+%830 = OpLoad %ulong %259
+%831 = OpIAdd %ulong %ulong_7 %830
+OpStore %307 %831
+%833 = OpAccessChain %_ptr_Function_ulong %258 %uint_2
+%834 = OpLoad %ulong %307
+OpStore %833 %834
+%836 = OpLoad %ulong %259
+%837 = OpIAdd %ulong %ulong_15 %836
+OpStore %308 %837
+%839 = OpAccessChain %_ptr_Function_ulong %258 %uint_3
+%840 = OpLoad %ulong %308
+OpStore %839 %840
+%842 = OpLoad %ulong %259
+%843 = OpIAdd %ulong %ulong_31 %842
+OpStore %309 %843
+%845 = OpAccessChain %_ptr_Function_ulong %258 %uint_4
+%846 = OpLoad %ulong %309
+OpStore %845 %846
+%848 = OpLoad %ulong %259
+%849 = OpIAdd %ulong %ulong_63 %848
+OpStore %310 %849
+%851 = OpAccessChain %_ptr_Function_ulong %258 %uint_5
+%852 = OpLoad %ulong %310
+OpStore %851 %852
+%853 = OpLoad %ulong %304
+OpStore %327 %853
+OpStore %328 %ulong_0
+OpStore %329 %ulong_0
+OpBranch %72
+%72 = OpLabel
+%854 = OpLoad %ulong %329
+%856 = OpULessThan %bool %854 %ulong_6
+OpStore %311 %856
+%857 = OpLoad %bool %311
+OpLoopMerge %74 %245 None
+OpBranchConditional %857 %73 %74
+%74 = OpLabel
+OpBranch %88
+%88 = OpLabel
+%858 = OpLoad %ulong %327
+OpStore %346 %858
+OpStore %347 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%859 = OpLoad %ulong %347
+%860 = OpULessThan %bool %859 %ulong_8
+OpStore %339 %860
+%861 = OpLoad %bool %339
+OpLoopMerge %91 %244 None
+OpBranchConditional %861 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%862 = OpLoad %ulong %270
+%863 = OpLoad %ulong %268
+%864 = OpULessThan %bool %862 %863
+OpStore %316 %864
+%865 = OpLoad %bool %316
+OpSelectionMerge %77 None
+OpBranchConditional %865 %75 %76
+%76 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%866 = OpLoad %ulong %346
+OpStore %364 %866
+OpStore %365 %ulong_0
+OpBranch %99
+%99 = OpLabel
+%867 = OpLoad %ulong %365
+%868 = OpULessThan %bool %867 %ulong_8
+OpStore %357 %868
+%869 = OpLoad %bool %357
+OpLoopMerge %101 %241 None
+OpBranchConditional %869 %100 %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%870 = OpLoad %ulong %364
+OpStore %326 %870
+OpBranch %77
+%100 = OpLabel
+%871 = OpLoad %ulong %365
+%872 = OpIMul %ulong %871 %ulong_8
+OpStore %358 %872
+%874 = OpLoad %ulong %358
+%875 = OpShiftRightLogical %ulong %ulong_22 %874
+OpStore %359 %875
+%876 = OpLoad %ulong %359
+%878 = OpBitwiseAnd %ulong %876 %ulong_255
+OpStore %360 %878
+%879 = OpLoad %ulong %364
+%880 = OpLoad %ulong %360
+%881 = OpBitwiseXor %ulong %879 %880
+OpStore %361 %881
+%882 = OpLoad %ulong %361
+%883 = OpIMul %ulong %882 %ulong_1099511628211
+OpStore %362 %883
+%884 = OpLoad %ulong %365
+%885 = OpIAdd %ulong %884 %ulong_1
+OpStore %363 %885
+%886 = OpLoad %ulong %362
+OpStore %364 %886
+%887 = OpLoad %ulong %363
+OpStore %365 %887
+OpBranch %241
+%75 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%888 = OpLoad %ulong %346
+OpStore %355 %888
+OpStore %356 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%889 = OpLoad %ulong %356
+%890 = OpULessThan %bool %889 %ulong_8
+OpStore %348 %890
+%891 = OpLoad %bool %348
+OpLoopMerge %96 %240 None
+OpBranchConditional %891 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%892 = OpLoad %ulong %355
+OpStore %326 %892
+OpBranch %77
+%77 = OpLabel
+OpBranch %103
+%103 = OpLabel
+%893 = OpLoad %ulong %326
+OpStore %373 %893
+OpStore %374 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%894 = OpLoad %ulong %374
+%895 = OpULessThan %bool %894 %ulong_8
+OpStore %366 %895
+%896 = OpLoad %bool %366
+OpLoopMerge %106 %242 None
+OpBranchConditional %896 %105 %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%898 = OpLoad %ulong %267
+%899 = OpULessThan %bool %ulong_65535 %898
+OpStore %317 %899
+%900 = OpLoad %bool %317
+OpSelectionMerge %80 None
+OpBranchConditional %900 %78 %79
+%79 = OpLabel
+OpBranch %113
+%113 = OpLabel
+%901 = OpLoad %ulong %373
+OpStore %391 %901
+OpStore %392 %ulong_0
+OpBranch %114
+%114 = OpLabel
+%902 = OpLoad %ulong %392
+%903 = OpULessThan %bool %902 %ulong_8
+OpStore %384 %903
+%904 = OpLoad %bool %384
+OpLoopMerge %116 %239 None
+OpBranchConditional %904 %115 %116
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
+%905 = OpLoad %ulong %391
+OpStore %325 %905
+OpBranch %80
+%115 = OpLabel
+%906 = OpLoad %ulong %392
+%907 = OpIMul %ulong %906 %ulong_8
+OpStore %385 %907
+%909 = OpLoad %ulong %385
+%910 = OpShiftRightLogical %ulong %ulong_44 %909
+OpStore %386 %910
+%911 = OpLoad %ulong %386
+%912 = OpBitwiseAnd %ulong %911 %ulong_255
+OpStore %387 %912
+%913 = OpLoad %ulong %391
+%914 = OpLoad %ulong %387
+%915 = OpBitwiseXor %ulong %913 %914
+OpStore %388 %915
+%916 = OpLoad %ulong %388
+%917 = OpIMul %ulong %916 %ulong_1099511628211
+OpStore %389 %917
+%918 = OpLoad %ulong %392
+%919 = OpIAdd %ulong %918 %ulong_1
+OpStore %390 %919
+%920 = OpLoad %ulong %389
+OpStore %391 %920
+%921 = OpLoad %ulong %390
+OpStore %392 %921
+OpBranch %239
+%78 = OpLabel
+OpBranch %108
+%108 = OpLabel
+%922 = OpLoad %ulong %373
+OpStore %382 %922
+OpStore %383 %ulong_0
+OpBranch %109
+%109 = OpLabel
+%923 = OpLoad %ulong %383
+%924 = OpULessThan %bool %923 %ulong_8
+OpStore %375 %924
+%925 = OpLoad %bool %375
+OpLoopMerge %111 %238 None
+OpBranchConditional %925 %110 %111
+%111 = OpLabel
+OpBranch %112
+%112 = OpLabel
+%926 = OpLoad %ulong %382
+OpStore %325 %926
+OpBranch %80
+%80 = OpLabel
+%927 = OpLoad %ulong %259
+%928 = OpUConvert %uchar %927
+OpStore %318 %928
+%929 = OpLoad %uchar %318
+%930 = OpIAdd %uchar %uchar_1 %929
+OpStore %319 %930
+OpBranch %118
+%118 = OpLabel
+%931 = OpLoad %ulong %270
+%932 = OpShiftRightLogical %ulong %931 %ulong_29
+OpStore %393 %932
+%933 = OpLoad %ulong %270
+%934 = OpLoad %ulong %393
+%935 = OpBitwiseXor %ulong %933 %934
+OpStore %394 %935
+%936 = OpLoad %ulong %394
+%937 = OpIMul %ulong %936 %ulong_1099511628211
+OpStore %395 %937
+OpBranch %119
+%119 = OpLabel
+OpBranch %125
+%125 = OpLabel
+%938 = OpLoad %ulong %325
+OpStore %412 %938
+OpStore %413 %ulong_0
+OpBranch %126
+%126 = OpLabel
+%939 = OpLoad %ulong %413
+%940 = OpULessThan %bool %939 %ulong_8
+OpStore %405 %940
+%941 = OpLoad %bool %405
+OpLoopMerge %128 %237 None
+OpBranchConditional %941 %127 %128
+%128 = OpLabel
+OpBranch %129
+%129 = OpLabel
+OpBranch %135
+%135 = OpLabel
+%942 = OpLoad %uchar %318
+%943 = OpIEqual %bool %942 %uchar_0
+OpStore %423 %943
+%944 = OpLoad %bool %423
+OpSelectionMerge %138 None
+OpBranchConditional %944 %136 %137
+%137 = OpLabel
+%945 = OpLoad %uchar %318
+%946 = OpIEqual %bool %945 %uchar_1
+OpStore %427 %946
+%947 = OpLoad %bool %427
+OpSelectionMerge %141 None
+OpBranchConditional %947 %139 %140
+%140 = OpLabel
+OpStore %432 %ulong_0
+OpBranch %141
+%139 = OpLabel
+%948 = OpLoad %ulong %270
+%949 = OpShiftLeftLogical %ulong %948 %ulong_17
+OpStore %428 %949
+%950 = OpLoad %ulong %270
+%951 = OpShiftRightLogical %ulong %950 %ulong_47
+OpStore %429 %951
+%952 = OpLoad %ulong %428
+%953 = OpLoad %ulong %429
+%954 = OpBitwiseOr %ulong %952 %953
+OpStore %430 %954
+%955 = OpLoad %ulong %430
+%956 = OpIAdd %ulong %955 %ulong_12345
+OpStore %431 %956
+%957 = OpLoad %ulong %431
+OpStore %432 %957
+OpBranch %141
+%141 = OpLabel
+%958 = OpLoad %ulong %432
+OpStore %433 %958
+OpBranch %138
+%136 = OpLabel
+%959 = OpLoad %ulong %270
+%960 = OpShiftRightLogical %ulong %959 %ulong_29
+OpStore %424 %960
+%961 = OpLoad %ulong %270
+%962 = OpLoad %ulong %424
+%963 = OpBitwiseXor %ulong %961 %962
+OpStore %425 %963
+%964 = OpLoad %ulong %425
+%965 = OpIMul %ulong %964 %ulong_1099511628211
+OpStore %426 %965
+%966 = OpLoad %ulong %426
+OpStore %433 %966
+OpBranch %138
+%138 = OpLabel
+OpBranch %142
+%142 = OpLabel
+OpBranch %148
+%148 = OpLabel
+%967 = OpLoad %ulong %412
+OpStore %450 %967
+OpStore %451 %ulong_0
+OpBranch %149
+%149 = OpLabel
+%968 = OpLoad %ulong %451
+%969 = OpULessThan %bool %968 %ulong_8
+OpStore %443 %969
+%970 = OpLoad %bool %443
+OpLoopMerge %151 %236 None
+OpBranchConditional %970 %150 %151
+%151 = OpLabel
+OpBranch %152
+%152 = OpLabel
+OpBranch %158
+%158 = OpLabel
+%971 = OpLoad %ulong %270
+%972 = OpShiftLeftLogical %ulong %971 %ulong_17
+OpStore %461 %972
+%973 = OpLoad %ulong %270
+%974 = OpShiftRightLogical %ulong %973 %ulong_47
+OpStore %462 %974
+%975 = OpLoad %ulong %461
+%976 = OpLoad %ulong %462
+%977 = OpBitwiseOr %ulong %975 %976
+OpStore %463 %977
+%978 = OpLoad %ulong %463
+%979 = OpIAdd %ulong %978 %ulong_12345
+OpStore %464 %979
+OpBranch %159
+%159 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%980 = OpLoad %ulong %450
+OpStore %481 %980
+OpStore %482 %ulong_0
+OpBranch %166
+%166 = OpLabel
+%981 = OpLoad %ulong %482
+%982 = OpULessThan %bool %981 %ulong_8
+OpStore %474 %982
+%983 = OpLoad %bool %474
+OpLoopMerge %168 %235 None
+OpBranchConditional %983 %167 %168
+%168 = OpLabel
+OpBranch %169
+%169 = OpLabel
+OpBranch %175
+%175 = OpLabel
+%984 = OpLoad %uchar %319
+%985 = OpIEqual %bool %984 %uchar_0
+OpStore %492 %985
+%986 = OpLoad %bool %492
+OpSelectionMerge %178 None
+OpBranchConditional %986 %176 %177
+%177 = OpLabel
+%987 = OpLoad %uchar %319
+%988 = OpIEqual %bool %987 %uchar_1
+OpStore %496 %988
+%989 = OpLoad %bool %496
+OpSelectionMerge %181 None
+OpBranchConditional %989 %179 %180
+%180 = OpLabel
+OpStore %501 %ulong_0
+OpBranch %181
+%179 = OpLabel
+%990 = OpLoad %ulong %270
+%991 = OpShiftLeftLogical %ulong %990 %ulong_17
+OpStore %497 %991
+%992 = OpLoad %ulong %270
+%993 = OpShiftRightLogical %ulong %992 %ulong_47
+OpStore %498 %993
+%994 = OpLoad %ulong %497
+%995 = OpLoad %ulong %498
+%996 = OpBitwiseOr %ulong %994 %995
+OpStore %499 %996
+%997 = OpLoad %ulong %499
+%998 = OpIAdd %ulong %997 %ulong_12345
+OpStore %500 %998
+%999 = OpLoad %ulong %500
+OpStore %501 %999
+OpBranch %181
+%181 = OpLabel
+%1000 = OpLoad %ulong %501
+OpStore %502 %1000
+OpBranch %178
+%176 = OpLabel
+%1001 = OpLoad %ulong %270
+%1002 = OpShiftRightLogical %ulong %1001 %ulong_29
+OpStore %493 %1002
+%1003 = OpLoad %ulong %270
+%1004 = OpLoad %ulong %493
+%1005 = OpBitwiseXor %ulong %1003 %1004
+OpStore %494 %1005
+%1006 = OpLoad %ulong %494
+%1007 = OpIMul %ulong %1006 %ulong_1099511628211
+OpStore %495 %1007
+%1008 = OpLoad %ulong %495
+OpStore %502 %1008
+OpBranch %178
+%178 = OpLabel
+OpBranch %182
+%182 = OpLabel
+%1009 = OpLoad %ulong %481
+%1010 = OpLoad %ulong %502
+%1011 = OpFunctionCall %ulong %5 %1009 %1010
+OpStore %320 %1011
+OpBranch %185
+%185 = OpLabel
+%1012 = OpLoad %ulong %267
+%1013 = OpShiftRightLogical %ulong %1012 %ulong_29
+OpStore %505 %1013
+%1014 = OpLoad %ulong %267
+%1015 = OpLoad %ulong %505
+%1016 = OpBitwiseXor %ulong %1014 %1015
+OpStore %506 %1016
+%1017 = OpLoad %ulong %506
+%1018 = OpIMul %ulong %1017 %ulong_1099511628211
+OpStore %507 %1018
+OpBranch %186
+%186 = OpLabel
+%1019 = OpLoad %ulong %320
+%1020 = OpLoad %ulong %507
+%1021 = OpFunctionCall %ulong %5 %1019 %1020
+OpStore %321 %1021
+OpBranch %189
+%189 = OpLabel
+%1022 = OpLoad %uchar %318
+%1023 = OpIEqual %bool %1022 %uchar_0
+OpStore %510 %1023
+%1024 = OpLoad %bool %510
+OpSelectionMerge %192 None
+OpBranchConditional %1024 %190 %191
+%191 = OpLabel
+%1025 = OpLoad %uchar %318
+%1026 = OpIEqual %bool %1025 %uchar_1
+OpStore %514 %1026
+%1027 = OpLoad %bool %514
+OpSelectionMerge %195 None
+OpBranchConditional %1027 %193 %194
+%194 = OpLabel
+OpStore %519 %ulong_0
+OpBranch %195
+%193 = OpLabel
+%1028 = OpLoad %ulong %267
+%1029 = OpShiftLeftLogical %ulong %1028 %ulong_17
+OpStore %515 %1029
+%1030 = OpLoad %ulong %267
+%1031 = OpShiftRightLogical %ulong %1030 %ulong_47
+OpStore %516 %1031
+%1032 = OpLoad %ulong %515
+%1033 = OpLoad %ulong %516
+%1034 = OpBitwiseOr %ulong %1032 %1033
+OpStore %517 %1034
+%1035 = OpLoad %ulong %517
+%1036 = OpIAdd %ulong %1035 %ulong_12345
+OpStore %518 %1036
+%1037 = OpLoad %ulong %518
+OpStore %519 %1037
+OpBranch %195
+%195 = OpLabel
+%1038 = OpLoad %ulong %519
+OpStore %520 %1038
+OpBranch %192
+%190 = OpLabel
+%1039 = OpLoad %ulong %267
+%1040 = OpShiftRightLogical %ulong %1039 %ulong_29
+OpStore %511 %1040
+%1041 = OpLoad %ulong %267
+%1042 = OpLoad %ulong %511
+%1043 = OpBitwiseXor %ulong %1041 %1042
+OpStore %512 %1043
+%1044 = OpLoad %ulong %512
+%1045 = OpIMul %ulong %1044 %ulong_1099511628211
+OpStore %513 %1045
+%1046 = OpLoad %ulong %513
+OpStore %520 %1046
+OpBranch %192
+%192 = OpLabel
+OpBranch %196
+%196 = OpLabel
+%1047 = OpLoad %ulong %321
+%1048 = OpLoad %ulong %520
+%1049 = OpFunctionCall %ulong %5 %1047 %1048
+OpStore %322 %1049
+OpBranch %199
+%199 = OpLabel
+%1050 = OpLoad %ulong %267
+%1051 = OpShiftLeftLogical %ulong %1050 %ulong_17
+OpStore %523 %1051
+%1052 = OpLoad %ulong %267
+%1053 = OpShiftRightLogical %ulong %1052 %ulong_47
+OpStore %524 %1053
+%1054 = OpLoad %ulong %523
+%1055 = OpLoad %ulong %524
+%1056 = OpBitwiseOr %ulong %1054 %1055
+OpStore %525 %1056
+%1057 = OpLoad %ulong %525
+%1058 = OpIAdd %ulong %1057 %ulong_12345
+OpStore %526 %1058
+OpBranch %200
+%200 = OpLabel
+%1059 = OpLoad %ulong %322
+%1060 = OpLoad %ulong %526
+%1061 = OpFunctionCall %ulong %5 %1059 %1060
+OpStore %323 %1061
+OpBranch %203
+%203 = OpLabel
+%1062 = OpLoad %uchar %319
+%1063 = OpIEqual %bool %1062 %uchar_0
+OpStore %529 %1063
+%1064 = OpLoad %bool %529
+OpSelectionMerge %206 None
+OpBranchConditional %1064 %204 %205
+%205 = OpLabel
+%1065 = OpLoad %uchar %319
+%1066 = OpIEqual %bool %1065 %uchar_1
+OpStore %533 %1066
+%1067 = OpLoad %bool %533
+OpSelectionMerge %209 None
+OpBranchConditional %1067 %207 %208
+%208 = OpLabel
+OpStore %538 %ulong_0
+OpBranch %209
+%207 = OpLabel
+%1068 = OpLoad %ulong %267
+%1069 = OpShiftLeftLogical %ulong %1068 %ulong_17
+OpStore %534 %1069
+%1070 = OpLoad %ulong %267
+%1071 = OpShiftRightLogical %ulong %1070 %ulong_47
+OpStore %535 %1071
+%1072 = OpLoad %ulong %534
+%1073 = OpLoad %ulong %535
+%1074 = OpBitwiseOr %ulong %1072 %1073
+OpStore %536 %1074
+%1075 = OpLoad %ulong %536
+%1076 = OpIAdd %ulong %1075 %ulong_12345
+OpStore %537 %1076
+%1077 = OpLoad %ulong %537
+OpStore %538 %1077
+OpBranch %209
+%209 = OpLabel
+%1078 = OpLoad %ulong %538
+OpStore %539 %1078
+OpBranch %206
+%204 = OpLabel
+%1079 = OpLoad %ulong %267
+%1080 = OpShiftRightLogical %ulong %1079 %ulong_29
+OpStore %530 %1080
+%1081 = OpLoad %ulong %267
+%1082 = OpLoad %ulong %530
+%1083 = OpBitwiseXor %ulong %1081 %1082
+OpStore %531 %1083
+%1084 = OpLoad %ulong %531
+%1085 = OpIMul %ulong %1084 %ulong_1099511628211
+OpStore %532 %1085
+%1086 = OpLoad %ulong %532
+OpStore %539 %1086
+OpBranch %206
+%206 = OpLabel
+OpBranch %210
+%210 = OpLabel
+%1087 = OpLoad %ulong %323
+%1088 = OpLoad %ulong %539
+%1089 = OpFunctionCall %ulong %5 %1087 %1088
+OpStore %324 %1089
+%1090 = OpLoad %ulong %324
+OpReturnValue %1090
+%167 = OpLabel
+%1091 = OpLoad %ulong %482
+%1092 = OpIMul %ulong %1091 %ulong_8
+OpStore %475 %1092
+%1093 = OpLoad %ulong %464
+%1094 = OpLoad %ulong %475
+%1095 = OpShiftRightLogical %ulong %1093 %1094
+OpStore %476 %1095
+%1096 = OpLoad %ulong %476
+%1097 = OpBitwiseAnd %ulong %1096 %ulong_255
+OpStore %477 %1097
+%1098 = OpLoad %ulong %481
+%1099 = OpLoad %ulong %477
+%1100 = OpBitwiseXor %ulong %1098 %1099
+OpStore %478 %1100
+%1101 = OpLoad %ulong %478
+%1102 = OpIMul %ulong %1101 %ulong_1099511628211
+OpStore %479 %1102
+%1103 = OpLoad %ulong %482
+%1104 = OpIAdd %ulong %1103 %ulong_1
+OpStore %480 %1104
+%1105 = OpLoad %ulong %479
+OpStore %481 %1105
+%1106 = OpLoad %ulong %480
+OpStore %482 %1106
+OpBranch %235
+%150 = OpLabel
+%1107 = OpLoad %ulong %451
+%1108 = OpIMul %ulong %1107 %ulong_8
+OpStore %444 %1108
+%1109 = OpLoad %ulong %433
+%1110 = OpLoad %ulong %444
+%1111 = OpShiftRightLogical %ulong %1109 %1110
+OpStore %445 %1111
+%1112 = OpLoad %ulong %445
+%1113 = OpBitwiseAnd %ulong %1112 %ulong_255
+OpStore %446 %1113
+%1114 = OpLoad %ulong %450
+%1115 = OpLoad %ulong %446
+%1116 = OpBitwiseXor %ulong %1114 %1115
+OpStore %447 %1116
+%1117 = OpLoad %ulong %447
+%1118 = OpIMul %ulong %1117 %ulong_1099511628211
+OpStore %448 %1118
+%1119 = OpLoad %ulong %451
+%1120 = OpIAdd %ulong %1119 %ulong_1
+OpStore %449 %1120
+%1121 = OpLoad %ulong %448
+OpStore %450 %1121
+%1122 = OpLoad %ulong %449
+OpStore %451 %1122
+OpBranch %236
+%127 = OpLabel
+%1123 = OpLoad %ulong %413
+%1124 = OpIMul %ulong %1123 %ulong_8
+OpStore %406 %1124
+%1125 = OpLoad %ulong %395
+%1126 = OpLoad %ulong %406
+%1127 = OpShiftRightLogical %ulong %1125 %1126
+OpStore %407 %1127
+%1128 = OpLoad %ulong %407
+%1129 = OpBitwiseAnd %ulong %1128 %ulong_255
+OpStore %408 %1129
+%1130 = OpLoad %ulong %412
+%1131 = OpLoad %ulong %408
+%1132 = OpBitwiseXor %ulong %1130 %1131
+OpStore %409 %1132
+%1133 = OpLoad %ulong %409
+%1134 = OpIMul %ulong %1133 %ulong_1099511628211
+OpStore %410 %1134
+%1135 = OpLoad %ulong %413
+%1136 = OpIAdd %ulong %1135 %ulong_1
+OpStore %411 %1136
+%1137 = OpLoad %ulong %410
+OpStore %412 %1137
+%1138 = OpLoad %ulong %411
+OpStore %413 %1138
+OpBranch %237
+%110 = OpLabel
+%1139 = OpLoad %ulong %383
+%1140 = OpIMul %ulong %1139 %ulong_8
+OpStore %376 %1140
+%1142 = OpLoad %ulong %376
+%1143 = OpShiftRightLogical %ulong %ulong_33 %1142
+OpStore %377 %1143
+%1144 = OpLoad %ulong %377
+%1145 = OpBitwiseAnd %ulong %1144 %ulong_255
+OpStore %378 %1145
+%1146 = OpLoad %ulong %382
+%1147 = OpLoad %ulong %378
+%1148 = OpBitwiseXor %ulong %1146 %1147
+OpStore %379 %1148
+%1149 = OpLoad %ulong %379
+%1150 = OpIMul %ulong %1149 %ulong_1099511628211
+OpStore %380 %1150
+%1151 = OpLoad %ulong %383
+%1152 = OpIAdd %ulong %1151 %ulong_1
+OpStore %381 %1152
+%1153 = OpLoad %ulong %380
+OpStore %382 %1153
+%1154 = OpLoad %ulong %381
+OpStore %383 %1154
+OpBranch %238
+%105 = OpLabel
+%1155 = OpLoad %ulong %374
+%1156 = OpIMul %ulong %1155 %ulong_8
+OpStore %367 %1156
+%1157 = OpLoad %ulong %367
+%1158 = OpShiftRightLogical %ulong %ulong_33 %1157
+OpStore %368 %1158
+%1159 = OpLoad %ulong %368
+%1160 = OpBitwiseAnd %ulong %1159 %ulong_255
+OpStore %369 %1160
+%1161 = OpLoad %ulong %373
+%1162 = OpLoad %ulong %369
+%1163 = OpBitwiseXor %ulong %1161 %1162
+OpStore %370 %1163
+%1164 = OpLoad %ulong %370
+%1165 = OpIMul %ulong %1164 %ulong_1099511628211
+OpStore %371 %1165
+%1166 = OpLoad %ulong %374
+%1167 = OpIAdd %ulong %1166 %ulong_1
+OpStore %372 %1167
+%1168 = OpLoad %ulong %371
+OpStore %373 %1168
+%1169 = OpLoad %ulong %372
+OpStore %374 %1169
+OpBranch %242
+%95 = OpLabel
+%1170 = OpLoad %ulong %356
+%1171 = OpIMul %ulong %1170 %ulong_8
+OpStore %349 %1171
+%1173 = OpLoad %ulong %349
+%1174 = OpShiftRightLogical %ulong %ulong_11 %1173
+OpStore %350 %1174
+%1175 = OpLoad %ulong %350
+%1176 = OpBitwiseAnd %ulong %1175 %ulong_255
+OpStore %351 %1176
+%1177 = OpLoad %ulong %355
+%1178 = OpLoad %ulong %351
+%1179 = OpBitwiseXor %ulong %1177 %1178
+OpStore %352 %1179
+%1180 = OpLoad %ulong %352
+%1181 = OpIMul %ulong %1180 %ulong_1099511628211
+OpStore %353 %1181
+%1182 = OpLoad %ulong %356
+%1183 = OpIAdd %ulong %1182 %ulong_1
+OpStore %354 %1183
+%1184 = OpLoad %ulong %353
+OpStore %355 %1184
+%1185 = OpLoad %ulong %354
+OpStore %356 %1185
+OpBranch %240
+%90 = OpLabel
+%1186 = OpLoad %ulong %347
+%1187 = OpIMul %ulong %1186 %ulong_8
+OpStore %340 %1187
+%1188 = OpLoad %ulong %340
+%1189 = OpShiftRightLogical %ulong %ulong_11 %1188
+OpStore %341 %1189
+%1190 = OpLoad %ulong %341
+%1191 = OpBitwiseAnd %ulong %1190 %ulong_255
+OpStore %342 %1191
+%1192 = OpLoad %ulong %346
+%1193 = OpLoad %ulong %342
+%1194 = OpBitwiseXor %ulong %1192 %1193
+OpStore %343 %1194
+%1195 = OpLoad %ulong %343
+%1196 = OpIMul %ulong %1195 %ulong_1099511628211
+OpStore %344 %1196
+%1197 = OpLoad %ulong %347
+%1198 = OpIAdd %ulong %1197 %ulong_1
+OpStore %345 %1198
+%1199 = OpLoad %ulong %344
+OpStore %346 %1199
+%1200 = OpLoad %ulong %345
+OpStore %347 %1200
+OpBranch %244
+%73 = OpLabel
+%1201 = OpLoad %ulong %329
+%1202 = OpAccessChain %_ptr_Function_ulong %258 %1201
+%1203 = OpLoad %ulong %1202
+OpStore %312 %1203
+%1204 = OpLoad %ulong %312
+%1205 = OpIMul %ulong %1204 %ulong_2654435761
+OpStore %313 %1205
+%1206 = OpLoad %ulong %328
+%1207 = OpLoad %ulong %313
+%1208 = OpBitwiseXor %ulong %1206 %1207
+OpStore %314 %1208
+OpBranch %83
+%83 = OpLabel
+%1209 = OpLoad %ulong %327
+OpStore %337 %1209
+OpStore %338 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%1210 = OpLoad %ulong %338
+%1211 = OpULessThan %bool %1210 %ulong_8
+OpStore %330 %1211
+%1212 = OpLoad %bool %330
+OpLoopMerge %86 %243 None
+OpBranchConditional %1212 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+%1213 = OpLoad %ulong %329
+%1214 = OpIAdd %ulong %1213 %ulong_1
+OpStore %315 %1214
+%1215 = OpLoad %ulong %337
+OpStore %327 %1215
+%1216 = OpLoad %ulong %314
+OpStore %328 %1216
+%1217 = OpLoad %ulong %315
+OpStore %329 %1217
+OpBranch %245
+%85 = OpLabel
+%1218 = OpLoad %ulong %338
+%1219 = OpIMul %ulong %1218 %ulong_8
+OpStore %331 %1219
+%1220 = OpLoad %ulong %314
+%1221 = OpLoad %ulong %331
+%1222 = OpShiftRightLogical %ulong %1220 %1221
+OpStore %332 %1222
+%1223 = OpLoad %ulong %332
+%1224 = OpBitwiseAnd %ulong %1223 %ulong_255
+OpStore %333 %1224
+%1225 = OpLoad %ulong %337
+%1226 = OpLoad %ulong %333
+%1227 = OpBitwiseXor %ulong %1225 %1226
+OpStore %334 %1227
+%1228 = OpLoad %ulong %334
+%1229 = OpIMul %ulong %1228 %ulong_1099511628211
+OpStore %335 %1229
+%1230 = OpLoad %ulong %338
+%1231 = OpIAdd %ulong %1230 %ulong_1
+OpStore %336 %1231
+%1232 = OpLoad %ulong %335
+OpStore %337 %1232
+%1233 = OpLoad %ulong %336
+OpStore %338 %1233
+OpBranch %243
+%172 = OpLabel
+%1234 = OpLoad %ulong %491
+%1235 = OpIMul %ulong %1234 %ulong_8
+OpStore %484 %1235
+%1236 = OpLoad %ulong %264
+%1237 = OpLoad %ulong %484
+%1238 = OpShiftRightLogical %ulong %1236 %1237
+OpStore %485 %1238
+%1239 = OpLoad %ulong %485
+%1240 = OpBitwiseAnd %ulong %1239 %ulong_255
+OpStore %486 %1240
+%1241 = OpLoad %ulong %490
+%1242 = OpLoad %ulong %486
+%1243 = OpBitwiseXor %ulong %1241 %1242
+OpStore %487 %1243
+%1244 = OpLoad %ulong %487
+%1245 = OpIMul %ulong %1244 %ulong_1099511628211
+OpStore %488 %1245
+%1246 = OpLoad %ulong %491
+%1247 = OpIAdd %ulong %1246 %ulong_1
+OpStore %489 %1247
+%1248 = OpLoad %ulong %488
+OpStore %490 %1248
+%1249 = OpLoad %ulong %489
+OpStore %491 %1249
+OpBranch %246
+%162 = OpLabel
+%1250 = OpLoad %ulong %473
+%1251 = OpIMul %ulong %1250 %ulong_8
+OpStore %466 %1251
+%1253 = OpLoad %ulong %466
+%1254 = OpShiftRightLogical %ulong %ulong_7544905068303 %1253
+OpStore %467 %1254
+%1255 = OpLoad %ulong %467
+%1256 = OpBitwiseAnd %ulong %1255 %ulong_255
+OpStore %468 %1256
+%1257 = OpLoad %ulong %472
+%1258 = OpLoad %ulong %468
+%1259 = OpBitwiseXor %ulong %1257 %1258
+OpStore %469 %1259
+%1260 = OpLoad %ulong %469
+%1261 = OpIMul %ulong %1260 %ulong_1099511628211
+OpStore %470 %1261
+%1262 = OpLoad %ulong %473
+%1263 = OpIAdd %ulong %1262 %ulong_1
+OpStore %471 %1263
+%1264 = OpLoad %ulong %470
+OpStore %472 %1264
+%1265 = OpLoad %ulong %471
+OpStore %473 %1265
+OpBranch %247
+%155 = OpLabel
+%1266 = OpLoad %ulong %460
+%1267 = OpIMul %ulong %1266 %ulong_8
+OpStore %453 %1267
+%1268 = OpLoad %ulong %262
+%1269 = OpLoad %ulong %453
+%1270 = OpShiftRightLogical %ulong %1268 %1269
+OpStore %454 %1270
+%1271 = OpLoad %ulong %454
+%1272 = OpBitwiseAnd %ulong %1271 %ulong_255
+OpStore %455 %1272
+%1273 = OpLoad %ulong %459
+%1274 = OpLoad %ulong %455
+%1275 = OpBitwiseXor %ulong %1273 %1274
+OpStore %456 %1275
+%1276 = OpLoad %ulong %456
+%1277 = OpIMul %ulong %1276 %ulong_1099511628211
+OpStore %457 %1277
+%1278 = OpLoad %ulong %460
+%1279 = OpIAdd %ulong %1278 %ulong_1
+OpStore %458 %1279
+%1280 = OpLoad %ulong %457
+OpStore %459 %1280
+%1281 = OpLoad %ulong %458
+OpStore %460 %1281
+OpBranch %248
+%145 = OpLabel
+%1282 = OpLoad %ulong %442
+%1283 = OpIMul %ulong %1282 %ulong_8
+OpStore %435 %1283
+%1285 = OpLoad %ulong %435
+%1286 = OpShiftRightLogical %ulong %ulong_916259695 %1285
+OpStore %436 %1286
+%1287 = OpLoad %ulong %436
+%1288 = OpBitwiseAnd %ulong %1287 %ulong_255
+OpStore %437 %1288
+%1289 = OpLoad %ulong %441
+%1290 = OpLoad %ulong %437
+%1291 = OpBitwiseXor %ulong %1289 %1290
+OpStore %438 %1291
+%1292 = OpLoad %ulong %438
+%1293 = OpIMul %ulong %1292 %ulong_1099511628211
+OpStore %439 %1293
+%1294 = OpLoad %ulong %442
+%1295 = OpIAdd %ulong %1294 %ulong_1
+OpStore %440 %1295
+%1296 = OpLoad %ulong %439
+OpStore %441 %1296
+%1297 = OpLoad %ulong %440
+OpStore %442 %1297
+OpBranch %249
+%132 = OpLabel
+%1298 = OpLoad %ulong %422
+%1299 = OpIMul %ulong %1298 %ulong_8
+OpStore %415 %1299
+%1300 = OpLoad %ulong %260
+%1301 = OpLoad %ulong %415
+%1302 = OpShiftRightLogical %ulong %1300 %1301
+OpStore %416 %1302
+%1303 = OpLoad %ulong %416
+%1304 = OpBitwiseAnd %ulong %1303 %ulong_255
+OpStore %417 %1304
+%1305 = OpLoad %ulong %421
+%1306 = OpLoad %ulong %417
+%1307 = OpBitwiseXor %ulong %1305 %1306
+OpStore %418 %1307
+%1308 = OpLoad %ulong %418
+%1309 = OpIMul %ulong %1308 %ulong_1099511628211
+OpStore %419 %1309
+%1310 = OpLoad %ulong %422
+%1311 = OpIAdd %ulong %1310 %ulong_1
+OpStore %420 %1311
+%1312 = OpLoad %ulong %419
+OpStore %421 %1312
+%1313 = OpLoad %ulong %420
+OpStore %422 %1313
+OpBranch %250
+%122 = OpLabel
+%1314 = OpLoad %ulong %404
+%1315 = OpIMul %ulong %1314 %ulong_8
+OpStore %397 %1315
+%1316 = OpLoad %ulong %397
+%1317 = OpShiftRightLogical %ulong %ulong_305419896 %1316
+OpStore %398 %1317
+%1318 = OpLoad %ulong %398
+%1319 = OpBitwiseAnd %ulong %1318 %ulong_255
+OpStore %399 %1319
+%1320 = OpLoad %ulong %403
+%1321 = OpLoad %ulong %399
+%1322 = OpBitwiseXor %ulong %1320 %1321
+OpStore %400 %1322
+%1323 = OpLoad %ulong %400
+%1324 = OpIMul %ulong %1323 %ulong_1099511628211
+OpStore %401 %1324
+%1325 = OpLoad %ulong %404
+%1326 = OpIAdd %ulong %1325 %ulong_1
+OpStore %402 %1326
+%1327 = OpLoad %ulong %401
+OpStore %403 %1327
+%1328 = OpLoad %ulong %402
+OpStore %404 %1328
+OpBranch %251
+%235 = OpLabel
+OpBranch %166
+%236 = OpLabel
+OpBranch %149
+%237 = OpLabel
+OpBranch %126
+%238 = OpLabel
+OpBranch %109
+%239 = OpLabel
+OpBranch %114
+%240 = OpLabel
+OpBranch %94
+%241 = OpLabel
+OpBranch %99
+%242 = OpLabel
+OpBranch %104
+%243 = OpLabel
+OpBranch %84
+%244 = OpLabel
+OpBranch %89
+%245 = OpLabel
+OpBranch %72
+%246 = OpLabel
+OpBranch %171
+%247 = OpLabel
+OpBranch %161
+%248 = OpLabel
+OpBranch %154
+%249 = OpLabel
+OpBranch %144
+%250 = OpLabel
+OpBranch %131
+%251 = OpLabel
+OpBranch %121
 OpFunctionEnd
-%3 = OpFunction %ulong None %72
-%729 = OpFunctionParameter %ulong
-%730 = OpLabel
-%731 = OpVariable %_ptr_Function_ulong Function
-%732 = OpVariable %_ptr_Function_ulong Function
-%733 = OpVariable %_ptr_Function_ulong Function
-%734 = OpVariable %_ptr_Function_ulong Function
-OpStore %731 %729
-%735 = OpLoad %ulong %731
-%736 = OpShiftRightLogical %ulong %735 %ulong_29
-OpStore %732 %736
-%737 = OpLoad %ulong %731
-%738 = OpLoad %ulong %732
-%739 = OpBitwiseXor %ulong %737 %738
-OpStore %733 %739
-%740 = OpLoad %ulong %733
-%741 = OpIMul %ulong %740 %ulong_1099511628211
-OpStore %734 %741
-%742 = OpLoad %ulong %734
-OpReturnValue %742
+%3 = OpFunction %ulong None %69
+%1329 = OpFunctionParameter %ulong
+%1330 = OpLabel
+%1331 = OpVariable %_ptr_Function_ulong Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_ulong Function
+%1334 = OpVariable %_ptr_Function_ulong Function
+OpStore %1331 %1329
+%1335 = OpLoad %ulong %1331
+%1336 = OpShiftRightLogical %ulong %1335 %ulong_29
+OpStore %1332 %1336
+%1337 = OpLoad %ulong %1331
+%1338 = OpLoad %ulong %1332
+%1339 = OpBitwiseXor %ulong %1337 %1338
+OpStore %1333 %1339
+%1340 = OpLoad %ulong %1333
+%1341 = OpIMul %ulong %1340 %ulong_1099511628211
+OpStore %1334 %1341
+%1342 = OpLoad %ulong %1334
+OpReturnValue %1342
 OpFunctionEnd
-%4 = OpFunction %ulong None %72
-%743 = OpFunctionParameter %ulong
-%744 = OpLabel
-%745 = OpVariable %_ptr_Function_ulong Function
-%746 = OpVariable %_ptr_Function_ulong Function
-%747 = OpVariable %_ptr_Function_ulong Function
-%748 = OpVariable %_ptr_Function_ulong Function
-%749 = OpVariable %_ptr_Function_ulong Function
-OpStore %745 %743
-%750 = OpLoad %ulong %745
-%751 = OpShiftLeftLogical %ulong %750 %ulong_17
-OpStore %746 %751
-%752 = OpLoad %ulong %745
-%753 = OpShiftRightLogical %ulong %752 %ulong_47
-OpStore %747 %753
-%754 = OpLoad %ulong %746
-%755 = OpLoad %ulong %747
-%756 = OpBitwiseOr %ulong %754 %755
-OpStore %748 %756
-%757 = OpLoad %ulong %748
-%758 = OpIAdd %ulong %757 %ulong_12345
-OpStore %749 %758
-%759 = OpLoad %ulong %749
-OpReturnValue %759
+%4 = OpFunction %ulong None %69
+%1343 = OpFunctionParameter %ulong
+%1344 = OpLabel
+%1345 = OpVariable %_ptr_Function_ulong Function
+%1346 = OpVariable %_ptr_Function_ulong Function
+%1347 = OpVariable %_ptr_Function_ulong Function
+%1348 = OpVariable %_ptr_Function_ulong Function
+%1349 = OpVariable %_ptr_Function_ulong Function
+OpStore %1345 %1343
+%1350 = OpLoad %ulong %1345
+%1351 = OpShiftLeftLogical %ulong %1350 %ulong_17
+OpStore %1346 %1351
+%1352 = OpLoad %ulong %1345
+%1353 = OpShiftRightLogical %ulong %1352 %ulong_47
+OpStore %1347 %1353
+%1354 = OpLoad %ulong %1346
+%1355 = OpLoad %ulong %1347
+%1356 = OpBitwiseOr %ulong %1354 %1355
+OpStore %1348 %1356
+%1357 = OpLoad %ulong %1348
+%1358 = OpIAdd %ulong %1357 %ulong_12345
+OpStore %1349 %1358
+%1359 = OpLoad %ulong %1349
+OpReturnValue %1359
 OpFunctionEnd
-%5 = OpFunction %ulong None %760
-%761 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%6 = OpFunction %ulong None %763
-%764 = OpFunctionParameter %ulong
-%765 = OpFunctionParameter %ulong
-%766 = OpLabel
-%771 = OpVariable %_ptr_Function_ulong Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_bool Function
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_ulong Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_ulong Function
-%778 = OpVariable %_ptr_Function_ulong Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_ulong Function
-OpStore %771 %764
-OpStore %772 %765
-%782 = OpLoad %ulong %771
-OpStore %780 %782
-OpStore %781 %ulong_0
-OpBranch %767
-%767 = OpLabel
-%783 = OpLoad %ulong %781
-%785 = OpULessThan %bool %783 %ulong_8
-OpStore %773 %785
-%786 = OpLoad %bool %773
-OpLoopMerge %769 %770 None
-OpBranchConditional %786 %768 %769
-%769 = OpLabel
-%787 = OpLoad %ulong %780
-OpReturnValue %787
-%768 = OpLabel
-%788 = OpLoad %ulong %781
-%789 = OpIMul %ulong %788 %ulong_8
-OpStore %774 %789
-%790 = OpLoad %ulong %772
-%791 = OpLoad %ulong %774
-%792 = OpShiftRightLogical %ulong %790 %791
-OpStore %775 %792
-%793 = OpLoad %ulong %775
-%795 = OpBitwiseAnd %ulong %793 %ulong_255
-OpStore %776 %795
-%796 = OpLoad %ulong %780
-%797 = OpLoad %ulong %776
-%798 = OpBitwiseXor %ulong %796 %797
-OpStore %777 %798
-%799 = OpLoad %ulong %777
-%800 = OpIMul %ulong %799 %ulong_1099511628211
-OpStore %778 %800
-%801 = OpLoad %ulong %781
-%802 = OpIAdd %ulong %801 %ulong_1
-OpStore %779 %802
-%803 = OpLoad %ulong %778
-OpStore %780 %803
-%804 = OpLoad %ulong %779
-OpStore %781 %804
-OpBranch %770
-%770 = OpLabel
-OpBranch %767
-OpFunctionEnd
-%7 = OpFunction %ulong None %805
-%806 = OpFunctionParameter %ulong
-%807 = OpFunctionParameter %float
-%808 = OpLabel
-%815 = OpVariable %_ptr_Function_ulong Function
-%816 = OpVariable %_ptr_Function_float Function
-%818 = OpVariable %_ptr_Function_uint Function
-%819 = OpVariable %_ptr_Function_ulong Function
-%820 = OpVariable %_ptr_Function_bool Function
-%821 = OpVariable %_ptr_Function_ulong Function
-%822 = OpVariable %_ptr_Function_ulong Function
-%823 = OpVariable %_ptr_Function_ulong Function
-%824 = OpVariable %_ptr_Function_ulong Function
-%825 = OpVariable %_ptr_Function_ulong Function
-%826 = OpVariable %_ptr_Function_ulong Function
-%827 = OpVariable %_ptr_Function_ulong Function
-%828 = OpVariable %_ptr_Function_ulong Function
-OpStore %815 %806
-OpStore %816 %807
-%829 = OpLoad %float %816
-%830 = OpBitcast %uint %829
-OpStore %818 %830
-%831 = OpLoad %uint %818
-%832 = OpUConvert %ulong %831
-OpStore %819 %832
-OpBranch %809
-%809 = OpLabel
-%833 = OpLoad %ulong %815
-OpStore %827 %833
-OpStore %828 %ulong_0
-OpBranch %810
-%810 = OpLabel
-%834 = OpLoad %ulong %828
-%835 = OpULessThan %bool %834 %ulong_8
-OpStore %820 %835
-%836 = OpLoad %bool %820
-OpLoopMerge %812 %814 None
-OpBranchConditional %836 %811 %812
-%812 = OpLabel
-OpBranch %813
-%813 = OpLabel
-%837 = OpLoad %ulong %827
-OpReturnValue %837
-%811 = OpLabel
-%838 = OpLoad %ulong %828
-%839 = OpIMul %ulong %838 %ulong_8
-OpStore %821 %839
-%840 = OpLoad %ulong %819
-%841 = OpLoad %ulong %821
-%842 = OpShiftRightLogical %ulong %840 %841
-OpStore %822 %842
-%843 = OpLoad %ulong %822
-%844 = OpBitwiseAnd %ulong %843 %ulong_255
-OpStore %823 %844
-%845 = OpLoad %ulong %827
-%846 = OpLoad %ulong %823
-%847 = OpBitwiseXor %ulong %845 %846
-OpStore %824 %847
-%848 = OpLoad %ulong %824
-%849 = OpIMul %ulong %848 %ulong_1099511628211
-OpStore %825 %849
-%850 = OpLoad %ulong %828
-%851 = OpIAdd %ulong %850 %ulong_1
-OpStore %826 %851
-%852 = OpLoad %ulong %825
-OpStore %827 %852
-%853 = OpLoad %ulong %826
-OpStore %828 %853
-OpBranch %814
-%814 = OpLabel
-OpBranch %810
-OpFunctionEnd
-%8 = OpFunction %ulong None %854
-%855 = OpFunctionParameter %ulong
-%856 = OpFunctionParameter %double
-%857 = OpLabel
-%864 = OpVariable %_ptr_Function_ulong Function
-%865 = OpVariable %_ptr_Function_double Function
-%866 = OpVariable %_ptr_Function_ulong Function
-%867 = OpVariable %_ptr_Function_bool Function
-%868 = OpVariable %_ptr_Function_ulong Function
-%869 = OpVariable %_ptr_Function_ulong Function
-%870 = OpVariable %_ptr_Function_ulong Function
-%871 = OpVariable %_ptr_Function_ulong Function
-%872 = OpVariable %_ptr_Function_ulong Function
-%873 = OpVariable %_ptr_Function_ulong Function
-%874 = OpVariable %_ptr_Function_ulong Function
-%875 = OpVariable %_ptr_Function_ulong Function
-OpStore %864 %855
-OpStore %865 %856
-%876 = OpLoad %double %865
-%877 = OpBitcast %ulong %876
-OpStore %866 %877
-OpBranch %858
-%858 = OpLabel
-%878 = OpLoad %ulong %864
-OpStore %874 %878
-OpStore %875 %ulong_0
-OpBranch %859
-%859 = OpLabel
-%879 = OpLoad %ulong %875
-%880 = OpULessThan %bool %879 %ulong_8
-OpStore %867 %880
-%881 = OpLoad %bool %867
-OpLoopMerge %861 %863 None
-OpBranchConditional %881 %860 %861
-%861 = OpLabel
-OpBranch %862
-%862 = OpLabel
-%882 = OpLoad %ulong %874
-OpReturnValue %882
-%860 = OpLabel
-%883 = OpLoad %ulong %875
-%884 = OpIMul %ulong %883 %ulong_8
-OpStore %868 %884
-%885 = OpLoad %ulong %866
-%886 = OpLoad %ulong %868
-%887 = OpShiftRightLogical %ulong %885 %886
-OpStore %869 %887
-%888 = OpLoad %ulong %869
-%889 = OpBitwiseAnd %ulong %888 %ulong_255
-OpStore %870 %889
-%890 = OpLoad %ulong %874
-%891 = OpLoad %ulong %870
-%892 = OpBitwiseXor %ulong %890 %891
-OpStore %871 %892
-%893 = OpLoad %ulong %871
-%894 = OpIMul %ulong %893 %ulong_1099511628211
-OpStore %872 %894
-%895 = OpLoad %ulong %875
-%896 = OpIAdd %ulong %895 %ulong_1
-OpStore %873 %896
-%897 = OpLoad %ulong %872
-OpStore %874 %897
-%898 = OpLoad %ulong %873
-OpStore %875 %898
-OpBranch %863
-%863 = OpLabel
-OpBranch %859
+%5 = OpFunction %ulong None %1360
+%1361 = OpFunctionParameter %ulong
+%1362 = OpFunctionParameter %ulong
+%1363 = OpLabel
+%1368 = OpVariable %_ptr_Function_ulong Function
+%1369 = OpVariable %_ptr_Function_ulong Function
+%1370 = OpVariable %_ptr_Function_bool Function
+%1371 = OpVariable %_ptr_Function_ulong Function
+%1372 = OpVariable %_ptr_Function_ulong Function
+%1373 = OpVariable %_ptr_Function_ulong Function
+%1374 = OpVariable %_ptr_Function_ulong Function
+%1375 = OpVariable %_ptr_Function_ulong Function
+%1376 = OpVariable %_ptr_Function_ulong Function
+%1377 = OpVariable %_ptr_Function_ulong Function
+%1378 = OpVariable %_ptr_Function_ulong Function
+OpStore %1368 %1361
+OpStore %1369 %1362
+%1379 = OpLoad %ulong %1368
+OpStore %1377 %1379
+OpStore %1378 %ulong_0
+OpBranch %1364
+%1364 = OpLabel
+%1380 = OpLoad %ulong %1378
+%1381 = OpULessThan %bool %1380 %ulong_8
+OpStore %1370 %1381
+%1382 = OpLoad %bool %1370
+OpLoopMerge %1366 %1367 None
+OpBranchConditional %1382 %1365 %1366
+%1366 = OpLabel
+%1383 = OpLoad %ulong %1377
+OpReturnValue %1383
+%1365 = OpLabel
+%1384 = OpLoad %ulong %1378
+%1385 = OpIMul %ulong %1384 %ulong_8
+OpStore %1371 %1385
+%1386 = OpLoad %ulong %1369
+%1387 = OpLoad %ulong %1371
+%1388 = OpShiftRightLogical %ulong %1386 %1387
+OpStore %1372 %1388
+%1389 = OpLoad %ulong %1372
+%1390 = OpBitwiseAnd %ulong %1389 %ulong_255
+OpStore %1373 %1390
+%1391 = OpLoad %ulong %1377
+%1392 = OpLoad %ulong %1373
+%1393 = OpBitwiseXor %ulong %1391 %1392
+OpStore %1374 %1393
+%1394 = OpLoad %ulong %1374
+%1395 = OpIMul %ulong %1394 %ulong_1099511628211
+OpStore %1375 %1395
+%1396 = OpLoad %ulong %1378
+%1397 = OpIAdd %ulong %1396 %ulong_1
+OpStore %1376 %1397
+%1398 = OpLoad %ulong %1375
+OpStore %1377 %1398
+%1399 = OpLoad %ulong %1376
+OpStore %1378 %1399
+OpBranch %1367
+%1367 = OpLabel
+OpBranch %1364
 OpFunctionEnd

--- a/test/golden/spirv/convert/bitcast.dis
+++ b/test/golden/spirv/convert/bitcast.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 285
+; Bound: 450
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,403 +10,670 @@ OpCapability Float64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.convert.bitcast.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %float = OpTypeFloat 32
+%bool = OpTypeBool
 %double = OpTypeFloat 64
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_double = OpTypePointer Function %double
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uint_3226013659 = OpConstant %uint 3226013659
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ulong_4614256656552045848 = OpConstant %ulong 4614256656552045848
 %uint_1078530011 = OpConstant %uint 1078530011
 %ulong_4613303445314885481 = OpConstant %ulong 4613303445314885481
-%97 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%100 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%147 = OpTypeFunction %ulong %ulong %uint
-%192 = OpTypeFunction %ulong %ulong %float
-%240 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_float Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_double Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_uint Function
-%34 = OpVariable %_ptr_Function_float Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_double Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-OpStore %15 %9
-%41 = OpFunctionCall %ulong %2
-OpStore %16 %41
-%42 = OpLoad %ulong %15
-%43 = OpUConvert %uint %42
-OpStore %18 %43
-%44 = OpLoad %uint %18
-%46 = OpBitwiseXor %uint %44 %uint_3226013659
-OpStore %19 %46
-%47 = OpLoad %uint %19
-%48 = OpBitcast %float %47
-OpStore %21 %48
-%49 = OpLoad %float %21
-%50 = OpBitcast %uint %49
-OpStore %22 %50
-%51 = OpLoad %ulong %16
-%52 = OpLoad %uint %19
-%53 = OpFunctionCall %ulong %4 %51 %52
-OpStore %23 %53
-%54 = OpLoad %ulong %23
-%55 = OpLoad %float %21
-%56 = OpFunctionCall %ulong %5 %54 %55
-OpStore %24 %56
-%57 = OpLoad %ulong %24
-%58 = OpLoad %uint %22
-%59 = OpFunctionCall %ulong %4 %57 %58
-OpStore %25 %59
-%60 = OpLoad %ulong %15
-%62 = OpBitwiseXor %ulong %60 %ulong_4614256656552045848
-OpStore %26 %62
-%63 = OpLoad %ulong %26
-%64 = OpBitcast %double %63
-OpStore %28 %64
-%65 = OpLoad %double %28
-%66 = OpBitcast %ulong %65
-OpStore %29 %66
-%67 = OpLoad %ulong %25
-%68 = OpLoad %ulong %26
-%69 = OpFunctionCall %ulong %3 %67 %68
-OpStore %30 %69
-%70 = OpLoad %ulong %30
-%71 = OpLoad %double %28
-%72 = OpFunctionCall %ulong %6 %70 %71
-OpStore %31 %72
-%73 = OpLoad %ulong %31
-%74 = OpLoad %ulong %29
-%75 = OpFunctionCall %ulong %3 %73 %74
-OpStore %32 %75
-%77 = OpBitcast %uint %uint_1078530011
-OpStore %33 %77
-%78 = OpLoad %uint %33
-%79 = OpBitcast %float %78
-OpStore %34 %79
-%80 = OpLoad %ulong %32
-%81 = OpLoad %uint %33
-%82 = OpFunctionCall %ulong %4 %80 %81
-OpStore %35 %82
-%83 = OpLoad %ulong %35
-%84 = OpLoad %float %34
-%85 = OpFunctionCall %ulong %5 %83 %84
-OpStore %36 %85
-%87 = OpBitcast %ulong %ulong_4613303445314885481
-OpStore %37 %87
-%88 = OpLoad %ulong %37
-%89 = OpBitcast %double %88
-OpStore %38 %89
-%90 = OpLoad %ulong %36
-%91 = OpLoad %ulong %37
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %39 %92
-%93 = OpLoad %ulong %39
-%94 = OpLoad %double %38
-%95 = OpFunctionCall %ulong %6 %93 %94
-OpStore %40 %95
-%96 = OpLoad %ulong %40
-OpReturnValue %96
-OpFunctionEnd
-%2 = OpFunction %ulong None %97
-%98 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %100
-%101 = OpFunctionParameter %ulong
-%102 = OpFunctionParameter %ulong
-%103 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%87 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_uint Function
+%90 = OpVariable %_ptr_Function_uint Function
+%92 = OpVariable %_ptr_Function_float Function
+%93 = OpVariable %_ptr_Function_uint Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_double Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_uint Function
+%99 = OpVariable %_ptr_Function_float Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_double Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_bool Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
 %109 = OpVariable %_ptr_Function_ulong Function
 %110 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_bool Function
-%113 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_uint Function
 %114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_bool Function
 %116 = OpVariable %_ptr_Function_ulong Function
 %117 = OpVariable %_ptr_Function_ulong Function
 %118 = OpVariable %_ptr_Function_ulong Function
 %119 = OpVariable %_ptr_Function_ulong Function
 %120 = OpVariable %_ptr_Function_ulong Function
-OpStore %109 %101
-OpStore %110 %102
-%121 = OpLoad %ulong %109
-OpStore %119 %121
-OpStore %120 %ulong_0
-OpBranch %104
-%104 = OpLabel
-%123 = OpLoad %ulong %120
-%125 = OpULessThan %bool %123 %ulong_8
-OpStore %112 %125
-%126 = OpLoad %bool %112
-OpLoopMerge %106 %107 None
-OpBranchConditional %126 %105 %106
-%106 = OpLabel
-%127 = OpLoad %ulong %119
-OpReturnValue %127
-%105 = OpLabel
-%128 = OpLoad %ulong %120
-%129 = OpIMul %ulong %128 %ulong_8
-OpStore %113 %129
-%130 = OpLoad %ulong %110
-%131 = OpLoad %ulong %113
-%132 = OpShiftRightLogical %ulong %130 %131
-OpStore %114 %132
-%133 = OpLoad %ulong %114
-%135 = OpBitwiseAnd %ulong %133 %ulong_255
-OpStore %115 %135
-%136 = OpLoad %ulong %119
-%137 = OpLoad %ulong %115
-%138 = OpBitwiseXor %ulong %136 %137
-OpStore %116 %138
-%139 = OpLoad %ulong %116
-%141 = OpIMul %ulong %139 %ulong_1099511628211
-OpStore %117 %141
-%142 = OpLoad %ulong %120
-%144 = OpIAdd %ulong %142 %ulong_1
-OpStore %118 %144
-%145 = OpLoad %ulong %117
-OpStore %119 %145
-%146 = OpLoad %ulong %118
-OpStore %120 %146
-OpBranch %107
-%107 = OpLabel
-OpBranch %104
-OpFunctionEnd
-%4 = OpFunction %ulong None %147
-%148 = OpFunctionParameter %ulong
-%149 = OpFunctionParameter %uint
-%150 = OpLabel
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_bool Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_bool Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_bool Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
 %157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_bool Function
+%160 = OpVariable %_ptr_Function_ulong Function
 %161 = OpVariable %_ptr_Function_ulong Function
 %162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_bool Function
 %164 = OpVariable %_ptr_Function_ulong Function
 %165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-OpStore %157 %148
-OpStore %158 %149
-%169 = OpLoad %uint %158
-%170 = OpUConvert %ulong %169
-OpStore %159 %170
-OpBranch %151
-%151 = OpLabel
-%171 = OpLoad %ulong %157
-OpStore %167 %171
-OpStore %168 %ulong_0
-OpBranch %152
-%152 = OpLabel
-%172 = OpLoad %ulong %168
-%173 = OpULessThan %bool %172 %ulong_8
-OpStore %160 %173
-%174 = OpLoad %bool %160
-OpLoopMerge %154 %156 None
-OpBranchConditional %174 %153 %154
-%154 = OpLabel
-OpBranch %155
-%155 = OpLabel
-%175 = OpLoad %ulong %167
-OpReturnValue %175
-%153 = OpLabel
-%176 = OpLoad %ulong %168
-%177 = OpIMul %ulong %176 %ulong_8
-OpStore %161 %177
-%178 = OpLoad %ulong %159
-%179 = OpLoad %ulong %161
-%180 = OpShiftRightLogical %ulong %178 %179
-OpStore %162 %180
-%181 = OpLoad %ulong %162
-%182 = OpBitwiseAnd %ulong %181 %ulong_255
-OpStore %163 %182
-%183 = OpLoad %ulong %167
-%184 = OpLoad %ulong %163
-%185 = OpBitwiseXor %ulong %183 %184
-OpStore %164 %185
-%186 = OpLoad %ulong %164
-%187 = OpIMul %ulong %186 %ulong_1099511628211
-OpStore %165 %187
-%188 = OpLoad %ulong %168
-%189 = OpIAdd %ulong %188 %ulong_1
-OpStore %166 %189
-%190 = OpLoad %ulong %165
-OpStore %167 %190
-%191 = OpLoad %ulong %166
-OpStore %168 %191
-OpBranch %156
-%156 = OpLabel
-OpBranch %152
-OpFunctionEnd
-%5 = OpFunction %ulong None %192
-%193 = OpFunctionParameter %ulong
-%194 = OpFunctionParameter %float
-%195 = OpLabel
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_uint Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_bool Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ulong Function
-OpStore %202 %193
-OpStore %203 %194
-%215 = OpLoad %float %203
-%216 = OpBitcast %uint %215
-OpStore %204 %216
-%217 = OpLoad %uint %204
-%218 = OpUConvert %ulong %217
-OpStore %205 %218
-OpBranch %196
-%196 = OpLabel
-%219 = OpLoad %ulong %202
-OpStore %213 %219
-OpStore %214 %ulong_0
-OpBranch %197
-%197 = OpLabel
-%220 = OpLoad %ulong %214
-%221 = OpULessThan %bool %220 %ulong_8
-OpStore %206 %221
-%222 = OpLoad %bool %206
-OpLoopMerge %199 %201 None
-OpBranchConditional %222 %198 %199
-%199 = OpLabel
-OpBranch %200
-%200 = OpLabel
-%223 = OpLoad %ulong %213
-OpReturnValue %223
-%198 = OpLabel
-%224 = OpLoad %ulong %214
-%225 = OpIMul %ulong %224 %ulong_8
-OpStore %207 %225
-%226 = OpLoad %ulong %205
-%227 = OpLoad %ulong %207
-%228 = OpShiftRightLogical %ulong %226 %227
-OpStore %208 %228
-%229 = OpLoad %ulong %208
-%230 = OpBitwiseAnd %ulong %229 %ulong_255
-OpStore %209 %230
-%231 = OpLoad %ulong %213
-%232 = OpLoad %ulong %209
-%233 = OpBitwiseXor %ulong %231 %232
-OpStore %210 %233
-%234 = OpLoad %ulong %210
-%235 = OpIMul %ulong %234 %ulong_1099511628211
-OpStore %211 %235
-%236 = OpLoad %ulong %214
-%237 = OpIAdd %ulong %236 %ulong_1
-OpStore %212 %237
-%238 = OpLoad %ulong %211
-OpStore %213 %238
-%239 = OpLoad %ulong %212
-OpStore %214 %239
-OpBranch %201
-%201 = OpLabel
-OpBranch %197
-OpFunctionEnd
-%6 = OpFunction %ulong None %240
-%241 = OpFunctionParameter %ulong
-%242 = OpFunctionParameter %double
-%243 = OpLabel
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_double Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_bool Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-OpStore %250 %241
-OpStore %251 %242
-%262 = OpLoad %double %251
-%263 = OpBitcast %ulong %262
-OpStore %252 %263
-OpBranch %244
-%244 = OpLabel
-%264 = OpLoad %ulong %250
-OpStore %260 %264
-OpStore %261 %ulong_0
-OpBranch %245
-%245 = OpLabel
-%265 = OpLoad %ulong %261
-%266 = OpULessThan %bool %265 %ulong_8
-OpStore %253 %266
-%267 = OpLoad %bool %253
-OpLoopMerge %247 %249 None
-OpBranchConditional %267 %246 %247
-%247 = OpLabel
-OpBranch %248
-%248 = OpLabel
-%268 = OpLoad %ulong %260
-OpReturnValue %268
-%246 = OpLabel
-%269 = OpLoad %ulong %261
-%270 = OpIMul %ulong %269 %ulong_8
-OpStore %254 %270
-%271 = OpLoad %ulong %252
-%272 = OpLoad %ulong %254
-%273 = OpShiftRightLogical %ulong %271 %272
-OpStore %255 %273
-%274 = OpLoad %ulong %255
-%275 = OpBitwiseAnd %ulong %274 %ulong_255
-OpStore %256 %275
-%276 = OpLoad %ulong %260
-%277 = OpLoad %ulong %256
-%278 = OpBitwiseXor %ulong %276 %277
-OpStore %257 %278
-%279 = OpLoad %ulong %257
-%280 = OpIMul %ulong %279 %ulong_1099511628211
-OpStore %258 %280
-%281 = OpLoad %ulong %261
-%282 = OpIAdd %ulong %281 %ulong_1
-OpStore %259 %282
-%283 = OpLoad %ulong %258
-OpStore %260 %283
-%284 = OpLoad %ulong %259
-OpStore %261 %284
-OpBranch %249
-%249 = OpLabel
-OpBranch %245
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_uint Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_bool Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_bool Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_bool Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+OpStore %87 %4
+OpBranch %6
+%6 = OpLabel
+OpBranch %7
+%7 = OpLabel
+%202 = OpLoad %ulong %87
+%203 = OpUConvert %uint %202
+OpStore %89 %203
+%204 = OpLoad %uint %89
+%206 = OpBitwiseXor %uint %204 %uint_3226013659
+OpStore %90 %206
+%207 = OpLoad %uint %90
+%208 = OpBitcast %float %207
+OpStore %92 %208
+%209 = OpLoad %float %92
+%210 = OpBitcast %uint %209
+OpStore %93 %210
+OpBranch %8
+%8 = OpLabel
+%211 = OpLoad %uint %90
+%212 = OpUConvert %ulong %211
+OpStore %102 %212
+OpBranch %10
+%10 = OpLabel
+OpStore %111 %ulong_14695981039346656037
+OpStore %112 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%215 = OpLoad %ulong %112
+%217 = OpULessThan %bool %215 %ulong_8
+OpStore %104 %217
+%218 = OpLoad %bool %104
+OpLoopMerge %13 %81 None
+OpBranchConditional %218 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%9 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%219 = OpLoad %float %92
+%220 = OpBitcast %uint %219
+OpStore %113 %220
+%221 = OpLoad %uint %113
+%222 = OpUConvert %ulong %221
+OpStore %114 %222
+OpBranch %17
+%17 = OpLabel
+%223 = OpLoad %ulong %111
+OpStore %122 %223
+OpStore %123 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%224 = OpLoad %ulong %123
+%225 = OpULessThan %bool %224 %ulong_8
+OpStore %115 %225
+%226 = OpLoad %bool %115
+OpLoopMerge %20 %80 None
+OpBranchConditional %226 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%227 = OpLoad %uint %93
+%228 = OpUConvert %ulong %227
+OpStore %124 %228
+OpBranch %24
+%24 = OpLabel
+%229 = OpLoad %ulong %122
+OpStore %132 %229
+OpStore %133 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%230 = OpLoad %ulong %133
+%231 = OpULessThan %bool %230 %ulong_8
+OpStore %125 %231
+%232 = OpLoad %bool %125
+OpLoopMerge %27 %79 None
+OpBranchConditional %232 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%233 = OpLoad %ulong %87
+%235 = OpBitwiseXor %ulong %233 %ulong_4614256656552045848
+OpStore %94 %235
+%236 = OpLoad %ulong %94
+%237 = OpBitcast %double %236
+OpStore %96 %237
+%238 = OpLoad %double %96
+%239 = OpBitcast %ulong %238
+OpStore %97 %239
+OpBranch %29
+%29 = OpLabel
+%240 = OpLoad %ulong %132
+OpStore %141 %240
+OpStore %142 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%241 = OpLoad %ulong %142
+%242 = OpULessThan %bool %241 %ulong_8
+OpStore %134 %242
+%243 = OpLoad %bool %134
+OpLoopMerge %32 %78 None
+OpBranchConditional %243 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%244 = OpLoad %double %96
+%245 = OpBitcast %ulong %244
+OpStore %143 %245
+OpBranch %36
+%36 = OpLabel
+%246 = OpLoad %ulong %141
+OpStore %151 %246
+OpStore %152 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%247 = OpLoad %ulong %152
+%248 = OpULessThan %bool %247 %ulong_8
+OpStore %144 %248
+%249 = OpLoad %bool %144
+OpLoopMerge %39 %77 None
+OpBranchConditional %249 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%250 = OpLoad %ulong %151
+OpStore %160 %250
+OpStore %161 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%251 = OpLoad %ulong %161
+%252 = OpULessThan %bool %251 %ulong_8
+OpStore %153 %252
+%253 = OpLoad %bool %153
+OpLoopMerge %44 %76 None
+OpBranchConditional %253 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%255 = OpBitcast %uint %uint_1078530011
+OpStore %98 %255
+%256 = OpLoad %uint %98
+%257 = OpBitcast %float %256
+OpStore %99 %257
+OpBranch %46
+%46 = OpLabel
+%258 = OpLoad %uint %98
+%259 = OpUConvert %ulong %258
+OpStore %162 %259
+OpBranch %48
+%48 = OpLabel
+%260 = OpLoad %ulong %160
+OpStore %170 %260
+OpStore %171 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%261 = OpLoad %ulong %171
+%262 = OpULessThan %bool %261 %ulong_8
+OpStore %163 %262
+%263 = OpLoad %bool %163
+OpLoopMerge %51 %75 None
+OpBranchConditional %263 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%264 = OpLoad %float %99
+%265 = OpBitcast %uint %264
+OpStore %172 %265
+%266 = OpLoad %uint %172
+%267 = OpUConvert %ulong %266
+OpStore %173 %267
+OpBranch %55
+%55 = OpLabel
+%268 = OpLoad %ulong %170
+OpStore %181 %268
+OpStore %182 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%269 = OpLoad %ulong %182
+%270 = OpULessThan %bool %269 %ulong_8
+OpStore %174 %270
+%271 = OpLoad %bool %174
+OpLoopMerge %58 %74 None
+OpBranchConditional %271 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%273 = OpBitcast %ulong %ulong_4613303445314885481
+OpStore %100 %273
+%274 = OpLoad %ulong %100
+%275 = OpBitcast %double %274
+OpStore %101 %275
+OpBranch %60
+%60 = OpLabel
+%276 = OpLoad %ulong %181
+OpStore %190 %276
+OpStore %191 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%277 = OpLoad %ulong %191
+%278 = OpULessThan %bool %277 %ulong_8
+OpStore %183 %278
+%279 = OpLoad %bool %183
+OpLoopMerge %63 %73 None
+OpBranchConditional %279 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+%280 = OpLoad %double %101
+%281 = OpBitcast %ulong %280
+OpStore %192 %281
+OpBranch %67
+%67 = OpLabel
+%282 = OpLoad %ulong %190
+OpStore %200 %282
+OpStore %201 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%283 = OpLoad %ulong %201
+%284 = OpULessThan %bool %283 %ulong_8
+OpStore %193 %284
+%285 = OpLoad %bool %193
+OpLoopMerge %70 %72 None
+OpBranchConditional %285 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+OpBranch %66
+%66 = OpLabel
+%286 = OpLoad %ulong %200
+OpReturnValue %286
+%69 = OpLabel
+%287 = OpLoad %ulong %201
+%288 = OpIMul %ulong %287 %ulong_8
+OpStore %194 %288
+%289 = OpLoad %ulong %192
+%290 = OpLoad %ulong %194
+%291 = OpShiftRightLogical %ulong %289 %290
+OpStore %195 %291
+%292 = OpLoad %ulong %195
+%294 = OpBitwiseAnd %ulong %292 %ulong_255
+OpStore %196 %294
+%295 = OpLoad %ulong %200
+%296 = OpLoad %ulong %196
+%297 = OpBitwiseXor %ulong %295 %296
+OpStore %197 %297
+%298 = OpLoad %ulong %197
+%300 = OpIMul %ulong %298 %ulong_1099511628211
+OpStore %198 %300
+%301 = OpLoad %ulong %201
+%303 = OpIAdd %ulong %301 %ulong_1
+OpStore %199 %303
+%304 = OpLoad %ulong %198
+OpStore %200 %304
+%305 = OpLoad %ulong %199
+OpStore %201 %305
+OpBranch %72
+%62 = OpLabel
+%306 = OpLoad %ulong %191
+%307 = OpIMul %ulong %306 %ulong_8
+OpStore %184 %307
+%308 = OpLoad %ulong %100
+%309 = OpLoad %ulong %184
+%310 = OpShiftRightLogical %ulong %308 %309
+OpStore %185 %310
+%311 = OpLoad %ulong %185
+%312 = OpBitwiseAnd %ulong %311 %ulong_255
+OpStore %186 %312
+%313 = OpLoad %ulong %190
+%314 = OpLoad %ulong %186
+%315 = OpBitwiseXor %ulong %313 %314
+OpStore %187 %315
+%316 = OpLoad %ulong %187
+%317 = OpIMul %ulong %316 %ulong_1099511628211
+OpStore %188 %317
+%318 = OpLoad %ulong %191
+%319 = OpIAdd %ulong %318 %ulong_1
+OpStore %189 %319
+%320 = OpLoad %ulong %188
+OpStore %190 %320
+%321 = OpLoad %ulong %189
+OpStore %191 %321
+OpBranch %73
+%57 = OpLabel
+%322 = OpLoad %ulong %182
+%323 = OpIMul %ulong %322 %ulong_8
+OpStore %175 %323
+%324 = OpLoad %ulong %173
+%325 = OpLoad %ulong %175
+%326 = OpShiftRightLogical %ulong %324 %325
+OpStore %176 %326
+%327 = OpLoad %ulong %176
+%328 = OpBitwiseAnd %ulong %327 %ulong_255
+OpStore %177 %328
+%329 = OpLoad %ulong %181
+%330 = OpLoad %ulong %177
+%331 = OpBitwiseXor %ulong %329 %330
+OpStore %178 %331
+%332 = OpLoad %ulong %178
+%333 = OpIMul %ulong %332 %ulong_1099511628211
+OpStore %179 %333
+%334 = OpLoad %ulong %182
+%335 = OpIAdd %ulong %334 %ulong_1
+OpStore %180 %335
+%336 = OpLoad %ulong %179
+OpStore %181 %336
+%337 = OpLoad %ulong %180
+OpStore %182 %337
+OpBranch %74
+%50 = OpLabel
+%338 = OpLoad %ulong %171
+%339 = OpIMul %ulong %338 %ulong_8
+OpStore %164 %339
+%340 = OpLoad %ulong %162
+%341 = OpLoad %ulong %164
+%342 = OpShiftRightLogical %ulong %340 %341
+OpStore %165 %342
+%343 = OpLoad %ulong %165
+%344 = OpBitwiseAnd %ulong %343 %ulong_255
+OpStore %166 %344
+%345 = OpLoad %ulong %170
+%346 = OpLoad %ulong %166
+%347 = OpBitwiseXor %ulong %345 %346
+OpStore %167 %347
+%348 = OpLoad %ulong %167
+%349 = OpIMul %ulong %348 %ulong_1099511628211
+OpStore %168 %349
+%350 = OpLoad %ulong %171
+%351 = OpIAdd %ulong %350 %ulong_1
+OpStore %169 %351
+%352 = OpLoad %ulong %168
+OpStore %170 %352
+%353 = OpLoad %ulong %169
+OpStore %171 %353
+OpBranch %75
+%43 = OpLabel
+%354 = OpLoad %ulong %161
+%355 = OpIMul %ulong %354 %ulong_8
+OpStore %154 %355
+%356 = OpLoad %ulong %97
+%357 = OpLoad %ulong %154
+%358 = OpShiftRightLogical %ulong %356 %357
+OpStore %155 %358
+%359 = OpLoad %ulong %155
+%360 = OpBitwiseAnd %ulong %359 %ulong_255
+OpStore %156 %360
+%361 = OpLoad %ulong %160
+%362 = OpLoad %ulong %156
+%363 = OpBitwiseXor %ulong %361 %362
+OpStore %157 %363
+%364 = OpLoad %ulong %157
+%365 = OpIMul %ulong %364 %ulong_1099511628211
+OpStore %158 %365
+%366 = OpLoad %ulong %161
+%367 = OpIAdd %ulong %366 %ulong_1
+OpStore %159 %367
+%368 = OpLoad %ulong %158
+OpStore %160 %368
+%369 = OpLoad %ulong %159
+OpStore %161 %369
+OpBranch %76
+%38 = OpLabel
+%370 = OpLoad %ulong %152
+%371 = OpIMul %ulong %370 %ulong_8
+OpStore %145 %371
+%372 = OpLoad %ulong %143
+%373 = OpLoad %ulong %145
+%374 = OpShiftRightLogical %ulong %372 %373
+OpStore %146 %374
+%375 = OpLoad %ulong %146
+%376 = OpBitwiseAnd %ulong %375 %ulong_255
+OpStore %147 %376
+%377 = OpLoad %ulong %151
+%378 = OpLoad %ulong %147
+%379 = OpBitwiseXor %ulong %377 %378
+OpStore %148 %379
+%380 = OpLoad %ulong %148
+%381 = OpIMul %ulong %380 %ulong_1099511628211
+OpStore %149 %381
+%382 = OpLoad %ulong %152
+%383 = OpIAdd %ulong %382 %ulong_1
+OpStore %150 %383
+%384 = OpLoad %ulong %149
+OpStore %151 %384
+%385 = OpLoad %ulong %150
+OpStore %152 %385
+OpBranch %77
+%31 = OpLabel
+%386 = OpLoad %ulong %142
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %135 %387
+%388 = OpLoad %ulong %94
+%389 = OpLoad %ulong %135
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %136 %390
+%391 = OpLoad %ulong %136
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %137 %392
+%393 = OpLoad %ulong %141
+%394 = OpLoad %ulong %137
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %138 %395
+%396 = OpLoad %ulong %138
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %139 %397
+%398 = OpLoad %ulong %142
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %140 %399
+%400 = OpLoad %ulong %139
+OpStore %141 %400
+%401 = OpLoad %ulong %140
+OpStore %142 %401
+OpBranch %78
+%26 = OpLabel
+%402 = OpLoad %ulong %133
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %126 %403
+%404 = OpLoad %ulong %124
+%405 = OpLoad %ulong %126
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %127 %406
+%407 = OpLoad %ulong %127
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %128 %408
+%409 = OpLoad %ulong %132
+%410 = OpLoad %ulong %128
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %129 %411
+%412 = OpLoad %ulong %129
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %130 %413
+%414 = OpLoad %ulong %133
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %131 %415
+%416 = OpLoad %ulong %130
+OpStore %132 %416
+%417 = OpLoad %ulong %131
+OpStore %133 %417
+OpBranch %79
+%19 = OpLabel
+%418 = OpLoad %ulong %123
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %116 %419
+%420 = OpLoad %ulong %114
+%421 = OpLoad %ulong %116
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %117 %422
+%423 = OpLoad %ulong %117
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %118 %424
+%425 = OpLoad %ulong %122
+%426 = OpLoad %ulong %118
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %119 %427
+%428 = OpLoad %ulong %119
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %120 %429
+%430 = OpLoad %ulong %123
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %121 %431
+%432 = OpLoad %ulong %120
+OpStore %122 %432
+%433 = OpLoad %ulong %121
+OpStore %123 %433
+OpBranch %80
+%12 = OpLabel
+%434 = OpLoad %ulong %112
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %105 %435
+%436 = OpLoad %ulong %102
+%437 = OpLoad %ulong %105
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %106 %438
+%439 = OpLoad %ulong %106
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %107 %440
+%441 = OpLoad %ulong %111
+%442 = OpLoad %ulong %107
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %108 %443
+%444 = OpLoad %ulong %108
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %109 %445
+%446 = OpLoad %ulong %112
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %110 %447
+%448 = OpLoad %ulong %109
+OpStore %111 %448
+%449 = OpLoad %ulong %110
+OpStore %112 %449
+OpBranch %81
+%72 = OpLabel
+OpBranch %68
+%73 = OpLabel
+OpBranch %61
+%74 = OpLabel
+OpBranch %56
+%75 = OpLabel
+OpBranch %49
+%76 = OpLabel
+OpBranch %42
+%77 = OpLabel
+OpBranch %37
+%78 = OpLabel
+OpBranch %30
+%79 = OpLabel
+OpBranch %25
+%80 = OpLabel
+OpBranch %18
+%81 = OpLabel
+OpBranch %11
 OpFunctionEnd

--- a/test/golden/spirv/convert/ext_sign.dis
+++ b/test/golden/spirv/convert/ext_sign.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 301
+; Bound: 660
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,415 +11,983 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.convert.ext_sign.checksum" Export
 %ulong = OpTypeInt 64 0
-%7 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uchar_128 = OpConstant %uchar 128
 %ushort_32768 = OpConstant %ushort 32768
 %uint_2147483648 = OpConstant %uint 2147483648
-%159 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%162 = OpTypeFunction %ulong %ulong %ushort
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%214 = OpTypeFunction %ulong %ulong %uint
-%259 = OpTypeFunction %ulong %ulong %ulong
-%1 = OpFunction %ulong None %7
-%8 = OpFunctionParameter %ulong
-%9 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_uchar Function
-%18 = OpVariable %_ptr_Function_uchar Function
-%19 = OpVariable %_ptr_Function_uchar Function
-%21 = OpVariable %_ptr_Function_ushort Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %8
-%58 = OpFunctionCall %ulong %2
-OpStore %15 %58
-%59 = OpLoad %ulong %14
-%60 = OpUConvert %uchar %59
-OpStore %17 %60
-%61 = OpLoad %uchar %17
-%63 = OpBitwiseOr %uchar %61 %uchar_128
-OpStore %18 %63
-%64 = OpLoad %uchar %18
-%65 = OpNot %uchar %64
-OpStore %19 %65
-%66 = OpLoad %ulong %14
-%67 = OpUConvert %ushort %66
-OpStore %21 %67
-%68 = OpLoad %ushort %21
-%70 = OpBitwiseOr %ushort %68 %ushort_32768
-OpStore %22 %70
-%71 = OpLoad %ushort %22
-%72 = OpNot %ushort %71
-OpStore %23 %72
-%73 = OpLoad %ulong %14
-%74 = OpUConvert %uint %73
-OpStore %25 %74
-%75 = OpLoad %uint %25
-%77 = OpBitwiseOr %uint %75 %uint_2147483648
-OpStore %26 %77
-%78 = OpLoad %uint %26
-%79 = OpNot %uint %78
-OpStore %27 %79
-%80 = OpLoad %uchar %18
-%81 = OpSConvert %ushort %80
-OpStore %28 %81
-%82 = OpLoad %ulong %15
-%83 = OpLoad %ushort %28
-%84 = OpFunctionCall %ulong %3 %82 %83
-OpStore %29 %84
-%85 = OpLoad %uchar %19
-%86 = OpSConvert %ushort %85
-OpStore %30 %86
-%87 = OpLoad %ulong %29
-%88 = OpLoad %ushort %30
-%89 = OpFunctionCall %ulong %3 %87 %88
-OpStore %31 %89
-%90 = OpLoad %uchar %18
-%91 = OpSConvert %uint %90
-OpStore %32 %91
-%92 = OpLoad %ulong %31
-%93 = OpLoad %uint %32
-%94 = OpFunctionCall %ulong %4 %92 %93
-OpStore %33 %94
-%95 = OpLoad %uchar %19
-%96 = OpSConvert %uint %95
-OpStore %34 %96
-%97 = OpLoad %ulong %33
-%98 = OpLoad %uint %34
-%99 = OpFunctionCall %ulong %4 %97 %98
-OpStore %35 %99
-%100 = OpLoad %uchar %18
-%101 = OpSConvert %ulong %100
-OpStore %36 %101
-%102 = OpLoad %ulong %35
-%103 = OpLoad %ulong %36
-%104 = OpFunctionCall %ulong %5 %102 %103
-OpStore %37 %104
-%105 = OpLoad %uchar %19
-%106 = OpSConvert %ulong %105
-OpStore %38 %106
-%107 = OpLoad %ulong %37
-%108 = OpLoad %ulong %38
-%109 = OpFunctionCall %ulong %5 %107 %108
-OpStore %39 %109
-%110 = OpLoad %ushort %22
-%111 = OpSConvert %uint %110
-OpStore %40 %111
-%112 = OpLoad %ulong %39
-%113 = OpLoad %uint %40
-%114 = OpFunctionCall %ulong %4 %112 %113
-OpStore %41 %114
-%115 = OpLoad %ushort %23
-%116 = OpSConvert %uint %115
-OpStore %42 %116
-%117 = OpLoad %ulong %41
-%118 = OpLoad %uint %42
-%119 = OpFunctionCall %ulong %4 %117 %118
-OpStore %43 %119
-%120 = OpLoad %ushort %22
-%121 = OpSConvert %ulong %120
-OpStore %44 %121
-%122 = OpLoad %ulong %43
-%123 = OpLoad %ulong %44
-%124 = OpFunctionCall %ulong %5 %122 %123
-OpStore %45 %124
-%125 = OpLoad %ushort %23
-%126 = OpSConvert %ulong %125
-OpStore %46 %126
-%127 = OpLoad %ulong %45
-%128 = OpLoad %ulong %46
-%129 = OpFunctionCall %ulong %5 %127 %128
-OpStore %47 %129
-%130 = OpLoad %uint %26
-%131 = OpSConvert %ulong %130
-OpStore %48 %131
-%132 = OpLoad %ulong %47
-%133 = OpLoad %ulong %48
-%134 = OpFunctionCall %ulong %5 %132 %133
-OpStore %49 %134
-%135 = OpLoad %uint %27
-%136 = OpSConvert %ulong %135
-OpStore %50 %136
-%137 = OpLoad %ulong %49
-%138 = OpLoad %ulong %50
-%139 = OpFunctionCall %ulong %5 %137 %138
-OpStore %51 %139
-%140 = OpLoad %ulong %36
-%141 = OpLoad %ulong %44
-%142 = OpIAdd %ulong %140 %141
-OpStore %52 %142
-%143 = OpLoad %ulong %52
-%144 = OpLoad %ulong %48
-%145 = OpIAdd %ulong %143 %144
-OpStore %53 %145
-%146 = OpLoad %ulong %51
-%147 = OpLoad %ulong %53
-%148 = OpFunctionCall %ulong %5 %146 %147
-OpStore %54 %148
-%149 = OpLoad %ulong %38
-%150 = OpLoad %ulong %46
-%151 = OpIAdd %ulong %149 %150
-OpStore %55 %151
-%152 = OpLoad %ulong %55
-%153 = OpLoad %ulong %50
-%154 = OpIAdd %ulong %152 %153
-OpStore %56 %154
-%155 = OpLoad %ulong %54
-%156 = OpLoad %ulong %56
-%157 = OpFunctionCall %ulong %5 %155 %156
-OpStore %57 %157
-%158 = OpLoad %ulong %57
-OpReturnValue %158
-OpFunctionEnd
-%2 = OpFunction %ulong None %159
-%160 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %162
-%163 = OpFunctionParameter %ulong
-%164 = OpFunctionParameter %ushort
-%165 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%125 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_uchar Function
+%128 = OpVariable %_ptr_Function_uchar Function
+%129 = OpVariable %_ptr_Function_uchar Function
+%131 = OpVariable %_ptr_Function_ushort Function
+%132 = OpVariable %_ptr_Function_ushort Function
+%133 = OpVariable %_ptr_Function_ushort Function
+%135 = OpVariable %_ptr_Function_uint Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_uint Function
+%138 = OpVariable %_ptr_Function_ushort Function
+%139 = OpVariable %_ptr_Function_ushort Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_bool Function
 %173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ushort Function
+%174 = OpVariable %_ptr_Function_ulong Function
 %175 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
 %179 = OpVariable %_ptr_Function_ulong Function
 %180 = OpVariable %_ptr_Function_ulong Function
 %181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_bool Function
 %183 = OpVariable %_ptr_Function_ulong Function
 %184 = OpVariable %_ptr_Function_ulong Function
 %185 = OpVariable %_ptr_Function_ulong Function
-OpStore %173 %163
-OpStore %174 %164
-%186 = OpLoad %ushort %174
-%187 = OpSConvert %ulong %186
-OpStore %175 %187
-OpBranch %166
-%166 = OpLabel
-%188 = OpLoad %ulong %173
-OpStore %184 %188
-OpStore %185 %ulong_0
-OpBranch %167
-%167 = OpLabel
-%190 = OpLoad %ulong %185
-%192 = OpULessThan %bool %190 %ulong_8
-OpStore %177 %192
-%193 = OpLoad %bool %177
-OpLoopMerge %169 %171 None
-OpBranchConditional %193 %168 %169
-%169 = OpLabel
-OpBranch %170
-%170 = OpLabel
-%194 = OpLoad %ulong %184
-OpReturnValue %194
-%168 = OpLabel
-%195 = OpLoad %ulong %185
-%196 = OpIMul %ulong %195 %ulong_8
-OpStore %178 %196
-%197 = OpLoad %ulong %175
-%198 = OpLoad %ulong %178
-%199 = OpShiftRightLogical %ulong %197 %198
-OpStore %179 %199
-%200 = OpLoad %ulong %179
-%202 = OpBitwiseAnd %ulong %200 %ulong_255
-OpStore %180 %202
-%203 = OpLoad %ulong %184
-%204 = OpLoad %ulong %180
-%205 = OpBitwiseXor %ulong %203 %204
-OpStore %181 %205
-%206 = OpLoad %ulong %181
-%208 = OpIMul %ulong %206 %ulong_1099511628211
-OpStore %182 %208
-%209 = OpLoad %ulong %185
-%211 = OpIAdd %ulong %209 %ulong_1
-OpStore %183 %211
-%212 = OpLoad %ulong %182
-OpStore %184 %212
-%213 = OpLoad %ulong %183
-OpStore %185 %213
-OpBranch %171
-%171 = OpLabel
-OpBranch %167
-OpFunctionEnd
-%4 = OpFunction %ulong None %214
-%215 = OpFunctionParameter %ulong
-%216 = OpFunctionParameter %uint
-%217 = OpLabel
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_bool Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_bool Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_bool Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_bool Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
 %224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_uint Function
+%225 = OpVariable %_ptr_Function_ulong Function
 %226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
 %228 = OpVariable %_ptr_Function_ulong Function
 %229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_bool Function
 %231 = OpVariable %_ptr_Function_ulong Function
 %232 = OpVariable %_ptr_Function_ulong Function
 %233 = OpVariable %_ptr_Function_ulong Function
 %234 = OpVariable %_ptr_Function_ulong Function
 %235 = OpVariable %_ptr_Function_ulong Function
-OpStore %224 %215
-OpStore %225 %216
-%236 = OpLoad %uint %225
-%237 = OpSConvert %ulong %236
-OpStore %226 %237
-OpBranch %218
-%218 = OpLabel
-%238 = OpLoad %ulong %224
-OpStore %234 %238
-OpStore %235 %ulong_0
-OpBranch %219
-%219 = OpLabel
-%239 = OpLoad %ulong %235
-%240 = OpULessThan %bool %239 %ulong_8
-OpStore %227 %240
-%241 = OpLoad %bool %227
-OpLoopMerge %221 %223 None
-OpBranchConditional %241 %220 %221
-%221 = OpLabel
-OpBranch %222
-%222 = OpLabel
-%242 = OpLoad %ulong %234
-OpReturnValue %242
-%220 = OpLabel
-%243 = OpLoad %ulong %235
-%244 = OpIMul %ulong %243 %ulong_8
-OpStore %228 %244
-%245 = OpLoad %ulong %226
-%246 = OpLoad %ulong %228
-%247 = OpShiftRightLogical %ulong %245 %246
-OpStore %229 %247
-%248 = OpLoad %ulong %229
-%249 = OpBitwiseAnd %ulong %248 %ulong_255
-OpStore %230 %249
-%250 = OpLoad %ulong %234
-%251 = OpLoad %ulong %230
-%252 = OpBitwiseXor %ulong %250 %251
-OpStore %231 %252
-%253 = OpLoad %ulong %231
-%254 = OpIMul %ulong %253 %ulong_1099511628211
-OpStore %232 %254
-%255 = OpLoad %ulong %235
-%256 = OpIAdd %ulong %255 %ulong_1
-OpStore %233 %256
-%257 = OpLoad %ulong %232
-OpStore %234 %257
-%258 = OpLoad %ulong %233
-OpStore %235 %258
-OpBranch %223
-%223 = OpLabel
-OpBranch %219
-OpFunctionEnd
-%5 = OpFunction %ulong None %259
-%260 = OpFunctionParameter %ulong
-%261 = OpFunctionParameter %ulong
-%262 = OpLabel
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_bool Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_bool Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_bool Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
 %269 = OpVariable %_ptr_Function_ulong Function
 %270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_bool Function
+%271 = OpVariable %_ptr_Function_ulong Function
 %272 = OpVariable %_ptr_Function_ulong Function
 %273 = OpVariable %_ptr_Function_ulong Function
 %274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
 %276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
-OpStore %269 %260
-OpStore %270 %261
-OpBranch %263
-%263 = OpLabel
-%280 = OpLoad %ulong %269
-OpStore %278 %280
-OpStore %279 %ulong_0
-OpBranch %264
-%264 = OpLabel
-%281 = OpLoad %ulong %279
-%282 = OpULessThan %bool %281 %ulong_8
-OpStore %271 %282
-%283 = OpLoad %bool %271
-OpLoopMerge %266 %268 None
-OpBranchConditional %283 %265 %266
-%266 = OpLabel
-OpBranch %267
-%267 = OpLabel
-%284 = OpLoad %ulong %278
-OpReturnValue %284
-%265 = OpLabel
-%285 = OpLoad %ulong %279
-%286 = OpIMul %ulong %285 %ulong_8
-OpStore %272 %286
-%287 = OpLoad %ulong %270
-%288 = OpLoad %ulong %272
-%289 = OpShiftRightLogical %ulong %287 %288
-OpStore %273 %289
-%290 = OpLoad %ulong %273
-%291 = OpBitwiseAnd %ulong %290 %ulong_255
-OpStore %274 %291
-%292 = OpLoad %ulong %278
-%293 = OpLoad %ulong %274
-%294 = OpBitwiseXor %ulong %292 %293
-OpStore %275 %294
-%295 = OpLoad %ulong %275
-%296 = OpIMul %ulong %295 %ulong_1099511628211
-OpStore %276 %296
-%297 = OpLoad %ulong %279
-%298 = OpIAdd %ulong %297 %ulong_1
-OpStore %277 %298
-%299 = OpLoad %ulong %276
-OpStore %278 %299
-%300 = OpLoad %ulong %277
-OpStore %279 %300
-OpBranch %268
-%268 = OpLabel
-OpBranch %264
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_bool Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+OpStore %125 %4
+OpBranch %6
+%6 = OpLabel
+OpBranch %7
+%7 = OpLabel
+%293 = OpLoad %ulong %125
+%294 = OpUConvert %uchar %293
+OpStore %127 %294
+%295 = OpLoad %uchar %127
+%297 = OpBitwiseOr %uchar %295 %uchar_128
+OpStore %128 %297
+%298 = OpLoad %uchar %128
+%299 = OpNot %uchar %298
+OpStore %129 %299
+%300 = OpLoad %ulong %125
+%301 = OpUConvert %ushort %300
+OpStore %131 %301
+%302 = OpLoad %ushort %131
+%304 = OpBitwiseOr %ushort %302 %ushort_32768
+OpStore %132 %304
+%305 = OpLoad %ushort %132
+%306 = OpNot %ushort %305
+OpStore %133 %306
+%307 = OpLoad %ulong %125
+%308 = OpUConvert %uint %307
+OpStore %135 %308
+%309 = OpLoad %uint %135
+%311 = OpBitwiseOr %uint %309 %uint_2147483648
+OpStore %136 %311
+%312 = OpLoad %uint %136
+%313 = OpNot %uint %312
+OpStore %137 %313
+%314 = OpLoad %uchar %128
+%315 = OpSConvert %ushort %314
+OpStore %138 %315
+OpBranch %8
+%8 = OpLabel
+%316 = OpLoad %ushort %138
+%317 = OpSConvert %ulong %316
+OpStore %160 %317
+OpBranch %10
+%10 = OpLabel
+OpStore %169 %ulong_14695981039346656037
+OpStore %170 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%320 = OpLoad %ulong %170
+%322 = OpULessThan %bool %320 %ulong_8
+OpStore %162 %322
+%323 = OpLoad %bool %162
+OpLoopMerge %13 %119 None
+OpBranchConditional %323 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%9 = OpLabel
+%324 = OpLoad %uchar %129
+%325 = OpSConvert %ushort %324
+OpStore %139 %325
+OpBranch %15
+%15 = OpLabel
+%326 = OpLoad %ushort %139
+%327 = OpSConvert %ulong %326
+OpStore %171 %327
+OpBranch %17
+%17 = OpLabel
+%328 = OpLoad %ulong %169
+OpStore %179 %328
+OpStore %180 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%329 = OpLoad %ulong %180
+%330 = OpULessThan %bool %329 %ulong_8
+OpStore %172 %330
+%331 = OpLoad %bool %172
+OpLoopMerge %20 %118 None
+OpBranchConditional %331 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%332 = OpLoad %uchar %128
+%333 = OpSConvert %uint %332
+OpStore %140 %333
+OpBranch %22
+%22 = OpLabel
+%334 = OpLoad %uint %140
+%335 = OpSConvert %ulong %334
+OpStore %181 %335
+OpBranch %24
+%24 = OpLabel
+%336 = OpLoad %ulong %179
+OpStore %189 %336
+OpStore %190 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%337 = OpLoad %ulong %190
+%338 = OpULessThan %bool %337 %ulong_8
+OpStore %182 %338
+%339 = OpLoad %bool %182
+OpLoopMerge %27 %117 None
+OpBranchConditional %339 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%340 = OpLoad %uchar %129
+%341 = OpSConvert %uint %340
+OpStore %141 %341
+OpBranch %29
+%29 = OpLabel
+%342 = OpLoad %uint %141
+%343 = OpSConvert %ulong %342
+OpStore %191 %343
+OpBranch %31
+%31 = OpLabel
+%344 = OpLoad %ulong %189
+OpStore %199 %344
+OpStore %200 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%345 = OpLoad %ulong %200
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %192 %346
+%347 = OpLoad %bool %192
+OpLoopMerge %34 %116 None
+OpBranchConditional %347 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%348 = OpLoad %uchar %128
+%349 = OpSConvert %ulong %348
+OpStore %142 %349
+OpBranch %36
+%36 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%350 = OpLoad %ulong %199
+OpStore %208 %350
+OpStore %209 %ulong_0
+OpBranch %39
+%39 = OpLabel
+%351 = OpLoad %ulong %209
+%352 = OpULessThan %bool %351 %ulong_8
+OpStore %201 %352
+%353 = OpLoad %bool %201
+OpLoopMerge %41 %115 None
+OpBranchConditional %353 %40 %41
+%41 = OpLabel
+OpBranch %42
+%42 = OpLabel
+OpBranch %37
+%37 = OpLabel
+%354 = OpLoad %uchar %129
+%355 = OpSConvert %ulong %354
+OpStore %143 %355
+OpBranch %43
+%43 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%356 = OpLoad %ulong %208
+OpStore %217 %356
+OpStore %218 %ulong_0
+OpBranch %46
+%46 = OpLabel
+%357 = OpLoad %ulong %218
+%358 = OpULessThan %bool %357 %ulong_8
+OpStore %210 %358
+%359 = OpLoad %bool %210
+OpLoopMerge %48 %114 None
+OpBranchConditional %359 %47 %48
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%360 = OpLoad %ushort %132
+%361 = OpSConvert %uint %360
+OpStore %144 %361
+OpBranch %50
+%50 = OpLabel
+%362 = OpLoad %uint %144
+%363 = OpSConvert %ulong %362
+OpStore %219 %363
+OpBranch %52
+%52 = OpLabel
+%364 = OpLoad %ulong %217
+OpStore %227 %364
+OpStore %228 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%365 = OpLoad %ulong %228
+%366 = OpULessThan %bool %365 %ulong_8
+OpStore %220 %366
+%367 = OpLoad %bool %220
+OpLoopMerge %55 %113 None
+OpBranchConditional %367 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpBranch %51
+%51 = OpLabel
+%368 = OpLoad %ushort %133
+%369 = OpSConvert %uint %368
+OpStore %145 %369
+OpBranch %57
+%57 = OpLabel
+%370 = OpLoad %uint %145
+%371 = OpSConvert %ulong %370
+OpStore %229 %371
+OpBranch %59
+%59 = OpLabel
+%372 = OpLoad %ulong %227
+OpStore %237 %372
+OpStore %238 %ulong_0
+OpBranch %60
+%60 = OpLabel
+%373 = OpLoad %ulong %238
+%374 = OpULessThan %bool %373 %ulong_8
+OpStore %230 %374
+%375 = OpLoad %bool %230
+OpLoopMerge %62 %112 None
+OpBranchConditional %375 %61 %62
+%62 = OpLabel
+OpBranch %63
+%63 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%376 = OpLoad %ushort %132
+%377 = OpSConvert %ulong %376
+OpStore %146 %377
+OpBranch %64
+%64 = OpLabel
+OpBranch %66
+%66 = OpLabel
+%378 = OpLoad %ulong %237
+OpStore %246 %378
+OpStore %247 %ulong_0
+OpBranch %67
+%67 = OpLabel
+%379 = OpLoad %ulong %247
+%380 = OpULessThan %bool %379 %ulong_8
+OpStore %239 %380
+%381 = OpLoad %bool %239
+OpLoopMerge %69 %111 None
+OpBranchConditional %381 %68 %69
+%69 = OpLabel
+OpBranch %70
+%70 = OpLabel
+OpBranch %65
+%65 = OpLabel
+%382 = OpLoad %ushort %133
+%383 = OpSConvert %ulong %382
+OpStore %147 %383
+OpBranch %71
+%71 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%384 = OpLoad %ulong %246
+OpStore %255 %384
+OpStore %256 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%385 = OpLoad %ulong %256
+%386 = OpULessThan %bool %385 %ulong_8
+OpStore %248 %386
+%387 = OpLoad %bool %248
+OpLoopMerge %76 %110 None
+OpBranchConditional %387 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%388 = OpLoad %uint %136
+%389 = OpSConvert %ulong %388
+OpStore %148 %389
+OpBranch %78
+%78 = OpLabel
+OpBranch %80
+%80 = OpLabel
+%390 = OpLoad %ulong %255
+OpStore %264 %390
+OpStore %265 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%391 = OpLoad %ulong %265
+%392 = OpULessThan %bool %391 %ulong_8
+OpStore %257 %392
+%393 = OpLoad %bool %257
+OpLoopMerge %83 %109 None
+OpBranchConditional %393 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%394 = OpLoad %uint %137
+%395 = OpSConvert %ulong %394
+OpStore %149 %395
+OpBranch %85
+%85 = OpLabel
+OpBranch %87
+%87 = OpLabel
+%396 = OpLoad %ulong %264
+OpStore %273 %396
+OpStore %274 %ulong_0
+OpBranch %88
+%88 = OpLabel
+%397 = OpLoad %ulong %274
+%398 = OpULessThan %bool %397 %ulong_8
+OpStore %266 %398
+%399 = OpLoad %bool %266
+OpLoopMerge %90 %108 None
+OpBranchConditional %399 %89 %90
+%90 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%400 = OpLoad %uchar %128
+%401 = OpSConvert %ulong %400
+OpStore %150 %401
+%402 = OpLoad %ushort %132
+%403 = OpSConvert %ulong %402
+OpStore %151 %403
+%404 = OpLoad %ulong %150
+%405 = OpLoad %ulong %151
+%406 = OpIAdd %ulong %404 %405
+OpStore %152 %406
+%407 = OpLoad %uint %136
+%408 = OpSConvert %ulong %407
+OpStore %153 %408
+%409 = OpLoad %ulong %152
+%410 = OpLoad %ulong %153
+%411 = OpIAdd %ulong %409 %410
+OpStore %154 %411
+OpBranch %92
+%92 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%412 = OpLoad %ulong %273
+OpStore %282 %412
+OpStore %283 %ulong_0
+OpBranch %95
+%95 = OpLabel
+%413 = OpLoad %ulong %283
+%414 = OpULessThan %bool %413 %ulong_8
+OpStore %275 %414
+%415 = OpLoad %bool %275
+OpLoopMerge %97 %107 None
+OpBranchConditional %415 %96 %97
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%416 = OpLoad %uchar %129
+%417 = OpSConvert %ulong %416
+OpStore %155 %417
+%418 = OpLoad %ushort %133
+%419 = OpSConvert %ulong %418
+OpStore %156 %419
+%420 = OpLoad %ulong %155
+%421 = OpLoad %ulong %156
+%422 = OpIAdd %ulong %420 %421
+OpStore %157 %422
+%423 = OpLoad %uint %137
+%424 = OpSConvert %ulong %423
+OpStore %158 %424
+%425 = OpLoad %ulong %157
+%426 = OpLoad %ulong %158
+%427 = OpIAdd %ulong %425 %426
+OpStore %159 %427
+OpBranch %99
+%99 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%428 = OpLoad %ulong %282
+OpStore %291 %428
+OpStore %292 %ulong_0
+OpBranch %102
+%102 = OpLabel
+%429 = OpLoad %ulong %292
+%430 = OpULessThan %bool %429 %ulong_8
+OpStore %284 %430
+%431 = OpLoad %bool %284
+OpLoopMerge %104 %106 None
+OpBranchConditional %431 %103 %104
+%104 = OpLabel
+OpBranch %105
+%105 = OpLabel
+OpBranch %100
+%100 = OpLabel
+%432 = OpLoad %ulong %291
+OpReturnValue %432
+%103 = OpLabel
+%433 = OpLoad %ulong %292
+%434 = OpIMul %ulong %433 %ulong_8
+OpStore %285 %434
+%435 = OpLoad %ulong %159
+%436 = OpLoad %ulong %285
+%437 = OpShiftRightLogical %ulong %435 %436
+OpStore %286 %437
+%438 = OpLoad %ulong %286
+%440 = OpBitwiseAnd %ulong %438 %ulong_255
+OpStore %287 %440
+%441 = OpLoad %ulong %291
+%442 = OpLoad %ulong %287
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %288 %443
+%444 = OpLoad %ulong %288
+%446 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %289 %446
+%447 = OpLoad %ulong %292
+%449 = OpIAdd %ulong %447 %ulong_1
+OpStore %290 %449
+%450 = OpLoad %ulong %289
+OpStore %291 %450
+%451 = OpLoad %ulong %290
+OpStore %292 %451
+OpBranch %106
+%96 = OpLabel
+%452 = OpLoad %ulong %283
+%453 = OpIMul %ulong %452 %ulong_8
+OpStore %276 %453
+%454 = OpLoad %ulong %154
+%455 = OpLoad %ulong %276
+%456 = OpShiftRightLogical %ulong %454 %455
+OpStore %277 %456
+%457 = OpLoad %ulong %277
+%458 = OpBitwiseAnd %ulong %457 %ulong_255
+OpStore %278 %458
+%459 = OpLoad %ulong %282
+%460 = OpLoad %ulong %278
+%461 = OpBitwiseXor %ulong %459 %460
+OpStore %279 %461
+%462 = OpLoad %ulong %279
+%463 = OpIMul %ulong %462 %ulong_1099511628211
+OpStore %280 %463
+%464 = OpLoad %ulong %283
+%465 = OpIAdd %ulong %464 %ulong_1
+OpStore %281 %465
+%466 = OpLoad %ulong %280
+OpStore %282 %466
+%467 = OpLoad %ulong %281
+OpStore %283 %467
+OpBranch %107
+%89 = OpLabel
+%468 = OpLoad %ulong %274
+%469 = OpIMul %ulong %468 %ulong_8
+OpStore %267 %469
+%470 = OpLoad %ulong %149
+%471 = OpLoad %ulong %267
+%472 = OpShiftRightLogical %ulong %470 %471
+OpStore %268 %472
+%473 = OpLoad %ulong %268
+%474 = OpBitwiseAnd %ulong %473 %ulong_255
+OpStore %269 %474
+%475 = OpLoad %ulong %273
+%476 = OpLoad %ulong %269
+%477 = OpBitwiseXor %ulong %475 %476
+OpStore %270 %477
+%478 = OpLoad %ulong %270
+%479 = OpIMul %ulong %478 %ulong_1099511628211
+OpStore %271 %479
+%480 = OpLoad %ulong %274
+%481 = OpIAdd %ulong %480 %ulong_1
+OpStore %272 %481
+%482 = OpLoad %ulong %271
+OpStore %273 %482
+%483 = OpLoad %ulong %272
+OpStore %274 %483
+OpBranch %108
+%82 = OpLabel
+%484 = OpLoad %ulong %265
+%485 = OpIMul %ulong %484 %ulong_8
+OpStore %258 %485
+%486 = OpLoad %ulong %148
+%487 = OpLoad %ulong %258
+%488 = OpShiftRightLogical %ulong %486 %487
+OpStore %259 %488
+%489 = OpLoad %ulong %259
+%490 = OpBitwiseAnd %ulong %489 %ulong_255
+OpStore %260 %490
+%491 = OpLoad %ulong %264
+%492 = OpLoad %ulong %260
+%493 = OpBitwiseXor %ulong %491 %492
+OpStore %261 %493
+%494 = OpLoad %ulong %261
+%495 = OpIMul %ulong %494 %ulong_1099511628211
+OpStore %262 %495
+%496 = OpLoad %ulong %265
+%497 = OpIAdd %ulong %496 %ulong_1
+OpStore %263 %497
+%498 = OpLoad %ulong %262
+OpStore %264 %498
+%499 = OpLoad %ulong %263
+OpStore %265 %499
+OpBranch %109
+%75 = OpLabel
+%500 = OpLoad %ulong %256
+%501 = OpIMul %ulong %500 %ulong_8
+OpStore %249 %501
+%502 = OpLoad %ulong %147
+%503 = OpLoad %ulong %249
+%504 = OpShiftRightLogical %ulong %502 %503
+OpStore %250 %504
+%505 = OpLoad %ulong %250
+%506 = OpBitwiseAnd %ulong %505 %ulong_255
+OpStore %251 %506
+%507 = OpLoad %ulong %255
+%508 = OpLoad %ulong %251
+%509 = OpBitwiseXor %ulong %507 %508
+OpStore %252 %509
+%510 = OpLoad %ulong %252
+%511 = OpIMul %ulong %510 %ulong_1099511628211
+OpStore %253 %511
+%512 = OpLoad %ulong %256
+%513 = OpIAdd %ulong %512 %ulong_1
+OpStore %254 %513
+%514 = OpLoad %ulong %253
+OpStore %255 %514
+%515 = OpLoad %ulong %254
+OpStore %256 %515
+OpBranch %110
+%68 = OpLabel
+%516 = OpLoad %ulong %247
+%517 = OpIMul %ulong %516 %ulong_8
+OpStore %240 %517
+%518 = OpLoad %ulong %146
+%519 = OpLoad %ulong %240
+%520 = OpShiftRightLogical %ulong %518 %519
+OpStore %241 %520
+%521 = OpLoad %ulong %241
+%522 = OpBitwiseAnd %ulong %521 %ulong_255
+OpStore %242 %522
+%523 = OpLoad %ulong %246
+%524 = OpLoad %ulong %242
+%525 = OpBitwiseXor %ulong %523 %524
+OpStore %243 %525
+%526 = OpLoad %ulong %243
+%527 = OpIMul %ulong %526 %ulong_1099511628211
+OpStore %244 %527
+%528 = OpLoad %ulong %247
+%529 = OpIAdd %ulong %528 %ulong_1
+OpStore %245 %529
+%530 = OpLoad %ulong %244
+OpStore %246 %530
+%531 = OpLoad %ulong %245
+OpStore %247 %531
+OpBranch %111
+%61 = OpLabel
+%532 = OpLoad %ulong %238
+%533 = OpIMul %ulong %532 %ulong_8
+OpStore %231 %533
+%534 = OpLoad %ulong %229
+%535 = OpLoad %ulong %231
+%536 = OpShiftRightLogical %ulong %534 %535
+OpStore %232 %536
+%537 = OpLoad %ulong %232
+%538 = OpBitwiseAnd %ulong %537 %ulong_255
+OpStore %233 %538
+%539 = OpLoad %ulong %237
+%540 = OpLoad %ulong %233
+%541 = OpBitwiseXor %ulong %539 %540
+OpStore %234 %541
+%542 = OpLoad %ulong %234
+%543 = OpIMul %ulong %542 %ulong_1099511628211
+OpStore %235 %543
+%544 = OpLoad %ulong %238
+%545 = OpIAdd %ulong %544 %ulong_1
+OpStore %236 %545
+%546 = OpLoad %ulong %235
+OpStore %237 %546
+%547 = OpLoad %ulong %236
+OpStore %238 %547
+OpBranch %112
+%54 = OpLabel
+%548 = OpLoad %ulong %228
+%549 = OpIMul %ulong %548 %ulong_8
+OpStore %221 %549
+%550 = OpLoad %ulong %219
+%551 = OpLoad %ulong %221
+%552 = OpShiftRightLogical %ulong %550 %551
+OpStore %222 %552
+%553 = OpLoad %ulong %222
+%554 = OpBitwiseAnd %ulong %553 %ulong_255
+OpStore %223 %554
+%555 = OpLoad %ulong %227
+%556 = OpLoad %ulong %223
+%557 = OpBitwiseXor %ulong %555 %556
+OpStore %224 %557
+%558 = OpLoad %ulong %224
+%559 = OpIMul %ulong %558 %ulong_1099511628211
+OpStore %225 %559
+%560 = OpLoad %ulong %228
+%561 = OpIAdd %ulong %560 %ulong_1
+OpStore %226 %561
+%562 = OpLoad %ulong %225
+OpStore %227 %562
+%563 = OpLoad %ulong %226
+OpStore %228 %563
+OpBranch %113
+%47 = OpLabel
+%564 = OpLoad %ulong %218
+%565 = OpIMul %ulong %564 %ulong_8
+OpStore %211 %565
+%566 = OpLoad %ulong %143
+%567 = OpLoad %ulong %211
+%568 = OpShiftRightLogical %ulong %566 %567
+OpStore %212 %568
+%569 = OpLoad %ulong %212
+%570 = OpBitwiseAnd %ulong %569 %ulong_255
+OpStore %213 %570
+%571 = OpLoad %ulong %217
+%572 = OpLoad %ulong %213
+%573 = OpBitwiseXor %ulong %571 %572
+OpStore %214 %573
+%574 = OpLoad %ulong %214
+%575 = OpIMul %ulong %574 %ulong_1099511628211
+OpStore %215 %575
+%576 = OpLoad %ulong %218
+%577 = OpIAdd %ulong %576 %ulong_1
+OpStore %216 %577
+%578 = OpLoad %ulong %215
+OpStore %217 %578
+%579 = OpLoad %ulong %216
+OpStore %218 %579
+OpBranch %114
+%40 = OpLabel
+%580 = OpLoad %ulong %209
+%581 = OpIMul %ulong %580 %ulong_8
+OpStore %202 %581
+%582 = OpLoad %ulong %142
+%583 = OpLoad %ulong %202
+%584 = OpShiftRightLogical %ulong %582 %583
+OpStore %203 %584
+%585 = OpLoad %ulong %203
+%586 = OpBitwiseAnd %ulong %585 %ulong_255
+OpStore %204 %586
+%587 = OpLoad %ulong %208
+%588 = OpLoad %ulong %204
+%589 = OpBitwiseXor %ulong %587 %588
+OpStore %205 %589
+%590 = OpLoad %ulong %205
+%591 = OpIMul %ulong %590 %ulong_1099511628211
+OpStore %206 %591
+%592 = OpLoad %ulong %209
+%593 = OpIAdd %ulong %592 %ulong_1
+OpStore %207 %593
+%594 = OpLoad %ulong %206
+OpStore %208 %594
+%595 = OpLoad %ulong %207
+OpStore %209 %595
+OpBranch %115
+%33 = OpLabel
+%596 = OpLoad %ulong %200
+%597 = OpIMul %ulong %596 %ulong_8
+OpStore %193 %597
+%598 = OpLoad %ulong %191
+%599 = OpLoad %ulong %193
+%600 = OpShiftRightLogical %ulong %598 %599
+OpStore %194 %600
+%601 = OpLoad %ulong %194
+%602 = OpBitwiseAnd %ulong %601 %ulong_255
+OpStore %195 %602
+%603 = OpLoad %ulong %199
+%604 = OpLoad %ulong %195
+%605 = OpBitwiseXor %ulong %603 %604
+OpStore %196 %605
+%606 = OpLoad %ulong %196
+%607 = OpIMul %ulong %606 %ulong_1099511628211
+OpStore %197 %607
+%608 = OpLoad %ulong %200
+%609 = OpIAdd %ulong %608 %ulong_1
+OpStore %198 %609
+%610 = OpLoad %ulong %197
+OpStore %199 %610
+%611 = OpLoad %ulong %198
+OpStore %200 %611
+OpBranch %116
+%26 = OpLabel
+%612 = OpLoad %ulong %190
+%613 = OpIMul %ulong %612 %ulong_8
+OpStore %183 %613
+%614 = OpLoad %ulong %181
+%615 = OpLoad %ulong %183
+%616 = OpShiftRightLogical %ulong %614 %615
+OpStore %184 %616
+%617 = OpLoad %ulong %184
+%618 = OpBitwiseAnd %ulong %617 %ulong_255
+OpStore %185 %618
+%619 = OpLoad %ulong %189
+%620 = OpLoad %ulong %185
+%621 = OpBitwiseXor %ulong %619 %620
+OpStore %186 %621
+%622 = OpLoad %ulong %186
+%623 = OpIMul %ulong %622 %ulong_1099511628211
+OpStore %187 %623
+%624 = OpLoad %ulong %190
+%625 = OpIAdd %ulong %624 %ulong_1
+OpStore %188 %625
+%626 = OpLoad %ulong %187
+OpStore %189 %626
+%627 = OpLoad %ulong %188
+OpStore %190 %627
+OpBranch %117
+%19 = OpLabel
+%628 = OpLoad %ulong %180
+%629 = OpIMul %ulong %628 %ulong_8
+OpStore %173 %629
+%630 = OpLoad %ulong %171
+%631 = OpLoad %ulong %173
+%632 = OpShiftRightLogical %ulong %630 %631
+OpStore %174 %632
+%633 = OpLoad %ulong %174
+%634 = OpBitwiseAnd %ulong %633 %ulong_255
+OpStore %175 %634
+%635 = OpLoad %ulong %179
+%636 = OpLoad %ulong %175
+%637 = OpBitwiseXor %ulong %635 %636
+OpStore %176 %637
+%638 = OpLoad %ulong %176
+%639 = OpIMul %ulong %638 %ulong_1099511628211
+OpStore %177 %639
+%640 = OpLoad %ulong %180
+%641 = OpIAdd %ulong %640 %ulong_1
+OpStore %178 %641
+%642 = OpLoad %ulong %177
+OpStore %179 %642
+%643 = OpLoad %ulong %178
+OpStore %180 %643
+OpBranch %118
+%12 = OpLabel
+%644 = OpLoad %ulong %170
+%645 = OpIMul %ulong %644 %ulong_8
+OpStore %163 %645
+%646 = OpLoad %ulong %160
+%647 = OpLoad %ulong %163
+%648 = OpShiftRightLogical %ulong %646 %647
+OpStore %164 %648
+%649 = OpLoad %ulong %164
+%650 = OpBitwiseAnd %ulong %649 %ulong_255
+OpStore %165 %650
+%651 = OpLoad %ulong %169
+%652 = OpLoad %ulong %165
+%653 = OpBitwiseXor %ulong %651 %652
+OpStore %166 %653
+%654 = OpLoad %ulong %166
+%655 = OpIMul %ulong %654 %ulong_1099511628211
+OpStore %167 %655
+%656 = OpLoad %ulong %170
+%657 = OpIAdd %ulong %656 %ulong_1
+OpStore %168 %657
+%658 = OpLoad %ulong %167
+OpStore %169 %658
+%659 = OpLoad %ulong %168
+OpStore %170 %659
+OpBranch %119
+%106 = OpLabel
+OpBranch %102
+%107 = OpLabel
+OpBranch %95
+%108 = OpLabel
+OpBranch %88
+%109 = OpLabel
+OpBranch %81
+%110 = OpLabel
+OpBranch %74
+%111 = OpLabel
+OpBranch %67
+%112 = OpLabel
+OpBranch %60
+%113 = OpLabel
+OpBranch %53
+%114 = OpLabel
+OpBranch %46
+%115 = OpLabel
+OpBranch %39
+%116 = OpLabel
+OpBranch %32
+%117 = OpLabel
+OpBranch %25
+%118 = OpLabel
+OpBranch %18
+%119 = OpLabel
+OpBranch %11
 OpFunctionEnd

--- a/test/golden/spirv/convert/ext_zero.dis
+++ b/test/golden/spirv/convert/ext_zero.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 302
+; Bound: 647
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,228 +11,96 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.convert.ext_zero.checksum" Export
 %ulong = OpTypeInt 64 0
-%7 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uchar_128 = OpConstant %uchar 128
 %uchar_255 = OpConstant %uchar 255
 %ushort_32768 = OpConstant %ushort 32768
 %ushort_65535 = OpConstant %ushort 65535
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_4294967295 = OpConstant %uint 4294967295
-%162 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%165 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%212 = OpTypeFunction %ulong %ulong %ushort
-%257 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %7
-%8 = OpFunctionParameter %ulong
-%9 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_uchar Function
-%18 = OpVariable %_ptr_Function_uchar Function
-%19 = OpVariable %_ptr_Function_uchar Function
-%21 = OpVariable %_ptr_Function_ushort Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %8
-%58 = OpFunctionCall %ulong %2
-OpStore %15 %58
-%59 = OpLoad %ulong %14
-%60 = OpUConvert %uchar %59
-OpStore %17 %60
-%61 = OpLoad %uchar %17
-%63 = OpBitwiseOr %uchar %61 %uchar_128
-OpStore %18 %63
-%65 = OpLoad %uchar %18
-%66 = OpISub %uchar %uchar_255 %65
-OpStore %19 %66
-%67 = OpLoad %ulong %14
-%68 = OpUConvert %ushort %67
-OpStore %21 %68
-%69 = OpLoad %ushort %21
-%71 = OpBitwiseOr %ushort %69 %ushort_32768
-OpStore %22 %71
-%73 = OpLoad %ushort %22
-%74 = OpISub %ushort %ushort_65535 %73
-OpStore %23 %74
-%75 = OpLoad %ulong %14
-%76 = OpUConvert %uint %75
-OpStore %25 %76
-%77 = OpLoad %uint %25
-%79 = OpBitwiseOr %uint %77 %uint_2147483648
-OpStore %26 %79
-%81 = OpLoad %uint %26
-%82 = OpISub %uint %uint_4294967295 %81
-OpStore %27 %82
-%83 = OpLoad %uchar %18
-%84 = OpUConvert %ushort %83
-OpStore %28 %84
-%85 = OpLoad %ulong %15
-%86 = OpLoad %ushort %28
-%87 = OpFunctionCall %ulong %4 %85 %86
-OpStore %29 %87
-%88 = OpLoad %uchar %19
-%89 = OpUConvert %ushort %88
-OpStore %30 %89
-%90 = OpLoad %ulong %29
-%91 = OpLoad %ushort %30
-%92 = OpFunctionCall %ulong %4 %90 %91
-OpStore %31 %92
-%93 = OpLoad %uchar %18
-%94 = OpUConvert %uint %93
-OpStore %32 %94
-%95 = OpLoad %ulong %31
-%96 = OpLoad %uint %32
-%97 = OpFunctionCall %ulong %5 %95 %96
-OpStore %33 %97
-%98 = OpLoad %uchar %19
-%99 = OpUConvert %uint %98
-OpStore %34 %99
-%100 = OpLoad %ulong %33
-%101 = OpLoad %uint %34
-%102 = OpFunctionCall %ulong %5 %100 %101
-OpStore %35 %102
-%103 = OpLoad %uchar %18
-%104 = OpUConvert %ulong %103
-OpStore %36 %104
-%105 = OpLoad %ulong %35
-%106 = OpLoad %ulong %36
-%107 = OpFunctionCall %ulong %3 %105 %106
-OpStore %37 %107
-%108 = OpLoad %uchar %19
-%109 = OpUConvert %ulong %108
-OpStore %38 %109
-%110 = OpLoad %ulong %37
-%111 = OpLoad %ulong %38
-%112 = OpFunctionCall %ulong %3 %110 %111
-OpStore %39 %112
-%113 = OpLoad %ushort %22
-%114 = OpUConvert %uint %113
-OpStore %40 %114
-%115 = OpLoad %ulong %39
-%116 = OpLoad %uint %40
-%117 = OpFunctionCall %ulong %5 %115 %116
-OpStore %41 %117
-%118 = OpLoad %ushort %23
-%119 = OpUConvert %uint %118
-OpStore %42 %119
-%120 = OpLoad %ulong %41
-%121 = OpLoad %uint %42
-%122 = OpFunctionCall %ulong %5 %120 %121
-OpStore %43 %122
-%123 = OpLoad %ushort %22
-%124 = OpUConvert %ulong %123
-OpStore %44 %124
-%125 = OpLoad %ulong %43
-%126 = OpLoad %ulong %44
-%127 = OpFunctionCall %ulong %3 %125 %126
-OpStore %45 %127
-%128 = OpLoad %ushort %23
-%129 = OpUConvert %ulong %128
-OpStore %46 %129
-%130 = OpLoad %ulong %45
-%131 = OpLoad %ulong %46
-%132 = OpFunctionCall %ulong %3 %130 %131
-OpStore %47 %132
-%133 = OpLoad %uint %26
-%134 = OpUConvert %ulong %133
-OpStore %48 %134
-%135 = OpLoad %ulong %47
-%136 = OpLoad %ulong %48
-%137 = OpFunctionCall %ulong %3 %135 %136
-OpStore %49 %137
-%138 = OpLoad %uint %27
-%139 = OpUConvert %ulong %138
-OpStore %50 %139
-%140 = OpLoad %ulong %49
-%141 = OpLoad %ulong %50
-%142 = OpFunctionCall %ulong %3 %140 %141
-OpStore %51 %142
-%143 = OpLoad %ulong %36
-%144 = OpLoad %ulong %44
-%145 = OpIAdd %ulong %143 %144
-OpStore %52 %145
-%146 = OpLoad %ulong %52
-%147 = OpLoad %ulong %48
-%148 = OpIAdd %ulong %146 %147
-OpStore %53 %148
-%149 = OpLoad %ulong %51
-%150 = OpLoad %ulong %53
-%151 = OpFunctionCall %ulong %3 %149 %150
-OpStore %54 %151
-%152 = OpLoad %ulong %38
-%153 = OpLoad %ulong %46
-%154 = OpIAdd %ulong %152 %153
-OpStore %55 %154
-%155 = OpLoad %ulong %55
-%156 = OpLoad %ulong %50
-%157 = OpIAdd %ulong %155 %156
-OpStore %56 %157
-%158 = OpLoad %ulong %54
-%159 = OpLoad %ulong %56
-%160 = OpFunctionCall %ulong %3 %158 %159
-OpStore %57 %160
-%161 = OpLoad %ulong %57
-OpReturnValue %161
-OpFunctionEnd
-%2 = OpFunction %ulong None %162
-%163 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %165
-%166 = OpFunctionParameter %ulong
-%167 = OpFunctionParameter %ulong
-%168 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%109 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_uchar Function
+%112 = OpVariable %_ptr_Function_uchar Function
+%113 = OpVariable %_ptr_Function_uchar Function
+%115 = OpVariable %_ptr_Function_ushort Function
+%116 = OpVariable %_ptr_Function_ushort Function
+%117 = OpVariable %_ptr_Function_ushort Function
+%119 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_uint Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_ushort Function
+%123 = OpVariable %_ptr_Function_ushort Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_uint Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_bool Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_bool Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
 %175 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_bool Function
+%177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
 %179 = OpVariable %_ptr_Function_ulong Function
 %180 = OpVariable %_ptr_Function_ulong Function
@@ -240,185 +108,857 @@ OpFunctionEnd
 %182 = OpVariable %_ptr_Function_ulong Function
 %183 = OpVariable %_ptr_Function_ulong Function
 %184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
-OpStore %174 %166
-OpStore %175 %167
-%186 = OpLoad %ulong %174
-OpStore %184 %186
-OpStore %185 %ulong_0
-OpBranch %169
-%169 = OpLabel
-%188 = OpLoad %ulong %185
-%190 = OpULessThan %bool %188 %ulong_8
-OpStore %177 %190
-%191 = OpLoad %bool %177
-OpLoopMerge %171 %172 None
-OpBranchConditional %191 %170 %171
-%171 = OpLabel
-%192 = OpLoad %ulong %184
-OpReturnValue %192
-%170 = OpLabel
-%193 = OpLoad %ulong %185
-%194 = OpIMul %ulong %193 %ulong_8
-OpStore %178 %194
-%195 = OpLoad %ulong %175
-%196 = OpLoad %ulong %178
-%197 = OpShiftRightLogical %ulong %195 %196
-OpStore %179 %197
-%198 = OpLoad %ulong %179
-%200 = OpBitwiseAnd %ulong %198 %ulong_255
-OpStore %180 %200
-%201 = OpLoad %ulong %184
-%202 = OpLoad %ulong %180
-%203 = OpBitwiseXor %ulong %201 %202
-OpStore %181 %203
-%204 = OpLoad %ulong %181
-%206 = OpIMul %ulong %204 %ulong_1099511628211
-OpStore %182 %206
-%207 = OpLoad %ulong %185
-%209 = OpIAdd %ulong %207 %ulong_1
-OpStore %183 %209
-%210 = OpLoad %ulong %182
-OpStore %184 %210
-%211 = OpLoad %ulong %183
-OpStore %185 %211
-OpBranch %172
-%172 = OpLabel
-OpBranch %169
-OpFunctionEnd
-%4 = OpFunction %ulong None %212
-%213 = OpFunctionParameter %ulong
-%214 = OpFunctionParameter %ushort
-%215 = OpLabel
+%185 = OpVariable %_ptr_Function_bool Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_bool Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_bool Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_bool Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
 %222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ushort Function
+%223 = OpVariable %_ptr_Function_bool Function
 %224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_bool Function
+%225 = OpVariable %_ptr_Function_ulong Function
 %226 = OpVariable %_ptr_Function_ulong Function
 %227 = OpVariable %_ptr_Function_ulong Function
 %228 = OpVariable %_ptr_Function_ulong Function
 %229 = OpVariable %_ptr_Function_ulong Function
 %230 = OpVariable %_ptr_Function_ulong Function
 %231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_bool Function
 %233 = OpVariable %_ptr_Function_ulong Function
-OpStore %222 %213
-OpStore %223 %214
-%234 = OpLoad %ushort %223
-%235 = OpUConvert %ulong %234
-OpStore %224 %235
-OpBranch %216
-%216 = OpLabel
-%236 = OpLoad %ulong %222
-OpStore %232 %236
-OpStore %233 %ulong_0
-OpBranch %217
-%217 = OpLabel
-%237 = OpLoad %ulong %233
-%238 = OpULessThan %bool %237 %ulong_8
-OpStore %225 %238
-%239 = OpLoad %bool %225
-OpLoopMerge %219 %221 None
-OpBranchConditional %239 %218 %219
-%219 = OpLabel
-OpBranch %220
-%220 = OpLabel
-%240 = OpLoad %ulong %232
-OpReturnValue %240
-%218 = OpLabel
-%241 = OpLoad %ulong %233
-%242 = OpIMul %ulong %241 %ulong_8
-OpStore %226 %242
-%243 = OpLoad %ulong %224
-%244 = OpLoad %ulong %226
-%245 = OpShiftRightLogical %ulong %243 %244
-OpStore %227 %245
-%246 = OpLoad %ulong %227
-%247 = OpBitwiseAnd %ulong %246 %ulong_255
-OpStore %228 %247
-%248 = OpLoad %ulong %232
-%249 = OpLoad %ulong %228
-%250 = OpBitwiseXor %ulong %248 %249
-OpStore %229 %250
-%251 = OpLoad %ulong %229
-%252 = OpIMul %ulong %251 %ulong_1099511628211
-OpStore %230 %252
-%253 = OpLoad %ulong %233
-%254 = OpIAdd %ulong %253 %ulong_1
-OpStore %231 %254
-%255 = OpLoad %ulong %230
-OpStore %232 %255
-%256 = OpLoad %ulong %231
-OpStore %233 %256
-OpBranch %221
-%221 = OpLabel
-OpBranch %217
-OpFunctionEnd
-%5 = OpFunction %ulong None %257
-%258 = OpFunctionParameter %ulong
-%259 = OpFunctionParameter %uint
-%260 = OpLabel
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_bool Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_bool Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
 %267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_uint Function
+%268 = OpVariable %_ptr_Function_bool Function
 %269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_bool Function
+%270 = OpVariable %_ptr_Function_ulong Function
 %271 = OpVariable %_ptr_Function_ulong Function
 %272 = OpVariable %_ptr_Function_ulong Function
 %273 = OpVariable %_ptr_Function_ulong Function
 %274 = OpVariable %_ptr_Function_ulong Function
 %275 = OpVariable %_ptr_Function_ulong Function
 %276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_ulong Function
-OpStore %267 %258
-OpStore %268 %259
-%279 = OpLoad %uint %268
-%280 = OpUConvert %ulong %279
-OpStore %269 %280
-OpBranch %261
-%261 = OpLabel
-%281 = OpLoad %ulong %267
-OpStore %277 %281
-OpStore %278 %ulong_0
-OpBranch %262
-%262 = OpLabel
-%282 = OpLoad %ulong %278
-%283 = OpULessThan %bool %282 %ulong_8
-OpStore %270 %283
-%284 = OpLoad %bool %270
-OpLoopMerge %264 %266 None
-OpBranchConditional %284 %263 %264
-%264 = OpLabel
-OpBranch %265
-%265 = OpLabel
-%285 = OpLoad %ulong %277
-OpReturnValue %285
-%263 = OpLabel
-%286 = OpLoad %ulong %278
-%287 = OpIMul %ulong %286 %ulong_8
-OpStore %271 %287
-%288 = OpLoad %ulong %269
-%289 = OpLoad %ulong %271
-%290 = OpShiftRightLogical %ulong %288 %289
-OpStore %272 %290
-%291 = OpLoad %ulong %272
-%292 = OpBitwiseAnd %ulong %291 %ulong_255
-OpStore %273 %292
-%293 = OpLoad %ulong %277
-%294 = OpLoad %ulong %273
-%295 = OpBitwiseXor %ulong %293 %294
-OpStore %274 %295
-%296 = OpLoad %ulong %274
-%297 = OpIMul %ulong %296 %ulong_1099511628211
-OpStore %275 %297
-%298 = OpLoad %ulong %278
-%299 = OpIAdd %ulong %298 %ulong_1
-OpStore %276 %299
-%300 = OpLoad %ulong %275
-OpStore %277 %300
-%301 = OpLoad %ulong %276
-OpStore %278 %301
-OpBranch %266
-%266 = OpLabel
-OpBranch %262
+OpStore %109 %4
+OpBranch %6
+%6 = OpLabel
+OpBranch %7
+%7 = OpLabel
+%277 = OpLoad %ulong %109
+%278 = OpUConvert %uchar %277
+OpStore %111 %278
+%279 = OpLoad %uchar %111
+%281 = OpBitwiseOr %uchar %279 %uchar_128
+OpStore %112 %281
+%283 = OpLoad %uchar %112
+%284 = OpISub %uchar %uchar_255 %283
+OpStore %113 %284
+%285 = OpLoad %ulong %109
+%286 = OpUConvert %ushort %285
+OpStore %115 %286
+%287 = OpLoad %ushort %115
+%289 = OpBitwiseOr %ushort %287 %ushort_32768
+OpStore %116 %289
+%291 = OpLoad %ushort %116
+%292 = OpISub %ushort %ushort_65535 %291
+OpStore %117 %292
+%293 = OpLoad %ulong %109
+%294 = OpUConvert %uint %293
+OpStore %119 %294
+%295 = OpLoad %uint %119
+%297 = OpBitwiseOr %uint %295 %uint_2147483648
+OpStore %120 %297
+%299 = OpLoad %uint %120
+%300 = OpISub %uint %uint_4294967295 %299
+OpStore %121 %300
+%301 = OpLoad %uchar %112
+%302 = OpUConvert %ushort %301
+OpStore %122 %302
+OpBranch %8
+%8 = OpLabel
+%303 = OpLoad %ushort %122
+%304 = OpUConvert %ulong %303
+OpStore %144 %304
+OpBranch %10
+%10 = OpLabel
+OpStore %153 %ulong_14695981039346656037
+OpStore %154 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%307 = OpLoad %ulong %154
+%309 = OpULessThan %bool %307 %ulong_8
+OpStore %146 %309
+%310 = OpLoad %bool %146
+OpLoopMerge %13 %103 None
+OpBranchConditional %310 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%9 = OpLabel
+%311 = OpLoad %uchar %113
+%312 = OpUConvert %ushort %311
+OpStore %123 %312
+OpBranch %15
+%15 = OpLabel
+%313 = OpLoad %ushort %123
+%314 = OpUConvert %ulong %313
+OpStore %155 %314
+OpBranch %17
+%17 = OpLabel
+%315 = OpLoad %ulong %153
+OpStore %163 %315
+OpStore %164 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%316 = OpLoad %ulong %164
+%317 = OpULessThan %bool %316 %ulong_8
+OpStore %156 %317
+%318 = OpLoad %bool %156
+OpLoopMerge %20 %102 None
+OpBranchConditional %318 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%319 = OpLoad %uchar %112
+%320 = OpUConvert %uint %319
+OpStore %124 %320
+OpBranch %22
+%22 = OpLabel
+%321 = OpLoad %uint %124
+%322 = OpUConvert %ulong %321
+OpStore %165 %322
+OpBranch %24
+%24 = OpLabel
+%323 = OpLoad %ulong %163
+OpStore %173 %323
+OpStore %174 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%324 = OpLoad %ulong %174
+%325 = OpULessThan %bool %324 %ulong_8
+OpStore %166 %325
+%326 = OpLoad %bool %166
+OpLoopMerge %27 %101 None
+OpBranchConditional %326 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%327 = OpLoad %uchar %113
+%328 = OpUConvert %uint %327
+OpStore %125 %328
+OpBranch %29
+%29 = OpLabel
+%329 = OpLoad %uint %125
+%330 = OpUConvert %ulong %329
+OpStore %175 %330
+OpBranch %31
+%31 = OpLabel
+%331 = OpLoad %ulong %173
+OpStore %183 %331
+OpStore %184 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%332 = OpLoad %ulong %184
+%333 = OpULessThan %bool %332 %ulong_8
+OpStore %176 %333
+%334 = OpLoad %bool %176
+OpLoopMerge %34 %100 None
+OpBranchConditional %334 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%335 = OpLoad %uchar %112
+%336 = OpUConvert %ulong %335
+OpStore %126 %336
+OpBranch %36
+%36 = OpLabel
+%337 = OpLoad %ulong %183
+OpStore %192 %337
+OpStore %193 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%338 = OpLoad %ulong %193
+%339 = OpULessThan %bool %338 %ulong_8
+OpStore %185 %339
+%340 = OpLoad %bool %185
+OpLoopMerge %39 %99 None
+OpBranchConditional %340 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%341 = OpLoad %uchar %113
+%342 = OpUConvert %ulong %341
+OpStore %127 %342
+OpBranch %41
+%41 = OpLabel
+%343 = OpLoad %ulong %192
+OpStore %201 %343
+OpStore %202 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%344 = OpLoad %ulong %202
+%345 = OpULessThan %bool %344 %ulong_8
+OpStore %194 %345
+%346 = OpLoad %bool %194
+OpLoopMerge %44 %98 None
+OpBranchConditional %346 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%347 = OpLoad %ushort %116
+%348 = OpUConvert %uint %347
+OpStore %128 %348
+OpBranch %46
+%46 = OpLabel
+%349 = OpLoad %uint %128
+%350 = OpUConvert %ulong %349
+OpStore %203 %350
+OpBranch %48
+%48 = OpLabel
+%351 = OpLoad %ulong %201
+OpStore %211 %351
+OpStore %212 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%352 = OpLoad %ulong %212
+%353 = OpULessThan %bool %352 %ulong_8
+OpStore %204 %353
+%354 = OpLoad %bool %204
+OpLoopMerge %51 %97 None
+OpBranchConditional %354 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%355 = OpLoad %ushort %117
+%356 = OpUConvert %uint %355
+OpStore %129 %356
+OpBranch %53
+%53 = OpLabel
+%357 = OpLoad %uint %129
+%358 = OpUConvert %ulong %357
+OpStore %213 %358
+OpBranch %55
+%55 = OpLabel
+%359 = OpLoad %ulong %211
+OpStore %221 %359
+OpStore %222 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%360 = OpLoad %ulong %222
+%361 = OpULessThan %bool %360 %ulong_8
+OpStore %214 %361
+%362 = OpLoad %bool %214
+OpLoopMerge %58 %96 None
+OpBranchConditional %362 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%363 = OpLoad %ushort %116
+%364 = OpUConvert %ulong %363
+OpStore %130 %364
+OpBranch %60
+%60 = OpLabel
+%365 = OpLoad %ulong %221
+OpStore %230 %365
+OpStore %231 %ulong_0
+OpBranch %61
+%61 = OpLabel
+%366 = OpLoad %ulong %231
+%367 = OpULessThan %bool %366 %ulong_8
+OpStore %223 %367
+%368 = OpLoad %bool %223
+OpLoopMerge %63 %95 None
+OpBranchConditional %368 %62 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%369 = OpLoad %ushort %117
+%370 = OpUConvert %ulong %369
+OpStore %131 %370
+OpBranch %65
+%65 = OpLabel
+%371 = OpLoad %ulong %230
+OpStore %239 %371
+OpStore %240 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%372 = OpLoad %ulong %240
+%373 = OpULessThan %bool %372 %ulong_8
+OpStore %232 %373
+%374 = OpLoad %bool %232
+OpLoopMerge %68 %94 None
+OpBranchConditional %374 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%375 = OpLoad %uint %120
+%376 = OpUConvert %ulong %375
+OpStore %132 %376
+OpBranch %70
+%70 = OpLabel
+%377 = OpLoad %ulong %239
+OpStore %248 %377
+OpStore %249 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%378 = OpLoad %ulong %249
+%379 = OpULessThan %bool %378 %ulong_8
+OpStore %241 %379
+%380 = OpLoad %bool %241
+OpLoopMerge %73 %93 None
+OpBranchConditional %380 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%381 = OpLoad %uint %121
+%382 = OpUConvert %ulong %381
+OpStore %133 %382
+OpBranch %75
+%75 = OpLabel
+%383 = OpLoad %ulong %248
+OpStore %257 %383
+OpStore %258 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%384 = OpLoad %ulong %258
+%385 = OpULessThan %bool %384 %ulong_8
+OpStore %250 %385
+%386 = OpLoad %bool %250
+OpLoopMerge %78 %92 None
+OpBranchConditional %386 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%387 = OpLoad %uchar %112
+%388 = OpUConvert %ulong %387
+OpStore %134 %388
+%389 = OpLoad %ushort %116
+%390 = OpUConvert %ulong %389
+OpStore %135 %390
+%391 = OpLoad %ulong %134
+%392 = OpLoad %ulong %135
+%393 = OpIAdd %ulong %391 %392
+OpStore %136 %393
+%394 = OpLoad %uint %120
+%395 = OpUConvert %ulong %394
+OpStore %137 %395
+%396 = OpLoad %ulong %136
+%397 = OpLoad %ulong %137
+%398 = OpIAdd %ulong %396 %397
+OpStore %138 %398
+OpBranch %80
+%80 = OpLabel
+%399 = OpLoad %ulong %257
+OpStore %266 %399
+OpStore %267 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%400 = OpLoad %ulong %267
+%401 = OpULessThan %bool %400 %ulong_8
+OpStore %259 %401
+%402 = OpLoad %bool %259
+OpLoopMerge %83 %91 None
+OpBranchConditional %402 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%403 = OpLoad %uchar %113
+%404 = OpUConvert %ulong %403
+OpStore %139 %404
+%405 = OpLoad %ushort %117
+%406 = OpUConvert %ulong %405
+OpStore %140 %406
+%407 = OpLoad %ulong %139
+%408 = OpLoad %ulong %140
+%409 = OpIAdd %ulong %407 %408
+OpStore %141 %409
+%410 = OpLoad %uint %121
+%411 = OpUConvert %ulong %410
+OpStore %142 %411
+%412 = OpLoad %ulong %141
+%413 = OpLoad %ulong %142
+%414 = OpIAdd %ulong %412 %413
+OpStore %143 %414
+OpBranch %85
+%85 = OpLabel
+%415 = OpLoad %ulong %266
+OpStore %275 %415
+OpStore %276 %ulong_0
+OpBranch %86
+%86 = OpLabel
+%416 = OpLoad %ulong %276
+%417 = OpULessThan %bool %416 %ulong_8
+OpStore %268 %417
+%418 = OpLoad %bool %268
+OpLoopMerge %88 %90 None
+OpBranchConditional %418 %87 %88
+%88 = OpLabel
+OpBranch %89
+%89 = OpLabel
+%419 = OpLoad %ulong %275
+OpReturnValue %419
+%87 = OpLabel
+%420 = OpLoad %ulong %276
+%421 = OpIMul %ulong %420 %ulong_8
+OpStore %269 %421
+%422 = OpLoad %ulong %143
+%423 = OpLoad %ulong %269
+%424 = OpShiftRightLogical %ulong %422 %423
+OpStore %270 %424
+%425 = OpLoad %ulong %270
+%427 = OpBitwiseAnd %ulong %425 %ulong_255
+OpStore %271 %427
+%428 = OpLoad %ulong %275
+%429 = OpLoad %ulong %271
+%430 = OpBitwiseXor %ulong %428 %429
+OpStore %272 %430
+%431 = OpLoad %ulong %272
+%433 = OpIMul %ulong %431 %ulong_1099511628211
+OpStore %273 %433
+%434 = OpLoad %ulong %276
+%436 = OpIAdd %ulong %434 %ulong_1
+OpStore %274 %436
+%437 = OpLoad %ulong %273
+OpStore %275 %437
+%438 = OpLoad %ulong %274
+OpStore %276 %438
+OpBranch %90
+%82 = OpLabel
+%439 = OpLoad %ulong %267
+%440 = OpIMul %ulong %439 %ulong_8
+OpStore %260 %440
+%441 = OpLoad %ulong %138
+%442 = OpLoad %ulong %260
+%443 = OpShiftRightLogical %ulong %441 %442
+OpStore %261 %443
+%444 = OpLoad %ulong %261
+%445 = OpBitwiseAnd %ulong %444 %ulong_255
+OpStore %262 %445
+%446 = OpLoad %ulong %266
+%447 = OpLoad %ulong %262
+%448 = OpBitwiseXor %ulong %446 %447
+OpStore %263 %448
+%449 = OpLoad %ulong %263
+%450 = OpIMul %ulong %449 %ulong_1099511628211
+OpStore %264 %450
+%451 = OpLoad %ulong %267
+%452 = OpIAdd %ulong %451 %ulong_1
+OpStore %265 %452
+%453 = OpLoad %ulong %264
+OpStore %266 %453
+%454 = OpLoad %ulong %265
+OpStore %267 %454
+OpBranch %91
+%77 = OpLabel
+%455 = OpLoad %ulong %258
+%456 = OpIMul %ulong %455 %ulong_8
+OpStore %251 %456
+%457 = OpLoad %ulong %133
+%458 = OpLoad %ulong %251
+%459 = OpShiftRightLogical %ulong %457 %458
+OpStore %252 %459
+%460 = OpLoad %ulong %252
+%461 = OpBitwiseAnd %ulong %460 %ulong_255
+OpStore %253 %461
+%462 = OpLoad %ulong %257
+%463 = OpLoad %ulong %253
+%464 = OpBitwiseXor %ulong %462 %463
+OpStore %254 %464
+%465 = OpLoad %ulong %254
+%466 = OpIMul %ulong %465 %ulong_1099511628211
+OpStore %255 %466
+%467 = OpLoad %ulong %258
+%468 = OpIAdd %ulong %467 %ulong_1
+OpStore %256 %468
+%469 = OpLoad %ulong %255
+OpStore %257 %469
+%470 = OpLoad %ulong %256
+OpStore %258 %470
+OpBranch %92
+%72 = OpLabel
+%471 = OpLoad %ulong %249
+%472 = OpIMul %ulong %471 %ulong_8
+OpStore %242 %472
+%473 = OpLoad %ulong %132
+%474 = OpLoad %ulong %242
+%475 = OpShiftRightLogical %ulong %473 %474
+OpStore %243 %475
+%476 = OpLoad %ulong %243
+%477 = OpBitwiseAnd %ulong %476 %ulong_255
+OpStore %244 %477
+%478 = OpLoad %ulong %248
+%479 = OpLoad %ulong %244
+%480 = OpBitwiseXor %ulong %478 %479
+OpStore %245 %480
+%481 = OpLoad %ulong %245
+%482 = OpIMul %ulong %481 %ulong_1099511628211
+OpStore %246 %482
+%483 = OpLoad %ulong %249
+%484 = OpIAdd %ulong %483 %ulong_1
+OpStore %247 %484
+%485 = OpLoad %ulong %246
+OpStore %248 %485
+%486 = OpLoad %ulong %247
+OpStore %249 %486
+OpBranch %93
+%67 = OpLabel
+%487 = OpLoad %ulong %240
+%488 = OpIMul %ulong %487 %ulong_8
+OpStore %233 %488
+%489 = OpLoad %ulong %131
+%490 = OpLoad %ulong %233
+%491 = OpShiftRightLogical %ulong %489 %490
+OpStore %234 %491
+%492 = OpLoad %ulong %234
+%493 = OpBitwiseAnd %ulong %492 %ulong_255
+OpStore %235 %493
+%494 = OpLoad %ulong %239
+%495 = OpLoad %ulong %235
+%496 = OpBitwiseXor %ulong %494 %495
+OpStore %236 %496
+%497 = OpLoad %ulong %236
+%498 = OpIMul %ulong %497 %ulong_1099511628211
+OpStore %237 %498
+%499 = OpLoad %ulong %240
+%500 = OpIAdd %ulong %499 %ulong_1
+OpStore %238 %500
+%501 = OpLoad %ulong %237
+OpStore %239 %501
+%502 = OpLoad %ulong %238
+OpStore %240 %502
+OpBranch %94
+%62 = OpLabel
+%503 = OpLoad %ulong %231
+%504 = OpIMul %ulong %503 %ulong_8
+OpStore %224 %504
+%505 = OpLoad %ulong %130
+%506 = OpLoad %ulong %224
+%507 = OpShiftRightLogical %ulong %505 %506
+OpStore %225 %507
+%508 = OpLoad %ulong %225
+%509 = OpBitwiseAnd %ulong %508 %ulong_255
+OpStore %226 %509
+%510 = OpLoad %ulong %230
+%511 = OpLoad %ulong %226
+%512 = OpBitwiseXor %ulong %510 %511
+OpStore %227 %512
+%513 = OpLoad %ulong %227
+%514 = OpIMul %ulong %513 %ulong_1099511628211
+OpStore %228 %514
+%515 = OpLoad %ulong %231
+%516 = OpIAdd %ulong %515 %ulong_1
+OpStore %229 %516
+%517 = OpLoad %ulong %228
+OpStore %230 %517
+%518 = OpLoad %ulong %229
+OpStore %231 %518
+OpBranch %95
+%57 = OpLabel
+%519 = OpLoad %ulong %222
+%520 = OpIMul %ulong %519 %ulong_8
+OpStore %215 %520
+%521 = OpLoad %ulong %213
+%522 = OpLoad %ulong %215
+%523 = OpShiftRightLogical %ulong %521 %522
+OpStore %216 %523
+%524 = OpLoad %ulong %216
+%525 = OpBitwiseAnd %ulong %524 %ulong_255
+OpStore %217 %525
+%526 = OpLoad %ulong %221
+%527 = OpLoad %ulong %217
+%528 = OpBitwiseXor %ulong %526 %527
+OpStore %218 %528
+%529 = OpLoad %ulong %218
+%530 = OpIMul %ulong %529 %ulong_1099511628211
+OpStore %219 %530
+%531 = OpLoad %ulong %222
+%532 = OpIAdd %ulong %531 %ulong_1
+OpStore %220 %532
+%533 = OpLoad %ulong %219
+OpStore %221 %533
+%534 = OpLoad %ulong %220
+OpStore %222 %534
+OpBranch %96
+%50 = OpLabel
+%535 = OpLoad %ulong %212
+%536 = OpIMul %ulong %535 %ulong_8
+OpStore %205 %536
+%537 = OpLoad %ulong %203
+%538 = OpLoad %ulong %205
+%539 = OpShiftRightLogical %ulong %537 %538
+OpStore %206 %539
+%540 = OpLoad %ulong %206
+%541 = OpBitwiseAnd %ulong %540 %ulong_255
+OpStore %207 %541
+%542 = OpLoad %ulong %211
+%543 = OpLoad %ulong %207
+%544 = OpBitwiseXor %ulong %542 %543
+OpStore %208 %544
+%545 = OpLoad %ulong %208
+%546 = OpIMul %ulong %545 %ulong_1099511628211
+OpStore %209 %546
+%547 = OpLoad %ulong %212
+%548 = OpIAdd %ulong %547 %ulong_1
+OpStore %210 %548
+%549 = OpLoad %ulong %209
+OpStore %211 %549
+%550 = OpLoad %ulong %210
+OpStore %212 %550
+OpBranch %97
+%43 = OpLabel
+%551 = OpLoad %ulong %202
+%552 = OpIMul %ulong %551 %ulong_8
+OpStore %195 %552
+%553 = OpLoad %ulong %127
+%554 = OpLoad %ulong %195
+%555 = OpShiftRightLogical %ulong %553 %554
+OpStore %196 %555
+%556 = OpLoad %ulong %196
+%557 = OpBitwiseAnd %ulong %556 %ulong_255
+OpStore %197 %557
+%558 = OpLoad %ulong %201
+%559 = OpLoad %ulong %197
+%560 = OpBitwiseXor %ulong %558 %559
+OpStore %198 %560
+%561 = OpLoad %ulong %198
+%562 = OpIMul %ulong %561 %ulong_1099511628211
+OpStore %199 %562
+%563 = OpLoad %ulong %202
+%564 = OpIAdd %ulong %563 %ulong_1
+OpStore %200 %564
+%565 = OpLoad %ulong %199
+OpStore %201 %565
+%566 = OpLoad %ulong %200
+OpStore %202 %566
+OpBranch %98
+%38 = OpLabel
+%567 = OpLoad %ulong %193
+%568 = OpIMul %ulong %567 %ulong_8
+OpStore %186 %568
+%569 = OpLoad %ulong %126
+%570 = OpLoad %ulong %186
+%571 = OpShiftRightLogical %ulong %569 %570
+OpStore %187 %571
+%572 = OpLoad %ulong %187
+%573 = OpBitwiseAnd %ulong %572 %ulong_255
+OpStore %188 %573
+%574 = OpLoad %ulong %192
+%575 = OpLoad %ulong %188
+%576 = OpBitwiseXor %ulong %574 %575
+OpStore %189 %576
+%577 = OpLoad %ulong %189
+%578 = OpIMul %ulong %577 %ulong_1099511628211
+OpStore %190 %578
+%579 = OpLoad %ulong %193
+%580 = OpIAdd %ulong %579 %ulong_1
+OpStore %191 %580
+%581 = OpLoad %ulong %190
+OpStore %192 %581
+%582 = OpLoad %ulong %191
+OpStore %193 %582
+OpBranch %99
+%33 = OpLabel
+%583 = OpLoad %ulong %184
+%584 = OpIMul %ulong %583 %ulong_8
+OpStore %177 %584
+%585 = OpLoad %ulong %175
+%586 = OpLoad %ulong %177
+%587 = OpShiftRightLogical %ulong %585 %586
+OpStore %178 %587
+%588 = OpLoad %ulong %178
+%589 = OpBitwiseAnd %ulong %588 %ulong_255
+OpStore %179 %589
+%590 = OpLoad %ulong %183
+%591 = OpLoad %ulong %179
+%592 = OpBitwiseXor %ulong %590 %591
+OpStore %180 %592
+%593 = OpLoad %ulong %180
+%594 = OpIMul %ulong %593 %ulong_1099511628211
+OpStore %181 %594
+%595 = OpLoad %ulong %184
+%596 = OpIAdd %ulong %595 %ulong_1
+OpStore %182 %596
+%597 = OpLoad %ulong %181
+OpStore %183 %597
+%598 = OpLoad %ulong %182
+OpStore %184 %598
+OpBranch %100
+%26 = OpLabel
+%599 = OpLoad %ulong %174
+%600 = OpIMul %ulong %599 %ulong_8
+OpStore %167 %600
+%601 = OpLoad %ulong %165
+%602 = OpLoad %ulong %167
+%603 = OpShiftRightLogical %ulong %601 %602
+OpStore %168 %603
+%604 = OpLoad %ulong %168
+%605 = OpBitwiseAnd %ulong %604 %ulong_255
+OpStore %169 %605
+%606 = OpLoad %ulong %173
+%607 = OpLoad %ulong %169
+%608 = OpBitwiseXor %ulong %606 %607
+OpStore %170 %608
+%609 = OpLoad %ulong %170
+%610 = OpIMul %ulong %609 %ulong_1099511628211
+OpStore %171 %610
+%611 = OpLoad %ulong %174
+%612 = OpIAdd %ulong %611 %ulong_1
+OpStore %172 %612
+%613 = OpLoad %ulong %171
+OpStore %173 %613
+%614 = OpLoad %ulong %172
+OpStore %174 %614
+OpBranch %101
+%19 = OpLabel
+%615 = OpLoad %ulong %164
+%616 = OpIMul %ulong %615 %ulong_8
+OpStore %157 %616
+%617 = OpLoad %ulong %155
+%618 = OpLoad %ulong %157
+%619 = OpShiftRightLogical %ulong %617 %618
+OpStore %158 %619
+%620 = OpLoad %ulong %158
+%621 = OpBitwiseAnd %ulong %620 %ulong_255
+OpStore %159 %621
+%622 = OpLoad %ulong %163
+%623 = OpLoad %ulong %159
+%624 = OpBitwiseXor %ulong %622 %623
+OpStore %160 %624
+%625 = OpLoad %ulong %160
+%626 = OpIMul %ulong %625 %ulong_1099511628211
+OpStore %161 %626
+%627 = OpLoad %ulong %164
+%628 = OpIAdd %ulong %627 %ulong_1
+OpStore %162 %628
+%629 = OpLoad %ulong %161
+OpStore %163 %629
+%630 = OpLoad %ulong %162
+OpStore %164 %630
+OpBranch %102
+%12 = OpLabel
+%631 = OpLoad %ulong %154
+%632 = OpIMul %ulong %631 %ulong_8
+OpStore %147 %632
+%633 = OpLoad %ulong %144
+%634 = OpLoad %ulong %147
+%635 = OpShiftRightLogical %ulong %633 %634
+OpStore %148 %635
+%636 = OpLoad %ulong %148
+%637 = OpBitwiseAnd %ulong %636 %ulong_255
+OpStore %149 %637
+%638 = OpLoad %ulong %153
+%639 = OpLoad %ulong %149
+%640 = OpBitwiseXor %ulong %638 %639
+OpStore %150 %640
+%641 = OpLoad %ulong %150
+%642 = OpIMul %ulong %641 %ulong_1099511628211
+OpStore %151 %642
+%643 = OpLoad %ulong %154
+%644 = OpIAdd %ulong %643 %ulong_1
+OpStore %152 %644
+%645 = OpLoad %ulong %151
+OpStore %153 %645
+%646 = OpLoad %ulong %152
+OpStore %154 %646
+OpBranch %103
+%90 = OpLabel
+OpBranch %86
+%91 = OpLabel
+OpBranch %81
+%92 = OpLabel
+OpBranch %76
+%93 = OpLabel
+OpBranch %71
+%94 = OpLabel
+OpBranch %66
+%95 = OpLabel
+OpBranch %61
+%96 = OpLabel
+OpBranch %56
+%97 = OpLabel
+OpBranch %49
+%98 = OpLabel
+OpBranch %42
+%99 = OpLabel
+OpBranch %37
+%100 = OpLabel
+OpBranch %32
+%101 = OpLabel
+OpBranch %25
+%102 = OpLabel
+OpBranch %18
+%103 = OpLabel
+OpBranch %11
 OpFunctionEnd

--- a/test/golden/spirv/convert/f2f.dis
+++ b/test/golden/spirv/convert/f2f.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 203
+; Bound: 476
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,279 +10,708 @@ OpCapability Float64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.convert.f2f.checksum" Export
 %ulong = OpTypeInt 64 0
-%6 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %double = OpTypeFloat 64
 %float = OpTypeFloat 32
+%bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_double = OpTypePointer Function %double
 %_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_bool = OpTypePointer Function %bool
+%_ptr_Function_uint = OpTypePointer Function %uint
 %double_1_0000000596046448 = OpConstant %double 1.0000000596046448
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %double_0_10000000000000001 = OpConstant %double 0.10000000000000001
 %double_16777217 = OpConstant %double 16777217
 %float_3_40282347e_38 = OpConstant %float 3.40282347e+38
-%98 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%101 = OpTypeFunction %ulong %ulong %float
-%uint = OpTypeInt 32 0
-%bool = OpTypeBool
-%_ptr_Function_uint = OpTypePointer Function %uint
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%158 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %6
-%7 = OpFunctionParameter %ulong
-%8 = OpLabel
-%12 = OpVariable %_ptr_Function_ulong Function
-%13 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_double Function
-%17 = OpVariable %_ptr_Function_float Function
-%18 = OpVariable %_ptr_Function_double Function
-%19 = OpVariable %_ptr_Function_float Function
-%20 = OpVariable %_ptr_Function_double Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_double Function
-%25 = OpVariable %_ptr_Function_float Function
-%26 = OpVariable %_ptr_Function_double Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_double Function
-%31 = OpVariable %_ptr_Function_float Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_float Function
-%35 = OpVariable %_ptr_Function_double Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-OpStore %12 %7
-%38 = OpFunctionCall %ulong %2
-OpStore %13 %38
-%39 = OpLoad %ulong %12
-%40 = OpConvertUToF %double %39
-OpStore %15 %40
-%41 = OpLoad %ulong %12
-%42 = OpConvertUToF %float %41
-OpStore %17 %42
-%44 = OpLoad %double %15
-%45 = OpFAdd %double %double_1_0000000596046448 %44
-OpStore %18 %45
-%46 = OpLoad %double %18
-%47 = OpFConvert %float %46
-OpStore %19 %47
-%48 = OpLoad %float %19
-%49 = OpFConvert %double %48
-OpStore %20 %49
-%50 = OpLoad %ulong %13
-%51 = OpLoad %double %18
-%52 = OpFunctionCall %ulong %4 %50 %51
-OpStore %21 %52
-%53 = OpLoad %ulong %21
-%54 = OpLoad %float %19
-%55 = OpFunctionCall %ulong %3 %53 %54
-OpStore %22 %55
-%56 = OpLoad %ulong %22
-%57 = OpLoad %double %20
-%58 = OpFunctionCall %ulong %4 %56 %57
-OpStore %23 %58
-%60 = OpLoad %double %15
-%61 = OpFAdd %double %double_0_10000000000000001 %60
-OpStore %24 %61
-%62 = OpLoad %double %24
-%63 = OpFConvert %float %62
-OpStore %25 %63
-%64 = OpLoad %float %25
-%65 = OpFConvert %double %64
-OpStore %26 %65
-%66 = OpLoad %ulong %23
-%67 = OpLoad %double %24
-%68 = OpFunctionCall %ulong %4 %66 %67
-OpStore %27 %68
-%69 = OpLoad %ulong %27
-%70 = OpLoad %float %25
-%71 = OpFunctionCall %ulong %3 %69 %70
-OpStore %28 %71
-%72 = OpLoad %ulong %28
-%73 = OpLoad %double %26
-%74 = OpFunctionCall %ulong %4 %72 %73
-OpStore %29 %74
-%76 = OpLoad %double %15
-%77 = OpFAdd %double %double_16777217 %76
-OpStore %30 %77
-%78 = OpLoad %double %30
-%79 = OpFConvert %float %78
-OpStore %31 %79
-%80 = OpLoad %ulong %29
-%81 = OpLoad %double %30
-%82 = OpFunctionCall %ulong %4 %80 %81
-OpStore %32 %82
-%83 = OpLoad %ulong %32
-%84 = OpLoad %float %31
-%85 = OpFunctionCall %ulong %3 %83 %84
-OpStore %33 %85
-%87 = OpLoad %float %17
-%88 = OpFAdd %float %float_3_40282347e_38 %87
-OpStore %34 %88
-%89 = OpLoad %float %34
-%90 = OpFConvert %double %89
-OpStore %35 %90
-%91 = OpLoad %ulong %33
-%92 = OpLoad %float %34
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %36 %93
-%94 = OpLoad %ulong %36
-%95 = OpLoad %double %35
-%96 = OpFunctionCall %ulong %4 %94 %95
-OpStore %37 %96
-%97 = OpLoad %ulong %37
-OpReturnValue %97
-OpFunctionEnd
-%2 = OpFunction %ulong None %98
-%99 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %101
-%102 = OpFunctionParameter %ulong
-%103 = OpFunctionParameter %float
-%104 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%93 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_double Function
+%97 = OpVariable %_ptr_Function_float Function
+%98 = OpVariable %_ptr_Function_double Function
+%99 = OpVariable %_ptr_Function_float Function
+%100 = OpVariable %_ptr_Function_double Function
+%101 = OpVariable %_ptr_Function_double Function
+%102 = OpVariable %_ptr_Function_float Function
+%103 = OpVariable %_ptr_Function_double Function
+%104 = OpVariable %_ptr_Function_double Function
+%105 = OpVariable %_ptr_Function_float Function
+%106 = OpVariable %_ptr_Function_float Function
+%107 = OpVariable %_ptr_Function_double Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_bool Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
 %113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_float Function
-%116 = OpVariable %_ptr_Function_uint Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
 %117 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_bool Function
-%120 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_uint Function
 %121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_bool Function
 %123 = OpVariable %_ptr_Function_ulong Function
 %124 = OpVariable %_ptr_Function_ulong Function
 %125 = OpVariable %_ptr_Function_ulong Function
 %126 = OpVariable %_ptr_Function_ulong Function
 %127 = OpVariable %_ptr_Function_ulong Function
-OpStore %113 %102
-OpStore %114 %103
-%128 = OpLoad %float %114
-%129 = OpBitcast %uint %128
-OpStore %116 %129
-%130 = OpLoad %uint %116
-%131 = OpUConvert %ulong %130
-OpStore %117 %131
-OpBranch %105
-%105 = OpLabel
-%132 = OpLoad %ulong %113
-OpStore %126 %132
-OpStore %127 %ulong_0
-OpBranch %106
-%106 = OpLabel
-%134 = OpLoad %ulong %127
-%136 = OpULessThan %bool %134 %ulong_8
-OpStore %119 %136
-%137 = OpLoad %bool %119
-OpLoopMerge %108 %110 None
-OpBranchConditional %137 %107 %108
-%108 = OpLabel
-OpBranch %109
-%109 = OpLabel
-%138 = OpLoad %ulong %126
-OpReturnValue %138
-%107 = OpLabel
-%139 = OpLoad %ulong %127
-%140 = OpIMul %ulong %139 %ulong_8
-OpStore %120 %140
-%141 = OpLoad %ulong %117
-%142 = OpLoad %ulong %120
-%143 = OpShiftRightLogical %ulong %141 %142
-OpStore %121 %143
-%144 = OpLoad %ulong %121
-%146 = OpBitwiseAnd %ulong %144 %ulong_255
-OpStore %122 %146
-%147 = OpLoad %ulong %126
-%148 = OpLoad %ulong %122
-%149 = OpBitwiseXor %ulong %147 %148
-OpStore %123 %149
-%150 = OpLoad %ulong %123
-%152 = OpIMul %ulong %150 %ulong_1099511628211
-OpStore %124 %152
-%153 = OpLoad %ulong %127
-%155 = OpIAdd %ulong %153 %ulong_1
-OpStore %125 %155
-%156 = OpLoad %ulong %124
-OpStore %126 %156
-%157 = OpLoad %ulong %125
-OpStore %127 %157
-OpBranch %110
-%110 = OpLabel
-OpBranch %106
-OpFunctionEnd
-%4 = OpFunction %ulong None %158
-%159 = OpFunctionParameter %ulong
-%160 = OpFunctionParameter %double
-%161 = OpLabel
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_bool Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_bool Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_uint Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_bool Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_double Function
+%169 = OpVariable %_ptr_Function_ulong Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_bool Function
 %174 = OpVariable %_ptr_Function_ulong Function
 %175 = OpVariable %_ptr_Function_ulong Function
 %176 = OpVariable %_ptr_Function_ulong Function
 %177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
 %179 = OpVariable %_ptr_Function_ulong Function
-OpStore %168 %159
-OpStore %169 %160
-%180 = OpLoad %double %169
-%181 = OpBitcast %ulong %180
-OpStore %170 %181
-OpBranch %162
-%162 = OpLabel
-%182 = OpLoad %ulong %168
-OpStore %178 %182
-OpStore %179 %ulong_0
-OpBranch %163
-%163 = OpLabel
-%183 = OpLoad %ulong %179
-%184 = OpULessThan %bool %183 %ulong_8
-OpStore %171 %184
-%185 = OpLoad %bool %171
-OpLoopMerge %165 %167 None
-OpBranchConditional %185 %164 %165
-%165 = OpLabel
-OpBranch %166
-%166 = OpLabel
-%186 = OpLoad %ulong %178
-OpReturnValue %186
-%164 = OpLabel
-%187 = OpLoad %ulong %179
-%188 = OpIMul %ulong %187 %ulong_8
-OpStore %172 %188
-%189 = OpLoad %ulong %170
-%190 = OpLoad %ulong %172
-%191 = OpShiftRightLogical %ulong %189 %190
-OpStore %173 %191
-%192 = OpLoad %ulong %173
-%193 = OpBitwiseAnd %ulong %192 %ulong_255
-OpStore %174 %193
-%194 = OpLoad %ulong %178
-%195 = OpLoad %ulong %174
-%196 = OpBitwiseXor %ulong %194 %195
-OpStore %175 %196
-%197 = OpLoad %ulong %175
-%198 = OpIMul %ulong %197 %ulong_1099511628211
-OpStore %176 %198
-%199 = OpLoad %ulong %179
-%200 = OpIAdd %ulong %199 %ulong_1
-OpStore %177 %200
-%201 = OpLoad %ulong %176
-OpStore %178 %201
-%202 = OpLoad %ulong %177
-OpStore %179 %202
-OpBranch %167
-%167 = OpLabel
-OpBranch %163
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_uint Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_bool Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_uint Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_bool Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_bool Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+OpStore %93 %4
+OpBranch %6
+%6 = OpLabel
+OpBranch %7
+%7 = OpLabel
+%214 = OpLoad %ulong %93
+%215 = OpConvertUToF %double %214
+OpStore %95 %215
+%216 = OpLoad %ulong %93
+%217 = OpConvertUToF %float %216
+OpStore %97 %217
+%219 = OpLoad %double %95
+%220 = OpFAdd %double %double_1_0000000596046448 %219
+OpStore %98 %220
+%221 = OpLoad %double %98
+%222 = OpFConvert %float %221
+OpStore %99 %222
+%223 = OpLoad %float %99
+%224 = OpFConvert %double %223
+OpStore %100 %224
+OpBranch %8
+%8 = OpLabel
+%225 = OpLoad %double %98
+%226 = OpBitcast %ulong %225
+OpStore %108 %226
+OpBranch %10
+%10 = OpLabel
+OpStore %117 %ulong_14695981039346656037
+OpStore %118 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%229 = OpLoad %ulong %118
+%231 = OpULessThan %bool %229 %ulong_8
+OpStore %110 %231
+%232 = OpLoad %bool %110
+OpLoopMerge %13 %87 None
+OpBranchConditional %232 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%9 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%233 = OpLoad %float %99
+%234 = OpBitcast %uint %233
+OpStore %120 %234
+%235 = OpLoad %uint %120
+%236 = OpUConvert %ulong %235
+OpStore %121 %236
+OpBranch %17
+%17 = OpLabel
+%237 = OpLoad %ulong %117
+OpStore %129 %237
+OpStore %130 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%238 = OpLoad %ulong %130
+%239 = OpULessThan %bool %238 %ulong_8
+OpStore %122 %239
+%240 = OpLoad %bool %122
+OpLoopMerge %20 %86 None
+OpBranchConditional %240 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%241 = OpLoad %double %100
+%242 = OpBitcast %ulong %241
+OpStore %131 %242
+OpBranch %24
+%24 = OpLabel
+%243 = OpLoad %ulong %129
+OpStore %139 %243
+OpStore %140 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%244 = OpLoad %ulong %140
+%245 = OpULessThan %bool %244 %ulong_8
+OpStore %132 %245
+%246 = OpLoad %bool %132
+OpLoopMerge %27 %85 None
+OpBranchConditional %246 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%248 = OpLoad %double %95
+%249 = OpFAdd %double %double_0_10000000000000001 %248
+OpStore %101 %249
+%250 = OpLoad %double %101
+%251 = OpFConvert %float %250
+OpStore %102 %251
+%252 = OpLoad %float %102
+%253 = OpFConvert %double %252
+OpStore %103 %253
+OpBranch %29
+%29 = OpLabel
+%254 = OpLoad %double %101
+%255 = OpBitcast %ulong %254
+OpStore %141 %255
+OpBranch %31
+%31 = OpLabel
+%256 = OpLoad %ulong %139
+OpStore %149 %256
+OpStore %150 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%257 = OpLoad %ulong %150
+%258 = OpULessThan %bool %257 %ulong_8
+OpStore %142 %258
+%259 = OpLoad %bool %142
+OpLoopMerge %34 %84 None
+OpBranchConditional %259 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%260 = OpLoad %float %102
+%261 = OpBitcast %uint %260
+OpStore %151 %261
+%262 = OpLoad %uint %151
+%263 = OpUConvert %ulong %262
+OpStore %152 %263
+OpBranch %38
+%38 = OpLabel
+%264 = OpLoad %ulong %149
+OpStore %160 %264
+OpStore %161 %ulong_0
+OpBranch %39
+%39 = OpLabel
+%265 = OpLoad %ulong %161
+%266 = OpULessThan %bool %265 %ulong_8
+OpStore %153 %266
+%267 = OpLoad %bool %153
+OpLoopMerge %41 %83 None
+OpBranchConditional %267 %40 %41
+%41 = OpLabel
+OpBranch %42
+%42 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %43
+%43 = OpLabel
+%268 = OpLoad %double %103
+%269 = OpBitcast %ulong %268
+OpStore %162 %269
+OpBranch %45
+%45 = OpLabel
+%270 = OpLoad %ulong %160
+OpStore %170 %270
+OpStore %171 %ulong_0
+OpBranch %46
+%46 = OpLabel
+%271 = OpLoad %ulong %171
+%272 = OpULessThan %bool %271 %ulong_8
+OpStore %163 %272
+%273 = OpLoad %bool %163
+OpLoopMerge %48 %82 None
+OpBranchConditional %273 %47 %48
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%275 = OpLoad %double %95
+%276 = OpFAdd %double %double_16777217 %275
+OpStore %104 %276
+%277 = OpLoad %double %104
+%278 = OpFConvert %float %277
+OpStore %105 %278
+OpBranch %50
+%50 = OpLabel
+%279 = OpLoad %double %104
+%280 = OpBitcast %ulong %279
+OpStore %172 %280
+OpBranch %52
+%52 = OpLabel
+%281 = OpLoad %ulong %170
+OpStore %180 %281
+OpStore %181 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%282 = OpLoad %ulong %181
+%283 = OpULessThan %bool %282 %ulong_8
+OpStore %173 %283
+%284 = OpLoad %bool %173
+OpLoopMerge %55 %81 None
+OpBranchConditional %284 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpBranch %51
+%51 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%285 = OpLoad %float %105
+%286 = OpBitcast %uint %285
+OpStore %182 %286
+%287 = OpLoad %uint %182
+%288 = OpUConvert %ulong %287
+OpStore %183 %288
+OpBranch %59
+%59 = OpLabel
+%289 = OpLoad %ulong %180
+OpStore %191 %289
+OpStore %192 %ulong_0
+OpBranch %60
+%60 = OpLabel
+%290 = OpLoad %ulong %192
+%291 = OpULessThan %bool %290 %ulong_8
+OpStore %184 %291
+%292 = OpLoad %bool %184
+OpLoopMerge %62 %80 None
+OpBranchConditional %292 %61 %62
+%62 = OpLabel
+OpBranch %63
+%63 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%294 = OpLoad %float %97
+%295 = OpFAdd %float %float_3_40282347e_38 %294
+OpStore %106 %295
+%296 = OpLoad %float %106
+%297 = OpFConvert %double %296
+OpStore %107 %297
+OpBranch %64
+%64 = OpLabel
+%298 = OpLoad %float %106
+%299 = OpBitcast %uint %298
+OpStore %193 %299
+%300 = OpLoad %uint %193
+%301 = OpUConvert %ulong %300
+OpStore %194 %301
+OpBranch %66
+%66 = OpLabel
+%302 = OpLoad %ulong %191
+OpStore %202 %302
+OpStore %203 %ulong_0
+OpBranch %67
+%67 = OpLabel
+%303 = OpLoad %ulong %203
+%304 = OpULessThan %bool %303 %ulong_8
+OpStore %195 %304
+%305 = OpLoad %bool %195
+OpLoopMerge %69 %79 None
+OpBranchConditional %305 %68 %69
+%69 = OpLabel
+OpBranch %70
+%70 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%306 = OpLoad %double %107
+%307 = OpBitcast %ulong %306
+OpStore %204 %307
+OpBranch %73
+%73 = OpLabel
+%308 = OpLoad %ulong %202
+OpStore %212 %308
+OpStore %213 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%309 = OpLoad %ulong %213
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %205 %310
+%311 = OpLoad %bool %205
+OpLoopMerge %76 %78 None
+OpBranchConditional %311 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%312 = OpLoad %ulong %212
+OpReturnValue %312
+%75 = OpLabel
+%313 = OpLoad %ulong %213
+%314 = OpIMul %ulong %313 %ulong_8
+OpStore %206 %314
+%315 = OpLoad %ulong %204
+%316 = OpLoad %ulong %206
+%317 = OpShiftRightLogical %ulong %315 %316
+OpStore %207 %317
+%318 = OpLoad %ulong %207
+%320 = OpBitwiseAnd %ulong %318 %ulong_255
+OpStore %208 %320
+%321 = OpLoad %ulong %212
+%322 = OpLoad %ulong %208
+%323 = OpBitwiseXor %ulong %321 %322
+OpStore %209 %323
+%324 = OpLoad %ulong %209
+%326 = OpIMul %ulong %324 %ulong_1099511628211
+OpStore %210 %326
+%327 = OpLoad %ulong %213
+%329 = OpIAdd %ulong %327 %ulong_1
+OpStore %211 %329
+%330 = OpLoad %ulong %210
+OpStore %212 %330
+%331 = OpLoad %ulong %211
+OpStore %213 %331
+OpBranch %78
+%68 = OpLabel
+%332 = OpLoad %ulong %203
+%333 = OpIMul %ulong %332 %ulong_8
+OpStore %196 %333
+%334 = OpLoad %ulong %194
+%335 = OpLoad %ulong %196
+%336 = OpShiftRightLogical %ulong %334 %335
+OpStore %197 %336
+%337 = OpLoad %ulong %197
+%338 = OpBitwiseAnd %ulong %337 %ulong_255
+OpStore %198 %338
+%339 = OpLoad %ulong %202
+%340 = OpLoad %ulong %198
+%341 = OpBitwiseXor %ulong %339 %340
+OpStore %199 %341
+%342 = OpLoad %ulong %199
+%343 = OpIMul %ulong %342 %ulong_1099511628211
+OpStore %200 %343
+%344 = OpLoad %ulong %203
+%345 = OpIAdd %ulong %344 %ulong_1
+OpStore %201 %345
+%346 = OpLoad %ulong %200
+OpStore %202 %346
+%347 = OpLoad %ulong %201
+OpStore %203 %347
+OpBranch %79
+%61 = OpLabel
+%348 = OpLoad %ulong %192
+%349 = OpIMul %ulong %348 %ulong_8
+OpStore %185 %349
+%350 = OpLoad %ulong %183
+%351 = OpLoad %ulong %185
+%352 = OpShiftRightLogical %ulong %350 %351
+OpStore %186 %352
+%353 = OpLoad %ulong %186
+%354 = OpBitwiseAnd %ulong %353 %ulong_255
+OpStore %187 %354
+%355 = OpLoad %ulong %191
+%356 = OpLoad %ulong %187
+%357 = OpBitwiseXor %ulong %355 %356
+OpStore %188 %357
+%358 = OpLoad %ulong %188
+%359 = OpIMul %ulong %358 %ulong_1099511628211
+OpStore %189 %359
+%360 = OpLoad %ulong %192
+%361 = OpIAdd %ulong %360 %ulong_1
+OpStore %190 %361
+%362 = OpLoad %ulong %189
+OpStore %191 %362
+%363 = OpLoad %ulong %190
+OpStore %192 %363
+OpBranch %80
+%54 = OpLabel
+%364 = OpLoad %ulong %181
+%365 = OpIMul %ulong %364 %ulong_8
+OpStore %174 %365
+%366 = OpLoad %ulong %172
+%367 = OpLoad %ulong %174
+%368 = OpShiftRightLogical %ulong %366 %367
+OpStore %175 %368
+%369 = OpLoad %ulong %175
+%370 = OpBitwiseAnd %ulong %369 %ulong_255
+OpStore %176 %370
+%371 = OpLoad %ulong %180
+%372 = OpLoad %ulong %176
+%373 = OpBitwiseXor %ulong %371 %372
+OpStore %177 %373
+%374 = OpLoad %ulong %177
+%375 = OpIMul %ulong %374 %ulong_1099511628211
+OpStore %178 %375
+%376 = OpLoad %ulong %181
+%377 = OpIAdd %ulong %376 %ulong_1
+OpStore %179 %377
+%378 = OpLoad %ulong %178
+OpStore %180 %378
+%379 = OpLoad %ulong %179
+OpStore %181 %379
+OpBranch %81
+%47 = OpLabel
+%380 = OpLoad %ulong %171
+%381 = OpIMul %ulong %380 %ulong_8
+OpStore %164 %381
+%382 = OpLoad %ulong %162
+%383 = OpLoad %ulong %164
+%384 = OpShiftRightLogical %ulong %382 %383
+OpStore %165 %384
+%385 = OpLoad %ulong %165
+%386 = OpBitwiseAnd %ulong %385 %ulong_255
+OpStore %166 %386
+%387 = OpLoad %ulong %170
+%388 = OpLoad %ulong %166
+%389 = OpBitwiseXor %ulong %387 %388
+OpStore %167 %389
+%390 = OpLoad %ulong %167
+%391 = OpIMul %ulong %390 %ulong_1099511628211
+OpStore %168 %391
+%392 = OpLoad %ulong %171
+%393 = OpIAdd %ulong %392 %ulong_1
+OpStore %169 %393
+%394 = OpLoad %ulong %168
+OpStore %170 %394
+%395 = OpLoad %ulong %169
+OpStore %171 %395
+OpBranch %82
+%40 = OpLabel
+%396 = OpLoad %ulong %161
+%397 = OpIMul %ulong %396 %ulong_8
+OpStore %154 %397
+%398 = OpLoad %ulong %152
+%399 = OpLoad %ulong %154
+%400 = OpShiftRightLogical %ulong %398 %399
+OpStore %155 %400
+%401 = OpLoad %ulong %155
+%402 = OpBitwiseAnd %ulong %401 %ulong_255
+OpStore %156 %402
+%403 = OpLoad %ulong %160
+%404 = OpLoad %ulong %156
+%405 = OpBitwiseXor %ulong %403 %404
+OpStore %157 %405
+%406 = OpLoad %ulong %157
+%407 = OpIMul %ulong %406 %ulong_1099511628211
+OpStore %158 %407
+%408 = OpLoad %ulong %161
+%409 = OpIAdd %ulong %408 %ulong_1
+OpStore %159 %409
+%410 = OpLoad %ulong %158
+OpStore %160 %410
+%411 = OpLoad %ulong %159
+OpStore %161 %411
+OpBranch %83
+%33 = OpLabel
+%412 = OpLoad %ulong %150
+%413 = OpIMul %ulong %412 %ulong_8
+OpStore %143 %413
+%414 = OpLoad %ulong %141
+%415 = OpLoad %ulong %143
+%416 = OpShiftRightLogical %ulong %414 %415
+OpStore %144 %416
+%417 = OpLoad %ulong %144
+%418 = OpBitwiseAnd %ulong %417 %ulong_255
+OpStore %145 %418
+%419 = OpLoad %ulong %149
+%420 = OpLoad %ulong %145
+%421 = OpBitwiseXor %ulong %419 %420
+OpStore %146 %421
+%422 = OpLoad %ulong %146
+%423 = OpIMul %ulong %422 %ulong_1099511628211
+OpStore %147 %423
+%424 = OpLoad %ulong %150
+%425 = OpIAdd %ulong %424 %ulong_1
+OpStore %148 %425
+%426 = OpLoad %ulong %147
+OpStore %149 %426
+%427 = OpLoad %ulong %148
+OpStore %150 %427
+OpBranch %84
+%26 = OpLabel
+%428 = OpLoad %ulong %140
+%429 = OpIMul %ulong %428 %ulong_8
+OpStore %133 %429
+%430 = OpLoad %ulong %131
+%431 = OpLoad %ulong %133
+%432 = OpShiftRightLogical %ulong %430 %431
+OpStore %134 %432
+%433 = OpLoad %ulong %134
+%434 = OpBitwiseAnd %ulong %433 %ulong_255
+OpStore %135 %434
+%435 = OpLoad %ulong %139
+%436 = OpLoad %ulong %135
+%437 = OpBitwiseXor %ulong %435 %436
+OpStore %136 %437
+%438 = OpLoad %ulong %136
+%439 = OpIMul %ulong %438 %ulong_1099511628211
+OpStore %137 %439
+%440 = OpLoad %ulong %140
+%441 = OpIAdd %ulong %440 %ulong_1
+OpStore %138 %441
+%442 = OpLoad %ulong %137
+OpStore %139 %442
+%443 = OpLoad %ulong %138
+OpStore %140 %443
+OpBranch %85
+%19 = OpLabel
+%444 = OpLoad %ulong %130
+%445 = OpIMul %ulong %444 %ulong_8
+OpStore %123 %445
+%446 = OpLoad %ulong %121
+%447 = OpLoad %ulong %123
+%448 = OpShiftRightLogical %ulong %446 %447
+OpStore %124 %448
+%449 = OpLoad %ulong %124
+%450 = OpBitwiseAnd %ulong %449 %ulong_255
+OpStore %125 %450
+%451 = OpLoad %ulong %129
+%452 = OpLoad %ulong %125
+%453 = OpBitwiseXor %ulong %451 %452
+OpStore %126 %453
+%454 = OpLoad %ulong %126
+%455 = OpIMul %ulong %454 %ulong_1099511628211
+OpStore %127 %455
+%456 = OpLoad %ulong %130
+%457 = OpIAdd %ulong %456 %ulong_1
+OpStore %128 %457
+%458 = OpLoad %ulong %127
+OpStore %129 %458
+%459 = OpLoad %ulong %128
+OpStore %130 %459
+OpBranch %86
+%12 = OpLabel
+%460 = OpLoad %ulong %118
+%461 = OpIMul %ulong %460 %ulong_8
+OpStore %111 %461
+%462 = OpLoad %ulong %108
+%463 = OpLoad %ulong %111
+%464 = OpShiftRightLogical %ulong %462 %463
+OpStore %112 %464
+%465 = OpLoad %ulong %112
+%466 = OpBitwiseAnd %ulong %465 %ulong_255
+OpStore %113 %466
+%467 = OpLoad %ulong %117
+%468 = OpLoad %ulong %113
+%469 = OpBitwiseXor %ulong %467 %468
+OpStore %114 %469
+%470 = OpLoad %ulong %114
+%471 = OpIMul %ulong %470 %ulong_1099511628211
+OpStore %115 %471
+%472 = OpLoad %ulong %118
+%473 = OpIAdd %ulong %472 %ulong_1
+OpStore %116 %473
+%474 = OpLoad %ulong %115
+OpStore %117 %474
+%475 = OpLoad %ulong %116
+OpStore %118 %475
+OpBranch %87
+%78 = OpLabel
+OpBranch %74
+%79 = OpLabel
+OpBranch %67
+%80 = OpLabel
+OpBranch %60
+%81 = OpLabel
+OpBranch %53
+%82 = OpLabel
+OpBranch %46
+%83 = OpLabel
+OpBranch %39
+%84 = OpLabel
+OpBranch %32
+%85 = OpLabel
+OpBranch %25
+%86 = OpLabel
+OpBranch %18
+%87 = OpLabel
+OpBranch %11
 OpFunctionEnd

--- a/test/golden/spirv/convert/f2i.dis
+++ b/test/golden/spirv/convert/f2i.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 822
+; Bound: 1716
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -16,9 +16,10 @@ OpDecorate %3 LinkageAttributes "corpus.cases.convert.f2i.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %double = OpTypeFloat 64
-%16 = OpTypeFunction %ulong %ulong %float %double
+%8 = OpTypeFunction %ulong %ulong %float %double
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
+%bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_float = OpTypePointer Function %float
@@ -26,1128 +27,2543 @@ OpDecorate %3 LinkageAttributes "corpus.cases.convert.f2i.checksum" Export
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
-%210 = OpTypeFunction %ulong %ulong
-%float_40_75 = OpConstant %float 40.75
-%double_40_75 = OpConstant %double 40.75
-%double_n40_75 = OpConstant %double -40.75
-%float_127 = OpConstant %float 127
-%float_255 = OpConstant %float 255
-%double_0_99990000000000001 = OpConstant %double 0.99990000000000001
-%double_n0_99990000000000001 = OpConstant %double -0.99990000000000001
-%464 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%467 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%514 = OpTypeFunction %ulong %ulong %uchar
-%559 = OpTypeFunction %ulong %ulong %ushort
-%604 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %16
-%17 = OpFunctionParameter %ulong
-%18 = OpFunctionParameter %float
-%19 = OpFunctionParameter %double
-%20 = OpLabel
-%25 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_float Function
-%29 = OpVariable %_ptr_Function_double Function
-%31 = OpVariable %_ptr_Function_uchar Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ushort Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_uchar Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ushort Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uint Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uchar Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ushort Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uchar Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ushort Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_uint Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-OpStore %25 %17
-OpStore %27 %18
-OpStore %29 %19
-%65 = OpLoad %float %27
-%66 = OpConvertFToU %uchar %65
-OpStore %31 %66
-%67 = OpLoad %ulong %25
-%68 = OpLoad %uchar %31
-%69 = OpFunctionCall %ulong %6 %67 %68
-OpStore %32 %69
-%70 = OpLoad %float %27
-%71 = OpConvertFToU %ushort %70
-OpStore %34 %71
-%72 = OpLoad %ulong %32
-%73 = OpLoad %ushort %34
-%74 = OpFunctionCall %ulong %7 %72 %73
-OpStore %35 %74
-%75 = OpLoad %float %27
-%76 = OpConvertFToU %uint %75
-OpStore %37 %76
-%77 = OpLoad %ulong %35
-%78 = OpLoad %uint %37
-%79 = OpFunctionCall %ulong %8 %77 %78
-OpStore %38 %79
-%80 = OpLoad %float %27
-%81 = OpConvertFToU %ulong %80
-OpStore %39 %81
-%82 = OpLoad %ulong %38
-%83 = OpLoad %ulong %39
-%84 = OpFunctionCall %ulong %5 %82 %83
-OpStore %40 %84
-%85 = OpLoad %float %27
-%86 = OpConvertFToS %uchar %85
-OpStore %41 %86
-%87 = OpLoad %ulong %40
-%88 = OpLoad %uchar %41
-%89 = OpFunctionCall %ulong %9 %87 %88
-OpStore %42 %89
-%90 = OpLoad %float %27
-%91 = OpConvertFToS %ushort %90
-OpStore %43 %91
-%92 = OpLoad %ulong %42
-%93 = OpLoad %ushort %43
-%94 = OpFunctionCall %ulong %10 %92 %93
-OpStore %44 %94
-%95 = OpLoad %float %27
-%96 = OpConvertFToS %uint %95
-OpStore %45 %96
-%97 = OpLoad %ulong %44
-%98 = OpLoad %uint %45
-%99 = OpFunctionCall %ulong %11 %97 %98
-OpStore %46 %99
-%100 = OpLoad %float %27
-%101 = OpConvertFToS %ulong %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %ulong %47
-%104 = OpFunctionCall %ulong %12 %102 %103
-OpStore %48 %104
-%105 = OpLoad %double %29
-%106 = OpConvertFToU %uchar %105
-OpStore %49 %106
-%107 = OpLoad %ulong %48
-%108 = OpLoad %uchar %49
-%109 = OpFunctionCall %ulong %6 %107 %108
-OpStore %50 %109
-%110 = OpLoad %double %29
-%111 = OpConvertFToU %ushort %110
-OpStore %51 %111
-%112 = OpLoad %ulong %50
-%113 = OpLoad %ushort %51
-%114 = OpFunctionCall %ulong %7 %112 %113
-OpStore %52 %114
-%115 = OpLoad %double %29
-%116 = OpConvertFToU %uint %115
-OpStore %53 %116
-%117 = OpLoad %ulong %52
-%118 = OpLoad %uint %53
-%119 = OpFunctionCall %ulong %8 %117 %118
-OpStore %54 %119
-%120 = OpLoad %double %29
-%121 = OpConvertFToU %ulong %120
-OpStore %55 %121
-%122 = OpLoad %ulong %54
-%123 = OpLoad %ulong %55
-%124 = OpFunctionCall %ulong %5 %122 %123
-OpStore %56 %124
-%125 = OpLoad %double %29
-%126 = OpConvertFToS %uchar %125
-OpStore %57 %126
-%127 = OpLoad %ulong %56
-%128 = OpLoad %uchar %57
-%129 = OpFunctionCall %ulong %9 %127 %128
-OpStore %58 %129
-%130 = OpLoad %double %29
-%131 = OpConvertFToS %ushort %130
-OpStore %59 %131
-%132 = OpLoad %ulong %58
-%133 = OpLoad %ushort %59
-%134 = OpFunctionCall %ulong %10 %132 %133
-OpStore %60 %134
-%135 = OpLoad %double %29
-%136 = OpConvertFToS %uint %135
-OpStore %61 %136
-%137 = OpLoad %ulong %60
-%138 = OpLoad %uint %61
-%139 = OpFunctionCall %ulong %11 %137 %138
-OpStore %62 %139
-%140 = OpLoad %double %29
-%141 = OpConvertFToS %ulong %140
-OpStore %63 %141
-%142 = OpLoad %ulong %62
-%143 = OpLoad %ulong %63
-%144 = OpFunctionCall %ulong %12 %142 %143
-OpStore %64 %144
-%145 = OpLoad %ulong %64
-OpReturnValue %145
-OpFunctionEnd
-%2 = OpFunction %ulong None %16
-%146 = OpFunctionParameter %ulong
-%147 = OpFunctionParameter %float
-%148 = OpFunctionParameter %double
-%149 = OpLabel
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_float Function
-%152 = OpVariable %_ptr_Function_double Function
-%153 = OpVariable %_ptr_Function_uchar Function
-%154 = OpVariable %_ptr_Function_ulong Function
+%803 = OpTypeFunction %ulong %ulong
+%float_40_75 = OpConstant %float 40.75
+%double_40_75 = OpConstant %double 40.75
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%double_n40_75 = OpConstant %double -40.75
+%float_127 = OpConstant %float 127
+%float_255 = OpConstant %float 255
+%double_0_99990000000000001 = OpConstant %double 0.99990000000000001
+%double_n0_99990000000000001 = OpConstant %double -0.99990000000000001
+%1676 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %float
+%11 = OpFunctionParameter %double
+%12 = OpLabel
+%142 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_float Function
+%146 = OpVariable %_ptr_Function_double Function
+%148 = OpVariable %_ptr_Function_uchar Function
+%150 = OpVariable %_ptr_Function_ushort Function
+%152 = OpVariable %_ptr_Function_uint Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_uchar Function
 %155 = OpVariable %_ptr_Function_ushort Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_uint Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_uchar Function
-%162 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_uchar Function
+%159 = OpVariable %_ptr_Function_ushort Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_uchar Function
 %163 = OpVariable %_ptr_Function_ushort Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_uint Function
+%164 = OpVariable %_ptr_Function_uint Function
+%165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-OpStore %150 %146
-OpStore %151 %147
-OpStore %152 %148
-%169 = OpLoad %float %151
-%170 = OpConvertFToS %uchar %169
-OpStore %153 %170
-%171 = OpLoad %ulong %150
-%172 = OpLoad %uchar %153
-%173 = OpFunctionCall %ulong %9 %171 %172
-OpStore %154 %173
-%174 = OpLoad %float %151
-%175 = OpConvertFToS %ushort %174
-OpStore %155 %175
-%176 = OpLoad %ulong %154
-%177 = OpLoad %ushort %155
-%178 = OpFunctionCall %ulong %10 %176 %177
-OpStore %156 %178
-%179 = OpLoad %float %151
-%180 = OpConvertFToS %uint %179
-OpStore %157 %180
-%181 = OpLoad %ulong %156
-%182 = OpLoad %uint %157
-%183 = OpFunctionCall %ulong %11 %181 %182
-OpStore %158 %183
-%184 = OpLoad %float %151
-%185 = OpConvertFToS %ulong %184
-OpStore %159 %185
-%186 = OpLoad %ulong %158
-%187 = OpLoad %ulong %159
-%188 = OpFunctionCall %ulong %12 %186 %187
-OpStore %160 %188
-%189 = OpLoad %double %152
-%190 = OpConvertFToS %uchar %189
-OpStore %161 %190
-%191 = OpLoad %ulong %160
-%192 = OpLoad %uchar %161
-%193 = OpFunctionCall %ulong %9 %191 %192
-OpStore %162 %193
-%194 = OpLoad %double %152
-%195 = OpConvertFToS %ushort %194
-OpStore %163 %195
-%196 = OpLoad %ulong %162
-%197 = OpLoad %ushort %163
-%198 = OpFunctionCall %ulong %10 %196 %197
-OpStore %164 %198
-%199 = OpLoad %double %152
-%200 = OpConvertFToS %uint %199
-OpStore %165 %200
-%201 = OpLoad %ulong %164
-%202 = OpLoad %uint %165
-%203 = OpFunctionCall %ulong %11 %201 %202
-OpStore %166 %203
-%204 = OpLoad %double %152
-%205 = OpConvertFToS %ulong %204
-OpStore %167 %205
-%206 = OpLoad %ulong %166
-%207 = OpLoad %ulong %167
-%208 = OpFunctionCall %ulong %12 %206 %207
-OpStore %168 %208
-%209 = OpLoad %ulong %168
-OpReturnValue %209
-OpFunctionEnd
-%3 = OpFunction %ulong None %210
-%211 = OpFunctionParameter %ulong
-%212 = OpLabel
-%217 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_bool Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_bool Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_bool Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
 %218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_float Function
-%220 = OpVariable %_ptr_Function_double Function
-%221 = OpVariable %_ptr_Function_float Function
-%222 = OpVariable %_ptr_Function_double Function
-%223 = OpVariable %_ptr_Function_float Function
-%224 = OpVariable %_ptr_Function_float Function
-%225 = OpVariable %_ptr_Function_double Function
-%226 = OpVariable %_ptr_Function_float Function
-%227 = OpVariable %_ptr_Function_uchar Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_bool Function
 %228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_float Function
-%230 = OpVariable %_ptr_Function_uchar Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
 %231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_double Function
-%233 = OpVariable %_ptr_Function_uchar Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
 %234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_uchar Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_double Function
-%238 = OpVariable %_ptr_Function_uchar Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
 %239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_uchar Function
+%240 = OpVariable %_ptr_Function_ulong Function
 %241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ushort Function
+%242 = OpVariable %_ptr_Function_ulong Function
 %243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_uint Function
+%244 = OpVariable %_ptr_Function_ulong Function
 %245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_bool Function
 %247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_uchar Function
+%248 = OpVariable %_ptr_Function_ulong Function
 %249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ushort Function
+%250 = OpVariable %_ptr_Function_ulong Function
 %251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_uint Function
+%252 = OpVariable %_ptr_Function_ulong Function
 %253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
 %255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_uchar Function
+%256 = OpVariable %_ptr_Function_bool Function
 %257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ushort Function
+%258 = OpVariable %_ptr_Function_ulong Function
 %259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_uint Function
+%260 = OpVariable %_ptr_Function_ulong Function
 %261 = OpVariable %_ptr_Function_ulong Function
 %262 = OpVariable %_ptr_Function_ulong Function
 %263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_uchar Function
+%264 = OpVariable %_ptr_Function_ulong Function
 %265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ushort Function
+%266 = OpVariable %_ptr_Function_bool Function
 %267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_uint Function
+%268 = OpVariable %_ptr_Function_ulong Function
 %269 = OpVariable %_ptr_Function_ulong Function
 %270 = OpVariable %_ptr_Function_ulong Function
 %271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_uchar Function
+%272 = OpVariable %_ptr_Function_ulong Function
 %273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ushort Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_uint Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
 %277 = OpVariable %_ptr_Function_ulong Function
 %278 = OpVariable %_ptr_Function_ulong Function
 %279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_uchar Function
+%280 = OpVariable %_ptr_Function_ulong Function
 %281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ushort Function
+%282 = OpVariable %_ptr_Function_ulong Function
 %283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_uint Function
-%285 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_bool Function
 %286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
-OpStore %217 %211
-%288 = OpFunctionCall %ulong %4
-OpStore %218 %288
-%289 = OpLoad %ulong %217
-%290 = OpConvertUToF %float %289
-OpStore %219 %290
-%291 = OpLoad %ulong %217
-%292 = OpConvertUToF %double %291
-OpStore %220 %292
-%294 = OpLoad %float %219
-%295 = OpFAdd %float %float_40_75 %294
-OpStore %221 %295
-%297 = OpLoad %double %220
-%298 = OpFAdd %double %double_40_75 %297
-OpStore %222 %298
-OpBranch %213
-%213 = OpLabel
-%299 = OpLoad %float %221
-%300 = OpConvertFToU %uchar %299
-OpStore %240 %300
-%301 = OpLoad %ulong %218
-%302 = OpLoad %uchar %240
-%303 = OpFunctionCall %ulong %6 %301 %302
-OpStore %241 %303
-%304 = OpLoad %float %221
-%305 = OpConvertFToU %ushort %304
-OpStore %242 %305
-%306 = OpLoad %ulong %241
-%307 = OpLoad %ushort %242
-%308 = OpFunctionCall %ulong %7 %306 %307
-OpStore %243 %308
-%309 = OpLoad %float %221
-%310 = OpConvertFToU %uint %309
-OpStore %244 %310
-%311 = OpLoad %ulong %243
-%312 = OpLoad %uint %244
-%313 = OpFunctionCall %ulong %8 %311 %312
-OpStore %245 %313
-%314 = OpLoad %float %221
-%315 = OpConvertFToU %ulong %314
-OpStore %246 %315
-%316 = OpLoad %ulong %245
-%317 = OpLoad %ulong %246
-%318 = OpFunctionCall %ulong %5 %316 %317
-OpStore %247 %318
-%319 = OpLoad %float %221
-%320 = OpConvertFToS %uchar %319
-OpStore %248 %320
-%321 = OpLoad %ulong %247
-%322 = OpLoad %uchar %248
-%323 = OpFunctionCall %ulong %9 %321 %322
-OpStore %249 %323
-%324 = OpLoad %float %221
-%325 = OpConvertFToS %ushort %324
-OpStore %250 %325
-%326 = OpLoad %ulong %249
-%327 = OpLoad %ushort %250
-%328 = OpFunctionCall %ulong %10 %326 %327
-OpStore %251 %328
-%329 = OpLoad %float %221
-%330 = OpConvertFToS %uint %329
-OpStore %252 %330
-%331 = OpLoad %ulong %251
-%332 = OpLoad %uint %252
-%333 = OpFunctionCall %ulong %11 %331 %332
-OpStore %253 %333
-%334 = OpLoad %float %221
-%335 = OpConvertFToS %ulong %334
-OpStore %254 %335
-%336 = OpLoad %ulong %253
-%337 = OpLoad %ulong %254
-%338 = OpFunctionCall %ulong %12 %336 %337
-OpStore %255 %338
-%339 = OpLoad %double %222
-%340 = OpConvertFToU %uchar %339
-OpStore %256 %340
-%341 = OpLoad %ulong %255
-%342 = OpLoad %uchar %256
-%343 = OpFunctionCall %ulong %6 %341 %342
-OpStore %257 %343
-%344 = OpLoad %double %222
-%345 = OpConvertFToU %ushort %344
-OpStore %258 %345
-%346 = OpLoad %ulong %257
-%347 = OpLoad %ushort %258
-%348 = OpFunctionCall %ulong %7 %346 %347
-OpStore %259 %348
-%349 = OpLoad %double %222
-%350 = OpConvertFToU %uint %349
-OpStore %260 %350
-%351 = OpLoad %ulong %259
-%352 = OpLoad %uint %260
-%353 = OpFunctionCall %ulong %8 %351 %352
-OpStore %261 %353
-%354 = OpLoad %double %222
-%355 = OpConvertFToU %ulong %354
-OpStore %262 %355
-%356 = OpLoad %ulong %261
-%357 = OpLoad %ulong %262
-%358 = OpFunctionCall %ulong %5 %356 %357
-OpStore %263 %358
-%359 = OpLoad %double %222
-%360 = OpConvertFToS %uchar %359
-OpStore %264 %360
-%361 = OpLoad %ulong %263
-%362 = OpLoad %uchar %264
-%363 = OpFunctionCall %ulong %9 %361 %362
-OpStore %265 %363
-%364 = OpLoad %double %222
-%365 = OpConvertFToS %ushort %364
-OpStore %266 %365
-%366 = OpLoad %ulong %265
-%367 = OpLoad %ushort %266
-%368 = OpFunctionCall %ulong %10 %366 %367
-OpStore %267 %368
-%369 = OpLoad %double %222
-%370 = OpConvertFToS %uint %369
-OpStore %268 %370
-%371 = OpLoad %ulong %267
-%372 = OpLoad %uint %268
-%373 = OpFunctionCall %ulong %11 %371 %372
-OpStore %269 %373
-%374 = OpLoad %double %222
-%375 = OpConvertFToS %ulong %374
-OpStore %270 %375
-%376 = OpLoad %ulong %269
-%377 = OpLoad %ulong %270
-%378 = OpFunctionCall %ulong %12 %376 %377
-OpStore %271 %378
-OpBranch %214
-%214 = OpLabel
-%379 = OpFNegate %float %float_40_75
-OpStore %223 %379
-%380 = OpLoad %float %223
-%381 = OpLoad %float %219
-%382 = OpFSub %float %380 %381
-OpStore %224 %382
-%384 = OpLoad %double %220
-%385 = OpFSub %double %double_n40_75 %384
-OpStore %225 %385
-OpBranch %215
-%215 = OpLabel
-%386 = OpLoad %float %224
-%387 = OpConvertFToS %uchar %386
-OpStore %272 %387
-%388 = OpLoad %ulong %271
-%389 = OpLoad %uchar %272
-%390 = OpFunctionCall %ulong %9 %388 %389
-OpStore %273 %390
-%391 = OpLoad %float %224
-%392 = OpConvertFToS %ushort %391
-OpStore %274 %392
-%393 = OpLoad %ulong %273
-%394 = OpLoad %ushort %274
-%395 = OpFunctionCall %ulong %10 %393 %394
-OpStore %275 %395
-%396 = OpLoad %float %224
-%397 = OpConvertFToS %uint %396
-OpStore %276 %397
-%398 = OpLoad %ulong %275
-%399 = OpLoad %uint %276
-%400 = OpFunctionCall %ulong %11 %398 %399
-OpStore %277 %400
-%401 = OpLoad %float %224
-%402 = OpConvertFToS %ulong %401
-OpStore %278 %402
-%403 = OpLoad %ulong %277
-%404 = OpLoad %ulong %278
-%405 = OpFunctionCall %ulong %12 %403 %404
-OpStore %279 %405
-%406 = OpLoad %double %225
-%407 = OpConvertFToS %uchar %406
-OpStore %280 %407
-%408 = OpLoad %ulong %279
-%409 = OpLoad %uchar %280
-%410 = OpFunctionCall %ulong %9 %408 %409
-OpStore %281 %410
-%411 = OpLoad %double %225
-%412 = OpConvertFToS %ushort %411
-OpStore %282 %412
-%413 = OpLoad %ulong %281
-%414 = OpLoad %ushort %282
-%415 = OpFunctionCall %ulong %10 %413 %414
-OpStore %283 %415
-%416 = OpLoad %double %225
-%417 = OpConvertFToS %uint %416
-OpStore %284 %417
-%418 = OpLoad %ulong %283
-%419 = OpLoad %uint %284
-%420 = OpFunctionCall %ulong %11 %418 %419
-OpStore %285 %420
-%421 = OpLoad %double %225
-%422 = OpConvertFToS %ulong %421
-OpStore %286 %422
-%423 = OpLoad %ulong %285
-%424 = OpLoad %ulong %286
-%425 = OpFunctionCall %ulong %12 %423 %424
-OpStore %287 %425
-OpBranch %216
-%216 = OpLabel
-%427 = OpLoad %float %219
-%428 = OpFAdd %float %float_127 %427
-OpStore %226 %428
-%429 = OpLoad %float %226
-%430 = OpConvertFToS %uchar %429
-OpStore %227 %430
-%431 = OpLoad %ulong %287
-%432 = OpLoad %uchar %227
-%433 = OpFunctionCall %ulong %9 %431 %432
-OpStore %228 %433
-%435 = OpLoad %float %219
-%436 = OpFAdd %float %float_255 %435
-OpStore %229 %436
-%437 = OpLoad %float %229
-%438 = OpConvertFToU %uchar %437
-OpStore %230 %438
-%439 = OpLoad %ulong %228
-%440 = OpLoad %uchar %230
-%441 = OpFunctionCall %ulong %6 %439 %440
-OpStore %231 %441
-%443 = OpLoad %double %220
-%444 = OpFAdd %double %double_0_99990000000000001 %443
-OpStore %232 %444
-%445 = OpLoad %double %232
-%446 = OpConvertFToU %uchar %445
-OpStore %233 %446
-%447 = OpLoad %ulong %231
-%448 = OpLoad %uchar %233
-%449 = OpFunctionCall %ulong %6 %447 %448
-OpStore %234 %449
-%450 = OpLoad %double %232
-%451 = OpConvertFToS %uchar %450
-OpStore %235 %451
-%452 = OpLoad %ulong %234
-%453 = OpLoad %uchar %235
-%454 = OpFunctionCall %ulong %9 %452 %453
-OpStore %236 %454
-%456 = OpLoad %double %220
-%457 = OpFSub %double %double_n0_99990000000000001 %456
-OpStore %237 %457
-%458 = OpLoad %double %237
-%459 = OpConvertFToS %uchar %458
-OpStore %238 %459
-%460 = OpLoad %ulong %236
-%461 = OpLoad %uchar %238
-%462 = OpFunctionCall %ulong %9 %460 %461
-OpStore %239 %462
-%463 = OpLoad %ulong %239
-OpReturnValue %463
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_bool Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_bool Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+OpStore %142 %9
+OpStore %144 %10
+OpStore %146 %11
+%323 = OpLoad %float %144
+%324 = OpConvertFToU %uchar %323
+OpStore %148 %324
+OpBranch %13
+%13 = OpLabel
+%325 = OpLoad %uchar %148
+%326 = OpUConvert %ulong %325
+OpStore %166 %326
+OpBranch %15
+%15 = OpLabel
+%327 = OpLoad %ulong %142
+OpStore %175 %327
+OpStore %176 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%329 = OpLoad %ulong %176
+%331 = OpULessThan %bool %329 %ulong_8
+OpStore %168 %331
+%332 = OpLoad %bool %168
+OpLoopMerge %18 %136 None
+OpBranchConditional %332 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%333 = OpLoad %float %144
+%334 = OpConvertFToU %ushort %333
+OpStore %150 %334
+OpBranch %20
+%20 = OpLabel
+%335 = OpLoad %ushort %150
+%336 = OpUConvert %ulong %335
+OpStore %177 %336
+OpBranch %22
+%22 = OpLabel
+%337 = OpLoad %ulong %175
+OpStore %185 %337
+OpStore %186 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%338 = OpLoad %ulong %186
+%339 = OpULessThan %bool %338 %ulong_8
+OpStore %178 %339
+%340 = OpLoad %bool %178
+OpLoopMerge %25 %135 None
+OpBranchConditional %340 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%341 = OpLoad %float %144
+%342 = OpConvertFToU %uint %341
+OpStore %152 %342
+OpBranch %27
+%27 = OpLabel
+%343 = OpLoad %uint %152
+%344 = OpUConvert %ulong %343
+OpStore %187 %344
+OpBranch %29
+%29 = OpLabel
+%345 = OpLoad %ulong %185
+OpStore %195 %345
+OpStore %196 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%346 = OpLoad %ulong %196
+%347 = OpULessThan %bool %346 %ulong_8
+OpStore %188 %347
+%348 = OpLoad %bool %188
+OpLoopMerge %32 %134 None
+OpBranchConditional %348 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%349 = OpLoad %float %144
+%350 = OpConvertFToU %ulong %349
+OpStore %153 %350
+OpBranch %34
+%34 = OpLabel
+%351 = OpLoad %ulong %195
+OpStore %204 %351
+OpStore %205 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%352 = OpLoad %ulong %205
+%353 = OpULessThan %bool %352 %ulong_8
+OpStore %197 %353
+%354 = OpLoad %bool %197
+OpLoopMerge %37 %133 None
+OpBranchConditional %354 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%355 = OpLoad %float %144
+%356 = OpConvertFToS %uchar %355
+OpStore %154 %356
+OpBranch %39
+%39 = OpLabel
+%357 = OpLoad %uchar %154
+%358 = OpSConvert %ulong %357
+OpStore %206 %358
+OpBranch %41
+%41 = OpLabel
+%359 = OpLoad %ulong %204
+OpStore %214 %359
+OpStore %215 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%360 = OpLoad %ulong %215
+%361 = OpULessThan %bool %360 %ulong_8
+OpStore %207 %361
+%362 = OpLoad %bool %207
+OpLoopMerge %44 %132 None
+OpBranchConditional %362 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%363 = OpLoad %float %144
+%364 = OpConvertFToS %ushort %363
+OpStore %155 %364
+OpBranch %46
+%46 = OpLabel
+%365 = OpLoad %ushort %155
+%366 = OpSConvert %ulong %365
+OpStore %216 %366
+OpBranch %48
+%48 = OpLabel
+%367 = OpLoad %ulong %214
+OpStore %224 %367
+OpStore %225 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%368 = OpLoad %ulong %225
+%369 = OpULessThan %bool %368 %ulong_8
+OpStore %217 %369
+%370 = OpLoad %bool %217
+OpLoopMerge %51 %131 None
+OpBranchConditional %370 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%371 = OpLoad %float %144
+%372 = OpConvertFToS %uint %371
+OpStore %156 %372
+OpBranch %53
+%53 = OpLabel
+%373 = OpLoad %uint %156
+%374 = OpSConvert %ulong %373
+OpStore %226 %374
+OpBranch %55
+%55 = OpLabel
+%375 = OpLoad %ulong %224
+OpStore %234 %375
+OpStore %235 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%376 = OpLoad %ulong %235
+%377 = OpULessThan %bool %376 %ulong_8
+OpStore %227 %377
+%378 = OpLoad %bool %227
+OpLoopMerge %58 %130 None
+OpBranchConditional %378 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%379 = OpLoad %float %144
+%380 = OpConvertFToS %ulong %379
+OpStore %157 %380
+OpBranch %60
+%60 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%381 = OpLoad %ulong %234
+OpStore %243 %381
+OpStore %244 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%382 = OpLoad %ulong %244
+%383 = OpULessThan %bool %382 %ulong_8
+OpStore %236 %383
+%384 = OpLoad %bool %236
+OpLoopMerge %65 %129 None
+OpBranchConditional %384 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%385 = OpLoad %double %146
+%386 = OpConvertFToU %uchar %385
+OpStore %158 %386
+OpBranch %67
+%67 = OpLabel
+%387 = OpLoad %uchar %158
+%388 = OpUConvert %ulong %387
+OpStore %245 %388
+OpBranch %69
+%69 = OpLabel
+%389 = OpLoad %ulong %243
+OpStore %253 %389
+OpStore %254 %ulong_0
+OpBranch %70
+%70 = OpLabel
+%390 = OpLoad %ulong %254
+%391 = OpULessThan %bool %390 %ulong_8
+OpStore %246 %391
+%392 = OpLoad %bool %246
+OpLoopMerge %72 %128 None
+OpBranchConditional %392 %71 %72
+%72 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%393 = OpLoad %double %146
+%394 = OpConvertFToU %ushort %393
+OpStore %159 %394
+OpBranch %74
+%74 = OpLabel
+%395 = OpLoad %ushort %159
+%396 = OpUConvert %ulong %395
+OpStore %255 %396
+OpBranch %76
+%76 = OpLabel
+%397 = OpLoad %ulong %253
+OpStore %263 %397
+OpStore %264 %ulong_0
+OpBranch %77
+%77 = OpLabel
+%398 = OpLoad %ulong %264
+%399 = OpULessThan %bool %398 %ulong_8
+OpStore %256 %399
+%400 = OpLoad %bool %256
+OpLoopMerge %79 %127 None
+OpBranchConditional %400 %78 %79
+%79 = OpLabel
+OpBranch %80
+%80 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%401 = OpLoad %double %146
+%402 = OpConvertFToU %uint %401
+OpStore %160 %402
+OpBranch %81
+%81 = OpLabel
+%403 = OpLoad %uint %160
+%404 = OpUConvert %ulong %403
+OpStore %265 %404
+OpBranch %83
+%83 = OpLabel
+%405 = OpLoad %ulong %263
+OpStore %273 %405
+OpStore %274 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%406 = OpLoad %ulong %274
+%407 = OpULessThan %bool %406 %ulong_8
+OpStore %266 %407
+%408 = OpLoad %bool %266
+OpLoopMerge %86 %126 None
+OpBranchConditional %408 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+OpBranch %82
+%82 = OpLabel
+%409 = OpLoad %double %146
+%410 = OpConvertFToU %ulong %409
+OpStore %161 %410
+OpBranch %88
+%88 = OpLabel
+%411 = OpLoad %ulong %273
+OpStore %282 %411
+OpStore %283 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%412 = OpLoad %ulong %283
+%413 = OpULessThan %bool %412 %ulong_8
+OpStore %275 %413
+%414 = OpLoad %bool %275
+OpLoopMerge %91 %125 None
+OpBranchConditional %414 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%415 = OpLoad %double %146
+%416 = OpConvertFToS %uchar %415
+OpStore %162 %416
+OpBranch %93
+%93 = OpLabel
+%417 = OpLoad %uchar %162
+%418 = OpSConvert %ulong %417
+OpStore %284 %418
+OpBranch %95
+%95 = OpLabel
+%419 = OpLoad %ulong %282
+OpStore %292 %419
+OpStore %293 %ulong_0
+OpBranch %96
+%96 = OpLabel
+%420 = OpLoad %ulong %293
+%421 = OpULessThan %bool %420 %ulong_8
+OpStore %285 %421
+%422 = OpLoad %bool %285
+OpLoopMerge %98 %124 None
+OpBranchConditional %422 %97 %98
+%98 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%423 = OpLoad %double %146
+%424 = OpConvertFToS %ushort %423
+OpStore %163 %424
+OpBranch %100
+%100 = OpLabel
+%425 = OpLoad %ushort %163
+%426 = OpSConvert %ulong %425
+OpStore %294 %426
+OpBranch %102
+%102 = OpLabel
+%427 = OpLoad %ulong %292
+OpStore %302 %427
+OpStore %303 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%428 = OpLoad %ulong %303
+%429 = OpULessThan %bool %428 %ulong_8
+OpStore %295 %429
+%430 = OpLoad %bool %295
+OpLoopMerge %105 %123 None
+OpBranchConditional %430 %104 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%431 = OpLoad %double %146
+%432 = OpConvertFToS %uint %431
+OpStore %164 %432
+OpBranch %107
+%107 = OpLabel
+%433 = OpLoad %uint %164
+%434 = OpSConvert %ulong %433
+OpStore %304 %434
+OpBranch %109
+%109 = OpLabel
+%435 = OpLoad %ulong %302
+OpStore %312 %435
+OpStore %313 %ulong_0
+OpBranch %110
+%110 = OpLabel
+%436 = OpLoad %ulong %313
+%437 = OpULessThan %bool %436 %ulong_8
+OpStore %305 %437
+%438 = OpLoad %bool %305
+OpLoopMerge %112 %122 None
+OpBranchConditional %438 %111 %112
+%112 = OpLabel
+OpBranch %113
+%113 = OpLabel
+OpBranch %108
+%108 = OpLabel
+%439 = OpLoad %double %146
+%440 = OpConvertFToS %ulong %439
+OpStore %165 %440
+OpBranch %114
+%114 = OpLabel
+OpBranch %116
+%116 = OpLabel
+%441 = OpLoad %ulong %312
+OpStore %321 %441
+OpStore %322 %ulong_0
+OpBranch %117
+%117 = OpLabel
+%442 = OpLoad %ulong %322
+%443 = OpULessThan %bool %442 %ulong_8
+OpStore %314 %443
+%444 = OpLoad %bool %314
+OpLoopMerge %119 %121 None
+OpBranchConditional %444 %118 %119
+%119 = OpLabel
+OpBranch %120
+%120 = OpLabel
+OpBranch %115
+%115 = OpLabel
+%445 = OpLoad %ulong %321
+OpReturnValue %445
+%118 = OpLabel
+%446 = OpLoad %ulong %322
+%447 = OpIMul %ulong %446 %ulong_8
+OpStore %315 %447
+%448 = OpLoad %ulong %165
+%449 = OpLoad %ulong %315
+%450 = OpShiftRightLogical %ulong %448 %449
+OpStore %316 %450
+%451 = OpLoad %ulong %316
+%453 = OpBitwiseAnd %ulong %451 %ulong_255
+OpStore %317 %453
+%454 = OpLoad %ulong %321
+%455 = OpLoad %ulong %317
+%456 = OpBitwiseXor %ulong %454 %455
+OpStore %318 %456
+%457 = OpLoad %ulong %318
+%459 = OpIMul %ulong %457 %ulong_1099511628211
+OpStore %319 %459
+%460 = OpLoad %ulong %322
+%462 = OpIAdd %ulong %460 %ulong_1
+OpStore %320 %462
+%463 = OpLoad %ulong %319
+OpStore %321 %463
+%464 = OpLoad %ulong %320
+OpStore %322 %464
+OpBranch %121
+%111 = OpLabel
+%465 = OpLoad %ulong %313
+%466 = OpIMul %ulong %465 %ulong_8
+OpStore %306 %466
+%467 = OpLoad %ulong %304
+%468 = OpLoad %ulong %306
+%469 = OpShiftRightLogical %ulong %467 %468
+OpStore %307 %469
+%470 = OpLoad %ulong %307
+%471 = OpBitwiseAnd %ulong %470 %ulong_255
+OpStore %308 %471
+%472 = OpLoad %ulong %312
+%473 = OpLoad %ulong %308
+%474 = OpBitwiseXor %ulong %472 %473
+OpStore %309 %474
+%475 = OpLoad %ulong %309
+%476 = OpIMul %ulong %475 %ulong_1099511628211
+OpStore %310 %476
+%477 = OpLoad %ulong %313
+%478 = OpIAdd %ulong %477 %ulong_1
+OpStore %311 %478
+%479 = OpLoad %ulong %310
+OpStore %312 %479
+%480 = OpLoad %ulong %311
+OpStore %313 %480
+OpBranch %122
+%104 = OpLabel
+%481 = OpLoad %ulong %303
+%482 = OpIMul %ulong %481 %ulong_8
+OpStore %296 %482
+%483 = OpLoad %ulong %294
+%484 = OpLoad %ulong %296
+%485 = OpShiftRightLogical %ulong %483 %484
+OpStore %297 %485
+%486 = OpLoad %ulong %297
+%487 = OpBitwiseAnd %ulong %486 %ulong_255
+OpStore %298 %487
+%488 = OpLoad %ulong %302
+%489 = OpLoad %ulong %298
+%490 = OpBitwiseXor %ulong %488 %489
+OpStore %299 %490
+%491 = OpLoad %ulong %299
+%492 = OpIMul %ulong %491 %ulong_1099511628211
+OpStore %300 %492
+%493 = OpLoad %ulong %303
+%494 = OpIAdd %ulong %493 %ulong_1
+OpStore %301 %494
+%495 = OpLoad %ulong %300
+OpStore %302 %495
+%496 = OpLoad %ulong %301
+OpStore %303 %496
+OpBranch %123
+%97 = OpLabel
+%497 = OpLoad %ulong %293
+%498 = OpIMul %ulong %497 %ulong_8
+OpStore %286 %498
+%499 = OpLoad %ulong %284
+%500 = OpLoad %ulong %286
+%501 = OpShiftRightLogical %ulong %499 %500
+OpStore %287 %501
+%502 = OpLoad %ulong %287
+%503 = OpBitwiseAnd %ulong %502 %ulong_255
+OpStore %288 %503
+%504 = OpLoad %ulong %292
+%505 = OpLoad %ulong %288
+%506 = OpBitwiseXor %ulong %504 %505
+OpStore %289 %506
+%507 = OpLoad %ulong %289
+%508 = OpIMul %ulong %507 %ulong_1099511628211
+OpStore %290 %508
+%509 = OpLoad %ulong %293
+%510 = OpIAdd %ulong %509 %ulong_1
+OpStore %291 %510
+%511 = OpLoad %ulong %290
+OpStore %292 %511
+%512 = OpLoad %ulong %291
+OpStore %293 %512
+OpBranch %124
+%90 = OpLabel
+%513 = OpLoad %ulong %283
+%514 = OpIMul %ulong %513 %ulong_8
+OpStore %276 %514
+%515 = OpLoad %ulong %161
+%516 = OpLoad %ulong %276
+%517 = OpShiftRightLogical %ulong %515 %516
+OpStore %277 %517
+%518 = OpLoad %ulong %277
+%519 = OpBitwiseAnd %ulong %518 %ulong_255
+OpStore %278 %519
+%520 = OpLoad %ulong %282
+%521 = OpLoad %ulong %278
+%522 = OpBitwiseXor %ulong %520 %521
+OpStore %279 %522
+%523 = OpLoad %ulong %279
+%524 = OpIMul %ulong %523 %ulong_1099511628211
+OpStore %280 %524
+%525 = OpLoad %ulong %283
+%526 = OpIAdd %ulong %525 %ulong_1
+OpStore %281 %526
+%527 = OpLoad %ulong %280
+OpStore %282 %527
+%528 = OpLoad %ulong %281
+OpStore %283 %528
+OpBranch %125
+%85 = OpLabel
+%529 = OpLoad %ulong %274
+%530 = OpIMul %ulong %529 %ulong_8
+OpStore %267 %530
+%531 = OpLoad %ulong %265
+%532 = OpLoad %ulong %267
+%533 = OpShiftRightLogical %ulong %531 %532
+OpStore %268 %533
+%534 = OpLoad %ulong %268
+%535 = OpBitwiseAnd %ulong %534 %ulong_255
+OpStore %269 %535
+%536 = OpLoad %ulong %273
+%537 = OpLoad %ulong %269
+%538 = OpBitwiseXor %ulong %536 %537
+OpStore %270 %538
+%539 = OpLoad %ulong %270
+%540 = OpIMul %ulong %539 %ulong_1099511628211
+OpStore %271 %540
+%541 = OpLoad %ulong %274
+%542 = OpIAdd %ulong %541 %ulong_1
+OpStore %272 %542
+%543 = OpLoad %ulong %271
+OpStore %273 %543
+%544 = OpLoad %ulong %272
+OpStore %274 %544
+OpBranch %126
+%78 = OpLabel
+%545 = OpLoad %ulong %264
+%546 = OpIMul %ulong %545 %ulong_8
+OpStore %257 %546
+%547 = OpLoad %ulong %255
+%548 = OpLoad %ulong %257
+%549 = OpShiftRightLogical %ulong %547 %548
+OpStore %258 %549
+%550 = OpLoad %ulong %258
+%551 = OpBitwiseAnd %ulong %550 %ulong_255
+OpStore %259 %551
+%552 = OpLoad %ulong %263
+%553 = OpLoad %ulong %259
+%554 = OpBitwiseXor %ulong %552 %553
+OpStore %260 %554
+%555 = OpLoad %ulong %260
+%556 = OpIMul %ulong %555 %ulong_1099511628211
+OpStore %261 %556
+%557 = OpLoad %ulong %264
+%558 = OpIAdd %ulong %557 %ulong_1
+OpStore %262 %558
+%559 = OpLoad %ulong %261
+OpStore %263 %559
+%560 = OpLoad %ulong %262
+OpStore %264 %560
+OpBranch %127
+%71 = OpLabel
+%561 = OpLoad %ulong %254
+%562 = OpIMul %ulong %561 %ulong_8
+OpStore %247 %562
+%563 = OpLoad %ulong %245
+%564 = OpLoad %ulong %247
+%565 = OpShiftRightLogical %ulong %563 %564
+OpStore %248 %565
+%566 = OpLoad %ulong %248
+%567 = OpBitwiseAnd %ulong %566 %ulong_255
+OpStore %249 %567
+%568 = OpLoad %ulong %253
+%569 = OpLoad %ulong %249
+%570 = OpBitwiseXor %ulong %568 %569
+OpStore %250 %570
+%571 = OpLoad %ulong %250
+%572 = OpIMul %ulong %571 %ulong_1099511628211
+OpStore %251 %572
+%573 = OpLoad %ulong %254
+%574 = OpIAdd %ulong %573 %ulong_1
+OpStore %252 %574
+%575 = OpLoad %ulong %251
+OpStore %253 %575
+%576 = OpLoad %ulong %252
+OpStore %254 %576
+OpBranch %128
+%64 = OpLabel
+%577 = OpLoad %ulong %244
+%578 = OpIMul %ulong %577 %ulong_8
+OpStore %237 %578
+%579 = OpLoad %ulong %157
+%580 = OpLoad %ulong %237
+%581 = OpShiftRightLogical %ulong %579 %580
+OpStore %238 %581
+%582 = OpLoad %ulong %238
+%583 = OpBitwiseAnd %ulong %582 %ulong_255
+OpStore %239 %583
+%584 = OpLoad %ulong %243
+%585 = OpLoad %ulong %239
+%586 = OpBitwiseXor %ulong %584 %585
+OpStore %240 %586
+%587 = OpLoad %ulong %240
+%588 = OpIMul %ulong %587 %ulong_1099511628211
+OpStore %241 %588
+%589 = OpLoad %ulong %244
+%590 = OpIAdd %ulong %589 %ulong_1
+OpStore %242 %590
+%591 = OpLoad %ulong %241
+OpStore %243 %591
+%592 = OpLoad %ulong %242
+OpStore %244 %592
+OpBranch %129
+%57 = OpLabel
+%593 = OpLoad %ulong %235
+%594 = OpIMul %ulong %593 %ulong_8
+OpStore %228 %594
+%595 = OpLoad %ulong %226
+%596 = OpLoad %ulong %228
+%597 = OpShiftRightLogical %ulong %595 %596
+OpStore %229 %597
+%598 = OpLoad %ulong %229
+%599 = OpBitwiseAnd %ulong %598 %ulong_255
+OpStore %230 %599
+%600 = OpLoad %ulong %234
+%601 = OpLoad %ulong %230
+%602 = OpBitwiseXor %ulong %600 %601
+OpStore %231 %602
+%603 = OpLoad %ulong %231
+%604 = OpIMul %ulong %603 %ulong_1099511628211
+OpStore %232 %604
+%605 = OpLoad %ulong %235
+%606 = OpIAdd %ulong %605 %ulong_1
+OpStore %233 %606
+%607 = OpLoad %ulong %232
+OpStore %234 %607
+%608 = OpLoad %ulong %233
+OpStore %235 %608
+OpBranch %130
+%50 = OpLabel
+%609 = OpLoad %ulong %225
+%610 = OpIMul %ulong %609 %ulong_8
+OpStore %218 %610
+%611 = OpLoad %ulong %216
+%612 = OpLoad %ulong %218
+%613 = OpShiftRightLogical %ulong %611 %612
+OpStore %219 %613
+%614 = OpLoad %ulong %219
+%615 = OpBitwiseAnd %ulong %614 %ulong_255
+OpStore %220 %615
+%616 = OpLoad %ulong %224
+%617 = OpLoad %ulong %220
+%618 = OpBitwiseXor %ulong %616 %617
+OpStore %221 %618
+%619 = OpLoad %ulong %221
+%620 = OpIMul %ulong %619 %ulong_1099511628211
+OpStore %222 %620
+%621 = OpLoad %ulong %225
+%622 = OpIAdd %ulong %621 %ulong_1
+OpStore %223 %622
+%623 = OpLoad %ulong %222
+OpStore %224 %623
+%624 = OpLoad %ulong %223
+OpStore %225 %624
+OpBranch %131
+%43 = OpLabel
+%625 = OpLoad %ulong %215
+%626 = OpIMul %ulong %625 %ulong_8
+OpStore %208 %626
+%627 = OpLoad %ulong %206
+%628 = OpLoad %ulong %208
+%629 = OpShiftRightLogical %ulong %627 %628
+OpStore %209 %629
+%630 = OpLoad %ulong %209
+%631 = OpBitwiseAnd %ulong %630 %ulong_255
+OpStore %210 %631
+%632 = OpLoad %ulong %214
+%633 = OpLoad %ulong %210
+%634 = OpBitwiseXor %ulong %632 %633
+OpStore %211 %634
+%635 = OpLoad %ulong %211
+%636 = OpIMul %ulong %635 %ulong_1099511628211
+OpStore %212 %636
+%637 = OpLoad %ulong %215
+%638 = OpIAdd %ulong %637 %ulong_1
+OpStore %213 %638
+%639 = OpLoad %ulong %212
+OpStore %214 %639
+%640 = OpLoad %ulong %213
+OpStore %215 %640
+OpBranch %132
+%36 = OpLabel
+%641 = OpLoad %ulong %205
+%642 = OpIMul %ulong %641 %ulong_8
+OpStore %198 %642
+%643 = OpLoad %ulong %153
+%644 = OpLoad %ulong %198
+%645 = OpShiftRightLogical %ulong %643 %644
+OpStore %199 %645
+%646 = OpLoad %ulong %199
+%647 = OpBitwiseAnd %ulong %646 %ulong_255
+OpStore %200 %647
+%648 = OpLoad %ulong %204
+%649 = OpLoad %ulong %200
+%650 = OpBitwiseXor %ulong %648 %649
+OpStore %201 %650
+%651 = OpLoad %ulong %201
+%652 = OpIMul %ulong %651 %ulong_1099511628211
+OpStore %202 %652
+%653 = OpLoad %ulong %205
+%654 = OpIAdd %ulong %653 %ulong_1
+OpStore %203 %654
+%655 = OpLoad %ulong %202
+OpStore %204 %655
+%656 = OpLoad %ulong %203
+OpStore %205 %656
+OpBranch %133
+%31 = OpLabel
+%657 = OpLoad %ulong %196
+%658 = OpIMul %ulong %657 %ulong_8
+OpStore %189 %658
+%659 = OpLoad %ulong %187
+%660 = OpLoad %ulong %189
+%661 = OpShiftRightLogical %ulong %659 %660
+OpStore %190 %661
+%662 = OpLoad %ulong %190
+%663 = OpBitwiseAnd %ulong %662 %ulong_255
+OpStore %191 %663
+%664 = OpLoad %ulong %195
+%665 = OpLoad %ulong %191
+%666 = OpBitwiseXor %ulong %664 %665
+OpStore %192 %666
+%667 = OpLoad %ulong %192
+%668 = OpIMul %ulong %667 %ulong_1099511628211
+OpStore %193 %668
+%669 = OpLoad %ulong %196
+%670 = OpIAdd %ulong %669 %ulong_1
+OpStore %194 %670
+%671 = OpLoad %ulong %193
+OpStore %195 %671
+%672 = OpLoad %ulong %194
+OpStore %196 %672
+OpBranch %134
+%24 = OpLabel
+%673 = OpLoad %ulong %186
+%674 = OpIMul %ulong %673 %ulong_8
+OpStore %179 %674
+%675 = OpLoad %ulong %177
+%676 = OpLoad %ulong %179
+%677 = OpShiftRightLogical %ulong %675 %676
+OpStore %180 %677
+%678 = OpLoad %ulong %180
+%679 = OpBitwiseAnd %ulong %678 %ulong_255
+OpStore %181 %679
+%680 = OpLoad %ulong %185
+%681 = OpLoad %ulong %181
+%682 = OpBitwiseXor %ulong %680 %681
+OpStore %182 %682
+%683 = OpLoad %ulong %182
+%684 = OpIMul %ulong %683 %ulong_1099511628211
+OpStore %183 %684
+%685 = OpLoad %ulong %186
+%686 = OpIAdd %ulong %685 %ulong_1
+OpStore %184 %686
+%687 = OpLoad %ulong %183
+OpStore %185 %687
+%688 = OpLoad %ulong %184
+OpStore %186 %688
+OpBranch %135
+%17 = OpLabel
+%689 = OpLoad %ulong %176
+%690 = OpIMul %ulong %689 %ulong_8
+OpStore %169 %690
+%691 = OpLoad %ulong %166
+%692 = OpLoad %ulong %169
+%693 = OpShiftRightLogical %ulong %691 %692
+OpStore %170 %693
+%694 = OpLoad %ulong %170
+%695 = OpBitwiseAnd %ulong %694 %ulong_255
+OpStore %171 %695
+%696 = OpLoad %ulong %175
+%697 = OpLoad %ulong %171
+%698 = OpBitwiseXor %ulong %696 %697
+OpStore %172 %698
+%699 = OpLoad %ulong %172
+%700 = OpIMul %ulong %699 %ulong_1099511628211
+OpStore %173 %700
+%701 = OpLoad %ulong %176
+%702 = OpIAdd %ulong %701 %ulong_1
+OpStore %174 %702
+%703 = OpLoad %ulong %173
+OpStore %175 %703
+%704 = OpLoad %ulong %174
+OpStore %176 %704
+OpBranch %136
+%121 = OpLabel
+OpBranch %117
+%122 = OpLabel
+OpBranch %110
+%123 = OpLabel
+OpBranch %103
+%124 = OpLabel
+OpBranch %96
+%125 = OpLabel
+OpBranch %89
+%126 = OpLabel
+OpBranch %84
+%127 = OpLabel
+OpBranch %77
+%128 = OpLabel
+OpBranch %70
+%129 = OpLabel
+OpBranch %63
+%130 = OpLabel
+OpBranch %56
+%131 = OpLabel
+OpBranch %49
+%132 = OpLabel
+OpBranch %42
+%133 = OpLabel
+OpBranch %35
+%134 = OpLabel
+OpBranch %30
+%135 = OpLabel
+OpBranch %23
+%136 = OpLabel
+OpBranch %16
 OpFunctionEnd
-%4 = OpFunction %ulong None %464
-%465 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %467
-%468 = OpFunctionParameter %ulong
-%469 = OpFunctionParameter %ulong
-%470 = OpLabel
-%476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_bool Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_ulong Function
-OpStore %476 %468
-OpStore %477 %469
-%488 = OpLoad %ulong %476
-OpStore %486 %488
-OpStore %487 %ulong_0
-OpBranch %471
-%471 = OpLabel
-%490 = OpLoad %ulong %487
-%492 = OpULessThan %bool %490 %ulong_8
-OpStore %479 %492
-%493 = OpLoad %bool %479
-OpLoopMerge %473 %474 None
-OpBranchConditional %493 %472 %473
-%473 = OpLabel
-%494 = OpLoad %ulong %486
-OpReturnValue %494
-%472 = OpLabel
-%495 = OpLoad %ulong %487
-%496 = OpIMul %ulong %495 %ulong_8
-OpStore %480 %496
-%497 = OpLoad %ulong %477
-%498 = OpLoad %ulong %480
-%499 = OpShiftRightLogical %ulong %497 %498
-OpStore %481 %499
-%500 = OpLoad %ulong %481
-%502 = OpBitwiseAnd %ulong %500 %ulong_255
-OpStore %482 %502
-%503 = OpLoad %ulong %486
-%504 = OpLoad %ulong %482
-%505 = OpBitwiseXor %ulong %503 %504
-OpStore %483 %505
-%506 = OpLoad %ulong %483
-%508 = OpIMul %ulong %506 %ulong_1099511628211
-OpStore %484 %508
-%509 = OpLoad %ulong %487
-%511 = OpIAdd %ulong %509 %ulong_1
-OpStore %485 %511
-%512 = OpLoad %ulong %484
-OpStore %486 %512
-%513 = OpLoad %ulong %485
-OpStore %487 %513
-OpBranch %474
-%474 = OpLabel
-OpBranch %471
-OpFunctionEnd
-%6 = OpFunction %ulong None %514
-%515 = OpFunctionParameter %ulong
-%516 = OpFunctionParameter %uchar
-%517 = OpLabel
-%524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_uchar Function
-%526 = OpVariable %_ptr_Function_ulong Function
-%527 = OpVariable %_ptr_Function_bool Function
-%528 = OpVariable %_ptr_Function_ulong Function
-%529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_ulong Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_ulong Function
-%533 = OpVariable %_ptr_Function_ulong Function
-%534 = OpVariable %_ptr_Function_ulong Function
-%535 = OpVariable %_ptr_Function_ulong Function
-OpStore %524 %515
-OpStore %525 %516
-%536 = OpLoad %uchar %525
-%537 = OpUConvert %ulong %536
-OpStore %526 %537
-OpBranch %518
-%518 = OpLabel
-%538 = OpLoad %ulong %524
-OpStore %534 %538
-OpStore %535 %ulong_0
-OpBranch %519
-%519 = OpLabel
-%539 = OpLoad %ulong %535
-%540 = OpULessThan %bool %539 %ulong_8
-OpStore %527 %540
-%541 = OpLoad %bool %527
-OpLoopMerge %521 %523 None
-OpBranchConditional %541 %520 %521
-%521 = OpLabel
-OpBranch %522
-%522 = OpLabel
-%542 = OpLoad %ulong %534
-OpReturnValue %542
-%520 = OpLabel
-%543 = OpLoad %ulong %535
-%544 = OpIMul %ulong %543 %ulong_8
-OpStore %528 %544
-%545 = OpLoad %ulong %526
-%546 = OpLoad %ulong %528
-%547 = OpShiftRightLogical %ulong %545 %546
-OpStore %529 %547
-%548 = OpLoad %ulong %529
-%549 = OpBitwiseAnd %ulong %548 %ulong_255
-OpStore %530 %549
-%550 = OpLoad %ulong %534
-%551 = OpLoad %ulong %530
-%552 = OpBitwiseXor %ulong %550 %551
-OpStore %531 %552
-%553 = OpLoad %ulong %531
-%554 = OpIMul %ulong %553 %ulong_1099511628211
-OpStore %532 %554
-%555 = OpLoad %ulong %535
-%556 = OpIAdd %ulong %555 %ulong_1
-OpStore %533 %556
-%557 = OpLoad %ulong %532
-OpStore %534 %557
-%558 = OpLoad %ulong %533
-OpStore %535 %558
-OpBranch %523
-%523 = OpLabel
-OpBranch %519
-OpFunctionEnd
-%7 = OpFunction %ulong None %559
-%560 = OpFunctionParameter %ulong
-%561 = OpFunctionParameter %ushort
-%562 = OpLabel
-%569 = OpVariable %_ptr_Function_ulong Function
-%570 = OpVariable %_ptr_Function_ushort Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_bool Function
-%573 = OpVariable %_ptr_Function_ulong Function
-%574 = OpVariable %_ptr_Function_ulong Function
-%575 = OpVariable %_ptr_Function_ulong Function
-%576 = OpVariable %_ptr_Function_ulong Function
-%577 = OpVariable %_ptr_Function_ulong Function
-%578 = OpVariable %_ptr_Function_ulong Function
-%579 = OpVariable %_ptr_Function_ulong Function
-%580 = OpVariable %_ptr_Function_ulong Function
-OpStore %569 %560
-OpStore %570 %561
-%581 = OpLoad %ushort %570
-%582 = OpUConvert %ulong %581
-OpStore %571 %582
-OpBranch %563
-%563 = OpLabel
-%583 = OpLoad %ulong %569
-OpStore %579 %583
-OpStore %580 %ulong_0
-OpBranch %564
-%564 = OpLabel
-%584 = OpLoad %ulong %580
-%585 = OpULessThan %bool %584 %ulong_8
-OpStore %572 %585
-%586 = OpLoad %bool %572
-OpLoopMerge %566 %568 None
-OpBranchConditional %586 %565 %566
-%566 = OpLabel
-OpBranch %567
-%567 = OpLabel
-%587 = OpLoad %ulong %579
-OpReturnValue %587
-%565 = OpLabel
-%588 = OpLoad %ulong %580
-%589 = OpIMul %ulong %588 %ulong_8
-OpStore %573 %589
-%590 = OpLoad %ulong %571
-%591 = OpLoad %ulong %573
-%592 = OpShiftRightLogical %ulong %590 %591
-OpStore %574 %592
-%593 = OpLoad %ulong %574
-%594 = OpBitwiseAnd %ulong %593 %ulong_255
-OpStore %575 %594
-%595 = OpLoad %ulong %579
-%596 = OpLoad %ulong %575
-%597 = OpBitwiseXor %ulong %595 %596
-OpStore %576 %597
-%598 = OpLoad %ulong %576
-%599 = OpIMul %ulong %598 %ulong_1099511628211
-OpStore %577 %599
-%600 = OpLoad %ulong %580
-%601 = OpIAdd %ulong %600 %ulong_1
-OpStore %578 %601
-%602 = OpLoad %ulong %577
-OpStore %579 %602
-%603 = OpLoad %ulong %578
-OpStore %580 %603
-OpBranch %568
-%568 = OpLabel
-OpBranch %564
-OpFunctionEnd
-%8 = OpFunction %ulong None %604
-%605 = OpFunctionParameter %ulong
-%606 = OpFunctionParameter %uint
-%607 = OpLabel
-%614 = OpVariable %_ptr_Function_ulong Function
-%615 = OpVariable %_ptr_Function_uint Function
-%616 = OpVariable %_ptr_Function_ulong Function
-%617 = OpVariable %_ptr_Function_bool Function
-%618 = OpVariable %_ptr_Function_ulong Function
-%619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_ulong Function
-%621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_ulong Function
-%623 = OpVariable %_ptr_Function_ulong Function
-%624 = OpVariable %_ptr_Function_ulong Function
-%625 = OpVariable %_ptr_Function_ulong Function
-OpStore %614 %605
-OpStore %615 %606
-%626 = OpLoad %uint %615
-%627 = OpUConvert %ulong %626
-OpStore %616 %627
-OpBranch %608
-%608 = OpLabel
-%628 = OpLoad %ulong %614
-OpStore %624 %628
-OpStore %625 %ulong_0
-OpBranch %609
-%609 = OpLabel
-%629 = OpLoad %ulong %625
-%630 = OpULessThan %bool %629 %ulong_8
-OpStore %617 %630
-%631 = OpLoad %bool %617
-OpLoopMerge %611 %613 None
-OpBranchConditional %631 %610 %611
-%611 = OpLabel
-OpBranch %612
-%612 = OpLabel
-%632 = OpLoad %ulong %624
-OpReturnValue %632
-%610 = OpLabel
-%633 = OpLoad %ulong %625
-%634 = OpIMul %ulong %633 %ulong_8
-OpStore %618 %634
-%635 = OpLoad %ulong %616
-%636 = OpLoad %ulong %618
-%637 = OpShiftRightLogical %ulong %635 %636
-OpStore %619 %637
-%638 = OpLoad %ulong %619
-%639 = OpBitwiseAnd %ulong %638 %ulong_255
-OpStore %620 %639
-%640 = OpLoad %ulong %624
-%641 = OpLoad %ulong %620
-%642 = OpBitwiseXor %ulong %640 %641
-OpStore %621 %642
-%643 = OpLoad %ulong %621
-%644 = OpIMul %ulong %643 %ulong_1099511628211
-OpStore %622 %644
-%645 = OpLoad %ulong %625
-%646 = OpIAdd %ulong %645 %ulong_1
-OpStore %623 %646
-%647 = OpLoad %ulong %622
-OpStore %624 %647
-%648 = OpLoad %ulong %623
-OpStore %625 %648
-OpBranch %613
-%613 = OpLabel
-OpBranch %609
-OpFunctionEnd
-%9 = OpFunction %ulong None %514
-%649 = OpFunctionParameter %ulong
-%650 = OpFunctionParameter %uchar
-%651 = OpLabel
-%658 = OpVariable %_ptr_Function_ulong Function
-%659 = OpVariable %_ptr_Function_uchar Function
-%660 = OpVariable %_ptr_Function_ulong Function
-%661 = OpVariable %_ptr_Function_bool Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_ulong Function
-%668 = OpVariable %_ptr_Function_ulong Function
-%669 = OpVariable %_ptr_Function_ulong Function
-OpStore %658 %649
-OpStore %659 %650
-%670 = OpLoad %uchar %659
-%671 = OpSConvert %ulong %670
-OpStore %660 %671
-OpBranch %652
-%652 = OpLabel
-%672 = OpLoad %ulong %658
-OpStore %668 %672
-OpStore %669 %ulong_0
-OpBranch %653
-%653 = OpLabel
-%673 = OpLoad %ulong %669
-%674 = OpULessThan %bool %673 %ulong_8
-OpStore %661 %674
-%675 = OpLoad %bool %661
-OpLoopMerge %655 %657 None
-OpBranchConditional %675 %654 %655
-%655 = OpLabel
-OpBranch %656
-%656 = OpLabel
-%676 = OpLoad %ulong %668
-OpReturnValue %676
-%654 = OpLabel
-%677 = OpLoad %ulong %669
-%678 = OpIMul %ulong %677 %ulong_8
-OpStore %662 %678
-%679 = OpLoad %ulong %660
-%680 = OpLoad %ulong %662
-%681 = OpShiftRightLogical %ulong %679 %680
-OpStore %663 %681
-%682 = OpLoad %ulong %663
-%683 = OpBitwiseAnd %ulong %682 %ulong_255
-OpStore %664 %683
-%684 = OpLoad %ulong %668
-%685 = OpLoad %ulong %664
-%686 = OpBitwiseXor %ulong %684 %685
-OpStore %665 %686
-%687 = OpLoad %ulong %665
-%688 = OpIMul %ulong %687 %ulong_1099511628211
-OpStore %666 %688
-%689 = OpLoad %ulong %669
-%690 = OpIAdd %ulong %689 %ulong_1
-OpStore %667 %690
-%691 = OpLoad %ulong %666
-OpStore %668 %691
-%692 = OpLoad %ulong %667
-OpStore %669 %692
-OpBranch %657
-%657 = OpLabel
-OpBranch %653
-OpFunctionEnd
-%10 = OpFunction %ulong None %559
-%693 = OpFunctionParameter %ulong
-%694 = OpFunctionParameter %ushort
-%695 = OpLabel
-%702 = OpVariable %_ptr_Function_ulong Function
-%703 = OpVariable %_ptr_Function_ushort Function
-%704 = OpVariable %_ptr_Function_ulong Function
-%705 = OpVariable %_ptr_Function_bool Function
-%706 = OpVariable %_ptr_Function_ulong Function
-%707 = OpVariable %_ptr_Function_ulong Function
-%708 = OpVariable %_ptr_Function_ulong Function
-%709 = OpVariable %_ptr_Function_ulong Function
-%710 = OpVariable %_ptr_Function_ulong Function
-%711 = OpVariable %_ptr_Function_ulong Function
-%712 = OpVariable %_ptr_Function_ulong Function
-%713 = OpVariable %_ptr_Function_ulong Function
-OpStore %702 %693
-OpStore %703 %694
-%714 = OpLoad %ushort %703
-%715 = OpSConvert %ulong %714
-OpStore %704 %715
-OpBranch %696
-%696 = OpLabel
-%716 = OpLoad %ulong %702
-OpStore %712 %716
-OpStore %713 %ulong_0
-OpBranch %697
-%697 = OpLabel
-%717 = OpLoad %ulong %713
-%718 = OpULessThan %bool %717 %ulong_8
-OpStore %705 %718
-%719 = OpLoad %bool %705
-OpLoopMerge %699 %701 None
-OpBranchConditional %719 %698 %699
-%699 = OpLabel
-OpBranch %700
-%700 = OpLabel
-%720 = OpLoad %ulong %712
-OpReturnValue %720
-%698 = OpLabel
-%721 = OpLoad %ulong %713
-%722 = OpIMul %ulong %721 %ulong_8
-OpStore %706 %722
-%723 = OpLoad %ulong %704
-%724 = OpLoad %ulong %706
-%725 = OpShiftRightLogical %ulong %723 %724
-OpStore %707 %725
-%726 = OpLoad %ulong %707
-%727 = OpBitwiseAnd %ulong %726 %ulong_255
-OpStore %708 %727
-%728 = OpLoad %ulong %712
-%729 = OpLoad %ulong %708
-%730 = OpBitwiseXor %ulong %728 %729
-OpStore %709 %730
-%731 = OpLoad %ulong %709
-%732 = OpIMul %ulong %731 %ulong_1099511628211
-OpStore %710 %732
-%733 = OpLoad %ulong %713
-%734 = OpIAdd %ulong %733 %ulong_1
-OpStore %711 %734
-%735 = OpLoad %ulong %710
-OpStore %712 %735
-%736 = OpLoad %ulong %711
-OpStore %713 %736
-OpBranch %701
-%701 = OpLabel
-OpBranch %697
-OpFunctionEnd
-%11 = OpFunction %ulong None %604
-%737 = OpFunctionParameter %ulong
-%738 = OpFunctionParameter %uint
-%739 = OpLabel
+%2 = OpFunction %ulong None %8
+%705 = OpFunctionParameter %ulong
+%706 = OpFunctionParameter %float
+%707 = OpFunctionParameter %double
+%708 = OpLabel
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_float Function
+%727 = OpVariable %_ptr_Function_double Function
+%728 = OpVariable %_ptr_Function_uchar Function
+%729 = OpVariable %_ptr_Function_ushort Function
+%730 = OpVariable %_ptr_Function_uint Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_uchar Function
+%733 = OpVariable %_ptr_Function_ushort Function
+%734 = OpVariable %_ptr_Function_uint Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
 %746 = OpVariable %_ptr_Function_ulong Function
-%747 = OpVariable %_ptr_Function_uint Function
+%747 = OpVariable %_ptr_Function_ulong Function
 %748 = OpVariable %_ptr_Function_ulong Function
-%749 = OpVariable %_ptr_Function_bool Function
-%750 = OpVariable %_ptr_Function_ulong Function
-%751 = OpVariable %_ptr_Function_ulong Function
-%752 = OpVariable %_ptr_Function_ulong Function
-%753 = OpVariable %_ptr_Function_ulong Function
-%754 = OpVariable %_ptr_Function_ulong Function
-%755 = OpVariable %_ptr_Function_ulong Function
-%756 = OpVariable %_ptr_Function_ulong Function
-%757 = OpVariable %_ptr_Function_ulong Function
-OpStore %746 %737
-OpStore %747 %738
-%758 = OpLoad %uint %747
-%759 = OpSConvert %ulong %758
-OpStore %748 %759
-OpBranch %740
-%740 = OpLabel
-%760 = OpLoad %ulong %746
-OpStore %756 %760
-OpStore %757 %ulong_0
-OpBranch %741
-%741 = OpLabel
-%761 = OpLoad %ulong %757
-%762 = OpULessThan %bool %761 %ulong_8
-OpStore %749 %762
-%763 = OpLoad %bool %749
-OpLoopMerge %743 %745 None
-OpBranchConditional %763 %742 %743
-%743 = OpLabel
-OpBranch %744
-%744 = OpLabel
-%764 = OpLoad %ulong %756
-OpReturnValue %764
-%742 = OpLabel
-%765 = OpLoad %ulong %757
-%766 = OpIMul %ulong %765 %ulong_8
-OpStore %750 %766
-%767 = OpLoad %ulong %748
-%768 = OpLoad %ulong %750
-%769 = OpShiftRightLogical %ulong %767 %768
-OpStore %751 %769
-%770 = OpLoad %ulong %751
-%771 = OpBitwiseAnd %ulong %770 %ulong_255
-OpStore %752 %771
-%772 = OpLoad %ulong %756
-%773 = OpLoad %ulong %752
-%774 = OpBitwiseXor %ulong %772 %773
-OpStore %753 %774
-%775 = OpLoad %ulong %753
-%776 = OpIMul %ulong %775 %ulong_1099511628211
-OpStore %754 %776
-%777 = OpLoad %ulong %757
-%778 = OpIAdd %ulong %777 %ulong_1
-OpStore %755 %778
-%779 = OpLoad %ulong %754
-OpStore %756 %779
-%780 = OpLoad %ulong %755
-OpStore %757 %780
-OpBranch %745
-%745 = OpLabel
-OpBranch %741
+%749 = OpVariable %_ptr_Function_ulong Function
+OpStore %725 %705
+OpStore %726 %706
+OpStore %727 %707
+%750 = OpLoad %float %726
+%751 = OpConvertFToS %uchar %750
+OpStore %728 %751
+OpBranch %709
+%709 = OpLabel
+%752 = OpLoad %uchar %728
+%753 = OpSConvert %ulong %752
+OpStore %736 %753
+%754 = OpLoad %ulong %725
+%755 = OpLoad %ulong %736
+%756 = OpFunctionCall %ulong %4 %754 %755
+OpStore %737 %756
+OpBranch %710
+%710 = OpLabel
+%757 = OpLoad %float %726
+%758 = OpConvertFToS %ushort %757
+OpStore %729 %758
+OpBranch %711
+%711 = OpLabel
+%759 = OpLoad %ushort %729
+%760 = OpSConvert %ulong %759
+OpStore %738 %760
+%761 = OpLoad %ulong %737
+%762 = OpLoad %ulong %738
+%763 = OpFunctionCall %ulong %4 %761 %762
+OpStore %739 %763
+OpBranch %712
+%712 = OpLabel
+%764 = OpLoad %float %726
+%765 = OpConvertFToS %uint %764
+OpStore %730 %765
+OpBranch %713
+%713 = OpLabel
+%766 = OpLoad %uint %730
+%767 = OpSConvert %ulong %766
+OpStore %740 %767
+%768 = OpLoad %ulong %739
+%769 = OpLoad %ulong %740
+%770 = OpFunctionCall %ulong %4 %768 %769
+OpStore %741 %770
+OpBranch %714
+%714 = OpLabel
+%771 = OpLoad %float %726
+%772 = OpConvertFToS %ulong %771
+OpStore %731 %772
+OpBranch %715
+%715 = OpLabel
+%773 = OpLoad %ulong %741
+%774 = OpLoad %ulong %731
+%775 = OpFunctionCall %ulong %4 %773 %774
+OpStore %742 %775
+OpBranch %716
+%716 = OpLabel
+%776 = OpLoad %double %727
+%777 = OpConvertFToS %uchar %776
+OpStore %732 %777
+OpBranch %717
+%717 = OpLabel
+%778 = OpLoad %uchar %732
+%779 = OpSConvert %ulong %778
+OpStore %743 %779
+%780 = OpLoad %ulong %742
+%781 = OpLoad %ulong %743
+%782 = OpFunctionCall %ulong %4 %780 %781
+OpStore %744 %782
+OpBranch %718
+%718 = OpLabel
+%783 = OpLoad %double %727
+%784 = OpConvertFToS %ushort %783
+OpStore %733 %784
+OpBranch %719
+%719 = OpLabel
+%785 = OpLoad %ushort %733
+%786 = OpSConvert %ulong %785
+OpStore %745 %786
+%787 = OpLoad %ulong %744
+%788 = OpLoad %ulong %745
+%789 = OpFunctionCall %ulong %4 %787 %788
+OpStore %746 %789
+OpBranch %720
+%720 = OpLabel
+%790 = OpLoad %double %727
+%791 = OpConvertFToS %uint %790
+OpStore %734 %791
+OpBranch %721
+%721 = OpLabel
+%792 = OpLoad %uint %734
+%793 = OpSConvert %ulong %792
+OpStore %747 %793
+%794 = OpLoad %ulong %746
+%795 = OpLoad %ulong %747
+%796 = OpFunctionCall %ulong %4 %794 %795
+OpStore %748 %796
+OpBranch %722
+%722 = OpLabel
+%797 = OpLoad %double %727
+%798 = OpConvertFToS %ulong %797
+OpStore %735 %798
+OpBranch %723
+%723 = OpLabel
+%799 = OpLoad %ulong %748
+%800 = OpLoad %ulong %735
+%801 = OpFunctionCall %ulong %4 %799 %800
+OpStore %749 %801
+OpBranch %724
+%724 = OpLabel
+%802 = OpLoad %ulong %749
+OpReturnValue %802
 OpFunctionEnd
-%12 = OpFunction %ulong None %467
-%781 = OpFunctionParameter %ulong
-%782 = OpFunctionParameter %ulong
-%783 = OpLabel
-%790 = OpVariable %_ptr_Function_ulong Function
-%791 = OpVariable %_ptr_Function_ulong Function
-%792 = OpVariable %_ptr_Function_bool Function
-%793 = OpVariable %_ptr_Function_ulong Function
-%794 = OpVariable %_ptr_Function_ulong Function
-%795 = OpVariable %_ptr_Function_ulong Function
-%796 = OpVariable %_ptr_Function_ulong Function
-%797 = OpVariable %_ptr_Function_ulong Function
-%798 = OpVariable %_ptr_Function_ulong Function
-%799 = OpVariable %_ptr_Function_ulong Function
-%800 = OpVariable %_ptr_Function_ulong Function
-OpStore %790 %781
-OpStore %791 %782
-OpBranch %784
-%784 = OpLabel
-%801 = OpLoad %ulong %790
-OpStore %799 %801
-OpStore %800 %ulong_0
-OpBranch %785
-%785 = OpLabel
-%802 = OpLoad %ulong %800
-%803 = OpULessThan %bool %802 %ulong_8
-OpStore %792 %803
-%804 = OpLoad %bool %792
-OpLoopMerge %787 %789 None
-OpBranchConditional %804 %786 %787
-%787 = OpLabel
-OpBranch %788
-%788 = OpLabel
-%805 = OpLoad %ulong %799
-OpReturnValue %805
-%786 = OpLabel
-%806 = OpLoad %ulong %800
-%807 = OpIMul %ulong %806 %ulong_8
-OpStore %793 %807
-%808 = OpLoad %ulong %791
-%809 = OpLoad %ulong %793
-%810 = OpShiftRightLogical %ulong %808 %809
-OpStore %794 %810
-%811 = OpLoad %ulong %794
-%812 = OpBitwiseAnd %ulong %811 %ulong_255
-OpStore %795 %812
-%813 = OpLoad %ulong %799
-%814 = OpLoad %ulong %795
-%815 = OpBitwiseXor %ulong %813 %814
-OpStore %796 %815
-%816 = OpLoad %ulong %796
-%817 = OpIMul %ulong %816 %ulong_1099511628211
-OpStore %797 %817
-%818 = OpLoad %ulong %800
-%819 = OpIAdd %ulong %818 %ulong_1
-OpStore %798 %819
-%820 = OpLoad %ulong %797
-OpStore %799 %820
-%821 = OpLoad %ulong %798
-OpStore %800 %821
-OpBranch %789
-%789 = OpLabel
-OpBranch %785
+%3 = OpFunction %ulong None %803
+%804 = OpFunctionParameter %ulong
+%805 = OpLabel
+%962 = OpVariable %_ptr_Function_ulong Function
+%963 = OpVariable %_ptr_Function_float Function
+%964 = OpVariable %_ptr_Function_double Function
+%965 = OpVariable %_ptr_Function_float Function
+%966 = OpVariable %_ptr_Function_double Function
+%967 = OpVariable %_ptr_Function_float Function
+%968 = OpVariable %_ptr_Function_float Function
+%969 = OpVariable %_ptr_Function_double Function
+%970 = OpVariable %_ptr_Function_float Function
+%971 = OpVariable %_ptr_Function_uchar Function
+%972 = OpVariable %_ptr_Function_float Function
+%973 = OpVariable %_ptr_Function_uchar Function
+%974 = OpVariable %_ptr_Function_double Function
+%975 = OpVariable %_ptr_Function_uchar Function
+%976 = OpVariable %_ptr_Function_uchar Function
+%977 = OpVariable %_ptr_Function_double Function
+%978 = OpVariable %_ptr_Function_uchar Function
+%979 = OpVariable %_ptr_Function_uchar Function
+%980 = OpVariable %_ptr_Function_ushort Function
+%981 = OpVariable %_ptr_Function_uint Function
+%982 = OpVariable %_ptr_Function_ulong Function
+%983 = OpVariable %_ptr_Function_uchar Function
+%984 = OpVariable %_ptr_Function_ushort Function
+%985 = OpVariable %_ptr_Function_uint Function
+%986 = OpVariable %_ptr_Function_ulong Function
+%987 = OpVariable %_ptr_Function_uchar Function
+%988 = OpVariable %_ptr_Function_ushort Function
+%989 = OpVariable %_ptr_Function_uint Function
+%990 = OpVariable %_ptr_Function_ulong Function
+%991 = OpVariable %_ptr_Function_uchar Function
+%992 = OpVariable %_ptr_Function_ushort Function
+%993 = OpVariable %_ptr_Function_uint Function
+%994 = OpVariable %_ptr_Function_ulong Function
+%995 = OpVariable %_ptr_Function_ulong Function
+%996 = OpVariable %_ptr_Function_bool Function
+%997 = OpVariable %_ptr_Function_ulong Function
+%998 = OpVariable %_ptr_Function_ulong Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_ulong Function
+%1001 = OpVariable %_ptr_Function_ulong Function
+%1002 = OpVariable %_ptr_Function_ulong Function
+%1003 = OpVariable %_ptr_Function_ulong Function
+%1004 = OpVariable %_ptr_Function_ulong Function
+%1005 = OpVariable %_ptr_Function_ulong Function
+%1006 = OpVariable %_ptr_Function_bool Function
+%1007 = OpVariable %_ptr_Function_ulong Function
+%1008 = OpVariable %_ptr_Function_ulong Function
+%1009 = OpVariable %_ptr_Function_ulong Function
+%1010 = OpVariable %_ptr_Function_ulong Function
+%1011 = OpVariable %_ptr_Function_ulong Function
+%1012 = OpVariable %_ptr_Function_ulong Function
+%1013 = OpVariable %_ptr_Function_ulong Function
+%1014 = OpVariable %_ptr_Function_ulong Function
+%1015 = OpVariable %_ptr_Function_ulong Function
+%1016 = OpVariable %_ptr_Function_bool Function
+%1017 = OpVariable %_ptr_Function_ulong Function
+%1018 = OpVariable %_ptr_Function_ulong Function
+%1019 = OpVariable %_ptr_Function_ulong Function
+%1020 = OpVariable %_ptr_Function_ulong Function
+%1021 = OpVariable %_ptr_Function_ulong Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_ulong Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_bool Function
+%1026 = OpVariable %_ptr_Function_ulong Function
+%1027 = OpVariable %_ptr_Function_ulong Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_ulong Function
+%1030 = OpVariable %_ptr_Function_ulong Function
+%1031 = OpVariable %_ptr_Function_ulong Function
+%1032 = OpVariable %_ptr_Function_ulong Function
+%1033 = OpVariable %_ptr_Function_ulong Function
+%1034 = OpVariable %_ptr_Function_ulong Function
+%1035 = OpVariable %_ptr_Function_bool Function
+%1036 = OpVariable %_ptr_Function_ulong Function
+%1037 = OpVariable %_ptr_Function_ulong Function
+%1038 = OpVariable %_ptr_Function_ulong Function
+%1039 = OpVariable %_ptr_Function_ulong Function
+%1040 = OpVariable %_ptr_Function_ulong Function
+%1041 = OpVariable %_ptr_Function_ulong Function
+%1042 = OpVariable %_ptr_Function_ulong Function
+%1043 = OpVariable %_ptr_Function_ulong Function
+%1044 = OpVariable %_ptr_Function_ulong Function
+%1045 = OpVariable %_ptr_Function_bool Function
+%1046 = OpVariable %_ptr_Function_ulong Function
+%1047 = OpVariable %_ptr_Function_ulong Function
+%1048 = OpVariable %_ptr_Function_ulong Function
+%1049 = OpVariable %_ptr_Function_ulong Function
+%1050 = OpVariable %_ptr_Function_ulong Function
+%1051 = OpVariable %_ptr_Function_ulong Function
+%1052 = OpVariable %_ptr_Function_ulong Function
+%1053 = OpVariable %_ptr_Function_ulong Function
+%1054 = OpVariable %_ptr_Function_ulong Function
+%1055 = OpVariable %_ptr_Function_bool Function
+%1056 = OpVariable %_ptr_Function_ulong Function
+%1057 = OpVariable %_ptr_Function_ulong Function
+%1058 = OpVariable %_ptr_Function_ulong Function
+%1059 = OpVariable %_ptr_Function_ulong Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_ulong Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_ulong Function
+%1064 = OpVariable %_ptr_Function_bool Function
+%1065 = OpVariable %_ptr_Function_ulong Function
+%1066 = OpVariable %_ptr_Function_ulong Function
+%1067 = OpVariable %_ptr_Function_ulong Function
+%1068 = OpVariable %_ptr_Function_ulong Function
+%1069 = OpVariable %_ptr_Function_ulong Function
+%1070 = OpVariable %_ptr_Function_ulong Function
+%1071 = OpVariable %_ptr_Function_ulong Function
+%1072 = OpVariable %_ptr_Function_ulong Function
+%1073 = OpVariable %_ptr_Function_ulong Function
+%1074 = OpVariable %_ptr_Function_bool Function
+%1075 = OpVariable %_ptr_Function_ulong Function
+%1076 = OpVariable %_ptr_Function_ulong Function
+%1077 = OpVariable %_ptr_Function_ulong Function
+%1078 = OpVariable %_ptr_Function_ulong Function
+%1079 = OpVariable %_ptr_Function_ulong Function
+%1080 = OpVariable %_ptr_Function_ulong Function
+%1081 = OpVariable %_ptr_Function_ulong Function
+%1082 = OpVariable %_ptr_Function_ulong Function
+%1083 = OpVariable %_ptr_Function_ulong Function
+%1084 = OpVariable %_ptr_Function_bool Function
+%1085 = OpVariable %_ptr_Function_ulong Function
+%1086 = OpVariable %_ptr_Function_ulong Function
+%1087 = OpVariable %_ptr_Function_ulong Function
+%1088 = OpVariable %_ptr_Function_ulong Function
+%1089 = OpVariable %_ptr_Function_ulong Function
+%1090 = OpVariable %_ptr_Function_ulong Function
+%1091 = OpVariable %_ptr_Function_ulong Function
+%1092 = OpVariable %_ptr_Function_ulong Function
+%1093 = OpVariable %_ptr_Function_ulong Function
+%1094 = OpVariable %_ptr_Function_bool Function
+%1095 = OpVariable %_ptr_Function_ulong Function
+%1096 = OpVariable %_ptr_Function_ulong Function
+%1097 = OpVariable %_ptr_Function_ulong Function
+%1098 = OpVariable %_ptr_Function_ulong Function
+%1099 = OpVariable %_ptr_Function_ulong Function
+%1100 = OpVariable %_ptr_Function_ulong Function
+%1101 = OpVariable %_ptr_Function_ulong Function
+%1102 = OpVariable %_ptr_Function_ulong Function
+%1103 = OpVariable %_ptr_Function_bool Function
+%1104 = OpVariable %_ptr_Function_ulong Function
+%1105 = OpVariable %_ptr_Function_ulong Function
+%1106 = OpVariable %_ptr_Function_ulong Function
+%1107 = OpVariable %_ptr_Function_ulong Function
+%1108 = OpVariable %_ptr_Function_ulong Function
+%1109 = OpVariable %_ptr_Function_ulong Function
+%1110 = OpVariable %_ptr_Function_ulong Function
+%1111 = OpVariable %_ptr_Function_ulong Function
+%1112 = OpVariable %_ptr_Function_ulong Function
+%1113 = OpVariable %_ptr_Function_bool Function
+%1114 = OpVariable %_ptr_Function_ulong Function
+%1115 = OpVariable %_ptr_Function_ulong Function
+%1116 = OpVariable %_ptr_Function_ulong Function
+%1117 = OpVariable %_ptr_Function_ulong Function
+%1118 = OpVariable %_ptr_Function_ulong Function
+%1119 = OpVariable %_ptr_Function_ulong Function
+%1120 = OpVariable %_ptr_Function_ulong Function
+%1121 = OpVariable %_ptr_Function_ulong Function
+%1122 = OpVariable %_ptr_Function_ulong Function
+%1123 = OpVariable %_ptr_Function_bool Function
+%1124 = OpVariable %_ptr_Function_ulong Function
+%1125 = OpVariable %_ptr_Function_ulong Function
+%1126 = OpVariable %_ptr_Function_ulong Function
+%1127 = OpVariable %_ptr_Function_ulong Function
+%1128 = OpVariable %_ptr_Function_ulong Function
+%1129 = OpVariable %_ptr_Function_ulong Function
+%1130 = OpVariable %_ptr_Function_ulong Function
+%1131 = OpVariable %_ptr_Function_ulong Function
+%1132 = OpVariable %_ptr_Function_ulong Function
+%1133 = OpVariable %_ptr_Function_bool Function
+%1134 = OpVariable %_ptr_Function_ulong Function
+%1135 = OpVariable %_ptr_Function_ulong Function
+%1136 = OpVariable %_ptr_Function_ulong Function
+%1137 = OpVariable %_ptr_Function_ulong Function
+%1138 = OpVariable %_ptr_Function_ulong Function
+%1139 = OpVariable %_ptr_Function_ulong Function
+%1140 = OpVariable %_ptr_Function_ulong Function
+%1141 = OpVariable %_ptr_Function_ulong Function
+%1142 = OpVariable %_ptr_Function_bool Function
+%1143 = OpVariable %_ptr_Function_ulong Function
+%1144 = OpVariable %_ptr_Function_ulong Function
+%1145 = OpVariable %_ptr_Function_ulong Function
+%1146 = OpVariable %_ptr_Function_ulong Function
+%1147 = OpVariable %_ptr_Function_ulong Function
+%1148 = OpVariable %_ptr_Function_ulong Function
+%1149 = OpVariable %_ptr_Function_ulong Function
+%1150 = OpVariable %_ptr_Function_ulong Function
+%1151 = OpVariable %_ptr_Function_uchar Function
+%1152 = OpVariable %_ptr_Function_ushort Function
+%1153 = OpVariable %_ptr_Function_uint Function
+%1154 = OpVariable %_ptr_Function_ulong Function
+%1155 = OpVariable %_ptr_Function_uchar Function
+%1156 = OpVariable %_ptr_Function_ushort Function
+%1157 = OpVariable %_ptr_Function_uint Function
+%1158 = OpVariable %_ptr_Function_ulong Function
+%1159 = OpVariable %_ptr_Function_ulong Function
+%1160 = OpVariable %_ptr_Function_ulong Function
+%1161 = OpVariable %_ptr_Function_ulong Function
+%1162 = OpVariable %_ptr_Function_ulong Function
+%1163 = OpVariable %_ptr_Function_ulong Function
+%1164 = OpVariable %_ptr_Function_ulong Function
+%1165 = OpVariable %_ptr_Function_ulong Function
+%1166 = OpVariable %_ptr_Function_ulong Function
+%1167 = OpVariable %_ptr_Function_ulong Function
+%1168 = OpVariable %_ptr_Function_ulong Function
+%1169 = OpVariable %_ptr_Function_ulong Function
+%1170 = OpVariable %_ptr_Function_ulong Function
+%1171 = OpVariable %_ptr_Function_ulong Function
+%1172 = OpVariable %_ptr_Function_ulong Function
+%1173 = OpVariable %_ptr_Function_ulong Function
+%1174 = OpVariable %_ptr_Function_ulong Function
+%1175 = OpVariable %_ptr_Function_ulong Function
+%1176 = OpVariable %_ptr_Function_ulong Function
+%1177 = OpVariable %_ptr_Function_ulong Function
+%1178 = OpVariable %_ptr_Function_ulong Function
+%1179 = OpVariable %_ptr_Function_ulong Function
+%1180 = OpVariable %_ptr_Function_ulong Function
+%1181 = OpVariable %_ptr_Function_ulong Function
+%1182 = OpVariable %_ptr_Function_ulong Function
+OpStore %962 %804
+OpBranch %806
+%806 = OpLabel
+OpBranch %807
+%807 = OpLabel
+%1183 = OpLoad %ulong %962
+%1184 = OpConvertUToF %float %1183
+OpStore %963 %1184
+%1185 = OpLoad %ulong %962
+%1186 = OpConvertUToF %double %1185
+OpStore %964 %1186
+%1188 = OpLoad %float %963
+%1189 = OpFAdd %float %float_40_75 %1188
+OpStore %965 %1189
+%1191 = OpLoad %double %964
+%1192 = OpFAdd %double %double_40_75 %1191
+OpStore %966 %1192
+OpBranch %808
+%808 = OpLabel
+%1193 = OpLoad %float %965
+%1194 = OpConvertFToU %uchar %1193
+OpStore %979 %1194
+OpBranch %809
+%809 = OpLabel
+%1195 = OpLoad %uchar %979
+%1196 = OpUConvert %ulong %1195
+OpStore %995 %1196
+OpBranch %811
+%811 = OpLabel
+OpStore %1003 %ulong_14695981039346656037
+OpStore %1004 %ulong_0
+OpBranch %812
+%812 = OpLabel
+%1198 = OpLoad %ulong %1004
+%1199 = OpULessThan %bool %1198 %ulong_8
+OpStore %996 %1199
+%1200 = OpLoad %bool %996
+OpLoopMerge %814 %961 None
+OpBranchConditional %1200 %813 %814
+%814 = OpLabel
+OpBranch %815
+%815 = OpLabel
+OpBranch %810
+%810 = OpLabel
+%1201 = OpLoad %float %965
+%1202 = OpConvertFToU %ushort %1201
+OpStore %980 %1202
+OpBranch %816
+%816 = OpLabel
+%1203 = OpLoad %ushort %980
+%1204 = OpUConvert %ulong %1203
+OpStore %1005 %1204
+OpBranch %818
+%818 = OpLabel
+%1205 = OpLoad %ulong %1003
+OpStore %1013 %1205
+OpStore %1014 %ulong_0
+OpBranch %819
+%819 = OpLabel
+%1206 = OpLoad %ulong %1014
+%1207 = OpULessThan %bool %1206 %ulong_8
+OpStore %1006 %1207
+%1208 = OpLoad %bool %1006
+OpLoopMerge %821 %960 None
+OpBranchConditional %1208 %820 %821
+%821 = OpLabel
+OpBranch %822
+%822 = OpLabel
+OpBranch %817
+%817 = OpLabel
+%1209 = OpLoad %float %965
+%1210 = OpConvertFToU %uint %1209
+OpStore %981 %1210
+OpBranch %823
+%823 = OpLabel
+%1211 = OpLoad %uint %981
+%1212 = OpUConvert %ulong %1211
+OpStore %1015 %1212
+OpBranch %825
+%825 = OpLabel
+%1213 = OpLoad %ulong %1013
+OpStore %1023 %1213
+OpStore %1024 %ulong_0
+OpBranch %826
+%826 = OpLabel
+%1214 = OpLoad %ulong %1024
+%1215 = OpULessThan %bool %1214 %ulong_8
+OpStore %1016 %1215
+%1216 = OpLoad %bool %1016
+OpLoopMerge %828 %959 None
+OpBranchConditional %1216 %827 %828
+%828 = OpLabel
+OpBranch %829
+%829 = OpLabel
+OpBranch %824
+%824 = OpLabel
+%1217 = OpLoad %float %965
+%1218 = OpConvertFToU %ulong %1217
+OpStore %982 %1218
+OpBranch %830
+%830 = OpLabel
+%1219 = OpLoad %ulong %1023
+OpStore %1032 %1219
+OpStore %1033 %ulong_0
+OpBranch %831
+%831 = OpLabel
+%1220 = OpLoad %ulong %1033
+%1221 = OpULessThan %bool %1220 %ulong_8
+OpStore %1025 %1221
+%1222 = OpLoad %bool %1025
+OpLoopMerge %833 %958 None
+OpBranchConditional %1222 %832 %833
+%833 = OpLabel
+OpBranch %834
+%834 = OpLabel
+%1223 = OpLoad %float %965
+%1224 = OpConvertFToS %uchar %1223
+OpStore %983 %1224
+OpBranch %835
+%835 = OpLabel
+%1225 = OpLoad %uchar %983
+%1226 = OpSConvert %ulong %1225
+OpStore %1034 %1226
+OpBranch %837
+%837 = OpLabel
+%1227 = OpLoad %ulong %1032
+OpStore %1042 %1227
+OpStore %1043 %ulong_0
+OpBranch %838
+%838 = OpLabel
+%1228 = OpLoad %ulong %1043
+%1229 = OpULessThan %bool %1228 %ulong_8
+OpStore %1035 %1229
+%1230 = OpLoad %bool %1035
+OpLoopMerge %840 %957 None
+OpBranchConditional %1230 %839 %840
+%840 = OpLabel
+OpBranch %841
+%841 = OpLabel
+OpBranch %836
+%836 = OpLabel
+%1231 = OpLoad %float %965
+%1232 = OpConvertFToS %ushort %1231
+OpStore %984 %1232
+OpBranch %842
+%842 = OpLabel
+%1233 = OpLoad %ushort %984
+%1234 = OpSConvert %ulong %1233
+OpStore %1044 %1234
+OpBranch %844
+%844 = OpLabel
+%1235 = OpLoad %ulong %1042
+OpStore %1052 %1235
+OpStore %1053 %ulong_0
+OpBranch %845
+%845 = OpLabel
+%1236 = OpLoad %ulong %1053
+%1237 = OpULessThan %bool %1236 %ulong_8
+OpStore %1045 %1237
+%1238 = OpLoad %bool %1045
+OpLoopMerge %847 %956 None
+OpBranchConditional %1238 %846 %847
+%847 = OpLabel
+OpBranch %848
+%848 = OpLabel
+OpBranch %843
+%843 = OpLabel
+%1239 = OpLoad %float %965
+%1240 = OpConvertFToS %uint %1239
+OpStore %985 %1240
+OpBranch %849
+%849 = OpLabel
+%1241 = OpLoad %uint %985
+%1242 = OpSConvert %ulong %1241
+OpStore %1054 %1242
+OpBranch %851
+%851 = OpLabel
+%1243 = OpLoad %ulong %1052
+OpStore %1062 %1243
+OpStore %1063 %ulong_0
+OpBranch %852
+%852 = OpLabel
+%1244 = OpLoad %ulong %1063
+%1245 = OpULessThan %bool %1244 %ulong_8
+OpStore %1055 %1245
+%1246 = OpLoad %bool %1055
+OpLoopMerge %854 %955 None
+OpBranchConditional %1246 %853 %854
+%854 = OpLabel
+OpBranch %855
+%855 = OpLabel
+OpBranch %850
+%850 = OpLabel
+%1247 = OpLoad %float %965
+%1248 = OpConvertFToS %ulong %1247
+OpStore %986 %1248
+OpBranch %856
+%856 = OpLabel
+OpBranch %858
+%858 = OpLabel
+%1249 = OpLoad %ulong %1062
+OpStore %1071 %1249
+OpStore %1072 %ulong_0
+OpBranch %859
+%859 = OpLabel
+%1250 = OpLoad %ulong %1072
+%1251 = OpULessThan %bool %1250 %ulong_8
+OpStore %1064 %1251
+%1252 = OpLoad %bool %1064
+OpLoopMerge %861 %954 None
+OpBranchConditional %1252 %860 %861
+%861 = OpLabel
+OpBranch %862
+%862 = OpLabel
+OpBranch %857
+%857 = OpLabel
+%1253 = OpLoad %double %966
+%1254 = OpConvertFToU %uchar %1253
+OpStore %987 %1254
+OpBranch %863
+%863 = OpLabel
+%1255 = OpLoad %uchar %987
+%1256 = OpUConvert %ulong %1255
+OpStore %1073 %1256
+OpBranch %865
+%865 = OpLabel
+%1257 = OpLoad %ulong %1071
+OpStore %1081 %1257
+OpStore %1082 %ulong_0
+OpBranch %866
+%866 = OpLabel
+%1258 = OpLoad %ulong %1082
+%1259 = OpULessThan %bool %1258 %ulong_8
+OpStore %1074 %1259
+%1260 = OpLoad %bool %1074
+OpLoopMerge %868 %953 None
+OpBranchConditional %1260 %867 %868
+%868 = OpLabel
+OpBranch %869
+%869 = OpLabel
+OpBranch %864
+%864 = OpLabel
+%1261 = OpLoad %double %966
+%1262 = OpConvertFToU %ushort %1261
+OpStore %988 %1262
+OpBranch %870
+%870 = OpLabel
+%1263 = OpLoad %ushort %988
+%1264 = OpUConvert %ulong %1263
+OpStore %1083 %1264
+OpBranch %872
+%872 = OpLabel
+%1265 = OpLoad %ulong %1081
+OpStore %1091 %1265
+OpStore %1092 %ulong_0
+OpBranch %873
+%873 = OpLabel
+%1266 = OpLoad %ulong %1092
+%1267 = OpULessThan %bool %1266 %ulong_8
+OpStore %1084 %1267
+%1268 = OpLoad %bool %1084
+OpLoopMerge %875 %952 None
+OpBranchConditional %1268 %874 %875
+%875 = OpLabel
+OpBranch %876
+%876 = OpLabel
+OpBranch %871
+%871 = OpLabel
+%1269 = OpLoad %double %966
+%1270 = OpConvertFToU %uint %1269
+OpStore %989 %1270
+OpBranch %877
+%877 = OpLabel
+%1271 = OpLoad %uint %989
+%1272 = OpUConvert %ulong %1271
+OpStore %1093 %1272
+OpBranch %879
+%879 = OpLabel
+%1273 = OpLoad %ulong %1091
+OpStore %1101 %1273
+OpStore %1102 %ulong_0
+OpBranch %880
+%880 = OpLabel
+%1274 = OpLoad %ulong %1102
+%1275 = OpULessThan %bool %1274 %ulong_8
+OpStore %1094 %1275
+%1276 = OpLoad %bool %1094
+OpLoopMerge %882 %951 None
+OpBranchConditional %1276 %881 %882
+%882 = OpLabel
+OpBranch %883
+%883 = OpLabel
+OpBranch %878
+%878 = OpLabel
+%1277 = OpLoad %double %966
+%1278 = OpConvertFToU %ulong %1277
+OpStore %990 %1278
+OpBranch %884
+%884 = OpLabel
+%1279 = OpLoad %ulong %1101
+OpStore %1110 %1279
+OpStore %1111 %ulong_0
+OpBranch %885
+%885 = OpLabel
+%1280 = OpLoad %ulong %1111
+%1281 = OpULessThan %bool %1280 %ulong_8
+OpStore %1103 %1281
+%1282 = OpLoad %bool %1103
+OpLoopMerge %887 %950 None
+OpBranchConditional %1282 %886 %887
+%887 = OpLabel
+OpBranch %888
+%888 = OpLabel
+%1283 = OpLoad %double %966
+%1284 = OpConvertFToS %uchar %1283
+OpStore %991 %1284
+OpBranch %889
+%889 = OpLabel
+%1285 = OpLoad %uchar %991
+%1286 = OpSConvert %ulong %1285
+OpStore %1112 %1286
+OpBranch %891
+%891 = OpLabel
+%1287 = OpLoad %ulong %1110
+OpStore %1120 %1287
+OpStore %1121 %ulong_0
+OpBranch %892
+%892 = OpLabel
+%1288 = OpLoad %ulong %1121
+%1289 = OpULessThan %bool %1288 %ulong_8
+OpStore %1113 %1289
+%1290 = OpLoad %bool %1113
+OpLoopMerge %894 %949 None
+OpBranchConditional %1290 %893 %894
+%894 = OpLabel
+OpBranch %895
+%895 = OpLabel
+OpBranch %890
+%890 = OpLabel
+%1291 = OpLoad %double %966
+%1292 = OpConvertFToS %ushort %1291
+OpStore %992 %1292
+OpBranch %896
+%896 = OpLabel
+%1293 = OpLoad %ushort %992
+%1294 = OpSConvert %ulong %1293
+OpStore %1122 %1294
+OpBranch %898
+%898 = OpLabel
+%1295 = OpLoad %ulong %1120
+OpStore %1130 %1295
+OpStore %1131 %ulong_0
+OpBranch %899
+%899 = OpLabel
+%1296 = OpLoad %ulong %1131
+%1297 = OpULessThan %bool %1296 %ulong_8
+OpStore %1123 %1297
+%1298 = OpLoad %bool %1123
+OpLoopMerge %901 %948 None
+OpBranchConditional %1298 %900 %901
+%901 = OpLabel
+OpBranch %902
+%902 = OpLabel
+OpBranch %897
+%897 = OpLabel
+%1299 = OpLoad %double %966
+%1300 = OpConvertFToS %uint %1299
+OpStore %993 %1300
+OpBranch %903
+%903 = OpLabel
+%1301 = OpLoad %uint %993
+%1302 = OpSConvert %ulong %1301
+OpStore %1132 %1302
+OpBranch %905
+%905 = OpLabel
+%1303 = OpLoad %ulong %1130
+OpStore %1140 %1303
+OpStore %1141 %ulong_0
+OpBranch %906
+%906 = OpLabel
+%1304 = OpLoad %ulong %1141
+%1305 = OpULessThan %bool %1304 %ulong_8
+OpStore %1133 %1305
+%1306 = OpLoad %bool %1133
+OpLoopMerge %908 %947 None
+OpBranchConditional %1306 %907 %908
+%908 = OpLabel
+OpBranch %909
+%909 = OpLabel
+OpBranch %904
+%904 = OpLabel
+%1307 = OpLoad %double %966
+%1308 = OpConvertFToS %ulong %1307
+OpStore %994 %1308
+OpBranch %910
+%910 = OpLabel
+OpBranch %912
+%912 = OpLabel
+%1309 = OpLoad %ulong %1140
+OpStore %1149 %1309
+OpStore %1150 %ulong_0
+OpBranch %913
+%913 = OpLabel
+%1310 = OpLoad %ulong %1150
+%1311 = OpULessThan %bool %1310 %ulong_8
+OpStore %1142 %1311
+%1312 = OpLoad %bool %1142
+OpLoopMerge %915 %946 None
+OpBranchConditional %1312 %914 %915
+%915 = OpLabel
+OpBranch %916
+%916 = OpLabel
+OpBranch %911
+%911 = OpLabel
+OpBranch %917
+%917 = OpLabel
+%1313 = OpFNegate %float %float_40_75
+OpStore %967 %1313
+%1314 = OpLoad %float %967
+%1315 = OpLoad %float %963
+%1316 = OpFSub %float %1314 %1315
+OpStore %968 %1316
+%1318 = OpLoad %double %964
+%1319 = OpFSub %double %double_n40_75 %1318
+OpStore %969 %1319
+OpBranch %918
+%918 = OpLabel
+%1320 = OpLoad %float %968
+%1321 = OpConvertFToS %uchar %1320
+OpStore %1151 %1321
+OpBranch %919
+%919 = OpLabel
+%1322 = OpLoad %uchar %1151
+%1323 = OpSConvert %ulong %1322
+OpStore %1159 %1323
+%1324 = OpLoad %ulong %1149
+%1325 = OpLoad %ulong %1159
+%1326 = OpFunctionCall %ulong %4 %1324 %1325
+OpStore %1160 %1326
+OpBranch %920
+%920 = OpLabel
+%1327 = OpLoad %float %968
+%1328 = OpConvertFToS %ushort %1327
+OpStore %1152 %1328
+OpBranch %921
+%921 = OpLabel
+%1329 = OpLoad %ushort %1152
+%1330 = OpSConvert %ulong %1329
+OpStore %1161 %1330
+%1331 = OpLoad %ulong %1160
+%1332 = OpLoad %ulong %1161
+%1333 = OpFunctionCall %ulong %4 %1331 %1332
+OpStore %1162 %1333
+OpBranch %922
+%922 = OpLabel
+%1334 = OpLoad %float %968
+%1335 = OpConvertFToS %uint %1334
+OpStore %1153 %1335
+OpBranch %923
+%923 = OpLabel
+%1336 = OpLoad %uint %1153
+%1337 = OpSConvert %ulong %1336
+OpStore %1163 %1337
+%1338 = OpLoad %ulong %1162
+%1339 = OpLoad %ulong %1163
+%1340 = OpFunctionCall %ulong %4 %1338 %1339
+OpStore %1164 %1340
+OpBranch %924
+%924 = OpLabel
+%1341 = OpLoad %float %968
+%1342 = OpConvertFToS %ulong %1341
+OpStore %1154 %1342
+OpBranch %925
+%925 = OpLabel
+%1343 = OpLoad %ulong %1164
+%1344 = OpLoad %ulong %1154
+%1345 = OpFunctionCall %ulong %4 %1343 %1344
+OpStore %1165 %1345
+OpBranch %926
+%926 = OpLabel
+%1346 = OpLoad %double %969
+%1347 = OpConvertFToS %uchar %1346
+OpStore %1155 %1347
+OpBranch %927
+%927 = OpLabel
+%1348 = OpLoad %uchar %1155
+%1349 = OpSConvert %ulong %1348
+OpStore %1166 %1349
+%1350 = OpLoad %ulong %1165
+%1351 = OpLoad %ulong %1166
+%1352 = OpFunctionCall %ulong %4 %1350 %1351
+OpStore %1167 %1352
+OpBranch %928
+%928 = OpLabel
+%1353 = OpLoad %double %969
+%1354 = OpConvertFToS %ushort %1353
+OpStore %1156 %1354
+OpBranch %929
+%929 = OpLabel
+%1355 = OpLoad %ushort %1156
+%1356 = OpSConvert %ulong %1355
+OpStore %1168 %1356
+%1357 = OpLoad %ulong %1167
+%1358 = OpLoad %ulong %1168
+%1359 = OpFunctionCall %ulong %4 %1357 %1358
+OpStore %1169 %1359
+OpBranch %930
+%930 = OpLabel
+%1360 = OpLoad %double %969
+%1361 = OpConvertFToS %uint %1360
+OpStore %1157 %1361
+OpBranch %931
+%931 = OpLabel
+%1362 = OpLoad %uint %1157
+%1363 = OpSConvert %ulong %1362
+OpStore %1170 %1363
+%1364 = OpLoad %ulong %1169
+%1365 = OpLoad %ulong %1170
+%1366 = OpFunctionCall %ulong %4 %1364 %1365
+OpStore %1171 %1366
+OpBranch %932
+%932 = OpLabel
+%1367 = OpLoad %double %969
+%1368 = OpConvertFToS %ulong %1367
+OpStore %1158 %1368
+OpBranch %933
+%933 = OpLabel
+%1369 = OpLoad %ulong %1171
+%1370 = OpLoad %ulong %1158
+%1371 = OpFunctionCall %ulong %4 %1369 %1370
+OpStore %1172 %1371
+OpBranch %934
+%934 = OpLabel
+OpBranch %935
+%935 = OpLabel
+%1373 = OpLoad %float %963
+%1374 = OpFAdd %float %float_127 %1373
+OpStore %970 %1374
+%1375 = OpLoad %float %970
+%1376 = OpConvertFToS %uchar %1375
+OpStore %971 %1376
+OpBranch %936
+%936 = OpLabel
+%1377 = OpLoad %uchar %971
+%1378 = OpSConvert %ulong %1377
+OpStore %1173 %1378
+%1379 = OpLoad %ulong %1172
+%1380 = OpLoad %ulong %1173
+%1381 = OpFunctionCall %ulong %4 %1379 %1380
+OpStore %1174 %1381
+OpBranch %937
+%937 = OpLabel
+%1383 = OpLoad %float %963
+%1384 = OpFAdd %float %float_255 %1383
+OpStore %972 %1384
+%1385 = OpLoad %float %972
+%1386 = OpConvertFToU %uchar %1385
+OpStore %973 %1386
+OpBranch %938
+%938 = OpLabel
+%1387 = OpLoad %uchar %973
+%1388 = OpUConvert %ulong %1387
+OpStore %1175 %1388
+%1389 = OpLoad %ulong %1174
+%1390 = OpLoad %ulong %1175
+%1391 = OpFunctionCall %ulong %4 %1389 %1390
+OpStore %1176 %1391
+OpBranch %939
+%939 = OpLabel
+%1393 = OpLoad %double %964
+%1394 = OpFAdd %double %double_0_99990000000000001 %1393
+OpStore %974 %1394
+%1395 = OpLoad %double %974
+%1396 = OpConvertFToU %uchar %1395
+OpStore %975 %1396
+OpBranch %940
+%940 = OpLabel
+%1397 = OpLoad %uchar %975
+%1398 = OpUConvert %ulong %1397
+OpStore %1177 %1398
+%1399 = OpLoad %ulong %1176
+%1400 = OpLoad %ulong %1177
+%1401 = OpFunctionCall %ulong %4 %1399 %1400
+OpStore %1178 %1401
+OpBranch %941
+%941 = OpLabel
+%1402 = OpLoad %double %974
+%1403 = OpConvertFToS %uchar %1402
+OpStore %976 %1403
+OpBranch %942
+%942 = OpLabel
+%1404 = OpLoad %uchar %976
+%1405 = OpSConvert %ulong %1404
+OpStore %1179 %1405
+%1406 = OpLoad %ulong %1178
+%1407 = OpLoad %ulong %1179
+%1408 = OpFunctionCall %ulong %4 %1406 %1407
+OpStore %1180 %1408
+OpBranch %943
+%943 = OpLabel
+%1410 = OpLoad %double %964
+%1411 = OpFSub %double %double_n0_99990000000000001 %1410
+OpStore %977 %1411
+%1412 = OpLoad %double %977
+%1413 = OpConvertFToS %uchar %1412
+OpStore %978 %1413
+OpBranch %944
+%944 = OpLabel
+%1414 = OpLoad %uchar %978
+%1415 = OpSConvert %ulong %1414
+OpStore %1181 %1415
+%1416 = OpLoad %ulong %1180
+%1417 = OpLoad %ulong %1181
+%1418 = OpFunctionCall %ulong %4 %1416 %1417
+OpStore %1182 %1418
+OpBranch %945
+%945 = OpLabel
+%1419 = OpLoad %ulong %1182
+OpReturnValue %1419
+%914 = OpLabel
+%1420 = OpLoad %ulong %1150
+%1421 = OpIMul %ulong %1420 %ulong_8
+OpStore %1143 %1421
+%1422 = OpLoad %ulong %994
+%1423 = OpLoad %ulong %1143
+%1424 = OpShiftRightLogical %ulong %1422 %1423
+OpStore %1144 %1424
+%1425 = OpLoad %ulong %1144
+%1426 = OpBitwiseAnd %ulong %1425 %ulong_255
+OpStore %1145 %1426
+%1427 = OpLoad %ulong %1149
+%1428 = OpLoad %ulong %1145
+%1429 = OpBitwiseXor %ulong %1427 %1428
+OpStore %1146 %1429
+%1430 = OpLoad %ulong %1146
+%1431 = OpIMul %ulong %1430 %ulong_1099511628211
+OpStore %1147 %1431
+%1432 = OpLoad %ulong %1150
+%1433 = OpIAdd %ulong %1432 %ulong_1
+OpStore %1148 %1433
+%1434 = OpLoad %ulong %1147
+OpStore %1149 %1434
+%1435 = OpLoad %ulong %1148
+OpStore %1150 %1435
+OpBranch %946
+%907 = OpLabel
+%1436 = OpLoad %ulong %1141
+%1437 = OpIMul %ulong %1436 %ulong_8
+OpStore %1134 %1437
+%1438 = OpLoad %ulong %1132
+%1439 = OpLoad %ulong %1134
+%1440 = OpShiftRightLogical %ulong %1438 %1439
+OpStore %1135 %1440
+%1441 = OpLoad %ulong %1135
+%1442 = OpBitwiseAnd %ulong %1441 %ulong_255
+OpStore %1136 %1442
+%1443 = OpLoad %ulong %1140
+%1444 = OpLoad %ulong %1136
+%1445 = OpBitwiseXor %ulong %1443 %1444
+OpStore %1137 %1445
+%1446 = OpLoad %ulong %1137
+%1447 = OpIMul %ulong %1446 %ulong_1099511628211
+OpStore %1138 %1447
+%1448 = OpLoad %ulong %1141
+%1449 = OpIAdd %ulong %1448 %ulong_1
+OpStore %1139 %1449
+%1450 = OpLoad %ulong %1138
+OpStore %1140 %1450
+%1451 = OpLoad %ulong %1139
+OpStore %1141 %1451
+OpBranch %947
+%900 = OpLabel
+%1452 = OpLoad %ulong %1131
+%1453 = OpIMul %ulong %1452 %ulong_8
+OpStore %1124 %1453
+%1454 = OpLoad %ulong %1122
+%1455 = OpLoad %ulong %1124
+%1456 = OpShiftRightLogical %ulong %1454 %1455
+OpStore %1125 %1456
+%1457 = OpLoad %ulong %1125
+%1458 = OpBitwiseAnd %ulong %1457 %ulong_255
+OpStore %1126 %1458
+%1459 = OpLoad %ulong %1130
+%1460 = OpLoad %ulong %1126
+%1461 = OpBitwiseXor %ulong %1459 %1460
+OpStore %1127 %1461
+%1462 = OpLoad %ulong %1127
+%1463 = OpIMul %ulong %1462 %ulong_1099511628211
+OpStore %1128 %1463
+%1464 = OpLoad %ulong %1131
+%1465 = OpIAdd %ulong %1464 %ulong_1
+OpStore %1129 %1465
+%1466 = OpLoad %ulong %1128
+OpStore %1130 %1466
+%1467 = OpLoad %ulong %1129
+OpStore %1131 %1467
+OpBranch %948
+%893 = OpLabel
+%1468 = OpLoad %ulong %1121
+%1469 = OpIMul %ulong %1468 %ulong_8
+OpStore %1114 %1469
+%1470 = OpLoad %ulong %1112
+%1471 = OpLoad %ulong %1114
+%1472 = OpShiftRightLogical %ulong %1470 %1471
+OpStore %1115 %1472
+%1473 = OpLoad %ulong %1115
+%1474 = OpBitwiseAnd %ulong %1473 %ulong_255
+OpStore %1116 %1474
+%1475 = OpLoad %ulong %1120
+%1476 = OpLoad %ulong %1116
+%1477 = OpBitwiseXor %ulong %1475 %1476
+OpStore %1117 %1477
+%1478 = OpLoad %ulong %1117
+%1479 = OpIMul %ulong %1478 %ulong_1099511628211
+OpStore %1118 %1479
+%1480 = OpLoad %ulong %1121
+%1481 = OpIAdd %ulong %1480 %ulong_1
+OpStore %1119 %1481
+%1482 = OpLoad %ulong %1118
+OpStore %1120 %1482
+%1483 = OpLoad %ulong %1119
+OpStore %1121 %1483
+OpBranch %949
+%886 = OpLabel
+%1484 = OpLoad %ulong %1111
+%1485 = OpIMul %ulong %1484 %ulong_8
+OpStore %1104 %1485
+%1486 = OpLoad %ulong %990
+%1487 = OpLoad %ulong %1104
+%1488 = OpShiftRightLogical %ulong %1486 %1487
+OpStore %1105 %1488
+%1489 = OpLoad %ulong %1105
+%1490 = OpBitwiseAnd %ulong %1489 %ulong_255
+OpStore %1106 %1490
+%1491 = OpLoad %ulong %1110
+%1492 = OpLoad %ulong %1106
+%1493 = OpBitwiseXor %ulong %1491 %1492
+OpStore %1107 %1493
+%1494 = OpLoad %ulong %1107
+%1495 = OpIMul %ulong %1494 %ulong_1099511628211
+OpStore %1108 %1495
+%1496 = OpLoad %ulong %1111
+%1497 = OpIAdd %ulong %1496 %ulong_1
+OpStore %1109 %1497
+%1498 = OpLoad %ulong %1108
+OpStore %1110 %1498
+%1499 = OpLoad %ulong %1109
+OpStore %1111 %1499
+OpBranch %950
+%881 = OpLabel
+%1500 = OpLoad %ulong %1102
+%1501 = OpIMul %ulong %1500 %ulong_8
+OpStore %1095 %1501
+%1502 = OpLoad %ulong %1093
+%1503 = OpLoad %ulong %1095
+%1504 = OpShiftRightLogical %ulong %1502 %1503
+OpStore %1096 %1504
+%1505 = OpLoad %ulong %1096
+%1506 = OpBitwiseAnd %ulong %1505 %ulong_255
+OpStore %1097 %1506
+%1507 = OpLoad %ulong %1101
+%1508 = OpLoad %ulong %1097
+%1509 = OpBitwiseXor %ulong %1507 %1508
+OpStore %1098 %1509
+%1510 = OpLoad %ulong %1098
+%1511 = OpIMul %ulong %1510 %ulong_1099511628211
+OpStore %1099 %1511
+%1512 = OpLoad %ulong %1102
+%1513 = OpIAdd %ulong %1512 %ulong_1
+OpStore %1100 %1513
+%1514 = OpLoad %ulong %1099
+OpStore %1101 %1514
+%1515 = OpLoad %ulong %1100
+OpStore %1102 %1515
+OpBranch %951
+%874 = OpLabel
+%1516 = OpLoad %ulong %1092
+%1517 = OpIMul %ulong %1516 %ulong_8
+OpStore %1085 %1517
+%1518 = OpLoad %ulong %1083
+%1519 = OpLoad %ulong %1085
+%1520 = OpShiftRightLogical %ulong %1518 %1519
+OpStore %1086 %1520
+%1521 = OpLoad %ulong %1086
+%1522 = OpBitwiseAnd %ulong %1521 %ulong_255
+OpStore %1087 %1522
+%1523 = OpLoad %ulong %1091
+%1524 = OpLoad %ulong %1087
+%1525 = OpBitwiseXor %ulong %1523 %1524
+OpStore %1088 %1525
+%1526 = OpLoad %ulong %1088
+%1527 = OpIMul %ulong %1526 %ulong_1099511628211
+OpStore %1089 %1527
+%1528 = OpLoad %ulong %1092
+%1529 = OpIAdd %ulong %1528 %ulong_1
+OpStore %1090 %1529
+%1530 = OpLoad %ulong %1089
+OpStore %1091 %1530
+%1531 = OpLoad %ulong %1090
+OpStore %1092 %1531
+OpBranch %952
+%867 = OpLabel
+%1532 = OpLoad %ulong %1082
+%1533 = OpIMul %ulong %1532 %ulong_8
+OpStore %1075 %1533
+%1534 = OpLoad %ulong %1073
+%1535 = OpLoad %ulong %1075
+%1536 = OpShiftRightLogical %ulong %1534 %1535
+OpStore %1076 %1536
+%1537 = OpLoad %ulong %1076
+%1538 = OpBitwiseAnd %ulong %1537 %ulong_255
+OpStore %1077 %1538
+%1539 = OpLoad %ulong %1081
+%1540 = OpLoad %ulong %1077
+%1541 = OpBitwiseXor %ulong %1539 %1540
+OpStore %1078 %1541
+%1542 = OpLoad %ulong %1078
+%1543 = OpIMul %ulong %1542 %ulong_1099511628211
+OpStore %1079 %1543
+%1544 = OpLoad %ulong %1082
+%1545 = OpIAdd %ulong %1544 %ulong_1
+OpStore %1080 %1545
+%1546 = OpLoad %ulong %1079
+OpStore %1081 %1546
+%1547 = OpLoad %ulong %1080
+OpStore %1082 %1547
+OpBranch %953
+%860 = OpLabel
+%1548 = OpLoad %ulong %1072
+%1549 = OpIMul %ulong %1548 %ulong_8
+OpStore %1065 %1549
+%1550 = OpLoad %ulong %986
+%1551 = OpLoad %ulong %1065
+%1552 = OpShiftRightLogical %ulong %1550 %1551
+OpStore %1066 %1552
+%1553 = OpLoad %ulong %1066
+%1554 = OpBitwiseAnd %ulong %1553 %ulong_255
+OpStore %1067 %1554
+%1555 = OpLoad %ulong %1071
+%1556 = OpLoad %ulong %1067
+%1557 = OpBitwiseXor %ulong %1555 %1556
+OpStore %1068 %1557
+%1558 = OpLoad %ulong %1068
+%1559 = OpIMul %ulong %1558 %ulong_1099511628211
+OpStore %1069 %1559
+%1560 = OpLoad %ulong %1072
+%1561 = OpIAdd %ulong %1560 %ulong_1
+OpStore %1070 %1561
+%1562 = OpLoad %ulong %1069
+OpStore %1071 %1562
+%1563 = OpLoad %ulong %1070
+OpStore %1072 %1563
+OpBranch %954
+%853 = OpLabel
+%1564 = OpLoad %ulong %1063
+%1565 = OpIMul %ulong %1564 %ulong_8
+OpStore %1056 %1565
+%1566 = OpLoad %ulong %1054
+%1567 = OpLoad %ulong %1056
+%1568 = OpShiftRightLogical %ulong %1566 %1567
+OpStore %1057 %1568
+%1569 = OpLoad %ulong %1057
+%1570 = OpBitwiseAnd %ulong %1569 %ulong_255
+OpStore %1058 %1570
+%1571 = OpLoad %ulong %1062
+%1572 = OpLoad %ulong %1058
+%1573 = OpBitwiseXor %ulong %1571 %1572
+OpStore %1059 %1573
+%1574 = OpLoad %ulong %1059
+%1575 = OpIMul %ulong %1574 %ulong_1099511628211
+OpStore %1060 %1575
+%1576 = OpLoad %ulong %1063
+%1577 = OpIAdd %ulong %1576 %ulong_1
+OpStore %1061 %1577
+%1578 = OpLoad %ulong %1060
+OpStore %1062 %1578
+%1579 = OpLoad %ulong %1061
+OpStore %1063 %1579
+OpBranch %955
+%846 = OpLabel
+%1580 = OpLoad %ulong %1053
+%1581 = OpIMul %ulong %1580 %ulong_8
+OpStore %1046 %1581
+%1582 = OpLoad %ulong %1044
+%1583 = OpLoad %ulong %1046
+%1584 = OpShiftRightLogical %ulong %1582 %1583
+OpStore %1047 %1584
+%1585 = OpLoad %ulong %1047
+%1586 = OpBitwiseAnd %ulong %1585 %ulong_255
+OpStore %1048 %1586
+%1587 = OpLoad %ulong %1052
+%1588 = OpLoad %ulong %1048
+%1589 = OpBitwiseXor %ulong %1587 %1588
+OpStore %1049 %1589
+%1590 = OpLoad %ulong %1049
+%1591 = OpIMul %ulong %1590 %ulong_1099511628211
+OpStore %1050 %1591
+%1592 = OpLoad %ulong %1053
+%1593 = OpIAdd %ulong %1592 %ulong_1
+OpStore %1051 %1593
+%1594 = OpLoad %ulong %1050
+OpStore %1052 %1594
+%1595 = OpLoad %ulong %1051
+OpStore %1053 %1595
+OpBranch %956
+%839 = OpLabel
+%1596 = OpLoad %ulong %1043
+%1597 = OpIMul %ulong %1596 %ulong_8
+OpStore %1036 %1597
+%1598 = OpLoad %ulong %1034
+%1599 = OpLoad %ulong %1036
+%1600 = OpShiftRightLogical %ulong %1598 %1599
+OpStore %1037 %1600
+%1601 = OpLoad %ulong %1037
+%1602 = OpBitwiseAnd %ulong %1601 %ulong_255
+OpStore %1038 %1602
+%1603 = OpLoad %ulong %1042
+%1604 = OpLoad %ulong %1038
+%1605 = OpBitwiseXor %ulong %1603 %1604
+OpStore %1039 %1605
+%1606 = OpLoad %ulong %1039
+%1607 = OpIMul %ulong %1606 %ulong_1099511628211
+OpStore %1040 %1607
+%1608 = OpLoad %ulong %1043
+%1609 = OpIAdd %ulong %1608 %ulong_1
+OpStore %1041 %1609
+%1610 = OpLoad %ulong %1040
+OpStore %1042 %1610
+%1611 = OpLoad %ulong %1041
+OpStore %1043 %1611
+OpBranch %957
+%832 = OpLabel
+%1612 = OpLoad %ulong %1033
+%1613 = OpIMul %ulong %1612 %ulong_8
+OpStore %1026 %1613
+%1614 = OpLoad %ulong %982
+%1615 = OpLoad %ulong %1026
+%1616 = OpShiftRightLogical %ulong %1614 %1615
+OpStore %1027 %1616
+%1617 = OpLoad %ulong %1027
+%1618 = OpBitwiseAnd %ulong %1617 %ulong_255
+OpStore %1028 %1618
+%1619 = OpLoad %ulong %1032
+%1620 = OpLoad %ulong %1028
+%1621 = OpBitwiseXor %ulong %1619 %1620
+OpStore %1029 %1621
+%1622 = OpLoad %ulong %1029
+%1623 = OpIMul %ulong %1622 %ulong_1099511628211
+OpStore %1030 %1623
+%1624 = OpLoad %ulong %1033
+%1625 = OpIAdd %ulong %1624 %ulong_1
+OpStore %1031 %1625
+%1626 = OpLoad %ulong %1030
+OpStore %1032 %1626
+%1627 = OpLoad %ulong %1031
+OpStore %1033 %1627
+OpBranch %958
+%827 = OpLabel
+%1628 = OpLoad %ulong %1024
+%1629 = OpIMul %ulong %1628 %ulong_8
+OpStore %1017 %1629
+%1630 = OpLoad %ulong %1015
+%1631 = OpLoad %ulong %1017
+%1632 = OpShiftRightLogical %ulong %1630 %1631
+OpStore %1018 %1632
+%1633 = OpLoad %ulong %1018
+%1634 = OpBitwiseAnd %ulong %1633 %ulong_255
+OpStore %1019 %1634
+%1635 = OpLoad %ulong %1023
+%1636 = OpLoad %ulong %1019
+%1637 = OpBitwiseXor %ulong %1635 %1636
+OpStore %1020 %1637
+%1638 = OpLoad %ulong %1020
+%1639 = OpIMul %ulong %1638 %ulong_1099511628211
+OpStore %1021 %1639
+%1640 = OpLoad %ulong %1024
+%1641 = OpIAdd %ulong %1640 %ulong_1
+OpStore %1022 %1641
+%1642 = OpLoad %ulong %1021
+OpStore %1023 %1642
+%1643 = OpLoad %ulong %1022
+OpStore %1024 %1643
+OpBranch %959
+%820 = OpLabel
+%1644 = OpLoad %ulong %1014
+%1645 = OpIMul %ulong %1644 %ulong_8
+OpStore %1007 %1645
+%1646 = OpLoad %ulong %1005
+%1647 = OpLoad %ulong %1007
+%1648 = OpShiftRightLogical %ulong %1646 %1647
+OpStore %1008 %1648
+%1649 = OpLoad %ulong %1008
+%1650 = OpBitwiseAnd %ulong %1649 %ulong_255
+OpStore %1009 %1650
+%1651 = OpLoad %ulong %1013
+%1652 = OpLoad %ulong %1009
+%1653 = OpBitwiseXor %ulong %1651 %1652
+OpStore %1010 %1653
+%1654 = OpLoad %ulong %1010
+%1655 = OpIMul %ulong %1654 %ulong_1099511628211
+OpStore %1011 %1655
+%1656 = OpLoad %ulong %1014
+%1657 = OpIAdd %ulong %1656 %ulong_1
+OpStore %1012 %1657
+%1658 = OpLoad %ulong %1011
+OpStore %1013 %1658
+%1659 = OpLoad %ulong %1012
+OpStore %1014 %1659
+OpBranch %960
+%813 = OpLabel
+%1660 = OpLoad %ulong %1004
+%1661 = OpIMul %ulong %1660 %ulong_8
+OpStore %997 %1661
+%1662 = OpLoad %ulong %995
+%1663 = OpLoad %ulong %997
+%1664 = OpShiftRightLogical %ulong %1662 %1663
+OpStore %998 %1664
+%1665 = OpLoad %ulong %998
+%1666 = OpBitwiseAnd %ulong %1665 %ulong_255
+OpStore %999 %1666
+%1667 = OpLoad %ulong %1003
+%1668 = OpLoad %ulong %999
+%1669 = OpBitwiseXor %ulong %1667 %1668
+OpStore %1000 %1669
+%1670 = OpLoad %ulong %1000
+%1671 = OpIMul %ulong %1670 %ulong_1099511628211
+OpStore %1001 %1671
+%1672 = OpLoad %ulong %1004
+%1673 = OpIAdd %ulong %1672 %ulong_1
+OpStore %1002 %1673
+%1674 = OpLoad %ulong %1001
+OpStore %1003 %1674
+%1675 = OpLoad %ulong %1002
+OpStore %1004 %1675
+OpBranch %961
+%946 = OpLabel
+OpBranch %913
+%947 = OpLabel
+OpBranch %906
+%948 = OpLabel
+OpBranch %899
+%949 = OpLabel
+OpBranch %892
+%950 = OpLabel
+OpBranch %885
+%951 = OpLabel
+OpBranch %880
+%952 = OpLabel
+OpBranch %873
+%953 = OpLabel
+OpBranch %866
+%954 = OpLabel
+OpBranch %859
+%955 = OpLabel
+OpBranch %852
+%956 = OpLabel
+OpBranch %845
+%957 = OpLabel
+OpBranch %838
+%958 = OpLabel
+OpBranch %831
+%959 = OpLabel
+OpBranch %826
+%960 = OpLabel
+OpBranch %819
+%961 = OpLabel
+OpBranch %812
+OpFunctionEnd
+%4 = OpFunction %ulong None %1676
+%1677 = OpFunctionParameter %ulong
+%1678 = OpFunctionParameter %ulong
+%1679 = OpLabel
+%1684 = OpVariable %_ptr_Function_ulong Function
+%1685 = OpVariable %_ptr_Function_ulong Function
+%1686 = OpVariable %_ptr_Function_bool Function
+%1687 = OpVariable %_ptr_Function_ulong Function
+%1688 = OpVariable %_ptr_Function_ulong Function
+%1689 = OpVariable %_ptr_Function_ulong Function
+%1690 = OpVariable %_ptr_Function_ulong Function
+%1691 = OpVariable %_ptr_Function_ulong Function
+%1692 = OpVariable %_ptr_Function_ulong Function
+%1693 = OpVariable %_ptr_Function_ulong Function
+%1694 = OpVariable %_ptr_Function_ulong Function
+OpStore %1684 %1677
+OpStore %1685 %1678
+%1695 = OpLoad %ulong %1684
+OpStore %1693 %1695
+OpStore %1694 %ulong_0
+OpBranch %1680
+%1680 = OpLabel
+%1696 = OpLoad %ulong %1694
+%1697 = OpULessThan %bool %1696 %ulong_8
+OpStore %1686 %1697
+%1698 = OpLoad %bool %1686
+OpLoopMerge %1682 %1683 None
+OpBranchConditional %1698 %1681 %1682
+%1682 = OpLabel
+%1699 = OpLoad %ulong %1693
+OpReturnValue %1699
+%1681 = OpLabel
+%1700 = OpLoad %ulong %1694
+%1701 = OpIMul %ulong %1700 %ulong_8
+OpStore %1687 %1701
+%1702 = OpLoad %ulong %1685
+%1703 = OpLoad %ulong %1687
+%1704 = OpShiftRightLogical %ulong %1702 %1703
+OpStore %1688 %1704
+%1705 = OpLoad %ulong %1688
+%1706 = OpBitwiseAnd %ulong %1705 %ulong_255
+OpStore %1689 %1706
+%1707 = OpLoad %ulong %1693
+%1708 = OpLoad %ulong %1689
+%1709 = OpBitwiseXor %ulong %1707 %1708
+OpStore %1690 %1709
+%1710 = OpLoad %ulong %1690
+%1711 = OpIMul %ulong %1710 %ulong_1099511628211
+OpStore %1691 %1711
+%1712 = OpLoad %ulong %1694
+%1713 = OpIAdd %ulong %1712 %ulong_1
+OpStore %1692 %1713
+%1714 = OpLoad %ulong %1691
+OpStore %1693 %1714
+%1715 = OpLoad %ulong %1692
+OpStore %1694 %1715
+OpBranch %1683
+%1683 = OpLabel
+OpBranch %1680
 OpFunctionEnd

--- a/test/golden/spirv/convert/f2u_high.dis
+++ b/test/golden/spirv/convert/f2u_high.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 439
+; Bound: 1152
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,16 +15,24 @@ OpDecorate %4 LinkageAttributes "corpus.cases.convert.f2u_high.f64_u64" Export
 OpDecorate %5 LinkageAttributes "corpus.cases.convert.f2u_high.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
-%11 = OpTypeFunction %ulong %ulong %float
+%8 = OpTypeFunction %ulong %ulong %float
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %double = OpTypeFloat 64
-%30 = OpTypeFunction %ulong %ulong %double
+%70 = OpTypeFunction %ulong %ulong %double
 %_ptr_Function_double = OpTypePointer Function %double
-%71 = OpTypeFunction %ulong %ulong
+%209 = OpTypeFunction %ulong %ulong
 %float_2_14748352e_09 = OpConstant %float 2.14748352e+09
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_2_14748365e_09 = OpConstant %float 2.14748365e+09
 %float_2_1474839e_09 = OpConstant %float 2.1474839e+09
 %float_3_22122547e_09 = OpConstant %float 3.22122547e+09
@@ -44,585 +52,1690 @@ OpDecorate %5 LinkageAttributes "corpus.cases.convert.f2u_high.checksum" Export
 %double_9_2233720368547779e_18 = OpConstant %double 9.2233720368547779e+18
 %double_1_3835058055282164e_19 = OpConstant %double 1.3835058055282164e+19
 %double_1_844674407370955e_19 = OpConstant %double 1.844674407370955e+19
-%344 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%347 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%394 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %float
-%14 = OpLabel
-%17 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_uint Function
-%22 = OpVariable %_ptr_Function_ulong Function
-OpStore %17 %12
-OpStore %19 %13
-%23 = OpLoad %float %19
-%24 = OpConvertFToU %uint %23
-OpStore %21 %24
-%25 = OpLoad %ulong %17
-%26 = OpLoad %uint %21
-%27 = OpFunctionCall %ulong %8 %25 %26
-OpStore %22 %27
-%28 = OpLoad %ulong %22
-OpReturnValue %28
-OpFunctionEnd
-%2 = OpFunction %ulong None %30
-%31 = OpFunctionParameter %ulong
-%32 = OpFunctionParameter %double
-%33 = OpLabel
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %float
+%11 = OpLabel
+%23 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_float Function
+%27 = OpVariable %_ptr_Function_uint Function
+%28 = OpVariable %_ptr_Function_ulong Function
+%30 = OpVariable %_ptr_Function_bool Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%32 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_ulong Function
 %34 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_double Function
-%37 = OpVariable %_ptr_Function_uint Function
+%35 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_ulong Function
+%37 = OpVariable %_ptr_Function_ulong Function
 %38 = OpVariable %_ptr_Function_ulong Function
-OpStore %34 %31
-OpStore %36 %32
-%39 = OpLoad %double %36
+OpStore %23 %9
+OpStore %25 %10
+%39 = OpLoad %float %25
 %40 = OpConvertFToU %uint %39
-OpStore %37 %40
-%41 = OpLoad %ulong %34
-%42 = OpLoad %uint %37
-%43 = OpFunctionCall %ulong %8 %41 %42
-OpStore %38 %43
-%44 = OpLoad %ulong %38
-OpReturnValue %44
+OpStore %27 %40
+OpBranch %12
+%12 = OpLabel
+%41 = OpLoad %uint %27
+%42 = OpUConvert %ulong %41
+OpStore %28 %42
+OpBranch %14
+%14 = OpLabel
+%43 = OpLoad %ulong %23
+OpStore %37 %43
+OpStore %38 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%45 = OpLoad %ulong %38
+%47 = OpULessThan %bool %45 %ulong_8
+OpStore %30 %47
+%48 = OpLoad %bool %30
+OpLoopMerge %17 %19 None
+OpBranchConditional %48 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%49 = OpLoad %ulong %37
+OpReturnValue %49
+%16 = OpLabel
+%50 = OpLoad %ulong %38
+%51 = OpIMul %ulong %50 %ulong_8
+OpStore %31 %51
+%52 = OpLoad %ulong %28
+%53 = OpLoad %ulong %31
+%54 = OpShiftRightLogical %ulong %52 %53
+OpStore %32 %54
+%55 = OpLoad %ulong %32
+%57 = OpBitwiseAnd %ulong %55 %ulong_255
+OpStore %33 %57
+%58 = OpLoad %ulong %37
+%59 = OpLoad %ulong %33
+%60 = OpBitwiseXor %ulong %58 %59
+OpStore %34 %60
+%61 = OpLoad %ulong %34
+%63 = OpIMul %ulong %61 %ulong_1099511628211
+OpStore %35 %63
+%64 = OpLoad %ulong %38
+%66 = OpIAdd %ulong %64 %ulong_1
+OpStore %36 %66
+%67 = OpLoad %ulong %35
+OpStore %37 %67
+%68 = OpLoad %ulong %36
+OpStore %38 %68
+OpBranch %19
+%19 = OpLabel
+OpBranch %15
 OpFunctionEnd
-%3 = OpFunction %ulong None %11
-%45 = OpFunctionParameter %ulong
-%46 = OpFunctionParameter %float
-%47 = OpLabel
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_float Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-OpStore %48 %45
-OpStore %49 %46
-%52 = OpLoad %float %49
-%53 = OpConvertFToU %ulong %52
-OpStore %50 %53
-%54 = OpLoad %ulong %48
-%55 = OpLoad %ulong %50
-%56 = OpFunctionCall %ulong %7 %54 %55
-OpStore %51 %56
-%57 = OpLoad %ulong %51
-OpReturnValue %57
-OpFunctionEnd
-%4 = OpFunction %ulong None %30
-%58 = OpFunctionParameter %ulong
-%59 = OpFunctionParameter %double
-%60 = OpLabel
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_double Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-OpStore %61 %58
-OpStore %62 %59
-%65 = OpLoad %double %62
-%66 = OpConvertFToU %ulong %65
-OpStore %63 %66
-%67 = OpLoad %ulong %61
-%68 = OpLoad %ulong %63
-%69 = OpFunctionCall %ulong %7 %67 %68
-OpStore %64 %69
-%70 = OpLoad %ulong %64
-OpReturnValue %70
-OpFunctionEnd
-%5 = OpFunction %ulong None %71
-%72 = OpFunctionParameter %ulong
+%2 = OpFunction %ulong None %70
+%71 = OpFunctionParameter %ulong
+%72 = OpFunctionParameter %double
 %73 = OpLabel
-%114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_float Function
-%117 = OpVariable %_ptr_Function_double Function
-%118 = OpVariable %_ptr_Function_float Function
-%119 = OpVariable %_ptr_Function_float Function
-%120 = OpVariable %_ptr_Function_float Function
-%121 = OpVariable %_ptr_Function_float Function
-%122 = OpVariable %_ptr_Function_float Function
-%123 = OpVariable %_ptr_Function_double Function
-%124 = OpVariable %_ptr_Function_double Function
-%125 = OpVariable %_ptr_Function_double Function
-%126 = OpVariable %_ptr_Function_double Function
-%127 = OpVariable %_ptr_Function_double Function
-%128 = OpVariable %_ptr_Function_float Function
-%129 = OpVariable %_ptr_Function_float Function
-%130 = OpVariable %_ptr_Function_float Function
-%131 = OpVariable %_ptr_Function_float Function
-%132 = OpVariable %_ptr_Function_float Function
-%133 = OpVariable %_ptr_Function_double Function
-%134 = OpVariable %_ptr_Function_double Function
-%135 = OpVariable %_ptr_Function_double Function
-%136 = OpVariable %_ptr_Function_double Function
-%137 = OpVariable %_ptr_Function_double Function
-%138 = OpVariable %_ptr_Function_uint Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_uint Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_uint Function
-%143 = OpVariable %_ptr_Function_ulong Function
-%144 = OpVariable %_ptr_Function_uint Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_uint Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_uint Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_uint Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_uint Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_uint Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_uint Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-OpStore %114 %72
-%178 = OpFunctionCall %ulong %6
-OpStore %115 %178
-%179 = OpLoad %ulong %114
-%180 = OpConvertUToF %float %179
-OpStore %116 %180
-%181 = OpLoad %ulong %114
-%182 = OpConvertUToF %double %181
-OpStore %117 %182
-%184 = OpLoad %float %116
-%185 = OpFAdd %float %float_2_14748352e_09 %184
-OpStore %118 %185
+%82 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_double Function
+%85 = OpVariable %_ptr_Function_uint Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_bool Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+OpStore %82 %71
+OpStore %84 %72
+%96 = OpLoad %double %84
+%97 = OpConvertFToU %uint %96
+OpStore %85 %97
 OpBranch %74
 %74 = OpLabel
-%186 = OpLoad %float %118
-%187 = OpConvertFToU %uint %186
-OpStore %138 %187
-%188 = OpLoad %ulong %115
-%189 = OpLoad %uint %138
-%190 = OpFunctionCall %ulong %8 %188 %189
-OpStore %139 %190
-OpBranch %75
-%75 = OpLabel
-%192 = OpLoad %float %116
-%193 = OpFAdd %float %float_2_14748365e_09 %192
-OpStore %119 %193
+%98 = OpLoad %uint %85
+%99 = OpUConvert %ulong %98
+OpStore %86 %99
 OpBranch %76
 %76 = OpLabel
-%194 = OpLoad %float %119
-%195 = OpConvertFToU %uint %194
-OpStore %140 %195
-%196 = OpLoad %ulong %139
-%197 = OpLoad %uint %140
-%198 = OpFunctionCall %ulong %8 %196 %197
-OpStore %141 %198
+%100 = OpLoad %ulong %82
+OpStore %94 %100
+OpStore %95 %ulong_0
 OpBranch %77
 %77 = OpLabel
-%200 = OpLoad %float %116
-%201 = OpFAdd %float %float_2_1474839e_09 %200
-OpStore %120 %201
-OpBranch %78
-%78 = OpLabel
-%202 = OpLoad %float %120
-%203 = OpConvertFToU %uint %202
-OpStore %142 %203
-%204 = OpLoad %ulong %141
-%205 = OpLoad %uint %142
-%206 = OpFunctionCall %ulong %8 %204 %205
-OpStore %143 %206
-OpBranch %79
+%101 = OpLoad %ulong %95
+%102 = OpULessThan %bool %101 %ulong_8
+OpStore %87 %102
+%103 = OpLoad %bool %87
+OpLoopMerge %79 %81 None
+OpBranchConditional %103 %78 %79
 %79 = OpLabel
-%208 = OpLoad %float %116
-%209 = OpFAdd %float %float_3_22122547e_09 %208
-OpStore %121 %209
 OpBranch %80
 %80 = OpLabel
-%210 = OpLoad %float %121
-%211 = OpConvertFToU %uint %210
-OpStore %144 %211
-%212 = OpLoad %ulong %143
-%213 = OpLoad %uint %144
-%214 = OpFunctionCall %ulong %8 %212 %213
-OpStore %145 %214
+OpBranch %75
+%75 = OpLabel
+%104 = OpLoad %ulong %94
+OpReturnValue %104
+%78 = OpLabel
+%105 = OpLoad %ulong %95
+%106 = OpIMul %ulong %105 %ulong_8
+OpStore %88 %106
+%107 = OpLoad %ulong %86
+%108 = OpLoad %ulong %88
+%109 = OpShiftRightLogical %ulong %107 %108
+OpStore %89 %109
+%110 = OpLoad %ulong %89
+%111 = OpBitwiseAnd %ulong %110 %ulong_255
+OpStore %90 %111
+%112 = OpLoad %ulong %94
+%113 = OpLoad %ulong %90
+%114 = OpBitwiseXor %ulong %112 %113
+OpStore %91 %114
+%115 = OpLoad %ulong %91
+%116 = OpIMul %ulong %115 %ulong_1099511628211
+OpStore %92 %116
+%117 = OpLoad %ulong %95
+%118 = OpIAdd %ulong %117 %ulong_1
+OpStore %93 %118
+%119 = OpLoad %ulong %92
+OpStore %94 %119
+%120 = OpLoad %ulong %93
+OpStore %95 %120
 OpBranch %81
 %81 = OpLabel
-%216 = OpLoad %float %116
-%217 = OpFAdd %float %float_4_29496704e_09 %216
-OpStore %122 %217
-OpBranch %82
-%82 = OpLabel
-%218 = OpLoad %float %122
-%219 = OpConvertFToU %uint %218
-OpStore %146 %219
-%220 = OpLoad %ulong %145
-%221 = OpLoad %uint %146
-%222 = OpFunctionCall %ulong %8 %220 %221
-OpStore %147 %222
-OpBranch %83
-%83 = OpLabel
-%224 = OpLoad %double %117
-%225 = OpFAdd %double %double_2147483647 %224
-OpStore %123 %225
-OpBranch %84
-%84 = OpLabel
-%226 = OpLoad %double %123
-%227 = OpConvertFToU %uint %226
-OpStore %148 %227
-%228 = OpLoad %ulong %147
-%229 = OpLoad %uint %148
-%230 = OpFunctionCall %ulong %8 %228 %229
-OpStore %149 %230
-OpBranch %85
-%85 = OpLabel
-%232 = OpLoad %double %117
-%233 = OpFAdd %double %double_2147483648 %232
-OpStore %124 %233
-OpBranch %86
-%86 = OpLabel
-%234 = OpLoad %double %124
-%235 = OpConvertFToU %uint %234
-OpStore %150 %235
-%236 = OpLoad %ulong %149
-%237 = OpLoad %uint %150
-%238 = OpFunctionCall %ulong %8 %236 %237
-OpStore %151 %238
-OpBranch %87
-%87 = OpLabel
-%240 = OpLoad %double %117
-%241 = OpFAdd %double %double_2147483649 %240
-OpStore %125 %241
-OpBranch %88
-%88 = OpLabel
-%242 = OpLoad %double %125
-%243 = OpConvertFToU %uint %242
-OpStore %152 %243
-%244 = OpLoad %ulong %151
-%245 = OpLoad %uint %152
-%246 = OpFunctionCall %ulong %8 %244 %245
-OpStore %153 %246
-OpBranch %89
-%89 = OpLabel
-%248 = OpLoad %double %117
-%249 = OpFAdd %double %double_3000000000 %248
-OpStore %126 %249
-OpBranch %90
-%90 = OpLabel
-%250 = OpLoad %double %126
-%251 = OpConvertFToU %uint %250
-OpStore %154 %251
-%252 = OpLoad %ulong %153
-%253 = OpLoad %uint %154
-%254 = OpFunctionCall %ulong %8 %252 %253
-OpStore %155 %254
-OpBranch %91
-%91 = OpLabel
-%256 = OpLoad %double %117
-%257 = OpFAdd %double %double_4294967295 %256
-OpStore %127 %257
-OpBranch %92
-%92 = OpLabel
-%258 = OpLoad %double %127
-%259 = OpConvertFToU %uint %258
-OpStore %156 %259
-%260 = OpLoad %ulong %155
-%261 = OpLoad %uint %156
-%262 = OpFunctionCall %ulong %8 %260 %261
-OpStore %157 %262
-OpBranch %93
-%93 = OpLabel
-%264 = OpLoad %float %116
-%265 = OpFAdd %float %float_4_61168602e_18 %264
-OpStore %128 %265
-OpBranch %94
-%94 = OpLabel
-%266 = OpLoad %float %128
-%267 = OpConvertFToU %ulong %266
-OpStore %158 %267
-%268 = OpLoad %ulong %157
-%269 = OpLoad %ulong %158
-%270 = OpFunctionCall %ulong %7 %268 %269
-OpStore %159 %270
-OpBranch %95
-%95 = OpLabel
-%272 = OpLoad %float %116
-%273 = OpFAdd %float %float_9_22337204e_18 %272
-OpStore %129 %273
-OpBranch %96
-%96 = OpLabel
-%274 = OpLoad %float %129
-%275 = OpConvertFToU %ulong %274
-OpStore %160 %275
-%276 = OpLoad %ulong %159
-%277 = OpLoad %ulong %160
-%278 = OpFunctionCall %ulong %7 %276 %277
-OpStore %161 %278
-OpBranch %97
-%97 = OpLabel
-%280 = OpLoad %float %116
-%281 = OpFAdd %float %float_9_22337314e_18 %280
-OpStore %130 %281
-OpBranch %98
-%98 = OpLabel
-%282 = OpLoad %float %130
-%283 = OpConvertFToU %ulong %282
-OpStore %162 %283
-%284 = OpLoad %ulong %161
-%285 = OpLoad %ulong %162
-%286 = OpFunctionCall %ulong %7 %284 %285
-OpStore %163 %286
-OpBranch %99
-%99 = OpLabel
-%288 = OpLoad %float %116
-%289 = OpFAdd %float %float_1_38350581e_19 %288
-OpStore %131 %289
-OpBranch %100
-%100 = OpLabel
-%290 = OpLoad %float %131
-%291 = OpConvertFToU %ulong %290
-OpStore %164 %291
-%292 = OpLoad %ulong %163
-%293 = OpLoad %ulong %164
-%294 = OpFunctionCall %ulong %7 %292 %293
-OpStore %165 %294
-OpBranch %101
-%101 = OpLabel
-%296 = OpLoad %float %116
-%297 = OpFAdd %float %float_1_8446743e_19 %296
-OpStore %132 %297
-OpBranch %102
-%102 = OpLabel
-%298 = OpLoad %float %132
-%299 = OpConvertFToU %ulong %298
-OpStore %166 %299
-%300 = OpLoad %ulong %165
-%301 = OpLoad %ulong %166
-%302 = OpFunctionCall %ulong %7 %300 %301
-OpStore %167 %302
-OpBranch %103
-%103 = OpLabel
-%304 = OpLoad %double %117
-%305 = OpFAdd %double %double_9_2233720368547748e_18 %304
-OpStore %133 %305
-OpBranch %104
-%104 = OpLabel
-%306 = OpLoad %double %133
-%307 = OpConvertFToU %ulong %306
-OpStore %168 %307
-%308 = OpLoad %ulong %167
-%309 = OpLoad %ulong %168
-%310 = OpFunctionCall %ulong %7 %308 %309
-OpStore %169 %310
-OpBranch %105
-%105 = OpLabel
-%312 = OpLoad %double %117
-%313 = OpFAdd %double %double_9_2233720368547758e_18 %312
-OpStore %134 %313
-OpBranch %106
-%106 = OpLabel
-%314 = OpLoad %double %134
-%315 = OpConvertFToU %ulong %314
-OpStore %170 %315
-%316 = OpLoad %ulong %169
-%317 = OpLoad %ulong %170
-%318 = OpFunctionCall %ulong %7 %316 %317
-OpStore %171 %318
-OpBranch %107
-%107 = OpLabel
-%320 = OpLoad %double %117
-%321 = OpFAdd %double %double_9_2233720368547779e_18 %320
-OpStore %135 %321
-OpBranch %108
-%108 = OpLabel
-%322 = OpLoad %double %135
-%323 = OpConvertFToU %ulong %322
-OpStore %172 %323
-%324 = OpLoad %ulong %171
-%325 = OpLoad %ulong %172
-%326 = OpFunctionCall %ulong %7 %324 %325
-OpStore %173 %326
-OpBranch %109
-%109 = OpLabel
-%328 = OpLoad %double %117
-%329 = OpFAdd %double %double_1_3835058055282164e_19 %328
-OpStore %136 %329
-OpBranch %110
-%110 = OpLabel
-%330 = OpLoad %double %136
-%331 = OpConvertFToU %ulong %330
-OpStore %174 %331
-%332 = OpLoad %ulong %173
-%333 = OpLoad %ulong %174
-%334 = OpFunctionCall %ulong %7 %332 %333
-OpStore %175 %334
-OpBranch %111
-%111 = OpLabel
-%336 = OpLoad %double %117
-%337 = OpFAdd %double %double_1_844674407370955e_19 %336
-OpStore %137 %337
-OpBranch %112
-%112 = OpLabel
-%338 = OpLoad %double %137
-%339 = OpConvertFToU %ulong %338
-OpStore %176 %339
-%340 = OpLoad %ulong %175
-%341 = OpLoad %ulong %176
-%342 = OpFunctionCall %ulong %7 %340 %341
-OpStore %177 %342
-OpBranch %113
-%113 = OpLabel
-%343 = OpLoad %ulong %177
-OpReturnValue %343
+OpBranch %77
 OpFunctionEnd
-%6 = OpFunction %ulong None %344
+%3 = OpFunction %ulong None %8
+%121 = OpFunctionParameter %ulong
+%122 = OpFunctionParameter %float
+%123 = OpLabel
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_float Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_bool Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+OpStore %130 %121
+OpStore %131 %122
+%142 = OpLoad %float %131
+%143 = OpConvertFToU %ulong %142
+OpStore %132 %143
+OpBranch %124
+%124 = OpLabel
+%144 = OpLoad %ulong %130
+OpStore %140 %144
+OpStore %141 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%145 = OpLoad %ulong %141
+%146 = OpULessThan %bool %145 %ulong_8
+OpStore %133 %146
+%147 = OpLoad %bool %133
+OpLoopMerge %127 %129 None
+OpBranchConditional %147 %126 %127
+%127 = OpLabel
+OpBranch %128
+%128 = OpLabel
+%148 = OpLoad %ulong %140
+OpReturnValue %148
+%126 = OpLabel
+%149 = OpLoad %ulong %141
+%150 = OpIMul %ulong %149 %ulong_8
+OpStore %134 %150
+%151 = OpLoad %ulong %132
+%152 = OpLoad %ulong %134
+%153 = OpShiftRightLogical %ulong %151 %152
+OpStore %135 %153
+%154 = OpLoad %ulong %135
+%155 = OpBitwiseAnd %ulong %154 %ulong_255
+OpStore %136 %155
+%156 = OpLoad %ulong %140
+%157 = OpLoad %ulong %136
+%158 = OpBitwiseXor %ulong %156 %157
+OpStore %137 %158
+%159 = OpLoad %ulong %137
+%160 = OpIMul %ulong %159 %ulong_1099511628211
+OpStore %138 %160
+%161 = OpLoad %ulong %141
+%162 = OpIAdd %ulong %161 %ulong_1
+OpStore %139 %162
+%163 = OpLoad %ulong %138
+OpStore %140 %163
+%164 = OpLoad %ulong %139
+OpStore %141 %164
+OpBranch %129
+%129 = OpLabel
+OpBranch %125
+OpFunctionEnd
+%4 = OpFunction %ulong None %70
+%165 = OpFunctionParameter %ulong
+%166 = OpFunctionParameter %double
+%167 = OpLabel
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_double Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_bool Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+OpStore %174 %165
+OpStore %175 %166
+%186 = OpLoad %double %175
+%187 = OpConvertFToU %ulong %186
+OpStore %176 %187
+OpBranch %168
+%168 = OpLabel
+%188 = OpLoad %ulong %174
+OpStore %184 %188
+OpStore %185 %ulong_0
+OpBranch %169
+%169 = OpLabel
+%189 = OpLoad %ulong %185
+%190 = OpULessThan %bool %189 %ulong_8
+OpStore %177 %190
+%191 = OpLoad %bool %177
+OpLoopMerge %171 %173 None
+OpBranchConditional %191 %170 %171
+%171 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%192 = OpLoad %ulong %184
+OpReturnValue %192
+%170 = OpLabel
+%193 = OpLoad %ulong %185
+%194 = OpIMul %ulong %193 %ulong_8
+OpStore %178 %194
+%195 = OpLoad %ulong %176
+%196 = OpLoad %ulong %178
+%197 = OpShiftRightLogical %ulong %195 %196
+OpStore %179 %197
+%198 = OpLoad %ulong %179
+%199 = OpBitwiseAnd %ulong %198 %ulong_255
+OpStore %180 %199
+%200 = OpLoad %ulong %184
+%201 = OpLoad %ulong %180
+%202 = OpBitwiseXor %ulong %200 %201
+OpStore %181 %202
+%203 = OpLoad %ulong %181
+%204 = OpIMul %ulong %203 %ulong_1099511628211
+OpStore %182 %204
+%205 = OpLoad %ulong %185
+%206 = OpIAdd %ulong %205 %ulong_1
+OpStore %183 %206
+%207 = OpLoad %ulong %182
+OpStore %184 %207
+%208 = OpLoad %ulong %183
+OpStore %185 %208
+OpBranch %173
+%173 = OpLabel
+OpBranch %169
+OpFunctionEnd
+%5 = OpFunction %ulong None %209
+%210 = OpFunctionParameter %ulong
+%211 = OpLabel
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_float Function
+%396 = OpVariable %_ptr_Function_double Function
+%397 = OpVariable %_ptr_Function_float Function
+%398 = OpVariable %_ptr_Function_float Function
+%399 = OpVariable %_ptr_Function_float Function
+%400 = OpVariable %_ptr_Function_float Function
+%401 = OpVariable %_ptr_Function_float Function
+%402 = OpVariable %_ptr_Function_double Function
+%403 = OpVariable %_ptr_Function_double Function
+%404 = OpVariable %_ptr_Function_double Function
+%405 = OpVariable %_ptr_Function_double Function
+%406 = OpVariable %_ptr_Function_double Function
+%407 = OpVariable %_ptr_Function_float Function
+%408 = OpVariable %_ptr_Function_float Function
+%409 = OpVariable %_ptr_Function_float Function
+%410 = OpVariable %_ptr_Function_float Function
+%411 = OpVariable %_ptr_Function_float Function
+%412 = OpVariable %_ptr_Function_double Function
+%413 = OpVariable %_ptr_Function_double Function
+%414 = OpVariable %_ptr_Function_double Function
+%415 = OpVariable %_ptr_Function_double Function
+%416 = OpVariable %_ptr_Function_double Function
+%417 = OpVariable %_ptr_Function_uint Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_bool Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_uint Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_bool Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_uint Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_bool Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_uint Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_bool Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_uint Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_bool Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_uint Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_bool Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_uint Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_bool Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_uint Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_bool Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_uint Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_bool Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_uint Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_bool Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_bool Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_bool Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_bool Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_bool Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_bool Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_ulong Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_bool Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_ulong Function
+%588 = OpVariable %_ptr_Function_bool Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_ulong Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_bool Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_ulong Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_ulong Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_bool Function
+%609 = OpVariable %_ptr_Function_ulong Function
+%610 = OpVariable %_ptr_Function_ulong Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_ulong Function
+%613 = OpVariable %_ptr_Function_ulong Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_ulong Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+%618 = OpVariable %_ptr_Function_bool Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_ulong Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_ulong Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function_ulong Function
+OpStore %394 %210
+OpBranch %212
+%212 = OpLabel
+OpBranch %213
+%213 = OpLabel
+%627 = OpLoad %ulong %394
+%628 = OpConvertUToF %float %627
+OpStore %395 %628
+%629 = OpLoad %ulong %394
+%630 = OpConvertUToF %double %629
+OpStore %396 %630
+%632 = OpLoad %float %395
+%633 = OpFAdd %float %float_2_14748352e_09 %632
+OpStore %397 %633
+OpBranch %214
+%214 = OpLabel
+%634 = OpLoad %float %397
+%635 = OpConvertFToU %uint %634
+OpStore %417 %635
+OpBranch %215
+%215 = OpLabel
+%636 = OpLoad %uint %417
+%637 = OpUConvert %ulong %636
+OpStore %418 %637
+OpBranch %217
+%217 = OpLabel
+OpStore %426 %ulong_14695981039346656037
+OpStore %427 %ulong_0
+OpBranch %218
+%218 = OpLabel
+%639 = OpLoad %ulong %427
+%640 = OpULessThan %bool %639 %ulong_8
+OpStore %419 %640
+%641 = OpLoad %bool %419
+OpLoopMerge %220 %393 None
+OpBranchConditional %641 %219 %220
+%220 = OpLabel
+OpBranch %221
+%221 = OpLabel
+OpBranch %216
+%216 = OpLabel
+OpBranch %222
+%222 = OpLabel
+%643 = OpLoad %float %395
+%644 = OpFAdd %float %float_2_14748365e_09 %643
+OpStore %398 %644
+OpBranch %223
+%223 = OpLabel
+%645 = OpLoad %float %398
+%646 = OpConvertFToU %uint %645
+OpStore %428 %646
+OpBranch %224
+%224 = OpLabel
+%647 = OpLoad %uint %428
+%648 = OpUConvert %ulong %647
+OpStore %429 %648
+OpBranch %226
+%226 = OpLabel
+%649 = OpLoad %ulong %426
+OpStore %437 %649
+OpStore %438 %ulong_0
+OpBranch %227
+%227 = OpLabel
+%650 = OpLoad %ulong %438
+%651 = OpULessThan %bool %650 %ulong_8
+OpStore %430 %651
+%652 = OpLoad %bool %430
+OpLoopMerge %229 %392 None
+OpBranchConditional %652 %228 %229
+%229 = OpLabel
+OpBranch %230
+%230 = OpLabel
+OpBranch %225
+%225 = OpLabel
+OpBranch %231
+%231 = OpLabel
+%654 = OpLoad %float %395
+%655 = OpFAdd %float %float_2_1474839e_09 %654
+OpStore %399 %655
+OpBranch %232
+%232 = OpLabel
+%656 = OpLoad %float %399
+%657 = OpConvertFToU %uint %656
+OpStore %439 %657
+OpBranch %233
+%233 = OpLabel
+%658 = OpLoad %uint %439
+%659 = OpUConvert %ulong %658
+OpStore %440 %659
+OpBranch %235
+%235 = OpLabel
+%660 = OpLoad %ulong %437
+OpStore %448 %660
+OpStore %449 %ulong_0
+OpBranch %236
+%236 = OpLabel
+%661 = OpLoad %ulong %449
+%662 = OpULessThan %bool %661 %ulong_8
+OpStore %441 %662
+%663 = OpLoad %bool %441
+OpLoopMerge %238 %391 None
+OpBranchConditional %663 %237 %238
+%238 = OpLabel
+OpBranch %239
+%239 = OpLabel
+OpBranch %234
+%234 = OpLabel
+OpBranch %240
+%240 = OpLabel
+%665 = OpLoad %float %395
+%666 = OpFAdd %float %float_3_22122547e_09 %665
+OpStore %400 %666
+OpBranch %241
+%241 = OpLabel
+%667 = OpLoad %float %400
+%668 = OpConvertFToU %uint %667
+OpStore %450 %668
+OpBranch %242
+%242 = OpLabel
+%669 = OpLoad %uint %450
+%670 = OpUConvert %ulong %669
+OpStore %451 %670
+OpBranch %244
+%244 = OpLabel
+%671 = OpLoad %ulong %448
+OpStore %459 %671
+OpStore %460 %ulong_0
+OpBranch %245
+%245 = OpLabel
+%672 = OpLoad %ulong %460
+%673 = OpULessThan %bool %672 %ulong_8
+OpStore %452 %673
+%674 = OpLoad %bool %452
+OpLoopMerge %247 %390 None
+OpBranchConditional %674 %246 %247
+%247 = OpLabel
+OpBranch %248
+%248 = OpLabel
+OpBranch %243
+%243 = OpLabel
+OpBranch %249
+%249 = OpLabel
+%676 = OpLoad %float %395
+%677 = OpFAdd %float %float_4_29496704e_09 %676
+OpStore %401 %677
+OpBranch %250
+%250 = OpLabel
+%678 = OpLoad %float %401
+%679 = OpConvertFToU %uint %678
+OpStore %461 %679
+OpBranch %251
+%251 = OpLabel
+%680 = OpLoad %uint %461
+%681 = OpUConvert %ulong %680
+OpStore %462 %681
+OpBranch %253
+%253 = OpLabel
+%682 = OpLoad %ulong %459
+OpStore %470 %682
+OpStore %471 %ulong_0
+OpBranch %254
+%254 = OpLabel
+%683 = OpLoad %ulong %471
+%684 = OpULessThan %bool %683 %ulong_8
+OpStore %463 %684
+%685 = OpLoad %bool %463
+OpLoopMerge %256 %389 None
+OpBranchConditional %685 %255 %256
+%256 = OpLabel
+OpBranch %257
+%257 = OpLabel
+OpBranch %252
+%252 = OpLabel
+OpBranch %258
+%258 = OpLabel
+%687 = OpLoad %double %396
+%688 = OpFAdd %double %double_2147483647 %687
+OpStore %402 %688
+OpBranch %259
+%259 = OpLabel
+%689 = OpLoad %double %402
+%690 = OpConvertFToU %uint %689
+OpStore %472 %690
+OpBranch %260
+%260 = OpLabel
+%691 = OpLoad %uint %472
+%692 = OpUConvert %ulong %691
+OpStore %473 %692
+OpBranch %262
+%262 = OpLabel
+%693 = OpLoad %ulong %470
+OpStore %481 %693
+OpStore %482 %ulong_0
+OpBranch %263
+%263 = OpLabel
+%694 = OpLoad %ulong %482
+%695 = OpULessThan %bool %694 %ulong_8
+OpStore %474 %695
+%696 = OpLoad %bool %474
+OpLoopMerge %265 %388 None
+OpBranchConditional %696 %264 %265
+%265 = OpLabel
+OpBranch %266
+%266 = OpLabel
+OpBranch %261
+%261 = OpLabel
+OpBranch %267
+%267 = OpLabel
+%698 = OpLoad %double %396
+%699 = OpFAdd %double %double_2147483648 %698
+OpStore %403 %699
+OpBranch %268
+%268 = OpLabel
+%700 = OpLoad %double %403
+%701 = OpConvertFToU %uint %700
+OpStore %483 %701
+OpBranch %269
+%269 = OpLabel
+%702 = OpLoad %uint %483
+%703 = OpUConvert %ulong %702
+OpStore %484 %703
+OpBranch %271
+%271 = OpLabel
+%704 = OpLoad %ulong %481
+OpStore %492 %704
+OpStore %493 %ulong_0
+OpBranch %272
+%272 = OpLabel
+%705 = OpLoad %ulong %493
+%706 = OpULessThan %bool %705 %ulong_8
+OpStore %485 %706
+%707 = OpLoad %bool %485
+OpLoopMerge %274 %387 None
+OpBranchConditional %707 %273 %274
+%274 = OpLabel
+OpBranch %275
+%275 = OpLabel
+OpBranch %270
+%270 = OpLabel
+OpBranch %276
+%276 = OpLabel
+%709 = OpLoad %double %396
+%710 = OpFAdd %double %double_2147483649 %709
+OpStore %404 %710
+OpBranch %277
+%277 = OpLabel
+%711 = OpLoad %double %404
+%712 = OpConvertFToU %uint %711
+OpStore %494 %712
+OpBranch %278
+%278 = OpLabel
+%713 = OpLoad %uint %494
+%714 = OpUConvert %ulong %713
+OpStore %495 %714
+OpBranch %280
+%280 = OpLabel
+%715 = OpLoad %ulong %492
+OpStore %503 %715
+OpStore %504 %ulong_0
+OpBranch %281
+%281 = OpLabel
+%716 = OpLoad %ulong %504
+%717 = OpULessThan %bool %716 %ulong_8
+OpStore %496 %717
+%718 = OpLoad %bool %496
+OpLoopMerge %283 %386 None
+OpBranchConditional %718 %282 %283
+%283 = OpLabel
+OpBranch %284
+%284 = OpLabel
+OpBranch %279
+%279 = OpLabel
+OpBranch %285
+%285 = OpLabel
+%720 = OpLoad %double %396
+%721 = OpFAdd %double %double_3000000000 %720
+OpStore %405 %721
+OpBranch %286
+%286 = OpLabel
+%722 = OpLoad %double %405
+%723 = OpConvertFToU %uint %722
+OpStore %505 %723
+OpBranch %287
+%287 = OpLabel
+%724 = OpLoad %uint %505
+%725 = OpUConvert %ulong %724
+OpStore %506 %725
+OpBranch %289
+%289 = OpLabel
+%726 = OpLoad %ulong %503
+OpStore %514 %726
+OpStore %515 %ulong_0
+OpBranch %290
+%290 = OpLabel
+%727 = OpLoad %ulong %515
+%728 = OpULessThan %bool %727 %ulong_8
+OpStore %507 %728
+%729 = OpLoad %bool %507
+OpLoopMerge %292 %385 None
+OpBranchConditional %729 %291 %292
+%292 = OpLabel
+OpBranch %293
+%293 = OpLabel
+OpBranch %288
+%288 = OpLabel
+OpBranch %294
+%294 = OpLabel
+%731 = OpLoad %double %396
+%732 = OpFAdd %double %double_4294967295 %731
+OpStore %406 %732
+OpBranch %295
+%295 = OpLabel
+%733 = OpLoad %double %406
+%734 = OpConvertFToU %uint %733
+OpStore %516 %734
+OpBranch %296
+%296 = OpLabel
+%735 = OpLoad %uint %516
+%736 = OpUConvert %ulong %735
+OpStore %517 %736
+OpBranch %298
+%298 = OpLabel
+%737 = OpLoad %ulong %514
+OpStore %525 %737
+OpStore %526 %ulong_0
+OpBranch %299
+%299 = OpLabel
+%738 = OpLoad %ulong %526
+%739 = OpULessThan %bool %738 %ulong_8
+OpStore %518 %739
+%740 = OpLoad %bool %518
+OpLoopMerge %301 %384 None
+OpBranchConditional %740 %300 %301
+%301 = OpLabel
+OpBranch %302
+%302 = OpLabel
+OpBranch %297
+%297 = OpLabel
+OpBranch %303
+%303 = OpLabel
+%742 = OpLoad %float %395
+%743 = OpFAdd %float %float_4_61168602e_18 %742
+OpStore %407 %743
+OpBranch %304
+%304 = OpLabel
+%744 = OpLoad %float %407
+%745 = OpConvertFToU %ulong %744
+OpStore %527 %745
+OpBranch %305
+%305 = OpLabel
+%746 = OpLoad %ulong %525
+OpStore %535 %746
+OpStore %536 %ulong_0
+OpBranch %306
+%306 = OpLabel
+%747 = OpLoad %ulong %536
+%748 = OpULessThan %bool %747 %ulong_8
+OpStore %528 %748
+%749 = OpLoad %bool %528
+OpLoopMerge %308 %383 None
+OpBranchConditional %749 %307 %308
+%308 = OpLabel
+OpBranch %309
+%309 = OpLabel
+OpBranch %310
+%310 = OpLabel
+%751 = OpLoad %float %395
+%752 = OpFAdd %float %float_9_22337204e_18 %751
+OpStore %408 %752
+OpBranch %311
+%311 = OpLabel
+%753 = OpLoad %float %408
+%754 = OpConvertFToU %ulong %753
+OpStore %537 %754
+OpBranch %312
+%312 = OpLabel
+%755 = OpLoad %ulong %535
+OpStore %545 %755
+OpStore %546 %ulong_0
+OpBranch %313
+%313 = OpLabel
+%756 = OpLoad %ulong %546
+%757 = OpULessThan %bool %756 %ulong_8
+OpStore %538 %757
+%758 = OpLoad %bool %538
+OpLoopMerge %315 %382 None
+OpBranchConditional %758 %314 %315
+%315 = OpLabel
+OpBranch %316
+%316 = OpLabel
+OpBranch %317
+%317 = OpLabel
+%760 = OpLoad %float %395
+%761 = OpFAdd %float %float_9_22337314e_18 %760
+OpStore %409 %761
+OpBranch %318
+%318 = OpLabel
+%762 = OpLoad %float %409
+%763 = OpConvertFToU %ulong %762
+OpStore %547 %763
+OpBranch %319
+%319 = OpLabel
+%764 = OpLoad %ulong %545
+OpStore %555 %764
+OpStore %556 %ulong_0
+OpBranch %320
+%320 = OpLabel
+%765 = OpLoad %ulong %556
+%766 = OpULessThan %bool %765 %ulong_8
+OpStore %548 %766
+%767 = OpLoad %bool %548
+OpLoopMerge %322 %381 None
+OpBranchConditional %767 %321 %322
+%322 = OpLabel
+OpBranch %323
+%323 = OpLabel
+OpBranch %324
+%324 = OpLabel
+%769 = OpLoad %float %395
+%770 = OpFAdd %float %float_1_38350581e_19 %769
+OpStore %410 %770
+OpBranch %325
+%325 = OpLabel
+%771 = OpLoad %float %410
+%772 = OpConvertFToU %ulong %771
+OpStore %557 %772
+OpBranch %326
+%326 = OpLabel
+%773 = OpLoad %ulong %555
+OpStore %565 %773
+OpStore %566 %ulong_0
+OpBranch %327
+%327 = OpLabel
+%774 = OpLoad %ulong %566
+%775 = OpULessThan %bool %774 %ulong_8
+OpStore %558 %775
+%776 = OpLoad %bool %558
+OpLoopMerge %329 %380 None
+OpBranchConditional %776 %328 %329
+%329 = OpLabel
+OpBranch %330
+%330 = OpLabel
+OpBranch %331
+%331 = OpLabel
+%778 = OpLoad %float %395
+%779 = OpFAdd %float %float_1_8446743e_19 %778
+OpStore %411 %779
+OpBranch %332
+%332 = OpLabel
+%780 = OpLoad %float %411
+%781 = OpConvertFToU %ulong %780
+OpStore %567 %781
+OpBranch %333
+%333 = OpLabel
+%782 = OpLoad %ulong %565
+OpStore %575 %782
+OpStore %576 %ulong_0
+OpBranch %334
+%334 = OpLabel
+%783 = OpLoad %ulong %576
+%784 = OpULessThan %bool %783 %ulong_8
+OpStore %568 %784
+%785 = OpLoad %bool %568
+OpLoopMerge %336 %379 None
+OpBranchConditional %785 %335 %336
+%336 = OpLabel
+OpBranch %337
+%337 = OpLabel
+OpBranch %338
+%338 = OpLabel
+%787 = OpLoad %double %396
+%788 = OpFAdd %double %double_9_2233720368547748e_18 %787
+OpStore %412 %788
+OpBranch %339
+%339 = OpLabel
+%789 = OpLoad %double %412
+%790 = OpConvertFToU %ulong %789
+OpStore %577 %790
+OpBranch %340
+%340 = OpLabel
+%791 = OpLoad %ulong %575
+OpStore %585 %791
+OpStore %586 %ulong_0
+OpBranch %341
+%341 = OpLabel
+%792 = OpLoad %ulong %586
+%793 = OpULessThan %bool %792 %ulong_8
+OpStore %578 %793
+%794 = OpLoad %bool %578
+OpLoopMerge %343 %378 None
+OpBranchConditional %794 %342 %343
+%343 = OpLabel
+OpBranch %344
+%344 = OpLabel
+OpBranch %345
 %345 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%7 = OpFunction %ulong None %347
-%348 = OpFunctionParameter %ulong
-%349 = OpFunctionParameter %ulong
+%796 = OpLoad %double %396
+%797 = OpFAdd %double %double_9_2233720368547758e_18 %796
+OpStore %413 %797
+OpBranch %346
+%346 = OpLabel
+%798 = OpLoad %double %413
+%799 = OpConvertFToU %ulong %798
+OpStore %587 %799
+OpBranch %347
+%347 = OpLabel
+%800 = OpLoad %ulong %585
+OpStore %595 %800
+OpStore %596 %ulong_0
+OpBranch %348
+%348 = OpLabel
+%801 = OpLoad %ulong %596
+%802 = OpULessThan %bool %801 %ulong_8
+OpStore %588 %802
+%803 = OpLoad %bool %588
+OpLoopMerge %350 %377 None
+OpBranchConditional %803 %349 %350
 %350 = OpLabel
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_bool Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_ulong Function
-OpStore %356 %348
-OpStore %357 %349
-%368 = OpLoad %ulong %356
-OpStore %366 %368
-OpStore %367 %ulong_0
 OpBranch %351
 %351 = OpLabel
-%370 = OpLoad %ulong %367
-%372 = OpULessThan %bool %370 %ulong_8
-OpStore %359 %372
-%373 = OpLoad %bool %359
-OpLoopMerge %353 %354 None
-OpBranchConditional %373 %352 %353
-%353 = OpLabel
-%374 = OpLoad %ulong %366
-OpReturnValue %374
+OpBranch %352
 %352 = OpLabel
-%375 = OpLoad %ulong %367
-%376 = OpIMul %ulong %375 %ulong_8
-OpStore %360 %376
-%377 = OpLoad %ulong %357
-%378 = OpLoad %ulong %360
-%379 = OpShiftRightLogical %ulong %377 %378
-OpStore %361 %379
-%380 = OpLoad %ulong %361
-%382 = OpBitwiseAnd %ulong %380 %ulong_255
-OpStore %362 %382
-%383 = OpLoad %ulong %366
-%384 = OpLoad %ulong %362
-%385 = OpBitwiseXor %ulong %383 %384
-OpStore %363 %385
-%386 = OpLoad %ulong %363
-%388 = OpIMul %ulong %386 %ulong_1099511628211
-OpStore %364 %388
-%389 = OpLoad %ulong %367
-%391 = OpIAdd %ulong %389 %ulong_1
-OpStore %365 %391
-%392 = OpLoad %ulong %364
-OpStore %366 %392
-%393 = OpLoad %ulong %365
-OpStore %367 %393
+%805 = OpLoad %double %396
+%806 = OpFAdd %double %double_9_2233720368547779e_18 %805
+OpStore %414 %806
+OpBranch %353
+%353 = OpLabel
+%807 = OpLoad %double %414
+%808 = OpConvertFToU %ulong %807
+OpStore %597 %808
 OpBranch %354
 %354 = OpLabel
-OpBranch %351
-OpFunctionEnd
-%8 = OpFunction %ulong None %394
-%395 = OpFunctionParameter %ulong
-%396 = OpFunctionParameter %uint
-%397 = OpLabel
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_uint Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_bool Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_ulong Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_ulong Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_ulong Function
-OpStore %404 %395
-OpStore %405 %396
-%416 = OpLoad %uint %405
-%417 = OpUConvert %ulong %416
-OpStore %406 %417
-OpBranch %398
-%398 = OpLabel
-%418 = OpLoad %ulong %404
-OpStore %414 %418
-OpStore %415 %ulong_0
-OpBranch %399
-%399 = OpLabel
-%419 = OpLoad %ulong %415
-%420 = OpULessThan %bool %419 %ulong_8
-OpStore %407 %420
-%421 = OpLoad %bool %407
-OpLoopMerge %401 %403 None
-OpBranchConditional %421 %400 %401
-%401 = OpLabel
-OpBranch %402
-%402 = OpLabel
-%422 = OpLoad %ulong %414
-OpReturnValue %422
-%400 = OpLabel
-%423 = OpLoad %ulong %415
-%424 = OpIMul %ulong %423 %ulong_8
-OpStore %408 %424
-%425 = OpLoad %ulong %406
-%426 = OpLoad %ulong %408
-%427 = OpShiftRightLogical %ulong %425 %426
-OpStore %409 %427
-%428 = OpLoad %ulong %409
-%429 = OpBitwiseAnd %ulong %428 %ulong_255
-OpStore %410 %429
-%430 = OpLoad %ulong %414
-%431 = OpLoad %ulong %410
-%432 = OpBitwiseXor %ulong %430 %431
-OpStore %411 %432
-%433 = OpLoad %ulong %411
-%434 = OpIMul %ulong %433 %ulong_1099511628211
-OpStore %412 %434
-%435 = OpLoad %ulong %415
-%436 = OpIAdd %ulong %435 %ulong_1
-OpStore %413 %436
-%437 = OpLoad %ulong %412
-OpStore %414 %437
-%438 = OpLoad %ulong %413
-OpStore %415 %438
-OpBranch %403
-%403 = OpLabel
-OpBranch %399
+%809 = OpLoad %ulong %595
+OpStore %605 %809
+OpStore %606 %ulong_0
+OpBranch %355
+%355 = OpLabel
+%810 = OpLoad %ulong %606
+%811 = OpULessThan %bool %810 %ulong_8
+OpStore %598 %811
+%812 = OpLoad %bool %598
+OpLoopMerge %357 %376 None
+OpBranchConditional %812 %356 %357
+%357 = OpLabel
+OpBranch %358
+%358 = OpLabel
+OpBranch %359
+%359 = OpLabel
+%814 = OpLoad %double %396
+%815 = OpFAdd %double %double_1_3835058055282164e_19 %814
+OpStore %415 %815
+OpBranch %360
+%360 = OpLabel
+%816 = OpLoad %double %415
+%817 = OpConvertFToU %ulong %816
+OpStore %607 %817
+OpBranch %361
+%361 = OpLabel
+%818 = OpLoad %ulong %605
+OpStore %615 %818
+OpStore %616 %ulong_0
+OpBranch %362
+%362 = OpLabel
+%819 = OpLoad %ulong %616
+%820 = OpULessThan %bool %819 %ulong_8
+OpStore %608 %820
+%821 = OpLoad %bool %608
+OpLoopMerge %364 %375 None
+OpBranchConditional %821 %363 %364
+%364 = OpLabel
+OpBranch %365
+%365 = OpLabel
+OpBranch %366
+%366 = OpLabel
+%823 = OpLoad %double %396
+%824 = OpFAdd %double %double_1_844674407370955e_19 %823
+OpStore %416 %824
+OpBranch %367
+%367 = OpLabel
+%825 = OpLoad %double %416
+%826 = OpConvertFToU %ulong %825
+OpStore %617 %826
+OpBranch %368
+%368 = OpLabel
+%827 = OpLoad %ulong %615
+OpStore %625 %827
+OpStore %626 %ulong_0
+OpBranch %369
+%369 = OpLabel
+%828 = OpLoad %ulong %626
+%829 = OpULessThan %bool %828 %ulong_8
+OpStore %618 %829
+%830 = OpLoad %bool %618
+OpLoopMerge %371 %374 None
+OpBranchConditional %830 %370 %371
+%371 = OpLabel
+OpBranch %372
+%372 = OpLabel
+OpBranch %373
+%373 = OpLabel
+%831 = OpLoad %ulong %625
+OpReturnValue %831
+%370 = OpLabel
+%832 = OpLoad %ulong %626
+%833 = OpIMul %ulong %832 %ulong_8
+OpStore %619 %833
+%834 = OpLoad %ulong %617
+%835 = OpLoad %ulong %619
+%836 = OpShiftRightLogical %ulong %834 %835
+OpStore %620 %836
+%837 = OpLoad %ulong %620
+%838 = OpBitwiseAnd %ulong %837 %ulong_255
+OpStore %621 %838
+%839 = OpLoad %ulong %625
+%840 = OpLoad %ulong %621
+%841 = OpBitwiseXor %ulong %839 %840
+OpStore %622 %841
+%842 = OpLoad %ulong %622
+%843 = OpIMul %ulong %842 %ulong_1099511628211
+OpStore %623 %843
+%844 = OpLoad %ulong %626
+%845 = OpIAdd %ulong %844 %ulong_1
+OpStore %624 %845
+%846 = OpLoad %ulong %623
+OpStore %625 %846
+%847 = OpLoad %ulong %624
+OpStore %626 %847
+OpBranch %374
+%363 = OpLabel
+%848 = OpLoad %ulong %616
+%849 = OpIMul %ulong %848 %ulong_8
+OpStore %609 %849
+%850 = OpLoad %ulong %607
+%851 = OpLoad %ulong %609
+%852 = OpShiftRightLogical %ulong %850 %851
+OpStore %610 %852
+%853 = OpLoad %ulong %610
+%854 = OpBitwiseAnd %ulong %853 %ulong_255
+OpStore %611 %854
+%855 = OpLoad %ulong %615
+%856 = OpLoad %ulong %611
+%857 = OpBitwiseXor %ulong %855 %856
+OpStore %612 %857
+%858 = OpLoad %ulong %612
+%859 = OpIMul %ulong %858 %ulong_1099511628211
+OpStore %613 %859
+%860 = OpLoad %ulong %616
+%861 = OpIAdd %ulong %860 %ulong_1
+OpStore %614 %861
+%862 = OpLoad %ulong %613
+OpStore %615 %862
+%863 = OpLoad %ulong %614
+OpStore %616 %863
+OpBranch %375
+%356 = OpLabel
+%864 = OpLoad %ulong %606
+%865 = OpIMul %ulong %864 %ulong_8
+OpStore %599 %865
+%866 = OpLoad %ulong %597
+%867 = OpLoad %ulong %599
+%868 = OpShiftRightLogical %ulong %866 %867
+OpStore %600 %868
+%869 = OpLoad %ulong %600
+%870 = OpBitwiseAnd %ulong %869 %ulong_255
+OpStore %601 %870
+%871 = OpLoad %ulong %605
+%872 = OpLoad %ulong %601
+%873 = OpBitwiseXor %ulong %871 %872
+OpStore %602 %873
+%874 = OpLoad %ulong %602
+%875 = OpIMul %ulong %874 %ulong_1099511628211
+OpStore %603 %875
+%876 = OpLoad %ulong %606
+%877 = OpIAdd %ulong %876 %ulong_1
+OpStore %604 %877
+%878 = OpLoad %ulong %603
+OpStore %605 %878
+%879 = OpLoad %ulong %604
+OpStore %606 %879
+OpBranch %376
+%349 = OpLabel
+%880 = OpLoad %ulong %596
+%881 = OpIMul %ulong %880 %ulong_8
+OpStore %589 %881
+%882 = OpLoad %ulong %587
+%883 = OpLoad %ulong %589
+%884 = OpShiftRightLogical %ulong %882 %883
+OpStore %590 %884
+%885 = OpLoad %ulong %590
+%886 = OpBitwiseAnd %ulong %885 %ulong_255
+OpStore %591 %886
+%887 = OpLoad %ulong %595
+%888 = OpLoad %ulong %591
+%889 = OpBitwiseXor %ulong %887 %888
+OpStore %592 %889
+%890 = OpLoad %ulong %592
+%891 = OpIMul %ulong %890 %ulong_1099511628211
+OpStore %593 %891
+%892 = OpLoad %ulong %596
+%893 = OpIAdd %ulong %892 %ulong_1
+OpStore %594 %893
+%894 = OpLoad %ulong %593
+OpStore %595 %894
+%895 = OpLoad %ulong %594
+OpStore %596 %895
+OpBranch %377
+%342 = OpLabel
+%896 = OpLoad %ulong %586
+%897 = OpIMul %ulong %896 %ulong_8
+OpStore %579 %897
+%898 = OpLoad %ulong %577
+%899 = OpLoad %ulong %579
+%900 = OpShiftRightLogical %ulong %898 %899
+OpStore %580 %900
+%901 = OpLoad %ulong %580
+%902 = OpBitwiseAnd %ulong %901 %ulong_255
+OpStore %581 %902
+%903 = OpLoad %ulong %585
+%904 = OpLoad %ulong %581
+%905 = OpBitwiseXor %ulong %903 %904
+OpStore %582 %905
+%906 = OpLoad %ulong %582
+%907 = OpIMul %ulong %906 %ulong_1099511628211
+OpStore %583 %907
+%908 = OpLoad %ulong %586
+%909 = OpIAdd %ulong %908 %ulong_1
+OpStore %584 %909
+%910 = OpLoad %ulong %583
+OpStore %585 %910
+%911 = OpLoad %ulong %584
+OpStore %586 %911
+OpBranch %378
+%335 = OpLabel
+%912 = OpLoad %ulong %576
+%913 = OpIMul %ulong %912 %ulong_8
+OpStore %569 %913
+%914 = OpLoad %ulong %567
+%915 = OpLoad %ulong %569
+%916 = OpShiftRightLogical %ulong %914 %915
+OpStore %570 %916
+%917 = OpLoad %ulong %570
+%918 = OpBitwiseAnd %ulong %917 %ulong_255
+OpStore %571 %918
+%919 = OpLoad %ulong %575
+%920 = OpLoad %ulong %571
+%921 = OpBitwiseXor %ulong %919 %920
+OpStore %572 %921
+%922 = OpLoad %ulong %572
+%923 = OpIMul %ulong %922 %ulong_1099511628211
+OpStore %573 %923
+%924 = OpLoad %ulong %576
+%925 = OpIAdd %ulong %924 %ulong_1
+OpStore %574 %925
+%926 = OpLoad %ulong %573
+OpStore %575 %926
+%927 = OpLoad %ulong %574
+OpStore %576 %927
+OpBranch %379
+%328 = OpLabel
+%928 = OpLoad %ulong %566
+%929 = OpIMul %ulong %928 %ulong_8
+OpStore %559 %929
+%930 = OpLoad %ulong %557
+%931 = OpLoad %ulong %559
+%932 = OpShiftRightLogical %ulong %930 %931
+OpStore %560 %932
+%933 = OpLoad %ulong %560
+%934 = OpBitwiseAnd %ulong %933 %ulong_255
+OpStore %561 %934
+%935 = OpLoad %ulong %565
+%936 = OpLoad %ulong %561
+%937 = OpBitwiseXor %ulong %935 %936
+OpStore %562 %937
+%938 = OpLoad %ulong %562
+%939 = OpIMul %ulong %938 %ulong_1099511628211
+OpStore %563 %939
+%940 = OpLoad %ulong %566
+%941 = OpIAdd %ulong %940 %ulong_1
+OpStore %564 %941
+%942 = OpLoad %ulong %563
+OpStore %565 %942
+%943 = OpLoad %ulong %564
+OpStore %566 %943
+OpBranch %380
+%321 = OpLabel
+%944 = OpLoad %ulong %556
+%945 = OpIMul %ulong %944 %ulong_8
+OpStore %549 %945
+%946 = OpLoad %ulong %547
+%947 = OpLoad %ulong %549
+%948 = OpShiftRightLogical %ulong %946 %947
+OpStore %550 %948
+%949 = OpLoad %ulong %550
+%950 = OpBitwiseAnd %ulong %949 %ulong_255
+OpStore %551 %950
+%951 = OpLoad %ulong %555
+%952 = OpLoad %ulong %551
+%953 = OpBitwiseXor %ulong %951 %952
+OpStore %552 %953
+%954 = OpLoad %ulong %552
+%955 = OpIMul %ulong %954 %ulong_1099511628211
+OpStore %553 %955
+%956 = OpLoad %ulong %556
+%957 = OpIAdd %ulong %956 %ulong_1
+OpStore %554 %957
+%958 = OpLoad %ulong %553
+OpStore %555 %958
+%959 = OpLoad %ulong %554
+OpStore %556 %959
+OpBranch %381
+%314 = OpLabel
+%960 = OpLoad %ulong %546
+%961 = OpIMul %ulong %960 %ulong_8
+OpStore %539 %961
+%962 = OpLoad %ulong %537
+%963 = OpLoad %ulong %539
+%964 = OpShiftRightLogical %ulong %962 %963
+OpStore %540 %964
+%965 = OpLoad %ulong %540
+%966 = OpBitwiseAnd %ulong %965 %ulong_255
+OpStore %541 %966
+%967 = OpLoad %ulong %545
+%968 = OpLoad %ulong %541
+%969 = OpBitwiseXor %ulong %967 %968
+OpStore %542 %969
+%970 = OpLoad %ulong %542
+%971 = OpIMul %ulong %970 %ulong_1099511628211
+OpStore %543 %971
+%972 = OpLoad %ulong %546
+%973 = OpIAdd %ulong %972 %ulong_1
+OpStore %544 %973
+%974 = OpLoad %ulong %543
+OpStore %545 %974
+%975 = OpLoad %ulong %544
+OpStore %546 %975
+OpBranch %382
+%307 = OpLabel
+%976 = OpLoad %ulong %536
+%977 = OpIMul %ulong %976 %ulong_8
+OpStore %529 %977
+%978 = OpLoad %ulong %527
+%979 = OpLoad %ulong %529
+%980 = OpShiftRightLogical %ulong %978 %979
+OpStore %530 %980
+%981 = OpLoad %ulong %530
+%982 = OpBitwiseAnd %ulong %981 %ulong_255
+OpStore %531 %982
+%983 = OpLoad %ulong %535
+%984 = OpLoad %ulong %531
+%985 = OpBitwiseXor %ulong %983 %984
+OpStore %532 %985
+%986 = OpLoad %ulong %532
+%987 = OpIMul %ulong %986 %ulong_1099511628211
+OpStore %533 %987
+%988 = OpLoad %ulong %536
+%989 = OpIAdd %ulong %988 %ulong_1
+OpStore %534 %989
+%990 = OpLoad %ulong %533
+OpStore %535 %990
+%991 = OpLoad %ulong %534
+OpStore %536 %991
+OpBranch %383
+%300 = OpLabel
+%992 = OpLoad %ulong %526
+%993 = OpIMul %ulong %992 %ulong_8
+OpStore %519 %993
+%994 = OpLoad %ulong %517
+%995 = OpLoad %ulong %519
+%996 = OpShiftRightLogical %ulong %994 %995
+OpStore %520 %996
+%997 = OpLoad %ulong %520
+%998 = OpBitwiseAnd %ulong %997 %ulong_255
+OpStore %521 %998
+%999 = OpLoad %ulong %525
+%1000 = OpLoad %ulong %521
+%1001 = OpBitwiseXor %ulong %999 %1000
+OpStore %522 %1001
+%1002 = OpLoad %ulong %522
+%1003 = OpIMul %ulong %1002 %ulong_1099511628211
+OpStore %523 %1003
+%1004 = OpLoad %ulong %526
+%1005 = OpIAdd %ulong %1004 %ulong_1
+OpStore %524 %1005
+%1006 = OpLoad %ulong %523
+OpStore %525 %1006
+%1007 = OpLoad %ulong %524
+OpStore %526 %1007
+OpBranch %384
+%291 = OpLabel
+%1008 = OpLoad %ulong %515
+%1009 = OpIMul %ulong %1008 %ulong_8
+OpStore %508 %1009
+%1010 = OpLoad %ulong %506
+%1011 = OpLoad %ulong %508
+%1012 = OpShiftRightLogical %ulong %1010 %1011
+OpStore %509 %1012
+%1013 = OpLoad %ulong %509
+%1014 = OpBitwiseAnd %ulong %1013 %ulong_255
+OpStore %510 %1014
+%1015 = OpLoad %ulong %514
+%1016 = OpLoad %ulong %510
+%1017 = OpBitwiseXor %ulong %1015 %1016
+OpStore %511 %1017
+%1018 = OpLoad %ulong %511
+%1019 = OpIMul %ulong %1018 %ulong_1099511628211
+OpStore %512 %1019
+%1020 = OpLoad %ulong %515
+%1021 = OpIAdd %ulong %1020 %ulong_1
+OpStore %513 %1021
+%1022 = OpLoad %ulong %512
+OpStore %514 %1022
+%1023 = OpLoad %ulong %513
+OpStore %515 %1023
+OpBranch %385
+%282 = OpLabel
+%1024 = OpLoad %ulong %504
+%1025 = OpIMul %ulong %1024 %ulong_8
+OpStore %497 %1025
+%1026 = OpLoad %ulong %495
+%1027 = OpLoad %ulong %497
+%1028 = OpShiftRightLogical %ulong %1026 %1027
+OpStore %498 %1028
+%1029 = OpLoad %ulong %498
+%1030 = OpBitwiseAnd %ulong %1029 %ulong_255
+OpStore %499 %1030
+%1031 = OpLoad %ulong %503
+%1032 = OpLoad %ulong %499
+%1033 = OpBitwiseXor %ulong %1031 %1032
+OpStore %500 %1033
+%1034 = OpLoad %ulong %500
+%1035 = OpIMul %ulong %1034 %ulong_1099511628211
+OpStore %501 %1035
+%1036 = OpLoad %ulong %504
+%1037 = OpIAdd %ulong %1036 %ulong_1
+OpStore %502 %1037
+%1038 = OpLoad %ulong %501
+OpStore %503 %1038
+%1039 = OpLoad %ulong %502
+OpStore %504 %1039
+OpBranch %386
+%273 = OpLabel
+%1040 = OpLoad %ulong %493
+%1041 = OpIMul %ulong %1040 %ulong_8
+OpStore %486 %1041
+%1042 = OpLoad %ulong %484
+%1043 = OpLoad %ulong %486
+%1044 = OpShiftRightLogical %ulong %1042 %1043
+OpStore %487 %1044
+%1045 = OpLoad %ulong %487
+%1046 = OpBitwiseAnd %ulong %1045 %ulong_255
+OpStore %488 %1046
+%1047 = OpLoad %ulong %492
+%1048 = OpLoad %ulong %488
+%1049 = OpBitwiseXor %ulong %1047 %1048
+OpStore %489 %1049
+%1050 = OpLoad %ulong %489
+%1051 = OpIMul %ulong %1050 %ulong_1099511628211
+OpStore %490 %1051
+%1052 = OpLoad %ulong %493
+%1053 = OpIAdd %ulong %1052 %ulong_1
+OpStore %491 %1053
+%1054 = OpLoad %ulong %490
+OpStore %492 %1054
+%1055 = OpLoad %ulong %491
+OpStore %493 %1055
+OpBranch %387
+%264 = OpLabel
+%1056 = OpLoad %ulong %482
+%1057 = OpIMul %ulong %1056 %ulong_8
+OpStore %475 %1057
+%1058 = OpLoad %ulong %473
+%1059 = OpLoad %ulong %475
+%1060 = OpShiftRightLogical %ulong %1058 %1059
+OpStore %476 %1060
+%1061 = OpLoad %ulong %476
+%1062 = OpBitwiseAnd %ulong %1061 %ulong_255
+OpStore %477 %1062
+%1063 = OpLoad %ulong %481
+%1064 = OpLoad %ulong %477
+%1065 = OpBitwiseXor %ulong %1063 %1064
+OpStore %478 %1065
+%1066 = OpLoad %ulong %478
+%1067 = OpIMul %ulong %1066 %ulong_1099511628211
+OpStore %479 %1067
+%1068 = OpLoad %ulong %482
+%1069 = OpIAdd %ulong %1068 %ulong_1
+OpStore %480 %1069
+%1070 = OpLoad %ulong %479
+OpStore %481 %1070
+%1071 = OpLoad %ulong %480
+OpStore %482 %1071
+OpBranch %388
+%255 = OpLabel
+%1072 = OpLoad %ulong %471
+%1073 = OpIMul %ulong %1072 %ulong_8
+OpStore %464 %1073
+%1074 = OpLoad %ulong %462
+%1075 = OpLoad %ulong %464
+%1076 = OpShiftRightLogical %ulong %1074 %1075
+OpStore %465 %1076
+%1077 = OpLoad %ulong %465
+%1078 = OpBitwiseAnd %ulong %1077 %ulong_255
+OpStore %466 %1078
+%1079 = OpLoad %ulong %470
+%1080 = OpLoad %ulong %466
+%1081 = OpBitwiseXor %ulong %1079 %1080
+OpStore %467 %1081
+%1082 = OpLoad %ulong %467
+%1083 = OpIMul %ulong %1082 %ulong_1099511628211
+OpStore %468 %1083
+%1084 = OpLoad %ulong %471
+%1085 = OpIAdd %ulong %1084 %ulong_1
+OpStore %469 %1085
+%1086 = OpLoad %ulong %468
+OpStore %470 %1086
+%1087 = OpLoad %ulong %469
+OpStore %471 %1087
+OpBranch %389
+%246 = OpLabel
+%1088 = OpLoad %ulong %460
+%1089 = OpIMul %ulong %1088 %ulong_8
+OpStore %453 %1089
+%1090 = OpLoad %ulong %451
+%1091 = OpLoad %ulong %453
+%1092 = OpShiftRightLogical %ulong %1090 %1091
+OpStore %454 %1092
+%1093 = OpLoad %ulong %454
+%1094 = OpBitwiseAnd %ulong %1093 %ulong_255
+OpStore %455 %1094
+%1095 = OpLoad %ulong %459
+%1096 = OpLoad %ulong %455
+%1097 = OpBitwiseXor %ulong %1095 %1096
+OpStore %456 %1097
+%1098 = OpLoad %ulong %456
+%1099 = OpIMul %ulong %1098 %ulong_1099511628211
+OpStore %457 %1099
+%1100 = OpLoad %ulong %460
+%1101 = OpIAdd %ulong %1100 %ulong_1
+OpStore %458 %1101
+%1102 = OpLoad %ulong %457
+OpStore %459 %1102
+%1103 = OpLoad %ulong %458
+OpStore %460 %1103
+OpBranch %390
+%237 = OpLabel
+%1104 = OpLoad %ulong %449
+%1105 = OpIMul %ulong %1104 %ulong_8
+OpStore %442 %1105
+%1106 = OpLoad %ulong %440
+%1107 = OpLoad %ulong %442
+%1108 = OpShiftRightLogical %ulong %1106 %1107
+OpStore %443 %1108
+%1109 = OpLoad %ulong %443
+%1110 = OpBitwiseAnd %ulong %1109 %ulong_255
+OpStore %444 %1110
+%1111 = OpLoad %ulong %448
+%1112 = OpLoad %ulong %444
+%1113 = OpBitwiseXor %ulong %1111 %1112
+OpStore %445 %1113
+%1114 = OpLoad %ulong %445
+%1115 = OpIMul %ulong %1114 %ulong_1099511628211
+OpStore %446 %1115
+%1116 = OpLoad %ulong %449
+%1117 = OpIAdd %ulong %1116 %ulong_1
+OpStore %447 %1117
+%1118 = OpLoad %ulong %446
+OpStore %448 %1118
+%1119 = OpLoad %ulong %447
+OpStore %449 %1119
+OpBranch %391
+%228 = OpLabel
+%1120 = OpLoad %ulong %438
+%1121 = OpIMul %ulong %1120 %ulong_8
+OpStore %431 %1121
+%1122 = OpLoad %ulong %429
+%1123 = OpLoad %ulong %431
+%1124 = OpShiftRightLogical %ulong %1122 %1123
+OpStore %432 %1124
+%1125 = OpLoad %ulong %432
+%1126 = OpBitwiseAnd %ulong %1125 %ulong_255
+OpStore %433 %1126
+%1127 = OpLoad %ulong %437
+%1128 = OpLoad %ulong %433
+%1129 = OpBitwiseXor %ulong %1127 %1128
+OpStore %434 %1129
+%1130 = OpLoad %ulong %434
+%1131 = OpIMul %ulong %1130 %ulong_1099511628211
+OpStore %435 %1131
+%1132 = OpLoad %ulong %438
+%1133 = OpIAdd %ulong %1132 %ulong_1
+OpStore %436 %1133
+%1134 = OpLoad %ulong %435
+OpStore %437 %1134
+%1135 = OpLoad %ulong %436
+OpStore %438 %1135
+OpBranch %392
+%219 = OpLabel
+%1136 = OpLoad %ulong %427
+%1137 = OpIMul %ulong %1136 %ulong_8
+OpStore %420 %1137
+%1138 = OpLoad %ulong %418
+%1139 = OpLoad %ulong %420
+%1140 = OpShiftRightLogical %ulong %1138 %1139
+OpStore %421 %1140
+%1141 = OpLoad %ulong %421
+%1142 = OpBitwiseAnd %ulong %1141 %ulong_255
+OpStore %422 %1142
+%1143 = OpLoad %ulong %426
+%1144 = OpLoad %ulong %422
+%1145 = OpBitwiseXor %ulong %1143 %1144
+OpStore %423 %1145
+%1146 = OpLoad %ulong %423
+%1147 = OpIMul %ulong %1146 %ulong_1099511628211
+OpStore %424 %1147
+%1148 = OpLoad %ulong %427
+%1149 = OpIAdd %ulong %1148 %ulong_1
+OpStore %425 %1149
+%1150 = OpLoad %ulong %424
+OpStore %426 %1150
+%1151 = OpLoad %ulong %425
+OpStore %427 %1151
+OpBranch %393
+%374 = OpLabel
+OpBranch %369
+%375 = OpLabel
+OpBranch %362
+%376 = OpLabel
+OpBranch %355
+%377 = OpLabel
+OpBranch %348
+%378 = OpLabel
+OpBranch %341
+%379 = OpLabel
+OpBranch %334
+%380 = OpLabel
+OpBranch %327
+%381 = OpLabel
+OpBranch %320
+%382 = OpLabel
+OpBranch %313
+%383 = OpLabel
+OpBranch %306
+%384 = OpLabel
+OpBranch %299
+%385 = OpLabel
+OpBranch %290
+%386 = OpLabel
+OpBranch %281
+%387 = OpLabel
+OpBranch %272
+%388 = OpLabel
+OpBranch %263
+%389 = OpLabel
+OpBranch %254
+%390 = OpLabel
+OpBranch %245
+%391 = OpLabel
+OpBranch %236
+%392 = OpLabel
+OpBranch %227
+%393 = OpLabel
+OpBranch %218
 OpFunctionEnd

--- a/test/golden/spirv/convert/i2f.dis
+++ b/test/golden/spirv/convert/i2f.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 434
+; Bound: 1602
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -16,579 +16,2389 @@ OpDecorate %2 LinkageAttributes "corpus.cases.convert.i2f.checksum" Export
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
-%10 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong %uchar %ushort %uint %ulong
+%8 = OpTypeFunction %ulong %ulong %uchar %ushort %uint %ulong %uchar %ushort %uint %ulong
 %float = OpTypeFloat 32
 %double = OpTypeFloat 64
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_double = OpTypePointer Function %double
-%151 = OpTypeFunction %ulong %ulong
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%756 = OpTypeFunction %ulong %ulong
 %uchar_128 = OpConstant %uchar 128
 %ushort_32768 = OpConstant %ushort 32768
 %uint_2147483648 = OpConstant %uint 2147483648
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
-%ulong_1 = OpConstant %ulong 1
-%ulong_0 = OpConstant %ulong 0
-%333 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%336 = OpTypeFunction %ulong %ulong %float
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%389 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %10
-%11 = OpFunctionParameter %ulong
-%12 = OpFunctionParameter %uchar
-%13 = OpFunctionParameter %ushort
-%14 = OpFunctionParameter %uint
-%15 = OpFunctionParameter %ulong
-%16 = OpFunctionParameter %uchar
-%17 = OpFunctionParameter %ushort
-%18 = OpFunctionParameter %uint
-%19 = OpFunctionParameter %ulong
-%20 = OpLabel
-%24 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uchar Function
-%33 = OpVariable %_ptr_Function_ushort Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_float Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_double Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_float Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_double Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_float Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_double Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_float Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_double Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_float Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_double Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_float Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_double Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_float Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_double Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_float Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_double Function
-%69 = OpVariable %_ptr_Function_ulong Function
-OpStore %24 %11
-OpStore %26 %12
-OpStore %28 %13
-OpStore %30 %14
-OpStore %31 %15
-OpStore %32 %16
-OpStore %33 %17
-OpStore %34 %18
-OpStore %35 %19
-%70 = OpLoad %uchar %26
-%71 = OpConvertUToF %float %70
-OpStore %37 %71
-%72 = OpLoad %ulong %24
-%73 = OpLoad %float %37
-%74 = OpFunctionCall %ulong %4 %72 %73
-OpStore %38 %74
-%75 = OpLoad %uchar %26
-%76 = OpConvertUToF %double %75
-OpStore %40 %76
-%77 = OpLoad %ulong %38
-%78 = OpLoad %double %40
-%79 = OpFunctionCall %ulong %5 %77 %78
-OpStore %41 %79
-%80 = OpLoad %ushort %28
-%81 = OpConvertUToF %float %80
-OpStore %42 %81
-%82 = OpLoad %ulong %41
-%83 = OpLoad %float %42
-%84 = OpFunctionCall %ulong %4 %82 %83
-OpStore %43 %84
-%85 = OpLoad %ushort %28
-%86 = OpConvertUToF %double %85
-OpStore %44 %86
-%87 = OpLoad %ulong %43
-%88 = OpLoad %double %44
-%89 = OpFunctionCall %ulong %5 %87 %88
-OpStore %45 %89
-%90 = OpLoad %uint %30
-%91 = OpConvertUToF %float %90
-OpStore %46 %91
-%92 = OpLoad %ulong %45
-%93 = OpLoad %float %46
-%94 = OpFunctionCall %ulong %4 %92 %93
-OpStore %47 %94
-%95 = OpLoad %uint %30
-%96 = OpConvertUToF %double %95
-OpStore %48 %96
-%97 = OpLoad %ulong %47
-%98 = OpLoad %double %48
-%99 = OpFunctionCall %ulong %5 %97 %98
-OpStore %49 %99
-%100 = OpLoad %ulong %31
-%101 = OpConvertUToF %float %100
-OpStore %50 %101
-%102 = OpLoad %ulong %49
-%103 = OpLoad %float %50
-%104 = OpFunctionCall %ulong %4 %102 %103
-OpStore %51 %104
-%105 = OpLoad %ulong %31
-%106 = OpConvertUToF %double %105
-OpStore %52 %106
-%107 = OpLoad %ulong %51
-%108 = OpLoad %double %52
-%109 = OpFunctionCall %ulong %5 %107 %108
-OpStore %53 %109
-%110 = OpLoad %uchar %32
-%111 = OpConvertSToF %float %110
-OpStore %54 %111
-%112 = OpLoad %ulong %53
-%113 = OpLoad %float %54
-%114 = OpFunctionCall %ulong %4 %112 %113
-OpStore %55 %114
-%115 = OpLoad %uchar %32
-%116 = OpConvertSToF %double %115
-OpStore %56 %116
-%117 = OpLoad %ulong %55
-%118 = OpLoad %double %56
-%119 = OpFunctionCall %ulong %5 %117 %118
-OpStore %57 %119
-%120 = OpLoad %ushort %33
-%121 = OpConvertSToF %float %120
-OpStore %58 %121
-%122 = OpLoad %ulong %57
-%123 = OpLoad %float %58
-%124 = OpFunctionCall %ulong %4 %122 %123
-OpStore %59 %124
-%125 = OpLoad %ushort %33
-%126 = OpConvertSToF %double %125
-OpStore %60 %126
-%127 = OpLoad %ulong %59
-%128 = OpLoad %double %60
-%129 = OpFunctionCall %ulong %5 %127 %128
-OpStore %61 %129
-%130 = OpLoad %uint %34
-%131 = OpConvertSToF %float %130
-OpStore %62 %131
-%132 = OpLoad %ulong %61
-%133 = OpLoad %float %62
-%134 = OpFunctionCall %ulong %4 %132 %133
-OpStore %63 %134
-%135 = OpLoad %uint %34
-%136 = OpConvertSToF %double %135
-OpStore %64 %136
-%137 = OpLoad %ulong %63
-%138 = OpLoad %double %64
-%139 = OpFunctionCall %ulong %5 %137 %138
-OpStore %65 %139
-%140 = OpLoad %ulong %35
-%141 = OpConvertSToF %float %140
-OpStore %66 %141
-%142 = OpLoad %ulong %65
-%143 = OpLoad %float %66
-%144 = OpFunctionCall %ulong %4 %142 %143
-OpStore %67 %144
-%145 = OpLoad %ulong %35
-%146 = OpConvertSToF %double %145
-OpStore %68 %146
-%147 = OpLoad %ulong %67
-%148 = OpLoad %double %68
-%149 = OpFunctionCall %ulong %5 %147 %148
-OpStore %69 %149
-%150 = OpLoad %ulong %69
-OpReturnValue %150
-OpFunctionEnd
-%2 = OpFunction %ulong None %151
-%152 = OpFunctionParameter %ulong
-%153 = OpLabel
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_uchar Function
+%1562 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %uchar
+%11 = OpFunctionParameter %ushort
+%12 = OpFunctionParameter %uint
+%13 = OpFunctionParameter %ulong
+%14 = OpFunctionParameter %uchar
+%15 = OpFunctionParameter %ushort
+%16 = OpFunctionParameter %uint
+%17 = OpFunctionParameter %ulong
+%18 = OpLabel
+%151 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_uchar Function
+%155 = OpVariable %_ptr_Function_ushort Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_uchar Function
 %160 = OpVariable %_ptr_Function_ushort Function
-%161 = OpVariable %_ptr_Function_ushort Function
-%162 = OpVariable %_ptr_Function_uint Function
-%163 = OpVariable %_ptr_Function_uint Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_float Function
+%166 = OpVariable %_ptr_Function_double Function
 %167 = OpVariable %_ptr_Function_float Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_double Function
-%170 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_double Function
+%169 = OpVariable %_ptr_Function_float Function
+%170 = OpVariable %_ptr_Function_double Function
 %171 = OpVariable %_ptr_Function_float Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_double Function
-%174 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_double Function
+%173 = OpVariable %_ptr_Function_float Function
+%174 = OpVariable %_ptr_Function_double Function
 %175 = OpVariable %_ptr_Function_float Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_double Function
-%178 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_double Function
+%177 = OpVariable %_ptr_Function_float Function
+%178 = OpVariable %_ptr_Function_double Function
 %179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_double Function
+%180 = OpVariable %_ptr_Function_double Function
+%181 = OpVariable %_ptr_Function_uint Function
 %182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_double Function
+%184 = OpVariable %_ptr_Function_bool Function
+%185 = OpVariable %_ptr_Function_ulong Function
 %186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_float Function
+%187 = OpVariable %_ptr_Function_ulong Function
 %188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_double Function
+%189 = OpVariable %_ptr_Function_ulong Function
 %190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_float Function
+%191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_double Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_float Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_bool Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_double Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_float Function
+%199 = OpVariable %_ptr_Function_ulong Function
 %200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_double Function
+%201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_float Function
+%203 = OpVariable %_ptr_Function_uint Function
 %204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_double Function
+%205 = OpVariable %_ptr_Function_bool Function
 %206 = OpVariable %_ptr_Function_ulong Function
-OpStore %156 %152
-%207 = OpFunctionCall %ulong %3
-OpStore %157 %207
-%208 = OpLoad %ulong %156
-%209 = OpUConvert %uchar %208
-OpStore %158 %209
-%210 = OpLoad %uchar %158
-%212 = OpBitwiseOr %uchar %210 %uchar_128
-OpStore %159 %212
-%213 = OpLoad %ulong %156
-%214 = OpUConvert %ushort %213
-OpStore %160 %214
-%215 = OpLoad %ushort %160
-%217 = OpBitwiseOr %ushort %215 %ushort_32768
-OpStore %161 %217
-%218 = OpLoad %ulong %156
-%219 = OpUConvert %uint %218
-OpStore %162 %219
-%220 = OpLoad %uint %162
-%222 = OpBitwiseOr %uint %220 %uint_2147483648
-OpStore %163 %222
-%223 = OpLoad %ulong %156
-%225 = OpBitwiseOr %ulong %223 %ulong_9223372036854775808
-OpStore %164 %225
-OpBranch %154
-%154 = OpLabel
-%226 = OpLoad %uchar %159
-%227 = OpConvertUToF %float %226
-OpStore %175 %227
-%228 = OpLoad %ulong %157
-%229 = OpLoad %float %175
-%230 = OpFunctionCall %ulong %4 %228 %229
-OpStore %176 %230
-%231 = OpLoad %uchar %159
-%232 = OpConvertUToF %double %231
-OpStore %177 %232
-%233 = OpLoad %ulong %176
-%234 = OpLoad %double %177
-%235 = OpFunctionCall %ulong %5 %233 %234
-OpStore %178 %235
-%236 = OpLoad %ushort %161
-%237 = OpConvertUToF %float %236
-OpStore %179 %237
-%238 = OpLoad %ulong %178
-%239 = OpLoad %float %179
-%240 = OpFunctionCall %ulong %4 %238 %239
-OpStore %180 %240
-%241 = OpLoad %ushort %161
-%242 = OpConvertUToF %double %241
-OpStore %181 %242
-%243 = OpLoad %ulong %180
-%244 = OpLoad %double %181
-%245 = OpFunctionCall %ulong %5 %243 %244
-OpStore %182 %245
-%246 = OpLoad %uint %163
-%247 = OpConvertUToF %float %246
-OpStore %183 %247
-%248 = OpLoad %ulong %182
-%249 = OpLoad %float %183
-%250 = OpFunctionCall %ulong %4 %248 %249
-OpStore %184 %250
-%251 = OpLoad %uint %163
-%252 = OpConvertUToF %double %251
-OpStore %185 %252
-%253 = OpLoad %ulong %184
-%254 = OpLoad %double %185
-%255 = OpFunctionCall %ulong %5 %253 %254
-OpStore %186 %255
-%256 = OpLoad %ulong %164
-%257 = OpConvertUToF %float %256
-OpStore %187 %257
-%258 = OpLoad %ulong %186
-%259 = OpLoad %float %187
-%260 = OpFunctionCall %ulong %4 %258 %259
-OpStore %188 %260
-%261 = OpLoad %ulong %164
-%262 = OpConvertUToF %double %261
-OpStore %189 %262
-%263 = OpLoad %ulong %188
-%264 = OpLoad %double %189
-%265 = OpFunctionCall %ulong %5 %263 %264
-OpStore %190 %265
-%266 = OpLoad %uchar %159
-%267 = OpConvertSToF %float %266
-OpStore %191 %267
-%268 = OpLoad %ulong %190
-%269 = OpLoad %float %191
-%270 = OpFunctionCall %ulong %4 %268 %269
-OpStore %192 %270
-%271 = OpLoad %uchar %159
-%272 = OpConvertSToF %double %271
-OpStore %193 %272
-%273 = OpLoad %ulong %192
-%274 = OpLoad %double %193
-%275 = OpFunctionCall %ulong %5 %273 %274
-OpStore %194 %275
-%276 = OpLoad %ushort %161
-%277 = OpConvertSToF %float %276
-OpStore %195 %277
-%278 = OpLoad %ulong %194
-%279 = OpLoad %float %195
-%280 = OpFunctionCall %ulong %4 %278 %279
-OpStore %196 %280
-%281 = OpLoad %ushort %161
-%282 = OpConvertSToF %double %281
-OpStore %197 %282
-%283 = OpLoad %ulong %196
-%284 = OpLoad %double %197
-%285 = OpFunctionCall %ulong %5 %283 %284
-OpStore %198 %285
-%286 = OpLoad %uint %163
-%287 = OpConvertSToF %float %286
-OpStore %199 %287
-%288 = OpLoad %ulong %198
-%289 = OpLoad %float %199
-%290 = OpFunctionCall %ulong %4 %288 %289
-OpStore %200 %290
-%291 = OpLoad %uint %163
-%292 = OpConvertSToF %double %291
-OpStore %201 %292
-%293 = OpLoad %ulong %200
-%294 = OpLoad %double %201
-%295 = OpFunctionCall %ulong %5 %293 %294
-OpStore %202 %295
-%296 = OpLoad %ulong %164
-%297 = OpConvertSToF %float %296
-OpStore %203 %297
-%298 = OpLoad %ulong %202
-%299 = OpLoad %float %203
-%300 = OpFunctionCall %ulong %4 %298 %299
-OpStore %204 %300
-%301 = OpLoad %ulong %164
-%302 = OpConvertSToF %double %301
-OpStore %205 %302
-%303 = OpLoad %ulong %204
-%304 = OpLoad %double %205
-%305 = OpFunctionCall %ulong %5 %303 %304
-OpStore %206 %305
-OpBranch %155
-%155 = OpLabel
-%306 = OpLoad %ulong %156
-%308 = OpBitwiseOr %ulong %306 %ulong_1
-OpStore %165 %308
-%310 = OpLoad %ulong %165
-%311 = OpISub %ulong %ulong_0 %310
-OpStore %166 %311
-%312 = OpLoad %ulong %165
-%313 = OpConvertUToF %float %312
-OpStore %167 %313
-%314 = OpLoad %ulong %206
-%315 = OpLoad %float %167
-%316 = OpFunctionCall %ulong %4 %314 %315
-OpStore %168 %316
-%317 = OpLoad %ulong %165
-%318 = OpConvertUToF %double %317
-OpStore %169 %318
-%319 = OpLoad %ulong %168
-%320 = OpLoad %double %169
-%321 = OpFunctionCall %ulong %5 %319 %320
-OpStore %170 %321
-%322 = OpLoad %ulong %166
-%323 = OpConvertSToF %float %322
-OpStore %171 %323
-%324 = OpLoad %ulong %170
-%325 = OpLoad %float %171
-%326 = OpFunctionCall %ulong %4 %324 %325
-OpStore %172 %326
-%327 = OpLoad %ulong %166
-%328 = OpConvertSToF %double %327
-OpStore %173 %328
-%329 = OpLoad %ulong %172
-%330 = OpLoad %double %173
-%331 = OpFunctionCall %ulong %5 %329 %330
-OpStore %174 %331
-%332 = OpLoad %ulong %174
-OpReturnValue %332
-OpFunctionEnd
-%3 = OpFunction %ulong None %333
-%334 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %336
-%337 = OpFunctionParameter %ulong
-%338 = OpFunctionParameter %float
-%339 = OpLabel
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_bool Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_uint Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_uint Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_bool Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_bool Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_uint Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_bool Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_bool Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_bool Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_bool Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_uint Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_bool Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_uint Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_bool Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_bool Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
 %347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_uint Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%352 = OpVariable %_ptr_Function_bool Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_ulong Function
-OpStore %347 %337
-OpStore %348 %338
-%361 = OpLoad %float %348
-%362 = OpBitcast %uint %361
-OpStore %349 %362
-%363 = OpLoad %uint %349
-%364 = OpUConvert %ulong %363
-OpStore %350 %364
-OpBranch %340
-%340 = OpLabel
-%365 = OpLoad %ulong %347
-OpStore %359 %365
-OpStore %360 %ulong_0
-OpBranch %341
-%341 = OpLabel
-%366 = OpLoad %ulong %360
-%368 = OpULessThan %bool %366 %ulong_8
-OpStore %352 %368
-%369 = OpLoad %bool %352
-OpLoopMerge %343 %345 None
-OpBranchConditional %369 %342 %343
-%343 = OpLabel
-OpBranch %344
-%344 = OpLabel
-%370 = OpLoad %ulong %359
-OpReturnValue %370
-%342 = OpLabel
-%371 = OpLoad %ulong %360
-%372 = OpIMul %ulong %371 %ulong_8
-OpStore %353 %372
-%373 = OpLoad %ulong %350
-%374 = OpLoad %ulong %353
-%375 = OpShiftRightLogical %ulong %373 %374
-OpStore %354 %375
-%376 = OpLoad %ulong %354
-%378 = OpBitwiseAnd %ulong %376 %ulong_255
-OpStore %355 %378
-%379 = OpLoad %ulong %359
-%380 = OpLoad %ulong %355
-%381 = OpBitwiseXor %ulong %379 %380
-OpStore %356 %381
-%382 = OpLoad %ulong %356
-%384 = OpIMul %ulong %382 %ulong_1099511628211
-OpStore %357 %384
-%385 = OpLoad %ulong %360
-%386 = OpIAdd %ulong %385 %ulong_1
-OpStore %358 %386
-%387 = OpLoad %ulong %357
-OpStore %359 %387
-%388 = OpLoad %ulong %358
-OpStore %360 %388
-OpBranch %345
-%345 = OpLabel
-OpBranch %341
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+OpStore %151 %9
+OpStore %153 %10
+OpStore %155 %11
+OpStore %157 %12
+OpStore %158 %13
+OpStore %159 %14
+OpStore %160 %15
+OpStore %161 %16
+OpStore %162 %17
+%350 = OpLoad %uchar %153
+%351 = OpConvertUToF %float %350
+OpStore %164 %351
+OpBranch %19
+%19 = OpLabel
+%352 = OpLoad %float %164
+%353 = OpBitcast %uint %352
+OpStore %181 %353
+%354 = OpLoad %uint %181
+%355 = OpUConvert %ulong %354
+OpStore %182 %355
+OpBranch %21
+%21 = OpLabel
+%356 = OpLoad %ulong %151
+OpStore %191 %356
+OpStore %192 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%358 = OpLoad %ulong %192
+%360 = OpULessThan %bool %358 %ulong_8
+OpStore %184 %360
+%361 = OpLoad %bool %184
+OpLoopMerge %24 %146 None
+OpBranchConditional %361 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%362 = OpLoad %uchar %153
+%363 = OpConvertUToF %double %362
+OpStore %166 %363
+OpBranch %26
+%26 = OpLabel
+%364 = OpLoad %double %166
+%365 = OpBitcast %ulong %364
+OpStore %193 %365
+OpBranch %28
+%28 = OpLabel
+%366 = OpLoad %ulong %191
+OpStore %201 %366
+OpStore %202 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%367 = OpLoad %ulong %202
+%368 = OpULessThan %bool %367 %ulong_8
+OpStore %194 %368
+%369 = OpLoad %bool %194
+OpLoopMerge %31 %145 None
+OpBranchConditional %369 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%370 = OpLoad %ushort %155
+%371 = OpConvertUToF %float %370
+OpStore %167 %371
+OpBranch %33
+%33 = OpLabel
+%372 = OpLoad %float %167
+%373 = OpBitcast %uint %372
+OpStore %203 %373
+%374 = OpLoad %uint %203
+%375 = OpUConvert %ulong %374
+OpStore %204 %375
+OpBranch %35
+%35 = OpLabel
+%376 = OpLoad %ulong %201
+OpStore %212 %376
+OpStore %213 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%377 = OpLoad %ulong %213
+%378 = OpULessThan %bool %377 %ulong_8
+OpStore %205 %378
+%379 = OpLoad %bool %205
+OpLoopMerge %38 %144 None
+OpBranchConditional %379 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%380 = OpLoad %ushort %155
+%381 = OpConvertUToF %double %380
+OpStore %168 %381
+OpBranch %40
+%40 = OpLabel
+%382 = OpLoad %double %168
+%383 = OpBitcast %ulong %382
+OpStore %214 %383
+OpBranch %42
+%42 = OpLabel
+%384 = OpLoad %ulong %212
+OpStore %222 %384
+OpStore %223 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%385 = OpLoad %ulong %223
+%386 = OpULessThan %bool %385 %ulong_8
+OpStore %215 %386
+%387 = OpLoad %bool %215
+OpLoopMerge %45 %143 None
+OpBranchConditional %387 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%388 = OpLoad %uint %157
+%389 = OpConvertUToF %float %388
+OpStore %169 %389
+OpBranch %47
+%47 = OpLabel
+%390 = OpLoad %float %169
+%391 = OpBitcast %uint %390
+OpStore %224 %391
+%392 = OpLoad %uint %224
+%393 = OpUConvert %ulong %392
+OpStore %225 %393
+OpBranch %49
+%49 = OpLabel
+%394 = OpLoad %ulong %222
+OpStore %233 %394
+OpStore %234 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%395 = OpLoad %ulong %234
+%396 = OpULessThan %bool %395 %ulong_8
+OpStore %226 %396
+%397 = OpLoad %bool %226
+OpLoopMerge %52 %142 None
+OpBranchConditional %397 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%398 = OpLoad %uint %157
+%399 = OpConvertUToF %double %398
+OpStore %170 %399
+OpBranch %54
+%54 = OpLabel
+%400 = OpLoad %double %170
+%401 = OpBitcast %ulong %400
+OpStore %235 %401
+OpBranch %56
+%56 = OpLabel
+%402 = OpLoad %ulong %233
+OpStore %243 %402
+OpStore %244 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%403 = OpLoad %ulong %244
+%404 = OpULessThan %bool %403 %ulong_8
+OpStore %236 %404
+%405 = OpLoad %bool %236
+OpLoopMerge %59 %141 None
+OpBranchConditional %405 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%406 = OpLoad %ulong %158
+%407 = OpConvertUToF %float %406
+OpStore %171 %407
+OpBranch %61
+%61 = OpLabel
+%408 = OpLoad %float %171
+%409 = OpBitcast %uint %408
+OpStore %245 %409
+%410 = OpLoad %uint %245
+%411 = OpUConvert %ulong %410
+OpStore %246 %411
+OpBranch %63
+%63 = OpLabel
+%412 = OpLoad %ulong %243
+OpStore %254 %412
+OpStore %255 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%413 = OpLoad %ulong %255
+%414 = OpULessThan %bool %413 %ulong_8
+OpStore %247 %414
+%415 = OpLoad %bool %247
+OpLoopMerge %66 %140 None
+OpBranchConditional %415 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%416 = OpLoad %ulong %158
+%417 = OpConvertUToF %double %416
+OpStore %172 %417
+OpBranch %68
+%68 = OpLabel
+%418 = OpLoad %double %172
+%419 = OpBitcast %ulong %418
+OpStore %256 %419
+OpBranch %70
+%70 = OpLabel
+%420 = OpLoad %ulong %254
+OpStore %264 %420
+OpStore %265 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%421 = OpLoad %ulong %265
+%422 = OpULessThan %bool %421 %ulong_8
+OpStore %257 %422
+%423 = OpLoad %bool %257
+OpLoopMerge %73 %139 None
+OpBranchConditional %423 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%424 = OpLoad %uchar %159
+%425 = OpConvertSToF %float %424
+OpStore %173 %425
+OpBranch %75
+%75 = OpLabel
+%426 = OpLoad %float %173
+%427 = OpBitcast %uint %426
+OpStore %266 %427
+%428 = OpLoad %uint %266
+%429 = OpUConvert %ulong %428
+OpStore %267 %429
+OpBranch %77
+%77 = OpLabel
+%430 = OpLoad %ulong %264
+OpStore %275 %430
+OpStore %276 %ulong_0
+OpBranch %78
+%78 = OpLabel
+%431 = OpLoad %ulong %276
+%432 = OpULessThan %bool %431 %ulong_8
+OpStore %268 %432
+%433 = OpLoad %bool %268
+OpLoopMerge %80 %138 None
+OpBranchConditional %433 %79 %80
+%80 = OpLabel
+OpBranch %81
+%81 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%434 = OpLoad %uchar %159
+%435 = OpConvertSToF %double %434
+OpStore %174 %435
+OpBranch %82
+%82 = OpLabel
+%436 = OpLoad %double %174
+%437 = OpBitcast %ulong %436
+OpStore %277 %437
+OpBranch %84
+%84 = OpLabel
+%438 = OpLoad %ulong %275
+OpStore %285 %438
+OpStore %286 %ulong_0
+OpBranch %85
+%85 = OpLabel
+%439 = OpLoad %ulong %286
+%440 = OpULessThan %bool %439 %ulong_8
+OpStore %278 %440
+%441 = OpLoad %bool %278
+OpLoopMerge %87 %137 None
+OpBranchConditional %441 %86 %87
+%87 = OpLabel
+OpBranch %88
+%88 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%442 = OpLoad %ushort %160
+%443 = OpConvertSToF %float %442
+OpStore %175 %443
+OpBranch %89
+%89 = OpLabel
+%444 = OpLoad %float %175
+%445 = OpBitcast %uint %444
+OpStore %287 %445
+%446 = OpLoad %uint %287
+%447 = OpUConvert %ulong %446
+OpStore %288 %447
+OpBranch %91
+%91 = OpLabel
+%448 = OpLoad %ulong %285
+OpStore %296 %448
+OpStore %297 %ulong_0
+OpBranch %92
+%92 = OpLabel
+%449 = OpLoad %ulong %297
+%450 = OpULessThan %bool %449 %ulong_8
+OpStore %289 %450
+%451 = OpLoad %bool %289
+OpLoopMerge %94 %136 None
+OpBranchConditional %451 %93 %94
+%94 = OpLabel
+OpBranch %95
+%95 = OpLabel
+OpBranch %90
+%90 = OpLabel
+%452 = OpLoad %ushort %160
+%453 = OpConvertSToF %double %452
+OpStore %176 %453
+OpBranch %96
+%96 = OpLabel
+%454 = OpLoad %double %176
+%455 = OpBitcast %ulong %454
+OpStore %298 %455
+OpBranch %98
+%98 = OpLabel
+%456 = OpLoad %ulong %296
+OpStore %306 %456
+OpStore %307 %ulong_0
+OpBranch %99
+%99 = OpLabel
+%457 = OpLoad %ulong %307
+%458 = OpULessThan %bool %457 %ulong_8
+OpStore %299 %458
+%459 = OpLoad %bool %299
+OpLoopMerge %101 %135 None
+OpBranchConditional %459 %100 %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%460 = OpLoad %uint %161
+%461 = OpConvertSToF %float %460
+OpStore %177 %461
+OpBranch %103
+%103 = OpLabel
+%462 = OpLoad %float %177
+%463 = OpBitcast %uint %462
+OpStore %308 %463
+%464 = OpLoad %uint %308
+%465 = OpUConvert %ulong %464
+OpStore %309 %465
+OpBranch %105
+%105 = OpLabel
+%466 = OpLoad %ulong %306
+OpStore %317 %466
+OpStore %318 %ulong_0
+OpBranch %106
+%106 = OpLabel
+%467 = OpLoad %ulong %318
+%468 = OpULessThan %bool %467 %ulong_8
+OpStore %310 %468
+%469 = OpLoad %bool %310
+OpLoopMerge %108 %134 None
+OpBranchConditional %469 %107 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %104
+%104 = OpLabel
+%470 = OpLoad %uint %161
+%471 = OpConvertSToF %double %470
+OpStore %178 %471
+OpBranch %110
+%110 = OpLabel
+%472 = OpLoad %double %178
+%473 = OpBitcast %ulong %472
+OpStore %319 %473
+OpBranch %112
+%112 = OpLabel
+%474 = OpLoad %ulong %317
+OpStore %327 %474
+OpStore %328 %ulong_0
+OpBranch %113
+%113 = OpLabel
+%475 = OpLoad %ulong %328
+%476 = OpULessThan %bool %475 %ulong_8
+OpStore %320 %476
+%477 = OpLoad %bool %320
+OpLoopMerge %115 %133 None
+OpBranchConditional %477 %114 %115
+%115 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%478 = OpLoad %ulong %162
+%479 = OpConvertSToF %float %478
+OpStore %179 %479
+OpBranch %117
+%117 = OpLabel
+%480 = OpLoad %float %179
+%481 = OpBitcast %uint %480
+OpStore %329 %481
+%482 = OpLoad %uint %329
+%483 = OpUConvert %ulong %482
+OpStore %330 %483
+OpBranch %119
+%119 = OpLabel
+%484 = OpLoad %ulong %327
+OpStore %338 %484
+OpStore %339 %ulong_0
+OpBranch %120
+%120 = OpLabel
+%485 = OpLoad %ulong %339
+%486 = OpULessThan %bool %485 %ulong_8
+OpStore %331 %486
+%487 = OpLoad %bool %331
+OpLoopMerge %122 %132 None
+OpBranchConditional %487 %121 %122
+%122 = OpLabel
+OpBranch %123
+%123 = OpLabel
+OpBranch %118
+%118 = OpLabel
+%488 = OpLoad %ulong %162
+%489 = OpConvertSToF %double %488
+OpStore %180 %489
+OpBranch %124
+%124 = OpLabel
+%490 = OpLoad %double %180
+%491 = OpBitcast %ulong %490
+OpStore %340 %491
+OpBranch %126
+%126 = OpLabel
+%492 = OpLoad %ulong %338
+OpStore %348 %492
+OpStore %349 %ulong_0
+OpBranch %127
+%127 = OpLabel
+%493 = OpLoad %ulong %349
+%494 = OpULessThan %bool %493 %ulong_8
+OpStore %341 %494
+%495 = OpLoad %bool %341
+OpLoopMerge %129 %131 None
+OpBranchConditional %495 %128 %129
+%129 = OpLabel
+OpBranch %130
+%130 = OpLabel
+OpBranch %125
+%125 = OpLabel
+%496 = OpLoad %ulong %348
+OpReturnValue %496
+%128 = OpLabel
+%497 = OpLoad %ulong %349
+%498 = OpIMul %ulong %497 %ulong_8
+OpStore %342 %498
+%499 = OpLoad %ulong %340
+%500 = OpLoad %ulong %342
+%501 = OpShiftRightLogical %ulong %499 %500
+OpStore %343 %501
+%502 = OpLoad %ulong %343
+%504 = OpBitwiseAnd %ulong %502 %ulong_255
+OpStore %344 %504
+%505 = OpLoad %ulong %348
+%506 = OpLoad %ulong %344
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %345 %507
+%508 = OpLoad %ulong %345
+%510 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %346 %510
+%511 = OpLoad %ulong %349
+%513 = OpIAdd %ulong %511 %ulong_1
+OpStore %347 %513
+%514 = OpLoad %ulong %346
+OpStore %348 %514
+%515 = OpLoad %ulong %347
+OpStore %349 %515
+OpBranch %131
+%121 = OpLabel
+%516 = OpLoad %ulong %339
+%517 = OpIMul %ulong %516 %ulong_8
+OpStore %332 %517
+%518 = OpLoad %ulong %330
+%519 = OpLoad %ulong %332
+%520 = OpShiftRightLogical %ulong %518 %519
+OpStore %333 %520
+%521 = OpLoad %ulong %333
+%522 = OpBitwiseAnd %ulong %521 %ulong_255
+OpStore %334 %522
+%523 = OpLoad %ulong %338
+%524 = OpLoad %ulong %334
+%525 = OpBitwiseXor %ulong %523 %524
+OpStore %335 %525
+%526 = OpLoad %ulong %335
+%527 = OpIMul %ulong %526 %ulong_1099511628211
+OpStore %336 %527
+%528 = OpLoad %ulong %339
+%529 = OpIAdd %ulong %528 %ulong_1
+OpStore %337 %529
+%530 = OpLoad %ulong %336
+OpStore %338 %530
+%531 = OpLoad %ulong %337
+OpStore %339 %531
+OpBranch %132
+%114 = OpLabel
+%532 = OpLoad %ulong %328
+%533 = OpIMul %ulong %532 %ulong_8
+OpStore %321 %533
+%534 = OpLoad %ulong %319
+%535 = OpLoad %ulong %321
+%536 = OpShiftRightLogical %ulong %534 %535
+OpStore %322 %536
+%537 = OpLoad %ulong %322
+%538 = OpBitwiseAnd %ulong %537 %ulong_255
+OpStore %323 %538
+%539 = OpLoad %ulong %327
+%540 = OpLoad %ulong %323
+%541 = OpBitwiseXor %ulong %539 %540
+OpStore %324 %541
+%542 = OpLoad %ulong %324
+%543 = OpIMul %ulong %542 %ulong_1099511628211
+OpStore %325 %543
+%544 = OpLoad %ulong %328
+%545 = OpIAdd %ulong %544 %ulong_1
+OpStore %326 %545
+%546 = OpLoad %ulong %325
+OpStore %327 %546
+%547 = OpLoad %ulong %326
+OpStore %328 %547
+OpBranch %133
+%107 = OpLabel
+%548 = OpLoad %ulong %318
+%549 = OpIMul %ulong %548 %ulong_8
+OpStore %311 %549
+%550 = OpLoad %ulong %309
+%551 = OpLoad %ulong %311
+%552 = OpShiftRightLogical %ulong %550 %551
+OpStore %312 %552
+%553 = OpLoad %ulong %312
+%554 = OpBitwiseAnd %ulong %553 %ulong_255
+OpStore %313 %554
+%555 = OpLoad %ulong %317
+%556 = OpLoad %ulong %313
+%557 = OpBitwiseXor %ulong %555 %556
+OpStore %314 %557
+%558 = OpLoad %ulong %314
+%559 = OpIMul %ulong %558 %ulong_1099511628211
+OpStore %315 %559
+%560 = OpLoad %ulong %318
+%561 = OpIAdd %ulong %560 %ulong_1
+OpStore %316 %561
+%562 = OpLoad %ulong %315
+OpStore %317 %562
+%563 = OpLoad %ulong %316
+OpStore %318 %563
+OpBranch %134
+%100 = OpLabel
+%564 = OpLoad %ulong %307
+%565 = OpIMul %ulong %564 %ulong_8
+OpStore %300 %565
+%566 = OpLoad %ulong %298
+%567 = OpLoad %ulong %300
+%568 = OpShiftRightLogical %ulong %566 %567
+OpStore %301 %568
+%569 = OpLoad %ulong %301
+%570 = OpBitwiseAnd %ulong %569 %ulong_255
+OpStore %302 %570
+%571 = OpLoad %ulong %306
+%572 = OpLoad %ulong %302
+%573 = OpBitwiseXor %ulong %571 %572
+OpStore %303 %573
+%574 = OpLoad %ulong %303
+%575 = OpIMul %ulong %574 %ulong_1099511628211
+OpStore %304 %575
+%576 = OpLoad %ulong %307
+%577 = OpIAdd %ulong %576 %ulong_1
+OpStore %305 %577
+%578 = OpLoad %ulong %304
+OpStore %306 %578
+%579 = OpLoad %ulong %305
+OpStore %307 %579
+OpBranch %135
+%93 = OpLabel
+%580 = OpLoad %ulong %297
+%581 = OpIMul %ulong %580 %ulong_8
+OpStore %290 %581
+%582 = OpLoad %ulong %288
+%583 = OpLoad %ulong %290
+%584 = OpShiftRightLogical %ulong %582 %583
+OpStore %291 %584
+%585 = OpLoad %ulong %291
+%586 = OpBitwiseAnd %ulong %585 %ulong_255
+OpStore %292 %586
+%587 = OpLoad %ulong %296
+%588 = OpLoad %ulong %292
+%589 = OpBitwiseXor %ulong %587 %588
+OpStore %293 %589
+%590 = OpLoad %ulong %293
+%591 = OpIMul %ulong %590 %ulong_1099511628211
+OpStore %294 %591
+%592 = OpLoad %ulong %297
+%593 = OpIAdd %ulong %592 %ulong_1
+OpStore %295 %593
+%594 = OpLoad %ulong %294
+OpStore %296 %594
+%595 = OpLoad %ulong %295
+OpStore %297 %595
+OpBranch %136
+%86 = OpLabel
+%596 = OpLoad %ulong %286
+%597 = OpIMul %ulong %596 %ulong_8
+OpStore %279 %597
+%598 = OpLoad %ulong %277
+%599 = OpLoad %ulong %279
+%600 = OpShiftRightLogical %ulong %598 %599
+OpStore %280 %600
+%601 = OpLoad %ulong %280
+%602 = OpBitwiseAnd %ulong %601 %ulong_255
+OpStore %281 %602
+%603 = OpLoad %ulong %285
+%604 = OpLoad %ulong %281
+%605 = OpBitwiseXor %ulong %603 %604
+OpStore %282 %605
+%606 = OpLoad %ulong %282
+%607 = OpIMul %ulong %606 %ulong_1099511628211
+OpStore %283 %607
+%608 = OpLoad %ulong %286
+%609 = OpIAdd %ulong %608 %ulong_1
+OpStore %284 %609
+%610 = OpLoad %ulong %283
+OpStore %285 %610
+%611 = OpLoad %ulong %284
+OpStore %286 %611
+OpBranch %137
+%79 = OpLabel
+%612 = OpLoad %ulong %276
+%613 = OpIMul %ulong %612 %ulong_8
+OpStore %269 %613
+%614 = OpLoad %ulong %267
+%615 = OpLoad %ulong %269
+%616 = OpShiftRightLogical %ulong %614 %615
+OpStore %270 %616
+%617 = OpLoad %ulong %270
+%618 = OpBitwiseAnd %ulong %617 %ulong_255
+OpStore %271 %618
+%619 = OpLoad %ulong %275
+%620 = OpLoad %ulong %271
+%621 = OpBitwiseXor %ulong %619 %620
+OpStore %272 %621
+%622 = OpLoad %ulong %272
+%623 = OpIMul %ulong %622 %ulong_1099511628211
+OpStore %273 %623
+%624 = OpLoad %ulong %276
+%625 = OpIAdd %ulong %624 %ulong_1
+OpStore %274 %625
+%626 = OpLoad %ulong %273
+OpStore %275 %626
+%627 = OpLoad %ulong %274
+OpStore %276 %627
+OpBranch %138
+%72 = OpLabel
+%628 = OpLoad %ulong %265
+%629 = OpIMul %ulong %628 %ulong_8
+OpStore %258 %629
+%630 = OpLoad %ulong %256
+%631 = OpLoad %ulong %258
+%632 = OpShiftRightLogical %ulong %630 %631
+OpStore %259 %632
+%633 = OpLoad %ulong %259
+%634 = OpBitwiseAnd %ulong %633 %ulong_255
+OpStore %260 %634
+%635 = OpLoad %ulong %264
+%636 = OpLoad %ulong %260
+%637 = OpBitwiseXor %ulong %635 %636
+OpStore %261 %637
+%638 = OpLoad %ulong %261
+%639 = OpIMul %ulong %638 %ulong_1099511628211
+OpStore %262 %639
+%640 = OpLoad %ulong %265
+%641 = OpIAdd %ulong %640 %ulong_1
+OpStore %263 %641
+%642 = OpLoad %ulong %262
+OpStore %264 %642
+%643 = OpLoad %ulong %263
+OpStore %265 %643
+OpBranch %139
+%65 = OpLabel
+%644 = OpLoad %ulong %255
+%645 = OpIMul %ulong %644 %ulong_8
+OpStore %248 %645
+%646 = OpLoad %ulong %246
+%647 = OpLoad %ulong %248
+%648 = OpShiftRightLogical %ulong %646 %647
+OpStore %249 %648
+%649 = OpLoad %ulong %249
+%650 = OpBitwiseAnd %ulong %649 %ulong_255
+OpStore %250 %650
+%651 = OpLoad %ulong %254
+%652 = OpLoad %ulong %250
+%653 = OpBitwiseXor %ulong %651 %652
+OpStore %251 %653
+%654 = OpLoad %ulong %251
+%655 = OpIMul %ulong %654 %ulong_1099511628211
+OpStore %252 %655
+%656 = OpLoad %ulong %255
+%657 = OpIAdd %ulong %656 %ulong_1
+OpStore %253 %657
+%658 = OpLoad %ulong %252
+OpStore %254 %658
+%659 = OpLoad %ulong %253
+OpStore %255 %659
+OpBranch %140
+%58 = OpLabel
+%660 = OpLoad %ulong %244
+%661 = OpIMul %ulong %660 %ulong_8
+OpStore %237 %661
+%662 = OpLoad %ulong %235
+%663 = OpLoad %ulong %237
+%664 = OpShiftRightLogical %ulong %662 %663
+OpStore %238 %664
+%665 = OpLoad %ulong %238
+%666 = OpBitwiseAnd %ulong %665 %ulong_255
+OpStore %239 %666
+%667 = OpLoad %ulong %243
+%668 = OpLoad %ulong %239
+%669 = OpBitwiseXor %ulong %667 %668
+OpStore %240 %669
+%670 = OpLoad %ulong %240
+%671 = OpIMul %ulong %670 %ulong_1099511628211
+OpStore %241 %671
+%672 = OpLoad %ulong %244
+%673 = OpIAdd %ulong %672 %ulong_1
+OpStore %242 %673
+%674 = OpLoad %ulong %241
+OpStore %243 %674
+%675 = OpLoad %ulong %242
+OpStore %244 %675
+OpBranch %141
+%51 = OpLabel
+%676 = OpLoad %ulong %234
+%677 = OpIMul %ulong %676 %ulong_8
+OpStore %227 %677
+%678 = OpLoad %ulong %225
+%679 = OpLoad %ulong %227
+%680 = OpShiftRightLogical %ulong %678 %679
+OpStore %228 %680
+%681 = OpLoad %ulong %228
+%682 = OpBitwiseAnd %ulong %681 %ulong_255
+OpStore %229 %682
+%683 = OpLoad %ulong %233
+%684 = OpLoad %ulong %229
+%685 = OpBitwiseXor %ulong %683 %684
+OpStore %230 %685
+%686 = OpLoad %ulong %230
+%687 = OpIMul %ulong %686 %ulong_1099511628211
+OpStore %231 %687
+%688 = OpLoad %ulong %234
+%689 = OpIAdd %ulong %688 %ulong_1
+OpStore %232 %689
+%690 = OpLoad %ulong %231
+OpStore %233 %690
+%691 = OpLoad %ulong %232
+OpStore %234 %691
+OpBranch %142
+%44 = OpLabel
+%692 = OpLoad %ulong %223
+%693 = OpIMul %ulong %692 %ulong_8
+OpStore %216 %693
+%694 = OpLoad %ulong %214
+%695 = OpLoad %ulong %216
+%696 = OpShiftRightLogical %ulong %694 %695
+OpStore %217 %696
+%697 = OpLoad %ulong %217
+%698 = OpBitwiseAnd %ulong %697 %ulong_255
+OpStore %218 %698
+%699 = OpLoad %ulong %222
+%700 = OpLoad %ulong %218
+%701 = OpBitwiseXor %ulong %699 %700
+OpStore %219 %701
+%702 = OpLoad %ulong %219
+%703 = OpIMul %ulong %702 %ulong_1099511628211
+OpStore %220 %703
+%704 = OpLoad %ulong %223
+%705 = OpIAdd %ulong %704 %ulong_1
+OpStore %221 %705
+%706 = OpLoad %ulong %220
+OpStore %222 %706
+%707 = OpLoad %ulong %221
+OpStore %223 %707
+OpBranch %143
+%37 = OpLabel
+%708 = OpLoad %ulong %213
+%709 = OpIMul %ulong %708 %ulong_8
+OpStore %206 %709
+%710 = OpLoad %ulong %204
+%711 = OpLoad %ulong %206
+%712 = OpShiftRightLogical %ulong %710 %711
+OpStore %207 %712
+%713 = OpLoad %ulong %207
+%714 = OpBitwiseAnd %ulong %713 %ulong_255
+OpStore %208 %714
+%715 = OpLoad %ulong %212
+%716 = OpLoad %ulong %208
+%717 = OpBitwiseXor %ulong %715 %716
+OpStore %209 %717
+%718 = OpLoad %ulong %209
+%719 = OpIMul %ulong %718 %ulong_1099511628211
+OpStore %210 %719
+%720 = OpLoad %ulong %213
+%721 = OpIAdd %ulong %720 %ulong_1
+OpStore %211 %721
+%722 = OpLoad %ulong %210
+OpStore %212 %722
+%723 = OpLoad %ulong %211
+OpStore %213 %723
+OpBranch %144
+%30 = OpLabel
+%724 = OpLoad %ulong %202
+%725 = OpIMul %ulong %724 %ulong_8
+OpStore %195 %725
+%726 = OpLoad %ulong %193
+%727 = OpLoad %ulong %195
+%728 = OpShiftRightLogical %ulong %726 %727
+OpStore %196 %728
+%729 = OpLoad %ulong %196
+%730 = OpBitwiseAnd %ulong %729 %ulong_255
+OpStore %197 %730
+%731 = OpLoad %ulong %201
+%732 = OpLoad %ulong %197
+%733 = OpBitwiseXor %ulong %731 %732
+OpStore %198 %733
+%734 = OpLoad %ulong %198
+%735 = OpIMul %ulong %734 %ulong_1099511628211
+OpStore %199 %735
+%736 = OpLoad %ulong %202
+%737 = OpIAdd %ulong %736 %ulong_1
+OpStore %200 %737
+%738 = OpLoad %ulong %199
+OpStore %201 %738
+%739 = OpLoad %ulong %200
+OpStore %202 %739
+OpBranch %145
+%23 = OpLabel
+%740 = OpLoad %ulong %192
+%741 = OpIMul %ulong %740 %ulong_8
+OpStore %185 %741
+%742 = OpLoad %ulong %182
+%743 = OpLoad %ulong %185
+%744 = OpShiftRightLogical %ulong %742 %743
+OpStore %186 %744
+%745 = OpLoad %ulong %186
+%746 = OpBitwiseAnd %ulong %745 %ulong_255
+OpStore %187 %746
+%747 = OpLoad %ulong %191
+%748 = OpLoad %ulong %187
+%749 = OpBitwiseXor %ulong %747 %748
+OpStore %188 %749
+%750 = OpLoad %ulong %188
+%751 = OpIMul %ulong %750 %ulong_1099511628211
+OpStore %189 %751
+%752 = OpLoad %ulong %192
+%753 = OpIAdd %ulong %752 %ulong_1
+OpStore %190 %753
+%754 = OpLoad %ulong %189
+OpStore %191 %754
+%755 = OpLoad %ulong %190
+OpStore %192 %755
+OpBranch %146
+%131 = OpLabel
+OpBranch %127
+%132 = OpLabel
+OpBranch %120
+%133 = OpLabel
+OpBranch %113
+%134 = OpLabel
+OpBranch %106
+%135 = OpLabel
+OpBranch %99
+%136 = OpLabel
+OpBranch %92
+%137 = OpLabel
+OpBranch %85
+%138 = OpLabel
+OpBranch %78
+%139 = OpLabel
+OpBranch %71
+%140 = OpLabel
+OpBranch %64
+%141 = OpLabel
+OpBranch %57
+%142 = OpLabel
+OpBranch %50
+%143 = OpLabel
+OpBranch %43
+%144 = OpLabel
+OpBranch %36
+%145 = OpLabel
+OpBranch %29
+%146 = OpLabel
+OpBranch %22
 OpFunctionEnd
-%5 = OpFunction %ulong None %389
-%390 = OpFunctionParameter %ulong
-%391 = OpFunctionParameter %double
-%392 = OpLabel
-%399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_double Function
-%401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_bool Function
-%403 = OpVariable %_ptr_Function_ulong Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_ulong Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_ulong Function
-OpStore %399 %390
-OpStore %400 %391
-%411 = OpLoad %double %400
-%412 = OpBitcast %ulong %411
-OpStore %401 %412
-OpBranch %393
-%393 = OpLabel
-%413 = OpLoad %ulong %399
-OpStore %409 %413
-OpStore %410 %ulong_0
-OpBranch %394
-%394 = OpLabel
-%414 = OpLoad %ulong %410
-%415 = OpULessThan %bool %414 %ulong_8
-OpStore %402 %415
-%416 = OpLoad %bool %402
-OpLoopMerge %396 %398 None
-OpBranchConditional %416 %395 %396
-%396 = OpLabel
-OpBranch %397
-%397 = OpLabel
-%417 = OpLoad %ulong %409
-OpReturnValue %417
-%395 = OpLabel
-%418 = OpLoad %ulong %410
-%419 = OpIMul %ulong %418 %ulong_8
-OpStore %403 %419
-%420 = OpLoad %ulong %401
-%421 = OpLoad %ulong %403
-%422 = OpShiftRightLogical %ulong %420 %421
-OpStore %404 %422
-%423 = OpLoad %ulong %404
-%424 = OpBitwiseAnd %ulong %423 %ulong_255
-OpStore %405 %424
-%425 = OpLoad %ulong %409
-%426 = OpLoad %ulong %405
-%427 = OpBitwiseXor %ulong %425 %426
-OpStore %406 %427
-%428 = OpLoad %ulong %406
-%429 = OpIMul %ulong %428 %ulong_1099511628211
-OpStore %407 %429
-%430 = OpLoad %ulong %410
-%431 = OpIAdd %ulong %430 %ulong_1
-OpStore %408 %431
-%432 = OpLoad %ulong %407
-OpStore %409 %432
-%433 = OpLoad %ulong %408
-OpStore %410 %433
-OpBranch %398
-%398 = OpLabel
-OpBranch %394
+%2 = OpFunction %ulong None %756
+%757 = OpFunctionParameter %ulong
+%758 = OpLabel
+%899 = OpVariable %_ptr_Function_ulong Function
+%900 = OpVariable %_ptr_Function_uchar Function
+%901 = OpVariable %_ptr_Function_uchar Function
+%902 = OpVariable %_ptr_Function_ushort Function
+%903 = OpVariable %_ptr_Function_ushort Function
+%904 = OpVariable %_ptr_Function_uint Function
+%905 = OpVariable %_ptr_Function_uint Function
+%906 = OpVariable %_ptr_Function_ulong Function
+%907 = OpVariable %_ptr_Function_ulong Function
+%908 = OpVariable %_ptr_Function_ulong Function
+%909 = OpVariable %_ptr_Function_float Function
+%910 = OpVariable %_ptr_Function_double Function
+%911 = OpVariable %_ptr_Function_float Function
+%912 = OpVariable %_ptr_Function_double Function
+%913 = OpVariable %_ptr_Function_float Function
+%914 = OpVariable %_ptr_Function_double Function
+%915 = OpVariable %_ptr_Function_float Function
+%916 = OpVariable %_ptr_Function_double Function
+%917 = OpVariable %_ptr_Function_float Function
+%918 = OpVariable %_ptr_Function_double Function
+%919 = OpVariable %_ptr_Function_float Function
+%920 = OpVariable %_ptr_Function_double Function
+%921 = OpVariable %_ptr_Function_float Function
+%922 = OpVariable %_ptr_Function_double Function
+%923 = OpVariable %_ptr_Function_float Function
+%924 = OpVariable %_ptr_Function_double Function
+%925 = OpVariable %_ptr_Function_float Function
+%926 = OpVariable %_ptr_Function_double Function
+%927 = OpVariable %_ptr_Function_float Function
+%928 = OpVariable %_ptr_Function_double Function
+%929 = OpVariable %_ptr_Function_uint Function
+%930 = OpVariable %_ptr_Function_ulong Function
+%931 = OpVariable %_ptr_Function_bool Function
+%932 = OpVariable %_ptr_Function_ulong Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_ulong Function
+%935 = OpVariable %_ptr_Function_ulong Function
+%936 = OpVariable %_ptr_Function_ulong Function
+%937 = OpVariable %_ptr_Function_ulong Function
+%938 = OpVariable %_ptr_Function_ulong Function
+%939 = OpVariable %_ptr_Function_ulong Function
+%940 = OpVariable %_ptr_Function_ulong Function
+%941 = OpVariable %_ptr_Function_bool Function
+%942 = OpVariable %_ptr_Function_ulong Function
+%943 = OpVariable %_ptr_Function_ulong Function
+%944 = OpVariable %_ptr_Function_ulong Function
+%945 = OpVariable %_ptr_Function_ulong Function
+%946 = OpVariable %_ptr_Function_ulong Function
+%947 = OpVariable %_ptr_Function_ulong Function
+%948 = OpVariable %_ptr_Function_ulong Function
+%949 = OpVariable %_ptr_Function_ulong Function
+%950 = OpVariable %_ptr_Function_uint Function
+%951 = OpVariable %_ptr_Function_ulong Function
+%952 = OpVariable %_ptr_Function_bool Function
+%953 = OpVariable %_ptr_Function_ulong Function
+%954 = OpVariable %_ptr_Function_ulong Function
+%955 = OpVariable %_ptr_Function_ulong Function
+%956 = OpVariable %_ptr_Function_ulong Function
+%957 = OpVariable %_ptr_Function_ulong Function
+%958 = OpVariable %_ptr_Function_ulong Function
+%959 = OpVariable %_ptr_Function_ulong Function
+%960 = OpVariable %_ptr_Function_ulong Function
+%961 = OpVariable %_ptr_Function_ulong Function
+%962 = OpVariable %_ptr_Function_bool Function
+%963 = OpVariable %_ptr_Function_ulong Function
+%964 = OpVariable %_ptr_Function_ulong Function
+%965 = OpVariable %_ptr_Function_ulong Function
+%966 = OpVariable %_ptr_Function_ulong Function
+%967 = OpVariable %_ptr_Function_ulong Function
+%968 = OpVariable %_ptr_Function_ulong Function
+%969 = OpVariable %_ptr_Function_ulong Function
+%970 = OpVariable %_ptr_Function_ulong Function
+%971 = OpVariable %_ptr_Function_uint Function
+%972 = OpVariable %_ptr_Function_ulong Function
+%973 = OpVariable %_ptr_Function_bool Function
+%974 = OpVariable %_ptr_Function_ulong Function
+%975 = OpVariable %_ptr_Function_ulong Function
+%976 = OpVariable %_ptr_Function_ulong Function
+%977 = OpVariable %_ptr_Function_ulong Function
+%978 = OpVariable %_ptr_Function_ulong Function
+%979 = OpVariable %_ptr_Function_ulong Function
+%980 = OpVariable %_ptr_Function_ulong Function
+%981 = OpVariable %_ptr_Function_ulong Function
+%982 = OpVariable %_ptr_Function_ulong Function
+%983 = OpVariable %_ptr_Function_bool Function
+%984 = OpVariable %_ptr_Function_ulong Function
+%985 = OpVariable %_ptr_Function_ulong Function
+%986 = OpVariable %_ptr_Function_ulong Function
+%987 = OpVariable %_ptr_Function_ulong Function
+%988 = OpVariable %_ptr_Function_ulong Function
+%989 = OpVariable %_ptr_Function_ulong Function
+%990 = OpVariable %_ptr_Function_ulong Function
+%991 = OpVariable %_ptr_Function_ulong Function
+%992 = OpVariable %_ptr_Function_uint Function
+%993 = OpVariable %_ptr_Function_ulong Function
+%994 = OpVariable %_ptr_Function_bool Function
+%995 = OpVariable %_ptr_Function_ulong Function
+%996 = OpVariable %_ptr_Function_ulong Function
+%997 = OpVariable %_ptr_Function_ulong Function
+%998 = OpVariable %_ptr_Function_ulong Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_ulong Function
+%1001 = OpVariable %_ptr_Function_ulong Function
+%1002 = OpVariable %_ptr_Function_ulong Function
+%1003 = OpVariable %_ptr_Function_ulong Function
+%1004 = OpVariable %_ptr_Function_bool Function
+%1005 = OpVariable %_ptr_Function_ulong Function
+%1006 = OpVariable %_ptr_Function_ulong Function
+%1007 = OpVariable %_ptr_Function_ulong Function
+%1008 = OpVariable %_ptr_Function_ulong Function
+%1009 = OpVariable %_ptr_Function_ulong Function
+%1010 = OpVariable %_ptr_Function_ulong Function
+%1011 = OpVariable %_ptr_Function_ulong Function
+%1012 = OpVariable %_ptr_Function_ulong Function
+%1013 = OpVariable %_ptr_Function_uint Function
+%1014 = OpVariable %_ptr_Function_ulong Function
+%1015 = OpVariable %_ptr_Function_bool Function
+%1016 = OpVariable %_ptr_Function_ulong Function
+%1017 = OpVariable %_ptr_Function_ulong Function
+%1018 = OpVariable %_ptr_Function_ulong Function
+%1019 = OpVariable %_ptr_Function_ulong Function
+%1020 = OpVariable %_ptr_Function_ulong Function
+%1021 = OpVariable %_ptr_Function_ulong Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_ulong Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_bool Function
+%1026 = OpVariable %_ptr_Function_ulong Function
+%1027 = OpVariable %_ptr_Function_ulong Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_ulong Function
+%1030 = OpVariable %_ptr_Function_ulong Function
+%1031 = OpVariable %_ptr_Function_ulong Function
+%1032 = OpVariable %_ptr_Function_ulong Function
+%1033 = OpVariable %_ptr_Function_ulong Function
+%1034 = OpVariable %_ptr_Function_uint Function
+%1035 = OpVariable %_ptr_Function_ulong Function
+%1036 = OpVariable %_ptr_Function_bool Function
+%1037 = OpVariable %_ptr_Function_ulong Function
+%1038 = OpVariable %_ptr_Function_ulong Function
+%1039 = OpVariable %_ptr_Function_ulong Function
+%1040 = OpVariable %_ptr_Function_ulong Function
+%1041 = OpVariable %_ptr_Function_ulong Function
+%1042 = OpVariable %_ptr_Function_ulong Function
+%1043 = OpVariable %_ptr_Function_ulong Function
+%1044 = OpVariable %_ptr_Function_ulong Function
+%1045 = OpVariable %_ptr_Function_ulong Function
+%1046 = OpVariable %_ptr_Function_bool Function
+%1047 = OpVariable %_ptr_Function_ulong Function
+%1048 = OpVariable %_ptr_Function_ulong Function
+%1049 = OpVariable %_ptr_Function_ulong Function
+%1050 = OpVariable %_ptr_Function_ulong Function
+%1051 = OpVariable %_ptr_Function_ulong Function
+%1052 = OpVariable %_ptr_Function_ulong Function
+%1053 = OpVariable %_ptr_Function_ulong Function
+%1054 = OpVariable %_ptr_Function_ulong Function
+%1055 = OpVariable %_ptr_Function_uint Function
+%1056 = OpVariable %_ptr_Function_ulong Function
+%1057 = OpVariable %_ptr_Function_bool Function
+%1058 = OpVariable %_ptr_Function_ulong Function
+%1059 = OpVariable %_ptr_Function_ulong Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_ulong Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_ulong Function
+%1064 = OpVariable %_ptr_Function_ulong Function
+%1065 = OpVariable %_ptr_Function_ulong Function
+%1066 = OpVariable %_ptr_Function_ulong Function
+%1067 = OpVariable %_ptr_Function_bool Function
+%1068 = OpVariable %_ptr_Function_ulong Function
+%1069 = OpVariable %_ptr_Function_ulong Function
+%1070 = OpVariable %_ptr_Function_ulong Function
+%1071 = OpVariable %_ptr_Function_ulong Function
+%1072 = OpVariable %_ptr_Function_ulong Function
+%1073 = OpVariable %_ptr_Function_ulong Function
+%1074 = OpVariable %_ptr_Function_ulong Function
+%1075 = OpVariable %_ptr_Function_ulong Function
+%1076 = OpVariable %_ptr_Function_uint Function
+%1077 = OpVariable %_ptr_Function_ulong Function
+%1078 = OpVariable %_ptr_Function_bool Function
+%1079 = OpVariable %_ptr_Function_ulong Function
+%1080 = OpVariable %_ptr_Function_ulong Function
+%1081 = OpVariable %_ptr_Function_ulong Function
+%1082 = OpVariable %_ptr_Function_ulong Function
+%1083 = OpVariable %_ptr_Function_ulong Function
+%1084 = OpVariable %_ptr_Function_ulong Function
+%1085 = OpVariable %_ptr_Function_ulong Function
+%1086 = OpVariable %_ptr_Function_ulong Function
+%1087 = OpVariable %_ptr_Function_ulong Function
+%1088 = OpVariable %_ptr_Function_bool Function
+%1089 = OpVariable %_ptr_Function_ulong Function
+%1090 = OpVariable %_ptr_Function_ulong Function
+%1091 = OpVariable %_ptr_Function_ulong Function
+%1092 = OpVariable %_ptr_Function_ulong Function
+%1093 = OpVariable %_ptr_Function_ulong Function
+%1094 = OpVariable %_ptr_Function_ulong Function
+%1095 = OpVariable %_ptr_Function_ulong Function
+%1096 = OpVariable %_ptr_Function_ulong Function
+%1097 = OpVariable %_ptr_Function_uint Function
+%1098 = OpVariable %_ptr_Function_ulong Function
+%1099 = OpVariable %_ptr_Function_ulong Function
+%1100 = OpVariable %_ptr_Function_ulong Function
+%1101 = OpVariable %_ptr_Function_ulong Function
+%1102 = OpVariable %_ptr_Function_uint Function
+%1103 = OpVariable %_ptr_Function_ulong Function
+%1104 = OpVariable %_ptr_Function_ulong Function
+%1105 = OpVariable %_ptr_Function_ulong Function
+%1106 = OpVariable %_ptr_Function_ulong Function
+OpStore %899 %757
+OpBranch %759
+%759 = OpLabel
+OpBranch %760
+%760 = OpLabel
+%1107 = OpLoad %ulong %899
+%1108 = OpUConvert %uchar %1107
+OpStore %900 %1108
+%1109 = OpLoad %uchar %900
+%1111 = OpBitwiseOr %uchar %1109 %uchar_128
+OpStore %901 %1111
+%1112 = OpLoad %ulong %899
+%1113 = OpUConvert %ushort %1112
+OpStore %902 %1113
+%1114 = OpLoad %ushort %902
+%1116 = OpBitwiseOr %ushort %1114 %ushort_32768
+OpStore %903 %1116
+%1117 = OpLoad %ulong %899
+%1118 = OpUConvert %uint %1117
+OpStore %904 %1118
+%1119 = OpLoad %uint %904
+%1121 = OpBitwiseOr %uint %1119 %uint_2147483648
+OpStore %905 %1121
+%1122 = OpLoad %ulong %899
+%1124 = OpBitwiseOr %ulong %1122 %ulong_9223372036854775808
+OpStore %906 %1124
+OpBranch %761
+%761 = OpLabel
+%1125 = OpLoad %uchar %901
+%1126 = OpConvertUToF %float %1125
+OpStore %913 %1126
+OpBranch %762
+%762 = OpLabel
+%1127 = OpLoad %float %913
+%1128 = OpBitcast %uint %1127
+OpStore %929 %1128
+%1129 = OpLoad %uint %929
+%1130 = OpUConvert %ulong %1129
+OpStore %930 %1130
+OpBranch %764
+%764 = OpLabel
+OpStore %938 %ulong_14695981039346656037
+OpStore %939 %ulong_0
+OpBranch %765
+%765 = OpLabel
+%1132 = OpLoad %ulong %939
+%1133 = OpULessThan %bool %1132 %ulong_8
+OpStore %931 %1133
+%1134 = OpLoad %bool %931
+OpLoopMerge %767 %898 None
+OpBranchConditional %1134 %766 %767
+%767 = OpLabel
+OpBranch %768
+%768 = OpLabel
+OpBranch %763
+%763 = OpLabel
+%1135 = OpLoad %uchar %901
+%1136 = OpConvertUToF %double %1135
+OpStore %914 %1136
+OpBranch %769
+%769 = OpLabel
+%1137 = OpLoad %double %914
+%1138 = OpBitcast %ulong %1137
+OpStore %940 %1138
+OpBranch %771
+%771 = OpLabel
+%1139 = OpLoad %ulong %938
+OpStore %948 %1139
+OpStore %949 %ulong_0
+OpBranch %772
+%772 = OpLabel
+%1140 = OpLoad %ulong %949
+%1141 = OpULessThan %bool %1140 %ulong_8
+OpStore %941 %1141
+%1142 = OpLoad %bool %941
+OpLoopMerge %774 %897 None
+OpBranchConditional %1142 %773 %774
+%774 = OpLabel
+OpBranch %775
+%775 = OpLabel
+OpBranch %770
+%770 = OpLabel
+%1143 = OpLoad %ushort %903
+%1144 = OpConvertUToF %float %1143
+OpStore %915 %1144
+OpBranch %776
+%776 = OpLabel
+%1145 = OpLoad %float %915
+%1146 = OpBitcast %uint %1145
+OpStore %950 %1146
+%1147 = OpLoad %uint %950
+%1148 = OpUConvert %ulong %1147
+OpStore %951 %1148
+OpBranch %778
+%778 = OpLabel
+%1149 = OpLoad %ulong %948
+OpStore %959 %1149
+OpStore %960 %ulong_0
+OpBranch %779
+%779 = OpLabel
+%1150 = OpLoad %ulong %960
+%1151 = OpULessThan %bool %1150 %ulong_8
+OpStore %952 %1151
+%1152 = OpLoad %bool %952
+OpLoopMerge %781 %896 None
+OpBranchConditional %1152 %780 %781
+%781 = OpLabel
+OpBranch %782
+%782 = OpLabel
+OpBranch %777
+%777 = OpLabel
+%1153 = OpLoad %ushort %903
+%1154 = OpConvertUToF %double %1153
+OpStore %916 %1154
+OpBranch %783
+%783 = OpLabel
+%1155 = OpLoad %double %916
+%1156 = OpBitcast %ulong %1155
+OpStore %961 %1156
+OpBranch %785
+%785 = OpLabel
+%1157 = OpLoad %ulong %959
+OpStore %969 %1157
+OpStore %970 %ulong_0
+OpBranch %786
+%786 = OpLabel
+%1158 = OpLoad %ulong %970
+%1159 = OpULessThan %bool %1158 %ulong_8
+OpStore %962 %1159
+%1160 = OpLoad %bool %962
+OpLoopMerge %788 %895 None
+OpBranchConditional %1160 %787 %788
+%788 = OpLabel
+OpBranch %789
+%789 = OpLabel
+OpBranch %784
+%784 = OpLabel
+%1161 = OpLoad %uint %905
+%1162 = OpConvertUToF %float %1161
+OpStore %917 %1162
+OpBranch %790
+%790 = OpLabel
+%1163 = OpLoad %float %917
+%1164 = OpBitcast %uint %1163
+OpStore %971 %1164
+%1165 = OpLoad %uint %971
+%1166 = OpUConvert %ulong %1165
+OpStore %972 %1166
+OpBranch %792
+%792 = OpLabel
+%1167 = OpLoad %ulong %969
+OpStore %980 %1167
+OpStore %981 %ulong_0
+OpBranch %793
+%793 = OpLabel
+%1168 = OpLoad %ulong %981
+%1169 = OpULessThan %bool %1168 %ulong_8
+OpStore %973 %1169
+%1170 = OpLoad %bool %973
+OpLoopMerge %795 %894 None
+OpBranchConditional %1170 %794 %795
+%795 = OpLabel
+OpBranch %796
+%796 = OpLabel
+OpBranch %791
+%791 = OpLabel
+%1171 = OpLoad %uint %905
+%1172 = OpConvertUToF %double %1171
+OpStore %918 %1172
+OpBranch %797
+%797 = OpLabel
+%1173 = OpLoad %double %918
+%1174 = OpBitcast %ulong %1173
+OpStore %982 %1174
+OpBranch %799
+%799 = OpLabel
+%1175 = OpLoad %ulong %980
+OpStore %990 %1175
+OpStore %991 %ulong_0
+OpBranch %800
+%800 = OpLabel
+%1176 = OpLoad %ulong %991
+%1177 = OpULessThan %bool %1176 %ulong_8
+OpStore %983 %1177
+%1178 = OpLoad %bool %983
+OpLoopMerge %802 %893 None
+OpBranchConditional %1178 %801 %802
+%802 = OpLabel
+OpBranch %803
+%803 = OpLabel
+OpBranch %798
+%798 = OpLabel
+%1179 = OpLoad %ulong %906
+%1180 = OpConvertUToF %float %1179
+OpStore %919 %1180
+OpBranch %804
+%804 = OpLabel
+%1181 = OpLoad %float %919
+%1182 = OpBitcast %uint %1181
+OpStore %992 %1182
+%1183 = OpLoad %uint %992
+%1184 = OpUConvert %ulong %1183
+OpStore %993 %1184
+OpBranch %806
+%806 = OpLabel
+%1185 = OpLoad %ulong %990
+OpStore %1001 %1185
+OpStore %1002 %ulong_0
+OpBranch %807
+%807 = OpLabel
+%1186 = OpLoad %ulong %1002
+%1187 = OpULessThan %bool %1186 %ulong_8
+OpStore %994 %1187
+%1188 = OpLoad %bool %994
+OpLoopMerge %809 %892 None
+OpBranchConditional %1188 %808 %809
+%809 = OpLabel
+OpBranch %810
+%810 = OpLabel
+OpBranch %805
+%805 = OpLabel
+%1189 = OpLoad %ulong %906
+%1190 = OpConvertUToF %double %1189
+OpStore %920 %1190
+OpBranch %811
+%811 = OpLabel
+%1191 = OpLoad %double %920
+%1192 = OpBitcast %ulong %1191
+OpStore %1003 %1192
+OpBranch %813
+%813 = OpLabel
+%1193 = OpLoad %ulong %1001
+OpStore %1011 %1193
+OpStore %1012 %ulong_0
+OpBranch %814
+%814 = OpLabel
+%1194 = OpLoad %ulong %1012
+%1195 = OpULessThan %bool %1194 %ulong_8
+OpStore %1004 %1195
+%1196 = OpLoad %bool %1004
+OpLoopMerge %816 %891 None
+OpBranchConditional %1196 %815 %816
+%816 = OpLabel
+OpBranch %817
+%817 = OpLabel
+OpBranch %812
+%812 = OpLabel
+%1197 = OpLoad %uchar %901
+%1198 = OpConvertSToF %float %1197
+OpStore %921 %1198
+OpBranch %818
+%818 = OpLabel
+%1199 = OpLoad %float %921
+%1200 = OpBitcast %uint %1199
+OpStore %1013 %1200
+%1201 = OpLoad %uint %1013
+%1202 = OpUConvert %ulong %1201
+OpStore %1014 %1202
+OpBranch %820
+%820 = OpLabel
+%1203 = OpLoad %ulong %1011
+OpStore %1022 %1203
+OpStore %1023 %ulong_0
+OpBranch %821
+%821 = OpLabel
+%1204 = OpLoad %ulong %1023
+%1205 = OpULessThan %bool %1204 %ulong_8
+OpStore %1015 %1205
+%1206 = OpLoad %bool %1015
+OpLoopMerge %823 %890 None
+OpBranchConditional %1206 %822 %823
+%823 = OpLabel
+OpBranch %824
+%824 = OpLabel
+OpBranch %819
+%819 = OpLabel
+%1207 = OpLoad %uchar %901
+%1208 = OpConvertSToF %double %1207
+OpStore %922 %1208
+OpBranch %825
+%825 = OpLabel
+%1209 = OpLoad %double %922
+%1210 = OpBitcast %ulong %1209
+OpStore %1024 %1210
+OpBranch %827
+%827 = OpLabel
+%1211 = OpLoad %ulong %1022
+OpStore %1032 %1211
+OpStore %1033 %ulong_0
+OpBranch %828
+%828 = OpLabel
+%1212 = OpLoad %ulong %1033
+%1213 = OpULessThan %bool %1212 %ulong_8
+OpStore %1025 %1213
+%1214 = OpLoad %bool %1025
+OpLoopMerge %830 %889 None
+OpBranchConditional %1214 %829 %830
+%830 = OpLabel
+OpBranch %831
+%831 = OpLabel
+OpBranch %826
+%826 = OpLabel
+%1215 = OpLoad %ushort %903
+%1216 = OpConvertSToF %float %1215
+OpStore %923 %1216
+OpBranch %832
+%832 = OpLabel
+%1217 = OpLoad %float %923
+%1218 = OpBitcast %uint %1217
+OpStore %1034 %1218
+%1219 = OpLoad %uint %1034
+%1220 = OpUConvert %ulong %1219
+OpStore %1035 %1220
+OpBranch %834
+%834 = OpLabel
+%1221 = OpLoad %ulong %1032
+OpStore %1043 %1221
+OpStore %1044 %ulong_0
+OpBranch %835
+%835 = OpLabel
+%1222 = OpLoad %ulong %1044
+%1223 = OpULessThan %bool %1222 %ulong_8
+OpStore %1036 %1223
+%1224 = OpLoad %bool %1036
+OpLoopMerge %837 %888 None
+OpBranchConditional %1224 %836 %837
+%837 = OpLabel
+OpBranch %838
+%838 = OpLabel
+OpBranch %833
+%833 = OpLabel
+%1225 = OpLoad %ushort %903
+%1226 = OpConvertSToF %double %1225
+OpStore %924 %1226
+OpBranch %839
+%839 = OpLabel
+%1227 = OpLoad %double %924
+%1228 = OpBitcast %ulong %1227
+OpStore %1045 %1228
+OpBranch %841
+%841 = OpLabel
+%1229 = OpLoad %ulong %1043
+OpStore %1053 %1229
+OpStore %1054 %ulong_0
+OpBranch %842
+%842 = OpLabel
+%1230 = OpLoad %ulong %1054
+%1231 = OpULessThan %bool %1230 %ulong_8
+OpStore %1046 %1231
+%1232 = OpLoad %bool %1046
+OpLoopMerge %844 %887 None
+OpBranchConditional %1232 %843 %844
+%844 = OpLabel
+OpBranch %845
+%845 = OpLabel
+OpBranch %840
+%840 = OpLabel
+%1233 = OpLoad %uint %905
+%1234 = OpConvertSToF %float %1233
+OpStore %925 %1234
+OpBranch %846
+%846 = OpLabel
+%1235 = OpLoad %float %925
+%1236 = OpBitcast %uint %1235
+OpStore %1055 %1236
+%1237 = OpLoad %uint %1055
+%1238 = OpUConvert %ulong %1237
+OpStore %1056 %1238
+OpBranch %848
+%848 = OpLabel
+%1239 = OpLoad %ulong %1053
+OpStore %1064 %1239
+OpStore %1065 %ulong_0
+OpBranch %849
+%849 = OpLabel
+%1240 = OpLoad %ulong %1065
+%1241 = OpULessThan %bool %1240 %ulong_8
+OpStore %1057 %1241
+%1242 = OpLoad %bool %1057
+OpLoopMerge %851 %886 None
+OpBranchConditional %1242 %850 %851
+%851 = OpLabel
+OpBranch %852
+%852 = OpLabel
+OpBranch %847
+%847 = OpLabel
+%1243 = OpLoad %uint %905
+%1244 = OpConvertSToF %double %1243
+OpStore %926 %1244
+OpBranch %853
+%853 = OpLabel
+%1245 = OpLoad %double %926
+%1246 = OpBitcast %ulong %1245
+OpStore %1066 %1246
+OpBranch %855
+%855 = OpLabel
+%1247 = OpLoad %ulong %1064
+OpStore %1074 %1247
+OpStore %1075 %ulong_0
+OpBranch %856
+%856 = OpLabel
+%1248 = OpLoad %ulong %1075
+%1249 = OpULessThan %bool %1248 %ulong_8
+OpStore %1067 %1249
+%1250 = OpLoad %bool %1067
+OpLoopMerge %858 %885 None
+OpBranchConditional %1250 %857 %858
+%858 = OpLabel
+OpBranch %859
+%859 = OpLabel
+OpBranch %854
+%854 = OpLabel
+%1251 = OpLoad %ulong %906
+%1252 = OpConvertSToF %float %1251
+OpStore %927 %1252
+OpBranch %860
+%860 = OpLabel
+%1253 = OpLoad %float %927
+%1254 = OpBitcast %uint %1253
+OpStore %1076 %1254
+%1255 = OpLoad %uint %1076
+%1256 = OpUConvert %ulong %1255
+OpStore %1077 %1256
+OpBranch %862
+%862 = OpLabel
+%1257 = OpLoad %ulong %1074
+OpStore %1085 %1257
+OpStore %1086 %ulong_0
+OpBranch %863
+%863 = OpLabel
+%1258 = OpLoad %ulong %1086
+%1259 = OpULessThan %bool %1258 %ulong_8
+OpStore %1078 %1259
+%1260 = OpLoad %bool %1078
+OpLoopMerge %865 %884 None
+OpBranchConditional %1260 %864 %865
+%865 = OpLabel
+OpBranch %866
+%866 = OpLabel
+OpBranch %861
+%861 = OpLabel
+%1261 = OpLoad %ulong %906
+%1262 = OpConvertSToF %double %1261
+OpStore %928 %1262
+OpBranch %867
+%867 = OpLabel
+%1263 = OpLoad %double %928
+%1264 = OpBitcast %ulong %1263
+OpStore %1087 %1264
+OpBranch %869
+%869 = OpLabel
+%1265 = OpLoad %ulong %1085
+OpStore %1095 %1265
+OpStore %1096 %ulong_0
+OpBranch %870
+%870 = OpLabel
+%1266 = OpLoad %ulong %1096
+%1267 = OpULessThan %bool %1266 %ulong_8
+OpStore %1088 %1267
+%1268 = OpLoad %bool %1088
+OpLoopMerge %872 %883 None
+OpBranchConditional %1268 %871 %872
+%872 = OpLabel
+OpBranch %873
+%873 = OpLabel
+OpBranch %868
+%868 = OpLabel
+OpBranch %874
+%874 = OpLabel
+%1269 = OpLoad %ulong %899
+%1270 = OpBitwiseOr %ulong %1269 %ulong_1
+OpStore %907 %1270
+%1271 = OpLoad %ulong %907
+%1272 = OpISub %ulong %ulong_0 %1271
+OpStore %908 %1272
+%1273 = OpLoad %ulong %907
+%1274 = OpConvertUToF %float %1273
+OpStore %909 %1274
+OpBranch %875
+%875 = OpLabel
+%1275 = OpLoad %float %909
+%1276 = OpBitcast %uint %1275
+OpStore %1097 %1276
+%1277 = OpLoad %uint %1097
+%1278 = OpUConvert %ulong %1277
+OpStore %1098 %1278
+%1279 = OpLoad %ulong %1095
+%1280 = OpLoad %ulong %1098
+%1281 = OpFunctionCall %ulong %3 %1279 %1280
+OpStore %1099 %1281
+OpBranch %876
+%876 = OpLabel
+%1282 = OpLoad %ulong %907
+%1283 = OpConvertUToF %double %1282
+OpStore %910 %1283
+OpBranch %877
+%877 = OpLabel
+%1284 = OpLoad %double %910
+%1285 = OpBitcast %ulong %1284
+OpStore %1100 %1285
+%1286 = OpLoad %ulong %1099
+%1287 = OpLoad %ulong %1100
+%1288 = OpFunctionCall %ulong %3 %1286 %1287
+OpStore %1101 %1288
+OpBranch %878
+%878 = OpLabel
+%1289 = OpLoad %ulong %908
+%1290 = OpConvertSToF %float %1289
+OpStore %911 %1290
+OpBranch %879
+%879 = OpLabel
+%1291 = OpLoad %float %911
+%1292 = OpBitcast %uint %1291
+OpStore %1102 %1292
+%1293 = OpLoad %uint %1102
+%1294 = OpUConvert %ulong %1293
+OpStore %1103 %1294
+%1295 = OpLoad %ulong %1101
+%1296 = OpLoad %ulong %1103
+%1297 = OpFunctionCall %ulong %3 %1295 %1296
+OpStore %1104 %1297
+OpBranch %880
+%880 = OpLabel
+%1298 = OpLoad %ulong %908
+%1299 = OpConvertSToF %double %1298
+OpStore %912 %1299
+OpBranch %881
+%881 = OpLabel
+%1300 = OpLoad %double %912
+%1301 = OpBitcast %ulong %1300
+OpStore %1105 %1301
+%1302 = OpLoad %ulong %1104
+%1303 = OpLoad %ulong %1105
+%1304 = OpFunctionCall %ulong %3 %1302 %1303
+OpStore %1106 %1304
+OpBranch %882
+%882 = OpLabel
+%1305 = OpLoad %ulong %1106
+OpReturnValue %1305
+%871 = OpLabel
+%1306 = OpLoad %ulong %1096
+%1307 = OpIMul %ulong %1306 %ulong_8
+OpStore %1089 %1307
+%1308 = OpLoad %ulong %1087
+%1309 = OpLoad %ulong %1089
+%1310 = OpShiftRightLogical %ulong %1308 %1309
+OpStore %1090 %1310
+%1311 = OpLoad %ulong %1090
+%1312 = OpBitwiseAnd %ulong %1311 %ulong_255
+OpStore %1091 %1312
+%1313 = OpLoad %ulong %1095
+%1314 = OpLoad %ulong %1091
+%1315 = OpBitwiseXor %ulong %1313 %1314
+OpStore %1092 %1315
+%1316 = OpLoad %ulong %1092
+%1317 = OpIMul %ulong %1316 %ulong_1099511628211
+OpStore %1093 %1317
+%1318 = OpLoad %ulong %1096
+%1319 = OpIAdd %ulong %1318 %ulong_1
+OpStore %1094 %1319
+%1320 = OpLoad %ulong %1093
+OpStore %1095 %1320
+%1321 = OpLoad %ulong %1094
+OpStore %1096 %1321
+OpBranch %883
+%864 = OpLabel
+%1322 = OpLoad %ulong %1086
+%1323 = OpIMul %ulong %1322 %ulong_8
+OpStore %1079 %1323
+%1324 = OpLoad %ulong %1077
+%1325 = OpLoad %ulong %1079
+%1326 = OpShiftRightLogical %ulong %1324 %1325
+OpStore %1080 %1326
+%1327 = OpLoad %ulong %1080
+%1328 = OpBitwiseAnd %ulong %1327 %ulong_255
+OpStore %1081 %1328
+%1329 = OpLoad %ulong %1085
+%1330 = OpLoad %ulong %1081
+%1331 = OpBitwiseXor %ulong %1329 %1330
+OpStore %1082 %1331
+%1332 = OpLoad %ulong %1082
+%1333 = OpIMul %ulong %1332 %ulong_1099511628211
+OpStore %1083 %1333
+%1334 = OpLoad %ulong %1086
+%1335 = OpIAdd %ulong %1334 %ulong_1
+OpStore %1084 %1335
+%1336 = OpLoad %ulong %1083
+OpStore %1085 %1336
+%1337 = OpLoad %ulong %1084
+OpStore %1086 %1337
+OpBranch %884
+%857 = OpLabel
+%1338 = OpLoad %ulong %1075
+%1339 = OpIMul %ulong %1338 %ulong_8
+OpStore %1068 %1339
+%1340 = OpLoad %ulong %1066
+%1341 = OpLoad %ulong %1068
+%1342 = OpShiftRightLogical %ulong %1340 %1341
+OpStore %1069 %1342
+%1343 = OpLoad %ulong %1069
+%1344 = OpBitwiseAnd %ulong %1343 %ulong_255
+OpStore %1070 %1344
+%1345 = OpLoad %ulong %1074
+%1346 = OpLoad %ulong %1070
+%1347 = OpBitwiseXor %ulong %1345 %1346
+OpStore %1071 %1347
+%1348 = OpLoad %ulong %1071
+%1349 = OpIMul %ulong %1348 %ulong_1099511628211
+OpStore %1072 %1349
+%1350 = OpLoad %ulong %1075
+%1351 = OpIAdd %ulong %1350 %ulong_1
+OpStore %1073 %1351
+%1352 = OpLoad %ulong %1072
+OpStore %1074 %1352
+%1353 = OpLoad %ulong %1073
+OpStore %1075 %1353
+OpBranch %885
+%850 = OpLabel
+%1354 = OpLoad %ulong %1065
+%1355 = OpIMul %ulong %1354 %ulong_8
+OpStore %1058 %1355
+%1356 = OpLoad %ulong %1056
+%1357 = OpLoad %ulong %1058
+%1358 = OpShiftRightLogical %ulong %1356 %1357
+OpStore %1059 %1358
+%1359 = OpLoad %ulong %1059
+%1360 = OpBitwiseAnd %ulong %1359 %ulong_255
+OpStore %1060 %1360
+%1361 = OpLoad %ulong %1064
+%1362 = OpLoad %ulong %1060
+%1363 = OpBitwiseXor %ulong %1361 %1362
+OpStore %1061 %1363
+%1364 = OpLoad %ulong %1061
+%1365 = OpIMul %ulong %1364 %ulong_1099511628211
+OpStore %1062 %1365
+%1366 = OpLoad %ulong %1065
+%1367 = OpIAdd %ulong %1366 %ulong_1
+OpStore %1063 %1367
+%1368 = OpLoad %ulong %1062
+OpStore %1064 %1368
+%1369 = OpLoad %ulong %1063
+OpStore %1065 %1369
+OpBranch %886
+%843 = OpLabel
+%1370 = OpLoad %ulong %1054
+%1371 = OpIMul %ulong %1370 %ulong_8
+OpStore %1047 %1371
+%1372 = OpLoad %ulong %1045
+%1373 = OpLoad %ulong %1047
+%1374 = OpShiftRightLogical %ulong %1372 %1373
+OpStore %1048 %1374
+%1375 = OpLoad %ulong %1048
+%1376 = OpBitwiseAnd %ulong %1375 %ulong_255
+OpStore %1049 %1376
+%1377 = OpLoad %ulong %1053
+%1378 = OpLoad %ulong %1049
+%1379 = OpBitwiseXor %ulong %1377 %1378
+OpStore %1050 %1379
+%1380 = OpLoad %ulong %1050
+%1381 = OpIMul %ulong %1380 %ulong_1099511628211
+OpStore %1051 %1381
+%1382 = OpLoad %ulong %1054
+%1383 = OpIAdd %ulong %1382 %ulong_1
+OpStore %1052 %1383
+%1384 = OpLoad %ulong %1051
+OpStore %1053 %1384
+%1385 = OpLoad %ulong %1052
+OpStore %1054 %1385
+OpBranch %887
+%836 = OpLabel
+%1386 = OpLoad %ulong %1044
+%1387 = OpIMul %ulong %1386 %ulong_8
+OpStore %1037 %1387
+%1388 = OpLoad %ulong %1035
+%1389 = OpLoad %ulong %1037
+%1390 = OpShiftRightLogical %ulong %1388 %1389
+OpStore %1038 %1390
+%1391 = OpLoad %ulong %1038
+%1392 = OpBitwiseAnd %ulong %1391 %ulong_255
+OpStore %1039 %1392
+%1393 = OpLoad %ulong %1043
+%1394 = OpLoad %ulong %1039
+%1395 = OpBitwiseXor %ulong %1393 %1394
+OpStore %1040 %1395
+%1396 = OpLoad %ulong %1040
+%1397 = OpIMul %ulong %1396 %ulong_1099511628211
+OpStore %1041 %1397
+%1398 = OpLoad %ulong %1044
+%1399 = OpIAdd %ulong %1398 %ulong_1
+OpStore %1042 %1399
+%1400 = OpLoad %ulong %1041
+OpStore %1043 %1400
+%1401 = OpLoad %ulong %1042
+OpStore %1044 %1401
+OpBranch %888
+%829 = OpLabel
+%1402 = OpLoad %ulong %1033
+%1403 = OpIMul %ulong %1402 %ulong_8
+OpStore %1026 %1403
+%1404 = OpLoad %ulong %1024
+%1405 = OpLoad %ulong %1026
+%1406 = OpShiftRightLogical %ulong %1404 %1405
+OpStore %1027 %1406
+%1407 = OpLoad %ulong %1027
+%1408 = OpBitwiseAnd %ulong %1407 %ulong_255
+OpStore %1028 %1408
+%1409 = OpLoad %ulong %1032
+%1410 = OpLoad %ulong %1028
+%1411 = OpBitwiseXor %ulong %1409 %1410
+OpStore %1029 %1411
+%1412 = OpLoad %ulong %1029
+%1413 = OpIMul %ulong %1412 %ulong_1099511628211
+OpStore %1030 %1413
+%1414 = OpLoad %ulong %1033
+%1415 = OpIAdd %ulong %1414 %ulong_1
+OpStore %1031 %1415
+%1416 = OpLoad %ulong %1030
+OpStore %1032 %1416
+%1417 = OpLoad %ulong %1031
+OpStore %1033 %1417
+OpBranch %889
+%822 = OpLabel
+%1418 = OpLoad %ulong %1023
+%1419 = OpIMul %ulong %1418 %ulong_8
+OpStore %1016 %1419
+%1420 = OpLoad %ulong %1014
+%1421 = OpLoad %ulong %1016
+%1422 = OpShiftRightLogical %ulong %1420 %1421
+OpStore %1017 %1422
+%1423 = OpLoad %ulong %1017
+%1424 = OpBitwiseAnd %ulong %1423 %ulong_255
+OpStore %1018 %1424
+%1425 = OpLoad %ulong %1022
+%1426 = OpLoad %ulong %1018
+%1427 = OpBitwiseXor %ulong %1425 %1426
+OpStore %1019 %1427
+%1428 = OpLoad %ulong %1019
+%1429 = OpIMul %ulong %1428 %ulong_1099511628211
+OpStore %1020 %1429
+%1430 = OpLoad %ulong %1023
+%1431 = OpIAdd %ulong %1430 %ulong_1
+OpStore %1021 %1431
+%1432 = OpLoad %ulong %1020
+OpStore %1022 %1432
+%1433 = OpLoad %ulong %1021
+OpStore %1023 %1433
+OpBranch %890
+%815 = OpLabel
+%1434 = OpLoad %ulong %1012
+%1435 = OpIMul %ulong %1434 %ulong_8
+OpStore %1005 %1435
+%1436 = OpLoad %ulong %1003
+%1437 = OpLoad %ulong %1005
+%1438 = OpShiftRightLogical %ulong %1436 %1437
+OpStore %1006 %1438
+%1439 = OpLoad %ulong %1006
+%1440 = OpBitwiseAnd %ulong %1439 %ulong_255
+OpStore %1007 %1440
+%1441 = OpLoad %ulong %1011
+%1442 = OpLoad %ulong %1007
+%1443 = OpBitwiseXor %ulong %1441 %1442
+OpStore %1008 %1443
+%1444 = OpLoad %ulong %1008
+%1445 = OpIMul %ulong %1444 %ulong_1099511628211
+OpStore %1009 %1445
+%1446 = OpLoad %ulong %1012
+%1447 = OpIAdd %ulong %1446 %ulong_1
+OpStore %1010 %1447
+%1448 = OpLoad %ulong %1009
+OpStore %1011 %1448
+%1449 = OpLoad %ulong %1010
+OpStore %1012 %1449
+OpBranch %891
+%808 = OpLabel
+%1450 = OpLoad %ulong %1002
+%1451 = OpIMul %ulong %1450 %ulong_8
+OpStore %995 %1451
+%1452 = OpLoad %ulong %993
+%1453 = OpLoad %ulong %995
+%1454 = OpShiftRightLogical %ulong %1452 %1453
+OpStore %996 %1454
+%1455 = OpLoad %ulong %996
+%1456 = OpBitwiseAnd %ulong %1455 %ulong_255
+OpStore %997 %1456
+%1457 = OpLoad %ulong %1001
+%1458 = OpLoad %ulong %997
+%1459 = OpBitwiseXor %ulong %1457 %1458
+OpStore %998 %1459
+%1460 = OpLoad %ulong %998
+%1461 = OpIMul %ulong %1460 %ulong_1099511628211
+OpStore %999 %1461
+%1462 = OpLoad %ulong %1002
+%1463 = OpIAdd %ulong %1462 %ulong_1
+OpStore %1000 %1463
+%1464 = OpLoad %ulong %999
+OpStore %1001 %1464
+%1465 = OpLoad %ulong %1000
+OpStore %1002 %1465
+OpBranch %892
+%801 = OpLabel
+%1466 = OpLoad %ulong %991
+%1467 = OpIMul %ulong %1466 %ulong_8
+OpStore %984 %1467
+%1468 = OpLoad %ulong %982
+%1469 = OpLoad %ulong %984
+%1470 = OpShiftRightLogical %ulong %1468 %1469
+OpStore %985 %1470
+%1471 = OpLoad %ulong %985
+%1472 = OpBitwiseAnd %ulong %1471 %ulong_255
+OpStore %986 %1472
+%1473 = OpLoad %ulong %990
+%1474 = OpLoad %ulong %986
+%1475 = OpBitwiseXor %ulong %1473 %1474
+OpStore %987 %1475
+%1476 = OpLoad %ulong %987
+%1477 = OpIMul %ulong %1476 %ulong_1099511628211
+OpStore %988 %1477
+%1478 = OpLoad %ulong %991
+%1479 = OpIAdd %ulong %1478 %ulong_1
+OpStore %989 %1479
+%1480 = OpLoad %ulong %988
+OpStore %990 %1480
+%1481 = OpLoad %ulong %989
+OpStore %991 %1481
+OpBranch %893
+%794 = OpLabel
+%1482 = OpLoad %ulong %981
+%1483 = OpIMul %ulong %1482 %ulong_8
+OpStore %974 %1483
+%1484 = OpLoad %ulong %972
+%1485 = OpLoad %ulong %974
+%1486 = OpShiftRightLogical %ulong %1484 %1485
+OpStore %975 %1486
+%1487 = OpLoad %ulong %975
+%1488 = OpBitwiseAnd %ulong %1487 %ulong_255
+OpStore %976 %1488
+%1489 = OpLoad %ulong %980
+%1490 = OpLoad %ulong %976
+%1491 = OpBitwiseXor %ulong %1489 %1490
+OpStore %977 %1491
+%1492 = OpLoad %ulong %977
+%1493 = OpIMul %ulong %1492 %ulong_1099511628211
+OpStore %978 %1493
+%1494 = OpLoad %ulong %981
+%1495 = OpIAdd %ulong %1494 %ulong_1
+OpStore %979 %1495
+%1496 = OpLoad %ulong %978
+OpStore %980 %1496
+%1497 = OpLoad %ulong %979
+OpStore %981 %1497
+OpBranch %894
+%787 = OpLabel
+%1498 = OpLoad %ulong %970
+%1499 = OpIMul %ulong %1498 %ulong_8
+OpStore %963 %1499
+%1500 = OpLoad %ulong %961
+%1501 = OpLoad %ulong %963
+%1502 = OpShiftRightLogical %ulong %1500 %1501
+OpStore %964 %1502
+%1503 = OpLoad %ulong %964
+%1504 = OpBitwiseAnd %ulong %1503 %ulong_255
+OpStore %965 %1504
+%1505 = OpLoad %ulong %969
+%1506 = OpLoad %ulong %965
+%1507 = OpBitwiseXor %ulong %1505 %1506
+OpStore %966 %1507
+%1508 = OpLoad %ulong %966
+%1509 = OpIMul %ulong %1508 %ulong_1099511628211
+OpStore %967 %1509
+%1510 = OpLoad %ulong %970
+%1511 = OpIAdd %ulong %1510 %ulong_1
+OpStore %968 %1511
+%1512 = OpLoad %ulong %967
+OpStore %969 %1512
+%1513 = OpLoad %ulong %968
+OpStore %970 %1513
+OpBranch %895
+%780 = OpLabel
+%1514 = OpLoad %ulong %960
+%1515 = OpIMul %ulong %1514 %ulong_8
+OpStore %953 %1515
+%1516 = OpLoad %ulong %951
+%1517 = OpLoad %ulong %953
+%1518 = OpShiftRightLogical %ulong %1516 %1517
+OpStore %954 %1518
+%1519 = OpLoad %ulong %954
+%1520 = OpBitwiseAnd %ulong %1519 %ulong_255
+OpStore %955 %1520
+%1521 = OpLoad %ulong %959
+%1522 = OpLoad %ulong %955
+%1523 = OpBitwiseXor %ulong %1521 %1522
+OpStore %956 %1523
+%1524 = OpLoad %ulong %956
+%1525 = OpIMul %ulong %1524 %ulong_1099511628211
+OpStore %957 %1525
+%1526 = OpLoad %ulong %960
+%1527 = OpIAdd %ulong %1526 %ulong_1
+OpStore %958 %1527
+%1528 = OpLoad %ulong %957
+OpStore %959 %1528
+%1529 = OpLoad %ulong %958
+OpStore %960 %1529
+OpBranch %896
+%773 = OpLabel
+%1530 = OpLoad %ulong %949
+%1531 = OpIMul %ulong %1530 %ulong_8
+OpStore %942 %1531
+%1532 = OpLoad %ulong %940
+%1533 = OpLoad %ulong %942
+%1534 = OpShiftRightLogical %ulong %1532 %1533
+OpStore %943 %1534
+%1535 = OpLoad %ulong %943
+%1536 = OpBitwiseAnd %ulong %1535 %ulong_255
+OpStore %944 %1536
+%1537 = OpLoad %ulong %948
+%1538 = OpLoad %ulong %944
+%1539 = OpBitwiseXor %ulong %1537 %1538
+OpStore %945 %1539
+%1540 = OpLoad %ulong %945
+%1541 = OpIMul %ulong %1540 %ulong_1099511628211
+OpStore %946 %1541
+%1542 = OpLoad %ulong %949
+%1543 = OpIAdd %ulong %1542 %ulong_1
+OpStore %947 %1543
+%1544 = OpLoad %ulong %946
+OpStore %948 %1544
+%1545 = OpLoad %ulong %947
+OpStore %949 %1545
+OpBranch %897
+%766 = OpLabel
+%1546 = OpLoad %ulong %939
+%1547 = OpIMul %ulong %1546 %ulong_8
+OpStore %932 %1547
+%1548 = OpLoad %ulong %930
+%1549 = OpLoad %ulong %932
+%1550 = OpShiftRightLogical %ulong %1548 %1549
+OpStore %933 %1550
+%1551 = OpLoad %ulong %933
+%1552 = OpBitwiseAnd %ulong %1551 %ulong_255
+OpStore %934 %1552
+%1553 = OpLoad %ulong %938
+%1554 = OpLoad %ulong %934
+%1555 = OpBitwiseXor %ulong %1553 %1554
+OpStore %935 %1555
+%1556 = OpLoad %ulong %935
+%1557 = OpIMul %ulong %1556 %ulong_1099511628211
+OpStore %936 %1557
+%1558 = OpLoad %ulong %939
+%1559 = OpIAdd %ulong %1558 %ulong_1
+OpStore %937 %1559
+%1560 = OpLoad %ulong %936
+OpStore %938 %1560
+%1561 = OpLoad %ulong %937
+OpStore %939 %1561
+OpBranch %898
+%883 = OpLabel
+OpBranch %870
+%884 = OpLabel
+OpBranch %863
+%885 = OpLabel
+OpBranch %856
+%886 = OpLabel
+OpBranch %849
+%887 = OpLabel
+OpBranch %842
+%888 = OpLabel
+OpBranch %835
+%889 = OpLabel
+OpBranch %828
+%890 = OpLabel
+OpBranch %821
+%891 = OpLabel
+OpBranch %814
+%892 = OpLabel
+OpBranch %807
+%893 = OpLabel
+OpBranch %800
+%894 = OpLabel
+OpBranch %793
+%895 = OpLabel
+OpBranch %786
+%896 = OpLabel
+OpBranch %779
+%897 = OpLabel
+OpBranch %772
+%898 = OpLabel
+OpBranch %765
+OpFunctionEnd
+%3 = OpFunction %ulong None %1562
+%1563 = OpFunctionParameter %ulong
+%1564 = OpFunctionParameter %ulong
+%1565 = OpLabel
+%1570 = OpVariable %_ptr_Function_ulong Function
+%1571 = OpVariable %_ptr_Function_ulong Function
+%1572 = OpVariable %_ptr_Function_bool Function
+%1573 = OpVariable %_ptr_Function_ulong Function
+%1574 = OpVariable %_ptr_Function_ulong Function
+%1575 = OpVariable %_ptr_Function_ulong Function
+%1576 = OpVariable %_ptr_Function_ulong Function
+%1577 = OpVariable %_ptr_Function_ulong Function
+%1578 = OpVariable %_ptr_Function_ulong Function
+%1579 = OpVariable %_ptr_Function_ulong Function
+%1580 = OpVariable %_ptr_Function_ulong Function
+OpStore %1570 %1563
+OpStore %1571 %1564
+%1581 = OpLoad %ulong %1570
+OpStore %1579 %1581
+OpStore %1580 %ulong_0
+OpBranch %1566
+%1566 = OpLabel
+%1582 = OpLoad %ulong %1580
+%1583 = OpULessThan %bool %1582 %ulong_8
+OpStore %1572 %1583
+%1584 = OpLoad %bool %1572
+OpLoopMerge %1568 %1569 None
+OpBranchConditional %1584 %1567 %1568
+%1568 = OpLabel
+%1585 = OpLoad %ulong %1579
+OpReturnValue %1585
+%1567 = OpLabel
+%1586 = OpLoad %ulong %1580
+%1587 = OpIMul %ulong %1586 %ulong_8
+OpStore %1573 %1587
+%1588 = OpLoad %ulong %1571
+%1589 = OpLoad %ulong %1573
+%1590 = OpShiftRightLogical %ulong %1588 %1589
+OpStore %1574 %1590
+%1591 = OpLoad %ulong %1574
+%1592 = OpBitwiseAnd %ulong %1591 %ulong_255
+OpStore %1575 %1592
+%1593 = OpLoad %ulong %1579
+%1594 = OpLoad %ulong %1575
+%1595 = OpBitwiseXor %ulong %1593 %1594
+OpStore %1576 %1595
+%1596 = OpLoad %ulong %1576
+%1597 = OpIMul %ulong %1596 %ulong_1099511628211
+OpStore %1577 %1597
+%1598 = OpLoad %ulong %1580
+%1599 = OpIAdd %ulong %1598 %ulong_1
+OpStore %1578 %1599
+%1600 = OpLoad %ulong %1577
+OpStore %1579 %1600
+%1601 = OpLoad %ulong %1578
+OpStore %1580 %1601
+OpBranch %1569
+%1569 = OpLabel
+OpBranch %1566
 OpFunctionEnd

--- a/test/golden/spirv/convert/trunc.dis
+++ b/test/golden/spirv/convert/trunc.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 306
+; Bound: 401
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,430 +11,589 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.convert.trunc.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %ushort = OpTypeInt 16 0
 %uchar = OpTypeInt 8 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uchar = OpTypePointer Function %uchar
+%_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_1311768467463790320 = OpConstant %ulong 1311768467463790320
 %ulong_1 = OpConstant %ulong 1
-%uint_1431655765 = OpConstant %uint 1431655765
-%ushort_21845 = OpConstant %ushort 21845
-%122 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%125 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
+%uint_1431655765 = OpConstant %uint 1431655765
+%ushort_21845 = OpConstant %ushort 21845
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%171 = OpTypeFunction %ulong %ulong %uchar
-%216 = OpTypeFunction %ulong %ulong %ushort
-%261 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_uint Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%24 = OpVariable %_ptr_Function_uchar Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ushort Function
-%30 = OpVariable %_ptr_Function_uchar Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ushort Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-OpStore %15 %9
-%48 = OpFunctionCall %ulong %2
-OpStore %16 %48
-%49 = OpLoad %ulong %15
-%51 = OpBitwiseXor %ulong %49 %ulong_1311768467463790320
-OpStore %17 %51
-%52 = OpLoad %ulong %17
-%54 = OpBitwiseOr %ulong %52 %ulong_1
-OpStore %18 %54
-%55 = OpLoad %ulong %18
-%56 = OpUConvert %uint %55
-OpStore %20 %56
-%57 = OpLoad %ulong %18
-%58 = OpUConvert %ushort %57
-OpStore %22 %58
-%59 = OpLoad %ulong %18
-%60 = OpUConvert %uchar %59
-OpStore %24 %60
-%61 = OpLoad %ulong %16
-%62 = OpLoad %uint %20
-%63 = OpFunctionCall %ulong %6 %61 %62
-OpStore %25 %63
-%64 = OpLoad %ulong %25
-%65 = OpLoad %ushort %22
-%66 = OpFunctionCall %ulong %5 %64 %65
-OpStore %26 %66
-%67 = OpLoad %ulong %26
-%68 = OpLoad %uchar %24
-%69 = OpFunctionCall %ulong %4 %67 %68
-OpStore %27 %69
-%70 = OpLoad %uint %20
-%72 = OpBitwiseXor %uint %70 %uint_1431655765
-OpStore %28 %72
-%73 = OpLoad %uint %28
-%74 = OpUConvert %ushort %73
-OpStore %29 %74
-%75 = OpLoad %uint %28
-%76 = OpUConvert %uchar %75
-OpStore %30 %76
-%77 = OpLoad %ulong %27
-%78 = OpLoad %ushort %29
-%79 = OpFunctionCall %ulong %5 %77 %78
-OpStore %31 %79
-%80 = OpLoad %ulong %31
-%81 = OpLoad %uchar %30
-%82 = OpFunctionCall %ulong %4 %80 %81
-OpStore %32 %82
-%83 = OpLoad %ushort %22
-%85 = OpBitwiseXor %ushort %83 %ushort_21845
-OpStore %33 %85
-%86 = OpLoad %ushort %33
-%87 = OpUConvert %uchar %86
-OpStore %34 %87
-%88 = OpLoad %ulong %32
-%89 = OpLoad %uchar %34
-%90 = OpFunctionCall %ulong %4 %88 %89
-OpStore %35 %90
-%91 = OpLoad %uint %20
-%92 = OpUConvert %ulong %91
-OpStore %36 %92
-%93 = OpLoad %ushort %22
-%94 = OpUConvert %ulong %93
-OpStore %37 %94
-%95 = OpLoad %ulong %36
-%96 = OpLoad %ulong %37
-%97 = OpIAdd %ulong %95 %96
-OpStore %38 %97
-%98 = OpLoad %uchar %24
-%99 = OpUConvert %ulong %98
-OpStore %39 %99
-%100 = OpLoad %ulong %38
-%101 = OpLoad %ulong %39
-%102 = OpIAdd %ulong %100 %101
-OpStore %40 %102
-%103 = OpLoad %ulong %35
-%104 = OpLoad %ulong %40
-%105 = OpFunctionCall %ulong %3 %103 %104
-OpStore %41 %105
-%106 = OpLoad %ushort %29
-%107 = OpUConvert %ulong %106
-OpStore %42 %107
-%108 = OpLoad %uchar %30
-%109 = OpUConvert %ulong %108
-OpStore %43 %109
-%110 = OpLoad %ulong %42
-%111 = OpLoad %ulong %43
-%112 = OpIAdd %ulong %110 %111
-OpStore %44 %112
-%113 = OpLoad %uchar %34
-%114 = OpUConvert %ulong %113
-OpStore %45 %114
-%115 = OpLoad %ulong %44
-%116 = OpLoad %ulong %45
-%117 = OpIAdd %ulong %115 %116
-OpStore %46 %117
-%118 = OpLoad %ulong %41
-%119 = OpLoad %ulong %46
-%120 = OpFunctionCall %ulong %3 %118 %119
-OpStore %47 %120
-%121 = OpLoad %ulong %47
-OpReturnValue %121
-OpFunctionEnd
-%2 = OpFunction %ulong None %122
-%123 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %125
-%126 = OpFunctionParameter %ulong
-%127 = OpFunctionParameter %ulong
-%128 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_uint Function
+%79 = OpVariable %_ptr_Function_ushort Function
+%81 = OpVariable %_ptr_Function_uchar Function
+%82 = OpVariable %_ptr_Function_uint Function
+%83 = OpVariable %_ptr_Function_ushort Function
+%84 = OpVariable %_ptr_Function_uchar Function
+%85 = OpVariable %_ptr_Function_ushort Function
+%86 = OpVariable %_ptr_Function_uchar Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_bool Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_bool Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_bool Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_bool Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
 %134 = OpVariable %_ptr_Function_ulong Function
 %135 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_bool Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
 %138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_bool Function
 %140 = OpVariable %_ptr_Function_ulong Function
 %141 = OpVariable %_ptr_Function_ulong Function
 %142 = OpVariable %_ptr_Function_ulong Function
 %143 = OpVariable %_ptr_Function_ulong Function
 %144 = OpVariable %_ptr_Function_ulong Function
 %145 = OpVariable %_ptr_Function_ulong Function
-OpStore %134 %126
-OpStore %135 %127
-%146 = OpLoad %ulong %134
-OpStore %144 %146
-OpStore %145 %ulong_0
-OpBranch %129
-%129 = OpLabel
-%148 = OpLoad %ulong %145
-%150 = OpULessThan %bool %148 %ulong_8
-OpStore %137 %150
-%151 = OpLoad %bool %137
-OpLoopMerge %131 %132 None
-OpBranchConditional %151 %130 %131
-%131 = OpLabel
-%152 = OpLoad %ulong %144
-OpReturnValue %152
-%130 = OpLabel
-%153 = OpLoad %ulong %145
-%154 = OpIMul %ulong %153 %ulong_8
-OpStore %138 %154
-%155 = OpLoad %ulong %135
-%156 = OpLoad %ulong %138
-%157 = OpShiftRightLogical %ulong %155 %156
-OpStore %139 %157
-%158 = OpLoad %ulong %139
-%160 = OpBitwiseAnd %ulong %158 %ulong_255
-OpStore %140 %160
-%161 = OpLoad %ulong %144
-%162 = OpLoad %ulong %140
-%163 = OpBitwiseXor %ulong %161 %162
-OpStore %141 %163
-%164 = OpLoad %ulong %141
-%166 = OpIMul %ulong %164 %ulong_1099511628211
-OpStore %142 %166
-%167 = OpLoad %ulong %145
-%168 = OpIAdd %ulong %167 %ulong_1
-OpStore %143 %168
-%169 = OpLoad %ulong %142
-OpStore %144 %169
-%170 = OpLoad %ulong %143
-OpStore %145 %170
-OpBranch %132
-%132 = OpLabel
-OpBranch %129
-OpFunctionEnd
-%4 = OpFunction %ulong None %171
-%172 = OpFunctionParameter %ulong
-%173 = OpFunctionParameter %uchar
-%174 = OpLabel
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_uchar Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_bool Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-OpStore %181 %172
-OpStore %182 %173
-%193 = OpLoad %uchar %182
-%194 = OpUConvert %ulong %193
-OpStore %183 %194
-OpBranch %175
-%175 = OpLabel
-%195 = OpLoad %ulong %181
-OpStore %191 %195
-OpStore %192 %ulong_0
-OpBranch %176
-%176 = OpLabel
-%196 = OpLoad %ulong %192
-%197 = OpULessThan %bool %196 %ulong_8
-OpStore %184 %197
-%198 = OpLoad %bool %184
-OpLoopMerge %178 %180 None
-OpBranchConditional %198 %177 %178
-%178 = OpLabel
-OpBranch %179
-%179 = OpLabel
-%199 = OpLoad %ulong %191
-OpReturnValue %199
-%177 = OpLabel
-%200 = OpLoad %ulong %192
-%201 = OpIMul %ulong %200 %ulong_8
-OpStore %185 %201
-%202 = OpLoad %ulong %183
-%203 = OpLoad %ulong %185
-%204 = OpShiftRightLogical %ulong %202 %203
-OpStore %186 %204
-%205 = OpLoad %ulong %186
-%206 = OpBitwiseAnd %ulong %205 %ulong_255
-OpStore %187 %206
-%207 = OpLoad %ulong %191
-%208 = OpLoad %ulong %187
-%209 = OpBitwiseXor %ulong %207 %208
-OpStore %188 %209
-%210 = OpLoad %ulong %188
-%211 = OpIMul %ulong %210 %ulong_1099511628211
-OpStore %189 %211
-%212 = OpLoad %ulong %192
-%213 = OpIAdd %ulong %212 %ulong_1
-OpStore %190 %213
-%214 = OpLoad %ulong %189
-OpStore %191 %214
-%215 = OpLoad %ulong %190
-OpStore %192 %215
-OpBranch %180
-%180 = OpLabel
-OpBranch %176
-OpFunctionEnd
-%5 = OpFunction %ulong None %216
-%217 = OpFunctionParameter %ulong
-%218 = OpFunctionParameter %ushort
-%219 = OpLabel
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ushort Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_bool Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_ulong Function
-OpStore %226 %217
-OpStore %227 %218
-%238 = OpLoad %ushort %227
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_bool Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_bool Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_bool Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+OpStore %73 %4
+OpBranch %6
+%6 = OpLabel
+OpBranch %7
+%7 = OpLabel
+%176 = OpLoad %ulong %73
+%178 = OpBitwiseXor %ulong %176 %ulong_1311768467463790320
+OpStore %74 %178
+%179 = OpLoad %ulong %74
+%181 = OpBitwiseOr %ulong %179 %ulong_1
+OpStore %75 %181
+%182 = OpLoad %ulong %75
+%183 = OpUConvert %uint %182
+OpStore %77 %183
+%184 = OpLoad %ulong %75
+%185 = OpUConvert %ushort %184
+OpStore %79 %185
+%186 = OpLoad %ulong %75
+%187 = OpUConvert %uchar %186
+OpStore %81 %187
+OpBranch %8
+%8 = OpLabel
+%188 = OpLoad %uint %77
+%189 = OpUConvert %ulong %188
+OpStore %97 %189
+OpBranch %10
+%10 = OpLabel
+OpStore %106 %ulong_14695981039346656037
+OpStore %107 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%192 = OpLoad %ulong %107
+%194 = OpULessThan %bool %192 %ulong_8
+OpStore %99 %194
+%195 = OpLoad %bool %99
+OpLoopMerge %13 %67 None
+OpBranchConditional %195 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %9
+%9 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%196 = OpLoad %ushort %79
+%197 = OpUConvert %ulong %196
+OpStore %108 %197
+OpBranch %17
+%17 = OpLabel
+%198 = OpLoad %ulong %106
+OpStore %116 %198
+OpStore %117 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%199 = OpLoad %ulong %117
+%200 = OpULessThan %bool %199 %ulong_8
+OpStore %109 %200
+%201 = OpLoad %bool %109
+OpLoopMerge %20 %66 None
+OpBranchConditional %201 %19 %20
+%20 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%202 = OpLoad %uchar %81
+%203 = OpUConvert %ulong %202
+OpStore %118 %203
+OpBranch %24
+%24 = OpLabel
+%204 = OpLoad %ulong %116
+OpStore %126 %204
+OpStore %127 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%205 = OpLoad %ulong %127
+%206 = OpULessThan %bool %205 %ulong_8
+OpStore %119 %206
+%207 = OpLoad %bool %119
+OpLoopMerge %27 %65 None
+OpBranchConditional %207 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%208 = OpLoad %uint %77
+%210 = OpBitwiseXor %uint %208 %uint_1431655765
+OpStore %82 %210
+%211 = OpLoad %uint %82
+%212 = OpUConvert %ushort %211
+OpStore %83 %212
+%213 = OpLoad %uint %82
+%214 = OpUConvert %uchar %213
+OpStore %84 %214
+OpBranch %29
+%29 = OpLabel
+%215 = OpLoad %ushort %83
+%216 = OpUConvert %ulong %215
+OpStore %128 %216
+OpBranch %31
+%31 = OpLabel
+%217 = OpLoad %ulong %126
+OpStore %136 %217
+OpStore %137 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%218 = OpLoad %ulong %137
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %129 %219
+%220 = OpLoad %bool %129
+OpLoopMerge %34 %64 None
+OpBranchConditional %220 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%221 = OpLoad %uchar %84
+%222 = OpUConvert %ulong %221
+OpStore %138 %222
+OpBranch %38
+%38 = OpLabel
+%223 = OpLoad %ulong %136
+OpStore %146 %223
+OpStore %147 %ulong_0
+OpBranch %39
+%39 = OpLabel
+%224 = OpLoad %ulong %147
+%225 = OpULessThan %bool %224 %ulong_8
+OpStore %139 %225
+%226 = OpLoad %bool %139
+OpLoopMerge %41 %63 None
+OpBranchConditional %226 %40 %41
+%41 = OpLabel
+OpBranch %42
+%42 = OpLabel
+OpBranch %37
+%37 = OpLabel
+%227 = OpLoad %ushort %79
+%229 = OpBitwiseXor %ushort %227 %ushort_21845
+OpStore %85 %229
+%230 = OpLoad %ushort %85
+%231 = OpUConvert %uchar %230
+OpStore %86 %231
+OpBranch %43
+%43 = OpLabel
+%232 = OpLoad %uchar %86
+%233 = OpUConvert %ulong %232
+OpStore %148 %233
+OpBranch %45
+%45 = OpLabel
+%234 = OpLoad %ulong %146
+OpStore %156 %234
+OpStore %157 %ulong_0
+OpBranch %46
+%46 = OpLabel
+%235 = OpLoad %ulong %157
+%236 = OpULessThan %bool %235 %ulong_8
+OpStore %149 %236
+%237 = OpLoad %bool %149
+OpLoopMerge %48 %62 None
+OpBranchConditional %237 %47 %48
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%238 = OpLoad %uint %77
 %239 = OpUConvert %ulong %238
-OpStore %228 %239
-OpBranch %220
-%220 = OpLabel
-%240 = OpLoad %ulong %226
-OpStore %236 %240
-OpStore %237 %ulong_0
-OpBranch %221
-%221 = OpLabel
-%241 = OpLoad %ulong %237
-%242 = OpULessThan %bool %241 %ulong_8
-OpStore %229 %242
-%243 = OpLoad %bool %229
-OpLoopMerge %223 %225 None
-OpBranchConditional %243 %222 %223
-%223 = OpLabel
-OpBranch %224
-%224 = OpLabel
-%244 = OpLoad %ulong %236
-OpReturnValue %244
-%222 = OpLabel
-%245 = OpLoad %ulong %237
-%246 = OpIMul %ulong %245 %ulong_8
-OpStore %230 %246
-%247 = OpLoad %ulong %228
-%248 = OpLoad %ulong %230
-%249 = OpShiftRightLogical %ulong %247 %248
-OpStore %231 %249
-%250 = OpLoad %ulong %231
-%251 = OpBitwiseAnd %ulong %250 %ulong_255
-OpStore %232 %251
-%252 = OpLoad %ulong %236
-%253 = OpLoad %ulong %232
-%254 = OpBitwiseXor %ulong %252 %253
-OpStore %233 %254
-%255 = OpLoad %ulong %233
-%256 = OpIMul %ulong %255 %ulong_1099511628211
-OpStore %234 %256
-%257 = OpLoad %ulong %237
-%258 = OpIAdd %ulong %257 %ulong_1
-OpStore %235 %258
-%259 = OpLoad %ulong %234
-OpStore %236 %259
-%260 = OpLoad %ulong %235
-OpStore %237 %260
-OpBranch %225
-%225 = OpLabel
-OpBranch %221
-OpFunctionEnd
-%6 = OpFunction %ulong None %261
-%262 = OpFunctionParameter %ulong
-%263 = OpFunctionParameter %uint
-%264 = OpLabel
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_uint Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_bool Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ulong Function
-OpStore %271 %262
-OpStore %272 %263
-%283 = OpLoad %uint %272
-%284 = OpUConvert %ulong %283
-OpStore %273 %284
-OpBranch %265
-%265 = OpLabel
-%285 = OpLoad %ulong %271
-OpStore %281 %285
-OpStore %282 %ulong_0
-OpBranch %266
-%266 = OpLabel
-%286 = OpLoad %ulong %282
-%287 = OpULessThan %bool %286 %ulong_8
-OpStore %274 %287
-%288 = OpLoad %bool %274
-OpLoopMerge %268 %270 None
-OpBranchConditional %288 %267 %268
-%268 = OpLabel
-OpBranch %269
-%269 = OpLabel
-%289 = OpLoad %ulong %281
-OpReturnValue %289
-%267 = OpLabel
-%290 = OpLoad %ulong %282
-%291 = OpIMul %ulong %290 %ulong_8
-OpStore %275 %291
-%292 = OpLoad %ulong %273
-%293 = OpLoad %ulong %275
-%294 = OpShiftRightLogical %ulong %292 %293
-OpStore %276 %294
-%295 = OpLoad %ulong %276
-%296 = OpBitwiseAnd %ulong %295 %ulong_255
-OpStore %277 %296
-%297 = OpLoad %ulong %281
-%298 = OpLoad %ulong %277
-%299 = OpBitwiseXor %ulong %297 %298
-OpStore %278 %299
-%300 = OpLoad %ulong %278
-%301 = OpIMul %ulong %300 %ulong_1099511628211
-OpStore %279 %301
-%302 = OpLoad %ulong %282
-%303 = OpIAdd %ulong %302 %ulong_1
-OpStore %280 %303
-%304 = OpLoad %ulong %279
-OpStore %281 %304
-%305 = OpLoad %ulong %280
-OpStore %282 %305
-OpBranch %270
-%270 = OpLabel
-OpBranch %266
+OpStore %87 %239
+%240 = OpLoad %ushort %79
+%241 = OpUConvert %ulong %240
+OpStore %88 %241
+%242 = OpLoad %ulong %87
+%243 = OpLoad %ulong %88
+%244 = OpIAdd %ulong %242 %243
+OpStore %89 %244
+%245 = OpLoad %uchar %81
+%246 = OpUConvert %ulong %245
+OpStore %90 %246
+%247 = OpLoad %ulong %89
+%248 = OpLoad %ulong %90
+%249 = OpIAdd %ulong %247 %248
+OpStore %91 %249
+OpBranch %50
+%50 = OpLabel
+%250 = OpLoad %ulong %156
+OpStore %165 %250
+OpStore %166 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%251 = OpLoad %ulong %166
+%252 = OpULessThan %bool %251 %ulong_8
+OpStore %158 %252
+%253 = OpLoad %bool %158
+OpLoopMerge %53 %61 None
+OpBranchConditional %253 %52 %53
+%53 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%254 = OpLoad %ushort %83
+%255 = OpUConvert %ulong %254
+OpStore %92 %255
+%256 = OpLoad %uchar %84
+%257 = OpUConvert %ulong %256
+OpStore %93 %257
+%258 = OpLoad %ulong %92
+%259 = OpLoad %ulong %93
+%260 = OpIAdd %ulong %258 %259
+OpStore %94 %260
+%261 = OpLoad %uchar %86
+%262 = OpUConvert %ulong %261
+OpStore %95 %262
+%263 = OpLoad %ulong %94
+%264 = OpLoad %ulong %95
+%265 = OpIAdd %ulong %263 %264
+OpStore %96 %265
+OpBranch %55
+%55 = OpLabel
+%266 = OpLoad %ulong %165
+OpStore %174 %266
+OpStore %175 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%267 = OpLoad %ulong %175
+%268 = OpULessThan %bool %267 %ulong_8
+OpStore %167 %268
+%269 = OpLoad %bool %167
+OpLoopMerge %58 %60 None
+OpBranchConditional %269 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+%270 = OpLoad %ulong %174
+OpReturnValue %270
+%57 = OpLabel
+%271 = OpLoad %ulong %175
+%272 = OpIMul %ulong %271 %ulong_8
+OpStore %168 %272
+%273 = OpLoad %ulong %96
+%274 = OpLoad %ulong %168
+%275 = OpShiftRightLogical %ulong %273 %274
+OpStore %169 %275
+%276 = OpLoad %ulong %169
+%278 = OpBitwiseAnd %ulong %276 %ulong_255
+OpStore %170 %278
+%279 = OpLoad %ulong %174
+%280 = OpLoad %ulong %170
+%281 = OpBitwiseXor %ulong %279 %280
+OpStore %171 %281
+%282 = OpLoad %ulong %171
+%284 = OpIMul %ulong %282 %ulong_1099511628211
+OpStore %172 %284
+%285 = OpLoad %ulong %175
+%286 = OpIAdd %ulong %285 %ulong_1
+OpStore %173 %286
+%287 = OpLoad %ulong %172
+OpStore %174 %287
+%288 = OpLoad %ulong %173
+OpStore %175 %288
+OpBranch %60
+%52 = OpLabel
+%289 = OpLoad %ulong %166
+%290 = OpIMul %ulong %289 %ulong_8
+OpStore %159 %290
+%291 = OpLoad %ulong %91
+%292 = OpLoad %ulong %159
+%293 = OpShiftRightLogical %ulong %291 %292
+OpStore %160 %293
+%294 = OpLoad %ulong %160
+%295 = OpBitwiseAnd %ulong %294 %ulong_255
+OpStore %161 %295
+%296 = OpLoad %ulong %165
+%297 = OpLoad %ulong %161
+%298 = OpBitwiseXor %ulong %296 %297
+OpStore %162 %298
+%299 = OpLoad %ulong %162
+%300 = OpIMul %ulong %299 %ulong_1099511628211
+OpStore %163 %300
+%301 = OpLoad %ulong %166
+%302 = OpIAdd %ulong %301 %ulong_1
+OpStore %164 %302
+%303 = OpLoad %ulong %163
+OpStore %165 %303
+%304 = OpLoad %ulong %164
+OpStore %166 %304
+OpBranch %61
+%47 = OpLabel
+%305 = OpLoad %ulong %157
+%306 = OpIMul %ulong %305 %ulong_8
+OpStore %150 %306
+%307 = OpLoad %ulong %148
+%308 = OpLoad %ulong %150
+%309 = OpShiftRightLogical %ulong %307 %308
+OpStore %151 %309
+%310 = OpLoad %ulong %151
+%311 = OpBitwiseAnd %ulong %310 %ulong_255
+OpStore %152 %311
+%312 = OpLoad %ulong %156
+%313 = OpLoad %ulong %152
+%314 = OpBitwiseXor %ulong %312 %313
+OpStore %153 %314
+%315 = OpLoad %ulong %153
+%316 = OpIMul %ulong %315 %ulong_1099511628211
+OpStore %154 %316
+%317 = OpLoad %ulong %157
+%318 = OpIAdd %ulong %317 %ulong_1
+OpStore %155 %318
+%319 = OpLoad %ulong %154
+OpStore %156 %319
+%320 = OpLoad %ulong %155
+OpStore %157 %320
+OpBranch %62
+%40 = OpLabel
+%321 = OpLoad %ulong %147
+%322 = OpIMul %ulong %321 %ulong_8
+OpStore %140 %322
+%323 = OpLoad %ulong %138
+%324 = OpLoad %ulong %140
+%325 = OpShiftRightLogical %ulong %323 %324
+OpStore %141 %325
+%326 = OpLoad %ulong %141
+%327 = OpBitwiseAnd %ulong %326 %ulong_255
+OpStore %142 %327
+%328 = OpLoad %ulong %146
+%329 = OpLoad %ulong %142
+%330 = OpBitwiseXor %ulong %328 %329
+OpStore %143 %330
+%331 = OpLoad %ulong %143
+%332 = OpIMul %ulong %331 %ulong_1099511628211
+OpStore %144 %332
+%333 = OpLoad %ulong %147
+%334 = OpIAdd %ulong %333 %ulong_1
+OpStore %145 %334
+%335 = OpLoad %ulong %144
+OpStore %146 %335
+%336 = OpLoad %ulong %145
+OpStore %147 %336
+OpBranch %63
+%33 = OpLabel
+%337 = OpLoad %ulong %137
+%338 = OpIMul %ulong %337 %ulong_8
+OpStore %130 %338
+%339 = OpLoad %ulong %128
+%340 = OpLoad %ulong %130
+%341 = OpShiftRightLogical %ulong %339 %340
+OpStore %131 %341
+%342 = OpLoad %ulong %131
+%343 = OpBitwiseAnd %ulong %342 %ulong_255
+OpStore %132 %343
+%344 = OpLoad %ulong %136
+%345 = OpLoad %ulong %132
+%346 = OpBitwiseXor %ulong %344 %345
+OpStore %133 %346
+%347 = OpLoad %ulong %133
+%348 = OpIMul %ulong %347 %ulong_1099511628211
+OpStore %134 %348
+%349 = OpLoad %ulong %137
+%350 = OpIAdd %ulong %349 %ulong_1
+OpStore %135 %350
+%351 = OpLoad %ulong %134
+OpStore %136 %351
+%352 = OpLoad %ulong %135
+OpStore %137 %352
+OpBranch %64
+%26 = OpLabel
+%353 = OpLoad %ulong %127
+%354 = OpIMul %ulong %353 %ulong_8
+OpStore %120 %354
+%355 = OpLoad %ulong %118
+%356 = OpLoad %ulong %120
+%357 = OpShiftRightLogical %ulong %355 %356
+OpStore %121 %357
+%358 = OpLoad %ulong %121
+%359 = OpBitwiseAnd %ulong %358 %ulong_255
+OpStore %122 %359
+%360 = OpLoad %ulong %126
+%361 = OpLoad %ulong %122
+%362 = OpBitwiseXor %ulong %360 %361
+OpStore %123 %362
+%363 = OpLoad %ulong %123
+%364 = OpIMul %ulong %363 %ulong_1099511628211
+OpStore %124 %364
+%365 = OpLoad %ulong %127
+%366 = OpIAdd %ulong %365 %ulong_1
+OpStore %125 %366
+%367 = OpLoad %ulong %124
+OpStore %126 %367
+%368 = OpLoad %ulong %125
+OpStore %127 %368
+OpBranch %65
+%19 = OpLabel
+%369 = OpLoad %ulong %117
+%370 = OpIMul %ulong %369 %ulong_8
+OpStore %110 %370
+%371 = OpLoad %ulong %108
+%372 = OpLoad %ulong %110
+%373 = OpShiftRightLogical %ulong %371 %372
+OpStore %111 %373
+%374 = OpLoad %ulong %111
+%375 = OpBitwiseAnd %ulong %374 %ulong_255
+OpStore %112 %375
+%376 = OpLoad %ulong %116
+%377 = OpLoad %ulong %112
+%378 = OpBitwiseXor %ulong %376 %377
+OpStore %113 %378
+%379 = OpLoad %ulong %113
+%380 = OpIMul %ulong %379 %ulong_1099511628211
+OpStore %114 %380
+%381 = OpLoad %ulong %117
+%382 = OpIAdd %ulong %381 %ulong_1
+OpStore %115 %382
+%383 = OpLoad %ulong %114
+OpStore %116 %383
+%384 = OpLoad %ulong %115
+OpStore %117 %384
+OpBranch %66
+%12 = OpLabel
+%385 = OpLoad %ulong %107
+%386 = OpIMul %ulong %385 %ulong_8
+OpStore %100 %386
+%387 = OpLoad %ulong %97
+%388 = OpLoad %ulong %100
+%389 = OpShiftRightLogical %ulong %387 %388
+OpStore %101 %389
+%390 = OpLoad %ulong %101
+%391 = OpBitwiseAnd %ulong %390 %ulong_255
+OpStore %102 %391
+%392 = OpLoad %ulong %106
+%393 = OpLoad %ulong %102
+%394 = OpBitwiseXor %ulong %392 %393
+OpStore %103 %394
+%395 = OpLoad %ulong %103
+%396 = OpIMul %ulong %395 %ulong_1099511628211
+OpStore %104 %396
+%397 = OpLoad %ulong %107
+%398 = OpIAdd %ulong %397 %ulong_1
+OpStore %105 %398
+%399 = OpLoad %ulong %104
+OpStore %106 %399
+%400 = OpLoad %ulong %105
+OpStore %107 %400
+OpBranch %67
+%60 = OpLabel
+OpBranch %56
+%61 = OpLabel
+OpBranch %51
+%62 = OpLabel
+OpBranch %46
+%63 = OpLabel
+OpBranch %39
+%64 = OpLabel
+OpBranch %32
+%65 = OpLabel
+OpBranch %25
+%66 = OpLabel
+OpBranch %18
+%67 = OpLabel
+OpBranch %11
 OpFunctionEnd

--- a/test/golden/spirv/float/arith_f32.dis
+++ b/test/golden/spirv/float/arith_f32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1969
+; Bound: 1687
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,19 +12,25 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.arith_f32.fold32" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.float.arith_f32.checksum" Export
 %float = OpTypeFloat 32
 %uint = OpTypeInt 32 0
-%9 = OpTypeFunction %float %uint %uint
+%6 = OpTypeFunction %float %uint %uint
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
 %ulong = OpTypeInt 64 0
-%26 = OpTypeFunction %ulong %ulong %float
+%23 = OpTypeFunction %ulong %ulong %float
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
-%uint_4294967295 = OpConstant %uint 4294967295
-%54 = OpTypeFunction %ulong %ulong
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%ulong_4294967295 = OpConstant %ulong 4294967295
+%128 = OpTypeFunction %ulong %ulong
 %uint_1065353216 = OpConstant %uint 1065353216
 %float_1_5 = OpConstant %float 1.5
 %float_0_25 = OpConstant %float 0.25
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
 %float_3 = OpConstant %float 3
 %float_49 = OpConstant %float 49
@@ -41,2933 +47,2477 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.arith_f32.checksum" Export
 %float_5_5 = OpConstant %float 5.5
 %float_7 = OpConstant %float 7
 %float_1048576 = OpConstant %float 1048576
-%1869 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1872 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %float None %9
-%10 = OpFunctionParameter %uint
-%11 = OpFunctionParameter %uint
-%12 = OpLabel
-%14 = OpVariable %_ptr_Function_uint Function
-%15 = OpVariable %_ptr_Function_uint Function
-%16 = OpVariable %_ptr_Function_uint Function
-%18 = OpVariable %_ptr_Function_float Function
-OpStore %14 %10
-OpStore %15 %11
-%19 = OpLoad %uint %14
-%20 = OpLoad %uint %15
-%21 = OpIAdd %uint %19 %20
-OpStore %16 %21
-%22 = OpLoad %uint %16
-%23 = OpBitcast %float %22
-OpStore %18 %23
-%24 = OpLoad %float %18
-OpReturnValue %24
+%1 = OpFunction %float None %6
+%7 = OpFunctionParameter %uint
+%8 = OpFunctionParameter %uint
+%9 = OpLabel
+%11 = OpVariable %_ptr_Function_uint Function
+%12 = OpVariable %_ptr_Function_uint Function
+%13 = OpVariable %_ptr_Function_uint Function
+%15 = OpVariable %_ptr_Function_float Function
+OpStore %11 %7
+OpStore %12 %8
+%16 = OpLoad %uint %11
+%17 = OpLoad %uint %12
+%18 = OpIAdd %uint %16 %17
+OpStore %13 %18
+%19 = OpLoad %uint %13
+%20 = OpBitcast %float %19
+OpStore %15 %20
+%21 = OpLoad %float %15
+OpReturnValue %21
 OpFunctionEnd
-%2 = OpFunction %ulong None %26
-%27 = OpFunctionParameter %ulong
-%28 = OpFunctionParameter %float
+%2 = OpFunction %ulong None %23
+%24 = OpFunctionParameter %ulong
+%25 = OpFunctionParameter %float
+%26 = OpLabel
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_float Function
+%52 = OpVariable %_ptr_Function_bool Function
+%53 = OpVariable %_ptr_Function_uint Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_bool Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_bool Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+OpStore %49 %24
+OpStore %50 %25
+%73 = OpLoad %float %50
+%74 = OpLoad %float %50
+%75 = OpFUnordNotEqual %bool %73 %74
+OpStore %52 %75
+%76 = OpLoad %bool %52
+OpSelectionMerge %46 None
+OpBranchConditional %76 %27 %28
+%28 = OpLabel
+OpBranch %29
 %29 = OpLabel
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_float Function
-%39 = OpVariable %_ptr_Function_bool Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-OpStore %36 %27
-OpStore %37 %28
-%42 = OpLoad %float %37
-%43 = OpLoad %float %37
-%44 = OpFUnordNotEqual %bool %42 %43
-OpStore %39 %44
-%45 = OpLoad %bool %39
-OpSelectionMerge %33 None
-OpBranchConditional %45 %30 %31
-%31 = OpLabel
 OpBranch %32
 %32 = OpLabel
-%46 = OpLoad %ulong %36
-%47 = OpLoad %float %37
-%48 = OpFunctionCall %ulong %6 %46 %47
-OpStore %41 %48
-%49 = OpLoad %ulong %41
-OpReturnValue %49
-%30 = OpLabel
-%50 = OpLoad %ulong %36
-%52 = OpFunctionCall %ulong %5 %50 %uint_4294967295
-OpStore %40 %52
-%53 = OpLoad %ulong %40
-OpReturnValue %53
+%77 = OpLoad %float %50
+%78 = OpBitcast %uint %77
+OpStore %53 %78
+%79 = OpLoad %uint %53
+%80 = OpUConvert %ulong %79
+OpStore %54 %80
+OpBranch %39
+%39 = OpLabel
+%81 = OpLoad %ulong %49
+OpStore %71 %81
+OpStore %72 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%83 = OpLoad %ulong %72
+%85 = OpULessThan %bool %83 %ulong_8
+OpStore %64 %85
+%86 = OpLoad %bool %64
+OpLoopMerge %42 %44 None
+OpBranchConditional %86 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %33
 %33 = OpLabel
+%87 = OpLoad %ulong %71
+OpReturnValue %87
+%41 = OpLabel
+%88 = OpLoad %ulong %72
+%89 = OpIMul %ulong %88 %ulong_8
+OpStore %65 %89
+%90 = OpLoad %ulong %54
+%91 = OpLoad %ulong %65
+%92 = OpShiftRightLogical %ulong %90 %91
+OpStore %66 %92
+%93 = OpLoad %ulong %66
+%95 = OpBitwiseAnd %ulong %93 %ulong_255
+OpStore %67 %95
+%96 = OpLoad %ulong %71
+%97 = OpLoad %ulong %67
+%98 = OpBitwiseXor %ulong %96 %97
+OpStore %68 %98
+%99 = OpLoad %ulong %68
+%101 = OpIMul %ulong %99 %ulong_1099511628211
+OpStore %69 %101
+%102 = OpLoad %ulong %72
+%104 = OpIAdd %ulong %102 %ulong_1
+OpStore %70 %104
+%105 = OpLoad %ulong %69
+OpStore %71 %105
+%106 = OpLoad %ulong %70
+OpStore %72 %106
+OpBranch %44
+%27 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%107 = OpLoad %ulong %49
+OpStore %62 %107
+OpStore %63 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%108 = OpLoad %ulong %63
+%109 = OpULessThan %bool %108 %ulong_8
+OpStore %55 %109
+%110 = OpLoad %bool %55
+OpLoopMerge %37 %45 None
+OpBranchConditional %110 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%111 = OpLoad %ulong %62
+OpReturnValue %111
+%36 = OpLabel
+%112 = OpLoad %ulong %63
+%113 = OpIMul %ulong %112 %ulong_8
+OpStore %56 %113
+%115 = OpLoad %ulong %56
+%116 = OpShiftRightLogical %ulong %ulong_4294967295 %115
+OpStore %57 %116
+%117 = OpLoad %ulong %57
+%118 = OpBitwiseAnd %ulong %117 %ulong_255
+OpStore %58 %118
+%119 = OpLoad %ulong %62
+%120 = OpLoad %ulong %58
+%121 = OpBitwiseXor %ulong %119 %120
+OpStore %59 %121
+%122 = OpLoad %ulong %59
+%123 = OpIMul %ulong %122 %ulong_1099511628211
+OpStore %60 %123
+%124 = OpLoad %ulong %63
+%125 = OpIAdd %ulong %124 %ulong_1
+OpStore %61 %125
+%126 = OpLoad %ulong %60
+OpStore %62 %126
+%127 = OpLoad %ulong %61
+OpStore %63 %127
+OpBranch %45
+%44 = OpLabel
+OpBranch %40
+%45 = OpLabel
+OpBranch %35
+%46 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%3 = OpFunction %ulong None %54
-%55 = OpFunctionParameter %ulong
-%56 = OpLabel
-%381 = OpVariable %_ptr_Function_ulong Function
+%3 = OpFunction %ulong None %128
+%129 = OpFunctionParameter %ulong
+%130 = OpLabel
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_uint Function
+%379 = OpVariable %_ptr_Function_float Function
+%380 = OpVariable %_ptr_Function_float Function
+%381 = OpVariable %_ptr_Function_float Function
 %382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_uint Function
-%384 = OpVariable %_ptr_Function_float Function
+%383 = OpVariable %_ptr_Function_float Function
+%384 = OpVariable %_ptr_Function_ulong Function
 %385 = OpVariable %_ptr_Function_float Function
-%386 = OpVariable %_ptr_Function_float Function
+%386 = OpVariable %_ptr_Function_ulong Function
 %387 = OpVariable %_ptr_Function_float Function
-%388 = OpVariable %_ptr_Function_float Function
+%388 = OpVariable %_ptr_Function_ulong Function
 %389 = OpVariable %_ptr_Function_float Function
-%390 = OpVariable %_ptr_Function_float Function
-%391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_float Function
-%393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_float Function
-%395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_float Function
-%397 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_float Function
-%399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_float Function
-%401 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_float Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_float Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_float Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%397 = OpVariable %_ptr_Function_float Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_float Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_float Function
 %402 = OpVariable %_ptr_Function_float Function
-%403 = OpVariable %_ptr_Function_float Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_float Function
-%406 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_float Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_float Function
 %407 = OpVariable %_ptr_Function_float Function
 %408 = OpVariable %_ptr_Function_float Function
-%409 = OpVariable %_ptr_Function_float Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_float Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_float Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_float Function
-%416 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_float Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_float Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_float Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_float Function
 %417 = OpVariable %_ptr_Function_float Function
-%418 = OpVariable %_ptr_Function_float Function
-%419 = OpVariable %_ptr_Function_ulong Function
-%420 = OpVariable %_ptr_Function_float Function
-%421 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_float Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_float Function
 %422 = OpVariable %_ptr_Function_float Function
-%423 = OpVariable %_ptr_Function_float Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_float Function
-%426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_float Function
-%428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_float Function
-%430 = OpVariable %_ptr_Function_bool Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_float Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_float Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_float Function
+%429 = OpVariable %_ptr_Function_bool Function
+%430 = OpVariable %_ptr_Function_float Function
 %431 = OpVariable %_ptr_Function_float Function
-%432 = OpVariable %_ptr_Function_float Function
+%432 = OpVariable %_ptr_Function_ulong Function
 %433 = OpVariable %_ptr_Function_uint Function
-%434 = OpVariable %_ptr_Function_float Function
+%434 = OpVariable %_ptr_Function_ulong Function
 %435 = OpVariable %_ptr_Function_float Function
-%436 = OpVariable %_ptr_Function_float Function
-%437 = OpVariable %_ptr_Function_ulong Function
-%438 = OpVariable %_ptr_Function_float Function
-%439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_float Function
-%441 = OpVariable %_ptr_Function_ulong Function
-%442 = OpVariable %_ptr_Function_float Function
-%443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_float Function
-%445 = OpVariable %_ptr_Function_ulong Function
-%446 = OpVariable %_ptr_Function_float Function
-%447 = OpVariable %_ptr_Function_ulong Function
-%448 = OpVariable %_ptr_Function_float Function
-%449 = OpVariable %_ptr_Function_ulong Function
-%450 = OpVariable %_ptr_Function_float Function
-%451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_float Function
-%453 = OpVariable %_ptr_Function_ulong Function
-%454 = OpVariable %_ptr_Function_float Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_float Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_float Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_float Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_float Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_float Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_float Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_float Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_float Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_float Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_float Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_float Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_float Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_float Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_float Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_float Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_float Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_float Function
+%462 = OpVariable %_ptr_Function_ulong Function
 %463 = OpVariable %_ptr_Function_float Function
-%464 = OpVariable %_ptr_Function_bool Function
+%464 = OpVariable %_ptr_Function_ulong Function
 %465 = OpVariable %_ptr_Function_float Function
-%466 = OpVariable %_ptr_Function_bool Function
+%466 = OpVariable %_ptr_Function_float Function
 %467 = OpVariable %_ptr_Function_bool Function
-%468 = OpVariable %_ptr_Function_bool Function
+%468 = OpVariable %_ptr_Function_float Function
 %469 = OpVariable %_ptr_Function_bool Function
-%470 = OpVariable %_ptr_Function_float Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_float Function
+%470 = OpVariable %_ptr_Function_bool Function
+%471 = OpVariable %_ptr_Function_bool Function
+%472 = OpVariable %_ptr_Function_bool Function
 %473 = OpVariable %_ptr_Function_float Function
-%474 = OpVariable %_ptr_Function_float Function
-%475 = OpVariable %_ptr_Function_bool Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_float Function
 %476 = OpVariable %_ptr_Function_float Function
 %477 = OpVariable %_ptr_Function_float Function
 %478 = OpVariable %_ptr_Function_bool Function
 %479 = OpVariable %_ptr_Function_float Function
 %480 = OpVariable %_ptr_Function_float Function
-%481 = OpVariable %_ptr_Function_float Function
+%481 = OpVariable %_ptr_Function_bool Function
 %482 = OpVariable %_ptr_Function_float Function
-%483 = OpVariable %_ptr_Function_bool Function
+%483 = OpVariable %_ptr_Function_float Function
 %484 = OpVariable %_ptr_Function_float Function
 %485 = OpVariable %_ptr_Function_float Function
-%486 = OpVariable %_ptr_Function_float Function
-%487 = OpVariable %_ptr_Function_bool Function
-%488 = OpVariable %_ptr_Function_bool Function
+%486 = OpVariable %_ptr_Function_bool Function
+%487 = OpVariable %_ptr_Function_float Function
+%488 = OpVariable %_ptr_Function_float Function
 %489 = OpVariable %_ptr_Function_float Function
-%490 = OpVariable %_ptr_Function_float Function
-%491 = OpVariable %_ptr_Function_float Function
+%490 = OpVariable %_ptr_Function_bool Function
+%491 = OpVariable %_ptr_Function_bool Function
 %492 = OpVariable %_ptr_Function_float Function
 %493 = OpVariable %_ptr_Function_float Function
 %494 = OpVariable %_ptr_Function_float Function
 %495 = OpVariable %_ptr_Function_float Function
-%496 = OpVariable %_ptr_Function_bool Function
+%496 = OpVariable %_ptr_Function_float Function
 %497 = OpVariable %_ptr_Function_float Function
-%498 = OpVariable %_ptr_Function_bool Function
-%499 = OpVariable %_ptr_Function_bool Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_float Function
 %500 = OpVariable %_ptr_Function_bool Function
-%501 = OpVariable %_ptr_Function_bool Function
-%502 = OpVariable %_ptr_Function_float Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_float Function
-%505 = OpVariable %_ptr_Function_float Function
+%501 = OpVariable %_ptr_Function_float Function
+%502 = OpVariable %_ptr_Function_bool Function
+%503 = OpVariable %_ptr_Function_bool Function
+%504 = OpVariable %_ptr_Function_bool Function
+%505 = OpVariable %_ptr_Function_bool Function
 %506 = OpVariable %_ptr_Function_float Function
-%507 = OpVariable %_ptr_Function_bool Function
+%507 = OpVariable %_ptr_Function_ulong Function
 %508 = OpVariable %_ptr_Function_float Function
 %509 = OpVariable %_ptr_Function_float Function
-%510 = OpVariable %_ptr_Function_bool Function
-%511 = OpVariable %_ptr_Function_float Function
+%510 = OpVariable %_ptr_Function_float Function
+%511 = OpVariable %_ptr_Function_bool Function
 %512 = OpVariable %_ptr_Function_float Function
 %513 = OpVariable %_ptr_Function_float Function
-%514 = OpVariable %_ptr_Function_float Function
-%515 = OpVariable %_ptr_Function_bool Function
+%514 = OpVariable %_ptr_Function_bool Function
+%515 = OpVariable %_ptr_Function_float Function
 %516 = OpVariable %_ptr_Function_float Function
 %517 = OpVariable %_ptr_Function_float Function
 %518 = OpVariable %_ptr_Function_float Function
 %519 = OpVariable %_ptr_Function_bool Function
-%520 = OpVariable %_ptr_Function_bool Function
+%520 = OpVariable %_ptr_Function_float Function
 %521 = OpVariable %_ptr_Function_float Function
 %522 = OpVariable %_ptr_Function_float Function
-%523 = OpVariable %_ptr_Function_float Function
-%524 = OpVariable %_ptr_Function_float Function
+%523 = OpVariable %_ptr_Function_bool Function
+%524 = OpVariable %_ptr_Function_bool Function
 %525 = OpVariable %_ptr_Function_float Function
 %526 = OpVariable %_ptr_Function_float Function
 %527 = OpVariable %_ptr_Function_float Function
-%528 = OpVariable %_ptr_Function_bool Function
+%528 = OpVariable %_ptr_Function_float Function
 %529 = OpVariable %_ptr_Function_float Function
-%530 = OpVariable %_ptr_Function_bool Function
-%531 = OpVariable %_ptr_Function_bool Function
-%532 = OpVariable %_ptr_Function_bool Function
+%530 = OpVariable %_ptr_Function_float Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_float Function
 %533 = OpVariable %_ptr_Function_bool Function
 %534 = OpVariable %_ptr_Function_float Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_float Function
-%537 = OpVariable %_ptr_Function_float Function
-%538 = OpVariable %_ptr_Function_float Function
-%539 = OpVariable %_ptr_Function_bool Function
-%540 = OpVariable %_ptr_Function_float Function
+%535 = OpVariable %_ptr_Function_bool Function
+%536 = OpVariable %_ptr_Function_bool Function
+%537 = OpVariable %_ptr_Function_bool Function
+%538 = OpVariable %_ptr_Function_bool Function
+%539 = OpVariable %_ptr_Function_float Function
+%540 = OpVariable %_ptr_Function_ulong Function
 %541 = OpVariable %_ptr_Function_float Function
-%542 = OpVariable %_ptr_Function_bool Function
+%542 = OpVariable %_ptr_Function_float Function
 %543 = OpVariable %_ptr_Function_float Function
-%544 = OpVariable %_ptr_Function_float Function
+%544 = OpVariable %_ptr_Function_bool Function
 %545 = OpVariable %_ptr_Function_float Function
 %546 = OpVariable %_ptr_Function_float Function
 %547 = OpVariable %_ptr_Function_bool Function
 %548 = OpVariable %_ptr_Function_float Function
 %549 = OpVariable %_ptr_Function_float Function
 %550 = OpVariable %_ptr_Function_float Function
-%551 = OpVariable %_ptr_Function_bool Function
+%551 = OpVariable %_ptr_Function_float Function
 %552 = OpVariable %_ptr_Function_bool Function
 %553 = OpVariable %_ptr_Function_float Function
 %554 = OpVariable %_ptr_Function_float Function
 %555 = OpVariable %_ptr_Function_float Function
-%556 = OpVariable %_ptr_Function_float Function
-%557 = OpVariable %_ptr_Function_float Function
+%556 = OpVariable %_ptr_Function_bool Function
+%557 = OpVariable %_ptr_Function_bool Function
 %558 = OpVariable %_ptr_Function_float Function
 %559 = OpVariable %_ptr_Function_float Function
 %560 = OpVariable %_ptr_Function_float Function
-%561 = OpVariable %_ptr_Function_bool Function
+%561 = OpVariable %_ptr_Function_float Function
 %562 = OpVariable %_ptr_Function_float Function
-%563 = OpVariable %_ptr_Function_bool Function
-%564 = OpVariable %_ptr_Function_bool Function
-%565 = OpVariable %_ptr_Function_bool Function
-%566 = OpVariable %_ptr_Function_bool Function
-%567 = OpVariable %_ptr_Function_float Function
-%568 = OpVariable %_ptr_Function_ulong Function
-%569 = OpVariable %_ptr_Function_float Function
-%570 = OpVariable %_ptr_Function_float Function
-%571 = OpVariable %_ptr_Function_float Function
+%563 = OpVariable %_ptr_Function_float Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_float Function
+%566 = OpVariable %_ptr_Function_float Function
+%567 = OpVariable %_ptr_Function_bool Function
+%568 = OpVariable %_ptr_Function_float Function
+%569 = OpVariable %_ptr_Function_bool Function
+%570 = OpVariable %_ptr_Function_bool Function
+%571 = OpVariable %_ptr_Function_bool Function
 %572 = OpVariable %_ptr_Function_bool Function
 %573 = OpVariable %_ptr_Function_float Function
-%574 = OpVariable %_ptr_Function_float Function
-%575 = OpVariable %_ptr_Function_bool Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_float Function
 %576 = OpVariable %_ptr_Function_float Function
 %577 = OpVariable %_ptr_Function_float Function
-%578 = OpVariable %_ptr_Function_float Function
+%578 = OpVariable %_ptr_Function_bool Function
 %579 = OpVariable %_ptr_Function_float Function
-%580 = OpVariable %_ptr_Function_bool Function
-%581 = OpVariable %_ptr_Function_float Function
+%580 = OpVariable %_ptr_Function_float Function
+%581 = OpVariable %_ptr_Function_bool Function
 %582 = OpVariable %_ptr_Function_float Function
 %583 = OpVariable %_ptr_Function_float Function
-%584 = OpVariable %_ptr_Function_bool Function
-%585 = OpVariable %_ptr_Function_bool Function
-%586 = OpVariable %_ptr_Function_float Function
+%584 = OpVariable %_ptr_Function_float Function
+%585 = OpVariable %_ptr_Function_float Function
+%586 = OpVariable %_ptr_Function_bool Function
 %587 = OpVariable %_ptr_Function_float Function
 %588 = OpVariable %_ptr_Function_float Function
 %589 = OpVariable %_ptr_Function_float Function
-%590 = OpVariable %_ptr_Function_float Function
-%591 = OpVariable %_ptr_Function_float Function
+%590 = OpVariable %_ptr_Function_bool Function
+%591 = OpVariable %_ptr_Function_bool Function
 %592 = OpVariable %_ptr_Function_float Function
-%593 = OpVariable %_ptr_Function_bool Function
+%593 = OpVariable %_ptr_Function_float Function
 %594 = OpVariable %_ptr_Function_float Function
-%595 = OpVariable %_ptr_Function_bool Function
-%596 = OpVariable %_ptr_Function_bool Function
-%597 = OpVariable %_ptr_Function_bool Function
-%598 = OpVariable %_ptr_Function_bool Function
+%595 = OpVariable %_ptr_Function_float Function
+%596 = OpVariable %_ptr_Function_float Function
+%597 = OpVariable %_ptr_Function_float Function
+%598 = OpVariable %_ptr_Function_ulong Function
 %599 = OpVariable %_ptr_Function_float Function
-%600 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_bool Function
 %601 = OpVariable %_ptr_Function_float Function
-%602 = OpVariable %_ptr_Function_float Function
-%603 = OpVariable %_ptr_Function_float Function
+%602 = OpVariable %_ptr_Function_bool Function
+%603 = OpVariable %_ptr_Function_bool Function
 %604 = OpVariable %_ptr_Function_bool Function
-%605 = OpVariable %_ptr_Function_float Function
+%605 = OpVariable %_ptr_Function_bool Function
 %606 = OpVariable %_ptr_Function_float Function
-%607 = OpVariable %_ptr_Function_bool Function
+%607 = OpVariable %_ptr_Function_ulong Function
 %608 = OpVariable %_ptr_Function_float Function
 %609 = OpVariable %_ptr_Function_float Function
 %610 = OpVariable %_ptr_Function_float Function
-%611 = OpVariable %_ptr_Function_float Function
-%612 = OpVariable %_ptr_Function_bool Function
+%611 = OpVariable %_ptr_Function_bool Function
+%612 = OpVariable %_ptr_Function_float Function
 %613 = OpVariable %_ptr_Function_float Function
-%614 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function_bool Function
 %615 = OpVariable %_ptr_Function_float Function
-%616 = OpVariable %_ptr_Function_bool Function
-%617 = OpVariable %_ptr_Function_bool Function
+%616 = OpVariable %_ptr_Function_float Function
+%617 = OpVariable %_ptr_Function_float Function
 %618 = OpVariable %_ptr_Function_float Function
-%619 = OpVariable %_ptr_Function_float Function
+%619 = OpVariable %_ptr_Function_bool Function
 %620 = OpVariable %_ptr_Function_float Function
 %621 = OpVariable %_ptr_Function_float Function
 %622 = OpVariable %_ptr_Function_float Function
-%623 = OpVariable %_ptr_Function_float Function
+%623 = OpVariable %_ptr_Function_bool Function
 %624 = OpVariable %_ptr_Function_bool Function
 %625 = OpVariable %_ptr_Function_float Function
-%626 = OpVariable %_ptr_Function_bool Function
-%627 = OpVariable %_ptr_Function_bool Function
-%628 = OpVariable %_ptr_Function_bool Function
-%629 = OpVariable %_ptr_Function_bool Function
+%626 = OpVariable %_ptr_Function_float Function
+%627 = OpVariable %_ptr_Function_float Function
+%628 = OpVariable %_ptr_Function_float Function
+%629 = OpVariable %_ptr_Function_float Function
 %630 = OpVariable %_ptr_Function_float Function
 %631 = OpVariable %_ptr_Function_ulong Function
-%632 = OpVariable %_ptr_Function_float Function
+%632 = OpVariable %_ptr_Function_bool Function
 %633 = OpVariable %_ptr_Function_float Function
-%634 = OpVariable %_ptr_Function_float Function
+%634 = OpVariable %_ptr_Function_bool Function
 %635 = OpVariable %_ptr_Function_bool Function
-%636 = OpVariable %_ptr_Function_float Function
-%637 = OpVariable %_ptr_Function_float Function
-%638 = OpVariable %_ptr_Function_bool Function
-%639 = OpVariable %_ptr_Function_float Function
+%636 = OpVariable %_ptr_Function_bool Function
+%637 = OpVariable %_ptr_Function_bool Function
+%638 = OpVariable %_ptr_Function_float Function
+%639 = OpVariable %_ptr_Function_ulong Function
 %640 = OpVariable %_ptr_Function_float Function
 %641 = OpVariable %_ptr_Function_float Function
 %642 = OpVariable %_ptr_Function_float Function
 %643 = OpVariable %_ptr_Function_bool Function
 %644 = OpVariable %_ptr_Function_float Function
 %645 = OpVariable %_ptr_Function_float Function
-%646 = OpVariable %_ptr_Function_float Function
-%647 = OpVariable %_ptr_Function_bool Function
-%648 = OpVariable %_ptr_Function_bool Function
+%646 = OpVariable %_ptr_Function_bool Function
+%647 = OpVariable %_ptr_Function_float Function
+%648 = OpVariable %_ptr_Function_float Function
 %649 = OpVariable %_ptr_Function_float Function
 %650 = OpVariable %_ptr_Function_float Function
-%651 = OpVariable %_ptr_Function_float Function
+%651 = OpVariable %_ptr_Function_bool Function
 %652 = OpVariable %_ptr_Function_float Function
 %653 = OpVariable %_ptr_Function_float Function
 %654 = OpVariable %_ptr_Function_float Function
 %655 = OpVariable %_ptr_Function_bool Function
-%656 = OpVariable %_ptr_Function_float Function
-%657 = OpVariable %_ptr_Function_bool Function
-%658 = OpVariable %_ptr_Function_bool Function
-%659 = OpVariable %_ptr_Function_bool Function
-%660 = OpVariable %_ptr_Function_bool Function
+%656 = OpVariable %_ptr_Function_bool Function
+%657 = OpVariable %_ptr_Function_float Function
+%658 = OpVariable %_ptr_Function_float Function
+%659 = OpVariable %_ptr_Function_float Function
+%660 = OpVariable %_ptr_Function_float Function
 %661 = OpVariable %_ptr_Function_float Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_float Function
-%664 = OpVariable %_ptr_Function_float Function
+%662 = OpVariable %_ptr_Function_float Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_bool Function
 %665 = OpVariable %_ptr_Function_float Function
 %666 = OpVariable %_ptr_Function_bool Function
-%667 = OpVariable %_ptr_Function_float Function
-%668 = OpVariable %_ptr_Function_float Function
+%667 = OpVariable %_ptr_Function_bool Function
+%668 = OpVariable %_ptr_Function_bool Function
 %669 = OpVariable %_ptr_Function_bool Function
 %670 = OpVariable %_ptr_Function_float Function
-%671 = OpVariable %_ptr_Function_float Function
+%671 = OpVariable %_ptr_Function_ulong Function
 %672 = OpVariable %_ptr_Function_float Function
 %673 = OpVariable %_ptr_Function_float Function
-%674 = OpVariable %_ptr_Function_bool Function
-%675 = OpVariable %_ptr_Function_float Function
+%674 = OpVariable %_ptr_Function_float Function
+%675 = OpVariable %_ptr_Function_bool Function
 %676 = OpVariable %_ptr_Function_float Function
 %677 = OpVariable %_ptr_Function_float Function
 %678 = OpVariable %_ptr_Function_bool Function
-%679 = OpVariable %_ptr_Function_bool Function
+%679 = OpVariable %_ptr_Function_float Function
 %680 = OpVariable %_ptr_Function_float Function
 %681 = OpVariable %_ptr_Function_float Function
 %682 = OpVariable %_ptr_Function_float Function
-%683 = OpVariable %_ptr_Function_float Function
+%683 = OpVariable %_ptr_Function_bool Function
 %684 = OpVariable %_ptr_Function_float Function
 %685 = OpVariable %_ptr_Function_float Function
 %686 = OpVariable %_ptr_Function_float Function
 %687 = OpVariable %_ptr_Function_bool Function
-%688 = OpVariable %_ptr_Function_float Function
-%689 = OpVariable %_ptr_Function_bool Function
-%690 = OpVariable %_ptr_Function_bool Function
-%691 = OpVariable %_ptr_Function_bool Function
-%692 = OpVariable %_ptr_Function_bool Function
+%688 = OpVariable %_ptr_Function_bool Function
+%689 = OpVariable %_ptr_Function_float Function
+%690 = OpVariable %_ptr_Function_float Function
+%691 = OpVariable %_ptr_Function_float Function
+%692 = OpVariable %_ptr_Function_float Function
 %693 = OpVariable %_ptr_Function_float Function
-%694 = OpVariable %_ptr_Function_ulong Function
-%695 = OpVariable %_ptr_Function_float Function
+%694 = OpVariable %_ptr_Function_float Function
+%695 = OpVariable %_ptr_Function_ulong Function
 %696 = OpVariable %_ptr_Function_float Function
-%697 = OpVariable %_ptr_Function_float Function
-%698 = OpVariable %_ptr_Function_bool Function
-%699 = OpVariable %_ptr_Function_float Function
-%700 = OpVariable %_ptr_Function_float Function
+%697 = OpVariable %_ptr_Function_bool Function
+%698 = OpVariable %_ptr_Function_float Function
+%699 = OpVariable %_ptr_Function_bool Function
+%700 = OpVariable %_ptr_Function_bool Function
 %701 = OpVariable %_ptr_Function_bool Function
-%702 = OpVariable %_ptr_Function_float Function
+%702 = OpVariable %_ptr_Function_bool Function
 %703 = OpVariable %_ptr_Function_float Function
-%704 = OpVariable %_ptr_Function_float Function
+%704 = OpVariable %_ptr_Function_ulong Function
 %705 = OpVariable %_ptr_Function_float Function
-%706 = OpVariable %_ptr_Function_bool Function
+%706 = OpVariable %_ptr_Function_float Function
 %707 = OpVariable %_ptr_Function_float Function
-%708 = OpVariable %_ptr_Function_float Function
+%708 = OpVariable %_ptr_Function_bool Function
 %709 = OpVariable %_ptr_Function_float Function
-%710 = OpVariable %_ptr_Function_bool Function
+%710 = OpVariable %_ptr_Function_float Function
 %711 = OpVariable %_ptr_Function_bool Function
 %712 = OpVariable %_ptr_Function_float Function
 %713 = OpVariable %_ptr_Function_float Function
 %714 = OpVariable %_ptr_Function_float Function
 %715 = OpVariable %_ptr_Function_float Function
-%716 = OpVariable %_ptr_Function_float Function
+%716 = OpVariable %_ptr_Function_bool Function
 %717 = OpVariable %_ptr_Function_float Function
-%718 = OpVariable %_ptr_Function_ulong Function
+%718 = OpVariable %_ptr_Function_float Function
 %719 = OpVariable %_ptr_Function_float Function
-%720 = OpVariable %_ptr_Function_uint Function
-%721 = OpVariable %_ptr_Function_uint Function
+%720 = OpVariable %_ptr_Function_bool Function
+%721 = OpVariable %_ptr_Function_bool Function
 %722 = OpVariable %_ptr_Function_float Function
-%723 = OpVariable %_ptr_Function_bool Function
-%724 = OpVariable %_ptr_Function_ulong Function
-%725 = OpVariable %_ptr_Function_ulong Function
-%726 = OpVariable %_ptr_Function_ulong Function
-%727 = OpVariable %_ptr_Function_uint Function
-%728 = OpVariable %_ptr_Function_float Function
-%729 = OpVariable %_ptr_Function_bool Function
-%730 = OpVariable %_ptr_Function_ulong Function
-%731 = OpVariable %_ptr_Function_ulong Function
-%732 = OpVariable %_ptr_Function_ulong Function
-%733 = OpVariable %_ptr_Function_bool Function
-%734 = OpVariable %_ptr_Function_ulong Function
-%735 = OpVariable %_ptr_Function_ulong Function
-%736 = OpVariable %_ptr_Function_ulong Function
-%737 = OpVariable %_ptr_Function_bool Function
-%738 = OpVariable %_ptr_Function_ulong Function
-%739 = OpVariable %_ptr_Function_ulong Function
-%740 = OpVariable %_ptr_Function_ulong Function
-%741 = OpVariable %_ptr_Function_bool Function
-%742 = OpVariable %_ptr_Function_ulong Function
-%743 = OpVariable %_ptr_Function_ulong Function
-%744 = OpVariable %_ptr_Function_ulong Function
-%745 = OpVariable %_ptr_Function_bool Function
-%746 = OpVariable %_ptr_Function_ulong Function
-%747 = OpVariable %_ptr_Function_ulong Function
-%748 = OpVariable %_ptr_Function_ulong Function
-%749 = OpVariable %_ptr_Function_bool Function
-%750 = OpVariable %_ptr_Function_ulong Function
-%751 = OpVariable %_ptr_Function_ulong Function
-%752 = OpVariable %_ptr_Function_ulong Function
-%753 = OpVariable %_ptr_Function_bool Function
-%754 = OpVariable %_ptr_Function_ulong Function
-%755 = OpVariable %_ptr_Function_ulong Function
-%756 = OpVariable %_ptr_Function_ulong Function
-%757 = OpVariable %_ptr_Function_bool Function
-%758 = OpVariable %_ptr_Function_ulong Function
-%759 = OpVariable %_ptr_Function_ulong Function
-%760 = OpVariable %_ptr_Function_ulong Function
-%761 = OpVariable %_ptr_Function_bool Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_ulong Function
-%764 = OpVariable %_ptr_Function_ulong Function
-%765 = OpVariable %_ptr_Function_bool Function
-%766 = OpVariable %_ptr_Function_ulong Function
-%767 = OpVariable %_ptr_Function_ulong Function
-%768 = OpVariable %_ptr_Function_ulong Function
-%769 = OpVariable %_ptr_Function_bool Function
-%770 = OpVariable %_ptr_Function_ulong Function
-%771 = OpVariable %_ptr_Function_ulong Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_bool Function
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_ulong Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_bool Function
-%778 = OpVariable %_ptr_Function_ulong Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_bool Function
-%782 = OpVariable %_ptr_Function_ulong Function
-%783 = OpVariable %_ptr_Function_ulong Function
-%784 = OpVariable %_ptr_Function_ulong Function
-%785 = OpVariable %_ptr_Function_bool Function
-%786 = OpVariable %_ptr_Function_ulong Function
-%787 = OpVariable %_ptr_Function_ulong Function
-%788 = OpVariable %_ptr_Function_ulong Function
-%789 = OpVariable %_ptr_Function_uint Function
-%790 = OpVariable %_ptr_Function_float Function
-%791 = OpVariable %_ptr_Function_uint Function
-%792 = OpVariable %_ptr_Function_float Function
-OpStore %381 %55
-%793 = OpFunctionCall %ulong %4
-OpStore %382 %793
-%794 = OpLoad %ulong %381
-%795 = OpUConvert %uint %794
-OpStore %383 %795
-OpBranch %260
-%260 = OpLabel
-%797 = OpLoad %uint %383
-%798 = OpIAdd %uint %uint_1065353216 %797
-OpStore %721 %798
-%799 = OpLoad %uint %721
-%800 = OpBitcast %float %799
-OpStore %722 %800
-OpBranch %261
-%261 = OpLabel
-%802 = OpLoad %float %722
-%803 = OpFMul %float %float_1_5 %802
-OpStore %384 %803
-%805 = OpLoad %float %722
-%806 = OpFMul %float %float_0_25 %805
-OpStore %385 %806
-%807 = OpLoad %float %384
-%808 = OpLoad %float %385
-%809 = OpFAdd %float %807 %808
-OpStore %386 %809
-OpBranch %309
-%309 = OpLabel
-%810 = OpLoad %float %386
-%811 = OpLoad %float %386
-%812 = OpFUnordNotEqual %bool %810 %811
-OpStore %761 %812
-%813 = OpLoad %bool %761
-OpSelectionMerge %313 None
-OpBranchConditional %813 %310 %311
-%311 = OpLabel
-OpBranch %312
-%312 = OpLabel
-%814 = OpLoad %ulong %382
-%815 = OpLoad %float %386
-%816 = OpFunctionCall %ulong %6 %814 %815
-OpStore %763 %816
-%817 = OpLoad %ulong %763
-OpStore %764 %817
-OpBranch %313
-%310 = OpLabel
-%818 = OpLoad %ulong %382
-%819 = OpFunctionCall %ulong %5 %818 %uint_4294967295
-OpStore %762 %819
-%820 = OpLoad %ulong %762
-OpStore %764 %820
-OpBranch %313
-%313 = OpLabel
-%821 = OpLoad %float %384
-%822 = OpLoad %float %385
-%823 = OpFSub %float %821 %822
-OpStore %387 %823
-OpBranch %319
-%319 = OpLabel
-%824 = OpLoad %float %387
-%825 = OpLoad %float %387
-%826 = OpFUnordNotEqual %bool %824 %825
-OpStore %769 %826
-%827 = OpLoad %bool %769
-OpSelectionMerge %323 None
-OpBranchConditional %827 %320 %321
-%321 = OpLabel
-OpBranch %322
-%322 = OpLabel
-%828 = OpLoad %ulong %764
-%829 = OpLoad %float %387
-%830 = OpFunctionCall %ulong %6 %828 %829
-OpStore %771 %830
-%831 = OpLoad %ulong %771
-OpStore %772 %831
-OpBranch %323
-%320 = OpLabel
-%832 = OpLoad %ulong %764
-%833 = OpFunctionCall %ulong %5 %832 %uint_4294967295
-OpStore %770 %833
-%834 = OpLoad %ulong %770
-OpStore %772 %834
-OpBranch %323
-%323 = OpLabel
-%835 = OpLoad %float %385
-%836 = OpLoad %float %384
-%837 = OpFSub %float %835 %836
-OpStore %388 %837
-OpBranch %329
-%329 = OpLabel
-%838 = OpLoad %float %388
-%839 = OpLoad %float %388
-%840 = OpFUnordNotEqual %bool %838 %839
-OpStore %777 %840
-%841 = OpLoad %bool %777
-OpSelectionMerge %333 None
-OpBranchConditional %841 %330 %331
-%331 = OpLabel
-OpBranch %332
-%332 = OpLabel
-%842 = OpLoad %ulong %772
-%843 = OpLoad %float %388
-%844 = OpFunctionCall %ulong %6 %842 %843
-OpStore %779 %844
-%845 = OpLoad %ulong %779
-OpStore %780 %845
-OpBranch %333
-%330 = OpLabel
-%846 = OpLoad %ulong %772
-%847 = OpFunctionCall %ulong %5 %846 %uint_4294967295
-OpStore %778 %847
-%848 = OpLoad %ulong %778
-OpStore %780 %848
-OpBranch %333
-%333 = OpLabel
-%849 = OpLoad %float %384
-%850 = OpLoad %float %385
-%851 = OpFMul %float %849 %850
-OpStore %389 %851
+%723 = OpVariable %_ptr_Function_float Function
+%724 = OpVariable %_ptr_Function_float Function
+%725 = OpVariable %_ptr_Function_float Function
+%726 = OpVariable %_ptr_Function_float Function
+%727 = OpVariable %_ptr_Function_float Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_float Function
+%731 = OpVariable %_ptr_Function_uint Function
+%732 = OpVariable %_ptr_Function_uint Function
+%733 = OpVariable %_ptr_Function_float Function
+%734 = OpVariable %_ptr_Function_uint Function
+%735 = OpVariable %_ptr_Function_float Function
+%736 = OpVariable %_ptr_Function_uint Function
+%737 = OpVariable %_ptr_Function_float Function
+%738 = OpVariable %_ptr_Function_uint Function
+%739 = OpVariable %_ptr_Function_float Function
+OpStore %377 %129
+OpBranch %334
+%334 = OpLabel
+OpBranch %335
+%335 = OpLabel
+%740 = OpLoad %ulong %377
+%741 = OpUConvert %uint %740
+OpStore %378 %741
+OpBranch %338
+%338 = OpLabel
+%743 = OpLoad %uint %378
+%744 = OpIAdd %uint %uint_1065353216 %743
+OpStore %734 %744
+%745 = OpLoad %uint %734
+%746 = OpBitcast %float %745
+OpStore %735 %746
 OpBranch %339
 %339 = OpLabel
-%852 = OpLoad %float %389
-%853 = OpLoad %float %389
-%854 = OpFUnordNotEqual %bool %852 %853
-OpStore %785 %854
-%855 = OpLoad %bool %785
-OpSelectionMerge %343 None
-OpBranchConditional %855 %340 %341
+%748 = OpLoad %float %735
+%749 = OpFMul %float %float_1_5 %748
+OpStore %379 %749
+%751 = OpLoad %float %735
+%752 = OpFMul %float %float_0_25 %751
+OpStore %380 %752
+%753 = OpLoad %float %379
+%754 = OpLoad %float %380
+%755 = OpFAdd %float %753 %754
+OpStore %381 %755
+%757 = OpLoad %float %381
+%758 = OpFunctionCall %ulong %2 %ulong_14695981039346656037 %757
+OpStore %382 %758
+%759 = OpLoad %float %379
+%760 = OpLoad %float %380
+%761 = OpFSub %float %759 %760
+OpStore %383 %761
+%762 = OpLoad %ulong %382
+%763 = OpLoad %float %383
+%764 = OpFunctionCall %ulong %2 %762 %763
+OpStore %384 %764
+%765 = OpLoad %float %380
+%766 = OpLoad %float %379
+%767 = OpFSub %float %765 %766
+OpStore %385 %767
+%768 = OpLoad %ulong %384
+%769 = OpLoad %float %385
+%770 = OpFunctionCall %ulong %2 %768 %769
+OpStore %386 %770
+%771 = OpLoad %float %379
+%772 = OpLoad %float %380
+%773 = OpFMul %float %771 %772
+OpStore %387 %773
+%774 = OpLoad %ulong %386
+%775 = OpLoad %float %387
+%776 = OpFunctionCall %ulong %2 %774 %775
+OpStore %388 %776
+%777 = OpLoad %float %379
+%778 = OpLoad %float %380
+%779 = OpFDiv %float %777 %778
+OpStore %389 %779
+%780 = OpLoad %ulong %388
+%781 = OpLoad %float %389
+%782 = OpFunctionCall %ulong %2 %780 %781
+OpStore %390 %782
+%783 = OpLoad %float %380
+%784 = OpLoad %float %379
+%785 = OpFDiv %float %783 %784
+OpStore %391 %785
+%786 = OpLoad %ulong %390
+%787 = OpLoad %float %391
+%788 = OpFunctionCall %ulong %2 %786 %787
+OpStore %392 %788
+%789 = OpLoad %float %379
+%790 = OpFNegate %float %789
+OpStore %393 %790
+%791 = OpLoad %ulong %392
+%792 = OpLoad %float %393
+%793 = OpFunctionCall %ulong %2 %791 %792
+OpStore %394 %793
+%795 = OpLoad %float %379
+%796 = OpFSub %float %float_0 %795
+OpStore %395 %796
+%797 = OpLoad %ulong %394
+%798 = OpLoad %float %395
+%799 = OpFunctionCall %ulong %2 %797 %798
+OpStore %396 %799
+%800 = OpLoad %float %379
+%801 = OpLoad %float %379
+%802 = OpFSub %float %800 %801
+OpStore %397 %802
+%803 = OpLoad %ulong %396
+%804 = OpLoad %float %397
+%805 = OpFunctionCall %ulong %2 %803 %804
+OpStore %398 %805
+%806 = OpLoad %float %395
+%807 = OpLoad %float %379
+%808 = OpFAdd %float %806 %807
+OpStore %399 %808
+%809 = OpLoad %ulong %398
+%810 = OpLoad %float %399
+%811 = OpFunctionCall %ulong %2 %809 %810
+OpStore %400 %811
+%813 = OpLoad %float %735
+%814 = OpFMul %float %float_3 %813
+OpStore %401 %814
+%815 = OpLoad %float %735
+%816 = OpLoad %float %401
+%817 = OpFDiv %float %815 %816
+OpStore %402 %817
+%818 = OpLoad %ulong %400
+%819 = OpLoad %float %402
+%820 = OpFunctionCall %ulong %2 %818 %819
+OpStore %403 %820
+%821 = OpLoad %float %402
+%822 = OpLoad %float %401
+%823 = OpFMul %float %821 %822
+OpStore %404 %823
+%824 = OpLoad %ulong %403
+%825 = OpLoad %float %404
+%826 = OpFunctionCall %ulong %2 %824 %825
+OpStore %405 %826
+%827 = OpLoad %float %735
+%828 = OpLoad %float %402
+%829 = OpFSub %float %827 %828
+OpStore %406 %829
+%830 = OpLoad %float %406
+%831 = OpLoad %float %402
+%832 = OpFSub %float %830 %831
+OpStore %407 %832
+%833 = OpLoad %float %407
+%834 = OpLoad %float %402
+%835 = OpFSub %float %833 %834
+OpStore %408 %835
+%836 = OpLoad %ulong %405
+%837 = OpLoad %float %408
+%838 = OpFunctionCall %ulong %2 %836 %837
+OpStore %409 %838
+%839 = OpLoad %float %735
+%841 = OpFDiv %float %839 %float_49
+OpStore %410 %841
+%842 = OpLoad %ulong %409
+%843 = OpLoad %float %410
+%844 = OpFunctionCall %ulong %2 %842 %843
+OpStore %411 %844
+%845 = OpLoad %float %735
+%847 = OpFDiv %float %845 %float_1048576_5
+OpStore %412 %847
+%848 = OpLoad %ulong %411
+%849 = OpLoad %float %412
+%850 = OpFunctionCall %ulong %2 %848 %849
+OpStore %413 %850
+%851 = OpLoad %float %401
+%852 = OpFDiv %float %float_1048576_5 %851
+OpStore %414 %852
+%853 = OpLoad %ulong %413
+%854 = OpLoad %float %414
+%855 = OpFunctionCall %ulong %2 %853 %854
+OpStore %415 %855
+%857 = OpLoad %float %735
+%858 = OpFMul %float %float_16777216 %857
+OpStore %416 %858
+%859 = OpLoad %float %416
+%860 = OpLoad %float %735
+%861 = OpFAdd %float %859 %860
+OpStore %417 %861
+%862 = OpLoad %ulong %415
+%863 = OpLoad %float %417
+%864 = OpFunctionCall %ulong %2 %862 %863
+OpStore %418 %864
+%865 = OpLoad %float %417
+%866 = OpLoad %float %735
+%867 = OpFAdd %float %865 %866
+OpStore %419 %867
+%868 = OpLoad %ulong %418
+%869 = OpLoad %float %419
+%870 = OpFunctionCall %ulong %2 %868 %869
+OpStore %420 %870
+%871 = OpLoad %float %735
+%872 = OpLoad %float %735
+%873 = OpFAdd %float %871 %872
+OpStore %421 %873
+%874 = OpLoad %float %416
+%875 = OpLoad %float %421
+%876 = OpFAdd %float %874 %875
+OpStore %422 %876
+%877 = OpLoad %ulong %420
+%878 = OpLoad %float %422
+%879 = OpFunctionCall %ulong %2 %877 %878
+OpStore %423 %879
+%880 = OpLoad %float %416
+%881 = OpLoad %float %735
+%882 = OpFSub %float %880 %881
+OpStore %424 %882
+%883 = OpLoad %ulong %423
+%884 = OpLoad %float %424
+%885 = OpFunctionCall %ulong %2 %883 %884
+OpStore %425 %885
+%886 = OpLoad %float %417
+%887 = OpLoad %float %416
+%888 = OpFSub %float %886 %887
+OpStore %426 %888
+%889 = OpLoad %ulong %425
+%890 = OpLoad %float %426
+%891 = OpFunctionCall %ulong %2 %889 %890
+OpStore %427 %891
+%892 = OpLoad %float %735
+%893 = OpFMul %float %float_0 %892
+OpStore %428 %893
+%894 = OpLoad %ulong %427
+OpStore %729 %894
+%895 = OpLoad %float %428
+OpStore %730 %895
+OpStore %731 %uint_0
+OpBranch %131
+%131 = OpLabel
+%897 = OpLoad %uint %731
+%899 = OpULessThan %bool %897 %uint_24
+OpStore %429 %899
+%900 = OpLoad %bool %429
+OpLoopMerge %133 %376 None
+OpBranchConditional %900 %132 %133
+%133 = OpLabel
+OpBranch %336
+%336 = OpLabel
+%902 = OpLoad %uint %378
+%903 = OpIAdd %uint %uint_2139095039 %902
+OpStore %732 %903
+%904 = OpLoad %uint %732
+%905 = OpBitcast %float %904
+OpStore %733 %905
+OpBranch %337
+%337 = OpLabel
+%906 = OpLoad %ulong %729
+%907 = OpLoad %float %733
+%908 = OpFunctionCall %ulong %2 %906 %907
+OpStore %434 %908
+%909 = OpLoad %float %733
+%911 = OpFDiv %float %909 %float_2
+OpStore %435 %911
+%912 = OpLoad %ulong %434
+%913 = OpLoad %float %435
+%914 = OpFunctionCall %ulong %2 %912 %913
+OpStore %436 %914
+%915 = OpLoad %float %733
+%916 = OpLoad %float %733
+%917 = OpFAdd %float %915 %916
+OpStore %437 %917
+%918 = OpLoad %ulong %436
+%919 = OpLoad %float %437
+%920 = OpFunctionCall %ulong %2 %918 %919
+OpStore %438 %920
+%921 = OpLoad %float %733
+%922 = OpFMul %float %921 %float_2
+OpStore %439 %922
+%923 = OpLoad %ulong %438
+%924 = OpLoad %float %439
+%925 = OpFunctionCall %ulong %2 %923 %924
+OpStore %440 %925
+%926 = OpLoad %float %439
+%927 = OpFSub %float %float_0 %926
+OpStore %441 %927
+%928 = OpLoad %ulong %440
+%929 = OpLoad %float %441
+%930 = OpFunctionCall %ulong %2 %928 %929
+OpStore %442 %930
+%931 = OpLoad %float %733
+%932 = OpLoad %float %733
+%933 = OpFMul %float %931 %932
+OpStore %443 %933
+%934 = OpLoad %ulong %442
+%935 = OpLoad %float %443
+%936 = OpFunctionCall %ulong %2 %934 %935
+OpStore %444 %936
+%937 = OpLoad %float %733
+%938 = OpLoad %float %733
+%939 = OpFSub %float %937 %938
+OpStore %445 %939
+%940 = OpLoad %ulong %444
+%941 = OpLoad %float %445
+%942 = OpFunctionCall %ulong %2 %940 %941
+OpStore %446 %942
+OpBranch %340
+%340 = OpLabel
+%944 = OpLoad %uint %378
+%945 = OpIAdd %uint %uint_8388608 %944
+OpStore %736 %945
+%946 = OpLoad %uint %736
+%947 = OpBitcast %float %946
+OpStore %737 %947
+OpBranch %341
 %341 = OpLabel
 OpBranch %342
 %342 = OpLabel
-%856 = OpLoad %ulong %780
-%857 = OpLoad %float %389
-%858 = OpFunctionCall %ulong %6 %856 %857
-OpStore %787 %858
-%859 = OpLoad %ulong %787
-OpStore %788 %859
-OpBranch %343
-%340 = OpLabel
-%860 = OpLoad %ulong %780
-%861 = OpFunctionCall %ulong %5 %860 %uint_4294967295
-OpStore %786 %861
-%862 = OpLoad %ulong %786
-OpStore %788 %862
+%949 = OpLoad %uint %378
+%950 = OpIAdd %uint %uint_1 %949
+OpStore %738 %950
+%951 = OpLoad %uint %738
+%952 = OpBitcast %float %951
+OpStore %739 %952
 OpBranch %343
 %343 = OpLabel
-%863 = OpLoad %float %384
-%864 = OpLoad %float %385
-%865 = OpFDiv %float %863 %864
-OpStore %390 %865
-%866 = OpLoad %ulong %788
-%867 = OpLoad %float %390
-%868 = OpFunctionCall %ulong %2 %866 %867
-OpStore %391 %868
-%869 = OpLoad %float %385
-%870 = OpLoad %float %384
-%871 = OpFDiv %float %869 %870
-OpStore %392 %871
-%872 = OpLoad %ulong %391
-%873 = OpLoad %float %392
-%874 = OpFunctionCall %ulong %2 %872 %873
-OpStore %393 %874
-%875 = OpLoad %float %384
-%876 = OpFNegate %float %875
-OpStore %394 %876
-%877 = OpLoad %ulong %393
-%878 = OpLoad %float %394
-%879 = OpFunctionCall %ulong %2 %877 %878
-OpStore %395 %879
-%881 = OpLoad %float %384
-%882 = OpFSub %float %float_0 %881
-OpStore %396 %882
-%883 = OpLoad %ulong %395
-%884 = OpLoad %float %396
-%885 = OpFunctionCall %ulong %2 %883 %884
-OpStore %397 %885
-%886 = OpLoad %float %384
-%887 = OpLoad %float %384
-%888 = OpFSub %float %886 %887
-OpStore %398 %888
-%889 = OpLoad %ulong %397
-%890 = OpLoad %float %398
-%891 = OpFunctionCall %ulong %2 %889 %890
-OpStore %399 %891
-%892 = OpLoad %float %396
-%893 = OpLoad %float %384
-%894 = OpFAdd %float %892 %893
-OpStore %400 %894
-%895 = OpLoad %ulong %399
-%896 = OpLoad %float %400
-%897 = OpFunctionCall %ulong %2 %895 %896
-OpStore %401 %897
-%899 = OpLoad %float %722
-%900 = OpFMul %float %float_3 %899
-OpStore %402 %900
-%901 = OpLoad %float %722
-%902 = OpLoad %float %402
-%903 = OpFDiv %float %901 %902
-OpStore %403 %903
-%904 = OpLoad %ulong %401
-%905 = OpLoad %float %403
-%906 = OpFunctionCall %ulong %2 %904 %905
-OpStore %404 %906
-%907 = OpLoad %float %403
-%908 = OpLoad %float %402
-%909 = OpFMul %float %907 %908
-OpStore %405 %909
-%910 = OpLoad %ulong %404
-%911 = OpLoad %float %405
-%912 = OpFunctionCall %ulong %2 %910 %911
-OpStore %406 %912
-%913 = OpLoad %float %722
-%914 = OpLoad %float %403
-%915 = OpFSub %float %913 %914
-OpStore %407 %915
-%916 = OpLoad %float %407
-%917 = OpLoad %float %403
-%918 = OpFSub %float %916 %917
-OpStore %408 %918
-%919 = OpLoad %float %408
-%920 = OpLoad %float %403
-%921 = OpFSub %float %919 %920
-OpStore %409 %921
-%922 = OpLoad %ulong %406
-%923 = OpLoad %float %409
-%924 = OpFunctionCall %ulong %2 %922 %923
-OpStore %410 %924
-%925 = OpLoad %float %722
-%927 = OpFDiv %float %925 %float_49
-OpStore %411 %927
-%928 = OpLoad %ulong %410
-%929 = OpLoad %float %411
-%930 = OpFunctionCall %ulong %2 %928 %929
-OpStore %412 %930
-%931 = OpLoad %float %722
-%933 = OpFDiv %float %931 %float_1048576_5
-OpStore %413 %933
-%934 = OpLoad %ulong %412
-%935 = OpLoad %float %413
-%936 = OpFunctionCall %ulong %2 %934 %935
-OpStore %414 %936
-%937 = OpLoad %float %402
-%938 = OpFDiv %float %float_1048576_5 %937
-OpStore %415 %938
-%939 = OpLoad %ulong %414
-%940 = OpLoad %float %415
-%941 = OpFunctionCall %ulong %2 %939 %940
-OpStore %416 %941
-%943 = OpLoad %float %722
-%944 = OpFMul %float %float_16777216 %943
-OpStore %417 %944
-%945 = OpLoad %float %417
-%946 = OpLoad %float %722
-%947 = OpFAdd %float %945 %946
-OpStore %418 %947
-%948 = OpLoad %ulong %416
-%949 = OpLoad %float %418
-%950 = OpFunctionCall %ulong %2 %948 %949
-OpStore %419 %950
-%951 = OpLoad %float %418
-%952 = OpLoad %float %722
-%953 = OpFAdd %float %951 %952
-OpStore %420 %953
-%954 = OpLoad %ulong %419
-%955 = OpLoad %float %420
-%956 = OpFunctionCall %ulong %2 %954 %955
-OpStore %421 %956
-%957 = OpLoad %float %722
-%958 = OpLoad %float %722
-%959 = OpFAdd %float %957 %958
-OpStore %422 %959
-%960 = OpLoad %float %417
-%961 = OpLoad %float %422
-%962 = OpFAdd %float %960 %961
-OpStore %423 %962
-%963 = OpLoad %ulong %421
-%964 = OpLoad %float %423
-%965 = OpFunctionCall %ulong %2 %963 %964
-OpStore %424 %965
-%966 = OpLoad %float %417
-%967 = OpLoad %float %722
-%968 = OpFSub %float %966 %967
-OpStore %425 %968
-%969 = OpLoad %ulong %424
-%970 = OpLoad %float %425
-%971 = OpFunctionCall %ulong %2 %969 %970
-OpStore %426 %971
-%972 = OpLoad %float %418
-%973 = OpLoad %float %417
-%974 = OpFSub %float %972 %973
-OpStore %427 %974
-%975 = OpLoad %ulong %426
-%976 = OpLoad %float %427
-%977 = OpFunctionCall %ulong %2 %975 %976
-OpStore %428 %977
-%978 = OpLoad %float %722
-%979 = OpFMul %float %float_0 %978
-OpStore %429 %979
-%980 = OpLoad %ulong %428
-OpStore %718 %980
-%981 = OpLoad %float %429
-OpStore %719 %981
-OpStore %720 %uint_0
-OpBranch %57
-%57 = OpLabel
-%983 = OpLoad %uint %720
-%985 = OpULessThan %bool %983 %uint_24
-OpStore %430 %985
-%986 = OpLoad %bool %430
-OpLoopMerge %59 %380 None
-OpBranchConditional %986 %58 %59
-%59 = OpLabel
-OpBranch %267
-%267 = OpLabel
-%988 = OpLoad %uint %383
-%989 = OpIAdd %uint %uint_2139095039 %988
-OpStore %727 %989
-%990 = OpLoad %uint %727
-%991 = OpBitcast %float %990
-OpStore %728 %991
-OpBranch %268
-%268 = OpLabel
-OpBranch %314
-%314 = OpLabel
-%992 = OpLoad %float %728
-%993 = OpLoad %float %728
-%994 = OpFUnordNotEqual %bool %992 %993
-OpStore %765 %994
-%995 = OpLoad %bool %765
-OpSelectionMerge %318 None
-OpBranchConditional %995 %315 %316
-%316 = OpLabel
-OpBranch %317
-%317 = OpLabel
-%996 = OpLoad %ulong %718
-%997 = OpLoad %float %728
-%998 = OpFunctionCall %ulong %6 %996 %997
-OpStore %767 %998
-%999 = OpLoad %ulong %767
-OpStore %768 %999
-OpBranch %318
-%315 = OpLabel
-%1000 = OpLoad %ulong %718
-%1001 = OpFunctionCall %ulong %5 %1000 %uint_4294967295
-OpStore %766 %1001
-%1002 = OpLoad %ulong %766
-OpStore %768 %1002
-OpBranch %318
-%318 = OpLabel
-%1003 = OpLoad %float %728
-%1005 = OpFDiv %float %1003 %float_2
-OpStore %434 %1005
-OpBranch %324
-%324 = OpLabel
-%1006 = OpLoad %float %434
-%1007 = OpLoad %float %434
-%1008 = OpFUnordNotEqual %bool %1006 %1007
-OpStore %773 %1008
-%1009 = OpLoad %bool %773
-OpSelectionMerge %328 None
-OpBranchConditional %1009 %325 %326
-%326 = OpLabel
-OpBranch %327
-%327 = OpLabel
-%1010 = OpLoad %ulong %768
-%1011 = OpLoad %float %434
-%1012 = OpFunctionCall %ulong %6 %1010 %1011
-OpStore %775 %1012
-%1013 = OpLoad %ulong %775
-OpStore %776 %1013
-OpBranch %328
-%325 = OpLabel
-%1014 = OpLoad %ulong %768
-%1015 = OpFunctionCall %ulong %5 %1014 %uint_4294967295
-OpStore %774 %1015
-%1016 = OpLoad %ulong %774
-OpStore %776 %1016
-OpBranch %328
-%328 = OpLabel
-%1017 = OpLoad %float %728
-%1018 = OpLoad %float %728
-%1019 = OpFAdd %float %1017 %1018
-OpStore %435 %1019
-OpBranch %334
-%334 = OpLabel
-%1020 = OpLoad %float %435
-%1021 = OpLoad %float %435
-%1022 = OpFUnordNotEqual %bool %1020 %1021
-OpStore %781 %1022
-%1023 = OpLoad %bool %781
-OpSelectionMerge %338 None
-OpBranchConditional %1023 %335 %336
-%336 = OpLabel
-OpBranch %337
-%337 = OpLabel
-%1024 = OpLoad %ulong %776
-%1025 = OpLoad %float %435
-%1026 = OpFunctionCall %ulong %6 %1024 %1025
-OpStore %783 %1026
-%1027 = OpLoad %ulong %783
-OpStore %784 %1027
-OpBranch %338
-%335 = OpLabel
-%1028 = OpLoad %ulong %776
-%1029 = OpFunctionCall %ulong %5 %1028 %uint_4294967295
-OpStore %782 %1029
-%1030 = OpLoad %ulong %782
-OpStore %784 %1030
-OpBranch %338
-%338 = OpLabel
-%1031 = OpLoad %float %728
-%1032 = OpFMul %float %1031 %float_2
-OpStore %436 %1032
-%1033 = OpLoad %ulong %784
-%1034 = OpLoad %float %436
-%1035 = OpFunctionCall %ulong %2 %1033 %1034
-OpStore %437 %1035
-%1036 = OpLoad %float %436
-%1037 = OpFSub %float %float_0 %1036
-OpStore %438 %1037
-%1038 = OpLoad %ulong %437
-%1039 = OpLoad %float %438
-%1040 = OpFunctionCall %ulong %2 %1038 %1039
-OpStore %439 %1040
-%1041 = OpLoad %float %728
-%1042 = OpLoad %float %728
-%1043 = OpFMul %float %1041 %1042
-OpStore %440 %1043
-%1044 = OpLoad %ulong %439
-%1045 = OpLoad %float %440
-%1046 = OpFunctionCall %ulong %2 %1044 %1045
-OpStore %441 %1046
-%1047 = OpLoad %float %728
-%1048 = OpLoad %float %728
-%1049 = OpFSub %float %1047 %1048
-OpStore %442 %1049
-%1050 = OpLoad %ulong %441
-%1051 = OpLoad %float %442
-%1052 = OpFunctionCall %ulong %2 %1050 %1051
-OpStore %443 %1052
-OpBranch %344
-%344 = OpLabel
-%1054 = OpLoad %uint %383
-%1055 = OpIAdd %uint %uint_8388608 %1054
-OpStore %789 %1055
-%1056 = OpLoad %uint %789
-%1057 = OpBitcast %float %1056
-OpStore %790 %1057
-OpBranch %345
-%345 = OpLabel
-OpBranch %346
-%346 = OpLabel
-%1059 = OpLoad %uint %383
-%1060 = OpIAdd %uint %uint_1 %1059
-OpStore %791 %1060
-%1061 = OpLoad %uint %791
-%1062 = OpBitcast %float %1061
-OpStore %792 %1062
-OpBranch %347
-%347 = OpLabel
-%1063 = OpLoad %float %790
-%1065 = OpFMul %float %1063 %float_0_5
-OpStore %444 %1065
-%1066 = OpLoad %ulong %443
-%1067 = OpLoad %float %444
-%1068 = OpFunctionCall %ulong %2 %1066 %1067
-OpStore %445 %1068
-%1069 = OpLoad %float %790
-%1070 = OpFDiv %float %1069 %float_2
-OpStore %446 %1070
-%1071 = OpLoad %ulong %445
-%1072 = OpLoad %float %446
-%1073 = OpFunctionCall %ulong %2 %1071 %1072
-OpStore %447 %1073
-%1074 = OpLoad %float %790
-%1075 = OpLoad %float %792
-%1076 = OpFSub %float %1074 %1075
-OpStore %448 %1076
-%1077 = OpLoad %ulong %447
-%1078 = OpLoad %float %448
-%1079 = OpFunctionCall %ulong %2 %1077 %1078
-OpStore %449 %1079
-%1080 = OpLoad %float %790
-%1081 = OpLoad %float %722
-%1082 = OpFMul %float %1080 %1081
-OpStore %450 %1082
-%1083 = OpLoad %ulong %449
-%1084 = OpLoad %float %450
-%1085 = OpFunctionCall %ulong %2 %1083 %1084
-OpStore %451 %1085
-%1086 = OpLoad %float %792
-%1087 = OpLoad %float %792
-%1088 = OpFAdd %float %1086 %1087
-OpStore %452 %1088
-%1089 = OpLoad %ulong %451
-%1090 = OpLoad %float %452
-%1091 = OpFunctionCall %ulong %2 %1089 %1090
-OpStore %453 %1091
-%1092 = OpLoad %float %792
-%1093 = OpFMul %float %1092 %float_0_5
-OpStore %454 %1093
-%1094 = OpLoad %ulong %453
-%1095 = OpLoad %float %454
-%1096 = OpFunctionCall %ulong %2 %1094 %1095
-OpStore %455 %1096
-%1097 = OpLoad %float %792
-%1099 = OpFMul %float %1097 %float_0_75
-OpStore %456 %1099
-%1100 = OpLoad %ulong %455
-%1101 = OpLoad %float %456
-%1102 = OpFunctionCall %ulong %2 %1100 %1101
-OpStore %457 %1102
-%1103 = OpLoad %float %792
-%1104 = OpFMul %float %1103 %float_16777216
-OpStore %458 %1104
-%1105 = OpLoad %ulong %457
-%1106 = OpLoad %float %458
-%1107 = OpFunctionCall %ulong %2 %1105 %1106
-OpStore %459 %1107
-%1108 = OpLoad %float %792
-%1109 = OpLoad %float %790
-%1110 = OpFDiv %float %1108 %1109
-OpStore %460 %1110
-%1111 = OpLoad %ulong %459
-%1112 = OpLoad %float %460
-%1113 = OpFunctionCall %ulong %2 %1111 %1112
-OpStore %461 %1113
-%1115 = OpLoad %float %722
-%1116 = OpFMul %float %float_5_5 %1115
-OpStore %462 %1116
-%1117 = OpLoad %float %722
-%1118 = OpFMul %float %float_3 %1117
-OpStore %463 %1118
-%1119 = OpLoad %float %463
-%1120 = OpFOrdEqual %bool %1119 %float_0
-OpStore %464 %1120
-%1121 = OpLoad %bool %464
-OpSelectionMerge %63 None
-OpBranchConditional %1121 %349 %60
-%60 = OpLabel
-%1122 = OpLoad %float %462
-%1123 = OpFMul %float %1122 %float_2
-OpStore %465 %1123
-%1124 = OpLoad %float %462
-%1125 = OpLoad %float %465
-%1126 = OpFOrdEqual %bool %1124 %1125
-OpStore %466 %1126
-%1127 = OpLoad %bool %466
-OpSelectionMerge %62 None
-OpBranchConditional %1127 %61 %348
-%348 = OpLabel
-%1128 = OpLoad %bool %466
-OpStore %468 %1128
-OpBranch %62
-%61 = OpLabel
-%1129 = OpLoad %float %462
-%1130 = OpFUnordNotEqual %bool %1129 %float_0
-OpStore %467 %1130
-%1131 = OpLoad %bool %467
-OpStore %468 %1131
-OpBranch %62
-%62 = OpLabel
-%1132 = OpLoad %bool %468
-OpStore %469 %1132
-OpBranch %63
-%349 = OpLabel
-%1133 = OpLoad %bool %464
-OpStore %469 %1133
-OpBranch %63
-%63 = OpLabel
-%1134 = OpLoad %bool %469
-OpSelectionMerge %66 None
-OpBranchConditional %1134 %64 %65
-%65 = OpLabel
-%1135 = OpLoad %float %462
-%1136 = OpFOrdLessThan %bool %1135 %float_0
-OpStore %475 %1136
-%1137 = OpLoad %bool %475
-OpSelectionMerge %69 None
-OpBranchConditional %1137 %67 %68
-%68 = OpLabel
-%1138 = OpLoad %float %462
-OpStore %477 %1138
-OpBranch %69
-%67 = OpLabel
-%1139 = OpLoad %float %462
-%1140 = OpFSub %float %float_0 %1139
-OpStore %476 %1140
-%1141 = OpLoad %float %476
-OpStore %477 %1141
-OpBranch %69
-%69 = OpLabel
-%1142 = OpLoad %float %463
-%1143 = OpFOrdLessThan %bool %1142 %float_0
-OpStore %478 %1143
-%1144 = OpLoad %bool %478
-OpSelectionMerge %72 None
-OpBranchConditional %1144 %70 %71
-%71 = OpLabel
-%1145 = OpLoad %float %463
-OpStore %480 %1145
-OpBranch %72
-%70 = OpLabel
-%1146 = OpLoad %float %463
-%1147 = OpFSub %float %float_0 %1146
-OpStore %479 %1147
-%1148 = OpLoad %float %479
-OpStore %480 %1148
-OpBranch %72
-%72 = OpLabel
-%1149 = OpLoad %float %477
-%1150 = OpFDiv %float %1149 %float_2
-OpStore %481 %1150
-%1151 = OpLoad %float %480
-OpStore %482 %1151
-OpBranch %73
-%73 = OpLabel
-%1152 = OpLoad %float %482
-%1153 = OpLoad %float %481
-%1154 = OpFOrdLessThanEqual %bool %1152 %1153
-OpStore %483 %1154
-%1155 = OpLoad %bool %483
-OpLoopMerge %75 %379 None
-OpBranchConditional %1155 %74 %75
-%75 = OpLabel
-%1156 = OpLoad %float %477
-OpStore %485 %1156
-%1157 = OpLoad %float %482
-OpStore %486 %1157
-OpBranch %76
-%76 = OpLabel
-%1158 = OpLoad %float %480
-%1159 = OpLoad %float %486
-%1160 = OpFOrdLessThanEqual %bool %1158 %1159
-OpStore %487 %1160
-%1161 = OpLoad %bool %487
-OpLoopMerge %80 %378 None
-OpBranchConditional %1161 %81 %80
-%80 = OpLabel
-%1162 = OpLoad %bool %475
-OpSelectionMerge %84 None
-OpBranchConditional %1162 %82 %83
-%83 = OpLabel
-%1163 = OpLoad %float %485
-OpStore %493 %1163
-OpBranch %84
-%82 = OpLabel
-%1164 = OpLoad %float %485
-%1165 = OpFNegate %float %1164
-OpStore %492 %1165
-%1166 = OpLoad %float %492
-OpStore %493 %1166
-OpBranch %84
-%84 = OpLabel
-%1167 = OpLoad %float %493
-OpStore %494 %1167
-OpBranch %66
-%81 = OpLabel
-%1168 = OpLoad %float %486
-%1169 = OpLoad %float %485
-%1170 = OpFOrdLessThanEqual %bool %1168 %1169
-OpStore %488 %1170
-%1171 = OpLoad %bool %488
-OpSelectionMerge %79 None
-OpBranchConditional %1171 %77 %78
-%78 = OpLabel
-%1172 = OpLoad %float %485
-OpStore %490 %1172
-OpBranch %79
-%77 = OpLabel
-%1173 = OpLoad %float %485
-%1174 = OpLoad %float %486
-%1175 = OpFSub %float %1173 %1174
-OpStore %489 %1175
-%1176 = OpLoad %float %489
-OpStore %490 %1176
-OpBranch %79
-%79 = OpLabel
-%1177 = OpLoad %float %486
-%1178 = OpFDiv %float %1177 %float_2
-OpStore %491 %1178
-%1179 = OpLoad %float %490
-OpStore %485 %1179
-%1180 = OpLoad %float %491
-OpStore %486 %1180
-OpBranch %378
-%74 = OpLabel
-%1181 = OpLoad %float %482
-%1182 = OpFMul %float %1181 %float_2
-OpStore %484 %1182
-%1183 = OpLoad %float %484
-OpStore %482 %1183
-OpBranch %379
-%64 = OpLabel
-%1184 = OpLoad %float %462
-%1185 = OpLoad %float %463
-%1186 = OpFDiv %float %1184 %1185
-OpStore %470 %1186
-%1187 = OpLoad %float %470
-%1188 = OpConvertFToS %ulong %1187
-OpStore %471 %1188
-%1189 = OpLoad %ulong %471
-%1190 = OpConvertSToF %float %1189
-OpStore %472 %1190
-%1191 = OpLoad %float %472
-%1192 = OpLoad %float %463
-%1193 = OpFMul %float %1191 %1192
-OpStore %473 %1193
-%1194 = OpLoad %float %462
-%1195 = OpLoad %float %473
-%1196 = OpFSub %float %1194 %1195
-OpStore %474 %1196
-%1197 = OpLoad %float %474
-OpStore %494 %1197
-OpBranch %66
-%66 = OpLabel
-OpBranch %269
-%269 = OpLabel
-%1198 = OpLoad %float %494
-%1199 = OpLoad %float %494
-%1200 = OpFUnordNotEqual %bool %1198 %1199
-OpStore %729 %1200
-%1201 = OpLoad %bool %729
-OpSelectionMerge %273 None
-OpBranchConditional %1201 %270 %271
-%271 = OpLabel
-OpBranch %272
-%272 = OpLabel
-%1202 = OpLoad %ulong %461
-%1203 = OpLoad %float %494
-%1204 = OpFunctionCall %ulong %6 %1202 %1203
-OpStore %731 %1204
-%1205 = OpLoad %ulong %731
-OpStore %732 %1205
-OpBranch %273
-%270 = OpLabel
-%1206 = OpLoad %ulong %461
-%1207 = OpFunctionCall %ulong %5 %1206 %uint_4294967295
-OpStore %730 %1207
-%1208 = OpLoad %ulong %730
-OpStore %732 %1208
-OpBranch %273
-%273 = OpLabel
-%1209 = OpLoad %float %462
-%1210 = OpFSub %float %float_0 %1209
-OpStore %495 %1210
-%1211 = OpLoad %float %463
-%1212 = OpFOrdEqual %bool %1211 %float_0
-OpStore %496 %1212
-%1213 = OpLoad %bool %496
-OpSelectionMerge %88 None
-OpBranchConditional %1213 %351 %85
-%85 = OpLabel
-%1214 = OpLoad %float %495
-%1215 = OpFMul %float %1214 %float_2
-OpStore %497 %1215
-%1216 = OpLoad %float %495
-%1217 = OpLoad %float %497
-%1218 = OpFOrdEqual %bool %1216 %1217
-OpStore %498 %1218
-%1219 = OpLoad %bool %498
-OpSelectionMerge %87 None
-OpBranchConditional %1219 %86 %350
-%350 = OpLabel
-%1220 = OpLoad %bool %498
-OpStore %500 %1220
-OpBranch %87
-%86 = OpLabel
-%1221 = OpLoad %float %495
-%1222 = OpFUnordNotEqual %bool %1221 %float_0
-OpStore %499 %1222
-%1223 = OpLoad %bool %499
-OpStore %500 %1223
-OpBranch %87
-%87 = OpLabel
-%1224 = OpLoad %bool %500
-OpStore %501 %1224
-OpBranch %88
-%351 = OpLabel
-%1225 = OpLoad %bool %496
-OpStore %501 %1225
-OpBranch %88
-%88 = OpLabel
-%1226 = OpLoad %bool %501
-OpSelectionMerge %91 None
-OpBranchConditional %1226 %89 %90
-%90 = OpLabel
-%1227 = OpLoad %float %495
-%1228 = OpFOrdLessThan %bool %1227 %float_0
-OpStore %507 %1228
-%1229 = OpLoad %bool %507
-OpSelectionMerge %94 None
-OpBranchConditional %1229 %92 %93
-%93 = OpLabel
-%1230 = OpLoad %float %495
-OpStore %509 %1230
-OpBranch %94
-%92 = OpLabel
-%1231 = OpLoad %float %495
-%1232 = OpFSub %float %float_0 %1231
-OpStore %508 %1232
-%1233 = OpLoad %float %508
-OpStore %509 %1233
-OpBranch %94
-%94 = OpLabel
-%1234 = OpLoad %float %463
-%1235 = OpFOrdLessThan %bool %1234 %float_0
-OpStore %510 %1235
-%1236 = OpLoad %bool %510
-OpSelectionMerge %97 None
-OpBranchConditional %1236 %95 %96
-%96 = OpLabel
-%1237 = OpLoad %float %463
-OpStore %512 %1237
-OpBranch %97
-%95 = OpLabel
-%1238 = OpLoad %float %463
-%1239 = OpFSub %float %float_0 %1238
-OpStore %511 %1239
-%1240 = OpLoad %float %511
-OpStore %512 %1240
-OpBranch %97
-%97 = OpLabel
-%1241 = OpLoad %float %509
-%1242 = OpFDiv %float %1241 %float_2
-OpStore %513 %1242
-%1243 = OpLoad %float %512
-OpStore %514 %1243
-OpBranch %98
-%98 = OpLabel
-%1244 = OpLoad %float %514
-%1245 = OpLoad %float %513
-%1246 = OpFOrdLessThanEqual %bool %1244 %1245
-OpStore %515 %1246
-%1247 = OpLoad %bool %515
-OpLoopMerge %100 %377 None
-OpBranchConditional %1247 %99 %100
-%100 = OpLabel
-%1248 = OpLoad %float %509
-OpStore %517 %1248
-%1249 = OpLoad %float %514
-OpStore %518 %1249
-OpBranch %101
-%101 = OpLabel
-%1250 = OpLoad %float %512
-%1251 = OpLoad %float %518
-%1252 = OpFOrdLessThanEqual %bool %1250 %1251
-OpStore %519 %1252
-%1253 = OpLoad %bool %519
-OpLoopMerge %105 %376 None
-OpBranchConditional %1253 %106 %105
-%105 = OpLabel
-%1254 = OpLoad %bool %507
-OpSelectionMerge %109 None
-OpBranchConditional %1254 %107 %108
-%108 = OpLabel
-%1255 = OpLoad %float %517
-OpStore %525 %1255
-OpBranch %109
-%107 = OpLabel
-%1256 = OpLoad %float %517
-%1257 = OpFNegate %float %1256
-OpStore %524 %1257
-%1258 = OpLoad %float %524
-OpStore %525 %1258
-OpBranch %109
-%109 = OpLabel
-%1259 = OpLoad %float %525
-OpStore %526 %1259
-OpBranch %91
-%106 = OpLabel
-%1260 = OpLoad %float %518
-%1261 = OpLoad %float %517
-%1262 = OpFOrdLessThanEqual %bool %1260 %1261
-OpStore %520 %1262
-%1263 = OpLoad %bool %520
-OpSelectionMerge %104 None
-OpBranchConditional %1263 %102 %103
-%103 = OpLabel
-%1264 = OpLoad %float %517
-OpStore %522 %1264
-OpBranch %104
-%102 = OpLabel
-%1265 = OpLoad %float %517
-%1266 = OpLoad %float %518
-%1267 = OpFSub %float %1265 %1266
-OpStore %521 %1267
-%1268 = OpLoad %float %521
-OpStore %522 %1268
-OpBranch %104
-%104 = OpLabel
-%1269 = OpLoad %float %518
-%1270 = OpFDiv %float %1269 %float_2
-OpStore %523 %1270
-%1271 = OpLoad %float %522
-OpStore %517 %1271
-%1272 = OpLoad %float %523
-OpStore %518 %1272
-OpBranch %376
-%99 = OpLabel
-%1273 = OpLoad %float %514
-%1274 = OpFMul %float %1273 %float_2
-OpStore %516 %1274
-%1275 = OpLoad %float %516
-OpStore %514 %1275
-OpBranch %377
-%89 = OpLabel
-%1276 = OpLoad %float %495
-%1277 = OpLoad %float %463
-%1278 = OpFDiv %float %1276 %1277
-OpStore %502 %1278
-%1279 = OpLoad %float %502
-%1280 = OpConvertFToS %ulong %1279
-OpStore %503 %1280
-%1281 = OpLoad %ulong %503
-%1282 = OpConvertSToF %float %1281
-OpStore %504 %1282
-%1283 = OpLoad %float %504
-%1284 = OpLoad %float %463
-%1285 = OpFMul %float %1283 %1284
-OpStore %505 %1285
-%1286 = OpLoad %float %495
-%1287 = OpLoad %float %505
-%1288 = OpFSub %float %1286 %1287
-OpStore %506 %1288
-%1289 = OpLoad %float %506
-OpStore %526 %1289
-OpBranch %91
-%91 = OpLabel
-OpBranch %274
-%274 = OpLabel
-%1290 = OpLoad %float %526
-%1291 = OpLoad %float %526
-%1292 = OpFUnordNotEqual %bool %1290 %1291
-OpStore %733 %1292
-%1293 = OpLoad %bool %733
-OpSelectionMerge %278 None
-OpBranchConditional %1293 %275 %276
-%276 = OpLabel
-OpBranch %277
-%277 = OpLabel
-%1294 = OpLoad %ulong %732
-%1295 = OpLoad %float %526
-%1296 = OpFunctionCall %ulong %6 %1294 %1295
-OpStore %735 %1296
-%1297 = OpLoad %ulong %735
-OpStore %736 %1297
-OpBranch %278
-%275 = OpLabel
-%1298 = OpLoad %ulong %732
-%1299 = OpFunctionCall %ulong %5 %1298 %uint_4294967295
-OpStore %734 %1299
-%1300 = OpLoad %ulong %734
-OpStore %736 %1300
-OpBranch %278
-%278 = OpLabel
-%1301 = OpLoad %float %463
-%1302 = OpFSub %float %float_0 %1301
-OpStore %527 %1302
-%1303 = OpLoad %float %527
-%1304 = OpFOrdEqual %bool %1303 %float_0
-OpStore %528 %1304
-%1305 = OpLoad %bool %528
-OpSelectionMerge %113 None
-OpBranchConditional %1305 %353 %110
-%110 = OpLabel
-%1306 = OpLoad %float %462
-%1307 = OpFMul %float %1306 %float_2
-OpStore %529 %1307
-%1308 = OpLoad %float %462
-%1309 = OpLoad %float %529
-%1310 = OpFOrdEqual %bool %1308 %1309
-OpStore %530 %1310
-%1311 = OpLoad %bool %530
-OpSelectionMerge %112 None
-OpBranchConditional %1311 %111 %352
-%352 = OpLabel
-%1312 = OpLoad %bool %530
-OpStore %532 %1312
-OpBranch %112
-%111 = OpLabel
-%1313 = OpLoad %float %462
-%1314 = OpFUnordNotEqual %bool %1313 %float_0
-OpStore %531 %1314
-%1315 = OpLoad %bool %531
-OpStore %532 %1315
-OpBranch %112
-%112 = OpLabel
-%1316 = OpLoad %bool %532
-OpStore %533 %1316
-OpBranch %113
-%353 = OpLabel
-%1317 = OpLoad %bool %528
-OpStore %533 %1317
-OpBranch %113
-%113 = OpLabel
-%1318 = OpLoad %bool %533
-OpSelectionMerge %116 None
-OpBranchConditional %1318 %114 %115
-%115 = OpLabel
-%1319 = OpLoad %float %462
-%1320 = OpFOrdLessThan %bool %1319 %float_0
-OpStore %539 %1320
-%1321 = OpLoad %bool %539
-OpSelectionMerge %119 None
-OpBranchConditional %1321 %117 %118
-%118 = OpLabel
-%1322 = OpLoad %float %462
-OpStore %541 %1322
-OpBranch %119
-%117 = OpLabel
-%1323 = OpLoad %float %462
-%1324 = OpFSub %float %float_0 %1323
-OpStore %540 %1324
-%1325 = OpLoad %float %540
-OpStore %541 %1325
-OpBranch %119
-%119 = OpLabel
-%1326 = OpLoad %float %527
-%1327 = OpFOrdLessThan %bool %1326 %float_0
-OpStore %542 %1327
-%1328 = OpLoad %bool %542
-OpSelectionMerge %122 None
-OpBranchConditional %1328 %120 %121
-%121 = OpLabel
-%1329 = OpLoad %float %527
-OpStore %544 %1329
-OpBranch %122
-%120 = OpLabel
-%1330 = OpLoad %float %527
-%1331 = OpFSub %float %float_0 %1330
-OpStore %543 %1331
-%1332 = OpLoad %float %543
-OpStore %544 %1332
-OpBranch %122
-%122 = OpLabel
-%1333 = OpLoad %float %541
-%1334 = OpFDiv %float %1333 %float_2
-OpStore %545 %1334
-%1335 = OpLoad %float %544
-OpStore %546 %1335
-OpBranch %123
-%123 = OpLabel
-%1336 = OpLoad %float %546
-%1337 = OpLoad %float %545
-%1338 = OpFOrdLessThanEqual %bool %1336 %1337
-OpStore %547 %1338
-%1339 = OpLoad %bool %547
-OpLoopMerge %125 %375 None
-OpBranchConditional %1339 %124 %125
-%125 = OpLabel
-%1340 = OpLoad %float %541
-OpStore %549 %1340
-%1341 = OpLoad %float %546
-OpStore %550 %1341
-OpBranch %126
-%126 = OpLabel
-%1342 = OpLoad %float %544
-%1343 = OpLoad %float %550
-%1344 = OpFOrdLessThanEqual %bool %1342 %1343
-OpStore %551 %1344
-%1345 = OpLoad %bool %551
-OpLoopMerge %130 %374 None
-OpBranchConditional %1345 %131 %130
-%130 = OpLabel
-%1346 = OpLoad %bool %539
-OpSelectionMerge %134 None
-OpBranchConditional %1346 %132 %133
-%133 = OpLabel
-%1347 = OpLoad %float %549
-OpStore %557 %1347
-OpBranch %134
-%132 = OpLabel
-%1348 = OpLoad %float %549
-%1349 = OpFNegate %float %1348
-OpStore %556 %1349
-%1350 = OpLoad %float %556
-OpStore %557 %1350
-OpBranch %134
-%134 = OpLabel
-%1351 = OpLoad %float %557
-OpStore %558 %1351
-OpBranch %116
-%131 = OpLabel
-%1352 = OpLoad %float %550
-%1353 = OpLoad %float %549
-%1354 = OpFOrdLessThanEqual %bool %1352 %1353
-OpStore %552 %1354
-%1355 = OpLoad %bool %552
-OpSelectionMerge %129 None
-OpBranchConditional %1355 %127 %128
-%128 = OpLabel
-%1356 = OpLoad %float %549
-OpStore %554 %1356
-OpBranch %129
-%127 = OpLabel
-%1357 = OpLoad %float %549
-%1358 = OpLoad %float %550
-%1359 = OpFSub %float %1357 %1358
-OpStore %553 %1359
-%1360 = OpLoad %float %553
-OpStore %554 %1360
-OpBranch %129
-%129 = OpLabel
-%1361 = OpLoad %float %550
-%1362 = OpFDiv %float %1361 %float_2
-OpStore %555 %1362
-%1363 = OpLoad %float %554
-OpStore %549 %1363
-%1364 = OpLoad %float %555
-OpStore %550 %1364
-OpBranch %374
-%124 = OpLabel
-%1365 = OpLoad %float %546
-%1366 = OpFMul %float %1365 %float_2
-OpStore %548 %1366
-%1367 = OpLoad %float %548
-OpStore %546 %1367
-OpBranch %375
-%114 = OpLabel
-%1368 = OpLoad %float %462
-%1369 = OpLoad %float %527
-%1370 = OpFDiv %float %1368 %1369
-OpStore %534 %1370
-%1371 = OpLoad %float %534
-%1372 = OpConvertFToS %ulong %1371
-OpStore %535 %1372
-%1373 = OpLoad %ulong %535
-%1374 = OpConvertSToF %float %1373
-OpStore %536 %1374
-%1375 = OpLoad %float %536
-%1376 = OpLoad %float %527
-%1377 = OpFMul %float %1375 %1376
-OpStore %537 %1377
-%1378 = OpLoad %float %462
-%1379 = OpLoad %float %537
-%1380 = OpFSub %float %1378 %1379
-OpStore %538 %1380
-%1381 = OpLoad %float %538
-OpStore %558 %1381
-OpBranch %116
-%116 = OpLabel
-OpBranch %279
-%279 = OpLabel
-%1382 = OpLoad %float %558
-%1383 = OpLoad %float %558
-%1384 = OpFUnordNotEqual %bool %1382 %1383
-OpStore %737 %1384
-%1385 = OpLoad %bool %737
-OpSelectionMerge %283 None
-OpBranchConditional %1385 %280 %281
-%281 = OpLabel
-OpBranch %282
-%282 = OpLabel
-%1386 = OpLoad %ulong %736
-%1387 = OpLoad %float %558
-%1388 = OpFunctionCall %ulong %6 %1386 %1387
-OpStore %739 %1388
-%1389 = OpLoad %ulong %739
-OpStore %740 %1389
-OpBranch %283
-%280 = OpLabel
-%1390 = OpLoad %ulong %736
-%1391 = OpFunctionCall %ulong %5 %1390 %uint_4294967295
-OpStore %738 %1391
-%1392 = OpLoad %ulong %738
-OpStore %740 %1392
-OpBranch %283
-%283 = OpLabel
-%1393 = OpLoad %float %462
-%1394 = OpFSub %float %float_0 %1393
-OpStore %559 %1394
-%1395 = OpLoad %float %463
-%1396 = OpFSub %float %float_0 %1395
-OpStore %560 %1396
-%1397 = OpLoad %float %560
-%1398 = OpFOrdEqual %bool %1397 %float_0
-OpStore %561 %1398
-%1399 = OpLoad %bool %561
-OpSelectionMerge %138 None
-OpBranchConditional %1399 %355 %135
-%135 = OpLabel
-%1400 = OpLoad %float %559
-%1401 = OpFMul %float %1400 %float_2
-OpStore %562 %1401
-%1402 = OpLoad %float %559
-%1403 = OpLoad %float %562
-%1404 = OpFOrdEqual %bool %1402 %1403
-OpStore %563 %1404
-%1405 = OpLoad %bool %563
+%953 = OpLoad %float %737
+%955 = OpFMul %float %953 %float_0_5
+OpStore %447 %955
+%956 = OpLoad %ulong %446
+%957 = OpLoad %float %447
+%958 = OpFunctionCall %ulong %2 %956 %957
+OpStore %448 %958
+%959 = OpLoad %float %737
+%960 = OpFDiv %float %959 %float_2
+OpStore %449 %960
+%961 = OpLoad %ulong %448
+%962 = OpLoad %float %449
+%963 = OpFunctionCall %ulong %2 %961 %962
+OpStore %450 %963
+%964 = OpLoad %float %737
+%965 = OpLoad %float %739
+%966 = OpFSub %float %964 %965
+OpStore %451 %966
+%967 = OpLoad %ulong %450
+%968 = OpLoad %float %451
+%969 = OpFunctionCall %ulong %2 %967 %968
+OpStore %452 %969
+%970 = OpLoad %float %737
+%971 = OpLoad %float %735
+%972 = OpFMul %float %970 %971
+OpStore %453 %972
+%973 = OpLoad %ulong %452
+%974 = OpLoad %float %453
+%975 = OpFunctionCall %ulong %2 %973 %974
+OpStore %454 %975
+%976 = OpLoad %float %739
+%977 = OpLoad %float %739
+%978 = OpFAdd %float %976 %977
+OpStore %455 %978
+%979 = OpLoad %ulong %454
+%980 = OpLoad %float %455
+%981 = OpFunctionCall %ulong %2 %979 %980
+OpStore %456 %981
+%982 = OpLoad %float %739
+%983 = OpFMul %float %982 %float_0_5
+OpStore %457 %983
+%984 = OpLoad %ulong %456
+%985 = OpLoad %float %457
+%986 = OpFunctionCall %ulong %2 %984 %985
+OpStore %458 %986
+%987 = OpLoad %float %739
+%989 = OpFMul %float %987 %float_0_75
+OpStore %459 %989
+%990 = OpLoad %ulong %458
+%991 = OpLoad %float %459
+%992 = OpFunctionCall %ulong %2 %990 %991
+OpStore %460 %992
+%993 = OpLoad %float %739
+%994 = OpFMul %float %993 %float_16777216
+OpStore %461 %994
+%995 = OpLoad %ulong %460
+%996 = OpLoad %float %461
+%997 = OpFunctionCall %ulong %2 %995 %996
+OpStore %462 %997
+%998 = OpLoad %float %739
+%999 = OpLoad %float %737
+%1000 = OpFDiv %float %998 %999
+OpStore %463 %1000
+%1001 = OpLoad %ulong %462
+%1002 = OpLoad %float %463
+%1003 = OpFunctionCall %ulong %2 %1001 %1002
+OpStore %464 %1003
+%1005 = OpLoad %float %735
+%1006 = OpFMul %float %float_5_5 %1005
+OpStore %465 %1006
+%1007 = OpLoad %float %735
+%1008 = OpFMul %float %float_3 %1007
+OpStore %466 %1008
+%1009 = OpLoad %float %466
+%1010 = OpFOrdEqual %bool %1009 %float_0
+OpStore %467 %1010
+%1011 = OpLoad %bool %467
 OpSelectionMerge %137 None
-OpBranchConditional %1405 %136 %354
-%354 = OpLabel
-%1406 = OpLoad %bool %563
-OpStore %565 %1406
-OpBranch %137
+OpBranchConditional %1011 %345 %134
+%134 = OpLabel
+%1012 = OpLoad %float %465
+%1013 = OpFMul %float %1012 %float_2
+OpStore %468 %1013
+%1014 = OpLoad %float %465
+%1015 = OpLoad %float %468
+%1016 = OpFOrdEqual %bool %1014 %1015
+OpStore %469 %1016
+%1017 = OpLoad %bool %469
+OpSelectionMerge %136 None
+OpBranchConditional %1017 %135 %344
+%344 = OpLabel
+%1018 = OpLoad %bool %469
+OpStore %471 %1018
+OpBranch %136
+%135 = OpLabel
+%1019 = OpLoad %float %465
+%1020 = OpFUnordNotEqual %bool %1019 %float_0
+OpStore %470 %1020
+%1021 = OpLoad %bool %470
+OpStore %471 %1021
+OpBranch %136
 %136 = OpLabel
-%1407 = OpLoad %float %559
-%1408 = OpFUnordNotEqual %bool %1407 %float_0
-OpStore %564 %1408
-%1409 = OpLoad %bool %564
-OpStore %565 %1409
+%1022 = OpLoad %bool %471
+OpStore %472 %1022
+OpBranch %137
+%345 = OpLabel
+%1023 = OpLoad %bool %467
+OpStore %472 %1023
 OpBranch %137
 %137 = OpLabel
-%1410 = OpLoad %bool %565
-OpStore %566 %1410
-OpBranch %138
-%355 = OpLabel
-%1411 = OpLoad %bool %561
-OpStore %566 %1411
-OpBranch %138
-%138 = OpLabel
-%1412 = OpLoad %bool %566
-OpSelectionMerge %141 None
-OpBranchConditional %1412 %139 %140
-%140 = OpLabel
-%1413 = OpLoad %float %559
-%1414 = OpFOrdLessThan %bool %1413 %float_0
-OpStore %572 %1414
-%1415 = OpLoad %bool %572
-OpSelectionMerge %144 None
-OpBranchConditional %1415 %142 %143
-%143 = OpLabel
-%1416 = OpLoad %float %559
-OpStore %574 %1416
-OpBranch %144
+%1024 = OpLoad %bool %472
+OpSelectionMerge %140 None
+OpBranchConditional %1024 %138 %139
+%139 = OpLabel
+%1025 = OpLoad %float %465
+%1026 = OpFOrdLessThan %bool %1025 %float_0
+OpStore %478 %1026
+%1027 = OpLoad %bool %478
+OpSelectionMerge %143 None
+OpBranchConditional %1027 %141 %142
 %142 = OpLabel
-%1417 = OpLoad %float %559
-%1418 = OpFSub %float %float_0 %1417
-OpStore %573 %1418
-%1419 = OpLoad %float %573
-OpStore %574 %1419
-OpBranch %144
-%144 = OpLabel
-%1420 = OpLoad %float %560
-%1421 = OpFOrdLessThan %bool %1420 %float_0
-OpStore %575 %1421
-%1422 = OpLoad %bool %575
-OpSelectionMerge %147 None
-OpBranchConditional %1422 %145 %146
-%146 = OpLabel
-%1423 = OpLoad %float %560
-OpStore %577 %1423
-OpBranch %147
+%1028 = OpLoad %float %465
+OpStore %480 %1028
+OpBranch %143
+%141 = OpLabel
+%1029 = OpLoad %float %465
+%1030 = OpFSub %float %float_0 %1029
+OpStore %479 %1030
+%1031 = OpLoad %float %479
+OpStore %480 %1031
+OpBranch %143
+%143 = OpLabel
+%1032 = OpLoad %float %466
+%1033 = OpFOrdLessThan %bool %1032 %float_0
+OpStore %481 %1033
+%1034 = OpLoad %bool %481
+OpSelectionMerge %146 None
+OpBranchConditional %1034 %144 %145
 %145 = OpLabel
-%1424 = OpLoad %float %560
-%1425 = OpFSub %float %float_0 %1424
-OpStore %576 %1425
-%1426 = OpLoad %float %576
-OpStore %577 %1426
+%1035 = OpLoad %float %466
+OpStore %483 %1035
+OpBranch %146
+%144 = OpLabel
+%1036 = OpLoad %float %466
+%1037 = OpFSub %float %float_0 %1036
+OpStore %482 %1037
+%1038 = OpLoad %float %482
+OpStore %483 %1038
+OpBranch %146
+%146 = OpLabel
+%1039 = OpLoad %float %480
+%1040 = OpFDiv %float %1039 %float_2
+OpStore %484 %1040
+%1041 = OpLoad %float %483
+OpStore %485 %1041
 OpBranch %147
 %147 = OpLabel
-%1427 = OpLoad %float %574
-%1428 = OpFDiv %float %1427 %float_2
-OpStore %578 %1428
-%1429 = OpLoad %float %577
-OpStore %579 %1429
-OpBranch %148
-%148 = OpLabel
-%1430 = OpLoad %float %579
-%1431 = OpLoad %float %578
-%1432 = OpFOrdLessThanEqual %bool %1430 %1431
-OpStore %580 %1432
-%1433 = OpLoad %bool %580
-OpLoopMerge %150 %373 None
-OpBranchConditional %1433 %149 %150
-%150 = OpLabel
-%1434 = OpLoad %float %574
-OpStore %582 %1434
-%1435 = OpLoad %float %579
-OpStore %583 %1435
-OpBranch %151
-%151 = OpLabel
-%1436 = OpLoad %float %577
-%1437 = OpLoad %float %583
-%1438 = OpFOrdLessThanEqual %bool %1436 %1437
-OpStore %584 %1438
-%1439 = OpLoad %bool %584
-OpLoopMerge %155 %372 None
-OpBranchConditional %1439 %156 %155
-%155 = OpLabel
-%1440 = OpLoad %bool %572
-OpSelectionMerge %159 None
-OpBranchConditional %1440 %157 %158
-%158 = OpLabel
-%1441 = OpLoad %float %582
-OpStore %590 %1441
-OpBranch %159
-%157 = OpLabel
-%1442 = OpLoad %float %582
-%1443 = OpFNegate %float %1442
-OpStore %589 %1443
-%1444 = OpLoad %float %589
-OpStore %590 %1444
-OpBranch %159
-%159 = OpLabel
-%1445 = OpLoad %float %590
-OpStore %591 %1445
-OpBranch %141
-%156 = OpLabel
-%1446 = OpLoad %float %583
-%1447 = OpLoad %float %582
-%1448 = OpFOrdLessThanEqual %bool %1446 %1447
-OpStore %585 %1448
-%1449 = OpLoad %bool %585
-OpSelectionMerge %154 None
-OpBranchConditional %1449 %152 %153
-%153 = OpLabel
-%1450 = OpLoad %float %582
-OpStore %587 %1450
-OpBranch %154
-%152 = OpLabel
-%1451 = OpLoad %float %582
-%1452 = OpLoad %float %583
-%1453 = OpFSub %float %1451 %1452
-OpStore %586 %1453
-%1454 = OpLoad %float %586
-OpStore %587 %1454
-OpBranch %154
-%154 = OpLabel
-%1455 = OpLoad %float %583
-%1456 = OpFDiv %float %1455 %float_2
-OpStore %588 %1456
-%1457 = OpLoad %float %587
-OpStore %582 %1457
-%1458 = OpLoad %float %588
-OpStore %583 %1458
-OpBranch %372
+%1042 = OpLoad %float %485
+%1043 = OpLoad %float %484
+%1044 = OpFOrdLessThanEqual %bool %1042 %1043
+OpStore %486 %1044
+%1045 = OpLoad %bool %486
+OpLoopMerge %149 %375 None
+OpBranchConditional %1045 %148 %149
 %149 = OpLabel
-%1459 = OpLoad %float %579
-%1460 = OpFMul %float %1459 %float_2
-OpStore %581 %1460
-%1461 = OpLoad %float %581
-OpStore %579 %1461
+%1046 = OpLoad %float %480
+OpStore %488 %1046
+%1047 = OpLoad %float %485
+OpStore %489 %1047
+OpBranch %150
+%150 = OpLabel
+%1048 = OpLoad %float %483
+%1049 = OpLoad %float %489
+%1050 = OpFOrdLessThanEqual %bool %1048 %1049
+OpStore %490 %1050
+%1051 = OpLoad %bool %490
+OpLoopMerge %154 %373 None
+OpBranchConditional %1051 %155 %154
+%154 = OpLabel
+%1052 = OpLoad %bool %478
+OpSelectionMerge %158 None
+OpBranchConditional %1052 %156 %157
+%157 = OpLabel
+%1053 = OpLoad %float %488
+OpStore %496 %1053
+OpBranch %158
+%156 = OpLabel
+%1054 = OpLoad %float %488
+%1055 = OpFNegate %float %1054
+OpStore %495 %1055
+%1056 = OpLoad %float %495
+OpStore %496 %1056
+OpBranch %158
+%158 = OpLabel
+%1057 = OpLoad %float %496
+OpStore %497 %1057
+OpBranch %140
+%155 = OpLabel
+%1058 = OpLoad %float %489
+%1059 = OpLoad %float %488
+%1060 = OpFOrdLessThanEqual %bool %1058 %1059
+OpStore %491 %1060
+%1061 = OpLoad %bool %491
+OpSelectionMerge %153 None
+OpBranchConditional %1061 %151 %152
+%152 = OpLabel
+%1062 = OpLoad %float %488
+OpStore %493 %1062
+OpBranch %153
+%151 = OpLabel
+%1063 = OpLoad %float %488
+%1064 = OpLoad %float %489
+%1065 = OpFSub %float %1063 %1064
+OpStore %492 %1065
+%1066 = OpLoad %float %492
+OpStore %493 %1066
+OpBranch %153
+%153 = OpLabel
+%1067 = OpLoad %float %489
+%1068 = OpFDiv %float %1067 %float_2
+OpStore %494 %1068
+%1069 = OpLoad %float %493
+OpStore %488 %1069
+%1070 = OpLoad %float %494
+OpStore %489 %1070
 OpBranch %373
-%139 = OpLabel
-%1462 = OpLoad %float %559
-%1463 = OpLoad %float %560
-%1464 = OpFDiv %float %1462 %1463
-OpStore %567 %1464
-%1465 = OpLoad %float %567
-%1466 = OpConvertFToS %ulong %1465
-OpStore %568 %1466
-%1467 = OpLoad %ulong %568
-%1468 = OpConvertSToF %float %1467
-OpStore %569 %1468
-%1469 = OpLoad %float %569
-%1470 = OpLoad %float %560
-%1471 = OpFMul %float %1469 %1470
-OpStore %570 %1471
-%1472 = OpLoad %float %559
-%1473 = OpLoad %float %570
-%1474 = OpFSub %float %1472 %1473
-OpStore %571 %1474
-%1475 = OpLoad %float %571
-OpStore %591 %1475
-OpBranch %141
-%141 = OpLabel
-OpBranch %284
-%284 = OpLabel
-%1476 = OpLoad %float %591
-%1477 = OpLoad %float %591
-%1478 = OpFUnordNotEqual %bool %1476 %1477
-OpStore %741 %1478
-%1479 = OpLoad %bool %741
-OpSelectionMerge %288 None
-OpBranchConditional %1479 %285 %286
-%286 = OpLabel
-OpBranch %287
-%287 = OpLabel
-%1480 = OpLoad %ulong %740
-%1481 = OpLoad %float %591
-%1482 = OpFunctionCall %ulong %6 %1480 %1481
-OpStore %743 %1482
-%1483 = OpLoad %ulong %743
-OpStore %744 %1483
-OpBranch %288
-%285 = OpLabel
-%1484 = OpLoad %ulong %740
-%1485 = OpFunctionCall %ulong %5 %1484 %uint_4294967295
-OpStore %742 %1485
-%1486 = OpLoad %ulong %742
-OpStore %744 %1486
-OpBranch %288
-%288 = OpLabel
-%1488 = OpLoad %float %722
-%1489 = OpFMul %float %float_7 %1488
-OpStore %592 %1489
-%1490 = OpFOrdEqual %bool %float_0_5 %float_0
-OpStore %593 %1490
-%1491 = OpLoad %bool %593
-OpSelectionMerge %163 None
-OpBranchConditional %1491 %357 %160
-%160 = OpLabel
-%1492 = OpLoad %float %592
-%1493 = OpFMul %float %1492 %float_2
-OpStore %594 %1493
-%1494 = OpLoad %float %592
-%1495 = OpLoad %float %594
-%1496 = OpFOrdEqual %bool %1494 %1495
-OpStore %595 %1496
-%1497 = OpLoad %bool %595
+%148 = OpLabel
+%1071 = OpLoad %float %485
+%1072 = OpFMul %float %1071 %float_2
+OpStore %487 %1072
+%1073 = OpLoad %float %487
+OpStore %485 %1073
+OpBranch %375
+%138 = OpLabel
+%1074 = OpLoad %float %465
+%1075 = OpLoad %float %466
+%1076 = OpFDiv %float %1074 %1075
+OpStore %473 %1076
+%1077 = OpLoad %float %473
+%1078 = OpConvertFToS %ulong %1077
+OpStore %474 %1078
+%1079 = OpLoad %ulong %474
+%1080 = OpConvertSToF %float %1079
+OpStore %475 %1080
+%1081 = OpLoad %float %475
+%1082 = OpLoad %float %466
+%1083 = OpFMul %float %1081 %1082
+OpStore %476 %1083
+%1084 = OpLoad %float %465
+%1085 = OpLoad %float %476
+%1086 = OpFSub %float %1084 %1085
+OpStore %477 %1086
+%1087 = OpLoad %float %477
+OpStore %497 %1087
+OpBranch %140
+%140 = OpLabel
+%1088 = OpLoad %ulong %464
+%1089 = OpLoad %float %497
+%1090 = OpFunctionCall %ulong %2 %1088 %1089
+OpStore %498 %1090
+%1091 = OpLoad %float %465
+%1092 = OpFSub %float %float_0 %1091
+OpStore %499 %1092
+%1093 = OpLoad %float %466
+%1094 = OpFOrdEqual %bool %1093 %float_0
+OpStore %500 %1094
+%1095 = OpLoad %bool %500
 OpSelectionMerge %162 None
-OpBranchConditional %1497 %161 %356
-%356 = OpLabel
-%1498 = OpLoad %bool %595
-OpStore %597 %1498
-OpBranch %162
+OpBranchConditional %1095 %347 %159
+%159 = OpLabel
+%1096 = OpLoad %float %499
+%1097 = OpFMul %float %1096 %float_2
+OpStore %501 %1097
+%1098 = OpLoad %float %499
+%1099 = OpLoad %float %501
+%1100 = OpFOrdEqual %bool %1098 %1099
+OpStore %502 %1100
+%1101 = OpLoad %bool %502
+OpSelectionMerge %161 None
+OpBranchConditional %1101 %160 %346
+%346 = OpLabel
+%1102 = OpLoad %bool %502
+OpStore %504 %1102
+OpBranch %161
+%160 = OpLabel
+%1103 = OpLoad %float %499
+%1104 = OpFUnordNotEqual %bool %1103 %float_0
+OpStore %503 %1104
+%1105 = OpLoad %bool %503
+OpStore %504 %1105
+OpBranch %161
 %161 = OpLabel
-%1499 = OpLoad %float %592
-%1500 = OpFUnordNotEqual %bool %1499 %float_0
-OpStore %596 %1500
-%1501 = OpLoad %bool %596
-OpStore %597 %1501
+%1106 = OpLoad %bool %504
+OpStore %505 %1106
+OpBranch %162
+%347 = OpLabel
+%1107 = OpLoad %bool %500
+OpStore %505 %1107
 OpBranch %162
 %162 = OpLabel
-%1502 = OpLoad %bool %597
-OpStore %598 %1502
-OpBranch %163
-%357 = OpLabel
-%1503 = OpLoad %bool %593
-OpStore %598 %1503
-OpBranch %163
-%163 = OpLabel
-%1504 = OpLoad %bool %598
-OpSelectionMerge %166 None
-OpBranchConditional %1504 %164 %165
-%165 = OpLabel
-%1505 = OpLoad %float %592
-%1506 = OpFOrdLessThan %bool %1505 %float_0
-OpStore %604 %1506
-%1507 = OpLoad %bool %604
-OpSelectionMerge %169 None
-OpBranchConditional %1507 %167 %168
-%168 = OpLabel
-%1508 = OpLoad %float %592
-OpStore %606 %1508
-OpBranch %169
+%1108 = OpLoad %bool %505
+OpSelectionMerge %165 None
+OpBranchConditional %1108 %163 %164
+%164 = OpLabel
+%1109 = OpLoad %float %499
+%1110 = OpFOrdLessThan %bool %1109 %float_0
+OpStore %511 %1110
+%1111 = OpLoad %bool %511
+OpSelectionMerge %168 None
+OpBranchConditional %1111 %166 %167
 %167 = OpLabel
-%1509 = OpLoad %float %592
-%1510 = OpFSub %float %float_0 %1509
-OpStore %605 %1510
-%1511 = OpLoad %float %605
-OpStore %606 %1511
-OpBranch %169
-%169 = OpLabel
-%1512 = OpFOrdLessThan %bool %float_0_5 %float_0
-OpStore %607 %1512
-%1513 = OpLoad %bool %607
-OpSelectionMerge %172 None
-OpBranchConditional %1513 %170 %171
-%171 = OpLabel
-OpStore %609 %float_0_5
-OpBranch %172
+%1112 = OpLoad %float %499
+OpStore %513 %1112
+OpBranch %168
+%166 = OpLabel
+%1113 = OpLoad %float %499
+%1114 = OpFSub %float %float_0 %1113
+OpStore %512 %1114
+%1115 = OpLoad %float %512
+OpStore %513 %1115
+OpBranch %168
+%168 = OpLabel
+%1116 = OpLoad %float %466
+%1117 = OpFOrdLessThan %bool %1116 %float_0
+OpStore %514 %1117
+%1118 = OpLoad %bool %514
+OpSelectionMerge %171 None
+OpBranchConditional %1118 %169 %170
 %170 = OpLabel
-%1514 = OpFSub %float %float_0 %float_0_5
-OpStore %608 %1514
-%1515 = OpLoad %float %608
-OpStore %609 %1515
+%1119 = OpLoad %float %466
+OpStore %516 %1119
+OpBranch %171
+%169 = OpLabel
+%1120 = OpLoad %float %466
+%1121 = OpFSub %float %float_0 %1120
+OpStore %515 %1121
+%1122 = OpLoad %float %515
+OpStore %516 %1122
+OpBranch %171
+%171 = OpLabel
+%1123 = OpLoad %float %513
+%1124 = OpFDiv %float %1123 %float_2
+OpStore %517 %1124
+%1125 = OpLoad %float %516
+OpStore %518 %1125
 OpBranch %172
 %172 = OpLabel
-%1516 = OpLoad %float %606
-%1517 = OpFDiv %float %1516 %float_2
-OpStore %610 %1517
-%1518 = OpLoad %float %609
-OpStore %611 %1518
-OpBranch %173
-%173 = OpLabel
-%1519 = OpLoad %float %611
-%1520 = OpLoad %float %610
-%1521 = OpFOrdLessThanEqual %bool %1519 %1520
-OpStore %612 %1521
-%1522 = OpLoad %bool %612
-OpLoopMerge %175 %371 None
-OpBranchConditional %1522 %174 %175
-%175 = OpLabel
-%1523 = OpLoad %float %606
-OpStore %614 %1523
-%1524 = OpLoad %float %611
-OpStore %615 %1524
-OpBranch %176
-%176 = OpLabel
-%1525 = OpLoad %float %609
-%1526 = OpLoad %float %615
-%1527 = OpFOrdLessThanEqual %bool %1525 %1526
-OpStore %616 %1527
-%1528 = OpLoad %bool %616
-OpLoopMerge %180 %370 None
-OpBranchConditional %1528 %181 %180
-%180 = OpLabel
-%1529 = OpLoad %bool %604
-OpSelectionMerge %184 None
-OpBranchConditional %1529 %182 %183
-%183 = OpLabel
-%1530 = OpLoad %float %614
-OpStore %622 %1530
-OpBranch %184
-%182 = OpLabel
-%1531 = OpLoad %float %614
-%1532 = OpFNegate %float %1531
-OpStore %621 %1532
-%1533 = OpLoad %float %621
-OpStore %622 %1533
-OpBranch %184
-%184 = OpLabel
-%1534 = OpLoad %float %622
-OpStore %623 %1534
-OpBranch %166
-%181 = OpLabel
-%1535 = OpLoad %float %615
-%1536 = OpLoad %float %614
-%1537 = OpFOrdLessThanEqual %bool %1535 %1536
-OpStore %617 %1537
-%1538 = OpLoad %bool %617
-OpSelectionMerge %179 None
-OpBranchConditional %1538 %177 %178
-%178 = OpLabel
-%1539 = OpLoad %float %614
-OpStore %619 %1539
-OpBranch %179
-%177 = OpLabel
-%1540 = OpLoad %float %614
-%1541 = OpLoad %float %615
-%1542 = OpFSub %float %1540 %1541
-OpStore %618 %1542
-%1543 = OpLoad %float %618
-OpStore %619 %1543
-OpBranch %179
-%179 = OpLabel
-%1544 = OpLoad %float %615
-%1545 = OpFDiv %float %1544 %float_2
-OpStore %620 %1545
-%1546 = OpLoad %float %619
-OpStore %614 %1546
-%1547 = OpLoad %float %620
-OpStore %615 %1547
-OpBranch %370
+%1126 = OpLoad %float %518
+%1127 = OpLoad %float %517
+%1128 = OpFOrdLessThanEqual %bool %1126 %1127
+OpStore %519 %1128
+%1129 = OpLoad %bool %519
+OpLoopMerge %174 %374 None
+OpBranchConditional %1129 %173 %174
 %174 = OpLabel
-%1548 = OpLoad %float %611
-%1549 = OpFMul %float %1548 %float_2
-OpStore %613 %1549
-%1550 = OpLoad %float %613
-OpStore %611 %1550
+%1130 = OpLoad %float %513
+OpStore %521 %1130
+%1131 = OpLoad %float %518
+OpStore %522 %1131
+OpBranch %175
+%175 = OpLabel
+%1132 = OpLoad %float %516
+%1133 = OpLoad %float %522
+%1134 = OpFOrdLessThanEqual %bool %1132 %1133
+OpStore %523 %1134
+%1135 = OpLoad %bool %523
+OpLoopMerge %179 %371 None
+OpBranchConditional %1135 %180 %179
+%179 = OpLabel
+%1136 = OpLoad %bool %511
+OpSelectionMerge %183 None
+OpBranchConditional %1136 %181 %182
+%182 = OpLabel
+%1137 = OpLoad %float %521
+OpStore %529 %1137
+OpBranch %183
+%181 = OpLabel
+%1138 = OpLoad %float %521
+%1139 = OpFNegate %float %1138
+OpStore %528 %1139
+%1140 = OpLoad %float %528
+OpStore %529 %1140
+OpBranch %183
+%183 = OpLabel
+%1141 = OpLoad %float %529
+OpStore %530 %1141
+OpBranch %165
+%180 = OpLabel
+%1142 = OpLoad %float %522
+%1143 = OpLoad %float %521
+%1144 = OpFOrdLessThanEqual %bool %1142 %1143
+OpStore %524 %1144
+%1145 = OpLoad %bool %524
+OpSelectionMerge %178 None
+OpBranchConditional %1145 %176 %177
+%177 = OpLabel
+%1146 = OpLoad %float %521
+OpStore %526 %1146
+OpBranch %178
+%176 = OpLabel
+%1147 = OpLoad %float %521
+%1148 = OpLoad %float %522
+%1149 = OpFSub %float %1147 %1148
+OpStore %525 %1149
+%1150 = OpLoad %float %525
+OpStore %526 %1150
+OpBranch %178
+%178 = OpLabel
+%1151 = OpLoad %float %522
+%1152 = OpFDiv %float %1151 %float_2
+OpStore %527 %1152
+%1153 = OpLoad %float %526
+OpStore %521 %1153
+%1154 = OpLoad %float %527
+OpStore %522 %1154
 OpBranch %371
-%164 = OpLabel
-%1551 = OpLoad %float %592
-%1552 = OpFDiv %float %1551 %float_0_5
-OpStore %599 %1552
-%1553 = OpLoad %float %599
-%1554 = OpConvertFToS %ulong %1553
-OpStore %600 %1554
-%1555 = OpLoad %ulong %600
-%1556 = OpConvertSToF %float %1555
-OpStore %601 %1556
-%1557 = OpLoad %float %601
-%1558 = OpFMul %float %1557 %float_0_5
-OpStore %602 %1558
-%1559 = OpLoad %float %592
-%1560 = OpLoad %float %602
-%1561 = OpFSub %float %1559 %1560
-OpStore %603 %1561
-%1562 = OpLoad %float %603
-OpStore %623 %1562
-OpBranch %166
-%166 = OpLabel
-OpBranch %289
-%289 = OpLabel
-%1563 = OpLoad %float %623
-%1564 = OpLoad %float %623
-%1565 = OpFUnordNotEqual %bool %1563 %1564
-OpStore %745 %1565
-%1566 = OpLoad %bool %745
-OpSelectionMerge %293 None
-OpBranchConditional %1566 %290 %291
-%291 = OpLabel
-OpBranch %292
-%292 = OpLabel
-%1567 = OpLoad %ulong %744
-%1568 = OpLoad %float %623
-%1569 = OpFunctionCall %ulong %6 %1567 %1568
-OpStore %747 %1569
-%1570 = OpLoad %ulong %747
-OpStore %748 %1570
-OpBranch %293
-%290 = OpLabel
-%1571 = OpLoad %ulong %744
-%1572 = OpFunctionCall %ulong %5 %1571 %uint_4294967295
-OpStore %746 %1572
-%1573 = OpLoad %ulong %746
-OpStore %748 %1573
-OpBranch %293
-%293 = OpLabel
-%1574 = OpLoad %float %463
-%1575 = OpFOrdEqual %bool %1574 %float_0
-OpStore %624 %1575
-%1576 = OpLoad %bool %624
-OpSelectionMerge %188 None
-OpBranchConditional %1576 %359 %185
-%185 = OpLabel
-%1577 = OpLoad %float %722
-%1578 = OpFMul %float %1577 %float_2
-OpStore %625 %1578
-%1579 = OpLoad %float %722
-%1580 = OpLoad %float %625
-%1581 = OpFOrdEqual %bool %1579 %1580
-OpStore %626 %1581
-%1582 = OpLoad %bool %626
+%173 = OpLabel
+%1155 = OpLoad %float %518
+%1156 = OpFMul %float %1155 %float_2
+OpStore %520 %1156
+%1157 = OpLoad %float %520
+OpStore %518 %1157
+OpBranch %374
+%163 = OpLabel
+%1158 = OpLoad %float %499
+%1159 = OpLoad %float %466
+%1160 = OpFDiv %float %1158 %1159
+OpStore %506 %1160
+%1161 = OpLoad %float %506
+%1162 = OpConvertFToS %ulong %1161
+OpStore %507 %1162
+%1163 = OpLoad %ulong %507
+%1164 = OpConvertSToF %float %1163
+OpStore %508 %1164
+%1165 = OpLoad %float %508
+%1166 = OpLoad %float %466
+%1167 = OpFMul %float %1165 %1166
+OpStore %509 %1167
+%1168 = OpLoad %float %499
+%1169 = OpLoad %float %509
+%1170 = OpFSub %float %1168 %1169
+OpStore %510 %1170
+%1171 = OpLoad %float %510
+OpStore %530 %1171
+OpBranch %165
+%165 = OpLabel
+%1172 = OpLoad %ulong %498
+%1173 = OpLoad %float %530
+%1174 = OpFunctionCall %ulong %2 %1172 %1173
+OpStore %531 %1174
+%1175 = OpLoad %float %466
+%1176 = OpFSub %float %float_0 %1175
+OpStore %532 %1176
+%1177 = OpLoad %float %532
+%1178 = OpFOrdEqual %bool %1177 %float_0
+OpStore %533 %1178
+%1179 = OpLoad %bool %533
 OpSelectionMerge %187 None
-OpBranchConditional %1582 %186 %358
-%358 = OpLabel
-%1583 = OpLoad %bool %626
-OpStore %628 %1583
-OpBranch %187
+OpBranchConditional %1179 %349 %184
+%184 = OpLabel
+%1180 = OpLoad %float %465
+%1181 = OpFMul %float %1180 %float_2
+OpStore %534 %1181
+%1182 = OpLoad %float %465
+%1183 = OpLoad %float %534
+%1184 = OpFOrdEqual %bool %1182 %1183
+OpStore %535 %1184
+%1185 = OpLoad %bool %535
+OpSelectionMerge %186 None
+OpBranchConditional %1185 %185 %348
+%348 = OpLabel
+%1186 = OpLoad %bool %535
+OpStore %537 %1186
+OpBranch %186
+%185 = OpLabel
+%1187 = OpLoad %float %465
+%1188 = OpFUnordNotEqual %bool %1187 %float_0
+OpStore %536 %1188
+%1189 = OpLoad %bool %536
+OpStore %537 %1189
+OpBranch %186
 %186 = OpLabel
-%1584 = OpLoad %float %722
-%1585 = OpFUnordNotEqual %bool %1584 %float_0
-OpStore %627 %1585
-%1586 = OpLoad %bool %627
-OpStore %628 %1586
+%1190 = OpLoad %bool %537
+OpStore %538 %1190
+OpBranch %187
+%349 = OpLabel
+%1191 = OpLoad %bool %533
+OpStore %538 %1191
 OpBranch %187
 %187 = OpLabel
-%1587 = OpLoad %bool %628
-OpStore %629 %1587
-OpBranch %188
-%359 = OpLabel
-%1588 = OpLoad %bool %624
-OpStore %629 %1588
-OpBranch %188
-%188 = OpLabel
-%1589 = OpLoad %bool %629
-OpSelectionMerge %191 None
-OpBranchConditional %1589 %189 %190
-%190 = OpLabel
-%1590 = OpLoad %float %722
-%1591 = OpFOrdLessThan %bool %1590 %float_0
-OpStore %635 %1591
-%1592 = OpLoad %bool %635
-OpSelectionMerge %194 None
-OpBranchConditional %1592 %192 %193
-%193 = OpLabel
-%1593 = OpLoad %float %722
-OpStore %637 %1593
-OpBranch %194
+%1192 = OpLoad %bool %538
+OpSelectionMerge %190 None
+OpBranchConditional %1192 %188 %189
+%189 = OpLabel
+%1193 = OpLoad %float %465
+%1194 = OpFOrdLessThan %bool %1193 %float_0
+OpStore %544 %1194
+%1195 = OpLoad %bool %544
+OpSelectionMerge %193 None
+OpBranchConditional %1195 %191 %192
 %192 = OpLabel
-%1594 = OpLoad %float %722
-%1595 = OpFSub %float %float_0 %1594
-OpStore %636 %1595
-%1596 = OpLoad %float %636
-OpStore %637 %1596
-OpBranch %194
-%194 = OpLabel
-%1597 = OpLoad %float %463
-%1598 = OpFOrdLessThan %bool %1597 %float_0
-OpStore %638 %1598
-%1599 = OpLoad %bool %638
-OpSelectionMerge %197 None
-OpBranchConditional %1599 %195 %196
-%196 = OpLabel
-%1600 = OpLoad %float %463
-OpStore %640 %1600
-OpBranch %197
+%1196 = OpLoad %float %465
+OpStore %546 %1196
+OpBranch %193
+%191 = OpLabel
+%1197 = OpLoad %float %465
+%1198 = OpFSub %float %float_0 %1197
+OpStore %545 %1198
+%1199 = OpLoad %float %545
+OpStore %546 %1199
+OpBranch %193
+%193 = OpLabel
+%1200 = OpLoad %float %532
+%1201 = OpFOrdLessThan %bool %1200 %float_0
+OpStore %547 %1201
+%1202 = OpLoad %bool %547
+OpSelectionMerge %196 None
+OpBranchConditional %1202 %194 %195
 %195 = OpLabel
-%1601 = OpLoad %float %463
-%1602 = OpFSub %float %float_0 %1601
-OpStore %639 %1602
-%1603 = OpLoad %float %639
-OpStore %640 %1603
+%1203 = OpLoad %float %532
+OpStore %549 %1203
+OpBranch %196
+%194 = OpLabel
+%1204 = OpLoad %float %532
+%1205 = OpFSub %float %float_0 %1204
+OpStore %548 %1205
+%1206 = OpLoad %float %548
+OpStore %549 %1206
+OpBranch %196
+%196 = OpLabel
+%1207 = OpLoad %float %546
+%1208 = OpFDiv %float %1207 %float_2
+OpStore %550 %1208
+%1209 = OpLoad %float %549
+OpStore %551 %1209
 OpBranch %197
 %197 = OpLabel
-%1604 = OpLoad %float %637
-%1605 = OpFDiv %float %1604 %float_2
-OpStore %641 %1605
-%1606 = OpLoad %float %640
-OpStore %642 %1606
-OpBranch %198
-%198 = OpLabel
-%1607 = OpLoad %float %642
-%1608 = OpLoad %float %641
-%1609 = OpFOrdLessThanEqual %bool %1607 %1608
-OpStore %643 %1609
-%1610 = OpLoad %bool %643
-OpLoopMerge %200 %369 None
-OpBranchConditional %1610 %199 %200
-%200 = OpLabel
-%1611 = OpLoad %float %637
-OpStore %645 %1611
-%1612 = OpLoad %float %642
-OpStore %646 %1612
-OpBranch %201
-%201 = OpLabel
-%1613 = OpLoad %float %640
-%1614 = OpLoad %float %646
-%1615 = OpFOrdLessThanEqual %bool %1613 %1614
-OpStore %647 %1615
-%1616 = OpLoad %bool %647
-OpLoopMerge %205 %368 None
-OpBranchConditional %1616 %206 %205
-%205 = OpLabel
-%1617 = OpLoad %bool %635
-OpSelectionMerge %209 None
-OpBranchConditional %1617 %207 %208
-%208 = OpLabel
-%1618 = OpLoad %float %645
-OpStore %653 %1618
-OpBranch %209
-%207 = OpLabel
-%1619 = OpLoad %float %645
-%1620 = OpFNegate %float %1619
-OpStore %652 %1620
-%1621 = OpLoad %float %652
-OpStore %653 %1621
-OpBranch %209
-%209 = OpLabel
-%1622 = OpLoad %float %653
-OpStore %654 %1622
-OpBranch %191
-%206 = OpLabel
-%1623 = OpLoad %float %646
-%1624 = OpLoad %float %645
-%1625 = OpFOrdLessThanEqual %bool %1623 %1624
-OpStore %648 %1625
-%1626 = OpLoad %bool %648
-OpSelectionMerge %204 None
-OpBranchConditional %1626 %202 %203
-%203 = OpLabel
-%1627 = OpLoad %float %645
-OpStore %650 %1627
-OpBranch %204
-%202 = OpLabel
-%1628 = OpLoad %float %645
-%1629 = OpLoad %float %646
-%1630 = OpFSub %float %1628 %1629
-OpStore %649 %1630
-%1631 = OpLoad %float %649
-OpStore %650 %1631
-OpBranch %204
-%204 = OpLabel
-%1632 = OpLoad %float %646
-%1633 = OpFDiv %float %1632 %float_2
-OpStore %651 %1633
-%1634 = OpLoad %float %650
-OpStore %645 %1634
-%1635 = OpLoad %float %651
-OpStore %646 %1635
-OpBranch %368
+%1210 = OpLoad %float %551
+%1211 = OpLoad %float %550
+%1212 = OpFOrdLessThanEqual %bool %1210 %1211
+OpStore %552 %1212
+%1213 = OpLoad %bool %552
+OpLoopMerge %199 %372 None
+OpBranchConditional %1213 %198 %199
 %199 = OpLabel
-%1636 = OpLoad %float %642
-%1637 = OpFMul %float %1636 %float_2
-OpStore %644 %1637
-%1638 = OpLoad %float %644
-OpStore %642 %1638
+%1214 = OpLoad %float %546
+OpStore %554 %1214
+%1215 = OpLoad %float %551
+OpStore %555 %1215
+OpBranch %200
+%200 = OpLabel
+%1216 = OpLoad %float %549
+%1217 = OpLoad %float %555
+%1218 = OpFOrdLessThanEqual %bool %1216 %1217
+OpStore %556 %1218
+%1219 = OpLoad %bool %556
+OpLoopMerge %204 %369 None
+OpBranchConditional %1219 %205 %204
+%204 = OpLabel
+%1220 = OpLoad %bool %544
+OpSelectionMerge %208 None
+OpBranchConditional %1220 %206 %207
+%207 = OpLabel
+%1221 = OpLoad %float %554
+OpStore %562 %1221
+OpBranch %208
+%206 = OpLabel
+%1222 = OpLoad %float %554
+%1223 = OpFNegate %float %1222
+OpStore %561 %1223
+%1224 = OpLoad %float %561
+OpStore %562 %1224
+OpBranch %208
+%208 = OpLabel
+%1225 = OpLoad %float %562
+OpStore %563 %1225
+OpBranch %190
+%205 = OpLabel
+%1226 = OpLoad %float %555
+%1227 = OpLoad %float %554
+%1228 = OpFOrdLessThanEqual %bool %1226 %1227
+OpStore %557 %1228
+%1229 = OpLoad %bool %557
+OpSelectionMerge %203 None
+OpBranchConditional %1229 %201 %202
+%202 = OpLabel
+%1230 = OpLoad %float %554
+OpStore %559 %1230
+OpBranch %203
+%201 = OpLabel
+%1231 = OpLoad %float %554
+%1232 = OpLoad %float %555
+%1233 = OpFSub %float %1231 %1232
+OpStore %558 %1233
+%1234 = OpLoad %float %558
+OpStore %559 %1234
+OpBranch %203
+%203 = OpLabel
+%1235 = OpLoad %float %555
+%1236 = OpFDiv %float %1235 %float_2
+OpStore %560 %1236
+%1237 = OpLoad %float %559
+OpStore %554 %1237
+%1238 = OpLoad %float %560
+OpStore %555 %1238
 OpBranch %369
-%189 = OpLabel
-%1639 = OpLoad %float %722
-%1640 = OpLoad %float %463
-%1641 = OpFDiv %float %1639 %1640
-OpStore %630 %1641
-%1642 = OpLoad %float %630
-%1643 = OpConvertFToS %ulong %1642
-OpStore %631 %1643
-%1644 = OpLoad %ulong %631
-%1645 = OpConvertSToF %float %1644
-OpStore %632 %1645
-%1646 = OpLoad %float %632
-%1647 = OpLoad %float %463
-%1648 = OpFMul %float %1646 %1647
-OpStore %633 %1648
-%1649 = OpLoad %float %722
-%1650 = OpLoad %float %633
-%1651 = OpFSub %float %1649 %1650
-OpStore %634 %1651
-%1652 = OpLoad %float %634
-OpStore %654 %1652
-OpBranch %191
-%191 = OpLabel
-OpBranch %294
-%294 = OpLabel
-%1653 = OpLoad %float %654
-%1654 = OpLoad %float %654
-%1655 = OpFUnordNotEqual %bool %1653 %1654
-OpStore %749 %1655
-%1656 = OpLoad %bool %749
-OpSelectionMerge %298 None
-OpBranchConditional %1656 %295 %296
-%296 = OpLabel
-OpBranch %297
-%297 = OpLabel
-%1657 = OpLoad %ulong %748
-%1658 = OpLoad %float %654
-%1659 = OpFunctionCall %ulong %6 %1657 %1658
-OpStore %751 %1659
-%1660 = OpLoad %ulong %751
-OpStore %752 %1660
-OpBranch %298
-%295 = OpLabel
-%1661 = OpLoad %ulong %748
-%1662 = OpFunctionCall %ulong %5 %1661 %uint_4294967295
-OpStore %750 %1662
-%1663 = OpLoad %ulong %750
-OpStore %752 %1663
-OpBranch %298
-%298 = OpLabel
-%1664 = OpLoad %float %463
-%1665 = OpFOrdEqual %bool %1664 %float_0
-OpStore %655 %1665
-%1666 = OpLoad %bool %655
-OpSelectionMerge %213 None
-OpBranchConditional %1666 %361 %210
-%210 = OpLabel
-%1667 = OpLoad %float %463
-%1668 = OpFMul %float %1667 %float_2
-OpStore %656 %1668
-%1669 = OpLoad %float %463
-%1670 = OpLoad %float %656
-%1671 = OpFOrdEqual %bool %1669 %1670
-OpStore %657 %1671
-%1672 = OpLoad %bool %657
+%198 = OpLabel
+%1239 = OpLoad %float %551
+%1240 = OpFMul %float %1239 %float_2
+OpStore %553 %1240
+%1241 = OpLoad %float %553
+OpStore %551 %1241
+OpBranch %372
+%188 = OpLabel
+%1242 = OpLoad %float %465
+%1243 = OpLoad %float %532
+%1244 = OpFDiv %float %1242 %1243
+OpStore %539 %1244
+%1245 = OpLoad %float %539
+%1246 = OpConvertFToS %ulong %1245
+OpStore %540 %1246
+%1247 = OpLoad %ulong %540
+%1248 = OpConvertSToF %float %1247
+OpStore %541 %1248
+%1249 = OpLoad %float %541
+%1250 = OpLoad %float %532
+%1251 = OpFMul %float %1249 %1250
+OpStore %542 %1251
+%1252 = OpLoad %float %465
+%1253 = OpLoad %float %542
+%1254 = OpFSub %float %1252 %1253
+OpStore %543 %1254
+%1255 = OpLoad %float %543
+OpStore %563 %1255
+OpBranch %190
+%190 = OpLabel
+%1256 = OpLoad %ulong %531
+%1257 = OpLoad %float %563
+%1258 = OpFunctionCall %ulong %2 %1256 %1257
+OpStore %564 %1258
+%1259 = OpLoad %float %465
+%1260 = OpFSub %float %float_0 %1259
+OpStore %565 %1260
+%1261 = OpLoad %float %466
+%1262 = OpFSub %float %float_0 %1261
+OpStore %566 %1262
+%1263 = OpLoad %float %566
+%1264 = OpFOrdEqual %bool %1263 %float_0
+OpStore %567 %1264
+%1265 = OpLoad %bool %567
 OpSelectionMerge %212 None
-OpBranchConditional %1672 %211 %360
-%360 = OpLabel
-%1673 = OpLoad %bool %657
-OpStore %659 %1673
-OpBranch %212
+OpBranchConditional %1265 %351 %209
+%209 = OpLabel
+%1266 = OpLoad %float %565
+%1267 = OpFMul %float %1266 %float_2
+OpStore %568 %1267
+%1268 = OpLoad %float %565
+%1269 = OpLoad %float %568
+%1270 = OpFOrdEqual %bool %1268 %1269
+OpStore %569 %1270
+%1271 = OpLoad %bool %569
+OpSelectionMerge %211 None
+OpBranchConditional %1271 %210 %350
+%350 = OpLabel
+%1272 = OpLoad %bool %569
+OpStore %571 %1272
+OpBranch %211
+%210 = OpLabel
+%1273 = OpLoad %float %565
+%1274 = OpFUnordNotEqual %bool %1273 %float_0
+OpStore %570 %1274
+%1275 = OpLoad %bool %570
+OpStore %571 %1275
+OpBranch %211
 %211 = OpLabel
-%1674 = OpLoad %float %463
-%1675 = OpFUnordNotEqual %bool %1674 %float_0
-OpStore %658 %1675
-%1676 = OpLoad %bool %658
-OpStore %659 %1676
+%1276 = OpLoad %bool %571
+OpStore %572 %1276
+OpBranch %212
+%351 = OpLabel
+%1277 = OpLoad %bool %567
+OpStore %572 %1277
 OpBranch %212
 %212 = OpLabel
-%1677 = OpLoad %bool %659
-OpStore %660 %1677
-OpBranch %213
-%361 = OpLabel
-%1678 = OpLoad %bool %655
-OpStore %660 %1678
-OpBranch %213
-%213 = OpLabel
-%1679 = OpLoad %bool %660
-OpSelectionMerge %216 None
-OpBranchConditional %1679 %214 %215
-%215 = OpLabel
-%1680 = OpLoad %float %463
-%1681 = OpFOrdLessThan %bool %1680 %float_0
-OpStore %666 %1681
-%1682 = OpLoad %bool %666
-OpSelectionMerge %219 None
-OpBranchConditional %1682 %217 %218
-%218 = OpLabel
-%1683 = OpLoad %float %463
-OpStore %668 %1683
-OpBranch %219
+%1278 = OpLoad %bool %572
+OpSelectionMerge %215 None
+OpBranchConditional %1278 %213 %214
+%214 = OpLabel
+%1279 = OpLoad %float %565
+%1280 = OpFOrdLessThan %bool %1279 %float_0
+OpStore %578 %1280
+%1281 = OpLoad %bool %578
+OpSelectionMerge %218 None
+OpBranchConditional %1281 %216 %217
 %217 = OpLabel
-%1684 = OpLoad %float %463
-%1685 = OpFSub %float %float_0 %1684
-OpStore %667 %1685
-%1686 = OpLoad %float %667
-OpStore %668 %1686
-OpBranch %219
-%219 = OpLabel
-%1687 = OpLoad %float %463
-%1688 = OpFOrdLessThan %bool %1687 %float_0
-OpStore %669 %1688
-%1689 = OpLoad %bool %669
-OpSelectionMerge %222 None
-OpBranchConditional %1689 %220 %221
-%221 = OpLabel
-%1690 = OpLoad %float %463
-OpStore %671 %1690
-OpBranch %222
+%1282 = OpLoad %float %565
+OpStore %580 %1282
+OpBranch %218
+%216 = OpLabel
+%1283 = OpLoad %float %565
+%1284 = OpFSub %float %float_0 %1283
+OpStore %579 %1284
+%1285 = OpLoad %float %579
+OpStore %580 %1285
+OpBranch %218
+%218 = OpLabel
+%1286 = OpLoad %float %566
+%1287 = OpFOrdLessThan %bool %1286 %float_0
+OpStore %581 %1287
+%1288 = OpLoad %bool %581
+OpSelectionMerge %221 None
+OpBranchConditional %1288 %219 %220
 %220 = OpLabel
-%1691 = OpLoad %float %463
-%1692 = OpFSub %float %float_0 %1691
-OpStore %670 %1692
-%1693 = OpLoad %float %670
-OpStore %671 %1693
+%1289 = OpLoad %float %566
+OpStore %583 %1289
+OpBranch %221
+%219 = OpLabel
+%1290 = OpLoad %float %566
+%1291 = OpFSub %float %float_0 %1290
+OpStore %582 %1291
+%1292 = OpLoad %float %582
+OpStore %583 %1292
+OpBranch %221
+%221 = OpLabel
+%1293 = OpLoad %float %580
+%1294 = OpFDiv %float %1293 %float_2
+OpStore %584 %1294
+%1295 = OpLoad %float %583
+OpStore %585 %1295
 OpBranch %222
 %222 = OpLabel
-%1694 = OpLoad %float %668
-%1695 = OpFDiv %float %1694 %float_2
-OpStore %672 %1695
-%1696 = OpLoad %float %671
-OpStore %673 %1696
-OpBranch %223
-%223 = OpLabel
-%1697 = OpLoad %float %673
-%1698 = OpLoad %float %672
-%1699 = OpFOrdLessThanEqual %bool %1697 %1698
-OpStore %674 %1699
-%1700 = OpLoad %bool %674
-OpLoopMerge %225 %367 None
-OpBranchConditional %1700 %224 %225
-%225 = OpLabel
-%1701 = OpLoad %float %668
-OpStore %676 %1701
-%1702 = OpLoad %float %673
-OpStore %677 %1702
-OpBranch %226
-%226 = OpLabel
-%1703 = OpLoad %float %671
-%1704 = OpLoad %float %677
-%1705 = OpFOrdLessThanEqual %bool %1703 %1704
-OpStore %678 %1705
-%1706 = OpLoad %bool %678
-OpLoopMerge %230 %366 None
-OpBranchConditional %1706 %231 %230
-%230 = OpLabel
-%1707 = OpLoad %bool %666
-OpSelectionMerge %234 None
-OpBranchConditional %1707 %232 %233
-%233 = OpLabel
-%1708 = OpLoad %float %676
-OpStore %684 %1708
-OpBranch %234
-%232 = OpLabel
-%1709 = OpLoad %float %676
-%1710 = OpFNegate %float %1709
-OpStore %683 %1710
-%1711 = OpLoad %float %683
-OpStore %684 %1711
-OpBranch %234
-%234 = OpLabel
-%1712 = OpLoad %float %684
-OpStore %685 %1712
-OpBranch %216
-%231 = OpLabel
-%1713 = OpLoad %float %677
-%1714 = OpLoad %float %676
-%1715 = OpFOrdLessThanEqual %bool %1713 %1714
-OpStore %679 %1715
-%1716 = OpLoad %bool %679
-OpSelectionMerge %229 None
-OpBranchConditional %1716 %227 %228
-%228 = OpLabel
-%1717 = OpLoad %float %676
-OpStore %681 %1717
-OpBranch %229
-%227 = OpLabel
-%1718 = OpLoad %float %676
-%1719 = OpLoad %float %677
-%1720 = OpFSub %float %1718 %1719
-OpStore %680 %1720
-%1721 = OpLoad %float %680
-OpStore %681 %1721
-OpBranch %229
-%229 = OpLabel
-%1722 = OpLoad %float %677
-%1723 = OpFDiv %float %1722 %float_2
-OpStore %682 %1723
-%1724 = OpLoad %float %681
-OpStore %676 %1724
-%1725 = OpLoad %float %682
-OpStore %677 %1725
-OpBranch %366
+%1296 = OpLoad %float %585
+%1297 = OpLoad %float %584
+%1298 = OpFOrdLessThanEqual %bool %1296 %1297
+OpStore %586 %1298
+%1299 = OpLoad %bool %586
+OpLoopMerge %224 %370 None
+OpBranchConditional %1299 %223 %224
 %224 = OpLabel
-%1726 = OpLoad %float %673
-%1727 = OpFMul %float %1726 %float_2
-OpStore %675 %1727
-%1728 = OpLoad %float %675
-OpStore %673 %1728
+%1300 = OpLoad %float %580
+OpStore %588 %1300
+%1301 = OpLoad %float %585
+OpStore %589 %1301
+OpBranch %225
+%225 = OpLabel
+%1302 = OpLoad %float %583
+%1303 = OpLoad %float %589
+%1304 = OpFOrdLessThanEqual %bool %1302 %1303
+OpStore %590 %1304
+%1305 = OpLoad %bool %590
+OpLoopMerge %229 %367 None
+OpBranchConditional %1305 %230 %229
+%229 = OpLabel
+%1306 = OpLoad %bool %578
+OpSelectionMerge %233 None
+OpBranchConditional %1306 %231 %232
+%232 = OpLabel
+%1307 = OpLoad %float %588
+OpStore %596 %1307
+OpBranch %233
+%231 = OpLabel
+%1308 = OpLoad %float %588
+%1309 = OpFNegate %float %1308
+OpStore %595 %1309
+%1310 = OpLoad %float %595
+OpStore %596 %1310
+OpBranch %233
+%233 = OpLabel
+%1311 = OpLoad %float %596
+OpStore %597 %1311
+OpBranch %215
+%230 = OpLabel
+%1312 = OpLoad %float %589
+%1313 = OpLoad %float %588
+%1314 = OpFOrdLessThanEqual %bool %1312 %1313
+OpStore %591 %1314
+%1315 = OpLoad %bool %591
+OpSelectionMerge %228 None
+OpBranchConditional %1315 %226 %227
+%227 = OpLabel
+%1316 = OpLoad %float %588
+OpStore %593 %1316
+OpBranch %228
+%226 = OpLabel
+%1317 = OpLoad %float %588
+%1318 = OpLoad %float %589
+%1319 = OpFSub %float %1317 %1318
+OpStore %592 %1319
+%1320 = OpLoad %float %592
+OpStore %593 %1320
+OpBranch %228
+%228 = OpLabel
+%1321 = OpLoad %float %589
+%1322 = OpFDiv %float %1321 %float_2
+OpStore %594 %1322
+%1323 = OpLoad %float %593
+OpStore %588 %1323
+%1324 = OpLoad %float %594
+OpStore %589 %1324
 OpBranch %367
-%214 = OpLabel
-%1729 = OpLoad %float %463
-%1730 = OpLoad %float %463
-%1731 = OpFDiv %float %1729 %1730
-OpStore %661 %1731
-%1732 = OpLoad %float %661
-%1733 = OpConvertFToS %ulong %1732
-OpStore %662 %1733
-%1734 = OpLoad %ulong %662
-%1735 = OpConvertSToF %float %1734
-OpStore %663 %1735
-%1736 = OpLoad %float %663
-%1737 = OpLoad %float %463
-%1738 = OpFMul %float %1736 %1737
-OpStore %664 %1738
-%1739 = OpLoad %float %463
-%1740 = OpLoad %float %664
-%1741 = OpFSub %float %1739 %1740
-OpStore %665 %1741
-%1742 = OpLoad %float %665
-OpStore %685 %1742
-OpBranch %216
-%216 = OpLabel
-OpBranch %299
-%299 = OpLabel
-%1743 = OpLoad %float %685
-%1744 = OpLoad %float %685
-%1745 = OpFUnordNotEqual %bool %1743 %1744
-OpStore %753 %1745
-%1746 = OpLoad %bool %753
-OpSelectionMerge %303 None
-OpBranchConditional %1746 %300 %301
-%301 = OpLabel
-OpBranch %302
-%302 = OpLabel
-%1747 = OpLoad %ulong %752
-%1748 = OpLoad %float %685
-%1749 = OpFunctionCall %ulong %6 %1747 %1748
-OpStore %755 %1749
-%1750 = OpLoad %ulong %755
-OpStore %756 %1750
-OpBranch %303
-%300 = OpLabel
-%1751 = OpLoad %ulong %752
-%1752 = OpFunctionCall %ulong %5 %1751 %uint_4294967295
-OpStore %754 %1752
-%1753 = OpLoad %ulong %754
-OpStore %756 %1753
-OpBranch %303
-%303 = OpLabel
-%1755 = OpLoad %float %722
-%1756 = OpFMul %float %float_1048576 %1755
-OpStore %686 %1756
-%1757 = OpLoad %float %463
-%1758 = OpFOrdEqual %bool %1757 %float_0
-OpStore %687 %1758
-%1759 = OpLoad %bool %687
-OpSelectionMerge %238 None
-OpBranchConditional %1759 %363 %235
-%235 = OpLabel
-%1760 = OpLoad %float %686
-%1761 = OpFMul %float %1760 %float_2
-OpStore %688 %1761
-%1762 = OpLoad %float %686
-%1763 = OpLoad %float %688
-%1764 = OpFOrdEqual %bool %1762 %1763
-OpStore %689 %1764
-%1765 = OpLoad %bool %689
+%223 = OpLabel
+%1325 = OpLoad %float %585
+%1326 = OpFMul %float %1325 %float_2
+OpStore %587 %1326
+%1327 = OpLoad %float %587
+OpStore %585 %1327
+OpBranch %370
+%213 = OpLabel
+%1328 = OpLoad %float %565
+%1329 = OpLoad %float %566
+%1330 = OpFDiv %float %1328 %1329
+OpStore %573 %1330
+%1331 = OpLoad %float %573
+%1332 = OpConvertFToS %ulong %1331
+OpStore %574 %1332
+%1333 = OpLoad %ulong %574
+%1334 = OpConvertSToF %float %1333
+OpStore %575 %1334
+%1335 = OpLoad %float %575
+%1336 = OpLoad %float %566
+%1337 = OpFMul %float %1335 %1336
+OpStore %576 %1337
+%1338 = OpLoad %float %565
+%1339 = OpLoad %float %576
+%1340 = OpFSub %float %1338 %1339
+OpStore %577 %1340
+%1341 = OpLoad %float %577
+OpStore %597 %1341
+OpBranch %215
+%215 = OpLabel
+%1342 = OpLoad %ulong %564
+%1343 = OpLoad %float %597
+%1344 = OpFunctionCall %ulong %2 %1342 %1343
+OpStore %598 %1344
+%1346 = OpLoad %float %735
+%1347 = OpFMul %float %float_7 %1346
+OpStore %599 %1347
+%1348 = OpFOrdEqual %bool %float_0_5 %float_0
+OpStore %600 %1348
+%1349 = OpLoad %bool %600
 OpSelectionMerge %237 None
-OpBranchConditional %1765 %236 %362
-%362 = OpLabel
-%1766 = OpLoad %bool %689
-OpStore %691 %1766
-OpBranch %237
+OpBranchConditional %1349 %353 %234
+%234 = OpLabel
+%1350 = OpLoad %float %599
+%1351 = OpFMul %float %1350 %float_2
+OpStore %601 %1351
+%1352 = OpLoad %float %599
+%1353 = OpLoad %float %601
+%1354 = OpFOrdEqual %bool %1352 %1353
+OpStore %602 %1354
+%1355 = OpLoad %bool %602
+OpSelectionMerge %236 None
+OpBranchConditional %1355 %235 %352
+%352 = OpLabel
+%1356 = OpLoad %bool %602
+OpStore %604 %1356
+OpBranch %236
+%235 = OpLabel
+%1357 = OpLoad %float %599
+%1358 = OpFUnordNotEqual %bool %1357 %float_0
+OpStore %603 %1358
+%1359 = OpLoad %bool %603
+OpStore %604 %1359
+OpBranch %236
 %236 = OpLabel
-%1767 = OpLoad %float %686
-%1768 = OpFUnordNotEqual %bool %1767 %float_0
-OpStore %690 %1768
-%1769 = OpLoad %bool %690
-OpStore %691 %1769
+%1360 = OpLoad %bool %604
+OpStore %605 %1360
+OpBranch %237
+%353 = OpLabel
+%1361 = OpLoad %bool %600
+OpStore %605 %1361
 OpBranch %237
 %237 = OpLabel
-%1770 = OpLoad %bool %691
-OpStore %692 %1770
-OpBranch %238
-%363 = OpLabel
-%1771 = OpLoad %bool %687
-OpStore %692 %1771
-OpBranch %238
-%238 = OpLabel
-%1772 = OpLoad %bool %692
-OpSelectionMerge %241 None
-OpBranchConditional %1772 %239 %240
-%240 = OpLabel
-%1773 = OpLoad %float %686
-%1774 = OpFOrdLessThan %bool %1773 %float_0
-OpStore %698 %1774
-%1775 = OpLoad %bool %698
-OpSelectionMerge %244 None
-OpBranchConditional %1775 %242 %243
-%243 = OpLabel
-%1776 = OpLoad %float %686
-OpStore %700 %1776
-OpBranch %244
+%1362 = OpLoad %bool %605
+OpSelectionMerge %240 None
+OpBranchConditional %1362 %238 %239
+%239 = OpLabel
+%1363 = OpLoad %float %599
+%1364 = OpFOrdLessThan %bool %1363 %float_0
+OpStore %611 %1364
+%1365 = OpLoad %bool %611
+OpSelectionMerge %243 None
+OpBranchConditional %1365 %241 %242
 %242 = OpLabel
-%1777 = OpLoad %float %686
-%1778 = OpFSub %float %float_0 %1777
-OpStore %699 %1778
-%1779 = OpLoad %float %699
-OpStore %700 %1779
-OpBranch %244
-%244 = OpLabel
-%1780 = OpLoad %float %463
-%1781 = OpFOrdLessThan %bool %1780 %float_0
-OpStore %701 %1781
-%1782 = OpLoad %bool %701
-OpSelectionMerge %247 None
-OpBranchConditional %1782 %245 %246
-%246 = OpLabel
-%1783 = OpLoad %float %463
-OpStore %703 %1783
-OpBranch %247
+%1366 = OpLoad %float %599
+OpStore %613 %1366
+OpBranch %243
+%241 = OpLabel
+%1367 = OpLoad %float %599
+%1368 = OpFSub %float %float_0 %1367
+OpStore %612 %1368
+%1369 = OpLoad %float %612
+OpStore %613 %1369
+OpBranch %243
+%243 = OpLabel
+%1370 = OpFOrdLessThan %bool %float_0_5 %float_0
+OpStore %614 %1370
+%1371 = OpLoad %bool %614
+OpSelectionMerge %246 None
+OpBranchConditional %1371 %244 %245
 %245 = OpLabel
-%1784 = OpLoad %float %463
-%1785 = OpFSub %float %float_0 %1784
-OpStore %702 %1785
-%1786 = OpLoad %float %702
-OpStore %703 %1786
+OpStore %616 %float_0_5
+OpBranch %246
+%244 = OpLabel
+%1372 = OpFSub %float %float_0 %float_0_5
+OpStore %615 %1372
+%1373 = OpLoad %float %615
+OpStore %616 %1373
+OpBranch %246
+%246 = OpLabel
+%1374 = OpLoad %float %613
+%1375 = OpFDiv %float %1374 %float_2
+OpStore %617 %1375
+%1376 = OpLoad %float %616
+OpStore %618 %1376
 OpBranch %247
 %247 = OpLabel
-%1787 = OpLoad %float %700
-%1788 = OpFDiv %float %1787 %float_2
-OpStore %704 %1788
-%1789 = OpLoad %float %703
-OpStore %705 %1789
-OpBranch %248
-%248 = OpLabel
-%1790 = OpLoad %float %705
-%1791 = OpLoad %float %704
-%1792 = OpFOrdLessThanEqual %bool %1790 %1791
-OpStore %706 %1792
-%1793 = OpLoad %bool %706
-OpLoopMerge %250 %365 None
-OpBranchConditional %1793 %249 %250
-%250 = OpLabel
-%1794 = OpLoad %float %700
-OpStore %708 %1794
-%1795 = OpLoad %float %705
-OpStore %709 %1795
-OpBranch %251
-%251 = OpLabel
-%1796 = OpLoad %float %703
-%1797 = OpLoad %float %709
-%1798 = OpFOrdLessThanEqual %bool %1796 %1797
-OpStore %710 %1798
-%1799 = OpLoad %bool %710
-OpLoopMerge %255 %364 None
-OpBranchConditional %1799 %256 %255
-%255 = OpLabel
-%1800 = OpLoad %bool %698
-OpSelectionMerge %259 None
-OpBranchConditional %1800 %257 %258
-%258 = OpLabel
-%1801 = OpLoad %float %708
-OpStore %716 %1801
-OpBranch %259
-%257 = OpLabel
-%1802 = OpLoad %float %708
-%1803 = OpFNegate %float %1802
-OpStore %715 %1803
-%1804 = OpLoad %float %715
-OpStore %716 %1804
-OpBranch %259
-%259 = OpLabel
-%1805 = OpLoad %float %716
-OpStore %717 %1805
-OpBranch %241
-%256 = OpLabel
-%1806 = OpLoad %float %709
-%1807 = OpLoad %float %708
-%1808 = OpFOrdLessThanEqual %bool %1806 %1807
-OpStore %711 %1808
-%1809 = OpLoad %bool %711
-OpSelectionMerge %254 None
-OpBranchConditional %1809 %252 %253
-%253 = OpLabel
-%1810 = OpLoad %float %708
-OpStore %713 %1810
-OpBranch %254
-%252 = OpLabel
-%1811 = OpLoad %float %708
-%1812 = OpLoad %float %709
-%1813 = OpFSub %float %1811 %1812
-OpStore %712 %1813
-%1814 = OpLoad %float %712
-OpStore %713 %1814
-OpBranch %254
-%254 = OpLabel
-%1815 = OpLoad %float %709
-%1816 = OpFDiv %float %1815 %float_2
-OpStore %714 %1816
-%1817 = OpLoad %float %713
-OpStore %708 %1817
-%1818 = OpLoad %float %714
-OpStore %709 %1818
-OpBranch %364
+%1377 = OpLoad %float %618
+%1378 = OpLoad %float %617
+%1379 = OpFOrdLessThanEqual %bool %1377 %1378
+OpStore %619 %1379
+%1380 = OpLoad %bool %619
+OpLoopMerge %249 %368 None
+OpBranchConditional %1380 %248 %249
 %249 = OpLabel
-%1819 = OpLoad %float %705
-%1820 = OpFMul %float %1819 %float_2
-OpStore %707 %1820
-%1821 = OpLoad %float %707
-OpStore %705 %1821
+%1381 = OpLoad %float %613
+OpStore %621 %1381
+%1382 = OpLoad %float %618
+OpStore %622 %1382
+OpBranch %250
+%250 = OpLabel
+%1383 = OpLoad %float %616
+%1384 = OpLoad %float %622
+%1385 = OpFOrdLessThanEqual %bool %1383 %1384
+OpStore %623 %1385
+%1386 = OpLoad %bool %623
+OpLoopMerge %254 %365 None
+OpBranchConditional %1386 %255 %254
+%254 = OpLabel
+%1387 = OpLoad %bool %611
+OpSelectionMerge %258 None
+OpBranchConditional %1387 %256 %257
+%257 = OpLabel
+%1388 = OpLoad %float %621
+OpStore %629 %1388
+OpBranch %258
+%256 = OpLabel
+%1389 = OpLoad %float %621
+%1390 = OpFNegate %float %1389
+OpStore %628 %1390
+%1391 = OpLoad %float %628
+OpStore %629 %1391
+OpBranch %258
+%258 = OpLabel
+%1392 = OpLoad %float %629
+OpStore %630 %1392
+OpBranch %240
+%255 = OpLabel
+%1393 = OpLoad %float %622
+%1394 = OpLoad %float %621
+%1395 = OpFOrdLessThanEqual %bool %1393 %1394
+OpStore %624 %1395
+%1396 = OpLoad %bool %624
+OpSelectionMerge %253 None
+OpBranchConditional %1396 %251 %252
+%252 = OpLabel
+%1397 = OpLoad %float %621
+OpStore %626 %1397
+OpBranch %253
+%251 = OpLabel
+%1398 = OpLoad %float %621
+%1399 = OpLoad %float %622
+%1400 = OpFSub %float %1398 %1399
+OpStore %625 %1400
+%1401 = OpLoad %float %625
+OpStore %626 %1401
+OpBranch %253
+%253 = OpLabel
+%1402 = OpLoad %float %622
+%1403 = OpFDiv %float %1402 %float_2
+OpStore %627 %1403
+%1404 = OpLoad %float %626
+OpStore %621 %1404
+%1405 = OpLoad %float %627
+OpStore %622 %1405
 OpBranch %365
-%239 = OpLabel
-%1822 = OpLoad %float %686
-%1823 = OpLoad %float %463
-%1824 = OpFDiv %float %1822 %1823
-OpStore %693 %1824
-%1825 = OpLoad %float %693
-%1826 = OpConvertFToS %ulong %1825
-OpStore %694 %1826
-%1827 = OpLoad %ulong %694
-%1828 = OpConvertSToF %float %1827
-OpStore %695 %1828
-%1829 = OpLoad %float %695
-%1830 = OpLoad %float %463
-%1831 = OpFMul %float %1829 %1830
-OpStore %696 %1831
-%1832 = OpLoad %float %686
-%1833 = OpLoad %float %696
-%1834 = OpFSub %float %1832 %1833
-OpStore %697 %1834
-%1835 = OpLoad %float %697
-OpStore %717 %1835
-OpBranch %241
-%241 = OpLabel
-OpBranch %304
-%304 = OpLabel
-%1836 = OpLoad %float %717
-%1837 = OpLoad %float %717
-%1838 = OpFUnordNotEqual %bool %1836 %1837
-OpStore %757 %1838
-%1839 = OpLoad %bool %757
-OpSelectionMerge %308 None
-OpBranchConditional %1839 %305 %306
-%306 = OpLabel
-OpBranch %307
-%307 = OpLabel
-%1840 = OpLoad %ulong %756
-%1841 = OpLoad %float %717
-%1842 = OpFunctionCall %ulong %6 %1840 %1841
-OpStore %759 %1842
-%1843 = OpLoad %ulong %759
-OpStore %760 %1843
-OpBranch %308
-%305 = OpLabel
-%1844 = OpLoad %ulong %756
-%1845 = OpFunctionCall %ulong %5 %1844 %uint_4294967295
-OpStore %758 %1845
-%1846 = OpLoad %ulong %758
-OpStore %760 %1846
-OpBranch %308
-%308 = OpLabel
-%1847 = OpLoad %ulong %760
-OpReturnValue %1847
-%58 = OpLabel
-%1848 = OpLoad %float %719
-%1849 = OpLoad %float %403
-%1850 = OpFAdd %float %1848 %1849
-OpStore %431 %1850
-%1851 = OpLoad %float %431
-%1852 = OpFMul %float %1851 %float_1_5
-OpStore %432 %1852
+%248 = OpLabel
+%1406 = OpLoad %float %618
+%1407 = OpFMul %float %1406 %float_2
+OpStore %620 %1407
+%1408 = OpLoad %float %620
+OpStore %618 %1408
+OpBranch %368
+%238 = OpLabel
+%1409 = OpLoad %float %599
+%1410 = OpFDiv %float %1409 %float_0_5
+OpStore %606 %1410
+%1411 = OpLoad %float %606
+%1412 = OpConvertFToS %ulong %1411
+OpStore %607 %1412
+%1413 = OpLoad %ulong %607
+%1414 = OpConvertSToF %float %1413
+OpStore %608 %1414
+%1415 = OpLoad %float %608
+%1416 = OpFMul %float %1415 %float_0_5
+OpStore %609 %1416
+%1417 = OpLoad %float %599
+%1418 = OpLoad %float %609
+%1419 = OpFSub %float %1417 %1418
+OpStore %610 %1419
+%1420 = OpLoad %float %610
+OpStore %630 %1420
+OpBranch %240
+%240 = OpLabel
+%1421 = OpLoad %ulong %598
+%1422 = OpLoad %float %630
+%1423 = OpFunctionCall %ulong %2 %1421 %1422
+OpStore %631 %1423
+%1424 = OpLoad %float %466
+%1425 = OpFOrdEqual %bool %1424 %float_0
+OpStore %632 %1425
+%1426 = OpLoad %bool %632
+OpSelectionMerge %262 None
+OpBranchConditional %1426 %355 %259
+%259 = OpLabel
+%1427 = OpLoad %float %735
+%1428 = OpFMul %float %1427 %float_2
+OpStore %633 %1428
+%1429 = OpLoad %float %735
+%1430 = OpLoad %float %633
+%1431 = OpFOrdEqual %bool %1429 %1430
+OpStore %634 %1431
+%1432 = OpLoad %bool %634
+OpSelectionMerge %261 None
+OpBranchConditional %1432 %260 %354
+%354 = OpLabel
+%1433 = OpLoad %bool %634
+OpStore %636 %1433
+OpBranch %261
+%260 = OpLabel
+%1434 = OpLoad %float %735
+%1435 = OpFUnordNotEqual %bool %1434 %float_0
+OpStore %635 %1435
+%1436 = OpLoad %bool %635
+OpStore %636 %1436
+OpBranch %261
+%261 = OpLabel
+%1437 = OpLoad %bool %636
+OpStore %637 %1437
+OpBranch %262
+%355 = OpLabel
+%1438 = OpLoad %bool %632
+OpStore %637 %1438
 OpBranch %262
 %262 = OpLabel
-%1853 = OpLoad %float %432
-%1854 = OpLoad %float %432
-%1855 = OpFUnordNotEqual %bool %1853 %1854
-OpStore %723 %1855
-%1856 = OpLoad %bool %723
-OpSelectionMerge %266 None
-OpBranchConditional %1856 %263 %264
+%1439 = OpLoad %bool %637
+OpSelectionMerge %265 None
+OpBranchConditional %1439 %263 %264
 %264 = OpLabel
+%1440 = OpLoad %float %735
+%1441 = OpFOrdLessThan %bool %1440 %float_0
+OpStore %643 %1441
+%1442 = OpLoad %bool %643
+OpSelectionMerge %268 None
+OpBranchConditional %1442 %266 %267
+%267 = OpLabel
+%1443 = OpLoad %float %735
+OpStore %645 %1443
+OpBranch %268
+%266 = OpLabel
+%1444 = OpLoad %float %735
+%1445 = OpFSub %float %float_0 %1444
+OpStore %644 %1445
+%1446 = OpLoad %float %644
+OpStore %645 %1446
+OpBranch %268
+%268 = OpLabel
+%1447 = OpLoad %float %466
+%1448 = OpFOrdLessThan %bool %1447 %float_0
+OpStore %646 %1448
+%1449 = OpLoad %bool %646
+OpSelectionMerge %271 None
+OpBranchConditional %1449 %269 %270
+%270 = OpLabel
+%1450 = OpLoad %float %466
+OpStore %648 %1450
+OpBranch %271
+%269 = OpLabel
+%1451 = OpLoad %float %466
+%1452 = OpFSub %float %float_0 %1451
+OpStore %647 %1452
+%1453 = OpLoad %float %647
+OpStore %648 %1453
+OpBranch %271
+%271 = OpLabel
+%1454 = OpLoad %float %645
+%1455 = OpFDiv %float %1454 %float_2
+OpStore %649 %1455
+%1456 = OpLoad %float %648
+OpStore %650 %1456
+OpBranch %272
+%272 = OpLabel
+%1457 = OpLoad %float %650
+%1458 = OpLoad %float %649
+%1459 = OpFOrdLessThanEqual %bool %1457 %1458
+OpStore %651 %1459
+%1460 = OpLoad %bool %651
+OpLoopMerge %274 %366 None
+OpBranchConditional %1460 %273 %274
+%274 = OpLabel
+%1461 = OpLoad %float %645
+OpStore %653 %1461
+%1462 = OpLoad %float %650
+OpStore %654 %1462
+OpBranch %275
+%275 = OpLabel
+%1463 = OpLoad %float %648
+%1464 = OpLoad %float %654
+%1465 = OpFOrdLessThanEqual %bool %1463 %1464
+OpStore %655 %1465
+%1466 = OpLoad %bool %655
+OpLoopMerge %279 %363 None
+OpBranchConditional %1466 %280 %279
+%279 = OpLabel
+%1467 = OpLoad %bool %643
+OpSelectionMerge %283 None
+OpBranchConditional %1467 %281 %282
+%282 = OpLabel
+%1468 = OpLoad %float %653
+OpStore %661 %1468
+OpBranch %283
+%281 = OpLabel
+%1469 = OpLoad %float %653
+%1470 = OpFNegate %float %1469
+OpStore %660 %1470
+%1471 = OpLoad %float %660
+OpStore %661 %1471
+OpBranch %283
+%283 = OpLabel
+%1472 = OpLoad %float %661
+OpStore %662 %1472
+OpBranch %265
+%280 = OpLabel
+%1473 = OpLoad %float %654
+%1474 = OpLoad %float %653
+%1475 = OpFOrdLessThanEqual %bool %1473 %1474
+OpStore %656 %1475
+%1476 = OpLoad %bool %656
+OpSelectionMerge %278 None
+OpBranchConditional %1476 %276 %277
+%277 = OpLabel
+%1477 = OpLoad %float %653
+OpStore %658 %1477
+OpBranch %278
+%276 = OpLabel
+%1478 = OpLoad %float %653
+%1479 = OpLoad %float %654
+%1480 = OpFSub %float %1478 %1479
+OpStore %657 %1480
+%1481 = OpLoad %float %657
+OpStore %658 %1481
+OpBranch %278
+%278 = OpLabel
+%1482 = OpLoad %float %654
+%1483 = OpFDiv %float %1482 %float_2
+OpStore %659 %1483
+%1484 = OpLoad %float %658
+OpStore %653 %1484
+%1485 = OpLoad %float %659
+OpStore %654 %1485
+OpBranch %363
+%273 = OpLabel
+%1486 = OpLoad %float %650
+%1487 = OpFMul %float %1486 %float_2
+OpStore %652 %1487
+%1488 = OpLoad %float %652
+OpStore %650 %1488
+OpBranch %366
+%263 = OpLabel
+%1489 = OpLoad %float %735
+%1490 = OpLoad %float %466
+%1491 = OpFDiv %float %1489 %1490
+OpStore %638 %1491
+%1492 = OpLoad %float %638
+%1493 = OpConvertFToS %ulong %1492
+OpStore %639 %1493
+%1494 = OpLoad %ulong %639
+%1495 = OpConvertSToF %float %1494
+OpStore %640 %1495
+%1496 = OpLoad %float %640
+%1497 = OpLoad %float %466
+%1498 = OpFMul %float %1496 %1497
+OpStore %641 %1498
+%1499 = OpLoad %float %735
+%1500 = OpLoad %float %641
+%1501 = OpFSub %float %1499 %1500
+OpStore %642 %1501
+%1502 = OpLoad %float %642
+OpStore %662 %1502
 OpBranch %265
 %265 = OpLabel
-%1857 = OpLoad %ulong %718
-%1858 = OpLoad %float %432
-%1859 = OpFunctionCall %ulong %6 %1857 %1858
-OpStore %725 %1859
-%1860 = OpLoad %ulong %725
-OpStore %726 %1860
-OpBranch %266
-%263 = OpLabel
-%1861 = OpLoad %ulong %718
-%1862 = OpFunctionCall %ulong %5 %1861 %uint_4294967295
-OpStore %724 %1862
-%1863 = OpLoad %ulong %724
-OpStore %726 %1863
-OpBranch %266
-%266 = OpLabel
-%1864 = OpLoad %uint %720
-%1865 = OpIAdd %uint %1864 %uint_1
-OpStore %433 %1865
-%1866 = OpLoad %ulong %726
-OpStore %718 %1866
-%1867 = OpLoad %float %432
-OpStore %719 %1867
-%1868 = OpLoad %uint %433
-OpStore %720 %1868
-OpBranch %380
+%1503 = OpLoad %ulong %631
+%1504 = OpLoad %float %662
+%1505 = OpFunctionCall %ulong %2 %1503 %1504
+OpStore %663 %1505
+%1506 = OpLoad %float %466
+%1507 = OpFOrdEqual %bool %1506 %float_0
+OpStore %664 %1507
+%1508 = OpLoad %bool %664
+OpSelectionMerge %287 None
+OpBranchConditional %1508 %357 %284
+%284 = OpLabel
+%1509 = OpLoad %float %466
+%1510 = OpFMul %float %1509 %float_2
+OpStore %665 %1510
+%1511 = OpLoad %float %466
+%1512 = OpLoad %float %665
+%1513 = OpFOrdEqual %bool %1511 %1512
+OpStore %666 %1513
+%1514 = OpLoad %bool %666
+OpSelectionMerge %286 None
+OpBranchConditional %1514 %285 %356
+%356 = OpLabel
+%1515 = OpLoad %bool %666
+OpStore %668 %1515
+OpBranch %286
+%285 = OpLabel
+%1516 = OpLoad %float %466
+%1517 = OpFUnordNotEqual %bool %1516 %float_0
+OpStore %667 %1517
+%1518 = OpLoad %bool %667
+OpStore %668 %1518
+OpBranch %286
+%286 = OpLabel
+%1519 = OpLoad %bool %668
+OpStore %669 %1519
+OpBranch %287
+%357 = OpLabel
+%1520 = OpLoad %bool %664
+OpStore %669 %1520
+OpBranch %287
+%287 = OpLabel
+%1521 = OpLoad %bool %669
+OpSelectionMerge %290 None
+OpBranchConditional %1521 %288 %289
+%289 = OpLabel
+%1522 = OpLoad %float %466
+%1523 = OpFOrdLessThan %bool %1522 %float_0
+OpStore %675 %1523
+%1524 = OpLoad %bool %675
+OpSelectionMerge %293 None
+OpBranchConditional %1524 %291 %292
+%292 = OpLabel
+%1525 = OpLoad %float %466
+OpStore %677 %1525
+OpBranch %293
+%291 = OpLabel
+%1526 = OpLoad %float %466
+%1527 = OpFSub %float %float_0 %1526
+OpStore %676 %1527
+%1528 = OpLoad %float %676
+OpStore %677 %1528
+OpBranch %293
+%293 = OpLabel
+%1529 = OpLoad %float %466
+%1530 = OpFOrdLessThan %bool %1529 %float_0
+OpStore %678 %1530
+%1531 = OpLoad %bool %678
+OpSelectionMerge %296 None
+OpBranchConditional %1531 %294 %295
+%295 = OpLabel
+%1532 = OpLoad %float %466
+OpStore %680 %1532
+OpBranch %296
+%294 = OpLabel
+%1533 = OpLoad %float %466
+%1534 = OpFSub %float %float_0 %1533
+OpStore %679 %1534
+%1535 = OpLoad %float %679
+OpStore %680 %1535
+OpBranch %296
+%296 = OpLabel
+%1536 = OpLoad %float %677
+%1537 = OpFDiv %float %1536 %float_2
+OpStore %681 %1537
+%1538 = OpLoad %float %680
+OpStore %682 %1538
+OpBranch %297
+%297 = OpLabel
+%1539 = OpLoad %float %682
+%1540 = OpLoad %float %681
+%1541 = OpFOrdLessThanEqual %bool %1539 %1540
+OpStore %683 %1541
+%1542 = OpLoad %bool %683
+OpLoopMerge %299 %364 None
+OpBranchConditional %1542 %298 %299
+%299 = OpLabel
+%1543 = OpLoad %float %677
+OpStore %685 %1543
+%1544 = OpLoad %float %682
+OpStore %686 %1544
+OpBranch %300
+%300 = OpLabel
+%1545 = OpLoad %float %680
+%1546 = OpLoad %float %686
+%1547 = OpFOrdLessThanEqual %bool %1545 %1546
+OpStore %687 %1547
+%1548 = OpLoad %bool %687
+OpLoopMerge %304 %361 None
+OpBranchConditional %1548 %305 %304
+%304 = OpLabel
+%1549 = OpLoad %bool %675
+OpSelectionMerge %308 None
+OpBranchConditional %1549 %306 %307
+%307 = OpLabel
+%1550 = OpLoad %float %685
+OpStore %693 %1550
+OpBranch %308
+%306 = OpLabel
+%1551 = OpLoad %float %685
+%1552 = OpFNegate %float %1551
+OpStore %692 %1552
+%1553 = OpLoad %float %692
+OpStore %693 %1553
+OpBranch %308
+%308 = OpLabel
+%1554 = OpLoad %float %693
+OpStore %694 %1554
+OpBranch %290
+%305 = OpLabel
+%1555 = OpLoad %float %686
+%1556 = OpLoad %float %685
+%1557 = OpFOrdLessThanEqual %bool %1555 %1556
+OpStore %688 %1557
+%1558 = OpLoad %bool %688
+OpSelectionMerge %303 None
+OpBranchConditional %1558 %301 %302
+%302 = OpLabel
+%1559 = OpLoad %float %685
+OpStore %690 %1559
+OpBranch %303
+%301 = OpLabel
+%1560 = OpLoad %float %685
+%1561 = OpLoad %float %686
+%1562 = OpFSub %float %1560 %1561
+OpStore %689 %1562
+%1563 = OpLoad %float %689
+OpStore %690 %1563
+OpBranch %303
+%303 = OpLabel
+%1564 = OpLoad %float %686
+%1565 = OpFDiv %float %1564 %float_2
+OpStore %691 %1565
+%1566 = OpLoad %float %690
+OpStore %685 %1566
+%1567 = OpLoad %float %691
+OpStore %686 %1567
+OpBranch %361
+%298 = OpLabel
+%1568 = OpLoad %float %682
+%1569 = OpFMul %float %1568 %float_2
+OpStore %684 %1569
+%1570 = OpLoad %float %684
+OpStore %682 %1570
+OpBranch %364
+%288 = OpLabel
+%1571 = OpLoad %float %466
+%1572 = OpLoad %float %466
+%1573 = OpFDiv %float %1571 %1572
+OpStore %670 %1573
+%1574 = OpLoad %float %670
+%1575 = OpConvertFToS %ulong %1574
+OpStore %671 %1575
+%1576 = OpLoad %ulong %671
+%1577 = OpConvertSToF %float %1576
+OpStore %672 %1577
+%1578 = OpLoad %float %672
+%1579 = OpLoad %float %466
+%1580 = OpFMul %float %1578 %1579
+OpStore %673 %1580
+%1581 = OpLoad %float %466
+%1582 = OpLoad %float %673
+%1583 = OpFSub %float %1581 %1582
+OpStore %674 %1583
+%1584 = OpLoad %float %674
+OpStore %694 %1584
+OpBranch %290
+%290 = OpLabel
+%1585 = OpLoad %ulong %663
+%1586 = OpLoad %float %694
+%1587 = OpFunctionCall %ulong %2 %1585 %1586
+OpStore %695 %1587
+%1589 = OpLoad %float %735
+%1590 = OpFMul %float %float_1048576 %1589
+OpStore %696 %1590
+%1591 = OpLoad %float %466
+%1592 = OpFOrdEqual %bool %1591 %float_0
+OpStore %697 %1592
+%1593 = OpLoad %bool %697
+OpSelectionMerge %312 None
+OpBranchConditional %1593 %359 %309
+%309 = OpLabel
+%1594 = OpLoad %float %696
+%1595 = OpFMul %float %1594 %float_2
+OpStore %698 %1595
+%1596 = OpLoad %float %696
+%1597 = OpLoad %float %698
+%1598 = OpFOrdEqual %bool %1596 %1597
+OpStore %699 %1598
+%1599 = OpLoad %bool %699
+OpSelectionMerge %311 None
+OpBranchConditional %1599 %310 %358
+%358 = OpLabel
+%1600 = OpLoad %bool %699
+OpStore %701 %1600
+OpBranch %311
+%310 = OpLabel
+%1601 = OpLoad %float %696
+%1602 = OpFUnordNotEqual %bool %1601 %float_0
+OpStore %700 %1602
+%1603 = OpLoad %bool %700
+OpStore %701 %1603
+OpBranch %311
+%311 = OpLabel
+%1604 = OpLoad %bool %701
+OpStore %702 %1604
+OpBranch %312
+%359 = OpLabel
+%1605 = OpLoad %bool %697
+OpStore %702 %1605
+OpBranch %312
+%312 = OpLabel
+%1606 = OpLoad %bool %702
+OpSelectionMerge %315 None
+OpBranchConditional %1606 %313 %314
+%314 = OpLabel
+%1607 = OpLoad %float %696
+%1608 = OpFOrdLessThan %bool %1607 %float_0
+OpStore %708 %1608
+%1609 = OpLoad %bool %708
+OpSelectionMerge %318 None
+OpBranchConditional %1609 %316 %317
+%317 = OpLabel
+%1610 = OpLoad %float %696
+OpStore %710 %1610
+OpBranch %318
+%316 = OpLabel
+%1611 = OpLoad %float %696
+%1612 = OpFSub %float %float_0 %1611
+OpStore %709 %1612
+%1613 = OpLoad %float %709
+OpStore %710 %1613
+OpBranch %318
+%318 = OpLabel
+%1614 = OpLoad %float %466
+%1615 = OpFOrdLessThan %bool %1614 %float_0
+OpStore %711 %1615
+%1616 = OpLoad %bool %711
+OpSelectionMerge %321 None
+OpBranchConditional %1616 %319 %320
+%320 = OpLabel
+%1617 = OpLoad %float %466
+OpStore %713 %1617
+OpBranch %321
+%319 = OpLabel
+%1618 = OpLoad %float %466
+%1619 = OpFSub %float %float_0 %1618
+OpStore %712 %1619
+%1620 = OpLoad %float %712
+OpStore %713 %1620
+OpBranch %321
+%321 = OpLabel
+%1621 = OpLoad %float %710
+%1622 = OpFDiv %float %1621 %float_2
+OpStore %714 %1622
+%1623 = OpLoad %float %713
+OpStore %715 %1623
+OpBranch %322
+%322 = OpLabel
+%1624 = OpLoad %float %715
+%1625 = OpLoad %float %714
+%1626 = OpFOrdLessThanEqual %bool %1624 %1625
+OpStore %716 %1626
+%1627 = OpLoad %bool %716
+OpLoopMerge %324 %362 None
+OpBranchConditional %1627 %323 %324
+%324 = OpLabel
+%1628 = OpLoad %float %710
+OpStore %718 %1628
+%1629 = OpLoad %float %715
+OpStore %719 %1629
+OpBranch %325
+%325 = OpLabel
+%1630 = OpLoad %float %713
+%1631 = OpLoad %float %719
+%1632 = OpFOrdLessThanEqual %bool %1630 %1631
+OpStore %720 %1632
+%1633 = OpLoad %bool %720
+OpLoopMerge %329 %360 None
+OpBranchConditional %1633 %330 %329
+%329 = OpLabel
+%1634 = OpLoad %bool %708
+OpSelectionMerge %333 None
+OpBranchConditional %1634 %331 %332
+%332 = OpLabel
+%1635 = OpLoad %float %718
+OpStore %726 %1635
+OpBranch %333
+%331 = OpLabel
+%1636 = OpLoad %float %718
+%1637 = OpFNegate %float %1636
+OpStore %725 %1637
+%1638 = OpLoad %float %725
+OpStore %726 %1638
+OpBranch %333
+%333 = OpLabel
+%1639 = OpLoad %float %726
+OpStore %727 %1639
+OpBranch %315
+%330 = OpLabel
+%1640 = OpLoad %float %719
+%1641 = OpLoad %float %718
+%1642 = OpFOrdLessThanEqual %bool %1640 %1641
+OpStore %721 %1642
+%1643 = OpLoad %bool %721
+OpSelectionMerge %328 None
+OpBranchConditional %1643 %326 %327
+%327 = OpLabel
+%1644 = OpLoad %float %718
+OpStore %723 %1644
+OpBranch %328
+%326 = OpLabel
+%1645 = OpLoad %float %718
+%1646 = OpLoad %float %719
+%1647 = OpFSub %float %1645 %1646
+OpStore %722 %1647
+%1648 = OpLoad %float %722
+OpStore %723 %1648
+OpBranch %328
+%328 = OpLabel
+%1649 = OpLoad %float %719
+%1650 = OpFDiv %float %1649 %float_2
+OpStore %724 %1650
+%1651 = OpLoad %float %723
+OpStore %718 %1651
+%1652 = OpLoad %float %724
+OpStore %719 %1652
+OpBranch %360
+%323 = OpLabel
+%1653 = OpLoad %float %715
+%1654 = OpFMul %float %1653 %float_2
+OpStore %717 %1654
+%1655 = OpLoad %float %717
+OpStore %715 %1655
+OpBranch %362
+%313 = OpLabel
+%1656 = OpLoad %float %696
+%1657 = OpLoad %float %466
+%1658 = OpFDiv %float %1656 %1657
+OpStore %703 %1658
+%1659 = OpLoad %float %703
+%1660 = OpConvertFToS %ulong %1659
+OpStore %704 %1660
+%1661 = OpLoad %ulong %704
+%1662 = OpConvertSToF %float %1661
+OpStore %705 %1662
+%1663 = OpLoad %float %705
+%1664 = OpLoad %float %466
+%1665 = OpFMul %float %1663 %1664
+OpStore %706 %1665
+%1666 = OpLoad %float %696
+%1667 = OpLoad %float %706
+%1668 = OpFSub %float %1666 %1667
+OpStore %707 %1668
+%1669 = OpLoad %float %707
+OpStore %727 %1669
+OpBranch %315
+%315 = OpLabel
+%1670 = OpLoad %ulong %695
+%1671 = OpLoad %float %727
+%1672 = OpFunctionCall %ulong %2 %1670 %1671
+OpStore %728 %1672
+%1673 = OpLoad %ulong %728
+OpReturnValue %1673
+%132 = OpLabel
+%1674 = OpLoad %float %730
+%1675 = OpLoad %float %402
+%1676 = OpFAdd %float %1674 %1675
+OpStore %430 %1676
+%1677 = OpLoad %float %430
+%1678 = OpFMul %float %1677 %float_1_5
+OpStore %431 %1678
+%1679 = OpLoad %ulong %729
+%1680 = OpLoad %float %431
+%1681 = OpFunctionCall %ulong %2 %1679 %1680
+OpStore %432 %1681
+%1682 = OpLoad %uint %731
+%1683 = OpIAdd %uint %1682 %uint_1
+OpStore %433 %1683
+%1684 = OpLoad %ulong %432
+OpStore %729 %1684
+%1685 = OpLoad %float %431
+OpStore %730 %1685
+%1686 = OpLoad %uint %433
+OpStore %731 %1686
+OpBranch %376
+%360 = OpLabel
+OpBranch %325
+%361 = OpLabel
+OpBranch %300
+%362 = OpLabel
+OpBranch %322
+%363 = OpLabel
+OpBranch %275
 %364 = OpLabel
-OpBranch %251
+OpBranch %297
 %365 = OpLabel
-OpBranch %248
+OpBranch %250
 %366 = OpLabel
-OpBranch %226
+OpBranch %272
 %367 = OpLabel
-OpBranch %223
+OpBranch %225
 %368 = OpLabel
-OpBranch %201
+OpBranch %247
 %369 = OpLabel
-OpBranch %198
+OpBranch %200
 %370 = OpLabel
-OpBranch %176
+OpBranch %222
 %371 = OpLabel
-OpBranch %173
+OpBranch %175
 %372 = OpLabel
-OpBranch %151
+OpBranch %197
 %373 = OpLabel
-OpBranch %148
+OpBranch %150
 %374 = OpLabel
-OpBranch %126
+OpBranch %172
 %375 = OpLabel
-OpBranch %123
+OpBranch %147
 %376 = OpLabel
-OpBranch %101
-%377 = OpLabel
-OpBranch %98
-%378 = OpLabel
-OpBranch %76
-%379 = OpLabel
-OpBranch %73
-%380 = OpLabel
-OpBranch %57
-OpFunctionEnd
-%4 = OpFunction %ulong None %1869
-%1870 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %1872
-%1873 = OpFunctionParameter %ulong
-%1874 = OpFunctionParameter %uint
-%1875 = OpLabel
-%1882 = OpVariable %_ptr_Function_ulong Function
-%1883 = OpVariable %_ptr_Function_uint Function
-%1884 = OpVariable %_ptr_Function_ulong Function
-%1885 = OpVariable %_ptr_Function_bool Function
-%1886 = OpVariable %_ptr_Function_ulong Function
-%1887 = OpVariable %_ptr_Function_ulong Function
-%1888 = OpVariable %_ptr_Function_ulong Function
-%1889 = OpVariable %_ptr_Function_ulong Function
-%1890 = OpVariable %_ptr_Function_ulong Function
-%1891 = OpVariable %_ptr_Function_ulong Function
-%1892 = OpVariable %_ptr_Function_ulong Function
-%1893 = OpVariable %_ptr_Function_ulong Function
-OpStore %1882 %1873
-OpStore %1883 %1874
-%1894 = OpLoad %uint %1883
-%1895 = OpUConvert %ulong %1894
-OpStore %1884 %1895
-OpBranch %1876
-%1876 = OpLabel
-%1896 = OpLoad %ulong %1882
-OpStore %1892 %1896
-OpStore %1893 %ulong_0
-OpBranch %1877
-%1877 = OpLabel
-%1898 = OpLoad %ulong %1893
-%1900 = OpULessThan %bool %1898 %ulong_8
-OpStore %1885 %1900
-%1901 = OpLoad %bool %1885
-OpLoopMerge %1879 %1881 None
-OpBranchConditional %1901 %1878 %1879
-%1879 = OpLabel
-OpBranch %1880
-%1880 = OpLabel
-%1902 = OpLoad %ulong %1892
-OpReturnValue %1902
-%1878 = OpLabel
-%1903 = OpLoad %ulong %1893
-%1904 = OpIMul %ulong %1903 %ulong_8
-OpStore %1886 %1904
-%1905 = OpLoad %ulong %1884
-%1906 = OpLoad %ulong %1886
-%1907 = OpShiftRightLogical %ulong %1905 %1906
-OpStore %1887 %1907
-%1908 = OpLoad %ulong %1887
-%1910 = OpBitwiseAnd %ulong %1908 %ulong_255
-OpStore %1888 %1910
-%1911 = OpLoad %ulong %1892
-%1912 = OpLoad %ulong %1888
-%1913 = OpBitwiseXor %ulong %1911 %1912
-OpStore %1889 %1913
-%1914 = OpLoad %ulong %1889
-%1916 = OpIMul %ulong %1914 %ulong_1099511628211
-OpStore %1890 %1916
-%1917 = OpLoad %ulong %1893
-%1919 = OpIAdd %ulong %1917 %ulong_1
-OpStore %1891 %1919
-%1920 = OpLoad %ulong %1890
-OpStore %1892 %1920
-%1921 = OpLoad %ulong %1891
-OpStore %1893 %1921
-OpBranch %1881
-%1881 = OpLabel
-OpBranch %1877
-OpFunctionEnd
-%6 = OpFunction %ulong None %26
-%1922 = OpFunctionParameter %ulong
-%1923 = OpFunctionParameter %float
-%1924 = OpLabel
-%1931 = OpVariable %_ptr_Function_ulong Function
-%1932 = OpVariable %_ptr_Function_float Function
-%1933 = OpVariable %_ptr_Function_uint Function
-%1934 = OpVariable %_ptr_Function_ulong Function
-%1935 = OpVariable %_ptr_Function_bool Function
-%1936 = OpVariable %_ptr_Function_ulong Function
-%1937 = OpVariable %_ptr_Function_ulong Function
-%1938 = OpVariable %_ptr_Function_ulong Function
-%1939 = OpVariable %_ptr_Function_ulong Function
-%1940 = OpVariable %_ptr_Function_ulong Function
-%1941 = OpVariable %_ptr_Function_ulong Function
-%1942 = OpVariable %_ptr_Function_ulong Function
-%1943 = OpVariable %_ptr_Function_ulong Function
-OpStore %1931 %1922
-OpStore %1932 %1923
-%1944 = OpLoad %float %1932
-%1945 = OpBitcast %uint %1944
-OpStore %1933 %1945
-%1946 = OpLoad %uint %1933
-%1947 = OpUConvert %ulong %1946
-OpStore %1934 %1947
-OpBranch %1925
-%1925 = OpLabel
-%1948 = OpLoad %ulong %1931
-OpStore %1942 %1948
-OpStore %1943 %ulong_0
-OpBranch %1926
-%1926 = OpLabel
-%1949 = OpLoad %ulong %1943
-%1950 = OpULessThan %bool %1949 %ulong_8
-OpStore %1935 %1950
-%1951 = OpLoad %bool %1935
-OpLoopMerge %1928 %1930 None
-OpBranchConditional %1951 %1927 %1928
-%1928 = OpLabel
-OpBranch %1929
-%1929 = OpLabel
-%1952 = OpLoad %ulong %1942
-OpReturnValue %1952
-%1927 = OpLabel
-%1953 = OpLoad %ulong %1943
-%1954 = OpIMul %ulong %1953 %ulong_8
-OpStore %1936 %1954
-%1955 = OpLoad %ulong %1934
-%1956 = OpLoad %ulong %1936
-%1957 = OpShiftRightLogical %ulong %1955 %1956
-OpStore %1937 %1957
-%1958 = OpLoad %ulong %1937
-%1959 = OpBitwiseAnd %ulong %1958 %ulong_255
-OpStore %1938 %1959
-%1960 = OpLoad %ulong %1942
-%1961 = OpLoad %ulong %1938
-%1962 = OpBitwiseXor %ulong %1960 %1961
-OpStore %1939 %1962
-%1963 = OpLoad %ulong %1939
-%1964 = OpIMul %ulong %1963 %ulong_1099511628211
-OpStore %1940 %1964
-%1965 = OpLoad %ulong %1943
-%1966 = OpIAdd %ulong %1965 %ulong_1
-OpStore %1941 %1966
-%1967 = OpLoad %ulong %1940
-OpStore %1942 %1967
-%1968 = OpLoad %ulong %1941
-OpStore %1943 %1968
-OpBranch %1930
-%1930 = OpLabel
-OpBranch %1926
+OpBranch %131
 OpFunctionEnd

--- a/test/golden/spirv/float/arith_f64.dis
+++ b/test/golden/spirv/float/arith_f64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1937
+; Bound: 1658
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -13,106 +13,217 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.arith_f64.fold64" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.float.arith_f64.checksum" Export
 %double = OpTypeFloat 64
 %ulong = OpTypeInt 64 0
-%9 = OpTypeFunction %double %ulong %ulong
+%6 = OpTypeFunction %double %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_double = OpTypePointer Function %double
-%25 = OpTypeFunction %ulong %ulong %double
+%22 = OpTypeFunction %ulong %ulong %double
 %bool = OpTypeBool
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%52 = OpTypeFunction %ulong %ulong
+%121 = OpTypeFunction %ulong %ulong
 %ulong_4607182418800017408 = OpConstant %ulong 4607182418800017408
 %double_1_5 = OpConstant %double 1.5
 %double_0_25 = OpConstant %double 0.25
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %double_0 = OpConstant %double 0
 %double_3 = OpConstant %double 3
 %double_49 = OpConstant %double 49
 %double_1048576_5 = OpConstant %double 1048576.5
 %double_9007199254740992 = OpConstant %double 9007199254740992
-%ulong_0 = OpConstant %ulong 0
 %ulong_24 = OpConstant %ulong 24
 %ulong_9218868437227405311 = OpConstant %ulong 9218868437227405311
 %double_2 = OpConstant %double 2
 %ulong_4503599627370496 = OpConstant %ulong 4503599627370496
-%ulong_1 = OpConstant %ulong 1
 %double_0_5 = OpConstant %double 0.5
 %double_0_75 = OpConstant %double 0.75
 %double_5_5 = OpConstant %double 5.5
 %double_7 = OpConstant %double 7
 %double_1048576 = OpConstant %double 1048576
-%1847 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1850 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %double None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %ulong
-%12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_double Function
-OpStore %14 %10
-OpStore %15 %11
-%19 = OpLoad %ulong %14
-%20 = OpLoad %ulong %15
-%21 = OpIAdd %ulong %19 %20
-OpStore %16 %21
-%22 = OpLoad %ulong %16
-%23 = OpBitcast %double %22
-OpStore %18 %23
-%24 = OpLoad %double %18
-OpReturnValue %24
+%1 = OpFunction %double None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %ulong
+%9 = OpLabel
+%11 = OpVariable %_ptr_Function_ulong Function
+%12 = OpVariable %_ptr_Function_ulong Function
+%13 = OpVariable %_ptr_Function_ulong Function
+%15 = OpVariable %_ptr_Function_double Function
+OpStore %11 %7
+OpStore %12 %8
+%16 = OpLoad %ulong %11
+%17 = OpLoad %ulong %12
+%18 = OpIAdd %ulong %16 %17
+OpStore %13 %18
+%19 = OpLoad %ulong %13
+%20 = OpBitcast %double %19
+OpStore %15 %20
+%21 = OpLoad %double %15
+OpReturnValue %21
 OpFunctionEnd
-%2 = OpFunction %ulong None %25
-%26 = OpFunctionParameter %ulong
-%27 = OpFunctionParameter %double
+%2 = OpFunction %ulong None %22
+%23 = OpFunctionParameter %ulong
+%24 = OpFunctionParameter %double
+%25 = OpLabel
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_double Function
+%48 = OpVariable %_ptr_Function_bool Function
+%49 = OpVariable %_ptr_Function_bool Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_bool Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+OpStore %45 %23
+OpStore %46 %24
+%68 = OpLoad %double %46
+%69 = OpLoad %double %46
+%70 = OpFUnordNotEqual %bool %68 %69
+OpStore %48 %70
+%71 = OpLoad %bool %48
+OpSelectionMerge %43 None
+OpBranchConditional %71 %26 %27
+%27 = OpLabel
+OpBranch %28
 %28 = OpLabel
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_double Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-OpStore %34 %26
-OpStore %35 %27
-%40 = OpLoad %double %35
-%41 = OpLoad %double %35
-%42 = OpFUnordNotEqual %bool %40 %41
-OpStore %37 %42
-%43 = OpLoad %bool %37
-OpSelectionMerge %32 None
-OpBranchConditional %43 %29 %30
-%30 = OpLabel
-OpBranch %31
-%31 = OpLabel
-%44 = OpLoad %ulong %34
-%45 = OpLoad %double %35
-%46 = OpFunctionCall %ulong %6 %44 %45
-OpStore %39 %46
-%47 = OpLoad %ulong %39
-OpReturnValue %47
+OpBranch %34
+%34 = OpLabel
+%72 = OpLoad %double %46
+%73 = OpBitcast %ulong %72
+OpStore %58 %73
+OpBranch %36
+%36 = OpLabel
+%74 = OpLoad %ulong %45
+OpStore %66 %74
+OpStore %67 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%76 = OpLoad %ulong %67
+%78 = OpULessThan %bool %76 %ulong_8
+OpStore %59 %78
+%79 = OpLoad %bool %59
+OpLoopMerge %39 %41 None
+OpBranchConditional %79 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%80 = OpLoad %ulong %66
+OpReturnValue %80
+%38 = OpLabel
+%81 = OpLoad %ulong %67
+%82 = OpIMul %ulong %81 %ulong_8
+OpStore %60 %82
+%83 = OpLoad %ulong %58
+%84 = OpLoad %ulong %60
+%85 = OpShiftRightLogical %ulong %83 %84
+OpStore %61 %85
+%86 = OpLoad %ulong %61
+%88 = OpBitwiseAnd %ulong %86 %ulong_255
+OpStore %62 %88
+%89 = OpLoad %ulong %66
+%90 = OpLoad %ulong %62
+%91 = OpBitwiseXor %ulong %89 %90
+OpStore %63 %91
+%92 = OpLoad %ulong %63
+%94 = OpIMul %ulong %92 %ulong_1099511628211
+OpStore %64 %94
+%95 = OpLoad %ulong %67
+%97 = OpIAdd %ulong %95 %ulong_1
+OpStore %65 %97
+%98 = OpLoad %ulong %64
+OpStore %66 %98
+%99 = OpLoad %ulong %65
+OpStore %67 %99
+OpBranch %41
+%26 = OpLabel
+OpBranch %29
 %29 = OpLabel
-%48 = OpLoad %ulong %34
-%50 = OpFunctionCall %ulong %5 %48 %ulong_18446744073709551615
-OpStore %38 %50
-%51 = OpLoad %ulong %38
-OpReturnValue %51
+%100 = OpLoad %ulong %45
+OpStore %56 %100
+OpStore %57 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%101 = OpLoad %ulong %57
+%102 = OpULessThan %bool %101 %ulong_8
+OpStore %49 %102
+%103 = OpLoad %bool %49
+OpLoopMerge %32 %42 None
+OpBranchConditional %103 %31 %32
 %32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%104 = OpLoad %ulong %56
+OpReturnValue %104
+%31 = OpLabel
+%105 = OpLoad %ulong %57
+%106 = OpIMul %ulong %105 %ulong_8
+OpStore %50 %106
+%108 = OpLoad %ulong %50
+%109 = OpShiftRightLogical %ulong %ulong_18446744073709551615 %108
+OpStore %51 %109
+%110 = OpLoad %ulong %51
+%111 = OpBitwiseAnd %ulong %110 %ulong_255
+OpStore %52 %111
+%112 = OpLoad %ulong %56
+%113 = OpLoad %ulong %52
+%114 = OpBitwiseXor %ulong %112 %113
+OpStore %53 %114
+%115 = OpLoad %ulong %53
+%116 = OpIMul %ulong %115 %ulong_1099511628211
+OpStore %54 %116
+%117 = OpLoad %ulong %57
+%118 = OpIAdd %ulong %117 %ulong_1
+OpStore %55 %118
+%119 = OpLoad %ulong %54
+OpStore %56 %119
+%120 = OpLoad %ulong %55
+OpStore %57 %120
+OpBranch %42
+%41 = OpLabel
+OpBranch %37
+%42 = OpLabel
+OpBranch %30
+%43 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%3 = OpFunction %ulong None %52
-%53 = OpFunctionParameter %ulong
-%54 = OpLabel
-%377 = OpVariable %_ptr_Function_ulong Function
+%3 = OpFunction %ulong None %121
+%122 = OpFunctionParameter %ulong
+%123 = OpLabel
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_double Function
+%370 = OpVariable %_ptr_Function_double Function
+%371 = OpVariable %_ptr_Function_double Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_double Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_double Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_double Function
 %378 = OpVariable %_ptr_Function_ulong Function
 %379 = OpVariable %_ptr_Function_double Function
-%380 = OpVariable %_ptr_Function_double Function
+%380 = OpVariable %_ptr_Function_ulong Function
 %381 = OpVariable %_ptr_Function_double Function
-%382 = OpVariable %_ptr_Function_double Function
+%382 = OpVariable %_ptr_Function_ulong Function
 %383 = OpVariable %_ptr_Function_double Function
-%384 = OpVariable %_ptr_Function_double Function
+%384 = OpVariable %_ptr_Function_ulong Function
 %385 = OpVariable %_ptr_Function_double Function
 %386 = OpVariable %_ptr_Function_ulong Function
 %387 = OpVariable %_ptr_Function_double Function
@@ -120,45 +231,45 @@ OpFunctionEnd
 %389 = OpVariable %_ptr_Function_double Function
 %390 = OpVariable %_ptr_Function_ulong Function
 %391 = OpVariable %_ptr_Function_double Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_double Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_double Function
-%396 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_double Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_double Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_double Function
 %397 = OpVariable %_ptr_Function_double Function
 %398 = OpVariable %_ptr_Function_double Function
 %399 = OpVariable %_ptr_Function_ulong Function
 %400 = OpVariable %_ptr_Function_double Function
 %401 = OpVariable %_ptr_Function_ulong Function
 %402 = OpVariable %_ptr_Function_double Function
-%403 = OpVariable %_ptr_Function_double Function
+%403 = OpVariable %_ptr_Function_ulong Function
 %404 = OpVariable %_ptr_Function_double Function
 %405 = OpVariable %_ptr_Function_ulong Function
 %406 = OpVariable %_ptr_Function_double Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_double Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_double Function
-%411 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_double Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_double Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_double Function
 %412 = OpVariable %_ptr_Function_double Function
-%413 = OpVariable %_ptr_Function_double Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_double Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_double Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_double Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_double Function
+%417 = OpVariable %_ptr_Function_ulong Function
 %418 = OpVariable %_ptr_Function_double Function
-%419 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_bool Function
 %420 = OpVariable %_ptr_Function_double Function
-%421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_double Function
+%421 = OpVariable %_ptr_Function_double Function
+%422 = OpVariable %_ptr_Function_ulong Function
 %423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_double Function
-%425 = OpVariable %_ptr_Function_bool Function
-%426 = OpVariable %_ptr_Function_double Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_double Function
+%426 = OpVariable %_ptr_Function_ulong Function
 %427 = OpVariable %_ptr_Function_double Function
 %428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_double Function
-%430 = OpVariable %_ptr_Function_double Function
+%430 = OpVariable %_ptr_Function_ulong Function
 %431 = OpVariable %_ptr_Function_double Function
 %432 = OpVariable %_ptr_Function_ulong Function
 %433 = OpVariable %_ptr_Function_double Function
@@ -184,72 +295,72 @@ OpFunctionEnd
 %453 = OpVariable %_ptr_Function_double Function
 %454 = OpVariable %_ptr_Function_ulong Function
 %455 = OpVariable %_ptr_Function_double Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_double Function
+%456 = OpVariable %_ptr_Function_double Function
+%457 = OpVariable %_ptr_Function_bool Function
 %458 = OpVariable %_ptr_Function_double Function
 %459 = OpVariable %_ptr_Function_bool Function
-%460 = OpVariable %_ptr_Function_double Function
+%460 = OpVariable %_ptr_Function_bool Function
 %461 = OpVariable %_ptr_Function_bool Function
 %462 = OpVariable %_ptr_Function_bool Function
-%463 = OpVariable %_ptr_Function_bool Function
-%464 = OpVariable %_ptr_Function_bool Function
+%463 = OpVariable %_ptr_Function_double Function
+%464 = OpVariable %_ptr_Function_ulong Function
 %465 = OpVariable %_ptr_Function_double Function
-%466 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_double Function
 %467 = OpVariable %_ptr_Function_double Function
-%468 = OpVariable %_ptr_Function_double Function
+%468 = OpVariable %_ptr_Function_bool Function
 %469 = OpVariable %_ptr_Function_double Function
-%470 = OpVariable %_ptr_Function_bool Function
-%471 = OpVariable %_ptr_Function_double Function
+%470 = OpVariable %_ptr_Function_double Function
+%471 = OpVariable %_ptr_Function_bool Function
 %472 = OpVariable %_ptr_Function_double Function
-%473 = OpVariable %_ptr_Function_bool Function
+%473 = OpVariable %_ptr_Function_double Function
 %474 = OpVariable %_ptr_Function_double Function
 %475 = OpVariable %_ptr_Function_double Function
-%476 = OpVariable %_ptr_Function_double Function
+%476 = OpVariable %_ptr_Function_bool Function
 %477 = OpVariable %_ptr_Function_double Function
-%478 = OpVariable %_ptr_Function_bool Function
+%478 = OpVariable %_ptr_Function_double Function
 %479 = OpVariable %_ptr_Function_double Function
-%480 = OpVariable %_ptr_Function_double Function
-%481 = OpVariable %_ptr_Function_double Function
-%482 = OpVariable %_ptr_Function_bool Function
-%483 = OpVariable %_ptr_Function_bool Function
+%480 = OpVariable %_ptr_Function_bool Function
+%481 = OpVariable %_ptr_Function_bool Function
+%482 = OpVariable %_ptr_Function_double Function
+%483 = OpVariable %_ptr_Function_double Function
 %484 = OpVariable %_ptr_Function_double Function
 %485 = OpVariable %_ptr_Function_double Function
 %486 = OpVariable %_ptr_Function_double Function
 %487 = OpVariable %_ptr_Function_double Function
-%488 = OpVariable %_ptr_Function_double Function
+%488 = OpVariable %_ptr_Function_ulong Function
 %489 = OpVariable %_ptr_Function_double Function
-%490 = OpVariable %_ptr_Function_double Function
-%491 = OpVariable %_ptr_Function_bool Function
-%492 = OpVariable %_ptr_Function_double Function
+%490 = OpVariable %_ptr_Function_bool Function
+%491 = OpVariable %_ptr_Function_double Function
+%492 = OpVariable %_ptr_Function_bool Function
 %493 = OpVariable %_ptr_Function_bool Function
 %494 = OpVariable %_ptr_Function_bool Function
 %495 = OpVariable %_ptr_Function_bool Function
-%496 = OpVariable %_ptr_Function_bool Function
-%497 = OpVariable %_ptr_Function_double Function
-%498 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_double Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_double Function
 %499 = OpVariable %_ptr_Function_double Function
 %500 = OpVariable %_ptr_Function_double Function
-%501 = OpVariable %_ptr_Function_double Function
-%502 = OpVariable %_ptr_Function_bool Function
+%501 = OpVariable %_ptr_Function_bool Function
+%502 = OpVariable %_ptr_Function_double Function
 %503 = OpVariable %_ptr_Function_double Function
-%504 = OpVariable %_ptr_Function_double Function
-%505 = OpVariable %_ptr_Function_bool Function
+%504 = OpVariable %_ptr_Function_bool Function
+%505 = OpVariable %_ptr_Function_double Function
 %506 = OpVariable %_ptr_Function_double Function
 %507 = OpVariable %_ptr_Function_double Function
 %508 = OpVariable %_ptr_Function_double Function
-%509 = OpVariable %_ptr_Function_double Function
-%510 = OpVariable %_ptr_Function_bool Function
+%509 = OpVariable %_ptr_Function_bool Function
+%510 = OpVariable %_ptr_Function_double Function
 %511 = OpVariable %_ptr_Function_double Function
 %512 = OpVariable %_ptr_Function_double Function
-%513 = OpVariable %_ptr_Function_double Function
+%513 = OpVariable %_ptr_Function_bool Function
 %514 = OpVariable %_ptr_Function_bool Function
-%515 = OpVariable %_ptr_Function_bool Function
+%515 = OpVariable %_ptr_Function_double Function
 %516 = OpVariable %_ptr_Function_double Function
 %517 = OpVariable %_ptr_Function_double Function
 %518 = OpVariable %_ptr_Function_double Function
 %519 = OpVariable %_ptr_Function_double Function
 %520 = OpVariable %_ptr_Function_double Function
-%521 = OpVariable %_ptr_Function_double Function
+%521 = OpVariable %_ptr_Function_ulong Function
 %522 = OpVariable %_ptr_Function_double Function
 %523 = OpVariable %_ptr_Function_bool Function
 %524 = OpVariable %_ptr_Function_double Function
@@ -282,2645 +393,2088 @@ OpFunctionEnd
 %551 = OpVariable %_ptr_Function_double Function
 %552 = OpVariable %_ptr_Function_double Function
 %553 = OpVariable %_ptr_Function_double Function
-%554 = OpVariable %_ptr_Function_double Function
+%554 = OpVariable %_ptr_Function_ulong Function
 %555 = OpVariable %_ptr_Function_double Function
-%556 = OpVariable %_ptr_Function_bool Function
-%557 = OpVariable %_ptr_Function_double Function
-%558 = OpVariable %_ptr_Function_bool Function
+%556 = OpVariable %_ptr_Function_double Function
+%557 = OpVariable %_ptr_Function_bool Function
+%558 = OpVariable %_ptr_Function_double Function
 %559 = OpVariable %_ptr_Function_bool Function
 %560 = OpVariable %_ptr_Function_bool Function
 %561 = OpVariable %_ptr_Function_bool Function
-%562 = OpVariable %_ptr_Function_double Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_double Function
+%562 = OpVariable %_ptr_Function_bool Function
+%563 = OpVariable %_ptr_Function_double Function
+%564 = OpVariable %_ptr_Function_ulong Function
 %565 = OpVariable %_ptr_Function_double Function
 %566 = OpVariable %_ptr_Function_double Function
-%567 = OpVariable %_ptr_Function_bool Function
-%568 = OpVariable %_ptr_Function_double Function
+%567 = OpVariable %_ptr_Function_double Function
+%568 = OpVariable %_ptr_Function_bool Function
 %569 = OpVariable %_ptr_Function_double Function
-%570 = OpVariable %_ptr_Function_bool Function
-%571 = OpVariable %_ptr_Function_double Function
+%570 = OpVariable %_ptr_Function_double Function
+%571 = OpVariable %_ptr_Function_bool Function
 %572 = OpVariable %_ptr_Function_double Function
 %573 = OpVariable %_ptr_Function_double Function
 %574 = OpVariable %_ptr_Function_double Function
-%575 = OpVariable %_ptr_Function_bool Function
-%576 = OpVariable %_ptr_Function_double Function
+%575 = OpVariable %_ptr_Function_double Function
+%576 = OpVariable %_ptr_Function_bool Function
 %577 = OpVariable %_ptr_Function_double Function
 %578 = OpVariable %_ptr_Function_double Function
-%579 = OpVariable %_ptr_Function_bool Function
+%579 = OpVariable %_ptr_Function_double Function
 %580 = OpVariable %_ptr_Function_bool Function
-%581 = OpVariable %_ptr_Function_double Function
+%581 = OpVariable %_ptr_Function_bool Function
 %582 = OpVariable %_ptr_Function_double Function
 %583 = OpVariable %_ptr_Function_double Function
 %584 = OpVariable %_ptr_Function_double Function
 %585 = OpVariable %_ptr_Function_double Function
 %586 = OpVariable %_ptr_Function_double Function
 %587 = OpVariable %_ptr_Function_double Function
-%588 = OpVariable %_ptr_Function_double Function
-%589 = OpVariable %_ptr_Function_bool Function
-%590 = OpVariable %_ptr_Function_bool Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_double Function
+%590 = OpVariable %_ptr_Function_double Function
 %591 = OpVariable %_ptr_Function_bool Function
-%592 = OpVariable %_ptr_Function_double Function
-%593 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_bool Function
+%593 = OpVariable %_ptr_Function_bool Function
 %594 = OpVariable %_ptr_Function_double Function
-%595 = OpVariable %_ptr_Function_double Function
+%595 = OpVariable %_ptr_Function_ulong Function
 %596 = OpVariable %_ptr_Function_double Function
-%597 = OpVariable %_ptr_Function_bool Function
+%597 = OpVariable %_ptr_Function_double Function
 %598 = OpVariable %_ptr_Function_double Function
-%599 = OpVariable %_ptr_Function_double Function
+%599 = OpVariable %_ptr_Function_bool Function
 %600 = OpVariable %_ptr_Function_double Function
 %601 = OpVariable %_ptr_Function_double Function
-%602 = OpVariable %_ptr_Function_bool Function
+%602 = OpVariable %_ptr_Function_double Function
 %603 = OpVariable %_ptr_Function_double Function
-%604 = OpVariable %_ptr_Function_double Function
+%604 = OpVariable %_ptr_Function_bool Function
 %605 = OpVariable %_ptr_Function_double Function
-%606 = OpVariable %_ptr_Function_bool Function
-%607 = OpVariable %_ptr_Function_bool Function
-%608 = OpVariable %_ptr_Function_double Function
-%609 = OpVariable %_ptr_Function_double Function
+%606 = OpVariable %_ptr_Function_double Function
+%607 = OpVariable %_ptr_Function_double Function
+%608 = OpVariable %_ptr_Function_bool Function
+%609 = OpVariable %_ptr_Function_bool Function
 %610 = OpVariable %_ptr_Function_double Function
 %611 = OpVariable %_ptr_Function_double Function
 %612 = OpVariable %_ptr_Function_double Function
 %613 = OpVariable %_ptr_Function_double Function
-%614 = OpVariable %_ptr_Function_bool Function
+%614 = OpVariable %_ptr_Function_double Function
 %615 = OpVariable %_ptr_Function_double Function
-%616 = OpVariable %_ptr_Function_bool Function
+%616 = OpVariable %_ptr_Function_ulong Function
 %617 = OpVariable %_ptr_Function_bool Function
-%618 = OpVariable %_ptr_Function_bool Function
+%618 = OpVariable %_ptr_Function_double Function
 %619 = OpVariable %_ptr_Function_bool Function
-%620 = OpVariable %_ptr_Function_double Function
-%621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_double Function
+%620 = OpVariable %_ptr_Function_bool Function
+%621 = OpVariable %_ptr_Function_bool Function
+%622 = OpVariable %_ptr_Function_bool Function
 %623 = OpVariable %_ptr_Function_double Function
-%624 = OpVariable %_ptr_Function_double Function
-%625 = OpVariable %_ptr_Function_bool Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_double Function
 %626 = OpVariable %_ptr_Function_double Function
 %627 = OpVariable %_ptr_Function_double Function
 %628 = OpVariable %_ptr_Function_bool Function
 %629 = OpVariable %_ptr_Function_double Function
 %630 = OpVariable %_ptr_Function_double Function
-%631 = OpVariable %_ptr_Function_double Function
+%631 = OpVariable %_ptr_Function_bool Function
 %632 = OpVariable %_ptr_Function_double Function
-%633 = OpVariable %_ptr_Function_bool Function
+%633 = OpVariable %_ptr_Function_double Function
 %634 = OpVariable %_ptr_Function_double Function
 %635 = OpVariable %_ptr_Function_double Function
-%636 = OpVariable %_ptr_Function_double Function
-%637 = OpVariable %_ptr_Function_bool Function
-%638 = OpVariable %_ptr_Function_bool Function
+%636 = OpVariable %_ptr_Function_bool Function
+%637 = OpVariable %_ptr_Function_double Function
+%638 = OpVariable %_ptr_Function_double Function
 %639 = OpVariable %_ptr_Function_double Function
-%640 = OpVariable %_ptr_Function_double Function
-%641 = OpVariable %_ptr_Function_double Function
+%640 = OpVariable %_ptr_Function_bool Function
+%641 = OpVariable %_ptr_Function_bool Function
 %642 = OpVariable %_ptr_Function_double Function
 %643 = OpVariable %_ptr_Function_double Function
 %644 = OpVariable %_ptr_Function_double Function
-%645 = OpVariable %_ptr_Function_bool Function
+%645 = OpVariable %_ptr_Function_double Function
 %646 = OpVariable %_ptr_Function_double Function
-%647 = OpVariable %_ptr_Function_bool Function
-%648 = OpVariable %_ptr_Function_bool Function
+%647 = OpVariable %_ptr_Function_double Function
+%648 = OpVariable %_ptr_Function_ulong Function
 %649 = OpVariable %_ptr_Function_bool Function
-%650 = OpVariable %_ptr_Function_bool Function
-%651 = OpVariable %_ptr_Function_double Function
-%652 = OpVariable %_ptr_Function_ulong Function
-%653 = OpVariable %_ptr_Function_double Function
-%654 = OpVariable %_ptr_Function_double Function
+%650 = OpVariable %_ptr_Function_double Function
+%651 = OpVariable %_ptr_Function_bool Function
+%652 = OpVariable %_ptr_Function_bool Function
+%653 = OpVariable %_ptr_Function_bool Function
+%654 = OpVariable %_ptr_Function_bool Function
 %655 = OpVariable %_ptr_Function_double Function
-%656 = OpVariable %_ptr_Function_bool Function
+%656 = OpVariable %_ptr_Function_ulong Function
 %657 = OpVariable %_ptr_Function_double Function
 %658 = OpVariable %_ptr_Function_double Function
-%659 = OpVariable %_ptr_Function_bool Function
-%660 = OpVariable %_ptr_Function_double Function
+%659 = OpVariable %_ptr_Function_double Function
+%660 = OpVariable %_ptr_Function_bool Function
 %661 = OpVariable %_ptr_Function_double Function
 %662 = OpVariable %_ptr_Function_double Function
-%663 = OpVariable %_ptr_Function_double Function
-%664 = OpVariable %_ptr_Function_bool Function
+%663 = OpVariable %_ptr_Function_bool Function
+%664 = OpVariable %_ptr_Function_double Function
 %665 = OpVariable %_ptr_Function_double Function
 %666 = OpVariable %_ptr_Function_double Function
 %667 = OpVariable %_ptr_Function_double Function
 %668 = OpVariable %_ptr_Function_bool Function
-%669 = OpVariable %_ptr_Function_bool Function
+%669 = OpVariable %_ptr_Function_double Function
 %670 = OpVariable %_ptr_Function_double Function
 %671 = OpVariable %_ptr_Function_double Function
-%672 = OpVariable %_ptr_Function_double Function
-%673 = OpVariable %_ptr_Function_double Function
+%672 = OpVariable %_ptr_Function_bool Function
+%673 = OpVariable %_ptr_Function_bool Function
 %674 = OpVariable %_ptr_Function_double Function
 %675 = OpVariable %_ptr_Function_double Function
 %676 = OpVariable %_ptr_Function_double Function
-%677 = OpVariable %_ptr_Function_bool Function
+%677 = OpVariable %_ptr_Function_double Function
 %678 = OpVariable %_ptr_Function_double Function
-%679 = OpVariable %_ptr_Function_bool Function
-%680 = OpVariable %_ptr_Function_bool Function
-%681 = OpVariable %_ptr_Function_bool Function
+%679 = OpVariable %_ptr_Function_double Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%681 = OpVariable %_ptr_Function_double Function
 %682 = OpVariable %_ptr_Function_bool Function
 %683 = OpVariable %_ptr_Function_double Function
-%684 = OpVariable %_ptr_Function_ulong Function
-%685 = OpVariable %_ptr_Function_double Function
-%686 = OpVariable %_ptr_Function_double Function
-%687 = OpVariable %_ptr_Function_double Function
-%688 = OpVariable %_ptr_Function_bool Function
-%689 = OpVariable %_ptr_Function_double Function
+%684 = OpVariable %_ptr_Function_bool Function
+%685 = OpVariable %_ptr_Function_bool Function
+%686 = OpVariable %_ptr_Function_bool Function
+%687 = OpVariable %_ptr_Function_bool Function
+%688 = OpVariable %_ptr_Function_double Function
+%689 = OpVariable %_ptr_Function_ulong Function
 %690 = OpVariable %_ptr_Function_double Function
-%691 = OpVariable %_ptr_Function_bool Function
+%691 = OpVariable %_ptr_Function_double Function
 %692 = OpVariable %_ptr_Function_double Function
-%693 = OpVariable %_ptr_Function_double Function
+%693 = OpVariable %_ptr_Function_bool Function
 %694 = OpVariable %_ptr_Function_double Function
 %695 = OpVariable %_ptr_Function_double Function
 %696 = OpVariable %_ptr_Function_bool Function
 %697 = OpVariable %_ptr_Function_double Function
 %698 = OpVariable %_ptr_Function_double Function
 %699 = OpVariable %_ptr_Function_double Function
-%700 = OpVariable %_ptr_Function_bool Function
+%700 = OpVariable %_ptr_Function_double Function
 %701 = OpVariable %_ptr_Function_bool Function
 %702 = OpVariable %_ptr_Function_double Function
 %703 = OpVariable %_ptr_Function_double Function
 %704 = OpVariable %_ptr_Function_double Function
-%705 = OpVariable %_ptr_Function_double Function
-%706 = OpVariable %_ptr_Function_double Function
+%705 = OpVariable %_ptr_Function_bool Function
+%706 = OpVariable %_ptr_Function_bool Function
 %707 = OpVariable %_ptr_Function_double Function
-%708 = OpVariable %_ptr_Function_ulong Function
+%708 = OpVariable %_ptr_Function_double Function
 %709 = OpVariable %_ptr_Function_double Function
-%710 = OpVariable %_ptr_Function_ulong Function
-%711 = OpVariable %_ptr_Function_ulong Function
+%710 = OpVariable %_ptr_Function_double Function
+%711 = OpVariable %_ptr_Function_double Function
 %712 = OpVariable %_ptr_Function_double Function
-%713 = OpVariable %_ptr_Function_bool Function
+%713 = OpVariable %_ptr_Function_ulong Function
 %714 = OpVariable %_ptr_Function_ulong Function
-%715 = OpVariable %_ptr_Function_ulong Function
+%715 = OpVariable %_ptr_Function_double Function
 %716 = OpVariable %_ptr_Function_ulong Function
 %717 = OpVariable %_ptr_Function_ulong Function
 %718 = OpVariable %_ptr_Function_double Function
-%719 = OpVariable %_ptr_Function_bool Function
-%720 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_ulong Function
+%720 = OpVariable %_ptr_Function_double Function
 %721 = OpVariable %_ptr_Function_ulong Function
-%722 = OpVariable %_ptr_Function_ulong Function
-%723 = OpVariable %_ptr_Function_bool Function
-%724 = OpVariable %_ptr_Function_ulong Function
-%725 = OpVariable %_ptr_Function_ulong Function
-%726 = OpVariable %_ptr_Function_ulong Function
-%727 = OpVariable %_ptr_Function_bool Function
-%728 = OpVariable %_ptr_Function_ulong Function
-%729 = OpVariable %_ptr_Function_ulong Function
-%730 = OpVariable %_ptr_Function_ulong Function
-%731 = OpVariable %_ptr_Function_bool Function
-%732 = OpVariable %_ptr_Function_ulong Function
-%733 = OpVariable %_ptr_Function_ulong Function
-%734 = OpVariable %_ptr_Function_ulong Function
-%735 = OpVariable %_ptr_Function_bool Function
-%736 = OpVariable %_ptr_Function_ulong Function
-%737 = OpVariable %_ptr_Function_ulong Function
-%738 = OpVariable %_ptr_Function_ulong Function
-%739 = OpVariable %_ptr_Function_bool Function
-%740 = OpVariable %_ptr_Function_ulong Function
-%741 = OpVariable %_ptr_Function_ulong Function
-%742 = OpVariable %_ptr_Function_ulong Function
-%743 = OpVariable %_ptr_Function_bool Function
-%744 = OpVariable %_ptr_Function_ulong Function
-%745 = OpVariable %_ptr_Function_ulong Function
-%746 = OpVariable %_ptr_Function_ulong Function
-%747 = OpVariable %_ptr_Function_bool Function
-%748 = OpVariable %_ptr_Function_ulong Function
-%749 = OpVariable %_ptr_Function_ulong Function
-%750 = OpVariable %_ptr_Function_ulong Function
-%751 = OpVariable %_ptr_Function_bool Function
-%752 = OpVariable %_ptr_Function_ulong Function
-%753 = OpVariable %_ptr_Function_ulong Function
-%754 = OpVariable %_ptr_Function_ulong Function
-%755 = OpVariable %_ptr_Function_bool Function
-%756 = OpVariable %_ptr_Function_ulong Function
-%757 = OpVariable %_ptr_Function_ulong Function
-%758 = OpVariable %_ptr_Function_ulong Function
-%759 = OpVariable %_ptr_Function_bool Function
-%760 = OpVariable %_ptr_Function_ulong Function
-%761 = OpVariable %_ptr_Function_ulong Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_bool Function
-%764 = OpVariable %_ptr_Function_ulong Function
-%765 = OpVariable %_ptr_Function_ulong Function
-%766 = OpVariable %_ptr_Function_ulong Function
-%767 = OpVariable %_ptr_Function_bool Function
-%768 = OpVariable %_ptr_Function_ulong Function
-%769 = OpVariable %_ptr_Function_ulong Function
-%770 = OpVariable %_ptr_Function_ulong Function
-%771 = OpVariable %_ptr_Function_bool Function
-%772 = OpVariable %_ptr_Function_ulong Function
-%773 = OpVariable %_ptr_Function_ulong Function
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_bool Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_ulong Function
-%778 = OpVariable %_ptr_Function_ulong Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_double Function
-%781 = OpVariable %_ptr_Function_ulong Function
-%782 = OpVariable %_ptr_Function_double Function
-OpStore %377 %53
-%783 = OpFunctionCall %ulong %4
-OpStore %378 %783
-OpBranch %257
-%257 = OpLabel
-%785 = OpLoad %ulong %377
-%786 = OpIAdd %ulong %ulong_4607182418800017408 %785
-OpStore %711 %786
-%787 = OpLoad %ulong %711
-%788 = OpBitcast %double %787
-OpStore %712 %788
-OpBranch %258
-%258 = OpLabel
-%790 = OpLoad %double %712
-%791 = OpFMul %double %double_1_5 %790
-OpStore %379 %791
-%793 = OpLoad %double %712
-%794 = OpFMul %double %double_0_25 %793
-OpStore %380 %794
-%795 = OpLoad %double %379
-%796 = OpLoad %double %380
-%797 = OpFAdd %double %795 %796
-OpStore %381 %797
-OpBranch %306
-%306 = OpLabel
-%798 = OpLoad %double %381
-%799 = OpLoad %double %381
-%800 = OpFUnordNotEqual %bool %798 %799
-OpStore %751 %800
-%801 = OpLoad %bool %751
-OpSelectionMerge %310 None
-OpBranchConditional %801 %307 %308
-%308 = OpLabel
-OpBranch %309
-%309 = OpLabel
-%802 = OpLoad %ulong %378
-%803 = OpLoad %double %381
-%804 = OpFunctionCall %ulong %6 %802 %803
-OpStore %753 %804
-%805 = OpLoad %ulong %753
-OpStore %754 %805
-OpBranch %310
-%307 = OpLabel
-%806 = OpLoad %ulong %378
-%807 = OpFunctionCall %ulong %5 %806 %ulong_18446744073709551615
-OpStore %752 %807
-%808 = OpLoad %ulong %752
-OpStore %754 %808
-OpBranch %310
-%310 = OpLabel
-%809 = OpLoad %double %379
-%810 = OpLoad %double %380
-%811 = OpFSub %double %809 %810
-OpStore %382 %811
-OpBranch %316
-%316 = OpLabel
-%812 = OpLoad %double %382
-%813 = OpLoad %double %382
-%814 = OpFUnordNotEqual %bool %812 %813
-OpStore %759 %814
-%815 = OpLoad %bool %759
-OpSelectionMerge %320 None
-OpBranchConditional %815 %317 %318
-%318 = OpLabel
-OpBranch %319
-%319 = OpLabel
-%816 = OpLoad %ulong %754
-%817 = OpLoad %double %382
-%818 = OpFunctionCall %ulong %6 %816 %817
-OpStore %761 %818
-%819 = OpLoad %ulong %761
-OpStore %762 %819
-OpBranch %320
-%317 = OpLabel
-%820 = OpLoad %ulong %754
-%821 = OpFunctionCall %ulong %5 %820 %ulong_18446744073709551615
-OpStore %760 %821
-%822 = OpLoad %ulong %760
-OpStore %762 %822
-OpBranch %320
-%320 = OpLabel
-%823 = OpLoad %double %380
-%824 = OpLoad %double %379
-%825 = OpFSub %double %823 %824
-OpStore %383 %825
+%722 = OpVariable %_ptr_Function_double Function
+%723 = OpVariable %_ptr_Function_ulong Function
+%724 = OpVariable %_ptr_Function_double Function
+OpStore %368 %122
 OpBranch %326
 %326 = OpLabel
-%826 = OpLoad %double %383
-%827 = OpLoad %double %383
-%828 = OpFUnordNotEqual %bool %826 %827
-OpStore %767 %828
-%829 = OpLoad %bool %767
-OpSelectionMerge %330 None
-OpBranchConditional %829 %327 %328
-%328 = OpLabel
-OpBranch %329
-%329 = OpLabel
-%830 = OpLoad %ulong %762
-%831 = OpLoad %double %383
-%832 = OpFunctionCall %ulong %6 %830 %831
-OpStore %769 %832
-%833 = OpLoad %ulong %769
-OpStore %770 %833
-OpBranch %330
+OpBranch %327
 %327 = OpLabel
-%834 = OpLoad %ulong %762
-%835 = OpFunctionCall %ulong %5 %834 %ulong_18446744073709551615
-OpStore %768 %835
-%836 = OpLoad %ulong %768
-OpStore %770 %836
 OpBranch %330
 %330 = OpLabel
-%837 = OpLoad %double %379
-%838 = OpLoad %double %380
-%839 = OpFMul %double %837 %838
-OpStore %384 %839
-OpBranch %336
-%336 = OpLabel
-%840 = OpLoad %double %384
-%841 = OpLoad %double %384
-%842 = OpFUnordNotEqual %bool %840 %841
-OpStore %775 %842
-%843 = OpLoad %bool %775
-OpSelectionMerge %340 None
-OpBranchConditional %843 %337 %338
-%338 = OpLabel
-OpBranch %339
-%339 = OpLabel
-%844 = OpLoad %ulong %770
-%845 = OpLoad %double %384
-%846 = OpFunctionCall %ulong %6 %844 %845
-OpStore %777 %846
-%847 = OpLoad %ulong %777
-OpStore %778 %847
-OpBranch %340
-%337 = OpLabel
-%848 = OpLoad %ulong %770
-%849 = OpFunctionCall %ulong %5 %848 %ulong_18446744073709551615
-OpStore %776 %849
-%850 = OpLoad %ulong %776
-OpStore %778 %850
-OpBranch %340
-%340 = OpLabel
-%851 = OpLoad %double %379
-%852 = OpLoad %double %380
-%853 = OpFDiv %double %851 %852
-OpStore %385 %853
-%854 = OpLoad %ulong %778
-%855 = OpLoad %double %385
-%856 = OpFunctionCall %ulong %2 %854 %855
-OpStore %386 %856
-%857 = OpLoad %double %380
-%858 = OpLoad %double %379
-%859 = OpFDiv %double %857 %858
-OpStore %387 %859
-%860 = OpLoad %ulong %386
-%861 = OpLoad %double %387
-%862 = OpFunctionCall %ulong %2 %860 %861
-OpStore %388 %862
-%863 = OpLoad %double %379
-%864 = OpFNegate %double %863
-OpStore %389 %864
-%865 = OpLoad %ulong %388
-%866 = OpLoad %double %389
-%867 = OpFunctionCall %ulong %2 %865 %866
-OpStore %390 %867
-%869 = OpLoad %double %379
-%870 = OpFSub %double %double_0 %869
-OpStore %391 %870
-%871 = OpLoad %ulong %390
-%872 = OpLoad %double %391
-%873 = OpFunctionCall %ulong %2 %871 %872
-OpStore %392 %873
-%874 = OpLoad %double %379
-%875 = OpLoad %double %379
-%876 = OpFSub %double %874 %875
-OpStore %393 %876
-%877 = OpLoad %ulong %392
-%878 = OpLoad %double %393
-%879 = OpFunctionCall %ulong %2 %877 %878
-OpStore %394 %879
-%880 = OpLoad %double %391
-%881 = OpLoad %double %379
-%882 = OpFAdd %double %880 %881
-OpStore %395 %882
-%883 = OpLoad %ulong %394
-%884 = OpLoad %double %395
-%885 = OpFunctionCall %ulong %2 %883 %884
-OpStore %396 %885
-%887 = OpLoad %double %712
-%888 = OpFMul %double %double_3 %887
-OpStore %397 %888
-%889 = OpLoad %double %712
-%890 = OpLoad %double %397
-%891 = OpFDiv %double %889 %890
-OpStore %398 %891
-%892 = OpLoad %ulong %396
-%893 = OpLoad %double %398
-%894 = OpFunctionCall %ulong %2 %892 %893
-OpStore %399 %894
-%895 = OpLoad %double %398
-%896 = OpLoad %double %397
-%897 = OpFMul %double %895 %896
-OpStore %400 %897
-%898 = OpLoad %ulong %399
-%899 = OpLoad %double %400
-%900 = OpFunctionCall %ulong %2 %898 %899
-OpStore %401 %900
-%901 = OpLoad %double %712
-%902 = OpLoad %double %398
-%903 = OpFSub %double %901 %902
-OpStore %402 %903
-%904 = OpLoad %double %402
-%905 = OpLoad %double %398
-%906 = OpFSub %double %904 %905
-OpStore %403 %906
-%907 = OpLoad %double %403
-%908 = OpLoad %double %398
-%909 = OpFSub %double %907 %908
-OpStore %404 %909
-%910 = OpLoad %ulong %401
-%911 = OpLoad %double %404
-%912 = OpFunctionCall %ulong %2 %910 %911
-OpStore %405 %912
-%913 = OpLoad %double %712
-%915 = OpFDiv %double %913 %double_49
-OpStore %406 %915
-%916 = OpLoad %ulong %405
-%917 = OpLoad %double %406
-%918 = OpFunctionCall %ulong %2 %916 %917
-OpStore %407 %918
-%919 = OpLoad %double %712
-%921 = OpFDiv %double %919 %double_1048576_5
-OpStore %408 %921
-%922 = OpLoad %ulong %407
-%923 = OpLoad %double %408
-%924 = OpFunctionCall %ulong %2 %922 %923
-OpStore %409 %924
-%925 = OpLoad %double %397
-%926 = OpFDiv %double %double_1048576_5 %925
-OpStore %410 %926
-%927 = OpLoad %ulong %409
-%928 = OpLoad %double %410
-%929 = OpFunctionCall %ulong %2 %927 %928
-OpStore %411 %929
-%931 = OpLoad %double %712
-%932 = OpFMul %double %double_9007199254740992 %931
-OpStore %412 %932
-%933 = OpLoad %double %412
-%934 = OpLoad %double %712
-%935 = OpFAdd %double %933 %934
-OpStore %413 %935
-%936 = OpLoad %ulong %411
-%937 = OpLoad %double %413
-%938 = OpFunctionCall %ulong %2 %936 %937
-OpStore %414 %938
-%939 = OpLoad %double %413
-%940 = OpLoad %double %712
-%941 = OpFAdd %double %939 %940
-OpStore %415 %941
-%942 = OpLoad %ulong %414
-%943 = OpLoad %double %415
-%944 = OpFunctionCall %ulong %2 %942 %943
-OpStore %416 %944
-%945 = OpLoad %double %712
-%946 = OpLoad %double %712
-%947 = OpFAdd %double %945 %946
-OpStore %417 %947
-%948 = OpLoad %double %412
-%949 = OpLoad %double %417
-%950 = OpFAdd %double %948 %949
-OpStore %418 %950
-%951 = OpLoad %ulong %416
-%952 = OpLoad %double %418
-%953 = OpFunctionCall %ulong %2 %951 %952
-OpStore %419 %953
-%954 = OpLoad %double %412
-%955 = OpLoad %double %712
-%956 = OpFSub %double %954 %955
-OpStore %420 %956
-%957 = OpLoad %ulong %419
-%958 = OpLoad %double %420
-%959 = OpFunctionCall %ulong %2 %957 %958
-OpStore %421 %959
-%960 = OpLoad %double %413
-%961 = OpLoad %double %412
-%962 = OpFSub %double %960 %961
-OpStore %422 %962
-%963 = OpLoad %ulong %421
-%964 = OpLoad %double %422
-%965 = OpFunctionCall %ulong %2 %963 %964
-OpStore %423 %965
-%966 = OpLoad %double %712
-%967 = OpFMul %double %double_0 %966
-OpStore %424 %967
-%968 = OpLoad %ulong %423
-OpStore %708 %968
-%969 = OpLoad %double %424
-OpStore %709 %969
-OpStore %710 %ulong_0
-OpBranch %55
-%55 = OpLabel
-%971 = OpLoad %ulong %710
-%973 = OpULessThan %bool %971 %ulong_24
-OpStore %425 %973
-%974 = OpLoad %bool %425
-OpLoopMerge %57 %376 None
-OpBranchConditional %974 %56 %57
-%57 = OpLabel
-OpBranch %264
-%264 = OpLabel
-%976 = OpLoad %ulong %377
-%977 = OpIAdd %ulong %ulong_9218868437227405311 %976
-OpStore %717 %977
-%978 = OpLoad %ulong %717
-%979 = OpBitcast %double %978
-OpStore %718 %979
-OpBranch %265
-%265 = OpLabel
-OpBranch %311
-%311 = OpLabel
-%980 = OpLoad %double %718
-%981 = OpLoad %double %718
-%982 = OpFUnordNotEqual %bool %980 %981
-OpStore %755 %982
-%983 = OpLoad %bool %755
-OpSelectionMerge %315 None
-OpBranchConditional %983 %312 %313
-%313 = OpLabel
-OpBranch %314
-%314 = OpLabel
-%984 = OpLoad %ulong %708
-%985 = OpLoad %double %718
-%986 = OpFunctionCall %ulong %6 %984 %985
-OpStore %757 %986
-%987 = OpLoad %ulong %757
-OpStore %758 %987
-OpBranch %315
-%312 = OpLabel
-%988 = OpLoad %ulong %708
-%989 = OpFunctionCall %ulong %5 %988 %ulong_18446744073709551615
-OpStore %756 %989
-%990 = OpLoad %ulong %756
-OpStore %758 %990
-OpBranch %315
-%315 = OpLabel
-%991 = OpLoad %double %718
-%993 = OpFDiv %double %991 %double_2
-OpStore %429 %993
-OpBranch %321
-%321 = OpLabel
-%994 = OpLoad %double %429
-%995 = OpLoad %double %429
-%996 = OpFUnordNotEqual %bool %994 %995
-OpStore %763 %996
-%997 = OpLoad %bool %763
-OpSelectionMerge %325 None
-OpBranchConditional %997 %322 %323
-%323 = OpLabel
-OpBranch %324
-%324 = OpLabel
-%998 = OpLoad %ulong %758
-%999 = OpLoad %double %429
-%1000 = OpFunctionCall %ulong %6 %998 %999
-OpStore %765 %1000
-%1001 = OpLoad %ulong %765
-OpStore %766 %1001
-OpBranch %325
-%322 = OpLabel
-%1002 = OpLoad %ulong %758
-%1003 = OpFunctionCall %ulong %5 %1002 %ulong_18446744073709551615
-OpStore %764 %1003
-%1004 = OpLoad %ulong %764
-OpStore %766 %1004
-OpBranch %325
-%325 = OpLabel
-%1005 = OpLoad %double %718
-%1006 = OpLoad %double %718
-%1007 = OpFAdd %double %1005 %1006
-OpStore %430 %1007
+%726 = OpLoad %ulong %368
+%727 = OpIAdd %ulong %ulong_4607182418800017408 %726
+OpStore %719 %727
+%728 = OpLoad %ulong %719
+%729 = OpBitcast %double %728
+OpStore %720 %729
 OpBranch %331
 %331 = OpLabel
-%1008 = OpLoad %double %430
-%1009 = OpLoad %double %430
-%1010 = OpFUnordNotEqual %bool %1008 %1009
-OpStore %771 %1010
-%1011 = OpLoad %bool %771
-OpSelectionMerge %335 None
-OpBranchConditional %1011 %332 %333
+%731 = OpLoad %double %720
+%732 = OpFMul %double %double_1_5 %731
+OpStore %369 %732
+%734 = OpLoad %double %720
+%735 = OpFMul %double %double_0_25 %734
+OpStore %370 %735
+%736 = OpLoad %double %369
+%737 = OpLoad %double %370
+%738 = OpFAdd %double %736 %737
+OpStore %371 %738
+%740 = OpLoad %double %371
+%741 = OpFunctionCall %ulong %2 %ulong_14695981039346656037 %740
+OpStore %372 %741
+%742 = OpLoad %double %369
+%743 = OpLoad %double %370
+%744 = OpFSub %double %742 %743
+OpStore %373 %744
+%745 = OpLoad %ulong %372
+%746 = OpLoad %double %373
+%747 = OpFunctionCall %ulong %2 %745 %746
+OpStore %374 %747
+%748 = OpLoad %double %370
+%749 = OpLoad %double %369
+%750 = OpFSub %double %748 %749
+OpStore %375 %750
+%751 = OpLoad %ulong %374
+%752 = OpLoad %double %375
+%753 = OpFunctionCall %ulong %2 %751 %752
+OpStore %376 %753
+%754 = OpLoad %double %369
+%755 = OpLoad %double %370
+%756 = OpFMul %double %754 %755
+OpStore %377 %756
+%757 = OpLoad %ulong %376
+%758 = OpLoad %double %377
+%759 = OpFunctionCall %ulong %2 %757 %758
+OpStore %378 %759
+%760 = OpLoad %double %369
+%761 = OpLoad %double %370
+%762 = OpFDiv %double %760 %761
+OpStore %379 %762
+%763 = OpLoad %ulong %378
+%764 = OpLoad %double %379
+%765 = OpFunctionCall %ulong %2 %763 %764
+OpStore %380 %765
+%766 = OpLoad %double %370
+%767 = OpLoad %double %369
+%768 = OpFDiv %double %766 %767
+OpStore %381 %768
+%769 = OpLoad %ulong %380
+%770 = OpLoad %double %381
+%771 = OpFunctionCall %ulong %2 %769 %770
+OpStore %382 %771
+%772 = OpLoad %double %369
+%773 = OpFNegate %double %772
+OpStore %383 %773
+%774 = OpLoad %ulong %382
+%775 = OpLoad %double %383
+%776 = OpFunctionCall %ulong %2 %774 %775
+OpStore %384 %776
+%778 = OpLoad %double %369
+%779 = OpFSub %double %double_0 %778
+OpStore %385 %779
+%780 = OpLoad %ulong %384
+%781 = OpLoad %double %385
+%782 = OpFunctionCall %ulong %2 %780 %781
+OpStore %386 %782
+%783 = OpLoad %double %369
+%784 = OpLoad %double %369
+%785 = OpFSub %double %783 %784
+OpStore %387 %785
+%786 = OpLoad %ulong %386
+%787 = OpLoad %double %387
+%788 = OpFunctionCall %ulong %2 %786 %787
+OpStore %388 %788
+%789 = OpLoad %double %385
+%790 = OpLoad %double %369
+%791 = OpFAdd %double %789 %790
+OpStore %389 %791
+%792 = OpLoad %ulong %388
+%793 = OpLoad %double %389
+%794 = OpFunctionCall %ulong %2 %792 %793
+OpStore %390 %794
+%796 = OpLoad %double %720
+%797 = OpFMul %double %double_3 %796
+OpStore %391 %797
+%798 = OpLoad %double %720
+%799 = OpLoad %double %391
+%800 = OpFDiv %double %798 %799
+OpStore %392 %800
+%801 = OpLoad %ulong %390
+%802 = OpLoad %double %392
+%803 = OpFunctionCall %ulong %2 %801 %802
+OpStore %393 %803
+%804 = OpLoad %double %392
+%805 = OpLoad %double %391
+%806 = OpFMul %double %804 %805
+OpStore %394 %806
+%807 = OpLoad %ulong %393
+%808 = OpLoad %double %394
+%809 = OpFunctionCall %ulong %2 %807 %808
+OpStore %395 %809
+%810 = OpLoad %double %720
+%811 = OpLoad %double %392
+%812 = OpFSub %double %810 %811
+OpStore %396 %812
+%813 = OpLoad %double %396
+%814 = OpLoad %double %392
+%815 = OpFSub %double %813 %814
+OpStore %397 %815
+%816 = OpLoad %double %397
+%817 = OpLoad %double %392
+%818 = OpFSub %double %816 %817
+OpStore %398 %818
+%819 = OpLoad %ulong %395
+%820 = OpLoad %double %398
+%821 = OpFunctionCall %ulong %2 %819 %820
+OpStore %399 %821
+%822 = OpLoad %double %720
+%824 = OpFDiv %double %822 %double_49
+OpStore %400 %824
+%825 = OpLoad %ulong %399
+%826 = OpLoad %double %400
+%827 = OpFunctionCall %ulong %2 %825 %826
+OpStore %401 %827
+%828 = OpLoad %double %720
+%830 = OpFDiv %double %828 %double_1048576_5
+OpStore %402 %830
+%831 = OpLoad %ulong %401
+%832 = OpLoad %double %402
+%833 = OpFunctionCall %ulong %2 %831 %832
+OpStore %403 %833
+%834 = OpLoad %double %391
+%835 = OpFDiv %double %double_1048576_5 %834
+OpStore %404 %835
+%836 = OpLoad %ulong %403
+%837 = OpLoad %double %404
+%838 = OpFunctionCall %ulong %2 %836 %837
+OpStore %405 %838
+%840 = OpLoad %double %720
+%841 = OpFMul %double %double_9007199254740992 %840
+OpStore %406 %841
+%842 = OpLoad %double %406
+%843 = OpLoad %double %720
+%844 = OpFAdd %double %842 %843
+OpStore %407 %844
+%845 = OpLoad %ulong %405
+%846 = OpLoad %double %407
+%847 = OpFunctionCall %ulong %2 %845 %846
+OpStore %408 %847
+%848 = OpLoad %double %407
+%849 = OpLoad %double %720
+%850 = OpFAdd %double %848 %849
+OpStore %409 %850
+%851 = OpLoad %ulong %408
+%852 = OpLoad %double %409
+%853 = OpFunctionCall %ulong %2 %851 %852
+OpStore %410 %853
+%854 = OpLoad %double %720
+%855 = OpLoad %double %720
+%856 = OpFAdd %double %854 %855
+OpStore %411 %856
+%857 = OpLoad %double %406
+%858 = OpLoad %double %411
+%859 = OpFAdd %double %857 %858
+OpStore %412 %859
+%860 = OpLoad %ulong %410
+%861 = OpLoad %double %412
+%862 = OpFunctionCall %ulong %2 %860 %861
+OpStore %413 %862
+%863 = OpLoad %double %406
+%864 = OpLoad %double %720
+%865 = OpFSub %double %863 %864
+OpStore %414 %865
+%866 = OpLoad %ulong %413
+%867 = OpLoad %double %414
+%868 = OpFunctionCall %ulong %2 %866 %867
+OpStore %415 %868
+%869 = OpLoad %double %407
+%870 = OpLoad %double %406
+%871 = OpFSub %double %869 %870
+OpStore %416 %871
+%872 = OpLoad %ulong %415
+%873 = OpLoad %double %416
+%874 = OpFunctionCall %ulong %2 %872 %873
+OpStore %417 %874
+%875 = OpLoad %double %720
+%876 = OpFMul %double %double_0 %875
+OpStore %418 %876
+%877 = OpLoad %ulong %417
+OpStore %714 %877
+%878 = OpLoad %double %418
+OpStore %715 %878
+OpStore %716 %ulong_0
+OpBranch %124
+%124 = OpLabel
+%879 = OpLoad %ulong %716
+%881 = OpULessThan %bool %879 %ulong_24
+OpStore %419 %881
+%882 = OpLoad %bool %419
+OpLoopMerge %126 %367 None
+OpBranchConditional %882 %125 %126
+%126 = OpLabel
+OpBranch %328
+%328 = OpLabel
+%884 = OpLoad %ulong %368
+%885 = OpIAdd %ulong %ulong_9218868437227405311 %884
+OpStore %717 %885
+%886 = OpLoad %ulong %717
+%887 = OpBitcast %double %886
+OpStore %718 %887
+OpBranch %329
+%329 = OpLabel
+%888 = OpLoad %ulong %714
+%889 = OpLoad %double %718
+%890 = OpFunctionCall %ulong %2 %888 %889
+OpStore %424 %890
+%891 = OpLoad %double %718
+%893 = OpFDiv %double %891 %double_2
+OpStore %425 %893
+%894 = OpLoad %ulong %424
+%895 = OpLoad %double %425
+%896 = OpFunctionCall %ulong %2 %894 %895
+OpStore %426 %896
+%897 = OpLoad %double %718
+%898 = OpLoad %double %718
+%899 = OpFAdd %double %897 %898
+OpStore %427 %899
+%900 = OpLoad %ulong %426
+%901 = OpLoad %double %427
+%902 = OpFunctionCall %ulong %2 %900 %901
+OpStore %428 %902
+%903 = OpLoad %double %718
+%904 = OpFMul %double %903 %double_2
+OpStore %429 %904
+%905 = OpLoad %ulong %428
+%906 = OpLoad %double %429
+%907 = OpFunctionCall %ulong %2 %905 %906
+OpStore %430 %907
+%908 = OpLoad %double %429
+%909 = OpFSub %double %double_0 %908
+OpStore %431 %909
+%910 = OpLoad %ulong %430
+%911 = OpLoad %double %431
+%912 = OpFunctionCall %ulong %2 %910 %911
+OpStore %432 %912
+%913 = OpLoad %double %718
+%914 = OpLoad %double %718
+%915 = OpFMul %double %913 %914
+OpStore %433 %915
+%916 = OpLoad %ulong %432
+%917 = OpLoad %double %433
+%918 = OpFunctionCall %ulong %2 %916 %917
+OpStore %434 %918
+%919 = OpLoad %double %718
+%920 = OpLoad %double %718
+%921 = OpFSub %double %919 %920
+OpStore %435 %921
+%922 = OpLoad %ulong %434
+%923 = OpLoad %double %435
+%924 = OpFunctionCall %ulong %2 %922 %923
+OpStore %436 %924
+OpBranch %332
+%332 = OpLabel
+%926 = OpLoad %ulong %368
+%927 = OpIAdd %ulong %ulong_4503599627370496 %926
+OpStore %721 %927
+%928 = OpLoad %ulong %721
+%929 = OpBitcast %double %928
+OpStore %722 %929
+OpBranch %333
 %333 = OpLabel
 OpBranch %334
 %334 = OpLabel
-%1012 = OpLoad %ulong %766
-%1013 = OpLoad %double %430
-%1014 = OpFunctionCall %ulong %6 %1012 %1013
-OpStore %773 %1014
-%1015 = OpLoad %ulong %773
-OpStore %774 %1015
-OpBranch %335
-%332 = OpLabel
-%1016 = OpLoad %ulong %766
-%1017 = OpFunctionCall %ulong %5 %1016 %ulong_18446744073709551615
-OpStore %772 %1017
-%1018 = OpLoad %ulong %772
-OpStore %774 %1018
+%930 = OpLoad %ulong %368
+%931 = OpIAdd %ulong %ulong_1 %930
+OpStore %723 %931
+%932 = OpLoad %ulong %723
+%933 = OpBitcast %double %932
+OpStore %724 %933
 OpBranch %335
 %335 = OpLabel
-%1019 = OpLoad %double %718
-%1020 = OpFMul %double %1019 %double_2
-OpStore %431 %1020
-%1021 = OpLoad %ulong %774
-%1022 = OpLoad %double %431
-%1023 = OpFunctionCall %ulong %2 %1021 %1022
-OpStore %432 %1023
-%1024 = OpLoad %double %431
-%1025 = OpFSub %double %double_0 %1024
-OpStore %433 %1025
-%1026 = OpLoad %ulong %432
-%1027 = OpLoad %double %433
-%1028 = OpFunctionCall %ulong %2 %1026 %1027
-OpStore %434 %1028
-%1029 = OpLoad %double %718
-%1030 = OpLoad %double %718
-%1031 = OpFMul %double %1029 %1030
-OpStore %435 %1031
-%1032 = OpLoad %ulong %434
-%1033 = OpLoad %double %435
-%1034 = OpFunctionCall %ulong %2 %1032 %1033
-OpStore %436 %1034
-%1035 = OpLoad %double %718
-%1036 = OpLoad %double %718
-%1037 = OpFSub %double %1035 %1036
-OpStore %437 %1037
-%1038 = OpLoad %ulong %436
-%1039 = OpLoad %double %437
-%1040 = OpFunctionCall %ulong %2 %1038 %1039
-OpStore %438 %1040
-OpBranch %341
-%341 = OpLabel
-%1042 = OpLoad %ulong %377
-%1043 = OpIAdd %ulong %ulong_4503599627370496 %1042
-OpStore %779 %1043
-%1044 = OpLoad %ulong %779
-%1045 = OpBitcast %double %1044
-OpStore %780 %1045
-OpBranch %342
-%342 = OpLabel
-OpBranch %343
-%343 = OpLabel
-%1047 = OpLoad %ulong %377
-%1048 = OpIAdd %ulong %ulong_1 %1047
-OpStore %781 %1048
-%1049 = OpLoad %ulong %781
-%1050 = OpBitcast %double %1049
-OpStore %782 %1050
-OpBranch %344
-%344 = OpLabel
-%1051 = OpLoad %double %780
-%1053 = OpFMul %double %1051 %double_0_5
-OpStore %439 %1053
-%1054 = OpLoad %ulong %438
-%1055 = OpLoad %double %439
-%1056 = OpFunctionCall %ulong %2 %1054 %1055
-OpStore %440 %1056
-%1057 = OpLoad %double %780
-%1058 = OpFDiv %double %1057 %double_2
-OpStore %441 %1058
-%1059 = OpLoad %ulong %440
-%1060 = OpLoad %double %441
-%1061 = OpFunctionCall %ulong %2 %1059 %1060
-OpStore %442 %1061
-%1062 = OpLoad %double %780
-%1063 = OpLoad %double %782
-%1064 = OpFSub %double %1062 %1063
-OpStore %443 %1064
-%1065 = OpLoad %ulong %442
-%1066 = OpLoad %double %443
-%1067 = OpFunctionCall %ulong %2 %1065 %1066
-OpStore %444 %1067
-%1068 = OpLoad %double %780
-%1069 = OpLoad %double %712
-%1070 = OpFMul %double %1068 %1069
-OpStore %445 %1070
-%1071 = OpLoad %ulong %444
-%1072 = OpLoad %double %445
-%1073 = OpFunctionCall %ulong %2 %1071 %1072
-OpStore %446 %1073
-%1074 = OpLoad %double %782
-%1075 = OpLoad %double %782
-%1076 = OpFAdd %double %1074 %1075
-OpStore %447 %1076
-%1077 = OpLoad %ulong %446
-%1078 = OpLoad %double %447
-%1079 = OpFunctionCall %ulong %2 %1077 %1078
-OpStore %448 %1079
-%1080 = OpLoad %double %782
-%1081 = OpFMul %double %1080 %double_0_5
-OpStore %449 %1081
-%1082 = OpLoad %ulong %448
-%1083 = OpLoad %double %449
-%1084 = OpFunctionCall %ulong %2 %1082 %1083
-OpStore %450 %1084
-%1085 = OpLoad %double %782
-%1087 = OpFMul %double %1085 %double_0_75
-OpStore %451 %1087
-%1088 = OpLoad %ulong %450
-%1089 = OpLoad %double %451
-%1090 = OpFunctionCall %ulong %2 %1088 %1089
-OpStore %452 %1090
-%1091 = OpLoad %double %782
-%1092 = OpFMul %double %1091 %double_9007199254740992
-OpStore %453 %1092
-%1093 = OpLoad %ulong %452
-%1094 = OpLoad %double %453
-%1095 = OpFunctionCall %ulong %2 %1093 %1094
-OpStore %454 %1095
-%1096 = OpLoad %double %782
-%1097 = OpLoad %double %780
-%1098 = OpFDiv %double %1096 %1097
-OpStore %455 %1098
-%1099 = OpLoad %ulong %454
-%1100 = OpLoad %double %455
-%1101 = OpFunctionCall %ulong %2 %1099 %1100
-OpStore %456 %1101
-%1103 = OpLoad %double %712
-%1104 = OpFMul %double %double_5_5 %1103
-OpStore %457 %1104
-%1105 = OpLoad %double %712
-%1106 = OpFMul %double %double_3 %1105
-OpStore %458 %1106
-%1107 = OpLoad %double %458
-%1108 = OpFOrdEqual %bool %1107 %double_0
-OpStore %459 %1108
-%1109 = OpLoad %bool %459
-OpSelectionMerge %61 None
-OpBranchConditional %1109 %346 %58
-%58 = OpLabel
-%1110 = OpLoad %double %457
-%1111 = OpFMul %double %1110 %double_2
-OpStore %460 %1111
-%1112 = OpLoad %double %457
-%1113 = OpLoad %double %460
-%1114 = OpFOrdEqual %bool %1112 %1113
-OpStore %461 %1114
-%1115 = OpLoad %bool %461
-OpSelectionMerge %60 None
-OpBranchConditional %1115 %59 %345
-%345 = OpLabel
-%1116 = OpLoad %bool %461
-OpStore %463 %1116
-OpBranch %60
-%59 = OpLabel
-%1117 = OpLoad %double %457
-%1118 = OpFUnordNotEqual %bool %1117 %double_0
-OpStore %462 %1118
-%1119 = OpLoad %bool %462
-OpStore %463 %1119
-OpBranch %60
-%60 = OpLabel
-%1120 = OpLoad %bool %463
-OpStore %464 %1120
-OpBranch %61
-%346 = OpLabel
-%1121 = OpLoad %bool %459
-OpStore %464 %1121
-OpBranch %61
-%61 = OpLabel
-%1122 = OpLoad %bool %464
-OpSelectionMerge %64 None
-OpBranchConditional %1122 %62 %63
-%63 = OpLabel
-%1123 = OpLoad %double %457
-%1124 = OpFOrdLessThan %bool %1123 %double_0
-OpStore %470 %1124
-%1125 = OpLoad %bool %470
-OpSelectionMerge %67 None
-OpBranchConditional %1125 %65 %66
-%66 = OpLabel
-%1126 = OpLoad %double %457
-OpStore %472 %1126
-OpBranch %67
-%65 = OpLabel
-%1127 = OpLoad %double %457
-%1128 = OpFSub %double %double_0 %1127
-OpStore %471 %1128
-%1129 = OpLoad %double %471
-OpStore %472 %1129
-OpBranch %67
-%67 = OpLabel
-%1130 = OpLoad %double %458
-%1131 = OpFOrdLessThan %bool %1130 %double_0
-OpStore %473 %1131
-%1132 = OpLoad %bool %473
-OpSelectionMerge %70 None
-OpBranchConditional %1132 %68 %69
-%69 = OpLabel
-%1133 = OpLoad %double %458
-OpStore %475 %1133
-OpBranch %70
-%68 = OpLabel
-%1134 = OpLoad %double %458
-%1135 = OpFSub %double %double_0 %1134
-OpStore %474 %1135
-%1136 = OpLoad %double %474
-OpStore %475 %1136
-OpBranch %70
-%70 = OpLabel
-%1137 = OpLoad %double %472
-%1138 = OpFDiv %double %1137 %double_2
-OpStore %476 %1138
-%1139 = OpLoad %double %475
-OpStore %477 %1139
-OpBranch %71
-%71 = OpLabel
-%1140 = OpLoad %double %477
-%1141 = OpLoad %double %476
-%1142 = OpFOrdLessThanEqual %bool %1140 %1141
-OpStore %478 %1142
-%1143 = OpLoad %bool %478
-OpLoopMerge %73 %375 None
-OpBranchConditional %1143 %72 %73
-%73 = OpLabel
-%1144 = OpLoad %double %472
-OpStore %480 %1144
-%1145 = OpLoad %double %477
-OpStore %481 %1145
-OpBranch %74
-%74 = OpLabel
-%1146 = OpLoad %double %475
-%1147 = OpLoad %double %481
-%1148 = OpFOrdLessThanEqual %bool %1146 %1147
-OpStore %482 %1148
-%1149 = OpLoad %bool %482
-OpLoopMerge %78 %374 None
-OpBranchConditional %1149 %79 %78
-%78 = OpLabel
-%1150 = OpLoad %bool %470
-OpSelectionMerge %82 None
-OpBranchConditional %1150 %80 %81
-%81 = OpLabel
-%1151 = OpLoad %double %480
-OpStore %488 %1151
-OpBranch %82
-%80 = OpLabel
-%1152 = OpLoad %double %480
-%1153 = OpFNegate %double %1152
-OpStore %487 %1153
-%1154 = OpLoad %double %487
-OpStore %488 %1154
-OpBranch %82
-%82 = OpLabel
-%1155 = OpLoad %double %488
-OpStore %489 %1155
-OpBranch %64
-%79 = OpLabel
-%1156 = OpLoad %double %481
-%1157 = OpLoad %double %480
-%1158 = OpFOrdLessThanEqual %bool %1156 %1157
-OpStore %483 %1158
-%1159 = OpLoad %bool %483
-OpSelectionMerge %77 None
-OpBranchConditional %1159 %75 %76
-%76 = OpLabel
-%1160 = OpLoad %double %480
-OpStore %485 %1160
-OpBranch %77
-%75 = OpLabel
-%1161 = OpLoad %double %480
-%1162 = OpLoad %double %481
-%1163 = OpFSub %double %1161 %1162
-OpStore %484 %1163
-%1164 = OpLoad %double %484
-OpStore %485 %1164
-OpBranch %77
-%77 = OpLabel
-%1165 = OpLoad %double %481
-%1166 = OpFDiv %double %1165 %double_2
-OpStore %486 %1166
-%1167 = OpLoad %double %485
-OpStore %480 %1167
-%1168 = OpLoad %double %486
-OpStore %481 %1168
-OpBranch %374
-%72 = OpLabel
-%1169 = OpLoad %double %477
-%1170 = OpFMul %double %1169 %double_2
-OpStore %479 %1170
-%1171 = OpLoad %double %479
-OpStore %477 %1171
-OpBranch %375
-%62 = OpLabel
-%1172 = OpLoad %double %457
-%1173 = OpLoad %double %458
-%1174 = OpFDiv %double %1172 %1173
-OpStore %465 %1174
-%1175 = OpLoad %double %465
-%1176 = OpConvertFToS %ulong %1175
-OpStore %466 %1176
-%1177 = OpLoad %ulong %466
-%1178 = OpConvertSToF %double %1177
-OpStore %467 %1178
-%1179 = OpLoad %double %467
-%1180 = OpLoad %double %458
-%1181 = OpFMul %double %1179 %1180
-OpStore %468 %1181
-%1182 = OpLoad %double %457
-%1183 = OpLoad %double %468
-%1184 = OpFSub %double %1182 %1183
-OpStore %469 %1184
-%1185 = OpLoad %double %469
-OpStore %489 %1185
-OpBranch %64
-%64 = OpLabel
-OpBranch %266
-%266 = OpLabel
-%1186 = OpLoad %double %489
-%1187 = OpLoad %double %489
-%1188 = OpFUnordNotEqual %bool %1186 %1187
-OpStore %719 %1188
-%1189 = OpLoad %bool %719
-OpSelectionMerge %270 None
-OpBranchConditional %1189 %267 %268
-%268 = OpLabel
-OpBranch %269
-%269 = OpLabel
-%1190 = OpLoad %ulong %456
-%1191 = OpLoad %double %489
-%1192 = OpFunctionCall %ulong %6 %1190 %1191
-OpStore %721 %1192
-%1193 = OpLoad %ulong %721
-OpStore %722 %1193
-OpBranch %270
-%267 = OpLabel
-%1194 = OpLoad %ulong %456
-%1195 = OpFunctionCall %ulong %5 %1194 %ulong_18446744073709551615
-OpStore %720 %1195
-%1196 = OpLoad %ulong %720
-OpStore %722 %1196
-OpBranch %270
-%270 = OpLabel
-%1197 = OpLoad %double %457
-%1198 = OpFSub %double %double_0 %1197
-OpStore %490 %1198
-%1199 = OpLoad %double %458
-%1200 = OpFOrdEqual %bool %1199 %double_0
-OpStore %491 %1200
-%1201 = OpLoad %bool %491
-OpSelectionMerge %86 None
-OpBranchConditional %1201 %348 %83
-%83 = OpLabel
-%1202 = OpLoad %double %490
-%1203 = OpFMul %double %1202 %double_2
-OpStore %492 %1203
-%1204 = OpLoad %double %490
-%1205 = OpLoad %double %492
-%1206 = OpFOrdEqual %bool %1204 %1205
-OpStore %493 %1206
-%1207 = OpLoad %bool %493
-OpSelectionMerge %85 None
-OpBranchConditional %1207 %84 %347
-%347 = OpLabel
-%1208 = OpLoad %bool %493
-OpStore %495 %1208
-OpBranch %85
-%84 = OpLabel
-%1209 = OpLoad %double %490
-%1210 = OpFUnordNotEqual %bool %1209 %double_0
-OpStore %494 %1210
-%1211 = OpLoad %bool %494
-OpStore %495 %1211
-OpBranch %85
-%85 = OpLabel
-%1212 = OpLoad %bool %495
-OpStore %496 %1212
-OpBranch %86
-%348 = OpLabel
-%1213 = OpLoad %bool %491
-OpStore %496 %1213
-OpBranch %86
-%86 = OpLabel
-%1214 = OpLoad %bool %496
-OpSelectionMerge %89 None
-OpBranchConditional %1214 %87 %88
-%88 = OpLabel
-%1215 = OpLoad %double %490
-%1216 = OpFOrdLessThan %bool %1215 %double_0
-OpStore %502 %1216
-%1217 = OpLoad %bool %502
-OpSelectionMerge %92 None
-OpBranchConditional %1217 %90 %91
-%91 = OpLabel
-%1218 = OpLoad %double %490
-OpStore %504 %1218
-OpBranch %92
-%90 = OpLabel
-%1219 = OpLoad %double %490
-%1220 = OpFSub %double %double_0 %1219
-OpStore %503 %1220
-%1221 = OpLoad %double %503
-OpStore %504 %1221
-OpBranch %92
-%92 = OpLabel
-%1222 = OpLoad %double %458
-%1223 = OpFOrdLessThan %bool %1222 %double_0
-OpStore %505 %1223
-%1224 = OpLoad %bool %505
-OpSelectionMerge %95 None
-OpBranchConditional %1224 %93 %94
-%94 = OpLabel
-%1225 = OpLoad %double %458
-OpStore %507 %1225
-OpBranch %95
-%93 = OpLabel
-%1226 = OpLoad %double %458
-%1227 = OpFSub %double %double_0 %1226
-OpStore %506 %1227
-%1228 = OpLoad %double %506
-OpStore %507 %1228
-OpBranch %95
-%95 = OpLabel
-%1229 = OpLoad %double %504
-%1230 = OpFDiv %double %1229 %double_2
-OpStore %508 %1230
-%1231 = OpLoad %double %507
-OpStore %509 %1231
-OpBranch %96
-%96 = OpLabel
-%1232 = OpLoad %double %509
-%1233 = OpLoad %double %508
-%1234 = OpFOrdLessThanEqual %bool %1232 %1233
-OpStore %510 %1234
-%1235 = OpLoad %bool %510
-OpLoopMerge %98 %373 None
-OpBranchConditional %1235 %97 %98
-%98 = OpLabel
-%1236 = OpLoad %double %504
-OpStore %512 %1236
-%1237 = OpLoad %double %509
-OpStore %513 %1237
-OpBranch %99
-%99 = OpLabel
-%1238 = OpLoad %double %507
-%1239 = OpLoad %double %513
-%1240 = OpFOrdLessThanEqual %bool %1238 %1239
-OpStore %514 %1240
-%1241 = OpLoad %bool %514
-OpLoopMerge %103 %372 None
-OpBranchConditional %1241 %104 %103
-%103 = OpLabel
-%1242 = OpLoad %bool %502
-OpSelectionMerge %107 None
-OpBranchConditional %1242 %105 %106
-%106 = OpLabel
-%1243 = OpLoad %double %512
-OpStore %520 %1243
-OpBranch %107
-%105 = OpLabel
-%1244 = OpLoad %double %512
-%1245 = OpFNegate %double %1244
-OpStore %519 %1245
-%1246 = OpLoad %double %519
-OpStore %520 %1246
-OpBranch %107
-%107 = OpLabel
-%1247 = OpLoad %double %520
-OpStore %521 %1247
-OpBranch %89
-%104 = OpLabel
-%1248 = OpLoad %double %513
-%1249 = OpLoad %double %512
-%1250 = OpFOrdLessThanEqual %bool %1248 %1249
-OpStore %515 %1250
-%1251 = OpLoad %bool %515
-OpSelectionMerge %102 None
-OpBranchConditional %1251 %100 %101
-%101 = OpLabel
-%1252 = OpLoad %double %512
-OpStore %517 %1252
-OpBranch %102
-%100 = OpLabel
-%1253 = OpLoad %double %512
-%1254 = OpLoad %double %513
-%1255 = OpFSub %double %1253 %1254
-OpStore %516 %1255
-%1256 = OpLoad %double %516
-OpStore %517 %1256
-OpBranch %102
-%102 = OpLabel
-%1257 = OpLoad %double %513
-%1258 = OpFDiv %double %1257 %double_2
-OpStore %518 %1258
-%1259 = OpLoad %double %517
-OpStore %512 %1259
-%1260 = OpLoad %double %518
-OpStore %513 %1260
-OpBranch %372
-%97 = OpLabel
-%1261 = OpLoad %double %509
-%1262 = OpFMul %double %1261 %double_2
-OpStore %511 %1262
-%1263 = OpLoad %double %511
-OpStore %509 %1263
-OpBranch %373
-%87 = OpLabel
-%1264 = OpLoad %double %490
-%1265 = OpLoad %double %458
-%1266 = OpFDiv %double %1264 %1265
-OpStore %497 %1266
-%1267 = OpLoad %double %497
-%1268 = OpConvertFToS %ulong %1267
-OpStore %498 %1268
-%1269 = OpLoad %ulong %498
-%1270 = OpConvertSToF %double %1269
-OpStore %499 %1270
-%1271 = OpLoad %double %499
-%1272 = OpLoad %double %458
-%1273 = OpFMul %double %1271 %1272
-OpStore %500 %1273
-%1274 = OpLoad %double %490
-%1275 = OpLoad %double %500
-%1276 = OpFSub %double %1274 %1275
-OpStore %501 %1276
-%1277 = OpLoad %double %501
-OpStore %521 %1277
-OpBranch %89
-%89 = OpLabel
-OpBranch %271
-%271 = OpLabel
-%1278 = OpLoad %double %521
-%1279 = OpLoad %double %521
-%1280 = OpFUnordNotEqual %bool %1278 %1279
-OpStore %723 %1280
-%1281 = OpLoad %bool %723
-OpSelectionMerge %275 None
-OpBranchConditional %1281 %272 %273
-%273 = OpLabel
-OpBranch %274
-%274 = OpLabel
-%1282 = OpLoad %ulong %722
-%1283 = OpLoad %double %521
-%1284 = OpFunctionCall %ulong %6 %1282 %1283
-OpStore %725 %1284
-%1285 = OpLoad %ulong %725
-OpStore %726 %1285
-OpBranch %275
-%272 = OpLabel
-%1286 = OpLoad %ulong %722
-%1287 = OpFunctionCall %ulong %5 %1286 %ulong_18446744073709551615
-OpStore %724 %1287
-%1288 = OpLoad %ulong %724
-OpStore %726 %1288
-OpBranch %275
-%275 = OpLabel
-%1289 = OpLoad %double %458
-%1290 = OpFSub %double %double_0 %1289
-OpStore %522 %1290
-%1291 = OpLoad %double %522
-%1292 = OpFOrdEqual %bool %1291 %double_0
-OpStore %523 %1292
-%1293 = OpLoad %bool %523
-OpSelectionMerge %111 None
-OpBranchConditional %1293 %350 %108
-%108 = OpLabel
-%1294 = OpLoad %double %457
-%1295 = OpFMul %double %1294 %double_2
-OpStore %524 %1295
-%1296 = OpLoad %double %457
-%1297 = OpLoad %double %524
-%1298 = OpFOrdEqual %bool %1296 %1297
-OpStore %525 %1298
-%1299 = OpLoad %bool %525
-OpSelectionMerge %110 None
-OpBranchConditional %1299 %109 %349
-%349 = OpLabel
-%1300 = OpLoad %bool %525
-OpStore %527 %1300
-OpBranch %110
-%109 = OpLabel
-%1301 = OpLoad %double %457
-%1302 = OpFUnordNotEqual %bool %1301 %double_0
-OpStore %526 %1302
-%1303 = OpLoad %bool %526
-OpStore %527 %1303
-OpBranch %110
-%110 = OpLabel
-%1304 = OpLoad %bool %527
-OpStore %528 %1304
-OpBranch %111
-%350 = OpLabel
-%1305 = OpLoad %bool %523
-OpStore %528 %1305
-OpBranch %111
-%111 = OpLabel
-%1306 = OpLoad %bool %528
-OpSelectionMerge %114 None
-OpBranchConditional %1306 %112 %113
-%113 = OpLabel
-%1307 = OpLoad %double %457
-%1308 = OpFOrdLessThan %bool %1307 %double_0
-OpStore %534 %1308
-%1309 = OpLoad %bool %534
-OpSelectionMerge %117 None
-OpBranchConditional %1309 %115 %116
-%116 = OpLabel
-%1310 = OpLoad %double %457
-OpStore %536 %1310
-OpBranch %117
-%115 = OpLabel
-%1311 = OpLoad %double %457
-%1312 = OpFSub %double %double_0 %1311
-OpStore %535 %1312
-%1313 = OpLoad %double %535
-OpStore %536 %1313
-OpBranch %117
-%117 = OpLabel
-%1314 = OpLoad %double %522
-%1315 = OpFOrdLessThan %bool %1314 %double_0
-OpStore %537 %1315
-%1316 = OpLoad %bool %537
-OpSelectionMerge %120 None
-OpBranchConditional %1316 %118 %119
-%119 = OpLabel
-%1317 = OpLoad %double %522
-OpStore %539 %1317
-OpBranch %120
-%118 = OpLabel
-%1318 = OpLoad %double %522
-%1319 = OpFSub %double %double_0 %1318
-OpStore %538 %1319
-%1320 = OpLoad %double %538
-OpStore %539 %1320
-OpBranch %120
-%120 = OpLabel
-%1321 = OpLoad %double %536
-%1322 = OpFDiv %double %1321 %double_2
-OpStore %540 %1322
-%1323 = OpLoad %double %539
-OpStore %541 %1323
-OpBranch %121
-%121 = OpLabel
-%1324 = OpLoad %double %541
-%1325 = OpLoad %double %540
-%1326 = OpFOrdLessThanEqual %bool %1324 %1325
-OpStore %542 %1326
-%1327 = OpLoad %bool %542
-OpLoopMerge %123 %371 None
-OpBranchConditional %1327 %122 %123
-%123 = OpLabel
-%1328 = OpLoad %double %536
-OpStore %544 %1328
-%1329 = OpLoad %double %541
-OpStore %545 %1329
-OpBranch %124
-%124 = OpLabel
-%1330 = OpLoad %double %539
-%1331 = OpLoad %double %545
-%1332 = OpFOrdLessThanEqual %bool %1330 %1331
-OpStore %546 %1332
-%1333 = OpLoad %bool %546
-OpLoopMerge %128 %370 None
-OpBranchConditional %1333 %129 %128
-%128 = OpLabel
-%1334 = OpLoad %bool %534
-OpSelectionMerge %132 None
-OpBranchConditional %1334 %130 %131
-%131 = OpLabel
-%1335 = OpLoad %double %544
-OpStore %552 %1335
-OpBranch %132
-%130 = OpLabel
-%1336 = OpLoad %double %544
-%1337 = OpFNegate %double %1336
-OpStore %551 %1337
-%1338 = OpLoad %double %551
-OpStore %552 %1338
-OpBranch %132
-%132 = OpLabel
-%1339 = OpLoad %double %552
-OpStore %553 %1339
-OpBranch %114
-%129 = OpLabel
-%1340 = OpLoad %double %545
-%1341 = OpLoad %double %544
-%1342 = OpFOrdLessThanEqual %bool %1340 %1341
-OpStore %547 %1342
-%1343 = OpLoad %bool %547
-OpSelectionMerge %127 None
-OpBranchConditional %1343 %125 %126
-%126 = OpLabel
-%1344 = OpLoad %double %544
-OpStore %549 %1344
-OpBranch %127
-%125 = OpLabel
-%1345 = OpLoad %double %544
-%1346 = OpLoad %double %545
-%1347 = OpFSub %double %1345 %1346
-OpStore %548 %1347
-%1348 = OpLoad %double %548
-OpStore %549 %1348
-OpBranch %127
+%934 = OpLoad %double %722
+%936 = OpFMul %double %934 %double_0_5
+OpStore %437 %936
+%937 = OpLoad %ulong %436
+%938 = OpLoad %double %437
+%939 = OpFunctionCall %ulong %2 %937 %938
+OpStore %438 %939
+%940 = OpLoad %double %722
+%941 = OpFDiv %double %940 %double_2
+OpStore %439 %941
+%942 = OpLoad %ulong %438
+%943 = OpLoad %double %439
+%944 = OpFunctionCall %ulong %2 %942 %943
+OpStore %440 %944
+%945 = OpLoad %double %722
+%946 = OpLoad %double %724
+%947 = OpFSub %double %945 %946
+OpStore %441 %947
+%948 = OpLoad %ulong %440
+%949 = OpLoad %double %441
+%950 = OpFunctionCall %ulong %2 %948 %949
+OpStore %442 %950
+%951 = OpLoad %double %722
+%952 = OpLoad %double %720
+%953 = OpFMul %double %951 %952
+OpStore %443 %953
+%954 = OpLoad %ulong %442
+%955 = OpLoad %double %443
+%956 = OpFunctionCall %ulong %2 %954 %955
+OpStore %444 %956
+%957 = OpLoad %double %724
+%958 = OpLoad %double %724
+%959 = OpFAdd %double %957 %958
+OpStore %445 %959
+%960 = OpLoad %ulong %444
+%961 = OpLoad %double %445
+%962 = OpFunctionCall %ulong %2 %960 %961
+OpStore %446 %962
+%963 = OpLoad %double %724
+%964 = OpFMul %double %963 %double_0_5
+OpStore %447 %964
+%965 = OpLoad %ulong %446
+%966 = OpLoad %double %447
+%967 = OpFunctionCall %ulong %2 %965 %966
+OpStore %448 %967
+%968 = OpLoad %double %724
+%970 = OpFMul %double %968 %double_0_75
+OpStore %449 %970
+%971 = OpLoad %ulong %448
+%972 = OpLoad %double %449
+%973 = OpFunctionCall %ulong %2 %971 %972
+OpStore %450 %973
+%974 = OpLoad %double %724
+%975 = OpFMul %double %974 %double_9007199254740992
+OpStore %451 %975
+%976 = OpLoad %ulong %450
+%977 = OpLoad %double %451
+%978 = OpFunctionCall %ulong %2 %976 %977
+OpStore %452 %978
+%979 = OpLoad %double %724
+%980 = OpLoad %double %722
+%981 = OpFDiv %double %979 %980
+OpStore %453 %981
+%982 = OpLoad %ulong %452
+%983 = OpLoad %double %453
+%984 = OpFunctionCall %ulong %2 %982 %983
+OpStore %454 %984
+%986 = OpLoad %double %720
+%987 = OpFMul %double %double_5_5 %986
+OpStore %455 %987
+%988 = OpLoad %double %720
+%989 = OpFMul %double %double_3 %988
+OpStore %456 %989
+%990 = OpLoad %double %456
+%991 = OpFOrdEqual %bool %990 %double_0
+OpStore %457 %991
+%992 = OpLoad %bool %457
+OpSelectionMerge %130 None
+OpBranchConditional %992 %337 %127
 %127 = OpLabel
-%1349 = OpLoad %double %545
-%1350 = OpFDiv %double %1349 %double_2
-OpStore %550 %1350
-%1351 = OpLoad %double %549
-OpStore %544 %1351
-%1352 = OpLoad %double %550
-OpStore %545 %1352
-OpBranch %370
-%122 = OpLabel
-%1353 = OpLoad %double %541
-%1354 = OpFMul %double %1353 %double_2
-OpStore %543 %1354
-%1355 = OpLoad %double %543
-OpStore %541 %1355
-OpBranch %371
-%112 = OpLabel
-%1356 = OpLoad %double %457
-%1357 = OpLoad %double %522
-%1358 = OpFDiv %double %1356 %1357
-OpStore %529 %1358
-%1359 = OpLoad %double %529
-%1360 = OpConvertFToS %ulong %1359
-OpStore %530 %1360
-%1361 = OpLoad %ulong %530
-%1362 = OpConvertSToF %double %1361
-OpStore %531 %1362
-%1363 = OpLoad %double %531
-%1364 = OpLoad %double %522
-%1365 = OpFMul %double %1363 %1364
-OpStore %532 %1365
-%1366 = OpLoad %double %457
-%1367 = OpLoad %double %532
-%1368 = OpFSub %double %1366 %1367
-OpStore %533 %1368
-%1369 = OpLoad %double %533
-OpStore %553 %1369
-OpBranch %114
-%114 = OpLabel
-OpBranch %276
-%276 = OpLabel
-%1370 = OpLoad %double %553
-%1371 = OpLoad %double %553
-%1372 = OpFUnordNotEqual %bool %1370 %1371
-OpStore %727 %1372
-%1373 = OpLoad %bool %727
-OpSelectionMerge %280 None
-OpBranchConditional %1373 %277 %278
-%278 = OpLabel
-OpBranch %279
-%279 = OpLabel
-%1374 = OpLoad %ulong %726
-%1375 = OpLoad %double %553
-%1376 = OpFunctionCall %ulong %6 %1374 %1375
-OpStore %729 %1376
-%1377 = OpLoad %ulong %729
-OpStore %730 %1377
-OpBranch %280
-%277 = OpLabel
-%1378 = OpLoad %ulong %726
-%1379 = OpFunctionCall %ulong %5 %1378 %ulong_18446744073709551615
-OpStore %728 %1379
-%1380 = OpLoad %ulong %728
-OpStore %730 %1380
-OpBranch %280
-%280 = OpLabel
-%1381 = OpLoad %double %457
-%1382 = OpFSub %double %double_0 %1381
-OpStore %554 %1382
-%1383 = OpLoad %double %458
-%1384 = OpFSub %double %double_0 %1383
-OpStore %555 %1384
-%1385 = OpLoad %double %555
-%1386 = OpFOrdEqual %bool %1385 %double_0
-OpStore %556 %1386
-%1387 = OpLoad %bool %556
+%993 = OpLoad %double %455
+%994 = OpFMul %double %993 %double_2
+OpStore %458 %994
+%995 = OpLoad %double %455
+%996 = OpLoad %double %458
+%997 = OpFOrdEqual %bool %995 %996
+OpStore %459 %997
+%998 = OpLoad %bool %459
+OpSelectionMerge %129 None
+OpBranchConditional %998 %128 %336
+%336 = OpLabel
+%999 = OpLoad %bool %459
+OpStore %461 %999
+OpBranch %129
+%128 = OpLabel
+%1000 = OpLoad %double %455
+%1001 = OpFUnordNotEqual %bool %1000 %double_0
+OpStore %460 %1001
+%1002 = OpLoad %bool %460
+OpStore %461 %1002
+OpBranch %129
+%129 = OpLabel
+%1003 = OpLoad %bool %461
+OpStore %462 %1003
+OpBranch %130
+%337 = OpLabel
+%1004 = OpLoad %bool %457
+OpStore %462 %1004
+OpBranch %130
+%130 = OpLabel
+%1005 = OpLoad %bool %462
+OpSelectionMerge %133 None
+OpBranchConditional %1005 %131 %132
+%132 = OpLabel
+%1006 = OpLoad %double %455
+%1007 = OpFOrdLessThan %bool %1006 %double_0
+OpStore %468 %1007
+%1008 = OpLoad %bool %468
 OpSelectionMerge %136 None
-OpBranchConditional %1387 %352 %133
-%133 = OpLabel
-%1388 = OpLoad %double %554
-%1389 = OpFMul %double %1388 %double_2
-OpStore %557 %1389
-%1390 = OpLoad %double %554
-%1391 = OpLoad %double %557
-%1392 = OpFOrdEqual %bool %1390 %1391
-OpStore %558 %1392
-%1393 = OpLoad %bool %558
-OpSelectionMerge %135 None
-OpBranchConditional %1393 %134 %351
-%351 = OpLabel
-%1394 = OpLoad %bool %558
-OpStore %560 %1394
-OpBranch %135
-%134 = OpLabel
-%1395 = OpLoad %double %554
-%1396 = OpFUnordNotEqual %bool %1395 %double_0
-OpStore %559 %1396
-%1397 = OpLoad %bool %559
-OpStore %560 %1397
-OpBranch %135
+OpBranchConditional %1008 %134 %135
 %135 = OpLabel
-%1398 = OpLoad %bool %560
-OpStore %561 %1398
+%1009 = OpLoad %double %455
+OpStore %470 %1009
 OpBranch %136
-%352 = OpLabel
-%1399 = OpLoad %bool %556
-OpStore %561 %1399
+%134 = OpLabel
+%1010 = OpLoad %double %455
+%1011 = OpFSub %double %double_0 %1010
+OpStore %469 %1011
+%1012 = OpLoad %double %469
+OpStore %470 %1012
 OpBranch %136
 %136 = OpLabel
-%1400 = OpLoad %bool %561
+%1013 = OpLoad %double %456
+%1014 = OpFOrdLessThan %bool %1013 %double_0
+OpStore %471 %1014
+%1015 = OpLoad %bool %471
 OpSelectionMerge %139 None
-OpBranchConditional %1400 %137 %138
+OpBranchConditional %1015 %137 %138
 %138 = OpLabel
-%1401 = OpLoad %double %554
-%1402 = OpFOrdLessThan %bool %1401 %double_0
-OpStore %567 %1402
-%1403 = OpLoad %bool %567
-OpSelectionMerge %142 None
-OpBranchConditional %1403 %140 %141
-%141 = OpLabel
-%1404 = OpLoad %double %554
-OpStore %569 %1404
-OpBranch %142
-%140 = OpLabel
-%1405 = OpLoad %double %554
-%1406 = OpFSub %double %double_0 %1405
-OpStore %568 %1406
-%1407 = OpLoad %double %568
-OpStore %569 %1407
-OpBranch %142
-%142 = OpLabel
-%1408 = OpLoad %double %555
-%1409 = OpFOrdLessThan %bool %1408 %double_0
-OpStore %570 %1409
-%1410 = OpLoad %bool %570
-OpSelectionMerge %145 None
-OpBranchConditional %1410 %143 %144
-%144 = OpLabel
-%1411 = OpLoad %double %555
-OpStore %572 %1411
-OpBranch %145
-%143 = OpLabel
-%1412 = OpLoad %double %555
-%1413 = OpFSub %double %double_0 %1412
-OpStore %571 %1413
-%1414 = OpLoad %double %571
-OpStore %572 %1414
-OpBranch %145
-%145 = OpLabel
-%1415 = OpLoad %double %569
-%1416 = OpFDiv %double %1415 %double_2
-OpStore %573 %1416
-%1417 = OpLoad %double %572
-OpStore %574 %1417
-OpBranch %146
-%146 = OpLabel
-%1418 = OpLoad %double %574
-%1419 = OpLoad %double %573
-%1420 = OpFOrdLessThanEqual %bool %1418 %1419
-OpStore %575 %1420
-%1421 = OpLoad %bool %575
-OpLoopMerge %148 %369 None
-OpBranchConditional %1421 %147 %148
-%148 = OpLabel
-%1422 = OpLoad %double %569
-OpStore %577 %1422
-%1423 = OpLoad %double %574
-OpStore %578 %1423
-OpBranch %149
-%149 = OpLabel
-%1424 = OpLoad %double %572
-%1425 = OpLoad %double %578
-%1426 = OpFOrdLessThanEqual %bool %1424 %1425
-OpStore %579 %1426
-%1427 = OpLoad %bool %579
-OpLoopMerge %153 %368 None
-OpBranchConditional %1427 %154 %153
-%153 = OpLabel
-%1428 = OpLoad %bool %567
-OpSelectionMerge %157 None
-OpBranchConditional %1428 %155 %156
-%156 = OpLabel
-%1429 = OpLoad %double %577
-OpStore %585 %1429
-OpBranch %157
-%155 = OpLabel
-%1430 = OpLoad %double %577
-%1431 = OpFNegate %double %1430
-OpStore %584 %1431
-%1432 = OpLoad %double %584
-OpStore %585 %1432
-OpBranch %157
-%157 = OpLabel
-%1433 = OpLoad %double %585
-OpStore %586 %1433
+%1016 = OpLoad %double %456
+OpStore %473 %1016
 OpBranch %139
-%154 = OpLabel
-%1434 = OpLoad %double %578
-%1435 = OpLoad %double %577
-%1436 = OpFOrdLessThanEqual %bool %1434 %1435
-OpStore %580 %1436
-%1437 = OpLoad %bool %580
-OpSelectionMerge %152 None
-OpBranchConditional %1437 %150 %151
-%151 = OpLabel
-%1438 = OpLoad %double %577
-OpStore %582 %1438
-OpBranch %152
-%150 = OpLabel
-%1439 = OpLoad %double %577
-%1440 = OpLoad %double %578
-%1441 = OpFSub %double %1439 %1440
-OpStore %581 %1441
-%1442 = OpLoad %double %581
-OpStore %582 %1442
-OpBranch %152
-%152 = OpLabel
-%1443 = OpLoad %double %578
-%1444 = OpFDiv %double %1443 %double_2
-OpStore %583 %1444
-%1445 = OpLoad %double %582
-OpStore %577 %1445
-%1446 = OpLoad %double %583
-OpStore %578 %1446
-OpBranch %368
-%147 = OpLabel
-%1447 = OpLoad %double %574
-%1448 = OpFMul %double %1447 %double_2
-OpStore %576 %1448
-%1449 = OpLoad %double %576
-OpStore %574 %1449
-OpBranch %369
 %137 = OpLabel
-%1450 = OpLoad %double %554
-%1451 = OpLoad %double %555
-%1452 = OpFDiv %double %1450 %1451
-OpStore %562 %1452
-%1453 = OpLoad %double %562
-%1454 = OpConvertFToS %ulong %1453
-OpStore %563 %1454
-%1455 = OpLoad %ulong %563
-%1456 = OpConvertSToF %double %1455
-OpStore %564 %1456
-%1457 = OpLoad %double %564
-%1458 = OpLoad %double %555
-%1459 = OpFMul %double %1457 %1458
-OpStore %565 %1459
-%1460 = OpLoad %double %554
-%1461 = OpLoad %double %565
-%1462 = OpFSub %double %1460 %1461
-OpStore %566 %1462
-%1463 = OpLoad %double %566
-OpStore %586 %1463
+%1017 = OpLoad %double %456
+%1018 = OpFSub %double %double_0 %1017
+OpStore %472 %1018
+%1019 = OpLoad %double %472
+OpStore %473 %1019
 OpBranch %139
 %139 = OpLabel
-OpBranch %281
-%281 = OpLabel
-%1464 = OpLoad %double %586
-%1465 = OpLoad %double %586
-%1466 = OpFUnordNotEqual %bool %1464 %1465
-OpStore %731 %1466
-%1467 = OpLoad %bool %731
-OpSelectionMerge %285 None
-OpBranchConditional %1467 %282 %283
-%283 = OpLabel
-OpBranch %284
-%284 = OpLabel
-%1468 = OpLoad %ulong %730
-%1469 = OpLoad %double %586
-%1470 = OpFunctionCall %ulong %6 %1468 %1469
-OpStore %733 %1470
-%1471 = OpLoad %ulong %733
-OpStore %734 %1471
-OpBranch %285
-%282 = OpLabel
-%1472 = OpLoad %ulong %730
-%1473 = OpFunctionCall %ulong %5 %1472 %ulong_18446744073709551615
-OpStore %732 %1473
-%1474 = OpLoad %ulong %732
-OpStore %734 %1474
-OpBranch %285
-%285 = OpLabel
-%1476 = OpLoad %double %712
-%1477 = OpFMul %double %double_7 %1476
-OpStore %587 %1477
-OpBranch %158
-%158 = OpLabel
-%1478 = OpLoad %double %587
-%1479 = OpFMul %double %1478 %double_2
-OpStore %588 %1479
-%1480 = OpLoad %double %587
-%1481 = OpLoad %double %588
-%1482 = OpFOrdEqual %bool %1480 %1481
-OpStore %589 %1482
-%1483 = OpLoad %bool %589
-OpSelectionMerge %160 None
-OpBranchConditional %1483 %159 %353
-%353 = OpLabel
-%1484 = OpLoad %bool %589
-OpStore %591 %1484
-OpBranch %160
-%159 = OpLabel
-%1485 = OpLoad %double %587
-%1486 = OpFUnordNotEqual %bool %1485 %double_0
-OpStore %590 %1486
-%1487 = OpLoad %bool %590
-OpStore %591 %1487
-OpBranch %160
+%1020 = OpLoad %double %470
+%1021 = OpFDiv %double %1020 %double_2
+OpStore %474 %1021
+%1022 = OpLoad %double %473
+OpStore %475 %1022
+OpBranch %140
+%140 = OpLabel
+%1023 = OpLoad %double %475
+%1024 = OpLoad %double %474
+%1025 = OpFOrdLessThanEqual %bool %1023 %1024
+OpStore %476 %1025
+%1026 = OpLoad %bool %476
+OpLoopMerge %142 %366 None
+OpBranchConditional %1026 %141 %142
+%142 = OpLabel
+%1027 = OpLoad %double %470
+OpStore %478 %1027
+%1028 = OpLoad %double %475
+OpStore %479 %1028
+OpBranch %143
+%143 = OpLabel
+%1029 = OpLoad %double %473
+%1030 = OpLoad %double %479
+%1031 = OpFOrdLessThanEqual %bool %1029 %1030
+OpStore %480 %1031
+%1032 = OpLoad %bool %480
+OpLoopMerge %147 %364 None
+OpBranchConditional %1032 %148 %147
+%147 = OpLabel
+%1033 = OpLoad %bool %468
+OpSelectionMerge %151 None
+OpBranchConditional %1033 %149 %150
+%150 = OpLabel
+%1034 = OpLoad %double %478
+OpStore %486 %1034
+OpBranch %151
+%149 = OpLabel
+%1035 = OpLoad %double %478
+%1036 = OpFNegate %double %1035
+OpStore %485 %1036
+%1037 = OpLoad %double %485
+OpStore %486 %1037
+OpBranch %151
+%151 = OpLabel
+%1038 = OpLoad %double %486
+OpStore %487 %1038
+OpBranch %133
+%148 = OpLabel
+%1039 = OpLoad %double %479
+%1040 = OpLoad %double %478
+%1041 = OpFOrdLessThanEqual %bool %1039 %1040
+OpStore %481 %1041
+%1042 = OpLoad %bool %481
+OpSelectionMerge %146 None
+OpBranchConditional %1042 %144 %145
+%145 = OpLabel
+%1043 = OpLoad %double %478
+OpStore %483 %1043
+OpBranch %146
+%144 = OpLabel
+%1044 = OpLoad %double %478
+%1045 = OpLoad %double %479
+%1046 = OpFSub %double %1044 %1045
+OpStore %482 %1046
+%1047 = OpLoad %double %482
+OpStore %483 %1047
+OpBranch %146
+%146 = OpLabel
+%1048 = OpLoad %double %479
+%1049 = OpFDiv %double %1048 %double_2
+OpStore %484 %1049
+%1050 = OpLoad %double %483
+OpStore %478 %1050
+%1051 = OpLoad %double %484
+OpStore %479 %1051
+OpBranch %364
+%141 = OpLabel
+%1052 = OpLoad %double %475
+%1053 = OpFMul %double %1052 %double_2
+OpStore %477 %1053
+%1054 = OpLoad %double %477
+OpStore %475 %1054
+OpBranch %366
+%131 = OpLabel
+%1055 = OpLoad %double %455
+%1056 = OpLoad %double %456
+%1057 = OpFDiv %double %1055 %1056
+OpStore %463 %1057
+%1058 = OpLoad %double %463
+%1059 = OpConvertFToS %ulong %1058
+OpStore %464 %1059
+%1060 = OpLoad %ulong %464
+%1061 = OpConvertSToF %double %1060
+OpStore %465 %1061
+%1062 = OpLoad %double %465
+%1063 = OpLoad %double %456
+%1064 = OpFMul %double %1062 %1063
+OpStore %466 %1064
+%1065 = OpLoad %double %455
+%1066 = OpLoad %double %466
+%1067 = OpFSub %double %1065 %1066
+OpStore %467 %1067
+%1068 = OpLoad %double %467
+OpStore %487 %1068
+OpBranch %133
+%133 = OpLabel
+%1069 = OpLoad %ulong %454
+%1070 = OpLoad %double %487
+%1071 = OpFunctionCall %ulong %2 %1069 %1070
+OpStore %488 %1071
+%1072 = OpLoad %double %455
+%1073 = OpFSub %double %double_0 %1072
+OpStore %489 %1073
+%1074 = OpLoad %double %456
+%1075 = OpFOrdEqual %bool %1074 %double_0
+OpStore %490 %1075
+%1076 = OpLoad %bool %490
+OpSelectionMerge %155 None
+OpBranchConditional %1076 %339 %152
+%152 = OpLabel
+%1077 = OpLoad %double %489
+%1078 = OpFMul %double %1077 %double_2
+OpStore %491 %1078
+%1079 = OpLoad %double %489
+%1080 = OpLoad %double %491
+%1081 = OpFOrdEqual %bool %1079 %1080
+OpStore %492 %1081
+%1082 = OpLoad %bool %492
+OpSelectionMerge %154 None
+OpBranchConditional %1082 %153 %338
+%338 = OpLabel
+%1083 = OpLoad %bool %492
+OpStore %494 %1083
+OpBranch %154
+%153 = OpLabel
+%1084 = OpLoad %double %489
+%1085 = OpFUnordNotEqual %bool %1084 %double_0
+OpStore %493 %1085
+%1086 = OpLoad %bool %493
+OpStore %494 %1086
+OpBranch %154
+%154 = OpLabel
+%1087 = OpLoad %bool %494
+OpStore %495 %1087
+OpBranch %155
+%339 = OpLabel
+%1088 = OpLoad %bool %490
+OpStore %495 %1088
+OpBranch %155
+%155 = OpLabel
+%1089 = OpLoad %bool %495
+OpSelectionMerge %158 None
+OpBranchConditional %1089 %156 %157
+%157 = OpLabel
+%1090 = OpLoad %double %489
+%1091 = OpFOrdLessThan %bool %1090 %double_0
+OpStore %501 %1091
+%1092 = OpLoad %bool %501
+OpSelectionMerge %161 None
+OpBranchConditional %1092 %159 %160
 %160 = OpLabel
+%1093 = OpLoad %double %489
+OpStore %503 %1093
+OpBranch %161
+%159 = OpLabel
+%1094 = OpLoad %double %489
+%1095 = OpFSub %double %double_0 %1094
+OpStore %502 %1095
+%1096 = OpLoad %double %502
+OpStore %503 %1096
 OpBranch %161
 %161 = OpLabel
-%1488 = OpLoad %bool %591
+%1097 = OpLoad %double %456
+%1098 = OpFOrdLessThan %bool %1097 %double_0
+OpStore %504 %1098
+%1099 = OpLoad %bool %504
 OpSelectionMerge %164 None
-OpBranchConditional %1488 %162 %163
+OpBranchConditional %1099 %162 %163
 %163 = OpLabel
-%1489 = OpLoad %double %587
-%1490 = OpFOrdLessThan %bool %1489 %double_0
-OpStore %597 %1490
-%1491 = OpLoad %bool %597
-OpSelectionMerge %167 None
-OpBranchConditional %1491 %165 %166
-%166 = OpLabel
-%1492 = OpLoad %double %587
-OpStore %599 %1492
-OpBranch %167
-%165 = OpLabel
-%1493 = OpLoad %double %587
-%1494 = OpFSub %double %double_0 %1493
-OpStore %598 %1494
-%1495 = OpLoad %double %598
-OpStore %599 %1495
-OpBranch %167
-%167 = OpLabel
-OpBranch %168
-%168 = OpLabel
-OpBranch %169
-%169 = OpLabel
-%1496 = OpLoad %double %599
-%1497 = OpFDiv %double %1496 %double_2
-OpStore %600 %1497
-OpStore %601 %double_0_5
-OpBranch %170
-%170 = OpLabel
-%1498 = OpLoad %double %601
-%1499 = OpLoad %double %600
-%1500 = OpFOrdLessThanEqual %bool %1498 %1499
-OpStore %602 %1500
-%1501 = OpLoad %bool %602
-OpLoopMerge %172 %367 None
-OpBranchConditional %1501 %171 %172
-%172 = OpLabel
-%1502 = OpLoad %double %599
-OpStore %604 %1502
-%1503 = OpLoad %double %601
-OpStore %605 %1503
-OpBranch %173
-%173 = OpLabel
-%1504 = OpLoad %double %605
-%1505 = OpFOrdLessThanEqual %bool %double_0_5 %1504
-OpStore %606 %1505
-%1506 = OpLoad %bool %606
-OpLoopMerge %177 %366 None
-OpBranchConditional %1506 %178 %177
-%177 = OpLabel
-%1507 = OpLoad %bool %597
-OpSelectionMerge %181 None
-OpBranchConditional %1507 %179 %180
-%180 = OpLabel
-%1508 = OpLoad %double %604
-OpStore %612 %1508
-OpBranch %181
-%179 = OpLabel
-%1509 = OpLoad %double %604
-%1510 = OpFNegate %double %1509
-OpStore %611 %1510
-%1511 = OpLoad %double %611
-OpStore %612 %1511
-OpBranch %181
-%181 = OpLabel
-%1512 = OpLoad %double %612
-OpStore %613 %1512
+%1100 = OpLoad %double %456
+OpStore %506 %1100
 OpBranch %164
-%178 = OpLabel
-%1513 = OpLoad %double %605
-%1514 = OpLoad %double %604
-%1515 = OpFOrdLessThanEqual %bool %1513 %1514
-OpStore %607 %1515
-%1516 = OpLoad %bool %607
-OpSelectionMerge %176 None
-OpBranchConditional %1516 %174 %175
-%175 = OpLabel
-%1517 = OpLoad %double %604
-OpStore %609 %1517
-OpBranch %176
-%174 = OpLabel
-%1518 = OpLoad %double %604
-%1519 = OpLoad %double %605
-%1520 = OpFSub %double %1518 %1519
-OpStore %608 %1520
-%1521 = OpLoad %double %608
-OpStore %609 %1521
-OpBranch %176
-%176 = OpLabel
-%1522 = OpLoad %double %605
-%1523 = OpFDiv %double %1522 %double_2
-OpStore %610 %1523
-%1524 = OpLoad %double %609
-OpStore %604 %1524
-%1525 = OpLoad %double %610
-OpStore %605 %1525
-OpBranch %366
-%171 = OpLabel
-%1526 = OpLoad %double %601
-%1527 = OpFMul %double %1526 %double_2
-OpStore %603 %1527
-%1528 = OpLoad %double %603
-OpStore %601 %1528
-OpBranch %367
 %162 = OpLabel
-%1529 = OpLoad %double %587
-%1530 = OpFDiv %double %1529 %double_0_5
-OpStore %592 %1530
-%1531 = OpLoad %double %592
-%1532 = OpConvertFToS %ulong %1531
-OpStore %593 %1532
-%1533 = OpLoad %ulong %593
-%1534 = OpConvertSToF %double %1533
-OpStore %594 %1534
-%1535 = OpLoad %double %594
-%1536 = OpFMul %double %1535 %double_0_5
-OpStore %595 %1536
-%1537 = OpLoad %double %587
-%1538 = OpLoad %double %595
-%1539 = OpFSub %double %1537 %1538
-OpStore %596 %1539
-%1540 = OpLoad %double %596
-OpStore %613 %1540
+%1101 = OpLoad %double %456
+%1102 = OpFSub %double %double_0 %1101
+OpStore %505 %1102
+%1103 = OpLoad %double %505
+OpStore %506 %1103
 OpBranch %164
 %164 = OpLabel
-OpBranch %286
-%286 = OpLabel
-%1541 = OpLoad %double %613
-%1542 = OpLoad %double %613
-%1543 = OpFUnordNotEqual %bool %1541 %1542
-OpStore %735 %1543
-%1544 = OpLoad %bool %735
-OpSelectionMerge %290 None
-OpBranchConditional %1544 %287 %288
-%288 = OpLabel
-OpBranch %289
-%289 = OpLabel
-%1545 = OpLoad %ulong %734
-%1546 = OpLoad %double %613
-%1547 = OpFunctionCall %ulong %6 %1545 %1546
-OpStore %737 %1547
-%1548 = OpLoad %ulong %737
-OpStore %738 %1548
-OpBranch %290
-%287 = OpLabel
-%1549 = OpLoad %ulong %734
-%1550 = OpFunctionCall %ulong %5 %1549 %ulong_18446744073709551615
-OpStore %736 %1550
-%1551 = OpLoad %ulong %736
-OpStore %738 %1551
-OpBranch %290
-%290 = OpLabel
-%1552 = OpLoad %double %458
-%1553 = OpFOrdEqual %bool %1552 %double_0
-OpStore %614 %1553
-%1554 = OpLoad %bool %614
-OpSelectionMerge %185 None
-OpBranchConditional %1554 %355 %182
+%1104 = OpLoad %double %503
+%1105 = OpFDiv %double %1104 %double_2
+OpStore %507 %1105
+%1106 = OpLoad %double %506
+OpStore %508 %1106
+OpBranch %165
+%165 = OpLabel
+%1107 = OpLoad %double %508
+%1108 = OpLoad %double %507
+%1109 = OpFOrdLessThanEqual %bool %1107 %1108
+OpStore %509 %1109
+%1110 = OpLoad %bool %509
+OpLoopMerge %167 %365 None
+OpBranchConditional %1110 %166 %167
+%167 = OpLabel
+%1111 = OpLoad %double %503
+OpStore %511 %1111
+%1112 = OpLoad %double %508
+OpStore %512 %1112
+OpBranch %168
+%168 = OpLabel
+%1113 = OpLoad %double %506
+%1114 = OpLoad %double %512
+%1115 = OpFOrdLessThanEqual %bool %1113 %1114
+OpStore %513 %1115
+%1116 = OpLoad %bool %513
+OpLoopMerge %172 %362 None
+OpBranchConditional %1116 %173 %172
+%172 = OpLabel
+%1117 = OpLoad %bool %501
+OpSelectionMerge %176 None
+OpBranchConditional %1117 %174 %175
+%175 = OpLabel
+%1118 = OpLoad %double %511
+OpStore %519 %1118
+OpBranch %176
+%174 = OpLabel
+%1119 = OpLoad %double %511
+%1120 = OpFNegate %double %1119
+OpStore %518 %1120
+%1121 = OpLoad %double %518
+OpStore %519 %1121
+OpBranch %176
+%176 = OpLabel
+%1122 = OpLoad %double %519
+OpStore %520 %1122
+OpBranch %158
+%173 = OpLabel
+%1123 = OpLoad %double %512
+%1124 = OpLoad %double %511
+%1125 = OpFOrdLessThanEqual %bool %1123 %1124
+OpStore %514 %1125
+%1126 = OpLoad %bool %514
+OpSelectionMerge %171 None
+OpBranchConditional %1126 %169 %170
+%170 = OpLabel
+%1127 = OpLoad %double %511
+OpStore %516 %1127
+OpBranch %171
+%169 = OpLabel
+%1128 = OpLoad %double %511
+%1129 = OpLoad %double %512
+%1130 = OpFSub %double %1128 %1129
+OpStore %515 %1130
+%1131 = OpLoad %double %515
+OpStore %516 %1131
+OpBranch %171
+%171 = OpLabel
+%1132 = OpLoad %double %512
+%1133 = OpFDiv %double %1132 %double_2
+OpStore %517 %1133
+%1134 = OpLoad %double %516
+OpStore %511 %1134
+%1135 = OpLoad %double %517
+OpStore %512 %1135
+OpBranch %362
+%166 = OpLabel
+%1136 = OpLoad %double %508
+%1137 = OpFMul %double %1136 %double_2
+OpStore %510 %1137
+%1138 = OpLoad %double %510
+OpStore %508 %1138
+OpBranch %365
+%156 = OpLabel
+%1139 = OpLoad %double %489
+%1140 = OpLoad %double %456
+%1141 = OpFDiv %double %1139 %1140
+OpStore %496 %1141
+%1142 = OpLoad %double %496
+%1143 = OpConvertFToS %ulong %1142
+OpStore %497 %1143
+%1144 = OpLoad %ulong %497
+%1145 = OpConvertSToF %double %1144
+OpStore %498 %1145
+%1146 = OpLoad %double %498
+%1147 = OpLoad %double %456
+%1148 = OpFMul %double %1146 %1147
+OpStore %499 %1148
+%1149 = OpLoad %double %489
+%1150 = OpLoad %double %499
+%1151 = OpFSub %double %1149 %1150
+OpStore %500 %1151
+%1152 = OpLoad %double %500
+OpStore %520 %1152
+OpBranch %158
+%158 = OpLabel
+%1153 = OpLoad %ulong %488
+%1154 = OpLoad %double %520
+%1155 = OpFunctionCall %ulong %2 %1153 %1154
+OpStore %521 %1155
+%1156 = OpLoad %double %456
+%1157 = OpFSub %double %double_0 %1156
+OpStore %522 %1157
+%1158 = OpLoad %double %522
+%1159 = OpFOrdEqual %bool %1158 %double_0
+OpStore %523 %1159
+%1160 = OpLoad %bool %523
+OpSelectionMerge %180 None
+OpBranchConditional %1160 %341 %177
+%177 = OpLabel
+%1161 = OpLoad %double %455
+%1162 = OpFMul %double %1161 %double_2
+OpStore %524 %1162
+%1163 = OpLoad %double %455
+%1164 = OpLoad %double %524
+%1165 = OpFOrdEqual %bool %1163 %1164
+OpStore %525 %1165
+%1166 = OpLoad %bool %525
+OpSelectionMerge %179 None
+OpBranchConditional %1166 %178 %340
+%340 = OpLabel
+%1167 = OpLoad %bool %525
+OpStore %527 %1167
+OpBranch %179
+%178 = OpLabel
+%1168 = OpLoad %double %455
+%1169 = OpFUnordNotEqual %bool %1168 %double_0
+OpStore %526 %1169
+%1170 = OpLoad %bool %526
+OpStore %527 %1170
+OpBranch %179
+%179 = OpLabel
+%1171 = OpLoad %bool %527
+OpStore %528 %1171
+OpBranch %180
+%341 = OpLabel
+%1172 = OpLoad %bool %523
+OpStore %528 %1172
+OpBranch %180
+%180 = OpLabel
+%1173 = OpLoad %bool %528
+OpSelectionMerge %183 None
+OpBranchConditional %1173 %181 %182
 %182 = OpLabel
-%1555 = OpLoad %double %712
-%1556 = OpFMul %double %1555 %double_2
-OpStore %615 %1556
-%1557 = OpLoad %double %712
-%1558 = OpLoad %double %615
-%1559 = OpFOrdEqual %bool %1557 %1558
-OpStore %616 %1559
-%1560 = OpLoad %bool %616
-OpSelectionMerge %184 None
-OpBranchConditional %1560 %183 %354
-%354 = OpLabel
-%1561 = OpLoad %bool %616
-OpStore %618 %1561
-OpBranch %184
-%183 = OpLabel
-%1562 = OpLoad %double %712
-%1563 = OpFUnordNotEqual %bool %1562 %double_0
-OpStore %617 %1563
-%1564 = OpLoad %bool %617
-OpStore %618 %1564
-OpBranch %184
-%184 = OpLabel
-%1565 = OpLoad %bool %618
-OpStore %619 %1565
-OpBranch %185
-%355 = OpLabel
-%1566 = OpLoad %bool %614
-OpStore %619 %1566
-OpBranch %185
+%1174 = OpLoad %double %455
+%1175 = OpFOrdLessThan %bool %1174 %double_0
+OpStore %534 %1175
+%1176 = OpLoad %bool %534
+OpSelectionMerge %186 None
+OpBranchConditional %1176 %184 %185
 %185 = OpLabel
-%1567 = OpLoad %bool %619
-OpSelectionMerge %188 None
-OpBranchConditional %1567 %186 %187
+%1177 = OpLoad %double %455
+OpStore %536 %1177
+OpBranch %186
+%184 = OpLabel
+%1178 = OpLoad %double %455
+%1179 = OpFSub %double %double_0 %1178
+OpStore %535 %1179
+%1180 = OpLoad %double %535
+OpStore %536 %1180
+OpBranch %186
+%186 = OpLabel
+%1181 = OpLoad %double %522
+%1182 = OpFOrdLessThan %bool %1181 %double_0
+OpStore %537 %1182
+%1183 = OpLoad %bool %537
+OpSelectionMerge %189 None
+OpBranchConditional %1183 %187 %188
+%188 = OpLabel
+%1184 = OpLoad %double %522
+OpStore %539 %1184
+OpBranch %189
 %187 = OpLabel
-%1568 = OpLoad %double %712
-%1569 = OpFOrdLessThan %bool %1568 %double_0
-OpStore %625 %1569
-%1570 = OpLoad %bool %625
-OpSelectionMerge %191 None
-OpBranchConditional %1570 %189 %190
-%190 = OpLabel
-%1571 = OpLoad %double %712
-OpStore %627 %1571
-OpBranch %191
+%1185 = OpLoad %double %522
+%1186 = OpFSub %double %double_0 %1185
+OpStore %538 %1186
+%1187 = OpLoad %double %538
+OpStore %539 %1187
+OpBranch %189
 %189 = OpLabel
-%1572 = OpLoad %double %712
-%1573 = OpFSub %double %double_0 %1572
-OpStore %626 %1573
-%1574 = OpLoad %double %626
-OpStore %627 %1574
-OpBranch %191
-%191 = OpLabel
-%1575 = OpLoad %double %458
-%1576 = OpFOrdLessThan %bool %1575 %double_0
-OpStore %628 %1576
-%1577 = OpLoad %bool %628
-OpSelectionMerge %194 None
-OpBranchConditional %1577 %192 %193
-%193 = OpLabel
-%1578 = OpLoad %double %458
-OpStore %630 %1578
-OpBranch %194
+%1188 = OpLoad %double %536
+%1189 = OpFDiv %double %1188 %double_2
+OpStore %540 %1189
+%1190 = OpLoad %double %539
+OpStore %541 %1190
+OpBranch %190
+%190 = OpLabel
+%1191 = OpLoad %double %541
+%1192 = OpLoad %double %540
+%1193 = OpFOrdLessThanEqual %bool %1191 %1192
+OpStore %542 %1193
+%1194 = OpLoad %bool %542
+OpLoopMerge %192 %363 None
+OpBranchConditional %1194 %191 %192
 %192 = OpLabel
-%1579 = OpLoad %double %458
-%1580 = OpFSub %double %double_0 %1579
-OpStore %629 %1580
-%1581 = OpLoad %double %629
-OpStore %630 %1581
-OpBranch %194
-%194 = OpLabel
-%1582 = OpLoad %double %627
-%1583 = OpFDiv %double %1582 %double_2
-OpStore %631 %1583
-%1584 = OpLoad %double %630
-OpStore %632 %1584
-OpBranch %195
-%195 = OpLabel
-%1585 = OpLoad %double %632
-%1586 = OpLoad %double %631
-%1587 = OpFOrdLessThanEqual %bool %1585 %1586
-OpStore %633 %1587
-%1588 = OpLoad %bool %633
-OpLoopMerge %197 %365 None
-OpBranchConditional %1588 %196 %197
+%1195 = OpLoad %double %536
+OpStore %544 %1195
+%1196 = OpLoad %double %541
+OpStore %545 %1196
+OpBranch %193
+%193 = OpLabel
+%1197 = OpLoad %double %539
+%1198 = OpLoad %double %545
+%1199 = OpFOrdLessThanEqual %bool %1197 %1198
+OpStore %546 %1199
+%1200 = OpLoad %bool %546
+OpLoopMerge %197 %360 None
+OpBranchConditional %1200 %198 %197
 %197 = OpLabel
-%1589 = OpLoad %double %627
-OpStore %635 %1589
-%1590 = OpLoad %double %632
-OpStore %636 %1590
-OpBranch %198
-%198 = OpLabel
-%1591 = OpLoad %double %630
-%1592 = OpLoad %double %636
-%1593 = OpFOrdLessThanEqual %bool %1591 %1592
-OpStore %637 %1593
-%1594 = OpLoad %bool %637
-OpLoopMerge %202 %364 None
-OpBranchConditional %1594 %203 %202
-%202 = OpLabel
-%1595 = OpLoad %bool %625
-OpSelectionMerge %206 None
-OpBranchConditional %1595 %204 %205
-%205 = OpLabel
-%1596 = OpLoad %double %635
-OpStore %643 %1596
-OpBranch %206
-%204 = OpLabel
-%1597 = OpLoad %double %635
-%1598 = OpFNegate %double %1597
-OpStore %642 %1598
-%1599 = OpLoad %double %642
-OpStore %643 %1599
-OpBranch %206
-%206 = OpLabel
-%1600 = OpLoad %double %643
-OpStore %644 %1600
-OpBranch %188
-%203 = OpLabel
-%1601 = OpLoad %double %636
-%1602 = OpLoad %double %635
-%1603 = OpFOrdLessThanEqual %bool %1601 %1602
-OpStore %638 %1603
-%1604 = OpLoad %bool %638
+%1201 = OpLoad %bool %534
 OpSelectionMerge %201 None
-OpBranchConditional %1604 %199 %200
+OpBranchConditional %1201 %199 %200
 %200 = OpLabel
-%1605 = OpLoad %double %635
-OpStore %640 %1605
+%1202 = OpLoad %double %544
+OpStore %552 %1202
 OpBranch %201
 %199 = OpLabel
-%1606 = OpLoad %double %635
-%1607 = OpLoad %double %636
-%1608 = OpFSub %double %1606 %1607
-OpStore %639 %1608
-%1609 = OpLoad %double %639
-OpStore %640 %1609
+%1203 = OpLoad %double %544
+%1204 = OpFNegate %double %1203
+OpStore %551 %1204
+%1205 = OpLoad %double %551
+OpStore %552 %1205
 OpBranch %201
 %201 = OpLabel
-%1610 = OpLoad %double %636
-%1611 = OpFDiv %double %1610 %double_2
-OpStore %641 %1611
-%1612 = OpLoad %double %640
-OpStore %635 %1612
-%1613 = OpLoad %double %641
-OpStore %636 %1613
-OpBranch %364
+%1206 = OpLoad %double %552
+OpStore %553 %1206
+OpBranch %183
+%198 = OpLabel
+%1207 = OpLoad %double %545
+%1208 = OpLoad %double %544
+%1209 = OpFOrdLessThanEqual %bool %1207 %1208
+OpStore %547 %1209
+%1210 = OpLoad %bool %547
+OpSelectionMerge %196 None
+OpBranchConditional %1210 %194 %195
+%195 = OpLabel
+%1211 = OpLoad %double %544
+OpStore %549 %1211
+OpBranch %196
+%194 = OpLabel
+%1212 = OpLoad %double %544
+%1213 = OpLoad %double %545
+%1214 = OpFSub %double %1212 %1213
+OpStore %548 %1214
+%1215 = OpLoad %double %548
+OpStore %549 %1215
+OpBranch %196
 %196 = OpLabel
-%1614 = OpLoad %double %632
-%1615 = OpFMul %double %1614 %double_2
-OpStore %634 %1615
-%1616 = OpLoad %double %634
-OpStore %632 %1616
-OpBranch %365
-%186 = OpLabel
-%1617 = OpLoad %double %712
-%1618 = OpLoad %double %458
-%1619 = OpFDiv %double %1617 %1618
-OpStore %620 %1619
-%1620 = OpLoad %double %620
-%1621 = OpConvertFToS %ulong %1620
-OpStore %621 %1621
-%1622 = OpLoad %ulong %621
-%1623 = OpConvertSToF %double %1622
-OpStore %622 %1623
-%1624 = OpLoad %double %622
-%1625 = OpLoad %double %458
-%1626 = OpFMul %double %1624 %1625
-OpStore %623 %1626
-%1627 = OpLoad %double %712
-%1628 = OpLoad %double %623
-%1629 = OpFSub %double %1627 %1628
-OpStore %624 %1629
-%1630 = OpLoad %double %624
-OpStore %644 %1630
-OpBranch %188
-%188 = OpLabel
-OpBranch %291
-%291 = OpLabel
-%1631 = OpLoad %double %644
-%1632 = OpLoad %double %644
-%1633 = OpFUnordNotEqual %bool %1631 %1632
-OpStore %739 %1633
-%1634 = OpLoad %bool %739
-OpSelectionMerge %295 None
-OpBranchConditional %1634 %292 %293
-%293 = OpLabel
-OpBranch %294
-%294 = OpLabel
-%1635 = OpLoad %ulong %738
-%1636 = OpLoad %double %644
-%1637 = OpFunctionCall %ulong %6 %1635 %1636
-OpStore %741 %1637
-%1638 = OpLoad %ulong %741
-OpStore %742 %1638
-OpBranch %295
-%292 = OpLabel
-%1639 = OpLoad %ulong %738
-%1640 = OpFunctionCall %ulong %5 %1639 %ulong_18446744073709551615
-OpStore %740 %1640
-%1641 = OpLoad %ulong %740
-OpStore %742 %1641
-OpBranch %295
-%295 = OpLabel
-%1642 = OpLoad %double %458
-%1643 = OpFOrdEqual %bool %1642 %double_0
-OpStore %645 %1643
-%1644 = OpLoad %bool %645
-OpSelectionMerge %210 None
-OpBranchConditional %1644 %357 %207
+%1216 = OpLoad %double %545
+%1217 = OpFDiv %double %1216 %double_2
+OpStore %550 %1217
+%1218 = OpLoad %double %549
+OpStore %544 %1218
+%1219 = OpLoad %double %550
+OpStore %545 %1219
+OpBranch %360
+%191 = OpLabel
+%1220 = OpLoad %double %541
+%1221 = OpFMul %double %1220 %double_2
+OpStore %543 %1221
+%1222 = OpLoad %double %543
+OpStore %541 %1222
+OpBranch %363
+%181 = OpLabel
+%1223 = OpLoad %double %455
+%1224 = OpLoad %double %522
+%1225 = OpFDiv %double %1223 %1224
+OpStore %529 %1225
+%1226 = OpLoad %double %529
+%1227 = OpConvertFToS %ulong %1226
+OpStore %530 %1227
+%1228 = OpLoad %ulong %530
+%1229 = OpConvertSToF %double %1228
+OpStore %531 %1229
+%1230 = OpLoad %double %531
+%1231 = OpLoad %double %522
+%1232 = OpFMul %double %1230 %1231
+OpStore %532 %1232
+%1233 = OpLoad %double %455
+%1234 = OpLoad %double %532
+%1235 = OpFSub %double %1233 %1234
+OpStore %533 %1235
+%1236 = OpLoad %double %533
+OpStore %553 %1236
+OpBranch %183
+%183 = OpLabel
+%1237 = OpLoad %ulong %521
+%1238 = OpLoad %double %553
+%1239 = OpFunctionCall %ulong %2 %1237 %1238
+OpStore %554 %1239
+%1240 = OpLoad %double %455
+%1241 = OpFSub %double %double_0 %1240
+OpStore %555 %1241
+%1242 = OpLoad %double %456
+%1243 = OpFSub %double %double_0 %1242
+OpStore %556 %1243
+%1244 = OpLoad %double %556
+%1245 = OpFOrdEqual %bool %1244 %double_0
+OpStore %557 %1245
+%1246 = OpLoad %bool %557
+OpSelectionMerge %205 None
+OpBranchConditional %1246 %343 %202
+%202 = OpLabel
+%1247 = OpLoad %double %555
+%1248 = OpFMul %double %1247 %double_2
+OpStore %558 %1248
+%1249 = OpLoad %double %555
+%1250 = OpLoad %double %558
+%1251 = OpFOrdEqual %bool %1249 %1250
+OpStore %559 %1251
+%1252 = OpLoad %bool %559
+OpSelectionMerge %204 None
+OpBranchConditional %1252 %203 %342
+%342 = OpLabel
+%1253 = OpLoad %bool %559
+OpStore %561 %1253
+OpBranch %204
+%203 = OpLabel
+%1254 = OpLoad %double %555
+%1255 = OpFUnordNotEqual %bool %1254 %double_0
+OpStore %560 %1255
+%1256 = OpLoad %bool %560
+OpStore %561 %1256
+OpBranch %204
+%204 = OpLabel
+%1257 = OpLoad %bool %561
+OpStore %562 %1257
+OpBranch %205
+%343 = OpLabel
+%1258 = OpLoad %bool %557
+OpStore %562 %1258
+OpBranch %205
+%205 = OpLabel
+%1259 = OpLoad %bool %562
+OpSelectionMerge %208 None
+OpBranchConditional %1259 %206 %207
 %207 = OpLabel
-%1645 = OpLoad %double %458
-%1646 = OpFMul %double %1645 %double_2
-OpStore %646 %1646
-%1647 = OpLoad %double %458
-%1648 = OpLoad %double %646
-%1649 = OpFOrdEqual %bool %1647 %1648
-OpStore %647 %1649
-%1650 = OpLoad %bool %647
-OpSelectionMerge %209 None
-OpBranchConditional %1650 %208 %356
-%356 = OpLabel
-%1651 = OpLoad %bool %647
-OpStore %649 %1651
-OpBranch %209
-%208 = OpLabel
-%1652 = OpLoad %double %458
-%1653 = OpFUnordNotEqual %bool %1652 %double_0
-OpStore %648 %1653
-%1654 = OpLoad %bool %648
-OpStore %649 %1654
-OpBranch %209
-%209 = OpLabel
-%1655 = OpLoad %bool %649
-OpStore %650 %1655
-OpBranch %210
-%357 = OpLabel
-%1656 = OpLoad %bool %645
-OpStore %650 %1656
-OpBranch %210
+%1260 = OpLoad %double %555
+%1261 = OpFOrdLessThan %bool %1260 %double_0
+OpStore %568 %1261
+%1262 = OpLoad %bool %568
+OpSelectionMerge %211 None
+OpBranchConditional %1262 %209 %210
 %210 = OpLabel
-%1657 = OpLoad %bool %650
-OpSelectionMerge %213 None
-OpBranchConditional %1657 %211 %212
+%1263 = OpLoad %double %555
+OpStore %570 %1263
+OpBranch %211
+%209 = OpLabel
+%1264 = OpLoad %double %555
+%1265 = OpFSub %double %double_0 %1264
+OpStore %569 %1265
+%1266 = OpLoad %double %569
+OpStore %570 %1266
+OpBranch %211
+%211 = OpLabel
+%1267 = OpLoad %double %556
+%1268 = OpFOrdLessThan %bool %1267 %double_0
+OpStore %571 %1268
+%1269 = OpLoad %bool %571
+OpSelectionMerge %214 None
+OpBranchConditional %1269 %212 %213
+%213 = OpLabel
+%1270 = OpLoad %double %556
+OpStore %573 %1270
+OpBranch %214
 %212 = OpLabel
-%1658 = OpLoad %double %458
-%1659 = OpFOrdLessThan %bool %1658 %double_0
-OpStore %656 %1659
-%1660 = OpLoad %bool %656
-OpSelectionMerge %216 None
-OpBranchConditional %1660 %214 %215
-%215 = OpLabel
-%1661 = OpLoad %double %458
-OpStore %658 %1661
-OpBranch %216
+%1271 = OpLoad %double %556
+%1272 = OpFSub %double %double_0 %1271
+OpStore %572 %1272
+%1273 = OpLoad %double %572
+OpStore %573 %1273
+OpBranch %214
 %214 = OpLabel
-%1662 = OpLoad %double %458
-%1663 = OpFSub %double %double_0 %1662
-OpStore %657 %1663
-%1664 = OpLoad %double %657
-OpStore %658 %1664
-OpBranch %216
-%216 = OpLabel
-%1665 = OpLoad %double %458
-%1666 = OpFOrdLessThan %bool %1665 %double_0
-OpStore %659 %1666
-%1667 = OpLoad %bool %659
-OpSelectionMerge %219 None
-OpBranchConditional %1667 %217 %218
-%218 = OpLabel
-%1668 = OpLoad %double %458
-OpStore %661 %1668
-OpBranch %219
+%1274 = OpLoad %double %570
+%1275 = OpFDiv %double %1274 %double_2
+OpStore %574 %1275
+%1276 = OpLoad %double %573
+OpStore %575 %1276
+OpBranch %215
+%215 = OpLabel
+%1277 = OpLoad %double %575
+%1278 = OpLoad %double %574
+%1279 = OpFOrdLessThanEqual %bool %1277 %1278
+OpStore %576 %1279
+%1280 = OpLoad %bool %576
+OpLoopMerge %217 %361 None
+OpBranchConditional %1280 %216 %217
 %217 = OpLabel
-%1669 = OpLoad %double %458
-%1670 = OpFSub %double %double_0 %1669
-OpStore %660 %1670
-%1671 = OpLoad %double %660
-OpStore %661 %1671
-OpBranch %219
-%219 = OpLabel
-%1672 = OpLoad %double %658
-%1673 = OpFDiv %double %1672 %double_2
-OpStore %662 %1673
-%1674 = OpLoad %double %661
-OpStore %663 %1674
-OpBranch %220
-%220 = OpLabel
-%1675 = OpLoad %double %663
-%1676 = OpLoad %double %662
-%1677 = OpFOrdLessThanEqual %bool %1675 %1676
-OpStore %664 %1677
-%1678 = OpLoad %bool %664
-OpLoopMerge %222 %363 None
-OpBranchConditional %1678 %221 %222
+%1281 = OpLoad %double %570
+OpStore %578 %1281
+%1282 = OpLoad %double %575
+OpStore %579 %1282
+OpBranch %218
+%218 = OpLabel
+%1283 = OpLoad %double %573
+%1284 = OpLoad %double %579
+%1285 = OpFOrdLessThanEqual %bool %1283 %1284
+OpStore %580 %1285
+%1286 = OpLoad %bool %580
+OpLoopMerge %222 %359 None
+OpBranchConditional %1286 %223 %222
 %222 = OpLabel
-%1679 = OpLoad %double %658
-OpStore %666 %1679
-%1680 = OpLoad %double %663
-OpStore %667 %1680
-OpBranch %223
-%223 = OpLabel
-%1681 = OpLoad %double %661
-%1682 = OpLoad %double %667
-%1683 = OpFOrdLessThanEqual %bool %1681 %1682
-OpStore %668 %1683
-%1684 = OpLoad %bool %668
-OpLoopMerge %227 %362 None
-OpBranchConditional %1684 %228 %227
-%227 = OpLabel
-%1685 = OpLoad %bool %656
-OpSelectionMerge %231 None
-OpBranchConditional %1685 %229 %230
-%230 = OpLabel
-%1686 = OpLoad %double %666
-OpStore %674 %1686
-OpBranch %231
-%229 = OpLabel
-%1687 = OpLoad %double %666
-%1688 = OpFNegate %double %1687
-OpStore %673 %1688
-%1689 = OpLoad %double %673
-OpStore %674 %1689
-OpBranch %231
-%231 = OpLabel
-%1690 = OpLoad %double %674
-OpStore %675 %1690
-OpBranch %213
-%228 = OpLabel
-%1691 = OpLoad %double %667
-%1692 = OpLoad %double %666
-%1693 = OpFOrdLessThanEqual %bool %1691 %1692
-OpStore %669 %1693
-%1694 = OpLoad %bool %669
+%1287 = OpLoad %bool %568
 OpSelectionMerge %226 None
-OpBranchConditional %1694 %224 %225
+OpBranchConditional %1287 %224 %225
 %225 = OpLabel
-%1695 = OpLoad %double %666
-OpStore %671 %1695
+%1288 = OpLoad %double %578
+OpStore %586 %1288
 OpBranch %226
 %224 = OpLabel
-%1696 = OpLoad %double %666
-%1697 = OpLoad %double %667
-%1698 = OpFSub %double %1696 %1697
-OpStore %670 %1698
-%1699 = OpLoad %double %670
-OpStore %671 %1699
+%1289 = OpLoad %double %578
+%1290 = OpFNegate %double %1289
+OpStore %585 %1290
+%1291 = OpLoad %double %585
+OpStore %586 %1291
 OpBranch %226
 %226 = OpLabel
-%1700 = OpLoad %double %667
-%1701 = OpFDiv %double %1700 %double_2
-OpStore %672 %1701
-%1702 = OpLoad %double %671
-OpStore %666 %1702
-%1703 = OpLoad %double %672
-OpStore %667 %1703
-OpBranch %362
+%1292 = OpLoad %double %586
+OpStore %587 %1292
+OpBranch %208
+%223 = OpLabel
+%1293 = OpLoad %double %579
+%1294 = OpLoad %double %578
+%1295 = OpFOrdLessThanEqual %bool %1293 %1294
+OpStore %581 %1295
+%1296 = OpLoad %bool %581
+OpSelectionMerge %221 None
+OpBranchConditional %1296 %219 %220
+%220 = OpLabel
+%1297 = OpLoad %double %578
+OpStore %583 %1297
+OpBranch %221
+%219 = OpLabel
+%1298 = OpLoad %double %578
+%1299 = OpLoad %double %579
+%1300 = OpFSub %double %1298 %1299
+OpStore %582 %1300
+%1301 = OpLoad %double %582
+OpStore %583 %1301
+OpBranch %221
 %221 = OpLabel
-%1704 = OpLoad %double %663
-%1705 = OpFMul %double %1704 %double_2
-OpStore %665 %1705
-%1706 = OpLoad %double %665
-OpStore %663 %1706
-OpBranch %363
-%211 = OpLabel
-%1707 = OpLoad %double %458
-%1708 = OpLoad %double %458
-%1709 = OpFDiv %double %1707 %1708
-OpStore %651 %1709
-%1710 = OpLoad %double %651
-%1711 = OpConvertFToS %ulong %1710
-OpStore %652 %1711
-%1712 = OpLoad %ulong %652
-%1713 = OpConvertSToF %double %1712
-OpStore %653 %1713
-%1714 = OpLoad %double %653
-%1715 = OpLoad %double %458
-%1716 = OpFMul %double %1714 %1715
-OpStore %654 %1716
-%1717 = OpLoad %double %458
-%1718 = OpLoad %double %654
-%1719 = OpFSub %double %1717 %1718
-OpStore %655 %1719
-%1720 = OpLoad %double %655
-OpStore %675 %1720
-OpBranch %213
-%213 = OpLabel
-OpBranch %296
-%296 = OpLabel
-%1721 = OpLoad %double %675
-%1722 = OpLoad %double %675
-%1723 = OpFUnordNotEqual %bool %1721 %1722
-OpStore %743 %1723
-%1724 = OpLoad %bool %743
-OpSelectionMerge %300 None
-OpBranchConditional %1724 %297 %298
-%298 = OpLabel
-OpBranch %299
-%299 = OpLabel
-%1725 = OpLoad %ulong %742
-%1726 = OpLoad %double %675
-%1727 = OpFunctionCall %ulong %6 %1725 %1726
-OpStore %745 %1727
-%1728 = OpLoad %ulong %745
-OpStore %746 %1728
-OpBranch %300
-%297 = OpLabel
-%1729 = OpLoad %ulong %742
-%1730 = OpFunctionCall %ulong %5 %1729 %ulong_18446744073709551615
-OpStore %744 %1730
-%1731 = OpLoad %ulong %744
-OpStore %746 %1731
-OpBranch %300
-%300 = OpLabel
-%1733 = OpLoad %double %712
-%1734 = OpFMul %double %double_1048576 %1733
-OpStore %676 %1734
-%1735 = OpLoad %double %458
-%1736 = OpFOrdEqual %bool %1735 %double_0
-OpStore %677 %1736
-%1737 = OpLoad %bool %677
-OpSelectionMerge %235 None
-OpBranchConditional %1737 %359 %232
-%232 = OpLabel
-%1738 = OpLoad %double %676
-%1739 = OpFMul %double %1738 %double_2
-OpStore %678 %1739
-%1740 = OpLoad %double %676
-%1741 = OpLoad %double %678
-%1742 = OpFOrdEqual %bool %1740 %1741
-OpStore %679 %1742
-%1743 = OpLoad %bool %679
-OpSelectionMerge %234 None
-OpBranchConditional %1743 %233 %358
-%358 = OpLabel
-%1744 = OpLoad %bool %679
-OpStore %681 %1744
-OpBranch %234
-%233 = OpLabel
-%1745 = OpLoad %double %676
-%1746 = OpFUnordNotEqual %bool %1745 %double_0
-OpStore %680 %1746
-%1747 = OpLoad %bool %680
-OpStore %681 %1747
-OpBranch %234
-%234 = OpLabel
-%1748 = OpLoad %bool %681
-OpStore %682 %1748
-OpBranch %235
-%359 = OpLabel
-%1749 = OpLoad %bool %677
-OpStore %682 %1749
-OpBranch %235
-%235 = OpLabel
-%1750 = OpLoad %bool %682
-OpSelectionMerge %238 None
-OpBranchConditional %1750 %236 %237
-%237 = OpLabel
-%1751 = OpLoad %double %676
-%1752 = OpFOrdLessThan %bool %1751 %double_0
-OpStore %688 %1752
-%1753 = OpLoad %bool %688
-OpSelectionMerge %241 None
-OpBranchConditional %1753 %239 %240
-%240 = OpLabel
-%1754 = OpLoad %double %676
-OpStore %690 %1754
-OpBranch %241
-%239 = OpLabel
-%1755 = OpLoad %double %676
-%1756 = OpFSub %double %double_0 %1755
-OpStore %689 %1756
-%1757 = OpLoad %double %689
-OpStore %690 %1757
-OpBranch %241
-%241 = OpLabel
-%1758 = OpLoad %double %458
-%1759 = OpFOrdLessThan %bool %1758 %double_0
-OpStore %691 %1759
-%1760 = OpLoad %bool %691
-OpSelectionMerge %244 None
-OpBranchConditional %1760 %242 %243
-%243 = OpLabel
-%1761 = OpLoad %double %458
-OpStore %693 %1761
-OpBranch %244
-%242 = OpLabel
-%1762 = OpLoad %double %458
-%1763 = OpFSub %double %double_0 %1762
-OpStore %692 %1763
-%1764 = OpLoad %double %692
-OpStore %693 %1764
-OpBranch %244
-%244 = OpLabel
-%1765 = OpLoad %double %690
-%1766 = OpFDiv %double %1765 %double_2
-OpStore %694 %1766
-%1767 = OpLoad %double %693
-OpStore %695 %1767
-OpBranch %245
-%245 = OpLabel
-%1768 = OpLoad %double %695
-%1769 = OpLoad %double %694
-%1770 = OpFOrdLessThanEqual %bool %1768 %1769
-OpStore %696 %1770
-%1771 = OpLoad %bool %696
-OpLoopMerge %247 %361 None
-OpBranchConditional %1771 %246 %247
-%247 = OpLabel
-%1772 = OpLoad %double %690
-OpStore %698 %1772
-%1773 = OpLoad %double %695
-OpStore %699 %1773
-OpBranch %248
-%248 = OpLabel
-%1774 = OpLoad %double %693
-%1775 = OpLoad %double %699
-%1776 = OpFOrdLessThanEqual %bool %1774 %1775
-OpStore %700 %1776
-%1777 = OpLoad %bool %700
-OpLoopMerge %252 %360 None
-OpBranchConditional %1777 %253 %252
-%252 = OpLabel
-%1778 = OpLoad %bool %688
-OpSelectionMerge %256 None
-OpBranchConditional %1778 %254 %255
-%255 = OpLabel
-%1779 = OpLoad %double %698
-OpStore %706 %1779
-OpBranch %256
-%254 = OpLabel
-%1780 = OpLoad %double %698
-%1781 = OpFNegate %double %1780
-OpStore %705 %1781
-%1782 = OpLoad %double %705
-OpStore %706 %1782
-OpBranch %256
-%256 = OpLabel
-%1783 = OpLoad %double %706
-OpStore %707 %1783
-OpBranch %238
-%253 = OpLabel
-%1784 = OpLoad %double %699
-%1785 = OpLoad %double %698
-%1786 = OpFOrdLessThanEqual %bool %1784 %1785
-OpStore %701 %1786
-%1787 = OpLoad %bool %701
-OpSelectionMerge %251 None
-OpBranchConditional %1787 %249 %250
-%250 = OpLabel
-%1788 = OpLoad %double %698
-OpStore %703 %1788
-OpBranch %251
-%249 = OpLabel
-%1789 = OpLoad %double %698
-%1790 = OpLoad %double %699
-%1791 = OpFSub %double %1789 %1790
-OpStore %702 %1791
-%1792 = OpLoad %double %702
-OpStore %703 %1792
-OpBranch %251
-%251 = OpLabel
-%1793 = OpLoad %double %699
-%1794 = OpFDiv %double %1793 %double_2
-OpStore %704 %1794
-%1795 = OpLoad %double %703
-OpStore %698 %1795
-%1796 = OpLoad %double %704
-OpStore %699 %1796
-OpBranch %360
-%246 = OpLabel
-%1797 = OpLoad %double %695
-%1798 = OpFMul %double %1797 %double_2
-OpStore %697 %1798
-%1799 = OpLoad %double %697
-OpStore %695 %1799
+%1302 = OpLoad %double %579
+%1303 = OpFDiv %double %1302 %double_2
+OpStore %584 %1303
+%1304 = OpLoad %double %583
+OpStore %578 %1304
+%1305 = OpLoad %double %584
+OpStore %579 %1305
+OpBranch %359
+%216 = OpLabel
+%1306 = OpLoad %double %575
+%1307 = OpFMul %double %1306 %double_2
+OpStore %577 %1307
+%1308 = OpLoad %double %577
+OpStore %575 %1308
 OpBranch %361
+%206 = OpLabel
+%1309 = OpLoad %double %555
+%1310 = OpLoad %double %556
+%1311 = OpFDiv %double %1309 %1310
+OpStore %563 %1311
+%1312 = OpLoad %double %563
+%1313 = OpConvertFToS %ulong %1312
+OpStore %564 %1313
+%1314 = OpLoad %ulong %564
+%1315 = OpConvertSToF %double %1314
+OpStore %565 %1315
+%1316 = OpLoad %double %565
+%1317 = OpLoad %double %556
+%1318 = OpFMul %double %1316 %1317
+OpStore %566 %1318
+%1319 = OpLoad %double %555
+%1320 = OpLoad %double %566
+%1321 = OpFSub %double %1319 %1320
+OpStore %567 %1321
+%1322 = OpLoad %double %567
+OpStore %587 %1322
+OpBranch %208
+%208 = OpLabel
+%1323 = OpLoad %ulong %554
+%1324 = OpLoad %double %587
+%1325 = OpFunctionCall %ulong %2 %1323 %1324
+OpStore %588 %1325
+%1327 = OpLoad %double %720
+%1328 = OpFMul %double %double_7 %1327
+OpStore %589 %1328
+OpBranch %227
+%227 = OpLabel
+%1329 = OpLoad %double %589
+%1330 = OpFMul %double %1329 %double_2
+OpStore %590 %1330
+%1331 = OpLoad %double %589
+%1332 = OpLoad %double %590
+%1333 = OpFOrdEqual %bool %1331 %1332
+OpStore %591 %1333
+%1334 = OpLoad %bool %591
+OpSelectionMerge %229 None
+OpBranchConditional %1334 %228 %344
+%344 = OpLabel
+%1335 = OpLoad %bool %591
+OpStore %593 %1335
+OpBranch %229
+%228 = OpLabel
+%1336 = OpLoad %double %589
+%1337 = OpFUnordNotEqual %bool %1336 %double_0
+OpStore %592 %1337
+%1338 = OpLoad %bool %592
+OpStore %593 %1338
+OpBranch %229
+%229 = OpLabel
+OpBranch %230
+%230 = OpLabel
+%1339 = OpLoad %bool %593
+OpSelectionMerge %233 None
+OpBranchConditional %1339 %231 %232
+%232 = OpLabel
+%1340 = OpLoad %double %589
+%1341 = OpFOrdLessThan %bool %1340 %double_0
+OpStore %599 %1341
+%1342 = OpLoad %bool %599
+OpSelectionMerge %236 None
+OpBranchConditional %1342 %234 %235
+%235 = OpLabel
+%1343 = OpLoad %double %589
+OpStore %601 %1343
+OpBranch %236
+%234 = OpLabel
+%1344 = OpLoad %double %589
+%1345 = OpFSub %double %double_0 %1344
+OpStore %600 %1345
+%1346 = OpLoad %double %600
+OpStore %601 %1346
+OpBranch %236
 %236 = OpLabel
-%1800 = OpLoad %double %676
-%1801 = OpLoad %double %458
-%1802 = OpFDiv %double %1800 %1801
-OpStore %683 %1802
-%1803 = OpLoad %double %683
-%1804 = OpConvertFToS %ulong %1803
-OpStore %684 %1804
-%1805 = OpLoad %ulong %684
-%1806 = OpConvertSToF %double %1805
-OpStore %685 %1806
-%1807 = OpLoad %double %685
-%1808 = OpLoad %double %458
-%1809 = OpFMul %double %1807 %1808
-OpStore %686 %1809
-%1810 = OpLoad %double %676
-%1811 = OpLoad %double %686
-%1812 = OpFSub %double %1810 %1811
-OpStore %687 %1812
-%1813 = OpLoad %double %687
-OpStore %707 %1813
+OpBranch %237
+%237 = OpLabel
 OpBranch %238
 %238 = OpLabel
-OpBranch %301
-%301 = OpLabel
-%1814 = OpLoad %double %707
-%1815 = OpLoad %double %707
-%1816 = OpFUnordNotEqual %bool %1814 %1815
-OpStore %747 %1816
-%1817 = OpLoad %bool %747
-OpSelectionMerge %305 None
-OpBranchConditional %1817 %302 %303
-%303 = OpLabel
-OpBranch %304
-%304 = OpLabel
-%1818 = OpLoad %ulong %746
-%1819 = OpLoad %double %707
-%1820 = OpFunctionCall %ulong %6 %1818 %1819
-OpStore %749 %1820
-%1821 = OpLoad %ulong %749
-OpStore %750 %1821
-OpBranch %305
-%302 = OpLabel
-%1822 = OpLoad %ulong %746
-%1823 = OpFunctionCall %ulong %5 %1822 %ulong_18446744073709551615
-OpStore %748 %1823
-%1824 = OpLoad %ulong %748
-OpStore %750 %1824
-OpBranch %305
-%305 = OpLabel
-%1825 = OpLoad %ulong %750
-OpReturnValue %1825
-%56 = OpLabel
-%1826 = OpLoad %double %709
-%1827 = OpLoad %double %398
-%1828 = OpFAdd %double %1826 %1827
-OpStore %426 %1828
-%1829 = OpLoad %double %426
-%1830 = OpFMul %double %1829 %double_1_5
-OpStore %427 %1830
-OpBranch %259
+%1347 = OpLoad %double %601
+%1348 = OpFDiv %double %1347 %double_2
+OpStore %602 %1348
+OpStore %603 %double_0_5
+OpBranch %239
+%239 = OpLabel
+%1349 = OpLoad %double %603
+%1350 = OpLoad %double %602
+%1351 = OpFOrdLessThanEqual %bool %1349 %1350
+OpStore %604 %1351
+%1352 = OpLoad %bool %604
+OpLoopMerge %241 %358 None
+OpBranchConditional %1352 %240 %241
+%241 = OpLabel
+%1353 = OpLoad %double %601
+OpStore %606 %1353
+%1354 = OpLoad %double %603
+OpStore %607 %1354
+OpBranch %242
+%242 = OpLabel
+%1355 = OpLoad %double %607
+%1356 = OpFOrdLessThanEqual %bool %double_0_5 %1355
+OpStore %608 %1356
+%1357 = OpLoad %bool %608
+OpLoopMerge %246 %356 None
+OpBranchConditional %1357 %247 %246
+%246 = OpLabel
+%1358 = OpLoad %bool %599
+OpSelectionMerge %250 None
+OpBranchConditional %1358 %248 %249
+%249 = OpLabel
+%1359 = OpLoad %double %606
+OpStore %614 %1359
+OpBranch %250
+%248 = OpLabel
+%1360 = OpLoad %double %606
+%1361 = OpFNegate %double %1360
+OpStore %613 %1361
+%1362 = OpLoad %double %613
+OpStore %614 %1362
+OpBranch %250
+%250 = OpLabel
+%1363 = OpLoad %double %614
+OpStore %615 %1363
+OpBranch %233
+%247 = OpLabel
+%1364 = OpLoad %double %607
+%1365 = OpLoad %double %606
+%1366 = OpFOrdLessThanEqual %bool %1364 %1365
+OpStore %609 %1366
+%1367 = OpLoad %bool %609
+OpSelectionMerge %245 None
+OpBranchConditional %1367 %243 %244
+%244 = OpLabel
+%1368 = OpLoad %double %606
+OpStore %611 %1368
+OpBranch %245
+%243 = OpLabel
+%1369 = OpLoad %double %606
+%1370 = OpLoad %double %607
+%1371 = OpFSub %double %1369 %1370
+OpStore %610 %1371
+%1372 = OpLoad %double %610
+OpStore %611 %1372
+OpBranch %245
+%245 = OpLabel
+%1373 = OpLoad %double %607
+%1374 = OpFDiv %double %1373 %double_2
+OpStore %612 %1374
+%1375 = OpLoad %double %611
+OpStore %606 %1375
+%1376 = OpLoad %double %612
+OpStore %607 %1376
+OpBranch %356
+%240 = OpLabel
+%1377 = OpLoad %double %603
+%1378 = OpFMul %double %1377 %double_2
+OpStore %605 %1378
+%1379 = OpLoad %double %605
+OpStore %603 %1379
+OpBranch %358
+%231 = OpLabel
+%1380 = OpLoad %double %589
+%1381 = OpFDiv %double %1380 %double_0_5
+OpStore %594 %1381
+%1382 = OpLoad %double %594
+%1383 = OpConvertFToS %ulong %1382
+OpStore %595 %1383
+%1384 = OpLoad %ulong %595
+%1385 = OpConvertSToF %double %1384
+OpStore %596 %1385
+%1386 = OpLoad %double %596
+%1387 = OpFMul %double %1386 %double_0_5
+OpStore %597 %1387
+%1388 = OpLoad %double %589
+%1389 = OpLoad %double %597
+%1390 = OpFSub %double %1388 %1389
+OpStore %598 %1390
+%1391 = OpLoad %double %598
+OpStore %615 %1391
+OpBranch %233
+%233 = OpLabel
+%1392 = OpLoad %ulong %588
+%1393 = OpLoad %double %615
+%1394 = OpFunctionCall %ulong %2 %1392 %1393
+OpStore %616 %1394
+%1395 = OpLoad %double %456
+%1396 = OpFOrdEqual %bool %1395 %double_0
+OpStore %617 %1396
+%1397 = OpLoad %bool %617
+OpSelectionMerge %254 None
+OpBranchConditional %1397 %346 %251
+%251 = OpLabel
+%1398 = OpLoad %double %720
+%1399 = OpFMul %double %1398 %double_2
+OpStore %618 %1399
+%1400 = OpLoad %double %720
+%1401 = OpLoad %double %618
+%1402 = OpFOrdEqual %bool %1400 %1401
+OpStore %619 %1402
+%1403 = OpLoad %bool %619
+OpSelectionMerge %253 None
+OpBranchConditional %1403 %252 %345
+%345 = OpLabel
+%1404 = OpLoad %bool %619
+OpStore %621 %1404
+OpBranch %253
+%252 = OpLabel
+%1405 = OpLoad %double %720
+%1406 = OpFUnordNotEqual %bool %1405 %double_0
+OpStore %620 %1406
+%1407 = OpLoad %bool %620
+OpStore %621 %1407
+OpBranch %253
+%253 = OpLabel
+%1408 = OpLoad %bool %621
+OpStore %622 %1408
+OpBranch %254
+%346 = OpLabel
+%1409 = OpLoad %bool %617
+OpStore %622 %1409
+OpBranch %254
+%254 = OpLabel
+%1410 = OpLoad %bool %622
+OpSelectionMerge %257 None
+OpBranchConditional %1410 %255 %256
+%256 = OpLabel
+%1411 = OpLoad %double %720
+%1412 = OpFOrdLessThan %bool %1411 %double_0
+OpStore %628 %1412
+%1413 = OpLoad %bool %628
+OpSelectionMerge %260 None
+OpBranchConditional %1413 %258 %259
 %259 = OpLabel
-%1831 = OpLoad %double %427
-%1832 = OpLoad %double %427
-%1833 = OpFUnordNotEqual %bool %1831 %1832
-OpStore %713 %1833
-%1834 = OpLoad %bool %713
-OpSelectionMerge %263 None
-OpBranchConditional %1834 %260 %261
-%261 = OpLabel
-OpBranch %262
-%262 = OpLabel
-%1835 = OpLoad %ulong %708
-%1836 = OpLoad %double %427
-%1837 = OpFunctionCall %ulong %6 %1835 %1836
-OpStore %715 %1837
-%1838 = OpLoad %ulong %715
-OpStore %716 %1838
-OpBranch %263
+%1414 = OpLoad %double %720
+OpStore %630 %1414
+OpBranch %260
+%258 = OpLabel
+%1415 = OpLoad %double %720
+%1416 = OpFSub %double %double_0 %1415
+OpStore %629 %1416
+%1417 = OpLoad %double %629
+OpStore %630 %1417
+OpBranch %260
 %260 = OpLabel
-%1839 = OpLoad %ulong %708
-%1840 = OpFunctionCall %ulong %5 %1839 %ulong_18446744073709551615
-OpStore %714 %1840
-%1841 = OpLoad %ulong %714
-OpStore %716 %1841
+%1418 = OpLoad %double %456
+%1419 = OpFOrdLessThan %bool %1418 %double_0
+OpStore %631 %1419
+%1420 = OpLoad %bool %631
+OpSelectionMerge %263 None
+OpBranchConditional %1420 %261 %262
+%262 = OpLabel
+%1421 = OpLoad %double %456
+OpStore %633 %1421
+OpBranch %263
+%261 = OpLabel
+%1422 = OpLoad %double %456
+%1423 = OpFSub %double %double_0 %1422
+OpStore %632 %1423
+%1424 = OpLoad %double %632
+OpStore %633 %1424
 OpBranch %263
 %263 = OpLabel
-%1842 = OpLoad %ulong %710
-%1843 = OpIAdd %ulong %1842 %ulong_1
-OpStore %428 %1843
-%1844 = OpLoad %ulong %716
-OpStore %708 %1844
-%1845 = OpLoad %double %427
-OpStore %709 %1845
-%1846 = OpLoad %ulong %428
-OpStore %710 %1846
-OpBranch %376
+%1425 = OpLoad %double %630
+%1426 = OpFDiv %double %1425 %double_2
+OpStore %634 %1426
+%1427 = OpLoad %double %633
+OpStore %635 %1427
+OpBranch %264
+%264 = OpLabel
+%1428 = OpLoad %double %635
+%1429 = OpLoad %double %634
+%1430 = OpFOrdLessThanEqual %bool %1428 %1429
+OpStore %636 %1430
+%1431 = OpLoad %bool %636
+OpLoopMerge %266 %357 None
+OpBranchConditional %1431 %265 %266
+%266 = OpLabel
+%1432 = OpLoad %double %630
+OpStore %638 %1432
+%1433 = OpLoad %double %635
+OpStore %639 %1433
+OpBranch %267
+%267 = OpLabel
+%1434 = OpLoad %double %633
+%1435 = OpLoad %double %639
+%1436 = OpFOrdLessThanEqual %bool %1434 %1435
+OpStore %640 %1436
+%1437 = OpLoad %bool %640
+OpLoopMerge %271 %354 None
+OpBranchConditional %1437 %272 %271
+%271 = OpLabel
+%1438 = OpLoad %bool %628
+OpSelectionMerge %275 None
+OpBranchConditional %1438 %273 %274
+%274 = OpLabel
+%1439 = OpLoad %double %638
+OpStore %646 %1439
+OpBranch %275
+%273 = OpLabel
+%1440 = OpLoad %double %638
+%1441 = OpFNegate %double %1440
+OpStore %645 %1441
+%1442 = OpLoad %double %645
+OpStore %646 %1442
+OpBranch %275
+%275 = OpLabel
+%1443 = OpLoad %double %646
+OpStore %647 %1443
+OpBranch %257
+%272 = OpLabel
+%1444 = OpLoad %double %639
+%1445 = OpLoad %double %638
+%1446 = OpFOrdLessThanEqual %bool %1444 %1445
+OpStore %641 %1446
+%1447 = OpLoad %bool %641
+OpSelectionMerge %270 None
+OpBranchConditional %1447 %268 %269
+%269 = OpLabel
+%1448 = OpLoad %double %638
+OpStore %643 %1448
+OpBranch %270
+%268 = OpLabel
+%1449 = OpLoad %double %638
+%1450 = OpLoad %double %639
+%1451 = OpFSub %double %1449 %1450
+OpStore %642 %1451
+%1452 = OpLoad %double %642
+OpStore %643 %1452
+OpBranch %270
+%270 = OpLabel
+%1453 = OpLoad %double %639
+%1454 = OpFDiv %double %1453 %double_2
+OpStore %644 %1454
+%1455 = OpLoad %double %643
+OpStore %638 %1455
+%1456 = OpLoad %double %644
+OpStore %639 %1456
+OpBranch %354
+%265 = OpLabel
+%1457 = OpLoad %double %635
+%1458 = OpFMul %double %1457 %double_2
+OpStore %637 %1458
+%1459 = OpLoad %double %637
+OpStore %635 %1459
+OpBranch %357
+%255 = OpLabel
+%1460 = OpLoad %double %720
+%1461 = OpLoad %double %456
+%1462 = OpFDiv %double %1460 %1461
+OpStore %623 %1462
+%1463 = OpLoad %double %623
+%1464 = OpConvertFToS %ulong %1463
+OpStore %624 %1464
+%1465 = OpLoad %ulong %624
+%1466 = OpConvertSToF %double %1465
+OpStore %625 %1466
+%1467 = OpLoad %double %625
+%1468 = OpLoad %double %456
+%1469 = OpFMul %double %1467 %1468
+OpStore %626 %1469
+%1470 = OpLoad %double %720
+%1471 = OpLoad %double %626
+%1472 = OpFSub %double %1470 %1471
+OpStore %627 %1472
+%1473 = OpLoad %double %627
+OpStore %647 %1473
+OpBranch %257
+%257 = OpLabel
+%1474 = OpLoad %ulong %616
+%1475 = OpLoad %double %647
+%1476 = OpFunctionCall %ulong %2 %1474 %1475
+OpStore %648 %1476
+%1477 = OpLoad %double %456
+%1478 = OpFOrdEqual %bool %1477 %double_0
+OpStore %649 %1478
+%1479 = OpLoad %bool %649
+OpSelectionMerge %279 None
+OpBranchConditional %1479 %348 %276
+%276 = OpLabel
+%1480 = OpLoad %double %456
+%1481 = OpFMul %double %1480 %double_2
+OpStore %650 %1481
+%1482 = OpLoad %double %456
+%1483 = OpLoad %double %650
+%1484 = OpFOrdEqual %bool %1482 %1483
+OpStore %651 %1484
+%1485 = OpLoad %bool %651
+OpSelectionMerge %278 None
+OpBranchConditional %1485 %277 %347
+%347 = OpLabel
+%1486 = OpLoad %bool %651
+OpStore %653 %1486
+OpBranch %278
+%277 = OpLabel
+%1487 = OpLoad %double %456
+%1488 = OpFUnordNotEqual %bool %1487 %double_0
+OpStore %652 %1488
+%1489 = OpLoad %bool %652
+OpStore %653 %1489
+OpBranch %278
+%278 = OpLabel
+%1490 = OpLoad %bool %653
+OpStore %654 %1490
+OpBranch %279
+%348 = OpLabel
+%1491 = OpLoad %bool %649
+OpStore %654 %1491
+OpBranch %279
+%279 = OpLabel
+%1492 = OpLoad %bool %654
+OpSelectionMerge %282 None
+OpBranchConditional %1492 %280 %281
+%281 = OpLabel
+%1493 = OpLoad %double %456
+%1494 = OpFOrdLessThan %bool %1493 %double_0
+OpStore %660 %1494
+%1495 = OpLoad %bool %660
+OpSelectionMerge %285 None
+OpBranchConditional %1495 %283 %284
+%284 = OpLabel
+%1496 = OpLoad %double %456
+OpStore %662 %1496
+OpBranch %285
+%283 = OpLabel
+%1497 = OpLoad %double %456
+%1498 = OpFSub %double %double_0 %1497
+OpStore %661 %1498
+%1499 = OpLoad %double %661
+OpStore %662 %1499
+OpBranch %285
+%285 = OpLabel
+%1500 = OpLoad %double %456
+%1501 = OpFOrdLessThan %bool %1500 %double_0
+OpStore %663 %1501
+%1502 = OpLoad %bool %663
+OpSelectionMerge %288 None
+OpBranchConditional %1502 %286 %287
+%287 = OpLabel
+%1503 = OpLoad %double %456
+OpStore %665 %1503
+OpBranch %288
+%286 = OpLabel
+%1504 = OpLoad %double %456
+%1505 = OpFSub %double %double_0 %1504
+OpStore %664 %1505
+%1506 = OpLoad %double %664
+OpStore %665 %1506
+OpBranch %288
+%288 = OpLabel
+%1507 = OpLoad %double %662
+%1508 = OpFDiv %double %1507 %double_2
+OpStore %666 %1508
+%1509 = OpLoad %double %665
+OpStore %667 %1509
+OpBranch %289
+%289 = OpLabel
+%1510 = OpLoad %double %667
+%1511 = OpLoad %double %666
+%1512 = OpFOrdLessThanEqual %bool %1510 %1511
+OpStore %668 %1512
+%1513 = OpLoad %bool %668
+OpLoopMerge %291 %355 None
+OpBranchConditional %1513 %290 %291
+%291 = OpLabel
+%1514 = OpLoad %double %662
+OpStore %670 %1514
+%1515 = OpLoad %double %667
+OpStore %671 %1515
+OpBranch %292
+%292 = OpLabel
+%1516 = OpLoad %double %665
+%1517 = OpLoad %double %671
+%1518 = OpFOrdLessThanEqual %bool %1516 %1517
+OpStore %672 %1518
+%1519 = OpLoad %bool %672
+OpLoopMerge %296 %352 None
+OpBranchConditional %1519 %297 %296
+%296 = OpLabel
+%1520 = OpLoad %bool %660
+OpSelectionMerge %300 None
+OpBranchConditional %1520 %298 %299
+%299 = OpLabel
+%1521 = OpLoad %double %670
+OpStore %678 %1521
+OpBranch %300
+%298 = OpLabel
+%1522 = OpLoad %double %670
+%1523 = OpFNegate %double %1522
+OpStore %677 %1523
+%1524 = OpLoad %double %677
+OpStore %678 %1524
+OpBranch %300
+%300 = OpLabel
+%1525 = OpLoad %double %678
+OpStore %679 %1525
+OpBranch %282
+%297 = OpLabel
+%1526 = OpLoad %double %671
+%1527 = OpLoad %double %670
+%1528 = OpFOrdLessThanEqual %bool %1526 %1527
+OpStore %673 %1528
+%1529 = OpLoad %bool %673
+OpSelectionMerge %295 None
+OpBranchConditional %1529 %293 %294
+%294 = OpLabel
+%1530 = OpLoad %double %670
+OpStore %675 %1530
+OpBranch %295
+%293 = OpLabel
+%1531 = OpLoad %double %670
+%1532 = OpLoad %double %671
+%1533 = OpFSub %double %1531 %1532
+OpStore %674 %1533
+%1534 = OpLoad %double %674
+OpStore %675 %1534
+OpBranch %295
+%295 = OpLabel
+%1535 = OpLoad %double %671
+%1536 = OpFDiv %double %1535 %double_2
+OpStore %676 %1536
+%1537 = OpLoad %double %675
+OpStore %670 %1537
+%1538 = OpLoad %double %676
+OpStore %671 %1538
+OpBranch %352
+%290 = OpLabel
+%1539 = OpLoad %double %667
+%1540 = OpFMul %double %1539 %double_2
+OpStore %669 %1540
+%1541 = OpLoad %double %669
+OpStore %667 %1541
+OpBranch %355
+%280 = OpLabel
+%1542 = OpLoad %double %456
+%1543 = OpLoad %double %456
+%1544 = OpFDiv %double %1542 %1543
+OpStore %655 %1544
+%1545 = OpLoad %double %655
+%1546 = OpConvertFToS %ulong %1545
+OpStore %656 %1546
+%1547 = OpLoad %ulong %656
+%1548 = OpConvertSToF %double %1547
+OpStore %657 %1548
+%1549 = OpLoad %double %657
+%1550 = OpLoad %double %456
+%1551 = OpFMul %double %1549 %1550
+OpStore %658 %1551
+%1552 = OpLoad %double %456
+%1553 = OpLoad %double %658
+%1554 = OpFSub %double %1552 %1553
+OpStore %659 %1554
+%1555 = OpLoad %double %659
+OpStore %679 %1555
+OpBranch %282
+%282 = OpLabel
+%1556 = OpLoad %ulong %648
+%1557 = OpLoad %double %679
+%1558 = OpFunctionCall %ulong %2 %1556 %1557
+OpStore %680 %1558
+%1560 = OpLoad %double %720
+%1561 = OpFMul %double %double_1048576 %1560
+OpStore %681 %1561
+%1562 = OpLoad %double %456
+%1563 = OpFOrdEqual %bool %1562 %double_0
+OpStore %682 %1563
+%1564 = OpLoad %bool %682
+OpSelectionMerge %304 None
+OpBranchConditional %1564 %350 %301
+%301 = OpLabel
+%1565 = OpLoad %double %681
+%1566 = OpFMul %double %1565 %double_2
+OpStore %683 %1566
+%1567 = OpLoad %double %681
+%1568 = OpLoad %double %683
+%1569 = OpFOrdEqual %bool %1567 %1568
+OpStore %684 %1569
+%1570 = OpLoad %bool %684
+OpSelectionMerge %303 None
+OpBranchConditional %1570 %302 %349
+%349 = OpLabel
+%1571 = OpLoad %bool %684
+OpStore %686 %1571
+OpBranch %303
+%302 = OpLabel
+%1572 = OpLoad %double %681
+%1573 = OpFUnordNotEqual %bool %1572 %double_0
+OpStore %685 %1573
+%1574 = OpLoad %bool %685
+OpStore %686 %1574
+OpBranch %303
+%303 = OpLabel
+%1575 = OpLoad %bool %686
+OpStore %687 %1575
+OpBranch %304
+%350 = OpLabel
+%1576 = OpLoad %bool %682
+OpStore %687 %1576
+OpBranch %304
+%304 = OpLabel
+%1577 = OpLoad %bool %687
+OpSelectionMerge %307 None
+OpBranchConditional %1577 %305 %306
+%306 = OpLabel
+%1578 = OpLoad %double %681
+%1579 = OpFOrdLessThan %bool %1578 %double_0
+OpStore %693 %1579
+%1580 = OpLoad %bool %693
+OpSelectionMerge %310 None
+OpBranchConditional %1580 %308 %309
+%309 = OpLabel
+%1581 = OpLoad %double %681
+OpStore %695 %1581
+OpBranch %310
+%308 = OpLabel
+%1582 = OpLoad %double %681
+%1583 = OpFSub %double %double_0 %1582
+OpStore %694 %1583
+%1584 = OpLoad %double %694
+OpStore %695 %1584
+OpBranch %310
+%310 = OpLabel
+%1585 = OpLoad %double %456
+%1586 = OpFOrdLessThan %bool %1585 %double_0
+OpStore %696 %1586
+%1587 = OpLoad %bool %696
+OpSelectionMerge %313 None
+OpBranchConditional %1587 %311 %312
+%312 = OpLabel
+%1588 = OpLoad %double %456
+OpStore %698 %1588
+OpBranch %313
+%311 = OpLabel
+%1589 = OpLoad %double %456
+%1590 = OpFSub %double %double_0 %1589
+OpStore %697 %1590
+%1591 = OpLoad %double %697
+OpStore %698 %1591
+OpBranch %313
+%313 = OpLabel
+%1592 = OpLoad %double %695
+%1593 = OpFDiv %double %1592 %double_2
+OpStore %699 %1593
+%1594 = OpLoad %double %698
+OpStore %700 %1594
+OpBranch %314
+%314 = OpLabel
+%1595 = OpLoad %double %700
+%1596 = OpLoad %double %699
+%1597 = OpFOrdLessThanEqual %bool %1595 %1596
+OpStore %701 %1597
+%1598 = OpLoad %bool %701
+OpLoopMerge %316 %353 None
+OpBranchConditional %1598 %315 %316
+%316 = OpLabel
+%1599 = OpLoad %double %695
+OpStore %703 %1599
+%1600 = OpLoad %double %700
+OpStore %704 %1600
+OpBranch %317
+%317 = OpLabel
+%1601 = OpLoad %double %698
+%1602 = OpLoad %double %704
+%1603 = OpFOrdLessThanEqual %bool %1601 %1602
+OpStore %705 %1603
+%1604 = OpLoad %bool %705
+OpLoopMerge %321 %351 None
+OpBranchConditional %1604 %322 %321
+%321 = OpLabel
+%1605 = OpLoad %bool %693
+OpSelectionMerge %325 None
+OpBranchConditional %1605 %323 %324
+%324 = OpLabel
+%1606 = OpLoad %double %703
+OpStore %711 %1606
+OpBranch %325
+%323 = OpLabel
+%1607 = OpLoad %double %703
+%1608 = OpFNegate %double %1607
+OpStore %710 %1608
+%1609 = OpLoad %double %710
+OpStore %711 %1609
+OpBranch %325
+%325 = OpLabel
+%1610 = OpLoad %double %711
+OpStore %712 %1610
+OpBranch %307
+%322 = OpLabel
+%1611 = OpLoad %double %704
+%1612 = OpLoad %double %703
+%1613 = OpFOrdLessThanEqual %bool %1611 %1612
+OpStore %706 %1613
+%1614 = OpLoad %bool %706
+OpSelectionMerge %320 None
+OpBranchConditional %1614 %318 %319
+%319 = OpLabel
+%1615 = OpLoad %double %703
+OpStore %708 %1615
+OpBranch %320
+%318 = OpLabel
+%1616 = OpLoad %double %703
+%1617 = OpLoad %double %704
+%1618 = OpFSub %double %1616 %1617
+OpStore %707 %1618
+%1619 = OpLoad %double %707
+OpStore %708 %1619
+OpBranch %320
+%320 = OpLabel
+%1620 = OpLoad %double %704
+%1621 = OpFDiv %double %1620 %double_2
+OpStore %709 %1621
+%1622 = OpLoad %double %708
+OpStore %703 %1622
+%1623 = OpLoad %double %709
+OpStore %704 %1623
+OpBranch %351
+%315 = OpLabel
+%1624 = OpLoad %double %700
+%1625 = OpFMul %double %1624 %double_2
+OpStore %702 %1625
+%1626 = OpLoad %double %702
+OpStore %700 %1626
+OpBranch %353
+%305 = OpLabel
+%1627 = OpLoad %double %681
+%1628 = OpLoad %double %456
+%1629 = OpFDiv %double %1627 %1628
+OpStore %688 %1629
+%1630 = OpLoad %double %688
+%1631 = OpConvertFToS %ulong %1630
+OpStore %689 %1631
+%1632 = OpLoad %ulong %689
+%1633 = OpConvertSToF %double %1632
+OpStore %690 %1633
+%1634 = OpLoad %double %690
+%1635 = OpLoad %double %456
+%1636 = OpFMul %double %1634 %1635
+OpStore %691 %1636
+%1637 = OpLoad %double %681
+%1638 = OpLoad %double %691
+%1639 = OpFSub %double %1637 %1638
+OpStore %692 %1639
+%1640 = OpLoad %double %692
+OpStore %712 %1640
+OpBranch %307
+%307 = OpLabel
+%1641 = OpLoad %ulong %680
+%1642 = OpLoad %double %712
+%1643 = OpFunctionCall %ulong %2 %1641 %1642
+OpStore %713 %1643
+%1644 = OpLoad %ulong %713
+OpReturnValue %1644
+%125 = OpLabel
+%1645 = OpLoad %double %715
+%1646 = OpLoad %double %392
+%1647 = OpFAdd %double %1645 %1646
+OpStore %420 %1647
+%1648 = OpLoad %double %420
+%1649 = OpFMul %double %1648 %double_1_5
+OpStore %421 %1649
+%1650 = OpLoad %ulong %714
+%1651 = OpLoad %double %421
+%1652 = OpFunctionCall %ulong %2 %1650 %1651
+OpStore %422 %1652
+%1653 = OpLoad %ulong %716
+%1654 = OpIAdd %ulong %1653 %ulong_1
+OpStore %423 %1654
+%1655 = OpLoad %ulong %422
+OpStore %714 %1655
+%1656 = OpLoad %double %421
+OpStore %715 %1656
+%1657 = OpLoad %ulong %423
+OpStore %716 %1657
+OpBranch %367
+%351 = OpLabel
+OpBranch %317
+%352 = OpLabel
+OpBranch %292
+%353 = OpLabel
+OpBranch %314
+%354 = OpLabel
+OpBranch %267
+%355 = OpLabel
+OpBranch %289
+%356 = OpLabel
+OpBranch %242
+%357 = OpLabel
+OpBranch %264
+%358 = OpLabel
+OpBranch %239
+%359 = OpLabel
+OpBranch %218
 %360 = OpLabel
-OpBranch %248
+OpBranch %193
 %361 = OpLabel
-OpBranch %245
+OpBranch %215
 %362 = OpLabel
-OpBranch %223
+OpBranch %168
 %363 = OpLabel
-OpBranch %220
+OpBranch %190
 %364 = OpLabel
-OpBranch %198
+OpBranch %143
 %365 = OpLabel
-OpBranch %195
+OpBranch %165
 %366 = OpLabel
-OpBranch %173
+OpBranch %140
 %367 = OpLabel
-OpBranch %170
-%368 = OpLabel
-OpBranch %149
-%369 = OpLabel
-OpBranch %146
-%370 = OpLabel
 OpBranch %124
-%371 = OpLabel
-OpBranch %121
-%372 = OpLabel
-OpBranch %99
-%373 = OpLabel
-OpBranch %96
-%374 = OpLabel
-OpBranch %74
-%375 = OpLabel
-OpBranch %71
-%376 = OpLabel
-OpBranch %55
-OpFunctionEnd
-%4 = OpFunction %ulong None %1847
-%1848 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %1850
-%1851 = OpFunctionParameter %ulong
-%1852 = OpFunctionParameter %ulong
-%1853 = OpLabel
-%1858 = OpVariable %_ptr_Function_ulong Function
-%1859 = OpVariable %_ptr_Function_ulong Function
-%1860 = OpVariable %_ptr_Function_bool Function
-%1861 = OpVariable %_ptr_Function_ulong Function
-%1862 = OpVariable %_ptr_Function_ulong Function
-%1863 = OpVariable %_ptr_Function_ulong Function
-%1864 = OpVariable %_ptr_Function_ulong Function
-%1865 = OpVariable %_ptr_Function_ulong Function
-%1866 = OpVariable %_ptr_Function_ulong Function
-%1867 = OpVariable %_ptr_Function_ulong Function
-%1868 = OpVariable %_ptr_Function_ulong Function
-OpStore %1858 %1851
-OpStore %1859 %1852
-%1869 = OpLoad %ulong %1858
-OpStore %1867 %1869
-OpStore %1868 %ulong_0
-OpBranch %1854
-%1854 = OpLabel
-%1870 = OpLoad %ulong %1868
-%1872 = OpULessThan %bool %1870 %ulong_8
-OpStore %1860 %1872
-%1873 = OpLoad %bool %1860
-OpLoopMerge %1856 %1857 None
-OpBranchConditional %1873 %1855 %1856
-%1856 = OpLabel
-%1874 = OpLoad %ulong %1867
-OpReturnValue %1874
-%1855 = OpLabel
-%1875 = OpLoad %ulong %1868
-%1876 = OpIMul %ulong %1875 %ulong_8
-OpStore %1861 %1876
-%1877 = OpLoad %ulong %1859
-%1878 = OpLoad %ulong %1861
-%1879 = OpShiftRightLogical %ulong %1877 %1878
-OpStore %1862 %1879
-%1880 = OpLoad %ulong %1862
-%1882 = OpBitwiseAnd %ulong %1880 %ulong_255
-OpStore %1863 %1882
-%1883 = OpLoad %ulong %1867
-%1884 = OpLoad %ulong %1863
-%1885 = OpBitwiseXor %ulong %1883 %1884
-OpStore %1864 %1885
-%1886 = OpLoad %ulong %1864
-%1888 = OpIMul %ulong %1886 %ulong_1099511628211
-OpStore %1865 %1888
-%1889 = OpLoad %ulong %1868
-%1890 = OpIAdd %ulong %1889 %ulong_1
-OpStore %1866 %1890
-%1891 = OpLoad %ulong %1865
-OpStore %1867 %1891
-%1892 = OpLoad %ulong %1866
-OpStore %1868 %1892
-OpBranch %1857
-%1857 = OpLabel
-OpBranch %1854
-OpFunctionEnd
-%6 = OpFunction %ulong None %25
-%1893 = OpFunctionParameter %ulong
-%1894 = OpFunctionParameter %double
-%1895 = OpLabel
-%1902 = OpVariable %_ptr_Function_ulong Function
-%1903 = OpVariable %_ptr_Function_double Function
-%1904 = OpVariable %_ptr_Function_ulong Function
-%1905 = OpVariable %_ptr_Function_bool Function
-%1906 = OpVariable %_ptr_Function_ulong Function
-%1907 = OpVariable %_ptr_Function_ulong Function
-%1908 = OpVariable %_ptr_Function_ulong Function
-%1909 = OpVariable %_ptr_Function_ulong Function
-%1910 = OpVariable %_ptr_Function_ulong Function
-%1911 = OpVariable %_ptr_Function_ulong Function
-%1912 = OpVariable %_ptr_Function_ulong Function
-%1913 = OpVariable %_ptr_Function_ulong Function
-OpStore %1902 %1893
-OpStore %1903 %1894
-%1914 = OpLoad %double %1903
-%1915 = OpBitcast %ulong %1914
-OpStore %1904 %1915
-OpBranch %1896
-%1896 = OpLabel
-%1916 = OpLoad %ulong %1902
-OpStore %1912 %1916
-OpStore %1913 %ulong_0
-OpBranch %1897
-%1897 = OpLabel
-%1917 = OpLoad %ulong %1913
-%1918 = OpULessThan %bool %1917 %ulong_8
-OpStore %1905 %1918
-%1919 = OpLoad %bool %1905
-OpLoopMerge %1899 %1901 None
-OpBranchConditional %1919 %1898 %1899
-%1899 = OpLabel
-OpBranch %1900
-%1900 = OpLabel
-%1920 = OpLoad %ulong %1912
-OpReturnValue %1920
-%1898 = OpLabel
-%1921 = OpLoad %ulong %1913
-%1922 = OpIMul %ulong %1921 %ulong_8
-OpStore %1906 %1922
-%1923 = OpLoad %ulong %1904
-%1924 = OpLoad %ulong %1906
-%1925 = OpShiftRightLogical %ulong %1923 %1924
-OpStore %1907 %1925
-%1926 = OpLoad %ulong %1907
-%1927 = OpBitwiseAnd %ulong %1926 %ulong_255
-OpStore %1908 %1927
-%1928 = OpLoad %ulong %1912
-%1929 = OpLoad %ulong %1908
-%1930 = OpBitwiseXor %ulong %1928 %1929
-OpStore %1909 %1930
-%1931 = OpLoad %ulong %1909
-%1932 = OpIMul %ulong %1931 %ulong_1099511628211
-OpStore %1910 %1932
-%1933 = OpLoad %ulong %1913
-%1934 = OpIAdd %ulong %1933 %ulong_1
-OpStore %1911 %1934
-%1935 = OpLoad %ulong %1910
-OpStore %1912 %1935
-%1936 = OpLoad %ulong %1911
-OpStore %1913 %1936
-OpBranch %1901
-%1901 = OpLabel
-OpBranch %1897
 OpFunctionEnd

--- a/test/golden/spirv/float/cmp_f32.dis
+++ b/test/golden/spirv/float/cmp_f32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 795
+; Bound: 1163
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,21 +12,26 @@ OpDecorate %1 LinkageAttributes "corpus.cases.float.cmp_f32.fold32" Export
 OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f32.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
-%9 = OpTypeFunction %ulong %ulong %float
+%5 = OpTypeFunction %ulong %ulong %float
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_bool = OpTypePointer Function %bool
-%uint = OpTypeInt 32 0
-%uint_4294967295 = OpConstant %uint 4294967295
-%39 = OpTypeFunction %ulong %ulong
+%_ptr_Function_uint = OpTypePointer Function %uint
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%ulong_4294967295 = OpConstant %ulong 4294967295
+%113 = OpTypeFunction %ulong %ulong
 %uchar = OpTypeInt 8 0
 %uint_12 = OpConstant %uint 12
 %_arr_float_uint_12 = OpTypeArray %float %uint_12
 %_ptr_Function__arr_float_uint_12 = OpTypePointer Function %_arr_float_uint_12
-%_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%254 = OpConstantNull %_arr_float_uint_12
+%533 = OpConstantNull %_arr_float_uint_12
 %uint_4286578688 = OpConstant %uint 4286578688
 %uint_0 = OpConstant %uint 0
 %uint_3212836864 = OpConstant %uint 3212836864
@@ -49,6 +54,7 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f32.checksum" Export
 %uint_10 = OpConstant %uint 10
 %uint_2139095041 = OpConstant %uint 2139095041
 %uint_11 = OpConstant %uint 11
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
 %uchar_2 = OpConstant %uchar 2
@@ -56,1096 +62,1668 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f32.checksum" Export
 %uchar_8 = OpConstant %uchar 8
 %uchar_16 = OpConstant %uchar 16
 %uchar_32 = OpConstant %uchar 32
-%650 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%653 = OpTypeFunction %ulong %ulong %uchar
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%703 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %float
-%12 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_bool Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %19 %10
-OpStore %21 %11
-%26 = OpLoad %float %21
-%27 = OpLoad %float %21
-%28 = OpFUnordNotEqual %bool %26 %27
-OpStore %23 %28
-%29 = OpLoad %bool %23
-OpSelectionMerge %16 None
-OpBranchConditional %29 %13 %14
+%1 = OpFunction %ulong None %5
+%6 = OpFunctionParameter %ulong
+%7 = OpFunctionParameter %float
+%8 = OpLabel
+%32 = OpVariable %_ptr_Function_ulong Function
+%34 = OpVariable %_ptr_Function_float Function
+%36 = OpVariable %_ptr_Function_bool Function
+%38 = OpVariable %_ptr_Function_uint Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_bool Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_bool Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+OpStore %32 %6
+OpStore %34 %7
+%58 = OpLoad %float %34
+%59 = OpLoad %float %34
+%60 = OpFUnordNotEqual %bool %58 %59
+OpStore %36 %60
+%61 = OpLoad %bool %36
+OpSelectionMerge %28 None
+OpBranchConditional %61 %9 %10
+%10 = OpLabel
+OpBranch %11
+%11 = OpLabel
+OpBranch %14
 %14 = OpLabel
+%62 = OpLoad %float %34
+%63 = OpBitcast %uint %62
+OpStore %38 %63
+%64 = OpLoad %uint %38
+%65 = OpUConvert %ulong %64
+OpStore %39 %65
+OpBranch %21
+%21 = OpLabel
+%66 = OpLoad %ulong %32
+OpStore %56 %66
+OpStore %57 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%68 = OpLoad %ulong %57
+%70 = OpULessThan %bool %68 %ulong_8
+OpStore %49 %70
+%71 = OpLoad %bool %49
+OpLoopMerge %24 %26 None
+OpBranchConditional %71 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
 OpBranch %15
 %15 = OpLabel
-%30 = OpLoad %ulong %19
-%31 = OpLoad %float %21
-%32 = OpFunctionCall %ulong %6 %30 %31
-OpStore %25 %32
-%33 = OpLoad %ulong %25
-OpReturnValue %33
-%13 = OpLabel
-%35 = OpLoad %ulong %19
-%37 = OpFunctionCall %ulong %5 %35 %uint_4294967295
-OpStore %24 %37
-%38 = OpLoad %ulong %24
-OpReturnValue %38
+%72 = OpLoad %ulong %56
+OpReturnValue %72
+%23 = OpLabel
+%73 = OpLoad %ulong %57
+%74 = OpIMul %ulong %73 %ulong_8
+OpStore %50 %74
+%75 = OpLoad %ulong %39
+%76 = OpLoad %ulong %50
+%77 = OpShiftRightLogical %ulong %75 %76
+OpStore %51 %77
+%78 = OpLoad %ulong %51
+%80 = OpBitwiseAnd %ulong %78 %ulong_255
+OpStore %52 %80
+%81 = OpLoad %ulong %56
+%82 = OpLoad %ulong %52
+%83 = OpBitwiseXor %ulong %81 %82
+OpStore %53 %83
+%84 = OpLoad %ulong %53
+%86 = OpIMul %ulong %84 %ulong_1099511628211
+OpStore %54 %86
+%87 = OpLoad %ulong %57
+%89 = OpIAdd %ulong %87 %ulong_1
+OpStore %55 %89
+%90 = OpLoad %ulong %54
+OpStore %56 %90
+%91 = OpLoad %ulong %55
+OpStore %57 %91
+OpBranch %26
+%9 = OpLabel
+OpBranch %12
+%12 = OpLabel
+OpBranch %16
 %16 = OpLabel
+%92 = OpLoad %ulong %32
+OpStore %47 %92
+OpStore %48 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%93 = OpLoad %ulong %48
+%94 = OpULessThan %bool %93 %ulong_8
+OpStore %40 %94
+%95 = OpLoad %bool %40
+OpLoopMerge %19 %27 None
+OpBranchConditional %95 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%96 = OpLoad %ulong %47
+OpReturnValue %96
+%18 = OpLabel
+%97 = OpLoad %ulong %48
+%98 = OpIMul %ulong %97 %ulong_8
+OpStore %41 %98
+%100 = OpLoad %ulong %41
+%101 = OpShiftRightLogical %ulong %ulong_4294967295 %100
+OpStore %42 %101
+%102 = OpLoad %ulong %42
+%103 = OpBitwiseAnd %ulong %102 %ulong_255
+OpStore %43 %103
+%104 = OpLoad %ulong %47
+%105 = OpLoad %ulong %43
+%106 = OpBitwiseXor %ulong %104 %105
+OpStore %44 %106
+%107 = OpLoad %ulong %44
+%108 = OpIMul %ulong %107 %ulong_1099511628211
+OpStore %45 %108
+%109 = OpLoad %ulong %48
+%110 = OpIAdd %ulong %109 %ulong_1
+OpStore %46 %110
+%111 = OpLoad %ulong %45
+OpStore %47 %111
+%112 = OpLoad %ulong %46
+OpStore %48 %112
+OpBranch %27
+%26 = OpLabel
+OpBranch %22
+%27 = OpLabel
+OpBranch %17
+%28 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%2 = OpFunction %ulong None %39
-%40 = OpFunctionParameter %ulong
-%41 = OpLabel
-%112 = OpVariable %_ptr_Function__arr_float_uint_12 Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_uint Function
-%117 = OpVariable %_ptr_Function_uint Function
-%118 = OpVariable %_ptr_Function_float Function
-%119 = OpVariable %_ptr_Function_uint Function
-%120 = OpVariable %_ptr_Function_float Function
-%121 = OpVariable %_ptr_Function_uint Function
-%122 = OpVariable %_ptr_Function_float Function
-%123 = OpVariable %_ptr_Function_uint Function
-%124 = OpVariable %_ptr_Function_float Function
-%125 = OpVariable %_ptr_Function_uint Function
-%126 = OpVariable %_ptr_Function_float Function
-%127 = OpVariable %_ptr_Function_float Function
-%128 = OpVariable %_ptr_Function_uint Function
-%129 = OpVariable %_ptr_Function_float Function
-%130 = OpVariable %_ptr_Function_uint Function
-%131 = OpVariable %_ptr_Function_float Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_float Function
-%134 = OpVariable %_ptr_Function_uint Function
-%135 = OpVariable %_ptr_Function_float Function
-%136 = OpVariable %_ptr_Function_uint Function
-%137 = OpVariable %_ptr_Function_float Function
-%138 = OpVariable %_ptr_Function_uint Function
-%139 = OpVariable %_ptr_Function_float Function
-%140 = OpVariable %_ptr_Function_bool Function
-%141 = OpVariable %_ptr_Function_bool Function
-%142 = OpVariable %_ptr_Function_float Function
-%143 = OpVariable %_ptr_Function_float Function
-%144 = OpVariable %_ptr_Function_bool Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_bool Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_bool Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_bool Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_bool Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_bool Function
-%158 = OpVariable %_ptr_Function_uchar Function
-%159 = OpVariable %_ptr_Function_bool Function
-%160 = OpVariable %_ptr_Function_uchar Function
-%161 = OpVariable %_ptr_Function_bool Function
-%162 = OpVariable %_ptr_Function_uchar Function
-%163 = OpVariable %_ptr_Function_bool Function
-%164 = OpVariable %_ptr_Function_uchar Function
-%165 = OpVariable %_ptr_Function_bool Function
-%166 = OpVariable %_ptr_Function_uchar Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_bool Function
-%169 = OpVariable %_ptr_Function_bool Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_bool Function
-%172 = OpVariable %_ptr_Function_bool Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_bool Function
-%175 = OpVariable %_ptr_Function_bool Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_bool Function
-%178 = OpVariable %_ptr_Function_bool Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_bool Function
-%181 = OpVariable %_ptr_Function_bool Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_uint Function
-%184 = OpVariable %_ptr_Function_uint Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_bool Function
-%188 = OpVariable %_ptr_Function_float Function
-%189 = OpVariable %_ptr_Function_bool Function
-%190 = OpVariable %_ptr_Function_float Function
-%191 = OpVariable %_ptr_Function_float Function
-%192 = OpVariable %_ptr_Function_bool Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_uint Function
-%195 = OpVariable %_ptr_Function_bool Function
-%196 = OpVariable %_ptr_Function_bool Function
-%197 = OpVariable %_ptr_Function_float Function
-%198 = OpVariable %_ptr_Function_float Function
-%199 = OpVariable %_ptr_Function_bool Function
-%200 = OpVariable %_ptr_Function_uint Function
-%201 = OpVariable %_ptr_Function_uint Function
-%202 = OpVariable %_ptr_Function_float Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_bool Function
-%205 = OpVariable %_ptr_Function_uint Function
-%206 = OpVariable %_ptr_Function_uint Function
-%207 = OpVariable %_ptr_Function_float Function
-%208 = OpVariable %_ptr_Function_float Function
-%209 = OpVariable %_ptr_Function_bool Function
-%210 = OpVariable %_ptr_Function_uint Function
-%211 = OpVariable %_ptr_Function_uint Function
-%212 = OpVariable %_ptr_Function_float Function
-%213 = OpVariable %_ptr_Function_float Function
-%214 = OpVariable %_ptr_Function_bool Function
-%215 = OpVariable %_ptr_Function_uint Function
-%216 = OpVariable %_ptr_Function_uint Function
-%217 = OpVariable %_ptr_Function_uint Function
-%218 = OpVariable %_ptr_Function_uint Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_uint Function
-%223 = OpVariable %_ptr_Function_uint Function
-%224 = OpVariable %_ptr_Function_uchar Function
-%225 = OpVariable %_ptr_Function_uchar Function
-%226 = OpVariable %_ptr_Function_uchar Function
-%227 = OpVariable %_ptr_Function_uchar Function
-%228 = OpVariable %_ptr_Function_uchar Function
-%229 = OpVariable %_ptr_Function_uchar Function
-%230 = OpVariable %_ptr_Function_bool Function
-%231 = OpVariable %_ptr_Function_bool Function
-%232 = OpVariable %_ptr_Function_bool Function
-%233 = OpVariable %_ptr_Function_bool Function
-%234 = OpVariable %_ptr_Function_float Function
-%235 = OpVariable %_ptr_Function_float Function
-%236 = OpVariable %_ptr_Function_float Function
-%237 = OpVariable %_ptr_Function_float Function
-%238 = OpVariable %_ptr_Function_uint Function
-%239 = OpVariable %_ptr_Function_uint Function
-%240 = OpVariable %_ptr_Function_uint Function
-%241 = OpVariable %_ptr_Function_uint Function
-%242 = OpVariable %_ptr_Function_uint Function
-%243 = OpVariable %_ptr_Function_bool Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_bool Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ulong Function
-OpStore %113 %40
-%251 = OpFunctionCall %ulong %3
-OpStore %114 %251
-%252 = OpLoad %ulong %113
-%253 = OpUConvert %uint %252
-OpStore %116 %253
-OpStore %112 %254
-%256 = OpLoad %uint %116
-%257 = OpIAdd %uint %uint_4286578688 %256
-OpStore %117 %257
-%258 = OpLoad %uint %117
-%259 = OpBitcast %float %258
-OpStore %118 %259
-%261 = OpAccessChain %_ptr_Function_float %112 %uint_0
-%262 = OpLoad %float %118
-OpStore %261 %262
-%264 = OpLoad %uint %116
-%265 = OpIAdd %uint %uint_3212836864 %264
-OpStore %119 %265
-%266 = OpLoad %uint %119
-%267 = OpBitcast %float %266
-OpStore %120 %267
-%269 = OpAccessChain %_ptr_Function_float %112 %uint_1
-%270 = OpLoad %float %120
-OpStore %269 %270
-%272 = OpLoad %uint %116
-%273 = OpIAdd %uint %uint_2155872256 %272
-OpStore %121 %273
-%274 = OpLoad %uint %121
-%275 = OpBitcast %float %274
-OpStore %122 %275
-%277 = OpAccessChain %_ptr_Function_float %112 %uint_2
-%278 = OpLoad %float %122
-OpStore %277 %278
-%280 = OpLoad %uint %116
-%281 = OpIAdd %uint %uint_2147483649 %280
-OpStore %123 %281
-%282 = OpLoad %uint %123
-%283 = OpBitcast %float %282
-OpStore %124 %283
-%285 = OpAccessChain %_ptr_Function_float %112 %uint_3
-%286 = OpLoad %float %124
-OpStore %285 %286
-%288 = OpLoad %uint %116
-%289 = OpIAdd %uint %uint_2147483648 %288
-OpStore %125 %289
-%290 = OpLoad %uint %125
-%291 = OpBitcast %float %290
-OpStore %126 %291
-%293 = OpAccessChain %_ptr_Function_float %112 %uint_4
-%294 = OpLoad %float %126
-OpStore %293 %294
-%295 = OpLoad %uint %116
-%296 = OpBitcast %float %295
-OpStore %127 %296
-%298 = OpAccessChain %_ptr_Function_float %112 %uint_5
-%299 = OpLoad %float %127
-OpStore %298 %299
-%300 = OpLoad %uint %116
-%301 = OpIAdd %uint %uint_1 %300
-OpStore %128 %301
-%302 = OpLoad %uint %128
-%303 = OpBitcast %float %302
-OpStore %129 %303
-%305 = OpAccessChain %_ptr_Function_float %112 %uint_6
-%306 = OpLoad %float %129
-OpStore %305 %306
-%308 = OpLoad %uint %116
-%309 = OpIAdd %uint %uint_1065353216 %308
-OpStore %130 %309
-%310 = OpLoad %uint %130
-%311 = OpBitcast %float %310
-OpStore %131 %311
-%313 = OpAccessChain %_ptr_Function_float %112 %uint_7
-%314 = OpLoad %float %131
-OpStore %313 %314
-%316 = OpLoad %uint %116
-%317 = OpIAdd %uint %uint_2139095039 %316
-OpStore %132 %317
-%318 = OpLoad %uint %132
-%319 = OpBitcast %float %318
-OpStore %133 %319
-%321 = OpAccessChain %_ptr_Function_float %112 %uint_8
-%322 = OpLoad %float %133
-OpStore %321 %322
-%324 = OpLoad %uint %116
-%325 = OpIAdd %uint %uint_2139095040 %324
-OpStore %134 %325
-%326 = OpLoad %uint %134
-%327 = OpBitcast %float %326
-OpStore %135 %327
-%329 = OpAccessChain %_ptr_Function_float %112 %uint_9
-%330 = OpLoad %float %135
-OpStore %329 %330
-%332 = OpLoad %uint %116
-%333 = OpIAdd %uint %uint_2143289344 %332
-OpStore %136 %333
-%334 = OpLoad %uint %136
-%335 = OpBitcast %float %334
-OpStore %137 %335
-%337 = OpAccessChain %_ptr_Function_float %112 %uint_10
-%338 = OpLoad %float %137
-OpStore %337 %338
-%340 = OpLoad %uint %116
-%341 = OpIAdd %uint %uint_2139095041 %340
-OpStore %138 %341
-%342 = OpLoad %uint %138
-%343 = OpBitcast %float %342
-OpStore %139 %343
-%345 = OpAccessChain %_ptr_Function_float %112 %uint_11
-%346 = OpLoad %float %139
-OpStore %345 %346
-%347 = OpLoad %ulong %114
-OpStore %221 %347
-OpStore %222 %uint_0
-OpBranch %42
-%42 = OpLabel
-%348 = OpLoad %uint %222
-%349 = OpULessThan %bool %348 %uint_12
-OpStore %140 %349
-%350 = OpLoad %bool %140
-OpLoopMerge %44 %107 None
-OpBranchConditional %350 %43 %44
-%44 = OpLabel
-%351 = OpAccessChain %_ptr_Function_float %112 %uint_0
-%352 = OpLoad %float %351
-OpStore %185 %352
-%353 = OpLoad %float %351
-OpStore %186 %353
-%354 = OpLoad %float %185
-OpStore %235 %354
-%355 = OpLoad %float %186
-OpStore %237 %355
-OpStore %238 %uint_1
-OpBranch %74
-%74 = OpLabel
-%356 = OpLoad %uint %238
-%357 = OpULessThan %bool %356 %uint_12
-OpStore %187 %357
-%358 = OpLoad %bool %187
-OpLoopMerge %76 %106 None
-OpBranchConditional %358 %75 %76
-%76 = OpLabel
-OpBranch %89
-%89 = OpLabel
-%359 = OpLoad %float %235
-%360 = OpLoad %float %235
-%361 = OpFUnordNotEqual %bool %359 %360
-OpStore %243 %361
-%362 = OpLoad %bool %243
-OpSelectionMerge %93 None
-OpBranchConditional %362 %90 %91
-%91 = OpLabel
-OpBranch %92
-%92 = OpLabel
-%363 = OpLoad %ulong %221
-%364 = OpLoad %float %235
-%365 = OpFunctionCall %ulong %6 %363 %364
-OpStore %245 %365
-%366 = OpLoad %ulong %245
-OpStore %246 %366
-OpBranch %93
-%90 = OpLabel
-%367 = OpLoad %ulong %221
-%368 = OpFunctionCall %ulong %5 %367 %uint_4294967295
-OpStore %244 %368
-%369 = OpLoad %ulong %244
-OpStore %246 %369
-OpBranch %93
-%93 = OpLabel
-OpBranch %94
-%94 = OpLabel
-%370 = OpLoad %float %237
-%371 = OpLoad %float %237
-%372 = OpFUnordNotEqual %bool %370 %371
-OpStore %247 %372
-%373 = OpLoad %bool %247
-OpSelectionMerge %98 None
-OpBranchConditional %373 %95 %96
-%96 = OpLabel
-OpBranch %97
-%97 = OpLabel
-%374 = OpLoad %ulong %246
-%375 = OpLoad %float %237
-%376 = OpFunctionCall %ulong %6 %374 %375
-OpStore %249 %376
-%377 = OpLoad %ulong %249
-OpStore %250 %377
-OpBranch %98
-%95 = OpLabel
-%378 = OpLoad %ulong %246
-%379 = OpFunctionCall %ulong %5 %378 %uint_4294967295
-OpStore %248 %379
-%380 = OpLoad %ulong %248
-OpStore %250 %380
-OpBranch %98
-%98 = OpLabel
-OpStore %240 %uint_0
-OpStore %241 %uint_0
-OpBranch %83
-%83 = OpLabel
-%381 = OpLoad %uint %241
-%382 = OpULessThan %bool %381 %uint_12
-OpStore %195 %382
-%383 = OpLoad %bool %195
-OpLoopMerge %85 %104 None
-OpBranchConditional %383 %84 %85
-%85 = OpLabel
-%384 = OpLoad %ulong %250
-%385 = OpLoad %uint %240
-%386 = OpFunctionCall %ulong %5 %384 %385
-OpStore %219 %386
-%387 = OpLoad %ulong %219
-OpReturnValue %387
-%84 = OpLabel
-%388 = OpLoad %uint %241
-%389 = OpAccessChain %_ptr_Function_float %112 %388
-%390 = OpLoad %uint %240
-OpStore %239 %390
-OpStore %242 %uint_0
-OpBranch %86
-%86 = OpLabel
-%391 = OpLoad %uint %242
-%392 = OpULessThan %bool %391 %uint_12
-OpStore %196 %392
-%393 = OpLoad %bool %196
-OpLoopMerge %88 %103 None
-OpBranchConditional %393 %87 %88
-%88 = OpLabel
-%394 = OpLoad %uint %241
-%395 = OpIAdd %uint %394 %uint_1
-OpStore %218 %395
-%396 = OpLoad %uint %239
-OpStore %240 %396
-%397 = OpLoad %uint %218
-OpStore %241 %397
-OpBranch %104
-%87 = OpLabel
-%398 = OpLoad %float %389
-OpStore %197 %398
-%399 = OpLoad %uint %242
-%400 = OpAccessChain %_ptr_Function_float %112 %399
-%401 = OpLoad %float %400
-OpStore %198 %401
-%402 = OpLoad %float %197
-%403 = OpLoad %float %198
-%404 = OpFOrdLessThan %bool %402 %403
-OpStore %199 %404
-%405 = OpLoad %bool %199
-%408 = OpSelect %uchar %405 %uchar_1 %uchar_0
-%409 = OpUConvert %uint %408
-OpStore %200 %409
-%410 = OpLoad %uint %239
-%411 = OpLoad %uint %200
-%412 = OpIAdd %uint %410 %411
-OpStore %201 %412
-%413 = OpLoad %float %389
-OpStore %202 %413
-%414 = OpLoad %float %400
-OpStore %203 %414
-%415 = OpLoad %float %202
-%416 = OpLoad %float %203
-%417 = OpFOrdLessThanEqual %bool %415 %416
-OpStore %204 %417
-%418 = OpLoad %bool %204
-%419 = OpSelect %uchar %418 %uchar_1 %uchar_0
-%420 = OpUConvert %uint %419
-OpStore %205 %420
-%421 = OpLoad %uint %201
-%422 = OpLoad %uint %205
-%423 = OpIAdd %uint %421 %422
-OpStore %206 %423
-%424 = OpLoad %float %389
-OpStore %207 %424
-%425 = OpLoad %float %400
-OpStore %208 %425
-%426 = OpLoad %float %207
-%427 = OpLoad %float %208
-%428 = OpFOrdEqual %bool %426 %427
-OpStore %209 %428
-%429 = OpLoad %bool %209
-%430 = OpSelect %uchar %429 %uchar_1 %uchar_0
-%431 = OpUConvert %uint %430
-OpStore %210 %431
-%432 = OpLoad %uint %206
-%433 = OpLoad %uint %210
-%434 = OpIAdd %uint %432 %433
-OpStore %211 %434
-%435 = OpLoad %float %389
-OpStore %212 %435
-%436 = OpLoad %float %400
-OpStore %213 %436
-%437 = OpLoad %float %212
-%438 = OpLoad %float %213
-%439 = OpFUnordNotEqual %bool %437 %438
-OpStore %214 %439
-%440 = OpLoad %bool %214
-%441 = OpSelect %uchar %440 %uchar_1 %uchar_0
-%442 = OpUConvert %uint %441
-OpStore %215 %442
-%443 = OpLoad %uint %211
-%444 = OpLoad %uint %215
-%445 = OpIAdd %uint %443 %444
-OpStore %216 %445
-%446 = OpLoad %uint %242
-%447 = OpIAdd %uint %446 %uint_1
-OpStore %217 %447
-%448 = OpLoad %uint %216
-OpStore %239 %448
-%449 = OpLoad %uint %217
-OpStore %242 %449
-OpBranch %103
-%75 = OpLabel
-%450 = OpLoad %uint %238
-%451 = OpAccessChain %_ptr_Function_float %112 %450
-%452 = OpLoad %float %451
-OpStore %188 %452
-%453 = OpLoad %float %188
-%454 = OpLoad %float %235
-%455 = OpFOrdLessThan %bool %453 %454
-OpStore %189 %455
-%456 = OpLoad %bool %189
-OpSelectionMerge %79 None
-OpBranchConditional %456 %77 %78
-%78 = OpLabel
-%457 = OpLoad %float %235
-OpStore %234 %457
-OpBranch %79
-%77 = OpLabel
-%458 = OpLoad %uint %238
-%459 = OpAccessChain %_ptr_Function_float %112 %458
-%460 = OpLoad %float %459
-OpStore %190 %460
-%461 = OpLoad %float %190
-OpStore %234 %461
-OpBranch %79
-%79 = OpLabel
-%462 = OpLoad %uint %238
-%463 = OpAccessChain %_ptr_Function_float %112 %462
-%464 = OpLoad %float %463
-OpStore %191 %464
-%465 = OpLoad %float %237
-%466 = OpLoad %float %191
-%467 = OpFOrdLessThan %bool %465 %466
-OpStore %192 %467
-%468 = OpLoad %bool %192
-OpSelectionMerge %82 None
-OpBranchConditional %468 %80 %81
-%81 = OpLabel
-%469 = OpLoad %float %237
-OpStore %236 %469
-OpBranch %82
-%80 = OpLabel
-%470 = OpLoad %uint %238
-%471 = OpAccessChain %_ptr_Function_float %112 %470
-%472 = OpLoad %float %471
-OpStore %193 %472
-%473 = OpLoad %float %193
-OpStore %236 %473
-OpBranch %82
-%82 = OpLabel
-%474 = OpLoad %uint %238
-%475 = OpIAdd %uint %474 %uint_1
-OpStore %194 %475
-%476 = OpLoad %float %234
-OpStore %235 %476
-%477 = OpLoad %float %236
-OpStore %237 %477
-%478 = OpLoad %uint %194
-OpStore %238 %478
-OpBranch %106
-%43 = OpLabel
-%479 = OpLoad %uint %222
-%480 = OpAccessChain %_ptr_Function_float %112 %479
-%481 = OpLoad %ulong %221
-OpStore %220 %481
-OpStore %223 %uint_0
-OpBranch %45
-%45 = OpLabel
-%482 = OpLoad %uint %223
-%483 = OpULessThan %bool %482 %uint_12
-OpStore %141 %483
-%484 = OpLoad %bool %141
-OpLoopMerge %47 %105 None
-OpBranchConditional %484 %46 %47
-%47 = OpLabel
-%485 = OpLoad %uint %222
-%486 = OpIAdd %uint %485 %uint_1
-OpStore %184 %486
-%487 = OpLoad %ulong %220
-OpStore %221 %487
-%488 = OpLoad %uint %184
-OpStore %222 %488
-OpBranch %107
-%46 = OpLabel
-%489 = OpLoad %float %480
-OpStore %142 %489
-%490 = OpLoad %uint %223
-%491 = OpAccessChain %_ptr_Function_float %112 %490
-%492 = OpLoad %float %491
-OpStore %143 %492
-%493 = OpLoad %float %142
-%494 = OpLoad %float %143
-%495 = OpFOrdEqual %bool %493 %494
-OpStore %144 %495
-%496 = OpLoad %ulong %220
-%497 = OpLoad %bool %144
-%498 = OpSelect %uchar %497 %uchar_1 %uchar_0
-%499 = OpFunctionCall %ulong %4 %496 %498
-OpStore %145 %499
-%500 = OpLoad %float %142
-%501 = OpLoad %float %143
-%502 = OpFUnordNotEqual %bool %500 %501
-OpStore %146 %502
-%503 = OpLoad %ulong %145
-%504 = OpLoad %bool %146
-%505 = OpSelect %uchar %504 %uchar_1 %uchar_0
-%506 = OpFunctionCall %ulong %4 %503 %505
-OpStore %147 %506
-%507 = OpLoad %float %142
-%508 = OpLoad %float %143
-%509 = OpFOrdLessThan %bool %507 %508
-OpStore %148 %509
-%510 = OpLoad %ulong %147
-%511 = OpLoad %bool %148
-%512 = OpSelect %uchar %511 %uchar_1 %uchar_0
-%513 = OpFunctionCall %ulong %4 %510 %512
-OpStore %149 %513
-%514 = OpLoad %float %142
-%515 = OpLoad %float %143
-%516 = OpFOrdLessThanEqual %bool %514 %515
-OpStore %150 %516
-%517 = OpLoad %ulong %149
-%518 = OpLoad %bool %150
-%519 = OpSelect %uchar %518 %uchar_1 %uchar_0
-%520 = OpFunctionCall %ulong %4 %517 %519
-OpStore %151 %520
-%521 = OpLoad %float %143
-%522 = OpLoad %float %142
-%523 = OpFOrdLessThan %bool %521 %522
-OpStore %152 %523
-%524 = OpLoad %ulong %151
-%525 = OpLoad %bool %152
-%526 = OpSelect %uchar %525 %uchar_1 %uchar_0
-%527 = OpFunctionCall %ulong %4 %524 %526
-OpStore %153 %527
-%528 = OpLoad %float %143
-%529 = OpLoad %float %142
-%530 = OpFOrdLessThanEqual %bool %528 %529
-OpStore %154 %530
-%531 = OpLoad %ulong %153
-%532 = OpLoad %bool %154
-%533 = OpSelect %uchar %532 %uchar_1 %uchar_0
-%534 = OpFunctionCall %ulong %4 %531 %533
-OpStore %155 %534
-%535 = OpLoad %bool %148
-OpSelectionMerge %50 None
-OpBranchConditional %535 %48 %49
-%49 = OpLabel
-OpStore %229 %uchar_0
-OpBranch %50
-%48 = OpLabel
-OpStore %229 %uchar_1
-OpBranch %50
-%50 = OpLabel
-%536 = OpLoad %float %142
-%537 = OpLoad %float %143
-%538 = OpFOrdLessThanEqual %bool %536 %537
-OpStore %156 %538
-%539 = OpLoad %bool %156
-OpSelectionMerge %53 None
-OpBranchConditional %539 %51 %52
-%52 = OpLabel
-%540 = OpLoad %uchar %229
-OpStore %228 %540
-OpBranch %53
-%51 = OpLabel
-%541 = OpLoad %uchar %229
-%543 = OpIAdd %uchar %541 %uchar_2
-OpStore %158 %543
-%544 = OpLoad %uchar %158
-OpStore %228 %544
-OpBranch %53
-%53 = OpLabel
-%545 = OpLoad %float %143
-%546 = OpLoad %float %142
-%547 = OpFOrdLessThan %bool %545 %546
-OpStore %159 %547
-%548 = OpLoad %bool %159
-OpSelectionMerge %56 None
-OpBranchConditional %548 %54 %55
-%55 = OpLabel
-%549 = OpLoad %uchar %228
-OpStore %227 %549
-OpBranch %56
-%54 = OpLabel
-%550 = OpLoad %uchar %228
-%552 = OpIAdd %uchar %550 %uchar_4
-OpStore %160 %552
-%553 = OpLoad %uchar %160
-OpStore %227 %553
-OpBranch %56
-%56 = OpLabel
-%554 = OpLoad %float %143
-%555 = OpLoad %float %142
-%556 = OpFOrdLessThanEqual %bool %554 %555
-OpStore %161 %556
-%557 = OpLoad %bool %161
-OpSelectionMerge %59 None
-OpBranchConditional %557 %57 %58
-%58 = OpLabel
-%558 = OpLoad %uchar %227
-OpStore %226 %558
-OpBranch %59
-%57 = OpLabel
-%559 = OpLoad %uchar %227
-%561 = OpIAdd %uchar %559 %uchar_8
-OpStore %162 %561
-%562 = OpLoad %uchar %162
-OpStore %226 %562
-OpBranch %59
-%59 = OpLabel
-%563 = OpLoad %float %142
-%564 = OpLoad %float %143
-%565 = OpFOrdEqual %bool %563 %564
-OpStore %163 %565
-%566 = OpLoad %bool %163
-OpSelectionMerge %62 None
-OpBranchConditional %566 %60 %61
-%61 = OpLabel
-%567 = OpLoad %uchar %226
-OpStore %225 %567
-OpBranch %62
-%60 = OpLabel
-%568 = OpLoad %uchar %226
-%570 = OpIAdd %uchar %568 %uchar_16
-OpStore %164 %570
-%571 = OpLoad %uchar %164
-OpStore %225 %571
-OpBranch %62
-%62 = OpLabel
-%572 = OpLoad %float %142
-%573 = OpLoad %float %143
-%574 = OpFUnordNotEqual %bool %572 %573
-OpStore %165 %574
-%575 = OpLoad %bool %165
-OpSelectionMerge %65 None
-OpBranchConditional %575 %63 %64
-%64 = OpLabel
-%576 = OpLoad %uchar %225
-OpStore %224 %576
-OpBranch %65
-%63 = OpLabel
-%577 = OpLoad %uchar %225
-%579 = OpIAdd %uchar %577 %uchar_32
-OpStore %166 %579
-%580 = OpLoad %uchar %166
-OpStore %224 %580
-OpBranch %65
-%65 = OpLabel
-%581 = OpLoad %ulong %155
-%582 = OpLoad %uchar %224
-%583 = OpFunctionCall %ulong %4 %581 %582
-OpStore %167 %583
-%584 = OpLoad %float %142
-%585 = OpLoad %float %143
-%586 = OpFOrdLessThan %bool %584 %585
-OpStore %168 %586
-%587 = OpLoad %bool %168
-OpSelectionMerge %67 None
-OpBranchConditional %587 %66 %99
-%99 = OpLabel
-%588 = OpLoad %bool %168
-OpStore %230 %588
-OpBranch %67
-%66 = OpLabel
-%589 = OpLoad %float %143
-%590 = OpLoad %float %142
-%591 = OpFOrdLessThan %bool %589 %590
-OpStore %169 %591
-%592 = OpLoad %bool %169
-OpStore %230 %592
-OpBranch %67
-%67 = OpLabel
-%593 = OpLoad %ulong %167
-%594 = OpLoad %bool %230
-%595 = OpSelect %uchar %594 %uchar_1 %uchar_0
-%596 = OpFunctionCall %ulong %4 %593 %595
-OpStore %170 %596
-%597 = OpLoad %float %142
-%598 = OpLoad %float %143
-%599 = OpFOrdLessThan %bool %597 %598
-OpStore %171 %599
-%600 = OpLoad %bool %171
-OpSelectionMerge %69 None
-OpBranchConditional %600 %100 %68
-%68 = OpLabel
-%601 = OpLoad %float %143
-%602 = OpLoad %float %142
-%603 = OpFOrdLessThan %bool %601 %602
-OpStore %172 %603
-%604 = OpLoad %bool %172
-OpStore %231 %604
-OpBranch %69
-%100 = OpLabel
-%605 = OpLoad %bool %171
-OpStore %231 %605
-OpBranch %69
-%69 = OpLabel
-%606 = OpLoad %ulong %170
-%607 = OpLoad %bool %231
-%608 = OpSelect %uchar %607 %uchar_1 %uchar_0
-%609 = OpFunctionCall %ulong %4 %606 %608
-OpStore %173 %609
-%610 = OpLoad %float %142
-%611 = OpLoad %float %143
-%612 = OpFOrdLessThan %bool %610 %611
-OpStore %174 %612
-%613 = OpLoad %bool %174
-%614 = OpSelect %uchar %613 %uchar_1 %uchar_0
-%615 = OpINotEqual %bool %614 %uchar_1
-OpStore %175 %615
-%616 = OpLoad %ulong %173
-%617 = OpLoad %bool %175
-%618 = OpSelect %uchar %617 %uchar_1 %uchar_0
-%619 = OpFunctionCall %ulong %4 %616 %618
-OpStore %176 %619
-%620 = OpLoad %float %142
-%621 = OpLoad %float %142
-%622 = OpFOrdEqual %bool %620 %621
-OpStore %177 %622
-%623 = OpLoad %bool %177
-OpSelectionMerge %71 None
-OpBranchConditional %623 %70 %101
-%101 = OpLabel
-%624 = OpLoad %bool %177
-OpStore %232 %624
-OpBranch %71
-%70 = OpLabel
-%625 = OpLoad %float %143
-%626 = OpLoad %float %143
-%627 = OpFOrdEqual %bool %625 %626
-OpStore %178 %627
-%628 = OpLoad %bool %178
-OpStore %232 %628
-OpBranch %71
-%71 = OpLabel
-%629 = OpLoad %ulong %176
-%630 = OpLoad %bool %232
-%631 = OpSelect %uchar %630 %uchar_1 %uchar_0
-%632 = OpFunctionCall %ulong %4 %629 %631
-OpStore %179 %632
-%633 = OpLoad %float %142
-%634 = OpLoad %float %142
-%635 = OpFUnordNotEqual %bool %633 %634
-OpStore %180 %635
-%636 = OpLoad %bool %180
-OpSelectionMerge %73 None
-OpBranchConditional %636 %102 %72
-%72 = OpLabel
-%637 = OpLoad %float %143
-%638 = OpLoad %float %143
-%639 = OpFUnordNotEqual %bool %637 %638
-OpStore %181 %639
-%640 = OpLoad %bool %181
-OpStore %233 %640
-OpBranch %73
-%102 = OpLabel
-%641 = OpLoad %bool %180
-OpStore %233 %641
-OpBranch %73
-%73 = OpLabel
-%642 = OpLoad %ulong %179
-%643 = OpLoad %bool %233
-%644 = OpSelect %uchar %643 %uchar_1 %uchar_0
-%645 = OpFunctionCall %ulong %4 %642 %644
-OpStore %182 %645
-%646 = OpLoad %uint %223
-%647 = OpIAdd %uint %646 %uint_1
-OpStore %183 %647
-%648 = OpLoad %ulong %182
-OpStore %220 %648
-%649 = OpLoad %uint %183
-OpStore %223 %649
-OpBranch %105
-%103 = OpLabel
-OpBranch %86
-%104 = OpLabel
-OpBranch %83
-%105 = OpLabel
-OpBranch %45
-%106 = OpLabel
-OpBranch %74
-%107 = OpLabel
-OpBranch %42
-OpFunctionEnd
-%3 = OpFunction %ulong None %650
-%651 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %653
-%654 = OpFunctionParameter %ulong
-%655 = OpFunctionParameter %uchar
-%656 = OpLabel
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_uchar Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_bool Function
-%667 = OpVariable %_ptr_Function_ulong Function
-%668 = OpVariable %_ptr_Function_ulong Function
-%669 = OpVariable %_ptr_Function_ulong Function
-%670 = OpVariable %_ptr_Function_ulong Function
-%671 = OpVariable %_ptr_Function_ulong Function
-%672 = OpVariable %_ptr_Function_ulong Function
-%673 = OpVariable %_ptr_Function_ulong Function
-%674 = OpVariable %_ptr_Function_ulong Function
-OpStore %663 %654
-OpStore %664 %655
-%675 = OpLoad %uchar %664
-%676 = OpUConvert %ulong %675
-OpStore %665 %676
-OpBranch %657
-%657 = OpLabel
-%677 = OpLoad %ulong %663
-OpStore %673 %677
-OpStore %674 %ulong_0
-OpBranch %658
-%658 = OpLabel
-%679 = OpLoad %ulong %674
-%681 = OpULessThan %bool %679 %ulong_8
-OpStore %666 %681
-%682 = OpLoad %bool %666
-OpLoopMerge %660 %662 None
-OpBranchConditional %682 %659 %660
-%660 = OpLabel
-OpBranch %661
-%661 = OpLabel
-%683 = OpLoad %ulong %673
-OpReturnValue %683
-%659 = OpLabel
-%684 = OpLoad %ulong %674
-%685 = OpIMul %ulong %684 %ulong_8
-OpStore %667 %685
-%686 = OpLoad %ulong %665
-%687 = OpLoad %ulong %667
-%688 = OpShiftRightLogical %ulong %686 %687
-OpStore %668 %688
-%689 = OpLoad %ulong %668
-%691 = OpBitwiseAnd %ulong %689 %ulong_255
-OpStore %669 %691
-%692 = OpLoad %ulong %673
-%693 = OpLoad %ulong %669
-%694 = OpBitwiseXor %ulong %692 %693
-OpStore %670 %694
-%695 = OpLoad %ulong %670
-%697 = OpIMul %ulong %695 %ulong_1099511628211
-OpStore %671 %697
-%698 = OpLoad %ulong %674
-%700 = OpIAdd %ulong %698 %ulong_1
-OpStore %672 %700
-%701 = OpLoad %ulong %671
-OpStore %673 %701
-%702 = OpLoad %ulong %672
-OpStore %674 %702
-OpBranch %662
-%662 = OpLabel
-OpBranch %658
-OpFunctionEnd
-%5 = OpFunction %ulong None %703
-%704 = OpFunctionParameter %ulong
-%705 = OpFunctionParameter %uint
-%706 = OpLabel
-%713 = OpVariable %_ptr_Function_ulong Function
-%714 = OpVariable %_ptr_Function_uint Function
-%715 = OpVariable %_ptr_Function_ulong Function
-%716 = OpVariable %_ptr_Function_bool Function
-%717 = OpVariable %_ptr_Function_ulong Function
-%718 = OpVariable %_ptr_Function_ulong Function
-%719 = OpVariable %_ptr_Function_ulong Function
-%720 = OpVariable %_ptr_Function_ulong Function
-%721 = OpVariable %_ptr_Function_ulong Function
-%722 = OpVariable %_ptr_Function_ulong Function
-%723 = OpVariable %_ptr_Function_ulong Function
-%724 = OpVariable %_ptr_Function_ulong Function
-OpStore %713 %704
-OpStore %714 %705
-%725 = OpLoad %uint %714
-%726 = OpUConvert %ulong %725
-OpStore %715 %726
-OpBranch %707
-%707 = OpLabel
-%727 = OpLoad %ulong %713
-OpStore %723 %727
-OpStore %724 %ulong_0
-OpBranch %708
-%708 = OpLabel
-%728 = OpLoad %ulong %724
-%729 = OpULessThan %bool %728 %ulong_8
-OpStore %716 %729
-%730 = OpLoad %bool %716
-OpLoopMerge %710 %712 None
-OpBranchConditional %730 %709 %710
-%710 = OpLabel
-OpBranch %711
-%711 = OpLabel
-%731 = OpLoad %ulong %723
-OpReturnValue %731
-%709 = OpLabel
-%732 = OpLoad %ulong %724
-%733 = OpIMul %ulong %732 %ulong_8
-OpStore %717 %733
-%734 = OpLoad %ulong %715
-%735 = OpLoad %ulong %717
-%736 = OpShiftRightLogical %ulong %734 %735
-OpStore %718 %736
-%737 = OpLoad %ulong %718
-%738 = OpBitwiseAnd %ulong %737 %ulong_255
-OpStore %719 %738
-%739 = OpLoad %ulong %723
-%740 = OpLoad %ulong %719
-%741 = OpBitwiseXor %ulong %739 %740
-OpStore %720 %741
-%742 = OpLoad %ulong %720
-%743 = OpIMul %ulong %742 %ulong_1099511628211
-OpStore %721 %743
-%744 = OpLoad %ulong %724
-%745 = OpIAdd %ulong %744 %ulong_1
-OpStore %722 %745
-%746 = OpLoad %ulong %721
-OpStore %723 %746
-%747 = OpLoad %ulong %722
-OpStore %724 %747
-OpBranch %712
-%712 = OpLabel
-OpBranch %708
-OpFunctionEnd
-%6 = OpFunction %ulong None %9
-%748 = OpFunctionParameter %ulong
-%749 = OpFunctionParameter %float
-%750 = OpLabel
-%757 = OpVariable %_ptr_Function_ulong Function
-%758 = OpVariable %_ptr_Function_float Function
-%759 = OpVariable %_ptr_Function_uint Function
-%760 = OpVariable %_ptr_Function_ulong Function
-%761 = OpVariable %_ptr_Function_bool Function
-%762 = OpVariable %_ptr_Function_ulong Function
-%763 = OpVariable %_ptr_Function_ulong Function
-%764 = OpVariable %_ptr_Function_ulong Function
-%765 = OpVariable %_ptr_Function_ulong Function
-%766 = OpVariable %_ptr_Function_ulong Function
-%767 = OpVariable %_ptr_Function_ulong Function
-%768 = OpVariable %_ptr_Function_ulong Function
-%769 = OpVariable %_ptr_Function_ulong Function
-OpStore %757 %748
-OpStore %758 %749
-%770 = OpLoad %float %758
-%771 = OpBitcast %uint %770
-OpStore %759 %771
-%772 = OpLoad %uint %759
-%773 = OpUConvert %ulong %772
-OpStore %760 %773
-OpBranch %751
-%751 = OpLabel
-%774 = OpLoad %ulong %757
-OpStore %768 %774
-OpStore %769 %ulong_0
-OpBranch %752
-%752 = OpLabel
-%775 = OpLoad %ulong %769
-%776 = OpULessThan %bool %775 %ulong_8
-OpStore %761 %776
-%777 = OpLoad %bool %761
-OpLoopMerge %754 %756 None
-OpBranchConditional %777 %753 %754
-%754 = OpLabel
-OpBranch %755
-%755 = OpLabel
-%778 = OpLoad %ulong %768
-OpReturnValue %778
-%753 = OpLabel
-%779 = OpLoad %ulong %769
-%780 = OpIMul %ulong %779 %ulong_8
-OpStore %762 %780
-%781 = OpLoad %ulong %760
-%782 = OpLoad %ulong %762
-%783 = OpShiftRightLogical %ulong %781 %782
-OpStore %763 %783
-%784 = OpLoad %ulong %763
-%785 = OpBitwiseAnd %ulong %784 %ulong_255
-OpStore %764 %785
-%786 = OpLoad %ulong %768
-%787 = OpLoad %ulong %764
-%788 = OpBitwiseXor %ulong %786 %787
-OpStore %765 %788
-%789 = OpLoad %ulong %765
-%790 = OpIMul %ulong %789 %ulong_1099511628211
-OpStore %766 %790
-%791 = OpLoad %ulong %769
-%792 = OpIAdd %ulong %791 %ulong_1
-OpStore %767 %792
-%793 = OpLoad %ulong %766
-OpStore %768 %793
-%794 = OpLoad %ulong %767
-OpStore %769 %794
-OpBranch %756
-%756 = OpLabel
-OpBranch %752
+%2 = OpFunction %ulong None %113
+%114 = OpFunctionParameter %ulong
+%115 = OpLabel
+%282 = OpVariable %_ptr_Function__arr_float_uint_12 Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_uint Function
+%285 = OpVariable %_ptr_Function_uint Function
+%286 = OpVariable %_ptr_Function_float Function
+%287 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_float Function
+%289 = OpVariable %_ptr_Function_uint Function
+%290 = OpVariable %_ptr_Function_float Function
+%291 = OpVariable %_ptr_Function_uint Function
+%292 = OpVariable %_ptr_Function_float Function
+%293 = OpVariable %_ptr_Function_uint Function
+%294 = OpVariable %_ptr_Function_float Function
+%295 = OpVariable %_ptr_Function_float Function
+%296 = OpVariable %_ptr_Function_uint Function
+%297 = OpVariable %_ptr_Function_float Function
+%298 = OpVariable %_ptr_Function_uint Function
+%299 = OpVariable %_ptr_Function_float Function
+%300 = OpVariable %_ptr_Function_uint Function
+%301 = OpVariable %_ptr_Function_float Function
+%302 = OpVariable %_ptr_Function_uint Function
+%303 = OpVariable %_ptr_Function_float Function
+%304 = OpVariable %_ptr_Function_uint Function
+%305 = OpVariable %_ptr_Function_float Function
+%306 = OpVariable %_ptr_Function_uint Function
+%307 = OpVariable %_ptr_Function_float Function
+%308 = OpVariable %_ptr_Function_bool Function
+%309 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_float Function
+%311 = OpVariable %_ptr_Function_float Function
+%312 = OpVariable %_ptr_Function_bool Function
+%313 = OpVariable %_ptr_Function_bool Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_bool Function
+%316 = OpVariable %_ptr_Function_bool Function
+%317 = OpVariable %_ptr_Function_bool Function
+%318 = OpVariable %_ptr_Function_bool Function
+%319 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_uchar Function
+%322 = OpVariable %_ptr_Function_bool Function
+%323 = OpVariable %_ptr_Function_uchar Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_uchar Function
+%326 = OpVariable %_ptr_Function_bool Function
+%327 = OpVariable %_ptr_Function_uchar Function
+%328 = OpVariable %_ptr_Function_bool Function
+%329 = OpVariable %_ptr_Function_uchar Function
+%330 = OpVariable %_ptr_Function_bool Function
+%331 = OpVariable %_ptr_Function_bool Function
+%332 = OpVariable %_ptr_Function_bool Function
+%333 = OpVariable %_ptr_Function_bool Function
+%334 = OpVariable %_ptr_Function_bool Function
+%335 = OpVariable %_ptr_Function_bool Function
+%336 = OpVariable %_ptr_Function_bool Function
+%337 = OpVariable %_ptr_Function_bool Function
+%338 = OpVariable %_ptr_Function_bool Function
+%339 = OpVariable %_ptr_Function_bool Function
+%340 = OpVariable %_ptr_Function_uint Function
+%341 = OpVariable %_ptr_Function_uint Function
+%342 = OpVariable %_ptr_Function_float Function
+%343 = OpVariable %_ptr_Function_float Function
+%344 = OpVariable %_ptr_Function_bool Function
+%345 = OpVariable %_ptr_Function_float Function
+%346 = OpVariable %_ptr_Function_bool Function
+%347 = OpVariable %_ptr_Function_float Function
+%348 = OpVariable %_ptr_Function_float Function
+%349 = OpVariable %_ptr_Function_bool Function
+%350 = OpVariable %_ptr_Function_float Function
+%351 = OpVariable %_ptr_Function_uint Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_bool Function
+%355 = OpVariable %_ptr_Function_bool Function
+%356 = OpVariable %_ptr_Function_float Function
+%357 = OpVariable %_ptr_Function_float Function
+%358 = OpVariable %_ptr_Function_bool Function
+%359 = OpVariable %_ptr_Function_uint Function
+%360 = OpVariable %_ptr_Function_uint Function
+%361 = OpVariable %_ptr_Function_float Function
+%362 = OpVariable %_ptr_Function_float Function
+%363 = OpVariable %_ptr_Function_bool Function
+%364 = OpVariable %_ptr_Function_uint Function
+%365 = OpVariable %_ptr_Function_uint Function
+%366 = OpVariable %_ptr_Function_float Function
+%367 = OpVariable %_ptr_Function_float Function
+%368 = OpVariable %_ptr_Function_bool Function
+%369 = OpVariable %_ptr_Function_uint Function
+%370 = OpVariable %_ptr_Function_uint Function
+%371 = OpVariable %_ptr_Function_float Function
+%372 = OpVariable %_ptr_Function_float Function
+%373 = OpVariable %_ptr_Function_bool Function
+%374 = OpVariable %_ptr_Function_uint Function
+%375 = OpVariable %_ptr_Function_uint Function
+%376 = OpVariable %_ptr_Function_uint Function
+%377 = OpVariable %_ptr_Function_uint Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_uint Function
+%381 = OpVariable %_ptr_Function_uint Function
+%382 = OpVariable %_ptr_Function_uchar Function
+%383 = OpVariable %_ptr_Function_uchar Function
+%384 = OpVariable %_ptr_Function_uchar Function
+%385 = OpVariable %_ptr_Function_uchar Function
+%386 = OpVariable %_ptr_Function_uchar Function
+%387 = OpVariable %_ptr_Function_uchar Function
+%388 = OpVariable %_ptr_Function_bool Function
+%389 = OpVariable %_ptr_Function_bool Function
+%390 = OpVariable %_ptr_Function_bool Function
+%391 = OpVariable %_ptr_Function_bool Function
+%392 = OpVariable %_ptr_Function_float Function
+%393 = OpVariable %_ptr_Function_float Function
+%394 = OpVariable %_ptr_Function_float Function
+%395 = OpVariable %_ptr_Function_float Function
+%396 = OpVariable %_ptr_Function_uint Function
+%397 = OpVariable %_ptr_Function_uint Function
+%398 = OpVariable %_ptr_Function_uint Function
+%399 = OpVariable %_ptr_Function_uint Function
+%400 = OpVariable %_ptr_Function_uint Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_bool Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_bool Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_bool Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_bool Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_bool Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_bool Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_bool Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_bool Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_bool Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_bool Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_bool Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+OpStore %283 %114
+OpBranch %163
+%163 = OpLabel
+OpBranch %164
+%164 = OpLabel
+%531 = OpLoad %ulong %283
+%532 = OpUConvert %uint %531
+OpStore %284 %532
+OpStore %282 %533
+%535 = OpLoad %uint %284
+%536 = OpIAdd %uint %uint_4286578688 %535
+OpStore %285 %536
+%537 = OpLoad %uint %285
+%538 = OpBitcast %float %537
+OpStore %286 %538
+%540 = OpAccessChain %_ptr_Function_float %282 %uint_0
+%541 = OpLoad %float %286
+OpStore %540 %541
+%543 = OpLoad %uint %284
+%544 = OpIAdd %uint %uint_3212836864 %543
+OpStore %287 %544
+%545 = OpLoad %uint %287
+%546 = OpBitcast %float %545
+OpStore %288 %546
+%548 = OpAccessChain %_ptr_Function_float %282 %uint_1
+%549 = OpLoad %float %288
+OpStore %548 %549
+%551 = OpLoad %uint %284
+%552 = OpIAdd %uint %uint_2155872256 %551
+OpStore %289 %552
+%553 = OpLoad %uint %289
+%554 = OpBitcast %float %553
+OpStore %290 %554
+%556 = OpAccessChain %_ptr_Function_float %282 %uint_2
+%557 = OpLoad %float %290
+OpStore %556 %557
+%559 = OpLoad %uint %284
+%560 = OpIAdd %uint %uint_2147483649 %559
+OpStore %291 %560
+%561 = OpLoad %uint %291
+%562 = OpBitcast %float %561
+OpStore %292 %562
+%564 = OpAccessChain %_ptr_Function_float %282 %uint_3
+%565 = OpLoad %float %292
+OpStore %564 %565
+%567 = OpLoad %uint %284
+%568 = OpIAdd %uint %uint_2147483648 %567
+OpStore %293 %568
+%569 = OpLoad %uint %293
+%570 = OpBitcast %float %569
+OpStore %294 %570
+%572 = OpAccessChain %_ptr_Function_float %282 %uint_4
+%573 = OpLoad %float %294
+OpStore %572 %573
+%574 = OpLoad %uint %284
+%575 = OpBitcast %float %574
+OpStore %295 %575
+%577 = OpAccessChain %_ptr_Function_float %282 %uint_5
+%578 = OpLoad %float %295
+OpStore %577 %578
+%579 = OpLoad %uint %284
+%580 = OpIAdd %uint %uint_1 %579
+OpStore %296 %580
+%581 = OpLoad %uint %296
+%582 = OpBitcast %float %581
+OpStore %297 %582
+%584 = OpAccessChain %_ptr_Function_float %282 %uint_6
+%585 = OpLoad %float %297
+OpStore %584 %585
+%587 = OpLoad %uint %284
+%588 = OpIAdd %uint %uint_1065353216 %587
+OpStore %298 %588
+%589 = OpLoad %uint %298
+%590 = OpBitcast %float %589
+OpStore %299 %590
+%592 = OpAccessChain %_ptr_Function_float %282 %uint_7
+%593 = OpLoad %float %299
+OpStore %592 %593
+%595 = OpLoad %uint %284
+%596 = OpIAdd %uint %uint_2139095039 %595
+OpStore %300 %596
+%597 = OpLoad %uint %300
+%598 = OpBitcast %float %597
+OpStore %301 %598
+%600 = OpAccessChain %_ptr_Function_float %282 %uint_8
+%601 = OpLoad %float %301
+OpStore %600 %601
+%603 = OpLoad %uint %284
+%604 = OpIAdd %uint %uint_2139095040 %603
+OpStore %302 %604
+%605 = OpLoad %uint %302
+%606 = OpBitcast %float %605
+OpStore %303 %606
+%608 = OpAccessChain %_ptr_Function_float %282 %uint_9
+%609 = OpLoad %float %303
+OpStore %608 %609
+%611 = OpLoad %uint %284
+%612 = OpIAdd %uint %uint_2143289344 %611
+OpStore %304 %612
+%613 = OpLoad %uint %304
+%614 = OpBitcast %float %613
+OpStore %305 %614
+%616 = OpAccessChain %_ptr_Function_float %282 %uint_10
+%617 = OpLoad %float %305
+OpStore %616 %617
+%619 = OpLoad %uint %284
+%620 = OpIAdd %uint %uint_2139095041 %619
+OpStore %306 %620
+%621 = OpLoad %uint %306
+%622 = OpBitcast %float %621
+OpStore %307 %622
+%624 = OpAccessChain %_ptr_Function_float %282 %uint_11
+%625 = OpLoad %float %307
+OpStore %624 %625
+OpStore %379 %ulong_14695981039346656037
+OpStore %380 %uint_0
+OpBranch %116
+%116 = OpLabel
+%627 = OpLoad %uint %380
+%628 = OpULessThan %bool %627 %uint_12
+OpStore %308 %628
+%629 = OpLoad %bool %308
+OpLoopMerge %118 %277 None
+OpBranchConditional %629 %117 %118
+%118 = OpLabel
+%630 = OpAccessChain %_ptr_Function_float %282 %uint_0
+%631 = OpLoad %float %630
+OpStore %342 %631
+%632 = OpLoad %float %630
+OpStore %343 %632
+%633 = OpLoad %float %342
+OpStore %393 %633
+%634 = OpLoad %float %343
+OpStore %395 %634
+OpStore %396 %uint_1
+OpBranch %148
+%148 = OpLabel
+%635 = OpLoad %uint %396
+%636 = OpULessThan %bool %635 %uint_12
+OpStore %344 %636
+%637 = OpLoad %bool %344
+OpLoopMerge %150 %276 None
+OpBranchConditional %637 %149 %150
+%150 = OpLabel
+%638 = OpLoad %ulong %379
+%639 = OpLoad %float %393
+%640 = OpFunctionCall %ulong %1 %638 %639
+OpStore %352 %640
+%641 = OpLoad %ulong %352
+%642 = OpLoad %float %395
+%643 = OpFunctionCall %ulong %1 %641 %642
+OpStore %353 %643
+OpStore %398 %uint_0
+OpStore %399 %uint_0
+OpBranch %157
+%157 = OpLabel
+%644 = OpLoad %uint %399
+%645 = OpULessThan %bool %644 %uint_12
+OpStore %354 %645
+%646 = OpLoad %bool %354
+OpLoopMerge %159 %274 None
+OpBranchConditional %646 %158 %159
+%159 = OpLabel
+OpBranch %177
+%177 = OpLabel
+%647 = OpLoad %uint %398
+%648 = OpUConvert %ulong %647
+OpStore %407 %648
+OpBranch %213
+%213 = OpLabel
+%649 = OpLoad %ulong %353
+OpStore %471 %649
+OpStore %472 %ulong_0
+OpBranch %214
+%214 = OpLabel
+%650 = OpLoad %ulong %472
+%651 = OpULessThan %bool %650 %ulong_8
+OpStore %464 %651
+%652 = OpLoad %bool %464
+OpLoopMerge %216 %271 None
+OpBranchConditional %652 %215 %216
+%216 = OpLabel
+OpBranch %217
+%217 = OpLabel
+OpBranch %178
+%178 = OpLabel
+%653 = OpLoad %ulong %471
+OpReturnValue %653
+%215 = OpLabel
+%654 = OpLoad %ulong %472
+%655 = OpIMul %ulong %654 %ulong_8
+OpStore %465 %655
+%656 = OpLoad %ulong %407
+%657 = OpLoad %ulong %465
+%658 = OpShiftRightLogical %ulong %656 %657
+OpStore %466 %658
+%659 = OpLoad %ulong %466
+%660 = OpBitwiseAnd %ulong %659 %ulong_255
+OpStore %467 %660
+%661 = OpLoad %ulong %471
+%662 = OpLoad %ulong %467
+%663 = OpBitwiseXor %ulong %661 %662
+OpStore %468 %663
+%664 = OpLoad %ulong %468
+%665 = OpIMul %ulong %664 %ulong_1099511628211
+OpStore %469 %665
+%666 = OpLoad %ulong %472
+%667 = OpIAdd %ulong %666 %ulong_1
+OpStore %470 %667
+%668 = OpLoad %ulong %469
+OpStore %471 %668
+%669 = OpLoad %ulong %470
+OpStore %472 %669
+OpBranch %271
+%158 = OpLabel
+%670 = OpLoad %uint %399
+%671 = OpAccessChain %_ptr_Function_float %282 %670
+%672 = OpLoad %uint %398
+OpStore %397 %672
+OpStore %400 %uint_0
+OpBranch %160
+%160 = OpLabel
+%673 = OpLoad %uint %400
+%674 = OpULessThan %bool %673 %uint_12
+OpStore %355 %674
+%675 = OpLoad %bool %355
+OpLoopMerge %162 %272 None
+OpBranchConditional %675 %161 %162
+%162 = OpLabel
+%676 = OpLoad %uint %399
+%677 = OpIAdd %uint %676 %uint_1
+OpStore %377 %677
+%678 = OpLoad %uint %397
+OpStore %398 %678
+%679 = OpLoad %uint %377
+OpStore %399 %679
+OpBranch %274
+%161 = OpLabel
+%680 = OpLoad %float %671
+OpStore %356 %680
+%681 = OpLoad %uint %400
+%682 = OpAccessChain %_ptr_Function_float %282 %681
+%683 = OpLoad %float %682
+OpStore %357 %683
+%684 = OpLoad %float %356
+%685 = OpLoad %float %357
+%686 = OpFOrdLessThan %bool %684 %685
+OpStore %358 %686
+%687 = OpLoad %bool %358
+%690 = OpSelect %uchar %687 %uchar_1 %uchar_0
+%691 = OpUConvert %uint %690
+OpStore %359 %691
+%692 = OpLoad %uint %397
+%693 = OpLoad %uint %359
+%694 = OpIAdd %uint %692 %693
+OpStore %360 %694
+%695 = OpLoad %float %671
+OpStore %361 %695
+%696 = OpLoad %float %682
+OpStore %362 %696
+%697 = OpLoad %float %361
+%698 = OpLoad %float %362
+%699 = OpFOrdLessThanEqual %bool %697 %698
+OpStore %363 %699
+%700 = OpLoad %bool %363
+%701 = OpSelect %uchar %700 %uchar_1 %uchar_0
+%702 = OpUConvert %uint %701
+OpStore %364 %702
+%703 = OpLoad %uint %360
+%704 = OpLoad %uint %364
+%705 = OpIAdd %uint %703 %704
+OpStore %365 %705
+%706 = OpLoad %float %671
+OpStore %366 %706
+%707 = OpLoad %float %682
+OpStore %367 %707
+%708 = OpLoad %float %366
+%709 = OpLoad %float %367
+%710 = OpFOrdEqual %bool %708 %709
+OpStore %368 %710
+%711 = OpLoad %bool %368
+%712 = OpSelect %uchar %711 %uchar_1 %uchar_0
+%713 = OpUConvert %uint %712
+OpStore %369 %713
+%714 = OpLoad %uint %365
+%715 = OpLoad %uint %369
+%716 = OpIAdd %uint %714 %715
+OpStore %370 %716
+%717 = OpLoad %float %671
+OpStore %371 %717
+%718 = OpLoad %float %682
+OpStore %372 %718
+%719 = OpLoad %float %371
+%720 = OpLoad %float %372
+%721 = OpFUnordNotEqual %bool %719 %720
+OpStore %373 %721
+%722 = OpLoad %bool %373
+%723 = OpSelect %uchar %722 %uchar_1 %uchar_0
+%724 = OpUConvert %uint %723
+OpStore %374 %724
+%725 = OpLoad %uint %370
+%726 = OpLoad %uint %374
+%727 = OpIAdd %uint %725 %726
+OpStore %375 %727
+%728 = OpLoad %uint %400
+%729 = OpIAdd %uint %728 %uint_1
+OpStore %376 %729
+%730 = OpLoad %uint %375
+OpStore %397 %730
+%731 = OpLoad %uint %376
+OpStore %400 %731
+OpBranch %272
+%149 = OpLabel
+%732 = OpLoad %uint %396
+%733 = OpAccessChain %_ptr_Function_float %282 %732
+%734 = OpLoad %float %733
+OpStore %345 %734
+%735 = OpLoad %float %345
+%736 = OpLoad %float %393
+%737 = OpFOrdLessThan %bool %735 %736
+OpStore %346 %737
+%738 = OpLoad %bool %346
+OpSelectionMerge %153 None
+OpBranchConditional %738 %151 %152
+%152 = OpLabel
+%739 = OpLoad %float %393
+OpStore %392 %739
+OpBranch %153
+%151 = OpLabel
+%740 = OpLoad %uint %396
+%741 = OpAccessChain %_ptr_Function_float %282 %740
+%742 = OpLoad %float %741
+OpStore %347 %742
+%743 = OpLoad %float %347
+OpStore %392 %743
+OpBranch %153
+%153 = OpLabel
+%744 = OpLoad %uint %396
+%745 = OpAccessChain %_ptr_Function_float %282 %744
+%746 = OpLoad %float %745
+OpStore %348 %746
+%747 = OpLoad %float %395
+%748 = OpLoad %float %348
+%749 = OpFOrdLessThan %bool %747 %748
+OpStore %349 %749
+%750 = OpLoad %bool %349
+OpSelectionMerge %156 None
+OpBranchConditional %750 %154 %155
+%155 = OpLabel
+%751 = OpLoad %float %395
+OpStore %394 %751
+OpBranch %156
+%154 = OpLabel
+%752 = OpLoad %uint %396
+%753 = OpAccessChain %_ptr_Function_float %282 %752
+%754 = OpLoad %float %753
+OpStore %350 %754
+%755 = OpLoad %float %350
+OpStore %394 %755
+OpBranch %156
+%156 = OpLabel
+%756 = OpLoad %uint %396
+%757 = OpIAdd %uint %756 %uint_1
+OpStore %351 %757
+%758 = OpLoad %float %392
+OpStore %393 %758
+%759 = OpLoad %float %394
+OpStore %395 %759
+%760 = OpLoad %uint %351
+OpStore %396 %760
+OpBranch %276
+%117 = OpLabel
+%761 = OpLoad %uint %380
+%762 = OpAccessChain %_ptr_Function_float %282 %761
+%763 = OpLoad %ulong %379
+OpStore %378 %763
+OpStore %381 %uint_0
+OpBranch %119
+%119 = OpLabel
+%764 = OpLoad %uint %381
+%765 = OpULessThan %bool %764 %uint_12
+OpStore %309 %765
+%766 = OpLoad %bool %309
+OpLoopMerge %121 %275 None
+OpBranchConditional %766 %120 %121
+%121 = OpLabel
+%767 = OpLoad %uint %380
+%768 = OpIAdd %uint %767 %uint_1
+OpStore %341 %768
+%769 = OpLoad %ulong %378
+OpStore %379 %769
+%770 = OpLoad %uint %341
+OpStore %380 %770
+OpBranch %277
+%120 = OpLabel
+%771 = OpLoad %float %762
+OpStore %310 %771
+%772 = OpLoad %uint %381
+%773 = OpAccessChain %_ptr_Function_float %282 %772
+%774 = OpLoad %float %773
+OpStore %311 %774
+%775 = OpLoad %float %310
+%776 = OpLoad %float %311
+%777 = OpFOrdEqual %bool %775 %776
+OpStore %312 %777
+OpBranch %165
+%165 = OpLabel
+%778 = OpLoad %bool %312
+%779 = OpSelect %uchar %778 %uchar_1 %uchar_0
+%780 = OpUConvert %ulong %779
+OpStore %401 %780
+OpBranch %179
+%179 = OpLabel
+%781 = OpLoad %ulong %378
+OpStore %415 %781
+OpStore %416 %ulong_0
+OpBranch %180
+%180 = OpLabel
+%782 = OpLoad %ulong %416
+%783 = OpULessThan %bool %782 %ulong_8
+OpStore %408 %783
+%784 = OpLoad %bool %408
+OpLoopMerge %182 %273 None
+OpBranchConditional %784 %181 %182
+%182 = OpLabel
+OpBranch %183
+%183 = OpLabel
+OpBranch %166
+%166 = OpLabel
+%785 = OpLoad %float %310
+%786 = OpLoad %float %311
+%787 = OpFUnordNotEqual %bool %785 %786
+OpStore %313 %787
+OpBranch %184
+%184 = OpLabel
+%788 = OpLoad %bool %313
+%789 = OpSelect %uchar %788 %uchar_1 %uchar_0
+%790 = OpUConvert %ulong %789
+OpStore %417 %790
+OpBranch %218
+%218 = OpLabel
+%791 = OpLoad %ulong %415
+OpStore %480 %791
+OpStore %481 %ulong_0
+OpBranch %219
+%219 = OpLabel
+%792 = OpLoad %ulong %481
+%793 = OpULessThan %bool %792 %ulong_8
+OpStore %473 %793
+%794 = OpLoad %bool %473
+OpLoopMerge %221 %270 None
+OpBranchConditional %794 %220 %221
+%221 = OpLabel
+OpBranch %222
+%222 = OpLabel
+OpBranch %185
+%185 = OpLabel
+%795 = OpLoad %float %310
+%796 = OpLoad %float %311
+%797 = OpFOrdLessThan %bool %795 %796
+OpStore %314 %797
+OpBranch %223
+%223 = OpLabel
+%798 = OpLoad %bool %314
+%799 = OpSelect %uchar %798 %uchar_1 %uchar_0
+%800 = OpUConvert %ulong %799
+OpStore %482 %800
+OpBranch %230
+%230 = OpLabel
+%801 = OpLoad %ulong %480
+OpStore %499 %801
+OpStore %500 %ulong_0
+OpBranch %231
+%231 = OpLabel
+%802 = OpLoad %ulong %500
+%803 = OpULessThan %bool %802 %ulong_8
+OpStore %492 %803
+%804 = OpLoad %bool %492
+OpLoopMerge %233 %269 None
+OpBranchConditional %804 %232 %233
+%233 = OpLabel
+OpBranch %234
+%234 = OpLabel
+OpBranch %224
+%224 = OpLabel
+%805 = OpLoad %float %310
+%806 = OpLoad %float %311
+%807 = OpFOrdLessThanEqual %bool %805 %806
+OpStore %315 %807
+OpBranch %235
+%235 = OpLabel
+%808 = OpLoad %bool %315
+%809 = OpSelect %uchar %808 %uchar_1 %uchar_0
+%810 = OpUConvert %ulong %809
+OpStore %501 %810
+OpBranch %237
+%237 = OpLabel
+%811 = OpLoad %ulong %499
+OpStore %509 %811
+OpStore %510 %ulong_0
+OpBranch %238
+%238 = OpLabel
+%812 = OpLoad %ulong %510
+%813 = OpULessThan %bool %812 %ulong_8
+OpStore %502 %813
+%814 = OpLoad %bool %502
+OpLoopMerge %240 %268 None
+OpBranchConditional %814 %239 %240
+%240 = OpLabel
+OpBranch %241
+%241 = OpLabel
+OpBranch %236
+%236 = OpLabel
+%815 = OpLoad %float %311
+%816 = OpLoad %float %310
+%817 = OpFOrdLessThan %bool %815 %816
+OpStore %316 %817
+OpBranch %242
+%242 = OpLabel
+%818 = OpLoad %bool %316
+%819 = OpSelect %uchar %818 %uchar_1 %uchar_0
+%820 = OpUConvert %ulong %819
+OpStore %511 %820
+OpBranch %244
+%244 = OpLabel
+%821 = OpLoad %ulong %509
+OpStore %519 %821
+OpStore %520 %ulong_0
+OpBranch %245
+%245 = OpLabel
+%822 = OpLoad %ulong %520
+%823 = OpULessThan %bool %822 %ulong_8
+OpStore %512 %823
+%824 = OpLoad %bool %512
+OpLoopMerge %247 %267 None
+OpBranchConditional %824 %246 %247
+%247 = OpLabel
+OpBranch %248
+%248 = OpLabel
+OpBranch %243
+%243 = OpLabel
+%825 = OpLoad %float %311
+%826 = OpLoad %float %310
+%827 = OpFOrdLessThanEqual %bool %825 %826
+OpStore %317 %827
+OpBranch %249
+%249 = OpLabel
+%828 = OpLoad %bool %317
+%829 = OpSelect %uchar %828 %uchar_1 %uchar_0
+%830 = OpUConvert %ulong %829
+OpStore %521 %830
+OpBranch %251
+%251 = OpLabel
+%831 = OpLoad %ulong %519
+OpStore %529 %831
+OpStore %530 %ulong_0
+OpBranch %252
+%252 = OpLabel
+%832 = OpLoad %ulong %530
+%833 = OpULessThan %bool %832 %ulong_8
+OpStore %522 %833
+%834 = OpLoad %bool %522
+OpLoopMerge %254 %266 None
+OpBranchConditional %834 %253 %254
+%254 = OpLabel
+OpBranch %255
+%255 = OpLabel
+OpBranch %250
+%250 = OpLabel
+%835 = OpLoad %float %310
+%836 = OpLoad %float %311
+%837 = OpFOrdLessThan %bool %835 %836
+OpStore %318 %837
+%838 = OpLoad %bool %318
+OpSelectionMerge %124 None
+OpBranchConditional %838 %122 %123
+%123 = OpLabel
+OpStore %387 %uchar_0
+OpBranch %124
+%122 = OpLabel
+OpStore %387 %uchar_1
+OpBranch %124
+%124 = OpLabel
+%839 = OpLoad %float %310
+%840 = OpLoad %float %311
+%841 = OpFOrdLessThanEqual %bool %839 %840
+OpStore %319 %841
+%842 = OpLoad %bool %319
+OpSelectionMerge %127 None
+OpBranchConditional %842 %125 %126
+%126 = OpLabel
+%843 = OpLoad %uchar %387
+OpStore %386 %843
+OpBranch %127
+%125 = OpLabel
+%844 = OpLoad %uchar %387
+%846 = OpIAdd %uchar %844 %uchar_2
+OpStore %321 %846
+%847 = OpLoad %uchar %321
+OpStore %386 %847
+OpBranch %127
+%127 = OpLabel
+%848 = OpLoad %float %311
+%849 = OpLoad %float %310
+%850 = OpFOrdLessThan %bool %848 %849
+OpStore %322 %850
+%851 = OpLoad %bool %322
+OpSelectionMerge %130 None
+OpBranchConditional %851 %128 %129
+%129 = OpLabel
+%852 = OpLoad %uchar %386
+OpStore %385 %852
+OpBranch %130
+%128 = OpLabel
+%853 = OpLoad %uchar %386
+%855 = OpIAdd %uchar %853 %uchar_4
+OpStore %323 %855
+%856 = OpLoad %uchar %323
+OpStore %385 %856
+OpBranch %130
+%130 = OpLabel
+%857 = OpLoad %float %311
+%858 = OpLoad %float %310
+%859 = OpFOrdLessThanEqual %bool %857 %858
+OpStore %324 %859
+%860 = OpLoad %bool %324
+OpSelectionMerge %133 None
+OpBranchConditional %860 %131 %132
+%132 = OpLabel
+%861 = OpLoad %uchar %385
+OpStore %384 %861
+OpBranch %133
+%131 = OpLabel
+%862 = OpLoad %uchar %385
+%864 = OpIAdd %uchar %862 %uchar_8
+OpStore %325 %864
+%865 = OpLoad %uchar %325
+OpStore %384 %865
+OpBranch %133
+%133 = OpLabel
+%866 = OpLoad %float %310
+%867 = OpLoad %float %311
+%868 = OpFOrdEqual %bool %866 %867
+OpStore %326 %868
+%869 = OpLoad %bool %326
+OpSelectionMerge %136 None
+OpBranchConditional %869 %134 %135
+%135 = OpLabel
+%870 = OpLoad %uchar %384
+OpStore %383 %870
+OpBranch %136
+%134 = OpLabel
+%871 = OpLoad %uchar %384
+%873 = OpIAdd %uchar %871 %uchar_16
+OpStore %327 %873
+%874 = OpLoad %uchar %327
+OpStore %383 %874
+OpBranch %136
+%136 = OpLabel
+%875 = OpLoad %float %310
+%876 = OpLoad %float %311
+%877 = OpFUnordNotEqual %bool %875 %876
+OpStore %328 %877
+%878 = OpLoad %bool %328
+OpSelectionMerge %139 None
+OpBranchConditional %878 %137 %138
+%138 = OpLabel
+%879 = OpLoad %uchar %383
+OpStore %382 %879
+OpBranch %139
+%137 = OpLabel
+%880 = OpLoad %uchar %383
+%882 = OpIAdd %uchar %880 %uchar_32
+OpStore %329 %882
+%883 = OpLoad %uchar %329
+OpStore %382 %883
+OpBranch %139
+%139 = OpLabel
+OpBranch %167
+%167 = OpLabel
+%884 = OpLoad %uchar %382
+%885 = OpUConvert %ulong %884
+OpStore %402 %885
+OpBranch %186
+%186 = OpLabel
+%886 = OpLoad %ulong %529
+OpStore %425 %886
+OpStore %426 %ulong_0
+OpBranch %187
+%187 = OpLabel
+%887 = OpLoad %ulong %426
+%888 = OpULessThan %bool %887 %ulong_8
+OpStore %418 %888
+%889 = OpLoad %bool %418
+OpLoopMerge %189 %265 None
+OpBranchConditional %889 %188 %189
+%189 = OpLabel
+OpBranch %190
+%190 = OpLabel
+OpBranch %168
+%168 = OpLabel
+%890 = OpLoad %float %310
+%891 = OpLoad %float %311
+%892 = OpFOrdLessThan %bool %890 %891
+OpStore %330 %892
+%893 = OpLoad %bool %330
+OpSelectionMerge %141 None
+OpBranchConditional %893 %140 %256
+%256 = OpLabel
+%894 = OpLoad %bool %330
+OpStore %388 %894
+OpBranch %141
+%140 = OpLabel
+%895 = OpLoad %float %311
+%896 = OpLoad %float %310
+%897 = OpFOrdLessThan %bool %895 %896
+OpStore %331 %897
+%898 = OpLoad %bool %331
+OpStore %388 %898
+OpBranch %141
+%141 = OpLabel
+OpBranch %169
+%169 = OpLabel
+%899 = OpLoad %bool %388
+%900 = OpSelect %uchar %899 %uchar_1 %uchar_0
+%901 = OpUConvert %ulong %900
+OpStore %403 %901
+OpBranch %191
+%191 = OpLabel
+%902 = OpLoad %ulong %425
+OpStore %434 %902
+OpStore %435 %ulong_0
+OpBranch %192
+%192 = OpLabel
+%903 = OpLoad %ulong %435
+%904 = OpULessThan %bool %903 %ulong_8
+OpStore %427 %904
+%905 = OpLoad %bool %427
+OpLoopMerge %194 %264 None
+OpBranchConditional %905 %193 %194
+%194 = OpLabel
+OpBranch %195
+%195 = OpLabel
+OpBranch %170
+%170 = OpLabel
+%906 = OpLoad %float %310
+%907 = OpLoad %float %311
+%908 = OpFOrdLessThan %bool %906 %907
+OpStore %332 %908
+%909 = OpLoad %bool %332
+OpSelectionMerge %143 None
+OpBranchConditional %909 %257 %142
+%142 = OpLabel
+%910 = OpLoad %float %311
+%911 = OpLoad %float %310
+%912 = OpFOrdLessThan %bool %910 %911
+OpStore %333 %912
+%913 = OpLoad %bool %333
+OpStore %389 %913
+OpBranch %143
+%257 = OpLabel
+%914 = OpLoad %bool %332
+OpStore %389 %914
+OpBranch %143
+%143 = OpLabel
+OpBranch %171
+%171 = OpLabel
+%915 = OpLoad %bool %389
+%916 = OpSelect %uchar %915 %uchar_1 %uchar_0
+%917 = OpUConvert %ulong %916
+OpStore %404 %917
+OpBranch %196
+%196 = OpLabel
+%918 = OpLoad %ulong %434
+OpStore %443 %918
+OpStore %444 %ulong_0
+OpBranch %197
+%197 = OpLabel
+%919 = OpLoad %ulong %444
+%920 = OpULessThan %bool %919 %ulong_8
+OpStore %436 %920
+%921 = OpLoad %bool %436
+OpLoopMerge %199 %263 None
+OpBranchConditional %921 %198 %199
+%199 = OpLabel
+OpBranch %200
+%200 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%922 = OpLoad %float %310
+%923 = OpLoad %float %311
+%924 = OpFOrdLessThan %bool %922 %923
+OpStore %334 %924
+%925 = OpLoad %bool %334
+%926 = OpSelect %uchar %925 %uchar_1 %uchar_0
+%927 = OpINotEqual %bool %926 %uchar_1
+OpStore %335 %927
+OpBranch %201
+%201 = OpLabel
+%928 = OpLoad %bool %335
+%929 = OpSelect %uchar %928 %uchar_1 %uchar_0
+%930 = OpUConvert %ulong %929
+OpStore %445 %930
+OpBranch %225
+%225 = OpLabel
+%931 = OpLoad %ulong %443
+OpStore %490 %931
+OpStore %491 %ulong_0
+OpBranch %226
+%226 = OpLabel
+%932 = OpLoad %ulong %491
+%933 = OpULessThan %bool %932 %ulong_8
+OpStore %483 %933
+%934 = OpLoad %bool %483
+OpLoopMerge %228 %262 None
+OpBranchConditional %934 %227 %228
+%228 = OpLabel
+OpBranch %229
+%229 = OpLabel
+OpBranch %202
+%202 = OpLabel
+%935 = OpLoad %float %310
+%936 = OpLoad %float %310
+%937 = OpFOrdEqual %bool %935 %936
+OpStore %336 %937
+%938 = OpLoad %bool %336
+OpSelectionMerge %145 None
+OpBranchConditional %938 %144 %258
+%258 = OpLabel
+%939 = OpLoad %bool %336
+OpStore %390 %939
+OpBranch %145
+%144 = OpLabel
+%940 = OpLoad %float %311
+%941 = OpLoad %float %311
+%942 = OpFOrdEqual %bool %940 %941
+OpStore %337 %942
+%943 = OpLoad %bool %337
+OpStore %390 %943
+OpBranch %145
+%145 = OpLabel
+OpBranch %173
+%173 = OpLabel
+%944 = OpLoad %bool %390
+%945 = OpSelect %uchar %944 %uchar_1 %uchar_0
+%946 = OpUConvert %ulong %945
+OpStore %405 %946
+OpBranch %203
+%203 = OpLabel
+%947 = OpLoad %ulong %490
+OpStore %453 %947
+OpStore %454 %ulong_0
+OpBranch %204
+%204 = OpLabel
+%948 = OpLoad %ulong %454
+%949 = OpULessThan %bool %948 %ulong_8
+OpStore %446 %949
+%950 = OpLoad %bool %446
+OpLoopMerge %206 %261 None
+OpBranchConditional %950 %205 %206
+%206 = OpLabel
+OpBranch %207
+%207 = OpLabel
+OpBranch %174
+%174 = OpLabel
+%951 = OpLoad %float %310
+%952 = OpLoad %float %310
+%953 = OpFUnordNotEqual %bool %951 %952
+OpStore %338 %953
+%954 = OpLoad %bool %338
+OpSelectionMerge %147 None
+OpBranchConditional %954 %259 %146
+%146 = OpLabel
+%955 = OpLoad %float %311
+%956 = OpLoad %float %311
+%957 = OpFUnordNotEqual %bool %955 %956
+OpStore %339 %957
+%958 = OpLoad %bool %339
+OpStore %391 %958
+OpBranch %147
+%259 = OpLabel
+%959 = OpLoad %bool %338
+OpStore %391 %959
+OpBranch %147
+%147 = OpLabel
+OpBranch %175
+%175 = OpLabel
+%960 = OpLoad %bool %391
+%961 = OpSelect %uchar %960 %uchar_1 %uchar_0
+%962 = OpUConvert %ulong %961
+OpStore %406 %962
+OpBranch %208
+%208 = OpLabel
+%963 = OpLoad %ulong %453
+OpStore %462 %963
+OpStore %463 %ulong_0
+OpBranch %209
+%209 = OpLabel
+%964 = OpLoad %ulong %463
+%965 = OpULessThan %bool %964 %ulong_8
+OpStore %455 %965
+%966 = OpLoad %bool %455
+OpLoopMerge %211 %260 None
+OpBranchConditional %966 %210 %211
+%211 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpBranch %176
+%176 = OpLabel
+%967 = OpLoad %uint %381
+%968 = OpIAdd %uint %967 %uint_1
+OpStore %340 %968
+%969 = OpLoad %ulong %462
+OpStore %378 %969
+%970 = OpLoad %uint %340
+OpStore %381 %970
+OpBranch %275
+%210 = OpLabel
+%971 = OpLoad %ulong %463
+%972 = OpIMul %ulong %971 %ulong_8
+OpStore %456 %972
+%973 = OpLoad %ulong %406
+%974 = OpLoad %ulong %456
+%975 = OpShiftRightLogical %ulong %973 %974
+OpStore %457 %975
+%976 = OpLoad %ulong %457
+%977 = OpBitwiseAnd %ulong %976 %ulong_255
+OpStore %458 %977
+%978 = OpLoad %ulong %462
+%979 = OpLoad %ulong %458
+%980 = OpBitwiseXor %ulong %978 %979
+OpStore %459 %980
+%981 = OpLoad %ulong %459
+%982 = OpIMul %ulong %981 %ulong_1099511628211
+OpStore %460 %982
+%983 = OpLoad %ulong %463
+%984 = OpIAdd %ulong %983 %ulong_1
+OpStore %461 %984
+%985 = OpLoad %ulong %460
+OpStore %462 %985
+%986 = OpLoad %ulong %461
+OpStore %463 %986
+OpBranch %260
+%205 = OpLabel
+%987 = OpLoad %ulong %454
+%988 = OpIMul %ulong %987 %ulong_8
+OpStore %447 %988
+%989 = OpLoad %ulong %405
+%990 = OpLoad %ulong %447
+%991 = OpShiftRightLogical %ulong %989 %990
+OpStore %448 %991
+%992 = OpLoad %ulong %448
+%993 = OpBitwiseAnd %ulong %992 %ulong_255
+OpStore %449 %993
+%994 = OpLoad %ulong %453
+%995 = OpLoad %ulong %449
+%996 = OpBitwiseXor %ulong %994 %995
+OpStore %450 %996
+%997 = OpLoad %ulong %450
+%998 = OpIMul %ulong %997 %ulong_1099511628211
+OpStore %451 %998
+%999 = OpLoad %ulong %454
+%1000 = OpIAdd %ulong %999 %ulong_1
+OpStore %452 %1000
+%1001 = OpLoad %ulong %451
+OpStore %453 %1001
+%1002 = OpLoad %ulong %452
+OpStore %454 %1002
+OpBranch %261
+%227 = OpLabel
+%1003 = OpLoad %ulong %491
+%1004 = OpIMul %ulong %1003 %ulong_8
+OpStore %484 %1004
+%1005 = OpLoad %ulong %445
+%1006 = OpLoad %ulong %484
+%1007 = OpShiftRightLogical %ulong %1005 %1006
+OpStore %485 %1007
+%1008 = OpLoad %ulong %485
+%1009 = OpBitwiseAnd %ulong %1008 %ulong_255
+OpStore %486 %1009
+%1010 = OpLoad %ulong %490
+%1011 = OpLoad %ulong %486
+%1012 = OpBitwiseXor %ulong %1010 %1011
+OpStore %487 %1012
+%1013 = OpLoad %ulong %487
+%1014 = OpIMul %ulong %1013 %ulong_1099511628211
+OpStore %488 %1014
+%1015 = OpLoad %ulong %491
+%1016 = OpIAdd %ulong %1015 %ulong_1
+OpStore %489 %1016
+%1017 = OpLoad %ulong %488
+OpStore %490 %1017
+%1018 = OpLoad %ulong %489
+OpStore %491 %1018
+OpBranch %262
+%198 = OpLabel
+%1019 = OpLoad %ulong %444
+%1020 = OpIMul %ulong %1019 %ulong_8
+OpStore %437 %1020
+%1021 = OpLoad %ulong %404
+%1022 = OpLoad %ulong %437
+%1023 = OpShiftRightLogical %ulong %1021 %1022
+OpStore %438 %1023
+%1024 = OpLoad %ulong %438
+%1025 = OpBitwiseAnd %ulong %1024 %ulong_255
+OpStore %439 %1025
+%1026 = OpLoad %ulong %443
+%1027 = OpLoad %ulong %439
+%1028 = OpBitwiseXor %ulong %1026 %1027
+OpStore %440 %1028
+%1029 = OpLoad %ulong %440
+%1030 = OpIMul %ulong %1029 %ulong_1099511628211
+OpStore %441 %1030
+%1031 = OpLoad %ulong %444
+%1032 = OpIAdd %ulong %1031 %ulong_1
+OpStore %442 %1032
+%1033 = OpLoad %ulong %441
+OpStore %443 %1033
+%1034 = OpLoad %ulong %442
+OpStore %444 %1034
+OpBranch %263
+%193 = OpLabel
+%1035 = OpLoad %ulong %435
+%1036 = OpIMul %ulong %1035 %ulong_8
+OpStore %428 %1036
+%1037 = OpLoad %ulong %403
+%1038 = OpLoad %ulong %428
+%1039 = OpShiftRightLogical %ulong %1037 %1038
+OpStore %429 %1039
+%1040 = OpLoad %ulong %429
+%1041 = OpBitwiseAnd %ulong %1040 %ulong_255
+OpStore %430 %1041
+%1042 = OpLoad %ulong %434
+%1043 = OpLoad %ulong %430
+%1044 = OpBitwiseXor %ulong %1042 %1043
+OpStore %431 %1044
+%1045 = OpLoad %ulong %431
+%1046 = OpIMul %ulong %1045 %ulong_1099511628211
+OpStore %432 %1046
+%1047 = OpLoad %ulong %435
+%1048 = OpIAdd %ulong %1047 %ulong_1
+OpStore %433 %1048
+%1049 = OpLoad %ulong %432
+OpStore %434 %1049
+%1050 = OpLoad %ulong %433
+OpStore %435 %1050
+OpBranch %264
+%188 = OpLabel
+%1051 = OpLoad %ulong %426
+%1052 = OpIMul %ulong %1051 %ulong_8
+OpStore %419 %1052
+%1053 = OpLoad %ulong %402
+%1054 = OpLoad %ulong %419
+%1055 = OpShiftRightLogical %ulong %1053 %1054
+OpStore %420 %1055
+%1056 = OpLoad %ulong %420
+%1057 = OpBitwiseAnd %ulong %1056 %ulong_255
+OpStore %421 %1057
+%1058 = OpLoad %ulong %425
+%1059 = OpLoad %ulong %421
+%1060 = OpBitwiseXor %ulong %1058 %1059
+OpStore %422 %1060
+%1061 = OpLoad %ulong %422
+%1062 = OpIMul %ulong %1061 %ulong_1099511628211
+OpStore %423 %1062
+%1063 = OpLoad %ulong %426
+%1064 = OpIAdd %ulong %1063 %ulong_1
+OpStore %424 %1064
+%1065 = OpLoad %ulong %423
+OpStore %425 %1065
+%1066 = OpLoad %ulong %424
+OpStore %426 %1066
+OpBranch %265
+%253 = OpLabel
+%1067 = OpLoad %ulong %530
+%1068 = OpIMul %ulong %1067 %ulong_8
+OpStore %523 %1068
+%1069 = OpLoad %ulong %521
+%1070 = OpLoad %ulong %523
+%1071 = OpShiftRightLogical %ulong %1069 %1070
+OpStore %524 %1071
+%1072 = OpLoad %ulong %524
+%1073 = OpBitwiseAnd %ulong %1072 %ulong_255
+OpStore %525 %1073
+%1074 = OpLoad %ulong %529
+%1075 = OpLoad %ulong %525
+%1076 = OpBitwiseXor %ulong %1074 %1075
+OpStore %526 %1076
+%1077 = OpLoad %ulong %526
+%1078 = OpIMul %ulong %1077 %ulong_1099511628211
+OpStore %527 %1078
+%1079 = OpLoad %ulong %530
+%1080 = OpIAdd %ulong %1079 %ulong_1
+OpStore %528 %1080
+%1081 = OpLoad %ulong %527
+OpStore %529 %1081
+%1082 = OpLoad %ulong %528
+OpStore %530 %1082
+OpBranch %266
+%246 = OpLabel
+%1083 = OpLoad %ulong %520
+%1084 = OpIMul %ulong %1083 %ulong_8
+OpStore %513 %1084
+%1085 = OpLoad %ulong %511
+%1086 = OpLoad %ulong %513
+%1087 = OpShiftRightLogical %ulong %1085 %1086
+OpStore %514 %1087
+%1088 = OpLoad %ulong %514
+%1089 = OpBitwiseAnd %ulong %1088 %ulong_255
+OpStore %515 %1089
+%1090 = OpLoad %ulong %519
+%1091 = OpLoad %ulong %515
+%1092 = OpBitwiseXor %ulong %1090 %1091
+OpStore %516 %1092
+%1093 = OpLoad %ulong %516
+%1094 = OpIMul %ulong %1093 %ulong_1099511628211
+OpStore %517 %1094
+%1095 = OpLoad %ulong %520
+%1096 = OpIAdd %ulong %1095 %ulong_1
+OpStore %518 %1096
+%1097 = OpLoad %ulong %517
+OpStore %519 %1097
+%1098 = OpLoad %ulong %518
+OpStore %520 %1098
+OpBranch %267
+%239 = OpLabel
+%1099 = OpLoad %ulong %510
+%1100 = OpIMul %ulong %1099 %ulong_8
+OpStore %503 %1100
+%1101 = OpLoad %ulong %501
+%1102 = OpLoad %ulong %503
+%1103 = OpShiftRightLogical %ulong %1101 %1102
+OpStore %504 %1103
+%1104 = OpLoad %ulong %504
+%1105 = OpBitwiseAnd %ulong %1104 %ulong_255
+OpStore %505 %1105
+%1106 = OpLoad %ulong %509
+%1107 = OpLoad %ulong %505
+%1108 = OpBitwiseXor %ulong %1106 %1107
+OpStore %506 %1108
+%1109 = OpLoad %ulong %506
+%1110 = OpIMul %ulong %1109 %ulong_1099511628211
+OpStore %507 %1110
+%1111 = OpLoad %ulong %510
+%1112 = OpIAdd %ulong %1111 %ulong_1
+OpStore %508 %1112
+%1113 = OpLoad %ulong %507
+OpStore %509 %1113
+%1114 = OpLoad %ulong %508
+OpStore %510 %1114
+OpBranch %268
+%232 = OpLabel
+%1115 = OpLoad %ulong %500
+%1116 = OpIMul %ulong %1115 %ulong_8
+OpStore %493 %1116
+%1117 = OpLoad %ulong %482
+%1118 = OpLoad %ulong %493
+%1119 = OpShiftRightLogical %ulong %1117 %1118
+OpStore %494 %1119
+%1120 = OpLoad %ulong %494
+%1121 = OpBitwiseAnd %ulong %1120 %ulong_255
+OpStore %495 %1121
+%1122 = OpLoad %ulong %499
+%1123 = OpLoad %ulong %495
+%1124 = OpBitwiseXor %ulong %1122 %1123
+OpStore %496 %1124
+%1125 = OpLoad %ulong %496
+%1126 = OpIMul %ulong %1125 %ulong_1099511628211
+OpStore %497 %1126
+%1127 = OpLoad %ulong %500
+%1128 = OpIAdd %ulong %1127 %ulong_1
+OpStore %498 %1128
+%1129 = OpLoad %ulong %497
+OpStore %499 %1129
+%1130 = OpLoad %ulong %498
+OpStore %500 %1130
+OpBranch %269
+%220 = OpLabel
+%1131 = OpLoad %ulong %481
+%1132 = OpIMul %ulong %1131 %ulong_8
+OpStore %474 %1132
+%1133 = OpLoad %ulong %417
+%1134 = OpLoad %ulong %474
+%1135 = OpShiftRightLogical %ulong %1133 %1134
+OpStore %475 %1135
+%1136 = OpLoad %ulong %475
+%1137 = OpBitwiseAnd %ulong %1136 %ulong_255
+OpStore %476 %1137
+%1138 = OpLoad %ulong %480
+%1139 = OpLoad %ulong %476
+%1140 = OpBitwiseXor %ulong %1138 %1139
+OpStore %477 %1140
+%1141 = OpLoad %ulong %477
+%1142 = OpIMul %ulong %1141 %ulong_1099511628211
+OpStore %478 %1142
+%1143 = OpLoad %ulong %481
+%1144 = OpIAdd %ulong %1143 %ulong_1
+OpStore %479 %1144
+%1145 = OpLoad %ulong %478
+OpStore %480 %1145
+%1146 = OpLoad %ulong %479
+OpStore %481 %1146
+OpBranch %270
+%181 = OpLabel
+%1147 = OpLoad %ulong %416
+%1148 = OpIMul %ulong %1147 %ulong_8
+OpStore %409 %1148
+%1149 = OpLoad %ulong %401
+%1150 = OpLoad %ulong %409
+%1151 = OpShiftRightLogical %ulong %1149 %1150
+OpStore %410 %1151
+%1152 = OpLoad %ulong %410
+%1153 = OpBitwiseAnd %ulong %1152 %ulong_255
+OpStore %411 %1153
+%1154 = OpLoad %ulong %415
+%1155 = OpLoad %ulong %411
+%1156 = OpBitwiseXor %ulong %1154 %1155
+OpStore %412 %1156
+%1157 = OpLoad %ulong %412
+%1158 = OpIMul %ulong %1157 %ulong_1099511628211
+OpStore %413 %1158
+%1159 = OpLoad %ulong %416
+%1160 = OpIAdd %ulong %1159 %ulong_1
+OpStore %414 %1160
+%1161 = OpLoad %ulong %413
+OpStore %415 %1161
+%1162 = OpLoad %ulong %414
+OpStore %416 %1162
+OpBranch %273
+%260 = OpLabel
+OpBranch %209
+%261 = OpLabel
+OpBranch %204
+%262 = OpLabel
+OpBranch %226
+%263 = OpLabel
+OpBranch %197
+%264 = OpLabel
+OpBranch %192
+%265 = OpLabel
+OpBranch %187
+%266 = OpLabel
+OpBranch %252
+%267 = OpLabel
+OpBranch %245
+%268 = OpLabel
+OpBranch %238
+%269 = OpLabel
+OpBranch %231
+%270 = OpLabel
+OpBranch %219
+%271 = OpLabel
+OpBranch %214
+%272 = OpLabel
+OpBranch %160
+%273 = OpLabel
+OpBranch %180
+%274 = OpLabel
+OpBranch %157
+%275 = OpLabel
+OpBranch %119
+%276 = OpLabel
+OpBranch %148
+%277 = OpLabel
+OpBranch %116
 OpFunctionEnd

--- a/test/golden/spirv/float/cmp_f64.dis
+++ b/test/golden/spirv/float/cmp_f64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1004
+; Bound: 1482
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -13,26 +13,31 @@ OpDecorate %1 LinkageAttributes "corpus.cases.float.cmp_f64.fold64" Export
 OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f64.checksum" Export
 %ulong = OpTypeInt 64 0
 %double = OpTypeFloat 64
-%10 = OpTypeFunction %ulong %ulong %double
+%7 = OpTypeFunction %ulong %ulong %double
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_double = OpTypePointer Function %double
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%39 = OpTypeFunction %ulong %ulong
+%108 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %float = OpTypeFloat 32
 %uchar = OpTypeInt 8 0
-%uint_12 = OpConstant %uint 12
-%_arr_double_uint_12 = OpTypeArray %double %uint_12
-%_ptr_Function__arr_double_uint_12 = OpTypePointer Function %_arr_double_uint_12
 %uint_8 = OpConstant %uint 8
 %_arr_float_uint_8 = OpTypeArray %float %uint_8
 %_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+%uint_12 = OpConstant %uint 12
+%_arr_double_uint_12 = OpTypeArray %double %uint_12
+%_ptr_Function__arr_double_uint_12 = OpTypePointer Function %_arr_double_uint_12
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_float = OpTypePointer Function %float
-%307 = OpConstantNull %_arr_double_uint_12
+%613 = OpConstantNull %_arr_double_uint_12
 %ulong_18442240474082181120 = OpConstant %ulong 18442240474082181120
 %uint_0 = OpConstant %uint 0
 %ulong_13830554455654793216 = OpConstant %ulong 13830554455654793216
@@ -44,7 +49,6 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f64.checksum" Export
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %uint_4 = OpConstant %uint 4
 %uint_5 = OpConstant %uint 5
-%ulong_1 = OpConstant %ulong 1
 %uint_6 = OpConstant %uint 6
 %ulong_4607182418800017408 = OpConstant %ulong 4607182418800017408
 %uint_7 = OpConstant %uint 7
@@ -55,9 +59,9 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f64.checksum" Export
 %uint_10 = OpConstant %uint 10
 %ulong_9218868437227405313 = OpConstant %ulong 9218868437227405313
 %uint_11 = OpConstant %uint 11
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_12 = OpConstant %ulong 12
-%406 = OpConstantNull %_arr_float_uint_8
+%710 = OpConstantNull %_arr_float_uint_8
 %uint_4286578688 = OpConstant %uint 4286578688
 %uint_3212836864 = OpConstant %uint 3212836864
 %uint_2147483648 = OpConstant %uint 2147483648
@@ -66,1376 +70,2115 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f64.checksum" Export
 %uint_2143289344 = OpConstant %uint 2143289344
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
-%ulong_8 = OpConstant %ulong 8
 %uchar_2 = OpConstant %uchar 2
 %uchar_4 = OpConstant %uchar 4
 %uchar_8 = OpConstant %uchar 8
 %uchar_16 = OpConstant %uchar 16
 %uchar_32 = OpConstant %uchar 32
-%825 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%828 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%870 = OpTypeFunction %ulong %ulong %uchar
-%915 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %10
-%11 = OpFunctionParameter %ulong
-%12 = OpFunctionParameter %double
+%1397 = OpTypeFunction %ulong %ulong %ulong
+%1437 = OpTypeFunction %ulong %ulong %uchar
+%1 = OpFunction %ulong None %7
+%8 = OpFunctionParameter %ulong
+%9 = OpFunctionParameter %double
+%10 = OpLabel
+%31 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_double Function
+%35 = OpVariable %_ptr_Function_bool Function
+%36 = OpVariable %_ptr_Function_bool Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%38 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_bool Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+OpStore %31 %8
+OpStore %33 %9
+%55 = OpLoad %double %33
+%56 = OpLoad %double %33
+%57 = OpFUnordNotEqual %bool %55 %56
+OpStore %35 %57
+%58 = OpLoad %bool %35
+OpSelectionMerge %28 None
+OpBranchConditional %58 %11 %12
+%12 = OpLabel
+OpBranch %13
 %13 = OpLabel
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_double Function
-%24 = OpVariable %_ptr_Function_bool Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-OpStore %20 %11
-OpStore %22 %12
-%27 = OpLoad %double %22
-%28 = OpLoad %double %22
-%29 = OpFUnordNotEqual %bool %27 %28
-OpStore %24 %29
-%30 = OpLoad %bool %24
-OpSelectionMerge %17 None
-OpBranchConditional %30 %14 %15
-%15 = OpLabel
-OpBranch %16
-%16 = OpLabel
-%31 = OpLoad %ulong %20
-%32 = OpLoad %double %22
-%33 = OpFunctionCall %ulong %7 %31 %32
-OpStore %26 %33
-%34 = OpLoad %ulong %26
-OpReturnValue %34
+OpBranch %19
+%19 = OpLabel
+%59 = OpLoad %double %33
+%60 = OpBitcast %ulong %59
+OpStore %45 %60
+OpBranch %21
+%21 = OpLabel
+%61 = OpLoad %ulong %31
+OpStore %53 %61
+OpStore %54 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%63 = OpLoad %ulong %54
+%65 = OpULessThan %bool %63 %ulong_8
+OpStore %46 %65
+%66 = OpLoad %bool %46
+OpLoopMerge %24 %26 None
+OpBranchConditional %66 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%67 = OpLoad %ulong %53
+OpReturnValue %67
+%23 = OpLabel
+%68 = OpLoad %ulong %54
+%69 = OpIMul %ulong %68 %ulong_8
+OpStore %47 %69
+%70 = OpLoad %ulong %45
+%71 = OpLoad %ulong %47
+%72 = OpShiftRightLogical %ulong %70 %71
+OpStore %48 %72
+%73 = OpLoad %ulong %48
+%75 = OpBitwiseAnd %ulong %73 %ulong_255
+OpStore %49 %75
+%76 = OpLoad %ulong %53
+%77 = OpLoad %ulong %49
+%78 = OpBitwiseXor %ulong %76 %77
+OpStore %50 %78
+%79 = OpLoad %ulong %50
+%81 = OpIMul %ulong %79 %ulong_1099511628211
+OpStore %51 %81
+%82 = OpLoad %ulong %54
+%84 = OpIAdd %ulong %82 %ulong_1
+OpStore %52 %84
+%85 = OpLoad %ulong %51
+OpStore %53 %85
+%86 = OpLoad %ulong %52
+OpStore %54 %86
+OpBranch %26
+%11 = OpLabel
+OpBranch %14
 %14 = OpLabel
-%35 = OpLoad %ulong %20
-%37 = OpFunctionCall %ulong %4 %35 %ulong_18446744073709551615
-OpStore %25 %37
-%38 = OpLoad %ulong %25
-OpReturnValue %38
+%87 = OpLoad %ulong %31
+OpStore %43 %87
+OpStore %44 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%88 = OpLoad %ulong %44
+%89 = OpULessThan %bool %88 %ulong_8
+OpStore %36 %89
+%90 = OpLoad %bool %36
+OpLoopMerge %17 %27 None
+OpBranchConditional %90 %16 %17
 %17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%91 = OpLoad %ulong %43
+OpReturnValue %91
+%16 = OpLabel
+%92 = OpLoad %ulong %44
+%93 = OpIMul %ulong %92 %ulong_8
+OpStore %37 %93
+%95 = OpLoad %ulong %37
+%96 = OpShiftRightLogical %ulong %ulong_18446744073709551615 %95
+OpStore %38 %96
+%97 = OpLoad %ulong %38
+%98 = OpBitwiseAnd %ulong %97 %ulong_255
+OpStore %39 %98
+%99 = OpLoad %ulong %43
+%100 = OpLoad %ulong %39
+%101 = OpBitwiseXor %ulong %99 %100
+OpStore %40 %101
+%102 = OpLoad %ulong %40
+%103 = OpIMul %ulong %102 %ulong_1099511628211
+OpStore %41 %103
+%104 = OpLoad %ulong %44
+%105 = OpIAdd %ulong %104 %ulong_1
+OpStore %42 %105
+%106 = OpLoad %ulong %41
+OpStore %43 %106
+%107 = OpLoad %ulong %42
+OpStore %44 %107
+OpBranch %27
+%26 = OpLabel
+OpBranch %22
+%27 = OpLabel
+OpBranch %15
+%28 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%2 = OpFunction %ulong None %39
-%40 = OpFunctionParameter %ulong
-%41 = OpLabel
-%122 = OpVariable %_ptr_Function__arr_double_uint_12 Function
-%126 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_uint Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_double Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_double Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_double Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_double Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_double Function
-%141 = OpVariable %_ptr_Function_double Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_double Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_double Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_double Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_double Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_double Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_double Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_bool Function
-%156 = OpVariable %_ptr_Function_double Function
-%157 = OpVariable %_ptr_Function_double Function
-%158 = OpVariable %_ptr_Function_bool Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_bool Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_bool Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_bool Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_bool Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_bool Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_bool Function
-%172 = OpVariable %_ptr_Function_uchar Function
-%173 = OpVariable %_ptr_Function_bool Function
-%174 = OpVariable %_ptr_Function_uchar Function
-%175 = OpVariable %_ptr_Function_bool Function
-%176 = OpVariable %_ptr_Function_uchar Function
-%177 = OpVariable %_ptr_Function_bool Function
-%178 = OpVariable %_ptr_Function_uchar Function
-%179 = OpVariable %_ptr_Function_bool Function
-%180 = OpVariable %_ptr_Function_uchar Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_bool Function
-%183 = OpVariable %_ptr_Function_bool Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_bool Function
-%186 = OpVariable %_ptr_Function_bool Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_bool Function
-%189 = OpVariable %_ptr_Function_bool Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_bool Function
-%192 = OpVariable %_ptr_Function_bool Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_bool Function
-%195 = OpVariable %_ptr_Function_bool Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_uint Function
-%201 = OpVariable %_ptr_Function_float Function
-%202 = OpVariable %_ptr_Function_uint Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_uint Function
-%205 = OpVariable %_ptr_Function_float Function
-%206 = OpVariable %_ptr_Function_float Function
-%207 = OpVariable %_ptr_Function_uint Function
-%208 = OpVariable %_ptr_Function_float Function
-%209 = OpVariable %_ptr_Function_uint Function
-%210 = OpVariable %_ptr_Function_float Function
-%211 = OpVariable %_ptr_Function_uint Function
-%212 = OpVariable %_ptr_Function_float Function
-%213 = OpVariable %_ptr_Function_uint Function
-%214 = OpVariable %_ptr_Function_float Function
-%215 = OpVariable %_ptr_Function_bool Function
-%216 = OpVariable %_ptr_Function_bool Function
-%217 = OpVariable %_ptr_Function_double Function
-%218 = OpVariable %_ptr_Function_float Function
-%219 = OpVariable %_ptr_Function_double Function
-%220 = OpVariable %_ptr_Function_bool Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_bool Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_bool Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_bool Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_bool Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_bool Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_double Function
-%235 = OpVariable %_ptr_Function_double Function
-%236 = OpVariable %_ptr_Function_bool Function
-%237 = OpVariable %_ptr_Function_double Function
-%238 = OpVariable %_ptr_Function_bool Function
-%239 = OpVariable %_ptr_Function_double Function
-%240 = OpVariable %_ptr_Function_double Function
-%241 = OpVariable %_ptr_Function_bool Function
-%242 = OpVariable %_ptr_Function_double Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_bool Function
-%245 = OpVariable %_ptr_Function_bool Function
-%246 = OpVariable %_ptr_Function_double Function
-%247 = OpVariable %_ptr_Function_double Function
-%248 = OpVariable %_ptr_Function_bool Function
-%249 = OpVariable %_ptr_Function_uint Function
-%250 = OpVariable %_ptr_Function_uint Function
-%251 = OpVariable %_ptr_Function_double Function
-%252 = OpVariable %_ptr_Function_double Function
-%253 = OpVariable %_ptr_Function_bool Function
-%254 = OpVariable %_ptr_Function_uint Function
-%255 = OpVariable %_ptr_Function_uint Function
-%256 = OpVariable %_ptr_Function_double Function
-%257 = OpVariable %_ptr_Function_double Function
-%258 = OpVariable %_ptr_Function_bool Function
-%259 = OpVariable %_ptr_Function_uint Function
-%260 = OpVariable %_ptr_Function_uint Function
-%261 = OpVariable %_ptr_Function_double Function
-%262 = OpVariable %_ptr_Function_double Function
-%263 = OpVariable %_ptr_Function_bool Function
-%264 = OpVariable %_ptr_Function_uint Function
-%265 = OpVariable %_ptr_Function_uint Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_uchar Function
-%276 = OpVariable %_ptr_Function_uchar Function
-%277 = OpVariable %_ptr_Function_uchar Function
-%278 = OpVariable %_ptr_Function_uchar Function
-%279 = OpVariable %_ptr_Function_uchar Function
-%280 = OpVariable %_ptr_Function_uchar Function
-%281 = OpVariable %_ptr_Function_bool Function
-%282 = OpVariable %_ptr_Function_bool Function
-%283 = OpVariable %_ptr_Function_bool Function
-%284 = OpVariable %_ptr_Function_bool Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_double Function
-%288 = OpVariable %_ptr_Function_double Function
-%289 = OpVariable %_ptr_Function_double Function
-%290 = OpVariable %_ptr_Function_double Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_uint Function
-%293 = OpVariable %_ptr_Function_uint Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_bool Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_bool Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_ulong Function
-OpStore %127 %40
-%304 = OpFunctionCall %ulong %3
-OpStore %128 %304
-%305 = OpLoad %ulong %127
-%306 = OpUConvert %uint %305
-OpStore %130 %306
-OpStore %122 %307
-%309 = OpLoad %ulong %127
-%310 = OpIAdd %ulong %ulong_18442240474082181120 %309
-OpStore %131 %310
-%311 = OpLoad %ulong %131
-%312 = OpBitcast %double %311
-OpStore %132 %312
-%314 = OpAccessChain %_ptr_Function_double %122 %uint_0
-%315 = OpLoad %double %132
-OpStore %314 %315
-%317 = OpLoad %ulong %127
-%318 = OpIAdd %ulong %ulong_13830554455654793216 %317
-OpStore %133 %318
-%319 = OpLoad %ulong %133
-%320 = OpBitcast %double %319
-OpStore %134 %320
-%322 = OpAccessChain %_ptr_Function_double %122 %uint_1
-%323 = OpLoad %double %134
-OpStore %322 %323
-%325 = OpLoad %ulong %127
-%326 = OpIAdd %ulong %ulong_9227875636482146304 %325
-OpStore %135 %326
-%327 = OpLoad %ulong %135
-%328 = OpBitcast %double %327
-OpStore %136 %328
-%330 = OpAccessChain %_ptr_Function_double %122 %uint_2
-%331 = OpLoad %double %136
-OpStore %330 %331
-%333 = OpLoad %ulong %127
-%334 = OpIAdd %ulong %ulong_9223372036854775809 %333
-OpStore %137 %334
-%335 = OpLoad %ulong %137
-%336 = OpBitcast %double %335
-OpStore %138 %336
-%338 = OpAccessChain %_ptr_Function_double %122 %uint_3
-%339 = OpLoad %double %138
-OpStore %338 %339
-%341 = OpLoad %ulong %127
-%342 = OpIAdd %ulong %ulong_9223372036854775808 %341
-OpStore %139 %342
-%343 = OpLoad %ulong %139
-%344 = OpBitcast %double %343
-OpStore %140 %344
-%346 = OpAccessChain %_ptr_Function_double %122 %uint_4
-%347 = OpLoad %double %140
-OpStore %346 %347
-%348 = OpLoad %ulong %127
-%349 = OpBitcast %double %348
-OpStore %141 %349
-%351 = OpAccessChain %_ptr_Function_double %122 %uint_5
-%352 = OpLoad %double %141
-OpStore %351 %352
-%354 = OpLoad %ulong %127
-%355 = OpIAdd %ulong %ulong_1 %354
-OpStore %142 %355
-%356 = OpLoad %ulong %142
-%357 = OpBitcast %double %356
-OpStore %143 %357
-%359 = OpAccessChain %_ptr_Function_double %122 %uint_6
-%360 = OpLoad %double %143
-OpStore %359 %360
-%362 = OpLoad %ulong %127
-%363 = OpIAdd %ulong %ulong_4607182418800017408 %362
-OpStore %144 %363
-%364 = OpLoad %ulong %144
-%365 = OpBitcast %double %364
-OpStore %145 %365
-%367 = OpAccessChain %_ptr_Function_double %122 %uint_7
-%368 = OpLoad %double %145
-OpStore %367 %368
-%370 = OpLoad %ulong %127
-%371 = OpIAdd %ulong %ulong_9218868437227405311 %370
-OpStore %146 %371
-%372 = OpLoad %ulong %146
-%373 = OpBitcast %double %372
-OpStore %147 %373
-%374 = OpAccessChain %_ptr_Function_double %122 %uint_8
-%375 = OpLoad %double %147
-OpStore %374 %375
-%377 = OpLoad %ulong %127
-%378 = OpIAdd %ulong %ulong_9218868437227405312 %377
-OpStore %148 %378
-%379 = OpLoad %ulong %148
-%380 = OpBitcast %double %379
-OpStore %149 %380
-%382 = OpAccessChain %_ptr_Function_double %122 %uint_9
-%383 = OpLoad %double %149
-OpStore %382 %383
-%385 = OpLoad %ulong %127
-%386 = OpIAdd %ulong %ulong_9221120237041090560 %385
-OpStore %150 %386
-%387 = OpLoad %ulong %150
-%388 = OpBitcast %double %387
-OpStore %151 %388
-%390 = OpAccessChain %_ptr_Function_double %122 %uint_10
-%391 = OpLoad %double %151
-OpStore %390 %391
-%393 = OpLoad %ulong %127
-%394 = OpIAdd %ulong %ulong_9218868437227405313 %393
-OpStore %152 %394
-%395 = OpLoad %ulong %152
-%396 = OpBitcast %double %395
-OpStore %153 %396
-%398 = OpAccessChain %_ptr_Function_double %122 %uint_11
-%399 = OpLoad %double %153
-OpStore %398 %399
-%400 = OpLoad %ulong %128
-OpStore %272 %400
-OpStore %273 %ulong_0
-OpBranch %42
-%42 = OpLabel
-%402 = OpLoad %ulong %273
-%404 = OpULessThan %bool %402 %ulong_12
-OpStore %154 %404
-%405 = OpLoad %bool %154
-OpLoopMerge %44 %115 None
-OpBranchConditional %405 %43 %44
-%44 = OpLabel
-OpStore %126 %406
-%408 = OpLoad %uint %130
-%409 = OpIAdd %uint %uint_4286578688 %408
-OpStore %199 %409
-%410 = OpLoad %uint %199
-%411 = OpBitcast %float %410
-OpStore %201 %411
-%412 = OpAccessChain %_ptr_Function_float %126 %uint_0
-%413 = OpLoad %float %201
-OpStore %412 %413
-%415 = OpLoad %uint %130
-%416 = OpIAdd %uint %uint_3212836864 %415
-OpStore %202 %416
-%417 = OpLoad %uint %202
-%418 = OpBitcast %float %417
-OpStore %203 %418
-%419 = OpAccessChain %_ptr_Function_float %126 %uint_1
-%420 = OpLoad %float %203
-OpStore %419 %420
-%422 = OpLoad %uint %130
-%423 = OpIAdd %uint %uint_2147483648 %422
-OpStore %204 %423
-%424 = OpLoad %uint %204
-%425 = OpBitcast %float %424
-OpStore %205 %425
-%426 = OpAccessChain %_ptr_Function_float %126 %uint_2
-%427 = OpLoad %float %205
-OpStore %426 %427
-%428 = OpLoad %uint %130
-%429 = OpBitcast %float %428
-OpStore %206 %429
-%430 = OpAccessChain %_ptr_Function_float %126 %uint_3
-%431 = OpLoad %float %206
-OpStore %430 %431
-%432 = OpLoad %uint %130
-%433 = OpIAdd %uint %uint_1 %432
-OpStore %207 %433
-%434 = OpLoad %uint %207
-%435 = OpBitcast %float %434
-OpStore %208 %435
-%436 = OpAccessChain %_ptr_Function_float %126 %uint_4
-%437 = OpLoad %float %208
-OpStore %436 %437
-%439 = OpLoad %uint %130
-%440 = OpIAdd %uint %uint_1065353216 %439
-OpStore %209 %440
-%441 = OpLoad %uint %209
-%442 = OpBitcast %float %441
-OpStore %210 %442
-%443 = OpAccessChain %_ptr_Function_float %126 %uint_5
-%444 = OpLoad %float %210
-OpStore %443 %444
-%446 = OpLoad %uint %130
-%447 = OpIAdd %uint %uint_2139095040 %446
-OpStore %211 %447
-%448 = OpLoad %uint %211
-%449 = OpBitcast %float %448
-OpStore %212 %449
-%450 = OpAccessChain %_ptr_Function_float %126 %uint_6
-%451 = OpLoad %float %212
-OpStore %450 %451
-%453 = OpLoad %uint %130
-%454 = OpIAdd %uint %uint_2143289344 %453
-OpStore %213 %454
-%455 = OpLoad %uint %213
-%456 = OpBitcast %float %455
-OpStore %214 %456
-%457 = OpAccessChain %_ptr_Function_float %126 %uint_7
-%458 = OpLoad %float %214
-OpStore %457 %458
-%459 = OpLoad %ulong %272
-OpStore %270 %459
-OpStore %285 %ulong_0
-OpBranch %74
-%74 = OpLabel
-%460 = OpLoad %ulong %285
-%461 = OpULessThan %bool %460 %ulong_12
-OpStore %215 %461
-%462 = OpLoad %bool %215
-OpLoopMerge %76 %114 None
-OpBranchConditional %462 %75 %76
-%76 = OpLabel
-%463 = OpAccessChain %_ptr_Function_double %122 %uint_0
-%464 = OpLoad %double %463
-OpStore %234 %464
-%465 = OpLoad %double %463
-OpStore %235 %465
-%466 = OpLoad %double %234
-OpStore %288 %466
-%467 = OpLoad %double %235
-OpStore %290 %467
-OpStore %291 %ulong_1
-OpBranch %80
-%80 = OpLabel
-%468 = OpLoad %ulong %291
-%469 = OpULessThan %bool %468 %ulong_12
-OpStore %236 %469
-%470 = OpLoad %bool %236
-OpLoopMerge %82 %112 None
-OpBranchConditional %470 %81 %82
-%82 = OpLabel
-OpBranch %95
-%95 = OpLabel
-%471 = OpLoad %double %288
-%472 = OpLoad %double %288
-%473 = OpFUnordNotEqual %bool %471 %472
-OpStore %296 %473
-%474 = OpLoad %bool %296
-OpSelectionMerge %99 None
-OpBranchConditional %474 %96 %97
-%97 = OpLabel
-OpBranch %98
-%98 = OpLabel
-%475 = OpLoad %ulong %270
-%476 = OpLoad %double %288
-%477 = OpFunctionCall %ulong %7 %475 %476
-OpStore %298 %477
-%478 = OpLoad %ulong %298
-OpStore %299 %478
-OpBranch %99
-%96 = OpLabel
-%479 = OpLoad %ulong %270
-%480 = OpFunctionCall %ulong %4 %479 %ulong_18446744073709551615
-OpStore %297 %480
-%481 = OpLoad %ulong %297
-OpStore %299 %481
-OpBranch %99
-%99 = OpLabel
-OpBranch %100
-%100 = OpLabel
-%482 = OpLoad %double %290
-%483 = OpLoad %double %290
-%484 = OpFUnordNotEqual %bool %482 %483
-OpStore %300 %484
-%485 = OpLoad %bool %300
-OpSelectionMerge %104 None
-OpBranchConditional %485 %101 %102
-%102 = OpLabel
-OpBranch %103
-%103 = OpLabel
-%486 = OpLoad %ulong %299
-%487 = OpLoad %double %290
-%488 = OpFunctionCall %ulong %7 %486 %487
-OpStore %302 %488
-%489 = OpLoad %ulong %302
-OpStore %303 %489
-OpBranch %104
-%101 = OpLabel
-%490 = OpLoad %ulong %299
-%491 = OpFunctionCall %ulong %4 %490 %ulong_18446744073709551615
-OpStore %301 %491
-%492 = OpLoad %ulong %301
-OpStore %303 %492
-OpBranch %104
-%104 = OpLabel
-OpStore %293 %uint_0
-OpStore %294 %ulong_0
-OpBranch %89
-%89 = OpLabel
-%493 = OpLoad %ulong %294
-%494 = OpULessThan %bool %493 %ulong_12
-OpStore %244 %494
-%495 = OpLoad %bool %244
-OpLoopMerge %91 %110 None
-OpBranchConditional %495 %90 %91
-%91 = OpLabel
-%496 = OpLoad %ulong %303
-%497 = OpLoad %uint %293
-%498 = OpFunctionCall %ulong %6 %496 %497
-OpStore %268 %498
-%499 = OpLoad %ulong %268
-OpReturnValue %499
-%90 = OpLabel
-%500 = OpLoad %ulong %294
-%501 = OpAccessChain %_ptr_Function_double %122 %500
-%502 = OpLoad %uint %293
-OpStore %292 %502
-OpStore %295 %ulong_0
-OpBranch %92
-%92 = OpLabel
-%503 = OpLoad %ulong %295
-%504 = OpULessThan %bool %503 %ulong_12
-OpStore %245 %504
-%505 = OpLoad %bool %245
-OpLoopMerge %94 %109 None
-OpBranchConditional %505 %93 %94
-%94 = OpLabel
-%506 = OpLoad %ulong %294
-%507 = OpIAdd %ulong %506 %ulong_1
-OpStore %267 %507
-%508 = OpLoad %uint %292
-OpStore %293 %508
-%509 = OpLoad %ulong %267
-OpStore %294 %509
-OpBranch %110
-%93 = OpLabel
-%510 = OpLoad %double %501
-OpStore %246 %510
-%511 = OpLoad %ulong %295
-%512 = OpAccessChain %_ptr_Function_double %122 %511
-%513 = OpLoad %double %512
-OpStore %247 %513
-%514 = OpLoad %double %246
-%515 = OpLoad %double %247
-%516 = OpFOrdLessThan %bool %514 %515
-OpStore %248 %516
-%517 = OpLoad %bool %248
-%520 = OpSelect %uchar %517 %uchar_1 %uchar_0
-%521 = OpUConvert %uint %520
-OpStore %249 %521
-%522 = OpLoad %uint %292
-%523 = OpLoad %uint %249
-%524 = OpIAdd %uint %522 %523
-OpStore %250 %524
-%525 = OpLoad %double %501
-OpStore %251 %525
-%526 = OpLoad %double %512
-OpStore %252 %526
-%527 = OpLoad %double %251
-%528 = OpLoad %double %252
-%529 = OpFOrdLessThanEqual %bool %527 %528
-OpStore %253 %529
-%530 = OpLoad %bool %253
-%531 = OpSelect %uchar %530 %uchar_1 %uchar_0
-%532 = OpUConvert %uint %531
-OpStore %254 %532
-%533 = OpLoad %uint %250
-%534 = OpLoad %uint %254
-%535 = OpIAdd %uint %533 %534
-OpStore %255 %535
-%536 = OpLoad %double %501
-OpStore %256 %536
-%537 = OpLoad %double %512
-OpStore %257 %537
-%538 = OpLoad %double %256
-%539 = OpLoad %double %257
-%540 = OpFOrdEqual %bool %538 %539
-OpStore %258 %540
-%541 = OpLoad %bool %258
-%542 = OpSelect %uchar %541 %uchar_1 %uchar_0
-%543 = OpUConvert %uint %542
-OpStore %259 %543
-%544 = OpLoad %uint %255
-%545 = OpLoad %uint %259
-%546 = OpIAdd %uint %544 %545
-OpStore %260 %546
-%547 = OpLoad %double %501
-OpStore %261 %547
-%548 = OpLoad %double %512
-OpStore %262 %548
-%549 = OpLoad %double %261
-%550 = OpLoad %double %262
-%551 = OpFUnordNotEqual %bool %549 %550
-OpStore %263 %551
-%552 = OpLoad %bool %263
-%553 = OpSelect %uchar %552 %uchar_1 %uchar_0
-%554 = OpUConvert %uint %553
-OpStore %264 %554
-%555 = OpLoad %uint %260
-%556 = OpLoad %uint %264
-%557 = OpIAdd %uint %555 %556
-OpStore %265 %557
-%558 = OpLoad %ulong %295
-%559 = OpIAdd %ulong %558 %ulong_1
-OpStore %266 %559
-%560 = OpLoad %uint %265
-OpStore %292 %560
-%561 = OpLoad %ulong %266
-OpStore %295 %561
-OpBranch %109
-%81 = OpLabel
-%562 = OpLoad %ulong %291
-%563 = OpAccessChain %_ptr_Function_double %122 %562
-%564 = OpLoad %double %563
-OpStore %237 %564
-%565 = OpLoad %double %237
-%566 = OpLoad %double %288
-%567 = OpFOrdLessThan %bool %565 %566
-OpStore %238 %567
-%568 = OpLoad %bool %238
-OpSelectionMerge %85 None
-OpBranchConditional %568 %83 %84
-%84 = OpLabel
-%569 = OpLoad %double %288
-OpStore %287 %569
-OpBranch %85
-%83 = OpLabel
-%570 = OpLoad %ulong %291
-%571 = OpAccessChain %_ptr_Function_double %122 %570
-%572 = OpLoad %double %571
-OpStore %239 %572
-%573 = OpLoad %double %239
-OpStore %287 %573
-OpBranch %85
-%85 = OpLabel
-%574 = OpLoad %ulong %291
-%575 = OpAccessChain %_ptr_Function_double %122 %574
-%576 = OpLoad %double %575
-OpStore %240 %576
-%577 = OpLoad %double %290
-%578 = OpLoad %double %240
-%579 = OpFOrdLessThan %bool %577 %578
-OpStore %241 %579
-%580 = OpLoad %bool %241
-OpSelectionMerge %88 None
-OpBranchConditional %580 %86 %87
-%87 = OpLabel
-%581 = OpLoad %double %290
-OpStore %289 %581
-OpBranch %88
-%86 = OpLabel
-%582 = OpLoad %ulong %291
-%583 = OpAccessChain %_ptr_Function_double %122 %582
-%584 = OpLoad %double %583
-OpStore %242 %584
-%585 = OpLoad %double %242
-OpStore %289 %585
-OpBranch %88
-%88 = OpLabel
-%586 = OpLoad %ulong %291
-%587 = OpIAdd %ulong %586 %ulong_1
-OpStore %243 %587
-%588 = OpLoad %double %287
-OpStore %288 %588
-%589 = OpLoad %double %289
-OpStore %290 %589
-%590 = OpLoad %ulong %243
-OpStore %291 %590
-OpBranch %112
-%75 = OpLabel
-%591 = OpLoad %ulong %285
-%592 = OpAccessChain %_ptr_Function_double %122 %591
-%593 = OpLoad %ulong %270
-OpStore %269 %593
-OpStore %286 %ulong_0
-OpBranch %77
-%77 = OpLabel
-%594 = OpLoad %ulong %286
-%596 = OpULessThan %bool %594 %ulong_8
-OpStore %216 %596
-%597 = OpLoad %bool %216
-OpLoopMerge %79 %111 None
-OpBranchConditional %597 %78 %79
-%79 = OpLabel
-%598 = OpLoad %ulong %285
-%599 = OpIAdd %ulong %598 %ulong_1
-OpStore %233 %599
-%600 = OpLoad %ulong %269
-OpStore %270 %600
-%601 = OpLoad %ulong %233
-OpStore %285 %601
-OpBranch %114
-%78 = OpLabel
-%602 = OpLoad %double %592
-OpStore %217 %602
-%603 = OpLoad %ulong %286
-%604 = OpAccessChain %_ptr_Function_float %126 %603
-%605 = OpLoad %float %604
-OpStore %218 %605
-%606 = OpLoad %float %218
-%607 = OpFConvert %double %606
-OpStore %219 %607
-%608 = OpLoad %double %217
-%609 = OpLoad %double %219
-%610 = OpFOrdEqual %bool %608 %609
-OpStore %220 %610
-%611 = OpLoad %ulong %269
-%612 = OpLoad %bool %220
-%613 = OpSelect %uchar %612 %uchar_1 %uchar_0
-%614 = OpFunctionCall %ulong %5 %611 %613
-OpStore %221 %614
-%615 = OpLoad %double %217
-%616 = OpLoad %double %219
-%617 = OpFUnordNotEqual %bool %615 %616
-OpStore %222 %617
-%618 = OpLoad %ulong %221
-%619 = OpLoad %bool %222
-%620 = OpSelect %uchar %619 %uchar_1 %uchar_0
-%621 = OpFunctionCall %ulong %5 %618 %620
-OpStore %223 %621
-%622 = OpLoad %double %217
-%623 = OpLoad %double %219
-%624 = OpFOrdLessThan %bool %622 %623
-OpStore %224 %624
-%625 = OpLoad %ulong %223
-%626 = OpLoad %bool %224
-%627 = OpSelect %uchar %626 %uchar_1 %uchar_0
-%628 = OpFunctionCall %ulong %5 %625 %627
-OpStore %225 %628
-%629 = OpLoad %double %217
-%630 = OpLoad %double %219
-%631 = OpFOrdLessThanEqual %bool %629 %630
-OpStore %226 %631
-%632 = OpLoad %ulong %225
-%633 = OpLoad %bool %226
-%634 = OpSelect %uchar %633 %uchar_1 %uchar_0
-%635 = OpFunctionCall %ulong %5 %632 %634
-OpStore %227 %635
-%636 = OpLoad %double %219
-%637 = OpLoad %double %217
-%638 = OpFOrdLessThan %bool %636 %637
-OpStore %228 %638
-%639 = OpLoad %ulong %227
-%640 = OpLoad %bool %228
-%641 = OpSelect %uchar %640 %uchar_1 %uchar_0
-%642 = OpFunctionCall %ulong %5 %639 %641
-OpStore %229 %642
-%643 = OpLoad %double %219
-%644 = OpLoad %double %217
-%645 = OpFOrdLessThanEqual %bool %643 %644
-OpStore %230 %645
-%646 = OpLoad %ulong %229
-%647 = OpLoad %bool %230
-%648 = OpSelect %uchar %647 %uchar_1 %uchar_0
-%649 = OpFunctionCall %ulong %5 %646 %648
-OpStore %231 %649
-%650 = OpLoad %ulong %286
-%651 = OpIAdd %ulong %650 %ulong_1
-OpStore %232 %651
-%652 = OpLoad %ulong %231
-OpStore %269 %652
-%653 = OpLoad %ulong %232
-OpStore %286 %653
-OpBranch %111
-%43 = OpLabel
-%654 = OpLoad %ulong %273
-%655 = OpAccessChain %_ptr_Function_double %122 %654
-%656 = OpLoad %ulong %272
-OpStore %271 %656
-OpStore %274 %ulong_0
-OpBranch %45
-%45 = OpLabel
-%657 = OpLoad %ulong %274
-%658 = OpULessThan %bool %657 %ulong_12
-OpStore %155 %658
-%659 = OpLoad %bool %155
-OpLoopMerge %47 %113 None
-OpBranchConditional %659 %46 %47
-%47 = OpLabel
-%660 = OpLoad %ulong %273
-%661 = OpIAdd %ulong %660 %ulong_1
-OpStore %198 %661
-%662 = OpLoad %ulong %271
-OpStore %272 %662
-%663 = OpLoad %ulong %198
-OpStore %273 %663
-OpBranch %115
-%46 = OpLabel
-%664 = OpLoad %double %655
-OpStore %156 %664
-%665 = OpLoad %ulong %274
-%666 = OpAccessChain %_ptr_Function_double %122 %665
-%667 = OpLoad %double %666
-OpStore %157 %667
-%668 = OpLoad %double %156
-%669 = OpLoad %double %157
-%670 = OpFOrdEqual %bool %668 %669
-OpStore %158 %670
-%671 = OpLoad %ulong %271
-%672 = OpLoad %bool %158
-%673 = OpSelect %uchar %672 %uchar_1 %uchar_0
-%674 = OpFunctionCall %ulong %5 %671 %673
-OpStore %159 %674
-%675 = OpLoad %double %156
-%676 = OpLoad %double %157
-%677 = OpFUnordNotEqual %bool %675 %676
-OpStore %160 %677
-%678 = OpLoad %ulong %159
-%679 = OpLoad %bool %160
-%680 = OpSelect %uchar %679 %uchar_1 %uchar_0
-%681 = OpFunctionCall %ulong %5 %678 %680
-OpStore %161 %681
-%682 = OpLoad %double %156
-%683 = OpLoad %double %157
-%684 = OpFOrdLessThan %bool %682 %683
-OpStore %162 %684
-%685 = OpLoad %ulong %161
-%686 = OpLoad %bool %162
-%687 = OpSelect %uchar %686 %uchar_1 %uchar_0
-%688 = OpFunctionCall %ulong %5 %685 %687
-OpStore %163 %688
-%689 = OpLoad %double %156
-%690 = OpLoad %double %157
-%691 = OpFOrdLessThanEqual %bool %689 %690
-OpStore %164 %691
-%692 = OpLoad %ulong %163
-%693 = OpLoad %bool %164
-%694 = OpSelect %uchar %693 %uchar_1 %uchar_0
-%695 = OpFunctionCall %ulong %5 %692 %694
-OpStore %165 %695
-%696 = OpLoad %double %157
-%697 = OpLoad %double %156
-%698 = OpFOrdLessThan %bool %696 %697
-OpStore %166 %698
-%699 = OpLoad %ulong %165
-%700 = OpLoad %bool %166
-%701 = OpSelect %uchar %700 %uchar_1 %uchar_0
-%702 = OpFunctionCall %ulong %5 %699 %701
-OpStore %167 %702
-%703 = OpLoad %double %157
-%704 = OpLoad %double %156
-%705 = OpFOrdLessThanEqual %bool %703 %704
-OpStore %168 %705
-%706 = OpLoad %ulong %167
-%707 = OpLoad %bool %168
-%708 = OpSelect %uchar %707 %uchar_1 %uchar_0
-%709 = OpFunctionCall %ulong %5 %706 %708
-OpStore %169 %709
-%710 = OpLoad %bool %162
-OpSelectionMerge %50 None
-OpBranchConditional %710 %48 %49
-%49 = OpLabel
-OpStore %280 %uchar_0
-OpBranch %50
-%48 = OpLabel
-OpStore %280 %uchar_1
-OpBranch %50
-%50 = OpLabel
-%711 = OpLoad %double %156
-%712 = OpLoad %double %157
-%713 = OpFOrdLessThanEqual %bool %711 %712
-OpStore %170 %713
-%714 = OpLoad %bool %170
-OpSelectionMerge %53 None
-OpBranchConditional %714 %51 %52
-%52 = OpLabel
-%715 = OpLoad %uchar %280
-OpStore %279 %715
-OpBranch %53
-%51 = OpLabel
-%716 = OpLoad %uchar %280
-%718 = OpIAdd %uchar %716 %uchar_2
-OpStore %172 %718
-%719 = OpLoad %uchar %172
-OpStore %279 %719
-OpBranch %53
-%53 = OpLabel
-%720 = OpLoad %double %157
-%721 = OpLoad %double %156
-%722 = OpFOrdLessThan %bool %720 %721
-OpStore %173 %722
-%723 = OpLoad %bool %173
-OpSelectionMerge %56 None
-OpBranchConditional %723 %54 %55
-%55 = OpLabel
-%724 = OpLoad %uchar %279
-OpStore %278 %724
-OpBranch %56
-%54 = OpLabel
-%725 = OpLoad %uchar %279
-%727 = OpIAdd %uchar %725 %uchar_4
-OpStore %174 %727
-%728 = OpLoad %uchar %174
-OpStore %278 %728
-OpBranch %56
-%56 = OpLabel
-%729 = OpLoad %double %157
-%730 = OpLoad %double %156
-%731 = OpFOrdLessThanEqual %bool %729 %730
-OpStore %175 %731
-%732 = OpLoad %bool %175
-OpSelectionMerge %59 None
-OpBranchConditional %732 %57 %58
-%58 = OpLabel
-%733 = OpLoad %uchar %278
-OpStore %277 %733
-OpBranch %59
-%57 = OpLabel
-%734 = OpLoad %uchar %278
-%736 = OpIAdd %uchar %734 %uchar_8
-OpStore %176 %736
-%737 = OpLoad %uchar %176
-OpStore %277 %737
-OpBranch %59
-%59 = OpLabel
-%738 = OpLoad %double %156
-%739 = OpLoad %double %157
-%740 = OpFOrdEqual %bool %738 %739
-OpStore %177 %740
-%741 = OpLoad %bool %177
-OpSelectionMerge %62 None
-OpBranchConditional %741 %60 %61
-%61 = OpLabel
-%742 = OpLoad %uchar %277
-OpStore %276 %742
-OpBranch %62
-%60 = OpLabel
-%743 = OpLoad %uchar %277
-%745 = OpIAdd %uchar %743 %uchar_16
-OpStore %178 %745
-%746 = OpLoad %uchar %178
-OpStore %276 %746
-OpBranch %62
-%62 = OpLabel
-%747 = OpLoad %double %156
-%748 = OpLoad %double %157
-%749 = OpFUnordNotEqual %bool %747 %748
-OpStore %179 %749
-%750 = OpLoad %bool %179
-OpSelectionMerge %65 None
-OpBranchConditional %750 %63 %64
-%64 = OpLabel
-%751 = OpLoad %uchar %276
-OpStore %275 %751
-OpBranch %65
-%63 = OpLabel
-%752 = OpLoad %uchar %276
-%754 = OpIAdd %uchar %752 %uchar_32
-OpStore %180 %754
-%755 = OpLoad %uchar %180
-OpStore %275 %755
-OpBranch %65
-%65 = OpLabel
-%756 = OpLoad %ulong %169
-%757 = OpLoad %uchar %275
-%758 = OpFunctionCall %ulong %5 %756 %757
-OpStore %181 %758
-%759 = OpLoad %double %156
-%760 = OpLoad %double %157
-%761 = OpFOrdLessThan %bool %759 %760
-OpStore %182 %761
-%762 = OpLoad %bool %182
-OpSelectionMerge %67 None
-OpBranchConditional %762 %66 %105
-%105 = OpLabel
-%763 = OpLoad %bool %182
-OpStore %281 %763
-OpBranch %67
-%66 = OpLabel
-%764 = OpLoad %double %157
-%765 = OpLoad %double %156
-%766 = OpFOrdLessThan %bool %764 %765
-OpStore %183 %766
-%767 = OpLoad %bool %183
-OpStore %281 %767
-OpBranch %67
-%67 = OpLabel
-%768 = OpLoad %ulong %181
-%769 = OpLoad %bool %281
-%770 = OpSelect %uchar %769 %uchar_1 %uchar_0
-%771 = OpFunctionCall %ulong %5 %768 %770
-OpStore %184 %771
-%772 = OpLoad %double %156
-%773 = OpLoad %double %157
-%774 = OpFOrdLessThan %bool %772 %773
-OpStore %185 %774
-%775 = OpLoad %bool %185
-OpSelectionMerge %69 None
-OpBranchConditional %775 %106 %68
-%68 = OpLabel
-%776 = OpLoad %double %157
-%777 = OpLoad %double %156
-%778 = OpFOrdLessThan %bool %776 %777
-OpStore %186 %778
-%779 = OpLoad %bool %186
-OpStore %282 %779
-OpBranch %69
-%106 = OpLabel
-%780 = OpLoad %bool %185
-OpStore %282 %780
-OpBranch %69
-%69 = OpLabel
-%781 = OpLoad %ulong %184
-%782 = OpLoad %bool %282
-%783 = OpSelect %uchar %782 %uchar_1 %uchar_0
-%784 = OpFunctionCall %ulong %5 %781 %783
-OpStore %187 %784
-%785 = OpLoad %double %156
-%786 = OpLoad %double %157
-%787 = OpFOrdLessThan %bool %785 %786
-OpStore %188 %787
-%788 = OpLoad %bool %188
-%789 = OpSelect %uchar %788 %uchar_1 %uchar_0
-%790 = OpINotEqual %bool %789 %uchar_1
-OpStore %189 %790
-%791 = OpLoad %ulong %187
-%792 = OpLoad %bool %189
-%793 = OpSelect %uchar %792 %uchar_1 %uchar_0
-%794 = OpFunctionCall %ulong %5 %791 %793
-OpStore %190 %794
-%795 = OpLoad %double %156
-%796 = OpLoad %double %156
-%797 = OpFOrdEqual %bool %795 %796
-OpStore %191 %797
-%798 = OpLoad %bool %191
-OpSelectionMerge %71 None
-OpBranchConditional %798 %70 %107
-%107 = OpLabel
-%799 = OpLoad %bool %191
-OpStore %283 %799
-OpBranch %71
-%70 = OpLabel
-%800 = OpLoad %double %157
-%801 = OpLoad %double %157
-%802 = OpFOrdEqual %bool %800 %801
-OpStore %192 %802
-%803 = OpLoad %bool %192
-OpStore %283 %803
-OpBranch %71
-%71 = OpLabel
-%804 = OpLoad %ulong %190
-%805 = OpLoad %bool %283
-%806 = OpSelect %uchar %805 %uchar_1 %uchar_0
-%807 = OpFunctionCall %ulong %5 %804 %806
-OpStore %193 %807
-%808 = OpLoad %double %156
-%809 = OpLoad %double %156
-%810 = OpFUnordNotEqual %bool %808 %809
-OpStore %194 %810
-%811 = OpLoad %bool %194
-OpSelectionMerge %73 None
-OpBranchConditional %811 %108 %72
-%72 = OpLabel
-%812 = OpLoad %double %157
-%813 = OpLoad %double %157
-%814 = OpFUnordNotEqual %bool %812 %813
-OpStore %195 %814
-%815 = OpLoad %bool %195
-OpStore %284 %815
-OpBranch %73
-%108 = OpLabel
-%816 = OpLoad %bool %194
-OpStore %284 %816
-OpBranch %73
-%73 = OpLabel
-%817 = OpLoad %ulong %193
-%818 = OpLoad %bool %284
-%819 = OpSelect %uchar %818 %uchar_1 %uchar_0
-%820 = OpFunctionCall %ulong %5 %817 %819
-OpStore %196 %820
-%821 = OpLoad %ulong %274
-%822 = OpIAdd %ulong %821 %ulong_1
-OpStore %197 %822
-%823 = OpLoad %ulong %196
-OpStore %271 %823
-%824 = OpLoad %ulong %197
-OpStore %274 %824
-OpBranch %113
-%109 = OpLabel
-OpBranch %92
+%2 = OpFunction %ulong None %108
+%109 = OpFunctionParameter %ulong
 %110 = OpLabel
-OpBranch %89
+%301 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%305 = OpVariable %_ptr_Function__arr_double_uint_12 Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_uint Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_double Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_double Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_double Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_double Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_double Function
+%319 = OpVariable %_ptr_Function_double Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_double Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_double Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_double Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_double Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_double Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_double Function
+%332 = OpVariable %_ptr_Function_bool Function
+%333 = OpVariable %_ptr_Function_bool Function
+%334 = OpVariable %_ptr_Function_double Function
+%335 = OpVariable %_ptr_Function_double Function
+%336 = OpVariable %_ptr_Function_bool Function
+%337 = OpVariable %_ptr_Function_bool Function
+%338 = OpVariable %_ptr_Function_bool Function
+%339 = OpVariable %_ptr_Function_bool Function
+%340 = OpVariable %_ptr_Function_bool Function
+%341 = OpVariable %_ptr_Function_bool Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_bool Function
+%344 = OpVariable %_ptr_Function_bool Function
+%346 = OpVariable %_ptr_Function_uchar Function
+%347 = OpVariable %_ptr_Function_bool Function
+%348 = OpVariable %_ptr_Function_uchar Function
+%349 = OpVariable %_ptr_Function_bool Function
+%350 = OpVariable %_ptr_Function_uchar Function
+%351 = OpVariable %_ptr_Function_bool Function
+%352 = OpVariable %_ptr_Function_uchar Function
+%353 = OpVariable %_ptr_Function_bool Function
+%354 = OpVariable %_ptr_Function_uchar Function
+%355 = OpVariable %_ptr_Function_bool Function
+%356 = OpVariable %_ptr_Function_bool Function
+%357 = OpVariable %_ptr_Function_bool Function
+%358 = OpVariable %_ptr_Function_bool Function
+%359 = OpVariable %_ptr_Function_bool Function
+%360 = OpVariable %_ptr_Function_bool Function
+%361 = OpVariable %_ptr_Function_bool Function
+%362 = OpVariable %_ptr_Function_bool Function
+%363 = OpVariable %_ptr_Function_bool Function
+%364 = OpVariable %_ptr_Function_bool Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_uint Function
+%369 = OpVariable %_ptr_Function_float Function
+%370 = OpVariable %_ptr_Function_uint Function
+%371 = OpVariable %_ptr_Function_float Function
+%372 = OpVariable %_ptr_Function_uint Function
+%373 = OpVariable %_ptr_Function_float Function
+%374 = OpVariable %_ptr_Function_float Function
+%375 = OpVariable %_ptr_Function_uint Function
+%376 = OpVariable %_ptr_Function_float Function
+%377 = OpVariable %_ptr_Function_uint Function
+%378 = OpVariable %_ptr_Function_float Function
+%379 = OpVariable %_ptr_Function_uint Function
+%380 = OpVariable %_ptr_Function_float Function
+%381 = OpVariable %_ptr_Function_uint Function
+%382 = OpVariable %_ptr_Function_float Function
+%383 = OpVariable %_ptr_Function_bool Function
+%384 = OpVariable %_ptr_Function_bool Function
+%385 = OpVariable %_ptr_Function_double Function
+%386 = OpVariable %_ptr_Function_float Function
+%387 = OpVariable %_ptr_Function_double Function
+%388 = OpVariable %_ptr_Function_bool Function
+%389 = OpVariable %_ptr_Function_double Function
+%390 = OpVariable %_ptr_Function_bool Function
+%391 = OpVariable %_ptr_Function_double Function
+%392 = OpVariable %_ptr_Function_bool Function
+%393 = OpVariable %_ptr_Function_double Function
+%394 = OpVariable %_ptr_Function_bool Function
+%395 = OpVariable %_ptr_Function_double Function
+%396 = OpVariable %_ptr_Function_bool Function
+%397 = OpVariable %_ptr_Function_double Function
+%398 = OpVariable %_ptr_Function_bool Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_double Function
+%403 = OpVariable %_ptr_Function_double Function
+%404 = OpVariable %_ptr_Function_bool Function
+%405 = OpVariable %_ptr_Function_double Function
+%406 = OpVariable %_ptr_Function_bool Function
+%407 = OpVariable %_ptr_Function_double Function
+%408 = OpVariable %_ptr_Function_double Function
+%409 = OpVariable %_ptr_Function_bool Function
+%410 = OpVariable %_ptr_Function_double Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_bool Function
+%415 = OpVariable %_ptr_Function_bool Function
+%416 = OpVariable %_ptr_Function_double Function
+%417 = OpVariable %_ptr_Function_double Function
+%418 = OpVariable %_ptr_Function_bool Function
+%419 = OpVariable %_ptr_Function_uint Function
+%420 = OpVariable %_ptr_Function_uint Function
+%421 = OpVariable %_ptr_Function_double Function
+%422 = OpVariable %_ptr_Function_double Function
+%423 = OpVariable %_ptr_Function_bool Function
+%424 = OpVariable %_ptr_Function_uint Function
+%425 = OpVariable %_ptr_Function_uint Function
+%426 = OpVariable %_ptr_Function_double Function
+%427 = OpVariable %_ptr_Function_double Function
+%428 = OpVariable %_ptr_Function_bool Function
+%429 = OpVariable %_ptr_Function_uint Function
+%430 = OpVariable %_ptr_Function_uint Function
+%431 = OpVariable %_ptr_Function_double Function
+%432 = OpVariable %_ptr_Function_double Function
+%433 = OpVariable %_ptr_Function_bool Function
+%434 = OpVariable %_ptr_Function_uint Function
+%435 = OpVariable %_ptr_Function_uint Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_uchar Function
+%445 = OpVariable %_ptr_Function_uchar Function
+%446 = OpVariable %_ptr_Function_uchar Function
+%447 = OpVariable %_ptr_Function_uchar Function
+%448 = OpVariable %_ptr_Function_uchar Function
+%449 = OpVariable %_ptr_Function_uchar Function
+%450 = OpVariable %_ptr_Function_bool Function
+%451 = OpVariable %_ptr_Function_bool Function
+%452 = OpVariable %_ptr_Function_bool Function
+%453 = OpVariable %_ptr_Function_bool Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_double Function
+%457 = OpVariable %_ptr_Function_double Function
+%458 = OpVariable %_ptr_Function_double Function
+%459 = OpVariable %_ptr_Function_double Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_uint Function
+%462 = OpVariable %_ptr_Function_uint Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_bool Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_bool Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_bool Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_bool Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_bool Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_bool Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_bool Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_bool Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_bool Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_bool Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_ulong Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_bool Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_bool Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_ulong Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_bool Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_ulong Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_ulong Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_ulong Function
+%610 = OpVariable %_ptr_Function_ulong Function
+OpStore %306 %109
+OpBranch %164
+%164 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%611 = OpLoad %ulong %306
+%612 = OpUConvert %uint %611
+OpStore %308 %612
+OpStore %305 %613
+%615 = OpLoad %ulong %306
+%616 = OpIAdd %ulong %ulong_18442240474082181120 %615
+OpStore %309 %616
+%617 = OpLoad %ulong %309
+%618 = OpBitcast %double %617
+OpStore %310 %618
+%620 = OpAccessChain %_ptr_Function_double %305 %uint_0
+%621 = OpLoad %double %310
+OpStore %620 %621
+%623 = OpLoad %ulong %306
+%624 = OpIAdd %ulong %ulong_13830554455654793216 %623
+OpStore %311 %624
+%625 = OpLoad %ulong %311
+%626 = OpBitcast %double %625
+OpStore %312 %626
+%628 = OpAccessChain %_ptr_Function_double %305 %uint_1
+%629 = OpLoad %double %312
+OpStore %628 %629
+%631 = OpLoad %ulong %306
+%632 = OpIAdd %ulong %ulong_9227875636482146304 %631
+OpStore %313 %632
+%633 = OpLoad %ulong %313
+%634 = OpBitcast %double %633
+OpStore %314 %634
+%636 = OpAccessChain %_ptr_Function_double %305 %uint_2
+%637 = OpLoad %double %314
+OpStore %636 %637
+%639 = OpLoad %ulong %306
+%640 = OpIAdd %ulong %ulong_9223372036854775809 %639
+OpStore %315 %640
+%641 = OpLoad %ulong %315
+%642 = OpBitcast %double %641
+OpStore %316 %642
+%644 = OpAccessChain %_ptr_Function_double %305 %uint_3
+%645 = OpLoad %double %316
+OpStore %644 %645
+%647 = OpLoad %ulong %306
+%648 = OpIAdd %ulong %ulong_9223372036854775808 %647
+OpStore %317 %648
+%649 = OpLoad %ulong %317
+%650 = OpBitcast %double %649
+OpStore %318 %650
+%652 = OpAccessChain %_ptr_Function_double %305 %uint_4
+%653 = OpLoad %double %318
+OpStore %652 %653
+%654 = OpLoad %ulong %306
+%655 = OpBitcast %double %654
+OpStore %319 %655
+%657 = OpAccessChain %_ptr_Function_double %305 %uint_5
+%658 = OpLoad %double %319
+OpStore %657 %658
+%659 = OpLoad %ulong %306
+%660 = OpIAdd %ulong %ulong_1 %659
+OpStore %320 %660
+%661 = OpLoad %ulong %320
+%662 = OpBitcast %double %661
+OpStore %321 %662
+%664 = OpAccessChain %_ptr_Function_double %305 %uint_6
+%665 = OpLoad %double %321
+OpStore %664 %665
+%667 = OpLoad %ulong %306
+%668 = OpIAdd %ulong %ulong_4607182418800017408 %667
+OpStore %322 %668
+%669 = OpLoad %ulong %322
+%670 = OpBitcast %double %669
+OpStore %323 %670
+%672 = OpAccessChain %_ptr_Function_double %305 %uint_7
+%673 = OpLoad %double %323
+OpStore %672 %673
+%675 = OpLoad %ulong %306
+%676 = OpIAdd %ulong %ulong_9218868437227405311 %675
+OpStore %324 %676
+%677 = OpLoad %ulong %324
+%678 = OpBitcast %double %677
+OpStore %325 %678
+%679 = OpAccessChain %_ptr_Function_double %305 %uint_8
+%680 = OpLoad %double %325
+OpStore %679 %680
+%682 = OpLoad %ulong %306
+%683 = OpIAdd %ulong %ulong_9218868437227405312 %682
+OpStore %326 %683
+%684 = OpLoad %ulong %326
+%685 = OpBitcast %double %684
+OpStore %327 %685
+%687 = OpAccessChain %_ptr_Function_double %305 %uint_9
+%688 = OpLoad %double %327
+OpStore %687 %688
+%690 = OpLoad %ulong %306
+%691 = OpIAdd %ulong %ulong_9221120237041090560 %690
+OpStore %328 %691
+%692 = OpLoad %ulong %328
+%693 = OpBitcast %double %692
+OpStore %329 %693
+%695 = OpAccessChain %_ptr_Function_double %305 %uint_10
+%696 = OpLoad %double %329
+OpStore %695 %696
+%698 = OpLoad %ulong %306
+%699 = OpIAdd %ulong %ulong_9218868437227405313 %698
+OpStore %330 %699
+%700 = OpLoad %ulong %330
+%701 = OpBitcast %double %700
+OpStore %331 %701
+%703 = OpAccessChain %_ptr_Function_double %305 %uint_11
+%704 = OpLoad %double %331
+OpStore %703 %704
+OpStore %441 %ulong_14695981039346656037
+OpStore %442 %ulong_0
+OpBranch %111
 %111 = OpLabel
-OpBranch %77
-%112 = OpLabel
-OpBranch %80
+%706 = OpLoad %ulong %442
+%708 = OpULessThan %bool %706 %ulong_12
+OpStore %332 %708
+%709 = OpLoad %bool %332
+OpLoopMerge %113 %294 None
+OpBranchConditional %709 %112 %113
 %113 = OpLabel
-OpBranch %45
+OpStore %301 %710
+%712 = OpLoad %uint %308
+%713 = OpIAdd %uint %uint_4286578688 %712
+OpStore %367 %713
+%714 = OpLoad %uint %367
+%715 = OpBitcast %float %714
+OpStore %369 %715
+%716 = OpAccessChain %_ptr_Function_float %301 %uint_0
+%717 = OpLoad %float %369
+OpStore %716 %717
+%719 = OpLoad %uint %308
+%720 = OpIAdd %uint %uint_3212836864 %719
+OpStore %370 %720
+%721 = OpLoad %uint %370
+%722 = OpBitcast %float %721
+OpStore %371 %722
+%723 = OpAccessChain %_ptr_Function_float %301 %uint_1
+%724 = OpLoad %float %371
+OpStore %723 %724
+%726 = OpLoad %uint %308
+%727 = OpIAdd %uint %uint_2147483648 %726
+OpStore %372 %727
+%728 = OpLoad %uint %372
+%729 = OpBitcast %float %728
+OpStore %373 %729
+%730 = OpAccessChain %_ptr_Function_float %301 %uint_2
+%731 = OpLoad %float %373
+OpStore %730 %731
+%732 = OpLoad %uint %308
+%733 = OpBitcast %float %732
+OpStore %374 %733
+%734 = OpAccessChain %_ptr_Function_float %301 %uint_3
+%735 = OpLoad %float %374
+OpStore %734 %735
+%736 = OpLoad %uint %308
+%737 = OpIAdd %uint %uint_1 %736
+OpStore %375 %737
+%738 = OpLoad %uint %375
+%739 = OpBitcast %float %738
+OpStore %376 %739
+%740 = OpAccessChain %_ptr_Function_float %301 %uint_4
+%741 = OpLoad %float %376
+OpStore %740 %741
+%743 = OpLoad %uint %308
+%744 = OpIAdd %uint %uint_1065353216 %743
+OpStore %377 %744
+%745 = OpLoad %uint %377
+%746 = OpBitcast %float %745
+OpStore %378 %746
+%747 = OpAccessChain %_ptr_Function_float %301 %uint_5
+%748 = OpLoad %float %378
+OpStore %747 %748
+%750 = OpLoad %uint %308
+%751 = OpIAdd %uint %uint_2139095040 %750
+OpStore %379 %751
+%752 = OpLoad %uint %379
+%753 = OpBitcast %float %752
+OpStore %380 %753
+%754 = OpAccessChain %_ptr_Function_float %301 %uint_6
+%755 = OpLoad %float %380
+OpStore %754 %755
+%757 = OpLoad %uint %308
+%758 = OpIAdd %uint %uint_2143289344 %757
+OpStore %381 %758
+%759 = OpLoad %uint %381
+%760 = OpBitcast %float %759
+OpStore %382 %760
+%761 = OpAccessChain %_ptr_Function_float %301 %uint_7
+%762 = OpLoad %float %382
+OpStore %761 %762
+%763 = OpLoad %ulong %441
+OpStore %439 %763
+OpStore %454 %ulong_0
+OpBranch %143
+%143 = OpLabel
+%764 = OpLoad %ulong %454
+%765 = OpULessThan %bool %764 %ulong_12
+OpStore %383 %765
+%766 = OpLoad %bool %383
+OpLoopMerge %145 %293 None
+OpBranchConditional %766 %144 %145
+%145 = OpLabel
+%767 = OpAccessChain %_ptr_Function_double %305 %uint_0
+%768 = OpLoad %double %767
+OpStore %402 %768
+%769 = OpLoad %double %767
+OpStore %403 %769
+%770 = OpLoad %double %402
+OpStore %457 %770
+%771 = OpLoad %double %403
+OpStore %459 %771
+OpStore %460 %ulong_1
+OpBranch %149
+%149 = OpLabel
+%772 = OpLoad %ulong %460
+%773 = OpULessThan %bool %772 %ulong_12
+OpStore %404 %773
+%774 = OpLoad %bool %404
+OpLoopMerge %151 %291 None
+OpBranchConditional %774 %150 %151
+%151 = OpLabel
+%775 = OpLoad %ulong %439
+%776 = OpLoad %double %457
+%777 = OpFunctionCall %ulong %1 %775 %776
+OpStore %412 %777
+%778 = OpLoad %ulong %412
+%779 = OpLoad %double %459
+%780 = OpFunctionCall %ulong %1 %778 %779
+OpStore %413 %780
+OpStore %462 %uint_0
+OpStore %463 %ulong_0
+OpBranch %158
+%158 = OpLabel
+%781 = OpLoad %ulong %463
+%782 = OpULessThan %bool %781 %ulong_12
+OpStore %414 %782
+%783 = OpLoad %bool %414
+OpLoopMerge %160 %288 None
+OpBranchConditional %783 %159 %160
+%160 = OpLabel
+OpBranch %180
+%180 = OpLabel
+%784 = OpLoad %uint %462
+%785 = OpUConvert %ulong %784
+OpStore %472 %785
+OpBranch %223
+%223 = OpLabel
+%786 = OpLoad %ulong %413
+OpStore %546 %786
+OpStore %547 %ulong_0
+OpBranch %224
+%224 = OpLabel
+%787 = OpLoad %ulong %547
+%788 = OpULessThan %bool %787 %ulong_8
+OpStore %539 %788
+%789 = OpLoad %bool %539
+OpLoopMerge %226 %285 None
+OpBranchConditional %789 %225 %226
+%226 = OpLabel
+OpBranch %227
+%227 = OpLabel
+OpBranch %181
+%181 = OpLabel
+%790 = OpLoad %ulong %546
+OpReturnValue %790
+%225 = OpLabel
+%791 = OpLoad %ulong %547
+%792 = OpIMul %ulong %791 %ulong_8
+OpStore %540 %792
+%793 = OpLoad %ulong %472
+%794 = OpLoad %ulong %540
+%795 = OpShiftRightLogical %ulong %793 %794
+OpStore %541 %795
+%796 = OpLoad %ulong %541
+%797 = OpBitwiseAnd %ulong %796 %ulong_255
+OpStore %542 %797
+%798 = OpLoad %ulong %546
+%799 = OpLoad %ulong %542
+%800 = OpBitwiseXor %ulong %798 %799
+OpStore %543 %800
+%801 = OpLoad %ulong %543
+%802 = OpIMul %ulong %801 %ulong_1099511628211
+OpStore %544 %802
+%803 = OpLoad %ulong %547
+%804 = OpIAdd %ulong %803 %ulong_1
+OpStore %545 %804
+%805 = OpLoad %ulong %544
+OpStore %546 %805
+%806 = OpLoad %ulong %545
+OpStore %547 %806
+OpBranch %285
+%159 = OpLabel
+%807 = OpLoad %ulong %463
+%808 = OpAccessChain %_ptr_Function_double %305 %807
+%809 = OpLoad %uint %462
+OpStore %461 %809
+OpStore %464 %ulong_0
+OpBranch %161
+%161 = OpLabel
+%810 = OpLoad %ulong %464
+%811 = OpULessThan %bool %810 %ulong_12
+OpStore %415 %811
+%812 = OpLoad %bool %415
+OpLoopMerge %163 %286 None
+OpBranchConditional %812 %162 %163
+%163 = OpLabel
+%813 = OpLoad %ulong %463
+%814 = OpIAdd %ulong %813 %ulong_1
+OpStore %437 %814
+%815 = OpLoad %uint %461
+OpStore %462 %815
+%816 = OpLoad %ulong %437
+OpStore %463 %816
+OpBranch %288
+%162 = OpLabel
+%817 = OpLoad %double %808
+OpStore %416 %817
+%818 = OpLoad %ulong %464
+%819 = OpAccessChain %_ptr_Function_double %305 %818
+%820 = OpLoad %double %819
+OpStore %417 %820
+%821 = OpLoad %double %416
+%822 = OpLoad %double %417
+%823 = OpFOrdLessThan %bool %821 %822
+OpStore %418 %823
+%824 = OpLoad %bool %418
+%827 = OpSelect %uchar %824 %uchar_1 %uchar_0
+%828 = OpUConvert %uint %827
+OpStore %419 %828
+%829 = OpLoad %uint %461
+%830 = OpLoad %uint %419
+%831 = OpIAdd %uint %829 %830
+OpStore %420 %831
+%832 = OpLoad %double %808
+OpStore %421 %832
+%833 = OpLoad %double %819
+OpStore %422 %833
+%834 = OpLoad %double %421
+%835 = OpLoad %double %422
+%836 = OpFOrdLessThanEqual %bool %834 %835
+OpStore %423 %836
+%837 = OpLoad %bool %423
+%838 = OpSelect %uchar %837 %uchar_1 %uchar_0
+%839 = OpUConvert %uint %838
+OpStore %424 %839
+%840 = OpLoad %uint %420
+%841 = OpLoad %uint %424
+%842 = OpIAdd %uint %840 %841
+OpStore %425 %842
+%843 = OpLoad %double %808
+OpStore %426 %843
+%844 = OpLoad %double %819
+OpStore %427 %844
+%845 = OpLoad %double %426
+%846 = OpLoad %double %427
+%847 = OpFOrdEqual %bool %845 %846
+OpStore %428 %847
+%848 = OpLoad %bool %428
+%849 = OpSelect %uchar %848 %uchar_1 %uchar_0
+%850 = OpUConvert %uint %849
+OpStore %429 %850
+%851 = OpLoad %uint %425
+%852 = OpLoad %uint %429
+%853 = OpIAdd %uint %851 %852
+OpStore %430 %853
+%854 = OpLoad %double %808
+OpStore %431 %854
+%855 = OpLoad %double %819
+OpStore %432 %855
+%856 = OpLoad %double %431
+%857 = OpLoad %double %432
+%858 = OpFUnordNotEqual %bool %856 %857
+OpStore %433 %858
+%859 = OpLoad %bool %433
+%860 = OpSelect %uchar %859 %uchar_1 %uchar_0
+%861 = OpUConvert %uint %860
+OpStore %434 %861
+%862 = OpLoad %uint %430
+%863 = OpLoad %uint %434
+%864 = OpIAdd %uint %862 %863
+OpStore %435 %864
+%865 = OpLoad %ulong %464
+%866 = OpIAdd %ulong %865 %ulong_1
+OpStore %436 %866
+%867 = OpLoad %uint %435
+OpStore %461 %867
+%868 = OpLoad %ulong %436
+OpStore %464 %868
+OpBranch %286
+%150 = OpLabel
+%869 = OpLoad %ulong %460
+%870 = OpAccessChain %_ptr_Function_double %305 %869
+%871 = OpLoad %double %870
+OpStore %405 %871
+%872 = OpLoad %double %405
+%873 = OpLoad %double %457
+%874 = OpFOrdLessThan %bool %872 %873
+OpStore %406 %874
+%875 = OpLoad %bool %406
+OpSelectionMerge %154 None
+OpBranchConditional %875 %152 %153
+%153 = OpLabel
+%876 = OpLoad %double %457
+OpStore %456 %876
+OpBranch %154
+%152 = OpLabel
+%877 = OpLoad %ulong %460
+%878 = OpAccessChain %_ptr_Function_double %305 %877
+%879 = OpLoad %double %878
+OpStore %407 %879
+%880 = OpLoad %double %407
+OpStore %456 %880
+OpBranch %154
+%154 = OpLabel
+%881 = OpLoad %ulong %460
+%882 = OpAccessChain %_ptr_Function_double %305 %881
+%883 = OpLoad %double %882
+OpStore %408 %883
+%884 = OpLoad %double %459
+%885 = OpLoad %double %408
+%886 = OpFOrdLessThan %bool %884 %885
+OpStore %409 %886
+%887 = OpLoad %bool %409
+OpSelectionMerge %157 None
+OpBranchConditional %887 %155 %156
+%156 = OpLabel
+%888 = OpLoad %double %459
+OpStore %458 %888
+OpBranch %157
+%155 = OpLabel
+%889 = OpLoad %ulong %460
+%890 = OpAccessChain %_ptr_Function_double %305 %889
+%891 = OpLoad %double %890
+OpStore %410 %891
+%892 = OpLoad %double %410
+OpStore %458 %892
+OpBranch %157
+%157 = OpLabel
+%893 = OpLoad %ulong %460
+%894 = OpIAdd %ulong %893 %ulong_1
+OpStore %411 %894
+%895 = OpLoad %double %456
+OpStore %457 %895
+%896 = OpLoad %double %458
+OpStore %459 %896
+%897 = OpLoad %ulong %411
+OpStore %460 %897
+OpBranch %291
+%144 = OpLabel
+%898 = OpLoad %ulong %454
+%899 = OpAccessChain %_ptr_Function_double %305 %898
+%900 = OpLoad %ulong %439
+OpStore %438 %900
+OpStore %455 %ulong_0
+OpBranch %146
+%146 = OpLabel
+%901 = OpLoad %ulong %455
+%902 = OpULessThan %bool %901 %ulong_8
+OpStore %384 %902
+%903 = OpLoad %bool %384
+OpLoopMerge %148 %290 None
+OpBranchConditional %903 %147 %148
+%148 = OpLabel
+%904 = OpLoad %ulong %454
+%905 = OpIAdd %ulong %904 %ulong_1
+OpStore %401 %905
+%906 = OpLoad %ulong %438
+OpStore %439 %906
+%907 = OpLoad %ulong %401
+OpStore %454 %907
+OpBranch %293
+%147 = OpLabel
+%908 = OpLoad %double %899
+OpStore %385 %908
+%909 = OpLoad %ulong %455
+%910 = OpAccessChain %_ptr_Function_float %301 %909
+%911 = OpLoad %float %910
+OpStore %386 %911
+%912 = OpLoad %float %386
+%913 = OpFConvert %double %912
+OpStore %387 %913
+%914 = OpLoad %double %385
+%915 = OpLoad %double %387
+%916 = OpFOrdEqual %bool %914 %915
+OpStore %388 %916
+OpBranch %178
+%178 = OpLabel
+%917 = OpLoad %bool %388
+%918 = OpSelect %uchar %917 %uchar_1 %uchar_0
+%919 = OpUConvert %ulong %918
+OpStore %471 %919
+OpBranch %216
+%216 = OpLabel
+%920 = OpLoad %ulong %438
+OpStore %536 %920
+OpStore %537 %ulong_0
+OpBranch %217
+%217 = OpLabel
+%921 = OpLoad %ulong %537
+%922 = OpULessThan %bool %921 %ulong_8
+OpStore %529 %922
+%923 = OpLoad %bool %529
+OpLoopMerge %219 %287 None
+OpBranchConditional %923 %218 %219
+%219 = OpLabel
+OpBranch %220
+%220 = OpLabel
+OpBranch %179
+%179 = OpLabel
+%924 = OpLoad %float %386
+%925 = OpFConvert %double %924
+OpStore %389 %925
+%926 = OpLoad %double %385
+%927 = OpLoad %double %389
+%928 = OpFUnordNotEqual %bool %926 %927
+OpStore %390 %928
+OpBranch %221
+%221 = OpLabel
+%929 = OpLoad %bool %390
+%930 = OpSelect %uchar %929 %uchar_1 %uchar_0
+%931 = OpUConvert %ulong %930
+OpStore %538 %931
+OpBranch %240
+%240 = OpLabel
+%932 = OpLoad %ulong %536
+OpStore %574 %932
+OpStore %575 %ulong_0
+OpBranch %241
+%241 = OpLabel
+%933 = OpLoad %ulong %575
+%934 = OpULessThan %bool %933 %ulong_8
+OpStore %567 %934
+%935 = OpLoad %bool %567
+OpLoopMerge %243 %283 None
+OpBranchConditional %935 %242 %243
+%243 = OpLabel
+OpBranch %244
+%244 = OpLabel
+OpBranch %222
+%222 = OpLabel
+%936 = OpLoad %float %386
+%937 = OpFConvert %double %936
+OpStore %391 %937
+%938 = OpLoad %double %385
+%939 = OpLoad %double %391
+%940 = OpFOrdLessThan %bool %938 %939
+OpStore %392 %940
+OpBranch %245
+%245 = OpLabel
+%941 = OpLoad %bool %392
+%942 = OpSelect %uchar %941 %uchar_1 %uchar_0
+%943 = OpUConvert %ulong %942
+OpStore %576 %943
+OpBranch %254
+%254 = OpLabel
+%944 = OpLoad %ulong %574
+OpStore %594 %944
+OpStore %595 %ulong_0
+OpBranch %255
+%255 = OpLabel
+%945 = OpLoad %ulong %595
+%946 = OpULessThan %bool %945 %ulong_8
+OpStore %587 %946
+%947 = OpLoad %bool %587
+OpLoopMerge %257 %281 None
+OpBranchConditional %947 %256 %257
+%257 = OpLabel
+OpBranch %258
+%258 = OpLabel
+OpBranch %246
+%246 = OpLabel
+%948 = OpLoad %float %386
+%949 = OpFConvert %double %948
+OpStore %393 %949
+%950 = OpLoad %double %385
+%951 = OpLoad %double %393
+%952 = OpFOrdLessThanEqual %bool %950 %951
+OpStore %394 %952
+OpBranch %259
+%259 = OpLabel
+%953 = OpLoad %bool %394
+%954 = OpSelect %uchar %953 %uchar_1 %uchar_0
+%955 = OpUConvert %ulong %954
+OpStore %596 %955
+%956 = OpLoad %ulong %594
+%957 = OpLoad %ulong %596
+%958 = OpFunctionCall %ulong %3 %956 %957
+OpStore %597 %958
+OpBranch %260
+%260 = OpLabel
+%959 = OpLoad %float %386
+%960 = OpFConvert %double %959
+OpStore %395 %960
+%961 = OpLoad %double %395
+%962 = OpLoad %double %385
+%963 = OpFOrdLessThan %bool %961 %962
+OpStore %396 %963
+OpBranch %268
+%268 = OpLabel
+%964 = OpLoad %bool %396
+%965 = OpSelect %uchar %964 %uchar_1 %uchar_0
+%966 = OpUConvert %ulong %965
+OpStore %609 %966
+%967 = OpLoad %ulong %597
+%968 = OpLoad %ulong %609
+%969 = OpFunctionCall %ulong %3 %967 %968
+OpStore %610 %969
+OpBranch %269
+%269 = OpLabel
+%970 = OpLoad %float %386
+%971 = OpFConvert %double %970
+OpStore %397 %971
+%972 = OpLoad %double %397
+%973 = OpLoad %double %385
+%974 = OpFOrdLessThanEqual %bool %972 %973
+OpStore %398 %974
+%975 = OpLoad %ulong %610
+%976 = OpLoad %bool %398
+%977 = OpSelect %uchar %976 %uchar_1 %uchar_0
+%978 = OpFunctionCall %ulong %4 %975 %977
+OpStore %399 %978
+%979 = OpLoad %ulong %455
+%980 = OpIAdd %ulong %979 %ulong_1
+OpStore %400 %980
+%981 = OpLoad %ulong %399
+OpStore %438 %981
+%982 = OpLoad %ulong %400
+OpStore %455 %982
+OpBranch %290
+%256 = OpLabel
+%983 = OpLoad %ulong %595
+%984 = OpIMul %ulong %983 %ulong_8
+OpStore %588 %984
+%985 = OpLoad %ulong %576
+%986 = OpLoad %ulong %588
+%987 = OpShiftRightLogical %ulong %985 %986
+OpStore %589 %987
+%988 = OpLoad %ulong %589
+%989 = OpBitwiseAnd %ulong %988 %ulong_255
+OpStore %590 %989
+%990 = OpLoad %ulong %594
+%991 = OpLoad %ulong %590
+%992 = OpBitwiseXor %ulong %990 %991
+OpStore %591 %992
+%993 = OpLoad %ulong %591
+%994 = OpIMul %ulong %993 %ulong_1099511628211
+OpStore %592 %994
+%995 = OpLoad %ulong %595
+%996 = OpIAdd %ulong %995 %ulong_1
+OpStore %593 %996
+%997 = OpLoad %ulong %592
+OpStore %594 %997
+%998 = OpLoad %ulong %593
+OpStore %595 %998
+OpBranch %281
+%242 = OpLabel
+%999 = OpLoad %ulong %575
+%1000 = OpIMul %ulong %999 %ulong_8
+OpStore %568 %1000
+%1001 = OpLoad %ulong %538
+%1002 = OpLoad %ulong %568
+%1003 = OpShiftRightLogical %ulong %1001 %1002
+OpStore %569 %1003
+%1004 = OpLoad %ulong %569
+%1005 = OpBitwiseAnd %ulong %1004 %ulong_255
+OpStore %570 %1005
+%1006 = OpLoad %ulong %574
+%1007 = OpLoad %ulong %570
+%1008 = OpBitwiseXor %ulong %1006 %1007
+OpStore %571 %1008
+%1009 = OpLoad %ulong %571
+%1010 = OpIMul %ulong %1009 %ulong_1099511628211
+OpStore %572 %1010
+%1011 = OpLoad %ulong %575
+%1012 = OpIAdd %ulong %1011 %ulong_1
+OpStore %573 %1012
+%1013 = OpLoad %ulong %572
+OpStore %574 %1013
+%1014 = OpLoad %ulong %573
+OpStore %575 %1014
+OpBranch %283
+%218 = OpLabel
+%1015 = OpLoad %ulong %537
+%1016 = OpIMul %ulong %1015 %ulong_8
+OpStore %530 %1016
+%1017 = OpLoad %ulong %471
+%1018 = OpLoad %ulong %530
+%1019 = OpShiftRightLogical %ulong %1017 %1018
+OpStore %531 %1019
+%1020 = OpLoad %ulong %531
+%1021 = OpBitwiseAnd %ulong %1020 %ulong_255
+OpStore %532 %1021
+%1022 = OpLoad %ulong %536
+%1023 = OpLoad %ulong %532
+%1024 = OpBitwiseXor %ulong %1022 %1023
+OpStore %533 %1024
+%1025 = OpLoad %ulong %533
+%1026 = OpIMul %ulong %1025 %ulong_1099511628211
+OpStore %534 %1026
+%1027 = OpLoad %ulong %537
+%1028 = OpIAdd %ulong %1027 %ulong_1
+OpStore %535 %1028
+%1029 = OpLoad %ulong %534
+OpStore %536 %1029
+%1030 = OpLoad %ulong %535
+OpStore %537 %1030
+OpBranch %287
+%112 = OpLabel
+%1031 = OpLoad %ulong %442
+%1032 = OpAccessChain %_ptr_Function_double %305 %1031
+%1033 = OpLoad %ulong %441
+OpStore %440 %1033
+OpStore %443 %ulong_0
+OpBranch %114
 %114 = OpLabel
-OpBranch %74
+%1034 = OpLoad %ulong %443
+%1035 = OpULessThan %bool %1034 %ulong_12
+OpStore %333 %1035
+%1036 = OpLoad %bool %333
+OpLoopMerge %116 %292 None
+OpBranchConditional %1036 %115 %116
+%116 = OpLabel
+%1037 = OpLoad %ulong %442
+%1038 = OpIAdd %ulong %1037 %ulong_1
+OpStore %366 %1038
+%1039 = OpLoad %ulong %440
+OpStore %441 %1039
+%1040 = OpLoad %ulong %366
+OpStore %442 %1040
+OpBranch %294
 %115 = OpLabel
-OpBranch %42
+%1041 = OpLoad %double %1032
+OpStore %334 %1041
+%1042 = OpLoad %ulong %443
+%1043 = OpAccessChain %_ptr_Function_double %305 %1042
+%1044 = OpLoad %double %1043
+OpStore %335 %1044
+%1045 = OpLoad %double %334
+%1046 = OpLoad %double %335
+%1047 = OpFOrdEqual %bool %1045 %1046
+OpStore %336 %1047
+OpBranch %166
+%166 = OpLabel
+%1048 = OpLoad %bool %336
+%1049 = OpSelect %uchar %1048 %uchar_1 %uchar_0
+%1050 = OpUConvert %ulong %1049
+OpStore %465 %1050
+OpBranch %182
+%182 = OpLabel
+%1051 = OpLoad %ulong %440
+OpStore %480 %1051
+OpStore %481 %ulong_0
+OpBranch %183
+%183 = OpLabel
+%1052 = OpLoad %ulong %481
+%1053 = OpULessThan %bool %1052 %ulong_8
+OpStore %473 %1053
+%1054 = OpLoad %bool %473
+OpLoopMerge %185 %289 None
+OpBranchConditional %1054 %184 %185
+%185 = OpLabel
+OpBranch %186
+%186 = OpLabel
+OpBranch %167
+%167 = OpLabel
+%1055 = OpLoad %double %334
+%1056 = OpLoad %double %335
+%1057 = OpFUnordNotEqual %bool %1055 %1056
+OpStore %337 %1057
+OpBranch %187
+%187 = OpLabel
+%1058 = OpLoad %bool %337
+%1059 = OpSelect %uchar %1058 %uchar_1 %uchar_0
+%1060 = OpUConvert %ulong %1059
+OpStore %482 %1060
+OpBranch %228
+%228 = OpLabel
+%1061 = OpLoad %ulong %480
+OpStore %555 %1061
+OpStore %556 %ulong_0
+OpBranch %229
+%229 = OpLabel
+%1062 = OpLoad %ulong %556
+%1063 = OpULessThan %bool %1062 %ulong_8
+OpStore %548 %1063
+%1064 = OpLoad %bool %548
+OpLoopMerge %231 %284 None
+OpBranchConditional %1064 %230 %231
+%231 = OpLabel
+OpBranch %232
+%232 = OpLabel
+OpBranch %188
+%188 = OpLabel
+%1065 = OpLoad %double %334
+%1066 = OpLoad %double %335
+%1067 = OpFOrdLessThan %bool %1065 %1066
+OpStore %338 %1067
+OpBranch %233
+%233 = OpLabel
+%1068 = OpLoad %bool %338
+%1069 = OpSelect %uchar %1068 %uchar_1 %uchar_0
+%1070 = OpUConvert %ulong %1069
+OpStore %557 %1070
+OpBranch %247
+%247 = OpLabel
+%1071 = OpLoad %ulong %555
+OpStore %584 %1071
+OpStore %585 %ulong_0
+OpBranch %248
+%248 = OpLabel
+%1072 = OpLoad %ulong %585
+%1073 = OpULessThan %bool %1072 %ulong_8
+OpStore %577 %1073
+%1074 = OpLoad %bool %577
+OpLoopMerge %250 %282 None
+OpBranchConditional %1074 %249 %250
+%250 = OpLabel
+OpBranch %251
+%251 = OpLabel
+OpBranch %234
+%234 = OpLabel
+%1075 = OpLoad %double %334
+%1076 = OpLoad %double %335
+%1077 = OpFOrdLessThanEqual %bool %1075 %1076
+OpStore %339 %1077
+OpBranch %252
+%252 = OpLabel
+%1078 = OpLoad %bool %339
+%1079 = OpSelect %uchar %1078 %uchar_1 %uchar_0
+%1080 = OpUConvert %ulong %1079
+OpStore %586 %1080
+OpBranch %261
+%261 = OpLabel
+%1081 = OpLoad %ulong %584
+OpStore %605 %1081
+OpStore %606 %ulong_0
+OpBranch %262
+%262 = OpLabel
+%1082 = OpLoad %ulong %606
+%1083 = OpULessThan %bool %1082 %ulong_8
+OpStore %598 %1083
+%1084 = OpLoad %bool %598
+OpLoopMerge %264 %280 None
+OpBranchConditional %1084 %263 %264
+%264 = OpLabel
+OpBranch %265
+%265 = OpLabel
+OpBranch %253
+%253 = OpLabel
+%1085 = OpLoad %double %335
+%1086 = OpLoad %double %334
+%1087 = OpFOrdLessThan %bool %1085 %1086
+OpStore %340 %1087
+OpBranch %266
+%266 = OpLabel
+%1088 = OpLoad %bool %340
+%1089 = OpSelect %uchar %1088 %uchar_1 %uchar_0
+%1090 = OpUConvert %ulong %1089
+OpStore %607 %1090
+%1091 = OpLoad %ulong %605
+%1092 = OpLoad %ulong %607
+%1093 = OpFunctionCall %ulong %3 %1091 %1092
+OpStore %608 %1093
+OpBranch %267
+%267 = OpLabel
+%1094 = OpLoad %double %335
+%1095 = OpLoad %double %334
+%1096 = OpFOrdLessThanEqual %bool %1094 %1095
+OpStore %341 %1096
+%1097 = OpLoad %ulong %608
+%1098 = OpLoad %bool %341
+%1099 = OpSelect %uchar %1098 %uchar_1 %uchar_0
+%1100 = OpFunctionCall %ulong %4 %1097 %1099
+OpStore %342 %1100
+%1101 = OpLoad %double %334
+%1102 = OpLoad %double %335
+%1103 = OpFOrdLessThan %bool %1101 %1102
+OpStore %343 %1103
+%1104 = OpLoad %bool %343
+OpSelectionMerge %119 None
+OpBranchConditional %1104 %117 %118
+%118 = OpLabel
+OpStore %449 %uchar_0
+OpBranch %119
+%117 = OpLabel
+OpStore %449 %uchar_1
+OpBranch %119
+%119 = OpLabel
+%1105 = OpLoad %double %334
+%1106 = OpLoad %double %335
+%1107 = OpFOrdLessThanEqual %bool %1105 %1106
+OpStore %344 %1107
+%1108 = OpLoad %bool %344
+OpSelectionMerge %122 None
+OpBranchConditional %1108 %120 %121
+%121 = OpLabel
+%1109 = OpLoad %uchar %449
+OpStore %448 %1109
+OpBranch %122
+%120 = OpLabel
+%1110 = OpLoad %uchar %449
+%1112 = OpIAdd %uchar %1110 %uchar_2
+OpStore %346 %1112
+%1113 = OpLoad %uchar %346
+OpStore %448 %1113
+OpBranch %122
+%122 = OpLabel
+%1114 = OpLoad %double %335
+%1115 = OpLoad %double %334
+%1116 = OpFOrdLessThan %bool %1114 %1115
+OpStore %347 %1116
+%1117 = OpLoad %bool %347
+OpSelectionMerge %125 None
+OpBranchConditional %1117 %123 %124
+%124 = OpLabel
+%1118 = OpLoad %uchar %448
+OpStore %447 %1118
+OpBranch %125
+%123 = OpLabel
+%1119 = OpLoad %uchar %448
+%1121 = OpIAdd %uchar %1119 %uchar_4
+OpStore %348 %1121
+%1122 = OpLoad %uchar %348
+OpStore %447 %1122
+OpBranch %125
+%125 = OpLabel
+%1123 = OpLoad %double %335
+%1124 = OpLoad %double %334
+%1125 = OpFOrdLessThanEqual %bool %1123 %1124
+OpStore %349 %1125
+%1126 = OpLoad %bool %349
+OpSelectionMerge %128 None
+OpBranchConditional %1126 %126 %127
+%127 = OpLabel
+%1127 = OpLoad %uchar %447
+OpStore %446 %1127
+OpBranch %128
+%126 = OpLabel
+%1128 = OpLoad %uchar %447
+%1130 = OpIAdd %uchar %1128 %uchar_8
+OpStore %350 %1130
+%1131 = OpLoad %uchar %350
+OpStore %446 %1131
+OpBranch %128
+%128 = OpLabel
+%1132 = OpLoad %double %334
+%1133 = OpLoad %double %335
+%1134 = OpFOrdEqual %bool %1132 %1133
+OpStore %351 %1134
+%1135 = OpLoad %bool %351
+OpSelectionMerge %131 None
+OpBranchConditional %1135 %129 %130
+%130 = OpLabel
+%1136 = OpLoad %uchar %446
+OpStore %445 %1136
+OpBranch %131
+%129 = OpLabel
+%1137 = OpLoad %uchar %446
+%1139 = OpIAdd %uchar %1137 %uchar_16
+OpStore %352 %1139
+%1140 = OpLoad %uchar %352
+OpStore %445 %1140
+OpBranch %131
+%131 = OpLabel
+%1141 = OpLoad %double %334
+%1142 = OpLoad %double %335
+%1143 = OpFUnordNotEqual %bool %1141 %1142
+OpStore %353 %1143
+%1144 = OpLoad %bool %353
+OpSelectionMerge %134 None
+OpBranchConditional %1144 %132 %133
+%133 = OpLabel
+%1145 = OpLoad %uchar %445
+OpStore %444 %1145
+OpBranch %134
+%132 = OpLabel
+%1146 = OpLoad %uchar %445
+%1148 = OpIAdd %uchar %1146 %uchar_32
+OpStore %354 %1148
+%1149 = OpLoad %uchar %354
+OpStore %444 %1149
+OpBranch %134
+%134 = OpLabel
+OpBranch %168
+%168 = OpLabel
+%1150 = OpLoad %uchar %444
+%1151 = OpUConvert %ulong %1150
+OpStore %466 %1151
+OpBranch %189
+%189 = OpLabel
+%1152 = OpLoad %ulong %342
+OpStore %490 %1152
+OpStore %491 %ulong_0
+OpBranch %190
+%190 = OpLabel
+%1153 = OpLoad %ulong %491
+%1154 = OpULessThan %bool %1153 %ulong_8
+OpStore %483 %1154
+%1155 = OpLoad %bool %483
+OpLoopMerge %192 %279 None
+OpBranchConditional %1155 %191 %192
+%192 = OpLabel
+OpBranch %193
+%193 = OpLabel
+OpBranch %169
+%169 = OpLabel
+%1156 = OpLoad %double %334
+%1157 = OpLoad %double %335
+%1158 = OpFOrdLessThan %bool %1156 %1157
+OpStore %355 %1158
+%1159 = OpLoad %bool %355
+OpSelectionMerge %136 None
+OpBranchConditional %1159 %135 %270
+%270 = OpLabel
+%1160 = OpLoad %bool %355
+OpStore %450 %1160
+OpBranch %136
+%135 = OpLabel
+%1161 = OpLoad %double %335
+%1162 = OpLoad %double %334
+%1163 = OpFOrdLessThan %bool %1161 %1162
+OpStore %356 %1163
+%1164 = OpLoad %bool %356
+OpStore %450 %1164
+OpBranch %136
+%136 = OpLabel
+OpBranch %170
+%170 = OpLabel
+%1165 = OpLoad %bool %450
+%1166 = OpSelect %uchar %1165 %uchar_1 %uchar_0
+%1167 = OpUConvert %ulong %1166
+OpStore %467 %1167
+OpBranch %194
+%194 = OpLabel
+%1168 = OpLoad %ulong %490
+OpStore %499 %1168
+OpStore %500 %ulong_0
+OpBranch %195
+%195 = OpLabel
+%1169 = OpLoad %ulong %500
+%1170 = OpULessThan %bool %1169 %ulong_8
+OpStore %492 %1170
+%1171 = OpLoad %bool %492
+OpLoopMerge %197 %278 None
+OpBranchConditional %1171 %196 %197
+%197 = OpLabel
+OpBranch %198
+%198 = OpLabel
+OpBranch %171
+%171 = OpLabel
+%1172 = OpLoad %double %334
+%1173 = OpLoad %double %335
+%1174 = OpFOrdLessThan %bool %1172 %1173
+OpStore %357 %1174
+%1175 = OpLoad %bool %357
+OpSelectionMerge %138 None
+OpBranchConditional %1175 %271 %137
+%137 = OpLabel
+%1176 = OpLoad %double %335
+%1177 = OpLoad %double %334
+%1178 = OpFOrdLessThan %bool %1176 %1177
+OpStore %358 %1178
+%1179 = OpLoad %bool %358
+OpStore %451 %1179
+OpBranch %138
+%271 = OpLabel
+%1180 = OpLoad %bool %357
+OpStore %451 %1180
+OpBranch %138
+%138 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%1181 = OpLoad %bool %451
+%1182 = OpSelect %uchar %1181 %uchar_1 %uchar_0
+%1183 = OpUConvert %ulong %1182
+OpStore %468 %1183
+OpBranch %199
+%199 = OpLabel
+%1184 = OpLoad %ulong %499
+OpStore %508 %1184
+OpStore %509 %ulong_0
+OpBranch %200
+%200 = OpLabel
+%1185 = OpLoad %ulong %509
+%1186 = OpULessThan %bool %1185 %ulong_8
+OpStore %501 %1186
+%1187 = OpLoad %bool %501
+OpLoopMerge %202 %277 None
+OpBranchConditional %1187 %201 %202
+%202 = OpLabel
+OpBranch %203
+%203 = OpLabel
+OpBranch %173
+%173 = OpLabel
+%1188 = OpLoad %double %334
+%1189 = OpLoad %double %335
+%1190 = OpFOrdLessThan %bool %1188 %1189
+OpStore %359 %1190
+%1191 = OpLoad %bool %359
+%1192 = OpSelect %uchar %1191 %uchar_1 %uchar_0
+%1193 = OpINotEqual %bool %1192 %uchar_1
+OpStore %360 %1193
+OpBranch %204
+%204 = OpLabel
+%1194 = OpLoad %bool %360
+%1195 = OpSelect %uchar %1194 %uchar_1 %uchar_0
+%1196 = OpUConvert %ulong %1195
+OpStore %510 %1196
+OpBranch %235
+%235 = OpLabel
+%1197 = OpLoad %ulong %508
+OpStore %565 %1197
+OpStore %566 %ulong_0
+OpBranch %236
+%236 = OpLabel
+%1198 = OpLoad %ulong %566
+%1199 = OpULessThan %bool %1198 %ulong_8
+OpStore %558 %1199
+%1200 = OpLoad %bool %558
+OpLoopMerge %238 %276 None
+OpBranchConditional %1200 %237 %238
+%238 = OpLabel
+OpBranch %239
+%239 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%1201 = OpLoad %double %334
+%1202 = OpLoad %double %334
+%1203 = OpFOrdEqual %bool %1201 %1202
+OpStore %361 %1203
+%1204 = OpLoad %bool %361
+OpSelectionMerge %140 None
+OpBranchConditional %1204 %139 %272
+%272 = OpLabel
+%1205 = OpLoad %bool %361
+OpStore %452 %1205
+OpBranch %140
+%139 = OpLabel
+%1206 = OpLoad %double %335
+%1207 = OpLoad %double %335
+%1208 = OpFOrdEqual %bool %1206 %1207
+OpStore %362 %1208
+%1209 = OpLoad %bool %362
+OpStore %452 %1209
+OpBranch %140
+%140 = OpLabel
+OpBranch %174
+%174 = OpLabel
+%1210 = OpLoad %bool %452
+%1211 = OpSelect %uchar %1210 %uchar_1 %uchar_0
+%1212 = OpUConvert %ulong %1211
+OpStore %469 %1212
+OpBranch %206
+%206 = OpLabel
+%1213 = OpLoad %ulong %565
+OpStore %518 %1213
+OpStore %519 %ulong_0
+OpBranch %207
+%207 = OpLabel
+%1214 = OpLoad %ulong %519
+%1215 = OpULessThan %bool %1214 %ulong_8
+OpStore %511 %1215
+%1216 = OpLoad %bool %511
+OpLoopMerge %209 %275 None
+OpBranchConditional %1216 %208 %209
+%209 = OpLabel
+OpBranch %210
+%210 = OpLabel
+OpBranch %175
+%175 = OpLabel
+%1217 = OpLoad %double %334
+%1218 = OpLoad %double %334
+%1219 = OpFUnordNotEqual %bool %1217 %1218
+OpStore %363 %1219
+%1220 = OpLoad %bool %363
+OpSelectionMerge %142 None
+OpBranchConditional %1220 %273 %141
+%141 = OpLabel
+%1221 = OpLoad %double %335
+%1222 = OpLoad %double %335
+%1223 = OpFUnordNotEqual %bool %1221 %1222
+OpStore %364 %1223
+%1224 = OpLoad %bool %364
+OpStore %453 %1224
+OpBranch %142
+%273 = OpLabel
+%1225 = OpLoad %bool %363
+OpStore %453 %1225
+OpBranch %142
+%142 = OpLabel
+OpBranch %176
+%176 = OpLabel
+%1226 = OpLoad %bool %453
+%1227 = OpSelect %uchar %1226 %uchar_1 %uchar_0
+%1228 = OpUConvert %ulong %1227
+OpStore %470 %1228
+OpBranch %211
+%211 = OpLabel
+%1229 = OpLoad %ulong %518
+OpStore %527 %1229
+OpStore %528 %ulong_0
+OpBranch %212
+%212 = OpLabel
+%1230 = OpLoad %ulong %528
+%1231 = OpULessThan %bool %1230 %ulong_8
+OpStore %520 %1231
+%1232 = OpLoad %bool %520
+OpLoopMerge %214 %274 None
+OpBranchConditional %1232 %213 %214
+%214 = OpLabel
+OpBranch %215
+%215 = OpLabel
+OpBranch %177
+%177 = OpLabel
+%1233 = OpLoad %ulong %443
+%1234 = OpIAdd %ulong %1233 %ulong_1
+OpStore %365 %1234
+%1235 = OpLoad %ulong %527
+OpStore %440 %1235
+%1236 = OpLoad %ulong %365
+OpStore %443 %1236
+OpBranch %292
+%213 = OpLabel
+%1237 = OpLoad %ulong %528
+%1238 = OpIMul %ulong %1237 %ulong_8
+OpStore %521 %1238
+%1239 = OpLoad %ulong %470
+%1240 = OpLoad %ulong %521
+%1241 = OpShiftRightLogical %ulong %1239 %1240
+OpStore %522 %1241
+%1242 = OpLoad %ulong %522
+%1243 = OpBitwiseAnd %ulong %1242 %ulong_255
+OpStore %523 %1243
+%1244 = OpLoad %ulong %527
+%1245 = OpLoad %ulong %523
+%1246 = OpBitwiseXor %ulong %1244 %1245
+OpStore %524 %1246
+%1247 = OpLoad %ulong %524
+%1248 = OpIMul %ulong %1247 %ulong_1099511628211
+OpStore %525 %1248
+%1249 = OpLoad %ulong %528
+%1250 = OpIAdd %ulong %1249 %ulong_1
+OpStore %526 %1250
+%1251 = OpLoad %ulong %525
+OpStore %527 %1251
+%1252 = OpLoad %ulong %526
+OpStore %528 %1252
+OpBranch %274
+%208 = OpLabel
+%1253 = OpLoad %ulong %519
+%1254 = OpIMul %ulong %1253 %ulong_8
+OpStore %512 %1254
+%1255 = OpLoad %ulong %469
+%1256 = OpLoad %ulong %512
+%1257 = OpShiftRightLogical %ulong %1255 %1256
+OpStore %513 %1257
+%1258 = OpLoad %ulong %513
+%1259 = OpBitwiseAnd %ulong %1258 %ulong_255
+OpStore %514 %1259
+%1260 = OpLoad %ulong %518
+%1261 = OpLoad %ulong %514
+%1262 = OpBitwiseXor %ulong %1260 %1261
+OpStore %515 %1262
+%1263 = OpLoad %ulong %515
+%1264 = OpIMul %ulong %1263 %ulong_1099511628211
+OpStore %516 %1264
+%1265 = OpLoad %ulong %519
+%1266 = OpIAdd %ulong %1265 %ulong_1
+OpStore %517 %1266
+%1267 = OpLoad %ulong %516
+OpStore %518 %1267
+%1268 = OpLoad %ulong %517
+OpStore %519 %1268
+OpBranch %275
+%237 = OpLabel
+%1269 = OpLoad %ulong %566
+%1270 = OpIMul %ulong %1269 %ulong_8
+OpStore %559 %1270
+%1271 = OpLoad %ulong %510
+%1272 = OpLoad %ulong %559
+%1273 = OpShiftRightLogical %ulong %1271 %1272
+OpStore %560 %1273
+%1274 = OpLoad %ulong %560
+%1275 = OpBitwiseAnd %ulong %1274 %ulong_255
+OpStore %561 %1275
+%1276 = OpLoad %ulong %565
+%1277 = OpLoad %ulong %561
+%1278 = OpBitwiseXor %ulong %1276 %1277
+OpStore %562 %1278
+%1279 = OpLoad %ulong %562
+%1280 = OpIMul %ulong %1279 %ulong_1099511628211
+OpStore %563 %1280
+%1281 = OpLoad %ulong %566
+%1282 = OpIAdd %ulong %1281 %ulong_1
+OpStore %564 %1282
+%1283 = OpLoad %ulong %563
+OpStore %565 %1283
+%1284 = OpLoad %ulong %564
+OpStore %566 %1284
+OpBranch %276
+%201 = OpLabel
+%1285 = OpLoad %ulong %509
+%1286 = OpIMul %ulong %1285 %ulong_8
+OpStore %502 %1286
+%1287 = OpLoad %ulong %468
+%1288 = OpLoad %ulong %502
+%1289 = OpShiftRightLogical %ulong %1287 %1288
+OpStore %503 %1289
+%1290 = OpLoad %ulong %503
+%1291 = OpBitwiseAnd %ulong %1290 %ulong_255
+OpStore %504 %1291
+%1292 = OpLoad %ulong %508
+%1293 = OpLoad %ulong %504
+%1294 = OpBitwiseXor %ulong %1292 %1293
+OpStore %505 %1294
+%1295 = OpLoad %ulong %505
+%1296 = OpIMul %ulong %1295 %ulong_1099511628211
+OpStore %506 %1296
+%1297 = OpLoad %ulong %509
+%1298 = OpIAdd %ulong %1297 %ulong_1
+OpStore %507 %1298
+%1299 = OpLoad %ulong %506
+OpStore %508 %1299
+%1300 = OpLoad %ulong %507
+OpStore %509 %1300
+OpBranch %277
+%196 = OpLabel
+%1301 = OpLoad %ulong %500
+%1302 = OpIMul %ulong %1301 %ulong_8
+OpStore %493 %1302
+%1303 = OpLoad %ulong %467
+%1304 = OpLoad %ulong %493
+%1305 = OpShiftRightLogical %ulong %1303 %1304
+OpStore %494 %1305
+%1306 = OpLoad %ulong %494
+%1307 = OpBitwiseAnd %ulong %1306 %ulong_255
+OpStore %495 %1307
+%1308 = OpLoad %ulong %499
+%1309 = OpLoad %ulong %495
+%1310 = OpBitwiseXor %ulong %1308 %1309
+OpStore %496 %1310
+%1311 = OpLoad %ulong %496
+%1312 = OpIMul %ulong %1311 %ulong_1099511628211
+OpStore %497 %1312
+%1313 = OpLoad %ulong %500
+%1314 = OpIAdd %ulong %1313 %ulong_1
+OpStore %498 %1314
+%1315 = OpLoad %ulong %497
+OpStore %499 %1315
+%1316 = OpLoad %ulong %498
+OpStore %500 %1316
+OpBranch %278
+%191 = OpLabel
+%1317 = OpLoad %ulong %491
+%1318 = OpIMul %ulong %1317 %ulong_8
+OpStore %484 %1318
+%1319 = OpLoad %ulong %466
+%1320 = OpLoad %ulong %484
+%1321 = OpShiftRightLogical %ulong %1319 %1320
+OpStore %485 %1321
+%1322 = OpLoad %ulong %485
+%1323 = OpBitwiseAnd %ulong %1322 %ulong_255
+OpStore %486 %1323
+%1324 = OpLoad %ulong %490
+%1325 = OpLoad %ulong %486
+%1326 = OpBitwiseXor %ulong %1324 %1325
+OpStore %487 %1326
+%1327 = OpLoad %ulong %487
+%1328 = OpIMul %ulong %1327 %ulong_1099511628211
+OpStore %488 %1328
+%1329 = OpLoad %ulong %491
+%1330 = OpIAdd %ulong %1329 %ulong_1
+OpStore %489 %1330
+%1331 = OpLoad %ulong %488
+OpStore %490 %1331
+%1332 = OpLoad %ulong %489
+OpStore %491 %1332
+OpBranch %279
+%263 = OpLabel
+%1333 = OpLoad %ulong %606
+%1334 = OpIMul %ulong %1333 %ulong_8
+OpStore %599 %1334
+%1335 = OpLoad %ulong %586
+%1336 = OpLoad %ulong %599
+%1337 = OpShiftRightLogical %ulong %1335 %1336
+OpStore %600 %1337
+%1338 = OpLoad %ulong %600
+%1339 = OpBitwiseAnd %ulong %1338 %ulong_255
+OpStore %601 %1339
+%1340 = OpLoad %ulong %605
+%1341 = OpLoad %ulong %601
+%1342 = OpBitwiseXor %ulong %1340 %1341
+OpStore %602 %1342
+%1343 = OpLoad %ulong %602
+%1344 = OpIMul %ulong %1343 %ulong_1099511628211
+OpStore %603 %1344
+%1345 = OpLoad %ulong %606
+%1346 = OpIAdd %ulong %1345 %ulong_1
+OpStore %604 %1346
+%1347 = OpLoad %ulong %603
+OpStore %605 %1347
+%1348 = OpLoad %ulong %604
+OpStore %606 %1348
+OpBranch %280
+%249 = OpLabel
+%1349 = OpLoad %ulong %585
+%1350 = OpIMul %ulong %1349 %ulong_8
+OpStore %578 %1350
+%1351 = OpLoad %ulong %557
+%1352 = OpLoad %ulong %578
+%1353 = OpShiftRightLogical %ulong %1351 %1352
+OpStore %579 %1353
+%1354 = OpLoad %ulong %579
+%1355 = OpBitwiseAnd %ulong %1354 %ulong_255
+OpStore %580 %1355
+%1356 = OpLoad %ulong %584
+%1357 = OpLoad %ulong %580
+%1358 = OpBitwiseXor %ulong %1356 %1357
+OpStore %581 %1358
+%1359 = OpLoad %ulong %581
+%1360 = OpIMul %ulong %1359 %ulong_1099511628211
+OpStore %582 %1360
+%1361 = OpLoad %ulong %585
+%1362 = OpIAdd %ulong %1361 %ulong_1
+OpStore %583 %1362
+%1363 = OpLoad %ulong %582
+OpStore %584 %1363
+%1364 = OpLoad %ulong %583
+OpStore %585 %1364
+OpBranch %282
+%230 = OpLabel
+%1365 = OpLoad %ulong %556
+%1366 = OpIMul %ulong %1365 %ulong_8
+OpStore %549 %1366
+%1367 = OpLoad %ulong %482
+%1368 = OpLoad %ulong %549
+%1369 = OpShiftRightLogical %ulong %1367 %1368
+OpStore %550 %1369
+%1370 = OpLoad %ulong %550
+%1371 = OpBitwiseAnd %ulong %1370 %ulong_255
+OpStore %551 %1371
+%1372 = OpLoad %ulong %555
+%1373 = OpLoad %ulong %551
+%1374 = OpBitwiseXor %ulong %1372 %1373
+OpStore %552 %1374
+%1375 = OpLoad %ulong %552
+%1376 = OpIMul %ulong %1375 %ulong_1099511628211
+OpStore %553 %1376
+%1377 = OpLoad %ulong %556
+%1378 = OpIAdd %ulong %1377 %ulong_1
+OpStore %554 %1378
+%1379 = OpLoad %ulong %553
+OpStore %555 %1379
+%1380 = OpLoad %ulong %554
+OpStore %556 %1380
+OpBranch %284
+%184 = OpLabel
+%1381 = OpLoad %ulong %481
+%1382 = OpIMul %ulong %1381 %ulong_8
+OpStore %474 %1382
+%1383 = OpLoad %ulong %465
+%1384 = OpLoad %ulong %474
+%1385 = OpShiftRightLogical %ulong %1383 %1384
+OpStore %475 %1385
+%1386 = OpLoad %ulong %475
+%1387 = OpBitwiseAnd %ulong %1386 %ulong_255
+OpStore %476 %1387
+%1388 = OpLoad %ulong %480
+%1389 = OpLoad %ulong %476
+%1390 = OpBitwiseXor %ulong %1388 %1389
+OpStore %477 %1390
+%1391 = OpLoad %ulong %477
+%1392 = OpIMul %ulong %1391 %ulong_1099511628211
+OpStore %478 %1392
+%1393 = OpLoad %ulong %481
+%1394 = OpIAdd %ulong %1393 %ulong_1
+OpStore %479 %1394
+%1395 = OpLoad %ulong %478
+OpStore %480 %1395
+%1396 = OpLoad %ulong %479
+OpStore %481 %1396
+OpBranch %289
+%274 = OpLabel
+OpBranch %212
+%275 = OpLabel
+OpBranch %207
+%276 = OpLabel
+OpBranch %236
+%277 = OpLabel
+OpBranch %200
+%278 = OpLabel
+OpBranch %195
+%279 = OpLabel
+OpBranch %190
+%280 = OpLabel
+OpBranch %262
+%281 = OpLabel
+OpBranch %255
+%282 = OpLabel
+OpBranch %248
+%283 = OpLabel
+OpBranch %241
+%284 = OpLabel
+OpBranch %229
+%285 = OpLabel
+OpBranch %224
+%286 = OpLabel
+OpBranch %161
+%287 = OpLabel
+OpBranch %217
+%288 = OpLabel
+OpBranch %158
+%289 = OpLabel
+OpBranch %183
+%290 = OpLabel
+OpBranch %146
+%291 = OpLabel
+OpBranch %149
+%292 = OpLabel
+OpBranch %114
+%293 = OpLabel
+OpBranch %143
+%294 = OpLabel
+OpBranch %111
 OpFunctionEnd
-%3 = OpFunction %ulong None %825
-%826 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%3 = OpFunction %ulong None %1397
+%1398 = OpFunctionParameter %ulong
+%1399 = OpFunctionParameter %ulong
+%1400 = OpLabel
+%1405 = OpVariable %_ptr_Function_ulong Function
+%1406 = OpVariable %_ptr_Function_ulong Function
+%1407 = OpVariable %_ptr_Function_bool Function
+%1408 = OpVariable %_ptr_Function_ulong Function
+%1409 = OpVariable %_ptr_Function_ulong Function
+%1410 = OpVariable %_ptr_Function_ulong Function
+%1411 = OpVariable %_ptr_Function_ulong Function
+%1412 = OpVariable %_ptr_Function_ulong Function
+%1413 = OpVariable %_ptr_Function_ulong Function
+%1414 = OpVariable %_ptr_Function_ulong Function
+%1415 = OpVariable %_ptr_Function_ulong Function
+OpStore %1405 %1398
+OpStore %1406 %1399
+%1416 = OpLoad %ulong %1405
+OpStore %1414 %1416
+OpStore %1415 %ulong_0
+OpBranch %1401
+%1401 = OpLabel
+%1417 = OpLoad %ulong %1415
+%1418 = OpULessThan %bool %1417 %ulong_8
+OpStore %1407 %1418
+%1419 = OpLoad %bool %1407
+OpLoopMerge %1403 %1404 None
+OpBranchConditional %1419 %1402 %1403
+%1403 = OpLabel
+%1420 = OpLoad %ulong %1414
+OpReturnValue %1420
+%1402 = OpLabel
+%1421 = OpLoad %ulong %1415
+%1422 = OpIMul %ulong %1421 %ulong_8
+OpStore %1408 %1422
+%1423 = OpLoad %ulong %1406
+%1424 = OpLoad %ulong %1408
+%1425 = OpShiftRightLogical %ulong %1423 %1424
+OpStore %1409 %1425
+%1426 = OpLoad %ulong %1409
+%1427 = OpBitwiseAnd %ulong %1426 %ulong_255
+OpStore %1410 %1427
+%1428 = OpLoad %ulong %1414
+%1429 = OpLoad %ulong %1410
+%1430 = OpBitwiseXor %ulong %1428 %1429
+OpStore %1411 %1430
+%1431 = OpLoad %ulong %1411
+%1432 = OpIMul %ulong %1431 %ulong_1099511628211
+OpStore %1412 %1432
+%1433 = OpLoad %ulong %1415
+%1434 = OpIAdd %ulong %1433 %ulong_1
+OpStore %1413 %1434
+%1435 = OpLoad %ulong %1412
+OpStore %1414 %1435
+%1436 = OpLoad %ulong %1413
+OpStore %1415 %1436
+OpBranch %1404
+%1404 = OpLabel
+OpBranch %1401
 OpFunctionEnd
-%4 = OpFunction %ulong None %828
-%829 = OpFunctionParameter %ulong
-%830 = OpFunctionParameter %ulong
-%831 = OpLabel
-%836 = OpVariable %_ptr_Function_ulong Function
-%837 = OpVariable %_ptr_Function_ulong Function
-%838 = OpVariable %_ptr_Function_bool Function
-%839 = OpVariable %_ptr_Function_ulong Function
-%840 = OpVariable %_ptr_Function_ulong Function
-%841 = OpVariable %_ptr_Function_ulong Function
-%842 = OpVariable %_ptr_Function_ulong Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_ulong Function
-OpStore %836 %829
-OpStore %837 %830
-%847 = OpLoad %ulong %836
-OpStore %845 %847
-OpStore %846 %ulong_0
-OpBranch %832
-%832 = OpLabel
-%848 = OpLoad %ulong %846
-%849 = OpULessThan %bool %848 %ulong_8
-OpStore %838 %849
-%850 = OpLoad %bool %838
-OpLoopMerge %834 %835 None
-OpBranchConditional %850 %833 %834
-%834 = OpLabel
-%851 = OpLoad %ulong %845
-OpReturnValue %851
-%833 = OpLabel
-%852 = OpLoad %ulong %846
-%853 = OpIMul %ulong %852 %ulong_8
-OpStore %839 %853
-%854 = OpLoad %ulong %837
-%855 = OpLoad %ulong %839
-%856 = OpShiftRightLogical %ulong %854 %855
-OpStore %840 %856
-%857 = OpLoad %ulong %840
-%859 = OpBitwiseAnd %ulong %857 %ulong_255
-OpStore %841 %859
-%860 = OpLoad %ulong %845
-%861 = OpLoad %ulong %841
-%862 = OpBitwiseXor %ulong %860 %861
-OpStore %842 %862
-%863 = OpLoad %ulong %842
-%865 = OpIMul %ulong %863 %ulong_1099511628211
-OpStore %843 %865
-%866 = OpLoad %ulong %846
-%867 = OpIAdd %ulong %866 %ulong_1
-OpStore %844 %867
-%868 = OpLoad %ulong %843
-OpStore %845 %868
-%869 = OpLoad %ulong %844
-OpStore %846 %869
-OpBranch %835
-%835 = OpLabel
-OpBranch %832
-OpFunctionEnd
-%5 = OpFunction %ulong None %870
-%871 = OpFunctionParameter %ulong
-%872 = OpFunctionParameter %uchar
-%873 = OpLabel
-%880 = OpVariable %_ptr_Function_ulong Function
-%881 = OpVariable %_ptr_Function_uchar Function
-%882 = OpVariable %_ptr_Function_ulong Function
-%883 = OpVariable %_ptr_Function_bool Function
-%884 = OpVariable %_ptr_Function_ulong Function
-%885 = OpVariable %_ptr_Function_ulong Function
-%886 = OpVariable %_ptr_Function_ulong Function
-%887 = OpVariable %_ptr_Function_ulong Function
-%888 = OpVariable %_ptr_Function_ulong Function
-%889 = OpVariable %_ptr_Function_ulong Function
-%890 = OpVariable %_ptr_Function_ulong Function
-%891 = OpVariable %_ptr_Function_ulong Function
-OpStore %880 %871
-OpStore %881 %872
-%892 = OpLoad %uchar %881
-%893 = OpUConvert %ulong %892
-OpStore %882 %893
-OpBranch %874
-%874 = OpLabel
-%894 = OpLoad %ulong %880
-OpStore %890 %894
-OpStore %891 %ulong_0
-OpBranch %875
-%875 = OpLabel
-%895 = OpLoad %ulong %891
-%896 = OpULessThan %bool %895 %ulong_8
-OpStore %883 %896
-%897 = OpLoad %bool %883
-OpLoopMerge %877 %879 None
-OpBranchConditional %897 %876 %877
-%877 = OpLabel
-OpBranch %878
-%878 = OpLabel
-%898 = OpLoad %ulong %890
-OpReturnValue %898
-%876 = OpLabel
-%899 = OpLoad %ulong %891
-%900 = OpIMul %ulong %899 %ulong_8
-OpStore %884 %900
-%901 = OpLoad %ulong %882
-%902 = OpLoad %ulong %884
-%903 = OpShiftRightLogical %ulong %901 %902
-OpStore %885 %903
-%904 = OpLoad %ulong %885
-%905 = OpBitwiseAnd %ulong %904 %ulong_255
-OpStore %886 %905
-%906 = OpLoad %ulong %890
-%907 = OpLoad %ulong %886
-%908 = OpBitwiseXor %ulong %906 %907
-OpStore %887 %908
-%909 = OpLoad %ulong %887
-%910 = OpIMul %ulong %909 %ulong_1099511628211
-OpStore %888 %910
-%911 = OpLoad %ulong %891
-%912 = OpIAdd %ulong %911 %ulong_1
-OpStore %889 %912
-%913 = OpLoad %ulong %888
-OpStore %890 %913
-%914 = OpLoad %ulong %889
-OpStore %891 %914
-OpBranch %879
-%879 = OpLabel
-OpBranch %875
-OpFunctionEnd
-%6 = OpFunction %ulong None %915
-%916 = OpFunctionParameter %ulong
-%917 = OpFunctionParameter %uint
-%918 = OpLabel
-%925 = OpVariable %_ptr_Function_ulong Function
-%926 = OpVariable %_ptr_Function_uint Function
-%927 = OpVariable %_ptr_Function_ulong Function
-%928 = OpVariable %_ptr_Function_bool Function
-%929 = OpVariable %_ptr_Function_ulong Function
-%930 = OpVariable %_ptr_Function_ulong Function
-%931 = OpVariable %_ptr_Function_ulong Function
-%932 = OpVariable %_ptr_Function_ulong Function
-%933 = OpVariable %_ptr_Function_ulong Function
-%934 = OpVariable %_ptr_Function_ulong Function
-%935 = OpVariable %_ptr_Function_ulong Function
-%936 = OpVariable %_ptr_Function_ulong Function
-OpStore %925 %916
-OpStore %926 %917
-%937 = OpLoad %uint %926
-%938 = OpUConvert %ulong %937
-OpStore %927 %938
-OpBranch %919
-%919 = OpLabel
-%939 = OpLoad %ulong %925
-OpStore %935 %939
-OpStore %936 %ulong_0
-OpBranch %920
-%920 = OpLabel
-%940 = OpLoad %ulong %936
-%941 = OpULessThan %bool %940 %ulong_8
-OpStore %928 %941
-%942 = OpLoad %bool %928
-OpLoopMerge %922 %924 None
-OpBranchConditional %942 %921 %922
-%922 = OpLabel
-OpBranch %923
-%923 = OpLabel
-%943 = OpLoad %ulong %935
-OpReturnValue %943
-%921 = OpLabel
-%944 = OpLoad %ulong %936
-%945 = OpIMul %ulong %944 %ulong_8
-OpStore %929 %945
-%946 = OpLoad %ulong %927
-%947 = OpLoad %ulong %929
-%948 = OpShiftRightLogical %ulong %946 %947
-OpStore %930 %948
-%949 = OpLoad %ulong %930
-%950 = OpBitwiseAnd %ulong %949 %ulong_255
-OpStore %931 %950
-%951 = OpLoad %ulong %935
-%952 = OpLoad %ulong %931
-%953 = OpBitwiseXor %ulong %951 %952
-OpStore %932 %953
-%954 = OpLoad %ulong %932
-%955 = OpIMul %ulong %954 %ulong_1099511628211
-OpStore %933 %955
-%956 = OpLoad %ulong %936
-%957 = OpIAdd %ulong %956 %ulong_1
-OpStore %934 %957
-%958 = OpLoad %ulong %933
-OpStore %935 %958
-%959 = OpLoad %ulong %934
-OpStore %936 %959
-OpBranch %924
-%924 = OpLabel
-OpBranch %920
-OpFunctionEnd
-%7 = OpFunction %ulong None %10
-%960 = OpFunctionParameter %ulong
-%961 = OpFunctionParameter %double
-%962 = OpLabel
-%969 = OpVariable %_ptr_Function_ulong Function
-%970 = OpVariable %_ptr_Function_double Function
-%971 = OpVariable %_ptr_Function_ulong Function
-%972 = OpVariable %_ptr_Function_bool Function
-%973 = OpVariable %_ptr_Function_ulong Function
-%974 = OpVariable %_ptr_Function_ulong Function
-%975 = OpVariable %_ptr_Function_ulong Function
-%976 = OpVariable %_ptr_Function_ulong Function
-%977 = OpVariable %_ptr_Function_ulong Function
-%978 = OpVariable %_ptr_Function_ulong Function
-%979 = OpVariable %_ptr_Function_ulong Function
-%980 = OpVariable %_ptr_Function_ulong Function
-OpStore %969 %960
-OpStore %970 %961
-%981 = OpLoad %double %970
-%982 = OpBitcast %ulong %981
-OpStore %971 %982
-OpBranch %963
-%963 = OpLabel
-%983 = OpLoad %ulong %969
-OpStore %979 %983
-OpStore %980 %ulong_0
-OpBranch %964
-%964 = OpLabel
-%984 = OpLoad %ulong %980
-%985 = OpULessThan %bool %984 %ulong_8
-OpStore %972 %985
-%986 = OpLoad %bool %972
-OpLoopMerge %966 %968 None
-OpBranchConditional %986 %965 %966
-%966 = OpLabel
-OpBranch %967
-%967 = OpLabel
-%987 = OpLoad %ulong %979
-OpReturnValue %987
-%965 = OpLabel
-%988 = OpLoad %ulong %980
-%989 = OpIMul %ulong %988 %ulong_8
-OpStore %973 %989
-%990 = OpLoad %ulong %971
-%991 = OpLoad %ulong %973
-%992 = OpShiftRightLogical %ulong %990 %991
-OpStore %974 %992
-%993 = OpLoad %ulong %974
-%994 = OpBitwiseAnd %ulong %993 %ulong_255
-OpStore %975 %994
-%995 = OpLoad %ulong %979
-%996 = OpLoad %ulong %975
-%997 = OpBitwiseXor %ulong %995 %996
-OpStore %976 %997
-%998 = OpLoad %ulong %976
-%999 = OpIMul %ulong %998 %ulong_1099511628211
-OpStore %977 %999
-%1000 = OpLoad %ulong %980
-%1001 = OpIAdd %ulong %1000 %ulong_1
-OpStore %978 %1001
-%1002 = OpLoad %ulong %977
-OpStore %979 %1002
-%1003 = OpLoad %ulong %978
-OpStore %980 %1003
-OpBranch %968
-%968 = OpLabel
-OpBranch %964
+%4 = OpFunction %ulong None %1437
+%1438 = OpFunctionParameter %ulong
+%1439 = OpFunctionParameter %uchar
+%1440 = OpLabel
+%1447 = OpVariable %_ptr_Function_ulong Function
+%1448 = OpVariable %_ptr_Function_uchar Function
+%1449 = OpVariable %_ptr_Function_ulong Function
+%1450 = OpVariable %_ptr_Function_bool Function
+%1451 = OpVariable %_ptr_Function_ulong Function
+%1452 = OpVariable %_ptr_Function_ulong Function
+%1453 = OpVariable %_ptr_Function_ulong Function
+%1454 = OpVariable %_ptr_Function_ulong Function
+%1455 = OpVariable %_ptr_Function_ulong Function
+%1456 = OpVariable %_ptr_Function_ulong Function
+%1457 = OpVariable %_ptr_Function_ulong Function
+%1458 = OpVariable %_ptr_Function_ulong Function
+OpStore %1447 %1438
+OpStore %1448 %1439
+%1459 = OpLoad %uchar %1448
+%1460 = OpUConvert %ulong %1459
+OpStore %1449 %1460
+OpBranch %1441
+%1441 = OpLabel
+%1461 = OpLoad %ulong %1447
+OpStore %1457 %1461
+OpStore %1458 %ulong_0
+OpBranch %1442
+%1442 = OpLabel
+%1462 = OpLoad %ulong %1458
+%1463 = OpULessThan %bool %1462 %ulong_8
+OpStore %1450 %1463
+%1464 = OpLoad %bool %1450
+OpLoopMerge %1444 %1446 None
+OpBranchConditional %1464 %1443 %1444
+%1444 = OpLabel
+OpBranch %1445
+%1445 = OpLabel
+%1465 = OpLoad %ulong %1457
+OpReturnValue %1465
+%1443 = OpLabel
+%1466 = OpLoad %ulong %1458
+%1467 = OpIMul %ulong %1466 %ulong_8
+OpStore %1451 %1467
+%1468 = OpLoad %ulong %1449
+%1469 = OpLoad %ulong %1451
+%1470 = OpShiftRightLogical %ulong %1468 %1469
+OpStore %1452 %1470
+%1471 = OpLoad %ulong %1452
+%1472 = OpBitwiseAnd %ulong %1471 %ulong_255
+OpStore %1453 %1472
+%1473 = OpLoad %ulong %1457
+%1474 = OpLoad %ulong %1453
+%1475 = OpBitwiseXor %ulong %1473 %1474
+OpStore %1454 %1475
+%1476 = OpLoad %ulong %1454
+%1477 = OpIMul %ulong %1476 %ulong_1099511628211
+OpStore %1455 %1477
+%1478 = OpLoad %ulong %1458
+%1479 = OpIAdd %ulong %1478 %ulong_1
+OpStore %1456 %1479
+%1480 = OpLoad %ulong %1455
+OpStore %1457 %1480
+%1481 = OpLoad %ulong %1456
+OpStore %1458 %1481
+OpBranch %1446
+%1446 = OpLabel
+OpBranch %1442
 OpFunctionEnd

--- a/test/golden/spirv/float/special_f32.dis
+++ b/test/golden/spirv/float/special_f32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1522
+; Bound: 1708
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -13,16 +13,21 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.special_f32.fold32" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f32.checksum" Export
 %float = OpTypeFloat 32
 %uint = OpTypeInt 32 0
-%12 = OpTypeFunction %float %uint %uint
+%7 = OpTypeFunction %float %uint %uint
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
 %ulong = OpTypeInt 64 0
-%29 = OpTypeFunction %ulong %ulong %float
+%24 = OpTypeFunction %ulong %ulong %float
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
-%uint_4294967295 = OpConstant %uint 4294967295
-%57 = OpTypeFunction %ulong %ulong
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%ulong_4294967295 = OpConstant %ulong 4294967295
+%129 = OpTypeFunction %ulong %ulong
 %uint_8 = OpConstant %uint 8
 %_arr_uint_uint_8 = OpTypeArray %uint %uint_8
 %_ptr_Function__arr_uint_uint_8 = OpTypePointer Function %_arr_uint_uint_8
@@ -36,6 +41,7 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f32.checksum" Export
 %uint_8388608 = OpConstant %uint 8388608
 %uint_8388607 = OpConstant %uint 8388607
 %uint_1 = OpConstant %uint 1
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
@@ -45,7 +51,7 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f32.checksum" Export
 %float_8388608 = OpConstant %float 8388608
 %uint_0 = OpConstant %uint 0
 %uint_30 = OpConstant %uint 30
-%1060 = OpConstantNull %_arr_uint_uint_8
+%1248 = OpConstantNull %_arr_uint_uint_8
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
@@ -57,2063 +63,2342 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f32.checksum" Export
 %uint_16777216 = OpConstant %uint 16777216
 %uint_16777217 = OpConstant %uint 16777217
 %uint_16777219 = OpConstant %uint 16777219
+%uint_4294967295 = OpConstant %uint 4294967295
 %uint_4278190079 = OpConstant %uint 4278190079
 %float_16777216 = OpConstant %float 16777216
 %float_2_14748352e_09 = OpConstant %float 2.14748352e+09
-%1290 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1293 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1344 = OpTypeFunction %ulong %ulong %uint
-%1433 = OpTypeFunction %ulong %ulong %ulong
-%1 = OpFunction %float None %12
-%13 = OpFunctionParameter %uint
-%14 = OpFunctionParameter %uint
-%15 = OpLabel
-%17 = OpVariable %_ptr_Function_uint Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_float Function
-OpStore %17 %13
-OpStore %18 %14
-%22 = OpLoad %uint %17
-%23 = OpLoad %uint %18
-%24 = OpIAdd %uint %22 %23
-OpStore %19 %24
-%25 = OpLoad %uint %19
-%26 = OpBitcast %float %25
-OpStore %21 %26
-%27 = OpLoad %float %21
-OpReturnValue %27
+%1668 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %float None %7
+%8 = OpFunctionParameter %uint
+%9 = OpFunctionParameter %uint
+%10 = OpLabel
+%12 = OpVariable %_ptr_Function_uint Function
+%13 = OpVariable %_ptr_Function_uint Function
+%14 = OpVariable %_ptr_Function_uint Function
+%16 = OpVariable %_ptr_Function_float Function
+OpStore %12 %8
+OpStore %13 %9
+%17 = OpLoad %uint %12
+%18 = OpLoad %uint %13
+%19 = OpIAdd %uint %17 %18
+OpStore %14 %19
+%20 = OpLoad %uint %14
+%21 = OpBitcast %float %20
+OpStore %16 %21
+%22 = OpLoad %float %16
+OpReturnValue %22
 OpFunctionEnd
-%2 = OpFunction %ulong None %29
-%30 = OpFunctionParameter %ulong
-%31 = OpFunctionParameter %float
-%32 = OpLabel
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_float Function
-%42 = OpVariable %_ptr_Function_bool Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-OpStore %39 %30
-OpStore %40 %31
-%45 = OpLoad %float %40
-%46 = OpLoad %float %40
-%47 = OpFUnordNotEqual %bool %45 %46
-OpStore %42 %47
-%48 = OpLoad %bool %42
-OpSelectionMerge %36 None
-OpBranchConditional %48 %33 %34
+%2 = OpFunction %ulong None %24
+%25 = OpFunctionParameter %ulong
+%26 = OpFunctionParameter %float
+%27 = OpLabel
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_float Function
+%53 = OpVariable %_ptr_Function_bool Function
+%54 = OpVariable %_ptr_Function_uint Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_bool Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_bool Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+OpStore %50 %25
+OpStore %51 %26
+%74 = OpLoad %float %51
+%75 = OpLoad %float %51
+%76 = OpFUnordNotEqual %bool %74 %75
+OpStore %53 %76
+%77 = OpLoad %bool %53
+OpSelectionMerge %47 None
+OpBranchConditional %77 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%78 = OpLoad %float %51
+%79 = OpBitcast %uint %78
+OpStore %54 %79
+%80 = OpLoad %uint %54
+%81 = OpUConvert %ulong %80
+OpStore %55 %81
+OpBranch %40
+%40 = OpLabel
+%82 = OpLoad %ulong %50
+OpStore %72 %82
+OpStore %73 %ulong_0
+OpBranch %41
+%41 = OpLabel
+%84 = OpLoad %ulong %73
+%86 = OpULessThan %bool %84 %ulong_8
+OpStore %65 %86
+%87 = OpLoad %bool %65
+OpLoopMerge %43 %45 None
+OpBranchConditional %87 %42 %43
+%43 = OpLabel
+OpBranch %44
+%44 = OpLabel
+OpBranch %34
 %34 = OpLabel
+%88 = OpLoad %ulong %72
+OpReturnValue %88
+%42 = OpLabel
+%89 = OpLoad %ulong %73
+%90 = OpIMul %ulong %89 %ulong_8
+OpStore %66 %90
+%91 = OpLoad %ulong %55
+%92 = OpLoad %ulong %66
+%93 = OpShiftRightLogical %ulong %91 %92
+OpStore %67 %93
+%94 = OpLoad %ulong %67
+%96 = OpBitwiseAnd %ulong %94 %ulong_255
+OpStore %68 %96
+%97 = OpLoad %ulong %72
+%98 = OpLoad %ulong %68
+%99 = OpBitwiseXor %ulong %97 %98
+OpStore %69 %99
+%100 = OpLoad %ulong %69
+%102 = OpIMul %ulong %100 %ulong_1099511628211
+OpStore %70 %102
+%103 = OpLoad %ulong %73
+%105 = OpIAdd %ulong %103 %ulong_1
+OpStore %71 %105
+%106 = OpLoad %ulong %70
+OpStore %72 %106
+%107 = OpLoad %ulong %71
+OpStore %73 %107
+OpBranch %45
+%28 = OpLabel
+OpBranch %31
+%31 = OpLabel
 OpBranch %35
 %35 = OpLabel
-%49 = OpLoad %ulong %39
-%50 = OpLoad %float %40
-%51 = OpFunctionCall %ulong %9 %49 %50
-OpStore %44 %51
-%52 = OpLoad %ulong %44
-OpReturnValue %52
-%33 = OpLabel
-%53 = OpLoad %ulong %39
-%55 = OpFunctionCall %ulong %6 %53 %uint_4294967295
-OpStore %43 %55
-%56 = OpLoad %ulong %43
-OpReturnValue %56
+%108 = OpLoad %ulong %50
+OpStore %63 %108
+OpStore %64 %ulong_0
+OpBranch %36
 %36 = OpLabel
+%109 = OpLoad %ulong %64
+%110 = OpULessThan %bool %109 %ulong_8
+OpStore %56 %110
+%111 = OpLoad %bool %56
+OpLoopMerge %38 %46 None
+OpBranchConditional %111 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%112 = OpLoad %ulong %63
+OpReturnValue %112
+%37 = OpLabel
+%113 = OpLoad %ulong %64
+%114 = OpIMul %ulong %113 %ulong_8
+OpStore %57 %114
+%116 = OpLoad %ulong %57
+%117 = OpShiftRightLogical %ulong %ulong_4294967295 %116
+OpStore %58 %117
+%118 = OpLoad %ulong %58
+%119 = OpBitwiseAnd %ulong %118 %ulong_255
+OpStore %59 %119
+%120 = OpLoad %ulong %63
+%121 = OpLoad %ulong %59
+%122 = OpBitwiseXor %ulong %120 %121
+OpStore %60 %122
+%123 = OpLoad %ulong %60
+%124 = OpIMul %ulong %123 %ulong_1099511628211
+OpStore %61 %124
+%125 = OpLoad %ulong %64
+%126 = OpIAdd %ulong %125 %ulong_1
+OpStore %62 %126
+%127 = OpLoad %ulong %61
+OpStore %63 %127
+%128 = OpLoad %ulong %62
+OpStore %64 %128
+OpBranch %46
+%45 = OpLabel
+OpBranch %41
+%46 = OpLabel
+OpBranch %36
+%47 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%3 = OpFunction %ulong None %57
-%58 = OpFunctionParameter %ulong
-%59 = OpLabel
-%173 = OpVariable %_ptr_Function__arr_uint_uint_8 Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_uint Function
-%177 = OpVariable %_ptr_Function_float Function
-%178 = OpVariable %_ptr_Function_float Function
-%179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_float Function
-%181 = OpVariable %_ptr_Function_float Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_float Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_float Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_float Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_float Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_float Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_float Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_float Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_float Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_float Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_float Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_bool Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_bool Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_bool Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_float Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_float Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_float Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_float Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_float Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_float Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_float Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_float Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_float Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_float Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_float Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_float Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_float Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_float Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_float Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_float Function
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_bool Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_float Function
-%254 = OpVariable %_ptr_Function_bool Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_float Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_float Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_float Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_float Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_float Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_float Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_float Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_uint Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_bool Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_bool Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_bool Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_bool Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_float Function
-%281 = OpVariable %_ptr_Function_uint Function
-%282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_float Function
-%284 = OpVariable %_ptr_Function_uint Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_float Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_float Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_float Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_float Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_float Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_float Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_float Function
-%302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_float Function
+%3 = OpFunction %ulong None %129
+%130 = OpFunctionParameter %ulong
+%131 = OpLabel
+%303 = OpVariable %_ptr_Function__arr_uint_uint_8 Function
 %304 = OpVariable %_ptr_Function_ulong Function
-%305 = OpVariable %_ptr_Function_float Function
+%305 = OpVariable %_ptr_Function_uint Function
 %306 = OpVariable %_ptr_Function_ulong Function
-%307 = OpVariable %_ptr_Function_float Function
-%308 = OpVariable %_ptr_Function_ulong Function
-%309 = OpVariable %_ptr_Function_float Function
-%310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_float Function
-%312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_float Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_float Function
-%316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_bool Function
-%318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_bool Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_float Function
-%322 = OpVariable %_ptr_Function_bool Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_float Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_float Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_float Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_float Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_float Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_float Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_float Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_float Function
 %323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_bool Function
-%325 = OpVariable %_ptr_Function_float Function
-%326 = OpVariable %_ptr_Function_uint Function
-%327 = OpVariable %_ptr_Function_bool Function
-%328 = OpVariable %_ptr_Function_uint Function
-%329 = OpVariable %_ptr_Function_uint Function
+%324 = OpVariable %_ptr_Function_float Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_float Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_float Function
+%329 = OpVariable %_ptr_Function_ulong Function
 %330 = OpVariable %_ptr_Function_float Function
-%331 = OpVariable %_ptr_Function_uint Function
-%332 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_uint Function
-%334 = OpVariable %_ptr_Function_uint Function
-%335 = OpVariable %_ptr_Function_uint Function
-%336 = OpVariable %_ptr_Function_uint Function
-%337 = OpVariable %_ptr_Function_uint Function
-%338 = OpVariable %_ptr_Function_uint Function
-%339 = OpVariable %_ptr_Function_uint Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_float Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_float Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_float Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_float Function
+%339 = OpVariable %_ptr_Function_ulong Function
 %340 = OpVariable %_ptr_Function_float Function
-%341 = OpVariable %_ptr_Function_float Function
+%341 = OpVariable %_ptr_Function_ulong Function
 %342 = OpVariable %_ptr_Function_float Function
-%343 = OpVariable %_ptr_Function_float Function
+%343 = OpVariable %_ptr_Function_ulong Function
 %344 = OpVariable %_ptr_Function_float Function
-%345 = OpVariable %_ptr_Function_float Function
+%345 = OpVariable %_ptr_Function_ulong Function
 %346 = OpVariable %_ptr_Function_float Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_float Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_uint Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_uint Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_uint Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_uint Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_uint Function
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_uint Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_uint Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_float Function
-%367 = OpVariable %_ptr_Function_uint Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_bool Function
+%349 = OpVariable %_ptr_Function_bool Function
+%350 = OpVariable %_ptr_Function_bool Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_float Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_float Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_float Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_float Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_float Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_float Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_float Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_float Function
 %368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_float Function
 %370 = OpVariable %_ptr_Function_ulong Function
 %371 = OpVariable %_ptr_Function_float Function
 %372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_float Function
 %374 = OpVariable %_ptr_Function_ulong Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_float Function
-%377 = OpVariable %_ptr_Function_uint Function
-%378 = OpVariable %_ptr_Function_uint Function
-%379 = OpVariable %_ptr_Function_uint Function
-%380 = OpVariable %_ptr_Function_float Function
-%381 = OpVariable %_ptr_Function_bool Function
+%375 = OpVariable %_ptr_Function_float Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_float Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_float Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_float Function
 %382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_float Function
 %384 = OpVariable %_ptr_Function_ulong Function
 %385 = OpVariable %_ptr_Function_bool Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_ulong Function
-%388 = OpVariable %_ptr_Function_ulong Function
-%389 = OpVariable %_ptr_Function_uint Function
+%386 = OpVariable %_ptr_Function_float Function
+%387 = OpVariable %_ptr_Function_bool Function
+%388 = OpVariable %_ptr_Function_float Function
+%389 = OpVariable %_ptr_Function_ulong Function
 %390 = OpVariable %_ptr_Function_float Function
-%391 = OpVariable %_ptr_Function_bool Function
-%392 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_float Function
 %393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_float Function
-%396 = OpVariable %_ptr_Function_bool Function
+%394 = OpVariable %_ptr_Function_float Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_float Function
 %397 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_float Function
 %399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_uint Function
-%401 = OpVariable %_ptr_Function_float Function
-%402 = OpVariable %_ptr_Function_bool Function
-%403 = OpVariable %_ptr_Function_ulong Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_ulong Function
-%406 = OpVariable %_ptr_Function_uint Function
+%400 = OpVariable %_ptr_Function_float Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_uint Function
+%403 = OpVariable %_ptr_Function_bool Function
+%404 = OpVariable %_ptr_Function_bool Function
+%405 = OpVariable %_ptr_Function_bool Function
+%406 = OpVariable %_ptr_Function_bool Function
 %407 = OpVariable %_ptr_Function_float Function
-%408 = OpVariable %_ptr_Function_bool Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_ulong Function
-%412 = OpVariable %_ptr_Function_uint Function
-%413 = OpVariable %_ptr_Function_float Function
-%414 = OpVariable %_ptr_Function_bool Function
+%408 = OpVariable %_ptr_Function_uint Function
+%409 = OpVariable %_ptr_Function_float Function
+%410 = OpVariable %_ptr_Function_float Function
+%411 = OpVariable %_ptr_Function_uint Function
+%412 = OpVariable %_ptr_Function_float Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_float Function
 %415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_float Function
 %417 = OpVariable %_ptr_Function_ulong Function
-%418 = OpVariable %_ptr_Function_uint Function
-%419 = OpVariable %_ptr_Function_float Function
-%420 = OpVariable %_ptr_Function_bool Function
+%418 = OpVariable %_ptr_Function_float Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_float Function
 %421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_float Function
 %423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_uint Function
-%425 = OpVariable %_ptr_Function_float Function
-%426 = OpVariable %_ptr_Function_uint Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
 %427 = OpVariable %_ptr_Function_float Function
-%428 = OpVariable %_ptr_Function_uint Function
+%428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_float Function
-%430 = OpVariable %_ptr_Function_uint Function
+%430 = OpVariable %_ptr_Function_ulong Function
 %431 = OpVariable %_ptr_Function_float Function
-%432 = OpVariable %_ptr_Function_bool Function
-%433 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_float Function
 %434 = OpVariable %_ptr_Function_ulong Function
-%435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_bool Function
-%437 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_float Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_float Function
 %438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_bool Function
-%441 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_float Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_float Function
 %442 = OpVariable %_ptr_Function_ulong Function
-%443 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_bool Function
 %444 = OpVariable %_ptr_Function_bool Function
-%445 = OpVariable %_ptr_Function_ulong Function
-%446 = OpVariable %_ptr_Function_ulong Function
-%447 = OpVariable %_ptr_Function_ulong Function
-%448 = OpVariable %_ptr_Function_bool Function
+%445 = OpVariable %_ptr_Function_float Function
+%446 = OpVariable %_ptr_Function_bool Function
+%447 = OpVariable %_ptr_Function_bool Function
+%448 = OpVariable %_ptr_Function_float Function
 %449 = OpVariable %_ptr_Function_ulong Function
-%450 = OpVariable %_ptr_Function_ulong Function
-%451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_bool Function
-%453 = OpVariable %_ptr_Function_ulong Function
-%454 = OpVariable %_ptr_Function_ulong Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_bool Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_bool Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-OpStore %174 %58
-%464 = OpFunctionCall %ulong %4
-OpStore %175 %464
-%465 = OpLoad %ulong %174
-%466 = OpUConvert %uint %465
-OpStore %176 %466
-OpBranch %66
-%66 = OpLabel
-%468 = OpLoad %uint %176
-%469 = OpIAdd %uint %uint_1065353216 %468
-OpStore %379 %469
-%470 = OpLoad %uint %379
-%471 = OpBitcast %float %470
-OpStore %380 %471
-OpBranch %67
-%67 = OpLabel
-OpBranch %78
-%78 = OpLabel
-%473 = OpLoad %uint %176
-%474 = OpIAdd %uint %uint_3212836864 %473
-OpStore %389 %474
-%475 = OpLoad %uint %389
-%476 = OpBitcast %float %475
-OpStore %390 %476
-OpBranch %79
-%79 = OpLabel
-OpBranch %85
-%85 = OpLabel
-%477 = OpLoad %uint %176
-%478 = OpBitcast %float %477
-OpStore %395 %478
-OpBranch %86
-%86 = OpLabel
-OpBranch %92
-%92 = OpLabel
-%480 = OpLoad %uint %176
-%481 = OpIAdd %uint %uint_2147483648 %480
-OpStore %400 %481
-%482 = OpLoad %uint %400
-%483 = OpBitcast %float %482
-OpStore %401 %483
-OpBranch %93
-%93 = OpLabel
-OpBranch %99
-%99 = OpLabel
-%485 = OpLoad %uint %176
-%486 = OpIAdd %uint %uint_2139095040 %485
-OpStore %406 %486
-%487 = OpLoad %uint %406
-%488 = OpBitcast %float %487
-OpStore %407 %488
-OpBranch %100
-%100 = OpLabel
-OpBranch %106
-%106 = OpLabel
-%490 = OpLoad %uint %176
-%491 = OpIAdd %uint %uint_4286578688 %490
-OpStore %412 %491
-%492 = OpLoad %uint %412
-%493 = OpBitcast %float %492
-OpStore %413 %493
-OpBranch %107
-%107 = OpLabel
-OpBranch %113
-%113 = OpLabel
-%495 = OpLoad %uint %176
-%496 = OpIAdd %uint %uint_2143289344 %495
-OpStore %418 %496
-%497 = OpLoad %uint %418
-%498 = OpBitcast %float %497
-OpStore %419 %498
-OpBranch %114
-%114 = OpLabel
-OpBranch %120
-%120 = OpLabel
-%500 = OpLoad %uint %176
-%501 = OpIAdd %uint %uint_2139095039 %500
-OpStore %424 %501
-%502 = OpLoad %uint %424
-%503 = OpBitcast %float %502
-OpStore %425 %503
-OpBranch %121
-%121 = OpLabel
-OpBranch %122
-%122 = OpLabel
-%505 = OpLoad %uint %176
-%506 = OpIAdd %uint %uint_8388608 %505
-OpStore %426 %506
-%507 = OpLoad %uint %426
-%508 = OpBitcast %float %507
-OpStore %427 %508
-OpBranch %123
-%123 = OpLabel
-OpBranch %124
-%124 = OpLabel
-%510 = OpLoad %uint %176
-%511 = OpIAdd %uint %uint_8388607 %510
-OpStore %428 %511
-%512 = OpLoad %uint %428
-%513 = OpBitcast %float %512
-OpStore %429 %513
-OpBranch %125
-%125 = OpLabel
-OpBranch %126
-%126 = OpLabel
-%515 = OpLoad %uint %176
-%516 = OpIAdd %uint %uint_1 %515
-OpStore %430 %516
-%517 = OpLoad %uint %430
-%518 = OpBitcast %float %517
-OpStore %431 %518
-OpBranch %127
-%127 = OpLabel
-OpBranch %128
-%128 = OpLabel
-%519 = OpLoad %float %395
-%520 = OpLoad %float %395
-%521 = OpFUnordNotEqual %bool %519 %520
-OpStore %432 %521
-%522 = OpLoad %bool %432
-OpSelectionMerge %132 None
-OpBranchConditional %522 %129 %130
-%130 = OpLabel
-OpBranch %131
-%131 = OpLabel
-%523 = OpLoad %ulong %175
-%524 = OpLoad %float %395
-%525 = OpFunctionCall %ulong %9 %523 %524
-OpStore %434 %525
-%526 = OpLoad %ulong %434
-OpStore %435 %526
-OpBranch %132
-%129 = OpLabel
-%527 = OpLoad %ulong %175
-%528 = OpFunctionCall %ulong %6 %527 %uint_4294967295
-OpStore %433 %528
-%529 = OpLoad %ulong %433
-OpStore %435 %529
-OpBranch %132
-%132 = OpLabel
-OpBranch %133
-%133 = OpLabel
-%530 = OpLoad %float %401
-%531 = OpLoad %float %401
-%532 = OpFUnordNotEqual %bool %530 %531
-OpStore %436 %532
-%533 = OpLoad %bool %436
-OpSelectionMerge %137 None
-OpBranchConditional %533 %134 %135
-%135 = OpLabel
-OpBranch %136
-%136 = OpLabel
-%534 = OpLoad %ulong %435
-%535 = OpLoad %float %401
-%536 = OpFunctionCall %ulong %9 %534 %535
-OpStore %438 %536
-%537 = OpLoad %ulong %438
-OpStore %439 %537
-OpBranch %137
-%134 = OpLabel
-%538 = OpLoad %ulong %435
-%539 = OpFunctionCall %ulong %6 %538 %uint_4294967295
-OpStore %437 %539
-%540 = OpLoad %ulong %437
-OpStore %439 %540
-OpBranch %137
-%137 = OpLabel
-%541 = OpLoad %float %395
-%542 = OpLoad %float %395
-%543 = OpFAdd %float %541 %542
-OpStore %177 %543
+%450 = OpVariable %_ptr_Function_uint Function
+%451 = OpVariable %_ptr_Function_bool Function
+%452 = OpVariable %_ptr_Function_uint Function
+%453 = OpVariable %_ptr_Function_uint Function
+%454 = OpVariable %_ptr_Function_float Function
+%455 = OpVariable %_ptr_Function_uint Function
+%456 = OpVariable %_ptr_Function_uint Function
+%457 = OpVariable %_ptr_Function_uint Function
+%458 = OpVariable %_ptr_Function_uint Function
+%459 = OpVariable %_ptr_Function_uint Function
+%460 = OpVariable %_ptr_Function_uint Function
+%461 = OpVariable %_ptr_Function_uint Function
+%462 = OpVariable %_ptr_Function_uint Function
+%463 = OpVariable %_ptr_Function_float Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_float Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_float Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_float Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_float Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_float Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_float Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_float Function
+%478 = OpVariable %_ptr_Function_float Function
+%479 = OpVariable %_ptr_Function_float Function
+%480 = OpVariable %_ptr_Function_float Function
+%481 = OpVariable %_ptr_Function_float Function
+%482 = OpVariable %_ptr_Function_uint Function
+%483 = OpVariable %_ptr_Function_uint Function
+%484 = OpVariable %_ptr_Function_uint Function
+%485 = OpVariable %_ptr_Function_uint Function
+%486 = OpVariable %_ptr_Function_uint Function
+%487 = OpVariable %_ptr_Function_uint Function
+%488 = OpVariable %_ptr_Function_uint Function
+%489 = OpVariable %_ptr_Function_float Function
+%490 = OpVariable %_ptr_Function_uint Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_float Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_float Function
+%497 = OpVariable %_ptr_Function_uint Function
+%498 = OpVariable %_ptr_Function_uint Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_uint Function
+%502 = OpVariable %_ptr_Function_float Function
+%503 = OpVariable %_ptr_Function_bool Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_bool Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_uint Function
+%523 = OpVariable %_ptr_Function_float Function
+%524 = OpVariable %_ptr_Function_bool Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_float Function
+%535 = OpVariable %_ptr_Function_bool Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_uint Function
+%546 = OpVariable %_ptr_Function_float Function
+%547 = OpVariable %_ptr_Function_bool Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_uint Function
+%558 = OpVariable %_ptr_Function_float Function
+%559 = OpVariable %_ptr_Function_bool Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_uint Function
+%570 = OpVariable %_ptr_Function_float Function
+%571 = OpVariable %_ptr_Function_bool Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_uint Function
+%582 = OpVariable %_ptr_Function_float Function
+%583 = OpVariable %_ptr_Function_bool Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_ulong Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_uint Function
+%594 = OpVariable %_ptr_Function_float Function
+%595 = OpVariable %_ptr_Function_bool Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_ulong Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_uint Function
+%605 = OpVariable %_ptr_Function_float Function
+%606 = OpVariable %_ptr_Function_bool Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_ulong Function
+%610 = OpVariable %_ptr_Function_ulong Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_ulong Function
+%613 = OpVariable %_ptr_Function_ulong Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_uint Function
+%616 = OpVariable %_ptr_Function_float Function
+%617 = OpVariable %_ptr_Function_bool Function
+%618 = OpVariable %_ptr_Function_ulong Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_ulong Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_ulong Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function_uint Function
+%627 = OpVariable %_ptr_Function_float Function
+%628 = OpVariable %_ptr_Function_ulong Function
+%629 = OpVariable %_ptr_Function_bool Function
+%630 = OpVariable %_ptr_Function_ulong Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_ulong Function
+%633 = OpVariable %_ptr_Function_ulong Function
+%634 = OpVariable %_ptr_Function_ulong Function
+%635 = OpVariable %_ptr_Function_ulong Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function_ulong Function
+%638 = OpVariable %_ptr_Function_ulong Function
+%639 = OpVariable %_ptr_Function_bool Function
+%640 = OpVariable %_ptr_Function_ulong Function
+%641 = OpVariable %_ptr_Function_ulong Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_ulong Function
+%644 = OpVariable %_ptr_Function_ulong Function
+%645 = OpVariable %_ptr_Function_ulong Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_ulong Function
+%648 = OpVariable %_ptr_Function_ulong Function
+%649 = OpVariable %_ptr_Function_bool Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_ulong Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_ulong Function
+%667 = OpVariable %_ptr_Function_ulong Function
+%668 = OpVariable %_ptr_Function_ulong Function
+%669 = OpVariable %_ptr_Function_ulong Function
+%670 = OpVariable %_ptr_Function_ulong Function
+%671 = OpVariable %_ptr_Function_ulong Function
+%672 = OpVariable %_ptr_Function_ulong Function
+%673 = OpVariable %_ptr_Function_ulong Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_ulong Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_ulong Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_ulong Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%681 = OpVariable %_ptr_Function_ulong Function
+OpStore %304 %130
 OpBranch %138
 %138 = OpLabel
-%544 = OpLoad %float %177
-%545 = OpLoad %float %177
-%546 = OpFUnordNotEqual %bool %544 %545
-OpStore %440 %546
-%547 = OpLoad %bool %440
-OpSelectionMerge %142 None
-OpBranchConditional %547 %139 %140
-%140 = OpLabel
-OpBranch %141
-%141 = OpLabel
-%548 = OpLoad %ulong %439
-%549 = OpLoad %float %177
-%550 = OpFunctionCall %ulong %9 %548 %549
-OpStore %442 %550
-%551 = OpLoad %ulong %442
-OpStore %443 %551
-OpBranch %142
+OpBranch %139
 %139 = OpLabel
-%552 = OpLoad %ulong %439
-%553 = OpFunctionCall %ulong %6 %552 %uint_4294967295
-OpStore %441 %553
-%554 = OpLoad %ulong %441
-OpStore %443 %554
-OpBranch %142
-%142 = OpLabel
-%555 = OpLoad %float %395
-%556 = OpLoad %float %401
-%557 = OpFAdd %float %555 %556
-OpStore %178 %557
-OpBranch %143
-%143 = OpLabel
-%558 = OpLoad %float %178
-%559 = OpLoad %float %178
-%560 = OpFUnordNotEqual %bool %558 %559
-OpStore %444 %560
-%561 = OpLoad %bool %444
-OpSelectionMerge %147 None
-OpBranchConditional %561 %144 %145
-%145 = OpLabel
-OpBranch %146
-%146 = OpLabel
-%562 = OpLoad %ulong %443
-%563 = OpLoad %float %178
-%564 = OpFunctionCall %ulong %9 %562 %563
-OpStore %446 %564
-%565 = OpLoad %ulong %446
-OpStore %447 %565
-OpBranch %147
+%682 = OpLoad %ulong %304
+%683 = OpUConvert %uint %682
+OpStore %305 %683
+OpBranch %144
 %144 = OpLabel
-%566 = OpLoad %ulong %443
-%567 = OpFunctionCall %ulong %6 %566 %uint_4294967295
-OpStore %445 %567
-%568 = OpLoad %ulong %445
-OpStore %447 %568
-OpBranch %147
-%147 = OpLabel
-%569 = OpLoad %float %401
-%570 = OpLoad %float %395
-%571 = OpFAdd %float %569 %570
-OpStore %179 %571
-OpBranch %148
-%148 = OpLabel
-%572 = OpLoad %float %179
-%573 = OpLoad %float %179
-%574 = OpFUnordNotEqual %bool %572 %573
-OpStore %448 %574
-%575 = OpLoad %bool %448
-OpSelectionMerge %152 None
-OpBranchConditional %575 %149 %150
-%150 = OpLabel
-OpBranch %151
-%151 = OpLabel
-%576 = OpLoad %ulong %447
-%577 = OpLoad %float %179
-%578 = OpFunctionCall %ulong %9 %576 %577
-OpStore %450 %578
-%579 = OpLoad %ulong %450
-OpStore %451 %579
-OpBranch %152
-%149 = OpLabel
-%580 = OpLoad %ulong %447
-%581 = OpFunctionCall %ulong %6 %580 %uint_4294967295
-OpStore %449 %581
-%582 = OpLoad %ulong %449
-OpStore %451 %582
-OpBranch %152
-%152 = OpLabel
-%583 = OpLoad %float %401
-%584 = OpLoad %float %401
-%585 = OpFAdd %float %583 %584
-OpStore %180 %585
-OpBranch %153
-%153 = OpLabel
-%586 = OpLoad %float %180
-%587 = OpLoad %float %180
-%588 = OpFUnordNotEqual %bool %586 %587
-OpStore %452 %588
-%589 = OpLoad %bool %452
-OpSelectionMerge %157 None
-OpBranchConditional %589 %154 %155
-%155 = OpLabel
-OpBranch %156
-%156 = OpLabel
-%590 = OpLoad %ulong %451
-%591 = OpLoad %float %180
-%592 = OpFunctionCall %ulong %9 %590 %591
-OpStore %454 %592
-%593 = OpLoad %ulong %454
-OpStore %455 %593
-OpBranch %157
-%154 = OpLabel
-%594 = OpLoad %ulong %451
-%595 = OpFunctionCall %ulong %6 %594 %uint_4294967295
-OpStore %453 %595
-%596 = OpLoad %ulong %453
-OpStore %455 %596
-OpBranch %157
-%157 = OpLabel
-%597 = OpLoad %float %395
-%598 = OpLoad %float %395
-%599 = OpFSub %float %597 %598
-OpStore %181 %599
+%685 = OpLoad %uint %305
+%686 = OpIAdd %uint %uint_1065353216 %685
+OpStore %501 %686
+%687 = OpLoad %uint %501
+%688 = OpBitcast %float %687
+OpStore %502 %688
+OpBranch %145
+%145 = OpLabel
 OpBranch %158
 %158 = OpLabel
-%600 = OpLoad %float %181
-%601 = OpLoad %float %181
-%602 = OpFUnordNotEqual %bool %600 %601
-OpStore %456 %602
-%603 = OpLoad %bool %456
-OpSelectionMerge %162 None
-OpBranchConditional %603 %159 %160
-%160 = OpLabel
-OpBranch %161
-%161 = OpLabel
-%604 = OpLoad %ulong %455
-%605 = OpLoad %float %181
-%606 = OpFunctionCall %ulong %9 %604 %605
-OpStore %458 %606
-%607 = OpLoad %ulong %458
-OpStore %459 %607
-OpBranch %162
+%690 = OpLoad %uint %305
+%691 = OpIAdd %uint %uint_3212836864 %690
+OpStore %522 %691
+%692 = OpLoad %uint %522
+%693 = OpBitcast %float %692
+OpStore %523 %693
+OpBranch %159
 %159 = OpLabel
-%608 = OpLoad %ulong %455
-%609 = OpFunctionCall %ulong %6 %608 %uint_4294967295
-OpStore %457 %609
-%610 = OpLoad %ulong %457
-OpStore %459 %610
-OpBranch %162
-%162 = OpLabel
-%611 = OpLoad %float %395
-%612 = OpLoad %float %401
-%613 = OpFSub %float %611 %612
-OpStore %182 %613
-OpBranch %163
-%163 = OpLabel
-%614 = OpLoad %float %182
-%615 = OpLoad %float %182
-%616 = OpFUnordNotEqual %bool %614 %615
-OpStore %460 %616
-%617 = OpLoad %bool %460
-OpSelectionMerge %167 None
-OpBranchConditional %617 %164 %165
-%165 = OpLabel
-OpBranch %166
-%166 = OpLabel
-%618 = OpLoad %ulong %459
-%619 = OpLoad %float %182
-%620 = OpFunctionCall %ulong %9 %618 %619
-OpStore %462 %620
-%621 = OpLoad %ulong %462
-OpStore %463 %621
-OpBranch %167
-%164 = OpLabel
-%622 = OpLoad %ulong %459
-%623 = OpFunctionCall %ulong %6 %622 %uint_4294967295
-OpStore %461 %623
-%624 = OpLoad %ulong %461
-OpStore %463 %624
 OpBranch %167
 %167 = OpLabel
-%625 = OpLoad %float %401
-%626 = OpLoad %float %395
-%627 = OpFSub %float %625 %626
-OpStore %183 %627
-%628 = OpLoad %ulong %463
-%629 = OpLoad %float %183
-%630 = OpFunctionCall %ulong %2 %628 %629
-OpStore %184 %630
-%631 = OpLoad %float %401
-%632 = OpLoad %float %401
-%633 = OpFSub %float %631 %632
-OpStore %185 %633
-%634 = OpLoad %ulong %184
-%635 = OpLoad %float %185
-%636 = OpFunctionCall %ulong %2 %634 %635
-OpStore %186 %636
-%637 = OpLoad %float %395
-%638 = OpLoad %float %380
-%639 = OpFMul %float %637 %638
-OpStore %187 %639
-%640 = OpLoad %ulong %186
-%641 = OpLoad %float %187
-%642 = OpFunctionCall %ulong %2 %640 %641
-OpStore %188 %642
-%643 = OpLoad %float %395
-%644 = OpLoad %float %390
-%645 = OpFMul %float %643 %644
-OpStore %189 %645
-%646 = OpLoad %ulong %188
-%647 = OpLoad %float %189
-%648 = OpFunctionCall %ulong %2 %646 %647
-OpStore %190 %648
-%649 = OpLoad %float %401
-%650 = OpLoad %float %380
-%651 = OpFMul %float %649 %650
-OpStore %191 %651
-%652 = OpLoad %ulong %190
-%653 = OpLoad %float %191
-%654 = OpFunctionCall %ulong %2 %652 %653
-OpStore %192 %654
-%655 = OpLoad %float %401
-%656 = OpLoad %float %390
-%657 = OpFMul %float %655 %656
-OpStore %193 %657
-%658 = OpLoad %ulong %192
-%659 = OpLoad %float %193
-%660 = OpFunctionCall %ulong %2 %658 %659
-OpStore %194 %660
-%661 = OpLoad %float %401
-%662 = OpLoad %float %401
-%663 = OpFMul %float %661 %662
-OpStore %195 %663
-%664 = OpLoad %ulong %194
-%665 = OpLoad %float %195
-%666 = OpFunctionCall %ulong %2 %664 %665
-OpStore %196 %666
-%667 = OpLoad %float %395
-%668 = OpLoad %float %401
-%669 = OpFMul %float %667 %668
-OpStore %197 %669
-%670 = OpLoad %ulong %196
-%671 = OpLoad %float %197
-%672 = OpFunctionCall %ulong %2 %670 %671
-OpStore %198 %672
-%673 = OpLoad %float %395
-%674 = OpFNegate %float %673
-OpStore %199 %674
-%675 = OpLoad %ulong %198
-%676 = OpLoad %float %199
-%677 = OpFunctionCall %ulong %2 %675 %676
-OpStore %200 %677
-%678 = OpLoad %float %401
-%679 = OpFNegate %float %678
-OpStore %201 %679
-%680 = OpLoad %ulong %200
-%681 = OpLoad %float %201
-%682 = OpFunctionCall %ulong %2 %680 %681
-OpStore %202 %682
-%683 = OpLoad %float %395
-%684 = OpLoad %float %380
-%685 = OpFDiv %float %683 %684
-OpStore %203 %685
-%686 = OpLoad %ulong %202
-%687 = OpLoad %float %203
-%688 = OpFunctionCall %ulong %2 %686 %687
-OpStore %204 %688
-%689 = OpLoad %float %395
-%690 = OpLoad %float %390
-%691 = OpFDiv %float %689 %690
-OpStore %205 %691
-%692 = OpLoad %ulong %204
-%693 = OpLoad %float %205
-%694 = OpFunctionCall %ulong %2 %692 %693
-OpStore %206 %694
-%695 = OpLoad %float %401
-%696 = OpLoad %float %380
-%697 = OpFDiv %float %695 %696
-OpStore %207 %697
-%698 = OpLoad %ulong %206
-%699 = OpLoad %float %207
-%700 = OpFunctionCall %ulong %2 %698 %699
-OpStore %208 %700
-%701 = OpLoad %float %401
-%702 = OpLoad %float %390
-%703 = OpFDiv %float %701 %702
-OpStore %209 %703
-%704 = OpLoad %ulong %208
-%705 = OpLoad %float %209
-%706 = OpFunctionCall %ulong %2 %704 %705
-OpStore %210 %706
-%707 = OpLoad %float %395
-%708 = OpLoad %float %401
-%709 = OpFOrdEqual %bool %707 %708
-OpStore %211 %709
-%711 = OpLoad %ulong %210
-%712 = OpLoad %bool %211
-%715 = OpSelect %uchar %712 %uchar_1 %uchar_0
-%716 = OpFunctionCall %ulong %5 %711 %715
-OpStore %212 %716
-%717 = OpLoad %float %395
-%718 = OpLoad %float %401
-%719 = OpFOrdLessThan %bool %717 %718
-OpStore %213 %719
-%720 = OpLoad %ulong %212
-%721 = OpLoad %bool %213
-%722 = OpSelect %uchar %721 %uchar_1 %uchar_0
-%723 = OpFunctionCall %ulong %5 %720 %722
-OpStore %214 %723
-%724 = OpLoad %float %401
-%725 = OpLoad %float %395
-%726 = OpFOrdLessThan %bool %724 %725
-OpStore %215 %726
-%727 = OpLoad %ulong %214
-%728 = OpLoad %bool %215
-%729 = OpSelect %uchar %728 %uchar_1 %uchar_0
-%730 = OpFunctionCall %ulong %5 %727 %729
-OpStore %216 %730
-%731 = OpLoad %ulong %216
-%732 = OpLoad %float %407
-%733 = OpFunctionCall %ulong %2 %731 %732
-OpStore %217 %733
-%734 = OpLoad %ulong %217
-%735 = OpLoad %float %413
-%736 = OpFunctionCall %ulong %2 %734 %735
-OpStore %218 %736
-%737 = OpLoad %float %407
-%738 = OpFNegate %float %737
-OpStore %219 %738
-%739 = OpLoad %ulong %218
-%740 = OpLoad %float %219
-%741 = OpFunctionCall %ulong %2 %739 %740
-OpStore %220 %741
-%742 = OpLoad %float %380
-%743 = OpLoad %float %395
-%744 = OpFDiv %float %742 %743
-OpStore %221 %744
-%745 = OpLoad %ulong %220
-%746 = OpLoad %float %221
-%747 = OpFunctionCall %ulong %2 %745 %746
-OpStore %222 %747
-%748 = OpLoad %float %380
-%749 = OpLoad %float %401
-%750 = OpFDiv %float %748 %749
-OpStore %223 %750
-%751 = OpLoad %ulong %222
-%752 = OpLoad %float %223
-%753 = OpFunctionCall %ulong %2 %751 %752
-OpStore %224 %753
-%754 = OpLoad %float %390
-%755 = OpLoad %float %395
-%756 = OpFDiv %float %754 %755
-OpStore %225 %756
-%757 = OpLoad %ulong %224
-%758 = OpLoad %float %225
-%759 = OpFunctionCall %ulong %2 %757 %758
-OpStore %226 %759
-%760 = OpLoad %float %390
-%761 = OpLoad %float %401
-%762 = OpFDiv %float %760 %761
-OpStore %227 %762
-%763 = OpLoad %ulong %226
-%764 = OpLoad %float %227
-%765 = OpFunctionCall %ulong %2 %763 %764
-OpStore %228 %765
-%766 = OpLoad %float %407
-%767 = OpLoad %float %380
-%768 = OpFAdd %float %766 %767
-OpStore %229 %768
-%769 = OpLoad %ulong %228
-%770 = OpLoad %float %229
-%771 = OpFunctionCall %ulong %2 %769 %770
-OpStore %230 %771
-%772 = OpLoad %float %407
-%773 = OpLoad %float %407
-%774 = OpFAdd %float %772 %773
-OpStore %231 %774
-%775 = OpLoad %ulong %230
-%776 = OpLoad %float %231
-%777 = OpFunctionCall %ulong %2 %775 %776
-OpStore %232 %777
-%778 = OpLoad %float %407
-%779 = OpLoad %float %413
-%780 = OpFSub %float %778 %779
-OpStore %233 %780
-%781 = OpLoad %ulong %232
-%782 = OpLoad %float %233
-%783 = OpFunctionCall %ulong %2 %781 %782
-OpStore %234 %783
-%784 = OpLoad %float %407
-%785 = OpLoad %float %407
-%786 = OpFMul %float %784 %785
-OpStore %235 %786
-%787 = OpLoad %ulong %234
-%788 = OpLoad %float %235
-%789 = OpFunctionCall %ulong %2 %787 %788
-OpStore %236 %789
-%790 = OpLoad %float %407
-%791 = OpLoad %float %413
-%792 = OpFMul %float %790 %791
-OpStore %237 %792
-%793 = OpLoad %ulong %236
-%794 = OpLoad %float %237
-%795 = OpFunctionCall %ulong %2 %793 %794
-OpStore %238 %795
-%796 = OpLoad %float %407
-%797 = OpLoad %float %390
-%798 = OpFMul %float %796 %797
-OpStore %239 %798
-%799 = OpLoad %ulong %238
-%800 = OpLoad %float %239
-%801 = OpFunctionCall %ulong %2 %799 %800
-OpStore %240 %801
-%802 = OpLoad %float %380
-%803 = OpLoad %float %407
-%804 = OpFDiv %float %802 %803
-OpStore %241 %804
-%805 = OpLoad %ulong %240
-%806 = OpLoad %float %241
-%807 = OpFunctionCall %ulong %2 %805 %806
-OpStore %242 %807
-%808 = OpLoad %float %390
-%809 = OpLoad %float %407
-%810 = OpFDiv %float %808 %809
-OpStore %243 %810
-%811 = OpLoad %ulong %242
-%812 = OpLoad %float %243
-%813 = OpFunctionCall %ulong %2 %811 %812
-OpStore %244 %813
-%814 = OpLoad %float %380
-%815 = OpLoad %float %413
-%816 = OpFDiv %float %814 %815
-OpStore %245 %816
-%817 = OpLoad %ulong %244
-%818 = OpLoad %float %245
-%819 = OpFunctionCall %ulong %2 %817 %818
-OpStore %246 %819
-%820 = OpLoad %float %407
-%821 = OpLoad %float %380
-%822 = OpFDiv %float %820 %821
-OpStore %247 %822
-%823 = OpLoad %ulong %246
-%824 = OpLoad %float %247
-%825 = OpFunctionCall %ulong %2 %823 %824
-OpStore %248 %825
-%826 = OpLoad %float %425
-%827 = OpLoad %float %425
-%828 = OpFAdd %float %826 %827
-OpStore %249 %828
-%829 = OpLoad %ulong %248
-%830 = OpLoad %float %249
-%831 = OpFunctionCall %ulong %2 %829 %830
-OpStore %250 %831
-%832 = OpLoad %float %425
-%833 = OpLoad %float %407
-%834 = OpFOrdLessThan %bool %832 %833
-OpStore %251 %834
-%835 = OpLoad %ulong %250
-%836 = OpLoad %bool %251
-%837 = OpSelect %uchar %836 %uchar_1 %uchar_0
-%838 = OpFunctionCall %ulong %5 %835 %837
-OpStore %252 %838
-%840 = OpLoad %float %425
-%841 = OpFSub %float %float_0 %840
-OpStore %253 %841
-%842 = OpLoad %float %413
-%843 = OpLoad %float %253
-%844 = OpFOrdLessThan %bool %842 %843
-OpStore %254 %844
-%845 = OpLoad %ulong %252
-%846 = OpLoad %bool %254
-%847 = OpSelect %uchar %846 %uchar_1 %uchar_0
-%848 = OpFunctionCall %ulong %5 %845 %847
-OpStore %255 %848
-%849 = OpLoad %float %407
-%850 = OpLoad %float %407
-%851 = OpFSub %float %849 %850
-OpStore %256 %851
-%852 = OpLoad %ulong %255
-%853 = OpLoad %float %256
-%854 = OpFunctionCall %ulong %2 %852 %853
-OpStore %257 %854
-%855 = OpLoad %float %413
-%856 = OpLoad %float %407
-%857 = OpFAdd %float %855 %856
-OpStore %258 %857
-%858 = OpLoad %ulong %257
-%859 = OpLoad %float %258
-%860 = OpFunctionCall %ulong %2 %858 %859
-OpStore %259 %860
-%861 = OpLoad %float %407
-%862 = OpLoad %float %395
-%863 = OpFMul %float %861 %862
-OpStore %260 %863
-%864 = OpLoad %ulong %259
-%865 = OpLoad %float %260
-%866 = OpFunctionCall %ulong %2 %864 %865
-OpStore %261 %866
-%867 = OpLoad %float %413
-%868 = OpLoad %float %401
-%869 = OpFMul %float %867 %868
-OpStore %262 %869
-%870 = OpLoad %ulong %261
-%871 = OpLoad %float %262
-%872 = OpFunctionCall %ulong %2 %870 %871
-OpStore %263 %872
-%873 = OpLoad %float %407
-%874 = OpLoad %float %407
-%875 = OpFDiv %float %873 %874
-OpStore %264 %875
-%876 = OpLoad %ulong %263
-%877 = OpLoad %float %264
-%878 = OpFunctionCall %ulong %2 %876 %877
-OpStore %265 %878
-%879 = OpLoad %float %395
-%880 = OpLoad %float %395
-%881 = OpFDiv %float %879 %880
-OpStore %266 %881
-%882 = OpLoad %ulong %265
-%883 = OpLoad %float %266
-%884 = OpFunctionCall %ulong %2 %882 %883
-OpStore %267 %884
-%885 = OpLoad %float %401
-%886 = OpLoad %float %395
-%887 = OpFDiv %float %885 %886
-OpStore %268 %887
-%888 = OpLoad %ulong %267
-%889 = OpLoad %float %268
-%890 = OpFunctionCall %ulong %2 %888 %889
-OpStore %269 %890
-%891 = OpLoad %float %419
-%892 = OpBitcast %uint %891
-OpStore %270 %892
-%893 = OpLoad %ulong %269
-%894 = OpLoad %uint %270
-%895 = OpFunctionCall %ulong %6 %893 %894
-OpStore %271 %895
-%896 = OpLoad %float %419
-%897 = OpLoad %float %419
-%898 = OpFUnordNotEqual %bool %896 %897
-OpStore %272 %898
-%899 = OpLoad %ulong %271
-%900 = OpLoad %bool %272
-%901 = OpSelect %uchar %900 %uchar_1 %uchar_0
-%902 = OpFunctionCall %ulong %5 %899 %901
-OpStore %273 %902
-%903 = OpLoad %float %419
-%904 = OpLoad %float %419
-%905 = OpFOrdEqual %bool %903 %904
-OpStore %274 %905
-%906 = OpLoad %ulong %273
-%907 = OpLoad %bool %274
-%908 = OpSelect %uchar %907 %uchar_1 %uchar_0
-%909 = OpFunctionCall %ulong %5 %906 %908
-OpStore %275 %909
-%910 = OpLoad %float %419
-%911 = OpLoad %float %419
-%912 = OpFOrdLessThan %bool %910 %911
-OpStore %276 %912
-%913 = OpLoad %ulong %275
-%914 = OpLoad %bool %276
-%915 = OpSelect %uchar %914 %uchar_1 %uchar_0
-%916 = OpFunctionCall %ulong %5 %913 %915
-OpStore %277 %916
-%917 = OpLoad %float %419
-%918 = OpLoad %float %419
-%919 = OpFOrdLessThanEqual %bool %917 %918
-OpStore %278 %919
-%920 = OpLoad %ulong %277
-%921 = OpLoad %bool %278
-%922 = OpSelect %uchar %921 %uchar_1 %uchar_0
-%923 = OpFunctionCall %ulong %5 %920 %922
-OpStore %279 %923
-%924 = OpLoad %float %419
-%925 = OpFNegate %float %924
-OpStore %280 %925
-%926 = OpLoad %float %280
-%927 = OpBitcast %uint %926
-OpStore %281 %927
-%928 = OpLoad %ulong %279
-%929 = OpLoad %uint %281
-%930 = OpFunctionCall %ulong %6 %928 %929
-OpStore %282 %930
-%931 = OpLoad %float %280
-%932 = OpFNegate %float %931
-OpStore %283 %932
-%933 = OpLoad %float %283
-%934 = OpBitcast %uint %933
-OpStore %284 %934
-%935 = OpLoad %ulong %282
-%936 = OpLoad %uint %284
-%937 = OpFunctionCall %ulong %6 %935 %936
-OpStore %285 %937
-%938 = OpLoad %float %419
-%939 = OpLoad %float %380
-%940 = OpFAdd %float %938 %939
-OpStore %286 %940
-%941 = OpLoad %ulong %285
-%942 = OpLoad %float %286
-%943 = OpFunctionCall %ulong %2 %941 %942
-OpStore %287 %943
-%944 = OpLoad %float %380
-%945 = OpLoad %float %419
-%946 = OpFAdd %float %944 %945
-OpStore %288 %946
-%947 = OpLoad %ulong %287
-%948 = OpLoad %float %288
-%949 = OpFunctionCall %ulong %2 %947 %948
-OpStore %289 %949
-%950 = OpLoad %float %419
-%951 = OpLoad %float %395
-%952 = OpFMul %float %950 %951
-OpStore %290 %952
-%953 = OpLoad %ulong %289
-%954 = OpLoad %float %290
-%955 = OpFunctionCall %ulong %2 %953 %954
-OpStore %291 %955
-%956 = OpLoad %float %419
-%957 = OpLoad %float %419
-%958 = OpFSub %float %956 %957
-OpStore %292 %958
-%959 = OpLoad %ulong %291
-%960 = OpLoad %float %292
-%961 = OpFunctionCall %ulong %2 %959 %960
-OpStore %293 %961
-%962 = OpLoad %float %419
-%963 = OpLoad %float %419
-%964 = OpFDiv %float %962 %963
-OpStore %294 %964
-%965 = OpLoad %ulong %293
-%966 = OpLoad %float %294
-%967 = OpFunctionCall %ulong %2 %965 %966
-OpStore %295 %967
-%968 = OpLoad %float %419
-%969 = OpLoad %float %407
-%970 = OpFDiv %float %968 %969
-OpStore %296 %970
-%971 = OpLoad %ulong %295
-%972 = OpLoad %float %296
-%973 = OpFunctionCall %ulong %2 %971 %972
-OpStore %297 %973
-%974 = OpLoad %ulong %297
-%975 = OpLoad %float %431
-%976 = OpFunctionCall %ulong %2 %974 %975
-OpStore %298 %976
-%977 = OpLoad %ulong %298
-%978 = OpLoad %float %429
-%979 = OpFunctionCall %ulong %2 %977 %978
-OpStore %299 %979
-%980 = OpLoad %ulong %299
-%981 = OpLoad %float %427
-%982 = OpFunctionCall %ulong %2 %980 %981
-OpStore %300 %982
-%983 = OpLoad %float %429
-%984 = OpLoad %float %431
-%985 = OpFAdd %float %983 %984
-OpStore %301 %985
-%986 = OpLoad %ulong %300
-%987 = OpLoad %float %301
-%988 = OpFunctionCall %ulong %2 %986 %987
-OpStore %302 %988
-%989 = OpLoad %float %427
-%990 = OpLoad %float %431
-%991 = OpFSub %float %989 %990
-OpStore %303 %991
-%992 = OpLoad %ulong %302
-%993 = OpLoad %float %303
-%994 = OpFunctionCall %ulong %2 %992 %993
-OpStore %304 %994
-%995 = OpLoad %float %431
-%996 = OpLoad %float %431
-%997 = OpFAdd %float %995 %996
-OpStore %305 %997
-%998 = OpLoad %ulong %304
-%999 = OpLoad %float %305
-%1000 = OpFunctionCall %ulong %2 %998 %999
-OpStore %306 %1000
-%1001 = OpLoad %float %431
-%1003 = OpFMul %float %1001 %float_1_5
-OpStore %307 %1003
-%1004 = OpLoad %ulong %306
-%1005 = OpLoad %float %307
-%1006 = OpFunctionCall %ulong %2 %1004 %1005
-OpStore %308 %1006
-%1007 = OpLoad %float %431
-%1009 = OpFMul %float %1007 %float_0_5
-OpStore %309 %1009
-%1010 = OpLoad %ulong %308
-%1011 = OpLoad %float %309
-%1012 = OpFunctionCall %ulong %2 %1010 %1011
-OpStore %310 %1012
-%1013 = OpLoad %float %431
-%1014 = OpFNegate %float %1013
-OpStore %311 %1014
-%1015 = OpLoad %ulong %310
-%1016 = OpLoad %float %311
-%1017 = OpFunctionCall %ulong %2 %1015 %1016
-OpStore %312 %1017
-%1018 = OpLoad %float %431
-%1020 = OpFMul %float %1018 %float_8388608
-OpStore %313 %1020
-%1021 = OpLoad %ulong %312
-%1022 = OpLoad %float %313
-%1023 = OpFunctionCall %ulong %2 %1021 %1022
-OpStore %314 %1023
-%1024 = OpLoad %float %429
-%1025 = OpLoad %float %427
-%1026 = OpFDiv %float %1024 %1025
-OpStore %315 %1026
-%1027 = OpLoad %ulong %314
-%1028 = OpLoad %float %315
-%1029 = OpFunctionCall %ulong %2 %1027 %1028
-OpStore %316 %1029
-%1030 = OpLoad %float %395
-%1031 = OpLoad %float %431
-%1032 = OpFOrdLessThan %bool %1030 %1031
-OpStore %317 %1032
-%1033 = OpLoad %ulong %316
-%1034 = OpLoad %bool %317
-%1035 = OpSelect %uchar %1034 %uchar_1 %uchar_0
-%1036 = OpFunctionCall %ulong %5 %1033 %1035
-OpStore %318 %1036
-%1037 = OpLoad %float %431
-%1038 = OpLoad %float %395
-%1039 = OpFOrdEqual %bool %1037 %1038
-OpStore %319 %1039
-%1040 = OpLoad %ulong %318
-%1041 = OpLoad %bool %319
-%1042 = OpSelect %uchar %1041 %uchar_1 %uchar_0
-%1043 = OpFunctionCall %ulong %5 %1040 %1042
-OpStore %320 %1043
-%1044 = OpLoad %float %431
-%1045 = OpFSub %float %float_0 %1044
-OpStore %321 %1045
-%1046 = OpLoad %float %321
-%1047 = OpLoad %float %401
-%1048 = OpFOrdLessThan %bool %1046 %1047
-OpStore %322 %1048
-%1049 = OpLoad %ulong %320
-%1050 = OpLoad %bool %322
-%1051 = OpSelect %uchar %1050 %uchar_1 %uchar_0
-%1052 = OpFunctionCall %ulong %5 %1049 %1051
-OpStore %323 %1052
-%1053 = OpLoad %ulong %323
-OpStore %375 %1053
-%1054 = OpLoad %float %427
-OpStore %376 %1054
-OpStore %377 %uint_0
-OpBranch %60
-%60 = OpLabel
-%1056 = OpLoad %uint %377
-%1058 = OpULessThan %bool %1056 %uint_30
-OpStore %324 %1058
-%1059 = OpLoad %bool %324
-OpLoopMerge %62 %169 None
-OpBranchConditional %1059 %61 %62
-%62 = OpLabel
-OpStore %173 %1060
-%1061 = OpAccessChain %_ptr_Function_uint %173 %uint_0
-OpStore %1061 %uint_0
-%1062 = OpAccessChain %_ptr_Function_uint %173 %uint_1
-OpStore %1062 %uint_2147483648
-%1064 = OpAccessChain %_ptr_Function_uint %173 %uint_2
-OpStore %1064 %uint_1
-%1066 = OpAccessChain %_ptr_Function_uint %173 %uint_3
-OpStore %1066 %uint_2139095040
-%1068 = OpAccessChain %_ptr_Function_uint %173 %uint_4
-OpStore %1068 %uint_4286578688
-%1070 = OpAccessChain %_ptr_Function_uint %173 %uint_5
-OpStore %1070 %uint_2143289344
-%1072 = OpAccessChain %_ptr_Function_uint %173 %uint_6
-OpStore %1072 %uint_4290829997
-%1075 = OpAccessChain %_ptr_Function_uint %173 %uint_7
-OpStore %1075 %uint_2139095041
-%1077 = OpLoad %ulong %375
-OpStore %374 %1077
-OpStore %378 %uint_0
-OpBranch %63
-%63 = OpLabel
-%1078 = OpLoad %uint %378
-%1079 = OpULessThan %bool %1078 %uint_8
-OpStore %327 %1079
-%1080 = OpLoad %bool %327
-OpLoopMerge %65 %168 None
-OpBranchConditional %1080 %64 %65
-%65 = OpLabel
-%1082 = OpLoad %uint %176
-%1083 = OpIAdd %uint %uint_16777216 %1082
-OpStore %334 %1083
-%1085 = OpLoad %uint %176
-%1086 = OpIAdd %uint %uint_16777217 %1085
-OpStore %335 %1086
-%1088 = OpLoad %uint %176
-%1089 = OpIAdd %uint %uint_16777219 %1088
-OpStore %336 %1089
-%1090 = OpLoad %uint %176
-%1091 = OpIAdd %uint %uint_4294967295 %1090
-OpStore %337 %1091
-%1093 = OpLoad %uint %176
-%1094 = OpIAdd %uint %uint_4278190079 %1093
-OpStore %338 %1094
-%1095 = OpLoad %uint %176
-%1096 = OpIAdd %uint %uint_2147483648 %1095
-OpStore %339 %1096
-%1097 = OpLoad %uint %334
-%1098 = OpConvertUToF %float %1097
-OpStore %340 %1098
-OpBranch %73
-%73 = OpLabel
-%1099 = OpLoad %float %340
-%1100 = OpLoad %float %340
-%1101 = OpFUnordNotEqual %bool %1099 %1100
-OpStore %385 %1101
-%1102 = OpLoad %bool %385
-OpSelectionMerge %77 None
-OpBranchConditional %1102 %74 %75
-%75 = OpLabel
-OpBranch %76
-%76 = OpLabel
-%1103 = OpLoad %ulong %374
-%1104 = OpLoad %float %340
-%1105 = OpFunctionCall %ulong %9 %1103 %1104
-OpStore %387 %1105
-%1106 = OpLoad %ulong %387
-OpStore %388 %1106
-OpBranch %77
-%74 = OpLabel
-%1107 = OpLoad %ulong %374
-%1108 = OpFunctionCall %ulong %6 %1107 %uint_4294967295
-OpStore %386 %1108
-%1109 = OpLoad %ulong %386
-OpStore %388 %1109
-OpBranch %77
-%77 = OpLabel
-%1110 = OpLoad %uint %335
-%1111 = OpConvertUToF %float %1110
-OpStore %341 %1111
-OpBranch %80
-%80 = OpLabel
-%1112 = OpLoad %float %341
-%1113 = OpLoad %float %341
-%1114 = OpFUnordNotEqual %bool %1112 %1113
-OpStore %391 %1114
-%1115 = OpLoad %bool %391
-OpSelectionMerge %84 None
-OpBranchConditional %1115 %81 %82
-%82 = OpLabel
-OpBranch %83
-%83 = OpLabel
-%1116 = OpLoad %ulong %388
-%1117 = OpLoad %float %341
-%1118 = OpFunctionCall %ulong %9 %1116 %1117
-OpStore %393 %1118
-%1119 = OpLoad %ulong %393
-OpStore %394 %1119
-OpBranch %84
-%81 = OpLabel
-%1120 = OpLoad %ulong %388
-%1121 = OpFunctionCall %ulong %6 %1120 %uint_4294967295
-OpStore %392 %1121
-%1122 = OpLoad %ulong %392
-OpStore %394 %1122
-OpBranch %84
-%84 = OpLabel
-%1123 = OpLoad %uint %336
-%1124 = OpConvertUToF %float %1123
-OpStore %342 %1124
-OpBranch %87
-%87 = OpLabel
-%1125 = OpLoad %float %342
-%1126 = OpLoad %float %342
-%1127 = OpFUnordNotEqual %bool %1125 %1126
-OpStore %396 %1127
-%1128 = OpLoad %bool %396
-OpSelectionMerge %91 None
-OpBranchConditional %1128 %88 %89
-%89 = OpLabel
-OpBranch %90
-%90 = OpLabel
-%1129 = OpLoad %ulong %394
-%1130 = OpLoad %float %342
-%1131 = OpFunctionCall %ulong %9 %1129 %1130
-OpStore %398 %1131
-%1132 = OpLoad %ulong %398
-OpStore %399 %1132
-OpBranch %91
-%88 = OpLabel
-%1133 = OpLoad %ulong %394
-%1134 = OpFunctionCall %ulong %6 %1133 %uint_4294967295
-OpStore %397 %1134
-%1135 = OpLoad %ulong %397
-OpStore %399 %1135
-OpBranch %91
-%91 = OpLabel
-%1136 = OpLoad %uint %337
-%1137 = OpConvertUToF %float %1136
-OpStore %343 %1137
-OpBranch %94
-%94 = OpLabel
-%1138 = OpLoad %float %343
-%1139 = OpLoad %float %343
-%1140 = OpFUnordNotEqual %bool %1138 %1139
-OpStore %402 %1140
-%1141 = OpLoad %bool %402
-OpSelectionMerge %98 None
-OpBranchConditional %1141 %95 %96
-%96 = OpLabel
-OpBranch %97
-%97 = OpLabel
-%1142 = OpLoad %ulong %399
-%1143 = OpLoad %float %343
-%1144 = OpFunctionCall %ulong %9 %1142 %1143
-OpStore %404 %1144
-%1145 = OpLoad %ulong %404
-OpStore %405 %1145
-OpBranch %98
-%95 = OpLabel
-%1146 = OpLoad %ulong %399
-%1147 = OpFunctionCall %ulong %6 %1146 %uint_4294967295
-OpStore %403 %1147
-%1148 = OpLoad %ulong %403
-OpStore %405 %1148
-OpBranch %98
-%98 = OpLabel
-%1149 = OpLoad %uint %176
-%1150 = OpConvertUToF %float %1149
-OpStore %344 %1150
-OpBranch %101
-%101 = OpLabel
-%1151 = OpLoad %float %344
-%1152 = OpLoad %float %344
-%1153 = OpFUnordNotEqual %bool %1151 %1152
-OpStore %408 %1153
-%1154 = OpLoad %bool %408
-OpSelectionMerge %105 None
-OpBranchConditional %1154 %102 %103
-%103 = OpLabel
-OpBranch %104
-%104 = OpLabel
-%1155 = OpLoad %ulong %405
-%1156 = OpLoad %float %344
-%1157 = OpFunctionCall %ulong %9 %1155 %1156
-OpStore %410 %1157
-%1158 = OpLoad %ulong %410
-OpStore %411 %1158
-OpBranch %105
-%102 = OpLabel
-%1159 = OpLoad %ulong %405
-%1160 = OpFunctionCall %ulong %6 %1159 %uint_4294967295
-OpStore %409 %1160
-%1161 = OpLoad %ulong %409
-OpStore %411 %1161
-OpBranch %105
-%105 = OpLabel
-%1162 = OpLoad %uint %338
-%1163 = OpConvertSToF %float %1162
-OpStore %345 %1163
-OpBranch %108
-%108 = OpLabel
-%1164 = OpLoad %float %345
-%1165 = OpLoad %float %345
-%1166 = OpFUnordNotEqual %bool %1164 %1165
-OpStore %414 %1166
-%1167 = OpLoad %bool %414
-OpSelectionMerge %112 None
-OpBranchConditional %1167 %109 %110
-%110 = OpLabel
-OpBranch %111
-%111 = OpLabel
-%1168 = OpLoad %ulong %411
-%1169 = OpLoad %float %345
-%1170 = OpFunctionCall %ulong %9 %1168 %1169
-OpStore %416 %1170
-%1171 = OpLoad %ulong %416
-OpStore %417 %1171
-OpBranch %112
-%109 = OpLabel
-%1172 = OpLoad %ulong %411
-%1173 = OpFunctionCall %ulong %6 %1172 %uint_4294967295
-OpStore %415 %1173
-%1174 = OpLoad %ulong %415
-OpStore %417 %1174
-OpBranch %112
-%112 = OpLabel
-%1175 = OpLoad %uint %339
-%1176 = OpConvertSToF %float %1175
-OpStore %346 %1176
-OpBranch %115
-%115 = OpLabel
-%1177 = OpLoad %float %346
-%1178 = OpLoad %float %346
-%1179 = OpFUnordNotEqual %bool %1177 %1178
-OpStore %420 %1179
-%1180 = OpLoad %bool %420
-OpSelectionMerge %119 None
-OpBranchConditional %1180 %116 %117
-%117 = OpLabel
-OpBranch %118
-%118 = OpLabel
-%1181 = OpLoad %ulong %417
-%1182 = OpLoad %float %346
-%1183 = OpFunctionCall %ulong %9 %1181 %1182
-OpStore %422 %1183
-%1184 = OpLoad %ulong %422
-OpStore %423 %1184
-OpBranch %119
-%116 = OpLabel
-%1185 = OpLoad %ulong %417
-%1186 = OpFunctionCall %ulong %6 %1185 %uint_4294967295
-OpStore %421 %1186
-%1187 = OpLoad %ulong %421
-OpStore %423 %1187
-OpBranch %119
-%119 = OpLabel
-%1188 = OpLoad %float %380
-%1189 = OpFMul %float %float_1_5 %1188
-OpStore %347 %1189
-%1191 = OpLoad %float %380
-%1192 = OpFMul %float %float_16777216 %1191
-OpStore %348 %1192
-%1194 = OpLoad %float %380
-%1195 = OpFMul %float %float_2_14748352e_09 %1194
-OpStore %349 %1195
-%1196 = OpLoad %float %347
-%1197 = OpFSub %float %float_0 %1196
-OpStore %350 %1197
-%1198 = OpLoad %float %380
-%1199 = OpFMul %float %float_0_5 %1198
-OpStore %351 %1199
-%1200 = OpLoad %float %347
-%1201 = OpConvertFToU %uint %1200
-OpStore %352 %1201
-%1202 = OpLoad %ulong %423
-%1203 = OpLoad %uint %352
-%1204 = OpFunctionCall %ulong %6 %1202 %1203
-OpStore %353 %1204
-%1205 = OpLoad %float %348
-%1206 = OpConvertFToU %uint %1205
-OpStore %354 %1206
-%1207 = OpLoad %ulong %353
-%1208 = OpLoad %uint %354
-%1209 = OpFunctionCall %ulong %6 %1207 %1208
-OpStore %355 %1209
-%1210 = OpLoad %float %349
-%1211 = OpConvertFToU %uint %1210
-OpStore %356 %1211
-%1212 = OpLoad %ulong %355
-%1213 = OpLoad %uint %356
-%1214 = OpFunctionCall %ulong %6 %1212 %1213
-OpStore %357 %1214
-%1215 = OpLoad %float %351
-%1216 = OpConvertFToU %uint %1215
-OpStore %358 %1216
-%1217 = OpLoad %ulong %357
-%1218 = OpLoad %uint %358
-%1219 = OpFunctionCall %ulong %6 %1217 %1218
-OpStore %359 %1219
-%1220 = OpLoad %float %395
-%1221 = OpConvertFToU %uint %1220
-OpStore %360 %1221
-%1222 = OpLoad %ulong %359
-%1223 = OpLoad %uint %360
-%1224 = OpFunctionCall %ulong %6 %1222 %1223
-OpStore %361 %1224
-%1225 = OpLoad %float %350
-%1226 = OpConvertFToS %uint %1225
-OpStore %362 %1226
-%1227 = OpLoad %ulong %361
-%1228 = OpLoad %uint %362
-%1229 = OpFunctionCall %ulong %7 %1227 %1228
-OpStore %363 %1229
-%1230 = OpLoad %float %349
-%1231 = OpConvertFToS %uint %1230
-OpStore %364 %1231
-%1232 = OpLoad %ulong %363
-%1233 = OpLoad %uint %364
-%1234 = OpFunctionCall %ulong %7 %1232 %1233
-OpStore %365 %1234
-%1235 = OpLoad %float %351
-%1236 = OpFSub %float %float_0 %1235
-OpStore %366 %1236
-%1237 = OpLoad %float %366
-%1238 = OpConvertFToS %uint %1237
-OpStore %367 %1238
-%1239 = OpLoad %ulong %365
-%1240 = OpLoad %uint %367
-%1241 = OpFunctionCall %ulong %7 %1239 %1240
-OpStore %368 %1241
-%1242 = OpLoad %float %350
-%1243 = OpConvertFToS %ulong %1242
-OpStore %369 %1243
-%1244 = OpLoad %ulong %368
-%1245 = OpLoad %ulong %369
-%1246 = OpFunctionCall %ulong %8 %1244 %1245
-OpStore %370 %1246
-%1247 = OpLoad %float %348
-%1248 = OpFSub %float %float_0 %1247
-OpStore %371 %1248
-%1249 = OpLoad %float %371
-%1250 = OpConvertFToS %ulong %1249
-OpStore %372 %1250
-%1251 = OpLoad %ulong %370
-%1252 = OpLoad %ulong %372
-%1253 = OpFunctionCall %ulong %8 %1251 %1252
-OpStore %373 %1253
-%1254 = OpLoad %ulong %373
-OpReturnValue %1254
-%64 = OpLabel
-%1255 = OpLoad %uint %378
-%1256 = OpAccessChain %_ptr_Function_uint %173 %1255
-%1257 = OpLoad %uint %1256
-OpStore %328 %1257
-%1258 = OpLoad %uint %328
-%1259 = OpLoad %uint %176
-%1260 = OpIAdd %uint %1258 %1259
-OpStore %329 %1260
-%1261 = OpLoad %uint %329
-%1262 = OpBitcast %float %1261
-OpStore %330 %1262
-%1263 = OpLoad %float %330
-%1264 = OpBitcast %uint %1263
-OpStore %331 %1264
-%1265 = OpLoad %ulong %374
-%1266 = OpLoad %uint %331
-%1267 = OpFunctionCall %ulong %6 %1265 %1266
-OpStore %332 %1267
-%1268 = OpLoad %uint %378
-%1269 = OpIAdd %uint %1268 %uint_1
-OpStore %333 %1269
-%1270 = OpLoad %ulong %332
-OpStore %374 %1270
-%1271 = OpLoad %uint %333
-OpStore %378 %1271
+%694 = OpLoad %uint %305
+%695 = OpBitcast %float %694
+OpStore %534 %695
 OpBranch %168
-%61 = OpLabel
-%1272 = OpLoad %float %376
-%1273 = OpFMul %float %1272 %float_0_5
-OpStore %325 %1273
-OpBranch %68
-%68 = OpLabel
-%1274 = OpLoad %float %325
-%1275 = OpLoad %float %325
-%1276 = OpFUnordNotEqual %bool %1274 %1275
-OpStore %381 %1276
-%1277 = OpLoad %bool %381
-OpSelectionMerge %72 None
-OpBranchConditional %1277 %69 %70
-%70 = OpLabel
-OpBranch %71
-%71 = OpLabel
-%1278 = OpLoad %ulong %375
-%1279 = OpLoad %float %325
-%1280 = OpFunctionCall %ulong %9 %1278 %1279
-OpStore %383 %1280
-%1281 = OpLoad %ulong %383
-OpStore %384 %1281
-OpBranch %72
-%69 = OpLabel
-%1282 = OpLoad %ulong %375
-%1283 = OpFunctionCall %ulong %6 %1282 %uint_4294967295
-OpStore %382 %1283
-%1284 = OpLoad %ulong %382
-OpStore %384 %1284
-OpBranch %72
-%72 = OpLabel
-%1285 = OpLoad %uint %377
-%1286 = OpIAdd %uint %1285 %uint_1
-OpStore %326 %1286
-%1287 = OpLoad %ulong %384
-OpStore %375 %1287
-%1288 = OpLoad %float %325
-OpStore %376 %1288
-%1289 = OpLoad %uint %326
-OpStore %377 %1289
-OpBranch %169
 %168 = OpLabel
-OpBranch %63
+OpBranch %176
+%176 = OpLabel
+%697 = OpLoad %uint %305
+%698 = OpIAdd %uint %uint_2147483648 %697
+OpStore %545 %698
+%699 = OpLoad %uint %545
+%700 = OpBitcast %float %699
+OpStore %546 %700
+OpBranch %177
+%177 = OpLabel
+OpBranch %185
+%185 = OpLabel
+%702 = OpLoad %uint %305
+%703 = OpIAdd %uint %uint_2139095040 %702
+OpStore %557 %703
+%704 = OpLoad %uint %557
+%705 = OpBitcast %float %704
+OpStore %558 %705
+OpBranch %186
+%186 = OpLabel
+OpBranch %194
+%194 = OpLabel
+%707 = OpLoad %uint %305
+%708 = OpIAdd %uint %uint_4286578688 %707
+OpStore %569 %708
+%709 = OpLoad %uint %569
+%710 = OpBitcast %float %709
+OpStore %570 %710
+OpBranch %195
+%195 = OpLabel
+OpBranch %203
+%203 = OpLabel
+%712 = OpLoad %uint %305
+%713 = OpIAdd %uint %uint_2143289344 %712
+OpStore %581 %713
+%714 = OpLoad %uint %581
+%715 = OpBitcast %float %714
+OpStore %582 %715
+OpBranch %204
+%204 = OpLabel
+OpBranch %212
+%212 = OpLabel
+%717 = OpLoad %uint %305
+%718 = OpIAdd %uint %uint_2139095039 %717
+OpStore %593 %718
+%719 = OpLoad %uint %593
+%720 = OpBitcast %float %719
+OpStore %594 %720
+OpBranch %213
+%213 = OpLabel
+OpBranch %221
+%221 = OpLabel
+%722 = OpLoad %uint %305
+%723 = OpIAdd %uint %uint_8388608 %722
+OpStore %604 %723
+%724 = OpLoad %uint %604
+%725 = OpBitcast %float %724
+OpStore %605 %725
+OpBranch %222
+%222 = OpLabel
+OpBranch %230
+%230 = OpLabel
+%727 = OpLoad %uint %305
+%728 = OpIAdd %uint %uint_8388607 %727
+OpStore %615 %728
+%729 = OpLoad %uint %615
+%730 = OpBitcast %float %729
+OpStore %616 %730
+OpBranch %231
+%231 = OpLabel
+OpBranch %237
+%237 = OpLabel
+%732 = OpLoad %uint %305
+%733 = OpIAdd %uint %uint_1 %732
+OpStore %626 %733
+%734 = OpLoad %uint %626
+%735 = OpBitcast %float %734
+OpStore %627 %735
+OpBranch %238
+%238 = OpLabel
+%737 = OpLoad %float %534
+%738 = OpFunctionCall %ulong %2 %ulong_14695981039346656037 %737
+OpStore %306 %738
+%739 = OpLoad %ulong %306
+%740 = OpLoad %float %546
+%741 = OpFunctionCall %ulong %2 %739 %740
+OpStore %307 %741
+%742 = OpLoad %float %534
+%743 = OpLoad %float %534
+%744 = OpFAdd %float %742 %743
+OpStore %308 %744
+%745 = OpLoad %ulong %307
+%746 = OpLoad %float %308
+%747 = OpFunctionCall %ulong %2 %745 %746
+OpStore %309 %747
+%748 = OpLoad %float %534
+%749 = OpLoad %float %546
+%750 = OpFAdd %float %748 %749
+OpStore %310 %750
+%751 = OpLoad %ulong %309
+%752 = OpLoad %float %310
+%753 = OpFunctionCall %ulong %2 %751 %752
+OpStore %311 %753
+%754 = OpLoad %float %546
+%755 = OpLoad %float %534
+%756 = OpFAdd %float %754 %755
+OpStore %312 %756
+%757 = OpLoad %ulong %311
+%758 = OpLoad %float %312
+%759 = OpFunctionCall %ulong %2 %757 %758
+OpStore %313 %759
+%760 = OpLoad %float %546
+%761 = OpLoad %float %546
+%762 = OpFAdd %float %760 %761
+OpStore %314 %762
+%763 = OpLoad %ulong %313
+%764 = OpLoad %float %314
+%765 = OpFunctionCall %ulong %2 %763 %764
+OpStore %315 %765
+%766 = OpLoad %float %534
+%767 = OpLoad %float %534
+%768 = OpFSub %float %766 %767
+OpStore %316 %768
+%769 = OpLoad %ulong %315
+%770 = OpLoad %float %316
+%771 = OpFunctionCall %ulong %2 %769 %770
+OpStore %317 %771
+%772 = OpLoad %float %534
+%773 = OpLoad %float %546
+%774 = OpFSub %float %772 %773
+OpStore %318 %774
+%775 = OpLoad %ulong %317
+%776 = OpLoad %float %318
+%777 = OpFunctionCall %ulong %2 %775 %776
+OpStore %319 %777
+%778 = OpLoad %float %546
+%779 = OpLoad %float %534
+%780 = OpFSub %float %778 %779
+OpStore %320 %780
+%781 = OpLoad %ulong %319
+%782 = OpLoad %float %320
+%783 = OpFunctionCall %ulong %2 %781 %782
+OpStore %321 %783
+%784 = OpLoad %float %546
+%785 = OpLoad %float %546
+%786 = OpFSub %float %784 %785
+OpStore %322 %786
+%787 = OpLoad %ulong %321
+%788 = OpLoad %float %322
+%789 = OpFunctionCall %ulong %2 %787 %788
+OpStore %323 %789
+%790 = OpLoad %float %534
+%791 = OpLoad %float %502
+%792 = OpFMul %float %790 %791
+OpStore %324 %792
+%793 = OpLoad %ulong %323
+%794 = OpLoad %float %324
+%795 = OpFunctionCall %ulong %2 %793 %794
+OpStore %325 %795
+%796 = OpLoad %float %534
+%797 = OpLoad %float %523
+%798 = OpFMul %float %796 %797
+OpStore %326 %798
+%799 = OpLoad %ulong %325
+%800 = OpLoad %float %326
+%801 = OpFunctionCall %ulong %2 %799 %800
+OpStore %327 %801
+%802 = OpLoad %float %546
+%803 = OpLoad %float %502
+%804 = OpFMul %float %802 %803
+OpStore %328 %804
+%805 = OpLoad %ulong %327
+%806 = OpLoad %float %328
+%807 = OpFunctionCall %ulong %2 %805 %806
+OpStore %329 %807
+%808 = OpLoad %float %546
+%809 = OpLoad %float %523
+%810 = OpFMul %float %808 %809
+OpStore %330 %810
+%811 = OpLoad %ulong %329
+%812 = OpLoad %float %330
+%813 = OpFunctionCall %ulong %2 %811 %812
+OpStore %331 %813
+%814 = OpLoad %float %546
+%815 = OpLoad %float %546
+%816 = OpFMul %float %814 %815
+OpStore %332 %816
+%817 = OpLoad %ulong %331
+%818 = OpLoad %float %332
+%819 = OpFunctionCall %ulong %2 %817 %818
+OpStore %333 %819
+%820 = OpLoad %float %534
+%821 = OpLoad %float %546
+%822 = OpFMul %float %820 %821
+OpStore %334 %822
+%823 = OpLoad %ulong %333
+%824 = OpLoad %float %334
+%825 = OpFunctionCall %ulong %2 %823 %824
+OpStore %335 %825
+%826 = OpLoad %float %534
+%827 = OpFNegate %float %826
+OpStore %336 %827
+%828 = OpLoad %ulong %335
+%829 = OpLoad %float %336
+%830 = OpFunctionCall %ulong %2 %828 %829
+OpStore %337 %830
+%831 = OpLoad %float %546
+%832 = OpFNegate %float %831
+OpStore %338 %832
+%833 = OpLoad %ulong %337
+%834 = OpLoad %float %338
+%835 = OpFunctionCall %ulong %2 %833 %834
+OpStore %339 %835
+%836 = OpLoad %float %534
+%837 = OpLoad %float %502
+%838 = OpFDiv %float %836 %837
+OpStore %340 %838
+%839 = OpLoad %ulong %339
+%840 = OpLoad %float %340
+%841 = OpFunctionCall %ulong %2 %839 %840
+OpStore %341 %841
+%842 = OpLoad %float %534
+%843 = OpLoad %float %523
+%844 = OpFDiv %float %842 %843
+OpStore %342 %844
+%845 = OpLoad %ulong %341
+%846 = OpLoad %float %342
+%847 = OpFunctionCall %ulong %2 %845 %846
+OpStore %343 %847
+%848 = OpLoad %float %546
+%849 = OpLoad %float %502
+%850 = OpFDiv %float %848 %849
+OpStore %344 %850
+%851 = OpLoad %ulong %343
+%852 = OpLoad %float %344
+%853 = OpFunctionCall %ulong %2 %851 %852
+OpStore %345 %853
+%854 = OpLoad %float %546
+%855 = OpLoad %float %523
+%856 = OpFDiv %float %854 %855
+OpStore %346 %856
+%857 = OpLoad %ulong %345
+%858 = OpLoad %float %346
+%859 = OpFunctionCall %ulong %2 %857 %858
+OpStore %347 %859
+%860 = OpLoad %float %534
+%861 = OpLoad %float %546
+%862 = OpFOrdEqual %bool %860 %861
+OpStore %348 %862
+OpBranch %239
+%239 = OpLabel
+%864 = OpLoad %bool %348
+%867 = OpSelect %uchar %864 %uchar_1 %uchar_0
+%868 = OpUConvert %ulong %867
+OpStore %628 %868
+OpBranch %241
+%241 = OpLabel
+%869 = OpLoad %ulong %347
+OpStore %636 %869
+OpStore %637 %ulong_0
+OpBranch %242
+%242 = OpLabel
+%870 = OpLoad %ulong %637
+%871 = OpULessThan %bool %870 %ulong_8
+OpStore %629 %871
+%872 = OpLoad %bool %629
+OpLoopMerge %244 %299 None
+OpBranchConditional %872 %243 %244
+%244 = OpLabel
+OpBranch %245
+%245 = OpLabel
+OpBranch %240
+%240 = OpLabel
+%873 = OpLoad %float %534
+%874 = OpLoad %float %546
+%875 = OpFOrdLessThan %bool %873 %874
+OpStore %349 %875
+OpBranch %246
+%246 = OpLabel
+%876 = OpLoad %bool %349
+%877 = OpSelect %uchar %876 %uchar_1 %uchar_0
+%878 = OpUConvert %ulong %877
+OpStore %638 %878
+OpBranch %248
+%248 = OpLabel
+%879 = OpLoad %ulong %636
+OpStore %646 %879
+OpStore %647 %ulong_0
+OpBranch %249
+%249 = OpLabel
+%880 = OpLoad %ulong %647
+%881 = OpULessThan %bool %880 %ulong_8
+OpStore %639 %881
+%882 = OpLoad %bool %639
+OpLoopMerge %251 %298 None
+OpBranchConditional %882 %250 %251
+%251 = OpLabel
+OpBranch %252
+%252 = OpLabel
+OpBranch %247
+%247 = OpLabel
+%883 = OpLoad %float %546
+%884 = OpLoad %float %534
+%885 = OpFOrdLessThan %bool %883 %884
+OpStore %350 %885
+OpBranch %253
+%253 = OpLabel
+%886 = OpLoad %bool %350
+%887 = OpSelect %uchar %886 %uchar_1 %uchar_0
+%888 = OpUConvert %ulong %887
+OpStore %648 %888
+OpBranch %255
+%255 = OpLabel
+%889 = OpLoad %ulong %646
+OpStore %656 %889
+OpStore %657 %ulong_0
+OpBranch %256
+%256 = OpLabel
+%890 = OpLoad %ulong %657
+%891 = OpULessThan %bool %890 %ulong_8
+OpStore %649 %891
+%892 = OpLoad %bool %649
+OpLoopMerge %258 %297 None
+OpBranchConditional %892 %257 %258
+%258 = OpLabel
+OpBranch %259
+%259 = OpLabel
+OpBranch %254
+%254 = OpLabel
+%893 = OpLoad %ulong %656
+%894 = OpLoad %float %558
+%895 = OpFunctionCall %ulong %2 %893 %894
+OpStore %351 %895
+%896 = OpLoad %ulong %351
+%897 = OpLoad %float %570
+%898 = OpFunctionCall %ulong %2 %896 %897
+OpStore %352 %898
+%899 = OpLoad %float %558
+%900 = OpFNegate %float %899
+OpStore %353 %900
+%901 = OpLoad %ulong %352
+%902 = OpLoad %float %353
+%903 = OpFunctionCall %ulong %2 %901 %902
+OpStore %354 %903
+%904 = OpLoad %float %502
+%905 = OpLoad %float %534
+%906 = OpFDiv %float %904 %905
+OpStore %355 %906
+%907 = OpLoad %ulong %354
+%908 = OpLoad %float %355
+%909 = OpFunctionCall %ulong %2 %907 %908
+OpStore %356 %909
+%910 = OpLoad %float %502
+%911 = OpLoad %float %546
+%912 = OpFDiv %float %910 %911
+OpStore %357 %912
+%913 = OpLoad %ulong %356
+%914 = OpLoad %float %357
+%915 = OpFunctionCall %ulong %2 %913 %914
+OpStore %358 %915
+%916 = OpLoad %float %523
+%917 = OpLoad %float %534
+%918 = OpFDiv %float %916 %917
+OpStore %359 %918
+%919 = OpLoad %ulong %358
+%920 = OpLoad %float %359
+%921 = OpFunctionCall %ulong %2 %919 %920
+OpStore %360 %921
+%922 = OpLoad %float %523
+%923 = OpLoad %float %546
+%924 = OpFDiv %float %922 %923
+OpStore %361 %924
+%925 = OpLoad %ulong %360
+%926 = OpLoad %float %361
+%927 = OpFunctionCall %ulong %2 %925 %926
+OpStore %362 %927
+%928 = OpLoad %float %558
+%929 = OpLoad %float %502
+%930 = OpFAdd %float %928 %929
+OpStore %363 %930
+%931 = OpLoad %ulong %362
+%932 = OpLoad %float %363
+%933 = OpFunctionCall %ulong %2 %931 %932
+OpStore %364 %933
+%934 = OpLoad %float %558
+%935 = OpLoad %float %558
+%936 = OpFAdd %float %934 %935
+OpStore %365 %936
+%937 = OpLoad %ulong %364
+%938 = OpLoad %float %365
+%939 = OpFunctionCall %ulong %2 %937 %938
+OpStore %366 %939
+%940 = OpLoad %float %558
+%941 = OpLoad %float %570
+%942 = OpFSub %float %940 %941
+OpStore %367 %942
+%943 = OpLoad %ulong %366
+%944 = OpLoad %float %367
+%945 = OpFunctionCall %ulong %2 %943 %944
+OpStore %368 %945
+%946 = OpLoad %float %558
+%947 = OpLoad %float %558
+%948 = OpFMul %float %946 %947
+OpStore %369 %948
+%949 = OpLoad %ulong %368
+%950 = OpLoad %float %369
+%951 = OpFunctionCall %ulong %2 %949 %950
+OpStore %370 %951
+%952 = OpLoad %float %558
+%953 = OpLoad %float %570
+%954 = OpFMul %float %952 %953
+OpStore %371 %954
+%955 = OpLoad %ulong %370
+%956 = OpLoad %float %371
+%957 = OpFunctionCall %ulong %2 %955 %956
+OpStore %372 %957
+%958 = OpLoad %float %558
+%959 = OpLoad %float %523
+%960 = OpFMul %float %958 %959
+OpStore %373 %960
+%961 = OpLoad %ulong %372
+%962 = OpLoad %float %373
+%963 = OpFunctionCall %ulong %2 %961 %962
+OpStore %374 %963
+%964 = OpLoad %float %502
+%965 = OpLoad %float %558
+%966 = OpFDiv %float %964 %965
+OpStore %375 %966
+%967 = OpLoad %ulong %374
+%968 = OpLoad %float %375
+%969 = OpFunctionCall %ulong %2 %967 %968
+OpStore %376 %969
+%970 = OpLoad %float %523
+%971 = OpLoad %float %558
+%972 = OpFDiv %float %970 %971
+OpStore %377 %972
+%973 = OpLoad %ulong %376
+%974 = OpLoad %float %377
+%975 = OpFunctionCall %ulong %2 %973 %974
+OpStore %378 %975
+%976 = OpLoad %float %502
+%977 = OpLoad %float %570
+%978 = OpFDiv %float %976 %977
+OpStore %379 %978
+%979 = OpLoad %ulong %378
+%980 = OpLoad %float %379
+%981 = OpFunctionCall %ulong %2 %979 %980
+OpStore %380 %981
+%982 = OpLoad %float %558
+%983 = OpLoad %float %502
+%984 = OpFDiv %float %982 %983
+OpStore %381 %984
+%985 = OpLoad %ulong %380
+%986 = OpLoad %float %381
+%987 = OpFunctionCall %ulong %2 %985 %986
+OpStore %382 %987
+%988 = OpLoad %float %594
+%989 = OpLoad %float %594
+%990 = OpFAdd %float %988 %989
+OpStore %383 %990
+%991 = OpLoad %ulong %382
+%992 = OpLoad %float %383
+%993 = OpFunctionCall %ulong %2 %991 %992
+OpStore %384 %993
+%994 = OpLoad %float %594
+%995 = OpLoad %float %558
+%996 = OpFOrdLessThan %bool %994 %995
+OpStore %385 %996
+OpBranch %260
+%260 = OpLabel
+%997 = OpLoad %bool %385
+%998 = OpSelect %uchar %997 %uchar_1 %uchar_0
+%999 = OpUConvert %ulong %998
+OpStore %658 %999
+%1000 = OpLoad %ulong %384
+%1001 = OpLoad %ulong %658
+%1002 = OpFunctionCall %ulong %4 %1000 %1001
+OpStore %659 %1002
+OpBranch %261
+%261 = OpLabel
+%1004 = OpLoad %float %594
+%1005 = OpFSub %float %float_0 %1004
+OpStore %386 %1005
+%1006 = OpLoad %float %570
+%1007 = OpLoad %float %386
+%1008 = OpFOrdLessThan %bool %1006 %1007
+OpStore %387 %1008
+OpBranch %262
+%262 = OpLabel
+%1009 = OpLoad %bool %387
+%1010 = OpSelect %uchar %1009 %uchar_1 %uchar_0
+%1011 = OpUConvert %ulong %1010
+OpStore %660 %1011
+%1012 = OpLoad %ulong %659
+%1013 = OpLoad %ulong %660
+%1014 = OpFunctionCall %ulong %4 %1012 %1013
+OpStore %661 %1014
+OpBranch %263
+%263 = OpLabel
+%1015 = OpLoad %float %558
+%1016 = OpLoad %float %558
+%1017 = OpFSub %float %1015 %1016
+OpStore %388 %1017
+%1018 = OpLoad %ulong %661
+%1019 = OpLoad %float %388
+%1020 = OpFunctionCall %ulong %2 %1018 %1019
+OpStore %389 %1020
+%1021 = OpLoad %float %570
+%1022 = OpLoad %float %558
+%1023 = OpFAdd %float %1021 %1022
+OpStore %390 %1023
+%1024 = OpLoad %ulong %389
+%1025 = OpLoad %float %390
+%1026 = OpFunctionCall %ulong %2 %1024 %1025
+OpStore %391 %1026
+%1027 = OpLoad %float %558
+%1028 = OpLoad %float %534
+%1029 = OpFMul %float %1027 %1028
+OpStore %392 %1029
+%1030 = OpLoad %ulong %391
+%1031 = OpLoad %float %392
+%1032 = OpFunctionCall %ulong %2 %1030 %1031
+OpStore %393 %1032
+%1033 = OpLoad %float %570
+%1034 = OpLoad %float %546
+%1035 = OpFMul %float %1033 %1034
+OpStore %394 %1035
+%1036 = OpLoad %ulong %393
+%1037 = OpLoad %float %394
+%1038 = OpFunctionCall %ulong %2 %1036 %1037
+OpStore %395 %1038
+%1039 = OpLoad %float %558
+%1040 = OpLoad %float %558
+%1041 = OpFDiv %float %1039 %1040
+OpStore %396 %1041
+%1042 = OpLoad %ulong %395
+%1043 = OpLoad %float %396
+%1044 = OpFunctionCall %ulong %2 %1042 %1043
+OpStore %397 %1044
+%1045 = OpLoad %float %534
+%1046 = OpLoad %float %534
+%1047 = OpFDiv %float %1045 %1046
+OpStore %398 %1047
+%1048 = OpLoad %ulong %397
+%1049 = OpLoad %float %398
+%1050 = OpFunctionCall %ulong %2 %1048 %1049
+OpStore %399 %1050
+%1051 = OpLoad %float %546
+%1052 = OpLoad %float %534
+%1053 = OpFDiv %float %1051 %1052
+OpStore %400 %1053
+%1054 = OpLoad %ulong %399
+%1055 = OpLoad %float %400
+%1056 = OpFunctionCall %ulong %2 %1054 %1055
+OpStore %401 %1056
+%1057 = OpLoad %float %582
+%1058 = OpBitcast %uint %1057
+OpStore %402 %1058
+OpBranch %264
+%264 = OpLabel
+%1059 = OpLoad %uint %402
+%1060 = OpUConvert %ulong %1059
+OpStore %662 %1060
+%1061 = OpLoad %ulong %401
+%1062 = OpLoad %ulong %662
+%1063 = OpFunctionCall %ulong %4 %1061 %1062
+OpStore %663 %1063
+OpBranch %265
+%265 = OpLabel
+%1064 = OpLoad %float %582
+%1065 = OpLoad %float %582
+%1066 = OpFUnordNotEqual %bool %1064 %1065
+OpStore %403 %1066
+OpBranch %266
+%266 = OpLabel
+%1067 = OpLoad %bool %403
+%1068 = OpSelect %uchar %1067 %uchar_1 %uchar_0
+%1069 = OpUConvert %ulong %1068
+OpStore %664 %1069
+%1070 = OpLoad %ulong %663
+%1071 = OpLoad %ulong %664
+%1072 = OpFunctionCall %ulong %4 %1070 %1071
+OpStore %665 %1072
+OpBranch %267
+%267 = OpLabel
+%1073 = OpLoad %float %582
+%1074 = OpLoad %float %582
+%1075 = OpFOrdEqual %bool %1073 %1074
+OpStore %404 %1075
+OpBranch %268
+%268 = OpLabel
+%1076 = OpLoad %bool %404
+%1077 = OpSelect %uchar %1076 %uchar_1 %uchar_0
+%1078 = OpUConvert %ulong %1077
+OpStore %666 %1078
+%1079 = OpLoad %ulong %665
+%1080 = OpLoad %ulong %666
+%1081 = OpFunctionCall %ulong %4 %1079 %1080
+OpStore %667 %1081
+OpBranch %269
+%269 = OpLabel
+%1082 = OpLoad %float %582
+%1083 = OpLoad %float %582
+%1084 = OpFOrdLessThan %bool %1082 %1083
+OpStore %405 %1084
+OpBranch %270
+%270 = OpLabel
+%1085 = OpLoad %bool %405
+%1086 = OpSelect %uchar %1085 %uchar_1 %uchar_0
+%1087 = OpUConvert %ulong %1086
+OpStore %668 %1087
+%1088 = OpLoad %ulong %667
+%1089 = OpLoad %ulong %668
+%1090 = OpFunctionCall %ulong %4 %1088 %1089
+OpStore %669 %1090
+OpBranch %271
+%271 = OpLabel
+%1091 = OpLoad %float %582
+%1092 = OpLoad %float %582
+%1093 = OpFOrdLessThanEqual %bool %1091 %1092
+OpStore %406 %1093
+OpBranch %272
+%272 = OpLabel
+%1094 = OpLoad %bool %406
+%1095 = OpSelect %uchar %1094 %uchar_1 %uchar_0
+%1096 = OpUConvert %ulong %1095
+OpStore %670 %1096
+%1097 = OpLoad %ulong %669
+%1098 = OpLoad %ulong %670
+%1099 = OpFunctionCall %ulong %4 %1097 %1098
+OpStore %671 %1099
+OpBranch %273
+%273 = OpLabel
+%1100 = OpLoad %float %582
+%1101 = OpFNegate %float %1100
+OpStore %407 %1101
+%1102 = OpLoad %float %407
+%1103 = OpBitcast %uint %1102
+OpStore %408 %1103
+OpBranch %274
+%274 = OpLabel
+%1104 = OpLoad %uint %408
+%1105 = OpUConvert %ulong %1104
+OpStore %672 %1105
+%1106 = OpLoad %ulong %671
+%1107 = OpLoad %ulong %672
+%1108 = OpFunctionCall %ulong %4 %1106 %1107
+OpStore %673 %1108
+OpBranch %275
+%275 = OpLabel
+%1109 = OpLoad %float %582
+%1110 = OpFNegate %float %1109
+OpStore %409 %1110
+%1111 = OpLoad %float %409
+%1112 = OpFNegate %float %1111
+OpStore %410 %1112
+%1113 = OpLoad %float %410
+%1114 = OpBitcast %uint %1113
+OpStore %411 %1114
+OpBranch %276
+%276 = OpLabel
+%1115 = OpLoad %uint %411
+%1116 = OpUConvert %ulong %1115
+OpStore %674 %1116
+%1117 = OpLoad %ulong %673
+%1118 = OpLoad %ulong %674
+%1119 = OpFunctionCall %ulong %4 %1117 %1118
+OpStore %675 %1119
+OpBranch %277
+%277 = OpLabel
+%1120 = OpLoad %float %582
+%1121 = OpLoad %float %502
+%1122 = OpFAdd %float %1120 %1121
+OpStore %412 %1122
+%1123 = OpLoad %ulong %675
+%1124 = OpLoad %float %412
+%1125 = OpFunctionCall %ulong %2 %1123 %1124
+OpStore %413 %1125
+%1126 = OpLoad %float %502
+%1127 = OpLoad %float %582
+%1128 = OpFAdd %float %1126 %1127
+OpStore %414 %1128
+%1129 = OpLoad %ulong %413
+%1130 = OpLoad %float %414
+%1131 = OpFunctionCall %ulong %2 %1129 %1130
+OpStore %415 %1131
+%1132 = OpLoad %float %582
+%1133 = OpLoad %float %534
+%1134 = OpFMul %float %1132 %1133
+OpStore %416 %1134
+%1135 = OpLoad %ulong %415
+%1136 = OpLoad %float %416
+%1137 = OpFunctionCall %ulong %2 %1135 %1136
+OpStore %417 %1137
+%1138 = OpLoad %float %582
+%1139 = OpLoad %float %582
+%1140 = OpFSub %float %1138 %1139
+OpStore %418 %1140
+%1141 = OpLoad %ulong %417
+%1142 = OpLoad %float %418
+%1143 = OpFunctionCall %ulong %2 %1141 %1142
+OpStore %419 %1143
+%1144 = OpLoad %float %582
+%1145 = OpLoad %float %582
+%1146 = OpFDiv %float %1144 %1145
+OpStore %420 %1146
+%1147 = OpLoad %ulong %419
+%1148 = OpLoad %float %420
+%1149 = OpFunctionCall %ulong %2 %1147 %1148
+OpStore %421 %1149
+%1150 = OpLoad %float %582
+%1151 = OpLoad %float %558
+%1152 = OpFDiv %float %1150 %1151
+OpStore %422 %1152
+%1153 = OpLoad %ulong %421
+%1154 = OpLoad %float %422
+%1155 = OpFunctionCall %ulong %2 %1153 %1154
+OpStore %423 %1155
+%1156 = OpLoad %ulong %423
+%1157 = OpLoad %float %627
+%1158 = OpFunctionCall %ulong %2 %1156 %1157
+OpStore %424 %1158
+%1159 = OpLoad %ulong %424
+%1160 = OpLoad %float %616
+%1161 = OpFunctionCall %ulong %2 %1159 %1160
+OpStore %425 %1161
+%1162 = OpLoad %ulong %425
+%1163 = OpLoad %float %605
+%1164 = OpFunctionCall %ulong %2 %1162 %1163
+OpStore %426 %1164
+%1165 = OpLoad %float %616
+%1166 = OpLoad %float %627
+%1167 = OpFAdd %float %1165 %1166
+OpStore %427 %1167
+%1168 = OpLoad %ulong %426
+%1169 = OpLoad %float %427
+%1170 = OpFunctionCall %ulong %2 %1168 %1169
+OpStore %428 %1170
+%1171 = OpLoad %float %605
+%1172 = OpLoad %float %627
+%1173 = OpFSub %float %1171 %1172
+OpStore %429 %1173
+%1174 = OpLoad %ulong %428
+%1175 = OpLoad %float %429
+%1176 = OpFunctionCall %ulong %2 %1174 %1175
+OpStore %430 %1176
+%1177 = OpLoad %float %627
+%1178 = OpLoad %float %627
+%1179 = OpFAdd %float %1177 %1178
+OpStore %431 %1179
+%1180 = OpLoad %ulong %430
+%1181 = OpLoad %float %431
+%1182 = OpFunctionCall %ulong %2 %1180 %1181
+OpStore %432 %1182
+%1183 = OpLoad %float %627
+%1185 = OpFMul %float %1183 %float_1_5
+OpStore %433 %1185
+%1186 = OpLoad %ulong %432
+%1187 = OpLoad %float %433
+%1188 = OpFunctionCall %ulong %2 %1186 %1187
+OpStore %434 %1188
+%1189 = OpLoad %float %627
+%1191 = OpFMul %float %1189 %float_0_5
+OpStore %435 %1191
+%1192 = OpLoad %ulong %434
+%1193 = OpLoad %float %435
+%1194 = OpFunctionCall %ulong %2 %1192 %1193
+OpStore %436 %1194
+%1195 = OpLoad %float %627
+%1196 = OpFNegate %float %1195
+OpStore %437 %1196
+%1197 = OpLoad %ulong %436
+%1198 = OpLoad %float %437
+%1199 = OpFunctionCall %ulong %2 %1197 %1198
+OpStore %438 %1199
+%1200 = OpLoad %float %627
+%1202 = OpFMul %float %1200 %float_8388608
+OpStore %439 %1202
+%1203 = OpLoad %ulong %438
+%1204 = OpLoad %float %439
+%1205 = OpFunctionCall %ulong %2 %1203 %1204
+OpStore %440 %1205
+%1206 = OpLoad %float %616
+%1207 = OpLoad %float %605
+%1208 = OpFDiv %float %1206 %1207
+OpStore %441 %1208
+%1209 = OpLoad %ulong %440
+%1210 = OpLoad %float %441
+%1211 = OpFunctionCall %ulong %2 %1209 %1210
+OpStore %442 %1211
+%1212 = OpLoad %float %534
+%1213 = OpLoad %float %627
+%1214 = OpFOrdLessThan %bool %1212 %1213
+OpStore %443 %1214
+OpBranch %278
+%278 = OpLabel
+%1215 = OpLoad %bool %443
+%1216 = OpSelect %uchar %1215 %uchar_1 %uchar_0
+%1217 = OpUConvert %ulong %1216
+OpStore %676 %1217
+%1218 = OpLoad %ulong %442
+%1219 = OpLoad %ulong %676
+%1220 = OpFunctionCall %ulong %4 %1218 %1219
+OpStore %677 %1220
+OpBranch %279
+%279 = OpLabel
+%1221 = OpLoad %float %627
+%1222 = OpLoad %float %534
+%1223 = OpFOrdEqual %bool %1221 %1222
+OpStore %444 %1223
+OpBranch %280
+%280 = OpLabel
+%1224 = OpLoad %bool %444
+%1225 = OpSelect %uchar %1224 %uchar_1 %uchar_0
+%1226 = OpUConvert %ulong %1225
+OpStore %678 %1226
+%1227 = OpLoad %ulong %677
+%1228 = OpLoad %ulong %678
+%1229 = OpFunctionCall %ulong %4 %1227 %1228
+OpStore %679 %1229
+OpBranch %281
+%281 = OpLabel
+%1230 = OpLoad %float %627
+%1231 = OpFSub %float %float_0 %1230
+OpStore %445 %1231
+%1232 = OpLoad %float %445
+%1233 = OpLoad %float %546
+%1234 = OpFOrdLessThan %bool %1232 %1233
+OpStore %446 %1234
+OpBranch %282
+%282 = OpLabel
+%1235 = OpLoad %bool %446
+%1236 = OpSelect %uchar %1235 %uchar_1 %uchar_0
+%1237 = OpUConvert %ulong %1236
+OpStore %680 %1237
+%1238 = OpLoad %ulong %679
+%1239 = OpLoad %ulong %680
+%1240 = OpFunctionCall %ulong %4 %1238 %1239
+OpStore %681 %1240
+OpBranch %283
+%283 = OpLabel
+%1241 = OpLoad %ulong %681
+OpStore %495 %1241
+%1242 = OpLoad %float %605
+OpStore %496 %1242
+OpStore %497 %uint_0
+OpBranch %132
+%132 = OpLabel
+%1244 = OpLoad %uint %497
+%1246 = OpULessThan %bool %1244 %uint_30
+OpStore %447 %1246
+%1247 = OpLoad %bool %447
+OpLoopMerge %134 %296 None
+OpBranchConditional %1247 %133 %134
+%134 = OpLabel
+OpStore %303 %1248
+%1249 = OpAccessChain %_ptr_Function_uint %303 %uint_0
+OpStore %1249 %uint_0
+%1250 = OpAccessChain %_ptr_Function_uint %303 %uint_1
+OpStore %1250 %uint_2147483648
+%1252 = OpAccessChain %_ptr_Function_uint %303 %uint_2
+OpStore %1252 %uint_1
+%1254 = OpAccessChain %_ptr_Function_uint %303 %uint_3
+OpStore %1254 %uint_2139095040
+%1256 = OpAccessChain %_ptr_Function_uint %303 %uint_4
+OpStore %1256 %uint_4286578688
+%1258 = OpAccessChain %_ptr_Function_uint %303 %uint_5
+OpStore %1258 %uint_2143289344
+%1260 = OpAccessChain %_ptr_Function_uint %303 %uint_6
+OpStore %1260 %uint_4290829997
+%1263 = OpAccessChain %_ptr_Function_uint %303 %uint_7
+OpStore %1263 %uint_2139095041
+%1265 = OpLoad %ulong %495
+OpStore %494 %1265
+OpStore %498 %uint_0
+OpBranch %135
+%135 = OpLabel
+%1266 = OpLoad %uint %498
+%1267 = OpULessThan %bool %1266 %uint_8
+OpStore %451 %1267
+%1268 = OpLoad %bool %451
+OpLoopMerge %137 %295 None
+OpBranchConditional %1268 %136 %137
+%137 = OpLabel
+%1270 = OpLoad %uint %305
+%1271 = OpIAdd %uint %uint_16777216 %1270
+OpStore %457 %1271
+%1273 = OpLoad %uint %305
+%1274 = OpIAdd %uint %uint_16777217 %1273
+OpStore %458 %1274
+%1276 = OpLoad %uint %305
+%1277 = OpIAdd %uint %uint_16777219 %1276
+OpStore %459 %1277
+%1279 = OpLoad %uint %305
+%1280 = OpIAdd %uint %uint_4294967295 %1279
+OpStore %460 %1280
+%1282 = OpLoad %uint %305
+%1283 = OpIAdd %uint %uint_4278190079 %1282
+OpStore %461 %1283
+%1284 = OpLoad %uint %305
+%1285 = OpIAdd %uint %uint_2147483648 %1284
+OpStore %462 %1285
+%1286 = OpLoad %uint %457
+%1287 = OpConvertUToF %float %1286
+OpStore %463 %1287
+%1288 = OpLoad %ulong %494
+%1289 = OpLoad %float %463
+%1290 = OpFunctionCall %ulong %2 %1288 %1289
+OpStore %464 %1290
+%1291 = OpLoad %uint %458
+%1292 = OpConvertUToF %float %1291
+OpStore %465 %1292
+%1293 = OpLoad %ulong %464
+%1294 = OpLoad %float %465
+%1295 = OpFunctionCall %ulong %2 %1293 %1294
+OpStore %466 %1295
+%1296 = OpLoad %uint %459
+%1297 = OpConvertUToF %float %1296
+OpStore %467 %1297
+%1298 = OpLoad %ulong %466
+%1299 = OpLoad %float %467
+%1300 = OpFunctionCall %ulong %2 %1298 %1299
+OpStore %468 %1300
+%1301 = OpLoad %uint %460
+%1302 = OpConvertUToF %float %1301
+OpStore %469 %1302
+%1303 = OpLoad %ulong %468
+%1304 = OpLoad %float %469
+%1305 = OpFunctionCall %ulong %2 %1303 %1304
+OpStore %470 %1305
+%1306 = OpLoad %uint %305
+%1307 = OpConvertUToF %float %1306
+OpStore %471 %1307
+%1308 = OpLoad %ulong %470
+%1309 = OpLoad %float %471
+%1310 = OpFunctionCall %ulong %2 %1308 %1309
+OpStore %472 %1310
+%1311 = OpLoad %uint %461
+%1312 = OpConvertSToF %float %1311
+OpStore %473 %1312
+%1313 = OpLoad %ulong %472
+%1314 = OpLoad %float %473
+%1315 = OpFunctionCall %ulong %2 %1313 %1314
+OpStore %474 %1315
+%1316 = OpLoad %uint %462
+%1317 = OpConvertSToF %float %1316
+OpStore %475 %1317
+%1318 = OpLoad %ulong %474
+%1319 = OpLoad %float %475
+%1320 = OpFunctionCall %ulong %2 %1318 %1319
+OpStore %476 %1320
+%1321 = OpLoad %float %502
+%1322 = OpFMul %float %float_1_5 %1321
+OpStore %477 %1322
+%1324 = OpLoad %float %502
+%1325 = OpFMul %float %float_16777216 %1324
+OpStore %478 %1325
+%1327 = OpLoad %float %502
+%1328 = OpFMul %float %float_2_14748352e_09 %1327
+OpStore %479 %1328
+%1329 = OpLoad %float %477
+%1330 = OpFSub %float %float_0 %1329
+OpStore %480 %1330
+%1331 = OpLoad %float %502
+%1332 = OpFMul %float %float_0_5 %1331
+OpStore %481 %1332
+%1333 = OpLoad %float %477
+%1334 = OpConvertFToU %uint %1333
+OpStore %482 %1334
+OpBranch %142
+%142 = OpLabel
+%1335 = OpLoad %uint %482
+%1336 = OpUConvert %ulong %1335
+OpStore %500 %1336
+OpBranch %151
+%151 = OpLabel
+%1337 = OpLoad %ulong %476
+OpStore %519 %1337
+OpStore %520 %ulong_0
+OpBranch %152
+%152 = OpLabel
+%1338 = OpLoad %ulong %520
+%1339 = OpULessThan %bool %1338 %ulong_8
+OpStore %512 %1339
+%1340 = OpLoad %bool %512
+OpLoopMerge %154 %294 None
+OpBranchConditional %1340 %153 %154
+%154 = OpLabel
+OpBranch %155
+%155 = OpLabel
+OpBranch %143
+%143 = OpLabel
+%1341 = OpLoad %float %478
+%1342 = OpConvertFToU %uint %1341
+OpStore %483 %1342
+OpBranch %156
+%156 = OpLabel
+%1343 = OpLoad %uint %483
+%1344 = OpUConvert %ulong %1343
+OpStore %521 %1344
+OpBranch %160
+%160 = OpLabel
+%1345 = OpLoad %ulong %519
+OpStore %531 %1345
+OpStore %532 %ulong_0
+OpBranch %161
+%161 = OpLabel
+%1346 = OpLoad %ulong %532
+%1347 = OpULessThan %bool %1346 %ulong_8
+OpStore %524 %1347
+%1348 = OpLoad %bool %524
+OpLoopMerge %163 %292 None
+OpBranchConditional %1348 %162 %163
+%163 = OpLabel
+OpBranch %164
+%164 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%1349 = OpLoad %float %479
+%1350 = OpConvertFToU %uint %1349
+OpStore %484 %1350
+OpBranch %165
+%165 = OpLabel
+%1351 = OpLoad %uint %484
+%1352 = OpUConvert %ulong %1351
+OpStore %533 %1352
+OpBranch %169
 %169 = OpLabel
-OpBranch %60
+%1353 = OpLoad %ulong %531
+OpStore %542 %1353
+OpStore %543 %ulong_0
+OpBranch %170
+%170 = OpLabel
+%1354 = OpLoad %ulong %543
+%1355 = OpULessThan %bool %1354 %ulong_8
+OpStore %535 %1355
+%1356 = OpLoad %bool %535
+OpLoopMerge %172 %291 None
+OpBranchConditional %1356 %171 %172
+%172 = OpLabel
+OpBranch %173
+%173 = OpLabel
+OpBranch %166
+%166 = OpLabel
+%1357 = OpLoad %float %481
+%1358 = OpConvertFToU %uint %1357
+OpStore %485 %1358
+OpBranch %174
+%174 = OpLabel
+%1359 = OpLoad %uint %485
+%1360 = OpUConvert %ulong %1359
+OpStore %544 %1360
+OpBranch %178
+%178 = OpLabel
+%1361 = OpLoad %ulong %542
+OpStore %554 %1361
+OpStore %555 %ulong_0
+OpBranch %179
+%179 = OpLabel
+%1362 = OpLoad %ulong %555
+%1363 = OpULessThan %bool %1362 %ulong_8
+OpStore %547 %1363
+%1364 = OpLoad %bool %547
+OpLoopMerge %181 %290 None
+OpBranchConditional %1364 %180 %181
+%181 = OpLabel
+OpBranch %182
+%182 = OpLabel
+OpBranch %175
+%175 = OpLabel
+%1365 = OpLoad %float %534
+%1366 = OpConvertFToU %uint %1365
+OpStore %486 %1366
+OpBranch %183
+%183 = OpLabel
+%1367 = OpLoad %uint %486
+%1368 = OpUConvert %ulong %1367
+OpStore %556 %1368
+OpBranch %187
+%187 = OpLabel
+%1369 = OpLoad %ulong %554
+OpStore %566 %1369
+OpStore %567 %ulong_0
+OpBranch %188
+%188 = OpLabel
+%1370 = OpLoad %ulong %567
+%1371 = OpULessThan %bool %1370 %ulong_8
+OpStore %559 %1371
+%1372 = OpLoad %bool %559
+OpLoopMerge %190 %289 None
+OpBranchConditional %1372 %189 %190
+%190 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %184
+%184 = OpLabel
+%1373 = OpLoad %float %480
+%1374 = OpConvertFToS %uint %1373
+OpStore %487 %1374
+OpBranch %192
+%192 = OpLabel
+%1375 = OpLoad %uint %487
+%1376 = OpSConvert %ulong %1375
+OpStore %568 %1376
+OpBranch %196
+%196 = OpLabel
+%1377 = OpLoad %ulong %566
+OpStore %578 %1377
+OpStore %579 %ulong_0
+OpBranch %197
+%197 = OpLabel
+%1378 = OpLoad %ulong %579
+%1379 = OpULessThan %bool %1378 %ulong_8
+OpStore %571 %1379
+%1380 = OpLoad %bool %571
+OpLoopMerge %199 %288 None
+OpBranchConditional %1380 %198 %199
+%199 = OpLabel
+OpBranch %200
+%200 = OpLabel
+OpBranch %193
+%193 = OpLabel
+%1381 = OpLoad %float %479
+%1382 = OpConvertFToS %uint %1381
+OpStore %488 %1382
+OpBranch %201
+%201 = OpLabel
+%1383 = OpLoad %uint %488
+%1384 = OpSConvert %ulong %1383
+OpStore %580 %1384
+OpBranch %205
+%205 = OpLabel
+%1385 = OpLoad %ulong %578
+OpStore %590 %1385
+OpStore %591 %ulong_0
+OpBranch %206
+%206 = OpLabel
+%1386 = OpLoad %ulong %591
+%1387 = OpULessThan %bool %1386 %ulong_8
+OpStore %583 %1387
+%1388 = OpLoad %bool %583
+OpLoopMerge %208 %287 None
+OpBranchConditional %1388 %207 %208
+%208 = OpLabel
+OpBranch %209
+%209 = OpLabel
+OpBranch %202
+%202 = OpLabel
+%1389 = OpLoad %float %481
+%1390 = OpFSub %float %float_0 %1389
+OpStore %489 %1390
+%1391 = OpLoad %float %489
+%1392 = OpConvertFToS %uint %1391
+OpStore %490 %1392
+OpBranch %210
+%210 = OpLabel
+%1393 = OpLoad %uint %490
+%1394 = OpSConvert %ulong %1393
+OpStore %592 %1394
+OpBranch %214
+%214 = OpLabel
+%1395 = OpLoad %ulong %590
+OpStore %602 %1395
+OpStore %603 %ulong_0
+OpBranch %215
+%215 = OpLabel
+%1396 = OpLoad %ulong %603
+%1397 = OpULessThan %bool %1396 %ulong_8
+OpStore %595 %1397
+%1398 = OpLoad %bool %595
+OpLoopMerge %217 %286 None
+OpBranchConditional %1398 %216 %217
+%217 = OpLabel
+OpBranch %218
+%218 = OpLabel
+OpBranch %211
+%211 = OpLabel
+%1399 = OpLoad %float %480
+%1400 = OpConvertFToS %ulong %1399
+OpStore %491 %1400
+OpBranch %219
+%219 = OpLabel
+OpBranch %223
+%223 = OpLabel
+%1401 = OpLoad %ulong %602
+OpStore %613 %1401
+OpStore %614 %ulong_0
+OpBranch %224
+%224 = OpLabel
+%1402 = OpLoad %ulong %614
+%1403 = OpULessThan %bool %1402 %ulong_8
+OpStore %606 %1403
+%1404 = OpLoad %bool %606
+OpLoopMerge %226 %285 None
+OpBranchConditional %1404 %225 %226
+%226 = OpLabel
+OpBranch %227
+%227 = OpLabel
+OpBranch %220
+%220 = OpLabel
+%1405 = OpLoad %float %478
+%1406 = OpFSub %float %float_0 %1405
+OpStore %492 %1406
+%1407 = OpLoad %float %492
+%1408 = OpConvertFToS %ulong %1407
+OpStore %493 %1408
+OpBranch %228
+%228 = OpLabel
+OpBranch %232
+%232 = OpLabel
+%1409 = OpLoad %ulong %613
+OpStore %624 %1409
+OpStore %625 %ulong_0
+OpBranch %233
+%233 = OpLabel
+%1410 = OpLoad %ulong %625
+%1411 = OpULessThan %bool %1410 %ulong_8
+OpStore %617 %1411
+%1412 = OpLoad %bool %617
+OpLoopMerge %235 %284 None
+OpBranchConditional %1412 %234 %235
+%235 = OpLabel
+OpBranch %236
+%236 = OpLabel
+OpBranch %229
+%229 = OpLabel
+%1413 = OpLoad %ulong %624
+OpReturnValue %1413
+%234 = OpLabel
+%1414 = OpLoad %ulong %625
+%1415 = OpIMul %ulong %1414 %ulong_8
+OpStore %618 %1415
+%1416 = OpLoad %ulong %493
+%1417 = OpLoad %ulong %618
+%1418 = OpShiftRightLogical %ulong %1416 %1417
+OpStore %619 %1418
+%1419 = OpLoad %ulong %619
+%1420 = OpBitwiseAnd %ulong %1419 %ulong_255
+OpStore %620 %1420
+%1421 = OpLoad %ulong %624
+%1422 = OpLoad %ulong %620
+%1423 = OpBitwiseXor %ulong %1421 %1422
+OpStore %621 %1423
+%1424 = OpLoad %ulong %621
+%1425 = OpIMul %ulong %1424 %ulong_1099511628211
+OpStore %622 %1425
+%1426 = OpLoad %ulong %625
+%1427 = OpIAdd %ulong %1426 %ulong_1
+OpStore %623 %1427
+%1428 = OpLoad %ulong %622
+OpStore %624 %1428
+%1429 = OpLoad %ulong %623
+OpStore %625 %1429
+OpBranch %284
+%225 = OpLabel
+%1430 = OpLoad %ulong %614
+%1431 = OpIMul %ulong %1430 %ulong_8
+OpStore %607 %1431
+%1432 = OpLoad %ulong %491
+%1433 = OpLoad %ulong %607
+%1434 = OpShiftRightLogical %ulong %1432 %1433
+OpStore %608 %1434
+%1435 = OpLoad %ulong %608
+%1436 = OpBitwiseAnd %ulong %1435 %ulong_255
+OpStore %609 %1436
+%1437 = OpLoad %ulong %613
+%1438 = OpLoad %ulong %609
+%1439 = OpBitwiseXor %ulong %1437 %1438
+OpStore %610 %1439
+%1440 = OpLoad %ulong %610
+%1441 = OpIMul %ulong %1440 %ulong_1099511628211
+OpStore %611 %1441
+%1442 = OpLoad %ulong %614
+%1443 = OpIAdd %ulong %1442 %ulong_1
+OpStore %612 %1443
+%1444 = OpLoad %ulong %611
+OpStore %613 %1444
+%1445 = OpLoad %ulong %612
+OpStore %614 %1445
+OpBranch %285
+%216 = OpLabel
+%1446 = OpLoad %ulong %603
+%1447 = OpIMul %ulong %1446 %ulong_8
+OpStore %596 %1447
+%1448 = OpLoad %ulong %592
+%1449 = OpLoad %ulong %596
+%1450 = OpShiftRightLogical %ulong %1448 %1449
+OpStore %597 %1450
+%1451 = OpLoad %ulong %597
+%1452 = OpBitwiseAnd %ulong %1451 %ulong_255
+OpStore %598 %1452
+%1453 = OpLoad %ulong %602
+%1454 = OpLoad %ulong %598
+%1455 = OpBitwiseXor %ulong %1453 %1454
+OpStore %599 %1455
+%1456 = OpLoad %ulong %599
+%1457 = OpIMul %ulong %1456 %ulong_1099511628211
+OpStore %600 %1457
+%1458 = OpLoad %ulong %603
+%1459 = OpIAdd %ulong %1458 %ulong_1
+OpStore %601 %1459
+%1460 = OpLoad %ulong %600
+OpStore %602 %1460
+%1461 = OpLoad %ulong %601
+OpStore %603 %1461
+OpBranch %286
+%207 = OpLabel
+%1462 = OpLoad %ulong %591
+%1463 = OpIMul %ulong %1462 %ulong_8
+OpStore %584 %1463
+%1464 = OpLoad %ulong %580
+%1465 = OpLoad %ulong %584
+%1466 = OpShiftRightLogical %ulong %1464 %1465
+OpStore %585 %1466
+%1467 = OpLoad %ulong %585
+%1468 = OpBitwiseAnd %ulong %1467 %ulong_255
+OpStore %586 %1468
+%1469 = OpLoad %ulong %590
+%1470 = OpLoad %ulong %586
+%1471 = OpBitwiseXor %ulong %1469 %1470
+OpStore %587 %1471
+%1472 = OpLoad %ulong %587
+%1473 = OpIMul %ulong %1472 %ulong_1099511628211
+OpStore %588 %1473
+%1474 = OpLoad %ulong %591
+%1475 = OpIAdd %ulong %1474 %ulong_1
+OpStore %589 %1475
+%1476 = OpLoad %ulong %588
+OpStore %590 %1476
+%1477 = OpLoad %ulong %589
+OpStore %591 %1477
+OpBranch %287
+%198 = OpLabel
+%1478 = OpLoad %ulong %579
+%1479 = OpIMul %ulong %1478 %ulong_8
+OpStore %572 %1479
+%1480 = OpLoad %ulong %568
+%1481 = OpLoad %ulong %572
+%1482 = OpShiftRightLogical %ulong %1480 %1481
+OpStore %573 %1482
+%1483 = OpLoad %ulong %573
+%1484 = OpBitwiseAnd %ulong %1483 %ulong_255
+OpStore %574 %1484
+%1485 = OpLoad %ulong %578
+%1486 = OpLoad %ulong %574
+%1487 = OpBitwiseXor %ulong %1485 %1486
+OpStore %575 %1487
+%1488 = OpLoad %ulong %575
+%1489 = OpIMul %ulong %1488 %ulong_1099511628211
+OpStore %576 %1489
+%1490 = OpLoad %ulong %579
+%1491 = OpIAdd %ulong %1490 %ulong_1
+OpStore %577 %1491
+%1492 = OpLoad %ulong %576
+OpStore %578 %1492
+%1493 = OpLoad %ulong %577
+OpStore %579 %1493
+OpBranch %288
+%189 = OpLabel
+%1494 = OpLoad %ulong %567
+%1495 = OpIMul %ulong %1494 %ulong_8
+OpStore %560 %1495
+%1496 = OpLoad %ulong %556
+%1497 = OpLoad %ulong %560
+%1498 = OpShiftRightLogical %ulong %1496 %1497
+OpStore %561 %1498
+%1499 = OpLoad %ulong %561
+%1500 = OpBitwiseAnd %ulong %1499 %ulong_255
+OpStore %562 %1500
+%1501 = OpLoad %ulong %566
+%1502 = OpLoad %ulong %562
+%1503 = OpBitwiseXor %ulong %1501 %1502
+OpStore %563 %1503
+%1504 = OpLoad %ulong %563
+%1505 = OpIMul %ulong %1504 %ulong_1099511628211
+OpStore %564 %1505
+%1506 = OpLoad %ulong %567
+%1507 = OpIAdd %ulong %1506 %ulong_1
+OpStore %565 %1507
+%1508 = OpLoad %ulong %564
+OpStore %566 %1508
+%1509 = OpLoad %ulong %565
+OpStore %567 %1509
+OpBranch %289
+%180 = OpLabel
+%1510 = OpLoad %ulong %555
+%1511 = OpIMul %ulong %1510 %ulong_8
+OpStore %548 %1511
+%1512 = OpLoad %ulong %544
+%1513 = OpLoad %ulong %548
+%1514 = OpShiftRightLogical %ulong %1512 %1513
+OpStore %549 %1514
+%1515 = OpLoad %ulong %549
+%1516 = OpBitwiseAnd %ulong %1515 %ulong_255
+OpStore %550 %1516
+%1517 = OpLoad %ulong %554
+%1518 = OpLoad %ulong %550
+%1519 = OpBitwiseXor %ulong %1517 %1518
+OpStore %551 %1519
+%1520 = OpLoad %ulong %551
+%1521 = OpIMul %ulong %1520 %ulong_1099511628211
+OpStore %552 %1521
+%1522 = OpLoad %ulong %555
+%1523 = OpIAdd %ulong %1522 %ulong_1
+OpStore %553 %1523
+%1524 = OpLoad %ulong %552
+OpStore %554 %1524
+%1525 = OpLoad %ulong %553
+OpStore %555 %1525
+OpBranch %290
+%171 = OpLabel
+%1526 = OpLoad %ulong %543
+%1527 = OpIMul %ulong %1526 %ulong_8
+OpStore %536 %1527
+%1528 = OpLoad %ulong %533
+%1529 = OpLoad %ulong %536
+%1530 = OpShiftRightLogical %ulong %1528 %1529
+OpStore %537 %1530
+%1531 = OpLoad %ulong %537
+%1532 = OpBitwiseAnd %ulong %1531 %ulong_255
+OpStore %538 %1532
+%1533 = OpLoad %ulong %542
+%1534 = OpLoad %ulong %538
+%1535 = OpBitwiseXor %ulong %1533 %1534
+OpStore %539 %1535
+%1536 = OpLoad %ulong %539
+%1537 = OpIMul %ulong %1536 %ulong_1099511628211
+OpStore %540 %1537
+%1538 = OpLoad %ulong %543
+%1539 = OpIAdd %ulong %1538 %ulong_1
+OpStore %541 %1539
+%1540 = OpLoad %ulong %540
+OpStore %542 %1540
+%1541 = OpLoad %ulong %541
+OpStore %543 %1541
+OpBranch %291
+%162 = OpLabel
+%1542 = OpLoad %ulong %532
+%1543 = OpIMul %ulong %1542 %ulong_8
+OpStore %525 %1543
+%1544 = OpLoad %ulong %521
+%1545 = OpLoad %ulong %525
+%1546 = OpShiftRightLogical %ulong %1544 %1545
+OpStore %526 %1546
+%1547 = OpLoad %ulong %526
+%1548 = OpBitwiseAnd %ulong %1547 %ulong_255
+OpStore %527 %1548
+%1549 = OpLoad %ulong %531
+%1550 = OpLoad %ulong %527
+%1551 = OpBitwiseXor %ulong %1549 %1550
+OpStore %528 %1551
+%1552 = OpLoad %ulong %528
+%1553 = OpIMul %ulong %1552 %ulong_1099511628211
+OpStore %529 %1553
+%1554 = OpLoad %ulong %532
+%1555 = OpIAdd %ulong %1554 %ulong_1
+OpStore %530 %1555
+%1556 = OpLoad %ulong %529
+OpStore %531 %1556
+%1557 = OpLoad %ulong %530
+OpStore %532 %1557
+OpBranch %292
+%153 = OpLabel
+%1558 = OpLoad %ulong %520
+%1559 = OpIMul %ulong %1558 %ulong_8
+OpStore %513 %1559
+%1560 = OpLoad %ulong %500
+%1561 = OpLoad %ulong %513
+%1562 = OpShiftRightLogical %ulong %1560 %1561
+OpStore %514 %1562
+%1563 = OpLoad %ulong %514
+%1564 = OpBitwiseAnd %ulong %1563 %ulong_255
+OpStore %515 %1564
+%1565 = OpLoad %ulong %519
+%1566 = OpLoad %ulong %515
+%1567 = OpBitwiseXor %ulong %1565 %1566
+OpStore %516 %1567
+%1568 = OpLoad %ulong %516
+%1569 = OpIMul %ulong %1568 %ulong_1099511628211
+OpStore %517 %1569
+%1570 = OpLoad %ulong %520
+%1571 = OpIAdd %ulong %1570 %ulong_1
+OpStore %518 %1571
+%1572 = OpLoad %ulong %517
+OpStore %519 %1572
+%1573 = OpLoad %ulong %518
+OpStore %520 %1573
+OpBranch %294
+%136 = OpLabel
+%1574 = OpLoad %uint %498
+%1575 = OpAccessChain %_ptr_Function_uint %303 %1574
+%1576 = OpLoad %uint %1575
+OpStore %452 %1576
+%1577 = OpLoad %uint %452
+%1578 = OpLoad %uint %305
+%1579 = OpIAdd %uint %1577 %1578
+OpStore %453 %1579
+%1580 = OpLoad %uint %453
+%1581 = OpBitcast %float %1580
+OpStore %454 %1581
+%1582 = OpLoad %float %454
+%1583 = OpBitcast %uint %1582
+OpStore %455 %1583
+OpBranch %140
+%140 = OpLabel
+%1584 = OpLoad %uint %455
+%1585 = OpUConvert %ulong %1584
+OpStore %499 %1585
+OpBranch %146
+%146 = OpLabel
+%1586 = OpLoad %ulong %494
+OpStore %510 %1586
+OpStore %511 %ulong_0
+OpBranch %147
+%147 = OpLabel
+%1587 = OpLoad %ulong %511
+%1588 = OpULessThan %bool %1587 %ulong_8
+OpStore %503 %1588
+%1589 = OpLoad %bool %503
+OpLoopMerge %149 %293 None
+OpBranchConditional %1589 %148 %149
+%149 = OpLabel
+OpBranch %150
+%150 = OpLabel
+OpBranch %141
+%141 = OpLabel
+%1590 = OpLoad %uint %498
+%1591 = OpIAdd %uint %1590 %uint_1
+OpStore %456 %1591
+%1592 = OpLoad %ulong %510
+OpStore %494 %1592
+%1593 = OpLoad %uint %456
+OpStore %498 %1593
+OpBranch %295
+%148 = OpLabel
+%1594 = OpLoad %ulong %511
+%1595 = OpIMul %ulong %1594 %ulong_8
+OpStore %504 %1595
+%1596 = OpLoad %ulong %499
+%1597 = OpLoad %ulong %504
+%1598 = OpShiftRightLogical %ulong %1596 %1597
+OpStore %505 %1598
+%1599 = OpLoad %ulong %505
+%1600 = OpBitwiseAnd %ulong %1599 %ulong_255
+OpStore %506 %1600
+%1601 = OpLoad %ulong %510
+%1602 = OpLoad %ulong %506
+%1603 = OpBitwiseXor %ulong %1601 %1602
+OpStore %507 %1603
+%1604 = OpLoad %ulong %507
+%1605 = OpIMul %ulong %1604 %ulong_1099511628211
+OpStore %508 %1605
+%1606 = OpLoad %ulong %511
+%1607 = OpIAdd %ulong %1606 %ulong_1
+OpStore %509 %1607
+%1608 = OpLoad %ulong %508
+OpStore %510 %1608
+%1609 = OpLoad %ulong %509
+OpStore %511 %1609
+OpBranch %293
+%133 = OpLabel
+%1610 = OpLoad %float %496
+%1611 = OpFMul %float %1610 %float_0_5
+OpStore %448 %1611
+%1612 = OpLoad %ulong %495
+%1613 = OpLoad %float %448
+%1614 = OpFunctionCall %ulong %2 %1612 %1613
+OpStore %449 %1614
+%1615 = OpLoad %uint %497
+%1616 = OpIAdd %uint %1615 %uint_1
+OpStore %450 %1616
+%1617 = OpLoad %ulong %449
+OpStore %495 %1617
+%1618 = OpLoad %float %448
+OpStore %496 %1618
+%1619 = OpLoad %uint %450
+OpStore %497 %1619
+OpBranch %296
+%257 = OpLabel
+%1620 = OpLoad %ulong %657
+%1621 = OpIMul %ulong %1620 %ulong_8
+OpStore %650 %1621
+%1622 = OpLoad %ulong %648
+%1623 = OpLoad %ulong %650
+%1624 = OpShiftRightLogical %ulong %1622 %1623
+OpStore %651 %1624
+%1625 = OpLoad %ulong %651
+%1626 = OpBitwiseAnd %ulong %1625 %ulong_255
+OpStore %652 %1626
+%1627 = OpLoad %ulong %656
+%1628 = OpLoad %ulong %652
+%1629 = OpBitwiseXor %ulong %1627 %1628
+OpStore %653 %1629
+%1630 = OpLoad %ulong %653
+%1631 = OpIMul %ulong %1630 %ulong_1099511628211
+OpStore %654 %1631
+%1632 = OpLoad %ulong %657
+%1633 = OpIAdd %ulong %1632 %ulong_1
+OpStore %655 %1633
+%1634 = OpLoad %ulong %654
+OpStore %656 %1634
+%1635 = OpLoad %ulong %655
+OpStore %657 %1635
+OpBranch %297
+%250 = OpLabel
+%1636 = OpLoad %ulong %647
+%1637 = OpIMul %ulong %1636 %ulong_8
+OpStore %640 %1637
+%1638 = OpLoad %ulong %638
+%1639 = OpLoad %ulong %640
+%1640 = OpShiftRightLogical %ulong %1638 %1639
+OpStore %641 %1640
+%1641 = OpLoad %ulong %641
+%1642 = OpBitwiseAnd %ulong %1641 %ulong_255
+OpStore %642 %1642
+%1643 = OpLoad %ulong %646
+%1644 = OpLoad %ulong %642
+%1645 = OpBitwiseXor %ulong %1643 %1644
+OpStore %643 %1645
+%1646 = OpLoad %ulong %643
+%1647 = OpIMul %ulong %1646 %ulong_1099511628211
+OpStore %644 %1647
+%1648 = OpLoad %ulong %647
+%1649 = OpIAdd %ulong %1648 %ulong_1
+OpStore %645 %1649
+%1650 = OpLoad %ulong %644
+OpStore %646 %1650
+%1651 = OpLoad %ulong %645
+OpStore %647 %1651
+OpBranch %298
+%243 = OpLabel
+%1652 = OpLoad %ulong %637
+%1653 = OpIMul %ulong %1652 %ulong_8
+OpStore %630 %1653
+%1654 = OpLoad %ulong %628
+%1655 = OpLoad %ulong %630
+%1656 = OpShiftRightLogical %ulong %1654 %1655
+OpStore %631 %1656
+%1657 = OpLoad %ulong %631
+%1658 = OpBitwiseAnd %ulong %1657 %ulong_255
+OpStore %632 %1658
+%1659 = OpLoad %ulong %636
+%1660 = OpLoad %ulong %632
+%1661 = OpBitwiseXor %ulong %1659 %1660
+OpStore %633 %1661
+%1662 = OpLoad %ulong %633
+%1663 = OpIMul %ulong %1662 %ulong_1099511628211
+OpStore %634 %1663
+%1664 = OpLoad %ulong %637
+%1665 = OpIAdd %ulong %1664 %ulong_1
+OpStore %635 %1665
+%1666 = OpLoad %ulong %634
+OpStore %636 %1666
+%1667 = OpLoad %ulong %635
+OpStore %637 %1667
+OpBranch %299
+%284 = OpLabel
+OpBranch %233
+%285 = OpLabel
+OpBranch %224
+%286 = OpLabel
+OpBranch %215
+%287 = OpLabel
+OpBranch %206
+%288 = OpLabel
+OpBranch %197
+%289 = OpLabel
+OpBranch %188
+%290 = OpLabel
+OpBranch %179
+%291 = OpLabel
+OpBranch %170
+%292 = OpLabel
+OpBranch %161
+%293 = OpLabel
+OpBranch %147
+%294 = OpLabel
+OpBranch %152
+%295 = OpLabel
+OpBranch %135
+%296 = OpLabel
+OpBranch %132
+%297 = OpLabel
+OpBranch %256
+%298 = OpLabel
+OpBranch %249
+%299 = OpLabel
+OpBranch %242
 OpFunctionEnd
-%4 = OpFunction %ulong None %1290
-%1291 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %1293
-%1294 = OpFunctionParameter %ulong
-%1295 = OpFunctionParameter %uchar
-%1296 = OpLabel
-%1303 = OpVariable %_ptr_Function_ulong Function
-%1305 = OpVariable %_ptr_Function_uchar Function
-%1306 = OpVariable %_ptr_Function_ulong Function
-%1307 = OpVariable %_ptr_Function_bool Function
-%1308 = OpVariable %_ptr_Function_ulong Function
-%1309 = OpVariable %_ptr_Function_ulong Function
-%1310 = OpVariable %_ptr_Function_ulong Function
-%1311 = OpVariable %_ptr_Function_ulong Function
-%1312 = OpVariable %_ptr_Function_ulong Function
-%1313 = OpVariable %_ptr_Function_ulong Function
-%1314 = OpVariable %_ptr_Function_ulong Function
-%1315 = OpVariable %_ptr_Function_ulong Function
-OpStore %1303 %1294
-OpStore %1305 %1295
-%1316 = OpLoad %uchar %1305
-%1317 = OpUConvert %ulong %1316
-OpStore %1306 %1317
-OpBranch %1297
-%1297 = OpLabel
-%1318 = OpLoad %ulong %1303
-OpStore %1314 %1318
-OpStore %1315 %ulong_0
-OpBranch %1298
-%1298 = OpLabel
-%1320 = OpLoad %ulong %1315
-%1322 = OpULessThan %bool %1320 %ulong_8
-OpStore %1307 %1322
-%1323 = OpLoad %bool %1307
-OpLoopMerge %1300 %1302 None
-OpBranchConditional %1323 %1299 %1300
-%1300 = OpLabel
-OpBranch %1301
-%1301 = OpLabel
-%1324 = OpLoad %ulong %1314
-OpReturnValue %1324
-%1299 = OpLabel
-%1325 = OpLoad %ulong %1315
-%1326 = OpIMul %ulong %1325 %ulong_8
-OpStore %1308 %1326
-%1327 = OpLoad %ulong %1306
-%1328 = OpLoad %ulong %1308
-%1329 = OpShiftRightLogical %ulong %1327 %1328
-OpStore %1309 %1329
-%1330 = OpLoad %ulong %1309
-%1332 = OpBitwiseAnd %ulong %1330 %ulong_255
-OpStore %1310 %1332
-%1333 = OpLoad %ulong %1314
-%1334 = OpLoad %ulong %1310
-%1335 = OpBitwiseXor %ulong %1333 %1334
-OpStore %1311 %1335
-%1336 = OpLoad %ulong %1311
-%1338 = OpIMul %ulong %1336 %ulong_1099511628211
-OpStore %1312 %1338
-%1339 = OpLoad %ulong %1315
-%1341 = OpIAdd %ulong %1339 %ulong_1
-OpStore %1313 %1341
-%1342 = OpLoad %ulong %1312
-OpStore %1314 %1342
-%1343 = OpLoad %ulong %1313
-OpStore %1315 %1343
-OpBranch %1302
-%1302 = OpLabel
-OpBranch %1298
-OpFunctionEnd
-%6 = OpFunction %ulong None %1344
-%1345 = OpFunctionParameter %ulong
-%1346 = OpFunctionParameter %uint
-%1347 = OpLabel
-%1354 = OpVariable %_ptr_Function_ulong Function
-%1355 = OpVariable %_ptr_Function_uint Function
-%1356 = OpVariable %_ptr_Function_ulong Function
-%1357 = OpVariable %_ptr_Function_bool Function
-%1358 = OpVariable %_ptr_Function_ulong Function
-%1359 = OpVariable %_ptr_Function_ulong Function
-%1360 = OpVariable %_ptr_Function_ulong Function
-%1361 = OpVariable %_ptr_Function_ulong Function
-%1362 = OpVariable %_ptr_Function_ulong Function
-%1363 = OpVariable %_ptr_Function_ulong Function
-%1364 = OpVariable %_ptr_Function_ulong Function
-%1365 = OpVariable %_ptr_Function_ulong Function
-OpStore %1354 %1345
-OpStore %1355 %1346
-%1366 = OpLoad %uint %1355
-%1367 = OpUConvert %ulong %1366
-OpStore %1356 %1367
-OpBranch %1348
-%1348 = OpLabel
-%1368 = OpLoad %ulong %1354
-OpStore %1364 %1368
-OpStore %1365 %ulong_0
-OpBranch %1349
-%1349 = OpLabel
-%1369 = OpLoad %ulong %1365
-%1370 = OpULessThan %bool %1369 %ulong_8
-OpStore %1357 %1370
-%1371 = OpLoad %bool %1357
-OpLoopMerge %1351 %1353 None
-OpBranchConditional %1371 %1350 %1351
-%1351 = OpLabel
-OpBranch %1352
-%1352 = OpLabel
-%1372 = OpLoad %ulong %1364
-OpReturnValue %1372
-%1350 = OpLabel
-%1373 = OpLoad %ulong %1365
-%1374 = OpIMul %ulong %1373 %ulong_8
-OpStore %1358 %1374
-%1375 = OpLoad %ulong %1356
-%1376 = OpLoad %ulong %1358
-%1377 = OpShiftRightLogical %ulong %1375 %1376
-OpStore %1359 %1377
-%1378 = OpLoad %ulong %1359
-%1379 = OpBitwiseAnd %ulong %1378 %ulong_255
-OpStore %1360 %1379
-%1380 = OpLoad %ulong %1364
-%1381 = OpLoad %ulong %1360
-%1382 = OpBitwiseXor %ulong %1380 %1381
-OpStore %1361 %1382
-%1383 = OpLoad %ulong %1361
-%1384 = OpIMul %ulong %1383 %ulong_1099511628211
-OpStore %1362 %1384
-%1385 = OpLoad %ulong %1365
-%1386 = OpIAdd %ulong %1385 %ulong_1
-OpStore %1363 %1386
-%1387 = OpLoad %ulong %1362
-OpStore %1364 %1387
-%1388 = OpLoad %ulong %1363
-OpStore %1365 %1388
-OpBranch %1353
-%1353 = OpLabel
-OpBranch %1349
-OpFunctionEnd
-%7 = OpFunction %ulong None %1344
-%1389 = OpFunctionParameter %ulong
-%1390 = OpFunctionParameter %uint
-%1391 = OpLabel
-%1398 = OpVariable %_ptr_Function_ulong Function
-%1399 = OpVariable %_ptr_Function_uint Function
-%1400 = OpVariable %_ptr_Function_ulong Function
-%1401 = OpVariable %_ptr_Function_bool Function
-%1402 = OpVariable %_ptr_Function_ulong Function
-%1403 = OpVariable %_ptr_Function_ulong Function
-%1404 = OpVariable %_ptr_Function_ulong Function
-%1405 = OpVariable %_ptr_Function_ulong Function
-%1406 = OpVariable %_ptr_Function_ulong Function
-%1407 = OpVariable %_ptr_Function_ulong Function
-%1408 = OpVariable %_ptr_Function_ulong Function
-%1409 = OpVariable %_ptr_Function_ulong Function
-OpStore %1398 %1389
-OpStore %1399 %1390
-%1410 = OpLoad %uint %1399
-%1411 = OpSConvert %ulong %1410
-OpStore %1400 %1411
-OpBranch %1392
-%1392 = OpLabel
-%1412 = OpLoad %ulong %1398
-OpStore %1408 %1412
-OpStore %1409 %ulong_0
-OpBranch %1393
-%1393 = OpLabel
-%1413 = OpLoad %ulong %1409
-%1414 = OpULessThan %bool %1413 %ulong_8
-OpStore %1401 %1414
-%1415 = OpLoad %bool %1401
-OpLoopMerge %1395 %1397 None
-OpBranchConditional %1415 %1394 %1395
-%1395 = OpLabel
-OpBranch %1396
-%1396 = OpLabel
-%1416 = OpLoad %ulong %1408
-OpReturnValue %1416
-%1394 = OpLabel
-%1417 = OpLoad %ulong %1409
-%1418 = OpIMul %ulong %1417 %ulong_8
-OpStore %1402 %1418
-%1419 = OpLoad %ulong %1400
-%1420 = OpLoad %ulong %1402
-%1421 = OpShiftRightLogical %ulong %1419 %1420
-OpStore %1403 %1421
-%1422 = OpLoad %ulong %1403
-%1423 = OpBitwiseAnd %ulong %1422 %ulong_255
-OpStore %1404 %1423
-%1424 = OpLoad %ulong %1408
-%1425 = OpLoad %ulong %1404
-%1426 = OpBitwiseXor %ulong %1424 %1425
-OpStore %1405 %1426
-%1427 = OpLoad %ulong %1405
-%1428 = OpIMul %ulong %1427 %ulong_1099511628211
-OpStore %1406 %1428
-%1429 = OpLoad %ulong %1409
-%1430 = OpIAdd %ulong %1429 %ulong_1
-OpStore %1407 %1430
-%1431 = OpLoad %ulong %1406
-OpStore %1408 %1431
-%1432 = OpLoad %ulong %1407
-OpStore %1409 %1432
-OpBranch %1397
-%1397 = OpLabel
-OpBranch %1393
-OpFunctionEnd
-%8 = OpFunction %ulong None %1433
-%1434 = OpFunctionParameter %ulong
-%1435 = OpFunctionParameter %ulong
-%1436 = OpLabel
-%1443 = OpVariable %_ptr_Function_ulong Function
-%1444 = OpVariable %_ptr_Function_ulong Function
-%1445 = OpVariable %_ptr_Function_bool Function
-%1446 = OpVariable %_ptr_Function_ulong Function
-%1447 = OpVariable %_ptr_Function_ulong Function
-%1448 = OpVariable %_ptr_Function_ulong Function
-%1449 = OpVariable %_ptr_Function_ulong Function
-%1450 = OpVariable %_ptr_Function_ulong Function
-%1451 = OpVariable %_ptr_Function_ulong Function
-%1452 = OpVariable %_ptr_Function_ulong Function
-%1453 = OpVariable %_ptr_Function_ulong Function
-OpStore %1443 %1434
-OpStore %1444 %1435
-OpBranch %1437
-%1437 = OpLabel
-%1454 = OpLoad %ulong %1443
-OpStore %1452 %1454
-OpStore %1453 %ulong_0
-OpBranch %1438
-%1438 = OpLabel
-%1455 = OpLoad %ulong %1453
-%1456 = OpULessThan %bool %1455 %ulong_8
-OpStore %1445 %1456
-%1457 = OpLoad %bool %1445
-OpLoopMerge %1440 %1442 None
-OpBranchConditional %1457 %1439 %1440
-%1440 = OpLabel
-OpBranch %1441
-%1441 = OpLabel
-%1458 = OpLoad %ulong %1452
-OpReturnValue %1458
-%1439 = OpLabel
-%1459 = OpLoad %ulong %1453
-%1460 = OpIMul %ulong %1459 %ulong_8
-OpStore %1446 %1460
-%1461 = OpLoad %ulong %1444
-%1462 = OpLoad %ulong %1446
-%1463 = OpShiftRightLogical %ulong %1461 %1462
-OpStore %1447 %1463
-%1464 = OpLoad %ulong %1447
-%1465 = OpBitwiseAnd %ulong %1464 %ulong_255
-OpStore %1448 %1465
-%1466 = OpLoad %ulong %1452
-%1467 = OpLoad %ulong %1448
-%1468 = OpBitwiseXor %ulong %1466 %1467
-OpStore %1449 %1468
-%1469 = OpLoad %ulong %1449
-%1470 = OpIMul %ulong %1469 %ulong_1099511628211
-OpStore %1450 %1470
-%1471 = OpLoad %ulong %1453
-%1472 = OpIAdd %ulong %1471 %ulong_1
-OpStore %1451 %1472
-%1473 = OpLoad %ulong %1450
-OpStore %1452 %1473
-%1474 = OpLoad %ulong %1451
-OpStore %1453 %1474
-OpBranch %1442
-%1442 = OpLabel
-OpBranch %1438
-OpFunctionEnd
-%9 = OpFunction %ulong None %29
-%1475 = OpFunctionParameter %ulong
-%1476 = OpFunctionParameter %float
-%1477 = OpLabel
-%1484 = OpVariable %_ptr_Function_ulong Function
-%1485 = OpVariable %_ptr_Function_float Function
-%1486 = OpVariable %_ptr_Function_uint Function
-%1487 = OpVariable %_ptr_Function_ulong Function
-%1488 = OpVariable %_ptr_Function_bool Function
-%1489 = OpVariable %_ptr_Function_ulong Function
-%1490 = OpVariable %_ptr_Function_ulong Function
-%1491 = OpVariable %_ptr_Function_ulong Function
-%1492 = OpVariable %_ptr_Function_ulong Function
-%1493 = OpVariable %_ptr_Function_ulong Function
-%1494 = OpVariable %_ptr_Function_ulong Function
-%1495 = OpVariable %_ptr_Function_ulong Function
-%1496 = OpVariable %_ptr_Function_ulong Function
-OpStore %1484 %1475
-OpStore %1485 %1476
-%1497 = OpLoad %float %1485
-%1498 = OpBitcast %uint %1497
-OpStore %1486 %1498
-%1499 = OpLoad %uint %1486
-%1500 = OpUConvert %ulong %1499
-OpStore %1487 %1500
-OpBranch %1478
-%1478 = OpLabel
-%1501 = OpLoad %ulong %1484
-OpStore %1495 %1501
-OpStore %1496 %ulong_0
-OpBranch %1479
-%1479 = OpLabel
-%1502 = OpLoad %ulong %1496
-%1503 = OpULessThan %bool %1502 %ulong_8
-OpStore %1488 %1503
-%1504 = OpLoad %bool %1488
-OpLoopMerge %1481 %1483 None
-OpBranchConditional %1504 %1480 %1481
-%1481 = OpLabel
-OpBranch %1482
-%1482 = OpLabel
-%1505 = OpLoad %ulong %1495
-OpReturnValue %1505
-%1480 = OpLabel
-%1506 = OpLoad %ulong %1496
-%1507 = OpIMul %ulong %1506 %ulong_8
-OpStore %1489 %1507
-%1508 = OpLoad %ulong %1487
-%1509 = OpLoad %ulong %1489
-%1510 = OpShiftRightLogical %ulong %1508 %1509
-OpStore %1490 %1510
-%1511 = OpLoad %ulong %1490
-%1512 = OpBitwiseAnd %ulong %1511 %ulong_255
-OpStore %1491 %1512
-%1513 = OpLoad %ulong %1495
-%1514 = OpLoad %ulong %1491
-%1515 = OpBitwiseXor %ulong %1513 %1514
-OpStore %1492 %1515
-%1516 = OpLoad %ulong %1492
-%1517 = OpIMul %ulong %1516 %ulong_1099511628211
-OpStore %1493 %1517
-%1518 = OpLoad %ulong %1496
-%1519 = OpIAdd %ulong %1518 %ulong_1
-OpStore %1494 %1519
-%1520 = OpLoad %ulong %1493
-OpStore %1495 %1520
-%1521 = OpLoad %ulong %1494
-OpStore %1496 %1521
-OpBranch %1483
-%1483 = OpLabel
-OpBranch %1479
+%4 = OpFunction %ulong None %1668
+%1669 = OpFunctionParameter %ulong
+%1670 = OpFunctionParameter %ulong
+%1671 = OpLabel
+%1676 = OpVariable %_ptr_Function_ulong Function
+%1677 = OpVariable %_ptr_Function_ulong Function
+%1678 = OpVariable %_ptr_Function_bool Function
+%1679 = OpVariable %_ptr_Function_ulong Function
+%1680 = OpVariable %_ptr_Function_ulong Function
+%1681 = OpVariable %_ptr_Function_ulong Function
+%1682 = OpVariable %_ptr_Function_ulong Function
+%1683 = OpVariable %_ptr_Function_ulong Function
+%1684 = OpVariable %_ptr_Function_ulong Function
+%1685 = OpVariable %_ptr_Function_ulong Function
+%1686 = OpVariable %_ptr_Function_ulong Function
+OpStore %1676 %1669
+OpStore %1677 %1670
+%1687 = OpLoad %ulong %1676
+OpStore %1685 %1687
+OpStore %1686 %ulong_0
+OpBranch %1672
+%1672 = OpLabel
+%1688 = OpLoad %ulong %1686
+%1689 = OpULessThan %bool %1688 %ulong_8
+OpStore %1678 %1689
+%1690 = OpLoad %bool %1678
+OpLoopMerge %1674 %1675 None
+OpBranchConditional %1690 %1673 %1674
+%1674 = OpLabel
+%1691 = OpLoad %ulong %1685
+OpReturnValue %1691
+%1673 = OpLabel
+%1692 = OpLoad %ulong %1686
+%1693 = OpIMul %ulong %1692 %ulong_8
+OpStore %1679 %1693
+%1694 = OpLoad %ulong %1677
+%1695 = OpLoad %ulong %1679
+%1696 = OpShiftRightLogical %ulong %1694 %1695
+OpStore %1680 %1696
+%1697 = OpLoad %ulong %1680
+%1698 = OpBitwiseAnd %ulong %1697 %ulong_255
+OpStore %1681 %1698
+%1699 = OpLoad %ulong %1685
+%1700 = OpLoad %ulong %1681
+%1701 = OpBitwiseXor %ulong %1699 %1700
+OpStore %1682 %1701
+%1702 = OpLoad %ulong %1682
+%1703 = OpIMul %ulong %1702 %ulong_1099511628211
+OpStore %1683 %1703
+%1704 = OpLoad %ulong %1686
+%1705 = OpIAdd %ulong %1704 %ulong_1
+OpStore %1684 %1705
+%1706 = OpLoad %ulong %1683
+OpStore %1685 %1706
+%1707 = OpLoad %ulong %1684
+OpStore %1686 %1707
+OpBranch %1675
+%1675 = OpLabel
+OpBranch %1672
 OpFunctionEnd

--- a/test/golden/spirv/float/special_f64.dis
+++ b/test/golden/spirv/float/special_f64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1701
+; Bound: 1800
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,14 +14,19 @@ OpDecorate %2 LinkageAttributes "corpus.cases.float.special_f64.fold64" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f64.checksum" Export
 %double = OpTypeFloat 64
 %ulong = OpTypeInt 64 0
-%14 = OpTypeFunction %double %ulong %ulong
+%7 = OpTypeFunction %double %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_double = OpTypePointer Function %double
-%30 = OpTypeFunction %ulong %ulong %double
+%23 = OpTypeFunction %ulong %ulong %double
 %bool = OpTypeBool
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%57 = OpTypeFunction %ulong %ulong
+%122 = OpTypeFunction %ulong %ulong
 %float = OpTypeFloat 32
 %uint = OpTypeInt 32 0
 %uint_8 = OpConstant %uint 8
@@ -38,7 +43,7 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f64.checksum" Export
 %ulong_9218868437227405311 = OpConstant %ulong 9218868437227405311
 %ulong_4503599627370496 = OpConstant %ulong 4503599627370496
 %ulong_4503599627370495 = OpConstant %ulong 4503599627370495
-%ulong_1 = OpConstant %ulong 1
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar = OpTypeInt 8 0
 %uchar_1 = OpConstant %uchar 1
 %uchar_0 = OpConstant %uchar 0
@@ -46,9 +51,8 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f64.checksum" Export
 %double_1_5 = OpConstant %double 1.5
 %double_0_5 = OpConstant %double 0.5
 %double_4503599627370496 = OpConstant %double 4503599627370496
-%ulong_0 = OpConstant %ulong 0
 %ulong_60 = OpConstant %ulong 60
-%1068 = OpConstantNull %_arr_ulong_uint_8
+%1261 = OpConstantNull %_arr_ulong_uint_8
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
@@ -59,7 +63,6 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f64.checksum" Export
 %ulong_18444492273908506285 = OpConstant %ulong 18444492273908506285
 %uint_7 = OpConstant %uint 7
 %ulong_9218868437227405313 = OpConstant %ulong 9218868437227405313
-%ulong_8 = OpConstant %ulong 8
 %ulong_3936146074321813504 = OpConstant %ulong 3936146074321813504
 %ulong_4607182419068452864 = OpConstant %ulong 4607182419068452864
 %ulong_4607182419605323776 = OpConstant %ulong 4607182419605323776
@@ -69,2304 +72,2452 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.special_f64.checksum" Export
 %ulong_18437736874454810623 = OpConstant %ulong 18437736874454810623
 %double_9007199254740992 = OpConstant %double 9007199254740992
 %double_4_6116860184273879e_18 = OpConstant %double 4.6116860184273879e+18
-%1388 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1391 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1433 = OpTypeFunction %ulong %ulong %uchar
-%_ptr_Function_uchar = OpTypePointer Function %uchar
-%1479 = OpTypeFunction %ulong %ulong %uint
-%1609 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %double None %14
-%15 = OpFunctionParameter %ulong
-%16 = OpFunctionParameter %ulong
-%17 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_double Function
-OpStore %19 %15
-OpStore %20 %16
-%24 = OpLoad %ulong %19
-%25 = OpLoad %ulong %20
-%26 = OpIAdd %ulong %24 %25
-OpStore %21 %26
-%27 = OpLoad %ulong %21
-%28 = OpBitcast %double %27
-OpStore %23 %28
-%29 = OpLoad %double %23
-OpReturnValue %29
+%1760 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %double None %7
+%8 = OpFunctionParameter %ulong
+%9 = OpFunctionParameter %ulong
+%10 = OpLabel
+%12 = OpVariable %_ptr_Function_ulong Function
+%13 = OpVariable %_ptr_Function_ulong Function
+%14 = OpVariable %_ptr_Function_ulong Function
+%16 = OpVariable %_ptr_Function_double Function
+OpStore %12 %8
+OpStore %13 %9
+%17 = OpLoad %ulong %12
+%18 = OpLoad %ulong %13
+%19 = OpIAdd %ulong %17 %18
+OpStore %14 %19
+%20 = OpLoad %ulong %14
+%21 = OpBitcast %double %20
+OpStore %16 %21
+%22 = OpLoad %double %16
+OpReturnValue %22
 OpFunctionEnd
-%2 = OpFunction %ulong None %30
-%31 = OpFunctionParameter %ulong
-%32 = OpFunctionParameter %double
-%33 = OpLabel
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_double Function
-%42 = OpVariable %_ptr_Function_bool Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-OpStore %39 %31
-OpStore %40 %32
-%45 = OpLoad %double %40
-%46 = OpLoad %double %40
-%47 = OpFUnordNotEqual %bool %45 %46
-OpStore %42 %47
-%48 = OpLoad %bool %42
-OpSelectionMerge %37 None
-OpBranchConditional %48 %34 %35
+%2 = OpFunction %ulong None %23
+%24 = OpFunctionParameter %ulong
+%25 = OpFunctionParameter %double
+%26 = OpLabel
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_double Function
+%49 = OpVariable %_ptr_Function_bool Function
+%50 = OpVariable %_ptr_Function_bool Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_bool Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+OpStore %46 %24
+OpStore %47 %25
+%69 = OpLoad %double %47
+%70 = OpLoad %double %47
+%71 = OpFUnordNotEqual %bool %69 %70
+OpStore %49 %71
+%72 = OpLoad %bool %49
+OpSelectionMerge %44 None
+OpBranchConditional %72 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+OpBranch %35
 %35 = OpLabel
+%73 = OpLoad %double %47
+%74 = OpBitcast %ulong %73
+OpStore %59 %74
+OpBranch %37
+%37 = OpLabel
+%75 = OpLoad %ulong %46
+OpStore %67 %75
+OpStore %68 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%77 = OpLoad %ulong %68
+%79 = OpULessThan %bool %77 %ulong_8
+OpStore %60 %79
+%80 = OpLoad %bool %60
+OpLoopMerge %40 %42 None
+OpBranchConditional %80 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
 OpBranch %36
 %36 = OpLabel
-%49 = OpLoad %ulong %39
-%50 = OpLoad %double %40
-%51 = OpFunctionCall %ulong %11 %49 %50
-OpStore %44 %51
-%52 = OpLoad %ulong %44
-OpReturnValue %52
+%81 = OpLoad %ulong %67
+OpReturnValue %81
+%39 = OpLabel
+%82 = OpLoad %ulong %68
+%83 = OpIMul %ulong %82 %ulong_8
+OpStore %61 %83
+%84 = OpLoad %ulong %59
+%85 = OpLoad %ulong %61
+%86 = OpShiftRightLogical %ulong %84 %85
+OpStore %62 %86
+%87 = OpLoad %ulong %62
+%89 = OpBitwiseAnd %ulong %87 %ulong_255
+OpStore %63 %89
+%90 = OpLoad %ulong %67
+%91 = OpLoad %ulong %63
+%92 = OpBitwiseXor %ulong %90 %91
+OpStore %64 %92
+%93 = OpLoad %ulong %64
+%95 = OpIMul %ulong %93 %ulong_1099511628211
+OpStore %65 %95
+%96 = OpLoad %ulong %68
+%98 = OpIAdd %ulong %96 %ulong_1
+OpStore %66 %98
+%99 = OpLoad %ulong %65
+OpStore %67 %99
+%100 = OpLoad %ulong %66
+OpStore %68 %100
+OpBranch %42
+%27 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%101 = OpLoad %ulong %46
+OpStore %57 %101
+OpStore %58 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%102 = OpLoad %ulong %58
+%103 = OpULessThan %bool %102 %ulong_8
+OpStore %50 %103
+%104 = OpLoad %bool %50
+OpLoopMerge %33 %43 None
+OpBranchConditional %104 %32 %33
+%33 = OpLabel
+OpBranch %34
 %34 = OpLabel
-%53 = OpLoad %ulong %39
-%55 = OpFunctionCall %ulong %5 %53 %ulong_18446744073709551615
-OpStore %43 %55
-%56 = OpLoad %ulong %43
-OpReturnValue %56
-%37 = OpLabel
+%105 = OpLoad %ulong %57
+OpReturnValue %105
+%32 = OpLabel
+%106 = OpLoad %ulong %58
+%107 = OpIMul %ulong %106 %ulong_8
+OpStore %51 %107
+%109 = OpLoad %ulong %51
+%110 = OpShiftRightLogical %ulong %ulong_18446744073709551615 %109
+OpStore %52 %110
+%111 = OpLoad %ulong %52
+%112 = OpBitwiseAnd %ulong %111 %ulong_255
+OpStore %53 %112
+%113 = OpLoad %ulong %57
+%114 = OpLoad %ulong %53
+%115 = OpBitwiseXor %ulong %113 %114
+OpStore %54 %115
+%116 = OpLoad %ulong %54
+%117 = OpIMul %ulong %116 %ulong_1099511628211
+OpStore %55 %117
+%118 = OpLoad %ulong %58
+%119 = OpIAdd %ulong %118 %ulong_1
+OpStore %56 %119
+%120 = OpLoad %ulong %55
+OpStore %57 %120
+%121 = OpLoad %ulong %56
+OpStore %58 %121
+OpBranch %43
+%42 = OpLabel
+OpBranch %38
+%43 = OpLabel
+OpBranch %31
+%44 = OpLabel
 OpUnreachable
 OpFunctionEnd
-%3 = OpFunction %ulong None %57
-%58 = OpFunctionParameter %ulong
-%59 = OpLabel
-%181 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_double Function
-%185 = OpVariable %_ptr_Function_double Function
-%186 = OpVariable %_ptr_Function_double Function
-%187 = OpVariable %_ptr_Function_double Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_double Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_double Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_double Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_double Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_double Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_double Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_double Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_double Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_double Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_double Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_double Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_double Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_double Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_double Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_double Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_double Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_bool Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_bool Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_bool Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_double Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_double Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_double Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_double Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_double Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_double Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_double Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_double Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_double Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_double Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_double Function
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_double Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_double Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_double Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_double Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_double Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_bool Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_double Function
-%264 = OpVariable %_ptr_Function_bool Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_double Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_double Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_double Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_double Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_double Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_double Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_double Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_bool Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_bool Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_bool Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_bool Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_double Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_double Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_double Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_double Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_double Function
+%3 = OpFunction %ulong None %122
+%123 = OpFunctionParameter %ulong
+%124 = OpLabel
+%300 = OpVariable %_ptr_Function__arr_ulong_uint_8 Function
 %301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_double Function
+%302 = OpVariable %_ptr_Function_ulong Function
 %303 = OpVariable %_ptr_Function_ulong Function
 %304 = OpVariable %_ptr_Function_double Function
 %305 = OpVariable %_ptr_Function_ulong Function
 %306 = OpVariable %_ptr_Function_double Function
 %307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_double Function
 %309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_double Function
-%312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_double Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_double Function
-%316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_double Function
-%318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_double Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_double Function
-%322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_double Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_double Function
-%326 = OpVariable %_ptr_Function_ulong Function
-%327 = OpVariable %_ptr_Function_bool Function
-%328 = OpVariable %_ptr_Function_ulong Function
-%329 = OpVariable %_ptr_Function_bool Function
-%330 = OpVariable %_ptr_Function_ulong Function
-%331 = OpVariable %_ptr_Function_double Function
-%332 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_double Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_double Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_double Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_double Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_double Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_double Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_double Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_double Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_double Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_double Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_double Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_double Function
 %333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_bool Function
-%335 = OpVariable %_ptr_Function_double Function
-%336 = OpVariable %_ptr_Function_ulong Function
-%337 = OpVariable %_ptr_Function_bool Function
-%338 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_double Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_double Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_double Function
 %339 = OpVariable %_ptr_Function_ulong Function
 %340 = OpVariable %_ptr_Function_double Function
 %341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_double Function
 %343 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_float Function
-%346 = OpVariable %_ptr_Function_float Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_float Function
-%351 = OpVariable %_ptr_Function_float Function
+%344 = OpVariable %_ptr_Function_bool Function
+%345 = OpVariable %_ptr_Function_bool Function
+%346 = OpVariable %_ptr_Function_bool Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_double Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_double Function
 %352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_double Function
 %354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_double Function
 %356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_double Function
 %358 = OpVariable %_ptr_Function_ulong Function
 %359 = OpVariable %_ptr_Function_double Function
-%360 = OpVariable %_ptr_Function_double Function
+%360 = OpVariable %_ptr_Function_ulong Function
 %361 = OpVariable %_ptr_Function_double Function
 %362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_double Function
 %364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_double Function
 %366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_ulong Function
-%368 = OpVariable %_ptr_Function_double Function
+%367 = OpVariable %_ptr_Function_double Function
+%368 = OpVariable %_ptr_Function_ulong Function
 %369 = OpVariable %_ptr_Function_double Function
-%370 = OpVariable %_ptr_Function_double Function
+%370 = OpVariable %_ptr_Function_ulong Function
 %371 = OpVariable %_ptr_Function_double Function
-%372 = OpVariable %_ptr_Function_double Function
+%372 = OpVariable %_ptr_Function_ulong Function
 %373 = OpVariable %_ptr_Function_double Function
-%374 = OpVariable %_ptr_Function_double Function
+%374 = OpVariable %_ptr_Function_ulong Function
 %375 = OpVariable %_ptr_Function_double Function
-%376 = OpVariable %_ptr_Function_double Function
+%376 = OpVariable %_ptr_Function_ulong Function
 %377 = OpVariable %_ptr_Function_double Function
-%378 = OpVariable %_ptr_Function_double Function
+%378 = OpVariable %_ptr_Function_ulong Function
 %379 = OpVariable %_ptr_Function_double Function
 %380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_ulong Function
-%384 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_bool Function
+%382 = OpVariable %_ptr_Function_double Function
+%383 = OpVariable %_ptr_Function_bool Function
+%384 = OpVariable %_ptr_Function_double Function
 %385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_double Function
 %387 = OpVariable %_ptr_Function_ulong Function
-%388 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_double Function
 %389 = OpVariable %_ptr_Function_ulong Function
-%390 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_double Function
 %391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_double Function
 %393 = OpVariable %_ptr_Function_ulong Function
 %394 = OpVariable %_ptr_Function_double Function
 %395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_uint Function
+%396 = OpVariable %_ptr_Function_double Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
 %399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_uint Function
-%401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_bool Function
+%401 = OpVariable %_ptr_Function_bool Function
+%402 = OpVariable %_ptr_Function_bool Function
+%403 = OpVariable %_ptr_Function_bool Function
 %404 = OpVariable %_ptr_Function_double Function
 %405 = OpVariable %_ptr_Function_ulong Function
 %406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_double Function
-%409 = OpVariable %_ptr_Function_bool Function
-%410 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_double Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_double Function
 %411 = OpVariable %_ptr_Function_ulong Function
-%412 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_double Function
 %413 = OpVariable %_ptr_Function_ulong Function
 %414 = OpVariable %_ptr_Function_double Function
 %415 = OpVariable %_ptr_Function_ulong Function
 %416 = OpVariable %_ptr_Function_double Function
 %417 = OpVariable %_ptr_Function_ulong Function
 %418 = OpVariable %_ptr_Function_double Function
-%419 = OpVariable %_ptr_Function_double Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_double Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_double Function
+%421 = OpVariable %_ptr_Function_ulong Function
 %422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_double Function
-%424 = OpVariable %_ptr_Function_bool Function
-%425 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_double Function
 %426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_double Function
 %428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_double Function
-%430 = OpVariable %_ptr_Function_bool Function
-%431 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_double Function
 %432 = OpVariable %_ptr_Function_ulong Function
-%433 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_double Function
 %434 = OpVariable %_ptr_Function_ulong Function
 %435 = OpVariable %_ptr_Function_double Function
-%436 = OpVariable %_ptr_Function_bool Function
-%437 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_double Function
 %438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_double Function
 %440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_double Function
+%441 = OpVariable %_ptr_Function_bool Function
 %442 = OpVariable %_ptr_Function_bool Function
-%443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_ulong Function
-%446 = OpVariable %_ptr_Function_ulong Function
-%447 = OpVariable %_ptr_Function_double Function
-%448 = OpVariable %_ptr_Function_bool Function
-%449 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_double Function
+%444 = OpVariable %_ptr_Function_bool Function
+%445 = OpVariable %_ptr_Function_bool Function
+%446 = OpVariable %_ptr_Function_double Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_bool Function
 %450 = OpVariable %_ptr_Function_ulong Function
 %451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_double Function
-%454 = OpVariable %_ptr_Function_bool Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_ulong Function
-%459 = OpVariable %_ptr_Function_double Function
-%460 = OpVariable %_ptr_Function_bool Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_double Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_float Function
+%457 = OpVariable %_ptr_Function_float Function
+%458 = OpVariable %_ptr_Function_float Function
+%459 = OpVariable %_ptr_Function_float Function
+%460 = OpVariable %_ptr_Function_float Function
+%461 = OpVariable %_ptr_Function_float Function
+%462 = OpVariable %_ptr_Function_float Function
+%463 = OpVariable %_ptr_Function_double Function
 %464 = OpVariable %_ptr_Function_ulong Function
 %465 = OpVariable %_ptr_Function_double Function
-%466 = OpVariable %_ptr_Function_bool Function
-%467 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_double Function
 %468 = OpVariable %_ptr_Function_ulong Function
 %469 = OpVariable %_ptr_Function_ulong Function
-%470 = OpVariable %_ptr_Function_bool Function
+%470 = OpVariable %_ptr_Function_ulong Function
 %471 = OpVariable %_ptr_Function_ulong Function
 %472 = OpVariable %_ptr_Function_ulong Function
 %473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_bool Function
-%475 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_double Function
 %476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_ulong Function
-%478 = OpVariable %_ptr_Function_bool Function
-%479 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_double Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_double Function
 %480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_bool Function
-%483 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_double Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_double Function
 %484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_bool Function
-%487 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_double Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_double Function
 %488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_bool Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_bool Function
+%489 = OpVariable %_ptr_Function_double Function
+%490 = OpVariable %_ptr_Function_double Function
+%491 = OpVariable %_ptr_Function_double Function
+%492 = OpVariable %_ptr_Function_double Function
+%493 = OpVariable %_ptr_Function_double Function
+%494 = OpVariable %_ptr_Function_ulong Function
 %495 = OpVariable %_ptr_Function_ulong Function
 %496 = OpVariable %_ptr_Function_ulong Function
 %497 = OpVariable %_ptr_Function_ulong Function
-OpStore %182 %58
-%498 = OpFunctionCall %ulong %4
-OpStore %183 %498
-OpBranch %66
-%66 = OpLabel
-%500 = OpLoad %ulong %182
-%501 = OpIAdd %ulong %ulong_4607182418800017408 %500
-OpStore %407 %501
-%502 = OpLoad %ulong %407
-%503 = OpBitcast %double %502
-OpStore %408 %503
-OpBranch %67
-%67 = OpLabel
-OpBranch %75
-%75 = OpLabel
-%505 = OpLoad %ulong %182
-%506 = OpIAdd %ulong %ulong_13830554455654793216 %505
-OpStore %415 %506
-%507 = OpLoad %ulong %415
-%508 = OpBitcast %double %507
-OpStore %416 %508
-OpBranch %76
-%76 = OpLabel
-OpBranch %79
-%79 = OpLabel
-%509 = OpLoad %ulong %182
-%510 = OpBitcast %double %509
-OpStore %419 %510
-OpBranch %80
-%80 = OpLabel
-OpBranch %83
-%83 = OpLabel
-%512 = OpLoad %ulong %182
-%513 = OpIAdd %ulong %ulong_9223372036854775808 %512
-OpStore %422 %513
-%514 = OpLoad %ulong %422
-%515 = OpBitcast %double %514
-OpStore %423 %515
-OpBranch %84
-%84 = OpLabel
-OpBranch %90
-%90 = OpLabel
-%517 = OpLoad %ulong %182
-%518 = OpIAdd %ulong %ulong_9218868437227405312 %517
-OpStore %428 %518
-%519 = OpLoad %ulong %428
-%520 = OpBitcast %double %519
-OpStore %429 %520
-OpBranch %91
-%91 = OpLabel
-OpBranch %97
-%97 = OpLabel
-%522 = OpLoad %ulong %182
-%523 = OpIAdd %ulong %ulong_18442240474082181120 %522
-OpStore %434 %523
-%524 = OpLoad %ulong %434
-%525 = OpBitcast %double %524
-OpStore %435 %525
-OpBranch %98
-%98 = OpLabel
-OpBranch %104
-%104 = OpLabel
-%527 = OpLoad %ulong %182
-%528 = OpIAdd %ulong %ulong_9221120237041090560 %527
-OpStore %440 %528
-%529 = OpLoad %ulong %440
-%530 = OpBitcast %double %529
-OpStore %441 %530
-OpBranch %105
-%105 = OpLabel
-OpBranch %111
-%111 = OpLabel
-%532 = OpLoad %ulong %182
-%533 = OpIAdd %ulong %ulong_9218868437227405311 %532
-OpStore %446 %533
-%534 = OpLoad %ulong %446
-%535 = OpBitcast %double %534
-OpStore %447 %535
-OpBranch %112
-%112 = OpLabel
-OpBranch %118
-%118 = OpLabel
-%537 = OpLoad %ulong %182
-%538 = OpIAdd %ulong %ulong_4503599627370496 %537
-OpStore %452 %538
-%539 = OpLoad %ulong %452
-%540 = OpBitcast %double %539
-OpStore %453 %540
-OpBranch %119
-%119 = OpLabel
-OpBranch %125
-%125 = OpLabel
-%542 = OpLoad %ulong %182
-%543 = OpIAdd %ulong %ulong_4503599627370495 %542
-OpStore %458 %543
-%544 = OpLoad %ulong %458
-%545 = OpBitcast %double %544
-OpStore %459 %545
-OpBranch %126
-%126 = OpLabel
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_double Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_uint Function
+%506 = OpVariable %_ptr_Function_uint Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_double Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_bool Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_double Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_double Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_double Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_double Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_double Function
+%531 = OpVariable %_ptr_Function_double Function
+%532 = OpVariable %_ptr_Function_uint Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_double Function
+%536 = OpVariable %_ptr_Function_bool Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_uint Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_double Function
+%549 = OpVariable %_ptr_Function_bool Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_uint Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_double Function
+%562 = OpVariable %_ptr_Function_bool Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_uint Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_double Function
+%575 = OpVariable %_ptr_Function_bool Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_uint Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_double Function
+%588 = OpVariable %_ptr_Function_bool Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_ulong Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_uint Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_double Function
+%601 = OpVariable %_ptr_Function_bool Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_ulong Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_ulong Function
+%610 = OpVariable %_ptr_Function_uint Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_ulong Function
+%613 = OpVariable %_ptr_Function_double Function
+%614 = OpVariable %_ptr_Function_bool Function
+%615 = OpVariable %_ptr_Function_ulong Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+%618 = OpVariable %_ptr_Function_ulong Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_ulong Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_bool Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function_ulong Function
+%627 = OpVariable %_ptr_Function_ulong Function
+%628 = OpVariable %_ptr_Function_ulong Function
+%629 = OpVariable %_ptr_Function_ulong Function
+%630 = OpVariable %_ptr_Function_ulong Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_ulong Function
+%633 = OpVariable %_ptr_Function_double Function
+%634 = OpVariable %_ptr_Function_bool Function
+%635 = OpVariable %_ptr_Function_ulong Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function_ulong Function
+%638 = OpVariable %_ptr_Function_ulong Function
+%639 = OpVariable %_ptr_Function_ulong Function
+%640 = OpVariable %_ptr_Function_ulong Function
+%641 = OpVariable %_ptr_Function_ulong Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_ulong Function
+%644 = OpVariable %_ptr_Function_bool Function
+%645 = OpVariable %_ptr_Function_ulong Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_ulong Function
+%648 = OpVariable %_ptr_Function_ulong Function
+%649 = OpVariable %_ptr_Function_ulong Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_ulong Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_bool Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_bool Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_ulong Function
+%667 = OpVariable %_ptr_Function_ulong Function
+%668 = OpVariable %_ptr_Function_ulong Function
+%669 = OpVariable %_ptr_Function_ulong Function
+%670 = OpVariable %_ptr_Function_ulong Function
+%671 = OpVariable %_ptr_Function_ulong Function
+%672 = OpVariable %_ptr_Function_bool Function
+%673 = OpVariable %_ptr_Function_ulong Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_ulong Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_ulong Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_ulong Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%681 = OpVariable %_ptr_Function_ulong Function
+%682 = OpVariable %_ptr_Function_ulong Function
+%683 = OpVariable %_ptr_Function_ulong Function
+%684 = OpVariable %_ptr_Function_ulong Function
+%685 = OpVariable %_ptr_Function_ulong Function
+%686 = OpVariable %_ptr_Function_ulong Function
+%687 = OpVariable %_ptr_Function_ulong Function
+%688 = OpVariable %_ptr_Function_ulong Function
+%689 = OpVariable %_ptr_Function_ulong Function
+%690 = OpVariable %_ptr_Function_ulong Function
+%691 = OpVariable %_ptr_Function_ulong Function
+%692 = OpVariable %_ptr_Function_ulong Function
+%693 = OpVariable %_ptr_Function_ulong Function
+%694 = OpVariable %_ptr_Function_ulong Function
+%695 = OpVariable %_ptr_Function_ulong Function
+%696 = OpVariable %_ptr_Function_ulong Function
+%697 = OpVariable %_ptr_Function_ulong Function
+%698 = OpVariable %_ptr_Function_ulong Function
+%699 = OpVariable %_ptr_Function_ulong Function
+%700 = OpVariable %_ptr_Function_ulong Function
+%701 = OpVariable %_ptr_Function_ulong Function
+%702 = OpVariable %_ptr_Function_ulong Function
+%703 = OpVariable %_ptr_Function_ulong Function
+%704 = OpVariable %_ptr_Function_ulong Function
+%705 = OpVariable %_ptr_Function_ulong Function
+%706 = OpVariable %_ptr_Function_ulong Function
+%707 = OpVariable %_ptr_Function_ulong Function
+OpStore %301 %123
+OpBranch %131
+%131 = OpLabel
 OpBranch %132
 %132 = OpLabel
-%547 = OpLoad %ulong %182
-%548 = OpIAdd %ulong %ulong_1 %547
-OpStore %464 %548
-%549 = OpLoad %ulong %464
-%550 = OpBitcast %double %549
-OpStore %465 %550
-OpBranch %133
-%133 = OpLabel
-OpBranch %139
-%139 = OpLabel
-%551 = OpLoad %double %419
-%552 = OpLoad %double %419
-%553 = OpFUnordNotEqual %bool %551 %552
-OpStore %470 %553
-%554 = OpLoad %bool %470
-OpSelectionMerge %143 None
-OpBranchConditional %554 %140 %141
-%141 = OpLabel
-OpBranch %142
-%142 = OpLabel
-%555 = OpLoad %ulong %183
-%556 = OpLoad %double %419
-%557 = OpFunctionCall %ulong %11 %555 %556
-OpStore %472 %557
-%558 = OpLoad %ulong %472
-OpStore %473 %558
-OpBranch %143
+OpBranch %140
 %140 = OpLabel
-%559 = OpLoad %ulong %183
-%560 = OpFunctionCall %ulong %5 %559 %ulong_18446744073709551615
-OpStore %471 %560
-%561 = OpLoad %ulong %471
-OpStore %473 %561
-OpBranch %143
-%143 = OpLabel
+%709 = OpLoad %ulong %301
+%710 = OpIAdd %ulong %ulong_4607182418800017408 %709
+OpStore %523 %710
+%711 = OpLoad %ulong %523
+%712 = OpBitcast %double %711
+OpStore %524 %712
+OpBranch %141
+%141 = OpLabel
+OpBranch %144
+%144 = OpLabel
+%714 = OpLoad %ulong %301
+%715 = OpIAdd %ulong %ulong_13830554455654793216 %714
+OpStore %527 %715
+%716 = OpLoad %ulong %527
+%717 = OpBitcast %double %716
+OpStore %528 %717
+OpBranch %145
+%145 = OpLabel
+OpBranch %148
+%148 = OpLabel
+%718 = OpLoad %ulong %301
+%719 = OpBitcast %double %718
+OpStore %531 %719
 OpBranch %149
 %149 = OpLabel
-%562 = OpLoad %double %423
-%563 = OpLoad %double %423
-%564 = OpFUnordNotEqual %bool %562 %563
-OpStore %478 %564
-%565 = OpLoad %bool %478
-OpSelectionMerge %153 None
-OpBranchConditional %565 %150 %151
-%151 = OpLabel
 OpBranch %152
 %152 = OpLabel
-%566 = OpLoad %ulong %473
-%567 = OpLoad %double %423
-%568 = OpFunctionCall %ulong %11 %566 %567
-OpStore %480 %568
-%569 = OpLoad %ulong %480
-OpStore %481 %569
-OpBranch %153
-%150 = OpLabel
-%570 = OpLoad %ulong %473
-%571 = OpFunctionCall %ulong %5 %570 %ulong_18446744073709551615
-OpStore %479 %571
-%572 = OpLoad %ulong %479
-OpStore %481 %572
+%721 = OpLoad %ulong %301
+%722 = OpIAdd %ulong %ulong_9223372036854775808 %721
+OpStore %534 %722
+%723 = OpLoad %ulong %534
+%724 = OpBitcast %double %723
+OpStore %535 %724
 OpBranch %153
 %153 = OpLabel
-%573 = OpLoad %double %419
-%574 = OpLoad %double %419
-%575 = OpFAdd %double %573 %574
-OpStore %184 %575
-OpBranch %159
-%159 = OpLabel
-%576 = OpLoad %double %184
-%577 = OpLoad %double %184
-%578 = OpFUnordNotEqual %bool %576 %577
-OpStore %486 %578
-%579 = OpLoad %bool %486
-OpSelectionMerge %163 None
-OpBranchConditional %579 %160 %161
+OpBranch %161
 %161 = OpLabel
+%726 = OpLoad %ulong %301
+%727 = OpIAdd %ulong %ulong_9218868437227405312 %726
+OpStore %547 %727
+%728 = OpLoad %ulong %547
+%729 = OpBitcast %double %728
+OpStore %548 %729
 OpBranch %162
 %162 = OpLabel
-%580 = OpLoad %ulong %481
-%581 = OpLoad %double %184
-%582 = OpFunctionCall %ulong %11 %580 %581
-OpStore %488 %582
-%583 = OpLoad %ulong %488
-OpStore %489 %583
-OpBranch %163
-%160 = OpLabel
-%584 = OpLoad %ulong %481
-%585 = OpFunctionCall %ulong %5 %584 %ulong_18446744073709551615
-OpStore %487 %585
-%586 = OpLoad %ulong %487
-OpStore %489 %586
+OpBranch %170
+%170 = OpLabel
+%731 = OpLoad %ulong %301
+%732 = OpIAdd %ulong %ulong_18442240474082181120 %731
+OpStore %560 %732
+%733 = OpLoad %ulong %560
+%734 = OpBitcast %double %733
+OpStore %561 %734
+OpBranch %171
+%171 = OpLabel
+OpBranch %179
+%179 = OpLabel
+%736 = OpLoad %ulong %301
+%737 = OpIAdd %ulong %ulong_9221120237041090560 %736
+OpStore %573 %737
+%738 = OpLoad %ulong %573
+%739 = OpBitcast %double %738
+OpStore %574 %739
+OpBranch %180
+%180 = OpLabel
+OpBranch %188
+%188 = OpLabel
+%741 = OpLoad %ulong %301
+%742 = OpIAdd %ulong %ulong_9218868437227405311 %741
+OpStore %586 %742
+%743 = OpLoad %ulong %586
+%744 = OpBitcast %double %743
+OpStore %587 %744
+OpBranch %189
+%189 = OpLabel
+OpBranch %197
+%197 = OpLabel
+%746 = OpLoad %ulong %301
+%747 = OpIAdd %ulong %ulong_4503599627370496 %746
+OpStore %599 %747
+%748 = OpLoad %ulong %599
+%749 = OpBitcast %double %748
+OpStore %600 %749
+OpBranch %198
+%198 = OpLabel
+OpBranch %206
+%206 = OpLabel
+%751 = OpLoad %ulong %301
+%752 = OpIAdd %ulong %ulong_4503599627370495 %751
+OpStore %612 %752
+%753 = OpLoad %ulong %612
+%754 = OpBitcast %double %753
+OpStore %613 %754
+OpBranch %207
+%207 = OpLabel
+OpBranch %218
+%218 = OpLabel
+%755 = OpLoad %ulong %301
+%756 = OpIAdd %ulong %ulong_1 %755
+OpStore %632 %756
+%757 = OpLoad %ulong %632
+%758 = OpBitcast %double %757
+OpStore %633 %758
+OpBranch %219
+%219 = OpLabel
+%760 = OpLoad %double %531
+%761 = OpFunctionCall %ulong %2 %ulong_14695981039346656037 %760
+OpStore %302 %761
+%762 = OpLoad %ulong %302
+%763 = OpLoad %double %535
+%764 = OpFunctionCall %ulong %2 %762 %763
+OpStore %303 %764
+%765 = OpLoad %double %531
+%766 = OpLoad %double %531
+%767 = OpFAdd %double %765 %766
+OpStore %304 %767
+%768 = OpLoad %ulong %303
+%769 = OpLoad %double %304
+%770 = OpFunctionCall %ulong %2 %768 %769
+OpStore %305 %770
+%771 = OpLoad %double %531
+%772 = OpLoad %double %535
+%773 = OpFAdd %double %771 %772
+OpStore %306 %773
+%774 = OpLoad %ulong %305
+%775 = OpLoad %double %306
+%776 = OpFunctionCall %ulong %2 %774 %775
+OpStore %307 %776
+%777 = OpLoad %double %535
+%778 = OpLoad %double %531
+%779 = OpFAdd %double %777 %778
+OpStore %308 %779
+%780 = OpLoad %ulong %307
+%781 = OpLoad %double %308
+%782 = OpFunctionCall %ulong %2 %780 %781
+OpStore %309 %782
+%783 = OpLoad %double %535
+%784 = OpLoad %double %535
+%785 = OpFAdd %double %783 %784
+OpStore %310 %785
+%786 = OpLoad %ulong %309
+%787 = OpLoad %double %310
+%788 = OpFunctionCall %ulong %2 %786 %787
+OpStore %311 %788
+%789 = OpLoad %double %531
+%790 = OpLoad %double %531
+%791 = OpFSub %double %789 %790
+OpStore %312 %791
+%792 = OpLoad %ulong %311
+%793 = OpLoad %double %312
+%794 = OpFunctionCall %ulong %2 %792 %793
+OpStore %313 %794
+%795 = OpLoad %double %531
+%796 = OpLoad %double %535
+%797 = OpFSub %double %795 %796
+OpStore %314 %797
+%798 = OpLoad %ulong %313
+%799 = OpLoad %double %314
+%800 = OpFunctionCall %ulong %2 %798 %799
+OpStore %315 %800
+%801 = OpLoad %double %535
+%802 = OpLoad %double %531
+%803 = OpFSub %double %801 %802
+OpStore %316 %803
+%804 = OpLoad %ulong %315
+%805 = OpLoad %double %316
+%806 = OpFunctionCall %ulong %2 %804 %805
+OpStore %317 %806
+%807 = OpLoad %double %535
+%808 = OpLoad %double %535
+%809 = OpFSub %double %807 %808
+OpStore %318 %809
+%810 = OpLoad %ulong %317
+%811 = OpLoad %double %318
+%812 = OpFunctionCall %ulong %2 %810 %811
+OpStore %319 %812
+%813 = OpLoad %double %531
+%814 = OpLoad %double %524
+%815 = OpFMul %double %813 %814
+OpStore %320 %815
+%816 = OpLoad %ulong %319
+%817 = OpLoad %double %320
+%818 = OpFunctionCall %ulong %2 %816 %817
+OpStore %321 %818
+%819 = OpLoad %double %531
+%820 = OpLoad %double %528
+%821 = OpFMul %double %819 %820
+OpStore %322 %821
+%822 = OpLoad %ulong %321
+%823 = OpLoad %double %322
+%824 = OpFunctionCall %ulong %2 %822 %823
+OpStore %323 %824
+%825 = OpLoad %double %535
+%826 = OpLoad %double %524
+%827 = OpFMul %double %825 %826
+OpStore %324 %827
+%828 = OpLoad %ulong %323
+%829 = OpLoad %double %324
+%830 = OpFunctionCall %ulong %2 %828 %829
+OpStore %325 %830
+%831 = OpLoad %double %535
+%832 = OpLoad %double %528
+%833 = OpFMul %double %831 %832
+OpStore %326 %833
+%834 = OpLoad %ulong %325
+%835 = OpLoad %double %326
+%836 = OpFunctionCall %ulong %2 %834 %835
+OpStore %327 %836
+%837 = OpLoad %double %535
+%838 = OpLoad %double %535
+%839 = OpFMul %double %837 %838
+OpStore %328 %839
+%840 = OpLoad %ulong %327
+%841 = OpLoad %double %328
+%842 = OpFunctionCall %ulong %2 %840 %841
+OpStore %329 %842
+%843 = OpLoad %double %531
+%844 = OpLoad %double %535
+%845 = OpFMul %double %843 %844
+OpStore %330 %845
+%846 = OpLoad %ulong %329
+%847 = OpLoad %double %330
+%848 = OpFunctionCall %ulong %2 %846 %847
+OpStore %331 %848
+%849 = OpLoad %double %531
+%850 = OpFNegate %double %849
+OpStore %332 %850
+%851 = OpLoad %ulong %331
+%852 = OpLoad %double %332
+%853 = OpFunctionCall %ulong %2 %851 %852
+OpStore %333 %853
+%854 = OpLoad %double %535
+%855 = OpFNegate %double %854
+OpStore %334 %855
+%856 = OpLoad %ulong %333
+%857 = OpLoad %double %334
+%858 = OpFunctionCall %ulong %2 %856 %857
+OpStore %335 %858
+%859 = OpLoad %double %531
+%860 = OpLoad %double %524
+%861 = OpFDiv %double %859 %860
+OpStore %336 %861
+%862 = OpLoad %ulong %335
+%863 = OpLoad %double %336
+%864 = OpFunctionCall %ulong %2 %862 %863
+OpStore %337 %864
+%865 = OpLoad %double %531
+%866 = OpLoad %double %528
+%867 = OpFDiv %double %865 %866
+OpStore %338 %867
+%868 = OpLoad %ulong %337
+%869 = OpLoad %double %338
+%870 = OpFunctionCall %ulong %2 %868 %869
+OpStore %339 %870
+%871 = OpLoad %double %535
+%872 = OpLoad %double %524
+%873 = OpFDiv %double %871 %872
+OpStore %340 %873
+%874 = OpLoad %ulong %339
+%875 = OpLoad %double %340
+%876 = OpFunctionCall %ulong %2 %874 %875
+OpStore %341 %876
+%877 = OpLoad %double %535
+%878 = OpLoad %double %528
+%879 = OpFDiv %double %877 %878
+OpStore %342 %879
+%880 = OpLoad %ulong %341
+%881 = OpLoad %double %342
+%882 = OpFunctionCall %ulong %2 %880 %881
+OpStore %343 %882
+%883 = OpLoad %double %531
+%884 = OpLoad %double %535
+%885 = OpFOrdEqual %bool %883 %884
+OpStore %344 %885
+OpBranch %225
+%225 = OpLabel
+%887 = OpLoad %bool %344
+%890 = OpSelect %uchar %887 %uchar_1 %uchar_0
+%891 = OpUConvert %ulong %890
+OpStore %643 %891
+OpBranch %232
+%232 = OpLabel
+%892 = OpLoad %ulong %343
+OpStore %660 %892
+OpStore %661 %ulong_0
+OpBranch %233
+%233 = OpLabel
+%893 = OpLoad %ulong %661
+%894 = OpULessThan %bool %893 %ulong_8
+OpStore %653 %894
+%895 = OpLoad %bool %653
+OpLoopMerge %235 %294 None
+OpBranchConditional %895 %234 %235
+%235 = OpLabel
+OpBranch %236
+%236 = OpLabel
+OpBranch %226
+%226 = OpLabel
+%896 = OpLoad %double %531
+%897 = OpLoad %double %535
+%898 = OpFOrdLessThan %bool %896 %897
+OpStore %345 %898
+OpBranch %237
+%237 = OpLabel
+%899 = OpLoad %bool %345
+%900 = OpSelect %uchar %899 %uchar_1 %uchar_0
+%901 = OpUConvert %ulong %900
+OpStore %662 %901
+OpBranch %244
+%244 = OpLabel
+%902 = OpLoad %ulong %660
+OpStore %679 %902
+OpStore %680 %ulong_0
+OpBranch %245
+%245 = OpLabel
+%903 = OpLoad %ulong %680
+%904 = OpULessThan %bool %903 %ulong_8
+OpStore %672 %904
+%905 = OpLoad %bool %672
+OpLoopMerge %247 %293 None
+OpBranchConditional %905 %246 %247
+%247 = OpLabel
+OpBranch %248
+%248 = OpLabel
+OpBranch %238
+%238 = OpLabel
+%906 = OpLoad %double %535
+%907 = OpLoad %double %531
+%908 = OpFOrdLessThan %bool %906 %907
+OpStore %346 %908
+OpBranch %249
+%249 = OpLabel
+%909 = OpLoad %bool %346
+%910 = OpSelect %uchar %909 %uchar_1 %uchar_0
+%911 = OpUConvert %ulong %910
+OpStore %681 %911
+%912 = OpLoad %ulong %679
+%913 = OpLoad %ulong %681
+%914 = OpFunctionCall %ulong %4 %912 %913
+OpStore %682 %914
+OpBranch %250
+%250 = OpLabel
+%915 = OpLoad %ulong %682
+%916 = OpLoad %double %548
+%917 = OpFunctionCall %ulong %2 %915 %916
+OpStore %347 %917
+%918 = OpLoad %ulong %347
+%919 = OpLoad %double %561
+%920 = OpFunctionCall %ulong %2 %918 %919
+OpStore %348 %920
+%921 = OpLoad %double %548
+%922 = OpFNegate %double %921
+OpStore %349 %922
+%923 = OpLoad %ulong %348
+%924 = OpLoad %double %349
+%925 = OpFunctionCall %ulong %2 %923 %924
+OpStore %350 %925
+%926 = OpLoad %double %524
+%927 = OpLoad %double %531
+%928 = OpFDiv %double %926 %927
+OpStore %351 %928
+%929 = OpLoad %ulong %350
+%930 = OpLoad %double %351
+%931 = OpFunctionCall %ulong %2 %929 %930
+OpStore %352 %931
+%932 = OpLoad %double %524
+%933 = OpLoad %double %535
+%934 = OpFDiv %double %932 %933
+OpStore %353 %934
+%935 = OpLoad %ulong %352
+%936 = OpLoad %double %353
+%937 = OpFunctionCall %ulong %2 %935 %936
+OpStore %354 %937
+%938 = OpLoad %double %528
+%939 = OpLoad %double %531
+%940 = OpFDiv %double %938 %939
+OpStore %355 %940
+%941 = OpLoad %ulong %354
+%942 = OpLoad %double %355
+%943 = OpFunctionCall %ulong %2 %941 %942
+OpStore %356 %943
+%944 = OpLoad %double %528
+%945 = OpLoad %double %535
+%946 = OpFDiv %double %944 %945
+OpStore %357 %946
+%947 = OpLoad %ulong %356
+%948 = OpLoad %double %357
+%949 = OpFunctionCall %ulong %2 %947 %948
+OpStore %358 %949
+%950 = OpLoad %double %548
+%951 = OpLoad %double %524
+%952 = OpFAdd %double %950 %951
+OpStore %359 %952
+%953 = OpLoad %ulong %358
+%954 = OpLoad %double %359
+%955 = OpFunctionCall %ulong %2 %953 %954
+OpStore %360 %955
+%956 = OpLoad %double %548
+%957 = OpLoad %double %548
+%958 = OpFAdd %double %956 %957
+OpStore %361 %958
+%959 = OpLoad %ulong %360
+%960 = OpLoad %double %361
+%961 = OpFunctionCall %ulong %2 %959 %960
+OpStore %362 %961
+%962 = OpLoad %double %548
+%963 = OpLoad %double %561
+%964 = OpFSub %double %962 %963
+OpStore %363 %964
+%965 = OpLoad %ulong %362
+%966 = OpLoad %double %363
+%967 = OpFunctionCall %ulong %2 %965 %966
+OpStore %364 %967
+%968 = OpLoad %double %548
+%969 = OpLoad %double %548
+%970 = OpFMul %double %968 %969
+OpStore %365 %970
+%971 = OpLoad %ulong %364
+%972 = OpLoad %double %365
+%973 = OpFunctionCall %ulong %2 %971 %972
+OpStore %366 %973
+%974 = OpLoad %double %548
+%975 = OpLoad %double %561
+%976 = OpFMul %double %974 %975
+OpStore %367 %976
+%977 = OpLoad %ulong %366
+%978 = OpLoad %double %367
+%979 = OpFunctionCall %ulong %2 %977 %978
+OpStore %368 %979
+%980 = OpLoad %double %548
+%981 = OpLoad %double %528
+%982 = OpFMul %double %980 %981
+OpStore %369 %982
+%983 = OpLoad %ulong %368
+%984 = OpLoad %double %369
+%985 = OpFunctionCall %ulong %2 %983 %984
+OpStore %370 %985
+%986 = OpLoad %double %524
+%987 = OpLoad %double %548
+%988 = OpFDiv %double %986 %987
+OpStore %371 %988
+%989 = OpLoad %ulong %370
+%990 = OpLoad %double %371
+%991 = OpFunctionCall %ulong %2 %989 %990
+OpStore %372 %991
+%992 = OpLoad %double %528
+%993 = OpLoad %double %548
+%994 = OpFDiv %double %992 %993
+OpStore %373 %994
+%995 = OpLoad %ulong %372
+%996 = OpLoad %double %373
+%997 = OpFunctionCall %ulong %2 %995 %996
+OpStore %374 %997
+%998 = OpLoad %double %524
+%999 = OpLoad %double %561
+%1000 = OpFDiv %double %998 %999
+OpStore %375 %1000
+%1001 = OpLoad %ulong %374
+%1002 = OpLoad %double %375
+%1003 = OpFunctionCall %ulong %2 %1001 %1002
+OpStore %376 %1003
+%1004 = OpLoad %double %548
+%1005 = OpLoad %double %524
+%1006 = OpFDiv %double %1004 %1005
+OpStore %377 %1006
+%1007 = OpLoad %ulong %376
+%1008 = OpLoad %double %377
+%1009 = OpFunctionCall %ulong %2 %1007 %1008
+OpStore %378 %1009
+%1010 = OpLoad %double %587
+%1011 = OpLoad %double %587
+%1012 = OpFAdd %double %1010 %1011
+OpStore %379 %1012
+%1013 = OpLoad %ulong %378
+%1014 = OpLoad %double %379
+%1015 = OpFunctionCall %ulong %2 %1013 %1014
+OpStore %380 %1015
+%1016 = OpLoad %double %587
+%1017 = OpLoad %double %548
+%1018 = OpFOrdLessThan %bool %1016 %1017
+OpStore %381 %1018
+OpBranch %253
+%253 = OpLabel
+%1019 = OpLoad %bool %381
+%1020 = OpSelect %uchar %1019 %uchar_1 %uchar_0
+%1021 = OpUConvert %ulong %1020
+OpStore %684 %1021
+%1022 = OpLoad %ulong %380
+%1023 = OpLoad %ulong %684
+%1024 = OpFunctionCall %ulong %4 %1022 %1023
+OpStore %685 %1024
+OpBranch %254
+%254 = OpLabel
+%1026 = OpLoad %double %587
+%1027 = OpFSub %double %double_0 %1026
+OpStore %382 %1027
+%1028 = OpLoad %double %561
+%1029 = OpLoad %double %382
+%1030 = OpFOrdLessThan %bool %1028 %1029
+OpStore %383 %1030
+OpBranch %257
+%257 = OpLabel
+%1031 = OpLoad %bool %383
+%1032 = OpSelect %uchar %1031 %uchar_1 %uchar_0
+%1033 = OpUConvert %ulong %1032
+OpStore %687 %1033
+%1034 = OpLoad %ulong %685
+%1035 = OpLoad %ulong %687
+%1036 = OpFunctionCall %ulong %4 %1034 %1035
+OpStore %688 %1036
+OpBranch %258
+%258 = OpLabel
+%1037 = OpLoad %double %548
+%1038 = OpLoad %double %548
+%1039 = OpFSub %double %1037 %1038
+OpStore %384 %1039
+%1040 = OpLoad %ulong %688
+%1041 = OpLoad %double %384
+%1042 = OpFunctionCall %ulong %2 %1040 %1041
+OpStore %385 %1042
+%1043 = OpLoad %double %561
+%1044 = OpLoad %double %548
+%1045 = OpFAdd %double %1043 %1044
+OpStore %386 %1045
+%1046 = OpLoad %ulong %385
+%1047 = OpLoad %double %386
+%1048 = OpFunctionCall %ulong %2 %1046 %1047
+OpStore %387 %1048
+%1049 = OpLoad %double %548
+%1050 = OpLoad %double %531
+%1051 = OpFMul %double %1049 %1050
+OpStore %388 %1051
+%1052 = OpLoad %ulong %387
+%1053 = OpLoad %double %388
+%1054 = OpFunctionCall %ulong %2 %1052 %1053
+OpStore %389 %1054
+%1055 = OpLoad %double %561
+%1056 = OpLoad %double %535
+%1057 = OpFMul %double %1055 %1056
+OpStore %390 %1057
+%1058 = OpLoad %ulong %389
+%1059 = OpLoad %double %390
+%1060 = OpFunctionCall %ulong %2 %1058 %1059
+OpStore %391 %1060
+%1061 = OpLoad %double %548
+%1062 = OpLoad %double %548
+%1063 = OpFDiv %double %1061 %1062
+OpStore %392 %1063
+%1064 = OpLoad %ulong %391
+%1065 = OpLoad %double %392
+%1066 = OpFunctionCall %ulong %2 %1064 %1065
+OpStore %393 %1066
+%1067 = OpLoad %double %531
+%1068 = OpLoad %double %531
+%1069 = OpFDiv %double %1067 %1068
+OpStore %394 %1069
+%1070 = OpLoad %ulong %393
+%1071 = OpLoad %double %394
+%1072 = OpFunctionCall %ulong %2 %1070 %1071
+OpStore %395 %1072
+%1073 = OpLoad %double %535
+%1074 = OpLoad %double %531
+%1075 = OpFDiv %double %1073 %1074
+OpStore %396 %1075
+%1076 = OpLoad %ulong %395
+%1077 = OpLoad %double %396
+%1078 = OpFunctionCall %ulong %2 %1076 %1077
+OpStore %397 %1078
+%1079 = OpLoad %double %574
+%1080 = OpBitcast %ulong %1079
+OpStore %398 %1080
+%1081 = OpLoad %ulong %397
+%1082 = OpLoad %ulong %398
+%1083 = OpFunctionCall %ulong %4 %1081 %1082
+OpStore %399 %1083
+%1084 = OpLoad %double %574
+%1085 = OpLoad %double %574
+%1086 = OpFUnordNotEqual %bool %1084 %1085
+OpStore %400 %1086
+OpBranch %261
+%261 = OpLabel
+%1087 = OpLoad %bool %400
+%1088 = OpSelect %uchar %1087 %uchar_1 %uchar_0
+%1089 = OpUConvert %ulong %1088
+OpStore %690 %1089
+%1090 = OpLoad %ulong %399
+%1091 = OpLoad %ulong %690
+%1092 = OpFunctionCall %ulong %4 %1090 %1091
+OpStore %691 %1092
+OpBranch %262
+%262 = OpLabel
+%1093 = OpLoad %double %574
+%1094 = OpLoad %double %574
+%1095 = OpFOrdEqual %bool %1093 %1094
+OpStore %401 %1095
+OpBranch %265
+%265 = OpLabel
+%1096 = OpLoad %bool %401
+%1097 = OpSelect %uchar %1096 %uchar_1 %uchar_0
+%1098 = OpUConvert %ulong %1097
+OpStore %694 %1098
+%1099 = OpLoad %ulong %691
+%1100 = OpLoad %ulong %694
+%1101 = OpFunctionCall %ulong %4 %1099 %1100
+OpStore %695 %1101
+OpBranch %266
+%266 = OpLabel
+%1102 = OpLoad %double %574
+%1103 = OpLoad %double %574
+%1104 = OpFOrdLessThan %bool %1102 %1103
+OpStore %402 %1104
+OpBranch %269
+%269 = OpLabel
+%1105 = OpLoad %bool %402
+%1106 = OpSelect %uchar %1105 %uchar_1 %uchar_0
+%1107 = OpUConvert %ulong %1106
+OpStore %698 %1107
+%1108 = OpLoad %ulong %695
+%1109 = OpLoad %ulong %698
+%1110 = OpFunctionCall %ulong %4 %1108 %1109
+OpStore %699 %1110
+OpBranch %270
+%270 = OpLabel
+%1111 = OpLoad %double %574
+%1112 = OpLoad %double %574
+%1113 = OpFOrdLessThanEqual %bool %1111 %1112
+OpStore %403 %1113
+OpBranch %271
+%271 = OpLabel
+%1114 = OpLoad %bool %403
+%1115 = OpSelect %uchar %1114 %uchar_1 %uchar_0
+%1116 = OpUConvert %ulong %1115
+OpStore %700 %1116
+%1117 = OpLoad %ulong %699
+%1118 = OpLoad %ulong %700
+%1119 = OpFunctionCall %ulong %4 %1117 %1118
+OpStore %701 %1119
+OpBranch %272
+%272 = OpLabel
+%1120 = OpLoad %double %574
+%1121 = OpFNegate %double %1120
+OpStore %404 %1121
+%1122 = OpLoad %double %404
+%1123 = OpBitcast %ulong %1122
+OpStore %405 %1123
+%1124 = OpLoad %ulong %701
+%1125 = OpLoad %ulong %405
+%1126 = OpFunctionCall %ulong %4 %1124 %1125
+OpStore %406 %1126
+%1127 = OpLoad %double %404
+%1128 = OpFNegate %double %1127
+OpStore %407 %1128
+%1129 = OpLoad %double %407
+%1130 = OpBitcast %ulong %1129
+OpStore %408 %1130
+%1131 = OpLoad %ulong %406
+%1132 = OpLoad %ulong %408
+%1133 = OpFunctionCall %ulong %4 %1131 %1132
+OpStore %409 %1133
+%1134 = OpLoad %double %574
+%1135 = OpLoad %double %524
+%1136 = OpFAdd %double %1134 %1135
+OpStore %410 %1136
+%1137 = OpLoad %ulong %409
+%1138 = OpLoad %double %410
+%1139 = OpFunctionCall %ulong %2 %1137 %1138
+OpStore %411 %1139
+%1140 = OpLoad %double %524
+%1141 = OpLoad %double %574
+%1142 = OpFAdd %double %1140 %1141
+OpStore %412 %1142
+%1143 = OpLoad %ulong %411
+%1144 = OpLoad %double %412
+%1145 = OpFunctionCall %ulong %2 %1143 %1144
+OpStore %413 %1145
+%1146 = OpLoad %double %574
+%1147 = OpLoad %double %531
+%1148 = OpFMul %double %1146 %1147
+OpStore %414 %1148
+%1149 = OpLoad %ulong %413
+%1150 = OpLoad %double %414
+%1151 = OpFunctionCall %ulong %2 %1149 %1150
+OpStore %415 %1151
+%1152 = OpLoad %double %574
+%1153 = OpLoad %double %574
+%1154 = OpFSub %double %1152 %1153
+OpStore %416 %1154
+%1155 = OpLoad %ulong %415
+%1156 = OpLoad %double %416
+%1157 = OpFunctionCall %ulong %2 %1155 %1156
+OpStore %417 %1157
+%1158 = OpLoad %double %574
+%1159 = OpLoad %double %574
+%1160 = OpFDiv %double %1158 %1159
+OpStore %418 %1160
+%1161 = OpLoad %ulong %417
+%1162 = OpLoad %double %418
+%1163 = OpFunctionCall %ulong %2 %1161 %1162
+OpStore %419 %1163
+%1164 = OpLoad %double %574
+%1165 = OpLoad %double %548
+%1166 = OpFDiv %double %1164 %1165
+OpStore %420 %1166
+%1167 = OpLoad %ulong %419
+%1168 = OpLoad %double %420
+%1169 = OpFunctionCall %ulong %2 %1167 %1168
+OpStore %421 %1169
+%1170 = OpLoad %ulong %421
+%1171 = OpLoad %double %633
+%1172 = OpFunctionCall %ulong %2 %1170 %1171
+OpStore %422 %1172
+%1173 = OpLoad %ulong %422
+%1174 = OpLoad %double %613
+%1175 = OpFunctionCall %ulong %2 %1173 %1174
+OpStore %423 %1175
+%1176 = OpLoad %ulong %423
+%1177 = OpLoad %double %600
+%1178 = OpFunctionCall %ulong %2 %1176 %1177
+OpStore %424 %1178
+%1179 = OpLoad %double %613
+%1180 = OpLoad %double %633
+%1181 = OpFAdd %double %1179 %1180
+OpStore %425 %1181
+%1182 = OpLoad %ulong %424
+%1183 = OpLoad %double %425
+%1184 = OpFunctionCall %ulong %2 %1182 %1183
+OpStore %426 %1184
+%1185 = OpLoad %double %600
+%1186 = OpLoad %double %633
+%1187 = OpFSub %double %1185 %1186
+OpStore %427 %1187
+%1188 = OpLoad %ulong %426
+%1189 = OpLoad %double %427
+%1190 = OpFunctionCall %ulong %2 %1188 %1189
+OpStore %428 %1190
+%1191 = OpLoad %double %633
+%1192 = OpLoad %double %633
+%1193 = OpFAdd %double %1191 %1192
+OpStore %429 %1193
+%1194 = OpLoad %ulong %428
+%1195 = OpLoad %double %429
+%1196 = OpFunctionCall %ulong %2 %1194 %1195
+OpStore %430 %1196
+%1197 = OpLoad %double %633
+%1199 = OpFMul %double %1197 %double_1_5
+OpStore %431 %1199
+%1200 = OpLoad %ulong %430
+%1201 = OpLoad %double %431
+%1202 = OpFunctionCall %ulong %2 %1200 %1201
+OpStore %432 %1202
+%1203 = OpLoad %double %633
+%1205 = OpFMul %double %1203 %double_0_5
+OpStore %433 %1205
+%1206 = OpLoad %ulong %432
+%1207 = OpLoad %double %433
+%1208 = OpFunctionCall %ulong %2 %1206 %1207
+OpStore %434 %1208
+%1209 = OpLoad %double %633
+%1210 = OpFNegate %double %1209
+OpStore %435 %1210
+%1211 = OpLoad %ulong %434
+%1212 = OpLoad %double %435
+%1213 = OpFunctionCall %ulong %2 %1211 %1212
+OpStore %436 %1213
+%1214 = OpLoad %double %633
+%1216 = OpFMul %double %1214 %double_4503599627370496
+OpStore %437 %1216
+%1217 = OpLoad %ulong %436
+%1218 = OpLoad %double %437
+%1219 = OpFunctionCall %ulong %2 %1217 %1218
+OpStore %438 %1219
+%1220 = OpLoad %double %613
+%1221 = OpLoad %double %600
+%1222 = OpFDiv %double %1220 %1221
+OpStore %439 %1222
+%1223 = OpLoad %ulong %438
+%1224 = OpLoad %double %439
+%1225 = OpFunctionCall %ulong %2 %1223 %1224
+OpStore %440 %1225
+%1226 = OpLoad %double %531
+%1227 = OpLoad %double %633
+%1228 = OpFOrdLessThan %bool %1226 %1227
+OpStore %441 %1228
+OpBranch %273
+%273 = OpLabel
+%1229 = OpLoad %bool %441
+%1230 = OpSelect %uchar %1229 %uchar_1 %uchar_0
+%1231 = OpUConvert %ulong %1230
+OpStore %702 %1231
+%1232 = OpLoad %ulong %440
+%1233 = OpLoad %ulong %702
+%1234 = OpFunctionCall %ulong %4 %1232 %1233
+OpStore %703 %1234
+OpBranch %274
+%274 = OpLabel
+%1235 = OpLoad %double %633
+%1236 = OpLoad %double %531
+%1237 = OpFOrdEqual %bool %1235 %1236
+OpStore %442 %1237
+OpBranch %275
+%275 = OpLabel
+%1238 = OpLoad %bool %442
+%1239 = OpSelect %uchar %1238 %uchar_1 %uchar_0
+%1240 = OpUConvert %ulong %1239
+OpStore %704 %1240
+%1241 = OpLoad %ulong %703
+%1242 = OpLoad %ulong %704
+%1243 = OpFunctionCall %ulong %4 %1241 %1242
+OpStore %705 %1243
+OpBranch %276
+%276 = OpLabel
+%1244 = OpLoad %double %633
+%1245 = OpFSub %double %double_0 %1244
+OpStore %443 %1245
+%1246 = OpLoad %double %443
+%1247 = OpLoad %double %535
+%1248 = OpFOrdLessThan %bool %1246 %1247
+OpStore %444 %1248
+OpBranch %277
+%277 = OpLabel
+%1249 = OpLoad %bool %444
+%1250 = OpSelect %uchar %1249 %uchar_1 %uchar_0
+%1251 = OpUConvert %ulong %1250
+OpStore %706 %1251
+%1252 = OpLoad %ulong %705
+%1253 = OpLoad %ulong %706
+%1254 = OpFunctionCall %ulong %4 %1252 %1253
+OpStore %707 %1254
+OpBranch %278
+%278 = OpLabel
+%1255 = OpLoad %ulong %707
+OpStore %508 %1255
+%1256 = OpLoad %double %600
+OpStore %509 %1256
+OpStore %510 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%1257 = OpLoad %ulong %510
+%1259 = OpULessThan %bool %1257 %ulong_60
+OpStore %445 %1259
+%1260 = OpLoad %bool %445
+OpLoopMerge %127 %292 None
+OpBranchConditional %1260 %126 %127
+%127 = OpLabel
+OpStore %300 %1261
+%1263 = OpAccessChain %_ptr_Function_ulong %300 %uint_0
+OpStore %1263 %ulong_0
+%1265 = OpAccessChain %_ptr_Function_ulong %300 %uint_1
+OpStore %1265 %ulong_9223372036854775808
+%1267 = OpAccessChain %_ptr_Function_ulong %300 %uint_2
+OpStore %1267 %ulong_1
+%1269 = OpAccessChain %_ptr_Function_ulong %300 %uint_3
+OpStore %1269 %ulong_9218868437227405312
+%1271 = OpAccessChain %_ptr_Function_ulong %300 %uint_4
+OpStore %1271 %ulong_18442240474082181120
+%1273 = OpAccessChain %_ptr_Function_ulong %300 %uint_5
+OpStore %1273 %ulong_9221120237041090560
+%1275 = OpAccessChain %_ptr_Function_ulong %300 %uint_6
+OpStore %1275 %ulong_18444492273908506285
+%1278 = OpAccessChain %_ptr_Function_ulong %300 %uint_7
+OpStore %1278 %ulong_9218868437227405313
+%1280 = OpLoad %ulong %508
+OpStore %507 %1280
+OpStore %511 %ulong_0
+OpBranch %128
+%128 = OpLabel
+%1281 = OpLoad %ulong %511
+%1282 = OpULessThan %bool %1281 %ulong_8
+OpStore %449 %1282
+%1283 = OpLoad %bool %449
+OpLoopMerge %130 %291 None
+OpBranchConditional %1283 %129 %130
+%130 = OpLabel
+%1284 = OpLoad %double %587
+%1285 = OpFConvert %float %1284
+OpStore %456 %1285
+%1286 = OpLoad %double %633
+%1287 = OpFConvert %float %1286
+OpStore %457 %1287
+OpBranch %138
+%138 = OpLabel
+%1289 = OpLoad %ulong %301
+%1290 = OpIAdd %ulong %ulong_3936146074321813504 %1289
+OpStore %521 %1290
+%1291 = OpLoad %ulong %521
+%1292 = OpBitcast %double %1291
+OpStore %522 %1292
+OpBranch %139
+%139 = OpLabel
+%1293 = OpLoad %double %522
+%1294 = OpFConvert %float %1293
+OpStore %458 %1294
+OpBranch %142
+%142 = OpLabel
+%1296 = OpLoad %ulong %301
+%1297 = OpIAdd %ulong %ulong_4607182419068452864 %1296
+OpStore %525 %1297
+%1298 = OpLoad %ulong %525
+%1299 = OpBitcast %double %1298
+OpStore %526 %1299
+OpBranch %143
+%143 = OpLabel
+%1300 = OpLoad %double %526
+%1301 = OpFConvert %float %1300
+OpStore %459 %1301
+OpBranch %146
+%146 = OpLabel
+%1303 = OpLoad %ulong %301
+%1304 = OpIAdd %ulong %ulong_4607182419605323776 %1303
+OpStore %529 %1304
+%1305 = OpLoad %ulong %529
+%1306 = OpBitcast %double %1305
+OpStore %530 %1306
+OpBranch %147
+%147 = OpLabel
+%1307 = OpLoad %double %530
+%1308 = OpFConvert %float %1307
+OpStore %460 %1308
+%1309 = OpLoad %double %535
+%1310 = OpFConvert %float %1309
+OpStore %461 %1310
+%1311 = OpLoad %double %561
+%1312 = OpFConvert %float %1311
+OpStore %462 %1312
+OpBranch %150
+%150 = OpLabel
+%1313 = OpLoad %float %456
+%1314 = OpBitcast %uint %1313
+OpStore %532 %1314
+%1315 = OpLoad %uint %532
+%1316 = OpUConvert %ulong %1315
+OpStore %533 %1316
+OpBranch %154
+%154 = OpLabel
+%1317 = OpLoad %ulong %507
+OpStore %543 %1317
+OpStore %544 %ulong_0
+OpBranch %155
+%155 = OpLabel
+%1318 = OpLoad %ulong %544
+%1319 = OpULessThan %bool %1318 %ulong_8
+OpStore %536 %1319
+%1320 = OpLoad %bool %536
+OpLoopMerge %157 %289 None
+OpBranchConditional %1320 %156 %157
+%157 = OpLabel
+OpBranch %158
+%158 = OpLabel
+OpBranch %151
+%151 = OpLabel
+OpBranch %159
+%159 = OpLabel
+%1321 = OpLoad %float %457
+%1322 = OpBitcast %uint %1321
+OpStore %545 %1322
+%1323 = OpLoad %uint %545
+%1324 = OpUConvert %ulong %1323
+OpStore %546 %1324
 OpBranch %163
 %163 = OpLabel
-%587 = OpLoad %double %419
-%588 = OpLoad %double %423
-%589 = OpFAdd %double %587 %588
-OpStore %185 %589
+%1325 = OpLoad %ulong %543
+OpStore %556 %1325
+OpStore %557 %ulong_0
 OpBranch %164
 %164 = OpLabel
-%590 = OpLoad %double %185
-%591 = OpLoad %double %185
-%592 = OpFUnordNotEqual %bool %590 %591
-OpStore %490 %592
-%593 = OpLoad %bool %490
-OpSelectionMerge %168 None
-OpBranchConditional %593 %165 %166
+%1326 = OpLoad %ulong %557
+%1327 = OpULessThan %bool %1326 %ulong_8
+OpStore %549 %1327
+%1328 = OpLoad %bool %549
+OpLoopMerge %166 %288 None
+OpBranchConditional %1328 %165 %166
 %166 = OpLabel
 OpBranch %167
 %167 = OpLabel
-%594 = OpLoad %ulong %489
-%595 = OpLoad %double %185
-%596 = OpFunctionCall %ulong %11 %594 %595
-OpStore %492 %596
-%597 = OpLoad %ulong %492
-OpStore %493 %597
-OpBranch %168
-%165 = OpLabel
-%598 = OpLoad %ulong %489
-%599 = OpFunctionCall %ulong %5 %598 %ulong_18446744073709551615
-OpStore %491 %599
-%600 = OpLoad %ulong %491
-OpStore %493 %600
+OpBranch %160
+%160 = OpLabel
 OpBranch %168
 %168 = OpLabel
-%601 = OpLoad %double %423
-%602 = OpLoad %double %419
-%603 = OpFAdd %double %601 %602
-OpStore %186 %603
-OpBranch %169
-%169 = OpLabel
-%604 = OpLoad %double %186
-%605 = OpLoad %double %186
-%606 = OpFUnordNotEqual %bool %604 %605
-OpStore %494 %606
-%607 = OpLoad %bool %494
-OpSelectionMerge %173 None
-OpBranchConditional %607 %170 %171
-%171 = OpLabel
+%1329 = OpLoad %float %458
+%1330 = OpBitcast %uint %1329
+OpStore %558 %1330
+%1331 = OpLoad %uint %558
+%1332 = OpUConvert %ulong %1331
+OpStore %559 %1332
 OpBranch %172
 %172 = OpLabel
-%608 = OpLoad %ulong %493
-%609 = OpLoad %double %186
-%610 = OpFunctionCall %ulong %11 %608 %609
-OpStore %496 %610
-%611 = OpLoad %ulong %496
-OpStore %497 %611
-OpBranch %173
-%170 = OpLabel
-%612 = OpLoad %ulong %493
-%613 = OpFunctionCall %ulong %5 %612 %ulong_18446744073709551615
-OpStore %495 %613
-%614 = OpLoad %ulong %495
-OpStore %497 %614
+%1333 = OpLoad %ulong %556
+OpStore %569 %1333
+OpStore %570 %ulong_0
 OpBranch %173
 %173 = OpLabel
-%615 = OpLoad %double %423
-%616 = OpLoad %double %423
-%617 = OpFAdd %double %615 %616
-OpStore %187 %617
-%618 = OpLoad %ulong %497
-%619 = OpLoad %double %187
-%620 = OpFunctionCall %ulong %2 %618 %619
-OpStore %188 %620
-%621 = OpLoad %double %419
-%622 = OpLoad %double %419
-%623 = OpFSub %double %621 %622
-OpStore %189 %623
-%624 = OpLoad %ulong %188
-%625 = OpLoad %double %189
-%626 = OpFunctionCall %ulong %2 %624 %625
-OpStore %190 %626
-%627 = OpLoad %double %419
-%628 = OpLoad %double %423
-%629 = OpFSub %double %627 %628
-OpStore %191 %629
-%630 = OpLoad %ulong %190
-%631 = OpLoad %double %191
-%632 = OpFunctionCall %ulong %2 %630 %631
-OpStore %192 %632
-%633 = OpLoad %double %423
-%634 = OpLoad %double %419
-%635 = OpFSub %double %633 %634
-OpStore %193 %635
-%636 = OpLoad %ulong %192
-%637 = OpLoad %double %193
-%638 = OpFunctionCall %ulong %2 %636 %637
-OpStore %194 %638
-%639 = OpLoad %double %423
-%640 = OpLoad %double %423
-%641 = OpFSub %double %639 %640
-OpStore %195 %641
-%642 = OpLoad %ulong %194
-%643 = OpLoad %double %195
-%644 = OpFunctionCall %ulong %2 %642 %643
-OpStore %196 %644
-%645 = OpLoad %double %419
-%646 = OpLoad %double %408
-%647 = OpFMul %double %645 %646
-OpStore %197 %647
-%648 = OpLoad %ulong %196
-%649 = OpLoad %double %197
-%650 = OpFunctionCall %ulong %2 %648 %649
-OpStore %198 %650
-%651 = OpLoad %double %419
-%652 = OpLoad %double %416
-%653 = OpFMul %double %651 %652
-OpStore %199 %653
-%654 = OpLoad %ulong %198
-%655 = OpLoad %double %199
-%656 = OpFunctionCall %ulong %2 %654 %655
-OpStore %200 %656
-%657 = OpLoad %double %423
-%658 = OpLoad %double %408
-%659 = OpFMul %double %657 %658
-OpStore %201 %659
-%660 = OpLoad %ulong %200
-%661 = OpLoad %double %201
-%662 = OpFunctionCall %ulong %2 %660 %661
-OpStore %202 %662
-%663 = OpLoad %double %423
-%664 = OpLoad %double %416
-%665 = OpFMul %double %663 %664
-OpStore %203 %665
-%666 = OpLoad %ulong %202
-%667 = OpLoad %double %203
-%668 = OpFunctionCall %ulong %2 %666 %667
-OpStore %204 %668
-%669 = OpLoad %double %423
-%670 = OpLoad %double %423
-%671 = OpFMul %double %669 %670
-OpStore %205 %671
-%672 = OpLoad %ulong %204
-%673 = OpLoad %double %205
-%674 = OpFunctionCall %ulong %2 %672 %673
-OpStore %206 %674
-%675 = OpLoad %double %419
-%676 = OpLoad %double %423
-%677 = OpFMul %double %675 %676
-OpStore %207 %677
-%678 = OpLoad %ulong %206
-%679 = OpLoad %double %207
-%680 = OpFunctionCall %ulong %2 %678 %679
-OpStore %208 %680
-%681 = OpLoad %double %419
-%682 = OpFNegate %double %681
-OpStore %209 %682
-%683 = OpLoad %ulong %208
-%684 = OpLoad %double %209
-%685 = OpFunctionCall %ulong %2 %683 %684
-OpStore %210 %685
-%686 = OpLoad %double %423
-%687 = OpFNegate %double %686
-OpStore %211 %687
-%688 = OpLoad %ulong %210
-%689 = OpLoad %double %211
-%690 = OpFunctionCall %ulong %2 %688 %689
-OpStore %212 %690
-%691 = OpLoad %double %419
-%692 = OpLoad %double %408
-%693 = OpFDiv %double %691 %692
-OpStore %213 %693
-%694 = OpLoad %ulong %212
-%695 = OpLoad %double %213
-%696 = OpFunctionCall %ulong %2 %694 %695
-OpStore %214 %696
-%697 = OpLoad %double %419
-%698 = OpLoad %double %416
-%699 = OpFDiv %double %697 %698
-OpStore %215 %699
-%700 = OpLoad %ulong %214
-%701 = OpLoad %double %215
-%702 = OpFunctionCall %ulong %2 %700 %701
-OpStore %216 %702
-%703 = OpLoad %double %423
-%704 = OpLoad %double %408
-%705 = OpFDiv %double %703 %704
-OpStore %217 %705
-%706 = OpLoad %ulong %216
-%707 = OpLoad %double %217
-%708 = OpFunctionCall %ulong %2 %706 %707
-OpStore %218 %708
-%709 = OpLoad %double %423
-%710 = OpLoad %double %416
-%711 = OpFDiv %double %709 %710
-OpStore %219 %711
-%712 = OpLoad %ulong %218
-%713 = OpLoad %double %219
-%714 = OpFunctionCall %ulong %2 %712 %713
-OpStore %220 %714
-%715 = OpLoad %double %419
-%716 = OpLoad %double %423
-%717 = OpFOrdEqual %bool %715 %716
-OpStore %221 %717
-%719 = OpLoad %ulong %220
-%720 = OpLoad %bool %221
-%723 = OpSelect %uchar %720 %uchar_1 %uchar_0
-%724 = OpFunctionCall %ulong %6 %719 %723
-OpStore %222 %724
-%725 = OpLoad %double %419
-%726 = OpLoad %double %423
-%727 = OpFOrdLessThan %bool %725 %726
-OpStore %223 %727
-%728 = OpLoad %ulong %222
-%729 = OpLoad %bool %223
-%730 = OpSelect %uchar %729 %uchar_1 %uchar_0
-%731 = OpFunctionCall %ulong %6 %728 %730
-OpStore %224 %731
-%732 = OpLoad %double %423
-%733 = OpLoad %double %419
-%734 = OpFOrdLessThan %bool %732 %733
-OpStore %225 %734
-%735 = OpLoad %ulong %224
-%736 = OpLoad %bool %225
-%737 = OpSelect %uchar %736 %uchar_1 %uchar_0
-%738 = OpFunctionCall %ulong %6 %735 %737
-OpStore %226 %738
-%739 = OpLoad %ulong %226
-%740 = OpLoad %double %429
-%741 = OpFunctionCall %ulong %2 %739 %740
-OpStore %227 %741
-%742 = OpLoad %ulong %227
-%743 = OpLoad %double %435
-%744 = OpFunctionCall %ulong %2 %742 %743
-OpStore %228 %744
-%745 = OpLoad %double %429
-%746 = OpFNegate %double %745
-OpStore %229 %746
-%747 = OpLoad %ulong %228
-%748 = OpLoad %double %229
-%749 = OpFunctionCall %ulong %2 %747 %748
-OpStore %230 %749
-%750 = OpLoad %double %408
-%751 = OpLoad %double %419
-%752 = OpFDiv %double %750 %751
-OpStore %231 %752
-%753 = OpLoad %ulong %230
-%754 = OpLoad %double %231
-%755 = OpFunctionCall %ulong %2 %753 %754
-OpStore %232 %755
-%756 = OpLoad %double %408
-%757 = OpLoad %double %423
-%758 = OpFDiv %double %756 %757
-OpStore %233 %758
-%759 = OpLoad %ulong %232
-%760 = OpLoad %double %233
-%761 = OpFunctionCall %ulong %2 %759 %760
-OpStore %234 %761
-%762 = OpLoad %double %416
-%763 = OpLoad %double %419
-%764 = OpFDiv %double %762 %763
-OpStore %235 %764
-%765 = OpLoad %ulong %234
-%766 = OpLoad %double %235
-%767 = OpFunctionCall %ulong %2 %765 %766
-OpStore %236 %767
-%768 = OpLoad %double %416
-%769 = OpLoad %double %423
-%770 = OpFDiv %double %768 %769
-OpStore %237 %770
-%771 = OpLoad %ulong %236
-%772 = OpLoad %double %237
-%773 = OpFunctionCall %ulong %2 %771 %772
-OpStore %238 %773
-%774 = OpLoad %double %429
-%775 = OpLoad %double %408
-%776 = OpFAdd %double %774 %775
-OpStore %239 %776
-%777 = OpLoad %ulong %238
-%778 = OpLoad %double %239
-%779 = OpFunctionCall %ulong %2 %777 %778
-OpStore %240 %779
-%780 = OpLoad %double %429
-%781 = OpLoad %double %429
-%782 = OpFAdd %double %780 %781
-OpStore %241 %782
-%783 = OpLoad %ulong %240
-%784 = OpLoad %double %241
-%785 = OpFunctionCall %ulong %2 %783 %784
-OpStore %242 %785
-%786 = OpLoad %double %429
-%787 = OpLoad %double %435
-%788 = OpFSub %double %786 %787
-OpStore %243 %788
-%789 = OpLoad %ulong %242
-%790 = OpLoad %double %243
-%791 = OpFunctionCall %ulong %2 %789 %790
-OpStore %244 %791
-%792 = OpLoad %double %429
-%793 = OpLoad %double %429
-%794 = OpFMul %double %792 %793
-OpStore %245 %794
-%795 = OpLoad %ulong %244
-%796 = OpLoad %double %245
-%797 = OpFunctionCall %ulong %2 %795 %796
-OpStore %246 %797
-%798 = OpLoad %double %429
-%799 = OpLoad %double %435
-%800 = OpFMul %double %798 %799
-OpStore %247 %800
-%801 = OpLoad %ulong %246
-%802 = OpLoad %double %247
-%803 = OpFunctionCall %ulong %2 %801 %802
-OpStore %248 %803
-%804 = OpLoad %double %429
-%805 = OpLoad %double %416
-%806 = OpFMul %double %804 %805
-OpStore %249 %806
-%807 = OpLoad %ulong %248
-%808 = OpLoad %double %249
-%809 = OpFunctionCall %ulong %2 %807 %808
-OpStore %250 %809
-%810 = OpLoad %double %408
-%811 = OpLoad %double %429
-%812 = OpFDiv %double %810 %811
-OpStore %251 %812
-%813 = OpLoad %ulong %250
-%814 = OpLoad %double %251
-%815 = OpFunctionCall %ulong %2 %813 %814
-OpStore %252 %815
-%816 = OpLoad %double %416
-%817 = OpLoad %double %429
-%818 = OpFDiv %double %816 %817
-OpStore %253 %818
-%819 = OpLoad %ulong %252
-%820 = OpLoad %double %253
-%821 = OpFunctionCall %ulong %2 %819 %820
-OpStore %254 %821
-%822 = OpLoad %double %408
-%823 = OpLoad %double %435
-%824 = OpFDiv %double %822 %823
-OpStore %255 %824
-%825 = OpLoad %ulong %254
-%826 = OpLoad %double %255
-%827 = OpFunctionCall %ulong %2 %825 %826
-OpStore %256 %827
-%828 = OpLoad %double %429
-%829 = OpLoad %double %408
-%830 = OpFDiv %double %828 %829
-OpStore %257 %830
-%831 = OpLoad %ulong %256
-%832 = OpLoad %double %257
-%833 = OpFunctionCall %ulong %2 %831 %832
-OpStore %258 %833
-%834 = OpLoad %double %447
-%835 = OpLoad %double %447
-%836 = OpFAdd %double %834 %835
-OpStore %259 %836
-%837 = OpLoad %ulong %258
-%838 = OpLoad %double %259
-%839 = OpFunctionCall %ulong %2 %837 %838
-OpStore %260 %839
-%840 = OpLoad %double %447
-%841 = OpLoad %double %429
-%842 = OpFOrdLessThan %bool %840 %841
-OpStore %261 %842
-%843 = OpLoad %ulong %260
-%844 = OpLoad %bool %261
-%845 = OpSelect %uchar %844 %uchar_1 %uchar_0
-%846 = OpFunctionCall %ulong %6 %843 %845
-OpStore %262 %846
-%848 = OpLoad %double %447
-%849 = OpFSub %double %double_0 %848
-OpStore %263 %849
-%850 = OpLoad %double %435
-%851 = OpLoad %double %263
-%852 = OpFOrdLessThan %bool %850 %851
-OpStore %264 %852
-%853 = OpLoad %ulong %262
-%854 = OpLoad %bool %264
-%855 = OpSelect %uchar %854 %uchar_1 %uchar_0
-%856 = OpFunctionCall %ulong %6 %853 %855
-OpStore %265 %856
-%857 = OpLoad %double %429
-%858 = OpLoad %double %429
-%859 = OpFSub %double %857 %858
-OpStore %266 %859
-%860 = OpLoad %ulong %265
-%861 = OpLoad %double %266
-%862 = OpFunctionCall %ulong %2 %860 %861
-OpStore %267 %862
-%863 = OpLoad %double %435
-%864 = OpLoad %double %429
-%865 = OpFAdd %double %863 %864
-OpStore %268 %865
-%866 = OpLoad %ulong %267
-%867 = OpLoad %double %268
-%868 = OpFunctionCall %ulong %2 %866 %867
-OpStore %269 %868
-%869 = OpLoad %double %429
-%870 = OpLoad %double %419
-%871 = OpFMul %double %869 %870
-OpStore %270 %871
-%872 = OpLoad %ulong %269
-%873 = OpLoad %double %270
-%874 = OpFunctionCall %ulong %2 %872 %873
-OpStore %271 %874
-%875 = OpLoad %double %435
-%876 = OpLoad %double %423
-%877 = OpFMul %double %875 %876
-OpStore %272 %877
-%878 = OpLoad %ulong %271
-%879 = OpLoad %double %272
-%880 = OpFunctionCall %ulong %2 %878 %879
-OpStore %273 %880
-%881 = OpLoad %double %429
-%882 = OpLoad %double %429
-%883 = OpFDiv %double %881 %882
-OpStore %274 %883
-%884 = OpLoad %ulong %273
-%885 = OpLoad %double %274
-%886 = OpFunctionCall %ulong %2 %884 %885
-OpStore %275 %886
-%887 = OpLoad %double %419
-%888 = OpLoad %double %419
-%889 = OpFDiv %double %887 %888
-OpStore %276 %889
-%890 = OpLoad %ulong %275
-%891 = OpLoad %double %276
-%892 = OpFunctionCall %ulong %2 %890 %891
-OpStore %277 %892
-%893 = OpLoad %double %423
-%894 = OpLoad %double %419
-%895 = OpFDiv %double %893 %894
-OpStore %278 %895
-%896 = OpLoad %ulong %277
-%897 = OpLoad %double %278
-%898 = OpFunctionCall %ulong %2 %896 %897
-OpStore %279 %898
-%899 = OpLoad %double %441
-%900 = OpBitcast %ulong %899
-OpStore %280 %900
-%901 = OpLoad %ulong %279
-%902 = OpLoad %ulong %280
-%903 = OpFunctionCall %ulong %5 %901 %902
-OpStore %281 %903
-%904 = OpLoad %double %441
-%905 = OpLoad %double %441
-%906 = OpFUnordNotEqual %bool %904 %905
-OpStore %282 %906
-%907 = OpLoad %ulong %281
-%908 = OpLoad %bool %282
-%909 = OpSelect %uchar %908 %uchar_1 %uchar_0
-%910 = OpFunctionCall %ulong %6 %907 %909
-OpStore %283 %910
-%911 = OpLoad %double %441
-%912 = OpLoad %double %441
-%913 = OpFOrdEqual %bool %911 %912
-OpStore %284 %913
-%914 = OpLoad %ulong %283
-%915 = OpLoad %bool %284
-%916 = OpSelect %uchar %915 %uchar_1 %uchar_0
-%917 = OpFunctionCall %ulong %6 %914 %916
-OpStore %285 %917
-%918 = OpLoad %double %441
-%919 = OpLoad %double %441
-%920 = OpFOrdLessThan %bool %918 %919
-OpStore %286 %920
-%921 = OpLoad %ulong %285
-%922 = OpLoad %bool %286
-%923 = OpSelect %uchar %922 %uchar_1 %uchar_0
-%924 = OpFunctionCall %ulong %6 %921 %923
-OpStore %287 %924
-%925 = OpLoad %double %441
-%926 = OpLoad %double %441
-%927 = OpFOrdLessThanEqual %bool %925 %926
-OpStore %288 %927
-%928 = OpLoad %ulong %287
-%929 = OpLoad %bool %288
-%930 = OpSelect %uchar %929 %uchar_1 %uchar_0
-%931 = OpFunctionCall %ulong %6 %928 %930
-OpStore %289 %931
-%932 = OpLoad %double %441
-%933 = OpFNegate %double %932
-OpStore %290 %933
-%934 = OpLoad %double %290
-%935 = OpBitcast %ulong %934
-OpStore %291 %935
-%936 = OpLoad %ulong %289
-%937 = OpLoad %ulong %291
-%938 = OpFunctionCall %ulong %5 %936 %937
-OpStore %292 %938
-%939 = OpLoad %double %290
-%940 = OpFNegate %double %939
-OpStore %293 %940
-%941 = OpLoad %double %293
-%942 = OpBitcast %ulong %941
-OpStore %294 %942
-%943 = OpLoad %ulong %292
-%944 = OpLoad %ulong %294
-%945 = OpFunctionCall %ulong %5 %943 %944
-OpStore %295 %945
-%946 = OpLoad %double %441
-%947 = OpLoad %double %408
-%948 = OpFAdd %double %946 %947
-OpStore %296 %948
-%949 = OpLoad %ulong %295
-%950 = OpLoad %double %296
-%951 = OpFunctionCall %ulong %2 %949 %950
-OpStore %297 %951
-%952 = OpLoad %double %408
-%953 = OpLoad %double %441
-%954 = OpFAdd %double %952 %953
-OpStore %298 %954
-%955 = OpLoad %ulong %297
-%956 = OpLoad %double %298
-%957 = OpFunctionCall %ulong %2 %955 %956
-OpStore %299 %957
-%958 = OpLoad %double %441
-%959 = OpLoad %double %419
-%960 = OpFMul %double %958 %959
-OpStore %300 %960
-%961 = OpLoad %ulong %299
-%962 = OpLoad %double %300
-%963 = OpFunctionCall %ulong %2 %961 %962
-OpStore %301 %963
-%964 = OpLoad %double %441
-%965 = OpLoad %double %441
-%966 = OpFSub %double %964 %965
-OpStore %302 %966
-%967 = OpLoad %ulong %301
-%968 = OpLoad %double %302
-%969 = OpFunctionCall %ulong %2 %967 %968
-OpStore %303 %969
-%970 = OpLoad %double %441
-%971 = OpLoad %double %441
-%972 = OpFDiv %double %970 %971
-OpStore %304 %972
-%973 = OpLoad %ulong %303
-%974 = OpLoad %double %304
-%975 = OpFunctionCall %ulong %2 %973 %974
-OpStore %305 %975
-%976 = OpLoad %double %441
-%977 = OpLoad %double %429
-%978 = OpFDiv %double %976 %977
-OpStore %306 %978
-%979 = OpLoad %ulong %305
-%980 = OpLoad %double %306
-%981 = OpFunctionCall %ulong %2 %979 %980
-OpStore %307 %981
-%982 = OpLoad %ulong %307
-%983 = OpLoad %double %465
-%984 = OpFunctionCall %ulong %2 %982 %983
-OpStore %308 %984
-%985 = OpLoad %ulong %308
-%986 = OpLoad %double %459
-%987 = OpFunctionCall %ulong %2 %985 %986
-OpStore %309 %987
-%988 = OpLoad %ulong %309
-%989 = OpLoad %double %453
-%990 = OpFunctionCall %ulong %2 %988 %989
-OpStore %310 %990
-%991 = OpLoad %double %459
-%992 = OpLoad %double %465
-%993 = OpFAdd %double %991 %992
-OpStore %311 %993
-%994 = OpLoad %ulong %310
-%995 = OpLoad %double %311
-%996 = OpFunctionCall %ulong %2 %994 %995
-OpStore %312 %996
-%997 = OpLoad %double %453
-%998 = OpLoad %double %465
-%999 = OpFSub %double %997 %998
-OpStore %313 %999
-%1000 = OpLoad %ulong %312
-%1001 = OpLoad %double %313
-%1002 = OpFunctionCall %ulong %2 %1000 %1001
-OpStore %314 %1002
-%1003 = OpLoad %double %465
-%1004 = OpLoad %double %465
-%1005 = OpFAdd %double %1003 %1004
-OpStore %315 %1005
-%1006 = OpLoad %ulong %314
-%1007 = OpLoad %double %315
-%1008 = OpFunctionCall %ulong %2 %1006 %1007
-OpStore %316 %1008
-%1009 = OpLoad %double %465
-%1011 = OpFMul %double %1009 %double_1_5
-OpStore %317 %1011
-%1012 = OpLoad %ulong %316
-%1013 = OpLoad %double %317
-%1014 = OpFunctionCall %ulong %2 %1012 %1013
-OpStore %318 %1014
-%1015 = OpLoad %double %465
-%1017 = OpFMul %double %1015 %double_0_5
-OpStore %319 %1017
-%1018 = OpLoad %ulong %318
-%1019 = OpLoad %double %319
-%1020 = OpFunctionCall %ulong %2 %1018 %1019
-OpStore %320 %1020
-%1021 = OpLoad %double %465
-%1022 = OpFNegate %double %1021
-OpStore %321 %1022
-%1023 = OpLoad %ulong %320
-%1024 = OpLoad %double %321
-%1025 = OpFunctionCall %ulong %2 %1023 %1024
-OpStore %322 %1025
-%1026 = OpLoad %double %465
-%1028 = OpFMul %double %1026 %double_4503599627370496
-OpStore %323 %1028
-%1029 = OpLoad %ulong %322
-%1030 = OpLoad %double %323
-%1031 = OpFunctionCall %ulong %2 %1029 %1030
-OpStore %324 %1031
-%1032 = OpLoad %double %459
-%1033 = OpLoad %double %453
-%1034 = OpFDiv %double %1032 %1033
-OpStore %325 %1034
-%1035 = OpLoad %ulong %324
-%1036 = OpLoad %double %325
-%1037 = OpFunctionCall %ulong %2 %1035 %1036
-OpStore %326 %1037
-%1038 = OpLoad %double %419
-%1039 = OpLoad %double %465
-%1040 = OpFOrdLessThan %bool %1038 %1039
-OpStore %327 %1040
-%1041 = OpLoad %ulong %326
-%1042 = OpLoad %bool %327
-%1043 = OpSelect %uchar %1042 %uchar_1 %uchar_0
-%1044 = OpFunctionCall %ulong %6 %1041 %1043
-OpStore %328 %1044
-%1045 = OpLoad %double %465
-%1046 = OpLoad %double %419
-%1047 = OpFOrdEqual %bool %1045 %1046
-OpStore %329 %1047
-%1048 = OpLoad %ulong %328
-%1049 = OpLoad %bool %329
-%1050 = OpSelect %uchar %1049 %uchar_1 %uchar_0
-%1051 = OpFunctionCall %ulong %6 %1048 %1050
-OpStore %330 %1051
-%1052 = OpLoad %double %465
-%1053 = OpFSub %double %double_0 %1052
-OpStore %331 %1053
-%1054 = OpLoad %double %331
-%1055 = OpLoad %double %423
-%1056 = OpFOrdLessThan %bool %1054 %1055
-OpStore %332 %1056
-%1057 = OpLoad %ulong %330
-%1058 = OpLoad %bool %332
-%1059 = OpSelect %uchar %1058 %uchar_1 %uchar_0
-%1060 = OpFunctionCall %ulong %6 %1057 %1059
-OpStore %333 %1060
-%1061 = OpLoad %ulong %333
-OpStore %403 %1061
-%1062 = OpLoad %double %453
-OpStore %404 %1062
-OpStore %405 %ulong_0
-OpBranch %60
-%60 = OpLabel
-%1064 = OpLoad %ulong %405
-%1066 = OpULessThan %bool %1064 %ulong_60
-OpStore %334 %1066
-%1067 = OpLoad %bool %334
-OpLoopMerge %62 %175 None
-OpBranchConditional %1067 %61 %62
-%62 = OpLabel
-OpStore %181 %1068
-%1070 = OpAccessChain %_ptr_Function_ulong %181 %uint_0
-OpStore %1070 %ulong_0
-%1072 = OpAccessChain %_ptr_Function_ulong %181 %uint_1
-OpStore %1072 %ulong_9223372036854775808
-%1074 = OpAccessChain %_ptr_Function_ulong %181 %uint_2
-OpStore %1074 %ulong_1
-%1076 = OpAccessChain %_ptr_Function_ulong %181 %uint_3
-OpStore %1076 %ulong_9218868437227405312
-%1078 = OpAccessChain %_ptr_Function_ulong %181 %uint_4
-OpStore %1078 %ulong_18442240474082181120
-%1080 = OpAccessChain %_ptr_Function_ulong %181 %uint_5
-OpStore %1080 %ulong_9221120237041090560
-%1082 = OpAccessChain %_ptr_Function_ulong %181 %uint_6
-OpStore %1082 %ulong_18444492273908506285
-%1085 = OpAccessChain %_ptr_Function_ulong %181 %uint_7
-OpStore %1085 %ulong_9218868437227405313
-%1087 = OpLoad %ulong %403
-OpStore %402 %1087
-OpStore %406 %ulong_0
-OpBranch %63
-%63 = OpLabel
-%1088 = OpLoad %ulong %406
-%1090 = OpULessThan %bool %1088 %ulong_8
-OpStore %337 %1090
-%1091 = OpLoad %bool %337
-OpLoopMerge %65 %174 None
-OpBranchConditional %1091 %64 %65
-%65 = OpLabel
-%1092 = OpLoad %double %447
-%1093 = OpFConvert %float %1092
-OpStore %345 %1093
-%1094 = OpLoad %double %465
-%1095 = OpFConvert %float %1094
-OpStore %346 %1095
-OpBranch %73
-%73 = OpLabel
-%1097 = OpLoad %ulong %182
-%1098 = OpIAdd %ulong %ulong_3936146074321813504 %1097
-OpStore %413 %1098
-%1099 = OpLoad %ulong %413
-%1100 = OpBitcast %double %1099
-OpStore %414 %1100
-OpBranch %74
-%74 = OpLabel
-%1101 = OpLoad %double %414
-%1102 = OpFConvert %float %1101
-OpStore %347 %1102
-OpBranch %77
-%77 = OpLabel
-%1104 = OpLoad %ulong %182
-%1105 = OpIAdd %ulong %ulong_4607182419068452864 %1104
-OpStore %417 %1105
-%1106 = OpLoad %ulong %417
-%1107 = OpBitcast %double %1106
-OpStore %418 %1107
-OpBranch %78
-%78 = OpLabel
-%1108 = OpLoad %double %418
-%1109 = OpFConvert %float %1108
-OpStore %348 %1109
-OpBranch %81
-%81 = OpLabel
-%1111 = OpLoad %ulong %182
-%1112 = OpIAdd %ulong %ulong_4607182419605323776 %1111
-OpStore %420 %1112
-%1113 = OpLoad %ulong %420
-%1114 = OpBitcast %double %1113
-OpStore %421 %1114
-OpBranch %82
-%82 = OpLabel
-%1115 = OpLoad %double %421
-%1116 = OpFConvert %float %1115
-OpStore %349 %1116
-%1117 = OpLoad %double %423
-%1118 = OpFConvert %float %1117
-OpStore %350 %1118
-%1119 = OpLoad %double %435
-%1120 = OpFConvert %float %1119
-OpStore %351 %1120
-%1121 = OpLoad %ulong %402
-%1122 = OpLoad %float %345
-%1123 = OpFunctionCall %ulong %10 %1121 %1122
-OpStore %352 %1123
-%1124 = OpLoad %ulong %352
-%1125 = OpLoad %float %346
-%1126 = OpFunctionCall %ulong %10 %1124 %1125
-OpStore %353 %1126
-%1127 = OpLoad %ulong %353
-%1128 = OpLoad %float %347
-%1129 = OpFunctionCall %ulong %10 %1127 %1128
-OpStore %354 %1129
-%1130 = OpLoad %ulong %354
-%1131 = OpLoad %float %348
-%1132 = OpFunctionCall %ulong %10 %1130 %1131
-OpStore %355 %1132
-%1133 = OpLoad %ulong %355
-%1134 = OpLoad %float %349
-%1135 = OpFunctionCall %ulong %10 %1133 %1134
-OpStore %356 %1135
-%1136 = OpLoad %ulong %356
-%1137 = OpLoad %float %350
-%1138 = OpFunctionCall %ulong %10 %1136 %1137
-OpStore %357 %1138
-%1139 = OpLoad %ulong %357
-%1140 = OpLoad %float %351
-%1141 = OpFunctionCall %ulong %10 %1139 %1140
-OpStore %358 %1141
-%1142 = OpLoad %float %347
-%1143 = OpFConvert %double %1142
-OpStore %359 %1143
-OpBranch %85
-%85 = OpLabel
-%1144 = OpLoad %double %359
-%1145 = OpLoad %double %359
-%1146 = OpFUnordNotEqual %bool %1144 %1145
-OpStore %424 %1146
-%1147 = OpLoad %bool %424
-OpSelectionMerge %89 None
-OpBranchConditional %1147 %86 %87
-%87 = OpLabel
-OpBranch %88
-%88 = OpLabel
-%1148 = OpLoad %ulong %358
-%1149 = OpLoad %double %359
-%1150 = OpFunctionCall %ulong %11 %1148 %1149
-OpStore %426 %1150
-%1151 = OpLoad %ulong %426
-OpStore %427 %1151
-OpBranch %89
-%86 = OpLabel
-%1152 = OpLoad %ulong %358
-%1153 = OpFunctionCall %ulong %5 %1152 %ulong_18446744073709551615
-OpStore %425 %1153
-%1154 = OpLoad %ulong %425
-OpStore %427 %1154
-OpBranch %89
-%89 = OpLabel
-%1155 = OpLoad %float %350
-%1156 = OpFConvert %double %1155
-OpStore %360 %1156
-OpBranch %92
-%92 = OpLabel
-%1157 = OpLoad %double %360
-%1158 = OpLoad %double %360
-%1159 = OpFUnordNotEqual %bool %1157 %1158
-OpStore %430 %1159
-%1160 = OpLoad %bool %430
-OpSelectionMerge %96 None
-OpBranchConditional %1160 %93 %94
-%94 = OpLabel
-OpBranch %95
-%95 = OpLabel
-%1161 = OpLoad %ulong %427
-%1162 = OpLoad %double %360
-%1163 = OpFunctionCall %ulong %11 %1161 %1162
-OpStore %432 %1163
-%1164 = OpLoad %ulong %432
-OpStore %433 %1164
-OpBranch %96
-%93 = OpLabel
-%1165 = OpLoad %ulong %427
-%1166 = OpFunctionCall %ulong %5 %1165 %ulong_18446744073709551615
-OpStore %431 %1166
-%1167 = OpLoad %ulong %431
-OpStore %433 %1167
-OpBranch %96
-%96 = OpLabel
-%1168 = OpLoad %float %351
-%1169 = OpFConvert %double %1168
-OpStore %361 %1169
-OpBranch %99
-%99 = OpLabel
-%1170 = OpLoad %double %361
-%1171 = OpLoad %double %361
-%1172 = OpFUnordNotEqual %bool %1170 %1171
-OpStore %436 %1172
-%1173 = OpLoad %bool %436
-OpSelectionMerge %103 None
-OpBranchConditional %1173 %100 %101
-%101 = OpLabel
-OpBranch %102
-%102 = OpLabel
-%1174 = OpLoad %ulong %433
-%1175 = OpLoad %double %361
-%1176 = OpFunctionCall %ulong %11 %1174 %1175
-OpStore %438 %1176
-%1177 = OpLoad %ulong %438
-OpStore %439 %1177
-OpBranch %103
-%100 = OpLabel
-%1178 = OpLoad %ulong %433
-%1179 = OpFunctionCall %ulong %5 %1178 %ulong_18446744073709551615
-OpStore %437 %1179
-%1180 = OpLoad %ulong %437
-OpStore %439 %1180
-OpBranch %103
-%103 = OpLabel
-%1182 = OpLoad %ulong %182
-%1183 = OpIAdd %ulong %ulong_9007199254740992 %1182
-OpStore %362 %1183
-%1185 = OpLoad %ulong %182
-%1186 = OpIAdd %ulong %ulong_9007199254740993 %1185
-OpStore %363 %1186
-%1188 = OpLoad %ulong %182
-%1189 = OpIAdd %ulong %ulong_9007199254740995 %1188
-OpStore %364 %1189
-%1190 = OpLoad %ulong %182
-%1191 = OpIAdd %ulong %ulong_18446744073709551615 %1190
-OpStore %365 %1191
-%1193 = OpLoad %ulong %182
-%1194 = OpIAdd %ulong %ulong_18437736874454810623 %1193
-OpStore %366 %1194
-%1195 = OpLoad %ulong %182
-%1196 = OpIAdd %ulong %ulong_9223372036854775808 %1195
-OpStore %367 %1196
-%1197 = OpLoad %ulong %362
-%1198 = OpConvertUToF %double %1197
-OpStore %368 %1198
-OpBranch %106
-%106 = OpLabel
-%1199 = OpLoad %double %368
-%1200 = OpLoad %double %368
-%1201 = OpFUnordNotEqual %bool %1199 %1200
-OpStore %442 %1201
-%1202 = OpLoad %bool %442
-OpSelectionMerge %110 None
-OpBranchConditional %1202 %107 %108
-%108 = OpLabel
-OpBranch %109
-%109 = OpLabel
-%1203 = OpLoad %ulong %439
-%1204 = OpLoad %double %368
-%1205 = OpFunctionCall %ulong %11 %1203 %1204
-OpStore %444 %1205
-%1206 = OpLoad %ulong %444
-OpStore %445 %1206
-OpBranch %110
-%107 = OpLabel
-%1207 = OpLoad %ulong %439
-%1208 = OpFunctionCall %ulong %5 %1207 %ulong_18446744073709551615
-OpStore %443 %1208
-%1209 = OpLoad %ulong %443
-OpStore %445 %1209
-OpBranch %110
-%110 = OpLabel
-%1210 = OpLoad %ulong %363
-%1211 = OpConvertUToF %double %1210
-OpStore %369 %1211
-OpBranch %113
-%113 = OpLabel
-%1212 = OpLoad %double %369
-%1213 = OpLoad %double %369
-%1214 = OpFUnordNotEqual %bool %1212 %1213
-OpStore %448 %1214
-%1215 = OpLoad %bool %448
-OpSelectionMerge %117 None
-OpBranchConditional %1215 %114 %115
-%115 = OpLabel
-OpBranch %116
-%116 = OpLabel
-%1216 = OpLoad %ulong %445
-%1217 = OpLoad %double %369
-%1218 = OpFunctionCall %ulong %11 %1216 %1217
-OpStore %450 %1218
-%1219 = OpLoad %ulong %450
-OpStore %451 %1219
-OpBranch %117
-%114 = OpLabel
-%1220 = OpLoad %ulong %445
-%1221 = OpFunctionCall %ulong %5 %1220 %ulong_18446744073709551615
-OpStore %449 %1221
-%1222 = OpLoad %ulong %449
-OpStore %451 %1222
-OpBranch %117
-%117 = OpLabel
-%1223 = OpLoad %ulong %364
-%1224 = OpConvertUToF %double %1223
-OpStore %370 %1224
-OpBranch %120
-%120 = OpLabel
-%1225 = OpLoad %double %370
-%1226 = OpLoad %double %370
-%1227 = OpFUnordNotEqual %bool %1225 %1226
-OpStore %454 %1227
-%1228 = OpLoad %bool %454
-OpSelectionMerge %124 None
-OpBranchConditional %1228 %121 %122
-%122 = OpLabel
-OpBranch %123
-%123 = OpLabel
-%1229 = OpLoad %ulong %451
-%1230 = OpLoad %double %370
-%1231 = OpFunctionCall %ulong %11 %1229 %1230
-OpStore %456 %1231
-%1232 = OpLoad %ulong %456
-OpStore %457 %1232
-OpBranch %124
-%121 = OpLabel
-%1233 = OpLoad %ulong %451
-%1234 = OpFunctionCall %ulong %5 %1233 %ulong_18446744073709551615
-OpStore %455 %1234
-%1235 = OpLoad %ulong %455
-OpStore %457 %1235
-OpBranch %124
-%124 = OpLabel
-%1236 = OpLoad %ulong %365
-%1237 = OpConvertUToF %double %1236
-OpStore %371 %1237
-OpBranch %127
-%127 = OpLabel
-%1238 = OpLoad %double %371
-%1239 = OpLoad %double %371
-%1240 = OpFUnordNotEqual %bool %1238 %1239
-OpStore %460 %1240
-%1241 = OpLoad %bool %460
-OpSelectionMerge %131 None
-OpBranchConditional %1241 %128 %129
+%1334 = OpLoad %ulong %570
+%1335 = OpULessThan %bool %1334 %ulong_8
+OpStore %562 %1335
+%1336 = OpLoad %bool %562
+OpLoopMerge %175 %287 None
+OpBranchConditional %1336 %174 %175
+%175 = OpLabel
+OpBranch %176
+%176 = OpLabel
+OpBranch %169
+%169 = OpLabel
+OpBranch %177
+%177 = OpLabel
+%1337 = OpLoad %float %459
+%1338 = OpBitcast %uint %1337
+OpStore %571 %1338
+%1339 = OpLoad %uint %571
+%1340 = OpUConvert %ulong %1339
+OpStore %572 %1340
+OpBranch %181
+%181 = OpLabel
+%1341 = OpLoad %ulong %569
+OpStore %582 %1341
+OpStore %583 %ulong_0
+OpBranch %182
+%182 = OpLabel
+%1342 = OpLoad %ulong %583
+%1343 = OpULessThan %bool %1342 %ulong_8
+OpStore %575 %1343
+%1344 = OpLoad %bool %575
+OpLoopMerge %184 %286 None
+OpBranchConditional %1344 %183 %184
+%184 = OpLabel
+OpBranch %185
+%185 = OpLabel
+OpBranch %178
+%178 = OpLabel
+OpBranch %186
+%186 = OpLabel
+%1345 = OpLoad %float %460
+%1346 = OpBitcast %uint %1345
+OpStore %584 %1346
+%1347 = OpLoad %uint %584
+%1348 = OpUConvert %ulong %1347
+OpStore %585 %1348
+OpBranch %190
+%190 = OpLabel
+%1349 = OpLoad %ulong %582
+OpStore %595 %1349
+OpStore %596 %ulong_0
+OpBranch %191
+%191 = OpLabel
+%1350 = OpLoad %ulong %596
+%1351 = OpULessThan %bool %1350 %ulong_8
+OpStore %588 %1351
+%1352 = OpLoad %bool %588
+OpLoopMerge %193 %285 None
+OpBranchConditional %1352 %192 %193
+%193 = OpLabel
+OpBranch %194
+%194 = OpLabel
+OpBranch %187
+%187 = OpLabel
+OpBranch %195
+%195 = OpLabel
+%1353 = OpLoad %float %461
+%1354 = OpBitcast %uint %1353
+OpStore %597 %1354
+%1355 = OpLoad %uint %597
+%1356 = OpUConvert %ulong %1355
+OpStore %598 %1356
+OpBranch %199
+%199 = OpLabel
+%1357 = OpLoad %ulong %595
+OpStore %608 %1357
+OpStore %609 %ulong_0
+OpBranch %200
+%200 = OpLabel
+%1358 = OpLoad %ulong %609
+%1359 = OpULessThan %bool %1358 %ulong_8
+OpStore %601 %1359
+%1360 = OpLoad %bool %601
+OpLoopMerge %202 %284 None
+OpBranchConditional %1360 %201 %202
+%202 = OpLabel
+OpBranch %203
+%203 = OpLabel
+OpBranch %196
+%196 = OpLabel
+OpBranch %204
+%204 = OpLabel
+%1361 = OpLoad %float %462
+%1362 = OpBitcast %uint %1361
+OpStore %610 %1362
+%1363 = OpLoad %uint %610
+%1364 = OpUConvert %ulong %1363
+OpStore %611 %1364
+OpBranch %208
+%208 = OpLabel
+%1365 = OpLoad %ulong %608
+OpStore %621 %1365
+OpStore %622 %ulong_0
+OpBranch %209
+%209 = OpLabel
+%1366 = OpLoad %ulong %622
+%1367 = OpULessThan %bool %1366 %ulong_8
+OpStore %614 %1367
+%1368 = OpLoad %bool %614
+OpLoopMerge %211 %283 None
+OpBranchConditional %1368 %210 %211
+%211 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%1369 = OpLoad %float %458
+%1370 = OpFConvert %double %1369
+OpStore %463 %1370
+%1371 = OpLoad %ulong %621
+%1372 = OpLoad %double %463
+%1373 = OpFunctionCall %ulong %2 %1371 %1372
+OpStore %464 %1373
+%1374 = OpLoad %float %461
+%1375 = OpFConvert %double %1374
+OpStore %465 %1375
+%1376 = OpLoad %ulong %464
+%1377 = OpLoad %double %465
+%1378 = OpFunctionCall %ulong %2 %1376 %1377
+OpStore %466 %1378
+%1379 = OpLoad %float %462
+%1380 = OpFConvert %double %1379
+OpStore %467 %1380
+%1381 = OpLoad %ulong %466
+%1382 = OpLoad %double %467
+%1383 = OpFunctionCall %ulong %2 %1381 %1382
+OpStore %468 %1383
+%1385 = OpLoad %ulong %301
+%1386 = OpIAdd %ulong %ulong_9007199254740992 %1385
+OpStore %469 %1386
+%1388 = OpLoad %ulong %301
+%1389 = OpIAdd %ulong %ulong_9007199254740993 %1388
+OpStore %470 %1389
+%1391 = OpLoad %ulong %301
+%1392 = OpIAdd %ulong %ulong_9007199254740995 %1391
+OpStore %471 %1392
+%1393 = OpLoad %ulong %301
+%1394 = OpIAdd %ulong %ulong_18446744073709551615 %1393
+OpStore %472 %1394
+%1396 = OpLoad %ulong %301
+%1397 = OpIAdd %ulong %ulong_18437736874454810623 %1396
+OpStore %473 %1397
+%1398 = OpLoad %ulong %301
+%1399 = OpIAdd %ulong %ulong_9223372036854775808 %1398
+OpStore %474 %1399
+%1400 = OpLoad %ulong %469
+%1401 = OpConvertUToF %double %1400
+OpStore %475 %1401
+%1402 = OpLoad %ulong %468
+%1403 = OpLoad %double %475
+%1404 = OpFunctionCall %ulong %2 %1402 %1403
+OpStore %476 %1404
+%1405 = OpLoad %ulong %470
+%1406 = OpConvertUToF %double %1405
+OpStore %477 %1406
+%1407 = OpLoad %ulong %476
+%1408 = OpLoad %double %477
+%1409 = OpFunctionCall %ulong %2 %1407 %1408
+OpStore %478 %1409
+%1410 = OpLoad %ulong %471
+%1411 = OpConvertUToF %double %1410
+OpStore %479 %1411
+%1412 = OpLoad %ulong %478
+%1413 = OpLoad %double %479
+%1414 = OpFunctionCall %ulong %2 %1412 %1413
+OpStore %480 %1414
+%1415 = OpLoad %ulong %472
+%1416 = OpConvertUToF %double %1415
+OpStore %481 %1416
+%1417 = OpLoad %ulong %480
+%1418 = OpLoad %double %481
+%1419 = OpFunctionCall %ulong %2 %1417 %1418
+OpStore %482 %1419
+%1420 = OpLoad %ulong %301
+%1421 = OpConvertUToF %double %1420
+OpStore %483 %1421
+%1422 = OpLoad %ulong %482
+%1423 = OpLoad %double %483
+%1424 = OpFunctionCall %ulong %2 %1422 %1423
+OpStore %484 %1424
+%1425 = OpLoad %ulong %473
+%1426 = OpConvertSToF %double %1425
+OpStore %485 %1426
+%1427 = OpLoad %ulong %484
+%1428 = OpLoad %double %485
+%1429 = OpFunctionCall %ulong %2 %1427 %1428
+OpStore %486 %1429
+%1430 = OpLoad %ulong %474
+%1431 = OpConvertSToF %double %1430
+OpStore %487 %1431
+%1432 = OpLoad %ulong %486
+%1433 = OpLoad %double %487
+%1434 = OpFunctionCall %ulong %2 %1432 %1433
+OpStore %488 %1434
+%1435 = OpLoad %double %524
+%1436 = OpFMul %double %double_1_5 %1435
+OpStore %489 %1436
+%1438 = OpLoad %double %524
+%1439 = OpFMul %double %double_9007199254740992 %1438
+OpStore %490 %1439
+%1441 = OpLoad %double %524
+%1442 = OpFMul %double %double_4_6116860184273879e_18 %1441
+OpStore %491 %1442
+%1443 = OpLoad %double %489
+%1444 = OpFSub %double %double_0 %1443
+OpStore %492 %1444
+%1445 = OpLoad %double %524
+%1446 = OpFMul %double %double_0_5 %1445
+OpStore %493 %1446
+%1447 = OpLoad %double %489
+%1448 = OpConvertFToU %ulong %1447
+OpStore %494 %1448
+OpBranch %213
+%213 = OpLabel
+%1449 = OpLoad %ulong %488
+OpStore %630 %1449
+OpStore %631 %ulong_0
+OpBranch %214
+%214 = OpLabel
+%1450 = OpLoad %ulong %631
+%1451 = OpULessThan %bool %1450 %ulong_8
+OpStore %623 %1451
+%1452 = OpLoad %bool %623
+OpLoopMerge %216 %282 None
+OpBranchConditional %1452 %215 %216
+%216 = OpLabel
+OpBranch %217
+%217 = OpLabel
+%1453 = OpLoad %double %490
+%1454 = OpConvertFToU %ulong %1453
+OpStore %495 %1454
+OpBranch %220
+%220 = OpLabel
+%1455 = OpLoad %ulong %630
+OpStore %641 %1455
+OpStore %642 %ulong_0
+OpBranch %221
+%221 = OpLabel
+%1456 = OpLoad %ulong %642
+%1457 = OpULessThan %bool %1456 %ulong_8
+OpStore %634 %1457
+%1458 = OpLoad %bool %634
+OpLoopMerge %223 %281 None
+OpBranchConditional %1458 %222 %223
+%223 = OpLabel
+OpBranch %224
+%224 = OpLabel
+%1459 = OpLoad %double %491
+%1460 = OpConvertFToU %ulong %1459
+OpStore %496 %1460
+OpBranch %227
+%227 = OpLabel
+%1461 = OpLoad %ulong %641
+OpStore %651 %1461
+OpStore %652 %ulong_0
+OpBranch %228
+%228 = OpLabel
+%1462 = OpLoad %ulong %652
+%1463 = OpULessThan %bool %1462 %ulong_8
+OpStore %644 %1463
+%1464 = OpLoad %bool %644
+OpLoopMerge %230 %280 None
+OpBranchConditional %1464 %229 %230
+%230 = OpLabel
+OpBranch %231
+%231 = OpLabel
+%1465 = OpLoad %double %493
+%1466 = OpConvertFToU %ulong %1465
+OpStore %497 %1466
+OpBranch %239
+%239 = OpLabel
+%1467 = OpLoad %ulong %651
+OpStore %670 %1467
+OpStore %671 %ulong_0
+OpBranch %240
+%240 = OpLabel
+%1468 = OpLoad %ulong %671
+%1469 = OpULessThan %bool %1468 %ulong_8
+OpStore %663 %1469
+%1470 = OpLoad %bool %663
+OpLoopMerge %242 %279 None
+OpBranchConditional %1470 %241 %242
+%242 = OpLabel
+OpBranch %243
+%243 = OpLabel
+%1471 = OpLoad %double %531
+%1472 = OpConvertFToU %ulong %1471
+OpStore %498 %1472
+%1473 = OpLoad %ulong %670
+%1474 = OpLoad %ulong %498
+%1475 = OpFunctionCall %ulong %4 %1473 %1474
+OpStore %499 %1475
+%1476 = OpLoad %double %492
+%1477 = OpConvertFToS %ulong %1476
+OpStore %500 %1477
+OpBranch %251
+%251 = OpLabel
+%1478 = OpLoad %ulong %499
+%1479 = OpLoad %ulong %500
+%1480 = OpFunctionCall %ulong %4 %1478 %1479
+OpStore %683 %1480
+OpBranch %252
+%252 = OpLabel
+%1481 = OpLoad %double %491
+%1482 = OpConvertFToS %ulong %1481
+OpStore %501 %1482
+OpBranch %255
+%255 = OpLabel
+%1483 = OpLoad %ulong %683
+%1484 = OpLoad %ulong %501
+%1485 = OpFunctionCall %ulong %4 %1483 %1484
+OpStore %686 %1485
+OpBranch %256
+%256 = OpLabel
+%1486 = OpLoad %double %493
+%1487 = OpFSub %double %double_0 %1486
+OpStore %502 %1487
+%1488 = OpLoad %double %502
+%1489 = OpConvertFToS %ulong %1488
+OpStore %503 %1489
+OpBranch %259
+%259 = OpLabel
+%1490 = OpLoad %ulong %686
+%1491 = OpLoad %ulong %503
+%1492 = OpFunctionCall %ulong %4 %1490 %1491
+OpStore %689 %1492
+OpBranch %260
+%260 = OpLabel
+%1493 = OpLoad %double %492
+%1494 = OpConvertFToS %uint %1493
+OpStore %505 %1494
+OpBranch %263
+%263 = OpLabel
+%1495 = OpLoad %uint %505
+%1496 = OpSConvert %ulong %1495
+OpStore %692 %1496
+%1497 = OpLoad %ulong %689
+%1498 = OpLoad %ulong %692
+%1499 = OpFunctionCall %ulong %4 %1497 %1498
+OpStore %693 %1499
+OpBranch %264
+%264 = OpLabel
+%1500 = OpLoad %double %489
+%1501 = OpConvertFToU %uint %1500
+OpStore %506 %1501
+OpBranch %267
+%267 = OpLabel
+%1502 = OpLoad %uint %506
+%1503 = OpUConvert %ulong %1502
+OpStore %696 %1503
+%1504 = OpLoad %ulong %693
+%1505 = OpLoad %ulong %696
+%1506 = OpFunctionCall %ulong %4 %1504 %1505
+OpStore %697 %1506
+OpBranch %268
+%268 = OpLabel
+%1507 = OpLoad %ulong %697
+OpReturnValue %1507
+%241 = OpLabel
+%1508 = OpLoad %ulong %671
+%1509 = OpIMul %ulong %1508 %ulong_8
+OpStore %664 %1509
+%1510 = OpLoad %ulong %497
+%1511 = OpLoad %ulong %664
+%1512 = OpShiftRightLogical %ulong %1510 %1511
+OpStore %665 %1512
+%1513 = OpLoad %ulong %665
+%1514 = OpBitwiseAnd %ulong %1513 %ulong_255
+OpStore %666 %1514
+%1515 = OpLoad %ulong %670
+%1516 = OpLoad %ulong %666
+%1517 = OpBitwiseXor %ulong %1515 %1516
+OpStore %667 %1517
+%1518 = OpLoad %ulong %667
+%1519 = OpIMul %ulong %1518 %ulong_1099511628211
+OpStore %668 %1519
+%1520 = OpLoad %ulong %671
+%1521 = OpIAdd %ulong %1520 %ulong_1
+OpStore %669 %1521
+%1522 = OpLoad %ulong %668
+OpStore %670 %1522
+%1523 = OpLoad %ulong %669
+OpStore %671 %1523
+OpBranch %279
+%229 = OpLabel
+%1524 = OpLoad %ulong %652
+%1525 = OpIMul %ulong %1524 %ulong_8
+OpStore %645 %1525
+%1526 = OpLoad %ulong %496
+%1527 = OpLoad %ulong %645
+%1528 = OpShiftRightLogical %ulong %1526 %1527
+OpStore %646 %1528
+%1529 = OpLoad %ulong %646
+%1530 = OpBitwiseAnd %ulong %1529 %ulong_255
+OpStore %647 %1530
+%1531 = OpLoad %ulong %651
+%1532 = OpLoad %ulong %647
+%1533 = OpBitwiseXor %ulong %1531 %1532
+OpStore %648 %1533
+%1534 = OpLoad %ulong %648
+%1535 = OpIMul %ulong %1534 %ulong_1099511628211
+OpStore %649 %1535
+%1536 = OpLoad %ulong %652
+%1537 = OpIAdd %ulong %1536 %ulong_1
+OpStore %650 %1537
+%1538 = OpLoad %ulong %649
+OpStore %651 %1538
+%1539 = OpLoad %ulong %650
+OpStore %652 %1539
+OpBranch %280
+%222 = OpLabel
+%1540 = OpLoad %ulong %642
+%1541 = OpIMul %ulong %1540 %ulong_8
+OpStore %635 %1541
+%1542 = OpLoad %ulong %495
+%1543 = OpLoad %ulong %635
+%1544 = OpShiftRightLogical %ulong %1542 %1543
+OpStore %636 %1544
+%1545 = OpLoad %ulong %636
+%1546 = OpBitwiseAnd %ulong %1545 %ulong_255
+OpStore %637 %1546
+%1547 = OpLoad %ulong %641
+%1548 = OpLoad %ulong %637
+%1549 = OpBitwiseXor %ulong %1547 %1548
+OpStore %638 %1549
+%1550 = OpLoad %ulong %638
+%1551 = OpIMul %ulong %1550 %ulong_1099511628211
+OpStore %639 %1551
+%1552 = OpLoad %ulong %642
+%1553 = OpIAdd %ulong %1552 %ulong_1
+OpStore %640 %1553
+%1554 = OpLoad %ulong %639
+OpStore %641 %1554
+%1555 = OpLoad %ulong %640
+OpStore %642 %1555
+OpBranch %281
+%215 = OpLabel
+%1556 = OpLoad %ulong %631
+%1557 = OpIMul %ulong %1556 %ulong_8
+OpStore %624 %1557
+%1558 = OpLoad %ulong %494
+%1559 = OpLoad %ulong %624
+%1560 = OpShiftRightLogical %ulong %1558 %1559
+OpStore %625 %1560
+%1561 = OpLoad %ulong %625
+%1562 = OpBitwiseAnd %ulong %1561 %ulong_255
+OpStore %626 %1562
+%1563 = OpLoad %ulong %630
+%1564 = OpLoad %ulong %626
+%1565 = OpBitwiseXor %ulong %1563 %1564
+OpStore %627 %1565
+%1566 = OpLoad %ulong %627
+%1567 = OpIMul %ulong %1566 %ulong_1099511628211
+OpStore %628 %1567
+%1568 = OpLoad %ulong %631
+%1569 = OpIAdd %ulong %1568 %ulong_1
+OpStore %629 %1569
+%1570 = OpLoad %ulong %628
+OpStore %630 %1570
+%1571 = OpLoad %ulong %629
+OpStore %631 %1571
+OpBranch %282
+%210 = OpLabel
+%1572 = OpLoad %ulong %622
+%1573 = OpIMul %ulong %1572 %ulong_8
+OpStore %615 %1573
+%1574 = OpLoad %ulong %611
+%1575 = OpLoad %ulong %615
+%1576 = OpShiftRightLogical %ulong %1574 %1575
+OpStore %616 %1576
+%1577 = OpLoad %ulong %616
+%1578 = OpBitwiseAnd %ulong %1577 %ulong_255
+OpStore %617 %1578
+%1579 = OpLoad %ulong %621
+%1580 = OpLoad %ulong %617
+%1581 = OpBitwiseXor %ulong %1579 %1580
+OpStore %618 %1581
+%1582 = OpLoad %ulong %618
+%1583 = OpIMul %ulong %1582 %ulong_1099511628211
+OpStore %619 %1583
+%1584 = OpLoad %ulong %622
+%1585 = OpIAdd %ulong %1584 %ulong_1
+OpStore %620 %1585
+%1586 = OpLoad %ulong %619
+OpStore %621 %1586
+%1587 = OpLoad %ulong %620
+OpStore %622 %1587
+OpBranch %283
+%201 = OpLabel
+%1588 = OpLoad %ulong %609
+%1589 = OpIMul %ulong %1588 %ulong_8
+OpStore %602 %1589
+%1590 = OpLoad %ulong %598
+%1591 = OpLoad %ulong %602
+%1592 = OpShiftRightLogical %ulong %1590 %1591
+OpStore %603 %1592
+%1593 = OpLoad %ulong %603
+%1594 = OpBitwiseAnd %ulong %1593 %ulong_255
+OpStore %604 %1594
+%1595 = OpLoad %ulong %608
+%1596 = OpLoad %ulong %604
+%1597 = OpBitwiseXor %ulong %1595 %1596
+OpStore %605 %1597
+%1598 = OpLoad %ulong %605
+%1599 = OpIMul %ulong %1598 %ulong_1099511628211
+OpStore %606 %1599
+%1600 = OpLoad %ulong %609
+%1601 = OpIAdd %ulong %1600 %ulong_1
+OpStore %607 %1601
+%1602 = OpLoad %ulong %606
+OpStore %608 %1602
+%1603 = OpLoad %ulong %607
+OpStore %609 %1603
+OpBranch %284
+%192 = OpLabel
+%1604 = OpLoad %ulong %596
+%1605 = OpIMul %ulong %1604 %ulong_8
+OpStore %589 %1605
+%1606 = OpLoad %ulong %585
+%1607 = OpLoad %ulong %589
+%1608 = OpShiftRightLogical %ulong %1606 %1607
+OpStore %590 %1608
+%1609 = OpLoad %ulong %590
+%1610 = OpBitwiseAnd %ulong %1609 %ulong_255
+OpStore %591 %1610
+%1611 = OpLoad %ulong %595
+%1612 = OpLoad %ulong %591
+%1613 = OpBitwiseXor %ulong %1611 %1612
+OpStore %592 %1613
+%1614 = OpLoad %ulong %592
+%1615 = OpIMul %ulong %1614 %ulong_1099511628211
+OpStore %593 %1615
+%1616 = OpLoad %ulong %596
+%1617 = OpIAdd %ulong %1616 %ulong_1
+OpStore %594 %1617
+%1618 = OpLoad %ulong %593
+OpStore %595 %1618
+%1619 = OpLoad %ulong %594
+OpStore %596 %1619
+OpBranch %285
+%183 = OpLabel
+%1620 = OpLoad %ulong %583
+%1621 = OpIMul %ulong %1620 %ulong_8
+OpStore %576 %1621
+%1622 = OpLoad %ulong %572
+%1623 = OpLoad %ulong %576
+%1624 = OpShiftRightLogical %ulong %1622 %1623
+OpStore %577 %1624
+%1625 = OpLoad %ulong %577
+%1626 = OpBitwiseAnd %ulong %1625 %ulong_255
+OpStore %578 %1626
+%1627 = OpLoad %ulong %582
+%1628 = OpLoad %ulong %578
+%1629 = OpBitwiseXor %ulong %1627 %1628
+OpStore %579 %1629
+%1630 = OpLoad %ulong %579
+%1631 = OpIMul %ulong %1630 %ulong_1099511628211
+OpStore %580 %1631
+%1632 = OpLoad %ulong %583
+%1633 = OpIAdd %ulong %1632 %ulong_1
+OpStore %581 %1633
+%1634 = OpLoad %ulong %580
+OpStore %582 %1634
+%1635 = OpLoad %ulong %581
+OpStore %583 %1635
+OpBranch %286
+%174 = OpLabel
+%1636 = OpLoad %ulong %570
+%1637 = OpIMul %ulong %1636 %ulong_8
+OpStore %563 %1637
+%1638 = OpLoad %ulong %559
+%1639 = OpLoad %ulong %563
+%1640 = OpShiftRightLogical %ulong %1638 %1639
+OpStore %564 %1640
+%1641 = OpLoad %ulong %564
+%1642 = OpBitwiseAnd %ulong %1641 %ulong_255
+OpStore %565 %1642
+%1643 = OpLoad %ulong %569
+%1644 = OpLoad %ulong %565
+%1645 = OpBitwiseXor %ulong %1643 %1644
+OpStore %566 %1645
+%1646 = OpLoad %ulong %566
+%1647 = OpIMul %ulong %1646 %ulong_1099511628211
+OpStore %567 %1647
+%1648 = OpLoad %ulong %570
+%1649 = OpIAdd %ulong %1648 %ulong_1
+OpStore %568 %1649
+%1650 = OpLoad %ulong %567
+OpStore %569 %1650
+%1651 = OpLoad %ulong %568
+OpStore %570 %1651
+OpBranch %287
+%165 = OpLabel
+%1652 = OpLoad %ulong %557
+%1653 = OpIMul %ulong %1652 %ulong_8
+OpStore %550 %1653
+%1654 = OpLoad %ulong %546
+%1655 = OpLoad %ulong %550
+%1656 = OpShiftRightLogical %ulong %1654 %1655
+OpStore %551 %1656
+%1657 = OpLoad %ulong %551
+%1658 = OpBitwiseAnd %ulong %1657 %ulong_255
+OpStore %552 %1658
+%1659 = OpLoad %ulong %556
+%1660 = OpLoad %ulong %552
+%1661 = OpBitwiseXor %ulong %1659 %1660
+OpStore %553 %1661
+%1662 = OpLoad %ulong %553
+%1663 = OpIMul %ulong %1662 %ulong_1099511628211
+OpStore %554 %1663
+%1664 = OpLoad %ulong %557
+%1665 = OpIAdd %ulong %1664 %ulong_1
+OpStore %555 %1665
+%1666 = OpLoad %ulong %554
+OpStore %556 %1666
+%1667 = OpLoad %ulong %555
+OpStore %557 %1667
+OpBranch %288
+%156 = OpLabel
+%1668 = OpLoad %ulong %544
+%1669 = OpIMul %ulong %1668 %ulong_8
+OpStore %537 %1669
+%1670 = OpLoad %ulong %533
+%1671 = OpLoad %ulong %537
+%1672 = OpShiftRightLogical %ulong %1670 %1671
+OpStore %538 %1672
+%1673 = OpLoad %ulong %538
+%1674 = OpBitwiseAnd %ulong %1673 %ulong_255
+OpStore %539 %1674
+%1675 = OpLoad %ulong %543
+%1676 = OpLoad %ulong %539
+%1677 = OpBitwiseXor %ulong %1675 %1676
+OpStore %540 %1677
+%1678 = OpLoad %ulong %540
+%1679 = OpIMul %ulong %1678 %ulong_1099511628211
+OpStore %541 %1679
+%1680 = OpLoad %ulong %544
+%1681 = OpIAdd %ulong %1680 %ulong_1
+OpStore %542 %1681
+%1682 = OpLoad %ulong %541
+OpStore %543 %1682
+%1683 = OpLoad %ulong %542
+OpStore %544 %1683
+OpBranch %289
 %129 = OpLabel
-OpBranch %130
-%130 = OpLabel
-%1242 = OpLoad %ulong %457
-%1243 = OpLoad %double %371
-%1244 = OpFunctionCall %ulong %11 %1242 %1243
-OpStore %462 %1244
-%1245 = OpLoad %ulong %462
-OpStore %463 %1245
-OpBranch %131
-%128 = OpLabel
-%1246 = OpLoad %ulong %457
-%1247 = OpFunctionCall %ulong %5 %1246 %ulong_18446744073709551615
-OpStore %461 %1247
-%1248 = OpLoad %ulong %461
-OpStore %463 %1248
-OpBranch %131
-%131 = OpLabel
-%1249 = OpLoad %ulong %182
-%1250 = OpConvertUToF %double %1249
-OpStore %372 %1250
+%1684 = OpLoad %ulong %511
+%1685 = OpAccessChain %_ptr_Function_ulong %300 %1684
+%1686 = OpLoad %ulong %1685
+OpStore %450 %1686
+%1687 = OpLoad %ulong %450
+%1688 = OpLoad %ulong %301
+%1689 = OpIAdd %ulong %1687 %1688
+OpStore %451 %1689
+%1690 = OpLoad %ulong %451
+%1691 = OpBitcast %double %1690
+OpStore %452 %1691
+%1692 = OpLoad %double %452
+%1693 = OpBitcast %ulong %1692
+OpStore %453 %1693
+OpBranch %133
+%133 = OpLabel
+%1694 = OpLoad %ulong %507
+OpStore %519 %1694
+OpStore %520 %ulong_0
 OpBranch %134
 %134 = OpLabel
-%1251 = OpLoad %double %372
-%1252 = OpLoad %double %372
-%1253 = OpFUnordNotEqual %bool %1251 %1252
-OpStore %466 %1253
-%1254 = OpLoad %bool %466
-OpSelectionMerge %138 None
-OpBranchConditional %1254 %135 %136
+%1695 = OpLoad %ulong %520
+%1696 = OpULessThan %bool %1695 %ulong_8
+OpStore %512 %1696
+%1697 = OpLoad %bool %512
+OpLoopMerge %136 %290 None
+OpBranchConditional %1697 %135 %136
 %136 = OpLabel
 OpBranch %137
 %137 = OpLabel
-%1255 = OpLoad %ulong %463
-%1256 = OpLoad %double %372
-%1257 = OpFunctionCall %ulong %11 %1255 %1256
-OpStore %468 %1257
-%1258 = OpLoad %ulong %468
-OpStore %469 %1258
-OpBranch %138
+%1698 = OpLoad %ulong %511
+%1699 = OpIAdd %ulong %1698 %ulong_1
+OpStore %454 %1699
+%1700 = OpLoad %ulong %519
+OpStore %507 %1700
+%1701 = OpLoad %ulong %454
+OpStore %511 %1701
+OpBranch %291
 %135 = OpLabel
-%1259 = OpLoad %ulong %463
-%1260 = OpFunctionCall %ulong %5 %1259 %ulong_18446744073709551615
-OpStore %467 %1260
-%1261 = OpLoad %ulong %467
-OpStore %469 %1261
-OpBranch %138
-%138 = OpLabel
-%1262 = OpLoad %ulong %366
-%1263 = OpConvertSToF %double %1262
-OpStore %373 %1263
-OpBranch %144
-%144 = OpLabel
-%1264 = OpLoad %double %373
-%1265 = OpLoad %double %373
-%1266 = OpFUnordNotEqual %bool %1264 %1265
-OpStore %474 %1266
-%1267 = OpLoad %bool %474
-OpSelectionMerge %148 None
-OpBranchConditional %1267 %145 %146
-%146 = OpLabel
-OpBranch %147
-%147 = OpLabel
-%1268 = OpLoad %ulong %469
-%1269 = OpLoad %double %373
-%1270 = OpFunctionCall %ulong %11 %1268 %1269
-OpStore %476 %1270
-%1271 = OpLoad %ulong %476
-OpStore %477 %1271
-OpBranch %148
-%145 = OpLabel
-%1272 = OpLoad %ulong %469
-%1273 = OpFunctionCall %ulong %5 %1272 %ulong_18446744073709551615
-OpStore %475 %1273
-%1274 = OpLoad %ulong %475
-OpStore %477 %1274
-OpBranch %148
-%148 = OpLabel
-%1275 = OpLoad %ulong %367
-%1276 = OpConvertSToF %double %1275
-OpStore %374 %1276
-OpBranch %154
-%154 = OpLabel
-%1277 = OpLoad %double %374
-%1278 = OpLoad %double %374
-%1279 = OpFUnordNotEqual %bool %1277 %1278
-OpStore %482 %1279
-%1280 = OpLoad %bool %482
-OpSelectionMerge %158 None
-OpBranchConditional %1280 %155 %156
-%156 = OpLabel
-OpBranch %157
-%157 = OpLabel
-%1281 = OpLoad %ulong %477
-%1282 = OpLoad %double %374
-%1283 = OpFunctionCall %ulong %11 %1281 %1282
-OpStore %484 %1283
-%1284 = OpLoad %ulong %484
-OpStore %485 %1284
-OpBranch %158
-%155 = OpLabel
-%1285 = OpLoad %ulong %477
-%1286 = OpFunctionCall %ulong %5 %1285 %ulong_18446744073709551615
-OpStore %483 %1286
-%1287 = OpLoad %ulong %483
-OpStore %485 %1287
-OpBranch %158
-%158 = OpLabel
-%1288 = OpLoad %double %408
-%1289 = OpFMul %double %double_1_5 %1288
-OpStore %375 %1289
-%1291 = OpLoad %double %408
-%1292 = OpFMul %double %double_9007199254740992 %1291
-OpStore %376 %1292
-%1294 = OpLoad %double %408
-%1295 = OpFMul %double %double_4_6116860184273879e_18 %1294
-OpStore %377 %1295
-%1296 = OpLoad %double %375
-%1297 = OpFSub %double %double_0 %1296
-OpStore %378 %1297
-%1298 = OpLoad %double %408
-%1299 = OpFMul %double %double_0_5 %1298
-OpStore %379 %1299
-%1300 = OpLoad %double %375
-%1301 = OpConvertFToU %ulong %1300
-OpStore %380 %1301
-%1302 = OpLoad %ulong %485
-%1303 = OpLoad %ulong %380
-%1304 = OpFunctionCall %ulong %5 %1302 %1303
-OpStore %381 %1304
-%1305 = OpLoad %double %376
-%1306 = OpConvertFToU %ulong %1305
-OpStore %382 %1306
-%1307 = OpLoad %ulong %381
-%1308 = OpLoad %ulong %382
-%1309 = OpFunctionCall %ulong %5 %1307 %1308
-OpStore %383 %1309
-%1310 = OpLoad %double %377
-%1311 = OpConvertFToU %ulong %1310
-OpStore %384 %1311
-%1312 = OpLoad %ulong %383
-%1313 = OpLoad %ulong %384
-%1314 = OpFunctionCall %ulong %5 %1312 %1313
-OpStore %385 %1314
-%1315 = OpLoad %double %379
-%1316 = OpConvertFToU %ulong %1315
-OpStore %386 %1316
-%1317 = OpLoad %ulong %385
-%1318 = OpLoad %ulong %386
-%1319 = OpFunctionCall %ulong %5 %1317 %1318
-OpStore %387 %1319
-%1320 = OpLoad %double %419
-%1321 = OpConvertFToU %ulong %1320
-OpStore %388 %1321
-%1322 = OpLoad %ulong %387
-%1323 = OpLoad %ulong %388
-%1324 = OpFunctionCall %ulong %5 %1322 %1323
-OpStore %389 %1324
-%1325 = OpLoad %double %378
-%1326 = OpConvertFToS %ulong %1325
-OpStore %390 %1326
-%1327 = OpLoad %ulong %389
-%1328 = OpLoad %ulong %390
-%1329 = OpFunctionCall %ulong %9 %1327 %1328
-OpStore %391 %1329
-%1330 = OpLoad %double %377
-%1331 = OpConvertFToS %ulong %1330
-OpStore %392 %1331
-%1332 = OpLoad %ulong %391
-%1333 = OpLoad %ulong %392
-%1334 = OpFunctionCall %ulong %9 %1332 %1333
-OpStore %393 %1334
-%1335 = OpLoad %double %379
-%1336 = OpFSub %double %double_0 %1335
-OpStore %394 %1336
-%1337 = OpLoad %double %394
-%1338 = OpConvertFToS %ulong %1337
-OpStore %395 %1338
-%1339 = OpLoad %ulong %393
-%1340 = OpLoad %ulong %395
-%1341 = OpFunctionCall %ulong %9 %1339 %1340
-OpStore %396 %1341
-%1342 = OpLoad %double %378
-%1343 = OpConvertFToS %uint %1342
-OpStore %398 %1343
-%1344 = OpLoad %ulong %396
-%1345 = OpLoad %uint %398
-%1346 = OpFunctionCall %ulong %8 %1344 %1345
-OpStore %399 %1346
-%1347 = OpLoad %double %375
-%1348 = OpConvertFToU %uint %1347
-OpStore %400 %1348
-%1349 = OpLoad %ulong %399
-%1350 = OpLoad %uint %400
-%1351 = OpFunctionCall %ulong %7 %1349 %1350
-OpStore %401 %1351
-%1352 = OpLoad %ulong %401
-OpReturnValue %1352
-%64 = OpLabel
-%1353 = OpLoad %ulong %406
-%1354 = OpAccessChain %_ptr_Function_ulong %181 %1353
-%1355 = OpLoad %ulong %1354
-OpStore %338 %1355
-%1356 = OpLoad %ulong %338
-%1357 = OpLoad %ulong %182
-%1358 = OpIAdd %ulong %1356 %1357
-OpStore %339 %1358
-%1359 = OpLoad %ulong %339
-%1360 = OpBitcast %double %1359
-OpStore %340 %1360
-%1361 = OpLoad %double %340
-%1362 = OpBitcast %ulong %1361
-OpStore %341 %1362
-%1363 = OpLoad %ulong %402
-%1364 = OpLoad %ulong %341
-%1365 = OpFunctionCall %ulong %5 %1363 %1364
-OpStore %342 %1365
-%1366 = OpLoad %ulong %406
-%1367 = OpIAdd %ulong %1366 %ulong_1
-OpStore %343 %1367
-%1368 = OpLoad %ulong %342
-OpStore %402 %1368
-%1369 = OpLoad %ulong %343
-OpStore %406 %1369
-OpBranch %174
-%61 = OpLabel
-%1370 = OpLoad %double %404
-%1371 = OpFMul %double %1370 %double_0_5
-OpStore %335 %1371
-OpBranch %68
-%68 = OpLabel
-%1372 = OpLoad %double %335
-%1373 = OpLoad %double %335
-%1374 = OpFUnordNotEqual %bool %1372 %1373
-OpStore %409 %1374
-%1375 = OpLoad %bool %409
-OpSelectionMerge %72 None
-OpBranchConditional %1375 %69 %70
-%70 = OpLabel
-OpBranch %71
-%71 = OpLabel
-%1376 = OpLoad %ulong %403
-%1377 = OpLoad %double %335
-%1378 = OpFunctionCall %ulong %11 %1376 %1377
-OpStore %411 %1378
-%1379 = OpLoad %ulong %411
-OpStore %412 %1379
-OpBranch %72
-%69 = OpLabel
-%1380 = OpLoad %ulong %403
-%1381 = OpFunctionCall %ulong %5 %1380 %ulong_18446744073709551615
-OpStore %410 %1381
-%1382 = OpLoad %ulong %410
-OpStore %412 %1382
-OpBranch %72
-%72 = OpLabel
-%1383 = OpLoad %ulong %405
-%1384 = OpIAdd %ulong %1383 %ulong_1
-OpStore %336 %1384
-%1385 = OpLoad %ulong %412
-OpStore %403 %1385
-%1386 = OpLoad %double %335
-OpStore %404 %1386
-%1387 = OpLoad %ulong %336
-OpStore %405 %1387
-OpBranch %175
-%174 = OpLabel
-OpBranch %63
-%175 = OpLabel
-OpBranch %60
+%1702 = OpLoad %ulong %520
+%1703 = OpIMul %ulong %1702 %ulong_8
+OpStore %513 %1703
+%1704 = OpLoad %ulong %453
+%1705 = OpLoad %ulong %513
+%1706 = OpShiftRightLogical %ulong %1704 %1705
+OpStore %514 %1706
+%1707 = OpLoad %ulong %514
+%1708 = OpBitwiseAnd %ulong %1707 %ulong_255
+OpStore %515 %1708
+%1709 = OpLoad %ulong %519
+%1710 = OpLoad %ulong %515
+%1711 = OpBitwiseXor %ulong %1709 %1710
+OpStore %516 %1711
+%1712 = OpLoad %ulong %516
+%1713 = OpIMul %ulong %1712 %ulong_1099511628211
+OpStore %517 %1713
+%1714 = OpLoad %ulong %520
+%1715 = OpIAdd %ulong %1714 %ulong_1
+OpStore %518 %1715
+%1716 = OpLoad %ulong %517
+OpStore %519 %1716
+%1717 = OpLoad %ulong %518
+OpStore %520 %1717
+OpBranch %290
+%126 = OpLabel
+%1718 = OpLoad %double %509
+%1719 = OpFMul %double %1718 %double_0_5
+OpStore %446 %1719
+%1720 = OpLoad %ulong %508
+%1721 = OpLoad %double %446
+%1722 = OpFunctionCall %ulong %2 %1720 %1721
+OpStore %447 %1722
+%1723 = OpLoad %ulong %510
+%1724 = OpIAdd %ulong %1723 %ulong_1
+OpStore %448 %1724
+%1725 = OpLoad %ulong %447
+OpStore %508 %1725
+%1726 = OpLoad %double %446
+OpStore %509 %1726
+%1727 = OpLoad %ulong %448
+OpStore %510 %1727
+OpBranch %292
+%246 = OpLabel
+%1728 = OpLoad %ulong %680
+%1729 = OpIMul %ulong %1728 %ulong_8
+OpStore %673 %1729
+%1730 = OpLoad %ulong %662
+%1731 = OpLoad %ulong %673
+%1732 = OpShiftRightLogical %ulong %1730 %1731
+OpStore %674 %1732
+%1733 = OpLoad %ulong %674
+%1734 = OpBitwiseAnd %ulong %1733 %ulong_255
+OpStore %675 %1734
+%1735 = OpLoad %ulong %679
+%1736 = OpLoad %ulong %675
+%1737 = OpBitwiseXor %ulong %1735 %1736
+OpStore %676 %1737
+%1738 = OpLoad %ulong %676
+%1739 = OpIMul %ulong %1738 %ulong_1099511628211
+OpStore %677 %1739
+%1740 = OpLoad %ulong %680
+%1741 = OpIAdd %ulong %1740 %ulong_1
+OpStore %678 %1741
+%1742 = OpLoad %ulong %677
+OpStore %679 %1742
+%1743 = OpLoad %ulong %678
+OpStore %680 %1743
+OpBranch %293
+%234 = OpLabel
+%1744 = OpLoad %ulong %661
+%1745 = OpIMul %ulong %1744 %ulong_8
+OpStore %654 %1745
+%1746 = OpLoad %ulong %643
+%1747 = OpLoad %ulong %654
+%1748 = OpShiftRightLogical %ulong %1746 %1747
+OpStore %655 %1748
+%1749 = OpLoad %ulong %655
+%1750 = OpBitwiseAnd %ulong %1749 %ulong_255
+OpStore %656 %1750
+%1751 = OpLoad %ulong %660
+%1752 = OpLoad %ulong %656
+%1753 = OpBitwiseXor %ulong %1751 %1752
+OpStore %657 %1753
+%1754 = OpLoad %ulong %657
+%1755 = OpIMul %ulong %1754 %ulong_1099511628211
+OpStore %658 %1755
+%1756 = OpLoad %ulong %661
+%1757 = OpIAdd %ulong %1756 %ulong_1
+OpStore %659 %1757
+%1758 = OpLoad %ulong %658
+OpStore %660 %1758
+%1759 = OpLoad %ulong %659
+OpStore %661 %1759
+OpBranch %294
+%279 = OpLabel
+OpBranch %240
+%280 = OpLabel
+OpBranch %228
+%281 = OpLabel
+OpBranch %221
+%282 = OpLabel
+OpBranch %214
+%283 = OpLabel
+OpBranch %209
+%284 = OpLabel
+OpBranch %200
+%285 = OpLabel
+OpBranch %191
+%286 = OpLabel
+OpBranch %182
+%287 = OpLabel
+OpBranch %173
+%288 = OpLabel
+OpBranch %164
+%289 = OpLabel
+OpBranch %155
+%290 = OpLabel
+OpBranch %134
+%291 = OpLabel
+OpBranch %128
+%292 = OpLabel
+OpBranch %125
+%293 = OpLabel
+OpBranch %245
+%294 = OpLabel
+OpBranch %233
 OpFunctionEnd
-%4 = OpFunction %ulong None %1388
-%1389 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %1391
-%1392 = OpFunctionParameter %ulong
-%1393 = OpFunctionParameter %ulong
-%1394 = OpLabel
-%1399 = OpVariable %_ptr_Function_ulong Function
-%1400 = OpVariable %_ptr_Function_ulong Function
-%1401 = OpVariable %_ptr_Function_bool Function
-%1402 = OpVariable %_ptr_Function_ulong Function
-%1403 = OpVariable %_ptr_Function_ulong Function
-%1404 = OpVariable %_ptr_Function_ulong Function
-%1405 = OpVariable %_ptr_Function_ulong Function
-%1406 = OpVariable %_ptr_Function_ulong Function
-%1407 = OpVariable %_ptr_Function_ulong Function
-%1408 = OpVariable %_ptr_Function_ulong Function
-%1409 = OpVariable %_ptr_Function_ulong Function
-OpStore %1399 %1392
-OpStore %1400 %1393
-%1410 = OpLoad %ulong %1399
-OpStore %1408 %1410
-OpStore %1409 %ulong_0
-OpBranch %1395
-%1395 = OpLabel
-%1411 = OpLoad %ulong %1409
-%1412 = OpULessThan %bool %1411 %ulong_8
-OpStore %1401 %1412
-%1413 = OpLoad %bool %1401
-OpLoopMerge %1397 %1398 None
-OpBranchConditional %1413 %1396 %1397
-%1397 = OpLabel
-%1414 = OpLoad %ulong %1408
-OpReturnValue %1414
-%1396 = OpLabel
-%1415 = OpLoad %ulong %1409
-%1416 = OpIMul %ulong %1415 %ulong_8
-OpStore %1402 %1416
-%1417 = OpLoad %ulong %1400
-%1418 = OpLoad %ulong %1402
-%1419 = OpShiftRightLogical %ulong %1417 %1418
-OpStore %1403 %1419
-%1420 = OpLoad %ulong %1403
-%1422 = OpBitwiseAnd %ulong %1420 %ulong_255
-OpStore %1404 %1422
-%1423 = OpLoad %ulong %1408
-%1424 = OpLoad %ulong %1404
-%1425 = OpBitwiseXor %ulong %1423 %1424
-OpStore %1405 %1425
-%1426 = OpLoad %ulong %1405
-%1428 = OpIMul %ulong %1426 %ulong_1099511628211
-OpStore %1406 %1428
-%1429 = OpLoad %ulong %1409
-%1430 = OpIAdd %ulong %1429 %ulong_1
-OpStore %1407 %1430
-%1431 = OpLoad %ulong %1406
-OpStore %1408 %1431
-%1432 = OpLoad %ulong %1407
-OpStore %1409 %1432
-OpBranch %1398
-%1398 = OpLabel
-OpBranch %1395
-OpFunctionEnd
-%6 = OpFunction %ulong None %1433
-%1434 = OpFunctionParameter %ulong
-%1435 = OpFunctionParameter %uchar
-%1436 = OpLabel
-%1443 = OpVariable %_ptr_Function_ulong Function
-%1445 = OpVariable %_ptr_Function_uchar Function
-%1446 = OpVariable %_ptr_Function_ulong Function
-%1447 = OpVariable %_ptr_Function_bool Function
-%1448 = OpVariable %_ptr_Function_ulong Function
-%1449 = OpVariable %_ptr_Function_ulong Function
-%1450 = OpVariable %_ptr_Function_ulong Function
-%1451 = OpVariable %_ptr_Function_ulong Function
-%1452 = OpVariable %_ptr_Function_ulong Function
-%1453 = OpVariable %_ptr_Function_ulong Function
-%1454 = OpVariable %_ptr_Function_ulong Function
-%1455 = OpVariable %_ptr_Function_ulong Function
-OpStore %1443 %1434
-OpStore %1445 %1435
-%1456 = OpLoad %uchar %1445
-%1457 = OpUConvert %ulong %1456
-OpStore %1446 %1457
-OpBranch %1437
-%1437 = OpLabel
-%1458 = OpLoad %ulong %1443
-OpStore %1454 %1458
-OpStore %1455 %ulong_0
-OpBranch %1438
-%1438 = OpLabel
-%1459 = OpLoad %ulong %1455
-%1460 = OpULessThan %bool %1459 %ulong_8
-OpStore %1447 %1460
-%1461 = OpLoad %bool %1447
-OpLoopMerge %1440 %1442 None
-OpBranchConditional %1461 %1439 %1440
-%1440 = OpLabel
-OpBranch %1441
-%1441 = OpLabel
-%1462 = OpLoad %ulong %1454
-OpReturnValue %1462
-%1439 = OpLabel
-%1463 = OpLoad %ulong %1455
-%1464 = OpIMul %ulong %1463 %ulong_8
-OpStore %1448 %1464
-%1465 = OpLoad %ulong %1446
-%1466 = OpLoad %ulong %1448
-%1467 = OpShiftRightLogical %ulong %1465 %1466
-OpStore %1449 %1467
-%1468 = OpLoad %ulong %1449
-%1469 = OpBitwiseAnd %ulong %1468 %ulong_255
-OpStore %1450 %1469
-%1470 = OpLoad %ulong %1454
-%1471 = OpLoad %ulong %1450
-%1472 = OpBitwiseXor %ulong %1470 %1471
-OpStore %1451 %1472
-%1473 = OpLoad %ulong %1451
-%1474 = OpIMul %ulong %1473 %ulong_1099511628211
-OpStore %1452 %1474
-%1475 = OpLoad %ulong %1455
-%1476 = OpIAdd %ulong %1475 %ulong_1
-OpStore %1453 %1476
-%1477 = OpLoad %ulong %1452
-OpStore %1454 %1477
-%1478 = OpLoad %ulong %1453
-OpStore %1455 %1478
-OpBranch %1442
-%1442 = OpLabel
-OpBranch %1438
-OpFunctionEnd
-%7 = OpFunction %ulong None %1479
-%1480 = OpFunctionParameter %ulong
-%1481 = OpFunctionParameter %uint
-%1482 = OpLabel
-%1489 = OpVariable %_ptr_Function_ulong Function
-%1490 = OpVariable %_ptr_Function_uint Function
-%1491 = OpVariable %_ptr_Function_ulong Function
-%1492 = OpVariable %_ptr_Function_bool Function
-%1493 = OpVariable %_ptr_Function_ulong Function
-%1494 = OpVariable %_ptr_Function_ulong Function
-%1495 = OpVariable %_ptr_Function_ulong Function
-%1496 = OpVariable %_ptr_Function_ulong Function
-%1497 = OpVariable %_ptr_Function_ulong Function
-%1498 = OpVariable %_ptr_Function_ulong Function
-%1499 = OpVariable %_ptr_Function_ulong Function
-%1500 = OpVariable %_ptr_Function_ulong Function
-OpStore %1489 %1480
-OpStore %1490 %1481
-%1501 = OpLoad %uint %1490
-%1502 = OpUConvert %ulong %1501
-OpStore %1491 %1502
-OpBranch %1483
-%1483 = OpLabel
-%1503 = OpLoad %ulong %1489
-OpStore %1499 %1503
-OpStore %1500 %ulong_0
-OpBranch %1484
-%1484 = OpLabel
-%1504 = OpLoad %ulong %1500
-%1505 = OpULessThan %bool %1504 %ulong_8
-OpStore %1492 %1505
-%1506 = OpLoad %bool %1492
-OpLoopMerge %1486 %1488 None
-OpBranchConditional %1506 %1485 %1486
-%1486 = OpLabel
-OpBranch %1487
-%1487 = OpLabel
-%1507 = OpLoad %ulong %1499
-OpReturnValue %1507
-%1485 = OpLabel
-%1508 = OpLoad %ulong %1500
-%1509 = OpIMul %ulong %1508 %ulong_8
-OpStore %1493 %1509
-%1510 = OpLoad %ulong %1491
-%1511 = OpLoad %ulong %1493
-%1512 = OpShiftRightLogical %ulong %1510 %1511
-OpStore %1494 %1512
-%1513 = OpLoad %ulong %1494
-%1514 = OpBitwiseAnd %ulong %1513 %ulong_255
-OpStore %1495 %1514
-%1515 = OpLoad %ulong %1499
-%1516 = OpLoad %ulong %1495
-%1517 = OpBitwiseXor %ulong %1515 %1516
-OpStore %1496 %1517
-%1518 = OpLoad %ulong %1496
-%1519 = OpIMul %ulong %1518 %ulong_1099511628211
-OpStore %1497 %1519
-%1520 = OpLoad %ulong %1500
-%1521 = OpIAdd %ulong %1520 %ulong_1
-OpStore %1498 %1521
-%1522 = OpLoad %ulong %1497
-OpStore %1499 %1522
-%1523 = OpLoad %ulong %1498
-OpStore %1500 %1523
-OpBranch %1488
-%1488 = OpLabel
-OpBranch %1484
-OpFunctionEnd
-%8 = OpFunction %ulong None %1479
-%1524 = OpFunctionParameter %ulong
-%1525 = OpFunctionParameter %uint
-%1526 = OpLabel
-%1533 = OpVariable %_ptr_Function_ulong Function
-%1534 = OpVariable %_ptr_Function_uint Function
-%1535 = OpVariable %_ptr_Function_ulong Function
-%1536 = OpVariable %_ptr_Function_bool Function
-%1537 = OpVariable %_ptr_Function_ulong Function
-%1538 = OpVariable %_ptr_Function_ulong Function
-%1539 = OpVariable %_ptr_Function_ulong Function
-%1540 = OpVariable %_ptr_Function_ulong Function
-%1541 = OpVariable %_ptr_Function_ulong Function
-%1542 = OpVariable %_ptr_Function_ulong Function
-%1543 = OpVariable %_ptr_Function_ulong Function
-%1544 = OpVariable %_ptr_Function_ulong Function
-OpStore %1533 %1524
-OpStore %1534 %1525
-%1545 = OpLoad %uint %1534
-%1546 = OpSConvert %ulong %1545
-OpStore %1535 %1546
-OpBranch %1527
-%1527 = OpLabel
-%1547 = OpLoad %ulong %1533
-OpStore %1543 %1547
-OpStore %1544 %ulong_0
-OpBranch %1528
-%1528 = OpLabel
-%1548 = OpLoad %ulong %1544
-%1549 = OpULessThan %bool %1548 %ulong_8
-OpStore %1536 %1549
-%1550 = OpLoad %bool %1536
-OpLoopMerge %1530 %1532 None
-OpBranchConditional %1550 %1529 %1530
-%1530 = OpLabel
-OpBranch %1531
-%1531 = OpLabel
-%1551 = OpLoad %ulong %1543
-OpReturnValue %1551
-%1529 = OpLabel
-%1552 = OpLoad %ulong %1544
-%1553 = OpIMul %ulong %1552 %ulong_8
-OpStore %1537 %1553
-%1554 = OpLoad %ulong %1535
-%1555 = OpLoad %ulong %1537
-%1556 = OpShiftRightLogical %ulong %1554 %1555
-OpStore %1538 %1556
-%1557 = OpLoad %ulong %1538
-%1558 = OpBitwiseAnd %ulong %1557 %ulong_255
-OpStore %1539 %1558
-%1559 = OpLoad %ulong %1543
-%1560 = OpLoad %ulong %1539
-%1561 = OpBitwiseXor %ulong %1559 %1560
-OpStore %1540 %1561
-%1562 = OpLoad %ulong %1540
-%1563 = OpIMul %ulong %1562 %ulong_1099511628211
-OpStore %1541 %1563
-%1564 = OpLoad %ulong %1544
-%1565 = OpIAdd %ulong %1564 %ulong_1
-OpStore %1542 %1565
-%1566 = OpLoad %ulong %1541
-OpStore %1543 %1566
-%1567 = OpLoad %ulong %1542
-OpStore %1544 %1567
-OpBranch %1532
-%1532 = OpLabel
-OpBranch %1528
-OpFunctionEnd
-%9 = OpFunction %ulong None %1391
-%1568 = OpFunctionParameter %ulong
-%1569 = OpFunctionParameter %ulong
-%1570 = OpLabel
-%1577 = OpVariable %_ptr_Function_ulong Function
-%1578 = OpVariable %_ptr_Function_ulong Function
-%1579 = OpVariable %_ptr_Function_bool Function
-%1580 = OpVariable %_ptr_Function_ulong Function
-%1581 = OpVariable %_ptr_Function_ulong Function
-%1582 = OpVariable %_ptr_Function_ulong Function
-%1583 = OpVariable %_ptr_Function_ulong Function
-%1584 = OpVariable %_ptr_Function_ulong Function
-%1585 = OpVariable %_ptr_Function_ulong Function
-%1586 = OpVariable %_ptr_Function_ulong Function
-%1587 = OpVariable %_ptr_Function_ulong Function
-OpStore %1577 %1568
-OpStore %1578 %1569
-OpBranch %1571
-%1571 = OpLabel
-%1588 = OpLoad %ulong %1577
-OpStore %1586 %1588
-OpStore %1587 %ulong_0
-OpBranch %1572
-%1572 = OpLabel
-%1589 = OpLoad %ulong %1587
-%1590 = OpULessThan %bool %1589 %ulong_8
-OpStore %1579 %1590
-%1591 = OpLoad %bool %1579
-OpLoopMerge %1574 %1576 None
-OpBranchConditional %1591 %1573 %1574
-%1574 = OpLabel
-OpBranch %1575
-%1575 = OpLabel
-%1592 = OpLoad %ulong %1586
-OpReturnValue %1592
-%1573 = OpLabel
-%1593 = OpLoad %ulong %1587
-%1594 = OpIMul %ulong %1593 %ulong_8
-OpStore %1580 %1594
-%1595 = OpLoad %ulong %1578
-%1596 = OpLoad %ulong %1580
-%1597 = OpShiftRightLogical %ulong %1595 %1596
-OpStore %1581 %1597
-%1598 = OpLoad %ulong %1581
-%1599 = OpBitwiseAnd %ulong %1598 %ulong_255
-OpStore %1582 %1599
-%1600 = OpLoad %ulong %1586
-%1601 = OpLoad %ulong %1582
-%1602 = OpBitwiseXor %ulong %1600 %1601
-OpStore %1583 %1602
-%1603 = OpLoad %ulong %1583
-%1604 = OpIMul %ulong %1603 %ulong_1099511628211
-OpStore %1584 %1604
-%1605 = OpLoad %ulong %1587
-%1606 = OpIAdd %ulong %1605 %ulong_1
-OpStore %1585 %1606
-%1607 = OpLoad %ulong %1584
-OpStore %1586 %1607
-%1608 = OpLoad %ulong %1585
-OpStore %1587 %1608
-OpBranch %1576
-%1576 = OpLabel
-OpBranch %1572
-OpFunctionEnd
-%10 = OpFunction %ulong None %1609
-%1610 = OpFunctionParameter %ulong
-%1611 = OpFunctionParameter %float
-%1612 = OpLabel
-%1619 = OpVariable %_ptr_Function_ulong Function
-%1620 = OpVariable %_ptr_Function_float Function
-%1621 = OpVariable %_ptr_Function_uint Function
-%1622 = OpVariable %_ptr_Function_ulong Function
-%1623 = OpVariable %_ptr_Function_bool Function
-%1624 = OpVariable %_ptr_Function_ulong Function
-%1625 = OpVariable %_ptr_Function_ulong Function
-%1626 = OpVariable %_ptr_Function_ulong Function
-%1627 = OpVariable %_ptr_Function_ulong Function
-%1628 = OpVariable %_ptr_Function_ulong Function
-%1629 = OpVariable %_ptr_Function_ulong Function
-%1630 = OpVariable %_ptr_Function_ulong Function
-%1631 = OpVariable %_ptr_Function_ulong Function
-OpStore %1619 %1610
-OpStore %1620 %1611
-%1632 = OpLoad %float %1620
-%1633 = OpBitcast %uint %1632
-OpStore %1621 %1633
-%1634 = OpLoad %uint %1621
-%1635 = OpUConvert %ulong %1634
-OpStore %1622 %1635
-OpBranch %1613
-%1613 = OpLabel
-%1636 = OpLoad %ulong %1619
-OpStore %1630 %1636
-OpStore %1631 %ulong_0
-OpBranch %1614
-%1614 = OpLabel
-%1637 = OpLoad %ulong %1631
-%1638 = OpULessThan %bool %1637 %ulong_8
-OpStore %1623 %1638
-%1639 = OpLoad %bool %1623
-OpLoopMerge %1616 %1618 None
-OpBranchConditional %1639 %1615 %1616
-%1616 = OpLabel
-OpBranch %1617
-%1617 = OpLabel
-%1640 = OpLoad %ulong %1630
-OpReturnValue %1640
-%1615 = OpLabel
-%1641 = OpLoad %ulong %1631
-%1642 = OpIMul %ulong %1641 %ulong_8
-OpStore %1624 %1642
-%1643 = OpLoad %ulong %1622
-%1644 = OpLoad %ulong %1624
-%1645 = OpShiftRightLogical %ulong %1643 %1644
-OpStore %1625 %1645
-%1646 = OpLoad %ulong %1625
-%1647 = OpBitwiseAnd %ulong %1646 %ulong_255
-OpStore %1626 %1647
-%1648 = OpLoad %ulong %1630
-%1649 = OpLoad %ulong %1626
-%1650 = OpBitwiseXor %ulong %1648 %1649
-OpStore %1627 %1650
-%1651 = OpLoad %ulong %1627
-%1652 = OpIMul %ulong %1651 %ulong_1099511628211
-OpStore %1628 %1652
-%1653 = OpLoad %ulong %1631
-%1654 = OpIAdd %ulong %1653 %ulong_1
-OpStore %1629 %1654
-%1655 = OpLoad %ulong %1628
-OpStore %1630 %1655
-%1656 = OpLoad %ulong %1629
-OpStore %1631 %1656
-OpBranch %1618
-%1618 = OpLabel
-OpBranch %1614
-OpFunctionEnd
-%11 = OpFunction %ulong None %30
-%1657 = OpFunctionParameter %ulong
-%1658 = OpFunctionParameter %double
-%1659 = OpLabel
-%1666 = OpVariable %_ptr_Function_ulong Function
-%1667 = OpVariable %_ptr_Function_double Function
-%1668 = OpVariable %_ptr_Function_ulong Function
-%1669 = OpVariable %_ptr_Function_bool Function
-%1670 = OpVariable %_ptr_Function_ulong Function
-%1671 = OpVariable %_ptr_Function_ulong Function
-%1672 = OpVariable %_ptr_Function_ulong Function
-%1673 = OpVariable %_ptr_Function_ulong Function
-%1674 = OpVariable %_ptr_Function_ulong Function
-%1675 = OpVariable %_ptr_Function_ulong Function
-%1676 = OpVariable %_ptr_Function_ulong Function
-%1677 = OpVariable %_ptr_Function_ulong Function
-OpStore %1666 %1657
-OpStore %1667 %1658
-%1678 = OpLoad %double %1667
-%1679 = OpBitcast %ulong %1678
-OpStore %1668 %1679
-OpBranch %1660
-%1660 = OpLabel
-%1680 = OpLoad %ulong %1666
-OpStore %1676 %1680
-OpStore %1677 %ulong_0
-OpBranch %1661
-%1661 = OpLabel
-%1681 = OpLoad %ulong %1677
-%1682 = OpULessThan %bool %1681 %ulong_8
-OpStore %1669 %1682
-%1683 = OpLoad %bool %1669
-OpLoopMerge %1663 %1665 None
-OpBranchConditional %1683 %1662 %1663
-%1663 = OpLabel
-OpBranch %1664
-%1664 = OpLabel
-%1684 = OpLoad %ulong %1676
-OpReturnValue %1684
-%1662 = OpLabel
-%1685 = OpLoad %ulong %1677
-%1686 = OpIMul %ulong %1685 %ulong_8
-OpStore %1670 %1686
-%1687 = OpLoad %ulong %1668
-%1688 = OpLoad %ulong %1670
-%1689 = OpShiftRightLogical %ulong %1687 %1688
-OpStore %1671 %1689
-%1690 = OpLoad %ulong %1671
-%1691 = OpBitwiseAnd %ulong %1690 %ulong_255
-OpStore %1672 %1691
-%1692 = OpLoad %ulong %1676
-%1693 = OpLoad %ulong %1672
-%1694 = OpBitwiseXor %ulong %1692 %1693
-OpStore %1673 %1694
-%1695 = OpLoad %ulong %1673
-%1696 = OpIMul %ulong %1695 %ulong_1099511628211
-OpStore %1674 %1696
-%1697 = OpLoad %ulong %1677
-%1698 = OpIAdd %ulong %1697 %ulong_1
-OpStore %1675 %1698
-%1699 = OpLoad %ulong %1674
-OpStore %1676 %1699
-%1700 = OpLoad %ulong %1675
-OpStore %1677 %1700
-OpBranch %1665
-%1665 = OpLabel
-OpBranch %1661
+%4 = OpFunction %ulong None %1760
+%1761 = OpFunctionParameter %ulong
+%1762 = OpFunctionParameter %ulong
+%1763 = OpLabel
+%1768 = OpVariable %_ptr_Function_ulong Function
+%1769 = OpVariable %_ptr_Function_ulong Function
+%1770 = OpVariable %_ptr_Function_bool Function
+%1771 = OpVariable %_ptr_Function_ulong Function
+%1772 = OpVariable %_ptr_Function_ulong Function
+%1773 = OpVariable %_ptr_Function_ulong Function
+%1774 = OpVariable %_ptr_Function_ulong Function
+%1775 = OpVariable %_ptr_Function_ulong Function
+%1776 = OpVariable %_ptr_Function_ulong Function
+%1777 = OpVariable %_ptr_Function_ulong Function
+%1778 = OpVariable %_ptr_Function_ulong Function
+OpStore %1768 %1761
+OpStore %1769 %1762
+%1779 = OpLoad %ulong %1768
+OpStore %1777 %1779
+OpStore %1778 %ulong_0
+OpBranch %1764
+%1764 = OpLabel
+%1780 = OpLoad %ulong %1778
+%1781 = OpULessThan %bool %1780 %ulong_8
+OpStore %1770 %1781
+%1782 = OpLoad %bool %1770
+OpLoopMerge %1766 %1767 None
+OpBranchConditional %1782 %1765 %1766
+%1766 = OpLabel
+%1783 = OpLoad %ulong %1777
+OpReturnValue %1783
+%1765 = OpLabel
+%1784 = OpLoad %ulong %1778
+%1785 = OpIMul %ulong %1784 %ulong_8
+OpStore %1771 %1785
+%1786 = OpLoad %ulong %1769
+%1787 = OpLoad %ulong %1771
+%1788 = OpShiftRightLogical %ulong %1786 %1787
+OpStore %1772 %1788
+%1789 = OpLoad %ulong %1772
+%1790 = OpBitwiseAnd %ulong %1789 %ulong_255
+OpStore %1773 %1790
+%1791 = OpLoad %ulong %1777
+%1792 = OpLoad %ulong %1773
+%1793 = OpBitwiseXor %ulong %1791 %1792
+OpStore %1774 %1793
+%1794 = OpLoad %ulong %1774
+%1795 = OpIMul %ulong %1794 %ulong_1099511628211
+OpStore %1775 %1795
+%1796 = OpLoad %ulong %1778
+%1797 = OpIAdd %ulong %1796 %ulong_1
+OpStore %1776 %1797
+%1798 = OpLoad %ulong %1775
+OpStore %1777 %1798
+%1799 = OpLoad %ulong %1776
+OpStore %1778 %1799
+OpBranch %1767
+%1767 = OpLabel
+OpBranch %1764
 OpFunctionEnd

--- a/test/golden/spirv/frame/frame_align.dis
+++ b/test/golden/spirv/frame/frame_align.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1368
+; Bound: 1376
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -18,44 +18,47 @@ OpDecorate %5 LinkageAttributes "corpus.cases.frame.frame_align.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v4float = OpTypeVector %float 4
-%16 = OpTypeFunction %ulong %ulong %v4float
+%10 = OpTypeFunction %ulong %ulong %v4float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %double = OpTypeFloat 64
 %v2double = OpTypeVector %double 2
-%56 = OpTypeFunction %ulong %ulong %v2double
+%215 = OpTypeFunction %ulong %ulong %v2double
 %_ptr_Function_v2double = OpTypePointer Function %v2double
 %_ptr_Function_double = OpTypePointer Function %double
-%uint = OpTypeInt 32 0
 %v4uint = OpTypeVector %uint 4
-%81 = OpTypeFunction %ulong %ulong %v4uint
+%311 = OpTypeFunction %ulong %ulong %v4uint
 %_ptr_Function_v4uint = OpTypePointer Function %v4uint
-%_ptr_Function_uint = OpTypePointer Function %uint
-%118 = OpTypeFunction %v4float %v4float
-%bool = OpTypeBool
+%491 = OpTypeFunction %v4float %v4float
 %uchar = OpTypeInt 8 0
 %uint_7 = OpConstant %uint 7
 %_arr_uchar_uint_7 = OpTypeArray %uchar %uint_7
 %_ptr_Function__arr_uchar_uint_7 = OpTypePointer Function %_arr_uchar_uint_7
-%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%149 = OpConstantNull %_arr_uchar_uint_7
+%520 = OpConstantNull %_arr_uchar_uint_7
 %float_0 = OpConstant %float 0
 %float_1_5 = OpConstant %float 1.5
 %float_0_5 = OpConstant %float 0.5
 %float_1_25 = OpConstant %float 1.25
 %float_0_75 = OpConstant %float 0.75
-%ulong_0 = OpConstant %ulong 0
 %ulong_4 = OpConstant %ulong 4
 %uint_3 = OpConstant %uint 3
 %ulong_17 = OpConstant %ulong 17
-%ulong_1 = OpConstant %ulong 1
-%196 = OpTypeFunction %ulong %ulong
+%565 = OpTypeFunction %ulong %ulong
 %ushort = OpTypeInt 16 0
-%_struct_262 = OpTypeStruct %ulong %ulong
-%_arr__struct_262_uint_3 = OpTypeArray %_struct_262 %uint_3
-%_ptr_Function__arr__struct_262_uint_3 = OpTypePointer Function %_arr__struct_262_uint_3
+%_struct_651 = OpTypeStruct %ulong %ulong
+%_arr__struct_651_uint_3 = OpTypeArray %_struct_651 %uint_3
+%_ptr_Function__arr__struct_651_uint_3 = OpTypePointer Function %_arr__struct_651_uint_3
 %uint_4 = OpConstant %uint 4
 %_arr_v4float_uint_4 = OpTypeArray %v4float %uint_4
 %_ptr_Function__arr_v4float_uint_4 = OpTypePointer Function %_arr_v4float_uint_4
@@ -73,1832 +76,1922 @@ OpDecorate %5 LinkageAttributes "corpus.cases.frame.frame_align.checksum" Export
 %uint_3266489917 = OpConstant %uint 3266489917
 %uint_2246822519 = OpConstant %uint 2246822519
 %uint_4294967291 = OpConstant %uint 4294967291
-%529 = OpConstantNull %_arr__struct_262_uint_3
-%530 = OpConstantNull %_arr_v4float_uint_4
+%878 = OpConstantNull %_arr__struct_651_uint_3
+%879 = OpConstantNull %_arr_v4float_uint_4
 %ulong_3 = OpConstant %ulong 3
 %ulong_5 = OpConstant %ulong 5
 %ulong_7 = OpConstant %ulong 7
 %ulong_65521 = OpConstant %ulong 65521
 %ulong_251 = OpConstant %ulong 251
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_2 = OpConstant %uint 2
 %ulong_1229782938247303441 = OpConstant %ulong 1229782938247303441
 %ulong_8608480567731124087 = OpConstant %ulong 8608480567731124087
-%uchar_0 = OpConstant %uchar 0
-%_ptr_Function__struct_262 = OpTypePointer Function %_struct_262
+%_ptr_Function__struct_651 = OpTypePointer Function %_struct_651
 %ulong_2654435761 = OpConstant %ulong 2654435761
 %ulong_40 = OpConstant %ulong 40
-%1094 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1097 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1140 = OpTypeFunction %ulong %ulong %uchar
-%1185 = OpTypeFunction %ulong %ulong %ushort
-%1230 = OpTypeFunction %ulong %ulong %uint
-%1275 = OpTypeFunction %ulong %ulong %float
-%1323 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %16
-%17 = OpFunctionParameter %ulong
-%18 = OpFunctionParameter %v4float
-%19 = OpLabel
-%21 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_v4float Function
-%25 = OpVariable %_ptr_Function_float Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_float Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_float Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_float Function
-%32 = OpVariable %_ptr_Function_ulong Function
-OpStore %21 %17
-OpStore %23 %18
-%33 = OpLoad %v4float %23
-%34 = OpCompositeExtract %float %33 0
-OpStore %25 %34
-%35 = OpLoad %ulong %21
-%36 = OpLoad %float %25
-%37 = OpFunctionCall %ulong %11 %35 %36
-OpStore %26 %37
-%38 = OpLoad %v4float %23
-%39 = OpCompositeExtract %float %38 1
-OpStore %27 %39
-%40 = OpLoad %ulong %26
-%41 = OpLoad %float %27
-%42 = OpFunctionCall %ulong %11 %40 %41
-OpStore %28 %42
-%43 = OpLoad %v4float %23
-%44 = OpCompositeExtract %float %43 2
-OpStore %29 %44
-%45 = OpLoad %ulong %28
-%46 = OpLoad %float %29
-%47 = OpFunctionCall %ulong %11 %45 %46
-OpStore %30 %47
-%48 = OpLoad %v4float %23
-%49 = OpCompositeExtract %float %48 3
-OpStore %31 %49
-%50 = OpLoad %ulong %30
-%51 = OpLoad %float %31
-%52 = OpFunctionCall %ulong %11 %50 %51
-OpStore %32 %52
-%53 = OpLoad %ulong %32
-OpReturnValue %53
-OpFunctionEnd
-%2 = OpFunction %ulong None %56
-%57 = OpFunctionParameter %ulong
-%58 = OpFunctionParameter %v2double
-%59 = OpLabel
-%60 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_v2double Function
-%64 = OpVariable %_ptr_Function_double Function
+%1336 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %10
+%11 = OpFunctionParameter %ulong
+%12 = OpFunctionParameter %v4float
+%13 = OpLabel
+%49 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_v4float Function
+%53 = OpVariable %_ptr_Function_float Function
+%54 = OpVariable %_ptr_Function_float Function
+%55 = OpVariable %_ptr_Function_float Function
+%56 = OpVariable %_ptr_Function_float Function
+%58 = OpVariable %_ptr_Function_uint Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_bool Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
 %65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_double Function
+%66 = OpVariable %_ptr_Function_ulong Function
 %67 = OpVariable %_ptr_Function_ulong Function
-OpStore %60 %57
-OpStore %62 %58
-%68 = OpLoad %v2double %62
-%69 = OpCompositeExtract %double %68 0
-OpStore %64 %69
-%70 = OpLoad %ulong %60
-%71 = OpLoad %double %64
-%72 = OpFunctionCall %ulong %12 %70 %71
-OpStore %65 %72
-%73 = OpLoad %v2double %62
-%74 = OpCompositeExtract %double %73 1
-OpStore %66 %74
-%75 = OpLoad %ulong %65
-%76 = OpLoad %double %66
-%77 = OpFunctionCall %ulong %12 %75 %76
-OpStore %67 %77
-%78 = OpLoad %ulong %67
-OpReturnValue %78
-OpFunctionEnd
-%3 = OpFunction %ulong None %81
-%82 = OpFunctionParameter %ulong
-%83 = OpFunctionParameter %v4uint
-%84 = OpLabel
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_uint Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_bool Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_uint Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_bool Function
+%84 = OpVariable %_ptr_Function_ulong Function
 %85 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_v4uint Function
-%89 = OpVariable %_ptr_Function_uint Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
 %90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_uint Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_uint Function
-%94 = OpVariable %_ptr_Function_ulong Function
-%95 = OpVariable %_ptr_Function_uint Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_uint Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_bool Function
+%95 = OpVariable %_ptr_Function_ulong Function
 %96 = OpVariable %_ptr_Function_ulong Function
-OpStore %85 %82
-OpStore %87 %83
-%97 = OpLoad %v4uint %87
-%98 = OpCompositeExtract %uint %97 0
-OpStore %89 %98
-%99 = OpLoad %ulong %85
-%100 = OpLoad %uint %89
-%101 = OpFunctionCall %ulong %10 %99 %100
-OpStore %90 %101
-%102 = OpLoad %v4uint %87
-%103 = OpCompositeExtract %uint %102 1
-OpStore %91 %103
-%104 = OpLoad %ulong %90
-%105 = OpLoad %uint %91
-%106 = OpFunctionCall %ulong %10 %104 %105
-OpStore %92 %106
-%107 = OpLoad %v4uint %87
-%108 = OpCompositeExtract %uint %107 2
-OpStore %93 %108
-%109 = OpLoad %ulong %92
-%110 = OpLoad %uint %93
-%111 = OpFunctionCall %ulong %10 %109 %110
-OpStore %94 %111
-%112 = OpLoad %v4uint %87
-%113 = OpCompositeExtract %uint %112 3
-OpStore %95 %113
-%114 = OpLoad %ulong %94
-%115 = OpLoad %uint %95
-%116 = OpFunctionCall %ulong %10 %114 %115
-OpStore %96 %116
-%117 = OpLoad %ulong %96
-OpReturnValue %117
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+OpStore %49 %11
+OpStore %51 %12
+%103 = OpLoad %v4float %51
+%104 = OpCompositeExtract %float %103 0
+OpStore %53 %104
+OpBranch %14
+%14 = OpLabel
+%105 = OpLoad %float %53
+%106 = OpBitcast %uint %105
+OpStore %58 %106
+%107 = OpLoad %uint %58
+%108 = OpUConvert %ulong %107
+OpStore %59 %108
+OpBranch %16
+%16 = OpLabel
+%109 = OpLoad %ulong %49
+OpStore %68 %109
+OpStore %69 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%111 = OpLoad %ulong %69
+%113 = OpULessThan %bool %111 %ulong_8
+OpStore %61 %113
+%114 = OpLoad %bool %61
+OpLoopMerge %19 %45 None
+OpBranchConditional %114 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%115 = OpLoad %v4float %51
+%116 = OpCompositeExtract %float %115 1
+OpStore %54 %116
+OpBranch %21
+%21 = OpLabel
+%117 = OpLoad %float %54
+%118 = OpBitcast %uint %117
+OpStore %70 %118
+%119 = OpLoad %uint %70
+%120 = OpUConvert %ulong %119
+OpStore %71 %120
+OpBranch %23
+%23 = OpLabel
+%121 = OpLoad %ulong %68
+OpStore %79 %121
+OpStore %80 %ulong_0
+OpBranch %24
+%24 = OpLabel
+%122 = OpLoad %ulong %80
+%123 = OpULessThan %bool %122 %ulong_8
+OpStore %72 %123
+%124 = OpLoad %bool %72
+OpLoopMerge %26 %44 None
+OpBranchConditional %124 %25 %26
+%26 = OpLabel
+OpBranch %27
+%27 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%125 = OpLoad %v4float %51
+%126 = OpCompositeExtract %float %125 2
+OpStore %55 %126
+OpBranch %28
+%28 = OpLabel
+%127 = OpLoad %float %55
+%128 = OpBitcast %uint %127
+OpStore %81 %128
+%129 = OpLoad %uint %81
+%130 = OpUConvert %ulong %129
+OpStore %82 %130
+OpBranch %30
+%30 = OpLabel
+%131 = OpLoad %ulong %79
+OpStore %90 %131
+OpStore %91 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%132 = OpLoad %ulong %91
+%133 = OpULessThan %bool %132 %ulong_8
+OpStore %83 %133
+%134 = OpLoad %bool %83
+OpLoopMerge %33 %43 None
+OpBranchConditional %134 %32 %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%135 = OpLoad %v4float %51
+%136 = OpCompositeExtract %float %135 3
+OpStore %56 %136
+OpBranch %35
+%35 = OpLabel
+%137 = OpLoad %float %56
+%138 = OpBitcast %uint %137
+OpStore %92 %138
+%139 = OpLoad %uint %92
+%140 = OpUConvert %ulong %139
+OpStore %93 %140
+OpBranch %37
+%37 = OpLabel
+%141 = OpLoad %ulong %90
+OpStore %101 %141
+OpStore %102 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%142 = OpLoad %ulong %102
+%143 = OpULessThan %bool %142 %ulong_8
+OpStore %94 %143
+%144 = OpLoad %bool %94
+OpLoopMerge %40 %42 None
+OpBranchConditional %144 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%145 = OpLoad %ulong %101
+OpReturnValue %145
+%39 = OpLabel
+%146 = OpLoad %ulong %102
+%147 = OpIMul %ulong %146 %ulong_8
+OpStore %95 %147
+%148 = OpLoad %ulong %93
+%149 = OpLoad %ulong %95
+%150 = OpShiftRightLogical %ulong %148 %149
+OpStore %96 %150
+%151 = OpLoad %ulong %96
+%153 = OpBitwiseAnd %ulong %151 %ulong_255
+OpStore %97 %153
+%154 = OpLoad %ulong %101
+%155 = OpLoad %ulong %97
+%156 = OpBitwiseXor %ulong %154 %155
+OpStore %98 %156
+%157 = OpLoad %ulong %98
+%159 = OpIMul %ulong %157 %ulong_1099511628211
+OpStore %99 %159
+%160 = OpLoad %ulong %102
+%162 = OpIAdd %ulong %160 %ulong_1
+OpStore %100 %162
+%163 = OpLoad %ulong %99
+OpStore %101 %163
+%164 = OpLoad %ulong %100
+OpStore %102 %164
+OpBranch %42
+%32 = OpLabel
+%165 = OpLoad %ulong %91
+%166 = OpIMul %ulong %165 %ulong_8
+OpStore %84 %166
+%167 = OpLoad %ulong %82
+%168 = OpLoad %ulong %84
+%169 = OpShiftRightLogical %ulong %167 %168
+OpStore %85 %169
+%170 = OpLoad %ulong %85
+%171 = OpBitwiseAnd %ulong %170 %ulong_255
+OpStore %86 %171
+%172 = OpLoad %ulong %90
+%173 = OpLoad %ulong %86
+%174 = OpBitwiseXor %ulong %172 %173
+OpStore %87 %174
+%175 = OpLoad %ulong %87
+%176 = OpIMul %ulong %175 %ulong_1099511628211
+OpStore %88 %176
+%177 = OpLoad %ulong %91
+%178 = OpIAdd %ulong %177 %ulong_1
+OpStore %89 %178
+%179 = OpLoad %ulong %88
+OpStore %90 %179
+%180 = OpLoad %ulong %89
+OpStore %91 %180
+OpBranch %43
+%25 = OpLabel
+%181 = OpLoad %ulong %80
+%182 = OpIMul %ulong %181 %ulong_8
+OpStore %73 %182
+%183 = OpLoad %ulong %71
+%184 = OpLoad %ulong %73
+%185 = OpShiftRightLogical %ulong %183 %184
+OpStore %74 %185
+%186 = OpLoad %ulong %74
+%187 = OpBitwiseAnd %ulong %186 %ulong_255
+OpStore %75 %187
+%188 = OpLoad %ulong %79
+%189 = OpLoad %ulong %75
+%190 = OpBitwiseXor %ulong %188 %189
+OpStore %76 %190
+%191 = OpLoad %ulong %76
+%192 = OpIMul %ulong %191 %ulong_1099511628211
+OpStore %77 %192
+%193 = OpLoad %ulong %80
+%194 = OpIAdd %ulong %193 %ulong_1
+OpStore %78 %194
+%195 = OpLoad %ulong %77
+OpStore %79 %195
+%196 = OpLoad %ulong %78
+OpStore %80 %196
+OpBranch %44
+%18 = OpLabel
+%197 = OpLoad %ulong %69
+%198 = OpIMul %ulong %197 %ulong_8
+OpStore %62 %198
+%199 = OpLoad %ulong %59
+%200 = OpLoad %ulong %62
+%201 = OpShiftRightLogical %ulong %199 %200
+OpStore %63 %201
+%202 = OpLoad %ulong %63
+%203 = OpBitwiseAnd %ulong %202 %ulong_255
+OpStore %64 %203
+%204 = OpLoad %ulong %68
+%205 = OpLoad %ulong %64
+%206 = OpBitwiseXor %ulong %204 %205
+OpStore %65 %206
+%207 = OpLoad %ulong %65
+%208 = OpIMul %ulong %207 %ulong_1099511628211
+OpStore %66 %208
+%209 = OpLoad %ulong %69
+%210 = OpIAdd %ulong %209 %ulong_1
+OpStore %67 %210
+%211 = OpLoad %ulong %66
+OpStore %68 %211
+%212 = OpLoad %ulong %67
+OpStore %69 %212
+OpBranch %45
+%42 = OpLabel
+OpBranch %38
+%43 = OpLabel
+OpBranch %31
+%44 = OpLabel
+OpBranch %24
+%45 = OpLabel
+OpBranch %17
 OpFunctionEnd
-%4 = OpFunction %v4float None %118
-%119 = OpFunctionParameter %v4float
-%120 = OpLabel
-%130 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
-%131 = OpVariable %_ptr_Function_v4float Function
-%132 = OpVariable %_ptr_Function_v4float Function
-%134 = OpVariable %_ptr_Function_bool Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_uchar Function
-%138 = OpVariable %_ptr_Function_v4float Function
-%139 = OpVariable %_ptr_Function_v4float Function
-%140 = OpVariable %_ptr_Function_v4float Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_float Function
-%143 = OpVariable %_ptr_Function_uchar Function
-%144 = OpVariable %_ptr_Function_float Function
-%145 = OpVariable %_ptr_Function_float Function
-%146 = OpVariable %_ptr_Function_v4float Function
-%147 = OpVariable %_ptr_Function_v4float Function
-%148 = OpVariable %_ptr_Function_ulong Function
-OpStore %131 %119
-OpStore %130 %149
-%150 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
-OpStore %132 %150
-%152 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
-OpStore %139 %152
-%157 = OpLoad %v4float %132
-OpStore %147 %157
-OpStore %148 %ulong_0
-OpBranch %121
-%121 = OpLabel
-%159 = OpLoad %ulong %148
-%161 = OpULessThan %bool %159 %ulong_4
-OpStore %134 %161
-%162 = OpLoad %bool %134
-OpLoopMerge %123 %124 None
-OpBranchConditional %162 %122 %123
-%123 = OpLabel
-%163 = OpLoad %v4float %147
-%164 = OpCompositeExtract %float %163 0
-OpStore %142 %164
-%166 = OpAccessChain %_ptr_Function_uchar %130 %uint_3
-%167 = OpLoad %uchar %166
-OpStore %143 %167
-%168 = OpLoad %uchar %143
-%169 = OpConvertUToF %float %168
-OpStore %144 %169
-%170 = OpLoad %float %142
-%171 = OpLoad %float %144
-%172 = OpFAdd %float %170 %171
-OpStore %145 %172
-%173 = OpLoad %v4float %147
-%174 = OpLoad %float %145
-%175 = OpCompositeInsert %v4float %174 %173 0
-OpStore %146 %175
-%176 = OpLoad %v4float %146
-OpReturnValue %176
-%122 = OpLabel
-%177 = OpLoad %ulong %148
-%179 = OpIMul %ulong %177 %ulong_17
-OpStore %135 %179
-%180 = OpLoad %ulong %135
-%181 = OpUConvert %uchar %180
-OpStore %137 %181
-%182 = OpLoad %ulong %148
-%183 = OpAccessChain %_ptr_Function_uchar %130 %182
-%184 = OpLoad %uchar %137
-OpStore %183 %184
-%185 = OpLoad %v4float %147
-%186 = OpLoad %v4float %131
-%187 = OpFAdd %v4float %185 %186
-OpStore %138 %187
-%188 = OpLoad %v4float %138
-%189 = OpLoad %v4float %139
-%190 = OpFMul %v4float %188 %189
-OpStore %140 %190
-%191 = OpLoad %ulong %148
-%193 = OpIAdd %ulong %191 %ulong_1
-OpStore %141 %193
-%194 = OpLoad %v4float %140
-OpStore %147 %194
-%195 = OpLoad %ulong %141
-OpStore %148 %195
-OpBranch %124
-%124 = OpLabel
-OpBranch %121
-OpFunctionEnd
-%5 = OpFunction %ulong None %196
-%197 = OpFunctionParameter %ulong
-%198 = OpLabel
-%265 = OpVariable %_ptr_Function__arr__struct_262_uint_3 Function
-%269 = OpVariable %_ptr_Function__arr_v4float_uint_4 Function
-%270 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
-%271 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
-%272 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_float Function
-%276 = OpVariable %_ptr_Function_double Function
-%277 = OpVariable %_ptr_Function_float Function
-%278 = OpVariable %_ptr_Function_float Function
-%279 = OpVariable %_ptr_Function_v4float Function
-%280 = OpVariable %_ptr_Function_v2double Function
-%281 = OpVariable %_ptr_Function_v4uint Function
-%282 = OpVariable %_ptr_Function_v2double Function
-%283 = OpVariable %_ptr_Function_v4uint Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_uchar Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_uchar Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_uchar Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_uchar Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ushort Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_uchar Function
-%297 = OpVariable %_ptr_Function_float Function
-%298 = OpVariable %_ptr_Function_float Function
-%299 = OpVariable %_ptr_Function_v4float Function
-%300 = OpVariable %_ptr_Function_double Function
-%301 = OpVariable %_ptr_Function_double Function
-%302 = OpVariable %_ptr_Function_v2double Function
-%303 = OpVariable %_ptr_Function_uint Function
-%304 = OpVariable %_ptr_Function_uint Function
-%305 = OpVariable %_ptr_Function_uint Function
-%306 = OpVariable %_ptr_Function_v4uint Function
-%307 = OpVariable %_ptr_Function_v4float Function
-%308 = OpVariable %_ptr_Function_v4float Function
-%309 = OpVariable %_ptr_Function_v2double Function
-%310 = OpVariable %_ptr_Function_v2double Function
-%311 = OpVariable %_ptr_Function_v2double Function
-%312 = OpVariable %_ptr_Function_v4uint Function
-%313 = OpVariable %_ptr_Function_v4uint Function
-%314 = OpVariable %_ptr_Function_v4uint Function
-%315 = OpVariable %_ptr_Function_v4float Function
-%316 = OpVariable %_ptr_Function_v4float Function
-%317 = OpVariable %_ptr_Function_v4float Function
-%318 = OpVariable %_ptr_Function_bool Function
-%319 = OpVariable %_ptr_Function_v4float Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_bool Function
-%326 = OpVariable %_ptr_Function_ulong Function
-%327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_ulong Function
-%329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_ulong Function
-%331 = OpVariable %_ptr_Function_bool Function
-%332 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_ulong Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ulong Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ulong Function
-%341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_ulong Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_float Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_float Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_float Function
-%358 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_float Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_float Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_float Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_double Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_double Function
-%368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_uint Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_uint Function
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_uint Function
-%374 = OpVariable %_ptr_Function_ulong Function
-%375 = OpVariable %_ptr_Function_uint Function
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_float Function
-%378 = OpVariable %_ptr_Function_ulong Function
-%379 = OpVariable %_ptr_Function_float Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_float Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_float Function
-%384 = OpVariable %_ptr_Function_ulong Function
-%385 = OpVariable %_ptr_Function_float Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_float Function
-%388 = OpVariable %_ptr_Function_ulong Function
-%389 = OpVariable %_ptr_Function_float Function
-%390 = OpVariable %_ptr_Function_ulong Function
-%391 = OpVariable %_ptr_Function_float Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_double Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_double Function
-%396 = OpVariable %_ptr_Function_ulong Function
-%397 = OpVariable %_ptr_Function_double Function
-%398 = OpVariable %_ptr_Function_ulong Function
-%399 = OpVariable %_ptr_Function_double Function
-%400 = OpVariable %_ptr_Function_ulong Function
-%401 = OpVariable %_ptr_Function_double Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_double Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_double Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_double Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_uint Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_uint Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_uint Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_uint Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_uint Function
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_uint Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_uint Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_uint Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_uint Function
-%426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_uint Function
-%428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_uint Function
-%430 = OpVariable %_ptr_Function_ulong Function
-%431 = OpVariable %_ptr_Function_uint Function
-%432 = OpVariable %_ptr_Function_ulong Function
-%433 = OpVariable %_ptr_Function_uint Function
-%434 = OpVariable %_ptr_Function_ulong Function
-%435 = OpVariable %_ptr_Function_uint Function
-%436 = OpVariable %_ptr_Function_ulong Function
-%437 = OpVariable %_ptr_Function_uint Function
-%438 = OpVariable %_ptr_Function_ulong Function
-%439 = OpVariable %_ptr_Function_uint Function
-%440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_v4float Function
-%442 = OpVariable %_ptr_Function_bool Function
-%443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_uchar Function
-%445 = OpVariable %_ptr_Function_v4float Function
-%446 = OpVariable %_ptr_Function_v4float Function
-%447 = OpVariable %_ptr_Function_v4float Function
-%448 = OpVariable %_ptr_Function_ulong Function
-%449 = OpVariable %_ptr_Function_float Function
-%450 = OpVariable %_ptr_Function_uchar Function
-%451 = OpVariable %_ptr_Function_float Function
-%452 = OpVariable %_ptr_Function_float Function
-%453 = OpVariable %_ptr_Function_v4float Function
-%454 = OpVariable %_ptr_Function_v4float Function
-%455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_float Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_float Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_float Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_float Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_v4float Function
-%465 = OpVariable %_ptr_Function_bool Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_uchar Function
-%468 = OpVariable %_ptr_Function_v4float Function
-%469 = OpVariable %_ptr_Function_v4float Function
-%470 = OpVariable %_ptr_Function_v4float Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_float Function
-%473 = OpVariable %_ptr_Function_uchar Function
-%474 = OpVariable %_ptr_Function_float Function
-%475 = OpVariable %_ptr_Function_float Function
-%476 = OpVariable %_ptr_Function_v4float Function
-%477 = OpVariable %_ptr_Function_v4float Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_float Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_float Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_float Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_float Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_v4float Function
-%488 = OpVariable %_ptr_Function_bool Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_uchar Function
-%491 = OpVariable %_ptr_Function_v4float Function
-%492 = OpVariable %_ptr_Function_v4float Function
-%493 = OpVariable %_ptr_Function_v4float Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_float Function
-%496 = OpVariable %_ptr_Function_uchar Function
-%497 = OpVariable %_ptr_Function_float Function
-%498 = OpVariable %_ptr_Function_float Function
-%499 = OpVariable %_ptr_Function_v4float Function
-%500 = OpVariable %_ptr_Function_v4float Function
-%501 = OpVariable %_ptr_Function_ulong Function
-OpStore %273 %197
-%502 = OpFunctionCall %ulong %6
-OpStore %274 %502
-%503 = OpLoad %ulong %273
-%504 = OpConvertUToF %float %503
-OpStore %275 %504
-%505 = OpLoad %ulong %273
-%506 = OpConvertUToF %double %505
-OpStore %276 %506
-%508 = OpFNegate %float %float_2_25
-OpStore %277 %508
-%509 = OpFNegate %float %float_0_5
-OpStore %278 %509
-%511 = OpLoad %float %277
-%513 = OpLoad %float %278
-%510 = OpCompositeConstruct %v4float %float_1_5 %511 %float_3_75 %513
-OpStore %279 %510
-%514 = OpCompositeConstruct %v2double %double_1_25 %double_n3_5
-OpStore %280 %514
-%517 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_1 %uint_2654435761 %uint_305419896
-OpStore %281 %517
-%522 = OpCompositeConstruct %v2double %double_0_5 %double_6_25
-OpStore %282 %522
-%525 = OpCompositeConstruct %v4uint %uint_3266489917 %uint_2246822519 %uint_7 %uint_4294967291
-OpStore %283 %525
-OpStore %265 %529
-OpStore %269 %530
-%531 = OpLoad %ulong %273
-%532 = OpIAdd %ulong %531 %ulong_1
-OpStore %284 %532
-%533 = OpLoad %ulong %284
-%534 = OpUConvert %uchar %533
-OpStore %285 %534
-%535 = OpLoad %ulong %273
-%537 = OpIAdd %ulong %535 %ulong_3
-OpStore %286 %537
-%538 = OpLoad %ulong %286
-%539 = OpUConvert %uchar %538
-OpStore %287 %539
-%540 = OpLoad %ulong %273
-%542 = OpIAdd %ulong %540 %ulong_5
-OpStore %288 %542
-%543 = OpLoad %ulong %288
-%544 = OpUConvert %uchar %543
-OpStore %289 %544
-%545 = OpLoad %ulong %273
-%547 = OpIAdd %ulong %545 %ulong_7
-OpStore %290 %547
-%548 = OpLoad %ulong %290
-%549 = OpUConvert %uchar %548
-OpStore %291 %549
-%550 = OpLoad %ulong %273
-%552 = OpIAdd %ulong %550 %ulong_65521
-OpStore %292 %552
-%553 = OpLoad %ulong %292
-%554 = OpUConvert %ushort %553
-OpStore %294 %554
-%555 = OpLoad %ulong %273
-%557 = OpIAdd %ulong %555 %ulong_251
-OpStore %295 %557
-%558 = OpLoad %ulong %295
-%559 = OpUConvert %uchar %558
-OpStore %296 %559
-%560 = OpLoad %v4float %279
-%561 = OpCompositeExtract %float %560 0
-OpStore %297 %561
-%562 = OpLoad %float %297
-%563 = OpLoad %float %275
-%564 = OpFAdd %float %562 %563
-OpStore %298 %564
-%565 = OpLoad %v4float %279
-%566 = OpLoad %float %298
-%567 = OpCompositeInsert %v4float %566 %565 0
-OpStore %299 %567
-%568 = OpLoad %v2double %280
-%569 = OpCompositeExtract %double %568 1
-OpStore %300 %569
-%570 = OpLoad %double %300
-%571 = OpLoad %double %276
-%572 = OpFAdd %double %570 %571
-OpStore %301 %572
-%573 = OpLoad %v2double %280
-%574 = OpLoad %double %301
-%575 = OpCompositeInsert %v2double %574 %573 1
-OpStore %302 %575
-%576 = OpLoad %v4uint %281
-%577 = OpCompositeExtract %uint %576 2
-OpStore %303 %577
-%578 = OpLoad %ulong %273
-%579 = OpUConvert %uint %578
-OpStore %304 %579
-%580 = OpLoad %uint %303
-%581 = OpLoad %uint %304
-%582 = OpIAdd %uint %580 %581
-OpStore %305 %582
-%583 = OpLoad %v4uint %281
-%584 = OpLoad %uint %305
-%585 = OpCompositeInsert %v4uint %584 %583 2
-OpStore %306 %585
-OpBranch %208
-%208 = OpLabel
-%586 = OpLoad %v4float %299
-%587 = OpCompositeExtract %float %586 0
-OpStore %349 %587
-%588 = OpLoad %ulong %274
-%589 = OpLoad %float %349
-%590 = OpFunctionCall %ulong %11 %588 %589
-OpStore %350 %590
-%591 = OpLoad %v4float %299
-%592 = OpCompositeExtract %float %591 1
-OpStore %351 %592
-%593 = OpLoad %ulong %350
-%594 = OpLoad %float %351
-%595 = OpFunctionCall %ulong %11 %593 %594
-OpStore %352 %595
-%596 = OpLoad %v4float %299
-%597 = OpCompositeExtract %float %596 2
-OpStore %353 %597
-%598 = OpLoad %ulong %352
-%599 = OpLoad %float %353
-%600 = OpFunctionCall %ulong %11 %598 %599
-OpStore %354 %600
-%601 = OpLoad %v4float %299
-%602 = OpCompositeExtract %float %601 3
-OpStore %355 %602
-%603 = OpLoad %ulong %354
-%604 = OpLoad %float %355
-%605 = OpFunctionCall %ulong %11 %603 %604
-OpStore %356 %605
-OpBranch %209
-%209 = OpLabel
-OpBranch %212
-%212 = OpLabel
-%606 = OpLoad %v2double %302
-%607 = OpCompositeExtract %double %606 0
-OpStore %365 %607
-%608 = OpLoad %ulong %356
-%609 = OpLoad %double %365
-%610 = OpFunctionCall %ulong %12 %608 %609
-OpStore %366 %610
-%611 = OpLoad %v2double %302
-%612 = OpCompositeExtract %double %611 1
-OpStore %367 %612
-%613 = OpLoad %ulong %366
-%614 = OpLoad %double %367
-%615 = OpFunctionCall %ulong %12 %613 %614
-OpStore %368 %615
-OpBranch %213
-%213 = OpLabel
-OpBranch %214
-%214 = OpLabel
-%616 = OpLoad %v4uint %306
-%617 = OpCompositeExtract %uint %616 0
-OpStore %369 %617
-%618 = OpLoad %ulong %368
-%619 = OpLoad %uint %369
-%620 = OpFunctionCall %ulong %10 %618 %619
-OpStore %370 %620
-%621 = OpLoad %v4uint %306
-%622 = OpCompositeExtract %uint %621 1
-OpStore %371 %622
-%623 = OpLoad %ulong %370
-%624 = OpLoad %uint %371
-%625 = OpFunctionCall %ulong %10 %623 %624
-OpStore %372 %625
-%626 = OpLoad %v4uint %306
-%627 = OpCompositeExtract %uint %626 2
-OpStore %373 %627
-%628 = OpLoad %ulong %372
-%629 = OpLoad %uint %373
-%630 = OpFunctionCall %ulong %10 %628 %629
-OpStore %374 %630
-%631 = OpLoad %v4uint %306
-%632 = OpCompositeExtract %uint %631 3
-OpStore %375 %632
-%633 = OpLoad %ulong %374
-%634 = OpLoad %uint %375
-%635 = OpFunctionCall %ulong %10 %633 %634
-OpStore %376 %635
-OpBranch %215
-%215 = OpLabel
-%636 = OpLoad %v4float %299
-%637 = OpLoad %v4float %299
-%638 = OpFAdd %v4float %636 %637
-OpStore %307 %638
-OpBranch %216
-%216 = OpLabel
-%639 = OpLoad %v4float %307
-%640 = OpCompositeExtract %float %639 0
-OpStore %377 %640
-%641 = OpLoad %ulong %376
-%642 = OpLoad %float %377
-%643 = OpFunctionCall %ulong %11 %641 %642
-OpStore %378 %643
-%644 = OpLoad %v4float %307
-%645 = OpCompositeExtract %float %644 1
-OpStore %379 %645
-%646 = OpLoad %ulong %378
-%647 = OpLoad %float %379
-%648 = OpFunctionCall %ulong %11 %646 %647
-OpStore %380 %648
-%649 = OpLoad %v4float %307
-%650 = OpCompositeExtract %float %649 2
-OpStore %381 %650
-%651 = OpLoad %ulong %380
-%652 = OpLoad %float %381
-%653 = OpFunctionCall %ulong %11 %651 %652
-OpStore %382 %653
-%654 = OpLoad %v4float %307
-%655 = OpCompositeExtract %float %654 3
-OpStore %383 %655
-%656 = OpLoad %ulong %382
-%657 = OpLoad %float %383
-%658 = OpFunctionCall %ulong %11 %656 %657
-OpStore %384 %658
-OpBranch %217
-%217 = OpLabel
-%659 = OpLoad %v4float %299
-%660 = OpLoad %v4float %299
-%661 = OpFMul %v4float %659 %660
-OpStore %308 %661
-OpBranch %218
+%2 = OpFunction %ulong None %215
+%216 = OpFunctionParameter %ulong
+%217 = OpFunctionParameter %v2double
 %218 = OpLabel
-%662 = OpLoad %v4float %308
-%663 = OpCompositeExtract %float %662 0
-OpStore %385 %663
-%664 = OpLoad %ulong %384
-%665 = OpLoad %float %385
-%666 = OpFunctionCall %ulong %11 %664 %665
-OpStore %386 %666
-%667 = OpLoad %v4float %308
-%668 = OpCompositeExtract %float %667 1
-OpStore %387 %668
-%669 = OpLoad %ulong %386
-%670 = OpLoad %float %387
-%671 = OpFunctionCall %ulong %11 %669 %670
-OpStore %388 %671
-%672 = OpLoad %v4float %308
-%673 = OpCompositeExtract %float %672 2
-OpStore %389 %673
-%674 = OpLoad %ulong %388
-%675 = OpLoad %float %389
-%676 = OpFunctionCall %ulong %11 %674 %675
-OpStore %390 %676
-%677 = OpLoad %v4float %308
-%678 = OpCompositeExtract %float %677 3
-OpStore %391 %678
-%679 = OpLoad %ulong %390
-%680 = OpLoad %float %391
-%681 = OpFunctionCall %ulong %11 %679 %680
-OpStore %392 %681
+%235 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_v2double Function
+%239 = OpVariable %_ptr_Function_double Function
+%240 = OpVariable %_ptr_Function_double Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_bool Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_bool Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+OpStore %235 %216
+OpStore %237 %217
+%261 = OpLoad %v2double %237
+%262 = OpCompositeExtract %double %261 0
+OpStore %239 %262
 OpBranch %219
 %219 = OpLabel
-OpBranch %220
-%220 = OpLabel
-%682 = OpLoad %v2double %282
-%683 = OpCompositeExtract %double %682 0
-OpStore %393 %683
-%684 = OpLoad %ulong %392
-%685 = OpLoad %double %393
-%686 = OpFunctionCall %ulong %12 %684 %685
-OpStore %394 %686
-%687 = OpLoad %v2double %282
-%688 = OpCompositeExtract %double %687 1
-OpStore %395 %688
-%689 = OpLoad %ulong %394
-%690 = OpLoad %double %395
-%691 = OpFunctionCall %ulong %12 %689 %690
-OpStore %396 %691
+%263 = OpLoad %double %239
+%264 = OpBitcast %ulong %263
+OpStore %241 %264
 OpBranch %221
 %221 = OpLabel
-%692 = OpLoad %v2double %302
-%693 = OpLoad %v2double %282
-%694 = OpFMul %v2double %692 %693
-OpStore %309 %694
+%265 = OpLoad %ulong %235
+OpStore %249 %265
+OpStore %250 %ulong_0
 OpBranch %222
 %222 = OpLabel
-%695 = OpLoad %v2double %309
-%696 = OpCompositeExtract %double %695 0
-OpStore %397 %696
-%697 = OpLoad %ulong %396
-%698 = OpLoad %double %397
-%699 = OpFunctionCall %ulong %12 %697 %698
-OpStore %398 %699
-%700 = OpLoad %v2double %309
-%701 = OpCompositeExtract %double %700 1
-OpStore %399 %701
-%702 = OpLoad %ulong %398
-%703 = OpLoad %double %399
-%704 = OpFunctionCall %ulong %12 %702 %703
-OpStore %400 %704
-OpBranch %223
-%223 = OpLabel
-%705 = OpLoad %v2double %302
-%706 = OpLoad %v2double %282
-%707 = OpFSub %v2double %705 %706
-OpStore %310 %707
-OpBranch %224
+%266 = OpLoad %ulong %250
+%267 = OpULessThan %bool %266 %ulong_8
+OpStore %242 %267
+%268 = OpLoad %bool %242
+OpLoopMerge %224 %234 None
+OpBranchConditional %268 %223 %224
 %224 = OpLabel
-%708 = OpLoad %v2double %310
-%709 = OpCompositeExtract %double %708 0
-OpStore %401 %709
-%710 = OpLoad %ulong %400
-%711 = OpLoad %double %401
-%712 = OpFunctionCall %ulong %12 %710 %711
-OpStore %402 %712
-%713 = OpLoad %v2double %310
-%714 = OpCompositeExtract %double %713 1
-OpStore %403 %714
-%715 = OpLoad %ulong %402
-%716 = OpLoad %double %403
-%717 = OpFunctionCall %ulong %12 %715 %716
-OpStore %404 %717
 OpBranch %225
 %225 = OpLabel
-%718 = OpLoad %v2double %302
-%719 = OpLoad %v2double %282
-%720 = OpFDiv %v2double %718 %719
-OpStore %311 %720
+OpBranch %220
+%220 = OpLabel
+%269 = OpLoad %v2double %237
+%270 = OpCompositeExtract %double %269 1
+OpStore %240 %270
 OpBranch %226
 %226 = OpLabel
-%721 = OpLoad %v2double %311
-%722 = OpCompositeExtract %double %721 0
-OpStore %405 %722
-%723 = OpLoad %ulong %404
-%724 = OpLoad %double %405
-%725 = OpFunctionCall %ulong %12 %723 %724
-OpStore %406 %725
-%726 = OpLoad %v2double %311
-%727 = OpCompositeExtract %double %726 1
-OpStore %407 %727
-%728 = OpLoad %ulong %406
-%729 = OpLoad %double %407
-%730 = OpFunctionCall %ulong %12 %728 %729
-OpStore %408 %730
-OpBranch %227
-%227 = OpLabel
+%271 = OpLoad %double %240
+%272 = OpBitcast %ulong %271
+OpStore %251 %272
 OpBranch %228
 %228 = OpLabel
-%731 = OpLoad %v4uint %283
-%732 = OpCompositeExtract %uint %731 0
-OpStore %409 %732
-%733 = OpLoad %ulong %408
-%734 = OpLoad %uint %409
-%735 = OpFunctionCall %ulong %10 %733 %734
-OpStore %410 %735
-%736 = OpLoad %v4uint %283
-%737 = OpCompositeExtract %uint %736 1
-OpStore %411 %737
-%738 = OpLoad %ulong %410
-%739 = OpLoad %uint %411
-%740 = OpFunctionCall %ulong %10 %738 %739
-OpStore %412 %740
-%741 = OpLoad %v4uint %283
-%742 = OpCompositeExtract %uint %741 2
-OpStore %413 %742
-%743 = OpLoad %ulong %412
-%744 = OpLoad %uint %413
-%745 = OpFunctionCall %ulong %10 %743 %744
-OpStore %414 %745
-%746 = OpLoad %v4uint %283
-%747 = OpCompositeExtract %uint %746 3
-OpStore %415 %747
-%748 = OpLoad %ulong %414
-%749 = OpLoad %uint %415
-%750 = OpFunctionCall %ulong %10 %748 %749
-OpStore %416 %750
+%273 = OpLoad %ulong %249
+OpStore %259 %273
+OpStore %260 %ulong_0
 OpBranch %229
 %229 = OpLabel
-%751 = OpLoad %v4uint %306
-%752 = OpLoad %v4uint %283
-%753 = OpIMul %v4uint %751 %752
-OpStore %312 %753
-OpBranch %230
-%230 = OpLabel
-%754 = OpLoad %v4uint %312
-%755 = OpCompositeExtract %uint %754 0
-OpStore %417 %755
-%756 = OpLoad %ulong %416
-%757 = OpLoad %uint %417
-%758 = OpFunctionCall %ulong %10 %756 %757
-OpStore %418 %758
-%759 = OpLoad %v4uint %312
-%760 = OpCompositeExtract %uint %759 1
-OpStore %419 %760
-%761 = OpLoad %ulong %418
-%762 = OpLoad %uint %419
-%763 = OpFunctionCall %ulong %10 %761 %762
-OpStore %420 %763
-%764 = OpLoad %v4uint %312
-%765 = OpCompositeExtract %uint %764 2
-OpStore %421 %765
-%766 = OpLoad %ulong %420
-%767 = OpLoad %uint %421
-%768 = OpFunctionCall %ulong %10 %766 %767
-OpStore %422 %768
-%769 = OpLoad %v4uint %312
-%770 = OpCompositeExtract %uint %769 3
-OpStore %423 %770
-%771 = OpLoad %ulong %422
-%772 = OpLoad %uint %423
-%773 = OpFunctionCall %ulong %10 %771 %772
-OpStore %424 %773
-OpBranch %231
+%274 = OpLoad %ulong %260
+%275 = OpULessThan %bool %274 %ulong_8
+OpStore %252 %275
+%276 = OpLoad %bool %252
+OpLoopMerge %231 %233 None
+OpBranchConditional %276 %230 %231
 %231 = OpLabel
-%774 = OpLoad %v4uint %306
-%775 = OpLoad %v4uint %283
-%776 = OpIAdd %v4uint %774 %775
-OpStore %313 %776
 OpBranch %232
 %232 = OpLabel
-%777 = OpLoad %v4uint %313
-%778 = OpCompositeExtract %uint %777 0
-OpStore %425 %778
-%779 = OpLoad %ulong %424
-%780 = OpLoad %uint %425
-%781 = OpFunctionCall %ulong %10 %779 %780
-OpStore %426 %781
-%782 = OpLoad %v4uint %313
-%783 = OpCompositeExtract %uint %782 1
-OpStore %427 %783
-%784 = OpLoad %ulong %426
-%785 = OpLoad %uint %427
-%786 = OpFunctionCall %ulong %10 %784 %785
-OpStore %428 %786
-%787 = OpLoad %v4uint %313
-%788 = OpCompositeExtract %uint %787 2
-OpStore %429 %788
-%789 = OpLoad %ulong %428
-%790 = OpLoad %uint %429
-%791 = OpFunctionCall %ulong %10 %789 %790
-OpStore %430 %791
-%792 = OpLoad %v4uint %313
-%793 = OpCompositeExtract %uint %792 3
-OpStore %431 %793
-%794 = OpLoad %ulong %430
-%795 = OpLoad %uint %431
-%796 = OpFunctionCall %ulong %10 %794 %795
-OpStore %432 %796
+OpBranch %227
+%227 = OpLabel
+%277 = OpLoad %ulong %259
+OpReturnValue %277
+%230 = OpLabel
+%278 = OpLoad %ulong %260
+%279 = OpIMul %ulong %278 %ulong_8
+OpStore %253 %279
+%280 = OpLoad %ulong %251
+%281 = OpLoad %ulong %253
+%282 = OpShiftRightLogical %ulong %280 %281
+OpStore %254 %282
+%283 = OpLoad %ulong %254
+%284 = OpBitwiseAnd %ulong %283 %ulong_255
+OpStore %255 %284
+%285 = OpLoad %ulong %259
+%286 = OpLoad %ulong %255
+%287 = OpBitwiseXor %ulong %285 %286
+OpStore %256 %287
+%288 = OpLoad %ulong %256
+%289 = OpIMul %ulong %288 %ulong_1099511628211
+OpStore %257 %289
+%290 = OpLoad %ulong %260
+%291 = OpIAdd %ulong %290 %ulong_1
+OpStore %258 %291
+%292 = OpLoad %ulong %257
+OpStore %259 %292
+%293 = OpLoad %ulong %258
+OpStore %260 %293
 OpBranch %233
-%233 = OpLabel
-%797 = OpLoad %v4uint %306
-%798 = OpLoad %v4uint %283
-%799 = OpBitwiseXor %v4uint %797 %798
-OpStore %314 %799
+%223 = OpLabel
+%294 = OpLoad %ulong %250
+%295 = OpIMul %ulong %294 %ulong_8
+OpStore %243 %295
+%296 = OpLoad %ulong %241
+%297 = OpLoad %ulong %243
+%298 = OpShiftRightLogical %ulong %296 %297
+OpStore %244 %298
+%299 = OpLoad %ulong %244
+%300 = OpBitwiseAnd %ulong %299 %ulong_255
+OpStore %245 %300
+%301 = OpLoad %ulong %249
+%302 = OpLoad %ulong %245
+%303 = OpBitwiseXor %ulong %301 %302
+OpStore %246 %303
+%304 = OpLoad %ulong %246
+%305 = OpIMul %ulong %304 %ulong_1099511628211
+OpStore %247 %305
+%306 = OpLoad %ulong %250
+%307 = OpIAdd %ulong %306 %ulong_1
+OpStore %248 %307
+%308 = OpLoad %ulong %247
+OpStore %249 %308
+%309 = OpLoad %ulong %248
+OpStore %250 %309
 OpBranch %234
+%233 = OpLabel
+OpBranch %229
 %234 = OpLabel
-%800 = OpLoad %v4uint %314
-%801 = OpCompositeExtract %uint %800 0
-OpStore %433 %801
-%802 = OpLoad %ulong %432
-%803 = OpLoad %uint %433
-%804 = OpFunctionCall %ulong %10 %802 %803
-OpStore %434 %804
-%805 = OpLoad %v4uint %314
-%806 = OpCompositeExtract %uint %805 1
-OpStore %435 %806
-%807 = OpLoad %ulong %434
-%808 = OpLoad %uint %435
-%809 = OpFunctionCall %ulong %10 %807 %808
-OpStore %436 %809
-%810 = OpLoad %v4uint %314
-%811 = OpCompositeExtract %uint %810 2
-OpStore %437 %811
-%812 = OpLoad %ulong %436
-%813 = OpLoad %uint %437
-%814 = OpFunctionCall %ulong %10 %812 %813
-OpStore %438 %814
-%815 = OpLoad %v4uint %314
-%816 = OpCompositeExtract %uint %815 3
-OpStore %439 %816
-%817 = OpLoad %ulong %438
-%818 = OpLoad %uint %439
-%819 = OpFunctionCall %ulong %10 %817 %818
-OpStore %440 %819
-OpBranch %235
-%235 = OpLabel
-OpBranch %236
-%236 = OpLabel
-OpStore %270 %149
-%820 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
-OpStore %441 %820
-%821 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
-OpStore %446 %821
-%822 = OpLoad %v4float %441
-OpStore %454 %822
-OpStore %455 %ulong_0
-OpBranch %237
-%237 = OpLabel
-%823 = OpLoad %ulong %455
-%824 = OpULessThan %bool %823 %ulong_4
-OpStore %442 %824
-%825 = OpLoad %bool %442
-OpLoopMerge %239 %260 None
-OpBranchConditional %825 %238 %239
-%239 = OpLabel
-%826 = OpLoad %v4float %454
-%827 = OpCompositeExtract %float %826 0
-OpStore %449 %827
-%828 = OpAccessChain %_ptr_Function_uchar %270 %uint_3
-%829 = OpLoad %uchar %828
-OpStore %450 %829
-%830 = OpLoad %uchar %450
-%831 = OpConvertUToF %float %830
-OpStore %451 %831
-%832 = OpLoad %float %449
-%833 = OpLoad %float %451
-%834 = OpFAdd %float %832 %833
-OpStore %452 %834
-%835 = OpLoad %v4float %454
-%836 = OpLoad %float %452
-%837 = OpCompositeInsert %v4float %836 %835 0
-OpStore %453 %837
-OpBranch %240
-%240 = OpLabel
-OpBranch %241
-%241 = OpLabel
-%838 = OpLoad %v4float %453
-%839 = OpCompositeExtract %float %838 0
-OpStore %456 %839
-%840 = OpLoad %ulong %440
-%841 = OpLoad %float %456
-%842 = OpFunctionCall %ulong %11 %840 %841
-OpStore %457 %842
-%843 = OpLoad %v4float %453
-%844 = OpCompositeExtract %float %843 1
-OpStore %458 %844
-%845 = OpLoad %ulong %457
-%846 = OpLoad %float %458
-%847 = OpFunctionCall %ulong %11 %845 %846
-OpStore %459 %847
-%848 = OpLoad %v4float %453
-%849 = OpCompositeExtract %float %848 2
-OpStore %460 %849
-%850 = OpLoad %ulong %459
-%851 = OpLoad %float %460
-%852 = OpFunctionCall %ulong %11 %850 %851
-OpStore %461 %852
-%853 = OpLoad %v4float %453
-%854 = OpCompositeExtract %float %853 3
-OpStore %462 %854
-%855 = OpLoad %ulong %461
-%856 = OpLoad %float %462
-%857 = OpFunctionCall %ulong %11 %855 %856
-OpStore %463 %857
-OpBranch %242
-%242 = OpLabel
-%858 = OpLoad %v4float %299
-%859 = OpLoad %v4float %299
-%860 = OpFMul %v4float %858 %859
-OpStore %315 %860
-OpBranch %243
-%243 = OpLabel
-OpStore %271 %149
-%861 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
-OpStore %464 %861
-%862 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
-OpStore %469 %862
-%863 = OpLoad %v4float %464
-OpStore %477 %863
-OpStore %478 %ulong_0
-OpBranch %244
-%244 = OpLabel
-%864 = OpLoad %ulong %478
-%865 = OpULessThan %bool %864 %ulong_4
-OpStore %465 %865
-%866 = OpLoad %bool %465
-OpLoopMerge %246 %259 None
-OpBranchConditional %866 %245 %246
-%246 = OpLabel
-%867 = OpLoad %v4float %477
-%868 = OpCompositeExtract %float %867 0
-OpStore %472 %868
-%869 = OpAccessChain %_ptr_Function_uchar %271 %uint_3
-%870 = OpLoad %uchar %869
-OpStore %473 %870
-%871 = OpLoad %uchar %473
-%872 = OpConvertUToF %float %871
-OpStore %474 %872
-%873 = OpLoad %float %472
-%874 = OpLoad %float %474
-%875 = OpFAdd %float %873 %874
-OpStore %475 %875
-%876 = OpLoad %v4float %477
-%877 = OpLoad %float %475
-%878 = OpCompositeInsert %v4float %877 %876 0
-OpStore %476 %878
-OpBranch %247
-%247 = OpLabel
-OpBranch %248
-%248 = OpLabel
-%879 = OpLoad %v4float %476
-%880 = OpCompositeExtract %float %879 0
-OpStore %479 %880
-%881 = OpLoad %ulong %463
-%882 = OpLoad %float %479
-%883 = OpFunctionCall %ulong %11 %881 %882
-OpStore %480 %883
-%884 = OpLoad %v4float %476
-%885 = OpCompositeExtract %float %884 1
-OpStore %481 %885
-%886 = OpLoad %ulong %480
-%887 = OpLoad %float %481
-%888 = OpFunctionCall %ulong %11 %886 %887
-OpStore %482 %888
-%889 = OpLoad %v4float %476
-%890 = OpCompositeExtract %float %889 2
-OpStore %483 %890
-%891 = OpLoad %ulong %482
-%892 = OpLoad %float %483
-%893 = OpFunctionCall %ulong %11 %891 %892
-OpStore %484 %893
-%894 = OpLoad %v4float %476
-%895 = OpCompositeExtract %float %894 3
-OpStore %485 %895
-%896 = OpLoad %ulong %484
-%897 = OpLoad %float %485
-%898 = OpFunctionCall %ulong %11 %896 %897
-OpStore %486 %898
-OpBranch %249
-%249 = OpLabel
-%900 = OpAccessChain %_ptr_Function_v4float %269 %uint_0
-%901 = OpLoad %v4float %299
-OpStore %900 %901
-%902 = OpLoad %v4float %299
-%903 = OpLoad %v4float %299
-%904 = OpFAdd %v4float %902 %903
-OpStore %316 %904
-%905 = OpAccessChain %_ptr_Function_v4float %269 %uint_1
-%906 = OpLoad %v4float %316
-OpStore %905 %906
-OpBranch %250
-%250 = OpLabel
-OpStore %272 %149
-%907 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
-OpStore %487 %907
-%908 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
-OpStore %492 %908
-%909 = OpLoad %v4float %487
-OpStore %500 %909
-OpStore %501 %ulong_0
-OpBranch %251
-%251 = OpLabel
-%910 = OpLoad %ulong %501
-%911 = OpULessThan %bool %910 %ulong_4
-OpStore %488 %911
-%912 = OpLoad %bool %488
-OpLoopMerge %253 %258 None
-OpBranchConditional %912 %252 %253
-%253 = OpLabel
-%913 = OpLoad %v4float %500
-%914 = OpCompositeExtract %float %913 0
-OpStore %495 %914
-%915 = OpAccessChain %_ptr_Function_uchar %272 %uint_3
-%916 = OpLoad %uchar %915
-OpStore %496 %916
-%917 = OpLoad %uchar %496
-%918 = OpConvertUToF %float %917
-OpStore %497 %918
-%919 = OpLoad %float %495
-%920 = OpLoad %float %497
-%921 = OpFAdd %float %919 %920
-OpStore %498 %921
-%922 = OpLoad %v4float %500
-%923 = OpLoad %float %498
-%924 = OpCompositeInsert %v4float %923 %922 0
-OpStore %499 %924
-OpBranch %254
-%254 = OpLabel
-%926 = OpAccessChain %_ptr_Function_v4float %269 %uint_2
-%927 = OpLoad %v4float %499
-OpStore %926 %927
-%928 = OpLoad %v4float %299
-%929 = OpLoad %v4float %299
-%930 = OpFMul %v4float %928 %929
-OpStore %317 %930
-%931 = OpAccessChain %_ptr_Function_v4float %269 %uint_3
-%932 = OpLoad %v4float %317
-OpStore %931 %932
-%933 = OpLoad %ulong %486
-OpStore %345 %933
-OpStore %348 %ulong_0
-OpBranch %199
-%199 = OpLabel
-%934 = OpLoad %ulong %348
-%935 = OpULessThan %bool %934 %ulong_4
-OpStore %318 %935
-%936 = OpLoad %bool %318
-OpLoopMerge %201 %257 None
-OpBranchConditional %936 %200 %201
-%201 = OpLabel
-%938 = OpLoad %ulong %273
-%939 = OpIAdd %ulong %ulong_1229782938247303441 %938
-OpStore %321 %939
-%941 = OpLoad %ulong %273
-%942 = OpBitwiseXor %ulong %ulong_8608480567731124087 %941
-OpStore %322 %942
-%943 = OpLoad %ulong %345
-%944 = OpLoad %ulong %321
-%945 = OpFunctionCall %ulong %7 %943 %944
-OpStore %323 %945
-%946 = OpLoad %ulong %323
-%947 = OpLoad %ulong %322
-%948 = OpFunctionCall %ulong %7 %946 %947
-OpStore %324 %948
-OpStore %347 %ulong_0
-OpBranch %202
-%202 = OpLabel
-%949 = OpLoad %ulong %347
-%950 = OpULessThan %bool %949 %ulong_3
-OpStore %325 %950
-%951 = OpLoad %bool %325
-OpLoopMerge %204 %256 None
-OpBranchConditional %951 %203 %204
-%204 = OpLabel
-%952 = OpLoad %ulong %324
-OpStore %344 %952
-OpStore %346 %ulong_0
-OpBranch %205
-%205 = OpLabel
-%953 = OpLoad %ulong %346
-%954 = OpULessThan %bool %953 %ulong_3
-OpStore %331 %954
-%955 = OpLoad %bool %331
-OpLoopMerge %207 %255 None
-OpBranchConditional %955 %206 %207
-%207 = OpLabel
-%956 = OpLoad %ulong %344
-%957 = OpLoad %uchar %285
-%958 = OpFunctionCall %ulong %8 %956 %957
-OpStore %337 %958
-%959 = OpLoad %ulong %337
-%961 = OpFunctionCall %ulong %8 %959 %uchar_0
-OpStore %338 %961
-%962 = OpLoad %ulong %338
-%963 = OpLoad %uchar %287
-%964 = OpFunctionCall %ulong %8 %962 %963
-OpStore %339 %964
-%965 = OpLoad %ulong %339
-%966 = OpLoad %uchar %289
-%967 = OpFunctionCall %ulong %8 %965 %966
-OpStore %340 %967
-%968 = OpLoad %ulong %340
-%969 = OpLoad %uchar %291
-%970 = OpFunctionCall %ulong %8 %968 %969
-OpStore %341 %970
-%971 = OpLoad %ulong %341
-%972 = OpLoad %ushort %294
-%973 = OpFunctionCall %ulong %9 %971 %972
-OpStore %342 %973
-%974 = OpLoad %ulong %342
-%975 = OpLoad %uchar %296
-%976 = OpFunctionCall %ulong %8 %974 %975
-OpStore %343 %976
-%977 = OpLoad %ulong %343
-OpReturnValue %977
-%206 = OpLabel
-%978 = OpLoad %ulong %346
-%980 = OpAccessChain %_ptr_Function__struct_262 %265 %978
-%981 = OpAccessChain %_ptr_Function_ulong %980 %uint_0
-%982 = OpLoad %ulong %981
-OpStore %332 %982
-%983 = OpLoad %ulong %344
-%984 = OpLoad %ulong %332
-%985 = OpFunctionCall %ulong %7 %983 %984
-OpStore %333 %985
-%986 = OpAccessChain %_ptr_Function_ulong %980 %uint_1
-%987 = OpLoad %ulong %986
-OpStore %334 %987
-%988 = OpLoad %ulong %333
-%989 = OpLoad %ulong %334
-%990 = OpFunctionCall %ulong %7 %988 %989
-OpStore %335 %990
-%991 = OpLoad %ulong %346
-%992 = OpIAdd %ulong %991 %ulong_1
-OpStore %336 %992
-%993 = OpLoad %ulong %335
-OpStore %344 %993
-%994 = OpLoad %ulong %336
-OpStore %346 %994
-OpBranch %255
-%203 = OpLabel
-%995 = OpLoad %ulong %347
-%997 = OpIMul %ulong %995 %ulong_2654435761
-OpStore %326 %997
-%998 = OpLoad %ulong %326
-%999 = OpLoad %ulong %273
-%1000 = OpIAdd %ulong %998 %999
-OpStore %327 %1000
-%1001 = OpLoad %ulong %347
-%1002 = OpAccessChain %_ptr_Function__struct_262 %265 %1001
-%1003 = OpAccessChain %_ptr_Function_ulong %1002 %uint_0
-%1004 = OpLoad %ulong %327
-OpStore %1003 %1004
-%1005 = OpLoad %ulong %347
-%1007 = OpShiftLeftLogical %ulong %1005 %ulong_40
-OpStore %328 %1007
-%1008 = OpLoad %ulong %328
-%1009 = OpLoad %ulong %321
-%1010 = OpBitwiseXor %ulong %1008 %1009
-OpStore %329 %1010
-%1011 = OpAccessChain %_ptr_Function_ulong %1002 %uint_1
-%1012 = OpLoad %ulong %329
-OpStore %1011 %1012
-%1013 = OpLoad %ulong %347
-%1014 = OpIAdd %ulong %1013 %ulong_1
-OpStore %330 %1014
-%1015 = OpLoad %ulong %330
-OpStore %347 %1015
-OpBranch %256
-%200 = OpLabel
-%1016 = OpLoad %ulong %348
-%1017 = OpAccessChain %_ptr_Function_v4float %269 %1016
-%1018 = OpLoad %v4float %1017
-OpStore %319 %1018
-OpBranch %210
-%210 = OpLabel
-%1019 = OpLoad %v4float %319
-%1020 = OpCompositeExtract %float %1019 0
-OpStore %357 %1020
-%1021 = OpLoad %ulong %345
-%1022 = OpLoad %float %357
-%1023 = OpFunctionCall %ulong %11 %1021 %1022
-OpStore %358 %1023
-%1024 = OpLoad %v4float %319
-%1025 = OpCompositeExtract %float %1024 1
-OpStore %359 %1025
-%1026 = OpLoad %ulong %358
-%1027 = OpLoad %float %359
-%1028 = OpFunctionCall %ulong %11 %1026 %1027
-OpStore %360 %1028
-%1029 = OpLoad %v4float %319
-%1030 = OpCompositeExtract %float %1029 2
-OpStore %361 %1030
-%1031 = OpLoad %ulong %360
-%1032 = OpLoad %float %361
-%1033 = OpFunctionCall %ulong %11 %1031 %1032
-OpStore %362 %1033
-%1034 = OpLoad %v4float %319
-%1035 = OpCompositeExtract %float %1034 3
-OpStore %363 %1035
-%1036 = OpLoad %ulong %362
-%1037 = OpLoad %float %363
-%1038 = OpFunctionCall %ulong %11 %1036 %1037
-OpStore %364 %1038
-OpBranch %211
-%211 = OpLabel
-%1039 = OpLoad %ulong %348
-%1040 = OpIAdd %ulong %1039 %ulong_1
-OpStore %320 %1040
-%1041 = OpLoad %ulong %364
-OpStore %345 %1041
-%1042 = OpLoad %ulong %320
-OpStore %348 %1042
-OpBranch %257
-%252 = OpLabel
-%1043 = OpLoad %ulong %501
-%1044 = OpIMul %ulong %1043 %ulong_17
-OpStore %489 %1044
-%1045 = OpLoad %ulong %489
-%1046 = OpUConvert %uchar %1045
-OpStore %490 %1046
-%1047 = OpLoad %ulong %501
-%1048 = OpAccessChain %_ptr_Function_uchar %272 %1047
-%1049 = OpLoad %uchar %490
-OpStore %1048 %1049
-%1050 = OpLoad %v4float %500
-%1051 = OpLoad %v4float %299
-%1052 = OpFAdd %v4float %1050 %1051
-OpStore %491 %1052
-%1053 = OpLoad %v4float %491
-%1054 = OpLoad %v4float %492
-%1055 = OpFMul %v4float %1053 %1054
-OpStore %493 %1055
-%1056 = OpLoad %ulong %501
-%1057 = OpIAdd %ulong %1056 %ulong_1
-OpStore %494 %1057
-%1058 = OpLoad %v4float %493
-OpStore %500 %1058
-%1059 = OpLoad %ulong %494
-OpStore %501 %1059
-OpBranch %258
-%245 = OpLabel
-%1060 = OpLoad %ulong %478
-%1061 = OpIMul %ulong %1060 %ulong_17
-OpStore %466 %1061
-%1062 = OpLoad %ulong %466
-%1063 = OpUConvert %uchar %1062
-OpStore %467 %1063
-%1064 = OpLoad %ulong %478
-%1065 = OpAccessChain %_ptr_Function_uchar %271 %1064
-%1066 = OpLoad %uchar %467
-OpStore %1065 %1066
-%1067 = OpLoad %v4float %477
-%1068 = OpLoad %v4float %315
-%1069 = OpFAdd %v4float %1067 %1068
-OpStore %468 %1069
-%1070 = OpLoad %v4float %468
-%1071 = OpLoad %v4float %469
-%1072 = OpFMul %v4float %1070 %1071
-OpStore %470 %1072
-%1073 = OpLoad %ulong %478
-%1074 = OpIAdd %ulong %1073 %ulong_1
-OpStore %471 %1074
-%1075 = OpLoad %v4float %470
-OpStore %477 %1075
-%1076 = OpLoad %ulong %471
-OpStore %478 %1076
-OpBranch %259
-%238 = OpLabel
-%1077 = OpLoad %ulong %455
-%1078 = OpIMul %ulong %1077 %ulong_17
-OpStore %443 %1078
-%1079 = OpLoad %ulong %443
-%1080 = OpUConvert %uchar %1079
-OpStore %444 %1080
-%1081 = OpLoad %ulong %455
-%1082 = OpAccessChain %_ptr_Function_uchar %270 %1081
-%1083 = OpLoad %uchar %444
-OpStore %1082 %1083
-%1084 = OpLoad %v4float %454
-%1085 = OpLoad %v4float %299
-%1086 = OpFAdd %v4float %1084 %1085
-OpStore %445 %1086
-%1087 = OpLoad %v4float %445
-%1088 = OpLoad %v4float %446
-%1089 = OpFMul %v4float %1087 %1088
-OpStore %447 %1089
-%1090 = OpLoad %ulong %455
-%1091 = OpIAdd %ulong %1090 %ulong_1
-OpStore %448 %1091
-%1092 = OpLoad %v4float %447
-OpStore %454 %1092
-%1093 = OpLoad %ulong %448
-OpStore %455 %1093
-OpBranch %260
-%255 = OpLabel
-OpBranch %205
-%256 = OpLabel
-OpBranch %202
-%257 = OpLabel
-OpBranch %199
-%258 = OpLabel
-OpBranch %251
-%259 = OpLabel
-OpBranch %244
-%260 = OpLabel
-OpBranch %237
+OpBranch %222
 OpFunctionEnd
-%6 = OpFunction %ulong None %1094
-%1095 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%3 = OpFunction %ulong None %311
+%312 = OpFunctionParameter %ulong
+%313 = OpFunctionParameter %v4uint
+%314 = OpLabel
+%347 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_v4uint Function
+%350 = OpVariable %_ptr_Function_uint Function
+%351 = OpVariable %_ptr_Function_uint Function
+%352 = OpVariable %_ptr_Function_uint Function
+%353 = OpVariable %_ptr_Function_uint Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_bool Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_bool Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_bool Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_bool Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+OpStore %347 %312
+OpStore %349 %313
+%394 = OpLoad %v4uint %349
+%395 = OpCompositeExtract %uint %394 0
+OpStore %350 %395
+OpBranch %315
+%315 = OpLabel
+%396 = OpLoad %uint %350
+%397 = OpUConvert %ulong %396
+OpStore %354 %397
+OpBranch %317
+%317 = OpLabel
+%398 = OpLoad %ulong %347
+OpStore %362 %398
+OpStore %363 %ulong_0
+OpBranch %318
+%318 = OpLabel
+%399 = OpLoad %ulong %363
+%400 = OpULessThan %bool %399 %ulong_8
+OpStore %355 %400
+%401 = OpLoad %bool %355
+OpLoopMerge %320 %346 None
+OpBranchConditional %401 %319 %320
+%320 = OpLabel
+OpBranch %321
+%321 = OpLabel
+OpBranch %316
+%316 = OpLabel
+%402 = OpLoad %v4uint %349
+%403 = OpCompositeExtract %uint %402 1
+OpStore %351 %403
+OpBranch %322
+%322 = OpLabel
+%404 = OpLoad %uint %351
+%405 = OpUConvert %ulong %404
+OpStore %364 %405
+OpBranch %324
+%324 = OpLabel
+%406 = OpLoad %ulong %362
+OpStore %372 %406
+OpStore %373 %ulong_0
+OpBranch %325
+%325 = OpLabel
+%407 = OpLoad %ulong %373
+%408 = OpULessThan %bool %407 %ulong_8
+OpStore %365 %408
+%409 = OpLoad %bool %365
+OpLoopMerge %327 %345 None
+OpBranchConditional %409 %326 %327
+%327 = OpLabel
+OpBranch %328
+%328 = OpLabel
+OpBranch %323
+%323 = OpLabel
+%410 = OpLoad %v4uint %349
+%411 = OpCompositeExtract %uint %410 2
+OpStore %352 %411
+OpBranch %329
+%329 = OpLabel
+%412 = OpLoad %uint %352
+%413 = OpUConvert %ulong %412
+OpStore %374 %413
+OpBranch %331
+%331 = OpLabel
+%414 = OpLoad %ulong %372
+OpStore %382 %414
+OpStore %383 %ulong_0
+OpBranch %332
+%332 = OpLabel
+%415 = OpLoad %ulong %383
+%416 = OpULessThan %bool %415 %ulong_8
+OpStore %375 %416
+%417 = OpLoad %bool %375
+OpLoopMerge %334 %344 None
+OpBranchConditional %417 %333 %334
+%334 = OpLabel
+OpBranch %335
+%335 = OpLabel
+OpBranch %330
+%330 = OpLabel
+%418 = OpLoad %v4uint %349
+%419 = OpCompositeExtract %uint %418 3
+OpStore %353 %419
+OpBranch %336
+%336 = OpLabel
+%420 = OpLoad %uint %353
+%421 = OpUConvert %ulong %420
+OpStore %384 %421
+OpBranch %338
+%338 = OpLabel
+%422 = OpLoad %ulong %382
+OpStore %392 %422
+OpStore %393 %ulong_0
+OpBranch %339
+%339 = OpLabel
+%423 = OpLoad %ulong %393
+%424 = OpULessThan %bool %423 %ulong_8
+OpStore %385 %424
+%425 = OpLoad %bool %385
+OpLoopMerge %341 %343 None
+OpBranchConditional %425 %340 %341
+%341 = OpLabel
+OpBranch %342
+%342 = OpLabel
+OpBranch %337
+%337 = OpLabel
+%426 = OpLoad %ulong %392
+OpReturnValue %426
+%340 = OpLabel
+%427 = OpLoad %ulong %393
+%428 = OpIMul %ulong %427 %ulong_8
+OpStore %386 %428
+%429 = OpLoad %ulong %384
+%430 = OpLoad %ulong %386
+%431 = OpShiftRightLogical %ulong %429 %430
+OpStore %387 %431
+%432 = OpLoad %ulong %387
+%433 = OpBitwiseAnd %ulong %432 %ulong_255
+OpStore %388 %433
+%434 = OpLoad %ulong %392
+%435 = OpLoad %ulong %388
+%436 = OpBitwiseXor %ulong %434 %435
+OpStore %389 %436
+%437 = OpLoad %ulong %389
+%438 = OpIMul %ulong %437 %ulong_1099511628211
+OpStore %390 %438
+%439 = OpLoad %ulong %393
+%440 = OpIAdd %ulong %439 %ulong_1
+OpStore %391 %440
+%441 = OpLoad %ulong %390
+OpStore %392 %441
+%442 = OpLoad %ulong %391
+OpStore %393 %442
+OpBranch %343
+%333 = OpLabel
+%443 = OpLoad %ulong %383
+%444 = OpIMul %ulong %443 %ulong_8
+OpStore %376 %444
+%445 = OpLoad %ulong %374
+%446 = OpLoad %ulong %376
+%447 = OpShiftRightLogical %ulong %445 %446
+OpStore %377 %447
+%448 = OpLoad %ulong %377
+%449 = OpBitwiseAnd %ulong %448 %ulong_255
+OpStore %378 %449
+%450 = OpLoad %ulong %382
+%451 = OpLoad %ulong %378
+%452 = OpBitwiseXor %ulong %450 %451
+OpStore %379 %452
+%453 = OpLoad %ulong %379
+%454 = OpIMul %ulong %453 %ulong_1099511628211
+OpStore %380 %454
+%455 = OpLoad %ulong %383
+%456 = OpIAdd %ulong %455 %ulong_1
+OpStore %381 %456
+%457 = OpLoad %ulong %380
+OpStore %382 %457
+%458 = OpLoad %ulong %381
+OpStore %383 %458
+OpBranch %344
+%326 = OpLabel
+%459 = OpLoad %ulong %373
+%460 = OpIMul %ulong %459 %ulong_8
+OpStore %366 %460
+%461 = OpLoad %ulong %364
+%462 = OpLoad %ulong %366
+%463 = OpShiftRightLogical %ulong %461 %462
+OpStore %367 %463
+%464 = OpLoad %ulong %367
+%465 = OpBitwiseAnd %ulong %464 %ulong_255
+OpStore %368 %465
+%466 = OpLoad %ulong %372
+%467 = OpLoad %ulong %368
+%468 = OpBitwiseXor %ulong %466 %467
+OpStore %369 %468
+%469 = OpLoad %ulong %369
+%470 = OpIMul %ulong %469 %ulong_1099511628211
+OpStore %370 %470
+%471 = OpLoad %ulong %373
+%472 = OpIAdd %ulong %471 %ulong_1
+OpStore %371 %472
+%473 = OpLoad %ulong %370
+OpStore %372 %473
+%474 = OpLoad %ulong %371
+OpStore %373 %474
+OpBranch %345
+%319 = OpLabel
+%475 = OpLoad %ulong %363
+%476 = OpIMul %ulong %475 %ulong_8
+OpStore %356 %476
+%477 = OpLoad %ulong %354
+%478 = OpLoad %ulong %356
+%479 = OpShiftRightLogical %ulong %477 %478
+OpStore %357 %479
+%480 = OpLoad %ulong %357
+%481 = OpBitwiseAnd %ulong %480 %ulong_255
+OpStore %358 %481
+%482 = OpLoad %ulong %362
+%483 = OpLoad %ulong %358
+%484 = OpBitwiseXor %ulong %482 %483
+OpStore %359 %484
+%485 = OpLoad %ulong %359
+%486 = OpIMul %ulong %485 %ulong_1099511628211
+OpStore %360 %486
+%487 = OpLoad %ulong %363
+%488 = OpIAdd %ulong %487 %ulong_1
+OpStore %361 %488
+%489 = OpLoad %ulong %360
+OpStore %362 %489
+%490 = OpLoad %ulong %361
+OpStore %363 %490
+OpBranch %346
+%343 = OpLabel
+OpBranch %339
+%344 = OpLabel
+OpBranch %332
+%345 = OpLabel
+OpBranch %325
+%346 = OpLabel
+OpBranch %318
 OpFunctionEnd
-%7 = OpFunction %ulong None %1097
-%1098 = OpFunctionParameter %ulong
-%1099 = OpFunctionParameter %ulong
-%1100 = OpLabel
-%1105 = OpVariable %_ptr_Function_ulong Function
-%1106 = OpVariable %_ptr_Function_ulong Function
-%1107 = OpVariable %_ptr_Function_bool Function
-%1108 = OpVariable %_ptr_Function_ulong Function
-%1109 = OpVariable %_ptr_Function_ulong Function
-%1110 = OpVariable %_ptr_Function_ulong Function
-%1111 = OpVariable %_ptr_Function_ulong Function
-%1112 = OpVariable %_ptr_Function_ulong Function
-%1113 = OpVariable %_ptr_Function_ulong Function
-%1114 = OpVariable %_ptr_Function_ulong Function
-%1115 = OpVariable %_ptr_Function_ulong Function
-OpStore %1105 %1098
-OpStore %1106 %1099
-%1116 = OpLoad %ulong %1105
-OpStore %1114 %1116
-OpStore %1115 %ulong_0
-OpBranch %1101
-%1101 = OpLabel
-%1117 = OpLoad %ulong %1115
-%1119 = OpULessThan %bool %1117 %ulong_8
-OpStore %1107 %1119
-%1120 = OpLoad %bool %1107
-OpLoopMerge %1103 %1104 None
-OpBranchConditional %1120 %1102 %1103
-%1103 = OpLabel
-%1121 = OpLoad %ulong %1114
-OpReturnValue %1121
-%1102 = OpLabel
-%1122 = OpLoad %ulong %1115
-%1123 = OpIMul %ulong %1122 %ulong_8
-OpStore %1108 %1123
-%1124 = OpLoad %ulong %1106
-%1125 = OpLoad %ulong %1108
-%1126 = OpShiftRightLogical %ulong %1124 %1125
-OpStore %1109 %1126
-%1127 = OpLoad %ulong %1109
-%1129 = OpBitwiseAnd %ulong %1127 %ulong_255
-OpStore %1110 %1129
-%1130 = OpLoad %ulong %1114
-%1131 = OpLoad %ulong %1110
-%1132 = OpBitwiseXor %ulong %1130 %1131
-OpStore %1111 %1132
-%1133 = OpLoad %ulong %1111
-%1135 = OpIMul %ulong %1133 %ulong_1099511628211
-OpStore %1112 %1135
-%1136 = OpLoad %ulong %1115
-%1137 = OpIAdd %ulong %1136 %ulong_1
-OpStore %1113 %1137
-%1138 = OpLoad %ulong %1112
-OpStore %1114 %1138
-%1139 = OpLoad %ulong %1113
-OpStore %1115 %1139
-OpBranch %1104
-%1104 = OpLabel
-OpBranch %1101
+%4 = OpFunction %v4float None %491
+%492 = OpFunctionParameter %v4float
+%493 = OpLabel
+%502 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
+%503 = OpVariable %_ptr_Function_v4float Function
+%504 = OpVariable %_ptr_Function_v4float Function
+%505 = OpVariable %_ptr_Function_bool Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_uchar Function
+%509 = OpVariable %_ptr_Function_v4float Function
+%510 = OpVariable %_ptr_Function_v4float Function
+%511 = OpVariable %_ptr_Function_v4float Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_float Function
+%514 = OpVariable %_ptr_Function_uchar Function
+%515 = OpVariable %_ptr_Function_float Function
+%516 = OpVariable %_ptr_Function_float Function
+%517 = OpVariable %_ptr_Function_v4float Function
+%518 = OpVariable %_ptr_Function_v4float Function
+%519 = OpVariable %_ptr_Function_ulong Function
+OpStore %503 %492
+OpStore %502 %520
+%521 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
+OpStore %504 %521
+%523 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
+OpStore %510 %523
+%528 = OpLoad %v4float %504
+OpStore %518 %528
+OpStore %519 %ulong_0
+OpBranch %494
+%494 = OpLabel
+%529 = OpLoad %ulong %519
+%531 = OpULessThan %bool %529 %ulong_4
+OpStore %505 %531
+%532 = OpLoad %bool %505
+OpLoopMerge %496 %497 None
+OpBranchConditional %532 %495 %496
+%496 = OpLabel
+%533 = OpLoad %v4float %518
+%534 = OpCompositeExtract %float %533 0
+OpStore %513 %534
+%536 = OpAccessChain %_ptr_Function_uchar %502 %uint_3
+%537 = OpLoad %uchar %536
+OpStore %514 %537
+%538 = OpLoad %uchar %514
+%539 = OpConvertUToF %float %538
+OpStore %515 %539
+%540 = OpLoad %float %513
+%541 = OpLoad %float %515
+%542 = OpFAdd %float %540 %541
+OpStore %516 %542
+%543 = OpLoad %v4float %518
+%544 = OpLoad %float %516
+%545 = OpCompositeInsert %v4float %544 %543 0
+OpStore %517 %545
+%546 = OpLoad %v4float %517
+OpReturnValue %546
+%495 = OpLabel
+%547 = OpLoad %ulong %519
+%549 = OpIMul %ulong %547 %ulong_17
+OpStore %506 %549
+%550 = OpLoad %ulong %506
+%551 = OpUConvert %uchar %550
+OpStore %508 %551
+%552 = OpLoad %ulong %519
+%553 = OpAccessChain %_ptr_Function_uchar %502 %552
+%554 = OpLoad %uchar %508
+OpStore %553 %554
+%555 = OpLoad %v4float %518
+%556 = OpLoad %v4float %503
+%557 = OpFAdd %v4float %555 %556
+OpStore %509 %557
+%558 = OpLoad %v4float %509
+%559 = OpLoad %v4float %510
+%560 = OpFMul %v4float %558 %559
+OpStore %511 %560
+%561 = OpLoad %ulong %519
+%562 = OpIAdd %ulong %561 %ulong_1
+OpStore %512 %562
+%563 = OpLoad %v4float %511
+OpStore %518 %563
+%564 = OpLoad %ulong %512
+OpStore %519 %564
+OpBranch %497
+%497 = OpLabel
+OpBranch %494
 OpFunctionEnd
-%8 = OpFunction %ulong None %1140
-%1141 = OpFunctionParameter %ulong
-%1142 = OpFunctionParameter %uchar
-%1143 = OpLabel
-%1150 = OpVariable %_ptr_Function_ulong Function
-%1151 = OpVariable %_ptr_Function_uchar Function
-%1152 = OpVariable %_ptr_Function_ulong Function
-%1153 = OpVariable %_ptr_Function_bool Function
-%1154 = OpVariable %_ptr_Function_ulong Function
-%1155 = OpVariable %_ptr_Function_ulong Function
-%1156 = OpVariable %_ptr_Function_ulong Function
-%1157 = OpVariable %_ptr_Function_ulong Function
-%1158 = OpVariable %_ptr_Function_ulong Function
-%1159 = OpVariable %_ptr_Function_ulong Function
-%1160 = OpVariable %_ptr_Function_ulong Function
-%1161 = OpVariable %_ptr_Function_ulong Function
-OpStore %1150 %1141
-OpStore %1151 %1142
-%1162 = OpLoad %uchar %1151
-%1163 = OpUConvert %ulong %1162
-OpStore %1152 %1163
-OpBranch %1144
-%1144 = OpLabel
-%1164 = OpLoad %ulong %1150
-OpStore %1160 %1164
-OpStore %1161 %ulong_0
-OpBranch %1145
-%1145 = OpLabel
-%1165 = OpLoad %ulong %1161
-%1166 = OpULessThan %bool %1165 %ulong_8
-OpStore %1153 %1166
-%1167 = OpLoad %bool %1153
-OpLoopMerge %1147 %1149 None
-OpBranchConditional %1167 %1146 %1147
-%1147 = OpLabel
-OpBranch %1148
-%1148 = OpLabel
-%1168 = OpLoad %ulong %1160
-OpReturnValue %1168
-%1146 = OpLabel
-%1169 = OpLoad %ulong %1161
-%1170 = OpIMul %ulong %1169 %ulong_8
-OpStore %1154 %1170
-%1171 = OpLoad %ulong %1152
-%1172 = OpLoad %ulong %1154
-%1173 = OpShiftRightLogical %ulong %1171 %1172
-OpStore %1155 %1173
-%1174 = OpLoad %ulong %1155
-%1175 = OpBitwiseAnd %ulong %1174 %ulong_255
-OpStore %1156 %1175
-%1176 = OpLoad %ulong %1160
-%1177 = OpLoad %ulong %1156
-%1178 = OpBitwiseXor %ulong %1176 %1177
-OpStore %1157 %1178
-%1179 = OpLoad %ulong %1157
-%1180 = OpIMul %ulong %1179 %ulong_1099511628211
-OpStore %1158 %1180
-%1181 = OpLoad %ulong %1161
-%1182 = OpIAdd %ulong %1181 %ulong_1
-OpStore %1159 %1182
-%1183 = OpLoad %ulong %1158
-OpStore %1160 %1183
-%1184 = OpLoad %ulong %1159
-OpStore %1161 %1184
-OpBranch %1149
-%1149 = OpLabel
-OpBranch %1145
-OpFunctionEnd
-%9 = OpFunction %ulong None %1185
-%1186 = OpFunctionParameter %ulong
-%1187 = OpFunctionParameter %ushort
-%1188 = OpLabel
-%1195 = OpVariable %_ptr_Function_ulong Function
-%1196 = OpVariable %_ptr_Function_ushort Function
-%1197 = OpVariable %_ptr_Function_ulong Function
-%1198 = OpVariable %_ptr_Function_bool Function
-%1199 = OpVariable %_ptr_Function_ulong Function
-%1200 = OpVariable %_ptr_Function_ulong Function
-%1201 = OpVariable %_ptr_Function_ulong Function
-%1202 = OpVariable %_ptr_Function_ulong Function
-%1203 = OpVariable %_ptr_Function_ulong Function
-%1204 = OpVariable %_ptr_Function_ulong Function
-%1205 = OpVariable %_ptr_Function_ulong Function
-%1206 = OpVariable %_ptr_Function_ulong Function
-OpStore %1195 %1186
-OpStore %1196 %1187
-%1207 = OpLoad %ushort %1196
-%1208 = OpUConvert %ulong %1207
-OpStore %1197 %1208
-OpBranch %1189
-%1189 = OpLabel
-%1209 = OpLoad %ulong %1195
-OpStore %1205 %1209
-OpStore %1206 %ulong_0
-OpBranch %1190
-%1190 = OpLabel
-%1210 = OpLoad %ulong %1206
-%1211 = OpULessThan %bool %1210 %ulong_8
-OpStore %1198 %1211
-%1212 = OpLoad %bool %1198
-OpLoopMerge %1192 %1194 None
-OpBranchConditional %1212 %1191 %1192
-%1192 = OpLabel
-OpBranch %1193
-%1193 = OpLabel
-%1213 = OpLoad %ulong %1205
-OpReturnValue %1213
-%1191 = OpLabel
-%1214 = OpLoad %ulong %1206
-%1215 = OpIMul %ulong %1214 %ulong_8
-OpStore %1199 %1215
-%1216 = OpLoad %ulong %1197
-%1217 = OpLoad %ulong %1199
-%1218 = OpShiftRightLogical %ulong %1216 %1217
-OpStore %1200 %1218
-%1219 = OpLoad %ulong %1200
-%1220 = OpBitwiseAnd %ulong %1219 %ulong_255
-OpStore %1201 %1220
-%1221 = OpLoad %ulong %1205
-%1222 = OpLoad %ulong %1201
-%1223 = OpBitwiseXor %ulong %1221 %1222
-OpStore %1202 %1223
-%1224 = OpLoad %ulong %1202
-%1225 = OpIMul %ulong %1224 %ulong_1099511628211
-OpStore %1203 %1225
-%1226 = OpLoad %ulong %1206
-%1227 = OpIAdd %ulong %1226 %ulong_1
-OpStore %1204 %1227
-%1228 = OpLoad %ulong %1203
-OpStore %1205 %1228
-%1229 = OpLoad %ulong %1204
-OpStore %1206 %1229
-OpBranch %1194
-%1194 = OpLabel
-OpBranch %1190
-OpFunctionEnd
-%10 = OpFunction %ulong None %1230
-%1231 = OpFunctionParameter %ulong
-%1232 = OpFunctionParameter %uint
-%1233 = OpLabel
-%1240 = OpVariable %_ptr_Function_ulong Function
-%1241 = OpVariable %_ptr_Function_uint Function
-%1242 = OpVariable %_ptr_Function_ulong Function
-%1243 = OpVariable %_ptr_Function_bool Function
-%1244 = OpVariable %_ptr_Function_ulong Function
-%1245 = OpVariable %_ptr_Function_ulong Function
-%1246 = OpVariable %_ptr_Function_ulong Function
-%1247 = OpVariable %_ptr_Function_ulong Function
-%1248 = OpVariable %_ptr_Function_ulong Function
-%1249 = OpVariable %_ptr_Function_ulong Function
-%1250 = OpVariable %_ptr_Function_ulong Function
-%1251 = OpVariable %_ptr_Function_ulong Function
-OpStore %1240 %1231
-OpStore %1241 %1232
-%1252 = OpLoad %uint %1241
-%1253 = OpUConvert %ulong %1252
-OpStore %1242 %1253
-OpBranch %1234
-%1234 = OpLabel
-%1254 = OpLoad %ulong %1240
-OpStore %1250 %1254
-OpStore %1251 %ulong_0
-OpBranch %1235
-%1235 = OpLabel
-%1255 = OpLoad %ulong %1251
-%1256 = OpULessThan %bool %1255 %ulong_8
-OpStore %1243 %1256
-%1257 = OpLoad %bool %1243
-OpLoopMerge %1237 %1239 None
-OpBranchConditional %1257 %1236 %1237
-%1237 = OpLabel
-OpBranch %1238
-%1238 = OpLabel
-%1258 = OpLoad %ulong %1250
-OpReturnValue %1258
-%1236 = OpLabel
-%1259 = OpLoad %ulong %1251
+%5 = OpFunction %ulong None %565
+%566 = OpFunctionParameter %ulong
+%567 = OpLabel
+%654 = OpVariable %_ptr_Function__arr__struct_651_uint_3 Function
+%658 = OpVariable %_ptr_Function__arr_v4float_uint_4 Function
+%659 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
+%660 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
+%661 = OpVariable %_ptr_Function__arr_uchar_uint_7 Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_float Function
+%664 = OpVariable %_ptr_Function_double Function
+%665 = OpVariable %_ptr_Function_float Function
+%666 = OpVariable %_ptr_Function_float Function
+%667 = OpVariable %_ptr_Function_v4float Function
+%668 = OpVariable %_ptr_Function_v2double Function
+%669 = OpVariable %_ptr_Function_v4uint Function
+%670 = OpVariable %_ptr_Function_v2double Function
+%671 = OpVariable %_ptr_Function_v4uint Function
+%672 = OpVariable %_ptr_Function_ulong Function
+%673 = OpVariable %_ptr_Function_uchar Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_uchar Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_uchar Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_uchar Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%682 = OpVariable %_ptr_Function_ushort Function
+%683 = OpVariable %_ptr_Function_ulong Function
+%684 = OpVariable %_ptr_Function_uchar Function
+%685 = OpVariable %_ptr_Function_float Function
+%686 = OpVariable %_ptr_Function_float Function
+%687 = OpVariable %_ptr_Function_v4float Function
+%688 = OpVariable %_ptr_Function_double Function
+%689 = OpVariable %_ptr_Function_double Function
+%690 = OpVariable %_ptr_Function_v2double Function
+%691 = OpVariable %_ptr_Function_uint Function
+%692 = OpVariable %_ptr_Function_uint Function
+%693 = OpVariable %_ptr_Function_uint Function
+%694 = OpVariable %_ptr_Function_v4uint Function
+%695 = OpVariable %_ptr_Function_ulong Function
+%696 = OpVariable %_ptr_Function_ulong Function
+%697 = OpVariable %_ptr_Function_ulong Function
+%698 = OpVariable %_ptr_Function_v4float Function
+%699 = OpVariable %_ptr_Function_ulong Function
+%700 = OpVariable %_ptr_Function_v4float Function
+%701 = OpVariable %_ptr_Function_ulong Function
+%702 = OpVariable %_ptr_Function_ulong Function
+%703 = OpVariable %_ptr_Function_v2double Function
+%704 = OpVariable %_ptr_Function_ulong Function
+%705 = OpVariable %_ptr_Function_v2double Function
+%706 = OpVariable %_ptr_Function_ulong Function
+%707 = OpVariable %_ptr_Function_v2double Function
+%708 = OpVariable %_ptr_Function_ulong Function
+%709 = OpVariable %_ptr_Function_ulong Function
+%710 = OpVariable %_ptr_Function_v4uint Function
+%711 = OpVariable %_ptr_Function_ulong Function
+%712 = OpVariable %_ptr_Function_v4uint Function
+%713 = OpVariable %_ptr_Function_ulong Function
+%714 = OpVariable %_ptr_Function_v4uint Function
+%715 = OpVariable %_ptr_Function_ulong Function
+%716 = OpVariable %_ptr_Function_ulong Function
+%717 = OpVariable %_ptr_Function_v4float Function
+%718 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_v4float Function
+%720 = OpVariable %_ptr_Function_v4float Function
+%721 = OpVariable %_ptr_Function_bool Function
+%722 = OpVariable %_ptr_Function_v4float Function
+%723 = OpVariable %_ptr_Function_ulong Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_bool Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_bool Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_bool Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_ulong Function
+%749 = OpVariable %_ptr_Function_ulong Function
+%750 = OpVariable %_ptr_Function_ulong Function
+%751 = OpVariable %_ptr_Function_bool Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_ulong Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_ulong Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_v4float Function
+%762 = OpVariable %_ptr_Function_bool Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_uchar Function
+%765 = OpVariable %_ptr_Function_v4float Function
+%766 = OpVariable %_ptr_Function_v4float Function
+%767 = OpVariable %_ptr_Function_v4float Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_float Function
+%770 = OpVariable %_ptr_Function_uchar Function
+%771 = OpVariable %_ptr_Function_float Function
+%772 = OpVariable %_ptr_Function_float Function
+%773 = OpVariable %_ptr_Function_v4float Function
+%774 = OpVariable %_ptr_Function_v4float Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_bool Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_ulong Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
+%783 = OpVariable %_ptr_Function_ulong Function
+%784 = OpVariable %_ptr_Function_ulong Function
+%785 = OpVariable %_ptr_Function_bool Function
+%786 = OpVariable %_ptr_Function_ulong Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_ulong Function
+%789 = OpVariable %_ptr_Function_ulong Function
+%790 = OpVariable %_ptr_Function_ulong Function
+%791 = OpVariable %_ptr_Function_ulong Function
+%792 = OpVariable %_ptr_Function_ulong Function
+%793 = OpVariable %_ptr_Function_ulong Function
+%794 = OpVariable %_ptr_Function_bool Function
+%795 = OpVariable %_ptr_Function_ulong Function
+%796 = OpVariable %_ptr_Function_ulong Function
+%797 = OpVariable %_ptr_Function_ulong Function
+%798 = OpVariable %_ptr_Function_ulong Function
+%799 = OpVariable %_ptr_Function_ulong Function
+%800 = OpVariable %_ptr_Function_ulong Function
+%801 = OpVariable %_ptr_Function_ulong Function
+%802 = OpVariable %_ptr_Function_ulong Function
+%803 = OpVariable %_ptr_Function_v4float Function
+%804 = OpVariable %_ptr_Function_bool Function
+%805 = OpVariable %_ptr_Function_ulong Function
+%806 = OpVariable %_ptr_Function_uchar Function
+%807 = OpVariable %_ptr_Function_v4float Function
+%808 = OpVariable %_ptr_Function_v4float Function
+%809 = OpVariable %_ptr_Function_v4float Function
+%810 = OpVariable %_ptr_Function_ulong Function
+%811 = OpVariable %_ptr_Function_float Function
+%812 = OpVariable %_ptr_Function_uchar Function
+%813 = OpVariable %_ptr_Function_float Function
+%814 = OpVariable %_ptr_Function_float Function
+%815 = OpVariable %_ptr_Function_v4float Function
+%816 = OpVariable %_ptr_Function_v4float Function
+%817 = OpVariable %_ptr_Function_ulong Function
+%818 = OpVariable %_ptr_Function_bool Function
+%819 = OpVariable %_ptr_Function_ulong Function
+%820 = OpVariable %_ptr_Function_ulong Function
+%821 = OpVariable %_ptr_Function_ulong Function
+%822 = OpVariable %_ptr_Function_ulong Function
+%823 = OpVariable %_ptr_Function_ulong Function
+%824 = OpVariable %_ptr_Function_ulong Function
+%825 = OpVariable %_ptr_Function_ulong Function
+%826 = OpVariable %_ptr_Function_ulong Function
+%827 = OpVariable %_ptr_Function_ulong Function
+%828 = OpVariable %_ptr_Function_ulong Function
+%829 = OpVariable %_ptr_Function_v4float Function
+%830 = OpVariable %_ptr_Function_bool Function
+%831 = OpVariable %_ptr_Function_ulong Function
+%832 = OpVariable %_ptr_Function_uchar Function
+%833 = OpVariable %_ptr_Function_v4float Function
+%834 = OpVariable %_ptr_Function_v4float Function
+%835 = OpVariable %_ptr_Function_v4float Function
+%836 = OpVariable %_ptr_Function_ulong Function
+%837 = OpVariable %_ptr_Function_float Function
+%838 = OpVariable %_ptr_Function_uchar Function
+%839 = OpVariable %_ptr_Function_float Function
+%840 = OpVariable %_ptr_Function_float Function
+%841 = OpVariable %_ptr_Function_v4float Function
+%842 = OpVariable %_ptr_Function_v4float Function
+%843 = OpVariable %_ptr_Function_ulong Function
+%844 = OpVariable %_ptr_Function_ulong Function
+%845 = OpVariable %_ptr_Function_ulong Function
+%846 = OpVariable %_ptr_Function_ulong Function
+%847 = OpVariable %_ptr_Function_ulong Function
+%848 = OpVariable %_ptr_Function_ulong Function
+%849 = OpVariable %_ptr_Function_ulong Function
+%850 = OpVariable %_ptr_Function_ulong Function
+%851 = OpVariable %_ptr_Function_ulong Function
+OpStore %662 %566
+OpBranch %577
+%577 = OpLabel
+OpBranch %578
+%578 = OpLabel
+%852 = OpLoad %ulong %662
+%853 = OpConvertUToF %float %852
+OpStore %663 %853
+%854 = OpLoad %ulong %662
+%855 = OpConvertUToF %double %854
+OpStore %664 %855
+%857 = OpFNegate %float %float_2_25
+OpStore %665 %857
+%858 = OpFNegate %float %float_0_5
+OpStore %666 %858
+%860 = OpLoad %float %665
+%862 = OpLoad %float %666
+%859 = OpCompositeConstruct %v4float %float_1_5 %860 %float_3_75 %862
+OpStore %667 %859
+%863 = OpCompositeConstruct %v2double %double_1_25 %double_n3_5
+OpStore %668 %863
+%866 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_1 %uint_2654435761 %uint_305419896
+OpStore %669 %866
+%871 = OpCompositeConstruct %v2double %double_0_5 %double_6_25
+OpStore %670 %871
+%874 = OpCompositeConstruct %v4uint %uint_3266489917 %uint_2246822519 %uint_7 %uint_4294967291
+OpStore %671 %874
+OpStore %654 %878
+OpStore %658 %879
+%880 = OpLoad %ulong %662
+%881 = OpIAdd %ulong %880 %ulong_1
+OpStore %672 %881
+%882 = OpLoad %ulong %672
+%883 = OpUConvert %uchar %882
+OpStore %673 %883
+%884 = OpLoad %ulong %662
+%886 = OpIAdd %ulong %884 %ulong_3
+OpStore %674 %886
+%887 = OpLoad %ulong %674
+%888 = OpUConvert %uchar %887
+OpStore %675 %888
+%889 = OpLoad %ulong %662
+%891 = OpIAdd %ulong %889 %ulong_5
+OpStore %676 %891
+%892 = OpLoad %ulong %676
+%893 = OpUConvert %uchar %892
+OpStore %677 %893
+%894 = OpLoad %ulong %662
+%896 = OpIAdd %ulong %894 %ulong_7
+OpStore %678 %896
+%897 = OpLoad %ulong %678
+%898 = OpUConvert %uchar %897
+OpStore %679 %898
+%899 = OpLoad %ulong %662
+%901 = OpIAdd %ulong %899 %ulong_65521
+OpStore %680 %901
+%902 = OpLoad %ulong %680
+%903 = OpUConvert %ushort %902
+OpStore %682 %903
+%904 = OpLoad %ulong %662
+%906 = OpIAdd %ulong %904 %ulong_251
+OpStore %683 %906
+%907 = OpLoad %ulong %683
+%908 = OpUConvert %uchar %907
+OpStore %684 %908
+%909 = OpLoad %v4float %667
+%910 = OpCompositeExtract %float %909 0
+OpStore %685 %910
+%911 = OpLoad %float %685
+%912 = OpLoad %float %663
+%913 = OpFAdd %float %911 %912
+OpStore %686 %913
+%914 = OpLoad %v4float %667
+%915 = OpLoad %float %686
+%916 = OpCompositeInsert %v4float %915 %914 0
+OpStore %687 %916
+%917 = OpLoad %v2double %668
+%918 = OpCompositeExtract %double %917 1
+OpStore %688 %918
+%919 = OpLoad %double %688
+%920 = OpLoad %double %664
+%921 = OpFAdd %double %919 %920
+OpStore %689 %921
+%922 = OpLoad %v2double %668
+%923 = OpLoad %double %689
+%924 = OpCompositeInsert %v2double %923 %922 1
+OpStore %690 %924
+%925 = OpLoad %v4uint %669
+%926 = OpCompositeExtract %uint %925 2
+OpStore %691 %926
+%927 = OpLoad %ulong %662
+%928 = OpUConvert %uint %927
+OpStore %692 %928
+%929 = OpLoad %uint %691
+%930 = OpLoad %uint %692
+%931 = OpIAdd %uint %929 %930
+OpStore %693 %931
+%932 = OpLoad %v4uint %669
+%933 = OpLoad %uint %693
+%934 = OpCompositeInsert %v4uint %933 %932 2
+OpStore %694 %934
+%936 = OpLoad %v4float %687
+%937 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %936
+OpStore %695 %937
+%938 = OpLoad %ulong %695
+%939 = OpLoad %v2double %690
+%940 = OpFunctionCall %ulong %2 %938 %939
+OpStore %696 %940
+%941 = OpLoad %ulong %696
+%942 = OpLoad %v4uint %694
+%943 = OpFunctionCall %ulong %3 %941 %942
+OpStore %697 %943
+%944 = OpLoad %v4float %687
+%945 = OpLoad %v4float %687
+%946 = OpFAdd %v4float %944 %945
+OpStore %698 %946
+%947 = OpLoad %ulong %697
+%948 = OpLoad %v4float %698
+%949 = OpFunctionCall %ulong %1 %947 %948
+OpStore %699 %949
+%950 = OpLoad %v4float %687
+%951 = OpLoad %v4float %687
+%952 = OpFMul %v4float %950 %951
+OpStore %700 %952
+%953 = OpLoad %ulong %699
+%954 = OpLoad %v4float %700
+%955 = OpFunctionCall %ulong %1 %953 %954
+OpStore %701 %955
+%956 = OpLoad %ulong %701
+%957 = OpLoad %v2double %670
+%958 = OpFunctionCall %ulong %2 %956 %957
+OpStore %702 %958
+%959 = OpLoad %v2double %690
+%960 = OpLoad %v2double %670
+%961 = OpFMul %v2double %959 %960
+OpStore %703 %961
+%962 = OpLoad %ulong %702
+%963 = OpLoad %v2double %703
+%964 = OpFunctionCall %ulong %2 %962 %963
+OpStore %704 %964
+%965 = OpLoad %v2double %690
+%966 = OpLoad %v2double %670
+%967 = OpFSub %v2double %965 %966
+OpStore %705 %967
+%968 = OpLoad %ulong %704
+%969 = OpLoad %v2double %705
+%970 = OpFunctionCall %ulong %2 %968 %969
+OpStore %706 %970
+%971 = OpLoad %v2double %690
+%972 = OpLoad %v2double %670
+%973 = OpFDiv %v2double %971 %972
+OpStore %707 %973
+%974 = OpLoad %ulong %706
+%975 = OpLoad %v2double %707
+%976 = OpFunctionCall %ulong %2 %974 %975
+OpStore %708 %976
+%977 = OpLoad %ulong %708
+%978 = OpLoad %v4uint %671
+%979 = OpFunctionCall %ulong %3 %977 %978
+OpStore %709 %979
+%980 = OpLoad %v4uint %694
+%981 = OpLoad %v4uint %671
+%982 = OpIMul %v4uint %980 %981
+OpStore %710 %982
+%983 = OpLoad %ulong %709
+%984 = OpLoad %v4uint %710
+%985 = OpFunctionCall %ulong %3 %983 %984
+OpStore %711 %985
+%986 = OpLoad %v4uint %694
+%987 = OpLoad %v4uint %671
+%988 = OpIAdd %v4uint %986 %987
+OpStore %712 %988
+%989 = OpLoad %ulong %711
+%990 = OpLoad %v4uint %712
+%991 = OpFunctionCall %ulong %3 %989 %990
+OpStore %713 %991
+%992 = OpLoad %v4uint %694
+%993 = OpLoad %v4uint %671
+%994 = OpBitwiseXor %v4uint %992 %993
+OpStore %714 %994
+%995 = OpLoad %ulong %713
+%996 = OpLoad %v4uint %714
+%997 = OpFunctionCall %ulong %3 %995 %996
+OpStore %715 %997
+OpBranch %591
+%591 = OpLabel
+OpStore %659 %520
+%998 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
+OpStore %761 %998
+%999 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
+OpStore %766 %999
+%1000 = OpLoad %v4float %761
+OpStore %774 %1000
+OpStore %775 %ulong_0
+OpBranch %592
+%592 = OpLabel
+%1001 = OpLoad %ulong %775
+%1002 = OpULessThan %bool %1001 %ulong_4
+OpStore %762 %1002
+%1003 = OpLoad %bool %762
+OpLoopMerge %594 %649 None
+OpBranchConditional %1003 %593 %594
+%594 = OpLabel
+%1004 = OpLoad %v4float %774
+%1005 = OpCompositeExtract %float %1004 0
+OpStore %769 %1005
+%1006 = OpAccessChain %_ptr_Function_uchar %659 %uint_3
+%1007 = OpLoad %uchar %1006
+OpStore %770 %1007
+%1008 = OpLoad %uchar %770
+%1009 = OpConvertUToF %float %1008
+OpStore %771 %1009
+%1010 = OpLoad %float %769
+%1011 = OpLoad %float %771
+%1012 = OpFAdd %float %1010 %1011
+OpStore %772 %1012
+%1013 = OpLoad %v4float %774
+%1014 = OpLoad %float %772
+%1015 = OpCompositeInsert %v4float %1014 %1013 0
+OpStore %773 %1015
+OpBranch %595
+%595 = OpLabel
+%1016 = OpLoad %ulong %715
+%1017 = OpLoad %v4float %773
+%1018 = OpFunctionCall %ulong %1 %1016 %1017
+OpStore %716 %1018
+%1019 = OpLoad %v4float %687
+%1020 = OpLoad %v4float %687
+%1021 = OpFMul %v4float %1019 %1020
+OpStore %717 %1021
+OpBranch %613
+%613 = OpLabel
+OpStore %660 %520
+%1022 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
+OpStore %803 %1022
+%1023 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
+OpStore %808 %1023
+%1024 = OpLoad %v4float %803
+OpStore %816 %1024
+OpStore %817 %ulong_0
+OpBranch %614
+%614 = OpLabel
+%1025 = OpLoad %ulong %817
+%1026 = OpULessThan %bool %1025 %ulong_4
+OpStore %804 %1026
+%1027 = OpLoad %bool %804
+OpLoopMerge %616 %648 None
+OpBranchConditional %1027 %615 %616
+%616 = OpLabel
+%1028 = OpLoad %v4float %816
+%1029 = OpCompositeExtract %float %1028 0
+OpStore %811 %1029
+%1030 = OpAccessChain %_ptr_Function_uchar %660 %uint_3
+%1031 = OpLoad %uchar %1030
+OpStore %812 %1031
+%1032 = OpLoad %uchar %812
+%1033 = OpConvertUToF %float %1032
+OpStore %813 %1033
+%1034 = OpLoad %float %811
+%1035 = OpLoad %float %813
+%1036 = OpFAdd %float %1034 %1035
+OpStore %814 %1036
+%1037 = OpLoad %v4float %816
+%1038 = OpLoad %float %814
+%1039 = OpCompositeInsert %v4float %1038 %1037 0
+OpStore %815 %1039
+OpBranch %617
+%617 = OpLabel
+%1040 = OpLoad %ulong %716
+%1041 = OpLoad %v4float %815
+%1042 = OpFunctionCall %ulong %1 %1040 %1041
+OpStore %718 %1042
+%1044 = OpAccessChain %_ptr_Function_v4float %658 %uint_0
+%1045 = OpLoad %v4float %687
+OpStore %1044 %1045
+%1046 = OpLoad %v4float %687
+%1047 = OpLoad %v4float %687
+%1048 = OpFAdd %v4float %1046 %1047
+OpStore %719 %1048
+%1049 = OpAccessChain %_ptr_Function_v4float %658 %uint_1
+%1050 = OpLoad %v4float %719
+OpStore %1049 %1050
+OpBranch %625
+%625 = OpLabel
+OpStore %661 %520
+%1051 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
+OpStore %829 %1051
+%1052 = OpCompositeConstruct %v4float %float_1_5 %float_0_5 %float_1_25 %float_0_75
+OpStore %834 %1052
+%1053 = OpLoad %v4float %829
+OpStore %842 %1053
+OpStore %843 %ulong_0
+OpBranch %626
+%626 = OpLabel
+%1054 = OpLoad %ulong %843
+%1055 = OpULessThan %bool %1054 %ulong_4
+OpStore %830 %1055
+%1056 = OpLoad %bool %830
+OpLoopMerge %628 %647 None
+OpBranchConditional %1056 %627 %628
+%628 = OpLabel
+%1057 = OpLoad %v4float %842
+%1058 = OpCompositeExtract %float %1057 0
+OpStore %837 %1058
+%1059 = OpAccessChain %_ptr_Function_uchar %661 %uint_3
+%1060 = OpLoad %uchar %1059
+OpStore %838 %1060
+%1061 = OpLoad %uchar %838
+%1062 = OpConvertUToF %float %1061
+OpStore %839 %1062
+%1063 = OpLoad %float %837
+%1064 = OpLoad %float %839
+%1065 = OpFAdd %float %1063 %1064
+OpStore %840 %1065
+%1066 = OpLoad %v4float %842
+%1067 = OpLoad %float %840
+%1068 = OpCompositeInsert %v4float %1067 %1066 0
+OpStore %841 %1068
+OpBranch %629
+%629 = OpLabel
+%1070 = OpAccessChain %_ptr_Function_v4float %658 %uint_2
+%1071 = OpLoad %v4float %841
+OpStore %1070 %1071
+%1072 = OpLoad %v4float %687
+%1073 = OpLoad %v4float %687
+%1074 = OpFMul %v4float %1072 %1073
+OpStore %720 %1074
+%1075 = OpAccessChain %_ptr_Function_v4float %658 %uint_3
+%1076 = OpLoad %v4float %720
+OpStore %1075 %1076
+%1077 = OpLoad %ulong %718
+OpStore %738 %1077
+OpStore %741 %ulong_0
+OpBranch %568
+%568 = OpLabel
+%1078 = OpLoad %ulong %741
+%1079 = OpULessThan %bool %1078 %ulong_4
+OpStore %721 %1079
+%1080 = OpLoad %bool %721
+OpLoopMerge %570 %646 None
+OpBranchConditional %1080 %569 %570
+%570 = OpLabel
+%1082 = OpLoad %ulong %662
+%1083 = OpIAdd %ulong %ulong_1229782938247303441 %1082
+OpStore %725 %1083
+%1085 = OpLoad %ulong %662
+%1086 = OpBitwiseXor %ulong %ulong_8608480567731124087 %1085
+OpStore %726 %1086
+OpBranch %579
+%579 = OpLabel
+%1087 = OpLoad %ulong %738
+OpStore %749 %1087
+OpStore %750 %ulong_0
+OpBranch %580
+%580 = OpLabel
+%1088 = OpLoad %ulong %750
+%1089 = OpULessThan %bool %1088 %ulong_8
+OpStore %742 %1089
+%1090 = OpLoad %bool %742
+OpLoopMerge %582 %645 None
+OpBranchConditional %1090 %581 %582
+%582 = OpLabel
+OpBranch %583
+%583 = OpLabel
+OpBranch %596
+%596 = OpLabel
+%1091 = OpLoad %ulong %749
+OpStore %783 %1091
+OpStore %784 %ulong_0
+OpBranch %597
+%597 = OpLabel
+%1092 = OpLoad %ulong %784
+%1093 = OpULessThan %bool %1092 %ulong_8
+OpStore %776 %1093
+%1094 = OpLoad %bool %776
+OpLoopMerge %599 %644 None
+OpBranchConditional %1094 %598 %599
+%599 = OpLabel
+OpBranch %600
+%600 = OpLabel
+OpStore %740 %ulong_0
+OpBranch %571
+%571 = OpLabel
+%1095 = OpLoad %ulong %740
+%1096 = OpULessThan %bool %1095 %ulong_3
+OpStore %727 %1096
+%1097 = OpLoad %bool %727
+OpLoopMerge %573 %643 None
+OpBranchConditional %1097 %572 %573
+%573 = OpLabel
+%1098 = OpLoad %ulong %783
+OpStore %737 %1098
+OpStore %739 %ulong_0
+OpBranch %574
+%574 = OpLabel
+%1099 = OpLoad %ulong %739
+%1100 = OpULessThan %bool %1099 %ulong_3
+OpStore %733 %1100
+%1101 = OpLoad %bool %733
+OpLoopMerge %576 %642 None
+OpBranchConditional %1101 %575 %576
+%576 = OpLabel
+OpBranch %589
+%589 = OpLabel
+%1102 = OpLoad %uchar %673
+%1103 = OpUConvert %ulong %1102
+OpStore %760 %1103
+OpBranch %606
+%606 = OpLabel
+%1104 = OpLoad %ulong %737
+OpStore %801 %1104
+OpStore %802 %ulong_0
+OpBranch %607
+%607 = OpLabel
+%1105 = OpLoad %ulong %802
+%1106 = OpULessThan %bool %1105 %ulong_8
+OpStore %794 %1106
+%1107 = OpLoad %bool %794
+OpLoopMerge %609 %640 None
+OpBranchConditional %1107 %608 %609
+%609 = OpLabel
+OpBranch %610
+%610 = OpLabel
+OpBranch %590
+%590 = OpLabel
+OpBranch %611
+%611 = OpLabel
+OpBranch %618
+%618 = OpLabel
+%1108 = OpLoad %ulong %801
+OpStore %825 %1108
+OpStore %826 %ulong_0
+OpBranch %619
+%619 = OpLabel
+%1109 = OpLoad %ulong %826
+%1110 = OpULessThan %bool %1109 %ulong_8
+OpStore %818 %1110
+%1111 = OpLoad %bool %818
+OpLoopMerge %621 %638 None
+OpBranchConditional %1111 %620 %621
+%621 = OpLabel
+OpBranch %622
+%622 = OpLabel
+OpBranch %612
+%612 = OpLabel
+OpBranch %623
+%623 = OpLabel
+%1112 = OpLoad %uchar %675
+%1113 = OpUConvert %ulong %1112
+OpStore %827 %1113
+%1114 = OpLoad %ulong %825
+%1115 = OpLoad %ulong %827
+%1116 = OpFunctionCall %ulong %6 %1114 %1115
+OpStore %828 %1116
+OpBranch %624
+%624 = OpLabel
+OpBranch %630
+%630 = OpLabel
+%1117 = OpLoad %uchar %677
+%1118 = OpUConvert %ulong %1117
+OpStore %844 %1118
+%1119 = OpLoad %ulong %828
+%1120 = OpLoad %ulong %844
+%1121 = OpFunctionCall %ulong %6 %1119 %1120
+OpStore %845 %1121
+OpBranch %631
+%631 = OpLabel
+OpBranch %632
+%632 = OpLabel
+%1122 = OpLoad %uchar %679
+%1123 = OpUConvert %ulong %1122
+OpStore %846 %1123
+%1124 = OpLoad %ulong %845
+%1125 = OpLoad %ulong %846
+%1126 = OpFunctionCall %ulong %6 %1124 %1125
+OpStore %847 %1126
+OpBranch %633
+%633 = OpLabel
+OpBranch %634
+%634 = OpLabel
+%1127 = OpLoad %ushort %682
+%1128 = OpUConvert %ulong %1127
+OpStore %848 %1128
+%1129 = OpLoad %ulong %847
+%1130 = OpLoad %ulong %848
+%1131 = OpFunctionCall %ulong %6 %1129 %1130
+OpStore %849 %1131
+OpBranch %635
+%635 = OpLabel
+OpBranch %636
+%636 = OpLabel
+%1132 = OpLoad %uchar %684
+%1133 = OpUConvert %ulong %1132
+OpStore %850 %1133
+%1134 = OpLoad %ulong %849
+%1135 = OpLoad %ulong %850
+%1136 = OpFunctionCall %ulong %6 %1134 %1135
+OpStore %851 %1136
+OpBranch %637
+%637 = OpLabel
+%1137 = OpLoad %ulong %851
+OpReturnValue %1137
+%620 = OpLabel
+%1138 = OpLoad %ulong %826
+%1139 = OpIMul %ulong %1138 %ulong_8
+OpStore %819 %1139
+%1140 = OpLoad %ulong %819
+%1141 = OpShiftRightLogical %ulong %ulong_0 %1140
+OpStore %820 %1141
+%1142 = OpLoad %ulong %820
+%1143 = OpBitwiseAnd %ulong %1142 %ulong_255
+OpStore %821 %1143
+%1144 = OpLoad %ulong %825
+%1145 = OpLoad %ulong %821
+%1146 = OpBitwiseXor %ulong %1144 %1145
+OpStore %822 %1146
+%1147 = OpLoad %ulong %822
+%1148 = OpIMul %ulong %1147 %ulong_1099511628211
+OpStore %823 %1148
+%1149 = OpLoad %ulong %826
+%1150 = OpIAdd %ulong %1149 %ulong_1
+OpStore %824 %1150
+%1151 = OpLoad %ulong %823
+OpStore %825 %1151
+%1152 = OpLoad %ulong %824
+OpStore %826 %1152
+OpBranch %638
+%608 = OpLabel
+%1153 = OpLoad %ulong %802
+%1154 = OpIMul %ulong %1153 %ulong_8
+OpStore %795 %1154
+%1155 = OpLoad %ulong %760
+%1156 = OpLoad %ulong %795
+%1157 = OpShiftRightLogical %ulong %1155 %1156
+OpStore %796 %1157
+%1158 = OpLoad %ulong %796
+%1159 = OpBitwiseAnd %ulong %1158 %ulong_255
+OpStore %797 %1159
+%1160 = OpLoad %ulong %801
+%1161 = OpLoad %ulong %797
+%1162 = OpBitwiseXor %ulong %1160 %1161
+OpStore %798 %1162
+%1163 = OpLoad %ulong %798
+%1164 = OpIMul %ulong %1163 %ulong_1099511628211
+OpStore %799 %1164
+%1165 = OpLoad %ulong %802
+%1166 = OpIAdd %ulong %1165 %ulong_1
+OpStore %800 %1166
+%1167 = OpLoad %ulong %799
+OpStore %801 %1167
+%1168 = OpLoad %ulong %800
+OpStore %802 %1168
+OpBranch %640
+%575 = OpLabel
+%1169 = OpLoad %ulong %739
+%1171 = OpAccessChain %_ptr_Function__struct_651 %654 %1169
+%1172 = OpAccessChain %_ptr_Function_ulong %1171 %uint_0
+%1173 = OpLoad %ulong %1172
+OpStore %734 %1173
+OpBranch %584
+%584 = OpLabel
+%1174 = OpLoad %ulong %737
+OpStore %758 %1174
+OpStore %759 %ulong_0
+OpBranch %585
+%585 = OpLabel
+%1175 = OpLoad %ulong %759
+%1176 = OpULessThan %bool %1175 %ulong_8
+OpStore %751 %1176
+%1177 = OpLoad %bool %751
+OpLoopMerge %587 %641 None
+OpBranchConditional %1177 %586 %587
+%587 = OpLabel
+OpBranch %588
+%588 = OpLabel
+%1178 = OpLoad %ulong %739
+%1179 = OpAccessChain %_ptr_Function__struct_651 %654 %1178
+%1180 = OpAccessChain %_ptr_Function_ulong %1179 %uint_1
+%1181 = OpLoad %ulong %1180
+OpStore %735 %1181
+OpBranch %601
+%601 = OpLabel
+%1182 = OpLoad %ulong %758
+OpStore %792 %1182
+OpStore %793 %ulong_0
+OpBranch %602
+%602 = OpLabel
+%1183 = OpLoad %ulong %793
+%1184 = OpULessThan %bool %1183 %ulong_8
+OpStore %785 %1184
+%1185 = OpLoad %bool %785
+OpLoopMerge %604 %639 None
+OpBranchConditional %1185 %603 %604
+%604 = OpLabel
+OpBranch %605
+%605 = OpLabel
+%1186 = OpLoad %ulong %739
+%1187 = OpIAdd %ulong %1186 %ulong_1
+OpStore %736 %1187
+%1188 = OpLoad %ulong %792
+OpStore %737 %1188
+%1189 = OpLoad %ulong %736
+OpStore %739 %1189
+OpBranch %642
+%603 = OpLabel
+%1190 = OpLoad %ulong %793
+%1191 = OpIMul %ulong %1190 %ulong_8
+OpStore %786 %1191
+%1192 = OpLoad %ulong %735
+%1193 = OpLoad %ulong %786
+%1194 = OpShiftRightLogical %ulong %1192 %1193
+OpStore %787 %1194
+%1195 = OpLoad %ulong %787
+%1196 = OpBitwiseAnd %ulong %1195 %ulong_255
+OpStore %788 %1196
+%1197 = OpLoad %ulong %792
+%1198 = OpLoad %ulong %788
+%1199 = OpBitwiseXor %ulong %1197 %1198
+OpStore %789 %1199
+%1200 = OpLoad %ulong %789
+%1201 = OpIMul %ulong %1200 %ulong_1099511628211
+OpStore %790 %1201
+%1202 = OpLoad %ulong %793
+%1203 = OpIAdd %ulong %1202 %ulong_1
+OpStore %791 %1203
+%1204 = OpLoad %ulong %790
+OpStore %792 %1204
+%1205 = OpLoad %ulong %791
+OpStore %793 %1205
+OpBranch %639
+%586 = OpLabel
+%1206 = OpLoad %ulong %759
+%1207 = OpIMul %ulong %1206 %ulong_8
+OpStore %752 %1207
+%1208 = OpLoad %ulong %734
+%1209 = OpLoad %ulong %752
+%1210 = OpShiftRightLogical %ulong %1208 %1209
+OpStore %753 %1210
+%1211 = OpLoad %ulong %753
+%1212 = OpBitwiseAnd %ulong %1211 %ulong_255
+OpStore %754 %1212
+%1213 = OpLoad %ulong %758
+%1214 = OpLoad %ulong %754
+%1215 = OpBitwiseXor %ulong %1213 %1214
+OpStore %755 %1215
+%1216 = OpLoad %ulong %755
+%1217 = OpIMul %ulong %1216 %ulong_1099511628211
+OpStore %756 %1217
+%1218 = OpLoad %ulong %759
+%1219 = OpIAdd %ulong %1218 %ulong_1
+OpStore %757 %1219
+%1220 = OpLoad %ulong %756
+OpStore %758 %1220
+%1221 = OpLoad %ulong %757
+OpStore %759 %1221
+OpBranch %641
+%572 = OpLabel
+%1222 = OpLoad %ulong %740
+%1224 = OpIMul %ulong %1222 %ulong_2654435761
+OpStore %728 %1224
+%1225 = OpLoad %ulong %728
+%1226 = OpLoad %ulong %662
+%1227 = OpIAdd %ulong %1225 %1226
+OpStore %729 %1227
+%1228 = OpLoad %ulong %740
+%1229 = OpAccessChain %_ptr_Function__struct_651 %654 %1228
+%1230 = OpAccessChain %_ptr_Function_ulong %1229 %uint_0
+%1231 = OpLoad %ulong %729
+OpStore %1230 %1231
+%1232 = OpLoad %ulong %740
+%1234 = OpShiftLeftLogical %ulong %1232 %ulong_40
+OpStore %730 %1234
+%1235 = OpLoad %ulong %730
+%1236 = OpLoad %ulong %725
+%1237 = OpBitwiseXor %ulong %1235 %1236
+OpStore %731 %1237
+%1238 = OpAccessChain %_ptr_Function_ulong %1229 %uint_1
+%1239 = OpLoad %ulong %731
+OpStore %1238 %1239
+%1240 = OpLoad %ulong %740
+%1241 = OpIAdd %ulong %1240 %ulong_1
+OpStore %732 %1241
+%1242 = OpLoad %ulong %732
+OpStore %740 %1242
+OpBranch %643
+%598 = OpLabel
+%1243 = OpLoad %ulong %784
+%1244 = OpIMul %ulong %1243 %ulong_8
+OpStore %777 %1244
+%1245 = OpLoad %ulong %726
+%1246 = OpLoad %ulong %777
+%1247 = OpShiftRightLogical %ulong %1245 %1246
+OpStore %778 %1247
+%1248 = OpLoad %ulong %778
+%1249 = OpBitwiseAnd %ulong %1248 %ulong_255
+OpStore %779 %1249
+%1250 = OpLoad %ulong %783
+%1251 = OpLoad %ulong %779
+%1252 = OpBitwiseXor %ulong %1250 %1251
+OpStore %780 %1252
+%1253 = OpLoad %ulong %780
+%1254 = OpIMul %ulong %1253 %ulong_1099511628211
+OpStore %781 %1254
+%1255 = OpLoad %ulong %784
+%1256 = OpIAdd %ulong %1255 %ulong_1
+OpStore %782 %1256
+%1257 = OpLoad %ulong %781
+OpStore %783 %1257
+%1258 = OpLoad %ulong %782
+OpStore %784 %1258
+OpBranch %644
+%581 = OpLabel
+%1259 = OpLoad %ulong %750
 %1260 = OpIMul %ulong %1259 %ulong_8
-OpStore %1244 %1260
-%1261 = OpLoad %ulong %1242
-%1262 = OpLoad %ulong %1244
+OpStore %743 %1260
+%1261 = OpLoad %ulong %725
+%1262 = OpLoad %ulong %743
 %1263 = OpShiftRightLogical %ulong %1261 %1262
-OpStore %1245 %1263
-%1264 = OpLoad %ulong %1245
+OpStore %744 %1263
+%1264 = OpLoad %ulong %744
 %1265 = OpBitwiseAnd %ulong %1264 %ulong_255
-OpStore %1246 %1265
-%1266 = OpLoad %ulong %1250
-%1267 = OpLoad %ulong %1246
+OpStore %745 %1265
+%1266 = OpLoad %ulong %749
+%1267 = OpLoad %ulong %745
 %1268 = OpBitwiseXor %ulong %1266 %1267
-OpStore %1247 %1268
-%1269 = OpLoad %ulong %1247
+OpStore %746 %1268
+%1269 = OpLoad %ulong %746
 %1270 = OpIMul %ulong %1269 %ulong_1099511628211
-OpStore %1248 %1270
-%1271 = OpLoad %ulong %1251
+OpStore %747 %1270
+%1271 = OpLoad %ulong %750
 %1272 = OpIAdd %ulong %1271 %ulong_1
-OpStore %1249 %1272
-%1273 = OpLoad %ulong %1248
-OpStore %1250 %1273
-%1274 = OpLoad %ulong %1249
-OpStore %1251 %1274
-OpBranch %1239
-%1239 = OpLabel
-OpBranch %1235
+OpStore %748 %1272
+%1273 = OpLoad %ulong %747
+OpStore %749 %1273
+%1274 = OpLoad %ulong %748
+OpStore %750 %1274
+OpBranch %645
+%569 = OpLabel
+%1275 = OpLoad %ulong %741
+%1276 = OpAccessChain %_ptr_Function_v4float %658 %1275
+%1277 = OpLoad %v4float %1276
+OpStore %722 %1277
+%1278 = OpLoad %ulong %738
+%1279 = OpLoad %v4float %722
+%1280 = OpFunctionCall %ulong %1 %1278 %1279
+OpStore %723 %1280
+%1281 = OpLoad %ulong %741
+%1282 = OpIAdd %ulong %1281 %ulong_1
+OpStore %724 %1282
+%1283 = OpLoad %ulong %723
+OpStore %738 %1283
+%1284 = OpLoad %ulong %724
+OpStore %741 %1284
+OpBranch %646
+%627 = OpLabel
+%1285 = OpLoad %ulong %843
+%1286 = OpIMul %ulong %1285 %ulong_17
+OpStore %831 %1286
+%1287 = OpLoad %ulong %831
+%1288 = OpUConvert %uchar %1287
+OpStore %832 %1288
+%1289 = OpLoad %ulong %843
+%1290 = OpAccessChain %_ptr_Function_uchar %661 %1289
+%1291 = OpLoad %uchar %832
+OpStore %1290 %1291
+%1292 = OpLoad %v4float %842
+%1293 = OpLoad %v4float %687
+%1294 = OpFAdd %v4float %1292 %1293
+OpStore %833 %1294
+%1295 = OpLoad %v4float %833
+%1296 = OpLoad %v4float %834
+%1297 = OpFMul %v4float %1295 %1296
+OpStore %835 %1297
+%1298 = OpLoad %ulong %843
+%1299 = OpIAdd %ulong %1298 %ulong_1
+OpStore %836 %1299
+%1300 = OpLoad %v4float %835
+OpStore %842 %1300
+%1301 = OpLoad %ulong %836
+OpStore %843 %1301
+OpBranch %647
+%615 = OpLabel
+%1302 = OpLoad %ulong %817
+%1303 = OpIMul %ulong %1302 %ulong_17
+OpStore %805 %1303
+%1304 = OpLoad %ulong %805
+%1305 = OpUConvert %uchar %1304
+OpStore %806 %1305
+%1306 = OpLoad %ulong %817
+%1307 = OpAccessChain %_ptr_Function_uchar %660 %1306
+%1308 = OpLoad %uchar %806
+OpStore %1307 %1308
+%1309 = OpLoad %v4float %816
+%1310 = OpLoad %v4float %717
+%1311 = OpFAdd %v4float %1309 %1310
+OpStore %807 %1311
+%1312 = OpLoad %v4float %807
+%1313 = OpLoad %v4float %808
+%1314 = OpFMul %v4float %1312 %1313
+OpStore %809 %1314
+%1315 = OpLoad %ulong %817
+%1316 = OpIAdd %ulong %1315 %ulong_1
+OpStore %810 %1316
+%1317 = OpLoad %v4float %809
+OpStore %816 %1317
+%1318 = OpLoad %ulong %810
+OpStore %817 %1318
+OpBranch %648
+%593 = OpLabel
+%1319 = OpLoad %ulong %775
+%1320 = OpIMul %ulong %1319 %ulong_17
+OpStore %763 %1320
+%1321 = OpLoad %ulong %763
+%1322 = OpUConvert %uchar %1321
+OpStore %764 %1322
+%1323 = OpLoad %ulong %775
+%1324 = OpAccessChain %_ptr_Function_uchar %659 %1323
+%1325 = OpLoad %uchar %764
+OpStore %1324 %1325
+%1326 = OpLoad %v4float %774
+%1327 = OpLoad %v4float %687
+%1328 = OpFAdd %v4float %1326 %1327
+OpStore %765 %1328
+%1329 = OpLoad %v4float %765
+%1330 = OpLoad %v4float %766
+%1331 = OpFMul %v4float %1329 %1330
+OpStore %767 %1331
+%1332 = OpLoad %ulong %775
+%1333 = OpIAdd %ulong %1332 %ulong_1
+OpStore %768 %1333
+%1334 = OpLoad %v4float %767
+OpStore %774 %1334
+%1335 = OpLoad %ulong %768
+OpStore %775 %1335
+OpBranch %649
+%638 = OpLabel
+OpBranch %619
+%639 = OpLabel
+OpBranch %602
+%640 = OpLabel
+OpBranch %607
+%641 = OpLabel
+OpBranch %585
+%642 = OpLabel
+OpBranch %574
+%643 = OpLabel
+OpBranch %571
+%644 = OpLabel
+OpBranch %597
+%645 = OpLabel
+OpBranch %580
+%646 = OpLabel
+OpBranch %568
+%647 = OpLabel
+OpBranch %626
+%648 = OpLabel
+OpBranch %614
+%649 = OpLabel
+OpBranch %592
 OpFunctionEnd
-%11 = OpFunction %ulong None %1275
-%1276 = OpFunctionParameter %ulong
-%1277 = OpFunctionParameter %float
-%1278 = OpLabel
-%1285 = OpVariable %_ptr_Function_ulong Function
-%1286 = OpVariable %_ptr_Function_float Function
-%1287 = OpVariable %_ptr_Function_uint Function
-%1288 = OpVariable %_ptr_Function_ulong Function
-%1289 = OpVariable %_ptr_Function_bool Function
-%1290 = OpVariable %_ptr_Function_ulong Function
-%1291 = OpVariable %_ptr_Function_ulong Function
-%1292 = OpVariable %_ptr_Function_ulong Function
-%1293 = OpVariable %_ptr_Function_ulong Function
-%1294 = OpVariable %_ptr_Function_ulong Function
-%1295 = OpVariable %_ptr_Function_ulong Function
-%1296 = OpVariable %_ptr_Function_ulong Function
-%1297 = OpVariable %_ptr_Function_ulong Function
-OpStore %1285 %1276
-OpStore %1286 %1277
-%1298 = OpLoad %float %1286
-%1299 = OpBitcast %uint %1298
-OpStore %1287 %1299
-%1300 = OpLoad %uint %1287
-%1301 = OpUConvert %ulong %1300
-OpStore %1288 %1301
-OpBranch %1279
-%1279 = OpLabel
-%1302 = OpLoad %ulong %1285
-OpStore %1296 %1302
-OpStore %1297 %ulong_0
-OpBranch %1280
-%1280 = OpLabel
-%1303 = OpLoad %ulong %1297
-%1304 = OpULessThan %bool %1303 %ulong_8
-OpStore %1289 %1304
-%1305 = OpLoad %bool %1289
-OpLoopMerge %1282 %1284 None
-OpBranchConditional %1305 %1281 %1282
-%1282 = OpLabel
-OpBranch %1283
-%1283 = OpLabel
-%1306 = OpLoad %ulong %1296
-OpReturnValue %1306
-%1281 = OpLabel
-%1307 = OpLoad %ulong %1297
-%1308 = OpIMul %ulong %1307 %ulong_8
-OpStore %1290 %1308
-%1309 = OpLoad %ulong %1288
-%1310 = OpLoad %ulong %1290
-%1311 = OpShiftRightLogical %ulong %1309 %1310
-OpStore %1291 %1311
-%1312 = OpLoad %ulong %1291
-%1313 = OpBitwiseAnd %ulong %1312 %ulong_255
-OpStore %1292 %1313
-%1314 = OpLoad %ulong %1296
-%1315 = OpLoad %ulong %1292
-%1316 = OpBitwiseXor %ulong %1314 %1315
-OpStore %1293 %1316
-%1317 = OpLoad %ulong %1293
-%1318 = OpIMul %ulong %1317 %ulong_1099511628211
-OpStore %1294 %1318
-%1319 = OpLoad %ulong %1297
-%1320 = OpIAdd %ulong %1319 %ulong_1
-OpStore %1295 %1320
-%1321 = OpLoad %ulong %1294
-OpStore %1296 %1321
-%1322 = OpLoad %ulong %1295
-OpStore %1297 %1322
-OpBranch %1284
-%1284 = OpLabel
-OpBranch %1280
-OpFunctionEnd
-%12 = OpFunction %ulong None %1323
-%1324 = OpFunctionParameter %ulong
-%1325 = OpFunctionParameter %double
-%1326 = OpLabel
-%1333 = OpVariable %_ptr_Function_ulong Function
-%1334 = OpVariable %_ptr_Function_double Function
-%1335 = OpVariable %_ptr_Function_ulong Function
-%1336 = OpVariable %_ptr_Function_bool Function
-%1337 = OpVariable %_ptr_Function_ulong Function
-%1338 = OpVariable %_ptr_Function_ulong Function
-%1339 = OpVariable %_ptr_Function_ulong Function
-%1340 = OpVariable %_ptr_Function_ulong Function
-%1341 = OpVariable %_ptr_Function_ulong Function
-%1342 = OpVariable %_ptr_Function_ulong Function
-%1343 = OpVariable %_ptr_Function_ulong Function
+%6 = OpFunction %ulong None %1336
+%1337 = OpFunctionParameter %ulong
+%1338 = OpFunctionParameter %ulong
+%1339 = OpLabel
 %1344 = OpVariable %_ptr_Function_ulong Function
-OpStore %1333 %1324
-OpStore %1334 %1325
-%1345 = OpLoad %double %1334
-%1346 = OpBitcast %ulong %1345
-OpStore %1335 %1346
-OpBranch %1327
-%1327 = OpLabel
-%1347 = OpLoad %ulong %1333
-OpStore %1343 %1347
-OpStore %1344 %ulong_0
-OpBranch %1328
-%1328 = OpLabel
-%1348 = OpLoad %ulong %1344
-%1349 = OpULessThan %bool %1348 %ulong_8
-OpStore %1336 %1349
-%1350 = OpLoad %bool %1336
-OpLoopMerge %1330 %1332 None
-OpBranchConditional %1350 %1329 %1330
-%1330 = OpLabel
-OpBranch %1331
-%1331 = OpLabel
-%1351 = OpLoad %ulong %1343
-OpReturnValue %1351
-%1329 = OpLabel
-%1352 = OpLoad %ulong %1344
-%1353 = OpIMul %ulong %1352 %ulong_8
-OpStore %1337 %1353
-%1354 = OpLoad %ulong %1335
-%1355 = OpLoad %ulong %1337
-%1356 = OpShiftRightLogical %ulong %1354 %1355
-OpStore %1338 %1356
-%1357 = OpLoad %ulong %1338
-%1358 = OpBitwiseAnd %ulong %1357 %ulong_255
-OpStore %1339 %1358
-%1359 = OpLoad %ulong %1343
-%1360 = OpLoad %ulong %1339
-%1361 = OpBitwiseXor %ulong %1359 %1360
-OpStore %1340 %1361
-%1362 = OpLoad %ulong %1340
-%1363 = OpIMul %ulong %1362 %ulong_1099511628211
-OpStore %1341 %1363
-%1364 = OpLoad %ulong %1344
-%1365 = OpIAdd %ulong %1364 %ulong_1
-OpStore %1342 %1365
-%1366 = OpLoad %ulong %1341
-OpStore %1343 %1366
-%1367 = OpLoad %ulong %1342
-OpStore %1344 %1367
-OpBranch %1332
-%1332 = OpLabel
-OpBranch %1328
+%1345 = OpVariable %_ptr_Function_ulong Function
+%1346 = OpVariable %_ptr_Function_bool Function
+%1347 = OpVariable %_ptr_Function_ulong Function
+%1348 = OpVariable %_ptr_Function_ulong Function
+%1349 = OpVariable %_ptr_Function_ulong Function
+%1350 = OpVariable %_ptr_Function_ulong Function
+%1351 = OpVariable %_ptr_Function_ulong Function
+%1352 = OpVariable %_ptr_Function_ulong Function
+%1353 = OpVariable %_ptr_Function_ulong Function
+%1354 = OpVariable %_ptr_Function_ulong Function
+OpStore %1344 %1337
+OpStore %1345 %1338
+%1355 = OpLoad %ulong %1344
+OpStore %1353 %1355
+OpStore %1354 %ulong_0
+OpBranch %1340
+%1340 = OpLabel
+%1356 = OpLoad %ulong %1354
+%1357 = OpULessThan %bool %1356 %ulong_8
+OpStore %1346 %1357
+%1358 = OpLoad %bool %1346
+OpLoopMerge %1342 %1343 None
+OpBranchConditional %1358 %1341 %1342
+%1342 = OpLabel
+%1359 = OpLoad %ulong %1353
+OpReturnValue %1359
+%1341 = OpLabel
+%1360 = OpLoad %ulong %1354
+%1361 = OpIMul %ulong %1360 %ulong_8
+OpStore %1347 %1361
+%1362 = OpLoad %ulong %1345
+%1363 = OpLoad %ulong %1347
+%1364 = OpShiftRightLogical %ulong %1362 %1363
+OpStore %1348 %1364
+%1365 = OpLoad %ulong %1348
+%1366 = OpBitwiseAnd %ulong %1365 %ulong_255
+OpStore %1349 %1366
+%1367 = OpLoad %ulong %1353
+%1368 = OpLoad %ulong %1349
+%1369 = OpBitwiseXor %ulong %1367 %1368
+OpStore %1350 %1369
+%1370 = OpLoad %ulong %1350
+%1371 = OpIMul %ulong %1370 %ulong_1099511628211
+OpStore %1351 %1371
+%1372 = OpLoad %ulong %1354
+%1373 = OpIAdd %ulong %1372 %ulong_1
+OpStore %1352 %1373
+%1374 = OpLoad %ulong %1351
+OpStore %1353 %1374
+%1375 = OpLoad %ulong %1352
+OpStore %1354 %1375
+OpBranch %1343
+%1343 = OpLabel
+OpBranch %1340
 OpFunctionEnd

--- a/test/golden/spirv/frame/frame_large.dis
+++ b/test/golden/spirv/frame/frame_large.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 498
+; Bound: 879
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,10 +10,10 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.frame.frame_large.checksum" Export
 %ulong = OpTypeInt 64 0
-%7 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %uchar = OpTypeInt 8 0
-%bool = OpTypeBool
 %uint_640 = OpConstant %uint 640
 %_arr_ulong_uint_640 = OpTypeArray %ulong %uint_640
 %_ptr_Function__arr_ulong_uint_640 = OpTypePointer Function %_arr_ulong_uint_640
@@ -27,14 +27,16 @@ OpDecorate %1 LinkageAttributes "corpus.cases.frame.frame_large.checksum" Export
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_bool = OpTypePointer Function %bool
-%129 = OpConstantNull %_arr_ulong_uint_640
-%130 = OpConstantNull %_arr_uint_uint_512
-%131 = OpConstantNull %_arr_uchar_uint_1024
+%365 = OpConstantNull %_arr_ulong_uint_640
+%366 = OpConstantNull %_arr_uint_uint_512
+%367 = OpConstantNull %_arr_uchar_uint_1024
 %uint_0 = OpConstant %uint 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_639 = OpConstant %uint 639
 %uint_511 = OpConstant %uint 511
 %uint_1023 = OpConstant %uint 1023
-%ulong_0 = OpConstant %ulong 0
 %ulong_640 = OpConstant %ulong 640
 %ulong_512 = OpConstant %ulong 512
 %ulong_1024 = OpConstant %ulong 1024
@@ -50,6 +52,8 @@ OpDecorate %1 LinkageAttributes "corpus.cases.frame.frame_large.checksum" Export
 %uint_638 = OpConstant %uint 638
 %uint_508 = OpConstant %uint 508
 %uint_1016 = OpConstant %uint 1016
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_9 = OpConstant %ulong 9
 %ulong_13 = OpConstant %ulong 13
 %ulong_29 = OpConstant %ulong 29
@@ -58,638 +62,1233 @@ OpDecorate %1 LinkageAttributes "corpus.cases.frame.frame_large.checksum" Export
 %ulong_2654435761 = OpConstant %ulong 2654435761
 %ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
 %ulong_17 = OpConstant %ulong 17
-%362 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%365 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%408 = OpTypeFunction %ulong %ulong %uchar
-%453 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %7
-%8 = OpFunctionParameter %ulong
-%9 = OpLabel
-%32 = OpVariable %_ptr_Function__arr_ulong_uint_640 Function
-%36 = OpVariable %_ptr_Function__arr_uint_uint_512 Function
-%40 = OpVariable %_ptr_Function__arr_uchar_uint_1024 Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uint Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_uchar Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_uchar Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_bool Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_bool Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_uint Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_bool Function
-%73 = OpVariable %_ptr_Function_ulong Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_uchar Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_bool Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_ulong Function
-%88 = OpVariable %_ptr_Function_uint Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_ulong Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_uchar Function
-%94 = OpVariable %_ptr_Function_ulong Function
-%95 = OpVariable %_ptr_Function_ulong Function
-%96 = OpVariable %_ptr_Function_ulong Function
-%97 = OpVariable %_ptr_Function_ulong Function
-%98 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_uint Function
-%101 = OpVariable %_ptr_Function_uint Function
-%102 = OpVariable %_ptr_Function_ulong Function
-%103 = OpVariable %_ptr_Function_ulong Function
-%104 = OpVariable %_ptr_Function_uchar Function
-%105 = OpVariable %_ptr_Function_uchar Function
-%106 = OpVariable %_ptr_Function_ulong Function
-%107 = OpVariable %_ptr_Function_ulong Function
-%108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_ulong Function
-%110 = OpVariable %_ptr_Function_ulong Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_uint Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_uint Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_uchar Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_uchar Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_ulong Function
-OpStore %42 %8
-%128 = OpFunctionCall %ulong %2
-OpStore %43 %128
-OpStore %32 %129
-OpStore %36 %130
-OpStore %40 %131
-%133 = OpAccessChain %_ptr_Function_ulong %32 %uint_0
-%134 = OpLoad %ulong %133
-OpStore %44 %134
-%135 = OpLoad %ulong %43
-%136 = OpLoad %ulong %44
-%137 = OpFunctionCall %ulong %3 %135 %136
-OpStore %45 %137
-%139 = OpAccessChain %_ptr_Function_ulong %32 %uint_639
-%140 = OpLoad %ulong %139
-OpStore %46 %140
-%141 = OpLoad %ulong %45
-%142 = OpLoad %ulong %46
-%143 = OpFunctionCall %ulong %3 %141 %142
-OpStore %47 %143
-%144 = OpAccessChain %_ptr_Function_uint %36 %uint_0
-%145 = OpLoad %uint %144
-OpStore %49 %145
-%146 = OpLoad %ulong %47
-%147 = OpLoad %uint %49
-%148 = OpFunctionCall %ulong %5 %146 %147
-OpStore %50 %148
-%150 = OpAccessChain %_ptr_Function_uint %36 %uint_511
-%151 = OpLoad %uint %150
-OpStore %51 %151
-%152 = OpLoad %ulong %50
-%153 = OpLoad %uint %51
-%154 = OpFunctionCall %ulong %5 %152 %153
-OpStore %52 %154
-%155 = OpAccessChain %_ptr_Function_uchar %40 %uint_0
-%156 = OpLoad %uchar %155
-OpStore %54 %156
-%157 = OpLoad %ulong %52
-%158 = OpLoad %uchar %54
-%159 = OpFunctionCall %ulong %4 %157 %158
-OpStore %55 %159
-%161 = OpAccessChain %_ptr_Function_uchar %40 %uint_1023
-%162 = OpLoad %uchar %161
-OpStore %56 %162
-%163 = OpLoad %ulong %55
-%164 = OpLoad %uchar %56
-%165 = OpFunctionCall %ulong %4 %163 %164
-OpStore %57 %165
-OpStore %123 %ulong_0
-OpBranch %10
-%10 = OpLabel
-%167 = OpLoad %ulong %123
-%169 = OpULessThan %bool %167 %ulong_640
-OpStore %59 %169
-%170 = OpLoad %bool %59
-OpLoopMerge %12 %25 None
-OpBranchConditional %170 %11 %12
-%12 = OpLabel
-OpStore %122 %ulong_0
-OpBranch %13
-%13 = OpLabel
-%171 = OpLoad %ulong %122
-%173 = OpULessThan %bool %171 %ulong_512
-OpStore %65 %173
-%174 = OpLoad %bool %65
-OpLoopMerge %15 %24 None
-OpBranchConditional %174 %14 %15
-%15 = OpLabel
-OpStore %121 %ulong_0
-OpBranch %16
-%16 = OpLabel
-%175 = OpLoad %ulong %121
-%177 = OpULessThan %bool %175 %ulong_1024
-OpStore %72 %177
-%178 = OpLoad %bool %72
-OpLoopMerge %18 %23 None
-OpBranchConditional %178 %17 %18
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%140 = OpVariable %_ptr_Function__arr_ulong_uint_640 Function
+%144 = OpVariable %_ptr_Function__arr_uint_uint_512 Function
+%148 = OpVariable %_ptr_Function__arr_uchar_uint_1024 Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_uint Function
+%155 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_uchar Function
+%158 = OpVariable %_ptr_Function_uchar Function
+%160 = OpVariable %_ptr_Function_bool Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_uint Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_bool Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_uchar Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_uint Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_uchar Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_uint Function
+%199 = OpVariable %_ptr_Function_uint Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_uchar Function
+%203 = OpVariable %_ptr_Function_uchar Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_uint Function
+%209 = OpVariable %_ptr_Function_uint Function
+%210 = OpVariable %_ptr_Function_uchar Function
+%211 = OpVariable %_ptr_Function_uchar Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_bool Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_bool Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_bool Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_bool Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_bool Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_bool Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_bool Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_bool Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+OpStore %150 %4
+OpBranch %18
 %18 = OpLabel
-%179 = OpLoad %ulong %57
-OpStore %120 %179
-OpStore %124 %ulong_0
 OpBranch %19
 %19 = OpLabel
-%180 = OpLoad %ulong %124
-%182 = OpULessThan %bool %180 %ulong_64
-OpStore %79 %182
-%183 = OpLoad %bool %79
-OpLoopMerge %21 %22 None
-OpBranchConditional %183 %20 %21
-%21 = OpLabel
-%184 = OpAccessChain %_ptr_Function_ulong %32 %uint_639
-%185 = OpLoad %ulong %184
-OpStore %96 %185
-%186 = OpLoad %ulong %96
-%188 = OpIAdd %ulong %186 %ulong_1
-OpStore %97 %188
-%189 = OpLoad %ulong %42
-%190 = OpBitwiseAnd %ulong %189 %ulong_1
-OpStore %98 %190
-%192 = OpLoad %ulong %98
-%193 = OpISub %ulong %ulong_639 %192
-OpStore %99 %193
-%194 = OpLoad %ulong %99
-%195 = OpAccessChain %_ptr_Function_ulong %32 %194
-%196 = OpLoad %ulong %97
-OpStore %195 %196
-%197 = OpAccessChain %_ptr_Function_uint %36 %uint_511
-%198 = OpLoad %uint %197
-OpStore %100 %198
-%199 = OpLoad %uint %100
-%201 = OpIAdd %uint %199 %uint_7
-OpStore %101 %201
-%202 = OpLoad %ulong %42
-%204 = OpBitwiseAnd %ulong %202 %ulong_3
-OpStore %102 %204
-%206 = OpLoad %ulong %102
-%207 = OpISub %ulong %ulong_511 %206
-OpStore %103 %207
-%208 = OpLoad %ulong %103
-%209 = OpAccessChain %_ptr_Function_uint %36 %208
-%210 = OpLoad %uint %101
-OpStore %209 %210
-%211 = OpAccessChain %_ptr_Function_uchar %40 %uint_1023
-%212 = OpLoad %uchar %211
-OpStore %104 %212
-%213 = OpLoad %uchar %104
-%215 = OpIAdd %uchar %213 %uchar_11
-OpStore %105 %215
-%216 = OpLoad %ulong %42
-%218 = OpBitwiseAnd %ulong %216 %ulong_7
-OpStore %106 %218
-%220 = OpLoad %ulong %106
-%221 = OpISub %ulong %ulong_1023 %220
-OpStore %107 %221
-%222 = OpLoad %ulong %107
-%223 = OpAccessChain %_ptr_Function_uchar %40 %222
-%224 = OpLoad %uchar %105
-OpStore %223 %224
-%226 = OpAccessChain %_ptr_Function_ulong %32 %uint_638
-%227 = OpLoad %ulong %226
-OpStore %108 %227
-%228 = OpLoad %ulong %120
-%229 = OpLoad %ulong %108
-%230 = OpFunctionCall %ulong %3 %228 %229
-OpStore %109 %230
-%231 = OpLoad %ulong %184
-OpStore %110 %231
-%232 = OpLoad %ulong %109
-%233 = OpLoad %ulong %110
-%234 = OpFunctionCall %ulong %3 %232 %233
-OpStore %111 %234
-%236 = OpAccessChain %_ptr_Function_uint %36 %uint_508
-%237 = OpLoad %uint %236
-OpStore %112 %237
-%238 = OpLoad %ulong %111
-%239 = OpLoad %uint %112
-%240 = OpFunctionCall %ulong %5 %238 %239
-OpStore %113 %240
-%241 = OpLoad %uint %197
-OpStore %114 %241
-%242 = OpLoad %ulong %113
-%243 = OpLoad %uint %114
-%244 = OpFunctionCall %ulong %5 %242 %243
-OpStore %115 %244
-%246 = OpAccessChain %_ptr_Function_uchar %40 %uint_1016
-%247 = OpLoad %uchar %246
-OpStore %116 %247
-%248 = OpLoad %ulong %115
-%249 = OpLoad %uchar %116
-%250 = OpFunctionCall %ulong %4 %248 %249
-OpStore %117 %250
-%251 = OpLoad %uchar %211
-OpStore %118 %251
-%252 = OpLoad %ulong %117
-%253 = OpLoad %uchar %118
-%254 = OpFunctionCall %ulong %4 %252 %253
-OpStore %119 %254
-%255 = OpLoad %ulong %119
-OpReturnValue %255
-%20 = OpLabel
-%256 = OpLoad %ulong %124
-%258 = OpIMul %ulong %256 %ulong_9
-OpStore %80 %258
-%259 = OpLoad %ulong %80
-%260 = OpLoad %ulong %42
-%261 = OpIAdd %ulong %259 %260
-OpStore %81 %261
-OpStore %125 %ulong_640
-%262 = OpLoad %ulong %81
-%263 = OpLoad %ulong %125
-%264 = OpUMod %ulong %262 %263
-OpStore %82 %264
-%265 = OpLoad %ulong %82
-%266 = OpAccessChain %_ptr_Function_ulong %32 %265
-%267 = OpLoad %ulong %266
-OpStore %83 %267
-%268 = OpLoad %ulong %120
-%269 = OpLoad %ulong %83
-%270 = OpFunctionCall %ulong %3 %268 %269
-OpStore %84 %270
-%271 = OpLoad %ulong %124
-%273 = OpIMul %ulong %271 %ulong_13
-OpStore %85 %273
-%274 = OpLoad %ulong %85
-%275 = OpLoad %ulong %42
-%276 = OpIAdd %ulong %274 %275
-OpStore %86 %276
-OpStore %126 %ulong_512
-%277 = OpLoad %ulong %86
-%278 = OpLoad %ulong %126
-%279 = OpUMod %ulong %277 %278
-OpStore %87 %279
-%280 = OpLoad %ulong %87
-%281 = OpAccessChain %_ptr_Function_uint %36 %280
-%282 = OpLoad %uint %281
-OpStore %88 %282
-%283 = OpLoad %ulong %84
-%284 = OpLoad %uint %88
-%285 = OpFunctionCall %ulong %5 %283 %284
-OpStore %89 %285
-%286 = OpLoad %ulong %124
-%288 = OpIMul %ulong %286 %ulong_29
-OpStore %90 %288
-%289 = OpLoad %ulong %90
-%290 = OpLoad %ulong %42
-%291 = OpIAdd %ulong %289 %290
-OpStore %91 %291
-OpStore %127 %ulong_1024
-%292 = OpLoad %ulong %91
-%293 = OpLoad %ulong %127
-%294 = OpUMod %ulong %292 %293
-OpStore %92 %294
-%295 = OpLoad %ulong %92
-%296 = OpAccessChain %_ptr_Function_uchar %40 %295
-%297 = OpLoad %uchar %296
-OpStore %93 %297
-%298 = OpLoad %ulong %89
-%299 = OpLoad %uchar %93
-%300 = OpFunctionCall %ulong %4 %298 %299
-OpStore %94 %300
-%301 = OpLoad %ulong %124
-%302 = OpIAdd %ulong %301 %ulong_1
-OpStore %95 %302
-%303 = OpLoad %ulong %94
-OpStore %120 %303
-%304 = OpLoad %ulong %95
-OpStore %124 %304
-OpBranch %22
-%17 = OpLabel
-%305 = OpLoad %ulong %121
-%307 = OpIMul %ulong %305 %ulong_131
-OpStore %73 %307
-%308 = OpLoad %ulong %73
-%309 = OpLoad %ulong %42
-%310 = OpIAdd %ulong %308 %309
-OpStore %74 %310
-%311 = OpLoad %ulong %121
-%313 = OpShiftRightLogical %ulong %311 %ulong_2
-OpStore %75 %313
-%314 = OpLoad %ulong %74
-%315 = OpLoad %ulong %75
-%316 = OpBitwiseXor %ulong %314 %315
-OpStore %76 %316
-%317 = OpLoad %ulong %76
-%318 = OpUConvert %uchar %317
-OpStore %77 %318
-%319 = OpLoad %ulong %121
-%320 = OpAccessChain %_ptr_Function_uchar %40 %319
-%321 = OpLoad %uchar %77
-OpStore %320 %321
-%322 = OpLoad %ulong %121
-%323 = OpIAdd %ulong %322 %ulong_1
-OpStore %78 %323
-%324 = OpLoad %ulong %78
-OpStore %121 %324
-OpBranch %23
-%14 = OpLabel
-%325 = OpLoad %ulong %122
-%327 = OpIMul %ulong %325 %ulong_2654435761
-OpStore %66 %327
-%328 = OpLoad %ulong %66
-%329 = OpLoad %ulong %42
-%330 = OpIAdd %ulong %328 %329
-OpStore %67 %330
-%331 = OpLoad %ulong %122
-%332 = OpShiftRightLogical %ulong %331 %ulong_3
-OpStore %68 %332
-%333 = OpLoad %ulong %67
-%334 = OpLoad %ulong %68
-%335 = OpBitwiseXor %ulong %333 %334
-OpStore %69 %335
-%336 = OpLoad %ulong %69
-%337 = OpUConvert %uint %336
-OpStore %70 %337
-%338 = OpLoad %ulong %122
-%339 = OpAccessChain %_ptr_Function_uint %36 %338
-%340 = OpLoad %uint %70
-OpStore %339 %340
-%341 = OpLoad %ulong %122
-%342 = OpIAdd %ulong %341 %ulong_1
-OpStore %71 %342
-%343 = OpLoad %ulong %71
-OpStore %122 %343
-OpBranch %24
+OpStore %140 %365
+OpStore %144 %366
+OpStore %148 %367
+%369 = OpAccessChain %_ptr_Function_ulong %140 %uint_0
+%370 = OpLoad %ulong %369
+OpStore %151 %370
+OpBranch %30
+%30 = OpLabel
+OpStore %242 %ulong_14695981039346656037
+OpStore %243 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%373 = OpLoad %ulong %243
+%375 = OpULessThan %bool %373 %ulong_8
+OpStore %235 %375
+%376 = OpLoad %bool %235
+OpLoopMerge %33 %133 None
+OpBranchConditional %376 %32 %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%378 = OpAccessChain %_ptr_Function_ulong %140 %uint_639
+%379 = OpLoad %ulong %378
+OpStore %152 %379
+OpBranch %42
+%42 = OpLabel
+%380 = OpLoad %ulong %242
+OpStore %261 %380
+OpStore %262 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%381 = OpLoad %ulong %262
+%382 = OpULessThan %bool %381 %ulong_8
+OpStore %254 %382
+%383 = OpLoad %bool %254
+OpLoopMerge %45 %132 None
+OpBranchConditional %383 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+%384 = OpAccessChain %_ptr_Function_uint %144 %uint_0
+%385 = OpLoad %uint %384
+OpStore %154 %385
+OpBranch %56
+%56 = OpLabel
+%386 = OpLoad %uint %154
+%387 = OpUConvert %ulong %386
+OpStore %274 %387
+OpBranch %70
+%70 = OpLabel
+%388 = OpLoad %ulong %261
+OpStore %301 %388
+OpStore %302 %ulong_0
+OpBranch %71
+%71 = OpLabel
+%389 = OpLoad %ulong %302
+%390 = OpULessThan %bool %389 %ulong_8
+OpStore %294 %390
+%391 = OpLoad %bool %294
+OpLoopMerge %73 %131 None
+OpBranchConditional %391 %72 %73
+%73 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%393 = OpAccessChain %_ptr_Function_uint %144 %uint_511
+%394 = OpLoad %uint %393
+OpStore %155 %394
+OpBranch %75
+%75 = OpLabel
+%395 = OpLoad %uint %155
+%396 = OpUConvert %ulong %395
+OpStore %303 %396
+OpBranch %84
+%84 = OpLabel
+%397 = OpLoad %ulong %301
+OpStore %321 %397
+OpStore %322 %ulong_0
+OpBranch %85
+%85 = OpLabel
+%398 = OpLoad %ulong %322
+%399 = OpULessThan %bool %398 %ulong_8
+OpStore %314 %399
+%400 = OpLoad %bool %314
+OpLoopMerge %87 %130 None
+OpBranchConditional %400 %86 %87
+%87 = OpLabel
+OpBranch %88
+%88 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%401 = OpAccessChain %_ptr_Function_uchar %148 %uint_0
+%402 = OpLoad %uchar %401
+OpStore %157 %402
+OpBranch %89
+%89 = OpLabel
+%403 = OpLoad %uchar %157
+%404 = OpUConvert %ulong %403
+OpStore %323 %404
+OpBranch %98
+%98 = OpLabel
+%405 = OpLoad %ulong %321
+OpStore %341 %405
+OpStore %342 %ulong_0
+OpBranch %99
+%99 = OpLabel
+%406 = OpLoad %ulong %342
+%407 = OpULessThan %bool %406 %ulong_8
+OpStore %334 %407
+%408 = OpLoad %bool %334
+OpLoopMerge %101 %129 None
+OpBranchConditional %408 %100 %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+OpBranch %90
+%90 = OpLabel
+%410 = OpAccessChain %_ptr_Function_uchar %148 %uint_1023
+%411 = OpLoad %uchar %410
+OpStore %158 %411
+OpBranch %103
+%103 = OpLabel
+%412 = OpLoad %uchar %158
+%413 = OpUConvert %ulong %412
+OpStore %343 %413
+OpBranch %110
+%110 = OpLabel
+%414 = OpLoad %ulong %341
+OpStore %360 %414
+OpStore %361 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%415 = OpLoad %ulong %361
+%416 = OpULessThan %bool %415 %ulong_8
+OpStore %353 %416
+%417 = OpLoad %bool %353
+OpLoopMerge %113 %128 None
+OpBranchConditional %417 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %104
+%104 = OpLabel
+OpStore %215 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%418 = OpLoad %ulong %215
+%420 = OpULessThan %bool %418 %ulong_640
+OpStore %160 %420
+%421 = OpLoad %bool %160
+OpLoopMerge %8 %127 None
+OpBranchConditional %421 %7 %8
+%8 = OpLabel
+OpStore %214 %ulong_0
+OpBranch %9
+%9 = OpLabel
+%422 = OpLoad %ulong %214
+%424 = OpULessThan %bool %422 %ulong_512
+OpStore %166 %424
+%425 = OpLoad %bool %166
+OpLoopMerge %11 %126 None
+OpBranchConditional %425 %10 %11
 %11 = OpLabel
-%344 = OpLoad %ulong %123
-%345 = OpLoad %ulong %42
-%346 = OpIAdd %ulong %344 %345
-OpStore %60 %346
-%347 = OpLoad %ulong %60
-%349 = OpIMul %ulong %347 %ulong_6364136223846793005
-OpStore %61 %349
-%350 = OpLoad %ulong %123
-%352 = OpShiftLeftLogical %ulong %350 %ulong_17
-OpStore %62 %352
-%353 = OpLoad %ulong %61
-%354 = OpLoad %ulong %62
-%355 = OpBitwiseXor %ulong %353 %354
-OpStore %63 %355
-%356 = OpLoad %ulong %123
-%357 = OpAccessChain %_ptr_Function_ulong %32 %356
-%358 = OpLoad %ulong %63
-OpStore %357 %358
-%359 = OpLoad %ulong %123
-%360 = OpIAdd %ulong %359 %ulong_1
-OpStore %64 %360
-%361 = OpLoad %ulong %64
-OpStore %123 %361
+OpStore %213 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%426 = OpLoad %ulong %213
+%428 = OpULessThan %bool %426 %ulong_1024
+OpStore %173 %428
+%429 = OpLoad %bool %173
+OpLoopMerge %14 %125 None
+OpBranchConditional %429 %13 %14
+%14 = OpLabel
+%430 = OpLoad %ulong %360
+OpStore %212 %430
+OpStore %216 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%431 = OpLoad %ulong %216
+%433 = OpULessThan %bool %431 %ulong_64
+OpStore %180 %433
+%434 = OpLoad %bool %180
+OpLoopMerge %17 %124 None
+OpBranchConditional %434 %16 %17
+%17 = OpLabel
+%435 = OpAccessChain %_ptr_Function_ulong %140 %uint_639
+%436 = OpLoad %ulong %435
+OpStore %194 %436
+%437 = OpLoad %ulong %194
+%439 = OpIAdd %ulong %437 %ulong_1
+OpStore %195 %439
+%440 = OpLoad %ulong %150
+%441 = OpBitwiseAnd %ulong %440 %ulong_1
+OpStore %196 %441
+%443 = OpLoad %ulong %196
+%444 = OpISub %ulong %ulong_639 %443
+OpStore %197 %444
+%445 = OpLoad %ulong %197
+%446 = OpAccessChain %_ptr_Function_ulong %140 %445
+%447 = OpLoad %ulong %195
+OpStore %446 %447
+%448 = OpAccessChain %_ptr_Function_uint %144 %uint_511
+%449 = OpLoad %uint %448
+OpStore %198 %449
+%450 = OpLoad %uint %198
+%452 = OpIAdd %uint %450 %uint_7
+OpStore %199 %452
+%453 = OpLoad %ulong %150
+%455 = OpBitwiseAnd %ulong %453 %ulong_3
+OpStore %200 %455
+%457 = OpLoad %ulong %200
+%458 = OpISub %ulong %ulong_511 %457
+OpStore %201 %458
+%459 = OpLoad %ulong %201
+%460 = OpAccessChain %_ptr_Function_uint %144 %459
+%461 = OpLoad %uint %199
+OpStore %460 %461
+%462 = OpAccessChain %_ptr_Function_uchar %148 %uint_1023
+%463 = OpLoad %uchar %462
+OpStore %202 %463
+%464 = OpLoad %uchar %202
+%466 = OpIAdd %uchar %464 %uchar_11
+OpStore %203 %466
+%467 = OpLoad %ulong %150
+%469 = OpBitwiseAnd %ulong %467 %ulong_7
+OpStore %204 %469
+%471 = OpLoad %ulong %204
+%472 = OpISub %ulong %ulong_1023 %471
+OpStore %205 %472
+%473 = OpLoad %ulong %205
+%474 = OpAccessChain %_ptr_Function_uchar %148 %473
+%475 = OpLoad %uchar %203
+OpStore %474 %475
+%477 = OpAccessChain %_ptr_Function_ulong %140 %uint_638
+%478 = OpLoad %ulong %477
+OpStore %206 %478
 OpBranch %25
-%22 = OpLabel
-OpBranch %19
-%23 = OpLabel
-OpBranch %16
-%24 = OpLabel
-OpBranch %13
 %25 = OpLabel
-OpBranch %10
-OpFunctionEnd
-%2 = OpFunction %ulong None %362
-%363 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %365
-%366 = OpFunctionParameter %ulong
-%367 = OpFunctionParameter %ulong
-%368 = OpLabel
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_ulong Function
-%375 = OpVariable %_ptr_Function_bool Function
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_ulong Function
-%378 = OpVariable %_ptr_Function_ulong Function
-%379 = OpVariable %_ptr_Function_ulong Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_ulong Function
-OpStore %373 %366
-OpStore %374 %367
-%384 = OpLoad %ulong %373
-OpStore %382 %384
-OpStore %383 %ulong_0
-OpBranch %369
-%369 = OpLabel
-%385 = OpLoad %ulong %383
-%387 = OpULessThan %bool %385 %ulong_8
-OpStore %375 %387
-%388 = OpLoad %bool %375
-OpLoopMerge %371 %372 None
-OpBranchConditional %388 %370 %371
-%371 = OpLabel
-%389 = OpLoad %ulong %382
-OpReturnValue %389
-%370 = OpLabel
-%390 = OpLoad %ulong %383
-%391 = OpIMul %ulong %390 %ulong_8
-OpStore %376 %391
-%392 = OpLoad %ulong %374
-%393 = OpLoad %ulong %376
-%394 = OpShiftRightLogical %ulong %392 %393
-OpStore %377 %394
-%395 = OpLoad %ulong %377
-%397 = OpBitwiseAnd %ulong %395 %ulong_255
-OpStore %378 %397
-%398 = OpLoad %ulong %382
-%399 = OpLoad %ulong %378
-%400 = OpBitwiseXor %ulong %398 %399
-OpStore %379 %400
-%401 = OpLoad %ulong %379
-%403 = OpIMul %ulong %401 %ulong_1099511628211
-OpStore %380 %403
-%404 = OpLoad %ulong %383
-%405 = OpIAdd %ulong %404 %ulong_1
-OpStore %381 %405
-%406 = OpLoad %ulong %380
-OpStore %382 %406
-%407 = OpLoad %ulong %381
-OpStore %383 %407
-OpBranch %372
-%372 = OpLabel
-OpBranch %369
-OpFunctionEnd
-%4 = OpFunction %ulong None %408
-%409 = OpFunctionParameter %ulong
-%410 = OpFunctionParameter %uchar
-%411 = OpLabel
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_uchar Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_bool Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_ulong Function
-%428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_ulong Function
-OpStore %418 %409
-OpStore %419 %410
-%430 = OpLoad %uchar %419
-%431 = OpUConvert %ulong %430
-OpStore %420 %431
-OpBranch %412
-%412 = OpLabel
-%432 = OpLoad %ulong %418
-OpStore %428 %432
-OpStore %429 %ulong_0
-OpBranch %413
-%413 = OpLabel
-%433 = OpLoad %ulong %429
-%434 = OpULessThan %bool %433 %ulong_8
-OpStore %421 %434
-%435 = OpLoad %bool %421
-OpLoopMerge %415 %417 None
-OpBranchConditional %435 %414 %415
-%415 = OpLabel
-OpBranch %416
-%416 = OpLabel
-%436 = OpLoad %ulong %428
-OpReturnValue %436
-%414 = OpLabel
-%437 = OpLoad %ulong %429
-%438 = OpIMul %ulong %437 %ulong_8
-OpStore %422 %438
-%439 = OpLoad %ulong %420
-%440 = OpLoad %ulong %422
-%441 = OpShiftRightLogical %ulong %439 %440
-OpStore %423 %441
-%442 = OpLoad %ulong %423
-%443 = OpBitwiseAnd %ulong %442 %ulong_255
-OpStore %424 %443
-%444 = OpLoad %ulong %428
-%445 = OpLoad %ulong %424
-%446 = OpBitwiseXor %ulong %444 %445
-OpStore %425 %446
-%447 = OpLoad %ulong %425
-%448 = OpIMul %ulong %447 %ulong_1099511628211
-OpStore %426 %448
-%449 = OpLoad %ulong %429
-%450 = OpIAdd %ulong %449 %ulong_1
-OpStore %427 %450
-%451 = OpLoad %ulong %426
-OpStore %428 %451
-%452 = OpLoad %ulong %427
-OpStore %429 %452
-OpBranch %417
-%417 = OpLabel
-OpBranch %413
-OpFunctionEnd
-%5 = OpFunction %ulong None %453
-%454 = OpFunctionParameter %ulong
-%455 = OpFunctionParameter %uint
-%456 = OpLabel
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_uint Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_bool Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_ulong Function
-%470 = OpVariable %_ptr_Function_ulong Function
-%471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_ulong Function
-%473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_ulong Function
-OpStore %463 %454
-OpStore %464 %455
-%475 = OpLoad %uint %464
-%476 = OpUConvert %ulong %475
-OpStore %465 %476
-OpBranch %457
-%457 = OpLabel
-%477 = OpLoad %ulong %463
-OpStore %473 %477
-OpStore %474 %ulong_0
-OpBranch %458
-%458 = OpLabel
-%478 = OpLoad %ulong %474
-%479 = OpULessThan %bool %478 %ulong_8
-OpStore %466 %479
-%480 = OpLoad %bool %466
-OpLoopMerge %460 %462 None
-OpBranchConditional %480 %459 %460
-%460 = OpLabel
-OpBranch %461
-%461 = OpLabel
-%481 = OpLoad %ulong %473
-OpReturnValue %481
-%459 = OpLabel
-%482 = OpLoad %ulong %474
-%483 = OpIMul %ulong %482 %ulong_8
-OpStore %467 %483
-%484 = OpLoad %ulong %465
-%485 = OpLoad %ulong %467
-%486 = OpShiftRightLogical %ulong %484 %485
-OpStore %468 %486
-%487 = OpLoad %ulong %468
-%488 = OpBitwiseAnd %ulong %487 %ulong_255
-OpStore %469 %488
-%489 = OpLoad %ulong %473
-%490 = OpLoad %ulong %469
-%491 = OpBitwiseXor %ulong %489 %490
-OpStore %470 %491
-%492 = OpLoad %ulong %470
-%493 = OpIMul %ulong %492 %ulong_1099511628211
-OpStore %471 %493
-%494 = OpLoad %ulong %474
-%495 = OpIAdd %ulong %494 %ulong_1
-OpStore %472 %495
-%496 = OpLoad %ulong %471
-OpStore %473 %496
-%497 = OpLoad %ulong %472
-OpStore %474 %497
-OpBranch %462
-%462 = OpLabel
-OpBranch %458
+%479 = OpLoad %ulong %212
+OpStore %233 %479
+OpStore %234 %ulong_0
+OpBranch %26
+%26 = OpLabel
+%480 = OpLoad %ulong %234
+%481 = OpULessThan %bool %480 %ulong_8
+OpStore %226 %481
+%482 = OpLoad %bool %226
+OpLoopMerge %28 %123 None
+OpBranchConditional %482 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%483 = OpAccessChain %_ptr_Function_ulong %140 %uint_639
+%484 = OpLoad %ulong %483
+OpStore %207 %484
+OpBranch %37
+%37 = OpLabel
+%485 = OpLoad %ulong %233
+OpStore %252 %485
+OpStore %253 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%486 = OpLoad %ulong %253
+%487 = OpULessThan %bool %486 %ulong_8
+OpStore %245 %487
+%488 = OpLoad %bool %245
+OpLoopMerge %40 %121 None
+OpBranchConditional %488 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%490 = OpAccessChain %_ptr_Function_uint %144 %uint_508
+%491 = OpLoad %uint %490
+OpStore %208 %491
+OpBranch %54
+%54 = OpLabel
+%492 = OpLoad %uint %208
+%493 = OpUConvert %ulong %492
+OpStore %273 %493
+OpBranch %63
+%63 = OpLabel
+%494 = OpLoad %ulong %252
+OpStore %291 %494
+OpStore %292 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%495 = OpLoad %ulong %292
+%496 = OpULessThan %bool %495 %ulong_8
+OpStore %284 %496
+%497 = OpLoad %bool %284
+OpLoopMerge %66 %119 None
+OpBranchConditional %497 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%498 = OpAccessChain %_ptr_Function_uint %144 %uint_511
+%499 = OpLoad %uint %498
+OpStore %209 %499
+OpBranch %68
+%68 = OpLabel
+%500 = OpLoad %uint %209
+%501 = OpUConvert %ulong %500
+OpStore %293 %501
+OpBranch %77
+%77 = OpLabel
+%502 = OpLoad %ulong %291
+OpStore %311 %502
+OpStore %312 %ulong_0
+OpBranch %78
+%78 = OpLabel
+%503 = OpLoad %ulong %312
+%504 = OpULessThan %bool %503 %ulong_8
+OpStore %304 %504
+%505 = OpLoad %bool %304
+OpLoopMerge %80 %117 None
+OpBranchConditional %505 %79 %80
+%80 = OpLabel
+OpBranch %81
+%81 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%507 = OpAccessChain %_ptr_Function_uchar %148 %uint_1016
+%508 = OpLoad %uchar %507
+OpStore %210 %508
+OpBranch %82
+%82 = OpLabel
+%509 = OpLoad %uchar %210
+%510 = OpUConvert %ulong %509
+OpStore %313 %510
+OpBranch %91
+%91 = OpLabel
+%511 = OpLoad %ulong %311
+OpStore %331 %511
+OpStore %332 %ulong_0
+OpBranch %92
+%92 = OpLabel
+%512 = OpLoad %ulong %332
+%513 = OpULessThan %bool %512 %ulong_8
+OpStore %324 %513
+%514 = OpLoad %bool %324
+OpLoopMerge %94 %116 None
+OpBranchConditional %514 %93 %94
+%94 = OpLabel
+OpBranch %95
+%95 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%515 = OpAccessChain %_ptr_Function_uchar %148 %uint_1023
+%516 = OpLoad %uchar %515
+OpStore %211 %516
+OpBranch %96
+%96 = OpLabel
+%517 = OpLoad %uchar %211
+%518 = OpUConvert %ulong %517
+OpStore %333 %518
+OpBranch %105
+%105 = OpLabel
+%519 = OpLoad %ulong %331
+OpStore %351 %519
+OpStore %352 %ulong_0
+OpBranch %106
+%106 = OpLabel
+%520 = OpLoad %ulong %352
+%521 = OpULessThan %bool %520 %ulong_8
+OpStore %344 %521
+%522 = OpLoad %bool %344
+OpLoopMerge %108 %115 None
+OpBranchConditional %522 %107 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%523 = OpLoad %ulong %351
+OpReturnValue %523
+%107 = OpLabel
+%524 = OpLoad %ulong %352
+%525 = OpIMul %ulong %524 %ulong_8
+OpStore %345 %525
+%526 = OpLoad %ulong %333
+%527 = OpLoad %ulong %345
+%528 = OpShiftRightLogical %ulong %526 %527
+OpStore %346 %528
+%529 = OpLoad %ulong %346
+%531 = OpBitwiseAnd %ulong %529 %ulong_255
+OpStore %347 %531
+%532 = OpLoad %ulong %351
+%533 = OpLoad %ulong %347
+%534 = OpBitwiseXor %ulong %532 %533
+OpStore %348 %534
+%535 = OpLoad %ulong %348
+%537 = OpIMul %ulong %535 %ulong_1099511628211
+OpStore %349 %537
+%538 = OpLoad %ulong %352
+%539 = OpIAdd %ulong %538 %ulong_1
+OpStore %350 %539
+%540 = OpLoad %ulong %349
+OpStore %351 %540
+%541 = OpLoad %ulong %350
+OpStore %352 %541
+OpBranch %115
+%93 = OpLabel
+%542 = OpLoad %ulong %332
+%543 = OpIMul %ulong %542 %ulong_8
+OpStore %325 %543
+%544 = OpLoad %ulong %313
+%545 = OpLoad %ulong %325
+%546 = OpShiftRightLogical %ulong %544 %545
+OpStore %326 %546
+%547 = OpLoad %ulong %326
+%548 = OpBitwiseAnd %ulong %547 %ulong_255
+OpStore %327 %548
+%549 = OpLoad %ulong %331
+%550 = OpLoad %ulong %327
+%551 = OpBitwiseXor %ulong %549 %550
+OpStore %328 %551
+%552 = OpLoad %ulong %328
+%553 = OpIMul %ulong %552 %ulong_1099511628211
+OpStore %329 %553
+%554 = OpLoad %ulong %332
+%555 = OpIAdd %ulong %554 %ulong_1
+OpStore %330 %555
+%556 = OpLoad %ulong %329
+OpStore %331 %556
+%557 = OpLoad %ulong %330
+OpStore %332 %557
+OpBranch %116
+%79 = OpLabel
+%558 = OpLoad %ulong %312
+%559 = OpIMul %ulong %558 %ulong_8
+OpStore %305 %559
+%560 = OpLoad %ulong %293
+%561 = OpLoad %ulong %305
+%562 = OpShiftRightLogical %ulong %560 %561
+OpStore %306 %562
+%563 = OpLoad %ulong %306
+%564 = OpBitwiseAnd %ulong %563 %ulong_255
+OpStore %307 %564
+%565 = OpLoad %ulong %311
+%566 = OpLoad %ulong %307
+%567 = OpBitwiseXor %ulong %565 %566
+OpStore %308 %567
+%568 = OpLoad %ulong %308
+%569 = OpIMul %ulong %568 %ulong_1099511628211
+OpStore %309 %569
+%570 = OpLoad %ulong %312
+%571 = OpIAdd %ulong %570 %ulong_1
+OpStore %310 %571
+%572 = OpLoad %ulong %309
+OpStore %311 %572
+%573 = OpLoad %ulong %310
+OpStore %312 %573
+OpBranch %117
+%65 = OpLabel
+%574 = OpLoad %ulong %292
+%575 = OpIMul %ulong %574 %ulong_8
+OpStore %285 %575
+%576 = OpLoad %ulong %273
+%577 = OpLoad %ulong %285
+%578 = OpShiftRightLogical %ulong %576 %577
+OpStore %286 %578
+%579 = OpLoad %ulong %286
+%580 = OpBitwiseAnd %ulong %579 %ulong_255
+OpStore %287 %580
+%581 = OpLoad %ulong %291
+%582 = OpLoad %ulong %287
+%583 = OpBitwiseXor %ulong %581 %582
+OpStore %288 %583
+%584 = OpLoad %ulong %288
+%585 = OpIMul %ulong %584 %ulong_1099511628211
+OpStore %289 %585
+%586 = OpLoad %ulong %292
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %290 %587
+%588 = OpLoad %ulong %289
+OpStore %291 %588
+%589 = OpLoad %ulong %290
+OpStore %292 %589
+OpBranch %119
+%39 = OpLabel
+%590 = OpLoad %ulong %253
+%591 = OpIMul %ulong %590 %ulong_8
+OpStore %246 %591
+%592 = OpLoad %ulong %207
+%593 = OpLoad %ulong %246
+%594 = OpShiftRightLogical %ulong %592 %593
+OpStore %247 %594
+%595 = OpLoad %ulong %247
+%596 = OpBitwiseAnd %ulong %595 %ulong_255
+OpStore %248 %596
+%597 = OpLoad %ulong %252
+%598 = OpLoad %ulong %248
+%599 = OpBitwiseXor %ulong %597 %598
+OpStore %249 %599
+%600 = OpLoad %ulong %249
+%601 = OpIMul %ulong %600 %ulong_1099511628211
+OpStore %250 %601
+%602 = OpLoad %ulong %253
+%603 = OpIAdd %ulong %602 %ulong_1
+OpStore %251 %603
+%604 = OpLoad %ulong %250
+OpStore %252 %604
+%605 = OpLoad %ulong %251
+OpStore %253 %605
+OpBranch %121
+%27 = OpLabel
+%606 = OpLoad %ulong %234
+%607 = OpIMul %ulong %606 %ulong_8
+OpStore %227 %607
+%608 = OpLoad %ulong %206
+%609 = OpLoad %ulong %227
+%610 = OpShiftRightLogical %ulong %608 %609
+OpStore %228 %610
+%611 = OpLoad %ulong %228
+%612 = OpBitwiseAnd %ulong %611 %ulong_255
+OpStore %229 %612
+%613 = OpLoad %ulong %233
+%614 = OpLoad %ulong %229
+%615 = OpBitwiseXor %ulong %613 %614
+OpStore %230 %615
+%616 = OpLoad %ulong %230
+%617 = OpIMul %ulong %616 %ulong_1099511628211
+OpStore %231 %617
+%618 = OpLoad %ulong %234
+%619 = OpIAdd %ulong %618 %ulong_1
+OpStore %232 %619
+%620 = OpLoad %ulong %231
+OpStore %233 %620
+%621 = OpLoad %ulong %232
+OpStore %234 %621
+OpBranch %123
+%16 = OpLabel
+%622 = OpLoad %ulong %216
+%624 = OpIMul %ulong %622 %ulong_9
+OpStore %181 %624
+%625 = OpLoad %ulong %181
+%626 = OpLoad %ulong %150
+%627 = OpIAdd %ulong %625 %626
+OpStore %182 %627
+OpStore %362 %ulong_640
+%628 = OpLoad %ulong %182
+%629 = OpLoad %ulong %362
+%630 = OpUMod %ulong %628 %629
+OpStore %183 %630
+%631 = OpLoad %ulong %183
+%632 = OpAccessChain %_ptr_Function_ulong %140 %631
+%633 = OpLoad %ulong %632
+OpStore %184 %633
+OpBranch %20
+%20 = OpLabel
+%634 = OpLoad %ulong %212
+OpStore %224 %634
+OpStore %225 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%635 = OpLoad %ulong %225
+%636 = OpULessThan %bool %635 %ulong_8
+OpStore %217 %636
+%637 = OpLoad %bool %217
+OpLoopMerge %23 %122 None
+OpBranchConditional %637 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+%638 = OpLoad %ulong %216
+%640 = OpIMul %ulong %638 %ulong_13
+OpStore %185 %640
+%641 = OpLoad %ulong %185
+%642 = OpLoad %ulong %150
+%643 = OpIAdd %ulong %641 %642
+OpStore %186 %643
+OpStore %363 %ulong_512
+%644 = OpLoad %ulong %186
+%645 = OpLoad %ulong %363
+%646 = OpUMod %ulong %644 %645
+OpStore %187 %646
+%647 = OpLoad %ulong %187
+%648 = OpAccessChain %_ptr_Function_uint %144 %647
+%649 = OpLoad %uint %648
+OpStore %188 %649
+OpBranch %35
+%35 = OpLabel
+%650 = OpLoad %uint %188
+%651 = OpUConvert %ulong %650
+OpStore %244 %651
+OpBranch %47
+%47 = OpLabel
+%652 = OpLoad %ulong %224
+OpStore %270 %652
+OpStore %271 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%653 = OpLoad %ulong %271
+%654 = OpULessThan %bool %653 %ulong_8
+OpStore %263 %654
+%655 = OpLoad %bool %263
+OpLoopMerge %50 %120 None
+OpBranchConditional %655 %49 %50
+%50 = OpLabel
+OpBranch %51
+%51 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%656 = OpLoad %ulong %216
+%658 = OpIMul %ulong %656 %ulong_29
+OpStore %189 %658
+%659 = OpLoad %ulong %189
+%660 = OpLoad %ulong %150
+%661 = OpIAdd %ulong %659 %660
+OpStore %190 %661
+OpStore %364 %ulong_1024
+%662 = OpLoad %ulong %190
+%663 = OpLoad %ulong %364
+%664 = OpUMod %ulong %662 %663
+OpStore %191 %664
+%665 = OpLoad %ulong %191
+%666 = OpAccessChain %_ptr_Function_uchar %148 %665
+%667 = OpLoad %uchar %666
+OpStore %192 %667
+OpBranch %52
+%52 = OpLabel
+%668 = OpLoad %uchar %192
+%669 = OpUConvert %ulong %668
+OpStore %272 %669
+OpBranch %58
+%58 = OpLabel
+%670 = OpLoad %ulong %270
+OpStore %282 %670
+OpStore %283 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%671 = OpLoad %ulong %283
+%672 = OpULessThan %bool %671 %ulong_8
+OpStore %275 %672
+%673 = OpLoad %bool %275
+OpLoopMerge %61 %118 None
+OpBranchConditional %673 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%674 = OpLoad %ulong %216
+%675 = OpIAdd %ulong %674 %ulong_1
+OpStore %193 %675
+%676 = OpLoad %ulong %282
+OpStore %212 %676
+%677 = OpLoad %ulong %193
+OpStore %216 %677
+OpBranch %124
+%60 = OpLabel
+%678 = OpLoad %ulong %283
+%679 = OpIMul %ulong %678 %ulong_8
+OpStore %276 %679
+%680 = OpLoad %ulong %272
+%681 = OpLoad %ulong %276
+%682 = OpShiftRightLogical %ulong %680 %681
+OpStore %277 %682
+%683 = OpLoad %ulong %277
+%684 = OpBitwiseAnd %ulong %683 %ulong_255
+OpStore %278 %684
+%685 = OpLoad %ulong %282
+%686 = OpLoad %ulong %278
+%687 = OpBitwiseXor %ulong %685 %686
+OpStore %279 %687
+%688 = OpLoad %ulong %279
+%689 = OpIMul %ulong %688 %ulong_1099511628211
+OpStore %280 %689
+%690 = OpLoad %ulong %283
+%691 = OpIAdd %ulong %690 %ulong_1
+OpStore %281 %691
+%692 = OpLoad %ulong %280
+OpStore %282 %692
+%693 = OpLoad %ulong %281
+OpStore %283 %693
+OpBranch %118
+%49 = OpLabel
+%694 = OpLoad %ulong %271
+%695 = OpIMul %ulong %694 %ulong_8
+OpStore %264 %695
+%696 = OpLoad %ulong %244
+%697 = OpLoad %ulong %264
+%698 = OpShiftRightLogical %ulong %696 %697
+OpStore %265 %698
+%699 = OpLoad %ulong %265
+%700 = OpBitwiseAnd %ulong %699 %ulong_255
+OpStore %266 %700
+%701 = OpLoad %ulong %270
+%702 = OpLoad %ulong %266
+%703 = OpBitwiseXor %ulong %701 %702
+OpStore %267 %703
+%704 = OpLoad %ulong %267
+%705 = OpIMul %ulong %704 %ulong_1099511628211
+OpStore %268 %705
+%706 = OpLoad %ulong %271
+%707 = OpIAdd %ulong %706 %ulong_1
+OpStore %269 %707
+%708 = OpLoad %ulong %268
+OpStore %270 %708
+%709 = OpLoad %ulong %269
+OpStore %271 %709
+OpBranch %120
+%22 = OpLabel
+%710 = OpLoad %ulong %225
+%711 = OpIMul %ulong %710 %ulong_8
+OpStore %218 %711
+%712 = OpLoad %ulong %184
+%713 = OpLoad %ulong %218
+%714 = OpShiftRightLogical %ulong %712 %713
+OpStore %219 %714
+%715 = OpLoad %ulong %219
+%716 = OpBitwiseAnd %ulong %715 %ulong_255
+OpStore %220 %716
+%717 = OpLoad %ulong %224
+%718 = OpLoad %ulong %220
+%719 = OpBitwiseXor %ulong %717 %718
+OpStore %221 %719
+%720 = OpLoad %ulong %221
+%721 = OpIMul %ulong %720 %ulong_1099511628211
+OpStore %222 %721
+%722 = OpLoad %ulong %225
+%723 = OpIAdd %ulong %722 %ulong_1
+OpStore %223 %723
+%724 = OpLoad %ulong %222
+OpStore %224 %724
+%725 = OpLoad %ulong %223
+OpStore %225 %725
+OpBranch %122
+%13 = OpLabel
+%726 = OpLoad %ulong %213
+%728 = OpIMul %ulong %726 %ulong_131
+OpStore %174 %728
+%729 = OpLoad %ulong %174
+%730 = OpLoad %ulong %150
+%731 = OpIAdd %ulong %729 %730
+OpStore %175 %731
+%732 = OpLoad %ulong %213
+%734 = OpShiftRightLogical %ulong %732 %ulong_2
+OpStore %176 %734
+%735 = OpLoad %ulong %175
+%736 = OpLoad %ulong %176
+%737 = OpBitwiseXor %ulong %735 %736
+OpStore %177 %737
+%738 = OpLoad %ulong %177
+%739 = OpUConvert %uchar %738
+OpStore %178 %739
+%740 = OpLoad %ulong %213
+%741 = OpAccessChain %_ptr_Function_uchar %148 %740
+%742 = OpLoad %uchar %178
+OpStore %741 %742
+%743 = OpLoad %ulong %213
+%744 = OpIAdd %ulong %743 %ulong_1
+OpStore %179 %744
+%745 = OpLoad %ulong %179
+OpStore %213 %745
+OpBranch %125
+%10 = OpLabel
+%746 = OpLoad %ulong %214
+%748 = OpIMul %ulong %746 %ulong_2654435761
+OpStore %167 %748
+%749 = OpLoad %ulong %167
+%750 = OpLoad %ulong %150
+%751 = OpIAdd %ulong %749 %750
+OpStore %168 %751
+%752 = OpLoad %ulong %214
+%753 = OpShiftRightLogical %ulong %752 %ulong_3
+OpStore %169 %753
+%754 = OpLoad %ulong %168
+%755 = OpLoad %ulong %169
+%756 = OpBitwiseXor %ulong %754 %755
+OpStore %170 %756
+%757 = OpLoad %ulong %170
+%758 = OpUConvert %uint %757
+OpStore %171 %758
+%759 = OpLoad %ulong %214
+%760 = OpAccessChain %_ptr_Function_uint %144 %759
+%761 = OpLoad %uint %171
+OpStore %760 %761
+%762 = OpLoad %ulong %214
+%763 = OpIAdd %ulong %762 %ulong_1
+OpStore %172 %763
+%764 = OpLoad %ulong %172
+OpStore %214 %764
+OpBranch %126
+%7 = OpLabel
+%765 = OpLoad %ulong %215
+%766 = OpLoad %ulong %150
+%767 = OpIAdd %ulong %765 %766
+OpStore %161 %767
+%768 = OpLoad %ulong %161
+%770 = OpIMul %ulong %768 %ulong_6364136223846793005
+OpStore %162 %770
+%771 = OpLoad %ulong %215
+%773 = OpShiftLeftLogical %ulong %771 %ulong_17
+OpStore %163 %773
+%774 = OpLoad %ulong %162
+%775 = OpLoad %ulong %163
+%776 = OpBitwiseXor %ulong %774 %775
+OpStore %164 %776
+%777 = OpLoad %ulong %215
+%778 = OpAccessChain %_ptr_Function_ulong %140 %777
+%779 = OpLoad %ulong %164
+OpStore %778 %779
+%780 = OpLoad %ulong %215
+%781 = OpIAdd %ulong %780 %ulong_1
+OpStore %165 %781
+%782 = OpLoad %ulong %165
+OpStore %215 %782
+OpBranch %127
+%112 = OpLabel
+%783 = OpLoad %ulong %361
+%784 = OpIMul %ulong %783 %ulong_8
+OpStore %354 %784
+%785 = OpLoad %ulong %343
+%786 = OpLoad %ulong %354
+%787 = OpShiftRightLogical %ulong %785 %786
+OpStore %355 %787
+%788 = OpLoad %ulong %355
+%789 = OpBitwiseAnd %ulong %788 %ulong_255
+OpStore %356 %789
+%790 = OpLoad %ulong %360
+%791 = OpLoad %ulong %356
+%792 = OpBitwiseXor %ulong %790 %791
+OpStore %357 %792
+%793 = OpLoad %ulong %357
+%794 = OpIMul %ulong %793 %ulong_1099511628211
+OpStore %358 %794
+%795 = OpLoad %ulong %361
+%796 = OpIAdd %ulong %795 %ulong_1
+OpStore %359 %796
+%797 = OpLoad %ulong %358
+OpStore %360 %797
+%798 = OpLoad %ulong %359
+OpStore %361 %798
+OpBranch %128
+%100 = OpLabel
+%799 = OpLoad %ulong %342
+%800 = OpIMul %ulong %799 %ulong_8
+OpStore %335 %800
+%801 = OpLoad %ulong %323
+%802 = OpLoad %ulong %335
+%803 = OpShiftRightLogical %ulong %801 %802
+OpStore %336 %803
+%804 = OpLoad %ulong %336
+%805 = OpBitwiseAnd %ulong %804 %ulong_255
+OpStore %337 %805
+%806 = OpLoad %ulong %341
+%807 = OpLoad %ulong %337
+%808 = OpBitwiseXor %ulong %806 %807
+OpStore %338 %808
+%809 = OpLoad %ulong %338
+%810 = OpIMul %ulong %809 %ulong_1099511628211
+OpStore %339 %810
+%811 = OpLoad %ulong %342
+%812 = OpIAdd %ulong %811 %ulong_1
+OpStore %340 %812
+%813 = OpLoad %ulong %339
+OpStore %341 %813
+%814 = OpLoad %ulong %340
+OpStore %342 %814
+OpBranch %129
+%86 = OpLabel
+%815 = OpLoad %ulong %322
+%816 = OpIMul %ulong %815 %ulong_8
+OpStore %315 %816
+%817 = OpLoad %ulong %303
+%818 = OpLoad %ulong %315
+%819 = OpShiftRightLogical %ulong %817 %818
+OpStore %316 %819
+%820 = OpLoad %ulong %316
+%821 = OpBitwiseAnd %ulong %820 %ulong_255
+OpStore %317 %821
+%822 = OpLoad %ulong %321
+%823 = OpLoad %ulong %317
+%824 = OpBitwiseXor %ulong %822 %823
+OpStore %318 %824
+%825 = OpLoad %ulong %318
+%826 = OpIMul %ulong %825 %ulong_1099511628211
+OpStore %319 %826
+%827 = OpLoad %ulong %322
+%828 = OpIAdd %ulong %827 %ulong_1
+OpStore %320 %828
+%829 = OpLoad %ulong %319
+OpStore %321 %829
+%830 = OpLoad %ulong %320
+OpStore %322 %830
+OpBranch %130
+%72 = OpLabel
+%831 = OpLoad %ulong %302
+%832 = OpIMul %ulong %831 %ulong_8
+OpStore %295 %832
+%833 = OpLoad %ulong %274
+%834 = OpLoad %ulong %295
+%835 = OpShiftRightLogical %ulong %833 %834
+OpStore %296 %835
+%836 = OpLoad %ulong %296
+%837 = OpBitwiseAnd %ulong %836 %ulong_255
+OpStore %297 %837
+%838 = OpLoad %ulong %301
+%839 = OpLoad %ulong %297
+%840 = OpBitwiseXor %ulong %838 %839
+OpStore %298 %840
+%841 = OpLoad %ulong %298
+%842 = OpIMul %ulong %841 %ulong_1099511628211
+OpStore %299 %842
+%843 = OpLoad %ulong %302
+%844 = OpIAdd %ulong %843 %ulong_1
+OpStore %300 %844
+%845 = OpLoad %ulong %299
+OpStore %301 %845
+%846 = OpLoad %ulong %300
+OpStore %302 %846
+OpBranch %131
+%44 = OpLabel
+%847 = OpLoad %ulong %262
+%848 = OpIMul %ulong %847 %ulong_8
+OpStore %255 %848
+%849 = OpLoad %ulong %152
+%850 = OpLoad %ulong %255
+%851 = OpShiftRightLogical %ulong %849 %850
+OpStore %256 %851
+%852 = OpLoad %ulong %256
+%853 = OpBitwiseAnd %ulong %852 %ulong_255
+OpStore %257 %853
+%854 = OpLoad %ulong %261
+%855 = OpLoad %ulong %257
+%856 = OpBitwiseXor %ulong %854 %855
+OpStore %258 %856
+%857 = OpLoad %ulong %258
+%858 = OpIMul %ulong %857 %ulong_1099511628211
+OpStore %259 %858
+%859 = OpLoad %ulong %262
+%860 = OpIAdd %ulong %859 %ulong_1
+OpStore %260 %860
+%861 = OpLoad %ulong %259
+OpStore %261 %861
+%862 = OpLoad %ulong %260
+OpStore %262 %862
+OpBranch %132
+%32 = OpLabel
+%863 = OpLoad %ulong %243
+%864 = OpIMul %ulong %863 %ulong_8
+OpStore %236 %864
+%865 = OpLoad %ulong %151
+%866 = OpLoad %ulong %236
+%867 = OpShiftRightLogical %ulong %865 %866
+OpStore %237 %867
+%868 = OpLoad %ulong %237
+%869 = OpBitwiseAnd %ulong %868 %ulong_255
+OpStore %238 %869
+%870 = OpLoad %ulong %242
+%871 = OpLoad %ulong %238
+%872 = OpBitwiseXor %ulong %870 %871
+OpStore %239 %872
+%873 = OpLoad %ulong %239
+%874 = OpIMul %ulong %873 %ulong_1099511628211
+OpStore %240 %874
+%875 = OpLoad %ulong %243
+%876 = OpIAdd %ulong %875 %ulong_1
+OpStore %241 %876
+%877 = OpLoad %ulong %240
+OpStore %242 %877
+%878 = OpLoad %ulong %241
+OpStore %243 %878
+OpBranch %133
+%115 = OpLabel
+OpBranch %106
+%116 = OpLabel
+OpBranch %92
+%117 = OpLabel
+OpBranch %78
+%118 = OpLabel
+OpBranch %59
+%119 = OpLabel
+OpBranch %64
+%120 = OpLabel
+OpBranch %48
+%121 = OpLabel
+OpBranch %38
+%122 = OpLabel
+OpBranch %21
+%123 = OpLabel
+OpBranch %26
+%124 = OpLabel
+OpBranch %15
+%125 = OpLabel
+OpBranch %12
+%126 = OpLabel
+OpBranch %9
+%127 = OpLabel
+OpBranch %6
+%128 = OpLabel
+OpBranch %111
+%129 = OpLabel
+OpBranch %99
+%130 = OpLabel
+OpBranch %85
+%131 = OpLabel
+OpBranch %71
+%132 = OpLabel
+OpBranch %43
+%133 = OpLabel
+OpBranch %31
 OpFunctionEnd

--- a/test/golden/spirv/frame/frame_spill.dis
+++ b/test/golden/spirv/frame/frame_spill.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 916
+; Bound: 1386
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,13 +11,13 @@ OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.frame.frame_spill.rol" Export
 OpDecorate %2 LinkageAttributes "corpus.cases.frame.frame_spill.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong %ulong
+%5 = OpTypeFunction %ulong %ulong %ulong
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %ulong_64 = OpConstant %ulong 64
-%32 = OpTypeFunction %ulong %ulong
+%29 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %double = OpTypeFloat 64
-%bool = OpTypeBool
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_double = OpTypePointer Function %double
 %_ptr_Function_bool = OpTypePointer Function %bool
@@ -49,8 +49,13 @@ OpDecorate %2 LinkageAttributes "corpus.cases.frame.frame_spill.checksum" Export
 %double_n1_375 = OpConstant %double -1.375
 %double_0_875 = OpConstant %double 0.875
 %double_n4_5 = OpConstant %double -4.5
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_24 = OpConstant %ulong 24
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ulong_29 = OpConstant %ulong 29
 %ulong_35 = OpConstant %ulong 35
 %ulong_7 = OpConstant %ulong 7
@@ -81,167 +86,39 @@ OpDecorate %2 LinkageAttributes "corpus.cases.frame.frame_spill.checksum" Export
 %double_1_75 = OpConstant %double 1.75
 %double_0_625 = OpConstant %double 0.625
 %double_1_125 = OpConstant %double 1.125
-%ulong_1 = OpConstant %ulong 1
-%781 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%826 = OpTypeFunction %ulong %ulong %uint
-%871 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpFunctionParameter %ulong
-%11 = OpLabel
+%1 = OpFunction %ulong None %5
+%6 = OpFunctionParameter %ulong
+%7 = OpFunctionParameter %ulong
+%8 = OpLabel
+%10 = OpVariable %_ptr_Function_ulong Function
+%11 = OpVariable %_ptr_Function_ulong Function
+%12 = OpVariable %_ptr_Function_ulong Function
 %13 = OpVariable %_ptr_Function_ulong Function
 %14 = OpVariable %_ptr_Function_ulong Function
 %15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-OpStore %14 %10
-%19 = OpLoad %ulong %13
-%20 = OpLoad %ulong %14
-%21 = OpShiftLeftLogical %ulong %19 %20
-OpStore %15 %21
-%23 = OpLoad %ulong %14
-%24 = OpISub %ulong %ulong_64 %23
-OpStore %16 %24
-%25 = OpLoad %ulong %13
-%26 = OpLoad %ulong %16
-%27 = OpShiftRightLogical %ulong %25 %26
-OpStore %17 %27
+OpStore %10 %6
+OpStore %11 %7
+%16 = OpLoad %ulong %10
+%17 = OpLoad %ulong %11
+%18 = OpShiftLeftLogical %ulong %16 %17
+OpStore %12 %18
+%20 = OpLoad %ulong %11
+%21 = OpISub %ulong %ulong_64 %20
+OpStore %13 %21
+%22 = OpLoad %ulong %10
+%23 = OpLoad %ulong %13
+%24 = OpShiftRightLogical %ulong %22 %23
+OpStore %14 %24
+%25 = OpLoad %ulong %12
+%26 = OpLoad %ulong %14
+%27 = OpBitwiseOr %ulong %25 %26
+OpStore %15 %27
 %28 = OpLoad %ulong %15
-%29 = OpLoad %ulong %17
-%30 = OpBitwiseOr %ulong %28 %29
-OpStore %18 %30
-%31 = OpLoad %ulong %18
-OpReturnValue %31
+OpReturnValue %28
 OpFunctionEnd
-%2 = OpFunction %ulong None %32
-%33 = OpFunctionParameter %ulong
-%34 = OpLabel
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_ulong Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_ulong Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_ulong Function
-%88 = OpVariable %_ptr_Function_ulong Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_ulong Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_uint Function
-%95 = OpVariable %_ptr_Function_ulong Function
-%96 = OpVariable %_ptr_Function_uint Function
-%97 = OpVariable %_ptr_Function_ulong Function
-%98 = OpVariable %_ptr_Function_uint Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_uint Function
-%102 = OpVariable %_ptr_Function_double Function
-%103 = OpVariable %_ptr_Function_double Function
-%104 = OpVariable %_ptr_Function_double Function
-%105 = OpVariable %_ptr_Function_double Function
-%106 = OpVariable %_ptr_Function_double Function
-%107 = OpVariable %_ptr_Function_double Function
-%108 = OpVariable %_ptr_Function_double Function
-%109 = OpVariable %_ptr_Function_double Function
-%110 = OpVariable %_ptr_Function_double Function
-%112 = OpVariable %_ptr_Function_bool Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_ulong Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_uint Function
-%131 = OpVariable %_ptr_Function_uint Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_uint Function
-%134 = OpVariable %_ptr_Function_uint Function
-%135 = OpVariable %_ptr_Function_uint Function
-%136 = OpVariable %_ptr_Function_uint Function
-%137 = OpVariable %_ptr_Function_uint Function
-%138 = OpVariable %_ptr_Function_double Function
-%139 = OpVariable %_ptr_Function_double Function
-%140 = OpVariable %_ptr_Function_double Function
-%141 = OpVariable %_ptr_Function_double Function
-%142 = OpVariable %_ptr_Function_double Function
-%143 = OpVariable %_ptr_Function_double Function
-%144 = OpVariable %_ptr_Function_double Function
-%145 = OpVariable %_ptr_Function_double Function
-%146 = OpVariable %_ptr_Function_double Function
-%147 = OpVariable %_ptr_Function_double Function
-%148 = OpVariable %_ptr_Function_double Function
-%149 = OpVariable %_ptr_Function_double Function
-%150 = OpVariable %_ptr_Function_double Function
-%151 = OpVariable %_ptr_Function_double Function
-%152 = OpVariable %_ptr_Function_double Function
-%153 = OpVariable %_ptr_Function_double Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_double Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %29
+%30 = OpFunctionParameter %ulong
+%31 = OpLabel
 %197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
 %199 = OpVariable %_ptr_Function_ulong Function
@@ -250,36 +127,33 @@ OpFunctionEnd
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_uint Function
-%206 = OpVariable %_ptr_Function_uint Function
-%207 = OpVariable %_ptr_Function_uint Function
-%208 = OpVariable %_ptr_Function_uint Function
-%209 = OpVariable %_ptr_Function_double Function
-%210 = OpVariable %_ptr_Function_double Function
-%211 = OpVariable %_ptr_Function_double Function
-%212 = OpVariable %_ptr_Function_double Function
-%213 = OpVariable %_ptr_Function_double Function
-%214 = OpVariable %_ptr_Function_double Function
-%215 = OpVariable %_ptr_Function_double Function
-%216 = OpVariable %_ptr_Function_double Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_uint Function
 %217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_uint Function
 %219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_uint Function
 %221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_uint Function
+%224 = OpVariable %_ptr_Function_double Function
+%225 = OpVariable %_ptr_Function_double Function
+%226 = OpVariable %_ptr_Function_double Function
+%227 = OpVariable %_ptr_Function_double Function
+%228 = OpVariable %_ptr_Function_double Function
+%229 = OpVariable %_ptr_Function_double Function
+%230 = OpVariable %_ptr_Function_double Function
+%231 = OpVariable %_ptr_Function_double Function
+%232 = OpVariable %_ptr_Function_double Function
+%234 = OpVariable %_ptr_Function_bool Function
 %235 = OpVariable %_ptr_Function_ulong Function
 %236 = OpVariable %_ptr_Function_ulong Function
 %237 = OpVariable %_ptr_Function_ulong Function
@@ -297,965 +171,1828 @@ OpFunctionEnd
 %249 = OpVariable %_ptr_Function_ulong Function
 %250 = OpVariable %_ptr_Function_ulong Function
 %251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
-OpStore %74 %33
-%266 = OpFunctionCall %ulong %3
-OpStore %75 %266
-%268 = OpLoad %ulong %74
-%269 = OpIAdd %ulong %ulong_6364136223846793005 %268
-OpStore %76 %269
-%271 = OpLoad %ulong %74
-%272 = OpBitwiseXor %ulong %ulong_1442695040888963407 %271
-OpStore %77 %272
-%274 = OpLoad %ulong %74
-%275 = OpIAdd %ulong %ulong_11400714819323198485 %274
-OpStore %78 %275
-%277 = OpLoad %ulong %74
-%278 = OpBitwiseXor %ulong %ulong_14029467366897019727 %277
-OpStore %79 %278
-%280 = OpLoad %ulong %74
-%281 = OpIAdd %ulong %ulong_1609587929392839161 %280
-OpStore %80 %281
-%283 = OpLoad %ulong %74
-%284 = OpBitwiseXor %ulong %ulong_9650029242287828579 %283
-OpStore %81 %284
-%286 = OpLoad %ulong %74
-%287 = OpIAdd %ulong %ulong_2870177450012600261 %286
-OpStore %82 %287
-%289 = OpLoad %ulong %74
-%290 = OpBitwiseXor %ulong %ulong_8261357461348097633 %289
-OpStore %83 %290
-%292 = OpLoad %ulong %74
-%293 = OpIAdd %ulong %ulong_4823894509314446453 %292
-OpStore %84 %293
-%295 = OpLoad %ulong %74
-%296 = OpBitwiseXor %ulong %ulong_3512524072905137951 %295
-OpStore %85 %296
-%298 = OpLoad %ulong %74
-%299 = OpIAdd %ulong %ulong_7046029254386353131 %298
-OpStore %86 %299
-%301 = OpLoad %ulong %74
-%302 = OpBitwiseXor %ulong %ulong_5545126536417089969 %301
-OpStore %87 %302
-%304 = OpLoad %ulong %74
-%305 = OpIAdd %ulong %ulong_12297829382473034411 %304
-OpStore %88 %305
-%307 = OpLoad %ulong %74
-%308 = OpBitwiseXor %ulong %ulong_15726070495360670683 %307
-OpStore %89 %308
-%310 = OpLoad %ulong %74
-%311 = OpIAdd %ulong %ulong_2246822519342508753 %310
-OpStore %90 %311
-%313 = OpLoad %ulong %74
-%314 = OpBitwiseXor %ulong %ulong_3266489917871134591 %313
-OpStore %91 %314
-%316 = OpLoad %ulong %74
-%317 = OpIAdd %ulong %ulong_2654435761 %316
-OpStore %92 %317
-%318 = OpLoad %ulong %92
-%319 = OpUConvert %uint %318
-OpStore %94 %319
-%321 = OpLoad %ulong %74
-%322 = OpBitwiseXor %ulong %ulong_40503 %321
-OpStore %95 %322
-%323 = OpLoad %ulong %95
-%324 = OpUConvert %uint %323
-OpStore %96 %324
-%326 = OpLoad %ulong %74
-%327 = OpIAdd %ulong %ulong_2246822519 %326
-OpStore %97 %327
-%328 = OpLoad %ulong %97
-%329 = OpUConvert %uint %328
-OpStore %98 %329
-%331 = OpLoad %ulong %74
-%332 = OpBitwiseXor %ulong %ulong_3266489917 %331
-OpStore %99 %332
-%333 = OpLoad %ulong %99
-%334 = OpUConvert %uint %333
-OpStore %100 %334
-%335 = OpLoad %ulong %74
-%336 = OpConvertUToF %double %335
-OpStore %102 %336
-%338 = OpLoad %double %102
-%339 = OpFAdd %double %double_1_5 %338
-OpStore %103 %339
-%341 = OpLoad %double %102
-%342 = OpFAdd %double %double_n2_25 %341
-OpStore %104 %342
-%344 = OpLoad %double %102
-%345 = OpFAdd %double %double_3_125 %344
-OpStore %105 %345
-%347 = OpLoad %double %102
-%348 = OpFAdd %double %double_n0_75 %347
-OpStore %106 %348
-%350 = OpLoad %double %102
-%351 = OpFAdd %double %double_5_625 %350
-OpStore %107 %351
-%353 = OpLoad %double %102
-%354 = OpFAdd %double %double_n1_375 %353
-OpStore %108 %354
-%356 = OpLoad %double %102
-%357 = OpFAdd %double %double_0_875 %356
-OpStore %109 %357
-%359 = OpLoad %double %102
-%360 = OpFAdd %double %double_n4_5 %359
-OpStore %110 %360
-%361 = OpLoad %ulong %75
-OpStore %188 %361
-%362 = OpLoad %ulong %76
-OpStore %189 %362
-%363 = OpLoad %ulong %77
-OpStore %190 %363
-%364 = OpLoad %ulong %78
-OpStore %191 %364
-%365 = OpLoad %ulong %79
-OpStore %192 %365
-%366 = OpLoad %ulong %80
-OpStore %193 %366
-%367 = OpLoad %ulong %81
-OpStore %194 %367
-%368 = OpLoad %ulong %82
-OpStore %195 %368
-%369 = OpLoad %ulong %83
-OpStore %196 %369
-%370 = OpLoad %ulong %84
-OpStore %197 %370
-%371 = OpLoad %ulong %85
-OpStore %198 %371
-%372 = OpLoad %ulong %86
-OpStore %199 %372
-%373 = OpLoad %ulong %87
-OpStore %200 %373
-%374 = OpLoad %ulong %88
-OpStore %201 %374
-%375 = OpLoad %ulong %89
-OpStore %202 %375
-%376 = OpLoad %ulong %90
-OpStore %203 %376
-%377 = OpLoad %ulong %91
-OpStore %204 %377
-%378 = OpLoad %uint %94
-OpStore %205 %378
-%379 = OpLoad %uint %96
-OpStore %206 %379
-%380 = OpLoad %uint %98
-OpStore %207 %380
-%381 = OpLoad %uint %100
-OpStore %208 %381
-%382 = OpLoad %double %103
-OpStore %209 %382
-%383 = OpLoad %double %104
-OpStore %210 %383
-%384 = OpLoad %double %105
-OpStore %211 %384
-%385 = OpLoad %double %106
-OpStore %212 %385
-%386 = OpLoad %double %107
-OpStore %213 %386
-%387 = OpLoad %double %108
-OpStore %214 %387
-%388 = OpLoad %double %109
-OpStore %215 %388
-%389 = OpLoad %double %110
-OpStore %216 %389
-OpStore %217 %ulong_0
+%252 = OpVariable %_ptr_Function_uint Function
+%253 = OpVariable %_ptr_Function_uint Function
+%254 = OpVariable %_ptr_Function_uint Function
+%255 = OpVariable %_ptr_Function_uint Function
+%256 = OpVariable %_ptr_Function_uint Function
+%257 = OpVariable %_ptr_Function_uint Function
+%258 = OpVariable %_ptr_Function_uint Function
+%259 = OpVariable %_ptr_Function_uint Function
+%260 = OpVariable %_ptr_Function_double Function
+%261 = OpVariable %_ptr_Function_double Function
+%262 = OpVariable %_ptr_Function_double Function
+%263 = OpVariable %_ptr_Function_double Function
+%264 = OpVariable %_ptr_Function_double Function
+%265 = OpVariable %_ptr_Function_double Function
+%266 = OpVariable %_ptr_Function_double Function
+%267 = OpVariable %_ptr_Function_double Function
+%268 = OpVariable %_ptr_Function_double Function
+%269 = OpVariable %_ptr_Function_double Function
+%270 = OpVariable %_ptr_Function_double Function
+%271 = OpVariable %_ptr_Function_double Function
+%272 = OpVariable %_ptr_Function_double Function
+%273 = OpVariable %_ptr_Function_double Function
+%274 = OpVariable %_ptr_Function_double Function
+%275 = OpVariable %_ptr_Function_double Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_double Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_uint Function
+%298 = OpVariable %_ptr_Function_uint Function
+%299 = OpVariable %_ptr_Function_uint Function
+%300 = OpVariable %_ptr_Function_uint Function
+%301 = OpVariable %_ptr_Function_double Function
+%302 = OpVariable %_ptr_Function_double Function
+%303 = OpVariable %_ptr_Function_double Function
+%304 = OpVariable %_ptr_Function_double Function
+%305 = OpVariable %_ptr_Function_double Function
+%306 = OpVariable %_ptr_Function_double Function
+%307 = OpVariable %_ptr_Function_double Function
+%308 = OpVariable %_ptr_Function_double Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_bool Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_bool Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_bool Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_bool Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_bool Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_bool Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_bool Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_ulong Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_ulong Function
+%397 = OpVariable %_ptr_Function_bool Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_bool Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_bool Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_bool Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_bool Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_bool Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_bool Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_bool Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_ulong Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_bool Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+OpStore %197 %30
 OpBranch %35
 %35 = OpLabel
-%391 = OpLoad %ulong %217
-%393 = OpULessThan %bool %391 %ulong_24
-OpStore %112 %393
-%394 = OpLoad %bool %112
-OpLoopMerge %37 %70 None
-OpBranchConditional %394 %36 %37
-%37 = OpLabel
-%395 = OpLoad %ulong %188
-%396 = OpLoad %ulong %189
-%397 = OpFunctionCall %ulong %4 %395 %396
-OpStore %160 %397
-%398 = OpLoad %ulong %160
-%399 = OpLoad %ulong %190
-%400 = OpFunctionCall %ulong %4 %398 %399
-OpStore %161 %400
-%401 = OpLoad %ulong %161
-%402 = OpLoad %ulong %191
-%403 = OpFunctionCall %ulong %4 %401 %402
-OpStore %162 %403
-%404 = OpLoad %ulong %162
-%405 = OpLoad %ulong %192
-%406 = OpFunctionCall %ulong %4 %404 %405
-OpStore %163 %406
-%407 = OpLoad %ulong %163
-%408 = OpLoad %ulong %193
-%409 = OpFunctionCall %ulong %4 %407 %408
-OpStore %164 %409
-%410 = OpLoad %ulong %164
-%411 = OpLoad %ulong %194
-%412 = OpFunctionCall %ulong %4 %410 %411
-OpStore %165 %412
-%413 = OpLoad %ulong %165
-%414 = OpLoad %ulong %195
-%415 = OpFunctionCall %ulong %4 %413 %414
-OpStore %166 %415
-%416 = OpLoad %ulong %166
-%417 = OpLoad %ulong %196
-%418 = OpFunctionCall %ulong %4 %416 %417
-OpStore %167 %418
-%419 = OpLoad %ulong %167
-%420 = OpLoad %ulong %197
-%421 = OpFunctionCall %ulong %4 %419 %420
-OpStore %168 %421
-%422 = OpLoad %ulong %168
-%423 = OpLoad %ulong %198
-%424 = OpFunctionCall %ulong %4 %422 %423
-OpStore %169 %424
-%425 = OpLoad %ulong %169
-%426 = OpLoad %ulong %199
-%427 = OpFunctionCall %ulong %4 %425 %426
-OpStore %170 %427
-%428 = OpLoad %ulong %170
-%429 = OpLoad %ulong %200
-%430 = OpFunctionCall %ulong %4 %428 %429
-OpStore %171 %430
-%431 = OpLoad %ulong %171
-%432 = OpLoad %ulong %201
-%433 = OpFunctionCall %ulong %4 %431 %432
-OpStore %172 %433
-%434 = OpLoad %ulong %172
-%435 = OpLoad %ulong %202
-%436 = OpFunctionCall %ulong %4 %434 %435
-OpStore %173 %436
-%437 = OpLoad %ulong %173
-%438 = OpLoad %ulong %203
-%439 = OpFunctionCall %ulong %4 %437 %438
-OpStore %174 %439
-%440 = OpLoad %ulong %174
-%441 = OpLoad %ulong %204
-%442 = OpFunctionCall %ulong %4 %440 %441
-OpStore %175 %442
-%443 = OpLoad %ulong %175
-%444 = OpLoad %uint %205
-%445 = OpFunctionCall %ulong %5 %443 %444
-OpStore %176 %445
-%446 = OpLoad %ulong %176
-%447 = OpLoad %uint %206
-%448 = OpFunctionCall %ulong %5 %446 %447
-OpStore %177 %448
-%449 = OpLoad %ulong %177
-%450 = OpLoad %uint %207
-%451 = OpFunctionCall %ulong %5 %449 %450
-OpStore %178 %451
-%452 = OpLoad %ulong %178
-%453 = OpLoad %uint %208
-%454 = OpFunctionCall %ulong %5 %452 %453
-OpStore %179 %454
-%455 = OpLoad %ulong %179
-%456 = OpLoad %double %209
-%457 = OpFunctionCall %ulong %6 %455 %456
-OpStore %180 %457
-%458 = OpLoad %ulong %180
-%459 = OpLoad %double %210
-%460 = OpFunctionCall %ulong %6 %458 %459
-OpStore %181 %460
-%461 = OpLoad %ulong %181
-%462 = OpLoad %double %211
-%463 = OpFunctionCall %ulong %6 %461 %462
-OpStore %182 %463
-%464 = OpLoad %ulong %182
-%465 = OpLoad %double %212
-%466 = OpFunctionCall %ulong %6 %464 %465
-OpStore %183 %466
-%467 = OpLoad %ulong %183
-%468 = OpLoad %double %213
-%469 = OpFunctionCall %ulong %6 %467 %468
-OpStore %184 %469
-%470 = OpLoad %ulong %184
-%471 = OpLoad %double %214
-%472 = OpFunctionCall %ulong %6 %470 %471
-OpStore %185 %472
-%473 = OpLoad %ulong %185
-%474 = OpLoad %double %215
-%475 = OpFunctionCall %ulong %6 %473 %474
-OpStore %186 %475
-%476 = OpLoad %ulong %186
-%477 = OpLoad %double %216
-%478 = OpFunctionCall %ulong %6 %476 %477
-OpStore %187 %478
-%479 = OpLoad %ulong %187
-OpReturnValue %479
+OpBranch %36
 %36 = OpLabel
-OpBranch %38
-%38 = OpLabel
-%480 = OpLoad %ulong %204
-%482 = OpShiftLeftLogical %ulong %480 %ulong_29
-OpStore %218 %482
-%483 = OpLoad %ulong %204
-%485 = OpShiftRightLogical %ulong %483 %ulong_35
-OpStore %219 %485
-%486 = OpLoad %ulong %218
-%487 = OpLoad %ulong %219
-%488 = OpBitwiseOr %ulong %486 %487
-OpStore %220 %488
+%531 = OpLoad %ulong %197
+%532 = OpIAdd %ulong %ulong_6364136223846793005 %531
+OpStore %198 %532
+%534 = OpLoad %ulong %197
+%535 = OpBitwiseXor %ulong %ulong_1442695040888963407 %534
+OpStore %199 %535
+%537 = OpLoad %ulong %197
+%538 = OpIAdd %ulong %ulong_11400714819323198485 %537
+OpStore %200 %538
+%540 = OpLoad %ulong %197
+%541 = OpBitwiseXor %ulong %ulong_14029467366897019727 %540
+OpStore %201 %541
+%543 = OpLoad %ulong %197
+%544 = OpIAdd %ulong %ulong_1609587929392839161 %543
+OpStore %202 %544
+%546 = OpLoad %ulong %197
+%547 = OpBitwiseXor %ulong %ulong_9650029242287828579 %546
+OpStore %203 %547
+%549 = OpLoad %ulong %197
+%550 = OpIAdd %ulong %ulong_2870177450012600261 %549
+OpStore %204 %550
+%552 = OpLoad %ulong %197
+%553 = OpBitwiseXor %ulong %ulong_8261357461348097633 %552
+OpStore %205 %553
+%555 = OpLoad %ulong %197
+%556 = OpIAdd %ulong %ulong_4823894509314446453 %555
+OpStore %206 %556
+%558 = OpLoad %ulong %197
+%559 = OpBitwiseXor %ulong %ulong_3512524072905137951 %558
+OpStore %207 %559
+%561 = OpLoad %ulong %197
+%562 = OpIAdd %ulong %ulong_7046029254386353131 %561
+OpStore %208 %562
+%564 = OpLoad %ulong %197
+%565 = OpBitwiseXor %ulong %ulong_5545126536417089969 %564
+OpStore %209 %565
+%567 = OpLoad %ulong %197
+%568 = OpIAdd %ulong %ulong_12297829382473034411 %567
+OpStore %210 %568
+%570 = OpLoad %ulong %197
+%571 = OpBitwiseXor %ulong %ulong_15726070495360670683 %570
+OpStore %211 %571
+%573 = OpLoad %ulong %197
+%574 = OpIAdd %ulong %ulong_2246822519342508753 %573
+OpStore %212 %574
+%576 = OpLoad %ulong %197
+%577 = OpBitwiseXor %ulong %ulong_3266489917871134591 %576
+OpStore %213 %577
+%579 = OpLoad %ulong %197
+%580 = OpIAdd %ulong %ulong_2654435761 %579
+OpStore %214 %580
+%581 = OpLoad %ulong %214
+%582 = OpUConvert %uint %581
+OpStore %216 %582
+%584 = OpLoad %ulong %197
+%585 = OpBitwiseXor %ulong %ulong_40503 %584
+OpStore %217 %585
+%586 = OpLoad %ulong %217
+%587 = OpUConvert %uint %586
+OpStore %218 %587
+%589 = OpLoad %ulong %197
+%590 = OpIAdd %ulong %ulong_2246822519 %589
+OpStore %219 %590
+%591 = OpLoad %ulong %219
+%592 = OpUConvert %uint %591
+OpStore %220 %592
+%594 = OpLoad %ulong %197
+%595 = OpBitwiseXor %ulong %ulong_3266489917 %594
+OpStore %221 %595
+%596 = OpLoad %ulong %221
+%597 = OpUConvert %uint %596
+OpStore %222 %597
+%598 = OpLoad %ulong %197
+%599 = OpConvertUToF %double %598
+OpStore %224 %599
+%601 = OpLoad %double %224
+%602 = OpFAdd %double %double_1_5 %601
+OpStore %225 %602
+%604 = OpLoad %double %224
+%605 = OpFAdd %double %double_n2_25 %604
+OpStore %226 %605
+%607 = OpLoad %double %224
+%608 = OpFAdd %double %double_3_125 %607
+OpStore %227 %608
+%610 = OpLoad %double %224
+%611 = OpFAdd %double %double_n0_75 %610
+OpStore %228 %611
+%613 = OpLoad %double %224
+%614 = OpFAdd %double %double_5_625 %613
+OpStore %229 %614
+%616 = OpLoad %double %224
+%617 = OpFAdd %double %double_n1_375 %616
+OpStore %230 %617
+%619 = OpLoad %double %224
+%620 = OpFAdd %double %double_0_875 %619
+OpStore %231 %620
+%622 = OpLoad %double %224
+%623 = OpFAdd %double %double_n4_5 %622
+OpStore %232 %623
+OpStore %280 %ulong_14695981039346656037
+%625 = OpLoad %ulong %198
+OpStore %281 %625
+%626 = OpLoad %ulong %199
+OpStore %282 %626
+%627 = OpLoad %ulong %200
+OpStore %283 %627
+%628 = OpLoad %ulong %201
+OpStore %284 %628
+%629 = OpLoad %ulong %202
+OpStore %285 %629
+%630 = OpLoad %ulong %203
+OpStore %286 %630
+%631 = OpLoad %ulong %204
+OpStore %287 %631
+%632 = OpLoad %ulong %205
+OpStore %288 %632
+%633 = OpLoad %ulong %206
+OpStore %289 %633
+%634 = OpLoad %ulong %207
+OpStore %290 %634
+%635 = OpLoad %ulong %208
+OpStore %291 %635
+%636 = OpLoad %ulong %209
+OpStore %292 %636
+%637 = OpLoad %ulong %210
+OpStore %293 %637
+%638 = OpLoad %ulong %211
+OpStore %294 %638
+%639 = OpLoad %ulong %212
+OpStore %295 %639
+%640 = OpLoad %ulong %213
+OpStore %296 %640
+%641 = OpLoad %uint %216
+OpStore %297 %641
+%642 = OpLoad %uint %218
+OpStore %298 %642
+%643 = OpLoad %uint %220
+OpStore %299 %643
+%644 = OpLoad %uint %222
+OpStore %300 %644
+%645 = OpLoad %double %225
+OpStore %301 %645
+%646 = OpLoad %double %226
+OpStore %302 %646
+%647 = OpLoad %double %227
+OpStore %303 %647
+%648 = OpLoad %double %228
+OpStore %304 %648
+%649 = OpLoad %double %229
+OpStore %305 %649
+%650 = OpLoad %double %230
+OpStore %306 %650
+%651 = OpLoad %double %231
+OpStore %307 %651
+%652 = OpLoad %double %232
+OpStore %308 %652
+OpStore %309 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%654 = OpLoad %ulong %309
+%656 = OpULessThan %bool %654 %ulong_24
+OpStore %234 %656
+%657 = OpLoad %bool %234
+OpLoopMerge %34 %193 None
+OpBranchConditional %657 %33 %34
+%34 = OpLabel
 OpBranch %39
 %39 = OpLabel
-%489 = OpLoad %ulong %189
-%490 = OpLoad %ulong %220
-%491 = OpBitwiseXor %ulong %489 %490
-OpStore %113 %491
+%658 = OpLoad %ulong %280
+OpStore %320 %658
+OpStore %321 %ulong_0
 OpBranch %40
 %40 = OpLabel
-%492 = OpLoad %ulong %189
-%494 = OpShiftLeftLogical %ulong %492 %ulong_7
-OpStore %221 %494
-%495 = OpLoad %ulong %189
-%497 = OpShiftRightLogical %ulong %495 %ulong_57
-OpStore %222 %497
-%498 = OpLoad %ulong %221
-%499 = OpLoad %ulong %222
-%500 = OpBitwiseOr %ulong %498 %499
-OpStore %223 %500
-OpBranch %41
-%41 = OpLabel
-%501 = OpLoad %ulong %190
-%502 = OpLoad %ulong %223
-%503 = OpIAdd %ulong %501 %502
-OpStore %114 %503
-OpBranch %42
+%659 = OpLoad %ulong %321
+%661 = OpULessThan %bool %659 %ulong_8
+OpStore %313 %661
+%662 = OpLoad %bool %313
+OpLoopMerge %42 %192 None
+OpBranchConditional %662 %41 %42
 %42 = OpLabel
-%504 = OpLoad %ulong %190
-%506 = OpShiftLeftLogical %ulong %504 %ulong_11
-OpStore %224 %506
-%507 = OpLoad %ulong %190
-%509 = OpShiftRightLogical %ulong %507 %ulong_53
-OpStore %225 %509
-%510 = OpLoad %ulong %224
-%511 = OpLoad %ulong %225
-%512 = OpBitwiseOr %ulong %510 %511
-OpStore %226 %512
 OpBranch %43
 %43 = OpLabel
-%513 = OpLoad %ulong %191
-%514 = OpLoad %ulong %226
-%515 = OpBitwiseXor %ulong %513 %514
-OpStore %115 %515
-OpBranch %44
-%44 = OpLabel
-%516 = OpLoad %ulong %191
-%518 = OpShiftLeftLogical %ulong %516 %ulong_13
-OpStore %227 %518
-%519 = OpLoad %ulong %191
-%521 = OpShiftRightLogical %ulong %519 %ulong_51
-OpStore %228 %521
-%522 = OpLoad %ulong %227
-%523 = OpLoad %ulong %228
-%524 = OpBitwiseOr %ulong %522 %523
-OpStore %229 %524
-OpBranch %45
-%45 = OpLabel
-%525 = OpLoad %ulong %192
-%526 = OpLoad %ulong %229
-%527 = OpIAdd %ulong %525 %526
-OpStore %116 %527
 OpBranch %46
 %46 = OpLabel
-%528 = OpLoad %ulong %192
-%530 = OpShiftLeftLogical %ulong %528 %ulong_17
-OpStore %230 %530
-%531 = OpLoad %ulong %192
-%533 = OpShiftRightLogical %ulong %531 %ulong_47
-OpStore %231 %533
-%534 = OpLoad %ulong %230
-%535 = OpLoad %ulong %231
-%536 = OpBitwiseOr %ulong %534 %535
-OpStore %232 %536
+%663 = OpLoad %ulong %320
+OpStore %332 %663
+OpStore %333 %ulong_0
 OpBranch %47
 %47 = OpLabel
-%537 = OpLoad %ulong %193
-%538 = OpLoad %ulong %232
-%539 = OpBitwiseXor %ulong %537 %538
-OpStore %117 %539
-OpBranch %48
-%48 = OpLabel
-%540 = OpLoad %ulong %193
-%542 = OpShiftLeftLogical %ulong %540 %ulong_19
-OpStore %233 %542
-%543 = OpLoad %ulong %193
-%545 = OpShiftRightLogical %ulong %543 %ulong_45
-OpStore %234 %545
-%546 = OpLoad %ulong %233
-%547 = OpLoad %ulong %234
-%548 = OpBitwiseOr %ulong %546 %547
-OpStore %235 %548
-OpBranch %49
+%664 = OpLoad %ulong %333
+%665 = OpULessThan %bool %664 %ulong_8
+OpStore %325 %665
+%666 = OpLoad %bool %325
+OpLoopMerge %49 %191 None
+OpBranchConditional %666 %48 %49
 %49 = OpLabel
-%549 = OpLoad %ulong %194
-%550 = OpLoad %ulong %235
-%551 = OpIAdd %ulong %549 %550
-OpStore %118 %551
 OpBranch %50
 %50 = OpLabel
-%552 = OpLoad %ulong %194
-%554 = OpShiftLeftLogical %ulong %552 %ulong_23
-OpStore %236 %554
-%555 = OpLoad %ulong %194
-%557 = OpShiftRightLogical %ulong %555 %ulong_41
-OpStore %237 %557
-%558 = OpLoad %ulong %236
-%559 = OpLoad %ulong %237
-%560 = OpBitwiseOr %ulong %558 %559
-OpStore %238 %560
-OpBranch %51
-%51 = OpLabel
-%561 = OpLoad %ulong %195
-%562 = OpLoad %ulong %238
-%563 = OpBitwiseXor %ulong %561 %562
-OpStore %119 %563
-OpBranch %52
-%52 = OpLabel
-%564 = OpLoad %ulong %195
-%566 = OpShiftLeftLogical %ulong %564 %ulong_31
-OpStore %239 %566
-%567 = OpLoad %ulong %195
-%569 = OpShiftRightLogical %ulong %567 %ulong_33
-OpStore %240 %569
-%570 = OpLoad %ulong %239
-%571 = OpLoad %ulong %240
-%572 = OpBitwiseOr %ulong %570 %571
-OpStore %241 %572
 OpBranch %53
 %53 = OpLabel
-%573 = OpLoad %ulong %196
-%574 = OpLoad %ulong %241
-%575 = OpIAdd %ulong %573 %574
-OpStore %120 %575
+%667 = OpLoad %ulong %332
+OpStore %344 %667
+OpStore %345 %ulong_0
 OpBranch %54
 %54 = OpLabel
-%576 = OpLoad %ulong %196
-%578 = OpShiftLeftLogical %ulong %576 %ulong_37
-OpStore %242 %578
-%579 = OpLoad %ulong %196
-%581 = OpShiftRightLogical %ulong %579 %ulong_27
-OpStore %243 %581
-%582 = OpLoad %ulong %242
-%583 = OpLoad %ulong %243
-%584 = OpBitwiseOr %ulong %582 %583
-OpStore %244 %584
-OpBranch %55
-%55 = OpLabel
-%585 = OpLoad %ulong %197
-%586 = OpLoad %ulong %244
-%587 = OpBitwiseXor %ulong %585 %586
-OpStore %121 %587
-OpBranch %56
+%668 = OpLoad %ulong %345
+%669 = OpULessThan %bool %668 %ulong_8
+OpStore %337 %669
+%670 = OpLoad %bool %337
+OpLoopMerge %56 %190 None
+OpBranchConditional %670 %55 %56
 %56 = OpLabel
-%588 = OpLoad %ulong %197
-%589 = OpShiftLeftLogical %ulong %588 %ulong_41
-OpStore %245 %589
-%590 = OpLoad %ulong %197
-%591 = OpShiftRightLogical %ulong %590 %ulong_23
-OpStore %246 %591
-%592 = OpLoad %ulong %245
-%593 = OpLoad %ulong %246
-%594 = OpBitwiseOr %ulong %592 %593
-OpStore %247 %594
 OpBranch %57
 %57 = OpLabel
-%595 = OpLoad %ulong %198
-%596 = OpLoad %ulong %247
-%597 = OpIAdd %ulong %595 %596
-OpStore %122 %597
-OpBranch %58
-%58 = OpLabel
-%598 = OpLoad %ulong %198
-%600 = OpShiftLeftLogical %ulong %598 %ulong_43
-OpStore %248 %600
-%601 = OpLoad %ulong %198
-%603 = OpShiftRightLogical %ulong %601 %ulong_21
-OpStore %249 %603
-%604 = OpLoad %ulong %248
-%605 = OpLoad %ulong %249
-%606 = OpBitwiseOr %ulong %604 %605
-OpStore %250 %606
-OpBranch %59
-%59 = OpLabel
-%607 = OpLoad %ulong %199
-%608 = OpLoad %ulong %250
-%609 = OpBitwiseXor %ulong %607 %608
-OpStore %123 %609
 OpBranch %60
 %60 = OpLabel
-%610 = OpLoad %ulong %199
-%611 = OpShiftLeftLogical %ulong %610 %ulong_47
-OpStore %251 %611
-%612 = OpLoad %ulong %199
-%613 = OpShiftRightLogical %ulong %612 %ulong_17
-OpStore %252 %613
-%614 = OpLoad %ulong %251
-%615 = OpLoad %ulong %252
-%616 = OpBitwiseOr %ulong %614 %615
-OpStore %253 %616
+%671 = OpLoad %ulong %344
+OpStore %356 %671
+OpStore %357 %ulong_0
 OpBranch %61
 %61 = OpLabel
-%617 = OpLoad %ulong %200
-%618 = OpLoad %ulong %253
-%619 = OpIAdd %ulong %617 %618
-OpStore %124 %619
-OpBranch %62
-%62 = OpLabel
-%620 = OpLoad %ulong %200
-%621 = OpShiftLeftLogical %ulong %620 %ulong_53
-OpStore %254 %621
-%622 = OpLoad %ulong %200
-%623 = OpShiftRightLogical %ulong %622 %ulong_11
-OpStore %255 %623
-%624 = OpLoad %ulong %254
-%625 = OpLoad %ulong %255
-%626 = OpBitwiseOr %ulong %624 %625
-OpStore %256 %626
-OpBranch %63
+%672 = OpLoad %ulong %357
+%673 = OpULessThan %bool %672 %ulong_8
+OpStore %349 %673
+%674 = OpLoad %bool %349
+OpLoopMerge %63 %189 None
+OpBranchConditional %674 %62 %63
 %63 = OpLabel
-%627 = OpLoad %ulong %201
-%628 = OpLoad %ulong %256
-%629 = OpBitwiseXor %ulong %627 %628
-OpStore %125 %629
 OpBranch %64
 %64 = OpLabel
-%630 = OpLoad %ulong %201
-%632 = OpShiftLeftLogical %ulong %630 %ulong_59
-OpStore %257 %632
-%633 = OpLoad %ulong %201
-%635 = OpShiftRightLogical %ulong %633 %ulong_5
-OpStore %258 %635
-%636 = OpLoad %ulong %257
-%637 = OpLoad %ulong %258
-%638 = OpBitwiseOr %ulong %636 %637
-OpStore %259 %638
-OpBranch %65
-%65 = OpLabel
-%639 = OpLoad %ulong %202
-%640 = OpLoad %ulong %259
-%641 = OpIAdd %ulong %639 %640
-OpStore %126 %641
-OpBranch %66
-%66 = OpLabel
-%642 = OpLoad %ulong %202
-%644 = OpShiftLeftLogical %ulong %642 %ulong_61
-OpStore %260 %644
-%645 = OpLoad %ulong %202
-%647 = OpShiftRightLogical %ulong %645 %ulong_3
-OpStore %261 %647
-%648 = OpLoad %ulong %260
-%649 = OpLoad %ulong %261
-%650 = OpBitwiseOr %ulong %648 %649
-OpStore %262 %650
 OpBranch %67
 %67 = OpLabel
-%651 = OpLoad %ulong %203
-%652 = OpLoad %ulong %262
-%653 = OpBitwiseXor %ulong %651 %652
-OpStore %127 %653
+%675 = OpLoad %ulong %356
+OpStore %368 %675
+OpStore %369 %ulong_0
 OpBranch %68
 %68 = OpLabel
-%654 = OpLoad %ulong %203
-%655 = OpShiftLeftLogical %ulong %654 %ulong_3
-OpStore %263 %655
-%656 = OpLoad %ulong %203
-%657 = OpShiftRightLogical %ulong %656 %ulong_61
-OpStore %264 %657
-%658 = OpLoad %ulong %263
-%659 = OpLoad %ulong %264
-%660 = OpBitwiseOr %ulong %658 %659
-OpStore %265 %660
-OpBranch %69
-%69 = OpLabel
-%661 = OpLoad %ulong %204
-%662 = OpLoad %ulong %265
-%663 = OpIAdd %ulong %661 %662
-OpStore %128 %663
-%664 = OpLoad %ulong %113
-%665 = OpLoad %ulong %217
-%666 = OpIAdd %ulong %664 %665
-OpStore %129 %666
-%667 = OpLoad %ulong %126
-%668 = OpUConvert %uint %667
-OpStore %130 %668
-%669 = OpLoad %uint %205
-%670 = OpLoad %uint %130
-%671 = OpBitwiseXor %uint %669 %670
-OpStore %131 %671
-%672 = OpLoad %ulong %114
-%673 = OpUConvert %uint %672
-OpStore %132 %673
-%674 = OpLoad %uint %206
-%675 = OpLoad %uint %132
-%676 = OpIAdd %uint %674 %675
-OpStore %133 %676
-%677 = OpLoad %ulong %118
-%678 = OpUConvert %uint %677
-OpStore %134 %678
-%679 = OpLoad %uint %207
-%680 = OpLoad %uint %134
-%681 = OpBitwiseXor %uint %679 %680
-OpStore %135 %681
-%682 = OpLoad %ulong %122
-%683 = OpUConvert %uint %682
-OpStore %136 %683
-%684 = OpLoad %uint %208
-%685 = OpLoad %uint %136
-%686 = OpIAdd %uint %684 %685
-OpStore %137 %686
-%687 = OpLoad %double %209
-%688 = OpFMul %double %687 %double_1_5
-OpStore %138 %688
-%689 = OpLoad %double %138
-%690 = OpLoad %double %210
-%691 = OpFAdd %double %689 %690
-OpStore %139 %691
-%692 = OpLoad %double %210
-%694 = OpFMul %double %692 %double_0_75
-OpStore %140 %694
-%695 = OpLoad %double %140
-%696 = OpLoad %double %211
-%697 = OpFAdd %double %695 %696
-OpStore %141 %697
-%698 = OpLoad %double %211
-%700 = OpFMul %double %698 %double_1_25
-OpStore %142 %700
-%701 = OpLoad %double %142
-%702 = OpLoad %double %212
-%703 = OpFAdd %double %701 %702
-OpStore %143 %703
-%704 = OpLoad %double %212
-%706 = OpFMul %double %704 %double_0_5
-OpStore %144 %706
-%707 = OpLoad %double %144
-%708 = OpLoad %double %213
-%709 = OpFAdd %double %707 %708
-OpStore %145 %709
-%710 = OpLoad %double %213
-%712 = OpFMul %double %710 %double_1_75
-OpStore %146 %712
-%713 = OpLoad %double %146
-%714 = OpLoad %double %214
-%715 = OpFAdd %double %713 %714
-OpStore %147 %715
-%716 = OpLoad %double %214
-%718 = OpFMul %double %716 %double_0_625
-OpStore %148 %718
-%719 = OpLoad %double %148
-%720 = OpLoad %double %215
-%721 = OpFAdd %double %719 %720
-OpStore %149 %721
-%722 = OpLoad %double %215
-%724 = OpFMul %double %722 %double_1_125
-OpStore %150 %724
-%725 = OpLoad %double %150
-%726 = OpLoad %double %216
-%727 = OpFAdd %double %725 %726
-OpStore %151 %727
-%728 = OpLoad %double %216
-%729 = OpFMul %double %728 %double_0_875
-OpStore %152 %729
-%730 = OpLoad %double %152
-%731 = OpLoad %double %209
-%732 = OpFAdd %double %730 %731
-OpStore %153 %732
-%733 = OpLoad %ulong %114
-%734 = OpLoad %ulong %122
-%735 = OpBitwiseXor %ulong %733 %734
-OpStore %154 %735
-%736 = OpLoad %ulong %188
-%737 = OpLoad %ulong %154
-%738 = OpFunctionCall %ulong %4 %736 %737
-OpStore %155 %738
-%739 = OpLoad %ulong %155
-%740 = OpLoad %uint %133
-%741 = OpFunctionCall %ulong %5 %739 %740
-OpStore %156 %741
-%742 = OpLoad %double %139
-%743 = OpLoad %double %147
-%744 = OpFAdd %double %742 %743
-OpStore %157 %744
-%745 = OpLoad %ulong %156
-%746 = OpLoad %double %157
-%747 = OpFunctionCall %ulong %6 %745 %746
-OpStore %158 %747
-%748 = OpLoad %ulong %217
-%750 = OpIAdd %ulong %748 %ulong_1
-OpStore %159 %750
-%751 = OpLoad %ulong %158
-OpStore %188 %751
-%752 = OpLoad %ulong %114
-OpStore %189 %752
-%753 = OpLoad %ulong %115
-OpStore %190 %753
-%754 = OpLoad %ulong %116
-OpStore %191 %754
-%755 = OpLoad %ulong %117
-OpStore %192 %755
-%756 = OpLoad %ulong %118
-OpStore %193 %756
-%757 = OpLoad %ulong %119
-OpStore %194 %757
-%758 = OpLoad %ulong %120
-OpStore %195 %758
-%759 = OpLoad %ulong %121
-OpStore %196 %759
-%760 = OpLoad %ulong %122
-OpStore %197 %760
-%761 = OpLoad %ulong %123
-OpStore %198 %761
-%762 = OpLoad %ulong %124
-OpStore %199 %762
-%763 = OpLoad %ulong %125
-OpStore %200 %763
-%764 = OpLoad %ulong %126
-OpStore %201 %764
-%765 = OpLoad %ulong %127
-OpStore %202 %765
-%766 = OpLoad %ulong %128
-OpStore %203 %766
-%767 = OpLoad %ulong %129
-OpStore %204 %767
-%768 = OpLoad %uint %133
-OpStore %205 %768
-%769 = OpLoad %uint %135
-OpStore %206 %769
-%770 = OpLoad %uint %137
-OpStore %207 %770
-%771 = OpLoad %uint %131
-OpStore %208 %771
-%772 = OpLoad %double %139
-OpStore %209 %772
-%773 = OpLoad %double %141
-OpStore %210 %773
-%774 = OpLoad %double %143
-OpStore %211 %774
-%775 = OpLoad %double %145
-OpStore %212 %775
-%776 = OpLoad %double %147
-OpStore %213 %776
-%777 = OpLoad %double %149
-OpStore %214 %777
-%778 = OpLoad %double %151
-OpStore %215 %778
-%779 = OpLoad %double %153
-OpStore %216 %779
-%780 = OpLoad %ulong %159
-OpStore %217 %780
-OpBranch %70
+%676 = OpLoad %ulong %369
+%677 = OpULessThan %bool %676 %ulong_8
+OpStore %361 %677
+%678 = OpLoad %bool %361
+OpLoopMerge %70 %188 None
+OpBranchConditional %678 %69 %70
 %70 = OpLabel
-OpBranch %35
+OpBranch %71
+%71 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%679 = OpLoad %ulong %368
+OpStore %380 %679
+OpStore %381 %ulong_0
+OpBranch %75
+%75 = OpLabel
+%680 = OpLoad %ulong %381
+%681 = OpULessThan %bool %680 %ulong_8
+OpStore %373 %681
+%682 = OpLoad %bool %373
+OpLoopMerge %77 %187 None
+OpBranchConditional %682 %76 %77
+%77 = OpLabel
+OpBranch %78
+%78 = OpLabel
+OpBranch %81
+%81 = OpLabel
+%683 = OpLoad %ulong %380
+OpStore %392 %683
+OpStore %393 %ulong_0
+OpBranch %82
+%82 = OpLabel
+%684 = OpLoad %ulong %393
+%685 = OpULessThan %bool %684 %ulong_8
+OpStore %385 %685
+%686 = OpLoad %bool %385
+OpLoopMerge %84 %186 None
+OpBranchConditional %686 %83 %84
+%84 = OpLabel
+OpBranch %85
+%85 = OpLabel
+OpBranch %88
+%88 = OpLabel
+%687 = OpLoad %ulong %392
+OpStore %404 %687
+OpStore %405 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%688 = OpLoad %ulong %405
+%689 = OpULessThan %bool %688 %ulong_8
+OpStore %397 %689
+%690 = OpLoad %bool %397
+OpLoopMerge %91 %185 None
+OpBranchConditional %690 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+OpBranch %95
+%95 = OpLabel
+%691 = OpLoad %ulong %404
+OpStore %416 %691
+OpStore %417 %ulong_0
+OpBranch %96
+%96 = OpLabel
+%692 = OpLoad %ulong %417
+%693 = OpULessThan %bool %692 %ulong_8
+OpStore %409 %693
+%694 = OpLoad %bool %409
+OpLoopMerge %98 %184 None
+OpBranchConditional %694 %97 %98
+%98 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%695 = OpLoad %ulong %416
+OpStore %428 %695
+OpStore %429 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%696 = OpLoad %ulong %429
+%697 = OpULessThan %bool %696 %ulong_8
+OpStore %421 %697
+%698 = OpLoad %bool %421
+OpLoopMerge %105 %183 None
+OpBranchConditional %698 %104 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%699 = OpLoad %ulong %428
+OpStore %440 %699
+OpStore %441 %ulong_0
+OpBranch %110
+%110 = OpLabel
+%700 = OpLoad %ulong %441
+%701 = OpULessThan %bool %700 %ulong_8
+OpStore %433 %701
+%702 = OpLoad %bool %433
+OpLoopMerge %112 %182 None
+OpBranchConditional %702 %111 %112
+%112 = OpLabel
+OpBranch %113
+%113 = OpLabel
+OpBranch %116
+%116 = OpLabel
+%703 = OpLoad %ulong %440
+OpStore %452 %703
+OpStore %453 %ulong_0
+OpBranch %117
+%117 = OpLabel
+%704 = OpLoad %ulong %453
+%705 = OpULessThan %bool %704 %ulong_8
+OpStore %445 %705
+%706 = OpLoad %bool %445
+OpLoopMerge %119 %181 None
+OpBranchConditional %706 %118 %119
+%119 = OpLabel
+OpBranch %120
+%120 = OpLabel
+OpBranch %123
+%123 = OpLabel
+%707 = OpLoad %ulong %452
+OpStore %464 %707
+OpStore %465 %ulong_0
+OpBranch %124
+%124 = OpLabel
+%708 = OpLoad %ulong %465
+%709 = OpULessThan %bool %708 %ulong_8
+OpStore %457 %709
+%710 = OpLoad %bool %457
+OpLoopMerge %126 %180 None
+OpBranchConditional %710 %125 %126
+%126 = OpLabel
+OpBranch %127
+%127 = OpLabel
+OpBranch %130
+%130 = OpLabel
+%711 = OpLoad %ulong %464
+OpStore %476 %711
+OpStore %477 %ulong_0
+OpBranch %131
+%131 = OpLabel
+%712 = OpLoad %ulong %477
+%713 = OpULessThan %bool %712 %ulong_8
+OpStore %469 %713
+%714 = OpLoad %bool %469
+OpLoopMerge %133 %179 None
+OpBranchConditional %714 %132 %133
+%133 = OpLabel
+OpBranch %134
+%134 = OpLabel
+OpBranch %137
+%137 = OpLabel
+%715 = OpLoad %ulong %476
+OpStore %488 %715
+OpStore %489 %ulong_0
+OpBranch %138
+%138 = OpLabel
+%716 = OpLoad %ulong %489
+%717 = OpULessThan %bool %716 %ulong_8
+OpStore %481 %717
+%718 = OpLoad %bool %481
+OpLoopMerge %140 %178 None
+OpBranchConditional %718 %139 %140
+%140 = OpLabel
+OpBranch %141
+%141 = OpLabel
+OpBranch %144
+%144 = OpLabel
+%719 = OpLoad %ulong %488
+OpStore %500 %719
+OpStore %501 %ulong_0
+OpBranch %145
+%145 = OpLabel
+%720 = OpLoad %ulong %501
+%721 = OpULessThan %bool %720 %ulong_8
+OpStore %493 %721
+%722 = OpLoad %bool %493
+OpLoopMerge %147 %177 None
+OpBranchConditional %722 %146 %147
+%147 = OpLabel
+OpBranch %148
+%148 = OpLabel
+OpBranch %151
+%151 = OpLabel
+%723 = OpLoad %uint %297
+%724 = OpUConvert %ulong %723
+OpStore %504 %724
+%725 = OpLoad %ulong %500
+%726 = OpLoad %ulong %504
+%727 = OpFunctionCall %ulong %3 %725 %726
+OpStore %505 %727
+OpBranch %152
+%152 = OpLabel
+OpBranch %155
+%155 = OpLabel
+%728 = OpLoad %uint %298
+%729 = OpUConvert %ulong %728
+OpStore %508 %729
+%730 = OpLoad %ulong %505
+%731 = OpLoad %ulong %508
+%732 = OpFunctionCall %ulong %3 %730 %731
+OpStore %509 %732
+OpBranch %156
+%156 = OpLabel
+OpBranch %157
+%157 = OpLabel
+%733 = OpLoad %uint %299
+%734 = OpUConvert %ulong %733
+OpStore %510 %734
+%735 = OpLoad %ulong %509
+%736 = OpLoad %ulong %510
+%737 = OpFunctionCall %ulong %3 %735 %736
+OpStore %511 %737
+OpBranch %158
+%158 = OpLabel
+OpBranch %159
+%159 = OpLabel
+%738 = OpLoad %uint %300
+%739 = OpUConvert %ulong %738
+OpStore %512 %739
+%740 = OpLoad %ulong %511
+%741 = OpLoad %ulong %512
+%742 = OpFunctionCall %ulong %3 %740 %741
+OpStore %513 %742
+OpBranch %160
+%160 = OpLabel
+OpBranch %161
+%161 = OpLabel
+%743 = OpLoad %double %301
+%744 = OpBitcast %ulong %743
+OpStore %514 %744
+%745 = OpLoad %ulong %513
+%746 = OpLoad %ulong %514
+%747 = OpFunctionCall %ulong %3 %745 %746
+OpStore %515 %747
+OpBranch %162
+%162 = OpLabel
+OpBranch %163
+%163 = OpLabel
+%748 = OpLoad %double %302
+%749 = OpBitcast %ulong %748
+OpStore %516 %749
+%750 = OpLoad %ulong %515
+%751 = OpLoad %ulong %516
+%752 = OpFunctionCall %ulong %3 %750 %751
+OpStore %517 %752
+OpBranch %164
+%164 = OpLabel
+OpBranch %165
+%165 = OpLabel
+%753 = OpLoad %double %303
+%754 = OpBitcast %ulong %753
+OpStore %518 %754
+%755 = OpLoad %ulong %517
+%756 = OpLoad %ulong %518
+%757 = OpFunctionCall %ulong %3 %755 %756
+OpStore %519 %757
+OpBranch %166
+%166 = OpLabel
+OpBranch %167
+%167 = OpLabel
+%758 = OpLoad %double %304
+%759 = OpBitcast %ulong %758
+OpStore %520 %759
+%760 = OpLoad %ulong %519
+%761 = OpLoad %ulong %520
+%762 = OpFunctionCall %ulong %3 %760 %761
+OpStore %521 %762
+OpBranch %168
+%168 = OpLabel
+OpBranch %169
+%169 = OpLabel
+%763 = OpLoad %double %305
+%764 = OpBitcast %ulong %763
+OpStore %522 %764
+%765 = OpLoad %ulong %521
+%766 = OpLoad %ulong %522
+%767 = OpFunctionCall %ulong %3 %765 %766
+OpStore %523 %767
+OpBranch %170
+%170 = OpLabel
+OpBranch %171
+%171 = OpLabel
+%768 = OpLoad %double %306
+%769 = OpBitcast %ulong %768
+OpStore %524 %769
+%770 = OpLoad %ulong %523
+%771 = OpLoad %ulong %524
+%772 = OpFunctionCall %ulong %3 %770 %771
+OpStore %525 %772
+OpBranch %172
+%172 = OpLabel
+OpBranch %173
+%173 = OpLabel
+%773 = OpLoad %double %307
+%774 = OpBitcast %ulong %773
+OpStore %526 %774
+%775 = OpLoad %ulong %525
+%776 = OpLoad %ulong %526
+%777 = OpFunctionCall %ulong %3 %775 %776
+OpStore %527 %777
+OpBranch %174
+%174 = OpLabel
+OpBranch %175
+%175 = OpLabel
+%778 = OpLoad %double %308
+%779 = OpBitcast %ulong %778
+OpStore %528 %779
+%780 = OpLoad %ulong %527
+%781 = OpLoad %ulong %528
+%782 = OpFunctionCall %ulong %3 %780 %781
+OpStore %529 %782
+OpBranch %176
+%176 = OpLabel
+%783 = OpLoad %ulong %529
+OpReturnValue %783
+%146 = OpLabel
+%784 = OpLoad %ulong %501
+%785 = OpIMul %ulong %784 %ulong_8
+OpStore %494 %785
+%786 = OpLoad %ulong %296
+%787 = OpLoad %ulong %494
+%788 = OpShiftRightLogical %ulong %786 %787
+OpStore %495 %788
+%789 = OpLoad %ulong %495
+%791 = OpBitwiseAnd %ulong %789 %ulong_255
+OpStore %496 %791
+%792 = OpLoad %ulong %500
+%793 = OpLoad %ulong %496
+%794 = OpBitwiseXor %ulong %792 %793
+OpStore %497 %794
+%795 = OpLoad %ulong %497
+%797 = OpIMul %ulong %795 %ulong_1099511628211
+OpStore %498 %797
+%798 = OpLoad %ulong %501
+%800 = OpIAdd %ulong %798 %ulong_1
+OpStore %499 %800
+%801 = OpLoad %ulong %498
+OpStore %500 %801
+%802 = OpLoad %ulong %499
+OpStore %501 %802
+OpBranch %177
+%139 = OpLabel
+%803 = OpLoad %ulong %489
+%804 = OpIMul %ulong %803 %ulong_8
+OpStore %482 %804
+%805 = OpLoad %ulong %295
+%806 = OpLoad %ulong %482
+%807 = OpShiftRightLogical %ulong %805 %806
+OpStore %483 %807
+%808 = OpLoad %ulong %483
+%809 = OpBitwiseAnd %ulong %808 %ulong_255
+OpStore %484 %809
+%810 = OpLoad %ulong %488
+%811 = OpLoad %ulong %484
+%812 = OpBitwiseXor %ulong %810 %811
+OpStore %485 %812
+%813 = OpLoad %ulong %485
+%814 = OpIMul %ulong %813 %ulong_1099511628211
+OpStore %486 %814
+%815 = OpLoad %ulong %489
+%816 = OpIAdd %ulong %815 %ulong_1
+OpStore %487 %816
+%817 = OpLoad %ulong %486
+OpStore %488 %817
+%818 = OpLoad %ulong %487
+OpStore %489 %818
+OpBranch %178
+%132 = OpLabel
+%819 = OpLoad %ulong %477
+%820 = OpIMul %ulong %819 %ulong_8
+OpStore %470 %820
+%821 = OpLoad %ulong %294
+%822 = OpLoad %ulong %470
+%823 = OpShiftRightLogical %ulong %821 %822
+OpStore %471 %823
+%824 = OpLoad %ulong %471
+%825 = OpBitwiseAnd %ulong %824 %ulong_255
+OpStore %472 %825
+%826 = OpLoad %ulong %476
+%827 = OpLoad %ulong %472
+%828 = OpBitwiseXor %ulong %826 %827
+OpStore %473 %828
+%829 = OpLoad %ulong %473
+%830 = OpIMul %ulong %829 %ulong_1099511628211
+OpStore %474 %830
+%831 = OpLoad %ulong %477
+%832 = OpIAdd %ulong %831 %ulong_1
+OpStore %475 %832
+%833 = OpLoad %ulong %474
+OpStore %476 %833
+%834 = OpLoad %ulong %475
+OpStore %477 %834
+OpBranch %179
+%125 = OpLabel
+%835 = OpLoad %ulong %465
+%836 = OpIMul %ulong %835 %ulong_8
+OpStore %458 %836
+%837 = OpLoad %ulong %293
+%838 = OpLoad %ulong %458
+%839 = OpShiftRightLogical %ulong %837 %838
+OpStore %459 %839
+%840 = OpLoad %ulong %459
+%841 = OpBitwiseAnd %ulong %840 %ulong_255
+OpStore %460 %841
+%842 = OpLoad %ulong %464
+%843 = OpLoad %ulong %460
+%844 = OpBitwiseXor %ulong %842 %843
+OpStore %461 %844
+%845 = OpLoad %ulong %461
+%846 = OpIMul %ulong %845 %ulong_1099511628211
+OpStore %462 %846
+%847 = OpLoad %ulong %465
+%848 = OpIAdd %ulong %847 %ulong_1
+OpStore %463 %848
+%849 = OpLoad %ulong %462
+OpStore %464 %849
+%850 = OpLoad %ulong %463
+OpStore %465 %850
+OpBranch %180
+%118 = OpLabel
+%851 = OpLoad %ulong %453
+%852 = OpIMul %ulong %851 %ulong_8
+OpStore %446 %852
+%853 = OpLoad %ulong %292
+%854 = OpLoad %ulong %446
+%855 = OpShiftRightLogical %ulong %853 %854
+OpStore %447 %855
+%856 = OpLoad %ulong %447
+%857 = OpBitwiseAnd %ulong %856 %ulong_255
+OpStore %448 %857
+%858 = OpLoad %ulong %452
+%859 = OpLoad %ulong %448
+%860 = OpBitwiseXor %ulong %858 %859
+OpStore %449 %860
+%861 = OpLoad %ulong %449
+%862 = OpIMul %ulong %861 %ulong_1099511628211
+OpStore %450 %862
+%863 = OpLoad %ulong %453
+%864 = OpIAdd %ulong %863 %ulong_1
+OpStore %451 %864
+%865 = OpLoad %ulong %450
+OpStore %452 %865
+%866 = OpLoad %ulong %451
+OpStore %453 %866
+OpBranch %181
+%111 = OpLabel
+%867 = OpLoad %ulong %441
+%868 = OpIMul %ulong %867 %ulong_8
+OpStore %434 %868
+%869 = OpLoad %ulong %291
+%870 = OpLoad %ulong %434
+%871 = OpShiftRightLogical %ulong %869 %870
+OpStore %435 %871
+%872 = OpLoad %ulong %435
+%873 = OpBitwiseAnd %ulong %872 %ulong_255
+OpStore %436 %873
+%874 = OpLoad %ulong %440
+%875 = OpLoad %ulong %436
+%876 = OpBitwiseXor %ulong %874 %875
+OpStore %437 %876
+%877 = OpLoad %ulong %437
+%878 = OpIMul %ulong %877 %ulong_1099511628211
+OpStore %438 %878
+%879 = OpLoad %ulong %441
+%880 = OpIAdd %ulong %879 %ulong_1
+OpStore %439 %880
+%881 = OpLoad %ulong %438
+OpStore %440 %881
+%882 = OpLoad %ulong %439
+OpStore %441 %882
+OpBranch %182
+%104 = OpLabel
+%883 = OpLoad %ulong %429
+%884 = OpIMul %ulong %883 %ulong_8
+OpStore %422 %884
+%885 = OpLoad %ulong %290
+%886 = OpLoad %ulong %422
+%887 = OpShiftRightLogical %ulong %885 %886
+OpStore %423 %887
+%888 = OpLoad %ulong %423
+%889 = OpBitwiseAnd %ulong %888 %ulong_255
+OpStore %424 %889
+%890 = OpLoad %ulong %428
+%891 = OpLoad %ulong %424
+%892 = OpBitwiseXor %ulong %890 %891
+OpStore %425 %892
+%893 = OpLoad %ulong %425
+%894 = OpIMul %ulong %893 %ulong_1099511628211
+OpStore %426 %894
+%895 = OpLoad %ulong %429
+%896 = OpIAdd %ulong %895 %ulong_1
+OpStore %427 %896
+%897 = OpLoad %ulong %426
+OpStore %428 %897
+%898 = OpLoad %ulong %427
+OpStore %429 %898
+OpBranch %183
+%97 = OpLabel
+%899 = OpLoad %ulong %417
+%900 = OpIMul %ulong %899 %ulong_8
+OpStore %410 %900
+%901 = OpLoad %ulong %289
+%902 = OpLoad %ulong %410
+%903 = OpShiftRightLogical %ulong %901 %902
+OpStore %411 %903
+%904 = OpLoad %ulong %411
+%905 = OpBitwiseAnd %ulong %904 %ulong_255
+OpStore %412 %905
+%906 = OpLoad %ulong %416
+%907 = OpLoad %ulong %412
+%908 = OpBitwiseXor %ulong %906 %907
+OpStore %413 %908
+%909 = OpLoad %ulong %413
+%910 = OpIMul %ulong %909 %ulong_1099511628211
+OpStore %414 %910
+%911 = OpLoad %ulong %417
+%912 = OpIAdd %ulong %911 %ulong_1
+OpStore %415 %912
+%913 = OpLoad %ulong %414
+OpStore %416 %913
+%914 = OpLoad %ulong %415
+OpStore %417 %914
+OpBranch %184
+%90 = OpLabel
+%915 = OpLoad %ulong %405
+%916 = OpIMul %ulong %915 %ulong_8
+OpStore %398 %916
+%917 = OpLoad %ulong %288
+%918 = OpLoad %ulong %398
+%919 = OpShiftRightLogical %ulong %917 %918
+OpStore %399 %919
+%920 = OpLoad %ulong %399
+%921 = OpBitwiseAnd %ulong %920 %ulong_255
+OpStore %400 %921
+%922 = OpLoad %ulong %404
+%923 = OpLoad %ulong %400
+%924 = OpBitwiseXor %ulong %922 %923
+OpStore %401 %924
+%925 = OpLoad %ulong %401
+%926 = OpIMul %ulong %925 %ulong_1099511628211
+OpStore %402 %926
+%927 = OpLoad %ulong %405
+%928 = OpIAdd %ulong %927 %ulong_1
+OpStore %403 %928
+%929 = OpLoad %ulong %402
+OpStore %404 %929
+%930 = OpLoad %ulong %403
+OpStore %405 %930
+OpBranch %185
+%83 = OpLabel
+%931 = OpLoad %ulong %393
+%932 = OpIMul %ulong %931 %ulong_8
+OpStore %386 %932
+%933 = OpLoad %ulong %287
+%934 = OpLoad %ulong %386
+%935 = OpShiftRightLogical %ulong %933 %934
+OpStore %387 %935
+%936 = OpLoad %ulong %387
+%937 = OpBitwiseAnd %ulong %936 %ulong_255
+OpStore %388 %937
+%938 = OpLoad %ulong %392
+%939 = OpLoad %ulong %388
+%940 = OpBitwiseXor %ulong %938 %939
+OpStore %389 %940
+%941 = OpLoad %ulong %389
+%942 = OpIMul %ulong %941 %ulong_1099511628211
+OpStore %390 %942
+%943 = OpLoad %ulong %393
+%944 = OpIAdd %ulong %943 %ulong_1
+OpStore %391 %944
+%945 = OpLoad %ulong %390
+OpStore %392 %945
+%946 = OpLoad %ulong %391
+OpStore %393 %946
+OpBranch %186
+%76 = OpLabel
+%947 = OpLoad %ulong %381
+%948 = OpIMul %ulong %947 %ulong_8
+OpStore %374 %948
+%949 = OpLoad %ulong %286
+%950 = OpLoad %ulong %374
+%951 = OpShiftRightLogical %ulong %949 %950
+OpStore %375 %951
+%952 = OpLoad %ulong %375
+%953 = OpBitwiseAnd %ulong %952 %ulong_255
+OpStore %376 %953
+%954 = OpLoad %ulong %380
+%955 = OpLoad %ulong %376
+%956 = OpBitwiseXor %ulong %954 %955
+OpStore %377 %956
+%957 = OpLoad %ulong %377
+%958 = OpIMul %ulong %957 %ulong_1099511628211
+OpStore %378 %958
+%959 = OpLoad %ulong %381
+%960 = OpIAdd %ulong %959 %ulong_1
+OpStore %379 %960
+%961 = OpLoad %ulong %378
+OpStore %380 %961
+%962 = OpLoad %ulong %379
+OpStore %381 %962
+OpBranch %187
+%69 = OpLabel
+%963 = OpLoad %ulong %369
+%964 = OpIMul %ulong %963 %ulong_8
+OpStore %362 %964
+%965 = OpLoad %ulong %285
+%966 = OpLoad %ulong %362
+%967 = OpShiftRightLogical %ulong %965 %966
+OpStore %363 %967
+%968 = OpLoad %ulong %363
+%969 = OpBitwiseAnd %ulong %968 %ulong_255
+OpStore %364 %969
+%970 = OpLoad %ulong %368
+%971 = OpLoad %ulong %364
+%972 = OpBitwiseXor %ulong %970 %971
+OpStore %365 %972
+%973 = OpLoad %ulong %365
+%974 = OpIMul %ulong %973 %ulong_1099511628211
+OpStore %366 %974
+%975 = OpLoad %ulong %369
+%976 = OpIAdd %ulong %975 %ulong_1
+OpStore %367 %976
+%977 = OpLoad %ulong %366
+OpStore %368 %977
+%978 = OpLoad %ulong %367
+OpStore %369 %978
+OpBranch %188
+%62 = OpLabel
+%979 = OpLoad %ulong %357
+%980 = OpIMul %ulong %979 %ulong_8
+OpStore %350 %980
+%981 = OpLoad %ulong %284
+%982 = OpLoad %ulong %350
+%983 = OpShiftRightLogical %ulong %981 %982
+OpStore %351 %983
+%984 = OpLoad %ulong %351
+%985 = OpBitwiseAnd %ulong %984 %ulong_255
+OpStore %352 %985
+%986 = OpLoad %ulong %356
+%987 = OpLoad %ulong %352
+%988 = OpBitwiseXor %ulong %986 %987
+OpStore %353 %988
+%989 = OpLoad %ulong %353
+%990 = OpIMul %ulong %989 %ulong_1099511628211
+OpStore %354 %990
+%991 = OpLoad %ulong %357
+%992 = OpIAdd %ulong %991 %ulong_1
+OpStore %355 %992
+%993 = OpLoad %ulong %354
+OpStore %356 %993
+%994 = OpLoad %ulong %355
+OpStore %357 %994
+OpBranch %189
+%55 = OpLabel
+%995 = OpLoad %ulong %345
+%996 = OpIMul %ulong %995 %ulong_8
+OpStore %338 %996
+%997 = OpLoad %ulong %283
+%998 = OpLoad %ulong %338
+%999 = OpShiftRightLogical %ulong %997 %998
+OpStore %339 %999
+%1000 = OpLoad %ulong %339
+%1001 = OpBitwiseAnd %ulong %1000 %ulong_255
+OpStore %340 %1001
+%1002 = OpLoad %ulong %344
+%1003 = OpLoad %ulong %340
+%1004 = OpBitwiseXor %ulong %1002 %1003
+OpStore %341 %1004
+%1005 = OpLoad %ulong %341
+%1006 = OpIMul %ulong %1005 %ulong_1099511628211
+OpStore %342 %1006
+%1007 = OpLoad %ulong %345
+%1008 = OpIAdd %ulong %1007 %ulong_1
+OpStore %343 %1008
+%1009 = OpLoad %ulong %342
+OpStore %344 %1009
+%1010 = OpLoad %ulong %343
+OpStore %345 %1010
+OpBranch %190
+%48 = OpLabel
+%1011 = OpLoad %ulong %333
+%1012 = OpIMul %ulong %1011 %ulong_8
+OpStore %326 %1012
+%1013 = OpLoad %ulong %282
+%1014 = OpLoad %ulong %326
+%1015 = OpShiftRightLogical %ulong %1013 %1014
+OpStore %327 %1015
+%1016 = OpLoad %ulong %327
+%1017 = OpBitwiseAnd %ulong %1016 %ulong_255
+OpStore %328 %1017
+%1018 = OpLoad %ulong %332
+%1019 = OpLoad %ulong %328
+%1020 = OpBitwiseXor %ulong %1018 %1019
+OpStore %329 %1020
+%1021 = OpLoad %ulong %329
+%1022 = OpIMul %ulong %1021 %ulong_1099511628211
+OpStore %330 %1022
+%1023 = OpLoad %ulong %333
+%1024 = OpIAdd %ulong %1023 %ulong_1
+OpStore %331 %1024
+%1025 = OpLoad %ulong %330
+OpStore %332 %1025
+%1026 = OpLoad %ulong %331
+OpStore %333 %1026
+OpBranch %191
+%41 = OpLabel
+%1027 = OpLoad %ulong %321
+%1028 = OpIMul %ulong %1027 %ulong_8
+OpStore %314 %1028
+%1029 = OpLoad %ulong %281
+%1030 = OpLoad %ulong %314
+%1031 = OpShiftRightLogical %ulong %1029 %1030
+OpStore %315 %1031
+%1032 = OpLoad %ulong %315
+%1033 = OpBitwiseAnd %ulong %1032 %ulong_255
+OpStore %316 %1033
+%1034 = OpLoad %ulong %320
+%1035 = OpLoad %ulong %316
+%1036 = OpBitwiseXor %ulong %1034 %1035
+OpStore %317 %1036
+%1037 = OpLoad %ulong %317
+%1038 = OpIMul %ulong %1037 %ulong_1099511628211
+OpStore %318 %1038
+%1039 = OpLoad %ulong %321
+%1040 = OpIAdd %ulong %1039 %ulong_1
+OpStore %319 %1040
+%1041 = OpLoad %ulong %318
+OpStore %320 %1041
+%1042 = OpLoad %ulong %319
+OpStore %321 %1042
+OpBranch %192
+%33 = OpLabel
+OpBranch %37
+%37 = OpLabel
+%1043 = OpLoad %ulong %296
+%1045 = OpShiftLeftLogical %ulong %1043 %ulong_29
+OpStore %310 %1045
+%1046 = OpLoad %ulong %296
+%1048 = OpShiftRightLogical %ulong %1046 %ulong_35
+OpStore %311 %1048
+%1049 = OpLoad %ulong %310
+%1050 = OpLoad %ulong %311
+%1051 = OpBitwiseOr %ulong %1049 %1050
+OpStore %312 %1051
+OpBranch %38
+%38 = OpLabel
+%1052 = OpLoad %ulong %281
+%1053 = OpLoad %ulong %312
+%1054 = OpBitwiseXor %ulong %1052 %1053
+OpStore %235 %1054
+OpBranch %44
+%44 = OpLabel
+%1055 = OpLoad %ulong %281
+%1057 = OpShiftLeftLogical %ulong %1055 %ulong_7
+OpStore %322 %1057
+%1058 = OpLoad %ulong %281
+%1060 = OpShiftRightLogical %ulong %1058 %ulong_57
+OpStore %323 %1060
+%1061 = OpLoad %ulong %322
+%1062 = OpLoad %ulong %323
+%1063 = OpBitwiseOr %ulong %1061 %1062
+OpStore %324 %1063
+OpBranch %45
+%45 = OpLabel
+%1064 = OpLoad %ulong %282
+%1065 = OpLoad %ulong %324
+%1066 = OpIAdd %ulong %1064 %1065
+OpStore %236 %1066
+OpBranch %51
+%51 = OpLabel
+%1067 = OpLoad %ulong %282
+%1069 = OpShiftLeftLogical %ulong %1067 %ulong_11
+OpStore %334 %1069
+%1070 = OpLoad %ulong %282
+%1072 = OpShiftRightLogical %ulong %1070 %ulong_53
+OpStore %335 %1072
+%1073 = OpLoad %ulong %334
+%1074 = OpLoad %ulong %335
+%1075 = OpBitwiseOr %ulong %1073 %1074
+OpStore %336 %1075
+OpBranch %52
+%52 = OpLabel
+%1076 = OpLoad %ulong %283
+%1077 = OpLoad %ulong %336
+%1078 = OpBitwiseXor %ulong %1076 %1077
+OpStore %237 %1078
+OpBranch %58
+%58 = OpLabel
+%1079 = OpLoad %ulong %283
+%1081 = OpShiftLeftLogical %ulong %1079 %ulong_13
+OpStore %346 %1081
+%1082 = OpLoad %ulong %283
+%1084 = OpShiftRightLogical %ulong %1082 %ulong_51
+OpStore %347 %1084
+%1085 = OpLoad %ulong %346
+%1086 = OpLoad %ulong %347
+%1087 = OpBitwiseOr %ulong %1085 %1086
+OpStore %348 %1087
+OpBranch %59
+%59 = OpLabel
+%1088 = OpLoad %ulong %284
+%1089 = OpLoad %ulong %348
+%1090 = OpIAdd %ulong %1088 %1089
+OpStore %238 %1090
+OpBranch %65
+%65 = OpLabel
+%1091 = OpLoad %ulong %284
+%1093 = OpShiftLeftLogical %ulong %1091 %ulong_17
+OpStore %358 %1093
+%1094 = OpLoad %ulong %284
+%1096 = OpShiftRightLogical %ulong %1094 %ulong_47
+OpStore %359 %1096
+%1097 = OpLoad %ulong %358
+%1098 = OpLoad %ulong %359
+%1099 = OpBitwiseOr %ulong %1097 %1098
+OpStore %360 %1099
+OpBranch %66
+%66 = OpLabel
+%1100 = OpLoad %ulong %285
+%1101 = OpLoad %ulong %360
+%1102 = OpBitwiseXor %ulong %1100 %1101
+OpStore %239 %1102
+OpBranch %72
+%72 = OpLabel
+%1103 = OpLoad %ulong %285
+%1105 = OpShiftLeftLogical %ulong %1103 %ulong_19
+OpStore %370 %1105
+%1106 = OpLoad %ulong %285
+%1108 = OpShiftRightLogical %ulong %1106 %ulong_45
+OpStore %371 %1108
+%1109 = OpLoad %ulong %370
+%1110 = OpLoad %ulong %371
+%1111 = OpBitwiseOr %ulong %1109 %1110
+OpStore %372 %1111
+OpBranch %73
+%73 = OpLabel
+%1112 = OpLoad %ulong %286
+%1113 = OpLoad %ulong %372
+%1114 = OpIAdd %ulong %1112 %1113
+OpStore %240 %1114
+OpBranch %79
+%79 = OpLabel
+%1115 = OpLoad %ulong %286
+%1117 = OpShiftLeftLogical %ulong %1115 %ulong_23
+OpStore %382 %1117
+%1118 = OpLoad %ulong %286
+%1120 = OpShiftRightLogical %ulong %1118 %ulong_41
+OpStore %383 %1120
+%1121 = OpLoad %ulong %382
+%1122 = OpLoad %ulong %383
+%1123 = OpBitwiseOr %ulong %1121 %1122
+OpStore %384 %1123
+OpBranch %80
+%80 = OpLabel
+%1124 = OpLoad %ulong %287
+%1125 = OpLoad %ulong %384
+%1126 = OpBitwiseXor %ulong %1124 %1125
+OpStore %241 %1126
+OpBranch %86
+%86 = OpLabel
+%1127 = OpLoad %ulong %287
+%1129 = OpShiftLeftLogical %ulong %1127 %ulong_31
+OpStore %394 %1129
+%1130 = OpLoad %ulong %287
+%1132 = OpShiftRightLogical %ulong %1130 %ulong_33
+OpStore %395 %1132
+%1133 = OpLoad %ulong %394
+%1134 = OpLoad %ulong %395
+%1135 = OpBitwiseOr %ulong %1133 %1134
+OpStore %396 %1135
+OpBranch %87
+%87 = OpLabel
+%1136 = OpLoad %ulong %288
+%1137 = OpLoad %ulong %396
+%1138 = OpIAdd %ulong %1136 %1137
+OpStore %242 %1138
+OpBranch %93
+%93 = OpLabel
+%1139 = OpLoad %ulong %288
+%1141 = OpShiftLeftLogical %ulong %1139 %ulong_37
+OpStore %406 %1141
+%1142 = OpLoad %ulong %288
+%1144 = OpShiftRightLogical %ulong %1142 %ulong_27
+OpStore %407 %1144
+%1145 = OpLoad %ulong %406
+%1146 = OpLoad %ulong %407
+%1147 = OpBitwiseOr %ulong %1145 %1146
+OpStore %408 %1147
+OpBranch %94
+%94 = OpLabel
+%1148 = OpLoad %ulong %289
+%1149 = OpLoad %ulong %408
+%1150 = OpBitwiseXor %ulong %1148 %1149
+OpStore %243 %1150
+OpBranch %100
+%100 = OpLabel
+%1151 = OpLoad %ulong %289
+%1152 = OpShiftLeftLogical %ulong %1151 %ulong_41
+OpStore %418 %1152
+%1153 = OpLoad %ulong %289
+%1154 = OpShiftRightLogical %ulong %1153 %ulong_23
+OpStore %419 %1154
+%1155 = OpLoad %ulong %418
+%1156 = OpLoad %ulong %419
+%1157 = OpBitwiseOr %ulong %1155 %1156
+OpStore %420 %1157
+OpBranch %101
+%101 = OpLabel
+%1158 = OpLoad %ulong %290
+%1159 = OpLoad %ulong %420
+%1160 = OpIAdd %ulong %1158 %1159
+OpStore %244 %1160
+OpBranch %107
+%107 = OpLabel
+%1161 = OpLoad %ulong %290
+%1163 = OpShiftLeftLogical %ulong %1161 %ulong_43
+OpStore %430 %1163
+%1164 = OpLoad %ulong %290
+%1166 = OpShiftRightLogical %ulong %1164 %ulong_21
+OpStore %431 %1166
+%1167 = OpLoad %ulong %430
+%1168 = OpLoad %ulong %431
+%1169 = OpBitwiseOr %ulong %1167 %1168
+OpStore %432 %1169
+OpBranch %108
+%108 = OpLabel
+%1170 = OpLoad %ulong %291
+%1171 = OpLoad %ulong %432
+%1172 = OpBitwiseXor %ulong %1170 %1171
+OpStore %245 %1172
+OpBranch %114
+%114 = OpLabel
+%1173 = OpLoad %ulong %291
+%1174 = OpShiftLeftLogical %ulong %1173 %ulong_47
+OpStore %442 %1174
+%1175 = OpLoad %ulong %291
+%1176 = OpShiftRightLogical %ulong %1175 %ulong_17
+OpStore %443 %1176
+%1177 = OpLoad %ulong %442
+%1178 = OpLoad %ulong %443
+%1179 = OpBitwiseOr %ulong %1177 %1178
+OpStore %444 %1179
+OpBranch %115
+%115 = OpLabel
+%1180 = OpLoad %ulong %292
+%1181 = OpLoad %ulong %444
+%1182 = OpIAdd %ulong %1180 %1181
+OpStore %246 %1182
+OpBranch %121
+%121 = OpLabel
+%1183 = OpLoad %ulong %292
+%1184 = OpShiftLeftLogical %ulong %1183 %ulong_53
+OpStore %454 %1184
+%1185 = OpLoad %ulong %292
+%1186 = OpShiftRightLogical %ulong %1185 %ulong_11
+OpStore %455 %1186
+%1187 = OpLoad %ulong %454
+%1188 = OpLoad %ulong %455
+%1189 = OpBitwiseOr %ulong %1187 %1188
+OpStore %456 %1189
+OpBranch %122
+%122 = OpLabel
+%1190 = OpLoad %ulong %293
+%1191 = OpLoad %ulong %456
+%1192 = OpBitwiseXor %ulong %1190 %1191
+OpStore %247 %1192
+OpBranch %128
+%128 = OpLabel
+%1193 = OpLoad %ulong %293
+%1195 = OpShiftLeftLogical %ulong %1193 %ulong_59
+OpStore %466 %1195
+%1196 = OpLoad %ulong %293
+%1198 = OpShiftRightLogical %ulong %1196 %ulong_5
+OpStore %467 %1198
+%1199 = OpLoad %ulong %466
+%1200 = OpLoad %ulong %467
+%1201 = OpBitwiseOr %ulong %1199 %1200
+OpStore %468 %1201
+OpBranch %129
+%129 = OpLabel
+%1202 = OpLoad %ulong %294
+%1203 = OpLoad %ulong %468
+%1204 = OpIAdd %ulong %1202 %1203
+OpStore %248 %1204
+OpBranch %135
+%135 = OpLabel
+%1205 = OpLoad %ulong %294
+%1207 = OpShiftLeftLogical %ulong %1205 %ulong_61
+OpStore %478 %1207
+%1208 = OpLoad %ulong %294
+%1210 = OpShiftRightLogical %ulong %1208 %ulong_3
+OpStore %479 %1210
+%1211 = OpLoad %ulong %478
+%1212 = OpLoad %ulong %479
+%1213 = OpBitwiseOr %ulong %1211 %1212
+OpStore %480 %1213
+OpBranch %136
+%136 = OpLabel
+%1214 = OpLoad %ulong %295
+%1215 = OpLoad %ulong %480
+%1216 = OpBitwiseXor %ulong %1214 %1215
+OpStore %249 %1216
+OpBranch %142
+%142 = OpLabel
+%1217 = OpLoad %ulong %295
+%1218 = OpShiftLeftLogical %ulong %1217 %ulong_3
+OpStore %490 %1218
+%1219 = OpLoad %ulong %295
+%1220 = OpShiftRightLogical %ulong %1219 %ulong_61
+OpStore %491 %1220
+%1221 = OpLoad %ulong %490
+%1222 = OpLoad %ulong %491
+%1223 = OpBitwiseOr %ulong %1221 %1222
+OpStore %492 %1223
+OpBranch %143
+%143 = OpLabel
+%1224 = OpLoad %ulong %296
+%1225 = OpLoad %ulong %492
+%1226 = OpIAdd %ulong %1224 %1225
+OpStore %250 %1226
+%1227 = OpLoad %ulong %235
+%1228 = OpLoad %ulong %309
+%1229 = OpIAdd %ulong %1227 %1228
+OpStore %251 %1229
+%1230 = OpLoad %ulong %248
+%1231 = OpUConvert %uint %1230
+OpStore %252 %1231
+%1232 = OpLoad %uint %297
+%1233 = OpLoad %uint %252
+%1234 = OpBitwiseXor %uint %1232 %1233
+OpStore %253 %1234
+%1235 = OpLoad %ulong %236
+%1236 = OpUConvert %uint %1235
+OpStore %254 %1236
+%1237 = OpLoad %uint %298
+%1238 = OpLoad %uint %254
+%1239 = OpIAdd %uint %1237 %1238
+OpStore %255 %1239
+%1240 = OpLoad %ulong %240
+%1241 = OpUConvert %uint %1240
+OpStore %256 %1241
+%1242 = OpLoad %uint %299
+%1243 = OpLoad %uint %256
+%1244 = OpBitwiseXor %uint %1242 %1243
+OpStore %257 %1244
+%1245 = OpLoad %ulong %244
+%1246 = OpUConvert %uint %1245
+OpStore %258 %1246
+%1247 = OpLoad %uint %300
+%1248 = OpLoad %uint %258
+%1249 = OpIAdd %uint %1247 %1248
+OpStore %259 %1249
+%1250 = OpLoad %double %301
+%1251 = OpFMul %double %1250 %double_1_5
+OpStore %260 %1251
+%1252 = OpLoad %double %260
+%1253 = OpLoad %double %302
+%1254 = OpFAdd %double %1252 %1253
+OpStore %261 %1254
+%1255 = OpLoad %double %302
+%1257 = OpFMul %double %1255 %double_0_75
+OpStore %262 %1257
+%1258 = OpLoad %double %262
+%1259 = OpLoad %double %303
+%1260 = OpFAdd %double %1258 %1259
+OpStore %263 %1260
+%1261 = OpLoad %double %303
+%1263 = OpFMul %double %1261 %double_1_25
+OpStore %264 %1263
+%1264 = OpLoad %double %264
+%1265 = OpLoad %double %304
+%1266 = OpFAdd %double %1264 %1265
+OpStore %265 %1266
+%1267 = OpLoad %double %304
+%1269 = OpFMul %double %1267 %double_0_5
+OpStore %266 %1269
+%1270 = OpLoad %double %266
+%1271 = OpLoad %double %305
+%1272 = OpFAdd %double %1270 %1271
+OpStore %267 %1272
+%1273 = OpLoad %double %305
+%1275 = OpFMul %double %1273 %double_1_75
+OpStore %268 %1275
+%1276 = OpLoad %double %268
+%1277 = OpLoad %double %306
+%1278 = OpFAdd %double %1276 %1277
+OpStore %269 %1278
+%1279 = OpLoad %double %306
+%1281 = OpFMul %double %1279 %double_0_625
+OpStore %270 %1281
+%1282 = OpLoad %double %270
+%1283 = OpLoad %double %307
+%1284 = OpFAdd %double %1282 %1283
+OpStore %271 %1284
+%1285 = OpLoad %double %307
+%1287 = OpFMul %double %1285 %double_1_125
+OpStore %272 %1287
+%1288 = OpLoad %double %272
+%1289 = OpLoad %double %308
+%1290 = OpFAdd %double %1288 %1289
+OpStore %273 %1290
+%1291 = OpLoad %double %308
+%1292 = OpFMul %double %1291 %double_0_875
+OpStore %274 %1292
+%1293 = OpLoad %double %274
+%1294 = OpLoad %double %301
+%1295 = OpFAdd %double %1293 %1294
+OpStore %275 %1295
+%1296 = OpLoad %ulong %236
+%1297 = OpLoad %ulong %244
+%1298 = OpBitwiseXor %ulong %1296 %1297
+OpStore %276 %1298
+%1299 = OpLoad %ulong %280
+%1300 = OpLoad %ulong %276
+%1301 = OpFunctionCall %ulong %3 %1299 %1300
+OpStore %277 %1301
+OpBranch %149
+%149 = OpLabel
+%1302 = OpLoad %uint %255
+%1303 = OpUConvert %ulong %1302
+OpStore %502 %1303
+%1304 = OpLoad %ulong %277
+%1305 = OpLoad %ulong %502
+%1306 = OpFunctionCall %ulong %3 %1304 %1305
+OpStore %503 %1306
+OpBranch %150
+%150 = OpLabel
+%1307 = OpLoad %double %261
+%1308 = OpLoad %double %269
+%1309 = OpFAdd %double %1307 %1308
+OpStore %278 %1309
+OpBranch %153
+%153 = OpLabel
+%1310 = OpLoad %double %278
+%1311 = OpBitcast %ulong %1310
+OpStore %506 %1311
+%1312 = OpLoad %ulong %503
+%1313 = OpLoad %ulong %506
+%1314 = OpFunctionCall %ulong %3 %1312 %1313
+OpStore %507 %1314
+OpBranch %154
+%154 = OpLabel
+%1315 = OpLoad %ulong %309
+%1316 = OpIAdd %ulong %1315 %ulong_1
+OpStore %279 %1316
+%1317 = OpLoad %ulong %507
+OpStore %280 %1317
+%1318 = OpLoad %ulong %236
+OpStore %281 %1318
+%1319 = OpLoad %ulong %237
+OpStore %282 %1319
+%1320 = OpLoad %ulong %238
+OpStore %283 %1320
+%1321 = OpLoad %ulong %239
+OpStore %284 %1321
+%1322 = OpLoad %ulong %240
+OpStore %285 %1322
+%1323 = OpLoad %ulong %241
+OpStore %286 %1323
+%1324 = OpLoad %ulong %242
+OpStore %287 %1324
+%1325 = OpLoad %ulong %243
+OpStore %288 %1325
+%1326 = OpLoad %ulong %244
+OpStore %289 %1326
+%1327 = OpLoad %ulong %245
+OpStore %290 %1327
+%1328 = OpLoad %ulong %246
+OpStore %291 %1328
+%1329 = OpLoad %ulong %247
+OpStore %292 %1329
+%1330 = OpLoad %ulong %248
+OpStore %293 %1330
+%1331 = OpLoad %ulong %249
+OpStore %294 %1331
+%1332 = OpLoad %ulong %250
+OpStore %295 %1332
+%1333 = OpLoad %ulong %251
+OpStore %296 %1333
+%1334 = OpLoad %uint %255
+OpStore %297 %1334
+%1335 = OpLoad %uint %257
+OpStore %298 %1335
+%1336 = OpLoad %uint %259
+OpStore %299 %1336
+%1337 = OpLoad %uint %253
+OpStore %300 %1337
+%1338 = OpLoad %double %261
+OpStore %301 %1338
+%1339 = OpLoad %double %263
+OpStore %302 %1339
+%1340 = OpLoad %double %265
+OpStore %303 %1340
+%1341 = OpLoad %double %267
+OpStore %304 %1341
+%1342 = OpLoad %double %269
+OpStore %305 %1342
+%1343 = OpLoad %double %271
+OpStore %306 %1343
+%1344 = OpLoad %double %273
+OpStore %307 %1344
+%1345 = OpLoad %double %275
+OpStore %308 %1345
+%1346 = OpLoad %ulong %279
+OpStore %309 %1346
+OpBranch %193
+%177 = OpLabel
+OpBranch %145
+%178 = OpLabel
+OpBranch %138
+%179 = OpLabel
+OpBranch %131
+%180 = OpLabel
+OpBranch %124
+%181 = OpLabel
+OpBranch %117
+%182 = OpLabel
+OpBranch %110
+%183 = OpLabel
+OpBranch %103
+%184 = OpLabel
+OpBranch %96
+%185 = OpLabel
+OpBranch %89
+%186 = OpLabel
+OpBranch %82
+%187 = OpLabel
+OpBranch %75
+%188 = OpLabel
+OpBranch %68
+%189 = OpLabel
+OpBranch %61
+%190 = OpLabel
+OpBranch %54
+%191 = OpLabel
+OpBranch %47
+%192 = OpLabel
+OpBranch %40
+%193 = OpLabel
+OpBranch %32
 OpFunctionEnd
-%3 = OpFunction %ulong None %781
-%782 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %8
-%784 = OpFunctionParameter %ulong
-%785 = OpFunctionParameter %ulong
-%786 = OpLabel
-%791 = OpVariable %_ptr_Function_ulong Function
-%792 = OpVariable %_ptr_Function_ulong Function
-%793 = OpVariable %_ptr_Function_bool Function
-%794 = OpVariable %_ptr_Function_ulong Function
-%795 = OpVariable %_ptr_Function_ulong Function
-%796 = OpVariable %_ptr_Function_ulong Function
-%797 = OpVariable %_ptr_Function_ulong Function
-%798 = OpVariable %_ptr_Function_ulong Function
-%799 = OpVariable %_ptr_Function_ulong Function
-%800 = OpVariable %_ptr_Function_ulong Function
-%801 = OpVariable %_ptr_Function_ulong Function
-OpStore %791 %784
-OpStore %792 %785
-%802 = OpLoad %ulong %791
-OpStore %800 %802
-OpStore %801 %ulong_0
-OpBranch %787
-%787 = OpLabel
-%803 = OpLoad %ulong %801
-%805 = OpULessThan %bool %803 %ulong_8
-OpStore %793 %805
-%806 = OpLoad %bool %793
-OpLoopMerge %789 %790 None
-OpBranchConditional %806 %788 %789
-%789 = OpLabel
-%807 = OpLoad %ulong %800
-OpReturnValue %807
-%788 = OpLabel
-%808 = OpLoad %ulong %801
-%809 = OpIMul %ulong %808 %ulong_8
-OpStore %794 %809
-%810 = OpLoad %ulong %792
-%811 = OpLoad %ulong %794
-%812 = OpShiftRightLogical %ulong %810 %811
-OpStore %795 %812
-%813 = OpLoad %ulong %795
-%815 = OpBitwiseAnd %ulong %813 %ulong_255
-OpStore %796 %815
-%816 = OpLoad %ulong %800
-%817 = OpLoad %ulong %796
-%818 = OpBitwiseXor %ulong %816 %817
-OpStore %797 %818
-%819 = OpLoad %ulong %797
-%821 = OpIMul %ulong %819 %ulong_1099511628211
-OpStore %798 %821
-%822 = OpLoad %ulong %801
-%823 = OpIAdd %ulong %822 %ulong_1
-OpStore %799 %823
-%824 = OpLoad %ulong %798
-OpStore %800 %824
-%825 = OpLoad %ulong %799
-OpStore %801 %825
-OpBranch %790
-%790 = OpLabel
-OpBranch %787
-OpFunctionEnd
-%5 = OpFunction %ulong None %826
-%827 = OpFunctionParameter %ulong
-%828 = OpFunctionParameter %uint
-%829 = OpLabel
-%836 = OpVariable %_ptr_Function_ulong Function
-%837 = OpVariable %_ptr_Function_uint Function
-%838 = OpVariable %_ptr_Function_ulong Function
-%839 = OpVariable %_ptr_Function_bool Function
-%840 = OpVariable %_ptr_Function_ulong Function
-%841 = OpVariable %_ptr_Function_ulong Function
-%842 = OpVariable %_ptr_Function_ulong Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_ulong Function
-%847 = OpVariable %_ptr_Function_ulong Function
-OpStore %836 %827
-OpStore %837 %828
-%848 = OpLoad %uint %837
-%849 = OpUConvert %ulong %848
-OpStore %838 %849
-OpBranch %830
-%830 = OpLabel
-%850 = OpLoad %ulong %836
-OpStore %846 %850
-OpStore %847 %ulong_0
-OpBranch %831
-%831 = OpLabel
-%851 = OpLoad %ulong %847
-%852 = OpULessThan %bool %851 %ulong_8
-OpStore %839 %852
-%853 = OpLoad %bool %839
-OpLoopMerge %833 %835 None
-OpBranchConditional %853 %832 %833
-%833 = OpLabel
-OpBranch %834
-%834 = OpLabel
-%854 = OpLoad %ulong %846
-OpReturnValue %854
-%832 = OpLabel
-%855 = OpLoad %ulong %847
-%856 = OpIMul %ulong %855 %ulong_8
-OpStore %840 %856
-%857 = OpLoad %ulong %838
-%858 = OpLoad %ulong %840
-%859 = OpShiftRightLogical %ulong %857 %858
-OpStore %841 %859
-%860 = OpLoad %ulong %841
-%861 = OpBitwiseAnd %ulong %860 %ulong_255
-OpStore %842 %861
-%862 = OpLoad %ulong %846
-%863 = OpLoad %ulong %842
-%864 = OpBitwiseXor %ulong %862 %863
-OpStore %843 %864
-%865 = OpLoad %ulong %843
-%866 = OpIMul %ulong %865 %ulong_1099511628211
-OpStore %844 %866
-%867 = OpLoad %ulong %847
-%868 = OpIAdd %ulong %867 %ulong_1
-OpStore %845 %868
-%869 = OpLoad %ulong %844
-OpStore %846 %869
-%870 = OpLoad %ulong %845
-OpStore %847 %870
-OpBranch %835
-%835 = OpLabel
-OpBranch %831
-OpFunctionEnd
-%6 = OpFunction %ulong None %871
-%872 = OpFunctionParameter %ulong
-%873 = OpFunctionParameter %double
-%874 = OpLabel
-%881 = OpVariable %_ptr_Function_ulong Function
-%882 = OpVariable %_ptr_Function_double Function
-%883 = OpVariable %_ptr_Function_ulong Function
-%884 = OpVariable %_ptr_Function_bool Function
-%885 = OpVariable %_ptr_Function_ulong Function
-%886 = OpVariable %_ptr_Function_ulong Function
-%887 = OpVariable %_ptr_Function_ulong Function
-%888 = OpVariable %_ptr_Function_ulong Function
-%889 = OpVariable %_ptr_Function_ulong Function
-%890 = OpVariable %_ptr_Function_ulong Function
-%891 = OpVariable %_ptr_Function_ulong Function
-%892 = OpVariable %_ptr_Function_ulong Function
-OpStore %881 %872
-OpStore %882 %873
-%893 = OpLoad %double %882
-%894 = OpBitcast %ulong %893
-OpStore %883 %894
-OpBranch %875
-%875 = OpLabel
-%895 = OpLoad %ulong %881
-OpStore %891 %895
-OpStore %892 %ulong_0
-OpBranch %876
-%876 = OpLabel
-%896 = OpLoad %ulong %892
-%897 = OpULessThan %bool %896 %ulong_8
-OpStore %884 %897
-%898 = OpLoad %bool %884
-OpLoopMerge %878 %880 None
-OpBranchConditional %898 %877 %878
-%878 = OpLabel
-OpBranch %879
-%879 = OpLabel
-%899 = OpLoad %ulong %891
-OpReturnValue %899
-%877 = OpLabel
-%900 = OpLoad %ulong %892
-%901 = OpIMul %ulong %900 %ulong_8
-OpStore %885 %901
-%902 = OpLoad %ulong %883
-%903 = OpLoad %ulong %885
-%904 = OpShiftRightLogical %ulong %902 %903
-OpStore %886 %904
-%905 = OpLoad %ulong %886
-%906 = OpBitwiseAnd %ulong %905 %ulong_255
-OpStore %887 %906
-%907 = OpLoad %ulong %891
-%908 = OpLoad %ulong %887
-%909 = OpBitwiseXor %ulong %907 %908
-OpStore %888 %909
-%910 = OpLoad %ulong %888
-%911 = OpIMul %ulong %910 %ulong_1099511628211
-OpStore %889 %911
-%912 = OpLoad %ulong %892
-%913 = OpIAdd %ulong %912 %ulong_1
-OpStore %890 %913
-%914 = OpLoad %ulong %889
-OpStore %891 %914
-%915 = OpLoad %ulong %890
-OpStore %892 %915
-OpBranch %880
-%880 = OpLabel
-OpBranch %876
+%3 = OpFunction %ulong None %5
+%1347 = OpFunctionParameter %ulong
+%1348 = OpFunctionParameter %ulong
+%1349 = OpLabel
+%1354 = OpVariable %_ptr_Function_ulong Function
+%1355 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_bool Function
+%1357 = OpVariable %_ptr_Function_ulong Function
+%1358 = OpVariable %_ptr_Function_ulong Function
+%1359 = OpVariable %_ptr_Function_ulong Function
+%1360 = OpVariable %_ptr_Function_ulong Function
+%1361 = OpVariable %_ptr_Function_ulong Function
+%1362 = OpVariable %_ptr_Function_ulong Function
+%1363 = OpVariable %_ptr_Function_ulong Function
+%1364 = OpVariable %_ptr_Function_ulong Function
+OpStore %1354 %1347
+OpStore %1355 %1348
+%1365 = OpLoad %ulong %1354
+OpStore %1363 %1365
+OpStore %1364 %ulong_0
+OpBranch %1350
+%1350 = OpLabel
+%1366 = OpLoad %ulong %1364
+%1367 = OpULessThan %bool %1366 %ulong_8
+OpStore %1356 %1367
+%1368 = OpLoad %bool %1356
+OpLoopMerge %1352 %1353 None
+OpBranchConditional %1368 %1351 %1352
+%1352 = OpLabel
+%1369 = OpLoad %ulong %1363
+OpReturnValue %1369
+%1351 = OpLabel
+%1370 = OpLoad %ulong %1364
+%1371 = OpIMul %ulong %1370 %ulong_8
+OpStore %1357 %1371
+%1372 = OpLoad %ulong %1355
+%1373 = OpLoad %ulong %1357
+%1374 = OpShiftRightLogical %ulong %1372 %1373
+OpStore %1358 %1374
+%1375 = OpLoad %ulong %1358
+%1376 = OpBitwiseAnd %ulong %1375 %ulong_255
+OpStore %1359 %1376
+%1377 = OpLoad %ulong %1363
+%1378 = OpLoad %ulong %1359
+%1379 = OpBitwiseXor %ulong %1377 %1378
+OpStore %1360 %1379
+%1380 = OpLoad %ulong %1360
+%1381 = OpIMul %ulong %1380 %ulong_1099511628211
+OpStore %1361 %1381
+%1382 = OpLoad %ulong %1364
+%1383 = OpIAdd %ulong %1382 %ulong_1
+OpStore %1362 %1383
+%1384 = OpLoad %ulong %1361
+OpStore %1363 %1384
+%1385 = OpLoad %ulong %1362
+OpStore %1364 %1385
+OpBranch %1353
+%1353 = OpLabel
+OpBranch %1350
 OpFunctionEnd

--- a/test/golden/spirv/imm/imm_add.dis
+++ b/test/golden/spirv/imm/imm_add.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 376
+; Bound: 810
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,11 +9,16 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_add.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uint_2047 = OpConstant %uint 2047
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_2048 = OpConstant %uint 2048
 %uint_4095 = OpConstant %uint 4095
 %uint_4096 = OpConstant %uint 4096
@@ -29,497 +34,1174 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_add.checksum" Export
 %ulong_4294967295 = OpConstant %ulong 4294967295
 %ulong_4294967296 = OpConstant %ulong 4294967296
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
-%196 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%199 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%246 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpLabel
-%13 = OpVariable %_ptr_Function_ulong Function
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_uint Function
-%17 = OpVariable %_ptr_Function_uint Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_uint Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_uint Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uint Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-%62 = OpFunctionCall %ulong %2
-OpStore %14 %62
-%63 = OpLoad %ulong %13
-%64 = OpUConvert %uint %63
-OpStore %16 %64
-%65 = OpLoad %uint %16
-%67 = OpIAdd %uint %65 %uint_2047
-OpStore %17 %67
-%68 = OpLoad %ulong %14
-%69 = OpLoad %uint %17
-%70 = OpFunctionCall %ulong %4 %68 %69
-OpStore %18 %70
-%71 = OpLoad %uint %17
-%73 = OpIAdd %uint %71 %uint_2048
-OpStore %19 %73
-%74 = OpLoad %ulong %18
-%75 = OpLoad %uint %19
-%76 = OpFunctionCall %ulong %4 %74 %75
-OpStore %20 %76
-%77 = OpLoad %uint %19
-%79 = OpIAdd %uint %77 %uint_4095
-OpStore %21 %79
-%80 = OpLoad %ulong %20
-%81 = OpLoad %uint %21
-%82 = OpFunctionCall %ulong %4 %80 %81
-OpStore %22 %82
-%83 = OpLoad %uint %21
-%85 = OpIAdd %uint %83 %uint_4096
-OpStore %23 %85
-%86 = OpLoad %ulong %22
-%87 = OpLoad %uint %23
-%88 = OpFunctionCall %ulong %4 %86 %87
-OpStore %24 %88
-%89 = OpLoad %uint %23
-%91 = OpIAdd %uint %89 %uint_2147483647
-OpStore %25 %91
-%92 = OpLoad %ulong %24
-%93 = OpLoad %uint %25
-%94 = OpFunctionCall %ulong %4 %92 %93
-OpStore %26 %94
-%95 = OpLoad %uint %25
-%97 = OpIAdd %uint %95 %uint_2147483648
-OpStore %27 %97
-%98 = OpLoad %ulong %26
-%99 = OpLoad %uint %27
-%100 = OpFunctionCall %ulong %4 %98 %99
-OpStore %28 %100
-%101 = OpLoad %uint %27
-%103 = OpIAdd %uint %101 %uint_4294967295
-OpStore %29 %103
-%104 = OpLoad %ulong %28
-%105 = OpLoad %uint %29
-%106 = OpFunctionCall %ulong %4 %104 %105
-OpStore %30 %106
-%107 = OpLoad %ulong %13
-%109 = OpIAdd %ulong %107 %ulong_2047
-OpStore %31 %109
-%110 = OpLoad %ulong %30
-%111 = OpLoad %ulong %31
-%112 = OpFunctionCall %ulong %3 %110 %111
-OpStore %32 %112
-%113 = OpLoad %ulong %31
-%115 = OpISub %ulong %113 %ulong_2048
-OpStore %33 %115
-%116 = OpLoad %ulong %32
-%117 = OpLoad %ulong %33
-%118 = OpFunctionCall %ulong %3 %116 %117
-OpStore %34 %118
-%119 = OpLoad %ulong %33
-%121 = OpIAdd %ulong %119 %ulong_16773120
-OpStore %35 %121
-%122 = OpLoad %ulong %34
-%123 = OpLoad %ulong %35
-%124 = OpFunctionCall %ulong %3 %122 %123
-OpStore %36 %124
-%125 = OpLoad %ulong %35
-%127 = OpIAdd %ulong %125 %ulong_16777215
-OpStore %37 %127
-%128 = OpLoad %ulong %36
-%129 = OpLoad %ulong %37
-%130 = OpFunctionCall %ulong %3 %128 %129
-OpStore %38 %130
-%131 = OpLoad %ulong %37
-%133 = OpIAdd %ulong %131 %ulong_2147483647
-OpStore %39 %133
-%134 = OpLoad %ulong %38
-%135 = OpLoad %ulong %39
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %40 %136
-%137 = OpLoad %ulong %39
-%139 = OpIAdd %ulong %137 %ulong_2147483648
-OpStore %41 %139
-%140 = OpLoad %ulong %40
-%141 = OpLoad %ulong %41
-%142 = OpFunctionCall %ulong %3 %140 %141
-OpStore %42 %142
-%143 = OpLoad %ulong %41
-%145 = OpIAdd %ulong %143 %ulong_4294967295
-OpStore %43 %145
-%146 = OpLoad %ulong %42
-%147 = OpLoad %ulong %43
-%148 = OpFunctionCall %ulong %3 %146 %147
-OpStore %44 %148
-%149 = OpLoad %ulong %43
-%151 = OpIAdd %ulong %149 %ulong_4294967296
-OpStore %45 %151
-%152 = OpLoad %ulong %44
-%153 = OpLoad %ulong %45
-%154 = OpFunctionCall %ulong %3 %152 %153
-OpStore %46 %154
-%155 = OpLoad %ulong %45
-%157 = OpIAdd %ulong %155 %ulong_9223372036854775808
-OpStore %47 %157
-%158 = OpLoad %ulong %46
-%159 = OpLoad %ulong %47
-%160 = OpFunctionCall %ulong %3 %158 %159
-OpStore %48 %160
-%161 = OpLoad %ulong %48
-%162 = OpLoad %uint %17
-%163 = OpFunctionCall %ulong %5 %161 %162
-OpStore %49 %163
-%164 = OpLoad %uint %17
-%165 = OpISub %uint %164 %uint_2048
-OpStore %50 %165
-%166 = OpLoad %ulong %49
-%167 = OpLoad %uint %50
-%168 = OpFunctionCall %ulong %5 %166 %167
-OpStore %51 %168
-%169 = OpLoad %uint %50
-%170 = OpIAdd %uint %169 %uint_2147483647
-OpStore %52 %170
-%171 = OpLoad %ulong %51
-%172 = OpLoad %uint %52
-%173 = OpFunctionCall %ulong %5 %171 %172
-OpStore %53 %173
-%174 = OpLoad %uint %52
-%175 = OpISub %uint %174 %uint_2147483648
-OpStore %54 %175
-%176 = OpLoad %ulong %53
-%177 = OpLoad %uint %54
-%178 = OpFunctionCall %ulong %5 %176 %177
-OpStore %55 %178
-%179 = OpLoad %ulong %55
-%180 = OpLoad %ulong %31
-%181 = OpFunctionCall %ulong %6 %179 %180
-OpStore %56 %181
-%182 = OpLoad %ulong %56
-%183 = OpLoad %ulong %33
-%184 = OpFunctionCall %ulong %6 %182 %183
-OpStore %57 %184
-%185 = OpLoad %ulong %33
-%186 = OpIAdd %ulong %185 %ulong_2147483647
-OpStore %58 %186
-%187 = OpLoad %ulong %57
-%188 = OpLoad %ulong %58
-%189 = OpFunctionCall %ulong %6 %187 %188
-OpStore %59 %189
-%190 = OpLoad %ulong %58
-%191 = OpISub %ulong %190 %ulong_9223372036854775808
-OpStore %60 %191
-%192 = OpLoad %ulong %59
-%193 = OpLoad %ulong %60
-%194 = OpFunctionCall %ulong %6 %192 %193
-OpStore %61 %194
-%195 = OpLoad %ulong %61
-OpReturnValue %195
-OpFunctionEnd
-%2 = OpFunction %ulong None %196
-%197 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %199
-%200 = OpFunctionParameter %ulong
-%201 = OpFunctionParameter %ulong
-%202 = OpLabel
-%208 = OpVariable %_ptr_Function_ulong Function
+%770 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%138 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_uint Function
+%143 = OpVariable %_ptr_Function_uint Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_bool Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_bool Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
 %209 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
 %212 = OpVariable %_ptr_Function_ulong Function
 %213 = OpVariable %_ptr_Function_ulong Function
 %214 = OpVariable %_ptr_Function_ulong Function
 %215 = OpVariable %_ptr_Function_ulong Function
 %216 = OpVariable %_ptr_Function_ulong Function
 %217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_bool Function
 %219 = OpVariable %_ptr_Function_ulong Function
-OpStore %208 %200
-OpStore %209 %201
-%220 = OpLoad %ulong %208
-OpStore %218 %220
-OpStore %219 %ulong_0
-OpBranch %203
-%203 = OpLabel
-%222 = OpLoad %ulong %219
-%224 = OpULessThan %bool %222 %ulong_8
-OpStore %211 %224
-%225 = OpLoad %bool %211
-OpLoopMerge %205 %206 None
-OpBranchConditional %225 %204 %205
-%205 = OpLabel
-%226 = OpLoad %ulong %218
-OpReturnValue %226
-%204 = OpLabel
-%227 = OpLoad %ulong %219
-%228 = OpIMul %ulong %227 %ulong_8
-OpStore %212 %228
-%229 = OpLoad %ulong %209
-%230 = OpLoad %ulong %212
-%231 = OpShiftRightLogical %ulong %229 %230
-OpStore %213 %231
-%232 = OpLoad %ulong %213
-%234 = OpBitwiseAnd %ulong %232 %ulong_255
-OpStore %214 %234
-%235 = OpLoad %ulong %218
-%236 = OpLoad %ulong %214
-%237 = OpBitwiseXor %ulong %235 %236
-OpStore %215 %237
-%238 = OpLoad %ulong %215
-%240 = OpIMul %ulong %238 %ulong_1099511628211
-OpStore %216 %240
-%241 = OpLoad %ulong %219
-%243 = OpIAdd %ulong %241 %ulong_1
-OpStore %217 %243
-%244 = OpLoad %ulong %216
-OpStore %218 %244
-%245 = OpLoad %ulong %217
-OpStore %219 %245
-OpBranch %206
-%206 = OpLabel
-OpBranch %203
-OpFunctionEnd
-%4 = OpFunction %ulong None %246
-%247 = OpFunctionParameter %ulong
-%248 = OpFunctionParameter %uint
-%249 = OpLabel
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_bool Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_bool Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_bool Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_bool Function
 %256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_uint Function
+%257 = OpVariable %_ptr_Function_ulong Function
 %258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_bool Function
+%259 = OpVariable %_ptr_Function_ulong Function
 %260 = OpVariable %_ptr_Function_ulong Function
 %261 = OpVariable %_ptr_Function_ulong Function
 %262 = OpVariable %_ptr_Function_ulong Function
 %263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_bool Function
 %265 = OpVariable %_ptr_Function_ulong Function
 %266 = OpVariable %_ptr_Function_ulong Function
 %267 = OpVariable %_ptr_Function_ulong Function
-OpStore %256 %247
-OpStore %257 %248
-%268 = OpLoad %uint %257
-%269 = OpUConvert %ulong %268
-OpStore %258 %269
-OpBranch %250
-%250 = OpLabel
-%270 = OpLoad %ulong %256
-OpStore %266 %270
-OpStore %267 %ulong_0
-OpBranch %251
-%251 = OpLabel
-%271 = OpLoad %ulong %267
-%272 = OpULessThan %bool %271 %ulong_8
-OpStore %259 %272
-%273 = OpLoad %bool %259
-OpLoopMerge %253 %255 None
-OpBranchConditional %273 %252 %253
-%253 = OpLabel
-OpBranch %254
-%254 = OpLabel
-%274 = OpLoad %ulong %266
-OpReturnValue %274
-%252 = OpLabel
-%275 = OpLoad %ulong %267
-%276 = OpIMul %ulong %275 %ulong_8
-OpStore %260 %276
-%277 = OpLoad %ulong %258
-%278 = OpLoad %ulong %260
-%279 = OpShiftRightLogical %ulong %277 %278
-OpStore %261 %279
-%280 = OpLoad %ulong %261
-%281 = OpBitwiseAnd %ulong %280 %ulong_255
-OpStore %262 %281
-%282 = OpLoad %ulong %266
-%283 = OpLoad %ulong %262
-%284 = OpBitwiseXor %ulong %282 %283
-OpStore %263 %284
-%285 = OpLoad %ulong %263
-%286 = OpIMul %ulong %285 %ulong_1099511628211
-OpStore %264 %286
-%287 = OpLoad %ulong %267
-%288 = OpIAdd %ulong %287 %ulong_1
-OpStore %265 %288
-%289 = OpLoad %ulong %264
-OpStore %266 %289
-%290 = OpLoad %ulong %265
-OpStore %267 %290
-OpBranch %255
-%255 = OpLabel
-OpBranch %251
-OpFunctionEnd
-%5 = OpFunction %ulong None %246
-%291 = OpFunctionParameter %ulong
-%292 = OpFunctionParameter %uint
-%293 = OpLabel
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_uint Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_bool Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_bool Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_bool Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_bool Function
+%301 = OpVariable %_ptr_Function_ulong Function
 %302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_bool Function
+%303 = OpVariable %_ptr_Function_ulong Function
 %304 = OpVariable %_ptr_Function_ulong Function
 %305 = OpVariable %_ptr_Function_ulong Function
 %306 = OpVariable %_ptr_Function_ulong Function
 %307 = OpVariable %_ptr_Function_ulong Function
 %308 = OpVariable %_ptr_Function_ulong Function
-%309 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_bool Function
 %310 = OpVariable %_ptr_Function_ulong Function
 %311 = OpVariable %_ptr_Function_ulong Function
-OpStore %300 %291
-OpStore %301 %292
-%312 = OpLoad %uint %301
-%313 = OpSConvert %ulong %312
-OpStore %302 %313
-OpBranch %294
-%294 = OpLabel
-%314 = OpLoad %ulong %300
-OpStore %310 %314
-OpStore %311 %ulong_0
-OpBranch %295
-%295 = OpLabel
-%315 = OpLoad %ulong %311
-%316 = OpULessThan %bool %315 %ulong_8
-OpStore %303 %316
-%317 = OpLoad %bool %303
-OpLoopMerge %297 %299 None
-OpBranchConditional %317 %296 %297
-%297 = OpLabel
-OpBranch %298
-%298 = OpLabel
-%318 = OpLoad %ulong %310
-OpReturnValue %318
-%296 = OpLabel
-%319 = OpLoad %ulong %311
-%320 = OpIMul %ulong %319 %ulong_8
-OpStore %304 %320
-%321 = OpLoad %ulong %302
-%322 = OpLoad %ulong %304
-%323 = OpShiftRightLogical %ulong %321 %322
-OpStore %305 %323
-%324 = OpLoad %ulong %305
-%325 = OpBitwiseAnd %ulong %324 %ulong_255
-OpStore %306 %325
-%326 = OpLoad %ulong %310
-%327 = OpLoad %ulong %306
-%328 = OpBitwiseXor %ulong %326 %327
-OpStore %307 %328
-%329 = OpLoad %ulong %307
-%330 = OpIMul %ulong %329 %ulong_1099511628211
-OpStore %308 %330
-%331 = OpLoad %ulong %311
-%332 = OpIAdd %ulong %331 %ulong_1
-OpStore %309 %332
-%333 = OpLoad %ulong %308
-OpStore %310 %333
-%334 = OpLoad %ulong %309
-OpStore %311 %334
-OpBranch %299
-%299 = OpLabel
-OpBranch %295
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+OpStore %138 %5
+OpBranch %7
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%330 = OpLoad %ulong %138
+%331 = OpUConvert %uint %330
+OpStore %140 %331
+%332 = OpLoad %uint %140
+%334 = OpIAdd %uint %332 %uint_2047
+OpStore %141 %334
+OpBranch %9
+%9 = OpLabel
+%335 = OpLoad %uint %141
+%336 = OpUConvert %ulong %335
+OpStore %166 %336
+OpBranch %11
+%11 = OpLabel
+OpStore %175 %ulong_14695981039346656037
+OpStore %176 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%339 = OpLoad %ulong %176
+%341 = OpULessThan %bool %339 %ulong_8
+OpStore %168 %341
+%342 = OpLoad %bool %168
+OpLoopMerge %14 %134 None
+OpBranchConditional %342 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%343 = OpLoad %uint %141
+%345 = OpIAdd %uint %343 %uint_2048
+OpStore %142 %345
+OpBranch %16
+%16 = OpLabel
+%346 = OpLoad %uint %142
+%347 = OpUConvert %ulong %346
+OpStore %177 %347
+OpBranch %18
+%18 = OpLabel
+%348 = OpLoad %ulong %175
+OpStore %185 %348
+OpStore %186 %ulong_0
+OpBranch %19
+%19 = OpLabel
+%349 = OpLoad %ulong %186
+%350 = OpULessThan %bool %349 %ulong_8
+OpStore %178 %350
+%351 = OpLoad %bool %178
+OpLoopMerge %21 %133 None
+OpBranchConditional %351 %20 %21
+%21 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%352 = OpLoad %uint %142
+%354 = OpIAdd %uint %352 %uint_4095
+OpStore %143 %354
+OpBranch %23
+%23 = OpLabel
+%355 = OpLoad %uint %143
+%356 = OpUConvert %ulong %355
+OpStore %187 %356
+OpBranch %25
+%25 = OpLabel
+%357 = OpLoad %ulong %185
+OpStore %195 %357
+OpStore %196 %ulong_0
+OpBranch %26
+%26 = OpLabel
+%358 = OpLoad %ulong %196
+%359 = OpULessThan %bool %358 %ulong_8
+OpStore %188 %359
+%360 = OpLoad %bool %188
+OpLoopMerge %28 %132 None
+OpBranchConditional %360 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+OpBranch %24
+%24 = OpLabel
+%361 = OpLoad %uint %143
+%363 = OpIAdd %uint %361 %uint_4096
+OpStore %144 %363
+OpBranch %30
+%30 = OpLabel
+%364 = OpLoad %uint %144
+%365 = OpUConvert %ulong %364
+OpStore %197 %365
+OpBranch %32
+%32 = OpLabel
+%366 = OpLoad %ulong %195
+OpStore %205 %366
+OpStore %206 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%367 = OpLoad %ulong %206
+%368 = OpULessThan %bool %367 %ulong_8
+OpStore %198 %368
+%369 = OpLoad %bool %198
+OpLoopMerge %35 %131 None
+OpBranchConditional %369 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%370 = OpLoad %uint %144
+%372 = OpIAdd %uint %370 %uint_2147483647
+OpStore %145 %372
+OpBranch %37
+%37 = OpLabel
+%373 = OpLoad %uint %145
+%374 = OpUConvert %ulong %373
+OpStore %207 %374
+OpBranch %39
+%39 = OpLabel
+%375 = OpLoad %ulong %205
+OpStore %215 %375
+OpStore %216 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%376 = OpLoad %ulong %216
+%377 = OpULessThan %bool %376 %ulong_8
+OpStore %208 %377
+%378 = OpLoad %bool %208
+OpLoopMerge %42 %130 None
+OpBranchConditional %378 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%379 = OpLoad %uint %145
+%381 = OpIAdd %uint %379 %uint_2147483648
+OpStore %146 %381
+OpBranch %44
+%44 = OpLabel
+%382 = OpLoad %uint %146
+%383 = OpUConvert %ulong %382
+OpStore %217 %383
+OpBranch %46
+%46 = OpLabel
+%384 = OpLoad %ulong %215
+OpStore %225 %384
+OpStore %226 %ulong_0
+OpBranch %47
+%47 = OpLabel
+%385 = OpLoad %ulong %226
+%386 = OpULessThan %bool %385 %ulong_8
+OpStore %218 %386
+%387 = OpLoad %bool %218
+OpLoopMerge %49 %129 None
+OpBranchConditional %387 %48 %49
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%388 = OpLoad %uint %146
+%390 = OpIAdd %uint %388 %uint_4294967295
+OpStore %147 %390
+OpBranch %51
+%51 = OpLabel
+%391 = OpLoad %uint %147
+%392 = OpUConvert %ulong %391
+OpStore %227 %392
+OpBranch %53
+%53 = OpLabel
+%393 = OpLoad %ulong %225
+OpStore %235 %393
+OpStore %236 %ulong_0
+OpBranch %54
+%54 = OpLabel
+%394 = OpLoad %ulong %236
+%395 = OpULessThan %bool %394 %ulong_8
+OpStore %228 %395
+%396 = OpLoad %bool %228
+OpLoopMerge %56 %128 None
+OpBranchConditional %396 %55 %56
+%56 = OpLabel
+OpBranch %57
+%57 = OpLabel
+OpBranch %52
+%52 = OpLabel
+%397 = OpLoad %ulong %138
+%399 = OpIAdd %ulong %397 %ulong_2047
+OpStore %148 %399
+OpBranch %58
+%58 = OpLabel
+%400 = OpLoad %ulong %235
+OpStore %244 %400
+OpStore %245 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%401 = OpLoad %ulong %245
+%402 = OpULessThan %bool %401 %ulong_8
+OpStore %237 %402
+%403 = OpLoad %bool %237
+OpLoopMerge %61 %127 None
+OpBranchConditional %403 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%404 = OpLoad %ulong %148
+%406 = OpISub %ulong %404 %ulong_2048
+OpStore %149 %406
+OpBranch %63
+%63 = OpLabel
+%407 = OpLoad %ulong %244
+OpStore %253 %407
+OpStore %254 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%408 = OpLoad %ulong %254
+%409 = OpULessThan %bool %408 %ulong_8
+OpStore %246 %409
+%410 = OpLoad %bool %246
+OpLoopMerge %66 %126 None
+OpBranchConditional %410 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%411 = OpLoad %ulong %149
+%413 = OpIAdd %ulong %411 %ulong_16773120
+OpStore %150 %413
+OpBranch %68
+%68 = OpLabel
+%414 = OpLoad %ulong %253
+OpStore %262 %414
+OpStore %263 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%415 = OpLoad %ulong %263
+%416 = OpULessThan %bool %415 %ulong_8
+OpStore %255 %416
+%417 = OpLoad %bool %255
+OpLoopMerge %71 %125 None
+OpBranchConditional %417 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%418 = OpLoad %ulong %150
+%420 = OpIAdd %ulong %418 %ulong_16777215
+OpStore %151 %420
+OpBranch %73
+%73 = OpLabel
+%421 = OpLoad %ulong %262
+OpStore %271 %421
+OpStore %272 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%422 = OpLoad %ulong %272
+%423 = OpULessThan %bool %422 %ulong_8
+OpStore %264 %423
+%424 = OpLoad %bool %264
+OpLoopMerge %76 %124 None
+OpBranchConditional %424 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%425 = OpLoad %ulong %151
+%427 = OpIAdd %ulong %425 %ulong_2147483647
+OpStore %152 %427
+OpBranch %78
+%78 = OpLabel
+%428 = OpLoad %ulong %271
+OpStore %280 %428
+OpStore %281 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%429 = OpLoad %ulong %281
+%430 = OpULessThan %bool %429 %ulong_8
+OpStore %273 %430
+%431 = OpLoad %bool %273
+OpLoopMerge %81 %123 None
+OpBranchConditional %431 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+%432 = OpLoad %ulong %152
+%434 = OpIAdd %ulong %432 %ulong_2147483648
+OpStore %153 %434
+OpBranch %83
+%83 = OpLabel
+%435 = OpLoad %ulong %280
+OpStore %289 %435
+OpStore %290 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%436 = OpLoad %ulong %290
+%437 = OpULessThan %bool %436 %ulong_8
+OpStore %282 %437
+%438 = OpLoad %bool %282
+OpLoopMerge %86 %122 None
+OpBranchConditional %438 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+%439 = OpLoad %ulong %153
+%441 = OpIAdd %ulong %439 %ulong_4294967295
+OpStore %154 %441
+OpBranch %88
+%88 = OpLabel
+%442 = OpLoad %ulong %289
+OpStore %298 %442
+OpStore %299 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%443 = OpLoad %ulong %299
+%444 = OpULessThan %bool %443 %ulong_8
+OpStore %291 %444
+%445 = OpLoad %bool %291
+OpLoopMerge %91 %121 None
+OpBranchConditional %445 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%446 = OpLoad %ulong %154
+%448 = OpIAdd %ulong %446 %ulong_4294967296
+OpStore %155 %448
+OpBranch %93
+%93 = OpLabel
+%449 = OpLoad %ulong %298
+OpStore %307 %449
+OpStore %308 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%450 = OpLoad %ulong %308
+%451 = OpULessThan %bool %450 %ulong_8
+OpStore %300 %451
+%452 = OpLoad %bool %300
+OpLoopMerge %96 %120 None
+OpBranchConditional %452 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%453 = OpLoad %ulong %155
+%455 = OpIAdd %ulong %453 %ulong_9223372036854775808
+OpStore %156 %455
+OpBranch %98
+%98 = OpLabel
+%456 = OpLoad %ulong %307
+OpStore %316 %456
+OpStore %317 %ulong_0
+OpBranch %99
+%99 = OpLabel
+%457 = OpLoad %ulong %317
+%458 = OpULessThan %bool %457 %ulong_8
+OpStore %309 %458
+%459 = OpLoad %bool %309
+OpLoopMerge %101 %119 None
+OpBranchConditional %459 %100 %101
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%460 = OpLoad %ulong %138
+%461 = OpUConvert %uint %460
+OpStore %157 %461
+%462 = OpLoad %uint %157
+%463 = OpIAdd %uint %462 %uint_2047
+OpStore %158 %463
+OpBranch %103
+%103 = OpLabel
+%464 = OpLoad %uint %158
+%465 = OpSConvert %ulong %464
+OpStore %318 %465
+%466 = OpLoad %ulong %316
+%467 = OpLoad %ulong %318
+%468 = OpFunctionCall %ulong %2 %466 %467
+OpStore %319 %468
+OpBranch %104
+%104 = OpLabel
+%469 = OpLoad %uint %158
+%470 = OpISub %uint %469 %uint_2048
+OpStore %159 %470
+OpBranch %105
+%105 = OpLabel
+%471 = OpLoad %uint %159
+%472 = OpSConvert %ulong %471
+OpStore %320 %472
+%473 = OpLoad %ulong %319
+%474 = OpLoad %ulong %320
+%475 = OpFunctionCall %ulong %2 %473 %474
+OpStore %321 %475
+OpBranch %106
+%106 = OpLabel
+%476 = OpLoad %uint %159
+%477 = OpIAdd %uint %476 %uint_2147483647
+OpStore %160 %477
+OpBranch %107
+%107 = OpLabel
+%478 = OpLoad %uint %160
+%479 = OpSConvert %ulong %478
+OpStore %322 %479
+%480 = OpLoad %ulong %321
+%481 = OpLoad %ulong %322
+%482 = OpFunctionCall %ulong %2 %480 %481
+OpStore %323 %482
+OpBranch %108
+%108 = OpLabel
+%483 = OpLoad %uint %160
+%484 = OpISub %uint %483 %uint_2147483648
+OpStore %161 %484
+OpBranch %109
+%109 = OpLabel
+%485 = OpLoad %uint %161
+%486 = OpSConvert %ulong %485
+OpStore %324 %486
+%487 = OpLoad %ulong %323
+%488 = OpLoad %ulong %324
+%489 = OpFunctionCall %ulong %2 %487 %488
+OpStore %325 %489
+OpBranch %110
+%110 = OpLabel
+%490 = OpLoad %ulong %138
+%491 = OpIAdd %ulong %490 %ulong_2047
+OpStore %162 %491
+OpBranch %111
+%111 = OpLabel
+%492 = OpLoad %ulong %325
+%493 = OpLoad %ulong %162
+%494 = OpFunctionCall %ulong %2 %492 %493
+OpStore %326 %494
+OpBranch %112
+%112 = OpLabel
+%495 = OpLoad %ulong %162
+%496 = OpISub %ulong %495 %ulong_2048
+OpStore %163 %496
+OpBranch %113
+%113 = OpLabel
+%497 = OpLoad %ulong %326
+%498 = OpLoad %ulong %163
+%499 = OpFunctionCall %ulong %2 %497 %498
+OpStore %327 %499
+OpBranch %114
+%114 = OpLabel
+%500 = OpLoad %ulong %163
+%501 = OpIAdd %ulong %500 %ulong_2147483647
+OpStore %164 %501
+OpBranch %115
+%115 = OpLabel
+%502 = OpLoad %ulong %327
+%503 = OpLoad %ulong %164
+%504 = OpFunctionCall %ulong %2 %502 %503
+OpStore %328 %504
+OpBranch %116
+%116 = OpLabel
+%505 = OpLoad %ulong %164
+%506 = OpISub %ulong %505 %ulong_9223372036854775808
+OpStore %165 %506
+OpBranch %117
+%117 = OpLabel
+%507 = OpLoad %ulong %328
+%508 = OpLoad %ulong %165
+%509 = OpFunctionCall %ulong %2 %507 %508
+OpStore %329 %509
+OpBranch %118
+%118 = OpLabel
+%510 = OpLoad %ulong %329
+OpReturnValue %510
+%100 = OpLabel
+%511 = OpLoad %ulong %317
+%512 = OpIMul %ulong %511 %ulong_8
+OpStore %310 %512
+%513 = OpLoad %ulong %156
+%514 = OpLoad %ulong %310
+%515 = OpShiftRightLogical %ulong %513 %514
+OpStore %311 %515
+%516 = OpLoad %ulong %311
+%518 = OpBitwiseAnd %ulong %516 %ulong_255
+OpStore %312 %518
+%519 = OpLoad %ulong %316
+%520 = OpLoad %ulong %312
+%521 = OpBitwiseXor %ulong %519 %520
+OpStore %313 %521
+%522 = OpLoad %ulong %313
+%524 = OpIMul %ulong %522 %ulong_1099511628211
+OpStore %314 %524
+%525 = OpLoad %ulong %317
+%527 = OpIAdd %ulong %525 %ulong_1
+OpStore %315 %527
+%528 = OpLoad %ulong %314
+OpStore %316 %528
+%529 = OpLoad %ulong %315
+OpStore %317 %529
+OpBranch %119
+%95 = OpLabel
+%530 = OpLoad %ulong %308
+%531 = OpIMul %ulong %530 %ulong_8
+OpStore %301 %531
+%532 = OpLoad %ulong %155
+%533 = OpLoad %ulong %301
+%534 = OpShiftRightLogical %ulong %532 %533
+OpStore %302 %534
+%535 = OpLoad %ulong %302
+%536 = OpBitwiseAnd %ulong %535 %ulong_255
+OpStore %303 %536
+%537 = OpLoad %ulong %307
+%538 = OpLoad %ulong %303
+%539 = OpBitwiseXor %ulong %537 %538
+OpStore %304 %539
+%540 = OpLoad %ulong %304
+%541 = OpIMul %ulong %540 %ulong_1099511628211
+OpStore %305 %541
+%542 = OpLoad %ulong %308
+%543 = OpIAdd %ulong %542 %ulong_1
+OpStore %306 %543
+%544 = OpLoad %ulong %305
+OpStore %307 %544
+%545 = OpLoad %ulong %306
+OpStore %308 %545
+OpBranch %120
+%90 = OpLabel
+%546 = OpLoad %ulong %299
+%547 = OpIMul %ulong %546 %ulong_8
+OpStore %292 %547
+%548 = OpLoad %ulong %154
+%549 = OpLoad %ulong %292
+%550 = OpShiftRightLogical %ulong %548 %549
+OpStore %293 %550
+%551 = OpLoad %ulong %293
+%552 = OpBitwiseAnd %ulong %551 %ulong_255
+OpStore %294 %552
+%553 = OpLoad %ulong %298
+%554 = OpLoad %ulong %294
+%555 = OpBitwiseXor %ulong %553 %554
+OpStore %295 %555
+%556 = OpLoad %ulong %295
+%557 = OpIMul %ulong %556 %ulong_1099511628211
+OpStore %296 %557
+%558 = OpLoad %ulong %299
+%559 = OpIAdd %ulong %558 %ulong_1
+OpStore %297 %559
+%560 = OpLoad %ulong %296
+OpStore %298 %560
+%561 = OpLoad %ulong %297
+OpStore %299 %561
+OpBranch %121
+%85 = OpLabel
+%562 = OpLoad %ulong %290
+%563 = OpIMul %ulong %562 %ulong_8
+OpStore %283 %563
+%564 = OpLoad %ulong %153
+%565 = OpLoad %ulong %283
+%566 = OpShiftRightLogical %ulong %564 %565
+OpStore %284 %566
+%567 = OpLoad %ulong %284
+%568 = OpBitwiseAnd %ulong %567 %ulong_255
+OpStore %285 %568
+%569 = OpLoad %ulong %289
+%570 = OpLoad %ulong %285
+%571 = OpBitwiseXor %ulong %569 %570
+OpStore %286 %571
+%572 = OpLoad %ulong %286
+%573 = OpIMul %ulong %572 %ulong_1099511628211
+OpStore %287 %573
+%574 = OpLoad %ulong %290
+%575 = OpIAdd %ulong %574 %ulong_1
+OpStore %288 %575
+%576 = OpLoad %ulong %287
+OpStore %289 %576
+%577 = OpLoad %ulong %288
+OpStore %290 %577
+OpBranch %122
+%80 = OpLabel
+%578 = OpLoad %ulong %281
+%579 = OpIMul %ulong %578 %ulong_8
+OpStore %274 %579
+%580 = OpLoad %ulong %152
+%581 = OpLoad %ulong %274
+%582 = OpShiftRightLogical %ulong %580 %581
+OpStore %275 %582
+%583 = OpLoad %ulong %275
+%584 = OpBitwiseAnd %ulong %583 %ulong_255
+OpStore %276 %584
+%585 = OpLoad %ulong %280
+%586 = OpLoad %ulong %276
+%587 = OpBitwiseXor %ulong %585 %586
+OpStore %277 %587
+%588 = OpLoad %ulong %277
+%589 = OpIMul %ulong %588 %ulong_1099511628211
+OpStore %278 %589
+%590 = OpLoad %ulong %281
+%591 = OpIAdd %ulong %590 %ulong_1
+OpStore %279 %591
+%592 = OpLoad %ulong %278
+OpStore %280 %592
+%593 = OpLoad %ulong %279
+OpStore %281 %593
+OpBranch %123
+%75 = OpLabel
+%594 = OpLoad %ulong %272
+%595 = OpIMul %ulong %594 %ulong_8
+OpStore %265 %595
+%596 = OpLoad %ulong %151
+%597 = OpLoad %ulong %265
+%598 = OpShiftRightLogical %ulong %596 %597
+OpStore %266 %598
+%599 = OpLoad %ulong %266
+%600 = OpBitwiseAnd %ulong %599 %ulong_255
+OpStore %267 %600
+%601 = OpLoad %ulong %271
+%602 = OpLoad %ulong %267
+%603 = OpBitwiseXor %ulong %601 %602
+OpStore %268 %603
+%604 = OpLoad %ulong %268
+%605 = OpIMul %ulong %604 %ulong_1099511628211
+OpStore %269 %605
+%606 = OpLoad %ulong %272
+%607 = OpIAdd %ulong %606 %ulong_1
+OpStore %270 %607
+%608 = OpLoad %ulong %269
+OpStore %271 %608
+%609 = OpLoad %ulong %270
+OpStore %272 %609
+OpBranch %124
+%70 = OpLabel
+%610 = OpLoad %ulong %263
+%611 = OpIMul %ulong %610 %ulong_8
+OpStore %256 %611
+%612 = OpLoad %ulong %150
+%613 = OpLoad %ulong %256
+%614 = OpShiftRightLogical %ulong %612 %613
+OpStore %257 %614
+%615 = OpLoad %ulong %257
+%616 = OpBitwiseAnd %ulong %615 %ulong_255
+OpStore %258 %616
+%617 = OpLoad %ulong %262
+%618 = OpLoad %ulong %258
+%619 = OpBitwiseXor %ulong %617 %618
+OpStore %259 %619
+%620 = OpLoad %ulong %259
+%621 = OpIMul %ulong %620 %ulong_1099511628211
+OpStore %260 %621
+%622 = OpLoad %ulong %263
+%623 = OpIAdd %ulong %622 %ulong_1
+OpStore %261 %623
+%624 = OpLoad %ulong %260
+OpStore %262 %624
+%625 = OpLoad %ulong %261
+OpStore %263 %625
+OpBranch %125
+%65 = OpLabel
+%626 = OpLoad %ulong %254
+%627 = OpIMul %ulong %626 %ulong_8
+OpStore %247 %627
+%628 = OpLoad %ulong %149
+%629 = OpLoad %ulong %247
+%630 = OpShiftRightLogical %ulong %628 %629
+OpStore %248 %630
+%631 = OpLoad %ulong %248
+%632 = OpBitwiseAnd %ulong %631 %ulong_255
+OpStore %249 %632
+%633 = OpLoad %ulong %253
+%634 = OpLoad %ulong %249
+%635 = OpBitwiseXor %ulong %633 %634
+OpStore %250 %635
+%636 = OpLoad %ulong %250
+%637 = OpIMul %ulong %636 %ulong_1099511628211
+OpStore %251 %637
+%638 = OpLoad %ulong %254
+%639 = OpIAdd %ulong %638 %ulong_1
+OpStore %252 %639
+%640 = OpLoad %ulong %251
+OpStore %253 %640
+%641 = OpLoad %ulong %252
+OpStore %254 %641
+OpBranch %126
+%60 = OpLabel
+%642 = OpLoad %ulong %245
+%643 = OpIMul %ulong %642 %ulong_8
+OpStore %238 %643
+%644 = OpLoad %ulong %148
+%645 = OpLoad %ulong %238
+%646 = OpShiftRightLogical %ulong %644 %645
+OpStore %239 %646
+%647 = OpLoad %ulong %239
+%648 = OpBitwiseAnd %ulong %647 %ulong_255
+OpStore %240 %648
+%649 = OpLoad %ulong %244
+%650 = OpLoad %ulong %240
+%651 = OpBitwiseXor %ulong %649 %650
+OpStore %241 %651
+%652 = OpLoad %ulong %241
+%653 = OpIMul %ulong %652 %ulong_1099511628211
+OpStore %242 %653
+%654 = OpLoad %ulong %245
+%655 = OpIAdd %ulong %654 %ulong_1
+OpStore %243 %655
+%656 = OpLoad %ulong %242
+OpStore %244 %656
+%657 = OpLoad %ulong %243
+OpStore %245 %657
+OpBranch %127
+%55 = OpLabel
+%658 = OpLoad %ulong %236
+%659 = OpIMul %ulong %658 %ulong_8
+OpStore %229 %659
+%660 = OpLoad %ulong %227
+%661 = OpLoad %ulong %229
+%662 = OpShiftRightLogical %ulong %660 %661
+OpStore %230 %662
+%663 = OpLoad %ulong %230
+%664 = OpBitwiseAnd %ulong %663 %ulong_255
+OpStore %231 %664
+%665 = OpLoad %ulong %235
+%666 = OpLoad %ulong %231
+%667 = OpBitwiseXor %ulong %665 %666
+OpStore %232 %667
+%668 = OpLoad %ulong %232
+%669 = OpIMul %ulong %668 %ulong_1099511628211
+OpStore %233 %669
+%670 = OpLoad %ulong %236
+%671 = OpIAdd %ulong %670 %ulong_1
+OpStore %234 %671
+%672 = OpLoad %ulong %233
+OpStore %235 %672
+%673 = OpLoad %ulong %234
+OpStore %236 %673
+OpBranch %128
+%48 = OpLabel
+%674 = OpLoad %ulong %226
+%675 = OpIMul %ulong %674 %ulong_8
+OpStore %219 %675
+%676 = OpLoad %ulong %217
+%677 = OpLoad %ulong %219
+%678 = OpShiftRightLogical %ulong %676 %677
+OpStore %220 %678
+%679 = OpLoad %ulong %220
+%680 = OpBitwiseAnd %ulong %679 %ulong_255
+OpStore %221 %680
+%681 = OpLoad %ulong %225
+%682 = OpLoad %ulong %221
+%683 = OpBitwiseXor %ulong %681 %682
+OpStore %222 %683
+%684 = OpLoad %ulong %222
+%685 = OpIMul %ulong %684 %ulong_1099511628211
+OpStore %223 %685
+%686 = OpLoad %ulong %226
+%687 = OpIAdd %ulong %686 %ulong_1
+OpStore %224 %687
+%688 = OpLoad %ulong %223
+OpStore %225 %688
+%689 = OpLoad %ulong %224
+OpStore %226 %689
+OpBranch %129
+%41 = OpLabel
+%690 = OpLoad %ulong %216
+%691 = OpIMul %ulong %690 %ulong_8
+OpStore %209 %691
+%692 = OpLoad %ulong %207
+%693 = OpLoad %ulong %209
+%694 = OpShiftRightLogical %ulong %692 %693
+OpStore %210 %694
+%695 = OpLoad %ulong %210
+%696 = OpBitwiseAnd %ulong %695 %ulong_255
+OpStore %211 %696
+%697 = OpLoad %ulong %215
+%698 = OpLoad %ulong %211
+%699 = OpBitwiseXor %ulong %697 %698
+OpStore %212 %699
+%700 = OpLoad %ulong %212
+%701 = OpIMul %ulong %700 %ulong_1099511628211
+OpStore %213 %701
+%702 = OpLoad %ulong %216
+%703 = OpIAdd %ulong %702 %ulong_1
+OpStore %214 %703
+%704 = OpLoad %ulong %213
+OpStore %215 %704
+%705 = OpLoad %ulong %214
+OpStore %216 %705
+OpBranch %130
+%34 = OpLabel
+%706 = OpLoad %ulong %206
+%707 = OpIMul %ulong %706 %ulong_8
+OpStore %199 %707
+%708 = OpLoad %ulong %197
+%709 = OpLoad %ulong %199
+%710 = OpShiftRightLogical %ulong %708 %709
+OpStore %200 %710
+%711 = OpLoad %ulong %200
+%712 = OpBitwiseAnd %ulong %711 %ulong_255
+OpStore %201 %712
+%713 = OpLoad %ulong %205
+%714 = OpLoad %ulong %201
+%715 = OpBitwiseXor %ulong %713 %714
+OpStore %202 %715
+%716 = OpLoad %ulong %202
+%717 = OpIMul %ulong %716 %ulong_1099511628211
+OpStore %203 %717
+%718 = OpLoad %ulong %206
+%719 = OpIAdd %ulong %718 %ulong_1
+OpStore %204 %719
+%720 = OpLoad %ulong %203
+OpStore %205 %720
+%721 = OpLoad %ulong %204
+OpStore %206 %721
+OpBranch %131
+%27 = OpLabel
+%722 = OpLoad %ulong %196
+%723 = OpIMul %ulong %722 %ulong_8
+OpStore %189 %723
+%724 = OpLoad %ulong %187
+%725 = OpLoad %ulong %189
+%726 = OpShiftRightLogical %ulong %724 %725
+OpStore %190 %726
+%727 = OpLoad %ulong %190
+%728 = OpBitwiseAnd %ulong %727 %ulong_255
+OpStore %191 %728
+%729 = OpLoad %ulong %195
+%730 = OpLoad %ulong %191
+%731 = OpBitwiseXor %ulong %729 %730
+OpStore %192 %731
+%732 = OpLoad %ulong %192
+%733 = OpIMul %ulong %732 %ulong_1099511628211
+OpStore %193 %733
+%734 = OpLoad %ulong %196
+%735 = OpIAdd %ulong %734 %ulong_1
+OpStore %194 %735
+%736 = OpLoad %ulong %193
+OpStore %195 %736
+%737 = OpLoad %ulong %194
+OpStore %196 %737
+OpBranch %132
+%20 = OpLabel
+%738 = OpLoad %ulong %186
+%739 = OpIMul %ulong %738 %ulong_8
+OpStore %179 %739
+%740 = OpLoad %ulong %177
+%741 = OpLoad %ulong %179
+%742 = OpShiftRightLogical %ulong %740 %741
+OpStore %180 %742
+%743 = OpLoad %ulong %180
+%744 = OpBitwiseAnd %ulong %743 %ulong_255
+OpStore %181 %744
+%745 = OpLoad %ulong %185
+%746 = OpLoad %ulong %181
+%747 = OpBitwiseXor %ulong %745 %746
+OpStore %182 %747
+%748 = OpLoad %ulong %182
+%749 = OpIMul %ulong %748 %ulong_1099511628211
+OpStore %183 %749
+%750 = OpLoad %ulong %186
+%751 = OpIAdd %ulong %750 %ulong_1
+OpStore %184 %751
+%752 = OpLoad %ulong %183
+OpStore %185 %752
+%753 = OpLoad %ulong %184
+OpStore %186 %753
+OpBranch %133
+%13 = OpLabel
+%754 = OpLoad %ulong %176
+%755 = OpIMul %ulong %754 %ulong_8
+OpStore %169 %755
+%756 = OpLoad %ulong %166
+%757 = OpLoad %ulong %169
+%758 = OpShiftRightLogical %ulong %756 %757
+OpStore %170 %758
+%759 = OpLoad %ulong %170
+%760 = OpBitwiseAnd %ulong %759 %ulong_255
+OpStore %171 %760
+%761 = OpLoad %ulong %175
+%762 = OpLoad %ulong %171
+%763 = OpBitwiseXor %ulong %761 %762
+OpStore %172 %763
+%764 = OpLoad %ulong %172
+%765 = OpIMul %ulong %764 %ulong_1099511628211
+OpStore %173 %765
+%766 = OpLoad %ulong %176
+%767 = OpIAdd %ulong %766 %ulong_1
+OpStore %174 %767
+%768 = OpLoad %ulong %173
+OpStore %175 %768
+%769 = OpLoad %ulong %174
+OpStore %176 %769
+OpBranch %134
+%119 = OpLabel
+OpBranch %99
+%120 = OpLabel
+OpBranch %94
+%121 = OpLabel
+OpBranch %89
+%122 = OpLabel
+OpBranch %84
+%123 = OpLabel
+OpBranch %79
+%124 = OpLabel
+OpBranch %74
+%125 = OpLabel
+OpBranch %69
+%126 = OpLabel
+OpBranch %64
+%127 = OpLabel
+OpBranch %59
+%128 = OpLabel
+OpBranch %54
+%129 = OpLabel
+OpBranch %47
+%130 = OpLabel
+OpBranch %40
+%131 = OpLabel
+OpBranch %33
+%132 = OpLabel
+OpBranch %26
+%133 = OpLabel
+OpBranch %19
+%134 = OpLabel
+OpBranch %12
 OpFunctionEnd
-%6 = OpFunction %ulong None %199
-%335 = OpFunctionParameter %ulong
-%336 = OpFunctionParameter %ulong
-%337 = OpLabel
-%344 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_bool Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_ulong Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_ulong Function
-OpStore %344 %335
-OpStore %345 %336
-OpBranch %338
-%338 = OpLabel
-%355 = OpLoad %ulong %344
-OpStore %353 %355
-OpStore %354 %ulong_0
-OpBranch %339
-%339 = OpLabel
-%356 = OpLoad %ulong %354
-%357 = OpULessThan %bool %356 %ulong_8
-OpStore %346 %357
-%358 = OpLoad %bool %346
-OpLoopMerge %341 %343 None
-OpBranchConditional %358 %340 %341
-%341 = OpLabel
-OpBranch %342
-%342 = OpLabel
-%359 = OpLoad %ulong %353
-OpReturnValue %359
-%340 = OpLabel
-%360 = OpLoad %ulong %354
-%361 = OpIMul %ulong %360 %ulong_8
-OpStore %347 %361
-%362 = OpLoad %ulong %345
-%363 = OpLoad %ulong %347
-%364 = OpShiftRightLogical %ulong %362 %363
-OpStore %348 %364
-%365 = OpLoad %ulong %348
-%366 = OpBitwiseAnd %ulong %365 %ulong_255
-OpStore %349 %366
-%367 = OpLoad %ulong %353
-%368 = OpLoad %ulong %349
-%369 = OpBitwiseXor %ulong %367 %368
-OpStore %350 %369
-%370 = OpLoad %ulong %350
-%371 = OpIMul %ulong %370 %ulong_1099511628211
-OpStore %351 %371
-%372 = OpLoad %ulong %354
-%373 = OpIAdd %ulong %372 %ulong_1
-OpStore %352 %373
-%374 = OpLoad %ulong %351
-OpStore %353 %374
-%375 = OpLoad %ulong %352
-OpStore %354 %375
-OpBranch %343
-%343 = OpLabel
-OpBranch %339
+%2 = OpFunction %ulong None %770
+%771 = OpFunctionParameter %ulong
+%772 = OpFunctionParameter %ulong
+%773 = OpLabel
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_bool Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
+%783 = OpVariable %_ptr_Function_ulong Function
+%784 = OpVariable %_ptr_Function_ulong Function
+%785 = OpVariable %_ptr_Function_ulong Function
+%786 = OpVariable %_ptr_Function_ulong Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_ulong Function
+OpStore %778 %771
+OpStore %779 %772
+%789 = OpLoad %ulong %778
+OpStore %787 %789
+OpStore %788 %ulong_0
+OpBranch %774
+%774 = OpLabel
+%790 = OpLoad %ulong %788
+%791 = OpULessThan %bool %790 %ulong_8
+OpStore %780 %791
+%792 = OpLoad %bool %780
+OpLoopMerge %776 %777 None
+OpBranchConditional %792 %775 %776
+%776 = OpLabel
+%793 = OpLoad %ulong %787
+OpReturnValue %793
+%775 = OpLabel
+%794 = OpLoad %ulong %788
+%795 = OpIMul %ulong %794 %ulong_8
+OpStore %781 %795
+%796 = OpLoad %ulong %779
+%797 = OpLoad %ulong %781
+%798 = OpShiftRightLogical %ulong %796 %797
+OpStore %782 %798
+%799 = OpLoad %ulong %782
+%800 = OpBitwiseAnd %ulong %799 %ulong_255
+OpStore %783 %800
+%801 = OpLoad %ulong %787
+%802 = OpLoad %ulong %783
+%803 = OpBitwiseXor %ulong %801 %802
+OpStore %784 %803
+%804 = OpLoad %ulong %784
+%805 = OpIMul %ulong %804 %ulong_1099511628211
+OpStore %785 %805
+%806 = OpLoad %ulong %788
+%807 = OpIAdd %ulong %806 %ulong_1
+OpStore %786 %807
+%808 = OpLoad %ulong %785
+OpStore %787 %808
+%809 = OpLoad %ulong %786
+OpStore %788 %809
+OpBranch %777
+%777 = OpLabel
+OpBranch %774
 OpFunctionEnd

--- a/test/golden/spirv/imm/imm_addr.dis
+++ b/test/golden/spirv/imm/imm_addr.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 411
+; Bound: 915
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,21 +9,23 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_addr.checksum" Export
 %ulong = OpTypeInt 64 0
-%6 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %uint_4224 = OpConstant %uint 4224
 %_arr_ulong_uint_4224 = OpTypeArray %ulong %uint_4224
 %_ptr_Function__arr_ulong_uint_4224 = OpTypePointer Function %_arr_ulong_uint_4224
 %uint_3 = OpConstant %uint 3
 %_arr_ulong_uint_3 = OpTypeArray %ulong %uint_3
-%_struct_16 = OpTypeStruct %uint %_arr_ulong_uint_3 %uint
+%_struct_121 = OpTypeStruct %uint %_arr_ulong_uint_3 %uint
 %uint_96 = OpConstant %uint 96
-%_arr__struct_16_uint_96 = OpTypeArray %_struct_16 %uint_96
-%_ptr_Function__arr__struct_16_uint_96 = OpTypePointer Function %_arr__struct_16_uint_96
+%_arr__struct_121_uint_96 = OpTypeArray %_struct_121 %uint_96
+%_ptr_Function__arr__struct_121_uint_96 = OpTypePointer Function %_arr__struct_121_uint_96
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
-%99 = OpConstantNull %_arr_ulong_uint_4224
-%100 = OpConstantNull %_arr__struct_16_uint_96
+%_ptr_Function_bool = OpTypePointer Function %bool
+%335 = OpConstantNull %_arr_ulong_uint_4224
+%336 = OpConstantNull %_arr__struct_121_uint_96
 %ulong_1 = OpConstant %ulong 1
 %uint_0 = OpConstant %uint 0
 %ulong_2 = OpConstant %ulong 2
@@ -36,15 +38,17 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_addr.checksum" Export
 %uint_4096 = OpConstant %uint 4096
 %ulong_6 = OpConstant %ulong 6
 %uint_4223 = OpConstant %uint 4223
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ulong_4224 = OpConstant %ulong 4224
 %ulong_4095 = OpConstant %ulong 4095
 %ulong_2048 = OpConstant %ulong 2048
 %ulong_7 = OpConstant %ulong 7
-%ulong_8 = OpConstant %ulong 8
 %ulong_9 = OpConstant %ulong 9
 %ulong_96 = OpConstant %ulong 96
 %ulong_63 = OpConstant %ulong 63
-%_ptr_Function__struct_16 = OpTypePointer Function %_struct_16
+%_ptr_Function__struct_121 = OpTypePointer Function %_struct_121
 %uint_4294967295 = OpConstant %uint 4294967295
 %ulong_10 = OpConstant %ulong 10
 %uint_1 = OpConstant %uint 1
@@ -59,506 +63,1266 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_addr.checksum" Export
 %ulong_15 = OpConstant %ulong 15
 %uint_19088743 = OpConstant %uint 19088743
 %ulong_16 = OpConstant %ulong 16
-%318 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%321 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%366 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %6
-%7 = OpFunctionParameter %ulong
-%8 = OpLabel
-%13 = OpVariable %_ptr_Function__arr_ulong_uint_4224 Function
-%20 = OpVariable %_ptr_Function__arr__struct_16_uint_96 Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_uint Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_ulong Function
-%72 = OpVariable %_ptr_Function_ulong Function
-%73 = OpVariable %_ptr_Function_ulong Function
-%74 = OpVariable %_ptr_Function_ulong Function
-%75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_ulong Function
-%77 = OpVariable %_ptr_Function_uint Function
-%78 = OpVariable %_ptr_Function_ulong Function
-%79 = OpVariable %_ptr_Function_uint Function
-%80 = OpVariable %_ptr_Function_ulong Function
-%81 = OpVariable %_ptr_Function_ulong Function
-%82 = OpVariable %_ptr_Function_ulong Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_uint Function
-%88 = OpVariable %_ptr_Function_ulong Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_ulong Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_ulong Function
-%95 = OpVariable %_ptr_Function_ulong Function
-%96 = OpVariable %_ptr_Function_ulong Function
-%97 = OpVariable %_ptr_Function_ulong Function
-OpStore %22 %7
-%98 = OpFunctionCall %ulong %2
-OpStore %23 %98
-OpStore %13 %99
-OpStore %20 %100
-%101 = OpLoad %ulong %22
-%103 = OpIAdd %ulong %101 %ulong_1
-OpStore %24 %103
-%105 = OpAccessChain %_ptr_Function_ulong %13 %uint_0
-%106 = OpLoad %ulong %24
-OpStore %105 %106
-%107 = OpLoad %ulong %22
-%109 = OpIAdd %ulong %107 %ulong_2
-OpStore %25 %109
-%111 = OpAccessChain %_ptr_Function_ulong %13 %uint_255
-%112 = OpLoad %ulong %25
-OpStore %111 %112
-%113 = OpLoad %ulong %22
-%115 = OpIAdd %ulong %113 %ulong_3
-OpStore %26 %115
-%117 = OpAccessChain %_ptr_Function_ulong %13 %uint_256
-%118 = OpLoad %ulong %26
-OpStore %117 %118
-%119 = OpLoad %ulong %22
-%121 = OpIAdd %ulong %119 %ulong_4
-OpStore %27 %121
-%123 = OpAccessChain %_ptr_Function_ulong %13 %uint_4095
-%124 = OpLoad %ulong %27
-OpStore %123 %124
-%125 = OpLoad %ulong %22
-%127 = OpIAdd %ulong %125 %ulong_5
-OpStore %28 %127
-%129 = OpAccessChain %_ptr_Function_ulong %13 %uint_4096
-%130 = OpLoad %ulong %28
-OpStore %129 %130
-%131 = OpLoad %ulong %22
-%133 = OpIAdd %ulong %131 %ulong_6
-OpStore %29 %133
-%135 = OpAccessChain %_ptr_Function_ulong %13 %uint_4223
-%136 = OpLoad %ulong %29
-OpStore %135 %136
-%137 = OpLoad %ulong %105
-OpStore %30 %137
-%138 = OpLoad %ulong %23
-%139 = OpLoad %ulong %30
-%140 = OpFunctionCall %ulong %3 %138 %139
-OpStore %31 %140
-%141 = OpLoad %ulong %111
-OpStore %32 %141
-%142 = OpLoad %ulong %31
-%143 = OpLoad %ulong %32
-%144 = OpFunctionCall %ulong %3 %142 %143
-OpStore %33 %144
-%145 = OpLoad %ulong %117
-OpStore %34 %145
-%146 = OpLoad %ulong %33
-%147 = OpLoad %ulong %34
-%148 = OpFunctionCall %ulong %3 %146 %147
-OpStore %35 %148
-%149 = OpLoad %ulong %123
-OpStore %36 %149
-%150 = OpLoad %ulong %35
-%151 = OpLoad %ulong %36
-%152 = OpFunctionCall %ulong %3 %150 %151
-OpStore %37 %152
-%153 = OpLoad %ulong %129
-OpStore %38 %153
-%154 = OpLoad %ulong %37
-%155 = OpLoad %ulong %38
-%156 = OpFunctionCall %ulong %3 %154 %155
-OpStore %39 %156
-%157 = OpLoad %ulong %135
-OpStore %40 %157
-%158 = OpLoad %ulong %39
-%159 = OpLoad %ulong %40
-%160 = OpFunctionCall %ulong %3 %158 %159
-OpStore %41 %160
-OpStore %93 %ulong_4224
-%162 = OpLoad %ulong %22
-%163 = OpLoad %ulong %93
-%164 = OpUMod %ulong %162 %163
-OpStore %42 %164
-%165 = OpLoad %ulong %22
-%167 = OpIAdd %ulong %165 %ulong_4095
-OpStore %43 %167
-OpStore %94 %ulong_4224
-%168 = OpLoad %ulong %43
-%169 = OpLoad %ulong %94
-%170 = OpUMod %ulong %168 %169
-OpStore %44 %170
-%171 = OpLoad %ulong %22
-%173 = OpIAdd %ulong %171 %ulong_2048
-OpStore %45 %173
-OpStore %95 %ulong_4224
-%174 = OpLoad %ulong %45
-%175 = OpLoad %ulong %95
-%176 = OpUMod %ulong %174 %175
-OpStore %46 %176
-%177 = OpLoad %ulong %42
-%178 = OpAccessChain %_ptr_Function_ulong %13 %177
-%179 = OpLoad %ulong %178
-OpStore %47 %179
-%180 = OpLoad %ulong %47
-%182 = OpIAdd %ulong %180 %ulong_7
-OpStore %48 %182
-%183 = OpLoad %ulong %48
-OpStore %178 %183
-%184 = OpLoad %ulong %44
-%185 = OpAccessChain %_ptr_Function_ulong %13 %184
-%186 = OpLoad %ulong %185
-OpStore %49 %186
-%187 = OpLoad %ulong %49
-%189 = OpIAdd %ulong %187 %ulong_8
-OpStore %50 %189
-%190 = OpLoad %ulong %50
-OpStore %185 %190
-%191 = OpLoad %ulong %46
-%192 = OpAccessChain %_ptr_Function_ulong %13 %191
-%193 = OpLoad %ulong %192
-OpStore %51 %193
-%194 = OpLoad %ulong %51
-%196 = OpIAdd %ulong %194 %ulong_9
-OpStore %52 %196
-%197 = OpLoad %ulong %52
-OpStore %192 %197
-%198 = OpLoad %ulong %178
-OpStore %53 %198
-%199 = OpLoad %ulong %41
-%200 = OpLoad %ulong %53
-%201 = OpFunctionCall %ulong %3 %199 %200
-OpStore %54 %201
-%202 = OpLoad %ulong %185
-OpStore %55 %202
-%203 = OpLoad %ulong %54
-%204 = OpLoad %ulong %55
-%205 = OpFunctionCall %ulong %3 %203 %204
-OpStore %56 %205
-%206 = OpLoad %ulong %192
-OpStore %57 %206
-%207 = OpLoad %ulong %56
-%208 = OpLoad %ulong %57
-%209 = OpFunctionCall %ulong %3 %207 %208
-OpStore %58 %209
-OpStore %96 %ulong_96
-%211 = OpLoad %ulong %22
-%212 = OpLoad %ulong %96
-%213 = OpUMod %ulong %211 %212
-OpStore %59 %213
-%214 = OpLoad %ulong %22
-%216 = OpIAdd %ulong %214 %ulong_63
-OpStore %60 %216
-OpStore %97 %ulong_96
-%217 = OpLoad %ulong %60
-%218 = OpLoad %ulong %97
-%219 = OpUMod %ulong %217 %218
-OpStore %61 %219
-%220 = OpLoad %ulong %59
-%222 = OpAccessChain %_ptr_Function__struct_16 %20 %220
-%223 = OpAccessChain %_ptr_Function_uint %222 %uint_0
-OpStore %223 %uint_4294967295
-%225 = OpLoad %ulong %22
-%227 = OpIAdd %ulong %225 %ulong_10
-OpStore %62 %227
-%230 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %222 %uint_1
-%231 = OpAccessChain %_ptr_Function_ulong %230 %uint_0
-%232 = OpLoad %ulong %62
-OpStore %231 %232
-%233 = OpLoad %ulong %22
-%235 = OpIAdd %ulong %233 %ulong_11
-OpStore %63 %235
-%236 = OpAccessChain %_ptr_Function_ulong %230 %uint_1
-%237 = OpLoad %ulong %63
-OpStore %236 %237
-%238 = OpLoad %ulong %22
-%240 = OpIAdd %ulong %238 %ulong_12
-OpStore %64 %240
-%242 = OpAccessChain %_ptr_Function_ulong %230 %uint_2
-%243 = OpLoad %ulong %64
-OpStore %242 %243
-%244 = OpAccessChain %_ptr_Function_uint %222 %uint_2
-OpStore %244 %uint_305419896
-%246 = OpLoad %ulong %61
-%247 = OpAccessChain %_ptr_Function__struct_16 %20 %246
-%248 = OpAccessChain %_ptr_Function_uint %247 %uint_0
-OpStore %248 %uint_2882400001
-%250 = OpLoad %ulong %22
-%252 = OpIAdd %ulong %250 %ulong_13
-OpStore %65 %252
-%253 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %247 %uint_1
-%254 = OpAccessChain %_ptr_Function_ulong %253 %uint_0
-%255 = OpLoad %ulong %65
-OpStore %254 %255
-%256 = OpLoad %ulong %22
-%258 = OpIAdd %ulong %256 %ulong_14
-OpStore %66 %258
-%259 = OpAccessChain %_ptr_Function_ulong %253 %uint_1
-%260 = OpLoad %ulong %66
-OpStore %259 %260
-%261 = OpLoad %ulong %22
-%263 = OpIAdd %ulong %261 %ulong_15
-OpStore %67 %263
-%264 = OpAccessChain %_ptr_Function_ulong %253 %uint_2
-%265 = OpLoad %ulong %67
-OpStore %264 %265
-%266 = OpAccessChain %_ptr_Function_uint %247 %uint_2
-OpStore %266 %uint_19088743
-%268 = OpLoad %uint %223
-OpStore %69 %268
-%269 = OpLoad %ulong %58
-%270 = OpLoad %uint %69
-%271 = OpFunctionCall %ulong %4 %269 %270
-OpStore %70 %271
-%272 = OpLoad %ulong %231
-OpStore %71 %272
-%273 = OpLoad %ulong %70
-%274 = OpLoad %ulong %71
-%275 = OpFunctionCall %ulong %3 %273 %274
-OpStore %72 %275
-%276 = OpLoad %ulong %236
-OpStore %73 %276
-%277 = OpLoad %ulong %72
-%278 = OpLoad %ulong %73
-%279 = OpFunctionCall %ulong %3 %277 %278
-OpStore %74 %279
-%280 = OpLoad %ulong %242
-OpStore %75 %280
-%281 = OpLoad %ulong %74
-%282 = OpLoad %ulong %75
-%283 = OpFunctionCall %ulong %3 %281 %282
-OpStore %76 %283
-%284 = OpLoad %uint %244
-OpStore %77 %284
-%285 = OpLoad %ulong %76
-%286 = OpLoad %uint %77
-%287 = OpFunctionCall %ulong %4 %285 %286
-OpStore %78 %287
-%288 = OpLoad %uint %248
-OpStore %79 %288
-%289 = OpLoad %ulong %78
-%290 = OpLoad %uint %79
-%291 = OpFunctionCall %ulong %4 %289 %290
-OpStore %80 %291
-%292 = OpLoad %ulong %254
-OpStore %81 %292
-%293 = OpLoad %ulong %80
-%294 = OpLoad %ulong %81
-%295 = OpFunctionCall %ulong %3 %293 %294
-OpStore %82 %295
-%296 = OpLoad %ulong %259
-OpStore %83 %296
-%297 = OpLoad %ulong %82
-%298 = OpLoad %ulong %83
-%299 = OpFunctionCall %ulong %3 %297 %298
-OpStore %84 %299
-%300 = OpLoad %ulong %264
-OpStore %85 %300
-%301 = OpLoad %ulong %84
-%302 = OpLoad %ulong %85
-%303 = OpFunctionCall %ulong %3 %301 %302
-OpStore %86 %303
-%304 = OpLoad %uint %266
-OpStore %87 %304
-%305 = OpLoad %ulong %86
-%306 = OpLoad %uint %87
-%307 = OpFunctionCall %ulong %4 %305 %306
-OpStore %88 %307
-%308 = OpLoad %ulong %123
-OpStore %89 %308
-%309 = OpLoad %ulong %89
-%311 = OpIAdd %ulong %309 %ulong_16
-OpStore %90 %311
-%312 = OpLoad %ulong %90
-OpStore %123 %312
-%313 = OpLoad %ulong %123
-OpStore %91 %313
-%314 = OpLoad %ulong %88
-%315 = OpLoad %ulong %91
-%316 = OpFunctionCall %ulong %3 %314 %315
-OpStore %92 %316
-%317 = OpLoad %ulong %92
-OpReturnValue %317
-OpFunctionEnd
-%2 = OpFunction %ulong None %318
-%319 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %321
-%322 = OpFunctionParameter %ulong
-%323 = OpFunctionParameter %ulong
-%324 = OpLabel
+%875 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%118 = OpVariable %_ptr_Function__arr_ulong_uint_4224 Function
+%125 = OpVariable %_ptr_Function__arr__struct_121_uint_96 Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_uint Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_uint Function
+%169 = OpVariable %_ptr_Function_uint Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_uint Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_bool Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_bool Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_bool Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_bool Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_bool Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_bool Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_bool Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_bool Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_bool Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
 %330 = OpVariable %_ptr_Function_ulong Function
 %331 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_bool Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
 %334 = OpVariable %_ptr_Function_ulong Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ulong Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ulong Function
-%341 = OpVariable %_ptr_Function_ulong Function
-OpStore %330 %322
-OpStore %331 %323
-%342 = OpLoad %ulong %330
-OpStore %340 %342
-OpStore %341 %ulong_0
-OpBranch %325
-%325 = OpLabel
-%344 = OpLoad %ulong %341
-%345 = OpULessThan %bool %344 %ulong_8
-OpStore %333 %345
-%346 = OpLoad %bool %333
-OpLoopMerge %327 %328 None
-OpBranchConditional %346 %326 %327
-%327 = OpLabel
-%347 = OpLoad %ulong %340
-OpReturnValue %347
-%326 = OpLabel
-%348 = OpLoad %ulong %341
-%349 = OpIMul %ulong %348 %ulong_8
-OpStore %334 %349
-%350 = OpLoad %ulong %331
-%351 = OpLoad %ulong %334
-%352 = OpShiftRightLogical %ulong %350 %351
-OpStore %335 %352
-%353 = OpLoad %ulong %335
-%355 = OpBitwiseAnd %ulong %353 %ulong_255
-OpStore %336 %355
-%356 = OpLoad %ulong %340
-%357 = OpLoad %ulong %336
-%358 = OpBitwiseXor %ulong %356 %357
-OpStore %337 %358
-%359 = OpLoad %ulong %337
-%361 = OpIMul %ulong %359 %ulong_1099511628211
-OpStore %338 %361
-%362 = OpLoad %ulong %341
-%363 = OpIAdd %ulong %362 %ulong_1
-OpStore %339 %363
-%364 = OpLoad %ulong %338
-OpStore %340 %364
-%365 = OpLoad %ulong %339
-OpStore %341 %365
-OpBranch %328
-%328 = OpLabel
-OpBranch %325
+OpStore %127 %5
+OpBranch %7
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+OpStore %118 %335
+OpStore %125 %336
+%337 = OpLoad %ulong %127
+%339 = OpIAdd %ulong %337 %ulong_1
+OpStore %128 %339
+%341 = OpAccessChain %_ptr_Function_ulong %118 %uint_0
+%342 = OpLoad %ulong %128
+OpStore %341 %342
+%343 = OpLoad %ulong %127
+%345 = OpIAdd %ulong %343 %ulong_2
+OpStore %129 %345
+%347 = OpAccessChain %_ptr_Function_ulong %118 %uint_255
+%348 = OpLoad %ulong %129
+OpStore %347 %348
+%349 = OpLoad %ulong %127
+%351 = OpIAdd %ulong %349 %ulong_3
+OpStore %130 %351
+%353 = OpAccessChain %_ptr_Function_ulong %118 %uint_256
+%354 = OpLoad %ulong %130
+OpStore %353 %354
+%355 = OpLoad %ulong %127
+%357 = OpIAdd %ulong %355 %ulong_4
+OpStore %131 %357
+%359 = OpAccessChain %_ptr_Function_ulong %118 %uint_4095
+%360 = OpLoad %ulong %131
+OpStore %359 %360
+%361 = OpLoad %ulong %127
+%363 = OpIAdd %ulong %361 %ulong_5
+OpStore %132 %363
+%365 = OpAccessChain %_ptr_Function_ulong %118 %uint_4096
+%366 = OpLoad %ulong %132
+OpStore %365 %366
+%367 = OpLoad %ulong %127
+%369 = OpIAdd %ulong %367 %ulong_6
+OpStore %133 %369
+%371 = OpAccessChain %_ptr_Function_ulong %118 %uint_4223
+%372 = OpLoad %ulong %133
+OpStore %371 %372
+%373 = OpLoad %ulong %341
+OpStore %134 %373
+OpBranch %9
+%9 = OpLabel
+OpStore %188 %ulong_14695981039346656037
+OpStore %189 %ulong_0
+OpBranch %10
+%10 = OpLabel
+%376 = OpLoad %ulong %189
+%378 = OpULessThan %bool %376 %ulong_8
+OpStore %181 %378
+%379 = OpLoad %bool %181
+OpLoopMerge %12 %112 None
+OpBranchConditional %379 %11 %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%380 = OpAccessChain %_ptr_Function_ulong %118 %uint_255
+%381 = OpLoad %ulong %380
+OpStore %135 %381
+OpBranch %14
+%14 = OpLabel
+%382 = OpLoad %ulong %188
+OpStore %197 %382
+OpStore %198 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%383 = OpLoad %ulong %198
+%384 = OpULessThan %bool %383 %ulong_8
+OpStore %190 %384
+%385 = OpLoad %bool %190
+OpLoopMerge %17 %111 None
+OpBranchConditional %385 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%386 = OpAccessChain %_ptr_Function_ulong %118 %uint_256
+%387 = OpLoad %ulong %386
+OpStore %136 %387
+OpBranch %19
+%19 = OpLabel
+%388 = OpLoad %ulong %197
+OpStore %206 %388
+OpStore %207 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%389 = OpLoad %ulong %207
+%390 = OpULessThan %bool %389 %ulong_8
+OpStore %199 %390
+%391 = OpLoad %bool %199
+OpLoopMerge %22 %110 None
+OpBranchConditional %391 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%392 = OpAccessChain %_ptr_Function_ulong %118 %uint_4095
+%393 = OpLoad %ulong %392
+OpStore %137 %393
+OpBranch %24
+%24 = OpLabel
+%394 = OpLoad %ulong %206
+OpStore %215 %394
+OpStore %216 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%395 = OpLoad %ulong %216
+%396 = OpULessThan %bool %395 %ulong_8
+OpStore %208 %396
+%397 = OpLoad %bool %208
+OpLoopMerge %27 %109 None
+OpBranchConditional %397 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%398 = OpAccessChain %_ptr_Function_ulong %118 %uint_4096
+%399 = OpLoad %ulong %398
+OpStore %138 %399
+OpBranch %29
+%29 = OpLabel
+%400 = OpLoad %ulong %215
+OpStore %224 %400
+OpStore %225 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%401 = OpLoad %ulong %225
+%402 = OpULessThan %bool %401 %ulong_8
+OpStore %217 %402
+%403 = OpLoad %bool %217
+OpLoopMerge %32 %108 None
+OpBranchConditional %403 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%404 = OpAccessChain %_ptr_Function_ulong %118 %uint_4223
+%405 = OpLoad %ulong %404
+OpStore %139 %405
+OpBranch %34
+%34 = OpLabel
+%406 = OpLoad %ulong %224
+OpStore %233 %406
+OpStore %234 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%407 = OpLoad %ulong %234
+%408 = OpULessThan %bool %407 %ulong_8
+OpStore %226 %408
+%409 = OpLoad %bool %226
+OpLoopMerge %37 %107 None
+OpBranchConditional %409 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpStore %330 %ulong_4224
+%411 = OpLoad %ulong %127
+%412 = OpLoad %ulong %330
+%413 = OpUMod %ulong %411 %412
+OpStore %140 %413
+%414 = OpLoad %ulong %127
+%416 = OpIAdd %ulong %414 %ulong_4095
+OpStore %141 %416
+OpStore %331 %ulong_4224
+%417 = OpLoad %ulong %141
+%418 = OpLoad %ulong %331
+%419 = OpUMod %ulong %417 %418
+OpStore %142 %419
+%420 = OpLoad %ulong %127
+%422 = OpIAdd %ulong %420 %ulong_2048
+OpStore %143 %422
+OpStore %332 %ulong_4224
+%423 = OpLoad %ulong %143
+%424 = OpLoad %ulong %332
+%425 = OpUMod %ulong %423 %424
+OpStore %144 %425
+%426 = OpLoad %ulong %140
+%427 = OpAccessChain %_ptr_Function_ulong %118 %426
+%428 = OpLoad %ulong %427
+OpStore %145 %428
+%429 = OpLoad %ulong %145
+%431 = OpIAdd %ulong %429 %ulong_7
+OpStore %146 %431
+%432 = OpLoad %ulong %146
+OpStore %427 %432
+%433 = OpLoad %ulong %142
+%434 = OpAccessChain %_ptr_Function_ulong %118 %433
+%435 = OpLoad %ulong %434
+OpStore %147 %435
+%436 = OpLoad %ulong %147
+%437 = OpIAdd %ulong %436 %ulong_8
+OpStore %148 %437
+%438 = OpLoad %ulong %148
+OpStore %434 %438
+%439 = OpLoad %ulong %144
+%440 = OpAccessChain %_ptr_Function_ulong %118 %439
+%441 = OpLoad %ulong %440
+OpStore %149 %441
+%442 = OpLoad %ulong %149
+%444 = OpIAdd %ulong %442 %ulong_9
+OpStore %150 %444
+%445 = OpLoad %ulong %150
+OpStore %440 %445
+%446 = OpLoad %ulong %427
+OpStore %151 %446
+OpBranch %39
+%39 = OpLabel
+%447 = OpLoad %ulong %233
+OpStore %242 %447
+OpStore %243 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%448 = OpLoad %ulong %243
+%449 = OpULessThan %bool %448 %ulong_8
+OpStore %235 %449
+%450 = OpLoad %bool %235
+OpLoopMerge %42 %106 None
+OpBranchConditional %450 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+%451 = OpLoad %ulong %142
+%452 = OpAccessChain %_ptr_Function_ulong %118 %451
+%453 = OpLoad %ulong %452
+OpStore %152 %453
+OpBranch %44
+%44 = OpLabel
+%454 = OpLoad %ulong %242
+OpStore %251 %454
+OpStore %252 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%455 = OpLoad %ulong %252
+%456 = OpULessThan %bool %455 %ulong_8
+OpStore %244 %456
+%457 = OpLoad %bool %244
+OpLoopMerge %47 %105 None
+OpBranchConditional %457 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%458 = OpLoad %ulong %144
+%459 = OpAccessChain %_ptr_Function_ulong %118 %458
+%460 = OpLoad %ulong %459
+OpStore %153 %460
+OpBranch %49
+%49 = OpLabel
+%461 = OpLoad %ulong %251
+OpStore %260 %461
+OpStore %261 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%462 = OpLoad %ulong %261
+%463 = OpULessThan %bool %462 %ulong_8
+OpStore %253 %463
+%464 = OpLoad %bool %253
+OpLoopMerge %52 %104 None
+OpBranchConditional %464 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpStore %333 %ulong_96
+%466 = OpLoad %ulong %127
+%467 = OpLoad %ulong %333
+%468 = OpUMod %ulong %466 %467
+OpStore %154 %468
+%469 = OpLoad %ulong %127
+%471 = OpIAdd %ulong %469 %ulong_63
+OpStore %155 %471
+OpStore %334 %ulong_96
+%472 = OpLoad %ulong %155
+%473 = OpLoad %ulong %334
+%474 = OpUMod %ulong %472 %473
+OpStore %156 %474
+%475 = OpLoad %ulong %154
+%477 = OpAccessChain %_ptr_Function__struct_121 %125 %475
+%478 = OpAccessChain %_ptr_Function_uint %477 %uint_0
+OpStore %478 %uint_4294967295
+%480 = OpLoad %ulong %127
+%482 = OpIAdd %ulong %480 %ulong_10
+OpStore %157 %482
+%485 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %477 %uint_1
+%486 = OpAccessChain %_ptr_Function_ulong %485 %uint_0
+%487 = OpLoad %ulong %157
+OpStore %486 %487
+%488 = OpLoad %ulong %127
+%490 = OpIAdd %ulong %488 %ulong_11
+OpStore %158 %490
+%491 = OpAccessChain %_ptr_Function_ulong %485 %uint_1
+%492 = OpLoad %ulong %158
+OpStore %491 %492
+%493 = OpLoad %ulong %127
+%495 = OpIAdd %ulong %493 %ulong_12
+OpStore %159 %495
+%497 = OpAccessChain %_ptr_Function_ulong %485 %uint_2
+%498 = OpLoad %ulong %159
+OpStore %497 %498
+%499 = OpAccessChain %_ptr_Function_uint %477 %uint_2
+OpStore %499 %uint_305419896
+%501 = OpLoad %ulong %156
+%502 = OpAccessChain %_ptr_Function__struct_121 %125 %501
+%503 = OpAccessChain %_ptr_Function_uint %502 %uint_0
+OpStore %503 %uint_2882400001
+%505 = OpLoad %ulong %127
+%507 = OpIAdd %ulong %505 %ulong_13
+OpStore %160 %507
+%508 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %502 %uint_1
+%509 = OpAccessChain %_ptr_Function_ulong %508 %uint_0
+%510 = OpLoad %ulong %160
+OpStore %509 %510
+%511 = OpLoad %ulong %127
+%513 = OpIAdd %ulong %511 %ulong_14
+OpStore %161 %513
+%514 = OpAccessChain %_ptr_Function_ulong %508 %uint_1
+%515 = OpLoad %ulong %161
+OpStore %514 %515
+%516 = OpLoad %ulong %127
+%518 = OpIAdd %ulong %516 %ulong_15
+OpStore %162 %518
+%519 = OpAccessChain %_ptr_Function_ulong %508 %uint_2
+%520 = OpLoad %ulong %162
+OpStore %519 %520
+%521 = OpAccessChain %_ptr_Function_uint %502 %uint_2
+OpStore %521 %uint_19088743
+%523 = OpLoad %uint %478
+OpStore %164 %523
+OpBranch %54
+%54 = OpLabel
+%524 = OpLoad %uint %164
+%525 = OpUConvert %ulong %524
+OpStore %262 %525
+OpBranch %56
+%56 = OpLabel
+%526 = OpLoad %ulong %260
+OpStore %270 %526
+OpStore %271 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%527 = OpLoad %ulong %271
+%528 = OpULessThan %bool %527 %ulong_8
+OpStore %263 %528
+%529 = OpLoad %bool %263
+OpLoopMerge %59 %103 None
+OpBranchConditional %529 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%530 = OpLoad %ulong %154
+%531 = OpAccessChain %_ptr_Function__struct_121 %125 %530
+%532 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %531 %uint_1
+%533 = OpAccessChain %_ptr_Function_ulong %532 %uint_0
+%534 = OpLoad %ulong %533
+OpStore %165 %534
+OpBranch %61
+%61 = OpLabel
+%535 = OpLoad %ulong %270
+OpStore %279 %535
+OpStore %280 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%536 = OpLoad %ulong %280
+%537 = OpULessThan %bool %536 %ulong_8
+OpStore %272 %537
+%538 = OpLoad %bool %272
+OpLoopMerge %64 %102 None
+OpBranchConditional %538 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+%539 = OpLoad %ulong %154
+%540 = OpAccessChain %_ptr_Function__struct_121 %125 %539
+%541 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %540 %uint_1
+%542 = OpAccessChain %_ptr_Function_ulong %541 %uint_1
+%543 = OpLoad %ulong %542
+OpStore %166 %543
+OpBranch %66
+%66 = OpLabel
+%544 = OpLoad %ulong %279
+OpStore %288 %544
+OpStore %289 %ulong_0
+OpBranch %67
+%67 = OpLabel
+%545 = OpLoad %ulong %289
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %281 %546
+%547 = OpLoad %bool %281
+OpLoopMerge %69 %101 None
+OpBranchConditional %547 %68 %69
+%69 = OpLabel
+OpBranch %70
+%70 = OpLabel
+%548 = OpLoad %ulong %154
+%549 = OpAccessChain %_ptr_Function__struct_121 %125 %548
+%550 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %549 %uint_1
+%551 = OpAccessChain %_ptr_Function_ulong %550 %uint_2
+%552 = OpLoad %ulong %551
+OpStore %167 %552
+OpBranch %71
+%71 = OpLabel
+%553 = OpLoad %ulong %288
+OpStore %297 %553
+OpStore %298 %ulong_0
+OpBranch %72
+%72 = OpLabel
+%554 = OpLoad %ulong %298
+%555 = OpULessThan %bool %554 %ulong_8
+OpStore %290 %555
+%556 = OpLoad %bool %290
+OpLoopMerge %74 %100 None
+OpBranchConditional %556 %73 %74
+%74 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%557 = OpLoad %ulong %154
+%558 = OpAccessChain %_ptr_Function__struct_121 %125 %557
+%559 = OpAccessChain %_ptr_Function_uint %558 %uint_2
+%560 = OpLoad %uint %559
+OpStore %168 %560
+OpBranch %76
+%76 = OpLabel
+%561 = OpLoad %uint %168
+%562 = OpUConvert %ulong %561
+OpStore %299 %562
+OpBranch %78
+%78 = OpLabel
+%563 = OpLoad %ulong %297
+OpStore %307 %563
+OpStore %308 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%564 = OpLoad %ulong %308
+%565 = OpULessThan %bool %564 %ulong_8
+OpStore %300 %565
+%566 = OpLoad %bool %300
+OpLoopMerge %81 %99 None
+OpBranchConditional %566 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%567 = OpLoad %ulong %156
+%568 = OpAccessChain %_ptr_Function__struct_121 %125 %567
+%569 = OpAccessChain %_ptr_Function_uint %568 %uint_0
+%570 = OpLoad %uint %569
+OpStore %169 %570
+OpBranch %83
+%83 = OpLabel
+%571 = OpLoad %uint %169
+%572 = OpUConvert %ulong %571
+OpStore %309 %572
+OpBranch %85
+%85 = OpLabel
+%573 = OpLoad %ulong %307
+OpStore %317 %573
+OpStore %318 %ulong_0
+OpBranch %86
+%86 = OpLabel
+%574 = OpLoad %ulong %318
+%575 = OpULessThan %bool %574 %ulong_8
+OpStore %310 %575
+%576 = OpLoad %bool %310
+OpLoopMerge %88 %98 None
+OpBranchConditional %576 %87 %88
+%88 = OpLabel
+OpBranch %89
+%89 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%577 = OpLoad %ulong %156
+%578 = OpAccessChain %_ptr_Function__struct_121 %125 %577
+%579 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %578 %uint_1
+%580 = OpAccessChain %_ptr_Function_ulong %579 %uint_0
+%581 = OpLoad %ulong %580
+OpStore %170 %581
+OpBranch %90
+%90 = OpLabel
+%582 = OpLoad %ulong %317
+OpStore %326 %582
+OpStore %327 %ulong_0
+OpBranch %91
+%91 = OpLabel
+%583 = OpLoad %ulong %327
+%584 = OpULessThan %bool %583 %ulong_8
+OpStore %319 %584
+%585 = OpLoad %bool %319
+OpLoopMerge %93 %97 None
+OpBranchConditional %585 %92 %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%586 = OpLoad %ulong %156
+%587 = OpAccessChain %_ptr_Function__struct_121 %125 %586
+%588 = OpAccessChain %_ptr_Function__arr_ulong_uint_3 %587 %uint_1
+%589 = OpAccessChain %_ptr_Function_ulong %588 %uint_1
+%590 = OpLoad %ulong %589
+OpStore %171 %590
+%591 = OpLoad %ulong %326
+%592 = OpLoad %ulong %171
+%593 = OpFunctionCall %ulong %2 %591 %592
+OpStore %172 %593
+%594 = OpAccessChain %_ptr_Function_ulong %588 %uint_2
+%595 = OpLoad %ulong %594
+OpStore %173 %595
+%596 = OpLoad %ulong %172
+%597 = OpLoad %ulong %173
+%598 = OpFunctionCall %ulong %2 %596 %597
+OpStore %174 %598
+%599 = OpAccessChain %_ptr_Function_uint %587 %uint_2
+%600 = OpLoad %uint %599
+OpStore %175 %600
+OpBranch %95
+%95 = OpLabel
+%601 = OpLoad %uint %175
+%602 = OpUConvert %ulong %601
+OpStore %328 %602
+%603 = OpLoad %ulong %174
+%604 = OpLoad %ulong %328
+%605 = OpFunctionCall %ulong %2 %603 %604
+OpStore %329 %605
+OpBranch %96
+%96 = OpLabel
+%606 = OpAccessChain %_ptr_Function_ulong %118 %uint_4095
+%607 = OpLoad %ulong %606
+OpStore %176 %607
+%608 = OpLoad %ulong %176
+%610 = OpIAdd %ulong %608 %ulong_16
+OpStore %177 %610
+%611 = OpLoad %ulong %177
+OpStore %606 %611
+%612 = OpLoad %ulong %606
+OpStore %178 %612
+%613 = OpLoad %ulong %329
+%614 = OpLoad %ulong %178
+%615 = OpFunctionCall %ulong %2 %613 %614
+OpStore %179 %615
+%616 = OpLoad %ulong %179
+OpReturnValue %616
+%92 = OpLabel
+%617 = OpLoad %ulong %327
+%618 = OpIMul %ulong %617 %ulong_8
+OpStore %320 %618
+%619 = OpLoad %ulong %170
+%620 = OpLoad %ulong %320
+%621 = OpShiftRightLogical %ulong %619 %620
+OpStore %321 %621
+%622 = OpLoad %ulong %321
+%624 = OpBitwiseAnd %ulong %622 %ulong_255
+OpStore %322 %624
+%625 = OpLoad %ulong %326
+%626 = OpLoad %ulong %322
+%627 = OpBitwiseXor %ulong %625 %626
+OpStore %323 %627
+%628 = OpLoad %ulong %323
+%630 = OpIMul %ulong %628 %ulong_1099511628211
+OpStore %324 %630
+%631 = OpLoad %ulong %327
+%632 = OpIAdd %ulong %631 %ulong_1
+OpStore %325 %632
+%633 = OpLoad %ulong %324
+OpStore %326 %633
+%634 = OpLoad %ulong %325
+OpStore %327 %634
+OpBranch %97
+%87 = OpLabel
+%635 = OpLoad %ulong %318
+%636 = OpIMul %ulong %635 %ulong_8
+OpStore %311 %636
+%637 = OpLoad %ulong %309
+%638 = OpLoad %ulong %311
+%639 = OpShiftRightLogical %ulong %637 %638
+OpStore %312 %639
+%640 = OpLoad %ulong %312
+%641 = OpBitwiseAnd %ulong %640 %ulong_255
+OpStore %313 %641
+%642 = OpLoad %ulong %317
+%643 = OpLoad %ulong %313
+%644 = OpBitwiseXor %ulong %642 %643
+OpStore %314 %644
+%645 = OpLoad %ulong %314
+%646 = OpIMul %ulong %645 %ulong_1099511628211
+OpStore %315 %646
+%647 = OpLoad %ulong %318
+%648 = OpIAdd %ulong %647 %ulong_1
+OpStore %316 %648
+%649 = OpLoad %ulong %315
+OpStore %317 %649
+%650 = OpLoad %ulong %316
+OpStore %318 %650
+OpBranch %98
+%80 = OpLabel
+%651 = OpLoad %ulong %308
+%652 = OpIMul %ulong %651 %ulong_8
+OpStore %301 %652
+%653 = OpLoad %ulong %299
+%654 = OpLoad %ulong %301
+%655 = OpShiftRightLogical %ulong %653 %654
+OpStore %302 %655
+%656 = OpLoad %ulong %302
+%657 = OpBitwiseAnd %ulong %656 %ulong_255
+OpStore %303 %657
+%658 = OpLoad %ulong %307
+%659 = OpLoad %ulong %303
+%660 = OpBitwiseXor %ulong %658 %659
+OpStore %304 %660
+%661 = OpLoad %ulong %304
+%662 = OpIMul %ulong %661 %ulong_1099511628211
+OpStore %305 %662
+%663 = OpLoad %ulong %308
+%664 = OpIAdd %ulong %663 %ulong_1
+OpStore %306 %664
+%665 = OpLoad %ulong %305
+OpStore %307 %665
+%666 = OpLoad %ulong %306
+OpStore %308 %666
+OpBranch %99
+%73 = OpLabel
+%667 = OpLoad %ulong %298
+%668 = OpIMul %ulong %667 %ulong_8
+OpStore %291 %668
+%669 = OpLoad %ulong %167
+%670 = OpLoad %ulong %291
+%671 = OpShiftRightLogical %ulong %669 %670
+OpStore %292 %671
+%672 = OpLoad %ulong %292
+%673 = OpBitwiseAnd %ulong %672 %ulong_255
+OpStore %293 %673
+%674 = OpLoad %ulong %297
+%675 = OpLoad %ulong %293
+%676 = OpBitwiseXor %ulong %674 %675
+OpStore %294 %676
+%677 = OpLoad %ulong %294
+%678 = OpIMul %ulong %677 %ulong_1099511628211
+OpStore %295 %678
+%679 = OpLoad %ulong %298
+%680 = OpIAdd %ulong %679 %ulong_1
+OpStore %296 %680
+%681 = OpLoad %ulong %295
+OpStore %297 %681
+%682 = OpLoad %ulong %296
+OpStore %298 %682
+OpBranch %100
+%68 = OpLabel
+%683 = OpLoad %ulong %289
+%684 = OpIMul %ulong %683 %ulong_8
+OpStore %282 %684
+%685 = OpLoad %ulong %166
+%686 = OpLoad %ulong %282
+%687 = OpShiftRightLogical %ulong %685 %686
+OpStore %283 %687
+%688 = OpLoad %ulong %283
+%689 = OpBitwiseAnd %ulong %688 %ulong_255
+OpStore %284 %689
+%690 = OpLoad %ulong %288
+%691 = OpLoad %ulong %284
+%692 = OpBitwiseXor %ulong %690 %691
+OpStore %285 %692
+%693 = OpLoad %ulong %285
+%694 = OpIMul %ulong %693 %ulong_1099511628211
+OpStore %286 %694
+%695 = OpLoad %ulong %289
+%696 = OpIAdd %ulong %695 %ulong_1
+OpStore %287 %696
+%697 = OpLoad %ulong %286
+OpStore %288 %697
+%698 = OpLoad %ulong %287
+OpStore %289 %698
+OpBranch %101
+%63 = OpLabel
+%699 = OpLoad %ulong %280
+%700 = OpIMul %ulong %699 %ulong_8
+OpStore %273 %700
+%701 = OpLoad %ulong %165
+%702 = OpLoad %ulong %273
+%703 = OpShiftRightLogical %ulong %701 %702
+OpStore %274 %703
+%704 = OpLoad %ulong %274
+%705 = OpBitwiseAnd %ulong %704 %ulong_255
+OpStore %275 %705
+%706 = OpLoad %ulong %279
+%707 = OpLoad %ulong %275
+%708 = OpBitwiseXor %ulong %706 %707
+OpStore %276 %708
+%709 = OpLoad %ulong %276
+%710 = OpIMul %ulong %709 %ulong_1099511628211
+OpStore %277 %710
+%711 = OpLoad %ulong %280
+%712 = OpIAdd %ulong %711 %ulong_1
+OpStore %278 %712
+%713 = OpLoad %ulong %277
+OpStore %279 %713
+%714 = OpLoad %ulong %278
+OpStore %280 %714
+OpBranch %102
+%58 = OpLabel
+%715 = OpLoad %ulong %271
+%716 = OpIMul %ulong %715 %ulong_8
+OpStore %264 %716
+%717 = OpLoad %ulong %262
+%718 = OpLoad %ulong %264
+%719 = OpShiftRightLogical %ulong %717 %718
+OpStore %265 %719
+%720 = OpLoad %ulong %265
+%721 = OpBitwiseAnd %ulong %720 %ulong_255
+OpStore %266 %721
+%722 = OpLoad %ulong %270
+%723 = OpLoad %ulong %266
+%724 = OpBitwiseXor %ulong %722 %723
+OpStore %267 %724
+%725 = OpLoad %ulong %267
+%726 = OpIMul %ulong %725 %ulong_1099511628211
+OpStore %268 %726
+%727 = OpLoad %ulong %271
+%728 = OpIAdd %ulong %727 %ulong_1
+OpStore %269 %728
+%729 = OpLoad %ulong %268
+OpStore %270 %729
+%730 = OpLoad %ulong %269
+OpStore %271 %730
+OpBranch %103
+%51 = OpLabel
+%731 = OpLoad %ulong %261
+%732 = OpIMul %ulong %731 %ulong_8
+OpStore %254 %732
+%733 = OpLoad %ulong %153
+%734 = OpLoad %ulong %254
+%735 = OpShiftRightLogical %ulong %733 %734
+OpStore %255 %735
+%736 = OpLoad %ulong %255
+%737 = OpBitwiseAnd %ulong %736 %ulong_255
+OpStore %256 %737
+%738 = OpLoad %ulong %260
+%739 = OpLoad %ulong %256
+%740 = OpBitwiseXor %ulong %738 %739
+OpStore %257 %740
+%741 = OpLoad %ulong %257
+%742 = OpIMul %ulong %741 %ulong_1099511628211
+OpStore %258 %742
+%743 = OpLoad %ulong %261
+%744 = OpIAdd %ulong %743 %ulong_1
+OpStore %259 %744
+%745 = OpLoad %ulong %258
+OpStore %260 %745
+%746 = OpLoad %ulong %259
+OpStore %261 %746
+OpBranch %104
+%46 = OpLabel
+%747 = OpLoad %ulong %252
+%748 = OpIMul %ulong %747 %ulong_8
+OpStore %245 %748
+%749 = OpLoad %ulong %152
+%750 = OpLoad %ulong %245
+%751 = OpShiftRightLogical %ulong %749 %750
+OpStore %246 %751
+%752 = OpLoad %ulong %246
+%753 = OpBitwiseAnd %ulong %752 %ulong_255
+OpStore %247 %753
+%754 = OpLoad %ulong %251
+%755 = OpLoad %ulong %247
+%756 = OpBitwiseXor %ulong %754 %755
+OpStore %248 %756
+%757 = OpLoad %ulong %248
+%758 = OpIMul %ulong %757 %ulong_1099511628211
+OpStore %249 %758
+%759 = OpLoad %ulong %252
+%760 = OpIAdd %ulong %759 %ulong_1
+OpStore %250 %760
+%761 = OpLoad %ulong %249
+OpStore %251 %761
+%762 = OpLoad %ulong %250
+OpStore %252 %762
+OpBranch %105
+%41 = OpLabel
+%763 = OpLoad %ulong %243
+%764 = OpIMul %ulong %763 %ulong_8
+OpStore %236 %764
+%765 = OpLoad %ulong %151
+%766 = OpLoad %ulong %236
+%767 = OpShiftRightLogical %ulong %765 %766
+OpStore %237 %767
+%768 = OpLoad %ulong %237
+%769 = OpBitwiseAnd %ulong %768 %ulong_255
+OpStore %238 %769
+%770 = OpLoad %ulong %242
+%771 = OpLoad %ulong %238
+%772 = OpBitwiseXor %ulong %770 %771
+OpStore %239 %772
+%773 = OpLoad %ulong %239
+%774 = OpIMul %ulong %773 %ulong_1099511628211
+OpStore %240 %774
+%775 = OpLoad %ulong %243
+%776 = OpIAdd %ulong %775 %ulong_1
+OpStore %241 %776
+%777 = OpLoad %ulong %240
+OpStore %242 %777
+%778 = OpLoad %ulong %241
+OpStore %243 %778
+OpBranch %106
+%36 = OpLabel
+%779 = OpLoad %ulong %234
+%780 = OpIMul %ulong %779 %ulong_8
+OpStore %227 %780
+%781 = OpLoad %ulong %139
+%782 = OpLoad %ulong %227
+%783 = OpShiftRightLogical %ulong %781 %782
+OpStore %228 %783
+%784 = OpLoad %ulong %228
+%785 = OpBitwiseAnd %ulong %784 %ulong_255
+OpStore %229 %785
+%786 = OpLoad %ulong %233
+%787 = OpLoad %ulong %229
+%788 = OpBitwiseXor %ulong %786 %787
+OpStore %230 %788
+%789 = OpLoad %ulong %230
+%790 = OpIMul %ulong %789 %ulong_1099511628211
+OpStore %231 %790
+%791 = OpLoad %ulong %234
+%792 = OpIAdd %ulong %791 %ulong_1
+OpStore %232 %792
+%793 = OpLoad %ulong %231
+OpStore %233 %793
+%794 = OpLoad %ulong %232
+OpStore %234 %794
+OpBranch %107
+%31 = OpLabel
+%795 = OpLoad %ulong %225
+%796 = OpIMul %ulong %795 %ulong_8
+OpStore %218 %796
+%797 = OpLoad %ulong %138
+%798 = OpLoad %ulong %218
+%799 = OpShiftRightLogical %ulong %797 %798
+OpStore %219 %799
+%800 = OpLoad %ulong %219
+%801 = OpBitwiseAnd %ulong %800 %ulong_255
+OpStore %220 %801
+%802 = OpLoad %ulong %224
+%803 = OpLoad %ulong %220
+%804 = OpBitwiseXor %ulong %802 %803
+OpStore %221 %804
+%805 = OpLoad %ulong %221
+%806 = OpIMul %ulong %805 %ulong_1099511628211
+OpStore %222 %806
+%807 = OpLoad %ulong %225
+%808 = OpIAdd %ulong %807 %ulong_1
+OpStore %223 %808
+%809 = OpLoad %ulong %222
+OpStore %224 %809
+%810 = OpLoad %ulong %223
+OpStore %225 %810
+OpBranch %108
+%26 = OpLabel
+%811 = OpLoad %ulong %216
+%812 = OpIMul %ulong %811 %ulong_8
+OpStore %209 %812
+%813 = OpLoad %ulong %137
+%814 = OpLoad %ulong %209
+%815 = OpShiftRightLogical %ulong %813 %814
+OpStore %210 %815
+%816 = OpLoad %ulong %210
+%817 = OpBitwiseAnd %ulong %816 %ulong_255
+OpStore %211 %817
+%818 = OpLoad %ulong %215
+%819 = OpLoad %ulong %211
+%820 = OpBitwiseXor %ulong %818 %819
+OpStore %212 %820
+%821 = OpLoad %ulong %212
+%822 = OpIMul %ulong %821 %ulong_1099511628211
+OpStore %213 %822
+%823 = OpLoad %ulong %216
+%824 = OpIAdd %ulong %823 %ulong_1
+OpStore %214 %824
+%825 = OpLoad %ulong %213
+OpStore %215 %825
+%826 = OpLoad %ulong %214
+OpStore %216 %826
+OpBranch %109
+%21 = OpLabel
+%827 = OpLoad %ulong %207
+%828 = OpIMul %ulong %827 %ulong_8
+OpStore %200 %828
+%829 = OpLoad %ulong %136
+%830 = OpLoad %ulong %200
+%831 = OpShiftRightLogical %ulong %829 %830
+OpStore %201 %831
+%832 = OpLoad %ulong %201
+%833 = OpBitwiseAnd %ulong %832 %ulong_255
+OpStore %202 %833
+%834 = OpLoad %ulong %206
+%835 = OpLoad %ulong %202
+%836 = OpBitwiseXor %ulong %834 %835
+OpStore %203 %836
+%837 = OpLoad %ulong %203
+%838 = OpIMul %ulong %837 %ulong_1099511628211
+OpStore %204 %838
+%839 = OpLoad %ulong %207
+%840 = OpIAdd %ulong %839 %ulong_1
+OpStore %205 %840
+%841 = OpLoad %ulong %204
+OpStore %206 %841
+%842 = OpLoad %ulong %205
+OpStore %207 %842
+OpBranch %110
+%16 = OpLabel
+%843 = OpLoad %ulong %198
+%844 = OpIMul %ulong %843 %ulong_8
+OpStore %191 %844
+%845 = OpLoad %ulong %135
+%846 = OpLoad %ulong %191
+%847 = OpShiftRightLogical %ulong %845 %846
+OpStore %192 %847
+%848 = OpLoad %ulong %192
+%849 = OpBitwiseAnd %ulong %848 %ulong_255
+OpStore %193 %849
+%850 = OpLoad %ulong %197
+%851 = OpLoad %ulong %193
+%852 = OpBitwiseXor %ulong %850 %851
+OpStore %194 %852
+%853 = OpLoad %ulong %194
+%854 = OpIMul %ulong %853 %ulong_1099511628211
+OpStore %195 %854
+%855 = OpLoad %ulong %198
+%856 = OpIAdd %ulong %855 %ulong_1
+OpStore %196 %856
+%857 = OpLoad %ulong %195
+OpStore %197 %857
+%858 = OpLoad %ulong %196
+OpStore %198 %858
+OpBranch %111
+%11 = OpLabel
+%859 = OpLoad %ulong %189
+%860 = OpIMul %ulong %859 %ulong_8
+OpStore %182 %860
+%861 = OpLoad %ulong %134
+%862 = OpLoad %ulong %182
+%863 = OpShiftRightLogical %ulong %861 %862
+OpStore %183 %863
+%864 = OpLoad %ulong %183
+%865 = OpBitwiseAnd %ulong %864 %ulong_255
+OpStore %184 %865
+%866 = OpLoad %ulong %188
+%867 = OpLoad %ulong %184
+%868 = OpBitwiseXor %ulong %866 %867
+OpStore %185 %868
+%869 = OpLoad %ulong %185
+%870 = OpIMul %ulong %869 %ulong_1099511628211
+OpStore %186 %870
+%871 = OpLoad %ulong %189
+%872 = OpIAdd %ulong %871 %ulong_1
+OpStore %187 %872
+%873 = OpLoad %ulong %186
+OpStore %188 %873
+%874 = OpLoad %ulong %187
+OpStore %189 %874
+OpBranch %112
+%97 = OpLabel
+OpBranch %91
+%98 = OpLabel
+OpBranch %86
+%99 = OpLabel
+OpBranch %79
+%100 = OpLabel
+OpBranch %72
+%101 = OpLabel
+OpBranch %67
+%102 = OpLabel
+OpBranch %62
+%103 = OpLabel
+OpBranch %57
+%104 = OpLabel
+OpBranch %50
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %35
+%108 = OpLabel
+OpBranch %30
+%109 = OpLabel
+OpBranch %25
+%110 = OpLabel
+OpBranch %20
+%111 = OpLabel
+OpBranch %15
+%112 = OpLabel
+OpBranch %10
 OpFunctionEnd
-%4 = OpFunction %ulong None %366
-%367 = OpFunctionParameter %ulong
-%368 = OpFunctionParameter %uint
-%369 = OpLabel
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_uint Function
-%378 = OpVariable %_ptr_Function_ulong Function
-%379 = OpVariable %_ptr_Function_bool Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_ulong Function
-%384 = OpVariable %_ptr_Function_ulong Function
-%385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_ulong Function
-OpStore %376 %367
-OpStore %377 %368
-%388 = OpLoad %uint %377
-%389 = OpUConvert %ulong %388
-OpStore %378 %389
-OpBranch %370
-%370 = OpLabel
-%390 = OpLoad %ulong %376
-OpStore %386 %390
-OpStore %387 %ulong_0
-OpBranch %371
-%371 = OpLabel
-%391 = OpLoad %ulong %387
-%392 = OpULessThan %bool %391 %ulong_8
-OpStore %379 %392
-%393 = OpLoad %bool %379
-OpLoopMerge %373 %375 None
-OpBranchConditional %393 %372 %373
-%373 = OpLabel
-OpBranch %374
-%374 = OpLabel
-%394 = OpLoad %ulong %386
-OpReturnValue %394
-%372 = OpLabel
-%395 = OpLoad %ulong %387
-%396 = OpIMul %ulong %395 %ulong_8
-OpStore %380 %396
-%397 = OpLoad %ulong %378
-%398 = OpLoad %ulong %380
-%399 = OpShiftRightLogical %ulong %397 %398
-OpStore %381 %399
-%400 = OpLoad %ulong %381
-%401 = OpBitwiseAnd %ulong %400 %ulong_255
-OpStore %382 %401
-%402 = OpLoad %ulong %386
-%403 = OpLoad %ulong %382
-%404 = OpBitwiseXor %ulong %402 %403
-OpStore %383 %404
-%405 = OpLoad %ulong %383
-%406 = OpIMul %ulong %405 %ulong_1099511628211
-OpStore %384 %406
-%407 = OpLoad %ulong %387
-%408 = OpIAdd %ulong %407 %ulong_1
-OpStore %385 %408
-%409 = OpLoad %ulong %384
-OpStore %386 %409
-%410 = OpLoad %ulong %385
-OpStore %387 %410
-OpBranch %375
-%375 = OpLabel
-OpBranch %371
+%2 = OpFunction %ulong None %875
+%876 = OpFunctionParameter %ulong
+%877 = OpFunctionParameter %ulong
+%878 = OpLabel
+%883 = OpVariable %_ptr_Function_ulong Function
+%884 = OpVariable %_ptr_Function_ulong Function
+%885 = OpVariable %_ptr_Function_bool Function
+%886 = OpVariable %_ptr_Function_ulong Function
+%887 = OpVariable %_ptr_Function_ulong Function
+%888 = OpVariable %_ptr_Function_ulong Function
+%889 = OpVariable %_ptr_Function_ulong Function
+%890 = OpVariable %_ptr_Function_ulong Function
+%891 = OpVariable %_ptr_Function_ulong Function
+%892 = OpVariable %_ptr_Function_ulong Function
+%893 = OpVariable %_ptr_Function_ulong Function
+OpStore %883 %876
+OpStore %884 %877
+%894 = OpLoad %ulong %883
+OpStore %892 %894
+OpStore %893 %ulong_0
+OpBranch %879
+%879 = OpLabel
+%895 = OpLoad %ulong %893
+%896 = OpULessThan %bool %895 %ulong_8
+OpStore %885 %896
+%897 = OpLoad %bool %885
+OpLoopMerge %881 %882 None
+OpBranchConditional %897 %880 %881
+%881 = OpLabel
+%898 = OpLoad %ulong %892
+OpReturnValue %898
+%880 = OpLabel
+%899 = OpLoad %ulong %893
+%900 = OpIMul %ulong %899 %ulong_8
+OpStore %886 %900
+%901 = OpLoad %ulong %884
+%902 = OpLoad %ulong %886
+%903 = OpShiftRightLogical %ulong %901 %902
+OpStore %887 %903
+%904 = OpLoad %ulong %887
+%905 = OpBitwiseAnd %ulong %904 %ulong_255
+OpStore %888 %905
+%906 = OpLoad %ulong %892
+%907 = OpLoad %ulong %888
+%908 = OpBitwiseXor %ulong %906 %907
+OpStore %889 %908
+%909 = OpLoad %ulong %889
+%910 = OpIMul %ulong %909 %ulong_1099511628211
+OpStore %890 %910
+%911 = OpLoad %ulong %893
+%912 = OpIAdd %ulong %911 %ulong_1
+OpStore %891 %912
+%913 = OpLoad %ulong %890
+OpStore %892 %913
+%914 = OpLoad %ulong %891
+OpStore %893 %914
+OpBranch %882
+%882 = OpLabel
+OpBranch %879
 OpFunctionEnd

--- a/test/golden/spirv/imm/imm_logic.dis
+++ b/test/golden/spirv/imm/imm_logic.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 363
+; Bound: 793
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,11 +9,16 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_logic.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
 %uint_1431655765 = OpConstant %uint 1431655765
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_252645135 = OpConstant %uint 252645135
 %uint_4294901760 = OpConstant %uint 4294901760
 %uint_65535 = OpConstant %uint 65535
@@ -21,240 +26,75 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_logic.checksum" Export
 %ulong_1085102592571150095 = OpConstant %ulong 1085102592571150095
 %ulong_18446462603027742720 = OpConstant %ulong 18446462603027742720
 %ulong_71777214294589695 = OpConstant %ulong 71777214294589695
-%183 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%186 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%233 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpLabel
-%13 = OpVariable %_ptr_Function_ulong Function
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_uint Function
-%17 = OpVariable %_ptr_Function_uint Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_uint Function
-%20 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_uint Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-%61 = OpFunctionCall %ulong %2
-OpStore %14 %61
-%62 = OpLoad %ulong %13
-%63 = OpUConvert %uint %62
-OpStore %16 %63
-%64 = OpLoad %uint %16
-%66 = OpBitwiseOr %uint %64 %uint_1431655765
-OpStore %17 %66
-%67 = OpLoad %ulong %14
-%68 = OpLoad %uint %17
-%69 = OpFunctionCall %ulong %4 %67 %68
-OpStore %18 %69
-%70 = OpLoad %uint %16
-%71 = OpBitwiseXor %uint %70 %uint_1431655765
-OpStore %19 %71
-%72 = OpLoad %uint %19
-%74 = OpBitwiseAnd %uint %72 %uint_252645135
-OpStore %20 %74
-%75 = OpLoad %ulong %18
-%76 = OpLoad %uint %20
-%77 = OpFunctionCall %ulong %4 %75 %76
-OpStore %21 %77
-%78 = OpLoad %uint %16
-%80 = OpBitwiseOr %uint %78 %uint_4294901760
-OpStore %22 %80
-%81 = OpLoad %ulong %21
-%82 = OpLoad %uint %22
-%83 = OpFunctionCall %ulong %4 %81 %82
-OpStore %23 %83
-%84 = OpLoad %uint %16
-%86 = OpBitwiseAnd %uint %84 %uint_65535
-OpStore %24 %86
-%87 = OpLoad %ulong %23
-%88 = OpLoad %uint %24
-%89 = OpFunctionCall %ulong %4 %87 %88
-OpStore %25 %89
-%90 = OpLoad %uint %16
-%91 = OpNot %uint %90
-OpStore %26 %91
-%92 = OpLoad %ulong %25
-%93 = OpLoad %uint %26
-%94 = OpFunctionCall %ulong %4 %92 %93
-OpStore %27 %94
-%95 = OpLoad %uint %26
-%96 = OpBitwiseOr %uint %95 %uint_1431655765
-OpStore %28 %96
-%97 = OpLoad %uint %28
-%98 = OpNot %uint %97
-OpStore %29 %98
-%99 = OpLoad %ulong %27
-%100 = OpLoad %uint %29
-%101 = OpFunctionCall %ulong %4 %99 %100
-OpStore %30 %101
-%102 = OpLoad %uint %16
-%103 = OpBitwiseAnd %uint %102 %uint_252645135
-OpStore %31 %103
-%104 = OpLoad %uint %31
-%105 = OpBitwiseXor %uint %104 %uint_4294901760
-OpStore %32 %105
-%106 = OpLoad %ulong %30
-%107 = OpLoad %uint %32
-%108 = OpFunctionCall %ulong %4 %106 %107
-OpStore %33 %108
-%109 = OpLoad %ulong %13
-%111 = OpBitwiseOr %ulong %109 %ulong_6148914691236517205
-OpStore %34 %111
-%112 = OpLoad %ulong %33
-%113 = OpLoad %ulong %34
-%114 = OpFunctionCall %ulong %3 %112 %113
-OpStore %35 %114
-%115 = OpLoad %ulong %13
-%116 = OpBitwiseXor %ulong %115 %ulong_6148914691236517205
-OpStore %36 %116
-%117 = OpLoad %ulong %36
-%119 = OpBitwiseAnd %ulong %117 %ulong_1085102592571150095
-OpStore %37 %119
-%120 = OpLoad %ulong %35
-%121 = OpLoad %ulong %37
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %38 %122
-%123 = OpLoad %ulong %13
-%125 = OpBitwiseOr %ulong %123 %ulong_18446462603027742720
-OpStore %39 %125
-%126 = OpLoad %ulong %38
-%127 = OpLoad %ulong %39
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %40 %128
-%129 = OpLoad %ulong %13
-%131 = OpBitwiseAnd %ulong %129 %ulong_71777214294589695
-OpStore %41 %131
-%132 = OpLoad %ulong %40
-%133 = OpLoad %ulong %41
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %42 %134
-%135 = OpLoad %ulong %13
-%136 = OpNot %ulong %135
-OpStore %43 %136
-%137 = OpLoad %ulong %42
-%138 = OpLoad %ulong %43
-%139 = OpFunctionCall %ulong %3 %137 %138
-OpStore %44 %139
-%140 = OpLoad %ulong %43
-%141 = OpBitwiseOr %ulong %140 %ulong_6148914691236517205
-OpStore %45 %141
-%142 = OpLoad %ulong %45
-%143 = OpNot %ulong %142
-OpStore %46 %143
-%144 = OpLoad %ulong %44
-%145 = OpLoad %ulong %46
-%146 = OpFunctionCall %ulong %3 %144 %145
-OpStore %47 %146
-%147 = OpLoad %ulong %13
-%148 = OpBitwiseAnd %ulong %147 %ulong_1085102592571150095
-OpStore %48 %148
-%149 = OpLoad %ulong %48
-%150 = OpBitwiseXor %ulong %149 %ulong_18446462603027742720
-OpStore %49 %150
-%151 = OpLoad %ulong %47
-%152 = OpLoad %ulong %49
-%153 = OpFunctionCall %ulong %3 %151 %152
-OpStore %50 %153
-%154 = OpLoad %ulong %50
-%155 = OpLoad %uint %17
-%156 = OpFunctionCall %ulong %5 %154 %155
-OpStore %51 %156
-%157 = OpLoad %ulong %51
-%158 = OpLoad %uint %26
-%159 = OpFunctionCall %ulong %5 %157 %158
-OpStore %52 %159
-%160 = OpLoad %uint %16
-%161 = OpLoad %uint %26
-%162 = OpBitwiseXor %uint %160 %161
-OpStore %53 %162
-%163 = OpLoad %uint %53
-%164 = OpBitwiseAnd %uint %163 %uint_252645135
-OpStore %54 %164
-%165 = OpLoad %ulong %52
-%166 = OpLoad %uint %54
-%167 = OpFunctionCall %ulong %5 %165 %166
-OpStore %55 %167
-%168 = OpLoad %ulong %55
-%169 = OpLoad %ulong %34
-%170 = OpFunctionCall %ulong %6 %168 %169
-OpStore %56 %170
-%171 = OpLoad %ulong %56
-%172 = OpLoad %ulong %43
-%173 = OpFunctionCall %ulong %6 %171 %172
-OpStore %57 %173
-%174 = OpLoad %ulong %13
-%175 = OpLoad %ulong %43
-%176 = OpBitwiseXor %ulong %174 %175
-OpStore %58 %176
-%177 = OpLoad %ulong %58
-%178 = OpBitwiseAnd %ulong %177 %ulong_1085102592571150095
-OpStore %59 %178
-%179 = OpLoad %ulong %57
-%180 = OpLoad %ulong %59
-%181 = OpFunctionCall %ulong %6 %179 %180
-OpStore %60 %181
-%182 = OpLoad %ulong %60
-OpReturnValue %182
-OpFunctionEnd
-%2 = OpFunction %ulong None %183
-%184 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %186
-%187 = OpFunctionParameter %ulong
-%188 = OpFunctionParameter %ulong
-%189 = OpLabel
+%753 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%134 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_uint Function
+%138 = OpVariable %_ptr_Function_uint Function
+%139 = OpVariable %_ptr_Function_uint Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_uint Function
+%143 = OpVariable %_ptr_Function_uint Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_uint Function
+%159 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_uint Function
+%161 = OpVariable %_ptr_Function_uint Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_bool Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
 %195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_bool Function
 %199 = OpVariable %_ptr_Function_ulong Function
 %200 = OpVariable %_ptr_Function_ulong Function
@@ -264,57 +104,44 @@ OpFunctionEnd
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
 %206 = OpVariable %_ptr_Function_ulong Function
-OpStore %195 %187
-OpStore %196 %188
-%207 = OpLoad %ulong %195
-OpStore %205 %207
-OpStore %206 %ulong_0
-OpBranch %190
-%190 = OpLabel
-%209 = OpLoad %ulong %206
-%211 = OpULessThan %bool %209 %ulong_8
-OpStore %198 %211
-%212 = OpLoad %bool %198
-OpLoopMerge %192 %193 None
-OpBranchConditional %212 %191 %192
-%192 = OpLabel
-%213 = OpLoad %ulong %205
-OpReturnValue %213
-%191 = OpLabel
-%214 = OpLoad %ulong %206
-%215 = OpIMul %ulong %214 %ulong_8
-OpStore %199 %215
-%216 = OpLoad %ulong %196
-%217 = OpLoad %ulong %199
-%218 = OpShiftRightLogical %ulong %216 %217
-OpStore %200 %218
-%219 = OpLoad %ulong %200
-%221 = OpBitwiseAnd %ulong %219 %ulong_255
-OpStore %201 %221
-%222 = OpLoad %ulong %205
-%223 = OpLoad %ulong %201
-%224 = OpBitwiseXor %ulong %222 %223
-OpStore %202 %224
-%225 = OpLoad %ulong %202
-%227 = OpIMul %ulong %225 %ulong_1099511628211
-OpStore %203 %227
-%228 = OpLoad %ulong %206
-%230 = OpIAdd %ulong %228 %ulong_1
-OpStore %204 %230
-%231 = OpLoad %ulong %203
-OpStore %205 %231
-%232 = OpLoad %ulong %204
-OpStore %206 %232
-OpBranch %193
-%193 = OpLabel
-OpBranch %190
-OpFunctionEnd
-%4 = OpFunction %ulong None %233
-%234 = OpFunctionParameter %ulong
-%235 = OpFunctionParameter %uint
-%236 = OpLabel
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_bool Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_bool Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_bool Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
 %243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_uint Function
+%244 = OpVariable %_ptr_Function_ulong Function
 %245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_bool Function
 %247 = OpVariable %_ptr_Function_ulong Function
@@ -325,67 +152,43 @@ OpFunctionEnd
 %252 = OpVariable %_ptr_Function_ulong Function
 %253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
-OpStore %243 %234
-OpStore %244 %235
-%255 = OpLoad %uint %244
-%256 = OpUConvert %ulong %255
-OpStore %245 %256
-OpBranch %237
-%237 = OpLabel
-%257 = OpLoad %ulong %243
-OpStore %253 %257
-OpStore %254 %ulong_0
-OpBranch %238
-%238 = OpLabel
-%258 = OpLoad %ulong %254
-%259 = OpULessThan %bool %258 %ulong_8
-OpStore %246 %259
-%260 = OpLoad %bool %246
-OpLoopMerge %240 %242 None
-OpBranchConditional %260 %239 %240
-%240 = OpLabel
-OpBranch %241
-%241 = OpLabel
-%261 = OpLoad %ulong %253
-OpReturnValue %261
-%239 = OpLabel
-%262 = OpLoad %ulong %254
-%263 = OpIMul %ulong %262 %ulong_8
-OpStore %247 %263
-%264 = OpLoad %ulong %245
-%265 = OpLoad %ulong %247
-%266 = OpShiftRightLogical %ulong %264 %265
-OpStore %248 %266
-%267 = OpLoad %ulong %248
-%268 = OpBitwiseAnd %ulong %267 %ulong_255
-OpStore %249 %268
-%269 = OpLoad %ulong %253
-%270 = OpLoad %ulong %249
-%271 = OpBitwiseXor %ulong %269 %270
-OpStore %250 %271
-%272 = OpLoad %ulong %250
-%273 = OpIMul %ulong %272 %ulong_1099511628211
-OpStore %251 %273
-%274 = OpLoad %ulong %254
-%275 = OpIAdd %ulong %274 %ulong_1
-OpStore %252 %275
-%276 = OpLoad %ulong %251
-OpStore %253 %276
-%277 = OpLoad %ulong %252
-OpStore %254 %277
-OpBranch %242
-%242 = OpLabel
-OpBranch %238
-OpFunctionEnd
-%5 = OpFunction %ulong None %233
-%278 = OpFunctionParameter %ulong
-%279 = OpFunctionParameter %uint
-%280 = OpLabel
+%255 = OpVariable %_ptr_Function_bool Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_bool Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_bool Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_bool Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
 %287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_ulong Function
 %289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_bool Function
-%291 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_bool Function
 %292 = OpVariable %_ptr_Function_ulong Function
 %293 = OpVariable %_ptr_Function_ulong Function
 %294 = OpVariable %_ptr_Function_ulong Function
@@ -393,119 +196,990 @@ OpFunctionEnd
 %296 = OpVariable %_ptr_Function_ulong Function
 %297 = OpVariable %_ptr_Function_ulong Function
 %298 = OpVariable %_ptr_Function_ulong Function
-OpStore %287 %278
-OpStore %288 %279
-%299 = OpLoad %uint %288
-%300 = OpSConvert %ulong %299
-OpStore %289 %300
-OpBranch %281
-%281 = OpLabel
-%301 = OpLoad %ulong %287
-OpStore %297 %301
-OpStore %298 %ulong_0
-OpBranch %282
-%282 = OpLabel
-%302 = OpLoad %ulong %298
-%303 = OpULessThan %bool %302 %ulong_8
-OpStore %290 %303
-%304 = OpLoad %bool %290
-OpLoopMerge %284 %286 None
-OpBranchConditional %304 %283 %284
-%284 = OpLabel
-OpBranch %285
-%285 = OpLabel
-%305 = OpLoad %ulong %297
-OpReturnValue %305
-%283 = OpLabel
-%306 = OpLoad %ulong %298
-%307 = OpIMul %ulong %306 %ulong_8
-OpStore %291 %307
-%308 = OpLoad %ulong %289
-%309 = OpLoad %ulong %291
-%310 = OpShiftRightLogical %ulong %308 %309
-OpStore %292 %310
-%311 = OpLoad %ulong %292
-%312 = OpBitwiseAnd %ulong %311 %ulong_255
-OpStore %293 %312
-%313 = OpLoad %ulong %297
-%314 = OpLoad %ulong %293
-%315 = OpBitwiseXor %ulong %313 %314
-OpStore %294 %315
-%316 = OpLoad %ulong %294
-%317 = OpIMul %ulong %316 %ulong_1099511628211
-OpStore %295 %317
-%318 = OpLoad %ulong %298
-%319 = OpIAdd %ulong %318 %ulong_1
-OpStore %296 %319
-%320 = OpLoad %ulong %295
-OpStore %297 %320
-%321 = OpLoad %ulong %296
-OpStore %298 %321
-OpBranch %286
-%286 = OpLabel
-OpBranch %282
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_bool Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_bool Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+OpStore %134 %5
+OpBranch %7
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%325 = OpLoad %ulong %134
+%326 = OpUConvert %uint %325
+OpStore %136 %326
+%327 = OpLoad %uint %136
+%329 = OpBitwiseOr %uint %327 %uint_1431655765
+OpStore %137 %329
+OpBranch %9
+%9 = OpLabel
+%330 = OpLoad %uint %137
+%331 = OpUConvert %ulong %330
+OpStore %166 %331
+OpBranch %11
+%11 = OpLabel
+OpStore %175 %ulong_14695981039346656037
+OpStore %176 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%334 = OpLoad %ulong %176
+%336 = OpULessThan %bool %334 %ulong_8
+OpStore %168 %336
+%337 = OpLoad %bool %168
+OpLoopMerge %14 %130 None
+OpBranchConditional %337 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%338 = OpLoad %uint %136
+%339 = OpBitwiseXor %uint %338 %uint_1431655765
+OpStore %138 %339
+%340 = OpLoad %uint %138
+%342 = OpBitwiseAnd %uint %340 %uint_252645135
+OpStore %139 %342
+OpBranch %16
+%16 = OpLabel
+%343 = OpLoad %uint %139
+%344 = OpUConvert %ulong %343
+OpStore %177 %344
+OpBranch %18
+%18 = OpLabel
+%345 = OpLoad %ulong %175
+OpStore %185 %345
+OpStore %186 %ulong_0
+OpBranch %19
+%19 = OpLabel
+%346 = OpLoad %ulong %186
+%347 = OpULessThan %bool %346 %ulong_8
+OpStore %178 %347
+%348 = OpLoad %bool %178
+OpLoopMerge %21 %129 None
+OpBranchConditional %348 %20 %21
+%21 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%349 = OpLoad %uint %136
+%351 = OpBitwiseOr %uint %349 %uint_4294901760
+OpStore %140 %351
+OpBranch %23
+%23 = OpLabel
+%352 = OpLoad %uint %140
+%353 = OpUConvert %ulong %352
+OpStore %187 %353
+OpBranch %25
+%25 = OpLabel
+%354 = OpLoad %ulong %185
+OpStore %195 %354
+OpStore %196 %ulong_0
+OpBranch %26
+%26 = OpLabel
+%355 = OpLoad %ulong %196
+%356 = OpULessThan %bool %355 %ulong_8
+OpStore %188 %356
+%357 = OpLoad %bool %188
+OpLoopMerge %28 %128 None
+OpBranchConditional %357 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+OpBranch %24
+%24 = OpLabel
+%358 = OpLoad %uint %136
+%360 = OpBitwiseAnd %uint %358 %uint_65535
+OpStore %141 %360
+OpBranch %30
+%30 = OpLabel
+%361 = OpLoad %uint %141
+%362 = OpUConvert %ulong %361
+OpStore %197 %362
+OpBranch %32
+%32 = OpLabel
+%363 = OpLoad %ulong %195
+OpStore %205 %363
+OpStore %206 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%364 = OpLoad %ulong %206
+%365 = OpULessThan %bool %364 %ulong_8
+OpStore %198 %365
+%366 = OpLoad %bool %198
+OpLoopMerge %35 %127 None
+OpBranchConditional %366 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%367 = OpLoad %uint %136
+%368 = OpNot %uint %367
+OpStore %142 %368
+OpBranch %37
+%37 = OpLabel
+%369 = OpLoad %uint %142
+%370 = OpUConvert %ulong %369
+OpStore %207 %370
+OpBranch %39
+%39 = OpLabel
+%371 = OpLoad %ulong %205
+OpStore %215 %371
+OpStore %216 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%372 = OpLoad %ulong %216
+%373 = OpULessThan %bool %372 %ulong_8
+OpStore %208 %373
+%374 = OpLoad %bool %208
+OpLoopMerge %42 %126 None
+OpBranchConditional %374 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%375 = OpLoad %uint %142
+%376 = OpBitwiseOr %uint %375 %uint_1431655765
+OpStore %143 %376
+%377 = OpLoad %uint %143
+%378 = OpNot %uint %377
+OpStore %144 %378
+OpBranch %44
+%44 = OpLabel
+%379 = OpLoad %uint %144
+%380 = OpUConvert %ulong %379
+OpStore %217 %380
+OpBranch %46
+%46 = OpLabel
+%381 = OpLoad %ulong %215
+OpStore %225 %381
+OpStore %226 %ulong_0
+OpBranch %47
+%47 = OpLabel
+%382 = OpLoad %ulong %226
+%383 = OpULessThan %bool %382 %ulong_8
+OpStore %218 %383
+%384 = OpLoad %bool %218
+OpLoopMerge %49 %125 None
+OpBranchConditional %384 %48 %49
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%385 = OpLoad %uint %136
+%386 = OpBitwiseAnd %uint %385 %uint_252645135
+OpStore %145 %386
+%387 = OpLoad %uint %145
+%388 = OpBitwiseXor %uint %387 %uint_4294901760
+OpStore %146 %388
+OpBranch %51
+%51 = OpLabel
+%389 = OpLoad %uint %146
+%390 = OpUConvert %ulong %389
+OpStore %227 %390
+OpBranch %53
+%53 = OpLabel
+%391 = OpLoad %ulong %225
+OpStore %235 %391
+OpStore %236 %ulong_0
+OpBranch %54
+%54 = OpLabel
+%392 = OpLoad %ulong %236
+%393 = OpULessThan %bool %392 %ulong_8
+OpStore %228 %393
+%394 = OpLoad %bool %228
+OpLoopMerge %56 %124 None
+OpBranchConditional %394 %55 %56
+%56 = OpLabel
+OpBranch %57
+%57 = OpLabel
+OpBranch %52
+%52 = OpLabel
+%395 = OpLoad %ulong %134
+%397 = OpBitwiseOr %ulong %395 %ulong_6148914691236517205
+OpStore %147 %397
+OpBranch %58
+%58 = OpLabel
+%398 = OpLoad %ulong %235
+OpStore %244 %398
+OpStore %245 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%399 = OpLoad %ulong %245
+%400 = OpULessThan %bool %399 %ulong_8
+OpStore %237 %400
+%401 = OpLoad %bool %237
+OpLoopMerge %61 %123 None
+OpBranchConditional %401 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%402 = OpLoad %ulong %134
+%403 = OpBitwiseXor %ulong %402 %ulong_6148914691236517205
+OpStore %148 %403
+%404 = OpLoad %ulong %148
+%406 = OpBitwiseAnd %ulong %404 %ulong_1085102592571150095
+OpStore %149 %406
+OpBranch %63
+%63 = OpLabel
+%407 = OpLoad %ulong %244
+OpStore %253 %407
+OpStore %254 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%408 = OpLoad %ulong %254
+%409 = OpULessThan %bool %408 %ulong_8
+OpStore %246 %409
+%410 = OpLoad %bool %246
+OpLoopMerge %66 %122 None
+OpBranchConditional %410 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%411 = OpLoad %ulong %134
+%413 = OpBitwiseOr %ulong %411 %ulong_18446462603027742720
+OpStore %150 %413
+OpBranch %68
+%68 = OpLabel
+%414 = OpLoad %ulong %253
+OpStore %262 %414
+OpStore %263 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%415 = OpLoad %ulong %263
+%416 = OpULessThan %bool %415 %ulong_8
+OpStore %255 %416
+%417 = OpLoad %bool %255
+OpLoopMerge %71 %121 None
+OpBranchConditional %417 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%418 = OpLoad %ulong %134
+%420 = OpBitwiseAnd %ulong %418 %ulong_71777214294589695
+OpStore %151 %420
+OpBranch %73
+%73 = OpLabel
+%421 = OpLoad %ulong %262
+OpStore %271 %421
+OpStore %272 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%422 = OpLoad %ulong %272
+%423 = OpULessThan %bool %422 %ulong_8
+OpStore %264 %423
+%424 = OpLoad %bool %264
+OpLoopMerge %76 %120 None
+OpBranchConditional %424 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%425 = OpLoad %ulong %134
+%426 = OpNot %ulong %425
+OpStore %152 %426
+OpBranch %78
+%78 = OpLabel
+%427 = OpLoad %ulong %271
+OpStore %280 %427
+OpStore %281 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%428 = OpLoad %ulong %281
+%429 = OpULessThan %bool %428 %ulong_8
+OpStore %273 %429
+%430 = OpLoad %bool %273
+OpLoopMerge %81 %119 None
+OpBranchConditional %430 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+%431 = OpLoad %ulong %152
+%432 = OpBitwiseOr %ulong %431 %ulong_6148914691236517205
+OpStore %153 %432
+%433 = OpLoad %ulong %153
+%434 = OpNot %ulong %433
+OpStore %154 %434
+OpBranch %83
+%83 = OpLabel
+%435 = OpLoad %ulong %280
+OpStore %289 %435
+OpStore %290 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%436 = OpLoad %ulong %290
+%437 = OpULessThan %bool %436 %ulong_8
+OpStore %282 %437
+%438 = OpLoad %bool %282
+OpLoopMerge %86 %118 None
+OpBranchConditional %438 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+%439 = OpLoad %ulong %134
+%440 = OpBitwiseAnd %ulong %439 %ulong_1085102592571150095
+OpStore %155 %440
+%441 = OpLoad %ulong %155
+%442 = OpBitwiseXor %ulong %441 %ulong_18446462603027742720
+OpStore %156 %442
+OpBranch %88
+%88 = OpLabel
+%443 = OpLoad %ulong %289
+OpStore %298 %443
+OpStore %299 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%444 = OpLoad %ulong %299
+%445 = OpULessThan %bool %444 %ulong_8
+OpStore %291 %445
+%446 = OpLoad %bool %291
+OpLoopMerge %91 %117 None
+OpBranchConditional %446 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%447 = OpLoad %ulong %134
+%448 = OpUConvert %uint %447
+OpStore %157 %448
+%449 = OpLoad %uint %157
+%450 = OpBitwiseOr %uint %449 %uint_1431655765
+OpStore %158 %450
+OpBranch %93
+%93 = OpLabel
+%451 = OpLoad %uint %158
+%452 = OpSConvert %ulong %451
+OpStore %300 %452
+OpBranch %95
+%95 = OpLabel
+%453 = OpLoad %ulong %298
+OpStore %308 %453
+OpStore %309 %ulong_0
+OpBranch %96
+%96 = OpLabel
+%454 = OpLoad %ulong %309
+%455 = OpULessThan %bool %454 %ulong_8
+OpStore %301 %455
+%456 = OpLoad %bool %301
+OpLoopMerge %98 %116 None
+OpBranchConditional %456 %97 %98
+%98 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%457 = OpLoad %uint %157
+%458 = OpNot %uint %457
+OpStore %159 %458
+OpBranch %100
+%100 = OpLabel
+%459 = OpLoad %uint %159
+%460 = OpSConvert %ulong %459
+OpStore %310 %460
+OpBranch %102
+%102 = OpLabel
+%461 = OpLoad %ulong %308
+OpStore %318 %461
+OpStore %319 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%462 = OpLoad %ulong %319
+%463 = OpULessThan %bool %462 %ulong_8
+OpStore %311 %463
+%464 = OpLoad %bool %311
+OpLoopMerge %105 %115 None
+OpBranchConditional %464 %104 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%465 = OpLoad %uint %157
+%466 = OpLoad %uint %159
+%467 = OpBitwiseXor %uint %465 %466
+OpStore %160 %467
+%468 = OpLoad %uint %160
+%469 = OpBitwiseAnd %uint %468 %uint_252645135
+OpStore %161 %469
+OpBranch %107
+%107 = OpLabel
+%470 = OpLoad %uint %161
+%471 = OpSConvert %ulong %470
+OpStore %320 %471
+%472 = OpLoad %ulong %318
+%473 = OpLoad %ulong %320
+%474 = OpFunctionCall %ulong %2 %472 %473
+OpStore %321 %474
+OpBranch %108
+%108 = OpLabel
+%475 = OpLoad %ulong %134
+%476 = OpBitwiseOr %ulong %475 %ulong_6148914691236517205
+OpStore %162 %476
+OpBranch %109
+%109 = OpLabel
+%477 = OpLoad %ulong %321
+%478 = OpLoad %ulong %162
+%479 = OpFunctionCall %ulong %2 %477 %478
+OpStore %322 %479
+OpBranch %110
+%110 = OpLabel
+%480 = OpLoad %ulong %134
+%481 = OpNot %ulong %480
+OpStore %163 %481
+OpBranch %111
+%111 = OpLabel
+%482 = OpLoad %ulong %322
+%483 = OpLoad %ulong %163
+%484 = OpFunctionCall %ulong %2 %482 %483
+OpStore %323 %484
+OpBranch %112
+%112 = OpLabel
+%485 = OpLoad %ulong %134
+%486 = OpLoad %ulong %163
+%487 = OpBitwiseXor %ulong %485 %486
+OpStore %164 %487
+%488 = OpLoad %ulong %164
+%489 = OpBitwiseAnd %ulong %488 %ulong_1085102592571150095
+OpStore %165 %489
+OpBranch %113
+%113 = OpLabel
+%490 = OpLoad %ulong %323
+%491 = OpLoad %ulong %165
+%492 = OpFunctionCall %ulong %2 %490 %491
+OpStore %324 %492
+OpBranch %114
+%114 = OpLabel
+%493 = OpLoad %ulong %324
+OpReturnValue %493
+%104 = OpLabel
+%494 = OpLoad %ulong %319
+%495 = OpIMul %ulong %494 %ulong_8
+OpStore %312 %495
+%496 = OpLoad %ulong %310
+%497 = OpLoad %ulong %312
+%498 = OpShiftRightLogical %ulong %496 %497
+OpStore %313 %498
+%499 = OpLoad %ulong %313
+%501 = OpBitwiseAnd %ulong %499 %ulong_255
+OpStore %314 %501
+%502 = OpLoad %ulong %318
+%503 = OpLoad %ulong %314
+%504 = OpBitwiseXor %ulong %502 %503
+OpStore %315 %504
+%505 = OpLoad %ulong %315
+%507 = OpIMul %ulong %505 %ulong_1099511628211
+OpStore %316 %507
+%508 = OpLoad %ulong %319
+%510 = OpIAdd %ulong %508 %ulong_1
+OpStore %317 %510
+%511 = OpLoad %ulong %316
+OpStore %318 %511
+%512 = OpLoad %ulong %317
+OpStore %319 %512
+OpBranch %115
+%97 = OpLabel
+%513 = OpLoad %ulong %309
+%514 = OpIMul %ulong %513 %ulong_8
+OpStore %302 %514
+%515 = OpLoad %ulong %300
+%516 = OpLoad %ulong %302
+%517 = OpShiftRightLogical %ulong %515 %516
+OpStore %303 %517
+%518 = OpLoad %ulong %303
+%519 = OpBitwiseAnd %ulong %518 %ulong_255
+OpStore %304 %519
+%520 = OpLoad %ulong %308
+%521 = OpLoad %ulong %304
+%522 = OpBitwiseXor %ulong %520 %521
+OpStore %305 %522
+%523 = OpLoad %ulong %305
+%524 = OpIMul %ulong %523 %ulong_1099511628211
+OpStore %306 %524
+%525 = OpLoad %ulong %309
+%526 = OpIAdd %ulong %525 %ulong_1
+OpStore %307 %526
+%527 = OpLoad %ulong %306
+OpStore %308 %527
+%528 = OpLoad %ulong %307
+OpStore %309 %528
+OpBranch %116
+%90 = OpLabel
+%529 = OpLoad %ulong %299
+%530 = OpIMul %ulong %529 %ulong_8
+OpStore %292 %530
+%531 = OpLoad %ulong %156
+%532 = OpLoad %ulong %292
+%533 = OpShiftRightLogical %ulong %531 %532
+OpStore %293 %533
+%534 = OpLoad %ulong %293
+%535 = OpBitwiseAnd %ulong %534 %ulong_255
+OpStore %294 %535
+%536 = OpLoad %ulong %298
+%537 = OpLoad %ulong %294
+%538 = OpBitwiseXor %ulong %536 %537
+OpStore %295 %538
+%539 = OpLoad %ulong %295
+%540 = OpIMul %ulong %539 %ulong_1099511628211
+OpStore %296 %540
+%541 = OpLoad %ulong %299
+%542 = OpIAdd %ulong %541 %ulong_1
+OpStore %297 %542
+%543 = OpLoad %ulong %296
+OpStore %298 %543
+%544 = OpLoad %ulong %297
+OpStore %299 %544
+OpBranch %117
+%85 = OpLabel
+%545 = OpLoad %ulong %290
+%546 = OpIMul %ulong %545 %ulong_8
+OpStore %283 %546
+%547 = OpLoad %ulong %154
+%548 = OpLoad %ulong %283
+%549 = OpShiftRightLogical %ulong %547 %548
+OpStore %284 %549
+%550 = OpLoad %ulong %284
+%551 = OpBitwiseAnd %ulong %550 %ulong_255
+OpStore %285 %551
+%552 = OpLoad %ulong %289
+%553 = OpLoad %ulong %285
+%554 = OpBitwiseXor %ulong %552 %553
+OpStore %286 %554
+%555 = OpLoad %ulong %286
+%556 = OpIMul %ulong %555 %ulong_1099511628211
+OpStore %287 %556
+%557 = OpLoad %ulong %290
+%558 = OpIAdd %ulong %557 %ulong_1
+OpStore %288 %558
+%559 = OpLoad %ulong %287
+OpStore %289 %559
+%560 = OpLoad %ulong %288
+OpStore %290 %560
+OpBranch %118
+%80 = OpLabel
+%561 = OpLoad %ulong %281
+%562 = OpIMul %ulong %561 %ulong_8
+OpStore %274 %562
+%563 = OpLoad %ulong %152
+%564 = OpLoad %ulong %274
+%565 = OpShiftRightLogical %ulong %563 %564
+OpStore %275 %565
+%566 = OpLoad %ulong %275
+%567 = OpBitwiseAnd %ulong %566 %ulong_255
+OpStore %276 %567
+%568 = OpLoad %ulong %280
+%569 = OpLoad %ulong %276
+%570 = OpBitwiseXor %ulong %568 %569
+OpStore %277 %570
+%571 = OpLoad %ulong %277
+%572 = OpIMul %ulong %571 %ulong_1099511628211
+OpStore %278 %572
+%573 = OpLoad %ulong %281
+%574 = OpIAdd %ulong %573 %ulong_1
+OpStore %279 %574
+%575 = OpLoad %ulong %278
+OpStore %280 %575
+%576 = OpLoad %ulong %279
+OpStore %281 %576
+OpBranch %119
+%75 = OpLabel
+%577 = OpLoad %ulong %272
+%578 = OpIMul %ulong %577 %ulong_8
+OpStore %265 %578
+%579 = OpLoad %ulong %151
+%580 = OpLoad %ulong %265
+%581 = OpShiftRightLogical %ulong %579 %580
+OpStore %266 %581
+%582 = OpLoad %ulong %266
+%583 = OpBitwiseAnd %ulong %582 %ulong_255
+OpStore %267 %583
+%584 = OpLoad %ulong %271
+%585 = OpLoad %ulong %267
+%586 = OpBitwiseXor %ulong %584 %585
+OpStore %268 %586
+%587 = OpLoad %ulong %268
+%588 = OpIMul %ulong %587 %ulong_1099511628211
+OpStore %269 %588
+%589 = OpLoad %ulong %272
+%590 = OpIAdd %ulong %589 %ulong_1
+OpStore %270 %590
+%591 = OpLoad %ulong %269
+OpStore %271 %591
+%592 = OpLoad %ulong %270
+OpStore %272 %592
+OpBranch %120
+%70 = OpLabel
+%593 = OpLoad %ulong %263
+%594 = OpIMul %ulong %593 %ulong_8
+OpStore %256 %594
+%595 = OpLoad %ulong %150
+%596 = OpLoad %ulong %256
+%597 = OpShiftRightLogical %ulong %595 %596
+OpStore %257 %597
+%598 = OpLoad %ulong %257
+%599 = OpBitwiseAnd %ulong %598 %ulong_255
+OpStore %258 %599
+%600 = OpLoad %ulong %262
+%601 = OpLoad %ulong %258
+%602 = OpBitwiseXor %ulong %600 %601
+OpStore %259 %602
+%603 = OpLoad %ulong %259
+%604 = OpIMul %ulong %603 %ulong_1099511628211
+OpStore %260 %604
+%605 = OpLoad %ulong %263
+%606 = OpIAdd %ulong %605 %ulong_1
+OpStore %261 %606
+%607 = OpLoad %ulong %260
+OpStore %262 %607
+%608 = OpLoad %ulong %261
+OpStore %263 %608
+OpBranch %121
+%65 = OpLabel
+%609 = OpLoad %ulong %254
+%610 = OpIMul %ulong %609 %ulong_8
+OpStore %247 %610
+%611 = OpLoad %ulong %149
+%612 = OpLoad %ulong %247
+%613 = OpShiftRightLogical %ulong %611 %612
+OpStore %248 %613
+%614 = OpLoad %ulong %248
+%615 = OpBitwiseAnd %ulong %614 %ulong_255
+OpStore %249 %615
+%616 = OpLoad %ulong %253
+%617 = OpLoad %ulong %249
+%618 = OpBitwiseXor %ulong %616 %617
+OpStore %250 %618
+%619 = OpLoad %ulong %250
+%620 = OpIMul %ulong %619 %ulong_1099511628211
+OpStore %251 %620
+%621 = OpLoad %ulong %254
+%622 = OpIAdd %ulong %621 %ulong_1
+OpStore %252 %622
+%623 = OpLoad %ulong %251
+OpStore %253 %623
+%624 = OpLoad %ulong %252
+OpStore %254 %624
+OpBranch %122
+%60 = OpLabel
+%625 = OpLoad %ulong %245
+%626 = OpIMul %ulong %625 %ulong_8
+OpStore %238 %626
+%627 = OpLoad %ulong %147
+%628 = OpLoad %ulong %238
+%629 = OpShiftRightLogical %ulong %627 %628
+OpStore %239 %629
+%630 = OpLoad %ulong %239
+%631 = OpBitwiseAnd %ulong %630 %ulong_255
+OpStore %240 %631
+%632 = OpLoad %ulong %244
+%633 = OpLoad %ulong %240
+%634 = OpBitwiseXor %ulong %632 %633
+OpStore %241 %634
+%635 = OpLoad %ulong %241
+%636 = OpIMul %ulong %635 %ulong_1099511628211
+OpStore %242 %636
+%637 = OpLoad %ulong %245
+%638 = OpIAdd %ulong %637 %ulong_1
+OpStore %243 %638
+%639 = OpLoad %ulong %242
+OpStore %244 %639
+%640 = OpLoad %ulong %243
+OpStore %245 %640
+OpBranch %123
+%55 = OpLabel
+%641 = OpLoad %ulong %236
+%642 = OpIMul %ulong %641 %ulong_8
+OpStore %229 %642
+%643 = OpLoad %ulong %227
+%644 = OpLoad %ulong %229
+%645 = OpShiftRightLogical %ulong %643 %644
+OpStore %230 %645
+%646 = OpLoad %ulong %230
+%647 = OpBitwiseAnd %ulong %646 %ulong_255
+OpStore %231 %647
+%648 = OpLoad %ulong %235
+%649 = OpLoad %ulong %231
+%650 = OpBitwiseXor %ulong %648 %649
+OpStore %232 %650
+%651 = OpLoad %ulong %232
+%652 = OpIMul %ulong %651 %ulong_1099511628211
+OpStore %233 %652
+%653 = OpLoad %ulong %236
+%654 = OpIAdd %ulong %653 %ulong_1
+OpStore %234 %654
+%655 = OpLoad %ulong %233
+OpStore %235 %655
+%656 = OpLoad %ulong %234
+OpStore %236 %656
+OpBranch %124
+%48 = OpLabel
+%657 = OpLoad %ulong %226
+%658 = OpIMul %ulong %657 %ulong_8
+OpStore %219 %658
+%659 = OpLoad %ulong %217
+%660 = OpLoad %ulong %219
+%661 = OpShiftRightLogical %ulong %659 %660
+OpStore %220 %661
+%662 = OpLoad %ulong %220
+%663 = OpBitwiseAnd %ulong %662 %ulong_255
+OpStore %221 %663
+%664 = OpLoad %ulong %225
+%665 = OpLoad %ulong %221
+%666 = OpBitwiseXor %ulong %664 %665
+OpStore %222 %666
+%667 = OpLoad %ulong %222
+%668 = OpIMul %ulong %667 %ulong_1099511628211
+OpStore %223 %668
+%669 = OpLoad %ulong %226
+%670 = OpIAdd %ulong %669 %ulong_1
+OpStore %224 %670
+%671 = OpLoad %ulong %223
+OpStore %225 %671
+%672 = OpLoad %ulong %224
+OpStore %226 %672
+OpBranch %125
+%41 = OpLabel
+%673 = OpLoad %ulong %216
+%674 = OpIMul %ulong %673 %ulong_8
+OpStore %209 %674
+%675 = OpLoad %ulong %207
+%676 = OpLoad %ulong %209
+%677 = OpShiftRightLogical %ulong %675 %676
+OpStore %210 %677
+%678 = OpLoad %ulong %210
+%679 = OpBitwiseAnd %ulong %678 %ulong_255
+OpStore %211 %679
+%680 = OpLoad %ulong %215
+%681 = OpLoad %ulong %211
+%682 = OpBitwiseXor %ulong %680 %681
+OpStore %212 %682
+%683 = OpLoad %ulong %212
+%684 = OpIMul %ulong %683 %ulong_1099511628211
+OpStore %213 %684
+%685 = OpLoad %ulong %216
+%686 = OpIAdd %ulong %685 %ulong_1
+OpStore %214 %686
+%687 = OpLoad %ulong %213
+OpStore %215 %687
+%688 = OpLoad %ulong %214
+OpStore %216 %688
+OpBranch %126
+%34 = OpLabel
+%689 = OpLoad %ulong %206
+%690 = OpIMul %ulong %689 %ulong_8
+OpStore %199 %690
+%691 = OpLoad %ulong %197
+%692 = OpLoad %ulong %199
+%693 = OpShiftRightLogical %ulong %691 %692
+OpStore %200 %693
+%694 = OpLoad %ulong %200
+%695 = OpBitwiseAnd %ulong %694 %ulong_255
+OpStore %201 %695
+%696 = OpLoad %ulong %205
+%697 = OpLoad %ulong %201
+%698 = OpBitwiseXor %ulong %696 %697
+OpStore %202 %698
+%699 = OpLoad %ulong %202
+%700 = OpIMul %ulong %699 %ulong_1099511628211
+OpStore %203 %700
+%701 = OpLoad %ulong %206
+%702 = OpIAdd %ulong %701 %ulong_1
+OpStore %204 %702
+%703 = OpLoad %ulong %203
+OpStore %205 %703
+%704 = OpLoad %ulong %204
+OpStore %206 %704
+OpBranch %127
+%27 = OpLabel
+%705 = OpLoad %ulong %196
+%706 = OpIMul %ulong %705 %ulong_8
+OpStore %189 %706
+%707 = OpLoad %ulong %187
+%708 = OpLoad %ulong %189
+%709 = OpShiftRightLogical %ulong %707 %708
+OpStore %190 %709
+%710 = OpLoad %ulong %190
+%711 = OpBitwiseAnd %ulong %710 %ulong_255
+OpStore %191 %711
+%712 = OpLoad %ulong %195
+%713 = OpLoad %ulong %191
+%714 = OpBitwiseXor %ulong %712 %713
+OpStore %192 %714
+%715 = OpLoad %ulong %192
+%716 = OpIMul %ulong %715 %ulong_1099511628211
+OpStore %193 %716
+%717 = OpLoad %ulong %196
+%718 = OpIAdd %ulong %717 %ulong_1
+OpStore %194 %718
+%719 = OpLoad %ulong %193
+OpStore %195 %719
+%720 = OpLoad %ulong %194
+OpStore %196 %720
+OpBranch %128
+%20 = OpLabel
+%721 = OpLoad %ulong %186
+%722 = OpIMul %ulong %721 %ulong_8
+OpStore %179 %722
+%723 = OpLoad %ulong %177
+%724 = OpLoad %ulong %179
+%725 = OpShiftRightLogical %ulong %723 %724
+OpStore %180 %725
+%726 = OpLoad %ulong %180
+%727 = OpBitwiseAnd %ulong %726 %ulong_255
+OpStore %181 %727
+%728 = OpLoad %ulong %185
+%729 = OpLoad %ulong %181
+%730 = OpBitwiseXor %ulong %728 %729
+OpStore %182 %730
+%731 = OpLoad %ulong %182
+%732 = OpIMul %ulong %731 %ulong_1099511628211
+OpStore %183 %732
+%733 = OpLoad %ulong %186
+%734 = OpIAdd %ulong %733 %ulong_1
+OpStore %184 %734
+%735 = OpLoad %ulong %183
+OpStore %185 %735
+%736 = OpLoad %ulong %184
+OpStore %186 %736
+OpBranch %129
+%13 = OpLabel
+%737 = OpLoad %ulong %176
+%738 = OpIMul %ulong %737 %ulong_8
+OpStore %169 %738
+%739 = OpLoad %ulong %166
+%740 = OpLoad %ulong %169
+%741 = OpShiftRightLogical %ulong %739 %740
+OpStore %170 %741
+%742 = OpLoad %ulong %170
+%743 = OpBitwiseAnd %ulong %742 %ulong_255
+OpStore %171 %743
+%744 = OpLoad %ulong %175
+%745 = OpLoad %ulong %171
+%746 = OpBitwiseXor %ulong %744 %745
+OpStore %172 %746
+%747 = OpLoad %ulong %172
+%748 = OpIMul %ulong %747 %ulong_1099511628211
+OpStore %173 %748
+%749 = OpLoad %ulong %176
+%750 = OpIAdd %ulong %749 %ulong_1
+OpStore %174 %750
+%751 = OpLoad %ulong %173
+OpStore %175 %751
+%752 = OpLoad %ulong %174
+OpStore %176 %752
+OpBranch %130
+%115 = OpLabel
+OpBranch %103
+%116 = OpLabel
+OpBranch %96
+%117 = OpLabel
+OpBranch %89
+%118 = OpLabel
+OpBranch %84
+%119 = OpLabel
+OpBranch %79
+%120 = OpLabel
+OpBranch %74
+%121 = OpLabel
+OpBranch %69
+%122 = OpLabel
+OpBranch %64
+%123 = OpLabel
+OpBranch %59
+%124 = OpLabel
+OpBranch %54
+%125 = OpLabel
+OpBranch %47
+%126 = OpLabel
+OpBranch %40
+%127 = OpLabel
+OpBranch %33
+%128 = OpLabel
+OpBranch %26
+%129 = OpLabel
+OpBranch %19
+%130 = OpLabel
+OpBranch %12
 OpFunctionEnd
-%6 = OpFunction %ulong None %186
-%322 = OpFunctionParameter %ulong
-%323 = OpFunctionParameter %ulong
-%324 = OpLabel
-%331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_bool Function
-%334 = OpVariable %_ptr_Function_ulong Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ulong Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ulong Function
-%341 = OpVariable %_ptr_Function_ulong Function
-OpStore %331 %322
-OpStore %332 %323
-OpBranch %325
-%325 = OpLabel
-%342 = OpLoad %ulong %331
-OpStore %340 %342
-OpStore %341 %ulong_0
-OpBranch %326
-%326 = OpLabel
-%343 = OpLoad %ulong %341
-%344 = OpULessThan %bool %343 %ulong_8
-OpStore %333 %344
-%345 = OpLoad %bool %333
-OpLoopMerge %328 %330 None
-OpBranchConditional %345 %327 %328
-%328 = OpLabel
-OpBranch %329
-%329 = OpLabel
-%346 = OpLoad %ulong %340
-OpReturnValue %346
-%327 = OpLabel
-%347 = OpLoad %ulong %341
-%348 = OpIMul %ulong %347 %ulong_8
-OpStore %334 %348
-%349 = OpLoad %ulong %332
-%350 = OpLoad %ulong %334
-%351 = OpShiftRightLogical %ulong %349 %350
-OpStore %335 %351
-%352 = OpLoad %ulong %335
-%353 = OpBitwiseAnd %ulong %352 %ulong_255
-OpStore %336 %353
-%354 = OpLoad %ulong %340
-%355 = OpLoad %ulong %336
-%356 = OpBitwiseXor %ulong %354 %355
-OpStore %337 %356
-%357 = OpLoad %ulong %337
-%358 = OpIMul %ulong %357 %ulong_1099511628211
-OpStore %338 %358
-%359 = OpLoad %ulong %341
-%360 = OpIAdd %ulong %359 %ulong_1
-OpStore %339 %360
-%361 = OpLoad %ulong %338
-OpStore %340 %361
-%362 = OpLoad %ulong %339
-OpStore %341 %362
-OpBranch %330
-%330 = OpLabel
-OpBranch %326
+%2 = OpFunction %ulong None %753
+%754 = OpFunctionParameter %ulong
+%755 = OpFunctionParameter %ulong
+%756 = OpLabel
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_bool Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+OpStore %761 %754
+OpStore %762 %755
+%772 = OpLoad %ulong %761
+OpStore %770 %772
+OpStore %771 %ulong_0
+OpBranch %757
+%757 = OpLabel
+%773 = OpLoad %ulong %771
+%774 = OpULessThan %bool %773 %ulong_8
+OpStore %763 %774
+%775 = OpLoad %bool %763
+OpLoopMerge %759 %760 None
+OpBranchConditional %775 %758 %759
+%759 = OpLabel
+%776 = OpLoad %ulong %770
+OpReturnValue %776
+%758 = OpLabel
+%777 = OpLoad %ulong %771
+%778 = OpIMul %ulong %777 %ulong_8
+OpStore %764 %778
+%779 = OpLoad %ulong %762
+%780 = OpLoad %ulong %764
+%781 = OpShiftRightLogical %ulong %779 %780
+OpStore %765 %781
+%782 = OpLoad %ulong %765
+%783 = OpBitwiseAnd %ulong %782 %ulong_255
+OpStore %766 %783
+%784 = OpLoad %ulong %770
+%785 = OpLoad %ulong %766
+%786 = OpBitwiseXor %ulong %784 %785
+OpStore %767 %786
+%787 = OpLoad %ulong %767
+%788 = OpIMul %ulong %787 %ulong_1099511628211
+OpStore %768 %788
+%789 = OpLoad %ulong %771
+%790 = OpIAdd %ulong %789 %ulong_1
+OpStore %769 %790
+%791 = OpLoad %ulong %768
+OpStore %770 %791
+%792 = OpLoad %ulong %769
+OpStore %771 %792
+OpBranch %760
+%760 = OpLabel
+OpBranch %757
 OpFunctionEnd

--- a/test/golden/spirv/imm/imm_mov.dis
+++ b/test/golden/spirv/imm/imm_mov.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 247
+; Bound: 518
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,7 +9,7 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_mov.checksum" Export
 %ulong = OpTypeInt 64 0
-%6 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %uint_3 = OpConstant %uint 3
@@ -21,6 +21,8 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_mov.checksum" Export
 %ulong_0 = OpConstant %ulong 0
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_2047 = OpConstant %uint 2047
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_8 = OpConstant %ulong 8
 %ulong_1 = OpConstant %ulong 1
 %ulong_9223372036854775807 = OpConstant %ulong 9223372036854775807
 %ulong_4294967295 = OpConstant %ulong 4294967295
@@ -30,332 +32,757 @@ OpDecorate %1 LinkageAttributes "corpus.cases.imm.imm_mov.checksum" Export
 %ulong_3 = OpConstant %ulong 3
 %ulong_18446462603027742720 = OpConstant %ulong 18446462603027742720
 %ulong_6148914691236517205 = OpConstant %ulong 6148914691236517205
-%101 = OpConstantNull %_arr_ulong_uint_3
+%274 = OpConstantNull %_arr_ulong_uint_3
 %uint_0 = OpConstant %uint 0
 %ulong_4294967296 = OpConstant %ulong 4294967296
 %uint_1 = OpConstant %uint 1
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %uint_2 = OpConstant %uint 2
 %ulong_4294901760 = OpConstant %ulong 4294901760
-%156 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%159 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
+%ulong_1431655765 = OpConstant %ulong 1431655765
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%202 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %6
-%7 = OpFunctionParameter %ulong
-%8 = OpLabel
-%26 = OpVariable %_ptr_Function__arr_ulong_uint_3 Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_bool Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_bool Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uint Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_uint Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-OpStore %28 %7
-%64 = OpFunctionCall %ulong %2
-OpStore %29 %64
-%65 = OpLoad %ulong %28
-%67 = OpIEqual %bool %65 %ulong_0
-OpStore %31 %67
-%68 = OpLoad %bool %31
-OpSelectionMerge %11 None
-OpBranchConditional %68 %9 %10
-%10 = OpLabel
-OpStore %57 %uint_2147483648
-OpBranch %11
-%9 = OpLabel
-OpStore %57 %uint_2047
-OpBranch %11
-%11 = OpLabel
-%71 = OpLoad %ulong %29
-%72 = OpLoad %uint %57
-%73 = OpFunctionCall %ulong %4 %71 %72
-OpStore %32 %73
-%74 = OpLoad %ulong %28
-%76 = OpIEqual %bool %74 %ulong_1
-OpStore %33 %76
-%77 = OpLoad %bool %33
-OpSelectionMerge %14 None
-OpBranchConditional %77 %12 %13
-%13 = OpLabel
-OpStore %58 %ulong_9223372036854775807
-OpBranch %14
-%12 = OpLabel
-OpStore %58 %ulong_4294967295
-OpBranch %14
-%14 = OpLabel
-%80 = OpLoad %ulong %32
-%81 = OpLoad %ulong %58
-%82 = OpFunctionCall %ulong %3 %80 %81
-OpStore %34 %82
-%83 = OpLoad %ulong %28
-%85 = OpIEqual %bool %83 %ulong_2
-OpStore %35 %85
-%86 = OpLoad %bool %35
-OpSelectionMerge %17 None
-OpBranchConditional %86 %15 %16
-%16 = OpLabel
-OpStore %59 %uint_252645135
-OpBranch %17
-%15 = OpLabel
-OpStore %59 %uint_1431655765
-OpBranch %17
-%17 = OpLabel
-%89 = OpLoad %ulong %34
-%90 = OpLoad %uint %59
-%91 = OpFunctionCall %ulong %4 %89 %90
-OpStore %36 %91
-%92 = OpLoad %ulong %28
-%94 = OpIEqual %bool %92 %ulong_3
-OpStore %37 %94
-%95 = OpLoad %bool %37
-OpSelectionMerge %20 None
-OpBranchConditional %95 %18 %19
-%19 = OpLabel
-OpStore %60 %ulong_18446462603027742720
-OpBranch %20
-%18 = OpLabel
-OpStore %60 %ulong_6148914691236517205
-OpBranch %20
-%20 = OpLabel
-%98 = OpLoad %ulong %36
-%99 = OpLoad %ulong %60
-%100 = OpFunctionCall %ulong %3 %98 %99
-OpStore %38 %100
-OpStore %26 %101
-%103 = OpAccessChain %_ptr_Function_ulong %26 %uint_0
-OpStore %103 %ulong_4294967296
-%106 = OpAccessChain %_ptr_Function_ulong %26 %uint_1
-OpStore %106 %ulong_9223372036854775808
-%109 = OpAccessChain %_ptr_Function_ulong %26 %uint_2
-OpStore %109 %ulong_4294901760
-OpStore %61 %ulong_3
-%111 = OpLoad %ulong %28
-%112 = OpLoad %ulong %61
-%113 = OpUMod %ulong %111 %112
-OpStore %39 %113
-%114 = OpLoad %ulong %39
-%115 = OpAccessChain %_ptr_Function_ulong %26 %114
-%116 = OpLoad %ulong %115
-OpStore %40 %116
-%117 = OpLoad %ulong %38
-%118 = OpLoad %ulong %40
-%119 = OpFunctionCall %ulong %3 %117 %118
-OpStore %41 %119
-%120 = OpLoad %ulong %39
-%121 = OpIAdd %ulong %120 %ulong_1
-OpStore %42 %121
-OpStore %62 %ulong_3
-%122 = OpLoad %ulong %42
-%123 = OpLoad %ulong %62
-%124 = OpUMod %ulong %122 %123
-OpStore %43 %124
-%125 = OpLoad %ulong %43
-%126 = OpAccessChain %_ptr_Function_ulong %26 %125
-%127 = OpLoad %ulong %126
-OpStore %44 %127
-%128 = OpLoad %ulong %41
-%129 = OpLoad %ulong %44
-%130 = OpFunctionCall %ulong %3 %128 %129
-OpStore %45 %130
-%131 = OpLoad %ulong %39
-%132 = OpIAdd %ulong %131 %ulong_2
-OpStore %46 %132
-OpStore %63 %ulong_3
-%133 = OpLoad %ulong %46
-%134 = OpLoad %ulong %63
-%135 = OpUMod %ulong %133 %134
-OpStore %47 %135
-%136 = OpLoad %ulong %47
-%137 = OpAccessChain %_ptr_Function_ulong %26 %136
-%138 = OpLoad %ulong %137
-OpStore %48 %138
-%139 = OpLoad %ulong %45
-%140 = OpLoad %ulong %48
-%141 = OpFunctionCall %ulong %3 %139 %140
-OpStore %49 %141
-%142 = OpLoad %ulong %28
-%143 = OpUConvert %uint %142
-OpStore %51 %143
-%144 = OpLoad %uint %51
-%145 = OpIAdd %uint %uint_2047 %144
-OpStore %52 %145
-%146 = OpLoad %ulong %49
-%147 = OpLoad %uint %52
-%148 = OpFunctionCall %ulong %4 %146 %147
-OpStore %53 %148
-%149 = OpLoad %ulong %53
-%150 = OpFunctionCall %ulong %4 %149 %uint_2147483648
-OpStore %54 %150
-%151 = OpLoad %ulong %54
-%152 = OpFunctionCall %ulong %3 %151 %ulong_9223372036854775808
-OpStore %55 %152
-%153 = OpLoad %ulong %55
-%154 = OpFunctionCall %ulong %4 %153 %uint_1431655765
-OpStore %56 %154
-%155 = OpLoad %ulong %56
-OpReturnValue %155
-OpFunctionEnd
-%2 = OpFunction %ulong None %156
-%157 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %159
-%160 = OpFunctionParameter %ulong
-%161 = OpFunctionParameter %ulong
-%162 = OpLabel
+%ulong_2147483648 = OpConstant %ulong 2147483648
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%101 = OpVariable %_ptr_Function__arr_ulong_uint_3 Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_bool Function
+%106 = OpVariable %_ptr_Function_bool Function
+%107 = OpVariable %_ptr_Function_bool Function
+%108 = OpVariable %_ptr_Function_bool Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_uint Function
+%119 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_uint Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_bool Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_bool Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_bool Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_bool Function
 %172 = OpVariable %_ptr_Function_ulong Function
 %173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
 %175 = OpVariable %_ptr_Function_ulong Function
 %176 = OpVariable %_ptr_Function_ulong Function
 %177 = OpVariable %_ptr_Function_ulong Function
-OpStore %167 %160
-OpStore %168 %161
-%178 = OpLoad %ulong %167
-OpStore %176 %178
-OpStore %177 %ulong_0
-OpBranch %163
-%163 = OpLabel
-%179 = OpLoad %ulong %177
-%181 = OpULessThan %bool %179 %ulong_8
-OpStore %169 %181
-%182 = OpLoad %bool %169
-OpLoopMerge %165 %166 None
-OpBranchConditional %182 %164 %165
-%165 = OpLabel
-%183 = OpLoad %ulong %176
-OpReturnValue %183
-%164 = OpLabel
-%184 = OpLoad %ulong %177
-%185 = OpIMul %ulong %184 %ulong_8
-OpStore %170 %185
-%186 = OpLoad %ulong %168
-%187 = OpLoad %ulong %170
-%188 = OpShiftRightLogical %ulong %186 %187
-OpStore %171 %188
-%189 = OpLoad %ulong %171
-%191 = OpBitwiseAnd %ulong %189 %ulong_255
-OpStore %172 %191
-%192 = OpLoad %ulong %176
-%193 = OpLoad %ulong %172
-%194 = OpBitwiseXor %ulong %192 %193
-OpStore %173 %194
-%195 = OpLoad %ulong %173
-%197 = OpIMul %ulong %195 %ulong_1099511628211
-OpStore %174 %197
-%198 = OpLoad %ulong %177
-%199 = OpIAdd %ulong %198 %ulong_1
-OpStore %175 %199
-%200 = OpLoad %ulong %174
-OpStore %176 %200
-%201 = OpLoad %ulong %175
-OpStore %177 %201
-OpBranch %166
-%166 = OpLabel
-OpBranch %163
-OpFunctionEnd
-%4 = OpFunction %ulong None %202
-%203 = OpFunctionParameter %ulong
-%204 = OpFunctionParameter %uint
-%205 = OpLabel
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_bool Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
 %212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_uint Function
+%213 = OpVariable %_ptr_Function_ulong Function
 %214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_bool Function
+%215 = OpVariable %_ptr_Function_ulong Function
 %216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
 %218 = OpVariable %_ptr_Function_ulong Function
 %219 = OpVariable %_ptr_Function_ulong Function
 %220 = OpVariable %_ptr_Function_ulong Function
 %221 = OpVariable %_ptr_Function_ulong Function
 %222 = OpVariable %_ptr_Function_ulong Function
 %223 = OpVariable %_ptr_Function_ulong Function
-OpStore %212 %203
-OpStore %213 %204
-%224 = OpLoad %uint %213
-%225 = OpUConvert %ulong %224
-OpStore %214 %225
-OpBranch %206
-%206 = OpLabel
-%226 = OpLoad %ulong %212
-OpStore %222 %226
-OpStore %223 %ulong_0
-OpBranch %207
-%207 = OpLabel
-%227 = OpLoad %ulong %223
-%228 = OpULessThan %bool %227 %ulong_8
-OpStore %215 %228
-%229 = OpLoad %bool %215
-OpLoopMerge %209 %211 None
-OpBranchConditional %229 %208 %209
-%209 = OpLabel
-OpBranch %210
-%210 = OpLabel
-%230 = OpLoad %ulong %222
-OpReturnValue %230
-%208 = OpLabel
-%231 = OpLoad %ulong %223
-%232 = OpIMul %ulong %231 %ulong_8
-OpStore %216 %232
-%233 = OpLoad %ulong %214
-%234 = OpLoad %ulong %216
-%235 = OpShiftRightLogical %ulong %233 %234
-OpStore %217 %235
-%236 = OpLoad %ulong %217
-%237 = OpBitwiseAnd %ulong %236 %ulong_255
-OpStore %218 %237
-%238 = OpLoad %ulong %222
-%239 = OpLoad %ulong %218
-%240 = OpBitwiseXor %ulong %238 %239
-OpStore %219 %240
-%241 = OpLoad %ulong %219
-%242 = OpIMul %ulong %241 %ulong_1099511628211
-OpStore %220 %242
-%243 = OpLoad %ulong %223
-%244 = OpIAdd %ulong %243 %ulong_1
-OpStore %221 %244
-%245 = OpLoad %ulong %220
-OpStore %222 %245
-%246 = OpLoad %ulong %221
-OpStore %223 %246
-OpBranch %211
-%211 = OpLabel
-OpBranch %207
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+OpStore %103 %4
+OpBranch %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%229 = OpLoad %ulong %103
+%231 = OpIEqual %bool %229 %ulong_0
+OpStore %105 %231
+%232 = OpLoad %bool %105
+OpSelectionMerge %8 None
+OpBranchConditional %232 %6 %7
+%7 = OpLabel
+OpStore %120 %uint_2147483648
+OpBranch %8
+%6 = OpLabel
+OpStore %120 %uint_2047
+OpBranch %8
+%8 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%235 = OpLoad %uint %120
+%236 = OpUConvert %ulong %235
+OpStore %124 %236
+OpBranch %34
+%34 = OpLabel
+OpStore %151 %ulong_14695981039346656037
+OpStore %152 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%238 = OpLoad %ulong %152
+%240 = OpULessThan %bool %238 %ulong_8
+OpStore %144 %240
+%241 = OpLoad %bool %144
+OpLoopMerge %37 %95 None
+OpBranchConditional %241 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%242 = OpLoad %ulong %103
+%244 = OpIEqual %bool %242 %ulong_1
+OpStore %106 %244
+%245 = OpLoad %bool %106
+OpSelectionMerge %11 None
+OpBranchConditional %245 %9 %10
+%10 = OpLabel
+OpStore %121 %ulong_9223372036854775807
+OpBranch %11
+%9 = OpLabel
+OpStore %121 %ulong_4294967295
+OpBranch %11
+%11 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%248 = OpLoad %ulong %151
+OpStore %132 %248
+OpStore %133 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%249 = OpLoad %ulong %133
+%250 = OpULessThan %bool %249 %ulong_8
+OpStore %125 %250
+%251 = OpLoad %bool %125
+OpLoopMerge %25 %94 None
+OpBranchConditional %251 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%252 = OpLoad %ulong %103
+%254 = OpIEqual %bool %252 %ulong_2
+OpStore %107 %254
+%255 = OpLoad %bool %107
+OpSelectionMerge %14 None
+OpBranchConditional %255 %12 %13
+%13 = OpLabel
+OpStore %122 %uint_252645135
+OpBranch %14
+%12 = OpLabel
+OpStore %122 %uint_1431655765
+OpBranch %14
+%14 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%258 = OpLoad %uint %122
+%259 = OpUConvert %ulong %258
+OpStore %134 %259
+OpBranch %39
+%39 = OpLabel
+%260 = OpLoad %ulong %132
+OpStore %160 %260
+OpStore %161 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%261 = OpLoad %ulong %161
+%262 = OpULessThan %bool %261 %ulong_8
+OpStore %153 %262
+%263 = OpLoad %bool %153
+OpLoopMerge %42 %93 None
+OpBranchConditional %263 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%264 = OpLoad %ulong %103
+%266 = OpIEqual %bool %264 %ulong_3
+OpStore %108 %266
+%267 = OpLoad %bool %108
+OpSelectionMerge %17 None
+OpBranchConditional %267 %15 %16
+%16 = OpLabel
+OpStore %123 %ulong_18446462603027742720
+OpBranch %17
+%15 = OpLabel
+OpStore %123 %ulong_6148914691236517205
+OpBranch %17
+%17 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%270 = OpLoad %ulong %160
+OpStore %142 %270
+OpStore %143 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%271 = OpLoad %ulong %143
+%272 = OpULessThan %bool %271 %ulong_8
+OpStore %135 %272
+%273 = OpLoad %bool %135
+OpLoopMerge %32 %92 None
+OpBranchConditional %273 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpStore %101 %274
+%276 = OpAccessChain %_ptr_Function_ulong %101 %uint_0
+OpStore %276 %ulong_4294967296
+%279 = OpAccessChain %_ptr_Function_ulong %101 %uint_1
+OpStore %279 %ulong_9223372036854775808
+%282 = OpAccessChain %_ptr_Function_ulong %101 %uint_2
+OpStore %282 %ulong_4294901760
+OpStore %226 %ulong_3
+%284 = OpLoad %ulong %103
+%285 = OpLoad %ulong %226
+%286 = OpUMod %ulong %284 %285
+OpStore %109 %286
+%287 = OpLoad %ulong %109
+%288 = OpAccessChain %_ptr_Function_ulong %101 %287
+%289 = OpLoad %ulong %288
+OpStore %110 %289
+OpBranch %44
+%44 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %169 %290
+OpStore %170 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%291 = OpLoad %ulong %170
+%292 = OpULessThan %bool %291 %ulong_8
+OpStore %162 %292
+%293 = OpLoad %bool %162
+OpLoopMerge %47 %91 None
+OpBranchConditional %293 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%294 = OpLoad %ulong %109
+%295 = OpIAdd %ulong %294 %ulong_1
+OpStore %111 %295
+OpStore %227 %ulong_3
+%296 = OpLoad %ulong %111
+%297 = OpLoad %ulong %227
+%298 = OpUMod %ulong %296 %297
+OpStore %112 %298
+%299 = OpLoad %ulong %112
+%300 = OpAccessChain %_ptr_Function_ulong %101 %299
+%301 = OpLoad %ulong %300
+OpStore %113 %301
+OpBranch %49
+%49 = OpLabel
+%302 = OpLoad %ulong %169
+OpStore %178 %302
+OpStore %179 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%303 = OpLoad %ulong %179
+%304 = OpULessThan %bool %303 %ulong_8
+OpStore %171 %304
+%305 = OpLoad %bool %171
+OpLoopMerge %52 %90 None
+OpBranchConditional %305 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%306 = OpLoad %ulong %109
+%307 = OpIAdd %ulong %306 %ulong_2
+OpStore %114 %307
+OpStore %228 %ulong_3
+%308 = OpLoad %ulong %114
+%309 = OpLoad %ulong %228
+%310 = OpUMod %ulong %308 %309
+OpStore %115 %310
+%311 = OpLoad %ulong %115
+%312 = OpAccessChain %_ptr_Function_ulong %101 %311
+%313 = OpLoad %ulong %312
+OpStore %116 %313
+OpBranch %54
+%54 = OpLabel
+%314 = OpLoad %ulong %178
+OpStore %187 %314
+OpStore %188 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%315 = OpLoad %ulong %188
+%316 = OpULessThan %bool %315 %ulong_8
+OpStore %180 %316
+%317 = OpLoad %bool %180
+OpLoopMerge %57 %89 None
+OpBranchConditional %317 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%318 = OpLoad %ulong %103
+%319 = OpUConvert %uint %318
+OpStore %118 %319
+%320 = OpLoad %uint %118
+%321 = OpIAdd %uint %uint_2047 %320
+OpStore %119 %321
+OpBranch %59
+%59 = OpLabel
+%322 = OpLoad %uint %119
+%323 = OpUConvert %ulong %322
+OpStore %189 %323
+OpBranch %61
+%61 = OpLabel
+%324 = OpLoad %ulong %187
+OpStore %197 %324
+OpStore %198 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%325 = OpLoad %ulong %198
+%326 = OpULessThan %bool %325 %ulong_8
+OpStore %190 %326
+%327 = OpLoad %bool %190
+OpLoopMerge %64 %88 None
+OpBranchConditional %327 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%328 = OpLoad %ulong %197
+OpStore %206 %328
+OpStore %207 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%329 = OpLoad %ulong %207
+%330 = OpULessThan %bool %329 %ulong_8
+OpStore %199 %330
+%331 = OpLoad %bool %199
+OpLoopMerge %71 %87 None
+OpBranchConditional %331 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%332 = OpLoad %ulong %206
+OpStore %215 %332
+OpStore %216 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%333 = OpLoad %ulong %216
+%334 = OpULessThan %bool %333 %ulong_8
+OpStore %208 %334
+%335 = OpLoad %bool %208
+OpLoopMerge %76 %86 None
+OpBranchConditional %335 %75 %76
+%76 = OpLabel
+OpBranch %77
+%77 = OpLabel
+OpBranch %78
+%78 = OpLabel
+OpBranch %80
+%80 = OpLabel
+%336 = OpLoad %ulong %215
+OpStore %224 %336
+OpStore %225 %ulong_0
+OpBranch %81
+%81 = OpLabel
+%337 = OpLoad %ulong %225
+%338 = OpULessThan %bool %337 %ulong_8
+OpStore %217 %338
+%339 = OpLoad %bool %217
+OpLoopMerge %83 %85 None
+OpBranchConditional %339 %82 %83
+%83 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%340 = OpLoad %ulong %224
+OpReturnValue %340
+%82 = OpLabel
+%341 = OpLoad %ulong %225
+%342 = OpIMul %ulong %341 %ulong_8
+OpStore %218 %342
+%344 = OpLoad %ulong %218
+%345 = OpShiftRightLogical %ulong %ulong_1431655765 %344
+OpStore %219 %345
+%346 = OpLoad %ulong %219
+%348 = OpBitwiseAnd %ulong %346 %ulong_255
+OpStore %220 %348
+%349 = OpLoad %ulong %224
+%350 = OpLoad %ulong %220
+%351 = OpBitwiseXor %ulong %349 %350
+OpStore %221 %351
+%352 = OpLoad %ulong %221
+%354 = OpIMul %ulong %352 %ulong_1099511628211
+OpStore %222 %354
+%355 = OpLoad %ulong %225
+%356 = OpIAdd %ulong %355 %ulong_1
+OpStore %223 %356
+%357 = OpLoad %ulong %222
+OpStore %224 %357
+%358 = OpLoad %ulong %223
+OpStore %225 %358
+OpBranch %85
+%75 = OpLabel
+%359 = OpLoad %ulong %216
+%360 = OpIMul %ulong %359 %ulong_8
+OpStore %209 %360
+%361 = OpLoad %ulong %209
+%362 = OpShiftRightLogical %ulong %ulong_9223372036854775808 %361
+OpStore %210 %362
+%363 = OpLoad %ulong %210
+%364 = OpBitwiseAnd %ulong %363 %ulong_255
+OpStore %211 %364
+%365 = OpLoad %ulong %215
+%366 = OpLoad %ulong %211
+%367 = OpBitwiseXor %ulong %365 %366
+OpStore %212 %367
+%368 = OpLoad %ulong %212
+%369 = OpIMul %ulong %368 %ulong_1099511628211
+OpStore %213 %369
+%370 = OpLoad %ulong %216
+%371 = OpIAdd %ulong %370 %ulong_1
+OpStore %214 %371
+%372 = OpLoad %ulong %213
+OpStore %215 %372
+%373 = OpLoad %ulong %214
+OpStore %216 %373
+OpBranch %86
+%70 = OpLabel
+%374 = OpLoad %ulong %207
+%375 = OpIMul %ulong %374 %ulong_8
+OpStore %200 %375
+%377 = OpLoad %ulong %200
+%378 = OpShiftRightLogical %ulong %ulong_2147483648 %377
+OpStore %201 %378
+%379 = OpLoad %ulong %201
+%380 = OpBitwiseAnd %ulong %379 %ulong_255
+OpStore %202 %380
+%381 = OpLoad %ulong %206
+%382 = OpLoad %ulong %202
+%383 = OpBitwiseXor %ulong %381 %382
+OpStore %203 %383
+%384 = OpLoad %ulong %203
+%385 = OpIMul %ulong %384 %ulong_1099511628211
+OpStore %204 %385
+%386 = OpLoad %ulong %207
+%387 = OpIAdd %ulong %386 %ulong_1
+OpStore %205 %387
+%388 = OpLoad %ulong %204
+OpStore %206 %388
+%389 = OpLoad %ulong %205
+OpStore %207 %389
+OpBranch %87
+%63 = OpLabel
+%390 = OpLoad %ulong %198
+%391 = OpIMul %ulong %390 %ulong_8
+OpStore %191 %391
+%392 = OpLoad %ulong %189
+%393 = OpLoad %ulong %191
+%394 = OpShiftRightLogical %ulong %392 %393
+OpStore %192 %394
+%395 = OpLoad %ulong %192
+%396 = OpBitwiseAnd %ulong %395 %ulong_255
+OpStore %193 %396
+%397 = OpLoad %ulong %197
+%398 = OpLoad %ulong %193
+%399 = OpBitwiseXor %ulong %397 %398
+OpStore %194 %399
+%400 = OpLoad %ulong %194
+%401 = OpIMul %ulong %400 %ulong_1099511628211
+OpStore %195 %401
+%402 = OpLoad %ulong %198
+%403 = OpIAdd %ulong %402 %ulong_1
+OpStore %196 %403
+%404 = OpLoad %ulong %195
+OpStore %197 %404
+%405 = OpLoad %ulong %196
+OpStore %198 %405
+OpBranch %88
+%56 = OpLabel
+%406 = OpLoad %ulong %188
+%407 = OpIMul %ulong %406 %ulong_8
+OpStore %181 %407
+%408 = OpLoad %ulong %116
+%409 = OpLoad %ulong %181
+%410 = OpShiftRightLogical %ulong %408 %409
+OpStore %182 %410
+%411 = OpLoad %ulong %182
+%412 = OpBitwiseAnd %ulong %411 %ulong_255
+OpStore %183 %412
+%413 = OpLoad %ulong %187
+%414 = OpLoad %ulong %183
+%415 = OpBitwiseXor %ulong %413 %414
+OpStore %184 %415
+%416 = OpLoad %ulong %184
+%417 = OpIMul %ulong %416 %ulong_1099511628211
+OpStore %185 %417
+%418 = OpLoad %ulong %188
+%419 = OpIAdd %ulong %418 %ulong_1
+OpStore %186 %419
+%420 = OpLoad %ulong %185
+OpStore %187 %420
+%421 = OpLoad %ulong %186
+OpStore %188 %421
+OpBranch %89
+%51 = OpLabel
+%422 = OpLoad %ulong %179
+%423 = OpIMul %ulong %422 %ulong_8
+OpStore %172 %423
+%424 = OpLoad %ulong %113
+%425 = OpLoad %ulong %172
+%426 = OpShiftRightLogical %ulong %424 %425
+OpStore %173 %426
+%427 = OpLoad %ulong %173
+%428 = OpBitwiseAnd %ulong %427 %ulong_255
+OpStore %174 %428
+%429 = OpLoad %ulong %178
+%430 = OpLoad %ulong %174
+%431 = OpBitwiseXor %ulong %429 %430
+OpStore %175 %431
+%432 = OpLoad %ulong %175
+%433 = OpIMul %ulong %432 %ulong_1099511628211
+OpStore %176 %433
+%434 = OpLoad %ulong %179
+%435 = OpIAdd %ulong %434 %ulong_1
+OpStore %177 %435
+%436 = OpLoad %ulong %176
+OpStore %178 %436
+%437 = OpLoad %ulong %177
+OpStore %179 %437
+OpBranch %90
+%46 = OpLabel
+%438 = OpLoad %ulong %170
+%439 = OpIMul %ulong %438 %ulong_8
+OpStore %163 %439
+%440 = OpLoad %ulong %110
+%441 = OpLoad %ulong %163
+%442 = OpShiftRightLogical %ulong %440 %441
+OpStore %164 %442
+%443 = OpLoad %ulong %164
+%444 = OpBitwiseAnd %ulong %443 %ulong_255
+OpStore %165 %444
+%445 = OpLoad %ulong %169
+%446 = OpLoad %ulong %165
+%447 = OpBitwiseXor %ulong %445 %446
+OpStore %166 %447
+%448 = OpLoad %ulong %166
+%449 = OpIMul %ulong %448 %ulong_1099511628211
+OpStore %167 %449
+%450 = OpLoad %ulong %170
+%451 = OpIAdd %ulong %450 %ulong_1
+OpStore %168 %451
+%452 = OpLoad %ulong %167
+OpStore %169 %452
+%453 = OpLoad %ulong %168
+OpStore %170 %453
+OpBranch %91
+%31 = OpLabel
+%454 = OpLoad %ulong %143
+%455 = OpIMul %ulong %454 %ulong_8
+OpStore %136 %455
+%456 = OpLoad %ulong %123
+%457 = OpLoad %ulong %136
+%458 = OpShiftRightLogical %ulong %456 %457
+OpStore %137 %458
+%459 = OpLoad %ulong %137
+%460 = OpBitwiseAnd %ulong %459 %ulong_255
+OpStore %138 %460
+%461 = OpLoad %ulong %142
+%462 = OpLoad %ulong %138
+%463 = OpBitwiseXor %ulong %461 %462
+OpStore %139 %463
+%464 = OpLoad %ulong %139
+%465 = OpIMul %ulong %464 %ulong_1099511628211
+OpStore %140 %465
+%466 = OpLoad %ulong %143
+%467 = OpIAdd %ulong %466 %ulong_1
+OpStore %141 %467
+%468 = OpLoad %ulong %140
+OpStore %142 %468
+%469 = OpLoad %ulong %141
+OpStore %143 %469
+OpBranch %92
+%41 = OpLabel
+%470 = OpLoad %ulong %161
+%471 = OpIMul %ulong %470 %ulong_8
+OpStore %154 %471
+%472 = OpLoad %ulong %134
+%473 = OpLoad %ulong %154
+%474 = OpShiftRightLogical %ulong %472 %473
+OpStore %155 %474
+%475 = OpLoad %ulong %155
+%476 = OpBitwiseAnd %ulong %475 %ulong_255
+OpStore %156 %476
+%477 = OpLoad %ulong %160
+%478 = OpLoad %ulong %156
+%479 = OpBitwiseXor %ulong %477 %478
+OpStore %157 %479
+%480 = OpLoad %ulong %157
+%481 = OpIMul %ulong %480 %ulong_1099511628211
+OpStore %158 %481
+%482 = OpLoad %ulong %161
+%483 = OpIAdd %ulong %482 %ulong_1
+OpStore %159 %483
+%484 = OpLoad %ulong %158
+OpStore %160 %484
+%485 = OpLoad %ulong %159
+OpStore %161 %485
+OpBranch %93
+%24 = OpLabel
+%486 = OpLoad %ulong %133
+%487 = OpIMul %ulong %486 %ulong_8
+OpStore %126 %487
+%488 = OpLoad %ulong %121
+%489 = OpLoad %ulong %126
+%490 = OpShiftRightLogical %ulong %488 %489
+OpStore %127 %490
+%491 = OpLoad %ulong %127
+%492 = OpBitwiseAnd %ulong %491 %ulong_255
+OpStore %128 %492
+%493 = OpLoad %ulong %132
+%494 = OpLoad %ulong %128
+%495 = OpBitwiseXor %ulong %493 %494
+OpStore %129 %495
+%496 = OpLoad %ulong %129
+%497 = OpIMul %ulong %496 %ulong_1099511628211
+OpStore %130 %497
+%498 = OpLoad %ulong %133
+%499 = OpIAdd %ulong %498 %ulong_1
+OpStore %131 %499
+%500 = OpLoad %ulong %130
+OpStore %132 %500
+%501 = OpLoad %ulong %131
+OpStore %133 %501
+OpBranch %94
+%36 = OpLabel
+%502 = OpLoad %ulong %152
+%503 = OpIMul %ulong %502 %ulong_8
+OpStore %145 %503
+%504 = OpLoad %ulong %124
+%505 = OpLoad %ulong %145
+%506 = OpShiftRightLogical %ulong %504 %505
+OpStore %146 %506
+%507 = OpLoad %ulong %146
+%508 = OpBitwiseAnd %ulong %507 %ulong_255
+OpStore %147 %508
+%509 = OpLoad %ulong %151
+%510 = OpLoad %ulong %147
+%511 = OpBitwiseXor %ulong %509 %510
+OpStore %148 %511
+%512 = OpLoad %ulong %148
+%513 = OpIMul %ulong %512 %ulong_1099511628211
+OpStore %149 %513
+%514 = OpLoad %ulong %152
+%515 = OpIAdd %ulong %514 %ulong_1
+OpStore %150 %515
+%516 = OpLoad %ulong %149
+OpStore %151 %516
+%517 = OpLoad %ulong %150
+OpStore %152 %517
+OpBranch %95
+%85 = OpLabel
+OpBranch %81
+%86 = OpLabel
+OpBranch %74
+%87 = OpLabel
+OpBranch %69
+%88 = OpLabel
+OpBranch %62
+%89 = OpLabel
+OpBranch %55
+%90 = OpLabel
+OpBranch %50
+%91 = OpLabel
+OpBranch %45
+%92 = OpLabel
+OpBranch %30
+%93 = OpLabel
+OpBranch %40
+%94 = OpLabel
+OpBranch %23
+%95 = OpLabel
+OpBranch %35
 OpFunctionEnd

--- a/test/golden/spirv/mem/addr_modes.dis
+++ b/test/golden/spirv/mem/addr_modes.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 968
+; Bound: 1447
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,11 +11,15 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.mem.addr_modes.checksum" Export
 %ulong = OpTypeInt 64 0
-%8 = OpTypeFunction %ulong %ulong
+%4 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
+%uint_8 = OpConstant %uint 8
+%_arr_uint_uint_8 = OpTypeArray %uint %uint_8
+%_arr__arr_uint_uint_8_uint_8 = OpTypeArray %_arr_uint_uint_8 %uint_8
+%_ptr_Function__arr__arr_uint_uint_8_uint_8 = OpTypePointer Function %_arr__arr_uint_uint_8_uint_8
 %uint_64 = OpConstant %uint 64
 %_arr_uchar_uint_64 = OpTypeArray %uchar %uint_64
 %_ptr_Function__arr_uchar_uint_64 = OpTypePointer Function %_arr_uchar_uint_64
@@ -25,42 +29,39 @@ OpDecorate %1 LinkageAttributes "corpus.cases.mem.addr_modes.checksum" Export
 %_ptr_Function__arr_uint_uint_64 = OpTypePointer Function %_arr_uint_uint_64
 %_arr_ulong_uint_64 = OpTypeArray %ulong %uint_64
 %_ptr_Function__arr_ulong_uint_64 = OpTypePointer Function %_arr_ulong_uint_64
-%_struct_68 = OpTypeStruct %ushort %uchar %ulong
-%_arr__struct_68_uint_64 = OpTypeArray %_struct_68 %uint_64
-%_ptr_Function__arr__struct_68_uint_64 = OpTypePointer Function %_arr__struct_68_uint_64
-%_struct_72 = OpTypeStruct %uint %uint %uint
-%_arr__struct_72_uint_64 = OpTypeArray %_struct_72 %uint_64
-%_ptr_Function__arr__struct_72_uint_64 = OpTypePointer Function %_arr__struct_72_uint_64
-%uint_8 = OpConstant %uint 8
-%_arr_uint_uint_8 = OpTypeArray %uint %uint_8
-%_arr__arr_uint_uint_8_uint_8 = OpTypeArray %_arr_uint_uint_8 %uint_8
-%_ptr_Function__arr__arr_uint_uint_8_uint_8 = OpTypePointer Function %_arr__arr_uint_uint_8_uint_8
+%_struct_209 = OpTypeStruct %ushort %uchar %ulong
+%_arr__struct_209_uint_64 = OpTypeArray %_struct_209 %uint_64
+%_ptr_Function__arr__struct_209_uint_64 = OpTypePointer Function %_arr__struct_209_uint_64
+%_struct_213 = OpTypeStruct %uint %uint %uint
+%_arr__struct_213_uint_64 = OpTypeArray %_struct_213 %uint_64
+%_ptr_Function__arr__struct_213_uint_64 = OpTypePointer Function %_arr__struct_213_uint_64
 %uint_1024 = OpConstant %uint 1024
 %_arr_ulong_uint_1024 = OpTypeArray %ulong %uint_1024
 %uint_512 = OpConstant %uint 512
 %_arr_uint_uint_512 = OpTypeArray %uint %uint_512
-%_struct_85 = OpTypeStruct %ulong %_arr_ulong_uint_1024 %uint %_arr_uint_uint_512 %ushort
-%_ptr_Function__struct_85 = OpTypePointer Function %_struct_85
+%_struct_221 = OpTypeStruct %ulong %_arr_ulong_uint_1024 %uint %_arr_uint_uint_512 %ushort
+%_ptr_Function__struct_221 = OpTypePointer Function %_struct_221
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
-%268 = OpConstantNull %_arr_uchar_uint_64
-%269 = OpConstantNull %_arr_ushort_uint_64
-%270 = OpConstantNull %_arr_uint_uint_64
-%271 = OpConstantNull %_arr_ulong_uint_64
-%272 = OpConstantNull %_arr__struct_68_uint_64
-%273 = OpConstantNull %_arr__struct_72_uint_64
+%553 = OpConstantNull %_arr_uchar_uint_64
+%554 = OpConstantNull %_arr_ushort_uint_64
+%555 = OpConstantNull %_arr_uint_uint_64
+%556 = OpConstantNull %_arr_ulong_uint_64
+%557 = OpConstantNull %_arr__struct_209_uint_64
+%558 = OpConstantNull %_arr__struct_213_uint_64
 %ulong_0 = OpConstant %ulong 0
 %ulong_64 = OpConstant %ulong 64
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_32 = OpConstant %ulong 32
-%288 = OpConstantNull %_arr__arr_uint_uint_8_uint_8
+%573 = OpConstantNull %_arr__arr_uint_uint_8_uint_8
 %ulong_8 = OpConstant %ulong 8
 %uint_7 = OpConstant %uint 7
 %_ptr_Function__arr_uint_uint_8 = OpTypePointer Function %_arr_uint_uint_8
 %uint_0 = OpConstant %uint 0
-%312 = OpConstantNull %_struct_85
+%603 = OpConstantNull %_struct_221
 %ulong_305419896 = OpConstant %ulong 305419896
 %uint_2596069104 = OpConstant %uint 2596069104
 %uint_2 = OpConstant %uint 2
@@ -80,8 +81,10 @@ OpDecorate %1 LinkageAttributes "corpus.cases.mem.addr_modes.checksum" Export
 %ulong_8204 = OpConstant %ulong 8204
 %ulong_10252 = OpConstant %ulong 10252
 %ulong_10256 = OpConstant %ulong 10256
-%ulong_3 = OpConstant %ulong 3
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
+%ulong_3 = OpConstant %ulong 3
 %ulong_37 = OpConstant %ulong 37
 %ulong_31 = OpConstant %ulong 31
 %ulong_7 = OpConstant %ulong 7
@@ -89,1247 +92,1990 @@ OpDecorate %1 LinkageAttributes "corpus.cases.mem.addr_modes.checksum" Export
 %ulong_13 = OpConstant %ulong 13
 %ulong_2 = OpConstant %ulong 2
 %ulong_63 = OpConstant %ulong 63
-%_ptr_Function__struct_68 = OpTypePointer Function %_struct_68
-%_ptr_Function__struct_72 = OpTypePointer Function %_struct_72
+%_ptr_Function__struct_209 = OpTypePointer Function %_struct_209
+%_ptr_Function__struct_213 = OpTypePointer Function %_struct_213
 %ulong_1103 = OpConstant %ulong 1103
 %ulong_2654435761 = OpConstant %ulong 2654435761
 %ulong_11 = OpConstant %ulong 11
 %ulong_11400714819323198485 = OpConstant %ulong 11400714819323198485
 %ulong_5 = OpConstant %ulong 5
 %ulong_128 = OpConstant %ulong 128
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_17 = OpConstant %ulong 17
-%789 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%792 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%833 = OpTypeFunction %ulong %ulong %uchar
-%878 = OpTypeFunction %ulong %ulong %ushort
-%923 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpLabel
-%58 = OpVariable %_ptr_Function__arr_uchar_uint_64 Function
-%61 = OpVariable %_ptr_Function__arr_ushort_uint_64 Function
-%64 = OpVariable %_ptr_Function__arr_uint_uint_64 Function
-%67 = OpVariable %_ptr_Function__arr_ulong_uint_64 Function
-%71 = OpVariable %_ptr_Function__arr__struct_68_uint_64 Function
-%75 = OpVariable %_ptr_Function__arr__struct_72_uint_64 Function
-%80 = OpVariable %_ptr_Function__arr__arr_uint_uint_8_uint_8 Function
-%87 = OpVariable %_ptr_Function__struct_85 Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%92 = OpVariable %_ptr_Function_bool Function
-%93 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_ulong Function
-%95 = OpVariable %_ptr_Function_ulong Function
-%97 = OpVariable %_ptr_Function_uchar Function
-%98 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_ulong Function
-%102 = OpVariable %_ptr_Function_ushort Function
-%103 = OpVariable %_ptr_Function_ulong Function
-%104 = OpVariable %_ptr_Function_ulong Function
-%105 = OpVariable %_ptr_Function_ulong Function
-%107 = OpVariable %_ptr_Function_uint Function
-%108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_ulong Function
-%110 = OpVariable %_ptr_Function_ulong Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_ulong Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_ushort Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_uchar Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_uint Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_uint Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%128 = OpVariable %_ptr_Function_uint Function
-%129 = OpVariable %_ptr_Function_bool Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_uchar Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_ushort Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_uint Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_ushort Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_uchar Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_uint Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_uint Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_uint Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_uint Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_uint Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_uchar Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_bool Function
-%174 = OpVariable %_ptr_Function_bool Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_uint Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_bool Function
-%183 = OpVariable %_ptr_Function_uint Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_uint Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_uint Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_uint Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_uint Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_uint Function
-%198 = OpVariable %_ptr_Function_uint Function
-%199 = OpVariable %_ptr_Function_ushort Function
-%200 = OpVariable %_ptr_Function_ushort Function
-%201 = OpVariable %_ptr_Function_bool Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_bool Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_uint Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_uint Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_uint Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_uint Function
+%1407 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %4
+%5 = OpFunctionParameter %ulong
+%6 = OpLabel
+%195 = OpVariable %_ptr_Function__arr__arr_uint_uint_8_uint_8 Function
+%199 = OpVariable %_ptr_Function__arr_uchar_uint_64 Function
+%202 = OpVariable %_ptr_Function__arr_ushort_uint_64 Function
+%205 = OpVariable %_ptr_Function__arr_uint_uint_64 Function
+%208 = OpVariable %_ptr_Function__arr_ulong_uint_64 Function
+%212 = OpVariable %_ptr_Function__arr__struct_209_uint_64 Function
+%216 = OpVariable %_ptr_Function__arr__struct_213_uint_64 Function
+%223 = OpVariable %_ptr_Function__struct_221 Function
 %225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_uint Function
+%227 = OpVariable %_ptr_Function_bool Function
+%228 = OpVariable %_ptr_Function_ulong Function
 %229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ushort Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_uchar Function
 %233 = OpVariable %_ptr_Function_ulong Function
 %234 = OpVariable %_ptr_Function_ulong Function
 %235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_bool Function
-%237 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ushort Function
 %238 = OpVariable %_ptr_Function_ulong Function
 %239 = OpVariable %_ptr_Function_ulong Function
 %240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_bool Function
-%243 = OpVariable %_ptr_Function_uint Function
+%242 = OpVariable %_ptr_Function_uint Function
+%243 = OpVariable %_ptr_Function_ulong Function
 %244 = OpVariable %_ptr_Function_ulong Function
 %245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_ulong Function
 %247 = OpVariable %_ptr_Function_ulong Function
 %248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ushort Function
 %250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_uchar Function
 %252 = OpVariable %_ptr_Function_ulong Function
 %253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
 %255 = OpVariable %_ptr_Function_ulong Function
 %256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_uint Function
 %258 = OpVariable %_ptr_Function_ulong Function
 %259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_uint Function
 %261 = OpVariable %_ptr_Function_ulong Function
 %262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_uint Function
+%264 = OpVariable %_ptr_Function_bool Function
 %265 = OpVariable %_ptr_Function_ulong Function
 %266 = OpVariable %_ptr_Function_ulong Function
-OpStore %89 %9
-%267 = OpFunctionCall %ulong %2
-OpStore %90 %267
-OpStore %58 %268
-OpStore %61 %269
-OpStore %64 %270
-OpStore %67 %271
-OpStore %71 %272
-OpStore %75 %273
-OpStore %260 %ulong_0
-OpBranch %11
-%11 = OpLabel
-%275 = OpLoad %ulong %260
-%277 = OpULessThan %bool %275 %ulong_64
-OpStore %92 %277
-%278 = OpLoad %bool %92
-OpLoopMerge %13 %50 None
-OpBranchConditional %278 %12 %13
-%13 = OpLabel
-%279 = OpLoad %ulong %90
-OpStore %252 %279
-OpStore %259 %ulong_0
-OpBranch %14
-%14 = OpLabel
-%280 = OpLoad %ulong %259
-%281 = OpULessThan %bool %280 %ulong_64
-OpStore %129 %281
-%282 = OpLoad %bool %129
-OpLoopMerge %16 %49 None
-OpBranchConditional %282 %15 %16
-%16 = OpLabel
-%283 = OpLoad %ulong %252
-OpStore %251 %283
-OpStore %258 %ulong_0
-OpBranch %17
-%17 = OpLabel
-%284 = OpLoad %ulong %258
-%286 = OpULessThan %bool %284 %ulong_32
-OpStore %154 %286
-%287 = OpLoad %bool %154
-OpLoopMerge %19 %48 None
-OpBranchConditional %287 %18 %19
-%19 = OpLabel
-OpStore %80 %288
-OpStore %261 %ulong_0
-OpBranch %20
-%20 = OpLabel
-%289 = OpLoad %ulong %261
-%291 = OpULessThan %bool %289 %ulong_8
-OpStore %173 %291
-%292 = OpLoad %bool %173
-OpLoopMerge %22 %47 None
-OpBranchConditional %292 %21 %22
-%22 = OpLabel
-%293 = OpLoad %ulong %251
-OpStore %250 %293
-OpStore %257 %ulong_0
-OpBranch %26
-%26 = OpLabel
-%294 = OpLoad %ulong %257
-%295 = OpULessThan %bool %294 %ulong_8
-OpStore %182 %295
-%296 = OpLoad %bool %182
-OpLoopMerge %28 %46 None
-OpBranchConditional %296 %27 %28
-%28 = OpLabel
-%299 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %80 %uint_7
-%300 = OpAccessChain %_ptr_Function_uint %299 %uint_7
-%301 = OpLoad %uint %300
-OpStore %192 %301
-%302 = OpLoad %ulong %250
-%303 = OpLoad %uint %192
-%304 = OpFunctionCall %ulong %6 %302 %303
-OpStore %193 %304
-%306 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %80 %uint_0
-%307 = OpAccessChain %_ptr_Function_uint %306 %uint_0
-%308 = OpLoad %uint %307
-OpStore %194 %308
-%309 = OpLoad %ulong %193
-%310 = OpLoad %uint %194
-%311 = OpFunctionCall %ulong %6 %309 %310
-OpStore %195 %311
-OpStore %87 %312
-%314 = OpLoad %ulong %89
-%315 = OpIAdd %ulong %ulong_305419896 %314
-OpStore %196 %315
-%316 = OpAccessChain %_ptr_Function_ulong %87 %uint_0
-%317 = OpLoad %ulong %196
-OpStore %316 %317
-%318 = OpLoad %ulong %89
-%319 = OpUConvert %uint %318
-OpStore %197 %319
-%321 = OpLoad %uint %197
-%322 = OpIAdd %uint %uint_2596069104 %321
-OpStore %198 %322
-%324 = OpAccessChain %_ptr_Function_uint %87 %uint_2
-%325 = OpLoad %uint %198
-OpStore %324 %325
-%326 = OpLoad %ulong %89
-%327 = OpUConvert %ushort %326
-OpStore %199 %327
-%329 = OpLoad %ushort %199
-%330 = OpIAdd %ushort %ushort_4660 %329
-OpStore %200 %330
-%332 = OpAccessChain %_ptr_Function_ushort %87 %uint_4
-%333 = OpLoad %ushort %200
-OpStore %332 %333
-OpStore %256 %ulong_0
-OpBranch %29
-%29 = OpLabel
-%334 = OpLoad %ulong %256
-%336 = OpULessThan %bool %334 %ulong_1024
-OpStore %201 %336
-%337 = OpLoad %bool %201
-OpLoopMerge %31 %44 None
-OpBranchConditional %337 %30 %31
-%31 = OpLabel
-OpStore %255 %ulong_0
-OpBranch %32
-%32 = OpLabel
-%338 = OpLoad %ulong %255
-%340 = OpULessThan %bool %338 %ulong_512
-OpStore %205 %340
-%341 = OpLoad %bool %205
-OpLoopMerge %34 %43 None
-OpBranchConditional %341 %33 %34
-%34 = OpLabel
-%342 = OpAccessChain %_ptr_Function_ulong %87 %uint_0
-%343 = OpLoad %ulong %342
-OpStore %210 %343
-%344 = OpLoad %ulong %195
-%345 = OpLoad %ulong %210
-%346 = OpFunctionCall %ulong %3 %344 %345
-OpStore %211 %346
-%349 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %87 %uint_1
-%350 = OpAccessChain %_ptr_Function_ulong %349 %uint_0
-%351 = OpLoad %ulong %350
-OpStore %212 %351
-%352 = OpLoad %ulong %211
-%353 = OpLoad %ulong %212
-%354 = OpFunctionCall %ulong %3 %352 %353
-OpStore %213 %354
-%356 = OpAccessChain %_ptr_Function_ulong %349 %uint_1023
-%357 = OpLoad %ulong %356
-OpStore %214 %357
-%358 = OpLoad %ulong %213
-%359 = OpLoad %ulong %214
-%360 = OpFunctionCall %ulong %3 %358 %359
-OpStore %215 %360
-%361 = OpLoad %ulong %89
-%363 = OpIAdd %ulong %361 %ulong_700
-OpStore %216 %363
-OpStore %265 %ulong_1024
-%364 = OpLoad %ulong %216
-%365 = OpLoad %ulong %265
-%366 = OpUMod %ulong %364 %365
-OpStore %217 %366
-%367 = OpLoad %ulong %217
-%368 = OpAccessChain %_ptr_Function_ulong %349 %367
-%369 = OpLoad %ulong %368
-OpStore %218 %369
-%370 = OpLoad %ulong %215
-%371 = OpLoad %ulong %218
-%372 = OpFunctionCall %ulong %3 %370 %371
-OpStore %219 %372
-%373 = OpAccessChain %_ptr_Function_uint %87 %uint_2
-%374 = OpLoad %uint %373
-OpStore %220 %374
-%375 = OpLoad %ulong %219
-%376 = OpLoad %uint %220
-%377 = OpFunctionCall %ulong %6 %375 %376
-OpStore %221 %377
-%380 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %87 %uint_3
-%381 = OpAccessChain %_ptr_Function_uint %380 %uint_0
-%382 = OpLoad %uint %381
-OpStore %222 %382
-%383 = OpLoad %ulong %221
-%384 = OpLoad %uint %222
-%385 = OpFunctionCall %ulong %6 %383 %384
-OpStore %223 %385
-%387 = OpAccessChain %_ptr_Function_uint %380 %uint_511
-%388 = OpLoad %uint %387
-OpStore %224 %388
-%389 = OpLoad %ulong %223
-%390 = OpLoad %uint %224
-%391 = OpFunctionCall %ulong %6 %389 %390
-OpStore %225 %391
-%392 = OpLoad %ulong %89
-%394 = OpIAdd %ulong %392 %ulong_300
-OpStore %226 %394
-OpStore %266 %ulong_512
-%395 = OpLoad %ulong %226
-%396 = OpLoad %ulong %266
-%397 = OpUMod %ulong %395 %396
-OpStore %227 %397
-%398 = OpLoad %ulong %227
-%399 = OpAccessChain %_ptr_Function_uint %380 %398
-%400 = OpLoad %uint %399
-OpStore %228 %400
-%401 = OpLoad %ulong %225
-%402 = OpLoad %uint %228
-%403 = OpFunctionCall %ulong %6 %401 %402
-OpStore %229 %403
-%404 = OpAccessChain %_ptr_Function_ushort %87 %uint_4
-%405 = OpLoad %ushort %404
-OpStore %230 %405
-%406 = OpLoad %ulong %229
-%407 = OpLoad %ushort %230
-%408 = OpFunctionCall %ulong %5 %406 %407
-OpStore %231 %408
-%409 = OpLoad %ulong %231
-%411 = OpFunctionCall %ulong %3 %409 %ulong_8200
-OpStore %232 %411
-%412 = OpLoad %ulong %232
-%414 = OpFunctionCall %ulong %3 %412 %ulong_8204
-OpStore %233 %414
-%415 = OpLoad %ulong %233
-%417 = OpFunctionCall %ulong %3 %415 %ulong_10252
-OpStore %234 %417
-%418 = OpLoad %ulong %234
-%420 = OpFunctionCall %ulong %3 %418 %ulong_10256
-OpStore %235 %420
-OpStore %254 %ulong_0
-OpStore %264 %ulong_0
-OpBranch %35
-%35 = OpLabel
-%421 = OpLoad %ulong %254
-%422 = OpULessThan %bool %421 %ulong_1024
-OpStore %236 %422
-%423 = OpLoad %bool %236
-OpLoopMerge %37 %42 None
-OpBranchConditional %423 %36 %37
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_uchar Function
+%269 = OpVariable %_ptr_Function_ushort Function
+%270 = OpVariable %_ptr_Function_uint Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ushort Function
+%273 = OpVariable %_ptr_Function_uchar Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_uint Function
+%277 = OpVariable %_ptr_Function_uint Function
+%278 = OpVariable %_ptr_Function_uint Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_bool Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_uint Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_uint Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_uchar Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_bool Function
+%298 = OpVariable %_ptr_Function_bool Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_uint Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_bool Function
+%307 = OpVariable %_ptr_Function_uint Function
+%308 = OpVariable %_ptr_Function_uint Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_uint Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_uint Function
+%314 = OpVariable %_ptr_Function_uint Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_uint Function
+%317 = OpVariable %_ptr_Function_uint Function
+%318 = OpVariable %_ptr_Function_ushort Function
+%319 = OpVariable %_ptr_Function_ushort Function
+%320 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_uint Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_uint Function
+%337 = OpVariable %_ptr_Function_uint Function
+%338 = OpVariable %_ptr_Function_uint Function
+%339 = OpVariable %_ptr_Function_ulong Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_uint Function
+%342 = OpVariable %_ptr_Function_ushort Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_bool Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_bool Function
+%353 = OpVariable %_ptr_Function_uint Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_ulong Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_ulong Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_bool Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_ulong Function
+%385 = OpVariable %_ptr_Function_ulong Function
+%386 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_bool Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_ulong Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_ulong Function
+%396 = OpVariable %_ptr_Function_bool Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_ulong Function
+%399 = OpVariable %_ptr_Function_ulong Function
+%400 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_bool Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_ulong Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_ulong Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_ulong Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_bool Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_bool Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_bool Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_bool Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_bool Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_bool Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_bool Function
+%483 = OpVariable %_ptr_Function_ulong Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_bool Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_bool Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_bool Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_bool Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_ulong Function
+%552 = OpVariable %_ptr_Function_ulong Function
+OpStore %225 %5
+OpBranch %37
 %37 = OpLabel
-%424 = OpLoad %ulong %235
-%425 = OpLoad %ulong %264
-%426 = OpFunctionCall %ulong %3 %424 %425
-OpStore %241 %426
-OpStore %253 %ulong_0
-OpStore %263 %ulong_0
 OpBranch %38
 %38 = OpLabel
-%427 = OpLoad %ulong %253
-%428 = OpULessThan %bool %427 %ulong_512
-OpStore %242 %428
-%429 = OpLoad %bool %242
-OpLoopMerge %40 %41 None
-OpBranchConditional %429 %39 %40
-%40 = OpLabel
-%430 = OpLoad %ulong %241
-%431 = OpLoad %ulong %263
-%432 = OpFunctionCall %ulong %3 %430 %431
-OpStore %249 %432
-%433 = OpLoad %ulong %249
-OpReturnValue %433
-%39 = OpLabel
-%434 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %87 %uint_3
-%435 = OpLoad %ulong %253
-%436 = OpAccessChain %_ptr_Function_uint %434 %435
-%437 = OpLoad %uint %436
-OpStore %243 %437
-%438 = OpLoad %uint %243
-%439 = OpUConvert %ulong %438
-OpStore %244 %439
-%440 = OpLoad %ulong %253
-%442 = OpIAdd %ulong %440 %ulong_3
-OpStore %245 %442
-%443 = OpLoad %ulong %244
-%444 = OpLoad %ulong %245
-%445 = OpIMul %ulong %443 %444
-OpStore %246 %445
-%446 = OpLoad %ulong %263
-%447 = OpLoad %ulong %246
-%448 = OpIAdd %ulong %446 %447
-OpStore %247 %448
-%449 = OpLoad %ulong %253
-%451 = OpIAdd %ulong %449 %ulong_1
-OpStore %248 %451
-%452 = OpLoad %ulong %248
-OpStore %253 %452
-%453 = OpLoad %ulong %247
-OpStore %263 %453
-OpBranch %41
-%36 = OpLabel
-%454 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %87 %uint_1
-%455 = OpLoad %ulong %254
-%456 = OpAccessChain %_ptr_Function_ulong %454 %455
-%457 = OpLoad %ulong %456
-OpStore %237 %457
-%458 = OpLoad %ulong %254
-%459 = OpIAdd %ulong %458 %ulong_1
-OpStore %238 %459
-%460 = OpLoad %ulong %237
-%461 = OpLoad %ulong %238
-%462 = OpIMul %ulong %460 %461
-OpStore %239 %462
-%463 = OpLoad %ulong %264
-%464 = OpLoad %ulong %239
-%465 = OpBitwiseXor %ulong %463 %464
-OpStore %240 %465
-%466 = OpLoad %ulong %238
-OpStore %254 %466
-%467 = OpLoad %ulong %240
-OpStore %264 %467
-OpBranch %42
-%33 = OpLabel
-%468 = OpLoad %ulong %255
-%470 = OpIMul %ulong %468 %ulong_37
-OpStore %206 %470
-%471 = OpLoad %ulong %206
-%472 = OpLoad %ulong %89
-%473 = OpIAdd %ulong %471 %472
-OpStore %207 %473
-%474 = OpLoad %ulong %207
-%475 = OpUConvert %uint %474
-OpStore %208 %475
-%476 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %87 %uint_3
-%477 = OpLoad %ulong %255
-%478 = OpAccessChain %_ptr_Function_uint %476 %477
-%479 = OpLoad %uint %208
-OpStore %478 %479
-%480 = OpLoad %ulong %255
-%481 = OpIAdd %ulong %480 %ulong_1
-OpStore %209 %481
-%482 = OpLoad %ulong %209
-OpStore %255 %482
-OpBranch %43
-%30 = OpLabel
-%483 = OpLoad %ulong %256
-%485 = OpIMul %ulong %483 %ulong_31
-OpStore %202 %485
-%486 = OpLoad %ulong %202
-%487 = OpLoad %ulong %89
-%488 = OpIAdd %ulong %486 %487
-OpStore %203 %488
-%489 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %87 %uint_1
-%490 = OpLoad %ulong %256
-%491 = OpAccessChain %_ptr_Function_ulong %489 %490
-%492 = OpLoad %ulong %203
-OpStore %491 %492
-%493 = OpLoad %ulong %256
-%494 = OpIAdd %ulong %493 %ulong_1
-OpStore %204 %494
-%495 = OpLoad %ulong %204
-OpStore %256 %495
-OpBranch %44
-%27 = OpLabel
-%496 = OpLoad %ulong %257
-%497 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %80 %496
-%498 = OpAccessChain %_ptr_Function_uint %497 %uint_3
-%499 = OpLoad %uint %498
-OpStore %183 %499
-%500 = OpLoad %ulong %250
-%501 = OpLoad %uint %183
-%502 = OpFunctionCall %ulong %6 %500 %501
-OpStore %184 %502
-%503 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %80 %uint_3
-%504 = OpLoad %ulong %257
-%505 = OpAccessChain %_ptr_Function_uint %503 %504
-%506 = OpLoad %uint %505
-OpStore %185 %506
-%507 = OpLoad %ulong %184
-%508 = OpLoad %uint %185
-%509 = OpFunctionCall %ulong %6 %507 %508
-OpStore %186 %509
-%510 = OpLoad %ulong %257
-%511 = OpLoad %ulong %89
-%512 = OpIAdd %ulong %510 %511
-OpStore %187 %512
-%513 = OpLoad %ulong %187
-%515 = OpBitwiseAnd %ulong %513 %ulong_7
-OpStore %188 %515
-%516 = OpLoad %ulong %188
-%517 = OpAccessChain %_ptr_Function_uint %497 %516
-%518 = OpLoad %uint %517
-OpStore %189 %518
-%519 = OpLoad %ulong %186
-%520 = OpLoad %uint %189
-%521 = OpFunctionCall %ulong %6 %519 %520
-OpStore %190 %521
-%522 = OpLoad %ulong %257
-%523 = OpIAdd %ulong %522 %ulong_1
-OpStore %191 %523
-%524 = OpLoad %ulong %190
-OpStore %250 %524
-%525 = OpLoad %ulong %191
-OpStore %257 %525
-OpBranch %46
-%21 = OpLabel
-%526 = OpLoad %ulong %261
-%528 = OpIMul %ulong %526 %ulong_71
-OpStore %175 %528
-%529 = OpLoad %ulong %261
-%530 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %80 %529
-OpStore %262 %ulong_0
-OpBranch %23
-%23 = OpLabel
-%531 = OpLoad %ulong %262
-%532 = OpULessThan %bool %531 %ulong_8
-OpStore %174 %532
-%533 = OpLoad %bool %174
-OpLoopMerge %25 %45 None
-OpBranchConditional %533 %24 %25
-%25 = OpLabel
-%534 = OpLoad %ulong %261
-%535 = OpIAdd %ulong %534 %ulong_1
-OpStore %181 %535
-%536 = OpLoad %ulong %181
-OpStore %261 %536
-OpBranch %47
-%24 = OpLabel
-%537 = OpLoad %ulong %262
-%539 = OpIMul %ulong %537 %ulong_13
-OpStore %176 %539
-%540 = OpLoad %ulong %175
-%541 = OpLoad %ulong %176
-%542 = OpIAdd %ulong %540 %541
-OpStore %177 %542
-%543 = OpLoad %ulong %177
-%544 = OpLoad %ulong %89
-%545 = OpIAdd %ulong %543 %544
-OpStore %178 %545
-%546 = OpLoad %ulong %178
-%547 = OpUConvert %uint %546
-OpStore %179 %547
-%548 = OpLoad %ulong %262
-%549 = OpAccessChain %_ptr_Function_uint %530 %548
-%550 = OpLoad %uint %179
-OpStore %549 %550
-%551 = OpLoad %ulong %262
-%552 = OpIAdd %ulong %551 %ulong_1
-OpStore %180 %552
-%553 = OpLoad %ulong %180
-OpStore %262 %553
-OpBranch %45
-%18 = OpLabel
-%554 = OpLoad %ulong %258
-%556 = OpIMul %ulong %554 %ulong_2
-OpStore %155 %556
-%557 = OpLoad %ulong %155
-%558 = OpAccessChain %_ptr_Function_uint %64 %557
-%559 = OpLoad %uint %558
-OpStore %156 %559
-%560 = OpLoad %ulong %251
-%561 = OpLoad %uint %156
-%562 = OpFunctionCall %ulong %6 %560 %561
-OpStore %157 %562
-%563 = OpLoad %ulong %258
-%564 = OpShiftLeftLogical %ulong %563 %ulong_1
-OpStore %158 %564
-%565 = OpLoad %ulong %158
-%566 = OpAccessChain %_ptr_Function_uint %64 %565
-%567 = OpLoad %uint %566
-OpStore %159 %567
-%568 = OpLoad %ulong %157
-%569 = OpLoad %uint %159
-%570 = OpFunctionCall %ulong %6 %568 %569
-OpStore %160 %570
-%571 = OpLoad %ulong %258
-%572 = OpIAdd %ulong %571 %ulong_1
-OpStore %161 %572
-%573 = OpLoad %ulong %161
-%574 = OpIMul %ulong %573 %ulong_2
-OpStore %162 %574
-%575 = OpLoad %ulong %162
-%576 = OpISub %ulong %575 %ulong_2
-OpStore %163 %576
-%577 = OpLoad %ulong %163
-%578 = OpAccessChain %_ptr_Function_ulong %67 %577
-%579 = OpLoad %ulong %578
-OpStore %164 %579
-%580 = OpLoad %ulong %160
-%581 = OpLoad %ulong %164
-%582 = OpFunctionCall %ulong %3 %580 %581
-OpStore %165 %582
-%584 = OpLoad %ulong %258
-%585 = OpISub %ulong %ulong_63 %584
-OpStore %166 %585
-%586 = OpLoad %ulong %166
-%587 = OpAccessChain %_ptr_Function_uchar %58 %586
-%588 = OpLoad %uchar %587
-OpStore %167 %588
-%589 = OpLoad %ulong %165
-%590 = OpLoad %uchar %167
-%591 = OpFunctionCall %ulong %4 %589 %590
-OpStore %168 %591
-%592 = OpLoad %ulong %155
-%593 = OpLoad %ulong %89
-%594 = OpIAdd %ulong %592 %593
-OpStore %169 %594
-%595 = OpLoad %ulong %169
-%596 = OpBitwiseAnd %ulong %595 %ulong_63
-OpStore %170 %596
-%597 = OpLoad %ulong %170
-%599 = OpAccessChain %_ptr_Function__struct_68 %71 %597
-%600 = OpAccessChain %_ptr_Function_ulong %599 %uint_2
-%601 = OpLoad %ulong %600
-OpStore %171 %601
-%602 = OpLoad %ulong %168
-%603 = OpLoad %ulong %171
-%604 = OpFunctionCall %ulong %3 %602 %603
-OpStore %172 %604
-%605 = OpLoad %ulong %172
-OpStore %251 %605
-%606 = OpLoad %ulong %161
-OpStore %258 %606
-OpBranch %48
-%15 = OpLabel
-%607 = OpLoad %ulong %259
-%608 = OpIMul %ulong %607 %ulong_13
-OpStore %130 %608
-%609 = OpLoad %ulong %130
-%610 = OpLoad %ulong %89
-%611 = OpIAdd %ulong %609 %610
-OpStore %131 %611
-%612 = OpLoad %ulong %131
-%613 = OpBitwiseAnd %ulong %612 %ulong_63
-OpStore %132 %613
-%614 = OpLoad %ulong %132
-%615 = OpAccessChain %_ptr_Function_uchar %58 %614
-%616 = OpLoad %uchar %615
-OpStore %133 %616
-%617 = OpLoad %ulong %252
-%618 = OpLoad %uchar %133
-%619 = OpFunctionCall %ulong %4 %617 %618
-OpStore %134 %619
-%620 = OpLoad %ulong %132
-%621 = OpAccessChain %_ptr_Function_ushort %61 %620
-%622 = OpLoad %ushort %621
-OpStore %135 %622
-%623 = OpLoad %ulong %134
-%624 = OpLoad %ushort %135
-%625 = OpFunctionCall %ulong %5 %623 %624
-OpStore %136 %625
-%626 = OpLoad %ulong %132
-%627 = OpAccessChain %_ptr_Function_uint %64 %626
-%628 = OpLoad %uint %627
-OpStore %137 %628
-%629 = OpLoad %ulong %136
-%630 = OpLoad %uint %137
-%631 = OpFunctionCall %ulong %6 %629 %630
-OpStore %138 %631
-%632 = OpLoad %ulong %132
-%633 = OpAccessChain %_ptr_Function_ulong %67 %632
-%634 = OpLoad %ulong %633
-OpStore %139 %634
-%635 = OpLoad %ulong %138
-%636 = OpLoad %ulong %139
-%637 = OpFunctionCall %ulong %3 %635 %636
-OpStore %140 %637
-%638 = OpLoad %ulong %132
-%639 = OpAccessChain %_ptr_Function__struct_68 %71 %638
-%640 = OpAccessChain %_ptr_Function_ushort %639 %uint_0
-%641 = OpLoad %ushort %640
-OpStore %141 %641
-%642 = OpLoad %ulong %140
-%643 = OpLoad %ushort %141
-%644 = OpFunctionCall %ulong %5 %642 %643
-OpStore %142 %644
-%645 = OpAccessChain %_ptr_Function_uchar %639 %uint_1
-%646 = OpLoad %uchar %645
-OpStore %143 %646
-%647 = OpLoad %ulong %142
-%648 = OpLoad %uchar %143
-%649 = OpFunctionCall %ulong %4 %647 %648
-OpStore %144 %649
-%650 = OpAccessChain %_ptr_Function_ulong %639 %uint_2
-%651 = OpLoad %ulong %650
-OpStore %145 %651
-%652 = OpLoad %ulong %144
-%653 = OpLoad %ulong %145
-%654 = OpFunctionCall %ulong %3 %652 %653
-OpStore %146 %654
-%655 = OpLoad %ulong %132
-%657 = OpAccessChain %_ptr_Function__struct_72 %75 %655
-%658 = OpAccessChain %_ptr_Function_uint %657 %uint_0
-%659 = OpLoad %uint %658
-OpStore %147 %659
-%660 = OpLoad %ulong %146
-%661 = OpLoad %uint %147
-%662 = OpFunctionCall %ulong %6 %660 %661
-OpStore %148 %662
-%663 = OpAccessChain %_ptr_Function_uint %657 %uint_1
-%664 = OpLoad %uint %663
-OpStore %149 %664
-%665 = OpLoad %ulong %148
-%666 = OpLoad %uint %149
-%667 = OpFunctionCall %ulong %6 %665 %666
-OpStore %150 %667
-%668 = OpAccessChain %_ptr_Function_uint %657 %uint_2
-%669 = OpLoad %uint %668
-OpStore %151 %669
-%670 = OpLoad %ulong %150
-%671 = OpLoad %uint %151
-%672 = OpFunctionCall %ulong %6 %670 %671
-OpStore %152 %672
-%673 = OpLoad %ulong %259
-%674 = OpIAdd %ulong %673 %ulong_1
-OpStore %153 %674
-%675 = OpLoad %ulong %152
-OpStore %252 %675
-%676 = OpLoad %ulong %153
-OpStore %259 %676
-OpBranch %49
+OpStore %199 %553
+OpStore %202 %554
+OpStore %205 %555
+OpStore %208 %556
+OpStore %212 %557
+OpStore %216 %558
+OpStore %369 %ulong_0
+OpBranch %7
+%7 = OpLabel
+%560 = OpLoad %ulong %369
+%562 = OpULessThan %bool %560 %ulong_64
+OpStore %227 %562
+%563 = OpLoad %bool %227
+OpLoopMerge %9 %186 None
+OpBranchConditional %563 %8 %9
+%9 = OpLabel
+OpStore %361 %ulong_14695981039346656037
+OpStore %368 %ulong_0
+OpBranch %10
+%10 = OpLabel
+%565 = OpLoad %ulong %368
+%566 = OpULessThan %bool %565 %ulong_64
+OpStore %264 %566
+%567 = OpLoad %bool %264
+OpLoopMerge %12 %185 None
+OpBranchConditional %567 %11 %12
 %12 = OpLabel
-%677 = OpLoad %ulong %260
-%678 = OpIMul %ulong %677 %ulong_3
-OpStore %93 %678
-%679 = OpLoad %ulong %93
-%680 = OpIAdd %ulong %679 %ulong_1
-OpStore %94 %680
-%681 = OpLoad %ulong %94
-%682 = OpLoad %ulong %89
-%683 = OpIAdd %ulong %681 %682
-OpStore %95 %683
-%684 = OpLoad %ulong %95
-%685 = OpUConvert %uchar %684
-OpStore %97 %685
-%686 = OpLoad %ulong %260
-%687 = OpAccessChain %_ptr_Function_uchar %58 %686
-%688 = OpLoad %uchar %97
-OpStore %687 %688
-%689 = OpLoad %ulong %260
-%691 = OpIMul %ulong %689 %ulong_1103
-OpStore %98 %691
-%692 = OpLoad %ulong %98
-%693 = OpIAdd %ulong %692 %ulong_7
-OpStore %99 %693
-%694 = OpLoad %ulong %99
-%695 = OpLoad %ulong %89
-%696 = OpIAdd %ulong %694 %695
-OpStore %100 %696
-%697 = OpLoad %ulong %100
-%698 = OpUConvert %ushort %697
-OpStore %102 %698
-%699 = OpLoad %ulong %260
-%700 = OpAccessChain %_ptr_Function_ushort %61 %699
-%701 = OpLoad %ushort %102
-OpStore %700 %701
-%702 = OpLoad %ulong %260
-%704 = OpIMul %ulong %702 %ulong_2654435761
-OpStore %103 %704
-%705 = OpLoad %ulong %103
-%707 = OpIAdd %ulong %705 %ulong_11
-OpStore %104 %707
-%708 = OpLoad %ulong %104
-%709 = OpLoad %ulong %89
-%710 = OpIAdd %ulong %708 %709
-OpStore %105 %710
-%711 = OpLoad %ulong %105
-%712 = OpUConvert %uint %711
-OpStore %107 %712
-%713 = OpLoad %ulong %260
-%714 = OpAccessChain %_ptr_Function_uint %64 %713
-%715 = OpLoad %uint %107
-OpStore %714 %715
-%716 = OpLoad %ulong %260
-%717 = OpIAdd %ulong %716 %ulong_1
-OpStore %108 %717
-%719 = OpLoad %ulong %108
-%720 = OpIMul %ulong %ulong_11400714819323198485 %719
-OpStore %109 %720
-%721 = OpLoad %ulong %109
-%722 = OpLoad %ulong %89
-%723 = OpIAdd %ulong %721 %722
-OpStore %110 %723
-%724 = OpLoad %ulong %260
-%725 = OpAccessChain %_ptr_Function_ulong %67 %724
-%726 = OpLoad %ulong %110
-OpStore %725 %726
-%727 = OpLoad %ulong %260
-%729 = OpIMul %ulong %727 %ulong_5
-OpStore %111 %729
-%730 = OpLoad %ulong %111
-%731 = OpIAdd %ulong %730 %ulong_2
-OpStore %112 %731
-%732 = OpLoad %ulong %112
-%733 = OpLoad %ulong %89
-%734 = OpIAdd %ulong %732 %733
-OpStore %113 %734
-%735 = OpLoad %ulong %113
-%736 = OpUConvert %ushort %735
-OpStore %114 %736
-%737 = OpLoad %ulong %260
-%738 = OpAccessChain %_ptr_Function__struct_68 %71 %737
-%739 = OpAccessChain %_ptr_Function_ushort %738 %uint_0
-%740 = OpLoad %ushort %114
-OpStore %739 %740
-%741 = OpLoad %ulong %260
-%743 = OpIAdd %ulong %741 %ulong_128
-OpStore %115 %743
-%744 = OpLoad %ulong %115
-%745 = OpUConvert %uchar %744
-OpStore %116 %745
-%746 = OpAccessChain %_ptr_Function_uchar %738 %uint_1
-%747 = OpLoad %uchar %116
-OpStore %746 %747
-%749 = OpLoad %ulong %108
-%750 = OpIMul %ulong %ulong_1099511628211 %749
-OpStore %117 %750
-%751 = OpLoad %ulong %117
-%752 = OpLoad %ulong %89
-%753 = OpIAdd %ulong %751 %752
-OpStore %118 %753
-%754 = OpAccessChain %_ptr_Function_ulong %738 %uint_2
-%755 = OpLoad %ulong %118
-OpStore %754 %755
-%756 = OpLoad %ulong %260
-%758 = OpIMul %ulong %756 %ulong_17
-OpStore %119 %758
-%759 = OpLoad %ulong %119
-%760 = OpIAdd %ulong %759 %ulong_1
-OpStore %120 %760
-%761 = OpLoad %ulong %120
-%762 = OpLoad %ulong %89
-%763 = OpIAdd %ulong %761 %762
-OpStore %121 %763
-%764 = OpLoad %ulong %121
-%765 = OpUConvert %uint %764
-OpStore %122 %765
-%766 = OpLoad %ulong %260
-%767 = OpAccessChain %_ptr_Function__struct_72 %75 %766
-%768 = OpAccessChain %_ptr_Function_uint %767 %uint_0
-%769 = OpLoad %uint %122
-OpStore %768 %769
-%770 = OpLoad %ulong %119
-%771 = OpIAdd %ulong %770 %ulong_2
-OpStore %123 %771
-%772 = OpLoad %ulong %123
-%773 = OpLoad %ulong %89
-%774 = OpIAdd %ulong %772 %773
-OpStore %124 %774
-%775 = OpLoad %ulong %124
-%776 = OpUConvert %uint %775
-OpStore %125 %776
-%777 = OpAccessChain %_ptr_Function_uint %767 %uint_1
-%778 = OpLoad %uint %125
-OpStore %777 %778
-%779 = OpLoad %ulong %119
-%780 = OpIAdd %ulong %779 %ulong_3
-OpStore %126 %780
-%781 = OpLoad %ulong %126
-%782 = OpLoad %ulong %89
-%783 = OpIAdd %ulong %781 %782
-OpStore %127 %783
-%784 = OpLoad %ulong %127
-%785 = OpUConvert %uint %784
-OpStore %128 %785
-%786 = OpAccessChain %_ptr_Function_uint %767 %uint_2
-%787 = OpLoad %uint %128
-OpStore %786 %787
-%788 = OpLoad %ulong %108
-OpStore %260 %788
-OpBranch %50
-%41 = OpLabel
-OpBranch %38
-%42 = OpLabel
-OpBranch %35
-%43 = OpLabel
-OpBranch %32
-%44 = OpLabel
-OpBranch %29
+%568 = OpLoad %ulong %361
+OpStore %360 %568
+OpStore %367 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%569 = OpLoad %ulong %367
+%571 = OpULessThan %bool %569 %ulong_32
+OpStore %280 %571
+%572 = OpLoad %bool %280
+OpLoopMerge %15 %184 None
+OpBranchConditional %572 %14 %15
+%15 = OpLabel
+OpStore %195 %573
+OpStore %370 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%574 = OpLoad %ulong %370
+%576 = OpULessThan %bool %574 %ulong_8
+OpStore %297 %576
+%577 = OpLoad %bool %297
+OpLoopMerge %18 %182 None
+OpBranchConditional %577 %17 %18
+%18 = OpLabel
+%578 = OpLoad %ulong %360
+OpStore %359 %578
+OpStore %366 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%579 = OpLoad %ulong %366
+%580 = OpULessThan %bool %579 %ulong_8
+OpStore %306 %580
+%581 = OpLoad %bool %306
+OpLoopMerge %24 %180 None
+OpBranchConditional %581 %23 %24
+%24 = OpLabel
+%584 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %uint_7
+%585 = OpAccessChain %_ptr_Function_uint %584 %uint_7
+%586 = OpLoad %uint %585
+OpStore %313 %586
+OpBranch %45
 %45 = OpLabel
-OpBranch %23
+%587 = OpLoad %uint %313
+%588 = OpUConvert %ulong %587
+OpStore %377 %588
+OpBranch %83
+%83 = OpLabel
+%589 = OpLoad %ulong %359
+OpStore %442 %589
+OpStore %443 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%590 = OpLoad %ulong %443
+%591 = OpULessThan %bool %590 %ulong_8
+OpStore %435 %591
+%592 = OpLoad %bool %435
+OpLoopMerge %86 %177 None
+OpBranchConditional %592 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+OpBranch %46
 %46 = OpLabel
-OpBranch %26
+%594 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %uint_0
+%595 = OpAccessChain %_ptr_Function_uint %594 %uint_0
+%596 = OpLoad %uint %595
+OpStore %314 %596
+OpBranch %88
+%88 = OpLabel
+%597 = OpLoad %uint %314
+%598 = OpUConvert %ulong %597
+OpStore %444 %598
+OpBranch %119
+%119 = OpLabel
+%599 = OpLoad %ulong %442
+OpStore %500 %599
+OpStore %501 %ulong_0
+OpBranch %120
+%120 = OpLabel
+%600 = OpLoad %ulong %501
+%601 = OpULessThan %bool %600 %ulong_8
+OpStore %493 %601
+%602 = OpLoad %bool %493
+OpLoopMerge %122 %173 None
+OpBranchConditional %602 %121 %122
+%122 = OpLabel
+OpBranch %123
+%123 = OpLabel
+OpBranch %89
+%89 = OpLabel
+OpStore %223 %603
+%605 = OpLoad %ulong %225
+%606 = OpIAdd %ulong %ulong_305419896 %605
+OpStore %315 %606
+%607 = OpAccessChain %_ptr_Function_ulong %223 %uint_0
+%608 = OpLoad %ulong %315
+OpStore %607 %608
+%609 = OpLoad %ulong %225
+%610 = OpUConvert %uint %609
+OpStore %316 %610
+%612 = OpLoad %uint %316
+%613 = OpIAdd %uint %uint_2596069104 %612
+OpStore %317 %613
+%615 = OpAccessChain %_ptr_Function_uint %223 %uint_2
+%616 = OpLoad %uint %317
+OpStore %615 %616
+%617 = OpLoad %ulong %225
+%618 = OpUConvert %ushort %617
+OpStore %318 %618
+%620 = OpLoad %ushort %318
+%621 = OpIAdd %ushort %ushort_4660 %620
+OpStore %319 %621
+%623 = OpAccessChain %_ptr_Function_ushort %223 %uint_4
+%624 = OpLoad %ushort %319
+OpStore %623 %624
+OpStore %365 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%625 = OpLoad %ulong %365
+%627 = OpULessThan %bool %625 %ulong_1024
+OpStore %320 %627
+%628 = OpLoad %bool %320
+OpLoopMerge %27 %170 None
+OpBranchConditional %628 %26 %27
+%27 = OpLabel
+OpStore %364 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%629 = OpLoad %ulong %364
+%631 = OpULessThan %bool %629 %ulong_512
+OpStore %324 %631
+%632 = OpLoad %bool %324
+OpLoopMerge %30 %168 None
+OpBranchConditional %632 %29 %30
+%30 = OpLabel
+%633 = OpAccessChain %_ptr_Function_ulong %223 %uint_0
+%634 = OpLoad %ulong %633
+OpStore %329 %634
+OpBranch %47
 %47 = OpLabel
-OpBranch %20
+%635 = OpLoad %ulong %500
+OpStore %385 %635
+OpStore %386 %ulong_0
+OpBranch %48
 %48 = OpLabel
-OpBranch %17
-%49 = OpLabel
-OpBranch %14
+%636 = OpLoad %ulong %386
+%637 = OpULessThan %bool %636 %ulong_8
+OpStore %378 %637
+%638 = OpLoad %bool %378
+OpLoopMerge %50 %167 None
+OpBranchConditional %638 %49 %50
 %50 = OpLabel
-OpBranch %11
+OpBranch %51
+%51 = OpLabel
+%641 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %223 %uint_1
+%642 = OpAccessChain %_ptr_Function_ulong %641 %uint_0
+%643 = OpLoad %ulong %642
+OpStore %330 %643
+OpBranch %90
+%90 = OpLabel
+%644 = OpLoad %ulong %385
+OpStore %452 %644
+OpStore %453 %ulong_0
+OpBranch %91
+%91 = OpLabel
+%645 = OpLoad %ulong %453
+%646 = OpULessThan %bool %645 %ulong_8
+OpStore %445 %646
+%647 = OpLoad %bool %445
+OpLoopMerge %93 %166 None
+OpBranchConditional %647 %92 %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%648 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %223 %uint_1
+%650 = OpAccessChain %_ptr_Function_ulong %648 %uint_1023
+%651 = OpLoad %ulong %650
+OpStore %331 %651
+OpBranch %124
+%124 = OpLabel
+%652 = OpLoad %ulong %452
+OpStore %509 %652
+OpStore %510 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%653 = OpLoad %ulong %510
+%654 = OpULessThan %bool %653 %ulong_8
+OpStore %502 %654
+%655 = OpLoad %bool %502
+OpLoopMerge %127 %165 None
+OpBranchConditional %655 %126 %127
+%127 = OpLabel
+OpBranch %128
+%128 = OpLabel
+%656 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %223 %uint_1
+%657 = OpLoad %ulong %225
+%659 = OpIAdd %ulong %657 %ulong_700
+OpStore %332 %659
+OpStore %551 %ulong_1024
+%660 = OpLoad %ulong %332
+%661 = OpLoad %ulong %551
+%662 = OpUMod %ulong %660 %661
+OpStore %333 %662
+%663 = OpLoad %ulong %333
+%664 = OpAccessChain %_ptr_Function_ulong %656 %663
+%665 = OpLoad %ulong %664
+OpStore %334 %665
+%666 = OpLoad %ulong %509
+%667 = OpLoad %ulong %334
+%668 = OpFunctionCall %ulong %2 %666 %667
+OpStore %335 %668
+%669 = OpAccessChain %_ptr_Function_uint %223 %uint_2
+%670 = OpLoad %uint %669
+OpStore %336 %670
+OpBranch %141
+%141 = OpLabel
+%671 = OpLoad %uint %336
+%672 = OpUConvert %ulong %671
+OpStore %531 %672
+%673 = OpLoad %ulong %335
+%674 = OpLoad %ulong %531
+%675 = OpFunctionCall %ulong %2 %673 %674
+OpStore %532 %675
+OpBranch %142
+%142 = OpLabel
+%678 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %223 %uint_3
+%679 = OpAccessChain %_ptr_Function_uint %678 %uint_0
+%680 = OpLoad %uint %679
+OpStore %337 %680
+OpBranch %145
+%145 = OpLabel
+%681 = OpLoad %uint %337
+%682 = OpUConvert %ulong %681
+OpStore %535 %682
+%683 = OpLoad %ulong %532
+%684 = OpLoad %ulong %535
+%685 = OpFunctionCall %ulong %2 %683 %684
+OpStore %536 %685
+OpBranch %146
+%146 = OpLabel
+%686 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %223 %uint_3
+%688 = OpAccessChain %_ptr_Function_uint %686 %uint_511
+%689 = OpLoad %uint %688
+OpStore %338 %689
+OpBranch %149
+%149 = OpLabel
+%690 = OpLoad %uint %338
+%691 = OpUConvert %ulong %690
+OpStore %539 %691
+%692 = OpLoad %ulong %536
+%693 = OpLoad %ulong %539
+%694 = OpFunctionCall %ulong %2 %692 %693
+OpStore %540 %694
+OpBranch %150
+%150 = OpLabel
+%695 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %223 %uint_3
+%696 = OpLoad %ulong %225
+%698 = OpIAdd %ulong %696 %ulong_300
+OpStore %339 %698
+OpStore %552 %ulong_512
+%699 = OpLoad %ulong %339
+%700 = OpLoad %ulong %552
+%701 = OpUMod %ulong %699 %700
+OpStore %340 %701
+%702 = OpLoad %ulong %340
+%703 = OpAccessChain %_ptr_Function_uint %695 %702
+%704 = OpLoad %uint %703
+OpStore %341 %704
+OpBranch %153
+%153 = OpLabel
+%705 = OpLoad %uint %341
+%706 = OpUConvert %ulong %705
+OpStore %543 %706
+%707 = OpLoad %ulong %540
+%708 = OpLoad %ulong %543
+%709 = OpFunctionCall %ulong %2 %707 %708
+OpStore %544 %709
+OpBranch %154
+%154 = OpLabel
+%710 = OpAccessChain %_ptr_Function_ushort %223 %uint_4
+%711 = OpLoad %ushort %710
+OpStore %342 %711
+OpBranch %157
+%157 = OpLabel
+%712 = OpLoad %ushort %342
+%713 = OpUConvert %ulong %712
+OpStore %547 %713
+%714 = OpLoad %ulong %544
+%715 = OpLoad %ulong %547
+%716 = OpFunctionCall %ulong %2 %714 %715
+OpStore %548 %716
+OpBranch %158
+%158 = OpLabel
+%717 = OpLoad %ulong %548
+%719 = OpFunctionCall %ulong %2 %717 %ulong_8200
+OpStore %343 %719
+%720 = OpLoad %ulong %343
+%722 = OpFunctionCall %ulong %2 %720 %ulong_8204
+OpStore %344 %722
+%723 = OpLoad %ulong %344
+%725 = OpFunctionCall %ulong %2 %723 %ulong_10252
+OpStore %345 %725
+%726 = OpLoad %ulong %345
+%728 = OpFunctionCall %ulong %2 %726 %ulong_10256
+OpStore %346 %728
+OpStore %363 %ulong_0
+OpStore %373 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%729 = OpLoad %ulong %363
+%730 = OpULessThan %bool %729 %ulong_1024
+OpStore %347 %730
+%731 = OpLoad %bool %347
+OpLoopMerge %33 %164 None
+OpBranchConditional %731 %32 %33
+%33 = OpLabel
+OpBranch %52
+%52 = OpLabel
+%732 = OpLoad %ulong %346
+OpStore %394 %732
+OpStore %395 %ulong_0
+OpBranch %53
+%53 = OpLabel
+%733 = OpLoad %ulong %395
+%734 = OpULessThan %bool %733 %ulong_8
+OpStore %387 %734
+%735 = OpLoad %bool %387
+OpLoopMerge %55 %163 None
+OpBranchConditional %735 %54 %55
+%55 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpStore %362 %ulong_0
+OpStore %372 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%736 = OpLoad %ulong %362
+%737 = OpULessThan %bool %736 %ulong_512
+OpStore %352 %737
+%738 = OpLoad %bool %352
+OpLoopMerge %36 %162 None
+OpBranchConditional %738 %35 %36
+%36 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%739 = OpLoad %ulong %394
+OpStore %403 %739
+OpStore %404 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%740 = OpLoad %ulong %404
+%741 = OpULessThan %bool %740 %ulong_8
+OpStore %396 %741
+%742 = OpLoad %bool %396
+OpLoopMerge %60 %161 None
+OpBranchConditional %742 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%743 = OpLoad %ulong %403
+OpReturnValue %743
+%59 = OpLabel
+%744 = OpLoad %ulong %404
+%745 = OpIMul %ulong %744 %ulong_8
+OpStore %397 %745
+%746 = OpLoad %ulong %372
+%747 = OpLoad %ulong %397
+%748 = OpShiftRightLogical %ulong %746 %747
+OpStore %398 %748
+%749 = OpLoad %ulong %398
+%751 = OpBitwiseAnd %ulong %749 %ulong_255
+OpStore %399 %751
+%752 = OpLoad %ulong %403
+%753 = OpLoad %ulong %399
+%754 = OpBitwiseXor %ulong %752 %753
+OpStore %400 %754
+%755 = OpLoad %ulong %400
+%757 = OpIMul %ulong %755 %ulong_1099511628211
+OpStore %401 %757
+%758 = OpLoad %ulong %404
+%760 = OpIAdd %ulong %758 %ulong_1
+OpStore %402 %760
+%761 = OpLoad %ulong %401
+OpStore %403 %761
+%762 = OpLoad %ulong %402
+OpStore %404 %762
+OpBranch %161
+%35 = OpLabel
+%763 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %223 %uint_3
+%764 = OpLoad %ulong %362
+%765 = OpAccessChain %_ptr_Function_uint %763 %764
+%766 = OpLoad %uint %765
+OpStore %353 %766
+%767 = OpLoad %uint %353
+%768 = OpUConvert %ulong %767
+OpStore %354 %768
+%769 = OpLoad %ulong %362
+%771 = OpIAdd %ulong %769 %ulong_3
+OpStore %355 %771
+%772 = OpLoad %ulong %354
+%773 = OpLoad %ulong %355
+%774 = OpIMul %ulong %772 %773
+OpStore %356 %774
+%775 = OpLoad %ulong %372
+%776 = OpLoad %ulong %356
+%777 = OpIAdd %ulong %775 %776
+OpStore %357 %777
+%778 = OpLoad %ulong %362
+%779 = OpIAdd %ulong %778 %ulong_1
+OpStore %358 %779
+%780 = OpLoad %ulong %358
+OpStore %362 %780
+%781 = OpLoad %ulong %357
+OpStore %372 %781
+OpBranch %162
+%54 = OpLabel
+%782 = OpLoad %ulong %395
+%783 = OpIMul %ulong %782 %ulong_8
+OpStore %388 %783
+%784 = OpLoad %ulong %373
+%785 = OpLoad %ulong %388
+%786 = OpShiftRightLogical %ulong %784 %785
+OpStore %389 %786
+%787 = OpLoad %ulong %389
+%788 = OpBitwiseAnd %ulong %787 %ulong_255
+OpStore %390 %788
+%789 = OpLoad %ulong %394
+%790 = OpLoad %ulong %390
+%791 = OpBitwiseXor %ulong %789 %790
+OpStore %391 %791
+%792 = OpLoad %ulong %391
+%793 = OpIMul %ulong %792 %ulong_1099511628211
+OpStore %392 %793
+%794 = OpLoad %ulong %395
+%795 = OpIAdd %ulong %794 %ulong_1
+OpStore %393 %795
+%796 = OpLoad %ulong %392
+OpStore %394 %796
+%797 = OpLoad %ulong %393
+OpStore %395 %797
+OpBranch %163
+%32 = OpLabel
+%798 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %223 %uint_1
+%799 = OpLoad %ulong %363
+%800 = OpAccessChain %_ptr_Function_ulong %798 %799
+%801 = OpLoad %ulong %800
+OpStore %348 %801
+%802 = OpLoad %ulong %363
+%803 = OpIAdd %ulong %802 %ulong_1
+OpStore %349 %803
+%804 = OpLoad %ulong %348
+%805 = OpLoad %ulong %349
+%806 = OpIMul %ulong %804 %805
+OpStore %350 %806
+%807 = OpLoad %ulong %373
+%808 = OpLoad %ulong %350
+%809 = OpBitwiseXor %ulong %807 %808
+OpStore %351 %809
+%810 = OpLoad %ulong %349
+OpStore %363 %810
+%811 = OpLoad %ulong %351
+OpStore %373 %811
+OpBranch %164
+%126 = OpLabel
+%812 = OpLoad %ulong %510
+%813 = OpIMul %ulong %812 %ulong_8
+OpStore %503 %813
+%814 = OpLoad %ulong %331
+%815 = OpLoad %ulong %503
+%816 = OpShiftRightLogical %ulong %814 %815
+OpStore %504 %816
+%817 = OpLoad %ulong %504
+%818 = OpBitwiseAnd %ulong %817 %ulong_255
+OpStore %505 %818
+%819 = OpLoad %ulong %509
+%820 = OpLoad %ulong %505
+%821 = OpBitwiseXor %ulong %819 %820
+OpStore %506 %821
+%822 = OpLoad %ulong %506
+%823 = OpIMul %ulong %822 %ulong_1099511628211
+OpStore %507 %823
+%824 = OpLoad %ulong %510
+%825 = OpIAdd %ulong %824 %ulong_1
+OpStore %508 %825
+%826 = OpLoad %ulong %507
+OpStore %509 %826
+%827 = OpLoad %ulong %508
+OpStore %510 %827
+OpBranch %165
+%92 = OpLabel
+%828 = OpLoad %ulong %453
+%829 = OpIMul %ulong %828 %ulong_8
+OpStore %446 %829
+%830 = OpLoad %ulong %330
+%831 = OpLoad %ulong %446
+%832 = OpShiftRightLogical %ulong %830 %831
+OpStore %447 %832
+%833 = OpLoad %ulong %447
+%834 = OpBitwiseAnd %ulong %833 %ulong_255
+OpStore %448 %834
+%835 = OpLoad %ulong %452
+%836 = OpLoad %ulong %448
+%837 = OpBitwiseXor %ulong %835 %836
+OpStore %449 %837
+%838 = OpLoad %ulong %449
+%839 = OpIMul %ulong %838 %ulong_1099511628211
+OpStore %450 %839
+%840 = OpLoad %ulong %453
+%841 = OpIAdd %ulong %840 %ulong_1
+OpStore %451 %841
+%842 = OpLoad %ulong %450
+OpStore %452 %842
+%843 = OpLoad %ulong %451
+OpStore %453 %843
+OpBranch %166
+%49 = OpLabel
+%844 = OpLoad %ulong %386
+%845 = OpIMul %ulong %844 %ulong_8
+OpStore %379 %845
+%846 = OpLoad %ulong %329
+%847 = OpLoad %ulong %379
+%848 = OpShiftRightLogical %ulong %846 %847
+OpStore %380 %848
+%849 = OpLoad %ulong %380
+%850 = OpBitwiseAnd %ulong %849 %ulong_255
+OpStore %381 %850
+%851 = OpLoad %ulong %385
+%852 = OpLoad %ulong %381
+%853 = OpBitwiseXor %ulong %851 %852
+OpStore %382 %853
+%854 = OpLoad %ulong %382
+%855 = OpIMul %ulong %854 %ulong_1099511628211
+OpStore %383 %855
+%856 = OpLoad %ulong %386
+%857 = OpIAdd %ulong %856 %ulong_1
+OpStore %384 %857
+%858 = OpLoad %ulong %383
+OpStore %385 %858
+%859 = OpLoad %ulong %384
+OpStore %386 %859
+OpBranch %167
+%29 = OpLabel
+%860 = OpLoad %ulong %364
+%862 = OpIMul %ulong %860 %ulong_37
+OpStore %325 %862
+%863 = OpLoad %ulong %325
+%864 = OpLoad %ulong %225
+%865 = OpIAdd %ulong %863 %864
+OpStore %326 %865
+%866 = OpLoad %ulong %326
+%867 = OpUConvert %uint %866
+OpStore %327 %867
+%868 = OpAccessChain %_ptr_Function__arr_uint_uint_512 %223 %uint_3
+%869 = OpLoad %ulong %364
+%870 = OpAccessChain %_ptr_Function_uint %868 %869
+%871 = OpLoad %uint %327
+OpStore %870 %871
+%872 = OpLoad %ulong %364
+%873 = OpIAdd %ulong %872 %ulong_1
+OpStore %328 %873
+%874 = OpLoad %ulong %328
+OpStore %364 %874
+OpBranch %168
+%26 = OpLabel
+%875 = OpLoad %ulong %365
+%877 = OpIMul %ulong %875 %ulong_31
+OpStore %321 %877
+%878 = OpLoad %ulong %321
+%879 = OpLoad %ulong %225
+%880 = OpIAdd %ulong %878 %879
+OpStore %322 %880
+%881 = OpAccessChain %_ptr_Function__arr_ulong_uint_1024 %223 %uint_1
+%882 = OpLoad %ulong %365
+%883 = OpAccessChain %_ptr_Function_ulong %881 %882
+%884 = OpLoad %ulong %322
+OpStore %883 %884
+%885 = OpLoad %ulong %365
+%886 = OpIAdd %ulong %885 %ulong_1
+OpStore %323 %886
+%887 = OpLoad %ulong %323
+OpStore %365 %887
+OpBranch %170
+%121 = OpLabel
+%888 = OpLoad %ulong %501
+%889 = OpIMul %ulong %888 %ulong_8
+OpStore %494 %889
+%890 = OpLoad %ulong %444
+%891 = OpLoad %ulong %494
+%892 = OpShiftRightLogical %ulong %890 %891
+OpStore %495 %892
+%893 = OpLoad %ulong %495
+%894 = OpBitwiseAnd %ulong %893 %ulong_255
+OpStore %496 %894
+%895 = OpLoad %ulong %500
+%896 = OpLoad %ulong %496
+%897 = OpBitwiseXor %ulong %895 %896
+OpStore %497 %897
+%898 = OpLoad %ulong %497
+%899 = OpIMul %ulong %898 %ulong_1099511628211
+OpStore %498 %899
+%900 = OpLoad %ulong %501
+%901 = OpIAdd %ulong %900 %ulong_1
+OpStore %499 %901
+%902 = OpLoad %ulong %498
+OpStore %500 %902
+%903 = OpLoad %ulong %499
+OpStore %501 %903
+OpBranch %173
+%85 = OpLabel
+%904 = OpLoad %ulong %443
+%905 = OpIMul %ulong %904 %ulong_8
+OpStore %436 %905
+%906 = OpLoad %ulong %377
+%907 = OpLoad %ulong %436
+%908 = OpShiftRightLogical %ulong %906 %907
+OpStore %437 %908
+%909 = OpLoad %ulong %437
+%910 = OpBitwiseAnd %ulong %909 %ulong_255
+OpStore %438 %910
+%911 = OpLoad %ulong %442
+%912 = OpLoad %ulong %438
+%913 = OpBitwiseXor %ulong %911 %912
+OpStore %439 %913
+%914 = OpLoad %ulong %439
+%915 = OpIMul %ulong %914 %ulong_1099511628211
+OpStore %440 %915
+%916 = OpLoad %ulong %443
+%917 = OpIAdd %ulong %916 %ulong_1
+OpStore %441 %917
+%918 = OpLoad %ulong %440
+OpStore %442 %918
+%919 = OpLoad %ulong %441
+OpStore %443 %919
+OpBranch %177
+%23 = OpLabel
+%920 = OpLoad %ulong %366
+%921 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %920
+%922 = OpAccessChain %_ptr_Function_uint %921 %uint_3
+%923 = OpLoad %uint %922
+OpStore %307 %923
+OpBranch %43
+%43 = OpLabel
+%924 = OpLoad %uint %307
+%925 = OpUConvert %ulong %924
+OpStore %376 %925
+OpBranch %76
+%76 = OpLabel
+%926 = OpLoad %ulong %359
+OpStore %432 %926
+OpStore %433 %ulong_0
+OpBranch %77
+%77 = OpLabel
+%927 = OpLoad %ulong %433
+%928 = OpULessThan %bool %927 %ulong_8
+OpStore %425 %928
+%929 = OpLoad %bool %425
+OpLoopMerge %79 %176 None
+OpBranchConditional %929 %78 %79
+%79 = OpLabel
+OpBranch %80
+%80 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%930 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %uint_3
+%931 = OpLoad %ulong %366
+%932 = OpAccessChain %_ptr_Function_uint %930 %931
+%933 = OpLoad %uint %932
+OpStore %308 %933
+OpBranch %81
+%81 = OpLabel
+%934 = OpLoad %uint %308
+%935 = OpUConvert %ulong %934
+OpStore %434 %935
+OpBranch %112
+%112 = OpLabel
+%936 = OpLoad %ulong %432
+OpStore %489 %936
+OpStore %490 %ulong_0
+OpBranch %113
+%113 = OpLabel
+%937 = OpLoad %ulong %490
+%938 = OpULessThan %bool %937 %ulong_8
+OpStore %482 %938
+%939 = OpLoad %bool %482
+OpLoopMerge %115 %172 None
+OpBranchConditional %939 %114 %115
+%115 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpBranch %82
+%82 = OpLabel
+%940 = OpLoad %ulong %366
+%941 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %940
+%942 = OpLoad %ulong %366
+%943 = OpLoad %ulong %225
+%944 = OpIAdd %ulong %942 %943
+OpStore %309 %944
+%945 = OpLoad %ulong %309
+%947 = OpBitwiseAnd %ulong %945 %ulong_7
+OpStore %310 %947
+%948 = OpLoad %ulong %310
+%949 = OpAccessChain %_ptr_Function_uint %941 %948
+%950 = OpLoad %uint %949
+OpStore %311 %950
+OpBranch %117
+%117 = OpLabel
+%951 = OpLoad %uint %311
+%952 = OpUConvert %ulong %951
+OpStore %491 %952
+%953 = OpLoad %ulong %489
+%954 = OpLoad %ulong %491
+%955 = OpFunctionCall %ulong %2 %953 %954
+OpStore %492 %955
+OpBranch %118
+%118 = OpLabel
+%956 = OpLoad %ulong %366
+%957 = OpIAdd %ulong %956 %ulong_1
+OpStore %312 %957
+%958 = OpLoad %ulong %492
+OpStore %359 %958
+%959 = OpLoad %ulong %312
+OpStore %366 %959
+OpBranch %180
+%114 = OpLabel
+%960 = OpLoad %ulong %490
+%961 = OpIMul %ulong %960 %ulong_8
+OpStore %483 %961
+%962 = OpLoad %ulong %434
+%963 = OpLoad %ulong %483
+%964 = OpShiftRightLogical %ulong %962 %963
+OpStore %484 %964
+%965 = OpLoad %ulong %484
+%966 = OpBitwiseAnd %ulong %965 %ulong_255
+OpStore %485 %966
+%967 = OpLoad %ulong %489
+%968 = OpLoad %ulong %485
+%969 = OpBitwiseXor %ulong %967 %968
+OpStore %486 %969
+%970 = OpLoad %ulong %486
+%971 = OpIMul %ulong %970 %ulong_1099511628211
+OpStore %487 %971
+%972 = OpLoad %ulong %490
+%973 = OpIAdd %ulong %972 %ulong_1
+OpStore %488 %973
+%974 = OpLoad %ulong %487
+OpStore %489 %974
+%975 = OpLoad %ulong %488
+OpStore %490 %975
+OpBranch %172
+%78 = OpLabel
+%976 = OpLoad %ulong %433
+%977 = OpIMul %ulong %976 %ulong_8
+OpStore %426 %977
+%978 = OpLoad %ulong %376
+%979 = OpLoad %ulong %426
+%980 = OpShiftRightLogical %ulong %978 %979
+OpStore %427 %980
+%981 = OpLoad %ulong %427
+%982 = OpBitwiseAnd %ulong %981 %ulong_255
+OpStore %428 %982
+%983 = OpLoad %ulong %432
+%984 = OpLoad %ulong %428
+%985 = OpBitwiseXor %ulong %983 %984
+OpStore %429 %985
+%986 = OpLoad %ulong %429
+%987 = OpIMul %ulong %986 %ulong_1099511628211
+OpStore %430 %987
+%988 = OpLoad %ulong %433
+%989 = OpIAdd %ulong %988 %ulong_1
+OpStore %431 %989
+%990 = OpLoad %ulong %430
+OpStore %432 %990
+%991 = OpLoad %ulong %431
+OpStore %433 %991
+OpBranch %176
+%17 = OpLabel
+%992 = OpLoad %ulong %370
+%994 = OpIMul %ulong %992 %ulong_71
+OpStore %299 %994
+%995 = OpLoad %ulong %370
+%996 = OpAccessChain %_ptr_Function__arr_uint_uint_8 %195 %995
+OpStore %371 %ulong_0
+OpBranch %19
+%19 = OpLabel
+%997 = OpLoad %ulong %371
+%998 = OpULessThan %bool %997 %ulong_8
+OpStore %298 %998
+%999 = OpLoad %bool %298
+OpLoopMerge %21 %179 None
+OpBranchConditional %999 %20 %21
+%21 = OpLabel
+%1000 = OpLoad %ulong %370
+%1001 = OpIAdd %ulong %1000 %ulong_1
+OpStore %305 %1001
+%1002 = OpLoad %ulong %305
+OpStore %370 %1002
+OpBranch %182
+%20 = OpLabel
+%1003 = OpLoad %ulong %371
+%1005 = OpIMul %ulong %1003 %ulong_13
+OpStore %300 %1005
+%1006 = OpLoad %ulong %299
+%1007 = OpLoad %ulong %300
+%1008 = OpIAdd %ulong %1006 %1007
+OpStore %301 %1008
+%1009 = OpLoad %ulong %301
+%1010 = OpLoad %ulong %225
+%1011 = OpIAdd %ulong %1009 %1010
+OpStore %302 %1011
+%1012 = OpLoad %ulong %302
+%1013 = OpUConvert %uint %1012
+OpStore %303 %1013
+%1014 = OpLoad %ulong %371
+%1015 = OpAccessChain %_ptr_Function_uint %996 %1014
+%1016 = OpLoad %uint %303
+OpStore %1015 %1016
+%1017 = OpLoad %ulong %371
+%1018 = OpIAdd %ulong %1017 %ulong_1
+OpStore %304 %1018
+%1019 = OpLoad %ulong %304
+OpStore %371 %1019
+OpBranch %179
+%14 = OpLabel
+%1020 = OpLoad %ulong %367
+%1022 = OpIMul %ulong %1020 %ulong_2
+OpStore %281 %1022
+%1023 = OpLoad %ulong %281
+%1024 = OpAccessChain %_ptr_Function_uint %205 %1023
+%1025 = OpLoad %uint %1024
+OpStore %282 %1025
+OpBranch %41
+%41 = OpLabel
+%1026 = OpLoad %uint %282
+%1027 = OpUConvert %ulong %1026
+OpStore %375 %1027
+OpBranch %69
+%69 = OpLabel
+%1028 = OpLoad %ulong %360
+OpStore %422 %1028
+OpStore %423 %ulong_0
+OpBranch %70
+%70 = OpLabel
+%1029 = OpLoad %ulong %423
+%1030 = OpULessThan %bool %1029 %ulong_8
+OpStore %415 %1030
+%1031 = OpLoad %bool %415
+OpLoopMerge %72 %181 None
+OpBranchConditional %1031 %71 %72
+%72 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%1032 = OpLoad %ulong %367
+%1033 = OpShiftLeftLogical %ulong %1032 %ulong_1
+OpStore %283 %1033
+%1034 = OpLoad %ulong %283
+%1035 = OpAccessChain %_ptr_Function_uint %205 %1034
+%1036 = OpLoad %uint %1035
+OpStore %284 %1036
+OpBranch %74
+%74 = OpLabel
+%1037 = OpLoad %uint %284
+%1038 = OpUConvert %ulong %1037
+OpStore %424 %1038
+OpBranch %102
+%102 = OpLabel
+%1039 = OpLoad %ulong %422
+OpStore %471 %1039
+OpStore %472 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%1040 = OpLoad %ulong %472
+%1041 = OpULessThan %bool %1040 %ulong_8
+OpStore %464 %1041
+%1042 = OpLoad %bool %464
+OpLoopMerge %105 %175 None
+OpBranchConditional %1042 %104 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%1043 = OpLoad %ulong %367
+%1044 = OpIAdd %ulong %1043 %ulong_1
+OpStore %285 %1044
+%1045 = OpLoad %ulong %285
+%1046 = OpIMul %ulong %1045 %ulong_2
+OpStore %286 %1046
+%1047 = OpLoad %ulong %286
+%1048 = OpISub %ulong %1047 %ulong_2
+OpStore %287 %1048
+%1049 = OpLoad %ulong %287
+%1050 = OpAccessChain %_ptr_Function_ulong %208 %1049
+%1051 = OpLoad %ulong %1050
+OpStore %288 %1051
+OpBranch %107
+%107 = OpLabel
+%1052 = OpLoad %ulong %471
+OpStore %480 %1052
+OpStore %481 %ulong_0
+OpBranch %108
+%108 = OpLabel
+%1053 = OpLoad %ulong %481
+%1054 = OpULessThan %bool %1053 %ulong_8
+OpStore %473 %1054
+%1055 = OpLoad %bool %473
+OpLoopMerge %110 %171 None
+OpBranchConditional %1055 %109 %110
+%110 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%1057 = OpLoad %ulong %367
+%1058 = OpISub %ulong %ulong_63 %1057
+OpStore %289 %1058
+%1059 = OpLoad %ulong %289
+%1060 = OpAccessChain %_ptr_Function_uchar %199 %1059
+%1061 = OpLoad %uchar %1060
+OpStore %290 %1061
+OpBranch %139
+%139 = OpLabel
+%1062 = OpLoad %uchar %290
+%1063 = OpUConvert %ulong %1062
+OpStore %529 %1063
+%1064 = OpLoad %ulong %480
+%1065 = OpLoad %ulong %529
+%1066 = OpFunctionCall %ulong %2 %1064 %1065
+OpStore %530 %1066
+OpBranch %140
+%140 = OpLabel
+%1067 = OpLoad %ulong %367
+%1068 = OpIMul %ulong %1067 %ulong_2
+OpStore %291 %1068
+%1069 = OpLoad %ulong %291
+%1070 = OpLoad %ulong %225
+%1071 = OpIAdd %ulong %1069 %1070
+OpStore %292 %1071
+%1072 = OpLoad %ulong %292
+%1073 = OpBitwiseAnd %ulong %1072 %ulong_63
+OpStore %293 %1073
+%1074 = OpLoad %ulong %293
+%1076 = OpAccessChain %_ptr_Function__struct_209 %212 %1074
+%1077 = OpAccessChain %_ptr_Function_ulong %1076 %uint_2
+%1078 = OpLoad %ulong %1077
+OpStore %294 %1078
+%1079 = OpLoad %ulong %530
+%1080 = OpLoad %ulong %294
+%1081 = OpFunctionCall %ulong %2 %1079 %1080
+OpStore %295 %1081
+%1082 = OpLoad %ulong %367
+%1083 = OpIAdd %ulong %1082 %ulong_1
+OpStore %296 %1083
+%1084 = OpLoad %ulong %295
+OpStore %360 %1084
+%1085 = OpLoad %ulong %296
+OpStore %367 %1085
+OpBranch %184
+%109 = OpLabel
+%1086 = OpLoad %ulong %481
+%1087 = OpIMul %ulong %1086 %ulong_8
+OpStore %474 %1087
+%1088 = OpLoad %ulong %288
+%1089 = OpLoad %ulong %474
+%1090 = OpShiftRightLogical %ulong %1088 %1089
+OpStore %475 %1090
+%1091 = OpLoad %ulong %475
+%1092 = OpBitwiseAnd %ulong %1091 %ulong_255
+OpStore %476 %1092
+%1093 = OpLoad %ulong %480
+%1094 = OpLoad %ulong %476
+%1095 = OpBitwiseXor %ulong %1093 %1094
+OpStore %477 %1095
+%1096 = OpLoad %ulong %477
+%1097 = OpIMul %ulong %1096 %ulong_1099511628211
+OpStore %478 %1097
+%1098 = OpLoad %ulong %481
+%1099 = OpIAdd %ulong %1098 %ulong_1
+OpStore %479 %1099
+%1100 = OpLoad %ulong %478
+OpStore %480 %1100
+%1101 = OpLoad %ulong %479
+OpStore %481 %1101
+OpBranch %171
+%104 = OpLabel
+%1102 = OpLoad %ulong %472
+%1103 = OpIMul %ulong %1102 %ulong_8
+OpStore %465 %1103
+%1104 = OpLoad %ulong %424
+%1105 = OpLoad %ulong %465
+%1106 = OpShiftRightLogical %ulong %1104 %1105
+OpStore %466 %1106
+%1107 = OpLoad %ulong %466
+%1108 = OpBitwiseAnd %ulong %1107 %ulong_255
+OpStore %467 %1108
+%1109 = OpLoad %ulong %471
+%1110 = OpLoad %ulong %467
+%1111 = OpBitwiseXor %ulong %1109 %1110
+OpStore %468 %1111
+%1112 = OpLoad %ulong %468
+%1113 = OpIMul %ulong %1112 %ulong_1099511628211
+OpStore %469 %1113
+%1114 = OpLoad %ulong %472
+%1115 = OpIAdd %ulong %1114 %ulong_1
+OpStore %470 %1115
+%1116 = OpLoad %ulong %469
+OpStore %471 %1116
+%1117 = OpLoad %ulong %470
+OpStore %472 %1117
+OpBranch %175
+%71 = OpLabel
+%1118 = OpLoad %ulong %423
+%1119 = OpIMul %ulong %1118 %ulong_8
+OpStore %416 %1119
+%1120 = OpLoad %ulong %375
+%1121 = OpLoad %ulong %416
+%1122 = OpShiftRightLogical %ulong %1120 %1121
+OpStore %417 %1122
+%1123 = OpLoad %ulong %417
+%1124 = OpBitwiseAnd %ulong %1123 %ulong_255
+OpStore %418 %1124
+%1125 = OpLoad %ulong %422
+%1126 = OpLoad %ulong %418
+%1127 = OpBitwiseXor %ulong %1125 %1126
+OpStore %419 %1127
+%1128 = OpLoad %ulong %419
+%1129 = OpIMul %ulong %1128 %ulong_1099511628211
+OpStore %420 %1129
+%1130 = OpLoad %ulong %423
+%1131 = OpIAdd %ulong %1130 %ulong_1
+OpStore %421 %1131
+%1132 = OpLoad %ulong %420
+OpStore %422 %1132
+%1133 = OpLoad %ulong %421
+OpStore %423 %1133
+OpBranch %181
+%11 = OpLabel
+%1134 = OpLoad %ulong %368
+%1135 = OpIMul %ulong %1134 %ulong_13
+OpStore %265 %1135
+%1136 = OpLoad %ulong %265
+%1137 = OpLoad %ulong %225
+%1138 = OpIAdd %ulong %1136 %1137
+OpStore %266 %1138
+%1139 = OpLoad %ulong %266
+%1140 = OpBitwiseAnd %ulong %1139 %ulong_63
+OpStore %267 %1140
+%1141 = OpLoad %ulong %267
+%1142 = OpAccessChain %_ptr_Function_uchar %199 %1141
+%1143 = OpLoad %uchar %1142
+OpStore %268 %1143
+OpBranch %39
+%39 = OpLabel
+%1144 = OpLoad %uchar %268
+%1145 = OpUConvert %ulong %1144
+OpStore %374 %1145
+OpBranch %62
+%62 = OpLabel
+%1146 = OpLoad %ulong %361
+OpStore %412 %1146
+OpStore %413 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%1147 = OpLoad %ulong %413
+%1148 = OpULessThan %bool %1147 %ulong_8
+OpStore %405 %1148
+%1149 = OpLoad %bool %405
+OpLoopMerge %65 %183 None
+OpBranchConditional %1149 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%1150 = OpLoad %ulong %267
+%1151 = OpAccessChain %_ptr_Function_ushort %202 %1150
+%1152 = OpLoad %ushort %1151
+OpStore %269 %1152
+OpBranch %67
+%67 = OpLabel
+%1153 = OpLoad %ushort %269
+%1154 = OpUConvert %ulong %1153
+OpStore %414 %1154
+OpBranch %95
+%95 = OpLabel
+%1155 = OpLoad %ulong %412
+OpStore %461 %1155
+OpStore %462 %ulong_0
+OpBranch %96
+%96 = OpLabel
+%1156 = OpLoad %ulong %462
+%1157 = OpULessThan %bool %1156 %ulong_8
+OpStore %454 %1157
+%1158 = OpLoad %bool %454
+OpLoopMerge %98 %178 None
+OpBranchConditional %1158 %97 %98
+%98 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%1159 = OpLoad %ulong %267
+%1160 = OpAccessChain %_ptr_Function_uint %205 %1159
+%1161 = OpLoad %uint %1160
+OpStore %270 %1161
+OpBranch %100
+%100 = OpLabel
+%1162 = OpLoad %uint %270
+%1163 = OpUConvert %ulong %1162
+OpStore %463 %1163
+OpBranch %129
+%129 = OpLabel
+%1164 = OpLoad %ulong %461
+OpStore %518 %1164
+OpStore %519 %ulong_0
+OpBranch %130
+%130 = OpLabel
+%1165 = OpLoad %ulong %519
+%1166 = OpULessThan %bool %1165 %ulong_8
+OpStore %511 %1166
+%1167 = OpLoad %bool %511
+OpLoopMerge %132 %174 None
+OpBranchConditional %1167 %131 %132
+%132 = OpLabel
+OpBranch %133
+%133 = OpLabel
+OpBranch %101
+%101 = OpLabel
+%1168 = OpLoad %ulong %267
+%1169 = OpAccessChain %_ptr_Function_ulong %208 %1168
+%1170 = OpLoad %ulong %1169
+OpStore %271 %1170
+OpBranch %134
+%134 = OpLabel
+%1171 = OpLoad %ulong %518
+OpStore %527 %1171
+OpStore %528 %ulong_0
+OpBranch %135
+%135 = OpLabel
+%1172 = OpLoad %ulong %528
+%1173 = OpULessThan %bool %1172 %ulong_8
+OpStore %520 %1173
+%1174 = OpLoad %bool %520
+OpLoopMerge %137 %169 None
+OpBranchConditional %1174 %136 %137
+%137 = OpLabel
+OpBranch %138
+%138 = OpLabel
+%1175 = OpLoad %ulong %267
+%1176 = OpAccessChain %_ptr_Function__struct_209 %212 %1175
+%1177 = OpAccessChain %_ptr_Function_ushort %1176 %uint_0
+%1178 = OpLoad %ushort %1177
+OpStore %272 %1178
+OpBranch %143
+%143 = OpLabel
+%1179 = OpLoad %ushort %272
+%1180 = OpUConvert %ulong %1179
+OpStore %533 %1180
+%1181 = OpLoad %ulong %527
+%1182 = OpLoad %ulong %533
+%1183 = OpFunctionCall %ulong %2 %1181 %1182
+OpStore %534 %1183
+OpBranch %144
+%144 = OpLabel
+%1184 = OpLoad %ulong %267
+%1185 = OpAccessChain %_ptr_Function__struct_209 %212 %1184
+%1186 = OpAccessChain %_ptr_Function_uchar %1185 %uint_1
+%1187 = OpLoad %uchar %1186
+OpStore %273 %1187
+OpBranch %147
+%147 = OpLabel
+%1188 = OpLoad %uchar %273
+%1189 = OpUConvert %ulong %1188
+OpStore %537 %1189
+%1190 = OpLoad %ulong %534
+%1191 = OpLoad %ulong %537
+%1192 = OpFunctionCall %ulong %2 %1190 %1191
+OpStore %538 %1192
+OpBranch %148
+%148 = OpLabel
+%1193 = OpLoad %ulong %267
+%1194 = OpAccessChain %_ptr_Function__struct_209 %212 %1193
+%1195 = OpAccessChain %_ptr_Function_ulong %1194 %uint_2
+%1196 = OpLoad %ulong %1195
+OpStore %274 %1196
+%1197 = OpLoad %ulong %538
+%1198 = OpLoad %ulong %274
+%1199 = OpFunctionCall %ulong %2 %1197 %1198
+OpStore %275 %1199
+%1200 = OpLoad %ulong %267
+%1202 = OpAccessChain %_ptr_Function__struct_213 %216 %1200
+%1203 = OpAccessChain %_ptr_Function_uint %1202 %uint_0
+%1204 = OpLoad %uint %1203
+OpStore %276 %1204
+OpBranch %151
+%151 = OpLabel
+%1205 = OpLoad %uint %276
+%1206 = OpUConvert %ulong %1205
+OpStore %541 %1206
+%1207 = OpLoad %ulong %275
+%1208 = OpLoad %ulong %541
+%1209 = OpFunctionCall %ulong %2 %1207 %1208
+OpStore %542 %1209
+OpBranch %152
+%152 = OpLabel
+%1210 = OpLoad %ulong %267
+%1211 = OpAccessChain %_ptr_Function__struct_213 %216 %1210
+%1212 = OpAccessChain %_ptr_Function_uint %1211 %uint_1
+%1213 = OpLoad %uint %1212
+OpStore %277 %1213
+OpBranch %155
+%155 = OpLabel
+%1214 = OpLoad %uint %277
+%1215 = OpUConvert %ulong %1214
+OpStore %545 %1215
+%1216 = OpLoad %ulong %542
+%1217 = OpLoad %ulong %545
+%1218 = OpFunctionCall %ulong %2 %1216 %1217
+OpStore %546 %1218
+OpBranch %156
+%156 = OpLabel
+%1219 = OpLoad %ulong %267
+%1220 = OpAccessChain %_ptr_Function__struct_213 %216 %1219
+%1221 = OpAccessChain %_ptr_Function_uint %1220 %uint_2
+%1222 = OpLoad %uint %1221
+OpStore %278 %1222
+OpBranch %159
+%159 = OpLabel
+%1223 = OpLoad %uint %278
+%1224 = OpUConvert %ulong %1223
+OpStore %549 %1224
+%1225 = OpLoad %ulong %546
+%1226 = OpLoad %ulong %549
+%1227 = OpFunctionCall %ulong %2 %1225 %1226
+OpStore %550 %1227
+OpBranch %160
+%160 = OpLabel
+%1228 = OpLoad %ulong %368
+%1229 = OpIAdd %ulong %1228 %ulong_1
+OpStore %279 %1229
+%1230 = OpLoad %ulong %550
+OpStore %361 %1230
+%1231 = OpLoad %ulong %279
+OpStore %368 %1231
+OpBranch %185
+%136 = OpLabel
+%1232 = OpLoad %ulong %528
+%1233 = OpIMul %ulong %1232 %ulong_8
+OpStore %521 %1233
+%1234 = OpLoad %ulong %271
+%1235 = OpLoad %ulong %521
+%1236 = OpShiftRightLogical %ulong %1234 %1235
+OpStore %522 %1236
+%1237 = OpLoad %ulong %522
+%1238 = OpBitwiseAnd %ulong %1237 %ulong_255
+OpStore %523 %1238
+%1239 = OpLoad %ulong %527
+%1240 = OpLoad %ulong %523
+%1241 = OpBitwiseXor %ulong %1239 %1240
+OpStore %524 %1241
+%1242 = OpLoad %ulong %524
+%1243 = OpIMul %ulong %1242 %ulong_1099511628211
+OpStore %525 %1243
+%1244 = OpLoad %ulong %528
+%1245 = OpIAdd %ulong %1244 %ulong_1
+OpStore %526 %1245
+%1246 = OpLoad %ulong %525
+OpStore %527 %1246
+%1247 = OpLoad %ulong %526
+OpStore %528 %1247
+OpBranch %169
+%131 = OpLabel
+%1248 = OpLoad %ulong %519
+%1249 = OpIMul %ulong %1248 %ulong_8
+OpStore %512 %1249
+%1250 = OpLoad %ulong %463
+%1251 = OpLoad %ulong %512
+%1252 = OpShiftRightLogical %ulong %1250 %1251
+OpStore %513 %1252
+%1253 = OpLoad %ulong %513
+%1254 = OpBitwiseAnd %ulong %1253 %ulong_255
+OpStore %514 %1254
+%1255 = OpLoad %ulong %518
+%1256 = OpLoad %ulong %514
+%1257 = OpBitwiseXor %ulong %1255 %1256
+OpStore %515 %1257
+%1258 = OpLoad %ulong %515
+%1259 = OpIMul %ulong %1258 %ulong_1099511628211
+OpStore %516 %1259
+%1260 = OpLoad %ulong %519
+%1261 = OpIAdd %ulong %1260 %ulong_1
+OpStore %517 %1261
+%1262 = OpLoad %ulong %516
+OpStore %518 %1262
+%1263 = OpLoad %ulong %517
+OpStore %519 %1263
+OpBranch %174
+%97 = OpLabel
+%1264 = OpLoad %ulong %462
+%1265 = OpIMul %ulong %1264 %ulong_8
+OpStore %455 %1265
+%1266 = OpLoad %ulong %414
+%1267 = OpLoad %ulong %455
+%1268 = OpShiftRightLogical %ulong %1266 %1267
+OpStore %456 %1268
+%1269 = OpLoad %ulong %456
+%1270 = OpBitwiseAnd %ulong %1269 %ulong_255
+OpStore %457 %1270
+%1271 = OpLoad %ulong %461
+%1272 = OpLoad %ulong %457
+%1273 = OpBitwiseXor %ulong %1271 %1272
+OpStore %458 %1273
+%1274 = OpLoad %ulong %458
+%1275 = OpIMul %ulong %1274 %ulong_1099511628211
+OpStore %459 %1275
+%1276 = OpLoad %ulong %462
+%1277 = OpIAdd %ulong %1276 %ulong_1
+OpStore %460 %1277
+%1278 = OpLoad %ulong %459
+OpStore %461 %1278
+%1279 = OpLoad %ulong %460
+OpStore %462 %1279
+OpBranch %178
+%64 = OpLabel
+%1280 = OpLoad %ulong %413
+%1281 = OpIMul %ulong %1280 %ulong_8
+OpStore %406 %1281
+%1282 = OpLoad %ulong %374
+%1283 = OpLoad %ulong %406
+%1284 = OpShiftRightLogical %ulong %1282 %1283
+OpStore %407 %1284
+%1285 = OpLoad %ulong %407
+%1286 = OpBitwiseAnd %ulong %1285 %ulong_255
+OpStore %408 %1286
+%1287 = OpLoad %ulong %412
+%1288 = OpLoad %ulong %408
+%1289 = OpBitwiseXor %ulong %1287 %1288
+OpStore %409 %1289
+%1290 = OpLoad %ulong %409
+%1291 = OpIMul %ulong %1290 %ulong_1099511628211
+OpStore %410 %1291
+%1292 = OpLoad %ulong %413
+%1293 = OpIAdd %ulong %1292 %ulong_1
+OpStore %411 %1293
+%1294 = OpLoad %ulong %410
+OpStore %412 %1294
+%1295 = OpLoad %ulong %411
+OpStore %413 %1295
+OpBranch %183
+%8 = OpLabel
+%1296 = OpLoad %ulong %369
+%1297 = OpIMul %ulong %1296 %ulong_3
+OpStore %228 %1297
+%1298 = OpLoad %ulong %228
+%1299 = OpIAdd %ulong %1298 %ulong_1
+OpStore %229 %1299
+%1300 = OpLoad %ulong %229
+%1301 = OpLoad %ulong %225
+%1302 = OpIAdd %ulong %1300 %1301
+OpStore %230 %1302
+%1303 = OpLoad %ulong %230
+%1304 = OpUConvert %uchar %1303
+OpStore %232 %1304
+%1305 = OpLoad %ulong %369
+%1306 = OpAccessChain %_ptr_Function_uchar %199 %1305
+%1307 = OpLoad %uchar %232
+OpStore %1306 %1307
+%1308 = OpLoad %ulong %369
+%1310 = OpIMul %ulong %1308 %ulong_1103
+OpStore %233 %1310
+%1311 = OpLoad %ulong %233
+%1312 = OpIAdd %ulong %1311 %ulong_7
+OpStore %234 %1312
+%1313 = OpLoad %ulong %234
+%1314 = OpLoad %ulong %225
+%1315 = OpIAdd %ulong %1313 %1314
+OpStore %235 %1315
+%1316 = OpLoad %ulong %235
+%1317 = OpUConvert %ushort %1316
+OpStore %237 %1317
+%1318 = OpLoad %ulong %369
+%1319 = OpAccessChain %_ptr_Function_ushort %202 %1318
+%1320 = OpLoad %ushort %237
+OpStore %1319 %1320
+%1321 = OpLoad %ulong %369
+%1323 = OpIMul %ulong %1321 %ulong_2654435761
+OpStore %238 %1323
+%1324 = OpLoad %ulong %238
+%1326 = OpIAdd %ulong %1324 %ulong_11
+OpStore %239 %1326
+%1327 = OpLoad %ulong %239
+%1328 = OpLoad %ulong %225
+%1329 = OpIAdd %ulong %1327 %1328
+OpStore %240 %1329
+%1330 = OpLoad %ulong %240
+%1331 = OpUConvert %uint %1330
+OpStore %242 %1331
+%1332 = OpLoad %ulong %369
+%1333 = OpAccessChain %_ptr_Function_uint %205 %1332
+%1334 = OpLoad %uint %242
+OpStore %1333 %1334
+%1335 = OpLoad %ulong %369
+%1336 = OpIAdd %ulong %1335 %ulong_1
+OpStore %243 %1336
+%1338 = OpLoad %ulong %243
+%1339 = OpIMul %ulong %ulong_11400714819323198485 %1338
+OpStore %244 %1339
+%1340 = OpLoad %ulong %244
+%1341 = OpLoad %ulong %225
+%1342 = OpIAdd %ulong %1340 %1341
+OpStore %245 %1342
+%1343 = OpLoad %ulong %369
+%1344 = OpAccessChain %_ptr_Function_ulong %208 %1343
+%1345 = OpLoad %ulong %245
+OpStore %1344 %1345
+%1346 = OpLoad %ulong %369
+%1348 = OpIMul %ulong %1346 %ulong_5
+OpStore %246 %1348
+%1349 = OpLoad %ulong %246
+%1350 = OpIAdd %ulong %1349 %ulong_2
+OpStore %247 %1350
+%1351 = OpLoad %ulong %247
+%1352 = OpLoad %ulong %225
+%1353 = OpIAdd %ulong %1351 %1352
+OpStore %248 %1353
+%1354 = OpLoad %ulong %248
+%1355 = OpUConvert %ushort %1354
+OpStore %249 %1355
+%1356 = OpLoad %ulong %369
+%1357 = OpAccessChain %_ptr_Function__struct_209 %212 %1356
+%1358 = OpAccessChain %_ptr_Function_ushort %1357 %uint_0
+%1359 = OpLoad %ushort %249
+OpStore %1358 %1359
+%1360 = OpLoad %ulong %369
+%1362 = OpIAdd %ulong %1360 %ulong_128
+OpStore %250 %1362
+%1363 = OpLoad %ulong %250
+%1364 = OpUConvert %uchar %1363
+OpStore %251 %1364
+%1365 = OpAccessChain %_ptr_Function_uchar %1357 %uint_1
+%1366 = OpLoad %uchar %251
+OpStore %1365 %1366
+%1367 = OpLoad %ulong %243
+%1368 = OpIMul %ulong %ulong_1099511628211 %1367
+OpStore %252 %1368
+%1369 = OpLoad %ulong %252
+%1370 = OpLoad %ulong %225
+%1371 = OpIAdd %ulong %1369 %1370
+OpStore %253 %1371
+%1372 = OpAccessChain %_ptr_Function_ulong %1357 %uint_2
+%1373 = OpLoad %ulong %253
+OpStore %1372 %1373
+%1374 = OpLoad %ulong %369
+%1376 = OpIMul %ulong %1374 %ulong_17
+OpStore %254 %1376
+%1377 = OpLoad %ulong %254
+%1378 = OpIAdd %ulong %1377 %ulong_1
+OpStore %255 %1378
+%1379 = OpLoad %ulong %255
+%1380 = OpLoad %ulong %225
+%1381 = OpIAdd %ulong %1379 %1380
+OpStore %256 %1381
+%1382 = OpLoad %ulong %256
+%1383 = OpUConvert %uint %1382
+OpStore %257 %1383
+%1384 = OpLoad %ulong %369
+%1385 = OpAccessChain %_ptr_Function__struct_213 %216 %1384
+%1386 = OpAccessChain %_ptr_Function_uint %1385 %uint_0
+%1387 = OpLoad %uint %257
+OpStore %1386 %1387
+%1388 = OpLoad %ulong %254
+%1389 = OpIAdd %ulong %1388 %ulong_2
+OpStore %258 %1389
+%1390 = OpLoad %ulong %258
+%1391 = OpLoad %ulong %225
+%1392 = OpIAdd %ulong %1390 %1391
+OpStore %259 %1392
+%1393 = OpLoad %ulong %259
+%1394 = OpUConvert %uint %1393
+OpStore %260 %1394
+%1395 = OpAccessChain %_ptr_Function_uint %1385 %uint_1
+%1396 = OpLoad %uint %260
+OpStore %1395 %1396
+%1397 = OpLoad %ulong %254
+%1398 = OpIAdd %ulong %1397 %ulong_3
+OpStore %261 %1398
+%1399 = OpLoad %ulong %261
+%1400 = OpLoad %ulong %225
+%1401 = OpIAdd %ulong %1399 %1400
+OpStore %262 %1401
+%1402 = OpLoad %ulong %262
+%1403 = OpUConvert %uint %1402
+OpStore %263 %1403
+%1404 = OpAccessChain %_ptr_Function_uint %1385 %uint_2
+%1405 = OpLoad %uint %263
+OpStore %1404 %1405
+%1406 = OpLoad %ulong %243
+OpStore %369 %1406
+OpBranch %186
+%161 = OpLabel
+OpBranch %58
+%162 = OpLabel
+OpBranch %34
+%163 = OpLabel
+OpBranch %53
+%164 = OpLabel
+OpBranch %31
+%165 = OpLabel
+OpBranch %125
+%166 = OpLabel
+OpBranch %91
+%167 = OpLabel
+OpBranch %48
+%168 = OpLabel
+OpBranch %28
+%169 = OpLabel
+OpBranch %135
+%170 = OpLabel
+OpBranch %25
+%171 = OpLabel
+OpBranch %108
+%172 = OpLabel
+OpBranch %113
+%173 = OpLabel
+OpBranch %120
+%174 = OpLabel
+OpBranch %130
+%175 = OpLabel
+OpBranch %103
+%176 = OpLabel
+OpBranch %77
+%177 = OpLabel
+OpBranch %84
+%178 = OpLabel
+OpBranch %96
+%179 = OpLabel
+OpBranch %19
+%180 = OpLabel
+OpBranch %22
+%181 = OpLabel
+OpBranch %70
+%182 = OpLabel
+OpBranch %16
+%183 = OpLabel
+OpBranch %63
+%184 = OpLabel
+OpBranch %13
+%185 = OpLabel
+OpBranch %10
+%186 = OpLabel
+OpBranch %7
 OpFunctionEnd
-%2 = OpFunction %ulong None %789
-%790 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %792
-%793 = OpFunctionParameter %ulong
-%794 = OpFunctionParameter %ulong
-%795 = OpLabel
-%800 = OpVariable %_ptr_Function_ulong Function
-%801 = OpVariable %_ptr_Function_ulong Function
-%802 = OpVariable %_ptr_Function_bool Function
-%803 = OpVariable %_ptr_Function_ulong Function
-%804 = OpVariable %_ptr_Function_ulong Function
-%805 = OpVariable %_ptr_Function_ulong Function
-%806 = OpVariable %_ptr_Function_ulong Function
-%807 = OpVariable %_ptr_Function_ulong Function
-%808 = OpVariable %_ptr_Function_ulong Function
-%809 = OpVariable %_ptr_Function_ulong Function
-%810 = OpVariable %_ptr_Function_ulong Function
-OpStore %800 %793
-OpStore %801 %794
-%811 = OpLoad %ulong %800
-OpStore %809 %811
-OpStore %810 %ulong_0
-OpBranch %796
-%796 = OpLabel
-%812 = OpLoad %ulong %810
-%813 = OpULessThan %bool %812 %ulong_8
-OpStore %802 %813
-%814 = OpLoad %bool %802
-OpLoopMerge %798 %799 None
-OpBranchConditional %814 %797 %798
-%798 = OpLabel
-%815 = OpLoad %ulong %809
-OpReturnValue %815
-%797 = OpLabel
-%816 = OpLoad %ulong %810
-%817 = OpIMul %ulong %816 %ulong_8
-OpStore %803 %817
-%818 = OpLoad %ulong %801
-%819 = OpLoad %ulong %803
-%820 = OpShiftRightLogical %ulong %818 %819
-OpStore %804 %820
-%821 = OpLoad %ulong %804
-%823 = OpBitwiseAnd %ulong %821 %ulong_255
-OpStore %805 %823
-%824 = OpLoad %ulong %809
-%825 = OpLoad %ulong %805
-%826 = OpBitwiseXor %ulong %824 %825
-OpStore %806 %826
-%827 = OpLoad %ulong %806
-%828 = OpIMul %ulong %827 %ulong_1099511628211
-OpStore %807 %828
-%829 = OpLoad %ulong %810
-%830 = OpIAdd %ulong %829 %ulong_1
-OpStore %808 %830
-%831 = OpLoad %ulong %807
-OpStore %809 %831
-%832 = OpLoad %ulong %808
-OpStore %810 %832
-OpBranch %799
-%799 = OpLabel
-OpBranch %796
-OpFunctionEnd
-%4 = OpFunction %ulong None %833
-%834 = OpFunctionParameter %ulong
-%835 = OpFunctionParameter %uchar
-%836 = OpLabel
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_uchar Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_bool Function
-%847 = OpVariable %_ptr_Function_ulong Function
-%848 = OpVariable %_ptr_Function_ulong Function
-%849 = OpVariable %_ptr_Function_ulong Function
-%850 = OpVariable %_ptr_Function_ulong Function
-%851 = OpVariable %_ptr_Function_ulong Function
-%852 = OpVariable %_ptr_Function_ulong Function
-%853 = OpVariable %_ptr_Function_ulong Function
-%854 = OpVariable %_ptr_Function_ulong Function
-OpStore %843 %834
-OpStore %844 %835
-%855 = OpLoad %uchar %844
-%856 = OpUConvert %ulong %855
-OpStore %845 %856
-OpBranch %837
-%837 = OpLabel
-%857 = OpLoad %ulong %843
-OpStore %853 %857
-OpStore %854 %ulong_0
-OpBranch %838
-%838 = OpLabel
-%858 = OpLoad %ulong %854
-%859 = OpULessThan %bool %858 %ulong_8
-OpStore %846 %859
-%860 = OpLoad %bool %846
-OpLoopMerge %840 %842 None
-OpBranchConditional %860 %839 %840
-%840 = OpLabel
-OpBranch %841
-%841 = OpLabel
-%861 = OpLoad %ulong %853
-OpReturnValue %861
-%839 = OpLabel
-%862 = OpLoad %ulong %854
-%863 = OpIMul %ulong %862 %ulong_8
-OpStore %847 %863
-%864 = OpLoad %ulong %845
-%865 = OpLoad %ulong %847
-%866 = OpShiftRightLogical %ulong %864 %865
-OpStore %848 %866
-%867 = OpLoad %ulong %848
-%868 = OpBitwiseAnd %ulong %867 %ulong_255
-OpStore %849 %868
-%869 = OpLoad %ulong %853
-%870 = OpLoad %ulong %849
-%871 = OpBitwiseXor %ulong %869 %870
-OpStore %850 %871
-%872 = OpLoad %ulong %850
-%873 = OpIMul %ulong %872 %ulong_1099511628211
-OpStore %851 %873
-%874 = OpLoad %ulong %854
-%875 = OpIAdd %ulong %874 %ulong_1
-OpStore %852 %875
-%876 = OpLoad %ulong %851
-OpStore %853 %876
-%877 = OpLoad %ulong %852
-OpStore %854 %877
-OpBranch %842
-%842 = OpLabel
-OpBranch %838
-OpFunctionEnd
-%5 = OpFunction %ulong None %878
-%879 = OpFunctionParameter %ulong
-%880 = OpFunctionParameter %ushort
-%881 = OpLabel
-%888 = OpVariable %_ptr_Function_ulong Function
-%889 = OpVariable %_ptr_Function_ushort Function
-%890 = OpVariable %_ptr_Function_ulong Function
-%891 = OpVariable %_ptr_Function_bool Function
-%892 = OpVariable %_ptr_Function_ulong Function
-%893 = OpVariable %_ptr_Function_ulong Function
-%894 = OpVariable %_ptr_Function_ulong Function
-%895 = OpVariable %_ptr_Function_ulong Function
-%896 = OpVariable %_ptr_Function_ulong Function
-%897 = OpVariable %_ptr_Function_ulong Function
-%898 = OpVariable %_ptr_Function_ulong Function
-%899 = OpVariable %_ptr_Function_ulong Function
-OpStore %888 %879
-OpStore %889 %880
-%900 = OpLoad %ushort %889
-%901 = OpUConvert %ulong %900
-OpStore %890 %901
-OpBranch %882
-%882 = OpLabel
-%902 = OpLoad %ulong %888
-OpStore %898 %902
-OpStore %899 %ulong_0
-OpBranch %883
-%883 = OpLabel
-%903 = OpLoad %ulong %899
-%904 = OpULessThan %bool %903 %ulong_8
-OpStore %891 %904
-%905 = OpLoad %bool %891
-OpLoopMerge %885 %887 None
-OpBranchConditional %905 %884 %885
-%885 = OpLabel
-OpBranch %886
-%886 = OpLabel
-%906 = OpLoad %ulong %898
-OpReturnValue %906
-%884 = OpLabel
-%907 = OpLoad %ulong %899
-%908 = OpIMul %ulong %907 %ulong_8
-OpStore %892 %908
-%909 = OpLoad %ulong %890
-%910 = OpLoad %ulong %892
-%911 = OpShiftRightLogical %ulong %909 %910
-OpStore %893 %911
-%912 = OpLoad %ulong %893
-%913 = OpBitwiseAnd %ulong %912 %ulong_255
-OpStore %894 %913
-%914 = OpLoad %ulong %898
-%915 = OpLoad %ulong %894
-%916 = OpBitwiseXor %ulong %914 %915
-OpStore %895 %916
-%917 = OpLoad %ulong %895
-%918 = OpIMul %ulong %917 %ulong_1099511628211
-OpStore %896 %918
-%919 = OpLoad %ulong %899
-%920 = OpIAdd %ulong %919 %ulong_1
-OpStore %897 %920
-%921 = OpLoad %ulong %896
-OpStore %898 %921
-%922 = OpLoad %ulong %897
-OpStore %899 %922
-OpBranch %887
-%887 = OpLabel
-OpBranch %883
-OpFunctionEnd
-%6 = OpFunction %ulong None %923
-%924 = OpFunctionParameter %ulong
-%925 = OpFunctionParameter %uint
-%926 = OpLabel
-%933 = OpVariable %_ptr_Function_ulong Function
-%934 = OpVariable %_ptr_Function_uint Function
-%935 = OpVariable %_ptr_Function_ulong Function
-%936 = OpVariable %_ptr_Function_bool Function
-%937 = OpVariable %_ptr_Function_ulong Function
-%938 = OpVariable %_ptr_Function_ulong Function
-%939 = OpVariable %_ptr_Function_ulong Function
-%940 = OpVariable %_ptr_Function_ulong Function
-%941 = OpVariable %_ptr_Function_ulong Function
-%942 = OpVariable %_ptr_Function_ulong Function
-%943 = OpVariable %_ptr_Function_ulong Function
-%944 = OpVariable %_ptr_Function_ulong Function
-OpStore %933 %924
-OpStore %934 %925
-%945 = OpLoad %uint %934
-%946 = OpUConvert %ulong %945
-OpStore %935 %946
-OpBranch %927
-%927 = OpLabel
-%947 = OpLoad %ulong %933
-OpStore %943 %947
-OpStore %944 %ulong_0
-OpBranch %928
-%928 = OpLabel
-%948 = OpLoad %ulong %944
-%949 = OpULessThan %bool %948 %ulong_8
-OpStore %936 %949
-%950 = OpLoad %bool %936
-OpLoopMerge %930 %932 None
-OpBranchConditional %950 %929 %930
-%930 = OpLabel
-OpBranch %931
-%931 = OpLabel
-%951 = OpLoad %ulong %943
-OpReturnValue %951
-%929 = OpLabel
-%952 = OpLoad %ulong %944
-%953 = OpIMul %ulong %952 %ulong_8
-OpStore %937 %953
-%954 = OpLoad %ulong %935
-%955 = OpLoad %ulong %937
-%956 = OpShiftRightLogical %ulong %954 %955
-OpStore %938 %956
-%957 = OpLoad %ulong %938
-%958 = OpBitwiseAnd %ulong %957 %ulong_255
-OpStore %939 %958
-%959 = OpLoad %ulong %943
-%960 = OpLoad %ulong %939
-%961 = OpBitwiseXor %ulong %959 %960
-OpStore %940 %961
-%962 = OpLoad %ulong %940
-%963 = OpIMul %ulong %962 %ulong_1099511628211
-OpStore %941 %963
-%964 = OpLoad %ulong %944
-%965 = OpIAdd %ulong %964 %ulong_1
-OpStore %942 %965
-%966 = OpLoad %ulong %941
-OpStore %943 %966
-%967 = OpLoad %ulong %942
-OpStore %944 %967
-OpBranch %932
-%932 = OpLabel
-OpBranch %928
+%2 = OpFunction %ulong None %1407
+%1408 = OpFunctionParameter %ulong
+%1409 = OpFunctionParameter %ulong
+%1410 = OpLabel
+%1415 = OpVariable %_ptr_Function_ulong Function
+%1416 = OpVariable %_ptr_Function_ulong Function
+%1417 = OpVariable %_ptr_Function_bool Function
+%1418 = OpVariable %_ptr_Function_ulong Function
+%1419 = OpVariable %_ptr_Function_ulong Function
+%1420 = OpVariable %_ptr_Function_ulong Function
+%1421 = OpVariable %_ptr_Function_ulong Function
+%1422 = OpVariable %_ptr_Function_ulong Function
+%1423 = OpVariable %_ptr_Function_ulong Function
+%1424 = OpVariable %_ptr_Function_ulong Function
+%1425 = OpVariable %_ptr_Function_ulong Function
+OpStore %1415 %1408
+OpStore %1416 %1409
+%1426 = OpLoad %ulong %1415
+OpStore %1424 %1426
+OpStore %1425 %ulong_0
+OpBranch %1411
+%1411 = OpLabel
+%1427 = OpLoad %ulong %1425
+%1428 = OpULessThan %bool %1427 %ulong_8
+OpStore %1417 %1428
+%1429 = OpLoad %bool %1417
+OpLoopMerge %1413 %1414 None
+OpBranchConditional %1429 %1412 %1413
+%1413 = OpLabel
+%1430 = OpLoad %ulong %1424
+OpReturnValue %1430
+%1412 = OpLabel
+%1431 = OpLoad %ulong %1425
+%1432 = OpIMul %ulong %1431 %ulong_8
+OpStore %1418 %1432
+%1433 = OpLoad %ulong %1416
+%1434 = OpLoad %ulong %1418
+%1435 = OpShiftRightLogical %ulong %1433 %1434
+OpStore %1419 %1435
+%1436 = OpLoad %ulong %1419
+%1437 = OpBitwiseAnd %ulong %1436 %ulong_255
+OpStore %1420 %1437
+%1438 = OpLoad %ulong %1424
+%1439 = OpLoad %ulong %1420
+%1440 = OpBitwiseXor %ulong %1438 %1439
+OpStore %1421 %1440
+%1441 = OpLoad %ulong %1421
+%1442 = OpIMul %ulong %1441 %ulong_1099511628211
+OpStore %1422 %1442
+%1443 = OpLoad %ulong %1425
+%1444 = OpIAdd %ulong %1443 %ulong_1
+OpStore %1423 %1444
+%1445 = OpLoad %ulong %1422
+OpStore %1424 %1445
+%1446 = OpLoad %ulong %1423
+OpStore %1425 %1446
+OpBranch %1414
+%1414 = OpLabel
+OpBranch %1411
 OpFunctionEnd

--- a/test/golden/spirv/mem/array_index.dis
+++ b/test/golden/spirv/mem/array_index.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1030
+; Bound: 1463
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,24 +14,27 @@ OpDecorate %2 LinkageAttributes "corpus.cases.mem.array_index.checksum" Export
 %ulong = OpTypeInt 64 0
 %ushort = OpTypeInt 16 0
 %uchar = OpTypeInt 8 0
-%_struct_11 = OpTypeStruct %ushort %uchar %ulong
-%12 = OpTypeFunction %ulong %ulong %_struct_11
-%_ptr_Function__struct_11 = OpTypePointer Function %_struct_11
+%_struct_7 = OpTypeStruct %ushort %uchar %ulong
+%8 = OpTypeFunction %ulong %ulong %_struct_7
+%bool = OpTypeBool
+%_ptr_Function__struct_7 = OpTypePointer Function %_struct_7
 %_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %uint = OpTypeInt 32 0
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
-%48 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%154 = OpTypeFunction %ulong %ulong
 %uint_7 = OpConstant %uint 7
 %_arr_uint_uint_7 = OpTypeArray %uint %uint_7
 %_ptr_Function__arr_uint_uint_7 = OpTypePointer Function %_arr_uint_uint_7
-%uint_32 = OpConstant %uint 32
-%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
-%_ptr_Function__arr_uint_uint_32 = OpTypePointer Function %_arr_uint_uint_32
 %uint_6 = OpConstant %uint 6
 %_arr_ushort_uint_6 = OpTypeArray %ushort %uint_6
 %uint_4 = OpConstant %uint 4
@@ -42,1442 +45,2133 @@ OpDecorate %2 LinkageAttributes "corpus.cases.mem.array_index.checksum" Export
 %_arr__arr_uchar_uint_3_uint_3 = OpTypeArray %_arr_uchar_uint_3 %uint_3
 %_arr__arr__arr_uchar_uint_3_uint_3_uint_3 = OpTypeArray %_arr__arr_uchar_uint_3_uint_3 %uint_3
 %_ptr_Function__arr__arr__arr_uchar_uint_3_uint_3_uint_3 = OpTypePointer Function %_arr__arr__arr_uchar_uint_3_uint_3_uint_3
+%uint_32 = OpConstant %uint 32
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
+%_ptr_Function__arr_uint_uint_32 = OpTypePointer Function %_arr_uint_uint_32
 %uint_5 = OpConstant %uint 5
-%_arr__struct_11_uint_5 = OpTypeArray %_struct_11 %uint_5
-%_ptr_Function__arr__struct_11_uint_5 = OpTypePointer Function %_arr__struct_11_uint_5
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_arr__struct_7_uint_5 = OpTypeArray %_struct_7 %uint_5
+%_ptr_Function__arr__struct_7_uint_5 = OpTypePointer Function %_arr__struct_7_uint_5
 %_ptr_Function_uint = OpTypePointer Function %uint
-%353 = OpConstantNull %_arr_uint_uint_32
-%ulong_0 = OpConstant %ulong 0
+%692 = OpConstantNull %_arr_uint_uint_32
 %ulong_32 = OpConstant %ulong 32
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_15 = OpConstant %uint 15
 %uint_31 = OpConstant %uint 31
-%393 = OpConstantNull %_arr__arr_ushort_uint_6_uint_4
+%740 = OpConstantNull %_arr__arr_ushort_uint_6_uint_4
 %ulong_4 = OpConstant %ulong 4
 %_ptr_Function__arr_ushort_uint_6 = OpTypePointer Function %_arr_ushort_uint_6
 %ulong_2 = OpConstant %ulong 2
 %ulong_3 = OpConstant %ulong 3
 %ulong_6 = OpConstant %ulong 6
-%438 = OpConstantNull %_arr__arr__arr_uchar_uint_3_uint_3_uint_3
+%792 = OpConstantNull %_arr__arr__arr_uchar_uint_3_uint_3_uint_3
 %_ptr_Function__arr__arr_uchar_uint_3_uint_3 = OpTypePointer Function %_arr__arr_uchar_uint_3_uint_3
 %_ptr_Function__arr_uchar_uint_3 = OpTypePointer Function %_arr_uchar_uint_3
-%ulong_1 = OpConstant %ulong 1
-%479 = OpConstantNull %_arr__struct_11_uint_5
+%837 = OpConstantNull %_arr__struct_7_uint_5
 %ulong_5 = OpConstant %ulong 5
 %ulong_16 = OpConstant %ulong 16
-%531 = OpConstantNull %_arr_uint_uint_7
+%881 = OpConstantNull %_arr_uint_uint_7
 %ulong_7 = OpConstant %ulong 7
-%uchar_17 = OpConstant %uchar 17
-%ushort_4660 = OpConstant %ushort 4660
 %uint_4042322160 = OpConstant %uint 4042322160
+%ulong_17 = OpConstant %ulong 17
+%ulong_4660 = OpConstant %ulong 4660
 %uint_305419896 = OpConstant %uint 305419896
 %ulong_200 = OpConstant %ulong 200
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_9 = OpConstant %ulong 9
 %ulong_100 = OpConstant %ulong 100
 %ulong_31 = OpConstant %ulong 31
 %ulong_2654435761 = OpConstant %ulong 2654435761
-%850 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%853 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%895 = OpTypeFunction %ulong %ulong %uchar
-%940 = OpTypeFunction %ulong %ulong %ushort
-%985 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %12
-%13 = OpFunctionParameter %ulong
-%14 = OpFunctionParameter %_struct_11
+%1423 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %_struct_7
+%11 = OpLabel
+%36 = OpVariable %_ptr_Function__struct_7 Function
+%38 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_bool Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_bool Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_bool Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ushort Function
+%72 = OpVariable %_ptr_Function_uchar Function
+%73 = OpVariable %_ptr_Function_ulong Function
+OpStore %38 %9
+OpStore %36 %10
+%76 = OpAccessChain %_ptr_Function_ushort %36 %uint_0
+%77 = OpLoad %ushort %76
+OpStore %70 %77
+%79 = OpAccessChain %_ptr_Function_uchar %36 %uint_1
+%80 = OpLoad %uchar %79
+OpStore %72 %80
+%82 = OpAccessChain %_ptr_Function_ulong %36 %uint_2
+%83 = OpLoad %ulong %82
+OpStore %73 %83
+OpBranch %12
+%12 = OpLabel
+%84 = OpLoad %ushort %70
+%85 = OpUConvert %ulong %84
+OpStore %39 %85
+OpBranch %14
+%14 = OpLabel
+%86 = OpLoad %ulong %38
+OpStore %48 %86
+OpStore %49 %ulong_0
+OpBranch %15
 %15 = OpLabel
-%17 = OpVariable %_ptr_Function__struct_11 Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ushort Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%27 = OpVariable %_ptr_Function_ulong Function
-OpStore %19 %13
-OpStore %17 %14
-%30 = OpAccessChain %_ptr_Function_ushort %17 %uint_0
-%31 = OpLoad %ushort %30
-OpStore %24 %31
-%33 = OpAccessChain %_ptr_Function_uchar %17 %uint_1
-%34 = OpLoad %uchar %33
-OpStore %26 %34
-%36 = OpAccessChain %_ptr_Function_ulong %17 %uint_2
-%37 = OpLoad %ulong %36
-OpStore %27 %37
-%38 = OpLoad %ulong %19
-%39 = OpLoad %ushort %24
-%40 = OpFunctionCall %ulong %6 %38 %39
-OpStore %20 %40
-%41 = OpLoad %ulong %20
-%42 = OpLoad %uchar %26
-%43 = OpFunctionCall %ulong %5 %41 %42
-OpStore %21 %43
-%44 = OpLoad %ulong %21
-%45 = OpLoad %ulong %27
-%46 = OpFunctionCall %ulong %4 %44 %45
-OpStore %22 %46
-%47 = OpLoad %ulong %22
-OpReturnValue %47
+%88 = OpLoad %ulong %49
+%90 = OpULessThan %bool %88 %ulong_8
+OpStore %41 %90
+%91 = OpLoad %bool %41
+OpLoopMerge %17 %33 None
+OpBranchConditional %91 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%92 = OpLoad %uchar %72
+%93 = OpUConvert %ulong %92
+OpStore %50 %93
+OpBranch %21
+%21 = OpLabel
+%94 = OpLoad %ulong %48
+OpStore %58 %94
+OpStore %59 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%95 = OpLoad %ulong %59
+%96 = OpULessThan %bool %95 %ulong_8
+OpStore %51 %96
+%97 = OpLoad %bool %51
+OpLoopMerge %24 %32 None
+OpBranchConditional %97 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%98 = OpLoad %ulong %58
+OpStore %67 %98
+OpStore %68 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%99 = OpLoad %ulong %68
+%100 = OpULessThan %bool %99 %ulong_8
+OpStore %60 %100
+%101 = OpLoad %bool %60
+OpLoopMerge %29 %31 None
+OpBranchConditional %101 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%102 = OpLoad %ulong %67
+OpReturnValue %102
+%28 = OpLabel
+%103 = OpLoad %ulong %68
+%104 = OpIMul %ulong %103 %ulong_8
+OpStore %61 %104
+%105 = OpLoad %ulong %73
+%106 = OpLoad %ulong %61
+%107 = OpShiftRightLogical %ulong %105 %106
+OpStore %62 %107
+%108 = OpLoad %ulong %62
+%110 = OpBitwiseAnd %ulong %108 %ulong_255
+OpStore %63 %110
+%111 = OpLoad %ulong %67
+%112 = OpLoad %ulong %63
+%113 = OpBitwiseXor %ulong %111 %112
+OpStore %64 %113
+%114 = OpLoad %ulong %64
+%116 = OpIMul %ulong %114 %ulong_1099511628211
+OpStore %65 %116
+%117 = OpLoad %ulong %68
+%119 = OpIAdd %ulong %117 %ulong_1
+OpStore %66 %119
+%120 = OpLoad %ulong %65
+OpStore %67 %120
+%121 = OpLoad %ulong %66
+OpStore %68 %121
+OpBranch %31
+%23 = OpLabel
+%122 = OpLoad %ulong %59
+%123 = OpIMul %ulong %122 %ulong_8
+OpStore %52 %123
+%124 = OpLoad %ulong %50
+%125 = OpLoad %ulong %52
+%126 = OpShiftRightLogical %ulong %124 %125
+OpStore %53 %126
+%127 = OpLoad %ulong %53
+%128 = OpBitwiseAnd %ulong %127 %ulong_255
+OpStore %54 %128
+%129 = OpLoad %ulong %58
+%130 = OpLoad %ulong %54
+%131 = OpBitwiseXor %ulong %129 %130
+OpStore %55 %131
+%132 = OpLoad %ulong %55
+%133 = OpIMul %ulong %132 %ulong_1099511628211
+OpStore %56 %133
+%134 = OpLoad %ulong %59
+%135 = OpIAdd %ulong %134 %ulong_1
+OpStore %57 %135
+%136 = OpLoad %ulong %56
+OpStore %58 %136
+%137 = OpLoad %ulong %57
+OpStore %59 %137
+OpBranch %32
+%16 = OpLabel
+%138 = OpLoad %ulong %49
+%139 = OpIMul %ulong %138 %ulong_8
+OpStore %42 %139
+%140 = OpLoad %ulong %39
+%141 = OpLoad %ulong %42
+%142 = OpShiftRightLogical %ulong %140 %141
+OpStore %43 %142
+%143 = OpLoad %ulong %43
+%144 = OpBitwiseAnd %ulong %143 %ulong_255
+OpStore %44 %144
+%145 = OpLoad %ulong %48
+%146 = OpLoad %ulong %44
+%147 = OpBitwiseXor %ulong %145 %146
+OpStore %45 %147
+%148 = OpLoad %ulong %45
+%149 = OpIMul %ulong %148 %ulong_1099511628211
+OpStore %46 %149
+%150 = OpLoad %ulong %49
+%151 = OpIAdd %ulong %150 %ulong_1
+OpStore %47 %151
+%152 = OpLoad %ulong %46
+OpStore %48 %152
+%153 = OpLoad %ulong %47
+OpStore %49 %153
+OpBranch %33
+%31 = OpLabel
+OpBranch %27
+%32 = OpLabel
+OpBranch %22
+%33 = OpLabel
+OpBranch %15
 OpFunctionEnd
-%2 = OpFunction %ulong None %48
-%49 = OpFunctionParameter %ulong
-%50 = OpLabel
-%139 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
-%143 = OpVariable %_ptr_Function__arr_uint_uint_32 Function
-%149 = OpVariable %_ptr_Function__arr__arr_ushort_uint_6_uint_4 Function
-%155 = OpVariable %_ptr_Function__arr__arr__arr_uchar_uint_3_uint_3_uint_3 Function
-%159 = OpVariable %_ptr_Function__arr__struct_11_uint_5 Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_bool Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_uint Function
-%169 = OpVariable %_ptr_Function_uint Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_uint Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_uint Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_uint Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_bool Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_uint Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_bool Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_uint Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_bool Function
-%189 = OpVariable %_ptr_Function_uint Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_bool Function
-%193 = OpVariable %_ptr_Function_bool Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ushort Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ushort Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ushort Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ushort Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_bool Function
-%212 = OpVariable %_ptr_Function_bool Function
-%213 = OpVariable %_ptr_Function_ushort Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_bool Function
-%218 = OpVariable %_ptr_Function_bool Function
-%219 = OpVariable %_ptr_Function_ushort Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_bool Function
-%224 = OpVariable %_ptr_Function_bool Function
-%225 = OpVariable %_ptr_Function_bool Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_uchar Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_bool Function
-%236 = OpVariable %_ptr_Function_bool Function
-%237 = OpVariable %_ptr_Function_bool Function
-%238 = OpVariable %_ptr_Function_uchar Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_uchar Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_uchar Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_bool Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ushort Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_uchar Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_bool Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ushort Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_bool Function
-%274 = OpVariable %_ptr_Function_uint Function
-%275 = OpVariable %_ptr_Function_uint Function
-%276 = OpVariable %_ptr_Function_uint Function
-%277 = OpVariable %_ptr_Function_uint Function
-%278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_bool Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_uint Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_uint Function
-%290 = OpVariable %_ptr_Function_uint Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_ulong Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_ulong Function
-%304 = OpVariable %_ptr_Function_ulong Function
-%305 = OpVariable %_ptr_Function_ulong Function
-%306 = OpVariable %_ptr_Function_ulong Function
-%307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_ulong Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_ulong Function
-%312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_ulong Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_ulong Function
-%316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_ulong Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_ulong Function
-%326 = OpVariable %_ptr_Function_ulong Function
-%327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_ulong Function
-%329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_ulong Function
-%331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_ushort Function
-%334 = OpVariable %_ptr_Function_uchar Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ushort Function
-%337 = OpVariable %_ptr_Function_uchar Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_uint Function
-%340 = OpVariable %_ptr_Function_uint Function
-%341 = OpVariable %_ptr_Function_uint Function
-%342 = OpVariable %_ptr_Function_uint Function
-%343 = OpVariable %_ptr_Function_uint Function
-%344 = OpVariable %_ptr_Function_uint Function
-%345 = OpVariable %_ptr_Function_uint Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_ulong Function
-OpStore %160 %49
-%352 = OpFunctionCall %ulong %3
-OpStore %161 %352
-OpStore %143 %353
-OpStore %310 %ulong_0
-OpBranch %51
-%51 = OpLabel
-%355 = OpLoad %ulong %310
-%357 = OpULessThan %bool %355 %ulong_32
-OpStore %163 %357
-%358 = OpLoad %bool %163
-OpLoopMerge %53 %134 None
-OpBranchConditional %358 %52 %53
-%53 = OpLabel
-%359 = OpAccessChain %_ptr_Function_uint %143 %uint_0
-%360 = OpLoad %uint %359
-OpStore %169 %360
-%361 = OpLoad %ulong %161
-%362 = OpLoad %uint %169
-%363 = OpFunctionCall %ulong %7 %361 %362
-OpStore %170 %363
-%364 = OpAccessChain %_ptr_Function_uint %143 %uint_1
-%365 = OpLoad %uint %364
-OpStore %171 %365
-%366 = OpLoad %ulong %170
-%367 = OpLoad %uint %171
-%368 = OpFunctionCall %ulong %7 %366 %367
-OpStore %172 %368
-%370 = OpAccessChain %_ptr_Function_uint %143 %uint_15
-%371 = OpLoad %uint %370
-OpStore %173 %371
-%372 = OpLoad %ulong %172
-%373 = OpLoad %uint %173
-%374 = OpFunctionCall %ulong %7 %372 %373
-OpStore %174 %374
-%376 = OpAccessChain %_ptr_Function_uint %143 %uint_31
-%377 = OpLoad %uint %376
-OpStore %175 %377
-%378 = OpLoad %ulong %174
-%379 = OpLoad %uint %175
-%380 = OpFunctionCall %ulong %7 %378 %379
-OpStore %176 %380
-%381 = OpLoad %ulong %176
-OpStore %306 %381
-OpStore %309 %ulong_0
-OpBranch %54
-%54 = OpLabel
-%382 = OpLoad %ulong %309
-%383 = OpULessThan %bool %382 %ulong_32
-OpStore %177 %383
-%384 = OpLoad %bool %177
-OpLoopMerge %56 %133 None
-OpBranchConditional %384 %55 %56
-%56 = OpLabel
-%385 = OpLoad %ulong %306
-OpStore %305 %385
-OpStore %308 %ulong_32
-OpBranch %57
-%57 = OpLabel
-%386 = OpLoad %ulong %308
-%387 = OpULessThan %bool %ulong_0 %386
-OpStore %184 %387
-%388 = OpLoad %bool %184
-OpLoopMerge %59 %132 None
-OpBranchConditional %388 %58 %59
-%59 = OpLabel
-%389 = OpLoad %ulong %305
-OpStore %304 %389
-OpStore %307 %ulong_0
-OpBranch %60
-%60 = OpLabel
-%390 = OpLoad %ulong %307
-%391 = OpULessThan %bool %390 %ulong_32
-OpStore %188 %391
-%392 = OpLoad %bool %188
-OpLoopMerge %62 %131 None
-OpBranchConditional %392 %61 %62
-%62 = OpLabel
-OpStore %149 %393
-OpStore %313 %ulong_0
-OpBranch %63
-%63 = OpLabel
-%394 = OpLoad %ulong %313
-%396 = OpULessThan %bool %394 %ulong_4
-OpStore %192 %396
-%397 = OpLoad %bool %192
-OpLoopMerge %65 %130 None
-OpBranchConditional %397 %64 %65
-%65 = OpLabel
-%399 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %uint_0
-%400 = OpAccessChain %_ptr_Function_ushort %399 %uint_0
-%401 = OpLoad %ushort %400
-OpStore %201 %401
-%402 = OpLoad %ulong %304
-%403 = OpLoad %ushort %201
-%404 = OpFunctionCall %ulong %6 %402 %403
-OpStore %202 %404
-%405 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %uint_3
-%406 = OpAccessChain %_ptr_Function_ushort %405 %uint_5
-%407 = OpLoad %ushort %406
-OpStore %203 %407
-%408 = OpLoad %ulong %202
-%409 = OpLoad %ushort %203
-%410 = OpFunctionCall %ulong %6 %408 %409
-OpStore %204 %410
-%411 = OpLoad %ulong %160
-%413 = OpIAdd %ulong %411 %ulong_2
-OpStore %205 %413
-%414 = OpLoad %ulong %205
-%416 = OpBitwiseAnd %ulong %414 %ulong_3
-OpStore %206 %416
-%417 = OpLoad %ulong %206
-%418 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %417
-%419 = OpLoad %ulong %160
-%420 = OpIAdd %ulong %419 %ulong_4
-OpStore %207 %420
-%421 = OpLoad %ulong %207
-%422 = OpBitwiseAnd %ulong %421 %ulong_3
-OpStore %208 %422
-%423 = OpLoad %ulong %208
-%424 = OpAccessChain %_ptr_Function_ushort %418 %423
-%425 = OpLoad %ushort %424
-OpStore %209 %425
-%426 = OpLoad %ulong %204
-%427 = OpLoad %ushort %209
-%428 = OpFunctionCall %ulong %6 %426 %427
-OpStore %210 %428
-%429 = OpLoad %ulong %210
-OpStore %303 %429
-OpStore %312 %ulong_0
-OpBranch %69
-%69 = OpLabel
-%430 = OpLoad %ulong %312
-%431 = OpULessThan %bool %430 %ulong_4
-OpStore %211 %431
-%432 = OpLoad %bool %211
-OpLoopMerge %71 %129 None
-OpBranchConditional %432 %70 %71
-%71 = OpLabel
-%433 = OpLoad %ulong %303
-OpStore %301 %433
-OpStore %316 %ulong_0
-OpBranch %75
-%75 = OpLabel
-%434 = OpLoad %ulong %316
-%436 = OpULessThan %bool %434 %ulong_6
-OpStore %217 %436
-%437 = OpLoad %bool %217
-OpLoopMerge %77 %127 None
-OpBranchConditional %437 %76 %77
-%77 = OpLabel
-OpStore %155 %438
-OpStore %318 %ulong_0
-OpBranch %81
-%81 = OpLabel
-%439 = OpLoad %ulong %318
-%440 = OpULessThan %bool %439 %ulong_3
-OpStore %223 %440
-%441 = OpLoad %bool %223
-OpLoopMerge %83 %125 None
-OpBranchConditional %441 %82 %83
-%83 = OpLabel
-%442 = OpLoad %ulong %301
-OpStore %299 %442
-OpStore %317 %ulong_0
-OpBranch %90
-%90 = OpLabel
-%443 = OpLoad %ulong %317
-%444 = OpULessThan %bool %443 %ulong_3
-OpStore %235 %444
-%445 = OpLoad %bool %235
-OpLoopMerge %92 %123 None
-OpBranchConditional %445 %91 %92
-%92 = OpLabel
-%447 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %155 %uint_2
-%449 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %447 %uint_0
-%450 = OpAccessChain %_ptr_Function_uchar %449 %uint_1
-%451 = OpLoad %uchar %450
-OpStore %243 %451
-%452 = OpLoad %ulong %299
-%453 = OpLoad %uchar %243
-%454 = OpFunctionCall %ulong %5 %452 %453
-OpStore %244 %454
-%455 = OpLoad %ulong %160
-%457 = OpIAdd %ulong %455 %ulong_1
-OpStore %245 %457
-OpStore %346 %ulong_3
-%458 = OpLoad %ulong %245
-%459 = OpLoad %ulong %346
-%460 = OpUMod %ulong %458 %459
-OpStore %246 %460
-%461 = OpLoad %ulong %246
-%462 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %155 %461
-%463 = OpLoad %ulong %160
-%464 = OpIAdd %ulong %463 %ulong_2
-OpStore %247 %464
-OpStore %347 %ulong_3
-%465 = OpLoad %ulong %247
-%466 = OpLoad %ulong %347
-%467 = OpUMod %ulong %465 %466
-OpStore %248 %467
-%468 = OpLoad %ulong %248
-%469 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %462 %468
-OpStore %348 %ulong_3
-%470 = OpLoad %ulong %160
-%471 = OpLoad %ulong %348
-%472 = OpUMod %ulong %470 %471
-OpStore %249 %472
-%473 = OpLoad %ulong %249
-%474 = OpAccessChain %_ptr_Function_uchar %469 %473
-%475 = OpLoad %uchar %474
-OpStore %250 %475
-%476 = OpLoad %ulong %244
-%477 = OpLoad %uchar %250
-%478 = OpFunctionCall %ulong %5 %476 %477
-OpStore %251 %478
-OpStore %159 %479
-OpStore %326 %ulong_0
-OpBranch %99
-%99 = OpLabel
-%480 = OpLoad %ulong %326
-%482 = OpULessThan %bool %480 %ulong_5
-OpStore %252 %482
-%483 = OpLoad %bool %252
-OpLoopMerge %101 %121 None
-OpBranchConditional %483 %100 %101
-%101 = OpLabel
-%484 = OpLoad %ulong %251
-OpStore %296 %484
-OpStore %325 %ulong_0
-OpBranch %102
-%102 = OpLabel
-%485 = OpLoad %ulong %325
-%486 = OpULessThan %bool %485 %ulong_5
-OpStore %262 %486
-%487 = OpLoad %bool %262
-OpLoopMerge %104 %118 None
-OpBranchConditional %487 %103 %104
-%104 = OpLabel
-%488 = OpLoad %ulong %160
-%489 = OpIAdd %ulong %488 %ulong_3
-OpStore %264 %489
-OpStore %349 %ulong_5
-%490 = OpLoad %ulong %264
-%491 = OpLoad %ulong %349
-%492 = OpUMod %ulong %490 %491
-OpStore %265 %492
-%493 = OpLoad %ulong %265
-%494 = OpAccessChain %_ptr_Function__struct_11 %159 %493
-%495 = OpAccessChain %_ptr_Function_ushort %494 %uint_0
-%496 = OpLoad %ushort %495
-OpStore %336 %496
-%497 = OpAccessChain %_ptr_Function_uchar %494 %uint_1
-%498 = OpLoad %uchar %497
-OpStore %337 %498
-%499 = OpAccessChain %_ptr_Function_ulong %494 %uint_2
-%500 = OpLoad %ulong %499
-OpStore %338 %500
-OpBranch %113
-%113 = OpLabel
-%501 = OpLoad %ulong %296
-%502 = OpLoad %ushort %336
-%503 = OpFunctionCall %ulong %6 %501 %502
-OpStore %330 %503
-%504 = OpLoad %ulong %330
-%505 = OpLoad %uchar %337
-%506 = OpFunctionCall %ulong %5 %504 %505
-OpStore %331 %506
-%507 = OpLoad %ulong %331
-%508 = OpLoad %ulong %338
-%509 = OpFunctionCall %ulong %4 %507 %508
-OpStore %332 %509
-OpBranch %114
-%114 = OpLabel
-%510 = OpAccessChain %_ptr_Function__struct_11 %159 %uint_4
-%511 = OpAccessChain %_ptr_Function_ulong %510 %uint_2
-%512 = OpLoad %ulong %511
-OpStore %266 %512
-%513 = OpLoad %ulong %332
-%514 = OpLoad %ulong %266
-%515 = OpFunctionCall %ulong %4 %513 %514
-OpStore %267 %515
-%516 = OpLoad %ulong %160
-%517 = OpIAdd %ulong %516 %ulong_1
-OpStore %268 %517
-OpStore %351 %ulong_5
-%518 = OpLoad %ulong %268
-%519 = OpLoad %ulong %351
-%520 = OpUMod %ulong %518 %519
-OpStore %269 %520
-%521 = OpLoad %ulong %269
-%522 = OpAccessChain %_ptr_Function__struct_11 %159 %521
-%523 = OpAccessChain %_ptr_Function_ushort %522 %uint_0
-%524 = OpLoad %ushort %523
-OpStore %270 %524
-%525 = OpLoad %ulong %267
-%526 = OpLoad %ushort %270
-%527 = OpFunctionCall %ulong %6 %525 %526
-OpStore %271 %527
-%528 = OpLoad %ulong %271
-%530 = OpFunctionCall %ulong %4 %528 %ulong_16
-OpStore %272 %530
-OpStore %139 %531
-%532 = OpLoad %ulong %160
-%533 = OpUConvert %uint %532
-OpStore %276 %533
-OpStore %324 %ulong_0
-OpBranch %105
-%105 = OpLabel
-%534 = OpLoad %ulong %324
-%536 = OpULessThan %bool %534 %ulong_7
-OpStore %273 %536
-%537 = OpLoad %bool %273
-OpLoopMerge %107 %116 None
-OpBranchConditional %537 %106 %107
-%107 = OpLabel
-%538 = OpLoad %ulong %272
-%540 = OpFunctionCall %ulong %5 %538 %uchar_17
-OpStore %279 %540
-%541 = OpLoad %ulong %279
-OpStore %295 %541
-OpStore %323 %ulong_0
-OpBranch %108
-%108 = OpLabel
-%542 = OpLoad %ulong %323
-%543 = OpULessThan %bool %542 %ulong_7
-OpStore %280 %543
-%544 = OpLoad %bool %280
-OpLoopMerge %110 %115 None
-OpBranchConditional %544 %109 %110
-%110 = OpLabel
-%545 = OpLoad %ulong %295
-%547 = OpFunctionCall %ulong %6 %545 %ushort_4660
-OpStore %287 %547
-%548 = OpLoad %ulong %287
-%549 = OpFunctionCall %ulong %4 %548 %ulong_4
-OpStore %288 %549
-%550 = OpAccessChain %_ptr_Function_uint %139 %uint_0
-%551 = OpLoad %uint %550
-OpStore %339 %551
-%552 = OpAccessChain %_ptr_Function_uint %139 %uint_1
-%553 = OpLoad %uint %552
-OpStore %340 %553
-%554 = OpAccessChain %_ptr_Function_uint %139 %uint_2
-%555 = OpLoad %uint %554
-OpStore %341 %555
-%556 = OpAccessChain %_ptr_Function_uint %139 %uint_3
-%557 = OpLoad %uint %556
-OpStore %342 %557
-%558 = OpAccessChain %_ptr_Function_uint %139 %uint_4
-%559 = OpLoad %uint %558
-OpStore %343 %559
-%560 = OpAccessChain %_ptr_Function_uint %139 %uint_5
-%561 = OpLoad %uint %560
-OpStore %344 %561
-%562 = OpAccessChain %_ptr_Function_uint %139 %uint_6
-%563 = OpLoad %uint %562
-OpStore %345 %563
-%564 = OpLoad %uint %342
-%566 = OpBitwiseXor %uint %564 %uint_4042322160
-OpStore %289 %566
-%567 = OpLoad %uint %556
-OpStore %290 %567
-%568 = OpLoad %ulong %288
-%569 = OpLoad %uint %290
-%570 = OpFunctionCall %ulong %7 %568 %569
-OpStore %291 %570
-%571 = OpLoad %ulong %291
-%572 = OpLoad %uint %289
-%573 = OpFunctionCall %ulong %7 %571 %572
-OpStore %292 %573
-%574 = OpLoad %ulong %292
-%575 = OpFunctionCall %ulong %5 %574 %uchar_17
-OpStore %293 %575
-%576 = OpLoad %ulong %293
-%577 = OpFunctionCall %ulong %6 %576 %ushort_4660
-OpStore %294 %577
-%578 = OpLoad %ulong %294
-OpReturnValue %578
-%109 = OpLabel
-%579 = OpLoad %ulong %323
-%580 = OpIMul %ulong %579 %ulong_3
-OpStore %281 %580
-%581 = OpLoad %ulong %281
-%582 = OpLoad %ulong %160
-%583 = OpIAdd %ulong %581 %582
-OpStore %282 %583
-OpStore %350 %ulong_7
-%584 = OpLoad %ulong %282
-%585 = OpLoad %ulong %350
-%586 = OpUMod %ulong %584 %585
-OpStore %283 %586
-%587 = OpLoad %ulong %283
-%588 = OpAccessChain %_ptr_Function_uint %139 %587
-%589 = OpLoad %uint %588
-OpStore %284 %589
-%590 = OpLoad %ulong %295
-%591 = OpLoad %uint %284
-%592 = OpFunctionCall %ulong %7 %590 %591
-OpStore %285 %592
-%593 = OpLoad %ulong %323
-%594 = OpIAdd %ulong %593 %ulong_1
-OpStore %286 %594
-%595 = OpLoad %ulong %285
-OpStore %295 %595
-%596 = OpLoad %ulong %286
-OpStore %323 %596
-OpBranch %115
-%106 = OpLabel
-%597 = OpLoad %ulong %324
-%598 = OpUConvert %uint %597
-OpStore %274 %598
-%599 = OpLoad %uint %274
-%601 = OpIMul %uint %599 %uint_305419896
-OpStore %275 %601
-%602 = OpLoad %uint %275
-%603 = OpLoad %uint %276
-%604 = OpIAdd %uint %602 %603
-OpStore %277 %604
-%605 = OpLoad %ulong %324
-%606 = OpAccessChain %_ptr_Function_uint %139 %605
-%607 = OpLoad %uint %277
-OpStore %606 %607
-%608 = OpLoad %ulong %324
-%609 = OpIAdd %ulong %608 %ulong_1
-OpStore %278 %609
-%610 = OpLoad %ulong %278
-OpStore %324 %610
-OpBranch %116
-%103 = OpLabel
-%611 = OpLoad %ulong %325
-%612 = OpAccessChain %_ptr_Function__struct_11 %159 %611
-%613 = OpAccessChain %_ptr_Function_ushort %612 %uint_0
-%614 = OpLoad %ushort %613
-OpStore %333 %614
-%615 = OpAccessChain %_ptr_Function_uchar %612 %uint_1
-%616 = OpLoad %uchar %615
-OpStore %334 %616
-%617 = OpAccessChain %_ptr_Function_ulong %612 %uint_2
-%618 = OpLoad %ulong %617
-OpStore %335 %618
-OpBranch %111
-%111 = OpLabel
-%619 = OpLoad %ulong %296
-%620 = OpLoad %ushort %333
-%621 = OpFunctionCall %ulong %6 %619 %620
-OpStore %327 %621
-%622 = OpLoad %ulong %327
-%623 = OpLoad %uchar %334
-%624 = OpFunctionCall %ulong %5 %622 %623
-OpStore %328 %624
-%625 = OpLoad %ulong %328
-%626 = OpLoad %ulong %335
-%627 = OpFunctionCall %ulong %4 %625 %626
-OpStore %329 %627
-OpBranch %112
-%112 = OpLabel
-%628 = OpLoad %ulong %325
-%629 = OpIAdd %ulong %628 %ulong_1
-OpStore %263 %629
-%630 = OpLoad %ulong %329
-OpStore %296 %630
-%631 = OpLoad %ulong %263
-OpStore %325 %631
-OpBranch %118
-%100 = OpLabel
-%632 = OpLoad %ulong %326
-%633 = OpIMul %ulong %632 %ulong_3
-OpStore %253 %633
-%634 = OpLoad %ulong %253
-%635 = OpIAdd %ulong %634 %ulong_1
-OpStore %254 %635
-%636 = OpLoad %ulong %254
-%637 = OpLoad %ulong %160
-%638 = OpIAdd %ulong %636 %637
-OpStore %255 %638
-%639 = OpLoad %ulong %255
-%640 = OpUConvert %ushort %639
-OpStore %256 %640
-%641 = OpLoad %ulong %326
-%642 = OpAccessChain %_ptr_Function__struct_11 %159 %641
-%643 = OpAccessChain %_ptr_Function_ushort %642 %uint_0
-%644 = OpLoad %ushort %256
-OpStore %643 %644
-%645 = OpLoad %ulong %326
-%647 = OpIAdd %ulong %645 %ulong_200
-OpStore %257 %647
-%648 = OpLoad %ulong %257
-%649 = OpUConvert %uchar %648
-OpStore %258 %649
-%650 = OpAccessChain %_ptr_Function_uchar %642 %uint_1
-%651 = OpLoad %uchar %258
-OpStore %650 %651
-%652 = OpLoad %ulong %326
-%653 = OpIAdd %ulong %652 %ulong_1
-OpStore %259 %653
-%655 = OpLoad %ulong %259
-%656 = OpIMul %ulong %ulong_1099511628211 %655
-OpStore %260 %656
-%657 = OpLoad %ulong %260
-%658 = OpLoad %ulong %160
-%659 = OpIAdd %ulong %657 %658
-OpStore %261 %659
-%660 = OpAccessChain %_ptr_Function_ulong %642 %uint_2
-%661 = OpLoad %ulong %261
-OpStore %660 %661
-%662 = OpLoad %ulong %259
-OpStore %326 %662
-OpBranch %121
-%91 = OpLabel
-%663 = OpLoad %ulong %299
-OpStore %298 %663
-OpStore %321 %ulong_0
-OpBranch %93
-%93 = OpLabel
-%664 = OpLoad %ulong %321
-%665 = OpULessThan %bool %664 %ulong_3
-OpStore %236 %665
-%666 = OpLoad %bool %236
-OpLoopMerge %95 %120 None
-OpBranchConditional %666 %94 %95
-%95 = OpLabel
-%667 = OpLoad %ulong %317
-%668 = OpIAdd %ulong %667 %ulong_1
-OpStore %242 %668
-%669 = OpLoad %ulong %298
-OpStore %299 %669
-%670 = OpLoad %ulong %242
-OpStore %317 %670
-OpBranch %123
-%94 = OpLabel
-%671 = OpLoad %ulong %298
-OpStore %297 %671
-OpStore %322 %ulong_0
-OpBranch %96
-%96 = OpLabel
-%672 = OpLoad %ulong %322
-%673 = OpULessThan %bool %672 %ulong_3
-OpStore %237 %673
-%674 = OpLoad %bool %237
-OpLoopMerge %98 %117 None
-OpBranchConditional %674 %97 %98
-%98 = OpLabel
-%675 = OpLoad %ulong %321
-%676 = OpIAdd %ulong %675 %ulong_1
-OpStore %241 %676
-%677 = OpLoad %ulong %297
-OpStore %298 %677
-%678 = OpLoad %ulong %241
-OpStore %321 %678
-OpBranch %120
-%97 = OpLabel
-%679 = OpLoad %ulong %322
-%680 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %155 %679
-%681 = OpLoad %ulong %321
-%682 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %680 %681
-%683 = OpLoad %ulong %317
-%684 = OpAccessChain %_ptr_Function_uchar %682 %683
-%685 = OpLoad %uchar %684
-OpStore %238 %685
-%686 = OpLoad %ulong %297
-%687 = OpLoad %uchar %238
-%688 = OpFunctionCall %ulong %5 %686 %687
-OpStore %239 %688
-%689 = OpLoad %ulong %322
-%690 = OpIAdd %ulong %689 %ulong_1
-OpStore %240 %690
-%691 = OpLoad %ulong %239
-OpStore %297 %691
-%692 = OpLoad %ulong %240
-OpStore %322 %692
-OpBranch %117
-%82 = OpLabel
-%693 = OpLoad %ulong %318
-%695 = OpIMul %ulong %693 %ulong_9
-OpStore %226 %695
-%696 = OpLoad %ulong %318
-%697 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %155 %696
-OpStore %319 %ulong_0
-OpBranch %84
-%84 = OpLabel
-%698 = OpLoad %ulong %319
-%699 = OpULessThan %bool %698 %ulong_3
-OpStore %224 %699
-%700 = OpLoad %bool %224
-OpLoopMerge %86 %122 None
-OpBranchConditional %700 %85 %86
-%86 = OpLabel
-%701 = OpLoad %ulong %318
-%702 = OpIAdd %ulong %701 %ulong_1
-OpStore %234 %702
-%703 = OpLoad %ulong %234
-OpStore %318 %703
-OpBranch %125
-%85 = OpLabel
-%704 = OpLoad %ulong %319
-%705 = OpIMul %ulong %704 %ulong_3
-OpStore %227 %705
-%706 = OpLoad %ulong %226
-%707 = OpLoad %ulong %227
-%708 = OpIAdd %ulong %706 %707
-OpStore %228 %708
-%709 = OpLoad %ulong %319
-%710 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %697 %709
-OpStore %320 %ulong_0
-OpBranch %87
-%87 = OpLabel
-%711 = OpLoad %ulong %320
-%712 = OpULessThan %bool %711 %ulong_3
-OpStore %225 %712
-%713 = OpLoad %bool %225
-OpLoopMerge %89 %119 None
-OpBranchConditional %713 %88 %89
-%89 = OpLabel
-%714 = OpLoad %ulong %319
-%715 = OpIAdd %ulong %714 %ulong_1
-OpStore %233 %715
-%716 = OpLoad %ulong %233
-OpStore %319 %716
-OpBranch %122
-%88 = OpLabel
-%717 = OpLoad %ulong %228
-%718 = OpLoad %ulong %320
-%719 = OpIAdd %ulong %717 %718
-OpStore %229 %719
-%720 = OpLoad %ulong %229
-%721 = OpLoad %ulong %160
-%722 = OpIAdd %ulong %720 %721
-OpStore %230 %722
-%723 = OpLoad %ulong %230
-%724 = OpUConvert %uchar %723
-OpStore %231 %724
-%725 = OpLoad %ulong %320
-%726 = OpAccessChain %_ptr_Function_uchar %710 %725
-%727 = OpLoad %uchar %231
-OpStore %726 %727
-%728 = OpLoad %ulong %320
-%729 = OpIAdd %ulong %728 %ulong_1
-OpStore %232 %729
-%730 = OpLoad %ulong %232
-OpStore %320 %730
-OpBranch %119
-%76 = OpLabel
-%731 = OpLoad %ulong %301
-OpStore %300 %731
-OpStore %311 %ulong_0
-OpBranch %78
-%78 = OpLabel
-%732 = OpLoad %ulong %311
-%733 = OpULessThan %bool %732 %ulong_4
-OpStore %218 %733
-%734 = OpLoad %bool %218
-OpLoopMerge %80 %124 None
-OpBranchConditional %734 %79 %80
-%80 = OpLabel
-%735 = OpLoad %ulong %316
-%736 = OpIAdd %ulong %735 %ulong_1
-OpStore %222 %736
-%737 = OpLoad %ulong %300
-OpStore %301 %737
-%738 = OpLoad %ulong %222
-OpStore %316 %738
-OpBranch %127
-%79 = OpLabel
-%739 = OpLoad %ulong %311
-%740 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %739
-%741 = OpLoad %ulong %316
-%742 = OpAccessChain %_ptr_Function_ushort %740 %741
-%743 = OpLoad %ushort %742
-OpStore %219 %743
-%744 = OpLoad %ulong %300
-%745 = OpLoad %ushort %219
-%746 = OpFunctionCall %ulong %6 %744 %745
-OpStore %220 %746
-%747 = OpLoad %ulong %311
-%748 = OpIAdd %ulong %747 %ulong_1
-OpStore %221 %748
-%749 = OpLoad %ulong %220
-OpStore %300 %749
-%750 = OpLoad %ulong %221
-OpStore %311 %750
-OpBranch %124
-%70 = OpLabel
-%751 = OpLoad %ulong %312
-%752 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %751
-%753 = OpLoad %ulong %303
-OpStore %302 %753
-OpStore %315 %ulong_0
-OpBranch %72
-%72 = OpLabel
-%754 = OpLoad %ulong %315
-%755 = OpULessThan %bool %754 %ulong_6
-OpStore %212 %755
-%756 = OpLoad %bool %212
-OpLoopMerge %74 %126 None
-OpBranchConditional %756 %73 %74
-%74 = OpLabel
-%757 = OpLoad %ulong %312
-%758 = OpIAdd %ulong %757 %ulong_1
-OpStore %216 %758
-%759 = OpLoad %ulong %302
-OpStore %303 %759
-%760 = OpLoad %ulong %216
-OpStore %312 %760
-OpBranch %129
-%73 = OpLabel
-%761 = OpLoad %ulong %315
-%762 = OpAccessChain %_ptr_Function_ushort %752 %761
-%763 = OpLoad %ushort %762
-OpStore %213 %763
-%764 = OpLoad %ulong %302
-%765 = OpLoad %ushort %213
-%766 = OpFunctionCall %ulong %6 %764 %765
-OpStore %214 %766
-%767 = OpLoad %ulong %315
-%768 = OpIAdd %ulong %767 %ulong_1
-OpStore %215 %768
-%769 = OpLoad %ulong %214
-OpStore %302 %769
-%770 = OpLoad %ulong %215
-OpStore %315 %770
-OpBranch %126
-%64 = OpLabel
-%771 = OpLoad %ulong %313
-%773 = OpIMul %ulong %771 %ulong_100
-OpStore %194 %773
-%774 = OpLoad %ulong %313
-%775 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %149 %774
-OpStore %314 %ulong_0
-OpBranch %66
-%66 = OpLabel
-%776 = OpLoad %ulong %314
-%777 = OpULessThan %bool %776 %ulong_6
-OpStore %193 %777
-%778 = OpLoad %bool %193
-OpLoopMerge %68 %128 None
-OpBranchConditional %778 %67 %68
-%68 = OpLabel
-%779 = OpLoad %ulong %313
-%780 = OpIAdd %ulong %779 %ulong_1
-OpStore %200 %780
-%781 = OpLoad %ulong %200
-OpStore %313 %781
-OpBranch %130
-%67 = OpLabel
-%782 = OpLoad %ulong %314
-%783 = OpIMul %ulong %782 %ulong_7
-OpStore %195 %783
-%784 = OpLoad %ulong %194
-%785 = OpLoad %ulong %195
-%786 = OpIAdd %ulong %784 %785
-OpStore %196 %786
-%787 = OpLoad %ulong %196
-%788 = OpLoad %ulong %160
-%789 = OpIAdd %ulong %787 %788
-OpStore %197 %789
-%790 = OpLoad %ulong %197
-%791 = OpUConvert %ushort %790
-OpStore %198 %791
-%792 = OpLoad %ulong %314
-%793 = OpAccessChain %_ptr_Function_ushort %775 %792
-%794 = OpLoad %ushort %198
-OpStore %793 %794
-%795 = OpLoad %ulong %314
-%796 = OpIAdd %ulong %795 %ulong_1
-OpStore %199 %796
-%797 = OpLoad %ulong %199
-OpStore %314 %797
-OpBranch %128
-%61 = OpLabel
-%798 = OpLoad %ulong %307
-%799 = OpAccessChain %_ptr_Function_uint %143 %798
-%800 = OpLoad %uint %799
-OpStore %189 %800
-%801 = OpLoad %ulong %304
-%802 = OpLoad %uint %189
-%803 = OpFunctionCall %ulong %7 %801 %802
-OpStore %190 %803
-%804 = OpLoad %ulong %307
-%805 = OpIAdd %ulong %804 %ulong_5
-OpStore %191 %805
-%806 = OpLoad %ulong %190
-OpStore %304 %806
-%807 = OpLoad %ulong %191
-OpStore %307 %807
-OpBranch %131
-%58 = OpLabel
-%808 = OpLoad %ulong %308
-%809 = OpISub %ulong %808 %ulong_1
-OpStore %185 %809
-%810 = OpLoad %ulong %185
-%811 = OpAccessChain %_ptr_Function_uint %143 %810
-%812 = OpLoad %uint %811
-OpStore %186 %812
-%813 = OpLoad %ulong %305
-%814 = OpLoad %uint %186
-%815 = OpFunctionCall %ulong %7 %813 %814
-OpStore %187 %815
-%816 = OpLoad %ulong %187
-OpStore %305 %816
-%817 = OpLoad %ulong %185
-OpStore %308 %817
-OpBranch %132
-%55 = OpLabel
-%818 = OpLoad %ulong %309
-%819 = OpIMul %ulong %818 %ulong_7
-OpStore %178 %819
-%820 = OpLoad %ulong %178
-%821 = OpLoad %ulong %160
-%822 = OpIAdd %ulong %820 %821
-OpStore %179 %822
-%823 = OpLoad %ulong %179
-%825 = OpBitwiseAnd %ulong %823 %ulong_31
-OpStore %180 %825
-%826 = OpLoad %ulong %180
-%827 = OpAccessChain %_ptr_Function_uint %143 %826
-%828 = OpLoad %uint %827
-OpStore %181 %828
-%829 = OpLoad %ulong %306
-%830 = OpLoad %uint %181
-%831 = OpFunctionCall %ulong %7 %829 %830
-OpStore %182 %831
-%832 = OpLoad %ulong %309
-%833 = OpIAdd %ulong %832 %ulong_1
-OpStore %183 %833
-%834 = OpLoad %ulong %182
-OpStore %306 %834
-%835 = OpLoad %ulong %183
-OpStore %309 %835
-OpBranch %133
-%52 = OpLabel
-%836 = OpLoad %ulong %310
-%837 = OpIAdd %ulong %836 %ulong_1
-OpStore %164 %837
-%839 = OpLoad %ulong %164
-%840 = OpIMul %ulong %ulong_2654435761 %839
-OpStore %165 %840
-%841 = OpLoad %ulong %165
-%842 = OpLoad %ulong %160
-%843 = OpIAdd %ulong %841 %842
-OpStore %166 %843
-%844 = OpLoad %ulong %166
-%845 = OpUConvert %uint %844
-OpStore %168 %845
-%846 = OpLoad %ulong %310
-%847 = OpAccessChain %_ptr_Function_uint %143 %846
-%848 = OpLoad %uint %168
-OpStore %847 %848
-%849 = OpLoad %ulong %164
-OpStore %310 %849
-OpBranch %134
-%115 = OpLabel
-OpBranch %108
-%116 = OpLabel
-OpBranch %105
-%117 = OpLabel
-OpBranch %96
-%118 = OpLabel
-OpBranch %102
-%119 = OpLabel
-OpBranch %87
-%120 = OpLabel
-OpBranch %93
-%121 = OpLabel
-OpBranch %99
-%122 = OpLabel
-OpBranch %84
-%123 = OpLabel
-OpBranch %90
-%124 = OpLabel
-OpBranch %78
-%125 = OpLabel
-OpBranch %81
-%126 = OpLabel
-OpBranch %72
-%127 = OpLabel
-OpBranch %75
-%128 = OpLabel
-OpBranch %66
-%129 = OpLabel
-OpBranch %69
-%130 = OpLabel
-OpBranch %63
-%131 = OpLabel
-OpBranch %60
-%132 = OpLabel
-OpBranch %57
-%133 = OpLabel
-OpBranch %54
-%134 = OpLabel
-OpBranch %51
+%2 = OpFunction %ulong None %154
+%155 = OpFunctionParameter %ulong
+%156 = OpLabel
+%366 = OpVariable %_ptr_Function__arr_uint_uint_7 Function
+%372 = OpVariable %_ptr_Function__arr__arr_ushort_uint_6_uint_4 Function
+%378 = OpVariable %_ptr_Function__arr__arr__arr_uchar_uint_3_uint_3_uint_3 Function
+%379 = OpVariable %_ptr_Function__struct_7 Function
+%380 = OpVariable %_ptr_Function__struct_7 Function
+%384 = OpVariable %_ptr_Function__arr_uint_uint_32 Function
+%388 = OpVariable %_ptr_Function__arr__struct_7_uint_5 Function
+%389 = OpVariable %_ptr_Function_ulong Function
+%390 = OpVariable %_ptr_Function_bool Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_ulong Function
+%393 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_uint Function
+%396 = OpVariable %_ptr_Function_uint Function
+%397 = OpVariable %_ptr_Function_uint Function
+%398 = OpVariable %_ptr_Function_uint Function
+%399 = OpVariable %_ptr_Function_uint Function
+%400 = OpVariable %_ptr_Function_bool Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_ulong Function
+%403 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_uint Function
+%405 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_bool Function
+%407 = OpVariable %_ptr_Function_ulong Function
+%408 = OpVariable %_ptr_Function_uint Function
+%409 = OpVariable %_ptr_Function_bool Function
+%410 = OpVariable %_ptr_Function_uint Function
+%411 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_bool Function
+%413 = OpVariable %_ptr_Function_bool Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ulong Function
+%416 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_ushort Function
+%419 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ushort Function
+%422 = OpVariable %_ptr_Function_ushort Function
+%423 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ushort Function
+%428 = OpVariable %_ptr_Function_bool Function
+%429 = OpVariable %_ptr_Function_bool Function
+%430 = OpVariable %_ptr_Function_ushort Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_bool Function
+%434 = OpVariable %_ptr_Function_bool Function
+%435 = OpVariable %_ptr_Function_ushort Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_bool Function
+%439 = OpVariable %_ptr_Function_bool Function
+%440 = OpVariable %_ptr_Function_bool Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_uchar Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_bool Function
+%451 = OpVariable %_ptr_Function_bool Function
+%452 = OpVariable %_ptr_Function_bool Function
+%453 = OpVariable %_ptr_Function_uchar Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_uchar Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_uchar Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ushort Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_uchar Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_bool Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_ushort Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_bool Function
+%486 = OpVariable %_ptr_Function_uint Function
+%487 = OpVariable %_ptr_Function_uint Function
+%488 = OpVariable %_ptr_Function_uint Function
+%489 = OpVariable %_ptr_Function_uint Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_bool Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_uint Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_uint Function
+%499 = OpVariable %_ptr_Function_uint Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_ulong Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_ulong Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_ulong Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_bool Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_ulong Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_bool Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_ulong Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_ulong Function
+%556 = OpVariable %_ptr_Function_ulong Function
+%557 = OpVariable %_ptr_Function_ulong Function
+%558 = OpVariable %_ptr_Function_ulong Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_ulong Function
+%561 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_bool Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_bool Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_bool Function
+%581 = OpVariable %_ptr_Function_ulong Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_ulong Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_bool Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_ulong Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_ulong Function
+%600 = OpVariable %_ptr_Function_bool Function
+%601 = OpVariable %_ptr_Function_ulong Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_ulong Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_ulong Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_bool Function
+%610 = OpVariable %_ptr_Function_ulong Function
+%611 = OpVariable %_ptr_Function_ulong Function
+%612 = OpVariable %_ptr_Function_ulong Function
+%613 = OpVariable %_ptr_Function_ulong Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_ulong Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+%618 = OpVariable %_ptr_Function_bool Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_ulong Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_ulong Function
+%624 = OpVariable %_ptr_Function_ulong Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function_ulong Function
+%627 = OpVariable %_ptr_Function_ulong Function
+%628 = OpVariable %_ptr_Function_ulong Function
+%629 = OpVariable %_ptr_Function_bool Function
+%630 = OpVariable %_ptr_Function_ulong Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_ulong Function
+%633 = OpVariable %_ptr_Function_ulong Function
+%634 = OpVariable %_ptr_Function_ulong Function
+%635 = OpVariable %_ptr_Function_ulong Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function_ulong Function
+%638 = OpVariable %_ptr_Function_ulong Function
+%639 = OpVariable %_ptr_Function_ulong Function
+%640 = OpVariable %_ptr_Function_bool Function
+%641 = OpVariable %_ptr_Function_ulong Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_ulong Function
+%644 = OpVariable %_ptr_Function_ulong Function
+%645 = OpVariable %_ptr_Function_ulong Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_ulong Function
+%648 = OpVariable %_ptr_Function_ulong Function
+%649 = OpVariable %_ptr_Function_bool Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_ulong Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_bool Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_ulong Function
+%667 = OpVariable %_ptr_Function_ulong Function
+%668 = OpVariable %_ptr_Function_ulong Function
+%669 = OpVariable %_ptr_Function_ulong Function
+%670 = OpVariable %_ptr_Function_ulong Function
+%671 = OpVariable %_ptr_Function_ulong Function
+%672 = OpVariable %_ptr_Function_ulong Function
+%673 = OpVariable %_ptr_Function_ulong Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_ulong Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_ulong Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_uint Function
+%680 = OpVariable %_ptr_Function_uint Function
+%681 = OpVariable %_ptr_Function_uint Function
+%682 = OpVariable %_ptr_Function_uint Function
+%683 = OpVariable %_ptr_Function_uint Function
+%684 = OpVariable %_ptr_Function_uint Function
+%685 = OpVariable %_ptr_Function_uint Function
+%686 = OpVariable %_ptr_Function_ulong Function
+%687 = OpVariable %_ptr_Function_ulong Function
+%688 = OpVariable %_ptr_Function_ulong Function
+%689 = OpVariable %_ptr_Function_ulong Function
+%690 = OpVariable %_ptr_Function_ulong Function
+%691 = OpVariable %_ptr_Function_ulong Function
+OpStore %389 %155
+OpBranch %217
+%217 = OpLabel
+OpBranch %218
+%218 = OpLabel
+OpStore %384 %692
+OpStore %515 %ulong_0
+OpBranch %157
+%157 = OpLabel
+%693 = OpLoad %ulong %515
+%695 = OpULessThan %bool %693 %ulong_32
+OpStore %390 %695
+%696 = OpLoad %bool %390
+OpLoopMerge %159 %362 None
+OpBranchConditional %696 %158 %159
+%159 = OpLabel
+%697 = OpAccessChain %_ptr_Function_uint %384 %uint_0
+%698 = OpLoad %uint %697
+OpStore %396 %698
+OpBranch %219
+%219 = OpLabel
+%699 = OpLoad %uint %396
+%700 = OpUConvert %ulong %699
+OpStore %532 %700
+OpBranch %248
+%248 = OpLabel
+OpStore %558 %ulong_14695981039346656037
+OpStore %559 %ulong_0
+OpBranch %249
+%249 = OpLabel
+%702 = OpLoad %ulong %559
+%703 = OpULessThan %bool %702 %ulong_8
+OpStore %551 %703
+%704 = OpLoad %bool %551
+OpLoopMerge %251 %361 None
+OpBranchConditional %704 %250 %251
+%251 = OpLabel
+OpBranch %252
+%252 = OpLabel
+OpBranch %220
+%220 = OpLabel
+%705 = OpAccessChain %_ptr_Function_uint %384 %uint_1
+%706 = OpLoad %uint %705
+OpStore %397 %706
+OpBranch %253
+%253 = OpLabel
+%707 = OpLoad %uint %397
+%708 = OpUConvert %ulong %707
+OpStore %560 %708
+%709 = OpLoad %ulong %558
+%710 = OpLoad %ulong %560
+%711 = OpFunctionCall %ulong %3 %709 %710
+OpStore %561 %711
+OpBranch %254
+%254 = OpLabel
+%713 = OpAccessChain %_ptr_Function_uint %384 %uint_15
+%714 = OpLoad %uint %713
+OpStore %398 %714
+OpBranch %318
+%318 = OpLabel
+%715 = OpLoad %uint %398
+%716 = OpUConvert %ulong %715
+OpStore %669 %716
+%717 = OpLoad %ulong %561
+%718 = OpLoad %ulong %669
+%719 = OpFunctionCall %ulong %3 %717 %718
+OpStore %670 %719
+OpBranch %319
+%319 = OpLabel
+%721 = OpAccessChain %_ptr_Function_uint %384 %uint_31
+%722 = OpLoad %uint %721
+OpStore %399 %722
+OpBranch %324
+%324 = OpLabel
+%723 = OpLoad %uint %399
+%724 = OpUConvert %ulong %723
+OpStore %675 %724
+%725 = OpLoad %ulong %670
+%726 = OpLoad %ulong %675
+%727 = OpFunctionCall %ulong %3 %725 %726
+OpStore %676 %727
+OpBranch %325
+%325 = OpLabel
+%728 = OpLoad %ulong %676
+OpStore %511 %728
+OpStore %514 %ulong_0
+OpBranch %160
+%160 = OpLabel
+%729 = OpLoad %ulong %514
+%730 = OpULessThan %bool %729 %ulong_32
+OpStore %400 %730
+%731 = OpLoad %bool %400
+OpLoopMerge %162 %360 None
+OpBranchConditional %731 %161 %162
+%162 = OpLabel
+%732 = OpLoad %ulong %511
+OpStore %510 %732
+OpStore %513 %ulong_32
+OpBranch %163
+%163 = OpLabel
+%733 = OpLoad %ulong %513
+%734 = OpULessThan %bool %ulong_0 %733
+OpStore %406 %734
+%735 = OpLoad %bool %406
+OpLoopMerge %165 %359 None
+OpBranchConditional %735 %164 %165
+%165 = OpLabel
+%736 = OpLoad %ulong %510
+OpStore %509 %736
+OpStore %512 %ulong_0
+OpBranch %166
+%166 = OpLabel
+%737 = OpLoad %ulong %512
+%738 = OpULessThan %bool %737 %ulong_32
+OpStore %409 %738
+%739 = OpLoad %bool %409
+OpLoopMerge %168 %357 None
+OpBranchConditional %739 %167 %168
+%168 = OpLabel
+OpStore %372 %740
+OpStore %518 %ulong_0
+OpBranch %169
+%169 = OpLabel
+%741 = OpLoad %ulong %518
+%743 = OpULessThan %bool %741 %ulong_4
+OpStore %412 %743
+%744 = OpLoad %bool %412
+OpLoopMerge %171 %355 None
+OpBranchConditional %744 %170 %171
+%171 = OpLabel
+%746 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %uint_0
+%747 = OpAccessChain %_ptr_Function_ushort %746 %uint_0
+%748 = OpLoad %ushort %747
+OpStore %421 %748
+OpBranch %227
+%227 = OpLabel
+%749 = OpLoad %ushort %421
+%750 = OpUConvert %ulong %749
+OpStore %536 %750
+OpBranch %270
+%270 = OpLabel
+%751 = OpLoad %ulong %509
+OpStore %596 %751
+OpStore %597 %ulong_0
+OpBranch %271
+%271 = OpLabel
+%752 = OpLoad %ulong %597
+%753 = OpULessThan %bool %752 %ulong_8
+OpStore %589 %753
+%754 = OpLoad %bool %589
+OpLoopMerge %273 %352 None
+OpBranchConditional %754 %272 %273
+%273 = OpLabel
+OpBranch %274
+%274 = OpLabel
+OpBranch %228
+%228 = OpLabel
+%755 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %uint_3
+%756 = OpAccessChain %_ptr_Function_ushort %755 %uint_5
+%757 = OpLoad %ushort %756
+OpStore %422 %757
+OpBranch %275
+%275 = OpLabel
+%758 = OpLoad %ushort %422
+%759 = OpUConvert %ulong %758
+OpStore %598 %759
+%760 = OpLoad %ulong %596
+%761 = OpLoad %ulong %598
+%762 = OpFunctionCall %ulong %3 %760 %761
+OpStore %599 %762
+OpBranch %276
+%276 = OpLabel
+%763 = OpLoad %ulong %389
+%765 = OpIAdd %ulong %763 %ulong_2
+OpStore %423 %765
+%766 = OpLoad %ulong %423
+%768 = OpBitwiseAnd %ulong %766 %ulong_3
+OpStore %424 %768
+%769 = OpLoad %ulong %424
+%770 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %769
+%771 = OpLoad %ulong %389
+%772 = OpIAdd %ulong %771 %ulong_4
+OpStore %425 %772
+%773 = OpLoad %ulong %425
+%774 = OpBitwiseAnd %ulong %773 %ulong_3
+OpStore %426 %774
+%775 = OpLoad %ulong %426
+%776 = OpAccessChain %_ptr_Function_ushort %770 %775
+%777 = OpLoad %ushort %776
+OpStore %427 %777
+OpBranch %320
+%320 = OpLabel
+%778 = OpLoad %ushort %427
+%779 = OpUConvert %ulong %778
+OpStore %671 %779
+%780 = OpLoad %ulong %599
+%781 = OpLoad %ulong %671
+%782 = OpFunctionCall %ulong %3 %780 %781
+OpStore %672 %782
+OpBranch %321
+%321 = OpLabel
+%783 = OpLoad %ulong %672
+OpStore %508 %783
+OpStore %517 %ulong_0
+OpBranch %175
+%175 = OpLabel
+%784 = OpLoad %ulong %517
+%785 = OpULessThan %bool %784 %ulong_4
+OpStore %428 %785
+%786 = OpLoad %bool %428
+OpLoopMerge %177 %351 None
+OpBranchConditional %786 %176 %177
+%177 = OpLabel
+%787 = OpLoad %ulong %508
+OpStore %506 %787
+OpStore %521 %ulong_0
+OpBranch %181
+%181 = OpLabel
+%788 = OpLoad %ulong %521
+%790 = OpULessThan %bool %788 %ulong_6
+OpStore %433 %790
+%791 = OpLoad %bool %433
+OpLoopMerge %183 %350 None
+OpBranchConditional %791 %182 %183
+%183 = OpLabel
+OpStore %378 %792
+OpStore %523 %ulong_0
+OpBranch %187
+%187 = OpLabel
+%793 = OpLoad %ulong %523
+%794 = OpULessThan %bool %793 %ulong_3
+OpStore %438 %794
+%795 = OpLoad %bool %438
+OpLoopMerge %189 %348 None
+OpBranchConditional %795 %188 %189
+%189 = OpLabel
+%796 = OpLoad %ulong %506
+OpStore %504 %796
+OpStore %522 %ulong_0
+OpBranch %196
+%196 = OpLabel
+%797 = OpLoad %ulong %522
+%798 = OpULessThan %bool %797 %ulong_3
+OpStore %450 %798
+%799 = OpLoad %bool %450
+OpLoopMerge %198 %345 None
+OpBranchConditional %799 %197 %198
+%198 = OpLabel
+%801 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %378 %uint_2
+%803 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %801 %uint_0
+%804 = OpAccessChain %_ptr_Function_uchar %803 %uint_1
+%805 = OpLoad %uchar %804
+OpStore %457 %805
+OpBranch %233
+%233 = OpLabel
+%806 = OpLoad %uchar %457
+%807 = OpUConvert %ulong %806
+OpStore %539 %807
+OpBranch %287
+%287 = OpLabel
+%808 = OpLoad %ulong %504
+OpStore %625 %808
+OpStore %626 %ulong_0
+OpBranch %288
+%288 = OpLabel
+%809 = OpLoad %ulong %626
+%810 = OpULessThan %bool %809 %ulong_8
+OpStore %618 %810
+%811 = OpLoad %bool %618
+OpLoopMerge %290 %340 None
+OpBranchConditional %811 %289 %290
+%290 = OpLabel
+OpBranch %291
+%291 = OpLabel
+OpBranch %234
+%234 = OpLabel
+%812 = OpLoad %ulong %389
+%813 = OpIAdd %ulong %812 %ulong_1
+OpStore %458 %813
+OpStore %688 %ulong_3
+%814 = OpLoad %ulong %458
+%815 = OpLoad %ulong %688
+%816 = OpUMod %ulong %814 %815
+OpStore %459 %816
+%817 = OpLoad %ulong %459
+%818 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %378 %817
+%819 = OpLoad %ulong %389
+%820 = OpIAdd %ulong %819 %ulong_2
+OpStore %460 %820
+OpStore %689 %ulong_3
+%821 = OpLoad %ulong %460
+%822 = OpLoad %ulong %689
+%823 = OpUMod %ulong %821 %822
+OpStore %461 %823
+%824 = OpLoad %ulong %461
+%825 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %818 %824
+OpStore %690 %ulong_3
+%826 = OpLoad %ulong %389
+%827 = OpLoad %ulong %690
+%828 = OpUMod %ulong %826 %827
+OpStore %462 %828
+%829 = OpLoad %ulong %462
+%830 = OpAccessChain %_ptr_Function_uchar %825 %829
+%831 = OpLoad %uchar %830
+OpStore %463 %831
+OpBranch %292
+%292 = OpLabel
+%832 = OpLoad %uchar %463
+%833 = OpUConvert %ulong %832
+OpStore %627 %833
+%834 = OpLoad %ulong %625
+%835 = OpLoad %ulong %627
+%836 = OpFunctionCall %ulong %3 %834 %835
+OpStore %628 %836
+OpBranch %293
+%293 = OpLabel
+OpStore %388 %837
+OpStore %531 %ulong_0
+OpBranch %205
+%205 = OpLabel
+%838 = OpLoad %ulong %531
+%840 = OpULessThan %bool %838 %ulong_5
+OpStore %464 %840
+%841 = OpLoad %bool %464
+OpLoopMerge %207 %337 None
+OpBranchConditional %841 %206 %207
+%207 = OpLabel
+%842 = OpLoad %ulong %628
+OpStore %501 %842
+OpStore %530 %ulong_0
+OpBranch %208
+%208 = OpLabel
+%843 = OpLoad %ulong %530
+%844 = OpULessThan %bool %843 %ulong_5
+OpStore %474 %844
+%845 = OpLoad %bool %474
+OpLoopMerge %210 %336 None
+OpBranchConditional %845 %209 %210
+%210 = OpLabel
+%846 = OpLoad %ulong %389
+%847 = OpIAdd %ulong %846 %ulong_3
+OpStore %477 %847
+OpStore %686 %ulong_5
+%848 = OpLoad %ulong %477
+%849 = OpLoad %ulong %686
+%850 = OpUMod %ulong %848 %849
+OpStore %478 %850
+%851 = OpLoad %ulong %478
+%852 = OpAccessChain %_ptr_Function__struct_7 %388 %851
+%853 = OpLoad %_struct_7 %852
+OpStore %380 %853
+%854 = OpLoad %ulong %501
+%855 = OpLoad %_struct_7 %380
+%856 = OpFunctionCall %ulong %1 %854 %855
+OpStore %479 %856
+%857 = OpAccessChain %_ptr_Function__struct_7 %388 %uint_4
+%858 = OpAccessChain %_ptr_Function_ulong %857 %uint_2
+%859 = OpLoad %ulong %858
+OpStore %480 %859
+OpBranch %237
+%237 = OpLabel
+%860 = OpLoad %ulong %479
+OpStore %548 %860
+OpStore %549 %ulong_0
+OpBranch %238
+%238 = OpLabel
+%861 = OpLoad %ulong %549
+%862 = OpULessThan %bool %861 %ulong_8
+OpStore %541 %862
+%863 = OpLoad %bool %541
+OpLoopMerge %240 %335 None
+OpBranchConditional %863 %239 %240
+%240 = OpLabel
+OpBranch %241
+%241 = OpLabel
+%864 = OpLoad %ulong %389
+%865 = OpIAdd %ulong %864 %ulong_1
+OpStore %481 %865
+OpStore %691 %ulong_5
+%866 = OpLoad %ulong %481
+%867 = OpLoad %ulong %691
+%868 = OpUMod %ulong %866 %867
+OpStore %482 %868
+%869 = OpLoad %ulong %482
+%870 = OpAccessChain %_ptr_Function__struct_7 %388 %869
+%871 = OpAccessChain %_ptr_Function_ushort %870 %uint_0
+%872 = OpLoad %ushort %871
+OpStore %483 %872
+OpBranch %299
+%299 = OpLabel
+%873 = OpLoad %ushort %483
+%874 = OpUConvert %ulong %873
+OpStore %638 %874
+%875 = OpLoad %ulong %548
+%876 = OpLoad %ulong %638
+%877 = OpFunctionCall %ulong %3 %875 %876
+OpStore %639 %877
+OpBranch %300
+%300 = OpLabel
+%878 = OpLoad %ulong %639
+%880 = OpFunctionCall %ulong %3 %878 %ulong_16
+OpStore %484 %880
+OpStore %366 %881
+%882 = OpLoad %ulong %389
+%883 = OpUConvert %uint %882
+OpStore %488 %883
+OpStore %529 %ulong_0
+OpBranch %211
+%211 = OpLabel
+%884 = OpLoad %ulong %529
+%886 = OpULessThan %bool %884 %ulong_7
+OpStore %485 %886
+%887 = OpLoad %bool %485
+OpLoopMerge %213 %334 None
+OpBranchConditional %887 %212 %213
+%213 = OpLabel
+OpBranch %242
+%242 = OpLabel
+OpBranch %301
+%301 = OpLabel
+%888 = OpLoad %ulong %484
+OpStore %647 %888
+OpStore %648 %ulong_0
+OpBranch %302
+%302 = OpLabel
+%889 = OpLoad %ulong %648
+%890 = OpULessThan %bool %889 %ulong_8
+OpStore %640 %890
+%891 = OpLoad %bool %640
+OpLoopMerge %304 %333 None
+OpBranchConditional %891 %303 %304
+%304 = OpLabel
+OpBranch %305
+%305 = OpLabel
+OpBranch %243
+%243 = OpLabel
+%892 = OpLoad %ulong %647
+OpStore %500 %892
+OpStore %528 %ulong_0
+OpBranch %214
+%214 = OpLabel
+%893 = OpLoad %ulong %528
+%894 = OpULessThan %bool %893 %ulong_7
+OpStore %491 %894
+%895 = OpLoad %bool %491
+OpLoopMerge %216 %332 None
+OpBranchConditional %895 %215 %216
+%216 = OpLabel
+OpBranch %246
+%246 = OpLabel
+OpBranch %311
+%311 = OpLabel
+%896 = OpLoad %ulong %500
+OpStore %665 %896
+OpStore %666 %ulong_0
+OpBranch %312
+%312 = OpLabel
+%897 = OpLoad %ulong %666
+%898 = OpULessThan %bool %897 %ulong_8
+OpStore %658 %898
+%899 = OpLoad %bool %658
+OpLoopMerge %314 %331 None
+OpBranchConditional %899 %313 %314
+%314 = OpLabel
+OpBranch %315
+%315 = OpLabel
+OpBranch %247
+%247 = OpLabel
+%900 = OpLoad %ulong %665
+%901 = OpFunctionCall %ulong %3 %900 %ulong_4
+OpStore %497 %901
+%902 = OpAccessChain %_ptr_Function_uint %366 %uint_0
+%903 = OpLoad %uint %902
+OpStore %679 %903
+%904 = OpAccessChain %_ptr_Function_uint %366 %uint_1
+%905 = OpLoad %uint %904
+OpStore %680 %905
+%906 = OpAccessChain %_ptr_Function_uint %366 %uint_2
+%907 = OpLoad %uint %906
+OpStore %681 %907
+%908 = OpAccessChain %_ptr_Function_uint %366 %uint_3
+%909 = OpLoad %uint %908
+OpStore %682 %909
+%910 = OpAccessChain %_ptr_Function_uint %366 %uint_4
+%911 = OpLoad %uint %910
+OpStore %683 %911
+%912 = OpAccessChain %_ptr_Function_uint %366 %uint_5
+%913 = OpLoad %uint %912
+OpStore %684 %913
+%914 = OpAccessChain %_ptr_Function_uint %366 %uint_6
+%915 = OpLoad %uint %914
+OpStore %685 %915
+%916 = OpLoad %uint %682
+%918 = OpBitwiseXor %uint %916 %uint_4042322160
+OpStore %498 %918
+%919 = OpLoad %uint %908
+OpStore %499 %919
+OpBranch %316
+%316 = OpLabel
+%920 = OpLoad %uint %499
+%921 = OpUConvert %ulong %920
+OpStore %667 %921
+%922 = OpLoad %ulong %497
+%923 = OpLoad %ulong %667
+%924 = OpFunctionCall %ulong %3 %922 %923
+OpStore %668 %924
+OpBranch %317
+%317 = OpLabel
+OpBranch %322
+%322 = OpLabel
+%925 = OpLoad %uint %498
+%926 = OpUConvert %ulong %925
+OpStore %673 %926
+%927 = OpLoad %ulong %668
+%928 = OpLoad %ulong %673
+%929 = OpFunctionCall %ulong %3 %927 %928
+OpStore %674 %929
+OpBranch %323
+%323 = OpLabel
+OpBranch %326
+%326 = OpLabel
+%930 = OpLoad %ulong %674
+%932 = OpFunctionCall %ulong %3 %930 %ulong_17
+OpStore %677 %932
+OpBranch %327
+%327 = OpLabel
+OpBranch %328
+%328 = OpLabel
+%933 = OpLoad %ulong %677
+%935 = OpFunctionCall %ulong %3 %933 %ulong_4660
+OpStore %678 %935
+OpBranch %329
+%329 = OpLabel
+%936 = OpLoad %ulong %678
+OpReturnValue %936
+%313 = OpLabel
+%937 = OpLoad %ulong %666
+%938 = OpIMul %ulong %937 %ulong_8
+OpStore %659 %938
+%939 = OpLoad %ulong %659
+%940 = OpShiftRightLogical %ulong %ulong_4660 %939
+OpStore %660 %940
+%941 = OpLoad %ulong %660
+%942 = OpBitwiseAnd %ulong %941 %ulong_255
+OpStore %661 %942
+%943 = OpLoad %ulong %665
+%944 = OpLoad %ulong %661
+%945 = OpBitwiseXor %ulong %943 %944
+OpStore %662 %945
+%946 = OpLoad %ulong %662
+%947 = OpIMul %ulong %946 %ulong_1099511628211
+OpStore %663 %947
+%948 = OpLoad %ulong %666
+%949 = OpIAdd %ulong %948 %ulong_1
+OpStore %664 %949
+%950 = OpLoad %ulong %663
+OpStore %665 %950
+%951 = OpLoad %ulong %664
+OpStore %666 %951
+OpBranch %331
+%215 = OpLabel
+%952 = OpLoad %ulong %528
+%953 = OpIMul %ulong %952 %ulong_3
+OpStore %492 %953
+%954 = OpLoad %ulong %492
+%955 = OpLoad %ulong %389
+%956 = OpIAdd %ulong %954 %955
+OpStore %493 %956
+OpStore %687 %ulong_7
+%957 = OpLoad %ulong %493
+%958 = OpLoad %ulong %687
+%959 = OpUMod %ulong %957 %958
+OpStore %494 %959
+%960 = OpLoad %ulong %494
+%961 = OpAccessChain %_ptr_Function_uint %366 %960
+%962 = OpLoad %uint %961
+OpStore %495 %962
+OpBranch %244
+%244 = OpLabel
+%963 = OpLoad %uint %495
+%964 = OpUConvert %ulong %963
+OpStore %550 %964
+OpBranch %306
+%306 = OpLabel
+%965 = OpLoad %ulong %500
+OpStore %656 %965
+OpStore %657 %ulong_0
+OpBranch %307
+%307 = OpLabel
+%966 = OpLoad %ulong %657
+%967 = OpULessThan %bool %966 %ulong_8
+OpStore %649 %967
+%968 = OpLoad %bool %649
+OpLoopMerge %309 %330 None
+OpBranchConditional %968 %308 %309
+%309 = OpLabel
+OpBranch %310
+%310 = OpLabel
+OpBranch %245
+%245 = OpLabel
+%969 = OpLoad %ulong %528
+%970 = OpIAdd %ulong %969 %ulong_1
+OpStore %496 %970
+%971 = OpLoad %ulong %656
+OpStore %500 %971
+%972 = OpLoad %ulong %496
+OpStore %528 %972
+OpBranch %332
+%308 = OpLabel
+%973 = OpLoad %ulong %657
+%974 = OpIMul %ulong %973 %ulong_8
+OpStore %650 %974
+%975 = OpLoad %ulong %550
+%976 = OpLoad %ulong %650
+%977 = OpShiftRightLogical %ulong %975 %976
+OpStore %651 %977
+%978 = OpLoad %ulong %651
+%979 = OpBitwiseAnd %ulong %978 %ulong_255
+OpStore %652 %979
+%980 = OpLoad %ulong %656
+%981 = OpLoad %ulong %652
+%982 = OpBitwiseXor %ulong %980 %981
+OpStore %653 %982
+%983 = OpLoad %ulong %653
+%984 = OpIMul %ulong %983 %ulong_1099511628211
+OpStore %654 %984
+%985 = OpLoad %ulong %657
+%986 = OpIAdd %ulong %985 %ulong_1
+OpStore %655 %986
+%987 = OpLoad %ulong %654
+OpStore %656 %987
+%988 = OpLoad %ulong %655
+OpStore %657 %988
+OpBranch %330
+%303 = OpLabel
+%989 = OpLoad %ulong %648
+%990 = OpIMul %ulong %989 %ulong_8
+OpStore %641 %990
+%991 = OpLoad %ulong %641
+%992 = OpShiftRightLogical %ulong %ulong_17 %991
+OpStore %642 %992
+%993 = OpLoad %ulong %642
+%994 = OpBitwiseAnd %ulong %993 %ulong_255
+OpStore %643 %994
+%995 = OpLoad %ulong %647
+%996 = OpLoad %ulong %643
+%997 = OpBitwiseXor %ulong %995 %996
+OpStore %644 %997
+%998 = OpLoad %ulong %644
+%999 = OpIMul %ulong %998 %ulong_1099511628211
+OpStore %645 %999
+%1000 = OpLoad %ulong %648
+%1001 = OpIAdd %ulong %1000 %ulong_1
+OpStore %646 %1001
+%1002 = OpLoad %ulong %645
+OpStore %647 %1002
+%1003 = OpLoad %ulong %646
+OpStore %648 %1003
+OpBranch %333
+%212 = OpLabel
+%1004 = OpLoad %ulong %529
+%1005 = OpUConvert %uint %1004
+OpStore %486 %1005
+%1006 = OpLoad %uint %486
+%1008 = OpIMul %uint %1006 %uint_305419896
+OpStore %487 %1008
+%1009 = OpLoad %uint %487
+%1010 = OpLoad %uint %488
+%1011 = OpIAdd %uint %1009 %1010
+OpStore %489 %1011
+%1012 = OpLoad %ulong %529
+%1013 = OpAccessChain %_ptr_Function_uint %366 %1012
+%1014 = OpLoad %uint %489
+OpStore %1013 %1014
+%1015 = OpLoad %ulong %529
+%1016 = OpIAdd %ulong %1015 %ulong_1
+OpStore %490 %1016
+%1017 = OpLoad %ulong %490
+OpStore %529 %1017
+OpBranch %334
+%239 = OpLabel
+%1018 = OpLoad %ulong %549
+%1019 = OpIMul %ulong %1018 %ulong_8
+OpStore %542 %1019
+%1020 = OpLoad %ulong %480
+%1021 = OpLoad %ulong %542
+%1022 = OpShiftRightLogical %ulong %1020 %1021
+OpStore %543 %1022
+%1023 = OpLoad %ulong %543
+%1024 = OpBitwiseAnd %ulong %1023 %ulong_255
+OpStore %544 %1024
+%1025 = OpLoad %ulong %548
+%1026 = OpLoad %ulong %544
+%1027 = OpBitwiseXor %ulong %1025 %1026
+OpStore %545 %1027
+%1028 = OpLoad %ulong %545
+%1029 = OpIMul %ulong %1028 %ulong_1099511628211
+OpStore %546 %1029
+%1030 = OpLoad %ulong %549
+%1031 = OpIAdd %ulong %1030 %ulong_1
+OpStore %547 %1031
+%1032 = OpLoad %ulong %546
+OpStore %548 %1032
+%1033 = OpLoad %ulong %547
+OpStore %549 %1033
+OpBranch %335
+%209 = OpLabel
+%1034 = OpLoad %ulong %530
+%1035 = OpAccessChain %_ptr_Function__struct_7 %388 %1034
+%1036 = OpLoad %_struct_7 %1035
+OpStore %379 %1036
+%1037 = OpLoad %ulong %501
+%1038 = OpLoad %_struct_7 %379
+%1039 = OpFunctionCall %ulong %1 %1037 %1038
+OpStore %475 %1039
+%1040 = OpLoad %ulong %530
+%1041 = OpIAdd %ulong %1040 %ulong_1
+OpStore %476 %1041
+%1042 = OpLoad %ulong %475
+OpStore %501 %1042
+%1043 = OpLoad %ulong %476
+OpStore %530 %1043
+OpBranch %336
+%206 = OpLabel
+%1044 = OpLoad %ulong %531
+%1045 = OpIMul %ulong %1044 %ulong_3
+OpStore %465 %1045
+%1046 = OpLoad %ulong %465
+%1047 = OpIAdd %ulong %1046 %ulong_1
+OpStore %466 %1047
+%1048 = OpLoad %ulong %466
+%1049 = OpLoad %ulong %389
+%1050 = OpIAdd %ulong %1048 %1049
+OpStore %467 %1050
+%1051 = OpLoad %ulong %467
+%1052 = OpUConvert %ushort %1051
+OpStore %468 %1052
+%1053 = OpLoad %ulong %531
+%1054 = OpAccessChain %_ptr_Function__struct_7 %388 %1053
+%1055 = OpAccessChain %_ptr_Function_ushort %1054 %uint_0
+%1056 = OpLoad %ushort %468
+OpStore %1055 %1056
+%1057 = OpLoad %ulong %531
+%1059 = OpIAdd %ulong %1057 %ulong_200
+OpStore %469 %1059
+%1060 = OpLoad %ulong %469
+%1061 = OpUConvert %uchar %1060
+OpStore %470 %1061
+%1062 = OpAccessChain %_ptr_Function_uchar %1054 %uint_1
+%1063 = OpLoad %uchar %470
+OpStore %1062 %1063
+%1064 = OpLoad %ulong %531
+%1065 = OpIAdd %ulong %1064 %ulong_1
+OpStore %471 %1065
+%1066 = OpLoad %ulong %471
+%1067 = OpIMul %ulong %ulong_1099511628211 %1066
+OpStore %472 %1067
+%1068 = OpLoad %ulong %472
+%1069 = OpLoad %ulong %389
+%1070 = OpIAdd %ulong %1068 %1069
+OpStore %473 %1070
+%1071 = OpAccessChain %_ptr_Function_ulong %1054 %uint_2
+%1072 = OpLoad %ulong %473
+OpStore %1071 %1072
+%1073 = OpLoad %ulong %471
+OpStore %531 %1073
+OpBranch %337
+%289 = OpLabel
+%1074 = OpLoad %ulong %626
+%1075 = OpIMul %ulong %1074 %ulong_8
+OpStore %619 %1075
+%1076 = OpLoad %ulong %539
+%1077 = OpLoad %ulong %619
+%1078 = OpShiftRightLogical %ulong %1076 %1077
+OpStore %620 %1078
+%1079 = OpLoad %ulong %620
+%1080 = OpBitwiseAnd %ulong %1079 %ulong_255
+OpStore %621 %1080
+%1081 = OpLoad %ulong %625
+%1082 = OpLoad %ulong %621
+%1083 = OpBitwiseXor %ulong %1081 %1082
+OpStore %622 %1083
+%1084 = OpLoad %ulong %622
+%1085 = OpIMul %ulong %1084 %ulong_1099511628211
+OpStore %623 %1085
+%1086 = OpLoad %ulong %626
+%1087 = OpIAdd %ulong %1086 %ulong_1
+OpStore %624 %1087
+%1088 = OpLoad %ulong %623
+OpStore %625 %1088
+%1089 = OpLoad %ulong %624
+OpStore %626 %1089
+OpBranch %340
+%197 = OpLabel
+%1090 = OpLoad %ulong %504
+OpStore %503 %1090
+OpStore %526 %ulong_0
+OpBranch %199
+%199 = OpLabel
+%1091 = OpLoad %ulong %526
+%1092 = OpULessThan %bool %1091 %ulong_3
+OpStore %451 %1092
+%1093 = OpLoad %bool %451
+OpLoopMerge %201 %342 None
+OpBranchConditional %1093 %200 %201
+%201 = OpLabel
+%1094 = OpLoad %ulong %522
+%1095 = OpIAdd %ulong %1094 %ulong_1
+OpStore %456 %1095
+%1096 = OpLoad %ulong %503
+OpStore %504 %1096
+%1097 = OpLoad %ulong %456
+OpStore %522 %1097
+OpBranch %345
+%200 = OpLabel
+%1098 = OpLoad %ulong %503
+OpStore %502 %1098
+OpStore %527 %ulong_0
+OpBranch %202
+%202 = OpLabel
+%1099 = OpLoad %ulong %527
+%1100 = OpULessThan %bool %1099 %ulong_3
+OpStore %452 %1100
+%1101 = OpLoad %bool %452
+OpLoopMerge %204 %339 None
+OpBranchConditional %1101 %203 %204
+%204 = OpLabel
+%1102 = OpLoad %ulong %526
+%1103 = OpIAdd %ulong %1102 %ulong_1
+OpStore %455 %1103
+%1104 = OpLoad %ulong %502
+OpStore %503 %1104
+%1105 = OpLoad %ulong %455
+OpStore %526 %1105
+OpBranch %342
+%203 = OpLabel
+%1106 = OpLoad %ulong %527
+%1107 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %378 %1106
+%1108 = OpLoad %ulong %526
+%1109 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %1107 %1108
+%1110 = OpLoad %ulong %522
+%1111 = OpAccessChain %_ptr_Function_uchar %1109 %1110
+%1112 = OpLoad %uchar %1111
+OpStore %453 %1112
+OpBranch %235
+%235 = OpLabel
+%1113 = OpLoad %uchar %453
+%1114 = OpUConvert %ulong %1113
+OpStore %540 %1114
+OpBranch %294
+%294 = OpLabel
+%1115 = OpLoad %ulong %502
+OpStore %636 %1115
+OpStore %637 %ulong_0
+OpBranch %295
+%295 = OpLabel
+%1116 = OpLoad %ulong %637
+%1117 = OpULessThan %bool %1116 %ulong_8
+OpStore %629 %1117
+%1118 = OpLoad %bool %629
+OpLoopMerge %297 %338 None
+OpBranchConditional %1118 %296 %297
+%297 = OpLabel
+OpBranch %298
+%298 = OpLabel
+OpBranch %236
+%236 = OpLabel
+%1119 = OpLoad %ulong %527
+%1120 = OpIAdd %ulong %1119 %ulong_1
+OpStore %454 %1120
+%1121 = OpLoad %ulong %636
+OpStore %502 %1121
+%1122 = OpLoad %ulong %454
+OpStore %527 %1122
+OpBranch %339
+%296 = OpLabel
+%1123 = OpLoad %ulong %637
+%1124 = OpIMul %ulong %1123 %ulong_8
+OpStore %630 %1124
+%1125 = OpLoad %ulong %540
+%1126 = OpLoad %ulong %630
+%1127 = OpShiftRightLogical %ulong %1125 %1126
+OpStore %631 %1127
+%1128 = OpLoad %ulong %631
+%1129 = OpBitwiseAnd %ulong %1128 %ulong_255
+OpStore %632 %1129
+%1130 = OpLoad %ulong %636
+%1131 = OpLoad %ulong %632
+%1132 = OpBitwiseXor %ulong %1130 %1131
+OpStore %633 %1132
+%1133 = OpLoad %ulong %633
+%1134 = OpIMul %ulong %1133 %ulong_1099511628211
+OpStore %634 %1134
+%1135 = OpLoad %ulong %637
+%1136 = OpIAdd %ulong %1135 %ulong_1
+OpStore %635 %1136
+%1137 = OpLoad %ulong %634
+OpStore %636 %1137
+%1138 = OpLoad %ulong %635
+OpStore %637 %1138
+OpBranch %338
+%188 = OpLabel
+%1139 = OpLoad %ulong %523
+%1141 = OpIMul %ulong %1139 %ulong_9
+OpStore %441 %1141
+%1142 = OpLoad %ulong %523
+%1143 = OpAccessChain %_ptr_Function__arr__arr_uchar_uint_3_uint_3 %378 %1142
+OpStore %524 %ulong_0
+OpBranch %190
+%190 = OpLabel
+%1144 = OpLoad %ulong %524
+%1145 = OpULessThan %bool %1144 %ulong_3
+OpStore %439 %1145
+%1146 = OpLoad %bool %439
+OpLoopMerge %192 %344 None
+OpBranchConditional %1146 %191 %192
+%192 = OpLabel
+%1147 = OpLoad %ulong %523
+%1148 = OpIAdd %ulong %1147 %ulong_1
+OpStore %449 %1148
+%1149 = OpLoad %ulong %449
+OpStore %523 %1149
+OpBranch %348
+%191 = OpLabel
+%1150 = OpLoad %ulong %524
+%1151 = OpIMul %ulong %1150 %ulong_3
+OpStore %442 %1151
+%1152 = OpLoad %ulong %441
+%1153 = OpLoad %ulong %442
+%1154 = OpIAdd %ulong %1152 %1153
+OpStore %443 %1154
+%1155 = OpLoad %ulong %524
+%1156 = OpAccessChain %_ptr_Function__arr_uchar_uint_3 %1143 %1155
+OpStore %525 %ulong_0
+OpBranch %193
+%193 = OpLabel
+%1157 = OpLoad %ulong %525
+%1158 = OpULessThan %bool %1157 %ulong_3
+OpStore %440 %1158
+%1159 = OpLoad %bool %440
+OpLoopMerge %195 %341 None
+OpBranchConditional %1159 %194 %195
+%195 = OpLabel
+%1160 = OpLoad %ulong %524
+%1161 = OpIAdd %ulong %1160 %ulong_1
+OpStore %448 %1161
+%1162 = OpLoad %ulong %448
+OpStore %524 %1162
+OpBranch %344
+%194 = OpLabel
+%1163 = OpLoad %ulong %443
+%1164 = OpLoad %ulong %525
+%1165 = OpIAdd %ulong %1163 %1164
+OpStore %444 %1165
+%1166 = OpLoad %ulong %444
+%1167 = OpLoad %ulong %389
+%1168 = OpIAdd %ulong %1166 %1167
+OpStore %445 %1168
+%1169 = OpLoad %ulong %445
+%1170 = OpUConvert %uchar %1169
+OpStore %446 %1170
+%1171 = OpLoad %ulong %525
+%1172 = OpAccessChain %_ptr_Function_uchar %1156 %1171
+%1173 = OpLoad %uchar %446
+OpStore %1172 %1173
+%1174 = OpLoad %ulong %525
+%1175 = OpIAdd %ulong %1174 %ulong_1
+OpStore %447 %1175
+%1176 = OpLoad %ulong %447
+OpStore %525 %1176
+OpBranch %341
+%182 = OpLabel
+%1177 = OpLoad %ulong %506
+OpStore %505 %1177
+OpStore %516 %ulong_0
+OpBranch %184
+%184 = OpLabel
+%1178 = OpLoad %ulong %516
+%1179 = OpULessThan %bool %1178 %ulong_4
+OpStore %434 %1179
+%1180 = OpLoad %bool %434
+OpLoopMerge %186 %347 None
+OpBranchConditional %1180 %185 %186
+%186 = OpLabel
+%1181 = OpLoad %ulong %521
+%1182 = OpIAdd %ulong %1181 %ulong_1
+OpStore %437 %1182
+%1183 = OpLoad %ulong %505
+OpStore %506 %1183
+%1184 = OpLoad %ulong %437
+OpStore %521 %1184
+OpBranch %350
+%185 = OpLabel
+%1185 = OpLoad %ulong %516
+%1186 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %1185
+%1187 = OpLoad %ulong %521
+%1188 = OpAccessChain %_ptr_Function_ushort %1186 %1187
+%1189 = OpLoad %ushort %1188
+OpStore %435 %1189
+OpBranch %231
+%231 = OpLabel
+%1190 = OpLoad %ushort %435
+%1191 = OpUConvert %ulong %1190
+OpStore %538 %1191
+OpBranch %282
+%282 = OpLabel
+%1192 = OpLoad %ulong %505
+OpStore %616 %1192
+OpStore %617 %ulong_0
+OpBranch %283
+%283 = OpLabel
+%1193 = OpLoad %ulong %617
+%1194 = OpULessThan %bool %1193 %ulong_8
+OpStore %609 %1194
+%1195 = OpLoad %bool %609
+OpLoopMerge %285 %343 None
+OpBranchConditional %1195 %284 %285
+%285 = OpLabel
+OpBranch %286
+%286 = OpLabel
+OpBranch %232
+%232 = OpLabel
+%1196 = OpLoad %ulong %516
+%1197 = OpIAdd %ulong %1196 %ulong_1
+OpStore %436 %1197
+%1198 = OpLoad %ulong %616
+OpStore %505 %1198
+%1199 = OpLoad %ulong %436
+OpStore %516 %1199
+OpBranch %347
+%284 = OpLabel
+%1200 = OpLoad %ulong %617
+%1201 = OpIMul %ulong %1200 %ulong_8
+OpStore %610 %1201
+%1202 = OpLoad %ulong %538
+%1203 = OpLoad %ulong %610
+%1204 = OpShiftRightLogical %ulong %1202 %1203
+OpStore %611 %1204
+%1205 = OpLoad %ulong %611
+%1206 = OpBitwiseAnd %ulong %1205 %ulong_255
+OpStore %612 %1206
+%1207 = OpLoad %ulong %616
+%1208 = OpLoad %ulong %612
+%1209 = OpBitwiseXor %ulong %1207 %1208
+OpStore %613 %1209
+%1210 = OpLoad %ulong %613
+%1211 = OpIMul %ulong %1210 %ulong_1099511628211
+OpStore %614 %1211
+%1212 = OpLoad %ulong %617
+%1213 = OpIAdd %ulong %1212 %ulong_1
+OpStore %615 %1213
+%1214 = OpLoad %ulong %614
+OpStore %616 %1214
+%1215 = OpLoad %ulong %615
+OpStore %617 %1215
+OpBranch %343
+%176 = OpLabel
+%1216 = OpLoad %ulong %517
+%1217 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %1216
+%1218 = OpLoad %ulong %508
+OpStore %507 %1218
+OpStore %520 %ulong_0
+OpBranch %178
+%178 = OpLabel
+%1219 = OpLoad %ulong %520
+%1220 = OpULessThan %bool %1219 %ulong_6
+OpStore %429 %1220
+%1221 = OpLoad %bool %429
+OpLoopMerge %180 %349 None
+OpBranchConditional %1221 %179 %180
+%180 = OpLabel
+%1222 = OpLoad %ulong %517
+%1223 = OpIAdd %ulong %1222 %ulong_1
+OpStore %432 %1223
+%1224 = OpLoad %ulong %507
+OpStore %508 %1224
+%1225 = OpLoad %ulong %432
+OpStore %517 %1225
+OpBranch %351
+%179 = OpLabel
+%1226 = OpLoad %ulong %520
+%1227 = OpAccessChain %_ptr_Function_ushort %1217 %1226
+%1228 = OpLoad %ushort %1227
+OpStore %430 %1228
+OpBranch %229
+%229 = OpLabel
+%1229 = OpLoad %ushort %430
+%1230 = OpUConvert %ulong %1229
+OpStore %537 %1230
+OpBranch %277
+%277 = OpLabel
+%1231 = OpLoad %ulong %507
+OpStore %607 %1231
+OpStore %608 %ulong_0
+OpBranch %278
+%278 = OpLabel
+%1232 = OpLoad %ulong %608
+%1233 = OpULessThan %bool %1232 %ulong_8
+OpStore %600 %1233
+%1234 = OpLoad %bool %600
+OpLoopMerge %280 %346 None
+OpBranchConditional %1234 %279 %280
+%280 = OpLabel
+OpBranch %281
+%281 = OpLabel
+OpBranch %230
+%230 = OpLabel
+%1235 = OpLoad %ulong %520
+%1236 = OpIAdd %ulong %1235 %ulong_1
+OpStore %431 %1236
+%1237 = OpLoad %ulong %607
+OpStore %507 %1237
+%1238 = OpLoad %ulong %431
+OpStore %520 %1238
+OpBranch %349
+%279 = OpLabel
+%1239 = OpLoad %ulong %608
+%1240 = OpIMul %ulong %1239 %ulong_8
+OpStore %601 %1240
+%1241 = OpLoad %ulong %537
+%1242 = OpLoad %ulong %601
+%1243 = OpShiftRightLogical %ulong %1241 %1242
+OpStore %602 %1243
+%1244 = OpLoad %ulong %602
+%1245 = OpBitwiseAnd %ulong %1244 %ulong_255
+OpStore %603 %1245
+%1246 = OpLoad %ulong %607
+%1247 = OpLoad %ulong %603
+%1248 = OpBitwiseXor %ulong %1246 %1247
+OpStore %604 %1248
+%1249 = OpLoad %ulong %604
+%1250 = OpIMul %ulong %1249 %ulong_1099511628211
+OpStore %605 %1250
+%1251 = OpLoad %ulong %608
+%1252 = OpIAdd %ulong %1251 %ulong_1
+OpStore %606 %1252
+%1253 = OpLoad %ulong %605
+OpStore %607 %1253
+%1254 = OpLoad %ulong %606
+OpStore %608 %1254
+OpBranch %346
+%272 = OpLabel
+%1255 = OpLoad %ulong %597
+%1256 = OpIMul %ulong %1255 %ulong_8
+OpStore %590 %1256
+%1257 = OpLoad %ulong %536
+%1258 = OpLoad %ulong %590
+%1259 = OpShiftRightLogical %ulong %1257 %1258
+OpStore %591 %1259
+%1260 = OpLoad %ulong %591
+%1261 = OpBitwiseAnd %ulong %1260 %ulong_255
+OpStore %592 %1261
+%1262 = OpLoad %ulong %596
+%1263 = OpLoad %ulong %592
+%1264 = OpBitwiseXor %ulong %1262 %1263
+OpStore %593 %1264
+%1265 = OpLoad %ulong %593
+%1266 = OpIMul %ulong %1265 %ulong_1099511628211
+OpStore %594 %1266
+%1267 = OpLoad %ulong %597
+%1268 = OpIAdd %ulong %1267 %ulong_1
+OpStore %595 %1268
+%1269 = OpLoad %ulong %594
+OpStore %596 %1269
+%1270 = OpLoad %ulong %595
+OpStore %597 %1270
+OpBranch %352
+%170 = OpLabel
+%1271 = OpLoad %ulong %518
+%1273 = OpIMul %ulong %1271 %ulong_100
+OpStore %414 %1273
+%1274 = OpLoad %ulong %518
+%1275 = OpAccessChain %_ptr_Function__arr_ushort_uint_6 %372 %1274
+OpStore %519 %ulong_0
+OpBranch %172
+%172 = OpLabel
+%1276 = OpLoad %ulong %519
+%1277 = OpULessThan %bool %1276 %ulong_6
+OpStore %413 %1277
+%1278 = OpLoad %bool %413
+OpLoopMerge %174 %353 None
+OpBranchConditional %1278 %173 %174
+%174 = OpLabel
+%1279 = OpLoad %ulong %518
+%1280 = OpIAdd %ulong %1279 %ulong_1
+OpStore %420 %1280
+%1281 = OpLoad %ulong %420
+OpStore %518 %1281
+OpBranch %355
+%173 = OpLabel
+%1282 = OpLoad %ulong %519
+%1283 = OpIMul %ulong %1282 %ulong_7
+OpStore %415 %1283
+%1284 = OpLoad %ulong %414
+%1285 = OpLoad %ulong %415
+%1286 = OpIAdd %ulong %1284 %1285
+OpStore %416 %1286
+%1287 = OpLoad %ulong %416
+%1288 = OpLoad %ulong %389
+%1289 = OpIAdd %ulong %1287 %1288
+OpStore %417 %1289
+%1290 = OpLoad %ulong %417
+%1291 = OpUConvert %ushort %1290
+OpStore %418 %1291
+%1292 = OpLoad %ulong %519
+%1293 = OpAccessChain %_ptr_Function_ushort %1275 %1292
+%1294 = OpLoad %ushort %418
+OpStore %1293 %1294
+%1295 = OpLoad %ulong %519
+%1296 = OpIAdd %ulong %1295 %ulong_1
+OpStore %419 %1296
+%1297 = OpLoad %ulong %419
+OpStore %519 %1297
+OpBranch %353
+%167 = OpLabel
+%1298 = OpLoad %ulong %512
+%1299 = OpAccessChain %_ptr_Function_uint %384 %1298
+%1300 = OpLoad %uint %1299
+OpStore %410 %1300
+OpBranch %225
+%225 = OpLabel
+%1301 = OpLoad %uint %410
+%1302 = OpUConvert %ulong %1301
+OpStore %535 %1302
+OpBranch %265
+%265 = OpLabel
+%1303 = OpLoad %ulong %509
+OpStore %587 %1303
+OpStore %588 %ulong_0
+OpBranch %266
+%266 = OpLabel
+%1304 = OpLoad %ulong %588
+%1305 = OpULessThan %bool %1304 %ulong_8
+OpStore %580 %1305
+%1306 = OpLoad %bool %580
+OpLoopMerge %268 %354 None
+OpBranchConditional %1306 %267 %268
+%268 = OpLabel
+OpBranch %269
+%269 = OpLabel
+OpBranch %226
+%226 = OpLabel
+%1307 = OpLoad %ulong %512
+%1308 = OpIAdd %ulong %1307 %ulong_5
+OpStore %411 %1308
+%1309 = OpLoad %ulong %587
+OpStore %509 %1309
+%1310 = OpLoad %ulong %411
+OpStore %512 %1310
+OpBranch %357
+%267 = OpLabel
+%1311 = OpLoad %ulong %588
+%1312 = OpIMul %ulong %1311 %ulong_8
+OpStore %581 %1312
+%1313 = OpLoad %ulong %535
+%1314 = OpLoad %ulong %581
+%1315 = OpShiftRightLogical %ulong %1313 %1314
+OpStore %582 %1315
+%1316 = OpLoad %ulong %582
+%1317 = OpBitwiseAnd %ulong %1316 %ulong_255
+OpStore %583 %1317
+%1318 = OpLoad %ulong %587
+%1319 = OpLoad %ulong %583
+%1320 = OpBitwiseXor %ulong %1318 %1319
+OpStore %584 %1320
+%1321 = OpLoad %ulong %584
+%1322 = OpIMul %ulong %1321 %ulong_1099511628211
+OpStore %585 %1322
+%1323 = OpLoad %ulong %588
+%1324 = OpIAdd %ulong %1323 %ulong_1
+OpStore %586 %1324
+%1325 = OpLoad %ulong %585
+OpStore %587 %1325
+%1326 = OpLoad %ulong %586
+OpStore %588 %1326
+OpBranch %354
+%164 = OpLabel
+%1327 = OpLoad %ulong %513
+%1328 = OpISub %ulong %1327 %ulong_1
+OpStore %407 %1328
+%1329 = OpLoad %ulong %407
+%1330 = OpAccessChain %_ptr_Function_uint %384 %1329
+%1331 = OpLoad %uint %1330
+OpStore %408 %1331
+OpBranch %223
+%223 = OpLabel
+%1332 = OpLoad %uint %408
+%1333 = OpUConvert %ulong %1332
+OpStore %534 %1333
+OpBranch %260
+%260 = OpLabel
+%1334 = OpLoad %ulong %510
+OpStore %578 %1334
+OpStore %579 %ulong_0
+OpBranch %261
+%261 = OpLabel
+%1335 = OpLoad %ulong %579
+%1336 = OpULessThan %bool %1335 %ulong_8
+OpStore %571 %1336
+%1337 = OpLoad %bool %571
+OpLoopMerge %263 %356 None
+OpBranchConditional %1337 %262 %263
+%263 = OpLabel
+OpBranch %264
+%264 = OpLabel
+OpBranch %224
+%224 = OpLabel
+%1338 = OpLoad %ulong %578
+OpStore %510 %1338
+%1339 = OpLoad %ulong %407
+OpStore %513 %1339
+OpBranch %359
+%262 = OpLabel
+%1340 = OpLoad %ulong %579
+%1341 = OpIMul %ulong %1340 %ulong_8
+OpStore %572 %1341
+%1342 = OpLoad %ulong %534
+%1343 = OpLoad %ulong %572
+%1344 = OpShiftRightLogical %ulong %1342 %1343
+OpStore %573 %1344
+%1345 = OpLoad %ulong %573
+%1346 = OpBitwiseAnd %ulong %1345 %ulong_255
+OpStore %574 %1346
+%1347 = OpLoad %ulong %578
+%1348 = OpLoad %ulong %574
+%1349 = OpBitwiseXor %ulong %1347 %1348
+OpStore %575 %1349
+%1350 = OpLoad %ulong %575
+%1351 = OpIMul %ulong %1350 %ulong_1099511628211
+OpStore %576 %1351
+%1352 = OpLoad %ulong %579
+%1353 = OpIAdd %ulong %1352 %ulong_1
+OpStore %577 %1353
+%1354 = OpLoad %ulong %576
+OpStore %578 %1354
+%1355 = OpLoad %ulong %577
+OpStore %579 %1355
+OpBranch %356
+%161 = OpLabel
+%1356 = OpLoad %ulong %514
+%1357 = OpIMul %ulong %1356 %ulong_7
+OpStore %401 %1357
+%1358 = OpLoad %ulong %401
+%1359 = OpLoad %ulong %389
+%1360 = OpIAdd %ulong %1358 %1359
+OpStore %402 %1360
+%1361 = OpLoad %ulong %402
+%1363 = OpBitwiseAnd %ulong %1361 %ulong_31
+OpStore %403 %1363
+%1364 = OpLoad %ulong %403
+%1365 = OpAccessChain %_ptr_Function_uint %384 %1364
+%1366 = OpLoad %uint %1365
+OpStore %404 %1366
+OpBranch %221
+%221 = OpLabel
+%1367 = OpLoad %uint %404
+%1368 = OpUConvert %ulong %1367
+OpStore %533 %1368
+OpBranch %255
+%255 = OpLabel
+%1369 = OpLoad %ulong %511
+OpStore %569 %1369
+OpStore %570 %ulong_0
+OpBranch %256
+%256 = OpLabel
+%1370 = OpLoad %ulong %570
+%1371 = OpULessThan %bool %1370 %ulong_8
+OpStore %562 %1371
+%1372 = OpLoad %bool %562
+OpLoopMerge %258 %358 None
+OpBranchConditional %1372 %257 %258
+%258 = OpLabel
+OpBranch %259
+%259 = OpLabel
+OpBranch %222
+%222 = OpLabel
+%1373 = OpLoad %ulong %514
+%1374 = OpIAdd %ulong %1373 %ulong_1
+OpStore %405 %1374
+%1375 = OpLoad %ulong %569
+OpStore %511 %1375
+%1376 = OpLoad %ulong %405
+OpStore %514 %1376
+OpBranch %360
+%257 = OpLabel
+%1377 = OpLoad %ulong %570
+%1378 = OpIMul %ulong %1377 %ulong_8
+OpStore %563 %1378
+%1379 = OpLoad %ulong %533
+%1380 = OpLoad %ulong %563
+%1381 = OpShiftRightLogical %ulong %1379 %1380
+OpStore %564 %1381
+%1382 = OpLoad %ulong %564
+%1383 = OpBitwiseAnd %ulong %1382 %ulong_255
+OpStore %565 %1383
+%1384 = OpLoad %ulong %569
+%1385 = OpLoad %ulong %565
+%1386 = OpBitwiseXor %ulong %1384 %1385
+OpStore %566 %1386
+%1387 = OpLoad %ulong %566
+%1388 = OpIMul %ulong %1387 %ulong_1099511628211
+OpStore %567 %1388
+%1389 = OpLoad %ulong %570
+%1390 = OpIAdd %ulong %1389 %ulong_1
+OpStore %568 %1390
+%1391 = OpLoad %ulong %567
+OpStore %569 %1391
+%1392 = OpLoad %ulong %568
+OpStore %570 %1392
+OpBranch %358
+%250 = OpLabel
+%1393 = OpLoad %ulong %559
+%1394 = OpIMul %ulong %1393 %ulong_8
+OpStore %552 %1394
+%1395 = OpLoad %ulong %532
+%1396 = OpLoad %ulong %552
+%1397 = OpShiftRightLogical %ulong %1395 %1396
+OpStore %553 %1397
+%1398 = OpLoad %ulong %553
+%1399 = OpBitwiseAnd %ulong %1398 %ulong_255
+OpStore %554 %1399
+%1400 = OpLoad %ulong %558
+%1401 = OpLoad %ulong %554
+%1402 = OpBitwiseXor %ulong %1400 %1401
+OpStore %555 %1402
+%1403 = OpLoad %ulong %555
+%1404 = OpIMul %ulong %1403 %ulong_1099511628211
+OpStore %556 %1404
+%1405 = OpLoad %ulong %559
+%1406 = OpIAdd %ulong %1405 %ulong_1
+OpStore %557 %1406
+%1407 = OpLoad %ulong %556
+OpStore %558 %1407
+%1408 = OpLoad %ulong %557
+OpStore %559 %1408
+OpBranch %361
+%158 = OpLabel
+%1409 = OpLoad %ulong %515
+%1410 = OpIAdd %ulong %1409 %ulong_1
+OpStore %391 %1410
+%1412 = OpLoad %ulong %391
+%1413 = OpIMul %ulong %ulong_2654435761 %1412
+OpStore %392 %1413
+%1414 = OpLoad %ulong %392
+%1415 = OpLoad %ulong %389
+%1416 = OpIAdd %ulong %1414 %1415
+OpStore %393 %1416
+%1417 = OpLoad %ulong %393
+%1418 = OpUConvert %uint %1417
+OpStore %395 %1418
+%1419 = OpLoad %ulong %515
+%1420 = OpAccessChain %_ptr_Function_uint %384 %1419
+%1421 = OpLoad %uint %395
+OpStore %1420 %1421
+%1422 = OpLoad %ulong %391
+OpStore %515 %1422
+OpBranch %362
+%330 = OpLabel
+OpBranch %307
+%331 = OpLabel
+OpBranch %312
+%332 = OpLabel
+OpBranch %214
+%333 = OpLabel
+OpBranch %302
+%334 = OpLabel
+OpBranch %211
+%335 = OpLabel
+OpBranch %238
+%336 = OpLabel
+OpBranch %208
+%337 = OpLabel
+OpBranch %205
+%338 = OpLabel
+OpBranch %295
+%339 = OpLabel
+OpBranch %202
+%340 = OpLabel
+OpBranch %288
+%341 = OpLabel
+OpBranch %193
+%342 = OpLabel
+OpBranch %199
+%343 = OpLabel
+OpBranch %283
+%344 = OpLabel
+OpBranch %190
+%345 = OpLabel
+OpBranch %196
+%346 = OpLabel
+OpBranch %278
+%347 = OpLabel
+OpBranch %184
+%348 = OpLabel
+OpBranch %187
+%349 = OpLabel
+OpBranch %178
+%350 = OpLabel
+OpBranch %181
+%351 = OpLabel
+OpBranch %175
+%352 = OpLabel
+OpBranch %271
+%353 = OpLabel
+OpBranch %172
+%354 = OpLabel
+OpBranch %266
+%355 = OpLabel
+OpBranch %169
+%356 = OpLabel
+OpBranch %261
+%357 = OpLabel
+OpBranch %166
+%358 = OpLabel
+OpBranch %256
+%359 = OpLabel
+OpBranch %163
+%360 = OpLabel
+OpBranch %160
+%361 = OpLabel
+OpBranch %249
+%362 = OpLabel
+OpBranch %157
 OpFunctionEnd
-%3 = OpFunction %ulong None %850
-%851 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %853
-%854 = OpFunctionParameter %ulong
-%855 = OpFunctionParameter %ulong
-%856 = OpLabel
-%861 = OpVariable %_ptr_Function_ulong Function
-%862 = OpVariable %_ptr_Function_ulong Function
-%863 = OpVariable %_ptr_Function_bool Function
-%864 = OpVariable %_ptr_Function_ulong Function
-%865 = OpVariable %_ptr_Function_ulong Function
-%866 = OpVariable %_ptr_Function_ulong Function
-%867 = OpVariable %_ptr_Function_ulong Function
-%868 = OpVariable %_ptr_Function_ulong Function
-%869 = OpVariable %_ptr_Function_ulong Function
-%870 = OpVariable %_ptr_Function_ulong Function
-%871 = OpVariable %_ptr_Function_ulong Function
-OpStore %861 %854
-OpStore %862 %855
-%872 = OpLoad %ulong %861
-OpStore %870 %872
-OpStore %871 %ulong_0
-OpBranch %857
-%857 = OpLabel
-%873 = OpLoad %ulong %871
-%875 = OpULessThan %bool %873 %ulong_8
-OpStore %863 %875
-%876 = OpLoad %bool %863
-OpLoopMerge %859 %860 None
-OpBranchConditional %876 %858 %859
-%859 = OpLabel
-%877 = OpLoad %ulong %870
-OpReturnValue %877
-%858 = OpLabel
-%878 = OpLoad %ulong %871
-%879 = OpIMul %ulong %878 %ulong_8
-OpStore %864 %879
-%880 = OpLoad %ulong %862
-%881 = OpLoad %ulong %864
-%882 = OpShiftRightLogical %ulong %880 %881
-OpStore %865 %882
-%883 = OpLoad %ulong %865
-%885 = OpBitwiseAnd %ulong %883 %ulong_255
-OpStore %866 %885
-%886 = OpLoad %ulong %870
-%887 = OpLoad %ulong %866
-%888 = OpBitwiseXor %ulong %886 %887
-OpStore %867 %888
-%889 = OpLoad %ulong %867
-%890 = OpIMul %ulong %889 %ulong_1099511628211
-OpStore %868 %890
-%891 = OpLoad %ulong %871
-%892 = OpIAdd %ulong %891 %ulong_1
-OpStore %869 %892
-%893 = OpLoad %ulong %868
-OpStore %870 %893
-%894 = OpLoad %ulong %869
-OpStore %871 %894
-OpBranch %860
-%860 = OpLabel
-OpBranch %857
-OpFunctionEnd
-%5 = OpFunction %ulong None %895
-%896 = OpFunctionParameter %ulong
-%897 = OpFunctionParameter %uchar
-%898 = OpLabel
-%905 = OpVariable %_ptr_Function_ulong Function
-%906 = OpVariable %_ptr_Function_uchar Function
-%907 = OpVariable %_ptr_Function_ulong Function
-%908 = OpVariable %_ptr_Function_bool Function
-%909 = OpVariable %_ptr_Function_ulong Function
-%910 = OpVariable %_ptr_Function_ulong Function
-%911 = OpVariable %_ptr_Function_ulong Function
-%912 = OpVariable %_ptr_Function_ulong Function
-%913 = OpVariable %_ptr_Function_ulong Function
-%914 = OpVariable %_ptr_Function_ulong Function
-%915 = OpVariable %_ptr_Function_ulong Function
-%916 = OpVariable %_ptr_Function_ulong Function
-OpStore %905 %896
-OpStore %906 %897
-%917 = OpLoad %uchar %906
-%918 = OpUConvert %ulong %917
-OpStore %907 %918
-OpBranch %899
-%899 = OpLabel
-%919 = OpLoad %ulong %905
-OpStore %915 %919
-OpStore %916 %ulong_0
-OpBranch %900
-%900 = OpLabel
-%920 = OpLoad %ulong %916
-%921 = OpULessThan %bool %920 %ulong_8
-OpStore %908 %921
-%922 = OpLoad %bool %908
-OpLoopMerge %902 %904 None
-OpBranchConditional %922 %901 %902
-%902 = OpLabel
-OpBranch %903
-%903 = OpLabel
-%923 = OpLoad %ulong %915
-OpReturnValue %923
-%901 = OpLabel
-%924 = OpLoad %ulong %916
-%925 = OpIMul %ulong %924 %ulong_8
-OpStore %909 %925
-%926 = OpLoad %ulong %907
-%927 = OpLoad %ulong %909
-%928 = OpShiftRightLogical %ulong %926 %927
-OpStore %910 %928
-%929 = OpLoad %ulong %910
-%930 = OpBitwiseAnd %ulong %929 %ulong_255
-OpStore %911 %930
-%931 = OpLoad %ulong %915
-%932 = OpLoad %ulong %911
-%933 = OpBitwiseXor %ulong %931 %932
-OpStore %912 %933
-%934 = OpLoad %ulong %912
-%935 = OpIMul %ulong %934 %ulong_1099511628211
-OpStore %913 %935
-%936 = OpLoad %ulong %916
-%937 = OpIAdd %ulong %936 %ulong_1
-OpStore %914 %937
-%938 = OpLoad %ulong %913
-OpStore %915 %938
-%939 = OpLoad %ulong %914
-OpStore %916 %939
-OpBranch %904
-%904 = OpLabel
-OpBranch %900
-OpFunctionEnd
-%6 = OpFunction %ulong None %940
-%941 = OpFunctionParameter %ulong
-%942 = OpFunctionParameter %ushort
-%943 = OpLabel
-%950 = OpVariable %_ptr_Function_ulong Function
-%951 = OpVariable %_ptr_Function_ushort Function
-%952 = OpVariable %_ptr_Function_ulong Function
-%953 = OpVariable %_ptr_Function_bool Function
-%954 = OpVariable %_ptr_Function_ulong Function
-%955 = OpVariable %_ptr_Function_ulong Function
-%956 = OpVariable %_ptr_Function_ulong Function
-%957 = OpVariable %_ptr_Function_ulong Function
-%958 = OpVariable %_ptr_Function_ulong Function
-%959 = OpVariable %_ptr_Function_ulong Function
-%960 = OpVariable %_ptr_Function_ulong Function
-%961 = OpVariable %_ptr_Function_ulong Function
-OpStore %950 %941
-OpStore %951 %942
-%962 = OpLoad %ushort %951
-%963 = OpUConvert %ulong %962
-OpStore %952 %963
-OpBranch %944
-%944 = OpLabel
-%964 = OpLoad %ulong %950
-OpStore %960 %964
-OpStore %961 %ulong_0
-OpBranch %945
-%945 = OpLabel
-%965 = OpLoad %ulong %961
-%966 = OpULessThan %bool %965 %ulong_8
-OpStore %953 %966
-%967 = OpLoad %bool %953
-OpLoopMerge %947 %949 None
-OpBranchConditional %967 %946 %947
-%947 = OpLabel
-OpBranch %948
-%948 = OpLabel
-%968 = OpLoad %ulong %960
-OpReturnValue %968
-%946 = OpLabel
-%969 = OpLoad %ulong %961
-%970 = OpIMul %ulong %969 %ulong_8
-OpStore %954 %970
-%971 = OpLoad %ulong %952
-%972 = OpLoad %ulong %954
-%973 = OpShiftRightLogical %ulong %971 %972
-OpStore %955 %973
-%974 = OpLoad %ulong %955
-%975 = OpBitwiseAnd %ulong %974 %ulong_255
-OpStore %956 %975
-%976 = OpLoad %ulong %960
-%977 = OpLoad %ulong %956
-%978 = OpBitwiseXor %ulong %976 %977
-OpStore %957 %978
-%979 = OpLoad %ulong %957
-%980 = OpIMul %ulong %979 %ulong_1099511628211
-OpStore %958 %980
-%981 = OpLoad %ulong %961
-%982 = OpIAdd %ulong %981 %ulong_1
-OpStore %959 %982
-%983 = OpLoad %ulong %958
-OpStore %960 %983
-%984 = OpLoad %ulong %959
-OpStore %961 %984
-OpBranch %949
-%949 = OpLabel
-OpBranch %945
-OpFunctionEnd
-%7 = OpFunction %ulong None %985
-%986 = OpFunctionParameter %ulong
-%987 = OpFunctionParameter %uint
-%988 = OpLabel
-%995 = OpVariable %_ptr_Function_ulong Function
-%996 = OpVariable %_ptr_Function_uint Function
-%997 = OpVariable %_ptr_Function_ulong Function
-%998 = OpVariable %_ptr_Function_bool Function
-%999 = OpVariable %_ptr_Function_ulong Function
-%1000 = OpVariable %_ptr_Function_ulong Function
-%1001 = OpVariable %_ptr_Function_ulong Function
-%1002 = OpVariable %_ptr_Function_ulong Function
-%1003 = OpVariable %_ptr_Function_ulong Function
-%1004 = OpVariable %_ptr_Function_ulong Function
-%1005 = OpVariable %_ptr_Function_ulong Function
-%1006 = OpVariable %_ptr_Function_ulong Function
-OpStore %995 %986
-OpStore %996 %987
-%1007 = OpLoad %uint %996
-%1008 = OpUConvert %ulong %1007
-OpStore %997 %1008
-OpBranch %989
-%989 = OpLabel
-%1009 = OpLoad %ulong %995
-OpStore %1005 %1009
-OpStore %1006 %ulong_0
-OpBranch %990
-%990 = OpLabel
-%1010 = OpLoad %ulong %1006
-%1011 = OpULessThan %bool %1010 %ulong_8
-OpStore %998 %1011
-%1012 = OpLoad %bool %998
-OpLoopMerge %992 %994 None
-OpBranchConditional %1012 %991 %992
-%992 = OpLabel
-OpBranch %993
-%993 = OpLabel
-%1013 = OpLoad %ulong %1005
-OpReturnValue %1013
-%991 = OpLabel
-%1014 = OpLoad %ulong %1006
-%1015 = OpIMul %ulong %1014 %ulong_8
-OpStore %999 %1015
-%1016 = OpLoad %ulong %997
-%1017 = OpLoad %ulong %999
-%1018 = OpShiftRightLogical %ulong %1016 %1017
-OpStore %1000 %1018
-%1019 = OpLoad %ulong %1000
-%1020 = OpBitwiseAnd %ulong %1019 %ulong_255
-OpStore %1001 %1020
-%1021 = OpLoad %ulong %1005
-%1022 = OpLoad %ulong %1001
-%1023 = OpBitwiseXor %ulong %1021 %1022
-OpStore %1002 %1023
-%1024 = OpLoad %ulong %1002
-%1025 = OpIMul %ulong %1024 %ulong_1099511628211
-OpStore %1003 %1025
-%1026 = OpLoad %ulong %1006
-%1027 = OpIAdd %ulong %1026 %ulong_1
-OpStore %1004 %1027
-%1028 = OpLoad %ulong %1003
-OpStore %1005 %1028
-%1029 = OpLoad %ulong %1004
-OpStore %1006 %1029
-OpBranch %994
-%994 = OpLabel
-OpBranch %990
+%3 = OpFunction %ulong None %1423
+%1424 = OpFunctionParameter %ulong
+%1425 = OpFunctionParameter %ulong
+%1426 = OpLabel
+%1431 = OpVariable %_ptr_Function_ulong Function
+%1432 = OpVariable %_ptr_Function_ulong Function
+%1433 = OpVariable %_ptr_Function_bool Function
+%1434 = OpVariable %_ptr_Function_ulong Function
+%1435 = OpVariable %_ptr_Function_ulong Function
+%1436 = OpVariable %_ptr_Function_ulong Function
+%1437 = OpVariable %_ptr_Function_ulong Function
+%1438 = OpVariable %_ptr_Function_ulong Function
+%1439 = OpVariable %_ptr_Function_ulong Function
+%1440 = OpVariable %_ptr_Function_ulong Function
+%1441 = OpVariable %_ptr_Function_ulong Function
+OpStore %1431 %1424
+OpStore %1432 %1425
+%1442 = OpLoad %ulong %1431
+OpStore %1440 %1442
+OpStore %1441 %ulong_0
+OpBranch %1427
+%1427 = OpLabel
+%1443 = OpLoad %ulong %1441
+%1444 = OpULessThan %bool %1443 %ulong_8
+OpStore %1433 %1444
+%1445 = OpLoad %bool %1433
+OpLoopMerge %1429 %1430 None
+OpBranchConditional %1445 %1428 %1429
+%1429 = OpLabel
+%1446 = OpLoad %ulong %1440
+OpReturnValue %1446
+%1428 = OpLabel
+%1447 = OpLoad %ulong %1441
+%1448 = OpIMul %ulong %1447 %ulong_8
+OpStore %1434 %1448
+%1449 = OpLoad %ulong %1432
+%1450 = OpLoad %ulong %1434
+%1451 = OpShiftRightLogical %ulong %1449 %1450
+OpStore %1435 %1451
+%1452 = OpLoad %ulong %1435
+%1453 = OpBitwiseAnd %ulong %1452 %ulong_255
+OpStore %1436 %1453
+%1454 = OpLoad %ulong %1440
+%1455 = OpLoad %ulong %1436
+%1456 = OpBitwiseXor %ulong %1454 %1455
+OpStore %1437 %1456
+%1457 = OpLoad %ulong %1437
+%1458 = OpIMul %ulong %1457 %ulong_1099511628211
+OpStore %1438 %1458
+%1459 = OpLoad %ulong %1441
+%1460 = OpIAdd %ulong %1459 %ulong_1
+OpStore %1439 %1460
+%1461 = OpLoad %ulong %1438
+OpStore %1440 %1461
+%1462 = OpLoad %ulong %1439
+OpStore %1441 %1462
+OpBranch %1430
+%1430 = OpLabel
+OpBranch %1427
 OpFunctionEnd

--- a/test/golden/spirv/mem/loadstore.dis
+++ b/test/golden/spirv/mem/loadstore.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 759
+; Bound: 1002
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,10 +15,12 @@ OpDecorate %2 LinkageAttributes "corpus.cases.mem.loadstore.checksum" Export
 %uchar = OpTypeInt 8 0
 %ushort = OpTypeInt 16 0
 %uint = OpTypeInt 32 0
-%_struct_16 = OpTypeStruct %uchar %uchar %uchar %uchar %ushort %ushort %uint %ulong
-%17 = OpTypeFunction %ulong %ulong %_struct_16
-%_ptr_Function__struct_16 = OpTypePointer Function %_struct_16
+%_struct_8 = OpTypeStruct %uchar %uchar %uchar %uchar %ushort %ushort %uint %ulong
+%9 = OpTypeFunction %ulong %ulong %_struct_8
+%bool = OpTypeBool
+%_ptr_Function__struct_8 = OpTypePointer Function %_struct_8
 %_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_uint = OpTypePointer Function %uint
@@ -30,739 +32,646 @@ OpDecorate %2 LinkageAttributes "corpus.cases.mem.loadstore.checksum" Export
 %uint_5 = OpConstant %uint 5
 %uint_6 = OpConstant %uint 6
 %uint_7 = OpConstant %uint 7
-%93 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%375 = OpTypeFunction %ulong %ulong
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
-%_ptr_Function_bool = OpTypePointer Function %bool
-%197 = OpConstantNull %_struct_16
+%610 = OpConstantNull %_struct_8
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_18364758544493064720 = OpConstant %ulong 18364758544493064720
-%ulong_8 = OpConstant %ulong 8
 %ulong_16 = OpConstant %ulong 16
 %ulong_24 = OpConstant %ulong 24
 %ulong_32 = OpConstant %ulong 32
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%261 = OpConstantNull %_arr_uchar_uint_16
+%672 = OpConstantNull %_arr_uchar_uint_16
 %ulong_11400714819323198485 = OpConstant %ulong 11400714819323198485
-%ulong_1 = OpConstant %ulong 1
 %ulong_7 = OpConstant %ulong 7
 %ulong_3 = OpConstant %ulong 3
 %ulong_5 = OpConstant %ulong 5
-%406 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%409 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%451 = OpTypeFunction %ulong %ulong %uchar
-%496 = OpTypeFunction %ulong %ulong %ushort
-%541 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %17
-%18 = OpFunctionParameter %ulong
-%19 = OpFunctionParameter %_struct_16
-%20 = OpLabel
-%22 = OpVariable %_ptr_Function__struct_16 Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_uchar Function
-%36 = OpVariable %_ptr_Function_uchar Function
-%37 = OpVariable %_ptr_Function_uchar Function
-%39 = OpVariable %_ptr_Function_ushort Function
-%40 = OpVariable %_ptr_Function_ushort Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_ulong Function
-OpStore %24 %18
-OpStore %22 %19
-%45 = OpAccessChain %_ptr_Function_uchar %22 %uint_0
-%46 = OpLoad %uchar %45
-OpStore %34 %46
-%48 = OpAccessChain %_ptr_Function_uchar %22 %uint_1
-%49 = OpLoad %uchar %48
-OpStore %35 %49
-%51 = OpAccessChain %_ptr_Function_uchar %22 %uint_2
-%52 = OpLoad %uchar %51
-OpStore %36 %52
-%54 = OpAccessChain %_ptr_Function_uchar %22 %uint_3
-%55 = OpLoad %uchar %54
-OpStore %37 %55
-%57 = OpAccessChain %_ptr_Function_ushort %22 %uint_4
-%58 = OpLoad %ushort %57
-OpStore %39 %58
-%60 = OpAccessChain %_ptr_Function_ushort %22 %uint_5
-%61 = OpLoad %ushort %60
-OpStore %40 %61
-%63 = OpAccessChain %_ptr_Function_uint %22 %uint_6
-%64 = OpLoad %uint %63
-OpStore %42 %64
-%66 = OpAccessChain %_ptr_Function_ulong %22 %uint_7
-%67 = OpLoad %ulong %66
-OpStore %43 %67
-%68 = OpLoad %ulong %24
-%69 = OpLoad %uchar %34
-%70 = OpFunctionCall %ulong %5 %68 %69
-OpStore %25 %70
-%71 = OpLoad %ulong %25
-%72 = OpLoad %uchar %35
-%73 = OpFunctionCall %ulong %5 %71 %72
-OpStore %26 %73
-%74 = OpLoad %ulong %26
-%75 = OpLoad %uchar %36
-%76 = OpFunctionCall %ulong %5 %74 %75
-OpStore %27 %76
-%77 = OpLoad %ulong %27
-%78 = OpLoad %uchar %37
-%79 = OpFunctionCall %ulong %5 %77 %78
-OpStore %28 %79
-%80 = OpLoad %ulong %28
-%81 = OpLoad %ushort %39
-%82 = OpFunctionCall %ulong %6 %80 %81
-OpStore %29 %82
-%83 = OpLoad %ulong %29
-%84 = OpLoad %ushort %40
-%85 = OpFunctionCall %ulong %6 %83 %84
-OpStore %30 %85
-%86 = OpLoad %ulong %30
-%87 = OpLoad %uint %42
-%88 = OpFunctionCall %ulong %7 %86 %87
-OpStore %31 %88
-%89 = OpLoad %ulong %31
-%90 = OpLoad %ulong %43
-%91 = OpFunctionCall %ulong %4 %89 %90
-OpStore %32 %91
-%92 = OpLoad %ulong %32
-OpReturnValue %92
-OpFunctionEnd
-%2 = OpFunction %ulong None %93
-%94 = OpFunctionParameter %ulong
-%95 = OpLabel
-%113 = OpVariable %_ptr_Function__struct_16 Function
-%114 = OpVariable %_ptr_Function__struct_16 Function
-%115 = OpVariable %_ptr_Function__struct_16 Function
-%116 = OpVariable %_ptr_Function__struct_16 Function
-%120 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%962 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %_struct_8
+%12 = OpLabel
+%77 = OpVariable %_ptr_Function__struct_8 Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_bool Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_bool Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_bool Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
 %121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_bool Function
 %123 = OpVariable %_ptr_Function_ulong Function
 %124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_uchar Function
+%125 = OpVariable %_ptr_Function_ulong Function
 %126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_uchar Function
+%127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_uchar Function
+%129 = OpVariable %_ptr_Function_ulong Function
 %130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_uchar Function
-%132 = OpVariable %_ptr_Function_ushort Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_bool Function
 %133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_ushort Function
-%135 = OpVariable %_ptr_Function_uint Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
 %136 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_bool Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
 %139 = OpVariable %_ptr_Function_ulong Function
 %140 = OpVariable %_ptr_Function_ulong Function
 %141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function_uchar Function
+%142 = OpVariable %_ptr_Function_bool Function
 %143 = OpVariable %_ptr_Function_ulong Function
-%144 = OpVariable %_ptr_Function_ushort Function
+%144 = OpVariable %_ptr_Function_ulong Function
 %145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_ulong Function
 %147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_bool Function
+%148 = OpVariable %_ptr_Function_ulong Function
 %149 = OpVariable %_ptr_Function_ulong Function
 %150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_uchar Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
 %153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_ushort Function
+%154 = OpVariable %_ptr_Function_ulong Function
 %155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_uint Function
+%156 = OpVariable %_ptr_Function_ulong Function
 %157 = OpVariable %_ptr_Function_ulong Function
 %158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_uchar Function
+%162 = OpVariable %_ptr_Function_uchar Function
+%163 = OpVariable %_ptr_Function_uchar Function
+%164 = OpVariable %_ptr_Function_uchar Function
+%166 = OpVariable %_ptr_Function_ushort Function
+%167 = OpVariable %_ptr_Function_ushort Function
+%169 = OpVariable %_ptr_Function_uint Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_bool Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_uchar Function
-%178 = OpVariable %_ptr_Function_uchar Function
-%179 = OpVariable %_ptr_Function_uchar Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_bool Function
-%182 = OpVariable %_ptr_Function_uchar Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-OpStore %121 %94
-%196 = OpFunctionCall %ulong %3
-OpStore %122 %196
-OpStore %113 %197
-%198 = OpLoad %_struct_16 %113
-OpStore %114 %198
-%199 = OpLoad %ulong %122
-%200 = OpLoad %_struct_16 %114
-%201 = OpFunctionCall %ulong %1 %199 %200
-OpStore %123 %201
-%203 = OpLoad %ulong %121
-%204 = OpIAdd %ulong %ulong_18364758544493064720 %203
-OpStore %124 %204
-%205 = OpLoad %ulong %124
-%206 = OpUConvert %uchar %205
-OpStore %125 %206
-%207 = OpAccessChain %_ptr_Function_uchar %113 %uint_0
-%208 = OpLoad %uchar %125
-OpStore %207 %208
-%209 = OpLoad %ulong %124
-%211 = OpShiftRightLogical %ulong %209 %ulong_8
-OpStore %126 %211
-%212 = OpLoad %ulong %126
-%213 = OpUConvert %uchar %212
-OpStore %127 %213
-%214 = OpAccessChain %_ptr_Function_uchar %113 %uint_1
-%215 = OpLoad %uchar %127
-OpStore %214 %215
-%216 = OpLoad %ulong %124
-%218 = OpShiftRightLogical %ulong %216 %ulong_16
-OpStore %128 %218
-%219 = OpLoad %ulong %128
-%220 = OpUConvert %uchar %219
-OpStore %129 %220
-%221 = OpAccessChain %_ptr_Function_uchar %113 %uint_2
-%222 = OpLoad %uchar %129
-OpStore %221 %222
-%223 = OpLoad %ulong %124
-%225 = OpShiftRightLogical %ulong %223 %ulong_24
-OpStore %130 %225
-%226 = OpLoad %ulong %130
-%227 = OpUConvert %uchar %226
-OpStore %131 %227
-%228 = OpAccessChain %_ptr_Function_uchar %113 %uint_3
-%229 = OpLoad %uchar %131
-OpStore %228 %229
-%230 = OpLoad %ulong %124
-%231 = OpUConvert %ushort %230
+OpStore %79 %10
+OpStore %77 %11
+%172 = OpAccessChain %_ptr_Function_uchar %77 %uint_0
+%173 = OpLoad %uchar %172
+OpStore %161 %173
+%175 = OpAccessChain %_ptr_Function_uchar %77 %uint_1
+%176 = OpLoad %uchar %175
+OpStore %162 %176
+%178 = OpAccessChain %_ptr_Function_uchar %77 %uint_2
+%179 = OpLoad %uchar %178
+OpStore %163 %179
+%181 = OpAccessChain %_ptr_Function_uchar %77 %uint_3
+%182 = OpLoad %uchar %181
+OpStore %164 %182
+%184 = OpAccessChain %_ptr_Function_ushort %77 %uint_4
+%185 = OpLoad %ushort %184
+OpStore %166 %185
+%187 = OpAccessChain %_ptr_Function_ushort %77 %uint_5
+%188 = OpLoad %ushort %187
+OpStore %167 %188
+%190 = OpAccessChain %_ptr_Function_uint %77 %uint_6
+%191 = OpLoad %uint %190
+OpStore %169 %191
+%193 = OpAccessChain %_ptr_Function_ulong %77 %uint_7
+%194 = OpLoad %ulong %193
+OpStore %170 %194
+OpBranch %13
+%13 = OpLabel
+%195 = OpLoad %uchar %161
+%196 = OpUConvert %ulong %195
+OpStore %80 %196
+OpBranch %15
+%15 = OpLabel
+%197 = OpLoad %ulong %79
+OpStore %89 %197
+OpStore %90 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%199 = OpLoad %ulong %90
+%201 = OpULessThan %bool %199 %ulong_8
+OpStore %82 %201
+%202 = OpLoad %bool %82
+OpLoopMerge %18 %74 None
+OpBranchConditional %202 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%203 = OpLoad %uchar %162
+%204 = OpUConvert %ulong %203
+OpStore %91 %204
+OpBranch %22
+%22 = OpLabel
+%205 = OpLoad %ulong %89
+OpStore %99 %205
+OpStore %100 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%206 = OpLoad %ulong %100
+%207 = OpULessThan %bool %206 %ulong_8
+OpStore %92 %207
+%208 = OpLoad %bool %92
+OpLoopMerge %25 %73 None
+OpBranchConditional %208 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %21
+%21 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%209 = OpLoad %uchar %163
+%210 = OpUConvert %ulong %209
+OpStore %101 %210
+OpBranch %29
+%29 = OpLabel
+%211 = OpLoad %ulong %99
+OpStore %109 %211
+OpStore %110 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%212 = OpLoad %ulong %110
+%213 = OpULessThan %bool %212 %ulong_8
+OpStore %102 %213
+%214 = OpLoad %bool %102
+OpLoopMerge %32 %72 None
+OpBranchConditional %214 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %28
+%28 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%215 = OpLoad %uchar %164
+%216 = OpUConvert %ulong %215
+OpStore %111 %216
+OpBranch %36
+%36 = OpLabel
+%217 = OpLoad %ulong %109
+OpStore %119 %217
+OpStore %120 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%218 = OpLoad %ulong %120
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %112 %219
+%220 = OpLoad %bool %112
+OpLoopMerge %39 %71 None
+OpBranchConditional %220 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%221 = OpLoad %ushort %166
+%222 = OpUConvert %ulong %221
+OpStore %121 %222
+OpBranch %43
+%43 = OpLabel
+%223 = OpLoad %ulong %119
+OpStore %129 %223
+OpStore %130 %ulong_0
+OpBranch %44
+%44 = OpLabel
+%224 = OpLoad %ulong %130
+%225 = OpULessThan %bool %224 %ulong_8
+OpStore %122 %225
+%226 = OpLoad %bool %122
+OpLoopMerge %46 %70 None
+OpBranchConditional %226 %45 %46
+%46 = OpLabel
+OpBranch %47
+%47 = OpLabel
+OpBranch %42
+%42 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%227 = OpLoad %ushort %167
+%228 = OpUConvert %ulong %227
+OpStore %131 %228
+OpBranch %50
+%50 = OpLabel
+%229 = OpLoad %ulong %129
+OpStore %139 %229
+OpStore %140 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%230 = OpLoad %ulong %140
+%231 = OpULessThan %bool %230 %ulong_8
 OpStore %132 %231
-%232 = OpAccessChain %_ptr_Function_ushort %113 %uint_4
-%233 = OpLoad %ushort %132
-OpStore %232 %233
-%234 = OpLoad %ulong %124
-%236 = OpShiftRightLogical %ulong %234 %ulong_32
-OpStore %133 %236
-%237 = OpLoad %ulong %133
-%238 = OpUConvert %ushort %237
-OpStore %134 %238
-%239 = OpAccessChain %_ptr_Function_ushort %113 %uint_5
-%240 = OpLoad %ushort %134
-OpStore %239 %240
-%241 = OpLoad %ulong %124
-%242 = OpUConvert %uint %241
-OpStore %135 %242
-%243 = OpAccessChain %_ptr_Function_uint %113 %uint_6
-%244 = OpLoad %uint %135
-OpStore %243 %244
-%245 = OpAccessChain %_ptr_Function_ulong %113 %uint_7
-%246 = OpLoad %ulong %124
-OpStore %245 %246
-%247 = OpLoad %_struct_16 %113
-OpStore %115 %247
-%248 = OpLoad %ulong %123
-%249 = OpLoad %_struct_16 %115
-%250 = OpFunctionCall %ulong %1 %248 %249
-OpStore %136 %250
-%251 = OpLoad %ulong %136
-OpStore %191 %251
-OpStore %192 %ulong_0
-OpBranch %96
-%96 = OpLabel
-%253 = OpLoad %ulong %192
-%254 = OpULessThan %bool %253 %ulong_8
-OpStore %138 %254
-%255 = OpLoad %bool %138
-OpLoopMerge %98 %111 None
-OpBranchConditional %255 %97 %98
-%98 = OpLabel
-%256 = OpLoad %ulong %191
-OpStore %190 %256
-OpStore %193 %ulong_0
-OpBranch %99
-%99 = OpLabel
-%257 = OpLoad %ulong %193
-%259 = OpULessThan %bool %257 %ulong_6
-OpStore %148 %259
-%260 = OpLoad %bool %148
-OpLoopMerge %101 %110 None
-OpBranchConditional %260 %100 %101
-%101 = OpLabel
-OpStore %120 %261
-OpStore %195 %ulong_0
-OpBranch %102
-%102 = OpLabel
-%262 = OpLoad %ulong %195
-%263 = OpULessThan %bool %262 %ulong_16
-OpStore %173 %263
-%264 = OpLoad %bool %173
-OpLoopMerge %104 %109 None
-OpBranchConditional %264 %103 %104
-%104 = OpLabel
-%265 = OpLoad %ulong %190
-OpStore %189 %265
-OpStore %194 %ulong_0
-OpBranch %105
-%105 = OpLabel
-%266 = OpLoad %ulong %194
-%267 = OpULessThan %bool %266 %ulong_16
-OpStore %181 %267
-%268 = OpLoad %bool %181
-OpLoopMerge %107 %108 None
-OpBranchConditional %268 %106 %107
-%107 = OpLabel
-%269 = OpLoad %ulong %124
-%271 = OpBitwiseXor %ulong %269 %ulong_11400714819323198485
-OpStore %185 %271
-%272 = OpLoad %ulong %189
-%273 = OpLoad %ulong %185
-%274 = OpFunctionCall %ulong %4 %272 %273
-OpStore %186 %274
-%275 = OpLoad %ulong %185
-%277 = OpIAdd %ulong %275 %ulong_1
-OpStore %187 %277
-%278 = OpLoad %ulong %186
-%279 = OpLoad %ulong %187
-%280 = OpFunctionCall %ulong %4 %278 %279
-OpStore %188 %280
-%281 = OpLoad %ulong %188
-OpReturnValue %281
-%106 = OpLabel
-%282 = OpLoad %ulong %194
-%283 = OpAccessChain %_ptr_Function_uchar %120 %282
-%284 = OpLoad %uchar %283
-OpStore %182 %284
-%285 = OpLoad %ulong %189
-%286 = OpLoad %uchar %182
-%287 = OpFunctionCall %ulong %5 %285 %286
-OpStore %183 %287
-%288 = OpLoad %ulong %194
-%289 = OpIAdd %ulong %288 %ulong_1
-OpStore %184 %289
-%290 = OpLoad %ulong %183
-OpStore %189 %290
-%291 = OpLoad %ulong %184
-OpStore %194 %291
-OpBranch %108
-%103 = OpLabel
-%292 = OpLoad %ulong %195
-%294 = OpBitwiseAnd %ulong %292 %ulong_7
-OpStore %174 %294
-%295 = OpLoad %ulong %174
+%232 = OpLoad %bool %132
+OpLoopMerge %53 %69 None
+OpBranchConditional %232 %52 %53
+%53 = OpLabel
+OpBranch %54
+%54 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%233 = OpLoad %uint %169
+%234 = OpUConvert %ulong %233
+OpStore %141 %234
+OpBranch %57
+%57 = OpLabel
+%235 = OpLoad %ulong %139
+OpStore %149 %235
+OpStore %150 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%236 = OpLoad %ulong %150
+%237 = OpULessThan %bool %236 %ulong_8
+OpStore %142 %237
+%238 = OpLoad %bool %142
+OpLoopMerge %60 %68 None
+OpBranchConditional %238 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%239 = OpLoad %ulong %149
+OpStore %158 %239
+OpStore %159 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%240 = OpLoad %ulong %159
+%241 = OpULessThan %bool %240 %ulong_8
+OpStore %151 %241
+%242 = OpLoad %bool %151
+OpLoopMerge %65 %67 None
+OpBranchConditional %242 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+%243 = OpLoad %ulong %158
+OpReturnValue %243
+%64 = OpLabel
+%244 = OpLoad %ulong %159
+%245 = OpIMul %ulong %244 %ulong_8
+OpStore %152 %245
+%246 = OpLoad %ulong %170
+%247 = OpLoad %ulong %152
+%248 = OpShiftRightLogical %ulong %246 %247
+OpStore %153 %248
+%249 = OpLoad %ulong %153
+%251 = OpBitwiseAnd %ulong %249 %ulong_255
+OpStore %154 %251
+%252 = OpLoad %ulong %158
+%253 = OpLoad %ulong %154
+%254 = OpBitwiseXor %ulong %252 %253
+OpStore %155 %254
+%255 = OpLoad %ulong %155
+%257 = OpIMul %ulong %255 %ulong_1099511628211
+OpStore %156 %257
+%258 = OpLoad %ulong %159
+%260 = OpIAdd %ulong %258 %ulong_1
+OpStore %157 %260
+%261 = OpLoad %ulong %156
+OpStore %158 %261
+%262 = OpLoad %ulong %157
+OpStore %159 %262
+OpBranch %67
+%59 = OpLabel
+%263 = OpLoad %ulong %150
+%264 = OpIMul %ulong %263 %ulong_8
+OpStore %143 %264
+%265 = OpLoad %ulong %141
+%266 = OpLoad %ulong %143
+%267 = OpShiftRightLogical %ulong %265 %266
+OpStore %144 %267
+%268 = OpLoad %ulong %144
+%269 = OpBitwiseAnd %ulong %268 %ulong_255
+OpStore %145 %269
+%270 = OpLoad %ulong %149
+%271 = OpLoad %ulong %145
+%272 = OpBitwiseXor %ulong %270 %271
+OpStore %146 %272
+%273 = OpLoad %ulong %146
+%274 = OpIMul %ulong %273 %ulong_1099511628211
+OpStore %147 %274
+%275 = OpLoad %ulong %150
+%276 = OpIAdd %ulong %275 %ulong_1
+OpStore %148 %276
+%277 = OpLoad %ulong %147
+OpStore %149 %277
+%278 = OpLoad %ulong %148
+OpStore %150 %278
+OpBranch %68
+%52 = OpLabel
+%279 = OpLoad %ulong %140
+%280 = OpIMul %ulong %279 %ulong_8
+OpStore %133 %280
+%281 = OpLoad %ulong %131
+%282 = OpLoad %ulong %133
+%283 = OpShiftRightLogical %ulong %281 %282
+OpStore %134 %283
+%284 = OpLoad %ulong %134
+%285 = OpBitwiseAnd %ulong %284 %ulong_255
+OpStore %135 %285
+%286 = OpLoad %ulong %139
+%287 = OpLoad %ulong %135
+%288 = OpBitwiseXor %ulong %286 %287
+OpStore %136 %288
+%289 = OpLoad %ulong %136
+%290 = OpIMul %ulong %289 %ulong_1099511628211
+OpStore %137 %290
+%291 = OpLoad %ulong %140
+%292 = OpIAdd %ulong %291 %ulong_1
+OpStore %138 %292
+%293 = OpLoad %ulong %137
+OpStore %139 %293
+%294 = OpLoad %ulong %138
+OpStore %140 %294
+OpBranch %69
+%45 = OpLabel
+%295 = OpLoad %ulong %130
 %296 = OpIMul %ulong %295 %ulong_8
-OpStore %175 %296
-%297 = OpLoad %ulong %124
-%298 = OpLoad %ulong %175
+OpStore %123 %296
+%297 = OpLoad %ulong %121
+%298 = OpLoad %ulong %123
 %299 = OpShiftRightLogical %ulong %297 %298
-OpStore %176 %299
-%300 = OpLoad %ulong %176
-%301 = OpUConvert %uchar %300
-OpStore %177 %301
-%302 = OpLoad %ulong %195
-%303 = OpUConvert %uchar %302
-OpStore %178 %303
-%304 = OpLoad %uchar %177
-%305 = OpLoad %uchar %178
-%306 = OpIAdd %uchar %304 %305
-OpStore %179 %306
-%307 = OpLoad %ulong %195
-%308 = OpAccessChain %_ptr_Function_uchar %120 %307
-%309 = OpLoad %uchar %179
-OpStore %308 %309
-%310 = OpLoad %ulong %195
-%311 = OpIAdd %ulong %310 %ulong_1
-OpStore %180 %311
-%312 = OpLoad %ulong %180
-OpStore %195 %312
-OpBranch %109
-%100 = OpLabel
-%313 = OpLoad %ulong %193
-%314 = OpIAdd %ulong %313 %ulong_1
-OpStore %149 %314
-%315 = OpLoad %ulong %149
-%316 = OpIMul %ulong %ulong_11400714819323198485 %315
-OpStore %150 %316
-%317 = OpLoad %ulong %150
-%318 = OpLoad %ulong %121
-%319 = OpIAdd %ulong %317 %318
-OpStore %151 %319
-%320 = OpLoad %ulong %151
-%321 = OpUConvert %uchar %320
-OpStore %152 %321
-%322 = OpLoad %ulong %151
-%323 = OpShiftRightLogical %ulong %322 %ulong_8
-OpStore %153 %323
-%324 = OpLoad %ulong %153
-%325 = OpUConvert %ushort %324
-OpStore %154 %325
-%326 = OpLoad %ulong %151
-%327 = OpShiftRightLogical %ulong %326 %ulong_16
-OpStore %155 %327
-%328 = OpLoad %ulong %155
-%329 = OpUConvert %uint %328
-OpStore %156 %329
-%330 = OpLoad %ulong %190
-%331 = OpLoad %uchar %152
-%332 = OpFunctionCall %ulong %8 %330 %331
-OpStore %157 %332
-%333 = OpLoad %ulong %157
-%334 = OpLoad %ushort %154
-%335 = OpFunctionCall %ulong %9 %333 %334
-OpStore %158 %335
-%336 = OpLoad %ulong %158
-%337 = OpLoad %uint %156
-%338 = OpFunctionCall %ulong %10 %336 %337
-OpStore %159 %338
-%339 = OpLoad %ulong %159
-%340 = OpLoad %ulong %151
-%341 = OpFunctionCall %ulong %11 %339 %340
-OpStore %160 %341
-%342 = OpLoad %uchar %152
-%343 = OpSConvert %ulong %342
-OpStore %161 %343
-%344 = OpLoad %ulong %160
-%345 = OpLoad %ulong %161
-%346 = OpFunctionCall %ulong %11 %344 %345
-OpStore %162 %346
-%347 = OpLoad %ushort %154
-%348 = OpSConvert %ulong %347
-OpStore %163 %348
-%349 = OpLoad %ulong %162
-%350 = OpLoad %ulong %163
-%351 = OpFunctionCall %ulong %11 %349 %350
-OpStore %164 %351
-%352 = OpLoad %uint %156
-%353 = OpSConvert %ulong %352
-OpStore %165 %353
-%354 = OpLoad %ulong %164
-%355 = OpLoad %ulong %165
-%356 = OpFunctionCall %ulong %11 %354 %355
-OpStore %166 %356
-%357 = OpLoad %uchar %152
-%358 = OpUConvert %ulong %357
-OpStore %167 %358
-%359 = OpLoad %ulong %166
-%360 = OpLoad %ulong %167
-%361 = OpFunctionCall %ulong %4 %359 %360
-OpStore %168 %361
-%362 = OpLoad %ushort %154
-%363 = OpUConvert %ulong %362
-OpStore %169 %363
-%364 = OpLoad %ulong %168
-%365 = OpLoad %ulong %169
-%366 = OpFunctionCall %ulong %4 %364 %365
-OpStore %170 %366
-%367 = OpLoad %uint %156
-%368 = OpUConvert %ulong %367
-OpStore %171 %368
-%369 = OpLoad %ulong %170
-%370 = OpLoad %ulong %171
-%371 = OpFunctionCall %ulong %4 %369 %370
-OpStore %172 %371
-%372 = OpLoad %ulong %172
-OpStore %190 %372
-%373 = OpLoad %ulong %149
-OpStore %193 %373
-OpBranch %110
-%97 = OpLabel
-%374 = OpLoad %ulong %192
-%375 = OpIAdd %ulong %374 %ulong_1
-OpStore %139 %375
-%376 = OpLoad %ulong %124
-%377 = OpLoad %ulong %139
-%378 = OpIMul %ulong %376 %377
-OpStore %140 %378
-%379 = OpLoad %ulong %140
-%380 = OpLoad %ulong %121
-%381 = OpIAdd %ulong %379 %380
-OpStore %141 %381
-%382 = OpLoad %ulong %141
-%383 = OpUConvert %uchar %382
-OpStore %142 %383
-%384 = OpAccessChain %_ptr_Function_uchar %113 %uint_1
-%385 = OpLoad %uchar %142
-OpStore %384 %385
-%386 = OpLoad %ulong %141
-%388 = OpShiftRightLogical %ulong %386 %ulong_3
-OpStore %143 %388
-%389 = OpLoad %ulong %143
-%390 = OpUConvert %ushort %389
-OpStore %144 %390
-%391 = OpAccessChain %_ptr_Function_ushort %113 %uint_5
-%392 = OpLoad %ushort %144
-OpStore %391 %392
-%393 = OpLoad %ulong %141
-%395 = OpShiftRightLogical %ulong %393 %ulong_5
-OpStore %145 %395
-%396 = OpLoad %ulong %145
-%397 = OpUConvert %uint %396
-OpStore %146 %397
-%398 = OpAccessChain %_ptr_Function_uint %113 %uint_6
-%399 = OpLoad %uint %146
-OpStore %398 %399
-%400 = OpLoad %_struct_16 %113
-OpStore %116 %400
-%401 = OpLoad %ulong %191
-%402 = OpLoad %_struct_16 %116
-%403 = OpFunctionCall %ulong %1 %401 %402
-OpStore %147 %403
-%404 = OpLoad %ulong %147
-OpStore %191 %404
-%405 = OpLoad %ulong %139
-OpStore %192 %405
-OpBranch %111
-%108 = OpLabel
-OpBranch %105
-%109 = OpLabel
-OpBranch %102
-%110 = OpLabel
-OpBranch %99
-%111 = OpLabel
-OpBranch %96
+OpStore %124 %299
+%300 = OpLoad %ulong %124
+%301 = OpBitwiseAnd %ulong %300 %ulong_255
+OpStore %125 %301
+%302 = OpLoad %ulong %129
+%303 = OpLoad %ulong %125
+%304 = OpBitwiseXor %ulong %302 %303
+OpStore %126 %304
+%305 = OpLoad %ulong %126
+%306 = OpIMul %ulong %305 %ulong_1099511628211
+OpStore %127 %306
+%307 = OpLoad %ulong %130
+%308 = OpIAdd %ulong %307 %ulong_1
+OpStore %128 %308
+%309 = OpLoad %ulong %127
+OpStore %129 %309
+%310 = OpLoad %ulong %128
+OpStore %130 %310
+OpBranch %70
+%38 = OpLabel
+%311 = OpLoad %ulong %120
+%312 = OpIMul %ulong %311 %ulong_8
+OpStore %113 %312
+%313 = OpLoad %ulong %111
+%314 = OpLoad %ulong %113
+%315 = OpShiftRightLogical %ulong %313 %314
+OpStore %114 %315
+%316 = OpLoad %ulong %114
+%317 = OpBitwiseAnd %ulong %316 %ulong_255
+OpStore %115 %317
+%318 = OpLoad %ulong %119
+%319 = OpLoad %ulong %115
+%320 = OpBitwiseXor %ulong %318 %319
+OpStore %116 %320
+%321 = OpLoad %ulong %116
+%322 = OpIMul %ulong %321 %ulong_1099511628211
+OpStore %117 %322
+%323 = OpLoad %ulong %120
+%324 = OpIAdd %ulong %323 %ulong_1
+OpStore %118 %324
+%325 = OpLoad %ulong %117
+OpStore %119 %325
+%326 = OpLoad %ulong %118
+OpStore %120 %326
+OpBranch %71
+%31 = OpLabel
+%327 = OpLoad %ulong %110
+%328 = OpIMul %ulong %327 %ulong_8
+OpStore %103 %328
+%329 = OpLoad %ulong %101
+%330 = OpLoad %ulong %103
+%331 = OpShiftRightLogical %ulong %329 %330
+OpStore %104 %331
+%332 = OpLoad %ulong %104
+%333 = OpBitwiseAnd %ulong %332 %ulong_255
+OpStore %105 %333
+%334 = OpLoad %ulong %109
+%335 = OpLoad %ulong %105
+%336 = OpBitwiseXor %ulong %334 %335
+OpStore %106 %336
+%337 = OpLoad %ulong %106
+%338 = OpIMul %ulong %337 %ulong_1099511628211
+OpStore %107 %338
+%339 = OpLoad %ulong %110
+%340 = OpIAdd %ulong %339 %ulong_1
+OpStore %108 %340
+%341 = OpLoad %ulong %107
+OpStore %109 %341
+%342 = OpLoad %ulong %108
+OpStore %110 %342
+OpBranch %72
+%24 = OpLabel
+%343 = OpLoad %ulong %100
+%344 = OpIMul %ulong %343 %ulong_8
+OpStore %93 %344
+%345 = OpLoad %ulong %91
+%346 = OpLoad %ulong %93
+%347 = OpShiftRightLogical %ulong %345 %346
+OpStore %94 %347
+%348 = OpLoad %ulong %94
+%349 = OpBitwiseAnd %ulong %348 %ulong_255
+OpStore %95 %349
+%350 = OpLoad %ulong %99
+%351 = OpLoad %ulong %95
+%352 = OpBitwiseXor %ulong %350 %351
+OpStore %96 %352
+%353 = OpLoad %ulong %96
+%354 = OpIMul %ulong %353 %ulong_1099511628211
+OpStore %97 %354
+%355 = OpLoad %ulong %100
+%356 = OpIAdd %ulong %355 %ulong_1
+OpStore %98 %356
+%357 = OpLoad %ulong %97
+OpStore %99 %357
+%358 = OpLoad %ulong %98
+OpStore %100 %358
+OpBranch %73
+%17 = OpLabel
+%359 = OpLoad %ulong %90
+%360 = OpIMul %ulong %359 %ulong_8
+OpStore %83 %360
+%361 = OpLoad %ulong %80
+%362 = OpLoad %ulong %83
+%363 = OpShiftRightLogical %ulong %361 %362
+OpStore %84 %363
+%364 = OpLoad %ulong %84
+%365 = OpBitwiseAnd %ulong %364 %ulong_255
+OpStore %85 %365
+%366 = OpLoad %ulong %89
+%367 = OpLoad %ulong %85
+%368 = OpBitwiseXor %ulong %366 %367
+OpStore %86 %368
+%369 = OpLoad %ulong %86
+%370 = OpIMul %ulong %369 %ulong_1099511628211
+OpStore %87 %370
+%371 = OpLoad %ulong %90
+%372 = OpIAdd %ulong %371 %ulong_1
+OpStore %88 %372
+%373 = OpLoad %ulong %87
+OpStore %89 %373
+%374 = OpLoad %ulong %88
+OpStore %90 %374
+OpBranch %74
+%67 = OpLabel
+OpBranch %63
+%68 = OpLabel
+OpBranch %58
+%69 = OpLabel
+OpBranch %51
+%70 = OpLabel
+OpBranch %44
+%71 = OpLabel
+OpBranch %37
+%72 = OpLabel
+OpBranch %30
+%73 = OpLabel
+OpBranch %23
+%74 = OpLabel
+OpBranch %16
 OpFunctionEnd
-%3 = OpFunction %ulong None %406
-%407 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %409
-%410 = OpFunctionParameter %ulong
-%411 = OpFunctionParameter %ulong
-%412 = OpLabel
-%417 = OpVariable %_ptr_Function_ulong Function
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_bool Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_ulong Function
-OpStore %417 %410
-OpStore %418 %411
-%428 = OpLoad %ulong %417
-OpStore %426 %428
-OpStore %427 %ulong_0
-OpBranch %413
-%413 = OpLabel
-%429 = OpLoad %ulong %427
-%430 = OpULessThan %bool %429 %ulong_8
-OpStore %419 %430
-%431 = OpLoad %bool %419
-OpLoopMerge %415 %416 None
-OpBranchConditional %431 %414 %415
-%415 = OpLabel
-%432 = OpLoad %ulong %426
-OpReturnValue %432
-%414 = OpLabel
-%433 = OpLoad %ulong %427
-%434 = OpIMul %ulong %433 %ulong_8
-OpStore %420 %434
-%435 = OpLoad %ulong %418
-%436 = OpLoad %ulong %420
-%437 = OpShiftRightLogical %ulong %435 %436
-OpStore %421 %437
-%438 = OpLoad %ulong %421
-%440 = OpBitwiseAnd %ulong %438 %ulong_255
-OpStore %422 %440
-%441 = OpLoad %ulong %426
-%442 = OpLoad %ulong %422
-%443 = OpBitwiseXor %ulong %441 %442
-OpStore %423 %443
-%444 = OpLoad %ulong %423
-%446 = OpIMul %ulong %444 %ulong_1099511628211
-OpStore %424 %446
-%447 = OpLoad %ulong %427
-%448 = OpIAdd %ulong %447 %ulong_1
-OpStore %425 %448
-%449 = OpLoad %ulong %424
-OpStore %426 %449
-%450 = OpLoad %ulong %425
-OpStore %427 %450
-OpBranch %416
-%416 = OpLabel
-OpBranch %413
-OpFunctionEnd
-%5 = OpFunction %ulong None %451
-%452 = OpFunctionParameter %ulong
-%453 = OpFunctionParameter %uchar
-%454 = OpLabel
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_uchar Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_bool Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %375
+%376 = OpFunctionParameter %ulong
+%377 = OpLabel
+%460 = OpVariable %_ptr_Function__struct_8 Function
+%464 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%465 = OpVariable %_ptr_Function__struct_8 Function
+%466 = OpVariable %_ptr_Function__struct_8 Function
+%467 = OpVariable %_ptr_Function__struct_8 Function
 %468 = OpVariable %_ptr_Function_ulong Function
 %469 = OpVariable %_ptr_Function_ulong Function
 %470 = OpVariable %_ptr_Function_ulong Function
-%471 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_uchar Function
 %472 = OpVariable %_ptr_Function_ulong Function
-OpStore %461 %452
-OpStore %462 %453
-%473 = OpLoad %uchar %462
-%474 = OpUConvert %ulong %473
-OpStore %463 %474
-OpBranch %455
-%455 = OpLabel
-%475 = OpLoad %ulong %461
-OpStore %471 %475
-OpStore %472 %ulong_0
-OpBranch %456
-%456 = OpLabel
-%476 = OpLoad %ulong %472
-%477 = OpULessThan %bool %476 %ulong_8
-OpStore %464 %477
-%478 = OpLoad %bool %464
-OpLoopMerge %458 %460 None
-OpBranchConditional %478 %457 %458
-%458 = OpLabel
-OpBranch %459
-%459 = OpLabel
-%479 = OpLoad %ulong %471
-OpReturnValue %479
-%457 = OpLabel
-%480 = OpLoad %ulong %472
-%481 = OpIMul %ulong %480 %ulong_8
-OpStore %465 %481
-%482 = OpLoad %ulong %463
-%483 = OpLoad %ulong %465
-%484 = OpShiftRightLogical %ulong %482 %483
-OpStore %466 %484
-%485 = OpLoad %ulong %466
-%486 = OpBitwiseAnd %ulong %485 %ulong_255
-OpStore %467 %486
-%487 = OpLoad %ulong %471
-%488 = OpLoad %ulong %467
-%489 = OpBitwiseXor %ulong %487 %488
-OpStore %468 %489
-%490 = OpLoad %ulong %468
-%491 = OpIMul %ulong %490 %ulong_1099511628211
-OpStore %469 %491
-%492 = OpLoad %ulong %472
-%493 = OpIAdd %ulong %492 %ulong_1
-OpStore %470 %493
-%494 = OpLoad %ulong %469
-OpStore %471 %494
-%495 = OpLoad %ulong %470
-OpStore %472 %495
-OpBranch %460
-%460 = OpLabel
-OpBranch %456
-OpFunctionEnd
-%6 = OpFunction %ulong None %496
-%497 = OpFunctionParameter %ulong
-%498 = OpFunctionParameter %ushort
-%499 = OpLabel
+%473 = OpVariable %_ptr_Function_uchar Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_uchar Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_uchar Function
+%478 = OpVariable %_ptr_Function_ushort Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ushort Function
+%481 = OpVariable %_ptr_Function_uint Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_uchar Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ushort Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_uint Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_bool Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_uchar Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ushort Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_uint Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
 %506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ushort Function
+%507 = OpVariable %_ptr_Function_ulong Function
 %508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_bool Function
+%509 = OpVariable %_ptr_Function_ulong Function
 %510 = OpVariable %_ptr_Function_ulong Function
 %511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
+%512 = OpVariable %_ptr_Function_bool Function
 %513 = OpVariable %_ptr_Function_ulong Function
 %514 = OpVariable %_ptr_Function_ulong Function
 %515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-OpStore %506 %497
-OpStore %507 %498
-%518 = OpLoad %ushort %507
-%519 = OpUConvert %ulong %518
-OpStore %508 %519
-OpBranch %500
-%500 = OpLabel
-%520 = OpLoad %ulong %506
-OpStore %516 %520
-OpStore %517 %ulong_0
-OpBranch %501
-%501 = OpLabel
-%521 = OpLoad %ulong %517
-%522 = OpULessThan %bool %521 %ulong_8
-OpStore %509 %522
-%523 = OpLoad %bool %509
-OpLoopMerge %503 %505 None
-OpBranchConditional %523 %502 %503
-%503 = OpLabel
-OpBranch %504
-%504 = OpLabel
-%524 = OpLoad %ulong %516
-OpReturnValue %524
-%502 = OpLabel
-%525 = OpLoad %ulong %517
-%526 = OpIMul %ulong %525 %ulong_8
-OpStore %510 %526
-%527 = OpLoad %ulong %508
-%528 = OpLoad %ulong %510
-%529 = OpShiftRightLogical %ulong %527 %528
-OpStore %511 %529
-%530 = OpLoad %ulong %511
-%531 = OpBitwiseAnd %ulong %530 %ulong_255
-OpStore %512 %531
-%532 = OpLoad %ulong %516
-%533 = OpLoad %ulong %512
-%534 = OpBitwiseXor %ulong %532 %533
-OpStore %513 %534
-%535 = OpLoad %ulong %513
-%536 = OpIMul %ulong %535 %ulong_1099511628211
-OpStore %514 %536
-%537 = OpLoad %ulong %517
-%538 = OpIAdd %ulong %537 %ulong_1
-OpStore %515 %538
-%539 = OpLoad %ulong %514
-OpStore %516 %539
-%540 = OpLoad %ulong %515
-OpStore %517 %540
-OpBranch %505
-%505 = OpLabel
-OpBranch %501
-OpFunctionEnd
-%7 = OpFunction %ulong None %541
-%542 = OpFunctionParameter %ulong
-%543 = OpFunctionParameter %uint
-%544 = OpLabel
+%516 = OpVariable %_ptr_Function_uchar Function
+%517 = OpVariable %_ptr_Function_uchar Function
+%518 = OpVariable %_ptr_Function_uchar Function
+%519 = OpVariable %_ptr_Function_ulong Function
+%520 = OpVariable %_ptr_Function_bool Function
+%521 = OpVariable %_ptr_Function_uchar Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_ulong Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_ulong Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_ulong Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_ulong Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_bool Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_bool Function
+%544 = OpVariable %_ptr_Function_ulong Function
+%545 = OpVariable %_ptr_Function_ulong Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_ulong Function
+%548 = OpVariable %_ptr_Function_ulong Function
+%549 = OpVariable %_ptr_Function_ulong Function
+%550 = OpVariable %_ptr_Function_ulong Function
 %551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_uint Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_bool Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_bool Function
+%554 = OpVariable %_ptr_Function_ulong Function
 %555 = OpVariable %_ptr_Function_ulong Function
 %556 = OpVariable %_ptr_Function_ulong Function
 %557 = OpVariable %_ptr_Function_ulong Function
@@ -770,68 +679,44 @@ OpFunctionEnd
 %559 = OpVariable %_ptr_Function_ulong Function
 %560 = OpVariable %_ptr_Function_ulong Function
 %561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_ulong Function
-OpStore %551 %542
-OpStore %552 %543
-%563 = OpLoad %uint %552
-%564 = OpUConvert %ulong %563
-OpStore %553 %564
-OpBranch %545
-%545 = OpLabel
-%565 = OpLoad %ulong %551
-OpStore %561 %565
-OpStore %562 %ulong_0
-OpBranch %546
-%546 = OpLabel
-%566 = OpLoad %ulong %562
-%567 = OpULessThan %bool %566 %ulong_8
-OpStore %554 %567
-%568 = OpLoad %bool %554
-OpLoopMerge %548 %550 None
-OpBranchConditional %568 %547 %548
-%548 = OpLabel
-OpBranch %549
-%549 = OpLabel
-%569 = OpLoad %ulong %561
-OpReturnValue %569
-%547 = OpLabel
-%570 = OpLoad %ulong %562
-%571 = OpIMul %ulong %570 %ulong_8
-OpStore %555 %571
-%572 = OpLoad %ulong %553
-%573 = OpLoad %ulong %555
-%574 = OpShiftRightLogical %ulong %572 %573
-OpStore %556 %574
-%575 = OpLoad %ulong %556
-%576 = OpBitwiseAnd %ulong %575 %ulong_255
-OpStore %557 %576
-%577 = OpLoad %ulong %561
-%578 = OpLoad %ulong %557
-%579 = OpBitwiseXor %ulong %577 %578
-OpStore %558 %579
-%580 = OpLoad %ulong %558
-%581 = OpIMul %ulong %580 %ulong_1099511628211
-OpStore %559 %581
-%582 = OpLoad %ulong %562
-%583 = OpIAdd %ulong %582 %ulong_1
-OpStore %560 %583
-%584 = OpLoad %ulong %559
-OpStore %561 %584
-%585 = OpLoad %ulong %560
-OpStore %562 %585
-OpBranch %550
-%550 = OpLabel
-OpBranch %546
-OpFunctionEnd
-%8 = OpFunction %ulong None %451
-%586 = OpFunctionParameter %ulong
-%587 = OpFunctionParameter %uchar
-%588 = OpLabel
+%562 = OpVariable %_ptr_Function_bool Function
+%563 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_bool Function
+%572 = OpVariable %_ptr_Function_ulong Function
+%573 = OpVariable %_ptr_Function_ulong Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_ulong Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_ulong Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_ulong Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_bool Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_ulong Function
+%584 = OpVariable %_ptr_Function_ulong Function
+%585 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_ulong Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_bool Function
+%591 = OpVariable %_ptr_Function_ulong Function
+%592 = OpVariable %_ptr_Function_ulong Function
+%593 = OpVariable %_ptr_Function_ulong Function
+%594 = OpVariable %_ptr_Function_ulong Function
 %595 = OpVariable %_ptr_Function_ulong Function
-%596 = OpVariable %_ptr_Function_uchar Function
+%596 = OpVariable %_ptr_Function_ulong Function
 %597 = OpVariable %_ptr_Function_ulong Function
-%598 = OpVariable %_ptr_Function_bool Function
-%599 = OpVariable %_ptr_Function_ulong Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_bool Function
 %600 = OpVariable %_ptr_Function_ulong Function
 %601 = OpVariable %_ptr_Function_ulong Function
 %602 = OpVariable %_ptr_Function_ulong Function
@@ -839,255 +724,766 @@ OpFunctionEnd
 %604 = OpVariable %_ptr_Function_ulong Function
 %605 = OpVariable %_ptr_Function_ulong Function
 %606 = OpVariable %_ptr_Function_ulong Function
-OpStore %595 %586
-OpStore %596 %587
-%607 = OpLoad %uchar %596
-%608 = OpSConvert %ulong %607
-OpStore %597 %608
-OpBranch %589
-%589 = OpLabel
-%609 = OpLoad %ulong %595
-OpStore %605 %609
-OpStore %606 %ulong_0
-OpBranch %590
-%590 = OpLabel
-%610 = OpLoad %ulong %606
-%611 = OpULessThan %bool %610 %ulong_8
-OpStore %598 %611
-%612 = OpLoad %bool %598
-OpLoopMerge %592 %594 None
-OpBranchConditional %612 %591 %592
-%592 = OpLabel
-OpBranch %593
-%593 = OpLabel
-%613 = OpLoad %ulong %605
-OpReturnValue %613
-%591 = OpLabel
-%614 = OpLoad %ulong %606
-%615 = OpIMul %ulong %614 %ulong_8
-OpStore %599 %615
-%616 = OpLoad %ulong %597
-%617 = OpLoad %ulong %599
-%618 = OpShiftRightLogical %ulong %616 %617
-OpStore %600 %618
-%619 = OpLoad %ulong %600
-%620 = OpBitwiseAnd %ulong %619 %ulong_255
-OpStore %601 %620
-%621 = OpLoad %ulong %605
-%622 = OpLoad %ulong %601
-%623 = OpBitwiseXor %ulong %621 %622
-OpStore %602 %623
-%624 = OpLoad %ulong %602
-%625 = OpIMul %ulong %624 %ulong_1099511628211
-OpStore %603 %625
-%626 = OpLoad %ulong %606
-%627 = OpIAdd %ulong %626 %ulong_1
-OpStore %604 %627
-%628 = OpLoad %ulong %603
-OpStore %605 %628
-%629 = OpLoad %ulong %604
-OpStore %606 %629
-OpBranch %594
-%594 = OpLabel
-OpBranch %590
+%607 = OpVariable %_ptr_Function_ulong Function
+%608 = OpVariable %_ptr_Function_ulong Function
+%609 = OpVariable %_ptr_Function_ulong Function
+OpStore %468 %376
+OpBranch %390
+%390 = OpLabel
+OpBranch %391
+%391 = OpLabel
+OpStore %465 %610
+%611 = OpLoad %_struct_8 %465
+OpStore %466 %611
+%613 = OpLoad %_struct_8 %466
+%614 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %613
+OpStore %469 %614
+%616 = OpLoad %ulong %468
+%617 = OpIAdd %ulong %ulong_18364758544493064720 %616
+OpStore %470 %617
+%618 = OpLoad %ulong %470
+%619 = OpUConvert %uchar %618
+OpStore %471 %619
+%620 = OpAccessChain %_ptr_Function_uchar %465 %uint_0
+%621 = OpLoad %uchar %471
+OpStore %620 %621
+%622 = OpLoad %ulong %470
+%623 = OpShiftRightLogical %ulong %622 %ulong_8
+OpStore %472 %623
+%624 = OpLoad %ulong %472
+%625 = OpUConvert %uchar %624
+OpStore %473 %625
+%626 = OpAccessChain %_ptr_Function_uchar %465 %uint_1
+%627 = OpLoad %uchar %473
+OpStore %626 %627
+%628 = OpLoad %ulong %470
+%630 = OpShiftRightLogical %ulong %628 %ulong_16
+OpStore %474 %630
+%631 = OpLoad %ulong %474
+%632 = OpUConvert %uchar %631
+OpStore %475 %632
+%633 = OpAccessChain %_ptr_Function_uchar %465 %uint_2
+%634 = OpLoad %uchar %475
+OpStore %633 %634
+%635 = OpLoad %ulong %470
+%637 = OpShiftRightLogical %ulong %635 %ulong_24
+OpStore %476 %637
+%638 = OpLoad %ulong %476
+%639 = OpUConvert %uchar %638
+OpStore %477 %639
+%640 = OpAccessChain %_ptr_Function_uchar %465 %uint_3
+%641 = OpLoad %uchar %477
+OpStore %640 %641
+%642 = OpLoad %ulong %470
+%643 = OpUConvert %ushort %642
+OpStore %478 %643
+%644 = OpAccessChain %_ptr_Function_ushort %465 %uint_4
+%645 = OpLoad %ushort %478
+OpStore %644 %645
+%646 = OpLoad %ulong %470
+%648 = OpShiftRightLogical %ulong %646 %ulong_32
+OpStore %479 %648
+%649 = OpLoad %ulong %479
+%650 = OpUConvert %ushort %649
+OpStore %480 %650
+%651 = OpAccessChain %_ptr_Function_ushort %465 %uint_5
+%652 = OpLoad %ushort %480
+OpStore %651 %652
+%653 = OpLoad %ulong %470
+%654 = OpUConvert %uint %653
+OpStore %481 %654
+%655 = OpAccessChain %_ptr_Function_uint %465 %uint_6
+%656 = OpLoad %uint %481
+OpStore %655 %656
+%657 = OpAccessChain %_ptr_Function_ulong %465 %uint_7
+%658 = OpLoad %ulong %470
+OpStore %657 %658
+%659 = OpLoad %_struct_8 %465
+OpStore %467 %659
+%660 = OpLoad %ulong %469
+%661 = OpLoad %_struct_8 %467
+%662 = OpFunctionCall %ulong %1 %660 %661
+OpStore %482 %662
+%663 = OpLoad %ulong %482
+OpStore %527 %663
+OpStore %528 %ulong_0
+OpBranch %378
+%378 = OpLabel
+%664 = OpLoad %ulong %528
+%665 = OpULessThan %bool %664 %ulong_8
+OpStore %483 %665
+%666 = OpLoad %bool %483
+OpLoopMerge %380 %459 None
+OpBranchConditional %666 %379 %380
+%380 = OpLabel
+%667 = OpLoad %ulong %527
+OpStore %526 %667
+OpStore %529 %ulong_0
+OpBranch %381
+%381 = OpLabel
+%668 = OpLoad %ulong %529
+%670 = OpULessThan %bool %668 %ulong_6
+OpStore %493 %670
+%671 = OpLoad %bool %493
+OpLoopMerge %383 %458 None
+OpBranchConditional %671 %382 %383
+%383 = OpLabel
+OpStore %464 %672
+OpStore %531 %ulong_0
+OpBranch %384
+%384 = OpLabel
+%673 = OpLoad %ulong %531
+%674 = OpULessThan %bool %673 %ulong_16
+OpStore %512 %674
+%675 = OpLoad %bool %512
+OpLoopMerge %386 %457 None
+OpBranchConditional %675 %385 %386
+%386 = OpLabel
+%676 = OpLoad %ulong %526
+OpStore %525 %676
+OpStore %530 %ulong_0
+OpBranch %387
+%387 = OpLabel
+%677 = OpLoad %ulong %530
+%678 = OpULessThan %bool %677 %ulong_16
+OpStore %520 %678
+%679 = OpLoad %bool %520
+OpLoopMerge %389 %455 None
+OpBranchConditional %679 %388 %389
+%389 = OpLabel
+%680 = OpLoad %ulong %470
+%682 = OpBitwiseXor %ulong %680 %ulong_11400714819323198485
+OpStore %523 %682
+OpBranch %396
+%396 = OpLabel
+%683 = OpLoad %ulong %525
+OpStore %541 %683
+OpStore %542 %ulong_0
+OpBranch %397
+%397 = OpLabel
+%684 = OpLoad %ulong %542
+%685 = OpULessThan %bool %684 %ulong_8
+OpStore %534 %685
+%686 = OpLoad %bool %534
+OpLoopMerge %399 %454 None
+OpBranchConditional %686 %398 %399
+%399 = OpLabel
+OpBranch %400
+%400 = OpLabel
+%687 = OpLoad %ulong %523
+%688 = OpIAdd %ulong %687 %ulong_1
+OpStore %524 %688
+OpBranch %413
+%413 = OpLabel
+%689 = OpLoad %ulong %541
+OpStore %569 %689
+OpStore %570 %ulong_0
+OpBranch %414
+%414 = OpLabel
+%690 = OpLoad %ulong %570
+%691 = OpULessThan %bool %690 %ulong_8
+OpStore %562 %691
+%692 = OpLoad %bool %562
+OpLoopMerge %416 %451 None
+OpBranchConditional %692 %415 %416
+%416 = OpLabel
+OpBranch %417
+%417 = OpLabel
+%693 = OpLoad %ulong %569
+OpReturnValue %693
+%415 = OpLabel
+%694 = OpLoad %ulong %570
+%695 = OpIMul %ulong %694 %ulong_8
+OpStore %563 %695
+%696 = OpLoad %ulong %524
+%697 = OpLoad %ulong %563
+%698 = OpShiftRightLogical %ulong %696 %697
+OpStore %564 %698
+%699 = OpLoad %ulong %564
+%700 = OpBitwiseAnd %ulong %699 %ulong_255
+OpStore %565 %700
+%701 = OpLoad %ulong %569
+%702 = OpLoad %ulong %565
+%703 = OpBitwiseXor %ulong %701 %702
+OpStore %566 %703
+%704 = OpLoad %ulong %566
+%705 = OpIMul %ulong %704 %ulong_1099511628211
+OpStore %567 %705
+%706 = OpLoad %ulong %570
+%707 = OpIAdd %ulong %706 %ulong_1
+OpStore %568 %707
+%708 = OpLoad %ulong %567
+OpStore %569 %708
+%709 = OpLoad %ulong %568
+OpStore %570 %709
+OpBranch %451
+%398 = OpLabel
+%710 = OpLoad %ulong %542
+%711 = OpIMul %ulong %710 %ulong_8
+OpStore %535 %711
+%712 = OpLoad %ulong %523
+%713 = OpLoad %ulong %535
+%714 = OpShiftRightLogical %ulong %712 %713
+OpStore %536 %714
+%715 = OpLoad %ulong %536
+%716 = OpBitwiseAnd %ulong %715 %ulong_255
+OpStore %537 %716
+%717 = OpLoad %ulong %541
+%718 = OpLoad %ulong %537
+%719 = OpBitwiseXor %ulong %717 %718
+OpStore %538 %719
+%720 = OpLoad %ulong %538
+%721 = OpIMul %ulong %720 %ulong_1099511628211
+OpStore %539 %721
+%722 = OpLoad %ulong %542
+%723 = OpIAdd %ulong %722 %ulong_1
+OpStore %540 %723
+%724 = OpLoad %ulong %539
+OpStore %541 %724
+%725 = OpLoad %ulong %540
+OpStore %542 %725
+OpBranch %454
+%388 = OpLabel
+%726 = OpLoad %ulong %530
+%727 = OpAccessChain %_ptr_Function_uchar %464 %726
+%728 = OpLoad %uchar %727
+OpStore %521 %728
+OpBranch %394
+%394 = OpLabel
+%729 = OpLoad %uchar %521
+%730 = OpUConvert %ulong %729
+OpStore %533 %730
+OpBranch %408
+%408 = OpLabel
+%731 = OpLoad %ulong %525
+OpStore %560 %731
+OpStore %561 %ulong_0
+OpBranch %409
+%409 = OpLabel
+%732 = OpLoad %ulong %561
+%733 = OpULessThan %bool %732 %ulong_8
+OpStore %553 %733
+%734 = OpLoad %bool %553
+OpLoopMerge %411 %453 None
+OpBranchConditional %734 %410 %411
+%411 = OpLabel
+OpBranch %412
+%412 = OpLabel
+OpBranch %395
+%395 = OpLabel
+%735 = OpLoad %ulong %530
+%736 = OpIAdd %ulong %735 %ulong_1
+OpStore %522 %736
+%737 = OpLoad %ulong %560
+OpStore %525 %737
+%738 = OpLoad %ulong %522
+OpStore %530 %738
+OpBranch %455
+%410 = OpLabel
+%739 = OpLoad %ulong %561
+%740 = OpIMul %ulong %739 %ulong_8
+OpStore %554 %740
+%741 = OpLoad %ulong %533
+%742 = OpLoad %ulong %554
+%743 = OpShiftRightLogical %ulong %741 %742
+OpStore %555 %743
+%744 = OpLoad %ulong %555
+%745 = OpBitwiseAnd %ulong %744 %ulong_255
+OpStore %556 %745
+%746 = OpLoad %ulong %560
+%747 = OpLoad %ulong %556
+%748 = OpBitwiseXor %ulong %746 %747
+OpStore %557 %748
+%749 = OpLoad %ulong %557
+%750 = OpIMul %ulong %749 %ulong_1099511628211
+OpStore %558 %750
+%751 = OpLoad %ulong %561
+%752 = OpIAdd %ulong %751 %ulong_1
+OpStore %559 %752
+%753 = OpLoad %ulong %558
+OpStore %560 %753
+%754 = OpLoad %ulong %559
+OpStore %561 %754
+OpBranch %453
+%385 = OpLabel
+%755 = OpLoad %ulong %531
+%757 = OpBitwiseAnd %ulong %755 %ulong_7
+OpStore %513 %757
+%758 = OpLoad %ulong %513
+%759 = OpIMul %ulong %758 %ulong_8
+OpStore %514 %759
+%760 = OpLoad %ulong %470
+%761 = OpLoad %ulong %514
+%762 = OpShiftRightLogical %ulong %760 %761
+OpStore %515 %762
+%763 = OpLoad %ulong %515
+%764 = OpUConvert %uchar %763
+OpStore %516 %764
+%765 = OpLoad %ulong %531
+%766 = OpUConvert %uchar %765
+OpStore %517 %766
+%767 = OpLoad %uchar %516
+%768 = OpLoad %uchar %517
+%769 = OpIAdd %uchar %767 %768
+OpStore %518 %769
+%770 = OpLoad %ulong %531
+%771 = OpAccessChain %_ptr_Function_uchar %464 %770
+%772 = OpLoad %uchar %518
+OpStore %771 %772
+%773 = OpLoad %ulong %531
+%774 = OpIAdd %ulong %773 %ulong_1
+OpStore %519 %774
+%775 = OpLoad %ulong %519
+OpStore %531 %775
+OpBranch %457
+%382 = OpLabel
+%776 = OpLoad %ulong %529
+%777 = OpIAdd %ulong %776 %ulong_1
+OpStore %494 %777
+%778 = OpLoad %ulong %494
+%779 = OpIMul %ulong %ulong_11400714819323198485 %778
+OpStore %495 %779
+%780 = OpLoad %ulong %495
+%781 = OpLoad %ulong %468
+%782 = OpIAdd %ulong %780 %781
+OpStore %496 %782
+%783 = OpLoad %ulong %496
+%784 = OpUConvert %uchar %783
+OpStore %497 %784
+%785 = OpLoad %ulong %496
+%786 = OpShiftRightLogical %ulong %785 %ulong_8
+OpStore %498 %786
+%787 = OpLoad %ulong %498
+%788 = OpUConvert %ushort %787
+OpStore %499 %788
+%789 = OpLoad %ulong %496
+%790 = OpShiftRightLogical %ulong %789 %ulong_16
+OpStore %500 %790
+%791 = OpLoad %ulong %500
+%792 = OpUConvert %uint %791
+OpStore %501 %792
+OpBranch %392
+%392 = OpLabel
+%793 = OpLoad %uchar %497
+%794 = OpSConvert %ulong %793
+OpStore %532 %794
+OpBranch %401
+%401 = OpLabel
+%795 = OpLoad %ulong %526
+OpStore %550 %795
+OpStore %551 %ulong_0
+OpBranch %402
+%402 = OpLabel
+%796 = OpLoad %ulong %551
+%797 = OpULessThan %bool %796 %ulong_8
+OpStore %543 %797
+%798 = OpLoad %bool %543
+OpLoopMerge %404 %456 None
+OpBranchConditional %798 %403 %404
+%404 = OpLabel
+OpBranch %405
+%405 = OpLabel
+OpBranch %393
+%393 = OpLabel
+OpBranch %406
+%406 = OpLabel
+%799 = OpLoad %ushort %499
+%800 = OpSConvert %ulong %799
+OpStore %552 %800
+OpBranch %418
+%418 = OpLabel
+%801 = OpLoad %ulong %550
+OpStore %578 %801
+OpStore %579 %ulong_0
+OpBranch %419
+%419 = OpLabel
+%802 = OpLoad %ulong %579
+%803 = OpULessThan %bool %802 %ulong_8
+OpStore %571 %803
+%804 = OpLoad %bool %571
+OpLoopMerge %421 %452 None
+OpBranchConditional %804 %420 %421
+%421 = OpLabel
+OpBranch %422
+%422 = OpLabel
+OpBranch %407
+%407 = OpLabel
+OpBranch %423
+%423 = OpLabel
+%805 = OpLoad %uint %501
+%806 = OpSConvert %ulong %805
+OpStore %580 %806
+OpBranch %425
+%425 = OpLabel
+%807 = OpLoad %ulong %578
+OpStore %588 %807
+OpStore %589 %ulong_0
+OpBranch %426
+%426 = OpLabel
+%808 = OpLoad %ulong %589
+%809 = OpULessThan %bool %808 %ulong_8
+OpStore %581 %809
+%810 = OpLoad %bool %581
+OpLoopMerge %428 %450 None
+OpBranchConditional %810 %427 %428
+%428 = OpLabel
+OpBranch %429
+%429 = OpLabel
+OpBranch %424
+%424 = OpLabel
+OpBranch %430
+%430 = OpLabel
+OpBranch %432
+%432 = OpLabel
+%811 = OpLoad %ulong %588
+OpStore %597 %811
+OpStore %598 %ulong_0
+OpBranch %433
+%433 = OpLabel
+%812 = OpLoad %ulong %598
+%813 = OpULessThan %bool %812 %ulong_8
+OpStore %590 %813
+%814 = OpLoad %bool %590
+OpLoopMerge %435 %449 None
+OpBranchConditional %814 %434 %435
+%435 = OpLabel
+OpBranch %436
+%436 = OpLabel
+OpBranch %431
+%431 = OpLabel
+%815 = OpLoad %uchar %497
+%816 = OpSConvert %ulong %815
+OpStore %502 %816
+OpBranch %437
+%437 = OpLabel
+OpBranch %439
+%439 = OpLabel
+%817 = OpLoad %ulong %597
+OpStore %606 %817
+OpStore %607 %ulong_0
+OpBranch %440
+%440 = OpLabel
+%818 = OpLoad %ulong %607
+%819 = OpULessThan %bool %818 %ulong_8
+OpStore %599 %819
+%820 = OpLoad %bool %599
+OpLoopMerge %442 %448 None
+OpBranchConditional %820 %441 %442
+%442 = OpLabel
+OpBranch %443
+%443 = OpLabel
+OpBranch %438
+%438 = OpLabel
+%821 = OpLoad %ushort %499
+%822 = OpSConvert %ulong %821
+OpStore %503 %822
+OpBranch %444
+%444 = OpLabel
+%823 = OpLoad %ulong %606
+%824 = OpLoad %ulong %503
+%825 = OpFunctionCall %ulong %3 %823 %824
+OpStore %608 %825
+OpBranch %445
+%445 = OpLabel
+%826 = OpLoad %uint %501
+%827 = OpSConvert %ulong %826
+OpStore %504 %827
+OpBranch %446
+%446 = OpLabel
+%828 = OpLoad %ulong %608
+%829 = OpLoad %ulong %504
+%830 = OpFunctionCall %ulong %3 %828 %829
+OpStore %609 %830
+OpBranch %447
+%447 = OpLabel
+%831 = OpLoad %uchar %497
+%832 = OpUConvert %ulong %831
+OpStore %505 %832
+%833 = OpLoad %ulong %609
+%834 = OpLoad %ulong %505
+%835 = OpFunctionCall %ulong %3 %833 %834
+OpStore %506 %835
+%836 = OpLoad %ushort %499
+%837 = OpUConvert %ulong %836
+OpStore %507 %837
+%838 = OpLoad %ulong %506
+%839 = OpLoad %ulong %507
+%840 = OpFunctionCall %ulong %3 %838 %839
+OpStore %508 %840
+%841 = OpLoad %uint %501
+%842 = OpUConvert %ulong %841
+OpStore %509 %842
+%843 = OpLoad %ulong %508
+%844 = OpLoad %ulong %509
+%845 = OpFunctionCall %ulong %3 %843 %844
+OpStore %510 %845
+%846 = OpLoad %ulong %529
+%847 = OpIAdd %ulong %846 %ulong_1
+OpStore %511 %847
+%848 = OpLoad %ulong %510
+OpStore %526 %848
+%849 = OpLoad %ulong %511
+OpStore %529 %849
+OpBranch %458
+%441 = OpLabel
+%850 = OpLoad %ulong %607
+%851 = OpIMul %ulong %850 %ulong_8
+OpStore %600 %851
+%852 = OpLoad %ulong %502
+%853 = OpLoad %ulong %600
+%854 = OpShiftRightLogical %ulong %852 %853
+OpStore %601 %854
+%855 = OpLoad %ulong %601
+%856 = OpBitwiseAnd %ulong %855 %ulong_255
+OpStore %602 %856
+%857 = OpLoad %ulong %606
+%858 = OpLoad %ulong %602
+%859 = OpBitwiseXor %ulong %857 %858
+OpStore %603 %859
+%860 = OpLoad %ulong %603
+%861 = OpIMul %ulong %860 %ulong_1099511628211
+OpStore %604 %861
+%862 = OpLoad %ulong %607
+%863 = OpIAdd %ulong %862 %ulong_1
+OpStore %605 %863
+%864 = OpLoad %ulong %604
+OpStore %606 %864
+%865 = OpLoad %ulong %605
+OpStore %607 %865
+OpBranch %448
+%434 = OpLabel
+%866 = OpLoad %ulong %598
+%867 = OpIMul %ulong %866 %ulong_8
+OpStore %591 %867
+%868 = OpLoad %ulong %496
+%869 = OpLoad %ulong %591
+%870 = OpShiftRightLogical %ulong %868 %869
+OpStore %592 %870
+%871 = OpLoad %ulong %592
+%872 = OpBitwiseAnd %ulong %871 %ulong_255
+OpStore %593 %872
+%873 = OpLoad %ulong %597
+%874 = OpLoad %ulong %593
+%875 = OpBitwiseXor %ulong %873 %874
+OpStore %594 %875
+%876 = OpLoad %ulong %594
+%877 = OpIMul %ulong %876 %ulong_1099511628211
+OpStore %595 %877
+%878 = OpLoad %ulong %598
+%879 = OpIAdd %ulong %878 %ulong_1
+OpStore %596 %879
+%880 = OpLoad %ulong %595
+OpStore %597 %880
+%881 = OpLoad %ulong %596
+OpStore %598 %881
+OpBranch %449
+%427 = OpLabel
+%882 = OpLoad %ulong %589
+%883 = OpIMul %ulong %882 %ulong_8
+OpStore %582 %883
+%884 = OpLoad %ulong %580
+%885 = OpLoad %ulong %582
+%886 = OpShiftRightLogical %ulong %884 %885
+OpStore %583 %886
+%887 = OpLoad %ulong %583
+%888 = OpBitwiseAnd %ulong %887 %ulong_255
+OpStore %584 %888
+%889 = OpLoad %ulong %588
+%890 = OpLoad %ulong %584
+%891 = OpBitwiseXor %ulong %889 %890
+OpStore %585 %891
+%892 = OpLoad %ulong %585
+%893 = OpIMul %ulong %892 %ulong_1099511628211
+OpStore %586 %893
+%894 = OpLoad %ulong %589
+%895 = OpIAdd %ulong %894 %ulong_1
+OpStore %587 %895
+%896 = OpLoad %ulong %586
+OpStore %588 %896
+%897 = OpLoad %ulong %587
+OpStore %589 %897
+OpBranch %450
+%420 = OpLabel
+%898 = OpLoad %ulong %579
+%899 = OpIMul %ulong %898 %ulong_8
+OpStore %572 %899
+%900 = OpLoad %ulong %552
+%901 = OpLoad %ulong %572
+%902 = OpShiftRightLogical %ulong %900 %901
+OpStore %573 %902
+%903 = OpLoad %ulong %573
+%904 = OpBitwiseAnd %ulong %903 %ulong_255
+OpStore %574 %904
+%905 = OpLoad %ulong %578
+%906 = OpLoad %ulong %574
+%907 = OpBitwiseXor %ulong %905 %906
+OpStore %575 %907
+%908 = OpLoad %ulong %575
+%909 = OpIMul %ulong %908 %ulong_1099511628211
+OpStore %576 %909
+%910 = OpLoad %ulong %579
+%911 = OpIAdd %ulong %910 %ulong_1
+OpStore %577 %911
+%912 = OpLoad %ulong %576
+OpStore %578 %912
+%913 = OpLoad %ulong %577
+OpStore %579 %913
+OpBranch %452
+%403 = OpLabel
+%914 = OpLoad %ulong %551
+%915 = OpIMul %ulong %914 %ulong_8
+OpStore %544 %915
+%916 = OpLoad %ulong %532
+%917 = OpLoad %ulong %544
+%918 = OpShiftRightLogical %ulong %916 %917
+OpStore %545 %918
+%919 = OpLoad %ulong %545
+%920 = OpBitwiseAnd %ulong %919 %ulong_255
+OpStore %546 %920
+%921 = OpLoad %ulong %550
+%922 = OpLoad %ulong %546
+%923 = OpBitwiseXor %ulong %921 %922
+OpStore %547 %923
+%924 = OpLoad %ulong %547
+%925 = OpIMul %ulong %924 %ulong_1099511628211
+OpStore %548 %925
+%926 = OpLoad %ulong %551
+%927 = OpIAdd %ulong %926 %ulong_1
+OpStore %549 %927
+%928 = OpLoad %ulong %548
+OpStore %550 %928
+%929 = OpLoad %ulong %549
+OpStore %551 %929
+OpBranch %456
+%379 = OpLabel
+%930 = OpLoad %ulong %528
+%931 = OpIAdd %ulong %930 %ulong_1
+OpStore %484 %931
+%932 = OpLoad %ulong %470
+%933 = OpLoad %ulong %484
+%934 = OpIMul %ulong %932 %933
+OpStore %485 %934
+%935 = OpLoad %ulong %485
+%936 = OpLoad %ulong %468
+%937 = OpIAdd %ulong %935 %936
+OpStore %486 %937
+%938 = OpLoad %ulong %486
+%939 = OpUConvert %uchar %938
+OpStore %487 %939
+%940 = OpAccessChain %_ptr_Function_uchar %465 %uint_1
+%941 = OpLoad %uchar %487
+OpStore %940 %941
+%942 = OpLoad %ulong %486
+%944 = OpShiftRightLogical %ulong %942 %ulong_3
+OpStore %488 %944
+%945 = OpLoad %ulong %488
+%946 = OpUConvert %ushort %945
+OpStore %489 %946
+%947 = OpAccessChain %_ptr_Function_ushort %465 %uint_5
+%948 = OpLoad %ushort %489
+OpStore %947 %948
+%949 = OpLoad %ulong %486
+%951 = OpShiftRightLogical %ulong %949 %ulong_5
+OpStore %490 %951
+%952 = OpLoad %ulong %490
+%953 = OpUConvert %uint %952
+OpStore %491 %953
+%954 = OpAccessChain %_ptr_Function_uint %465 %uint_6
+%955 = OpLoad %uint %491
+OpStore %954 %955
+%956 = OpLoad %_struct_8 %465
+OpStore %460 %956
+%957 = OpLoad %ulong %527
+%958 = OpLoad %_struct_8 %460
+%959 = OpFunctionCall %ulong %1 %957 %958
+OpStore %492 %959
+%960 = OpLoad %ulong %492
+OpStore %527 %960
+%961 = OpLoad %ulong %484
+OpStore %528 %961
+OpBranch %459
+%448 = OpLabel
+OpBranch %440
+%449 = OpLabel
+OpBranch %433
+%450 = OpLabel
+OpBranch %426
+%451 = OpLabel
+OpBranch %414
+%452 = OpLabel
+OpBranch %419
+%453 = OpLabel
+OpBranch %409
+%454 = OpLabel
+OpBranch %397
+%455 = OpLabel
+OpBranch %387
+%456 = OpLabel
+OpBranch %402
+%457 = OpLabel
+OpBranch %384
+%458 = OpLabel
+OpBranch %381
+%459 = OpLabel
+OpBranch %378
 OpFunctionEnd
-%9 = OpFunction %ulong None %496
-%630 = OpFunctionParameter %ulong
-%631 = OpFunctionParameter %ushort
-%632 = OpLabel
-%639 = OpVariable %_ptr_Function_ulong Function
-%640 = OpVariable %_ptr_Function_ushort Function
-%641 = OpVariable %_ptr_Function_ulong Function
-%642 = OpVariable %_ptr_Function_bool Function
-%643 = OpVariable %_ptr_Function_ulong Function
-%644 = OpVariable %_ptr_Function_ulong Function
-%645 = OpVariable %_ptr_Function_ulong Function
-%646 = OpVariable %_ptr_Function_ulong Function
-%647 = OpVariable %_ptr_Function_ulong Function
-%648 = OpVariable %_ptr_Function_ulong Function
-%649 = OpVariable %_ptr_Function_ulong Function
-%650 = OpVariable %_ptr_Function_ulong Function
-OpStore %639 %630
-OpStore %640 %631
-%651 = OpLoad %ushort %640
-%652 = OpSConvert %ulong %651
-OpStore %641 %652
-OpBranch %633
-%633 = OpLabel
-%653 = OpLoad %ulong %639
-OpStore %649 %653
-OpStore %650 %ulong_0
-OpBranch %634
-%634 = OpLabel
-%654 = OpLoad %ulong %650
-%655 = OpULessThan %bool %654 %ulong_8
-OpStore %642 %655
-%656 = OpLoad %bool %642
-OpLoopMerge %636 %638 None
-OpBranchConditional %656 %635 %636
-%636 = OpLabel
-OpBranch %637
-%637 = OpLabel
-%657 = OpLoad %ulong %649
-OpReturnValue %657
-%635 = OpLabel
-%658 = OpLoad %ulong %650
-%659 = OpIMul %ulong %658 %ulong_8
-OpStore %643 %659
-%660 = OpLoad %ulong %641
-%661 = OpLoad %ulong %643
-%662 = OpShiftRightLogical %ulong %660 %661
-OpStore %644 %662
-%663 = OpLoad %ulong %644
-%664 = OpBitwiseAnd %ulong %663 %ulong_255
-OpStore %645 %664
-%665 = OpLoad %ulong %649
-%666 = OpLoad %ulong %645
-%667 = OpBitwiseXor %ulong %665 %666
-OpStore %646 %667
-%668 = OpLoad %ulong %646
-%669 = OpIMul %ulong %668 %ulong_1099511628211
-OpStore %647 %669
-%670 = OpLoad %ulong %650
-%671 = OpIAdd %ulong %670 %ulong_1
-OpStore %648 %671
-%672 = OpLoad %ulong %647
-OpStore %649 %672
-%673 = OpLoad %ulong %648
-OpStore %650 %673
-OpBranch %638
-%638 = OpLabel
-OpBranch %634
-OpFunctionEnd
-%10 = OpFunction %ulong None %541
-%674 = OpFunctionParameter %ulong
-%675 = OpFunctionParameter %uint
-%676 = OpLabel
-%683 = OpVariable %_ptr_Function_ulong Function
-%684 = OpVariable %_ptr_Function_uint Function
-%685 = OpVariable %_ptr_Function_ulong Function
-%686 = OpVariable %_ptr_Function_bool Function
-%687 = OpVariable %_ptr_Function_ulong Function
-%688 = OpVariable %_ptr_Function_ulong Function
-%689 = OpVariable %_ptr_Function_ulong Function
-%690 = OpVariable %_ptr_Function_ulong Function
-%691 = OpVariable %_ptr_Function_ulong Function
-%692 = OpVariable %_ptr_Function_ulong Function
-%693 = OpVariable %_ptr_Function_ulong Function
-%694 = OpVariable %_ptr_Function_ulong Function
-OpStore %683 %674
-OpStore %684 %675
-%695 = OpLoad %uint %684
-%696 = OpSConvert %ulong %695
-OpStore %685 %696
-OpBranch %677
-%677 = OpLabel
-%697 = OpLoad %ulong %683
-OpStore %693 %697
-OpStore %694 %ulong_0
-OpBranch %678
-%678 = OpLabel
-%698 = OpLoad %ulong %694
-%699 = OpULessThan %bool %698 %ulong_8
-OpStore %686 %699
-%700 = OpLoad %bool %686
-OpLoopMerge %680 %682 None
-OpBranchConditional %700 %679 %680
-%680 = OpLabel
-OpBranch %681
-%681 = OpLabel
-%701 = OpLoad %ulong %693
-OpReturnValue %701
-%679 = OpLabel
-%702 = OpLoad %ulong %694
-%703 = OpIMul %ulong %702 %ulong_8
-OpStore %687 %703
-%704 = OpLoad %ulong %685
-%705 = OpLoad %ulong %687
-%706 = OpShiftRightLogical %ulong %704 %705
-OpStore %688 %706
-%707 = OpLoad %ulong %688
-%708 = OpBitwiseAnd %ulong %707 %ulong_255
-OpStore %689 %708
-%709 = OpLoad %ulong %693
-%710 = OpLoad %ulong %689
-%711 = OpBitwiseXor %ulong %709 %710
-OpStore %690 %711
-%712 = OpLoad %ulong %690
-%713 = OpIMul %ulong %712 %ulong_1099511628211
-OpStore %691 %713
-%714 = OpLoad %ulong %694
-%715 = OpIAdd %ulong %714 %ulong_1
-OpStore %692 %715
-%716 = OpLoad %ulong %691
-OpStore %693 %716
-%717 = OpLoad %ulong %692
-OpStore %694 %717
-OpBranch %682
-%682 = OpLabel
-OpBranch %678
-OpFunctionEnd
-%11 = OpFunction %ulong None %409
-%718 = OpFunctionParameter %ulong
-%719 = OpFunctionParameter %ulong
-%720 = OpLabel
-%727 = OpVariable %_ptr_Function_ulong Function
-%728 = OpVariable %_ptr_Function_ulong Function
-%729 = OpVariable %_ptr_Function_bool Function
-%730 = OpVariable %_ptr_Function_ulong Function
-%731 = OpVariable %_ptr_Function_ulong Function
-%732 = OpVariable %_ptr_Function_ulong Function
-%733 = OpVariable %_ptr_Function_ulong Function
-%734 = OpVariable %_ptr_Function_ulong Function
-%735 = OpVariable %_ptr_Function_ulong Function
-%736 = OpVariable %_ptr_Function_ulong Function
-%737 = OpVariable %_ptr_Function_ulong Function
-OpStore %727 %718
-OpStore %728 %719
-OpBranch %721
-%721 = OpLabel
-%738 = OpLoad %ulong %727
-OpStore %736 %738
-OpStore %737 %ulong_0
-OpBranch %722
-%722 = OpLabel
-%739 = OpLoad %ulong %737
-%740 = OpULessThan %bool %739 %ulong_8
-OpStore %729 %740
-%741 = OpLoad %bool %729
-OpLoopMerge %724 %726 None
-OpBranchConditional %741 %723 %724
-%724 = OpLabel
-OpBranch %725
-%725 = OpLabel
-%742 = OpLoad %ulong %736
-OpReturnValue %742
-%723 = OpLabel
-%743 = OpLoad %ulong %737
-%744 = OpIMul %ulong %743 %ulong_8
-OpStore %730 %744
-%745 = OpLoad %ulong %728
-%746 = OpLoad %ulong %730
-%747 = OpShiftRightLogical %ulong %745 %746
-OpStore %731 %747
-%748 = OpLoad %ulong %731
-%749 = OpBitwiseAnd %ulong %748 %ulong_255
-OpStore %732 %749
-%750 = OpLoad %ulong %736
-%751 = OpLoad %ulong %732
-%752 = OpBitwiseXor %ulong %750 %751
-OpStore %733 %752
-%753 = OpLoad %ulong %733
-%754 = OpIMul %ulong %753 %ulong_1099511628211
-OpStore %734 %754
-%755 = OpLoad %ulong %737
-%756 = OpIAdd %ulong %755 %ulong_1
-OpStore %735 %756
-%757 = OpLoad %ulong %734
-OpStore %736 %757
-%758 = OpLoad %ulong %735
-OpStore %737 %758
-OpBranch %726
-%726 = OpLabel
-OpBranch %722
+%3 = OpFunction %ulong None %962
+%963 = OpFunctionParameter %ulong
+%964 = OpFunctionParameter %ulong
+%965 = OpLabel
+%970 = OpVariable %_ptr_Function_ulong Function
+%971 = OpVariable %_ptr_Function_ulong Function
+%972 = OpVariable %_ptr_Function_bool Function
+%973 = OpVariable %_ptr_Function_ulong Function
+%974 = OpVariable %_ptr_Function_ulong Function
+%975 = OpVariable %_ptr_Function_ulong Function
+%976 = OpVariable %_ptr_Function_ulong Function
+%977 = OpVariable %_ptr_Function_ulong Function
+%978 = OpVariable %_ptr_Function_ulong Function
+%979 = OpVariable %_ptr_Function_ulong Function
+%980 = OpVariable %_ptr_Function_ulong Function
+OpStore %970 %963
+OpStore %971 %964
+%981 = OpLoad %ulong %970
+OpStore %979 %981
+OpStore %980 %ulong_0
+OpBranch %966
+%966 = OpLabel
+%982 = OpLoad %ulong %980
+%983 = OpULessThan %bool %982 %ulong_8
+OpStore %972 %983
+%984 = OpLoad %bool %972
+OpLoopMerge %968 %969 None
+OpBranchConditional %984 %967 %968
+%968 = OpLabel
+%985 = OpLoad %ulong %979
+OpReturnValue %985
+%967 = OpLabel
+%986 = OpLoad %ulong %980
+%987 = OpIMul %ulong %986 %ulong_8
+OpStore %973 %987
+%988 = OpLoad %ulong %971
+%989 = OpLoad %ulong %973
+%990 = OpShiftRightLogical %ulong %988 %989
+OpStore %974 %990
+%991 = OpLoad %ulong %974
+%992 = OpBitwiseAnd %ulong %991 %ulong_255
+OpStore %975 %992
+%993 = OpLoad %ulong %979
+%994 = OpLoad %ulong %975
+%995 = OpBitwiseXor %ulong %993 %994
+OpStore %976 %995
+%996 = OpLoad %ulong %976
+%997 = OpIMul %ulong %996 %ulong_1099511628211
+OpStore %977 %997
+%998 = OpLoad %ulong %980
+%999 = OpIAdd %ulong %998 %ulong_1
+OpStore %978 %999
+%1000 = OpLoad %ulong %977
+OpStore %979 %1000
+%1001 = OpLoad %ulong %978
+OpStore %980 %1001
+OpBranch %969
+%969 = OpLabel
+OpBranch %966
 OpFunctionEnd

--- a/test/golden/spirv/mem/rec_layout.dis
+++ b/test/golden/spirv/mem/rec_layout.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 827
+; Bound: 1518
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -18,47 +18,51 @@ OpDecorate %6 LinkageAttributes "corpus.cases.mem.rec_layout.checksum" Export
 %ulong = OpTypeInt 64 0
 %uchar = OpTypeInt 8 0
 %uint = OpTypeInt 32 0
-%_struct_15 = OpTypeStruct %uchar %uint %uchar
-%16 = OpTypeFunction %ulong %ulong %_struct_15
-%_ptr_Function__struct_15 = OpTypePointer Function %_struct_15
+%_struct_11 = OpTypeStruct %uchar %uint %uchar
+%12 = OpTypeFunction %ulong %ulong %_struct_11
+%bool = OpTypeBool
+%_ptr_Function__struct_11 = OpTypePointer Function %_struct_11
 %_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ushort = OpTypeInt 16 0
-%_struct_52 = OpTypeStruct %ushort %_struct_15 %uchar
-%53 = OpTypeFunction %ulong %ulong %_struct_52
-%_ptr_Function__struct_52 = OpTypePointer Function %_struct_52
+%_struct_163 = OpTypeStruct %ushort %_struct_11 %uchar
+%164 = OpTypeFunction %ulong %ulong %_struct_163
+%_ptr_Function__struct_163 = OpTypePointer Function %_struct_163
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %uint_3 = OpConstant %uint 3
 %_arr_ushort_uint_3 = OpTypeArray %ushort %uint_3
-%_struct_102 = OpTypeStruct %_struct_52 %ulong %_arr_ushort_uint_3 %uchar
-%103 = OpTypeFunction %ulong %ulong %_struct_102
-%_ptr_Function__struct_102 = OpTypePointer Function %_struct_102
+%_struct_393 = OpTypeStruct %_struct_163 %ulong %_arr_ushort_uint_3 %uchar
+%394 = OpTypeFunction %ulong %ulong %_struct_393
+%_ptr_Function__struct_393 = OpTypePointer Function %_struct_393
 %_ptr_Function__arr_ushort_uint_3 = OpTypePointer Function %_arr_ushort_uint_3
-%_arr__struct_52_uint_2 = OpTypeArray %_struct_52 %uint_2
-%_struct_158 = OpTypeStruct %_struct_102 %_arr__struct_52_uint_2 %uint
-%159 = OpTypeFunction %ulong %ulong %_struct_158
-%_ptr_Function__struct_158 = OpTypePointer Function %_struct_158
-%_ptr_Function__arr__struct_52_uint_2 = OpTypePointer Function %_arr__struct_52_uint_2
+%_arr__struct_163_uint_2 = OpTypeArray %_struct_163 %uint_2
+%_struct_626 = OpTypeStruct %_struct_393 %_arr__struct_163_uint_2 %uint
+%627 = OpTypeFunction %ulong %ulong %_struct_626
+%_ptr_Function__struct_626 = OpTypePointer Function %_struct_626
+%_ptr_Function__arr__struct_163_uint_2 = OpTypePointer Function %_arr__struct_163_uint_2
 %void = OpTypeVoid
-%243 = OpTypeFunction %void %_ptr_Function__struct_52 %uint
+%924 = OpTypeFunction %void %_ptr_Function__struct_163 %uint
 %uint_4 = OpConstant %uint 4
-%284 = OpTypeFunction %ulong %ulong
-%ulong_12 = OpConstant %ulong 12
-%ulong_20 = OpConstant %ulong 20
-%ulong_40 = OpConstant %ulong 40
-%ulong_88 = OpConstant %ulong 88
+%965 = OpTypeFunction %ulong %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_4 = OpConstant %ulong 4
-%ulong_8 = OpConstant %ulong 8
 %ulong_16 = OpConstant %ulong 16
 %ulong_24 = OpConstant %ulong 24
 %ulong_32 = OpConstant %ulong 32
 %ulong_38 = OpConstant %ulong 38
+%ulong_40 = OpConstant %ulong 40
 %ulong_80 = OpConstant %ulong 80
-%430 = OpConstantNull %_struct_158
+%1187 = OpConstantNull %_struct_626
 %uint_10 = OpConstant %uint 10
 %ulong_18364758544493064720 = OpConstant %ulong 18364758544493064720
 %uint_20 = OpConstant %uint 20
@@ -71,1074 +75,2150 @@ OpDecorate %6 LinkageAttributes "corpus.cases.mem.rec_layout.checksum" Export
 %uint_4042322160 = OpConstant %uint 4042322160
 %uchar_7 = OpConstant %uchar 7
 %ulong_3 = OpConstant %ulong 3
-%643 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%646 = OpTypeFunction %ulong %ulong %ulong
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%692 = OpTypeFunction %ulong %ulong %uchar
-%737 = OpTypeFunction %ulong %ulong %ushort
-%782 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %16
-%17 = OpFunctionParameter %ulong
-%18 = OpFunctionParameter %_struct_15
-%19 = OpLabel
-%21 = OpVariable %_ptr_Function__struct_15 Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uchar Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_uchar Function
-OpStore %23 %17
-OpStore %21 %18
-%33 = OpAccessChain %_ptr_Function_uchar %21 %uint_0
-%34 = OpLoad %uchar %33
-OpStore %28 %34
-%36 = OpAccessChain %_ptr_Function_uint %21 %uint_1
-%37 = OpLoad %uint %36
-OpStore %30 %37
-%39 = OpAccessChain %_ptr_Function_uchar %21 %uint_2
-%40 = OpLoad %uchar %39
-OpStore %31 %40
-%41 = OpLoad %ulong %23
-%42 = OpLoad %uchar %28
-%43 = OpFunctionCall %ulong %9 %41 %42
-OpStore %24 %43
-%44 = OpLoad %ulong %24
-%45 = OpLoad %uint %30
-%46 = OpFunctionCall %ulong %11 %44 %45
-OpStore %25 %46
-%47 = OpLoad %ulong %25
-%48 = OpLoad %uchar %31
-%49 = OpFunctionCall %ulong %9 %47 %48
-OpStore %26 %49
-%50 = OpLoad %ulong %26
-OpReturnValue %50
-OpFunctionEnd
-%2 = OpFunction %ulong None %53
-%54 = OpFunctionParameter %ulong
-%55 = OpFunctionParameter %_struct_52
-%56 = OpLabel
-%60 = OpVariable %_ptr_Function__struct_52 Function
+%ulong_88 = OpConstant %ulong 88
+%ulong_20 = OpConstant %ulong 20
+%ulong_12 = OpConstant %ulong 12
+%1478 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %12
+%13 = OpFunctionParameter %ulong
+%14 = OpFunctionParameter %_struct_11
+%15 = OpLabel
+%42 = OpVariable %_ptr_Function__struct_11 Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_bool Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_bool Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
 %61 = OpVariable %_ptr_Function_ulong Function
 %62 = OpVariable %_ptr_Function_ulong Function
 %63 = OpVariable %_ptr_Function_ulong Function
 %64 = OpVariable %_ptr_Function_ulong Function
 %65 = OpVariable %_ptr_Function_ulong Function
 %66 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ushort Function
-%69 = OpVariable %_ptr_Function_uchar Function
-%70 = OpVariable %_ptr_Function_uchar Function
-%71 = OpVariable %_ptr_Function_uint Function
-%72 = OpVariable %_ptr_Function_uchar Function
-OpStore %61 %54
-OpStore %60 %55
-%73 = OpAccessChain %_ptr_Function_ushort %60 %uint_0
-%74 = OpLoad %ushort %73
-OpStore %68 %74
-%75 = OpAccessChain %_ptr_Function__struct_15 %60 %uint_1
-%76 = OpAccessChain %_ptr_Function_uchar %75 %uint_0
-%77 = OpLoad %uchar %76
-OpStore %70 %77
-%78 = OpAccessChain %_ptr_Function_uint %75 %uint_1
-%79 = OpLoad %uint %78
-OpStore %71 %79
-%80 = OpAccessChain %_ptr_Function_uchar %75 %uint_2
-%81 = OpLoad %uchar %80
-OpStore %72 %81
-%82 = OpAccessChain %_ptr_Function_uchar %60 %uint_2
+%67 = OpVariable %_ptr_Function_bool Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_uchar Function
+%79 = OpVariable %_ptr_Function_uint Function
+%80 = OpVariable %_ptr_Function_uchar Function
+OpStore %44 %13
+OpStore %42 %14
+%82 = OpAccessChain %_ptr_Function_uchar %42 %uint_0
 %83 = OpLoad %uchar %82
-OpStore %69 %83
-%84 = OpLoad %ulong %61
-%85 = OpLoad %ushort %68
-%86 = OpFunctionCall %ulong %10 %84 %85
-OpStore %62 %86
-OpBranch %57
-%57 = OpLabel
-%87 = OpLoad %ulong %62
-%88 = OpLoad %uchar %70
-%89 = OpFunctionCall %ulong %9 %87 %88
-OpStore %64 %89
-%90 = OpLoad %ulong %64
-%91 = OpLoad %uint %71
-%92 = OpFunctionCall %ulong %11 %90 %91
-OpStore %65 %92
-%93 = OpLoad %ulong %65
-%94 = OpLoad %uchar %72
-%95 = OpFunctionCall %ulong %9 %93 %94
-OpStore %66 %95
-OpBranch %58
-%58 = OpLabel
-%96 = OpLoad %ulong %66
-%97 = OpLoad %uchar %69
-%98 = OpFunctionCall %ulong %9 %96 %97
-OpStore %63 %98
-%99 = OpLoad %ulong %63
-OpReturnValue %99
+OpStore %77 %83
+%85 = OpAccessChain %_ptr_Function_uint %42 %uint_1
+%86 = OpLoad %uint %85
+OpStore %79 %86
+%88 = OpAccessChain %_ptr_Function_uchar %42 %uint_2
+%89 = OpLoad %uchar %88
+OpStore %80 %89
+OpBranch %16
+%16 = OpLabel
+%90 = OpLoad %uchar %77
+%91 = OpUConvert %ulong %90
+OpStore %45 %91
+OpBranch %18
+%18 = OpLabel
+%92 = OpLoad %ulong %44
+OpStore %54 %92
+OpStore %55 %ulong_0
+OpBranch %19
+%19 = OpLabel
+%94 = OpLoad %ulong %55
+%96 = OpULessThan %bool %94 %ulong_8
+OpStore %47 %96
+%97 = OpLoad %bool %47
+OpLoopMerge %21 %39 None
+OpBranchConditional %97 %20 %21
+%21 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%98 = OpLoad %uint %79
+%99 = OpUConvert %ulong %98
+OpStore %56 %99
+OpBranch %25
+%25 = OpLabel
+%100 = OpLoad %ulong %54
+OpStore %64 %100
+OpStore %65 %ulong_0
+OpBranch %26
+%26 = OpLabel
+%101 = OpLoad %ulong %65
+%102 = OpULessThan %bool %101 %ulong_8
+OpStore %57 %102
+%103 = OpLoad %bool %57
+OpLoopMerge %28 %38 None
+OpBranchConditional %103 %27 %28
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%104 = OpLoad %uchar %80
+%105 = OpUConvert %ulong %104
+OpStore %66 %105
+OpBranch %32
+%32 = OpLabel
+%106 = OpLoad %ulong %64
+OpStore %74 %106
+OpStore %75 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%107 = OpLoad %ulong %75
+%108 = OpULessThan %bool %107 %ulong_8
+OpStore %67 %108
+%109 = OpLoad %bool %67
+OpLoopMerge %35 %37 None
+OpBranchConditional %109 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %31
+%31 = OpLabel
+%110 = OpLoad %ulong %74
+OpReturnValue %110
+%34 = OpLabel
+%111 = OpLoad %ulong %75
+%112 = OpIMul %ulong %111 %ulong_8
+OpStore %68 %112
+%113 = OpLoad %ulong %66
+%114 = OpLoad %ulong %68
+%115 = OpShiftRightLogical %ulong %113 %114
+OpStore %69 %115
+%116 = OpLoad %ulong %69
+%118 = OpBitwiseAnd %ulong %116 %ulong_255
+OpStore %70 %118
+%119 = OpLoad %ulong %74
+%120 = OpLoad %ulong %70
+%121 = OpBitwiseXor %ulong %119 %120
+OpStore %71 %121
+%122 = OpLoad %ulong %71
+%124 = OpIMul %ulong %122 %ulong_1099511628211
+OpStore %72 %124
+%125 = OpLoad %ulong %75
+%127 = OpIAdd %ulong %125 %ulong_1
+OpStore %73 %127
+%128 = OpLoad %ulong %72
+OpStore %74 %128
+%129 = OpLoad %ulong %73
+OpStore %75 %129
+OpBranch %37
+%27 = OpLabel
+%130 = OpLoad %ulong %65
+%131 = OpIMul %ulong %130 %ulong_8
+OpStore %58 %131
+%132 = OpLoad %ulong %56
+%133 = OpLoad %ulong %58
+%134 = OpShiftRightLogical %ulong %132 %133
+OpStore %59 %134
+%135 = OpLoad %ulong %59
+%136 = OpBitwiseAnd %ulong %135 %ulong_255
+OpStore %60 %136
+%137 = OpLoad %ulong %64
+%138 = OpLoad %ulong %60
+%139 = OpBitwiseXor %ulong %137 %138
+OpStore %61 %139
+%140 = OpLoad %ulong %61
+%141 = OpIMul %ulong %140 %ulong_1099511628211
+OpStore %62 %141
+%142 = OpLoad %ulong %65
+%143 = OpIAdd %ulong %142 %ulong_1
+OpStore %63 %143
+%144 = OpLoad %ulong %62
+OpStore %64 %144
+%145 = OpLoad %ulong %63
+OpStore %65 %145
+OpBranch %38
+%20 = OpLabel
+%146 = OpLoad %ulong %55
+%147 = OpIMul %ulong %146 %ulong_8
+OpStore %48 %147
+%148 = OpLoad %ulong %45
+%149 = OpLoad %ulong %48
+%150 = OpShiftRightLogical %ulong %148 %149
+OpStore %49 %150
+%151 = OpLoad %ulong %49
+%152 = OpBitwiseAnd %ulong %151 %ulong_255
+OpStore %50 %152
+%153 = OpLoad %ulong %54
+%154 = OpLoad %ulong %50
+%155 = OpBitwiseXor %ulong %153 %154
+OpStore %51 %155
+%156 = OpLoad %ulong %51
+%157 = OpIMul %ulong %156 %ulong_1099511628211
+OpStore %52 %157
+%158 = OpLoad %ulong %55
+%159 = OpIAdd %ulong %158 %ulong_1
+OpStore %53 %159
+%160 = OpLoad %ulong %52
+OpStore %54 %160
+%161 = OpLoad %ulong %53
+OpStore %55 %161
+OpBranch %39
+%37 = OpLabel
+OpBranch %33
+%38 = OpLabel
+OpBranch %26
+%39 = OpLabel
+OpBranch %19
 OpFunctionEnd
-%3 = OpFunction %ulong None %103
-%104 = OpFunctionParameter %ulong
-%105 = OpFunctionParameter %_struct_102
-%106 = OpLabel
-%108 = OpVariable %_ptr_Function__struct_102 Function
-%109 = OpVariable %_ptr_Function__struct_102 Function
-%110 = OpVariable %_ptr_Function__struct_52 Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_ulong Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_ushort Function
-%116 = OpVariable %_ptr_Function_ulong Function
-%117 = OpVariable %_ptr_Function_ushort Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_ushort Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_uchar Function
-%122 = OpVariable %_ptr_Function_ulong Function
-OpStore %111 %104
-OpStore %108 %105
-%123 = OpLoad %_struct_102 %108
-OpStore %109 %123
-%124 = OpAccessChain %_ptr_Function__struct_52 %109 %uint_0
-%125 = OpLoad %_struct_52 %124
-OpStore %110 %125
-%126 = OpLoad %ulong %111
-%127 = OpLoad %_struct_52 %110
-%128 = OpFunctionCall %ulong %2 %126 %127
-OpStore %112 %128
-%129 = OpAccessChain %_ptr_Function_ulong %109 %uint_1
-%130 = OpLoad %ulong %129
-OpStore %113 %130
-%131 = OpLoad %ulong %112
-%132 = OpLoad %ulong %113
-%133 = OpFunctionCall %ulong %8 %131 %132
-OpStore %114 %133
-%135 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %109 %uint_2
-%136 = OpAccessChain %_ptr_Function_ushort %135 %uint_0
-%137 = OpLoad %ushort %136
-OpStore %115 %137
-%138 = OpLoad %ulong %114
-%139 = OpLoad %ushort %115
-%140 = OpFunctionCall %ulong %10 %138 %139
-OpStore %116 %140
-%141 = OpAccessChain %_ptr_Function_ushort %135 %uint_1
-%142 = OpLoad %ushort %141
-OpStore %117 %142
-%143 = OpLoad %ulong %116
-%144 = OpLoad %ushort %117
-%145 = OpFunctionCall %ulong %10 %143 %144
-OpStore %118 %145
-%146 = OpAccessChain %_ptr_Function_ushort %135 %uint_2
-%147 = OpLoad %ushort %146
-OpStore %119 %147
-%148 = OpLoad %ulong %118
-%149 = OpLoad %ushort %119
-%150 = OpFunctionCall %ulong %10 %148 %149
-OpStore %120 %150
-%151 = OpAccessChain %_ptr_Function_uchar %109 %uint_3
-%152 = OpLoad %uchar %151
-OpStore %121 %152
-%153 = OpLoad %ulong %120
-%154 = OpLoad %uchar %121
-%155 = OpFunctionCall %ulong %9 %153 %154
-OpStore %122 %155
-%156 = OpLoad %ulong %122
-OpReturnValue %156
+%2 = OpFunction %ulong None %164
+%165 = OpFunctionParameter %ulong
+%166 = OpFunctionParameter %_struct_163
+%167 = OpLabel
+%211 = OpVariable %_ptr_Function__struct_163 Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_bool Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_bool Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_bool Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_bool Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ushort Function
+%265 = OpVariable %_ptr_Function_uchar Function
+%266 = OpVariable %_ptr_Function_uchar Function
+%267 = OpVariable %_ptr_Function_uint Function
+%268 = OpVariable %_ptr_Function_uchar Function
+OpStore %212 %165
+OpStore %211 %166
+%269 = OpAccessChain %_ptr_Function_ushort %211 %uint_0
+%270 = OpLoad %ushort %269
+OpStore %264 %270
+%271 = OpAccessChain %_ptr_Function__struct_11 %211 %uint_1
+%272 = OpAccessChain %_ptr_Function_uchar %271 %uint_0
+%273 = OpLoad %uchar %272
+OpStore %266 %273
+%274 = OpAccessChain %_ptr_Function_uint %271 %uint_1
+%275 = OpLoad %uint %274
+OpStore %267 %275
+%276 = OpAccessChain %_ptr_Function_uchar %271 %uint_2
+%277 = OpLoad %uchar %276
+OpStore %268 %277
+%278 = OpAccessChain %_ptr_Function_uchar %211 %uint_2
+%279 = OpLoad %uchar %278
+OpStore %265 %279
+OpBranch %168
+%168 = OpLabel
+%280 = OpLoad %ushort %264
+%281 = OpUConvert %ulong %280
+OpStore %213 %281
+OpBranch %170
+%170 = OpLabel
+%282 = OpLoad %ulong %212
+OpStore %221 %282
+OpStore %222 %ulong_0
+OpBranch %171
+%171 = OpLabel
+%283 = OpLoad %ulong %222
+%284 = OpULessThan %bool %283 %ulong_8
+OpStore %214 %284
+%285 = OpLoad %bool %214
+OpLoopMerge %173 %209 None
+OpBranchConditional %285 %172 %173
+%173 = OpLabel
+OpBranch %174
+%174 = OpLabel
+OpBranch %169
+%169 = OpLabel
+OpBranch %175
+%175 = OpLabel
+OpBranch %176
+%176 = OpLabel
+%286 = OpLoad %uchar %266
+%287 = OpUConvert %ulong %286
+OpStore %223 %287
+OpBranch %178
+%178 = OpLabel
+%288 = OpLoad %ulong %221
+OpStore %231 %288
+OpStore %232 %ulong_0
+OpBranch %179
+%179 = OpLabel
+%289 = OpLoad %ulong %232
+%290 = OpULessThan %bool %289 %ulong_8
+OpStore %224 %290
+%291 = OpLoad %bool %224
+OpLoopMerge %181 %208 None
+OpBranchConditional %291 %180 %181
+%181 = OpLabel
+OpBranch %182
+%182 = OpLabel
+OpBranch %177
+%177 = OpLabel
+OpBranch %183
+%183 = OpLabel
+%292 = OpLoad %uint %267
+%293 = OpUConvert %ulong %292
+OpStore %233 %293
+OpBranch %185
+%185 = OpLabel
+%294 = OpLoad %ulong %231
+OpStore %241 %294
+OpStore %242 %ulong_0
+OpBranch %186
+%186 = OpLabel
+%295 = OpLoad %ulong %242
+%296 = OpULessThan %bool %295 %ulong_8
+OpStore %234 %296
+%297 = OpLoad %bool %234
+OpLoopMerge %188 %207 None
+OpBranchConditional %297 %187 %188
+%188 = OpLabel
+OpBranch %189
+%189 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %190
+%190 = OpLabel
+%298 = OpLoad %uchar %268
+%299 = OpUConvert %ulong %298
+OpStore %243 %299
+OpBranch %192
+%192 = OpLabel
+%300 = OpLoad %ulong %241
+OpStore %251 %300
+OpStore %252 %ulong_0
+OpBranch %193
+%193 = OpLabel
+%301 = OpLoad %ulong %252
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %244 %302
+%303 = OpLoad %bool %244
+OpLoopMerge %195 %206 None
+OpBranchConditional %303 %194 %195
+%195 = OpLabel
+OpBranch %196
+%196 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %197
+%197 = OpLabel
+OpBranch %198
+%198 = OpLabel
+%304 = OpLoad %uchar %265
+%305 = OpUConvert %ulong %304
+OpStore %253 %305
+OpBranch %200
+%200 = OpLabel
+%306 = OpLoad %ulong %251
+OpStore %261 %306
+OpStore %262 %ulong_0
+OpBranch %201
+%201 = OpLabel
+%307 = OpLoad %ulong %262
+%308 = OpULessThan %bool %307 %ulong_8
+OpStore %254 %308
+%309 = OpLoad %bool %254
+OpLoopMerge %203 %205 None
+OpBranchConditional %309 %202 %203
+%203 = OpLabel
+OpBranch %204
+%204 = OpLabel
+OpBranch %199
+%199 = OpLabel
+%310 = OpLoad %ulong %261
+OpReturnValue %310
+%202 = OpLabel
+%311 = OpLoad %ulong %262
+%312 = OpIMul %ulong %311 %ulong_8
+OpStore %255 %312
+%313 = OpLoad %ulong %253
+%314 = OpLoad %ulong %255
+%315 = OpShiftRightLogical %ulong %313 %314
+OpStore %256 %315
+%316 = OpLoad %ulong %256
+%317 = OpBitwiseAnd %ulong %316 %ulong_255
+OpStore %257 %317
+%318 = OpLoad %ulong %261
+%319 = OpLoad %ulong %257
+%320 = OpBitwiseXor %ulong %318 %319
+OpStore %258 %320
+%321 = OpLoad %ulong %258
+%322 = OpIMul %ulong %321 %ulong_1099511628211
+OpStore %259 %322
+%323 = OpLoad %ulong %262
+%324 = OpIAdd %ulong %323 %ulong_1
+OpStore %260 %324
+%325 = OpLoad %ulong %259
+OpStore %261 %325
+%326 = OpLoad %ulong %260
+OpStore %262 %326
+OpBranch %205
+%194 = OpLabel
+%327 = OpLoad %ulong %252
+%328 = OpIMul %ulong %327 %ulong_8
+OpStore %245 %328
+%329 = OpLoad %ulong %243
+%330 = OpLoad %ulong %245
+%331 = OpShiftRightLogical %ulong %329 %330
+OpStore %246 %331
+%332 = OpLoad %ulong %246
+%333 = OpBitwiseAnd %ulong %332 %ulong_255
+OpStore %247 %333
+%334 = OpLoad %ulong %251
+%335 = OpLoad %ulong %247
+%336 = OpBitwiseXor %ulong %334 %335
+OpStore %248 %336
+%337 = OpLoad %ulong %248
+%338 = OpIMul %ulong %337 %ulong_1099511628211
+OpStore %249 %338
+%339 = OpLoad %ulong %252
+%340 = OpIAdd %ulong %339 %ulong_1
+OpStore %250 %340
+%341 = OpLoad %ulong %249
+OpStore %251 %341
+%342 = OpLoad %ulong %250
+OpStore %252 %342
+OpBranch %206
+%187 = OpLabel
+%343 = OpLoad %ulong %242
+%344 = OpIMul %ulong %343 %ulong_8
+OpStore %235 %344
+%345 = OpLoad %ulong %233
+%346 = OpLoad %ulong %235
+%347 = OpShiftRightLogical %ulong %345 %346
+OpStore %236 %347
+%348 = OpLoad %ulong %236
+%349 = OpBitwiseAnd %ulong %348 %ulong_255
+OpStore %237 %349
+%350 = OpLoad %ulong %241
+%351 = OpLoad %ulong %237
+%352 = OpBitwiseXor %ulong %350 %351
+OpStore %238 %352
+%353 = OpLoad %ulong %238
+%354 = OpIMul %ulong %353 %ulong_1099511628211
+OpStore %239 %354
+%355 = OpLoad %ulong %242
+%356 = OpIAdd %ulong %355 %ulong_1
+OpStore %240 %356
+%357 = OpLoad %ulong %239
+OpStore %241 %357
+%358 = OpLoad %ulong %240
+OpStore %242 %358
+OpBranch %207
+%180 = OpLabel
+%359 = OpLoad %ulong %232
+%360 = OpIMul %ulong %359 %ulong_8
+OpStore %225 %360
+%361 = OpLoad %ulong %223
+%362 = OpLoad %ulong %225
+%363 = OpShiftRightLogical %ulong %361 %362
+OpStore %226 %363
+%364 = OpLoad %ulong %226
+%365 = OpBitwiseAnd %ulong %364 %ulong_255
+OpStore %227 %365
+%366 = OpLoad %ulong %231
+%367 = OpLoad %ulong %227
+%368 = OpBitwiseXor %ulong %366 %367
+OpStore %228 %368
+%369 = OpLoad %ulong %228
+%370 = OpIMul %ulong %369 %ulong_1099511628211
+OpStore %229 %370
+%371 = OpLoad %ulong %232
+%372 = OpIAdd %ulong %371 %ulong_1
+OpStore %230 %372
+%373 = OpLoad %ulong %229
+OpStore %231 %373
+%374 = OpLoad %ulong %230
+OpStore %232 %374
+OpBranch %208
+%172 = OpLabel
+%375 = OpLoad %ulong %222
+%376 = OpIMul %ulong %375 %ulong_8
+OpStore %215 %376
+%377 = OpLoad %ulong %213
+%378 = OpLoad %ulong %215
+%379 = OpShiftRightLogical %ulong %377 %378
+OpStore %216 %379
+%380 = OpLoad %ulong %216
+%381 = OpBitwiseAnd %ulong %380 %ulong_255
+OpStore %217 %381
+%382 = OpLoad %ulong %221
+%383 = OpLoad %ulong %217
+%384 = OpBitwiseXor %ulong %382 %383
+OpStore %218 %384
+%385 = OpLoad %ulong %218
+%386 = OpIMul %ulong %385 %ulong_1099511628211
+OpStore %219 %386
+%387 = OpLoad %ulong %222
+%388 = OpIAdd %ulong %387 %ulong_1
+OpStore %220 %388
+%389 = OpLoad %ulong %219
+OpStore %221 %389
+%390 = OpLoad %ulong %220
+OpStore %222 %390
+OpBranch %209
+%205 = OpLabel
+OpBranch %201
+%206 = OpLabel
+OpBranch %193
+%207 = OpLabel
+OpBranch %186
+%208 = OpLabel
+OpBranch %179
+%209 = OpLabel
+OpBranch %171
 OpFunctionEnd
-%4 = OpFunction %ulong None %159
-%160 = OpFunctionParameter %ulong
-%161 = OpFunctionParameter %_struct_158
-%162 = OpLabel
-%166 = OpVariable %_ptr_Function__struct_158 Function
-%167 = OpVariable %_ptr_Function__struct_158 Function
-%168 = OpVariable %_ptr_Function__struct_102 Function
-%169 = OpVariable %_ptr_Function__struct_102 Function
-%170 = OpVariable %_ptr_Function__struct_52 Function
-%171 = OpVariable %_ptr_Function__struct_52 Function
-%172 = OpVariable %_ptr_Function__struct_52 Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_uint Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ushort Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ushort Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ushort Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_uchar Function
-%188 = OpVariable %_ptr_Function_ulong Function
-OpStore %173 %160
-OpStore %166 %161
-%189 = OpLoad %_struct_158 %166
-OpStore %167 %189
-%190 = OpAccessChain %_ptr_Function__struct_102 %167 %uint_0
-%191 = OpLoad %_struct_102 %190
-OpStore %168 %191
-OpBranch %163
-%163 = OpLabel
-%192 = OpLoad %_struct_102 %168
-OpStore %169 %192
-%193 = OpAccessChain %_ptr_Function__struct_52 %169 %uint_0
-%194 = OpLoad %_struct_52 %193
-OpStore %170 %194
-%195 = OpLoad %ulong %173
-%196 = OpLoad %_struct_52 %170
-%197 = OpFunctionCall %ulong %2 %195 %196
-OpStore %178 %197
-%198 = OpAccessChain %_ptr_Function_ulong %169 %uint_1
-%199 = OpLoad %ulong %198
-OpStore %179 %199
-%200 = OpLoad %ulong %178
-%201 = OpLoad %ulong %179
-%202 = OpFunctionCall %ulong %8 %200 %201
-OpStore %180 %202
-%203 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %169 %uint_2
-%204 = OpAccessChain %_ptr_Function_ushort %203 %uint_0
-%205 = OpLoad %ushort %204
-OpStore %181 %205
-%206 = OpLoad %ulong %180
-%207 = OpLoad %ushort %181
-%208 = OpFunctionCall %ulong %10 %206 %207
-OpStore %182 %208
-%209 = OpAccessChain %_ptr_Function_ushort %203 %uint_1
-%210 = OpLoad %ushort %209
-OpStore %183 %210
-%211 = OpLoad %ulong %182
-%212 = OpLoad %ushort %183
-%213 = OpFunctionCall %ulong %10 %211 %212
-OpStore %184 %213
-%214 = OpAccessChain %_ptr_Function_ushort %203 %uint_2
-%215 = OpLoad %ushort %214
-OpStore %185 %215
-%216 = OpLoad %ulong %184
-%217 = OpLoad %ushort %185
-%218 = OpFunctionCall %ulong %10 %216 %217
-OpStore %186 %218
-%219 = OpAccessChain %_ptr_Function_uchar %169 %uint_3
-%220 = OpLoad %uchar %219
-OpStore %187 %220
-%221 = OpLoad %ulong %186
-%222 = OpLoad %uchar %187
-%223 = OpFunctionCall %ulong %9 %221 %222
-OpStore %188 %223
-OpBranch %164
-%164 = OpLabel
-%225 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %167 %uint_1
-%226 = OpAccessChain %_ptr_Function__struct_52 %225 %uint_0
-%227 = OpLoad %_struct_52 %226
-OpStore %171 %227
-%228 = OpLoad %ulong %188
-%229 = OpLoad %_struct_52 %171
-%230 = OpFunctionCall %ulong %2 %228 %229
-OpStore %174 %230
-%231 = OpAccessChain %_ptr_Function__struct_52 %225 %uint_1
-%232 = OpLoad %_struct_52 %231
-OpStore %172 %232
-%233 = OpLoad %ulong %174
-%234 = OpLoad %_struct_52 %172
-%235 = OpFunctionCall %ulong %2 %233 %234
-OpStore %175 %235
-%236 = OpAccessChain %_ptr_Function_uint %167 %uint_2
-%237 = OpLoad %uint %236
-OpStore %176 %237
-%238 = OpLoad %ulong %175
-%239 = OpLoad %uint %176
-%240 = OpFunctionCall %ulong %11 %238 %239
-OpStore %177 %240
-%241 = OpLoad %ulong %177
-OpReturnValue %241
+%3 = OpFunction %ulong None %394
+%395 = OpFunctionParameter %ulong
+%396 = OpFunctionParameter %_struct_393
+%397 = OpLabel
+%437 = OpVariable %_ptr_Function__struct_393 Function
+%438 = OpVariable %_ptr_Function__struct_393 Function
+%439 = OpVariable %_ptr_Function__struct_163 Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ushort Function
+%444 = OpVariable %_ptr_Function_ushort Function
+%445 = OpVariable %_ptr_Function_ushort Function
+%446 = OpVariable %_ptr_Function_uchar Function
+%447 = OpVariable %_ptr_Function_bool Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_bool Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_bool Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_bool Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_ulong Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_bool Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+OpStore %440 %395
+OpStore %437 %396
+%496 = OpLoad %_struct_393 %437
+OpStore %438 %496
+%497 = OpAccessChain %_ptr_Function__struct_163 %438 %uint_0
+%498 = OpLoad %_struct_163 %497
+OpStore %439 %498
+%499 = OpLoad %ulong %440
+%500 = OpLoad %_struct_163 %439
+%501 = OpFunctionCall %ulong %2 %499 %500
+OpStore %441 %501
+%502 = OpAccessChain %_ptr_Function_ulong %438 %uint_1
+%503 = OpLoad %ulong %502
+OpStore %442 %503
+OpBranch %398
+%398 = OpLabel
+%504 = OpLoad %ulong %441
+OpStore %454 %504
+OpStore %455 %ulong_0
+OpBranch %399
+%399 = OpLabel
+%505 = OpLoad %ulong %455
+%506 = OpULessThan %bool %505 %ulong_8
+OpStore %447 %506
+%507 = OpLoad %bool %447
+OpLoopMerge %401 %435 None
+OpBranchConditional %507 %400 %401
+%401 = OpLabel
+OpBranch %402
+%402 = OpLabel
+%509 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %438 %uint_2
+%510 = OpAccessChain %_ptr_Function_ushort %509 %uint_0
+%511 = OpLoad %ushort %510
+OpStore %443 %511
+OpBranch %403
+%403 = OpLabel
+%512 = OpLoad %ushort %443
+%513 = OpUConvert %ulong %512
+OpStore %456 %513
+OpBranch %405
+%405 = OpLabel
+%514 = OpLoad %ulong %454
+OpStore %464 %514
+OpStore %465 %ulong_0
+OpBranch %406
+%406 = OpLabel
+%515 = OpLoad %ulong %465
+%516 = OpULessThan %bool %515 %ulong_8
+OpStore %457 %516
+%517 = OpLoad %bool %457
+OpLoopMerge %408 %434 None
+OpBranchConditional %517 %407 %408
+%408 = OpLabel
+OpBranch %409
+%409 = OpLabel
+OpBranch %404
+%404 = OpLabel
+%518 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %438 %uint_2
+%519 = OpAccessChain %_ptr_Function_ushort %518 %uint_1
+%520 = OpLoad %ushort %519
+OpStore %444 %520
+OpBranch %410
+%410 = OpLabel
+%521 = OpLoad %ushort %444
+%522 = OpUConvert %ulong %521
+OpStore %466 %522
+OpBranch %412
+%412 = OpLabel
+%523 = OpLoad %ulong %464
+OpStore %474 %523
+OpStore %475 %ulong_0
+OpBranch %413
+%413 = OpLabel
+%524 = OpLoad %ulong %475
+%525 = OpULessThan %bool %524 %ulong_8
+OpStore %467 %525
+%526 = OpLoad %bool %467
+OpLoopMerge %415 %433 None
+OpBranchConditional %526 %414 %415
+%415 = OpLabel
+OpBranch %416
+%416 = OpLabel
+OpBranch %411
+%411 = OpLabel
+%527 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %438 %uint_2
+%528 = OpAccessChain %_ptr_Function_ushort %527 %uint_2
+%529 = OpLoad %ushort %528
+OpStore %445 %529
+OpBranch %417
+%417 = OpLabel
+%530 = OpLoad %ushort %445
+%531 = OpUConvert %ulong %530
+OpStore %476 %531
+OpBranch %419
+%419 = OpLabel
+%532 = OpLoad %ulong %474
+OpStore %484 %532
+OpStore %485 %ulong_0
+OpBranch %420
+%420 = OpLabel
+%533 = OpLoad %ulong %485
+%534 = OpULessThan %bool %533 %ulong_8
+OpStore %477 %534
+%535 = OpLoad %bool %477
+OpLoopMerge %422 %432 None
+OpBranchConditional %535 %421 %422
+%422 = OpLabel
+OpBranch %423
+%423 = OpLabel
+OpBranch %418
+%418 = OpLabel
+%536 = OpAccessChain %_ptr_Function_uchar %438 %uint_3
+%537 = OpLoad %uchar %536
+OpStore %446 %537
+OpBranch %424
+%424 = OpLabel
+%538 = OpLoad %uchar %446
+%539 = OpUConvert %ulong %538
+OpStore %486 %539
+OpBranch %426
+%426 = OpLabel
+%540 = OpLoad %ulong %484
+OpStore %494 %540
+OpStore %495 %ulong_0
+OpBranch %427
+%427 = OpLabel
+%541 = OpLoad %ulong %495
+%542 = OpULessThan %bool %541 %ulong_8
+OpStore %487 %542
+%543 = OpLoad %bool %487
+OpLoopMerge %429 %431 None
+OpBranchConditional %543 %428 %429
+%429 = OpLabel
+OpBranch %430
+%430 = OpLabel
+OpBranch %425
+%425 = OpLabel
+%544 = OpLoad %ulong %494
+OpReturnValue %544
+%428 = OpLabel
+%545 = OpLoad %ulong %495
+%546 = OpIMul %ulong %545 %ulong_8
+OpStore %488 %546
+%547 = OpLoad %ulong %486
+%548 = OpLoad %ulong %488
+%549 = OpShiftRightLogical %ulong %547 %548
+OpStore %489 %549
+%550 = OpLoad %ulong %489
+%551 = OpBitwiseAnd %ulong %550 %ulong_255
+OpStore %490 %551
+%552 = OpLoad %ulong %494
+%553 = OpLoad %ulong %490
+%554 = OpBitwiseXor %ulong %552 %553
+OpStore %491 %554
+%555 = OpLoad %ulong %491
+%556 = OpIMul %ulong %555 %ulong_1099511628211
+OpStore %492 %556
+%557 = OpLoad %ulong %495
+%558 = OpIAdd %ulong %557 %ulong_1
+OpStore %493 %558
+%559 = OpLoad %ulong %492
+OpStore %494 %559
+%560 = OpLoad %ulong %493
+OpStore %495 %560
+OpBranch %431
+%421 = OpLabel
+%561 = OpLoad %ulong %485
+%562 = OpIMul %ulong %561 %ulong_8
+OpStore %478 %562
+%563 = OpLoad %ulong %476
+%564 = OpLoad %ulong %478
+%565 = OpShiftRightLogical %ulong %563 %564
+OpStore %479 %565
+%566 = OpLoad %ulong %479
+%567 = OpBitwiseAnd %ulong %566 %ulong_255
+OpStore %480 %567
+%568 = OpLoad %ulong %484
+%569 = OpLoad %ulong %480
+%570 = OpBitwiseXor %ulong %568 %569
+OpStore %481 %570
+%571 = OpLoad %ulong %481
+%572 = OpIMul %ulong %571 %ulong_1099511628211
+OpStore %482 %572
+%573 = OpLoad %ulong %485
+%574 = OpIAdd %ulong %573 %ulong_1
+OpStore %483 %574
+%575 = OpLoad %ulong %482
+OpStore %484 %575
+%576 = OpLoad %ulong %483
+OpStore %485 %576
+OpBranch %432
+%414 = OpLabel
+%577 = OpLoad %ulong %475
+%578 = OpIMul %ulong %577 %ulong_8
+OpStore %468 %578
+%579 = OpLoad %ulong %466
+%580 = OpLoad %ulong %468
+%581 = OpShiftRightLogical %ulong %579 %580
+OpStore %469 %581
+%582 = OpLoad %ulong %469
+%583 = OpBitwiseAnd %ulong %582 %ulong_255
+OpStore %470 %583
+%584 = OpLoad %ulong %474
+%585 = OpLoad %ulong %470
+%586 = OpBitwiseXor %ulong %584 %585
+OpStore %471 %586
+%587 = OpLoad %ulong %471
+%588 = OpIMul %ulong %587 %ulong_1099511628211
+OpStore %472 %588
+%589 = OpLoad %ulong %475
+%590 = OpIAdd %ulong %589 %ulong_1
+OpStore %473 %590
+%591 = OpLoad %ulong %472
+OpStore %474 %591
+%592 = OpLoad %ulong %473
+OpStore %475 %592
+OpBranch %433
+%407 = OpLabel
+%593 = OpLoad %ulong %465
+%594 = OpIMul %ulong %593 %ulong_8
+OpStore %458 %594
+%595 = OpLoad %ulong %456
+%596 = OpLoad %ulong %458
+%597 = OpShiftRightLogical %ulong %595 %596
+OpStore %459 %597
+%598 = OpLoad %ulong %459
+%599 = OpBitwiseAnd %ulong %598 %ulong_255
+OpStore %460 %599
+%600 = OpLoad %ulong %464
+%601 = OpLoad %ulong %460
+%602 = OpBitwiseXor %ulong %600 %601
+OpStore %461 %602
+%603 = OpLoad %ulong %461
+%604 = OpIMul %ulong %603 %ulong_1099511628211
+OpStore %462 %604
+%605 = OpLoad %ulong %465
+%606 = OpIAdd %ulong %605 %ulong_1
+OpStore %463 %606
+%607 = OpLoad %ulong %462
+OpStore %464 %607
+%608 = OpLoad %ulong %463
+OpStore %465 %608
+OpBranch %434
+%400 = OpLabel
+%609 = OpLoad %ulong %455
+%610 = OpIMul %ulong %609 %ulong_8
+OpStore %448 %610
+%611 = OpLoad %ulong %442
+%612 = OpLoad %ulong %448
+%613 = OpShiftRightLogical %ulong %611 %612
+OpStore %449 %613
+%614 = OpLoad %ulong %449
+%615 = OpBitwiseAnd %ulong %614 %ulong_255
+OpStore %450 %615
+%616 = OpLoad %ulong %454
+%617 = OpLoad %ulong %450
+%618 = OpBitwiseXor %ulong %616 %617
+OpStore %451 %618
+%619 = OpLoad %ulong %451
+%620 = OpIMul %ulong %619 %ulong_1099511628211
+OpStore %452 %620
+%621 = OpLoad %ulong %455
+%622 = OpIAdd %ulong %621 %ulong_1
+OpStore %453 %622
+%623 = OpLoad %ulong %452
+OpStore %454 %623
+%624 = OpLoad %ulong %453
+OpStore %455 %624
+OpBranch %435
+%431 = OpLabel
+OpBranch %427
+%432 = OpLabel
+OpBranch %420
+%433 = OpLabel
+OpBranch %413
+%434 = OpLabel
+OpBranch %406
+%435 = OpLabel
+OpBranch %399
 OpFunctionEnd
-%5 = OpFunction %void None %243
-%244 = OpFunctionParameter %_ptr_Function__struct_52
-%245 = OpFunctionParameter %uint
-%246 = OpLabel
-%247 = OpVariable %_ptr_Function_uint Function
-%248 = OpVariable %_ptr_Function_ushort Function
-%249 = OpVariable %_ptr_Function_uint Function
-%250 = OpVariable %_ptr_Function_uchar Function
-%251 = OpVariable %_ptr_Function_uint Function
-%252 = OpVariable %_ptr_Function_uint Function
-%253 = OpVariable %_ptr_Function_uchar Function
-%254 = OpVariable %_ptr_Function_uint Function
-%255 = OpVariable %_ptr_Function_uchar Function
-OpStore %247 %245
-%256 = OpLoad %uint %247
-%257 = OpUConvert %ushort %256
-OpStore %248 %257
-%258 = OpAccessChain %_ptr_Function_ushort %244 %uint_0
-%259 = OpLoad %ushort %248
-OpStore %258 %259
-%260 = OpLoad %uint %247
-%261 = OpIAdd %uint %260 %uint_1
-OpStore %249 %261
-%262 = OpLoad %uint %249
-%263 = OpUConvert %uchar %262
-OpStore %250 %263
-%264 = OpAccessChain %_ptr_Function__struct_15 %244 %uint_1
-%265 = OpAccessChain %_ptr_Function_uchar %264 %uint_0
-%266 = OpLoad %uchar %250
-OpStore %265 %266
-%267 = OpLoad %uint %247
-%268 = OpIAdd %uint %267 %uint_2
-OpStore %251 %268
-%269 = OpAccessChain %_ptr_Function_uint %264 %uint_1
-%270 = OpLoad %uint %251
-OpStore %269 %270
-%271 = OpLoad %uint %247
-%272 = OpIAdd %uint %271 %uint_3
-OpStore %252 %272
-%273 = OpLoad %uint %252
-%274 = OpUConvert %uchar %273
-OpStore %253 %274
-%275 = OpAccessChain %_ptr_Function_uchar %264 %uint_2
-%276 = OpLoad %uchar %253
-OpStore %275 %276
-%277 = OpLoad %uint %247
-%279 = OpIAdd %uint %277 %uint_4
-OpStore %254 %279
-%280 = OpLoad %uint %254
-%281 = OpUConvert %uchar %280
-OpStore %255 %281
-%282 = OpAccessChain %_ptr_Function_uchar %244 %uint_2
-%283 = OpLoad %uchar %255
-OpStore %282 %283
-OpReturn
-OpFunctionEnd
-%6 = OpFunction %ulong None %284
-%285 = OpFunctionParameter %ulong
-%286 = OpLabel
-%293 = OpVariable %_ptr_Function__struct_158 Function
-%294 = OpVariable %_ptr_Function__struct_158 Function
-%295 = OpVariable %_ptr_Function__struct_158 Function
-%296 = OpVariable %_ptr_Function__struct_158 Function
-%297 = OpVariable %_ptr_Function__struct_158 Function
-%298 = OpVariable %_ptr_Function__struct_158 Function
-%299 = OpVariable %_ptr_Function__struct_158 Function
-%300 = OpVariable %_ptr_Function__struct_52 Function
-%301 = OpVariable %_ptr_Function__struct_52 Function
-%302 = OpVariable %_ptr_Function__struct_52 Function
-%303 = OpVariable %_ptr_Function__struct_52 Function
-%304 = OpVariable %_ptr_Function__struct_52 Function
-%305 = OpVariable %_ptr_Function__struct_158 Function
-%306 = OpVariable %_ptr_Function_ulong Function
-%307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_uint Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_ulong Function
-%312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_ulong Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_ulong Function
-%316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_ulong Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_ulong Function
-%326 = OpVariable %_ptr_Function_ulong Function
-%327 = OpVariable %_ptr_Function_uint Function
-%328 = OpVariable %_ptr_Function_ulong Function
-%329 = OpVariable %_ptr_Function_uint Function
-%330 = OpVariable %_ptr_Function_ushort Function
-%331 = OpVariable %_ptr_Function_uint Function
-%332 = OpVariable %_ptr_Function_ushort Function
-%333 = OpVariable %_ptr_Function_uint Function
-%334 = OpVariable %_ptr_Function_ushort Function
-%335 = OpVariable %_ptr_Function_uint Function
-%336 = OpVariable %_ptr_Function_uchar Function
-%337 = OpVariable %_ptr_Function_uint Function
-%338 = OpVariable %_ptr_Function_uint Function
-%339 = OpVariable %_ptr_Function_uint Function
-%340 = OpVariable %_ptr_Function_ulong Function
-%341 = OpVariable %_ptr_Function_uint Function
-%342 = OpVariable %_ptr_Function_uint Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_uchar Function
-%345 = OpVariable %_ptr_Function_uchar Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_uint Function
-%351 = OpVariable %_ptr_Function_uint Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_uint Function
-%354 = OpVariable %_ptr_Function_uint Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_ushort Function
-%359 = OpVariable %_ptr_Function_uint Function
-%360 = OpVariable %_ptr_Function_uchar Function
-%361 = OpVariable %_ptr_Function_uint Function
-%362 = OpVariable %_ptr_Function_uint Function
-%363 = OpVariable %_ptr_Function_uchar Function
-%364 = OpVariable %_ptr_Function_uint Function
-%365 = OpVariable %_ptr_Function_uchar Function
-%366 = OpVariable %_ptr_Function_ushort Function
-%367 = OpVariable %_ptr_Function_uint Function
-%368 = OpVariable %_ptr_Function_uchar Function
-%369 = OpVariable %_ptr_Function_uint Function
-%370 = OpVariable %_ptr_Function_uint Function
-%371 = OpVariable %_ptr_Function_uchar Function
-%372 = OpVariable %_ptr_Function_uint Function
-%373 = OpVariable %_ptr_Function_uchar Function
-%374 = OpVariable %_ptr_Function_ushort Function
-%375 = OpVariable %_ptr_Function_uint Function
-%376 = OpVariable %_ptr_Function_uchar Function
-%377 = OpVariable %_ptr_Function_uint Function
-%378 = OpVariable %_ptr_Function_uint Function
-%379 = OpVariable %_ptr_Function_uchar Function
-%380 = OpVariable %_ptr_Function_uint Function
-%381 = OpVariable %_ptr_Function_uchar Function
-OpStore %306 %285
-%382 = OpFunctionCall %ulong %7
-OpStore %307 %382
-%383 = OpLoad %ulong %306
-%384 = OpUConvert %uint %383
-OpStore %308 %384
-%385 = OpLoad %ulong %307
-%387 = OpFunctionCall %ulong %8 %385 %ulong_12
-OpStore %309 %387
-%388 = OpLoad %ulong %309
-%390 = OpFunctionCall %ulong %8 %388 %ulong_20
-OpStore %310 %390
-%391 = OpLoad %ulong %310
-%393 = OpFunctionCall %ulong %8 %391 %ulong_40
-OpStore %311 %393
-%394 = OpLoad %ulong %311
-%396 = OpFunctionCall %ulong %8 %394 %ulong_88
-OpStore %312 %396
-%397 = OpLoad %ulong %312
-%399 = OpFunctionCall %ulong %8 %397 %ulong_4
-OpStore %313 %399
-%400 = OpLoad %ulong %313
-%401 = OpFunctionCall %ulong %8 %400 %ulong_4
-OpStore %314 %401
-%402 = OpLoad %ulong %314
-%404 = OpFunctionCall %ulong %8 %402 %ulong_8
-OpStore %315 %404
-%405 = OpLoad %ulong %315
-%406 = OpFunctionCall %ulong %8 %405 %ulong_8
-OpStore %316 %406
-%407 = OpLoad %ulong %316
-%408 = OpFunctionCall %ulong %8 %407 %ulong_4
-OpStore %317 %408
-%409 = OpLoad %ulong %317
-%410 = OpFunctionCall %ulong %8 %409 %ulong_8
-OpStore %318 %410
-%411 = OpLoad %ulong %318
-%412 = OpFunctionCall %ulong %8 %411 %ulong_4
-OpStore %319 %412
-%413 = OpLoad %ulong %319
-%415 = OpFunctionCall %ulong %8 %413 %ulong_16
-OpStore %320 %415
-%416 = OpLoad %ulong %320
-%418 = OpFunctionCall %ulong %8 %416 %ulong_24
-OpStore %321 %418
-%419 = OpLoad %ulong %321
-%421 = OpFunctionCall %ulong %8 %419 %ulong_32
-OpStore %322 %421
-%422 = OpLoad %ulong %322
-%424 = OpFunctionCall %ulong %8 %422 %ulong_38
-OpStore %323 %424
-%425 = OpLoad %ulong %323
-%426 = OpFunctionCall %ulong %8 %425 %ulong_40
-OpStore %324 %426
-%427 = OpLoad %ulong %324
-%429 = OpFunctionCall %ulong %8 %427 %ulong_80
-OpStore %325 %429
-OpStore %293 %430
-%431 = OpLoad %_struct_158 %293
-OpStore %294 %431
-%432 = OpLoad %ulong %325
-%433 = OpLoad %_struct_158 %294
-%434 = OpFunctionCall %ulong %4 %432 %433
-OpStore %326 %434
-%435 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
-%436 = OpAccessChain %_ptr_Function__struct_52 %435 %uint_0
-%438 = OpLoad %uint %308
-%439 = OpIAdd %uint %uint_10 %438
-OpStore %327 %439
-OpBranch %287
-%287 = OpLabel
-%440 = OpLoad %uint %327
-%441 = OpUConvert %ushort %440
-OpStore %358 %441
-%442 = OpAccessChain %_ptr_Function_ushort %436 %uint_0
-%443 = OpLoad %ushort %358
-OpStore %442 %443
-%444 = OpLoad %uint %327
-%445 = OpIAdd %uint %444 %uint_1
-OpStore %359 %445
-%446 = OpLoad %uint %359
-%447 = OpUConvert %uchar %446
-OpStore %360 %447
-%448 = OpAccessChain %_ptr_Function__struct_15 %436 %uint_1
-%449 = OpAccessChain %_ptr_Function_uchar %448 %uint_0
-%450 = OpLoad %uchar %360
-OpStore %449 %450
-%451 = OpLoad %uint %327
-%452 = OpIAdd %uint %451 %uint_2
-OpStore %361 %452
-%453 = OpAccessChain %_ptr_Function_uint %448 %uint_1
-%454 = OpLoad %uint %361
-OpStore %453 %454
-%455 = OpLoad %uint %327
-%456 = OpIAdd %uint %455 %uint_3
-OpStore %362 %456
-%457 = OpLoad %uint %362
-%458 = OpUConvert %uchar %457
-OpStore %363 %458
-%459 = OpAccessChain %_ptr_Function_uchar %448 %uint_2
-%460 = OpLoad %uchar %363
-OpStore %459 %460
-%461 = OpLoad %uint %327
-%462 = OpIAdd %uint %461 %uint_4
-OpStore %364 %462
-%463 = OpLoad %uint %364
-%464 = OpUConvert %uchar %463
-OpStore %365 %464
-%465 = OpAccessChain %_ptr_Function_uchar %436 %uint_2
-%466 = OpLoad %uchar %365
-OpStore %465 %466
-OpBranch %288
-%288 = OpLabel
-%468 = OpLoad %ulong %306
-%469 = OpIAdd %ulong %ulong_18364758544493064720 %468
-OpStore %328 %469
-%470 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
-%471 = OpAccessChain %_ptr_Function_ulong %470 %uint_1
-%472 = OpLoad %ulong %328
-OpStore %471 %472
-%474 = OpLoad %uint %308
-%475 = OpIAdd %uint %uint_20 %474
-OpStore %329 %475
-%476 = OpLoad %uint %329
-%477 = OpUConvert %ushort %476
-OpStore %330 %477
-%478 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %470 %uint_2
-%479 = OpAccessChain %_ptr_Function_ushort %478 %uint_0
-%480 = OpLoad %ushort %330
-OpStore %479 %480
-%482 = OpLoad %uint %308
-%483 = OpIAdd %uint %uint_21 %482
-OpStore %331 %483
-%484 = OpLoad %uint %331
-%485 = OpUConvert %ushort %484
-OpStore %332 %485
-%486 = OpAccessChain %_ptr_Function_ushort %478 %uint_1
-%487 = OpLoad %ushort %332
-OpStore %486 %487
-%489 = OpLoad %uint %308
-%490 = OpIAdd %uint %uint_22 %489
-OpStore %333 %490
-%491 = OpLoad %uint %333
-%492 = OpUConvert %ushort %491
-OpStore %334 %492
-%493 = OpAccessChain %_ptr_Function_ushort %478 %uint_2
-%494 = OpLoad %ushort %334
-OpStore %493 %494
-%496 = OpLoad %uint %308
-%497 = OpIAdd %uint %uint_23 %496
-OpStore %335 %497
-%498 = OpLoad %uint %335
-%499 = OpUConvert %uchar %498
-OpStore %336 %499
-%500 = OpAccessChain %_ptr_Function_uchar %470 %uint_3
-%501 = OpLoad %uchar %336
-OpStore %500 %501
-%502 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
-%503 = OpAccessChain %_ptr_Function__struct_52 %502 %uint_0
-%505 = OpLoad %uint %308
-%506 = OpIAdd %uint %uint_30 %505
-OpStore %337 %506
-OpBranch %289
-%289 = OpLabel
-%507 = OpLoad %uint %337
-%508 = OpUConvert %ushort %507
-OpStore %366 %508
-%509 = OpAccessChain %_ptr_Function_ushort %503 %uint_0
-%510 = OpLoad %ushort %366
-OpStore %509 %510
-%511 = OpLoad %uint %337
-%512 = OpIAdd %uint %511 %uint_1
-OpStore %367 %512
-%513 = OpLoad %uint %367
-%514 = OpUConvert %uchar %513
-OpStore %368 %514
-%515 = OpAccessChain %_ptr_Function__struct_15 %503 %uint_1
-%516 = OpAccessChain %_ptr_Function_uchar %515 %uint_0
-%517 = OpLoad %uchar %368
-OpStore %516 %517
-%518 = OpLoad %uint %337
-%519 = OpIAdd %uint %518 %uint_2
-OpStore %369 %519
-%520 = OpAccessChain %_ptr_Function_uint %515 %uint_1
-%521 = OpLoad %uint %369
-OpStore %520 %521
-%522 = OpLoad %uint %337
-%523 = OpIAdd %uint %522 %uint_3
-OpStore %370 %523
-%524 = OpLoad %uint %370
-%525 = OpUConvert %uchar %524
-OpStore %371 %525
-%526 = OpAccessChain %_ptr_Function_uchar %515 %uint_2
-%527 = OpLoad %uchar %371
-OpStore %526 %527
-%528 = OpLoad %uint %337
-%529 = OpIAdd %uint %528 %uint_4
-OpStore %372 %529
-%530 = OpLoad %uint %372
-%531 = OpUConvert %uchar %530
-OpStore %373 %531
-%532 = OpAccessChain %_ptr_Function_uchar %503 %uint_2
-%533 = OpLoad %uchar %373
-OpStore %532 %533
-OpBranch %290
-%290 = OpLabel
-%534 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
-%535 = OpAccessChain %_ptr_Function__struct_52 %534 %uint_1
-%537 = OpLoad %uint %308
-%538 = OpIAdd %uint %uint_40 %537
-OpStore %338 %538
-OpBranch %291
-%291 = OpLabel
-%539 = OpLoad %uint %338
-%540 = OpUConvert %ushort %539
-OpStore %374 %540
-%541 = OpAccessChain %_ptr_Function_ushort %535 %uint_0
-%542 = OpLoad %ushort %374
-OpStore %541 %542
-%543 = OpLoad %uint %338
-%544 = OpIAdd %uint %543 %uint_1
-OpStore %375 %544
-%545 = OpLoad %uint %375
-%546 = OpUConvert %uchar %545
-OpStore %376 %546
-%547 = OpAccessChain %_ptr_Function__struct_15 %535 %uint_1
-%548 = OpAccessChain %_ptr_Function_uchar %547 %uint_0
-%549 = OpLoad %uchar %376
-OpStore %548 %549
-%550 = OpLoad %uint %338
-%551 = OpIAdd %uint %550 %uint_2
-OpStore %377 %551
-%552 = OpAccessChain %_ptr_Function_uint %547 %uint_1
-%553 = OpLoad %uint %377
-OpStore %552 %553
-%554 = OpLoad %uint %338
-%555 = OpIAdd %uint %554 %uint_3
-OpStore %378 %555
-%556 = OpLoad %uint %378
-%557 = OpUConvert %uchar %556
-OpStore %379 %557
-%558 = OpAccessChain %_ptr_Function_uchar %547 %uint_2
-%559 = OpLoad %uchar %379
-OpStore %558 %559
-%560 = OpLoad %uint %338
-%561 = OpIAdd %uint %560 %uint_4
-OpStore %380 %561
-%562 = OpLoad %uint %380
-%563 = OpUConvert %uchar %562
-OpStore %381 %563
-%564 = OpAccessChain %_ptr_Function_uchar %535 %uint_2
-%565 = OpLoad %uchar %381
-OpStore %564 %565
-OpBranch %292
-%292 = OpLabel
-%567 = OpLoad %uint %308
-%568 = OpIAdd %uint %uint_50 %567
-OpStore %339 %568
-%569 = OpAccessChain %_ptr_Function_uint %293 %uint_2
-%570 = OpLoad %uint %339
-OpStore %569 %570
-%571 = OpLoad %_struct_158 %293
-OpStore %295 %571
-%572 = OpLoad %ulong %326
-%573 = OpLoad %_struct_158 %295
-%574 = OpFunctionCall %ulong %4 %572 %573
-OpStore %340 %574
-%575 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
-%576 = OpAccessChain %_ptr_Function__struct_52 %575 %uint_0
-%577 = OpAccessChain %_ptr_Function__struct_15 %576 %uint_1
-%578 = OpAccessChain %_ptr_Function_uint %577 %uint_1
-%579 = OpLoad %uint %578
-OpStore %341 %579
-%580 = OpLoad %uint %341
-%582 = OpBitwiseXor %uint %580 %uint_4042322160
-OpStore %342 %582
-%583 = OpLoad %uint %342
-OpStore %578 %583
-%584 = OpLoad %_struct_158 %293
-OpStore %296 %584
-%585 = OpLoad %ulong %340
-%586 = OpLoad %_struct_158 %296
-%587 = OpFunctionCall %ulong %4 %585 %586
-OpStore %343 %587
-%588 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
-%589 = OpAccessChain %_ptr_Function__struct_52 %588 %uint_1
-%590 = OpAccessChain %_ptr_Function__struct_15 %589 %uint_1
-%591 = OpAccessChain %_ptr_Function_uchar %590 %uint_2
-%592 = OpLoad %uchar %591
-OpStore %344 %592
-%593 = OpLoad %uchar %344
-%595 = OpIAdd %uchar %593 %uchar_7
-OpStore %345 %595
-%596 = OpLoad %uchar %345
-OpStore %591 %596
-%597 = OpLoad %_struct_158 %293
-OpStore %297 %597
-%598 = OpLoad %ulong %343
-%599 = OpLoad %_struct_158 %297
-%600 = OpFunctionCall %ulong %4 %598 %599
-OpStore %346 %600
-%601 = OpAccessChain %_ptr_Function_ulong %575 %uint_1
-%602 = OpLoad %ulong %601
-OpStore %347 %602
-%603 = OpLoad %ulong %347
-%605 = OpShiftRightLogical %ulong %603 %ulong_3
-OpStore %348 %605
-%606 = OpLoad %ulong %348
-OpStore %601 %606
-%607 = OpLoad %_struct_158 %293
-OpStore %298 %607
-%608 = OpLoad %ulong %346
-%609 = OpLoad %_struct_158 %298
-%610 = OpFunctionCall %ulong %4 %608 %609
-OpStore %349 %610
-%611 = OpLoad %uint %569
-OpStore %350 %611
-%612 = OpLoad %uint %350
-%613 = OpIMul %uint %612 %uint_3
-OpStore %351 %613
-%614 = OpLoad %uint %351
-OpStore %569 %614
-%615 = OpLoad %_struct_158 %293
-OpStore %299 %615
-%616 = OpLoad %ulong %349
-%617 = OpLoad %_struct_158 %299
-%618 = OpFunctionCall %ulong %4 %616 %617
-OpStore %352 %618
-%619 = OpAccessChain %_ptr_Function__struct_52 %588 %uint_0
-%620 = OpLoad %_struct_52 %619
-OpStore %301 %620
-%621 = OpLoad %_struct_52 %301
-OpStore %300 %621
-%622 = OpAccessChain %_ptr_Function__struct_15 %300 %uint_1
-%623 = OpAccessChain %_ptr_Function_uint %622 %uint_1
-%624 = OpLoad %uint %623
-OpStore %353 %624
-%625 = OpLoad %uint %353
-%626 = OpIAdd %uint %625 %uint_1
-OpStore %354 %626
-%627 = OpLoad %uint %354
-OpStore %623 %627
-%628 = OpLoad %_struct_52 %300
-OpStore %302 %628
-%629 = OpLoad %ulong %352
-%630 = OpLoad %_struct_52 %302
-%631 = OpFunctionCall %ulong %2 %629 %630
-OpStore %355 %631
-%632 = OpLoad %_struct_52 %619
-OpStore %303 %632
-%633 = OpLoad %ulong %355
-%634 = OpLoad %_struct_52 %303
-%635 = OpFunctionCall %ulong %2 %633 %634
-OpStore %356 %635
-%636 = OpLoad %_struct_52 %300
-OpStore %304 %636
-%637 = OpLoad %_struct_52 %304
-OpStore %619 %637
-%638 = OpLoad %_struct_158 %293
-OpStore %305 %638
-%639 = OpLoad %ulong %356
-%640 = OpLoad %_struct_158 %305
-%641 = OpFunctionCall %ulong %4 %639 %640
-OpStore %357 %641
-%642 = OpLoad %ulong %357
-OpReturnValue %642
-OpFunctionEnd
-%7 = OpFunction %ulong None %643
-%644 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%8 = OpFunction %ulong None %646
-%647 = OpFunctionParameter %ulong
-%648 = OpFunctionParameter %ulong
-%649 = OpLabel
-%655 = OpVariable %_ptr_Function_ulong Function
-%656 = OpVariable %_ptr_Function_ulong Function
-%658 = OpVariable %_ptr_Function_bool Function
-%659 = OpVariable %_ptr_Function_ulong Function
-%660 = OpVariable %_ptr_Function_ulong Function
-%661 = OpVariable %_ptr_Function_ulong Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_ulong Function
-OpStore %655 %647
-OpStore %656 %648
-%667 = OpLoad %ulong %655
-OpStore %665 %667
-OpStore %666 %ulong_0
-OpBranch %650
-%650 = OpLabel
-%669 = OpLoad %ulong %666
-%670 = OpULessThan %bool %669 %ulong_8
-OpStore %658 %670
-%671 = OpLoad %bool %658
-OpLoopMerge %652 %653 None
-OpBranchConditional %671 %651 %652
-%652 = OpLabel
-%672 = OpLoad %ulong %665
-OpReturnValue %672
-%651 = OpLabel
-%673 = OpLoad %ulong %666
-%674 = OpIMul %ulong %673 %ulong_8
-OpStore %659 %674
-%675 = OpLoad %ulong %656
-%676 = OpLoad %ulong %659
-%677 = OpShiftRightLogical %ulong %675 %676
-OpStore %660 %677
-%678 = OpLoad %ulong %660
-%680 = OpBitwiseAnd %ulong %678 %ulong_255
-OpStore %661 %680
-%681 = OpLoad %ulong %665
-%682 = OpLoad %ulong %661
-%683 = OpBitwiseXor %ulong %681 %682
-OpStore %662 %683
-%684 = OpLoad %ulong %662
-%686 = OpIMul %ulong %684 %ulong_1099511628211
-OpStore %663 %686
-%687 = OpLoad %ulong %666
-%689 = OpIAdd %ulong %687 %ulong_1
-OpStore %664 %689
-%690 = OpLoad %ulong %663
-OpStore %665 %690
-%691 = OpLoad %ulong %664
-OpStore %666 %691
-OpBranch %653
-%653 = OpLabel
-OpBranch %650
-OpFunctionEnd
-%9 = OpFunction %ulong None %692
-%693 = OpFunctionParameter %ulong
-%694 = OpFunctionParameter %uchar
-%695 = OpLabel
+%4 = OpFunction %ulong None %627
+%628 = OpFunctionParameter %ulong
+%629 = OpFunctionParameter %_struct_626
+%630 = OpLabel
+%680 = OpVariable %_ptr_Function__struct_626 Function
+%681 = OpVariable %_ptr_Function__struct_626 Function
+%682 = OpVariable %_ptr_Function__struct_393 Function
+%683 = OpVariable %_ptr_Function__struct_393 Function
+%684 = OpVariable %_ptr_Function__struct_163 Function
+%685 = OpVariable %_ptr_Function__struct_163 Function
+%686 = OpVariable %_ptr_Function__struct_163 Function
+%687 = OpVariable %_ptr_Function_ulong Function
+%688 = OpVariable %_ptr_Function_ulong Function
+%689 = OpVariable %_ptr_Function_ulong Function
+%690 = OpVariable %_ptr_Function_uint Function
+%691 = OpVariable %_ptr_Function_ulong Function
+%692 = OpVariable %_ptr_Function_ulong Function
+%693 = OpVariable %_ptr_Function_ushort Function
+%694 = OpVariable %_ptr_Function_ushort Function
+%695 = OpVariable %_ptr_Function_ushort Function
+%696 = OpVariable %_ptr_Function_uchar Function
+%697 = OpVariable %_ptr_Function_bool Function
+%698 = OpVariable %_ptr_Function_ulong Function
+%699 = OpVariable %_ptr_Function_ulong Function
+%700 = OpVariable %_ptr_Function_ulong Function
+%701 = OpVariable %_ptr_Function_ulong Function
 %702 = OpVariable %_ptr_Function_ulong Function
-%703 = OpVariable %_ptr_Function_uchar Function
+%703 = OpVariable %_ptr_Function_ulong Function
 %704 = OpVariable %_ptr_Function_ulong Function
-%705 = OpVariable %_ptr_Function_bool Function
+%705 = OpVariable %_ptr_Function_ulong Function
 %706 = OpVariable %_ptr_Function_ulong Function
-%707 = OpVariable %_ptr_Function_ulong Function
+%707 = OpVariable %_ptr_Function_bool Function
 %708 = OpVariable %_ptr_Function_ulong Function
 %709 = OpVariable %_ptr_Function_ulong Function
 %710 = OpVariable %_ptr_Function_ulong Function
 %711 = OpVariable %_ptr_Function_ulong Function
 %712 = OpVariable %_ptr_Function_ulong Function
 %713 = OpVariable %_ptr_Function_ulong Function
-OpStore %702 %693
-OpStore %703 %694
-%714 = OpLoad %uchar %703
-%715 = OpUConvert %ulong %714
-OpStore %704 %715
-OpBranch %696
-%696 = OpLabel
-%716 = OpLoad %ulong %702
-OpStore %712 %716
-OpStore %713 %ulong_0
-OpBranch %697
-%697 = OpLabel
-%717 = OpLoad %ulong %713
-%718 = OpULessThan %bool %717 %ulong_8
-OpStore %705 %718
-%719 = OpLoad %bool %705
-OpLoopMerge %699 %701 None
-OpBranchConditional %719 %698 %699
-%699 = OpLabel
-OpBranch %700
-%700 = OpLabel
-%720 = OpLoad %ulong %712
-OpReturnValue %720
-%698 = OpLabel
-%721 = OpLoad %ulong %713
-%722 = OpIMul %ulong %721 %ulong_8
-OpStore %706 %722
-%723 = OpLoad %ulong %704
-%724 = OpLoad %ulong %706
-%725 = OpShiftRightLogical %ulong %723 %724
-OpStore %707 %725
-%726 = OpLoad %ulong %707
-%727 = OpBitwiseAnd %ulong %726 %ulong_255
-OpStore %708 %727
-%728 = OpLoad %ulong %712
-%729 = OpLoad %ulong %708
-%730 = OpBitwiseXor %ulong %728 %729
-OpStore %709 %730
-%731 = OpLoad %ulong %709
-%732 = OpIMul %ulong %731 %ulong_1099511628211
-OpStore %710 %732
-%733 = OpLoad %ulong %713
-%734 = OpIAdd %ulong %733 %ulong_1
-OpStore %711 %734
-%735 = OpLoad %ulong %710
-OpStore %712 %735
-%736 = OpLoad %ulong %711
-OpStore %713 %736
-OpBranch %701
-%701 = OpLabel
-OpBranch %697
-OpFunctionEnd
-%10 = OpFunction %ulong None %737
-%738 = OpFunctionParameter %ulong
-%739 = OpFunctionParameter %ushort
-%740 = OpLabel
-%747 = OpVariable %_ptr_Function_ulong Function
-%748 = OpVariable %_ptr_Function_ushort Function
+%714 = OpVariable %_ptr_Function_ulong Function
+%715 = OpVariable %_ptr_Function_ulong Function
+%716 = OpVariable %_ptr_Function_ulong Function
+%717 = OpVariable %_ptr_Function_bool Function
+%718 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_ulong Function
+%720 = OpVariable %_ptr_Function_ulong Function
+%721 = OpVariable %_ptr_Function_ulong Function
+%722 = OpVariable %_ptr_Function_ulong Function
+%723 = OpVariable %_ptr_Function_ulong Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_bool Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_ulong Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_bool Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_bool Function
+%748 = OpVariable %_ptr_Function_ulong Function
 %749 = OpVariable %_ptr_Function_ulong Function
-%750 = OpVariable %_ptr_Function_bool Function
+%750 = OpVariable %_ptr_Function_ulong Function
 %751 = OpVariable %_ptr_Function_ulong Function
 %752 = OpVariable %_ptr_Function_ulong Function
 %753 = OpVariable %_ptr_Function_ulong Function
 %754 = OpVariable %_ptr_Function_ulong Function
 %755 = OpVariable %_ptr_Function_ulong Function
-%756 = OpVariable %_ptr_Function_ulong Function
-%757 = OpVariable %_ptr_Function_ulong Function
-%758 = OpVariable %_ptr_Function_ulong Function
-OpStore %747 %738
-OpStore %748 %739
-%759 = OpLoad %ushort %748
-%760 = OpUConvert %ulong %759
-OpStore %749 %760
-OpBranch %741
-%741 = OpLabel
-%761 = OpLoad %ulong %747
-OpStore %757 %761
-OpStore %758 %ulong_0
-OpBranch %742
-%742 = OpLabel
-%762 = OpLoad %ulong %758
-%763 = OpULessThan %bool %762 %ulong_8
-OpStore %750 %763
-%764 = OpLoad %bool %750
-OpLoopMerge %744 %746 None
-OpBranchConditional %764 %743 %744
-%744 = OpLabel
-OpBranch %745
-%745 = OpLabel
-%765 = OpLoad %ulong %757
-OpReturnValue %765
-%743 = OpLabel
-%766 = OpLoad %ulong %758
-%767 = OpIMul %ulong %766 %ulong_8
-OpStore %751 %767
-%768 = OpLoad %ulong %749
-%769 = OpLoad %ulong %751
-%770 = OpShiftRightLogical %ulong %768 %769
-OpStore %752 %770
-%771 = OpLoad %ulong %752
-%772 = OpBitwiseAnd %ulong %771 %ulong_255
-OpStore %753 %772
-%773 = OpLoad %ulong %757
-%774 = OpLoad %ulong %753
-%775 = OpBitwiseXor %ulong %773 %774
-OpStore %754 %775
-%776 = OpLoad %ulong %754
-%777 = OpIMul %ulong %776 %ulong_1099511628211
-OpStore %755 %777
-%778 = OpLoad %ulong %758
-%779 = OpIAdd %ulong %778 %ulong_1
-OpStore %756 %779
-%780 = OpLoad %ulong %755
-OpStore %757 %780
-%781 = OpLoad %ulong %756
-OpStore %758 %781
-OpBranch %746
-%746 = OpLabel
-OpBranch %742
+OpStore %687 %628
+OpStore %680 %629
+%756 = OpLoad %_struct_626 %680
+OpStore %681 %756
+%757 = OpAccessChain %_ptr_Function__struct_393 %681 %uint_0
+%758 = OpLoad %_struct_393 %757
+OpStore %682 %758
+OpBranch %631
+%631 = OpLabel
+%759 = OpLoad %_struct_393 %682
+OpStore %683 %759
+%760 = OpAccessChain %_ptr_Function__struct_163 %683 %uint_0
+%761 = OpLoad %_struct_163 %760
+OpStore %684 %761
+%762 = OpLoad %ulong %687
+%763 = OpLoad %_struct_163 %684
+%764 = OpFunctionCall %ulong %2 %762 %763
+OpStore %691 %764
+%765 = OpAccessChain %_ptr_Function_ulong %683 %uint_1
+%766 = OpLoad %ulong %765
+OpStore %692 %766
+OpBranch %632
+%632 = OpLabel
+%767 = OpLoad %ulong %691
+OpStore %704 %767
+OpStore %705 %ulong_0
+OpBranch %633
+%633 = OpLabel
+%768 = OpLoad %ulong %705
+%769 = OpULessThan %bool %768 %ulong_8
+OpStore %697 %769
+%770 = OpLoad %bool %697
+OpLoopMerge %635 %678 None
+OpBranchConditional %770 %634 %635
+%635 = OpLabel
+OpBranch %636
+%636 = OpLabel
+%771 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %683 %uint_2
+%772 = OpAccessChain %_ptr_Function_ushort %771 %uint_0
+%773 = OpLoad %ushort %772
+OpStore %693 %773
+OpBranch %637
+%637 = OpLabel
+%774 = OpLoad %ushort %693
+%775 = OpUConvert %ulong %774
+OpStore %706 %775
+OpBranch %639
+%639 = OpLabel
+%776 = OpLoad %ulong %704
+OpStore %714 %776
+OpStore %715 %ulong_0
+OpBranch %640
+%640 = OpLabel
+%777 = OpLoad %ulong %715
+%778 = OpULessThan %bool %777 %ulong_8
+OpStore %707 %778
+%779 = OpLoad %bool %707
+OpLoopMerge %642 %677 None
+OpBranchConditional %779 %641 %642
+%642 = OpLabel
+OpBranch %643
+%643 = OpLabel
+OpBranch %638
+%638 = OpLabel
+%780 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %683 %uint_2
+%781 = OpAccessChain %_ptr_Function_ushort %780 %uint_1
+%782 = OpLoad %ushort %781
+OpStore %694 %782
+OpBranch %644
+%644 = OpLabel
+%783 = OpLoad %ushort %694
+%784 = OpUConvert %ulong %783
+OpStore %716 %784
+OpBranch %646
+%646 = OpLabel
+%785 = OpLoad %ulong %714
+OpStore %724 %785
+OpStore %725 %ulong_0
+OpBranch %647
+%647 = OpLabel
+%786 = OpLoad %ulong %725
+%787 = OpULessThan %bool %786 %ulong_8
+OpStore %717 %787
+%788 = OpLoad %bool %717
+OpLoopMerge %649 %676 None
+OpBranchConditional %788 %648 %649
+%649 = OpLabel
+OpBranch %650
+%650 = OpLabel
+OpBranch %645
+%645 = OpLabel
+%789 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %683 %uint_2
+%790 = OpAccessChain %_ptr_Function_ushort %789 %uint_2
+%791 = OpLoad %ushort %790
+OpStore %695 %791
+OpBranch %651
+%651 = OpLabel
+%792 = OpLoad %ushort %695
+%793 = OpUConvert %ulong %792
+OpStore %726 %793
+OpBranch %653
+%653 = OpLabel
+%794 = OpLoad %ulong %724
+OpStore %734 %794
+OpStore %735 %ulong_0
+OpBranch %654
+%654 = OpLabel
+%795 = OpLoad %ulong %735
+%796 = OpULessThan %bool %795 %ulong_8
+OpStore %727 %796
+%797 = OpLoad %bool %727
+OpLoopMerge %656 %675 None
+OpBranchConditional %797 %655 %656
+%656 = OpLabel
+OpBranch %657
+%657 = OpLabel
+OpBranch %652
+%652 = OpLabel
+%798 = OpAccessChain %_ptr_Function_uchar %683 %uint_3
+%799 = OpLoad %uchar %798
+OpStore %696 %799
+OpBranch %658
+%658 = OpLabel
+%800 = OpLoad %uchar %696
+%801 = OpUConvert %ulong %800
+OpStore %736 %801
+OpBranch %660
+%660 = OpLabel
+%802 = OpLoad %ulong %734
+OpStore %744 %802
+OpStore %745 %ulong_0
+OpBranch %661
+%661 = OpLabel
+%803 = OpLoad %ulong %745
+%804 = OpULessThan %bool %803 %ulong_8
+OpStore %737 %804
+%805 = OpLoad %bool %737
+OpLoopMerge %663 %674 None
+OpBranchConditional %805 %662 %663
+%663 = OpLabel
+OpBranch %664
+%664 = OpLabel
+OpBranch %659
+%659 = OpLabel
+OpBranch %665
+%665 = OpLabel
+%807 = OpAccessChain %_ptr_Function__arr__struct_163_uint_2 %681 %uint_1
+%808 = OpAccessChain %_ptr_Function__struct_163 %807 %uint_0
+%809 = OpLoad %_struct_163 %808
+OpStore %685 %809
+%810 = OpLoad %ulong %744
+%811 = OpLoad %_struct_163 %685
+%812 = OpFunctionCall %ulong %2 %810 %811
+OpStore %688 %812
+%813 = OpAccessChain %_ptr_Function__struct_163 %807 %uint_1
+%814 = OpLoad %_struct_163 %813
+OpStore %686 %814
+%815 = OpLoad %ulong %688
+%816 = OpLoad %_struct_163 %686
+%817 = OpFunctionCall %ulong %2 %815 %816
+OpStore %689 %817
+%818 = OpAccessChain %_ptr_Function_uint %681 %uint_2
+%819 = OpLoad %uint %818
+OpStore %690 %819
+OpBranch %666
+%666 = OpLabel
+%820 = OpLoad %uint %690
+%821 = OpUConvert %ulong %820
+OpStore %746 %821
+OpBranch %668
+%668 = OpLabel
+%822 = OpLoad %ulong %689
+OpStore %754 %822
+OpStore %755 %ulong_0
+OpBranch %669
+%669 = OpLabel
+%823 = OpLoad %ulong %755
+%824 = OpULessThan %bool %823 %ulong_8
+OpStore %747 %824
+%825 = OpLoad %bool %747
+OpLoopMerge %671 %673 None
+OpBranchConditional %825 %670 %671
+%671 = OpLabel
+OpBranch %672
+%672 = OpLabel
+OpBranch %667
+%667 = OpLabel
+%826 = OpLoad %ulong %754
+OpReturnValue %826
+%670 = OpLabel
+%827 = OpLoad %ulong %755
+%828 = OpIMul %ulong %827 %ulong_8
+OpStore %748 %828
+%829 = OpLoad %ulong %746
+%830 = OpLoad %ulong %748
+%831 = OpShiftRightLogical %ulong %829 %830
+OpStore %749 %831
+%832 = OpLoad %ulong %749
+%833 = OpBitwiseAnd %ulong %832 %ulong_255
+OpStore %750 %833
+%834 = OpLoad %ulong %754
+%835 = OpLoad %ulong %750
+%836 = OpBitwiseXor %ulong %834 %835
+OpStore %751 %836
+%837 = OpLoad %ulong %751
+%838 = OpIMul %ulong %837 %ulong_1099511628211
+OpStore %752 %838
+%839 = OpLoad %ulong %755
+%840 = OpIAdd %ulong %839 %ulong_1
+OpStore %753 %840
+%841 = OpLoad %ulong %752
+OpStore %754 %841
+%842 = OpLoad %ulong %753
+OpStore %755 %842
+OpBranch %673
+%662 = OpLabel
+%843 = OpLoad %ulong %745
+%844 = OpIMul %ulong %843 %ulong_8
+OpStore %738 %844
+%845 = OpLoad %ulong %736
+%846 = OpLoad %ulong %738
+%847 = OpShiftRightLogical %ulong %845 %846
+OpStore %739 %847
+%848 = OpLoad %ulong %739
+%849 = OpBitwiseAnd %ulong %848 %ulong_255
+OpStore %740 %849
+%850 = OpLoad %ulong %744
+%851 = OpLoad %ulong %740
+%852 = OpBitwiseXor %ulong %850 %851
+OpStore %741 %852
+%853 = OpLoad %ulong %741
+%854 = OpIMul %ulong %853 %ulong_1099511628211
+OpStore %742 %854
+%855 = OpLoad %ulong %745
+%856 = OpIAdd %ulong %855 %ulong_1
+OpStore %743 %856
+%857 = OpLoad %ulong %742
+OpStore %744 %857
+%858 = OpLoad %ulong %743
+OpStore %745 %858
+OpBranch %674
+%655 = OpLabel
+%859 = OpLoad %ulong %735
+%860 = OpIMul %ulong %859 %ulong_8
+OpStore %728 %860
+%861 = OpLoad %ulong %726
+%862 = OpLoad %ulong %728
+%863 = OpShiftRightLogical %ulong %861 %862
+OpStore %729 %863
+%864 = OpLoad %ulong %729
+%865 = OpBitwiseAnd %ulong %864 %ulong_255
+OpStore %730 %865
+%866 = OpLoad %ulong %734
+%867 = OpLoad %ulong %730
+%868 = OpBitwiseXor %ulong %866 %867
+OpStore %731 %868
+%869 = OpLoad %ulong %731
+%870 = OpIMul %ulong %869 %ulong_1099511628211
+OpStore %732 %870
+%871 = OpLoad %ulong %735
+%872 = OpIAdd %ulong %871 %ulong_1
+OpStore %733 %872
+%873 = OpLoad %ulong %732
+OpStore %734 %873
+%874 = OpLoad %ulong %733
+OpStore %735 %874
+OpBranch %675
+%648 = OpLabel
+%875 = OpLoad %ulong %725
+%876 = OpIMul %ulong %875 %ulong_8
+OpStore %718 %876
+%877 = OpLoad %ulong %716
+%878 = OpLoad %ulong %718
+%879 = OpShiftRightLogical %ulong %877 %878
+OpStore %719 %879
+%880 = OpLoad %ulong %719
+%881 = OpBitwiseAnd %ulong %880 %ulong_255
+OpStore %720 %881
+%882 = OpLoad %ulong %724
+%883 = OpLoad %ulong %720
+%884 = OpBitwiseXor %ulong %882 %883
+OpStore %721 %884
+%885 = OpLoad %ulong %721
+%886 = OpIMul %ulong %885 %ulong_1099511628211
+OpStore %722 %886
+%887 = OpLoad %ulong %725
+%888 = OpIAdd %ulong %887 %ulong_1
+OpStore %723 %888
+%889 = OpLoad %ulong %722
+OpStore %724 %889
+%890 = OpLoad %ulong %723
+OpStore %725 %890
+OpBranch %676
+%641 = OpLabel
+%891 = OpLoad %ulong %715
+%892 = OpIMul %ulong %891 %ulong_8
+OpStore %708 %892
+%893 = OpLoad %ulong %706
+%894 = OpLoad %ulong %708
+%895 = OpShiftRightLogical %ulong %893 %894
+OpStore %709 %895
+%896 = OpLoad %ulong %709
+%897 = OpBitwiseAnd %ulong %896 %ulong_255
+OpStore %710 %897
+%898 = OpLoad %ulong %714
+%899 = OpLoad %ulong %710
+%900 = OpBitwiseXor %ulong %898 %899
+OpStore %711 %900
+%901 = OpLoad %ulong %711
+%902 = OpIMul %ulong %901 %ulong_1099511628211
+OpStore %712 %902
+%903 = OpLoad %ulong %715
+%904 = OpIAdd %ulong %903 %ulong_1
+OpStore %713 %904
+%905 = OpLoad %ulong %712
+OpStore %714 %905
+%906 = OpLoad %ulong %713
+OpStore %715 %906
+OpBranch %677
+%634 = OpLabel
+%907 = OpLoad %ulong %705
+%908 = OpIMul %ulong %907 %ulong_8
+OpStore %698 %908
+%909 = OpLoad %ulong %692
+%910 = OpLoad %ulong %698
+%911 = OpShiftRightLogical %ulong %909 %910
+OpStore %699 %911
+%912 = OpLoad %ulong %699
+%913 = OpBitwiseAnd %ulong %912 %ulong_255
+OpStore %700 %913
+%914 = OpLoad %ulong %704
+%915 = OpLoad %ulong %700
+%916 = OpBitwiseXor %ulong %914 %915
+OpStore %701 %916
+%917 = OpLoad %ulong %701
+%918 = OpIMul %ulong %917 %ulong_1099511628211
+OpStore %702 %918
+%919 = OpLoad %ulong %705
+%920 = OpIAdd %ulong %919 %ulong_1
+OpStore %703 %920
+%921 = OpLoad %ulong %702
+OpStore %704 %921
+%922 = OpLoad %ulong %703
+OpStore %705 %922
+OpBranch %678
+%673 = OpLabel
+OpBranch %669
+%674 = OpLabel
+OpBranch %661
+%675 = OpLabel
+OpBranch %654
+%676 = OpLabel
+OpBranch %647
+%677 = OpLabel
+OpBranch %640
+%678 = OpLabel
+OpBranch %633
 OpFunctionEnd
-%11 = OpFunction %ulong None %782
-%783 = OpFunctionParameter %ulong
-%784 = OpFunctionParameter %uint
-%785 = OpLabel
-%792 = OpVariable %_ptr_Function_ulong Function
-%793 = OpVariable %_ptr_Function_uint Function
-%794 = OpVariable %_ptr_Function_ulong Function
-%795 = OpVariable %_ptr_Function_bool Function
-%796 = OpVariable %_ptr_Function_ulong Function
-%797 = OpVariable %_ptr_Function_ulong Function
-%798 = OpVariable %_ptr_Function_ulong Function
-%799 = OpVariable %_ptr_Function_ulong Function
-%800 = OpVariable %_ptr_Function_ulong Function
-%801 = OpVariable %_ptr_Function_ulong Function
-%802 = OpVariable %_ptr_Function_ulong Function
-%803 = OpVariable %_ptr_Function_ulong Function
-OpStore %792 %783
-OpStore %793 %784
-%804 = OpLoad %uint %793
-%805 = OpUConvert %ulong %804
-OpStore %794 %805
-OpBranch %786
-%786 = OpLabel
-%806 = OpLoad %ulong %792
-OpStore %802 %806
-OpStore %803 %ulong_0
-OpBranch %787
-%787 = OpLabel
-%807 = OpLoad %ulong %803
-%808 = OpULessThan %bool %807 %ulong_8
-OpStore %795 %808
-%809 = OpLoad %bool %795
-OpLoopMerge %789 %791 None
-OpBranchConditional %809 %788 %789
-%789 = OpLabel
-OpBranch %790
-%790 = OpLabel
-%810 = OpLoad %ulong %802
-OpReturnValue %810
-%788 = OpLabel
-%811 = OpLoad %ulong %803
-%812 = OpIMul %ulong %811 %ulong_8
-OpStore %796 %812
-%813 = OpLoad %ulong %794
-%814 = OpLoad %ulong %796
-%815 = OpShiftRightLogical %ulong %813 %814
-OpStore %797 %815
-%816 = OpLoad %ulong %797
-%817 = OpBitwiseAnd %ulong %816 %ulong_255
-OpStore %798 %817
-%818 = OpLoad %ulong %802
-%819 = OpLoad %ulong %798
-%820 = OpBitwiseXor %ulong %818 %819
-OpStore %799 %820
-%821 = OpLoad %ulong %799
-%822 = OpIMul %ulong %821 %ulong_1099511628211
-OpStore %800 %822
-%823 = OpLoad %ulong %803
-%824 = OpIAdd %ulong %823 %ulong_1
-OpStore %801 %824
-%825 = OpLoad %ulong %800
-OpStore %802 %825
-%826 = OpLoad %ulong %801
-OpStore %803 %826
-OpBranch %791
-%791 = OpLabel
-OpBranch %787
+%5 = OpFunction %void None %924
+%925 = OpFunctionParameter %_ptr_Function__struct_163
+%926 = OpFunctionParameter %uint
+%927 = OpLabel
+%928 = OpVariable %_ptr_Function_uint Function
+%929 = OpVariable %_ptr_Function_ushort Function
+%930 = OpVariable %_ptr_Function_uint Function
+%931 = OpVariable %_ptr_Function_uchar Function
+%932 = OpVariable %_ptr_Function_uint Function
+%933 = OpVariable %_ptr_Function_uint Function
+%934 = OpVariable %_ptr_Function_uchar Function
+%935 = OpVariable %_ptr_Function_uint Function
+%936 = OpVariable %_ptr_Function_uchar Function
+OpStore %928 %926
+%937 = OpLoad %uint %928
+%938 = OpUConvert %ushort %937
+OpStore %929 %938
+%939 = OpAccessChain %_ptr_Function_ushort %925 %uint_0
+%940 = OpLoad %ushort %929
+OpStore %939 %940
+%941 = OpLoad %uint %928
+%942 = OpIAdd %uint %941 %uint_1
+OpStore %930 %942
+%943 = OpLoad %uint %930
+%944 = OpUConvert %uchar %943
+OpStore %931 %944
+%945 = OpAccessChain %_ptr_Function__struct_11 %925 %uint_1
+%946 = OpAccessChain %_ptr_Function_uchar %945 %uint_0
+%947 = OpLoad %uchar %931
+OpStore %946 %947
+%948 = OpLoad %uint %928
+%949 = OpIAdd %uint %948 %uint_2
+OpStore %932 %949
+%950 = OpAccessChain %_ptr_Function_uint %945 %uint_1
+%951 = OpLoad %uint %932
+OpStore %950 %951
+%952 = OpLoad %uint %928
+%953 = OpIAdd %uint %952 %uint_3
+OpStore %933 %953
+%954 = OpLoad %uint %933
+%955 = OpUConvert %uchar %954
+OpStore %934 %955
+%956 = OpAccessChain %_ptr_Function_uchar %945 %uint_2
+%957 = OpLoad %uchar %934
+OpStore %956 %957
+%958 = OpLoad %uint %928
+%960 = OpIAdd %uint %958 %uint_4
+OpStore %935 %960
+%961 = OpLoad %uint %935
+%962 = OpUConvert %uchar %961
+OpStore %936 %962
+%963 = OpAccessChain %_ptr_Function_uchar %925 %uint_2
+%964 = OpLoad %uchar %936
+OpStore %963 %964
+OpReturn
+OpFunctionEnd
+%6 = OpFunction %ulong None %965
+%966 = OpFunctionParameter %ulong
+%967 = OpLabel
+%1006 = OpVariable %_ptr_Function__struct_626 Function
+%1007 = OpVariable %_ptr_Function__struct_626 Function
+%1008 = OpVariable %_ptr_Function__struct_626 Function
+%1009 = OpVariable %_ptr_Function__struct_626 Function
+%1010 = OpVariable %_ptr_Function__struct_626 Function
+%1011 = OpVariable %_ptr_Function__struct_626 Function
+%1012 = OpVariable %_ptr_Function__struct_626 Function
+%1013 = OpVariable %_ptr_Function__struct_163 Function
+%1014 = OpVariable %_ptr_Function__struct_163 Function
+%1015 = OpVariable %_ptr_Function__struct_163 Function
+%1016 = OpVariable %_ptr_Function__struct_163 Function
+%1017 = OpVariable %_ptr_Function__struct_163 Function
+%1018 = OpVariable %_ptr_Function__struct_626 Function
+%1019 = OpVariable %_ptr_Function_ulong Function
+%1020 = OpVariable %_ptr_Function_uint Function
+%1021 = OpVariable %_ptr_Function_ulong Function
+%1022 = OpVariable %_ptr_Function_ulong Function
+%1023 = OpVariable %_ptr_Function_ulong Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_ulong Function
+%1026 = OpVariable %_ptr_Function_ulong Function
+%1027 = OpVariable %_ptr_Function_ulong Function
+%1028 = OpVariable %_ptr_Function_ulong Function
+%1029 = OpVariable %_ptr_Function_ulong Function
+%1030 = OpVariable %_ptr_Function_ulong Function
+%1031 = OpVariable %_ptr_Function_ulong Function
+%1032 = OpVariable %_ptr_Function_ulong Function
+%1033 = OpVariable %_ptr_Function_ulong Function
+%1034 = OpVariable %_ptr_Function_uint Function
+%1035 = OpVariable %_ptr_Function_ulong Function
+%1036 = OpVariable %_ptr_Function_uint Function
+%1037 = OpVariable %_ptr_Function_ushort Function
+%1038 = OpVariable %_ptr_Function_uint Function
+%1039 = OpVariable %_ptr_Function_ushort Function
+%1040 = OpVariable %_ptr_Function_uint Function
+%1041 = OpVariable %_ptr_Function_ushort Function
+%1042 = OpVariable %_ptr_Function_uint Function
+%1043 = OpVariable %_ptr_Function_uchar Function
+%1044 = OpVariable %_ptr_Function_uint Function
+%1045 = OpVariable %_ptr_Function_uint Function
+%1046 = OpVariable %_ptr_Function_uint Function
+%1047 = OpVariable %_ptr_Function_ulong Function
+%1048 = OpVariable %_ptr_Function_uint Function
+%1049 = OpVariable %_ptr_Function_uint Function
+%1050 = OpVariable %_ptr_Function_ulong Function
+%1051 = OpVariable %_ptr_Function_uchar Function
+%1052 = OpVariable %_ptr_Function_uchar Function
+%1053 = OpVariable %_ptr_Function_ulong Function
+%1054 = OpVariable %_ptr_Function_ulong Function
+%1055 = OpVariable %_ptr_Function_ulong Function
+%1056 = OpVariable %_ptr_Function_ulong Function
+%1057 = OpVariable %_ptr_Function_uint Function
+%1058 = OpVariable %_ptr_Function_uint Function
+%1059 = OpVariable %_ptr_Function_ulong Function
+%1060 = OpVariable %_ptr_Function_uint Function
+%1061 = OpVariable %_ptr_Function_uint Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_ulong Function
+%1064 = OpVariable %_ptr_Function_ulong Function
+%1065 = OpVariable %_ptr_Function_bool Function
+%1066 = OpVariable %_ptr_Function_ulong Function
+%1067 = OpVariable %_ptr_Function_ulong Function
+%1068 = OpVariable %_ptr_Function_ulong Function
+%1069 = OpVariable %_ptr_Function_ulong Function
+%1070 = OpVariable %_ptr_Function_ulong Function
+%1071 = OpVariable %_ptr_Function_ulong Function
+%1072 = OpVariable %_ptr_Function_ulong Function
+%1073 = OpVariable %_ptr_Function_ulong Function
+%1074 = OpVariable %_ptr_Function_bool Function
+%1075 = OpVariable %_ptr_Function_ulong Function
+%1076 = OpVariable %_ptr_Function_ulong Function
+%1077 = OpVariable %_ptr_Function_ulong Function
+%1078 = OpVariable %_ptr_Function_ulong Function
+%1079 = OpVariable %_ptr_Function_ulong Function
+%1080 = OpVariable %_ptr_Function_ulong Function
+%1081 = OpVariable %_ptr_Function_ulong Function
+%1082 = OpVariable %_ptr_Function_ulong Function
+%1083 = OpVariable %_ptr_Function_bool Function
+%1084 = OpVariable %_ptr_Function_ulong Function
+%1085 = OpVariable %_ptr_Function_ulong Function
+%1086 = OpVariable %_ptr_Function_ulong Function
+%1087 = OpVariable %_ptr_Function_ulong Function
+%1088 = OpVariable %_ptr_Function_ulong Function
+%1089 = OpVariable %_ptr_Function_ulong Function
+%1090 = OpVariable %_ptr_Function_ulong Function
+%1091 = OpVariable %_ptr_Function_ulong Function
+%1092 = OpVariable %_ptr_Function_bool Function
+%1093 = OpVariable %_ptr_Function_ulong Function
+%1094 = OpVariable %_ptr_Function_ulong Function
+%1095 = OpVariable %_ptr_Function_ulong Function
+%1096 = OpVariable %_ptr_Function_ulong Function
+%1097 = OpVariable %_ptr_Function_ulong Function
+%1098 = OpVariable %_ptr_Function_ulong Function
+%1099 = OpVariable %_ptr_Function_ulong Function
+%1100 = OpVariable %_ptr_Function_ulong Function
+%1101 = OpVariable %_ptr_Function_bool Function
+%1102 = OpVariable %_ptr_Function_ulong Function
+%1103 = OpVariable %_ptr_Function_ulong Function
+%1104 = OpVariable %_ptr_Function_ulong Function
+%1105 = OpVariable %_ptr_Function_ulong Function
+%1106 = OpVariable %_ptr_Function_ulong Function
+%1107 = OpVariable %_ptr_Function_ulong Function
+%1108 = OpVariable %_ptr_Function_ulong Function
+%1109 = OpVariable %_ptr_Function_ulong Function
+%1110 = OpVariable %_ptr_Function_ushort Function
+%1111 = OpVariable %_ptr_Function_uint Function
+%1112 = OpVariable %_ptr_Function_uchar Function
+%1113 = OpVariable %_ptr_Function_uint Function
+%1114 = OpVariable %_ptr_Function_uint Function
+%1115 = OpVariable %_ptr_Function_uchar Function
+%1116 = OpVariable %_ptr_Function_uint Function
+%1117 = OpVariable %_ptr_Function_uchar Function
+%1118 = OpVariable %_ptr_Function_ushort Function
+%1119 = OpVariable %_ptr_Function_uint Function
+%1120 = OpVariable %_ptr_Function_uchar Function
+%1121 = OpVariable %_ptr_Function_uint Function
+%1122 = OpVariable %_ptr_Function_uint Function
+%1123 = OpVariable %_ptr_Function_uchar Function
+%1124 = OpVariable %_ptr_Function_uint Function
+%1125 = OpVariable %_ptr_Function_uchar Function
+%1126 = OpVariable %_ptr_Function_ushort Function
+%1127 = OpVariable %_ptr_Function_uint Function
+%1128 = OpVariable %_ptr_Function_uchar Function
+%1129 = OpVariable %_ptr_Function_uint Function
+%1130 = OpVariable %_ptr_Function_uint Function
+%1131 = OpVariable %_ptr_Function_uchar Function
+%1132 = OpVariable %_ptr_Function_uint Function
+%1133 = OpVariable %_ptr_Function_uchar Function
+OpStore %1019 %966
+OpBranch %968
+%968 = OpLabel
+OpBranch %969
+%969 = OpLabel
+%1134 = OpLoad %ulong %1019
+%1135 = OpUConvert %uint %1134
+OpStore %1020 %1135
+OpBranch %970
+%970 = OpLabel
+OpStore %1072 %ulong_14695981039346656037
+OpStore %1073 %ulong_0
+OpBranch %971
+%971 = OpLabel
+%1137 = OpLoad %ulong %1073
+%1138 = OpULessThan %bool %1137 %ulong_8
+OpStore %1065 %1138
+%1139 = OpLoad %bool %1065
+OpLoopMerge %973 %1005 None
+OpBranchConditional %1139 %972 %973
+%973 = OpLabel
+OpBranch %974
+%974 = OpLabel
+OpBranch %975
+%975 = OpLabel
+%1140 = OpLoad %ulong %1072
+OpStore %1081 %1140
+OpStore %1082 %ulong_0
+OpBranch %976
+%976 = OpLabel
+%1141 = OpLoad %ulong %1082
+%1142 = OpULessThan %bool %1141 %ulong_8
+OpStore %1074 %1142
+%1143 = OpLoad %bool %1074
+OpLoopMerge %978 %1004 None
+OpBranchConditional %1143 %977 %978
+%978 = OpLabel
+OpBranch %979
+%979 = OpLabel
+OpBranch %980
+%980 = OpLabel
+%1144 = OpLoad %ulong %1081
+OpStore %1090 %1144
+OpStore %1091 %ulong_0
+OpBranch %981
+%981 = OpLabel
+%1145 = OpLoad %ulong %1091
+%1146 = OpULessThan %bool %1145 %ulong_8
+OpStore %1083 %1146
+%1147 = OpLoad %bool %1083
+OpLoopMerge %983 %1003 None
+OpBranchConditional %1147 %982 %983
+%983 = OpLabel
+OpBranch %984
+%984 = OpLabel
+OpBranch %985
+%985 = OpLabel
+%1148 = OpLoad %ulong %1090
+OpStore %1099 %1148
+OpStore %1100 %ulong_0
+OpBranch %986
+%986 = OpLabel
+%1149 = OpLoad %ulong %1100
+%1150 = OpULessThan %bool %1149 %ulong_8
+OpStore %1092 %1150
+%1151 = OpLoad %bool %1092
+OpLoopMerge %988 %1002 None
+OpBranchConditional %1151 %987 %988
+%988 = OpLabel
+OpBranch %989
+%989 = OpLabel
+OpBranch %990
+%990 = OpLabel
+%1152 = OpLoad %ulong %1099
+OpStore %1108 %1152
+OpStore %1109 %ulong_0
+OpBranch %991
+%991 = OpLabel
+%1153 = OpLoad %ulong %1109
+%1154 = OpULessThan %bool %1153 %ulong_8
+OpStore %1101 %1154
+%1155 = OpLoad %bool %1101
+OpLoopMerge %993 %1001 None
+OpBranchConditional %1155 %992 %993
+%993 = OpLabel
+OpBranch %994
+%994 = OpLabel
+%1156 = OpLoad %ulong %1108
+%1158 = OpFunctionCall %ulong %7 %1156 %ulong_4
+OpStore %1021 %1158
+%1159 = OpLoad %ulong %1021
+%1160 = OpFunctionCall %ulong %7 %1159 %ulong_8
+OpStore %1022 %1160
+%1161 = OpLoad %ulong %1022
+%1162 = OpFunctionCall %ulong %7 %1161 %ulong_8
+OpStore %1023 %1162
+%1163 = OpLoad %ulong %1023
+%1164 = OpFunctionCall %ulong %7 %1163 %ulong_4
+OpStore %1024 %1164
+%1165 = OpLoad %ulong %1024
+%1166 = OpFunctionCall %ulong %7 %1165 %ulong_8
+OpStore %1025 %1166
+%1167 = OpLoad %ulong %1025
+%1168 = OpFunctionCall %ulong %7 %1167 %ulong_4
+OpStore %1026 %1168
+%1169 = OpLoad %ulong %1026
+%1171 = OpFunctionCall %ulong %7 %1169 %ulong_16
+OpStore %1027 %1171
+%1172 = OpLoad %ulong %1027
+%1174 = OpFunctionCall %ulong %7 %1172 %ulong_24
+OpStore %1028 %1174
+%1175 = OpLoad %ulong %1028
+%1177 = OpFunctionCall %ulong %7 %1175 %ulong_32
+OpStore %1029 %1177
+%1178 = OpLoad %ulong %1029
+%1180 = OpFunctionCall %ulong %7 %1178 %ulong_38
+OpStore %1030 %1180
+%1181 = OpLoad %ulong %1030
+%1183 = OpFunctionCall %ulong %7 %1181 %ulong_40
+OpStore %1031 %1183
+%1184 = OpLoad %ulong %1031
+%1186 = OpFunctionCall %ulong %7 %1184 %ulong_80
+OpStore %1032 %1186
+OpStore %1006 %1187
+%1188 = OpLoad %_struct_626 %1006
+OpStore %1007 %1188
+%1189 = OpLoad %ulong %1032
+%1190 = OpLoad %_struct_626 %1007
+%1191 = OpFunctionCall %ulong %4 %1189 %1190
+OpStore %1033 %1191
+%1192 = OpAccessChain %_ptr_Function__struct_393 %1006 %uint_0
+%1193 = OpAccessChain %_ptr_Function__struct_163 %1192 %uint_0
+%1195 = OpLoad %uint %1020
+%1196 = OpIAdd %uint %uint_10 %1195
+OpStore %1034 %1196
+OpBranch %995
+%995 = OpLabel
+%1197 = OpLoad %uint %1034
+%1198 = OpUConvert %ushort %1197
+OpStore %1110 %1198
+%1199 = OpAccessChain %_ptr_Function_ushort %1193 %uint_0
+%1200 = OpLoad %ushort %1110
+OpStore %1199 %1200
+%1201 = OpLoad %uint %1034
+%1202 = OpIAdd %uint %1201 %uint_1
+OpStore %1111 %1202
+%1203 = OpLoad %uint %1111
+%1204 = OpUConvert %uchar %1203
+OpStore %1112 %1204
+%1205 = OpAccessChain %_ptr_Function__struct_11 %1193 %uint_1
+%1206 = OpAccessChain %_ptr_Function_uchar %1205 %uint_0
+%1207 = OpLoad %uchar %1112
+OpStore %1206 %1207
+%1208 = OpLoad %uint %1034
+%1209 = OpIAdd %uint %1208 %uint_2
+OpStore %1113 %1209
+%1210 = OpAccessChain %_ptr_Function_uint %1205 %uint_1
+%1211 = OpLoad %uint %1113
+OpStore %1210 %1211
+%1212 = OpLoad %uint %1034
+%1213 = OpIAdd %uint %1212 %uint_3
+OpStore %1114 %1213
+%1214 = OpLoad %uint %1114
+%1215 = OpUConvert %uchar %1214
+OpStore %1115 %1215
+%1216 = OpAccessChain %_ptr_Function_uchar %1205 %uint_2
+%1217 = OpLoad %uchar %1115
+OpStore %1216 %1217
+%1218 = OpLoad %uint %1034
+%1219 = OpIAdd %uint %1218 %uint_4
+OpStore %1116 %1219
+%1220 = OpLoad %uint %1116
+%1221 = OpUConvert %uchar %1220
+OpStore %1117 %1221
+%1222 = OpAccessChain %_ptr_Function_uchar %1193 %uint_2
+%1223 = OpLoad %uchar %1117
+OpStore %1222 %1223
+OpBranch %996
+%996 = OpLabel
+%1225 = OpLoad %ulong %1019
+%1226 = OpIAdd %ulong %ulong_18364758544493064720 %1225
+OpStore %1035 %1226
+%1227 = OpAccessChain %_ptr_Function__struct_393 %1006 %uint_0
+%1228 = OpAccessChain %_ptr_Function_ulong %1227 %uint_1
+%1229 = OpLoad %ulong %1035
+OpStore %1228 %1229
+%1231 = OpLoad %uint %1020
+%1232 = OpIAdd %uint %uint_20 %1231
+OpStore %1036 %1232
+%1233 = OpLoad %uint %1036
+%1234 = OpUConvert %ushort %1233
+OpStore %1037 %1234
+%1235 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %1227 %uint_2
+%1236 = OpAccessChain %_ptr_Function_ushort %1235 %uint_0
+%1237 = OpLoad %ushort %1037
+OpStore %1236 %1237
+%1239 = OpLoad %uint %1020
+%1240 = OpIAdd %uint %uint_21 %1239
+OpStore %1038 %1240
+%1241 = OpLoad %uint %1038
+%1242 = OpUConvert %ushort %1241
+OpStore %1039 %1242
+%1243 = OpAccessChain %_ptr_Function_ushort %1235 %uint_1
+%1244 = OpLoad %ushort %1039
+OpStore %1243 %1244
+%1246 = OpLoad %uint %1020
+%1247 = OpIAdd %uint %uint_22 %1246
+OpStore %1040 %1247
+%1248 = OpLoad %uint %1040
+%1249 = OpUConvert %ushort %1248
+OpStore %1041 %1249
+%1250 = OpAccessChain %_ptr_Function_ushort %1235 %uint_2
+%1251 = OpLoad %ushort %1041
+OpStore %1250 %1251
+%1253 = OpLoad %uint %1020
+%1254 = OpIAdd %uint %uint_23 %1253
+OpStore %1042 %1254
+%1255 = OpLoad %uint %1042
+%1256 = OpUConvert %uchar %1255
+OpStore %1043 %1256
+%1257 = OpAccessChain %_ptr_Function_uchar %1227 %uint_3
+%1258 = OpLoad %uchar %1043
+OpStore %1257 %1258
+%1259 = OpAccessChain %_ptr_Function__arr__struct_163_uint_2 %1006 %uint_1
+%1260 = OpAccessChain %_ptr_Function__struct_163 %1259 %uint_0
+%1262 = OpLoad %uint %1020
+%1263 = OpIAdd %uint %uint_30 %1262
+OpStore %1044 %1263
+OpBranch %997
+%997 = OpLabel
+%1264 = OpLoad %uint %1044
+%1265 = OpUConvert %ushort %1264
+OpStore %1118 %1265
+%1266 = OpAccessChain %_ptr_Function_ushort %1260 %uint_0
+%1267 = OpLoad %ushort %1118
+OpStore %1266 %1267
+%1268 = OpLoad %uint %1044
+%1269 = OpIAdd %uint %1268 %uint_1
+OpStore %1119 %1269
+%1270 = OpLoad %uint %1119
+%1271 = OpUConvert %uchar %1270
+OpStore %1120 %1271
+%1272 = OpAccessChain %_ptr_Function__struct_11 %1260 %uint_1
+%1273 = OpAccessChain %_ptr_Function_uchar %1272 %uint_0
+%1274 = OpLoad %uchar %1120
+OpStore %1273 %1274
+%1275 = OpLoad %uint %1044
+%1276 = OpIAdd %uint %1275 %uint_2
+OpStore %1121 %1276
+%1277 = OpAccessChain %_ptr_Function_uint %1272 %uint_1
+%1278 = OpLoad %uint %1121
+OpStore %1277 %1278
+%1279 = OpLoad %uint %1044
+%1280 = OpIAdd %uint %1279 %uint_3
+OpStore %1122 %1280
+%1281 = OpLoad %uint %1122
+%1282 = OpUConvert %uchar %1281
+OpStore %1123 %1282
+%1283 = OpAccessChain %_ptr_Function_uchar %1272 %uint_2
+%1284 = OpLoad %uchar %1123
+OpStore %1283 %1284
+%1285 = OpLoad %uint %1044
+%1286 = OpIAdd %uint %1285 %uint_4
+OpStore %1124 %1286
+%1287 = OpLoad %uint %1124
+%1288 = OpUConvert %uchar %1287
+OpStore %1125 %1288
+%1289 = OpAccessChain %_ptr_Function_uchar %1260 %uint_2
+%1290 = OpLoad %uchar %1125
+OpStore %1289 %1290
+OpBranch %998
+%998 = OpLabel
+%1291 = OpAccessChain %_ptr_Function__arr__struct_163_uint_2 %1006 %uint_1
+%1292 = OpAccessChain %_ptr_Function__struct_163 %1291 %uint_1
+%1294 = OpLoad %uint %1020
+%1295 = OpIAdd %uint %uint_40 %1294
+OpStore %1045 %1295
+OpBranch %999
+%999 = OpLabel
+%1296 = OpLoad %uint %1045
+%1297 = OpUConvert %ushort %1296
+OpStore %1126 %1297
+%1298 = OpAccessChain %_ptr_Function_ushort %1292 %uint_0
+%1299 = OpLoad %ushort %1126
+OpStore %1298 %1299
+%1300 = OpLoad %uint %1045
+%1301 = OpIAdd %uint %1300 %uint_1
+OpStore %1127 %1301
+%1302 = OpLoad %uint %1127
+%1303 = OpUConvert %uchar %1302
+OpStore %1128 %1303
+%1304 = OpAccessChain %_ptr_Function__struct_11 %1292 %uint_1
+%1305 = OpAccessChain %_ptr_Function_uchar %1304 %uint_0
+%1306 = OpLoad %uchar %1128
+OpStore %1305 %1306
+%1307 = OpLoad %uint %1045
+%1308 = OpIAdd %uint %1307 %uint_2
+OpStore %1129 %1308
+%1309 = OpAccessChain %_ptr_Function_uint %1304 %uint_1
+%1310 = OpLoad %uint %1129
+OpStore %1309 %1310
+%1311 = OpLoad %uint %1045
+%1312 = OpIAdd %uint %1311 %uint_3
+OpStore %1130 %1312
+%1313 = OpLoad %uint %1130
+%1314 = OpUConvert %uchar %1313
+OpStore %1131 %1314
+%1315 = OpAccessChain %_ptr_Function_uchar %1304 %uint_2
+%1316 = OpLoad %uchar %1131
+OpStore %1315 %1316
+%1317 = OpLoad %uint %1045
+%1318 = OpIAdd %uint %1317 %uint_4
+OpStore %1132 %1318
+%1319 = OpLoad %uint %1132
+%1320 = OpUConvert %uchar %1319
+OpStore %1133 %1320
+%1321 = OpAccessChain %_ptr_Function_uchar %1292 %uint_2
+%1322 = OpLoad %uchar %1133
+OpStore %1321 %1322
+OpBranch %1000
+%1000 = OpLabel
+%1324 = OpLoad %uint %1020
+%1325 = OpIAdd %uint %uint_50 %1324
+OpStore %1046 %1325
+%1326 = OpAccessChain %_ptr_Function_uint %1006 %uint_2
+%1327 = OpLoad %uint %1046
+OpStore %1326 %1327
+%1328 = OpLoad %_struct_626 %1006
+OpStore %1008 %1328
+%1329 = OpLoad %ulong %1033
+%1330 = OpLoad %_struct_626 %1008
+%1331 = OpFunctionCall %ulong %4 %1329 %1330
+OpStore %1047 %1331
+%1332 = OpAccessChain %_ptr_Function__struct_393 %1006 %uint_0
+%1333 = OpAccessChain %_ptr_Function__struct_163 %1332 %uint_0
+%1334 = OpAccessChain %_ptr_Function__struct_11 %1333 %uint_1
+%1335 = OpAccessChain %_ptr_Function_uint %1334 %uint_1
+%1336 = OpLoad %uint %1335
+OpStore %1048 %1336
+%1337 = OpLoad %uint %1048
+%1339 = OpBitwiseXor %uint %1337 %uint_4042322160
+OpStore %1049 %1339
+%1340 = OpLoad %uint %1049
+OpStore %1335 %1340
+%1341 = OpLoad %_struct_626 %1006
+OpStore %1009 %1341
+%1342 = OpLoad %ulong %1047
+%1343 = OpLoad %_struct_626 %1009
+%1344 = OpFunctionCall %ulong %4 %1342 %1343
+OpStore %1050 %1344
+%1345 = OpAccessChain %_ptr_Function__arr__struct_163_uint_2 %1006 %uint_1
+%1346 = OpAccessChain %_ptr_Function__struct_163 %1345 %uint_1
+%1347 = OpAccessChain %_ptr_Function__struct_11 %1346 %uint_1
+%1348 = OpAccessChain %_ptr_Function_uchar %1347 %uint_2
+%1349 = OpLoad %uchar %1348
+OpStore %1051 %1349
+%1350 = OpLoad %uchar %1051
+%1352 = OpIAdd %uchar %1350 %uchar_7
+OpStore %1052 %1352
+%1353 = OpLoad %uchar %1052
+OpStore %1348 %1353
+%1354 = OpLoad %_struct_626 %1006
+OpStore %1010 %1354
+%1355 = OpLoad %ulong %1050
+%1356 = OpLoad %_struct_626 %1010
+%1357 = OpFunctionCall %ulong %4 %1355 %1356
+OpStore %1053 %1357
+%1358 = OpAccessChain %_ptr_Function_ulong %1332 %uint_1
+%1359 = OpLoad %ulong %1358
+OpStore %1054 %1359
+%1360 = OpLoad %ulong %1054
+%1362 = OpShiftRightLogical %ulong %1360 %ulong_3
+OpStore %1055 %1362
+%1363 = OpLoad %ulong %1055
+OpStore %1358 %1363
+%1364 = OpLoad %_struct_626 %1006
+OpStore %1011 %1364
+%1365 = OpLoad %ulong %1053
+%1366 = OpLoad %_struct_626 %1011
+%1367 = OpFunctionCall %ulong %4 %1365 %1366
+OpStore %1056 %1367
+%1368 = OpLoad %uint %1326
+OpStore %1057 %1368
+%1369 = OpLoad %uint %1057
+%1370 = OpIMul %uint %1369 %uint_3
+OpStore %1058 %1370
+%1371 = OpLoad %uint %1058
+OpStore %1326 %1371
+%1372 = OpLoad %_struct_626 %1006
+OpStore %1012 %1372
+%1373 = OpLoad %ulong %1056
+%1374 = OpLoad %_struct_626 %1012
+%1375 = OpFunctionCall %ulong %4 %1373 %1374
+OpStore %1059 %1375
+%1376 = OpAccessChain %_ptr_Function__struct_163 %1345 %uint_0
+%1377 = OpLoad %_struct_163 %1376
+OpStore %1014 %1377
+%1378 = OpLoad %_struct_163 %1014
+OpStore %1013 %1378
+%1379 = OpAccessChain %_ptr_Function__struct_11 %1013 %uint_1
+%1380 = OpAccessChain %_ptr_Function_uint %1379 %uint_1
+%1381 = OpLoad %uint %1380
+OpStore %1060 %1381
+%1382 = OpLoad %uint %1060
+%1383 = OpIAdd %uint %1382 %uint_1
+OpStore %1061 %1383
+%1384 = OpLoad %uint %1061
+OpStore %1380 %1384
+%1385 = OpLoad %_struct_163 %1013
+OpStore %1015 %1385
+%1386 = OpLoad %ulong %1059
+%1387 = OpLoad %_struct_163 %1015
+%1388 = OpFunctionCall %ulong %2 %1386 %1387
+OpStore %1062 %1388
+%1389 = OpLoad %_struct_163 %1376
+OpStore %1016 %1389
+%1390 = OpLoad %ulong %1062
+%1391 = OpLoad %_struct_163 %1016
+%1392 = OpFunctionCall %ulong %2 %1390 %1391
+OpStore %1063 %1392
+%1393 = OpLoad %_struct_163 %1013
+OpStore %1017 %1393
+%1394 = OpLoad %_struct_163 %1017
+OpStore %1376 %1394
+%1395 = OpLoad %_struct_626 %1006
+OpStore %1018 %1395
+%1396 = OpLoad %ulong %1063
+%1397 = OpLoad %_struct_626 %1018
+%1398 = OpFunctionCall %ulong %4 %1396 %1397
+OpStore %1064 %1398
+%1399 = OpLoad %ulong %1064
+OpReturnValue %1399
+%992 = OpLabel
+%1400 = OpLoad %ulong %1109
+%1401 = OpIMul %ulong %1400 %ulong_8
+OpStore %1102 %1401
+%1402 = OpLoad %ulong %1102
+%1403 = OpShiftRightLogical %ulong %ulong_4 %1402
+OpStore %1103 %1403
+%1404 = OpLoad %ulong %1103
+%1405 = OpBitwiseAnd %ulong %1404 %ulong_255
+OpStore %1104 %1405
+%1406 = OpLoad %ulong %1108
+%1407 = OpLoad %ulong %1104
+%1408 = OpBitwiseXor %ulong %1406 %1407
+OpStore %1105 %1408
+%1409 = OpLoad %ulong %1105
+%1410 = OpIMul %ulong %1409 %ulong_1099511628211
+OpStore %1106 %1410
+%1411 = OpLoad %ulong %1109
+%1412 = OpIAdd %ulong %1411 %ulong_1
+OpStore %1107 %1412
+%1413 = OpLoad %ulong %1106
+OpStore %1108 %1413
+%1414 = OpLoad %ulong %1107
+OpStore %1109 %1414
+OpBranch %1001
+%987 = OpLabel
+%1415 = OpLoad %ulong %1100
+%1416 = OpIMul %ulong %1415 %ulong_8
+OpStore %1093 %1416
+%1418 = OpLoad %ulong %1093
+%1419 = OpShiftRightLogical %ulong %ulong_88 %1418
+OpStore %1094 %1419
+%1420 = OpLoad %ulong %1094
+%1421 = OpBitwiseAnd %ulong %1420 %ulong_255
+OpStore %1095 %1421
+%1422 = OpLoad %ulong %1099
+%1423 = OpLoad %ulong %1095
+%1424 = OpBitwiseXor %ulong %1422 %1423
+OpStore %1096 %1424
+%1425 = OpLoad %ulong %1096
+%1426 = OpIMul %ulong %1425 %ulong_1099511628211
+OpStore %1097 %1426
+%1427 = OpLoad %ulong %1100
+%1428 = OpIAdd %ulong %1427 %ulong_1
+OpStore %1098 %1428
+%1429 = OpLoad %ulong %1097
+OpStore %1099 %1429
+%1430 = OpLoad %ulong %1098
+OpStore %1100 %1430
+OpBranch %1002
+%982 = OpLabel
+%1431 = OpLoad %ulong %1091
+%1432 = OpIMul %ulong %1431 %ulong_8
+OpStore %1084 %1432
+%1433 = OpLoad %ulong %1084
+%1434 = OpShiftRightLogical %ulong %ulong_40 %1433
+OpStore %1085 %1434
+%1435 = OpLoad %ulong %1085
+%1436 = OpBitwiseAnd %ulong %1435 %ulong_255
+OpStore %1086 %1436
+%1437 = OpLoad %ulong %1090
+%1438 = OpLoad %ulong %1086
+%1439 = OpBitwiseXor %ulong %1437 %1438
+OpStore %1087 %1439
+%1440 = OpLoad %ulong %1087
+%1441 = OpIMul %ulong %1440 %ulong_1099511628211
+OpStore %1088 %1441
+%1442 = OpLoad %ulong %1091
+%1443 = OpIAdd %ulong %1442 %ulong_1
+OpStore %1089 %1443
+%1444 = OpLoad %ulong %1088
+OpStore %1090 %1444
+%1445 = OpLoad %ulong %1089
+OpStore %1091 %1445
+OpBranch %1003
+%977 = OpLabel
+%1446 = OpLoad %ulong %1082
+%1447 = OpIMul %ulong %1446 %ulong_8
+OpStore %1075 %1447
+%1449 = OpLoad %ulong %1075
+%1450 = OpShiftRightLogical %ulong %ulong_20 %1449
+OpStore %1076 %1450
+%1451 = OpLoad %ulong %1076
+%1452 = OpBitwiseAnd %ulong %1451 %ulong_255
+OpStore %1077 %1452
+%1453 = OpLoad %ulong %1081
+%1454 = OpLoad %ulong %1077
+%1455 = OpBitwiseXor %ulong %1453 %1454
+OpStore %1078 %1455
+%1456 = OpLoad %ulong %1078
+%1457 = OpIMul %ulong %1456 %ulong_1099511628211
+OpStore %1079 %1457
+%1458 = OpLoad %ulong %1082
+%1459 = OpIAdd %ulong %1458 %ulong_1
+OpStore %1080 %1459
+%1460 = OpLoad %ulong %1079
+OpStore %1081 %1460
+%1461 = OpLoad %ulong %1080
+OpStore %1082 %1461
+OpBranch %1004
+%972 = OpLabel
+%1462 = OpLoad %ulong %1073
+%1463 = OpIMul %ulong %1462 %ulong_8
+OpStore %1066 %1463
+%1465 = OpLoad %ulong %1066
+%1466 = OpShiftRightLogical %ulong %ulong_12 %1465
+OpStore %1067 %1466
+%1467 = OpLoad %ulong %1067
+%1468 = OpBitwiseAnd %ulong %1467 %ulong_255
+OpStore %1068 %1468
+%1469 = OpLoad %ulong %1072
+%1470 = OpLoad %ulong %1068
+%1471 = OpBitwiseXor %ulong %1469 %1470
+OpStore %1069 %1471
+%1472 = OpLoad %ulong %1069
+%1473 = OpIMul %ulong %1472 %ulong_1099511628211
+OpStore %1070 %1473
+%1474 = OpLoad %ulong %1073
+%1475 = OpIAdd %ulong %1474 %ulong_1
+OpStore %1071 %1475
+%1476 = OpLoad %ulong %1070
+OpStore %1072 %1476
+%1477 = OpLoad %ulong %1071
+OpStore %1073 %1477
+OpBranch %1005
+%1001 = OpLabel
+OpBranch %991
+%1002 = OpLabel
+OpBranch %986
+%1003 = OpLabel
+OpBranch %981
+%1004 = OpLabel
+OpBranch %976
+%1005 = OpLabel
+OpBranch %971
+OpFunctionEnd
+%7 = OpFunction %ulong None %1478
+%1479 = OpFunctionParameter %ulong
+%1480 = OpFunctionParameter %ulong
+%1481 = OpLabel
+%1486 = OpVariable %_ptr_Function_ulong Function
+%1487 = OpVariable %_ptr_Function_ulong Function
+%1488 = OpVariable %_ptr_Function_bool Function
+%1489 = OpVariable %_ptr_Function_ulong Function
+%1490 = OpVariable %_ptr_Function_ulong Function
+%1491 = OpVariable %_ptr_Function_ulong Function
+%1492 = OpVariable %_ptr_Function_ulong Function
+%1493 = OpVariable %_ptr_Function_ulong Function
+%1494 = OpVariable %_ptr_Function_ulong Function
+%1495 = OpVariable %_ptr_Function_ulong Function
+%1496 = OpVariable %_ptr_Function_ulong Function
+OpStore %1486 %1479
+OpStore %1487 %1480
+%1497 = OpLoad %ulong %1486
+OpStore %1495 %1497
+OpStore %1496 %ulong_0
+OpBranch %1482
+%1482 = OpLabel
+%1498 = OpLoad %ulong %1496
+%1499 = OpULessThan %bool %1498 %ulong_8
+OpStore %1488 %1499
+%1500 = OpLoad %bool %1488
+OpLoopMerge %1484 %1485 None
+OpBranchConditional %1500 %1483 %1484
+%1484 = OpLabel
+%1501 = OpLoad %ulong %1495
+OpReturnValue %1501
+%1483 = OpLabel
+%1502 = OpLoad %ulong %1496
+%1503 = OpIMul %ulong %1502 %ulong_8
+OpStore %1489 %1503
+%1504 = OpLoad %ulong %1487
+%1505 = OpLoad %ulong %1489
+%1506 = OpShiftRightLogical %ulong %1504 %1505
+OpStore %1490 %1506
+%1507 = OpLoad %ulong %1490
+%1508 = OpBitwiseAnd %ulong %1507 %ulong_255
+OpStore %1491 %1508
+%1509 = OpLoad %ulong %1495
+%1510 = OpLoad %ulong %1491
+%1511 = OpBitwiseXor %ulong %1509 %1510
+OpStore %1492 %1511
+%1512 = OpLoad %ulong %1492
+%1513 = OpIMul %ulong %1512 %ulong_1099511628211
+OpStore %1493 %1513
+%1514 = OpLoad %ulong %1496
+%1515 = OpIAdd %ulong %1514 %ulong_1
+OpStore %1494 %1515
+%1516 = OpLoad %ulong %1493
+OpStore %1495 %1516
+%1517 = OpLoad %ulong %1494
+OpStore %1496 %1517
+OpBranch %1485
+%1485 = OpLabel
+OpBranch %1482
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_i16.dis
+++ b/test/golden/spirv/scalar/arith_i16.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,322 +10,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_i16.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%ushort = OpTypeInt 16 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%ushort = OpTypeInt 16 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ushort_65520 = OpConstant %ushort 65520
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ushort_0 = OpConstant %ushort 0
 %ushort_32 = OpConstant %ushort 32
 %ushort_8 = OpConstant %ushort 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ushort_32767 = OpConstant %ushort 32767
 %ushort_32768 = OpConstant %ushort 32768
 %ushort_65535 = OpConstant %ushort 65535
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ushort_12345 = OpConstant %ushort 12345
 %ushort_1 = OpConstant %ushort 1
 %ushort_7 = OpConstant %ushort 7
 %ushort_3 = OpConstant %ushort 3
 %ushort_2 = OpConstant %ushort 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %ushort
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_ushort Function
-%27 = OpVariable %_ptr_Function_ushort Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ushort Function
-%32 = OpVariable %_ptr_Function_ushort Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ushort Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ushort Function
-%37 = OpVariable %_ptr_Function_ushort Function
-%38 = OpVariable %_ptr_Function_ushort Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ushort Function
-%41 = OpVariable %_ptr_Function_ushort Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ushort Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ushort Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ushort Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ushort Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ushort Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ushort Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ushort Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ushort Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ushort Function
-%62 = OpVariable %_ptr_Function_ushort Function
-%63 = OpVariable %_ptr_Function_ushort Function
-%64 = OpVariable %_ptr_Function_ushort Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %ushort %66
-OpStore %22 %67
-%69 = OpLoad %ushort %22
-%70 = OpIAdd %ushort %ushort_65520 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %ushort %23
-OpStore %61 %72
-OpStore %62 %ushort_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %ushort %62
-%76 = OpSLessThan %bool %74 %ushort_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %ushort %22
-OpStore %63 %79
-OpStore %64 %ushort_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %ushort %64
-%82 = OpSLessThan %bool %80 %ushort_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %ushort %61
-%85 = OpISub %ushort %ushort_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %ushort %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %ushort %41
-%90 = OpISub %ushort %ushort_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %ushort %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %ushort %22
-%95 = OpISub %ushort %ushort_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %ushort %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %ushort %61
-%101 = OpIAdd %ushort %ushort_32767 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %ushort %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %ushort %61
-%107 = OpISub %ushort %ushort_32768 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %ushort %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %ushort %61
-%113 = OpIAdd %ushort %ushort_65535 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %ushort %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %ushort %61
-%118 = OpLoad %ushort %63
-%119 = OpIAdd %ushort %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %ushort %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %ushort %61
-%124 = OpLoad %ushort %63
-%125 = OpISub %ushort %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %ushort %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %ushort %63
-%130 = OpLoad %ushort %61
-%131 = OpISub %ushort %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %ushort %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %ushort %64
-%138 = OpIMul %ushort %136 %ushort_12345
-OpStore %36 %138
-%139 = OpLoad %ushort %36
-%141 = OpIAdd %ushort %139 %ushort_1
-OpStore %37 %141
-%142 = OpLoad %ushort %63
-%143 = OpLoad %ushort %37
-%144 = OpISub %ushort %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %ushort %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %ushort %64
-%149 = OpIAdd %ushort %148 %ushort_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %ushort %38
-OpStore %63 %151
-%152 = OpLoad %ushort %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %ushort %62
-%155 = OpIMul %ushort %153 %ushort_7
-OpStore %26 %155
-%156 = OpLoad %ushort %26
-%157 = OpIAdd %ushort %156 %ushort_1
-OpStore %27 %157
-%158 = OpLoad %ushort %61
-%159 = OpLoad %ushort %27
-%160 = OpIAdd %ushort %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %ushort %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %ushort %62
-%166 = OpIMul %ushort %164 %ushort_3
-OpStore %30 %166
-%167 = OpLoad %ushort %30
-%169 = OpIAdd %ushort %167 %ushort_2
-OpStore %31 %169
-%170 = OpLoad %ushort %28
-%171 = OpLoad %ushort %31
-%172 = OpISub %ushort %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %ushort %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %ushort %62
-%177 = OpIAdd %ushort %176 %ushort_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %ushort %32
-OpStore %61 %179
-%180 = OpLoad %ushort %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %ushort
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ushort Function
+%118 = OpVariable %_ptr_Function_ushort Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_ushort Function
+%122 = OpVariable %_ptr_Function_ushort Function
+%123 = OpVariable %_ptr_Function_ushort Function
+%124 = OpVariable %_ptr_Function_ushort Function
+%125 = OpVariable %_ptr_Function_ushort Function
+%126 = OpVariable %_ptr_Function_ushort Function
+%127 = OpVariable %_ptr_Function_ushort Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_ushort Function
+%130 = OpVariable %_ptr_Function_ushort Function
+%131 = OpVariable %_ptr_Function_ushort Function
+%132 = OpVariable %_ptr_Function_ushort Function
+%133 = OpVariable %_ptr_Function_ushort Function
+%134 = OpVariable %_ptr_Function_ushort Function
+%135 = OpVariable %_ptr_Function_ushort Function
+%136 = OpVariable %_ptr_Function_ushort Function
+%137 = OpVariable %_ptr_Function_ushort Function
+%138 = OpVariable %_ptr_Function_ushort Function
+%139 = OpVariable %_ptr_Function_ushort Function
+%140 = OpVariable %_ptr_Function_ushort Function
+%141 = OpVariable %_ptr_Function_ushort Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ushort Function
+%145 = OpVariable %_ptr_Function_ushort Function
+%146 = OpVariable %_ptr_Function_ushort Function
+%147 = OpVariable %_ptr_Function_ushort Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ushort Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %ushort %195
-%207 = OpSConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %ushort %268
+OpStore %117 %269
+%271 = OpLoad %ushort %117
+%272 = OpIAdd %ushort %ushort_65520 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %ushort %118
+OpStore %144 %274
+OpStore %145 %ushort_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %ushort %145
+%278 = OpSLessThan %bool %276 %ushort_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %ushort %117
+OpStore %146 %281
+OpStore %147 %ushort_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %ushort %147
+%284 = OpSLessThan %bool %282 %ushort_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %ushort %144
+%287 = OpISub %ushort %ushort_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %ushort %133
+%289 = OpSConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %ushort %133
+%297 = OpISub %ushort %ushort_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %ushort %134
+%299 = OpSConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %ushort %117
+%305 = OpISub %ushort %ushort_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %ushort %135
+%307 = OpSConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %ushort %144
+%314 = OpIAdd %ushort %ushort_32767 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %ushort %136
+%316 = OpSConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %ushort %144
+%323 = OpISub %ushort %ushort_32768 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %ushort %137
+%325 = OpSConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %ushort %144
+%332 = OpIAdd %ushort %ushort_65535 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %ushort %138
+%334 = OpSConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %ushort %144
+%340 = OpLoad %ushort %146
+%341 = OpIAdd %ushort %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %ushort %139
+%343 = OpSConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %ushort %144
+%349 = OpLoad %ushort %146
+%350 = OpISub %ushort %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %ushort %140
+%352 = OpSConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %ushort %146
+%358 = OpLoad %ushort %144
+%359 = OpISub %ushort %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %ushort %141
+%361 = OpSConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %ushort %147
+%516 = OpIMul %ushort %514 %ushort_12345
+OpStore %129 %516
+%517 = OpLoad %ushort %129
+%519 = OpIAdd %ushort %517 %ushort_1
+OpStore %130 %519
+%520 = OpLoad %ushort %146
+%521 = OpLoad %ushort %130
+%522 = OpISub %ushort %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %ushort %131
+%524 = OpSConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %ushort %147
+%530 = OpIAdd %ushort %529 %ushort_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %ushort %131
+OpStore %146 %532
+%533 = OpLoad %ushort %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %ushort %145
+%552 = OpIMul %ushort %550 %ushort_7
+OpStore %121 %552
+%553 = OpLoad %ushort %121
+%554 = OpIAdd %ushort %553 %ushort_1
+OpStore %122 %554
+%555 = OpLoad %ushort %144
+%556 = OpLoad %ushort %122
+%557 = OpIAdd %ushort %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %ushort %123
+%559 = OpSConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %ushort %145
+%566 = OpIMul %ushort %564 %ushort_3
+OpStore %124 %566
+%567 = OpLoad %ushort %124
+%569 = OpIAdd %ushort %567 %ushort_2
+OpStore %125 %569
+%570 = OpLoad %ushort %123
+%571 = OpLoad %ushort %125
+%572 = OpISub %ushort %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %ushort %126
+%574 = OpSConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %ushort %145
+%580 = OpIAdd %ushort %579 %ushort_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %ushort %126
+OpStore %144 %582
+%583 = OpLoad %ushort %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_i32.dis
+++ b/test/golden/spirv/scalar/arith_i32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,322 +9,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_i32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967280 = OpConstant %uint 4294967280
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_32 = OpConstant %uint 32
 %uint_8 = OpConstant %uint 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_2147483647 = OpConstant %uint 2147483647
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_4294967295 = OpConstant %uint 4294967295
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %uint_305419896 = OpConstant %uint 305419896
 %uint_1 = OpConstant %uint 1
 %uint_7 = OpConstant %uint 7
 %uint_3 = OpConstant %uint 3
 %uint_2 = OpConstant %uint 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_uint Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_uint Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uint Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uint Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uint Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uint Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uint Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uint Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_uint Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %uint %66
-OpStore %22 %67
-%69 = OpLoad %uint %22
-%70 = OpIAdd %uint %uint_4294967280 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %uint %23
-OpStore %61 %72
-OpStore %62 %uint_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %uint %62
-%76 = OpSLessThan %bool %74 %uint_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %uint %22
-OpStore %63 %79
-OpStore %64 %uint_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %uint %64
-%82 = OpSLessThan %bool %80 %uint_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %uint %61
-%85 = OpISub %uint %uint_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %uint %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %uint %41
-%90 = OpISub %uint %uint_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %uint %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %uint %22
-%95 = OpISub %uint %uint_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %uint %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %uint %61
-%101 = OpIAdd %uint %uint_2147483647 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %uint %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %uint %61
-%107 = OpISub %uint %uint_2147483648 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %uint %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %uint %61
-%113 = OpIAdd %uint %uint_4294967295 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %uint %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %uint %61
-%118 = OpLoad %uint %63
-%119 = OpIAdd %uint %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %uint %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %uint %61
-%124 = OpLoad %uint %63
-%125 = OpISub %uint %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %uint %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %uint %63
-%130 = OpLoad %uint %61
-%131 = OpISub %uint %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %uint %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %uint %64
-%138 = OpIMul %uint %136 %uint_305419896
-OpStore %36 %138
-%139 = OpLoad %uint %36
-%141 = OpIAdd %uint %139 %uint_1
-OpStore %37 %141
-%142 = OpLoad %uint %63
-%143 = OpLoad %uint %37
-%144 = OpISub %uint %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %uint %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %uint %64
-%149 = OpIAdd %uint %148 %uint_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %uint %38
-OpStore %63 %151
-%152 = OpLoad %uint %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %uint %62
-%155 = OpIMul %uint %153 %uint_7
-OpStore %26 %155
-%156 = OpLoad %uint %26
-%157 = OpIAdd %uint %156 %uint_1
-OpStore %27 %157
-%158 = OpLoad %uint %61
-%159 = OpLoad %uint %27
-%160 = OpIAdd %uint %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %uint %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %uint %62
-%166 = OpIMul %uint %164 %uint_3
-OpStore %30 %166
-%167 = OpLoad %uint %30
-%169 = OpIAdd %uint %167 %uint_2
-OpStore %31 %169
-%170 = OpLoad %uint %28
-%171 = OpLoad %uint %31
-%172 = OpISub %uint %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %uint %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %uint %62
-%177 = OpIAdd %uint %176 %uint_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %uint %32
-OpStore %61 %179
-%180 = OpLoad %uint %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %uint
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_uint Function
+%118 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_uint Function
+%127 = OpVariable %_ptr_Function_uint Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_uint Function
+%132 = OpVariable %_ptr_Function_uint Function
+%133 = OpVariable %_ptr_Function_uint Function
+%134 = OpVariable %_ptr_Function_uint Function
+%135 = OpVariable %_ptr_Function_uint Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_uint Function
+%138 = OpVariable %_ptr_Function_uint Function
+%139 = OpVariable %_ptr_Function_uint Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %uint %195
-%207 = OpSConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %uint %268
+OpStore %117 %269
+%271 = OpLoad %uint %117
+%272 = OpIAdd %uint %uint_4294967280 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %uint %118
+OpStore %144 %274
+OpStore %145 %uint_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %uint %145
+%278 = OpSLessThan %bool %276 %uint_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %uint %117
+OpStore %146 %281
+OpStore %147 %uint_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %uint %147
+%284 = OpSLessThan %bool %282 %uint_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %uint %144
+%287 = OpISub %uint %uint_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %uint %133
+%289 = OpSConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %uint %133
+%297 = OpISub %uint %uint_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %uint %134
+%299 = OpSConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %uint %117
+%305 = OpISub %uint %uint_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %uint %135
+%307 = OpSConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %uint %144
+%314 = OpIAdd %uint %uint_2147483647 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %uint %136
+%316 = OpSConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %uint %144
+%323 = OpISub %uint %uint_2147483648 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %uint %137
+%325 = OpSConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %uint %144
+%332 = OpIAdd %uint %uint_4294967295 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %uint %138
+%334 = OpSConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %uint %144
+%340 = OpLoad %uint %146
+%341 = OpIAdd %uint %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %uint %139
+%343 = OpSConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %uint %144
+%349 = OpLoad %uint %146
+%350 = OpISub %uint %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %uint %140
+%352 = OpSConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %uint %146
+%358 = OpLoad %uint %144
+%359 = OpISub %uint %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %uint %141
+%361 = OpSConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %uint %147
+%516 = OpIMul %uint %514 %uint_305419896
+OpStore %129 %516
+%517 = OpLoad %uint %129
+%519 = OpIAdd %uint %517 %uint_1
+OpStore %130 %519
+%520 = OpLoad %uint %146
+%521 = OpLoad %uint %130
+%522 = OpISub %uint %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %uint %131
+%524 = OpSConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %uint %147
+%530 = OpIAdd %uint %529 %uint_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %uint %131
+OpStore %146 %532
+%533 = OpLoad %uint %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %uint %145
+%552 = OpIMul %uint %550 %uint_7
+OpStore %121 %552
+%553 = OpLoad %uint %121
+%554 = OpIAdd %uint %553 %uint_1
+OpStore %122 %554
+%555 = OpLoad %uint %144
+%556 = OpLoad %uint %122
+%557 = OpIAdd %uint %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %uint %123
+%559 = OpSConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %uint %145
+%566 = OpIMul %uint %564 %uint_3
+OpStore %124 %566
+%567 = OpLoad %uint %124
+%569 = OpIAdd %uint %567 %uint_2
+OpStore %125 %569
+%570 = OpLoad %uint %123
+%571 = OpLoad %uint %125
+%572 = OpISub %uint %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %uint %126
+%574 = OpSConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %uint %145
+%580 = OpIAdd %uint %579 %uint_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %uint %126
+OpStore %144 %582
+%583 = OpLoad %uint %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_i64.dis
+++ b/test/golden/spirv/scalar/arith_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 223
+; Bound: 572
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,255 +9,105 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_i64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551600 = OpConstant %ulong 18446744073709551600
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_32 = OpConstant %ulong 32
 %ulong_8 = OpConstant %ulong 8
 %ulong_9223372036854775807 = OpConstant %ulong 9223372036854775807
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%ulong_1311768467294899695 = OpConstant %ulong 1311768467294899695
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
+%ulong_1311768467294899695 = OpConstant %ulong 1311768467294899695
 %ulong_7 = OpConstant %ulong 7
 %ulong_3 = OpConstant %ulong 3
 %ulong_2 = OpConstant %ulong 2
-%176 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%179 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_bool Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_bool Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-OpStore %18 %6
-%62 = OpFunctionCall %ulong %2
-OpStore %19 %62
-%64 = OpLoad %ulong %18
-%65 = OpIAdd %ulong %ulong_18446744073709551600 %64
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-OpStore %57 %66
-%67 = OpLoad %ulong %20
-OpStore %58 %67
-OpStore %59 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%69 = OpLoad %ulong %59
-%71 = OpSLessThan %bool %69 %ulong_32
-OpStore %22 %71
-%72 = OpLoad %bool %22
-OpLoopMerge %10 %15 None
-OpBranchConditional %72 %9 %10
-%10 = OpLabel
-%73 = OpLoad %ulong %57
-OpStore %56 %73
-%74 = OpLoad %ulong %18
-OpStore %60 %74
-OpStore %61 %ulong_0
-OpBranch %11
-%11 = OpLabel
-%75 = OpLoad %ulong %61
-%77 = OpSLessThan %bool %75 %ulong_8
-OpStore %32 %77
-%78 = OpLoad %bool %32
-OpLoopMerge %13 %14 None
-OpBranchConditional %78 %12 %13
-%13 = OpLabel
-%79 = OpLoad %ulong %58
-%80 = OpISub %ulong %ulong_0 %79
-OpStore %38 %80
-%81 = OpLoad %ulong %56
-%82 = OpLoad %ulong %38
-%83 = OpFunctionCall %ulong %3 %81 %82
-OpStore %39 %83
-%84 = OpLoad %ulong %38
-%85 = OpISub %ulong %ulong_0 %84
-OpStore %40 %85
-%86 = OpLoad %ulong %39
-%87 = OpLoad %ulong %40
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %41 %88
-%89 = OpLoad %ulong %18
-%90 = OpISub %ulong %ulong_0 %89
-OpStore %42 %90
-%91 = OpLoad %ulong %41
-%92 = OpLoad %ulong %42
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %43 %93
-%95 = OpLoad %ulong %58
-%96 = OpIAdd %ulong %ulong_9223372036854775807 %95
-OpStore %44 %96
-%97 = OpLoad %ulong %43
-%98 = OpLoad %ulong %44
-%99 = OpFunctionCall %ulong %3 %97 %98
-OpStore %45 %99
-%101 = OpLoad %ulong %58
-%102 = OpISub %ulong %ulong_9223372036854775808 %101
-OpStore %46 %102
-%103 = OpLoad %ulong %45
-%104 = OpLoad %ulong %46
-%105 = OpFunctionCall %ulong %3 %103 %104
-OpStore %47 %105
-%107 = OpLoad %ulong %58
-%108 = OpIAdd %ulong %ulong_18446744073709551615 %107
-OpStore %48 %108
-%109 = OpLoad %ulong %47
-%110 = OpLoad %ulong %48
-%111 = OpFunctionCall %ulong %3 %109 %110
-OpStore %49 %111
-%112 = OpLoad %ulong %58
-%113 = OpLoad %ulong %60
-%114 = OpIAdd %ulong %112 %113
-OpStore %50 %114
-%115 = OpLoad %ulong %49
-%116 = OpLoad %ulong %50
-%117 = OpFunctionCall %ulong %3 %115 %116
-OpStore %51 %117
-%118 = OpLoad %ulong %58
-%119 = OpLoad %ulong %60
-%120 = OpISub %ulong %118 %119
-OpStore %52 %120
-%121 = OpLoad %ulong %51
-%122 = OpLoad %ulong %52
-%123 = OpFunctionCall %ulong %3 %121 %122
-OpStore %53 %123
-%124 = OpLoad %ulong %60
-%125 = OpLoad %ulong %58
-%126 = OpISub %ulong %124 %125
-OpStore %54 %126
-%127 = OpLoad %ulong %53
-%128 = OpLoad %ulong %54
-%129 = OpFunctionCall %ulong %3 %127 %128
-OpStore %55 %129
-%130 = OpLoad %ulong %55
-OpReturnValue %130
-%12 = OpLabel
-%131 = OpLoad %ulong %61
-%133 = OpIMul %ulong %131 %ulong_1311768467294899695
-OpStore %33 %133
-%134 = OpLoad %ulong %33
-%136 = OpIAdd %ulong %134 %ulong_1
-OpStore %34 %136
-%137 = OpLoad %ulong %60
-%138 = OpLoad %ulong %34
-%139 = OpISub %ulong %137 %138
-OpStore %35 %139
-%140 = OpLoad %ulong %56
-%141 = OpLoad %ulong %35
-%142 = OpFunctionCall %ulong %3 %140 %141
-OpStore %36 %142
-%143 = OpLoad %ulong %61
-%144 = OpIAdd %ulong %143 %ulong_1
-OpStore %37 %144
-%145 = OpLoad %ulong %36
-OpStore %56 %145
-%146 = OpLoad %ulong %35
-OpStore %60 %146
-%147 = OpLoad %ulong %37
-OpStore %61 %147
-OpBranch %14
-%9 = OpLabel
-%148 = OpLoad %ulong %59
-%150 = OpIMul %ulong %148 %ulong_7
-OpStore %23 %150
-%151 = OpLoad %ulong %23
-%152 = OpIAdd %ulong %151 %ulong_1
-OpStore %24 %152
-%153 = OpLoad %ulong %58
-%154 = OpLoad %ulong %24
-%155 = OpIAdd %ulong %153 %154
-OpStore %25 %155
-%156 = OpLoad %ulong %57
-%157 = OpLoad %ulong %25
-%158 = OpFunctionCall %ulong %3 %156 %157
-OpStore %26 %158
-%159 = OpLoad %ulong %59
-%161 = OpIMul %ulong %159 %ulong_3
-OpStore %27 %161
-%162 = OpLoad %ulong %27
-%164 = OpIAdd %ulong %162 %ulong_2
-OpStore %28 %164
-%165 = OpLoad %ulong %25
-%166 = OpLoad %ulong %28
-%167 = OpISub %ulong %165 %166
-OpStore %29 %167
-%168 = OpLoad %ulong %26
-%169 = OpLoad %ulong %29
-%170 = OpFunctionCall %ulong %3 %168 %169
-OpStore %30 %170
-%171 = OpLoad %ulong %59
-%172 = OpIAdd %ulong %171 %ulong_1
-OpStore %31 %172
-%173 = OpLoad %ulong %30
-OpStore %57 %173
-%174 = OpLoad %ulong %29
-OpStore %58 %174
-%175 = OpLoad %ulong %31
-OpStore %59 %175
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %176
-%177 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %179
-%180 = OpFunctionParameter %ulong
-%181 = OpFunctionParameter %ulong
-%182 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_bool Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_bool Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_bool Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_bool Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_bool Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_bool Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
 %189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_bool Function
+%191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
 %193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
@@ -265,53 +115,757 @@ OpFunctionEnd
 %196 = OpVariable %_ptr_Function_ulong Function
 %197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-OpStore %189 %180
-OpStore %190 %181
-OpBranch %183
-%183 = OpLabel
-%200 = OpLoad %ulong %189
-OpStore %198 %200
-OpStore %199 %ulong_0
-OpBranch %184
-%184 = OpLabel
-%201 = OpLoad %ulong %199
-%202 = OpULessThan %bool %201 %ulong_8
-OpStore %191 %202
-%203 = OpLoad %bool %191
-OpLoopMerge %186 %188 None
-OpBranchConditional %203 %185 %186
-%186 = OpLabel
-OpBranch %187
-%187 = OpLabel
-%204 = OpLoad %ulong %198
-OpReturnValue %204
-%185 = OpLabel
-%205 = OpLoad %ulong %199
-%206 = OpIMul %ulong %205 %ulong_8
-OpStore %192 %206
-%207 = OpLoad %ulong %190
-%208 = OpLoad %ulong %192
-%209 = OpShiftRightLogical %ulong %207 %208
-OpStore %193 %209
-%210 = OpLoad %ulong %193
-%212 = OpBitwiseAnd %ulong %210 %ulong_255
-OpStore %194 %212
-%213 = OpLoad %ulong %198
-%214 = OpLoad %ulong %194
-%215 = OpBitwiseXor %ulong %213 %214
-OpStore %195 %215
-%216 = OpLoad %ulong %195
-%218 = OpIMul %ulong %216 %ulong_1099511628211
-OpStore %196 %218
-%219 = OpLoad %ulong %199
-%220 = OpIAdd %ulong %219 %ulong_1
-OpStore %197 %220
-%221 = OpLoad %ulong %196
-OpStore %198 %221
-%222 = OpLoad %ulong %197
-OpStore %199 %222
-OpBranch %188
-%188 = OpLabel
-OpBranch %184
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_bool Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+OpStore %114 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%254 = OpLoad %ulong %114
+%255 = OpIAdd %ulong %ulong_18446744073709551600 %254
+OpStore %115 %255
+OpStore %140 %ulong_14695981039346656037
+%257 = OpLoad %ulong %115
+OpStore %141 %257
+OpStore %142 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%259 = OpLoad %ulong %142
+%261 = OpSLessThan %bool %259 %ulong_32
+OpStore %117 %261
+%262 = OpLoad %bool %117
+OpLoopMerge %8 %111 None
+OpBranchConditional %262 %7 %8
+%8 = OpLabel
+%263 = OpLoad %ulong %140
+OpStore %139 %263
+%264 = OpLoad %ulong %114
+OpStore %143 %264
+OpStore %144 %ulong_0
+OpBranch %9
+%9 = OpLabel
+%265 = OpLoad %ulong %144
+%267 = OpSLessThan %bool %265 %ulong_8
+OpStore %125 %267
+%268 = OpLoad %bool %125
+OpLoopMerge %11 %110 None
+OpBranchConditional %268 %10 %11
+%11 = OpLabel
+%269 = OpLoad %ulong %141
+%270 = OpISub %ulong %ulong_0 %269
+OpStore %130 %270
+OpBranch %18
+%18 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%271 = OpLoad %ulong %139
+OpStore %170 %271
+OpStore %171 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%272 = OpLoad %ulong %171
+%273 = OpULessThan %bool %272 %ulong_8
+OpStore %163 %273
+%274 = OpLoad %bool %163
+OpLoopMerge %35 %108 None
+OpBranchConditional %274 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%275 = OpLoad %ulong %130
+%276 = OpISub %ulong %ulong_0 %275
+OpStore %131 %276
+OpBranch %37
+%37 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%277 = OpLoad %ulong %170
+OpStore %188 %277
+OpStore %189 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%278 = OpLoad %ulong %189
+%279 = OpULessThan %bool %278 %ulong_8
+OpStore %181 %279
+%280 = OpLoad %bool %181
+OpLoopMerge %47 %105 None
+OpBranchConditional %280 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%281 = OpLoad %ulong %114
+%282 = OpISub %ulong %ulong_0 %281
+OpStore %132 %282
+OpBranch %49
+%49 = OpLabel
+OpBranch %51
+%51 = OpLabel
+%283 = OpLoad %ulong %188
+OpStore %197 %283
+OpStore %198 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%284 = OpLoad %ulong %198
+%285 = OpULessThan %bool %284 %ulong_8
+OpStore %190 %285
+%286 = OpLoad %bool %190
+OpLoopMerge %54 %104 None
+OpBranchConditional %286 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%288 = OpLoad %ulong %141
+%289 = OpIAdd %ulong %ulong_9223372036854775807 %288
+OpStore %133 %289
+OpBranch %56
+%56 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%290 = OpLoad %ulong %197
+OpStore %206 %290
+OpStore %207 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%291 = OpLoad %ulong %207
+%292 = OpULessThan %bool %291 %ulong_8
+OpStore %199 %292
+%293 = OpLoad %bool %199
+OpLoopMerge %61 %103 None
+OpBranchConditional %293 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%295 = OpLoad %ulong %141
+%296 = OpISub %ulong %ulong_9223372036854775808 %295
+OpStore %134 %296
+OpBranch %63
+%63 = OpLabel
+OpBranch %65
+%65 = OpLabel
+%297 = OpLoad %ulong %206
+OpStore %215 %297
+OpStore %216 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%298 = OpLoad %ulong %216
+%299 = OpULessThan %bool %298 %ulong_8
+OpStore %208 %299
+%300 = OpLoad %bool %208
+OpLoopMerge %68 %102 None
+OpBranchConditional %300 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%302 = OpLoad %ulong %141
+%303 = OpIAdd %ulong %ulong_18446744073709551615 %302
+OpStore %135 %303
+OpBranch %70
+%70 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%304 = OpLoad %ulong %215
+OpStore %224 %304
+OpStore %225 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%305 = OpLoad %ulong %225
+%306 = OpULessThan %bool %305 %ulong_8
+OpStore %217 %306
+%307 = OpLoad %bool %217
+OpLoopMerge %75 %101 None
+OpBranchConditional %307 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%308 = OpLoad %ulong %141
+%309 = OpLoad %ulong %143
+%310 = OpIAdd %ulong %308 %309
+OpStore %136 %310
+OpBranch %77
+%77 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%311 = OpLoad %ulong %224
+OpStore %233 %311
+OpStore %234 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%312 = OpLoad %ulong %234
+%313 = OpULessThan %bool %312 %ulong_8
+OpStore %226 %313
+%314 = OpLoad %bool %226
+OpLoopMerge %82 %100 None
+OpBranchConditional %314 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%315 = OpLoad %ulong %141
+%316 = OpLoad %ulong %143
+%317 = OpISub %ulong %315 %316
+OpStore %137 %317
+OpBranch %84
+%84 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%318 = OpLoad %ulong %233
+OpStore %242 %318
+OpStore %243 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%319 = OpLoad %ulong %243
+%320 = OpULessThan %bool %319 %ulong_8
+OpStore %235 %320
+%321 = OpLoad %bool %235
+OpLoopMerge %89 %99 None
+OpBranchConditional %321 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%322 = OpLoad %ulong %143
+%323 = OpLoad %ulong %141
+%324 = OpISub %ulong %322 %323
+OpStore %138 %324
+OpBranch %91
+%91 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%325 = OpLoad %ulong %242
+OpStore %251 %325
+OpStore %252 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%326 = OpLoad %ulong %252
+%327 = OpULessThan %bool %326 %ulong_8
+OpStore %244 %327
+%328 = OpLoad %bool %244
+OpLoopMerge %96 %98 None
+OpBranchConditional %328 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%329 = OpLoad %ulong %251
+OpReturnValue %329
+%95 = OpLabel
+%330 = OpLoad %ulong %252
+%331 = OpIMul %ulong %330 %ulong_8
+OpStore %245 %331
+%332 = OpLoad %ulong %138
+%333 = OpLoad %ulong %245
+%334 = OpShiftRightLogical %ulong %332 %333
+OpStore %246 %334
+%335 = OpLoad %ulong %246
+%337 = OpBitwiseAnd %ulong %335 %ulong_255
+OpStore %247 %337
+%338 = OpLoad %ulong %251
+%339 = OpLoad %ulong %247
+%340 = OpBitwiseXor %ulong %338 %339
+OpStore %248 %340
+%341 = OpLoad %ulong %248
+%343 = OpIMul %ulong %341 %ulong_1099511628211
+OpStore %249 %343
+%344 = OpLoad %ulong %252
+%346 = OpIAdd %ulong %344 %ulong_1
+OpStore %250 %346
+%347 = OpLoad %ulong %249
+OpStore %251 %347
+%348 = OpLoad %ulong %250
+OpStore %252 %348
+OpBranch %98
+%88 = OpLabel
+%349 = OpLoad %ulong %243
+%350 = OpIMul %ulong %349 %ulong_8
+OpStore %236 %350
+%351 = OpLoad %ulong %137
+%352 = OpLoad %ulong %236
+%353 = OpShiftRightLogical %ulong %351 %352
+OpStore %237 %353
+%354 = OpLoad %ulong %237
+%355 = OpBitwiseAnd %ulong %354 %ulong_255
+OpStore %238 %355
+%356 = OpLoad %ulong %242
+%357 = OpLoad %ulong %238
+%358 = OpBitwiseXor %ulong %356 %357
+OpStore %239 %358
+%359 = OpLoad %ulong %239
+%360 = OpIMul %ulong %359 %ulong_1099511628211
+OpStore %240 %360
+%361 = OpLoad %ulong %243
+%362 = OpIAdd %ulong %361 %ulong_1
+OpStore %241 %362
+%363 = OpLoad %ulong %240
+OpStore %242 %363
+%364 = OpLoad %ulong %241
+OpStore %243 %364
+OpBranch %99
+%81 = OpLabel
+%365 = OpLoad %ulong %234
+%366 = OpIMul %ulong %365 %ulong_8
+OpStore %227 %366
+%367 = OpLoad %ulong %136
+%368 = OpLoad %ulong %227
+%369 = OpShiftRightLogical %ulong %367 %368
+OpStore %228 %369
+%370 = OpLoad %ulong %228
+%371 = OpBitwiseAnd %ulong %370 %ulong_255
+OpStore %229 %371
+%372 = OpLoad %ulong %233
+%373 = OpLoad %ulong %229
+%374 = OpBitwiseXor %ulong %372 %373
+OpStore %230 %374
+%375 = OpLoad %ulong %230
+%376 = OpIMul %ulong %375 %ulong_1099511628211
+OpStore %231 %376
+%377 = OpLoad %ulong %234
+%378 = OpIAdd %ulong %377 %ulong_1
+OpStore %232 %378
+%379 = OpLoad %ulong %231
+OpStore %233 %379
+%380 = OpLoad %ulong %232
+OpStore %234 %380
+OpBranch %100
+%74 = OpLabel
+%381 = OpLoad %ulong %225
+%382 = OpIMul %ulong %381 %ulong_8
+OpStore %218 %382
+%383 = OpLoad %ulong %135
+%384 = OpLoad %ulong %218
+%385 = OpShiftRightLogical %ulong %383 %384
+OpStore %219 %385
+%386 = OpLoad %ulong %219
+%387 = OpBitwiseAnd %ulong %386 %ulong_255
+OpStore %220 %387
+%388 = OpLoad %ulong %224
+%389 = OpLoad %ulong %220
+%390 = OpBitwiseXor %ulong %388 %389
+OpStore %221 %390
+%391 = OpLoad %ulong %221
+%392 = OpIMul %ulong %391 %ulong_1099511628211
+OpStore %222 %392
+%393 = OpLoad %ulong %225
+%394 = OpIAdd %ulong %393 %ulong_1
+OpStore %223 %394
+%395 = OpLoad %ulong %222
+OpStore %224 %395
+%396 = OpLoad %ulong %223
+OpStore %225 %396
+OpBranch %101
+%67 = OpLabel
+%397 = OpLoad %ulong %216
+%398 = OpIMul %ulong %397 %ulong_8
+OpStore %209 %398
+%399 = OpLoad %ulong %134
+%400 = OpLoad %ulong %209
+%401 = OpShiftRightLogical %ulong %399 %400
+OpStore %210 %401
+%402 = OpLoad %ulong %210
+%403 = OpBitwiseAnd %ulong %402 %ulong_255
+OpStore %211 %403
+%404 = OpLoad %ulong %215
+%405 = OpLoad %ulong %211
+%406 = OpBitwiseXor %ulong %404 %405
+OpStore %212 %406
+%407 = OpLoad %ulong %212
+%408 = OpIMul %ulong %407 %ulong_1099511628211
+OpStore %213 %408
+%409 = OpLoad %ulong %216
+%410 = OpIAdd %ulong %409 %ulong_1
+OpStore %214 %410
+%411 = OpLoad %ulong %213
+OpStore %215 %411
+%412 = OpLoad %ulong %214
+OpStore %216 %412
+OpBranch %102
+%60 = OpLabel
+%413 = OpLoad %ulong %207
+%414 = OpIMul %ulong %413 %ulong_8
+OpStore %200 %414
+%415 = OpLoad %ulong %133
+%416 = OpLoad %ulong %200
+%417 = OpShiftRightLogical %ulong %415 %416
+OpStore %201 %417
+%418 = OpLoad %ulong %201
+%419 = OpBitwiseAnd %ulong %418 %ulong_255
+OpStore %202 %419
+%420 = OpLoad %ulong %206
+%421 = OpLoad %ulong %202
+%422 = OpBitwiseXor %ulong %420 %421
+OpStore %203 %422
+%423 = OpLoad %ulong %203
+%424 = OpIMul %ulong %423 %ulong_1099511628211
+OpStore %204 %424
+%425 = OpLoad %ulong %207
+%426 = OpIAdd %ulong %425 %ulong_1
+OpStore %205 %426
+%427 = OpLoad %ulong %204
+OpStore %206 %427
+%428 = OpLoad %ulong %205
+OpStore %207 %428
+OpBranch %103
+%53 = OpLabel
+%429 = OpLoad %ulong %198
+%430 = OpIMul %ulong %429 %ulong_8
+OpStore %191 %430
+%431 = OpLoad %ulong %132
+%432 = OpLoad %ulong %191
+%433 = OpShiftRightLogical %ulong %431 %432
+OpStore %192 %433
+%434 = OpLoad %ulong %192
+%435 = OpBitwiseAnd %ulong %434 %ulong_255
+OpStore %193 %435
+%436 = OpLoad %ulong %197
+%437 = OpLoad %ulong %193
+%438 = OpBitwiseXor %ulong %436 %437
+OpStore %194 %438
+%439 = OpLoad %ulong %194
+%440 = OpIMul %ulong %439 %ulong_1099511628211
+OpStore %195 %440
+%441 = OpLoad %ulong %198
+%442 = OpIAdd %ulong %441 %ulong_1
+OpStore %196 %442
+%443 = OpLoad %ulong %195
+OpStore %197 %443
+%444 = OpLoad %ulong %196
+OpStore %198 %444
+OpBranch %104
+%46 = OpLabel
+%445 = OpLoad %ulong %189
+%446 = OpIMul %ulong %445 %ulong_8
+OpStore %182 %446
+%447 = OpLoad %ulong %131
+%448 = OpLoad %ulong %182
+%449 = OpShiftRightLogical %ulong %447 %448
+OpStore %183 %449
+%450 = OpLoad %ulong %183
+%451 = OpBitwiseAnd %ulong %450 %ulong_255
+OpStore %184 %451
+%452 = OpLoad %ulong %188
+%453 = OpLoad %ulong %184
+%454 = OpBitwiseXor %ulong %452 %453
+OpStore %185 %454
+%455 = OpLoad %ulong %185
+%456 = OpIMul %ulong %455 %ulong_1099511628211
+OpStore %186 %456
+%457 = OpLoad %ulong %189
+%458 = OpIAdd %ulong %457 %ulong_1
+OpStore %187 %458
+%459 = OpLoad %ulong %186
+OpStore %188 %459
+%460 = OpLoad %ulong %187
+OpStore %189 %460
+OpBranch %105
+%34 = OpLabel
+%461 = OpLoad %ulong %171
+%462 = OpIMul %ulong %461 %ulong_8
+OpStore %164 %462
+%463 = OpLoad %ulong %130
+%464 = OpLoad %ulong %164
+%465 = OpShiftRightLogical %ulong %463 %464
+OpStore %165 %465
+%466 = OpLoad %ulong %165
+%467 = OpBitwiseAnd %ulong %466 %ulong_255
+OpStore %166 %467
+%468 = OpLoad %ulong %170
+%469 = OpLoad %ulong %166
+%470 = OpBitwiseXor %ulong %468 %469
+OpStore %167 %470
+%471 = OpLoad %ulong %167
+%472 = OpIMul %ulong %471 %ulong_1099511628211
+OpStore %168 %472
+%473 = OpLoad %ulong %171
+%474 = OpIAdd %ulong %473 %ulong_1
+OpStore %169 %474
+%475 = OpLoad %ulong %168
+OpStore %170 %475
+%476 = OpLoad %ulong %169
+OpStore %171 %476
+OpBranch %108
+%10 = OpLabel
+%477 = OpLoad %ulong %144
+%479 = OpIMul %ulong %477 %ulong_1311768467294899695
+OpStore %126 %479
+%480 = OpLoad %ulong %126
+%481 = OpIAdd %ulong %480 %ulong_1
+OpStore %127 %481
+%482 = OpLoad %ulong %143
+%483 = OpLoad %ulong %127
+%484 = OpISub %ulong %482 %483
+OpStore %128 %484
+OpBranch %16
+%16 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%485 = OpLoad %ulong %139
+OpStore %161 %485
+OpStore %162 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%486 = OpLoad %ulong %162
+%487 = OpULessThan %bool %486 %ulong_8
+OpStore %154 %487
+%488 = OpLoad %bool %154
+OpLoopMerge %30 %107 None
+OpBranchConditional %488 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%489 = OpLoad %ulong %144
+%490 = OpIAdd %ulong %489 %ulong_1
+OpStore %129 %490
+%491 = OpLoad %ulong %161
+OpStore %139 %491
+%492 = OpLoad %ulong %128
+OpStore %143 %492
+%493 = OpLoad %ulong %129
+OpStore %144 %493
+OpBranch %110
+%29 = OpLabel
+%494 = OpLoad %ulong %162
+%495 = OpIMul %ulong %494 %ulong_8
+OpStore %155 %495
+%496 = OpLoad %ulong %128
+%497 = OpLoad %ulong %155
+%498 = OpShiftRightLogical %ulong %496 %497
+OpStore %156 %498
+%499 = OpLoad %ulong %156
+%500 = OpBitwiseAnd %ulong %499 %ulong_255
+OpStore %157 %500
+%501 = OpLoad %ulong %161
+%502 = OpLoad %ulong %157
+%503 = OpBitwiseXor %ulong %501 %502
+OpStore %158 %503
+%504 = OpLoad %ulong %158
+%505 = OpIMul %ulong %504 %ulong_1099511628211
+OpStore %159 %505
+%506 = OpLoad %ulong %162
+%507 = OpIAdd %ulong %506 %ulong_1
+OpStore %160 %507
+%508 = OpLoad %ulong %159
+OpStore %161 %508
+%509 = OpLoad %ulong %160
+OpStore %162 %509
+OpBranch %107
+%7 = OpLabel
+%510 = OpLoad %ulong %142
+%512 = OpIMul %ulong %510 %ulong_7
+OpStore %118 %512
+%513 = OpLoad %ulong %118
+%514 = OpIAdd %ulong %513 %ulong_1
+OpStore %119 %514
+%515 = OpLoad %ulong %141
+%516 = OpLoad %ulong %119
+%517 = OpIAdd %ulong %515 %516
+OpStore %120 %517
+OpBranch %14
+%14 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%518 = OpLoad %ulong %140
+OpStore %152 %518
+OpStore %153 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%519 = OpLoad %ulong %153
+%520 = OpULessThan %bool %519 %ulong_8
+OpStore %145 %520
+%521 = OpLoad %bool %145
+OpLoopMerge %23 %109 None
+OpBranchConditional %521 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%522 = OpLoad %ulong %142
+%524 = OpIMul %ulong %522 %ulong_3
+OpStore %121 %524
+%525 = OpLoad %ulong %121
+%527 = OpIAdd %ulong %525 %ulong_2
+OpStore %122 %527
+%528 = OpLoad %ulong %120
+%529 = OpLoad %ulong %122
+%530 = OpISub %ulong %528 %529
+OpStore %123 %530
+OpBranch %25
+%25 = OpLabel
+OpBranch %39
+%39 = OpLabel
+%531 = OpLoad %ulong %152
+OpStore %179 %531
+OpStore %180 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%532 = OpLoad %ulong %180
+%533 = OpULessThan %bool %532 %ulong_8
+OpStore %172 %533
+%534 = OpLoad %bool %172
+OpLoopMerge %42 %106 None
+OpBranchConditional %534 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%535 = OpLoad %ulong %142
+%536 = OpIAdd %ulong %535 %ulong_1
+OpStore %124 %536
+%537 = OpLoad %ulong %179
+OpStore %140 %537
+%538 = OpLoad %ulong %123
+OpStore %141 %538
+%539 = OpLoad %ulong %124
+OpStore %142 %539
+OpBranch %111
+%41 = OpLabel
+%540 = OpLoad %ulong %180
+%541 = OpIMul %ulong %540 %ulong_8
+OpStore %173 %541
+%542 = OpLoad %ulong %123
+%543 = OpLoad %ulong %173
+%544 = OpShiftRightLogical %ulong %542 %543
+OpStore %174 %544
+%545 = OpLoad %ulong %174
+%546 = OpBitwiseAnd %ulong %545 %ulong_255
+OpStore %175 %546
+%547 = OpLoad %ulong %179
+%548 = OpLoad %ulong %175
+%549 = OpBitwiseXor %ulong %547 %548
+OpStore %176 %549
+%550 = OpLoad %ulong %176
+%551 = OpIMul %ulong %550 %ulong_1099511628211
+OpStore %177 %551
+%552 = OpLoad %ulong %180
+%553 = OpIAdd %ulong %552 %ulong_1
+OpStore %178 %553
+%554 = OpLoad %ulong %177
+OpStore %179 %554
+%555 = OpLoad %ulong %178
+OpStore %180 %555
+OpBranch %106
+%22 = OpLabel
+%556 = OpLoad %ulong %153
+%557 = OpIMul %ulong %556 %ulong_8
+OpStore %146 %557
+%558 = OpLoad %ulong %120
+%559 = OpLoad %ulong %146
+%560 = OpShiftRightLogical %ulong %558 %559
+OpStore %147 %560
+%561 = OpLoad %ulong %147
+%562 = OpBitwiseAnd %ulong %561 %ulong_255
+OpStore %148 %562
+%563 = OpLoad %ulong %152
+%564 = OpLoad %ulong %148
+%565 = OpBitwiseXor %ulong %563 %564
+OpStore %149 %565
+%566 = OpLoad %ulong %149
+%567 = OpIMul %ulong %566 %ulong_1099511628211
+OpStore %150 %567
+%568 = OpLoad %ulong %153
+%569 = OpIAdd %ulong %568 %ulong_1
+OpStore %151 %569
+%570 = OpLoad %ulong %150
+OpStore %152 %570
+%571 = OpLoad %ulong %151
+OpStore %153 %571
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_i8.dis
+++ b/test/golden/spirv/scalar/arith_i8.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,322 +10,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_i8.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uchar = OpTypeInt 8 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uchar = OpTypeInt 8 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uchar_240 = OpConstant %uchar 240
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar_0 = OpConstant %uchar 0
 %uchar_32 = OpConstant %uchar 32
 %uchar_8 = OpConstant %uchar 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uchar_127 = OpConstant %uchar 127
 %uchar_128 = OpConstant %uchar 128
 %uchar_255 = OpConstant %uchar 255
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %uchar_53 = OpConstant %uchar 53
 %uchar_1 = OpConstant %uchar 1
 %uchar_7 = OpConstant %uchar 7
 %uchar_3 = OpConstant %uchar 3
 %uchar_2 = OpConstant %uchar 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %uchar
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uchar Function
-%23 = OpVariable %_ptr_Function_uchar Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%27 = OpVariable %_ptr_Function_uchar Function
-%28 = OpVariable %_ptr_Function_uchar Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uchar Function
-%31 = OpVariable %_ptr_Function_uchar Function
-%32 = OpVariable %_ptr_Function_uchar Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_uchar Function
-%37 = OpVariable %_ptr_Function_uchar Function
-%38 = OpVariable %_ptr_Function_uchar Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uchar Function
-%41 = OpVariable %_ptr_Function_uchar Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uchar Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uchar Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uchar Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uchar Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uchar Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uchar Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uchar Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uchar Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_uchar Function
-%62 = OpVariable %_ptr_Function_uchar Function
-%63 = OpVariable %_ptr_Function_uchar Function
-%64 = OpVariable %_ptr_Function_uchar Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %uchar %66
-OpStore %22 %67
-%69 = OpLoad %uchar %22
-%70 = OpIAdd %uchar %uchar_240 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %uchar %23
-OpStore %61 %72
-OpStore %62 %uchar_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %uchar %62
-%76 = OpSLessThan %bool %74 %uchar_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %uchar %22
-OpStore %63 %79
-OpStore %64 %uchar_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %uchar %64
-%82 = OpSLessThan %bool %80 %uchar_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %uchar %61
-%85 = OpISub %uchar %uchar_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %uchar %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %uchar %41
-%90 = OpISub %uchar %uchar_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %uchar %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %uchar %22
-%95 = OpISub %uchar %uchar_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %uchar %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %uchar %61
-%101 = OpIAdd %uchar %uchar_127 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %uchar %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %uchar %61
-%107 = OpISub %uchar %uchar_128 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %uchar %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %uchar %61
-%113 = OpIAdd %uchar %uchar_255 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %uchar %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %uchar %61
-%118 = OpLoad %uchar %63
-%119 = OpIAdd %uchar %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %uchar %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %uchar %61
-%124 = OpLoad %uchar %63
-%125 = OpISub %uchar %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %uchar %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %uchar %63
-%130 = OpLoad %uchar %61
-%131 = OpISub %uchar %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %uchar %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %uchar %64
-%138 = OpIMul %uchar %136 %uchar_53
-OpStore %36 %138
-%139 = OpLoad %uchar %36
-%141 = OpIAdd %uchar %139 %uchar_1
-OpStore %37 %141
-%142 = OpLoad %uchar %63
-%143 = OpLoad %uchar %37
-%144 = OpISub %uchar %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %uchar %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %uchar %64
-%149 = OpIAdd %uchar %148 %uchar_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %uchar %38
-OpStore %63 %151
-%152 = OpLoad %uchar %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %uchar %62
-%155 = OpIMul %uchar %153 %uchar_7
-OpStore %26 %155
-%156 = OpLoad %uchar %26
-%157 = OpIAdd %uchar %156 %uchar_1
-OpStore %27 %157
-%158 = OpLoad %uchar %61
-%159 = OpLoad %uchar %27
-%160 = OpIAdd %uchar %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %uchar %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %uchar %62
-%166 = OpIMul %uchar %164 %uchar_3
-OpStore %30 %166
-%167 = OpLoad %uchar %30
-%169 = OpIAdd %uchar %167 %uchar_2
-OpStore %31 %169
-%170 = OpLoad %uchar %28
-%171 = OpLoad %uchar %31
-%172 = OpISub %uchar %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %uchar %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %uchar %62
-%177 = OpIAdd %uchar %176 %uchar_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %uchar %32
-OpStore %61 %179
-%180 = OpLoad %uchar %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %uchar
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_uchar Function
+%118 = OpVariable %_ptr_Function_uchar Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_uchar Function
+%122 = OpVariable %_ptr_Function_uchar Function
+%123 = OpVariable %_ptr_Function_uchar Function
+%124 = OpVariable %_ptr_Function_uchar Function
+%125 = OpVariable %_ptr_Function_uchar Function
+%126 = OpVariable %_ptr_Function_uchar Function
+%127 = OpVariable %_ptr_Function_uchar Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_uchar Function
+%130 = OpVariable %_ptr_Function_uchar Function
+%131 = OpVariable %_ptr_Function_uchar Function
+%132 = OpVariable %_ptr_Function_uchar Function
+%133 = OpVariable %_ptr_Function_uchar Function
+%134 = OpVariable %_ptr_Function_uchar Function
+%135 = OpVariable %_ptr_Function_uchar Function
+%136 = OpVariable %_ptr_Function_uchar Function
+%137 = OpVariable %_ptr_Function_uchar Function
+%138 = OpVariable %_ptr_Function_uchar Function
+%139 = OpVariable %_ptr_Function_uchar Function
+%140 = OpVariable %_ptr_Function_uchar Function
+%141 = OpVariable %_ptr_Function_uchar Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_uchar Function
+%145 = OpVariable %_ptr_Function_uchar Function
+%146 = OpVariable %_ptr_Function_uchar Function
+%147 = OpVariable %_ptr_Function_uchar Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_uchar Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %uchar %195
-%207 = OpSConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %uchar %268
+OpStore %117 %269
+%271 = OpLoad %uchar %117
+%272 = OpIAdd %uchar %uchar_240 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %uchar %118
+OpStore %144 %274
+OpStore %145 %uchar_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %uchar %145
+%278 = OpSLessThan %bool %276 %uchar_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %uchar %117
+OpStore %146 %281
+OpStore %147 %uchar_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %uchar %147
+%284 = OpSLessThan %bool %282 %uchar_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %uchar %144
+%287 = OpISub %uchar %uchar_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %uchar %133
+%289 = OpSConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %uchar %133
+%297 = OpISub %uchar %uchar_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %uchar %134
+%299 = OpSConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %uchar %117
+%305 = OpISub %uchar %uchar_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %uchar %135
+%307 = OpSConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %uchar %144
+%314 = OpIAdd %uchar %uchar_127 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %uchar %136
+%316 = OpSConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %uchar %144
+%323 = OpISub %uchar %uchar_128 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %uchar %137
+%325 = OpSConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %uchar %144
+%332 = OpIAdd %uchar %uchar_255 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %uchar %138
+%334 = OpSConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %uchar %144
+%340 = OpLoad %uchar %146
+%341 = OpIAdd %uchar %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %uchar %139
+%343 = OpSConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %uchar %144
+%349 = OpLoad %uchar %146
+%350 = OpISub %uchar %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %uchar %140
+%352 = OpSConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %uchar %146
+%358 = OpLoad %uchar %144
+%359 = OpISub %uchar %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %uchar %141
+%361 = OpSConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %uchar %147
+%516 = OpIMul %uchar %514 %uchar_53
+OpStore %129 %516
+%517 = OpLoad %uchar %129
+%519 = OpIAdd %uchar %517 %uchar_1
+OpStore %130 %519
+%520 = OpLoad %uchar %146
+%521 = OpLoad %uchar %130
+%522 = OpISub %uchar %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %uchar %131
+%524 = OpSConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %uchar %147
+%530 = OpIAdd %uchar %529 %uchar_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %uchar %131
+OpStore %146 %532
+%533 = OpLoad %uchar %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %uchar %145
+%552 = OpIMul %uchar %550 %uchar_7
+OpStore %121 %552
+%553 = OpLoad %uchar %121
+%554 = OpIAdd %uchar %553 %uchar_1
+OpStore %122 %554
+%555 = OpLoad %uchar %144
+%556 = OpLoad %uchar %122
+%557 = OpIAdd %uchar %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %uchar %123
+%559 = OpSConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %uchar %145
+%566 = OpIMul %uchar %564 %uchar_3
+OpStore %124 %566
+%567 = OpLoad %uchar %124
+%569 = OpIAdd %uchar %567 %uchar_2
+OpStore %125 %569
+%570 = OpLoad %uchar %123
+%571 = OpLoad %uchar %125
+%572 = OpISub %uchar %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %uchar %126
+%574 = OpSConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %uchar %145
+%580 = OpIAdd %uchar %579 %uchar_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %uchar %126
+OpStore %144 %582
+%583 = OpLoad %uchar %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_u16.dis
+++ b/test/golden/spirv/scalar/arith_u16.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,322 +10,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_u16.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%ushort = OpTypeInt 16 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%ushort = OpTypeInt 16 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ushort_65520 = OpConstant %ushort 65520
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ushort_0 = OpConstant %ushort 0
 %ushort_32 = OpConstant %ushort 32
 %ushort_8 = OpConstant %ushort 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %ushort_32767 = OpConstant %ushort 32767
 %ushort_32768 = OpConstant %ushort 32768
 %ushort_65535 = OpConstant %ushort 65535
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ushort_43981 = OpConstant %ushort 43981
 %ushort_1 = OpConstant %ushort 1
 %ushort_7 = OpConstant %ushort 7
 %ushort_3 = OpConstant %ushort 3
 %ushort_2 = OpConstant %ushort 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %ushort
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_ushort Function
-%27 = OpVariable %_ptr_Function_ushort Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ushort Function
-%32 = OpVariable %_ptr_Function_ushort Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ushort Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_ushort Function
-%37 = OpVariable %_ptr_Function_ushort Function
-%38 = OpVariable %_ptr_Function_ushort Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ushort Function
-%41 = OpVariable %_ptr_Function_ushort Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ushort Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ushort Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ushort Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ushort Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ushort Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ushort Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ushort Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ushort Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ushort Function
-%62 = OpVariable %_ptr_Function_ushort Function
-%63 = OpVariable %_ptr_Function_ushort Function
-%64 = OpVariable %_ptr_Function_ushort Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %ushort %66
-OpStore %22 %67
-%69 = OpLoad %ushort %22
-%70 = OpIAdd %ushort %ushort_65520 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %ushort %23
-OpStore %61 %72
-OpStore %62 %ushort_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %ushort %62
-%76 = OpULessThan %bool %74 %ushort_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %ushort %22
-OpStore %63 %79
-OpStore %64 %ushort_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %ushort %64
-%82 = OpULessThan %bool %80 %ushort_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %ushort %61
-%85 = OpISub %ushort %ushort_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %ushort %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %ushort %41
-%90 = OpISub %ushort %ushort_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %ushort %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %ushort %22
-%95 = OpISub %ushort %ushort_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %ushort %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %ushort %61
-%101 = OpIAdd %ushort %ushort_32767 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %ushort %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %ushort %61
-%107 = OpISub %ushort %ushort_32768 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %ushort %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %ushort %61
-%113 = OpIAdd %ushort %ushort_65535 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %ushort %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %ushort %61
-%118 = OpLoad %ushort %63
-%119 = OpIAdd %ushort %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %ushort %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %ushort %61
-%124 = OpLoad %ushort %63
-%125 = OpISub %ushort %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %ushort %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %ushort %63
-%130 = OpLoad %ushort %61
-%131 = OpISub %ushort %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %ushort %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %ushort %64
-%138 = OpIMul %ushort %136 %ushort_43981
-OpStore %36 %138
-%139 = OpLoad %ushort %36
-%141 = OpIAdd %ushort %139 %ushort_1
-OpStore %37 %141
-%142 = OpLoad %ushort %63
-%143 = OpLoad %ushort %37
-%144 = OpISub %ushort %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %ushort %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %ushort %64
-%149 = OpIAdd %ushort %148 %ushort_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %ushort %38
-OpStore %63 %151
-%152 = OpLoad %ushort %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %ushort %62
-%155 = OpIMul %ushort %153 %ushort_7
-OpStore %26 %155
-%156 = OpLoad %ushort %26
-%157 = OpIAdd %ushort %156 %ushort_1
-OpStore %27 %157
-%158 = OpLoad %ushort %61
-%159 = OpLoad %ushort %27
-%160 = OpIAdd %ushort %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %ushort %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %ushort %62
-%166 = OpIMul %ushort %164 %ushort_3
-OpStore %30 %166
-%167 = OpLoad %ushort %30
-%169 = OpIAdd %ushort %167 %ushort_2
-OpStore %31 %169
-%170 = OpLoad %ushort %28
-%171 = OpLoad %ushort %31
-%172 = OpISub %ushort %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %ushort %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %ushort %62
-%177 = OpIAdd %ushort %176 %ushort_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %ushort %32
-OpStore %61 %179
-%180 = OpLoad %ushort %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %ushort
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ushort Function
+%118 = OpVariable %_ptr_Function_ushort Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_ushort Function
+%122 = OpVariable %_ptr_Function_ushort Function
+%123 = OpVariable %_ptr_Function_ushort Function
+%124 = OpVariable %_ptr_Function_ushort Function
+%125 = OpVariable %_ptr_Function_ushort Function
+%126 = OpVariable %_ptr_Function_ushort Function
+%127 = OpVariable %_ptr_Function_ushort Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_ushort Function
+%130 = OpVariable %_ptr_Function_ushort Function
+%131 = OpVariable %_ptr_Function_ushort Function
+%132 = OpVariable %_ptr_Function_ushort Function
+%133 = OpVariable %_ptr_Function_ushort Function
+%134 = OpVariable %_ptr_Function_ushort Function
+%135 = OpVariable %_ptr_Function_ushort Function
+%136 = OpVariable %_ptr_Function_ushort Function
+%137 = OpVariable %_ptr_Function_ushort Function
+%138 = OpVariable %_ptr_Function_ushort Function
+%139 = OpVariable %_ptr_Function_ushort Function
+%140 = OpVariable %_ptr_Function_ushort Function
+%141 = OpVariable %_ptr_Function_ushort Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ushort Function
+%145 = OpVariable %_ptr_Function_ushort Function
+%146 = OpVariable %_ptr_Function_ushort Function
+%147 = OpVariable %_ptr_Function_ushort Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ushort Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %ushort %195
-%207 = OpUConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %ushort %268
+OpStore %117 %269
+%271 = OpLoad %ushort %117
+%272 = OpIAdd %ushort %ushort_65520 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %ushort %118
+OpStore %144 %274
+OpStore %145 %ushort_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %ushort %145
+%278 = OpULessThan %bool %276 %ushort_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %ushort %117
+OpStore %146 %281
+OpStore %147 %ushort_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %ushort %147
+%284 = OpULessThan %bool %282 %ushort_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %ushort %144
+%287 = OpISub %ushort %ushort_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %ushort %133
+%289 = OpUConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %ushort %133
+%297 = OpISub %ushort %ushort_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %ushort %134
+%299 = OpUConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %ushort %117
+%305 = OpISub %ushort %ushort_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %ushort %135
+%307 = OpUConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %ushort %144
+%314 = OpIAdd %ushort %ushort_32767 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %ushort %136
+%316 = OpUConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %ushort %144
+%323 = OpISub %ushort %ushort_32768 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %ushort %137
+%325 = OpUConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %ushort %144
+%332 = OpIAdd %ushort %ushort_65535 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %ushort %138
+%334 = OpUConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %ushort %144
+%340 = OpLoad %ushort %146
+%341 = OpIAdd %ushort %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %ushort %139
+%343 = OpUConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %ushort %144
+%349 = OpLoad %ushort %146
+%350 = OpISub %ushort %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %ushort %140
+%352 = OpUConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %ushort %146
+%358 = OpLoad %ushort %144
+%359 = OpISub %ushort %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %ushort %141
+%361 = OpUConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %ushort %147
+%516 = OpIMul %ushort %514 %ushort_43981
+OpStore %129 %516
+%517 = OpLoad %ushort %129
+%519 = OpIAdd %ushort %517 %ushort_1
+OpStore %130 %519
+%520 = OpLoad %ushort %146
+%521 = OpLoad %ushort %130
+%522 = OpISub %ushort %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %ushort %131
+%524 = OpUConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %ushort %147
+%530 = OpIAdd %ushort %529 %ushort_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %ushort %131
+OpStore %146 %532
+%533 = OpLoad %ushort %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %ushort %145
+%552 = OpIMul %ushort %550 %ushort_7
+OpStore %121 %552
+%553 = OpLoad %ushort %121
+%554 = OpIAdd %ushort %553 %ushort_1
+OpStore %122 %554
+%555 = OpLoad %ushort %144
+%556 = OpLoad %ushort %122
+%557 = OpIAdd %ushort %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %ushort %123
+%559 = OpUConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %ushort %145
+%566 = OpIMul %ushort %564 %ushort_3
+OpStore %124 %566
+%567 = OpLoad %ushort %124
+%569 = OpIAdd %ushort %567 %ushort_2
+OpStore %125 %569
+%570 = OpLoad %ushort %123
+%571 = OpLoad %ushort %125
+%572 = OpISub %ushort %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %ushort %126
+%574 = OpUConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %ushort %145
+%580 = OpIAdd %ushort %579 %ushort_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %ushort %126
+OpStore %144 %582
+%583 = OpLoad %ushort %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_u32.dis
+++ b/test/golden/spirv/scalar/arith_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,322 +9,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967280 = OpConstant %uint 4294967280
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_32 = OpConstant %uint 32
 %uint_8 = OpConstant %uint 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_2147483647 = OpConstant %uint 2147483647
 %uint_2147483648 = OpConstant %uint 2147483648
 %uint_4294967295 = OpConstant %uint 4294967295
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %uint_305419896 = OpConstant %uint 305419896
 %uint_1 = OpConstant %uint 1
 %uint_7 = OpConstant %uint 7
 %uint_3 = OpConstant %uint 3
 %uint_2 = OpConstant %uint 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_uint Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_uint Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uint Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uint Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uint Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uint Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uint Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uint Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_uint Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_uint Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %uint %66
-OpStore %22 %67
-%69 = OpLoad %uint %22
-%70 = OpIAdd %uint %uint_4294967280 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %uint %23
-OpStore %61 %72
-OpStore %62 %uint_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %uint %62
-%76 = OpULessThan %bool %74 %uint_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %uint %22
-OpStore %63 %79
-OpStore %64 %uint_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %uint %64
-%82 = OpULessThan %bool %80 %uint_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %uint %61
-%85 = OpISub %uint %uint_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %uint %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %uint %41
-%90 = OpISub %uint %uint_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %uint %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %uint %22
-%95 = OpISub %uint %uint_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %uint %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %uint %61
-%101 = OpIAdd %uint %uint_2147483647 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %uint %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %uint %61
-%107 = OpISub %uint %uint_2147483648 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %uint %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %uint %61
-%113 = OpIAdd %uint %uint_4294967295 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %uint %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %uint %61
-%118 = OpLoad %uint %63
-%119 = OpIAdd %uint %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %uint %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %uint %61
-%124 = OpLoad %uint %63
-%125 = OpISub %uint %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %uint %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %uint %63
-%130 = OpLoad %uint %61
-%131 = OpISub %uint %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %uint %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %uint %64
-%138 = OpIMul %uint %136 %uint_305419896
-OpStore %36 %138
-%139 = OpLoad %uint %36
-%141 = OpIAdd %uint %139 %uint_1
-OpStore %37 %141
-%142 = OpLoad %uint %63
-%143 = OpLoad %uint %37
-%144 = OpISub %uint %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %uint %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %uint %64
-%149 = OpIAdd %uint %148 %uint_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %uint %38
-OpStore %63 %151
-%152 = OpLoad %uint %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %uint %62
-%155 = OpIMul %uint %153 %uint_7
-OpStore %26 %155
-%156 = OpLoad %uint %26
-%157 = OpIAdd %uint %156 %uint_1
-OpStore %27 %157
-%158 = OpLoad %uint %61
-%159 = OpLoad %uint %27
-%160 = OpIAdd %uint %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %uint %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %uint %62
-%166 = OpIMul %uint %164 %uint_3
-OpStore %30 %166
-%167 = OpLoad %uint %30
-%169 = OpIAdd %uint %167 %uint_2
-OpStore %31 %169
-%170 = OpLoad %uint %28
-%171 = OpLoad %uint %31
-%172 = OpISub %uint %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %uint %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %uint %62
-%177 = OpIAdd %uint %176 %uint_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %uint %32
-OpStore %61 %179
-%180 = OpLoad %uint %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %uint
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_uint Function
+%118 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_uint Function
+%127 = OpVariable %_ptr_Function_uint Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_uint Function
+%132 = OpVariable %_ptr_Function_uint Function
+%133 = OpVariable %_ptr_Function_uint Function
+%134 = OpVariable %_ptr_Function_uint Function
+%135 = OpVariable %_ptr_Function_uint Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_uint Function
+%138 = OpVariable %_ptr_Function_uint Function
+%139 = OpVariable %_ptr_Function_uint Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %uint %195
-%207 = OpUConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %uint %268
+OpStore %117 %269
+%271 = OpLoad %uint %117
+%272 = OpIAdd %uint %uint_4294967280 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %uint %118
+OpStore %144 %274
+OpStore %145 %uint_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %uint %145
+%278 = OpULessThan %bool %276 %uint_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %uint %117
+OpStore %146 %281
+OpStore %147 %uint_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %uint %147
+%284 = OpULessThan %bool %282 %uint_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %uint %144
+%287 = OpISub %uint %uint_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %uint %133
+%289 = OpUConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %uint %133
+%297 = OpISub %uint %uint_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %uint %134
+%299 = OpUConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %uint %117
+%305 = OpISub %uint %uint_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %uint %135
+%307 = OpUConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %uint %144
+%314 = OpIAdd %uint %uint_2147483647 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %uint %136
+%316 = OpUConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %uint %144
+%323 = OpISub %uint %uint_2147483648 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %uint %137
+%325 = OpUConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %uint %144
+%332 = OpIAdd %uint %uint_4294967295 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %uint %138
+%334 = OpUConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %uint %144
+%340 = OpLoad %uint %146
+%341 = OpIAdd %uint %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %uint %139
+%343 = OpUConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %uint %144
+%349 = OpLoad %uint %146
+%350 = OpISub %uint %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %uint %140
+%352 = OpUConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %uint %146
+%358 = OpLoad %uint %144
+%359 = OpISub %uint %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %uint %141
+%361 = OpUConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %uint %147
+%516 = OpIMul %uint %514 %uint_305419896
+OpStore %129 %516
+%517 = OpLoad %uint %129
+%519 = OpIAdd %uint %517 %uint_1
+OpStore %130 %519
+%520 = OpLoad %uint %146
+%521 = OpLoad %uint %130
+%522 = OpISub %uint %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %uint %131
+%524 = OpUConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %uint %147
+%530 = OpIAdd %uint %529 %uint_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %uint %131
+OpStore %146 %532
+%533 = OpLoad %uint %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %uint %145
+%552 = OpIMul %uint %550 %uint_7
+OpStore %121 %552
+%553 = OpLoad %uint %121
+%554 = OpIAdd %uint %553 %uint_1
+OpStore %122 %554
+%555 = OpLoad %uint %144
+%556 = OpLoad %uint %122
+%557 = OpIAdd %uint %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %uint %123
+%559 = OpUConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %uint %145
+%566 = OpIMul %uint %564 %uint_3
+OpStore %124 %566
+%567 = OpLoad %uint %124
+%569 = OpIAdd %uint %567 %uint_2
+OpStore %125 %569
+%570 = OpLoad %uint %123
+%571 = OpLoad %uint %125
+%572 = OpISub %uint %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %uint %126
+%574 = OpUConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %uint %145
+%580 = OpIAdd %uint %579 %uint_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %uint %126
+OpStore %144 %582
+%583 = OpLoad %uint %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_u64.dis
+++ b/test/golden/spirv/scalar/arith_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 221
+; Bound: 548
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,305 +9,815 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551600 = OpConstant %ulong 18446744073709551600
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_32 = OpConstant %ulong 32
 %ulong_8 = OpConstant %ulong 8
 %ulong_9223372036854775807 = OpConstant %ulong 9223372036854775807
 %ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%ulong_1311768467294899695 = OpConstant %ulong 1311768467294899695
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
+%ulong_1311768467294899695 = OpConstant %ulong 1311768467294899695
 %ulong_7 = OpConstant %ulong 7
 %ulong_3 = OpConstant %ulong 3
 %ulong_2 = OpConstant %ulong 2
-%176 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%179 = OpTypeFunction %ulong %ulong %ulong
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_bool Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_bool Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-OpStore %18 %6
-%62 = OpFunctionCall %ulong %2
-OpStore %19 %62
-%64 = OpLoad %ulong %18
-%65 = OpIAdd %ulong %ulong_18446744073709551600 %64
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-OpStore %57 %66
-%67 = OpLoad %ulong %20
-OpStore %58 %67
-OpStore %59 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%69 = OpLoad %ulong %59
-%71 = OpULessThan %bool %69 %ulong_32
-OpStore %22 %71
-%72 = OpLoad %bool %22
-OpLoopMerge %10 %15 None
-OpBranchConditional %72 %9 %10
-%10 = OpLabel
-%73 = OpLoad %ulong %57
-OpStore %56 %73
-%74 = OpLoad %ulong %18
-OpStore %60 %74
-OpStore %61 %ulong_0
-OpBranch %11
-%11 = OpLabel
-%75 = OpLoad %ulong %61
-%77 = OpULessThan %bool %75 %ulong_8
-OpStore %32 %77
-%78 = OpLoad %bool %32
-OpLoopMerge %13 %14 None
-OpBranchConditional %78 %12 %13
-%13 = OpLabel
-%79 = OpLoad %ulong %58
-%80 = OpISub %ulong %ulong_0 %79
-OpStore %38 %80
-%81 = OpLoad %ulong %56
-%82 = OpLoad %ulong %38
-%83 = OpFunctionCall %ulong %3 %81 %82
-OpStore %39 %83
-%84 = OpLoad %ulong %38
-%85 = OpISub %ulong %ulong_0 %84
-OpStore %40 %85
-%86 = OpLoad %ulong %39
-%87 = OpLoad %ulong %40
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %41 %88
-%89 = OpLoad %ulong %18
-%90 = OpISub %ulong %ulong_0 %89
-OpStore %42 %90
-%91 = OpLoad %ulong %41
-%92 = OpLoad %ulong %42
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %43 %93
-%95 = OpLoad %ulong %58
-%96 = OpIAdd %ulong %ulong_9223372036854775807 %95
-OpStore %44 %96
-%97 = OpLoad %ulong %43
-%98 = OpLoad %ulong %44
-%99 = OpFunctionCall %ulong %3 %97 %98
-OpStore %45 %99
-%101 = OpLoad %ulong %58
-%102 = OpISub %ulong %ulong_9223372036854775808 %101
-OpStore %46 %102
-%103 = OpLoad %ulong %45
-%104 = OpLoad %ulong %46
-%105 = OpFunctionCall %ulong %3 %103 %104
-OpStore %47 %105
-%107 = OpLoad %ulong %58
-%108 = OpIAdd %ulong %ulong_18446744073709551615 %107
-OpStore %48 %108
-%109 = OpLoad %ulong %47
-%110 = OpLoad %ulong %48
-%111 = OpFunctionCall %ulong %3 %109 %110
-OpStore %49 %111
-%112 = OpLoad %ulong %58
-%113 = OpLoad %ulong %60
-%114 = OpIAdd %ulong %112 %113
-OpStore %50 %114
-%115 = OpLoad %ulong %49
-%116 = OpLoad %ulong %50
-%117 = OpFunctionCall %ulong %3 %115 %116
-OpStore %51 %117
-%118 = OpLoad %ulong %58
-%119 = OpLoad %ulong %60
-%120 = OpISub %ulong %118 %119
-OpStore %52 %120
-%121 = OpLoad %ulong %51
-%122 = OpLoad %ulong %52
-%123 = OpFunctionCall %ulong %3 %121 %122
-OpStore %53 %123
-%124 = OpLoad %ulong %60
-%125 = OpLoad %ulong %58
-%126 = OpISub %ulong %124 %125
-OpStore %54 %126
-%127 = OpLoad %ulong %53
-%128 = OpLoad %ulong %54
-%129 = OpFunctionCall %ulong %3 %127 %128
-OpStore %55 %129
-%130 = OpLoad %ulong %55
-OpReturnValue %130
-%12 = OpLabel
-%131 = OpLoad %ulong %61
-%133 = OpIMul %ulong %131 %ulong_1311768467294899695
-OpStore %33 %133
-%134 = OpLoad %ulong %33
-%136 = OpIAdd %ulong %134 %ulong_1
-OpStore %34 %136
-%137 = OpLoad %ulong %60
-%138 = OpLoad %ulong %34
-%139 = OpISub %ulong %137 %138
-OpStore %35 %139
-%140 = OpLoad %ulong %56
-%141 = OpLoad %ulong %35
-%142 = OpFunctionCall %ulong %3 %140 %141
-OpStore %36 %142
-%143 = OpLoad %ulong %61
-%144 = OpIAdd %ulong %143 %ulong_1
-OpStore %37 %144
-%145 = OpLoad %ulong %36
-OpStore %56 %145
-%146 = OpLoad %ulong %35
-OpStore %60 %146
-%147 = OpLoad %ulong %37
-OpStore %61 %147
-OpBranch %14
-%9 = OpLabel
-%148 = OpLoad %ulong %59
-%150 = OpIMul %ulong %148 %ulong_7
-OpStore %23 %150
-%151 = OpLoad %ulong %23
-%152 = OpIAdd %ulong %151 %ulong_1
-OpStore %24 %152
-%153 = OpLoad %ulong %58
-%154 = OpLoad %ulong %24
-%155 = OpIAdd %ulong %153 %154
-OpStore %25 %155
-%156 = OpLoad %ulong %57
-%157 = OpLoad %ulong %25
-%158 = OpFunctionCall %ulong %3 %156 %157
-OpStore %26 %158
-%159 = OpLoad %ulong %59
-%161 = OpIMul %ulong %159 %ulong_3
-OpStore %27 %161
-%162 = OpLoad %ulong %27
-%164 = OpIAdd %ulong %162 %ulong_2
-OpStore %28 %164
-%165 = OpLoad %ulong %25
-%166 = OpLoad %ulong %28
-%167 = OpISub %ulong %165 %166
-OpStore %29 %167
-%168 = OpLoad %ulong %26
-%169 = OpLoad %ulong %29
-%170 = OpFunctionCall %ulong %3 %168 %169
-OpStore %30 %170
-%171 = OpLoad %ulong %59
-%172 = OpIAdd %ulong %171 %ulong_1
-OpStore %31 %172
-%173 = OpLoad %ulong %30
-OpStore %57 %173
-%174 = OpLoad %ulong %29
-OpStore %58 %174
-%175 = OpLoad %ulong %31
-OpStore %59 %175
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %176
-%177 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %179
-%180 = OpFunctionParameter %ulong
-%181 = OpFunctionParameter %ulong
-%182 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_bool Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_bool Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_bool Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_bool Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_bool Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_bool Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_bool Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_bool Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
 %187 = OpVariable %_ptr_Function_ulong Function
 %188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_ulong Function
 %190 = OpVariable %_ptr_Function_ulong Function
 %191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_bool Function
 %194 = OpVariable %_ptr_Function_ulong Function
 %195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
 %197 = OpVariable %_ptr_Function_ulong Function
-OpStore %187 %180
-OpStore %188 %181
-%198 = OpLoad %ulong %187
-OpStore %196 %198
-OpStore %197 %ulong_0
-OpBranch %183
-%183 = OpLabel
-%199 = OpLoad %ulong %197
-%200 = OpULessThan %bool %199 %ulong_8
-OpStore %189 %200
-%201 = OpLoad %bool %189
-OpLoopMerge %185 %186 None
-OpBranchConditional %201 %184 %185
-%185 = OpLabel
-%202 = OpLoad %ulong %196
-OpReturnValue %202
-%184 = OpLabel
-%203 = OpLoad %ulong %197
-%204 = OpIMul %ulong %203 %ulong_8
-OpStore %190 %204
-%205 = OpLoad %ulong %188
-%206 = OpLoad %ulong %190
-%207 = OpShiftRightLogical %ulong %205 %206
-OpStore %191 %207
-%208 = OpLoad %ulong %191
-%210 = OpBitwiseAnd %ulong %208 %ulong_255
-OpStore %192 %210
-%211 = OpLoad %ulong %196
-%212 = OpLoad %ulong %192
-%213 = OpBitwiseXor %ulong %211 %212
-OpStore %193 %213
-%214 = OpLoad %ulong %193
-%216 = OpIMul %ulong %214 %ulong_1099511628211
-OpStore %194 %216
-%217 = OpLoad %ulong %197
-%218 = OpIAdd %ulong %217 %ulong_1
-OpStore %195 %218
-%219 = OpLoad %ulong %194
-OpStore %196 %219
-%220 = OpLoad %ulong %195
-OpStore %197 %220
-OpBranch %186
-%186 = OpLabel
-OpBranch %183
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_bool Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_bool Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_bool Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+OpStore %90 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%230 = OpLoad %ulong %90
+%231 = OpIAdd %ulong %ulong_18446744073709551600 %230
+OpStore %91 %231
+OpStore %116 %ulong_14695981039346656037
+%233 = OpLoad %ulong %91
+OpStore %117 %233
+OpStore %118 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%235 = OpLoad %ulong %118
+%237 = OpULessThan %bool %235 %ulong_32
+OpStore %93 %237
+%238 = OpLoad %bool %93
+OpLoopMerge %8 %87 None
+OpBranchConditional %238 %7 %8
+%8 = OpLabel
+%239 = OpLoad %ulong %116
+OpStore %115 %239
+%240 = OpLoad %ulong %90
+OpStore %119 %240
+OpStore %120 %ulong_0
+OpBranch %9
+%9 = OpLabel
+%241 = OpLoad %ulong %120
+%243 = OpULessThan %bool %241 %ulong_8
+OpStore %101 %243
+%244 = OpLoad %bool %101
+OpLoopMerge %11 %86 None
+OpBranchConditional %244 %10 %11
+%11 = OpLabel
+%245 = OpLoad %ulong %117
+%246 = OpISub %ulong %ulong_0 %245
+OpStore %106 %246
+OpBranch %24
+%24 = OpLabel
+%247 = OpLoad %ulong %115
+OpStore %146 %247
+OpStore %147 %ulong_0
+OpBranch %25
+%25 = OpLabel
+%248 = OpLoad %ulong %147
+%249 = OpULessThan %bool %248 %ulong_8
+OpStore %139 %249
+%250 = OpLoad %bool %139
+OpLoopMerge %27 %84 None
+OpBranchConditional %250 %26 %27
+%27 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%251 = OpLoad %ulong %106
+%252 = OpISub %ulong %ulong_0 %251
+OpStore %107 %252
+OpBranch %34
+%34 = OpLabel
+%253 = OpLoad %ulong %146
+OpStore %164 %253
+OpStore %165 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%254 = OpLoad %ulong %165
+%255 = OpULessThan %bool %254 %ulong_8
+OpStore %157 %255
+%256 = OpLoad %bool %157
+OpLoopMerge %37 %81 None
+OpBranchConditional %256 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%257 = OpLoad %ulong %90
+%258 = OpISub %ulong %ulong_0 %257
+OpStore %108 %258
+OpBranch %39
+%39 = OpLabel
+%259 = OpLoad %ulong %164
+OpStore %173 %259
+OpStore %174 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%260 = OpLoad %ulong %174
+%261 = OpULessThan %bool %260 %ulong_8
+OpStore %166 %261
+%262 = OpLoad %bool %166
+OpLoopMerge %42 %80 None
+OpBranchConditional %262 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+%264 = OpLoad %ulong %117
+%265 = OpIAdd %ulong %ulong_9223372036854775807 %264
+OpStore %109 %265
+OpBranch %44
+%44 = OpLabel
+%266 = OpLoad %ulong %173
+OpStore %182 %266
+OpStore %183 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%267 = OpLoad %ulong %183
+%268 = OpULessThan %bool %267 %ulong_8
+OpStore %175 %268
+%269 = OpLoad %bool %175
+OpLoopMerge %47 %79 None
+OpBranchConditional %269 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%271 = OpLoad %ulong %117
+%272 = OpISub %ulong %ulong_9223372036854775808 %271
+OpStore %110 %272
+OpBranch %49
+%49 = OpLabel
+%273 = OpLoad %ulong %182
+OpStore %191 %273
+OpStore %192 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%274 = OpLoad %ulong %192
+%275 = OpULessThan %bool %274 %ulong_8
+OpStore %184 %275
+%276 = OpLoad %bool %184
+OpLoopMerge %52 %78 None
+OpBranchConditional %276 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%278 = OpLoad %ulong %117
+%279 = OpIAdd %ulong %ulong_18446744073709551615 %278
+OpStore %111 %279
+OpBranch %54
+%54 = OpLabel
+%280 = OpLoad %ulong %191
+OpStore %200 %280
+OpStore %201 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%281 = OpLoad %ulong %201
+%282 = OpULessThan %bool %281 %ulong_8
+OpStore %193 %282
+%283 = OpLoad %bool %193
+OpLoopMerge %57 %77 None
+OpBranchConditional %283 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%284 = OpLoad %ulong %117
+%285 = OpLoad %ulong %119
+%286 = OpIAdd %ulong %284 %285
+OpStore %112 %286
+OpBranch %59
+%59 = OpLabel
+%287 = OpLoad %ulong %200
+OpStore %209 %287
+OpStore %210 %ulong_0
+OpBranch %60
+%60 = OpLabel
+%288 = OpLoad %ulong %210
+%289 = OpULessThan %bool %288 %ulong_8
+OpStore %202 %289
+%290 = OpLoad %bool %202
+OpLoopMerge %62 %76 None
+OpBranchConditional %290 %61 %62
+%62 = OpLabel
+OpBranch %63
+%63 = OpLabel
+%291 = OpLoad %ulong %117
+%292 = OpLoad %ulong %119
+%293 = OpISub %ulong %291 %292
+OpStore %113 %293
+OpBranch %64
+%64 = OpLabel
+%294 = OpLoad %ulong %209
+OpStore %218 %294
+OpStore %219 %ulong_0
+OpBranch %65
+%65 = OpLabel
+%295 = OpLoad %ulong %219
+%296 = OpULessThan %bool %295 %ulong_8
+OpStore %211 %296
+%297 = OpLoad %bool %211
+OpLoopMerge %67 %75 None
+OpBranchConditional %297 %66 %67
+%67 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%298 = OpLoad %ulong %119
+%299 = OpLoad %ulong %117
+%300 = OpISub %ulong %298 %299
+OpStore %114 %300
+OpBranch %69
+%69 = OpLabel
+%301 = OpLoad %ulong %218
+OpStore %227 %301
+OpStore %228 %ulong_0
+OpBranch %70
+%70 = OpLabel
+%302 = OpLoad %ulong %228
+%303 = OpULessThan %bool %302 %ulong_8
+OpStore %220 %303
+%304 = OpLoad %bool %220
+OpLoopMerge %72 %74 None
+OpBranchConditional %304 %71 %72
+%72 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%305 = OpLoad %ulong %227
+OpReturnValue %305
+%71 = OpLabel
+%306 = OpLoad %ulong %228
+%307 = OpIMul %ulong %306 %ulong_8
+OpStore %221 %307
+%308 = OpLoad %ulong %114
+%309 = OpLoad %ulong %221
+%310 = OpShiftRightLogical %ulong %308 %309
+OpStore %222 %310
+%311 = OpLoad %ulong %222
+%313 = OpBitwiseAnd %ulong %311 %ulong_255
+OpStore %223 %313
+%314 = OpLoad %ulong %227
+%315 = OpLoad %ulong %223
+%316 = OpBitwiseXor %ulong %314 %315
+OpStore %224 %316
+%317 = OpLoad %ulong %224
+%319 = OpIMul %ulong %317 %ulong_1099511628211
+OpStore %225 %319
+%320 = OpLoad %ulong %228
+%322 = OpIAdd %ulong %320 %ulong_1
+OpStore %226 %322
+%323 = OpLoad %ulong %225
+OpStore %227 %323
+%324 = OpLoad %ulong %226
+OpStore %228 %324
+OpBranch %74
+%66 = OpLabel
+%325 = OpLoad %ulong %219
+%326 = OpIMul %ulong %325 %ulong_8
+OpStore %212 %326
+%327 = OpLoad %ulong %113
+%328 = OpLoad %ulong %212
+%329 = OpShiftRightLogical %ulong %327 %328
+OpStore %213 %329
+%330 = OpLoad %ulong %213
+%331 = OpBitwiseAnd %ulong %330 %ulong_255
+OpStore %214 %331
+%332 = OpLoad %ulong %218
+%333 = OpLoad %ulong %214
+%334 = OpBitwiseXor %ulong %332 %333
+OpStore %215 %334
+%335 = OpLoad %ulong %215
+%336 = OpIMul %ulong %335 %ulong_1099511628211
+OpStore %216 %336
+%337 = OpLoad %ulong %219
+%338 = OpIAdd %ulong %337 %ulong_1
+OpStore %217 %338
+%339 = OpLoad %ulong %216
+OpStore %218 %339
+%340 = OpLoad %ulong %217
+OpStore %219 %340
+OpBranch %75
+%61 = OpLabel
+%341 = OpLoad %ulong %210
+%342 = OpIMul %ulong %341 %ulong_8
+OpStore %203 %342
+%343 = OpLoad %ulong %112
+%344 = OpLoad %ulong %203
+%345 = OpShiftRightLogical %ulong %343 %344
+OpStore %204 %345
+%346 = OpLoad %ulong %204
+%347 = OpBitwiseAnd %ulong %346 %ulong_255
+OpStore %205 %347
+%348 = OpLoad %ulong %209
+%349 = OpLoad %ulong %205
+%350 = OpBitwiseXor %ulong %348 %349
+OpStore %206 %350
+%351 = OpLoad %ulong %206
+%352 = OpIMul %ulong %351 %ulong_1099511628211
+OpStore %207 %352
+%353 = OpLoad %ulong %210
+%354 = OpIAdd %ulong %353 %ulong_1
+OpStore %208 %354
+%355 = OpLoad %ulong %207
+OpStore %209 %355
+%356 = OpLoad %ulong %208
+OpStore %210 %356
+OpBranch %76
+%56 = OpLabel
+%357 = OpLoad %ulong %201
+%358 = OpIMul %ulong %357 %ulong_8
+OpStore %194 %358
+%359 = OpLoad %ulong %111
+%360 = OpLoad %ulong %194
+%361 = OpShiftRightLogical %ulong %359 %360
+OpStore %195 %361
+%362 = OpLoad %ulong %195
+%363 = OpBitwiseAnd %ulong %362 %ulong_255
+OpStore %196 %363
+%364 = OpLoad %ulong %200
+%365 = OpLoad %ulong %196
+%366 = OpBitwiseXor %ulong %364 %365
+OpStore %197 %366
+%367 = OpLoad %ulong %197
+%368 = OpIMul %ulong %367 %ulong_1099511628211
+OpStore %198 %368
+%369 = OpLoad %ulong %201
+%370 = OpIAdd %ulong %369 %ulong_1
+OpStore %199 %370
+%371 = OpLoad %ulong %198
+OpStore %200 %371
+%372 = OpLoad %ulong %199
+OpStore %201 %372
+OpBranch %77
+%51 = OpLabel
+%373 = OpLoad %ulong %192
+%374 = OpIMul %ulong %373 %ulong_8
+OpStore %185 %374
+%375 = OpLoad %ulong %110
+%376 = OpLoad %ulong %185
+%377 = OpShiftRightLogical %ulong %375 %376
+OpStore %186 %377
+%378 = OpLoad %ulong %186
+%379 = OpBitwiseAnd %ulong %378 %ulong_255
+OpStore %187 %379
+%380 = OpLoad %ulong %191
+%381 = OpLoad %ulong %187
+%382 = OpBitwiseXor %ulong %380 %381
+OpStore %188 %382
+%383 = OpLoad %ulong %188
+%384 = OpIMul %ulong %383 %ulong_1099511628211
+OpStore %189 %384
+%385 = OpLoad %ulong %192
+%386 = OpIAdd %ulong %385 %ulong_1
+OpStore %190 %386
+%387 = OpLoad %ulong %189
+OpStore %191 %387
+%388 = OpLoad %ulong %190
+OpStore %192 %388
+OpBranch %78
+%46 = OpLabel
+%389 = OpLoad %ulong %183
+%390 = OpIMul %ulong %389 %ulong_8
+OpStore %176 %390
+%391 = OpLoad %ulong %109
+%392 = OpLoad %ulong %176
+%393 = OpShiftRightLogical %ulong %391 %392
+OpStore %177 %393
+%394 = OpLoad %ulong %177
+%395 = OpBitwiseAnd %ulong %394 %ulong_255
+OpStore %178 %395
+%396 = OpLoad %ulong %182
+%397 = OpLoad %ulong %178
+%398 = OpBitwiseXor %ulong %396 %397
+OpStore %179 %398
+%399 = OpLoad %ulong %179
+%400 = OpIMul %ulong %399 %ulong_1099511628211
+OpStore %180 %400
+%401 = OpLoad %ulong %183
+%402 = OpIAdd %ulong %401 %ulong_1
+OpStore %181 %402
+%403 = OpLoad %ulong %180
+OpStore %182 %403
+%404 = OpLoad %ulong %181
+OpStore %183 %404
+OpBranch %79
+%41 = OpLabel
+%405 = OpLoad %ulong %174
+%406 = OpIMul %ulong %405 %ulong_8
+OpStore %167 %406
+%407 = OpLoad %ulong %108
+%408 = OpLoad %ulong %167
+%409 = OpShiftRightLogical %ulong %407 %408
+OpStore %168 %409
+%410 = OpLoad %ulong %168
+%411 = OpBitwiseAnd %ulong %410 %ulong_255
+OpStore %169 %411
+%412 = OpLoad %ulong %173
+%413 = OpLoad %ulong %169
+%414 = OpBitwiseXor %ulong %412 %413
+OpStore %170 %414
+%415 = OpLoad %ulong %170
+%416 = OpIMul %ulong %415 %ulong_1099511628211
+OpStore %171 %416
+%417 = OpLoad %ulong %174
+%418 = OpIAdd %ulong %417 %ulong_1
+OpStore %172 %418
+%419 = OpLoad %ulong %171
+OpStore %173 %419
+%420 = OpLoad %ulong %172
+OpStore %174 %420
+OpBranch %80
+%36 = OpLabel
+%421 = OpLoad %ulong %165
+%422 = OpIMul %ulong %421 %ulong_8
+OpStore %158 %422
+%423 = OpLoad %ulong %107
+%424 = OpLoad %ulong %158
+%425 = OpShiftRightLogical %ulong %423 %424
+OpStore %159 %425
+%426 = OpLoad %ulong %159
+%427 = OpBitwiseAnd %ulong %426 %ulong_255
+OpStore %160 %427
+%428 = OpLoad %ulong %164
+%429 = OpLoad %ulong %160
+%430 = OpBitwiseXor %ulong %428 %429
+OpStore %161 %430
+%431 = OpLoad %ulong %161
+%432 = OpIMul %ulong %431 %ulong_1099511628211
+OpStore %162 %432
+%433 = OpLoad %ulong %165
+%434 = OpIAdd %ulong %433 %ulong_1
+OpStore %163 %434
+%435 = OpLoad %ulong %162
+OpStore %164 %435
+%436 = OpLoad %ulong %163
+OpStore %165 %436
+OpBranch %81
+%26 = OpLabel
+%437 = OpLoad %ulong %147
+%438 = OpIMul %ulong %437 %ulong_8
+OpStore %140 %438
+%439 = OpLoad %ulong %106
+%440 = OpLoad %ulong %140
+%441 = OpShiftRightLogical %ulong %439 %440
+OpStore %141 %441
+%442 = OpLoad %ulong %141
+%443 = OpBitwiseAnd %ulong %442 %ulong_255
+OpStore %142 %443
+%444 = OpLoad %ulong %146
+%445 = OpLoad %ulong %142
+%446 = OpBitwiseXor %ulong %444 %445
+OpStore %143 %446
+%447 = OpLoad %ulong %143
+%448 = OpIMul %ulong %447 %ulong_1099511628211
+OpStore %144 %448
+%449 = OpLoad %ulong %147
+%450 = OpIAdd %ulong %449 %ulong_1
+OpStore %145 %450
+%451 = OpLoad %ulong %144
+OpStore %146 %451
+%452 = OpLoad %ulong %145
+OpStore %147 %452
+OpBranch %84
+%10 = OpLabel
+%453 = OpLoad %ulong %120
+%455 = OpIMul %ulong %453 %ulong_1311768467294899695
+OpStore %102 %455
+%456 = OpLoad %ulong %102
+%457 = OpIAdd %ulong %456 %ulong_1
+OpStore %103 %457
+%458 = OpLoad %ulong %119
+%459 = OpLoad %ulong %103
+%460 = OpISub %ulong %458 %459
+OpStore %104 %460
+OpBranch %19
+%19 = OpLabel
+%461 = OpLoad %ulong %115
+OpStore %137 %461
+OpStore %138 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%462 = OpLoad %ulong %138
+%463 = OpULessThan %bool %462 %ulong_8
+OpStore %130 %463
+%464 = OpLoad %bool %130
+OpLoopMerge %22 %83 None
+OpBranchConditional %464 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%465 = OpLoad %ulong %120
+%466 = OpIAdd %ulong %465 %ulong_1
+OpStore %105 %466
+%467 = OpLoad %ulong %137
+OpStore %115 %467
+%468 = OpLoad %ulong %104
+OpStore %119 %468
+%469 = OpLoad %ulong %105
+OpStore %120 %469
+OpBranch %86
+%21 = OpLabel
+%470 = OpLoad %ulong %138
+%471 = OpIMul %ulong %470 %ulong_8
+OpStore %131 %471
+%472 = OpLoad %ulong %104
+%473 = OpLoad %ulong %131
+%474 = OpShiftRightLogical %ulong %472 %473
+OpStore %132 %474
+%475 = OpLoad %ulong %132
+%476 = OpBitwiseAnd %ulong %475 %ulong_255
+OpStore %133 %476
+%477 = OpLoad %ulong %137
+%478 = OpLoad %ulong %133
+%479 = OpBitwiseXor %ulong %477 %478
+OpStore %134 %479
+%480 = OpLoad %ulong %134
+%481 = OpIMul %ulong %480 %ulong_1099511628211
+OpStore %135 %481
+%482 = OpLoad %ulong %138
+%483 = OpIAdd %ulong %482 %ulong_1
+OpStore %136 %483
+%484 = OpLoad %ulong %135
+OpStore %137 %484
+%485 = OpLoad %ulong %136
+OpStore %138 %485
+OpBranch %83
+%7 = OpLabel
+%486 = OpLoad %ulong %118
+%488 = OpIMul %ulong %486 %ulong_7
+OpStore %94 %488
+%489 = OpLoad %ulong %94
+%490 = OpIAdd %ulong %489 %ulong_1
+OpStore %95 %490
+%491 = OpLoad %ulong %117
+%492 = OpLoad %ulong %95
+%493 = OpIAdd %ulong %491 %492
+OpStore %96 %493
+OpBranch %14
+%14 = OpLabel
+%494 = OpLoad %ulong %116
+OpStore %128 %494
+OpStore %129 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%495 = OpLoad %ulong %129
+%496 = OpULessThan %bool %495 %ulong_8
+OpStore %121 %496
+%497 = OpLoad %bool %121
+OpLoopMerge %17 %85 None
+OpBranchConditional %497 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%498 = OpLoad %ulong %118
+%500 = OpIMul %ulong %498 %ulong_3
+OpStore %97 %500
+%501 = OpLoad %ulong %97
+%503 = OpIAdd %ulong %501 %ulong_2
+OpStore %98 %503
+%504 = OpLoad %ulong %96
+%505 = OpLoad %ulong %98
+%506 = OpISub %ulong %504 %505
+OpStore %99 %506
+OpBranch %29
+%29 = OpLabel
+%507 = OpLoad %ulong %128
+OpStore %155 %507
+OpStore %156 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%508 = OpLoad %ulong %156
+%509 = OpULessThan %bool %508 %ulong_8
+OpStore %148 %509
+%510 = OpLoad %bool %148
+OpLoopMerge %32 %82 None
+OpBranchConditional %510 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%511 = OpLoad %ulong %118
+%512 = OpIAdd %ulong %511 %ulong_1
+OpStore %100 %512
+%513 = OpLoad %ulong %155
+OpStore %116 %513
+%514 = OpLoad %ulong %99
+OpStore %117 %514
+%515 = OpLoad %ulong %100
+OpStore %118 %515
+OpBranch %87
+%31 = OpLabel
+%516 = OpLoad %ulong %156
+%517 = OpIMul %ulong %516 %ulong_8
+OpStore %149 %517
+%518 = OpLoad %ulong %99
+%519 = OpLoad %ulong %149
+%520 = OpShiftRightLogical %ulong %518 %519
+OpStore %150 %520
+%521 = OpLoad %ulong %150
+%522 = OpBitwiseAnd %ulong %521 %ulong_255
+OpStore %151 %522
+%523 = OpLoad %ulong %155
+%524 = OpLoad %ulong %151
+%525 = OpBitwiseXor %ulong %523 %524
+OpStore %152 %525
+%526 = OpLoad %ulong %152
+%527 = OpIMul %ulong %526 %ulong_1099511628211
+OpStore %153 %527
+%528 = OpLoad %ulong %156
+%529 = OpIAdd %ulong %528 %ulong_1
+OpStore %154 %529
+%530 = OpLoad %ulong %153
+OpStore %155 %530
+%531 = OpLoad %ulong %154
+OpStore %156 %531
+OpBranch %82
+%16 = OpLabel
+%532 = OpLoad %ulong %129
+%533 = OpIMul %ulong %532 %ulong_8
+OpStore %122 %533
+%534 = OpLoad %ulong %96
+%535 = OpLoad %ulong %122
+%536 = OpShiftRightLogical %ulong %534 %535
+OpStore %123 %536
+%537 = OpLoad %ulong %123
+%538 = OpBitwiseAnd %ulong %537 %ulong_255
+OpStore %124 %538
+%539 = OpLoad %ulong %128
+%540 = OpLoad %ulong %124
+%541 = OpBitwiseXor %ulong %539 %540
+OpStore %125 %541
+%542 = OpLoad %ulong %125
+%543 = OpIMul %ulong %542 %ulong_1099511628211
+OpStore %126 %543
+%544 = OpLoad %ulong %129
+%545 = OpIAdd %ulong %544 %ulong_1
+OpStore %127 %545
+%546 = OpLoad %ulong %126
+OpStore %128 %546
+%547 = OpLoad %ulong %127
+OpStore %129 %547
+OpBranch %85
+%74 = OpLabel
+OpBranch %70
+%75 = OpLabel
+OpBranch %65
+%76 = OpLabel
+OpBranch %60
+%77 = OpLabel
+OpBranch %55
+%78 = OpLabel
+OpBranch %50
+%79 = OpLabel
+OpBranch %45
+%80 = OpLabel
+OpBranch %40
+%81 = OpLabel
+OpBranch %35
+%82 = OpLabel
+OpBranch %30
+%83 = OpLabel
+OpBranch %20
+%84 = OpLabel
+OpBranch %25
+%85 = OpLabel
+OpBranch %15
+%86 = OpLabel
+OpBranch %9
+%87 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/arith_u8.dis
+++ b/test/golden/spirv/scalar/arith_u8.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 234
+; Bound: 616
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -10,322 +10,920 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.arith_u8.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uchar = OpTypeInt 8 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uchar = OpTypeInt 8 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uchar_240 = OpConstant %uchar 240
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uchar_0 = OpConstant %uchar 0
 %uchar_32 = OpConstant %uchar 32
 %uchar_8 = OpConstant %uchar 8
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uchar_127 = OpConstant %uchar 127
 %uchar_128 = OpConstant %uchar 128
 %uchar_255 = OpConstant %uchar 255
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %uchar_181 = OpConstant %uchar 181
 %uchar_1 = OpConstant %uchar 1
 %uchar_7 = OpConstant %uchar 7
 %uchar_3 = OpConstant %uchar 3
 %uchar_2 = OpConstant %uchar 2
-%181 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%184 = OpTypeFunction %ulong %ulong %uchar
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uchar Function
-%23 = OpVariable %_ptr_Function_uchar Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%27 = OpVariable %_ptr_Function_uchar Function
-%28 = OpVariable %_ptr_Function_uchar Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uchar Function
-%31 = OpVariable %_ptr_Function_uchar Function
-%32 = OpVariable %_ptr_Function_uchar Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_bool Function
-%36 = OpVariable %_ptr_Function_uchar Function
-%37 = OpVariable %_ptr_Function_uchar Function
-%38 = OpVariable %_ptr_Function_uchar Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uchar Function
-%41 = OpVariable %_ptr_Function_uchar Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uchar Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uchar Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uchar Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uchar Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uchar Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uchar Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uchar Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uchar Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_uchar Function
-%62 = OpVariable %_ptr_Function_uchar Function
-%63 = OpVariable %_ptr_Function_uchar Function
-%64 = OpVariable %_ptr_Function_uchar Function
-OpStore %19 %6
-%65 = OpFunctionCall %ulong %2
-OpStore %20 %65
-%66 = OpLoad %ulong %19
-%67 = OpUConvert %uchar %66
-OpStore %22 %67
-%69 = OpLoad %uchar %22
-%70 = OpIAdd %uchar %uchar_240 %69
-OpStore %23 %70
-%71 = OpLoad %ulong %20
-OpStore %60 %71
-%72 = OpLoad %uchar %23
-OpStore %61 %72
-OpStore %62 %uchar_0
-OpBranch %8
-%8 = OpLabel
-%74 = OpLoad %uchar %62
-%76 = OpULessThan %bool %74 %uchar_32
-OpStore %25 %76
-%77 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %77 %9 %10
-%10 = OpLabel
-%78 = OpLoad %ulong %60
-OpStore %59 %78
-%79 = OpLoad %uchar %22
-OpStore %63 %79
-OpStore %64 %uchar_0
-OpBranch %11
-%11 = OpLabel
-%80 = OpLoad %uchar %64
-%82 = OpULessThan %bool %80 %uchar_8
-OpStore %35 %82
-%83 = OpLoad %bool %35
-OpLoopMerge %13 %14 None
-OpBranchConditional %83 %12 %13
-%13 = OpLabel
-%84 = OpLoad %uchar %61
-%85 = OpISub %uchar %uchar_0 %84
-OpStore %41 %85
-%86 = OpLoad %ulong %59
-%87 = OpLoad %uchar %41
-%88 = OpFunctionCall %ulong %3 %86 %87
-OpStore %42 %88
-%89 = OpLoad %uchar %41
-%90 = OpISub %uchar %uchar_0 %89
-OpStore %43 %90
-%91 = OpLoad %ulong %42
-%92 = OpLoad %uchar %43
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %44 %93
-%94 = OpLoad %uchar %22
-%95 = OpISub %uchar %uchar_0 %94
-OpStore %45 %95
-%96 = OpLoad %ulong %44
-%97 = OpLoad %uchar %45
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %46 %98
-%100 = OpLoad %uchar %61
-%101 = OpIAdd %uchar %uchar_127 %100
-OpStore %47 %101
-%102 = OpLoad %ulong %46
-%103 = OpLoad %uchar %47
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %48 %104
-%106 = OpLoad %uchar %61
-%107 = OpISub %uchar %uchar_128 %106
-OpStore %49 %107
-%108 = OpLoad %ulong %48
-%109 = OpLoad %uchar %49
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %50 %110
-%112 = OpLoad %uchar %61
-%113 = OpIAdd %uchar %uchar_255 %112
-OpStore %51 %113
-%114 = OpLoad %ulong %50
-%115 = OpLoad %uchar %51
-%116 = OpFunctionCall %ulong %3 %114 %115
-OpStore %52 %116
-%117 = OpLoad %uchar %61
-%118 = OpLoad %uchar %63
-%119 = OpIAdd %uchar %117 %118
-OpStore %53 %119
-%120 = OpLoad %ulong %52
-%121 = OpLoad %uchar %53
-%122 = OpFunctionCall %ulong %3 %120 %121
-OpStore %54 %122
-%123 = OpLoad %uchar %61
-%124 = OpLoad %uchar %63
-%125 = OpISub %uchar %123 %124
-OpStore %55 %125
-%126 = OpLoad %ulong %54
-%127 = OpLoad %uchar %55
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %56 %128
-%129 = OpLoad %uchar %63
-%130 = OpLoad %uchar %61
-%131 = OpISub %uchar %129 %130
-OpStore %57 %131
-%132 = OpLoad %ulong %56
-%133 = OpLoad %uchar %57
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %58 %134
-%135 = OpLoad %ulong %58
-OpReturnValue %135
-%12 = OpLabel
-%136 = OpLoad %uchar %64
-%138 = OpIMul %uchar %136 %uchar_181
-OpStore %36 %138
-%139 = OpLoad %uchar %36
-%141 = OpIAdd %uchar %139 %uchar_1
-OpStore %37 %141
-%142 = OpLoad %uchar %63
-%143 = OpLoad %uchar %37
-%144 = OpISub %uchar %142 %143
-OpStore %38 %144
-%145 = OpLoad %ulong %59
-%146 = OpLoad %uchar %38
-%147 = OpFunctionCall %ulong %3 %145 %146
-OpStore %39 %147
-%148 = OpLoad %uchar %64
-%149 = OpIAdd %uchar %148 %uchar_1
-OpStore %40 %149
-%150 = OpLoad %ulong %39
-OpStore %59 %150
-%151 = OpLoad %uchar %38
-OpStore %63 %151
-%152 = OpLoad %uchar %40
-OpStore %64 %152
-OpBranch %14
-%9 = OpLabel
-%153 = OpLoad %uchar %62
-%155 = OpIMul %uchar %153 %uchar_7
-OpStore %26 %155
-%156 = OpLoad %uchar %26
-%157 = OpIAdd %uchar %156 %uchar_1
-OpStore %27 %157
-%158 = OpLoad %uchar %61
-%159 = OpLoad %uchar %27
-%160 = OpIAdd %uchar %158 %159
-OpStore %28 %160
-%161 = OpLoad %ulong %60
-%162 = OpLoad %uchar %28
-%163 = OpFunctionCall %ulong %3 %161 %162
-OpStore %29 %163
-%164 = OpLoad %uchar %62
-%166 = OpIMul %uchar %164 %uchar_3
-OpStore %30 %166
-%167 = OpLoad %uchar %30
-%169 = OpIAdd %uchar %167 %uchar_2
-OpStore %31 %169
-%170 = OpLoad %uchar %28
-%171 = OpLoad %uchar %31
-%172 = OpISub %uchar %170 %171
-OpStore %32 %172
-%173 = OpLoad %ulong %29
-%174 = OpLoad %uchar %32
-%175 = OpFunctionCall %ulong %3 %173 %174
-OpStore %33 %175
-%176 = OpLoad %uchar %62
-%177 = OpIAdd %uchar %176 %uchar_1
-OpStore %34 %177
-%178 = OpLoad %ulong %33
-OpStore %60 %178
-%179 = OpLoad %uchar %32
-OpStore %61 %179
-%180 = OpLoad %uchar %34
-OpStore %62 %180
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %181
-%182 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %184
-%185 = OpFunctionParameter %ulong
-%186 = OpFunctionParameter %uchar
-%187 = OpLabel
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_uchar Function
+%118 = OpVariable %_ptr_Function_uchar Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_uchar Function
+%122 = OpVariable %_ptr_Function_uchar Function
+%123 = OpVariable %_ptr_Function_uchar Function
+%124 = OpVariable %_ptr_Function_uchar Function
+%125 = OpVariable %_ptr_Function_uchar Function
+%126 = OpVariable %_ptr_Function_uchar Function
+%127 = OpVariable %_ptr_Function_uchar Function
+%128 = OpVariable %_ptr_Function_bool Function
+%129 = OpVariable %_ptr_Function_uchar Function
+%130 = OpVariable %_ptr_Function_uchar Function
+%131 = OpVariable %_ptr_Function_uchar Function
+%132 = OpVariable %_ptr_Function_uchar Function
+%133 = OpVariable %_ptr_Function_uchar Function
+%134 = OpVariable %_ptr_Function_uchar Function
+%135 = OpVariable %_ptr_Function_uchar Function
+%136 = OpVariable %_ptr_Function_uchar Function
+%137 = OpVariable %_ptr_Function_uchar Function
+%138 = OpVariable %_ptr_Function_uchar Function
+%139 = OpVariable %_ptr_Function_uchar Function
+%140 = OpVariable %_ptr_Function_uchar Function
+%141 = OpVariable %_ptr_Function_uchar Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_uchar Function
+%145 = OpVariable %_ptr_Function_uchar Function
+%146 = OpVariable %_ptr_Function_uchar Function
+%147 = OpVariable %_ptr_Function_uchar Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_bool Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_uchar Function
+%195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
 %200 = OpVariable %_ptr_Function_ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
-OpStore %194 %185
-OpStore %195 %186
-%206 = OpLoad %uchar %195
-%207 = OpUConvert %ulong %206
-OpStore %196 %207
-OpBranch %188
-%188 = OpLabel
-%208 = OpLoad %ulong %194
-OpStore %204 %208
-OpStore %205 %ulong_0
-OpBranch %189
-%189 = OpLabel
-%210 = OpLoad %ulong %205
-%212 = OpULessThan %bool %210 %ulong_8
-OpStore %197 %212
-%213 = OpLoad %bool %197
-OpLoopMerge %191 %193 None
-OpBranchConditional %213 %190 %191
-%191 = OpLabel
-OpBranch %192
-%192 = OpLabel
-%214 = OpLoad %ulong %204
-OpReturnValue %214
-%190 = OpLabel
-%215 = OpLoad %ulong %205
-%216 = OpIMul %ulong %215 %ulong_8
-OpStore %198 %216
-%217 = OpLoad %ulong %196
-%218 = OpLoad %ulong %198
-%219 = OpShiftRightLogical %ulong %217 %218
-OpStore %199 %219
-%220 = OpLoad %ulong %199
-%222 = OpBitwiseAnd %ulong %220 %ulong_255
-OpStore %200 %222
-%223 = OpLoad %ulong %204
-%224 = OpLoad %ulong %200
-%225 = OpBitwiseXor %ulong %223 %224
-OpStore %201 %225
-%226 = OpLoad %ulong %201
-%228 = OpIMul %ulong %226 %ulong_1099511628211
-OpStore %202 %228
-%229 = OpLoad %ulong %205
-%231 = OpIAdd %ulong %229 %ulong_1
-OpStore %203 %231
-%232 = OpLoad %ulong %202
-OpStore %204 %232
-%233 = OpLoad %ulong %203
-OpStore %205 %233
-OpBranch %193
-%193 = OpLabel
-OpBranch %189
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%268 = OpLoad %ulong %115
+%269 = OpUConvert %uchar %268
+OpStore %117 %269
+%271 = OpLoad %uchar %117
+%272 = OpIAdd %uchar %uchar_240 %271
+OpStore %118 %272
+OpStore %143 %ulong_14695981039346656037
+%274 = OpLoad %uchar %118
+OpStore %144 %274
+OpStore %145 %uchar_0
+OpBranch %6
+%6 = OpLabel
+%276 = OpLoad %uchar %145
+%278 = OpULessThan %bool %276 %uchar_32
+OpStore %120 %278
+%279 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %279 %7 %8
+%8 = OpLabel
+%280 = OpLoad %ulong %143
+OpStore %142 %280
+%281 = OpLoad %uchar %117
+OpStore %146 %281
+OpStore %147 %uchar_0
+OpBranch %9
+%9 = OpLabel
+%282 = OpLoad %uchar %147
+%284 = OpULessThan %bool %282 %uchar_8
+OpStore %128 %284
+%285 = OpLoad %bool %128
+OpLoopMerge %11 %110 None
+OpBranchConditional %285 %10 %11
+%11 = OpLabel
+%286 = OpLoad %uchar %144
+%287 = OpISub %uchar %uchar_0 %286
+OpStore %133 %287
+OpBranch %18
+%18 = OpLabel
+%288 = OpLoad %uchar %133
+%289 = OpUConvert %ulong %288
+OpStore %150 %289
+OpBranch %32
+%32 = OpLabel
+%290 = OpLoad %ulong %142
+OpStore %177 %290
+OpStore %178 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%292 = OpLoad %ulong %178
+%294 = OpULessThan %bool %292 %ulong_8
+OpStore %170 %294
+%295 = OpLoad %bool %170
+OpLoopMerge %35 %108 None
+OpBranchConditional %295 %34 %35
+%35 = OpLabel
+OpBranch %36
+%36 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%296 = OpLoad %uchar %133
+%297 = OpISub %uchar %uchar_0 %296
+OpStore %134 %297
+OpBranch %37
+%37 = OpLabel
+%298 = OpLoad %uchar %134
+%299 = OpUConvert %ulong %298
+OpStore %179 %299
+OpBranch %44
+%44 = OpLabel
+%300 = OpLoad %ulong %177
+OpStore %196 %300
+OpStore %197 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%301 = OpLoad %ulong %197
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %189 %302
+%303 = OpLoad %bool %189
+OpLoopMerge %47 %105 None
+OpBranchConditional %303 %46 %47
+%47 = OpLabel
+OpBranch %48
+%48 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%304 = OpLoad %uchar %117
+%305 = OpISub %uchar %uchar_0 %304
+OpStore %135 %305
+OpBranch %49
+%49 = OpLabel
+%306 = OpLoad %uchar %135
+%307 = OpUConvert %ulong %306
+OpStore %198 %307
+OpBranch %51
+%51 = OpLabel
+%308 = OpLoad %ulong %196
+OpStore %206 %308
+OpStore %207 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%309 = OpLoad %ulong %207
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %199 %310
+%311 = OpLoad %bool %199
+OpLoopMerge %54 %104 None
+OpBranchConditional %311 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%313 = OpLoad %uchar %144
+%314 = OpIAdd %uchar %uchar_127 %313
+OpStore %136 %314
+OpBranch %56
+%56 = OpLabel
+%315 = OpLoad %uchar %136
+%316 = OpUConvert %ulong %315
+OpStore %208 %316
+OpBranch %58
+%58 = OpLabel
+%317 = OpLoad %ulong %206
+OpStore %216 %317
+OpStore %217 %ulong_0
+OpBranch %59
+%59 = OpLabel
+%318 = OpLoad %ulong %217
+%319 = OpULessThan %bool %318 %ulong_8
+OpStore %209 %319
+%320 = OpLoad %bool %209
+OpLoopMerge %61 %103 None
+OpBranchConditional %320 %60 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpBranch %57
+%57 = OpLabel
+%322 = OpLoad %uchar %144
+%323 = OpISub %uchar %uchar_128 %322
+OpStore %137 %323
+OpBranch %63
+%63 = OpLabel
+%324 = OpLoad %uchar %137
+%325 = OpUConvert %ulong %324
+OpStore %218 %325
+OpBranch %65
+%65 = OpLabel
+%326 = OpLoad %ulong %216
+OpStore %226 %326
+OpStore %227 %ulong_0
+OpBranch %66
+%66 = OpLabel
+%327 = OpLoad %ulong %227
+%328 = OpULessThan %bool %327 %ulong_8
+OpStore %219 %328
+%329 = OpLoad %bool %219
+OpLoopMerge %68 %102 None
+OpBranchConditional %329 %67 %68
+%68 = OpLabel
+OpBranch %69
+%69 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%331 = OpLoad %uchar %144
+%332 = OpIAdd %uchar %uchar_255 %331
+OpStore %138 %332
+OpBranch %70
+%70 = OpLabel
+%333 = OpLoad %uchar %138
+%334 = OpUConvert %ulong %333
+OpStore %228 %334
+OpBranch %72
+%72 = OpLabel
+%335 = OpLoad %ulong %226
+OpStore %236 %335
+OpStore %237 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%336 = OpLoad %ulong %237
+%337 = OpULessThan %bool %336 %ulong_8
+OpStore %229 %337
+%338 = OpLoad %bool %229
+OpLoopMerge %75 %101 None
+OpBranchConditional %338 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%339 = OpLoad %uchar %144
+%340 = OpLoad %uchar %146
+%341 = OpIAdd %uchar %339 %340
+OpStore %139 %341
+OpBranch %77
+%77 = OpLabel
+%342 = OpLoad %uchar %139
+%343 = OpUConvert %ulong %342
+OpStore %238 %343
+OpBranch %79
+%79 = OpLabel
+%344 = OpLoad %ulong %236
+OpStore %246 %344
+OpStore %247 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%345 = OpLoad %ulong %247
+%346 = OpULessThan %bool %345 %ulong_8
+OpStore %239 %346
+%347 = OpLoad %bool %239
+OpLoopMerge %82 %100 None
+OpBranchConditional %347 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+%348 = OpLoad %uchar %144
+%349 = OpLoad %uchar %146
+%350 = OpISub %uchar %348 %349
+OpStore %140 %350
+OpBranch %84
+%84 = OpLabel
+%351 = OpLoad %uchar %140
+%352 = OpUConvert %ulong %351
+OpStore %248 %352
+OpBranch %86
+%86 = OpLabel
+%353 = OpLoad %ulong %246
+OpStore %256 %353
+OpStore %257 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%354 = OpLoad %ulong %257
+%355 = OpULessThan %bool %354 %ulong_8
+OpStore %249 %355
+%356 = OpLoad %bool %249
+OpLoopMerge %89 %99 None
+OpBranchConditional %356 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%357 = OpLoad %uchar %146
+%358 = OpLoad %uchar %144
+%359 = OpISub %uchar %357 %358
+OpStore %141 %359
+OpBranch %91
+%91 = OpLabel
+%360 = OpLoad %uchar %141
+%361 = OpUConvert %ulong %360
+OpStore %258 %361
+OpBranch %93
+%93 = OpLabel
+%362 = OpLoad %ulong %256
+OpStore %266 %362
+OpStore %267 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%363 = OpLoad %ulong %267
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %259 %364
+%365 = OpLoad %bool %259
+OpLoopMerge %96 %98 None
+OpBranchConditional %365 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%366 = OpLoad %ulong %266
+OpReturnValue %366
+%95 = OpLabel
+%367 = OpLoad %ulong %267
+%368 = OpIMul %ulong %367 %ulong_8
+OpStore %260 %368
+%369 = OpLoad %ulong %258
+%370 = OpLoad %ulong %260
+%371 = OpShiftRightLogical %ulong %369 %370
+OpStore %261 %371
+%372 = OpLoad %ulong %261
+%374 = OpBitwiseAnd %ulong %372 %ulong_255
+OpStore %262 %374
+%375 = OpLoad %ulong %266
+%376 = OpLoad %ulong %262
+%377 = OpBitwiseXor %ulong %375 %376
+OpStore %263 %377
+%378 = OpLoad %ulong %263
+%380 = OpIMul %ulong %378 %ulong_1099511628211
+OpStore %264 %380
+%381 = OpLoad %ulong %267
+%383 = OpIAdd %ulong %381 %ulong_1
+OpStore %265 %383
+%384 = OpLoad %ulong %264
+OpStore %266 %384
+%385 = OpLoad %ulong %265
+OpStore %267 %385
+OpBranch %98
+%88 = OpLabel
+%386 = OpLoad %ulong %257
+%387 = OpIMul %ulong %386 %ulong_8
+OpStore %250 %387
+%388 = OpLoad %ulong %248
+%389 = OpLoad %ulong %250
+%390 = OpShiftRightLogical %ulong %388 %389
+OpStore %251 %390
+%391 = OpLoad %ulong %251
+%392 = OpBitwiseAnd %ulong %391 %ulong_255
+OpStore %252 %392
+%393 = OpLoad %ulong %256
+%394 = OpLoad %ulong %252
+%395 = OpBitwiseXor %ulong %393 %394
+OpStore %253 %395
+%396 = OpLoad %ulong %253
+%397 = OpIMul %ulong %396 %ulong_1099511628211
+OpStore %254 %397
+%398 = OpLoad %ulong %257
+%399 = OpIAdd %ulong %398 %ulong_1
+OpStore %255 %399
+%400 = OpLoad %ulong %254
+OpStore %256 %400
+%401 = OpLoad %ulong %255
+OpStore %257 %401
+OpBranch %99
+%81 = OpLabel
+%402 = OpLoad %ulong %247
+%403 = OpIMul %ulong %402 %ulong_8
+OpStore %240 %403
+%404 = OpLoad %ulong %238
+%405 = OpLoad %ulong %240
+%406 = OpShiftRightLogical %ulong %404 %405
+OpStore %241 %406
+%407 = OpLoad %ulong %241
+%408 = OpBitwiseAnd %ulong %407 %ulong_255
+OpStore %242 %408
+%409 = OpLoad %ulong %246
+%410 = OpLoad %ulong %242
+%411 = OpBitwiseXor %ulong %409 %410
+OpStore %243 %411
+%412 = OpLoad %ulong %243
+%413 = OpIMul %ulong %412 %ulong_1099511628211
+OpStore %244 %413
+%414 = OpLoad %ulong %247
+%415 = OpIAdd %ulong %414 %ulong_1
+OpStore %245 %415
+%416 = OpLoad %ulong %244
+OpStore %246 %416
+%417 = OpLoad %ulong %245
+OpStore %247 %417
+OpBranch %100
+%74 = OpLabel
+%418 = OpLoad %ulong %237
+%419 = OpIMul %ulong %418 %ulong_8
+OpStore %230 %419
+%420 = OpLoad %ulong %228
+%421 = OpLoad %ulong %230
+%422 = OpShiftRightLogical %ulong %420 %421
+OpStore %231 %422
+%423 = OpLoad %ulong %231
+%424 = OpBitwiseAnd %ulong %423 %ulong_255
+OpStore %232 %424
+%425 = OpLoad %ulong %236
+%426 = OpLoad %ulong %232
+%427 = OpBitwiseXor %ulong %425 %426
+OpStore %233 %427
+%428 = OpLoad %ulong %233
+%429 = OpIMul %ulong %428 %ulong_1099511628211
+OpStore %234 %429
+%430 = OpLoad %ulong %237
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %235 %431
+%432 = OpLoad %ulong %234
+OpStore %236 %432
+%433 = OpLoad %ulong %235
+OpStore %237 %433
+OpBranch %101
+%67 = OpLabel
+%434 = OpLoad %ulong %227
+%435 = OpIMul %ulong %434 %ulong_8
+OpStore %220 %435
+%436 = OpLoad %ulong %218
+%437 = OpLoad %ulong %220
+%438 = OpShiftRightLogical %ulong %436 %437
+OpStore %221 %438
+%439 = OpLoad %ulong %221
+%440 = OpBitwiseAnd %ulong %439 %ulong_255
+OpStore %222 %440
+%441 = OpLoad %ulong %226
+%442 = OpLoad %ulong %222
+%443 = OpBitwiseXor %ulong %441 %442
+OpStore %223 %443
+%444 = OpLoad %ulong %223
+%445 = OpIMul %ulong %444 %ulong_1099511628211
+OpStore %224 %445
+%446 = OpLoad %ulong %227
+%447 = OpIAdd %ulong %446 %ulong_1
+OpStore %225 %447
+%448 = OpLoad %ulong %224
+OpStore %226 %448
+%449 = OpLoad %ulong %225
+OpStore %227 %449
+OpBranch %102
+%60 = OpLabel
+%450 = OpLoad %ulong %217
+%451 = OpIMul %ulong %450 %ulong_8
+OpStore %210 %451
+%452 = OpLoad %ulong %208
+%453 = OpLoad %ulong %210
+%454 = OpShiftRightLogical %ulong %452 %453
+OpStore %211 %454
+%455 = OpLoad %ulong %211
+%456 = OpBitwiseAnd %ulong %455 %ulong_255
+OpStore %212 %456
+%457 = OpLoad %ulong %216
+%458 = OpLoad %ulong %212
+%459 = OpBitwiseXor %ulong %457 %458
+OpStore %213 %459
+%460 = OpLoad %ulong %213
+%461 = OpIMul %ulong %460 %ulong_1099511628211
+OpStore %214 %461
+%462 = OpLoad %ulong %217
+%463 = OpIAdd %ulong %462 %ulong_1
+OpStore %215 %463
+%464 = OpLoad %ulong %214
+OpStore %216 %464
+%465 = OpLoad %ulong %215
+OpStore %217 %465
+OpBranch %103
+%53 = OpLabel
+%466 = OpLoad %ulong %207
+%467 = OpIMul %ulong %466 %ulong_8
+OpStore %200 %467
+%468 = OpLoad %ulong %198
+%469 = OpLoad %ulong %200
+%470 = OpShiftRightLogical %ulong %468 %469
+OpStore %201 %470
+%471 = OpLoad %ulong %201
+%472 = OpBitwiseAnd %ulong %471 %ulong_255
+OpStore %202 %472
+%473 = OpLoad %ulong %206
+%474 = OpLoad %ulong %202
+%475 = OpBitwiseXor %ulong %473 %474
+OpStore %203 %475
+%476 = OpLoad %ulong %203
+%477 = OpIMul %ulong %476 %ulong_1099511628211
+OpStore %204 %477
+%478 = OpLoad %ulong %207
+%479 = OpIAdd %ulong %478 %ulong_1
+OpStore %205 %479
+%480 = OpLoad %ulong %204
+OpStore %206 %480
+%481 = OpLoad %ulong %205
+OpStore %207 %481
+OpBranch %104
+%46 = OpLabel
+%482 = OpLoad %ulong %197
+%483 = OpIMul %ulong %482 %ulong_8
+OpStore %190 %483
+%484 = OpLoad %ulong %179
+%485 = OpLoad %ulong %190
+%486 = OpShiftRightLogical %ulong %484 %485
+OpStore %191 %486
+%487 = OpLoad %ulong %191
+%488 = OpBitwiseAnd %ulong %487 %ulong_255
+OpStore %192 %488
+%489 = OpLoad %ulong %196
+%490 = OpLoad %ulong %192
+%491 = OpBitwiseXor %ulong %489 %490
+OpStore %193 %491
+%492 = OpLoad %ulong %193
+%493 = OpIMul %ulong %492 %ulong_1099511628211
+OpStore %194 %493
+%494 = OpLoad %ulong %197
+%495 = OpIAdd %ulong %494 %ulong_1
+OpStore %195 %495
+%496 = OpLoad %ulong %194
+OpStore %196 %496
+%497 = OpLoad %ulong %195
+OpStore %197 %497
+OpBranch %105
+%34 = OpLabel
+%498 = OpLoad %ulong %178
+%499 = OpIMul %ulong %498 %ulong_8
+OpStore %171 %499
+%500 = OpLoad %ulong %150
+%501 = OpLoad %ulong %171
+%502 = OpShiftRightLogical %ulong %500 %501
+OpStore %172 %502
+%503 = OpLoad %ulong %172
+%504 = OpBitwiseAnd %ulong %503 %ulong_255
+OpStore %173 %504
+%505 = OpLoad %ulong %177
+%506 = OpLoad %ulong %173
+%507 = OpBitwiseXor %ulong %505 %506
+OpStore %174 %507
+%508 = OpLoad %ulong %174
+%509 = OpIMul %ulong %508 %ulong_1099511628211
+OpStore %175 %509
+%510 = OpLoad %ulong %178
+%511 = OpIAdd %ulong %510 %ulong_1
+OpStore %176 %511
+%512 = OpLoad %ulong %175
+OpStore %177 %512
+%513 = OpLoad %ulong %176
+OpStore %178 %513
+OpBranch %108
+%10 = OpLabel
+%514 = OpLoad %uchar %147
+%516 = OpIMul %uchar %514 %uchar_181
+OpStore %129 %516
+%517 = OpLoad %uchar %129
+%519 = OpIAdd %uchar %517 %uchar_1
+OpStore %130 %519
+%520 = OpLoad %uchar %146
+%521 = OpLoad %uchar %130
+%522 = OpISub %uchar %520 %521
+OpStore %131 %522
+OpBranch %16
+%16 = OpLabel
+%523 = OpLoad %uchar %131
+%524 = OpUConvert %ulong %523
+OpStore %149 %524
+OpBranch %27
+%27 = OpLabel
+%525 = OpLoad %ulong %142
+OpStore %168 %525
+OpStore %169 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%526 = OpLoad %ulong %169
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %161 %527
+%528 = OpLoad %bool %161
+OpLoopMerge %30 %107 None
+OpBranchConditional %528 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%529 = OpLoad %uchar %147
+%530 = OpIAdd %uchar %529 %uchar_1
+OpStore %132 %530
+%531 = OpLoad %ulong %168
+OpStore %142 %531
+%532 = OpLoad %uchar %131
+OpStore %146 %532
+%533 = OpLoad %uchar %132
+OpStore %147 %533
+OpBranch %110
+%29 = OpLabel
+%534 = OpLoad %ulong %169
+%535 = OpIMul %ulong %534 %ulong_8
+OpStore %162 %535
+%536 = OpLoad %ulong %149
+%537 = OpLoad %ulong %162
+%538 = OpShiftRightLogical %ulong %536 %537
+OpStore %163 %538
+%539 = OpLoad %ulong %163
+%540 = OpBitwiseAnd %ulong %539 %ulong_255
+OpStore %164 %540
+%541 = OpLoad %ulong %168
+%542 = OpLoad %ulong %164
+%543 = OpBitwiseXor %ulong %541 %542
+OpStore %165 %543
+%544 = OpLoad %ulong %165
+%545 = OpIMul %ulong %544 %ulong_1099511628211
+OpStore %166 %545
+%546 = OpLoad %ulong %169
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %167 %547
+%548 = OpLoad %ulong %166
+OpStore %168 %548
+%549 = OpLoad %ulong %167
+OpStore %169 %549
+OpBranch %107
+%7 = OpLabel
+%550 = OpLoad %uchar %145
+%552 = OpIMul %uchar %550 %uchar_7
+OpStore %121 %552
+%553 = OpLoad %uchar %121
+%554 = OpIAdd %uchar %553 %uchar_1
+OpStore %122 %554
+%555 = OpLoad %uchar %144
+%556 = OpLoad %uchar %122
+%557 = OpIAdd %uchar %555 %556
+OpStore %123 %557
+OpBranch %14
+%14 = OpLabel
+%558 = OpLoad %uchar %123
+%559 = OpUConvert %ulong %558
+OpStore %148 %559
+OpBranch %20
+%20 = OpLabel
+%560 = OpLoad %ulong %143
+OpStore %158 %560
+OpStore %159 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%561 = OpLoad %ulong %159
+%562 = OpULessThan %bool %561 %ulong_8
+OpStore %151 %562
+%563 = OpLoad %bool %151
+OpLoopMerge %23 %109 None
+OpBranchConditional %563 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%564 = OpLoad %uchar %145
+%566 = OpIMul %uchar %564 %uchar_3
+OpStore %124 %566
+%567 = OpLoad %uchar %124
+%569 = OpIAdd %uchar %567 %uchar_2
+OpStore %125 %569
+%570 = OpLoad %uchar %123
+%571 = OpLoad %uchar %125
+%572 = OpISub %uchar %570 %571
+OpStore %126 %572
+OpBranch %25
+%25 = OpLabel
+%573 = OpLoad %uchar %126
+%574 = OpUConvert %ulong %573
+OpStore %160 %574
+OpBranch %39
+%39 = OpLabel
+%575 = OpLoad %ulong %158
+OpStore %187 %575
+OpStore %188 %ulong_0
+OpBranch %40
+%40 = OpLabel
+%576 = OpLoad %ulong %188
+%577 = OpULessThan %bool %576 %ulong_8
+OpStore %180 %577
+%578 = OpLoad %bool %180
+OpLoopMerge %42 %106 None
+OpBranchConditional %578 %41 %42
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%579 = OpLoad %uchar %145
+%580 = OpIAdd %uchar %579 %uchar_1
+OpStore %127 %580
+%581 = OpLoad %ulong %187
+OpStore %143 %581
+%582 = OpLoad %uchar %126
+OpStore %144 %582
+%583 = OpLoad %uchar %127
+OpStore %145 %583
+OpBranch %111
+%41 = OpLabel
+%584 = OpLoad %ulong %188
+%585 = OpIMul %ulong %584 %ulong_8
+OpStore %181 %585
+%586 = OpLoad %ulong %160
+%587 = OpLoad %ulong %181
+%588 = OpShiftRightLogical %ulong %586 %587
+OpStore %182 %588
+%589 = OpLoad %ulong %182
+%590 = OpBitwiseAnd %ulong %589 %ulong_255
+OpStore %183 %590
+%591 = OpLoad %ulong %187
+%592 = OpLoad %ulong %183
+%593 = OpBitwiseXor %ulong %591 %592
+OpStore %184 %593
+%594 = OpLoad %ulong %184
+%595 = OpIMul %ulong %594 %ulong_1099511628211
+OpStore %185 %595
+%596 = OpLoad %ulong %188
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %186 %597
+%598 = OpLoad %ulong %185
+OpStore %187 %598
+%599 = OpLoad %ulong %186
+OpStore %188 %599
+OpBranch %106
+%22 = OpLabel
+%600 = OpLoad %ulong %159
+%601 = OpIMul %ulong %600 %ulong_8
+OpStore %152 %601
+%602 = OpLoad %ulong %148
+%603 = OpLoad %ulong %152
+%604 = OpShiftRightLogical %ulong %602 %603
+OpStore %153 %604
+%605 = OpLoad %ulong %153
+%606 = OpBitwiseAnd %ulong %605 %ulong_255
+OpStore %154 %606
+%607 = OpLoad %ulong %158
+%608 = OpLoad %ulong %154
+%609 = OpBitwiseXor %ulong %607 %608
+OpStore %155 %609
+%610 = OpLoad %ulong %155
+%611 = OpIMul %ulong %610 %ulong_1099511628211
+OpStore %156 %611
+%612 = OpLoad %ulong %159
+%613 = OpIAdd %ulong %612 %ulong_1
+OpStore %157 %613
+%614 = OpLoad %ulong %156
+OpStore %158 %614
+%615 = OpLoad %ulong %157
+OpStore %159 %615
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %73
+%102 = OpLabel
+OpBranch %66
+%103 = OpLabel
+OpBranch %59
+%104 = OpLabel
+OpBranch %52
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %40
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %33
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/divrem_i32.dis
+++ b/test/golden/spirv/scalar/divrem_i32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 276
+; Bound: 658
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,315 +9,152 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.divrem_i32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_2000000000 = OpConstant %uint 2000000000
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_16 = OpConstant %uint 16
 %uint_8 = OpConstant %uint 8
 %uint_2147483644 = OpConstant %uint 2147483644
 %uint_3 = OpConstant %uint 3
-%uint_197 = OpConstant %uint 197
-%uint_5 = OpConstant %uint 5
-%uint_1 = OpConstant %uint 1
-%uint_131 = OpConstant %uint 131
-%223 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%226 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_bool Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_uint Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_uint Function
-%39 = OpVariable %_ptr_Function_uint Function
-%40 = OpVariable %_ptr_Function_bool Function
-%41 = OpVariable %_ptr_Function_uint Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_uint Function
-%44 = OpVariable %_ptr_Function_uint Function
-%45 = OpVariable %_ptr_Function_uint Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uint Function
-%49 = OpVariable %_ptr_Function_uint Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_uint Function
-%53 = OpVariable %_ptr_Function_uint Function
-%54 = OpVariable %_ptr_Function_uint Function
-%55 = OpVariable %_ptr_Function_uint Function
-%56 = OpVariable %_ptr_Function_uint Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_uint Function
-%60 = OpVariable %_ptr_Function_uint Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_uint Function
-%63 = OpVariable %_ptr_Function_uint Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_uint Function
-%67 = OpVariable %_ptr_Function_uint Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_uint Function
-%72 = OpVariable %_ptr_Function_uint Function
-%73 = OpVariable %_ptr_Function_uint Function
-%74 = OpVariable %_ptr_Function_uint Function
-OpStore %19 %6
-%75 = OpFunctionCall %ulong %2
-OpStore %20 %75
-%76 = OpLoad %ulong %19
-%77 = OpUConvert %uint %76
-OpStore %22 %77
-%79 = OpLoad %uint %22
-%80 = OpISub %uint %uint_2000000000 %79
-OpStore %23 %80
-%81 = OpLoad %ulong %20
-OpStore %70 %81
-%82 = OpLoad %uint %23
-OpStore %71 %82
-OpStore %73 %uint_0
-OpBranch %8
-%8 = OpLabel
-%84 = OpLoad %uint %73
-%86 = OpSLessThan %bool %84 %uint_16
-OpStore %25 %86
-%87 = OpLoad %bool %25
-OpLoopMerge %10 %15 None
-OpBranchConditional %87 %9 %10
-%10 = OpLabel
-%88 = OpLoad %uint %22
-%89 = OpIAdd %uint %uint_2000000000 %88
-OpStore %38 %89
-%90 = OpLoad %uint %38
-%91 = OpISub %uint %uint_0 %90
-OpStore %39 %91
-%92 = OpLoad %ulong %70
-OpStore %69 %92
-OpStore %72 %uint_0
-%93 = OpLoad %uint %39
-OpStore %74 %93
-OpBranch %11
-%11 = OpLabel
-%94 = OpLoad %uint %72
-%96 = OpSLessThan %bool %94 %uint_8
-OpStore %40 %96
-%97 = OpLoad %bool %40
-OpLoopMerge %13 %14 None
-OpBranchConditional %97 %12 %13
-%13 = OpLabel
-%99 = OpLoad %uint %22
-%100 = OpIAdd %uint %uint_2147483644 %99
-OpStore %53 %100
-%102 = OpLoad %uint %22
-%103 = OpIAdd %uint %uint_3 %102
-OpStore %54 %103
-%104 = OpLoad %uint %53
-%105 = OpLoad %uint %54
-%106 = OpSDiv %uint %104 %105
-OpStore %55 %106
-%107 = OpLoad %uint %53
-%108 = OpLoad %uint %54
-%109 = OpSRem %uint %107 %108
-OpStore %56 %109
-%110 = OpLoad %ulong %69
-%111 = OpLoad %uint %55
-%112 = OpFunctionCall %ulong %3 %110 %111
-OpStore %57 %112
-%113 = OpLoad %ulong %57
-%114 = OpLoad %uint %56
-%115 = OpFunctionCall %ulong %3 %113 %114
-OpStore %58 %115
-%116 = OpLoad %uint %54
-%117 = OpLoad %uint %55
-%118 = OpIMul %uint %116 %117
-OpStore %59 %118
-%119 = OpLoad %uint %59
-%120 = OpLoad %uint %56
-%121 = OpIAdd %uint %119 %120
-OpStore %60 %121
-%122 = OpLoad %ulong %58
-%123 = OpLoad %uint %60
-%124 = OpFunctionCall %ulong %3 %122 %123
-OpStore %61 %124
-%125 = OpLoad %uint %54
-%126 = OpLoad %uint %53
-%127 = OpSDiv %uint %125 %126
-OpStore %62 %127
-%128 = OpLoad %uint %54
-%129 = OpLoad %uint %53
-%130 = OpSRem %uint %128 %129
-OpStore %63 %130
-%131 = OpLoad %ulong %61
-%132 = OpLoad %uint %62
-%133 = OpFunctionCall %ulong %3 %131 %132
-OpStore %64 %133
-%134 = OpLoad %ulong %64
-%135 = OpLoad %uint %63
-%136 = OpFunctionCall %ulong %3 %134 %135
-OpStore %65 %136
-%137 = OpLoad %uint %53
-%138 = OpLoad %uint %62
-%139 = OpIMul %uint %137 %138
-OpStore %66 %139
-%140 = OpLoad %uint %66
-%141 = OpLoad %uint %63
-%142 = OpIAdd %uint %140 %141
-OpStore %67 %142
-%143 = OpLoad %ulong %65
-%144 = OpLoad %uint %67
-%145 = OpFunctionCall %ulong %3 %143 %144
-OpStore %68 %145
-%146 = OpLoad %ulong %68
-OpReturnValue %146
-%12 = OpLabel
-%147 = OpLoad %uint %72
-%149 = OpIMul %uint %147 %uint_197
-OpStore %41 %149
-%150 = OpLoad %uint %41
-%152 = OpIAdd %uint %150 %uint_5
-OpStore %42 %152
-%153 = OpLoad %uint %42
-%154 = OpLoad %uint %22
-%155 = OpIAdd %uint %153 %154
-OpStore %43 %155
-%156 = OpLoad %uint %74
-%157 = OpLoad %uint %43
-%158 = OpSDiv %uint %156 %157
-OpStore %44 %158
-%159 = OpLoad %uint %74
-%160 = OpLoad %uint %43
-%161 = OpSRem %uint %159 %160
-OpStore %45 %161
-%162 = OpLoad %ulong %69
-%163 = OpLoad %uint %44
-%164 = OpFunctionCall %ulong %3 %162 %163
-OpStore %46 %164
-%165 = OpLoad %ulong %46
-%166 = OpLoad %uint %45
-%167 = OpFunctionCall %ulong %3 %165 %166
-OpStore %47 %167
-%168 = OpLoad %uint %43
-%169 = OpLoad %uint %44
-%170 = OpIMul %uint %168 %169
-OpStore %48 %170
-%171 = OpLoad %uint %48
-%172 = OpLoad %uint %45
-%173 = OpIAdd %uint %171 %172
-OpStore %49 %173
-%174 = OpLoad %ulong %47
-%175 = OpLoad %uint %49
-%176 = OpFunctionCall %ulong %3 %174 %175
-OpStore %50 %176
-%177 = OpLoad %uint %74
-%178 = OpLoad %uint %43
-%179 = OpIAdd %uint %177 %178
-OpStore %51 %179
-%180 = OpLoad %uint %72
-%182 = OpIAdd %uint %180 %uint_1
-OpStore %52 %182
-%183 = OpLoad %ulong %50
-OpStore %69 %183
-%184 = OpLoad %uint %52
-OpStore %72 %184
-%185 = OpLoad %uint %51
-OpStore %74 %185
-OpBranch %14
-%9 = OpLabel
-%186 = OpLoad %uint %73
-%188 = OpIMul %uint %186 %uint_131
-OpStore %26 %188
-%189 = OpLoad %uint %26
-%190 = OpIAdd %uint %189 %uint_3
-OpStore %27 %190
-%191 = OpLoad %uint %27
-%192 = OpLoad %uint %22
-%193 = OpIAdd %uint %191 %192
-OpStore %28 %193
-%194 = OpLoad %uint %71
-%195 = OpLoad %uint %28
-%196 = OpSDiv %uint %194 %195
-OpStore %29 %196
-%197 = OpLoad %uint %71
-%198 = OpLoad %uint %28
-%199 = OpSRem %uint %197 %198
-OpStore %30 %199
-%200 = OpLoad %ulong %70
-%201 = OpLoad %uint %29
-%202 = OpFunctionCall %ulong %3 %200 %201
-OpStore %31 %202
-%203 = OpLoad %ulong %31
-%204 = OpLoad %uint %30
-%205 = OpFunctionCall %ulong %3 %203 %204
-OpStore %32 %205
-%206 = OpLoad %uint %28
-%207 = OpLoad %uint %29
-%208 = OpIMul %uint %206 %207
-OpStore %33 %208
-%209 = OpLoad %uint %33
-%210 = OpLoad %uint %30
-%211 = OpIAdd %uint %209 %210
-OpStore %34 %211
-%212 = OpLoad %ulong %32
-%213 = OpLoad %uint %34
-%214 = OpFunctionCall %ulong %3 %212 %213
-OpStore %35 %214
-%215 = OpLoad %uint %71
-%216 = OpLoad %uint %28
-%217 = OpISub %uint %215 %216
-OpStore %36 %217
-%218 = OpLoad %uint %73
-%219 = OpIAdd %uint %218 %uint_1
-OpStore %37 %219
-%220 = OpLoad %ulong %35
-OpStore %70 %220
-%221 = OpLoad %uint %36
-OpStore %71 %221
-%222 = OpLoad %uint %37
-OpStore %73 %222
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %223
-%224 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %226
-%227 = OpFunctionParameter %ulong
-%228 = OpFunctionParameter %uint
-%229 = OpLabel
+%uint_197 = OpConstant %uint 197
+%uint_5 = OpConstant %uint 5
+%uint_1 = OpConstant %uint 1
+%uint_131 = OpConstant %uint 131
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_uint Function
+%118 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_uint Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_uint Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_uint Function
+%127 = OpVariable %_ptr_Function_uint Function
+%128 = OpVariable %_ptr_Function_uint Function
+%129 = OpVariable %_ptr_Function_uint Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_uint Function
+%132 = OpVariable %_ptr_Function_bool Function
+%133 = OpVariable %_ptr_Function_uint Function
+%134 = OpVariable %_ptr_Function_uint Function
+%135 = OpVariable %_ptr_Function_uint Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_uint Function
+%138 = OpVariable %_ptr_Function_uint Function
+%139 = OpVariable %_ptr_Function_uint Function
+%140 = OpVariable %_ptr_Function_uint Function
+%141 = OpVariable %_ptr_Function_uint Function
+%142 = OpVariable %_ptr_Function_uint Function
+%143 = OpVariable %_ptr_Function_uint Function
+%144 = OpVariable %_ptr_Function_uint Function
+%145 = OpVariable %_ptr_Function_uint Function
+%146 = OpVariable %_ptr_Function_uint Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_uint Function
+%149 = OpVariable %_ptr_Function_uint Function
+%150 = OpVariable %_ptr_Function_uint Function
+%151 = OpVariable %_ptr_Function_uint Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_uint Function
+%155 = OpVariable %_ptr_Function_uint Function
+%156 = OpVariable %_ptr_Function_uint Function
+%157 = OpVariable %_ptr_Function_uint Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_bool Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_bool Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_bool Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_bool Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_bool Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
 %236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_uint Function
+%237 = OpVariable %_ptr_Function_ulong Function
 %238 = OpVariable %_ptr_Function_ulong Function
 %239 = OpVariable %_ptr_Function_bool Function
 %240 = OpVariable %_ptr_Function_ulong Function
@@ -328,55 +165,816 @@ OpFunctionEnd
 %245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_ulong Function
 %247 = OpVariable %_ptr_Function_ulong Function
-OpStore %236 %227
-OpStore %237 %228
-%248 = OpLoad %uint %237
-%249 = OpSConvert %ulong %248
-OpStore %238 %249
-OpBranch %230
-%230 = OpLabel
-%250 = OpLoad %ulong %236
-OpStore %246 %250
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_bool Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+OpStore %115 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%278 = OpLoad %ulong %115
+%279 = OpUConvert %uint %278
+OpStore %117 %279
+%281 = OpLoad %uint %117
+%282 = OpISub %uint %uint_2000000000 %281
+OpStore %118 %282
+OpStore %153 %ulong_14695981039346656037
+%284 = OpLoad %uint %118
+OpStore %154 %284
+OpStore %156 %uint_0
+OpBranch %6
+%6 = OpLabel
+%286 = OpLoad %uint %156
+%288 = OpSLessThan %bool %286 %uint_16
+OpStore %120 %288
+%289 = OpLoad %bool %120
+OpLoopMerge %8 %111 None
+OpBranchConditional %289 %7 %8
+%8 = OpLabel
+%290 = OpLoad %uint %117
+%291 = OpIAdd %uint %uint_2000000000 %290
+OpStore %130 %291
+%292 = OpLoad %uint %130
+%293 = OpISub %uint %uint_0 %292
+OpStore %131 %293
+%294 = OpLoad %ulong %153
+OpStore %152 %294
+OpStore %155 %uint_0
+%295 = OpLoad %uint %131
+OpStore %157 %295
+OpBranch %9
+%9 = OpLabel
+%296 = OpLoad %uint %155
+%298 = OpSLessThan %bool %296 %uint_8
+OpStore %132 %298
+%299 = OpLoad %bool %132
+OpLoopMerge %11 %110 None
+OpBranchConditional %299 %10 %11
+%11 = OpLabel
+%301 = OpLoad %uint %117
+%302 = OpIAdd %uint %uint_2147483644 %301
+OpStore %142 %302
+%304 = OpLoad %uint %117
+%305 = OpIAdd %uint %uint_3 %304
+OpStore %143 %305
+%306 = OpLoad %uint %142
+%307 = OpLoad %uint %143
+%308 = OpSDiv %uint %306 %307
+OpStore %144 %308
+%309 = OpLoad %uint %142
+%310 = OpLoad %uint %143
+%311 = OpSRem %uint %309 %310
+OpStore %145 %311
+OpBranch %18
+%18 = OpLabel
+%312 = OpLoad %uint %144
+%313 = OpSConvert %ulong %312
+OpStore %160 %313
+OpBranch %34
+%34 = OpLabel
+%314 = OpLoad %ulong %152
+OpStore %188 %314
+OpStore %189 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%316 = OpLoad %ulong %189
+%318 = OpULessThan %bool %316 %ulong_8
+OpStore %181 %318
+%319 = OpLoad %bool %181
+OpLoopMerge %37 %108 None
+OpBranchConditional %319 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %39
+%39 = OpLabel
+%320 = OpLoad %uint %145
+%321 = OpSConvert %ulong %320
+OpStore %190 %321
+OpBranch %55
+%55 = OpLabel
+%322 = OpLoad %ulong %188
+OpStore %218 %322
+OpStore %219 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%323 = OpLoad %ulong %219
+%324 = OpULessThan %bool %323 %ulong_8
+OpStore %211 %324
+%325 = OpLoad %bool %211
+OpLoopMerge %58 %105 None
+OpBranchConditional %325 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%326 = OpLoad %uint %143
+%327 = OpLoad %uint %144
+%328 = OpIMul %uint %326 %327
+OpStore %146 %328
+%329 = OpLoad %uint %146
+%330 = OpLoad %uint %145
+%331 = OpIAdd %uint %329 %330
+OpStore %147 %331
+OpBranch %60
+%60 = OpLabel
+%332 = OpLoad %uint %147
+%333 = OpSConvert %ulong %332
+OpStore %220 %333
+OpBranch %72
+%72 = OpLabel
+%334 = OpLoad %ulong %218
+OpStore %246 %334
 OpStore %247 %ulong_0
-OpBranch %231
-%231 = OpLabel
-%252 = OpLoad %ulong %247
-%254 = OpULessThan %bool %252 %ulong_8
-OpStore %239 %254
-%255 = OpLoad %bool %239
-OpLoopMerge %233 %235 None
-OpBranchConditional %255 %232 %233
-%233 = OpLabel
-OpBranch %234
-%234 = OpLabel
-%256 = OpLoad %ulong %246
-OpReturnValue %256
-%232 = OpLabel
-%257 = OpLoad %ulong %247
-%258 = OpIMul %ulong %257 %ulong_8
-OpStore %240 %258
-%259 = OpLoad %ulong %238
-%260 = OpLoad %ulong %240
-%261 = OpShiftRightLogical %ulong %259 %260
-OpStore %241 %261
-%262 = OpLoad %ulong %241
-%264 = OpBitwiseAnd %ulong %262 %ulong_255
-OpStore %242 %264
-%265 = OpLoad %ulong %246
-%266 = OpLoad %ulong %242
-%267 = OpBitwiseXor %ulong %265 %266
-OpStore %243 %267
-%268 = OpLoad %ulong %243
-%270 = OpIMul %ulong %268 %ulong_1099511628211
-OpStore %244 %270
-%271 = OpLoad %ulong %247
-%273 = OpIAdd %ulong %271 %ulong_1
-OpStore %245 %273
-%274 = OpLoad %ulong %244
-OpStore %246 %274
-%275 = OpLoad %ulong %245
-OpStore %247 %275
-OpBranch %235
-%235 = OpLabel
-OpBranch %231
+OpBranch %73
+%73 = OpLabel
+%335 = OpLoad %ulong %247
+%336 = OpULessThan %bool %335 %ulong_8
+OpStore %239 %336
+%337 = OpLoad %bool %239
+OpLoopMerge %75 %102 None
+OpBranchConditional %337 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%338 = OpLoad %uint %143
+%339 = OpLoad %uint %142
+%340 = OpSDiv %uint %338 %339
+OpStore %148 %340
+%341 = OpLoad %uint %143
+%342 = OpLoad %uint %142
+%343 = OpSRem %uint %341 %342
+OpStore %149 %343
+OpBranch %77
+%77 = OpLabel
+%344 = OpLoad %uint %148
+%345 = OpSConvert %ulong %344
+OpStore %248 %345
+OpBranch %79
+%79 = OpLabel
+%346 = OpLoad %ulong %246
+OpStore %256 %346
+OpStore %257 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%347 = OpLoad %ulong %257
+%348 = OpULessThan %bool %347 %ulong_8
+OpStore %249 %348
+%349 = OpLoad %bool %249
+OpLoopMerge %82 %100 None
+OpBranchConditional %349 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%350 = OpLoad %uint %149
+%351 = OpSConvert %ulong %350
+OpStore %258 %351
+OpBranch %86
+%86 = OpLabel
+%352 = OpLoad %ulong %256
+OpStore %266 %352
+OpStore %267 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%353 = OpLoad %ulong %267
+%354 = OpULessThan %bool %353 %ulong_8
+OpStore %259 %354
+%355 = OpLoad %bool %259
+OpLoopMerge %89 %99 None
+OpBranchConditional %355 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%356 = OpLoad %uint %142
+%357 = OpLoad %uint %148
+%358 = OpIMul %uint %356 %357
+OpStore %150 %358
+%359 = OpLoad %uint %150
+%360 = OpLoad %uint %149
+%361 = OpIAdd %uint %359 %360
+OpStore %151 %361
+OpBranch %91
+%91 = OpLabel
+%362 = OpLoad %uint %151
+%363 = OpSConvert %ulong %362
+OpStore %268 %363
+OpBranch %93
+%93 = OpLabel
+%364 = OpLoad %ulong %266
+OpStore %276 %364
+OpStore %277 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%365 = OpLoad %ulong %277
+%366 = OpULessThan %bool %365 %ulong_8
+OpStore %269 %366
+%367 = OpLoad %bool %269
+OpLoopMerge %96 %98 None
+OpBranchConditional %367 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%368 = OpLoad %ulong %276
+OpReturnValue %368
+%95 = OpLabel
+%369 = OpLoad %ulong %277
+%370 = OpIMul %ulong %369 %ulong_8
+OpStore %270 %370
+%371 = OpLoad %ulong %268
+%372 = OpLoad %ulong %270
+%373 = OpShiftRightLogical %ulong %371 %372
+OpStore %271 %373
+%374 = OpLoad %ulong %271
+%376 = OpBitwiseAnd %ulong %374 %ulong_255
+OpStore %272 %376
+%377 = OpLoad %ulong %276
+%378 = OpLoad %ulong %272
+%379 = OpBitwiseXor %ulong %377 %378
+OpStore %273 %379
+%380 = OpLoad %ulong %273
+%382 = OpIMul %ulong %380 %ulong_1099511628211
+OpStore %274 %382
+%383 = OpLoad %ulong %277
+%385 = OpIAdd %ulong %383 %ulong_1
+OpStore %275 %385
+%386 = OpLoad %ulong %274
+OpStore %276 %386
+%387 = OpLoad %ulong %275
+OpStore %277 %387
+OpBranch %98
+%88 = OpLabel
+%388 = OpLoad %ulong %267
+%389 = OpIMul %ulong %388 %ulong_8
+OpStore %260 %389
+%390 = OpLoad %ulong %258
+%391 = OpLoad %ulong %260
+%392 = OpShiftRightLogical %ulong %390 %391
+OpStore %261 %392
+%393 = OpLoad %ulong %261
+%394 = OpBitwiseAnd %ulong %393 %ulong_255
+OpStore %262 %394
+%395 = OpLoad %ulong %266
+%396 = OpLoad %ulong %262
+%397 = OpBitwiseXor %ulong %395 %396
+OpStore %263 %397
+%398 = OpLoad %ulong %263
+%399 = OpIMul %ulong %398 %ulong_1099511628211
+OpStore %264 %399
+%400 = OpLoad %ulong %267
+%401 = OpIAdd %ulong %400 %ulong_1
+OpStore %265 %401
+%402 = OpLoad %ulong %264
+OpStore %266 %402
+%403 = OpLoad %ulong %265
+OpStore %267 %403
+OpBranch %99
+%81 = OpLabel
+%404 = OpLoad %ulong %257
+%405 = OpIMul %ulong %404 %ulong_8
+OpStore %250 %405
+%406 = OpLoad %ulong %248
+%407 = OpLoad %ulong %250
+%408 = OpShiftRightLogical %ulong %406 %407
+OpStore %251 %408
+%409 = OpLoad %ulong %251
+%410 = OpBitwiseAnd %ulong %409 %ulong_255
+OpStore %252 %410
+%411 = OpLoad %ulong %256
+%412 = OpLoad %ulong %252
+%413 = OpBitwiseXor %ulong %411 %412
+OpStore %253 %413
+%414 = OpLoad %ulong %253
+%415 = OpIMul %ulong %414 %ulong_1099511628211
+OpStore %254 %415
+%416 = OpLoad %ulong %257
+%417 = OpIAdd %ulong %416 %ulong_1
+OpStore %255 %417
+%418 = OpLoad %ulong %254
+OpStore %256 %418
+%419 = OpLoad %ulong %255
+OpStore %257 %419
+OpBranch %100
+%74 = OpLabel
+%420 = OpLoad %ulong %247
+%421 = OpIMul %ulong %420 %ulong_8
+OpStore %240 %421
+%422 = OpLoad %ulong %220
+%423 = OpLoad %ulong %240
+%424 = OpShiftRightLogical %ulong %422 %423
+OpStore %241 %424
+%425 = OpLoad %ulong %241
+%426 = OpBitwiseAnd %ulong %425 %ulong_255
+OpStore %242 %426
+%427 = OpLoad %ulong %246
+%428 = OpLoad %ulong %242
+%429 = OpBitwiseXor %ulong %427 %428
+OpStore %243 %429
+%430 = OpLoad %ulong %243
+%431 = OpIMul %ulong %430 %ulong_1099511628211
+OpStore %244 %431
+%432 = OpLoad %ulong %247
+%433 = OpIAdd %ulong %432 %ulong_1
+OpStore %245 %433
+%434 = OpLoad %ulong %244
+OpStore %246 %434
+%435 = OpLoad %ulong %245
+OpStore %247 %435
+OpBranch %102
+%57 = OpLabel
+%436 = OpLoad %ulong %219
+%437 = OpIMul %ulong %436 %ulong_8
+OpStore %212 %437
+%438 = OpLoad %ulong %190
+%439 = OpLoad %ulong %212
+%440 = OpShiftRightLogical %ulong %438 %439
+OpStore %213 %440
+%441 = OpLoad %ulong %213
+%442 = OpBitwiseAnd %ulong %441 %ulong_255
+OpStore %214 %442
+%443 = OpLoad %ulong %218
+%444 = OpLoad %ulong %214
+%445 = OpBitwiseXor %ulong %443 %444
+OpStore %215 %445
+%446 = OpLoad %ulong %215
+%447 = OpIMul %ulong %446 %ulong_1099511628211
+OpStore %216 %447
+%448 = OpLoad %ulong %219
+%449 = OpIAdd %ulong %448 %ulong_1
+OpStore %217 %449
+%450 = OpLoad %ulong %216
+OpStore %218 %450
+%451 = OpLoad %ulong %217
+OpStore %219 %451
+OpBranch %105
+%36 = OpLabel
+%452 = OpLoad %ulong %189
+%453 = OpIMul %ulong %452 %ulong_8
+OpStore %182 %453
+%454 = OpLoad %ulong %160
+%455 = OpLoad %ulong %182
+%456 = OpShiftRightLogical %ulong %454 %455
+OpStore %183 %456
+%457 = OpLoad %ulong %183
+%458 = OpBitwiseAnd %ulong %457 %ulong_255
+OpStore %184 %458
+%459 = OpLoad %ulong %188
+%460 = OpLoad %ulong %184
+%461 = OpBitwiseXor %ulong %459 %460
+OpStore %185 %461
+%462 = OpLoad %ulong %185
+%463 = OpIMul %ulong %462 %ulong_1099511628211
+OpStore %186 %463
+%464 = OpLoad %ulong %189
+%465 = OpIAdd %ulong %464 %ulong_1
+OpStore %187 %465
+%466 = OpLoad %ulong %186
+OpStore %188 %466
+%467 = OpLoad %ulong %187
+OpStore %189 %467
+OpBranch %108
+%10 = OpLabel
+%468 = OpLoad %uint %155
+%470 = OpIMul %uint %468 %uint_197
+OpStore %133 %470
+%471 = OpLoad %uint %133
+%473 = OpIAdd %uint %471 %uint_5
+OpStore %134 %473
+%474 = OpLoad %uint %134
+%475 = OpLoad %uint %117
+%476 = OpIAdd %uint %474 %475
+OpStore %135 %476
+%477 = OpLoad %uint %157
+%478 = OpLoad %uint %135
+%479 = OpSDiv %uint %477 %478
+OpStore %136 %479
+%480 = OpLoad %uint %157
+%481 = OpLoad %uint %135
+%482 = OpSRem %uint %480 %481
+OpStore %137 %482
+OpBranch %16
+%16 = OpLabel
+%483 = OpLoad %uint %136
+%484 = OpSConvert %ulong %483
+OpStore %159 %484
+OpBranch %27
+%27 = OpLabel
+%485 = OpLoad %ulong %152
+OpStore %178 %485
+OpStore %179 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%486 = OpLoad %ulong %179
+%487 = OpULessThan %bool %486 %ulong_8
+OpStore %171 %487
+%488 = OpLoad %bool %171
+OpLoopMerge %30 %107 None
+OpBranchConditional %488 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%489 = OpLoad %uint %137
+%490 = OpSConvert %ulong %489
+OpStore %180 %490
+OpBranch %48
+%48 = OpLabel
+%491 = OpLoad %ulong %178
+OpStore %208 %491
+OpStore %209 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%492 = OpLoad %ulong %209
+%493 = OpULessThan %bool %492 %ulong_8
+OpStore %201 %493
+%494 = OpLoad %bool %201
+OpLoopMerge %51 %104 None
+OpBranchConditional %494 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%495 = OpLoad %uint %135
+%496 = OpLoad %uint %136
+%497 = OpIMul %uint %495 %496
+OpStore %138 %497
+%498 = OpLoad %uint %138
+%499 = OpLoad %uint %137
+%500 = OpIAdd %uint %498 %499
+OpStore %139 %500
+OpBranch %53
+%53 = OpLabel
+%501 = OpLoad %uint %139
+%502 = OpSConvert %ulong %501
+OpStore %210 %502
+OpBranch %67
+%67 = OpLabel
+%503 = OpLoad %ulong %208
+OpStore %237 %503
+OpStore %238 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%504 = OpLoad %ulong %238
+%505 = OpULessThan %bool %504 %ulong_8
+OpStore %230 %505
+%506 = OpLoad %bool %230
+OpLoopMerge %70 %101 None
+OpBranchConditional %506 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%507 = OpLoad %uint %157
+%508 = OpLoad %uint %135
+%509 = OpIAdd %uint %507 %508
+OpStore %140 %509
+%510 = OpLoad %uint %155
+%512 = OpIAdd %uint %510 %uint_1
+OpStore %141 %512
+%513 = OpLoad %ulong %237
+OpStore %152 %513
+%514 = OpLoad %uint %141
+OpStore %155 %514
+%515 = OpLoad %uint %140
+OpStore %157 %515
+OpBranch %110
+%69 = OpLabel
+%516 = OpLoad %ulong %238
+%517 = OpIMul %ulong %516 %ulong_8
+OpStore %231 %517
+%518 = OpLoad %ulong %210
+%519 = OpLoad %ulong %231
+%520 = OpShiftRightLogical %ulong %518 %519
+OpStore %232 %520
+%521 = OpLoad %ulong %232
+%522 = OpBitwiseAnd %ulong %521 %ulong_255
+OpStore %233 %522
+%523 = OpLoad %ulong %237
+%524 = OpLoad %ulong %233
+%525 = OpBitwiseXor %ulong %523 %524
+OpStore %234 %525
+%526 = OpLoad %ulong %234
+%527 = OpIMul %ulong %526 %ulong_1099511628211
+OpStore %235 %527
+%528 = OpLoad %ulong %238
+%529 = OpIAdd %ulong %528 %ulong_1
+OpStore %236 %529
+%530 = OpLoad %ulong %235
+OpStore %237 %530
+%531 = OpLoad %ulong %236
+OpStore %238 %531
+OpBranch %101
+%50 = OpLabel
+%532 = OpLoad %ulong %209
+%533 = OpIMul %ulong %532 %ulong_8
+OpStore %202 %533
+%534 = OpLoad %ulong %180
+%535 = OpLoad %ulong %202
+%536 = OpShiftRightLogical %ulong %534 %535
+OpStore %203 %536
+%537 = OpLoad %ulong %203
+%538 = OpBitwiseAnd %ulong %537 %ulong_255
+OpStore %204 %538
+%539 = OpLoad %ulong %208
+%540 = OpLoad %ulong %204
+%541 = OpBitwiseXor %ulong %539 %540
+OpStore %205 %541
+%542 = OpLoad %ulong %205
+%543 = OpIMul %ulong %542 %ulong_1099511628211
+OpStore %206 %543
+%544 = OpLoad %ulong %209
+%545 = OpIAdd %ulong %544 %ulong_1
+OpStore %207 %545
+%546 = OpLoad %ulong %206
+OpStore %208 %546
+%547 = OpLoad %ulong %207
+OpStore %209 %547
+OpBranch %104
+%29 = OpLabel
+%548 = OpLoad %ulong %179
+%549 = OpIMul %ulong %548 %ulong_8
+OpStore %172 %549
+%550 = OpLoad %ulong %159
+%551 = OpLoad %ulong %172
+%552 = OpShiftRightLogical %ulong %550 %551
+OpStore %173 %552
+%553 = OpLoad %ulong %173
+%554 = OpBitwiseAnd %ulong %553 %ulong_255
+OpStore %174 %554
+%555 = OpLoad %ulong %178
+%556 = OpLoad %ulong %174
+%557 = OpBitwiseXor %ulong %555 %556
+OpStore %175 %557
+%558 = OpLoad %ulong %175
+%559 = OpIMul %ulong %558 %ulong_1099511628211
+OpStore %176 %559
+%560 = OpLoad %ulong %179
+%561 = OpIAdd %ulong %560 %ulong_1
+OpStore %177 %561
+%562 = OpLoad %ulong %176
+OpStore %178 %562
+%563 = OpLoad %ulong %177
+OpStore %179 %563
+OpBranch %107
+%7 = OpLabel
+%564 = OpLoad %uint %156
+%566 = OpIMul %uint %564 %uint_131
+OpStore %121 %566
+%567 = OpLoad %uint %121
+%568 = OpIAdd %uint %567 %uint_3
+OpStore %122 %568
+%569 = OpLoad %uint %122
+%570 = OpLoad %uint %117
+%571 = OpIAdd %uint %569 %570
+OpStore %123 %571
+%572 = OpLoad %uint %154
+%573 = OpLoad %uint %123
+%574 = OpSDiv %uint %572 %573
+OpStore %124 %574
+%575 = OpLoad %uint %154
+%576 = OpLoad %uint %123
+%577 = OpSRem %uint %575 %576
+OpStore %125 %577
+OpBranch %14
+%14 = OpLabel
+%578 = OpLoad %uint %124
+%579 = OpSConvert %ulong %578
+OpStore %158 %579
+OpBranch %20
+%20 = OpLabel
+%580 = OpLoad %ulong %153
+OpStore %168 %580
+OpStore %169 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%581 = OpLoad %ulong %169
+%582 = OpULessThan %bool %581 %ulong_8
+OpStore %161 %582
+%583 = OpLoad %bool %161
+OpLoopMerge %23 %109 None
+OpBranchConditional %583 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%584 = OpLoad %uint %125
+%585 = OpSConvert %ulong %584
+OpStore %170 %585
+OpBranch %41
+%41 = OpLabel
+%586 = OpLoad %ulong %168
+OpStore %198 %586
+OpStore %199 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%587 = OpLoad %ulong %199
+%588 = OpULessThan %bool %587 %ulong_8
+OpStore %191 %588
+%589 = OpLoad %bool %191
+OpLoopMerge %44 %106 None
+OpBranchConditional %589 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%590 = OpLoad %uint %123
+%591 = OpLoad %uint %124
+%592 = OpIMul %uint %590 %591
+OpStore %126 %592
+%593 = OpLoad %uint %126
+%594 = OpLoad %uint %125
+%595 = OpIAdd %uint %593 %594
+OpStore %127 %595
+OpBranch %46
+%46 = OpLabel
+%596 = OpLoad %uint %127
+%597 = OpSConvert %ulong %596
+OpStore %200 %597
+OpBranch %62
+%62 = OpLabel
+%598 = OpLoad %ulong %198
+OpStore %228 %598
+OpStore %229 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%599 = OpLoad %ulong %229
+%600 = OpULessThan %bool %599 %ulong_8
+OpStore %221 %600
+%601 = OpLoad %bool %221
+OpLoopMerge %65 %103 None
+OpBranchConditional %601 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%602 = OpLoad %uint %154
+%603 = OpLoad %uint %123
+%604 = OpISub %uint %602 %603
+OpStore %128 %604
+%605 = OpLoad %uint %156
+%606 = OpIAdd %uint %605 %uint_1
+OpStore %129 %606
+%607 = OpLoad %ulong %228
+OpStore %153 %607
+%608 = OpLoad %uint %128
+OpStore %154 %608
+%609 = OpLoad %uint %129
+OpStore %156 %609
+OpBranch %111
+%64 = OpLabel
+%610 = OpLoad %ulong %229
+%611 = OpIMul %ulong %610 %ulong_8
+OpStore %222 %611
+%612 = OpLoad %ulong %200
+%613 = OpLoad %ulong %222
+%614 = OpShiftRightLogical %ulong %612 %613
+OpStore %223 %614
+%615 = OpLoad %ulong %223
+%616 = OpBitwiseAnd %ulong %615 %ulong_255
+OpStore %224 %616
+%617 = OpLoad %ulong %228
+%618 = OpLoad %ulong %224
+%619 = OpBitwiseXor %ulong %617 %618
+OpStore %225 %619
+%620 = OpLoad %ulong %225
+%621 = OpIMul %ulong %620 %ulong_1099511628211
+OpStore %226 %621
+%622 = OpLoad %ulong %229
+%623 = OpIAdd %ulong %622 %ulong_1
+OpStore %227 %623
+%624 = OpLoad %ulong %226
+OpStore %228 %624
+%625 = OpLoad %ulong %227
+OpStore %229 %625
+OpBranch %103
+%43 = OpLabel
+%626 = OpLoad %ulong %199
+%627 = OpIMul %ulong %626 %ulong_8
+OpStore %192 %627
+%628 = OpLoad %ulong %170
+%629 = OpLoad %ulong %192
+%630 = OpShiftRightLogical %ulong %628 %629
+OpStore %193 %630
+%631 = OpLoad %ulong %193
+%632 = OpBitwiseAnd %ulong %631 %ulong_255
+OpStore %194 %632
+%633 = OpLoad %ulong %198
+%634 = OpLoad %ulong %194
+%635 = OpBitwiseXor %ulong %633 %634
+OpStore %195 %635
+%636 = OpLoad %ulong %195
+%637 = OpIMul %ulong %636 %ulong_1099511628211
+OpStore %196 %637
+%638 = OpLoad %ulong %199
+%639 = OpIAdd %ulong %638 %ulong_1
+OpStore %197 %639
+%640 = OpLoad %ulong %196
+OpStore %198 %640
+%641 = OpLoad %ulong %197
+OpStore %199 %641
+OpBranch %106
+%22 = OpLabel
+%642 = OpLoad %ulong %169
+%643 = OpIMul %ulong %642 %ulong_8
+OpStore %162 %643
+%644 = OpLoad %ulong %158
+%645 = OpLoad %ulong %162
+%646 = OpShiftRightLogical %ulong %644 %645
+OpStore %163 %646
+%647 = OpLoad %ulong %163
+%648 = OpBitwiseAnd %ulong %647 %ulong_255
+OpStore %164 %648
+%649 = OpLoad %ulong %168
+%650 = OpLoad %ulong %164
+%651 = OpBitwiseXor %ulong %649 %650
+OpStore %165 %651
+%652 = OpLoad %ulong %165
+%653 = OpIMul %ulong %652 %ulong_1099511628211
+OpStore %166 %653
+%654 = OpLoad %ulong %169
+%655 = OpIAdd %ulong %654 %ulong_1
+OpStore %167 %655
+%656 = OpLoad %ulong %166
+OpStore %168 %656
+%657 = OpLoad %ulong %167
+OpStore %169 %657
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %68
+%102 = OpLabel
+OpBranch %73
+%103 = OpLabel
+OpBranch %63
+%104 = OpLabel
+OpBranch %49
+%105 = OpLabel
+OpBranch %56
+%106 = OpLabel
+OpBranch %42
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %35
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/divrem_i64.dis
+++ b/test/golden/spirv/scalar/divrem_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 265
+; Bound: 614
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,361 +9,915 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.divrem_i64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_9000000000000000000 = OpConstant %ulong 9000000000000000000
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_16 = OpConstant %ulong 16
 %ulong_8 = OpConstant %ulong 8
 %ulong_9223372036854775804 = OpConstant %ulong 9223372036854775804
 %ulong_3 = OpConstant %ulong 3
-%ulong_197 = OpConstant %ulong 197
-%ulong_5 = OpConstant %ulong 5
-%ulong_1 = OpConstant %ulong 1
-%ulong_131 = OpConstant %ulong 131
-%218 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%221 = OpTypeFunction %ulong %ulong %ulong
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_bool Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_bool Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_ulong Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_ulong Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_ulong Function
-%61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_ulong Function
-%63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_ulong Function
-%65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_ulong Function
-%67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_ulong Function
-%69 = OpVariable %_ptr_Function_ulong Function
-%70 = OpVariable %_ptr_Function_ulong Function
-%71 = OpVariable %_ptr_Function_ulong Function
-OpStore %18 %6
-%72 = OpFunctionCall %ulong %2
-OpStore %19 %72
-%74 = OpLoad %ulong %18
-%75 = OpISub %ulong %ulong_9000000000000000000 %74
-OpStore %20 %75
-%76 = OpLoad %ulong %19
-OpStore %67 %76
-%77 = OpLoad %ulong %20
-OpStore %68 %77
-OpStore %70 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%79 = OpLoad %ulong %70
-%81 = OpSLessThan %bool %79 %ulong_16
-OpStore %22 %81
-%82 = OpLoad %bool %22
-OpLoopMerge %10 %15 None
-OpBranchConditional %82 %9 %10
-%10 = OpLabel
-%83 = OpLoad %ulong %18
-%84 = OpIAdd %ulong %ulong_9000000000000000000 %83
-OpStore %35 %84
-%85 = OpLoad %ulong %35
-%86 = OpISub %ulong %ulong_0 %85
-OpStore %36 %86
-%87 = OpLoad %ulong %67
-OpStore %66 %87
-OpStore %69 %ulong_0
-%88 = OpLoad %ulong %36
-OpStore %71 %88
-OpBranch %11
-%11 = OpLabel
-%89 = OpLoad %ulong %69
-%91 = OpSLessThan %bool %89 %ulong_8
-OpStore %37 %91
-%92 = OpLoad %bool %37
-OpLoopMerge %13 %14 None
-OpBranchConditional %92 %12 %13
-%13 = OpLabel
-%94 = OpLoad %ulong %18
-%95 = OpIAdd %ulong %ulong_9223372036854775804 %94
-OpStore %50 %95
-%97 = OpLoad %ulong %18
-%98 = OpIAdd %ulong %ulong_3 %97
-OpStore %51 %98
-%99 = OpLoad %ulong %50
-%100 = OpLoad %ulong %51
-%101 = OpSDiv %ulong %99 %100
-OpStore %52 %101
-%102 = OpLoad %ulong %50
-%103 = OpLoad %ulong %51
-%104 = OpSRem %ulong %102 %103
-OpStore %53 %104
-%105 = OpLoad %ulong %66
-%106 = OpLoad %ulong %52
-%107 = OpFunctionCall %ulong %3 %105 %106
-OpStore %54 %107
-%108 = OpLoad %ulong %54
-%109 = OpLoad %ulong %53
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %55 %110
-%111 = OpLoad %ulong %51
-%112 = OpLoad %ulong %52
-%113 = OpIMul %ulong %111 %112
-OpStore %56 %113
-%114 = OpLoad %ulong %56
-%115 = OpLoad %ulong %53
-%116 = OpIAdd %ulong %114 %115
-OpStore %57 %116
-%117 = OpLoad %ulong %55
-%118 = OpLoad %ulong %57
-%119 = OpFunctionCall %ulong %3 %117 %118
-OpStore %58 %119
-%120 = OpLoad %ulong %51
-%121 = OpLoad %ulong %50
-%122 = OpSDiv %ulong %120 %121
-OpStore %59 %122
-%123 = OpLoad %ulong %51
-%124 = OpLoad %ulong %50
-%125 = OpSRem %ulong %123 %124
-OpStore %60 %125
-%126 = OpLoad %ulong %58
-%127 = OpLoad %ulong %59
-%128 = OpFunctionCall %ulong %3 %126 %127
-OpStore %61 %128
-%129 = OpLoad %ulong %61
-%130 = OpLoad %ulong %60
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %62 %131
-%132 = OpLoad %ulong %50
-%133 = OpLoad %ulong %59
-%134 = OpIMul %ulong %132 %133
-OpStore %63 %134
-%135 = OpLoad %ulong %63
-%136 = OpLoad %ulong %60
-%137 = OpIAdd %ulong %135 %136
-OpStore %64 %137
-%138 = OpLoad %ulong %62
-%139 = OpLoad %ulong %64
-%140 = OpFunctionCall %ulong %3 %138 %139
-OpStore %65 %140
-%141 = OpLoad %ulong %65
-OpReturnValue %141
-%12 = OpLabel
-%142 = OpLoad %ulong %69
-%144 = OpIMul %ulong %142 %ulong_197
-OpStore %38 %144
-%145 = OpLoad %ulong %38
-%147 = OpIAdd %ulong %145 %ulong_5
-OpStore %39 %147
-%148 = OpLoad %ulong %39
-%149 = OpLoad %ulong %18
-%150 = OpIAdd %ulong %148 %149
-OpStore %40 %150
-%151 = OpLoad %ulong %71
-%152 = OpLoad %ulong %40
-%153 = OpSDiv %ulong %151 %152
-OpStore %41 %153
-%154 = OpLoad %ulong %71
-%155 = OpLoad %ulong %40
-%156 = OpSRem %ulong %154 %155
-OpStore %42 %156
-%157 = OpLoad %ulong %66
-%158 = OpLoad %ulong %41
-%159 = OpFunctionCall %ulong %3 %157 %158
-OpStore %43 %159
-%160 = OpLoad %ulong %43
-%161 = OpLoad %ulong %42
-%162 = OpFunctionCall %ulong %3 %160 %161
-OpStore %44 %162
-%163 = OpLoad %ulong %40
-%164 = OpLoad %ulong %41
-%165 = OpIMul %ulong %163 %164
-OpStore %45 %165
-%166 = OpLoad %ulong %45
-%167 = OpLoad %ulong %42
-%168 = OpIAdd %ulong %166 %167
-OpStore %46 %168
-%169 = OpLoad %ulong %44
-%170 = OpLoad %ulong %46
-%171 = OpFunctionCall %ulong %3 %169 %170
-OpStore %47 %171
-%172 = OpLoad %ulong %71
-%173 = OpLoad %ulong %40
-%174 = OpIAdd %ulong %172 %173
-OpStore %48 %174
-%175 = OpLoad %ulong %69
-%177 = OpIAdd %ulong %175 %ulong_1
-OpStore %49 %177
-%178 = OpLoad %ulong %47
-OpStore %66 %178
-%179 = OpLoad %ulong %49
-OpStore %69 %179
-%180 = OpLoad %ulong %48
-OpStore %71 %180
-OpBranch %14
-%9 = OpLabel
-%181 = OpLoad %ulong %70
-%183 = OpIMul %ulong %181 %ulong_131
-OpStore %23 %183
-%184 = OpLoad %ulong %23
-%185 = OpIAdd %ulong %184 %ulong_3
-OpStore %24 %185
-%186 = OpLoad %ulong %24
-%187 = OpLoad %ulong %18
-%188 = OpIAdd %ulong %186 %187
-OpStore %25 %188
-%189 = OpLoad %ulong %68
-%190 = OpLoad %ulong %25
-%191 = OpSDiv %ulong %189 %190
-OpStore %26 %191
-%192 = OpLoad %ulong %68
-%193 = OpLoad %ulong %25
-%194 = OpSRem %ulong %192 %193
-OpStore %27 %194
-%195 = OpLoad %ulong %67
-%196 = OpLoad %ulong %26
-%197 = OpFunctionCall %ulong %3 %195 %196
-OpStore %28 %197
-%198 = OpLoad %ulong %28
-%199 = OpLoad %ulong %27
-%200 = OpFunctionCall %ulong %3 %198 %199
-OpStore %29 %200
-%201 = OpLoad %ulong %25
-%202 = OpLoad %ulong %26
-%203 = OpIMul %ulong %201 %202
-OpStore %30 %203
-%204 = OpLoad %ulong %30
-%205 = OpLoad %ulong %27
-%206 = OpIAdd %ulong %204 %205
-OpStore %31 %206
-%207 = OpLoad %ulong %29
-%208 = OpLoad %ulong %31
-%209 = OpFunctionCall %ulong %3 %207 %208
-OpStore %32 %209
-%210 = OpLoad %ulong %68
-%211 = OpLoad %ulong %25
-%212 = OpISub %ulong %210 %211
-OpStore %33 %212
-%213 = OpLoad %ulong %70
-%214 = OpIAdd %ulong %213 %ulong_1
-OpStore %34 %214
-%215 = OpLoad %ulong %32
-OpStore %67 %215
-%216 = OpLoad %ulong %33
-OpStore %68 %216
-%217 = OpLoad %ulong %34
-OpStore %70 %217
-OpBranch %15
-%14 = OpLabel
-OpBranch %11
-%15 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %218
-%219 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %221
-%222 = OpFunctionParameter %ulong
-%223 = OpFunctionParameter %ulong
-%224 = OpLabel
+%ulong_1 = OpConstant %ulong 1
+%ulong_197 = OpConstant %ulong 197
+%ulong_5 = OpConstant %ulong 5
+%ulong_131 = OpConstant %ulong 131
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_bool Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_bool Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_bool Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_bool Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_bool Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_bool Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_bool Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_bool Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_bool Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
 %231 = OpVariable %_ptr_Function_ulong Function
 %232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_bool Function
+%233 = OpVariable %_ptr_Function_ulong Function
 %234 = OpVariable %_ptr_Function_ulong Function
 %235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_bool Function
 %237 = OpVariable %_ptr_Function_ulong Function
 %238 = OpVariable %_ptr_Function_ulong Function
 %239 = OpVariable %_ptr_Function_ulong Function
 %240 = OpVariable %_ptr_Function_ulong Function
 %241 = OpVariable %_ptr_Function_ulong Function
-OpStore %231 %222
-OpStore %232 %223
-OpBranch %225
-%225 = OpLabel
-%242 = OpLoad %ulong %231
-OpStore %240 %242
-OpStore %241 %ulong_0
-OpBranch %226
-%226 = OpLabel
-%243 = OpLoad %ulong %241
-%244 = OpULessThan %bool %243 %ulong_8
-OpStore %233 %244
-%245 = OpLoad %bool %233
-OpLoopMerge %228 %230 None
-OpBranchConditional %245 %227 %228
-%228 = OpLabel
-OpBranch %229
-%229 = OpLabel
-%246 = OpLoad %ulong %240
-OpReturnValue %246
-%227 = OpLabel
-%247 = OpLoad %ulong %241
-%248 = OpIMul %ulong %247 %ulong_8
-OpStore %234 %248
-%249 = OpLoad %ulong %232
-%250 = OpLoad %ulong %234
-%251 = OpShiftRightLogical %ulong %249 %250
-OpStore %235 %251
-%252 = OpLoad %ulong %235
-%254 = OpBitwiseAnd %ulong %252 %ulong_255
-OpStore %236 %254
-%255 = OpLoad %ulong %240
-%256 = OpLoad %ulong %236
-%257 = OpBitwiseXor %ulong %255 %256
-OpStore %237 %257
-%258 = OpLoad %ulong %237
-%260 = OpIMul %ulong %258 %ulong_1099511628211
-OpStore %238 %260
-%261 = OpLoad %ulong %241
-%262 = OpIAdd %ulong %261 %ulong_1
-OpStore %239 %262
-%263 = OpLoad %ulong %238
-OpStore %240 %263
-%264 = OpLoad %ulong %239
-OpStore %241 %264
-OpBranch %230
-%230 = OpLabel
-OpBranch %226
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_bool Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+OpStore %114 %4
+OpBranch %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%264 = OpLoad %ulong %114
+%265 = OpISub %ulong %ulong_9000000000000000000 %264
+OpStore %115 %265
+OpStore %150 %ulong_14695981039346656037
+%267 = OpLoad %ulong %115
+OpStore %151 %267
+OpStore %153 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%269 = OpLoad %ulong %153
+%271 = OpSLessThan %bool %269 %ulong_16
+OpStore %117 %271
+%272 = OpLoad %bool %117
+OpLoopMerge %8 %111 None
+OpBranchConditional %272 %7 %8
+%8 = OpLabel
+%273 = OpLoad %ulong %114
+%274 = OpIAdd %ulong %ulong_9000000000000000000 %273
+OpStore %127 %274
+%275 = OpLoad %ulong %127
+%276 = OpISub %ulong %ulong_0 %275
+OpStore %128 %276
+%277 = OpLoad %ulong %150
+OpStore %149 %277
+OpStore %152 %ulong_0
+%278 = OpLoad %ulong %128
+OpStore %154 %278
+OpBranch %9
+%9 = OpLabel
+%279 = OpLoad %ulong %152
+%281 = OpSLessThan %bool %279 %ulong_8
+OpStore %129 %281
+%282 = OpLoad %bool %129
+OpLoopMerge %11 %110 None
+OpBranchConditional %282 %10 %11
+%11 = OpLabel
+%284 = OpLoad %ulong %114
+%285 = OpIAdd %ulong %ulong_9223372036854775804 %284
+OpStore %139 %285
+%287 = OpLoad %ulong %114
+%288 = OpIAdd %ulong %ulong_3 %287
+OpStore %140 %288
+%289 = OpLoad %ulong %139
+%290 = OpLoad %ulong %140
+%291 = OpSDiv %ulong %289 %290
+OpStore %141 %291
+%292 = OpLoad %ulong %139
+%293 = OpLoad %ulong %140
+%294 = OpSRem %ulong %292 %293
+OpStore %142 %294
+OpBranch %18
+%18 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%295 = OpLoad %ulong %149
+OpStore %180 %295
+OpStore %181 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%296 = OpLoad %ulong %181
+%297 = OpULessThan %bool %296 %ulong_8
+OpStore %173 %297
+%298 = OpLoad %bool %173
+OpLoopMerge %37 %108 None
+OpBranchConditional %298 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%299 = OpLoad %ulong %180
+OpStore %207 %299
+OpStore %208 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%300 = OpLoad %ulong %208
+%301 = OpULessThan %bool %300 %ulong_8
+OpStore %200 %301
+%302 = OpLoad %bool %200
+OpLoopMerge %58 %105 None
+OpBranchConditional %302 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%303 = OpLoad %ulong %140
+%304 = OpLoad %ulong %141
+%305 = OpIMul %ulong %303 %304
+OpStore %143 %305
+%306 = OpLoad %ulong %143
+%307 = OpLoad %ulong %142
+%308 = OpIAdd %ulong %306 %307
+OpStore %144 %308
+OpBranch %60
+%60 = OpLabel
+OpBranch %72
+%72 = OpLabel
+%309 = OpLoad %ulong %207
+OpStore %234 %309
+OpStore %235 %ulong_0
+OpBranch %73
+%73 = OpLabel
+%310 = OpLoad %ulong %235
+%311 = OpULessThan %bool %310 %ulong_8
+OpStore %227 %311
+%312 = OpLoad %bool %227
+OpLoopMerge %75 %102 None
+OpBranchConditional %312 %74 %75
+%75 = OpLabel
+OpBranch %76
+%76 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%313 = OpLoad %ulong %140
+%314 = OpLoad %ulong %139
+%315 = OpSDiv %ulong %313 %314
+OpStore %145 %315
+%316 = OpLoad %ulong %140
+%317 = OpLoad %ulong %139
+%318 = OpSRem %ulong %316 %317
+OpStore %146 %318
+OpBranch %77
+%77 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%319 = OpLoad %ulong %234
+OpStore %243 %319
+OpStore %244 %ulong_0
+OpBranch %80
+%80 = OpLabel
+%320 = OpLoad %ulong %244
+%321 = OpULessThan %bool %320 %ulong_8
+OpStore %236 %321
+%322 = OpLoad %bool %236
+OpLoopMerge %82 %100 None
+OpBranchConditional %322 %81 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+OpBranch %78
+%78 = OpLabel
+OpBranch %84
+%84 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%323 = OpLoad %ulong %243
+OpStore %252 %323
+OpStore %253 %ulong_0
+OpBranch %87
+%87 = OpLabel
+%324 = OpLoad %ulong %253
+%325 = OpULessThan %bool %324 %ulong_8
+OpStore %245 %325
+%326 = OpLoad %bool %245
+OpLoopMerge %89 %99 None
+OpBranchConditional %326 %88 %89
+%89 = OpLabel
+OpBranch %90
+%90 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%327 = OpLoad %ulong %139
+%328 = OpLoad %ulong %145
+%329 = OpIMul %ulong %327 %328
+OpStore %147 %329
+%330 = OpLoad %ulong %147
+%331 = OpLoad %ulong %146
+%332 = OpIAdd %ulong %330 %331
+OpStore %148 %332
+OpBranch %91
+%91 = OpLabel
+OpBranch %93
+%93 = OpLabel
+%333 = OpLoad %ulong %252
+OpStore %261 %333
+OpStore %262 %ulong_0
+OpBranch %94
+%94 = OpLabel
+%334 = OpLoad %ulong %262
+%335 = OpULessThan %bool %334 %ulong_8
+OpStore %254 %335
+%336 = OpLoad %bool %254
+OpLoopMerge %96 %98 None
+OpBranchConditional %336 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%337 = OpLoad %ulong %261
+OpReturnValue %337
+%95 = OpLabel
+%338 = OpLoad %ulong %262
+%339 = OpIMul %ulong %338 %ulong_8
+OpStore %255 %339
+%340 = OpLoad %ulong %148
+%341 = OpLoad %ulong %255
+%342 = OpShiftRightLogical %ulong %340 %341
+OpStore %256 %342
+%343 = OpLoad %ulong %256
+%345 = OpBitwiseAnd %ulong %343 %ulong_255
+OpStore %257 %345
+%346 = OpLoad %ulong %261
+%347 = OpLoad %ulong %257
+%348 = OpBitwiseXor %ulong %346 %347
+OpStore %258 %348
+%349 = OpLoad %ulong %258
+%351 = OpIMul %ulong %349 %ulong_1099511628211
+OpStore %259 %351
+%352 = OpLoad %ulong %262
+%354 = OpIAdd %ulong %352 %ulong_1
+OpStore %260 %354
+%355 = OpLoad %ulong %259
+OpStore %261 %355
+%356 = OpLoad %ulong %260
+OpStore %262 %356
+OpBranch %98
+%88 = OpLabel
+%357 = OpLoad %ulong %253
+%358 = OpIMul %ulong %357 %ulong_8
+OpStore %246 %358
+%359 = OpLoad %ulong %146
+%360 = OpLoad %ulong %246
+%361 = OpShiftRightLogical %ulong %359 %360
+OpStore %247 %361
+%362 = OpLoad %ulong %247
+%363 = OpBitwiseAnd %ulong %362 %ulong_255
+OpStore %248 %363
+%364 = OpLoad %ulong %252
+%365 = OpLoad %ulong %248
+%366 = OpBitwiseXor %ulong %364 %365
+OpStore %249 %366
+%367 = OpLoad %ulong %249
+%368 = OpIMul %ulong %367 %ulong_1099511628211
+OpStore %250 %368
+%369 = OpLoad %ulong %253
+%370 = OpIAdd %ulong %369 %ulong_1
+OpStore %251 %370
+%371 = OpLoad %ulong %250
+OpStore %252 %371
+%372 = OpLoad %ulong %251
+OpStore %253 %372
+OpBranch %99
+%81 = OpLabel
+%373 = OpLoad %ulong %244
+%374 = OpIMul %ulong %373 %ulong_8
+OpStore %237 %374
+%375 = OpLoad %ulong %145
+%376 = OpLoad %ulong %237
+%377 = OpShiftRightLogical %ulong %375 %376
+OpStore %238 %377
+%378 = OpLoad %ulong %238
+%379 = OpBitwiseAnd %ulong %378 %ulong_255
+OpStore %239 %379
+%380 = OpLoad %ulong %243
+%381 = OpLoad %ulong %239
+%382 = OpBitwiseXor %ulong %380 %381
+OpStore %240 %382
+%383 = OpLoad %ulong %240
+%384 = OpIMul %ulong %383 %ulong_1099511628211
+OpStore %241 %384
+%385 = OpLoad %ulong %244
+%386 = OpIAdd %ulong %385 %ulong_1
+OpStore %242 %386
+%387 = OpLoad %ulong %241
+OpStore %243 %387
+%388 = OpLoad %ulong %242
+OpStore %244 %388
+OpBranch %100
+%74 = OpLabel
+%389 = OpLoad %ulong %235
+%390 = OpIMul %ulong %389 %ulong_8
+OpStore %228 %390
+%391 = OpLoad %ulong %144
+%392 = OpLoad %ulong %228
+%393 = OpShiftRightLogical %ulong %391 %392
+OpStore %229 %393
+%394 = OpLoad %ulong %229
+%395 = OpBitwiseAnd %ulong %394 %ulong_255
+OpStore %230 %395
+%396 = OpLoad %ulong %234
+%397 = OpLoad %ulong %230
+%398 = OpBitwiseXor %ulong %396 %397
+OpStore %231 %398
+%399 = OpLoad %ulong %231
+%400 = OpIMul %ulong %399 %ulong_1099511628211
+OpStore %232 %400
+%401 = OpLoad %ulong %235
+%402 = OpIAdd %ulong %401 %ulong_1
+OpStore %233 %402
+%403 = OpLoad %ulong %232
+OpStore %234 %403
+%404 = OpLoad %ulong %233
+OpStore %235 %404
+OpBranch %102
+%57 = OpLabel
+%405 = OpLoad %ulong %208
+%406 = OpIMul %ulong %405 %ulong_8
+OpStore %201 %406
+%407 = OpLoad %ulong %142
+%408 = OpLoad %ulong %201
+%409 = OpShiftRightLogical %ulong %407 %408
+OpStore %202 %409
+%410 = OpLoad %ulong %202
+%411 = OpBitwiseAnd %ulong %410 %ulong_255
+OpStore %203 %411
+%412 = OpLoad %ulong %207
+%413 = OpLoad %ulong %203
+%414 = OpBitwiseXor %ulong %412 %413
+OpStore %204 %414
+%415 = OpLoad %ulong %204
+%416 = OpIMul %ulong %415 %ulong_1099511628211
+OpStore %205 %416
+%417 = OpLoad %ulong %208
+%418 = OpIAdd %ulong %417 %ulong_1
+OpStore %206 %418
+%419 = OpLoad %ulong %205
+OpStore %207 %419
+%420 = OpLoad %ulong %206
+OpStore %208 %420
+OpBranch %105
+%36 = OpLabel
+%421 = OpLoad %ulong %181
+%422 = OpIMul %ulong %421 %ulong_8
+OpStore %174 %422
+%423 = OpLoad %ulong %141
+%424 = OpLoad %ulong %174
+%425 = OpShiftRightLogical %ulong %423 %424
+OpStore %175 %425
+%426 = OpLoad %ulong %175
+%427 = OpBitwiseAnd %ulong %426 %ulong_255
+OpStore %176 %427
+%428 = OpLoad %ulong %180
+%429 = OpLoad %ulong %176
+%430 = OpBitwiseXor %ulong %428 %429
+OpStore %177 %430
+%431 = OpLoad %ulong %177
+%432 = OpIMul %ulong %431 %ulong_1099511628211
+OpStore %178 %432
+%433 = OpLoad %ulong %181
+%434 = OpIAdd %ulong %433 %ulong_1
+OpStore %179 %434
+%435 = OpLoad %ulong %178
+OpStore %180 %435
+%436 = OpLoad %ulong %179
+OpStore %181 %436
+OpBranch %108
+%10 = OpLabel
+%437 = OpLoad %ulong %152
+%439 = OpIMul %ulong %437 %ulong_197
+OpStore %130 %439
+%440 = OpLoad %ulong %130
+%442 = OpIAdd %ulong %440 %ulong_5
+OpStore %131 %442
+%443 = OpLoad %ulong %131
+%444 = OpLoad %ulong %114
+%445 = OpIAdd %ulong %443 %444
+OpStore %132 %445
+%446 = OpLoad %ulong %154
+%447 = OpLoad %ulong %132
+%448 = OpSDiv %ulong %446 %447
+OpStore %133 %448
+%449 = OpLoad %ulong %154
+%450 = OpLoad %ulong %132
+%451 = OpSRem %ulong %449 %450
+OpStore %134 %451
+OpBranch %16
+%16 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%452 = OpLoad %ulong %149
+OpStore %171 %452
+OpStore %172 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%453 = OpLoad %ulong %172
+%454 = OpULessThan %bool %453 %ulong_8
+OpStore %164 %454
+%455 = OpLoad %bool %164
+OpLoopMerge %30 %107 None
+OpBranchConditional %455 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %17
+%17 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%456 = OpLoad %ulong %171
+OpStore %198 %456
+OpStore %199 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%457 = OpLoad %ulong %199
+%458 = OpULessThan %bool %457 %ulong_8
+OpStore %191 %458
+%459 = OpLoad %bool %191
+OpLoopMerge %51 %104 None
+OpBranchConditional %459 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%460 = OpLoad %ulong %132
+%461 = OpLoad %ulong %133
+%462 = OpIMul %ulong %460 %461
+OpStore %135 %462
+%463 = OpLoad %ulong %135
+%464 = OpLoad %ulong %134
+%465 = OpIAdd %ulong %463 %464
+OpStore %136 %465
+OpBranch %53
+%53 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%466 = OpLoad %ulong %198
+OpStore %225 %466
+OpStore %226 %ulong_0
+OpBranch %68
+%68 = OpLabel
+%467 = OpLoad %ulong %226
+%468 = OpULessThan %bool %467 %ulong_8
+OpStore %218 %468
+%469 = OpLoad %bool %218
+OpLoopMerge %70 %101 None
+OpBranchConditional %469 %69 %70
+%70 = OpLabel
+OpBranch %71
+%71 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%470 = OpLoad %ulong %154
+%471 = OpLoad %ulong %132
+%472 = OpIAdd %ulong %470 %471
+OpStore %137 %472
+%473 = OpLoad %ulong %152
+%474 = OpIAdd %ulong %473 %ulong_1
+OpStore %138 %474
+%475 = OpLoad %ulong %225
+OpStore %149 %475
+%476 = OpLoad %ulong %138
+OpStore %152 %476
+%477 = OpLoad %ulong %137
+OpStore %154 %477
+OpBranch %110
+%69 = OpLabel
+%478 = OpLoad %ulong %226
+%479 = OpIMul %ulong %478 %ulong_8
+OpStore %219 %479
+%480 = OpLoad %ulong %136
+%481 = OpLoad %ulong %219
+%482 = OpShiftRightLogical %ulong %480 %481
+OpStore %220 %482
+%483 = OpLoad %ulong %220
+%484 = OpBitwiseAnd %ulong %483 %ulong_255
+OpStore %221 %484
+%485 = OpLoad %ulong %225
+%486 = OpLoad %ulong %221
+%487 = OpBitwiseXor %ulong %485 %486
+OpStore %222 %487
+%488 = OpLoad %ulong %222
+%489 = OpIMul %ulong %488 %ulong_1099511628211
+OpStore %223 %489
+%490 = OpLoad %ulong %226
+%491 = OpIAdd %ulong %490 %ulong_1
+OpStore %224 %491
+%492 = OpLoad %ulong %223
+OpStore %225 %492
+%493 = OpLoad %ulong %224
+OpStore %226 %493
+OpBranch %101
+%50 = OpLabel
+%494 = OpLoad %ulong %199
+%495 = OpIMul %ulong %494 %ulong_8
+OpStore %192 %495
+%496 = OpLoad %ulong %134
+%497 = OpLoad %ulong %192
+%498 = OpShiftRightLogical %ulong %496 %497
+OpStore %193 %498
+%499 = OpLoad %ulong %193
+%500 = OpBitwiseAnd %ulong %499 %ulong_255
+OpStore %194 %500
+%501 = OpLoad %ulong %198
+%502 = OpLoad %ulong %194
+%503 = OpBitwiseXor %ulong %501 %502
+OpStore %195 %503
+%504 = OpLoad %ulong %195
+%505 = OpIMul %ulong %504 %ulong_1099511628211
+OpStore %196 %505
+%506 = OpLoad %ulong %199
+%507 = OpIAdd %ulong %506 %ulong_1
+OpStore %197 %507
+%508 = OpLoad %ulong %196
+OpStore %198 %508
+%509 = OpLoad %ulong %197
+OpStore %199 %509
+OpBranch %104
+%29 = OpLabel
+%510 = OpLoad %ulong %172
+%511 = OpIMul %ulong %510 %ulong_8
+OpStore %165 %511
+%512 = OpLoad %ulong %133
+%513 = OpLoad %ulong %165
+%514 = OpShiftRightLogical %ulong %512 %513
+OpStore %166 %514
+%515 = OpLoad %ulong %166
+%516 = OpBitwiseAnd %ulong %515 %ulong_255
+OpStore %167 %516
+%517 = OpLoad %ulong %171
+%518 = OpLoad %ulong %167
+%519 = OpBitwiseXor %ulong %517 %518
+OpStore %168 %519
+%520 = OpLoad %ulong %168
+%521 = OpIMul %ulong %520 %ulong_1099511628211
+OpStore %169 %521
+%522 = OpLoad %ulong %172
+%523 = OpIAdd %ulong %522 %ulong_1
+OpStore %170 %523
+%524 = OpLoad %ulong %169
+OpStore %171 %524
+%525 = OpLoad %ulong %170
+OpStore %172 %525
+OpBranch %107
+%7 = OpLabel
+%526 = OpLoad %ulong %153
+%528 = OpIMul %ulong %526 %ulong_131
+OpStore %118 %528
+%529 = OpLoad %ulong %118
+%530 = OpIAdd %ulong %529 %ulong_3
+OpStore %119 %530
+%531 = OpLoad %ulong %119
+%532 = OpLoad %ulong %114
+%533 = OpIAdd %ulong %531 %532
+OpStore %120 %533
+%534 = OpLoad %ulong %151
+%535 = OpLoad %ulong %120
+%536 = OpSDiv %ulong %534 %535
+OpStore %121 %536
+%537 = OpLoad %ulong %151
+%538 = OpLoad %ulong %120
+%539 = OpSRem %ulong %537 %538
+OpStore %122 %539
+OpBranch %14
+%14 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%540 = OpLoad %ulong %150
+OpStore %162 %540
+OpStore %163 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%541 = OpLoad %ulong %163
+%542 = OpULessThan %bool %541 %ulong_8
+OpStore %155 %542
+%543 = OpLoad %bool %155
+OpLoopMerge %23 %109 None
+OpBranchConditional %543 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%544 = OpLoad %ulong %162
+OpStore %189 %544
+OpStore %190 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%545 = OpLoad %ulong %190
+%546 = OpULessThan %bool %545 %ulong_8
+OpStore %182 %546
+%547 = OpLoad %bool %182
+OpLoopMerge %44 %106 None
+OpBranchConditional %547 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%548 = OpLoad %ulong %120
+%549 = OpLoad %ulong %121
+%550 = OpIMul %ulong %548 %549
+OpStore %123 %550
+%551 = OpLoad %ulong %123
+%552 = OpLoad %ulong %122
+%553 = OpIAdd %ulong %551 %552
+OpStore %124 %553
+OpBranch %46
+%46 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%554 = OpLoad %ulong %189
+OpStore %216 %554
+OpStore %217 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%555 = OpLoad %ulong %217
+%556 = OpULessThan %bool %555 %ulong_8
+OpStore %209 %556
+%557 = OpLoad %bool %209
+OpLoopMerge %65 %103 None
+OpBranchConditional %557 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%558 = OpLoad %ulong %151
+%559 = OpLoad %ulong %120
+%560 = OpISub %ulong %558 %559
+OpStore %125 %560
+%561 = OpLoad %ulong %153
+%562 = OpIAdd %ulong %561 %ulong_1
+OpStore %126 %562
+%563 = OpLoad %ulong %216
+OpStore %150 %563
+%564 = OpLoad %ulong %125
+OpStore %151 %564
+%565 = OpLoad %ulong %126
+OpStore %153 %565
+OpBranch %111
+%64 = OpLabel
+%566 = OpLoad %ulong %217
+%567 = OpIMul %ulong %566 %ulong_8
+OpStore %210 %567
+%568 = OpLoad %ulong %124
+%569 = OpLoad %ulong %210
+%570 = OpShiftRightLogical %ulong %568 %569
+OpStore %211 %570
+%571 = OpLoad %ulong %211
+%572 = OpBitwiseAnd %ulong %571 %ulong_255
+OpStore %212 %572
+%573 = OpLoad %ulong %216
+%574 = OpLoad %ulong %212
+%575 = OpBitwiseXor %ulong %573 %574
+OpStore %213 %575
+%576 = OpLoad %ulong %213
+%577 = OpIMul %ulong %576 %ulong_1099511628211
+OpStore %214 %577
+%578 = OpLoad %ulong %217
+%579 = OpIAdd %ulong %578 %ulong_1
+OpStore %215 %579
+%580 = OpLoad %ulong %214
+OpStore %216 %580
+%581 = OpLoad %ulong %215
+OpStore %217 %581
+OpBranch %103
+%43 = OpLabel
+%582 = OpLoad %ulong %190
+%583 = OpIMul %ulong %582 %ulong_8
+OpStore %183 %583
+%584 = OpLoad %ulong %122
+%585 = OpLoad %ulong %183
+%586 = OpShiftRightLogical %ulong %584 %585
+OpStore %184 %586
+%587 = OpLoad %ulong %184
+%588 = OpBitwiseAnd %ulong %587 %ulong_255
+OpStore %185 %588
+%589 = OpLoad %ulong %189
+%590 = OpLoad %ulong %185
+%591 = OpBitwiseXor %ulong %589 %590
+OpStore %186 %591
+%592 = OpLoad %ulong %186
+%593 = OpIMul %ulong %592 %ulong_1099511628211
+OpStore %187 %593
+%594 = OpLoad %ulong %190
+%595 = OpIAdd %ulong %594 %ulong_1
+OpStore %188 %595
+%596 = OpLoad %ulong %187
+OpStore %189 %596
+%597 = OpLoad %ulong %188
+OpStore %190 %597
+OpBranch %106
+%22 = OpLabel
+%598 = OpLoad %ulong %163
+%599 = OpIMul %ulong %598 %ulong_8
+OpStore %156 %599
+%600 = OpLoad %ulong %121
+%601 = OpLoad %ulong %156
+%602 = OpShiftRightLogical %ulong %600 %601
+OpStore %157 %602
+%603 = OpLoad %ulong %157
+%604 = OpBitwiseAnd %ulong %603 %ulong_255
+OpStore %158 %604
+%605 = OpLoad %ulong %162
+%606 = OpLoad %ulong %158
+%607 = OpBitwiseXor %ulong %605 %606
+OpStore %159 %607
+%608 = OpLoad %ulong %159
+%609 = OpIMul %ulong %608 %ulong_1099511628211
+OpStore %160 %609
+%610 = OpLoad %ulong %163
+%611 = OpIAdd %ulong %610 %ulong_1
+OpStore %161 %611
+%612 = OpLoad %ulong %160
+OpStore %162 %612
+%613 = OpLoad %ulong %161
+OpStore %163 %613
+OpBranch %109
+%98 = OpLabel
+OpBranch %94
+%99 = OpLabel
+OpBranch %87
+%100 = OpLabel
+OpBranch %80
+%101 = OpLabel
+OpBranch %68
+%102 = OpLabel
+OpBranch %73
+%103 = OpLabel
+OpBranch %63
+%104 = OpLabel
+OpBranch %49
+%105 = OpLabel
+OpBranch %56
+%106 = OpLabel
+OpBranch %42
+%107 = OpLabel
+OpBranch %28
+%108 = OpLabel
+OpBranch %35
+%109 = OpLabel
+OpBranch %21
+%110 = OpLabel
+OpBranch %9
+%111 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/divrem_u32.dis
+++ b/test/golden/spirv/scalar/divrem_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 206
+; Bound: 480
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,278 +9,708 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.divrem_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_4294967295 = OpConstant %uint 4294967295
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_16 = OpConstant %uint 16
 %uint_4294967293 = OpConstant %uint 4294967293
 %uint_3 = OpConstant %uint 3
-%uint_131 = OpConstant %uint 131
-%uint_1 = OpConstant %uint 1
-%153 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%156 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_bool Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_uint Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_uint Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uint Function
-%41 = OpVariable %_ptr_Function_uint Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uint Function
-%44 = OpVariable %_ptr_Function_uint Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uint Function
-%48 = OpVariable %_ptr_Function_uint Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uint Function
-%52 = OpVariable %_ptr_Function_uint Function
-OpStore %15 %6
-%53 = OpFunctionCall %ulong %2
-OpStore %16 %53
-%54 = OpLoad %ulong %15
-%55 = OpUConvert %uint %54
-OpStore %18 %55
-%57 = OpLoad %uint %18
-%58 = OpISub %uint %uint_4294967295 %57
-OpStore %19 %58
-%59 = OpLoad %ulong %16
-OpStore %50 %59
-%60 = OpLoad %uint %19
-OpStore %51 %60
-OpStore %52 %uint_0
-OpBranch %8
-%8 = OpLabel
-%62 = OpLoad %uint %52
-%64 = OpULessThan %bool %62 %uint_16
-OpStore %21 %64
-%65 = OpLoad %bool %21
-OpLoopMerge %10 %11 None
-OpBranchConditional %65 %9 %10
-%10 = OpLabel
-%67 = OpLoad %uint %18
-%68 = OpIAdd %uint %uint_4294967293 %67
-OpStore %34 %68
-%70 = OpLoad %uint %18
-%71 = OpIAdd %uint %uint_3 %70
-OpStore %35 %71
-%72 = OpLoad %uint %34
-%73 = OpLoad %uint %35
-%74 = OpUDiv %uint %72 %73
-OpStore %36 %74
-%75 = OpLoad %uint %34
-%76 = OpLoad %uint %35
-%77 = OpUMod %uint %75 %76
-OpStore %37 %77
-%78 = OpLoad %ulong %50
-%79 = OpLoad %uint %36
-%80 = OpFunctionCall %ulong %3 %78 %79
-OpStore %38 %80
-%81 = OpLoad %ulong %38
-%82 = OpLoad %uint %37
-%83 = OpFunctionCall %ulong %3 %81 %82
-OpStore %39 %83
-%84 = OpLoad %uint %35
-%85 = OpLoad %uint %36
-%86 = OpIMul %uint %84 %85
-OpStore %40 %86
-%87 = OpLoad %uint %40
-%88 = OpLoad %uint %37
-%89 = OpIAdd %uint %87 %88
-OpStore %41 %89
-%90 = OpLoad %ulong %39
-%91 = OpLoad %uint %41
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %42 %92
-%93 = OpLoad %uint %35
-%94 = OpLoad %uint %34
-%95 = OpUDiv %uint %93 %94
-OpStore %43 %95
-%96 = OpLoad %uint %35
-%97 = OpLoad %uint %34
-%98 = OpUMod %uint %96 %97
-OpStore %44 %98
-%99 = OpLoad %ulong %42
-%100 = OpLoad %uint %43
-%101 = OpFunctionCall %ulong %3 %99 %100
-OpStore %45 %101
-%102 = OpLoad %ulong %45
-%103 = OpLoad %uint %44
-%104 = OpFunctionCall %ulong %3 %102 %103
-OpStore %46 %104
-%105 = OpLoad %uint %34
-%106 = OpLoad %uint %43
-%107 = OpIMul %uint %105 %106
-OpStore %47 %107
-%108 = OpLoad %uint %47
-%109 = OpLoad %uint %44
-%110 = OpIAdd %uint %108 %109
-OpStore %48 %110
-%111 = OpLoad %ulong %46
-%112 = OpLoad %uint %48
-%113 = OpFunctionCall %ulong %3 %111 %112
-OpStore %49 %113
-%114 = OpLoad %ulong %49
-OpReturnValue %114
-%9 = OpLabel
-%115 = OpLoad %uint %52
-%117 = OpIMul %uint %115 %uint_131
-OpStore %22 %117
-%118 = OpLoad %uint %22
-%119 = OpIAdd %uint %118 %uint_3
-OpStore %23 %119
-%120 = OpLoad %uint %23
-%121 = OpLoad %uint %18
-%122 = OpIAdd %uint %120 %121
-OpStore %24 %122
-%123 = OpLoad %uint %51
-%124 = OpLoad %uint %24
-%125 = OpUDiv %uint %123 %124
-OpStore %25 %125
-%126 = OpLoad %uint %51
-%127 = OpLoad %uint %24
-%128 = OpUMod %uint %126 %127
-OpStore %26 %128
-%129 = OpLoad %ulong %50
-%130 = OpLoad %uint %25
-%131 = OpFunctionCall %ulong %3 %129 %130
-OpStore %27 %131
-%132 = OpLoad %ulong %27
-%133 = OpLoad %uint %26
-%134 = OpFunctionCall %ulong %3 %132 %133
-OpStore %28 %134
-%135 = OpLoad %uint %24
-%136 = OpLoad %uint %25
-%137 = OpIMul %uint %135 %136
-OpStore %29 %137
-%138 = OpLoad %uint %29
-%139 = OpLoad %uint %26
-%140 = OpIAdd %uint %138 %139
-OpStore %30 %140
-%141 = OpLoad %ulong %28
-%142 = OpLoad %uint %30
-%143 = OpFunctionCall %ulong %3 %141 %142
-OpStore %31 %143
-%144 = OpLoad %uint %51
-%145 = OpLoad %uint %24
-%146 = OpISub %uint %144 %145
-OpStore %32 %146
-%147 = OpLoad %uint %52
-%149 = OpIAdd %uint %147 %uint_1
-OpStore %33 %149
-%150 = OpLoad %ulong %31
-OpStore %50 %150
-%151 = OpLoad %uint %32
-OpStore %51 %151
-%152 = OpLoad %uint %33
-OpStore %52 %152
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %153
-%154 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %156
-%157 = OpFunctionParameter %ulong
-%158 = OpFunctionParameter %uint
-%159 = OpLabel
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_uint Function
+%uint_131 = OpConstant %uint 131
+%uint_1 = OpConstant %uint 1
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%87 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_uint Function
+%90 = OpVariable %_ptr_Function_uint Function
+%92 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_uint Function
+%94 = OpVariable %_ptr_Function_uint Function
+%95 = OpVariable %_ptr_Function_uint Function
+%96 = OpVariable %_ptr_Function_uint Function
+%97 = OpVariable %_ptr_Function_uint Function
+%98 = OpVariable %_ptr_Function_uint Function
+%99 = OpVariable %_ptr_Function_uint Function
+%100 = OpVariable %_ptr_Function_uint Function
+%101 = OpVariable %_ptr_Function_uint Function
+%102 = OpVariable %_ptr_Function_uint Function
+%103 = OpVariable %_ptr_Function_uint Function
+%104 = OpVariable %_ptr_Function_uint Function
+%105 = OpVariable %_ptr_Function_uint Function
+%106 = OpVariable %_ptr_Function_uint Function
+%107 = OpVariable %_ptr_Function_uint Function
+%108 = OpVariable %_ptr_Function_uint Function
+%109 = OpVariable %_ptr_Function_uint Function
+%110 = OpVariable %_ptr_Function_uint Function
+%111 = OpVariable %_ptr_Function_uint Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_uint Function
+%114 = OpVariable %_ptr_Function_uint Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_bool Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_bool Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_bool Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_bool Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_bool Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
 %170 = OpVariable %_ptr_Function_ulong Function
 %171 = OpVariable %_ptr_Function_ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
 %173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
 %175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_bool Function
 %177 = OpVariable %_ptr_Function_ulong Function
-OpStore %166 %157
-OpStore %167 %158
-%178 = OpLoad %uint %167
-%179 = OpUConvert %ulong %178
-OpStore %168 %179
-OpBranch %160
-%160 = OpLabel
-%180 = OpLoad %ulong %166
-OpStore %176 %180
-OpStore %177 %ulong_0
-OpBranch %161
-%161 = OpLabel
-%182 = OpLoad %ulong %177
-%184 = OpULessThan %bool %182 %ulong_8
-OpStore %169 %184
-%185 = OpLoad %bool %169
-OpLoopMerge %163 %165 None
-OpBranchConditional %185 %162 %163
-%163 = OpLabel
-OpBranch %164
-%164 = OpLabel
-%186 = OpLoad %ulong %176
-OpReturnValue %186
-%162 = OpLabel
-%187 = OpLoad %ulong %177
-%188 = OpIMul %ulong %187 %ulong_8
-OpStore %170 %188
-%189 = OpLoad %ulong %168
-%190 = OpLoad %ulong %170
-%191 = OpShiftRightLogical %ulong %189 %190
-OpStore %171 %191
-%192 = OpLoad %ulong %171
-%194 = OpBitwiseAnd %ulong %192 %ulong_255
-OpStore %172 %194
-%195 = OpLoad %ulong %176
-%196 = OpLoad %ulong %172
-%197 = OpBitwiseXor %ulong %195 %196
-OpStore %173 %197
-%198 = OpLoad %ulong %173
-%200 = OpIMul %ulong %198 %ulong_1099511628211
-OpStore %174 %200
-%201 = OpLoad %ulong %177
-%203 = OpIAdd %ulong %201 %ulong_1
-OpStore %175 %203
-%204 = OpLoad %ulong %174
-OpStore %176 %204
-%205 = OpLoad %ulong %175
-OpStore %177 %205
-OpBranch %165
-%165 = OpLabel
-OpBranch %161
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_bool Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+OpStore %87 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%205 = OpLoad %ulong %87
+%206 = OpUConvert %uint %205
+OpStore %89 %206
+%208 = OpLoad %uint %89
+%209 = OpISub %uint %uint_4294967295 %208
+OpStore %90 %209
+OpStore %112 %ulong_14695981039346656037
+%211 = OpLoad %uint %90
+OpStore %113 %211
+OpStore %114 %uint_0
+OpBranch %6
+%6 = OpLabel
+%213 = OpLoad %uint %114
+%215 = OpULessThan %bool %213 %uint_16
+OpStore %92 %215
+%216 = OpLoad %bool %92
+OpLoopMerge %8 %83 None
+OpBranchConditional %216 %7 %8
+%8 = OpLabel
+%218 = OpLoad %uint %89
+%219 = OpIAdd %uint %uint_4294967293 %218
+OpStore %102 %219
+%221 = OpLoad %uint %89
+%222 = OpIAdd %uint %uint_3 %221
+OpStore %103 %222
+%223 = OpLoad %uint %102
+%224 = OpLoad %uint %103
+%225 = OpUDiv %uint %223 %224
+OpStore %104 %225
+%226 = OpLoad %uint %102
+%227 = OpLoad %uint %103
+%228 = OpUMod %uint %226 %227
+OpStore %105 %228
+OpBranch %13
+%13 = OpLabel
+%229 = OpLoad %uint %104
+%230 = OpUConvert %ulong %229
+OpStore %116 %230
+OpBranch %22
+%22 = OpLabel
+%231 = OpLoad %ulong %112
+OpStore %134 %231
+OpStore %135 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%233 = OpLoad %ulong %135
+%235 = OpULessThan %bool %233 %ulong_8
+OpStore %127 %235
+%236 = OpLoad %bool %127
+OpLoopMerge %25 %82 None
+OpBranchConditional %236 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %14
+%14 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%237 = OpLoad %uint %105
+%238 = OpUConvert %ulong %237
+OpStore %136 %238
+OpBranch %36
+%36 = OpLabel
+%239 = OpLoad %ulong %134
+OpStore %154 %239
+OpStore %155 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%240 = OpLoad %ulong %155
+%241 = OpULessThan %bool %240 %ulong_8
+OpStore %147 %241
+%242 = OpLoad %bool %147
+OpLoopMerge %39 %80 None
+OpBranchConditional %242 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%243 = OpLoad %uint %103
+%244 = OpLoad %uint %104
+%245 = OpIMul %uint %243 %244
+OpStore %106 %245
+%246 = OpLoad %uint %106
+%247 = OpLoad %uint %105
+%248 = OpIAdd %uint %246 %247
+OpStore %107 %248
+OpBranch %41
+%41 = OpLabel
+%249 = OpLoad %uint %107
+%250 = OpUConvert %ulong %249
+OpStore %156 %250
+OpBranch %48
+%48 = OpLabel
+%251 = OpLoad %ulong %154
+OpStore %173 %251
+OpStore %174 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%252 = OpLoad %ulong %174
+%253 = OpULessThan %bool %252 %ulong_8
+OpStore %166 %253
+%254 = OpLoad %bool %166
+OpLoopMerge %51 %78 None
+OpBranchConditional %254 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%255 = OpLoad %uint %103
+%256 = OpLoad %uint %102
+%257 = OpUDiv %uint %255 %256
+OpStore %108 %257
+%258 = OpLoad %uint %103
+%259 = OpLoad %uint %102
+%260 = OpUMod %uint %258 %259
+OpStore %109 %260
+OpBranch %53
+%53 = OpLabel
+%261 = OpLoad %uint %108
+%262 = OpUConvert %ulong %261
+OpStore %175 %262
+OpBranch %55
+%55 = OpLabel
+%263 = OpLoad %ulong %173
+OpStore %183 %263
+OpStore %184 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%264 = OpLoad %ulong %184
+%265 = OpULessThan %bool %264 %ulong_8
+OpStore %176 %265
+%266 = OpLoad %bool %176
+OpLoopMerge %58 %76 None
+OpBranchConditional %266 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+OpBranch %60
+%60 = OpLabel
+%267 = OpLoad %uint %109
+%268 = OpUConvert %ulong %267
+OpStore %185 %268
+OpBranch %62
+%62 = OpLabel
+%269 = OpLoad %ulong %183
+OpStore %193 %269
+OpStore %194 %ulong_0
+OpBranch %63
+%63 = OpLabel
+%270 = OpLoad %ulong %194
+%271 = OpULessThan %bool %270 %ulong_8
+OpStore %186 %271
+%272 = OpLoad %bool %186
+OpLoopMerge %65 %75 None
+OpBranchConditional %272 %64 %65
+%65 = OpLabel
+OpBranch %66
+%66 = OpLabel
+OpBranch %61
+%61 = OpLabel
+%273 = OpLoad %uint %102
+%274 = OpLoad %uint %108
+%275 = OpIMul %uint %273 %274
+OpStore %110 %275
+%276 = OpLoad %uint %110
+%277 = OpLoad %uint %109
+%278 = OpIAdd %uint %276 %277
+OpStore %111 %278
+OpBranch %67
+%67 = OpLabel
+%279 = OpLoad %uint %111
+%280 = OpUConvert %ulong %279
+OpStore %195 %280
+OpBranch %69
+%69 = OpLabel
+%281 = OpLoad %ulong %193
+OpStore %203 %281
+OpStore %204 %ulong_0
+OpBranch %70
+%70 = OpLabel
+%282 = OpLoad %ulong %204
+%283 = OpULessThan %bool %282 %ulong_8
+OpStore %196 %283
+%284 = OpLoad %bool %196
+OpLoopMerge %72 %74 None
+OpBranchConditional %284 %71 %72
+%72 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %68
+%68 = OpLabel
+%285 = OpLoad %ulong %203
+OpReturnValue %285
+%71 = OpLabel
+%286 = OpLoad %ulong %204
+%287 = OpIMul %ulong %286 %ulong_8
+OpStore %197 %287
+%288 = OpLoad %ulong %195
+%289 = OpLoad %ulong %197
+%290 = OpShiftRightLogical %ulong %288 %289
+OpStore %198 %290
+%291 = OpLoad %ulong %198
+%293 = OpBitwiseAnd %ulong %291 %ulong_255
+OpStore %199 %293
+%294 = OpLoad %ulong %203
+%295 = OpLoad %ulong %199
+%296 = OpBitwiseXor %ulong %294 %295
+OpStore %200 %296
+%297 = OpLoad %ulong %200
+%299 = OpIMul %ulong %297 %ulong_1099511628211
+OpStore %201 %299
+%300 = OpLoad %ulong %204
+%302 = OpIAdd %ulong %300 %ulong_1
+OpStore %202 %302
+%303 = OpLoad %ulong %201
+OpStore %203 %303
+%304 = OpLoad %ulong %202
+OpStore %204 %304
+OpBranch %74
+%64 = OpLabel
+%305 = OpLoad %ulong %194
+%306 = OpIMul %ulong %305 %ulong_8
+OpStore %187 %306
+%307 = OpLoad %ulong %185
+%308 = OpLoad %ulong %187
+%309 = OpShiftRightLogical %ulong %307 %308
+OpStore %188 %309
+%310 = OpLoad %ulong %188
+%311 = OpBitwiseAnd %ulong %310 %ulong_255
+OpStore %189 %311
+%312 = OpLoad %ulong %193
+%313 = OpLoad %ulong %189
+%314 = OpBitwiseXor %ulong %312 %313
+OpStore %190 %314
+%315 = OpLoad %ulong %190
+%316 = OpIMul %ulong %315 %ulong_1099511628211
+OpStore %191 %316
+%317 = OpLoad %ulong %194
+%318 = OpIAdd %ulong %317 %ulong_1
+OpStore %192 %318
+%319 = OpLoad %ulong %191
+OpStore %193 %319
+%320 = OpLoad %ulong %192
+OpStore %194 %320
+OpBranch %75
+%57 = OpLabel
+%321 = OpLoad %ulong %184
+%322 = OpIMul %ulong %321 %ulong_8
+OpStore %177 %322
+%323 = OpLoad %ulong %175
+%324 = OpLoad %ulong %177
+%325 = OpShiftRightLogical %ulong %323 %324
+OpStore %178 %325
+%326 = OpLoad %ulong %178
+%327 = OpBitwiseAnd %ulong %326 %ulong_255
+OpStore %179 %327
+%328 = OpLoad %ulong %183
+%329 = OpLoad %ulong %179
+%330 = OpBitwiseXor %ulong %328 %329
+OpStore %180 %330
+%331 = OpLoad %ulong %180
+%332 = OpIMul %ulong %331 %ulong_1099511628211
+OpStore %181 %332
+%333 = OpLoad %ulong %184
+%334 = OpIAdd %ulong %333 %ulong_1
+OpStore %182 %334
+%335 = OpLoad %ulong %181
+OpStore %183 %335
+%336 = OpLoad %ulong %182
+OpStore %184 %336
+OpBranch %76
+%50 = OpLabel
+%337 = OpLoad %ulong %174
+%338 = OpIMul %ulong %337 %ulong_8
+OpStore %167 %338
+%339 = OpLoad %ulong %156
+%340 = OpLoad %ulong %167
+%341 = OpShiftRightLogical %ulong %339 %340
+OpStore %168 %341
+%342 = OpLoad %ulong %168
+%343 = OpBitwiseAnd %ulong %342 %ulong_255
+OpStore %169 %343
+%344 = OpLoad %ulong %173
+%345 = OpLoad %ulong %169
+%346 = OpBitwiseXor %ulong %344 %345
+OpStore %170 %346
+%347 = OpLoad %ulong %170
+%348 = OpIMul %ulong %347 %ulong_1099511628211
+OpStore %171 %348
+%349 = OpLoad %ulong %174
+%350 = OpIAdd %ulong %349 %ulong_1
+OpStore %172 %350
+%351 = OpLoad %ulong %171
+OpStore %173 %351
+%352 = OpLoad %ulong %172
+OpStore %174 %352
+OpBranch %78
+%38 = OpLabel
+%353 = OpLoad %ulong %155
+%354 = OpIMul %ulong %353 %ulong_8
+OpStore %148 %354
+%355 = OpLoad %ulong %136
+%356 = OpLoad %ulong %148
+%357 = OpShiftRightLogical %ulong %355 %356
+OpStore %149 %357
+%358 = OpLoad %ulong %149
+%359 = OpBitwiseAnd %ulong %358 %ulong_255
+OpStore %150 %359
+%360 = OpLoad %ulong %154
+%361 = OpLoad %ulong %150
+%362 = OpBitwiseXor %ulong %360 %361
+OpStore %151 %362
+%363 = OpLoad %ulong %151
+%364 = OpIMul %ulong %363 %ulong_1099511628211
+OpStore %152 %364
+%365 = OpLoad %ulong %155
+%366 = OpIAdd %ulong %365 %ulong_1
+OpStore %153 %366
+%367 = OpLoad %ulong %152
+OpStore %154 %367
+%368 = OpLoad %ulong %153
+OpStore %155 %368
+OpBranch %80
+%24 = OpLabel
+%369 = OpLoad %ulong %135
+%370 = OpIMul %ulong %369 %ulong_8
+OpStore %128 %370
+%371 = OpLoad %ulong %116
+%372 = OpLoad %ulong %128
+%373 = OpShiftRightLogical %ulong %371 %372
+OpStore %129 %373
+%374 = OpLoad %ulong %129
+%375 = OpBitwiseAnd %ulong %374 %ulong_255
+OpStore %130 %375
+%376 = OpLoad %ulong %134
+%377 = OpLoad %ulong %130
+%378 = OpBitwiseXor %ulong %376 %377
+OpStore %131 %378
+%379 = OpLoad %ulong %131
+%380 = OpIMul %ulong %379 %ulong_1099511628211
+OpStore %132 %380
+%381 = OpLoad %ulong %135
+%382 = OpIAdd %ulong %381 %ulong_1
+OpStore %133 %382
+%383 = OpLoad %ulong %132
+OpStore %134 %383
+%384 = OpLoad %ulong %133
+OpStore %135 %384
+OpBranch %82
+%7 = OpLabel
+%385 = OpLoad %uint %114
+%387 = OpIMul %uint %385 %uint_131
+OpStore %93 %387
+%388 = OpLoad %uint %93
+%389 = OpIAdd %uint %388 %uint_3
+OpStore %94 %389
+%390 = OpLoad %uint %94
+%391 = OpLoad %uint %89
+%392 = OpIAdd %uint %390 %391
+OpStore %95 %392
+%393 = OpLoad %uint %113
+%394 = OpLoad %uint %95
+%395 = OpUDiv %uint %393 %394
+OpStore %96 %395
+%396 = OpLoad %uint %113
+%397 = OpLoad %uint %95
+%398 = OpUMod %uint %396 %397
+OpStore %97 %398
+OpBranch %11
+%11 = OpLabel
+%399 = OpLoad %uint %96
+%400 = OpUConvert %ulong %399
+OpStore %115 %400
+OpBranch %15
+%15 = OpLabel
+%401 = OpLoad %ulong %112
+OpStore %124 %401
+OpStore %125 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%402 = OpLoad %ulong %125
+%403 = OpULessThan %bool %402 %ulong_8
+OpStore %117 %403
+%404 = OpLoad %bool %117
+OpLoopMerge %18 %81 None
+OpBranchConditional %404 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %12
+%12 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%405 = OpLoad %uint %97
+%406 = OpUConvert %ulong %405
+OpStore %126 %406
+OpBranch %29
+%29 = OpLabel
+%407 = OpLoad %ulong %124
+OpStore %144 %407
+OpStore %145 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%408 = OpLoad %ulong %145
+%409 = OpULessThan %bool %408 %ulong_8
+OpStore %137 %409
+%410 = OpLoad %bool %137
+OpLoopMerge %32 %79 None
+OpBranchConditional %410 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%411 = OpLoad %uint %95
+%412 = OpLoad %uint %96
+%413 = OpIMul %uint %411 %412
+OpStore %98 %413
+%414 = OpLoad %uint %98
+%415 = OpLoad %uint %97
+%416 = OpIAdd %uint %414 %415
+OpStore %99 %416
+OpBranch %34
+%34 = OpLabel
+%417 = OpLoad %uint %99
+%418 = OpUConvert %ulong %417
+OpStore %146 %418
+OpBranch %43
+%43 = OpLabel
+%419 = OpLoad %ulong %144
+OpStore %164 %419
+OpStore %165 %ulong_0
+OpBranch %44
+%44 = OpLabel
+%420 = OpLoad %ulong %165
+%421 = OpULessThan %bool %420 %ulong_8
+OpStore %157 %421
+%422 = OpLoad %bool %157
+OpLoopMerge %46 %77 None
+OpBranchConditional %422 %45 %46
+%46 = OpLabel
+OpBranch %47
+%47 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%423 = OpLoad %uint %113
+%424 = OpLoad %uint %95
+%425 = OpISub %uint %423 %424
+OpStore %100 %425
+%426 = OpLoad %uint %114
+%428 = OpIAdd %uint %426 %uint_1
+OpStore %101 %428
+%429 = OpLoad %ulong %164
+OpStore %112 %429
+%430 = OpLoad %uint %100
+OpStore %113 %430
+%431 = OpLoad %uint %101
+OpStore %114 %431
+OpBranch %83
+%45 = OpLabel
+%432 = OpLoad %ulong %165
+%433 = OpIMul %ulong %432 %ulong_8
+OpStore %158 %433
+%434 = OpLoad %ulong %146
+%435 = OpLoad %ulong %158
+%436 = OpShiftRightLogical %ulong %434 %435
+OpStore %159 %436
+%437 = OpLoad %ulong %159
+%438 = OpBitwiseAnd %ulong %437 %ulong_255
+OpStore %160 %438
+%439 = OpLoad %ulong %164
+%440 = OpLoad %ulong %160
+%441 = OpBitwiseXor %ulong %439 %440
+OpStore %161 %441
+%442 = OpLoad %ulong %161
+%443 = OpIMul %ulong %442 %ulong_1099511628211
+OpStore %162 %443
+%444 = OpLoad %ulong %165
+%445 = OpIAdd %ulong %444 %ulong_1
+OpStore %163 %445
+%446 = OpLoad %ulong %162
+OpStore %164 %446
+%447 = OpLoad %ulong %163
+OpStore %165 %447
+OpBranch %77
+%31 = OpLabel
+%448 = OpLoad %ulong %145
+%449 = OpIMul %ulong %448 %ulong_8
+OpStore %138 %449
+%450 = OpLoad %ulong %126
+%451 = OpLoad %ulong %138
+%452 = OpShiftRightLogical %ulong %450 %451
+OpStore %139 %452
+%453 = OpLoad %ulong %139
+%454 = OpBitwiseAnd %ulong %453 %ulong_255
+OpStore %140 %454
+%455 = OpLoad %ulong %144
+%456 = OpLoad %ulong %140
+%457 = OpBitwiseXor %ulong %455 %456
+OpStore %141 %457
+%458 = OpLoad %ulong %141
+%459 = OpIMul %ulong %458 %ulong_1099511628211
+OpStore %142 %459
+%460 = OpLoad %ulong %145
+%461 = OpIAdd %ulong %460 %ulong_1
+OpStore %143 %461
+%462 = OpLoad %ulong %142
+OpStore %144 %462
+%463 = OpLoad %ulong %143
+OpStore %145 %463
+OpBranch %79
+%17 = OpLabel
+%464 = OpLoad %ulong %125
+%465 = OpIMul %ulong %464 %ulong_8
+OpStore %118 %465
+%466 = OpLoad %ulong %115
+%467 = OpLoad %ulong %118
+%468 = OpShiftRightLogical %ulong %466 %467
+OpStore %119 %468
+%469 = OpLoad %ulong %119
+%470 = OpBitwiseAnd %ulong %469 %ulong_255
+OpStore %120 %470
+%471 = OpLoad %ulong %124
+%472 = OpLoad %ulong %120
+%473 = OpBitwiseXor %ulong %471 %472
+OpStore %121 %473
+%474 = OpLoad %ulong %121
+%475 = OpIMul %ulong %474 %ulong_1099511628211
+OpStore %122 %475
+%476 = OpLoad %ulong %125
+%477 = OpIAdd %ulong %476 %ulong_1
+OpStore %123 %477
+%478 = OpLoad %ulong %122
+OpStore %124 %478
+%479 = OpLoad %ulong %123
+OpStore %125 %479
+OpBranch %81
+%74 = OpLabel
+OpBranch %70
+%75 = OpLabel
+OpBranch %63
+%76 = OpLabel
+OpBranch %56
+%77 = OpLabel
+OpBranch %44
+%78 = OpLabel
+OpBranch %49
+%79 = OpLabel
+OpBranch %30
+%80 = OpLabel
+OpBranch %37
+%81 = OpLabel
+OpBranch %16
+%82 = OpLabel
+OpBranch %23
+%83 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/divrem_u64.dis
+++ b/test/golden/spirv/scalar/divrem_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 194
+; Bound: 428
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,262 +9,628 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.divrem_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_16 = OpConstant %ulong 16
 %ulong_18446744073709551613 = OpConstant %ulong 18446744073709551613
 %ulong_3 = OpConstant %ulong 3
-%ulong_131 = OpConstant %ulong 131
-%ulong_1 = OpConstant %ulong 1
-%148 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%151 = OpTypeFunction %ulong %ulong %ulong
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_bool Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %6
-%50 = OpFunctionCall %ulong %2
-OpStore %15 %50
-%52 = OpLoad %ulong %14
-%53 = OpISub %ulong %ulong_18446744073709551615 %52
-OpStore %16 %53
-%54 = OpLoad %ulong %15
-OpStore %47 %54
-%55 = OpLoad %ulong %16
-OpStore %48 %55
-OpStore %49 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%57 = OpLoad %ulong %49
-%59 = OpULessThan %bool %57 %ulong_16
-OpStore %18 %59
-%60 = OpLoad %bool %18
-OpLoopMerge %10 %11 None
-OpBranchConditional %60 %9 %10
-%10 = OpLabel
-%62 = OpLoad %ulong %14
-%63 = OpIAdd %ulong %ulong_18446744073709551613 %62
-OpStore %31 %63
-%65 = OpLoad %ulong %14
-%66 = OpIAdd %ulong %ulong_3 %65
-OpStore %32 %66
-%67 = OpLoad %ulong %31
-%68 = OpLoad %ulong %32
-%69 = OpUDiv %ulong %67 %68
-OpStore %33 %69
-%70 = OpLoad %ulong %31
-%71 = OpLoad %ulong %32
-%72 = OpUMod %ulong %70 %71
-OpStore %34 %72
-%73 = OpLoad %ulong %47
-%74 = OpLoad %ulong %33
-%75 = OpFunctionCall %ulong %3 %73 %74
-OpStore %35 %75
-%76 = OpLoad %ulong %35
-%77 = OpLoad %ulong %34
-%78 = OpFunctionCall %ulong %3 %76 %77
-OpStore %36 %78
-%79 = OpLoad %ulong %32
-%80 = OpLoad %ulong %33
-%81 = OpIMul %ulong %79 %80
-OpStore %37 %81
-%82 = OpLoad %ulong %37
-%83 = OpLoad %ulong %34
-%84 = OpIAdd %ulong %82 %83
-OpStore %38 %84
-%85 = OpLoad %ulong %36
-%86 = OpLoad %ulong %38
-%87 = OpFunctionCall %ulong %3 %85 %86
-OpStore %39 %87
-%88 = OpLoad %ulong %32
-%89 = OpLoad %ulong %31
-%90 = OpUDiv %ulong %88 %89
-OpStore %40 %90
-%91 = OpLoad %ulong %32
-%92 = OpLoad %ulong %31
-%93 = OpUMod %ulong %91 %92
-OpStore %41 %93
-%94 = OpLoad %ulong %39
-%95 = OpLoad %ulong %40
-%96 = OpFunctionCall %ulong %3 %94 %95
-OpStore %42 %96
-%97 = OpLoad %ulong %42
-%98 = OpLoad %ulong %41
-%99 = OpFunctionCall %ulong %3 %97 %98
-OpStore %43 %99
-%100 = OpLoad %ulong %31
-%101 = OpLoad %ulong %40
-%102 = OpIMul %ulong %100 %101
-OpStore %44 %102
-%103 = OpLoad %ulong %44
-%104 = OpLoad %ulong %41
-%105 = OpIAdd %ulong %103 %104
-OpStore %45 %105
-%106 = OpLoad %ulong %43
-%107 = OpLoad %ulong %45
-%108 = OpFunctionCall %ulong %3 %106 %107
-OpStore %46 %108
-%109 = OpLoad %ulong %46
-OpReturnValue %109
-%9 = OpLabel
-%110 = OpLoad %ulong %49
-%112 = OpIMul %ulong %110 %ulong_131
-OpStore %19 %112
-%113 = OpLoad %ulong %19
-%114 = OpIAdd %ulong %113 %ulong_3
-OpStore %20 %114
-%115 = OpLoad %ulong %20
-%116 = OpLoad %ulong %14
-%117 = OpIAdd %ulong %115 %116
-OpStore %21 %117
-%118 = OpLoad %ulong %48
-%119 = OpLoad %ulong %21
-%120 = OpUDiv %ulong %118 %119
-OpStore %22 %120
-%121 = OpLoad %ulong %48
-%122 = OpLoad %ulong %21
-%123 = OpUMod %ulong %121 %122
-OpStore %23 %123
-%124 = OpLoad %ulong %47
-%125 = OpLoad %ulong %22
-%126 = OpFunctionCall %ulong %3 %124 %125
-OpStore %24 %126
-%127 = OpLoad %ulong %24
-%128 = OpLoad %ulong %23
-%129 = OpFunctionCall %ulong %3 %127 %128
-OpStore %25 %129
-%130 = OpLoad %ulong %21
-%131 = OpLoad %ulong %22
-%132 = OpIMul %ulong %130 %131
-OpStore %26 %132
-%133 = OpLoad %ulong %26
-%134 = OpLoad %ulong %23
-%135 = OpIAdd %ulong %133 %134
-OpStore %27 %135
-%136 = OpLoad %ulong %25
-%137 = OpLoad %ulong %27
-%138 = OpFunctionCall %ulong %3 %136 %137
-OpStore %28 %138
-%139 = OpLoad %ulong %48
-%140 = OpLoad %ulong %21
-%141 = OpISub %ulong %139 %140
-OpStore %29 %141
-%142 = OpLoad %ulong %49
-%144 = OpIAdd %ulong %142 %ulong_1
-OpStore %30 %144
-%145 = OpLoad %ulong %28
-OpStore %47 %145
-%146 = OpLoad %ulong %29
-OpStore %48 %146
-%147 = OpLoad %ulong %30
-OpStore %49 %147
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %148
-%149 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %151
-%152 = OpFunctionParameter %ulong
-%153 = OpFunctionParameter %ulong
-%154 = OpLabel
+%ulong_1 = OpConstant %ulong 1
+%ulong_131 = OpConstant %ulong 131
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_bool Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_bool Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_bool Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_bool Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_bool Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_bool Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_bool Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_bool Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_bool Function
+%158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_ulong Function
 %160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_bool Function
+%161 = OpVariable %_ptr_Function_ulong Function
 %162 = OpVariable %_ptr_Function_ulong Function
 %163 = OpVariable %_ptr_Function_ulong Function
 %164 = OpVariable %_ptr_Function_ulong Function
 %165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
 %169 = OpVariable %_ptr_Function_ulong Function
-OpStore %159 %152
-OpStore %160 %153
-%170 = OpLoad %ulong %159
-OpStore %168 %170
-OpStore %169 %ulong_0
-OpBranch %155
-%155 = OpLabel
-%171 = OpLoad %ulong %169
-%173 = OpULessThan %bool %171 %ulong_8
-OpStore %161 %173
-%174 = OpLoad %bool %161
-OpLoopMerge %157 %158 None
-OpBranchConditional %174 %156 %157
-%157 = OpLabel
-%175 = OpLoad %ulong %168
-OpReturnValue %175
-%156 = OpLabel
-%176 = OpLoad %ulong %169
-%177 = OpIMul %ulong %176 %ulong_8
-OpStore %162 %177
-%178 = OpLoad %ulong %160
-%179 = OpLoad %ulong %162
-%180 = OpShiftRightLogical %ulong %178 %179
-OpStore %163 %180
-%181 = OpLoad %ulong %163
-%183 = OpBitwiseAnd %ulong %181 %ulong_255
-OpStore %164 %183
-%184 = OpLoad %ulong %168
-%185 = OpLoad %ulong %164
-%186 = OpBitwiseXor %ulong %184 %185
-OpStore %165 %186
-%187 = OpLoad %ulong %165
-%189 = OpIMul %ulong %187 %ulong_1099511628211
-OpStore %166 %189
-%190 = OpLoad %ulong %169
-%191 = OpIAdd %ulong %190 %ulong_1
-OpStore %167 %191
-%192 = OpLoad %ulong %166
-OpStore %168 %192
-%193 = OpLoad %ulong %167
-OpStore %169 %193
-OpBranch %158
-%158 = OpLabel
-OpBranch %155
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+OpStore %68 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%176 = OpLoad %ulong %68
+%177 = OpISub %ulong %ulong_18446744073709551615 %176
+OpStore %69 %177
+OpStore %91 %ulong_14695981039346656037
+%179 = OpLoad %ulong %69
+OpStore %92 %179
+OpStore %93 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%181 = OpLoad %ulong %93
+%183 = OpULessThan %bool %181 %ulong_16
+OpStore %71 %183
+%184 = OpLoad %bool %71
+OpLoopMerge %8 %65 None
+OpBranchConditional %184 %7 %8
+%8 = OpLabel
+%186 = OpLoad %ulong %68
+%187 = OpIAdd %ulong %ulong_18446744073709551613 %186
+OpStore %81 %187
+%189 = OpLoad %ulong %68
+%190 = OpIAdd %ulong %ulong_3 %189
+OpStore %82 %190
+%191 = OpLoad %ulong %81
+%192 = OpLoad %ulong %82
+%193 = OpUDiv %ulong %191 %192
+OpStore %83 %193
+%194 = OpLoad %ulong %81
+%195 = OpLoad %ulong %82
+%196 = OpUMod %ulong %194 %195
+OpStore %84 %196
+OpBranch %16
+%16 = OpLabel
+%197 = OpLoad %ulong %91
+OpStore %110 %197
+OpStore %111 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%198 = OpLoad %ulong %111
+%200 = OpULessThan %bool %198 %ulong_8
+OpStore %103 %200
+%201 = OpLoad %bool %103
+OpLoopMerge %19 %64 None
+OpBranchConditional %201 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%202 = OpLoad %ulong %110
+OpStore %128 %202
+OpStore %129 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%203 = OpLoad %ulong %129
+%204 = OpULessThan %bool %203 %ulong_8
+OpStore %121 %204
+%205 = OpLoad %bool %121
+OpLoopMerge %29 %62 None
+OpBranchConditional %205 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%206 = OpLoad %ulong %82
+%207 = OpLoad %ulong %83
+%208 = OpIMul %ulong %206 %207
+OpStore %85 %208
+%209 = OpLoad %ulong %85
+%210 = OpLoad %ulong %84
+%211 = OpIAdd %ulong %209 %210
+OpStore %86 %211
+OpBranch %36
+%36 = OpLabel
+%212 = OpLoad %ulong %128
+OpStore %146 %212
+OpStore %147 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%213 = OpLoad %ulong %147
+%214 = OpULessThan %bool %213 %ulong_8
+OpStore %139 %214
+%215 = OpLoad %bool %139
+OpLoopMerge %39 %60 None
+OpBranchConditional %215 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%216 = OpLoad %ulong %82
+%217 = OpLoad %ulong %81
+%218 = OpUDiv %ulong %216 %217
+OpStore %87 %218
+%219 = OpLoad %ulong %82
+%220 = OpLoad %ulong %81
+%221 = OpUMod %ulong %219 %220
+OpStore %88 %221
+OpBranch %41
+%41 = OpLabel
+%222 = OpLoad %ulong %146
+OpStore %155 %222
+OpStore %156 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%223 = OpLoad %ulong %156
+%224 = OpULessThan %bool %223 %ulong_8
+OpStore %148 %224
+%225 = OpLoad %bool %148
+OpLoopMerge %44 %58 None
+OpBranchConditional %225 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+%226 = OpLoad %ulong %155
+OpStore %164 %226
+OpStore %165 %ulong_0
+OpBranch %47
+%47 = OpLabel
+%227 = OpLoad %ulong %165
+%228 = OpULessThan %bool %227 %ulong_8
+OpStore %157 %228
+%229 = OpLoad %bool %157
+OpLoopMerge %49 %57 None
+OpBranchConditional %229 %48 %49
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%230 = OpLoad %ulong %81
+%231 = OpLoad %ulong %87
+%232 = OpIMul %ulong %230 %231
+OpStore %89 %232
+%233 = OpLoad %ulong %89
+%234 = OpLoad %ulong %88
+%235 = OpIAdd %ulong %233 %234
+OpStore %90 %235
+OpBranch %51
+%51 = OpLabel
+%236 = OpLoad %ulong %164
+OpStore %173 %236
+OpStore %174 %ulong_0
+OpBranch %52
+%52 = OpLabel
+%237 = OpLoad %ulong %174
+%238 = OpULessThan %bool %237 %ulong_8
+OpStore %166 %238
+%239 = OpLoad %bool %166
+OpLoopMerge %54 %56 None
+OpBranchConditional %239 %53 %54
+%54 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%240 = OpLoad %ulong %173
+OpReturnValue %240
+%53 = OpLabel
+%241 = OpLoad %ulong %174
+%242 = OpIMul %ulong %241 %ulong_8
+OpStore %167 %242
+%243 = OpLoad %ulong %90
+%244 = OpLoad %ulong %167
+%245 = OpShiftRightLogical %ulong %243 %244
+OpStore %168 %245
+%246 = OpLoad %ulong %168
+%248 = OpBitwiseAnd %ulong %246 %ulong_255
+OpStore %169 %248
+%249 = OpLoad %ulong %173
+%250 = OpLoad %ulong %169
+%251 = OpBitwiseXor %ulong %249 %250
+OpStore %170 %251
+%252 = OpLoad %ulong %170
+%254 = OpIMul %ulong %252 %ulong_1099511628211
+OpStore %171 %254
+%255 = OpLoad %ulong %174
+%257 = OpIAdd %ulong %255 %ulong_1
+OpStore %172 %257
+%258 = OpLoad %ulong %171
+OpStore %173 %258
+%259 = OpLoad %ulong %172
+OpStore %174 %259
+OpBranch %56
+%48 = OpLabel
+%260 = OpLoad %ulong %165
+%261 = OpIMul %ulong %260 %ulong_8
+OpStore %158 %261
+%262 = OpLoad %ulong %88
+%263 = OpLoad %ulong %158
+%264 = OpShiftRightLogical %ulong %262 %263
+OpStore %159 %264
+%265 = OpLoad %ulong %159
+%266 = OpBitwiseAnd %ulong %265 %ulong_255
+OpStore %160 %266
+%267 = OpLoad %ulong %164
+%268 = OpLoad %ulong %160
+%269 = OpBitwiseXor %ulong %267 %268
+OpStore %161 %269
+%270 = OpLoad %ulong %161
+%271 = OpIMul %ulong %270 %ulong_1099511628211
+OpStore %162 %271
+%272 = OpLoad %ulong %165
+%273 = OpIAdd %ulong %272 %ulong_1
+OpStore %163 %273
+%274 = OpLoad %ulong %162
+OpStore %164 %274
+%275 = OpLoad %ulong %163
+OpStore %165 %275
+OpBranch %57
+%43 = OpLabel
+%276 = OpLoad %ulong %156
+%277 = OpIMul %ulong %276 %ulong_8
+OpStore %149 %277
+%278 = OpLoad %ulong %87
+%279 = OpLoad %ulong %149
+%280 = OpShiftRightLogical %ulong %278 %279
+OpStore %150 %280
+%281 = OpLoad %ulong %150
+%282 = OpBitwiseAnd %ulong %281 %ulong_255
+OpStore %151 %282
+%283 = OpLoad %ulong %155
+%284 = OpLoad %ulong %151
+%285 = OpBitwiseXor %ulong %283 %284
+OpStore %152 %285
+%286 = OpLoad %ulong %152
+%287 = OpIMul %ulong %286 %ulong_1099511628211
+OpStore %153 %287
+%288 = OpLoad %ulong %156
+%289 = OpIAdd %ulong %288 %ulong_1
+OpStore %154 %289
+%290 = OpLoad %ulong %153
+OpStore %155 %290
+%291 = OpLoad %ulong %154
+OpStore %156 %291
+OpBranch %58
+%38 = OpLabel
+%292 = OpLoad %ulong %147
+%293 = OpIMul %ulong %292 %ulong_8
+OpStore %140 %293
+%294 = OpLoad %ulong %86
+%295 = OpLoad %ulong %140
+%296 = OpShiftRightLogical %ulong %294 %295
+OpStore %141 %296
+%297 = OpLoad %ulong %141
+%298 = OpBitwiseAnd %ulong %297 %ulong_255
+OpStore %142 %298
+%299 = OpLoad %ulong %146
+%300 = OpLoad %ulong %142
+%301 = OpBitwiseXor %ulong %299 %300
+OpStore %143 %301
+%302 = OpLoad %ulong %143
+%303 = OpIMul %ulong %302 %ulong_1099511628211
+OpStore %144 %303
+%304 = OpLoad %ulong %147
+%305 = OpIAdd %ulong %304 %ulong_1
+OpStore %145 %305
+%306 = OpLoad %ulong %144
+OpStore %146 %306
+%307 = OpLoad %ulong %145
+OpStore %147 %307
+OpBranch %60
+%28 = OpLabel
+%308 = OpLoad %ulong %129
+%309 = OpIMul %ulong %308 %ulong_8
+OpStore %122 %309
+%310 = OpLoad %ulong %84
+%311 = OpLoad %ulong %122
+%312 = OpShiftRightLogical %ulong %310 %311
+OpStore %123 %312
+%313 = OpLoad %ulong %123
+%314 = OpBitwiseAnd %ulong %313 %ulong_255
+OpStore %124 %314
+%315 = OpLoad %ulong %128
+%316 = OpLoad %ulong %124
+%317 = OpBitwiseXor %ulong %315 %316
+OpStore %125 %317
+%318 = OpLoad %ulong %125
+%319 = OpIMul %ulong %318 %ulong_1099511628211
+OpStore %126 %319
+%320 = OpLoad %ulong %129
+%321 = OpIAdd %ulong %320 %ulong_1
+OpStore %127 %321
+%322 = OpLoad %ulong %126
+OpStore %128 %322
+%323 = OpLoad %ulong %127
+OpStore %129 %323
+OpBranch %62
+%18 = OpLabel
+%324 = OpLoad %ulong %111
+%325 = OpIMul %ulong %324 %ulong_8
+OpStore %104 %325
+%326 = OpLoad %ulong %83
+%327 = OpLoad %ulong %104
+%328 = OpShiftRightLogical %ulong %326 %327
+OpStore %105 %328
+%329 = OpLoad %ulong %105
+%330 = OpBitwiseAnd %ulong %329 %ulong_255
+OpStore %106 %330
+%331 = OpLoad %ulong %110
+%332 = OpLoad %ulong %106
+%333 = OpBitwiseXor %ulong %331 %332
+OpStore %107 %333
+%334 = OpLoad %ulong %107
+%335 = OpIMul %ulong %334 %ulong_1099511628211
+OpStore %108 %335
+%336 = OpLoad %ulong %111
+%337 = OpIAdd %ulong %336 %ulong_1
+OpStore %109 %337
+%338 = OpLoad %ulong %108
+OpStore %110 %338
+%339 = OpLoad %ulong %109
+OpStore %111 %339
+OpBranch %64
+%7 = OpLabel
+%340 = OpLoad %ulong %93
+%342 = OpIMul %ulong %340 %ulong_131
+OpStore %72 %342
+%343 = OpLoad %ulong %72
+%344 = OpIAdd %ulong %343 %ulong_3
+OpStore %73 %344
+%345 = OpLoad %ulong %73
+%346 = OpLoad %ulong %68
+%347 = OpIAdd %ulong %345 %346
+OpStore %74 %347
+%348 = OpLoad %ulong %92
+%349 = OpLoad %ulong %74
+%350 = OpUDiv %ulong %348 %349
+OpStore %75 %350
+%351 = OpLoad %ulong %92
+%352 = OpLoad %ulong %74
+%353 = OpUMod %ulong %351 %352
+OpStore %76 %353
+OpBranch %11
+%11 = OpLabel
+%354 = OpLoad %ulong %91
+OpStore %101 %354
+OpStore %102 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%355 = OpLoad %ulong %102
+%356 = OpULessThan %bool %355 %ulong_8
+OpStore %94 %356
+%357 = OpLoad %bool %94
+OpLoopMerge %14 %63 None
+OpBranchConditional %357 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%358 = OpLoad %ulong %101
+OpStore %119 %358
+OpStore %120 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%359 = OpLoad %ulong %120
+%360 = OpULessThan %bool %359 %ulong_8
+OpStore %112 %360
+%361 = OpLoad %bool %112
+OpLoopMerge %24 %61 None
+OpBranchConditional %361 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%362 = OpLoad %ulong %74
+%363 = OpLoad %ulong %75
+%364 = OpIMul %ulong %362 %363
+OpStore %77 %364
+%365 = OpLoad %ulong %77
+%366 = OpLoad %ulong %76
+%367 = OpIAdd %ulong %365 %366
+OpStore %78 %367
+OpBranch %31
+%31 = OpLabel
+%368 = OpLoad %ulong %119
+OpStore %137 %368
+OpStore %138 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%369 = OpLoad %ulong %138
+%370 = OpULessThan %bool %369 %ulong_8
+OpStore %130 %370
+%371 = OpLoad %bool %130
+OpLoopMerge %34 %59 None
+OpBranchConditional %371 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%372 = OpLoad %ulong %92
+%373 = OpLoad %ulong %74
+%374 = OpISub %ulong %372 %373
+OpStore %79 %374
+%375 = OpLoad %ulong %93
+%376 = OpIAdd %ulong %375 %ulong_1
+OpStore %80 %376
+%377 = OpLoad %ulong %137
+OpStore %91 %377
+%378 = OpLoad %ulong %79
+OpStore %92 %378
+%379 = OpLoad %ulong %80
+OpStore %93 %379
+OpBranch %65
+%33 = OpLabel
+%380 = OpLoad %ulong %138
+%381 = OpIMul %ulong %380 %ulong_8
+OpStore %131 %381
+%382 = OpLoad %ulong %78
+%383 = OpLoad %ulong %131
+%384 = OpShiftRightLogical %ulong %382 %383
+OpStore %132 %384
+%385 = OpLoad %ulong %132
+%386 = OpBitwiseAnd %ulong %385 %ulong_255
+OpStore %133 %386
+%387 = OpLoad %ulong %137
+%388 = OpLoad %ulong %133
+%389 = OpBitwiseXor %ulong %387 %388
+OpStore %134 %389
+%390 = OpLoad %ulong %134
+%391 = OpIMul %ulong %390 %ulong_1099511628211
+OpStore %135 %391
+%392 = OpLoad %ulong %138
+%393 = OpIAdd %ulong %392 %ulong_1
+OpStore %136 %393
+%394 = OpLoad %ulong %135
+OpStore %137 %394
+%395 = OpLoad %ulong %136
+OpStore %138 %395
+OpBranch %59
+%23 = OpLabel
+%396 = OpLoad %ulong %120
+%397 = OpIMul %ulong %396 %ulong_8
+OpStore %113 %397
+%398 = OpLoad %ulong %76
+%399 = OpLoad %ulong %113
+%400 = OpShiftRightLogical %ulong %398 %399
+OpStore %114 %400
+%401 = OpLoad %ulong %114
+%402 = OpBitwiseAnd %ulong %401 %ulong_255
+OpStore %115 %402
+%403 = OpLoad %ulong %119
+%404 = OpLoad %ulong %115
+%405 = OpBitwiseXor %ulong %403 %404
+OpStore %116 %405
+%406 = OpLoad %ulong %116
+%407 = OpIMul %ulong %406 %ulong_1099511628211
+OpStore %117 %407
+%408 = OpLoad %ulong %120
+%409 = OpIAdd %ulong %408 %ulong_1
+OpStore %118 %409
+%410 = OpLoad %ulong %117
+OpStore %119 %410
+%411 = OpLoad %ulong %118
+OpStore %120 %411
+OpBranch %61
+%13 = OpLabel
+%412 = OpLoad %ulong %102
+%413 = OpIMul %ulong %412 %ulong_8
+OpStore %95 %413
+%414 = OpLoad %ulong %75
+%415 = OpLoad %ulong %95
+%416 = OpShiftRightLogical %ulong %414 %415
+OpStore %96 %416
+%417 = OpLoad %ulong %96
+%418 = OpBitwiseAnd %ulong %417 %ulong_255
+OpStore %97 %418
+%419 = OpLoad %ulong %101
+%420 = OpLoad %ulong %97
+%421 = OpBitwiseXor %ulong %419 %420
+OpStore %98 %421
+%422 = OpLoad %ulong %98
+%423 = OpIMul %ulong %422 %ulong_1099511628211
+OpStore %99 %423
+%424 = OpLoad %ulong %102
+%425 = OpIAdd %ulong %424 %ulong_1
+OpStore %100 %425
+%426 = OpLoad %ulong %99
+OpStore %101 %426
+%427 = OpLoad %ulong %100
+OpStore %102 %427
+OpBranch %63
+%56 = OpLabel
+OpBranch %52
+%57 = OpLabel
+OpBranch %47
+%58 = OpLabel
+OpBranch %42
+%59 = OpLabel
+OpBranch %32
+%60 = OpLabel
+OpBranch %37
+%61 = OpLabel
+OpBranch %22
+%62 = OpLabel
+OpBranch %27
+%63 = OpLabel
+OpBranch %12
+%64 = OpLabel
+OpBranch %17
+%65 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/mul_i32.dis
+++ b/test/golden/spirv/scalar/mul_i32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 170
+; Bound: 372
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,174 +9,89 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.mul_i32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_2654435769 = OpConstant %uint 2654435769
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_16 = OpConstant %uint 16
 %uint_4294967231 = OpConstant %uint 4294967231
-%uint_4294967295 = OpConstant %uint 4294967295
-%uint_65537 = OpConstant %uint 65537
-%uint_2 = OpConstant %uint 2
-%uint_3 = OpConstant %uint 3
-%uint_1 = OpConstant %uint 1
-%117 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%120 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
+%uint_4294967295 = OpConstant %uint 4294967295
+%uint_65537 = OpConstant %uint 65537
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_bool Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_uint Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_uint Function
-OpStore %15 %6
-%44 = OpFunctionCall %ulong %2
-OpStore %16 %44
-%45 = OpLoad %ulong %15
-%46 = OpUConvert %uint %45
-OpStore %18 %46
-%48 = OpLoad %uint %18
-%49 = OpIAdd %uint %uint_2654435769 %48
-OpStore %19 %49
-%50 = OpLoad %ulong %16
-OpStore %41 %50
-%51 = OpLoad %uint %19
-OpStore %42 %51
-OpStore %43 %uint_0
-OpBranch %8
-%8 = OpLabel
-%53 = OpLoad %uint %43
-%55 = OpSLessThan %bool %53 %uint_16
-OpStore %21 %55
-%56 = OpLoad %bool %21
-OpLoopMerge %10 %11 None
-OpBranchConditional %56 %9 %10
-%10 = OpLabel
-%58 = OpLoad %uint %18
-%59 = OpIAdd %uint %uint_4294967231 %58
-OpStore %27 %59
-%60 = OpLoad %uint %27
-%61 = OpLoad %uint %27
-%62 = OpIMul %uint %60 %61
-OpStore %28 %62
-%63 = OpLoad %ulong %41
-%64 = OpLoad %uint %28
-%65 = OpFunctionCall %ulong %3 %63 %64
-OpStore %29 %65
-%66 = OpLoad %uint %27
-%68 = OpIMul %uint %66 %uint_4294967295
-OpStore %30 %68
-%69 = OpLoad %ulong %29
-%70 = OpLoad %uint %30
-%71 = OpFunctionCall %ulong %3 %69 %70
-OpStore %31 %71
-%72 = OpLoad %uint %42
-%73 = OpLoad %uint %27
-%74 = OpIMul %uint %72 %73
-OpStore %32 %74
-%75 = OpLoad %ulong %31
-%76 = OpLoad %uint %32
-%77 = OpFunctionCall %ulong %3 %75 %76
-OpStore %33 %77
-%78 = OpLoad %uint %27
-%79 = OpLoad %uint %42
-%80 = OpIMul %uint %78 %79
-OpStore %34 %80
-%81 = OpLoad %ulong %33
-%82 = OpLoad %uint %34
-%83 = OpFunctionCall %ulong %3 %81 %82
-OpStore %35 %83
-%85 = OpLoad %uint %18
-%86 = OpIAdd %uint %uint_65537 %85
-OpStore %36 %86
-%87 = OpLoad %uint %36
-%88 = OpLoad %uint %36
-%89 = OpIMul %uint %87 %88
-OpStore %37 %89
-%90 = OpLoad %ulong %35
-%91 = OpLoad %uint %37
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %38 %92
-%93 = OpLoad %uint %36
-%94 = OpIMul %uint %93 %uint_4294967295
-OpStore %39 %94
-%95 = OpLoad %ulong %38
-%96 = OpLoad %uint %39
-%97 = OpFunctionCall %ulong %3 %95 %96
-OpStore %40 %97
-%98 = OpLoad %ulong %40
-OpReturnValue %98
-%9 = OpLabel
-%100 = OpLoad %uint %43
-%101 = OpIMul %uint %uint_2 %100
-OpStore %22 %101
-%102 = OpLoad %uint %22
-%104 = OpIAdd %uint %102 %uint_3
-OpStore %23 %104
-%105 = OpLoad %uint %42
-%106 = OpLoad %uint %23
-%107 = OpIMul %uint %105 %106
-OpStore %24 %107
-%108 = OpLoad %ulong %41
-%109 = OpLoad %uint %24
-%110 = OpFunctionCall %ulong %3 %108 %109
-OpStore %25 %110
-%111 = OpLoad %uint %43
-%113 = OpIAdd %uint %111 %uint_1
-OpStore %26 %113
-%114 = OpLoad %ulong %25
-OpStore %41 %114
-%115 = OpLoad %uint %24
-OpStore %42 %115
-%116 = OpLoad %uint %26
-OpStore %43 %116
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %117
-%118 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %120
-%121 = OpFunctionParameter %ulong
-%122 = OpFunctionParameter %uint
-%123 = OpLabel
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%71 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_uint Function
+%74 = OpVariable %_ptr_Function_uint Function
+%76 = OpVariable %_ptr_Function_bool Function
+%77 = OpVariable %_ptr_Function_uint Function
+%78 = OpVariable %_ptr_Function_uint Function
+%79 = OpVariable %_ptr_Function_uint Function
+%80 = OpVariable %_ptr_Function_uint Function
+%81 = OpVariable %_ptr_Function_uint Function
+%82 = OpVariable %_ptr_Function_uint Function
+%83 = OpVariable %_ptr_Function_uint Function
+%84 = OpVariable %_ptr_Function_uint Function
+%85 = OpVariable %_ptr_Function_uint Function
+%86 = OpVariable %_ptr_Function_uint Function
+%87 = OpVariable %_ptr_Function_uint Function
+%88 = OpVariable %_ptr_Function_uint Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_uint Function
+%91 = OpVariable %_ptr_Function_uint Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_bool Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_bool Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_bool Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_bool Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
 %130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_ulong Function
 %132 = OpVariable %_ptr_Function_ulong Function
 %133 = OpVariable %_ptr_Function_bool Function
 %134 = OpVariable %_ptr_Function_ulong Function
@@ -187,55 +102,458 @@ OpFunctionEnd
 %139 = OpVariable %_ptr_Function_ulong Function
 %140 = OpVariable %_ptr_Function_ulong Function
 %141 = OpVariable %_ptr_Function_ulong Function
-OpStore %130 %121
-OpStore %131 %122
-%142 = OpLoad %uint %131
-%143 = OpSConvert %ulong %142
-OpStore %132 %143
-OpBranch %124
-%124 = OpLabel
-%144 = OpLoad %ulong %130
-OpStore %140 %144
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_bool Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+OpStore %71 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%162 = OpLoad %ulong %71
+%163 = OpUConvert %uint %162
+OpStore %73 %163
+%165 = OpLoad %uint %73
+%166 = OpIAdd %uint %uint_2654435769 %165
+OpStore %74 %166
+OpStore %89 %ulong_14695981039346656037
+%168 = OpLoad %uint %74
+OpStore %90 %168
+OpStore %91 %uint_0
+OpBranch %6
+%6 = OpLabel
+%170 = OpLoad %uint %91
+%172 = OpSLessThan %bool %170 %uint_16
+OpStore %76 %172
+%173 = OpLoad %bool %76
+OpLoopMerge %8 %67 None
+OpBranchConditional %173 %7 %8
+%8 = OpLabel
+%175 = OpLoad %uint %73
+%176 = OpIAdd %uint %uint_4294967231 %175
+OpStore %81 %176
+%177 = OpLoad %uint %81
+%178 = OpLoad %uint %81
+%179 = OpIMul %uint %177 %178
+OpStore %82 %179
+OpBranch %13
+%13 = OpLabel
+%180 = OpLoad %uint %82
+%181 = OpSConvert %ulong %180
+OpStore %93 %181
+OpBranch %20
+%20 = OpLabel
+%182 = OpLoad %ulong %89
+OpStore %110 %182
+OpStore %111 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%184 = OpLoad %ulong %111
+%186 = OpULessThan %bool %184 %ulong_8
+OpStore %103 %186
+%187 = OpLoad %bool %103
+OpLoopMerge %23 %66 None
+OpBranchConditional %187 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%188 = OpLoad %uint %81
+%190 = OpIMul %uint %188 %uint_4294967295
+OpStore %83 %190
+OpBranch %25
+%25 = OpLabel
+%191 = OpLoad %uint %83
+%192 = OpSConvert %ulong %191
+OpStore %112 %192
+OpBranch %27
+%27 = OpLabel
+%193 = OpLoad %ulong %110
+OpStore %120 %193
+OpStore %121 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%194 = OpLoad %ulong %121
+%195 = OpULessThan %bool %194 %ulong_8
+OpStore %113 %195
+%196 = OpLoad %bool %113
+OpLoopMerge %30 %64 None
+OpBranchConditional %196 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%197 = OpLoad %uint %90
+%198 = OpLoad %uint %81
+%199 = OpIMul %uint %197 %198
+OpStore %84 %199
+OpBranch %32
+%32 = OpLabel
+%200 = OpLoad %uint %84
+%201 = OpSConvert %ulong %200
+OpStore %122 %201
+OpBranch %34
+%34 = OpLabel
+%202 = OpLoad %ulong %120
+OpStore %130 %202
+OpStore %131 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%203 = OpLoad %ulong %131
+%204 = OpULessThan %bool %203 %ulong_8
+OpStore %123 %204
+%205 = OpLoad %bool %123
+OpLoopMerge %37 %63 None
+OpBranchConditional %205 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%206 = OpLoad %uint %81
+%207 = OpLoad %uint %90
+%208 = OpIMul %uint %206 %207
+OpStore %85 %208
+OpBranch %39
+%39 = OpLabel
+%209 = OpLoad %uint %85
+%210 = OpSConvert %ulong %209
+OpStore %132 %210
+OpBranch %41
+%41 = OpLabel
+%211 = OpLoad %ulong %130
+OpStore %140 %211
 OpStore %141 %ulong_0
-OpBranch %125
-%125 = OpLabel
-%146 = OpLoad %ulong %141
-%148 = OpULessThan %bool %146 %ulong_8
-OpStore %133 %148
-%149 = OpLoad %bool %133
-OpLoopMerge %127 %129 None
-OpBranchConditional %149 %126 %127
-%127 = OpLabel
-OpBranch %128
-%128 = OpLabel
-%150 = OpLoad %ulong %140
-OpReturnValue %150
-%126 = OpLabel
-%151 = OpLoad %ulong %141
-%152 = OpIMul %ulong %151 %ulong_8
-OpStore %134 %152
-%153 = OpLoad %ulong %132
-%154 = OpLoad %ulong %134
-%155 = OpShiftRightLogical %ulong %153 %154
-OpStore %135 %155
-%156 = OpLoad %ulong %135
-%158 = OpBitwiseAnd %ulong %156 %ulong_255
-OpStore %136 %158
-%159 = OpLoad %ulong %140
-%160 = OpLoad %ulong %136
-%161 = OpBitwiseXor %ulong %159 %160
-OpStore %137 %161
-%162 = OpLoad %ulong %137
-%164 = OpIMul %ulong %162 %ulong_1099511628211
-OpStore %138 %164
-%165 = OpLoad %ulong %141
-%167 = OpIAdd %ulong %165 %ulong_1
-OpStore %139 %167
-%168 = OpLoad %ulong %138
-OpStore %140 %168
-%169 = OpLoad %ulong %139
-OpStore %141 %169
-OpBranch %129
-%129 = OpLabel
-OpBranch %125
+OpBranch %42
+%42 = OpLabel
+%212 = OpLoad %ulong %141
+%213 = OpULessThan %bool %212 %ulong_8
+OpStore %133 %213
+%214 = OpLoad %bool %133
+OpLoopMerge %44 %62 None
+OpBranchConditional %214 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%216 = OpLoad %uint %73
+%217 = OpIAdd %uint %uint_65537 %216
+OpStore %86 %217
+%218 = OpLoad %uint %86
+%219 = OpLoad %uint %86
+%220 = OpIMul %uint %218 %219
+OpStore %87 %220
+OpBranch %46
+%46 = OpLabel
+%221 = OpLoad %uint %87
+%222 = OpSConvert %ulong %221
+OpStore %142 %222
+OpBranch %48
+%48 = OpLabel
+%223 = OpLoad %ulong %140
+OpStore %150 %223
+OpStore %151 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%224 = OpLoad %ulong %151
+%225 = OpULessThan %bool %224 %ulong_8
+OpStore %143 %225
+%226 = OpLoad %bool %143
+OpLoopMerge %51 %61 None
+OpBranchConditional %226 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%227 = OpLoad %uint %86
+%228 = OpIMul %uint %227 %uint_4294967295
+OpStore %88 %228
+OpBranch %53
+%53 = OpLabel
+%229 = OpLoad %uint %88
+%230 = OpSConvert %ulong %229
+OpStore %152 %230
+OpBranch %55
+%55 = OpLabel
+%231 = OpLoad %ulong %150
+OpStore %160 %231
+OpStore %161 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%232 = OpLoad %ulong %161
+%233 = OpULessThan %bool %232 %ulong_8
+OpStore %153 %233
+%234 = OpLoad %bool %153
+OpLoopMerge %58 %60 None
+OpBranchConditional %234 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%235 = OpLoad %ulong %160
+OpReturnValue %235
+%57 = OpLabel
+%236 = OpLoad %ulong %161
+%237 = OpIMul %ulong %236 %ulong_8
+OpStore %154 %237
+%238 = OpLoad %ulong %152
+%239 = OpLoad %ulong %154
+%240 = OpShiftRightLogical %ulong %238 %239
+OpStore %155 %240
+%241 = OpLoad %ulong %155
+%243 = OpBitwiseAnd %ulong %241 %ulong_255
+OpStore %156 %243
+%244 = OpLoad %ulong %160
+%245 = OpLoad %ulong %156
+%246 = OpBitwiseXor %ulong %244 %245
+OpStore %157 %246
+%247 = OpLoad %ulong %157
+%249 = OpIMul %ulong %247 %ulong_1099511628211
+OpStore %158 %249
+%250 = OpLoad %ulong %161
+%252 = OpIAdd %ulong %250 %ulong_1
+OpStore %159 %252
+%253 = OpLoad %ulong %158
+OpStore %160 %253
+%254 = OpLoad %ulong %159
+OpStore %161 %254
+OpBranch %60
+%50 = OpLabel
+%255 = OpLoad %ulong %151
+%256 = OpIMul %ulong %255 %ulong_8
+OpStore %144 %256
+%257 = OpLoad %ulong %142
+%258 = OpLoad %ulong %144
+%259 = OpShiftRightLogical %ulong %257 %258
+OpStore %145 %259
+%260 = OpLoad %ulong %145
+%261 = OpBitwiseAnd %ulong %260 %ulong_255
+OpStore %146 %261
+%262 = OpLoad %ulong %150
+%263 = OpLoad %ulong %146
+%264 = OpBitwiseXor %ulong %262 %263
+OpStore %147 %264
+%265 = OpLoad %ulong %147
+%266 = OpIMul %ulong %265 %ulong_1099511628211
+OpStore %148 %266
+%267 = OpLoad %ulong %151
+%268 = OpIAdd %ulong %267 %ulong_1
+OpStore %149 %268
+%269 = OpLoad %ulong %148
+OpStore %150 %269
+%270 = OpLoad %ulong %149
+OpStore %151 %270
+OpBranch %61
+%43 = OpLabel
+%271 = OpLoad %ulong %141
+%272 = OpIMul %ulong %271 %ulong_8
+OpStore %134 %272
+%273 = OpLoad %ulong %132
+%274 = OpLoad %ulong %134
+%275 = OpShiftRightLogical %ulong %273 %274
+OpStore %135 %275
+%276 = OpLoad %ulong %135
+%277 = OpBitwiseAnd %ulong %276 %ulong_255
+OpStore %136 %277
+%278 = OpLoad %ulong %140
+%279 = OpLoad %ulong %136
+%280 = OpBitwiseXor %ulong %278 %279
+OpStore %137 %280
+%281 = OpLoad %ulong %137
+%282 = OpIMul %ulong %281 %ulong_1099511628211
+OpStore %138 %282
+%283 = OpLoad %ulong %141
+%284 = OpIAdd %ulong %283 %ulong_1
+OpStore %139 %284
+%285 = OpLoad %ulong %138
+OpStore %140 %285
+%286 = OpLoad %ulong %139
+OpStore %141 %286
+OpBranch %62
+%36 = OpLabel
+%287 = OpLoad %ulong %131
+%288 = OpIMul %ulong %287 %ulong_8
+OpStore %124 %288
+%289 = OpLoad %ulong %122
+%290 = OpLoad %ulong %124
+%291 = OpShiftRightLogical %ulong %289 %290
+OpStore %125 %291
+%292 = OpLoad %ulong %125
+%293 = OpBitwiseAnd %ulong %292 %ulong_255
+OpStore %126 %293
+%294 = OpLoad %ulong %130
+%295 = OpLoad %ulong %126
+%296 = OpBitwiseXor %ulong %294 %295
+OpStore %127 %296
+%297 = OpLoad %ulong %127
+%298 = OpIMul %ulong %297 %ulong_1099511628211
+OpStore %128 %298
+%299 = OpLoad %ulong %131
+%300 = OpIAdd %ulong %299 %ulong_1
+OpStore %129 %300
+%301 = OpLoad %ulong %128
+OpStore %130 %301
+%302 = OpLoad %ulong %129
+OpStore %131 %302
+OpBranch %63
+%29 = OpLabel
+%303 = OpLoad %ulong %121
+%304 = OpIMul %ulong %303 %ulong_8
+OpStore %114 %304
+%305 = OpLoad %ulong %112
+%306 = OpLoad %ulong %114
+%307 = OpShiftRightLogical %ulong %305 %306
+OpStore %115 %307
+%308 = OpLoad %ulong %115
+%309 = OpBitwiseAnd %ulong %308 %ulong_255
+OpStore %116 %309
+%310 = OpLoad %ulong %120
+%311 = OpLoad %ulong %116
+%312 = OpBitwiseXor %ulong %310 %311
+OpStore %117 %312
+%313 = OpLoad %ulong %117
+%314 = OpIMul %ulong %313 %ulong_1099511628211
+OpStore %118 %314
+%315 = OpLoad %ulong %121
+%316 = OpIAdd %ulong %315 %ulong_1
+OpStore %119 %316
+%317 = OpLoad %ulong %118
+OpStore %120 %317
+%318 = OpLoad %ulong %119
+OpStore %121 %318
+OpBranch %64
+%22 = OpLabel
+%319 = OpLoad %ulong %111
+%320 = OpIMul %ulong %319 %ulong_8
+OpStore %104 %320
+%321 = OpLoad %ulong %93
+%322 = OpLoad %ulong %104
+%323 = OpShiftRightLogical %ulong %321 %322
+OpStore %105 %323
+%324 = OpLoad %ulong %105
+%325 = OpBitwiseAnd %ulong %324 %ulong_255
+OpStore %106 %325
+%326 = OpLoad %ulong %110
+%327 = OpLoad %ulong %106
+%328 = OpBitwiseXor %ulong %326 %327
+OpStore %107 %328
+%329 = OpLoad %ulong %107
+%330 = OpIMul %ulong %329 %ulong_1099511628211
+OpStore %108 %330
+%331 = OpLoad %ulong %111
+%332 = OpIAdd %ulong %331 %ulong_1
+OpStore %109 %332
+%333 = OpLoad %ulong %108
+OpStore %110 %333
+%334 = OpLoad %ulong %109
+OpStore %111 %334
+OpBranch %66
+%7 = OpLabel
+%336 = OpLoad %uint %91
+%337 = OpIMul %uint %uint_2 %336
+OpStore %77 %337
+%338 = OpLoad %uint %77
+%340 = OpIAdd %uint %338 %uint_3
+OpStore %78 %340
+%341 = OpLoad %uint %90
+%342 = OpLoad %uint %78
+%343 = OpIMul %uint %341 %342
+OpStore %79 %343
+OpBranch %11
+%11 = OpLabel
+%344 = OpLoad %uint %79
+%345 = OpSConvert %ulong %344
+OpStore %92 %345
+OpBranch %15
+%15 = OpLabel
+%346 = OpLoad %ulong %89
+OpStore %101 %346
+OpStore %102 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%347 = OpLoad %ulong %102
+%348 = OpULessThan %bool %347 %ulong_8
+OpStore %94 %348
+%349 = OpLoad %bool %94
+OpLoopMerge %18 %65 None
+OpBranchConditional %349 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%350 = OpLoad %uint %91
+%352 = OpIAdd %uint %350 %uint_1
+OpStore %80 %352
+%353 = OpLoad %ulong %101
+OpStore %89 %353
+%354 = OpLoad %uint %79
+OpStore %90 %354
+%355 = OpLoad %uint %80
+OpStore %91 %355
+OpBranch %67
+%17 = OpLabel
+%356 = OpLoad %ulong %102
+%357 = OpIMul %ulong %356 %ulong_8
+OpStore %95 %357
+%358 = OpLoad %ulong %92
+%359 = OpLoad %ulong %95
+%360 = OpShiftRightLogical %ulong %358 %359
+OpStore %96 %360
+%361 = OpLoad %ulong %96
+%362 = OpBitwiseAnd %ulong %361 %ulong_255
+OpStore %97 %362
+%363 = OpLoad %ulong %101
+%364 = OpLoad %ulong %97
+%365 = OpBitwiseXor %ulong %363 %364
+OpStore %98 %365
+%366 = OpLoad %ulong %98
+%367 = OpIMul %ulong %366 %ulong_1099511628211
+OpStore %99 %367
+%368 = OpLoad %ulong %102
+%369 = OpIAdd %ulong %368 %ulong_1
+OpStore %100 %369
+%370 = OpLoad %ulong %99
+OpStore %101 %370
+%371 = OpLoad %ulong %100
+OpStore %102 %371
+OpBranch %65
+%60 = OpLabel
+OpBranch %56
+%61 = OpLabel
+OpBranch %49
+%62 = OpLabel
+OpBranch %42
+%63 = OpLabel
+OpBranch %35
+%64 = OpLabel
+OpBranch %28
+%65 = OpLabel
+OpBranch %16
+%66 = OpLabel
+OpBranch %21
+%67 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/mul_i64.dis
+++ b/test/golden/spirv/scalar/mul_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 160
+; Bound: 344
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,221 +9,515 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.mul_i64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_11400714819323198485 = OpConstant %ulong 11400714819323198485
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_16 = OpConstant %ulong 16
 %ulong_18446744073709551553 = OpConstant %ulong 18446744073709551553
+%ulong_8 = OpConstant %ulong 8
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
 %ulong_4294967311 = OpConstant %ulong 4294967311
-%ulong_2 = OpConstant %ulong 2
-%ulong_3 = OpConstant %ulong 3
-%ulong_1 = OpConstant %ulong 1
-%112 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%115 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_bool Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %6
-%41 = OpFunctionCall %ulong %2
-OpStore %15 %41
-%43 = OpLoad %ulong %14
-%44 = OpIAdd %ulong %ulong_11400714819323198485 %43
-OpStore %16 %44
-%45 = OpLoad %ulong %15
-OpStore %38 %45
-%46 = OpLoad %ulong %16
-OpStore %39 %46
-OpStore %40 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%48 = OpLoad %ulong %40
-%50 = OpSLessThan %bool %48 %ulong_16
-OpStore %18 %50
-%51 = OpLoad %bool %18
-OpLoopMerge %10 %11 None
-OpBranchConditional %51 %9 %10
-%10 = OpLabel
-%53 = OpLoad %ulong %14
-%54 = OpIAdd %ulong %ulong_18446744073709551553 %53
-OpStore %24 %54
-%55 = OpLoad %ulong %24
-%56 = OpLoad %ulong %24
-%57 = OpIMul %ulong %55 %56
-OpStore %25 %57
-%58 = OpLoad %ulong %38
-%59 = OpLoad %ulong %25
-%60 = OpFunctionCall %ulong %3 %58 %59
-OpStore %26 %60
-%61 = OpLoad %ulong %24
-%63 = OpIMul %ulong %61 %ulong_18446744073709551615
-OpStore %27 %63
-%64 = OpLoad %ulong %26
-%65 = OpLoad %ulong %27
-%66 = OpFunctionCall %ulong %3 %64 %65
-OpStore %28 %66
-%67 = OpLoad %ulong %39
-%68 = OpLoad %ulong %24
-%69 = OpIMul %ulong %67 %68
-OpStore %29 %69
-%70 = OpLoad %ulong %28
-%71 = OpLoad %ulong %29
-%72 = OpFunctionCall %ulong %3 %70 %71
-OpStore %30 %72
-%73 = OpLoad %ulong %24
-%74 = OpLoad %ulong %39
-%75 = OpIMul %ulong %73 %74
-OpStore %31 %75
-%76 = OpLoad %ulong %30
-%77 = OpLoad %ulong %31
-%78 = OpFunctionCall %ulong %3 %76 %77
-OpStore %32 %78
-%80 = OpLoad %ulong %14
-%81 = OpIAdd %ulong %ulong_4294967311 %80
-OpStore %33 %81
-%82 = OpLoad %ulong %33
-%83 = OpLoad %ulong %33
-%84 = OpIMul %ulong %82 %83
-OpStore %34 %84
-%85 = OpLoad %ulong %32
-%86 = OpLoad %ulong %34
-%87 = OpFunctionCall %ulong %3 %85 %86
-OpStore %35 %87
-%88 = OpLoad %ulong %33
-%89 = OpIMul %ulong %88 %ulong_18446744073709551615
-OpStore %36 %89
-%90 = OpLoad %ulong %35
-%91 = OpLoad %ulong %36
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %37 %92
-%93 = OpLoad %ulong %37
-OpReturnValue %93
-%9 = OpLabel
-%95 = OpLoad %ulong %40
-%96 = OpIMul %ulong %ulong_2 %95
-OpStore %19 %96
-%97 = OpLoad %ulong %19
-%99 = OpIAdd %ulong %97 %ulong_3
-OpStore %20 %99
-%100 = OpLoad %ulong %39
-%101 = OpLoad %ulong %20
-%102 = OpIMul %ulong %100 %101
-OpStore %21 %102
-%103 = OpLoad %ulong %38
-%104 = OpLoad %ulong %21
-%105 = OpFunctionCall %ulong %3 %103 %104
-OpStore %22 %105
-%106 = OpLoad %ulong %40
-%108 = OpIAdd %ulong %106 %ulong_1
-OpStore %23 %108
-%109 = OpLoad %ulong %22
-OpStore %38 %109
-%110 = OpLoad %ulong %21
-OpStore %39 %110
-%111 = OpLoad %ulong %23
-OpStore %40 %111
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %112
-%113 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %115
-%116 = OpFunctionParameter %ulong
-%117 = OpFunctionParameter %ulong
-%118 = OpLabel
-%125 = OpVariable %_ptr_Function_ulong Function
+%ulong_1 = OpConstant %ulong 1
+%ulong_2 = OpConstant %ulong 2
+%ulong_3 = OpConstant %ulong 3
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_bool Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_bool Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_bool Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_bool Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_bool Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_bool Function
 %126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_bool Function
+%127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
 %129 = OpVariable %_ptr_Function_ulong Function
 %130 = OpVariable %_ptr_Function_ulong Function
 %131 = OpVariable %_ptr_Function_ulong Function
 %132 = OpVariable %_ptr_Function_ulong Function
 %133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_bool Function
 %135 = OpVariable %_ptr_Function_ulong Function
-OpStore %125 %116
-OpStore %126 %117
-OpBranch %119
-%119 = OpLabel
-%136 = OpLoad %ulong %125
-OpStore %134 %136
-OpStore %135 %ulong_0
-OpBranch %120
-%120 = OpLabel
-%137 = OpLoad %ulong %135
-%139 = OpULessThan %bool %137 %ulong_8
-OpStore %127 %139
-%140 = OpLoad %bool %127
-OpLoopMerge %122 %124 None
-OpBranchConditional %140 %121 %122
-%122 = OpLabel
-OpBranch %123
-%123 = OpLabel
-%141 = OpLoad %ulong %134
-OpReturnValue %141
-%121 = OpLabel
-%142 = OpLoad %ulong %135
-%143 = OpIMul %ulong %142 %ulong_8
-OpStore %128 %143
-%144 = OpLoad %ulong %126
-%145 = OpLoad %ulong %128
-%146 = OpShiftRightLogical %ulong %144 %145
-OpStore %129 %146
-%147 = OpLoad %ulong %129
-%149 = OpBitwiseAnd %ulong %147 %ulong_255
-OpStore %130 %149
-%150 = OpLoad %ulong %134
-%151 = OpLoad %ulong %130
-%152 = OpBitwiseXor %ulong %150 %151
-OpStore %131 %152
-%153 = OpLoad %ulong %131
-%155 = OpIMul %ulong %153 %ulong_1099511628211
-OpStore %132 %155
-%156 = OpLoad %ulong %135
-%157 = OpIAdd %ulong %156 %ulong_1
-OpStore %133 %157
-%158 = OpLoad %ulong %132
-OpStore %134 %158
-%159 = OpLoad %ulong %133
-OpStore %135 %159
-OpBranch %124
-%124 = OpLabel
-OpBranch %120
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_bool Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+OpStore %70 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%153 = OpLoad %ulong %70
+%154 = OpIAdd %ulong %ulong_11400714819323198485 %153
+OpStore %71 %154
+OpStore %86 %ulong_14695981039346656037
+%156 = OpLoad %ulong %71
+OpStore %87 %156
+OpStore %88 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%158 = OpLoad %ulong %88
+%160 = OpSLessThan %bool %158 %ulong_16
+OpStore %73 %160
+%161 = OpLoad %bool %73
+OpLoopMerge %8 %67 None
+OpBranchConditional %161 %7 %8
+%8 = OpLabel
+%163 = OpLoad %ulong %70
+%164 = OpIAdd %ulong %ulong_18446744073709551553 %163
+OpStore %78 %164
+%165 = OpLoad %ulong %78
+%166 = OpLoad %ulong %78
+%167 = OpIMul %ulong %165 %166
+OpStore %79 %167
+OpBranch %13
+%13 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%168 = OpLoad %ulong %86
+OpStore %105 %168
+OpStore %106 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%169 = OpLoad %ulong %106
+%171 = OpULessThan %bool %169 %ulong_8
+OpStore %98 %171
+%172 = OpLoad %bool %98
+OpLoopMerge %23 %66 None
+OpBranchConditional %172 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%173 = OpLoad %ulong %78
+%175 = OpIMul %ulong %173 %ulong_18446744073709551615
+OpStore %80 %175
+OpBranch %25
+%25 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%176 = OpLoad %ulong %105
+OpStore %114 %176
+OpStore %115 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%177 = OpLoad %ulong %115
+%178 = OpULessThan %bool %177 %ulong_8
+OpStore %107 %178
+%179 = OpLoad %bool %107
+OpLoopMerge %30 %64 None
+OpBranchConditional %179 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%180 = OpLoad %ulong %87
+%181 = OpLoad %ulong %78
+%182 = OpIMul %ulong %180 %181
+OpStore %81 %182
+OpBranch %32
+%32 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%183 = OpLoad %ulong %114
+OpStore %123 %183
+OpStore %124 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%184 = OpLoad %ulong %124
+%185 = OpULessThan %bool %184 %ulong_8
+OpStore %116 %185
+%186 = OpLoad %bool %116
+OpLoopMerge %37 %63 None
+OpBranchConditional %186 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%187 = OpLoad %ulong %78
+%188 = OpLoad %ulong %87
+%189 = OpIMul %ulong %187 %188
+OpStore %82 %189
+OpBranch %39
+%39 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%190 = OpLoad %ulong %123
+OpStore %132 %190
+OpStore %133 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%191 = OpLoad %ulong %133
+%192 = OpULessThan %bool %191 %ulong_8
+OpStore %125 %192
+%193 = OpLoad %bool %125
+OpLoopMerge %44 %62 None
+OpBranchConditional %193 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%195 = OpLoad %ulong %70
+%196 = OpIAdd %ulong %ulong_4294967311 %195
+OpStore %83 %196
+%197 = OpLoad %ulong %83
+%198 = OpLoad %ulong %83
+%199 = OpIMul %ulong %197 %198
+OpStore %84 %199
+OpBranch %46
+%46 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%200 = OpLoad %ulong %132
+OpStore %141 %200
+OpStore %142 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%201 = OpLoad %ulong %142
+%202 = OpULessThan %bool %201 %ulong_8
+OpStore %134 %202
+%203 = OpLoad %bool %134
+OpLoopMerge %51 %61 None
+OpBranchConditional %203 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%204 = OpLoad %ulong %83
+%205 = OpIMul %ulong %204 %ulong_18446744073709551615
+OpStore %85 %205
+OpBranch %53
+%53 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%206 = OpLoad %ulong %141
+OpStore %150 %206
+OpStore %151 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%207 = OpLoad %ulong %151
+%208 = OpULessThan %bool %207 %ulong_8
+OpStore %143 %208
+%209 = OpLoad %bool %143
+OpLoopMerge %58 %60 None
+OpBranchConditional %209 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%210 = OpLoad %ulong %150
+OpReturnValue %210
+%57 = OpLabel
+%211 = OpLoad %ulong %151
+%212 = OpIMul %ulong %211 %ulong_8
+OpStore %144 %212
+%213 = OpLoad %ulong %85
+%214 = OpLoad %ulong %144
+%215 = OpShiftRightLogical %ulong %213 %214
+OpStore %145 %215
+%216 = OpLoad %ulong %145
+%218 = OpBitwiseAnd %ulong %216 %ulong_255
+OpStore %146 %218
+%219 = OpLoad %ulong %150
+%220 = OpLoad %ulong %146
+%221 = OpBitwiseXor %ulong %219 %220
+OpStore %147 %221
+%222 = OpLoad %ulong %147
+%224 = OpIMul %ulong %222 %ulong_1099511628211
+OpStore %148 %224
+%225 = OpLoad %ulong %151
+%227 = OpIAdd %ulong %225 %ulong_1
+OpStore %149 %227
+%228 = OpLoad %ulong %148
+OpStore %150 %228
+%229 = OpLoad %ulong %149
+OpStore %151 %229
+OpBranch %60
+%50 = OpLabel
+%230 = OpLoad %ulong %142
+%231 = OpIMul %ulong %230 %ulong_8
+OpStore %135 %231
+%232 = OpLoad %ulong %84
+%233 = OpLoad %ulong %135
+%234 = OpShiftRightLogical %ulong %232 %233
+OpStore %136 %234
+%235 = OpLoad %ulong %136
+%236 = OpBitwiseAnd %ulong %235 %ulong_255
+OpStore %137 %236
+%237 = OpLoad %ulong %141
+%238 = OpLoad %ulong %137
+%239 = OpBitwiseXor %ulong %237 %238
+OpStore %138 %239
+%240 = OpLoad %ulong %138
+%241 = OpIMul %ulong %240 %ulong_1099511628211
+OpStore %139 %241
+%242 = OpLoad %ulong %142
+%243 = OpIAdd %ulong %242 %ulong_1
+OpStore %140 %243
+%244 = OpLoad %ulong %139
+OpStore %141 %244
+%245 = OpLoad %ulong %140
+OpStore %142 %245
+OpBranch %61
+%43 = OpLabel
+%246 = OpLoad %ulong %133
+%247 = OpIMul %ulong %246 %ulong_8
+OpStore %126 %247
+%248 = OpLoad %ulong %82
+%249 = OpLoad %ulong %126
+%250 = OpShiftRightLogical %ulong %248 %249
+OpStore %127 %250
+%251 = OpLoad %ulong %127
+%252 = OpBitwiseAnd %ulong %251 %ulong_255
+OpStore %128 %252
+%253 = OpLoad %ulong %132
+%254 = OpLoad %ulong %128
+%255 = OpBitwiseXor %ulong %253 %254
+OpStore %129 %255
+%256 = OpLoad %ulong %129
+%257 = OpIMul %ulong %256 %ulong_1099511628211
+OpStore %130 %257
+%258 = OpLoad %ulong %133
+%259 = OpIAdd %ulong %258 %ulong_1
+OpStore %131 %259
+%260 = OpLoad %ulong %130
+OpStore %132 %260
+%261 = OpLoad %ulong %131
+OpStore %133 %261
+OpBranch %62
+%36 = OpLabel
+%262 = OpLoad %ulong %124
+%263 = OpIMul %ulong %262 %ulong_8
+OpStore %117 %263
+%264 = OpLoad %ulong %81
+%265 = OpLoad %ulong %117
+%266 = OpShiftRightLogical %ulong %264 %265
+OpStore %118 %266
+%267 = OpLoad %ulong %118
+%268 = OpBitwiseAnd %ulong %267 %ulong_255
+OpStore %119 %268
+%269 = OpLoad %ulong %123
+%270 = OpLoad %ulong %119
+%271 = OpBitwiseXor %ulong %269 %270
+OpStore %120 %271
+%272 = OpLoad %ulong %120
+%273 = OpIMul %ulong %272 %ulong_1099511628211
+OpStore %121 %273
+%274 = OpLoad %ulong %124
+%275 = OpIAdd %ulong %274 %ulong_1
+OpStore %122 %275
+%276 = OpLoad %ulong %121
+OpStore %123 %276
+%277 = OpLoad %ulong %122
+OpStore %124 %277
+OpBranch %63
+%29 = OpLabel
+%278 = OpLoad %ulong %115
+%279 = OpIMul %ulong %278 %ulong_8
+OpStore %108 %279
+%280 = OpLoad %ulong %80
+%281 = OpLoad %ulong %108
+%282 = OpShiftRightLogical %ulong %280 %281
+OpStore %109 %282
+%283 = OpLoad %ulong %109
+%284 = OpBitwiseAnd %ulong %283 %ulong_255
+OpStore %110 %284
+%285 = OpLoad %ulong %114
+%286 = OpLoad %ulong %110
+%287 = OpBitwiseXor %ulong %285 %286
+OpStore %111 %287
+%288 = OpLoad %ulong %111
+%289 = OpIMul %ulong %288 %ulong_1099511628211
+OpStore %112 %289
+%290 = OpLoad %ulong %115
+%291 = OpIAdd %ulong %290 %ulong_1
+OpStore %113 %291
+%292 = OpLoad %ulong %112
+OpStore %114 %292
+%293 = OpLoad %ulong %113
+OpStore %115 %293
+OpBranch %64
+%22 = OpLabel
+%294 = OpLoad %ulong %106
+%295 = OpIMul %ulong %294 %ulong_8
+OpStore %99 %295
+%296 = OpLoad %ulong %79
+%297 = OpLoad %ulong %99
+%298 = OpShiftRightLogical %ulong %296 %297
+OpStore %100 %298
+%299 = OpLoad %ulong %100
+%300 = OpBitwiseAnd %ulong %299 %ulong_255
+OpStore %101 %300
+%301 = OpLoad %ulong %105
+%302 = OpLoad %ulong %101
+%303 = OpBitwiseXor %ulong %301 %302
+OpStore %102 %303
+%304 = OpLoad %ulong %102
+%305 = OpIMul %ulong %304 %ulong_1099511628211
+OpStore %103 %305
+%306 = OpLoad %ulong %106
+%307 = OpIAdd %ulong %306 %ulong_1
+OpStore %104 %307
+%308 = OpLoad %ulong %103
+OpStore %105 %308
+%309 = OpLoad %ulong %104
+OpStore %106 %309
+OpBranch %66
+%7 = OpLabel
+%311 = OpLoad %ulong %88
+%312 = OpIMul %ulong %ulong_2 %311
+OpStore %74 %312
+%313 = OpLoad %ulong %74
+%315 = OpIAdd %ulong %313 %ulong_3
+OpStore %75 %315
+%316 = OpLoad %ulong %87
+%317 = OpLoad %ulong %75
+%318 = OpIMul %ulong %316 %317
+OpStore %76 %318
+OpBranch %11
+%11 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%319 = OpLoad %ulong %86
+OpStore %96 %319
+OpStore %97 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%320 = OpLoad %ulong %97
+%321 = OpULessThan %bool %320 %ulong_8
+OpStore %89 %321
+%322 = OpLoad %bool %89
+OpLoopMerge %18 %65 None
+OpBranchConditional %322 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%323 = OpLoad %ulong %88
+%324 = OpIAdd %ulong %323 %ulong_1
+OpStore %77 %324
+%325 = OpLoad %ulong %96
+OpStore %86 %325
+%326 = OpLoad %ulong %76
+OpStore %87 %326
+%327 = OpLoad %ulong %77
+OpStore %88 %327
+OpBranch %67
+%17 = OpLabel
+%328 = OpLoad %ulong %97
+%329 = OpIMul %ulong %328 %ulong_8
+OpStore %90 %329
+%330 = OpLoad %ulong %76
+%331 = OpLoad %ulong %90
+%332 = OpShiftRightLogical %ulong %330 %331
+OpStore %91 %332
+%333 = OpLoad %ulong %91
+%334 = OpBitwiseAnd %ulong %333 %ulong_255
+OpStore %92 %334
+%335 = OpLoad %ulong %96
+%336 = OpLoad %ulong %92
+%337 = OpBitwiseXor %ulong %335 %336
+OpStore %93 %337
+%338 = OpLoad %ulong %93
+%339 = OpIMul %ulong %338 %ulong_1099511628211
+OpStore %94 %339
+%340 = OpLoad %ulong %97
+%341 = OpIAdd %ulong %340 %ulong_1
+OpStore %95 %341
+%342 = OpLoad %ulong %94
+OpStore %96 %342
+%343 = OpLoad %ulong %95
+OpStore %97 %343
+OpBranch %65
+%60 = OpLabel
+OpBranch %56
+%61 = OpLabel
+OpBranch %49
+%62 = OpLabel
+OpBranch %42
+%63 = OpLabel
+OpBranch %35
+%64 = OpLabel
+OpBranch %28
+%65 = OpLabel
+OpBranch %16
+%66 = OpLabel
+OpBranch %21
+%67 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/mul_u32.dis
+++ b/test/golden/spirv/scalar/mul_u32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 171
+; Bound: 373
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,177 +9,93 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.mul_u32.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
-%uint = OpTypeInt 32 0
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
+%uint = OpTypeInt 32 0
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
 %uint_2654435761 = OpConstant %uint 2654435761
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_0 = OpConstant %uint 0
 %uint_16 = OpConstant %uint 16
 %uint_4294967231 = OpConstant %uint 4294967231
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_65537 = OpConstant %uint 65537
 %uint_65535 = OpConstant %uint 65535
-%uint_2 = OpConstant %uint 2
-%uint_3 = OpConstant %uint 3
-%uint_1 = OpConstant %uint 1
-%118 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%121 = OpTypeFunction %ulong %ulong %uint
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
 %ulong_1 = OpConstant %ulong 1
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_bool Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uint Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_uint Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uint Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uint Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uint Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uint Function
-%37 = OpVariable %_ptr_Function_uint Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_uint Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uint Function
-%43 = OpVariable %_ptr_Function_uint Function
-OpStore %15 %6
-%44 = OpFunctionCall %ulong %2
-OpStore %16 %44
-%45 = OpLoad %ulong %15
-%46 = OpUConvert %uint %45
-OpStore %18 %46
-%48 = OpLoad %uint %18
-%49 = OpIAdd %uint %uint_2654435761 %48
-OpStore %19 %49
-%50 = OpLoad %ulong %16
-OpStore %41 %50
-%51 = OpLoad %uint %19
-OpStore %42 %51
-OpStore %43 %uint_0
-OpBranch %8
-%8 = OpLabel
-%53 = OpLoad %uint %43
-%55 = OpULessThan %bool %53 %uint_16
-OpStore %21 %55
-%56 = OpLoad %bool %21
-OpLoopMerge %10 %11 None
-OpBranchConditional %56 %9 %10
-%10 = OpLabel
-%58 = OpLoad %uint %18
-%59 = OpIAdd %uint %uint_4294967231 %58
-OpStore %27 %59
-%60 = OpLoad %uint %27
-%61 = OpLoad %uint %27
-%62 = OpIMul %uint %60 %61
-OpStore %28 %62
-%63 = OpLoad %ulong %41
-%64 = OpLoad %uint %28
-%65 = OpFunctionCall %ulong %3 %63 %64
-OpStore %29 %65
-%66 = OpLoad %uint %27
-%68 = OpIMul %uint %66 %uint_4294967295
-OpStore %30 %68
-%69 = OpLoad %ulong %29
-%70 = OpLoad %uint %30
-%71 = OpFunctionCall %ulong %3 %69 %70
-OpStore %31 %71
-%72 = OpLoad %uint %42
-%73 = OpLoad %uint %27
-%74 = OpIMul %uint %72 %73
-OpStore %32 %74
-%75 = OpLoad %ulong %31
-%76 = OpLoad %uint %32
-%77 = OpFunctionCall %ulong %3 %75 %76
-OpStore %33 %77
-%78 = OpLoad %uint %27
-%79 = OpLoad %uint %42
-%80 = OpIMul %uint %78 %79
-OpStore %34 %80
-%81 = OpLoad %ulong %33
-%82 = OpLoad %uint %34
-%83 = OpFunctionCall %ulong %3 %81 %82
-OpStore %35 %83
-%85 = OpLoad %uint %18
-%86 = OpIAdd %uint %uint_65537 %85
-OpStore %36 %86
-%87 = OpLoad %uint %36
-%88 = OpLoad %uint %36
-%89 = OpIMul %uint %87 %88
-OpStore %37 %89
-%90 = OpLoad %ulong %35
-%91 = OpLoad %uint %37
-%92 = OpFunctionCall %ulong %3 %90 %91
-OpStore %38 %92
-%93 = OpLoad %uint %36
-%95 = OpIMul %uint %93 %uint_65535
-OpStore %39 %95
-%96 = OpLoad %ulong %38
-%97 = OpLoad %uint %39
-%98 = OpFunctionCall %ulong %3 %96 %97
-OpStore %40 %98
-%99 = OpLoad %ulong %40
-OpReturnValue %99
-%9 = OpLabel
-%101 = OpLoad %uint %43
-%102 = OpIMul %uint %uint_2 %101
-OpStore %22 %102
-%103 = OpLoad %uint %22
-%105 = OpIAdd %uint %103 %uint_3
-OpStore %23 %105
-%106 = OpLoad %uint %42
-%107 = OpLoad %uint %23
-%108 = OpIMul %uint %106 %107
-OpStore %24 %108
-%109 = OpLoad %ulong %41
-%110 = OpLoad %uint %24
-%111 = OpFunctionCall %ulong %3 %109 %110
-OpStore %25 %111
-%112 = OpLoad %uint %43
-%114 = OpIAdd %uint %112 %uint_1
-OpStore %26 %114
-%115 = OpLoad %ulong %25
-OpStore %41 %115
-%116 = OpLoad %uint %24
-OpStore %42 %116
-%117 = OpLoad %uint %26
-OpStore %43 %117
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %118
-%119 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %121
-%122 = OpFunctionParameter %ulong
-%123 = OpFunctionParameter %uint
-%124 = OpLabel
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%71 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_uint Function
+%74 = OpVariable %_ptr_Function_uint Function
+%76 = OpVariable %_ptr_Function_bool Function
+%77 = OpVariable %_ptr_Function_uint Function
+%78 = OpVariable %_ptr_Function_uint Function
+%79 = OpVariable %_ptr_Function_uint Function
+%80 = OpVariable %_ptr_Function_uint Function
+%81 = OpVariable %_ptr_Function_uint Function
+%82 = OpVariable %_ptr_Function_uint Function
+%83 = OpVariable %_ptr_Function_uint Function
+%84 = OpVariable %_ptr_Function_uint Function
+%85 = OpVariable %_ptr_Function_uint Function
+%86 = OpVariable %_ptr_Function_uint Function
+%87 = OpVariable %_ptr_Function_uint Function
+%88 = OpVariable %_ptr_Function_uint Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_uint Function
+%91 = OpVariable %_ptr_Function_uint Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_bool Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_bool Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_bool Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_bool Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_ulong Function
 %131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_bool Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_bool Function
+%134 = OpVariable %_ptr_Function_ulong Function
 %135 = OpVariable %_ptr_Function_ulong Function
 %136 = OpVariable %_ptr_Function_ulong Function
 %137 = OpVariable %_ptr_Function_ulong Function
@@ -188,55 +104,457 @@ OpFunctionEnd
 %140 = OpVariable %_ptr_Function_ulong Function
 %141 = OpVariable %_ptr_Function_ulong Function
 %142 = OpVariable %_ptr_Function_ulong Function
-OpStore %131 %122
-OpStore %132 %123
-%143 = OpLoad %uint %132
-%144 = OpUConvert %ulong %143
-OpStore %133 %144
-OpBranch %125
-%125 = OpLabel
-%145 = OpLoad %ulong %131
-OpStore %141 %145
-OpStore %142 %ulong_0
-OpBranch %126
-%126 = OpLabel
-%147 = OpLoad %ulong %142
-%149 = OpULessThan %bool %147 %ulong_8
-OpStore %134 %149
-%150 = OpLoad %bool %134
-OpLoopMerge %128 %130 None
-OpBranchConditional %150 %127 %128
-%128 = OpLabel
-OpBranch %129
-%129 = OpLabel
-%151 = OpLoad %ulong %141
-OpReturnValue %151
-%127 = OpLabel
-%152 = OpLoad %ulong %142
-%153 = OpIMul %ulong %152 %ulong_8
-OpStore %135 %153
-%154 = OpLoad %ulong %133
-%155 = OpLoad %ulong %135
-%156 = OpShiftRightLogical %ulong %154 %155
-OpStore %136 %156
-%157 = OpLoad %ulong %136
-%159 = OpBitwiseAnd %ulong %157 %ulong_255
-OpStore %137 %159
-%160 = OpLoad %ulong %141
-%161 = OpLoad %ulong %137
-%162 = OpBitwiseXor %ulong %160 %161
-OpStore %138 %162
-%163 = OpLoad %ulong %138
-%165 = OpIMul %ulong %163 %ulong_1099511628211
-OpStore %139 %165
-%166 = OpLoad %ulong %142
-%168 = OpIAdd %ulong %166 %ulong_1
-OpStore %140 %168
-%169 = OpLoad %ulong %139
-OpStore %141 %169
-%170 = OpLoad %ulong %140
-OpStore %142 %170
-OpBranch %130
-%130 = OpLabel
-OpBranch %126
+%143 = OpVariable %_ptr_Function_bool Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+OpStore %71 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%162 = OpLoad %ulong %71
+%163 = OpUConvert %uint %162
+OpStore %73 %163
+%165 = OpLoad %uint %73
+%166 = OpIAdd %uint %uint_2654435761 %165
+OpStore %74 %166
+OpStore %89 %ulong_14695981039346656037
+%168 = OpLoad %uint %74
+OpStore %90 %168
+OpStore %91 %uint_0
+OpBranch %6
+%6 = OpLabel
+%170 = OpLoad %uint %91
+%172 = OpULessThan %bool %170 %uint_16
+OpStore %76 %172
+%173 = OpLoad %bool %76
+OpLoopMerge %8 %67 None
+OpBranchConditional %173 %7 %8
+%8 = OpLabel
+%175 = OpLoad %uint %73
+%176 = OpIAdd %uint %uint_4294967231 %175
+OpStore %81 %176
+%177 = OpLoad %uint %81
+%178 = OpLoad %uint %81
+%179 = OpIMul %uint %177 %178
+OpStore %82 %179
+OpBranch %13
+%13 = OpLabel
+%180 = OpLoad %uint %82
+%181 = OpUConvert %ulong %180
+OpStore %93 %181
+OpBranch %20
+%20 = OpLabel
+%182 = OpLoad %ulong %89
+OpStore %110 %182
+OpStore %111 %ulong_0
+OpBranch %21
+%21 = OpLabel
+%184 = OpLoad %ulong %111
+%186 = OpULessThan %bool %184 %ulong_8
+OpStore %103 %186
+%187 = OpLoad %bool %103
+OpLoopMerge %23 %66 None
+OpBranchConditional %187 %22 %23
+%23 = OpLabel
+OpBranch %24
+%24 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%188 = OpLoad %uint %81
+%190 = OpIMul %uint %188 %uint_4294967295
+OpStore %83 %190
+OpBranch %25
+%25 = OpLabel
+%191 = OpLoad %uint %83
+%192 = OpUConvert %ulong %191
+OpStore %112 %192
+OpBranch %27
+%27 = OpLabel
+%193 = OpLoad %ulong %110
+OpStore %120 %193
+OpStore %121 %ulong_0
+OpBranch %28
+%28 = OpLabel
+%194 = OpLoad %ulong %121
+%195 = OpULessThan %bool %194 %ulong_8
+OpStore %113 %195
+%196 = OpLoad %bool %113
+OpLoopMerge %30 %64 None
+OpBranchConditional %196 %29 %30
+%30 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%197 = OpLoad %uint %90
+%198 = OpLoad %uint %81
+%199 = OpIMul %uint %197 %198
+OpStore %84 %199
+OpBranch %32
+%32 = OpLabel
+%200 = OpLoad %uint %84
+%201 = OpUConvert %ulong %200
+OpStore %122 %201
+OpBranch %34
+%34 = OpLabel
+%202 = OpLoad %ulong %120
+OpStore %130 %202
+OpStore %131 %ulong_0
+OpBranch %35
+%35 = OpLabel
+%203 = OpLoad %ulong %131
+%204 = OpULessThan %bool %203 %ulong_8
+OpStore %123 %204
+%205 = OpLoad %bool %123
+OpLoopMerge %37 %63 None
+OpBranchConditional %205 %36 %37
+%37 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpBranch %33
+%33 = OpLabel
+%206 = OpLoad %uint %81
+%207 = OpLoad %uint %90
+%208 = OpIMul %uint %206 %207
+OpStore %85 %208
+OpBranch %39
+%39 = OpLabel
+%209 = OpLoad %uint %85
+%210 = OpUConvert %ulong %209
+OpStore %132 %210
+OpBranch %41
+%41 = OpLabel
+%211 = OpLoad %ulong %130
+OpStore %140 %211
+OpStore %141 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%212 = OpLoad %ulong %141
+%213 = OpULessThan %bool %212 %ulong_8
+OpStore %133 %213
+%214 = OpLoad %bool %133
+OpLoopMerge %44 %62 None
+OpBranchConditional %214 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%216 = OpLoad %uint %73
+%217 = OpIAdd %uint %uint_65537 %216
+OpStore %86 %217
+%218 = OpLoad %uint %86
+%219 = OpLoad %uint %86
+%220 = OpIMul %uint %218 %219
+OpStore %87 %220
+OpBranch %46
+%46 = OpLabel
+%221 = OpLoad %uint %87
+%222 = OpUConvert %ulong %221
+OpStore %142 %222
+OpBranch %48
+%48 = OpLabel
+%223 = OpLoad %ulong %140
+OpStore %150 %223
+OpStore %151 %ulong_0
+OpBranch %49
+%49 = OpLabel
+%224 = OpLoad %ulong %151
+%225 = OpULessThan %bool %224 %ulong_8
+OpStore %143 %225
+%226 = OpLoad %bool %143
+OpLoopMerge %51 %61 None
+OpBranchConditional %226 %50 %51
+%51 = OpLabel
+OpBranch %52
+%52 = OpLabel
+OpBranch %47
+%47 = OpLabel
+%227 = OpLoad %uint %86
+%229 = OpIMul %uint %227 %uint_65535
+OpStore %88 %229
+OpBranch %53
+%53 = OpLabel
+%230 = OpLoad %uint %88
+%231 = OpUConvert %ulong %230
+OpStore %152 %231
+OpBranch %55
+%55 = OpLabel
+%232 = OpLoad %ulong %150
+OpStore %160 %232
+OpStore %161 %ulong_0
+OpBranch %56
+%56 = OpLabel
+%233 = OpLoad %ulong %161
+%234 = OpULessThan %bool %233 %ulong_8
+OpStore %153 %234
+%235 = OpLoad %bool %153
+OpLoopMerge %58 %60 None
+OpBranchConditional %235 %57 %58
+%58 = OpLabel
+OpBranch %59
+%59 = OpLabel
+OpBranch %54
+%54 = OpLabel
+%236 = OpLoad %ulong %160
+OpReturnValue %236
+%57 = OpLabel
+%237 = OpLoad %ulong %161
+%238 = OpIMul %ulong %237 %ulong_8
+OpStore %154 %238
+%239 = OpLoad %ulong %152
+%240 = OpLoad %ulong %154
+%241 = OpShiftRightLogical %ulong %239 %240
+OpStore %155 %241
+%242 = OpLoad %ulong %155
+%244 = OpBitwiseAnd %ulong %242 %ulong_255
+OpStore %156 %244
+%245 = OpLoad %ulong %160
+%246 = OpLoad %ulong %156
+%247 = OpBitwiseXor %ulong %245 %246
+OpStore %157 %247
+%248 = OpLoad %ulong %157
+%250 = OpIMul %ulong %248 %ulong_1099511628211
+OpStore %158 %250
+%251 = OpLoad %ulong %161
+%253 = OpIAdd %ulong %251 %ulong_1
+OpStore %159 %253
+%254 = OpLoad %ulong %158
+OpStore %160 %254
+%255 = OpLoad %ulong %159
+OpStore %161 %255
+OpBranch %60
+%50 = OpLabel
+%256 = OpLoad %ulong %151
+%257 = OpIMul %ulong %256 %ulong_8
+OpStore %144 %257
+%258 = OpLoad %ulong %142
+%259 = OpLoad %ulong %144
+%260 = OpShiftRightLogical %ulong %258 %259
+OpStore %145 %260
+%261 = OpLoad %ulong %145
+%262 = OpBitwiseAnd %ulong %261 %ulong_255
+OpStore %146 %262
+%263 = OpLoad %ulong %150
+%264 = OpLoad %ulong %146
+%265 = OpBitwiseXor %ulong %263 %264
+OpStore %147 %265
+%266 = OpLoad %ulong %147
+%267 = OpIMul %ulong %266 %ulong_1099511628211
+OpStore %148 %267
+%268 = OpLoad %ulong %151
+%269 = OpIAdd %ulong %268 %ulong_1
+OpStore %149 %269
+%270 = OpLoad %ulong %148
+OpStore %150 %270
+%271 = OpLoad %ulong %149
+OpStore %151 %271
+OpBranch %61
+%43 = OpLabel
+%272 = OpLoad %ulong %141
+%273 = OpIMul %ulong %272 %ulong_8
+OpStore %134 %273
+%274 = OpLoad %ulong %132
+%275 = OpLoad %ulong %134
+%276 = OpShiftRightLogical %ulong %274 %275
+OpStore %135 %276
+%277 = OpLoad %ulong %135
+%278 = OpBitwiseAnd %ulong %277 %ulong_255
+OpStore %136 %278
+%279 = OpLoad %ulong %140
+%280 = OpLoad %ulong %136
+%281 = OpBitwiseXor %ulong %279 %280
+OpStore %137 %281
+%282 = OpLoad %ulong %137
+%283 = OpIMul %ulong %282 %ulong_1099511628211
+OpStore %138 %283
+%284 = OpLoad %ulong %141
+%285 = OpIAdd %ulong %284 %ulong_1
+OpStore %139 %285
+%286 = OpLoad %ulong %138
+OpStore %140 %286
+%287 = OpLoad %ulong %139
+OpStore %141 %287
+OpBranch %62
+%36 = OpLabel
+%288 = OpLoad %ulong %131
+%289 = OpIMul %ulong %288 %ulong_8
+OpStore %124 %289
+%290 = OpLoad %ulong %122
+%291 = OpLoad %ulong %124
+%292 = OpShiftRightLogical %ulong %290 %291
+OpStore %125 %292
+%293 = OpLoad %ulong %125
+%294 = OpBitwiseAnd %ulong %293 %ulong_255
+OpStore %126 %294
+%295 = OpLoad %ulong %130
+%296 = OpLoad %ulong %126
+%297 = OpBitwiseXor %ulong %295 %296
+OpStore %127 %297
+%298 = OpLoad %ulong %127
+%299 = OpIMul %ulong %298 %ulong_1099511628211
+OpStore %128 %299
+%300 = OpLoad %ulong %131
+%301 = OpIAdd %ulong %300 %ulong_1
+OpStore %129 %301
+%302 = OpLoad %ulong %128
+OpStore %130 %302
+%303 = OpLoad %ulong %129
+OpStore %131 %303
+OpBranch %63
+%29 = OpLabel
+%304 = OpLoad %ulong %121
+%305 = OpIMul %ulong %304 %ulong_8
+OpStore %114 %305
+%306 = OpLoad %ulong %112
+%307 = OpLoad %ulong %114
+%308 = OpShiftRightLogical %ulong %306 %307
+OpStore %115 %308
+%309 = OpLoad %ulong %115
+%310 = OpBitwiseAnd %ulong %309 %ulong_255
+OpStore %116 %310
+%311 = OpLoad %ulong %120
+%312 = OpLoad %ulong %116
+%313 = OpBitwiseXor %ulong %311 %312
+OpStore %117 %313
+%314 = OpLoad %ulong %117
+%315 = OpIMul %ulong %314 %ulong_1099511628211
+OpStore %118 %315
+%316 = OpLoad %ulong %121
+%317 = OpIAdd %ulong %316 %ulong_1
+OpStore %119 %317
+%318 = OpLoad %ulong %118
+OpStore %120 %318
+%319 = OpLoad %ulong %119
+OpStore %121 %319
+OpBranch %64
+%22 = OpLabel
+%320 = OpLoad %ulong %111
+%321 = OpIMul %ulong %320 %ulong_8
+OpStore %104 %321
+%322 = OpLoad %ulong %93
+%323 = OpLoad %ulong %104
+%324 = OpShiftRightLogical %ulong %322 %323
+OpStore %105 %324
+%325 = OpLoad %ulong %105
+%326 = OpBitwiseAnd %ulong %325 %ulong_255
+OpStore %106 %326
+%327 = OpLoad %ulong %110
+%328 = OpLoad %ulong %106
+%329 = OpBitwiseXor %ulong %327 %328
+OpStore %107 %329
+%330 = OpLoad %ulong %107
+%331 = OpIMul %ulong %330 %ulong_1099511628211
+OpStore %108 %331
+%332 = OpLoad %ulong %111
+%333 = OpIAdd %ulong %332 %ulong_1
+OpStore %109 %333
+%334 = OpLoad %ulong %108
+OpStore %110 %334
+%335 = OpLoad %ulong %109
+OpStore %111 %335
+OpBranch %66
+%7 = OpLabel
+%337 = OpLoad %uint %91
+%338 = OpIMul %uint %uint_2 %337
+OpStore %77 %338
+%339 = OpLoad %uint %77
+%341 = OpIAdd %uint %339 %uint_3
+OpStore %78 %341
+%342 = OpLoad %uint %90
+%343 = OpLoad %uint %78
+%344 = OpIMul %uint %342 %343
+OpStore %79 %344
+OpBranch %11
+%11 = OpLabel
+%345 = OpLoad %uint %79
+%346 = OpUConvert %ulong %345
+OpStore %92 %346
+OpBranch %15
+%15 = OpLabel
+%347 = OpLoad %ulong %89
+OpStore %101 %347
+OpStore %102 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%348 = OpLoad %ulong %102
+%349 = OpULessThan %bool %348 %ulong_8
+OpStore %94 %349
+%350 = OpLoad %bool %94
+OpLoopMerge %18 %65 None
+OpBranchConditional %350 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %12
+%12 = OpLabel
+%351 = OpLoad %uint %91
+%353 = OpIAdd %uint %351 %uint_1
+OpStore %80 %353
+%354 = OpLoad %ulong %101
+OpStore %89 %354
+%355 = OpLoad %uint %79
+OpStore %90 %355
+%356 = OpLoad %uint %80
+OpStore %91 %356
+OpBranch %67
+%17 = OpLabel
+%357 = OpLoad %ulong %102
+%358 = OpIMul %ulong %357 %ulong_8
+OpStore %95 %358
+%359 = OpLoad %ulong %92
+%360 = OpLoad %ulong %95
+%361 = OpShiftRightLogical %ulong %359 %360
+OpStore %96 %361
+%362 = OpLoad %ulong %96
+%363 = OpBitwiseAnd %ulong %362 %ulong_255
+OpStore %97 %363
+%364 = OpLoad %ulong %101
+%365 = OpLoad %ulong %97
+%366 = OpBitwiseXor %ulong %364 %365
+OpStore %98 %366
+%367 = OpLoad %ulong %98
+%368 = OpIMul %ulong %367 %ulong_1099511628211
+OpStore %99 %368
+%369 = OpLoad %ulong %102
+%370 = OpIAdd %ulong %369 %ulong_1
+OpStore %100 %370
+%371 = OpLoad %ulong %99
+OpStore %101 %371
+%372 = OpLoad %ulong %100
+OpStore %102 %372
+OpBranch %65
+%60 = OpLabel
+OpBranch %56
+%61 = OpLabel
+OpBranch %49
+%62 = OpLabel
+OpBranch %42
+%63 = OpLabel
+OpBranch %35
+%64 = OpLabel
+OpBranch %28
+%65 = OpLabel
+OpBranch %16
+%66 = OpLabel
+OpBranch %21
+%67 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/scalar/mul_u64.dis
+++ b/test/golden/spirv/scalar/mul_u64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 159
+; Bound: 331
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,218 +9,488 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.scalar.mul_u64.checksum" Export
 %ulong = OpTypeInt 64 0
-%5 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
 %bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_bool = OpTypePointer Function %bool
 %ulong_11400714819323198485 = OpConstant %ulong 11400714819323198485
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_0 = OpConstant %ulong 0
 %ulong_16 = OpConstant %ulong 16
 %ulong_18446744073709551553 = OpConstant %ulong 18446744073709551553
+%ulong_8 = OpConstant %ulong 8
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
 %ulong_4294967311 = OpConstant %ulong 4294967311
 %ulong_4294967295 = OpConstant %ulong 4294967295
-%ulong_2 = OpConstant %ulong 2
-%ulong_3 = OpConstant %ulong 3
-%ulong_1 = OpConstant %ulong 1
-%113 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%116 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %5
-%6 = OpFunctionParameter %ulong
-%7 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_bool Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %6
-%41 = OpFunctionCall %ulong %2
-OpStore %15 %41
-%43 = OpLoad %ulong %14
-%44 = OpIAdd %ulong %ulong_11400714819323198485 %43
-OpStore %16 %44
-%45 = OpLoad %ulong %15
-OpStore %38 %45
-%46 = OpLoad %ulong %16
-OpStore %39 %46
-OpStore %40 %ulong_0
-OpBranch %8
-%8 = OpLabel
-%48 = OpLoad %ulong %40
-%50 = OpULessThan %bool %48 %ulong_16
-OpStore %18 %50
-%51 = OpLoad %bool %18
-OpLoopMerge %10 %11 None
-OpBranchConditional %51 %9 %10
-%10 = OpLabel
-%53 = OpLoad %ulong %14
-%54 = OpIAdd %ulong %ulong_18446744073709551553 %53
-OpStore %24 %54
-%55 = OpLoad %ulong %24
-%56 = OpLoad %ulong %24
-%57 = OpIMul %ulong %55 %56
-OpStore %25 %57
-%58 = OpLoad %ulong %38
-%59 = OpLoad %ulong %25
-%60 = OpFunctionCall %ulong %3 %58 %59
-OpStore %26 %60
-%61 = OpLoad %ulong %24
-%63 = OpIMul %ulong %61 %ulong_18446744073709551615
-OpStore %27 %63
-%64 = OpLoad %ulong %26
-%65 = OpLoad %ulong %27
-%66 = OpFunctionCall %ulong %3 %64 %65
-OpStore %28 %66
-%67 = OpLoad %ulong %39
-%68 = OpLoad %ulong %24
-%69 = OpIMul %ulong %67 %68
-OpStore %29 %69
-%70 = OpLoad %ulong %28
-%71 = OpLoad %ulong %29
-%72 = OpFunctionCall %ulong %3 %70 %71
-OpStore %30 %72
-%73 = OpLoad %ulong %24
-%74 = OpLoad %ulong %39
-%75 = OpIMul %ulong %73 %74
-OpStore %31 %75
-%76 = OpLoad %ulong %30
-%77 = OpLoad %ulong %31
-%78 = OpFunctionCall %ulong %3 %76 %77
-OpStore %32 %78
-%80 = OpLoad %ulong %14
-%81 = OpIAdd %ulong %ulong_4294967311 %80
-OpStore %33 %81
-%82 = OpLoad %ulong %33
-%83 = OpLoad %ulong %33
-%84 = OpIMul %ulong %82 %83
-OpStore %34 %84
-%85 = OpLoad %ulong %32
-%86 = OpLoad %ulong %34
-%87 = OpFunctionCall %ulong %3 %85 %86
-OpStore %35 %87
-%88 = OpLoad %ulong %33
-%90 = OpIMul %ulong %88 %ulong_4294967295
-OpStore %36 %90
-%91 = OpLoad %ulong %35
-%92 = OpLoad %ulong %36
-%93 = OpFunctionCall %ulong %3 %91 %92
-OpStore %37 %93
-%94 = OpLoad %ulong %37
-OpReturnValue %94
-%9 = OpLabel
-%96 = OpLoad %ulong %40
-%97 = OpIMul %ulong %ulong_2 %96
-OpStore %19 %97
-%98 = OpLoad %ulong %19
-%100 = OpIAdd %ulong %98 %ulong_3
-OpStore %20 %100
-%101 = OpLoad %ulong %39
-%102 = OpLoad %ulong %20
-%103 = OpIMul %ulong %101 %102
-OpStore %21 %103
-%104 = OpLoad %ulong %38
-%105 = OpLoad %ulong %21
-%106 = OpFunctionCall %ulong %3 %104 %105
-OpStore %22 %106
-%107 = OpLoad %ulong %40
-%109 = OpIAdd %ulong %107 %ulong_1
-OpStore %23 %109
-%110 = OpLoad %ulong %22
-OpStore %38 %110
-%111 = OpLoad %ulong %21
-OpStore %39 %111
-%112 = OpLoad %ulong %23
-OpStore %40 %112
-OpBranch %11
-%11 = OpLabel
-OpBranch %8
-OpFunctionEnd
-%2 = OpFunction %ulong None %113
-%114 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %116
-%117 = OpFunctionParameter %ulong
-%118 = OpFunctionParameter %ulong
-%119 = OpLabel
+%ulong_1 = OpConstant %ulong 1
+%ulong_2 = OpConstant %ulong 2
+%ulong_3 = OpConstant %ulong 3
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_bool Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_bool Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_bool Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_bool Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_bool Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_bool Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_bool Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
 %124 = OpVariable %_ptr_Function_ulong Function
 %125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_bool Function
+%126 = OpVariable %_ptr_Function_ulong Function
 %127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_bool Function
 %130 = OpVariable %_ptr_Function_ulong Function
 %131 = OpVariable %_ptr_Function_ulong Function
 %132 = OpVariable %_ptr_Function_ulong Function
 %133 = OpVariable %_ptr_Function_ulong Function
 %134 = OpVariable %_ptr_Function_ulong Function
-OpStore %124 %117
-OpStore %125 %118
-%135 = OpLoad %ulong %124
-OpStore %133 %135
-OpStore %134 %ulong_0
-OpBranch %120
-%120 = OpLabel
-%136 = OpLoad %ulong %134
-%138 = OpULessThan %bool %136 %ulong_8
-OpStore %126 %138
-%139 = OpLoad %bool %126
-OpLoopMerge %122 %123 None
-OpBranchConditional %139 %121 %122
-%122 = OpLabel
-%140 = OpLoad %ulong %133
-OpReturnValue %140
-%121 = OpLabel
-%141 = OpLoad %ulong %134
-%142 = OpIMul %ulong %141 %ulong_8
-OpStore %127 %142
-%143 = OpLoad %ulong %125
-%144 = OpLoad %ulong %127
-%145 = OpShiftRightLogical %ulong %143 %144
-OpStore %128 %145
-%146 = OpLoad %ulong %128
-%148 = OpBitwiseAnd %ulong %146 %ulong_255
-OpStore %129 %148
-%149 = OpLoad %ulong %133
-%150 = OpLoad %ulong %129
-%151 = OpBitwiseXor %ulong %149 %150
-OpStore %130 %151
-%152 = OpLoad %ulong %130
-%154 = OpIMul %ulong %152 %ulong_1099511628211
-OpStore %131 %154
-%155 = OpLoad %ulong %134
-%156 = OpIAdd %ulong %155 %ulong_1
-OpStore %132 %156
-%157 = OpLoad %ulong %131
-OpStore %133 %157
-%158 = OpLoad %ulong %132
-OpStore %134 %158
-OpBranch %123
-%123 = OpLabel
-OpBranch %120
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+OpStore %56 %4
+OpBranch %9
+%9 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%139 = OpLoad %ulong %56
+%140 = OpIAdd %ulong %ulong_11400714819323198485 %139
+OpStore %57 %140
+OpStore %72 %ulong_14695981039346656037
+%142 = OpLoad %ulong %57
+OpStore %73 %142
+OpStore %74 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%144 = OpLoad %ulong %74
+%146 = OpULessThan %bool %144 %ulong_16
+OpStore %59 %146
+%147 = OpLoad %bool %59
+OpLoopMerge %8 %53 None
+OpBranchConditional %147 %7 %8
+%8 = OpLabel
+%149 = OpLoad %ulong %56
+%150 = OpIAdd %ulong %ulong_18446744073709551553 %149
+OpStore %64 %150
+%151 = OpLoad %ulong %64
+%152 = OpLoad %ulong %64
+%153 = OpIMul %ulong %151 %152
+OpStore %65 %153
+OpBranch %16
+%16 = OpLabel
+%154 = OpLoad %ulong %72
+OpStore %91 %154
+OpStore %92 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%155 = OpLoad %ulong %92
+%157 = OpULessThan %bool %155 %ulong_8
+OpStore %84 %157
+%158 = OpLoad %bool %84
+OpLoopMerge %19 %52 None
+OpBranchConditional %158 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%159 = OpLoad %ulong %64
+%161 = OpIMul %ulong %159 %ulong_18446744073709551615
+OpStore %66 %161
+OpBranch %21
+%21 = OpLabel
+%162 = OpLoad %ulong %91
+OpStore %100 %162
+OpStore %101 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%163 = OpLoad %ulong %101
+%164 = OpULessThan %bool %163 %ulong_8
+OpStore %93 %164
+%165 = OpLoad %bool %93
+OpLoopMerge %24 %50 None
+OpBranchConditional %165 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%166 = OpLoad %ulong %73
+%167 = OpLoad %ulong %64
+%168 = OpIMul %ulong %166 %167
+OpStore %67 %168
+OpBranch %26
+%26 = OpLabel
+%169 = OpLoad %ulong %100
+OpStore %109 %169
+OpStore %110 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%170 = OpLoad %ulong %110
+%171 = OpULessThan %bool %170 %ulong_8
+OpStore %102 %171
+%172 = OpLoad %bool %102
+OpLoopMerge %29 %49 None
+OpBranchConditional %172 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%173 = OpLoad %ulong %64
+%174 = OpLoad %ulong %73
+%175 = OpIMul %ulong %173 %174
+OpStore %68 %175
+OpBranch %31
+%31 = OpLabel
+%176 = OpLoad %ulong %109
+OpStore %118 %176
+OpStore %119 %ulong_0
+OpBranch %32
+%32 = OpLabel
+%177 = OpLoad %ulong %119
+%178 = OpULessThan %bool %177 %ulong_8
+OpStore %111 %178
+%179 = OpLoad %bool %111
+OpLoopMerge %34 %48 None
+OpBranchConditional %179 %33 %34
+%34 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%181 = OpLoad %ulong %56
+%182 = OpIAdd %ulong %ulong_4294967311 %181
+OpStore %69 %182
+%183 = OpLoad %ulong %69
+%184 = OpLoad %ulong %69
+%185 = OpIMul %ulong %183 %184
+OpStore %70 %185
+OpBranch %36
+%36 = OpLabel
+%186 = OpLoad %ulong %118
+OpStore %127 %186
+OpStore %128 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%187 = OpLoad %ulong %128
+%188 = OpULessThan %bool %187 %ulong_8
+OpStore %120 %188
+%189 = OpLoad %bool %120
+OpLoopMerge %39 %47 None
+OpBranchConditional %189 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+%190 = OpLoad %ulong %69
+%192 = OpIMul %ulong %190 %ulong_4294967295
+OpStore %71 %192
+OpBranch %41
+%41 = OpLabel
+%193 = OpLoad %ulong %127
+OpStore %136 %193
+OpStore %137 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%194 = OpLoad %ulong %137
+%195 = OpULessThan %bool %194 %ulong_8
+OpStore %129 %195
+%196 = OpLoad %bool %129
+OpLoopMerge %44 %46 None
+OpBranchConditional %196 %43 %44
+%44 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%197 = OpLoad %ulong %136
+OpReturnValue %197
+%43 = OpLabel
+%198 = OpLoad %ulong %137
+%199 = OpIMul %ulong %198 %ulong_8
+OpStore %130 %199
+%200 = OpLoad %ulong %71
+%201 = OpLoad %ulong %130
+%202 = OpShiftRightLogical %ulong %200 %201
+OpStore %131 %202
+%203 = OpLoad %ulong %131
+%205 = OpBitwiseAnd %ulong %203 %ulong_255
+OpStore %132 %205
+%206 = OpLoad %ulong %136
+%207 = OpLoad %ulong %132
+%208 = OpBitwiseXor %ulong %206 %207
+OpStore %133 %208
+%209 = OpLoad %ulong %133
+%211 = OpIMul %ulong %209 %ulong_1099511628211
+OpStore %134 %211
+%212 = OpLoad %ulong %137
+%214 = OpIAdd %ulong %212 %ulong_1
+OpStore %135 %214
+%215 = OpLoad %ulong %134
+OpStore %136 %215
+%216 = OpLoad %ulong %135
+OpStore %137 %216
+OpBranch %46
+%38 = OpLabel
+%217 = OpLoad %ulong %128
+%218 = OpIMul %ulong %217 %ulong_8
+OpStore %121 %218
+%219 = OpLoad %ulong %70
+%220 = OpLoad %ulong %121
+%221 = OpShiftRightLogical %ulong %219 %220
+OpStore %122 %221
+%222 = OpLoad %ulong %122
+%223 = OpBitwiseAnd %ulong %222 %ulong_255
+OpStore %123 %223
+%224 = OpLoad %ulong %127
+%225 = OpLoad %ulong %123
+%226 = OpBitwiseXor %ulong %224 %225
+OpStore %124 %226
+%227 = OpLoad %ulong %124
+%228 = OpIMul %ulong %227 %ulong_1099511628211
+OpStore %125 %228
+%229 = OpLoad %ulong %128
+%230 = OpIAdd %ulong %229 %ulong_1
+OpStore %126 %230
+%231 = OpLoad %ulong %125
+OpStore %127 %231
+%232 = OpLoad %ulong %126
+OpStore %128 %232
+OpBranch %47
+%33 = OpLabel
+%233 = OpLoad %ulong %119
+%234 = OpIMul %ulong %233 %ulong_8
+OpStore %112 %234
+%235 = OpLoad %ulong %68
+%236 = OpLoad %ulong %112
+%237 = OpShiftRightLogical %ulong %235 %236
+OpStore %113 %237
+%238 = OpLoad %ulong %113
+%239 = OpBitwiseAnd %ulong %238 %ulong_255
+OpStore %114 %239
+%240 = OpLoad %ulong %118
+%241 = OpLoad %ulong %114
+%242 = OpBitwiseXor %ulong %240 %241
+OpStore %115 %242
+%243 = OpLoad %ulong %115
+%244 = OpIMul %ulong %243 %ulong_1099511628211
+OpStore %116 %244
+%245 = OpLoad %ulong %119
+%246 = OpIAdd %ulong %245 %ulong_1
+OpStore %117 %246
+%247 = OpLoad %ulong %116
+OpStore %118 %247
+%248 = OpLoad %ulong %117
+OpStore %119 %248
+OpBranch %48
+%28 = OpLabel
+%249 = OpLoad %ulong %110
+%250 = OpIMul %ulong %249 %ulong_8
+OpStore %103 %250
+%251 = OpLoad %ulong %67
+%252 = OpLoad %ulong %103
+%253 = OpShiftRightLogical %ulong %251 %252
+OpStore %104 %253
+%254 = OpLoad %ulong %104
+%255 = OpBitwiseAnd %ulong %254 %ulong_255
+OpStore %105 %255
+%256 = OpLoad %ulong %109
+%257 = OpLoad %ulong %105
+%258 = OpBitwiseXor %ulong %256 %257
+OpStore %106 %258
+%259 = OpLoad %ulong %106
+%260 = OpIMul %ulong %259 %ulong_1099511628211
+OpStore %107 %260
+%261 = OpLoad %ulong %110
+%262 = OpIAdd %ulong %261 %ulong_1
+OpStore %108 %262
+%263 = OpLoad %ulong %107
+OpStore %109 %263
+%264 = OpLoad %ulong %108
+OpStore %110 %264
+OpBranch %49
+%23 = OpLabel
+%265 = OpLoad %ulong %101
+%266 = OpIMul %ulong %265 %ulong_8
+OpStore %94 %266
+%267 = OpLoad %ulong %66
+%268 = OpLoad %ulong %94
+%269 = OpShiftRightLogical %ulong %267 %268
+OpStore %95 %269
+%270 = OpLoad %ulong %95
+%271 = OpBitwiseAnd %ulong %270 %ulong_255
+OpStore %96 %271
+%272 = OpLoad %ulong %100
+%273 = OpLoad %ulong %96
+%274 = OpBitwiseXor %ulong %272 %273
+OpStore %97 %274
+%275 = OpLoad %ulong %97
+%276 = OpIMul %ulong %275 %ulong_1099511628211
+OpStore %98 %276
+%277 = OpLoad %ulong %101
+%278 = OpIAdd %ulong %277 %ulong_1
+OpStore %99 %278
+%279 = OpLoad %ulong %98
+OpStore %100 %279
+%280 = OpLoad %ulong %99
+OpStore %101 %280
+OpBranch %50
+%18 = OpLabel
+%281 = OpLoad %ulong %92
+%282 = OpIMul %ulong %281 %ulong_8
+OpStore %85 %282
+%283 = OpLoad %ulong %65
+%284 = OpLoad %ulong %85
+%285 = OpShiftRightLogical %ulong %283 %284
+OpStore %86 %285
+%286 = OpLoad %ulong %86
+%287 = OpBitwiseAnd %ulong %286 %ulong_255
+OpStore %87 %287
+%288 = OpLoad %ulong %91
+%289 = OpLoad %ulong %87
+%290 = OpBitwiseXor %ulong %288 %289
+OpStore %88 %290
+%291 = OpLoad %ulong %88
+%292 = OpIMul %ulong %291 %ulong_1099511628211
+OpStore %89 %292
+%293 = OpLoad %ulong %92
+%294 = OpIAdd %ulong %293 %ulong_1
+OpStore %90 %294
+%295 = OpLoad %ulong %89
+OpStore %91 %295
+%296 = OpLoad %ulong %90
+OpStore %92 %296
+OpBranch %52
+%7 = OpLabel
+%298 = OpLoad %ulong %74
+%299 = OpIMul %ulong %ulong_2 %298
+OpStore %60 %299
+%300 = OpLoad %ulong %60
+%302 = OpIAdd %ulong %300 %ulong_3
+OpStore %61 %302
+%303 = OpLoad %ulong %73
+%304 = OpLoad %ulong %61
+%305 = OpIMul %ulong %303 %304
+OpStore %62 %305
+OpBranch %11
+%11 = OpLabel
+%306 = OpLoad %ulong %72
+OpStore %82 %306
+OpStore %83 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%307 = OpLoad %ulong %83
+%308 = OpULessThan %bool %307 %ulong_8
+OpStore %75 %308
+%309 = OpLoad %bool %75
+OpLoopMerge %14 %51 None
+OpBranchConditional %309 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%310 = OpLoad %ulong %74
+%311 = OpIAdd %ulong %310 %ulong_1
+OpStore %63 %311
+%312 = OpLoad %ulong %82
+OpStore %72 %312
+%313 = OpLoad %ulong %62
+OpStore %73 %313
+%314 = OpLoad %ulong %63
+OpStore %74 %314
+OpBranch %53
+%13 = OpLabel
+%315 = OpLoad %ulong %83
+%316 = OpIMul %ulong %315 %ulong_8
+OpStore %76 %316
+%317 = OpLoad %ulong %62
+%318 = OpLoad %ulong %76
+%319 = OpShiftRightLogical %ulong %317 %318
+OpStore %77 %319
+%320 = OpLoad %ulong %77
+%321 = OpBitwiseAnd %ulong %320 %ulong_255
+OpStore %78 %321
+%322 = OpLoad %ulong %82
+%323 = OpLoad %ulong %78
+%324 = OpBitwiseXor %ulong %322 %323
+OpStore %79 %324
+%325 = OpLoad %ulong %79
+%326 = OpIMul %ulong %325 %ulong_1099511628211
+OpStore %80 %326
+%327 = OpLoad %ulong %83
+%328 = OpIAdd %ulong %327 %ulong_1
+OpStore %81 %328
+%329 = OpLoad %ulong %80
+OpStore %82 %329
+%330 = OpLoad %ulong %81
+OpStore %83 %330
+OpBranch %51
+%46 = OpLabel
+OpBranch %42
+%47 = OpLabel
+OpBranch %37
+%48 = OpLabel
+OpBranch %32
+%49 = OpLabel
+OpBranch %27
+%50 = OpLabel
+OpBranch %22
+%51 = OpLabel
+OpBranch %12
+%52 = OpLabel
+OpBranch %17
+%53 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/vec/autovec_loop.dis
+++ b/test/golden/spirv/vec/autovec_loop.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 699
+; Bound: 933
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -9,10 +9,10 @@ OpCapability Int64
 OpMemoryModel Logical GLSL450
 OpDecorate %1 LinkageAttributes "corpus.cases.vec.autovec_loop.checksum" Export
 %ulong = OpTypeInt 64 0
-%6 = OpTypeFunction %ulong %ulong
+%3 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
 %uint = OpTypeInt 32 0
 %float = OpTypeFloat 32
-%bool = OpTypeBool
 %uint_67 = OpConstant %uint 67
 %_arr_uint_uint_67 = OpTypeArray %uint %uint_67
 %_ptr_Function__arr_uint_uint_67 = OpTypePointer Function %_arr_uint_uint_67
@@ -26,12 +26,16 @@ OpDecorate %1 LinkageAttributes "corpus.cases.vec.autovec_loop.checksum" Export
 %ulong_1 = OpConstant %ulong 1
 %ulong_67 = OpConstant %ulong 67
 %ulong_37 = OpConstant %ulong 37
-%244 = OpConstantNull %_arr_uint_uint_67
+%397 = OpConstantNull %_arr_uint_uint_67
 %ulong_0 = OpConstant %ulong 0
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
-%318 = OpConstantNull %_arr_float_uint_37
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_8 = OpConstant %ulong 8
+%478 = OpConstantNull %_arr_float_uint_37
 %float_0 = OpConstant %float 0
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
 %float_1_25 = OpConstant %float 1.25
 %uint_31 = OpConstant %uint 31
 %ulong_2 = OpConstant %ulong 2
@@ -41,986 +45,1351 @@ OpDecorate %1 LinkageAttributes "corpus.cases.vec.autovec_loop.checksum" Export
 %uint_12345 = OpConstant %uint 12345
 %uint_40503 = OpConstant %uint 40503
 %uint_4294967295 = OpConstant %uint 4294967295
-%600 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%603 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%651 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %6
-%7 = OpFunctionParameter %ulong
-%8 = OpLabel
-%86 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%87 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%88 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%89 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%90 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%91 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
-%95 = OpVariable %_ptr_Function__arr_float_uint_37 Function
-%96 = OpVariable %_ptr_Function__arr_float_uint_37 Function
-%97 = OpVariable %_ptr_Function__arr_float_uint_37 Function
-%98 = OpVariable %_ptr_Function__arr_float_uint_37 Function
-%100 = OpVariable %_ptr_Function_ulong Function
-%101 = OpVariable %_ptr_Function_ulong Function
-%102 = OpVariable %_ptr_Function_ulong Function
-%103 = OpVariable %_ptr_Function_ulong Function
-%104 = OpVariable %_ptr_Function_ulong Function
-%106 = OpVariable %_ptr_Function_uint Function
-%108 = OpVariable %_ptr_Function_float Function
-%110 = OpVariable %_ptr_Function_bool Function
-%111 = OpVariable %_ptr_Function_uint Function
-%112 = OpVariable %_ptr_Function_uint Function
-%113 = OpVariable %_ptr_Function_uint Function
-%114 = OpVariable %_ptr_Function_uint Function
-%115 = OpVariable %_ptr_Function_uint Function
-%116 = OpVariable %_ptr_Function_ulong Function
-%117 = OpVariable %_ptr_Function_uint Function
-%118 = OpVariable %_ptr_Function_uint Function
-%119 = OpVariable %_ptr_Function_uint Function
-%120 = OpVariable %_ptr_Function_uint Function
-%121 = OpVariable %_ptr_Function_bool Function
-%122 = OpVariable %_ptr_Function_uint Function
-%123 = OpVariable %_ptr_Function_uint Function
-%124 = OpVariable %_ptr_Function_uint Function
-%125 = OpVariable %_ptr_Function_uint Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_bool Function
-%128 = OpVariable %_ptr_Function_uint Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_bool Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_uint Function
-%134 = OpVariable %_ptr_Function_uint Function
-%135 = OpVariable %_ptr_Function_uint Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_bool Function
-%140 = OpVariable %_ptr_Function_uint Function
-%141 = OpVariable %_ptr_Function_uint Function
-%142 = OpVariable %_ptr_Function_bool Function
-%143 = OpVariable %_ptr_Function_uint Function
-%144 = OpVariable %_ptr_Function_uint Function
-%145 = OpVariable %_ptr_Function_uint Function
-%146 = OpVariable %_ptr_Function_uint Function
-%147 = OpVariable %_ptr_Function_uint Function
-%148 = OpVariable %_ptr_Function_uint Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_bool Function
-%151 = OpVariable %_ptr_Function_uint Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_bool Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_bool Function
-%157 = OpVariable %_ptr_Function_uint Function
-%158 = OpVariable %_ptr_Function_uint Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_bool Function
-%161 = OpVariable %_ptr_Function_uint Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_uint Function
-%165 = OpVariable %_ptr_Function_bool Function
-%166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_uint Function
-%168 = OpVariable %_ptr_Function_uint Function
-%169 = OpVariable %_ptr_Function_uint Function
-%170 = OpVariable %_ptr_Function_uint Function
+%1 = OpFunction %ulong None %3
+%4 = OpFunctionParameter %ulong
+%5 = OpLabel
+%157 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
+%158 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
+%159 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
+%163 = OpVariable %_ptr_Function__arr_float_uint_37 Function
+%164 = OpVariable %_ptr_Function__arr_float_uint_37 Function
+%165 = OpVariable %_ptr_Function__arr_float_uint_37 Function
+%166 = OpVariable %_ptr_Function__arr_float_uint_37 Function
+%167 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
+%168 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
+%169 = OpVariable %_ptr_Function__arr_uint_uint_67 Function
 %171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_bool Function
-%173 = OpVariable %_ptr_Function_uint Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_bool Function
-%177 = OpVariable %_ptr_Function_float Function
+%176 = OpVariable %_ptr_Function_uint Function
 %178 = OpVariable %_ptr_Function_float Function
-%179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_bool Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_bool Function
-%187 = OpVariable %_ptr_Function_float Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_bool Function
-%191 = OpVariable %_ptr_Function_float Function
-%192 = OpVariable %_ptr_Function_float Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_bool Function
-%196 = OpVariable %_ptr_Function_float Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_bool Function
-%200 = OpVariable %_ptr_Function_float Function
-%201 = OpVariable %_ptr_Function_float Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_uint Function
+%182 = OpVariable %_ptr_Function_uint Function
+%183 = OpVariable %_ptr_Function_uint Function
+%184 = OpVariable %_ptr_Function_uint Function
+%185 = OpVariable %_ptr_Function_uint Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_uint Function
+%188 = OpVariable %_ptr_Function_uint Function
+%189 = OpVariable %_ptr_Function_uint Function
+%190 = OpVariable %_ptr_Function_uint Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_uint Function
+%193 = OpVariable %_ptr_Function_uint Function
+%194 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_uint Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_bool Function
+%198 = OpVariable %_ptr_Function_uint Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_bool Function
+%201 = OpVariable %_ptr_Function_uint Function
+%202 = OpVariable %_ptr_Function_uint Function
+%203 = OpVariable %_ptr_Function_uint Function
+%204 = OpVariable %_ptr_Function_uint Function
 %205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_bool Function
+%207 = OpVariable %_ptr_Function_uint Function
+%208 = OpVariable %_ptr_Function_uint Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_uint Function
+%211 = OpVariable %_ptr_Function_uint Function
+%212 = OpVariable %_ptr_Function_uint Function
+%213 = OpVariable %_ptr_Function_uint Function
+%214 = OpVariable %_ptr_Function_uint Function
+%215 = OpVariable %_ptr_Function_uint Function
 %216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_uint Function
 %219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_bool Function
 %221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_bool Function
+%223 = OpVariable %_ptr_Function_uint Function
+%224 = OpVariable %_ptr_Function_uint Function
 %225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
 %227 = OpVariable %_ptr_Function_uint Function
-%228 = OpVariable %_ptr_Function_uint Function
-%229 = OpVariable %_ptr_Function_float Function
-OpStore %100 %7
-%230 = OpFunctionCall %ulong %2
-OpStore %101 %230
-%231 = OpLoad %ulong %100
-%233 = OpBitwiseAnd %ulong %231 %ulong_1
-OpStore %102 %233
-%235 = OpLoad %ulong %102
-%236 = OpISub %ulong %ulong_67 %235
-OpStore %103 %236
-%238 = OpLoad %ulong %102
-%239 = OpISub %ulong %ulong_37 %238
-OpStore %104 %239
-%240 = OpLoad %ulong %100
-%241 = OpUConvert %uint %240
-OpStore %106 %241
-%242 = OpLoad %ulong %100
-%243 = OpConvertUToF %float %242
-OpStore %108 %243
-OpStore %86 %244
-OpStore %87 %244
-OpStore %226 %ulong_0
-OpBranch %9
-%9 = OpLabel
-%246 = OpLoad %ulong %226
-%247 = OpLoad %ulong %103
-%248 = OpULessThan %bool %246 %247
-OpStore %110 %248
-%249 = OpLoad %bool %110
-OpLoopMerge %11 %79 None
-OpBranchConditional %249 %10 %11
-%11 = OpLabel
-%251 = OpAccessChain %_ptr_Function_uint %86 %uint_0
-%252 = OpLoad %uint %251
-OpStore %117 %252
-%253 = OpLoad %uint %117
-%254 = OpLoad %uint %106
-%255 = OpIAdd %uint %253 %254
-OpStore %118 %255
-%256 = OpLoad %uint %118
-OpStore %251 %256
-%258 = OpAccessChain %_ptr_Function_uint %87 %uint_1
-%259 = OpLoad %uint %258
-OpStore %119 %259
-%260 = OpLoad %uint %119
-%261 = OpLoad %uint %106
-%262 = OpIAdd %uint %260 %261
-OpStore %120 %262
-%263 = OpLoad %uint %120
-OpStore %258 %263
-OpStore %88 %244
-OpStore %225 %ulong_0
-OpBranch %12
-%12 = OpLabel
-%264 = OpLoad %ulong %225
-%265 = OpLoad %ulong %103
-%266 = OpULessThan %bool %264 %265
-OpStore %121 %266
-%267 = OpLoad %bool %121
-OpLoopMerge %14 %78 None
-OpBranchConditional %267 %13 %14
-%14 = OpLabel
-%268 = OpLoad %ulong %101
-OpStore %209 %268
-OpStore %224 %ulong_0
-OpBranch %15
-%15 = OpLabel
-%269 = OpLoad %ulong %224
-%270 = OpLoad %ulong %103
-%271 = OpULessThan %bool %269 %270
-OpStore %127 %271
-%272 = OpLoad %bool %127
-OpLoopMerge %17 %77 None
-OpBranchConditional %272 %16 %17
-%17 = OpLabel
-OpStore %223 %ulong_0
-OpStore %227 %uint_0
-OpStore %228 %uint_0
-OpBranch %18
-%18 = OpLabel
-%273 = OpLoad %ulong %223
-%274 = OpLoad %ulong %103
-%275 = OpULessThan %bool %273 %274
-OpStore %131 %275
-%276 = OpLoad %bool %131
-OpLoopMerge %20 %76 None
-OpBranchConditional %276 %19 %20
-%20 = OpLabel
-%277 = OpLoad %ulong %209
-%278 = OpLoad %uint %227
-%279 = OpFunctionCall %ulong %3 %277 %278
-OpStore %137 %279
-%280 = OpLoad %ulong %137
-%281 = OpLoad %uint %228
-%282 = OpFunctionCall %ulong %3 %280 %281
-OpStore %138 %282
-OpStore %89 %244
-OpStore %222 %ulong_0
-OpBranch %21
-%21 = OpLabel
-%283 = OpLoad %ulong %222
-%284 = OpLoad %ulong %103
-%285 = OpULessThan %bool %283 %284
-OpStore %139 %285
-%286 = OpLoad %bool %139
-OpLoopMerge %23 %75 None
-OpBranchConditional %286 %22 %23
-%23 = OpLabel
-%287 = OpLoad %ulong %138
-OpStore %208 %287
-OpStore %221 %ulong_0
-OpBranch %27
-%27 = OpLabel
-%288 = OpLoad %ulong %221
-%289 = OpLoad %ulong %103
-%290 = OpULessThan %bool %288 %289
-OpStore %150 %290
-%291 = OpLoad %bool %150
-OpLoopMerge %29 %74 None
-OpBranchConditional %291 %28 %29
-%29 = OpLabel
-OpStore %90 %244
-OpStore %220 %ulong_0
-OpBranch %30
-%30 = OpLabel
-%292 = OpLoad %ulong %220
-%293 = OpLoad %ulong %103
-%294 = OpULessThan %bool %292 %293
-OpStore %154 %294
-%295 = OpLoad %bool %154
-OpLoopMerge %32 %73 None
-OpBranchConditional %295 %31 %32
-%32 = OpLabel
-OpStore %219 %ulong_0
-OpBranch %33
-%33 = OpLabel
-%296 = OpLoad %ulong %219
-%297 = OpLoad %ulong %103
-%298 = OpULessThan %bool %296 %297
-OpStore %156 %298
-%299 = OpLoad %bool %156
-OpLoopMerge %35 %72 None
-OpBranchConditional %299 %34 %35
-%35 = OpLabel
-%300 = OpLoad %ulong %208
-OpStore %207 %300
-OpStore %218 %ulong_0
-OpBranch %36
-%36 = OpLabel
-%301 = OpLoad %ulong %218
-%302 = OpLoad %ulong %103
-%303 = OpULessThan %bool %301 %302
-OpStore %160 %303
-%304 = OpLoad %bool %160
-OpLoopMerge %38 %71 None
-OpBranchConditional %304 %37 %38
-%38 = OpLabel
-OpStore %91 %244
-%305 = OpAccessChain %_ptr_Function_uint %86 %uint_0
-%306 = OpLoad %uint %305
-OpStore %164 %306
-%307 = OpAccessChain %_ptr_Function_uint %91 %uint_0
-%308 = OpLoad %uint %164
-OpStore %307 %308
-OpStore %217 %ulong_1
-OpBranch %39
-%39 = OpLabel
-%309 = OpLoad %ulong %217
-%310 = OpLoad %ulong %103
-%311 = OpULessThan %bool %309 %310
-OpStore %165 %311
-%312 = OpLoad %bool %165
-OpLoopMerge %41 %70 None
-OpBranchConditional %312 %40 %41
-%41 = OpLabel
-%313 = OpLoad %ulong %207
-OpStore %206 %313
-OpStore %216 %ulong_0
-OpBranch %42
-%42 = OpLabel
-%314 = OpLoad %ulong %216
-%315 = OpLoad %ulong %103
-%316 = OpULessThan %bool %314 %315
-OpStore %172 %316
-%317 = OpLoad %bool %172
-OpLoopMerge %44 %69 None
-OpBranchConditional %317 %43 %44
-%44 = OpLabel
-OpStore %95 %318
-OpStore %96 %318
-OpStore %215 %ulong_0
-OpBranch %45
-%45 = OpLabel
-%319 = OpLoad %ulong %215
-%320 = OpLoad %ulong %104
-%321 = OpULessThan %bool %319 %320
-OpStore %176 %321
-%322 = OpLoad %bool %176
-OpLoopMerge %47 %68 None
-OpBranchConditional %322 %46 %47
-%47 = OpLabel
-OpStore %97 %318
-OpStore %214 %ulong_0
-OpBranch %48
-%48 = OpLabel
-%323 = OpLoad %ulong %214
-%324 = OpLoad %ulong %104
-%325 = OpULessThan %bool %323 %324
-OpStore %181 %325
-%326 = OpLoad %bool %181
-OpLoopMerge %50 %67 None
-OpBranchConditional %326 %49 %50
-%50 = OpLabel
-%327 = OpLoad %ulong %206
-OpStore %205 %327
-OpStore %213 %ulong_0
-OpBranch %51
-%51 = OpLabel
-%328 = OpLoad %ulong %213
-%329 = OpLoad %ulong %104
-%330 = OpULessThan %bool %328 %329
-OpStore %186 %330
-%331 = OpLoad %bool %186
-OpLoopMerge %53 %66 None
-OpBranchConditional %331 %52 %53
-%53 = OpLabel
-OpStore %98 %318
-OpStore %212 %ulong_0
-OpBranch %54
-%54 = OpLabel
-%332 = OpLoad %ulong %212
-%333 = OpLoad %ulong %104
-%334 = OpULessThan %bool %332 %333
-OpStore %190 %334
-%335 = OpLoad %bool %190
-OpLoopMerge %56 %65 None
-OpBranchConditional %335 %55 %56
-%56 = OpLabel
-%336 = OpLoad %ulong %205
-OpStore %204 %336
-OpStore %211 %ulong_0
-OpBranch %57
-%57 = OpLabel
-%337 = OpLoad %ulong %211
-%338 = OpLoad %ulong %104
-%339 = OpULessThan %bool %337 %338
-OpStore %195 %339
-%340 = OpLoad %bool %195
-OpLoopMerge %59 %64 None
-OpBranchConditional %340 %58 %59
-%59 = OpLabel
-OpStore %210 %ulong_0
-OpStore %229 %float_0
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_uint Function
+%230 = OpVariable %_ptr_Function_bool Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_uint Function
+%233 = OpVariable %_ptr_Function_uint Function
+%234 = OpVariable %_ptr_Function_uint Function
+%235 = OpVariable %_ptr_Function_uint Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_bool Function
+%238 = OpVariable %_ptr_Function_uint Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_bool Function
+%241 = OpVariable %_ptr_Function_float Function
+%242 = OpVariable %_ptr_Function_float Function
+%243 = OpVariable %_ptr_Function_float Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_float Function
+%247 = OpVariable %_ptr_Function_float Function
+%248 = OpVariable %_ptr_Function_float Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_bool Function
+%251 = OpVariable %_ptr_Function_float Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_bool Function
+%254 = OpVariable %_ptr_Function_float Function
+%255 = OpVariable %_ptr_Function_float Function
+%256 = OpVariable %_ptr_Function_float Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_bool Function
+%259 = OpVariable %_ptr_Function_float Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_bool Function
+%262 = OpVariable %_ptr_Function_float Function
+%263 = OpVariable %_ptr_Function_float Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_uint Function
+%289 = OpVariable %_ptr_Function_uint Function
+%290 = OpVariable %_ptr_Function_float Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_uint Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_uint Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_uint Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_bool Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_bool Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_bool Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_bool Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+%333 = OpVariable %_ptr_Function_ulong Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_ulong Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function_ulong Function
+%339 = OpVariable %_ptr_Function_bool Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_bool Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_ulong Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_bool Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_ulong Function
+%363 = OpVariable %_ptr_Function_ulong Function
+%364 = OpVariable %_ptr_Function_ulong Function
+%365 = OpVariable %_ptr_Function_ulong Function
+%366 = OpVariable %_ptr_Function_bool Function
+%367 = OpVariable %_ptr_Function_ulong Function
+%368 = OpVariable %_ptr_Function_ulong Function
+%369 = OpVariable %_ptr_Function_ulong Function
+%370 = OpVariable %_ptr_Function_ulong Function
+%371 = OpVariable %_ptr_Function_ulong Function
+%372 = OpVariable %_ptr_Function_ulong Function
+%373 = OpVariable %_ptr_Function_ulong Function
+%374 = OpVariable %_ptr_Function_ulong Function
+%375 = OpVariable %_ptr_Function_bool Function
+%376 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_ulong Function
+%380 = OpVariable %_ptr_Function_ulong Function
+%381 = OpVariable %_ptr_Function_ulong Function
+%382 = OpVariable %_ptr_Function_ulong Function
+%383 = OpVariable %_ptr_Function_ulong Function
+OpStore %171 %4
 OpBranch %60
 %60 = OpLabel
-%342 = OpLoad %ulong %210
-%343 = OpLoad %ulong %104
-%344 = OpULessThan %bool %342 %343
-OpStore %199 %344
-%345 = OpLoad %bool %199
-OpLoopMerge %62 %63 None
-OpBranchConditional %345 %61 %62
-%62 = OpLabel
-%346 = OpLoad %ulong %204
-%347 = OpLoad %float %229
-%348 = OpFunctionCall %ulong %4 %346 %347
-OpStore %203 %348
-%349 = OpLoad %ulong %203
-OpReturnValue %349
+OpBranch %61
 %61 = OpLabel
-%350 = OpLoad %ulong %210
-%351 = OpAccessChain %_ptr_Function_float %98 %350
-%352 = OpLoad %float %351
-OpStore %200 %352
-%353 = OpLoad %float %229
-%354 = OpLoad %float %200
-%355 = OpFAdd %float %353 %354
-OpStore %201 %355
-%356 = OpLoad %ulong %210
-%357 = OpIAdd %ulong %356 %ulong_1
-OpStore %202 %357
-%358 = OpLoad %ulong %202
-OpStore %210 %358
-%359 = OpLoad %float %201
-OpStore %229 %359
-OpBranch %63
-%58 = OpLabel
-%360 = OpLoad %ulong %211
-%361 = OpAccessChain %_ptr_Function_float %98 %360
-%362 = OpLoad %float %361
-OpStore %196 %362
-%363 = OpLoad %ulong %204
-%364 = OpLoad %float %196
-%365 = OpFunctionCall %ulong %4 %363 %364
-OpStore %197 %365
-%366 = OpLoad %ulong %211
-%367 = OpIAdd %ulong %366 %ulong_1
-OpStore %198 %367
-%368 = OpLoad %ulong %197
-OpStore %204 %368
-%369 = OpLoad %ulong %198
-OpStore %211 %369
-OpBranch %64
-%55 = OpLabel
-%370 = OpLoad %ulong %212
-%371 = OpAccessChain %_ptr_Function_float %95 %370
-%372 = OpLoad %float %371
-OpStore %191 %372
-%373 = OpLoad %ulong %212
-%374 = OpAccessChain %_ptr_Function_float %96 %373
-%375 = OpLoad %float %374
-OpStore %192 %375
-%376 = OpLoad %float %191
-%377 = OpLoad %float %192
-%378 = OpFDiv %float %376 %377
-OpStore %193 %378
-%379 = OpLoad %ulong %212
-%380 = OpAccessChain %_ptr_Function_float %98 %379
-%381 = OpLoad %float %193
-OpStore %380 %381
-%382 = OpLoad %ulong %212
-%383 = OpIAdd %ulong %382 %ulong_1
-OpStore %194 %383
-%384 = OpLoad %ulong %194
-OpStore %212 %384
-OpBranch %65
-%52 = OpLabel
-%385 = OpLoad %ulong %213
-%386 = OpAccessChain %_ptr_Function_float %97 %385
-%387 = OpLoad %float %386
-OpStore %187 %387
-%388 = OpLoad %ulong %205
-%389 = OpLoad %float %187
-%390 = OpFunctionCall %ulong %4 %388 %389
-OpStore %188 %390
-%391 = OpLoad %ulong %213
-%392 = OpIAdd %ulong %391 %ulong_1
-OpStore %189 %392
-%393 = OpLoad %ulong %188
-OpStore %205 %393
-%394 = OpLoad %ulong %189
-OpStore %213 %394
-OpBranch %66
-%49 = OpLabel
-%395 = OpLoad %ulong %214
-%396 = OpAccessChain %_ptr_Function_float %95 %395
-%397 = OpLoad %float %396
-OpStore %182 %397
-%398 = OpLoad %ulong %214
-%399 = OpAccessChain %_ptr_Function_float %96 %398
-%400 = OpLoad %float %399
-OpStore %183 %400
-%401 = OpLoad %float %182
-%402 = OpLoad %float %183
-%403 = OpFMul %float %401 %402
-OpStore %184 %403
-%404 = OpLoad %ulong %214
-%405 = OpAccessChain %_ptr_Function_float %97 %404
-%406 = OpLoad %float %184
-OpStore %405 %406
-%407 = OpLoad %ulong %214
-%408 = OpIAdd %ulong %407 %ulong_1
-OpStore %185 %408
-%409 = OpLoad %ulong %185
-OpStore %214 %409
-OpBranch %67
-%46 = OpLabel
-%410 = OpLoad %ulong %215
-%411 = OpConvertUToF %float %410
-OpStore %177 %411
-%412 = OpLoad %float %177
-%413 = OpLoad %float %108
-%414 = OpFAdd %float %412 %413
-OpStore %178 %414
-%415 = OpLoad %ulong %215
-%416 = OpAccessChain %_ptr_Function_float %95 %415
-%417 = OpLoad %float %178
-OpStore %416 %417
-%419 = OpLoad %float %177
-%420 = OpFSub %float %float_1_25 %419
-OpStore %179 %420
-%421 = OpLoad %ulong %215
-%422 = OpAccessChain %_ptr_Function_float %96 %421
-%423 = OpLoad %float %179
-OpStore %422 %423
-%424 = OpLoad %ulong %215
-%425 = OpIAdd %ulong %424 %ulong_1
-OpStore %180 %425
-%426 = OpLoad %ulong %180
-OpStore %215 %426
-OpBranch %68
-%43 = OpLabel
-%427 = OpLoad %ulong %216
-%428 = OpAccessChain %_ptr_Function_uint %91 %427
-%429 = OpLoad %uint %428
-OpStore %173 %429
-%430 = OpLoad %ulong %206
-%431 = OpLoad %uint %173
-%432 = OpFunctionCall %ulong %3 %430 %431
-OpStore %174 %432
-%433 = OpLoad %ulong %216
-%434 = OpIAdd %ulong %433 %ulong_1
-OpStore %175 %434
-%435 = OpLoad %ulong %174
-OpStore %206 %435
-%436 = OpLoad %ulong %175
-OpStore %216 %436
-OpBranch %69
-%40 = OpLabel
-%437 = OpLoad %ulong %217
-%438 = OpISub %ulong %437 %ulong_1
-OpStore %166 %438
-%439 = OpLoad %ulong %166
-%440 = OpAccessChain %_ptr_Function_uint %91 %439
-%441 = OpLoad %uint %440
-OpStore %167 %441
-%442 = OpLoad %uint %167
-%444 = OpIMul %uint %442 %uint_31
-OpStore %168 %444
-%445 = OpLoad %ulong %217
-%446 = OpAccessChain %_ptr_Function_uint %86 %445
-%447 = OpLoad %uint %446
-OpStore %169 %447
-%448 = OpLoad %uint %168
-%449 = OpLoad %uint %169
-%450 = OpIAdd %uint %448 %449
-OpStore %170 %450
-%451 = OpLoad %ulong %217
-%452 = OpAccessChain %_ptr_Function_uint %91 %451
-%453 = OpLoad %uint %170
-OpStore %452 %453
-%454 = OpLoad %ulong %217
-%455 = OpIAdd %ulong %454 %ulong_1
-OpStore %171 %455
-%456 = OpLoad %ulong %171
-OpStore %217 %456
-OpBranch %70
-%37 = OpLabel
-%457 = OpLoad %ulong %218
-%458 = OpAccessChain %_ptr_Function_uint %90 %457
-%459 = OpLoad %uint %458
-OpStore %161 %459
-%460 = OpLoad %ulong %207
-%461 = OpLoad %uint %161
-%462 = OpFunctionCall %ulong %3 %460 %461
-OpStore %162 %462
-%463 = OpLoad %ulong %218
-%464 = OpIAdd %ulong %463 %ulong_1
-OpStore %163 %464
-%465 = OpLoad %ulong %162
-OpStore %207 %465
-%466 = OpLoad %ulong %163
-OpStore %218 %466
-OpBranch %71
-%34 = OpLabel
-%467 = OpLoad %ulong %219
-%468 = OpAccessChain %_ptr_Function_uint %88 %467
-%469 = OpLoad %uint %468
-OpStore %157 %469
-%470 = OpLoad %uint %157
-%471 = OpBitwiseXor %uint %470 %uint_1
-OpStore %158 %471
-%472 = OpLoad %ulong %219
-%473 = OpAccessChain %_ptr_Function_uint %90 %472
-%474 = OpLoad %uint %158
-OpStore %473 %474
-%475 = OpLoad %ulong %219
-%477 = OpIAdd %ulong %475 %ulong_2
-OpStore %159 %477
-%478 = OpLoad %ulong %159
-OpStore %219 %478
-OpBranch %72
-%31 = OpLabel
-%479 = OpLoad %ulong %220
-%480 = OpAccessChain %_ptr_Function_uint %90 %479
-OpStore %480 %uint_2863311530
-%482 = OpLoad %ulong %220
-%483 = OpIAdd %ulong %482 %ulong_1
-OpStore %155 %483
-%484 = OpLoad %ulong %155
-OpStore %220 %484
-OpBranch %73
-%28 = OpLabel
-%485 = OpLoad %ulong %221
-%486 = OpAccessChain %_ptr_Function_uint %89 %485
-%487 = OpLoad %uint %486
-OpStore %151 %487
-%488 = OpLoad %ulong %208
-%489 = OpLoad %uint %151
-%490 = OpFunctionCall %ulong %3 %488 %489
-OpStore %152 %490
-%491 = OpLoad %ulong %221
-%492 = OpIAdd %ulong %491 %ulong_1
-OpStore %153 %492
-%493 = OpLoad %ulong %152
-OpStore %208 %493
-%494 = OpLoad %ulong %153
-OpStore %221 %494
-OpBranch %74
-%22 = OpLabel
-%495 = OpLoad %ulong %222
-%496 = OpAccessChain %_ptr_Function_uint %86 %495
-%497 = OpLoad %uint %496
-OpStore %140 %497
-%498 = OpLoad %ulong %222
-%499 = OpAccessChain %_ptr_Function_uint %87 %498
-%500 = OpLoad %uint %499
-OpStore %141 %500
-%501 = OpLoad %uint %141
-%502 = OpLoad %uint %140
-%503 = OpULessThan %bool %501 %502
-OpStore %142 %503
-%504 = OpLoad %bool %142
-OpSelectionMerge %26 None
-OpBranchConditional %504 %24 %25
-%25 = OpLabel
-%505 = OpLoad %ulong %222
-%506 = OpAccessChain %_ptr_Function_uint %87 %505
-%507 = OpLoad %uint %506
-OpStore %146 %507
-%508 = OpLoad %ulong %222
-%509 = OpAccessChain %_ptr_Function_uint %86 %508
-%510 = OpLoad %uint %509
-OpStore %147 %510
-%511 = OpLoad %uint %146
-%512 = OpLoad %uint %147
-%513 = OpISub %uint %511 %512
-OpStore %148 %513
-%514 = OpLoad %ulong %222
-%515 = OpAccessChain %_ptr_Function_uint %89 %514
-%516 = OpLoad %uint %148
-OpStore %515 %516
-OpBranch %26
-%24 = OpLabel
-%517 = OpLoad %ulong %222
-%518 = OpAccessChain %_ptr_Function_uint %86 %517
-%519 = OpLoad %uint %518
-OpStore %143 %519
-%520 = OpLoad %ulong %222
-%521 = OpAccessChain %_ptr_Function_uint %87 %520
-%522 = OpLoad %uint %521
-OpStore %144 %522
-%523 = OpLoad %uint %143
-%524 = OpLoad %uint %144
-%525 = OpISub %uint %523 %524
-OpStore %145 %525
-%526 = OpLoad %ulong %222
-%527 = OpAccessChain %_ptr_Function_uint %89 %526
-%528 = OpLoad %uint %145
-OpStore %527 %528
-OpBranch %26
-%26 = OpLabel
-%529 = OpLoad %ulong %222
-%530 = OpIAdd %ulong %529 %ulong_1
-OpStore %149 %530
-%531 = OpLoad %ulong %149
-OpStore %222 %531
-OpBranch %75
-%19 = OpLabel
-%532 = OpLoad %ulong %223
-%533 = OpAccessChain %_ptr_Function_uint %88 %532
-%534 = OpLoad %uint %533
-OpStore %132 %534
-%535 = OpLoad %uint %227
-%536 = OpLoad %uint %132
-%537 = OpIAdd %uint %535 %536
-OpStore %133 %537
-%538 = OpLoad %ulong %223
-%539 = OpAccessChain %_ptr_Function_uint %86 %538
-%540 = OpLoad %uint %539
-OpStore %134 %540
-%541 = OpLoad %uint %228
-%542 = OpLoad %uint %134
-%543 = OpBitwiseXor %uint %541 %542
-OpStore %135 %543
-%544 = OpLoad %ulong %223
-%545 = OpIAdd %ulong %544 %ulong_1
-OpStore %136 %545
-%546 = OpLoad %ulong %136
-OpStore %223 %546
-%547 = OpLoad %uint %133
-OpStore %227 %547
-%548 = OpLoad %uint %135
-OpStore %228 %548
-OpBranch %76
-%16 = OpLabel
-%549 = OpLoad %ulong %224
-%550 = OpAccessChain %_ptr_Function_uint %88 %549
-%551 = OpLoad %uint %550
-OpStore %128 %551
-%552 = OpLoad %ulong %209
-%553 = OpLoad %uint %128
-%554 = OpFunctionCall %ulong %3 %552 %553
-OpStore %129 %554
-%555 = OpLoad %ulong %224
-%556 = OpIAdd %ulong %555 %ulong_1
-OpStore %130 %556
-%557 = OpLoad %ulong %129
-OpStore %209 %557
-%558 = OpLoad %ulong %130
-OpStore %224 %558
-OpBranch %77
-%13 = OpLabel
-%559 = OpLoad %ulong %225
-%560 = OpAccessChain %_ptr_Function_uint %86 %559
-%561 = OpLoad %uint %560
-OpStore %122 %561
-%562 = OpLoad %uint %122
-%564 = OpIMul %uint %562 %uint_3
-OpStore %123 %564
-%565 = OpLoad %ulong %225
-%566 = OpAccessChain %_ptr_Function_uint %87 %565
-%567 = OpLoad %uint %566
-OpStore %124 %567
-%568 = OpLoad %uint %123
-%569 = OpLoad %uint %124
-%570 = OpIAdd %uint %568 %569
-OpStore %125 %570
-%571 = OpLoad %ulong %225
-%572 = OpAccessChain %_ptr_Function_uint %88 %571
-%573 = OpLoad %uint %125
-OpStore %572 %573
-%574 = OpLoad %ulong %225
-%575 = OpIAdd %ulong %574 %ulong_1
-OpStore %126 %575
-%576 = OpLoad %ulong %126
-OpStore %225 %576
-OpBranch %78
-%10 = OpLabel
-%577 = OpLoad %ulong %226
-%578 = OpUConvert %uint %577
-OpStore %111 %578
-%579 = OpLoad %uint %111
-%581 = OpIMul %uint %579 %uint_2654435761
-OpStore %112 %581
-%582 = OpLoad %uint %112
-%584 = OpIAdd %uint %582 %uint_12345
-OpStore %113 %584
-%585 = OpLoad %ulong %226
-%586 = OpAccessChain %_ptr_Function_uint %86 %585
-%587 = OpLoad %uint %113
-OpStore %586 %587
-%588 = OpLoad %uint %111
-%590 = OpIMul %uint %588 %uint_40503
-OpStore %114 %590
-%592 = OpLoad %uint %114
-%593 = OpISub %uint %uint_4294967295 %592
-OpStore %115 %593
-%594 = OpLoad %ulong %226
-%595 = OpAccessChain %_ptr_Function_uint %87 %594
-%596 = OpLoad %uint %115
-OpStore %595 %596
-%597 = OpLoad %ulong %226
-%598 = OpIAdd %ulong %597 %ulong_1
-OpStore %116 %598
-%599 = OpLoad %ulong %116
-OpStore %226 %599
-OpBranch %79
-%63 = OpLabel
-OpBranch %60
-%64 = OpLabel
-OpBranch %57
-%65 = OpLabel
-OpBranch %54
-%66 = OpLabel
-OpBranch %51
-%67 = OpLabel
-OpBranch %48
-%68 = OpLabel
-OpBranch %45
-%69 = OpLabel
-OpBranch %42
-%70 = OpLabel
-OpBranch %39
-%71 = OpLabel
-OpBranch %36
-%72 = OpLabel
-OpBranch %33
-%73 = OpLabel
-OpBranch %30
-%74 = OpLabel
-OpBranch %27
-%75 = OpLabel
-OpBranch %21
-%76 = OpLabel
-OpBranch %18
-%77 = OpLabel
-OpBranch %15
-%78 = OpLabel
-OpBranch %12
-%79 = OpLabel
+%384 = OpLoad %ulong %171
+%386 = OpBitwiseAnd %ulong %384 %ulong_1
+OpStore %172 %386
+%388 = OpLoad %ulong %172
+%389 = OpISub %ulong %ulong_67 %388
+OpStore %173 %389
+%391 = OpLoad %ulong %172
+%392 = OpISub %ulong %ulong_37 %391
+OpStore %174 %392
+%393 = OpLoad %ulong %171
+%394 = OpUConvert %uint %393
+OpStore %176 %394
+%395 = OpLoad %ulong %171
+%396 = OpConvertUToF %float %395
+OpStore %178 %396
+OpStore %167 %397
+OpStore %168 %397
+OpStore %287 %ulong_0
+OpBranch %6
+%6 = OpLabel
+%399 = OpLoad %ulong %287
+%400 = OpLoad %ulong %173
+%401 = OpULessThan %bool %399 %400
+OpStore %180 %401
+%402 = OpLoad %bool %180
+OpLoopMerge %8 %150 None
+OpBranchConditional %402 %7 %8
+%8 = OpLabel
+%404 = OpAccessChain %_ptr_Function_uint %167 %uint_0
+%405 = OpLoad %uint %404
+OpStore %187 %405
+%406 = OpLoad %uint %187
+%407 = OpLoad %uint %176
+%408 = OpIAdd %uint %406 %407
+OpStore %188 %408
+%409 = OpLoad %uint %188
+OpStore %404 %409
+%411 = OpAccessChain %_ptr_Function_uint %168 %uint_1
+%412 = OpLoad %uint %411
+OpStore %189 %412
+%413 = OpLoad %uint %189
+%414 = OpLoad %uint %176
+%415 = OpIAdd %uint %413 %414
+OpStore %190 %415
+%416 = OpLoad %uint %190
+OpStore %411 %416
+OpStore %157 %397
+OpStore %286 %ulong_0
 OpBranch %9
-OpFunctionEnd
-%2 = OpFunction %ulong None %600
-%601 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%3 = OpFunction %ulong None %603
-%604 = OpFunctionParameter %ulong
-%605 = OpFunctionParameter %uint
-%606 = OpLabel
-%613 = OpVariable %_ptr_Function_ulong Function
-%614 = OpVariable %_ptr_Function_uint Function
-%615 = OpVariable %_ptr_Function_ulong Function
-%616 = OpVariable %_ptr_Function_bool Function
-%617 = OpVariable %_ptr_Function_ulong Function
-%618 = OpVariable %_ptr_Function_ulong Function
-%619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_ulong Function
-%621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_ulong Function
-%623 = OpVariable %_ptr_Function_ulong Function
-%624 = OpVariable %_ptr_Function_ulong Function
-OpStore %613 %604
-OpStore %614 %605
-%625 = OpLoad %uint %614
-%626 = OpUConvert %ulong %625
-OpStore %615 %626
-OpBranch %607
-%607 = OpLabel
-%627 = OpLoad %ulong %613
-OpStore %623 %627
-OpStore %624 %ulong_0
-OpBranch %608
-%608 = OpLabel
-%628 = OpLoad %ulong %624
-%630 = OpULessThan %bool %628 %ulong_8
-OpStore %616 %630
-%631 = OpLoad %bool %616
-OpLoopMerge %610 %612 None
-OpBranchConditional %631 %609 %610
-%610 = OpLabel
-OpBranch %611
-%611 = OpLabel
-%632 = OpLoad %ulong %623
-OpReturnValue %632
-%609 = OpLabel
-%633 = OpLoad %ulong %624
-%634 = OpIMul %ulong %633 %ulong_8
-OpStore %617 %634
-%635 = OpLoad %ulong %615
-%636 = OpLoad %ulong %617
-%637 = OpShiftRightLogical %ulong %635 %636
-OpStore %618 %637
-%638 = OpLoad %ulong %618
-%640 = OpBitwiseAnd %ulong %638 %ulong_255
-OpStore %619 %640
-%641 = OpLoad %ulong %623
-%642 = OpLoad %ulong %619
-%643 = OpBitwiseXor %ulong %641 %642
-OpStore %620 %643
-%644 = OpLoad %ulong %620
-%646 = OpIMul %ulong %644 %ulong_1099511628211
-OpStore %621 %646
-%647 = OpLoad %ulong %624
-%648 = OpIAdd %ulong %647 %ulong_1
-OpStore %622 %648
-%649 = OpLoad %ulong %621
-OpStore %623 %649
-%650 = OpLoad %ulong %622
-OpStore %624 %650
-OpBranch %612
-%612 = OpLabel
-OpBranch %608
-OpFunctionEnd
-%4 = OpFunction %ulong None %651
-%652 = OpFunctionParameter %ulong
-%653 = OpFunctionParameter %float
-%654 = OpLabel
-%661 = OpVariable %_ptr_Function_ulong Function
-%662 = OpVariable %_ptr_Function_float Function
-%663 = OpVariable %_ptr_Function_uint Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_bool Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_ulong Function
-%668 = OpVariable %_ptr_Function_ulong Function
-%669 = OpVariable %_ptr_Function_ulong Function
-%670 = OpVariable %_ptr_Function_ulong Function
-%671 = OpVariable %_ptr_Function_ulong Function
-%672 = OpVariable %_ptr_Function_ulong Function
-%673 = OpVariable %_ptr_Function_ulong Function
-OpStore %661 %652
-OpStore %662 %653
-%674 = OpLoad %float %662
-%675 = OpBitcast %uint %674
-OpStore %663 %675
-%676 = OpLoad %uint %663
-%677 = OpUConvert %ulong %676
-OpStore %664 %677
-OpBranch %655
-%655 = OpLabel
-%678 = OpLoad %ulong %661
-OpStore %672 %678
-OpStore %673 %ulong_0
-OpBranch %656
-%656 = OpLabel
-%679 = OpLoad %ulong %673
-%680 = OpULessThan %bool %679 %ulong_8
-OpStore %665 %680
-%681 = OpLoad %bool %665
-OpLoopMerge %658 %660 None
-OpBranchConditional %681 %657 %658
-%658 = OpLabel
-OpBranch %659
-%659 = OpLabel
-%682 = OpLoad %ulong %672
-OpReturnValue %682
-%657 = OpLabel
-%683 = OpLoad %ulong %673
-%684 = OpIMul %ulong %683 %ulong_8
-OpStore %666 %684
-%685 = OpLoad %ulong %664
-%686 = OpLoad %ulong %666
-%687 = OpShiftRightLogical %ulong %685 %686
-OpStore %667 %687
-%688 = OpLoad %ulong %667
-%689 = OpBitwiseAnd %ulong %688 %ulong_255
-OpStore %668 %689
-%690 = OpLoad %ulong %672
-%691 = OpLoad %ulong %668
-%692 = OpBitwiseXor %ulong %690 %691
-OpStore %669 %692
-%693 = OpLoad %ulong %669
-%694 = OpIMul %ulong %693 %ulong_1099511628211
-OpStore %670 %694
-%695 = OpLoad %ulong %673
-%696 = OpIAdd %ulong %695 %ulong_1
-OpStore %671 %696
-%697 = OpLoad %ulong %670
-OpStore %672 %697
-%698 = OpLoad %ulong %671
-OpStore %673 %698
-OpBranch %660
-%660 = OpLabel
-OpBranch %656
+%9 = OpLabel
+%417 = OpLoad %ulong %286
+%418 = OpLoad %ulong %173
+%419 = OpULessThan %bool %417 %418
+OpStore %191 %419
+%420 = OpLoad %bool %191
+OpLoopMerge %11 %149 None
+OpBranchConditional %420 %10 %11
+%11 = OpLabel
+OpStore %270 %ulong_14695981039346656037
+OpStore %285 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%422 = OpLoad %ulong %285
+%423 = OpLoad %ulong %173
+%424 = OpULessThan %bool %422 %423
+OpStore %197 %424
+%425 = OpLoad %bool %197
+OpLoopMerge %14 %148 None
+OpBranchConditional %425 %13 %14
+%14 = OpLabel
+OpStore %284 %ulong_0
+OpStore %288 %uint_0
+OpStore %289 %uint_0
+OpBranch %15
+%15 = OpLabel
+%426 = OpLoad %ulong %284
+%427 = OpLoad %ulong %173
+%428 = OpULessThan %bool %426 %427
+OpStore %200 %428
+%429 = OpLoad %bool %200
+OpLoopMerge %17 %147 None
+OpBranchConditional %429 %16 %17
+%17 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%430 = OpLoad %uint %288
+%431 = OpUConvert %ulong %430
+OpStore %292 %431
+OpBranch %83
+%83 = OpLabel
+%432 = OpLoad %ulong %270
+OpStore %318 %432
+OpStore %319 %ulong_0
+OpBranch %84
+%84 = OpLabel
+%433 = OpLoad %ulong %319
+%435 = OpULessThan %bool %433 %ulong_8
+OpStore %311 %435
+%436 = OpLoad %bool %311
+OpLoopMerge %86 %145 None
+OpBranchConditional %436 %85 %86
+%86 = OpLabel
+OpBranch %87
+%87 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %88
+%88 = OpLabel
+%437 = OpLoad %uint %289
+%438 = OpUConvert %ulong %437
+OpStore %320 %438
+OpBranch %120
+%120 = OpLabel
+%439 = OpLoad %ulong %318
+OpStore %382 %439
+OpStore %383 %ulong_0
+OpBranch %121
+%121 = OpLabel
+%440 = OpLoad %ulong %383
+%441 = OpULessThan %bool %440 %ulong_8
+OpStore %375 %441
+%442 = OpLoad %bool %375
+OpLoopMerge %123 %144 None
+OpBranchConditional %442 %122 %123
+%123 = OpLabel
+OpBranch %124
+%124 = OpLabel
+OpBranch %89
+%89 = OpLabel
+OpStore %169 %397
+OpStore %283 %ulong_0
+OpBranch %18
+%18 = OpLabel
+%443 = OpLoad %ulong %283
+%444 = OpLoad %ulong %173
+%445 = OpULessThan %bool %443 %444
+OpStore %206 %445
+%446 = OpLoad %bool %206
+OpLoopMerge %20 %143 None
+OpBranchConditional %446 %19 %20
+%20 = OpLabel
+%447 = OpLoad %ulong %382
+OpStore %269 %447
+OpStore %282 %ulong_0
+OpBranch %24
+%24 = OpLabel
+%448 = OpLoad %ulong %282
+%449 = OpLoad %ulong %173
+%450 = OpULessThan %bool %448 %449
+OpStore %217 %450
+%451 = OpLoad %bool %217
+OpLoopMerge %26 %142 None
+OpBranchConditional %451 %25 %26
+%26 = OpLabel
+OpStore %158 %397
+OpStore %281 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%452 = OpLoad %ulong %281
+%453 = OpLoad %ulong %173
+%454 = OpULessThan %bool %452 %453
+OpStore %220 %454
+%455 = OpLoad %bool %220
+OpLoopMerge %29 %141 None
+OpBranchConditional %455 %28 %29
+%29 = OpLabel
+OpStore %280 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%456 = OpLoad %ulong %280
+%457 = OpLoad %ulong %173
+%458 = OpULessThan %bool %456 %457
+OpStore %222 %458
+%459 = OpLoad %bool %222
+OpLoopMerge %32 %139 None
+OpBranchConditional %459 %31 %32
+%32 = OpLabel
+%460 = OpLoad %ulong %269
+OpStore %268 %460
+OpStore %279 %ulong_0
+OpBranch %33
+%33 = OpLabel
+%461 = OpLoad %ulong %279
+%462 = OpLoad %ulong %173
+%463 = OpULessThan %bool %461 %462
+OpStore %226 %463
+%464 = OpLoad %bool %226
+OpLoopMerge %35 %138 None
+OpBranchConditional %464 %34 %35
+%35 = OpLabel
+OpStore %159 %397
+%465 = OpAccessChain %_ptr_Function_uint %167 %uint_0
+%466 = OpLoad %uint %465
+OpStore %229 %466
+%467 = OpAccessChain %_ptr_Function_uint %159 %uint_0
+%468 = OpLoad %uint %229
+OpStore %467 %468
+OpStore %278 %ulong_1
+OpBranch %36
+%36 = OpLabel
+%469 = OpLoad %ulong %278
+%470 = OpLoad %ulong %173
+%471 = OpULessThan %bool %469 %470
+OpStore %230 %471
+%472 = OpLoad %bool %230
+OpLoopMerge %38 %137 None
+OpBranchConditional %472 %37 %38
+%38 = OpLabel
+%473 = OpLoad %ulong %268
+OpStore %267 %473
+OpStore %277 %ulong_0
+OpBranch %39
+%39 = OpLabel
+%474 = OpLoad %ulong %277
+%475 = OpLoad %ulong %173
+%476 = OpULessThan %bool %474 %475
+OpStore %237 %476
+%477 = OpLoad %bool %237
+OpLoopMerge %41 %135 None
+OpBranchConditional %477 %40 %41
+%41 = OpLabel
+OpStore %163 %478
+OpStore %164 %478
+OpStore %276 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%479 = OpLoad %ulong %276
+%480 = OpLoad %ulong %174
+%481 = OpULessThan %bool %479 %480
+OpStore %240 %481
+%482 = OpLoad %bool %240
+OpLoopMerge %44 %134 None
+OpBranchConditional %482 %43 %44
+%44 = OpLabel
+OpStore %165 %478
+OpStore %275 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%483 = OpLoad %ulong %275
+%484 = OpLoad %ulong %174
+%485 = OpULessThan %bool %483 %484
+OpStore %245 %485
+%486 = OpLoad %bool %245
+OpLoopMerge %47 %132 None
+OpBranchConditional %486 %46 %47
+%47 = OpLabel
+%487 = OpLoad %ulong %267
+OpStore %266 %487
+OpStore %274 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%488 = OpLoad %ulong %274
+%489 = OpLoad %ulong %174
+%490 = OpULessThan %bool %488 %489
+OpStore %250 %490
+%491 = OpLoad %bool %250
+OpLoopMerge %50 %131 None
+OpBranchConditional %491 %49 %50
+%50 = OpLabel
+OpStore %166 %478
+OpStore %273 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%492 = OpLoad %ulong %273
+%493 = OpLoad %ulong %174
+%494 = OpULessThan %bool %492 %493
+OpStore %253 %494
+%495 = OpLoad %bool %253
+OpLoopMerge %53 %130 None
+OpBranchConditional %495 %52 %53
+%53 = OpLabel
+%496 = OpLoad %ulong %266
+OpStore %265 %496
+OpStore %272 %ulong_0
+OpBranch %54
+%54 = OpLabel
+%497 = OpLoad %ulong %272
+%498 = OpLoad %ulong %174
+%499 = OpULessThan %bool %497 %498
+OpStore %258 %499
+%500 = OpLoad %bool %258
+OpLoopMerge %56 %128 None
+OpBranchConditional %500 %55 %56
+%56 = OpLabel
+OpStore %271 %ulong_0
+OpStore %290 %float_0
+OpBranch %57
+%57 = OpLabel
+%502 = OpLoad %ulong %271
+%503 = OpLoad %ulong %174
+%504 = OpULessThan %bool %502 %503
+OpStore %261 %504
+%505 = OpLoad %bool %261
+OpLoopMerge %59 %127 None
+OpBranchConditional %505 %58 %59
+%59 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%506 = OpLoad %float %290
+%507 = OpBitcast %uint %506
+OpStore %300 %507
+%508 = OpLoad %uint %300
+%509 = OpUConvert %ulong %508
+OpStore %301 %509
+OpBranch %115
+%115 = OpLabel
+%510 = OpLoad %ulong %265
+OpStore %373 %510
+OpStore %374 %ulong_0
+OpBranch %116
+%116 = OpLabel
+%511 = OpLoad %ulong %374
+%512 = OpULessThan %bool %511 %ulong_8
+OpStore %366 %512
+%513 = OpLoad %bool %366
+OpLoopMerge %118 %125 None
+OpBranchConditional %513 %117 %118
+%118 = OpLabel
+OpBranch %119
+%119 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%514 = OpLoad %ulong %373
+OpReturnValue %514
+%117 = OpLabel
+%515 = OpLoad %ulong %374
+%516 = OpIMul %ulong %515 %ulong_8
+OpStore %367 %516
+%517 = OpLoad %ulong %301
+%518 = OpLoad %ulong %367
+%519 = OpShiftRightLogical %ulong %517 %518
+OpStore %368 %519
+%520 = OpLoad %ulong %368
+%522 = OpBitwiseAnd %ulong %520 %ulong_255
+OpStore %369 %522
+%523 = OpLoad %ulong %373
+%524 = OpLoad %ulong %369
+%525 = OpBitwiseXor %ulong %523 %524
+OpStore %370 %525
+%526 = OpLoad %ulong %370
+%528 = OpIMul %ulong %526 %ulong_1099511628211
+OpStore %371 %528
+%529 = OpLoad %ulong %374
+%530 = OpIAdd %ulong %529 %ulong_1
+OpStore %372 %530
+%531 = OpLoad %ulong %371
+OpStore %373 %531
+%532 = OpLoad %ulong %372
+OpStore %374 %532
+OpBranch %125
+%58 = OpLabel
+%533 = OpLoad %ulong %271
+%534 = OpAccessChain %_ptr_Function_float %166 %533
+%535 = OpLoad %float %534
+OpStore %262 %535
+%536 = OpLoad %float %290
+%537 = OpLoad %float %262
+%538 = OpFAdd %float %536 %537
+OpStore %263 %538
+%539 = OpLoad %ulong %271
+%540 = OpIAdd %ulong %539 %ulong_1
+OpStore %264 %540
+%541 = OpLoad %ulong %264
+OpStore %271 %541
+%542 = OpLoad %float %263
+OpStore %290 %542
+OpBranch %127
+%55 = OpLabel
+%543 = OpLoad %ulong %272
+%544 = OpAccessChain %_ptr_Function_float %166 %543
+%545 = OpLoad %float %544
+OpStore %259 %545
+OpBranch %74
+%74 = OpLabel
+%546 = OpLoad %float %259
+%547 = OpBitcast %uint %546
+OpStore %298 %547
+%548 = OpLoad %uint %298
+%549 = OpUConvert %ulong %548
+OpStore %299 %549
+OpBranch %110
+%110 = OpLabel
+%550 = OpLoad %ulong %265
+OpStore %364 %550
+OpStore %365 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%551 = OpLoad %ulong %365
+%552 = OpULessThan %bool %551 %ulong_8
+OpStore %357 %552
+%553 = OpLoad %bool %357
+OpLoopMerge %113 %126 None
+OpBranchConditional %553 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %75
+%75 = OpLabel
+%554 = OpLoad %ulong %272
+%555 = OpIAdd %ulong %554 %ulong_1
+OpStore %260 %555
+%556 = OpLoad %ulong %364
+OpStore %265 %556
+%557 = OpLoad %ulong %260
+OpStore %272 %557
+OpBranch %128
+%112 = OpLabel
+%558 = OpLoad %ulong %365
+%559 = OpIMul %ulong %558 %ulong_8
+OpStore %358 %559
+%560 = OpLoad %ulong %299
+%561 = OpLoad %ulong %358
+%562 = OpShiftRightLogical %ulong %560 %561
+OpStore %359 %562
+%563 = OpLoad %ulong %359
+%564 = OpBitwiseAnd %ulong %563 %ulong_255
+OpStore %360 %564
+%565 = OpLoad %ulong %364
+%566 = OpLoad %ulong %360
+%567 = OpBitwiseXor %ulong %565 %566
+OpStore %361 %567
+%568 = OpLoad %ulong %361
+%569 = OpIMul %ulong %568 %ulong_1099511628211
+OpStore %362 %569
+%570 = OpLoad %ulong %365
+%571 = OpIAdd %ulong %570 %ulong_1
+OpStore %363 %571
+%572 = OpLoad %ulong %362
+OpStore %364 %572
+%573 = OpLoad %ulong %363
+OpStore %365 %573
+OpBranch %126
+%52 = OpLabel
+%574 = OpLoad %ulong %273
+%575 = OpAccessChain %_ptr_Function_float %163 %574
+%576 = OpLoad %float %575
+OpStore %254 %576
+%577 = OpLoad %ulong %273
+%578 = OpAccessChain %_ptr_Function_float %164 %577
+%579 = OpLoad %float %578
+OpStore %255 %579
+%580 = OpLoad %float %254
+%581 = OpLoad %float %255
+%582 = OpFDiv %float %580 %581
+OpStore %256 %582
+%583 = OpLoad %ulong %273
+%584 = OpAccessChain %_ptr_Function_float %166 %583
+%585 = OpLoad %float %256
+OpStore %584 %585
+%586 = OpLoad %ulong %273
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %257 %587
+%588 = OpLoad %ulong %257
+OpStore %273 %588
+OpBranch %130
+%49 = OpLabel
+%589 = OpLoad %ulong %274
+%590 = OpAccessChain %_ptr_Function_float %165 %589
+%591 = OpLoad %float %590
+OpStore %251 %591
+OpBranch %72
+%72 = OpLabel
+%592 = OpLoad %float %251
+%593 = OpBitcast %uint %592
+OpStore %296 %593
+%594 = OpLoad %uint %296
+%595 = OpUConvert %ulong %594
+OpStore %297 %595
+OpBranch %105
+%105 = OpLabel
+%596 = OpLoad %ulong %266
+OpStore %355 %596
+OpStore %356 %ulong_0
+OpBranch %106
+%106 = OpLabel
+%597 = OpLoad %ulong %356
+%598 = OpULessThan %bool %597 %ulong_8
+OpStore %348 %598
+%599 = OpLoad %bool %348
+OpLoopMerge %108 %129 None
+OpBranchConditional %599 %107 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %73
+%73 = OpLabel
+%600 = OpLoad %ulong %274
+%601 = OpIAdd %ulong %600 %ulong_1
+OpStore %252 %601
+%602 = OpLoad %ulong %355
+OpStore %266 %602
+%603 = OpLoad %ulong %252
+OpStore %274 %603
+OpBranch %131
+%107 = OpLabel
+%604 = OpLoad %ulong %356
+%605 = OpIMul %ulong %604 %ulong_8
+OpStore %349 %605
+%606 = OpLoad %ulong %297
+%607 = OpLoad %ulong %349
+%608 = OpShiftRightLogical %ulong %606 %607
+OpStore %350 %608
+%609 = OpLoad %ulong %350
+%610 = OpBitwiseAnd %ulong %609 %ulong_255
+OpStore %351 %610
+%611 = OpLoad %ulong %355
+%612 = OpLoad %ulong %351
+%613 = OpBitwiseXor %ulong %611 %612
+OpStore %352 %613
+%614 = OpLoad %ulong %352
+%615 = OpIMul %ulong %614 %ulong_1099511628211
+OpStore %353 %615
+%616 = OpLoad %ulong %356
+%617 = OpIAdd %ulong %616 %ulong_1
+OpStore %354 %617
+%618 = OpLoad %ulong %353
+OpStore %355 %618
+%619 = OpLoad %ulong %354
+OpStore %356 %619
+OpBranch %129
+%46 = OpLabel
+%620 = OpLoad %ulong %275
+%621 = OpAccessChain %_ptr_Function_float %163 %620
+%622 = OpLoad %float %621
+OpStore %246 %622
+%623 = OpLoad %ulong %275
+%624 = OpAccessChain %_ptr_Function_float %164 %623
+%625 = OpLoad %float %624
+OpStore %247 %625
+%626 = OpLoad %float %246
+%627 = OpLoad %float %247
+%628 = OpFMul %float %626 %627
+OpStore %248 %628
+%629 = OpLoad %ulong %275
+%630 = OpAccessChain %_ptr_Function_float %165 %629
+%631 = OpLoad %float %248
+OpStore %630 %631
+%632 = OpLoad %ulong %275
+%633 = OpIAdd %ulong %632 %ulong_1
+OpStore %249 %633
+%634 = OpLoad %ulong %249
+OpStore %275 %634
+OpBranch %132
+%43 = OpLabel
+%635 = OpLoad %ulong %276
+%636 = OpConvertUToF %float %635
+OpStore %241 %636
+%637 = OpLoad %float %241
+%638 = OpLoad %float %178
+%639 = OpFAdd %float %637 %638
+OpStore %242 %639
+%640 = OpLoad %ulong %276
+%641 = OpAccessChain %_ptr_Function_float %163 %640
+%642 = OpLoad %float %242
+OpStore %641 %642
+%644 = OpLoad %float %241
+%645 = OpFSub %float %float_1_25 %644
+OpStore %243 %645
+%646 = OpLoad %ulong %276
+%647 = OpAccessChain %_ptr_Function_float %164 %646
+%648 = OpLoad %float %243
+OpStore %647 %648
+%649 = OpLoad %ulong %276
+%650 = OpIAdd %ulong %649 %ulong_1
+OpStore %244 %650
+%651 = OpLoad %ulong %244
+OpStore %276 %651
+OpBranch %134
+%40 = OpLabel
+%652 = OpLoad %ulong %277
+%653 = OpAccessChain %_ptr_Function_uint %159 %652
+%654 = OpLoad %uint %653
+OpStore %238 %654
+OpBranch %70
+%70 = OpLabel
+%655 = OpLoad %uint %238
+%656 = OpUConvert %ulong %655
+OpStore %295 %656
+OpBranch %100
+%100 = OpLabel
+%657 = OpLoad %ulong %267
+OpStore %346 %657
+OpStore %347 %ulong_0
+OpBranch %101
+%101 = OpLabel
+%658 = OpLoad %ulong %347
+%659 = OpULessThan %bool %658 %ulong_8
+OpStore %339 %659
+%660 = OpLoad %bool %339
+OpLoopMerge %103 %133 None
+OpBranchConditional %660 %102 %103
+%103 = OpLabel
+OpBranch %104
+%104 = OpLabel
+OpBranch %71
+%71 = OpLabel
+%661 = OpLoad %ulong %277
+%662 = OpIAdd %ulong %661 %ulong_1
+OpStore %239 %662
+%663 = OpLoad %ulong %346
+OpStore %267 %663
+%664 = OpLoad %ulong %239
+OpStore %277 %664
+OpBranch %135
+%102 = OpLabel
+%665 = OpLoad %ulong %347
+%666 = OpIMul %ulong %665 %ulong_8
+OpStore %340 %666
+%667 = OpLoad %ulong %295
+%668 = OpLoad %ulong %340
+%669 = OpShiftRightLogical %ulong %667 %668
+OpStore %341 %669
+%670 = OpLoad %ulong %341
+%671 = OpBitwiseAnd %ulong %670 %ulong_255
+OpStore %342 %671
+%672 = OpLoad %ulong %346
+%673 = OpLoad %ulong %342
+%674 = OpBitwiseXor %ulong %672 %673
+OpStore %343 %674
+%675 = OpLoad %ulong %343
+%676 = OpIMul %ulong %675 %ulong_1099511628211
+OpStore %344 %676
+%677 = OpLoad %ulong %347
+%678 = OpIAdd %ulong %677 %ulong_1
+OpStore %345 %678
+%679 = OpLoad %ulong %344
+OpStore %346 %679
+%680 = OpLoad %ulong %345
+OpStore %347 %680
+OpBranch %133
+%37 = OpLabel
+%681 = OpLoad %ulong %278
+%682 = OpISub %ulong %681 %ulong_1
+OpStore %231 %682
+%683 = OpLoad %ulong %231
+%684 = OpAccessChain %_ptr_Function_uint %159 %683
+%685 = OpLoad %uint %684
+OpStore %232 %685
+%686 = OpLoad %uint %232
+%688 = OpIMul %uint %686 %uint_31
+OpStore %233 %688
+%689 = OpLoad %ulong %278
+%690 = OpAccessChain %_ptr_Function_uint %167 %689
+%691 = OpLoad %uint %690
+OpStore %234 %691
+%692 = OpLoad %uint %233
+%693 = OpLoad %uint %234
+%694 = OpIAdd %uint %692 %693
+OpStore %235 %694
+%695 = OpLoad %ulong %278
+%696 = OpAccessChain %_ptr_Function_uint %159 %695
+%697 = OpLoad %uint %235
+OpStore %696 %697
+%698 = OpLoad %ulong %278
+%699 = OpIAdd %ulong %698 %ulong_1
+OpStore %236 %699
+%700 = OpLoad %ulong %236
+OpStore %278 %700
+OpBranch %137
+%34 = OpLabel
+%701 = OpLoad %ulong %279
+%702 = OpAccessChain %_ptr_Function_uint %158 %701
+%703 = OpLoad %uint %702
+OpStore %227 %703
+OpBranch %68
+%68 = OpLabel
+%704 = OpLoad %uint %227
+%705 = OpUConvert %ulong %704
+OpStore %294 %705
+OpBranch %95
+%95 = OpLabel
+%706 = OpLoad %ulong %268
+OpStore %337 %706
+OpStore %338 %ulong_0
+OpBranch %96
+%96 = OpLabel
+%707 = OpLoad %ulong %338
+%708 = OpULessThan %bool %707 %ulong_8
+OpStore %330 %708
+%709 = OpLoad %bool %330
+OpLoopMerge %98 %136 None
+OpBranchConditional %709 %97 %98
+%98 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%710 = OpLoad %ulong %279
+%711 = OpIAdd %ulong %710 %ulong_1
+OpStore %228 %711
+%712 = OpLoad %ulong %337
+OpStore %268 %712
+%713 = OpLoad %ulong %228
+OpStore %279 %713
+OpBranch %138
+%97 = OpLabel
+%714 = OpLoad %ulong %338
+%715 = OpIMul %ulong %714 %ulong_8
+OpStore %331 %715
+%716 = OpLoad %ulong %294
+%717 = OpLoad %ulong %331
+%718 = OpShiftRightLogical %ulong %716 %717
+OpStore %332 %718
+%719 = OpLoad %ulong %332
+%720 = OpBitwiseAnd %ulong %719 %ulong_255
+OpStore %333 %720
+%721 = OpLoad %ulong %337
+%722 = OpLoad %ulong %333
+%723 = OpBitwiseXor %ulong %721 %722
+OpStore %334 %723
+%724 = OpLoad %ulong %334
+%725 = OpIMul %ulong %724 %ulong_1099511628211
+OpStore %335 %725
+%726 = OpLoad %ulong %338
+%727 = OpIAdd %ulong %726 %ulong_1
+OpStore %336 %727
+%728 = OpLoad %ulong %335
+OpStore %337 %728
+%729 = OpLoad %ulong %336
+OpStore %338 %729
+OpBranch %136
+%31 = OpLabel
+%730 = OpLoad %ulong %280
+%731 = OpAccessChain %_ptr_Function_uint %157 %730
+%732 = OpLoad %uint %731
+OpStore %223 %732
+%733 = OpLoad %uint %223
+%734 = OpBitwiseXor %uint %733 %uint_1
+OpStore %224 %734
+%735 = OpLoad %ulong %280
+%736 = OpAccessChain %_ptr_Function_uint %158 %735
+%737 = OpLoad %uint %224
+OpStore %736 %737
+%738 = OpLoad %ulong %280
+%740 = OpIAdd %ulong %738 %ulong_2
+OpStore %225 %740
+%741 = OpLoad %ulong %225
+OpStore %280 %741
+OpBranch %139
+%28 = OpLabel
+%742 = OpLoad %ulong %281
+%743 = OpAccessChain %_ptr_Function_uint %158 %742
+OpStore %743 %uint_2863311530
+%745 = OpLoad %ulong %281
+%746 = OpIAdd %ulong %745 %ulong_1
+OpStore %221 %746
+%747 = OpLoad %ulong %221
+OpStore %281 %747
+OpBranch %141
+%25 = OpLabel
+%748 = OpLoad %ulong %282
+%749 = OpAccessChain %_ptr_Function_uint %169 %748
+%750 = OpLoad %uint %749
+OpStore %218 %750
+OpBranch %66
+%66 = OpLabel
+%751 = OpLoad %uint %218
+%752 = OpUConvert %ulong %751
+OpStore %293 %752
+OpBranch %90
+%90 = OpLabel
+%753 = OpLoad %ulong %269
+OpStore %328 %753
+OpStore %329 %ulong_0
+OpBranch %91
+%91 = OpLabel
+%754 = OpLoad %ulong %329
+%755 = OpULessThan %bool %754 %ulong_8
+OpStore %321 %755
+%756 = OpLoad %bool %321
+OpLoopMerge %93 %140 None
+OpBranchConditional %756 %92 %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%757 = OpLoad %ulong %282
+%758 = OpIAdd %ulong %757 %ulong_1
+OpStore %219 %758
+%759 = OpLoad %ulong %328
+OpStore %269 %759
+%760 = OpLoad %ulong %219
+OpStore %282 %760
+OpBranch %142
+%92 = OpLabel
+%761 = OpLoad %ulong %329
+%762 = OpIMul %ulong %761 %ulong_8
+OpStore %322 %762
+%763 = OpLoad %ulong %293
+%764 = OpLoad %ulong %322
+%765 = OpShiftRightLogical %ulong %763 %764
+OpStore %323 %765
+%766 = OpLoad %ulong %323
+%767 = OpBitwiseAnd %ulong %766 %ulong_255
+OpStore %324 %767
+%768 = OpLoad %ulong %328
+%769 = OpLoad %ulong %324
+%770 = OpBitwiseXor %ulong %768 %769
+OpStore %325 %770
+%771 = OpLoad %ulong %325
+%772 = OpIMul %ulong %771 %ulong_1099511628211
+OpStore %326 %772
+%773 = OpLoad %ulong %329
+%774 = OpIAdd %ulong %773 %ulong_1
+OpStore %327 %774
+%775 = OpLoad %ulong %326
+OpStore %328 %775
+%776 = OpLoad %ulong %327
+OpStore %329 %776
+OpBranch %140
+%19 = OpLabel
+%777 = OpLoad %ulong %283
+%778 = OpAccessChain %_ptr_Function_uint %167 %777
+%779 = OpLoad %uint %778
+OpStore %207 %779
+%780 = OpLoad %ulong %283
+%781 = OpAccessChain %_ptr_Function_uint %168 %780
+%782 = OpLoad %uint %781
+OpStore %208 %782
+%783 = OpLoad %uint %208
+%784 = OpLoad %uint %207
+%785 = OpULessThan %bool %783 %784
+OpStore %209 %785
+%786 = OpLoad %bool %209
+OpSelectionMerge %23 None
+OpBranchConditional %786 %21 %22
+%22 = OpLabel
+%787 = OpLoad %ulong %283
+%788 = OpAccessChain %_ptr_Function_uint %168 %787
+%789 = OpLoad %uint %788
+OpStore %213 %789
+%790 = OpLoad %ulong %283
+%791 = OpAccessChain %_ptr_Function_uint %167 %790
+%792 = OpLoad %uint %791
+OpStore %214 %792
+%793 = OpLoad %uint %213
+%794 = OpLoad %uint %214
+%795 = OpISub %uint %793 %794
+OpStore %215 %795
+%796 = OpLoad %ulong %283
+%797 = OpAccessChain %_ptr_Function_uint %169 %796
+%798 = OpLoad %uint %215
+OpStore %797 %798
+OpBranch %23
+%21 = OpLabel
+%799 = OpLoad %ulong %283
+%800 = OpAccessChain %_ptr_Function_uint %167 %799
+%801 = OpLoad %uint %800
+OpStore %210 %801
+%802 = OpLoad %ulong %283
+%803 = OpAccessChain %_ptr_Function_uint %168 %802
+%804 = OpLoad %uint %803
+OpStore %211 %804
+%805 = OpLoad %uint %210
+%806 = OpLoad %uint %211
+%807 = OpISub %uint %805 %806
+OpStore %212 %807
+%808 = OpLoad %ulong %283
+%809 = OpAccessChain %_ptr_Function_uint %169 %808
+%810 = OpLoad %uint %212
+OpStore %809 %810
+OpBranch %23
+%23 = OpLabel
+%811 = OpLoad %ulong %283
+%812 = OpIAdd %ulong %811 %ulong_1
+OpStore %216 %812
+%813 = OpLoad %ulong %216
+OpStore %283 %813
+OpBranch %143
+%122 = OpLabel
+%814 = OpLoad %ulong %383
+%815 = OpIMul %ulong %814 %ulong_8
+OpStore %376 %815
+%816 = OpLoad %ulong %320
+%817 = OpLoad %ulong %376
+%818 = OpShiftRightLogical %ulong %816 %817
+OpStore %377 %818
+%819 = OpLoad %ulong %377
+%820 = OpBitwiseAnd %ulong %819 %ulong_255
+OpStore %378 %820
+%821 = OpLoad %ulong %382
+%822 = OpLoad %ulong %378
+%823 = OpBitwiseXor %ulong %821 %822
+OpStore %379 %823
+%824 = OpLoad %ulong %379
+%825 = OpIMul %ulong %824 %ulong_1099511628211
+OpStore %380 %825
+%826 = OpLoad %ulong %383
+%827 = OpIAdd %ulong %826 %ulong_1
+OpStore %381 %827
+%828 = OpLoad %ulong %380
+OpStore %382 %828
+%829 = OpLoad %ulong %381
+OpStore %383 %829
+OpBranch %144
+%85 = OpLabel
+%830 = OpLoad %ulong %319
+%831 = OpIMul %ulong %830 %ulong_8
+OpStore %312 %831
+%832 = OpLoad %ulong %292
+%833 = OpLoad %ulong %312
+%834 = OpShiftRightLogical %ulong %832 %833
+OpStore %313 %834
+%835 = OpLoad %ulong %313
+%836 = OpBitwiseAnd %ulong %835 %ulong_255
+OpStore %314 %836
+%837 = OpLoad %ulong %318
+%838 = OpLoad %ulong %314
+%839 = OpBitwiseXor %ulong %837 %838
+OpStore %315 %839
+%840 = OpLoad %ulong %315
+%841 = OpIMul %ulong %840 %ulong_1099511628211
+OpStore %316 %841
+%842 = OpLoad %ulong %319
+%843 = OpIAdd %ulong %842 %ulong_1
+OpStore %317 %843
+%844 = OpLoad %ulong %316
+OpStore %318 %844
+%845 = OpLoad %ulong %317
+OpStore %319 %845
+OpBranch %145
+%16 = OpLabel
+%846 = OpLoad %ulong %284
+%847 = OpAccessChain %_ptr_Function_uint %157 %846
+%848 = OpLoad %uint %847
+OpStore %201 %848
+%849 = OpLoad %uint %288
+%850 = OpLoad %uint %201
+%851 = OpIAdd %uint %849 %850
+OpStore %202 %851
+%852 = OpLoad %ulong %284
+%853 = OpAccessChain %_ptr_Function_uint %167 %852
+%854 = OpLoad %uint %853
+OpStore %203 %854
+%855 = OpLoad %uint %289
+%856 = OpLoad %uint %203
+%857 = OpBitwiseXor %uint %855 %856
+OpStore %204 %857
+%858 = OpLoad %ulong %284
+%859 = OpIAdd %ulong %858 %ulong_1
+OpStore %205 %859
+%860 = OpLoad %ulong %205
+OpStore %284 %860
+%861 = OpLoad %uint %202
+OpStore %288 %861
+%862 = OpLoad %uint %204
+OpStore %289 %862
+OpBranch %147
+%13 = OpLabel
+%863 = OpLoad %ulong %285
+%864 = OpAccessChain %_ptr_Function_uint %157 %863
+%865 = OpLoad %uint %864
+OpStore %198 %865
+OpBranch %62
+%62 = OpLabel
+%866 = OpLoad %uint %198
+%867 = OpUConvert %ulong %866
+OpStore %291 %867
+OpBranch %78
+%78 = OpLabel
+%868 = OpLoad %ulong %270
+OpStore %309 %868
+OpStore %310 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%869 = OpLoad %ulong %310
+%870 = OpULessThan %bool %869 %ulong_8
+OpStore %302 %870
+%871 = OpLoad %bool %302
+OpLoopMerge %81 %146 None
+OpBranchConditional %871 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+OpBranch %63
+%63 = OpLabel
+%872 = OpLoad %ulong %285
+%873 = OpIAdd %ulong %872 %ulong_1
+OpStore %199 %873
+%874 = OpLoad %ulong %309
+OpStore %270 %874
+%875 = OpLoad %ulong %199
+OpStore %285 %875
+OpBranch %148
+%80 = OpLabel
+%876 = OpLoad %ulong %310
+%877 = OpIMul %ulong %876 %ulong_8
+OpStore %303 %877
+%878 = OpLoad %ulong %291
+%879 = OpLoad %ulong %303
+%880 = OpShiftRightLogical %ulong %878 %879
+OpStore %304 %880
+%881 = OpLoad %ulong %304
+%882 = OpBitwiseAnd %ulong %881 %ulong_255
+OpStore %305 %882
+%883 = OpLoad %ulong %309
+%884 = OpLoad %ulong %305
+%885 = OpBitwiseXor %ulong %883 %884
+OpStore %306 %885
+%886 = OpLoad %ulong %306
+%887 = OpIMul %ulong %886 %ulong_1099511628211
+OpStore %307 %887
+%888 = OpLoad %ulong %310
+%889 = OpIAdd %ulong %888 %ulong_1
+OpStore %308 %889
+%890 = OpLoad %ulong %307
+OpStore %309 %890
+%891 = OpLoad %ulong %308
+OpStore %310 %891
+OpBranch %146
+%10 = OpLabel
+%892 = OpLoad %ulong %286
+%893 = OpAccessChain %_ptr_Function_uint %167 %892
+%894 = OpLoad %uint %893
+OpStore %192 %894
+%895 = OpLoad %uint %192
+%897 = OpIMul %uint %895 %uint_3
+OpStore %193 %897
+%898 = OpLoad %ulong %286
+%899 = OpAccessChain %_ptr_Function_uint %168 %898
+%900 = OpLoad %uint %899
+OpStore %194 %900
+%901 = OpLoad %uint %193
+%902 = OpLoad %uint %194
+%903 = OpIAdd %uint %901 %902
+OpStore %195 %903
+%904 = OpLoad %ulong %286
+%905 = OpAccessChain %_ptr_Function_uint %157 %904
+%906 = OpLoad %uint %195
+OpStore %905 %906
+%907 = OpLoad %ulong %286
+%908 = OpIAdd %ulong %907 %ulong_1
+OpStore %196 %908
+%909 = OpLoad %ulong %196
+OpStore %286 %909
+OpBranch %149
+%7 = OpLabel
+%910 = OpLoad %ulong %287
+%911 = OpUConvert %uint %910
+OpStore %181 %911
+%912 = OpLoad %uint %181
+%914 = OpIMul %uint %912 %uint_2654435761
+OpStore %182 %914
+%915 = OpLoad %uint %182
+%917 = OpIAdd %uint %915 %uint_12345
+OpStore %183 %917
+%918 = OpLoad %ulong %287
+%919 = OpAccessChain %_ptr_Function_uint %167 %918
+%920 = OpLoad %uint %183
+OpStore %919 %920
+%921 = OpLoad %uint %181
+%923 = OpIMul %uint %921 %uint_40503
+OpStore %184 %923
+%925 = OpLoad %uint %184
+%926 = OpISub %uint %uint_4294967295 %925
+OpStore %185 %926
+%927 = OpLoad %ulong %287
+%928 = OpAccessChain %_ptr_Function_uint %168 %927
+%929 = OpLoad %uint %185
+OpStore %928 %929
+%930 = OpLoad %ulong %287
+%931 = OpIAdd %ulong %930 %ulong_1
+OpStore %186 %931
+%932 = OpLoad %ulong %186
+OpStore %287 %932
+OpBranch %150
+%125 = OpLabel
+OpBranch %116
+%126 = OpLabel
+OpBranch %111
+%127 = OpLabel
+OpBranch %57
+%128 = OpLabel
+OpBranch %54
+%129 = OpLabel
+OpBranch %106
+%130 = OpLabel
+OpBranch %51
+%131 = OpLabel
+OpBranch %48
+%132 = OpLabel
+OpBranch %45
+%133 = OpLabel
+OpBranch %101
+%134 = OpLabel
+OpBranch %42
+%135 = OpLabel
+OpBranch %39
+%136 = OpLabel
+OpBranch %96
+%137 = OpLabel
+OpBranch %36
+%138 = OpLabel
+OpBranch %33
+%139 = OpLabel
+OpBranch %30
+%140 = OpLabel
+OpBranch %91
+%141 = OpLabel
+OpBranch %27
+%142 = OpLabel
+OpBranch %24
+%143 = OpLabel
+OpBranch %18
+%144 = OpLabel
+OpBranch %121
+%145 = OpLabel
+OpBranch %84
+%146 = OpLabel
+OpBranch %79
+%147 = OpLabel
+OpBranch %15
+%148 = OpLabel
+OpBranch %12
+%149 = OpLabel
+OpBranch %9
+%150 = OpLabel
+OpBranch %6
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_cmp_i64.dis
+++ b/test/golden/spirv/vec/vec_cmp_i64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 689
+; Bound: 630
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,20 +12,25 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.fold_i64x2" Export
 OpDecorate %3 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.checksum" Export
 %ulong = OpTypeInt 64 0
 %v2ulong = OpTypeVector %ulong 2
-%9 = OpTypeFunction %ulong %ulong %v2ulong
+%6 = OpTypeFunction %ulong %ulong %v2ulong
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v2ulong = OpTypePointer Function %v2ulong
-%52 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%184 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
-%uint_6 = OpConstant %uint 6
-%_arr_v2ulong_uint_6 = OpTypeArray %v2ulong %uint_6
-%_ptr_Function__arr_v2ulong_uint_6 = OpTypePointer Function %_arr_v2ulong_uint_6
 %uint_5 = OpConstant %uint 5
 %_arr_v2ulong_uint_5 = OpTypeArray %v2ulong %uint_5
 %_ptr_Function__arr_v2ulong_uint_5 = OpTypePointer Function %_arr_v2ulong_uint_5
-%_ptr_Function_bool = OpTypePointer Function %bool
-%231 = OpConstantNull %_arr_v2ulong_uint_6
+%uint_6 = OpConstant %uint 6
+%_arr_v2ulong_uint_6 = OpTypeArray %v2ulong %uint_6
+%_ptr_Function__arr_v2ulong_uint_6 = OpTypePointer Function %_arr_v2ulong_uint_6
+%326 = OpConstantNull %_arr_v2ulong_uint_6
 %ulong_8589934591 = OpConstant %ulong 8589934591
 %ulong_4294967297 = OpConstant %ulong 4294967297
 %uint_0 = OpConstant %uint 0
@@ -38,919 +43,855 @@ OpDecorate %3 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.checksum" Export
 %ulong_1311768467463790320 = OpConstant %ulong 1311768467463790320
 %uint_3 = OpConstant %uint 3
 %ulong_8589934592 = OpConstant %ulong 8589934592
-%ulong_0 = OpConstant %ulong 0
 %uint_4 = OpConstant %uint 4
 %ulong_266 = OpConstant %ulong 266
 %ulong_10 = OpConstant %ulong 10
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%289 = OpConstantNull %_arr_v2ulong_uint_5
+%383 = OpConstantNull %_arr_v2ulong_uint_5
 %ulong_9223372039002259456 = OpConstant %ulong 9223372039002259456
 %ulong_18446744069414584319 = OpConstant %ulong 18446744069414584319
 %ulong_5 = OpConstant %ulong 5
 %v2bool = OpTypeVector %bool 2
-%354 = OpConstantComposite %v2ulong %ulong_18446744073709551615 %ulong_18446744073709551615
-%355 = OpConstantComposite %v2ulong %ulong_0 %ulong_0
-%ulong_1 = OpConstant %ulong 1
-%602 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%605 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v2ulong
-%12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v2ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%21 = OpLoad %v2ulong %16
-%22 = OpCompositeExtract %ulong %21 0
-OpStore %17 %22
-%23 = OpLoad %ulong %14
-%24 = OpLoad %ulong %17
-%25 = OpFunctionCall %ulong %5 %23 %24
-OpStore %18 %25
-%26 = OpLoad %v2ulong %16
-%27 = OpCompositeExtract %ulong %26 1
-OpStore %19 %27
-%28 = OpLoad %ulong %18
-%29 = OpLoad %ulong %19
-%30 = OpFunctionCall %ulong %5 %28 %29
-OpStore %20 %30
-%31 = OpLoad %ulong %20
-OpReturnValue %31
-OpFunctionEnd
-%2 = OpFunction %ulong None %9
-%32 = OpFunctionParameter %ulong
-%33 = OpFunctionParameter %v2ulong
-%34 = OpLabel
+%448 = OpConstantComposite %v2ulong %ulong_18446744073709551615 %ulong_18446744073709551615
+%449 = OpConstantComposite %v2ulong %ulong_0 %ulong_0
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v2ulong
+%9 = OpLabel
+%24 = OpVariable %_ptr_Function_ulong Function
+%26 = OpVariable %_ptr_Function_v2ulong Function
+%27 = OpVariable %_ptr_Function_ulong Function
+%28 = OpVariable %_ptr_Function_ulong Function
+%30 = OpVariable %_ptr_Function_bool Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%32 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_ulong Function
+%34 = OpVariable %_ptr_Function_ulong Function
 %35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_v2ulong Function
+%36 = OpVariable %_ptr_Function_ulong Function
 %37 = OpVariable %_ptr_Function_ulong Function
 %38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_bool Function
 %40 = OpVariable %_ptr_Function_ulong Function
-OpStore %35 %32
-OpStore %36 %33
-%41 = OpLoad %v2ulong %36
-%42 = OpCompositeExtract %ulong %41 0
-OpStore %37 %42
-%43 = OpLoad %ulong %35
-%44 = OpLoad %ulong %37
-%45 = OpFunctionCall %ulong %6 %43 %44
-OpStore %38 %45
-%46 = OpLoad %v2ulong %36
-%47 = OpCompositeExtract %ulong %46 1
-OpStore %39 %47
-%48 = OpLoad %ulong %38
-%49 = OpLoad %ulong %39
-%50 = OpFunctionCall %ulong %6 %48 %49
-OpStore %40 %50
-%51 = OpLoad %ulong %40
-OpReturnValue %51
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_ulong Function
+OpStore %24 %7
+OpStore %26 %8
+%48 = OpLoad %v2ulong %26
+%49 = OpCompositeExtract %ulong %48 0
+OpStore %27 %49
+OpBranch %10
+%10 = OpLabel
+%50 = OpLoad %ulong %24
+OpStore %37 %50
+OpStore %38 %ulong_0
+OpBranch %11
+%11 = OpLabel
+%52 = OpLoad %ulong %38
+%54 = OpULessThan %bool %52 %ulong_8
+OpStore %30 %54
+%55 = OpLoad %bool %30
+OpLoopMerge %13 %21 None
+OpBranchConditional %55 %12 %13
+%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%56 = OpLoad %v2ulong %26
+%57 = OpCompositeExtract %ulong %56 1
+OpStore %28 %57
+OpBranch %15
+%15 = OpLabel
+%58 = OpLoad %ulong %37
+OpStore %46 %58
+OpStore %47 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%59 = OpLoad %ulong %47
+%60 = OpULessThan %bool %59 %ulong_8
+OpStore %39 %60
+%61 = OpLoad %bool %39
+OpLoopMerge %18 %20 None
+OpBranchConditional %61 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+%62 = OpLoad %ulong %46
+OpReturnValue %62
+%17 = OpLabel
+%63 = OpLoad %ulong %47
+%64 = OpIMul %ulong %63 %ulong_8
+OpStore %40 %64
+%65 = OpLoad %ulong %28
+%66 = OpLoad %ulong %40
+%67 = OpShiftRightLogical %ulong %65 %66
+OpStore %41 %67
+%68 = OpLoad %ulong %41
+%70 = OpBitwiseAnd %ulong %68 %ulong_255
+OpStore %42 %70
+%71 = OpLoad %ulong %46
+%72 = OpLoad %ulong %42
+%73 = OpBitwiseXor %ulong %71 %72
+OpStore %43 %73
+%74 = OpLoad %ulong %43
+%76 = OpIMul %ulong %74 %ulong_1099511628211
+OpStore %44 %76
+%77 = OpLoad %ulong %47
+%79 = OpIAdd %ulong %77 %ulong_1
+OpStore %45 %79
+%80 = OpLoad %ulong %44
+OpStore %46 %80
+%81 = OpLoad %ulong %45
+OpStore %47 %81
+OpBranch %20
+%12 = OpLabel
+%82 = OpLoad %ulong %38
+%83 = OpIMul %ulong %82 %ulong_8
+OpStore %31 %83
+%84 = OpLoad %ulong %27
+%85 = OpLoad %ulong %31
+%86 = OpShiftRightLogical %ulong %84 %85
+OpStore %32 %86
+%87 = OpLoad %ulong %32
+%88 = OpBitwiseAnd %ulong %87 %ulong_255
+OpStore %33 %88
+%89 = OpLoad %ulong %37
+%90 = OpLoad %ulong %33
+%91 = OpBitwiseXor %ulong %89 %90
+OpStore %34 %91
+%92 = OpLoad %ulong %34
+%93 = OpIMul %ulong %92 %ulong_1099511628211
+OpStore %35 %93
+%94 = OpLoad %ulong %38
+%95 = OpIAdd %ulong %94 %ulong_1
+OpStore %36 %95
+%96 = OpLoad %ulong %35
+OpStore %37 %96
+%97 = OpLoad %ulong %36
+OpStore %38 %97
+OpBranch %21
+%20 = OpLabel
+OpBranch %16
+%21 = OpLabel
+OpBranch %11
 OpFunctionEnd
-%3 = OpFunction %ulong None %52
-%53 = OpFunctionParameter %ulong
-%54 = OpLabel
-%96 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
-%97 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
-%101 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
-%102 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
-%103 = OpVariable %_ptr_Function_ulong Function
-%104 = OpVariable %_ptr_Function_ulong Function
-%105 = OpVariable %_ptr_Function_v2ulong Function
-%106 = OpVariable %_ptr_Function_v2ulong Function
-%107 = OpVariable %_ptr_Function_v2ulong Function
-%108 = OpVariable %_ptr_Function_v2ulong Function
-%109 = OpVariable %_ptr_Function_v2ulong Function
-%110 = OpVariable %_ptr_Function_v2ulong Function
-%111 = OpVariable %_ptr_Function_v2ulong Function
-%112 = OpVariable %_ptr_Function_v2ulong Function
-%113 = OpVariable %_ptr_Function_v2ulong Function
-%114 = OpVariable %_ptr_Function_v2ulong Function
-%115 = OpVariable %_ptr_Function_v2ulong Function
-%116 = OpVariable %_ptr_Function_v2ulong Function
-%118 = OpVariable %_ptr_Function_bool Function
-%119 = OpVariable %_ptr_Function_v2ulong Function
-%120 = OpVariable %_ptr_Function_v2ulong Function
-%121 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %6
+%98 = OpFunctionParameter %ulong
+%99 = OpFunctionParameter %v2ulong
+%100 = OpLabel
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_v2ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_bool Function
 %122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_v2ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
 %124 = OpVariable %_ptr_Function_ulong Function
 %125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_v2ulong Function
-%127 = OpVariable %_ptr_Function_v2ulong Function
-%128 = OpVariable %_ptr_Function_v2ulong Function
-%129 = OpVariable %_ptr_Function_v2ulong Function
-%130 = OpVariable %_ptr_Function_v2ulong Function
-%131 = OpVariable %_ptr_Function_v2ulong Function
-%132 = OpVariable %_ptr_Function_v2ulong Function
-%133 = OpVariable %_ptr_Function_v2ulong Function
-%134 = OpVariable %_ptr_Function_v2ulong Function
-%135 = OpVariable %_ptr_Function_v2ulong Function
-%136 = OpVariable %_ptr_Function_v2ulong Function
-%137 = OpVariable %_ptr_Function_v2ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_bool Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
 %138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_v2ulong Function
-%140 = OpVariable %_ptr_Function_v2ulong Function
-%141 = OpVariable %_ptr_Function_v2ulong Function
-%142 = OpVariable %_ptr_Function_v2ulong Function
-%143 = OpVariable %_ptr_Function_v2ulong Function
-%144 = OpVariable %_ptr_Function_v2ulong Function
-%145 = OpVariable %_ptr_Function_v2ulong Function
-%146 = OpVariable %_ptr_Function_v2ulong Function
-%147 = OpVariable %_ptr_Function_v2ulong Function
-%148 = OpVariable %_ptr_Function_v2ulong Function
-%149 = OpVariable %_ptr_Function_bool Function
-%150 = OpVariable %_ptr_Function_v2ulong Function
-%151 = OpVariable %_ptr_Function_v2ulong Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_v2ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_v2ulong Function
-%158 = OpVariable %_ptr_Function_v2ulong Function
-%159 = OpVariable %_ptr_Function_v2ulong Function
-%160 = OpVariable %_ptr_Function_v2ulong Function
-%161 = OpVariable %_ptr_Function_v2ulong Function
-%162 = OpVariable %_ptr_Function_v2ulong Function
-%163 = OpVariable %_ptr_Function_v2ulong Function
-%164 = OpVariable %_ptr_Function_v2ulong Function
-%165 = OpVariable %_ptr_Function_v2ulong Function
-%166 = OpVariable %_ptr_Function_v2ulong Function
-%167 = OpVariable %_ptr_Function_v2ulong Function
-%168 = OpVariable %_ptr_Function_v2ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_ulong Function
+OpStore %117 %98
+OpStore %118 %99
+%139 = OpLoad %v2ulong %118
+%140 = OpCompositeExtract %ulong %139 0
+OpStore %119 %140
+OpBranch %101
+%101 = OpLabel
+OpBranch %103
+%103 = OpLabel
+%141 = OpLoad %ulong %117
+OpStore %128 %141
+OpStore %129 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%142 = OpLoad %ulong %129
+%143 = OpULessThan %bool %142 %ulong_8
+OpStore %121 %143
+%144 = OpLoad %bool %121
+OpLoopMerge %106 %116 None
+OpBranchConditional %144 %105 %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%145 = OpLoad %v2ulong %118
+%146 = OpCompositeExtract %ulong %145 1
+OpStore %120 %146
+OpBranch %108
+%108 = OpLabel
+OpBranch %110
+%110 = OpLabel
+%147 = OpLoad %ulong %128
+OpStore %137 %147
+OpStore %138 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%148 = OpLoad %ulong %138
+%149 = OpULessThan %bool %148 %ulong_8
+OpStore %130 %149
+%150 = OpLoad %bool %130
+OpLoopMerge %113 %115 None
+OpBranchConditional %150 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%151 = OpLoad %ulong %137
+OpReturnValue %151
+%112 = OpLabel
+%152 = OpLoad %ulong %138
+%153 = OpIMul %ulong %152 %ulong_8
+OpStore %131 %153
+%154 = OpLoad %ulong %120
+%155 = OpLoad %ulong %131
+%156 = OpShiftRightLogical %ulong %154 %155
+OpStore %132 %156
+%157 = OpLoad %ulong %132
+%158 = OpBitwiseAnd %ulong %157 %ulong_255
+OpStore %133 %158
+%159 = OpLoad %ulong %137
+%160 = OpLoad %ulong %133
+%161 = OpBitwiseXor %ulong %159 %160
+OpStore %134 %161
+%162 = OpLoad %ulong %134
+%163 = OpIMul %ulong %162 %ulong_1099511628211
+OpStore %135 %163
+%164 = OpLoad %ulong %138
+%165 = OpIAdd %ulong %164 %ulong_1
+OpStore %136 %165
+%166 = OpLoad %ulong %135
+OpStore %137 %166
+%167 = OpLoad %ulong %136
+OpStore %138 %167
+OpBranch %115
+%105 = OpLabel
+%168 = OpLoad %ulong %129
+%169 = OpIMul %ulong %168 %ulong_8
+OpStore %122 %169
+%170 = OpLoad %ulong %119
+%171 = OpLoad %ulong %122
+%172 = OpShiftRightLogical %ulong %170 %171
+OpStore %123 %172
+%173 = OpLoad %ulong %123
+%174 = OpBitwiseAnd %ulong %173 %ulong_255
+OpStore %124 %174
+%175 = OpLoad %ulong %128
+%176 = OpLoad %ulong %124
+%177 = OpBitwiseXor %ulong %175 %176
+OpStore %125 %177
+%178 = OpLoad %ulong %125
+%179 = OpIMul %ulong %178 %ulong_1099511628211
+OpStore %126 %179
+%180 = OpLoad %ulong %129
+%181 = OpIAdd %ulong %180 %ulong_1
+OpStore %127 %181
+%182 = OpLoad %ulong %126
+OpStore %128 %182
+%183 = OpLoad %ulong %127
+OpStore %129 %183
+OpBranch %116
+%115 = OpLabel
+OpBranch %111
+%116 = OpLabel
+OpBranch %104
+OpFunctionEnd
+%3 = OpFunction %ulong None %184
+%185 = OpFunctionParameter %ulong
+%186 = OpLabel
+%219 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
+%220 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
+%224 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
+%225 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
 %226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ulong Function
-OpStore %103 %53
-%230 = OpFunctionCall %ulong %4
-OpStore %104 %230
-OpStore %96 %231
-OpStore %97 %231
-%232 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
-OpStore %105 %232
-%236 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_0
-%237 = OpLoad %v2ulong %105
-OpStore %236 %237
-%238 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
-OpStore %106 %238
-%239 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_0
-%240 = OpLoad %v2ulong %106
-OpStore %239 %240
-%241 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_18446744069414584320
-OpStore %107 %241
-%245 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_1
-%246 = OpLoad %v2ulong %107
-OpStore %245 %246
-%247 = OpCompositeConstruct %v2ulong %ulong_18446744069414584320 %ulong_18446744073709551615
-OpStore %108 %247
-%248 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_1
-%249 = OpLoad %v2ulong %108
-OpStore %248 %249
-%250 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
-OpStore %109 %250
-%254 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_2
-%255 = OpLoad %v2ulong %109
-OpStore %254 %255
-%256 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
-OpStore %110 %256
-%257 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_2
-%258 = OpLoad %v2ulong %110
-OpStore %257 %258
-%259 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_1311768467463790320
-OpStore %111 %259
-%262 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_3
-%263 = OpLoad %v2ulong %111
-OpStore %262 %263
-%264 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_1311768467463790320
-OpStore %112 %264
-%265 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_3
-%266 = OpLoad %v2ulong %112
-OpStore %265 %266
-%267 = OpCompositeConstruct %v2ulong %ulong_8589934592 %ulong_0
-OpStore %113 %267
-%271 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_4
-%272 = OpLoad %v2ulong %113
-OpStore %271 %272
-%273 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_18446744073709551615
-OpStore %114 %273
-%274 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_4
-%275 = OpLoad %v2ulong %114
-OpStore %274 %275
-%276 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
-OpStore %115 %276
-%278 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_5
-%279 = OpLoad %v2ulong %115
-OpStore %278 %279
-%280 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
-OpStore %116 %280
-%282 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_5
-%283 = OpLoad %v2ulong %116
-OpStore %282 %283
-%284 = OpLoad %ulong %104
-OpStore %171 %284
-OpStore %172 %ulong_0
-OpBranch %55
-%55 = OpLabel
-%285 = OpLoad %ulong %172
-%287 = OpULessThan %bool %285 %ulong_6
-OpStore %118 %287
-%288 = OpLoad %bool %118
-OpLoopMerge %57 %90 None
-OpBranchConditional %288 %56 %57
-%57 = OpLabel
-OpStore %101 %289
-OpStore %102 %289
-%290 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
-OpStore %139 %290
-%291 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_0
-%292 = OpLoad %v2ulong %139
-OpStore %291 %292
-%293 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
-OpStore %140 %293
-%294 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_0
-%295 = OpLoad %v2ulong %140
-OpStore %294 %295
-%296 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
-OpStore %141 %296
-%297 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_1
-%298 = OpLoad %v2ulong %141
-OpStore %297 %298
-%299 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
-OpStore %142 %299
-%300 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_1
-%301 = OpLoad %v2ulong %142
-OpStore %300 %301
-%302 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_0
-OpStore %143 %302
-%303 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_2
-%304 = OpLoad %v2ulong %143
-OpStore %303 %304
-%305 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_18446744073709551615
-OpStore %144 %305
-%306 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_2
-%307 = OpLoad %v2ulong %144
-OpStore %306 %307
-%308 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584320
-OpStore %145 %308
-%310 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_3
-%311 = OpLoad %v2ulong %145
-OpStore %310 %311
-%312 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584319
-OpStore %146 %312
-%314 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_3
-%315 = OpLoad %v2ulong %146
-OpStore %314 %315
-%316 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
-OpStore %147 %316
-%317 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_4
-%318 = OpLoad %v2ulong %147
-OpStore %317 %318
-%319 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
-OpStore %148 %319
-%320 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_4
-%321 = OpLoad %v2ulong %148
-OpStore %320 %321
-%322 = OpLoad %ulong %171
-OpStore %170 %322
-OpStore %173 %ulong_0
-OpBranch %58
-%58 = OpLabel
-%323 = OpLoad %ulong %173
-%325 = OpULessThan %bool %323 %ulong_5
-OpStore %149 %325
-%326 = OpLoad %bool %149
-OpLoopMerge %60 %89 None
-OpBranchConditional %326 %59 %60
-%60 = OpLabel
-%327 = OpLoad %ulong %170
-OpReturnValue %327
-%59 = OpLabel
-%328 = OpLoad %ulong %173
-%329 = OpAccessChain %_ptr_Function_v2ulong %101 %328
-%330 = OpLoad %v2ulong %329
-OpStore %150 %330
-%331 = OpLoad %ulong %173
-%332 = OpAccessChain %_ptr_Function_v2ulong %102 %331
-%333 = OpLoad %v2ulong %332
-OpStore %151 %333
-%334 = OpLoad %v2ulong %150
-%335 = OpCompositeExtract %ulong %334 0
-OpStore %152 %335
-%336 = OpLoad %ulong %152
-%337 = OpLoad %ulong %103
-%338 = OpIAdd %ulong %336 %337
-OpStore %153 %338
-%339 = OpLoad %v2ulong %150
-%340 = OpLoad %ulong %153
-%341 = OpCompositeInsert %v2ulong %340 %339 0
-OpStore %154 %341
-%342 = OpLoad %v2ulong %151
-%343 = OpCompositeExtract %ulong %342 1
-OpStore %155 %343
-%344 = OpLoad %ulong %155
-%345 = OpLoad %ulong %103
-%346 = OpIAdd %ulong %344 %345
-OpStore %156 %346
-%347 = OpLoad %v2ulong %151
-%348 = OpLoad %ulong %156
-%349 = OpCompositeInsert %v2ulong %348 %347 1
-OpStore %157 %349
-%351 = OpLoad %v2ulong %154
-%352 = OpLoad %v2ulong %157
-%353 = OpULessThan %v2bool %351 %352
-%356 = OpSelect %v2ulong %353 %354 %355
-OpStore %158 %356
-OpBranch %63
-%63 = OpLabel
-%357 = OpLoad %v2ulong %158
-%358 = OpCompositeExtract %ulong %357 0
-OpStore %178 %358
-%359 = OpLoad %ulong %170
-%360 = OpLoad %ulong %178
-%361 = OpFunctionCall %ulong %5 %359 %360
-OpStore %179 %361
-%362 = OpLoad %v2ulong %158
-%363 = OpCompositeExtract %ulong %362 1
-OpStore %180 %363
-%364 = OpLoad %ulong %179
-%365 = OpLoad %ulong %180
-%366 = OpFunctionCall %ulong %5 %364 %365
-OpStore %181 %366
-OpBranch %64
-%64 = OpLabel
-%367 = OpLoad %v2ulong %154
-%368 = OpLoad %v2ulong %157
-%369 = OpULessThanEqual %v2bool %367 %368
-%370 = OpSelect %v2ulong %369 %354 %355
-OpStore %159 %370
-OpBranch %67
-%67 = OpLabel
-%371 = OpLoad %v2ulong %159
-%372 = OpCompositeExtract %ulong %371 0
-OpStore %186 %372
-%373 = OpLoad %ulong %181
-%374 = OpLoad %ulong %186
-%375 = OpFunctionCall %ulong %5 %373 %374
-OpStore %187 %375
-%376 = OpLoad %v2ulong %159
-%377 = OpCompositeExtract %ulong %376 1
-OpStore %188 %377
-%378 = OpLoad %ulong %187
-%379 = OpLoad %ulong %188
-%380 = OpFunctionCall %ulong %5 %378 %379
-OpStore %189 %380
-OpBranch %68
-%68 = OpLabel
-%381 = OpLoad %v2ulong %157
-%382 = OpLoad %v2ulong %154
-%383 = OpULessThan %v2bool %381 %382
-%384 = OpSelect %v2ulong %383 %354 %355
-OpStore %160 %384
-OpBranch %71
-%71 = OpLabel
-%385 = OpLoad %v2ulong %160
-%386 = OpCompositeExtract %ulong %385 0
-OpStore %194 %386
-%387 = OpLoad %ulong %189
-%388 = OpLoad %ulong %194
-%389 = OpFunctionCall %ulong %5 %387 %388
-OpStore %195 %389
-%390 = OpLoad %v2ulong %160
-%391 = OpCompositeExtract %ulong %390 1
-OpStore %196 %391
-%392 = OpLoad %ulong %195
-%393 = OpLoad %ulong %196
-%394 = OpFunctionCall %ulong %5 %392 %393
-OpStore %197 %394
-OpBranch %72
-%72 = OpLabel
-%395 = OpLoad %v2ulong %157
-%396 = OpLoad %v2ulong %154
-%397 = OpULessThanEqual %v2bool %395 %396
-%398 = OpSelect %v2ulong %397 %354 %355
-OpStore %161 %398
-OpBranch %75
-%75 = OpLabel
-%399 = OpLoad %v2ulong %161
-%400 = OpCompositeExtract %ulong %399 0
-OpStore %202 %400
-%401 = OpLoad %ulong %197
-%402 = OpLoad %ulong %202
-%403 = OpFunctionCall %ulong %5 %401 %402
-OpStore %203 %403
-%404 = OpLoad %v2ulong %161
-%405 = OpCompositeExtract %ulong %404 1
-OpStore %204 %405
-%406 = OpLoad %ulong %203
-%407 = OpLoad %ulong %204
-%408 = OpFunctionCall %ulong %5 %406 %407
-OpStore %205 %408
-OpBranch %76
-%76 = OpLabel
-%409 = OpLoad %v2ulong %154
-%410 = OpLoad %v2ulong %157
-%411 = OpIEqual %v2bool %409 %410
-%412 = OpSelect %v2ulong %411 %354 %355
-OpStore %162 %412
-OpBranch %79
-%79 = OpLabel
-%413 = OpLoad %v2ulong %162
-%414 = OpCompositeExtract %ulong %413 0
-OpStore %210 %414
-%415 = OpLoad %ulong %205
-%416 = OpLoad %ulong %210
-%417 = OpFunctionCall %ulong %5 %415 %416
-OpStore %211 %417
-%418 = OpLoad %v2ulong %162
-%419 = OpCompositeExtract %ulong %418 1
-OpStore %212 %419
-%420 = OpLoad %ulong %211
-%421 = OpLoad %ulong %212
-%422 = OpFunctionCall %ulong %5 %420 %421
-OpStore %213 %422
-OpBranch %80
-%80 = OpLabel
-%423 = OpLoad %v2ulong %154
-%424 = OpLoad %v2ulong %157
-%425 = OpINotEqual %v2bool %423 %424
-%426 = OpSelect %v2ulong %425 %354 %355
-OpStore %163 %426
-OpBranch %83
-%83 = OpLabel
-%427 = OpLoad %v2ulong %163
-%428 = OpCompositeExtract %ulong %427 0
-OpStore %218 %428
-%429 = OpLoad %ulong %213
-%430 = OpLoad %ulong %218
-%431 = OpFunctionCall %ulong %5 %429 %430
-OpStore %219 %431
-%432 = OpLoad %v2ulong %163
-%433 = OpCompositeExtract %ulong %432 1
-OpStore %220 %433
-%434 = OpLoad %ulong %219
-%435 = OpLoad %ulong %220
-%436 = OpFunctionCall %ulong %5 %434 %435
-OpStore %221 %436
-OpBranch %84
-%84 = OpLabel
-%437 = OpLoad %v2ulong %154
-%438 = OpLoad %v2ulong %157
-%439 = OpULessThan %v2bool %437 %438
-%440 = OpSelect %v2ulong %439 %354 %355
-OpStore %164 %440
-%441 = OpLoad %v2ulong %164
-%442 = OpLoad %v2ulong %154
-%443 = OpBitwiseAnd %v2ulong %441 %442
-OpStore %165 %443
-%444 = OpLoad %v2ulong %164
-%445 = OpNot %v2ulong %444
-OpStore %166 %445
-%446 = OpLoad %v2ulong %166
-%447 = OpLoad %v2ulong %157
-%448 = OpBitwiseAnd %v2ulong %446 %447
-OpStore %167 %448
-%449 = OpLoad %v2ulong %165
-%450 = OpLoad %v2ulong %167
-%451 = OpBitwiseOr %v2ulong %449 %450
-OpStore %168 %451
-OpBranch %87
-%87 = OpLabel
-%452 = OpLoad %v2ulong %168
-%453 = OpCompositeExtract %ulong %452 0
-OpStore %226 %453
-%454 = OpLoad %ulong %221
-%455 = OpLoad %ulong %226
-%456 = OpFunctionCall %ulong %5 %454 %455
-OpStore %227 %456
-%457 = OpLoad %v2ulong %168
-%458 = OpCompositeExtract %ulong %457 1
-OpStore %228 %458
-%459 = OpLoad %ulong %227
-%460 = OpLoad %ulong %228
-%461 = OpFunctionCall %ulong %5 %459 %460
-OpStore %229 %461
-OpBranch %88
-%88 = OpLabel
-%462 = OpLoad %ulong %173
-%464 = OpIAdd %ulong %462 %ulong_1
-OpStore %169 %464
-%465 = OpLoad %ulong %229
-OpStore %170 %465
-%466 = OpLoad %ulong %169
-OpStore %173 %466
-OpBranch %89
-%56 = OpLabel
-%467 = OpLoad %ulong %172
-%468 = OpAccessChain %_ptr_Function_v2ulong %96 %467
-%469 = OpLoad %v2ulong %468
-OpStore %119 %469
-%470 = OpLoad %ulong %172
-%471 = OpAccessChain %_ptr_Function_v2ulong %97 %470
-%472 = OpLoad %v2ulong %471
-OpStore %120 %472
-%473 = OpLoad %v2ulong %119
-%474 = OpCompositeExtract %ulong %473 0
-OpStore %121 %474
-%475 = OpLoad %ulong %121
-%476 = OpLoad %ulong %103
-%477 = OpIAdd %ulong %475 %476
-OpStore %122 %477
-%478 = OpLoad %v2ulong %119
-%479 = OpLoad %ulong %122
-%480 = OpCompositeInsert %v2ulong %479 %478 0
-OpStore %123 %480
-%481 = OpLoad %v2ulong %120
-%482 = OpCompositeExtract %ulong %481 1
-OpStore %124 %482
-%483 = OpLoad %ulong %124
-%484 = OpLoad %ulong %103
-%485 = OpIAdd %ulong %483 %484
-OpStore %125 %485
-%486 = OpLoad %v2ulong %120
-%487 = OpLoad %ulong %125
-%488 = OpCompositeInsert %v2ulong %487 %486 1
-OpStore %126 %488
-%489 = OpLoad %v2ulong %123
-%490 = OpLoad %v2ulong %126
-%491 = OpSLessThan %v2bool %489 %490
-%492 = OpSelect %v2ulong %491 %354 %355
-OpStore %127 %492
-OpBranch %61
-%61 = OpLabel
-%493 = OpLoad %v2ulong %127
-%494 = OpCompositeExtract %ulong %493 0
-OpStore %174 %494
-%495 = OpLoad %ulong %171
-%496 = OpLoad %ulong %174
-%497 = OpFunctionCall %ulong %5 %495 %496
-OpStore %175 %497
-%498 = OpLoad %v2ulong %127
-%499 = OpCompositeExtract %ulong %498 1
-OpStore %176 %499
-%500 = OpLoad %ulong %175
-%501 = OpLoad %ulong %176
-%502 = OpFunctionCall %ulong %5 %500 %501
-OpStore %177 %502
-OpBranch %62
-%62 = OpLabel
-%503 = OpLoad %v2ulong %123
-%504 = OpLoad %v2ulong %126
-%505 = OpSLessThanEqual %v2bool %503 %504
-%506 = OpSelect %v2ulong %505 %354 %355
-OpStore %128 %506
-OpBranch %65
-%65 = OpLabel
-%507 = OpLoad %v2ulong %128
-%508 = OpCompositeExtract %ulong %507 0
-OpStore %182 %508
-%509 = OpLoad %ulong %177
-%510 = OpLoad %ulong %182
-%511 = OpFunctionCall %ulong %5 %509 %510
-OpStore %183 %511
-%512 = OpLoad %v2ulong %128
-%513 = OpCompositeExtract %ulong %512 1
-OpStore %184 %513
-%514 = OpLoad %ulong %183
-%515 = OpLoad %ulong %184
-%516 = OpFunctionCall %ulong %5 %514 %515
-OpStore %185 %516
-OpBranch %66
-%66 = OpLabel
-%517 = OpLoad %v2ulong %126
-%518 = OpLoad %v2ulong %123
-%519 = OpSLessThan %v2bool %517 %518
-%520 = OpSelect %v2ulong %519 %354 %355
-OpStore %129 %520
-OpBranch %69
-%69 = OpLabel
-%521 = OpLoad %v2ulong %129
-%522 = OpCompositeExtract %ulong %521 0
-OpStore %190 %522
-%523 = OpLoad %ulong %185
-%524 = OpLoad %ulong %190
-%525 = OpFunctionCall %ulong %5 %523 %524
-OpStore %191 %525
-%526 = OpLoad %v2ulong %129
-%527 = OpCompositeExtract %ulong %526 1
-OpStore %192 %527
-%528 = OpLoad %ulong %191
-%529 = OpLoad %ulong %192
-%530 = OpFunctionCall %ulong %5 %528 %529
-OpStore %193 %530
-OpBranch %70
-%70 = OpLabel
-%531 = OpLoad %v2ulong %126
-%532 = OpLoad %v2ulong %123
-%533 = OpSLessThanEqual %v2bool %531 %532
-%534 = OpSelect %v2ulong %533 %354 %355
-OpStore %130 %534
-OpBranch %73
-%73 = OpLabel
-%535 = OpLoad %v2ulong %130
-%536 = OpCompositeExtract %ulong %535 0
-OpStore %198 %536
-%537 = OpLoad %ulong %193
-%538 = OpLoad %ulong %198
-%539 = OpFunctionCall %ulong %5 %537 %538
-OpStore %199 %539
-%540 = OpLoad %v2ulong %130
-%541 = OpCompositeExtract %ulong %540 1
-OpStore %200 %541
-%542 = OpLoad %ulong %199
-%543 = OpLoad %ulong %200
-%544 = OpFunctionCall %ulong %5 %542 %543
-OpStore %201 %544
-OpBranch %74
-%74 = OpLabel
-%545 = OpLoad %v2ulong %123
-%546 = OpLoad %v2ulong %126
-%547 = OpIEqual %v2bool %545 %546
-%548 = OpSelect %v2ulong %547 %354 %355
-OpStore %131 %548
-OpBranch %77
-%77 = OpLabel
-%549 = OpLoad %v2ulong %131
-%550 = OpCompositeExtract %ulong %549 0
-OpStore %206 %550
-%551 = OpLoad %ulong %201
-%552 = OpLoad %ulong %206
-%553 = OpFunctionCall %ulong %5 %551 %552
-OpStore %207 %553
-%554 = OpLoad %v2ulong %131
-%555 = OpCompositeExtract %ulong %554 1
-OpStore %208 %555
-%556 = OpLoad %ulong %207
-%557 = OpLoad %ulong %208
-%558 = OpFunctionCall %ulong %5 %556 %557
-OpStore %209 %558
-OpBranch %78
-%78 = OpLabel
-%559 = OpLoad %v2ulong %123
-%560 = OpLoad %v2ulong %126
-%561 = OpINotEqual %v2bool %559 %560
-%562 = OpSelect %v2ulong %561 %354 %355
-OpStore %132 %562
-OpBranch %81
-%81 = OpLabel
-%563 = OpLoad %v2ulong %132
-%564 = OpCompositeExtract %ulong %563 0
-OpStore %214 %564
-%565 = OpLoad %ulong %209
-%566 = OpLoad %ulong %214
-%567 = OpFunctionCall %ulong %5 %565 %566
-OpStore %215 %567
-%568 = OpLoad %v2ulong %132
-%569 = OpCompositeExtract %ulong %568 1
-OpStore %216 %569
-%570 = OpLoad %ulong %215
-%571 = OpLoad %ulong %216
-%572 = OpFunctionCall %ulong %5 %570 %571
-OpStore %217 %572
-OpBranch %82
-%82 = OpLabel
-%573 = OpLoad %v2ulong %123
-%574 = OpLoad %v2ulong %126
-%575 = OpSLessThan %v2bool %573 %574
-%576 = OpSelect %v2ulong %575 %354 %355
-OpStore %133 %576
-%577 = OpLoad %v2ulong %133
-%578 = OpLoad %v2ulong %123
-%579 = OpBitwiseAnd %v2ulong %577 %578
-OpStore %134 %579
-%580 = OpLoad %v2ulong %133
-%581 = OpNot %v2ulong %580
-OpStore %135 %581
-%582 = OpLoad %v2ulong %135
-%583 = OpLoad %v2ulong %126
-%584 = OpBitwiseAnd %v2ulong %582 %583
-OpStore %136 %584
-%585 = OpLoad %v2ulong %134
-%586 = OpLoad %v2ulong %136
-%587 = OpBitwiseOr %v2ulong %585 %586
-OpStore %137 %587
-OpBranch %85
-%85 = OpLabel
-%588 = OpLoad %v2ulong %137
-%589 = OpCompositeExtract %ulong %588 0
-OpStore %222 %589
-%590 = OpLoad %ulong %217
-%591 = OpLoad %ulong %222
-%592 = OpFunctionCall %ulong %6 %590 %591
-OpStore %223 %592
-%593 = OpLoad %v2ulong %137
-%594 = OpCompositeExtract %ulong %593 1
-OpStore %224 %594
-%595 = OpLoad %ulong %223
-%596 = OpLoad %ulong %224
-%597 = OpFunctionCall %ulong %6 %595 %596
-OpStore %225 %597
-OpBranch %86
-%86 = OpLabel
-%598 = OpLoad %ulong %172
-%599 = OpIAdd %ulong %598 %ulong_1
-OpStore %138 %599
-%600 = OpLoad %ulong %225
-OpStore %171 %600
-%601 = OpLoad %ulong %138
-OpStore %172 %601
-OpBranch %90
-%89 = OpLabel
-OpBranch %58
-%90 = OpLabel
-OpBranch %55
-OpFunctionEnd
-%4 = OpFunction %ulong None %602
-%603 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%5 = OpFunction %ulong None %605
-%606 = OpFunctionParameter %ulong
-%607 = OpFunctionParameter %ulong
-%608 = OpLabel
-%613 = OpVariable %_ptr_Function_ulong Function
-%614 = OpVariable %_ptr_Function_ulong Function
-%615 = OpVariable %_ptr_Function_bool Function
-%616 = OpVariable %_ptr_Function_ulong Function
-%617 = OpVariable %_ptr_Function_ulong Function
-%618 = OpVariable %_ptr_Function_ulong Function
-%619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_ulong Function
-%621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_ulong Function
-%623 = OpVariable %_ptr_Function_ulong Function
-OpStore %613 %606
-OpStore %614 %607
-%624 = OpLoad %ulong %613
-OpStore %622 %624
-OpStore %623 %ulong_0
-OpBranch %609
-%609 = OpLabel
-%625 = OpLoad %ulong %623
-%627 = OpULessThan %bool %625 %ulong_8
-OpStore %615 %627
-%628 = OpLoad %bool %615
-OpLoopMerge %611 %612 None
-OpBranchConditional %628 %610 %611
-%611 = OpLabel
-%629 = OpLoad %ulong %622
-OpReturnValue %629
-%610 = OpLabel
-%630 = OpLoad %ulong %623
-%631 = OpIMul %ulong %630 %ulong_8
-OpStore %616 %631
-%632 = OpLoad %ulong %614
-%633 = OpLoad %ulong %616
-%634 = OpShiftRightLogical %ulong %632 %633
-OpStore %617 %634
-%635 = OpLoad %ulong %617
-%637 = OpBitwiseAnd %ulong %635 %ulong_255
-OpStore %618 %637
-%638 = OpLoad %ulong %622
-%639 = OpLoad %ulong %618
-%640 = OpBitwiseXor %ulong %638 %639
-OpStore %619 %640
-%641 = OpLoad %ulong %619
-%643 = OpIMul %ulong %641 %ulong_1099511628211
-OpStore %620 %643
-%644 = OpLoad %ulong %623
-%645 = OpIAdd %ulong %644 %ulong_1
-OpStore %621 %645
-%646 = OpLoad %ulong %620
-OpStore %622 %646
-%647 = OpLoad %ulong %621
-OpStore %623 %647
-OpBranch %612
-%612 = OpLabel
-OpBranch %609
-OpFunctionEnd
-%6 = OpFunction %ulong None %605
-%648 = OpFunctionParameter %ulong
-%649 = OpFunctionParameter %ulong
-%650 = OpLabel
-%657 = OpVariable %_ptr_Function_ulong Function
-%658 = OpVariable %_ptr_Function_ulong Function
-%659 = OpVariable %_ptr_Function_bool Function
-%660 = OpVariable %_ptr_Function_ulong Function
-%661 = OpVariable %_ptr_Function_ulong Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_ulong Function
-OpStore %657 %648
-OpStore %658 %649
-OpBranch %651
-%651 = OpLabel
-%668 = OpLoad %ulong %657
-OpStore %666 %668
-OpStore %667 %ulong_0
-OpBranch %652
-%652 = OpLabel
-%669 = OpLoad %ulong %667
-%670 = OpULessThan %bool %669 %ulong_8
-OpStore %659 %670
-%671 = OpLoad %bool %659
-OpLoopMerge %654 %656 None
-OpBranchConditional %671 %653 %654
-%654 = OpLabel
-OpBranch %655
-%655 = OpLabel
-%672 = OpLoad %ulong %666
-OpReturnValue %672
-%653 = OpLabel
-%673 = OpLoad %ulong %667
-%674 = OpIMul %ulong %673 %ulong_8
-OpStore %660 %674
-%675 = OpLoad %ulong %658
-%676 = OpLoad %ulong %660
-%677 = OpShiftRightLogical %ulong %675 %676
-OpStore %661 %677
-%678 = OpLoad %ulong %661
-%679 = OpBitwiseAnd %ulong %678 %ulong_255
-OpStore %662 %679
-%680 = OpLoad %ulong %666
-%681 = OpLoad %ulong %662
-%682 = OpBitwiseXor %ulong %680 %681
-OpStore %663 %682
-%683 = OpLoad %ulong %663
-%684 = OpIMul %ulong %683 %ulong_1099511628211
-OpStore %664 %684
-%685 = OpLoad %ulong %667
-%686 = OpIAdd %ulong %685 %ulong_1
-OpStore %665 %686
-%687 = OpLoad %ulong %664
-OpStore %666 %687
-%688 = OpLoad %ulong %665
-OpStore %667 %688
-OpBranch %656
-%656 = OpLabel
-OpBranch %652
+%227 = OpVariable %_ptr_Function_v2ulong Function
+%228 = OpVariable %_ptr_Function_v2ulong Function
+%229 = OpVariable %_ptr_Function_v2ulong Function
+%230 = OpVariable %_ptr_Function_v2ulong Function
+%231 = OpVariable %_ptr_Function_v2ulong Function
+%232 = OpVariable %_ptr_Function_v2ulong Function
+%233 = OpVariable %_ptr_Function_v2ulong Function
+%234 = OpVariable %_ptr_Function_v2ulong Function
+%235 = OpVariable %_ptr_Function_v2ulong Function
+%236 = OpVariable %_ptr_Function_v2ulong Function
+%237 = OpVariable %_ptr_Function_v2ulong Function
+%238 = OpVariable %_ptr_Function_v2ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_v2ulong Function
+%241 = OpVariable %_ptr_Function_v2ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_v2ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_v2ulong Function
+%248 = OpVariable %_ptr_Function_v2ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_v2ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_v2ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_v2ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_v2ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_v2ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_v2ulong Function
+%261 = OpVariable %_ptr_Function_v2ulong Function
+%262 = OpVariable %_ptr_Function_v2ulong Function
+%263 = OpVariable %_ptr_Function_v2ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_v2ulong Function
+%266 = OpVariable %_ptr_Function_v2ulong Function
+%267 = OpVariable %_ptr_Function_v2ulong Function
+%268 = OpVariable %_ptr_Function_v2ulong Function
+%269 = OpVariable %_ptr_Function_v2ulong Function
+%270 = OpVariable %_ptr_Function_v2ulong Function
+%271 = OpVariable %_ptr_Function_v2ulong Function
+%272 = OpVariable %_ptr_Function_v2ulong Function
+%273 = OpVariable %_ptr_Function_v2ulong Function
+%274 = OpVariable %_ptr_Function_v2ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_v2ulong Function
+%277 = OpVariable %_ptr_Function_v2ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_v2ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_v2ulong Function
+%284 = OpVariable %_ptr_Function_v2ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_v2ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_v2ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_v2ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_v2ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_v2ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_v2ulong Function
+%297 = OpVariable %_ptr_Function_v2ulong Function
+%298 = OpVariable %_ptr_Function_v2ulong Function
+%299 = OpVariable %_ptr_Function_v2ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_bool Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_bool Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+OpStore %226 %185
+OpBranch %193
+%193 = OpLabel
+OpBranch %194
+%194 = OpLabel
+OpStore %224 %326
+OpStore %225 %326
+%327 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
+OpStore %227 %327
+%331 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_0
+%332 = OpLoad %v2ulong %227
+OpStore %331 %332
+%333 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
+OpStore %228 %333
+%334 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_0
+%335 = OpLoad %v2ulong %228
+OpStore %334 %335
+%336 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_18446744069414584320
+OpStore %229 %336
+%340 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_1
+%341 = OpLoad %v2ulong %229
+OpStore %340 %341
+%342 = OpCompositeConstruct %v2ulong %ulong_18446744069414584320 %ulong_18446744073709551615
+OpStore %230 %342
+%343 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_1
+%344 = OpLoad %v2ulong %230
+OpStore %343 %344
+%345 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
+OpStore %231 %345
+%349 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_2
+%350 = OpLoad %v2ulong %231
+OpStore %349 %350
+%351 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
+OpStore %232 %351
+%352 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_2
+%353 = OpLoad %v2ulong %232
+OpStore %352 %353
+%354 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_1311768467463790320
+OpStore %233 %354
+%357 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_3
+%358 = OpLoad %v2ulong %233
+OpStore %357 %358
+%359 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_1311768467463790320
+OpStore %234 %359
+%360 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_3
+%361 = OpLoad %v2ulong %234
+OpStore %360 %361
+%362 = OpCompositeConstruct %v2ulong %ulong_8589934592 %ulong_0
+OpStore %235 %362
+%365 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_4
+%366 = OpLoad %v2ulong %235
+OpStore %365 %366
+%367 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_18446744073709551615
+OpStore %236 %367
+%368 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_4
+%369 = OpLoad %v2ulong %236
+OpStore %368 %369
+%370 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
+OpStore %237 %370
+%372 = OpAccessChain %_ptr_Function_v2ulong %224 %uint_5
+%373 = OpLoad %v2ulong %237
+OpStore %372 %373
+%374 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
+OpStore %238 %374
+%376 = OpAccessChain %_ptr_Function_v2ulong %225 %uint_5
+%377 = OpLoad %v2ulong %238
+OpStore %376 %377
+OpStore %303 %ulong_14695981039346656037
+OpStore %304 %ulong_0
+OpBranch %187
+%187 = OpLabel
+%379 = OpLoad %ulong %304
+%381 = OpULessThan %bool %379 %ulong_6
+OpStore %239 %381
+%382 = OpLoad %bool %239
+OpLoopMerge %189 %214 None
+OpBranchConditional %382 %188 %189
+%189 = OpLabel
+OpStore %219 %383
+OpStore %220 %383
+%384 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
+OpStore %265 %384
+%385 = OpAccessChain %_ptr_Function_v2ulong %219 %uint_0
+%386 = OpLoad %v2ulong %265
+OpStore %385 %386
+%387 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
+OpStore %266 %387
+%388 = OpAccessChain %_ptr_Function_v2ulong %220 %uint_0
+%389 = OpLoad %v2ulong %266
+OpStore %388 %389
+%390 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
+OpStore %267 %390
+%391 = OpAccessChain %_ptr_Function_v2ulong %219 %uint_1
+%392 = OpLoad %v2ulong %267
+OpStore %391 %392
+%393 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
+OpStore %268 %393
+%394 = OpAccessChain %_ptr_Function_v2ulong %220 %uint_1
+%395 = OpLoad %v2ulong %268
+OpStore %394 %395
+%396 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_0
+OpStore %269 %396
+%397 = OpAccessChain %_ptr_Function_v2ulong %219 %uint_2
+%398 = OpLoad %v2ulong %269
+OpStore %397 %398
+%399 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_18446744073709551615
+OpStore %270 %399
+%400 = OpAccessChain %_ptr_Function_v2ulong %220 %uint_2
+%401 = OpLoad %v2ulong %270
+OpStore %400 %401
+%402 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584320
+OpStore %271 %402
+%404 = OpAccessChain %_ptr_Function_v2ulong %219 %uint_3
+%405 = OpLoad %v2ulong %271
+OpStore %404 %405
+%406 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584319
+OpStore %272 %406
+%408 = OpAccessChain %_ptr_Function_v2ulong %220 %uint_3
+%409 = OpLoad %v2ulong %272
+OpStore %408 %409
+%410 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
+OpStore %273 %410
+%411 = OpAccessChain %_ptr_Function_v2ulong %219 %uint_4
+%412 = OpLoad %v2ulong %273
+OpStore %411 %412
+%413 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
+OpStore %274 %413
+%414 = OpAccessChain %_ptr_Function_v2ulong %220 %uint_4
+%415 = OpLoad %v2ulong %274
+OpStore %414 %415
+%416 = OpLoad %ulong %303
+OpStore %302 %416
+OpStore %305 %ulong_0
+OpBranch %190
+%190 = OpLabel
+%417 = OpLoad %ulong %305
+%419 = OpULessThan %bool %417 %ulong_5
+OpStore %275 %419
+%420 = OpLoad %bool %275
+OpLoopMerge %192 %213 None
+OpBranchConditional %420 %191 %192
+%192 = OpLabel
+%421 = OpLoad %ulong %302
+OpReturnValue %421
+%191 = OpLabel
+%422 = OpLoad %ulong %305
+%423 = OpAccessChain %_ptr_Function_v2ulong %219 %422
+%424 = OpLoad %v2ulong %423
+OpStore %276 %424
+%425 = OpLoad %ulong %305
+%426 = OpAccessChain %_ptr_Function_v2ulong %220 %425
+%427 = OpLoad %v2ulong %426
+OpStore %277 %427
+%428 = OpLoad %v2ulong %276
+%429 = OpCompositeExtract %ulong %428 0
+OpStore %278 %429
+%430 = OpLoad %ulong %278
+%431 = OpLoad %ulong %226
+%432 = OpIAdd %ulong %430 %431
+OpStore %279 %432
+%433 = OpLoad %v2ulong %276
+%434 = OpLoad %ulong %279
+%435 = OpCompositeInsert %v2ulong %434 %433 0
+OpStore %280 %435
+%436 = OpLoad %v2ulong %277
+%437 = OpCompositeExtract %ulong %436 1
+OpStore %281 %437
+%438 = OpLoad %ulong %281
+%439 = OpLoad %ulong %226
+%440 = OpIAdd %ulong %438 %439
+OpStore %282 %440
+%441 = OpLoad %v2ulong %277
+%442 = OpLoad %ulong %282
+%443 = OpCompositeInsert %v2ulong %442 %441 1
+OpStore %283 %443
+%445 = OpLoad %v2ulong %280
+%446 = OpLoad %v2ulong %283
+%447 = OpULessThan %v2bool %445 %446
+%450 = OpSelect %v2ulong %447 %448 %449
+OpStore %284 %450
+%451 = OpLoad %ulong %302
+%452 = OpLoad %v2ulong %284
+%453 = OpFunctionCall %ulong %1 %451 %452
+OpStore %285 %453
+%454 = OpLoad %v2ulong %280
+%455 = OpLoad %v2ulong %283
+%456 = OpULessThanEqual %v2bool %454 %455
+%457 = OpSelect %v2ulong %456 %448 %449
+OpStore %286 %457
+%458 = OpLoad %ulong %285
+%459 = OpLoad %v2ulong %286
+%460 = OpFunctionCall %ulong %1 %458 %459
+OpStore %287 %460
+%461 = OpLoad %v2ulong %283
+%462 = OpLoad %v2ulong %280
+%463 = OpULessThan %v2bool %461 %462
+%464 = OpSelect %v2ulong %463 %448 %449
+OpStore %288 %464
+%465 = OpLoad %ulong %287
+%466 = OpLoad %v2ulong %288
+%467 = OpFunctionCall %ulong %1 %465 %466
+OpStore %289 %467
+%468 = OpLoad %v2ulong %283
+%469 = OpLoad %v2ulong %280
+%470 = OpULessThanEqual %v2bool %468 %469
+%471 = OpSelect %v2ulong %470 %448 %449
+OpStore %290 %471
+%472 = OpLoad %ulong %289
+%473 = OpLoad %v2ulong %290
+%474 = OpFunctionCall %ulong %1 %472 %473
+OpStore %291 %474
+%475 = OpLoad %v2ulong %280
+%476 = OpLoad %v2ulong %283
+%477 = OpIEqual %v2bool %475 %476
+%478 = OpSelect %v2ulong %477 %448 %449
+OpStore %292 %478
+%479 = OpLoad %ulong %291
+%480 = OpLoad %v2ulong %292
+%481 = OpFunctionCall %ulong %1 %479 %480
+OpStore %293 %481
+%482 = OpLoad %v2ulong %280
+%483 = OpLoad %v2ulong %283
+%484 = OpINotEqual %v2bool %482 %483
+%485 = OpSelect %v2ulong %484 %448 %449
+OpStore %294 %485
+%486 = OpLoad %ulong %293
+%487 = OpLoad %v2ulong %294
+%488 = OpFunctionCall %ulong %1 %486 %487
+OpStore %295 %488
+%489 = OpLoad %v2ulong %284
+%490 = OpLoad %v2ulong %280
+%491 = OpBitwiseAnd %v2ulong %489 %490
+OpStore %296 %491
+%492 = OpLoad %v2ulong %284
+%493 = OpNot %v2ulong %492
+OpStore %297 %493
+%494 = OpLoad %v2ulong %297
+%495 = OpLoad %v2ulong %283
+%496 = OpBitwiseAnd %v2ulong %494 %495
+OpStore %298 %496
+%497 = OpLoad %v2ulong %296
+%498 = OpLoad %v2ulong %298
+%499 = OpBitwiseOr %v2ulong %497 %498
+OpStore %299 %499
+%500 = OpLoad %ulong %295
+%501 = OpLoad %v2ulong %299
+%502 = OpFunctionCall %ulong %1 %500 %501
+OpStore %300 %502
+%503 = OpLoad %ulong %305
+%504 = OpIAdd %ulong %503 %ulong_1
+OpStore %301 %504
+%505 = OpLoad %ulong %300
+OpStore %302 %505
+%506 = OpLoad %ulong %301
+OpStore %305 %506
+OpBranch %213
+%188 = OpLabel
+%507 = OpLoad %ulong %304
+%508 = OpAccessChain %_ptr_Function_v2ulong %224 %507
+%509 = OpLoad %v2ulong %508
+OpStore %240 %509
+%510 = OpLoad %ulong %304
+%511 = OpAccessChain %_ptr_Function_v2ulong %225 %510
+%512 = OpLoad %v2ulong %511
+OpStore %241 %512
+%513 = OpLoad %v2ulong %240
+%514 = OpCompositeExtract %ulong %513 0
+OpStore %242 %514
+%515 = OpLoad %ulong %242
+%516 = OpLoad %ulong %226
+%517 = OpIAdd %ulong %515 %516
+OpStore %243 %517
+%518 = OpLoad %v2ulong %240
+%519 = OpLoad %ulong %243
+%520 = OpCompositeInsert %v2ulong %519 %518 0
+OpStore %244 %520
+%521 = OpLoad %v2ulong %241
+%522 = OpCompositeExtract %ulong %521 1
+OpStore %245 %522
+%523 = OpLoad %ulong %245
+%524 = OpLoad %ulong %226
+%525 = OpIAdd %ulong %523 %524
+OpStore %246 %525
+%526 = OpLoad %v2ulong %241
+%527 = OpLoad %ulong %246
+%528 = OpCompositeInsert %v2ulong %527 %526 1
+OpStore %247 %528
+%529 = OpLoad %v2ulong %244
+%530 = OpLoad %v2ulong %247
+%531 = OpSLessThan %v2bool %529 %530
+%532 = OpSelect %v2ulong %531 %448 %449
+OpStore %248 %532
+%533 = OpLoad %ulong %303
+%534 = OpLoad %v2ulong %248
+%535 = OpFunctionCall %ulong %1 %533 %534
+OpStore %249 %535
+%536 = OpLoad %v2ulong %244
+%537 = OpLoad %v2ulong %247
+%538 = OpSLessThanEqual %v2bool %536 %537
+%539 = OpSelect %v2ulong %538 %448 %449
+OpStore %250 %539
+%540 = OpLoad %ulong %249
+%541 = OpLoad %v2ulong %250
+%542 = OpFunctionCall %ulong %1 %540 %541
+OpStore %251 %542
+%543 = OpLoad %v2ulong %247
+%544 = OpLoad %v2ulong %244
+%545 = OpSLessThan %v2bool %543 %544
+%546 = OpSelect %v2ulong %545 %448 %449
+OpStore %252 %546
+%547 = OpLoad %ulong %251
+%548 = OpLoad %v2ulong %252
+%549 = OpFunctionCall %ulong %1 %547 %548
+OpStore %253 %549
+%550 = OpLoad %v2ulong %247
+%551 = OpLoad %v2ulong %244
+%552 = OpSLessThanEqual %v2bool %550 %551
+%553 = OpSelect %v2ulong %552 %448 %449
+OpStore %254 %553
+%554 = OpLoad %ulong %253
+%555 = OpLoad %v2ulong %254
+%556 = OpFunctionCall %ulong %1 %554 %555
+OpStore %255 %556
+%557 = OpLoad %v2ulong %244
+%558 = OpLoad %v2ulong %247
+%559 = OpIEqual %v2bool %557 %558
+%560 = OpSelect %v2ulong %559 %448 %449
+OpStore %256 %560
+%561 = OpLoad %ulong %255
+%562 = OpLoad %v2ulong %256
+%563 = OpFunctionCall %ulong %1 %561 %562
+OpStore %257 %563
+%564 = OpLoad %v2ulong %244
+%565 = OpLoad %v2ulong %247
+%566 = OpINotEqual %v2bool %564 %565
+%567 = OpSelect %v2ulong %566 %448 %449
+OpStore %258 %567
+%568 = OpLoad %ulong %257
+%569 = OpLoad %v2ulong %258
+%570 = OpFunctionCall %ulong %1 %568 %569
+OpStore %259 %570
+%571 = OpLoad %v2ulong %248
+%572 = OpLoad %v2ulong %244
+%573 = OpBitwiseAnd %v2ulong %571 %572
+OpStore %260 %573
+%574 = OpLoad %v2ulong %248
+%575 = OpNot %v2ulong %574
+OpStore %261 %575
+%576 = OpLoad %v2ulong %261
+%577 = OpLoad %v2ulong %247
+%578 = OpBitwiseAnd %v2ulong %576 %577
+OpStore %262 %578
+%579 = OpLoad %v2ulong %260
+%580 = OpLoad %v2ulong %262
+%581 = OpBitwiseOr %v2ulong %579 %580
+OpStore %263 %581
+OpBranch %195
+%195 = OpLabel
+%582 = OpLoad %v2ulong %263
+%583 = OpCompositeExtract %ulong %582 0
+OpStore %306 %583
+OpBranch %196
+%196 = OpLabel
+OpBranch %198
+%198 = OpLabel
+%584 = OpLoad %ulong %259
+OpStore %315 %584
+OpStore %316 %ulong_0
+OpBranch %199
+%199 = OpLabel
+%585 = OpLoad %ulong %316
+%586 = OpULessThan %bool %585 %ulong_8
+OpStore %308 %586
+%587 = OpLoad %bool %308
+OpLoopMerge %201 %212 None
+OpBranchConditional %587 %200 %201
+%201 = OpLabel
+OpBranch %202
+%202 = OpLabel
+OpBranch %197
+%197 = OpLabel
+%588 = OpLoad %v2ulong %263
+%589 = OpCompositeExtract %ulong %588 1
+OpStore %307 %589
+OpBranch %203
+%203 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%590 = OpLoad %ulong %315
+OpStore %324 %590
+OpStore %325 %ulong_0
+OpBranch %206
+%206 = OpLabel
+%591 = OpLoad %ulong %325
+%592 = OpULessThan %bool %591 %ulong_8
+OpStore %317 %592
+%593 = OpLoad %bool %317
+OpLoopMerge %208 %211 None
+OpBranchConditional %593 %207 %208
+%208 = OpLabel
+OpBranch %209
+%209 = OpLabel
+OpBranch %204
+%204 = OpLabel
+OpBranch %210
+%210 = OpLabel
+%594 = OpLoad %ulong %304
+%595 = OpIAdd %ulong %594 %ulong_1
+OpStore %264 %595
+%596 = OpLoad %ulong %324
+OpStore %303 %596
+%597 = OpLoad %ulong %264
+OpStore %304 %597
+OpBranch %214
+%207 = OpLabel
+%598 = OpLoad %ulong %325
+%599 = OpIMul %ulong %598 %ulong_8
+OpStore %318 %599
+%600 = OpLoad %ulong %307
+%601 = OpLoad %ulong %318
+%602 = OpShiftRightLogical %ulong %600 %601
+OpStore %319 %602
+%603 = OpLoad %ulong %319
+%604 = OpBitwiseAnd %ulong %603 %ulong_255
+OpStore %320 %604
+%605 = OpLoad %ulong %324
+%606 = OpLoad %ulong %320
+%607 = OpBitwiseXor %ulong %605 %606
+OpStore %321 %607
+%608 = OpLoad %ulong %321
+%609 = OpIMul %ulong %608 %ulong_1099511628211
+OpStore %322 %609
+%610 = OpLoad %ulong %325
+%611 = OpIAdd %ulong %610 %ulong_1
+OpStore %323 %611
+%612 = OpLoad %ulong %322
+OpStore %324 %612
+%613 = OpLoad %ulong %323
+OpStore %325 %613
+OpBranch %211
+%200 = OpLabel
+%614 = OpLoad %ulong %316
+%615 = OpIMul %ulong %614 %ulong_8
+OpStore %309 %615
+%616 = OpLoad %ulong %306
+%617 = OpLoad %ulong %309
+%618 = OpShiftRightLogical %ulong %616 %617
+OpStore %310 %618
+%619 = OpLoad %ulong %310
+%620 = OpBitwiseAnd %ulong %619 %ulong_255
+OpStore %311 %620
+%621 = OpLoad %ulong %315
+%622 = OpLoad %ulong %311
+%623 = OpBitwiseXor %ulong %621 %622
+OpStore %312 %623
+%624 = OpLoad %ulong %312
+%625 = OpIMul %ulong %624 %ulong_1099511628211
+OpStore %313 %625
+%626 = OpLoad %ulong %316
+%627 = OpIAdd %ulong %626 %ulong_1
+OpStore %314 %627
+%628 = OpLoad %ulong %313
+OpStore %315 %628
+%629 = OpLoad %ulong %314
+OpStore %316 %629
+OpBranch %212
+%211 = OpLabel
+OpBranch %206
+%212 = OpLabel
+OpBranch %199
+%213 = OpLabel
+OpBranch %190
+%214 = OpLabel
+OpBranch %187
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_cmp_select.dis
+++ b/test/golden/spirv/vec/vec_cmp_select.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 4500
+; Bound: 4805
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -21,44 +21,50 @@ OpDecorate %6 LinkageAttributes "corpus.cases.vec.vec_cmp_select.checksum" Expor
 %uint = OpTypeInt 32 0
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
-%18 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%13 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
 %_ptr_Function_uchar = OpTypePointer Function %uchar
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %ushort = OpTypeInt 16 0
 %uint_8 = OpConstant %uint 8
 %_arr_ushort_uint_8 = OpTypeArray %ushort %uint_8
-%143 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
+%721 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
 %_ptr_Function__arr_ushort_uint_8 = OpTypePointer Function %_arr_ushort_uint_8
 %_ptr_Function_ushort = OpTypePointer Function %ushort
 %v4uint = OpTypeVector %uint 4
-%209 = OpTypeFunction %ulong %ulong %v4uint
+%827 = OpTypeFunction %ulong %ulong %v4uint
 %_ptr_Function_v4uint = OpTypePointer Function %v4uint
 %_ptr_Function_uint = OpTypePointer Function %uint
 %v2ulong = OpTypeVector %ulong 2
-%247 = OpTypeFunction %ulong %ulong %v2ulong
+%885 = OpTypeFunction %ulong %ulong %v2ulong
 %_ptr_Function_v2ulong = OpTypePointer Function %v2ulong
 %float = OpTypeFloat 32
 %v4float = OpTypeVector %float 4
-%271 = OpTypeFunction %ulong %ulong %v4float
+%909 = OpTypeFunction %ulong %ulong %v4float
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_float = OpTypePointer Function %float
-%308 = OpTypeFunction %ulong %ulong
+%978 = OpTypeFunction %ulong %ulong
 %double = OpTypeFloat 64
 %v2double = OpTypeVector %double 2
-%bool = OpTypeBool
 %_ptr_Function_v2double = OpTypePointer Function %v2double
 %_ptr_Function_double = OpTypePointer Function %double
-%_ptr_Function_bool = OpTypePointer Function %bool
 %uint_10 = OpConstant %uint 10
 %uint_20 = OpConstant %uint 20
 %uint_30 = OpConstant %uint 30
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_1 = OpConstant %uint 1
 %v4bool = OpTypeVector %bool 4
-%1488 = OpConstantComposite %v4uint %uint_4294967295 %uint_4294967295 %uint_4294967295 %uint_4294967295
+%2194 = OpConstantComposite %v4uint %uint_4294967295 %uint_4294967295 %uint_4294967295 %uint_4294967295
 %uint_0 = OpConstant %uint 0
-%1490 = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+%2196 = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %uint_5 = OpConstant %uint 5
 %uint_2294967296 = OpConstant %uint 2294967296
 %uint_7 = OpConstant %uint 7
@@ -75,9 +81,8 @@ OpDecorate %6 LinkageAttributes "corpus.cases.vec.vec_cmp_select.checksum" Expor
 %double_0 = OpConstant %double 0
 %v2bool = OpTypeVector %bool 2
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%2134 = OpConstantComposite %v2ulong %ulong_18446744073709551615 %ulong_18446744073709551615
-%ulong_0 = OpConstant %ulong 0
-%2136 = OpConstantComposite %v2ulong %ulong_0 %ulong_0
+%2883 = OpConstantComposite %v2ulong %ulong_18446744073709551615 %ulong_18446744073709551615
+%2884 = OpConstantComposite %v2ulong %ulong_0 %ulong_0
 %ushort_1 = OpConstant %ushort 1
 %ushort_65535 = OpConstant %ushort 65535
 %ushort_32768 = OpConstant %ushort 32768
@@ -110,5748 +115,6364 @@ OpDecorate %6 LinkageAttributes "corpus.cases.vec.vec_cmp_select.checksum" Expor
 %uchar_18 = OpConstant %uchar 18
 %uchar_22 = OpConstant %uchar 22
 %uchar_30 = OpConstant %uchar 30
-%4270 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%4273 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%4317 = OpTypeFunction %ulong %ulong %uchar
-%4362 = OpTypeFunction %ulong %ulong %ushort
-%4407 = OpTypeFunction %ulong %ulong %uint
-%4452 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %18
-%19 = OpFunctionParameter %ulong
-%20 = OpFunctionParameter %_arr_uchar_uint_16
-%21 = OpLabel
-%23 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%27 = OpVariable %_ptr_Function_uchar Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uchar Function
-%30 = OpVariable %_ptr_Function_ulong Function
-%31 = OpVariable %_ptr_Function_uchar Function
-%32 = OpVariable %_ptr_Function_ulong Function
-%33 = OpVariable %_ptr_Function_uchar Function
-%34 = OpVariable %_ptr_Function_ulong Function
-%35 = OpVariable %_ptr_Function_uchar Function
-%36 = OpVariable %_ptr_Function_ulong Function
-%37 = OpVariable %_ptr_Function_uchar Function
-%38 = OpVariable %_ptr_Function_ulong Function
-%39 = OpVariable %_ptr_Function_uchar Function
-%40 = OpVariable %_ptr_Function_ulong Function
-%41 = OpVariable %_ptr_Function_uchar Function
-%42 = OpVariable %_ptr_Function_ulong Function
-%43 = OpVariable %_ptr_Function_uchar Function
-%44 = OpVariable %_ptr_Function_ulong Function
-%45 = OpVariable %_ptr_Function_uchar Function
-%46 = OpVariable %_ptr_Function_ulong Function
-%47 = OpVariable %_ptr_Function_uchar Function
-%48 = OpVariable %_ptr_Function_ulong Function
-%49 = OpVariable %_ptr_Function_uchar Function
-%50 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function_uchar Function
-%52 = OpVariable %_ptr_Function_ulong Function
-%53 = OpVariable %_ptr_Function_uchar Function
-%54 = OpVariable %_ptr_Function_ulong Function
-%55 = OpVariable %_ptr_Function_uchar Function
-%56 = OpVariable %_ptr_Function_ulong Function
-%57 = OpVariable %_ptr_Function_uchar Function
-%58 = OpVariable %_ptr_Function_ulong Function
-OpStore %23 %19
-OpStore %25 %20
-%59 = OpLoad %_arr_uchar_uint_16 %25
-%60 = OpCompositeExtract %uchar %59 0
-OpStore %27 %60
-%61 = OpLoad %ulong %23
-%62 = OpLoad %uchar %27
-%63 = OpFunctionCall %ulong %9 %61 %62
-OpStore %28 %63
-%64 = OpLoad %_arr_uchar_uint_16 %25
-%65 = OpCompositeExtract %uchar %64 1
-OpStore %29 %65
-%66 = OpLoad %ulong %28
-%67 = OpLoad %uchar %29
-%68 = OpFunctionCall %ulong %9 %66 %67
-OpStore %30 %68
-%69 = OpLoad %_arr_uchar_uint_16 %25
-%70 = OpCompositeExtract %uchar %69 2
-OpStore %31 %70
-%71 = OpLoad %ulong %30
-%72 = OpLoad %uchar %31
-%73 = OpFunctionCall %ulong %9 %71 %72
-OpStore %32 %73
-%74 = OpLoad %_arr_uchar_uint_16 %25
-%75 = OpCompositeExtract %uchar %74 3
-OpStore %33 %75
-%76 = OpLoad %ulong %32
-%77 = OpLoad %uchar %33
-%78 = OpFunctionCall %ulong %9 %76 %77
-OpStore %34 %78
-%79 = OpLoad %_arr_uchar_uint_16 %25
-%80 = OpCompositeExtract %uchar %79 4
-OpStore %35 %80
-%81 = OpLoad %ulong %34
-%82 = OpLoad %uchar %35
-%83 = OpFunctionCall %ulong %9 %81 %82
-OpStore %36 %83
-%84 = OpLoad %_arr_uchar_uint_16 %25
-%85 = OpCompositeExtract %uchar %84 5
-OpStore %37 %85
-%86 = OpLoad %ulong %36
-%87 = OpLoad %uchar %37
-%88 = OpFunctionCall %ulong %9 %86 %87
-OpStore %38 %88
-%89 = OpLoad %_arr_uchar_uint_16 %25
-%90 = OpCompositeExtract %uchar %89 6
-OpStore %39 %90
-%91 = OpLoad %ulong %38
-%92 = OpLoad %uchar %39
-%93 = OpFunctionCall %ulong %9 %91 %92
-OpStore %40 %93
-%94 = OpLoad %_arr_uchar_uint_16 %25
-%95 = OpCompositeExtract %uchar %94 7
-OpStore %41 %95
-%96 = OpLoad %ulong %40
-%97 = OpLoad %uchar %41
-%98 = OpFunctionCall %ulong %9 %96 %97
-OpStore %42 %98
-%99 = OpLoad %_arr_uchar_uint_16 %25
-%100 = OpCompositeExtract %uchar %99 8
-OpStore %43 %100
-%101 = OpLoad %ulong %42
-%102 = OpLoad %uchar %43
-%103 = OpFunctionCall %ulong %9 %101 %102
-OpStore %44 %103
-%104 = OpLoad %_arr_uchar_uint_16 %25
-%105 = OpCompositeExtract %uchar %104 9
-OpStore %45 %105
-%106 = OpLoad %ulong %44
-%107 = OpLoad %uchar %45
-%108 = OpFunctionCall %ulong %9 %106 %107
-OpStore %46 %108
-%109 = OpLoad %_arr_uchar_uint_16 %25
-%110 = OpCompositeExtract %uchar %109 10
-OpStore %47 %110
-%111 = OpLoad %ulong %46
-%112 = OpLoad %uchar %47
-%113 = OpFunctionCall %ulong %9 %111 %112
-OpStore %48 %113
-%114 = OpLoad %_arr_uchar_uint_16 %25
-%115 = OpCompositeExtract %uchar %114 11
-OpStore %49 %115
-%116 = OpLoad %ulong %48
-%117 = OpLoad %uchar %49
-%118 = OpFunctionCall %ulong %9 %116 %117
-OpStore %50 %118
-%119 = OpLoad %_arr_uchar_uint_16 %25
-%120 = OpCompositeExtract %uchar %119 12
-OpStore %51 %120
-%121 = OpLoad %ulong %50
-%122 = OpLoad %uchar %51
-%123 = OpFunctionCall %ulong %9 %121 %122
-OpStore %52 %123
-%124 = OpLoad %_arr_uchar_uint_16 %25
-%125 = OpCompositeExtract %uchar %124 13
-OpStore %53 %125
-%126 = OpLoad %ulong %52
-%127 = OpLoad %uchar %53
-%128 = OpFunctionCall %ulong %9 %126 %127
-OpStore %54 %128
-%129 = OpLoad %_arr_uchar_uint_16 %25
-%130 = OpCompositeExtract %uchar %129 14
-OpStore %55 %130
-%131 = OpLoad %ulong %54
-%132 = OpLoad %uchar %55
-%133 = OpFunctionCall %ulong %9 %131 %132
-OpStore %56 %133
-%134 = OpLoad %_arr_uchar_uint_16 %25
-%135 = OpCompositeExtract %uchar %134 15
-OpStore %57 %135
-%136 = OpLoad %ulong %56
-%137 = OpLoad %uchar %57
-%138 = OpFunctionCall %ulong %9 %136 %137
-OpStore %58 %138
-%139 = OpLoad %ulong %58
-OpReturnValue %139
-OpFunctionEnd
-%2 = OpFunction %ulong None %143
-%144 = OpFunctionParameter %ulong
-%145 = OpFunctionParameter %_arr_ushort_uint_8
-%146 = OpLabel
+%4765 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %13
+%14 = OpFunctionParameter %ulong
+%15 = OpFunctionParameter %_arr_uchar_uint_16
+%16 = OpLabel
 %147 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%151 = OpVariable %_ptr_Function_ushort Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ushort Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ushort Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ushort Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ushort Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ushort Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ushort Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ushort Function
-%166 = OpVariable %_ptr_Function_ulong Function
-OpStore %147 %144
-OpStore %149 %145
-%167 = OpLoad %_arr_ushort_uint_8 %149
-%168 = OpCompositeExtract %ushort %167 0
-OpStore %151 %168
-%169 = OpLoad %ulong %147
-%170 = OpLoad %ushort %151
-%171 = OpFunctionCall %ulong %10 %169 %170
-OpStore %152 %171
-%172 = OpLoad %_arr_ushort_uint_8 %149
-%173 = OpCompositeExtract %ushort %172 1
-OpStore %153 %173
-%174 = OpLoad %ulong %152
-%175 = OpLoad %ushort %153
-%176 = OpFunctionCall %ulong %10 %174 %175
-OpStore %154 %176
-%177 = OpLoad %_arr_ushort_uint_8 %149
-%178 = OpCompositeExtract %ushort %177 2
-OpStore %155 %178
-%179 = OpLoad %ulong %154
-%180 = OpLoad %ushort %155
-%181 = OpFunctionCall %ulong %10 %179 %180
-OpStore %156 %181
-%182 = OpLoad %_arr_ushort_uint_8 %149
-%183 = OpCompositeExtract %ushort %182 3
-OpStore %157 %183
-%184 = OpLoad %ulong %156
-%185 = OpLoad %ushort %157
-%186 = OpFunctionCall %ulong %10 %184 %185
-OpStore %158 %186
-%187 = OpLoad %_arr_ushort_uint_8 %149
-%188 = OpCompositeExtract %ushort %187 4
-OpStore %159 %188
-%189 = OpLoad %ulong %158
-%190 = OpLoad %ushort %159
-%191 = OpFunctionCall %ulong %10 %189 %190
-OpStore %160 %191
-%192 = OpLoad %_arr_ushort_uint_8 %149
-%193 = OpCompositeExtract %ushort %192 5
-OpStore %161 %193
-%194 = OpLoad %ulong %160
-%195 = OpLoad %ushort %161
-%196 = OpFunctionCall %ulong %10 %194 %195
-OpStore %162 %196
-%197 = OpLoad %_arr_ushort_uint_8 %149
-%198 = OpCompositeExtract %ushort %197 6
-OpStore %163 %198
-%199 = OpLoad %ulong %162
-%200 = OpLoad %ushort %163
-%201 = OpFunctionCall %ulong %10 %199 %200
-OpStore %164 %201
-%202 = OpLoad %_arr_ushort_uint_8 %149
-%203 = OpCompositeExtract %ushort %202 7
-OpStore %165 %203
-%204 = OpLoad %ulong %164
-%205 = OpLoad %ushort %165
-%206 = OpFunctionCall %ulong %10 %204 %205
-OpStore %166 %206
-%207 = OpLoad %ulong %166
-OpReturnValue %207
-OpFunctionEnd
-%3 = OpFunction %ulong None %209
-%210 = OpFunctionParameter %ulong
-%211 = OpFunctionParameter %v4uint
-%212 = OpLabel
+%149 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%151 = OpVariable %_ptr_Function_uchar Function
+%152 = OpVariable %_ptr_Function_uchar Function
+%153 = OpVariable %_ptr_Function_uchar Function
+%154 = OpVariable %_ptr_Function_uchar Function
+%155 = OpVariable %_ptr_Function_uchar Function
+%156 = OpVariable %_ptr_Function_uchar Function
+%157 = OpVariable %_ptr_Function_uchar Function
+%158 = OpVariable %_ptr_Function_uchar Function
+%159 = OpVariable %_ptr_Function_uchar Function
+%160 = OpVariable %_ptr_Function_uchar Function
+%161 = OpVariable %_ptr_Function_uchar Function
+%162 = OpVariable %_ptr_Function_uchar Function
+%163 = OpVariable %_ptr_Function_uchar Function
+%164 = OpVariable %_ptr_Function_uchar Function
+%165 = OpVariable %_ptr_Function_uchar Function
+%166 = OpVariable %_ptr_Function_uchar Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_bool Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_bool Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
 %213 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_v4uint Function
-%217 = OpVariable %_ptr_Function_uint Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
 %218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_uint Function
+%219 = OpVariable %_ptr_Function_bool Function
 %220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_uint Function
+%221 = OpVariable %_ptr_Function_ulong Function
 %222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_uint Function
+%223 = OpVariable %_ptr_Function_ulong Function
 %224 = OpVariable %_ptr_Function_ulong Function
-OpStore %213 %210
-OpStore %215 %211
-%225 = OpLoad %v4uint %215
-%226 = OpCompositeExtract %uint %225 0
-OpStore %217 %226
-%227 = OpLoad %ulong %213
-%228 = OpLoad %uint %217
-%229 = OpFunctionCall %ulong %11 %227 %228
-OpStore %218 %229
-%230 = OpLoad %v4uint %215
-%231 = OpCompositeExtract %uint %230 1
-OpStore %219 %231
-%232 = OpLoad %ulong %218
-%233 = OpLoad %uint %219
-%234 = OpFunctionCall %ulong %11 %232 %233
-OpStore %220 %234
-%235 = OpLoad %v4uint %215
-%236 = OpCompositeExtract %uint %235 2
-OpStore %221 %236
-%237 = OpLoad %ulong %220
-%238 = OpLoad %uint %221
-%239 = OpFunctionCall %ulong %11 %237 %238
-OpStore %222 %239
-%240 = OpLoad %v4uint %215
-%241 = OpCompositeExtract %uint %240 3
-OpStore %223 %241
-%242 = OpLoad %ulong %222
-%243 = OpLoad %uint %223
-%244 = OpFunctionCall %ulong %11 %242 %243
-OpStore %224 %244
-%245 = OpLoad %ulong %224
-OpReturnValue %245
-OpFunctionEnd
-%4 = OpFunction %ulong None %247
-%248 = OpFunctionParameter %ulong
-%249 = OpFunctionParameter %v2ulong
-%250 = OpLabel
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_bool Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_bool Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_bool Function
+%250 = OpVariable %_ptr_Function_ulong Function
 %251 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_v2ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
 %254 = OpVariable %_ptr_Function_ulong Function
 %255 = OpVariable %_ptr_Function_ulong Function
 %256 = OpVariable %_ptr_Function_ulong Function
 %257 = OpVariable %_ptr_Function_ulong Function
-OpStore %251 %248
-OpStore %253 %249
-%258 = OpLoad %v2ulong %253
-%259 = OpCompositeExtract %ulong %258 0
-OpStore %254 %259
-%260 = OpLoad %ulong %251
-%261 = OpLoad %ulong %254
-%262 = OpFunctionCall %ulong %8 %260 %261
-OpStore %255 %262
-%263 = OpLoad %v2ulong %253
-%264 = OpCompositeExtract %ulong %263 1
-OpStore %256 %264
-%265 = OpLoad %ulong %255
-%266 = OpLoad %ulong %256
-%267 = OpFunctionCall %ulong %8 %265 %266
-OpStore %257 %267
-%268 = OpLoad %ulong %257
-OpReturnValue %268
-OpFunctionEnd
-%5 = OpFunction %ulong None %271
-%272 = OpFunctionParameter %ulong
-%273 = OpFunctionParameter %v4float
-%274 = OpLabel
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_bool Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_bool Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
 %275 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_v4float Function
-%279 = OpVariable %_ptr_Function_float Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_bool Function
 %280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_float Function
+%281 = OpVariable %_ptr_Function_ulong Function
 %282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_float Function
+%283 = OpVariable %_ptr_Function_ulong Function
 %284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_float Function
+%285 = OpVariable %_ptr_Function_ulong Function
 %286 = OpVariable %_ptr_Function_ulong Function
-OpStore %275 %272
-OpStore %277 %273
-%287 = OpLoad %v4float %277
-%288 = OpCompositeExtract %float %287 0
-OpStore %279 %288
-%289 = OpLoad %ulong %275
-%290 = OpLoad %float %279
-%291 = OpFunctionCall %ulong %12 %289 %290
-OpStore %280 %291
-%292 = OpLoad %v4float %277
-%293 = OpCompositeExtract %float %292 1
-OpStore %281 %293
-%294 = OpLoad %ulong %280
-%295 = OpLoad %float %281
-%296 = OpFunctionCall %ulong %12 %294 %295
-OpStore %282 %296
-%297 = OpLoad %v4float %277
-%298 = OpCompositeExtract %float %297 2
-OpStore %283 %298
-%299 = OpLoad %ulong %282
-%300 = OpLoad %float %283
-%301 = OpFunctionCall %ulong %12 %299 %300
-OpStore %284 %301
-%302 = OpLoad %v4float %277
-%303 = OpCompositeExtract %float %302 3
-OpStore %285 %303
-%304 = OpLoad %ulong %284
-%305 = OpLoad %float %285
-%306 = OpFunctionCall %ulong %12 %304 %305
-OpStore %286 %306
-%307 = OpLoad %ulong %286
-OpReturnValue %307
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_bool Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_bool Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_bool Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+OpStore %147 %14
+OpStore %149 %15
+%328 = OpLoad %_arr_uchar_uint_16 %149
+%329 = OpCompositeExtract %uchar %328 0
+OpStore %151 %329
+OpBranch %17
+%17 = OpLabel
+%330 = OpLoad %uchar %151
+%331 = OpUConvert %ulong %330
+OpStore %167 %331
+OpBranch %19
+%19 = OpLabel
+%332 = OpLoad %ulong %147
+OpStore %176 %332
+OpStore %177 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%334 = OpLoad %ulong %177
+%336 = OpULessThan %bool %334 %ulong_8
+OpStore %169 %336
+%337 = OpLoad %bool %169
+OpLoopMerge %22 %144 None
+OpBranchConditional %337 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%338 = OpLoad %_arr_uchar_uint_16 %149
+%339 = OpCompositeExtract %uchar %338 1
+OpStore %152 %339
+OpBranch %24
+%24 = OpLabel
+%340 = OpLoad %uchar %152
+%341 = OpUConvert %ulong %340
+OpStore %178 %341
+OpBranch %26
+%26 = OpLabel
+%342 = OpLoad %ulong %176
+OpStore %186 %342
+OpStore %187 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%343 = OpLoad %ulong %187
+%344 = OpULessThan %bool %343 %ulong_8
+OpStore %179 %344
+%345 = OpLoad %bool %179
+OpLoopMerge %29 %143 None
+OpBranchConditional %345 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%346 = OpLoad %_arr_uchar_uint_16 %149
+%347 = OpCompositeExtract %uchar %346 2
+OpStore %153 %347
+OpBranch %31
+%31 = OpLabel
+%348 = OpLoad %uchar %153
+%349 = OpUConvert %ulong %348
+OpStore %188 %349
+OpBranch %33
+%33 = OpLabel
+%350 = OpLoad %ulong %186
+OpStore %196 %350
+OpStore %197 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%351 = OpLoad %ulong %197
+%352 = OpULessThan %bool %351 %ulong_8
+OpStore %189 %352
+%353 = OpLoad %bool %189
+OpLoopMerge %36 %142 None
+OpBranchConditional %353 %35 %36
+%36 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%354 = OpLoad %_arr_uchar_uint_16 %149
+%355 = OpCompositeExtract %uchar %354 3
+OpStore %154 %355
+OpBranch %38
+%38 = OpLabel
+%356 = OpLoad %uchar %154
+%357 = OpUConvert %ulong %356
+OpStore %198 %357
+OpBranch %40
+%40 = OpLabel
+%358 = OpLoad %ulong %196
+OpStore %206 %358
+OpStore %207 %ulong_0
+OpBranch %41
+%41 = OpLabel
+%359 = OpLoad %ulong %207
+%360 = OpULessThan %bool %359 %ulong_8
+OpStore %199 %360
+%361 = OpLoad %bool %199
+OpLoopMerge %43 %141 None
+OpBranchConditional %361 %42 %43
+%43 = OpLabel
+OpBranch %44
+%44 = OpLabel
+OpBranch %39
+%39 = OpLabel
+%362 = OpLoad %_arr_uchar_uint_16 %149
+%363 = OpCompositeExtract %uchar %362 4
+OpStore %155 %363
+OpBranch %45
+%45 = OpLabel
+%364 = OpLoad %uchar %155
+%365 = OpUConvert %ulong %364
+OpStore %208 %365
+OpBranch %47
+%47 = OpLabel
+%366 = OpLoad %ulong %206
+OpStore %216 %366
+OpStore %217 %ulong_0
+OpBranch %48
+%48 = OpLabel
+%367 = OpLoad %ulong %217
+%368 = OpULessThan %bool %367 %ulong_8
+OpStore %209 %368
+%369 = OpLoad %bool %209
+OpLoopMerge %50 %140 None
+OpBranchConditional %369 %49 %50
+%50 = OpLabel
+OpBranch %51
+%51 = OpLabel
+OpBranch %46
+%46 = OpLabel
+%370 = OpLoad %_arr_uchar_uint_16 %149
+%371 = OpCompositeExtract %uchar %370 5
+OpStore %156 %371
+OpBranch %52
+%52 = OpLabel
+%372 = OpLoad %uchar %156
+%373 = OpUConvert %ulong %372
+OpStore %218 %373
+OpBranch %54
+%54 = OpLabel
+%374 = OpLoad %ulong %216
+OpStore %226 %374
+OpStore %227 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%375 = OpLoad %ulong %227
+%376 = OpULessThan %bool %375 %ulong_8
+OpStore %219 %376
+%377 = OpLoad %bool %219
+OpLoopMerge %57 %139 None
+OpBranchConditional %377 %56 %57
+%57 = OpLabel
+OpBranch %58
+%58 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%378 = OpLoad %_arr_uchar_uint_16 %149
+%379 = OpCompositeExtract %uchar %378 6
+OpStore %157 %379
+OpBranch %59
+%59 = OpLabel
+%380 = OpLoad %uchar %157
+%381 = OpUConvert %ulong %380
+OpStore %228 %381
+OpBranch %61
+%61 = OpLabel
+%382 = OpLoad %ulong %226
+OpStore %236 %382
+OpStore %237 %ulong_0
+OpBranch %62
+%62 = OpLabel
+%383 = OpLoad %ulong %237
+%384 = OpULessThan %bool %383 %ulong_8
+OpStore %229 %384
+%385 = OpLoad %bool %229
+OpLoopMerge %64 %138 None
+OpBranchConditional %385 %63 %64
+%64 = OpLabel
+OpBranch %65
+%65 = OpLabel
+OpBranch %60
+%60 = OpLabel
+%386 = OpLoad %_arr_uchar_uint_16 %149
+%387 = OpCompositeExtract %uchar %386 7
+OpStore %158 %387
+OpBranch %66
+%66 = OpLabel
+%388 = OpLoad %uchar %158
+%389 = OpUConvert %ulong %388
+OpStore %238 %389
+OpBranch %68
+%68 = OpLabel
+%390 = OpLoad %ulong %236
+OpStore %246 %390
+OpStore %247 %ulong_0
+OpBranch %69
+%69 = OpLabel
+%391 = OpLoad %ulong %247
+%392 = OpULessThan %bool %391 %ulong_8
+OpStore %239 %392
+%393 = OpLoad %bool %239
+OpLoopMerge %71 %137 None
+OpBranchConditional %393 %70 %71
+%71 = OpLabel
+OpBranch %72
+%72 = OpLabel
+OpBranch %67
+%67 = OpLabel
+%394 = OpLoad %_arr_uchar_uint_16 %149
+%395 = OpCompositeExtract %uchar %394 8
+OpStore %159 %395
+OpBranch %73
+%73 = OpLabel
+%396 = OpLoad %uchar %159
+%397 = OpUConvert %ulong %396
+OpStore %248 %397
+OpBranch %75
+%75 = OpLabel
+%398 = OpLoad %ulong %246
+OpStore %256 %398
+OpStore %257 %ulong_0
+OpBranch %76
+%76 = OpLabel
+%399 = OpLoad %ulong %257
+%400 = OpULessThan %bool %399 %ulong_8
+OpStore %249 %400
+%401 = OpLoad %bool %249
+OpLoopMerge %78 %136 None
+OpBranchConditional %401 %77 %78
+%78 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%402 = OpLoad %_arr_uchar_uint_16 %149
+%403 = OpCompositeExtract %uchar %402 9
+OpStore %160 %403
+OpBranch %80
+%80 = OpLabel
+%404 = OpLoad %uchar %160
+%405 = OpUConvert %ulong %404
+OpStore %258 %405
+OpBranch %82
+%82 = OpLabel
+%406 = OpLoad %ulong %256
+OpStore %266 %406
+OpStore %267 %ulong_0
+OpBranch %83
+%83 = OpLabel
+%407 = OpLoad %ulong %267
+%408 = OpULessThan %bool %407 %ulong_8
+OpStore %259 %408
+%409 = OpLoad %bool %259
+OpLoopMerge %85 %135 None
+OpBranchConditional %409 %84 %85
+%85 = OpLabel
+OpBranch %86
+%86 = OpLabel
+OpBranch %81
+%81 = OpLabel
+%410 = OpLoad %_arr_uchar_uint_16 %149
+%411 = OpCompositeExtract %uchar %410 10
+OpStore %161 %411
+OpBranch %87
+%87 = OpLabel
+%412 = OpLoad %uchar %161
+%413 = OpUConvert %ulong %412
+OpStore %268 %413
+OpBranch %89
+%89 = OpLabel
+%414 = OpLoad %ulong %266
+OpStore %276 %414
+OpStore %277 %ulong_0
+OpBranch %90
+%90 = OpLabel
+%415 = OpLoad %ulong %277
+%416 = OpULessThan %bool %415 %ulong_8
+OpStore %269 %416
+%417 = OpLoad %bool %269
+OpLoopMerge %92 %134 None
+OpBranchConditional %417 %91 %92
+%92 = OpLabel
+OpBranch %93
+%93 = OpLabel
+OpBranch %88
+%88 = OpLabel
+%418 = OpLoad %_arr_uchar_uint_16 %149
+%419 = OpCompositeExtract %uchar %418 11
+OpStore %162 %419
+OpBranch %94
+%94 = OpLabel
+%420 = OpLoad %uchar %162
+%421 = OpUConvert %ulong %420
+OpStore %278 %421
+OpBranch %96
+%96 = OpLabel
+%422 = OpLoad %ulong %276
+OpStore %286 %422
+OpStore %287 %ulong_0
+OpBranch %97
+%97 = OpLabel
+%423 = OpLoad %ulong %287
+%424 = OpULessThan %bool %423 %ulong_8
+OpStore %279 %424
+%425 = OpLoad %bool %279
+OpLoopMerge %99 %133 None
+OpBranchConditional %425 %98 %99
+%99 = OpLabel
+OpBranch %100
+%100 = OpLabel
+OpBranch %95
+%95 = OpLabel
+%426 = OpLoad %_arr_uchar_uint_16 %149
+%427 = OpCompositeExtract %uchar %426 12
+OpStore %163 %427
+OpBranch %101
+%101 = OpLabel
+%428 = OpLoad %uchar %163
+%429 = OpUConvert %ulong %428
+OpStore %288 %429
+OpBranch %103
+%103 = OpLabel
+%430 = OpLoad %ulong %286
+OpStore %296 %430
+OpStore %297 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%431 = OpLoad %ulong %297
+%432 = OpULessThan %bool %431 %ulong_8
+OpStore %289 %432
+%433 = OpLoad %bool %289
+OpLoopMerge %106 %132 None
+OpBranchConditional %433 %105 %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+OpBranch %102
+%102 = OpLabel
+%434 = OpLoad %_arr_uchar_uint_16 %149
+%435 = OpCompositeExtract %uchar %434 13
+OpStore %164 %435
+OpBranch %108
+%108 = OpLabel
+%436 = OpLoad %uchar %164
+%437 = OpUConvert %ulong %436
+OpStore %298 %437
+OpBranch %110
+%110 = OpLabel
+%438 = OpLoad %ulong %296
+OpStore %306 %438
+OpStore %307 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%439 = OpLoad %ulong %307
+%440 = OpULessThan %bool %439 %ulong_8
+OpStore %299 %440
+%441 = OpLoad %bool %299
+OpLoopMerge %113 %131 None
+OpBranchConditional %441 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%442 = OpLoad %_arr_uchar_uint_16 %149
+%443 = OpCompositeExtract %uchar %442 14
+OpStore %165 %443
+OpBranch %115
+%115 = OpLabel
+%444 = OpLoad %uchar %165
+%445 = OpUConvert %ulong %444
+OpStore %308 %445
+OpBranch %117
+%117 = OpLabel
+%446 = OpLoad %ulong %306
+OpStore %316 %446
+OpStore %317 %ulong_0
+OpBranch %118
+%118 = OpLabel
+%447 = OpLoad %ulong %317
+%448 = OpULessThan %bool %447 %ulong_8
+OpStore %309 %448
+%449 = OpLoad %bool %309
+OpLoopMerge %120 %130 None
+OpBranchConditional %449 %119 %120
+%120 = OpLabel
+OpBranch %121
+%121 = OpLabel
+OpBranch %116
+%116 = OpLabel
+%450 = OpLoad %_arr_uchar_uint_16 %149
+%451 = OpCompositeExtract %uchar %450 15
+OpStore %166 %451
+OpBranch %122
+%122 = OpLabel
+%452 = OpLoad %uchar %166
+%453 = OpUConvert %ulong %452
+OpStore %318 %453
+OpBranch %124
+%124 = OpLabel
+%454 = OpLoad %ulong %316
+OpStore %326 %454
+OpStore %327 %ulong_0
+OpBranch %125
+%125 = OpLabel
+%455 = OpLoad %ulong %327
+%456 = OpULessThan %bool %455 %ulong_8
+OpStore %319 %456
+%457 = OpLoad %bool %319
+OpLoopMerge %127 %129 None
+OpBranchConditional %457 %126 %127
+%127 = OpLabel
+OpBranch %128
+%128 = OpLabel
+OpBranch %123
+%123 = OpLabel
+%458 = OpLoad %ulong %326
+OpReturnValue %458
+%126 = OpLabel
+%459 = OpLoad %ulong %327
+%460 = OpIMul %ulong %459 %ulong_8
+OpStore %320 %460
+%461 = OpLoad %ulong %318
+%462 = OpLoad %ulong %320
+%463 = OpShiftRightLogical %ulong %461 %462
+OpStore %321 %463
+%464 = OpLoad %ulong %321
+%466 = OpBitwiseAnd %ulong %464 %ulong_255
+OpStore %322 %466
+%467 = OpLoad %ulong %326
+%468 = OpLoad %ulong %322
+%469 = OpBitwiseXor %ulong %467 %468
+OpStore %323 %469
+%470 = OpLoad %ulong %323
+%472 = OpIMul %ulong %470 %ulong_1099511628211
+OpStore %324 %472
+%473 = OpLoad %ulong %327
+%475 = OpIAdd %ulong %473 %ulong_1
+OpStore %325 %475
+%476 = OpLoad %ulong %324
+OpStore %326 %476
+%477 = OpLoad %ulong %325
+OpStore %327 %477
+OpBranch %129
+%119 = OpLabel
+%478 = OpLoad %ulong %317
+%479 = OpIMul %ulong %478 %ulong_8
+OpStore %310 %479
+%480 = OpLoad %ulong %308
+%481 = OpLoad %ulong %310
+%482 = OpShiftRightLogical %ulong %480 %481
+OpStore %311 %482
+%483 = OpLoad %ulong %311
+%484 = OpBitwiseAnd %ulong %483 %ulong_255
+OpStore %312 %484
+%485 = OpLoad %ulong %316
+%486 = OpLoad %ulong %312
+%487 = OpBitwiseXor %ulong %485 %486
+OpStore %313 %487
+%488 = OpLoad %ulong %313
+%489 = OpIMul %ulong %488 %ulong_1099511628211
+OpStore %314 %489
+%490 = OpLoad %ulong %317
+%491 = OpIAdd %ulong %490 %ulong_1
+OpStore %315 %491
+%492 = OpLoad %ulong %314
+OpStore %316 %492
+%493 = OpLoad %ulong %315
+OpStore %317 %493
+OpBranch %130
+%112 = OpLabel
+%494 = OpLoad %ulong %307
+%495 = OpIMul %ulong %494 %ulong_8
+OpStore %300 %495
+%496 = OpLoad %ulong %298
+%497 = OpLoad %ulong %300
+%498 = OpShiftRightLogical %ulong %496 %497
+OpStore %301 %498
+%499 = OpLoad %ulong %301
+%500 = OpBitwiseAnd %ulong %499 %ulong_255
+OpStore %302 %500
+%501 = OpLoad %ulong %306
+%502 = OpLoad %ulong %302
+%503 = OpBitwiseXor %ulong %501 %502
+OpStore %303 %503
+%504 = OpLoad %ulong %303
+%505 = OpIMul %ulong %504 %ulong_1099511628211
+OpStore %304 %505
+%506 = OpLoad %ulong %307
+%507 = OpIAdd %ulong %506 %ulong_1
+OpStore %305 %507
+%508 = OpLoad %ulong %304
+OpStore %306 %508
+%509 = OpLoad %ulong %305
+OpStore %307 %509
+OpBranch %131
+%105 = OpLabel
+%510 = OpLoad %ulong %297
+%511 = OpIMul %ulong %510 %ulong_8
+OpStore %290 %511
+%512 = OpLoad %ulong %288
+%513 = OpLoad %ulong %290
+%514 = OpShiftRightLogical %ulong %512 %513
+OpStore %291 %514
+%515 = OpLoad %ulong %291
+%516 = OpBitwiseAnd %ulong %515 %ulong_255
+OpStore %292 %516
+%517 = OpLoad %ulong %296
+%518 = OpLoad %ulong %292
+%519 = OpBitwiseXor %ulong %517 %518
+OpStore %293 %519
+%520 = OpLoad %ulong %293
+%521 = OpIMul %ulong %520 %ulong_1099511628211
+OpStore %294 %521
+%522 = OpLoad %ulong %297
+%523 = OpIAdd %ulong %522 %ulong_1
+OpStore %295 %523
+%524 = OpLoad %ulong %294
+OpStore %296 %524
+%525 = OpLoad %ulong %295
+OpStore %297 %525
+OpBranch %132
+%98 = OpLabel
+%526 = OpLoad %ulong %287
+%527 = OpIMul %ulong %526 %ulong_8
+OpStore %280 %527
+%528 = OpLoad %ulong %278
+%529 = OpLoad %ulong %280
+%530 = OpShiftRightLogical %ulong %528 %529
+OpStore %281 %530
+%531 = OpLoad %ulong %281
+%532 = OpBitwiseAnd %ulong %531 %ulong_255
+OpStore %282 %532
+%533 = OpLoad %ulong %286
+%534 = OpLoad %ulong %282
+%535 = OpBitwiseXor %ulong %533 %534
+OpStore %283 %535
+%536 = OpLoad %ulong %283
+%537 = OpIMul %ulong %536 %ulong_1099511628211
+OpStore %284 %537
+%538 = OpLoad %ulong %287
+%539 = OpIAdd %ulong %538 %ulong_1
+OpStore %285 %539
+%540 = OpLoad %ulong %284
+OpStore %286 %540
+%541 = OpLoad %ulong %285
+OpStore %287 %541
+OpBranch %133
+%91 = OpLabel
+%542 = OpLoad %ulong %277
+%543 = OpIMul %ulong %542 %ulong_8
+OpStore %270 %543
+%544 = OpLoad %ulong %268
+%545 = OpLoad %ulong %270
+%546 = OpShiftRightLogical %ulong %544 %545
+OpStore %271 %546
+%547 = OpLoad %ulong %271
+%548 = OpBitwiseAnd %ulong %547 %ulong_255
+OpStore %272 %548
+%549 = OpLoad %ulong %276
+%550 = OpLoad %ulong %272
+%551 = OpBitwiseXor %ulong %549 %550
+OpStore %273 %551
+%552 = OpLoad %ulong %273
+%553 = OpIMul %ulong %552 %ulong_1099511628211
+OpStore %274 %553
+%554 = OpLoad %ulong %277
+%555 = OpIAdd %ulong %554 %ulong_1
+OpStore %275 %555
+%556 = OpLoad %ulong %274
+OpStore %276 %556
+%557 = OpLoad %ulong %275
+OpStore %277 %557
+OpBranch %134
+%84 = OpLabel
+%558 = OpLoad %ulong %267
+%559 = OpIMul %ulong %558 %ulong_8
+OpStore %260 %559
+%560 = OpLoad %ulong %258
+%561 = OpLoad %ulong %260
+%562 = OpShiftRightLogical %ulong %560 %561
+OpStore %261 %562
+%563 = OpLoad %ulong %261
+%564 = OpBitwiseAnd %ulong %563 %ulong_255
+OpStore %262 %564
+%565 = OpLoad %ulong %266
+%566 = OpLoad %ulong %262
+%567 = OpBitwiseXor %ulong %565 %566
+OpStore %263 %567
+%568 = OpLoad %ulong %263
+%569 = OpIMul %ulong %568 %ulong_1099511628211
+OpStore %264 %569
+%570 = OpLoad %ulong %267
+%571 = OpIAdd %ulong %570 %ulong_1
+OpStore %265 %571
+%572 = OpLoad %ulong %264
+OpStore %266 %572
+%573 = OpLoad %ulong %265
+OpStore %267 %573
+OpBranch %135
+%77 = OpLabel
+%574 = OpLoad %ulong %257
+%575 = OpIMul %ulong %574 %ulong_8
+OpStore %250 %575
+%576 = OpLoad %ulong %248
+%577 = OpLoad %ulong %250
+%578 = OpShiftRightLogical %ulong %576 %577
+OpStore %251 %578
+%579 = OpLoad %ulong %251
+%580 = OpBitwiseAnd %ulong %579 %ulong_255
+OpStore %252 %580
+%581 = OpLoad %ulong %256
+%582 = OpLoad %ulong %252
+%583 = OpBitwiseXor %ulong %581 %582
+OpStore %253 %583
+%584 = OpLoad %ulong %253
+%585 = OpIMul %ulong %584 %ulong_1099511628211
+OpStore %254 %585
+%586 = OpLoad %ulong %257
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %255 %587
+%588 = OpLoad %ulong %254
+OpStore %256 %588
+%589 = OpLoad %ulong %255
+OpStore %257 %589
+OpBranch %136
+%70 = OpLabel
+%590 = OpLoad %ulong %247
+%591 = OpIMul %ulong %590 %ulong_8
+OpStore %240 %591
+%592 = OpLoad %ulong %238
+%593 = OpLoad %ulong %240
+%594 = OpShiftRightLogical %ulong %592 %593
+OpStore %241 %594
+%595 = OpLoad %ulong %241
+%596 = OpBitwiseAnd %ulong %595 %ulong_255
+OpStore %242 %596
+%597 = OpLoad %ulong %246
+%598 = OpLoad %ulong %242
+%599 = OpBitwiseXor %ulong %597 %598
+OpStore %243 %599
+%600 = OpLoad %ulong %243
+%601 = OpIMul %ulong %600 %ulong_1099511628211
+OpStore %244 %601
+%602 = OpLoad %ulong %247
+%603 = OpIAdd %ulong %602 %ulong_1
+OpStore %245 %603
+%604 = OpLoad %ulong %244
+OpStore %246 %604
+%605 = OpLoad %ulong %245
+OpStore %247 %605
+OpBranch %137
+%63 = OpLabel
+%606 = OpLoad %ulong %237
+%607 = OpIMul %ulong %606 %ulong_8
+OpStore %230 %607
+%608 = OpLoad %ulong %228
+%609 = OpLoad %ulong %230
+%610 = OpShiftRightLogical %ulong %608 %609
+OpStore %231 %610
+%611 = OpLoad %ulong %231
+%612 = OpBitwiseAnd %ulong %611 %ulong_255
+OpStore %232 %612
+%613 = OpLoad %ulong %236
+%614 = OpLoad %ulong %232
+%615 = OpBitwiseXor %ulong %613 %614
+OpStore %233 %615
+%616 = OpLoad %ulong %233
+%617 = OpIMul %ulong %616 %ulong_1099511628211
+OpStore %234 %617
+%618 = OpLoad %ulong %237
+%619 = OpIAdd %ulong %618 %ulong_1
+OpStore %235 %619
+%620 = OpLoad %ulong %234
+OpStore %236 %620
+%621 = OpLoad %ulong %235
+OpStore %237 %621
+OpBranch %138
+%56 = OpLabel
+%622 = OpLoad %ulong %227
+%623 = OpIMul %ulong %622 %ulong_8
+OpStore %220 %623
+%624 = OpLoad %ulong %218
+%625 = OpLoad %ulong %220
+%626 = OpShiftRightLogical %ulong %624 %625
+OpStore %221 %626
+%627 = OpLoad %ulong %221
+%628 = OpBitwiseAnd %ulong %627 %ulong_255
+OpStore %222 %628
+%629 = OpLoad %ulong %226
+%630 = OpLoad %ulong %222
+%631 = OpBitwiseXor %ulong %629 %630
+OpStore %223 %631
+%632 = OpLoad %ulong %223
+%633 = OpIMul %ulong %632 %ulong_1099511628211
+OpStore %224 %633
+%634 = OpLoad %ulong %227
+%635 = OpIAdd %ulong %634 %ulong_1
+OpStore %225 %635
+%636 = OpLoad %ulong %224
+OpStore %226 %636
+%637 = OpLoad %ulong %225
+OpStore %227 %637
+OpBranch %139
+%49 = OpLabel
+%638 = OpLoad %ulong %217
+%639 = OpIMul %ulong %638 %ulong_8
+OpStore %210 %639
+%640 = OpLoad %ulong %208
+%641 = OpLoad %ulong %210
+%642 = OpShiftRightLogical %ulong %640 %641
+OpStore %211 %642
+%643 = OpLoad %ulong %211
+%644 = OpBitwiseAnd %ulong %643 %ulong_255
+OpStore %212 %644
+%645 = OpLoad %ulong %216
+%646 = OpLoad %ulong %212
+%647 = OpBitwiseXor %ulong %645 %646
+OpStore %213 %647
+%648 = OpLoad %ulong %213
+%649 = OpIMul %ulong %648 %ulong_1099511628211
+OpStore %214 %649
+%650 = OpLoad %ulong %217
+%651 = OpIAdd %ulong %650 %ulong_1
+OpStore %215 %651
+%652 = OpLoad %ulong %214
+OpStore %216 %652
+%653 = OpLoad %ulong %215
+OpStore %217 %653
+OpBranch %140
+%42 = OpLabel
+%654 = OpLoad %ulong %207
+%655 = OpIMul %ulong %654 %ulong_8
+OpStore %200 %655
+%656 = OpLoad %ulong %198
+%657 = OpLoad %ulong %200
+%658 = OpShiftRightLogical %ulong %656 %657
+OpStore %201 %658
+%659 = OpLoad %ulong %201
+%660 = OpBitwiseAnd %ulong %659 %ulong_255
+OpStore %202 %660
+%661 = OpLoad %ulong %206
+%662 = OpLoad %ulong %202
+%663 = OpBitwiseXor %ulong %661 %662
+OpStore %203 %663
+%664 = OpLoad %ulong %203
+%665 = OpIMul %ulong %664 %ulong_1099511628211
+OpStore %204 %665
+%666 = OpLoad %ulong %207
+%667 = OpIAdd %ulong %666 %ulong_1
+OpStore %205 %667
+%668 = OpLoad %ulong %204
+OpStore %206 %668
+%669 = OpLoad %ulong %205
+OpStore %207 %669
+OpBranch %141
+%35 = OpLabel
+%670 = OpLoad %ulong %197
+%671 = OpIMul %ulong %670 %ulong_8
+OpStore %190 %671
+%672 = OpLoad %ulong %188
+%673 = OpLoad %ulong %190
+%674 = OpShiftRightLogical %ulong %672 %673
+OpStore %191 %674
+%675 = OpLoad %ulong %191
+%676 = OpBitwiseAnd %ulong %675 %ulong_255
+OpStore %192 %676
+%677 = OpLoad %ulong %196
+%678 = OpLoad %ulong %192
+%679 = OpBitwiseXor %ulong %677 %678
+OpStore %193 %679
+%680 = OpLoad %ulong %193
+%681 = OpIMul %ulong %680 %ulong_1099511628211
+OpStore %194 %681
+%682 = OpLoad %ulong %197
+%683 = OpIAdd %ulong %682 %ulong_1
+OpStore %195 %683
+%684 = OpLoad %ulong %194
+OpStore %196 %684
+%685 = OpLoad %ulong %195
+OpStore %197 %685
+OpBranch %142
+%28 = OpLabel
+%686 = OpLoad %ulong %187
+%687 = OpIMul %ulong %686 %ulong_8
+OpStore %180 %687
+%688 = OpLoad %ulong %178
+%689 = OpLoad %ulong %180
+%690 = OpShiftRightLogical %ulong %688 %689
+OpStore %181 %690
+%691 = OpLoad %ulong %181
+%692 = OpBitwiseAnd %ulong %691 %ulong_255
+OpStore %182 %692
+%693 = OpLoad %ulong %186
+%694 = OpLoad %ulong %182
+%695 = OpBitwiseXor %ulong %693 %694
+OpStore %183 %695
+%696 = OpLoad %ulong %183
+%697 = OpIMul %ulong %696 %ulong_1099511628211
+OpStore %184 %697
+%698 = OpLoad %ulong %187
+%699 = OpIAdd %ulong %698 %ulong_1
+OpStore %185 %699
+%700 = OpLoad %ulong %184
+OpStore %186 %700
+%701 = OpLoad %ulong %185
+OpStore %187 %701
+OpBranch %143
+%21 = OpLabel
+%702 = OpLoad %ulong %177
+%703 = OpIMul %ulong %702 %ulong_8
+OpStore %170 %703
+%704 = OpLoad %ulong %167
+%705 = OpLoad %ulong %170
+%706 = OpShiftRightLogical %ulong %704 %705
+OpStore %171 %706
+%707 = OpLoad %ulong %171
+%708 = OpBitwiseAnd %ulong %707 %ulong_255
+OpStore %172 %708
+%709 = OpLoad %ulong %176
+%710 = OpLoad %ulong %172
+%711 = OpBitwiseXor %ulong %709 %710
+OpStore %173 %711
+%712 = OpLoad %ulong %173
+%713 = OpIMul %ulong %712 %ulong_1099511628211
+OpStore %174 %713
+%714 = OpLoad %ulong %177
+%715 = OpIAdd %ulong %714 %ulong_1
+OpStore %175 %715
+%716 = OpLoad %ulong %174
+OpStore %176 %716
+%717 = OpLoad %ulong %175
+OpStore %177 %717
+OpBranch %144
+%129 = OpLabel
+OpBranch %125
+%130 = OpLabel
+OpBranch %118
+%131 = OpLabel
+OpBranch %111
+%132 = OpLabel
+OpBranch %104
+%133 = OpLabel
+OpBranch %97
+%134 = OpLabel
+OpBranch %90
+%135 = OpLabel
+OpBranch %83
+%136 = OpLabel
+OpBranch %76
+%137 = OpLabel
+OpBranch %69
+%138 = OpLabel
+OpBranch %62
+%139 = OpLabel
+OpBranch %55
+%140 = OpLabel
+OpBranch %48
+%141 = OpLabel
+OpBranch %41
+%142 = OpLabel
+OpBranch %34
+%143 = OpLabel
+OpBranch %27
+%144 = OpLabel
+OpBranch %20
 OpFunctionEnd
-%6 = OpFunction %ulong None %308
-%309 = OpFunctionParameter %ulong
-%310 = OpLabel
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_uint Function
-%375 = OpVariable %_ptr_Function_float Function
-%376 = OpVariable %_ptr_Function_ushort Function
-%377 = OpVariable %_ptr_Function_uchar Function
-%378 = OpVariable %_ptr_Function_v4uint Function
-%379 = OpVariable %_ptr_Function_v4uint Function
-%380 = OpVariable %_ptr_Function_uint Function
-%381 = OpVariable %_ptr_Function_uint Function
-%382 = OpVariable %_ptr_Function_v4uint Function
-%383 = OpVariable %_ptr_Function_uint Function
-%384 = OpVariable %_ptr_Function_uint Function
-%385 = OpVariable %_ptr_Function_v4uint Function
-%386 = OpVariable %_ptr_Function_v4uint Function
-%387 = OpVariable %_ptr_Function_v4uint Function
-%388 = OpVariable %_ptr_Function_v4uint Function
-%389 = OpVariable %_ptr_Function_v4uint Function
-%390 = OpVariable %_ptr_Function_v4uint Function
-%391 = OpVariable %_ptr_Function_v4uint Function
-%392 = OpVariable %_ptr_Function_v4uint Function
-%393 = OpVariable %_ptr_Function_v4uint Function
-%394 = OpVariable %_ptr_Function_v4uint Function
-%395 = OpVariable %_ptr_Function_v4uint Function
-%396 = OpVariable %_ptr_Function_v4uint Function
-%397 = OpVariable %_ptr_Function_v4uint Function
-%398 = OpVariable %_ptr_Function_v4uint Function
-%399 = OpVariable %_ptr_Function_v4uint Function
-%400 = OpVariable %_ptr_Function_v4uint Function
-%401 = OpVariable %_ptr_Function_v4uint Function
-%402 = OpVariable %_ptr_Function_v4uint Function
-%403 = OpVariable %_ptr_Function_v4uint Function
-%404 = OpVariable %_ptr_Function_v4uint Function
-%405 = OpVariable %_ptr_Function_v4uint Function
-%406 = OpVariable %_ptr_Function_v4uint Function
-%407 = OpVariable %_ptr_Function_v4uint Function
-%408 = OpVariable %_ptr_Function_uint Function
-%409 = OpVariable %_ptr_Function_uint Function
-%410 = OpVariable %_ptr_Function_v4uint Function
-%411 = OpVariable %_ptr_Function_uint Function
-%412 = OpVariable %_ptr_Function_uint Function
-%413 = OpVariable %_ptr_Function_v4uint Function
-%414 = OpVariable %_ptr_Function_v4uint Function
-%415 = OpVariable %_ptr_Function_v4uint Function
-%416 = OpVariable %_ptr_Function_v4uint Function
-%417 = OpVariable %_ptr_Function_v4uint Function
-%418 = OpVariable %_ptr_Function_v4uint Function
-%419 = OpVariable %_ptr_Function_v4uint Function
-%420 = OpVariable %_ptr_Function_float Function
-%421 = OpVariable %_ptr_Function_float Function
-%422 = OpVariable %_ptr_Function_v4float Function
-%423 = OpVariable %_ptr_Function_float Function
-%424 = OpVariable %_ptr_Function_v4float Function
-%425 = OpVariable %_ptr_Function_float Function
-%426 = OpVariable %_ptr_Function_float Function
-%427 = OpVariable %_ptr_Function_v4float Function
-%428 = OpVariable %_ptr_Function_v4uint Function
-%429 = OpVariable %_ptr_Function_ulong Function
-%430 = OpVariable %_ptr_Function_v4uint Function
-%431 = OpVariable %_ptr_Function_ulong Function
-%432 = OpVariable %_ptr_Function_v4uint Function
-%433 = OpVariable %_ptr_Function_ulong Function
-%434 = OpVariable %_ptr_Function_v4uint Function
-%435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_v4uint Function
-%437 = OpVariable %_ptr_Function_ulong Function
-%438 = OpVariable %_ptr_Function_v4uint Function
-%439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_v4uint Function
-%441 = OpVariable %_ptr_Function_v4uint Function
-%442 = OpVariable %_ptr_Function_v4uint Function
-%443 = OpVariable %_ptr_Function_v4uint Function
-%444 = OpVariable %_ptr_Function_v4uint Function
-%445 = OpVariable %_ptr_Function_v4uint Function
-%446 = OpVariable %_ptr_Function_v4float Function
-%447 = OpVariable %_ptr_Function_v4uint Function
-%448 = OpVariable %_ptr_Function_v4uint Function
-%449 = OpVariable %_ptr_Function_v4uint Function
-%450 = OpVariable %_ptr_Function_v4float Function
-%451 = OpVariable %_ptr_Function_v4float Function
-%453 = OpVariable %_ptr_Function_v2double Function
-%454 = OpVariable %_ptr_Function_v2double Function
-%456 = OpVariable %_ptr_Function_double Function
-%457 = OpVariable %_ptr_Function_double Function
-%458 = OpVariable %_ptr_Function_double Function
-%459 = OpVariable %_ptr_Function_v2double Function
-%460 = OpVariable %_ptr_Function_v2ulong Function
-%461 = OpVariable %_ptr_Function_v2ulong Function
-%462 = OpVariable %_ptr_Function_v2ulong Function
-%463 = OpVariable %_ptr_Function_v2ulong Function
-%464 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%465 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%466 = OpVariable %_ptr_Function_ushort Function
-%467 = OpVariable %_ptr_Function_ushort Function
-%468 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%469 = OpVariable %_ptr_Function_ushort Function
-%470 = OpVariable %_ptr_Function_ushort Function
-%471 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%472 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%473 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%474 = OpVariable %_ptr_Function_uchar Function
-%475 = OpVariable %_ptr_Function_uchar Function
-%476 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%477 = OpVariable %_ptr_Function_uchar Function
-%478 = OpVariable %_ptr_Function_uchar Function
-%479 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_uint Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_uint Function
-%487 = OpVariable %_ptr_Function_ulong Function
-%488 = OpVariable %_ptr_Function_uint Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_uint Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_uint Function
-%493 = OpVariable %_ptr_Function_ulong Function
-%494 = OpVariable %_ptr_Function_uint Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_uint Function
-%497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_uint Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_uint Function
-%501 = OpVariable %_ptr_Function_ulong Function
-%502 = OpVariable %_ptr_Function_uint Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_uint Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_uint Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_uint Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_uint Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_uint Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_uint Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_uint Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_uint Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_uint Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_uint Function
-%523 = OpVariable %_ptr_Function_ulong Function
-%524 = OpVariable %_ptr_Function_uint Function
-%525 = OpVariable %_ptr_Function_ulong Function
-%526 = OpVariable %_ptr_Function_uint Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_uint Function
-%529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_uint Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_uint Function
-%533 = OpVariable %_ptr_Function_ulong Function
-%534 = OpVariable %_ptr_Function_uint Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_uint Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_uint Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_uint Function
-%541 = OpVariable %_ptr_Function_ulong Function
-%542 = OpVariable %_ptr_Function_uint Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_uint Function
-%545 = OpVariable %_ptr_Function_ulong Function
-%546 = OpVariable %_ptr_Function_uint Function
-%547 = OpVariable %_ptr_Function_ulong Function
-%548 = OpVariable %_ptr_Function_uint Function
-%549 = OpVariable %_ptr_Function_ulong Function
-%550 = OpVariable %_ptr_Function_uint Function
-%551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_uint Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_uint Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_uint Function
-%557 = OpVariable %_ptr_Function_ulong Function
-%558 = OpVariable %_ptr_Function_uint Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_uint Function
-%561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_uint Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_uint Function
-%565 = OpVariable %_ptr_Function_ulong Function
-%566 = OpVariable %_ptr_Function_uint Function
-%567 = OpVariable %_ptr_Function_ulong Function
-%568 = OpVariable %_ptr_Function_uint Function
-%569 = OpVariable %_ptr_Function_ulong Function
-%570 = OpVariable %_ptr_Function_uint Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_uint Function
-%573 = OpVariable %_ptr_Function_ulong Function
-%574 = OpVariable %_ptr_Function_uint Function
-%575 = OpVariable %_ptr_Function_ulong Function
-%576 = OpVariable %_ptr_Function_uint Function
-%577 = OpVariable %_ptr_Function_ulong Function
-%578 = OpVariable %_ptr_Function_uint Function
-%579 = OpVariable %_ptr_Function_ulong Function
-%580 = OpVariable %_ptr_Function_uint Function
-%581 = OpVariable %_ptr_Function_ulong Function
-%582 = OpVariable %_ptr_Function_uint Function
-%583 = OpVariable %_ptr_Function_ulong Function
-%584 = OpVariable %_ptr_Function_uint Function
-%585 = OpVariable %_ptr_Function_ulong Function
-%586 = OpVariable %_ptr_Function_uint Function
-%587 = OpVariable %_ptr_Function_ulong Function
-%588 = OpVariable %_ptr_Function_uint Function
-%589 = OpVariable %_ptr_Function_ulong Function
-%590 = OpVariable %_ptr_Function_uint Function
-%591 = OpVariable %_ptr_Function_ulong Function
-%592 = OpVariable %_ptr_Function_uint Function
-%593 = OpVariable %_ptr_Function_ulong Function
-%594 = OpVariable %_ptr_Function_uint Function
-%595 = OpVariable %_ptr_Function_ulong Function
-%596 = OpVariable %_ptr_Function_uint Function
-%597 = OpVariable %_ptr_Function_ulong Function
-%598 = OpVariable %_ptr_Function_uint Function
-%599 = OpVariable %_ptr_Function_ulong Function
-%600 = OpVariable %_ptr_Function_uint Function
-%601 = OpVariable %_ptr_Function_ulong Function
-%602 = OpVariable %_ptr_Function_uint Function
-%603 = OpVariable %_ptr_Function_ulong Function
-%604 = OpVariable %_ptr_Function_uint Function
-%605 = OpVariable %_ptr_Function_ulong Function
-%606 = OpVariable %_ptr_Function_uint Function
-%607 = OpVariable %_ptr_Function_ulong Function
-%608 = OpVariable %_ptr_Function_uint Function
-%609 = OpVariable %_ptr_Function_ulong Function
-%610 = OpVariable %_ptr_Function_uint Function
-%611 = OpVariable %_ptr_Function_ulong Function
-%612 = OpVariable %_ptr_Function_float Function
-%613 = OpVariable %_ptr_Function_ulong Function
-%614 = OpVariable %_ptr_Function_float Function
-%615 = OpVariable %_ptr_Function_ulong Function
-%616 = OpVariable %_ptr_Function_float Function
-%617 = OpVariable %_ptr_Function_ulong Function
-%618 = OpVariable %_ptr_Function_float Function
-%619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_float Function
-%621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_float Function
-%623 = OpVariable %_ptr_Function_ulong Function
-%624 = OpVariable %_ptr_Function_float Function
-%625 = OpVariable %_ptr_Function_ulong Function
-%626 = OpVariable %_ptr_Function_float Function
-%627 = OpVariable %_ptr_Function_ulong Function
-%628 = OpVariable %_ptr_Function_float Function
-%629 = OpVariable %_ptr_Function_ulong Function
-%630 = OpVariable %_ptr_Function_float Function
-%631 = OpVariable %_ptr_Function_ulong Function
-%632 = OpVariable %_ptr_Function_float Function
-%633 = OpVariable %_ptr_Function_ulong Function
-%634 = OpVariable %_ptr_Function_float Function
-%635 = OpVariable %_ptr_Function_ulong Function
-%636 = OpVariable %_ptr_Function_float Function
-%637 = OpVariable %_ptr_Function_ulong Function
-%638 = OpVariable %_ptr_Function_float Function
-%639 = OpVariable %_ptr_Function_ulong Function
-%640 = OpVariable %_ptr_Function_float Function
-%641 = OpVariable %_ptr_Function_ulong Function
-%642 = OpVariable %_ptr_Function_float Function
-%643 = OpVariable %_ptr_Function_ulong Function
-%644 = OpVariable %_ptr_Function_float Function
-%645 = OpVariable %_ptr_Function_ulong Function
-%646 = OpVariable %_ptr_Function_float Function
-%647 = OpVariable %_ptr_Function_ulong Function
-%648 = OpVariable %_ptr_Function_float Function
-%649 = OpVariable %_ptr_Function_ulong Function
-%650 = OpVariable %_ptr_Function_float Function
-%651 = OpVariable %_ptr_Function_ulong Function
-%652 = OpVariable %_ptr_Function_ulong Function
-%653 = OpVariable %_ptr_Function_ulong Function
-%654 = OpVariable %_ptr_Function_ulong Function
-%655 = OpVariable %_ptr_Function_ulong Function
-%656 = OpVariable %_ptr_Function_ulong Function
-%657 = OpVariable %_ptr_Function_ulong Function
-%658 = OpVariable %_ptr_Function_ulong Function
-%659 = OpVariable %_ptr_Function_ulong Function
-%660 = OpVariable %_ptr_Function_ulong Function
-%661 = OpVariable %_ptr_Function_ulong Function
-%662 = OpVariable %_ptr_Function_ulong Function
-%663 = OpVariable %_ptr_Function_ulong Function
-%664 = OpVariable %_ptr_Function_ulong Function
-%665 = OpVariable %_ptr_Function_ulong Function
-%666 = OpVariable %_ptr_Function_ulong Function
-%667 = OpVariable %_ptr_Function_ulong Function
-%668 = OpVariable %_ptr_Function_ushort Function
-%669 = OpVariable %_ptr_Function_ulong Function
-%670 = OpVariable %_ptr_Function_ushort Function
-%671 = OpVariable %_ptr_Function_ulong Function
-%672 = OpVariable %_ptr_Function_ushort Function
-%673 = OpVariable %_ptr_Function_ulong Function
-%674 = OpVariable %_ptr_Function_ushort Function
-%675 = OpVariable %_ptr_Function_ulong Function
-%676 = OpVariable %_ptr_Function_ushort Function
-%677 = OpVariable %_ptr_Function_ulong Function
-%678 = OpVariable %_ptr_Function_ushort Function
-%679 = OpVariable %_ptr_Function_ulong Function
-%680 = OpVariable %_ptr_Function_ushort Function
-%681 = OpVariable %_ptr_Function_ulong Function
-%682 = OpVariable %_ptr_Function_ushort Function
-%683 = OpVariable %_ptr_Function_ulong Function
-%684 = OpVariable %_ptr_Function_ushort Function
-%685 = OpVariable %_ptr_Function_ulong Function
-%686 = OpVariable %_ptr_Function_ushort Function
-%687 = OpVariable %_ptr_Function_ulong Function
-%688 = OpVariable %_ptr_Function_ushort Function
-%689 = OpVariable %_ptr_Function_ulong Function
-%690 = OpVariable %_ptr_Function_ushort Function
-%691 = OpVariable %_ptr_Function_ulong Function
-%692 = OpVariable %_ptr_Function_ushort Function
-%693 = OpVariable %_ptr_Function_ulong Function
-%694 = OpVariable %_ptr_Function_ushort Function
-%695 = OpVariable %_ptr_Function_ulong Function
-%696 = OpVariable %_ptr_Function_ushort Function
-%697 = OpVariable %_ptr_Function_ulong Function
-%698 = OpVariable %_ptr_Function_ushort Function
-%699 = OpVariable %_ptr_Function_ulong Function
-%700 = OpVariable %_ptr_Function_ushort Function
-%701 = OpVariable %_ptr_Function_ulong Function
-%702 = OpVariable %_ptr_Function_ushort Function
-%703 = OpVariable %_ptr_Function_ulong Function
-%704 = OpVariable %_ptr_Function_ushort Function
-%705 = OpVariable %_ptr_Function_ulong Function
-%706 = OpVariable %_ptr_Function_ushort Function
-%707 = OpVariable %_ptr_Function_ulong Function
-%708 = OpVariable %_ptr_Function_ushort Function
-%709 = OpVariable %_ptr_Function_ulong Function
-%710 = OpVariable %_ptr_Function_ushort Function
-%711 = OpVariable %_ptr_Function_ulong Function
-%712 = OpVariable %_ptr_Function_ushort Function
-%713 = OpVariable %_ptr_Function_ulong Function
-%714 = OpVariable %_ptr_Function_ushort Function
-%715 = OpVariable %_ptr_Function_ulong Function
-%716 = OpVariable %_ptr_Function_ushort Function
-%717 = OpVariable %_ptr_Function_ulong Function
-%718 = OpVariable %_ptr_Function_ushort Function
-%719 = OpVariable %_ptr_Function_ulong Function
-%720 = OpVariable %_ptr_Function_ushort Function
-%721 = OpVariable %_ptr_Function_ulong Function
-%722 = OpVariable %_ptr_Function_ushort Function
-%723 = OpVariable %_ptr_Function_ulong Function
-%724 = OpVariable %_ptr_Function_ushort Function
-%725 = OpVariable %_ptr_Function_ulong Function
-%726 = OpVariable %_ptr_Function_ushort Function
-%727 = OpVariable %_ptr_Function_ulong Function
-%728 = OpVariable %_ptr_Function_ushort Function
-%729 = OpVariable %_ptr_Function_ulong Function
-%730 = OpVariable %_ptr_Function_ushort Function
-%731 = OpVariable %_ptr_Function_ulong Function
-%732 = OpVariable %_ptr_Function_ushort Function
-%733 = OpVariable %_ptr_Function_ushort Function
-%735 = OpVariable %_ptr_Function_bool Function
-%736 = OpVariable %_ptr_Function_ushort Function
-%737 = OpVariable %_ptr_Function_ushort Function
-%738 = OpVariable %_ptr_Function_ushort Function
-%739 = OpVariable %_ptr_Function_ushort Function
-%740 = OpVariable %_ptr_Function_bool Function
-%741 = OpVariable %_ptr_Function_ushort Function
-%742 = OpVariable %_ptr_Function_ushort Function
-%743 = OpVariable %_ptr_Function_ushort Function
-%744 = OpVariable %_ptr_Function_ushort Function
-%745 = OpVariable %_ptr_Function_bool Function
+%2 = OpFunction %ulong None %721
+%722 = OpFunctionParameter %ulong
+%723 = OpFunctionParameter %_arr_ushort_uint_8
+%724 = OpLabel
+%741 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%745 = OpVariable %_ptr_Function_ushort Function
 %746 = OpVariable %_ptr_Function_ushort Function
 %747 = OpVariable %_ptr_Function_ushort Function
 %748 = OpVariable %_ptr_Function_ushort Function
 %749 = OpVariable %_ptr_Function_ushort Function
-%750 = OpVariable %_ptr_Function_bool Function
+%750 = OpVariable %_ptr_Function_ushort Function
 %751 = OpVariable %_ptr_Function_ushort Function
 %752 = OpVariable %_ptr_Function_ushort Function
-%753 = OpVariable %_ptr_Function_ushort Function
-%754 = OpVariable %_ptr_Function_ushort Function
-%755 = OpVariable %_ptr_Function_bool Function
-%756 = OpVariable %_ptr_Function_ushort Function
-%757 = OpVariable %_ptr_Function_ushort Function
-%758 = OpVariable %_ptr_Function_ushort Function
-%759 = OpVariable %_ptr_Function_ushort Function
-%760 = OpVariable %_ptr_Function_bool Function
-%761 = OpVariable %_ptr_Function_ushort Function
-%762 = OpVariable %_ptr_Function_ushort Function
-%763 = OpVariable %_ptr_Function_ushort Function
-%764 = OpVariable %_ptr_Function_ushort Function
-%765 = OpVariable %_ptr_Function_bool Function
-%766 = OpVariable %_ptr_Function_ushort Function
-%767 = OpVariable %_ptr_Function_ushort Function
-%768 = OpVariable %_ptr_Function_ushort Function
-%769 = OpVariable %_ptr_Function_ushort Function
-%770 = OpVariable %_ptr_Function_bool Function
-%771 = OpVariable %_ptr_Function_ushort Function
-%772 = OpVariable %_ptr_Function_ushort Function
-%773 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%774 = OpVariable %_ptr_Function_ushort Function
-%775 = OpVariable %_ptr_Function_ushort Function
-%776 = OpVariable %_ptr_Function_bool Function
-%777 = OpVariable %_ptr_Function_ushort Function
-%778 = OpVariable %_ptr_Function_ushort Function
-%779 = OpVariable %_ptr_Function_ushort Function
-%780 = OpVariable %_ptr_Function_ushort Function
-%781 = OpVariable %_ptr_Function_bool Function
-%782 = OpVariable %_ptr_Function_ushort Function
-%783 = OpVariable %_ptr_Function_ushort Function
-%784 = OpVariable %_ptr_Function_ushort Function
-%785 = OpVariable %_ptr_Function_ushort Function
-%786 = OpVariable %_ptr_Function_bool Function
-%787 = OpVariable %_ptr_Function_ushort Function
-%788 = OpVariable %_ptr_Function_ushort Function
-%789 = OpVariable %_ptr_Function_ushort Function
-%790 = OpVariable %_ptr_Function_ushort Function
-%791 = OpVariable %_ptr_Function_bool Function
-%792 = OpVariable %_ptr_Function_ushort Function
-%793 = OpVariable %_ptr_Function_ushort Function
-%794 = OpVariable %_ptr_Function_ushort Function
-%795 = OpVariable %_ptr_Function_ushort Function
-%796 = OpVariable %_ptr_Function_bool Function
-%797 = OpVariable %_ptr_Function_ushort Function
-%798 = OpVariable %_ptr_Function_ushort Function
-%799 = OpVariable %_ptr_Function_ushort Function
-%800 = OpVariable %_ptr_Function_ushort Function
-%801 = OpVariable %_ptr_Function_bool Function
-%802 = OpVariable %_ptr_Function_ushort Function
-%803 = OpVariable %_ptr_Function_ushort Function
-%804 = OpVariable %_ptr_Function_ushort Function
-%805 = OpVariable %_ptr_Function_ushort Function
-%806 = OpVariable %_ptr_Function_bool Function
-%807 = OpVariable %_ptr_Function_ushort Function
-%808 = OpVariable %_ptr_Function_ushort Function
-%809 = OpVariable %_ptr_Function_ushort Function
-%810 = OpVariable %_ptr_Function_ushort Function
-%811 = OpVariable %_ptr_Function_bool Function
-%812 = OpVariable %_ptr_Function_ushort Function
-%813 = OpVariable %_ptr_Function_ushort Function
-%814 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%815 = OpVariable %_ptr_Function_ushort Function
-%816 = OpVariable %_ptr_Function_ushort Function
-%817 = OpVariable %_ptr_Function_bool Function
-%818 = OpVariable %_ptr_Function_ushort Function
-%819 = OpVariable %_ptr_Function_ushort Function
-%820 = OpVariable %_ptr_Function_ushort Function
-%821 = OpVariable %_ptr_Function_ushort Function
-%822 = OpVariable %_ptr_Function_bool Function
-%823 = OpVariable %_ptr_Function_ushort Function
-%824 = OpVariable %_ptr_Function_ushort Function
-%825 = OpVariable %_ptr_Function_ushort Function
-%826 = OpVariable %_ptr_Function_ushort Function
-%827 = OpVariable %_ptr_Function_bool Function
-%828 = OpVariable %_ptr_Function_ushort Function
-%829 = OpVariable %_ptr_Function_ushort Function
-%830 = OpVariable %_ptr_Function_ushort Function
-%831 = OpVariable %_ptr_Function_ushort Function
-%832 = OpVariable %_ptr_Function_bool Function
-%833 = OpVariable %_ptr_Function_ushort Function
-%834 = OpVariable %_ptr_Function_ushort Function
-%835 = OpVariable %_ptr_Function_ushort Function
-%836 = OpVariable %_ptr_Function_ushort Function
-%837 = OpVariable %_ptr_Function_bool Function
-%838 = OpVariable %_ptr_Function_ushort Function
-%839 = OpVariable %_ptr_Function_ushort Function
-%840 = OpVariable %_ptr_Function_ushort Function
-%841 = OpVariable %_ptr_Function_ushort Function
-%842 = OpVariable %_ptr_Function_bool Function
-%843 = OpVariable %_ptr_Function_ushort Function
-%844 = OpVariable %_ptr_Function_ushort Function
-%845 = OpVariable %_ptr_Function_ushort Function
-%846 = OpVariable %_ptr_Function_ushort Function
-%847 = OpVariable %_ptr_Function_bool Function
-%848 = OpVariable %_ptr_Function_ushort Function
-%849 = OpVariable %_ptr_Function_ushort Function
-%850 = OpVariable %_ptr_Function_ushort Function
-%851 = OpVariable %_ptr_Function_ushort Function
-%852 = OpVariable %_ptr_Function_bool Function
-%853 = OpVariable %_ptr_Function_ushort Function
-%854 = OpVariable %_ptr_Function_ushort Function
-%855 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%856 = OpVariable %_ptr_Function_ushort Function
-%857 = OpVariable %_ptr_Function_ushort Function
-%858 = OpVariable %_ptr_Function_bool Function
-%859 = OpVariable %_ptr_Function_ushort Function
-%860 = OpVariable %_ptr_Function_ushort Function
-%861 = OpVariable %_ptr_Function_ushort Function
-%862 = OpVariable %_ptr_Function_ushort Function
-%863 = OpVariable %_ptr_Function_bool Function
-%864 = OpVariable %_ptr_Function_ushort Function
-%865 = OpVariable %_ptr_Function_ushort Function
-%866 = OpVariable %_ptr_Function_ushort Function
-%867 = OpVariable %_ptr_Function_ushort Function
-%868 = OpVariable %_ptr_Function_bool Function
-%869 = OpVariable %_ptr_Function_ushort Function
-%870 = OpVariable %_ptr_Function_ushort Function
-%871 = OpVariable %_ptr_Function_ushort Function
-%872 = OpVariable %_ptr_Function_ushort Function
-%873 = OpVariable %_ptr_Function_bool Function
-%874 = OpVariable %_ptr_Function_ushort Function
-%875 = OpVariable %_ptr_Function_ushort Function
-%876 = OpVariable %_ptr_Function_ushort Function
-%877 = OpVariable %_ptr_Function_ushort Function
-%878 = OpVariable %_ptr_Function_bool Function
-%879 = OpVariable %_ptr_Function_ushort Function
-%880 = OpVariable %_ptr_Function_ushort Function
-%881 = OpVariable %_ptr_Function_ushort Function
-%882 = OpVariable %_ptr_Function_ushort Function
-%883 = OpVariable %_ptr_Function_bool Function
-%884 = OpVariable %_ptr_Function_ushort Function
-%885 = OpVariable %_ptr_Function_ushort Function
-%886 = OpVariable %_ptr_Function_ushort Function
-%887 = OpVariable %_ptr_Function_ushort Function
-%888 = OpVariable %_ptr_Function_bool Function
-%889 = OpVariable %_ptr_Function_ushort Function
-%890 = OpVariable %_ptr_Function_ushort Function
-%891 = OpVariable %_ptr_Function_ushort Function
-%892 = OpVariable %_ptr_Function_ushort Function
-%893 = OpVariable %_ptr_Function_bool Function
-%894 = OpVariable %_ptr_Function_ushort Function
-%895 = OpVariable %_ptr_Function_ushort Function
-%896 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%897 = OpVariable %_ptr_Function_ushort Function
-%898 = OpVariable %_ptr_Function_ushort Function
-%899 = OpVariable %_ptr_Function_ushort Function
-%900 = OpVariable %_ptr_Function_ushort Function
-%901 = OpVariable %_ptr_Function_ushort Function
-%902 = OpVariable %_ptr_Function_ushort Function
-%903 = OpVariable %_ptr_Function_ushort Function
-%904 = OpVariable %_ptr_Function_ushort Function
-%905 = OpVariable %_ptr_Function_ushort Function
-%906 = OpVariable %_ptr_Function_ushort Function
-%907 = OpVariable %_ptr_Function_ushort Function
-%908 = OpVariable %_ptr_Function_ushort Function
-%909 = OpVariable %_ptr_Function_ushort Function
-%910 = OpVariable %_ptr_Function_ushort Function
-%911 = OpVariable %_ptr_Function_ushort Function
-%912 = OpVariable %_ptr_Function_ushort Function
-%913 = OpVariable %_ptr_Function_ushort Function
-%914 = OpVariable %_ptr_Function_ushort Function
-%915 = OpVariable %_ptr_Function_ushort Function
-%916 = OpVariable %_ptr_Function_ushort Function
-%917 = OpVariable %_ptr_Function_ushort Function
-%918 = OpVariable %_ptr_Function_ushort Function
-%919 = OpVariable %_ptr_Function_ushort Function
-%920 = OpVariable %_ptr_Function_ushort Function
-%921 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%922 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%923 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%924 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%925 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%926 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%927 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%928 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%929 = OpVariable %_ptr_Function_ushort Function
-%930 = OpVariable %_ptr_Function_ushort Function
-%931 = OpVariable %_ptr_Function_ushort Function
-%932 = OpVariable %_ptr_Function_ushort Function
-%933 = OpVariable %_ptr_Function_ushort Function
-%934 = OpVariable %_ptr_Function_ushort Function
-%935 = OpVariable %_ptr_Function_ushort Function
-%936 = OpVariable %_ptr_Function_ushort Function
-%937 = OpVariable %_ptr_Function_ushort Function
-%938 = OpVariable %_ptr_Function_ushort Function
-%939 = OpVariable %_ptr_Function_ushort Function
-%940 = OpVariable %_ptr_Function_ushort Function
-%941 = OpVariable %_ptr_Function_ushort Function
-%942 = OpVariable %_ptr_Function_ushort Function
-%943 = OpVariable %_ptr_Function_ushort Function
-%944 = OpVariable %_ptr_Function_ushort Function
-%945 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%946 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%947 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%948 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%949 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%950 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%951 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%952 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%953 = OpVariable %_ptr_Function_ushort Function
-%954 = OpVariable %_ptr_Function_ushort Function
-%955 = OpVariable %_ptr_Function_ushort Function
-%956 = OpVariable %_ptr_Function_ushort Function
-%957 = OpVariable %_ptr_Function_ushort Function
-%958 = OpVariable %_ptr_Function_ushort Function
-%959 = OpVariable %_ptr_Function_ushort Function
-%960 = OpVariable %_ptr_Function_ushort Function
-%961 = OpVariable %_ptr_Function_ushort Function
-%962 = OpVariable %_ptr_Function_ushort Function
-%963 = OpVariable %_ptr_Function_ushort Function
-%964 = OpVariable %_ptr_Function_ushort Function
-%965 = OpVariable %_ptr_Function_ushort Function
-%966 = OpVariable %_ptr_Function_ushort Function
-%967 = OpVariable %_ptr_Function_ushort Function
-%968 = OpVariable %_ptr_Function_ushort Function
-%969 = OpVariable %_ptr_Function_ushort Function
-%970 = OpVariable %_ptr_Function_ushort Function
-%971 = OpVariable %_ptr_Function_ushort Function
-%972 = OpVariable %_ptr_Function_ushort Function
-%973 = OpVariable %_ptr_Function_ushort Function
-%974 = OpVariable %_ptr_Function_ushort Function
-%975 = OpVariable %_ptr_Function_ushort Function
-%976 = OpVariable %_ptr_Function_ushort Function
-%977 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%978 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%979 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%980 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%981 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%982 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%983 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%984 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%985 = OpVariable %_ptr_Function_ushort Function
-%986 = OpVariable %_ptr_Function_ushort Function
-%987 = OpVariable %_ptr_Function_ushort Function
-%988 = OpVariable %_ptr_Function_ushort Function
-%989 = OpVariable %_ptr_Function_ushort Function
-%990 = OpVariable %_ptr_Function_ushort Function
-%991 = OpVariable %_ptr_Function_ushort Function
-%992 = OpVariable %_ptr_Function_ushort Function
-%993 = OpVariable %_ptr_Function_ushort Function
-%994 = OpVariable %_ptr_Function_ushort Function
-%995 = OpVariable %_ptr_Function_ushort Function
-%996 = OpVariable %_ptr_Function_ushort Function
-%997 = OpVariable %_ptr_Function_ushort Function
-%998 = OpVariable %_ptr_Function_ushort Function
-%999 = OpVariable %_ptr_Function_ushort Function
-%1000 = OpVariable %_ptr_Function_ushort Function
-%1001 = OpVariable %_ptr_Function_ushort Function
-%1002 = OpVariable %_ptr_Function_ushort Function
-%1003 = OpVariable %_ptr_Function_ushort Function
-%1004 = OpVariable %_ptr_Function_ushort Function
-%1005 = OpVariable %_ptr_Function_ushort Function
-%1006 = OpVariable %_ptr_Function_ushort Function
-%1007 = OpVariable %_ptr_Function_ushort Function
-%1008 = OpVariable %_ptr_Function_ushort Function
-%1009 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1010 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1011 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1012 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1013 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1014 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1015 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1016 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1017 = OpVariable %_ptr_Function_uchar Function
-%1018 = OpVariable %_ptr_Function_uchar Function
-%1019 = OpVariable %_ptr_Function_bool Function
-%1020 = OpVariable %_ptr_Function_uchar Function
-%1021 = OpVariable %_ptr_Function_uchar Function
-%1022 = OpVariable %_ptr_Function_uchar Function
-%1023 = OpVariable %_ptr_Function_bool Function
-%1024 = OpVariable %_ptr_Function_uchar Function
-%1025 = OpVariable %_ptr_Function_uchar Function
-%1026 = OpVariable %_ptr_Function_uchar Function
-%1027 = OpVariable %_ptr_Function_bool Function
-%1028 = OpVariable %_ptr_Function_uchar Function
-%1029 = OpVariable %_ptr_Function_uchar Function
-%1030 = OpVariable %_ptr_Function_uchar Function
-%1031 = OpVariable %_ptr_Function_bool Function
-%1032 = OpVariable %_ptr_Function_uchar Function
-%1033 = OpVariable %_ptr_Function_uchar Function
-%1034 = OpVariable %_ptr_Function_uchar Function
-%1035 = OpVariable %_ptr_Function_bool Function
-%1036 = OpVariable %_ptr_Function_uchar Function
-%1037 = OpVariable %_ptr_Function_uchar Function
-%1038 = OpVariable %_ptr_Function_uchar Function
-%1039 = OpVariable %_ptr_Function_bool Function
-%1040 = OpVariable %_ptr_Function_uchar Function
-%1041 = OpVariable %_ptr_Function_uchar Function
-%1042 = OpVariable %_ptr_Function_uchar Function
-%1043 = OpVariable %_ptr_Function_bool Function
-%1044 = OpVariable %_ptr_Function_uchar Function
-%1045 = OpVariable %_ptr_Function_uchar Function
-%1046 = OpVariable %_ptr_Function_uchar Function
-%1047 = OpVariable %_ptr_Function_bool Function
-%1048 = OpVariable %_ptr_Function_uchar Function
-%1049 = OpVariable %_ptr_Function_uchar Function
-%1050 = OpVariable %_ptr_Function_uchar Function
-%1051 = OpVariable %_ptr_Function_bool Function
-%1052 = OpVariable %_ptr_Function_uchar Function
-%1053 = OpVariable %_ptr_Function_uchar Function
-%1054 = OpVariable %_ptr_Function_uchar Function
-%1055 = OpVariable %_ptr_Function_bool Function
-%1056 = OpVariable %_ptr_Function_uchar Function
-%1057 = OpVariable %_ptr_Function_uchar Function
-%1058 = OpVariable %_ptr_Function_uchar Function
-%1059 = OpVariable %_ptr_Function_bool Function
-%1060 = OpVariable %_ptr_Function_uchar Function
-%1061 = OpVariable %_ptr_Function_uchar Function
-%1062 = OpVariable %_ptr_Function_uchar Function
-%1063 = OpVariable %_ptr_Function_bool Function
-%1064 = OpVariable %_ptr_Function_uchar Function
-%1065 = OpVariable %_ptr_Function_uchar Function
-%1066 = OpVariable %_ptr_Function_uchar Function
-%1067 = OpVariable %_ptr_Function_bool Function
-%1068 = OpVariable %_ptr_Function_uchar Function
-%1069 = OpVariable %_ptr_Function_uchar Function
-%1070 = OpVariable %_ptr_Function_uchar Function
-%1071 = OpVariable %_ptr_Function_bool Function
-%1072 = OpVariable %_ptr_Function_uchar Function
-%1073 = OpVariable %_ptr_Function_uchar Function
-%1074 = OpVariable %_ptr_Function_uchar Function
-%1075 = OpVariable %_ptr_Function_bool Function
-%1076 = OpVariable %_ptr_Function_uchar Function
-%1077 = OpVariable %_ptr_Function_uchar Function
-%1078 = OpVariable %_ptr_Function_uchar Function
-%1079 = OpVariable %_ptr_Function_bool Function
-%1080 = OpVariable %_ptr_Function_uchar Function
-%1081 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1082 = OpVariable %_ptr_Function_uchar Function
-%1083 = OpVariable %_ptr_Function_uchar Function
-%1084 = OpVariable %_ptr_Function_bool Function
-%1085 = OpVariable %_ptr_Function_uchar Function
-%1086 = OpVariable %_ptr_Function_uchar Function
-%1087 = OpVariable %_ptr_Function_uchar Function
-%1088 = OpVariable %_ptr_Function_bool Function
-%1089 = OpVariable %_ptr_Function_uchar Function
-%1090 = OpVariable %_ptr_Function_uchar Function
-%1091 = OpVariable %_ptr_Function_uchar Function
-%1092 = OpVariable %_ptr_Function_bool Function
-%1093 = OpVariable %_ptr_Function_uchar Function
-%1094 = OpVariable %_ptr_Function_uchar Function
-%1095 = OpVariable %_ptr_Function_uchar Function
-%1096 = OpVariable %_ptr_Function_bool Function
-%1097 = OpVariable %_ptr_Function_uchar Function
-%1098 = OpVariable %_ptr_Function_uchar Function
-%1099 = OpVariable %_ptr_Function_uchar Function
-%1100 = OpVariable %_ptr_Function_bool Function
-%1101 = OpVariable %_ptr_Function_uchar Function
-%1102 = OpVariable %_ptr_Function_uchar Function
-%1103 = OpVariable %_ptr_Function_uchar Function
-%1104 = OpVariable %_ptr_Function_bool Function
-%1105 = OpVariable %_ptr_Function_uchar Function
-%1106 = OpVariable %_ptr_Function_uchar Function
-%1107 = OpVariable %_ptr_Function_uchar Function
-%1108 = OpVariable %_ptr_Function_bool Function
-%1109 = OpVariable %_ptr_Function_uchar Function
-%1110 = OpVariable %_ptr_Function_uchar Function
-%1111 = OpVariable %_ptr_Function_uchar Function
-%1112 = OpVariable %_ptr_Function_bool Function
-%1113 = OpVariable %_ptr_Function_uchar Function
-%1114 = OpVariable %_ptr_Function_uchar Function
-%1115 = OpVariable %_ptr_Function_uchar Function
-%1116 = OpVariable %_ptr_Function_bool Function
-%1117 = OpVariable %_ptr_Function_uchar Function
-%1118 = OpVariable %_ptr_Function_uchar Function
-%1119 = OpVariable %_ptr_Function_uchar Function
-%1120 = OpVariable %_ptr_Function_bool Function
-%1121 = OpVariable %_ptr_Function_uchar Function
-%1122 = OpVariable %_ptr_Function_uchar Function
-%1123 = OpVariable %_ptr_Function_uchar Function
-%1124 = OpVariable %_ptr_Function_bool Function
-%1125 = OpVariable %_ptr_Function_uchar Function
-%1126 = OpVariable %_ptr_Function_uchar Function
-%1127 = OpVariable %_ptr_Function_uchar Function
-%1128 = OpVariable %_ptr_Function_bool Function
-%1129 = OpVariable %_ptr_Function_uchar Function
-%1130 = OpVariable %_ptr_Function_uchar Function
-%1131 = OpVariable %_ptr_Function_uchar Function
-%1132 = OpVariable %_ptr_Function_bool Function
-%1133 = OpVariable %_ptr_Function_uchar Function
-%1134 = OpVariable %_ptr_Function_uchar Function
-%1135 = OpVariable %_ptr_Function_uchar Function
-%1136 = OpVariable %_ptr_Function_bool Function
-%1137 = OpVariable %_ptr_Function_uchar Function
-%1138 = OpVariable %_ptr_Function_uchar Function
-%1139 = OpVariable %_ptr_Function_uchar Function
-%1140 = OpVariable %_ptr_Function_bool Function
-%1141 = OpVariable %_ptr_Function_uchar Function
-%1142 = OpVariable %_ptr_Function_uchar Function
-%1143 = OpVariable %_ptr_Function_uchar Function
-%1144 = OpVariable %_ptr_Function_bool Function
-%1145 = OpVariable %_ptr_Function_uchar Function
-%1146 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1147 = OpVariable %_ptr_Function_uchar Function
-%1148 = OpVariable %_ptr_Function_uchar Function
-%1149 = OpVariable %_ptr_Function_bool Function
-%1150 = OpVariable %_ptr_Function_uchar Function
-%1151 = OpVariable %_ptr_Function_uchar Function
-%1152 = OpVariable %_ptr_Function_uchar Function
-%1153 = OpVariable %_ptr_Function_bool Function
-%1154 = OpVariable %_ptr_Function_uchar Function
-%1155 = OpVariable %_ptr_Function_uchar Function
-%1156 = OpVariable %_ptr_Function_uchar Function
-%1157 = OpVariable %_ptr_Function_bool Function
-%1158 = OpVariable %_ptr_Function_uchar Function
-%1159 = OpVariable %_ptr_Function_uchar Function
-%1160 = OpVariable %_ptr_Function_uchar Function
-%1161 = OpVariable %_ptr_Function_bool Function
-%1162 = OpVariable %_ptr_Function_uchar Function
-%1163 = OpVariable %_ptr_Function_uchar Function
-%1164 = OpVariable %_ptr_Function_uchar Function
-%1165 = OpVariable %_ptr_Function_bool Function
-%1166 = OpVariable %_ptr_Function_uchar Function
-%1167 = OpVariable %_ptr_Function_uchar Function
-%1168 = OpVariable %_ptr_Function_uchar Function
-%1169 = OpVariable %_ptr_Function_bool Function
-%1170 = OpVariable %_ptr_Function_uchar Function
-%1171 = OpVariable %_ptr_Function_uchar Function
-%1172 = OpVariable %_ptr_Function_uchar Function
-%1173 = OpVariable %_ptr_Function_bool Function
-%1174 = OpVariable %_ptr_Function_uchar Function
-%1175 = OpVariable %_ptr_Function_uchar Function
-%1176 = OpVariable %_ptr_Function_uchar Function
-%1177 = OpVariable %_ptr_Function_bool Function
-%1178 = OpVariable %_ptr_Function_uchar Function
-%1179 = OpVariable %_ptr_Function_uchar Function
-%1180 = OpVariable %_ptr_Function_uchar Function
-%1181 = OpVariable %_ptr_Function_bool Function
-%1182 = OpVariable %_ptr_Function_uchar Function
-%1183 = OpVariable %_ptr_Function_uchar Function
-%1184 = OpVariable %_ptr_Function_uchar Function
-%1185 = OpVariable %_ptr_Function_bool Function
-%1186 = OpVariable %_ptr_Function_uchar Function
-%1187 = OpVariable %_ptr_Function_uchar Function
-%1188 = OpVariable %_ptr_Function_uchar Function
-%1189 = OpVariable %_ptr_Function_bool Function
-%1190 = OpVariable %_ptr_Function_uchar Function
-%1191 = OpVariable %_ptr_Function_uchar Function
-%1192 = OpVariable %_ptr_Function_uchar Function
-%1193 = OpVariable %_ptr_Function_bool Function
-%1194 = OpVariable %_ptr_Function_uchar Function
-%1195 = OpVariable %_ptr_Function_uchar Function
-%1196 = OpVariable %_ptr_Function_uchar Function
-%1197 = OpVariable %_ptr_Function_bool Function
-%1198 = OpVariable %_ptr_Function_uchar Function
-%1199 = OpVariable %_ptr_Function_uchar Function
-%1200 = OpVariable %_ptr_Function_uchar Function
-%1201 = OpVariable %_ptr_Function_bool Function
-%1202 = OpVariable %_ptr_Function_uchar Function
-%1203 = OpVariable %_ptr_Function_uchar Function
-%1204 = OpVariable %_ptr_Function_uchar Function
-%1205 = OpVariable %_ptr_Function_bool Function
-%1206 = OpVariable %_ptr_Function_uchar Function
-%1207 = OpVariable %_ptr_Function_uchar Function
-%1208 = OpVariable %_ptr_Function_uchar Function
-%1209 = OpVariable %_ptr_Function_bool Function
-%1210 = OpVariable %_ptr_Function_uchar Function
-%1211 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1212 = OpVariable %_ptr_Function_uchar Function
-%1213 = OpVariable %_ptr_Function_uchar Function
-%1214 = OpVariable %_ptr_Function_uchar Function
-%1215 = OpVariable %_ptr_Function_uchar Function
-%1216 = OpVariable %_ptr_Function_uchar Function
-%1217 = OpVariable %_ptr_Function_uchar Function
-%1218 = OpVariable %_ptr_Function_uchar Function
-%1219 = OpVariable %_ptr_Function_uchar Function
-%1220 = OpVariable %_ptr_Function_uchar Function
-%1221 = OpVariable %_ptr_Function_uchar Function
-%1222 = OpVariable %_ptr_Function_uchar Function
-%1223 = OpVariable %_ptr_Function_uchar Function
-%1224 = OpVariable %_ptr_Function_uchar Function
-%1225 = OpVariable %_ptr_Function_uchar Function
-%1226 = OpVariable %_ptr_Function_uchar Function
-%1227 = OpVariable %_ptr_Function_uchar Function
-%1228 = OpVariable %_ptr_Function_uchar Function
-%1229 = OpVariable %_ptr_Function_uchar Function
-%1230 = OpVariable %_ptr_Function_uchar Function
-%1231 = OpVariable %_ptr_Function_uchar Function
-%1232 = OpVariable %_ptr_Function_uchar Function
-%1233 = OpVariable %_ptr_Function_uchar Function
-%1234 = OpVariable %_ptr_Function_uchar Function
-%1235 = OpVariable %_ptr_Function_uchar Function
-%1236 = OpVariable %_ptr_Function_uchar Function
-%1237 = OpVariable %_ptr_Function_uchar Function
-%1238 = OpVariable %_ptr_Function_uchar Function
-%1239 = OpVariable %_ptr_Function_uchar Function
-%1240 = OpVariable %_ptr_Function_uchar Function
-%1241 = OpVariable %_ptr_Function_uchar Function
-%1242 = OpVariable %_ptr_Function_uchar Function
-%1243 = OpVariable %_ptr_Function_uchar Function
-%1244 = OpVariable %_ptr_Function_uchar Function
-%1245 = OpVariable %_ptr_Function_uchar Function
-%1246 = OpVariable %_ptr_Function_uchar Function
-%1247 = OpVariable %_ptr_Function_uchar Function
-%1248 = OpVariable %_ptr_Function_uchar Function
-%1249 = OpVariable %_ptr_Function_uchar Function
-%1250 = OpVariable %_ptr_Function_uchar Function
-%1251 = OpVariable %_ptr_Function_uchar Function
-%1252 = OpVariable %_ptr_Function_uchar Function
-%1253 = OpVariable %_ptr_Function_uchar Function
-%1254 = OpVariable %_ptr_Function_uchar Function
-%1255 = OpVariable %_ptr_Function_uchar Function
-%1256 = OpVariable %_ptr_Function_uchar Function
-%1257 = OpVariable %_ptr_Function_uchar Function
-%1258 = OpVariable %_ptr_Function_uchar Function
-%1259 = OpVariable %_ptr_Function_uchar Function
-%1260 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%753 = OpVariable %_ptr_Function_ulong Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_ulong Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+OpStore %741 %722
+OpStore %743 %723
+%769 = OpLoad %_arr_ushort_uint_8 %743
+%770 = OpCompositeExtract %ushort %769 0
+OpStore %745 %770
+OpBranch %725
+%725 = OpLabel
+%771 = OpLoad %ushort %745
+%772 = OpUConvert %ulong %771
+OpStore %753 %772
+%773 = OpLoad %ulong %741
+%774 = OpLoad %ulong %753
+%775 = OpFunctionCall %ulong %7 %773 %774
+OpStore %754 %775
+OpBranch %726
+%726 = OpLabel
+%776 = OpLoad %_arr_ushort_uint_8 %743
+%777 = OpCompositeExtract %ushort %776 1
+OpStore %746 %777
+OpBranch %727
+%727 = OpLabel
+%778 = OpLoad %ushort %746
+%779 = OpUConvert %ulong %778
+OpStore %755 %779
+%780 = OpLoad %ulong %754
+%781 = OpLoad %ulong %755
+%782 = OpFunctionCall %ulong %7 %780 %781
+OpStore %756 %782
+OpBranch %728
+%728 = OpLabel
+%783 = OpLoad %_arr_ushort_uint_8 %743
+%784 = OpCompositeExtract %ushort %783 2
+OpStore %747 %784
+OpBranch %729
+%729 = OpLabel
+%785 = OpLoad %ushort %747
+%786 = OpUConvert %ulong %785
+OpStore %757 %786
+%787 = OpLoad %ulong %756
+%788 = OpLoad %ulong %757
+%789 = OpFunctionCall %ulong %7 %787 %788
+OpStore %758 %789
+OpBranch %730
+%730 = OpLabel
+%790 = OpLoad %_arr_ushort_uint_8 %743
+%791 = OpCompositeExtract %ushort %790 3
+OpStore %748 %791
+OpBranch %731
+%731 = OpLabel
+%792 = OpLoad %ushort %748
+%793 = OpUConvert %ulong %792
+OpStore %759 %793
+%794 = OpLoad %ulong %758
+%795 = OpLoad %ulong %759
+%796 = OpFunctionCall %ulong %7 %794 %795
+OpStore %760 %796
+OpBranch %732
+%732 = OpLabel
+%797 = OpLoad %_arr_ushort_uint_8 %743
+%798 = OpCompositeExtract %ushort %797 4
+OpStore %749 %798
+OpBranch %733
+%733 = OpLabel
+%799 = OpLoad %ushort %749
+%800 = OpUConvert %ulong %799
+OpStore %761 %800
+%801 = OpLoad %ulong %760
+%802 = OpLoad %ulong %761
+%803 = OpFunctionCall %ulong %7 %801 %802
+OpStore %762 %803
+OpBranch %734
+%734 = OpLabel
+%804 = OpLoad %_arr_ushort_uint_8 %743
+%805 = OpCompositeExtract %ushort %804 5
+OpStore %750 %805
+OpBranch %735
+%735 = OpLabel
+%806 = OpLoad %ushort %750
+%807 = OpUConvert %ulong %806
+OpStore %763 %807
+%808 = OpLoad %ulong %762
+%809 = OpLoad %ulong %763
+%810 = OpFunctionCall %ulong %7 %808 %809
+OpStore %764 %810
+OpBranch %736
+%736 = OpLabel
+%811 = OpLoad %_arr_ushort_uint_8 %743
+%812 = OpCompositeExtract %ushort %811 6
+OpStore %751 %812
+OpBranch %737
+%737 = OpLabel
+%813 = OpLoad %ushort %751
+%814 = OpUConvert %ulong %813
+OpStore %765 %814
+%815 = OpLoad %ulong %764
+%816 = OpLoad %ulong %765
+%817 = OpFunctionCall %ulong %7 %815 %816
+OpStore %766 %817
+OpBranch %738
+%738 = OpLabel
+%818 = OpLoad %_arr_ushort_uint_8 %743
+%819 = OpCompositeExtract %ushort %818 7
+OpStore %752 %819
+OpBranch %739
+%739 = OpLabel
+%820 = OpLoad %ushort %752
+%821 = OpUConvert %ulong %820
+OpStore %767 %821
+%822 = OpLoad %ulong %766
+%823 = OpLoad %ulong %767
+%824 = OpFunctionCall %ulong %7 %822 %823
+OpStore %768 %824
+OpBranch %740
+%740 = OpLabel
+%825 = OpLoad %ulong %768
+OpReturnValue %825
+OpFunctionEnd
+%3 = OpFunction %ulong None %827
+%828 = OpFunctionParameter %ulong
+%829 = OpFunctionParameter %v4uint
+%830 = OpLabel
+%839 = OpVariable %_ptr_Function_ulong Function
+%841 = OpVariable %_ptr_Function_v4uint Function
+%843 = OpVariable %_ptr_Function_uint Function
+%844 = OpVariable %_ptr_Function_uint Function
+%845 = OpVariable %_ptr_Function_uint Function
+%846 = OpVariable %_ptr_Function_uint Function
+%847 = OpVariable %_ptr_Function_ulong Function
+%848 = OpVariable %_ptr_Function_ulong Function
+%849 = OpVariable %_ptr_Function_ulong Function
+%850 = OpVariable %_ptr_Function_ulong Function
+%851 = OpVariable %_ptr_Function_ulong Function
+%852 = OpVariable %_ptr_Function_ulong Function
+%853 = OpVariable %_ptr_Function_ulong Function
+%854 = OpVariable %_ptr_Function_ulong Function
+OpStore %839 %828
+OpStore %841 %829
+%855 = OpLoad %v4uint %841
+%856 = OpCompositeExtract %uint %855 0
+OpStore %843 %856
+OpBranch %831
+%831 = OpLabel
+%857 = OpLoad %uint %843
+%858 = OpUConvert %ulong %857
+OpStore %847 %858
+%859 = OpLoad %ulong %839
+%860 = OpLoad %ulong %847
+%861 = OpFunctionCall %ulong %7 %859 %860
+OpStore %848 %861
+OpBranch %832
+%832 = OpLabel
+%862 = OpLoad %v4uint %841
+%863 = OpCompositeExtract %uint %862 1
+OpStore %844 %863
+OpBranch %833
+%833 = OpLabel
+%864 = OpLoad %uint %844
+%865 = OpUConvert %ulong %864
+OpStore %849 %865
+%866 = OpLoad %ulong %848
+%867 = OpLoad %ulong %849
+%868 = OpFunctionCall %ulong %7 %866 %867
+OpStore %850 %868
+OpBranch %834
+%834 = OpLabel
+%869 = OpLoad %v4uint %841
+%870 = OpCompositeExtract %uint %869 2
+OpStore %845 %870
+OpBranch %835
+%835 = OpLabel
+%871 = OpLoad %uint %845
+%872 = OpUConvert %ulong %871
+OpStore %851 %872
+%873 = OpLoad %ulong %850
+%874 = OpLoad %ulong %851
+%875 = OpFunctionCall %ulong %7 %873 %874
+OpStore %852 %875
+OpBranch %836
+%836 = OpLabel
+%876 = OpLoad %v4uint %841
+%877 = OpCompositeExtract %uint %876 3
+OpStore %846 %877
+OpBranch %837
+%837 = OpLabel
+%878 = OpLoad %uint %846
+%879 = OpUConvert %ulong %878
+OpStore %853 %879
+%880 = OpLoad %ulong %852
+%881 = OpLoad %ulong %853
+%882 = OpFunctionCall %ulong %7 %880 %881
+OpStore %854 %882
+OpBranch %838
+%838 = OpLabel
+%883 = OpLoad %ulong %854
+OpReturnValue %883
+OpFunctionEnd
+%4 = OpFunction %ulong None %885
+%886 = OpFunctionParameter %ulong
+%887 = OpFunctionParameter %v2ulong
+%888 = OpLabel
+%889 = OpVariable %_ptr_Function_ulong Function
+%891 = OpVariable %_ptr_Function_v2ulong Function
+%892 = OpVariable %_ptr_Function_ulong Function
+%893 = OpVariable %_ptr_Function_ulong Function
+%894 = OpVariable %_ptr_Function_ulong Function
+%895 = OpVariable %_ptr_Function_ulong Function
+OpStore %889 %886
+OpStore %891 %887
+%896 = OpLoad %v2ulong %891
+%897 = OpCompositeExtract %ulong %896 0
+OpStore %892 %897
+%898 = OpLoad %ulong %889
+%899 = OpLoad %ulong %892
+%900 = OpFunctionCall %ulong %7 %898 %899
+OpStore %893 %900
+%901 = OpLoad %v2ulong %891
+%902 = OpCompositeExtract %ulong %901 1
+OpStore %894 %902
+%903 = OpLoad %ulong %893
+%904 = OpLoad %ulong %894
+%905 = OpFunctionCall %ulong %7 %903 %904
+OpStore %895 %905
+%906 = OpLoad %ulong %895
+OpReturnValue %906
+OpFunctionEnd
+%5 = OpFunction %ulong None %909
+%910 = OpFunctionParameter %ulong
+%911 = OpFunctionParameter %v4float
+%912 = OpLabel
+%921 = OpVariable %_ptr_Function_ulong Function
+%923 = OpVariable %_ptr_Function_v4float Function
+%925 = OpVariable %_ptr_Function_float Function
+%926 = OpVariable %_ptr_Function_float Function
+%927 = OpVariable %_ptr_Function_float Function
+%928 = OpVariable %_ptr_Function_float Function
+%929 = OpVariable %_ptr_Function_uint Function
+%930 = OpVariable %_ptr_Function_ulong Function
+%931 = OpVariable %_ptr_Function_ulong Function
+%932 = OpVariable %_ptr_Function_uint Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_ulong Function
+%935 = OpVariable %_ptr_Function_uint Function
+%936 = OpVariable %_ptr_Function_ulong Function
+%937 = OpVariable %_ptr_Function_ulong Function
+%938 = OpVariable %_ptr_Function_uint Function
+%939 = OpVariable %_ptr_Function_ulong Function
+%940 = OpVariable %_ptr_Function_ulong Function
+OpStore %921 %910
+OpStore %923 %911
+%941 = OpLoad %v4float %923
+%942 = OpCompositeExtract %float %941 0
+OpStore %925 %942
+OpBranch %913
+%913 = OpLabel
+%943 = OpLoad %float %925
+%944 = OpBitcast %uint %943
+OpStore %929 %944
+%945 = OpLoad %uint %929
+%946 = OpUConvert %ulong %945
+OpStore %930 %946
+%947 = OpLoad %ulong %921
+%948 = OpLoad %ulong %930
+%949 = OpFunctionCall %ulong %7 %947 %948
+OpStore %931 %949
+OpBranch %914
+%914 = OpLabel
+%950 = OpLoad %v4float %923
+%951 = OpCompositeExtract %float %950 1
+OpStore %926 %951
+OpBranch %915
+%915 = OpLabel
+%952 = OpLoad %float %926
+%953 = OpBitcast %uint %952
+OpStore %932 %953
+%954 = OpLoad %uint %932
+%955 = OpUConvert %ulong %954
+OpStore %933 %955
+%956 = OpLoad %ulong %931
+%957 = OpLoad %ulong %933
+%958 = OpFunctionCall %ulong %7 %956 %957
+OpStore %934 %958
+OpBranch %916
+%916 = OpLabel
+%959 = OpLoad %v4float %923
+%960 = OpCompositeExtract %float %959 2
+OpStore %927 %960
+OpBranch %917
+%917 = OpLabel
+%961 = OpLoad %float %927
+%962 = OpBitcast %uint %961
+OpStore %935 %962
+%963 = OpLoad %uint %935
+%964 = OpUConvert %ulong %963
+OpStore %936 %964
+%965 = OpLoad %ulong %934
+%966 = OpLoad %ulong %936
+%967 = OpFunctionCall %ulong %7 %965 %966
+OpStore %937 %967
+OpBranch %918
+%918 = OpLabel
+%968 = OpLoad %v4float %923
+%969 = OpCompositeExtract %float %968 3
+OpStore %928 %969
+OpBranch %919
+%919 = OpLabel
+%970 = OpLoad %float %928
+%971 = OpBitcast %uint %970
+OpStore %938 %971
+%972 = OpLoad %uint %938
+%973 = OpUConvert %ulong %972
+OpStore %939 %973
+%974 = OpLoad %ulong %937
+%975 = OpLoad %ulong %939
+%976 = OpFunctionCall %ulong %7 %974 %975
+OpStore %940 %976
+OpBranch %920
+%920 = OpLabel
+%977 = OpLoad %ulong %940
+OpReturnValue %977
+OpFunctionEnd
+%6 = OpFunction %ulong None %978
+%979 = OpFunctionParameter %ulong
+%980 = OpLabel
+%1153 = OpVariable %_ptr_Function_ulong Function
+%1154 = OpVariable %_ptr_Function_uint Function
+%1155 = OpVariable %_ptr_Function_float Function
+%1156 = OpVariable %_ptr_Function_ushort Function
+%1157 = OpVariable %_ptr_Function_uchar Function
+%1158 = OpVariable %_ptr_Function_v4uint Function
+%1159 = OpVariable %_ptr_Function_v4uint Function
+%1160 = OpVariable %_ptr_Function_uint Function
+%1161 = OpVariable %_ptr_Function_uint Function
+%1162 = OpVariable %_ptr_Function_v4uint Function
+%1163 = OpVariable %_ptr_Function_uint Function
+%1164 = OpVariable %_ptr_Function_uint Function
+%1165 = OpVariable %_ptr_Function_v4uint Function
+%1166 = OpVariable %_ptr_Function_v4uint Function
+%1167 = OpVariable %_ptr_Function_v4uint Function
+%1168 = OpVariable %_ptr_Function_v4uint Function
+%1169 = OpVariable %_ptr_Function_v4uint Function
+%1170 = OpVariable %_ptr_Function_v4uint Function
+%1171 = OpVariable %_ptr_Function_v4uint Function
+%1172 = OpVariable %_ptr_Function_v4uint Function
+%1173 = OpVariable %_ptr_Function_v4uint Function
+%1174 = OpVariable %_ptr_Function_v4uint Function
+%1175 = OpVariable %_ptr_Function_v4uint Function
+%1176 = OpVariable %_ptr_Function_v4uint Function
+%1177 = OpVariable %_ptr_Function_v4uint Function
+%1178 = OpVariable %_ptr_Function_v4uint Function
+%1179 = OpVariable %_ptr_Function_v4uint Function
+%1180 = OpVariable %_ptr_Function_v4uint Function
+%1181 = OpVariable %_ptr_Function_v4uint Function
+%1182 = OpVariable %_ptr_Function_v4uint Function
+%1183 = OpVariable %_ptr_Function_v4uint Function
+%1184 = OpVariable %_ptr_Function_v4uint Function
+%1185 = OpVariable %_ptr_Function_v4uint Function
+%1186 = OpVariable %_ptr_Function_v4uint Function
+%1187 = OpVariable %_ptr_Function_v4uint Function
+%1188 = OpVariable %_ptr_Function_uint Function
+%1189 = OpVariable %_ptr_Function_uint Function
+%1190 = OpVariable %_ptr_Function_v4uint Function
+%1191 = OpVariable %_ptr_Function_uint Function
+%1192 = OpVariable %_ptr_Function_uint Function
+%1193 = OpVariable %_ptr_Function_v4uint Function
+%1194 = OpVariable %_ptr_Function_v4uint Function
+%1195 = OpVariable %_ptr_Function_v4uint Function
+%1196 = OpVariable %_ptr_Function_v4uint Function
+%1197 = OpVariable %_ptr_Function_v4uint Function
+%1198 = OpVariable %_ptr_Function_v4uint Function
+%1199 = OpVariable %_ptr_Function_v4uint Function
+%1200 = OpVariable %_ptr_Function_float Function
+%1201 = OpVariable %_ptr_Function_float Function
+%1202 = OpVariable %_ptr_Function_v4float Function
+%1203 = OpVariable %_ptr_Function_float Function
+%1204 = OpVariable %_ptr_Function_v4float Function
+%1205 = OpVariable %_ptr_Function_float Function
+%1206 = OpVariable %_ptr_Function_float Function
+%1207 = OpVariable %_ptr_Function_v4float Function
+%1208 = OpVariable %_ptr_Function_ulong Function
+%1209 = OpVariable %_ptr_Function_ulong Function
+%1210 = OpVariable %_ptr_Function_v4uint Function
+%1211 = OpVariable %_ptr_Function_ulong Function
+%1212 = OpVariable %_ptr_Function_v4uint Function
+%1213 = OpVariable %_ptr_Function_ulong Function
+%1214 = OpVariable %_ptr_Function_v4uint Function
+%1215 = OpVariable %_ptr_Function_ulong Function
+%1216 = OpVariable %_ptr_Function_v4uint Function
+%1217 = OpVariable %_ptr_Function_ulong Function
+%1218 = OpVariable %_ptr_Function_v4uint Function
+%1219 = OpVariable %_ptr_Function_ulong Function
+%1220 = OpVariable %_ptr_Function_v4uint Function
+%1221 = OpVariable %_ptr_Function_ulong Function
+%1222 = OpVariable %_ptr_Function_v4uint Function
+%1223 = OpVariable %_ptr_Function_v4uint Function
+%1224 = OpVariable %_ptr_Function_v4uint Function
+%1225 = OpVariable %_ptr_Function_v4uint Function
+%1226 = OpVariable %_ptr_Function_v4uint Function
+%1227 = OpVariable %_ptr_Function_v4uint Function
+%1228 = OpVariable %_ptr_Function_v4float Function
+%1229 = OpVariable %_ptr_Function_v4uint Function
+%1230 = OpVariable %_ptr_Function_v4uint Function
+%1231 = OpVariable %_ptr_Function_v4uint Function
+%1232 = OpVariable %_ptr_Function_v4float Function
+%1233 = OpVariable %_ptr_Function_ulong Function
+%1234 = OpVariable %_ptr_Function_ulong Function
+%1235 = OpVariable %_ptr_Function_v4float Function
+%1236 = OpVariable %_ptr_Function_ulong Function
+%1238 = OpVariable %_ptr_Function_v2double Function
+%1239 = OpVariable %_ptr_Function_v2double Function
+%1241 = OpVariable %_ptr_Function_double Function
+%1242 = OpVariable %_ptr_Function_double Function
+%1243 = OpVariable %_ptr_Function_double Function
+%1244 = OpVariable %_ptr_Function_v2double Function
+%1245 = OpVariable %_ptr_Function_v2ulong Function
+%1246 = OpVariable %_ptr_Function_v2ulong Function
+%1247 = OpVariable %_ptr_Function_v2ulong Function
+%1248 = OpVariable %_ptr_Function_v2ulong Function
+%1249 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1250 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1251 = OpVariable %_ptr_Function_ushort Function
+%1252 = OpVariable %_ptr_Function_ushort Function
+%1253 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1254 = OpVariable %_ptr_Function_ushort Function
+%1255 = OpVariable %_ptr_Function_ushort Function
+%1256 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1257 = OpVariable %_ptr_Function_ulong Function
+%1258 = OpVariable %_ptr_Function_ulong Function
+%1259 = OpVariable %_ptr_Function_ulong Function
+%1260 = OpVariable %_ptr_Function_ulong Function
 %1261 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1263 = OpVariable %_ptr_Function_uchar Function
+%1264 = OpVariable %_ptr_Function_uchar Function
 %1265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1266 = OpVariable %_ptr_Function_uchar Function
+%1267 = OpVariable %_ptr_Function_uchar Function
 %1268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1270 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1271 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1272 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1273 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1274 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1275 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1276 = OpVariable %_ptr_Function_uchar Function
-%1277 = OpVariable %_ptr_Function_uchar Function
-%1278 = OpVariable %_ptr_Function_uchar Function
-%1279 = OpVariable %_ptr_Function_uchar Function
-%1280 = OpVariable %_ptr_Function_uchar Function
-%1281 = OpVariable %_ptr_Function_uchar Function
-%1282 = OpVariable %_ptr_Function_uchar Function
-%1283 = OpVariable %_ptr_Function_uchar Function
-%1284 = OpVariable %_ptr_Function_uchar Function
-%1285 = OpVariable %_ptr_Function_uchar Function
-%1286 = OpVariable %_ptr_Function_uchar Function
-%1287 = OpVariable %_ptr_Function_uchar Function
-%1288 = OpVariable %_ptr_Function_uchar Function
-%1289 = OpVariable %_ptr_Function_uchar Function
-%1290 = OpVariable %_ptr_Function_uchar Function
-%1291 = OpVariable %_ptr_Function_uchar Function
-%1292 = OpVariable %_ptr_Function_uchar Function
-%1293 = OpVariable %_ptr_Function_uchar Function
-%1294 = OpVariable %_ptr_Function_uchar Function
-%1295 = OpVariable %_ptr_Function_uchar Function
-%1296 = OpVariable %_ptr_Function_uchar Function
-%1297 = OpVariable %_ptr_Function_uchar Function
-%1298 = OpVariable %_ptr_Function_uchar Function
-%1299 = OpVariable %_ptr_Function_uchar Function
-%1300 = OpVariable %_ptr_Function_uchar Function
-%1301 = OpVariable %_ptr_Function_uchar Function
-%1302 = OpVariable %_ptr_Function_uchar Function
-%1303 = OpVariable %_ptr_Function_uchar Function
-%1304 = OpVariable %_ptr_Function_uchar Function
-%1305 = OpVariable %_ptr_Function_uchar Function
-%1306 = OpVariable %_ptr_Function_uchar Function
-%1307 = OpVariable %_ptr_Function_uchar Function
-%1308 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1309 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1310 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1311 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1312 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1313 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1314 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1315 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1316 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1317 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1318 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1319 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1320 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1321 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1322 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1323 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1324 = OpVariable %_ptr_Function_uchar Function
-%1325 = OpVariable %_ptr_Function_uchar Function
-%1326 = OpVariable %_ptr_Function_uchar Function
-%1327 = OpVariable %_ptr_Function_uchar Function
-%1328 = OpVariable %_ptr_Function_uchar Function
-%1329 = OpVariable %_ptr_Function_uchar Function
-%1330 = OpVariable %_ptr_Function_uchar Function
-%1331 = OpVariable %_ptr_Function_uchar Function
-%1332 = OpVariable %_ptr_Function_uchar Function
-%1333 = OpVariable %_ptr_Function_uchar Function
-%1334 = OpVariable %_ptr_Function_uchar Function
-%1335 = OpVariable %_ptr_Function_uchar Function
-%1336 = OpVariable %_ptr_Function_uchar Function
-%1337 = OpVariable %_ptr_Function_uchar Function
-%1338 = OpVariable %_ptr_Function_uchar Function
-%1339 = OpVariable %_ptr_Function_uchar Function
-%1340 = OpVariable %_ptr_Function_uchar Function
-%1341 = OpVariable %_ptr_Function_uchar Function
-%1342 = OpVariable %_ptr_Function_uchar Function
-%1343 = OpVariable %_ptr_Function_uchar Function
-%1344 = OpVariable %_ptr_Function_uchar Function
-%1345 = OpVariable %_ptr_Function_uchar Function
-%1346 = OpVariable %_ptr_Function_uchar Function
-%1347 = OpVariable %_ptr_Function_uchar Function
-%1348 = OpVariable %_ptr_Function_uchar Function
-%1349 = OpVariable %_ptr_Function_uchar Function
-%1350 = OpVariable %_ptr_Function_uchar Function
-%1351 = OpVariable %_ptr_Function_uchar Function
-%1352 = OpVariable %_ptr_Function_uchar Function
-%1353 = OpVariable %_ptr_Function_uchar Function
-%1354 = OpVariable %_ptr_Function_uchar Function
-%1355 = OpVariable %_ptr_Function_uchar Function
-%1356 = OpVariable %_ptr_Function_uchar Function
-%1357 = OpVariable %_ptr_Function_uchar Function
-%1358 = OpVariable %_ptr_Function_uchar Function
-%1359 = OpVariable %_ptr_Function_uchar Function
-%1360 = OpVariable %_ptr_Function_uchar Function
-%1361 = OpVariable %_ptr_Function_uchar Function
-%1362 = OpVariable %_ptr_Function_uchar Function
-%1363 = OpVariable %_ptr_Function_uchar Function
-%1364 = OpVariable %_ptr_Function_uchar Function
-%1365 = OpVariable %_ptr_Function_uchar Function
-%1366 = OpVariable %_ptr_Function_uchar Function
-%1367 = OpVariable %_ptr_Function_uchar Function
-%1368 = OpVariable %_ptr_Function_uchar Function
-%1369 = OpVariable %_ptr_Function_uchar Function
-%1370 = OpVariable %_ptr_Function_uchar Function
-%1371 = OpVariable %_ptr_Function_uchar Function
-%1372 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1373 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1374 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1375 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1376 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1377 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1378 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1379 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1380 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1381 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1382 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1383 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1384 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1385 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1386 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1387 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1388 = OpVariable %_ptr_Function_uchar Function
-%1389 = OpVariable %_ptr_Function_uchar Function
-%1390 = OpVariable %_ptr_Function_uchar Function
-%1391 = OpVariable %_ptr_Function_uchar Function
-%1392 = OpVariable %_ptr_Function_uchar Function
-%1393 = OpVariable %_ptr_Function_uchar Function
-%1394 = OpVariable %_ptr_Function_uchar Function
-%1395 = OpVariable %_ptr_Function_uchar Function
-%1396 = OpVariable %_ptr_Function_uchar Function
-%1397 = OpVariable %_ptr_Function_uchar Function
-%1398 = OpVariable %_ptr_Function_uchar Function
-%1399 = OpVariable %_ptr_Function_uchar Function
-%1400 = OpVariable %_ptr_Function_uchar Function
-%1401 = OpVariable %_ptr_Function_uchar Function
-%1402 = OpVariable %_ptr_Function_uchar Function
-%1403 = OpVariable %_ptr_Function_uchar Function
-%1404 = OpVariable %_ptr_Function_uchar Function
-%1405 = OpVariable %_ptr_Function_uchar Function
-%1406 = OpVariable %_ptr_Function_uchar Function
-%1407 = OpVariable %_ptr_Function_uchar Function
-%1408 = OpVariable %_ptr_Function_uchar Function
-%1409 = OpVariable %_ptr_Function_uchar Function
-%1410 = OpVariable %_ptr_Function_uchar Function
-%1411 = OpVariable %_ptr_Function_uchar Function
-%1412 = OpVariable %_ptr_Function_uchar Function
-%1413 = OpVariable %_ptr_Function_uchar Function
-%1414 = OpVariable %_ptr_Function_uchar Function
-%1415 = OpVariable %_ptr_Function_uchar Function
-%1416 = OpVariable %_ptr_Function_uchar Function
-%1417 = OpVariable %_ptr_Function_uchar Function
-%1418 = OpVariable %_ptr_Function_uchar Function
-%1419 = OpVariable %_ptr_Function_uchar Function
-%1420 = OpVariable %_ptr_Function_uchar Function
-%1421 = OpVariable %_ptr_Function_uchar Function
-%1422 = OpVariable %_ptr_Function_uchar Function
-%1423 = OpVariable %_ptr_Function_uchar Function
-%1424 = OpVariable %_ptr_Function_uchar Function
-%1425 = OpVariable %_ptr_Function_uchar Function
-%1426 = OpVariable %_ptr_Function_uchar Function
-%1427 = OpVariable %_ptr_Function_uchar Function
-%1428 = OpVariable %_ptr_Function_uchar Function
-%1429 = OpVariable %_ptr_Function_uchar Function
-%1430 = OpVariable %_ptr_Function_uchar Function
-%1431 = OpVariable %_ptr_Function_uchar Function
-%1432 = OpVariable %_ptr_Function_uchar Function
-%1433 = OpVariable %_ptr_Function_uchar Function
-%1434 = OpVariable %_ptr_Function_uchar Function
-%1435 = OpVariable %_ptr_Function_uchar Function
-%1436 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1437 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1438 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1439 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1440 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1441 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1442 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1443 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1444 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1445 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1446 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1447 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1448 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1449 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1450 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1451 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-OpStore %372 %309
-%1452 = OpFunctionCall %ulong %7
-OpStore %373 %1452
-%1453 = OpLoad %ulong %372
-%1454 = OpUConvert %uint %1453
-OpStore %374 %1454
-%1455 = OpLoad %ulong %372
-%1456 = OpConvertUToF %float %1455
-OpStore %375 %1456
-%1457 = OpLoad %ulong %372
-%1458 = OpUConvert %ushort %1457
-OpStore %376 %1458
-%1459 = OpLoad %ulong %372
-%1460 = OpUConvert %uchar %1459
-OpStore %377 %1460
-%1461 = OpCompositeConstruct %v4uint %uint_10 %uint_20 %uint_30 %uint_4294967295
-OpStore %378 %1461
-%1466 = OpCompositeConstruct %v4uint %uint_20 %uint_20 %uint_10 %uint_1
-OpStore %379 %1466
-%1468 = OpLoad %v4uint %378
-%1469 = OpCompositeExtract %uint %1468 0
-OpStore %380 %1469
-%1470 = OpLoad %uint %380
-%1471 = OpLoad %uint %374
-%1472 = OpIAdd %uint %1470 %1471
-OpStore %381 %1472
-%1473 = OpLoad %v4uint %378
-%1474 = OpLoad %uint %381
-%1475 = OpCompositeInsert %v4uint %1474 %1473 0
-OpStore %382 %1475
-%1476 = OpLoad %v4uint %379
-%1477 = OpCompositeExtract %uint %1476 3
-OpStore %383 %1477
-%1478 = OpLoad %uint %383
-%1479 = OpLoad %uint %374
-%1480 = OpIAdd %uint %1478 %1479
-OpStore %384 %1480
-%1481 = OpLoad %v4uint %379
-%1482 = OpLoad %uint %384
-%1483 = OpCompositeInsert %v4uint %1482 %1481 3
-OpStore %385 %1483
-%1485 = OpLoad %v4uint %382
-%1486 = OpLoad %v4uint %385
-%1487 = OpULessThan %v4bool %1485 %1486
-%1491 = OpSelect %v4uint %1487 %1488 %1490
-OpStore %386 %1491
-OpBranch %311
-%311 = OpLabel
-%1492 = OpLoad %v4uint %386
-%1493 = OpCompositeExtract %uint %1492 0
-OpStore %484 %1493
-%1494 = OpLoad %ulong %373
-%1495 = OpLoad %uint %484
-%1496 = OpFunctionCall %ulong %11 %1494 %1495
-OpStore %485 %1496
-%1497 = OpLoad %v4uint %386
-%1498 = OpCompositeExtract %uint %1497 1
-OpStore %486 %1498
-%1499 = OpLoad %ulong %485
-%1500 = OpLoad %uint %486
-%1501 = OpFunctionCall %ulong %11 %1499 %1500
-OpStore %487 %1501
-%1502 = OpLoad %v4uint %386
-%1503 = OpCompositeExtract %uint %1502 2
-OpStore %488 %1503
-%1504 = OpLoad %ulong %487
-%1505 = OpLoad %uint %488
-%1506 = OpFunctionCall %ulong %11 %1504 %1505
-OpStore %489 %1506
-%1507 = OpLoad %v4uint %386
-%1508 = OpCompositeExtract %uint %1507 3
-OpStore %490 %1508
-%1509 = OpLoad %ulong %489
-%1510 = OpLoad %uint %490
-%1511 = OpFunctionCall %ulong %11 %1509 %1510
-OpStore %491 %1511
-OpBranch %312
-%312 = OpLabel
-%1512 = OpLoad %v4uint %385
-%1513 = OpLoad %v4uint %382
-%1514 = OpULessThan %v4bool %1512 %1513
-%1515 = OpSelect %v4uint %1514 %1488 %1490
-OpStore %387 %1515
-OpBranch %313
-%313 = OpLabel
-%1516 = OpLoad %v4uint %387
-%1517 = OpCompositeExtract %uint %1516 0
-OpStore %492 %1517
-%1518 = OpLoad %ulong %491
-%1519 = OpLoad %uint %492
-%1520 = OpFunctionCall %ulong %11 %1518 %1519
-OpStore %493 %1520
-%1521 = OpLoad %v4uint %387
-%1522 = OpCompositeExtract %uint %1521 1
-OpStore %494 %1522
-%1523 = OpLoad %ulong %493
-%1524 = OpLoad %uint %494
-%1525 = OpFunctionCall %ulong %11 %1523 %1524
-OpStore %495 %1525
-%1526 = OpLoad %v4uint %387
-%1527 = OpCompositeExtract %uint %1526 2
-OpStore %496 %1527
-%1528 = OpLoad %ulong %495
-%1529 = OpLoad %uint %496
-%1530 = OpFunctionCall %ulong %11 %1528 %1529
-OpStore %497 %1530
-%1531 = OpLoad %v4uint %387
-%1532 = OpCompositeExtract %uint %1531 3
-OpStore %498 %1532
-%1533 = OpLoad %ulong %497
-%1534 = OpLoad %uint %498
-%1535 = OpFunctionCall %ulong %11 %1533 %1534
-OpStore %499 %1535
-OpBranch %314
-%314 = OpLabel
-%1536 = OpLoad %v4uint %382
-%1537 = OpLoad %v4uint %385
-%1538 = OpIEqual %v4bool %1536 %1537
-%1539 = OpSelect %v4uint %1538 %1488 %1490
-OpStore %388 %1539
-OpBranch %315
-%315 = OpLabel
-%1540 = OpLoad %v4uint %388
-%1541 = OpCompositeExtract %uint %1540 0
-OpStore %500 %1541
-%1542 = OpLoad %ulong %499
-%1543 = OpLoad %uint %500
-%1544 = OpFunctionCall %ulong %11 %1542 %1543
-OpStore %501 %1544
-%1545 = OpLoad %v4uint %388
-%1546 = OpCompositeExtract %uint %1545 1
-OpStore %502 %1546
-%1547 = OpLoad %ulong %501
-%1548 = OpLoad %uint %502
-%1549 = OpFunctionCall %ulong %11 %1547 %1548
-OpStore %503 %1549
-%1550 = OpLoad %v4uint %388
-%1551 = OpCompositeExtract %uint %1550 2
-OpStore %504 %1551
-%1552 = OpLoad %ulong %503
-%1553 = OpLoad %uint %504
-%1554 = OpFunctionCall %ulong %11 %1552 %1553
-OpStore %505 %1554
-%1555 = OpLoad %v4uint %388
-%1556 = OpCompositeExtract %uint %1555 3
-OpStore %506 %1556
-%1557 = OpLoad %ulong %505
-%1558 = OpLoad %uint %506
-%1559 = OpFunctionCall %ulong %11 %1557 %1558
-OpStore %507 %1559
-OpBranch %316
-%316 = OpLabel
-%1560 = OpLoad %v4uint %382
-%1561 = OpLoad %v4uint %385
-%1562 = OpINotEqual %v4bool %1560 %1561
-%1563 = OpSelect %v4uint %1562 %1488 %1490
-OpStore %389 %1563
-OpBranch %317
-%317 = OpLabel
-%1564 = OpLoad %v4uint %389
-%1565 = OpCompositeExtract %uint %1564 0
-OpStore %508 %1565
-%1566 = OpLoad %ulong %507
-%1567 = OpLoad %uint %508
-%1568 = OpFunctionCall %ulong %11 %1566 %1567
-OpStore %509 %1568
-%1569 = OpLoad %v4uint %389
-%1570 = OpCompositeExtract %uint %1569 1
-OpStore %510 %1570
-%1571 = OpLoad %ulong %509
-%1572 = OpLoad %uint %510
-%1573 = OpFunctionCall %ulong %11 %1571 %1572
-OpStore %511 %1573
-%1574 = OpLoad %v4uint %389
-%1575 = OpCompositeExtract %uint %1574 2
-OpStore %512 %1575
-%1576 = OpLoad %ulong %511
-%1577 = OpLoad %uint %512
-%1578 = OpFunctionCall %ulong %11 %1576 %1577
-OpStore %513 %1578
-%1579 = OpLoad %v4uint %389
-%1580 = OpCompositeExtract %uint %1579 3
-OpStore %514 %1580
-%1581 = OpLoad %ulong %513
-%1582 = OpLoad %uint %514
-%1583 = OpFunctionCall %ulong %11 %1581 %1582
-OpStore %515 %1583
-OpBranch %318
-%318 = OpLabel
-%1584 = OpLoad %v4uint %382
-%1585 = OpLoad %v4uint %385
-%1586 = OpULessThanEqual %v4bool %1584 %1585
-%1587 = OpSelect %v4uint %1586 %1488 %1490
-OpStore %390 %1587
-OpBranch %319
-%319 = OpLabel
-%1588 = OpLoad %v4uint %390
-%1589 = OpCompositeExtract %uint %1588 0
-OpStore %516 %1589
-%1590 = OpLoad %ulong %515
-%1591 = OpLoad %uint %516
-%1592 = OpFunctionCall %ulong %11 %1590 %1591
-OpStore %517 %1592
-%1593 = OpLoad %v4uint %390
-%1594 = OpCompositeExtract %uint %1593 1
-OpStore %518 %1594
-%1595 = OpLoad %ulong %517
-%1596 = OpLoad %uint %518
-%1597 = OpFunctionCall %ulong %11 %1595 %1596
-OpStore %519 %1597
-%1598 = OpLoad %v4uint %390
-%1599 = OpCompositeExtract %uint %1598 2
-OpStore %520 %1599
-%1600 = OpLoad %ulong %519
-%1601 = OpLoad %uint %520
-%1602 = OpFunctionCall %ulong %11 %1600 %1601
-OpStore %521 %1602
-%1603 = OpLoad %v4uint %390
-%1604 = OpCompositeExtract %uint %1603 3
-OpStore %522 %1604
-%1605 = OpLoad %ulong %521
-%1606 = OpLoad %uint %522
-%1607 = OpFunctionCall %ulong %11 %1605 %1606
-OpStore %523 %1607
-OpBranch %320
-%320 = OpLabel
-%1608 = OpLoad %v4uint %385
-%1609 = OpLoad %v4uint %382
-%1610 = OpULessThanEqual %v4bool %1608 %1609
-%1611 = OpSelect %v4uint %1610 %1488 %1490
-OpStore %391 %1611
-OpBranch %321
-%321 = OpLabel
-%1612 = OpLoad %v4uint %391
-%1613 = OpCompositeExtract %uint %1612 0
-OpStore %524 %1613
-%1614 = OpLoad %ulong %523
-%1615 = OpLoad %uint %524
-%1616 = OpFunctionCall %ulong %11 %1614 %1615
-OpStore %525 %1616
-%1617 = OpLoad %v4uint %391
-%1618 = OpCompositeExtract %uint %1617 1
-OpStore %526 %1618
-%1619 = OpLoad %ulong %525
-%1620 = OpLoad %uint %526
-%1621 = OpFunctionCall %ulong %11 %1619 %1620
-OpStore %527 %1621
-%1622 = OpLoad %v4uint %391
-%1623 = OpCompositeExtract %uint %1622 2
-OpStore %528 %1623
-%1624 = OpLoad %ulong %527
-%1625 = OpLoad %uint %528
-%1626 = OpFunctionCall %ulong %11 %1624 %1625
-OpStore %529 %1626
-%1627 = OpLoad %v4uint %391
-%1628 = OpCompositeExtract %uint %1627 3
-OpStore %530 %1628
-%1629 = OpLoad %ulong %529
-%1630 = OpLoad %uint %530
-%1631 = OpFunctionCall %ulong %11 %1629 %1630
-OpStore %531 %1631
-OpBranch %322
-%322 = OpLabel
-%1632 = OpLoad %v4uint %382
-%1633 = OpLoad %v4uint %385
-%1634 = OpULessThan %v4bool %1632 %1633
-%1635 = OpSelect %v4uint %1634 %1488 %1490
-OpStore %392 %1635
-%1636 = OpLoad %v4uint %392
-%1637 = OpLoad %v4uint %382
-%1638 = OpBitwiseAnd %v4uint %1636 %1637
-OpStore %393 %1638
-%1639 = OpLoad %v4uint %392
-%1640 = OpNot %v4uint %1639
-OpStore %394 %1640
-%1641 = OpLoad %v4uint %394
-%1642 = OpLoad %v4uint %385
-%1643 = OpBitwiseAnd %v4uint %1641 %1642
-OpStore %395 %1643
-%1644 = OpLoad %v4uint %393
-%1645 = OpLoad %v4uint %395
-%1646 = OpBitwiseOr %v4uint %1644 %1645
-OpStore %396 %1646
-OpBranch %323
-%323 = OpLabel
-%1647 = OpLoad %v4uint %396
-%1648 = OpCompositeExtract %uint %1647 0
-OpStore %532 %1648
-%1649 = OpLoad %ulong %531
-%1650 = OpLoad %uint %532
-%1651 = OpFunctionCall %ulong %11 %1649 %1650
-OpStore %533 %1651
-%1652 = OpLoad %v4uint %396
-%1653 = OpCompositeExtract %uint %1652 1
-OpStore %534 %1653
-%1654 = OpLoad %ulong %533
-%1655 = OpLoad %uint %534
-%1656 = OpFunctionCall %ulong %11 %1654 %1655
-OpStore %535 %1656
-%1657 = OpLoad %v4uint %396
-%1658 = OpCompositeExtract %uint %1657 2
-OpStore %536 %1658
-%1659 = OpLoad %ulong %535
-%1660 = OpLoad %uint %536
-%1661 = OpFunctionCall %ulong %11 %1659 %1660
-OpStore %537 %1661
-%1662 = OpLoad %v4uint %396
-%1663 = OpCompositeExtract %uint %1662 3
-OpStore %538 %1663
-%1664 = OpLoad %ulong %537
-%1665 = OpLoad %uint %538
-%1666 = OpFunctionCall %ulong %11 %1664 %1665
-OpStore %539 %1666
-OpBranch %324
-%324 = OpLabel
-%1667 = OpLoad %v4uint %392
-%1668 = OpLoad %v4uint %385
-%1669 = OpBitwiseAnd %v4uint %1667 %1668
-OpStore %397 %1669
-%1670 = OpLoad %v4uint %392
-%1671 = OpNot %v4uint %1670
-OpStore %398 %1671
-%1672 = OpLoad %v4uint %398
-%1673 = OpLoad %v4uint %382
-%1674 = OpBitwiseAnd %v4uint %1672 %1673
-OpStore %399 %1674
-%1675 = OpLoad %v4uint %397
-%1676 = OpLoad %v4uint %399
-%1677 = OpBitwiseOr %v4uint %1675 %1676
-OpStore %400 %1677
-OpBranch %325
-%325 = OpLabel
-%1678 = OpLoad %v4uint %400
-%1679 = OpCompositeExtract %uint %1678 0
-OpStore %540 %1679
-%1680 = OpLoad %ulong %539
-%1681 = OpLoad %uint %540
-%1682 = OpFunctionCall %ulong %11 %1680 %1681
-OpStore %541 %1682
-%1683 = OpLoad %v4uint %400
-%1684 = OpCompositeExtract %uint %1683 1
-OpStore %542 %1684
-%1685 = OpLoad %ulong %541
-%1686 = OpLoad %uint %542
-%1687 = OpFunctionCall %ulong %11 %1685 %1686
-OpStore %543 %1687
-%1688 = OpLoad %v4uint %400
-%1689 = OpCompositeExtract %uint %1688 2
-OpStore %544 %1689
-%1690 = OpLoad %ulong %543
-%1691 = OpLoad %uint %544
-%1692 = OpFunctionCall %ulong %11 %1690 %1691
-OpStore %545 %1692
-%1693 = OpLoad %v4uint %400
-%1694 = OpCompositeExtract %uint %1693 3
-OpStore %546 %1694
-%1695 = OpLoad %ulong %545
-%1696 = OpLoad %uint %546
-%1697 = OpFunctionCall %ulong %11 %1695 %1696
-OpStore %547 %1697
-OpBranch %326
-%326 = OpLabel
-%1698 = OpLoad %v4uint %382
-%1699 = OpLoad %v4uint %385
-%1700 = OpIAdd %v4uint %1698 %1699
-OpStore %401 %1700
-%1701 = OpLoad %v4uint %392
-%1702 = OpLoad %v4uint %401
-%1703 = OpBitwiseAnd %v4uint %1701 %1702
-OpStore %402 %1703
-OpBranch %327
-%327 = OpLabel
-%1704 = OpLoad %v4uint %402
-%1705 = OpCompositeExtract %uint %1704 0
-OpStore %548 %1705
-%1706 = OpLoad %ulong %547
-%1707 = OpLoad %uint %548
-%1708 = OpFunctionCall %ulong %11 %1706 %1707
-OpStore %549 %1708
-%1709 = OpLoad %v4uint %402
-%1710 = OpCompositeExtract %uint %1709 1
-OpStore %550 %1710
-%1711 = OpLoad %ulong %549
-%1712 = OpLoad %uint %550
-%1713 = OpFunctionCall %ulong %11 %1711 %1712
-OpStore %551 %1713
-%1714 = OpLoad %v4uint %402
-%1715 = OpCompositeExtract %uint %1714 2
-OpStore %552 %1715
-%1716 = OpLoad %ulong %551
-%1717 = OpLoad %uint %552
-%1718 = OpFunctionCall %ulong %11 %1716 %1717
-OpStore %553 %1718
-%1719 = OpLoad %v4uint %402
-%1720 = OpCompositeExtract %uint %1719 3
-OpStore %554 %1720
-%1721 = OpLoad %ulong %553
-%1722 = OpLoad %uint %554
-%1723 = OpFunctionCall %ulong %11 %1721 %1722
-OpStore %555 %1723
-OpBranch %328
-%328 = OpLabel
-%1724 = OpLoad %v4uint %392
-%1725 = OpNot %v4uint %1724
-OpStore %403 %1725
-%1726 = OpLoad %v4uint %382
-%1727 = OpLoad %v4uint %385
-%1728 = OpISub %v4uint %1726 %1727
-OpStore %404 %1728
-%1729 = OpLoad %v4uint %403
-%1730 = OpLoad %v4uint %404
-%1731 = OpBitwiseOr %v4uint %1729 %1730
-OpStore %405 %1731
-OpBranch %329
-%329 = OpLabel
-%1732 = OpLoad %v4uint %405
-%1733 = OpCompositeExtract %uint %1732 0
-OpStore %556 %1733
-%1734 = OpLoad %ulong %555
-%1735 = OpLoad %uint %556
-%1736 = OpFunctionCall %ulong %11 %1734 %1735
-OpStore %557 %1736
-%1737 = OpLoad %v4uint %405
-%1738 = OpCompositeExtract %uint %1737 1
-OpStore %558 %1738
-%1739 = OpLoad %ulong %557
-%1740 = OpLoad %uint %558
-%1741 = OpFunctionCall %ulong %11 %1739 %1740
-OpStore %559 %1741
-%1742 = OpLoad %v4uint %405
-%1743 = OpCompositeExtract %uint %1742 2
-OpStore %560 %1743
-%1744 = OpLoad %ulong %559
-%1745 = OpLoad %uint %560
-%1746 = OpFunctionCall %ulong %11 %1744 %1745
-OpStore %561 %1746
-%1747 = OpLoad %v4uint %405
-%1748 = OpCompositeExtract %uint %1747 3
-OpStore %562 %1748
-%1749 = OpLoad %ulong %561
-%1750 = OpLoad %uint %562
-%1751 = OpFunctionCall %ulong %11 %1749 %1750
-OpStore %563 %1751
-OpBranch %330
-%330 = OpLabel
-%1752 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_5 %uint_2294967296 %uint_7
-OpStore %406 %1752
-%1756 = OpCompositeConstruct %v4uint %uint_1 %uint_5 %uint_2000000000 %uint_4294967289
-OpStore %407 %1756
-%1759 = OpLoad %v4uint %406
-%1760 = OpCompositeExtract %uint %1759 0
-OpStore %408 %1760
-%1761 = OpLoad %uint %408
-%1762 = OpLoad %uint %374
-%1763 = OpIAdd %uint %1761 %1762
-OpStore %409 %1763
-%1764 = OpLoad %v4uint %406
-%1765 = OpLoad %uint %409
-%1766 = OpCompositeInsert %v4uint %1765 %1764 0
-OpStore %410 %1766
-%1767 = OpLoad %v4uint %407
-%1768 = OpCompositeExtract %uint %1767 3
-OpStore %411 %1768
-%1769 = OpLoad %uint %411
-%1770 = OpLoad %uint %374
-%1771 = OpIAdd %uint %1769 %1770
-OpStore %412 %1771
-%1772 = OpLoad %v4uint %407
-%1773 = OpLoad %uint %412
-%1774 = OpCompositeInsert %v4uint %1773 %1772 3
-OpStore %413 %1774
-%1775 = OpLoad %v4uint %410
-%1776 = OpLoad %v4uint %413
-%1777 = OpSLessThan %v4bool %1775 %1776
-%1778 = OpSelect %v4uint %1777 %1488 %1490
-OpStore %414 %1778
-OpBranch %331
-%331 = OpLabel
-%1779 = OpLoad %v4uint %414
-%1780 = OpCompositeExtract %uint %1779 0
-OpStore %564 %1780
-%1781 = OpLoad %ulong %563
-%1782 = OpLoad %uint %564
-%1783 = OpFunctionCall %ulong %11 %1781 %1782
-OpStore %565 %1783
-%1784 = OpLoad %v4uint %414
-%1785 = OpCompositeExtract %uint %1784 1
-OpStore %566 %1785
-%1786 = OpLoad %ulong %565
-%1787 = OpLoad %uint %566
-%1788 = OpFunctionCall %ulong %11 %1786 %1787
-OpStore %567 %1788
-%1789 = OpLoad %v4uint %414
-%1790 = OpCompositeExtract %uint %1789 2
-OpStore %568 %1790
-%1791 = OpLoad %ulong %567
-%1792 = OpLoad %uint %568
-%1793 = OpFunctionCall %ulong %11 %1791 %1792
-OpStore %569 %1793
-%1794 = OpLoad %v4uint %414
-%1795 = OpCompositeExtract %uint %1794 3
-OpStore %570 %1795
-%1796 = OpLoad %ulong %569
-%1797 = OpLoad %uint %570
-%1798 = OpFunctionCall %ulong %11 %1796 %1797
-OpStore %571 %1798
-OpBranch %332
-%332 = OpLabel
-%1799 = OpLoad %v4uint %413
-%1800 = OpLoad %v4uint %410
-%1801 = OpSLessThan %v4bool %1799 %1800
-%1802 = OpSelect %v4uint %1801 %1488 %1490
-OpStore %415 %1802
-OpBranch %333
-%333 = OpLabel
-%1803 = OpLoad %v4uint %415
-%1804 = OpCompositeExtract %uint %1803 0
-OpStore %572 %1804
-%1805 = OpLoad %ulong %571
-%1806 = OpLoad %uint %572
-%1807 = OpFunctionCall %ulong %11 %1805 %1806
-OpStore %573 %1807
-%1808 = OpLoad %v4uint %415
-%1809 = OpCompositeExtract %uint %1808 1
-OpStore %574 %1809
-%1810 = OpLoad %ulong %573
-%1811 = OpLoad %uint %574
-%1812 = OpFunctionCall %ulong %11 %1810 %1811
-OpStore %575 %1812
-%1813 = OpLoad %v4uint %415
-%1814 = OpCompositeExtract %uint %1813 2
-OpStore %576 %1814
-%1815 = OpLoad %ulong %575
-%1816 = OpLoad %uint %576
-%1817 = OpFunctionCall %ulong %11 %1815 %1816
-OpStore %577 %1817
-%1818 = OpLoad %v4uint %415
-%1819 = OpCompositeExtract %uint %1818 3
-OpStore %578 %1819
-%1820 = OpLoad %ulong %577
-%1821 = OpLoad %uint %578
-%1822 = OpFunctionCall %ulong %11 %1820 %1821
-OpStore %579 %1822
-OpBranch %334
-%334 = OpLabel
-%1823 = OpLoad %v4uint %410
-%1824 = OpLoad %v4uint %413
-%1825 = OpIEqual %v4bool %1823 %1824
-%1826 = OpSelect %v4uint %1825 %1488 %1490
-OpStore %416 %1826
-OpBranch %335
-%335 = OpLabel
-%1827 = OpLoad %v4uint %416
-%1828 = OpCompositeExtract %uint %1827 0
-OpStore %580 %1828
-%1829 = OpLoad %ulong %579
-%1830 = OpLoad %uint %580
-%1831 = OpFunctionCall %ulong %11 %1829 %1830
-OpStore %581 %1831
-%1832 = OpLoad %v4uint %416
-%1833 = OpCompositeExtract %uint %1832 1
-OpStore %582 %1833
-%1834 = OpLoad %ulong %581
-%1835 = OpLoad %uint %582
-%1836 = OpFunctionCall %ulong %11 %1834 %1835
-OpStore %583 %1836
-%1837 = OpLoad %v4uint %416
-%1838 = OpCompositeExtract %uint %1837 2
-OpStore %584 %1838
-%1839 = OpLoad %ulong %583
-%1840 = OpLoad %uint %584
-%1841 = OpFunctionCall %ulong %11 %1839 %1840
-OpStore %585 %1841
-%1842 = OpLoad %v4uint %416
-%1843 = OpCompositeExtract %uint %1842 3
-OpStore %586 %1843
-%1844 = OpLoad %ulong %585
-%1845 = OpLoad %uint %586
-%1846 = OpFunctionCall %ulong %11 %1844 %1845
-OpStore %587 %1846
-OpBranch %336
-%336 = OpLabel
-%1847 = OpLoad %v4uint %410
-%1848 = OpLoad %v4uint %413
-%1849 = OpINotEqual %v4bool %1847 %1848
-%1850 = OpSelect %v4uint %1849 %1488 %1490
-OpStore %417 %1850
-OpBranch %337
-%337 = OpLabel
-%1851 = OpLoad %v4uint %417
-%1852 = OpCompositeExtract %uint %1851 0
-OpStore %588 %1852
-%1853 = OpLoad %ulong %587
-%1854 = OpLoad %uint %588
-%1855 = OpFunctionCall %ulong %11 %1853 %1854
-OpStore %589 %1855
-%1856 = OpLoad %v4uint %417
-%1857 = OpCompositeExtract %uint %1856 1
-OpStore %590 %1857
-%1858 = OpLoad %ulong %589
-%1859 = OpLoad %uint %590
-%1860 = OpFunctionCall %ulong %11 %1858 %1859
-OpStore %591 %1860
-%1861 = OpLoad %v4uint %417
-%1862 = OpCompositeExtract %uint %1861 2
-OpStore %592 %1862
-%1863 = OpLoad %ulong %591
-%1864 = OpLoad %uint %592
-%1865 = OpFunctionCall %ulong %11 %1863 %1864
-OpStore %593 %1865
-%1866 = OpLoad %v4uint %417
-%1867 = OpCompositeExtract %uint %1866 3
-OpStore %594 %1867
-%1868 = OpLoad %ulong %593
-%1869 = OpLoad %uint %594
-%1870 = OpFunctionCall %ulong %11 %1868 %1869
-OpStore %595 %1870
-OpBranch %338
-%338 = OpLabel
-%1871 = OpLoad %v4uint %410
-%1872 = OpLoad %v4uint %413
-%1873 = OpSLessThanEqual %v4bool %1871 %1872
-%1874 = OpSelect %v4uint %1873 %1488 %1490
-OpStore %418 %1874
-OpBranch %339
-%339 = OpLabel
-%1875 = OpLoad %v4uint %418
-%1876 = OpCompositeExtract %uint %1875 0
-OpStore %596 %1876
-%1877 = OpLoad %ulong %595
-%1878 = OpLoad %uint %596
-%1879 = OpFunctionCall %ulong %11 %1877 %1878
-OpStore %597 %1879
-%1880 = OpLoad %v4uint %418
-%1881 = OpCompositeExtract %uint %1880 1
-OpStore %598 %1881
-%1882 = OpLoad %ulong %597
-%1883 = OpLoad %uint %598
-%1884 = OpFunctionCall %ulong %11 %1882 %1883
-OpStore %599 %1884
-%1885 = OpLoad %v4uint %418
-%1886 = OpCompositeExtract %uint %1885 2
-OpStore %600 %1886
-%1887 = OpLoad %ulong %599
-%1888 = OpLoad %uint %600
-%1889 = OpFunctionCall %ulong %11 %1887 %1888
-OpStore %601 %1889
-%1890 = OpLoad %v4uint %418
-%1891 = OpCompositeExtract %uint %1890 3
-OpStore %602 %1891
-%1892 = OpLoad %ulong %601
-%1893 = OpLoad %uint %602
-%1894 = OpFunctionCall %ulong %11 %1892 %1893
-OpStore %603 %1894
-OpBranch %340
-%340 = OpLabel
-%1895 = OpLoad %v4uint %413
-%1896 = OpLoad %v4uint %410
-%1897 = OpSLessThanEqual %v4bool %1895 %1896
-%1898 = OpSelect %v4uint %1897 %1488 %1490
-OpStore %419 %1898
-OpBranch %341
-%341 = OpLabel
-%1899 = OpLoad %v4uint %419
-%1900 = OpCompositeExtract %uint %1899 0
-OpStore %604 %1900
-%1901 = OpLoad %ulong %603
-%1902 = OpLoad %uint %604
-%1903 = OpFunctionCall %ulong %11 %1901 %1902
-OpStore %605 %1903
-%1904 = OpLoad %v4uint %419
-%1905 = OpCompositeExtract %uint %1904 1
-OpStore %606 %1905
-%1906 = OpLoad %ulong %605
-%1907 = OpLoad %uint %606
-%1908 = OpFunctionCall %ulong %11 %1906 %1907
-OpStore %607 %1908
-%1909 = OpLoad %v4uint %419
-%1910 = OpCompositeExtract %uint %1909 2
-OpStore %608 %1910
-%1911 = OpLoad %ulong %607
-%1912 = OpLoad %uint %608
-%1913 = OpFunctionCall %ulong %11 %1911 %1912
-OpStore %609 %1913
-%1914 = OpLoad %v4uint %419
-%1915 = OpCompositeExtract %uint %1914 3
-OpStore %610 %1915
-%1916 = OpLoad %ulong %609
-%1917 = OpLoad %uint %610
-%1918 = OpFunctionCall %ulong %11 %1916 %1917
-OpStore %611 %1918
-OpBranch %342
-%342 = OpLabel
-%1920 = OpFNegate %float %float_0
-OpStore %420 %1920
-%1922 = OpFNegate %float %float_2
-OpStore %421 %1922
-%1925 = OpLoad %float %420
-%1927 = OpLoad %float %421
-%1923 = OpCompositeConstruct %v4float %float_1_5 %1925 %float_3 %1927
-OpStore %422 %1923
-%1928 = OpFNegate %float %float_3
-OpStore %423 %1928
-%1931 = OpLoad %float %423
-%1929 = OpCompositeConstruct %v4float %float_2_5 %float_0 %float_3 %1931
-OpStore %424 %1929
-%1932 = OpLoad %v4float %422
-%1933 = OpCompositeExtract %float %1932 0
-OpStore %425 %1933
-%1934 = OpLoad %float %425
-%1935 = OpLoad %float %375
-%1936 = OpFAdd %float %1934 %1935
-OpStore %426 %1936
-%1937 = OpLoad %v4float %422
-%1938 = OpLoad %float %426
-%1939 = OpCompositeInsert %v4float %1938 %1937 0
-OpStore %427 %1939
-OpBranch %343
-%343 = OpLabel
-%1940 = OpLoad %v4float %427
-%1941 = OpCompositeExtract %float %1940 0
-OpStore %612 %1941
-%1942 = OpLoad %ulong %611
-%1943 = OpLoad %float %612
-%1944 = OpFunctionCall %ulong %12 %1942 %1943
-OpStore %613 %1944
-%1945 = OpLoad %v4float %427
-%1946 = OpCompositeExtract %float %1945 1
-OpStore %614 %1946
-%1947 = OpLoad %ulong %613
-%1948 = OpLoad %float %614
-%1949 = OpFunctionCall %ulong %12 %1947 %1948
-OpStore %615 %1949
-%1950 = OpLoad %v4float %427
-%1951 = OpCompositeExtract %float %1950 2
-OpStore %616 %1951
-%1952 = OpLoad %ulong %615
-%1953 = OpLoad %float %616
-%1954 = OpFunctionCall %ulong %12 %1952 %1953
-OpStore %617 %1954
-%1955 = OpLoad %v4float %427
-%1956 = OpCompositeExtract %float %1955 3
-OpStore %618 %1956
-%1957 = OpLoad %ulong %617
-%1958 = OpLoad %float %618
-%1959 = OpFunctionCall %ulong %12 %1957 %1958
-OpStore %619 %1959
-OpBranch %344
-%344 = OpLabel
-OpBranch %345
-%345 = OpLabel
-%1960 = OpLoad %v4float %424
-%1961 = OpCompositeExtract %float %1960 0
-OpStore %620 %1961
-%1962 = OpLoad %ulong %619
-%1963 = OpLoad %float %620
-%1964 = OpFunctionCall %ulong %12 %1962 %1963
-OpStore %621 %1964
-%1965 = OpLoad %v4float %424
-%1966 = OpCompositeExtract %float %1965 1
-OpStore %622 %1966
-%1967 = OpLoad %ulong %621
-%1968 = OpLoad %float %622
-%1969 = OpFunctionCall %ulong %12 %1967 %1968
-OpStore %623 %1969
-%1970 = OpLoad %v4float %424
-%1971 = OpCompositeExtract %float %1970 2
-OpStore %624 %1971
-%1972 = OpLoad %ulong %623
-%1973 = OpLoad %float %624
-%1974 = OpFunctionCall %ulong %12 %1972 %1973
-OpStore %625 %1974
-%1975 = OpLoad %v4float %424
-%1976 = OpCompositeExtract %float %1975 3
-OpStore %626 %1976
-%1977 = OpLoad %ulong %625
-%1978 = OpLoad %float %626
-%1979 = OpFunctionCall %ulong %12 %1977 %1978
-OpStore %627 %1979
-OpBranch %346
-%346 = OpLabel
-%1980 = OpLoad %v4float %427
-%1981 = OpLoad %v4float %424
-%1982 = OpFOrdLessThan %v4bool %1980 %1981
-%1983 = OpSelect %v4uint %1982 %1488 %1490
-OpStore %428 %1983
-%1984 = OpLoad %ulong %627
-%1985 = OpLoad %v4uint %428
-%1986 = OpFunctionCall %ulong %3 %1984 %1985
-OpStore %429 %1986
-%1987 = OpLoad %v4float %424
-%1988 = OpLoad %v4float %427
-%1989 = OpFOrdLessThan %v4bool %1987 %1988
-%1990 = OpSelect %v4uint %1989 %1488 %1490
-OpStore %430 %1990
-%1991 = OpLoad %ulong %429
-%1992 = OpLoad %v4uint %430
-%1993 = OpFunctionCall %ulong %3 %1991 %1992
-OpStore %431 %1993
-%1994 = OpLoad %v4float %427
-%1995 = OpLoad %v4float %424
-%1996 = OpFOrdEqual %v4bool %1994 %1995
-%1997 = OpSelect %v4uint %1996 %1488 %1490
-OpStore %432 %1997
-%1998 = OpLoad %ulong %431
-%1999 = OpLoad %v4uint %432
-%2000 = OpFunctionCall %ulong %3 %1998 %1999
-OpStore %433 %2000
-%2001 = OpLoad %v4float %427
-%2002 = OpLoad %v4float %424
-%2003 = OpFUnordNotEqual %v4bool %2001 %2002
-%2004 = OpSelect %v4uint %2003 %1488 %1490
-OpStore %434 %2004
-%2005 = OpLoad %ulong %433
-%2006 = OpLoad %v4uint %434
-%2007 = OpFunctionCall %ulong %3 %2005 %2006
-OpStore %435 %2007
-%2008 = OpLoad %v4float %427
-%2009 = OpLoad %v4float %424
-%2010 = OpFOrdLessThanEqual %v4bool %2008 %2009
-%2011 = OpSelect %v4uint %2010 %1488 %1490
-OpStore %436 %2011
-%2012 = OpLoad %ulong %435
-%2013 = OpLoad %v4uint %436
-%2014 = OpFunctionCall %ulong %3 %2012 %2013
-OpStore %437 %2014
-%2015 = OpLoad %v4float %424
-%2016 = OpLoad %v4float %427
-%2017 = OpFOrdLessThanEqual %v4bool %2015 %2016
-%2018 = OpSelect %v4uint %2017 %1488 %1490
-OpStore %438 %2018
-%2019 = OpLoad %ulong %437
-%2020 = OpLoad %v4uint %438
-%2021 = OpFunctionCall %ulong %3 %2019 %2020
-OpStore %439 %2021
-%2022 = OpLoad %v4float %427
-%2023 = OpBitcast %v4uint %2022
-OpStore %440 %2023
-%2024 = OpLoad %v4uint %428
-%2025 = OpLoad %v4uint %440
-%2026 = OpBitwiseAnd %v4uint %2024 %2025
-OpStore %441 %2026
-%2027 = OpLoad %v4uint %428
-%2028 = OpNot %v4uint %2027
-OpStore %442 %2028
-%2029 = OpLoad %v4float %424
-%2030 = OpBitcast %v4uint %2029
-OpStore %443 %2030
-%2031 = OpLoad %v4uint %442
-%2032 = OpLoad %v4uint %443
-%2033 = OpBitwiseAnd %v4uint %2031 %2032
-OpStore %444 %2033
-%2034 = OpLoad %v4uint %441
-%2035 = OpLoad %v4uint %444
-%2036 = OpBitwiseOr %v4uint %2034 %2035
-OpStore %445 %2036
-%2037 = OpLoad %v4uint %445
-%2038 = OpBitcast %v4float %2037
-OpStore %446 %2038
-%2039 = OpLoad %v4uint %428
-%2040 = OpLoad %v4uint %443
-%2041 = OpBitwiseAnd %v4uint %2039 %2040
-OpStore %447 %2041
-%2042 = OpLoad %v4uint %442
-%2043 = OpLoad %v4uint %440
-%2044 = OpBitwiseAnd %v4uint %2042 %2043
-OpStore %448 %2044
-%2045 = OpLoad %v4uint %447
-%2046 = OpLoad %v4uint %448
-%2047 = OpBitwiseOr %v4uint %2045 %2046
-OpStore %449 %2047
-%2048 = OpLoad %v4uint %449
-%2049 = OpBitcast %v4float %2048
-OpStore %450 %2049
-OpBranch %347
-%347 = OpLabel
-%2050 = OpLoad %v4float %446
-%2051 = OpCompositeExtract %float %2050 0
-OpStore %628 %2051
-%2052 = OpLoad %ulong %439
-%2053 = OpLoad %float %628
-%2054 = OpFunctionCall %ulong %12 %2052 %2053
-OpStore %629 %2054
-%2055 = OpLoad %v4float %446
-%2056 = OpCompositeExtract %float %2055 1
-OpStore %630 %2056
-%2057 = OpLoad %ulong %629
-%2058 = OpLoad %float %630
-%2059 = OpFunctionCall %ulong %12 %2057 %2058
-OpStore %631 %2059
-%2060 = OpLoad %v4float %446
-%2061 = OpCompositeExtract %float %2060 2
-OpStore %632 %2061
-%2062 = OpLoad %ulong %631
-%2063 = OpLoad %float %632
-%2064 = OpFunctionCall %ulong %12 %2062 %2063
-OpStore %633 %2064
-%2065 = OpLoad %v4float %446
-%2066 = OpCompositeExtract %float %2065 3
-OpStore %634 %2066
-%2067 = OpLoad %ulong %633
-%2068 = OpLoad %float %634
-%2069 = OpFunctionCall %ulong %12 %2067 %2068
-OpStore %635 %2069
-OpBranch %348
-%348 = OpLabel
-OpBranch %349
-%349 = OpLabel
-%2070 = OpLoad %v4float %450
-%2071 = OpCompositeExtract %float %2070 0
-OpStore %636 %2071
-%2072 = OpLoad %ulong %635
-%2073 = OpLoad %float %636
-%2074 = OpFunctionCall %ulong %12 %2072 %2073
-OpStore %637 %2074
-%2075 = OpLoad %v4float %450
-%2076 = OpCompositeExtract %float %2075 1
-OpStore %638 %2076
-%2077 = OpLoad %ulong %637
-%2078 = OpLoad %float %638
-%2079 = OpFunctionCall %ulong %12 %2077 %2078
-OpStore %639 %2079
-%2080 = OpLoad %v4float %450
-%2081 = OpCompositeExtract %float %2080 2
-OpStore %640 %2081
-%2082 = OpLoad %ulong %639
-%2083 = OpLoad %float %640
-%2084 = OpFunctionCall %ulong %12 %2082 %2083
-OpStore %641 %2084
-%2085 = OpLoad %v4float %450
-%2086 = OpCompositeExtract %float %2085 3
-OpStore %642 %2086
-%2087 = OpLoad %ulong %641
-%2088 = OpLoad %float %642
-%2089 = OpFunctionCall %ulong %12 %2087 %2088
-OpStore %643 %2089
-OpBranch %350
-%350 = OpLabel
-%2090 = OpLoad %v4float %450
-%2091 = OpLoad %v4float %446
-%2092 = OpFSub %v4float %2090 %2091
-OpStore %451 %2092
-OpBranch %351
-%351 = OpLabel
-%2093 = OpLoad %v4float %451
-%2094 = OpCompositeExtract %float %2093 0
-OpStore %644 %2094
-%2095 = OpLoad %ulong %643
-%2096 = OpLoad %float %644
-%2097 = OpFunctionCall %ulong %12 %2095 %2096
-OpStore %645 %2097
-%2098 = OpLoad %v4float %451
-%2099 = OpCompositeExtract %float %2098 1
-OpStore %646 %2099
-%2100 = OpLoad %ulong %645
-%2101 = OpLoad %float %646
-%2102 = OpFunctionCall %ulong %12 %2100 %2101
-OpStore %647 %2102
-%2103 = OpLoad %v4float %451
-%2104 = OpCompositeExtract %float %2103 2
-OpStore %648 %2104
-%2105 = OpLoad %ulong %647
-%2106 = OpLoad %float %648
-%2107 = OpFunctionCall %ulong %12 %2105 %2106
-OpStore %649 %2107
-%2108 = OpLoad %v4float %451
-%2109 = OpCompositeExtract %float %2108 3
-OpStore %650 %2109
-%2110 = OpLoad %ulong %649
-%2111 = OpLoad %float %650
-%2112 = OpFunctionCall %ulong %12 %2110 %2111
-OpStore %651 %2112
-OpBranch %352
-%352 = OpLabel
-%2113 = OpCompositeConstruct %v2double %double_1_5 %double_n0
-OpStore %453 %2113
-%2116 = OpCompositeConstruct %v2double %double_2_5 %double_0
-OpStore %454 %2116
-%2119 = OpLoad %v2double %453
-%2120 = OpCompositeExtract %double %2119 0
-OpStore %456 %2120
-%2121 = OpLoad %ulong %372
-%2122 = OpConvertUToF %double %2121
-OpStore %457 %2122
-%2123 = OpLoad %double %456
-%2124 = OpLoad %double %457
-%2125 = OpFAdd %double %2123 %2124
-OpStore %458 %2125
-%2126 = OpLoad %v2double %453
-%2127 = OpLoad %double %458
-%2128 = OpCompositeInsert %v2double %2127 %2126 0
-OpStore %459 %2128
-%2130 = OpLoad %v2double %459
-%2131 = OpLoad %v2double %454
-%2132 = OpFOrdLessThan %v2bool %2130 %2131
-%2137 = OpSelect %v2ulong %2132 %2134 %2136
-OpStore %460 %2137
-OpBranch %353
-%353 = OpLabel
-%2138 = OpLoad %v2ulong %460
-%2139 = OpCompositeExtract %ulong %2138 0
-OpStore %652 %2139
-%2140 = OpLoad %ulong %651
-%2141 = OpLoad %ulong %652
-%2142 = OpFunctionCall %ulong %8 %2140 %2141
-OpStore %653 %2142
-%2143 = OpLoad %v2ulong %460
-%2144 = OpCompositeExtract %ulong %2143 1
-OpStore %654 %2144
-%2145 = OpLoad %ulong %653
-%2146 = OpLoad %ulong %654
-%2147 = OpFunctionCall %ulong %8 %2145 %2146
-OpStore %655 %2147
-OpBranch %354
-%354 = OpLabel
-%2148 = OpLoad %v2double %459
-%2149 = OpLoad %v2double %454
-%2150 = OpFOrdEqual %v2bool %2148 %2149
-%2151 = OpSelect %v2ulong %2150 %2134 %2136
-OpStore %461 %2151
-OpBranch %355
-%355 = OpLabel
-%2152 = OpLoad %v2ulong %461
-%2153 = OpCompositeExtract %ulong %2152 0
-OpStore %656 %2153
-%2154 = OpLoad %ulong %655
-%2155 = OpLoad %ulong %656
-%2156 = OpFunctionCall %ulong %8 %2154 %2155
-OpStore %657 %2156
-%2157 = OpLoad %v2ulong %461
-%2158 = OpCompositeExtract %ulong %2157 1
-OpStore %658 %2158
-%2159 = OpLoad %ulong %657
-%2160 = OpLoad %ulong %658
-%2161 = OpFunctionCall %ulong %8 %2159 %2160
-OpStore %659 %2161
-OpBranch %356
-%356 = OpLabel
-%2162 = OpLoad %v2double %459
-%2163 = OpLoad %v2double %454
-%2164 = OpFUnordNotEqual %v2bool %2162 %2163
-%2165 = OpSelect %v2ulong %2164 %2134 %2136
-OpStore %462 %2165
-OpBranch %357
-%357 = OpLabel
-%2166 = OpLoad %v2ulong %462
-%2167 = OpCompositeExtract %ulong %2166 0
-OpStore %660 %2167
-%2168 = OpLoad %ulong %659
-%2169 = OpLoad %ulong %660
-%2170 = OpFunctionCall %ulong %8 %2168 %2169
-OpStore %661 %2170
-%2171 = OpLoad %v2ulong %462
-%2172 = OpCompositeExtract %ulong %2171 1
-OpStore %662 %2172
-%2173 = OpLoad %ulong %661
-%2174 = OpLoad %ulong %662
-%2175 = OpFunctionCall %ulong %8 %2173 %2174
-OpStore %663 %2175
-OpBranch %358
-%358 = OpLabel
-%2176 = OpLoad %v2double %454
-%2177 = OpLoad %v2double %459
-%2178 = OpFOrdLessThanEqual %v2bool %2176 %2177
-%2179 = OpSelect %v2ulong %2178 %2134 %2136
-OpStore %463 %2179
-OpBranch %359
-%359 = OpLabel
-%2180 = OpLoad %v2ulong %463
-%2181 = OpCompositeExtract %ulong %2180 0
-OpStore %664 %2181
-%2182 = OpLoad %ulong %663
-%2183 = OpLoad %ulong %664
-%2184 = OpFunctionCall %ulong %8 %2182 %2183
-OpStore %665 %2184
-%2185 = OpLoad %v2ulong %463
-%2186 = OpCompositeExtract %ulong %2185 1
-OpStore %666 %2186
-%2187 = OpLoad %ulong %665
-%2188 = OpLoad %ulong %666
-%2189 = OpFunctionCall %ulong %8 %2187 %2188
-OpStore %667 %2189
-OpBranch %360
-%360 = OpLabel
-%2190 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_65535 %ushort_32768 %ushort_7 %ushort_7 %ushort_0 %ushort_300 %ushort_65534
-OpStore %464 %2190
-%2198 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_2 %ushort_1 %ushort_32767 %ushort_7 %ushort_8 %ushort_65535 %ushort_300 %ushort_65535
-OpStore %465 %2198
-%2202 = OpLoad %_arr_ushort_uint_8 %464
-%2203 = OpCompositeExtract %ushort %2202 0
-OpStore %466 %2203
-%2204 = OpLoad %ushort %466
-%2205 = OpLoad %ushort %376
-%2206 = OpIAdd %ushort %2204 %2205
-OpStore %467 %2206
-%2207 = OpLoad %_arr_ushort_uint_8 %464
-%2208 = OpLoad %ushort %467
-%2209 = OpCompositeInsert %_arr_ushort_uint_8 %2208 %2207 0
-OpStore %468 %2209
-%2210 = OpLoad %_arr_ushort_uint_8 %465
-%2211 = OpCompositeExtract %ushort %2210 7
-OpStore %469 %2211
-%2212 = OpLoad %ushort %469
-%2213 = OpLoad %ushort %376
-%2214 = OpIAdd %ushort %2212 %2213
-OpStore %470 %2214
-%2215 = OpLoad %_arr_ushort_uint_8 %465
-%2216 = OpLoad %ushort %470
-%2217 = OpCompositeInsert %_arr_ushort_uint_8 %2216 %2215 7
-OpStore %471 %2217
-%2218 = OpLoad %_arr_ushort_uint_8 %468
-%2219 = OpCompositeExtract %ushort %2218 0
-OpStore %732 %2219
-%2220 = OpLoad %_arr_ushort_uint_8 %471
-%2221 = OpCompositeExtract %ushort %2220 0
-OpStore %733 %2221
-%2222 = OpLoad %ushort %732
-%2223 = OpLoad %ushort %733
-%2224 = OpULessThan %bool %2222 %2223
-OpStore %735 %2224
-%2225 = OpLoad %bool %735
-%2228 = OpSelect %uchar %2225 %uchar_1 %uchar_0
-%2229 = OpUConvert %ushort %2228
-OpStore %736 %2229
-%2230 = OpLoad %ushort %736
-%2231 = OpISub %ushort %ushort_0 %2230
-OpStore %737 %2231
-%2232 = OpLoad %_arr_ushort_uint_8 %468
-%2233 = OpCompositeExtract %ushort %2232 1
-OpStore %738 %2233
-%2234 = OpLoad %_arr_ushort_uint_8 %471
-%2235 = OpCompositeExtract %ushort %2234 1
-OpStore %739 %2235
-%2236 = OpLoad %ushort %738
-%2237 = OpLoad %ushort %739
-%2238 = OpULessThan %bool %2236 %2237
-OpStore %740 %2238
-%2239 = OpLoad %bool %740
-%2240 = OpSelect %uchar %2239 %uchar_1 %uchar_0
-%2241 = OpUConvert %ushort %2240
-OpStore %741 %2241
-%2242 = OpLoad %ushort %741
-%2243 = OpISub %ushort %ushort_0 %2242
-OpStore %742 %2243
-%2244 = OpLoad %_arr_ushort_uint_8 %468
-%2245 = OpCompositeExtract %ushort %2244 2
-OpStore %743 %2245
-%2246 = OpLoad %_arr_ushort_uint_8 %471
-%2247 = OpCompositeExtract %ushort %2246 2
-OpStore %744 %2247
-%2248 = OpLoad %ushort %743
-%2249 = OpLoad %ushort %744
-%2250 = OpULessThan %bool %2248 %2249
-OpStore %745 %2250
-%2251 = OpLoad %bool %745
-%2252 = OpSelect %uchar %2251 %uchar_1 %uchar_0
-%2253 = OpUConvert %ushort %2252
-OpStore %746 %2253
-%2254 = OpLoad %ushort %746
-%2255 = OpISub %ushort %ushort_0 %2254
-OpStore %747 %2255
-%2256 = OpLoad %_arr_ushort_uint_8 %468
-%2257 = OpCompositeExtract %ushort %2256 3
-OpStore %748 %2257
-%2258 = OpLoad %_arr_ushort_uint_8 %471
-%2259 = OpCompositeExtract %ushort %2258 3
-OpStore %749 %2259
-%2260 = OpLoad %ushort %748
-%2261 = OpLoad %ushort %749
-%2262 = OpULessThan %bool %2260 %2261
-OpStore %750 %2262
-%2263 = OpLoad %bool %750
-%2264 = OpSelect %uchar %2263 %uchar_1 %uchar_0
-%2265 = OpUConvert %ushort %2264
-OpStore %751 %2265
-%2266 = OpLoad %ushort %751
-%2267 = OpISub %ushort %ushort_0 %2266
-OpStore %752 %2267
-%2268 = OpLoad %_arr_ushort_uint_8 %468
-%2269 = OpCompositeExtract %ushort %2268 4
-OpStore %753 %2269
-%2270 = OpLoad %_arr_ushort_uint_8 %471
-%2271 = OpCompositeExtract %ushort %2270 4
-OpStore %754 %2271
-%2272 = OpLoad %ushort %753
-%2273 = OpLoad %ushort %754
-%2274 = OpULessThan %bool %2272 %2273
-OpStore %755 %2274
-%2275 = OpLoad %bool %755
-%2276 = OpSelect %uchar %2275 %uchar_1 %uchar_0
-%2277 = OpUConvert %ushort %2276
-OpStore %756 %2277
-%2278 = OpLoad %ushort %756
-%2279 = OpISub %ushort %ushort_0 %2278
-OpStore %757 %2279
-%2280 = OpLoad %_arr_ushort_uint_8 %468
-%2281 = OpCompositeExtract %ushort %2280 5
-OpStore %758 %2281
-%2282 = OpLoad %_arr_ushort_uint_8 %471
-%2283 = OpCompositeExtract %ushort %2282 5
-OpStore %759 %2283
-%2284 = OpLoad %ushort %758
-%2285 = OpLoad %ushort %759
-%2286 = OpULessThan %bool %2284 %2285
-OpStore %760 %2286
-%2287 = OpLoad %bool %760
-%2288 = OpSelect %uchar %2287 %uchar_1 %uchar_0
-%2289 = OpUConvert %ushort %2288
-OpStore %761 %2289
-%2290 = OpLoad %ushort %761
-%2291 = OpISub %ushort %ushort_0 %2290
-OpStore %762 %2291
-%2292 = OpLoad %_arr_ushort_uint_8 %468
-%2293 = OpCompositeExtract %ushort %2292 6
-OpStore %763 %2293
-%2294 = OpLoad %_arr_ushort_uint_8 %471
-%2295 = OpCompositeExtract %ushort %2294 6
-OpStore %764 %2295
-%2296 = OpLoad %ushort %763
-%2297 = OpLoad %ushort %764
-%2298 = OpULessThan %bool %2296 %2297
-OpStore %765 %2298
-%2299 = OpLoad %bool %765
-%2300 = OpSelect %uchar %2299 %uchar_1 %uchar_0
-%2301 = OpUConvert %ushort %2300
-OpStore %766 %2301
-%2302 = OpLoad %ushort %766
-%2303 = OpISub %ushort %ushort_0 %2302
-OpStore %767 %2303
-%2304 = OpLoad %_arr_ushort_uint_8 %468
-%2305 = OpCompositeExtract %ushort %2304 7
-OpStore %768 %2305
-%2306 = OpLoad %_arr_ushort_uint_8 %471
-%2307 = OpCompositeExtract %ushort %2306 7
-OpStore %769 %2307
-%2308 = OpLoad %ushort %768
-%2309 = OpLoad %ushort %769
-%2310 = OpULessThan %bool %2308 %2309
-OpStore %770 %2310
-%2311 = OpLoad %bool %770
-%2312 = OpSelect %uchar %2311 %uchar_1 %uchar_0
-%2313 = OpUConvert %ushort %2312
-OpStore %771 %2313
-%2314 = OpLoad %ushort %771
-%2315 = OpISub %ushort %ushort_0 %2314
-OpStore %772 %2315
-%2317 = OpLoad %ushort %737
-%2318 = OpLoad %ushort %742
-%2319 = OpLoad %ushort %747
-%2320 = OpLoad %ushort %752
-%2321 = OpLoad %ushort %757
-%2322 = OpLoad %ushort %762
-%2323 = OpLoad %ushort %767
-%2324 = OpLoad %ushort %772
-%2316 = OpCompositeConstruct %_arr_ushort_uint_8 %2317 %2318 %2319 %2320 %2321 %2322 %2323 %2324
-OpStore %773 %2316
-OpBranch %361
-%361 = OpLabel
-%2325 = OpLoad %_arr_ushort_uint_8 %773
-%2326 = OpCompositeExtract %ushort %2325 0
-OpStore %668 %2326
-%2327 = OpLoad %ulong %667
-%2328 = OpLoad %ushort %668
-%2329 = OpFunctionCall %ulong %10 %2327 %2328
-OpStore %669 %2329
-%2330 = OpLoad %_arr_ushort_uint_8 %773
-%2331 = OpCompositeExtract %ushort %2330 1
-OpStore %670 %2331
-%2332 = OpLoad %ulong %669
-%2333 = OpLoad %ushort %670
-%2334 = OpFunctionCall %ulong %10 %2332 %2333
-OpStore %671 %2334
-%2335 = OpLoad %_arr_ushort_uint_8 %773
-%2336 = OpCompositeExtract %ushort %2335 2
-OpStore %672 %2336
-%2337 = OpLoad %ulong %671
-%2338 = OpLoad %ushort %672
-%2339 = OpFunctionCall %ulong %10 %2337 %2338
-OpStore %673 %2339
-%2340 = OpLoad %_arr_ushort_uint_8 %773
-%2341 = OpCompositeExtract %ushort %2340 3
-OpStore %674 %2341
-%2342 = OpLoad %ulong %673
-%2343 = OpLoad %ushort %674
-%2344 = OpFunctionCall %ulong %10 %2342 %2343
-OpStore %675 %2344
-%2345 = OpLoad %_arr_ushort_uint_8 %773
-%2346 = OpCompositeExtract %ushort %2345 4
-OpStore %676 %2346
-%2347 = OpLoad %ulong %675
-%2348 = OpLoad %ushort %676
-%2349 = OpFunctionCall %ulong %10 %2347 %2348
-OpStore %677 %2349
-%2350 = OpLoad %_arr_ushort_uint_8 %773
-%2351 = OpCompositeExtract %ushort %2350 5
-OpStore %678 %2351
-%2352 = OpLoad %ulong %677
-%2353 = OpLoad %ushort %678
-%2354 = OpFunctionCall %ulong %10 %2352 %2353
-OpStore %679 %2354
-%2355 = OpLoad %_arr_ushort_uint_8 %773
-%2356 = OpCompositeExtract %ushort %2355 6
-OpStore %680 %2356
-%2357 = OpLoad %ulong %679
-%2358 = OpLoad %ushort %680
-%2359 = OpFunctionCall %ulong %10 %2357 %2358
-OpStore %681 %2359
-%2360 = OpLoad %_arr_ushort_uint_8 %773
-%2361 = OpCompositeExtract %ushort %2360 7
-OpStore %682 %2361
-%2362 = OpLoad %ulong %681
-%2363 = OpLoad %ushort %682
-%2364 = OpFunctionCall %ulong %10 %2362 %2363
-OpStore %683 %2364
-OpBranch %362
-%362 = OpLabel
-%2365 = OpLoad %_arr_ushort_uint_8 %468
-%2366 = OpCompositeExtract %ushort %2365 0
-OpStore %774 %2366
-%2367 = OpLoad %_arr_ushort_uint_8 %471
-%2368 = OpCompositeExtract %ushort %2367 0
-OpStore %775 %2368
-%2369 = OpLoad %ushort %774
-%2370 = OpLoad %ushort %775
-%2371 = OpIEqual %bool %2369 %2370
-OpStore %776 %2371
-%2372 = OpLoad %bool %776
-%2373 = OpSelect %uchar %2372 %uchar_1 %uchar_0
-%2374 = OpUConvert %ushort %2373
-OpStore %777 %2374
-%2375 = OpLoad %ushort %777
-%2376 = OpISub %ushort %ushort_0 %2375
-OpStore %778 %2376
-%2377 = OpLoad %_arr_ushort_uint_8 %468
-%2378 = OpCompositeExtract %ushort %2377 1
-OpStore %779 %2378
-%2379 = OpLoad %_arr_ushort_uint_8 %471
-%2380 = OpCompositeExtract %ushort %2379 1
-OpStore %780 %2380
-%2381 = OpLoad %ushort %779
-%2382 = OpLoad %ushort %780
-%2383 = OpIEqual %bool %2381 %2382
-OpStore %781 %2383
-%2384 = OpLoad %bool %781
-%2385 = OpSelect %uchar %2384 %uchar_1 %uchar_0
-%2386 = OpUConvert %ushort %2385
-OpStore %782 %2386
-%2387 = OpLoad %ushort %782
-%2388 = OpISub %ushort %ushort_0 %2387
-OpStore %783 %2388
-%2389 = OpLoad %_arr_ushort_uint_8 %468
-%2390 = OpCompositeExtract %ushort %2389 2
-OpStore %784 %2390
-%2391 = OpLoad %_arr_ushort_uint_8 %471
-%2392 = OpCompositeExtract %ushort %2391 2
-OpStore %785 %2392
-%2393 = OpLoad %ushort %784
-%2394 = OpLoad %ushort %785
-%2395 = OpIEqual %bool %2393 %2394
-OpStore %786 %2395
-%2396 = OpLoad %bool %786
-%2397 = OpSelect %uchar %2396 %uchar_1 %uchar_0
-%2398 = OpUConvert %ushort %2397
-OpStore %787 %2398
-%2399 = OpLoad %ushort %787
-%2400 = OpISub %ushort %ushort_0 %2399
-OpStore %788 %2400
-%2401 = OpLoad %_arr_ushort_uint_8 %468
-%2402 = OpCompositeExtract %ushort %2401 3
-OpStore %789 %2402
-%2403 = OpLoad %_arr_ushort_uint_8 %471
-%2404 = OpCompositeExtract %ushort %2403 3
-OpStore %790 %2404
-%2405 = OpLoad %ushort %789
-%2406 = OpLoad %ushort %790
-%2407 = OpIEqual %bool %2405 %2406
-OpStore %791 %2407
-%2408 = OpLoad %bool %791
-%2409 = OpSelect %uchar %2408 %uchar_1 %uchar_0
-%2410 = OpUConvert %ushort %2409
-OpStore %792 %2410
-%2411 = OpLoad %ushort %792
-%2412 = OpISub %ushort %ushort_0 %2411
-OpStore %793 %2412
-%2413 = OpLoad %_arr_ushort_uint_8 %468
-%2414 = OpCompositeExtract %ushort %2413 4
-OpStore %794 %2414
-%2415 = OpLoad %_arr_ushort_uint_8 %471
-%2416 = OpCompositeExtract %ushort %2415 4
-OpStore %795 %2416
-%2417 = OpLoad %ushort %794
-%2418 = OpLoad %ushort %795
-%2419 = OpIEqual %bool %2417 %2418
-OpStore %796 %2419
-%2420 = OpLoad %bool %796
-%2421 = OpSelect %uchar %2420 %uchar_1 %uchar_0
-%2422 = OpUConvert %ushort %2421
-OpStore %797 %2422
-%2423 = OpLoad %ushort %797
-%2424 = OpISub %ushort %ushort_0 %2423
-OpStore %798 %2424
-%2425 = OpLoad %_arr_ushort_uint_8 %468
-%2426 = OpCompositeExtract %ushort %2425 5
-OpStore %799 %2426
-%2427 = OpLoad %_arr_ushort_uint_8 %471
-%2428 = OpCompositeExtract %ushort %2427 5
-OpStore %800 %2428
-%2429 = OpLoad %ushort %799
-%2430 = OpLoad %ushort %800
-%2431 = OpIEqual %bool %2429 %2430
-OpStore %801 %2431
-%2432 = OpLoad %bool %801
-%2433 = OpSelect %uchar %2432 %uchar_1 %uchar_0
-%2434 = OpUConvert %ushort %2433
-OpStore %802 %2434
-%2435 = OpLoad %ushort %802
-%2436 = OpISub %ushort %ushort_0 %2435
-OpStore %803 %2436
-%2437 = OpLoad %_arr_ushort_uint_8 %468
-%2438 = OpCompositeExtract %ushort %2437 6
-OpStore %804 %2438
-%2439 = OpLoad %_arr_ushort_uint_8 %471
-%2440 = OpCompositeExtract %ushort %2439 6
-OpStore %805 %2440
-%2441 = OpLoad %ushort %804
-%2442 = OpLoad %ushort %805
-%2443 = OpIEqual %bool %2441 %2442
-OpStore %806 %2443
-%2444 = OpLoad %bool %806
-%2445 = OpSelect %uchar %2444 %uchar_1 %uchar_0
-%2446 = OpUConvert %ushort %2445
-OpStore %807 %2446
-%2447 = OpLoad %ushort %807
-%2448 = OpISub %ushort %ushort_0 %2447
-OpStore %808 %2448
-%2449 = OpLoad %_arr_ushort_uint_8 %468
-%2450 = OpCompositeExtract %ushort %2449 7
-OpStore %809 %2450
-%2451 = OpLoad %_arr_ushort_uint_8 %471
-%2452 = OpCompositeExtract %ushort %2451 7
-OpStore %810 %2452
-%2453 = OpLoad %ushort %809
-%2454 = OpLoad %ushort %810
-%2455 = OpIEqual %bool %2453 %2454
-OpStore %811 %2455
-%2456 = OpLoad %bool %811
-%2457 = OpSelect %uchar %2456 %uchar_1 %uchar_0
-%2458 = OpUConvert %ushort %2457
-OpStore %812 %2458
-%2459 = OpLoad %ushort %812
-%2460 = OpISub %ushort %ushort_0 %2459
-OpStore %813 %2460
-%2462 = OpLoad %ushort %778
-%2463 = OpLoad %ushort %783
-%2464 = OpLoad %ushort %788
-%2465 = OpLoad %ushort %793
-%2466 = OpLoad %ushort %798
-%2467 = OpLoad %ushort %803
-%2468 = OpLoad %ushort %808
-%2469 = OpLoad %ushort %813
-%2461 = OpCompositeConstruct %_arr_ushort_uint_8 %2462 %2463 %2464 %2465 %2466 %2467 %2468 %2469
-OpStore %814 %2461
-OpBranch %363
-%363 = OpLabel
-%2470 = OpLoad %_arr_ushort_uint_8 %814
-%2471 = OpCompositeExtract %ushort %2470 0
-OpStore %684 %2471
-%2472 = OpLoad %ulong %683
-%2473 = OpLoad %ushort %684
-%2474 = OpFunctionCall %ulong %10 %2472 %2473
-OpStore %685 %2474
-%2475 = OpLoad %_arr_ushort_uint_8 %814
-%2476 = OpCompositeExtract %ushort %2475 1
-OpStore %686 %2476
-%2477 = OpLoad %ulong %685
-%2478 = OpLoad %ushort %686
-%2479 = OpFunctionCall %ulong %10 %2477 %2478
-OpStore %687 %2479
-%2480 = OpLoad %_arr_ushort_uint_8 %814
-%2481 = OpCompositeExtract %ushort %2480 2
-OpStore %688 %2481
-%2482 = OpLoad %ulong %687
-%2483 = OpLoad %ushort %688
-%2484 = OpFunctionCall %ulong %10 %2482 %2483
-OpStore %689 %2484
-%2485 = OpLoad %_arr_ushort_uint_8 %814
-%2486 = OpCompositeExtract %ushort %2485 3
-OpStore %690 %2486
-%2487 = OpLoad %ulong %689
-%2488 = OpLoad %ushort %690
-%2489 = OpFunctionCall %ulong %10 %2487 %2488
-OpStore %691 %2489
-%2490 = OpLoad %_arr_ushort_uint_8 %814
-%2491 = OpCompositeExtract %ushort %2490 4
-OpStore %692 %2491
-%2492 = OpLoad %ulong %691
-%2493 = OpLoad %ushort %692
-%2494 = OpFunctionCall %ulong %10 %2492 %2493
-OpStore %693 %2494
-%2495 = OpLoad %_arr_ushort_uint_8 %814
-%2496 = OpCompositeExtract %ushort %2495 5
-OpStore %694 %2496
-%2497 = OpLoad %ulong %693
-%2498 = OpLoad %ushort %694
-%2499 = OpFunctionCall %ulong %10 %2497 %2498
-OpStore %695 %2499
-%2500 = OpLoad %_arr_ushort_uint_8 %814
-%2501 = OpCompositeExtract %ushort %2500 6
-OpStore %696 %2501
-%2502 = OpLoad %ulong %695
-%2503 = OpLoad %ushort %696
-%2504 = OpFunctionCall %ulong %10 %2502 %2503
-OpStore %697 %2504
-%2505 = OpLoad %_arr_ushort_uint_8 %814
-%2506 = OpCompositeExtract %ushort %2505 7
-OpStore %698 %2506
-%2507 = OpLoad %ulong %697
-%2508 = OpLoad %ushort %698
-%2509 = OpFunctionCall %ulong %10 %2507 %2508
-OpStore %699 %2509
-OpBranch %364
-%364 = OpLabel
-%2510 = OpLoad %_arr_ushort_uint_8 %471
-%2511 = OpCompositeExtract %ushort %2510 0
-OpStore %815 %2511
-%2512 = OpLoad %_arr_ushort_uint_8 %468
-%2513 = OpCompositeExtract %ushort %2512 0
-OpStore %816 %2513
-%2514 = OpLoad %ushort %815
-%2515 = OpLoad %ushort %816
-%2516 = OpULessThan %bool %2514 %2515
-OpStore %817 %2516
-%2517 = OpLoad %bool %817
-%2518 = OpSelect %uchar %2517 %uchar_1 %uchar_0
-%2519 = OpUConvert %ushort %2518
-OpStore %818 %2519
-%2520 = OpLoad %ushort %818
-%2521 = OpISub %ushort %ushort_0 %2520
-OpStore %819 %2521
-%2522 = OpLoad %_arr_ushort_uint_8 %471
-%2523 = OpCompositeExtract %ushort %2522 1
-OpStore %820 %2523
-%2524 = OpLoad %_arr_ushort_uint_8 %468
-%2525 = OpCompositeExtract %ushort %2524 1
-OpStore %821 %2525
-%2526 = OpLoad %ushort %820
-%2527 = OpLoad %ushort %821
-%2528 = OpULessThan %bool %2526 %2527
-OpStore %822 %2528
-%2529 = OpLoad %bool %822
-%2530 = OpSelect %uchar %2529 %uchar_1 %uchar_0
-%2531 = OpUConvert %ushort %2530
-OpStore %823 %2531
-%2532 = OpLoad %ushort %823
-%2533 = OpISub %ushort %ushort_0 %2532
-OpStore %824 %2533
-%2534 = OpLoad %_arr_ushort_uint_8 %471
-%2535 = OpCompositeExtract %ushort %2534 2
-OpStore %825 %2535
-%2536 = OpLoad %_arr_ushort_uint_8 %468
-%2537 = OpCompositeExtract %ushort %2536 2
-OpStore %826 %2537
-%2538 = OpLoad %ushort %825
-%2539 = OpLoad %ushort %826
-%2540 = OpULessThan %bool %2538 %2539
-OpStore %827 %2540
-%2541 = OpLoad %bool %827
-%2542 = OpSelect %uchar %2541 %uchar_1 %uchar_0
-%2543 = OpUConvert %ushort %2542
-OpStore %828 %2543
-%2544 = OpLoad %ushort %828
-%2545 = OpISub %ushort %ushort_0 %2544
-OpStore %829 %2545
-%2546 = OpLoad %_arr_ushort_uint_8 %471
-%2547 = OpCompositeExtract %ushort %2546 3
-OpStore %830 %2547
-%2548 = OpLoad %_arr_ushort_uint_8 %468
-%2549 = OpCompositeExtract %ushort %2548 3
-OpStore %831 %2549
-%2550 = OpLoad %ushort %830
-%2551 = OpLoad %ushort %831
-%2552 = OpULessThan %bool %2550 %2551
-OpStore %832 %2552
-%2553 = OpLoad %bool %832
-%2554 = OpSelect %uchar %2553 %uchar_1 %uchar_0
-%2555 = OpUConvert %ushort %2554
-OpStore %833 %2555
-%2556 = OpLoad %ushort %833
-%2557 = OpISub %ushort %ushort_0 %2556
-OpStore %834 %2557
-%2558 = OpLoad %_arr_ushort_uint_8 %471
-%2559 = OpCompositeExtract %ushort %2558 4
-OpStore %835 %2559
-%2560 = OpLoad %_arr_ushort_uint_8 %468
-%2561 = OpCompositeExtract %ushort %2560 4
-OpStore %836 %2561
-%2562 = OpLoad %ushort %835
-%2563 = OpLoad %ushort %836
-%2564 = OpULessThan %bool %2562 %2563
-OpStore %837 %2564
-%2565 = OpLoad %bool %837
-%2566 = OpSelect %uchar %2565 %uchar_1 %uchar_0
-%2567 = OpUConvert %ushort %2566
-OpStore %838 %2567
-%2568 = OpLoad %ushort %838
-%2569 = OpISub %ushort %ushort_0 %2568
-OpStore %839 %2569
-%2570 = OpLoad %_arr_ushort_uint_8 %471
-%2571 = OpCompositeExtract %ushort %2570 5
-OpStore %840 %2571
-%2572 = OpLoad %_arr_ushort_uint_8 %468
-%2573 = OpCompositeExtract %ushort %2572 5
-OpStore %841 %2573
-%2574 = OpLoad %ushort %840
-%2575 = OpLoad %ushort %841
-%2576 = OpULessThan %bool %2574 %2575
-OpStore %842 %2576
-%2577 = OpLoad %bool %842
-%2578 = OpSelect %uchar %2577 %uchar_1 %uchar_0
-%2579 = OpUConvert %ushort %2578
-OpStore %843 %2579
-%2580 = OpLoad %ushort %843
-%2581 = OpISub %ushort %ushort_0 %2580
-OpStore %844 %2581
-%2582 = OpLoad %_arr_ushort_uint_8 %471
-%2583 = OpCompositeExtract %ushort %2582 6
-OpStore %845 %2583
-%2584 = OpLoad %_arr_ushort_uint_8 %468
-%2585 = OpCompositeExtract %ushort %2584 6
-OpStore %846 %2585
-%2586 = OpLoad %ushort %845
-%2587 = OpLoad %ushort %846
-%2588 = OpULessThan %bool %2586 %2587
-OpStore %847 %2588
-%2589 = OpLoad %bool %847
-%2590 = OpSelect %uchar %2589 %uchar_1 %uchar_0
-%2591 = OpUConvert %ushort %2590
-OpStore %848 %2591
-%2592 = OpLoad %ushort %848
-%2593 = OpISub %ushort %ushort_0 %2592
-OpStore %849 %2593
-%2594 = OpLoad %_arr_ushort_uint_8 %471
-%2595 = OpCompositeExtract %ushort %2594 7
-OpStore %850 %2595
-%2596 = OpLoad %_arr_ushort_uint_8 %468
-%2597 = OpCompositeExtract %ushort %2596 7
-OpStore %851 %2597
-%2598 = OpLoad %ushort %850
-%2599 = OpLoad %ushort %851
-%2600 = OpULessThan %bool %2598 %2599
-OpStore %852 %2600
-%2601 = OpLoad %bool %852
-%2602 = OpSelect %uchar %2601 %uchar_1 %uchar_0
-%2603 = OpUConvert %ushort %2602
-OpStore %853 %2603
-%2604 = OpLoad %ushort %853
-%2605 = OpISub %ushort %ushort_0 %2604
-OpStore %854 %2605
-%2607 = OpLoad %ushort %819
-%2608 = OpLoad %ushort %824
-%2609 = OpLoad %ushort %829
-%2610 = OpLoad %ushort %834
-%2611 = OpLoad %ushort %839
-%2612 = OpLoad %ushort %844
-%2613 = OpLoad %ushort %849
-%2614 = OpLoad %ushort %854
-%2606 = OpCompositeConstruct %_arr_ushort_uint_8 %2607 %2608 %2609 %2610 %2611 %2612 %2613 %2614
-OpStore %855 %2606
-OpBranch %365
-%365 = OpLabel
-%2615 = OpLoad %_arr_ushort_uint_8 %855
-%2616 = OpCompositeExtract %ushort %2615 0
-OpStore %700 %2616
-%2617 = OpLoad %ulong %699
-%2618 = OpLoad %ushort %700
-%2619 = OpFunctionCall %ulong %10 %2617 %2618
-OpStore %701 %2619
-%2620 = OpLoad %_arr_ushort_uint_8 %855
-%2621 = OpCompositeExtract %ushort %2620 1
-OpStore %702 %2621
-%2622 = OpLoad %ulong %701
-%2623 = OpLoad %ushort %702
-%2624 = OpFunctionCall %ulong %10 %2622 %2623
-OpStore %703 %2624
-%2625 = OpLoad %_arr_ushort_uint_8 %855
-%2626 = OpCompositeExtract %ushort %2625 2
-OpStore %704 %2626
-%2627 = OpLoad %ulong %703
-%2628 = OpLoad %ushort %704
-%2629 = OpFunctionCall %ulong %10 %2627 %2628
-OpStore %705 %2629
-%2630 = OpLoad %_arr_ushort_uint_8 %855
-%2631 = OpCompositeExtract %ushort %2630 3
-OpStore %706 %2631
-%2632 = OpLoad %ulong %705
-%2633 = OpLoad %ushort %706
-%2634 = OpFunctionCall %ulong %10 %2632 %2633
-OpStore %707 %2634
-%2635 = OpLoad %_arr_ushort_uint_8 %855
-%2636 = OpCompositeExtract %ushort %2635 4
-OpStore %708 %2636
-%2637 = OpLoad %ulong %707
-%2638 = OpLoad %ushort %708
-%2639 = OpFunctionCall %ulong %10 %2637 %2638
-OpStore %709 %2639
-%2640 = OpLoad %_arr_ushort_uint_8 %855
-%2641 = OpCompositeExtract %ushort %2640 5
-OpStore %710 %2641
-%2642 = OpLoad %ulong %709
-%2643 = OpLoad %ushort %710
-%2644 = OpFunctionCall %ulong %10 %2642 %2643
-OpStore %711 %2644
-%2645 = OpLoad %_arr_ushort_uint_8 %855
-%2646 = OpCompositeExtract %ushort %2645 6
-OpStore %712 %2646
-%2647 = OpLoad %ulong %711
-%2648 = OpLoad %ushort %712
-%2649 = OpFunctionCall %ulong %10 %2647 %2648
-OpStore %713 %2649
-%2650 = OpLoad %_arr_ushort_uint_8 %855
-%2651 = OpCompositeExtract %ushort %2650 7
-OpStore %714 %2651
-%2652 = OpLoad %ulong %713
-%2653 = OpLoad %ushort %714
-%2654 = OpFunctionCall %ulong %10 %2652 %2653
-OpStore %715 %2654
-OpBranch %366
-%366 = OpLabel
-%2655 = OpLoad %_arr_ushort_uint_8 %468
-%2656 = OpCompositeExtract %ushort %2655 0
-OpStore %856 %2656
-%2657 = OpLoad %_arr_ushort_uint_8 %471
-%2658 = OpCompositeExtract %ushort %2657 0
-OpStore %857 %2658
-%2659 = OpLoad %ushort %856
-%2660 = OpLoad %ushort %857
-%2661 = OpULessThan %bool %2659 %2660
-OpStore %858 %2661
-%2662 = OpLoad %bool %858
-%2663 = OpSelect %uchar %2662 %uchar_1 %uchar_0
-%2664 = OpUConvert %ushort %2663
-OpStore %859 %2664
-%2665 = OpLoad %ushort %859
-%2666 = OpISub %ushort %ushort_0 %2665
-OpStore %860 %2666
-%2667 = OpLoad %_arr_ushort_uint_8 %468
-%2668 = OpCompositeExtract %ushort %2667 1
-OpStore %861 %2668
-%2669 = OpLoad %_arr_ushort_uint_8 %471
-%2670 = OpCompositeExtract %ushort %2669 1
-OpStore %862 %2670
-%2671 = OpLoad %ushort %861
-%2672 = OpLoad %ushort %862
-%2673 = OpULessThan %bool %2671 %2672
-OpStore %863 %2673
-%2674 = OpLoad %bool %863
-%2675 = OpSelect %uchar %2674 %uchar_1 %uchar_0
-%2676 = OpUConvert %ushort %2675
-OpStore %864 %2676
-%2677 = OpLoad %ushort %864
-%2678 = OpISub %ushort %ushort_0 %2677
-OpStore %865 %2678
-%2679 = OpLoad %_arr_ushort_uint_8 %468
-%2680 = OpCompositeExtract %ushort %2679 2
-OpStore %866 %2680
-%2681 = OpLoad %_arr_ushort_uint_8 %471
-%2682 = OpCompositeExtract %ushort %2681 2
-OpStore %867 %2682
-%2683 = OpLoad %ushort %866
-%2684 = OpLoad %ushort %867
-%2685 = OpULessThan %bool %2683 %2684
-OpStore %868 %2685
-%2686 = OpLoad %bool %868
-%2687 = OpSelect %uchar %2686 %uchar_1 %uchar_0
-%2688 = OpUConvert %ushort %2687
-OpStore %869 %2688
-%2689 = OpLoad %ushort %869
-%2690 = OpISub %ushort %ushort_0 %2689
-OpStore %870 %2690
-%2691 = OpLoad %_arr_ushort_uint_8 %468
-%2692 = OpCompositeExtract %ushort %2691 3
-OpStore %871 %2692
-%2693 = OpLoad %_arr_ushort_uint_8 %471
-%2694 = OpCompositeExtract %ushort %2693 3
-OpStore %872 %2694
-%2695 = OpLoad %ushort %871
-%2696 = OpLoad %ushort %872
-%2697 = OpULessThan %bool %2695 %2696
-OpStore %873 %2697
-%2698 = OpLoad %bool %873
-%2699 = OpSelect %uchar %2698 %uchar_1 %uchar_0
-%2700 = OpUConvert %ushort %2699
-OpStore %874 %2700
-%2701 = OpLoad %ushort %874
-%2702 = OpISub %ushort %ushort_0 %2701
-OpStore %875 %2702
-%2703 = OpLoad %_arr_ushort_uint_8 %468
-%2704 = OpCompositeExtract %ushort %2703 4
-OpStore %876 %2704
-%2705 = OpLoad %_arr_ushort_uint_8 %471
-%2706 = OpCompositeExtract %ushort %2705 4
-OpStore %877 %2706
-%2707 = OpLoad %ushort %876
-%2708 = OpLoad %ushort %877
-%2709 = OpULessThan %bool %2707 %2708
-OpStore %878 %2709
-%2710 = OpLoad %bool %878
-%2711 = OpSelect %uchar %2710 %uchar_1 %uchar_0
-%2712 = OpUConvert %ushort %2711
-OpStore %879 %2712
-%2713 = OpLoad %ushort %879
-%2714 = OpISub %ushort %ushort_0 %2713
-OpStore %880 %2714
-%2715 = OpLoad %_arr_ushort_uint_8 %468
-%2716 = OpCompositeExtract %ushort %2715 5
-OpStore %881 %2716
-%2717 = OpLoad %_arr_ushort_uint_8 %471
-%2718 = OpCompositeExtract %ushort %2717 5
-OpStore %882 %2718
-%2719 = OpLoad %ushort %881
-%2720 = OpLoad %ushort %882
-%2721 = OpULessThan %bool %2719 %2720
-OpStore %883 %2721
-%2722 = OpLoad %bool %883
-%2723 = OpSelect %uchar %2722 %uchar_1 %uchar_0
-%2724 = OpUConvert %ushort %2723
-OpStore %884 %2724
-%2725 = OpLoad %ushort %884
-%2726 = OpISub %ushort %ushort_0 %2725
-OpStore %885 %2726
-%2727 = OpLoad %_arr_ushort_uint_8 %468
-%2728 = OpCompositeExtract %ushort %2727 6
-OpStore %886 %2728
-%2729 = OpLoad %_arr_ushort_uint_8 %471
-%2730 = OpCompositeExtract %ushort %2729 6
-OpStore %887 %2730
-%2731 = OpLoad %ushort %886
-%2732 = OpLoad %ushort %887
-%2733 = OpULessThan %bool %2731 %2732
-OpStore %888 %2733
-%2734 = OpLoad %bool %888
-%2735 = OpSelect %uchar %2734 %uchar_1 %uchar_0
-%2736 = OpUConvert %ushort %2735
-OpStore %889 %2736
-%2737 = OpLoad %ushort %889
-%2738 = OpISub %ushort %ushort_0 %2737
-OpStore %890 %2738
-%2739 = OpLoad %_arr_ushort_uint_8 %468
-%2740 = OpCompositeExtract %ushort %2739 7
-OpStore %891 %2740
-%2741 = OpLoad %_arr_ushort_uint_8 %471
-%2742 = OpCompositeExtract %ushort %2741 7
-OpStore %892 %2742
-%2743 = OpLoad %ushort %891
-%2744 = OpLoad %ushort %892
-%2745 = OpULessThan %bool %2743 %2744
-OpStore %893 %2745
-%2746 = OpLoad %bool %893
-%2747 = OpSelect %uchar %2746 %uchar_1 %uchar_0
-%2748 = OpUConvert %ushort %2747
-OpStore %894 %2748
-%2749 = OpLoad %ushort %894
-%2750 = OpISub %ushort %ushort_0 %2749
-OpStore %895 %2750
-%2752 = OpLoad %ushort %860
-%2753 = OpLoad %ushort %865
-%2754 = OpLoad %ushort %870
-%2755 = OpLoad %ushort %875
-%2756 = OpLoad %ushort %880
-%2757 = OpLoad %ushort %885
-%2758 = OpLoad %ushort %890
-%2759 = OpLoad %ushort %895
-%2751 = OpCompositeConstruct %_arr_ushort_uint_8 %2752 %2753 %2754 %2755 %2756 %2757 %2758 %2759
-OpStore %896 %2751
-%2760 = OpLoad %_arr_ushort_uint_8 %896
-%2761 = OpCompositeExtract %ushort %2760 0
-OpStore %897 %2761
-%2762 = OpLoad %_arr_ushort_uint_8 %468
-%2763 = OpCompositeExtract %ushort %2762 0
-OpStore %898 %2763
-%2764 = OpLoad %ushort %897
-%2765 = OpLoad %ushort %898
-%2766 = OpBitwiseAnd %ushort %2764 %2765
-OpStore %899 %2766
-%2767 = OpLoad %_arr_ushort_uint_8 %896
-%2768 = OpCompositeExtract %ushort %2767 1
-OpStore %900 %2768
-%2769 = OpLoad %_arr_ushort_uint_8 %468
-%2770 = OpCompositeExtract %ushort %2769 1
-OpStore %901 %2770
-%2771 = OpLoad %ushort %900
-%2772 = OpLoad %ushort %901
-%2773 = OpBitwiseAnd %ushort %2771 %2772
-OpStore %902 %2773
-%2774 = OpLoad %_arr_ushort_uint_8 %896
-%2775 = OpCompositeExtract %ushort %2774 2
-OpStore %903 %2775
-%2776 = OpLoad %_arr_ushort_uint_8 %468
-%2777 = OpCompositeExtract %ushort %2776 2
-OpStore %904 %2777
-%2778 = OpLoad %ushort %903
-%2779 = OpLoad %ushort %904
-%2780 = OpBitwiseAnd %ushort %2778 %2779
-OpStore %905 %2780
-%2781 = OpLoad %_arr_ushort_uint_8 %896
-%2782 = OpCompositeExtract %ushort %2781 3
-OpStore %906 %2782
-%2783 = OpLoad %_arr_ushort_uint_8 %468
-%2784 = OpCompositeExtract %ushort %2783 3
-OpStore %907 %2784
-%2785 = OpLoad %ushort %906
-%2786 = OpLoad %ushort %907
-%2787 = OpBitwiseAnd %ushort %2785 %2786
-OpStore %908 %2787
-%2788 = OpLoad %_arr_ushort_uint_8 %896
-%2789 = OpCompositeExtract %ushort %2788 4
-OpStore %909 %2789
-%2790 = OpLoad %_arr_ushort_uint_8 %468
-%2791 = OpCompositeExtract %ushort %2790 4
-OpStore %910 %2791
-%2792 = OpLoad %ushort %909
-%2793 = OpLoad %ushort %910
-%2794 = OpBitwiseAnd %ushort %2792 %2793
-OpStore %911 %2794
-%2795 = OpLoad %_arr_ushort_uint_8 %896
-%2796 = OpCompositeExtract %ushort %2795 5
-OpStore %912 %2796
-%2797 = OpLoad %_arr_ushort_uint_8 %468
-%2798 = OpCompositeExtract %ushort %2797 5
-OpStore %913 %2798
-%2799 = OpLoad %ushort %912
-%2800 = OpLoad %ushort %913
-%2801 = OpBitwiseAnd %ushort %2799 %2800
-OpStore %914 %2801
-%2802 = OpLoad %_arr_ushort_uint_8 %896
-%2803 = OpCompositeExtract %ushort %2802 6
-OpStore %915 %2803
-%2804 = OpLoad %_arr_ushort_uint_8 %468
-%2805 = OpCompositeExtract %ushort %2804 6
-OpStore %916 %2805
-%2806 = OpLoad %ushort %915
-%2807 = OpLoad %ushort %916
-%2808 = OpBitwiseAnd %ushort %2806 %2807
-OpStore %917 %2808
-%2809 = OpLoad %_arr_ushort_uint_8 %896
-%2810 = OpCompositeExtract %ushort %2809 7
-OpStore %918 %2810
-%2811 = OpLoad %_arr_ushort_uint_8 %468
-%2812 = OpCompositeExtract %ushort %2811 7
-OpStore %919 %2812
-%2813 = OpLoad %ushort %918
-%2814 = OpLoad %ushort %919
-%2815 = OpBitwiseAnd %ushort %2813 %2814
-OpStore %920 %2815
-%2816 = OpLoad %_arr_ushort_uint_8 %896
-%2817 = OpLoad %ushort %899
-%2818 = OpCompositeInsert %_arr_ushort_uint_8 %2817 %2816 0
-OpStore %921 %2818
-%2819 = OpLoad %_arr_ushort_uint_8 %921
-%2820 = OpLoad %ushort %902
-%2821 = OpCompositeInsert %_arr_ushort_uint_8 %2820 %2819 1
-OpStore %922 %2821
-%2822 = OpLoad %_arr_ushort_uint_8 %922
-%2823 = OpLoad %ushort %905
-%2824 = OpCompositeInsert %_arr_ushort_uint_8 %2823 %2822 2
-OpStore %923 %2824
-%2825 = OpLoad %_arr_ushort_uint_8 %923
-%2826 = OpLoad %ushort %908
-%2827 = OpCompositeInsert %_arr_ushort_uint_8 %2826 %2825 3
-OpStore %924 %2827
-%2828 = OpLoad %_arr_ushort_uint_8 %924
-%2829 = OpLoad %ushort %911
-%2830 = OpCompositeInsert %_arr_ushort_uint_8 %2829 %2828 4
-OpStore %925 %2830
-%2831 = OpLoad %_arr_ushort_uint_8 %925
-%2832 = OpLoad %ushort %914
-%2833 = OpCompositeInsert %_arr_ushort_uint_8 %2832 %2831 5
-OpStore %926 %2833
-%2834 = OpLoad %_arr_ushort_uint_8 %926
-%2835 = OpLoad %ushort %917
-%2836 = OpCompositeInsert %_arr_ushort_uint_8 %2835 %2834 6
-OpStore %927 %2836
-%2837 = OpLoad %_arr_ushort_uint_8 %927
-%2838 = OpLoad %ushort %920
-%2839 = OpCompositeInsert %_arr_ushort_uint_8 %2838 %2837 7
-OpStore %928 %2839
-%2840 = OpLoad %_arr_ushort_uint_8 %896
-%2841 = OpCompositeExtract %ushort %2840 0
-OpStore %929 %2841
-%2842 = OpLoad %ushort %929
-%2843 = OpNot %ushort %2842
-OpStore %930 %2843
-%2844 = OpLoad %_arr_ushort_uint_8 %896
-%2845 = OpCompositeExtract %ushort %2844 1
-OpStore %931 %2845
-%2846 = OpLoad %ushort %931
-%2847 = OpNot %ushort %2846
-OpStore %932 %2847
-%2848 = OpLoad %_arr_ushort_uint_8 %896
-%2849 = OpCompositeExtract %ushort %2848 2
-OpStore %933 %2849
-%2850 = OpLoad %ushort %933
-%2851 = OpNot %ushort %2850
-OpStore %934 %2851
-%2852 = OpLoad %_arr_ushort_uint_8 %896
-%2853 = OpCompositeExtract %ushort %2852 3
-OpStore %935 %2853
-%2854 = OpLoad %ushort %935
-%2855 = OpNot %ushort %2854
-OpStore %936 %2855
-%2856 = OpLoad %_arr_ushort_uint_8 %896
-%2857 = OpCompositeExtract %ushort %2856 4
-OpStore %937 %2857
-%2858 = OpLoad %ushort %937
-%2859 = OpNot %ushort %2858
-OpStore %938 %2859
-%2860 = OpLoad %_arr_ushort_uint_8 %896
-%2861 = OpCompositeExtract %ushort %2860 5
-OpStore %939 %2861
-%2862 = OpLoad %ushort %939
-%2863 = OpNot %ushort %2862
-OpStore %940 %2863
-%2864 = OpLoad %_arr_ushort_uint_8 %896
-%2865 = OpCompositeExtract %ushort %2864 6
-OpStore %941 %2865
-%2866 = OpLoad %ushort %941
-%2867 = OpNot %ushort %2866
-OpStore %942 %2867
-%2868 = OpLoad %_arr_ushort_uint_8 %896
-%2869 = OpCompositeExtract %ushort %2868 7
-OpStore %943 %2869
-%2870 = OpLoad %ushort %943
-%2871 = OpNot %ushort %2870
-OpStore %944 %2871
-%2872 = OpLoad %_arr_ushort_uint_8 %896
-%2873 = OpLoad %ushort %930
-%2874 = OpCompositeInsert %_arr_ushort_uint_8 %2873 %2872 0
-OpStore %945 %2874
-%2875 = OpLoad %_arr_ushort_uint_8 %945
-%2876 = OpLoad %ushort %932
-%2877 = OpCompositeInsert %_arr_ushort_uint_8 %2876 %2875 1
-OpStore %946 %2877
-%2878 = OpLoad %_arr_ushort_uint_8 %946
-%2879 = OpLoad %ushort %934
-%2880 = OpCompositeInsert %_arr_ushort_uint_8 %2879 %2878 2
-OpStore %947 %2880
-%2881 = OpLoad %_arr_ushort_uint_8 %947
-%2882 = OpLoad %ushort %936
-%2883 = OpCompositeInsert %_arr_ushort_uint_8 %2882 %2881 3
-OpStore %948 %2883
-%2884 = OpLoad %_arr_ushort_uint_8 %948
-%2885 = OpLoad %ushort %938
-%2886 = OpCompositeInsert %_arr_ushort_uint_8 %2885 %2884 4
-OpStore %949 %2886
-%2887 = OpLoad %_arr_ushort_uint_8 %949
-%2888 = OpLoad %ushort %940
-%2889 = OpCompositeInsert %_arr_ushort_uint_8 %2888 %2887 5
-OpStore %950 %2889
-%2890 = OpLoad %_arr_ushort_uint_8 %950
-%2891 = OpLoad %ushort %942
-%2892 = OpCompositeInsert %_arr_ushort_uint_8 %2891 %2890 6
-OpStore %951 %2892
-%2893 = OpLoad %_arr_ushort_uint_8 %951
-%2894 = OpLoad %ushort %944
-%2895 = OpCompositeInsert %_arr_ushort_uint_8 %2894 %2893 7
-OpStore %952 %2895
-%2896 = OpLoad %_arr_ushort_uint_8 %952
-%2897 = OpCompositeExtract %ushort %2896 0
-OpStore %953 %2897
-%2898 = OpLoad %_arr_ushort_uint_8 %471
-%2899 = OpCompositeExtract %ushort %2898 0
-OpStore %954 %2899
-%2900 = OpLoad %ushort %953
-%2901 = OpLoad %ushort %954
-%2902 = OpBitwiseAnd %ushort %2900 %2901
-OpStore %955 %2902
-%2903 = OpLoad %_arr_ushort_uint_8 %952
-%2904 = OpCompositeExtract %ushort %2903 1
-OpStore %956 %2904
-%2905 = OpLoad %_arr_ushort_uint_8 %471
-%2906 = OpCompositeExtract %ushort %2905 1
-OpStore %957 %2906
-%2907 = OpLoad %ushort %956
-%2908 = OpLoad %ushort %957
-%2909 = OpBitwiseAnd %ushort %2907 %2908
-OpStore %958 %2909
-%2910 = OpLoad %_arr_ushort_uint_8 %952
-%2911 = OpCompositeExtract %ushort %2910 2
-OpStore %959 %2911
-%2912 = OpLoad %_arr_ushort_uint_8 %471
-%2913 = OpCompositeExtract %ushort %2912 2
-OpStore %960 %2913
-%2914 = OpLoad %ushort %959
-%2915 = OpLoad %ushort %960
-%2916 = OpBitwiseAnd %ushort %2914 %2915
-OpStore %961 %2916
-%2917 = OpLoad %_arr_ushort_uint_8 %952
-%2918 = OpCompositeExtract %ushort %2917 3
-OpStore %962 %2918
-%2919 = OpLoad %_arr_ushort_uint_8 %471
-%2920 = OpCompositeExtract %ushort %2919 3
-OpStore %963 %2920
-%2921 = OpLoad %ushort %962
-%2922 = OpLoad %ushort %963
-%2923 = OpBitwiseAnd %ushort %2921 %2922
-OpStore %964 %2923
-%2924 = OpLoad %_arr_ushort_uint_8 %952
-%2925 = OpCompositeExtract %ushort %2924 4
-OpStore %965 %2925
-%2926 = OpLoad %_arr_ushort_uint_8 %471
-%2927 = OpCompositeExtract %ushort %2926 4
-OpStore %966 %2927
-%2928 = OpLoad %ushort %965
-%2929 = OpLoad %ushort %966
-%2930 = OpBitwiseAnd %ushort %2928 %2929
-OpStore %967 %2930
-%2931 = OpLoad %_arr_ushort_uint_8 %952
-%2932 = OpCompositeExtract %ushort %2931 5
-OpStore %968 %2932
-%2933 = OpLoad %_arr_ushort_uint_8 %471
-%2934 = OpCompositeExtract %ushort %2933 5
-OpStore %969 %2934
-%2935 = OpLoad %ushort %968
-%2936 = OpLoad %ushort %969
-%2937 = OpBitwiseAnd %ushort %2935 %2936
-OpStore %970 %2937
-%2938 = OpLoad %_arr_ushort_uint_8 %952
-%2939 = OpCompositeExtract %ushort %2938 6
-OpStore %971 %2939
-%2940 = OpLoad %_arr_ushort_uint_8 %471
-%2941 = OpCompositeExtract %ushort %2940 6
-OpStore %972 %2941
-%2942 = OpLoad %ushort %971
-%2943 = OpLoad %ushort %972
-%2944 = OpBitwiseAnd %ushort %2942 %2943
-OpStore %973 %2944
-%2945 = OpLoad %_arr_ushort_uint_8 %952
-%2946 = OpCompositeExtract %ushort %2945 7
-OpStore %974 %2946
-%2947 = OpLoad %_arr_ushort_uint_8 %471
-%2948 = OpCompositeExtract %ushort %2947 7
-OpStore %975 %2948
-%2949 = OpLoad %ushort %974
-%2950 = OpLoad %ushort %975
-%2951 = OpBitwiseAnd %ushort %2949 %2950
-OpStore %976 %2951
-%2952 = OpLoad %_arr_ushort_uint_8 %952
-%2953 = OpLoad %ushort %955
-%2954 = OpCompositeInsert %_arr_ushort_uint_8 %2953 %2952 0
-OpStore %977 %2954
-%2955 = OpLoad %_arr_ushort_uint_8 %977
-%2956 = OpLoad %ushort %958
-%2957 = OpCompositeInsert %_arr_ushort_uint_8 %2956 %2955 1
-OpStore %978 %2957
-%2958 = OpLoad %_arr_ushort_uint_8 %978
-%2959 = OpLoad %ushort %961
-%2960 = OpCompositeInsert %_arr_ushort_uint_8 %2959 %2958 2
-OpStore %979 %2960
-%2961 = OpLoad %_arr_ushort_uint_8 %979
-%2962 = OpLoad %ushort %964
-%2963 = OpCompositeInsert %_arr_ushort_uint_8 %2962 %2961 3
-OpStore %980 %2963
-%2964 = OpLoad %_arr_ushort_uint_8 %980
-%2965 = OpLoad %ushort %967
-%2966 = OpCompositeInsert %_arr_ushort_uint_8 %2965 %2964 4
-OpStore %981 %2966
-%2967 = OpLoad %_arr_ushort_uint_8 %981
-%2968 = OpLoad %ushort %970
-%2969 = OpCompositeInsert %_arr_ushort_uint_8 %2968 %2967 5
-OpStore %982 %2969
-%2970 = OpLoad %_arr_ushort_uint_8 %982
-%2971 = OpLoad %ushort %973
-%2972 = OpCompositeInsert %_arr_ushort_uint_8 %2971 %2970 6
-OpStore %983 %2972
-%2973 = OpLoad %_arr_ushort_uint_8 %983
-%2974 = OpLoad %ushort %976
-%2975 = OpCompositeInsert %_arr_ushort_uint_8 %2974 %2973 7
-OpStore %984 %2975
-%2976 = OpLoad %_arr_ushort_uint_8 %928
-%2977 = OpCompositeExtract %ushort %2976 0
-OpStore %985 %2977
-%2978 = OpLoad %_arr_ushort_uint_8 %984
-%2979 = OpCompositeExtract %ushort %2978 0
-OpStore %986 %2979
-%2980 = OpLoad %ushort %985
-%2981 = OpLoad %ushort %986
-%2982 = OpBitwiseOr %ushort %2980 %2981
-OpStore %987 %2982
-%2983 = OpLoad %_arr_ushort_uint_8 %928
-%2984 = OpCompositeExtract %ushort %2983 1
-OpStore %988 %2984
-%2985 = OpLoad %_arr_ushort_uint_8 %984
-%2986 = OpCompositeExtract %ushort %2985 1
-OpStore %989 %2986
-%2987 = OpLoad %ushort %988
-%2988 = OpLoad %ushort %989
-%2989 = OpBitwiseOr %ushort %2987 %2988
-OpStore %990 %2989
-%2990 = OpLoad %_arr_ushort_uint_8 %928
-%2991 = OpCompositeExtract %ushort %2990 2
-OpStore %991 %2991
-%2992 = OpLoad %_arr_ushort_uint_8 %984
+%1269 = OpVariable %_ptr_Function_ulong Function
+%1270 = OpVariable %_ptr_Function_ulong Function
+%1271 = OpVariable %_ptr_Function_ulong Function
+%1272 = OpVariable %_ptr_Function_ulong Function
+%1273 = OpVariable %_ptr_Function_uint Function
+%1274 = OpVariable %_ptr_Function_uint Function
+%1275 = OpVariable %_ptr_Function_uint Function
+%1276 = OpVariable %_ptr_Function_uint Function
+%1277 = OpVariable %_ptr_Function_ulong Function
+%1278 = OpVariable %_ptr_Function_ulong Function
+%1279 = OpVariable %_ptr_Function_ulong Function
+%1280 = OpVariable %_ptr_Function_ulong Function
+%1281 = OpVariable %_ptr_Function_ulong Function
+%1282 = OpVariable %_ptr_Function_ulong Function
+%1283 = OpVariable %_ptr_Function_ulong Function
+%1284 = OpVariable %_ptr_Function_ulong Function
+%1285 = OpVariable %_ptr_Function_uint Function
+%1286 = OpVariable %_ptr_Function_uint Function
+%1287 = OpVariable %_ptr_Function_uint Function
+%1288 = OpVariable %_ptr_Function_uint Function
+%1289 = OpVariable %_ptr_Function_ulong Function
+%1290 = OpVariable %_ptr_Function_ulong Function
+%1291 = OpVariable %_ptr_Function_ulong Function
+%1292 = OpVariable %_ptr_Function_ulong Function
+%1293 = OpVariable %_ptr_Function_ulong Function
+%1294 = OpVariable %_ptr_Function_ulong Function
+%1295 = OpVariable %_ptr_Function_ulong Function
+%1296 = OpVariable %_ptr_Function_ulong Function
+%1297 = OpVariable %_ptr_Function_uint Function
+%1298 = OpVariable %_ptr_Function_uint Function
+%1299 = OpVariable %_ptr_Function_uint Function
+%1300 = OpVariable %_ptr_Function_uint Function
+%1301 = OpVariable %_ptr_Function_ulong Function
+%1302 = OpVariable %_ptr_Function_ulong Function
+%1303 = OpVariable %_ptr_Function_ulong Function
+%1304 = OpVariable %_ptr_Function_ulong Function
+%1305 = OpVariable %_ptr_Function_ulong Function
+%1306 = OpVariable %_ptr_Function_ulong Function
+%1307 = OpVariable %_ptr_Function_ulong Function
+%1308 = OpVariable %_ptr_Function_ulong Function
+%1309 = OpVariable %_ptr_Function_uint Function
+%1310 = OpVariable %_ptr_Function_uint Function
+%1311 = OpVariable %_ptr_Function_uint Function
+%1312 = OpVariable %_ptr_Function_uint Function
+%1313 = OpVariable %_ptr_Function_ulong Function
+%1314 = OpVariable %_ptr_Function_ulong Function
+%1315 = OpVariable %_ptr_Function_ulong Function
+%1316 = OpVariable %_ptr_Function_ulong Function
+%1317 = OpVariable %_ptr_Function_ulong Function
+%1318 = OpVariable %_ptr_Function_ulong Function
+%1319 = OpVariable %_ptr_Function_ulong Function
+%1320 = OpVariable %_ptr_Function_ulong Function
+%1321 = OpVariable %_ptr_Function_uint Function
+%1322 = OpVariable %_ptr_Function_uint Function
+%1323 = OpVariable %_ptr_Function_uint Function
+%1324 = OpVariable %_ptr_Function_uint Function
+%1325 = OpVariable %_ptr_Function_ulong Function
+%1326 = OpVariable %_ptr_Function_ulong Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_ulong Function
+%1329 = OpVariable %_ptr_Function_ulong Function
+%1330 = OpVariable %_ptr_Function_ulong Function
+%1331 = OpVariable %_ptr_Function_ulong Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_uint Function
+%1334 = OpVariable %_ptr_Function_uint Function
+%1335 = OpVariable %_ptr_Function_uint Function
+%1336 = OpVariable %_ptr_Function_uint Function
+%1337 = OpVariable %_ptr_Function_ulong Function
+%1338 = OpVariable %_ptr_Function_ulong Function
+%1339 = OpVariable %_ptr_Function_ulong Function
+%1340 = OpVariable %_ptr_Function_ulong Function
+%1341 = OpVariable %_ptr_Function_ulong Function
+%1342 = OpVariable %_ptr_Function_ulong Function
+%1343 = OpVariable %_ptr_Function_ulong Function
+%1344 = OpVariable %_ptr_Function_ulong Function
+%1345 = OpVariable %_ptr_Function_uint Function
+%1346 = OpVariable %_ptr_Function_uint Function
+%1347 = OpVariable %_ptr_Function_uint Function
+%1348 = OpVariable %_ptr_Function_uint Function
+%1349 = OpVariable %_ptr_Function_ulong Function
+%1350 = OpVariable %_ptr_Function_ulong Function
+%1351 = OpVariable %_ptr_Function_ulong Function
+%1352 = OpVariable %_ptr_Function_ulong Function
+%1353 = OpVariable %_ptr_Function_ulong Function
+%1354 = OpVariable %_ptr_Function_ulong Function
+%1355 = OpVariable %_ptr_Function_ulong Function
+%1356 = OpVariable %_ptr_Function_ulong Function
+%1357 = OpVariable %_ptr_Function_uint Function
+%1358 = OpVariable %_ptr_Function_uint Function
+%1359 = OpVariable %_ptr_Function_uint Function
+%1360 = OpVariable %_ptr_Function_uint Function
+%1361 = OpVariable %_ptr_Function_ulong Function
+%1362 = OpVariable %_ptr_Function_ulong Function
+%1363 = OpVariable %_ptr_Function_ulong Function
+%1364 = OpVariable %_ptr_Function_ulong Function
+%1365 = OpVariable %_ptr_Function_ulong Function
+%1366 = OpVariable %_ptr_Function_ulong Function
+%1367 = OpVariable %_ptr_Function_ulong Function
+%1368 = OpVariable %_ptr_Function_ulong Function
+%1369 = OpVariable %_ptr_Function_uint Function
+%1370 = OpVariable %_ptr_Function_uint Function
+%1371 = OpVariable %_ptr_Function_uint Function
+%1372 = OpVariable %_ptr_Function_uint Function
+%1373 = OpVariable %_ptr_Function_ulong Function
+%1374 = OpVariable %_ptr_Function_ulong Function
+%1375 = OpVariable %_ptr_Function_ulong Function
+%1376 = OpVariable %_ptr_Function_ulong Function
+%1377 = OpVariable %_ptr_Function_ulong Function
+%1378 = OpVariable %_ptr_Function_ulong Function
+%1379 = OpVariable %_ptr_Function_ulong Function
+%1380 = OpVariable %_ptr_Function_ulong Function
+%1381 = OpVariable %_ptr_Function_uint Function
+%1382 = OpVariable %_ptr_Function_uint Function
+%1383 = OpVariable %_ptr_Function_uint Function
+%1384 = OpVariable %_ptr_Function_uint Function
+%1385 = OpVariable %_ptr_Function_ulong Function
+%1386 = OpVariable %_ptr_Function_ulong Function
+%1387 = OpVariable %_ptr_Function_ulong Function
+%1388 = OpVariable %_ptr_Function_ulong Function
+%1389 = OpVariable %_ptr_Function_ulong Function
+%1390 = OpVariable %_ptr_Function_ulong Function
+%1391 = OpVariable %_ptr_Function_ulong Function
+%1392 = OpVariable %_ptr_Function_ulong Function
+%1393 = OpVariable %_ptr_Function_uint Function
+%1394 = OpVariable %_ptr_Function_uint Function
+%1395 = OpVariable %_ptr_Function_uint Function
+%1396 = OpVariable %_ptr_Function_uint Function
+%1397 = OpVariable %_ptr_Function_ulong Function
+%1398 = OpVariable %_ptr_Function_ulong Function
+%1399 = OpVariable %_ptr_Function_ulong Function
+%1400 = OpVariable %_ptr_Function_ulong Function
+%1401 = OpVariable %_ptr_Function_ulong Function
+%1402 = OpVariable %_ptr_Function_ulong Function
+%1403 = OpVariable %_ptr_Function_ulong Function
+%1404 = OpVariable %_ptr_Function_ulong Function
+%1405 = OpVariable %_ptr_Function_uint Function
+%1406 = OpVariable %_ptr_Function_uint Function
+%1407 = OpVariable %_ptr_Function_uint Function
+%1408 = OpVariable %_ptr_Function_uint Function
+%1409 = OpVariable %_ptr_Function_ulong Function
+%1410 = OpVariable %_ptr_Function_ulong Function
+%1411 = OpVariable %_ptr_Function_ulong Function
+%1412 = OpVariable %_ptr_Function_ulong Function
+%1413 = OpVariable %_ptr_Function_ulong Function
+%1414 = OpVariable %_ptr_Function_ulong Function
+%1415 = OpVariable %_ptr_Function_ulong Function
+%1416 = OpVariable %_ptr_Function_ulong Function
+%1417 = OpVariable %_ptr_Function_uint Function
+%1418 = OpVariable %_ptr_Function_uint Function
+%1419 = OpVariable %_ptr_Function_uint Function
+%1420 = OpVariable %_ptr_Function_uint Function
+%1421 = OpVariable %_ptr_Function_ulong Function
+%1422 = OpVariable %_ptr_Function_ulong Function
+%1423 = OpVariable %_ptr_Function_ulong Function
+%1424 = OpVariable %_ptr_Function_ulong Function
+%1425 = OpVariable %_ptr_Function_ulong Function
+%1426 = OpVariable %_ptr_Function_ulong Function
+%1427 = OpVariable %_ptr_Function_ulong Function
+%1428 = OpVariable %_ptr_Function_ulong Function
+%1429 = OpVariable %_ptr_Function_uint Function
+%1430 = OpVariable %_ptr_Function_uint Function
+%1431 = OpVariable %_ptr_Function_uint Function
+%1432 = OpVariable %_ptr_Function_uint Function
+%1433 = OpVariable %_ptr_Function_ulong Function
+%1434 = OpVariable %_ptr_Function_ulong Function
+%1435 = OpVariable %_ptr_Function_ulong Function
+%1436 = OpVariable %_ptr_Function_ulong Function
+%1437 = OpVariable %_ptr_Function_ulong Function
+%1438 = OpVariable %_ptr_Function_ulong Function
+%1439 = OpVariable %_ptr_Function_ulong Function
+%1440 = OpVariable %_ptr_Function_ulong Function
+%1441 = OpVariable %_ptr_Function_uint Function
+%1442 = OpVariable %_ptr_Function_uint Function
+%1443 = OpVariable %_ptr_Function_uint Function
+%1444 = OpVariable %_ptr_Function_uint Function
+%1445 = OpVariable %_ptr_Function_ulong Function
+%1446 = OpVariable %_ptr_Function_ulong Function
+%1447 = OpVariable %_ptr_Function_ulong Function
+%1448 = OpVariable %_ptr_Function_ulong Function
+%1449 = OpVariable %_ptr_Function_ulong Function
+%1450 = OpVariable %_ptr_Function_ulong Function
+%1451 = OpVariable %_ptr_Function_ulong Function
+%1452 = OpVariable %_ptr_Function_ulong Function
+%1453 = OpVariable %_ptr_Function_uint Function
+%1454 = OpVariable %_ptr_Function_uint Function
+%1455 = OpVariable %_ptr_Function_uint Function
+%1456 = OpVariable %_ptr_Function_uint Function
+%1457 = OpVariable %_ptr_Function_ulong Function
+%1458 = OpVariable %_ptr_Function_ulong Function
+%1459 = OpVariable %_ptr_Function_ulong Function
+%1460 = OpVariable %_ptr_Function_ulong Function
+%1461 = OpVariable %_ptr_Function_ulong Function
+%1462 = OpVariable %_ptr_Function_ulong Function
+%1463 = OpVariable %_ptr_Function_ulong Function
+%1464 = OpVariable %_ptr_Function_ulong Function
+%1465 = OpVariable %_ptr_Function_ulong Function
+%1466 = OpVariable %_ptr_Function_ulong Function
+%1467 = OpVariable %_ptr_Function_ulong Function
+%1468 = OpVariable %_ptr_Function_ulong Function
+%1469 = OpVariable %_ptr_Function_ulong Function
+%1470 = OpVariable %_ptr_Function_ulong Function
+%1471 = OpVariable %_ptr_Function_ulong Function
+%1472 = OpVariable %_ptr_Function_ulong Function
+%1473 = OpVariable %_ptr_Function_ulong Function
+%1474 = OpVariable %_ptr_Function_ulong Function
+%1475 = OpVariable %_ptr_Function_ulong Function
+%1476 = OpVariable %_ptr_Function_ulong Function
+%1477 = OpVariable %_ptr_Function_ulong Function
+%1478 = OpVariable %_ptr_Function_ulong Function
+%1479 = OpVariable %_ptr_Function_ulong Function
+%1480 = OpVariable %_ptr_Function_ulong Function
+%1481 = OpVariable %_ptr_Function_ushort Function
+%1482 = OpVariable %_ptr_Function_ushort Function
+%1483 = OpVariable %_ptr_Function_bool Function
+%1484 = OpVariable %_ptr_Function_ushort Function
+%1485 = OpVariable %_ptr_Function_ushort Function
+%1486 = OpVariable %_ptr_Function_ushort Function
+%1487 = OpVariable %_ptr_Function_ushort Function
+%1488 = OpVariable %_ptr_Function_bool Function
+%1489 = OpVariable %_ptr_Function_ushort Function
+%1490 = OpVariable %_ptr_Function_ushort Function
+%1491 = OpVariable %_ptr_Function_ushort Function
+%1492 = OpVariable %_ptr_Function_ushort Function
+%1493 = OpVariable %_ptr_Function_bool Function
+%1494 = OpVariable %_ptr_Function_ushort Function
+%1495 = OpVariable %_ptr_Function_ushort Function
+%1496 = OpVariable %_ptr_Function_ushort Function
+%1497 = OpVariable %_ptr_Function_ushort Function
+%1498 = OpVariable %_ptr_Function_bool Function
+%1499 = OpVariable %_ptr_Function_ushort Function
+%1500 = OpVariable %_ptr_Function_ushort Function
+%1501 = OpVariable %_ptr_Function_ushort Function
+%1502 = OpVariable %_ptr_Function_ushort Function
+%1503 = OpVariable %_ptr_Function_bool Function
+%1504 = OpVariable %_ptr_Function_ushort Function
+%1505 = OpVariable %_ptr_Function_ushort Function
+%1506 = OpVariable %_ptr_Function_ushort Function
+%1507 = OpVariable %_ptr_Function_ushort Function
+%1508 = OpVariable %_ptr_Function_bool Function
+%1509 = OpVariable %_ptr_Function_ushort Function
+%1510 = OpVariable %_ptr_Function_ushort Function
+%1511 = OpVariable %_ptr_Function_ushort Function
+%1512 = OpVariable %_ptr_Function_ushort Function
+%1513 = OpVariable %_ptr_Function_bool Function
+%1514 = OpVariable %_ptr_Function_ushort Function
+%1515 = OpVariable %_ptr_Function_ushort Function
+%1516 = OpVariable %_ptr_Function_ushort Function
+%1517 = OpVariable %_ptr_Function_ushort Function
+%1518 = OpVariable %_ptr_Function_bool Function
+%1519 = OpVariable %_ptr_Function_ushort Function
+%1520 = OpVariable %_ptr_Function_ushort Function
+%1521 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1522 = OpVariable %_ptr_Function_ushort Function
+%1523 = OpVariable %_ptr_Function_ushort Function
+%1524 = OpVariable %_ptr_Function_bool Function
+%1525 = OpVariable %_ptr_Function_ushort Function
+%1526 = OpVariable %_ptr_Function_ushort Function
+%1527 = OpVariable %_ptr_Function_ushort Function
+%1528 = OpVariable %_ptr_Function_ushort Function
+%1529 = OpVariable %_ptr_Function_bool Function
+%1530 = OpVariable %_ptr_Function_ushort Function
+%1531 = OpVariable %_ptr_Function_ushort Function
+%1532 = OpVariable %_ptr_Function_ushort Function
+%1533 = OpVariable %_ptr_Function_ushort Function
+%1534 = OpVariable %_ptr_Function_bool Function
+%1535 = OpVariable %_ptr_Function_ushort Function
+%1536 = OpVariable %_ptr_Function_ushort Function
+%1537 = OpVariable %_ptr_Function_ushort Function
+%1538 = OpVariable %_ptr_Function_ushort Function
+%1539 = OpVariable %_ptr_Function_bool Function
+%1540 = OpVariable %_ptr_Function_ushort Function
+%1541 = OpVariable %_ptr_Function_ushort Function
+%1542 = OpVariable %_ptr_Function_ushort Function
+%1543 = OpVariable %_ptr_Function_ushort Function
+%1544 = OpVariable %_ptr_Function_bool Function
+%1545 = OpVariable %_ptr_Function_ushort Function
+%1546 = OpVariable %_ptr_Function_ushort Function
+%1547 = OpVariable %_ptr_Function_ushort Function
+%1548 = OpVariable %_ptr_Function_ushort Function
+%1549 = OpVariable %_ptr_Function_bool Function
+%1550 = OpVariable %_ptr_Function_ushort Function
+%1551 = OpVariable %_ptr_Function_ushort Function
+%1552 = OpVariable %_ptr_Function_ushort Function
+%1553 = OpVariable %_ptr_Function_ushort Function
+%1554 = OpVariable %_ptr_Function_bool Function
+%1555 = OpVariable %_ptr_Function_ushort Function
+%1556 = OpVariable %_ptr_Function_ushort Function
+%1557 = OpVariable %_ptr_Function_ushort Function
+%1558 = OpVariable %_ptr_Function_ushort Function
+%1559 = OpVariable %_ptr_Function_bool Function
+%1560 = OpVariable %_ptr_Function_ushort Function
+%1561 = OpVariable %_ptr_Function_ushort Function
+%1562 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1563 = OpVariable %_ptr_Function_ushort Function
+%1564 = OpVariable %_ptr_Function_ushort Function
+%1565 = OpVariable %_ptr_Function_bool Function
+%1566 = OpVariable %_ptr_Function_ushort Function
+%1567 = OpVariable %_ptr_Function_ushort Function
+%1568 = OpVariable %_ptr_Function_ushort Function
+%1569 = OpVariable %_ptr_Function_ushort Function
+%1570 = OpVariable %_ptr_Function_bool Function
+%1571 = OpVariable %_ptr_Function_ushort Function
+%1572 = OpVariable %_ptr_Function_ushort Function
+%1573 = OpVariable %_ptr_Function_ushort Function
+%1574 = OpVariable %_ptr_Function_ushort Function
+%1575 = OpVariable %_ptr_Function_bool Function
+%1576 = OpVariable %_ptr_Function_ushort Function
+%1577 = OpVariable %_ptr_Function_ushort Function
+%1578 = OpVariable %_ptr_Function_ushort Function
+%1579 = OpVariable %_ptr_Function_ushort Function
+%1580 = OpVariable %_ptr_Function_bool Function
+%1581 = OpVariable %_ptr_Function_ushort Function
+%1582 = OpVariable %_ptr_Function_ushort Function
+%1583 = OpVariable %_ptr_Function_ushort Function
+%1584 = OpVariable %_ptr_Function_ushort Function
+%1585 = OpVariable %_ptr_Function_bool Function
+%1586 = OpVariable %_ptr_Function_ushort Function
+%1587 = OpVariable %_ptr_Function_ushort Function
+%1588 = OpVariable %_ptr_Function_ushort Function
+%1589 = OpVariable %_ptr_Function_ushort Function
+%1590 = OpVariable %_ptr_Function_bool Function
+%1591 = OpVariable %_ptr_Function_ushort Function
+%1592 = OpVariable %_ptr_Function_ushort Function
+%1593 = OpVariable %_ptr_Function_ushort Function
+%1594 = OpVariable %_ptr_Function_ushort Function
+%1595 = OpVariable %_ptr_Function_bool Function
+%1596 = OpVariable %_ptr_Function_ushort Function
+%1597 = OpVariable %_ptr_Function_ushort Function
+%1598 = OpVariable %_ptr_Function_ushort Function
+%1599 = OpVariable %_ptr_Function_ushort Function
+%1600 = OpVariable %_ptr_Function_bool Function
+%1601 = OpVariable %_ptr_Function_ushort Function
+%1602 = OpVariable %_ptr_Function_ushort Function
+%1603 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1604 = OpVariable %_ptr_Function_ushort Function
+%1605 = OpVariable %_ptr_Function_ushort Function
+%1606 = OpVariable %_ptr_Function_ushort Function
+%1607 = OpVariable %_ptr_Function_ushort Function
+%1608 = OpVariable %_ptr_Function_ushort Function
+%1609 = OpVariable %_ptr_Function_ushort Function
+%1610 = OpVariable %_ptr_Function_ushort Function
+%1611 = OpVariable %_ptr_Function_ushort Function
+%1612 = OpVariable %_ptr_Function_ushort Function
+%1613 = OpVariable %_ptr_Function_ushort Function
+%1614 = OpVariable %_ptr_Function_ushort Function
+%1615 = OpVariable %_ptr_Function_ushort Function
+%1616 = OpVariable %_ptr_Function_ushort Function
+%1617 = OpVariable %_ptr_Function_ushort Function
+%1618 = OpVariable %_ptr_Function_ushort Function
+%1619 = OpVariable %_ptr_Function_ushort Function
+%1620 = OpVariable %_ptr_Function_ushort Function
+%1621 = OpVariable %_ptr_Function_ushort Function
+%1622 = OpVariable %_ptr_Function_ushort Function
+%1623 = OpVariable %_ptr_Function_ushort Function
+%1624 = OpVariable %_ptr_Function_ushort Function
+%1625 = OpVariable %_ptr_Function_ushort Function
+%1626 = OpVariable %_ptr_Function_ushort Function
+%1627 = OpVariable %_ptr_Function_ushort Function
+%1628 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1629 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1630 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1631 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1632 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1633 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1634 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1635 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1636 = OpVariable %_ptr_Function_ushort Function
+%1637 = OpVariable %_ptr_Function_ushort Function
+%1638 = OpVariable %_ptr_Function_ushort Function
+%1639 = OpVariable %_ptr_Function_ushort Function
+%1640 = OpVariable %_ptr_Function_ushort Function
+%1641 = OpVariable %_ptr_Function_ushort Function
+%1642 = OpVariable %_ptr_Function_ushort Function
+%1643 = OpVariable %_ptr_Function_ushort Function
+%1644 = OpVariable %_ptr_Function_ushort Function
+%1645 = OpVariable %_ptr_Function_ushort Function
+%1646 = OpVariable %_ptr_Function_ushort Function
+%1647 = OpVariable %_ptr_Function_ushort Function
+%1648 = OpVariable %_ptr_Function_ushort Function
+%1649 = OpVariable %_ptr_Function_ushort Function
+%1650 = OpVariable %_ptr_Function_ushort Function
+%1651 = OpVariable %_ptr_Function_ushort Function
+%1652 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1653 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1654 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1655 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1656 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1657 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1658 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1659 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1660 = OpVariable %_ptr_Function_ushort Function
+%1661 = OpVariable %_ptr_Function_ushort Function
+%1662 = OpVariable %_ptr_Function_ushort Function
+%1663 = OpVariable %_ptr_Function_ushort Function
+%1664 = OpVariable %_ptr_Function_ushort Function
+%1665 = OpVariable %_ptr_Function_ushort Function
+%1666 = OpVariable %_ptr_Function_ushort Function
+%1667 = OpVariable %_ptr_Function_ushort Function
+%1668 = OpVariable %_ptr_Function_ushort Function
+%1669 = OpVariable %_ptr_Function_ushort Function
+%1670 = OpVariable %_ptr_Function_ushort Function
+%1671 = OpVariable %_ptr_Function_ushort Function
+%1672 = OpVariable %_ptr_Function_ushort Function
+%1673 = OpVariable %_ptr_Function_ushort Function
+%1674 = OpVariable %_ptr_Function_ushort Function
+%1675 = OpVariable %_ptr_Function_ushort Function
+%1676 = OpVariable %_ptr_Function_ushort Function
+%1677 = OpVariable %_ptr_Function_ushort Function
+%1678 = OpVariable %_ptr_Function_ushort Function
+%1679 = OpVariable %_ptr_Function_ushort Function
+%1680 = OpVariable %_ptr_Function_ushort Function
+%1681 = OpVariable %_ptr_Function_ushort Function
+%1682 = OpVariable %_ptr_Function_ushort Function
+%1683 = OpVariable %_ptr_Function_ushort Function
+%1684 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1685 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1686 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1687 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1688 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1689 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1690 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1691 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1692 = OpVariable %_ptr_Function_ushort Function
+%1693 = OpVariable %_ptr_Function_ushort Function
+%1694 = OpVariable %_ptr_Function_ushort Function
+%1695 = OpVariable %_ptr_Function_ushort Function
+%1696 = OpVariable %_ptr_Function_ushort Function
+%1697 = OpVariable %_ptr_Function_ushort Function
+%1698 = OpVariable %_ptr_Function_ushort Function
+%1699 = OpVariable %_ptr_Function_ushort Function
+%1700 = OpVariable %_ptr_Function_ushort Function
+%1701 = OpVariable %_ptr_Function_ushort Function
+%1702 = OpVariable %_ptr_Function_ushort Function
+%1703 = OpVariable %_ptr_Function_ushort Function
+%1704 = OpVariable %_ptr_Function_ushort Function
+%1705 = OpVariable %_ptr_Function_ushort Function
+%1706 = OpVariable %_ptr_Function_ushort Function
+%1707 = OpVariable %_ptr_Function_ushort Function
+%1708 = OpVariable %_ptr_Function_ushort Function
+%1709 = OpVariable %_ptr_Function_ushort Function
+%1710 = OpVariable %_ptr_Function_ushort Function
+%1711 = OpVariable %_ptr_Function_ushort Function
+%1712 = OpVariable %_ptr_Function_ushort Function
+%1713 = OpVariable %_ptr_Function_ushort Function
+%1714 = OpVariable %_ptr_Function_ushort Function
+%1715 = OpVariable %_ptr_Function_ushort Function
+%1716 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1717 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1718 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1719 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1720 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1721 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1722 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1723 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1724 = OpVariable %_ptr_Function_uchar Function
+%1725 = OpVariable %_ptr_Function_uchar Function
+%1726 = OpVariable %_ptr_Function_bool Function
+%1727 = OpVariable %_ptr_Function_uchar Function
+%1728 = OpVariable %_ptr_Function_uchar Function
+%1729 = OpVariable %_ptr_Function_uchar Function
+%1730 = OpVariable %_ptr_Function_bool Function
+%1731 = OpVariable %_ptr_Function_uchar Function
+%1732 = OpVariable %_ptr_Function_uchar Function
+%1733 = OpVariable %_ptr_Function_uchar Function
+%1734 = OpVariable %_ptr_Function_bool Function
+%1735 = OpVariable %_ptr_Function_uchar Function
+%1736 = OpVariable %_ptr_Function_uchar Function
+%1737 = OpVariable %_ptr_Function_uchar Function
+%1738 = OpVariable %_ptr_Function_bool Function
+%1739 = OpVariable %_ptr_Function_uchar Function
+%1740 = OpVariable %_ptr_Function_uchar Function
+%1741 = OpVariable %_ptr_Function_uchar Function
+%1742 = OpVariable %_ptr_Function_bool Function
+%1743 = OpVariable %_ptr_Function_uchar Function
+%1744 = OpVariable %_ptr_Function_uchar Function
+%1745 = OpVariable %_ptr_Function_uchar Function
+%1746 = OpVariable %_ptr_Function_bool Function
+%1747 = OpVariable %_ptr_Function_uchar Function
+%1748 = OpVariable %_ptr_Function_uchar Function
+%1749 = OpVariable %_ptr_Function_uchar Function
+%1750 = OpVariable %_ptr_Function_bool Function
+%1751 = OpVariable %_ptr_Function_uchar Function
+%1752 = OpVariable %_ptr_Function_uchar Function
+%1753 = OpVariable %_ptr_Function_uchar Function
+%1754 = OpVariable %_ptr_Function_bool Function
+%1755 = OpVariable %_ptr_Function_uchar Function
+%1756 = OpVariable %_ptr_Function_uchar Function
+%1757 = OpVariable %_ptr_Function_uchar Function
+%1758 = OpVariable %_ptr_Function_bool Function
+%1759 = OpVariable %_ptr_Function_uchar Function
+%1760 = OpVariable %_ptr_Function_uchar Function
+%1761 = OpVariable %_ptr_Function_uchar Function
+%1762 = OpVariable %_ptr_Function_bool Function
+%1763 = OpVariable %_ptr_Function_uchar Function
+%1764 = OpVariable %_ptr_Function_uchar Function
+%1765 = OpVariable %_ptr_Function_uchar Function
+%1766 = OpVariable %_ptr_Function_bool Function
+%1767 = OpVariable %_ptr_Function_uchar Function
+%1768 = OpVariable %_ptr_Function_uchar Function
+%1769 = OpVariable %_ptr_Function_uchar Function
+%1770 = OpVariable %_ptr_Function_bool Function
+%1771 = OpVariable %_ptr_Function_uchar Function
+%1772 = OpVariable %_ptr_Function_uchar Function
+%1773 = OpVariable %_ptr_Function_uchar Function
+%1774 = OpVariable %_ptr_Function_bool Function
+%1775 = OpVariable %_ptr_Function_uchar Function
+%1776 = OpVariable %_ptr_Function_uchar Function
+%1777 = OpVariable %_ptr_Function_uchar Function
+%1778 = OpVariable %_ptr_Function_bool Function
+%1779 = OpVariable %_ptr_Function_uchar Function
+%1780 = OpVariable %_ptr_Function_uchar Function
+%1781 = OpVariable %_ptr_Function_uchar Function
+%1782 = OpVariable %_ptr_Function_bool Function
+%1783 = OpVariable %_ptr_Function_uchar Function
+%1784 = OpVariable %_ptr_Function_uchar Function
+%1785 = OpVariable %_ptr_Function_uchar Function
+%1786 = OpVariable %_ptr_Function_bool Function
+%1787 = OpVariable %_ptr_Function_uchar Function
+%1788 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1789 = OpVariable %_ptr_Function_uchar Function
+%1790 = OpVariable %_ptr_Function_uchar Function
+%1791 = OpVariable %_ptr_Function_bool Function
+%1792 = OpVariable %_ptr_Function_uchar Function
+%1793 = OpVariable %_ptr_Function_uchar Function
+%1794 = OpVariable %_ptr_Function_uchar Function
+%1795 = OpVariable %_ptr_Function_bool Function
+%1796 = OpVariable %_ptr_Function_uchar Function
+%1797 = OpVariable %_ptr_Function_uchar Function
+%1798 = OpVariable %_ptr_Function_uchar Function
+%1799 = OpVariable %_ptr_Function_bool Function
+%1800 = OpVariable %_ptr_Function_uchar Function
+%1801 = OpVariable %_ptr_Function_uchar Function
+%1802 = OpVariable %_ptr_Function_uchar Function
+%1803 = OpVariable %_ptr_Function_bool Function
+%1804 = OpVariable %_ptr_Function_uchar Function
+%1805 = OpVariable %_ptr_Function_uchar Function
+%1806 = OpVariable %_ptr_Function_uchar Function
+%1807 = OpVariable %_ptr_Function_bool Function
+%1808 = OpVariable %_ptr_Function_uchar Function
+%1809 = OpVariable %_ptr_Function_uchar Function
+%1810 = OpVariable %_ptr_Function_uchar Function
+%1811 = OpVariable %_ptr_Function_bool Function
+%1812 = OpVariable %_ptr_Function_uchar Function
+%1813 = OpVariable %_ptr_Function_uchar Function
+%1814 = OpVariable %_ptr_Function_uchar Function
+%1815 = OpVariable %_ptr_Function_bool Function
+%1816 = OpVariable %_ptr_Function_uchar Function
+%1817 = OpVariable %_ptr_Function_uchar Function
+%1818 = OpVariable %_ptr_Function_uchar Function
+%1819 = OpVariable %_ptr_Function_bool Function
+%1820 = OpVariable %_ptr_Function_uchar Function
+%1821 = OpVariable %_ptr_Function_uchar Function
+%1822 = OpVariable %_ptr_Function_uchar Function
+%1823 = OpVariable %_ptr_Function_bool Function
+%1824 = OpVariable %_ptr_Function_uchar Function
+%1825 = OpVariable %_ptr_Function_uchar Function
+%1826 = OpVariable %_ptr_Function_uchar Function
+%1827 = OpVariable %_ptr_Function_bool Function
+%1828 = OpVariable %_ptr_Function_uchar Function
+%1829 = OpVariable %_ptr_Function_uchar Function
+%1830 = OpVariable %_ptr_Function_uchar Function
+%1831 = OpVariable %_ptr_Function_bool Function
+%1832 = OpVariable %_ptr_Function_uchar Function
+%1833 = OpVariable %_ptr_Function_uchar Function
+%1834 = OpVariable %_ptr_Function_uchar Function
+%1835 = OpVariable %_ptr_Function_bool Function
+%1836 = OpVariable %_ptr_Function_uchar Function
+%1837 = OpVariable %_ptr_Function_uchar Function
+%1838 = OpVariable %_ptr_Function_uchar Function
+%1839 = OpVariable %_ptr_Function_bool Function
+%1840 = OpVariable %_ptr_Function_uchar Function
+%1841 = OpVariable %_ptr_Function_uchar Function
+%1842 = OpVariable %_ptr_Function_uchar Function
+%1843 = OpVariable %_ptr_Function_bool Function
+%1844 = OpVariable %_ptr_Function_uchar Function
+%1845 = OpVariable %_ptr_Function_uchar Function
+%1846 = OpVariable %_ptr_Function_uchar Function
+%1847 = OpVariable %_ptr_Function_bool Function
+%1848 = OpVariable %_ptr_Function_uchar Function
+%1849 = OpVariable %_ptr_Function_uchar Function
+%1850 = OpVariable %_ptr_Function_uchar Function
+%1851 = OpVariable %_ptr_Function_bool Function
+%1852 = OpVariable %_ptr_Function_uchar Function
+%1853 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1854 = OpVariable %_ptr_Function_uchar Function
+%1855 = OpVariable %_ptr_Function_uchar Function
+%1856 = OpVariable %_ptr_Function_bool Function
+%1857 = OpVariable %_ptr_Function_uchar Function
+%1858 = OpVariable %_ptr_Function_uchar Function
+%1859 = OpVariable %_ptr_Function_uchar Function
+%1860 = OpVariable %_ptr_Function_bool Function
+%1861 = OpVariable %_ptr_Function_uchar Function
+%1862 = OpVariable %_ptr_Function_uchar Function
+%1863 = OpVariable %_ptr_Function_uchar Function
+%1864 = OpVariable %_ptr_Function_bool Function
+%1865 = OpVariable %_ptr_Function_uchar Function
+%1866 = OpVariable %_ptr_Function_uchar Function
+%1867 = OpVariable %_ptr_Function_uchar Function
+%1868 = OpVariable %_ptr_Function_bool Function
+%1869 = OpVariable %_ptr_Function_uchar Function
+%1870 = OpVariable %_ptr_Function_uchar Function
+%1871 = OpVariable %_ptr_Function_uchar Function
+%1872 = OpVariable %_ptr_Function_bool Function
+%1873 = OpVariable %_ptr_Function_uchar Function
+%1874 = OpVariable %_ptr_Function_uchar Function
+%1875 = OpVariable %_ptr_Function_uchar Function
+%1876 = OpVariable %_ptr_Function_bool Function
+%1877 = OpVariable %_ptr_Function_uchar Function
+%1878 = OpVariable %_ptr_Function_uchar Function
+%1879 = OpVariable %_ptr_Function_uchar Function
+%1880 = OpVariable %_ptr_Function_bool Function
+%1881 = OpVariable %_ptr_Function_uchar Function
+%1882 = OpVariable %_ptr_Function_uchar Function
+%1883 = OpVariable %_ptr_Function_uchar Function
+%1884 = OpVariable %_ptr_Function_bool Function
+%1885 = OpVariable %_ptr_Function_uchar Function
+%1886 = OpVariable %_ptr_Function_uchar Function
+%1887 = OpVariable %_ptr_Function_uchar Function
+%1888 = OpVariable %_ptr_Function_bool Function
+%1889 = OpVariable %_ptr_Function_uchar Function
+%1890 = OpVariable %_ptr_Function_uchar Function
+%1891 = OpVariable %_ptr_Function_uchar Function
+%1892 = OpVariable %_ptr_Function_bool Function
+%1893 = OpVariable %_ptr_Function_uchar Function
+%1894 = OpVariable %_ptr_Function_uchar Function
+%1895 = OpVariable %_ptr_Function_uchar Function
+%1896 = OpVariable %_ptr_Function_bool Function
+%1897 = OpVariable %_ptr_Function_uchar Function
+%1898 = OpVariable %_ptr_Function_uchar Function
+%1899 = OpVariable %_ptr_Function_uchar Function
+%1900 = OpVariable %_ptr_Function_bool Function
+%1901 = OpVariable %_ptr_Function_uchar Function
+%1902 = OpVariable %_ptr_Function_uchar Function
+%1903 = OpVariable %_ptr_Function_uchar Function
+%1904 = OpVariable %_ptr_Function_bool Function
+%1905 = OpVariable %_ptr_Function_uchar Function
+%1906 = OpVariable %_ptr_Function_uchar Function
+%1907 = OpVariable %_ptr_Function_uchar Function
+%1908 = OpVariable %_ptr_Function_bool Function
+%1909 = OpVariable %_ptr_Function_uchar Function
+%1910 = OpVariable %_ptr_Function_uchar Function
+%1911 = OpVariable %_ptr_Function_uchar Function
+%1912 = OpVariable %_ptr_Function_bool Function
+%1913 = OpVariable %_ptr_Function_uchar Function
+%1914 = OpVariable %_ptr_Function_uchar Function
+%1915 = OpVariable %_ptr_Function_uchar Function
+%1916 = OpVariable %_ptr_Function_bool Function
+%1917 = OpVariable %_ptr_Function_uchar Function
+%1918 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1919 = OpVariable %_ptr_Function_uchar Function
+%1920 = OpVariable %_ptr_Function_uchar Function
+%1921 = OpVariable %_ptr_Function_uchar Function
+%1922 = OpVariable %_ptr_Function_uchar Function
+%1923 = OpVariable %_ptr_Function_uchar Function
+%1924 = OpVariable %_ptr_Function_uchar Function
+%1925 = OpVariable %_ptr_Function_uchar Function
+%1926 = OpVariable %_ptr_Function_uchar Function
+%1927 = OpVariable %_ptr_Function_uchar Function
+%1928 = OpVariable %_ptr_Function_uchar Function
+%1929 = OpVariable %_ptr_Function_uchar Function
+%1930 = OpVariable %_ptr_Function_uchar Function
+%1931 = OpVariable %_ptr_Function_uchar Function
+%1932 = OpVariable %_ptr_Function_uchar Function
+%1933 = OpVariable %_ptr_Function_uchar Function
+%1934 = OpVariable %_ptr_Function_uchar Function
+%1935 = OpVariable %_ptr_Function_uchar Function
+%1936 = OpVariable %_ptr_Function_uchar Function
+%1937 = OpVariable %_ptr_Function_uchar Function
+%1938 = OpVariable %_ptr_Function_uchar Function
+%1939 = OpVariable %_ptr_Function_uchar Function
+%1940 = OpVariable %_ptr_Function_uchar Function
+%1941 = OpVariable %_ptr_Function_uchar Function
+%1942 = OpVariable %_ptr_Function_uchar Function
+%1943 = OpVariable %_ptr_Function_uchar Function
+%1944 = OpVariable %_ptr_Function_uchar Function
+%1945 = OpVariable %_ptr_Function_uchar Function
+%1946 = OpVariable %_ptr_Function_uchar Function
+%1947 = OpVariable %_ptr_Function_uchar Function
+%1948 = OpVariable %_ptr_Function_uchar Function
+%1949 = OpVariable %_ptr_Function_uchar Function
+%1950 = OpVariable %_ptr_Function_uchar Function
+%1951 = OpVariable %_ptr_Function_uchar Function
+%1952 = OpVariable %_ptr_Function_uchar Function
+%1953 = OpVariable %_ptr_Function_uchar Function
+%1954 = OpVariable %_ptr_Function_uchar Function
+%1955 = OpVariable %_ptr_Function_uchar Function
+%1956 = OpVariable %_ptr_Function_uchar Function
+%1957 = OpVariable %_ptr_Function_uchar Function
+%1958 = OpVariable %_ptr_Function_uchar Function
+%1959 = OpVariable %_ptr_Function_uchar Function
+%1960 = OpVariable %_ptr_Function_uchar Function
+%1961 = OpVariable %_ptr_Function_uchar Function
+%1962 = OpVariable %_ptr_Function_uchar Function
+%1963 = OpVariable %_ptr_Function_uchar Function
+%1964 = OpVariable %_ptr_Function_uchar Function
+%1965 = OpVariable %_ptr_Function_uchar Function
+%1966 = OpVariable %_ptr_Function_uchar Function
+%1967 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1968 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1969 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1970 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1971 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1972 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1973 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1974 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1975 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1976 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1977 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1978 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1979 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1980 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1981 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1982 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1983 = OpVariable %_ptr_Function_uchar Function
+%1984 = OpVariable %_ptr_Function_uchar Function
+%1985 = OpVariable %_ptr_Function_uchar Function
+%1986 = OpVariable %_ptr_Function_uchar Function
+%1987 = OpVariable %_ptr_Function_uchar Function
+%1988 = OpVariable %_ptr_Function_uchar Function
+%1989 = OpVariable %_ptr_Function_uchar Function
+%1990 = OpVariable %_ptr_Function_uchar Function
+%1991 = OpVariable %_ptr_Function_uchar Function
+%1992 = OpVariable %_ptr_Function_uchar Function
+%1993 = OpVariable %_ptr_Function_uchar Function
+%1994 = OpVariable %_ptr_Function_uchar Function
+%1995 = OpVariable %_ptr_Function_uchar Function
+%1996 = OpVariable %_ptr_Function_uchar Function
+%1997 = OpVariable %_ptr_Function_uchar Function
+%1998 = OpVariable %_ptr_Function_uchar Function
+%1999 = OpVariable %_ptr_Function_uchar Function
+%2000 = OpVariable %_ptr_Function_uchar Function
+%2001 = OpVariable %_ptr_Function_uchar Function
+%2002 = OpVariable %_ptr_Function_uchar Function
+%2003 = OpVariable %_ptr_Function_uchar Function
+%2004 = OpVariable %_ptr_Function_uchar Function
+%2005 = OpVariable %_ptr_Function_uchar Function
+%2006 = OpVariable %_ptr_Function_uchar Function
+%2007 = OpVariable %_ptr_Function_uchar Function
+%2008 = OpVariable %_ptr_Function_uchar Function
+%2009 = OpVariable %_ptr_Function_uchar Function
+%2010 = OpVariable %_ptr_Function_uchar Function
+%2011 = OpVariable %_ptr_Function_uchar Function
+%2012 = OpVariable %_ptr_Function_uchar Function
+%2013 = OpVariable %_ptr_Function_uchar Function
+%2014 = OpVariable %_ptr_Function_uchar Function
+%2015 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2016 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2017 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2018 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2019 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2020 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2021 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2022 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2023 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2024 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2025 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2026 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2027 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2028 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2029 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2030 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2031 = OpVariable %_ptr_Function_uchar Function
+%2032 = OpVariable %_ptr_Function_uchar Function
+%2033 = OpVariable %_ptr_Function_uchar Function
+%2034 = OpVariable %_ptr_Function_uchar Function
+%2035 = OpVariable %_ptr_Function_uchar Function
+%2036 = OpVariable %_ptr_Function_uchar Function
+%2037 = OpVariable %_ptr_Function_uchar Function
+%2038 = OpVariable %_ptr_Function_uchar Function
+%2039 = OpVariable %_ptr_Function_uchar Function
+%2040 = OpVariable %_ptr_Function_uchar Function
+%2041 = OpVariable %_ptr_Function_uchar Function
+%2042 = OpVariable %_ptr_Function_uchar Function
+%2043 = OpVariable %_ptr_Function_uchar Function
+%2044 = OpVariable %_ptr_Function_uchar Function
+%2045 = OpVariable %_ptr_Function_uchar Function
+%2046 = OpVariable %_ptr_Function_uchar Function
+%2047 = OpVariable %_ptr_Function_uchar Function
+%2048 = OpVariable %_ptr_Function_uchar Function
+%2049 = OpVariable %_ptr_Function_uchar Function
+%2050 = OpVariable %_ptr_Function_uchar Function
+%2051 = OpVariable %_ptr_Function_uchar Function
+%2052 = OpVariable %_ptr_Function_uchar Function
+%2053 = OpVariable %_ptr_Function_uchar Function
+%2054 = OpVariable %_ptr_Function_uchar Function
+%2055 = OpVariable %_ptr_Function_uchar Function
+%2056 = OpVariable %_ptr_Function_uchar Function
+%2057 = OpVariable %_ptr_Function_uchar Function
+%2058 = OpVariable %_ptr_Function_uchar Function
+%2059 = OpVariable %_ptr_Function_uchar Function
+%2060 = OpVariable %_ptr_Function_uchar Function
+%2061 = OpVariable %_ptr_Function_uchar Function
+%2062 = OpVariable %_ptr_Function_uchar Function
+%2063 = OpVariable %_ptr_Function_uchar Function
+%2064 = OpVariable %_ptr_Function_uchar Function
+%2065 = OpVariable %_ptr_Function_uchar Function
+%2066 = OpVariable %_ptr_Function_uchar Function
+%2067 = OpVariable %_ptr_Function_uchar Function
+%2068 = OpVariable %_ptr_Function_uchar Function
+%2069 = OpVariable %_ptr_Function_uchar Function
+%2070 = OpVariable %_ptr_Function_uchar Function
+%2071 = OpVariable %_ptr_Function_uchar Function
+%2072 = OpVariable %_ptr_Function_uchar Function
+%2073 = OpVariable %_ptr_Function_uchar Function
+%2074 = OpVariable %_ptr_Function_uchar Function
+%2075 = OpVariable %_ptr_Function_uchar Function
+%2076 = OpVariable %_ptr_Function_uchar Function
+%2077 = OpVariable %_ptr_Function_uchar Function
+%2078 = OpVariable %_ptr_Function_uchar Function
+%2079 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2080 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2081 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2082 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2083 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2084 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2085 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2086 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2087 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2088 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2089 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2090 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2091 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2092 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2093 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2094 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2095 = OpVariable %_ptr_Function_uchar Function
+%2096 = OpVariable %_ptr_Function_uchar Function
+%2097 = OpVariable %_ptr_Function_uchar Function
+%2098 = OpVariable %_ptr_Function_uchar Function
+%2099 = OpVariable %_ptr_Function_uchar Function
+%2100 = OpVariable %_ptr_Function_uchar Function
+%2101 = OpVariable %_ptr_Function_uchar Function
+%2102 = OpVariable %_ptr_Function_uchar Function
+%2103 = OpVariable %_ptr_Function_uchar Function
+%2104 = OpVariable %_ptr_Function_uchar Function
+%2105 = OpVariable %_ptr_Function_uchar Function
+%2106 = OpVariable %_ptr_Function_uchar Function
+%2107 = OpVariable %_ptr_Function_uchar Function
+%2108 = OpVariable %_ptr_Function_uchar Function
+%2109 = OpVariable %_ptr_Function_uchar Function
+%2110 = OpVariable %_ptr_Function_uchar Function
+%2111 = OpVariable %_ptr_Function_uchar Function
+%2112 = OpVariable %_ptr_Function_uchar Function
+%2113 = OpVariable %_ptr_Function_uchar Function
+%2114 = OpVariable %_ptr_Function_uchar Function
+%2115 = OpVariable %_ptr_Function_uchar Function
+%2116 = OpVariable %_ptr_Function_uchar Function
+%2117 = OpVariable %_ptr_Function_uchar Function
+%2118 = OpVariable %_ptr_Function_uchar Function
+%2119 = OpVariable %_ptr_Function_uchar Function
+%2120 = OpVariable %_ptr_Function_uchar Function
+%2121 = OpVariable %_ptr_Function_uchar Function
+%2122 = OpVariable %_ptr_Function_uchar Function
+%2123 = OpVariable %_ptr_Function_uchar Function
+%2124 = OpVariable %_ptr_Function_uchar Function
+%2125 = OpVariable %_ptr_Function_uchar Function
+%2126 = OpVariable %_ptr_Function_uchar Function
+%2127 = OpVariable %_ptr_Function_uchar Function
+%2128 = OpVariable %_ptr_Function_uchar Function
+%2129 = OpVariable %_ptr_Function_uchar Function
+%2130 = OpVariable %_ptr_Function_uchar Function
+%2131 = OpVariable %_ptr_Function_uchar Function
+%2132 = OpVariable %_ptr_Function_uchar Function
+%2133 = OpVariable %_ptr_Function_uchar Function
+%2134 = OpVariable %_ptr_Function_uchar Function
+%2135 = OpVariable %_ptr_Function_uchar Function
+%2136 = OpVariable %_ptr_Function_uchar Function
+%2137 = OpVariable %_ptr_Function_uchar Function
+%2138 = OpVariable %_ptr_Function_uchar Function
+%2139 = OpVariable %_ptr_Function_uchar Function
+%2140 = OpVariable %_ptr_Function_uchar Function
+%2141 = OpVariable %_ptr_Function_uchar Function
+%2142 = OpVariable %_ptr_Function_uchar Function
+%2143 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2144 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2145 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2146 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2147 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2148 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2149 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2150 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2151 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2152 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2153 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2154 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2155 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2156 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2157 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2158 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+OpStore %1153 %979
+OpBranch %981
+%981 = OpLabel
+OpBranch %982
+%982 = OpLabel
+%2159 = OpLoad %ulong %1153
+%2160 = OpUConvert %uint %2159
+OpStore %1154 %2160
+%2161 = OpLoad %ulong %1153
+%2162 = OpConvertUToF %float %2161
+OpStore %1155 %2162
+%2163 = OpLoad %ulong %1153
+%2164 = OpUConvert %ushort %2163
+OpStore %1156 %2164
+%2165 = OpLoad %ulong %1153
+%2166 = OpUConvert %uchar %2165
+OpStore %1157 %2166
+%2167 = OpCompositeConstruct %v4uint %uint_10 %uint_20 %uint_30 %uint_4294967295
+OpStore %1158 %2167
+%2172 = OpCompositeConstruct %v4uint %uint_20 %uint_20 %uint_10 %uint_1
+OpStore %1159 %2172
+%2174 = OpLoad %v4uint %1158
+%2175 = OpCompositeExtract %uint %2174 0
+OpStore %1160 %2175
+%2176 = OpLoad %uint %1160
+%2177 = OpLoad %uint %1154
+%2178 = OpIAdd %uint %2176 %2177
+OpStore %1161 %2178
+%2179 = OpLoad %v4uint %1158
+%2180 = OpLoad %uint %1161
+%2181 = OpCompositeInsert %v4uint %2180 %2179 0
+OpStore %1162 %2181
+%2182 = OpLoad %v4uint %1159
+%2183 = OpCompositeExtract %uint %2182 3
+OpStore %1163 %2183
+%2184 = OpLoad %uint %1163
+%2185 = OpLoad %uint %1154
+%2186 = OpIAdd %uint %2184 %2185
+OpStore %1164 %2186
+%2187 = OpLoad %v4uint %1159
+%2188 = OpLoad %uint %1164
+%2189 = OpCompositeInsert %v4uint %2188 %2187 3
+OpStore %1165 %2189
+%2191 = OpLoad %v4uint %1162
+%2192 = OpLoad %v4uint %1165
+%2193 = OpULessThan %v4bool %2191 %2192
+%2197 = OpSelect %v4uint %2193 %2194 %2196
+OpStore %1166 %2197
+OpBranch %983
+%983 = OpLabel
+%2198 = OpLoad %v4uint %1166
+%2199 = OpCompositeExtract %uint %2198 0
+OpStore %1273 %2199
+OpBranch %984
+%984 = OpLabel
+%2200 = OpLoad %uint %1273
+%2201 = OpUConvert %ulong %2200
+OpStore %1277 %2201
+%2203 = OpLoad %ulong %1277
+%2204 = OpFunctionCall %ulong %7 %ulong_14695981039346656037 %2203
+OpStore %1278 %2204
+OpBranch %985
+%985 = OpLabel
+%2205 = OpLoad %v4uint %1166
+%2206 = OpCompositeExtract %uint %2205 1
+OpStore %1274 %2206
+OpBranch %986
+%986 = OpLabel
+%2207 = OpLoad %uint %1274
+%2208 = OpUConvert %ulong %2207
+OpStore %1279 %2208
+%2209 = OpLoad %ulong %1278
+%2210 = OpLoad %ulong %1279
+%2211 = OpFunctionCall %ulong %7 %2209 %2210
+OpStore %1280 %2211
+OpBranch %987
+%987 = OpLabel
+%2212 = OpLoad %v4uint %1166
+%2213 = OpCompositeExtract %uint %2212 2
+OpStore %1275 %2213
+OpBranch %988
+%988 = OpLabel
+%2214 = OpLoad %uint %1275
+%2215 = OpUConvert %ulong %2214
+OpStore %1281 %2215
+%2216 = OpLoad %ulong %1280
+%2217 = OpLoad %ulong %1281
+%2218 = OpFunctionCall %ulong %7 %2216 %2217
+OpStore %1282 %2218
+OpBranch %989
+%989 = OpLabel
+%2219 = OpLoad %v4uint %1166
+%2220 = OpCompositeExtract %uint %2219 3
+OpStore %1276 %2220
+OpBranch %990
+%990 = OpLabel
+%2221 = OpLoad %uint %1276
+%2222 = OpUConvert %ulong %2221
+OpStore %1283 %2222
+%2223 = OpLoad %ulong %1282
+%2224 = OpLoad %ulong %1283
+%2225 = OpFunctionCall %ulong %7 %2223 %2224
+OpStore %1284 %2225
+OpBranch %991
+%991 = OpLabel
+OpBranch %992
+%992 = OpLabel
+%2226 = OpLoad %v4uint %1165
+%2227 = OpLoad %v4uint %1162
+%2228 = OpULessThan %v4bool %2226 %2227
+%2229 = OpSelect %v4uint %2228 %2194 %2196
+OpStore %1167 %2229
+OpBranch %993
+%993 = OpLabel
+%2230 = OpLoad %v4uint %1167
+%2231 = OpCompositeExtract %uint %2230 0
+OpStore %1285 %2231
+OpBranch %994
+%994 = OpLabel
+%2232 = OpLoad %uint %1285
+%2233 = OpUConvert %ulong %2232
+OpStore %1289 %2233
+%2234 = OpLoad %ulong %1284
+%2235 = OpLoad %ulong %1289
+%2236 = OpFunctionCall %ulong %7 %2234 %2235
+OpStore %1290 %2236
+OpBranch %995
+%995 = OpLabel
+%2237 = OpLoad %v4uint %1167
+%2238 = OpCompositeExtract %uint %2237 1
+OpStore %1286 %2238
+OpBranch %996
+%996 = OpLabel
+%2239 = OpLoad %uint %1286
+%2240 = OpUConvert %ulong %2239
+OpStore %1291 %2240
+%2241 = OpLoad %ulong %1290
+%2242 = OpLoad %ulong %1291
+%2243 = OpFunctionCall %ulong %7 %2241 %2242
+OpStore %1292 %2243
+OpBranch %997
+%997 = OpLabel
+%2244 = OpLoad %v4uint %1167
+%2245 = OpCompositeExtract %uint %2244 2
+OpStore %1287 %2245
+OpBranch %998
+%998 = OpLabel
+%2246 = OpLoad %uint %1287
+%2247 = OpUConvert %ulong %2246
+OpStore %1293 %2247
+%2248 = OpLoad %ulong %1292
+%2249 = OpLoad %ulong %1293
+%2250 = OpFunctionCall %ulong %7 %2248 %2249
+OpStore %1294 %2250
+OpBranch %999
+%999 = OpLabel
+%2251 = OpLoad %v4uint %1167
+%2252 = OpCompositeExtract %uint %2251 3
+OpStore %1288 %2252
+OpBranch %1000
+%1000 = OpLabel
+%2253 = OpLoad %uint %1288
+%2254 = OpUConvert %ulong %2253
+OpStore %1295 %2254
+%2255 = OpLoad %ulong %1294
+%2256 = OpLoad %ulong %1295
+%2257 = OpFunctionCall %ulong %7 %2255 %2256
+OpStore %1296 %2257
+OpBranch %1001
+%1001 = OpLabel
+OpBranch %1002
+%1002 = OpLabel
+%2258 = OpLoad %v4uint %1162
+%2259 = OpLoad %v4uint %1165
+%2260 = OpIEqual %v4bool %2258 %2259
+%2261 = OpSelect %v4uint %2260 %2194 %2196
+OpStore %1168 %2261
+OpBranch %1003
+%1003 = OpLabel
+%2262 = OpLoad %v4uint %1168
+%2263 = OpCompositeExtract %uint %2262 0
+OpStore %1297 %2263
+OpBranch %1004
+%1004 = OpLabel
+%2264 = OpLoad %uint %1297
+%2265 = OpUConvert %ulong %2264
+OpStore %1301 %2265
+%2266 = OpLoad %ulong %1296
+%2267 = OpLoad %ulong %1301
+%2268 = OpFunctionCall %ulong %7 %2266 %2267
+OpStore %1302 %2268
+OpBranch %1005
+%1005 = OpLabel
+%2269 = OpLoad %v4uint %1168
+%2270 = OpCompositeExtract %uint %2269 1
+OpStore %1298 %2270
+OpBranch %1006
+%1006 = OpLabel
+%2271 = OpLoad %uint %1298
+%2272 = OpUConvert %ulong %2271
+OpStore %1303 %2272
+%2273 = OpLoad %ulong %1302
+%2274 = OpLoad %ulong %1303
+%2275 = OpFunctionCall %ulong %7 %2273 %2274
+OpStore %1304 %2275
+OpBranch %1007
+%1007 = OpLabel
+%2276 = OpLoad %v4uint %1168
+%2277 = OpCompositeExtract %uint %2276 2
+OpStore %1299 %2277
+OpBranch %1008
+%1008 = OpLabel
+%2278 = OpLoad %uint %1299
+%2279 = OpUConvert %ulong %2278
+OpStore %1305 %2279
+%2280 = OpLoad %ulong %1304
+%2281 = OpLoad %ulong %1305
+%2282 = OpFunctionCall %ulong %7 %2280 %2281
+OpStore %1306 %2282
+OpBranch %1009
+%1009 = OpLabel
+%2283 = OpLoad %v4uint %1168
+%2284 = OpCompositeExtract %uint %2283 3
+OpStore %1300 %2284
+OpBranch %1010
+%1010 = OpLabel
+%2285 = OpLoad %uint %1300
+%2286 = OpUConvert %ulong %2285
+OpStore %1307 %2286
+%2287 = OpLoad %ulong %1306
+%2288 = OpLoad %ulong %1307
+%2289 = OpFunctionCall %ulong %7 %2287 %2288
+OpStore %1308 %2289
+OpBranch %1011
+%1011 = OpLabel
+OpBranch %1012
+%1012 = OpLabel
+%2290 = OpLoad %v4uint %1162
+%2291 = OpLoad %v4uint %1165
+%2292 = OpINotEqual %v4bool %2290 %2291
+%2293 = OpSelect %v4uint %2292 %2194 %2196
+OpStore %1169 %2293
+OpBranch %1013
+%1013 = OpLabel
+%2294 = OpLoad %v4uint %1169
+%2295 = OpCompositeExtract %uint %2294 0
+OpStore %1309 %2295
+OpBranch %1014
+%1014 = OpLabel
+%2296 = OpLoad %uint %1309
+%2297 = OpUConvert %ulong %2296
+OpStore %1313 %2297
+%2298 = OpLoad %ulong %1308
+%2299 = OpLoad %ulong %1313
+%2300 = OpFunctionCall %ulong %7 %2298 %2299
+OpStore %1314 %2300
+OpBranch %1015
+%1015 = OpLabel
+%2301 = OpLoad %v4uint %1169
+%2302 = OpCompositeExtract %uint %2301 1
+OpStore %1310 %2302
+OpBranch %1016
+%1016 = OpLabel
+%2303 = OpLoad %uint %1310
+%2304 = OpUConvert %ulong %2303
+OpStore %1315 %2304
+%2305 = OpLoad %ulong %1314
+%2306 = OpLoad %ulong %1315
+%2307 = OpFunctionCall %ulong %7 %2305 %2306
+OpStore %1316 %2307
+OpBranch %1017
+%1017 = OpLabel
+%2308 = OpLoad %v4uint %1169
+%2309 = OpCompositeExtract %uint %2308 2
+OpStore %1311 %2309
+OpBranch %1018
+%1018 = OpLabel
+%2310 = OpLoad %uint %1311
+%2311 = OpUConvert %ulong %2310
+OpStore %1317 %2311
+%2312 = OpLoad %ulong %1316
+%2313 = OpLoad %ulong %1317
+%2314 = OpFunctionCall %ulong %7 %2312 %2313
+OpStore %1318 %2314
+OpBranch %1019
+%1019 = OpLabel
+%2315 = OpLoad %v4uint %1169
+%2316 = OpCompositeExtract %uint %2315 3
+OpStore %1312 %2316
+OpBranch %1020
+%1020 = OpLabel
+%2317 = OpLoad %uint %1312
+%2318 = OpUConvert %ulong %2317
+OpStore %1319 %2318
+%2319 = OpLoad %ulong %1318
+%2320 = OpLoad %ulong %1319
+%2321 = OpFunctionCall %ulong %7 %2319 %2320
+OpStore %1320 %2321
+OpBranch %1021
+%1021 = OpLabel
+OpBranch %1022
+%1022 = OpLabel
+%2322 = OpLoad %v4uint %1162
+%2323 = OpLoad %v4uint %1165
+%2324 = OpULessThanEqual %v4bool %2322 %2323
+%2325 = OpSelect %v4uint %2324 %2194 %2196
+OpStore %1170 %2325
+OpBranch %1023
+%1023 = OpLabel
+%2326 = OpLoad %v4uint %1170
+%2327 = OpCompositeExtract %uint %2326 0
+OpStore %1321 %2327
+OpBranch %1024
+%1024 = OpLabel
+%2328 = OpLoad %uint %1321
+%2329 = OpUConvert %ulong %2328
+OpStore %1325 %2329
+%2330 = OpLoad %ulong %1320
+%2331 = OpLoad %ulong %1325
+%2332 = OpFunctionCall %ulong %7 %2330 %2331
+OpStore %1326 %2332
+OpBranch %1025
+%1025 = OpLabel
+%2333 = OpLoad %v4uint %1170
+%2334 = OpCompositeExtract %uint %2333 1
+OpStore %1322 %2334
+OpBranch %1026
+%1026 = OpLabel
+%2335 = OpLoad %uint %1322
+%2336 = OpUConvert %ulong %2335
+OpStore %1327 %2336
+%2337 = OpLoad %ulong %1326
+%2338 = OpLoad %ulong %1327
+%2339 = OpFunctionCall %ulong %7 %2337 %2338
+OpStore %1328 %2339
+OpBranch %1027
+%1027 = OpLabel
+%2340 = OpLoad %v4uint %1170
+%2341 = OpCompositeExtract %uint %2340 2
+OpStore %1323 %2341
+OpBranch %1028
+%1028 = OpLabel
+%2342 = OpLoad %uint %1323
+%2343 = OpUConvert %ulong %2342
+OpStore %1329 %2343
+%2344 = OpLoad %ulong %1328
+%2345 = OpLoad %ulong %1329
+%2346 = OpFunctionCall %ulong %7 %2344 %2345
+OpStore %1330 %2346
+OpBranch %1029
+%1029 = OpLabel
+%2347 = OpLoad %v4uint %1170
+%2348 = OpCompositeExtract %uint %2347 3
+OpStore %1324 %2348
+OpBranch %1030
+%1030 = OpLabel
+%2349 = OpLoad %uint %1324
+%2350 = OpUConvert %ulong %2349
+OpStore %1331 %2350
+%2351 = OpLoad %ulong %1330
+%2352 = OpLoad %ulong %1331
+%2353 = OpFunctionCall %ulong %7 %2351 %2352
+OpStore %1332 %2353
+OpBranch %1031
+%1031 = OpLabel
+OpBranch %1032
+%1032 = OpLabel
+%2354 = OpLoad %v4uint %1165
+%2355 = OpLoad %v4uint %1162
+%2356 = OpULessThanEqual %v4bool %2354 %2355
+%2357 = OpSelect %v4uint %2356 %2194 %2196
+OpStore %1171 %2357
+OpBranch %1033
+%1033 = OpLabel
+%2358 = OpLoad %v4uint %1171
+%2359 = OpCompositeExtract %uint %2358 0
+OpStore %1333 %2359
+OpBranch %1034
+%1034 = OpLabel
+%2360 = OpLoad %uint %1333
+%2361 = OpUConvert %ulong %2360
+OpStore %1337 %2361
+%2362 = OpLoad %ulong %1332
+%2363 = OpLoad %ulong %1337
+%2364 = OpFunctionCall %ulong %7 %2362 %2363
+OpStore %1338 %2364
+OpBranch %1035
+%1035 = OpLabel
+%2365 = OpLoad %v4uint %1171
+%2366 = OpCompositeExtract %uint %2365 1
+OpStore %1334 %2366
+OpBranch %1036
+%1036 = OpLabel
+%2367 = OpLoad %uint %1334
+%2368 = OpUConvert %ulong %2367
+OpStore %1339 %2368
+%2369 = OpLoad %ulong %1338
+%2370 = OpLoad %ulong %1339
+%2371 = OpFunctionCall %ulong %7 %2369 %2370
+OpStore %1340 %2371
+OpBranch %1037
+%1037 = OpLabel
+%2372 = OpLoad %v4uint %1171
+%2373 = OpCompositeExtract %uint %2372 2
+OpStore %1335 %2373
+OpBranch %1038
+%1038 = OpLabel
+%2374 = OpLoad %uint %1335
+%2375 = OpUConvert %ulong %2374
+OpStore %1341 %2375
+%2376 = OpLoad %ulong %1340
+%2377 = OpLoad %ulong %1341
+%2378 = OpFunctionCall %ulong %7 %2376 %2377
+OpStore %1342 %2378
+OpBranch %1039
+%1039 = OpLabel
+%2379 = OpLoad %v4uint %1171
+%2380 = OpCompositeExtract %uint %2379 3
+OpStore %1336 %2380
+OpBranch %1040
+%1040 = OpLabel
+%2381 = OpLoad %uint %1336
+%2382 = OpUConvert %ulong %2381
+OpStore %1343 %2382
+%2383 = OpLoad %ulong %1342
+%2384 = OpLoad %ulong %1343
+%2385 = OpFunctionCall %ulong %7 %2383 %2384
+OpStore %1344 %2385
+OpBranch %1041
+%1041 = OpLabel
+OpBranch %1042
+%1042 = OpLabel
+%2386 = OpLoad %v4uint %1162
+%2387 = OpLoad %v4uint %1165
+%2388 = OpULessThan %v4bool %2386 %2387
+%2389 = OpSelect %v4uint %2388 %2194 %2196
+OpStore %1172 %2389
+%2390 = OpLoad %v4uint %1172
+%2391 = OpLoad %v4uint %1162
+%2392 = OpBitwiseAnd %v4uint %2390 %2391
+OpStore %1173 %2392
+%2393 = OpLoad %v4uint %1172
+%2394 = OpNot %v4uint %2393
+OpStore %1174 %2394
+%2395 = OpLoad %v4uint %1174
+%2396 = OpLoad %v4uint %1165
+%2397 = OpBitwiseAnd %v4uint %2395 %2396
+OpStore %1175 %2397
+%2398 = OpLoad %v4uint %1173
+%2399 = OpLoad %v4uint %1175
+%2400 = OpBitwiseOr %v4uint %2398 %2399
+OpStore %1176 %2400
+OpBranch %1043
+%1043 = OpLabel
+%2401 = OpLoad %v4uint %1176
+%2402 = OpCompositeExtract %uint %2401 0
+OpStore %1345 %2402
+OpBranch %1044
+%1044 = OpLabel
+%2403 = OpLoad %uint %1345
+%2404 = OpUConvert %ulong %2403
+OpStore %1349 %2404
+%2405 = OpLoad %ulong %1344
+%2406 = OpLoad %ulong %1349
+%2407 = OpFunctionCall %ulong %7 %2405 %2406
+OpStore %1350 %2407
+OpBranch %1045
+%1045 = OpLabel
+%2408 = OpLoad %v4uint %1176
+%2409 = OpCompositeExtract %uint %2408 1
+OpStore %1346 %2409
+OpBranch %1046
+%1046 = OpLabel
+%2410 = OpLoad %uint %1346
+%2411 = OpUConvert %ulong %2410
+OpStore %1351 %2411
+%2412 = OpLoad %ulong %1350
+%2413 = OpLoad %ulong %1351
+%2414 = OpFunctionCall %ulong %7 %2412 %2413
+OpStore %1352 %2414
+OpBranch %1047
+%1047 = OpLabel
+%2415 = OpLoad %v4uint %1176
+%2416 = OpCompositeExtract %uint %2415 2
+OpStore %1347 %2416
+OpBranch %1048
+%1048 = OpLabel
+%2417 = OpLoad %uint %1347
+%2418 = OpUConvert %ulong %2417
+OpStore %1353 %2418
+%2419 = OpLoad %ulong %1352
+%2420 = OpLoad %ulong %1353
+%2421 = OpFunctionCall %ulong %7 %2419 %2420
+OpStore %1354 %2421
+OpBranch %1049
+%1049 = OpLabel
+%2422 = OpLoad %v4uint %1176
+%2423 = OpCompositeExtract %uint %2422 3
+OpStore %1348 %2423
+OpBranch %1050
+%1050 = OpLabel
+%2424 = OpLoad %uint %1348
+%2425 = OpUConvert %ulong %2424
+OpStore %1355 %2425
+%2426 = OpLoad %ulong %1354
+%2427 = OpLoad %ulong %1355
+%2428 = OpFunctionCall %ulong %7 %2426 %2427
+OpStore %1356 %2428
+OpBranch %1051
+%1051 = OpLabel
+OpBranch %1052
+%1052 = OpLabel
+%2429 = OpLoad %v4uint %1172
+%2430 = OpLoad %v4uint %1165
+%2431 = OpBitwiseAnd %v4uint %2429 %2430
+OpStore %1177 %2431
+%2432 = OpLoad %v4uint %1172
+%2433 = OpNot %v4uint %2432
+OpStore %1178 %2433
+%2434 = OpLoad %v4uint %1178
+%2435 = OpLoad %v4uint %1162
+%2436 = OpBitwiseAnd %v4uint %2434 %2435
+OpStore %1179 %2436
+%2437 = OpLoad %v4uint %1177
+%2438 = OpLoad %v4uint %1179
+%2439 = OpBitwiseOr %v4uint %2437 %2438
+OpStore %1180 %2439
+OpBranch %1053
+%1053 = OpLabel
+%2440 = OpLoad %v4uint %1180
+%2441 = OpCompositeExtract %uint %2440 0
+OpStore %1357 %2441
+OpBranch %1054
+%1054 = OpLabel
+%2442 = OpLoad %uint %1357
+%2443 = OpUConvert %ulong %2442
+OpStore %1361 %2443
+%2444 = OpLoad %ulong %1356
+%2445 = OpLoad %ulong %1361
+%2446 = OpFunctionCall %ulong %7 %2444 %2445
+OpStore %1362 %2446
+OpBranch %1055
+%1055 = OpLabel
+%2447 = OpLoad %v4uint %1180
+%2448 = OpCompositeExtract %uint %2447 1
+OpStore %1358 %2448
+OpBranch %1056
+%1056 = OpLabel
+%2449 = OpLoad %uint %1358
+%2450 = OpUConvert %ulong %2449
+OpStore %1363 %2450
+%2451 = OpLoad %ulong %1362
+%2452 = OpLoad %ulong %1363
+%2453 = OpFunctionCall %ulong %7 %2451 %2452
+OpStore %1364 %2453
+OpBranch %1057
+%1057 = OpLabel
+%2454 = OpLoad %v4uint %1180
+%2455 = OpCompositeExtract %uint %2454 2
+OpStore %1359 %2455
+OpBranch %1058
+%1058 = OpLabel
+%2456 = OpLoad %uint %1359
+%2457 = OpUConvert %ulong %2456
+OpStore %1365 %2457
+%2458 = OpLoad %ulong %1364
+%2459 = OpLoad %ulong %1365
+%2460 = OpFunctionCall %ulong %7 %2458 %2459
+OpStore %1366 %2460
+OpBranch %1059
+%1059 = OpLabel
+%2461 = OpLoad %v4uint %1180
+%2462 = OpCompositeExtract %uint %2461 3
+OpStore %1360 %2462
+OpBranch %1060
+%1060 = OpLabel
+%2463 = OpLoad %uint %1360
+%2464 = OpUConvert %ulong %2463
+OpStore %1367 %2464
+%2465 = OpLoad %ulong %1366
+%2466 = OpLoad %ulong %1367
+%2467 = OpFunctionCall %ulong %7 %2465 %2466
+OpStore %1368 %2467
+OpBranch %1061
+%1061 = OpLabel
+OpBranch %1062
+%1062 = OpLabel
+%2468 = OpLoad %v4uint %1162
+%2469 = OpLoad %v4uint %1165
+%2470 = OpIAdd %v4uint %2468 %2469
+OpStore %1181 %2470
+%2471 = OpLoad %v4uint %1172
+%2472 = OpLoad %v4uint %1181
+%2473 = OpBitwiseAnd %v4uint %2471 %2472
+OpStore %1182 %2473
+OpBranch %1063
+%1063 = OpLabel
+%2474 = OpLoad %v4uint %1182
+%2475 = OpCompositeExtract %uint %2474 0
+OpStore %1369 %2475
+OpBranch %1064
+%1064 = OpLabel
+%2476 = OpLoad %uint %1369
+%2477 = OpUConvert %ulong %2476
+OpStore %1373 %2477
+%2478 = OpLoad %ulong %1368
+%2479 = OpLoad %ulong %1373
+%2480 = OpFunctionCall %ulong %7 %2478 %2479
+OpStore %1374 %2480
+OpBranch %1065
+%1065 = OpLabel
+%2481 = OpLoad %v4uint %1182
+%2482 = OpCompositeExtract %uint %2481 1
+OpStore %1370 %2482
+OpBranch %1066
+%1066 = OpLabel
+%2483 = OpLoad %uint %1370
+%2484 = OpUConvert %ulong %2483
+OpStore %1375 %2484
+%2485 = OpLoad %ulong %1374
+%2486 = OpLoad %ulong %1375
+%2487 = OpFunctionCall %ulong %7 %2485 %2486
+OpStore %1376 %2487
+OpBranch %1067
+%1067 = OpLabel
+%2488 = OpLoad %v4uint %1182
+%2489 = OpCompositeExtract %uint %2488 2
+OpStore %1371 %2489
+OpBranch %1068
+%1068 = OpLabel
+%2490 = OpLoad %uint %1371
+%2491 = OpUConvert %ulong %2490
+OpStore %1377 %2491
+%2492 = OpLoad %ulong %1376
+%2493 = OpLoad %ulong %1377
+%2494 = OpFunctionCall %ulong %7 %2492 %2493
+OpStore %1378 %2494
+OpBranch %1069
+%1069 = OpLabel
+%2495 = OpLoad %v4uint %1182
+%2496 = OpCompositeExtract %uint %2495 3
+OpStore %1372 %2496
+OpBranch %1070
+%1070 = OpLabel
+%2497 = OpLoad %uint %1372
+%2498 = OpUConvert %ulong %2497
+OpStore %1379 %2498
+%2499 = OpLoad %ulong %1378
+%2500 = OpLoad %ulong %1379
+%2501 = OpFunctionCall %ulong %7 %2499 %2500
+OpStore %1380 %2501
+OpBranch %1071
+%1071 = OpLabel
+OpBranch %1072
+%1072 = OpLabel
+%2502 = OpLoad %v4uint %1172
+%2503 = OpNot %v4uint %2502
+OpStore %1183 %2503
+%2504 = OpLoad %v4uint %1162
+%2505 = OpLoad %v4uint %1165
+%2506 = OpISub %v4uint %2504 %2505
+OpStore %1184 %2506
+%2507 = OpLoad %v4uint %1183
+%2508 = OpLoad %v4uint %1184
+%2509 = OpBitwiseOr %v4uint %2507 %2508
+OpStore %1185 %2509
+OpBranch %1073
+%1073 = OpLabel
+%2510 = OpLoad %v4uint %1185
+%2511 = OpCompositeExtract %uint %2510 0
+OpStore %1381 %2511
+OpBranch %1074
+%1074 = OpLabel
+%2512 = OpLoad %uint %1381
+%2513 = OpUConvert %ulong %2512
+OpStore %1385 %2513
+%2514 = OpLoad %ulong %1380
+%2515 = OpLoad %ulong %1385
+%2516 = OpFunctionCall %ulong %7 %2514 %2515
+OpStore %1386 %2516
+OpBranch %1075
+%1075 = OpLabel
+%2517 = OpLoad %v4uint %1185
+%2518 = OpCompositeExtract %uint %2517 1
+OpStore %1382 %2518
+OpBranch %1076
+%1076 = OpLabel
+%2519 = OpLoad %uint %1382
+%2520 = OpUConvert %ulong %2519
+OpStore %1387 %2520
+%2521 = OpLoad %ulong %1386
+%2522 = OpLoad %ulong %1387
+%2523 = OpFunctionCall %ulong %7 %2521 %2522
+OpStore %1388 %2523
+OpBranch %1077
+%1077 = OpLabel
+%2524 = OpLoad %v4uint %1185
+%2525 = OpCompositeExtract %uint %2524 2
+OpStore %1383 %2525
+OpBranch %1078
+%1078 = OpLabel
+%2526 = OpLoad %uint %1383
+%2527 = OpUConvert %ulong %2526
+OpStore %1389 %2527
+%2528 = OpLoad %ulong %1388
+%2529 = OpLoad %ulong %1389
+%2530 = OpFunctionCall %ulong %7 %2528 %2529
+OpStore %1390 %2530
+OpBranch %1079
+%1079 = OpLabel
+%2531 = OpLoad %v4uint %1185
+%2532 = OpCompositeExtract %uint %2531 3
+OpStore %1384 %2532
+OpBranch %1080
+%1080 = OpLabel
+%2533 = OpLoad %uint %1384
+%2534 = OpUConvert %ulong %2533
+OpStore %1391 %2534
+%2535 = OpLoad %ulong %1390
+%2536 = OpLoad %ulong %1391
+%2537 = OpFunctionCall %ulong %7 %2535 %2536
+OpStore %1392 %2537
+OpBranch %1081
+%1081 = OpLabel
+OpBranch %1082
+%1082 = OpLabel
+%2538 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_5 %uint_2294967296 %uint_7
+OpStore %1186 %2538
+%2542 = OpCompositeConstruct %v4uint %uint_1 %uint_5 %uint_2000000000 %uint_4294967289
+OpStore %1187 %2542
+%2545 = OpLoad %v4uint %1186
+%2546 = OpCompositeExtract %uint %2545 0
+OpStore %1188 %2546
+%2547 = OpLoad %uint %1188
+%2548 = OpLoad %uint %1154
+%2549 = OpIAdd %uint %2547 %2548
+OpStore %1189 %2549
+%2550 = OpLoad %v4uint %1186
+%2551 = OpLoad %uint %1189
+%2552 = OpCompositeInsert %v4uint %2551 %2550 0
+OpStore %1190 %2552
+%2553 = OpLoad %v4uint %1187
+%2554 = OpCompositeExtract %uint %2553 3
+OpStore %1191 %2554
+%2555 = OpLoad %uint %1191
+%2556 = OpLoad %uint %1154
+%2557 = OpIAdd %uint %2555 %2556
+OpStore %1192 %2557
+%2558 = OpLoad %v4uint %1187
+%2559 = OpLoad %uint %1192
+%2560 = OpCompositeInsert %v4uint %2559 %2558 3
+OpStore %1193 %2560
+%2561 = OpLoad %v4uint %1190
+%2562 = OpLoad %v4uint %1193
+%2563 = OpSLessThan %v4bool %2561 %2562
+%2564 = OpSelect %v4uint %2563 %2194 %2196
+OpStore %1194 %2564
+OpBranch %1083
+%1083 = OpLabel
+%2565 = OpLoad %v4uint %1194
+%2566 = OpCompositeExtract %uint %2565 0
+OpStore %1393 %2566
+OpBranch %1084
+%1084 = OpLabel
+%2567 = OpLoad %uint %1393
+%2568 = OpUConvert %ulong %2567
+OpStore %1397 %2568
+%2569 = OpLoad %ulong %1392
+%2570 = OpLoad %ulong %1397
+%2571 = OpFunctionCall %ulong %7 %2569 %2570
+OpStore %1398 %2571
+OpBranch %1085
+%1085 = OpLabel
+%2572 = OpLoad %v4uint %1194
+%2573 = OpCompositeExtract %uint %2572 1
+OpStore %1394 %2573
+OpBranch %1086
+%1086 = OpLabel
+%2574 = OpLoad %uint %1394
+%2575 = OpUConvert %ulong %2574
+OpStore %1399 %2575
+%2576 = OpLoad %ulong %1398
+%2577 = OpLoad %ulong %1399
+%2578 = OpFunctionCall %ulong %7 %2576 %2577
+OpStore %1400 %2578
+OpBranch %1087
+%1087 = OpLabel
+%2579 = OpLoad %v4uint %1194
+%2580 = OpCompositeExtract %uint %2579 2
+OpStore %1395 %2580
+OpBranch %1088
+%1088 = OpLabel
+%2581 = OpLoad %uint %1395
+%2582 = OpUConvert %ulong %2581
+OpStore %1401 %2582
+%2583 = OpLoad %ulong %1400
+%2584 = OpLoad %ulong %1401
+%2585 = OpFunctionCall %ulong %7 %2583 %2584
+OpStore %1402 %2585
+OpBranch %1089
+%1089 = OpLabel
+%2586 = OpLoad %v4uint %1194
+%2587 = OpCompositeExtract %uint %2586 3
+OpStore %1396 %2587
+OpBranch %1090
+%1090 = OpLabel
+%2588 = OpLoad %uint %1396
+%2589 = OpUConvert %ulong %2588
+OpStore %1403 %2589
+%2590 = OpLoad %ulong %1402
+%2591 = OpLoad %ulong %1403
+%2592 = OpFunctionCall %ulong %7 %2590 %2591
+OpStore %1404 %2592
+OpBranch %1091
+%1091 = OpLabel
+OpBranch %1092
+%1092 = OpLabel
+%2593 = OpLoad %v4uint %1193
+%2594 = OpLoad %v4uint %1190
+%2595 = OpSLessThan %v4bool %2593 %2594
+%2596 = OpSelect %v4uint %2595 %2194 %2196
+OpStore %1195 %2596
+OpBranch %1093
+%1093 = OpLabel
+%2597 = OpLoad %v4uint %1195
+%2598 = OpCompositeExtract %uint %2597 0
+OpStore %1405 %2598
+OpBranch %1094
+%1094 = OpLabel
+%2599 = OpLoad %uint %1405
+%2600 = OpUConvert %ulong %2599
+OpStore %1409 %2600
+%2601 = OpLoad %ulong %1404
+%2602 = OpLoad %ulong %1409
+%2603 = OpFunctionCall %ulong %7 %2601 %2602
+OpStore %1410 %2603
+OpBranch %1095
+%1095 = OpLabel
+%2604 = OpLoad %v4uint %1195
+%2605 = OpCompositeExtract %uint %2604 1
+OpStore %1406 %2605
+OpBranch %1096
+%1096 = OpLabel
+%2606 = OpLoad %uint %1406
+%2607 = OpUConvert %ulong %2606
+OpStore %1411 %2607
+%2608 = OpLoad %ulong %1410
+%2609 = OpLoad %ulong %1411
+%2610 = OpFunctionCall %ulong %7 %2608 %2609
+OpStore %1412 %2610
+OpBranch %1097
+%1097 = OpLabel
+%2611 = OpLoad %v4uint %1195
+%2612 = OpCompositeExtract %uint %2611 2
+OpStore %1407 %2612
+OpBranch %1098
+%1098 = OpLabel
+%2613 = OpLoad %uint %1407
+%2614 = OpUConvert %ulong %2613
+OpStore %1413 %2614
+%2615 = OpLoad %ulong %1412
+%2616 = OpLoad %ulong %1413
+%2617 = OpFunctionCall %ulong %7 %2615 %2616
+OpStore %1414 %2617
+OpBranch %1099
+%1099 = OpLabel
+%2618 = OpLoad %v4uint %1195
+%2619 = OpCompositeExtract %uint %2618 3
+OpStore %1408 %2619
+OpBranch %1100
+%1100 = OpLabel
+%2620 = OpLoad %uint %1408
+%2621 = OpUConvert %ulong %2620
+OpStore %1415 %2621
+%2622 = OpLoad %ulong %1414
+%2623 = OpLoad %ulong %1415
+%2624 = OpFunctionCall %ulong %7 %2622 %2623
+OpStore %1416 %2624
+OpBranch %1101
+%1101 = OpLabel
+OpBranch %1102
+%1102 = OpLabel
+%2625 = OpLoad %v4uint %1190
+%2626 = OpLoad %v4uint %1193
+%2627 = OpIEqual %v4bool %2625 %2626
+%2628 = OpSelect %v4uint %2627 %2194 %2196
+OpStore %1196 %2628
+OpBranch %1103
+%1103 = OpLabel
+%2629 = OpLoad %v4uint %1196
+%2630 = OpCompositeExtract %uint %2629 0
+OpStore %1417 %2630
+OpBranch %1104
+%1104 = OpLabel
+%2631 = OpLoad %uint %1417
+%2632 = OpUConvert %ulong %2631
+OpStore %1421 %2632
+%2633 = OpLoad %ulong %1416
+%2634 = OpLoad %ulong %1421
+%2635 = OpFunctionCall %ulong %7 %2633 %2634
+OpStore %1422 %2635
+OpBranch %1105
+%1105 = OpLabel
+%2636 = OpLoad %v4uint %1196
+%2637 = OpCompositeExtract %uint %2636 1
+OpStore %1418 %2637
+OpBranch %1106
+%1106 = OpLabel
+%2638 = OpLoad %uint %1418
+%2639 = OpUConvert %ulong %2638
+OpStore %1423 %2639
+%2640 = OpLoad %ulong %1422
+%2641 = OpLoad %ulong %1423
+%2642 = OpFunctionCall %ulong %7 %2640 %2641
+OpStore %1424 %2642
+OpBranch %1107
+%1107 = OpLabel
+%2643 = OpLoad %v4uint %1196
+%2644 = OpCompositeExtract %uint %2643 2
+OpStore %1419 %2644
+OpBranch %1108
+%1108 = OpLabel
+%2645 = OpLoad %uint %1419
+%2646 = OpUConvert %ulong %2645
+OpStore %1425 %2646
+%2647 = OpLoad %ulong %1424
+%2648 = OpLoad %ulong %1425
+%2649 = OpFunctionCall %ulong %7 %2647 %2648
+OpStore %1426 %2649
+OpBranch %1109
+%1109 = OpLabel
+%2650 = OpLoad %v4uint %1196
+%2651 = OpCompositeExtract %uint %2650 3
+OpStore %1420 %2651
+OpBranch %1110
+%1110 = OpLabel
+%2652 = OpLoad %uint %1420
+%2653 = OpUConvert %ulong %2652
+OpStore %1427 %2653
+%2654 = OpLoad %ulong %1426
+%2655 = OpLoad %ulong %1427
+%2656 = OpFunctionCall %ulong %7 %2654 %2655
+OpStore %1428 %2656
+OpBranch %1111
+%1111 = OpLabel
+OpBranch %1112
+%1112 = OpLabel
+%2657 = OpLoad %v4uint %1190
+%2658 = OpLoad %v4uint %1193
+%2659 = OpINotEqual %v4bool %2657 %2658
+%2660 = OpSelect %v4uint %2659 %2194 %2196
+OpStore %1197 %2660
+OpBranch %1113
+%1113 = OpLabel
+%2661 = OpLoad %v4uint %1197
+%2662 = OpCompositeExtract %uint %2661 0
+OpStore %1429 %2662
+OpBranch %1114
+%1114 = OpLabel
+%2663 = OpLoad %uint %1429
+%2664 = OpUConvert %ulong %2663
+OpStore %1433 %2664
+%2665 = OpLoad %ulong %1428
+%2666 = OpLoad %ulong %1433
+%2667 = OpFunctionCall %ulong %7 %2665 %2666
+OpStore %1434 %2667
+OpBranch %1115
+%1115 = OpLabel
+%2668 = OpLoad %v4uint %1197
+%2669 = OpCompositeExtract %uint %2668 1
+OpStore %1430 %2669
+OpBranch %1116
+%1116 = OpLabel
+%2670 = OpLoad %uint %1430
+%2671 = OpUConvert %ulong %2670
+OpStore %1435 %2671
+%2672 = OpLoad %ulong %1434
+%2673 = OpLoad %ulong %1435
+%2674 = OpFunctionCall %ulong %7 %2672 %2673
+OpStore %1436 %2674
+OpBranch %1117
+%1117 = OpLabel
+%2675 = OpLoad %v4uint %1197
+%2676 = OpCompositeExtract %uint %2675 2
+OpStore %1431 %2676
+OpBranch %1118
+%1118 = OpLabel
+%2677 = OpLoad %uint %1431
+%2678 = OpUConvert %ulong %2677
+OpStore %1437 %2678
+%2679 = OpLoad %ulong %1436
+%2680 = OpLoad %ulong %1437
+%2681 = OpFunctionCall %ulong %7 %2679 %2680
+OpStore %1438 %2681
+OpBranch %1119
+%1119 = OpLabel
+%2682 = OpLoad %v4uint %1197
+%2683 = OpCompositeExtract %uint %2682 3
+OpStore %1432 %2683
+OpBranch %1120
+%1120 = OpLabel
+%2684 = OpLoad %uint %1432
+%2685 = OpUConvert %ulong %2684
+OpStore %1439 %2685
+%2686 = OpLoad %ulong %1438
+%2687 = OpLoad %ulong %1439
+%2688 = OpFunctionCall %ulong %7 %2686 %2687
+OpStore %1440 %2688
+OpBranch %1121
+%1121 = OpLabel
+OpBranch %1122
+%1122 = OpLabel
+%2689 = OpLoad %v4uint %1190
+%2690 = OpLoad %v4uint %1193
+%2691 = OpSLessThanEqual %v4bool %2689 %2690
+%2692 = OpSelect %v4uint %2691 %2194 %2196
+OpStore %1198 %2692
+OpBranch %1123
+%1123 = OpLabel
+%2693 = OpLoad %v4uint %1198
+%2694 = OpCompositeExtract %uint %2693 0
+OpStore %1441 %2694
+OpBranch %1124
+%1124 = OpLabel
+%2695 = OpLoad %uint %1441
+%2696 = OpUConvert %ulong %2695
+OpStore %1445 %2696
+%2697 = OpLoad %ulong %1440
+%2698 = OpLoad %ulong %1445
+%2699 = OpFunctionCall %ulong %7 %2697 %2698
+OpStore %1446 %2699
+OpBranch %1125
+%1125 = OpLabel
+%2700 = OpLoad %v4uint %1198
+%2701 = OpCompositeExtract %uint %2700 1
+OpStore %1442 %2701
+OpBranch %1126
+%1126 = OpLabel
+%2702 = OpLoad %uint %1442
+%2703 = OpUConvert %ulong %2702
+OpStore %1447 %2703
+%2704 = OpLoad %ulong %1446
+%2705 = OpLoad %ulong %1447
+%2706 = OpFunctionCall %ulong %7 %2704 %2705
+OpStore %1448 %2706
+OpBranch %1127
+%1127 = OpLabel
+%2707 = OpLoad %v4uint %1198
+%2708 = OpCompositeExtract %uint %2707 2
+OpStore %1443 %2708
+OpBranch %1128
+%1128 = OpLabel
+%2709 = OpLoad %uint %1443
+%2710 = OpUConvert %ulong %2709
+OpStore %1449 %2710
+%2711 = OpLoad %ulong %1448
+%2712 = OpLoad %ulong %1449
+%2713 = OpFunctionCall %ulong %7 %2711 %2712
+OpStore %1450 %2713
+OpBranch %1129
+%1129 = OpLabel
+%2714 = OpLoad %v4uint %1198
+%2715 = OpCompositeExtract %uint %2714 3
+OpStore %1444 %2715
+OpBranch %1130
+%1130 = OpLabel
+%2716 = OpLoad %uint %1444
+%2717 = OpUConvert %ulong %2716
+OpStore %1451 %2717
+%2718 = OpLoad %ulong %1450
+%2719 = OpLoad %ulong %1451
+%2720 = OpFunctionCall %ulong %7 %2718 %2719
+OpStore %1452 %2720
+OpBranch %1131
+%1131 = OpLabel
+OpBranch %1132
+%1132 = OpLabel
+%2721 = OpLoad %v4uint %1193
+%2722 = OpLoad %v4uint %1190
+%2723 = OpSLessThanEqual %v4bool %2721 %2722
+%2724 = OpSelect %v4uint %2723 %2194 %2196
+OpStore %1199 %2724
+OpBranch %1133
+%1133 = OpLabel
+%2725 = OpLoad %v4uint %1199
+%2726 = OpCompositeExtract %uint %2725 0
+OpStore %1453 %2726
+OpBranch %1134
+%1134 = OpLabel
+%2727 = OpLoad %uint %1453
+%2728 = OpUConvert %ulong %2727
+OpStore %1457 %2728
+%2729 = OpLoad %ulong %1452
+%2730 = OpLoad %ulong %1457
+%2731 = OpFunctionCall %ulong %7 %2729 %2730
+OpStore %1458 %2731
+OpBranch %1135
+%1135 = OpLabel
+%2732 = OpLoad %v4uint %1199
+%2733 = OpCompositeExtract %uint %2732 1
+OpStore %1454 %2733
+OpBranch %1136
+%1136 = OpLabel
+%2734 = OpLoad %uint %1454
+%2735 = OpUConvert %ulong %2734
+OpStore %1459 %2735
+%2736 = OpLoad %ulong %1458
+%2737 = OpLoad %ulong %1459
+%2738 = OpFunctionCall %ulong %7 %2736 %2737
+OpStore %1460 %2738
+OpBranch %1137
+%1137 = OpLabel
+%2739 = OpLoad %v4uint %1199
+%2740 = OpCompositeExtract %uint %2739 2
+OpStore %1455 %2740
+OpBranch %1138
+%1138 = OpLabel
+%2741 = OpLoad %uint %1455
+%2742 = OpUConvert %ulong %2741
+OpStore %1461 %2742
+%2743 = OpLoad %ulong %1460
+%2744 = OpLoad %ulong %1461
+%2745 = OpFunctionCall %ulong %7 %2743 %2744
+OpStore %1462 %2745
+OpBranch %1139
+%1139 = OpLabel
+%2746 = OpLoad %v4uint %1199
+%2747 = OpCompositeExtract %uint %2746 3
+OpStore %1456 %2747
+OpBranch %1140
+%1140 = OpLabel
+%2748 = OpLoad %uint %1456
+%2749 = OpUConvert %ulong %2748
+OpStore %1463 %2749
+%2750 = OpLoad %ulong %1462
+%2751 = OpLoad %ulong %1463
+%2752 = OpFunctionCall %ulong %7 %2750 %2751
+OpStore %1464 %2752
+OpBranch %1141
+%1141 = OpLabel
+OpBranch %1142
+%1142 = OpLabel
+%2754 = OpFNegate %float %float_0
+OpStore %1200 %2754
+%2756 = OpFNegate %float %float_2
+OpStore %1201 %2756
+%2759 = OpLoad %float %1200
+%2761 = OpLoad %float %1201
+%2757 = OpCompositeConstruct %v4float %float_1_5 %2759 %float_3 %2761
+OpStore %1202 %2757
+%2762 = OpFNegate %float %float_3
+OpStore %1203 %2762
+%2765 = OpLoad %float %1203
+%2763 = OpCompositeConstruct %v4float %float_2_5 %float_0 %float_3 %2765
+OpStore %1204 %2763
+%2766 = OpLoad %v4float %1202
+%2767 = OpCompositeExtract %float %2766 0
+OpStore %1205 %2767
+%2768 = OpLoad %float %1205
+%2769 = OpLoad %float %1155
+%2770 = OpFAdd %float %2768 %2769
+OpStore %1206 %2770
+%2771 = OpLoad %v4float %1202
+%2772 = OpLoad %float %1206
+%2773 = OpCompositeInsert %v4float %2772 %2771 0
+OpStore %1207 %2773
+%2774 = OpLoad %ulong %1464
+%2775 = OpLoad %v4float %1207
+%2776 = OpFunctionCall %ulong %5 %2774 %2775
+OpStore %1208 %2776
+%2777 = OpLoad %ulong %1208
+%2778 = OpLoad %v4float %1204
+%2779 = OpFunctionCall %ulong %5 %2777 %2778
+OpStore %1209 %2779
+%2780 = OpLoad %v4float %1207
+%2781 = OpLoad %v4float %1204
+%2782 = OpFOrdLessThan %v4bool %2780 %2781
+%2783 = OpSelect %v4uint %2782 %2194 %2196
+OpStore %1210 %2783
+%2784 = OpLoad %ulong %1209
+%2785 = OpLoad %v4uint %1210
+%2786 = OpFunctionCall %ulong %3 %2784 %2785
+OpStore %1211 %2786
+%2787 = OpLoad %v4float %1204
+%2788 = OpLoad %v4float %1207
+%2789 = OpFOrdLessThan %v4bool %2787 %2788
+%2790 = OpSelect %v4uint %2789 %2194 %2196
+OpStore %1212 %2790
+%2791 = OpLoad %ulong %1211
+%2792 = OpLoad %v4uint %1212
+%2793 = OpFunctionCall %ulong %3 %2791 %2792
+OpStore %1213 %2793
+%2794 = OpLoad %v4float %1207
+%2795 = OpLoad %v4float %1204
+%2796 = OpFOrdEqual %v4bool %2794 %2795
+%2797 = OpSelect %v4uint %2796 %2194 %2196
+OpStore %1214 %2797
+%2798 = OpLoad %ulong %1213
+%2799 = OpLoad %v4uint %1214
+%2800 = OpFunctionCall %ulong %3 %2798 %2799
+OpStore %1215 %2800
+%2801 = OpLoad %v4float %1207
+%2802 = OpLoad %v4float %1204
+%2803 = OpFUnordNotEqual %v4bool %2801 %2802
+%2804 = OpSelect %v4uint %2803 %2194 %2196
+OpStore %1216 %2804
+%2805 = OpLoad %ulong %1215
+%2806 = OpLoad %v4uint %1216
+%2807 = OpFunctionCall %ulong %3 %2805 %2806
+OpStore %1217 %2807
+%2808 = OpLoad %v4float %1207
+%2809 = OpLoad %v4float %1204
+%2810 = OpFOrdLessThanEqual %v4bool %2808 %2809
+%2811 = OpSelect %v4uint %2810 %2194 %2196
+OpStore %1218 %2811
+%2812 = OpLoad %ulong %1217
+%2813 = OpLoad %v4uint %1218
+%2814 = OpFunctionCall %ulong %3 %2812 %2813
+OpStore %1219 %2814
+%2815 = OpLoad %v4float %1204
+%2816 = OpLoad %v4float %1207
+%2817 = OpFOrdLessThanEqual %v4bool %2815 %2816
+%2818 = OpSelect %v4uint %2817 %2194 %2196
+OpStore %1220 %2818
+%2819 = OpLoad %ulong %1219
+%2820 = OpLoad %v4uint %1220
+%2821 = OpFunctionCall %ulong %3 %2819 %2820
+OpStore %1221 %2821
+%2822 = OpLoad %v4float %1207
+%2823 = OpBitcast %v4uint %2822
+OpStore %1222 %2823
+%2824 = OpLoad %v4uint %1210
+%2825 = OpLoad %v4uint %1222
+%2826 = OpBitwiseAnd %v4uint %2824 %2825
+OpStore %1223 %2826
+%2827 = OpLoad %v4uint %1210
+%2828 = OpNot %v4uint %2827
+OpStore %1224 %2828
+%2829 = OpLoad %v4float %1204
+%2830 = OpBitcast %v4uint %2829
+OpStore %1225 %2830
+%2831 = OpLoad %v4uint %1224
+%2832 = OpLoad %v4uint %1225
+%2833 = OpBitwiseAnd %v4uint %2831 %2832
+OpStore %1226 %2833
+%2834 = OpLoad %v4uint %1223
+%2835 = OpLoad %v4uint %1226
+%2836 = OpBitwiseOr %v4uint %2834 %2835
+OpStore %1227 %2836
+%2837 = OpLoad %v4uint %1227
+%2838 = OpBitcast %v4float %2837
+OpStore %1228 %2838
+%2839 = OpLoad %v4uint %1210
+%2840 = OpLoad %v4uint %1225
+%2841 = OpBitwiseAnd %v4uint %2839 %2840
+OpStore %1229 %2841
+%2842 = OpLoad %v4uint %1224
+%2843 = OpLoad %v4uint %1222
+%2844 = OpBitwiseAnd %v4uint %2842 %2843
+OpStore %1230 %2844
+%2845 = OpLoad %v4uint %1229
+%2846 = OpLoad %v4uint %1230
+%2847 = OpBitwiseOr %v4uint %2845 %2846
+OpStore %1231 %2847
+%2848 = OpLoad %v4uint %1231
+%2849 = OpBitcast %v4float %2848
+OpStore %1232 %2849
+%2850 = OpLoad %ulong %1221
+%2851 = OpLoad %v4float %1228
+%2852 = OpFunctionCall %ulong %5 %2850 %2851
+OpStore %1233 %2852
+%2853 = OpLoad %ulong %1233
+%2854 = OpLoad %v4float %1232
+%2855 = OpFunctionCall %ulong %5 %2853 %2854
+OpStore %1234 %2855
+%2856 = OpLoad %v4float %1232
+%2857 = OpLoad %v4float %1228
+%2858 = OpFSub %v4float %2856 %2857
+OpStore %1235 %2858
+%2859 = OpLoad %ulong %1234
+%2860 = OpLoad %v4float %1235
+%2861 = OpFunctionCall %ulong %5 %2859 %2860
+OpStore %1236 %2861
+%2862 = OpCompositeConstruct %v2double %double_1_5 %double_n0
+OpStore %1238 %2862
+%2865 = OpCompositeConstruct %v2double %double_2_5 %double_0
+OpStore %1239 %2865
+%2868 = OpLoad %v2double %1238
+%2869 = OpCompositeExtract %double %2868 0
+OpStore %1241 %2869
+%2870 = OpLoad %ulong %1153
+%2871 = OpConvertUToF %double %2870
+OpStore %1242 %2871
+%2872 = OpLoad %double %1241
+%2873 = OpLoad %double %1242
+%2874 = OpFAdd %double %2872 %2873
+OpStore %1243 %2874
+%2875 = OpLoad %v2double %1238
+%2876 = OpLoad %double %1243
+%2877 = OpCompositeInsert %v2double %2876 %2875 0
+OpStore %1244 %2877
+%2879 = OpLoad %v2double %1244
+%2880 = OpLoad %v2double %1239
+%2881 = OpFOrdLessThan %v2bool %2879 %2880
+%2885 = OpSelect %v2ulong %2881 %2883 %2884
+OpStore %1245 %2885
+OpBranch %1143
+%1143 = OpLabel
+%2886 = OpLoad %v2ulong %1245
+%2887 = OpCompositeExtract %ulong %2886 0
+OpStore %1465 %2887
+%2888 = OpLoad %ulong %1236
+%2889 = OpLoad %ulong %1465
+%2890 = OpFunctionCall %ulong %7 %2888 %2889
+OpStore %1466 %2890
+%2891 = OpLoad %v2ulong %1245
+%2892 = OpCompositeExtract %ulong %2891 1
+OpStore %1467 %2892
+%2893 = OpLoad %ulong %1466
+%2894 = OpLoad %ulong %1467
+%2895 = OpFunctionCall %ulong %7 %2893 %2894
+OpStore %1468 %2895
+OpBranch %1144
+%1144 = OpLabel
+%2896 = OpLoad %v2double %1244
+%2897 = OpLoad %v2double %1239
+%2898 = OpFOrdEqual %v2bool %2896 %2897
+%2899 = OpSelect %v2ulong %2898 %2883 %2884
+OpStore %1246 %2899
+OpBranch %1145
+%1145 = OpLabel
+%2900 = OpLoad %v2ulong %1246
+%2901 = OpCompositeExtract %ulong %2900 0
+OpStore %1469 %2901
+%2902 = OpLoad %ulong %1468
+%2903 = OpLoad %ulong %1469
+%2904 = OpFunctionCall %ulong %7 %2902 %2903
+OpStore %1470 %2904
+%2905 = OpLoad %v2ulong %1246
+%2906 = OpCompositeExtract %ulong %2905 1
+OpStore %1471 %2906
+%2907 = OpLoad %ulong %1470
+%2908 = OpLoad %ulong %1471
+%2909 = OpFunctionCall %ulong %7 %2907 %2908
+OpStore %1472 %2909
+OpBranch %1146
+%1146 = OpLabel
+%2910 = OpLoad %v2double %1244
+%2911 = OpLoad %v2double %1239
+%2912 = OpFUnordNotEqual %v2bool %2910 %2911
+%2913 = OpSelect %v2ulong %2912 %2883 %2884
+OpStore %1247 %2913
+OpBranch %1147
+%1147 = OpLabel
+%2914 = OpLoad %v2ulong %1247
+%2915 = OpCompositeExtract %ulong %2914 0
+OpStore %1473 %2915
+%2916 = OpLoad %ulong %1472
+%2917 = OpLoad %ulong %1473
+%2918 = OpFunctionCall %ulong %7 %2916 %2917
+OpStore %1474 %2918
+%2919 = OpLoad %v2ulong %1247
+%2920 = OpCompositeExtract %ulong %2919 1
+OpStore %1475 %2920
+%2921 = OpLoad %ulong %1474
+%2922 = OpLoad %ulong %1475
+%2923 = OpFunctionCall %ulong %7 %2921 %2922
+OpStore %1476 %2923
+OpBranch %1148
+%1148 = OpLabel
+%2924 = OpLoad %v2double %1239
+%2925 = OpLoad %v2double %1244
+%2926 = OpFOrdLessThanEqual %v2bool %2924 %2925
+%2927 = OpSelect %v2ulong %2926 %2883 %2884
+OpStore %1248 %2927
+OpBranch %1149
+%1149 = OpLabel
+%2928 = OpLoad %v2ulong %1248
+%2929 = OpCompositeExtract %ulong %2928 0
+OpStore %1477 %2929
+%2930 = OpLoad %ulong %1476
+%2931 = OpLoad %ulong %1477
+%2932 = OpFunctionCall %ulong %7 %2930 %2931
+OpStore %1478 %2932
+%2933 = OpLoad %v2ulong %1248
+%2934 = OpCompositeExtract %ulong %2933 1
+OpStore %1479 %2934
+%2935 = OpLoad %ulong %1478
+%2936 = OpLoad %ulong %1479
+%2937 = OpFunctionCall %ulong %7 %2935 %2936
+OpStore %1480 %2937
+OpBranch %1150
+%1150 = OpLabel
+%2938 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_65535 %ushort_32768 %ushort_7 %ushort_7 %ushort_0 %ushort_300 %ushort_65534
+OpStore %1249 %2938
+%2946 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_2 %ushort_1 %ushort_32767 %ushort_7 %ushort_8 %ushort_65535 %ushort_300 %ushort_65535
+OpStore %1250 %2946
+%2950 = OpLoad %_arr_ushort_uint_8 %1249
+%2951 = OpCompositeExtract %ushort %2950 0
+OpStore %1251 %2951
+%2952 = OpLoad %ushort %1251
+%2953 = OpLoad %ushort %1156
+%2954 = OpIAdd %ushort %2952 %2953
+OpStore %1252 %2954
+%2955 = OpLoad %_arr_ushort_uint_8 %1249
+%2956 = OpLoad %ushort %1252
+%2957 = OpCompositeInsert %_arr_ushort_uint_8 %2956 %2955 0
+OpStore %1253 %2957
+%2958 = OpLoad %_arr_ushort_uint_8 %1250
+%2959 = OpCompositeExtract %ushort %2958 7
+OpStore %1254 %2959
+%2960 = OpLoad %ushort %1254
+%2961 = OpLoad %ushort %1156
+%2962 = OpIAdd %ushort %2960 %2961
+OpStore %1255 %2962
+%2963 = OpLoad %_arr_ushort_uint_8 %1250
+%2964 = OpLoad %ushort %1255
+%2965 = OpCompositeInsert %_arr_ushort_uint_8 %2964 %2963 7
+OpStore %1256 %2965
+%2966 = OpLoad %_arr_ushort_uint_8 %1253
+%2967 = OpCompositeExtract %ushort %2966 0
+OpStore %1481 %2967
+%2968 = OpLoad %_arr_ushort_uint_8 %1256
+%2969 = OpCompositeExtract %ushort %2968 0
+OpStore %1482 %2969
+%2970 = OpLoad %ushort %1481
+%2971 = OpLoad %ushort %1482
+%2972 = OpULessThan %bool %2970 %2971
+OpStore %1483 %2972
+%2973 = OpLoad %bool %1483
+%2976 = OpSelect %uchar %2973 %uchar_1 %uchar_0
+%2977 = OpUConvert %ushort %2976
+OpStore %1484 %2977
+%2978 = OpLoad %ushort %1484
+%2979 = OpISub %ushort %ushort_0 %2978
+OpStore %1485 %2979
+%2980 = OpLoad %_arr_ushort_uint_8 %1253
+%2981 = OpCompositeExtract %ushort %2980 1
+OpStore %1486 %2981
+%2982 = OpLoad %_arr_ushort_uint_8 %1256
+%2983 = OpCompositeExtract %ushort %2982 1
+OpStore %1487 %2983
+%2984 = OpLoad %ushort %1486
+%2985 = OpLoad %ushort %1487
+%2986 = OpULessThan %bool %2984 %2985
+OpStore %1488 %2986
+%2987 = OpLoad %bool %1488
+%2988 = OpSelect %uchar %2987 %uchar_1 %uchar_0
+%2989 = OpUConvert %ushort %2988
+OpStore %1489 %2989
+%2990 = OpLoad %ushort %1489
+%2991 = OpISub %ushort %ushort_0 %2990
+OpStore %1490 %2991
+%2992 = OpLoad %_arr_ushort_uint_8 %1253
 %2993 = OpCompositeExtract %ushort %2992 2
-OpStore %992 %2993
-%2994 = OpLoad %ushort %991
-%2995 = OpLoad %ushort %992
-%2996 = OpBitwiseOr %ushort %2994 %2995
-OpStore %993 %2996
-%2997 = OpLoad %_arr_ushort_uint_8 %928
-%2998 = OpCompositeExtract %ushort %2997 3
-OpStore %994 %2998
-%2999 = OpLoad %_arr_ushort_uint_8 %984
-%3000 = OpCompositeExtract %ushort %2999 3
-OpStore %995 %3000
-%3001 = OpLoad %ushort %994
-%3002 = OpLoad %ushort %995
-%3003 = OpBitwiseOr %ushort %3001 %3002
-OpStore %996 %3003
-%3004 = OpLoad %_arr_ushort_uint_8 %928
-%3005 = OpCompositeExtract %ushort %3004 4
-OpStore %997 %3005
-%3006 = OpLoad %_arr_ushort_uint_8 %984
-%3007 = OpCompositeExtract %ushort %3006 4
-OpStore %998 %3007
-%3008 = OpLoad %ushort %997
-%3009 = OpLoad %ushort %998
-%3010 = OpBitwiseOr %ushort %3008 %3009
-OpStore %999 %3010
-%3011 = OpLoad %_arr_ushort_uint_8 %928
-%3012 = OpCompositeExtract %ushort %3011 5
-OpStore %1000 %3012
-%3013 = OpLoad %_arr_ushort_uint_8 %984
-%3014 = OpCompositeExtract %ushort %3013 5
-OpStore %1001 %3014
-%3015 = OpLoad %ushort %1000
-%3016 = OpLoad %ushort %1001
-%3017 = OpBitwiseOr %ushort %3015 %3016
-OpStore %1002 %3017
-%3018 = OpLoad %_arr_ushort_uint_8 %928
-%3019 = OpCompositeExtract %ushort %3018 6
-OpStore %1003 %3019
-%3020 = OpLoad %_arr_ushort_uint_8 %984
-%3021 = OpCompositeExtract %ushort %3020 6
-OpStore %1004 %3021
-%3022 = OpLoad %ushort %1003
-%3023 = OpLoad %ushort %1004
-%3024 = OpBitwiseOr %ushort %3022 %3023
-OpStore %1005 %3024
-%3025 = OpLoad %_arr_ushort_uint_8 %928
-%3026 = OpCompositeExtract %ushort %3025 7
-OpStore %1006 %3026
-%3027 = OpLoad %_arr_ushort_uint_8 %984
-%3028 = OpCompositeExtract %ushort %3027 7
-OpStore %1007 %3028
-%3029 = OpLoad %ushort %1006
-%3030 = OpLoad %ushort %1007
-%3031 = OpBitwiseOr %ushort %3029 %3030
-OpStore %1008 %3031
-%3032 = OpLoad %_arr_ushort_uint_8 %928
-%3033 = OpLoad %ushort %987
-%3034 = OpCompositeInsert %_arr_ushort_uint_8 %3033 %3032 0
-OpStore %1009 %3034
-%3035 = OpLoad %_arr_ushort_uint_8 %1009
-%3036 = OpLoad %ushort %990
-%3037 = OpCompositeInsert %_arr_ushort_uint_8 %3036 %3035 1
-OpStore %1010 %3037
-%3038 = OpLoad %_arr_ushort_uint_8 %1010
-%3039 = OpLoad %ushort %993
-%3040 = OpCompositeInsert %_arr_ushort_uint_8 %3039 %3038 2
-OpStore %1011 %3040
-%3041 = OpLoad %_arr_ushort_uint_8 %1011
-%3042 = OpLoad %ushort %996
-%3043 = OpCompositeInsert %_arr_ushort_uint_8 %3042 %3041 3
-OpStore %1012 %3043
-%3044 = OpLoad %_arr_ushort_uint_8 %1012
-%3045 = OpLoad %ushort %999
-%3046 = OpCompositeInsert %_arr_ushort_uint_8 %3045 %3044 4
-OpStore %1013 %3046
-%3047 = OpLoad %_arr_ushort_uint_8 %1013
-%3048 = OpLoad %ushort %1002
-%3049 = OpCompositeInsert %_arr_ushort_uint_8 %3048 %3047 5
-OpStore %1014 %3049
-%3050 = OpLoad %_arr_ushort_uint_8 %1014
-%3051 = OpLoad %ushort %1005
-%3052 = OpCompositeInsert %_arr_ushort_uint_8 %3051 %3050 6
-OpStore %1015 %3052
-%3053 = OpLoad %_arr_ushort_uint_8 %1015
-%3054 = OpLoad %ushort %1008
-%3055 = OpCompositeInsert %_arr_ushort_uint_8 %3054 %3053 7
-OpStore %1016 %3055
-OpBranch %367
-%367 = OpLabel
-%3056 = OpLoad %_arr_ushort_uint_8 %1016
-%3057 = OpCompositeExtract %ushort %3056 0
-OpStore %716 %3057
-%3058 = OpLoad %ulong %715
-%3059 = OpLoad %ushort %716
-%3060 = OpFunctionCall %ulong %10 %3058 %3059
-OpStore %717 %3060
-%3061 = OpLoad %_arr_ushort_uint_8 %1016
-%3062 = OpCompositeExtract %ushort %3061 1
-OpStore %718 %3062
-%3063 = OpLoad %ulong %717
-%3064 = OpLoad %ushort %718
-%3065 = OpFunctionCall %ulong %10 %3063 %3064
-OpStore %719 %3065
-%3066 = OpLoad %_arr_ushort_uint_8 %1016
-%3067 = OpCompositeExtract %ushort %3066 2
-OpStore %720 %3067
-%3068 = OpLoad %ulong %719
-%3069 = OpLoad %ushort %720
-%3070 = OpFunctionCall %ulong %10 %3068 %3069
-OpStore %721 %3070
-%3071 = OpLoad %_arr_ushort_uint_8 %1016
-%3072 = OpCompositeExtract %ushort %3071 3
-OpStore %722 %3072
-%3073 = OpLoad %ulong %721
-%3074 = OpLoad %ushort %722
-%3075 = OpFunctionCall %ulong %10 %3073 %3074
-OpStore %723 %3075
-%3076 = OpLoad %_arr_ushort_uint_8 %1016
-%3077 = OpCompositeExtract %ushort %3076 4
-OpStore %724 %3077
-%3078 = OpLoad %ulong %723
-%3079 = OpLoad %ushort %724
-%3080 = OpFunctionCall %ulong %10 %3078 %3079
-OpStore %725 %3080
-%3081 = OpLoad %_arr_ushort_uint_8 %1016
-%3082 = OpCompositeExtract %ushort %3081 5
-OpStore %726 %3082
-%3083 = OpLoad %ulong %725
-%3084 = OpLoad %ushort %726
-%3085 = OpFunctionCall %ulong %10 %3083 %3084
-OpStore %727 %3085
-%3086 = OpLoad %_arr_ushort_uint_8 %1016
-%3087 = OpCompositeExtract %ushort %3086 6
-OpStore %728 %3087
-%3088 = OpLoad %ulong %727
-%3089 = OpLoad %ushort %728
-%3090 = OpFunctionCall %ulong %10 %3088 %3089
-OpStore %729 %3090
-%3091 = OpLoad %_arr_ushort_uint_8 %1016
-%3092 = OpCompositeExtract %ushort %3091 7
-OpStore %730 %3092
-%3093 = OpLoad %ulong %729
-%3094 = OpLoad %ushort %730
-%3095 = OpFunctionCall %ulong %10 %3093 %3094
-OpStore %731 %3095
-OpBranch %368
-%368 = OpLabel
-%3096 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_255 %uchar_128 %uchar_7 %uchar_7 %uchar_0 %uchar_200 %uchar_254 %uchar_3 %uchar_9 %uchar_11 %uchar_13 %uchar_17 %uchar_19 %uchar_23 %uchar_29
-OpStore %472 %3096
-%3110 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_2 %uchar_1 %uchar_127 %uchar_7 %uchar_8 %uchar_255 %uchar_200 %uchar_255 %uchar_3 %uchar_8 %uchar_12 %uchar_13 %uchar_18 %uchar_19 %uchar_22 %uchar_30
-OpStore %473 %3110
-%3118 = OpLoad %_arr_uchar_uint_16 %472
-%3119 = OpCompositeExtract %uchar %3118 0
-OpStore %474 %3119
-%3120 = OpLoad %uchar %474
-%3121 = OpLoad %uchar %377
-%3122 = OpIAdd %uchar %3120 %3121
-OpStore %475 %3122
-%3123 = OpLoad %_arr_uchar_uint_16 %472
-%3124 = OpLoad %uchar %475
-%3125 = OpCompositeInsert %_arr_uchar_uint_16 %3124 %3123 0
-OpStore %476 %3125
-%3126 = OpLoad %_arr_uchar_uint_16 %473
-%3127 = OpCompositeExtract %uchar %3126 15
-OpStore %477 %3127
-%3128 = OpLoad %uchar %477
-%3129 = OpLoad %uchar %377
-%3130 = OpIAdd %uchar %3128 %3129
-OpStore %478 %3130
-%3131 = OpLoad %_arr_uchar_uint_16 %473
-%3132 = OpLoad %uchar %478
-%3133 = OpCompositeInsert %_arr_uchar_uint_16 %3132 %3131 15
-OpStore %479 %3133
-%3134 = OpLoad %_arr_uchar_uint_16 %476
-%3135 = OpCompositeExtract %uchar %3134 0
-OpStore %1017 %3135
-%3136 = OpLoad %_arr_uchar_uint_16 %479
-%3137 = OpCompositeExtract %uchar %3136 0
-OpStore %1018 %3137
-%3138 = OpLoad %uchar %1017
-%3139 = OpLoad %uchar %1018
-%3140 = OpULessThan %bool %3138 %3139
-OpStore %1019 %3140
-%3141 = OpLoad %bool %1019
-%3142 = OpSelect %uchar %3141 %uchar_1 %uchar_0
-%3143 = OpISub %uchar %uchar_0 %3142
-OpStore %1020 %3143
-%3144 = OpLoad %_arr_uchar_uint_16 %476
-%3145 = OpCompositeExtract %uchar %3144 1
-OpStore %1021 %3145
-%3146 = OpLoad %_arr_uchar_uint_16 %479
-%3147 = OpCompositeExtract %uchar %3146 1
-OpStore %1022 %3147
-%3148 = OpLoad %uchar %1021
-%3149 = OpLoad %uchar %1022
-%3150 = OpULessThan %bool %3148 %3149
-OpStore %1023 %3150
-%3151 = OpLoad %bool %1023
-%3152 = OpSelect %uchar %3151 %uchar_1 %uchar_0
-%3153 = OpISub %uchar %uchar_0 %3152
-OpStore %1024 %3153
-%3154 = OpLoad %_arr_uchar_uint_16 %476
-%3155 = OpCompositeExtract %uchar %3154 2
-OpStore %1025 %3155
-%3156 = OpLoad %_arr_uchar_uint_16 %479
-%3157 = OpCompositeExtract %uchar %3156 2
-OpStore %1026 %3157
-%3158 = OpLoad %uchar %1025
-%3159 = OpLoad %uchar %1026
-%3160 = OpULessThan %bool %3158 %3159
-OpStore %1027 %3160
-%3161 = OpLoad %bool %1027
-%3162 = OpSelect %uchar %3161 %uchar_1 %uchar_0
-%3163 = OpISub %uchar %uchar_0 %3162
-OpStore %1028 %3163
-%3164 = OpLoad %_arr_uchar_uint_16 %476
-%3165 = OpCompositeExtract %uchar %3164 3
-OpStore %1029 %3165
-%3166 = OpLoad %_arr_uchar_uint_16 %479
-%3167 = OpCompositeExtract %uchar %3166 3
-OpStore %1030 %3167
-%3168 = OpLoad %uchar %1029
-%3169 = OpLoad %uchar %1030
-%3170 = OpULessThan %bool %3168 %3169
-OpStore %1031 %3170
-%3171 = OpLoad %bool %1031
-%3172 = OpSelect %uchar %3171 %uchar_1 %uchar_0
-%3173 = OpISub %uchar %uchar_0 %3172
-OpStore %1032 %3173
-%3174 = OpLoad %_arr_uchar_uint_16 %476
-%3175 = OpCompositeExtract %uchar %3174 4
-OpStore %1033 %3175
-%3176 = OpLoad %_arr_uchar_uint_16 %479
-%3177 = OpCompositeExtract %uchar %3176 4
-OpStore %1034 %3177
-%3178 = OpLoad %uchar %1033
-%3179 = OpLoad %uchar %1034
-%3180 = OpULessThan %bool %3178 %3179
-OpStore %1035 %3180
-%3181 = OpLoad %bool %1035
-%3182 = OpSelect %uchar %3181 %uchar_1 %uchar_0
-%3183 = OpISub %uchar %uchar_0 %3182
-OpStore %1036 %3183
-%3184 = OpLoad %_arr_uchar_uint_16 %476
-%3185 = OpCompositeExtract %uchar %3184 5
-OpStore %1037 %3185
-%3186 = OpLoad %_arr_uchar_uint_16 %479
-%3187 = OpCompositeExtract %uchar %3186 5
-OpStore %1038 %3187
-%3188 = OpLoad %uchar %1037
-%3189 = OpLoad %uchar %1038
+OpStore %1491 %2993
+%2994 = OpLoad %_arr_ushort_uint_8 %1256
+%2995 = OpCompositeExtract %ushort %2994 2
+OpStore %1492 %2995
+%2996 = OpLoad %ushort %1491
+%2997 = OpLoad %ushort %1492
+%2998 = OpULessThan %bool %2996 %2997
+OpStore %1493 %2998
+%2999 = OpLoad %bool %1493
+%3000 = OpSelect %uchar %2999 %uchar_1 %uchar_0
+%3001 = OpUConvert %ushort %3000
+OpStore %1494 %3001
+%3002 = OpLoad %ushort %1494
+%3003 = OpISub %ushort %ushort_0 %3002
+OpStore %1495 %3003
+%3004 = OpLoad %_arr_ushort_uint_8 %1253
+%3005 = OpCompositeExtract %ushort %3004 3
+OpStore %1496 %3005
+%3006 = OpLoad %_arr_ushort_uint_8 %1256
+%3007 = OpCompositeExtract %ushort %3006 3
+OpStore %1497 %3007
+%3008 = OpLoad %ushort %1496
+%3009 = OpLoad %ushort %1497
+%3010 = OpULessThan %bool %3008 %3009
+OpStore %1498 %3010
+%3011 = OpLoad %bool %1498
+%3012 = OpSelect %uchar %3011 %uchar_1 %uchar_0
+%3013 = OpUConvert %ushort %3012
+OpStore %1499 %3013
+%3014 = OpLoad %ushort %1499
+%3015 = OpISub %ushort %ushort_0 %3014
+OpStore %1500 %3015
+%3016 = OpLoad %_arr_ushort_uint_8 %1253
+%3017 = OpCompositeExtract %ushort %3016 4
+OpStore %1501 %3017
+%3018 = OpLoad %_arr_ushort_uint_8 %1256
+%3019 = OpCompositeExtract %ushort %3018 4
+OpStore %1502 %3019
+%3020 = OpLoad %ushort %1501
+%3021 = OpLoad %ushort %1502
+%3022 = OpULessThan %bool %3020 %3021
+OpStore %1503 %3022
+%3023 = OpLoad %bool %1503
+%3024 = OpSelect %uchar %3023 %uchar_1 %uchar_0
+%3025 = OpUConvert %ushort %3024
+OpStore %1504 %3025
+%3026 = OpLoad %ushort %1504
+%3027 = OpISub %ushort %ushort_0 %3026
+OpStore %1505 %3027
+%3028 = OpLoad %_arr_ushort_uint_8 %1253
+%3029 = OpCompositeExtract %ushort %3028 5
+OpStore %1506 %3029
+%3030 = OpLoad %_arr_ushort_uint_8 %1256
+%3031 = OpCompositeExtract %ushort %3030 5
+OpStore %1507 %3031
+%3032 = OpLoad %ushort %1506
+%3033 = OpLoad %ushort %1507
+%3034 = OpULessThan %bool %3032 %3033
+OpStore %1508 %3034
+%3035 = OpLoad %bool %1508
+%3036 = OpSelect %uchar %3035 %uchar_1 %uchar_0
+%3037 = OpUConvert %ushort %3036
+OpStore %1509 %3037
+%3038 = OpLoad %ushort %1509
+%3039 = OpISub %ushort %ushort_0 %3038
+OpStore %1510 %3039
+%3040 = OpLoad %_arr_ushort_uint_8 %1253
+%3041 = OpCompositeExtract %ushort %3040 6
+OpStore %1511 %3041
+%3042 = OpLoad %_arr_ushort_uint_8 %1256
+%3043 = OpCompositeExtract %ushort %3042 6
+OpStore %1512 %3043
+%3044 = OpLoad %ushort %1511
+%3045 = OpLoad %ushort %1512
+%3046 = OpULessThan %bool %3044 %3045
+OpStore %1513 %3046
+%3047 = OpLoad %bool %1513
+%3048 = OpSelect %uchar %3047 %uchar_1 %uchar_0
+%3049 = OpUConvert %ushort %3048
+OpStore %1514 %3049
+%3050 = OpLoad %ushort %1514
+%3051 = OpISub %ushort %ushort_0 %3050
+OpStore %1515 %3051
+%3052 = OpLoad %_arr_ushort_uint_8 %1253
+%3053 = OpCompositeExtract %ushort %3052 7
+OpStore %1516 %3053
+%3054 = OpLoad %_arr_ushort_uint_8 %1256
+%3055 = OpCompositeExtract %ushort %3054 7
+OpStore %1517 %3055
+%3056 = OpLoad %ushort %1516
+%3057 = OpLoad %ushort %1517
+%3058 = OpULessThan %bool %3056 %3057
+OpStore %1518 %3058
+%3059 = OpLoad %bool %1518
+%3060 = OpSelect %uchar %3059 %uchar_1 %uchar_0
+%3061 = OpUConvert %ushort %3060
+OpStore %1519 %3061
+%3062 = OpLoad %ushort %1519
+%3063 = OpISub %ushort %ushort_0 %3062
+OpStore %1520 %3063
+%3065 = OpLoad %ushort %1485
+%3066 = OpLoad %ushort %1490
+%3067 = OpLoad %ushort %1495
+%3068 = OpLoad %ushort %1500
+%3069 = OpLoad %ushort %1505
+%3070 = OpLoad %ushort %1510
+%3071 = OpLoad %ushort %1515
+%3072 = OpLoad %ushort %1520
+%3064 = OpCompositeConstruct %_arr_ushort_uint_8 %3065 %3066 %3067 %3068 %3069 %3070 %3071 %3072
+OpStore %1521 %3064
+%3073 = OpLoad %ulong %1480
+%3074 = OpLoad %_arr_ushort_uint_8 %1521
+%3075 = OpFunctionCall %ulong %2 %3073 %3074
+OpStore %1257 %3075
+%3076 = OpLoad %_arr_ushort_uint_8 %1253
+%3077 = OpCompositeExtract %ushort %3076 0
+OpStore %1522 %3077
+%3078 = OpLoad %_arr_ushort_uint_8 %1256
+%3079 = OpCompositeExtract %ushort %3078 0
+OpStore %1523 %3079
+%3080 = OpLoad %ushort %1522
+%3081 = OpLoad %ushort %1523
+%3082 = OpIEqual %bool %3080 %3081
+OpStore %1524 %3082
+%3083 = OpLoad %bool %1524
+%3084 = OpSelect %uchar %3083 %uchar_1 %uchar_0
+%3085 = OpUConvert %ushort %3084
+OpStore %1525 %3085
+%3086 = OpLoad %ushort %1525
+%3087 = OpISub %ushort %ushort_0 %3086
+OpStore %1526 %3087
+%3088 = OpLoad %_arr_ushort_uint_8 %1253
+%3089 = OpCompositeExtract %ushort %3088 1
+OpStore %1527 %3089
+%3090 = OpLoad %_arr_ushort_uint_8 %1256
+%3091 = OpCompositeExtract %ushort %3090 1
+OpStore %1528 %3091
+%3092 = OpLoad %ushort %1527
+%3093 = OpLoad %ushort %1528
+%3094 = OpIEqual %bool %3092 %3093
+OpStore %1529 %3094
+%3095 = OpLoad %bool %1529
+%3096 = OpSelect %uchar %3095 %uchar_1 %uchar_0
+%3097 = OpUConvert %ushort %3096
+OpStore %1530 %3097
+%3098 = OpLoad %ushort %1530
+%3099 = OpISub %ushort %ushort_0 %3098
+OpStore %1531 %3099
+%3100 = OpLoad %_arr_ushort_uint_8 %1253
+%3101 = OpCompositeExtract %ushort %3100 2
+OpStore %1532 %3101
+%3102 = OpLoad %_arr_ushort_uint_8 %1256
+%3103 = OpCompositeExtract %ushort %3102 2
+OpStore %1533 %3103
+%3104 = OpLoad %ushort %1532
+%3105 = OpLoad %ushort %1533
+%3106 = OpIEqual %bool %3104 %3105
+OpStore %1534 %3106
+%3107 = OpLoad %bool %1534
+%3108 = OpSelect %uchar %3107 %uchar_1 %uchar_0
+%3109 = OpUConvert %ushort %3108
+OpStore %1535 %3109
+%3110 = OpLoad %ushort %1535
+%3111 = OpISub %ushort %ushort_0 %3110
+OpStore %1536 %3111
+%3112 = OpLoad %_arr_ushort_uint_8 %1253
+%3113 = OpCompositeExtract %ushort %3112 3
+OpStore %1537 %3113
+%3114 = OpLoad %_arr_ushort_uint_8 %1256
+%3115 = OpCompositeExtract %ushort %3114 3
+OpStore %1538 %3115
+%3116 = OpLoad %ushort %1537
+%3117 = OpLoad %ushort %1538
+%3118 = OpIEqual %bool %3116 %3117
+OpStore %1539 %3118
+%3119 = OpLoad %bool %1539
+%3120 = OpSelect %uchar %3119 %uchar_1 %uchar_0
+%3121 = OpUConvert %ushort %3120
+OpStore %1540 %3121
+%3122 = OpLoad %ushort %1540
+%3123 = OpISub %ushort %ushort_0 %3122
+OpStore %1541 %3123
+%3124 = OpLoad %_arr_ushort_uint_8 %1253
+%3125 = OpCompositeExtract %ushort %3124 4
+OpStore %1542 %3125
+%3126 = OpLoad %_arr_ushort_uint_8 %1256
+%3127 = OpCompositeExtract %ushort %3126 4
+OpStore %1543 %3127
+%3128 = OpLoad %ushort %1542
+%3129 = OpLoad %ushort %1543
+%3130 = OpIEqual %bool %3128 %3129
+OpStore %1544 %3130
+%3131 = OpLoad %bool %1544
+%3132 = OpSelect %uchar %3131 %uchar_1 %uchar_0
+%3133 = OpUConvert %ushort %3132
+OpStore %1545 %3133
+%3134 = OpLoad %ushort %1545
+%3135 = OpISub %ushort %ushort_0 %3134
+OpStore %1546 %3135
+%3136 = OpLoad %_arr_ushort_uint_8 %1253
+%3137 = OpCompositeExtract %ushort %3136 5
+OpStore %1547 %3137
+%3138 = OpLoad %_arr_ushort_uint_8 %1256
+%3139 = OpCompositeExtract %ushort %3138 5
+OpStore %1548 %3139
+%3140 = OpLoad %ushort %1547
+%3141 = OpLoad %ushort %1548
+%3142 = OpIEqual %bool %3140 %3141
+OpStore %1549 %3142
+%3143 = OpLoad %bool %1549
+%3144 = OpSelect %uchar %3143 %uchar_1 %uchar_0
+%3145 = OpUConvert %ushort %3144
+OpStore %1550 %3145
+%3146 = OpLoad %ushort %1550
+%3147 = OpISub %ushort %ushort_0 %3146
+OpStore %1551 %3147
+%3148 = OpLoad %_arr_ushort_uint_8 %1253
+%3149 = OpCompositeExtract %ushort %3148 6
+OpStore %1552 %3149
+%3150 = OpLoad %_arr_ushort_uint_8 %1256
+%3151 = OpCompositeExtract %ushort %3150 6
+OpStore %1553 %3151
+%3152 = OpLoad %ushort %1552
+%3153 = OpLoad %ushort %1553
+%3154 = OpIEqual %bool %3152 %3153
+OpStore %1554 %3154
+%3155 = OpLoad %bool %1554
+%3156 = OpSelect %uchar %3155 %uchar_1 %uchar_0
+%3157 = OpUConvert %ushort %3156
+OpStore %1555 %3157
+%3158 = OpLoad %ushort %1555
+%3159 = OpISub %ushort %ushort_0 %3158
+OpStore %1556 %3159
+%3160 = OpLoad %_arr_ushort_uint_8 %1253
+%3161 = OpCompositeExtract %ushort %3160 7
+OpStore %1557 %3161
+%3162 = OpLoad %_arr_ushort_uint_8 %1256
+%3163 = OpCompositeExtract %ushort %3162 7
+OpStore %1558 %3163
+%3164 = OpLoad %ushort %1557
+%3165 = OpLoad %ushort %1558
+%3166 = OpIEqual %bool %3164 %3165
+OpStore %1559 %3166
+%3167 = OpLoad %bool %1559
+%3168 = OpSelect %uchar %3167 %uchar_1 %uchar_0
+%3169 = OpUConvert %ushort %3168
+OpStore %1560 %3169
+%3170 = OpLoad %ushort %1560
+%3171 = OpISub %ushort %ushort_0 %3170
+OpStore %1561 %3171
+%3173 = OpLoad %ushort %1526
+%3174 = OpLoad %ushort %1531
+%3175 = OpLoad %ushort %1536
+%3176 = OpLoad %ushort %1541
+%3177 = OpLoad %ushort %1546
+%3178 = OpLoad %ushort %1551
+%3179 = OpLoad %ushort %1556
+%3180 = OpLoad %ushort %1561
+%3172 = OpCompositeConstruct %_arr_ushort_uint_8 %3173 %3174 %3175 %3176 %3177 %3178 %3179 %3180
+OpStore %1562 %3172
+%3181 = OpLoad %ulong %1257
+%3182 = OpLoad %_arr_ushort_uint_8 %1562
+%3183 = OpFunctionCall %ulong %2 %3181 %3182
+OpStore %1258 %3183
+%3184 = OpLoad %_arr_ushort_uint_8 %1256
+%3185 = OpCompositeExtract %ushort %3184 0
+OpStore %1563 %3185
+%3186 = OpLoad %_arr_ushort_uint_8 %1253
+%3187 = OpCompositeExtract %ushort %3186 0
+OpStore %1564 %3187
+%3188 = OpLoad %ushort %1563
+%3189 = OpLoad %ushort %1564
 %3190 = OpULessThan %bool %3188 %3189
-OpStore %1039 %3190
-%3191 = OpLoad %bool %1039
+OpStore %1565 %3190
+%3191 = OpLoad %bool %1565
 %3192 = OpSelect %uchar %3191 %uchar_1 %uchar_0
-%3193 = OpISub %uchar %uchar_0 %3192
-OpStore %1040 %3193
-%3194 = OpLoad %_arr_uchar_uint_16 %476
-%3195 = OpCompositeExtract %uchar %3194 6
-OpStore %1041 %3195
-%3196 = OpLoad %_arr_uchar_uint_16 %479
-%3197 = OpCompositeExtract %uchar %3196 6
-OpStore %1042 %3197
-%3198 = OpLoad %uchar %1041
-%3199 = OpLoad %uchar %1042
-%3200 = OpULessThan %bool %3198 %3199
-OpStore %1043 %3200
-%3201 = OpLoad %bool %1043
-%3202 = OpSelect %uchar %3201 %uchar_1 %uchar_0
-%3203 = OpISub %uchar %uchar_0 %3202
-OpStore %1044 %3203
-%3204 = OpLoad %_arr_uchar_uint_16 %476
-%3205 = OpCompositeExtract %uchar %3204 7
-OpStore %1045 %3205
-%3206 = OpLoad %_arr_uchar_uint_16 %479
-%3207 = OpCompositeExtract %uchar %3206 7
-OpStore %1046 %3207
-%3208 = OpLoad %uchar %1045
-%3209 = OpLoad %uchar %1046
-%3210 = OpULessThan %bool %3208 %3209
-OpStore %1047 %3210
-%3211 = OpLoad %bool %1047
-%3212 = OpSelect %uchar %3211 %uchar_1 %uchar_0
-%3213 = OpISub %uchar %uchar_0 %3212
-OpStore %1048 %3213
-%3214 = OpLoad %_arr_uchar_uint_16 %476
-%3215 = OpCompositeExtract %uchar %3214 8
-OpStore %1049 %3215
-%3216 = OpLoad %_arr_uchar_uint_16 %479
-%3217 = OpCompositeExtract %uchar %3216 8
-OpStore %1050 %3217
-%3218 = OpLoad %uchar %1049
-%3219 = OpLoad %uchar %1050
-%3220 = OpULessThan %bool %3218 %3219
-OpStore %1051 %3220
-%3221 = OpLoad %bool %1051
-%3222 = OpSelect %uchar %3221 %uchar_1 %uchar_0
-%3223 = OpISub %uchar %uchar_0 %3222
-OpStore %1052 %3223
-%3224 = OpLoad %_arr_uchar_uint_16 %476
-%3225 = OpCompositeExtract %uchar %3224 9
-OpStore %1053 %3225
-%3226 = OpLoad %_arr_uchar_uint_16 %479
-%3227 = OpCompositeExtract %uchar %3226 9
-OpStore %1054 %3227
-%3228 = OpLoad %uchar %1053
-%3229 = OpLoad %uchar %1054
-%3230 = OpULessThan %bool %3228 %3229
-OpStore %1055 %3230
-%3231 = OpLoad %bool %1055
-%3232 = OpSelect %uchar %3231 %uchar_1 %uchar_0
-%3233 = OpISub %uchar %uchar_0 %3232
-OpStore %1056 %3233
-%3234 = OpLoad %_arr_uchar_uint_16 %476
-%3235 = OpCompositeExtract %uchar %3234 10
-OpStore %1057 %3235
-%3236 = OpLoad %_arr_uchar_uint_16 %479
-%3237 = OpCompositeExtract %uchar %3236 10
-OpStore %1058 %3237
-%3238 = OpLoad %uchar %1057
-%3239 = OpLoad %uchar %1058
-%3240 = OpULessThan %bool %3238 %3239
-OpStore %1059 %3240
-%3241 = OpLoad %bool %1059
-%3242 = OpSelect %uchar %3241 %uchar_1 %uchar_0
-%3243 = OpISub %uchar %uchar_0 %3242
-OpStore %1060 %3243
-%3244 = OpLoad %_arr_uchar_uint_16 %476
-%3245 = OpCompositeExtract %uchar %3244 11
-OpStore %1061 %3245
-%3246 = OpLoad %_arr_uchar_uint_16 %479
-%3247 = OpCompositeExtract %uchar %3246 11
-OpStore %1062 %3247
-%3248 = OpLoad %uchar %1061
-%3249 = OpLoad %uchar %1062
+%3193 = OpUConvert %ushort %3192
+OpStore %1566 %3193
+%3194 = OpLoad %ushort %1566
+%3195 = OpISub %ushort %ushort_0 %3194
+OpStore %1567 %3195
+%3196 = OpLoad %_arr_ushort_uint_8 %1256
+%3197 = OpCompositeExtract %ushort %3196 1
+OpStore %1568 %3197
+%3198 = OpLoad %_arr_ushort_uint_8 %1253
+%3199 = OpCompositeExtract %ushort %3198 1
+OpStore %1569 %3199
+%3200 = OpLoad %ushort %1568
+%3201 = OpLoad %ushort %1569
+%3202 = OpULessThan %bool %3200 %3201
+OpStore %1570 %3202
+%3203 = OpLoad %bool %1570
+%3204 = OpSelect %uchar %3203 %uchar_1 %uchar_0
+%3205 = OpUConvert %ushort %3204
+OpStore %1571 %3205
+%3206 = OpLoad %ushort %1571
+%3207 = OpISub %ushort %ushort_0 %3206
+OpStore %1572 %3207
+%3208 = OpLoad %_arr_ushort_uint_8 %1256
+%3209 = OpCompositeExtract %ushort %3208 2
+OpStore %1573 %3209
+%3210 = OpLoad %_arr_ushort_uint_8 %1253
+%3211 = OpCompositeExtract %ushort %3210 2
+OpStore %1574 %3211
+%3212 = OpLoad %ushort %1573
+%3213 = OpLoad %ushort %1574
+%3214 = OpULessThan %bool %3212 %3213
+OpStore %1575 %3214
+%3215 = OpLoad %bool %1575
+%3216 = OpSelect %uchar %3215 %uchar_1 %uchar_0
+%3217 = OpUConvert %ushort %3216
+OpStore %1576 %3217
+%3218 = OpLoad %ushort %1576
+%3219 = OpISub %ushort %ushort_0 %3218
+OpStore %1577 %3219
+%3220 = OpLoad %_arr_ushort_uint_8 %1256
+%3221 = OpCompositeExtract %ushort %3220 3
+OpStore %1578 %3221
+%3222 = OpLoad %_arr_ushort_uint_8 %1253
+%3223 = OpCompositeExtract %ushort %3222 3
+OpStore %1579 %3223
+%3224 = OpLoad %ushort %1578
+%3225 = OpLoad %ushort %1579
+%3226 = OpULessThan %bool %3224 %3225
+OpStore %1580 %3226
+%3227 = OpLoad %bool %1580
+%3228 = OpSelect %uchar %3227 %uchar_1 %uchar_0
+%3229 = OpUConvert %ushort %3228
+OpStore %1581 %3229
+%3230 = OpLoad %ushort %1581
+%3231 = OpISub %ushort %ushort_0 %3230
+OpStore %1582 %3231
+%3232 = OpLoad %_arr_ushort_uint_8 %1256
+%3233 = OpCompositeExtract %ushort %3232 4
+OpStore %1583 %3233
+%3234 = OpLoad %_arr_ushort_uint_8 %1253
+%3235 = OpCompositeExtract %ushort %3234 4
+OpStore %1584 %3235
+%3236 = OpLoad %ushort %1583
+%3237 = OpLoad %ushort %1584
+%3238 = OpULessThan %bool %3236 %3237
+OpStore %1585 %3238
+%3239 = OpLoad %bool %1585
+%3240 = OpSelect %uchar %3239 %uchar_1 %uchar_0
+%3241 = OpUConvert %ushort %3240
+OpStore %1586 %3241
+%3242 = OpLoad %ushort %1586
+%3243 = OpISub %ushort %ushort_0 %3242
+OpStore %1587 %3243
+%3244 = OpLoad %_arr_ushort_uint_8 %1256
+%3245 = OpCompositeExtract %ushort %3244 5
+OpStore %1588 %3245
+%3246 = OpLoad %_arr_ushort_uint_8 %1253
+%3247 = OpCompositeExtract %ushort %3246 5
+OpStore %1589 %3247
+%3248 = OpLoad %ushort %1588
+%3249 = OpLoad %ushort %1589
 %3250 = OpULessThan %bool %3248 %3249
-OpStore %1063 %3250
-%3251 = OpLoad %bool %1063
+OpStore %1590 %3250
+%3251 = OpLoad %bool %1590
 %3252 = OpSelect %uchar %3251 %uchar_1 %uchar_0
-%3253 = OpISub %uchar %uchar_0 %3252
-OpStore %1064 %3253
-%3254 = OpLoad %_arr_uchar_uint_16 %476
-%3255 = OpCompositeExtract %uchar %3254 12
-OpStore %1065 %3255
-%3256 = OpLoad %_arr_uchar_uint_16 %479
-%3257 = OpCompositeExtract %uchar %3256 12
-OpStore %1066 %3257
-%3258 = OpLoad %uchar %1065
-%3259 = OpLoad %uchar %1066
-%3260 = OpULessThan %bool %3258 %3259
-OpStore %1067 %3260
-%3261 = OpLoad %bool %1067
-%3262 = OpSelect %uchar %3261 %uchar_1 %uchar_0
-%3263 = OpISub %uchar %uchar_0 %3262
-OpStore %1068 %3263
-%3264 = OpLoad %_arr_uchar_uint_16 %476
-%3265 = OpCompositeExtract %uchar %3264 13
-OpStore %1069 %3265
-%3266 = OpLoad %_arr_uchar_uint_16 %479
-%3267 = OpCompositeExtract %uchar %3266 13
-OpStore %1070 %3267
-%3268 = OpLoad %uchar %1069
-%3269 = OpLoad %uchar %1070
-%3270 = OpULessThan %bool %3268 %3269
-OpStore %1071 %3270
-%3271 = OpLoad %bool %1071
-%3272 = OpSelect %uchar %3271 %uchar_1 %uchar_0
-%3273 = OpISub %uchar %uchar_0 %3272
-OpStore %1072 %3273
-%3274 = OpLoad %_arr_uchar_uint_16 %476
-%3275 = OpCompositeExtract %uchar %3274 14
-OpStore %1073 %3275
-%3276 = OpLoad %_arr_uchar_uint_16 %479
-%3277 = OpCompositeExtract %uchar %3276 14
-OpStore %1074 %3277
-%3278 = OpLoad %uchar %1073
-%3279 = OpLoad %uchar %1074
-%3280 = OpULessThan %bool %3278 %3279
-OpStore %1075 %3280
-%3281 = OpLoad %bool %1075
-%3282 = OpSelect %uchar %3281 %uchar_1 %uchar_0
-%3283 = OpISub %uchar %uchar_0 %3282
-OpStore %1076 %3283
-%3284 = OpLoad %_arr_uchar_uint_16 %476
-%3285 = OpCompositeExtract %uchar %3284 15
-OpStore %1077 %3285
-%3286 = OpLoad %_arr_uchar_uint_16 %479
-%3287 = OpCompositeExtract %uchar %3286 15
-OpStore %1078 %3287
-%3288 = OpLoad %uchar %1077
-%3289 = OpLoad %uchar %1078
-%3290 = OpULessThan %bool %3288 %3289
-OpStore %1079 %3290
-%3291 = OpLoad %bool %1079
-%3292 = OpSelect %uchar %3291 %uchar_1 %uchar_0
-%3293 = OpISub %uchar %uchar_0 %3292
-OpStore %1080 %3293
-%3295 = OpLoad %uchar %1020
-%3296 = OpLoad %uchar %1024
-%3297 = OpLoad %uchar %1028
-%3298 = OpLoad %uchar %1032
-%3299 = OpLoad %uchar %1036
-%3300 = OpLoad %uchar %1040
-%3301 = OpLoad %uchar %1044
-%3302 = OpLoad %uchar %1048
-%3303 = OpLoad %uchar %1052
-%3304 = OpLoad %uchar %1056
-%3305 = OpLoad %uchar %1060
-%3306 = OpLoad %uchar %1064
-%3307 = OpLoad %uchar %1068
-%3308 = OpLoad %uchar %1072
-%3309 = OpLoad %uchar %1076
-%3310 = OpLoad %uchar %1080
-%3294 = OpCompositeConstruct %_arr_uchar_uint_16 %3295 %3296 %3297 %3298 %3299 %3300 %3301 %3302 %3303 %3304 %3305 %3306 %3307 %3308 %3309 %3310
-OpStore %1081 %3294
-%3311 = OpLoad %ulong %731
-%3312 = OpLoad %_arr_uchar_uint_16 %1081
-%3313 = OpFunctionCall %ulong %1 %3311 %3312
-OpStore %480 %3313
-%3314 = OpLoad %_arr_uchar_uint_16 %476
-%3315 = OpCompositeExtract %uchar %3314 0
-OpStore %1082 %3315
-%3316 = OpLoad %_arr_uchar_uint_16 %479
-%3317 = OpCompositeExtract %uchar %3316 0
-OpStore %1083 %3317
-%3318 = OpLoad %uchar %1082
-%3319 = OpLoad %uchar %1083
-%3320 = OpIEqual %bool %3318 %3319
-OpStore %1084 %3320
-%3321 = OpLoad %bool %1084
-%3322 = OpSelect %uchar %3321 %uchar_1 %uchar_0
-%3323 = OpISub %uchar %uchar_0 %3322
-OpStore %1085 %3323
-%3324 = OpLoad %_arr_uchar_uint_16 %476
-%3325 = OpCompositeExtract %uchar %3324 1
-OpStore %1086 %3325
-%3326 = OpLoad %_arr_uchar_uint_16 %479
-%3327 = OpCompositeExtract %uchar %3326 1
-OpStore %1087 %3327
-%3328 = OpLoad %uchar %1086
-%3329 = OpLoad %uchar %1087
-%3330 = OpIEqual %bool %3328 %3329
-OpStore %1088 %3330
-%3331 = OpLoad %bool %1088
-%3332 = OpSelect %uchar %3331 %uchar_1 %uchar_0
-%3333 = OpISub %uchar %uchar_0 %3332
-OpStore %1089 %3333
-%3334 = OpLoad %_arr_uchar_uint_16 %476
-%3335 = OpCompositeExtract %uchar %3334 2
-OpStore %1090 %3335
-%3336 = OpLoad %_arr_uchar_uint_16 %479
-%3337 = OpCompositeExtract %uchar %3336 2
-OpStore %1091 %3337
-%3338 = OpLoad %uchar %1090
-%3339 = OpLoad %uchar %1091
-%3340 = OpIEqual %bool %3338 %3339
-OpStore %1092 %3340
-%3341 = OpLoad %bool %1092
-%3342 = OpSelect %uchar %3341 %uchar_1 %uchar_0
-%3343 = OpISub %uchar %uchar_0 %3342
-OpStore %1093 %3343
-%3344 = OpLoad %_arr_uchar_uint_16 %476
-%3345 = OpCompositeExtract %uchar %3344 3
-OpStore %1094 %3345
-%3346 = OpLoad %_arr_uchar_uint_16 %479
-%3347 = OpCompositeExtract %uchar %3346 3
-OpStore %1095 %3347
-%3348 = OpLoad %uchar %1094
-%3349 = OpLoad %uchar %1095
-%3350 = OpIEqual %bool %3348 %3349
-OpStore %1096 %3350
-%3351 = OpLoad %bool %1096
-%3352 = OpSelect %uchar %3351 %uchar_1 %uchar_0
-%3353 = OpISub %uchar %uchar_0 %3352
-OpStore %1097 %3353
-%3354 = OpLoad %_arr_uchar_uint_16 %476
-%3355 = OpCompositeExtract %uchar %3354 4
-OpStore %1098 %3355
-%3356 = OpLoad %_arr_uchar_uint_16 %479
-%3357 = OpCompositeExtract %uchar %3356 4
-OpStore %1099 %3357
-%3358 = OpLoad %uchar %1098
-%3359 = OpLoad %uchar %1099
-%3360 = OpIEqual %bool %3358 %3359
-OpStore %1100 %3360
-%3361 = OpLoad %bool %1100
-%3362 = OpSelect %uchar %3361 %uchar_1 %uchar_0
-%3363 = OpISub %uchar %uchar_0 %3362
-OpStore %1101 %3363
-%3364 = OpLoad %_arr_uchar_uint_16 %476
-%3365 = OpCompositeExtract %uchar %3364 5
-OpStore %1102 %3365
-%3366 = OpLoad %_arr_uchar_uint_16 %479
-%3367 = OpCompositeExtract %uchar %3366 5
-OpStore %1103 %3367
-%3368 = OpLoad %uchar %1102
-%3369 = OpLoad %uchar %1103
-%3370 = OpIEqual %bool %3368 %3369
-OpStore %1104 %3370
-%3371 = OpLoad %bool %1104
-%3372 = OpSelect %uchar %3371 %uchar_1 %uchar_0
-%3373 = OpISub %uchar %uchar_0 %3372
-OpStore %1105 %3373
-%3374 = OpLoad %_arr_uchar_uint_16 %476
-%3375 = OpCompositeExtract %uchar %3374 6
-OpStore %1106 %3375
-%3376 = OpLoad %_arr_uchar_uint_16 %479
-%3377 = OpCompositeExtract %uchar %3376 6
-OpStore %1107 %3377
-%3378 = OpLoad %uchar %1106
-%3379 = OpLoad %uchar %1107
-%3380 = OpIEqual %bool %3378 %3379
-OpStore %1108 %3380
-%3381 = OpLoad %bool %1108
-%3382 = OpSelect %uchar %3381 %uchar_1 %uchar_0
-%3383 = OpISub %uchar %uchar_0 %3382
-OpStore %1109 %3383
-%3384 = OpLoad %_arr_uchar_uint_16 %476
-%3385 = OpCompositeExtract %uchar %3384 7
-OpStore %1110 %3385
-%3386 = OpLoad %_arr_uchar_uint_16 %479
-%3387 = OpCompositeExtract %uchar %3386 7
-OpStore %1111 %3387
-%3388 = OpLoad %uchar %1110
-%3389 = OpLoad %uchar %1111
-%3390 = OpIEqual %bool %3388 %3389
-OpStore %1112 %3390
-%3391 = OpLoad %bool %1112
-%3392 = OpSelect %uchar %3391 %uchar_1 %uchar_0
-%3393 = OpISub %uchar %uchar_0 %3392
-OpStore %1113 %3393
-%3394 = OpLoad %_arr_uchar_uint_16 %476
-%3395 = OpCompositeExtract %uchar %3394 8
-OpStore %1114 %3395
-%3396 = OpLoad %_arr_uchar_uint_16 %479
-%3397 = OpCompositeExtract %uchar %3396 8
-OpStore %1115 %3397
-%3398 = OpLoad %uchar %1114
-%3399 = OpLoad %uchar %1115
-%3400 = OpIEqual %bool %3398 %3399
-OpStore %1116 %3400
-%3401 = OpLoad %bool %1116
-%3402 = OpSelect %uchar %3401 %uchar_1 %uchar_0
-%3403 = OpISub %uchar %uchar_0 %3402
-OpStore %1117 %3403
-%3404 = OpLoad %_arr_uchar_uint_16 %476
-%3405 = OpCompositeExtract %uchar %3404 9
-OpStore %1118 %3405
-%3406 = OpLoad %_arr_uchar_uint_16 %479
-%3407 = OpCompositeExtract %uchar %3406 9
-OpStore %1119 %3407
-%3408 = OpLoad %uchar %1118
-%3409 = OpLoad %uchar %1119
-%3410 = OpIEqual %bool %3408 %3409
-OpStore %1120 %3410
-%3411 = OpLoad %bool %1120
-%3412 = OpSelect %uchar %3411 %uchar_1 %uchar_0
-%3413 = OpISub %uchar %uchar_0 %3412
-OpStore %1121 %3413
-%3414 = OpLoad %_arr_uchar_uint_16 %476
-%3415 = OpCompositeExtract %uchar %3414 10
-OpStore %1122 %3415
-%3416 = OpLoad %_arr_uchar_uint_16 %479
-%3417 = OpCompositeExtract %uchar %3416 10
-OpStore %1123 %3417
-%3418 = OpLoad %uchar %1122
-%3419 = OpLoad %uchar %1123
-%3420 = OpIEqual %bool %3418 %3419
-OpStore %1124 %3420
-%3421 = OpLoad %bool %1124
-%3422 = OpSelect %uchar %3421 %uchar_1 %uchar_0
-%3423 = OpISub %uchar %uchar_0 %3422
-OpStore %1125 %3423
-%3424 = OpLoad %_arr_uchar_uint_16 %476
-%3425 = OpCompositeExtract %uchar %3424 11
-OpStore %1126 %3425
-%3426 = OpLoad %_arr_uchar_uint_16 %479
-%3427 = OpCompositeExtract %uchar %3426 11
-OpStore %1127 %3427
-%3428 = OpLoad %uchar %1126
-%3429 = OpLoad %uchar %1127
-%3430 = OpIEqual %bool %3428 %3429
-OpStore %1128 %3430
-%3431 = OpLoad %bool %1128
-%3432 = OpSelect %uchar %3431 %uchar_1 %uchar_0
-%3433 = OpISub %uchar %uchar_0 %3432
-OpStore %1129 %3433
-%3434 = OpLoad %_arr_uchar_uint_16 %476
-%3435 = OpCompositeExtract %uchar %3434 12
-OpStore %1130 %3435
-%3436 = OpLoad %_arr_uchar_uint_16 %479
-%3437 = OpCompositeExtract %uchar %3436 12
-OpStore %1131 %3437
-%3438 = OpLoad %uchar %1130
-%3439 = OpLoad %uchar %1131
-%3440 = OpIEqual %bool %3438 %3439
-OpStore %1132 %3440
-%3441 = OpLoad %bool %1132
-%3442 = OpSelect %uchar %3441 %uchar_1 %uchar_0
-%3443 = OpISub %uchar %uchar_0 %3442
-OpStore %1133 %3443
-%3444 = OpLoad %_arr_uchar_uint_16 %476
-%3445 = OpCompositeExtract %uchar %3444 13
-OpStore %1134 %3445
-%3446 = OpLoad %_arr_uchar_uint_16 %479
-%3447 = OpCompositeExtract %uchar %3446 13
-OpStore %1135 %3447
-%3448 = OpLoad %uchar %1134
-%3449 = OpLoad %uchar %1135
-%3450 = OpIEqual %bool %3448 %3449
-OpStore %1136 %3450
-%3451 = OpLoad %bool %1136
-%3452 = OpSelect %uchar %3451 %uchar_1 %uchar_0
-%3453 = OpISub %uchar %uchar_0 %3452
-OpStore %1137 %3453
-%3454 = OpLoad %_arr_uchar_uint_16 %476
-%3455 = OpCompositeExtract %uchar %3454 14
-OpStore %1138 %3455
-%3456 = OpLoad %_arr_uchar_uint_16 %479
-%3457 = OpCompositeExtract %uchar %3456 14
-OpStore %1139 %3457
-%3458 = OpLoad %uchar %1138
-%3459 = OpLoad %uchar %1139
-%3460 = OpIEqual %bool %3458 %3459
-OpStore %1140 %3460
-%3461 = OpLoad %bool %1140
-%3462 = OpSelect %uchar %3461 %uchar_1 %uchar_0
-%3463 = OpISub %uchar %uchar_0 %3462
-OpStore %1141 %3463
-%3464 = OpLoad %_arr_uchar_uint_16 %476
-%3465 = OpCompositeExtract %uchar %3464 15
-OpStore %1142 %3465
-%3466 = OpLoad %_arr_uchar_uint_16 %479
-%3467 = OpCompositeExtract %uchar %3466 15
-OpStore %1143 %3467
-%3468 = OpLoad %uchar %1142
-%3469 = OpLoad %uchar %1143
-%3470 = OpIEqual %bool %3468 %3469
-OpStore %1144 %3470
-%3471 = OpLoad %bool %1144
-%3472 = OpSelect %uchar %3471 %uchar_1 %uchar_0
-%3473 = OpISub %uchar %uchar_0 %3472
-OpStore %1145 %3473
-%3475 = OpLoad %uchar %1085
-%3476 = OpLoad %uchar %1089
-%3477 = OpLoad %uchar %1093
-%3478 = OpLoad %uchar %1097
-%3479 = OpLoad %uchar %1101
-%3480 = OpLoad %uchar %1105
-%3481 = OpLoad %uchar %1109
-%3482 = OpLoad %uchar %1113
-%3483 = OpLoad %uchar %1117
-%3484 = OpLoad %uchar %1121
-%3485 = OpLoad %uchar %1125
-%3486 = OpLoad %uchar %1129
-%3487 = OpLoad %uchar %1133
-%3488 = OpLoad %uchar %1137
-%3489 = OpLoad %uchar %1141
-%3490 = OpLoad %uchar %1145
-%3474 = OpCompositeConstruct %_arr_uchar_uint_16 %3475 %3476 %3477 %3478 %3479 %3480 %3481 %3482 %3483 %3484 %3485 %3486 %3487 %3488 %3489 %3490
-OpStore %1146 %3474
-%3491 = OpLoad %ulong %480
-%3492 = OpLoad %_arr_uchar_uint_16 %1146
-%3493 = OpFunctionCall %ulong %1 %3491 %3492
-OpStore %481 %3493
-%3494 = OpLoad %_arr_uchar_uint_16 %479
-%3495 = OpCompositeExtract %uchar %3494 0
-OpStore %1147 %3495
-%3496 = OpLoad %_arr_uchar_uint_16 %476
-%3497 = OpCompositeExtract %uchar %3496 0
-OpStore %1148 %3497
-%3498 = OpLoad %uchar %1147
-%3499 = OpLoad %uchar %1148
-%3500 = OpULessThanEqual %bool %3498 %3499
-OpStore %1149 %3500
-%3501 = OpLoad %bool %1149
-%3502 = OpSelect %uchar %3501 %uchar_1 %uchar_0
-%3503 = OpISub %uchar %uchar_0 %3502
-OpStore %1150 %3503
-%3504 = OpLoad %_arr_uchar_uint_16 %479
-%3505 = OpCompositeExtract %uchar %3504 1
-OpStore %1151 %3505
-%3506 = OpLoad %_arr_uchar_uint_16 %476
-%3507 = OpCompositeExtract %uchar %3506 1
-OpStore %1152 %3507
-%3508 = OpLoad %uchar %1151
-%3509 = OpLoad %uchar %1152
-%3510 = OpULessThanEqual %bool %3508 %3509
-OpStore %1153 %3510
-%3511 = OpLoad %bool %1153
-%3512 = OpSelect %uchar %3511 %uchar_1 %uchar_0
-%3513 = OpISub %uchar %uchar_0 %3512
-OpStore %1154 %3513
-%3514 = OpLoad %_arr_uchar_uint_16 %479
-%3515 = OpCompositeExtract %uchar %3514 2
-OpStore %1155 %3515
-%3516 = OpLoad %_arr_uchar_uint_16 %476
-%3517 = OpCompositeExtract %uchar %3516 2
-OpStore %1156 %3517
-%3518 = OpLoad %uchar %1155
-%3519 = OpLoad %uchar %1156
-%3520 = OpULessThanEqual %bool %3518 %3519
-OpStore %1157 %3520
-%3521 = OpLoad %bool %1157
-%3522 = OpSelect %uchar %3521 %uchar_1 %uchar_0
-%3523 = OpISub %uchar %uchar_0 %3522
-OpStore %1158 %3523
-%3524 = OpLoad %_arr_uchar_uint_16 %479
-%3525 = OpCompositeExtract %uchar %3524 3
-OpStore %1159 %3525
-%3526 = OpLoad %_arr_uchar_uint_16 %476
-%3527 = OpCompositeExtract %uchar %3526 3
-OpStore %1160 %3527
-%3528 = OpLoad %uchar %1159
-%3529 = OpLoad %uchar %1160
-%3530 = OpULessThanEqual %bool %3528 %3529
-OpStore %1161 %3530
-%3531 = OpLoad %bool %1161
-%3532 = OpSelect %uchar %3531 %uchar_1 %uchar_0
-%3533 = OpISub %uchar %uchar_0 %3532
-OpStore %1162 %3533
-%3534 = OpLoad %_arr_uchar_uint_16 %479
-%3535 = OpCompositeExtract %uchar %3534 4
-OpStore %1163 %3535
-%3536 = OpLoad %_arr_uchar_uint_16 %476
-%3537 = OpCompositeExtract %uchar %3536 4
-OpStore %1164 %3537
-%3538 = OpLoad %uchar %1163
-%3539 = OpLoad %uchar %1164
-%3540 = OpULessThanEqual %bool %3538 %3539
-OpStore %1165 %3540
-%3541 = OpLoad %bool %1165
-%3542 = OpSelect %uchar %3541 %uchar_1 %uchar_0
-%3543 = OpISub %uchar %uchar_0 %3542
-OpStore %1166 %3543
-%3544 = OpLoad %_arr_uchar_uint_16 %479
-%3545 = OpCompositeExtract %uchar %3544 5
-OpStore %1167 %3545
-%3546 = OpLoad %_arr_uchar_uint_16 %476
-%3547 = OpCompositeExtract %uchar %3546 5
-OpStore %1168 %3547
-%3548 = OpLoad %uchar %1167
-%3549 = OpLoad %uchar %1168
-%3550 = OpULessThanEqual %bool %3548 %3549
-OpStore %1169 %3550
-%3551 = OpLoad %bool %1169
-%3552 = OpSelect %uchar %3551 %uchar_1 %uchar_0
-%3553 = OpISub %uchar %uchar_0 %3552
-OpStore %1170 %3553
-%3554 = OpLoad %_arr_uchar_uint_16 %479
-%3555 = OpCompositeExtract %uchar %3554 6
-OpStore %1171 %3555
-%3556 = OpLoad %_arr_uchar_uint_16 %476
-%3557 = OpCompositeExtract %uchar %3556 6
-OpStore %1172 %3557
-%3558 = OpLoad %uchar %1171
-%3559 = OpLoad %uchar %1172
-%3560 = OpULessThanEqual %bool %3558 %3559
-OpStore %1173 %3560
-%3561 = OpLoad %bool %1173
-%3562 = OpSelect %uchar %3561 %uchar_1 %uchar_0
-%3563 = OpISub %uchar %uchar_0 %3562
-OpStore %1174 %3563
-%3564 = OpLoad %_arr_uchar_uint_16 %479
-%3565 = OpCompositeExtract %uchar %3564 7
-OpStore %1175 %3565
-%3566 = OpLoad %_arr_uchar_uint_16 %476
-%3567 = OpCompositeExtract %uchar %3566 7
-OpStore %1176 %3567
-%3568 = OpLoad %uchar %1175
-%3569 = OpLoad %uchar %1176
-%3570 = OpULessThanEqual %bool %3568 %3569
-OpStore %1177 %3570
-%3571 = OpLoad %bool %1177
-%3572 = OpSelect %uchar %3571 %uchar_1 %uchar_0
-%3573 = OpISub %uchar %uchar_0 %3572
-OpStore %1178 %3573
-%3574 = OpLoad %_arr_uchar_uint_16 %479
-%3575 = OpCompositeExtract %uchar %3574 8
-OpStore %1179 %3575
-%3576 = OpLoad %_arr_uchar_uint_16 %476
-%3577 = OpCompositeExtract %uchar %3576 8
-OpStore %1180 %3577
-%3578 = OpLoad %uchar %1179
-%3579 = OpLoad %uchar %1180
-%3580 = OpULessThanEqual %bool %3578 %3579
-OpStore %1181 %3580
-%3581 = OpLoad %bool %1181
-%3582 = OpSelect %uchar %3581 %uchar_1 %uchar_0
-%3583 = OpISub %uchar %uchar_0 %3582
-OpStore %1182 %3583
-%3584 = OpLoad %_arr_uchar_uint_16 %479
-%3585 = OpCompositeExtract %uchar %3584 9
-OpStore %1183 %3585
-%3586 = OpLoad %_arr_uchar_uint_16 %476
-%3587 = OpCompositeExtract %uchar %3586 9
-OpStore %1184 %3587
-%3588 = OpLoad %uchar %1183
-%3589 = OpLoad %uchar %1184
-%3590 = OpULessThanEqual %bool %3588 %3589
-OpStore %1185 %3590
-%3591 = OpLoad %bool %1185
-%3592 = OpSelect %uchar %3591 %uchar_1 %uchar_0
-%3593 = OpISub %uchar %uchar_0 %3592
-OpStore %1186 %3593
-%3594 = OpLoad %_arr_uchar_uint_16 %479
-%3595 = OpCompositeExtract %uchar %3594 10
-OpStore %1187 %3595
-%3596 = OpLoad %_arr_uchar_uint_16 %476
-%3597 = OpCompositeExtract %uchar %3596 10
-OpStore %1188 %3597
-%3598 = OpLoad %uchar %1187
-%3599 = OpLoad %uchar %1188
-%3600 = OpULessThanEqual %bool %3598 %3599
-OpStore %1189 %3600
-%3601 = OpLoad %bool %1189
-%3602 = OpSelect %uchar %3601 %uchar_1 %uchar_0
-%3603 = OpISub %uchar %uchar_0 %3602
-OpStore %1190 %3603
-%3604 = OpLoad %_arr_uchar_uint_16 %479
-%3605 = OpCompositeExtract %uchar %3604 11
-OpStore %1191 %3605
-%3606 = OpLoad %_arr_uchar_uint_16 %476
-%3607 = OpCompositeExtract %uchar %3606 11
-OpStore %1192 %3607
-%3608 = OpLoad %uchar %1191
-%3609 = OpLoad %uchar %1192
-%3610 = OpULessThanEqual %bool %3608 %3609
-OpStore %1193 %3610
-%3611 = OpLoad %bool %1193
-%3612 = OpSelect %uchar %3611 %uchar_1 %uchar_0
-%3613 = OpISub %uchar %uchar_0 %3612
-OpStore %1194 %3613
-%3614 = OpLoad %_arr_uchar_uint_16 %479
-%3615 = OpCompositeExtract %uchar %3614 12
-OpStore %1195 %3615
-%3616 = OpLoad %_arr_uchar_uint_16 %476
-%3617 = OpCompositeExtract %uchar %3616 12
-OpStore %1196 %3617
-%3618 = OpLoad %uchar %1195
-%3619 = OpLoad %uchar %1196
-%3620 = OpULessThanEqual %bool %3618 %3619
-OpStore %1197 %3620
-%3621 = OpLoad %bool %1197
-%3622 = OpSelect %uchar %3621 %uchar_1 %uchar_0
-%3623 = OpISub %uchar %uchar_0 %3622
-OpStore %1198 %3623
-%3624 = OpLoad %_arr_uchar_uint_16 %479
-%3625 = OpCompositeExtract %uchar %3624 13
-OpStore %1199 %3625
-%3626 = OpLoad %_arr_uchar_uint_16 %476
-%3627 = OpCompositeExtract %uchar %3626 13
-OpStore %1200 %3627
-%3628 = OpLoad %uchar %1199
-%3629 = OpLoad %uchar %1200
-%3630 = OpULessThanEqual %bool %3628 %3629
-OpStore %1201 %3630
-%3631 = OpLoad %bool %1201
-%3632 = OpSelect %uchar %3631 %uchar_1 %uchar_0
-%3633 = OpISub %uchar %uchar_0 %3632
-OpStore %1202 %3633
-%3634 = OpLoad %_arr_uchar_uint_16 %479
-%3635 = OpCompositeExtract %uchar %3634 14
-OpStore %1203 %3635
-%3636 = OpLoad %_arr_uchar_uint_16 %476
-%3637 = OpCompositeExtract %uchar %3636 14
-OpStore %1204 %3637
-%3638 = OpLoad %uchar %1203
-%3639 = OpLoad %uchar %1204
-%3640 = OpULessThanEqual %bool %3638 %3639
-OpStore %1205 %3640
-%3641 = OpLoad %bool %1205
-%3642 = OpSelect %uchar %3641 %uchar_1 %uchar_0
-%3643 = OpISub %uchar %uchar_0 %3642
-OpStore %1206 %3643
-%3644 = OpLoad %_arr_uchar_uint_16 %479
-%3645 = OpCompositeExtract %uchar %3644 15
-OpStore %1207 %3645
-%3646 = OpLoad %_arr_uchar_uint_16 %476
-%3647 = OpCompositeExtract %uchar %3646 15
-OpStore %1208 %3647
-%3648 = OpLoad %uchar %1207
-%3649 = OpLoad %uchar %1208
-%3650 = OpULessThanEqual %bool %3648 %3649
-OpStore %1209 %3650
-%3651 = OpLoad %bool %1209
-%3652 = OpSelect %uchar %3651 %uchar_1 %uchar_0
-%3653 = OpISub %uchar %uchar_0 %3652
-OpStore %1210 %3653
-%3655 = OpLoad %uchar %1150
-%3656 = OpLoad %uchar %1154
-%3657 = OpLoad %uchar %1158
-%3658 = OpLoad %uchar %1162
-%3659 = OpLoad %uchar %1166
-%3660 = OpLoad %uchar %1170
-%3661 = OpLoad %uchar %1174
-%3662 = OpLoad %uchar %1178
-%3663 = OpLoad %uchar %1182
-%3664 = OpLoad %uchar %1186
-%3665 = OpLoad %uchar %1190
-%3666 = OpLoad %uchar %1194
-%3667 = OpLoad %uchar %1198
-%3668 = OpLoad %uchar %1202
-%3669 = OpLoad %uchar %1206
-%3670 = OpLoad %uchar %1210
-%3654 = OpCompositeConstruct %_arr_uchar_uint_16 %3655 %3656 %3657 %3658 %3659 %3660 %3661 %3662 %3663 %3664 %3665 %3666 %3667 %3668 %3669 %3670
-OpStore %1211 %3654
-%3671 = OpLoad %ulong %481
-%3672 = OpLoad %_arr_uchar_uint_16 %1211
-%3673 = OpFunctionCall %ulong %1 %3671 %3672
-OpStore %482 %3673
-%3674 = OpLoad %_arr_uchar_uint_16 %1081
-%3675 = OpCompositeExtract %uchar %3674 0
-OpStore %1212 %3675
-%3676 = OpLoad %_arr_uchar_uint_16 %476
-%3677 = OpCompositeExtract %uchar %3676 0
-OpStore %1213 %3677
-%3678 = OpLoad %uchar %1212
-%3679 = OpLoad %uchar %1213
-%3680 = OpBitwiseAnd %uchar %3678 %3679
-OpStore %1214 %3680
-%3681 = OpLoad %_arr_uchar_uint_16 %1081
-%3682 = OpCompositeExtract %uchar %3681 1
-OpStore %1215 %3682
-%3683 = OpLoad %_arr_uchar_uint_16 %476
-%3684 = OpCompositeExtract %uchar %3683 1
-OpStore %1216 %3684
-%3685 = OpLoad %uchar %1215
-%3686 = OpLoad %uchar %1216
-%3687 = OpBitwiseAnd %uchar %3685 %3686
-OpStore %1217 %3687
-%3688 = OpLoad %_arr_uchar_uint_16 %1081
-%3689 = OpCompositeExtract %uchar %3688 2
-OpStore %1218 %3689
-%3690 = OpLoad %_arr_uchar_uint_16 %476
-%3691 = OpCompositeExtract %uchar %3690 2
-OpStore %1219 %3691
-%3692 = OpLoad %uchar %1218
-%3693 = OpLoad %uchar %1219
-%3694 = OpBitwiseAnd %uchar %3692 %3693
-OpStore %1220 %3694
-%3695 = OpLoad %_arr_uchar_uint_16 %1081
-%3696 = OpCompositeExtract %uchar %3695 3
-OpStore %1221 %3696
-%3697 = OpLoad %_arr_uchar_uint_16 %476
-%3698 = OpCompositeExtract %uchar %3697 3
-OpStore %1222 %3698
-%3699 = OpLoad %uchar %1221
-%3700 = OpLoad %uchar %1222
-%3701 = OpBitwiseAnd %uchar %3699 %3700
-OpStore %1223 %3701
-%3702 = OpLoad %_arr_uchar_uint_16 %1081
-%3703 = OpCompositeExtract %uchar %3702 4
-OpStore %1224 %3703
-%3704 = OpLoad %_arr_uchar_uint_16 %476
-%3705 = OpCompositeExtract %uchar %3704 4
-OpStore %1225 %3705
-%3706 = OpLoad %uchar %1224
-%3707 = OpLoad %uchar %1225
-%3708 = OpBitwiseAnd %uchar %3706 %3707
-OpStore %1226 %3708
-%3709 = OpLoad %_arr_uchar_uint_16 %1081
-%3710 = OpCompositeExtract %uchar %3709 5
-OpStore %1227 %3710
-%3711 = OpLoad %_arr_uchar_uint_16 %476
-%3712 = OpCompositeExtract %uchar %3711 5
-OpStore %1228 %3712
-%3713 = OpLoad %uchar %1227
-%3714 = OpLoad %uchar %1228
-%3715 = OpBitwiseAnd %uchar %3713 %3714
-OpStore %1229 %3715
-%3716 = OpLoad %_arr_uchar_uint_16 %1081
-%3717 = OpCompositeExtract %uchar %3716 6
-OpStore %1230 %3717
-%3718 = OpLoad %_arr_uchar_uint_16 %476
-%3719 = OpCompositeExtract %uchar %3718 6
-OpStore %1231 %3719
-%3720 = OpLoad %uchar %1230
-%3721 = OpLoad %uchar %1231
-%3722 = OpBitwiseAnd %uchar %3720 %3721
-OpStore %1232 %3722
-%3723 = OpLoad %_arr_uchar_uint_16 %1081
-%3724 = OpCompositeExtract %uchar %3723 7
-OpStore %1233 %3724
-%3725 = OpLoad %_arr_uchar_uint_16 %476
-%3726 = OpCompositeExtract %uchar %3725 7
-OpStore %1234 %3726
-%3727 = OpLoad %uchar %1233
-%3728 = OpLoad %uchar %1234
-%3729 = OpBitwiseAnd %uchar %3727 %3728
-OpStore %1235 %3729
-%3730 = OpLoad %_arr_uchar_uint_16 %1081
-%3731 = OpCompositeExtract %uchar %3730 8
-OpStore %1236 %3731
-%3732 = OpLoad %_arr_uchar_uint_16 %476
-%3733 = OpCompositeExtract %uchar %3732 8
-OpStore %1237 %3733
-%3734 = OpLoad %uchar %1236
-%3735 = OpLoad %uchar %1237
-%3736 = OpBitwiseAnd %uchar %3734 %3735
-OpStore %1238 %3736
-%3737 = OpLoad %_arr_uchar_uint_16 %1081
-%3738 = OpCompositeExtract %uchar %3737 9
-OpStore %1239 %3738
-%3739 = OpLoad %_arr_uchar_uint_16 %476
-%3740 = OpCompositeExtract %uchar %3739 9
-OpStore %1240 %3740
-%3741 = OpLoad %uchar %1239
-%3742 = OpLoad %uchar %1240
-%3743 = OpBitwiseAnd %uchar %3741 %3742
-OpStore %1241 %3743
-%3744 = OpLoad %_arr_uchar_uint_16 %1081
-%3745 = OpCompositeExtract %uchar %3744 10
-OpStore %1242 %3745
-%3746 = OpLoad %_arr_uchar_uint_16 %476
-%3747 = OpCompositeExtract %uchar %3746 10
-OpStore %1243 %3747
-%3748 = OpLoad %uchar %1242
-%3749 = OpLoad %uchar %1243
-%3750 = OpBitwiseAnd %uchar %3748 %3749
-OpStore %1244 %3750
-%3751 = OpLoad %_arr_uchar_uint_16 %1081
-%3752 = OpCompositeExtract %uchar %3751 11
-OpStore %1245 %3752
-%3753 = OpLoad %_arr_uchar_uint_16 %476
-%3754 = OpCompositeExtract %uchar %3753 11
-OpStore %1246 %3754
-%3755 = OpLoad %uchar %1245
-%3756 = OpLoad %uchar %1246
-%3757 = OpBitwiseAnd %uchar %3755 %3756
-OpStore %1247 %3757
-%3758 = OpLoad %_arr_uchar_uint_16 %1081
-%3759 = OpCompositeExtract %uchar %3758 12
-OpStore %1248 %3759
-%3760 = OpLoad %_arr_uchar_uint_16 %476
-%3761 = OpCompositeExtract %uchar %3760 12
-OpStore %1249 %3761
-%3762 = OpLoad %uchar %1248
-%3763 = OpLoad %uchar %1249
-%3764 = OpBitwiseAnd %uchar %3762 %3763
-OpStore %1250 %3764
-%3765 = OpLoad %_arr_uchar_uint_16 %1081
-%3766 = OpCompositeExtract %uchar %3765 13
-OpStore %1251 %3766
-%3767 = OpLoad %_arr_uchar_uint_16 %476
-%3768 = OpCompositeExtract %uchar %3767 13
-OpStore %1252 %3768
-%3769 = OpLoad %uchar %1251
-%3770 = OpLoad %uchar %1252
-%3771 = OpBitwiseAnd %uchar %3769 %3770
-OpStore %1253 %3771
-%3772 = OpLoad %_arr_uchar_uint_16 %1081
-%3773 = OpCompositeExtract %uchar %3772 14
-OpStore %1254 %3773
-%3774 = OpLoad %_arr_uchar_uint_16 %476
-%3775 = OpCompositeExtract %uchar %3774 14
-OpStore %1255 %3775
-%3776 = OpLoad %uchar %1254
-%3777 = OpLoad %uchar %1255
-%3778 = OpBitwiseAnd %uchar %3776 %3777
-OpStore %1256 %3778
-%3779 = OpLoad %_arr_uchar_uint_16 %1081
+%3253 = OpUConvert %ushort %3252
+OpStore %1591 %3253
+%3254 = OpLoad %ushort %1591
+%3255 = OpISub %ushort %ushort_0 %3254
+OpStore %1592 %3255
+%3256 = OpLoad %_arr_ushort_uint_8 %1256
+%3257 = OpCompositeExtract %ushort %3256 6
+OpStore %1593 %3257
+%3258 = OpLoad %_arr_ushort_uint_8 %1253
+%3259 = OpCompositeExtract %ushort %3258 6
+OpStore %1594 %3259
+%3260 = OpLoad %ushort %1593
+%3261 = OpLoad %ushort %1594
+%3262 = OpULessThan %bool %3260 %3261
+OpStore %1595 %3262
+%3263 = OpLoad %bool %1595
+%3264 = OpSelect %uchar %3263 %uchar_1 %uchar_0
+%3265 = OpUConvert %ushort %3264
+OpStore %1596 %3265
+%3266 = OpLoad %ushort %1596
+%3267 = OpISub %ushort %ushort_0 %3266
+OpStore %1597 %3267
+%3268 = OpLoad %_arr_ushort_uint_8 %1256
+%3269 = OpCompositeExtract %ushort %3268 7
+OpStore %1598 %3269
+%3270 = OpLoad %_arr_ushort_uint_8 %1253
+%3271 = OpCompositeExtract %ushort %3270 7
+OpStore %1599 %3271
+%3272 = OpLoad %ushort %1598
+%3273 = OpLoad %ushort %1599
+%3274 = OpULessThan %bool %3272 %3273
+OpStore %1600 %3274
+%3275 = OpLoad %bool %1600
+%3276 = OpSelect %uchar %3275 %uchar_1 %uchar_0
+%3277 = OpUConvert %ushort %3276
+OpStore %1601 %3277
+%3278 = OpLoad %ushort %1601
+%3279 = OpISub %ushort %ushort_0 %3278
+OpStore %1602 %3279
+%3281 = OpLoad %ushort %1567
+%3282 = OpLoad %ushort %1572
+%3283 = OpLoad %ushort %1577
+%3284 = OpLoad %ushort %1582
+%3285 = OpLoad %ushort %1587
+%3286 = OpLoad %ushort %1592
+%3287 = OpLoad %ushort %1597
+%3288 = OpLoad %ushort %1602
+%3280 = OpCompositeConstruct %_arr_ushort_uint_8 %3281 %3282 %3283 %3284 %3285 %3286 %3287 %3288
+OpStore %1603 %3280
+%3289 = OpLoad %ulong %1258
+%3290 = OpLoad %_arr_ushort_uint_8 %1603
+%3291 = OpFunctionCall %ulong %2 %3289 %3290
+OpStore %1259 %3291
+%3292 = OpLoad %_arr_ushort_uint_8 %1521
+%3293 = OpCompositeExtract %ushort %3292 0
+OpStore %1604 %3293
+%3294 = OpLoad %_arr_ushort_uint_8 %1253
+%3295 = OpCompositeExtract %ushort %3294 0
+OpStore %1605 %3295
+%3296 = OpLoad %ushort %1604
+%3297 = OpLoad %ushort %1605
+%3298 = OpBitwiseAnd %ushort %3296 %3297
+OpStore %1606 %3298
+%3299 = OpLoad %_arr_ushort_uint_8 %1521
+%3300 = OpCompositeExtract %ushort %3299 1
+OpStore %1607 %3300
+%3301 = OpLoad %_arr_ushort_uint_8 %1253
+%3302 = OpCompositeExtract %ushort %3301 1
+OpStore %1608 %3302
+%3303 = OpLoad %ushort %1607
+%3304 = OpLoad %ushort %1608
+%3305 = OpBitwiseAnd %ushort %3303 %3304
+OpStore %1609 %3305
+%3306 = OpLoad %_arr_ushort_uint_8 %1521
+%3307 = OpCompositeExtract %ushort %3306 2
+OpStore %1610 %3307
+%3308 = OpLoad %_arr_ushort_uint_8 %1253
+%3309 = OpCompositeExtract %ushort %3308 2
+OpStore %1611 %3309
+%3310 = OpLoad %ushort %1610
+%3311 = OpLoad %ushort %1611
+%3312 = OpBitwiseAnd %ushort %3310 %3311
+OpStore %1612 %3312
+%3313 = OpLoad %_arr_ushort_uint_8 %1521
+%3314 = OpCompositeExtract %ushort %3313 3
+OpStore %1613 %3314
+%3315 = OpLoad %_arr_ushort_uint_8 %1253
+%3316 = OpCompositeExtract %ushort %3315 3
+OpStore %1614 %3316
+%3317 = OpLoad %ushort %1613
+%3318 = OpLoad %ushort %1614
+%3319 = OpBitwiseAnd %ushort %3317 %3318
+OpStore %1615 %3319
+%3320 = OpLoad %_arr_ushort_uint_8 %1521
+%3321 = OpCompositeExtract %ushort %3320 4
+OpStore %1616 %3321
+%3322 = OpLoad %_arr_ushort_uint_8 %1253
+%3323 = OpCompositeExtract %ushort %3322 4
+OpStore %1617 %3323
+%3324 = OpLoad %ushort %1616
+%3325 = OpLoad %ushort %1617
+%3326 = OpBitwiseAnd %ushort %3324 %3325
+OpStore %1618 %3326
+%3327 = OpLoad %_arr_ushort_uint_8 %1521
+%3328 = OpCompositeExtract %ushort %3327 5
+OpStore %1619 %3328
+%3329 = OpLoad %_arr_ushort_uint_8 %1253
+%3330 = OpCompositeExtract %ushort %3329 5
+OpStore %1620 %3330
+%3331 = OpLoad %ushort %1619
+%3332 = OpLoad %ushort %1620
+%3333 = OpBitwiseAnd %ushort %3331 %3332
+OpStore %1621 %3333
+%3334 = OpLoad %_arr_ushort_uint_8 %1521
+%3335 = OpCompositeExtract %ushort %3334 6
+OpStore %1622 %3335
+%3336 = OpLoad %_arr_ushort_uint_8 %1253
+%3337 = OpCompositeExtract %ushort %3336 6
+OpStore %1623 %3337
+%3338 = OpLoad %ushort %1622
+%3339 = OpLoad %ushort %1623
+%3340 = OpBitwiseAnd %ushort %3338 %3339
+OpStore %1624 %3340
+%3341 = OpLoad %_arr_ushort_uint_8 %1521
+%3342 = OpCompositeExtract %ushort %3341 7
+OpStore %1625 %3342
+%3343 = OpLoad %_arr_ushort_uint_8 %1253
+%3344 = OpCompositeExtract %ushort %3343 7
+OpStore %1626 %3344
+%3345 = OpLoad %ushort %1625
+%3346 = OpLoad %ushort %1626
+%3347 = OpBitwiseAnd %ushort %3345 %3346
+OpStore %1627 %3347
+%3348 = OpLoad %_arr_ushort_uint_8 %1521
+%3349 = OpLoad %ushort %1606
+%3350 = OpCompositeInsert %_arr_ushort_uint_8 %3349 %3348 0
+OpStore %1628 %3350
+%3351 = OpLoad %_arr_ushort_uint_8 %1628
+%3352 = OpLoad %ushort %1609
+%3353 = OpCompositeInsert %_arr_ushort_uint_8 %3352 %3351 1
+OpStore %1629 %3353
+%3354 = OpLoad %_arr_ushort_uint_8 %1629
+%3355 = OpLoad %ushort %1612
+%3356 = OpCompositeInsert %_arr_ushort_uint_8 %3355 %3354 2
+OpStore %1630 %3356
+%3357 = OpLoad %_arr_ushort_uint_8 %1630
+%3358 = OpLoad %ushort %1615
+%3359 = OpCompositeInsert %_arr_ushort_uint_8 %3358 %3357 3
+OpStore %1631 %3359
+%3360 = OpLoad %_arr_ushort_uint_8 %1631
+%3361 = OpLoad %ushort %1618
+%3362 = OpCompositeInsert %_arr_ushort_uint_8 %3361 %3360 4
+OpStore %1632 %3362
+%3363 = OpLoad %_arr_ushort_uint_8 %1632
+%3364 = OpLoad %ushort %1621
+%3365 = OpCompositeInsert %_arr_ushort_uint_8 %3364 %3363 5
+OpStore %1633 %3365
+%3366 = OpLoad %_arr_ushort_uint_8 %1633
+%3367 = OpLoad %ushort %1624
+%3368 = OpCompositeInsert %_arr_ushort_uint_8 %3367 %3366 6
+OpStore %1634 %3368
+%3369 = OpLoad %_arr_ushort_uint_8 %1634
+%3370 = OpLoad %ushort %1627
+%3371 = OpCompositeInsert %_arr_ushort_uint_8 %3370 %3369 7
+OpStore %1635 %3371
+%3372 = OpLoad %_arr_ushort_uint_8 %1521
+%3373 = OpCompositeExtract %ushort %3372 0
+OpStore %1636 %3373
+%3374 = OpLoad %ushort %1636
+%3375 = OpNot %ushort %3374
+OpStore %1637 %3375
+%3376 = OpLoad %_arr_ushort_uint_8 %1521
+%3377 = OpCompositeExtract %ushort %3376 1
+OpStore %1638 %3377
+%3378 = OpLoad %ushort %1638
+%3379 = OpNot %ushort %3378
+OpStore %1639 %3379
+%3380 = OpLoad %_arr_ushort_uint_8 %1521
+%3381 = OpCompositeExtract %ushort %3380 2
+OpStore %1640 %3381
+%3382 = OpLoad %ushort %1640
+%3383 = OpNot %ushort %3382
+OpStore %1641 %3383
+%3384 = OpLoad %_arr_ushort_uint_8 %1521
+%3385 = OpCompositeExtract %ushort %3384 3
+OpStore %1642 %3385
+%3386 = OpLoad %ushort %1642
+%3387 = OpNot %ushort %3386
+OpStore %1643 %3387
+%3388 = OpLoad %_arr_ushort_uint_8 %1521
+%3389 = OpCompositeExtract %ushort %3388 4
+OpStore %1644 %3389
+%3390 = OpLoad %ushort %1644
+%3391 = OpNot %ushort %3390
+OpStore %1645 %3391
+%3392 = OpLoad %_arr_ushort_uint_8 %1521
+%3393 = OpCompositeExtract %ushort %3392 5
+OpStore %1646 %3393
+%3394 = OpLoad %ushort %1646
+%3395 = OpNot %ushort %3394
+OpStore %1647 %3395
+%3396 = OpLoad %_arr_ushort_uint_8 %1521
+%3397 = OpCompositeExtract %ushort %3396 6
+OpStore %1648 %3397
+%3398 = OpLoad %ushort %1648
+%3399 = OpNot %ushort %3398
+OpStore %1649 %3399
+%3400 = OpLoad %_arr_ushort_uint_8 %1521
+%3401 = OpCompositeExtract %ushort %3400 7
+OpStore %1650 %3401
+%3402 = OpLoad %ushort %1650
+%3403 = OpNot %ushort %3402
+OpStore %1651 %3403
+%3404 = OpLoad %_arr_ushort_uint_8 %1521
+%3405 = OpLoad %ushort %1637
+%3406 = OpCompositeInsert %_arr_ushort_uint_8 %3405 %3404 0
+OpStore %1652 %3406
+%3407 = OpLoad %_arr_ushort_uint_8 %1652
+%3408 = OpLoad %ushort %1639
+%3409 = OpCompositeInsert %_arr_ushort_uint_8 %3408 %3407 1
+OpStore %1653 %3409
+%3410 = OpLoad %_arr_ushort_uint_8 %1653
+%3411 = OpLoad %ushort %1641
+%3412 = OpCompositeInsert %_arr_ushort_uint_8 %3411 %3410 2
+OpStore %1654 %3412
+%3413 = OpLoad %_arr_ushort_uint_8 %1654
+%3414 = OpLoad %ushort %1643
+%3415 = OpCompositeInsert %_arr_ushort_uint_8 %3414 %3413 3
+OpStore %1655 %3415
+%3416 = OpLoad %_arr_ushort_uint_8 %1655
+%3417 = OpLoad %ushort %1645
+%3418 = OpCompositeInsert %_arr_ushort_uint_8 %3417 %3416 4
+OpStore %1656 %3418
+%3419 = OpLoad %_arr_ushort_uint_8 %1656
+%3420 = OpLoad %ushort %1647
+%3421 = OpCompositeInsert %_arr_ushort_uint_8 %3420 %3419 5
+OpStore %1657 %3421
+%3422 = OpLoad %_arr_ushort_uint_8 %1657
+%3423 = OpLoad %ushort %1649
+%3424 = OpCompositeInsert %_arr_ushort_uint_8 %3423 %3422 6
+OpStore %1658 %3424
+%3425 = OpLoad %_arr_ushort_uint_8 %1658
+%3426 = OpLoad %ushort %1651
+%3427 = OpCompositeInsert %_arr_ushort_uint_8 %3426 %3425 7
+OpStore %1659 %3427
+%3428 = OpLoad %_arr_ushort_uint_8 %1659
+%3429 = OpCompositeExtract %ushort %3428 0
+OpStore %1660 %3429
+%3430 = OpLoad %_arr_ushort_uint_8 %1256
+%3431 = OpCompositeExtract %ushort %3430 0
+OpStore %1661 %3431
+%3432 = OpLoad %ushort %1660
+%3433 = OpLoad %ushort %1661
+%3434 = OpBitwiseAnd %ushort %3432 %3433
+OpStore %1662 %3434
+%3435 = OpLoad %_arr_ushort_uint_8 %1659
+%3436 = OpCompositeExtract %ushort %3435 1
+OpStore %1663 %3436
+%3437 = OpLoad %_arr_ushort_uint_8 %1256
+%3438 = OpCompositeExtract %ushort %3437 1
+OpStore %1664 %3438
+%3439 = OpLoad %ushort %1663
+%3440 = OpLoad %ushort %1664
+%3441 = OpBitwiseAnd %ushort %3439 %3440
+OpStore %1665 %3441
+%3442 = OpLoad %_arr_ushort_uint_8 %1659
+%3443 = OpCompositeExtract %ushort %3442 2
+OpStore %1666 %3443
+%3444 = OpLoad %_arr_ushort_uint_8 %1256
+%3445 = OpCompositeExtract %ushort %3444 2
+OpStore %1667 %3445
+%3446 = OpLoad %ushort %1666
+%3447 = OpLoad %ushort %1667
+%3448 = OpBitwiseAnd %ushort %3446 %3447
+OpStore %1668 %3448
+%3449 = OpLoad %_arr_ushort_uint_8 %1659
+%3450 = OpCompositeExtract %ushort %3449 3
+OpStore %1669 %3450
+%3451 = OpLoad %_arr_ushort_uint_8 %1256
+%3452 = OpCompositeExtract %ushort %3451 3
+OpStore %1670 %3452
+%3453 = OpLoad %ushort %1669
+%3454 = OpLoad %ushort %1670
+%3455 = OpBitwiseAnd %ushort %3453 %3454
+OpStore %1671 %3455
+%3456 = OpLoad %_arr_ushort_uint_8 %1659
+%3457 = OpCompositeExtract %ushort %3456 4
+OpStore %1672 %3457
+%3458 = OpLoad %_arr_ushort_uint_8 %1256
+%3459 = OpCompositeExtract %ushort %3458 4
+OpStore %1673 %3459
+%3460 = OpLoad %ushort %1672
+%3461 = OpLoad %ushort %1673
+%3462 = OpBitwiseAnd %ushort %3460 %3461
+OpStore %1674 %3462
+%3463 = OpLoad %_arr_ushort_uint_8 %1659
+%3464 = OpCompositeExtract %ushort %3463 5
+OpStore %1675 %3464
+%3465 = OpLoad %_arr_ushort_uint_8 %1256
+%3466 = OpCompositeExtract %ushort %3465 5
+OpStore %1676 %3466
+%3467 = OpLoad %ushort %1675
+%3468 = OpLoad %ushort %1676
+%3469 = OpBitwiseAnd %ushort %3467 %3468
+OpStore %1677 %3469
+%3470 = OpLoad %_arr_ushort_uint_8 %1659
+%3471 = OpCompositeExtract %ushort %3470 6
+OpStore %1678 %3471
+%3472 = OpLoad %_arr_ushort_uint_8 %1256
+%3473 = OpCompositeExtract %ushort %3472 6
+OpStore %1679 %3473
+%3474 = OpLoad %ushort %1678
+%3475 = OpLoad %ushort %1679
+%3476 = OpBitwiseAnd %ushort %3474 %3475
+OpStore %1680 %3476
+%3477 = OpLoad %_arr_ushort_uint_8 %1659
+%3478 = OpCompositeExtract %ushort %3477 7
+OpStore %1681 %3478
+%3479 = OpLoad %_arr_ushort_uint_8 %1256
+%3480 = OpCompositeExtract %ushort %3479 7
+OpStore %1682 %3480
+%3481 = OpLoad %ushort %1681
+%3482 = OpLoad %ushort %1682
+%3483 = OpBitwiseAnd %ushort %3481 %3482
+OpStore %1683 %3483
+%3484 = OpLoad %_arr_ushort_uint_8 %1659
+%3485 = OpLoad %ushort %1662
+%3486 = OpCompositeInsert %_arr_ushort_uint_8 %3485 %3484 0
+OpStore %1684 %3486
+%3487 = OpLoad %_arr_ushort_uint_8 %1684
+%3488 = OpLoad %ushort %1665
+%3489 = OpCompositeInsert %_arr_ushort_uint_8 %3488 %3487 1
+OpStore %1685 %3489
+%3490 = OpLoad %_arr_ushort_uint_8 %1685
+%3491 = OpLoad %ushort %1668
+%3492 = OpCompositeInsert %_arr_ushort_uint_8 %3491 %3490 2
+OpStore %1686 %3492
+%3493 = OpLoad %_arr_ushort_uint_8 %1686
+%3494 = OpLoad %ushort %1671
+%3495 = OpCompositeInsert %_arr_ushort_uint_8 %3494 %3493 3
+OpStore %1687 %3495
+%3496 = OpLoad %_arr_ushort_uint_8 %1687
+%3497 = OpLoad %ushort %1674
+%3498 = OpCompositeInsert %_arr_ushort_uint_8 %3497 %3496 4
+OpStore %1688 %3498
+%3499 = OpLoad %_arr_ushort_uint_8 %1688
+%3500 = OpLoad %ushort %1677
+%3501 = OpCompositeInsert %_arr_ushort_uint_8 %3500 %3499 5
+OpStore %1689 %3501
+%3502 = OpLoad %_arr_ushort_uint_8 %1689
+%3503 = OpLoad %ushort %1680
+%3504 = OpCompositeInsert %_arr_ushort_uint_8 %3503 %3502 6
+OpStore %1690 %3504
+%3505 = OpLoad %_arr_ushort_uint_8 %1690
+%3506 = OpLoad %ushort %1683
+%3507 = OpCompositeInsert %_arr_ushort_uint_8 %3506 %3505 7
+OpStore %1691 %3507
+%3508 = OpLoad %_arr_ushort_uint_8 %1635
+%3509 = OpCompositeExtract %ushort %3508 0
+OpStore %1692 %3509
+%3510 = OpLoad %_arr_ushort_uint_8 %1691
+%3511 = OpCompositeExtract %ushort %3510 0
+OpStore %1693 %3511
+%3512 = OpLoad %ushort %1692
+%3513 = OpLoad %ushort %1693
+%3514 = OpBitwiseOr %ushort %3512 %3513
+OpStore %1694 %3514
+%3515 = OpLoad %_arr_ushort_uint_8 %1635
+%3516 = OpCompositeExtract %ushort %3515 1
+OpStore %1695 %3516
+%3517 = OpLoad %_arr_ushort_uint_8 %1691
+%3518 = OpCompositeExtract %ushort %3517 1
+OpStore %1696 %3518
+%3519 = OpLoad %ushort %1695
+%3520 = OpLoad %ushort %1696
+%3521 = OpBitwiseOr %ushort %3519 %3520
+OpStore %1697 %3521
+%3522 = OpLoad %_arr_ushort_uint_8 %1635
+%3523 = OpCompositeExtract %ushort %3522 2
+OpStore %1698 %3523
+%3524 = OpLoad %_arr_ushort_uint_8 %1691
+%3525 = OpCompositeExtract %ushort %3524 2
+OpStore %1699 %3525
+%3526 = OpLoad %ushort %1698
+%3527 = OpLoad %ushort %1699
+%3528 = OpBitwiseOr %ushort %3526 %3527
+OpStore %1700 %3528
+%3529 = OpLoad %_arr_ushort_uint_8 %1635
+%3530 = OpCompositeExtract %ushort %3529 3
+OpStore %1701 %3530
+%3531 = OpLoad %_arr_ushort_uint_8 %1691
+%3532 = OpCompositeExtract %ushort %3531 3
+OpStore %1702 %3532
+%3533 = OpLoad %ushort %1701
+%3534 = OpLoad %ushort %1702
+%3535 = OpBitwiseOr %ushort %3533 %3534
+OpStore %1703 %3535
+%3536 = OpLoad %_arr_ushort_uint_8 %1635
+%3537 = OpCompositeExtract %ushort %3536 4
+OpStore %1704 %3537
+%3538 = OpLoad %_arr_ushort_uint_8 %1691
+%3539 = OpCompositeExtract %ushort %3538 4
+OpStore %1705 %3539
+%3540 = OpLoad %ushort %1704
+%3541 = OpLoad %ushort %1705
+%3542 = OpBitwiseOr %ushort %3540 %3541
+OpStore %1706 %3542
+%3543 = OpLoad %_arr_ushort_uint_8 %1635
+%3544 = OpCompositeExtract %ushort %3543 5
+OpStore %1707 %3544
+%3545 = OpLoad %_arr_ushort_uint_8 %1691
+%3546 = OpCompositeExtract %ushort %3545 5
+OpStore %1708 %3546
+%3547 = OpLoad %ushort %1707
+%3548 = OpLoad %ushort %1708
+%3549 = OpBitwiseOr %ushort %3547 %3548
+OpStore %1709 %3549
+%3550 = OpLoad %_arr_ushort_uint_8 %1635
+%3551 = OpCompositeExtract %ushort %3550 6
+OpStore %1710 %3551
+%3552 = OpLoad %_arr_ushort_uint_8 %1691
+%3553 = OpCompositeExtract %ushort %3552 6
+OpStore %1711 %3553
+%3554 = OpLoad %ushort %1710
+%3555 = OpLoad %ushort %1711
+%3556 = OpBitwiseOr %ushort %3554 %3555
+OpStore %1712 %3556
+%3557 = OpLoad %_arr_ushort_uint_8 %1635
+%3558 = OpCompositeExtract %ushort %3557 7
+OpStore %1713 %3558
+%3559 = OpLoad %_arr_ushort_uint_8 %1691
+%3560 = OpCompositeExtract %ushort %3559 7
+OpStore %1714 %3560
+%3561 = OpLoad %ushort %1713
+%3562 = OpLoad %ushort %1714
+%3563 = OpBitwiseOr %ushort %3561 %3562
+OpStore %1715 %3563
+%3564 = OpLoad %_arr_ushort_uint_8 %1635
+%3565 = OpLoad %ushort %1694
+%3566 = OpCompositeInsert %_arr_ushort_uint_8 %3565 %3564 0
+OpStore %1716 %3566
+%3567 = OpLoad %_arr_ushort_uint_8 %1716
+%3568 = OpLoad %ushort %1697
+%3569 = OpCompositeInsert %_arr_ushort_uint_8 %3568 %3567 1
+OpStore %1717 %3569
+%3570 = OpLoad %_arr_ushort_uint_8 %1717
+%3571 = OpLoad %ushort %1700
+%3572 = OpCompositeInsert %_arr_ushort_uint_8 %3571 %3570 2
+OpStore %1718 %3572
+%3573 = OpLoad %_arr_ushort_uint_8 %1718
+%3574 = OpLoad %ushort %1703
+%3575 = OpCompositeInsert %_arr_ushort_uint_8 %3574 %3573 3
+OpStore %1719 %3575
+%3576 = OpLoad %_arr_ushort_uint_8 %1719
+%3577 = OpLoad %ushort %1706
+%3578 = OpCompositeInsert %_arr_ushort_uint_8 %3577 %3576 4
+OpStore %1720 %3578
+%3579 = OpLoad %_arr_ushort_uint_8 %1720
+%3580 = OpLoad %ushort %1709
+%3581 = OpCompositeInsert %_arr_ushort_uint_8 %3580 %3579 5
+OpStore %1721 %3581
+%3582 = OpLoad %_arr_ushort_uint_8 %1721
+%3583 = OpLoad %ushort %1712
+%3584 = OpCompositeInsert %_arr_ushort_uint_8 %3583 %3582 6
+OpStore %1722 %3584
+%3585 = OpLoad %_arr_ushort_uint_8 %1722
+%3586 = OpLoad %ushort %1715
+%3587 = OpCompositeInsert %_arr_ushort_uint_8 %3586 %3585 7
+OpStore %1723 %3587
+%3588 = OpLoad %ulong %1259
+%3589 = OpLoad %_arr_ushort_uint_8 %1723
+%3590 = OpFunctionCall %ulong %2 %3588 %3589
+OpStore %1260 %3590
+%3591 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_255 %uchar_128 %uchar_7 %uchar_7 %uchar_0 %uchar_200 %uchar_254 %uchar_3 %uchar_9 %uchar_11 %uchar_13 %uchar_17 %uchar_19 %uchar_23 %uchar_29
+OpStore %1261 %3591
+%3605 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_2 %uchar_1 %uchar_127 %uchar_7 %uchar_8 %uchar_255 %uchar_200 %uchar_255 %uchar_3 %uchar_8 %uchar_12 %uchar_13 %uchar_18 %uchar_19 %uchar_22 %uchar_30
+OpStore %1262 %3605
+%3613 = OpLoad %_arr_uchar_uint_16 %1261
+%3614 = OpCompositeExtract %uchar %3613 0
+OpStore %1263 %3614
+%3615 = OpLoad %uchar %1263
+%3616 = OpLoad %uchar %1157
+%3617 = OpIAdd %uchar %3615 %3616
+OpStore %1264 %3617
+%3618 = OpLoad %_arr_uchar_uint_16 %1261
+%3619 = OpLoad %uchar %1264
+%3620 = OpCompositeInsert %_arr_uchar_uint_16 %3619 %3618 0
+OpStore %1265 %3620
+%3621 = OpLoad %_arr_uchar_uint_16 %1262
+%3622 = OpCompositeExtract %uchar %3621 15
+OpStore %1266 %3622
+%3623 = OpLoad %uchar %1266
+%3624 = OpLoad %uchar %1157
+%3625 = OpIAdd %uchar %3623 %3624
+OpStore %1267 %3625
+%3626 = OpLoad %_arr_uchar_uint_16 %1262
+%3627 = OpLoad %uchar %1267
+%3628 = OpCompositeInsert %_arr_uchar_uint_16 %3627 %3626 15
+OpStore %1268 %3628
+%3629 = OpLoad %_arr_uchar_uint_16 %1265
+%3630 = OpCompositeExtract %uchar %3629 0
+OpStore %1724 %3630
+%3631 = OpLoad %_arr_uchar_uint_16 %1268
+%3632 = OpCompositeExtract %uchar %3631 0
+OpStore %1725 %3632
+%3633 = OpLoad %uchar %1724
+%3634 = OpLoad %uchar %1725
+%3635 = OpULessThan %bool %3633 %3634
+OpStore %1726 %3635
+%3636 = OpLoad %bool %1726
+%3637 = OpSelect %uchar %3636 %uchar_1 %uchar_0
+%3638 = OpISub %uchar %uchar_0 %3637
+OpStore %1727 %3638
+%3639 = OpLoad %_arr_uchar_uint_16 %1265
+%3640 = OpCompositeExtract %uchar %3639 1
+OpStore %1728 %3640
+%3641 = OpLoad %_arr_uchar_uint_16 %1268
+%3642 = OpCompositeExtract %uchar %3641 1
+OpStore %1729 %3642
+%3643 = OpLoad %uchar %1728
+%3644 = OpLoad %uchar %1729
+%3645 = OpULessThan %bool %3643 %3644
+OpStore %1730 %3645
+%3646 = OpLoad %bool %1730
+%3647 = OpSelect %uchar %3646 %uchar_1 %uchar_0
+%3648 = OpISub %uchar %uchar_0 %3647
+OpStore %1731 %3648
+%3649 = OpLoad %_arr_uchar_uint_16 %1265
+%3650 = OpCompositeExtract %uchar %3649 2
+OpStore %1732 %3650
+%3651 = OpLoad %_arr_uchar_uint_16 %1268
+%3652 = OpCompositeExtract %uchar %3651 2
+OpStore %1733 %3652
+%3653 = OpLoad %uchar %1732
+%3654 = OpLoad %uchar %1733
+%3655 = OpULessThan %bool %3653 %3654
+OpStore %1734 %3655
+%3656 = OpLoad %bool %1734
+%3657 = OpSelect %uchar %3656 %uchar_1 %uchar_0
+%3658 = OpISub %uchar %uchar_0 %3657
+OpStore %1735 %3658
+%3659 = OpLoad %_arr_uchar_uint_16 %1265
+%3660 = OpCompositeExtract %uchar %3659 3
+OpStore %1736 %3660
+%3661 = OpLoad %_arr_uchar_uint_16 %1268
+%3662 = OpCompositeExtract %uchar %3661 3
+OpStore %1737 %3662
+%3663 = OpLoad %uchar %1736
+%3664 = OpLoad %uchar %1737
+%3665 = OpULessThan %bool %3663 %3664
+OpStore %1738 %3665
+%3666 = OpLoad %bool %1738
+%3667 = OpSelect %uchar %3666 %uchar_1 %uchar_0
+%3668 = OpISub %uchar %uchar_0 %3667
+OpStore %1739 %3668
+%3669 = OpLoad %_arr_uchar_uint_16 %1265
+%3670 = OpCompositeExtract %uchar %3669 4
+OpStore %1740 %3670
+%3671 = OpLoad %_arr_uchar_uint_16 %1268
+%3672 = OpCompositeExtract %uchar %3671 4
+OpStore %1741 %3672
+%3673 = OpLoad %uchar %1740
+%3674 = OpLoad %uchar %1741
+%3675 = OpULessThan %bool %3673 %3674
+OpStore %1742 %3675
+%3676 = OpLoad %bool %1742
+%3677 = OpSelect %uchar %3676 %uchar_1 %uchar_0
+%3678 = OpISub %uchar %uchar_0 %3677
+OpStore %1743 %3678
+%3679 = OpLoad %_arr_uchar_uint_16 %1265
+%3680 = OpCompositeExtract %uchar %3679 5
+OpStore %1744 %3680
+%3681 = OpLoad %_arr_uchar_uint_16 %1268
+%3682 = OpCompositeExtract %uchar %3681 5
+OpStore %1745 %3682
+%3683 = OpLoad %uchar %1744
+%3684 = OpLoad %uchar %1745
+%3685 = OpULessThan %bool %3683 %3684
+OpStore %1746 %3685
+%3686 = OpLoad %bool %1746
+%3687 = OpSelect %uchar %3686 %uchar_1 %uchar_0
+%3688 = OpISub %uchar %uchar_0 %3687
+OpStore %1747 %3688
+%3689 = OpLoad %_arr_uchar_uint_16 %1265
+%3690 = OpCompositeExtract %uchar %3689 6
+OpStore %1748 %3690
+%3691 = OpLoad %_arr_uchar_uint_16 %1268
+%3692 = OpCompositeExtract %uchar %3691 6
+OpStore %1749 %3692
+%3693 = OpLoad %uchar %1748
+%3694 = OpLoad %uchar %1749
+%3695 = OpULessThan %bool %3693 %3694
+OpStore %1750 %3695
+%3696 = OpLoad %bool %1750
+%3697 = OpSelect %uchar %3696 %uchar_1 %uchar_0
+%3698 = OpISub %uchar %uchar_0 %3697
+OpStore %1751 %3698
+%3699 = OpLoad %_arr_uchar_uint_16 %1265
+%3700 = OpCompositeExtract %uchar %3699 7
+OpStore %1752 %3700
+%3701 = OpLoad %_arr_uchar_uint_16 %1268
+%3702 = OpCompositeExtract %uchar %3701 7
+OpStore %1753 %3702
+%3703 = OpLoad %uchar %1752
+%3704 = OpLoad %uchar %1753
+%3705 = OpULessThan %bool %3703 %3704
+OpStore %1754 %3705
+%3706 = OpLoad %bool %1754
+%3707 = OpSelect %uchar %3706 %uchar_1 %uchar_0
+%3708 = OpISub %uchar %uchar_0 %3707
+OpStore %1755 %3708
+%3709 = OpLoad %_arr_uchar_uint_16 %1265
+%3710 = OpCompositeExtract %uchar %3709 8
+OpStore %1756 %3710
+%3711 = OpLoad %_arr_uchar_uint_16 %1268
+%3712 = OpCompositeExtract %uchar %3711 8
+OpStore %1757 %3712
+%3713 = OpLoad %uchar %1756
+%3714 = OpLoad %uchar %1757
+%3715 = OpULessThan %bool %3713 %3714
+OpStore %1758 %3715
+%3716 = OpLoad %bool %1758
+%3717 = OpSelect %uchar %3716 %uchar_1 %uchar_0
+%3718 = OpISub %uchar %uchar_0 %3717
+OpStore %1759 %3718
+%3719 = OpLoad %_arr_uchar_uint_16 %1265
+%3720 = OpCompositeExtract %uchar %3719 9
+OpStore %1760 %3720
+%3721 = OpLoad %_arr_uchar_uint_16 %1268
+%3722 = OpCompositeExtract %uchar %3721 9
+OpStore %1761 %3722
+%3723 = OpLoad %uchar %1760
+%3724 = OpLoad %uchar %1761
+%3725 = OpULessThan %bool %3723 %3724
+OpStore %1762 %3725
+%3726 = OpLoad %bool %1762
+%3727 = OpSelect %uchar %3726 %uchar_1 %uchar_0
+%3728 = OpISub %uchar %uchar_0 %3727
+OpStore %1763 %3728
+%3729 = OpLoad %_arr_uchar_uint_16 %1265
+%3730 = OpCompositeExtract %uchar %3729 10
+OpStore %1764 %3730
+%3731 = OpLoad %_arr_uchar_uint_16 %1268
+%3732 = OpCompositeExtract %uchar %3731 10
+OpStore %1765 %3732
+%3733 = OpLoad %uchar %1764
+%3734 = OpLoad %uchar %1765
+%3735 = OpULessThan %bool %3733 %3734
+OpStore %1766 %3735
+%3736 = OpLoad %bool %1766
+%3737 = OpSelect %uchar %3736 %uchar_1 %uchar_0
+%3738 = OpISub %uchar %uchar_0 %3737
+OpStore %1767 %3738
+%3739 = OpLoad %_arr_uchar_uint_16 %1265
+%3740 = OpCompositeExtract %uchar %3739 11
+OpStore %1768 %3740
+%3741 = OpLoad %_arr_uchar_uint_16 %1268
+%3742 = OpCompositeExtract %uchar %3741 11
+OpStore %1769 %3742
+%3743 = OpLoad %uchar %1768
+%3744 = OpLoad %uchar %1769
+%3745 = OpULessThan %bool %3743 %3744
+OpStore %1770 %3745
+%3746 = OpLoad %bool %1770
+%3747 = OpSelect %uchar %3746 %uchar_1 %uchar_0
+%3748 = OpISub %uchar %uchar_0 %3747
+OpStore %1771 %3748
+%3749 = OpLoad %_arr_uchar_uint_16 %1265
+%3750 = OpCompositeExtract %uchar %3749 12
+OpStore %1772 %3750
+%3751 = OpLoad %_arr_uchar_uint_16 %1268
+%3752 = OpCompositeExtract %uchar %3751 12
+OpStore %1773 %3752
+%3753 = OpLoad %uchar %1772
+%3754 = OpLoad %uchar %1773
+%3755 = OpULessThan %bool %3753 %3754
+OpStore %1774 %3755
+%3756 = OpLoad %bool %1774
+%3757 = OpSelect %uchar %3756 %uchar_1 %uchar_0
+%3758 = OpISub %uchar %uchar_0 %3757
+OpStore %1775 %3758
+%3759 = OpLoad %_arr_uchar_uint_16 %1265
+%3760 = OpCompositeExtract %uchar %3759 13
+OpStore %1776 %3760
+%3761 = OpLoad %_arr_uchar_uint_16 %1268
+%3762 = OpCompositeExtract %uchar %3761 13
+OpStore %1777 %3762
+%3763 = OpLoad %uchar %1776
+%3764 = OpLoad %uchar %1777
+%3765 = OpULessThan %bool %3763 %3764
+OpStore %1778 %3765
+%3766 = OpLoad %bool %1778
+%3767 = OpSelect %uchar %3766 %uchar_1 %uchar_0
+%3768 = OpISub %uchar %uchar_0 %3767
+OpStore %1779 %3768
+%3769 = OpLoad %_arr_uchar_uint_16 %1265
+%3770 = OpCompositeExtract %uchar %3769 14
+OpStore %1780 %3770
+%3771 = OpLoad %_arr_uchar_uint_16 %1268
+%3772 = OpCompositeExtract %uchar %3771 14
+OpStore %1781 %3772
+%3773 = OpLoad %uchar %1780
+%3774 = OpLoad %uchar %1781
+%3775 = OpULessThan %bool %3773 %3774
+OpStore %1782 %3775
+%3776 = OpLoad %bool %1782
+%3777 = OpSelect %uchar %3776 %uchar_1 %uchar_0
+%3778 = OpISub %uchar %uchar_0 %3777
+OpStore %1783 %3778
+%3779 = OpLoad %_arr_uchar_uint_16 %1265
 %3780 = OpCompositeExtract %uchar %3779 15
-OpStore %1257 %3780
-%3781 = OpLoad %_arr_uchar_uint_16 %476
+OpStore %1784 %3780
+%3781 = OpLoad %_arr_uchar_uint_16 %1268
 %3782 = OpCompositeExtract %uchar %3781 15
-OpStore %1258 %3782
-%3783 = OpLoad %uchar %1257
-%3784 = OpLoad %uchar %1258
-%3785 = OpBitwiseAnd %uchar %3783 %3784
-OpStore %1259 %3785
-%3786 = OpLoad %_arr_uchar_uint_16 %1081
-%3787 = OpLoad %uchar %1214
-%3788 = OpCompositeInsert %_arr_uchar_uint_16 %3787 %3786 0
-OpStore %1260 %3788
-%3789 = OpLoad %_arr_uchar_uint_16 %1260
-%3790 = OpLoad %uchar %1217
-%3791 = OpCompositeInsert %_arr_uchar_uint_16 %3790 %3789 1
-OpStore %1261 %3791
-%3792 = OpLoad %_arr_uchar_uint_16 %1261
-%3793 = OpLoad %uchar %1220
-%3794 = OpCompositeInsert %_arr_uchar_uint_16 %3793 %3792 2
-OpStore %1262 %3794
-%3795 = OpLoad %_arr_uchar_uint_16 %1262
-%3796 = OpLoad %uchar %1223
-%3797 = OpCompositeInsert %_arr_uchar_uint_16 %3796 %3795 3
-OpStore %1263 %3797
-%3798 = OpLoad %_arr_uchar_uint_16 %1263
-%3799 = OpLoad %uchar %1226
-%3800 = OpCompositeInsert %_arr_uchar_uint_16 %3799 %3798 4
-OpStore %1264 %3800
-%3801 = OpLoad %_arr_uchar_uint_16 %1264
-%3802 = OpLoad %uchar %1229
-%3803 = OpCompositeInsert %_arr_uchar_uint_16 %3802 %3801 5
-OpStore %1265 %3803
-%3804 = OpLoad %_arr_uchar_uint_16 %1265
-%3805 = OpLoad %uchar %1232
-%3806 = OpCompositeInsert %_arr_uchar_uint_16 %3805 %3804 6
-OpStore %1266 %3806
-%3807 = OpLoad %_arr_uchar_uint_16 %1266
-%3808 = OpLoad %uchar %1235
-%3809 = OpCompositeInsert %_arr_uchar_uint_16 %3808 %3807 7
-OpStore %1267 %3809
-%3810 = OpLoad %_arr_uchar_uint_16 %1267
-%3811 = OpLoad %uchar %1238
-%3812 = OpCompositeInsert %_arr_uchar_uint_16 %3811 %3810 8
-OpStore %1268 %3812
-%3813 = OpLoad %_arr_uchar_uint_16 %1268
-%3814 = OpLoad %uchar %1241
-%3815 = OpCompositeInsert %_arr_uchar_uint_16 %3814 %3813 9
-OpStore %1269 %3815
-%3816 = OpLoad %_arr_uchar_uint_16 %1269
-%3817 = OpLoad %uchar %1244
-%3818 = OpCompositeInsert %_arr_uchar_uint_16 %3817 %3816 10
-OpStore %1270 %3818
-%3819 = OpLoad %_arr_uchar_uint_16 %1270
-%3820 = OpLoad %uchar %1247
-%3821 = OpCompositeInsert %_arr_uchar_uint_16 %3820 %3819 11
-OpStore %1271 %3821
-%3822 = OpLoad %_arr_uchar_uint_16 %1271
-%3823 = OpLoad %uchar %1250
-%3824 = OpCompositeInsert %_arr_uchar_uint_16 %3823 %3822 12
-OpStore %1272 %3824
-%3825 = OpLoad %_arr_uchar_uint_16 %1272
-%3826 = OpLoad %uchar %1253
-%3827 = OpCompositeInsert %_arr_uchar_uint_16 %3826 %3825 13
-OpStore %1273 %3827
-%3828 = OpLoad %_arr_uchar_uint_16 %1273
-%3829 = OpLoad %uchar %1256
-%3830 = OpCompositeInsert %_arr_uchar_uint_16 %3829 %3828 14
-OpStore %1274 %3830
-%3831 = OpLoad %_arr_uchar_uint_16 %1274
-%3832 = OpLoad %uchar %1259
-%3833 = OpCompositeInsert %_arr_uchar_uint_16 %3832 %3831 15
-OpStore %1275 %3833
-%3834 = OpLoad %_arr_uchar_uint_16 %1081
-%3835 = OpCompositeExtract %uchar %3834 0
-OpStore %1276 %3835
-%3836 = OpLoad %uchar %1276
-%3837 = OpNot %uchar %3836
-OpStore %1277 %3837
-%3838 = OpLoad %_arr_uchar_uint_16 %1081
-%3839 = OpCompositeExtract %uchar %3838 1
-OpStore %1278 %3839
-%3840 = OpLoad %uchar %1278
-%3841 = OpNot %uchar %3840
-OpStore %1279 %3841
-%3842 = OpLoad %_arr_uchar_uint_16 %1081
-%3843 = OpCompositeExtract %uchar %3842 2
-OpStore %1280 %3843
-%3844 = OpLoad %uchar %1280
-%3845 = OpNot %uchar %3844
-OpStore %1281 %3845
-%3846 = OpLoad %_arr_uchar_uint_16 %1081
-%3847 = OpCompositeExtract %uchar %3846 3
-OpStore %1282 %3847
-%3848 = OpLoad %uchar %1282
-%3849 = OpNot %uchar %3848
-OpStore %1283 %3849
-%3850 = OpLoad %_arr_uchar_uint_16 %1081
-%3851 = OpCompositeExtract %uchar %3850 4
-OpStore %1284 %3851
-%3852 = OpLoad %uchar %1284
-%3853 = OpNot %uchar %3852
-OpStore %1285 %3853
-%3854 = OpLoad %_arr_uchar_uint_16 %1081
-%3855 = OpCompositeExtract %uchar %3854 5
-OpStore %1286 %3855
-%3856 = OpLoad %uchar %1286
-%3857 = OpNot %uchar %3856
-OpStore %1287 %3857
-%3858 = OpLoad %_arr_uchar_uint_16 %1081
-%3859 = OpCompositeExtract %uchar %3858 6
-OpStore %1288 %3859
-%3860 = OpLoad %uchar %1288
-%3861 = OpNot %uchar %3860
-OpStore %1289 %3861
-%3862 = OpLoad %_arr_uchar_uint_16 %1081
-%3863 = OpCompositeExtract %uchar %3862 7
-OpStore %1290 %3863
-%3864 = OpLoad %uchar %1290
-%3865 = OpNot %uchar %3864
-OpStore %1291 %3865
-%3866 = OpLoad %_arr_uchar_uint_16 %1081
-%3867 = OpCompositeExtract %uchar %3866 8
-OpStore %1292 %3867
-%3868 = OpLoad %uchar %1292
-%3869 = OpNot %uchar %3868
-OpStore %1293 %3869
-%3870 = OpLoad %_arr_uchar_uint_16 %1081
-%3871 = OpCompositeExtract %uchar %3870 9
-OpStore %1294 %3871
-%3872 = OpLoad %uchar %1294
-%3873 = OpNot %uchar %3872
-OpStore %1295 %3873
-%3874 = OpLoad %_arr_uchar_uint_16 %1081
-%3875 = OpCompositeExtract %uchar %3874 10
-OpStore %1296 %3875
-%3876 = OpLoad %uchar %1296
-%3877 = OpNot %uchar %3876
-OpStore %1297 %3877
-%3878 = OpLoad %_arr_uchar_uint_16 %1081
-%3879 = OpCompositeExtract %uchar %3878 11
-OpStore %1298 %3879
-%3880 = OpLoad %uchar %1298
-%3881 = OpNot %uchar %3880
-OpStore %1299 %3881
-%3882 = OpLoad %_arr_uchar_uint_16 %1081
-%3883 = OpCompositeExtract %uchar %3882 12
-OpStore %1300 %3883
-%3884 = OpLoad %uchar %1300
-%3885 = OpNot %uchar %3884
-OpStore %1301 %3885
-%3886 = OpLoad %_arr_uchar_uint_16 %1081
-%3887 = OpCompositeExtract %uchar %3886 13
-OpStore %1302 %3887
-%3888 = OpLoad %uchar %1302
-%3889 = OpNot %uchar %3888
-OpStore %1303 %3889
-%3890 = OpLoad %_arr_uchar_uint_16 %1081
-%3891 = OpCompositeExtract %uchar %3890 14
-OpStore %1304 %3891
-%3892 = OpLoad %uchar %1304
-%3893 = OpNot %uchar %3892
-OpStore %1305 %3893
-%3894 = OpLoad %_arr_uchar_uint_16 %1081
-%3895 = OpCompositeExtract %uchar %3894 15
-OpStore %1306 %3895
-%3896 = OpLoad %uchar %1306
-%3897 = OpNot %uchar %3896
-OpStore %1307 %3897
-%3898 = OpLoad %_arr_uchar_uint_16 %1081
-%3899 = OpLoad %uchar %1277
-%3900 = OpCompositeInsert %_arr_uchar_uint_16 %3899 %3898 0
-OpStore %1308 %3900
-%3901 = OpLoad %_arr_uchar_uint_16 %1308
-%3902 = OpLoad %uchar %1279
-%3903 = OpCompositeInsert %_arr_uchar_uint_16 %3902 %3901 1
-OpStore %1309 %3903
-%3904 = OpLoad %_arr_uchar_uint_16 %1309
-%3905 = OpLoad %uchar %1281
-%3906 = OpCompositeInsert %_arr_uchar_uint_16 %3905 %3904 2
-OpStore %1310 %3906
-%3907 = OpLoad %_arr_uchar_uint_16 %1310
-%3908 = OpLoad %uchar %1283
-%3909 = OpCompositeInsert %_arr_uchar_uint_16 %3908 %3907 3
-OpStore %1311 %3909
-%3910 = OpLoad %_arr_uchar_uint_16 %1311
-%3911 = OpLoad %uchar %1285
-%3912 = OpCompositeInsert %_arr_uchar_uint_16 %3911 %3910 4
-OpStore %1312 %3912
-%3913 = OpLoad %_arr_uchar_uint_16 %1312
-%3914 = OpLoad %uchar %1287
-%3915 = OpCompositeInsert %_arr_uchar_uint_16 %3914 %3913 5
-OpStore %1313 %3915
-%3916 = OpLoad %_arr_uchar_uint_16 %1313
-%3917 = OpLoad %uchar %1289
-%3918 = OpCompositeInsert %_arr_uchar_uint_16 %3917 %3916 6
-OpStore %1314 %3918
-%3919 = OpLoad %_arr_uchar_uint_16 %1314
-%3920 = OpLoad %uchar %1291
-%3921 = OpCompositeInsert %_arr_uchar_uint_16 %3920 %3919 7
-OpStore %1315 %3921
-%3922 = OpLoad %_arr_uchar_uint_16 %1315
-%3923 = OpLoad %uchar %1293
-%3924 = OpCompositeInsert %_arr_uchar_uint_16 %3923 %3922 8
-OpStore %1316 %3924
-%3925 = OpLoad %_arr_uchar_uint_16 %1316
-%3926 = OpLoad %uchar %1295
-%3927 = OpCompositeInsert %_arr_uchar_uint_16 %3926 %3925 9
-OpStore %1317 %3927
-%3928 = OpLoad %_arr_uchar_uint_16 %1317
-%3929 = OpLoad %uchar %1297
-%3930 = OpCompositeInsert %_arr_uchar_uint_16 %3929 %3928 10
-OpStore %1318 %3930
-%3931 = OpLoad %_arr_uchar_uint_16 %1318
-%3932 = OpLoad %uchar %1299
-%3933 = OpCompositeInsert %_arr_uchar_uint_16 %3932 %3931 11
-OpStore %1319 %3933
-%3934 = OpLoad %_arr_uchar_uint_16 %1319
-%3935 = OpLoad %uchar %1301
-%3936 = OpCompositeInsert %_arr_uchar_uint_16 %3935 %3934 12
-OpStore %1320 %3936
-%3937 = OpLoad %_arr_uchar_uint_16 %1320
-%3938 = OpLoad %uchar %1303
-%3939 = OpCompositeInsert %_arr_uchar_uint_16 %3938 %3937 13
-OpStore %1321 %3939
-%3940 = OpLoad %_arr_uchar_uint_16 %1321
-%3941 = OpLoad %uchar %1305
-%3942 = OpCompositeInsert %_arr_uchar_uint_16 %3941 %3940 14
-OpStore %1322 %3942
-%3943 = OpLoad %_arr_uchar_uint_16 %1322
-%3944 = OpLoad %uchar %1307
-%3945 = OpCompositeInsert %_arr_uchar_uint_16 %3944 %3943 15
-OpStore %1323 %3945
-%3946 = OpLoad %_arr_uchar_uint_16 %1323
-%3947 = OpCompositeExtract %uchar %3946 0
-OpStore %1324 %3947
-%3948 = OpLoad %_arr_uchar_uint_16 %479
-%3949 = OpCompositeExtract %uchar %3948 0
-OpStore %1325 %3949
-%3950 = OpLoad %uchar %1324
-%3951 = OpLoad %uchar %1325
-%3952 = OpBitwiseAnd %uchar %3950 %3951
-OpStore %1326 %3952
-%3953 = OpLoad %_arr_uchar_uint_16 %1323
-%3954 = OpCompositeExtract %uchar %3953 1
-OpStore %1327 %3954
-%3955 = OpLoad %_arr_uchar_uint_16 %479
-%3956 = OpCompositeExtract %uchar %3955 1
-OpStore %1328 %3956
-%3957 = OpLoad %uchar %1327
-%3958 = OpLoad %uchar %1328
-%3959 = OpBitwiseAnd %uchar %3957 %3958
-OpStore %1329 %3959
-%3960 = OpLoad %_arr_uchar_uint_16 %1323
-%3961 = OpCompositeExtract %uchar %3960 2
-OpStore %1330 %3961
-%3962 = OpLoad %_arr_uchar_uint_16 %479
-%3963 = OpCompositeExtract %uchar %3962 2
-OpStore %1331 %3963
-%3964 = OpLoad %uchar %1330
-%3965 = OpLoad %uchar %1331
-%3966 = OpBitwiseAnd %uchar %3964 %3965
-OpStore %1332 %3966
-%3967 = OpLoad %_arr_uchar_uint_16 %1323
-%3968 = OpCompositeExtract %uchar %3967 3
-OpStore %1333 %3968
-%3969 = OpLoad %_arr_uchar_uint_16 %479
-%3970 = OpCompositeExtract %uchar %3969 3
-OpStore %1334 %3970
-%3971 = OpLoad %uchar %1333
-%3972 = OpLoad %uchar %1334
-%3973 = OpBitwiseAnd %uchar %3971 %3972
-OpStore %1335 %3973
-%3974 = OpLoad %_arr_uchar_uint_16 %1323
-%3975 = OpCompositeExtract %uchar %3974 4
-OpStore %1336 %3975
-%3976 = OpLoad %_arr_uchar_uint_16 %479
-%3977 = OpCompositeExtract %uchar %3976 4
-OpStore %1337 %3977
-%3978 = OpLoad %uchar %1336
-%3979 = OpLoad %uchar %1337
-%3980 = OpBitwiseAnd %uchar %3978 %3979
-OpStore %1338 %3980
-%3981 = OpLoad %_arr_uchar_uint_16 %1323
-%3982 = OpCompositeExtract %uchar %3981 5
-OpStore %1339 %3982
-%3983 = OpLoad %_arr_uchar_uint_16 %479
-%3984 = OpCompositeExtract %uchar %3983 5
-OpStore %1340 %3984
-%3985 = OpLoad %uchar %1339
-%3986 = OpLoad %uchar %1340
-%3987 = OpBitwiseAnd %uchar %3985 %3986
-OpStore %1341 %3987
-%3988 = OpLoad %_arr_uchar_uint_16 %1323
-%3989 = OpCompositeExtract %uchar %3988 6
-OpStore %1342 %3989
-%3990 = OpLoad %_arr_uchar_uint_16 %479
-%3991 = OpCompositeExtract %uchar %3990 6
-OpStore %1343 %3991
-%3992 = OpLoad %uchar %1342
-%3993 = OpLoad %uchar %1343
-%3994 = OpBitwiseAnd %uchar %3992 %3993
-OpStore %1344 %3994
-%3995 = OpLoad %_arr_uchar_uint_16 %1323
-%3996 = OpCompositeExtract %uchar %3995 7
-OpStore %1345 %3996
-%3997 = OpLoad %_arr_uchar_uint_16 %479
-%3998 = OpCompositeExtract %uchar %3997 7
-OpStore %1346 %3998
-%3999 = OpLoad %uchar %1345
-%4000 = OpLoad %uchar %1346
-%4001 = OpBitwiseAnd %uchar %3999 %4000
-OpStore %1347 %4001
-%4002 = OpLoad %_arr_uchar_uint_16 %1323
-%4003 = OpCompositeExtract %uchar %4002 8
-OpStore %1348 %4003
-%4004 = OpLoad %_arr_uchar_uint_16 %479
-%4005 = OpCompositeExtract %uchar %4004 8
-OpStore %1349 %4005
-%4006 = OpLoad %uchar %1348
-%4007 = OpLoad %uchar %1349
-%4008 = OpBitwiseAnd %uchar %4006 %4007
-OpStore %1350 %4008
-%4009 = OpLoad %_arr_uchar_uint_16 %1323
-%4010 = OpCompositeExtract %uchar %4009 9
-OpStore %1351 %4010
-%4011 = OpLoad %_arr_uchar_uint_16 %479
-%4012 = OpCompositeExtract %uchar %4011 9
-OpStore %1352 %4012
-%4013 = OpLoad %uchar %1351
-%4014 = OpLoad %uchar %1352
-%4015 = OpBitwiseAnd %uchar %4013 %4014
-OpStore %1353 %4015
-%4016 = OpLoad %_arr_uchar_uint_16 %1323
-%4017 = OpCompositeExtract %uchar %4016 10
-OpStore %1354 %4017
-%4018 = OpLoad %_arr_uchar_uint_16 %479
-%4019 = OpCompositeExtract %uchar %4018 10
-OpStore %1355 %4019
-%4020 = OpLoad %uchar %1354
-%4021 = OpLoad %uchar %1355
-%4022 = OpBitwiseAnd %uchar %4020 %4021
-OpStore %1356 %4022
-%4023 = OpLoad %_arr_uchar_uint_16 %1323
-%4024 = OpCompositeExtract %uchar %4023 11
-OpStore %1357 %4024
-%4025 = OpLoad %_arr_uchar_uint_16 %479
-%4026 = OpCompositeExtract %uchar %4025 11
-OpStore %1358 %4026
-%4027 = OpLoad %uchar %1357
-%4028 = OpLoad %uchar %1358
-%4029 = OpBitwiseAnd %uchar %4027 %4028
-OpStore %1359 %4029
-%4030 = OpLoad %_arr_uchar_uint_16 %1323
-%4031 = OpCompositeExtract %uchar %4030 12
-OpStore %1360 %4031
-%4032 = OpLoad %_arr_uchar_uint_16 %479
-%4033 = OpCompositeExtract %uchar %4032 12
-OpStore %1361 %4033
-%4034 = OpLoad %uchar %1360
-%4035 = OpLoad %uchar %1361
-%4036 = OpBitwiseAnd %uchar %4034 %4035
-OpStore %1362 %4036
-%4037 = OpLoad %_arr_uchar_uint_16 %1323
-%4038 = OpCompositeExtract %uchar %4037 13
-OpStore %1363 %4038
-%4039 = OpLoad %_arr_uchar_uint_16 %479
-%4040 = OpCompositeExtract %uchar %4039 13
-OpStore %1364 %4040
-%4041 = OpLoad %uchar %1363
-%4042 = OpLoad %uchar %1364
-%4043 = OpBitwiseAnd %uchar %4041 %4042
-OpStore %1365 %4043
-%4044 = OpLoad %_arr_uchar_uint_16 %1323
-%4045 = OpCompositeExtract %uchar %4044 14
-OpStore %1366 %4045
-%4046 = OpLoad %_arr_uchar_uint_16 %479
-%4047 = OpCompositeExtract %uchar %4046 14
-OpStore %1367 %4047
-%4048 = OpLoad %uchar %1366
-%4049 = OpLoad %uchar %1367
-%4050 = OpBitwiseAnd %uchar %4048 %4049
-OpStore %1368 %4050
-%4051 = OpLoad %_arr_uchar_uint_16 %1323
-%4052 = OpCompositeExtract %uchar %4051 15
-OpStore %1369 %4052
-%4053 = OpLoad %_arr_uchar_uint_16 %479
-%4054 = OpCompositeExtract %uchar %4053 15
-OpStore %1370 %4054
-%4055 = OpLoad %uchar %1369
-%4056 = OpLoad %uchar %1370
-%4057 = OpBitwiseAnd %uchar %4055 %4056
-OpStore %1371 %4057
-%4058 = OpLoad %_arr_uchar_uint_16 %1323
-%4059 = OpLoad %uchar %1326
-%4060 = OpCompositeInsert %_arr_uchar_uint_16 %4059 %4058 0
-OpStore %1372 %4060
-%4061 = OpLoad %_arr_uchar_uint_16 %1372
-%4062 = OpLoad %uchar %1329
-%4063 = OpCompositeInsert %_arr_uchar_uint_16 %4062 %4061 1
-OpStore %1373 %4063
-%4064 = OpLoad %_arr_uchar_uint_16 %1373
-%4065 = OpLoad %uchar %1332
-%4066 = OpCompositeInsert %_arr_uchar_uint_16 %4065 %4064 2
-OpStore %1374 %4066
-%4067 = OpLoad %_arr_uchar_uint_16 %1374
-%4068 = OpLoad %uchar %1335
-%4069 = OpCompositeInsert %_arr_uchar_uint_16 %4068 %4067 3
-OpStore %1375 %4069
-%4070 = OpLoad %_arr_uchar_uint_16 %1375
-%4071 = OpLoad %uchar %1338
-%4072 = OpCompositeInsert %_arr_uchar_uint_16 %4071 %4070 4
-OpStore %1376 %4072
-%4073 = OpLoad %_arr_uchar_uint_16 %1376
-%4074 = OpLoad %uchar %1341
-%4075 = OpCompositeInsert %_arr_uchar_uint_16 %4074 %4073 5
-OpStore %1377 %4075
-%4076 = OpLoad %_arr_uchar_uint_16 %1377
-%4077 = OpLoad %uchar %1344
-%4078 = OpCompositeInsert %_arr_uchar_uint_16 %4077 %4076 6
-OpStore %1378 %4078
-%4079 = OpLoad %_arr_uchar_uint_16 %1378
-%4080 = OpLoad %uchar %1347
-%4081 = OpCompositeInsert %_arr_uchar_uint_16 %4080 %4079 7
-OpStore %1379 %4081
-%4082 = OpLoad %_arr_uchar_uint_16 %1379
-%4083 = OpLoad %uchar %1350
-%4084 = OpCompositeInsert %_arr_uchar_uint_16 %4083 %4082 8
-OpStore %1380 %4084
-%4085 = OpLoad %_arr_uchar_uint_16 %1380
-%4086 = OpLoad %uchar %1353
-%4087 = OpCompositeInsert %_arr_uchar_uint_16 %4086 %4085 9
-OpStore %1381 %4087
-%4088 = OpLoad %_arr_uchar_uint_16 %1381
-%4089 = OpLoad %uchar %1356
-%4090 = OpCompositeInsert %_arr_uchar_uint_16 %4089 %4088 10
-OpStore %1382 %4090
-%4091 = OpLoad %_arr_uchar_uint_16 %1382
-%4092 = OpLoad %uchar %1359
-%4093 = OpCompositeInsert %_arr_uchar_uint_16 %4092 %4091 11
-OpStore %1383 %4093
-%4094 = OpLoad %_arr_uchar_uint_16 %1383
-%4095 = OpLoad %uchar %1362
-%4096 = OpCompositeInsert %_arr_uchar_uint_16 %4095 %4094 12
-OpStore %1384 %4096
-%4097 = OpLoad %_arr_uchar_uint_16 %1384
-%4098 = OpLoad %uchar %1365
-%4099 = OpCompositeInsert %_arr_uchar_uint_16 %4098 %4097 13
-OpStore %1385 %4099
-%4100 = OpLoad %_arr_uchar_uint_16 %1385
-%4101 = OpLoad %uchar %1368
-%4102 = OpCompositeInsert %_arr_uchar_uint_16 %4101 %4100 14
-OpStore %1386 %4102
-%4103 = OpLoad %_arr_uchar_uint_16 %1386
-%4104 = OpLoad %uchar %1371
-%4105 = OpCompositeInsert %_arr_uchar_uint_16 %4104 %4103 15
-OpStore %1387 %4105
-%4106 = OpLoad %_arr_uchar_uint_16 %1275
-%4107 = OpCompositeExtract %uchar %4106 0
-OpStore %1388 %4107
-%4108 = OpLoad %_arr_uchar_uint_16 %1387
-%4109 = OpCompositeExtract %uchar %4108 0
-OpStore %1389 %4109
-%4110 = OpLoad %uchar %1388
-%4111 = OpLoad %uchar %1389
-%4112 = OpBitwiseOr %uchar %4110 %4111
-OpStore %1390 %4112
-%4113 = OpLoad %_arr_uchar_uint_16 %1275
-%4114 = OpCompositeExtract %uchar %4113 1
-OpStore %1391 %4114
-%4115 = OpLoad %_arr_uchar_uint_16 %1387
-%4116 = OpCompositeExtract %uchar %4115 1
-OpStore %1392 %4116
-%4117 = OpLoad %uchar %1391
-%4118 = OpLoad %uchar %1392
-%4119 = OpBitwiseOr %uchar %4117 %4118
-OpStore %1393 %4119
-%4120 = OpLoad %_arr_uchar_uint_16 %1275
-%4121 = OpCompositeExtract %uchar %4120 2
-OpStore %1394 %4121
-%4122 = OpLoad %_arr_uchar_uint_16 %1387
-%4123 = OpCompositeExtract %uchar %4122 2
-OpStore %1395 %4123
-%4124 = OpLoad %uchar %1394
-%4125 = OpLoad %uchar %1395
-%4126 = OpBitwiseOr %uchar %4124 %4125
-OpStore %1396 %4126
-%4127 = OpLoad %_arr_uchar_uint_16 %1275
-%4128 = OpCompositeExtract %uchar %4127 3
-OpStore %1397 %4128
-%4129 = OpLoad %_arr_uchar_uint_16 %1387
-%4130 = OpCompositeExtract %uchar %4129 3
-OpStore %1398 %4130
-%4131 = OpLoad %uchar %1397
-%4132 = OpLoad %uchar %1398
-%4133 = OpBitwiseOr %uchar %4131 %4132
-OpStore %1399 %4133
-%4134 = OpLoad %_arr_uchar_uint_16 %1275
-%4135 = OpCompositeExtract %uchar %4134 4
-OpStore %1400 %4135
-%4136 = OpLoad %_arr_uchar_uint_16 %1387
-%4137 = OpCompositeExtract %uchar %4136 4
-OpStore %1401 %4137
-%4138 = OpLoad %uchar %1400
-%4139 = OpLoad %uchar %1401
-%4140 = OpBitwiseOr %uchar %4138 %4139
-OpStore %1402 %4140
-%4141 = OpLoad %_arr_uchar_uint_16 %1275
-%4142 = OpCompositeExtract %uchar %4141 5
-OpStore %1403 %4142
-%4143 = OpLoad %_arr_uchar_uint_16 %1387
-%4144 = OpCompositeExtract %uchar %4143 5
-OpStore %1404 %4144
-%4145 = OpLoad %uchar %1403
-%4146 = OpLoad %uchar %1404
-%4147 = OpBitwiseOr %uchar %4145 %4146
-OpStore %1405 %4147
-%4148 = OpLoad %_arr_uchar_uint_16 %1275
-%4149 = OpCompositeExtract %uchar %4148 6
-OpStore %1406 %4149
-%4150 = OpLoad %_arr_uchar_uint_16 %1387
-%4151 = OpCompositeExtract %uchar %4150 6
-OpStore %1407 %4151
-%4152 = OpLoad %uchar %1406
-%4153 = OpLoad %uchar %1407
-%4154 = OpBitwiseOr %uchar %4152 %4153
-OpStore %1408 %4154
-%4155 = OpLoad %_arr_uchar_uint_16 %1275
-%4156 = OpCompositeExtract %uchar %4155 7
-OpStore %1409 %4156
-%4157 = OpLoad %_arr_uchar_uint_16 %1387
-%4158 = OpCompositeExtract %uchar %4157 7
-OpStore %1410 %4158
-%4159 = OpLoad %uchar %1409
-%4160 = OpLoad %uchar %1410
-%4161 = OpBitwiseOr %uchar %4159 %4160
-OpStore %1411 %4161
-%4162 = OpLoad %_arr_uchar_uint_16 %1275
-%4163 = OpCompositeExtract %uchar %4162 8
-OpStore %1412 %4163
-%4164 = OpLoad %_arr_uchar_uint_16 %1387
-%4165 = OpCompositeExtract %uchar %4164 8
-OpStore %1413 %4165
-%4166 = OpLoad %uchar %1412
-%4167 = OpLoad %uchar %1413
-%4168 = OpBitwiseOr %uchar %4166 %4167
-OpStore %1414 %4168
-%4169 = OpLoad %_arr_uchar_uint_16 %1275
-%4170 = OpCompositeExtract %uchar %4169 9
-OpStore %1415 %4170
-%4171 = OpLoad %_arr_uchar_uint_16 %1387
-%4172 = OpCompositeExtract %uchar %4171 9
-OpStore %1416 %4172
-%4173 = OpLoad %uchar %1415
-%4174 = OpLoad %uchar %1416
-%4175 = OpBitwiseOr %uchar %4173 %4174
-OpStore %1417 %4175
-%4176 = OpLoad %_arr_uchar_uint_16 %1275
-%4177 = OpCompositeExtract %uchar %4176 10
-OpStore %1418 %4177
-%4178 = OpLoad %_arr_uchar_uint_16 %1387
-%4179 = OpCompositeExtract %uchar %4178 10
-OpStore %1419 %4179
-%4180 = OpLoad %uchar %1418
-%4181 = OpLoad %uchar %1419
-%4182 = OpBitwiseOr %uchar %4180 %4181
-OpStore %1420 %4182
-%4183 = OpLoad %_arr_uchar_uint_16 %1275
-%4184 = OpCompositeExtract %uchar %4183 11
-OpStore %1421 %4184
-%4185 = OpLoad %_arr_uchar_uint_16 %1387
-%4186 = OpCompositeExtract %uchar %4185 11
-OpStore %1422 %4186
-%4187 = OpLoad %uchar %1421
-%4188 = OpLoad %uchar %1422
-%4189 = OpBitwiseOr %uchar %4187 %4188
-OpStore %1423 %4189
-%4190 = OpLoad %_arr_uchar_uint_16 %1275
-%4191 = OpCompositeExtract %uchar %4190 12
-OpStore %1424 %4191
-%4192 = OpLoad %_arr_uchar_uint_16 %1387
-%4193 = OpCompositeExtract %uchar %4192 12
-OpStore %1425 %4193
-%4194 = OpLoad %uchar %1424
-%4195 = OpLoad %uchar %1425
-%4196 = OpBitwiseOr %uchar %4194 %4195
-OpStore %1426 %4196
-%4197 = OpLoad %_arr_uchar_uint_16 %1275
-%4198 = OpCompositeExtract %uchar %4197 13
-OpStore %1427 %4198
-%4199 = OpLoad %_arr_uchar_uint_16 %1387
-%4200 = OpCompositeExtract %uchar %4199 13
-OpStore %1428 %4200
-%4201 = OpLoad %uchar %1427
-%4202 = OpLoad %uchar %1428
-%4203 = OpBitwiseOr %uchar %4201 %4202
-OpStore %1429 %4203
-%4204 = OpLoad %_arr_uchar_uint_16 %1275
-%4205 = OpCompositeExtract %uchar %4204 14
-OpStore %1430 %4205
-%4206 = OpLoad %_arr_uchar_uint_16 %1387
-%4207 = OpCompositeExtract %uchar %4206 14
-OpStore %1431 %4207
-%4208 = OpLoad %uchar %1430
-%4209 = OpLoad %uchar %1431
-%4210 = OpBitwiseOr %uchar %4208 %4209
-OpStore %1432 %4210
-%4211 = OpLoad %_arr_uchar_uint_16 %1275
-%4212 = OpCompositeExtract %uchar %4211 15
-OpStore %1433 %4212
-%4213 = OpLoad %_arr_uchar_uint_16 %1387
-%4214 = OpCompositeExtract %uchar %4213 15
-OpStore %1434 %4214
-%4215 = OpLoad %uchar %1433
-%4216 = OpLoad %uchar %1434
-%4217 = OpBitwiseOr %uchar %4215 %4216
-OpStore %1435 %4217
-%4218 = OpLoad %_arr_uchar_uint_16 %1275
-%4219 = OpLoad %uchar %1390
-%4220 = OpCompositeInsert %_arr_uchar_uint_16 %4219 %4218 0
-OpStore %1436 %4220
-%4221 = OpLoad %_arr_uchar_uint_16 %1436
-%4222 = OpLoad %uchar %1393
-%4223 = OpCompositeInsert %_arr_uchar_uint_16 %4222 %4221 1
-OpStore %1437 %4223
-%4224 = OpLoad %_arr_uchar_uint_16 %1437
-%4225 = OpLoad %uchar %1396
-%4226 = OpCompositeInsert %_arr_uchar_uint_16 %4225 %4224 2
-OpStore %1438 %4226
-%4227 = OpLoad %_arr_uchar_uint_16 %1438
-%4228 = OpLoad %uchar %1399
-%4229 = OpCompositeInsert %_arr_uchar_uint_16 %4228 %4227 3
-OpStore %1439 %4229
-%4230 = OpLoad %_arr_uchar_uint_16 %1439
-%4231 = OpLoad %uchar %1402
-%4232 = OpCompositeInsert %_arr_uchar_uint_16 %4231 %4230 4
-OpStore %1440 %4232
-%4233 = OpLoad %_arr_uchar_uint_16 %1440
-%4234 = OpLoad %uchar %1405
-%4235 = OpCompositeInsert %_arr_uchar_uint_16 %4234 %4233 5
-OpStore %1441 %4235
-%4236 = OpLoad %_arr_uchar_uint_16 %1441
-%4237 = OpLoad %uchar %1408
-%4238 = OpCompositeInsert %_arr_uchar_uint_16 %4237 %4236 6
-OpStore %1442 %4238
-%4239 = OpLoad %_arr_uchar_uint_16 %1442
-%4240 = OpLoad %uchar %1411
-%4241 = OpCompositeInsert %_arr_uchar_uint_16 %4240 %4239 7
-OpStore %1443 %4241
-%4242 = OpLoad %_arr_uchar_uint_16 %1443
-%4243 = OpLoad %uchar %1414
-%4244 = OpCompositeInsert %_arr_uchar_uint_16 %4243 %4242 8
-OpStore %1444 %4244
-%4245 = OpLoad %_arr_uchar_uint_16 %1444
-%4246 = OpLoad %uchar %1417
-%4247 = OpCompositeInsert %_arr_uchar_uint_16 %4246 %4245 9
-OpStore %1445 %4247
-%4248 = OpLoad %_arr_uchar_uint_16 %1445
-%4249 = OpLoad %uchar %1420
-%4250 = OpCompositeInsert %_arr_uchar_uint_16 %4249 %4248 10
-OpStore %1446 %4250
-%4251 = OpLoad %_arr_uchar_uint_16 %1446
-%4252 = OpLoad %uchar %1423
-%4253 = OpCompositeInsert %_arr_uchar_uint_16 %4252 %4251 11
-OpStore %1447 %4253
-%4254 = OpLoad %_arr_uchar_uint_16 %1447
-%4255 = OpLoad %uchar %1426
-%4256 = OpCompositeInsert %_arr_uchar_uint_16 %4255 %4254 12
-OpStore %1448 %4256
-%4257 = OpLoad %_arr_uchar_uint_16 %1448
-%4258 = OpLoad %uchar %1429
-%4259 = OpCompositeInsert %_arr_uchar_uint_16 %4258 %4257 13
-OpStore %1449 %4259
-%4260 = OpLoad %_arr_uchar_uint_16 %1449
-%4261 = OpLoad %uchar %1432
-%4262 = OpCompositeInsert %_arr_uchar_uint_16 %4261 %4260 14
-OpStore %1450 %4262
-%4263 = OpLoad %_arr_uchar_uint_16 %1450
-%4264 = OpLoad %uchar %1435
-%4265 = OpCompositeInsert %_arr_uchar_uint_16 %4264 %4263 15
-OpStore %1451 %4265
-%4266 = OpLoad %ulong %482
-%4267 = OpLoad %_arr_uchar_uint_16 %1451
-%4268 = OpFunctionCall %ulong %1 %4266 %4267
-OpStore %483 %4268
-%4269 = OpLoad %ulong %483
-OpReturnValue %4269
+OpStore %1785 %3782
+%3783 = OpLoad %uchar %1784
+%3784 = OpLoad %uchar %1785
+%3785 = OpULessThan %bool %3783 %3784
+OpStore %1786 %3785
+%3786 = OpLoad %bool %1786
+%3787 = OpSelect %uchar %3786 %uchar_1 %uchar_0
+%3788 = OpISub %uchar %uchar_0 %3787
+OpStore %1787 %3788
+%3790 = OpLoad %uchar %1727
+%3791 = OpLoad %uchar %1731
+%3792 = OpLoad %uchar %1735
+%3793 = OpLoad %uchar %1739
+%3794 = OpLoad %uchar %1743
+%3795 = OpLoad %uchar %1747
+%3796 = OpLoad %uchar %1751
+%3797 = OpLoad %uchar %1755
+%3798 = OpLoad %uchar %1759
+%3799 = OpLoad %uchar %1763
+%3800 = OpLoad %uchar %1767
+%3801 = OpLoad %uchar %1771
+%3802 = OpLoad %uchar %1775
+%3803 = OpLoad %uchar %1779
+%3804 = OpLoad %uchar %1783
+%3805 = OpLoad %uchar %1787
+%3789 = OpCompositeConstruct %_arr_uchar_uint_16 %3790 %3791 %3792 %3793 %3794 %3795 %3796 %3797 %3798 %3799 %3800 %3801 %3802 %3803 %3804 %3805
+OpStore %1788 %3789
+%3806 = OpLoad %ulong %1260
+%3807 = OpLoad %_arr_uchar_uint_16 %1788
+%3808 = OpFunctionCall %ulong %1 %3806 %3807
+OpStore %1269 %3808
+%3809 = OpLoad %_arr_uchar_uint_16 %1265
+%3810 = OpCompositeExtract %uchar %3809 0
+OpStore %1789 %3810
+%3811 = OpLoad %_arr_uchar_uint_16 %1268
+%3812 = OpCompositeExtract %uchar %3811 0
+OpStore %1790 %3812
+%3813 = OpLoad %uchar %1789
+%3814 = OpLoad %uchar %1790
+%3815 = OpIEqual %bool %3813 %3814
+OpStore %1791 %3815
+%3816 = OpLoad %bool %1791
+%3817 = OpSelect %uchar %3816 %uchar_1 %uchar_0
+%3818 = OpISub %uchar %uchar_0 %3817
+OpStore %1792 %3818
+%3819 = OpLoad %_arr_uchar_uint_16 %1265
+%3820 = OpCompositeExtract %uchar %3819 1
+OpStore %1793 %3820
+%3821 = OpLoad %_arr_uchar_uint_16 %1268
+%3822 = OpCompositeExtract %uchar %3821 1
+OpStore %1794 %3822
+%3823 = OpLoad %uchar %1793
+%3824 = OpLoad %uchar %1794
+%3825 = OpIEqual %bool %3823 %3824
+OpStore %1795 %3825
+%3826 = OpLoad %bool %1795
+%3827 = OpSelect %uchar %3826 %uchar_1 %uchar_0
+%3828 = OpISub %uchar %uchar_0 %3827
+OpStore %1796 %3828
+%3829 = OpLoad %_arr_uchar_uint_16 %1265
+%3830 = OpCompositeExtract %uchar %3829 2
+OpStore %1797 %3830
+%3831 = OpLoad %_arr_uchar_uint_16 %1268
+%3832 = OpCompositeExtract %uchar %3831 2
+OpStore %1798 %3832
+%3833 = OpLoad %uchar %1797
+%3834 = OpLoad %uchar %1798
+%3835 = OpIEqual %bool %3833 %3834
+OpStore %1799 %3835
+%3836 = OpLoad %bool %1799
+%3837 = OpSelect %uchar %3836 %uchar_1 %uchar_0
+%3838 = OpISub %uchar %uchar_0 %3837
+OpStore %1800 %3838
+%3839 = OpLoad %_arr_uchar_uint_16 %1265
+%3840 = OpCompositeExtract %uchar %3839 3
+OpStore %1801 %3840
+%3841 = OpLoad %_arr_uchar_uint_16 %1268
+%3842 = OpCompositeExtract %uchar %3841 3
+OpStore %1802 %3842
+%3843 = OpLoad %uchar %1801
+%3844 = OpLoad %uchar %1802
+%3845 = OpIEqual %bool %3843 %3844
+OpStore %1803 %3845
+%3846 = OpLoad %bool %1803
+%3847 = OpSelect %uchar %3846 %uchar_1 %uchar_0
+%3848 = OpISub %uchar %uchar_0 %3847
+OpStore %1804 %3848
+%3849 = OpLoad %_arr_uchar_uint_16 %1265
+%3850 = OpCompositeExtract %uchar %3849 4
+OpStore %1805 %3850
+%3851 = OpLoad %_arr_uchar_uint_16 %1268
+%3852 = OpCompositeExtract %uchar %3851 4
+OpStore %1806 %3852
+%3853 = OpLoad %uchar %1805
+%3854 = OpLoad %uchar %1806
+%3855 = OpIEqual %bool %3853 %3854
+OpStore %1807 %3855
+%3856 = OpLoad %bool %1807
+%3857 = OpSelect %uchar %3856 %uchar_1 %uchar_0
+%3858 = OpISub %uchar %uchar_0 %3857
+OpStore %1808 %3858
+%3859 = OpLoad %_arr_uchar_uint_16 %1265
+%3860 = OpCompositeExtract %uchar %3859 5
+OpStore %1809 %3860
+%3861 = OpLoad %_arr_uchar_uint_16 %1268
+%3862 = OpCompositeExtract %uchar %3861 5
+OpStore %1810 %3862
+%3863 = OpLoad %uchar %1809
+%3864 = OpLoad %uchar %1810
+%3865 = OpIEqual %bool %3863 %3864
+OpStore %1811 %3865
+%3866 = OpLoad %bool %1811
+%3867 = OpSelect %uchar %3866 %uchar_1 %uchar_0
+%3868 = OpISub %uchar %uchar_0 %3867
+OpStore %1812 %3868
+%3869 = OpLoad %_arr_uchar_uint_16 %1265
+%3870 = OpCompositeExtract %uchar %3869 6
+OpStore %1813 %3870
+%3871 = OpLoad %_arr_uchar_uint_16 %1268
+%3872 = OpCompositeExtract %uchar %3871 6
+OpStore %1814 %3872
+%3873 = OpLoad %uchar %1813
+%3874 = OpLoad %uchar %1814
+%3875 = OpIEqual %bool %3873 %3874
+OpStore %1815 %3875
+%3876 = OpLoad %bool %1815
+%3877 = OpSelect %uchar %3876 %uchar_1 %uchar_0
+%3878 = OpISub %uchar %uchar_0 %3877
+OpStore %1816 %3878
+%3879 = OpLoad %_arr_uchar_uint_16 %1265
+%3880 = OpCompositeExtract %uchar %3879 7
+OpStore %1817 %3880
+%3881 = OpLoad %_arr_uchar_uint_16 %1268
+%3882 = OpCompositeExtract %uchar %3881 7
+OpStore %1818 %3882
+%3883 = OpLoad %uchar %1817
+%3884 = OpLoad %uchar %1818
+%3885 = OpIEqual %bool %3883 %3884
+OpStore %1819 %3885
+%3886 = OpLoad %bool %1819
+%3887 = OpSelect %uchar %3886 %uchar_1 %uchar_0
+%3888 = OpISub %uchar %uchar_0 %3887
+OpStore %1820 %3888
+%3889 = OpLoad %_arr_uchar_uint_16 %1265
+%3890 = OpCompositeExtract %uchar %3889 8
+OpStore %1821 %3890
+%3891 = OpLoad %_arr_uchar_uint_16 %1268
+%3892 = OpCompositeExtract %uchar %3891 8
+OpStore %1822 %3892
+%3893 = OpLoad %uchar %1821
+%3894 = OpLoad %uchar %1822
+%3895 = OpIEqual %bool %3893 %3894
+OpStore %1823 %3895
+%3896 = OpLoad %bool %1823
+%3897 = OpSelect %uchar %3896 %uchar_1 %uchar_0
+%3898 = OpISub %uchar %uchar_0 %3897
+OpStore %1824 %3898
+%3899 = OpLoad %_arr_uchar_uint_16 %1265
+%3900 = OpCompositeExtract %uchar %3899 9
+OpStore %1825 %3900
+%3901 = OpLoad %_arr_uchar_uint_16 %1268
+%3902 = OpCompositeExtract %uchar %3901 9
+OpStore %1826 %3902
+%3903 = OpLoad %uchar %1825
+%3904 = OpLoad %uchar %1826
+%3905 = OpIEqual %bool %3903 %3904
+OpStore %1827 %3905
+%3906 = OpLoad %bool %1827
+%3907 = OpSelect %uchar %3906 %uchar_1 %uchar_0
+%3908 = OpISub %uchar %uchar_0 %3907
+OpStore %1828 %3908
+%3909 = OpLoad %_arr_uchar_uint_16 %1265
+%3910 = OpCompositeExtract %uchar %3909 10
+OpStore %1829 %3910
+%3911 = OpLoad %_arr_uchar_uint_16 %1268
+%3912 = OpCompositeExtract %uchar %3911 10
+OpStore %1830 %3912
+%3913 = OpLoad %uchar %1829
+%3914 = OpLoad %uchar %1830
+%3915 = OpIEqual %bool %3913 %3914
+OpStore %1831 %3915
+%3916 = OpLoad %bool %1831
+%3917 = OpSelect %uchar %3916 %uchar_1 %uchar_0
+%3918 = OpISub %uchar %uchar_0 %3917
+OpStore %1832 %3918
+%3919 = OpLoad %_arr_uchar_uint_16 %1265
+%3920 = OpCompositeExtract %uchar %3919 11
+OpStore %1833 %3920
+%3921 = OpLoad %_arr_uchar_uint_16 %1268
+%3922 = OpCompositeExtract %uchar %3921 11
+OpStore %1834 %3922
+%3923 = OpLoad %uchar %1833
+%3924 = OpLoad %uchar %1834
+%3925 = OpIEqual %bool %3923 %3924
+OpStore %1835 %3925
+%3926 = OpLoad %bool %1835
+%3927 = OpSelect %uchar %3926 %uchar_1 %uchar_0
+%3928 = OpISub %uchar %uchar_0 %3927
+OpStore %1836 %3928
+%3929 = OpLoad %_arr_uchar_uint_16 %1265
+%3930 = OpCompositeExtract %uchar %3929 12
+OpStore %1837 %3930
+%3931 = OpLoad %_arr_uchar_uint_16 %1268
+%3932 = OpCompositeExtract %uchar %3931 12
+OpStore %1838 %3932
+%3933 = OpLoad %uchar %1837
+%3934 = OpLoad %uchar %1838
+%3935 = OpIEqual %bool %3933 %3934
+OpStore %1839 %3935
+%3936 = OpLoad %bool %1839
+%3937 = OpSelect %uchar %3936 %uchar_1 %uchar_0
+%3938 = OpISub %uchar %uchar_0 %3937
+OpStore %1840 %3938
+%3939 = OpLoad %_arr_uchar_uint_16 %1265
+%3940 = OpCompositeExtract %uchar %3939 13
+OpStore %1841 %3940
+%3941 = OpLoad %_arr_uchar_uint_16 %1268
+%3942 = OpCompositeExtract %uchar %3941 13
+OpStore %1842 %3942
+%3943 = OpLoad %uchar %1841
+%3944 = OpLoad %uchar %1842
+%3945 = OpIEqual %bool %3943 %3944
+OpStore %1843 %3945
+%3946 = OpLoad %bool %1843
+%3947 = OpSelect %uchar %3946 %uchar_1 %uchar_0
+%3948 = OpISub %uchar %uchar_0 %3947
+OpStore %1844 %3948
+%3949 = OpLoad %_arr_uchar_uint_16 %1265
+%3950 = OpCompositeExtract %uchar %3949 14
+OpStore %1845 %3950
+%3951 = OpLoad %_arr_uchar_uint_16 %1268
+%3952 = OpCompositeExtract %uchar %3951 14
+OpStore %1846 %3952
+%3953 = OpLoad %uchar %1845
+%3954 = OpLoad %uchar %1846
+%3955 = OpIEqual %bool %3953 %3954
+OpStore %1847 %3955
+%3956 = OpLoad %bool %1847
+%3957 = OpSelect %uchar %3956 %uchar_1 %uchar_0
+%3958 = OpISub %uchar %uchar_0 %3957
+OpStore %1848 %3958
+%3959 = OpLoad %_arr_uchar_uint_16 %1265
+%3960 = OpCompositeExtract %uchar %3959 15
+OpStore %1849 %3960
+%3961 = OpLoad %_arr_uchar_uint_16 %1268
+%3962 = OpCompositeExtract %uchar %3961 15
+OpStore %1850 %3962
+%3963 = OpLoad %uchar %1849
+%3964 = OpLoad %uchar %1850
+%3965 = OpIEqual %bool %3963 %3964
+OpStore %1851 %3965
+%3966 = OpLoad %bool %1851
+%3967 = OpSelect %uchar %3966 %uchar_1 %uchar_0
+%3968 = OpISub %uchar %uchar_0 %3967
+OpStore %1852 %3968
+%3970 = OpLoad %uchar %1792
+%3971 = OpLoad %uchar %1796
+%3972 = OpLoad %uchar %1800
+%3973 = OpLoad %uchar %1804
+%3974 = OpLoad %uchar %1808
+%3975 = OpLoad %uchar %1812
+%3976 = OpLoad %uchar %1816
+%3977 = OpLoad %uchar %1820
+%3978 = OpLoad %uchar %1824
+%3979 = OpLoad %uchar %1828
+%3980 = OpLoad %uchar %1832
+%3981 = OpLoad %uchar %1836
+%3982 = OpLoad %uchar %1840
+%3983 = OpLoad %uchar %1844
+%3984 = OpLoad %uchar %1848
+%3985 = OpLoad %uchar %1852
+%3969 = OpCompositeConstruct %_arr_uchar_uint_16 %3970 %3971 %3972 %3973 %3974 %3975 %3976 %3977 %3978 %3979 %3980 %3981 %3982 %3983 %3984 %3985
+OpStore %1853 %3969
+%3986 = OpLoad %ulong %1269
+%3987 = OpLoad %_arr_uchar_uint_16 %1853
+%3988 = OpFunctionCall %ulong %1 %3986 %3987
+OpStore %1270 %3988
+%3989 = OpLoad %_arr_uchar_uint_16 %1268
+%3990 = OpCompositeExtract %uchar %3989 0
+OpStore %1854 %3990
+%3991 = OpLoad %_arr_uchar_uint_16 %1265
+%3992 = OpCompositeExtract %uchar %3991 0
+OpStore %1855 %3992
+%3993 = OpLoad %uchar %1854
+%3994 = OpLoad %uchar %1855
+%3995 = OpULessThanEqual %bool %3993 %3994
+OpStore %1856 %3995
+%3996 = OpLoad %bool %1856
+%3997 = OpSelect %uchar %3996 %uchar_1 %uchar_0
+%3998 = OpISub %uchar %uchar_0 %3997
+OpStore %1857 %3998
+%3999 = OpLoad %_arr_uchar_uint_16 %1268
+%4000 = OpCompositeExtract %uchar %3999 1
+OpStore %1858 %4000
+%4001 = OpLoad %_arr_uchar_uint_16 %1265
+%4002 = OpCompositeExtract %uchar %4001 1
+OpStore %1859 %4002
+%4003 = OpLoad %uchar %1858
+%4004 = OpLoad %uchar %1859
+%4005 = OpULessThanEqual %bool %4003 %4004
+OpStore %1860 %4005
+%4006 = OpLoad %bool %1860
+%4007 = OpSelect %uchar %4006 %uchar_1 %uchar_0
+%4008 = OpISub %uchar %uchar_0 %4007
+OpStore %1861 %4008
+%4009 = OpLoad %_arr_uchar_uint_16 %1268
+%4010 = OpCompositeExtract %uchar %4009 2
+OpStore %1862 %4010
+%4011 = OpLoad %_arr_uchar_uint_16 %1265
+%4012 = OpCompositeExtract %uchar %4011 2
+OpStore %1863 %4012
+%4013 = OpLoad %uchar %1862
+%4014 = OpLoad %uchar %1863
+%4015 = OpULessThanEqual %bool %4013 %4014
+OpStore %1864 %4015
+%4016 = OpLoad %bool %1864
+%4017 = OpSelect %uchar %4016 %uchar_1 %uchar_0
+%4018 = OpISub %uchar %uchar_0 %4017
+OpStore %1865 %4018
+%4019 = OpLoad %_arr_uchar_uint_16 %1268
+%4020 = OpCompositeExtract %uchar %4019 3
+OpStore %1866 %4020
+%4021 = OpLoad %_arr_uchar_uint_16 %1265
+%4022 = OpCompositeExtract %uchar %4021 3
+OpStore %1867 %4022
+%4023 = OpLoad %uchar %1866
+%4024 = OpLoad %uchar %1867
+%4025 = OpULessThanEqual %bool %4023 %4024
+OpStore %1868 %4025
+%4026 = OpLoad %bool %1868
+%4027 = OpSelect %uchar %4026 %uchar_1 %uchar_0
+%4028 = OpISub %uchar %uchar_0 %4027
+OpStore %1869 %4028
+%4029 = OpLoad %_arr_uchar_uint_16 %1268
+%4030 = OpCompositeExtract %uchar %4029 4
+OpStore %1870 %4030
+%4031 = OpLoad %_arr_uchar_uint_16 %1265
+%4032 = OpCompositeExtract %uchar %4031 4
+OpStore %1871 %4032
+%4033 = OpLoad %uchar %1870
+%4034 = OpLoad %uchar %1871
+%4035 = OpULessThanEqual %bool %4033 %4034
+OpStore %1872 %4035
+%4036 = OpLoad %bool %1872
+%4037 = OpSelect %uchar %4036 %uchar_1 %uchar_0
+%4038 = OpISub %uchar %uchar_0 %4037
+OpStore %1873 %4038
+%4039 = OpLoad %_arr_uchar_uint_16 %1268
+%4040 = OpCompositeExtract %uchar %4039 5
+OpStore %1874 %4040
+%4041 = OpLoad %_arr_uchar_uint_16 %1265
+%4042 = OpCompositeExtract %uchar %4041 5
+OpStore %1875 %4042
+%4043 = OpLoad %uchar %1874
+%4044 = OpLoad %uchar %1875
+%4045 = OpULessThanEqual %bool %4043 %4044
+OpStore %1876 %4045
+%4046 = OpLoad %bool %1876
+%4047 = OpSelect %uchar %4046 %uchar_1 %uchar_0
+%4048 = OpISub %uchar %uchar_0 %4047
+OpStore %1877 %4048
+%4049 = OpLoad %_arr_uchar_uint_16 %1268
+%4050 = OpCompositeExtract %uchar %4049 6
+OpStore %1878 %4050
+%4051 = OpLoad %_arr_uchar_uint_16 %1265
+%4052 = OpCompositeExtract %uchar %4051 6
+OpStore %1879 %4052
+%4053 = OpLoad %uchar %1878
+%4054 = OpLoad %uchar %1879
+%4055 = OpULessThanEqual %bool %4053 %4054
+OpStore %1880 %4055
+%4056 = OpLoad %bool %1880
+%4057 = OpSelect %uchar %4056 %uchar_1 %uchar_0
+%4058 = OpISub %uchar %uchar_0 %4057
+OpStore %1881 %4058
+%4059 = OpLoad %_arr_uchar_uint_16 %1268
+%4060 = OpCompositeExtract %uchar %4059 7
+OpStore %1882 %4060
+%4061 = OpLoad %_arr_uchar_uint_16 %1265
+%4062 = OpCompositeExtract %uchar %4061 7
+OpStore %1883 %4062
+%4063 = OpLoad %uchar %1882
+%4064 = OpLoad %uchar %1883
+%4065 = OpULessThanEqual %bool %4063 %4064
+OpStore %1884 %4065
+%4066 = OpLoad %bool %1884
+%4067 = OpSelect %uchar %4066 %uchar_1 %uchar_0
+%4068 = OpISub %uchar %uchar_0 %4067
+OpStore %1885 %4068
+%4069 = OpLoad %_arr_uchar_uint_16 %1268
+%4070 = OpCompositeExtract %uchar %4069 8
+OpStore %1886 %4070
+%4071 = OpLoad %_arr_uchar_uint_16 %1265
+%4072 = OpCompositeExtract %uchar %4071 8
+OpStore %1887 %4072
+%4073 = OpLoad %uchar %1886
+%4074 = OpLoad %uchar %1887
+%4075 = OpULessThanEqual %bool %4073 %4074
+OpStore %1888 %4075
+%4076 = OpLoad %bool %1888
+%4077 = OpSelect %uchar %4076 %uchar_1 %uchar_0
+%4078 = OpISub %uchar %uchar_0 %4077
+OpStore %1889 %4078
+%4079 = OpLoad %_arr_uchar_uint_16 %1268
+%4080 = OpCompositeExtract %uchar %4079 9
+OpStore %1890 %4080
+%4081 = OpLoad %_arr_uchar_uint_16 %1265
+%4082 = OpCompositeExtract %uchar %4081 9
+OpStore %1891 %4082
+%4083 = OpLoad %uchar %1890
+%4084 = OpLoad %uchar %1891
+%4085 = OpULessThanEqual %bool %4083 %4084
+OpStore %1892 %4085
+%4086 = OpLoad %bool %1892
+%4087 = OpSelect %uchar %4086 %uchar_1 %uchar_0
+%4088 = OpISub %uchar %uchar_0 %4087
+OpStore %1893 %4088
+%4089 = OpLoad %_arr_uchar_uint_16 %1268
+%4090 = OpCompositeExtract %uchar %4089 10
+OpStore %1894 %4090
+%4091 = OpLoad %_arr_uchar_uint_16 %1265
+%4092 = OpCompositeExtract %uchar %4091 10
+OpStore %1895 %4092
+%4093 = OpLoad %uchar %1894
+%4094 = OpLoad %uchar %1895
+%4095 = OpULessThanEqual %bool %4093 %4094
+OpStore %1896 %4095
+%4096 = OpLoad %bool %1896
+%4097 = OpSelect %uchar %4096 %uchar_1 %uchar_0
+%4098 = OpISub %uchar %uchar_0 %4097
+OpStore %1897 %4098
+%4099 = OpLoad %_arr_uchar_uint_16 %1268
+%4100 = OpCompositeExtract %uchar %4099 11
+OpStore %1898 %4100
+%4101 = OpLoad %_arr_uchar_uint_16 %1265
+%4102 = OpCompositeExtract %uchar %4101 11
+OpStore %1899 %4102
+%4103 = OpLoad %uchar %1898
+%4104 = OpLoad %uchar %1899
+%4105 = OpULessThanEqual %bool %4103 %4104
+OpStore %1900 %4105
+%4106 = OpLoad %bool %1900
+%4107 = OpSelect %uchar %4106 %uchar_1 %uchar_0
+%4108 = OpISub %uchar %uchar_0 %4107
+OpStore %1901 %4108
+%4109 = OpLoad %_arr_uchar_uint_16 %1268
+%4110 = OpCompositeExtract %uchar %4109 12
+OpStore %1902 %4110
+%4111 = OpLoad %_arr_uchar_uint_16 %1265
+%4112 = OpCompositeExtract %uchar %4111 12
+OpStore %1903 %4112
+%4113 = OpLoad %uchar %1902
+%4114 = OpLoad %uchar %1903
+%4115 = OpULessThanEqual %bool %4113 %4114
+OpStore %1904 %4115
+%4116 = OpLoad %bool %1904
+%4117 = OpSelect %uchar %4116 %uchar_1 %uchar_0
+%4118 = OpISub %uchar %uchar_0 %4117
+OpStore %1905 %4118
+%4119 = OpLoad %_arr_uchar_uint_16 %1268
+%4120 = OpCompositeExtract %uchar %4119 13
+OpStore %1906 %4120
+%4121 = OpLoad %_arr_uchar_uint_16 %1265
+%4122 = OpCompositeExtract %uchar %4121 13
+OpStore %1907 %4122
+%4123 = OpLoad %uchar %1906
+%4124 = OpLoad %uchar %1907
+%4125 = OpULessThanEqual %bool %4123 %4124
+OpStore %1908 %4125
+%4126 = OpLoad %bool %1908
+%4127 = OpSelect %uchar %4126 %uchar_1 %uchar_0
+%4128 = OpISub %uchar %uchar_0 %4127
+OpStore %1909 %4128
+%4129 = OpLoad %_arr_uchar_uint_16 %1268
+%4130 = OpCompositeExtract %uchar %4129 14
+OpStore %1910 %4130
+%4131 = OpLoad %_arr_uchar_uint_16 %1265
+%4132 = OpCompositeExtract %uchar %4131 14
+OpStore %1911 %4132
+%4133 = OpLoad %uchar %1910
+%4134 = OpLoad %uchar %1911
+%4135 = OpULessThanEqual %bool %4133 %4134
+OpStore %1912 %4135
+%4136 = OpLoad %bool %1912
+%4137 = OpSelect %uchar %4136 %uchar_1 %uchar_0
+%4138 = OpISub %uchar %uchar_0 %4137
+OpStore %1913 %4138
+%4139 = OpLoad %_arr_uchar_uint_16 %1268
+%4140 = OpCompositeExtract %uchar %4139 15
+OpStore %1914 %4140
+%4141 = OpLoad %_arr_uchar_uint_16 %1265
+%4142 = OpCompositeExtract %uchar %4141 15
+OpStore %1915 %4142
+%4143 = OpLoad %uchar %1914
+%4144 = OpLoad %uchar %1915
+%4145 = OpULessThanEqual %bool %4143 %4144
+OpStore %1916 %4145
+%4146 = OpLoad %bool %1916
+%4147 = OpSelect %uchar %4146 %uchar_1 %uchar_0
+%4148 = OpISub %uchar %uchar_0 %4147
+OpStore %1917 %4148
+%4150 = OpLoad %uchar %1857
+%4151 = OpLoad %uchar %1861
+%4152 = OpLoad %uchar %1865
+%4153 = OpLoad %uchar %1869
+%4154 = OpLoad %uchar %1873
+%4155 = OpLoad %uchar %1877
+%4156 = OpLoad %uchar %1881
+%4157 = OpLoad %uchar %1885
+%4158 = OpLoad %uchar %1889
+%4159 = OpLoad %uchar %1893
+%4160 = OpLoad %uchar %1897
+%4161 = OpLoad %uchar %1901
+%4162 = OpLoad %uchar %1905
+%4163 = OpLoad %uchar %1909
+%4164 = OpLoad %uchar %1913
+%4165 = OpLoad %uchar %1917
+%4149 = OpCompositeConstruct %_arr_uchar_uint_16 %4150 %4151 %4152 %4153 %4154 %4155 %4156 %4157 %4158 %4159 %4160 %4161 %4162 %4163 %4164 %4165
+OpStore %1918 %4149
+%4166 = OpLoad %ulong %1270
+%4167 = OpLoad %_arr_uchar_uint_16 %1918
+%4168 = OpFunctionCall %ulong %1 %4166 %4167
+OpStore %1271 %4168
+%4169 = OpLoad %_arr_uchar_uint_16 %1788
+%4170 = OpCompositeExtract %uchar %4169 0
+OpStore %1919 %4170
+%4171 = OpLoad %_arr_uchar_uint_16 %1265
+%4172 = OpCompositeExtract %uchar %4171 0
+OpStore %1920 %4172
+%4173 = OpLoad %uchar %1919
+%4174 = OpLoad %uchar %1920
+%4175 = OpBitwiseAnd %uchar %4173 %4174
+OpStore %1921 %4175
+%4176 = OpLoad %_arr_uchar_uint_16 %1788
+%4177 = OpCompositeExtract %uchar %4176 1
+OpStore %1922 %4177
+%4178 = OpLoad %_arr_uchar_uint_16 %1265
+%4179 = OpCompositeExtract %uchar %4178 1
+OpStore %1923 %4179
+%4180 = OpLoad %uchar %1922
+%4181 = OpLoad %uchar %1923
+%4182 = OpBitwiseAnd %uchar %4180 %4181
+OpStore %1924 %4182
+%4183 = OpLoad %_arr_uchar_uint_16 %1788
+%4184 = OpCompositeExtract %uchar %4183 2
+OpStore %1925 %4184
+%4185 = OpLoad %_arr_uchar_uint_16 %1265
+%4186 = OpCompositeExtract %uchar %4185 2
+OpStore %1926 %4186
+%4187 = OpLoad %uchar %1925
+%4188 = OpLoad %uchar %1926
+%4189 = OpBitwiseAnd %uchar %4187 %4188
+OpStore %1927 %4189
+%4190 = OpLoad %_arr_uchar_uint_16 %1788
+%4191 = OpCompositeExtract %uchar %4190 3
+OpStore %1928 %4191
+%4192 = OpLoad %_arr_uchar_uint_16 %1265
+%4193 = OpCompositeExtract %uchar %4192 3
+OpStore %1929 %4193
+%4194 = OpLoad %uchar %1928
+%4195 = OpLoad %uchar %1929
+%4196 = OpBitwiseAnd %uchar %4194 %4195
+OpStore %1930 %4196
+%4197 = OpLoad %_arr_uchar_uint_16 %1788
+%4198 = OpCompositeExtract %uchar %4197 4
+OpStore %1931 %4198
+%4199 = OpLoad %_arr_uchar_uint_16 %1265
+%4200 = OpCompositeExtract %uchar %4199 4
+OpStore %1932 %4200
+%4201 = OpLoad %uchar %1931
+%4202 = OpLoad %uchar %1932
+%4203 = OpBitwiseAnd %uchar %4201 %4202
+OpStore %1933 %4203
+%4204 = OpLoad %_arr_uchar_uint_16 %1788
+%4205 = OpCompositeExtract %uchar %4204 5
+OpStore %1934 %4205
+%4206 = OpLoad %_arr_uchar_uint_16 %1265
+%4207 = OpCompositeExtract %uchar %4206 5
+OpStore %1935 %4207
+%4208 = OpLoad %uchar %1934
+%4209 = OpLoad %uchar %1935
+%4210 = OpBitwiseAnd %uchar %4208 %4209
+OpStore %1936 %4210
+%4211 = OpLoad %_arr_uchar_uint_16 %1788
+%4212 = OpCompositeExtract %uchar %4211 6
+OpStore %1937 %4212
+%4213 = OpLoad %_arr_uchar_uint_16 %1265
+%4214 = OpCompositeExtract %uchar %4213 6
+OpStore %1938 %4214
+%4215 = OpLoad %uchar %1937
+%4216 = OpLoad %uchar %1938
+%4217 = OpBitwiseAnd %uchar %4215 %4216
+OpStore %1939 %4217
+%4218 = OpLoad %_arr_uchar_uint_16 %1788
+%4219 = OpCompositeExtract %uchar %4218 7
+OpStore %1940 %4219
+%4220 = OpLoad %_arr_uchar_uint_16 %1265
+%4221 = OpCompositeExtract %uchar %4220 7
+OpStore %1941 %4221
+%4222 = OpLoad %uchar %1940
+%4223 = OpLoad %uchar %1941
+%4224 = OpBitwiseAnd %uchar %4222 %4223
+OpStore %1942 %4224
+%4225 = OpLoad %_arr_uchar_uint_16 %1788
+%4226 = OpCompositeExtract %uchar %4225 8
+OpStore %1943 %4226
+%4227 = OpLoad %_arr_uchar_uint_16 %1265
+%4228 = OpCompositeExtract %uchar %4227 8
+OpStore %1944 %4228
+%4229 = OpLoad %uchar %1943
+%4230 = OpLoad %uchar %1944
+%4231 = OpBitwiseAnd %uchar %4229 %4230
+OpStore %1945 %4231
+%4232 = OpLoad %_arr_uchar_uint_16 %1788
+%4233 = OpCompositeExtract %uchar %4232 9
+OpStore %1946 %4233
+%4234 = OpLoad %_arr_uchar_uint_16 %1265
+%4235 = OpCompositeExtract %uchar %4234 9
+OpStore %1947 %4235
+%4236 = OpLoad %uchar %1946
+%4237 = OpLoad %uchar %1947
+%4238 = OpBitwiseAnd %uchar %4236 %4237
+OpStore %1948 %4238
+%4239 = OpLoad %_arr_uchar_uint_16 %1788
+%4240 = OpCompositeExtract %uchar %4239 10
+OpStore %1949 %4240
+%4241 = OpLoad %_arr_uchar_uint_16 %1265
+%4242 = OpCompositeExtract %uchar %4241 10
+OpStore %1950 %4242
+%4243 = OpLoad %uchar %1949
+%4244 = OpLoad %uchar %1950
+%4245 = OpBitwiseAnd %uchar %4243 %4244
+OpStore %1951 %4245
+%4246 = OpLoad %_arr_uchar_uint_16 %1788
+%4247 = OpCompositeExtract %uchar %4246 11
+OpStore %1952 %4247
+%4248 = OpLoad %_arr_uchar_uint_16 %1265
+%4249 = OpCompositeExtract %uchar %4248 11
+OpStore %1953 %4249
+%4250 = OpLoad %uchar %1952
+%4251 = OpLoad %uchar %1953
+%4252 = OpBitwiseAnd %uchar %4250 %4251
+OpStore %1954 %4252
+%4253 = OpLoad %_arr_uchar_uint_16 %1788
+%4254 = OpCompositeExtract %uchar %4253 12
+OpStore %1955 %4254
+%4255 = OpLoad %_arr_uchar_uint_16 %1265
+%4256 = OpCompositeExtract %uchar %4255 12
+OpStore %1956 %4256
+%4257 = OpLoad %uchar %1955
+%4258 = OpLoad %uchar %1956
+%4259 = OpBitwiseAnd %uchar %4257 %4258
+OpStore %1957 %4259
+%4260 = OpLoad %_arr_uchar_uint_16 %1788
+%4261 = OpCompositeExtract %uchar %4260 13
+OpStore %1958 %4261
+%4262 = OpLoad %_arr_uchar_uint_16 %1265
+%4263 = OpCompositeExtract %uchar %4262 13
+OpStore %1959 %4263
+%4264 = OpLoad %uchar %1958
+%4265 = OpLoad %uchar %1959
+%4266 = OpBitwiseAnd %uchar %4264 %4265
+OpStore %1960 %4266
+%4267 = OpLoad %_arr_uchar_uint_16 %1788
+%4268 = OpCompositeExtract %uchar %4267 14
+OpStore %1961 %4268
+%4269 = OpLoad %_arr_uchar_uint_16 %1265
+%4270 = OpCompositeExtract %uchar %4269 14
+OpStore %1962 %4270
+%4271 = OpLoad %uchar %1961
+%4272 = OpLoad %uchar %1962
+%4273 = OpBitwiseAnd %uchar %4271 %4272
+OpStore %1963 %4273
+%4274 = OpLoad %_arr_uchar_uint_16 %1788
+%4275 = OpCompositeExtract %uchar %4274 15
+OpStore %1964 %4275
+%4276 = OpLoad %_arr_uchar_uint_16 %1265
+%4277 = OpCompositeExtract %uchar %4276 15
+OpStore %1965 %4277
+%4278 = OpLoad %uchar %1964
+%4279 = OpLoad %uchar %1965
+%4280 = OpBitwiseAnd %uchar %4278 %4279
+OpStore %1966 %4280
+%4281 = OpLoad %_arr_uchar_uint_16 %1788
+%4282 = OpLoad %uchar %1921
+%4283 = OpCompositeInsert %_arr_uchar_uint_16 %4282 %4281 0
+OpStore %1967 %4283
+%4284 = OpLoad %_arr_uchar_uint_16 %1967
+%4285 = OpLoad %uchar %1924
+%4286 = OpCompositeInsert %_arr_uchar_uint_16 %4285 %4284 1
+OpStore %1968 %4286
+%4287 = OpLoad %_arr_uchar_uint_16 %1968
+%4288 = OpLoad %uchar %1927
+%4289 = OpCompositeInsert %_arr_uchar_uint_16 %4288 %4287 2
+OpStore %1969 %4289
+%4290 = OpLoad %_arr_uchar_uint_16 %1969
+%4291 = OpLoad %uchar %1930
+%4292 = OpCompositeInsert %_arr_uchar_uint_16 %4291 %4290 3
+OpStore %1970 %4292
+%4293 = OpLoad %_arr_uchar_uint_16 %1970
+%4294 = OpLoad %uchar %1933
+%4295 = OpCompositeInsert %_arr_uchar_uint_16 %4294 %4293 4
+OpStore %1971 %4295
+%4296 = OpLoad %_arr_uchar_uint_16 %1971
+%4297 = OpLoad %uchar %1936
+%4298 = OpCompositeInsert %_arr_uchar_uint_16 %4297 %4296 5
+OpStore %1972 %4298
+%4299 = OpLoad %_arr_uchar_uint_16 %1972
+%4300 = OpLoad %uchar %1939
+%4301 = OpCompositeInsert %_arr_uchar_uint_16 %4300 %4299 6
+OpStore %1973 %4301
+%4302 = OpLoad %_arr_uchar_uint_16 %1973
+%4303 = OpLoad %uchar %1942
+%4304 = OpCompositeInsert %_arr_uchar_uint_16 %4303 %4302 7
+OpStore %1974 %4304
+%4305 = OpLoad %_arr_uchar_uint_16 %1974
+%4306 = OpLoad %uchar %1945
+%4307 = OpCompositeInsert %_arr_uchar_uint_16 %4306 %4305 8
+OpStore %1975 %4307
+%4308 = OpLoad %_arr_uchar_uint_16 %1975
+%4309 = OpLoad %uchar %1948
+%4310 = OpCompositeInsert %_arr_uchar_uint_16 %4309 %4308 9
+OpStore %1976 %4310
+%4311 = OpLoad %_arr_uchar_uint_16 %1976
+%4312 = OpLoad %uchar %1951
+%4313 = OpCompositeInsert %_arr_uchar_uint_16 %4312 %4311 10
+OpStore %1977 %4313
+%4314 = OpLoad %_arr_uchar_uint_16 %1977
+%4315 = OpLoad %uchar %1954
+%4316 = OpCompositeInsert %_arr_uchar_uint_16 %4315 %4314 11
+OpStore %1978 %4316
+%4317 = OpLoad %_arr_uchar_uint_16 %1978
+%4318 = OpLoad %uchar %1957
+%4319 = OpCompositeInsert %_arr_uchar_uint_16 %4318 %4317 12
+OpStore %1979 %4319
+%4320 = OpLoad %_arr_uchar_uint_16 %1979
+%4321 = OpLoad %uchar %1960
+%4322 = OpCompositeInsert %_arr_uchar_uint_16 %4321 %4320 13
+OpStore %1980 %4322
+%4323 = OpLoad %_arr_uchar_uint_16 %1980
+%4324 = OpLoad %uchar %1963
+%4325 = OpCompositeInsert %_arr_uchar_uint_16 %4324 %4323 14
+OpStore %1981 %4325
+%4326 = OpLoad %_arr_uchar_uint_16 %1981
+%4327 = OpLoad %uchar %1966
+%4328 = OpCompositeInsert %_arr_uchar_uint_16 %4327 %4326 15
+OpStore %1982 %4328
+%4329 = OpLoad %_arr_uchar_uint_16 %1788
+%4330 = OpCompositeExtract %uchar %4329 0
+OpStore %1983 %4330
+%4331 = OpLoad %uchar %1983
+%4332 = OpNot %uchar %4331
+OpStore %1984 %4332
+%4333 = OpLoad %_arr_uchar_uint_16 %1788
+%4334 = OpCompositeExtract %uchar %4333 1
+OpStore %1985 %4334
+%4335 = OpLoad %uchar %1985
+%4336 = OpNot %uchar %4335
+OpStore %1986 %4336
+%4337 = OpLoad %_arr_uchar_uint_16 %1788
+%4338 = OpCompositeExtract %uchar %4337 2
+OpStore %1987 %4338
+%4339 = OpLoad %uchar %1987
+%4340 = OpNot %uchar %4339
+OpStore %1988 %4340
+%4341 = OpLoad %_arr_uchar_uint_16 %1788
+%4342 = OpCompositeExtract %uchar %4341 3
+OpStore %1989 %4342
+%4343 = OpLoad %uchar %1989
+%4344 = OpNot %uchar %4343
+OpStore %1990 %4344
+%4345 = OpLoad %_arr_uchar_uint_16 %1788
+%4346 = OpCompositeExtract %uchar %4345 4
+OpStore %1991 %4346
+%4347 = OpLoad %uchar %1991
+%4348 = OpNot %uchar %4347
+OpStore %1992 %4348
+%4349 = OpLoad %_arr_uchar_uint_16 %1788
+%4350 = OpCompositeExtract %uchar %4349 5
+OpStore %1993 %4350
+%4351 = OpLoad %uchar %1993
+%4352 = OpNot %uchar %4351
+OpStore %1994 %4352
+%4353 = OpLoad %_arr_uchar_uint_16 %1788
+%4354 = OpCompositeExtract %uchar %4353 6
+OpStore %1995 %4354
+%4355 = OpLoad %uchar %1995
+%4356 = OpNot %uchar %4355
+OpStore %1996 %4356
+%4357 = OpLoad %_arr_uchar_uint_16 %1788
+%4358 = OpCompositeExtract %uchar %4357 7
+OpStore %1997 %4358
+%4359 = OpLoad %uchar %1997
+%4360 = OpNot %uchar %4359
+OpStore %1998 %4360
+%4361 = OpLoad %_arr_uchar_uint_16 %1788
+%4362 = OpCompositeExtract %uchar %4361 8
+OpStore %1999 %4362
+%4363 = OpLoad %uchar %1999
+%4364 = OpNot %uchar %4363
+OpStore %2000 %4364
+%4365 = OpLoad %_arr_uchar_uint_16 %1788
+%4366 = OpCompositeExtract %uchar %4365 9
+OpStore %2001 %4366
+%4367 = OpLoad %uchar %2001
+%4368 = OpNot %uchar %4367
+OpStore %2002 %4368
+%4369 = OpLoad %_arr_uchar_uint_16 %1788
+%4370 = OpCompositeExtract %uchar %4369 10
+OpStore %2003 %4370
+%4371 = OpLoad %uchar %2003
+%4372 = OpNot %uchar %4371
+OpStore %2004 %4372
+%4373 = OpLoad %_arr_uchar_uint_16 %1788
+%4374 = OpCompositeExtract %uchar %4373 11
+OpStore %2005 %4374
+%4375 = OpLoad %uchar %2005
+%4376 = OpNot %uchar %4375
+OpStore %2006 %4376
+%4377 = OpLoad %_arr_uchar_uint_16 %1788
+%4378 = OpCompositeExtract %uchar %4377 12
+OpStore %2007 %4378
+%4379 = OpLoad %uchar %2007
+%4380 = OpNot %uchar %4379
+OpStore %2008 %4380
+%4381 = OpLoad %_arr_uchar_uint_16 %1788
+%4382 = OpCompositeExtract %uchar %4381 13
+OpStore %2009 %4382
+%4383 = OpLoad %uchar %2009
+%4384 = OpNot %uchar %4383
+OpStore %2010 %4384
+%4385 = OpLoad %_arr_uchar_uint_16 %1788
+%4386 = OpCompositeExtract %uchar %4385 14
+OpStore %2011 %4386
+%4387 = OpLoad %uchar %2011
+%4388 = OpNot %uchar %4387
+OpStore %2012 %4388
+%4389 = OpLoad %_arr_uchar_uint_16 %1788
+%4390 = OpCompositeExtract %uchar %4389 15
+OpStore %2013 %4390
+%4391 = OpLoad %uchar %2013
+%4392 = OpNot %uchar %4391
+OpStore %2014 %4392
+%4393 = OpLoad %_arr_uchar_uint_16 %1788
+%4394 = OpLoad %uchar %1984
+%4395 = OpCompositeInsert %_arr_uchar_uint_16 %4394 %4393 0
+OpStore %2015 %4395
+%4396 = OpLoad %_arr_uchar_uint_16 %2015
+%4397 = OpLoad %uchar %1986
+%4398 = OpCompositeInsert %_arr_uchar_uint_16 %4397 %4396 1
+OpStore %2016 %4398
+%4399 = OpLoad %_arr_uchar_uint_16 %2016
+%4400 = OpLoad %uchar %1988
+%4401 = OpCompositeInsert %_arr_uchar_uint_16 %4400 %4399 2
+OpStore %2017 %4401
+%4402 = OpLoad %_arr_uchar_uint_16 %2017
+%4403 = OpLoad %uchar %1990
+%4404 = OpCompositeInsert %_arr_uchar_uint_16 %4403 %4402 3
+OpStore %2018 %4404
+%4405 = OpLoad %_arr_uchar_uint_16 %2018
+%4406 = OpLoad %uchar %1992
+%4407 = OpCompositeInsert %_arr_uchar_uint_16 %4406 %4405 4
+OpStore %2019 %4407
+%4408 = OpLoad %_arr_uchar_uint_16 %2019
+%4409 = OpLoad %uchar %1994
+%4410 = OpCompositeInsert %_arr_uchar_uint_16 %4409 %4408 5
+OpStore %2020 %4410
+%4411 = OpLoad %_arr_uchar_uint_16 %2020
+%4412 = OpLoad %uchar %1996
+%4413 = OpCompositeInsert %_arr_uchar_uint_16 %4412 %4411 6
+OpStore %2021 %4413
+%4414 = OpLoad %_arr_uchar_uint_16 %2021
+%4415 = OpLoad %uchar %1998
+%4416 = OpCompositeInsert %_arr_uchar_uint_16 %4415 %4414 7
+OpStore %2022 %4416
+%4417 = OpLoad %_arr_uchar_uint_16 %2022
+%4418 = OpLoad %uchar %2000
+%4419 = OpCompositeInsert %_arr_uchar_uint_16 %4418 %4417 8
+OpStore %2023 %4419
+%4420 = OpLoad %_arr_uchar_uint_16 %2023
+%4421 = OpLoad %uchar %2002
+%4422 = OpCompositeInsert %_arr_uchar_uint_16 %4421 %4420 9
+OpStore %2024 %4422
+%4423 = OpLoad %_arr_uchar_uint_16 %2024
+%4424 = OpLoad %uchar %2004
+%4425 = OpCompositeInsert %_arr_uchar_uint_16 %4424 %4423 10
+OpStore %2025 %4425
+%4426 = OpLoad %_arr_uchar_uint_16 %2025
+%4427 = OpLoad %uchar %2006
+%4428 = OpCompositeInsert %_arr_uchar_uint_16 %4427 %4426 11
+OpStore %2026 %4428
+%4429 = OpLoad %_arr_uchar_uint_16 %2026
+%4430 = OpLoad %uchar %2008
+%4431 = OpCompositeInsert %_arr_uchar_uint_16 %4430 %4429 12
+OpStore %2027 %4431
+%4432 = OpLoad %_arr_uchar_uint_16 %2027
+%4433 = OpLoad %uchar %2010
+%4434 = OpCompositeInsert %_arr_uchar_uint_16 %4433 %4432 13
+OpStore %2028 %4434
+%4435 = OpLoad %_arr_uchar_uint_16 %2028
+%4436 = OpLoad %uchar %2012
+%4437 = OpCompositeInsert %_arr_uchar_uint_16 %4436 %4435 14
+OpStore %2029 %4437
+%4438 = OpLoad %_arr_uchar_uint_16 %2029
+%4439 = OpLoad %uchar %2014
+%4440 = OpCompositeInsert %_arr_uchar_uint_16 %4439 %4438 15
+OpStore %2030 %4440
+%4441 = OpLoad %_arr_uchar_uint_16 %2030
+%4442 = OpCompositeExtract %uchar %4441 0
+OpStore %2031 %4442
+%4443 = OpLoad %_arr_uchar_uint_16 %1268
+%4444 = OpCompositeExtract %uchar %4443 0
+OpStore %2032 %4444
+%4445 = OpLoad %uchar %2031
+%4446 = OpLoad %uchar %2032
+%4447 = OpBitwiseAnd %uchar %4445 %4446
+OpStore %2033 %4447
+%4448 = OpLoad %_arr_uchar_uint_16 %2030
+%4449 = OpCompositeExtract %uchar %4448 1
+OpStore %2034 %4449
+%4450 = OpLoad %_arr_uchar_uint_16 %1268
+%4451 = OpCompositeExtract %uchar %4450 1
+OpStore %2035 %4451
+%4452 = OpLoad %uchar %2034
+%4453 = OpLoad %uchar %2035
+%4454 = OpBitwiseAnd %uchar %4452 %4453
+OpStore %2036 %4454
+%4455 = OpLoad %_arr_uchar_uint_16 %2030
+%4456 = OpCompositeExtract %uchar %4455 2
+OpStore %2037 %4456
+%4457 = OpLoad %_arr_uchar_uint_16 %1268
+%4458 = OpCompositeExtract %uchar %4457 2
+OpStore %2038 %4458
+%4459 = OpLoad %uchar %2037
+%4460 = OpLoad %uchar %2038
+%4461 = OpBitwiseAnd %uchar %4459 %4460
+OpStore %2039 %4461
+%4462 = OpLoad %_arr_uchar_uint_16 %2030
+%4463 = OpCompositeExtract %uchar %4462 3
+OpStore %2040 %4463
+%4464 = OpLoad %_arr_uchar_uint_16 %1268
+%4465 = OpCompositeExtract %uchar %4464 3
+OpStore %2041 %4465
+%4466 = OpLoad %uchar %2040
+%4467 = OpLoad %uchar %2041
+%4468 = OpBitwiseAnd %uchar %4466 %4467
+OpStore %2042 %4468
+%4469 = OpLoad %_arr_uchar_uint_16 %2030
+%4470 = OpCompositeExtract %uchar %4469 4
+OpStore %2043 %4470
+%4471 = OpLoad %_arr_uchar_uint_16 %1268
+%4472 = OpCompositeExtract %uchar %4471 4
+OpStore %2044 %4472
+%4473 = OpLoad %uchar %2043
+%4474 = OpLoad %uchar %2044
+%4475 = OpBitwiseAnd %uchar %4473 %4474
+OpStore %2045 %4475
+%4476 = OpLoad %_arr_uchar_uint_16 %2030
+%4477 = OpCompositeExtract %uchar %4476 5
+OpStore %2046 %4477
+%4478 = OpLoad %_arr_uchar_uint_16 %1268
+%4479 = OpCompositeExtract %uchar %4478 5
+OpStore %2047 %4479
+%4480 = OpLoad %uchar %2046
+%4481 = OpLoad %uchar %2047
+%4482 = OpBitwiseAnd %uchar %4480 %4481
+OpStore %2048 %4482
+%4483 = OpLoad %_arr_uchar_uint_16 %2030
+%4484 = OpCompositeExtract %uchar %4483 6
+OpStore %2049 %4484
+%4485 = OpLoad %_arr_uchar_uint_16 %1268
+%4486 = OpCompositeExtract %uchar %4485 6
+OpStore %2050 %4486
+%4487 = OpLoad %uchar %2049
+%4488 = OpLoad %uchar %2050
+%4489 = OpBitwiseAnd %uchar %4487 %4488
+OpStore %2051 %4489
+%4490 = OpLoad %_arr_uchar_uint_16 %2030
+%4491 = OpCompositeExtract %uchar %4490 7
+OpStore %2052 %4491
+%4492 = OpLoad %_arr_uchar_uint_16 %1268
+%4493 = OpCompositeExtract %uchar %4492 7
+OpStore %2053 %4493
+%4494 = OpLoad %uchar %2052
+%4495 = OpLoad %uchar %2053
+%4496 = OpBitwiseAnd %uchar %4494 %4495
+OpStore %2054 %4496
+%4497 = OpLoad %_arr_uchar_uint_16 %2030
+%4498 = OpCompositeExtract %uchar %4497 8
+OpStore %2055 %4498
+%4499 = OpLoad %_arr_uchar_uint_16 %1268
+%4500 = OpCompositeExtract %uchar %4499 8
+OpStore %2056 %4500
+%4501 = OpLoad %uchar %2055
+%4502 = OpLoad %uchar %2056
+%4503 = OpBitwiseAnd %uchar %4501 %4502
+OpStore %2057 %4503
+%4504 = OpLoad %_arr_uchar_uint_16 %2030
+%4505 = OpCompositeExtract %uchar %4504 9
+OpStore %2058 %4505
+%4506 = OpLoad %_arr_uchar_uint_16 %1268
+%4507 = OpCompositeExtract %uchar %4506 9
+OpStore %2059 %4507
+%4508 = OpLoad %uchar %2058
+%4509 = OpLoad %uchar %2059
+%4510 = OpBitwiseAnd %uchar %4508 %4509
+OpStore %2060 %4510
+%4511 = OpLoad %_arr_uchar_uint_16 %2030
+%4512 = OpCompositeExtract %uchar %4511 10
+OpStore %2061 %4512
+%4513 = OpLoad %_arr_uchar_uint_16 %1268
+%4514 = OpCompositeExtract %uchar %4513 10
+OpStore %2062 %4514
+%4515 = OpLoad %uchar %2061
+%4516 = OpLoad %uchar %2062
+%4517 = OpBitwiseAnd %uchar %4515 %4516
+OpStore %2063 %4517
+%4518 = OpLoad %_arr_uchar_uint_16 %2030
+%4519 = OpCompositeExtract %uchar %4518 11
+OpStore %2064 %4519
+%4520 = OpLoad %_arr_uchar_uint_16 %1268
+%4521 = OpCompositeExtract %uchar %4520 11
+OpStore %2065 %4521
+%4522 = OpLoad %uchar %2064
+%4523 = OpLoad %uchar %2065
+%4524 = OpBitwiseAnd %uchar %4522 %4523
+OpStore %2066 %4524
+%4525 = OpLoad %_arr_uchar_uint_16 %2030
+%4526 = OpCompositeExtract %uchar %4525 12
+OpStore %2067 %4526
+%4527 = OpLoad %_arr_uchar_uint_16 %1268
+%4528 = OpCompositeExtract %uchar %4527 12
+OpStore %2068 %4528
+%4529 = OpLoad %uchar %2067
+%4530 = OpLoad %uchar %2068
+%4531 = OpBitwiseAnd %uchar %4529 %4530
+OpStore %2069 %4531
+%4532 = OpLoad %_arr_uchar_uint_16 %2030
+%4533 = OpCompositeExtract %uchar %4532 13
+OpStore %2070 %4533
+%4534 = OpLoad %_arr_uchar_uint_16 %1268
+%4535 = OpCompositeExtract %uchar %4534 13
+OpStore %2071 %4535
+%4536 = OpLoad %uchar %2070
+%4537 = OpLoad %uchar %2071
+%4538 = OpBitwiseAnd %uchar %4536 %4537
+OpStore %2072 %4538
+%4539 = OpLoad %_arr_uchar_uint_16 %2030
+%4540 = OpCompositeExtract %uchar %4539 14
+OpStore %2073 %4540
+%4541 = OpLoad %_arr_uchar_uint_16 %1268
+%4542 = OpCompositeExtract %uchar %4541 14
+OpStore %2074 %4542
+%4543 = OpLoad %uchar %2073
+%4544 = OpLoad %uchar %2074
+%4545 = OpBitwiseAnd %uchar %4543 %4544
+OpStore %2075 %4545
+%4546 = OpLoad %_arr_uchar_uint_16 %2030
+%4547 = OpCompositeExtract %uchar %4546 15
+OpStore %2076 %4547
+%4548 = OpLoad %_arr_uchar_uint_16 %1268
+%4549 = OpCompositeExtract %uchar %4548 15
+OpStore %2077 %4549
+%4550 = OpLoad %uchar %2076
+%4551 = OpLoad %uchar %2077
+%4552 = OpBitwiseAnd %uchar %4550 %4551
+OpStore %2078 %4552
+%4553 = OpLoad %_arr_uchar_uint_16 %2030
+%4554 = OpLoad %uchar %2033
+%4555 = OpCompositeInsert %_arr_uchar_uint_16 %4554 %4553 0
+OpStore %2079 %4555
+%4556 = OpLoad %_arr_uchar_uint_16 %2079
+%4557 = OpLoad %uchar %2036
+%4558 = OpCompositeInsert %_arr_uchar_uint_16 %4557 %4556 1
+OpStore %2080 %4558
+%4559 = OpLoad %_arr_uchar_uint_16 %2080
+%4560 = OpLoad %uchar %2039
+%4561 = OpCompositeInsert %_arr_uchar_uint_16 %4560 %4559 2
+OpStore %2081 %4561
+%4562 = OpLoad %_arr_uchar_uint_16 %2081
+%4563 = OpLoad %uchar %2042
+%4564 = OpCompositeInsert %_arr_uchar_uint_16 %4563 %4562 3
+OpStore %2082 %4564
+%4565 = OpLoad %_arr_uchar_uint_16 %2082
+%4566 = OpLoad %uchar %2045
+%4567 = OpCompositeInsert %_arr_uchar_uint_16 %4566 %4565 4
+OpStore %2083 %4567
+%4568 = OpLoad %_arr_uchar_uint_16 %2083
+%4569 = OpLoad %uchar %2048
+%4570 = OpCompositeInsert %_arr_uchar_uint_16 %4569 %4568 5
+OpStore %2084 %4570
+%4571 = OpLoad %_arr_uchar_uint_16 %2084
+%4572 = OpLoad %uchar %2051
+%4573 = OpCompositeInsert %_arr_uchar_uint_16 %4572 %4571 6
+OpStore %2085 %4573
+%4574 = OpLoad %_arr_uchar_uint_16 %2085
+%4575 = OpLoad %uchar %2054
+%4576 = OpCompositeInsert %_arr_uchar_uint_16 %4575 %4574 7
+OpStore %2086 %4576
+%4577 = OpLoad %_arr_uchar_uint_16 %2086
+%4578 = OpLoad %uchar %2057
+%4579 = OpCompositeInsert %_arr_uchar_uint_16 %4578 %4577 8
+OpStore %2087 %4579
+%4580 = OpLoad %_arr_uchar_uint_16 %2087
+%4581 = OpLoad %uchar %2060
+%4582 = OpCompositeInsert %_arr_uchar_uint_16 %4581 %4580 9
+OpStore %2088 %4582
+%4583 = OpLoad %_arr_uchar_uint_16 %2088
+%4584 = OpLoad %uchar %2063
+%4585 = OpCompositeInsert %_arr_uchar_uint_16 %4584 %4583 10
+OpStore %2089 %4585
+%4586 = OpLoad %_arr_uchar_uint_16 %2089
+%4587 = OpLoad %uchar %2066
+%4588 = OpCompositeInsert %_arr_uchar_uint_16 %4587 %4586 11
+OpStore %2090 %4588
+%4589 = OpLoad %_arr_uchar_uint_16 %2090
+%4590 = OpLoad %uchar %2069
+%4591 = OpCompositeInsert %_arr_uchar_uint_16 %4590 %4589 12
+OpStore %2091 %4591
+%4592 = OpLoad %_arr_uchar_uint_16 %2091
+%4593 = OpLoad %uchar %2072
+%4594 = OpCompositeInsert %_arr_uchar_uint_16 %4593 %4592 13
+OpStore %2092 %4594
+%4595 = OpLoad %_arr_uchar_uint_16 %2092
+%4596 = OpLoad %uchar %2075
+%4597 = OpCompositeInsert %_arr_uchar_uint_16 %4596 %4595 14
+OpStore %2093 %4597
+%4598 = OpLoad %_arr_uchar_uint_16 %2093
+%4599 = OpLoad %uchar %2078
+%4600 = OpCompositeInsert %_arr_uchar_uint_16 %4599 %4598 15
+OpStore %2094 %4600
+%4601 = OpLoad %_arr_uchar_uint_16 %1982
+%4602 = OpCompositeExtract %uchar %4601 0
+OpStore %2095 %4602
+%4603 = OpLoad %_arr_uchar_uint_16 %2094
+%4604 = OpCompositeExtract %uchar %4603 0
+OpStore %2096 %4604
+%4605 = OpLoad %uchar %2095
+%4606 = OpLoad %uchar %2096
+%4607 = OpBitwiseOr %uchar %4605 %4606
+OpStore %2097 %4607
+%4608 = OpLoad %_arr_uchar_uint_16 %1982
+%4609 = OpCompositeExtract %uchar %4608 1
+OpStore %2098 %4609
+%4610 = OpLoad %_arr_uchar_uint_16 %2094
+%4611 = OpCompositeExtract %uchar %4610 1
+OpStore %2099 %4611
+%4612 = OpLoad %uchar %2098
+%4613 = OpLoad %uchar %2099
+%4614 = OpBitwiseOr %uchar %4612 %4613
+OpStore %2100 %4614
+%4615 = OpLoad %_arr_uchar_uint_16 %1982
+%4616 = OpCompositeExtract %uchar %4615 2
+OpStore %2101 %4616
+%4617 = OpLoad %_arr_uchar_uint_16 %2094
+%4618 = OpCompositeExtract %uchar %4617 2
+OpStore %2102 %4618
+%4619 = OpLoad %uchar %2101
+%4620 = OpLoad %uchar %2102
+%4621 = OpBitwiseOr %uchar %4619 %4620
+OpStore %2103 %4621
+%4622 = OpLoad %_arr_uchar_uint_16 %1982
+%4623 = OpCompositeExtract %uchar %4622 3
+OpStore %2104 %4623
+%4624 = OpLoad %_arr_uchar_uint_16 %2094
+%4625 = OpCompositeExtract %uchar %4624 3
+OpStore %2105 %4625
+%4626 = OpLoad %uchar %2104
+%4627 = OpLoad %uchar %2105
+%4628 = OpBitwiseOr %uchar %4626 %4627
+OpStore %2106 %4628
+%4629 = OpLoad %_arr_uchar_uint_16 %1982
+%4630 = OpCompositeExtract %uchar %4629 4
+OpStore %2107 %4630
+%4631 = OpLoad %_arr_uchar_uint_16 %2094
+%4632 = OpCompositeExtract %uchar %4631 4
+OpStore %2108 %4632
+%4633 = OpLoad %uchar %2107
+%4634 = OpLoad %uchar %2108
+%4635 = OpBitwiseOr %uchar %4633 %4634
+OpStore %2109 %4635
+%4636 = OpLoad %_arr_uchar_uint_16 %1982
+%4637 = OpCompositeExtract %uchar %4636 5
+OpStore %2110 %4637
+%4638 = OpLoad %_arr_uchar_uint_16 %2094
+%4639 = OpCompositeExtract %uchar %4638 5
+OpStore %2111 %4639
+%4640 = OpLoad %uchar %2110
+%4641 = OpLoad %uchar %2111
+%4642 = OpBitwiseOr %uchar %4640 %4641
+OpStore %2112 %4642
+%4643 = OpLoad %_arr_uchar_uint_16 %1982
+%4644 = OpCompositeExtract %uchar %4643 6
+OpStore %2113 %4644
+%4645 = OpLoad %_arr_uchar_uint_16 %2094
+%4646 = OpCompositeExtract %uchar %4645 6
+OpStore %2114 %4646
+%4647 = OpLoad %uchar %2113
+%4648 = OpLoad %uchar %2114
+%4649 = OpBitwiseOr %uchar %4647 %4648
+OpStore %2115 %4649
+%4650 = OpLoad %_arr_uchar_uint_16 %1982
+%4651 = OpCompositeExtract %uchar %4650 7
+OpStore %2116 %4651
+%4652 = OpLoad %_arr_uchar_uint_16 %2094
+%4653 = OpCompositeExtract %uchar %4652 7
+OpStore %2117 %4653
+%4654 = OpLoad %uchar %2116
+%4655 = OpLoad %uchar %2117
+%4656 = OpBitwiseOr %uchar %4654 %4655
+OpStore %2118 %4656
+%4657 = OpLoad %_arr_uchar_uint_16 %1982
+%4658 = OpCompositeExtract %uchar %4657 8
+OpStore %2119 %4658
+%4659 = OpLoad %_arr_uchar_uint_16 %2094
+%4660 = OpCompositeExtract %uchar %4659 8
+OpStore %2120 %4660
+%4661 = OpLoad %uchar %2119
+%4662 = OpLoad %uchar %2120
+%4663 = OpBitwiseOr %uchar %4661 %4662
+OpStore %2121 %4663
+%4664 = OpLoad %_arr_uchar_uint_16 %1982
+%4665 = OpCompositeExtract %uchar %4664 9
+OpStore %2122 %4665
+%4666 = OpLoad %_arr_uchar_uint_16 %2094
+%4667 = OpCompositeExtract %uchar %4666 9
+OpStore %2123 %4667
+%4668 = OpLoad %uchar %2122
+%4669 = OpLoad %uchar %2123
+%4670 = OpBitwiseOr %uchar %4668 %4669
+OpStore %2124 %4670
+%4671 = OpLoad %_arr_uchar_uint_16 %1982
+%4672 = OpCompositeExtract %uchar %4671 10
+OpStore %2125 %4672
+%4673 = OpLoad %_arr_uchar_uint_16 %2094
+%4674 = OpCompositeExtract %uchar %4673 10
+OpStore %2126 %4674
+%4675 = OpLoad %uchar %2125
+%4676 = OpLoad %uchar %2126
+%4677 = OpBitwiseOr %uchar %4675 %4676
+OpStore %2127 %4677
+%4678 = OpLoad %_arr_uchar_uint_16 %1982
+%4679 = OpCompositeExtract %uchar %4678 11
+OpStore %2128 %4679
+%4680 = OpLoad %_arr_uchar_uint_16 %2094
+%4681 = OpCompositeExtract %uchar %4680 11
+OpStore %2129 %4681
+%4682 = OpLoad %uchar %2128
+%4683 = OpLoad %uchar %2129
+%4684 = OpBitwiseOr %uchar %4682 %4683
+OpStore %2130 %4684
+%4685 = OpLoad %_arr_uchar_uint_16 %1982
+%4686 = OpCompositeExtract %uchar %4685 12
+OpStore %2131 %4686
+%4687 = OpLoad %_arr_uchar_uint_16 %2094
+%4688 = OpCompositeExtract %uchar %4687 12
+OpStore %2132 %4688
+%4689 = OpLoad %uchar %2131
+%4690 = OpLoad %uchar %2132
+%4691 = OpBitwiseOr %uchar %4689 %4690
+OpStore %2133 %4691
+%4692 = OpLoad %_arr_uchar_uint_16 %1982
+%4693 = OpCompositeExtract %uchar %4692 13
+OpStore %2134 %4693
+%4694 = OpLoad %_arr_uchar_uint_16 %2094
+%4695 = OpCompositeExtract %uchar %4694 13
+OpStore %2135 %4695
+%4696 = OpLoad %uchar %2134
+%4697 = OpLoad %uchar %2135
+%4698 = OpBitwiseOr %uchar %4696 %4697
+OpStore %2136 %4698
+%4699 = OpLoad %_arr_uchar_uint_16 %1982
+%4700 = OpCompositeExtract %uchar %4699 14
+OpStore %2137 %4700
+%4701 = OpLoad %_arr_uchar_uint_16 %2094
+%4702 = OpCompositeExtract %uchar %4701 14
+OpStore %2138 %4702
+%4703 = OpLoad %uchar %2137
+%4704 = OpLoad %uchar %2138
+%4705 = OpBitwiseOr %uchar %4703 %4704
+OpStore %2139 %4705
+%4706 = OpLoad %_arr_uchar_uint_16 %1982
+%4707 = OpCompositeExtract %uchar %4706 15
+OpStore %2140 %4707
+%4708 = OpLoad %_arr_uchar_uint_16 %2094
+%4709 = OpCompositeExtract %uchar %4708 15
+OpStore %2141 %4709
+%4710 = OpLoad %uchar %2140
+%4711 = OpLoad %uchar %2141
+%4712 = OpBitwiseOr %uchar %4710 %4711
+OpStore %2142 %4712
+%4713 = OpLoad %_arr_uchar_uint_16 %1982
+%4714 = OpLoad %uchar %2097
+%4715 = OpCompositeInsert %_arr_uchar_uint_16 %4714 %4713 0
+OpStore %2143 %4715
+%4716 = OpLoad %_arr_uchar_uint_16 %2143
+%4717 = OpLoad %uchar %2100
+%4718 = OpCompositeInsert %_arr_uchar_uint_16 %4717 %4716 1
+OpStore %2144 %4718
+%4719 = OpLoad %_arr_uchar_uint_16 %2144
+%4720 = OpLoad %uchar %2103
+%4721 = OpCompositeInsert %_arr_uchar_uint_16 %4720 %4719 2
+OpStore %2145 %4721
+%4722 = OpLoad %_arr_uchar_uint_16 %2145
+%4723 = OpLoad %uchar %2106
+%4724 = OpCompositeInsert %_arr_uchar_uint_16 %4723 %4722 3
+OpStore %2146 %4724
+%4725 = OpLoad %_arr_uchar_uint_16 %2146
+%4726 = OpLoad %uchar %2109
+%4727 = OpCompositeInsert %_arr_uchar_uint_16 %4726 %4725 4
+OpStore %2147 %4727
+%4728 = OpLoad %_arr_uchar_uint_16 %2147
+%4729 = OpLoad %uchar %2112
+%4730 = OpCompositeInsert %_arr_uchar_uint_16 %4729 %4728 5
+OpStore %2148 %4730
+%4731 = OpLoad %_arr_uchar_uint_16 %2148
+%4732 = OpLoad %uchar %2115
+%4733 = OpCompositeInsert %_arr_uchar_uint_16 %4732 %4731 6
+OpStore %2149 %4733
+%4734 = OpLoad %_arr_uchar_uint_16 %2149
+%4735 = OpLoad %uchar %2118
+%4736 = OpCompositeInsert %_arr_uchar_uint_16 %4735 %4734 7
+OpStore %2150 %4736
+%4737 = OpLoad %_arr_uchar_uint_16 %2150
+%4738 = OpLoad %uchar %2121
+%4739 = OpCompositeInsert %_arr_uchar_uint_16 %4738 %4737 8
+OpStore %2151 %4739
+%4740 = OpLoad %_arr_uchar_uint_16 %2151
+%4741 = OpLoad %uchar %2124
+%4742 = OpCompositeInsert %_arr_uchar_uint_16 %4741 %4740 9
+OpStore %2152 %4742
+%4743 = OpLoad %_arr_uchar_uint_16 %2152
+%4744 = OpLoad %uchar %2127
+%4745 = OpCompositeInsert %_arr_uchar_uint_16 %4744 %4743 10
+OpStore %2153 %4745
+%4746 = OpLoad %_arr_uchar_uint_16 %2153
+%4747 = OpLoad %uchar %2130
+%4748 = OpCompositeInsert %_arr_uchar_uint_16 %4747 %4746 11
+OpStore %2154 %4748
+%4749 = OpLoad %_arr_uchar_uint_16 %2154
+%4750 = OpLoad %uchar %2133
+%4751 = OpCompositeInsert %_arr_uchar_uint_16 %4750 %4749 12
+OpStore %2155 %4751
+%4752 = OpLoad %_arr_uchar_uint_16 %2155
+%4753 = OpLoad %uchar %2136
+%4754 = OpCompositeInsert %_arr_uchar_uint_16 %4753 %4752 13
+OpStore %2156 %4754
+%4755 = OpLoad %_arr_uchar_uint_16 %2156
+%4756 = OpLoad %uchar %2139
+%4757 = OpCompositeInsert %_arr_uchar_uint_16 %4756 %4755 14
+OpStore %2157 %4757
+%4758 = OpLoad %_arr_uchar_uint_16 %2157
+%4759 = OpLoad %uchar %2142
+%4760 = OpCompositeInsert %_arr_uchar_uint_16 %4759 %4758 15
+OpStore %2158 %4760
+%4761 = OpLoad %ulong %1271
+%4762 = OpLoad %_arr_uchar_uint_16 %2158
+%4763 = OpFunctionCall %ulong %1 %4761 %4762
+OpStore %1272 %4763
+%4764 = OpLoad %ulong %1272
+OpReturnValue %4764
 OpFunctionEnd
-%7 = OpFunction %ulong None %4270
-%4271 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%8 = OpFunction %ulong None %4273
-%4274 = OpFunctionParameter %ulong
-%4275 = OpFunctionParameter %ulong
-%4276 = OpLabel
-%4281 = OpVariable %_ptr_Function_ulong Function
-%4282 = OpVariable %_ptr_Function_ulong Function
-%4283 = OpVariable %_ptr_Function_bool Function
-%4284 = OpVariable %_ptr_Function_ulong Function
-%4285 = OpVariable %_ptr_Function_ulong Function
-%4286 = OpVariable %_ptr_Function_ulong Function
-%4287 = OpVariable %_ptr_Function_ulong Function
-%4288 = OpVariable %_ptr_Function_ulong Function
-%4289 = OpVariable %_ptr_Function_ulong Function
-%4290 = OpVariable %_ptr_Function_ulong Function
-%4291 = OpVariable %_ptr_Function_ulong Function
-OpStore %4281 %4274
-OpStore %4282 %4275
-%4292 = OpLoad %ulong %4281
-OpStore %4290 %4292
-OpStore %4291 %ulong_0
-OpBranch %4277
-%4277 = OpLabel
-%4293 = OpLoad %ulong %4291
-%4295 = OpULessThan %bool %4293 %ulong_8
-OpStore %4283 %4295
-%4296 = OpLoad %bool %4283
-OpLoopMerge %4279 %4280 None
-OpBranchConditional %4296 %4278 %4279
-%4279 = OpLabel
-%4297 = OpLoad %ulong %4290
-OpReturnValue %4297
-%4278 = OpLabel
-%4298 = OpLoad %ulong %4291
-%4299 = OpIMul %ulong %4298 %ulong_8
-OpStore %4284 %4299
-%4300 = OpLoad %ulong %4282
-%4301 = OpLoad %ulong %4284
-%4302 = OpShiftRightLogical %ulong %4300 %4301
-OpStore %4285 %4302
-%4303 = OpLoad %ulong %4285
-%4305 = OpBitwiseAnd %ulong %4303 %ulong_255
-OpStore %4286 %4305
-%4306 = OpLoad %ulong %4290
-%4307 = OpLoad %ulong %4286
-%4308 = OpBitwiseXor %ulong %4306 %4307
-OpStore %4287 %4308
-%4309 = OpLoad %ulong %4287
-%4311 = OpIMul %ulong %4309 %ulong_1099511628211
-OpStore %4288 %4311
-%4312 = OpLoad %ulong %4291
-%4314 = OpIAdd %ulong %4312 %ulong_1
-OpStore %4289 %4314
-%4315 = OpLoad %ulong %4288
-OpStore %4290 %4315
-%4316 = OpLoad %ulong %4289
-OpStore %4291 %4316
-OpBranch %4280
-%4280 = OpLabel
-OpBranch %4277
-OpFunctionEnd
-%9 = OpFunction %ulong None %4317
-%4318 = OpFunctionParameter %ulong
-%4319 = OpFunctionParameter %uchar
-%4320 = OpLabel
-%4327 = OpVariable %_ptr_Function_ulong Function
-%4328 = OpVariable %_ptr_Function_uchar Function
-%4329 = OpVariable %_ptr_Function_ulong Function
-%4330 = OpVariable %_ptr_Function_bool Function
-%4331 = OpVariable %_ptr_Function_ulong Function
-%4332 = OpVariable %_ptr_Function_ulong Function
-%4333 = OpVariable %_ptr_Function_ulong Function
-%4334 = OpVariable %_ptr_Function_ulong Function
-%4335 = OpVariable %_ptr_Function_ulong Function
-%4336 = OpVariable %_ptr_Function_ulong Function
-%4337 = OpVariable %_ptr_Function_ulong Function
-%4338 = OpVariable %_ptr_Function_ulong Function
-OpStore %4327 %4318
-OpStore %4328 %4319
-%4339 = OpLoad %uchar %4328
-%4340 = OpUConvert %ulong %4339
-OpStore %4329 %4340
-OpBranch %4321
-%4321 = OpLabel
-%4341 = OpLoad %ulong %4327
-OpStore %4337 %4341
-OpStore %4338 %ulong_0
-OpBranch %4322
-%4322 = OpLabel
-%4342 = OpLoad %ulong %4338
-%4343 = OpULessThan %bool %4342 %ulong_8
-OpStore %4330 %4343
-%4344 = OpLoad %bool %4330
-OpLoopMerge %4324 %4326 None
-OpBranchConditional %4344 %4323 %4324
-%4324 = OpLabel
-OpBranch %4325
-%4325 = OpLabel
-%4345 = OpLoad %ulong %4337
-OpReturnValue %4345
-%4323 = OpLabel
-%4346 = OpLoad %ulong %4338
-%4347 = OpIMul %ulong %4346 %ulong_8
-OpStore %4331 %4347
-%4348 = OpLoad %ulong %4329
-%4349 = OpLoad %ulong %4331
-%4350 = OpShiftRightLogical %ulong %4348 %4349
-OpStore %4332 %4350
-%4351 = OpLoad %ulong %4332
-%4352 = OpBitwiseAnd %ulong %4351 %ulong_255
-OpStore %4333 %4352
-%4353 = OpLoad %ulong %4337
-%4354 = OpLoad %ulong %4333
-%4355 = OpBitwiseXor %ulong %4353 %4354
-OpStore %4334 %4355
-%4356 = OpLoad %ulong %4334
-%4357 = OpIMul %ulong %4356 %ulong_1099511628211
-OpStore %4335 %4357
-%4358 = OpLoad %ulong %4338
-%4359 = OpIAdd %ulong %4358 %ulong_1
-OpStore %4336 %4359
-%4360 = OpLoad %ulong %4335
-OpStore %4337 %4360
-%4361 = OpLoad %ulong %4336
-OpStore %4338 %4361
-OpBranch %4326
-%4326 = OpLabel
-OpBranch %4322
-OpFunctionEnd
-%10 = OpFunction %ulong None %4362
-%4363 = OpFunctionParameter %ulong
-%4364 = OpFunctionParameter %ushort
-%4365 = OpLabel
-%4372 = OpVariable %_ptr_Function_ulong Function
-%4373 = OpVariable %_ptr_Function_ushort Function
-%4374 = OpVariable %_ptr_Function_ulong Function
-%4375 = OpVariable %_ptr_Function_bool Function
-%4376 = OpVariable %_ptr_Function_ulong Function
-%4377 = OpVariable %_ptr_Function_ulong Function
-%4378 = OpVariable %_ptr_Function_ulong Function
-%4379 = OpVariable %_ptr_Function_ulong Function
-%4380 = OpVariable %_ptr_Function_ulong Function
-%4381 = OpVariable %_ptr_Function_ulong Function
-%4382 = OpVariable %_ptr_Function_ulong Function
-%4383 = OpVariable %_ptr_Function_ulong Function
-OpStore %4372 %4363
-OpStore %4373 %4364
-%4384 = OpLoad %ushort %4373
-%4385 = OpUConvert %ulong %4384
-OpStore %4374 %4385
-OpBranch %4366
-%4366 = OpLabel
-%4386 = OpLoad %ulong %4372
-OpStore %4382 %4386
-OpStore %4383 %ulong_0
-OpBranch %4367
-%4367 = OpLabel
-%4387 = OpLoad %ulong %4383
-%4388 = OpULessThan %bool %4387 %ulong_8
-OpStore %4375 %4388
-%4389 = OpLoad %bool %4375
-OpLoopMerge %4369 %4371 None
-OpBranchConditional %4389 %4368 %4369
-%4369 = OpLabel
-OpBranch %4370
-%4370 = OpLabel
-%4390 = OpLoad %ulong %4382
-OpReturnValue %4390
-%4368 = OpLabel
-%4391 = OpLoad %ulong %4383
-%4392 = OpIMul %ulong %4391 %ulong_8
-OpStore %4376 %4392
-%4393 = OpLoad %ulong %4374
-%4394 = OpLoad %ulong %4376
-%4395 = OpShiftRightLogical %ulong %4393 %4394
-OpStore %4377 %4395
-%4396 = OpLoad %ulong %4377
-%4397 = OpBitwiseAnd %ulong %4396 %ulong_255
-OpStore %4378 %4397
-%4398 = OpLoad %ulong %4382
-%4399 = OpLoad %ulong %4378
-%4400 = OpBitwiseXor %ulong %4398 %4399
-OpStore %4379 %4400
-%4401 = OpLoad %ulong %4379
-%4402 = OpIMul %ulong %4401 %ulong_1099511628211
-OpStore %4380 %4402
-%4403 = OpLoad %ulong %4383
-%4404 = OpIAdd %ulong %4403 %ulong_1
-OpStore %4381 %4404
-%4405 = OpLoad %ulong %4380
-OpStore %4382 %4405
-%4406 = OpLoad %ulong %4381
-OpStore %4383 %4406
-OpBranch %4371
-%4371 = OpLabel
-OpBranch %4367
-OpFunctionEnd
-%11 = OpFunction %ulong None %4407
-%4408 = OpFunctionParameter %ulong
-%4409 = OpFunctionParameter %uint
-%4410 = OpLabel
-%4417 = OpVariable %_ptr_Function_ulong Function
-%4418 = OpVariable %_ptr_Function_uint Function
-%4419 = OpVariable %_ptr_Function_ulong Function
-%4420 = OpVariable %_ptr_Function_bool Function
-%4421 = OpVariable %_ptr_Function_ulong Function
-%4422 = OpVariable %_ptr_Function_ulong Function
-%4423 = OpVariable %_ptr_Function_ulong Function
-%4424 = OpVariable %_ptr_Function_ulong Function
-%4425 = OpVariable %_ptr_Function_ulong Function
-%4426 = OpVariable %_ptr_Function_ulong Function
-%4427 = OpVariable %_ptr_Function_ulong Function
-%4428 = OpVariable %_ptr_Function_ulong Function
-OpStore %4417 %4408
-OpStore %4418 %4409
-%4429 = OpLoad %uint %4418
-%4430 = OpUConvert %ulong %4429
-OpStore %4419 %4430
-OpBranch %4411
-%4411 = OpLabel
-%4431 = OpLoad %ulong %4417
-OpStore %4427 %4431
-OpStore %4428 %ulong_0
-OpBranch %4412
-%4412 = OpLabel
-%4432 = OpLoad %ulong %4428
-%4433 = OpULessThan %bool %4432 %ulong_8
-OpStore %4420 %4433
-%4434 = OpLoad %bool %4420
-OpLoopMerge %4414 %4416 None
-OpBranchConditional %4434 %4413 %4414
-%4414 = OpLabel
-OpBranch %4415
-%4415 = OpLabel
-%4435 = OpLoad %ulong %4427
-OpReturnValue %4435
-%4413 = OpLabel
-%4436 = OpLoad %ulong %4428
-%4437 = OpIMul %ulong %4436 %ulong_8
-OpStore %4421 %4437
-%4438 = OpLoad %ulong %4419
-%4439 = OpLoad %ulong %4421
-%4440 = OpShiftRightLogical %ulong %4438 %4439
-OpStore %4422 %4440
-%4441 = OpLoad %ulong %4422
-%4442 = OpBitwiseAnd %ulong %4441 %ulong_255
-OpStore %4423 %4442
-%4443 = OpLoad %ulong %4427
-%4444 = OpLoad %ulong %4423
-%4445 = OpBitwiseXor %ulong %4443 %4444
-OpStore %4424 %4445
-%4446 = OpLoad %ulong %4424
-%4447 = OpIMul %ulong %4446 %ulong_1099511628211
-OpStore %4425 %4447
-%4448 = OpLoad %ulong %4428
-%4449 = OpIAdd %ulong %4448 %ulong_1
-OpStore %4426 %4449
-%4450 = OpLoad %ulong %4425
-OpStore %4427 %4450
-%4451 = OpLoad %ulong %4426
-OpStore %4428 %4451
-OpBranch %4416
-%4416 = OpLabel
-OpBranch %4412
-OpFunctionEnd
-%12 = OpFunction %ulong None %4452
-%4453 = OpFunctionParameter %ulong
-%4454 = OpFunctionParameter %float
-%4455 = OpLabel
-%4462 = OpVariable %_ptr_Function_ulong Function
-%4463 = OpVariable %_ptr_Function_float Function
-%4464 = OpVariable %_ptr_Function_uint Function
-%4465 = OpVariable %_ptr_Function_ulong Function
-%4466 = OpVariable %_ptr_Function_bool Function
-%4467 = OpVariable %_ptr_Function_ulong Function
-%4468 = OpVariable %_ptr_Function_ulong Function
-%4469 = OpVariable %_ptr_Function_ulong Function
-%4470 = OpVariable %_ptr_Function_ulong Function
-%4471 = OpVariable %_ptr_Function_ulong Function
-%4472 = OpVariable %_ptr_Function_ulong Function
-%4473 = OpVariable %_ptr_Function_ulong Function
-%4474 = OpVariable %_ptr_Function_ulong Function
-OpStore %4462 %4453
-OpStore %4463 %4454
-%4475 = OpLoad %float %4463
-%4476 = OpBitcast %uint %4475
-OpStore %4464 %4476
-%4477 = OpLoad %uint %4464
-%4478 = OpUConvert %ulong %4477
-OpStore %4465 %4478
-OpBranch %4456
-%4456 = OpLabel
-%4479 = OpLoad %ulong %4462
-OpStore %4473 %4479
-OpStore %4474 %ulong_0
-OpBranch %4457
-%4457 = OpLabel
-%4480 = OpLoad %ulong %4474
-%4481 = OpULessThan %bool %4480 %ulong_8
-OpStore %4466 %4481
-%4482 = OpLoad %bool %4466
-OpLoopMerge %4459 %4461 None
-OpBranchConditional %4482 %4458 %4459
-%4459 = OpLabel
-OpBranch %4460
-%4460 = OpLabel
-%4483 = OpLoad %ulong %4473
-OpReturnValue %4483
-%4458 = OpLabel
-%4484 = OpLoad %ulong %4474
-%4485 = OpIMul %ulong %4484 %ulong_8
-OpStore %4467 %4485
-%4486 = OpLoad %ulong %4465
-%4487 = OpLoad %ulong %4467
-%4488 = OpShiftRightLogical %ulong %4486 %4487
-OpStore %4468 %4488
-%4489 = OpLoad %ulong %4468
-%4490 = OpBitwiseAnd %ulong %4489 %ulong_255
-OpStore %4469 %4490
-%4491 = OpLoad %ulong %4473
-%4492 = OpLoad %ulong %4469
-%4493 = OpBitwiseXor %ulong %4491 %4492
-OpStore %4470 %4493
-%4494 = OpLoad %ulong %4470
-%4495 = OpIMul %ulong %4494 %ulong_1099511628211
-OpStore %4471 %4495
-%4496 = OpLoad %ulong %4474
-%4497 = OpIAdd %ulong %4496 %ulong_1
-OpStore %4472 %4497
-%4498 = OpLoad %ulong %4471
-OpStore %4473 %4498
-%4499 = OpLoad %ulong %4472
-OpStore %4474 %4499
-OpBranch %4461
-%4461 = OpLabel
-OpBranch %4457
+%7 = OpFunction %ulong None %4765
+%4766 = OpFunctionParameter %ulong
+%4767 = OpFunctionParameter %ulong
+%4768 = OpLabel
+%4773 = OpVariable %_ptr_Function_ulong Function
+%4774 = OpVariable %_ptr_Function_ulong Function
+%4775 = OpVariable %_ptr_Function_bool Function
+%4776 = OpVariable %_ptr_Function_ulong Function
+%4777 = OpVariable %_ptr_Function_ulong Function
+%4778 = OpVariable %_ptr_Function_ulong Function
+%4779 = OpVariable %_ptr_Function_ulong Function
+%4780 = OpVariable %_ptr_Function_ulong Function
+%4781 = OpVariable %_ptr_Function_ulong Function
+%4782 = OpVariable %_ptr_Function_ulong Function
+%4783 = OpVariable %_ptr_Function_ulong Function
+OpStore %4773 %4766
+OpStore %4774 %4767
+%4784 = OpLoad %ulong %4773
+OpStore %4782 %4784
+OpStore %4783 %ulong_0
+OpBranch %4769
+%4769 = OpLabel
+%4785 = OpLoad %ulong %4783
+%4786 = OpULessThan %bool %4785 %ulong_8
+OpStore %4775 %4786
+%4787 = OpLoad %bool %4775
+OpLoopMerge %4771 %4772 None
+OpBranchConditional %4787 %4770 %4771
+%4771 = OpLabel
+%4788 = OpLoad %ulong %4782
+OpReturnValue %4788
+%4770 = OpLabel
+%4789 = OpLoad %ulong %4783
+%4790 = OpIMul %ulong %4789 %ulong_8
+OpStore %4776 %4790
+%4791 = OpLoad %ulong %4774
+%4792 = OpLoad %ulong %4776
+%4793 = OpShiftRightLogical %ulong %4791 %4792
+OpStore %4777 %4793
+%4794 = OpLoad %ulong %4777
+%4795 = OpBitwiseAnd %ulong %4794 %ulong_255
+OpStore %4778 %4795
+%4796 = OpLoad %ulong %4782
+%4797 = OpLoad %ulong %4778
+%4798 = OpBitwiseXor %ulong %4796 %4797
+OpStore %4779 %4798
+%4799 = OpLoad %ulong %4779
+%4800 = OpIMul %ulong %4799 %ulong_1099511628211
+OpStore %4780 %4800
+%4801 = OpLoad %ulong %4783
+%4802 = OpIAdd %ulong %4801 %ulong_1
+OpStore %4781 %4802
+%4803 = OpLoad %ulong %4780
+OpStore %4782 %4803
+%4804 = OpLoad %ulong %4781
+OpStore %4783 %4804
+OpBranch %4772
+%4772 = OpLabel
+OpBranch %4769
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f32x2.dis
+++ b/test/golden/spirv/vec/vec_f32x2.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 598
+; Bound: 458
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,825 +12,639 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x2.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v2float = OpTypeVector %float 2
-%9 = OpTypeFunction %ulong %ulong %v2float
+%6 = OpTypeFunction %ulong %ulong %v2float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v2float = OpTypePointer Function %v2float
 %_ptr_Function_float = OpTypePointer Function %float
-%33 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
-%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%117 = OpTypeFunction %ulong %ulong
 %uint_6 = OpConstant %uint 6
 %_arr_v2float_uint_6 = OpTypeArray %v2float %uint_6
 %_ptr_Function__arr_v2float_uint_6 = OpTypePointer Function %_arr_v2float_uint_6
-%_struct_82 = OpTypeStruct %uint %v2float %uint
-%_ptr_Function__struct_82 = OpTypePointer Function %_struct_82
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
+%_struct_150 = OpTypeStruct %uint %v2float %uint
+%_ptr_Function__struct_150 = OpTypePointer Function %_struct_150
 %float_2_25 = OpConstant %float 2.25
 %float_1_5 = OpConstant %float 1.5
 %float_0_5 = OpConstant %float 0.5
 %float_4 = OpConstant %float 4
 %float_1 = OpConstant %float 1
 %float_27 = OpConstant %float 27
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%374 = OpConstantNull %_arr_v2float_uint_6
+%330 = OpConstantNull %_arr_v2float_uint_6
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
 %uint_5 = OpConstant %uint 5
-%406 = OpConstantNull %_struct_82
+%362 = OpConstantNull %_struct_150
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%499 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%502 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%550 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v2float
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v2float
+%9 = OpLabel
+%29 = OpVariable %_ptr_Function_ulong Function
+%31 = OpVariable %_ptr_Function_v2float Function
+%33 = OpVariable %_ptr_Function_float Function
+%34 = OpVariable %_ptr_Function_float Function
+%36 = OpVariable %_ptr_Function_uint Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_bool Function
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_uint Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_bool Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+OpStore %29 %7
+OpStore %31 %8
+%59 = OpLoad %v2float %31
+%60 = OpCompositeExtract %float %59 0
+OpStore %33 %60
+OpBranch %10
+%10 = OpLabel
+%61 = OpLoad %float %33
+%62 = OpBitcast %uint %61
+OpStore %36 %62
+%63 = OpLoad %uint %36
+%64 = OpUConvert %ulong %63
+OpStore %37 %64
+OpBranch %12
 %12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v2float Function
-%18 = OpVariable %_ptr_Function_float Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%22 = OpLoad %v2float %16
-%23 = OpCompositeExtract %float %22 0
-OpStore %18 %23
-%24 = OpLoad %ulong %14
-%25 = OpLoad %float %18
-%26 = OpFunctionCall %ulong %5 %24 %25
-OpStore %19 %26
-%27 = OpLoad %v2float %16
-%28 = OpCompositeExtract %float %27 1
-OpStore %20 %28
-%29 = OpLoad %ulong %19
-%30 = OpLoad %float %20
-%31 = OpFunctionCall %ulong %5 %29 %30
-OpStore %21 %31
-%32 = OpLoad %ulong %21
-OpReturnValue %32
+%65 = OpLoad %ulong %29
+OpStore %46 %65
+OpStore %47 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%67 = OpLoad %ulong %47
+%69 = OpULessThan %bool %67 %ulong_8
+OpStore %39 %69
+%70 = OpLoad %bool %39
+OpLoopMerge %15 %25 None
+OpBranchConditional %70 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%71 = OpLoad %v2float %31
+%72 = OpCompositeExtract %float %71 1
+OpStore %34 %72
+OpBranch %17
+%17 = OpLabel
+%73 = OpLoad %float %34
+%74 = OpBitcast %uint %73
+OpStore %48 %74
+%75 = OpLoad %uint %48
+%76 = OpUConvert %ulong %75
+OpStore %49 %76
+OpBranch %19
+%19 = OpLabel
+%77 = OpLoad %ulong %46
+OpStore %57 %77
+OpStore %58 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%78 = OpLoad %ulong %58
+%79 = OpULessThan %bool %78 %ulong_8
+OpStore %50 %79
+%80 = OpLoad %bool %50
+OpLoopMerge %22 %24 None
+OpBranchConditional %80 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%81 = OpLoad %ulong %57
+OpReturnValue %81
+%21 = OpLabel
+%82 = OpLoad %ulong %58
+%83 = OpIMul %ulong %82 %ulong_8
+OpStore %51 %83
+%84 = OpLoad %ulong %49
+%85 = OpLoad %ulong %51
+%86 = OpShiftRightLogical %ulong %84 %85
+OpStore %52 %86
+%87 = OpLoad %ulong %52
+%89 = OpBitwiseAnd %ulong %87 %ulong_255
+OpStore %53 %89
+%90 = OpLoad %ulong %57
+%91 = OpLoad %ulong %53
+%92 = OpBitwiseXor %ulong %90 %91
+OpStore %54 %92
+%93 = OpLoad %ulong %54
+%95 = OpIMul %ulong %93 %ulong_1099511628211
+OpStore %55 %95
+%96 = OpLoad %ulong %58
+%98 = OpIAdd %ulong %96 %ulong_1
+OpStore %56 %98
+%99 = OpLoad %ulong %55
+OpStore %57 %99
+%100 = OpLoad %ulong %56
+OpStore %58 %100
+OpBranch %24
+%14 = OpLabel
+%101 = OpLoad %ulong %47
+%102 = OpIMul %ulong %101 %ulong_8
+OpStore %40 %102
+%103 = OpLoad %ulong %37
+%104 = OpLoad %ulong %40
+%105 = OpShiftRightLogical %ulong %103 %104
+OpStore %41 %105
+%106 = OpLoad %ulong %41
+%107 = OpBitwiseAnd %ulong %106 %ulong_255
+OpStore %42 %107
+%108 = OpLoad %ulong %46
+%109 = OpLoad %ulong %42
+%110 = OpBitwiseXor %ulong %108 %109
+OpStore %43 %110
+%111 = OpLoad %ulong %43
+%112 = OpIMul %ulong %111 %ulong_1099511628211
+OpStore %44 %112
+%113 = OpLoad %ulong %47
+%114 = OpIAdd %ulong %113 %ulong_1
+OpStore %45 %114
+%115 = OpLoad %ulong %44
+OpStore %46 %115
+%116 = OpLoad %ulong %45
+OpStore %47 %116
+OpBranch %25
+%24 = OpLabel
+OpBranch %20
+%25 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %33
-%34 = OpFunctionParameter %ulong
-%35 = OpLabel
-%81 = OpVariable %_ptr_Function__arr_v2float_uint_6 Function
-%84 = OpVariable %_ptr_Function__struct_82 Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_float Function
-%88 = OpVariable %_ptr_Function_float Function
-%89 = OpVariable %_ptr_Function_v2float Function
-%90 = OpVariable %_ptr_Function_v2float Function
-%91 = OpVariable %_ptr_Function_v2float Function
-%92 = OpVariable %_ptr_Function_float Function
-%93 = OpVariable %_ptr_Function_float Function
-%94 = OpVariable %_ptr_Function_v2float Function
-%95 = OpVariable %_ptr_Function_float Function
-%96 = OpVariable %_ptr_Function_float Function
-%97 = OpVariable %_ptr_Function_v2float Function
-%98 = OpVariable %_ptr_Function_v2float Function
-%99 = OpVariable %_ptr_Function_v2float Function
-%100 = OpVariable %_ptr_Function_v2float Function
-%101 = OpVariable %_ptr_Function_v2float Function
-%102 = OpVariable %_ptr_Function_v2float Function
-%103 = OpVariable %_ptr_Function_v2float Function
-%104 = OpVariable %_ptr_Function_v2float Function
-%105 = OpVariable %_ptr_Function_v2float Function
-%106 = OpVariable %_ptr_Function_v2float Function
-%107 = OpVariable %_ptr_Function_v2float Function
-%109 = OpVariable %_ptr_Function_bool Function
-%110 = OpVariable %_ptr_Function_v2float Function
-%111 = OpVariable %_ptr_Function_v2float Function
-%112 = OpVariable %_ptr_Function_v2float Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_v2float Function
-%115 = OpVariable %_ptr_Function_v2float Function
-%116 = OpVariable %_ptr_Function_v2float Function
-%117 = OpVariable %_ptr_Function_bool Function
-%118 = OpVariable %_ptr_Function_v2float Function
-%119 = OpVariable %_ptr_Function_ulong Function
-%120 = OpVariable %_ptr_Function_v2float Function
-%122 = OpVariable %_ptr_Function_uint Function
-%123 = OpVariable %_ptr_Function_ulong Function
-%124 = OpVariable %_ptr_Function_v2float Function
-%125 = OpVariable %_ptr_Function_uint Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_v2float Function
-%130 = OpVariable %_ptr_Function_v2float Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_float Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_float Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_float Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_float Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_float Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_float Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_float Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_float Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_float Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_float Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_float Function
-%154 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %117
+%118 = OpFunctionParameter %ulong
+%119 = OpLabel
+%149 = OpVariable %_ptr_Function__arr_v2float_uint_6 Function
+%152 = OpVariable %_ptr_Function__struct_150 Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_float Function
 %155 = OpVariable %_ptr_Function_float Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_float Function
-%158 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_v2float Function
+%157 = OpVariable %_ptr_Function_v2float Function
+%158 = OpVariable %_ptr_Function_v2float Function
 %159 = OpVariable %_ptr_Function_float Function
-%160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_float Function
-%162 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_float Function
+%161 = OpVariable %_ptr_Function_v2float Function
+%162 = OpVariable %_ptr_Function_float Function
 %163 = OpVariable %_ptr_Function_float Function
-%164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_float Function
+%164 = OpVariable %_ptr_Function_v2float Function
+%165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_float Function
+%167 = OpVariable %_ptr_Function_v2float Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_float Function
+%169 = OpVariable %_ptr_Function_v2float Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_float Function
+%171 = OpVariable %_ptr_Function_v2float Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_float Function
+%173 = OpVariable %_ptr_Function_v2float Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_float Function
+%175 = OpVariable %_ptr_Function_v2float Function
 %176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_float Function
+%177 = OpVariable %_ptr_Function_v2float Function
 %178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_float Function
+%179 = OpVariable %_ptr_Function_v2float Function
 %180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_float Function
+%181 = OpVariable %_ptr_Function_v2float Function
 %182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_float Function
+%183 = OpVariable %_ptr_Function_v2float Function
 %184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_float Function
+%185 = OpVariable %_ptr_Function_v2float Function
+%186 = OpVariable %_ptr_Function_bool Function
+%187 = OpVariable %_ptr_Function_v2float Function
 %188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_float Function
+%189 = OpVariable %_ptr_Function_v2float Function
 %190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_float Function
+%191 = OpVariable %_ptr_Function_v2float Function
 %192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_float Function
-%196 = OpVariable %_ptr_Function_ulong Function
-OpStore %85 %34
-%197 = OpFunctionCall %ulong %3
-OpStore %86 %197
-%198 = OpLoad %ulong %85
-%199 = OpConvertUToF %float %198
-OpStore %87 %199
-%201 = OpFNegate %float %float_2_25
-OpStore %88 %201
-%204 = OpLoad %float %88
-%202 = OpCompositeConstruct %v2float %float_1_5 %204
-OpStore %89 %202
-%205 = OpCompositeConstruct %v2float %float_0_5 %float_4
-OpStore %90 %205
-%208 = OpCompositeConstruct %v2float %float_1 %float_27
-OpStore %91 %208
-%211 = OpLoad %v2float %89
-%212 = OpCompositeExtract %float %211 0
-OpStore %92 %212
-%213 = OpLoad %float %92
-%214 = OpLoad %float %87
-%215 = OpFAdd %float %213 %214
-OpStore %93 %215
-%216 = OpLoad %v2float %89
-%217 = OpLoad %float %93
-%218 = OpCompositeInsert %v2float %217 %216 0
-OpStore %94 %218
-%219 = OpLoad %v2float %90
-%220 = OpCompositeExtract %float %219 1
-OpStore %95 %220
-%221 = OpLoad %float %95
-%222 = OpLoad %float %87
-%223 = OpFAdd %float %221 %222
-OpStore %96 %223
-%224 = OpLoad %v2float %90
-%225 = OpLoad %float %96
-%226 = OpCompositeInsert %v2float %225 %224 1
-OpStore %97 %226
-OpBranch %42
-%42 = OpLabel
-%227 = OpLoad %v2float %94
-%228 = OpCompositeExtract %float %227 0
-OpStore %133 %228
-%229 = OpLoad %ulong %86
-%230 = OpLoad %float %133
-%231 = OpFunctionCall %ulong %5 %229 %230
-OpStore %134 %231
-%232 = OpLoad %v2float %94
-%233 = OpCompositeExtract %float %232 1
-OpStore %135 %233
-%234 = OpLoad %ulong %134
-%235 = OpLoad %float %135
-%236 = OpFunctionCall %ulong %5 %234 %235
-OpStore %136 %236
-OpBranch %43
-%43 = OpLabel
-OpBranch %50
-%50 = OpLabel
-%237 = OpLoad %v2float %97
-%238 = OpCompositeExtract %float %237 0
-OpStore %149 %238
-%239 = OpLoad %ulong %136
-%240 = OpLoad %float %149
-%241 = OpFunctionCall %ulong %5 %239 %240
-OpStore %150 %241
-%242 = OpLoad %v2float %97
-%243 = OpCompositeExtract %float %242 1
-OpStore %151 %243
-%244 = OpLoad %ulong %150
-%245 = OpLoad %float %151
-%246 = OpFunctionCall %ulong %5 %244 %245
-OpStore %152 %246
-OpBranch %51
-%51 = OpLabel
-%247 = OpLoad %v2float %94
-%248 = OpLoad %v2float %97
-%249 = OpFAdd %v2float %247 %248
-OpStore %98 %249
-OpBranch %54
-%54 = OpLabel
-%250 = OpLoad %v2float %98
-%251 = OpCompositeExtract %float %250 0
-OpStore %157 %251
-%252 = OpLoad %ulong %152
-%253 = OpLoad %float %157
-%254 = OpFunctionCall %ulong %5 %252 %253
-OpStore %158 %254
-%255 = OpLoad %v2float %98
-%256 = OpCompositeExtract %float %255 1
-OpStore %159 %256
-%257 = OpLoad %ulong %158
-%258 = OpLoad %float %159
-%259 = OpFunctionCall %ulong %5 %257 %258
-OpStore %160 %259
-OpBranch %55
-%55 = OpLabel
-%260 = OpLoad %v2float %94
-%261 = OpLoad %v2float %97
-%262 = OpFSub %v2float %260 %261
-OpStore %99 %262
-OpBranch %58
-%58 = OpLabel
-%263 = OpLoad %v2float %99
-%264 = OpCompositeExtract %float %263 0
-OpStore %165 %264
-%265 = OpLoad %ulong %160
-%266 = OpLoad %float %165
-%267 = OpFunctionCall %ulong %5 %265 %266
-OpStore %166 %267
-%268 = OpLoad %v2float %99
-%269 = OpCompositeExtract %float %268 1
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_v2float Function
+%195 = OpVariable %_ptr_Function_v2float Function
+%196 = OpVariable %_ptr_Function_v2float Function
+%197 = OpVariable %_ptr_Function_bool Function
+%198 = OpVariable %_ptr_Function_v2float Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_v2float Function
+%202 = OpVariable %_ptr_Function_uint Function
+%203 = OpVariable %_ptr_Function_v2float Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_uint Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_v2float Function
+%209 = OpVariable %_ptr_Function_v2float Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_bool Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_bool Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+OpStore %153 %118
+OpBranch %126
+%126 = OpLabel
+OpBranch %127
+%127 = OpLabel
+%232 = OpLoad %ulong %153
+%233 = OpConvertUToF %float %232
+OpStore %154 %233
+%235 = OpFNegate %float %float_2_25
+OpStore %155 %235
+%238 = OpLoad %float %155
+%236 = OpCompositeConstruct %v2float %float_1_5 %238
+OpStore %156 %236
+%239 = OpCompositeConstruct %v2float %float_0_5 %float_4
+OpStore %157 %239
+%242 = OpCompositeConstruct %v2float %float_1 %float_27
+OpStore %158 %242
+%245 = OpLoad %v2float %156
+%246 = OpCompositeExtract %float %245 0
+OpStore %159 %246
+%247 = OpLoad %float %159
+%248 = OpLoad %float %154
+%249 = OpFAdd %float %247 %248
+OpStore %160 %249
+%250 = OpLoad %v2float %156
+%251 = OpLoad %float %160
+%252 = OpCompositeInsert %v2float %251 %250 0
+OpStore %161 %252
+%253 = OpLoad %v2float %157
+%254 = OpCompositeExtract %float %253 1
+OpStore %162 %254
+%255 = OpLoad %float %162
+%256 = OpLoad %float %154
+%257 = OpFAdd %float %255 %256
+OpStore %163 %257
+%258 = OpLoad %v2float %157
+%259 = OpLoad %float %163
+%260 = OpCompositeInsert %v2float %259 %258 1
+OpStore %164 %260
+%262 = OpLoad %v2float %161
+%263 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %262
+OpStore %165 %263
+%264 = OpLoad %ulong %165
+%265 = OpLoad %v2float %164
+%266 = OpFunctionCall %ulong %1 %264 %265
+OpStore %166 %266
+%267 = OpLoad %v2float %161
+%268 = OpLoad %v2float %164
+%269 = OpFAdd %v2float %267 %268
 OpStore %167 %269
 %270 = OpLoad %ulong %166
-%271 = OpLoad %float %167
-%272 = OpFunctionCall %ulong %5 %270 %271
+%271 = OpLoad %v2float %167
+%272 = OpFunctionCall %ulong %1 %270 %271
 OpStore %168 %272
-OpBranch %59
-%59 = OpLabel
-%273 = OpLoad %v2float %97
-%274 = OpLoad %v2float %94
+%273 = OpLoad %v2float %161
+%274 = OpLoad %v2float %164
 %275 = OpFSub %v2float %273 %274
-OpStore %100 %275
-OpBranch %60
-%60 = OpLabel
-%276 = OpLoad %v2float %100
-%277 = OpCompositeExtract %float %276 0
-OpStore %169 %277
-%278 = OpLoad %ulong %168
-%279 = OpLoad %float %169
-%280 = OpFunctionCall %ulong %5 %278 %279
-OpStore %170 %280
-%281 = OpLoad %v2float %100
-%282 = OpCompositeExtract %float %281 1
-OpStore %171 %282
-%283 = OpLoad %ulong %170
-%284 = OpLoad %float %171
-%285 = OpFunctionCall %ulong %5 %283 %284
-OpStore %172 %285
-OpBranch %61
-%61 = OpLabel
-%286 = OpLoad %v2float %94
-%287 = OpLoad %v2float %97
-%288 = OpFMul %v2float %286 %287
-OpStore %101 %288
-OpBranch %62
-%62 = OpLabel
-%289 = OpLoad %v2float %101
-%290 = OpCompositeExtract %float %289 0
-OpStore %173 %290
-%291 = OpLoad %ulong %172
-%292 = OpLoad %float %173
-%293 = OpFunctionCall %ulong %5 %291 %292
-OpStore %174 %293
-%294 = OpLoad %v2float %101
-%295 = OpCompositeExtract %float %294 1
-OpStore %175 %295
-%296 = OpLoad %ulong %174
-%297 = OpLoad %float %175
-%298 = OpFunctionCall %ulong %5 %296 %297
-OpStore %176 %298
-OpBranch %63
-%63 = OpLabel
-%299 = OpLoad %v2float %94
-%300 = OpLoad %v2float %97
-%301 = OpFDiv %v2float %299 %300
-OpStore %102 %301
-OpBranch %64
-%64 = OpLabel
-%302 = OpLoad %v2float %102
-%303 = OpCompositeExtract %float %302 0
-OpStore %177 %303
-%304 = OpLoad %ulong %176
-%305 = OpLoad %float %177
-%306 = OpFunctionCall %ulong %5 %304 %305
-OpStore %178 %306
-%307 = OpLoad %v2float %102
-%308 = OpCompositeExtract %float %307 1
-OpStore %179 %308
-%309 = OpLoad %ulong %178
-%310 = OpLoad %float %179
-%311 = OpFunctionCall %ulong %5 %309 %310
-OpStore %180 %311
-OpBranch %65
-%65 = OpLabel
-%312 = OpLoad %v2float %97
-%313 = OpLoad %v2float %94
-%314 = OpFDiv %v2float %312 %313
-OpStore %103 %314
-OpBranch %66
-%66 = OpLabel
-%315 = OpLoad %v2float %103
-%316 = OpCompositeExtract %float %315 0
-OpStore %181 %316
-%317 = OpLoad %ulong %180
-%318 = OpLoad %float %181
-%319 = OpFunctionCall %ulong %5 %317 %318
-OpStore %182 %319
-%320 = OpLoad %v2float %103
-%321 = OpCompositeExtract %float %320 1
-OpStore %183 %321
-%322 = OpLoad %ulong %182
-%323 = OpLoad %float %183
-%324 = OpFunctionCall %ulong %5 %322 %323
-OpStore %184 %324
-OpBranch %67
-%67 = OpLabel
-%325 = OpLoad %v2float %94
-%326 = OpLoad %v2float %91
-%327 = OpFMul %v2float %325 %326
-OpStore %104 %327
-OpBranch %68
-%68 = OpLabel
-%328 = OpLoad %v2float %104
-%329 = OpCompositeExtract %float %328 0
-OpStore %185 %329
-%330 = OpLoad %ulong %184
-%331 = OpLoad %float %185
-%332 = OpFunctionCall %ulong %5 %330 %331
-OpStore %186 %332
-%333 = OpLoad %v2float %104
-%334 = OpCompositeExtract %float %333 1
-OpStore %187 %334
-%335 = OpLoad %ulong %186
-%336 = OpLoad %float %187
-%337 = OpFunctionCall %ulong %5 %335 %336
-OpStore %188 %337
-OpBranch %69
-%69 = OpLabel
-%338 = OpLoad %v2float %91
-%339 = OpLoad %v2float %97
-%340 = OpFSub %v2float %338 %339
-OpStore %105 %340
-OpBranch %70
-%70 = OpLabel
-%341 = OpLoad %v2float %105
-%342 = OpCompositeExtract %float %341 0
-OpStore %189 %342
-%343 = OpLoad %ulong %188
-%344 = OpLoad %float %189
-%345 = OpFunctionCall %ulong %5 %343 %344
-OpStore %190 %345
-%346 = OpLoad %v2float %105
-%347 = OpCompositeExtract %float %346 1
-OpStore %191 %347
-%348 = OpLoad %ulong %190
-%349 = OpLoad %float %191
-%350 = OpFunctionCall %ulong %5 %348 %349
-OpStore %192 %350
-OpBranch %71
-%71 = OpLabel
-%351 = OpLoad %v2float %91
-%352 = OpLoad %v2float %94
-%353 = OpFDiv %v2float %351 %352
-OpStore %106 %353
-OpBranch %72
-%72 = OpLabel
-%354 = OpLoad %v2float %106
-%355 = OpCompositeExtract %float %354 0
-OpStore %193 %355
-%356 = OpLoad %ulong %192
-%357 = OpLoad %float %193
-%358 = OpFunctionCall %ulong %5 %356 %357
-OpStore %194 %358
-%359 = OpLoad %v2float %106
-%360 = OpCompositeExtract %float %359 1
-OpStore %195 %360
-%361 = OpLoad %ulong %194
-%362 = OpLoad %float %195
-%363 = OpFunctionCall %ulong %5 %361 %362
-OpStore %196 %363
-OpBranch %73
-%73 = OpLabel
-%364 = OpCompositeConstruct %v2float %float_0 %float_0
-OpStore %107 %364
-%366 = OpLoad %ulong %196
-OpStore %128 %366
-%367 = OpLoad %v2float %94
-OpStore %129 %367
-%368 = OpLoad %v2float %107
-OpStore %130 %368
-OpStore %131 %ulong_0
-OpBranch %36
-%36 = OpLabel
-%370 = OpLoad %ulong %131
-%372 = OpULessThan %bool %370 %ulong_6
-OpStore %109 %372
-%373 = OpLoad %bool %109
-OpLoopMerge %38 %75 None
-OpBranchConditional %373 %37 %38
-%38 = OpLabel
-OpStore %81 %374
-%376 = OpAccessChain %_ptr_Function_v2float %81 %uint_0
-%377 = OpLoad %v2float %129
-OpStore %376 %377
-%378 = OpLoad %v2float %129
-%379 = OpLoad %v2float %97
-%380 = OpFAdd %v2float %378 %379
-OpStore %114 %380
-%382 = OpAccessChain %_ptr_Function_v2float %81 %uint_1
-%383 = OpLoad %v2float %114
-OpStore %382 %383
-%384 = OpLoad %v2float %129
-%385 = OpLoad %v2float %91
-%386 = OpFMul %v2float %384 %385
-OpStore %115 %386
-%388 = OpAccessChain %_ptr_Function_v2float %81 %uint_2
-%389 = OpLoad %v2float %115
-OpStore %388 %389
-%391 = OpAccessChain %_ptr_Function_v2float %81 %uint_3
-%392 = OpLoad %v2float %130
-OpStore %391 %392
-%393 = OpLoad %v2float %97
-%394 = OpLoad %v2float %129
-%395 = OpFSub %v2float %393 %394
-OpStore %116 %395
-%397 = OpAccessChain %_ptr_Function_v2float %81 %uint_4
-%398 = OpLoad %v2float %116
-OpStore %397 %398
-%400 = OpAccessChain %_ptr_Function_v2float %81 %uint_5
-%401 = OpLoad %v2float %97
-OpStore %400 %401
-%402 = OpLoad %ulong %128
-OpStore %127 %402
-OpStore %132 %ulong_0
-OpBranch %39
-%39 = OpLabel
-%403 = OpLoad %ulong %132
-%404 = OpULessThan %bool %403 %ulong_6
-OpStore %117 %404
-%405 = OpLoad %bool %117
-OpLoopMerge %41 %74 None
-OpBranchConditional %405 %40 %41
-%41 = OpLabel
-OpStore %84 %406
-%407 = OpAccessChain %_ptr_Function_uint %84 %uint_0
-OpStore %407 %uint_4294967295
-%409 = OpAccessChain %_ptr_Function_v2float %81 %uint_2
-%410 = OpLoad %v2float %409
-OpStore %120 %410
-%411 = OpAccessChain %_ptr_Function_v2float %84 %uint_1
-%412 = OpLoad %v2float %120
-OpStore %411 %412
-%413 = OpAccessChain %_ptr_Function_uint %84 %uint_2
-OpStore %413 %uint_305419896
-%415 = OpLoad %uint %407
-OpStore %122 %415
-%416 = OpLoad %ulong %127
-%417 = OpLoad %uint %122
-%418 = OpFunctionCall %ulong %4 %416 %417
-OpStore %123 %418
-%419 = OpLoad %v2float %411
-OpStore %124 %419
-OpBranch %48
-%48 = OpLabel
-%420 = OpLoad %v2float %124
-%421 = OpCompositeExtract %float %420 0
-OpStore %145 %421
-%422 = OpLoad %ulong %123
-%423 = OpLoad %float %145
-%424 = OpFunctionCall %ulong %5 %422 %423
-OpStore %146 %424
-%425 = OpLoad %v2float %124
-%426 = OpCompositeExtract %float %425 1
-OpStore %147 %426
-%427 = OpLoad %ulong %146
-%428 = OpLoad %float %147
-%429 = OpFunctionCall %ulong %5 %427 %428
-OpStore %148 %429
-OpBranch %49
-%49 = OpLabel
-%430 = OpAccessChain %_ptr_Function_uint %84 %uint_2
-%431 = OpLoad %uint %430
-OpStore %125 %431
-%432 = OpLoad %ulong %148
-%433 = OpLoad %uint %125
-%434 = OpFunctionCall %ulong %4 %432 %433
-OpStore %126 %434
-%435 = OpLoad %ulong %126
-OpReturnValue %435
-%40 = OpLabel
-%436 = OpLoad %ulong %132
-%437 = OpAccessChain %_ptr_Function_v2float %81 %436
-%438 = OpLoad %v2float %437
-OpStore %118 %438
-OpBranch %46
-%46 = OpLabel
-%439 = OpLoad %v2float %118
-%440 = OpCompositeExtract %float %439 0
-OpStore %141 %440
-%441 = OpLoad %ulong %127
-%442 = OpLoad %float %141
-%443 = OpFunctionCall %ulong %5 %441 %442
-OpStore %142 %443
-%444 = OpLoad %v2float %118
-%445 = OpCompositeExtract %float %444 1
-OpStore %143 %445
-%446 = OpLoad %ulong %142
-%447 = OpLoad %float %143
-%448 = OpFunctionCall %ulong %5 %446 %447
-OpStore %144 %448
-OpBranch %47
-%47 = OpLabel
-%449 = OpLoad %ulong %132
-%451 = OpIAdd %ulong %449 %ulong_1
-OpStore %119 %451
-%452 = OpLoad %ulong %144
-OpStore %127 %452
-%453 = OpLoad %ulong %119
-OpStore %132 %453
-OpBranch %74
-%37 = OpLabel
-%454 = OpLoad %v2float %129
-%455 = OpLoad %v2float %91
-%456 = OpFMul %v2float %454 %455
-OpStore %110 %456
-OpBranch %44
-%44 = OpLabel
-%457 = OpLoad %v2float %110
-%458 = OpCompositeExtract %float %457 0
-OpStore %137 %458
-%459 = OpLoad %ulong %128
-%460 = OpLoad %float %137
-%461 = OpFunctionCall %ulong %5 %459 %460
-OpStore %138 %461
-%462 = OpLoad %v2float %110
-%463 = OpCompositeExtract %float %462 1
-OpStore %139 %463
-%464 = OpLoad %ulong %138
-%465 = OpLoad %float %139
-%466 = OpFunctionCall %ulong %5 %464 %465
-OpStore %140 %466
-OpBranch %45
-%45 = OpLabel
-%467 = OpLoad %v2float %130
-%468 = OpLoad %v2float %110
-%469 = OpFAdd %v2float %467 %468
-OpStore %111 %469
-OpBranch %52
-%52 = OpLabel
-%470 = OpLoad %v2float %111
-%471 = OpCompositeExtract %float %470 0
-OpStore %153 %471
-%472 = OpLoad %ulong %140
-%473 = OpLoad %float %153
-%474 = OpFunctionCall %ulong %5 %472 %473
-OpStore %154 %474
-%475 = OpLoad %v2float %111
-%476 = OpCompositeExtract %float %475 1
-OpStore %155 %476
-%477 = OpLoad %ulong %154
-%478 = OpLoad %float %155
-%479 = OpFunctionCall %ulong %5 %477 %478
-OpStore %156 %479
-OpBranch %53
-%53 = OpLabel
-%480 = OpLoad %v2float %129
-%481 = OpLoad %v2float %97
-%482 = OpFSub %v2float %480 %481
-OpStore %112 %482
-OpBranch %56
-%56 = OpLabel
-%483 = OpLoad %v2float %112
-%484 = OpCompositeExtract %float %483 0
-OpStore %161 %484
-%485 = OpLoad %ulong %156
-%486 = OpLoad %float %161
-%487 = OpFunctionCall %ulong %5 %485 %486
-OpStore %162 %487
-%488 = OpLoad %v2float %112
-%489 = OpCompositeExtract %float %488 1
-OpStore %163 %489
-%490 = OpLoad %ulong %162
-%491 = OpLoad %float %163
-%492 = OpFunctionCall %ulong %5 %490 %491
-OpStore %164 %492
-OpBranch %57
-%57 = OpLabel
-%493 = OpLoad %ulong %131
-%494 = OpIAdd %ulong %493 %ulong_1
-OpStore %113 %494
-%495 = OpLoad %ulong %164
-OpStore %128 %495
-%496 = OpLoad %v2float %112
-OpStore %129 %496
-%497 = OpLoad %v2float %111
-OpStore %130 %497
-%498 = OpLoad %ulong %113
-OpStore %131 %498
-OpBranch %75
-%74 = OpLabel
-OpBranch %39
-%75 = OpLabel
-OpBranch %36
-OpFunctionEnd
-%3 = OpFunction %ulong None %499
-%500 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %502
-%503 = OpFunctionParameter %ulong
-%504 = OpFunctionParameter %uint
-%505 = OpLabel
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_uint Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_bool Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_ulong Function
-OpStore %512 %503
-OpStore %513 %504
-%524 = OpLoad %uint %513
-%525 = OpUConvert %ulong %524
-OpStore %514 %525
-OpBranch %506
-%506 = OpLabel
-%526 = OpLoad %ulong %512
-OpStore %522 %526
-OpStore %523 %ulong_0
-OpBranch %507
-%507 = OpLabel
-%527 = OpLoad %ulong %523
-%529 = OpULessThan %bool %527 %ulong_8
-OpStore %515 %529
-%530 = OpLoad %bool %515
-OpLoopMerge %509 %511 None
-OpBranchConditional %530 %508 %509
-%509 = OpLabel
-OpBranch %510
-%510 = OpLabel
-%531 = OpLoad %ulong %522
-OpReturnValue %531
-%508 = OpLabel
-%532 = OpLoad %ulong %523
-%533 = OpIMul %ulong %532 %ulong_8
-OpStore %516 %533
-%534 = OpLoad %ulong %514
-%535 = OpLoad %ulong %516
-%536 = OpShiftRightLogical %ulong %534 %535
-OpStore %517 %536
-%537 = OpLoad %ulong %517
-%539 = OpBitwiseAnd %ulong %537 %ulong_255
-OpStore %518 %539
-%540 = OpLoad %ulong %522
-%541 = OpLoad %ulong %518
-%542 = OpBitwiseXor %ulong %540 %541
-OpStore %519 %542
-%543 = OpLoad %ulong %519
-%545 = OpIMul %ulong %543 %ulong_1099511628211
-OpStore %520 %545
-%546 = OpLoad %ulong %523
-%547 = OpIAdd %ulong %546 %ulong_1
-OpStore %521 %547
-%548 = OpLoad %ulong %520
-OpStore %522 %548
-%549 = OpLoad %ulong %521
-OpStore %523 %549
-OpBranch %511
-%511 = OpLabel
-OpBranch %507
-OpFunctionEnd
-%5 = OpFunction %ulong None %550
-%551 = OpFunctionParameter %ulong
-%552 = OpFunctionParameter %float
-%553 = OpLabel
-%560 = OpVariable %_ptr_Function_ulong Function
-%561 = OpVariable %_ptr_Function_float Function
-%562 = OpVariable %_ptr_Function_uint Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_bool Function
-%565 = OpVariable %_ptr_Function_ulong Function
-%566 = OpVariable %_ptr_Function_ulong Function
-%567 = OpVariable %_ptr_Function_ulong Function
-%568 = OpVariable %_ptr_Function_ulong Function
-%569 = OpVariable %_ptr_Function_ulong Function
-%570 = OpVariable %_ptr_Function_ulong Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_ulong Function
-OpStore %560 %551
-OpStore %561 %552
-%573 = OpLoad %float %561
-%574 = OpBitcast %uint %573
-OpStore %562 %574
-%575 = OpLoad %uint %562
-%576 = OpUConvert %ulong %575
-OpStore %563 %576
-OpBranch %554
-%554 = OpLabel
-%577 = OpLoad %ulong %560
-OpStore %571 %577
-OpStore %572 %ulong_0
-OpBranch %555
-%555 = OpLabel
-%578 = OpLoad %ulong %572
-%579 = OpULessThan %bool %578 %ulong_8
-OpStore %564 %579
-%580 = OpLoad %bool %564
-OpLoopMerge %557 %559 None
-OpBranchConditional %580 %556 %557
-%557 = OpLabel
-OpBranch %558
-%558 = OpLabel
-%581 = OpLoad %ulong %571
-OpReturnValue %581
-%556 = OpLabel
-%582 = OpLoad %ulong %572
-%583 = OpIMul %ulong %582 %ulong_8
-OpStore %565 %583
-%584 = OpLoad %ulong %563
-%585 = OpLoad %ulong %565
-%586 = OpShiftRightLogical %ulong %584 %585
-OpStore %566 %586
-%587 = OpLoad %ulong %566
-%588 = OpBitwiseAnd %ulong %587 %ulong_255
-OpStore %567 %588
-%589 = OpLoad %ulong %571
-%590 = OpLoad %ulong %567
-%591 = OpBitwiseXor %ulong %589 %590
-OpStore %568 %591
-%592 = OpLoad %ulong %568
-%593 = OpIMul %ulong %592 %ulong_1099511628211
-OpStore %569 %593
-%594 = OpLoad %ulong %572
-%595 = OpIAdd %ulong %594 %ulong_1
-OpStore %570 %595
-%596 = OpLoad %ulong %569
-OpStore %571 %596
-%597 = OpLoad %ulong %570
-OpStore %572 %597
-OpBranch %559
-%559 = OpLabel
-OpBranch %555
+OpStore %169 %275
+%276 = OpLoad %ulong %168
+%277 = OpLoad %v2float %169
+%278 = OpFunctionCall %ulong %1 %276 %277
+OpStore %170 %278
+%279 = OpLoad %v2float %164
+%280 = OpLoad %v2float %161
+%281 = OpFSub %v2float %279 %280
+OpStore %171 %281
+%282 = OpLoad %ulong %170
+%283 = OpLoad %v2float %171
+%284 = OpFunctionCall %ulong %1 %282 %283
+OpStore %172 %284
+%285 = OpLoad %v2float %161
+%286 = OpLoad %v2float %164
+%287 = OpFMul %v2float %285 %286
+OpStore %173 %287
+%288 = OpLoad %ulong %172
+%289 = OpLoad %v2float %173
+%290 = OpFunctionCall %ulong %1 %288 %289
+OpStore %174 %290
+%291 = OpLoad %v2float %161
+%292 = OpLoad %v2float %164
+%293 = OpFDiv %v2float %291 %292
+OpStore %175 %293
+%294 = OpLoad %ulong %174
+%295 = OpLoad %v2float %175
+%296 = OpFunctionCall %ulong %1 %294 %295
+OpStore %176 %296
+%297 = OpLoad %v2float %164
+%298 = OpLoad %v2float %161
+%299 = OpFDiv %v2float %297 %298
+OpStore %177 %299
+%300 = OpLoad %ulong %176
+%301 = OpLoad %v2float %177
+%302 = OpFunctionCall %ulong %1 %300 %301
+OpStore %178 %302
+%303 = OpLoad %v2float %161
+%304 = OpLoad %v2float %158
+%305 = OpFMul %v2float %303 %304
+OpStore %179 %305
+%306 = OpLoad %ulong %178
+%307 = OpLoad %v2float %179
+%308 = OpFunctionCall %ulong %1 %306 %307
+OpStore %180 %308
+%309 = OpLoad %v2float %158
+%310 = OpLoad %v2float %164
+%311 = OpFSub %v2float %309 %310
+OpStore %181 %311
+%312 = OpLoad %ulong %180
+%313 = OpLoad %v2float %181
+%314 = OpFunctionCall %ulong %1 %312 %313
+OpStore %182 %314
+%315 = OpLoad %v2float %158
+%316 = OpLoad %v2float %161
+%317 = OpFDiv %v2float %315 %316
+OpStore %183 %317
+%318 = OpLoad %ulong %182
+%319 = OpLoad %v2float %183
+%320 = OpFunctionCall %ulong %1 %318 %319
+OpStore %184 %320
+%321 = OpCompositeConstruct %v2float %float_0 %float_0
+OpStore %185 %321
+%323 = OpLoad %ulong %184
+OpStore %207 %323
+%324 = OpLoad %v2float %161
+OpStore %208 %324
+%325 = OpLoad %v2float %185
+OpStore %209 %325
+OpStore %210 %ulong_0
+OpBranch %120
+%120 = OpLabel
+%326 = OpLoad %ulong %210
+%328 = OpULessThan %bool %326 %ulong_6
+OpStore %186 %328
+%329 = OpLoad %bool %186
+OpLoopMerge %122 %145 None
+OpBranchConditional %329 %121 %122
+%122 = OpLabel
+OpStore %149 %330
+%332 = OpAccessChain %_ptr_Function_v2float %149 %uint_0
+%333 = OpLoad %v2float %208
+OpStore %332 %333
+%334 = OpLoad %v2float %208
+%335 = OpLoad %v2float %164
+%336 = OpFAdd %v2float %334 %335
+OpStore %194 %336
+%338 = OpAccessChain %_ptr_Function_v2float %149 %uint_1
+%339 = OpLoad %v2float %194
+OpStore %338 %339
+%340 = OpLoad %v2float %208
+%341 = OpLoad %v2float %158
+%342 = OpFMul %v2float %340 %341
+OpStore %195 %342
+%344 = OpAccessChain %_ptr_Function_v2float %149 %uint_2
+%345 = OpLoad %v2float %195
+OpStore %344 %345
+%347 = OpAccessChain %_ptr_Function_v2float %149 %uint_3
+%348 = OpLoad %v2float %209
+OpStore %347 %348
+%349 = OpLoad %v2float %164
+%350 = OpLoad %v2float %208
+%351 = OpFSub %v2float %349 %350
+OpStore %196 %351
+%353 = OpAccessChain %_ptr_Function_v2float %149 %uint_4
+%354 = OpLoad %v2float %196
+OpStore %353 %354
+%356 = OpAccessChain %_ptr_Function_v2float %149 %uint_5
+%357 = OpLoad %v2float %164
+OpStore %356 %357
+%358 = OpLoad %ulong %207
+OpStore %206 %358
+OpStore %211 %ulong_0
+OpBranch %123
+%123 = OpLabel
+%359 = OpLoad %ulong %211
+%360 = OpULessThan %bool %359 %ulong_6
+OpStore %197 %360
+%361 = OpLoad %bool %197
+OpLoopMerge %125 %144 None
+OpBranchConditional %361 %124 %125
+%125 = OpLabel
+OpStore %152 %362
+%363 = OpAccessChain %_ptr_Function_uint %152 %uint_0
+OpStore %363 %uint_4294967295
+%365 = OpAccessChain %_ptr_Function_v2float %149 %uint_2
+%366 = OpLoad %v2float %365
+OpStore %201 %366
+%367 = OpAccessChain %_ptr_Function_v2float %152 %uint_1
+%368 = OpLoad %v2float %201
+OpStore %367 %368
+%369 = OpAccessChain %_ptr_Function_uint %152 %uint_2
+OpStore %369 %uint_305419896
+%371 = OpLoad %uint %363
+OpStore %202 %371
+OpBranch %128
+%128 = OpLabel
+%372 = OpLoad %uint %202
+%373 = OpUConvert %ulong %372
+OpStore %212 %373
+OpBranch %130
+%130 = OpLabel
+%374 = OpLoad %ulong %206
+OpStore %220 %374
+OpStore %221 %ulong_0
+OpBranch %131
+%131 = OpLabel
+%375 = OpLoad %ulong %221
+%376 = OpULessThan %bool %375 %ulong_8
+OpStore %213 %376
+%377 = OpLoad %bool %213
+OpLoopMerge %133 %143 None
+OpBranchConditional %377 %132 %133
+%133 = OpLabel
+OpBranch %134
+%134 = OpLabel
+OpBranch %129
+%129 = OpLabel
+%378 = OpAccessChain %_ptr_Function_v2float %152 %uint_1
+%379 = OpLoad %v2float %378
+OpStore %203 %379
+%380 = OpLoad %ulong %220
+%381 = OpLoad %v2float %203
+%382 = OpFunctionCall %ulong %1 %380 %381
+OpStore %204 %382
+%383 = OpAccessChain %_ptr_Function_uint %152 %uint_2
+%384 = OpLoad %uint %383
+OpStore %205 %384
+OpBranch %135
+%135 = OpLabel
+%385 = OpLoad %uint %205
+%386 = OpUConvert %ulong %385
+OpStore %222 %386
+OpBranch %137
+%137 = OpLabel
+%387 = OpLoad %ulong %204
+OpStore %230 %387
+OpStore %231 %ulong_0
+OpBranch %138
+%138 = OpLabel
+%388 = OpLoad %ulong %231
+%389 = OpULessThan %bool %388 %ulong_8
+OpStore %223 %389
+%390 = OpLoad %bool %223
+OpLoopMerge %140 %142 None
+OpBranchConditional %390 %139 %140
+%140 = OpLabel
+OpBranch %141
+%141 = OpLabel
+OpBranch %136
+%136 = OpLabel
+%391 = OpLoad %ulong %230
+OpReturnValue %391
+%139 = OpLabel
+%392 = OpLoad %ulong %231
+%393 = OpIMul %ulong %392 %ulong_8
+OpStore %224 %393
+%394 = OpLoad %ulong %222
+%395 = OpLoad %ulong %224
+%396 = OpShiftRightLogical %ulong %394 %395
+OpStore %225 %396
+%397 = OpLoad %ulong %225
+%398 = OpBitwiseAnd %ulong %397 %ulong_255
+OpStore %226 %398
+%399 = OpLoad %ulong %230
+%400 = OpLoad %ulong %226
+%401 = OpBitwiseXor %ulong %399 %400
+OpStore %227 %401
+%402 = OpLoad %ulong %227
+%403 = OpIMul %ulong %402 %ulong_1099511628211
+OpStore %228 %403
+%404 = OpLoad %ulong %231
+%405 = OpIAdd %ulong %404 %ulong_1
+OpStore %229 %405
+%406 = OpLoad %ulong %228
+OpStore %230 %406
+%407 = OpLoad %ulong %229
+OpStore %231 %407
+OpBranch %142
+%132 = OpLabel
+%408 = OpLoad %ulong %221
+%409 = OpIMul %ulong %408 %ulong_8
+OpStore %214 %409
+%410 = OpLoad %ulong %212
+%411 = OpLoad %ulong %214
+%412 = OpShiftRightLogical %ulong %410 %411
+OpStore %215 %412
+%413 = OpLoad %ulong %215
+%414 = OpBitwiseAnd %ulong %413 %ulong_255
+OpStore %216 %414
+%415 = OpLoad %ulong %220
+%416 = OpLoad %ulong %216
+%417 = OpBitwiseXor %ulong %415 %416
+OpStore %217 %417
+%418 = OpLoad %ulong %217
+%419 = OpIMul %ulong %418 %ulong_1099511628211
+OpStore %218 %419
+%420 = OpLoad %ulong %221
+%421 = OpIAdd %ulong %420 %ulong_1
+OpStore %219 %421
+%422 = OpLoad %ulong %218
+OpStore %220 %422
+%423 = OpLoad %ulong %219
+OpStore %221 %423
+OpBranch %143
+%124 = OpLabel
+%424 = OpLoad %ulong %211
+%425 = OpAccessChain %_ptr_Function_v2float %149 %424
+%426 = OpLoad %v2float %425
+OpStore %198 %426
+%427 = OpLoad %ulong %206
+%428 = OpLoad %v2float %198
+%429 = OpFunctionCall %ulong %1 %427 %428
+OpStore %199 %429
+%430 = OpLoad %ulong %211
+%431 = OpIAdd %ulong %430 %ulong_1
+OpStore %200 %431
+%432 = OpLoad %ulong %199
+OpStore %206 %432
+%433 = OpLoad %ulong %200
+OpStore %211 %433
+OpBranch %144
+%121 = OpLabel
+%434 = OpLoad %v2float %208
+%435 = OpLoad %v2float %158
+%436 = OpFMul %v2float %434 %435
+OpStore %187 %436
+%437 = OpLoad %ulong %207
+%438 = OpLoad %v2float %187
+%439 = OpFunctionCall %ulong %1 %437 %438
+OpStore %188 %439
+%440 = OpLoad %v2float %209
+%441 = OpLoad %v2float %187
+%442 = OpFAdd %v2float %440 %441
+OpStore %189 %442
+%443 = OpLoad %ulong %188
+%444 = OpLoad %v2float %189
+%445 = OpFunctionCall %ulong %1 %443 %444
+OpStore %190 %445
+%446 = OpLoad %v2float %208
+%447 = OpLoad %v2float %164
+%448 = OpFSub %v2float %446 %447
+OpStore %191 %448
+%449 = OpLoad %ulong %190
+%450 = OpLoad %v2float %191
+%451 = OpFunctionCall %ulong %1 %449 %450
+OpStore %192 %451
+%452 = OpLoad %ulong %210
+%453 = OpIAdd %ulong %452 %ulong_1
+OpStore %193 %453
+%454 = OpLoad %ulong %192
+OpStore %207 %454
+%455 = OpLoad %v2float %191
+OpStore %208 %455
+%456 = OpLoad %v2float %189
+OpStore %209 %456
+%457 = OpLoad %ulong %193
+OpStore %210 %457
+OpBranch %145
+%142 = OpLabel
+OpBranch %138
+%143 = OpLabel
+OpBranch %131
+%144 = OpLabel
+OpBranch %123
+%145 = OpLabel
+OpBranch %120
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f32x3.dis
+++ b/test/golden/spirv/vec/vec_f32x3.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 494
+; Bound: 406
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,673 +12,575 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x3.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v3float = OpTypeVector %float 3
-%9 = OpTypeFunction %ulong %ulong %v3float
+%6 = OpTypeFunction %ulong %ulong %v3float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v3float = OpTypePointer Function %v3float
 %_ptr_Function_float = OpTypePointer Function %float
-%40 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
-%uint = OpTypeInt 32 0
-%_struct_67 = OpTypeStruct %uint %v3float %uint
-%_ptr_Function__struct_67 = OpTypePointer Function %_struct_67
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%163 = OpTypeFunction %ulong %ulong
+%_struct_188 = OpTypeStruct %uint %v3float %uint
+%_ptr_Function__struct_188 = OpTypePointer Function %_struct_188
 %uint_4 = OpConstant %uint 4
 %_arr_v3float_uint_4 = OpTypeArray %v3float %uint_4
 %_ptr_Function__arr_v3float_uint_4 = OpTypePointer Function %_arr_v3float_uint_4
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
 %float_2_25 = OpConstant %float 2.25
 %float_1_5 = OpConstant %float 1.5
 %float_3_75 = OpConstant %float 3.75
 %float_0_125 = OpConstant %float 0.125
 %float_0_5 = OpConstant %float 0.5
 %float_4 = OpConstant %float 4
-%312 = OpConstantNull %_arr_v3float_uint_4
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%316 = OpConstantNull %_arr_v3float_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
-%ulong_0 = OpConstant %ulong 0
 %ulong_4 = OpConstant %ulong 4
-%337 = OpConstantNull %_struct_67
+%334 = OpConstantNull %_struct_188
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%395 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%398 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%446 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v3float
-%12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v3float Function
-%18 = OpVariable %_ptr_Function_float Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%24 = OpLoad %v3float %16
-%25 = OpCompositeExtract %float %24 0
-OpStore %18 %25
-%26 = OpLoad %ulong %14
-%27 = OpLoad %float %18
-%28 = OpFunctionCall %ulong %5 %26 %27
-OpStore %19 %28
-%29 = OpLoad %v3float %16
-%30 = OpCompositeExtract %float %29 1
-OpStore %20 %30
-%31 = OpLoad %ulong %19
-%32 = OpLoad %float %20
-%33 = OpFunctionCall %ulong %5 %31 %32
-OpStore %21 %33
-%34 = OpLoad %v3float %16
-%35 = OpCompositeExtract %float %34 2
-OpStore %22 %35
-%36 = OpLoad %ulong %21
-%37 = OpLoad %float %22
-%38 = OpFunctionCall %ulong %5 %36 %37
-OpStore %23 %38
-%39 = OpLoad %ulong %23
-OpReturnValue %39
-OpFunctionEnd
-%2 = OpFunction %ulong None %40
-%41 = OpFunctionParameter %ulong
-%42 = OpLabel
-%69 = OpVariable %_ptr_Function__struct_67 Function
-%73 = OpVariable %_ptr_Function__arr_v3float_uint_4 Function
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v3float
+%9 = OpLabel
+%37 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_v3float Function
+%41 = OpVariable %_ptr_Function_float Function
+%42 = OpVariable %_ptr_Function_float Function
+%43 = OpVariable %_ptr_Function_float Function
+%45 = OpVariable %_ptr_Function_uint Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_bool Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_uint Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_bool Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_uint Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_bool Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
 %74 = OpVariable %_ptr_Function_ulong Function
 %75 = OpVariable %_ptr_Function_ulong Function
-%76 = OpVariable %_ptr_Function_float Function
-%77 = OpVariable %_ptr_Function_float Function
-%78 = OpVariable %_ptr_Function_v3float Function
-%79 = OpVariable %_ptr_Function_float Function
-%80 = OpVariable %_ptr_Function_v3float Function
-%81 = OpVariable %_ptr_Function_float Function
-%82 = OpVariable %_ptr_Function_float Function
-%83 = OpVariable %_ptr_Function_v3float Function
-%84 = OpVariable %_ptr_Function_float Function
-%85 = OpVariable %_ptr_Function_float Function
-%86 = OpVariable %_ptr_Function_v3float Function
-%87 = OpVariable %_ptr_Function_v3float Function
-%88 = OpVariable %_ptr_Function_v3float Function
-%89 = OpVariable %_ptr_Function_v3float Function
-%90 = OpVariable %_ptr_Function_v3float Function
-%91 = OpVariable %_ptr_Function_v3float Function
-%92 = OpVariable %_ptr_Function_v3float Function
-%93 = OpVariable %_ptr_Function_v3float Function
-%95 = OpVariable %_ptr_Function_bool Function
-%96 = OpVariable %_ptr_Function_v3float Function
-%97 = OpVariable %_ptr_Function_ulong Function
-%98 = OpVariable %_ptr_Function_v3float Function
-%100 = OpVariable %_ptr_Function_uint Function
-%101 = OpVariable %_ptr_Function_ulong Function
-%102 = OpVariable %_ptr_Function_v3float Function
-%103 = OpVariable %_ptr_Function_uint Function
-%104 = OpVariable %_ptr_Function_ulong Function
-%105 = OpVariable %_ptr_Function_ulong Function
-%106 = OpVariable %_ptr_Function_ulong Function
-%107 = OpVariable %_ptr_Function_float Function
-%108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_float Function
-%110 = OpVariable %_ptr_Function_ulong Function
-%111 = OpVariable %_ptr_Function_float Function
-%112 = OpVariable %_ptr_Function_ulong Function
-%113 = OpVariable %_ptr_Function_float Function
-%114 = OpVariable %_ptr_Function_ulong Function
-%115 = OpVariable %_ptr_Function_float Function
-%116 = OpVariable %_ptr_Function_ulong Function
-%117 = OpVariable %_ptr_Function_float Function
-%118 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_float Function
-%120 = OpVariable %_ptr_Function_ulong Function
-%121 = OpVariable %_ptr_Function_float Function
-%122 = OpVariable %_ptr_Function_ulong Function
-%123 = OpVariable %_ptr_Function_float Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_float Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_float Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_float Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_float Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_float Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_float Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_float Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_float Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_float Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_float Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_float Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_float Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_float Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_float Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_float Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_float Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_float Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_float Function
-%160 = OpVariable %_ptr_Function_ulong Function
-OpStore %74 %41
-%161 = OpFunctionCall %ulong %3
-OpStore %75 %161
-%162 = OpLoad %ulong %74
-%163 = OpConvertUToF %float %162
-OpStore %76 %163
-%165 = OpFNegate %float %float_2_25
-OpStore %77 %165
-%168 = OpLoad %float %77
-%166 = OpCompositeConstruct %v3float %float_1_5 %168 %float_3_75
-OpStore %78 %166
-%171 = OpFNegate %float %float_0_125
-OpStore %79 %171
-%175 = OpLoad %float %79
-%172 = OpCompositeConstruct %v3float %float_0_5 %float_4 %175
-OpStore %80 %172
-%176 = OpLoad %v3float %78
-%177 = OpCompositeExtract %float %176 0
-OpStore %81 %177
-%178 = OpLoad %float %81
-%179 = OpLoad %float %76
-%180 = OpFAdd %float %178 %179
-OpStore %82 %180
-%181 = OpLoad %v3float %78
-%182 = OpLoad %float %82
-%183 = OpCompositeInsert %v3float %182 %181 0
-OpStore %83 %183
-%184 = OpLoad %v3float %80
-%185 = OpCompositeExtract %float %184 2
-OpStore %84 %185
-%186 = OpLoad %float %84
-%187 = OpLoad %float %76
-%188 = OpFAdd %float %186 %187
-OpStore %85 %188
-%189 = OpLoad %v3float %80
-%190 = OpLoad %float %85
-%191 = OpCompositeInsert %v3float %190 %189 2
-OpStore %86 %191
-OpBranch %46
-%46 = OpLabel
-%192 = OpLoad %v3float %83
-%193 = OpCompositeExtract %float %192 0
-OpStore %107 %193
-%194 = OpLoad %ulong %75
-%195 = OpLoad %float %107
-%196 = OpFunctionCall %ulong %5 %194 %195
-OpStore %108 %196
-%197 = OpLoad %v3float %83
-%198 = OpCompositeExtract %float %197 1
-OpStore %109 %198
-%199 = OpLoad %ulong %108
-%200 = OpLoad %float %109
-%201 = OpFunctionCall %ulong %5 %199 %200
-OpStore %110 %201
-%202 = OpLoad %v3float %83
-%203 = OpCompositeExtract %float %202 2
-OpStore %111 %203
-%204 = OpLoad %ulong %110
-%205 = OpLoad %float %111
-%206 = OpFunctionCall %ulong %5 %204 %205
-OpStore %112 %206
-OpBranch %47
-%47 = OpLabel
-OpBranch %52
-%52 = OpLabel
-%207 = OpLoad %v3float %86
-%208 = OpCompositeExtract %float %207 0
-OpStore %125 %208
-%209 = OpLoad %ulong %112
-%210 = OpLoad %float %125
-%211 = OpFunctionCall %ulong %5 %209 %210
-OpStore %126 %211
-%212 = OpLoad %v3float %86
-%213 = OpCompositeExtract %float %212 1
-OpStore %127 %213
-%214 = OpLoad %ulong %126
-%215 = OpLoad %float %127
-%216 = OpFunctionCall %ulong %5 %214 %215
-OpStore %128 %216
-%217 = OpLoad %v3float %86
-%218 = OpCompositeExtract %float %217 2
-OpStore %129 %218
-%219 = OpLoad %ulong %128
-%220 = OpLoad %float %129
-%221 = OpFunctionCall %ulong %5 %219 %220
-OpStore %130 %221
-OpBranch %53
-%53 = OpLabel
-%222 = OpLoad %v3float %83
-%223 = OpLoad %v3float %86
-%224 = OpFAdd %v3float %222 %223
-OpStore %87 %224
-OpBranch %54
-%54 = OpLabel
-%225 = OpLoad %v3float %87
-%226 = OpCompositeExtract %float %225 0
-OpStore %131 %226
-%227 = OpLoad %ulong %130
-%228 = OpLoad %float %131
-%229 = OpFunctionCall %ulong %5 %227 %228
-OpStore %132 %229
-%230 = OpLoad %v3float %87
-%231 = OpCompositeExtract %float %230 1
-OpStore %133 %231
-%232 = OpLoad %ulong %132
-%233 = OpLoad %float %133
-%234 = OpFunctionCall %ulong %5 %232 %233
-OpStore %134 %234
-%235 = OpLoad %v3float %87
-%236 = OpCompositeExtract %float %235 2
-OpStore %135 %236
-%237 = OpLoad %ulong %134
-%238 = OpLoad %float %135
-%239 = OpFunctionCall %ulong %5 %237 %238
-OpStore %136 %239
-OpBranch %55
-%55 = OpLabel
-%240 = OpLoad %v3float %83
-%241 = OpLoad %v3float %86
-%242 = OpFSub %v3float %240 %241
-OpStore %88 %242
-OpBranch %56
-%56 = OpLabel
-%243 = OpLoad %v3float %88
-%244 = OpCompositeExtract %float %243 0
-OpStore %137 %244
-%245 = OpLoad %ulong %136
-%246 = OpLoad %float %137
-%247 = OpFunctionCall %ulong %5 %245 %246
-OpStore %138 %247
-%248 = OpLoad %v3float %88
-%249 = OpCompositeExtract %float %248 1
-OpStore %139 %249
-%250 = OpLoad %ulong %138
-%251 = OpLoad %float %139
-%252 = OpFunctionCall %ulong %5 %250 %251
-OpStore %140 %252
-%253 = OpLoad %v3float %88
-%254 = OpCompositeExtract %float %253 2
-OpStore %141 %254
-%255 = OpLoad %ulong %140
-%256 = OpLoad %float %141
-%257 = OpFunctionCall %ulong %5 %255 %256
-OpStore %142 %257
-OpBranch %57
-%57 = OpLabel
-%258 = OpLoad %v3float %86
-%259 = OpLoad %v3float %83
-%260 = OpFSub %v3float %258 %259
-OpStore %89 %260
-OpBranch %58
-%58 = OpLabel
-%261 = OpLoad %v3float %89
-%262 = OpCompositeExtract %float %261 0
-OpStore %143 %262
-%263 = OpLoad %ulong %142
-%264 = OpLoad %float %143
-%265 = OpFunctionCall %ulong %5 %263 %264
-OpStore %144 %265
-%266 = OpLoad %v3float %89
-%267 = OpCompositeExtract %float %266 1
-OpStore %145 %267
-%268 = OpLoad %ulong %144
-%269 = OpLoad %float %145
-%270 = OpFunctionCall %ulong %5 %268 %269
-OpStore %146 %270
-%271 = OpLoad %v3float %89
-%272 = OpCompositeExtract %float %271 2
-OpStore %147 %272
-%273 = OpLoad %ulong %146
-%274 = OpLoad %float %147
-%275 = OpFunctionCall %ulong %5 %273 %274
-OpStore %148 %275
-OpBranch %59
-%59 = OpLabel
-%276 = OpLoad %v3float %83
-%277 = OpLoad %v3float %86
-%278 = OpFMul %v3float %276 %277
-OpStore %90 %278
-OpBranch %60
-%60 = OpLabel
-%279 = OpLoad %v3float %90
-%280 = OpCompositeExtract %float %279 0
-OpStore %149 %280
-%281 = OpLoad %ulong %148
-%282 = OpLoad %float %149
-%283 = OpFunctionCall %ulong %5 %281 %282
-OpStore %150 %283
-%284 = OpLoad %v3float %90
-%285 = OpCompositeExtract %float %284 1
-OpStore %151 %285
-%286 = OpLoad %ulong %150
-%287 = OpLoad %float %151
-%288 = OpFunctionCall %ulong %5 %286 %287
-OpStore %152 %288
-%289 = OpLoad %v3float %90
-%290 = OpCompositeExtract %float %289 2
-OpStore %153 %290
-%291 = OpLoad %ulong %152
-%292 = OpLoad %float %153
-%293 = OpFunctionCall %ulong %5 %291 %292
-OpStore %154 %293
-OpBranch %61
-%61 = OpLabel
-%294 = OpLoad %v3float %83
-%295 = OpLoad %v3float %86
-%296 = OpFDiv %v3float %294 %295
-OpStore %91 %296
-OpBranch %62
-%62 = OpLabel
-%297 = OpLoad %v3float %91
-%298 = OpCompositeExtract %float %297 0
-OpStore %155 %298
-%299 = OpLoad %ulong %154
-%300 = OpLoad %float %155
-%301 = OpFunctionCall %ulong %5 %299 %300
-OpStore %156 %301
-%302 = OpLoad %v3float %91
-%303 = OpCompositeExtract %float %302 1
-OpStore %157 %303
-%304 = OpLoad %ulong %156
-%305 = OpLoad %float %157
-%306 = OpFunctionCall %ulong %5 %304 %305
-OpStore %158 %306
-%307 = OpLoad %v3float %91
-%308 = OpCompositeExtract %float %307 2
-OpStore %159 %308
-%309 = OpLoad %ulong %158
-%310 = OpLoad %float %159
-%311 = OpFunctionCall %ulong %5 %309 %310
-OpStore %160 %311
-OpBranch %63
-%63 = OpLabel
-OpStore %73 %312
-%314 = OpAccessChain %_ptr_Function_v3float %73 %uint_0
-%315 = OpLoad %v3float %83
-OpStore %314 %315
-%316 = OpLoad %v3float %83
-%317 = OpLoad %v3float %86
-%318 = OpFAdd %v3float %316 %317
-OpStore %92 %318
-%320 = OpAccessChain %_ptr_Function_v3float %73 %uint_1
-%321 = OpLoad %v3float %92
-OpStore %320 %321
-%322 = OpLoad %v3float %83
-%323 = OpLoad %v3float %86
-%324 = OpFMul %v3float %322 %323
-OpStore %93 %324
-%326 = OpAccessChain %_ptr_Function_v3float %73 %uint_2
-%327 = OpLoad %v3float %93
-OpStore %326 %327
-%329 = OpAccessChain %_ptr_Function_v3float %73 %uint_3
-%330 = OpLoad %v3float %86
-OpStore %329 %330
-%331 = OpLoad %ulong %160
-OpStore %105 %331
-OpStore %106 %ulong_0
-OpBranch %43
-%43 = OpLabel
-%333 = OpLoad %ulong %106
-%335 = OpULessThan %bool %333 %ulong_4
-OpStore %95 %335
-%336 = OpLoad %bool %95
-OpLoopMerge %45 %64 None
-OpBranchConditional %336 %44 %45
-%45 = OpLabel
-OpStore %69 %337
-%338 = OpAccessChain %_ptr_Function_uint %69 %uint_0
-OpStore %338 %uint_4294967295
-%340 = OpAccessChain %_ptr_Function_v3float %73 %uint_2
-%341 = OpLoad %v3float %340
-OpStore %98 %341
-%342 = OpAccessChain %_ptr_Function_v3float %69 %uint_1
-%343 = OpLoad %v3float %98
-OpStore %342 %343
-%344 = OpAccessChain %_ptr_Function_uint %69 %uint_2
-OpStore %344 %uint_305419896
-%346 = OpLoad %uint %338
-OpStore %100 %346
-%347 = OpLoad %ulong %105
-%348 = OpLoad %uint %100
-%349 = OpFunctionCall %ulong %4 %347 %348
-OpStore %101 %349
-%350 = OpLoad %v3float %342
-OpStore %102 %350
-OpBranch %50
-%50 = OpLabel
-%351 = OpLoad %v3float %102
-%352 = OpCompositeExtract %float %351 0
-OpStore %119 %352
-%353 = OpLoad %ulong %101
-%354 = OpLoad %float %119
-%355 = OpFunctionCall %ulong %5 %353 %354
-OpStore %120 %355
-%356 = OpLoad %v3float %102
-%357 = OpCompositeExtract %float %356 1
-OpStore %121 %357
-%358 = OpLoad %ulong %120
-%359 = OpLoad %float %121
-%360 = OpFunctionCall %ulong %5 %358 %359
-OpStore %122 %360
-%361 = OpLoad %v3float %102
-%362 = OpCompositeExtract %float %361 2
-OpStore %123 %362
-%363 = OpLoad %ulong %122
-%364 = OpLoad %float %123
-%365 = OpFunctionCall %ulong %5 %363 %364
-OpStore %124 %365
-OpBranch %51
-%51 = OpLabel
-%366 = OpAccessChain %_ptr_Function_uint %69 %uint_2
-%367 = OpLoad %uint %366
-OpStore %103 %367
-%368 = OpLoad %ulong %124
-%369 = OpLoad %uint %103
-%370 = OpFunctionCall %ulong %4 %368 %369
-OpStore %104 %370
-%371 = OpLoad %ulong %104
-OpReturnValue %371
-%44 = OpLabel
-%372 = OpLoad %ulong %106
-%373 = OpAccessChain %_ptr_Function_v3float %73 %372
-%374 = OpLoad %v3float %373
-OpStore %96 %374
-OpBranch %48
-%48 = OpLabel
-%375 = OpLoad %v3float %96
-%376 = OpCompositeExtract %float %375 0
-OpStore %113 %376
-%377 = OpLoad %ulong %105
-%378 = OpLoad %float %113
-%379 = OpFunctionCall %ulong %5 %377 %378
-OpStore %114 %379
-%380 = OpLoad %v3float %96
-%381 = OpCompositeExtract %float %380 1
-OpStore %115 %381
-%382 = OpLoad %ulong %114
-%383 = OpLoad %float %115
-%384 = OpFunctionCall %ulong %5 %382 %383
-OpStore %116 %384
-%385 = OpLoad %v3float %96
-%386 = OpCompositeExtract %float %385 2
-OpStore %117 %386
-%387 = OpLoad %ulong %116
-%388 = OpLoad %float %117
-%389 = OpFunctionCall %ulong %5 %387 %388
-OpStore %118 %389
-OpBranch %49
-%49 = OpLabel
-%390 = OpLoad %ulong %106
-%392 = OpIAdd %ulong %390 %ulong_1
-OpStore %97 %392
-%393 = OpLoad %ulong %118
-OpStore %105 %393
-%394 = OpLoad %ulong %97
-OpStore %106 %394
-OpBranch %64
-%64 = OpLabel
-OpBranch %43
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+OpStore %37 %7
+OpStore %39 %8
+%79 = OpLoad %v3float %39
+%80 = OpCompositeExtract %float %79 0
+OpStore %41 %80
+OpBranch %10
+%10 = OpLabel
+%81 = OpLoad %float %41
+%82 = OpBitcast %uint %81
+OpStore %45 %82
+%83 = OpLoad %uint %45
+%84 = OpUConvert %ulong %83
+OpStore %46 %84
+OpBranch %12
+%12 = OpLabel
+%85 = OpLoad %ulong %37
+OpStore %55 %85
+OpStore %56 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%87 = OpLoad %ulong %56
+%89 = OpULessThan %bool %87 %ulong_8
+OpStore %48 %89
+%90 = OpLoad %bool %48
+OpLoopMerge %15 %33 None
+OpBranchConditional %90 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%91 = OpLoad %v3float %39
+%92 = OpCompositeExtract %float %91 1
+OpStore %42 %92
+OpBranch %17
+%17 = OpLabel
+%93 = OpLoad %float %42
+%94 = OpBitcast %uint %93
+OpStore %57 %94
+%95 = OpLoad %uint %57
+%96 = OpUConvert %ulong %95
+OpStore %58 %96
+OpBranch %19
+%19 = OpLabel
+%97 = OpLoad %ulong %55
+OpStore %66 %97
+OpStore %67 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%98 = OpLoad %ulong %67
+%99 = OpULessThan %bool %98 %ulong_8
+OpStore %59 %99
+%100 = OpLoad %bool %59
+OpLoopMerge %22 %32 None
+OpBranchConditional %100 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%101 = OpLoad %v3float %39
+%102 = OpCompositeExtract %float %101 2
+OpStore %43 %102
+OpBranch %24
+%24 = OpLabel
+%103 = OpLoad %float %43
+%104 = OpBitcast %uint %103
+OpStore %68 %104
+%105 = OpLoad %uint %68
+%106 = OpUConvert %ulong %105
+OpStore %69 %106
+OpBranch %26
+%26 = OpLabel
+%107 = OpLoad %ulong %66
+OpStore %77 %107
+OpStore %78 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%108 = OpLoad %ulong %78
+%109 = OpULessThan %bool %108 %ulong_8
+OpStore %70 %109
+%110 = OpLoad %bool %70
+OpLoopMerge %29 %31 None
+OpBranchConditional %110 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%111 = OpLoad %ulong %77
+OpReturnValue %111
+%28 = OpLabel
+%112 = OpLoad %ulong %78
+%113 = OpIMul %ulong %112 %ulong_8
+OpStore %71 %113
+%114 = OpLoad %ulong %69
+%115 = OpLoad %ulong %71
+%116 = OpShiftRightLogical %ulong %114 %115
+OpStore %72 %116
+%117 = OpLoad %ulong %72
+%119 = OpBitwiseAnd %ulong %117 %ulong_255
+OpStore %73 %119
+%120 = OpLoad %ulong %77
+%121 = OpLoad %ulong %73
+%122 = OpBitwiseXor %ulong %120 %121
+OpStore %74 %122
+%123 = OpLoad %ulong %74
+%125 = OpIMul %ulong %123 %ulong_1099511628211
+OpStore %75 %125
+%126 = OpLoad %ulong %78
+%128 = OpIAdd %ulong %126 %ulong_1
+OpStore %76 %128
+%129 = OpLoad %ulong %75
+OpStore %77 %129
+%130 = OpLoad %ulong %76
+OpStore %78 %130
+OpBranch %31
+%21 = OpLabel
+%131 = OpLoad %ulong %67
+%132 = OpIMul %ulong %131 %ulong_8
+OpStore %60 %132
+%133 = OpLoad %ulong %58
+%134 = OpLoad %ulong %60
+%135 = OpShiftRightLogical %ulong %133 %134
+OpStore %61 %135
+%136 = OpLoad %ulong %61
+%137 = OpBitwiseAnd %ulong %136 %ulong_255
+OpStore %62 %137
+%138 = OpLoad %ulong %66
+%139 = OpLoad %ulong %62
+%140 = OpBitwiseXor %ulong %138 %139
+OpStore %63 %140
+%141 = OpLoad %ulong %63
+%142 = OpIMul %ulong %141 %ulong_1099511628211
+OpStore %64 %142
+%143 = OpLoad %ulong %67
+%144 = OpIAdd %ulong %143 %ulong_1
+OpStore %65 %144
+%145 = OpLoad %ulong %64
+OpStore %66 %145
+%146 = OpLoad %ulong %65
+OpStore %67 %146
+OpBranch %32
+%14 = OpLabel
+%147 = OpLoad %ulong %56
+%148 = OpIMul %ulong %147 %ulong_8
+OpStore %49 %148
+%149 = OpLoad %ulong %46
+%150 = OpLoad %ulong %49
+%151 = OpShiftRightLogical %ulong %149 %150
+OpStore %50 %151
+%152 = OpLoad %ulong %50
+%153 = OpBitwiseAnd %ulong %152 %ulong_255
+OpStore %51 %153
+%154 = OpLoad %ulong %55
+%155 = OpLoad %ulong %51
+%156 = OpBitwiseXor %ulong %154 %155
+OpStore %52 %156
+%157 = OpLoad %ulong %52
+%158 = OpIMul %ulong %157 %ulong_1099511628211
+OpStore %53 %158
+%159 = OpLoad %ulong %56
+%160 = OpIAdd %ulong %159 %ulong_1
+OpStore %54 %160
+%161 = OpLoad %ulong %53
+OpStore %55 %161
+%162 = OpLoad %ulong %54
+OpStore %56 %162
+OpBranch %33
+%31 = OpLabel
+OpBranch %27
+%32 = OpLabel
+OpBranch %20
+%33 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%3 = OpFunction %ulong None %395
-%396 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %398
-%399 = OpFunctionParameter %ulong
-%400 = OpFunctionParameter %uint
-%401 = OpLabel
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_uint Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_bool Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_ulong Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_ulong Function
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_ulong Function
-OpStore %408 %399
-OpStore %409 %400
-%420 = OpLoad %uint %409
-%421 = OpUConvert %ulong %420
-OpStore %410 %421
-OpBranch %402
-%402 = OpLabel
-%422 = OpLoad %ulong %408
-OpStore %418 %422
-OpStore %419 %ulong_0
-OpBranch %403
-%403 = OpLabel
-%423 = OpLoad %ulong %419
-%425 = OpULessThan %bool %423 %ulong_8
-OpStore %411 %425
-%426 = OpLoad %bool %411
-OpLoopMerge %405 %407 None
-OpBranchConditional %426 %404 %405
-%405 = OpLabel
-OpBranch %406
-%406 = OpLabel
-%427 = OpLoad %ulong %418
-OpReturnValue %427
-%404 = OpLabel
-%428 = OpLoad %ulong %419
-%429 = OpIMul %ulong %428 %ulong_8
-OpStore %412 %429
-%430 = OpLoad %ulong %410
-%431 = OpLoad %ulong %412
-%432 = OpShiftRightLogical %ulong %430 %431
-OpStore %413 %432
-%433 = OpLoad %ulong %413
-%435 = OpBitwiseAnd %ulong %433 %ulong_255
-OpStore %414 %435
-%436 = OpLoad %ulong %418
-%437 = OpLoad %ulong %414
-%438 = OpBitwiseXor %ulong %436 %437
-OpStore %415 %438
-%439 = OpLoad %ulong %415
-%441 = OpIMul %ulong %439 %ulong_1099511628211
-OpStore %416 %441
-%442 = OpLoad %ulong %419
-%443 = OpIAdd %ulong %442 %ulong_1
-OpStore %417 %443
-%444 = OpLoad %ulong %416
-OpStore %418 %444
-%445 = OpLoad %ulong %417
-OpStore %419 %445
-OpBranch %407
-%407 = OpLabel
-OpBranch %403
-OpFunctionEnd
-%5 = OpFunction %ulong None %446
-%447 = OpFunctionParameter %ulong
-%448 = OpFunctionParameter %float
-%449 = OpLabel
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_float Function
-%458 = OpVariable %_ptr_Function_uint Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_bool Function
-%461 = OpVariable %_ptr_Function_ulong Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
-OpStore %456 %447
-OpStore %457 %448
-%469 = OpLoad %float %457
-%470 = OpBitcast %uint %469
-OpStore %458 %470
-%471 = OpLoad %uint %458
-%472 = OpUConvert %ulong %471
-OpStore %459 %472
-OpBranch %450
-%450 = OpLabel
-%473 = OpLoad %ulong %456
-OpStore %467 %473
-OpStore %468 %ulong_0
-OpBranch %451
-%451 = OpLabel
-%474 = OpLoad %ulong %468
-%475 = OpULessThan %bool %474 %ulong_8
-OpStore %460 %475
-%476 = OpLoad %bool %460
-OpLoopMerge %453 %455 None
-OpBranchConditional %476 %452 %453
-%453 = OpLabel
-OpBranch %454
-%454 = OpLabel
-%477 = OpLoad %ulong %467
-OpReturnValue %477
-%452 = OpLabel
-%478 = OpLoad %ulong %468
-%479 = OpIMul %ulong %478 %ulong_8
-OpStore %461 %479
-%480 = OpLoad %ulong %459
-%481 = OpLoad %ulong %461
-%482 = OpShiftRightLogical %ulong %480 %481
-OpStore %462 %482
-%483 = OpLoad %ulong %462
-%484 = OpBitwiseAnd %ulong %483 %ulong_255
-OpStore %463 %484
-%485 = OpLoad %ulong %467
-%486 = OpLoad %ulong %463
-%487 = OpBitwiseXor %ulong %485 %486
-OpStore %464 %487
-%488 = OpLoad %ulong %464
-%489 = OpIMul %ulong %488 %ulong_1099511628211
-OpStore %465 %489
-%490 = OpLoad %ulong %468
-%491 = OpIAdd %ulong %490 %ulong_1
-OpStore %466 %491
-%492 = OpLoad %ulong %465
-OpStore %467 %492
-%493 = OpLoad %ulong %466
-OpStore %468 %493
-OpBranch %455
-%455 = OpLabel
-OpBranch %451
+%2 = OpFunction %ulong None %163
+%164 = OpFunctionParameter %ulong
+%165 = OpLabel
+%190 = OpVariable %_ptr_Function__struct_188 Function
+%194 = OpVariable %_ptr_Function__arr_v3float_uint_4 Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_float Function
+%197 = OpVariable %_ptr_Function_float Function
+%198 = OpVariable %_ptr_Function_v3float Function
+%199 = OpVariable %_ptr_Function_float Function
+%200 = OpVariable %_ptr_Function_v3float Function
+%201 = OpVariable %_ptr_Function_float Function
+%202 = OpVariable %_ptr_Function_float Function
+%203 = OpVariable %_ptr_Function_v3float Function
+%204 = OpVariable %_ptr_Function_float Function
+%205 = OpVariable %_ptr_Function_float Function
+%206 = OpVariable %_ptr_Function_v3float Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_v3float Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_v3float Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_v3float Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_v3float Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_v3float Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_bool Function
+%220 = OpVariable %_ptr_Function_v3float Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_v3float Function
+%224 = OpVariable %_ptr_Function_uint Function
+%225 = OpVariable %_ptr_Function_v3float Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_uint Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_bool Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_ulong Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_bool Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+OpStore %195 %164
+OpBranch %169
+%169 = OpLabel
+OpBranch %170
+%170 = OpLabel
+%250 = OpLoad %ulong %195
+%251 = OpConvertUToF %float %250
+OpStore %196 %251
+%253 = OpFNegate %float %float_2_25
+OpStore %197 %253
+%256 = OpLoad %float %197
+%254 = OpCompositeConstruct %v3float %float_1_5 %256 %float_3_75
+OpStore %198 %254
+%259 = OpFNegate %float %float_0_125
+OpStore %199 %259
+%263 = OpLoad %float %199
+%260 = OpCompositeConstruct %v3float %float_0_5 %float_4 %263
+OpStore %200 %260
+%264 = OpLoad %v3float %198
+%265 = OpCompositeExtract %float %264 0
+OpStore %201 %265
+%266 = OpLoad %float %201
+%267 = OpLoad %float %196
+%268 = OpFAdd %float %266 %267
+OpStore %202 %268
+%269 = OpLoad %v3float %198
+%270 = OpLoad %float %202
+%271 = OpCompositeInsert %v3float %270 %269 0
+OpStore %203 %271
+%272 = OpLoad %v3float %200
+%273 = OpCompositeExtract %float %272 2
+OpStore %204 %273
+%274 = OpLoad %float %204
+%275 = OpLoad %float %196
+%276 = OpFAdd %float %274 %275
+OpStore %205 %276
+%277 = OpLoad %v3float %200
+%278 = OpLoad %float %205
+%279 = OpCompositeInsert %v3float %278 %277 2
+OpStore %206 %279
+%281 = OpLoad %v3float %203
+%282 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %281
+OpStore %207 %282
+%283 = OpLoad %ulong %207
+%284 = OpLoad %v3float %206
+%285 = OpFunctionCall %ulong %1 %283 %284
+OpStore %208 %285
+%286 = OpLoad %v3float %203
+%287 = OpLoad %v3float %206
+%288 = OpFAdd %v3float %286 %287
+OpStore %209 %288
+%289 = OpLoad %ulong %208
+%290 = OpLoad %v3float %209
+%291 = OpFunctionCall %ulong %1 %289 %290
+OpStore %210 %291
+%292 = OpLoad %v3float %203
+%293 = OpLoad %v3float %206
+%294 = OpFSub %v3float %292 %293
+OpStore %211 %294
+%295 = OpLoad %ulong %210
+%296 = OpLoad %v3float %211
+%297 = OpFunctionCall %ulong %1 %295 %296
+OpStore %212 %297
+%298 = OpLoad %v3float %206
+%299 = OpLoad %v3float %203
+%300 = OpFSub %v3float %298 %299
+OpStore %213 %300
+%301 = OpLoad %ulong %212
+%302 = OpLoad %v3float %213
+%303 = OpFunctionCall %ulong %1 %301 %302
+OpStore %214 %303
+%304 = OpLoad %v3float %203
+%305 = OpLoad %v3float %206
+%306 = OpFMul %v3float %304 %305
+OpStore %215 %306
+%307 = OpLoad %ulong %214
+%308 = OpLoad %v3float %215
+%309 = OpFunctionCall %ulong %1 %307 %308
+OpStore %216 %309
+%310 = OpLoad %v3float %203
+%311 = OpLoad %v3float %206
+%312 = OpFDiv %v3float %310 %311
+OpStore %217 %312
+%313 = OpLoad %ulong %216
+%314 = OpLoad %v3float %217
+%315 = OpFunctionCall %ulong %1 %313 %314
+OpStore %218 %315
+OpStore %194 %316
+%318 = OpAccessChain %_ptr_Function_v3float %194 %uint_0
+%319 = OpLoad %v3float %203
+OpStore %318 %319
+%321 = OpAccessChain %_ptr_Function_v3float %194 %uint_1
+%322 = OpLoad %v3float %209
+OpStore %321 %322
+%324 = OpAccessChain %_ptr_Function_v3float %194 %uint_2
+%325 = OpLoad %v3float %215
+OpStore %324 %325
+%327 = OpAccessChain %_ptr_Function_v3float %194 %uint_3
+%328 = OpLoad %v3float %206
+OpStore %327 %328
+%329 = OpLoad %ulong %218
+OpStore %228 %329
+OpStore %229 %ulong_0
+OpBranch %166
+%166 = OpLabel
+%330 = OpLoad %ulong %229
+%332 = OpULessThan %bool %330 %ulong_4
+OpStore %219 %332
+%333 = OpLoad %bool %219
+OpLoopMerge %168 %187 None
+OpBranchConditional %333 %167 %168
+%168 = OpLabel
+OpStore %190 %334
+%335 = OpAccessChain %_ptr_Function_uint %190 %uint_0
+OpStore %335 %uint_4294967295
+%337 = OpAccessChain %_ptr_Function_v3float %194 %uint_2
+%338 = OpLoad %v3float %337
+OpStore %223 %338
+%339 = OpAccessChain %_ptr_Function_v3float %190 %uint_1
+%340 = OpLoad %v3float %223
+OpStore %339 %340
+%341 = OpAccessChain %_ptr_Function_uint %190 %uint_2
+OpStore %341 %uint_305419896
+%343 = OpLoad %uint %335
+OpStore %224 %343
+OpBranch %171
+%171 = OpLabel
+%344 = OpLoad %uint %224
+%345 = OpUConvert %ulong %344
+OpStore %230 %345
+OpBranch %173
+%173 = OpLabel
+%346 = OpLoad %ulong %228
+OpStore %238 %346
+OpStore %239 %ulong_0
+OpBranch %174
+%174 = OpLabel
+%347 = OpLoad %ulong %239
+%348 = OpULessThan %bool %347 %ulong_8
+OpStore %231 %348
+%349 = OpLoad %bool %231
+OpLoopMerge %176 %186 None
+OpBranchConditional %349 %175 %176
+%176 = OpLabel
+OpBranch %177
+%177 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%350 = OpAccessChain %_ptr_Function_v3float %190 %uint_1
+%351 = OpLoad %v3float %350
+OpStore %225 %351
+%352 = OpLoad %ulong %238
+%353 = OpLoad %v3float %225
+%354 = OpFunctionCall %ulong %1 %352 %353
+OpStore %226 %354
+%355 = OpAccessChain %_ptr_Function_uint %190 %uint_2
+%356 = OpLoad %uint %355
+OpStore %227 %356
+OpBranch %178
+%178 = OpLabel
+%357 = OpLoad %uint %227
+%358 = OpUConvert %ulong %357
+OpStore %240 %358
+OpBranch %180
+%180 = OpLabel
+%359 = OpLoad %ulong %226
+OpStore %248 %359
+OpStore %249 %ulong_0
+OpBranch %181
+%181 = OpLabel
+%360 = OpLoad %ulong %249
+%361 = OpULessThan %bool %360 %ulong_8
+OpStore %241 %361
+%362 = OpLoad %bool %241
+OpLoopMerge %183 %185 None
+OpBranchConditional %362 %182 %183
+%183 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %179
+%179 = OpLabel
+%363 = OpLoad %ulong %248
+OpReturnValue %363
+%182 = OpLabel
+%364 = OpLoad %ulong %249
+%365 = OpIMul %ulong %364 %ulong_8
+OpStore %242 %365
+%366 = OpLoad %ulong %240
+%367 = OpLoad %ulong %242
+%368 = OpShiftRightLogical %ulong %366 %367
+OpStore %243 %368
+%369 = OpLoad %ulong %243
+%370 = OpBitwiseAnd %ulong %369 %ulong_255
+OpStore %244 %370
+%371 = OpLoad %ulong %248
+%372 = OpLoad %ulong %244
+%373 = OpBitwiseXor %ulong %371 %372
+OpStore %245 %373
+%374 = OpLoad %ulong %245
+%375 = OpIMul %ulong %374 %ulong_1099511628211
+OpStore %246 %375
+%376 = OpLoad %ulong %249
+%377 = OpIAdd %ulong %376 %ulong_1
+OpStore %247 %377
+%378 = OpLoad %ulong %246
+OpStore %248 %378
+%379 = OpLoad %ulong %247
+OpStore %249 %379
+OpBranch %185
+%175 = OpLabel
+%380 = OpLoad %ulong %239
+%381 = OpIMul %ulong %380 %ulong_8
+OpStore %232 %381
+%382 = OpLoad %ulong %230
+%383 = OpLoad %ulong %232
+%384 = OpShiftRightLogical %ulong %382 %383
+OpStore %233 %384
+%385 = OpLoad %ulong %233
+%386 = OpBitwiseAnd %ulong %385 %ulong_255
+OpStore %234 %386
+%387 = OpLoad %ulong %238
+%388 = OpLoad %ulong %234
+%389 = OpBitwiseXor %ulong %387 %388
+OpStore %235 %389
+%390 = OpLoad %ulong %235
+%391 = OpIMul %ulong %390 %ulong_1099511628211
+OpStore %236 %391
+%392 = OpLoad %ulong %239
+%393 = OpIAdd %ulong %392 %ulong_1
+OpStore %237 %393
+%394 = OpLoad %ulong %236
+OpStore %238 %394
+%395 = OpLoad %ulong %237
+OpStore %239 %395
+OpBranch %186
+%167 = OpLabel
+%396 = OpLoad %ulong %229
+%397 = OpAccessChain %_ptr_Function_v3float %194 %396
+%398 = OpLoad %v3float %397
+OpStore %220 %398
+%399 = OpLoad %ulong %228
+%400 = OpLoad %v3float %220
+%401 = OpFunctionCall %ulong %1 %399 %400
+OpStore %221 %401
+%402 = OpLoad %ulong %229
+%403 = OpIAdd %ulong %402 %ulong_1
+OpStore %222 %403
+%404 = OpLoad %ulong %221
+OpStore %228 %404
+%405 = OpLoad %ulong %222
+OpStore %229 %405
+OpBranch %187
+%185 = OpLabel
+OpBranch %181
+%186 = OpLabel
+OpBranch %174
+%187 = OpLabel
+OpBranch %166
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f32x4.dis
+++ b/test/golden/spirv/vec/vec_f32x4.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 860
+; Bound: 574
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,20 +12,25 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x4.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v4float = OpTypeVector %float 4
-%9 = OpTypeFunction %ulong %ulong %v4float
+%6 = OpTypeFunction %ulong %ulong %v4float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_float = OpTypePointer Function %float
-%47 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
-%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%209 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr_v4float_uint_4 = OpTypeArray %v4float %uint_4
 %_ptr_Function__arr_v4float_uint_4 = OpTypePointer Function %_arr_v4float_uint_4
-%_struct_96 = OpTypeStruct %uint %v4float %uint
-%_ptr_Function__struct_96 = OpTypePointer Function %_struct_96
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
+%_struct_242 = OpTypeStruct %uint %v4float %uint
+%_ptr_Function__struct_242 = OpTypePointer Function %_struct_242
 %float_2_25 = OpConstant %float 2.25
 %float_0_5 = OpConstant %float 0.5
 %float_1_5 = OpConstant %float 1.5
@@ -37,1135 +42,776 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x4.checksum" Export
 %float_3 = OpConstant %float 3
 %float_9 = OpConstant %float 9
 %float_27 = OpConstant %float 27
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%594 = OpConstantNull %_arr_v4float_uint_4
+%454 = OpConstantNull %_arr_v4float_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%618 = OpConstantNull %_struct_96
+%478 = OpConstantNull %_struct_242
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%761 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%764 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%812 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v4float
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v4float
+%9 = OpLabel
+%45 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_v4float Function
+%49 = OpVariable %_ptr_Function_float Function
+%50 = OpVariable %_ptr_Function_float Function
+%51 = OpVariable %_ptr_Function_float Function
+%52 = OpVariable %_ptr_Function_float Function
+%54 = OpVariable %_ptr_Function_uint Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_bool Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_uint Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_bool Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_uint Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_bool Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_uint Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_bool Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+OpStore %45 %7
+OpStore %47 %8
+%99 = OpLoad %v4float %47
+%100 = OpCompositeExtract %float %99 0
+OpStore %49 %100
+OpBranch %10
+%10 = OpLabel
+%101 = OpLoad %float %49
+%102 = OpBitcast %uint %101
+OpStore %54 %102
+%103 = OpLoad %uint %54
+%104 = OpUConvert %ulong %103
+OpStore %55 %104
+OpBranch %12
 %12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v4float Function
-%18 = OpVariable %_ptr_Function_float Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_float Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%26 = OpLoad %v4float %16
-%27 = OpCompositeExtract %float %26 0
-OpStore %18 %27
-%28 = OpLoad %ulong %14
-%29 = OpLoad %float %18
-%30 = OpFunctionCall %ulong %5 %28 %29
-OpStore %19 %30
-%31 = OpLoad %v4float %16
-%32 = OpCompositeExtract %float %31 1
-OpStore %20 %32
-%33 = OpLoad %ulong %19
-%34 = OpLoad %float %20
-%35 = OpFunctionCall %ulong %5 %33 %34
-OpStore %21 %35
-%36 = OpLoad %v4float %16
-%37 = OpCompositeExtract %float %36 2
-OpStore %22 %37
-%38 = OpLoad %ulong %21
-%39 = OpLoad %float %22
-%40 = OpFunctionCall %ulong %5 %38 %39
-OpStore %23 %40
-%41 = OpLoad %v4float %16
-%42 = OpCompositeExtract %float %41 3
-OpStore %24 %42
-%43 = OpLoad %ulong %23
-%44 = OpLoad %float %24
-%45 = OpFunctionCall %ulong %5 %43 %44
-OpStore %25 %45
-%46 = OpLoad %ulong %25
-OpReturnValue %46
+%105 = OpLoad %ulong %45
+OpStore %64 %105
+OpStore %65 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%107 = OpLoad %ulong %65
+%109 = OpULessThan %bool %107 %ulong_8
+OpStore %57 %109
+%110 = OpLoad %bool %57
+OpLoopMerge %15 %41 None
+OpBranchConditional %110 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%111 = OpLoad %v4float %47
+%112 = OpCompositeExtract %float %111 1
+OpStore %50 %112
+OpBranch %17
+%17 = OpLabel
+%113 = OpLoad %float %50
+%114 = OpBitcast %uint %113
+OpStore %66 %114
+%115 = OpLoad %uint %66
+%116 = OpUConvert %ulong %115
+OpStore %67 %116
+OpBranch %19
+%19 = OpLabel
+%117 = OpLoad %ulong %64
+OpStore %75 %117
+OpStore %76 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%118 = OpLoad %ulong %76
+%119 = OpULessThan %bool %118 %ulong_8
+OpStore %68 %119
+%120 = OpLoad %bool %68
+OpLoopMerge %22 %40 None
+OpBranchConditional %120 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%121 = OpLoad %v4float %47
+%122 = OpCompositeExtract %float %121 2
+OpStore %51 %122
+OpBranch %24
+%24 = OpLabel
+%123 = OpLoad %float %51
+%124 = OpBitcast %uint %123
+OpStore %77 %124
+%125 = OpLoad %uint %77
+%126 = OpUConvert %ulong %125
+OpStore %78 %126
+OpBranch %26
+%26 = OpLabel
+%127 = OpLoad %ulong %75
+OpStore %86 %127
+OpStore %87 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%128 = OpLoad %ulong %87
+%129 = OpULessThan %bool %128 %ulong_8
+OpStore %79 %129
+%130 = OpLoad %bool %79
+OpLoopMerge %29 %39 None
+OpBranchConditional %130 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%131 = OpLoad %v4float %47
+%132 = OpCompositeExtract %float %131 3
+OpStore %52 %132
+OpBranch %31
+%31 = OpLabel
+%133 = OpLoad %float %52
+%134 = OpBitcast %uint %133
+OpStore %88 %134
+%135 = OpLoad %uint %88
+%136 = OpUConvert %ulong %135
+OpStore %89 %136
+OpBranch %33
+%33 = OpLabel
+%137 = OpLoad %ulong %86
+OpStore %97 %137
+OpStore %98 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%138 = OpLoad %ulong %98
+%139 = OpULessThan %bool %138 %ulong_8
+OpStore %90 %139
+%140 = OpLoad %bool %90
+OpLoopMerge %36 %38 None
+OpBranchConditional %140 %35 %36
+%36 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%141 = OpLoad %ulong %97
+OpReturnValue %141
+%35 = OpLabel
+%142 = OpLoad %ulong %98
+%143 = OpIMul %ulong %142 %ulong_8
+OpStore %91 %143
+%144 = OpLoad %ulong %89
+%145 = OpLoad %ulong %91
+%146 = OpShiftRightLogical %ulong %144 %145
+OpStore %92 %146
+%147 = OpLoad %ulong %92
+%149 = OpBitwiseAnd %ulong %147 %ulong_255
+OpStore %93 %149
+%150 = OpLoad %ulong %97
+%151 = OpLoad %ulong %93
+%152 = OpBitwiseXor %ulong %150 %151
+OpStore %94 %152
+%153 = OpLoad %ulong %94
+%155 = OpIMul %ulong %153 %ulong_1099511628211
+OpStore %95 %155
+%156 = OpLoad %ulong %98
+%158 = OpIAdd %ulong %156 %ulong_1
+OpStore %96 %158
+%159 = OpLoad %ulong %95
+OpStore %97 %159
+%160 = OpLoad %ulong %96
+OpStore %98 %160
+OpBranch %38
+%28 = OpLabel
+%161 = OpLoad %ulong %87
+%162 = OpIMul %ulong %161 %ulong_8
+OpStore %80 %162
+%163 = OpLoad %ulong %78
+%164 = OpLoad %ulong %80
+%165 = OpShiftRightLogical %ulong %163 %164
+OpStore %81 %165
+%166 = OpLoad %ulong %81
+%167 = OpBitwiseAnd %ulong %166 %ulong_255
+OpStore %82 %167
+%168 = OpLoad %ulong %86
+%169 = OpLoad %ulong %82
+%170 = OpBitwiseXor %ulong %168 %169
+OpStore %83 %170
+%171 = OpLoad %ulong %83
+%172 = OpIMul %ulong %171 %ulong_1099511628211
+OpStore %84 %172
+%173 = OpLoad %ulong %87
+%174 = OpIAdd %ulong %173 %ulong_1
+OpStore %85 %174
+%175 = OpLoad %ulong %84
+OpStore %86 %175
+%176 = OpLoad %ulong %85
+OpStore %87 %176
+OpBranch %39
+%21 = OpLabel
+%177 = OpLoad %ulong %76
+%178 = OpIMul %ulong %177 %ulong_8
+OpStore %69 %178
+%179 = OpLoad %ulong %67
+%180 = OpLoad %ulong %69
+%181 = OpShiftRightLogical %ulong %179 %180
+OpStore %70 %181
+%182 = OpLoad %ulong %70
+%183 = OpBitwiseAnd %ulong %182 %ulong_255
+OpStore %71 %183
+%184 = OpLoad %ulong %75
+%185 = OpLoad %ulong %71
+%186 = OpBitwiseXor %ulong %184 %185
+OpStore %72 %186
+%187 = OpLoad %ulong %72
+%188 = OpIMul %ulong %187 %ulong_1099511628211
+OpStore %73 %188
+%189 = OpLoad %ulong %76
+%190 = OpIAdd %ulong %189 %ulong_1
+OpStore %74 %190
+%191 = OpLoad %ulong %73
+OpStore %75 %191
+%192 = OpLoad %ulong %74
+OpStore %76 %192
+OpBranch %40
+%14 = OpLabel
+%193 = OpLoad %ulong %65
+%194 = OpIMul %ulong %193 %ulong_8
+OpStore %58 %194
+%195 = OpLoad %ulong %55
+%196 = OpLoad %ulong %58
+%197 = OpShiftRightLogical %ulong %195 %196
+OpStore %59 %197
+%198 = OpLoad %ulong %59
+%199 = OpBitwiseAnd %ulong %198 %ulong_255
+OpStore %60 %199
+%200 = OpLoad %ulong %64
+%201 = OpLoad %ulong %60
+%202 = OpBitwiseXor %ulong %200 %201
+OpStore %61 %202
+%203 = OpLoad %ulong %61
+%204 = OpIMul %ulong %203 %ulong_1099511628211
+OpStore %62 %204
+%205 = OpLoad %ulong %65
+%206 = OpIAdd %ulong %205 %ulong_1
+OpStore %63 %206
+%207 = OpLoad %ulong %62
+OpStore %64 %207
+%208 = OpLoad %ulong %63
+OpStore %65 %208
+OpBranch %41
+%38 = OpLabel
+OpBranch %34
+%39 = OpLabel
+OpBranch %27
+%40 = OpLabel
+OpBranch %20
+%41 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %47
-%48 = OpFunctionParameter %ulong
-%49 = OpLabel
-%95 = OpVariable %_ptr_Function__arr_v4float_uint_4 Function
-%98 = OpVariable %_ptr_Function__struct_96 Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_ulong Function
-%101 = OpVariable %_ptr_Function_float Function
-%102 = OpVariable %_ptr_Function_float Function
-%103 = OpVariable %_ptr_Function_float Function
-%104 = OpVariable %_ptr_Function_v4float Function
-%105 = OpVariable %_ptr_Function_float Function
-%106 = OpVariable %_ptr_Function_v4float Function
-%107 = OpVariable %_ptr_Function_v4float Function
-%108 = OpVariable %_ptr_Function_float Function
-%109 = OpVariable %_ptr_Function_float Function
-%110 = OpVariable %_ptr_Function_v4float Function
-%111 = OpVariable %_ptr_Function_float Function
-%112 = OpVariable %_ptr_Function_float Function
-%113 = OpVariable %_ptr_Function_v4float Function
-%114 = OpVariable %_ptr_Function_float Function
-%115 = OpVariable %_ptr_Function_float Function
-%116 = OpVariable %_ptr_Function_v4float Function
-%117 = OpVariable %_ptr_Function_float Function
-%118 = OpVariable %_ptr_Function_float Function
-%119 = OpVariable %_ptr_Function_v4float Function
-%120 = OpVariable %_ptr_Function_v4float Function
-%121 = OpVariable %_ptr_Function_v4float Function
-%122 = OpVariable %_ptr_Function_v4float Function
-%123 = OpVariable %_ptr_Function_v4float Function
-%124 = OpVariable %_ptr_Function_v4float Function
-%125 = OpVariable %_ptr_Function_v4float Function
-%126 = OpVariable %_ptr_Function_v4float Function
-%127 = OpVariable %_ptr_Function_v4float Function
-%128 = OpVariable %_ptr_Function_v4float Function
-%129 = OpVariable %_ptr_Function_v4float Function
-%131 = OpVariable %_ptr_Function_bool Function
-%132 = OpVariable %_ptr_Function_v4float Function
-%133 = OpVariable %_ptr_Function_v4float Function
-%134 = OpVariable %_ptr_Function_v4float Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_v4float Function
-%137 = OpVariable %_ptr_Function_v4float Function
-%138 = OpVariable %_ptr_Function_bool Function
-%139 = OpVariable %_ptr_Function_v4float Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_v4float Function
-%143 = OpVariable %_ptr_Function_uint Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_v4float Function
-%146 = OpVariable %_ptr_Function_uint Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_v4float Function
-%151 = OpVariable %_ptr_Function_v4float Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_float Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_float Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_float Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_float Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_float Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_float Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_float Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_float Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_float Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_float Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_float Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_float Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_float Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_float Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_float Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_float Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_float Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_float Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_float Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_float Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_float Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_float Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_float Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_float Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_float Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_float Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_float Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_float Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_float Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_float Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_float Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_float Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_float Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_float Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_float Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_float Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_float Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_float Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_float Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_float Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_float Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_float Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_float Function
+%2 = OpFunction %ulong None %209
+%210 = OpFunctionParameter %ulong
+%211 = OpLabel
+%241 = OpVariable %_ptr_Function__arr_v4float_uint_4 Function
+%244 = OpVariable %_ptr_Function__struct_242 Function
 %245 = OpVariable %_ptr_Function_ulong Function
 %246 = OpVariable %_ptr_Function_float Function
-%247 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_float Function
 %248 = OpVariable %_ptr_Function_float Function
-%249 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_v4float Function
 %250 = OpVariable %_ptr_Function_float Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_float Function
-%253 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_v4float Function
+%252 = OpVariable %_ptr_Function_v4float Function
+%253 = OpVariable %_ptr_Function_float Function
 %254 = OpVariable %_ptr_Function_float Function
-%255 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_v4float Function
 %256 = OpVariable %_ptr_Function_float Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_float Function
-%259 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_float Function
+%258 = OpVariable %_ptr_Function_v4float Function
+%259 = OpVariable %_ptr_Function_float Function
 %260 = OpVariable %_ptr_Function_float Function
-%261 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_v4float Function
 %262 = OpVariable %_ptr_Function_float Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_float Function
+%263 = OpVariable %_ptr_Function_float Function
+%264 = OpVariable %_ptr_Function_v4float Function
 %265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_float Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_float Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_float Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_float Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_float Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_float Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_float Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_float Function
-%281 = OpVariable %_ptr_Function_ulong Function
-OpStore %99 %48
-%282 = OpFunctionCall %ulong %3
-OpStore %100 %282
-%283 = OpLoad %ulong %99
-%284 = OpConvertUToF %float %283
-OpStore %101 %284
-%286 = OpFNegate %float %float_2_25
-OpStore %102 %286
-%288 = OpFNegate %float %float_0_5
-OpStore %103 %288
-%291 = OpLoad %float %102
-%293 = OpLoad %float %103
-%289 = OpCompositeConstruct %v4float %float_1_5 %291 %float_3_75 %293
-OpStore %104 %289
-%295 = OpFNegate %float %float_0_125
-OpStore %105 %295
-%298 = OpLoad %float %105
-%296 = OpCompositeConstruct %v4float %float_0_5 %float_4 %298 %float_8
-OpStore %106 %296
-%300 = OpCompositeConstruct %v4float %float_1 %float_3 %float_9 %float_27
-OpStore %107 %300
-%305 = OpLoad %v4float %104
-%306 = OpCompositeExtract %float %305 0
-OpStore %108 %306
-%307 = OpLoad %float %108
-%308 = OpLoad %float %101
-%309 = OpFAdd %float %307 %308
-OpStore %109 %309
-%310 = OpLoad %v4float %104
-%311 = OpLoad %float %109
-%312 = OpCompositeInsert %v4float %311 %310 0
-OpStore %110 %312
-%313 = OpLoad %v4float %110
-%314 = OpCompositeExtract %float %313 3
-OpStore %111 %314
-%315 = OpLoad %float %111
-%316 = OpLoad %float %101
-%317 = OpFAdd %float %315 %316
-OpStore %112 %317
-%318 = OpLoad %v4float %110
-%319 = OpLoad %float %112
-%320 = OpCompositeInsert %v4float %319 %318 3
-OpStore %113 %320
-%321 = OpLoad %v4float %106
-%322 = OpCompositeExtract %float %321 1
-OpStore %114 %322
-%323 = OpLoad %float %114
-%324 = OpLoad %float %101
-%325 = OpFAdd %float %323 %324
-OpStore %115 %325
-%326 = OpLoad %v4float %106
-%327 = OpLoad %float %115
-%328 = OpCompositeInsert %v4float %327 %326 1
-OpStore %116 %328
-%329 = OpLoad %v4float %116
-%330 = OpCompositeExtract %float %329 2
-OpStore %117 %330
-%331 = OpLoad %float %117
-%332 = OpLoad %float %101
-%333 = OpFAdd %float %331 %332
-OpStore %118 %333
-%334 = OpLoad %v4float %116
-%335 = OpLoad %float %118
-%336 = OpCompositeInsert %v4float %335 %334 2
-OpStore %119 %336
-OpBranch %56
-%56 = OpLabel
-%337 = OpLoad %v4float %113
-%338 = OpCompositeExtract %float %337 0
-OpStore %154 %338
-%339 = OpLoad %ulong %100
-%340 = OpLoad %float %154
-%341 = OpFunctionCall %ulong %5 %339 %340
-OpStore %155 %341
-%342 = OpLoad %v4float %113
-%343 = OpCompositeExtract %float %342 1
-OpStore %156 %343
-%344 = OpLoad %ulong %155
-%345 = OpLoad %float %156
-%346 = OpFunctionCall %ulong %5 %344 %345
-OpStore %157 %346
-%347 = OpLoad %v4float %113
-%348 = OpCompositeExtract %float %347 2
-OpStore %158 %348
-%349 = OpLoad %ulong %157
-%350 = OpLoad %float %158
-%351 = OpFunctionCall %ulong %5 %349 %350
-OpStore %159 %351
-%352 = OpLoad %v4float %113
-%353 = OpCompositeExtract %float %352 3
-OpStore %160 %353
-%354 = OpLoad %ulong %159
-%355 = OpLoad %float %160
-%356 = OpFunctionCall %ulong %5 %354 %355
-OpStore %161 %356
-OpBranch %57
-%57 = OpLabel
-OpBranch %64
-%64 = OpLabel
-%357 = OpLoad %v4float %119
-%358 = OpCompositeExtract %float %357 0
-OpStore %186 %358
-%359 = OpLoad %ulong %161
-%360 = OpLoad %float %186
-%361 = OpFunctionCall %ulong %5 %359 %360
-OpStore %187 %361
-%362 = OpLoad %v4float %119
-%363 = OpCompositeExtract %float %362 1
-OpStore %188 %363
-%364 = OpLoad %ulong %187
-%365 = OpLoad %float %188
-%366 = OpFunctionCall %ulong %5 %364 %365
-OpStore %189 %366
-%367 = OpLoad %v4float %119
-%368 = OpCompositeExtract %float %367 2
-OpStore %190 %368
-%369 = OpLoad %ulong %189
-%370 = OpLoad %float %190
-%371 = OpFunctionCall %ulong %5 %369 %370
-OpStore %191 %371
-%372 = OpLoad %v4float %119
-%373 = OpCompositeExtract %float %372 3
-OpStore %192 %373
-%374 = OpLoad %ulong %191
-%375 = OpLoad %float %192
-%376 = OpFunctionCall %ulong %5 %374 %375
-OpStore %193 %376
-OpBranch %65
-%65 = OpLabel
-%377 = OpLoad %v4float %113
-%378 = OpLoad %v4float %119
-%379 = OpFAdd %v4float %377 %378
-OpStore %120 %379
-OpBranch %68
-%68 = OpLabel
-%380 = OpLoad %v4float %120
-%381 = OpCompositeExtract %float %380 0
-OpStore %202 %381
-%382 = OpLoad %ulong %193
-%383 = OpLoad %float %202
-%384 = OpFunctionCall %ulong %5 %382 %383
-OpStore %203 %384
-%385 = OpLoad %v4float %120
-%386 = OpCompositeExtract %float %385 1
-OpStore %204 %386
-%387 = OpLoad %ulong %203
-%388 = OpLoad %float %204
-%389 = OpFunctionCall %ulong %5 %387 %388
-OpStore %205 %389
-%390 = OpLoad %v4float %120
-%391 = OpCompositeExtract %float %390 2
-OpStore %206 %391
-%392 = OpLoad %ulong %205
-%393 = OpLoad %float %206
-%394 = OpFunctionCall %ulong %5 %392 %393
-OpStore %207 %394
-%395 = OpLoad %v4float %120
-%396 = OpCompositeExtract %float %395 3
-OpStore %208 %396
-%397 = OpLoad %ulong %207
-%398 = OpLoad %float %208
-%399 = OpFunctionCall %ulong %5 %397 %398
-OpStore %209 %399
-OpBranch %69
-%69 = OpLabel
-%400 = OpLoad %v4float %113
-%401 = OpLoad %v4float %119
-%402 = OpFSub %v4float %400 %401
-OpStore %121 %402
-OpBranch %72
-%72 = OpLabel
-%403 = OpLoad %v4float %121
-%404 = OpCompositeExtract %float %403 0
-OpStore %218 %404
-%405 = OpLoad %ulong %209
-%406 = OpLoad %float %218
-%407 = OpFunctionCall %ulong %5 %405 %406
-OpStore %219 %407
-%408 = OpLoad %v4float %121
-%409 = OpCompositeExtract %float %408 1
-OpStore %220 %409
-%410 = OpLoad %ulong %219
-%411 = OpLoad %float %220
-%412 = OpFunctionCall %ulong %5 %410 %411
-OpStore %221 %412
-%413 = OpLoad %v4float %121
-%414 = OpCompositeExtract %float %413 2
-OpStore %222 %414
-%415 = OpLoad %ulong %221
-%416 = OpLoad %float %222
-%417 = OpFunctionCall %ulong %5 %415 %416
-OpStore %223 %417
-%418 = OpLoad %v4float %121
-%419 = OpCompositeExtract %float %418 3
-OpStore %224 %419
-%420 = OpLoad %ulong %223
-%421 = OpLoad %float %224
-%422 = OpFunctionCall %ulong %5 %420 %421
-OpStore %225 %422
-OpBranch %73
-%73 = OpLabel
-%423 = OpLoad %v4float %119
-%424 = OpLoad %v4float %113
-%425 = OpFSub %v4float %423 %424
-OpStore %122 %425
-OpBranch %74
-%74 = OpLabel
-%426 = OpLoad %v4float %122
-%427 = OpCompositeExtract %float %426 0
-OpStore %226 %427
-%428 = OpLoad %ulong %225
-%429 = OpLoad %float %226
-%430 = OpFunctionCall %ulong %5 %428 %429
-OpStore %227 %430
-%431 = OpLoad %v4float %122
-%432 = OpCompositeExtract %float %431 1
-OpStore %228 %432
-%433 = OpLoad %ulong %227
-%434 = OpLoad %float %228
-%435 = OpFunctionCall %ulong %5 %433 %434
-OpStore %229 %435
-%436 = OpLoad %v4float %122
-%437 = OpCompositeExtract %float %436 2
-OpStore %230 %437
-%438 = OpLoad %ulong %229
-%439 = OpLoad %float %230
-%440 = OpFunctionCall %ulong %5 %438 %439
-OpStore %231 %440
-%441 = OpLoad %v4float %122
-%442 = OpCompositeExtract %float %441 3
-OpStore %232 %442
-%443 = OpLoad %ulong %231
-%444 = OpLoad %float %232
-%445 = OpFunctionCall %ulong %5 %443 %444
-OpStore %233 %445
-OpBranch %75
-%75 = OpLabel
-%446 = OpLoad %v4float %113
-%447 = OpLoad %v4float %119
-%448 = OpFMul %v4float %446 %447
-OpStore %123 %448
-OpBranch %76
-%76 = OpLabel
-%449 = OpLoad %v4float %123
-%450 = OpCompositeExtract %float %449 0
-OpStore %234 %450
-%451 = OpLoad %ulong %233
-%452 = OpLoad %float %234
-%453 = OpFunctionCall %ulong %5 %451 %452
-OpStore %235 %453
-%454 = OpLoad %v4float %123
-%455 = OpCompositeExtract %float %454 1
-OpStore %236 %455
-%456 = OpLoad %ulong %235
-%457 = OpLoad %float %236
-%458 = OpFunctionCall %ulong %5 %456 %457
-OpStore %237 %458
-%459 = OpLoad %v4float %123
-%460 = OpCompositeExtract %float %459 2
-OpStore %238 %460
-%461 = OpLoad %ulong %237
-%462 = OpLoad %float %238
-%463 = OpFunctionCall %ulong %5 %461 %462
-OpStore %239 %463
-%464 = OpLoad %v4float %123
-%465 = OpCompositeExtract %float %464 3
-OpStore %240 %465
-%466 = OpLoad %ulong %239
-%467 = OpLoad %float %240
-%468 = OpFunctionCall %ulong %5 %466 %467
-OpStore %241 %468
-OpBranch %77
-%77 = OpLabel
-%469 = OpLoad %v4float %113
-%470 = OpLoad %v4float %119
-%471 = OpFDiv %v4float %469 %470
-OpStore %124 %471
-OpBranch %78
-%78 = OpLabel
-%472 = OpLoad %v4float %124
-%473 = OpCompositeExtract %float %472 0
-OpStore %242 %473
-%474 = OpLoad %ulong %241
-%475 = OpLoad %float %242
-%476 = OpFunctionCall %ulong %5 %474 %475
-OpStore %243 %476
-%477 = OpLoad %v4float %124
-%478 = OpCompositeExtract %float %477 1
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_v4float Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_v4float Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_v4float Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_v4float Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_v4float Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_v4float Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_v4float Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_v4float Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_v4float Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_v4float Function
+%286 = OpVariable %_ptr_Function_bool Function
+%287 = OpVariable %_ptr_Function_v4float Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_v4float Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_v4float Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_v4float Function
+%295 = OpVariable %_ptr_Function_v4float Function
+%296 = OpVariable %_ptr_Function_bool Function
+%297 = OpVariable %_ptr_Function_v4float Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_v4float Function
+%301 = OpVariable %_ptr_Function_uint Function
+%302 = OpVariable %_ptr_Function_v4float Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_uint Function
+%305 = OpVariable %_ptr_Function_ulong Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_v4float Function
+%308 = OpVariable %_ptr_Function_v4float Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_bool Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_bool Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+OpStore %245 %210
+OpBranch %218
+%218 = OpLabel
+OpBranch %219
+%219 = OpLabel
+%331 = OpLoad %ulong %245
+%332 = OpConvertUToF %float %331
+OpStore %246 %332
+%334 = OpFNegate %float %float_2_25
+OpStore %247 %334
+%336 = OpFNegate %float %float_0_5
+OpStore %248 %336
+%339 = OpLoad %float %247
+%341 = OpLoad %float %248
+%337 = OpCompositeConstruct %v4float %float_1_5 %339 %float_3_75 %341
+OpStore %249 %337
+%343 = OpFNegate %float %float_0_125
+OpStore %250 %343
+%346 = OpLoad %float %250
+%344 = OpCompositeConstruct %v4float %float_0_5 %float_4 %346 %float_8
+OpStore %251 %344
+%348 = OpCompositeConstruct %v4float %float_1 %float_3 %float_9 %float_27
+OpStore %252 %348
+%353 = OpLoad %v4float %249
+%354 = OpCompositeExtract %float %353 0
+OpStore %253 %354
+%355 = OpLoad %float %253
+%356 = OpLoad %float %246
+%357 = OpFAdd %float %355 %356
+OpStore %254 %357
+%358 = OpLoad %v4float %249
+%359 = OpLoad %float %254
+%360 = OpCompositeInsert %v4float %359 %358 0
+OpStore %255 %360
+%361 = OpLoad %v4float %255
+%362 = OpCompositeExtract %float %361 3
+OpStore %256 %362
+%363 = OpLoad %float %256
+%364 = OpLoad %float %246
+%365 = OpFAdd %float %363 %364
+OpStore %257 %365
+%366 = OpLoad %v4float %255
+%367 = OpLoad %float %257
+%368 = OpCompositeInsert %v4float %367 %366 3
+OpStore %258 %368
+%369 = OpLoad %v4float %251
+%370 = OpCompositeExtract %float %369 1
+OpStore %259 %370
+%371 = OpLoad %float %259
+%372 = OpLoad %float %246
+%373 = OpFAdd %float %371 %372
+OpStore %260 %373
+%374 = OpLoad %v4float %251
+%375 = OpLoad %float %260
+%376 = OpCompositeInsert %v4float %375 %374 1
+OpStore %261 %376
+%377 = OpLoad %v4float %261
+%378 = OpCompositeExtract %float %377 2
+OpStore %262 %378
+%379 = OpLoad %float %262
+%380 = OpLoad %float %246
+%381 = OpFAdd %float %379 %380
+OpStore %263 %381
+%382 = OpLoad %v4float %261
+%383 = OpLoad %float %263
+%384 = OpCompositeInsert %v4float %383 %382 2
+OpStore %264 %384
+%386 = OpLoad %v4float %258
+%387 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %386
+OpStore %265 %387
+%388 = OpLoad %ulong %265
+%389 = OpLoad %v4float %264
+%390 = OpFunctionCall %ulong %1 %388 %389
+OpStore %266 %390
+%391 = OpLoad %v4float %258
+%392 = OpLoad %v4float %264
+%393 = OpFAdd %v4float %391 %392
+OpStore %267 %393
+%394 = OpLoad %ulong %266
+%395 = OpLoad %v4float %267
+%396 = OpFunctionCall %ulong %1 %394 %395
+OpStore %268 %396
+%397 = OpLoad %v4float %258
+%398 = OpLoad %v4float %264
+%399 = OpFSub %v4float %397 %398
+OpStore %269 %399
+%400 = OpLoad %ulong %268
+%401 = OpLoad %v4float %269
+%402 = OpFunctionCall %ulong %1 %400 %401
+OpStore %270 %402
+%403 = OpLoad %v4float %264
+%404 = OpLoad %v4float %258
+%405 = OpFSub %v4float %403 %404
+OpStore %271 %405
+%406 = OpLoad %ulong %270
+%407 = OpLoad %v4float %271
+%408 = OpFunctionCall %ulong %1 %406 %407
+OpStore %272 %408
+%409 = OpLoad %v4float %258
+%410 = OpLoad %v4float %264
+%411 = OpFMul %v4float %409 %410
+OpStore %273 %411
+%412 = OpLoad %ulong %272
+%413 = OpLoad %v4float %273
+%414 = OpFunctionCall %ulong %1 %412 %413
+OpStore %274 %414
+%415 = OpLoad %v4float %258
+%416 = OpLoad %v4float %264
+%417 = OpFDiv %v4float %415 %416
+OpStore %275 %417
+%418 = OpLoad %ulong %274
+%419 = OpLoad %v4float %275
+%420 = OpFunctionCall %ulong %1 %418 %419
+OpStore %276 %420
+%421 = OpLoad %v4float %264
+%422 = OpLoad %v4float %258
+%423 = OpFDiv %v4float %421 %422
+OpStore %277 %423
+%424 = OpLoad %ulong %276
+%425 = OpLoad %v4float %277
+%426 = OpFunctionCall %ulong %1 %424 %425
+OpStore %278 %426
+%427 = OpLoad %v4float %258
+%428 = OpLoad %v4float %252
+%429 = OpFMul %v4float %427 %428
+OpStore %279 %429
+%430 = OpLoad %ulong %278
+%431 = OpLoad %v4float %279
+%432 = OpFunctionCall %ulong %1 %430 %431
+OpStore %280 %432
+%433 = OpLoad %v4float %252
+%434 = OpLoad %v4float %264
+%435 = OpFSub %v4float %433 %434
+OpStore %281 %435
+%436 = OpLoad %ulong %280
+%437 = OpLoad %v4float %281
+%438 = OpFunctionCall %ulong %1 %436 %437
+OpStore %282 %438
+%439 = OpLoad %v4float %252
+%440 = OpLoad %v4float %258
+%441 = OpFDiv %v4float %439 %440
+OpStore %283 %441
+%442 = OpLoad %ulong %282
+%443 = OpLoad %v4float %283
+%444 = OpFunctionCall %ulong %1 %442 %443
+OpStore %284 %444
+%445 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
+OpStore %285 %445
+%447 = OpLoad %ulong %284
+OpStore %306 %447
+%448 = OpLoad %v4float %258
+OpStore %307 %448
+%449 = OpLoad %v4float %285
+OpStore %308 %449
+OpStore %309 %ulong_0
+OpBranch %212
+%212 = OpLabel
+%450 = OpLoad %ulong %309
+%452 = OpULessThan %bool %450 %ulong_6
+OpStore %286 %452
+%453 = OpLoad %bool %286
+OpLoopMerge %214 %237 None
+OpBranchConditional %453 %213 %214
+%214 = OpLabel
+OpStore %241 %454
+%456 = OpAccessChain %_ptr_Function_v4float %241 %uint_0
+%457 = OpLoad %v4float %307
+OpStore %456 %457
+%458 = OpLoad %v4float %307
+%459 = OpLoad %v4float %264
+%460 = OpFAdd %v4float %458 %459
+OpStore %294 %460
+%462 = OpAccessChain %_ptr_Function_v4float %241 %uint_1
+%463 = OpLoad %v4float %294
+OpStore %462 %463
+%464 = OpLoad %v4float %307
+%465 = OpLoad %v4float %252
+%466 = OpFMul %v4float %464 %465
+OpStore %295 %466
+%468 = OpAccessChain %_ptr_Function_v4float %241 %uint_2
+%469 = OpLoad %v4float %295
+OpStore %468 %469
+%471 = OpAccessChain %_ptr_Function_v4float %241 %uint_3
+%472 = OpLoad %v4float %308
+OpStore %471 %472
+%473 = OpLoad %ulong %306
+OpStore %305 %473
+OpStore %310 %ulong_0
+OpBranch %215
+%215 = OpLabel
+%474 = OpLoad %ulong %310
+%476 = OpULessThan %bool %474 %ulong_4
+OpStore %296 %476
+%477 = OpLoad %bool %296
+OpLoopMerge %217 %236 None
+OpBranchConditional %477 %216 %217
+%217 = OpLabel
 OpStore %244 %478
-%479 = OpLoad %ulong %243
-%480 = OpLoad %float %244
-%481 = OpFunctionCall %ulong %5 %479 %480
-OpStore %245 %481
-%482 = OpLoad %v4float %124
-%483 = OpCompositeExtract %float %482 2
-OpStore %246 %483
-%484 = OpLoad %ulong %245
-%485 = OpLoad %float %246
-%486 = OpFunctionCall %ulong %5 %484 %485
-OpStore %247 %486
-%487 = OpLoad %v4float %124
-%488 = OpCompositeExtract %float %487 3
-OpStore %248 %488
-%489 = OpLoad %ulong %247
-%490 = OpLoad %float %248
-%491 = OpFunctionCall %ulong %5 %489 %490
-OpStore %249 %491
-OpBranch %79
-%79 = OpLabel
-%492 = OpLoad %v4float %119
-%493 = OpLoad %v4float %113
-%494 = OpFDiv %v4float %492 %493
-OpStore %125 %494
-OpBranch %80
-%80 = OpLabel
-%495 = OpLoad %v4float %125
-%496 = OpCompositeExtract %float %495 0
-OpStore %250 %496
-%497 = OpLoad %ulong %249
-%498 = OpLoad %float %250
-%499 = OpFunctionCall %ulong %5 %497 %498
-OpStore %251 %499
-%500 = OpLoad %v4float %125
-%501 = OpCompositeExtract %float %500 1
-OpStore %252 %501
-%502 = OpLoad %ulong %251
-%503 = OpLoad %float %252
-%504 = OpFunctionCall %ulong %5 %502 %503
-OpStore %253 %504
-%505 = OpLoad %v4float %125
-%506 = OpCompositeExtract %float %505 2
-OpStore %254 %506
-%507 = OpLoad %ulong %253
-%508 = OpLoad %float %254
-%509 = OpFunctionCall %ulong %5 %507 %508
-OpStore %255 %509
-%510 = OpLoad %v4float %125
-%511 = OpCompositeExtract %float %510 3
-OpStore %256 %511
-%512 = OpLoad %ulong %255
-%513 = OpLoad %float %256
-%514 = OpFunctionCall %ulong %5 %512 %513
-OpStore %257 %514
-OpBranch %81
-%81 = OpLabel
-%515 = OpLoad %v4float %113
-%516 = OpLoad %v4float %107
-%517 = OpFMul %v4float %515 %516
-OpStore %126 %517
-OpBranch %82
-%82 = OpLabel
-%518 = OpLoad %v4float %126
-%519 = OpCompositeExtract %float %518 0
-OpStore %258 %519
-%520 = OpLoad %ulong %257
-%521 = OpLoad %float %258
-%522 = OpFunctionCall %ulong %5 %520 %521
-OpStore %259 %522
-%523 = OpLoad %v4float %126
-%524 = OpCompositeExtract %float %523 1
-OpStore %260 %524
-%525 = OpLoad %ulong %259
-%526 = OpLoad %float %260
-%527 = OpFunctionCall %ulong %5 %525 %526
-OpStore %261 %527
-%528 = OpLoad %v4float %126
-%529 = OpCompositeExtract %float %528 2
-OpStore %262 %529
-%530 = OpLoad %ulong %261
-%531 = OpLoad %float %262
-%532 = OpFunctionCall %ulong %5 %530 %531
-OpStore %263 %532
-%533 = OpLoad %v4float %126
-%534 = OpCompositeExtract %float %533 3
-OpStore %264 %534
-%535 = OpLoad %ulong %263
-%536 = OpLoad %float %264
-%537 = OpFunctionCall %ulong %5 %535 %536
-OpStore %265 %537
-OpBranch %83
-%83 = OpLabel
-%538 = OpLoad %v4float %107
-%539 = OpLoad %v4float %119
-%540 = OpFSub %v4float %538 %539
-OpStore %127 %540
-OpBranch %84
-%84 = OpLabel
-%541 = OpLoad %v4float %127
-%542 = OpCompositeExtract %float %541 0
-OpStore %266 %542
-%543 = OpLoad %ulong %265
-%544 = OpLoad %float %266
-%545 = OpFunctionCall %ulong %5 %543 %544
-OpStore %267 %545
-%546 = OpLoad %v4float %127
-%547 = OpCompositeExtract %float %546 1
-OpStore %268 %547
-%548 = OpLoad %ulong %267
-%549 = OpLoad %float %268
-%550 = OpFunctionCall %ulong %5 %548 %549
-OpStore %269 %550
-%551 = OpLoad %v4float %127
-%552 = OpCompositeExtract %float %551 2
-OpStore %270 %552
-%553 = OpLoad %ulong %269
-%554 = OpLoad %float %270
-%555 = OpFunctionCall %ulong %5 %553 %554
-OpStore %271 %555
-%556 = OpLoad %v4float %127
-%557 = OpCompositeExtract %float %556 3
-OpStore %272 %557
-%558 = OpLoad %ulong %271
-%559 = OpLoad %float %272
-%560 = OpFunctionCall %ulong %5 %558 %559
-OpStore %273 %560
-OpBranch %85
-%85 = OpLabel
-%561 = OpLoad %v4float %107
-%562 = OpLoad %v4float %113
-%563 = OpFDiv %v4float %561 %562
-OpStore %128 %563
-OpBranch %86
-%86 = OpLabel
-%564 = OpLoad %v4float %128
-%565 = OpCompositeExtract %float %564 0
-OpStore %274 %565
-%566 = OpLoad %ulong %273
-%567 = OpLoad %float %274
-%568 = OpFunctionCall %ulong %5 %566 %567
-OpStore %275 %568
-%569 = OpLoad %v4float %128
-%570 = OpCompositeExtract %float %569 1
-OpStore %276 %570
-%571 = OpLoad %ulong %275
-%572 = OpLoad %float %276
-%573 = OpFunctionCall %ulong %5 %571 %572
-OpStore %277 %573
-%574 = OpLoad %v4float %128
-%575 = OpCompositeExtract %float %574 2
-OpStore %278 %575
-%576 = OpLoad %ulong %277
-%577 = OpLoad %float %278
-%578 = OpFunctionCall %ulong %5 %576 %577
-OpStore %279 %578
-%579 = OpLoad %v4float %128
-%580 = OpCompositeExtract %float %579 3
-OpStore %280 %580
-%581 = OpLoad %ulong %279
-%582 = OpLoad %float %280
-%583 = OpFunctionCall %ulong %5 %581 %582
-OpStore %281 %583
-OpBranch %87
-%87 = OpLabel
-%584 = OpCompositeConstruct %v4float %float_0 %float_0 %float_0 %float_0
-OpStore %129 %584
-%586 = OpLoad %ulong %281
-OpStore %149 %586
-%587 = OpLoad %v4float %113
-OpStore %150 %587
-%588 = OpLoad %v4float %129
-OpStore %151 %588
-OpStore %152 %ulong_0
-OpBranch %50
-%50 = OpLabel
-%590 = OpLoad %ulong %152
-%592 = OpULessThan %bool %590 %ulong_6
-OpStore %131 %592
-%593 = OpLoad %bool %131
-OpLoopMerge %52 %89 None
-OpBranchConditional %593 %51 %52
-%52 = OpLabel
-OpStore %95 %594
-%596 = OpAccessChain %_ptr_Function_v4float %95 %uint_0
-%597 = OpLoad %v4float %150
-OpStore %596 %597
-%598 = OpLoad %v4float %150
-%599 = OpLoad %v4float %119
-%600 = OpFAdd %v4float %598 %599
-OpStore %136 %600
-%602 = OpAccessChain %_ptr_Function_v4float %95 %uint_1
-%603 = OpLoad %v4float %136
-OpStore %602 %603
-%604 = OpLoad %v4float %150
-%605 = OpLoad %v4float %107
-%606 = OpFMul %v4float %604 %605
-OpStore %137 %606
-%608 = OpAccessChain %_ptr_Function_v4float %95 %uint_2
-%609 = OpLoad %v4float %137
-OpStore %608 %609
-%611 = OpAccessChain %_ptr_Function_v4float %95 %uint_3
-%612 = OpLoad %v4float %151
-OpStore %611 %612
-%613 = OpLoad %ulong %149
-OpStore %148 %613
-OpStore %153 %ulong_0
-OpBranch %53
-%53 = OpLabel
-%614 = OpLoad %ulong %153
-%616 = OpULessThan %bool %614 %ulong_4
-OpStore %138 %616
-%617 = OpLoad %bool %138
-OpLoopMerge %55 %88 None
-OpBranchConditional %617 %54 %55
-%55 = OpLabel
-OpStore %98 %618
-%619 = OpAccessChain %_ptr_Function_uint %98 %uint_0
-OpStore %619 %uint_4294967295
-%621 = OpAccessChain %_ptr_Function_v4float %95 %uint_2
-%622 = OpLoad %v4float %621
-OpStore %141 %622
-%623 = OpAccessChain %_ptr_Function_v4float %98 %uint_1
-%624 = OpLoad %v4float %141
-OpStore %623 %624
-%625 = OpAccessChain %_ptr_Function_uint %98 %uint_2
-OpStore %625 %uint_305419896
-%627 = OpLoad %uint %619
-OpStore %143 %627
-%628 = OpLoad %ulong %148
-%629 = OpLoad %uint %143
-%630 = OpFunctionCall %ulong %4 %628 %629
-OpStore %144 %630
-%631 = OpLoad %v4float %623
-OpStore %145 %631
-OpBranch %62
-%62 = OpLabel
-%632 = OpLoad %v4float %145
-%633 = OpCompositeExtract %float %632 0
-OpStore %178 %633
-%634 = OpLoad %ulong %144
-%635 = OpLoad %float %178
-%636 = OpFunctionCall %ulong %5 %634 %635
-OpStore %179 %636
-%637 = OpLoad %v4float %145
-%638 = OpCompositeExtract %float %637 1
-OpStore %180 %638
-%639 = OpLoad %ulong %179
-%640 = OpLoad %float %180
-%641 = OpFunctionCall %ulong %5 %639 %640
-OpStore %181 %641
-%642 = OpLoad %v4float %145
-%643 = OpCompositeExtract %float %642 2
-OpStore %182 %643
-%644 = OpLoad %ulong %181
-%645 = OpLoad %float %182
-%646 = OpFunctionCall %ulong %5 %644 %645
-OpStore %183 %646
-%647 = OpLoad %v4float %145
-%648 = OpCompositeExtract %float %647 3
-OpStore %184 %648
-%649 = OpLoad %ulong %183
-%650 = OpLoad %float %184
-%651 = OpFunctionCall %ulong %5 %649 %650
-OpStore %185 %651
-OpBranch %63
-%63 = OpLabel
-%652 = OpAccessChain %_ptr_Function_uint %98 %uint_2
-%653 = OpLoad %uint %652
-OpStore %146 %653
-%654 = OpLoad %ulong %185
-%655 = OpLoad %uint %146
-%656 = OpFunctionCall %ulong %4 %654 %655
-OpStore %147 %656
-%657 = OpLoad %ulong %147
-OpReturnValue %657
-%54 = OpLabel
-%658 = OpLoad %ulong %153
-%659 = OpAccessChain %_ptr_Function_v4float %95 %658
-%660 = OpLoad %v4float %659
-OpStore %139 %660
-OpBranch %60
-%60 = OpLabel
-%661 = OpLoad %v4float %139
-%662 = OpCompositeExtract %float %661 0
-OpStore %170 %662
-%663 = OpLoad %ulong %148
-%664 = OpLoad %float %170
-%665 = OpFunctionCall %ulong %5 %663 %664
-OpStore %171 %665
-%666 = OpLoad %v4float %139
-%667 = OpCompositeExtract %float %666 1
-OpStore %172 %667
-%668 = OpLoad %ulong %171
-%669 = OpLoad %float %172
-%670 = OpFunctionCall %ulong %5 %668 %669
-OpStore %173 %670
-%671 = OpLoad %v4float %139
-%672 = OpCompositeExtract %float %671 2
-OpStore %174 %672
-%673 = OpLoad %ulong %173
-%674 = OpLoad %float %174
-%675 = OpFunctionCall %ulong %5 %673 %674
-OpStore %175 %675
-%676 = OpLoad %v4float %139
-%677 = OpCompositeExtract %float %676 3
-OpStore %176 %677
-%678 = OpLoad %ulong %175
-%679 = OpLoad %float %176
-%680 = OpFunctionCall %ulong %5 %678 %679
-OpStore %177 %680
-OpBranch %61
-%61 = OpLabel
-%681 = OpLoad %ulong %153
-%683 = OpIAdd %ulong %681 %ulong_1
-OpStore %140 %683
-%684 = OpLoad %ulong %177
-OpStore %148 %684
-%685 = OpLoad %ulong %140
-OpStore %153 %685
-OpBranch %88
-%51 = OpLabel
-%686 = OpLoad %v4float %150
-%687 = OpLoad %v4float %107
-%688 = OpFMul %v4float %686 %687
-OpStore %132 %688
-OpBranch %58
-%58 = OpLabel
-%689 = OpLoad %v4float %132
-%690 = OpCompositeExtract %float %689 0
-OpStore %162 %690
-%691 = OpLoad %ulong %149
-%692 = OpLoad %float %162
-%693 = OpFunctionCall %ulong %5 %691 %692
-OpStore %163 %693
-%694 = OpLoad %v4float %132
-%695 = OpCompositeExtract %float %694 1
-OpStore %164 %695
-%696 = OpLoad %ulong %163
-%697 = OpLoad %float %164
-%698 = OpFunctionCall %ulong %5 %696 %697
-OpStore %165 %698
-%699 = OpLoad %v4float %132
-%700 = OpCompositeExtract %float %699 2
-OpStore %166 %700
-%701 = OpLoad %ulong %165
-%702 = OpLoad %float %166
-%703 = OpFunctionCall %ulong %5 %701 %702
-OpStore %167 %703
-%704 = OpLoad %v4float %132
-%705 = OpCompositeExtract %float %704 3
-OpStore %168 %705
-%706 = OpLoad %ulong %167
-%707 = OpLoad %float %168
-%708 = OpFunctionCall %ulong %5 %706 %707
-OpStore %169 %708
-OpBranch %59
-%59 = OpLabel
-%709 = OpLoad %v4float %151
-%710 = OpLoad %v4float %132
-%711 = OpFAdd %v4float %709 %710
-OpStore %133 %711
-OpBranch %66
-%66 = OpLabel
-%712 = OpLoad %v4float %133
-%713 = OpCompositeExtract %float %712 0
-OpStore %194 %713
-%714 = OpLoad %ulong %169
-%715 = OpLoad %float %194
-%716 = OpFunctionCall %ulong %5 %714 %715
-OpStore %195 %716
-%717 = OpLoad %v4float %133
-%718 = OpCompositeExtract %float %717 1
-OpStore %196 %718
-%719 = OpLoad %ulong %195
-%720 = OpLoad %float %196
-%721 = OpFunctionCall %ulong %5 %719 %720
-OpStore %197 %721
-%722 = OpLoad %v4float %133
-%723 = OpCompositeExtract %float %722 2
-OpStore %198 %723
-%724 = OpLoad %ulong %197
-%725 = OpLoad %float %198
-%726 = OpFunctionCall %ulong %5 %724 %725
-OpStore %199 %726
-%727 = OpLoad %v4float %133
-%728 = OpCompositeExtract %float %727 3
-OpStore %200 %728
-%729 = OpLoad %ulong %199
-%730 = OpLoad %float %200
-%731 = OpFunctionCall %ulong %5 %729 %730
-OpStore %201 %731
-OpBranch %67
-%67 = OpLabel
-%732 = OpLoad %v4float %150
-%733 = OpLoad %v4float %119
-%734 = OpFSub %v4float %732 %733
-OpStore %134 %734
-OpBranch %70
-%70 = OpLabel
-%735 = OpLoad %v4float %134
-%736 = OpCompositeExtract %float %735 0
-OpStore %210 %736
-%737 = OpLoad %ulong %201
-%738 = OpLoad %float %210
-%739 = OpFunctionCall %ulong %5 %737 %738
-OpStore %211 %739
-%740 = OpLoad %v4float %134
-%741 = OpCompositeExtract %float %740 1
-OpStore %212 %741
-%742 = OpLoad %ulong %211
-%743 = OpLoad %float %212
-%744 = OpFunctionCall %ulong %5 %742 %743
-OpStore %213 %744
-%745 = OpLoad %v4float %134
-%746 = OpCompositeExtract %float %745 2
-OpStore %214 %746
-%747 = OpLoad %ulong %213
-%748 = OpLoad %float %214
-%749 = OpFunctionCall %ulong %5 %747 %748
-OpStore %215 %749
-%750 = OpLoad %v4float %134
-%751 = OpCompositeExtract %float %750 3
-OpStore %216 %751
-%752 = OpLoad %ulong %215
-%753 = OpLoad %float %216
-%754 = OpFunctionCall %ulong %5 %752 %753
-OpStore %217 %754
-OpBranch %71
-%71 = OpLabel
-%755 = OpLoad %ulong %152
-%756 = OpIAdd %ulong %755 %ulong_1
-OpStore %135 %756
-%757 = OpLoad %ulong %217
-OpStore %149 %757
-%758 = OpLoad %v4float %134
-OpStore %150 %758
-%759 = OpLoad %v4float %133
-OpStore %151 %759
-%760 = OpLoad %ulong %135
-OpStore %152 %760
-OpBranch %89
-%88 = OpLabel
-OpBranch %53
-%89 = OpLabel
-OpBranch %50
-OpFunctionEnd
-%3 = OpFunction %ulong None %761
-%762 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %764
-%765 = OpFunctionParameter %ulong
-%766 = OpFunctionParameter %uint
-%767 = OpLabel
-%774 = OpVariable %_ptr_Function_ulong Function
-%775 = OpVariable %_ptr_Function_uint Function
-%776 = OpVariable %_ptr_Function_ulong Function
-%777 = OpVariable %_ptr_Function_bool Function
-%778 = OpVariable %_ptr_Function_ulong Function
-%779 = OpVariable %_ptr_Function_ulong Function
-%780 = OpVariable %_ptr_Function_ulong Function
-%781 = OpVariable %_ptr_Function_ulong Function
-%782 = OpVariable %_ptr_Function_ulong Function
-%783 = OpVariable %_ptr_Function_ulong Function
-%784 = OpVariable %_ptr_Function_ulong Function
-%785 = OpVariable %_ptr_Function_ulong Function
-OpStore %774 %765
-OpStore %775 %766
-%786 = OpLoad %uint %775
-%787 = OpUConvert %ulong %786
-OpStore %776 %787
-OpBranch %768
-%768 = OpLabel
-%788 = OpLoad %ulong %774
-OpStore %784 %788
-OpStore %785 %ulong_0
-OpBranch %769
-%769 = OpLabel
-%789 = OpLoad %ulong %785
-%791 = OpULessThan %bool %789 %ulong_8
-OpStore %777 %791
-%792 = OpLoad %bool %777
-OpLoopMerge %771 %773 None
-OpBranchConditional %792 %770 %771
-%771 = OpLabel
-OpBranch %772
-%772 = OpLabel
-%793 = OpLoad %ulong %784
-OpReturnValue %793
-%770 = OpLabel
-%794 = OpLoad %ulong %785
-%795 = OpIMul %ulong %794 %ulong_8
-OpStore %778 %795
-%796 = OpLoad %ulong %776
-%797 = OpLoad %ulong %778
-%798 = OpShiftRightLogical %ulong %796 %797
-OpStore %779 %798
-%799 = OpLoad %ulong %779
-%801 = OpBitwiseAnd %ulong %799 %ulong_255
-OpStore %780 %801
-%802 = OpLoad %ulong %784
-%803 = OpLoad %ulong %780
-%804 = OpBitwiseXor %ulong %802 %803
-OpStore %781 %804
-%805 = OpLoad %ulong %781
-%807 = OpIMul %ulong %805 %ulong_1099511628211
-OpStore %782 %807
-%808 = OpLoad %ulong %785
-%809 = OpIAdd %ulong %808 %ulong_1
-OpStore %783 %809
-%810 = OpLoad %ulong %782
-OpStore %784 %810
-%811 = OpLoad %ulong %783
-OpStore %785 %811
-OpBranch %773
-%773 = OpLabel
-OpBranch %769
-OpFunctionEnd
-%5 = OpFunction %ulong None %812
-%813 = OpFunctionParameter %ulong
-%814 = OpFunctionParameter %float
-%815 = OpLabel
-%822 = OpVariable %_ptr_Function_ulong Function
-%823 = OpVariable %_ptr_Function_float Function
-%824 = OpVariable %_ptr_Function_uint Function
-%825 = OpVariable %_ptr_Function_ulong Function
-%826 = OpVariable %_ptr_Function_bool Function
-%827 = OpVariable %_ptr_Function_ulong Function
-%828 = OpVariable %_ptr_Function_ulong Function
-%829 = OpVariable %_ptr_Function_ulong Function
-%830 = OpVariable %_ptr_Function_ulong Function
-%831 = OpVariable %_ptr_Function_ulong Function
-%832 = OpVariable %_ptr_Function_ulong Function
-%833 = OpVariable %_ptr_Function_ulong Function
-%834 = OpVariable %_ptr_Function_ulong Function
-OpStore %822 %813
-OpStore %823 %814
-%835 = OpLoad %float %823
-%836 = OpBitcast %uint %835
-OpStore %824 %836
-%837 = OpLoad %uint %824
-%838 = OpUConvert %ulong %837
-OpStore %825 %838
-OpBranch %816
-%816 = OpLabel
-%839 = OpLoad %ulong %822
-OpStore %833 %839
-OpStore %834 %ulong_0
-OpBranch %817
-%817 = OpLabel
-%840 = OpLoad %ulong %834
-%841 = OpULessThan %bool %840 %ulong_8
-OpStore %826 %841
-%842 = OpLoad %bool %826
-OpLoopMerge %819 %821 None
-OpBranchConditional %842 %818 %819
-%819 = OpLabel
-OpBranch %820
-%820 = OpLabel
-%843 = OpLoad %ulong %833
-OpReturnValue %843
-%818 = OpLabel
-%844 = OpLoad %ulong %834
-%845 = OpIMul %ulong %844 %ulong_8
-OpStore %827 %845
-%846 = OpLoad %ulong %825
-%847 = OpLoad %ulong %827
-%848 = OpShiftRightLogical %ulong %846 %847
-OpStore %828 %848
-%849 = OpLoad %ulong %828
-%850 = OpBitwiseAnd %ulong %849 %ulong_255
-OpStore %829 %850
-%851 = OpLoad %ulong %833
-%852 = OpLoad %ulong %829
-%853 = OpBitwiseXor %ulong %851 %852
-OpStore %830 %853
-%854 = OpLoad %ulong %830
-%855 = OpIMul %ulong %854 %ulong_1099511628211
-OpStore %831 %855
-%856 = OpLoad %ulong %834
-%857 = OpIAdd %ulong %856 %ulong_1
-OpStore %832 %857
-%858 = OpLoad %ulong %831
-OpStore %833 %858
-%859 = OpLoad %ulong %832
-OpStore %834 %859
-OpBranch %821
-%821 = OpLabel
-OpBranch %817
+%479 = OpAccessChain %_ptr_Function_uint %244 %uint_0
+OpStore %479 %uint_4294967295
+%481 = OpAccessChain %_ptr_Function_v4float %241 %uint_2
+%482 = OpLoad %v4float %481
+OpStore %300 %482
+%483 = OpAccessChain %_ptr_Function_v4float %244 %uint_1
+%484 = OpLoad %v4float %300
+OpStore %483 %484
+%485 = OpAccessChain %_ptr_Function_uint %244 %uint_2
+OpStore %485 %uint_305419896
+%487 = OpLoad %uint %479
+OpStore %301 %487
+OpBranch %220
+%220 = OpLabel
+%488 = OpLoad %uint %301
+%489 = OpUConvert %ulong %488
+OpStore %311 %489
+OpBranch %222
+%222 = OpLabel
+%490 = OpLoad %ulong %305
+OpStore %319 %490
+OpStore %320 %ulong_0
+OpBranch %223
+%223 = OpLabel
+%491 = OpLoad %ulong %320
+%492 = OpULessThan %bool %491 %ulong_8
+OpStore %312 %492
+%493 = OpLoad %bool %312
+OpLoopMerge %225 %235 None
+OpBranchConditional %493 %224 %225
+%225 = OpLabel
+OpBranch %226
+%226 = OpLabel
+OpBranch %221
+%221 = OpLabel
+%494 = OpAccessChain %_ptr_Function_v4float %244 %uint_1
+%495 = OpLoad %v4float %494
+OpStore %302 %495
+%496 = OpLoad %ulong %319
+%497 = OpLoad %v4float %302
+%498 = OpFunctionCall %ulong %1 %496 %497
+OpStore %303 %498
+%499 = OpAccessChain %_ptr_Function_uint %244 %uint_2
+%500 = OpLoad %uint %499
+OpStore %304 %500
+OpBranch %227
+%227 = OpLabel
+%501 = OpLoad %uint %304
+%502 = OpUConvert %ulong %501
+OpStore %321 %502
+OpBranch %229
+%229 = OpLabel
+%503 = OpLoad %ulong %303
+OpStore %329 %503
+OpStore %330 %ulong_0
+OpBranch %230
+%230 = OpLabel
+%504 = OpLoad %ulong %330
+%505 = OpULessThan %bool %504 %ulong_8
+OpStore %322 %505
+%506 = OpLoad %bool %322
+OpLoopMerge %232 %234 None
+OpBranchConditional %506 %231 %232
+%232 = OpLabel
+OpBranch %233
+%233 = OpLabel
+OpBranch %228
+%228 = OpLabel
+%507 = OpLoad %ulong %329
+OpReturnValue %507
+%231 = OpLabel
+%508 = OpLoad %ulong %330
+%509 = OpIMul %ulong %508 %ulong_8
+OpStore %323 %509
+%510 = OpLoad %ulong %321
+%511 = OpLoad %ulong %323
+%512 = OpShiftRightLogical %ulong %510 %511
+OpStore %324 %512
+%513 = OpLoad %ulong %324
+%514 = OpBitwiseAnd %ulong %513 %ulong_255
+OpStore %325 %514
+%515 = OpLoad %ulong %329
+%516 = OpLoad %ulong %325
+%517 = OpBitwiseXor %ulong %515 %516
+OpStore %326 %517
+%518 = OpLoad %ulong %326
+%519 = OpIMul %ulong %518 %ulong_1099511628211
+OpStore %327 %519
+%520 = OpLoad %ulong %330
+%521 = OpIAdd %ulong %520 %ulong_1
+OpStore %328 %521
+%522 = OpLoad %ulong %327
+OpStore %329 %522
+%523 = OpLoad %ulong %328
+OpStore %330 %523
+OpBranch %234
+%224 = OpLabel
+%524 = OpLoad %ulong %320
+%525 = OpIMul %ulong %524 %ulong_8
+OpStore %313 %525
+%526 = OpLoad %ulong %311
+%527 = OpLoad %ulong %313
+%528 = OpShiftRightLogical %ulong %526 %527
+OpStore %314 %528
+%529 = OpLoad %ulong %314
+%530 = OpBitwiseAnd %ulong %529 %ulong_255
+OpStore %315 %530
+%531 = OpLoad %ulong %319
+%532 = OpLoad %ulong %315
+%533 = OpBitwiseXor %ulong %531 %532
+OpStore %316 %533
+%534 = OpLoad %ulong %316
+%535 = OpIMul %ulong %534 %ulong_1099511628211
+OpStore %317 %535
+%536 = OpLoad %ulong %320
+%537 = OpIAdd %ulong %536 %ulong_1
+OpStore %318 %537
+%538 = OpLoad %ulong %317
+OpStore %319 %538
+%539 = OpLoad %ulong %318
+OpStore %320 %539
+OpBranch %235
+%216 = OpLabel
+%540 = OpLoad %ulong %310
+%541 = OpAccessChain %_ptr_Function_v4float %241 %540
+%542 = OpLoad %v4float %541
+OpStore %297 %542
+%543 = OpLoad %ulong %305
+%544 = OpLoad %v4float %297
+%545 = OpFunctionCall %ulong %1 %543 %544
+OpStore %298 %545
+%546 = OpLoad %ulong %310
+%547 = OpIAdd %ulong %546 %ulong_1
+OpStore %299 %547
+%548 = OpLoad %ulong %298
+OpStore %305 %548
+%549 = OpLoad %ulong %299
+OpStore %310 %549
+OpBranch %236
+%213 = OpLabel
+%550 = OpLoad %v4float %307
+%551 = OpLoad %v4float %252
+%552 = OpFMul %v4float %550 %551
+OpStore %287 %552
+%553 = OpLoad %ulong %306
+%554 = OpLoad %v4float %287
+%555 = OpFunctionCall %ulong %1 %553 %554
+OpStore %288 %555
+%556 = OpLoad %v4float %308
+%557 = OpLoad %v4float %287
+%558 = OpFAdd %v4float %556 %557
+OpStore %289 %558
+%559 = OpLoad %ulong %288
+%560 = OpLoad %v4float %289
+%561 = OpFunctionCall %ulong %1 %559 %560
+OpStore %290 %561
+%562 = OpLoad %v4float %307
+%563 = OpLoad %v4float %264
+%564 = OpFSub %v4float %562 %563
+OpStore %291 %564
+%565 = OpLoad %ulong %290
+%566 = OpLoad %v4float %291
+%567 = OpFunctionCall %ulong %1 %565 %566
+OpStore %292 %567
+%568 = OpLoad %ulong %309
+%569 = OpIAdd %ulong %568 %ulong_1
+OpStore %293 %569
+%570 = OpLoad %ulong %292
+OpStore %306 %570
+%571 = OpLoad %v4float %291
+OpStore %307 %571
+%572 = OpLoad %v4float %289
+OpStore %308 %572
+%573 = OpLoad %ulong %293
+OpStore %309 %573
+OpBranch %237
+%234 = OpLabel
+OpBranch %230
+%235 = OpLabel
+OpBranch %223
+%236 = OpLabel
+OpBranch %215
+%237 = OpLabel
+OpBranch %212
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f32x5.dis
+++ b/test/golden/spirv/vec/vec_f32x5.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1973
+; Bound: 1614
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,19 +14,24 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x5.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_5 = OpConstant %uint 5
 %_arr_float_uint_5 = OpTypeArray %float %uint_5
-%11 = OpTypeFunction %ulong %ulong %_arr_float_uint_5
+%8 = OpTypeFunction %ulong %ulong %_arr_float_uint_5
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_float_uint_5 = OpTypePointer Function %_arr_float_uint_5
 %_ptr_Function_float = OpTypePointer Function %float
-%56 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%256 = OpTypeFunction %ulong %ulong
 %uint_6 = OpConstant %uint 6
 %_arr__arr_float_uint_5_uint_6 = OpTypeArray %_arr_float_uint_5 %uint_6
 %_ptr_Function__arr__arr_float_uint_5_uint_6 = OpTypePointer Function %_arr__arr_float_uint_5_uint_6
-%_struct_104 = OpTypeStruct %uint %_arr_float_uint_5 %uint
-%_ptr_Function__struct_104 = OpTypePointer Function %_struct_104
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
+%_struct_289 = OpTypeStruct %uint %_arr_float_uint_5 %uint
+%_ptr_Function__struct_289 = OpTypePointer Function %_struct_289
 %float_2_25 = OpConstant %float 2.25
 %float_0_5 = OpConstant %float 0.5
 %float_1_5 = OpConstant %float 1.5
@@ -41,344 +46,453 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x5.checksum" Export
 %float_9 = OpConstant %float 9
 %float_27 = OpConstant %float 27
 %float_81 = OpConstant %float 81
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%1393 = OpConstantNull %_arr__arr_float_uint_5_uint_6
+%1205 = OpConstantNull %_arr__arr_float_uint_5_uint_6
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
-%1565 = OpConstantNull %_struct_104
+%1377 = OpConstantNull %_struct_289
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%1874 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1877 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1925 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_float_uint_5
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_float Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_float Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_float Function
-%29 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%30 = OpLoad %_arr_float_uint_5 %18
-%31 = OpCompositeExtract %float %30 0
-OpStore %20 %31
-%32 = OpLoad %ulong %16
-%33 = OpLoad %float %20
-%34 = OpFunctionCall %ulong %5 %32 %33
-OpStore %21 %34
-%35 = OpLoad %_arr_float_uint_5 %18
-%36 = OpCompositeExtract %float %35 1
-OpStore %22 %36
-%37 = OpLoad %ulong %21
-%38 = OpLoad %float %22
-%39 = OpFunctionCall %ulong %5 %37 %38
-OpStore %23 %39
-%40 = OpLoad %_arr_float_uint_5 %18
-%41 = OpCompositeExtract %float %40 2
-OpStore %24 %41
-%42 = OpLoad %ulong %23
-%43 = OpLoad %float %24
-%44 = OpFunctionCall %ulong %5 %42 %43
-OpStore %25 %44
-%45 = OpLoad %_arr_float_uint_5 %18
-%46 = OpCompositeExtract %float %45 3
-OpStore %26 %46
-%47 = OpLoad %ulong %25
-%48 = OpLoad %float %26
-%49 = OpFunctionCall %ulong %5 %47 %48
-OpStore %27 %49
-%50 = OpLoad %_arr_float_uint_5 %18
-%51 = OpCompositeExtract %float %50 4
-OpStore %28 %51
-%52 = OpLoad %ulong %27
-%53 = OpLoad %float %28
-%54 = OpFunctionCall %ulong %5 %52 %53
-OpStore %29 %54
-%55 = OpLoad %ulong %29
-OpReturnValue %55
-OpFunctionEnd
-%2 = OpFunction %ulong None %56
-%57 = OpFunctionParameter %ulong
-%58 = OpLabel
-%103 = OpVariable %_ptr_Function__arr__arr_float_uint_5_uint_6 Function
-%106 = OpVariable %_ptr_Function__struct_104 Function
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %_arr_float_uint_5
+%11 = OpLabel
+%54 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%58 = OpVariable %_ptr_Function_float Function
+%59 = OpVariable %_ptr_Function_float Function
+%60 = OpVariable %_ptr_Function_float Function
+%61 = OpVariable %_ptr_Function_float Function
+%62 = OpVariable %_ptr_Function_float Function
+%64 = OpVariable %_ptr_Function_uint Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_bool Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_uint Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_uint Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_bool Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_uint Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_bool Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
 %107 = OpVariable %_ptr_Function_ulong Function
 %108 = OpVariable %_ptr_Function_ulong Function
-%109 = OpVariable %_ptr_Function_float Function
-%110 = OpVariable %_ptr_Function_float Function
-%111 = OpVariable %_ptr_Function_float Function
-%112 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%113 = OpVariable %_ptr_Function_float Function
-%114 = OpVariable %_ptr_Function_float Function
-%115 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%116 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%117 = OpVariable %_ptr_Function_float Function
-%118 = OpVariable %_ptr_Function_float Function
-%119 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%120 = OpVariable %_ptr_Function_float Function
-%121 = OpVariable %_ptr_Function_float Function
-%122 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%123 = OpVariable %_ptr_Function_float Function
-%124 = OpVariable %_ptr_Function_float Function
-%125 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%126 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%128 = OpVariable %_ptr_Function_bool Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_bool Function
-%131 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%135 = OpVariable %_ptr_Function_uint Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%138 = OpVariable %_ptr_Function_uint Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%142 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%143 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_float Function
-%147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_float Function
-%149 = OpVariable %_ptr_Function_ulong Function
-%150 = OpVariable %_ptr_Function_float Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_float Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_float Function
-%155 = OpVariable %_ptr_Function_ulong Function
-%156 = OpVariable %_ptr_Function_float Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_float Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_float Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_float Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_float Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_float Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_float Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_float Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_float Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_float Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_float Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_float Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_float Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_float Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_float Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_float Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_float Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_float Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_float Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_float Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_float Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_float Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_float Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_float Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_float Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_float Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_float Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_float Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_float Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_float Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_float Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_float Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_float Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_float Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_float Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_float Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_float Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_float Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_float Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_float Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_float Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_float Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_float Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_float Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_float Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_float Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_float Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_float Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_float Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_float Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_float Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_float Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_float Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_float Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_float Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_float Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_float Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_float Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_float Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_float Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_float Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_float Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_float Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_float Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_float Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_float Function
-%293 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_uint Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_bool Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+OpStore %54 %9
+OpStore %56 %10
+%120 = OpLoad %_arr_float_uint_5 %56
+%121 = OpCompositeExtract %float %120 0
+OpStore %58 %121
+OpBranch %12
+%12 = OpLabel
+%122 = OpLoad %float %58
+%123 = OpBitcast %uint %122
+OpStore %64 %123
+%124 = OpLoad %uint %64
+%125 = OpUConvert %ulong %124
+OpStore %65 %125
+OpBranch %14
+%14 = OpLabel
+%126 = OpLoad %ulong %54
+OpStore %74 %126
+OpStore %75 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%128 = OpLoad %ulong %75
+%130 = OpULessThan %bool %128 %ulong_8
+OpStore %67 %130
+%131 = OpLoad %bool %67
+OpLoopMerge %17 %51 None
+OpBranchConditional %131 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%132 = OpLoad %_arr_float_uint_5 %56
+%133 = OpCompositeExtract %float %132 1
+OpStore %59 %133
+OpBranch %19
+%19 = OpLabel
+%134 = OpLoad %float %59
+%135 = OpBitcast %uint %134
+OpStore %76 %135
+%136 = OpLoad %uint %76
+%137 = OpUConvert %ulong %136
+OpStore %77 %137
+OpBranch %21
+%21 = OpLabel
+%138 = OpLoad %ulong %74
+OpStore %85 %138
+OpStore %86 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%139 = OpLoad %ulong %86
+%140 = OpULessThan %bool %139 %ulong_8
+OpStore %78 %140
+%141 = OpLoad %bool %78
+OpLoopMerge %24 %50 None
+OpBranchConditional %141 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%142 = OpLoad %_arr_float_uint_5 %56
+%143 = OpCompositeExtract %float %142 2
+OpStore %60 %143
+OpBranch %26
+%26 = OpLabel
+%144 = OpLoad %float %60
+%145 = OpBitcast %uint %144
+OpStore %87 %145
+%146 = OpLoad %uint %87
+%147 = OpUConvert %ulong %146
+OpStore %88 %147
+OpBranch %28
+%28 = OpLabel
+%148 = OpLoad %ulong %85
+OpStore %96 %148
+OpStore %97 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%149 = OpLoad %ulong %97
+%150 = OpULessThan %bool %149 %ulong_8
+OpStore %89 %150
+%151 = OpLoad %bool %89
+OpLoopMerge %31 %49 None
+OpBranchConditional %151 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%152 = OpLoad %_arr_float_uint_5 %56
+%153 = OpCompositeExtract %float %152 3
+OpStore %61 %153
+OpBranch %33
+%33 = OpLabel
+%154 = OpLoad %float %61
+%155 = OpBitcast %uint %154
+OpStore %98 %155
+%156 = OpLoad %uint %98
+%157 = OpUConvert %ulong %156
+OpStore %99 %157
+OpBranch %35
+%35 = OpLabel
+%158 = OpLoad %ulong %96
+OpStore %107 %158
+OpStore %108 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%159 = OpLoad %ulong %108
+%160 = OpULessThan %bool %159 %ulong_8
+OpStore %100 %160
+%161 = OpLoad %bool %100
+OpLoopMerge %38 %48 None
+OpBranchConditional %161 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%162 = OpLoad %_arr_float_uint_5 %56
+%163 = OpCompositeExtract %float %162 4
+OpStore %62 %163
+OpBranch %40
+%40 = OpLabel
+%164 = OpLoad %float %62
+%165 = OpBitcast %uint %164
+OpStore %109 %165
+%166 = OpLoad %uint %109
+%167 = OpUConvert %ulong %166
+OpStore %110 %167
+OpBranch %42
+%42 = OpLabel
+%168 = OpLoad %ulong %107
+OpStore %118 %168
+OpStore %119 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%169 = OpLoad %ulong %119
+%170 = OpULessThan %bool %169 %ulong_8
+OpStore %111 %170
+%171 = OpLoad %bool %111
+OpLoopMerge %45 %47 None
+OpBranchConditional %171 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%172 = OpLoad %ulong %118
+OpReturnValue %172
+%44 = OpLabel
+%173 = OpLoad %ulong %119
+%174 = OpIMul %ulong %173 %ulong_8
+OpStore %112 %174
+%175 = OpLoad %ulong %110
+%176 = OpLoad %ulong %112
+%177 = OpShiftRightLogical %ulong %175 %176
+OpStore %113 %177
+%178 = OpLoad %ulong %113
+%180 = OpBitwiseAnd %ulong %178 %ulong_255
+OpStore %114 %180
+%181 = OpLoad %ulong %118
+%182 = OpLoad %ulong %114
+%183 = OpBitwiseXor %ulong %181 %182
+OpStore %115 %183
+%184 = OpLoad %ulong %115
+%186 = OpIMul %ulong %184 %ulong_1099511628211
+OpStore %116 %186
+%187 = OpLoad %ulong %119
+%189 = OpIAdd %ulong %187 %ulong_1
+OpStore %117 %189
+%190 = OpLoad %ulong %116
+OpStore %118 %190
+%191 = OpLoad %ulong %117
+OpStore %119 %191
+OpBranch %47
+%37 = OpLabel
+%192 = OpLoad %ulong %108
+%193 = OpIMul %ulong %192 %ulong_8
+OpStore %101 %193
+%194 = OpLoad %ulong %99
+%195 = OpLoad %ulong %101
+%196 = OpShiftRightLogical %ulong %194 %195
+OpStore %102 %196
+%197 = OpLoad %ulong %102
+%198 = OpBitwiseAnd %ulong %197 %ulong_255
+OpStore %103 %198
+%199 = OpLoad %ulong %107
+%200 = OpLoad %ulong %103
+%201 = OpBitwiseXor %ulong %199 %200
+OpStore %104 %201
+%202 = OpLoad %ulong %104
+%203 = OpIMul %ulong %202 %ulong_1099511628211
+OpStore %105 %203
+%204 = OpLoad %ulong %108
+%205 = OpIAdd %ulong %204 %ulong_1
+OpStore %106 %205
+%206 = OpLoad %ulong %105
+OpStore %107 %206
+%207 = OpLoad %ulong %106
+OpStore %108 %207
+OpBranch %48
+%30 = OpLabel
+%208 = OpLoad %ulong %97
+%209 = OpIMul %ulong %208 %ulong_8
+OpStore %90 %209
+%210 = OpLoad %ulong %88
+%211 = OpLoad %ulong %90
+%212 = OpShiftRightLogical %ulong %210 %211
+OpStore %91 %212
+%213 = OpLoad %ulong %91
+%214 = OpBitwiseAnd %ulong %213 %ulong_255
+OpStore %92 %214
+%215 = OpLoad %ulong %96
+%216 = OpLoad %ulong %92
+%217 = OpBitwiseXor %ulong %215 %216
+OpStore %93 %217
+%218 = OpLoad %ulong %93
+%219 = OpIMul %ulong %218 %ulong_1099511628211
+OpStore %94 %219
+%220 = OpLoad %ulong %97
+%221 = OpIAdd %ulong %220 %ulong_1
+OpStore %95 %221
+%222 = OpLoad %ulong %94
+OpStore %96 %222
+%223 = OpLoad %ulong %95
+OpStore %97 %223
+OpBranch %49
+%23 = OpLabel
+%224 = OpLoad %ulong %86
+%225 = OpIMul %ulong %224 %ulong_8
+OpStore %79 %225
+%226 = OpLoad %ulong %77
+%227 = OpLoad %ulong %79
+%228 = OpShiftRightLogical %ulong %226 %227
+OpStore %80 %228
+%229 = OpLoad %ulong %80
+%230 = OpBitwiseAnd %ulong %229 %ulong_255
+OpStore %81 %230
+%231 = OpLoad %ulong %85
+%232 = OpLoad %ulong %81
+%233 = OpBitwiseXor %ulong %231 %232
+OpStore %82 %233
+%234 = OpLoad %ulong %82
+%235 = OpIMul %ulong %234 %ulong_1099511628211
+OpStore %83 %235
+%236 = OpLoad %ulong %86
+%237 = OpIAdd %ulong %236 %ulong_1
+OpStore %84 %237
+%238 = OpLoad %ulong %83
+OpStore %85 %238
+%239 = OpLoad %ulong %84
+OpStore %86 %239
+OpBranch %50
+%16 = OpLabel
+%240 = OpLoad %ulong %75
+%241 = OpIMul %ulong %240 %ulong_8
+OpStore %68 %241
+%242 = OpLoad %ulong %65
+%243 = OpLoad %ulong %68
+%244 = OpShiftRightLogical %ulong %242 %243
+OpStore %69 %244
+%245 = OpLoad %ulong %69
+%246 = OpBitwiseAnd %ulong %245 %ulong_255
+OpStore %70 %246
+%247 = OpLoad %ulong %74
+%248 = OpLoad %ulong %70
+%249 = OpBitwiseXor %ulong %247 %248
+OpStore %71 %249
+%250 = OpLoad %ulong %71
+%251 = OpIMul %ulong %250 %ulong_1099511628211
+OpStore %72 %251
+%252 = OpLoad %ulong %75
+%253 = OpIAdd %ulong %252 %ulong_1
+OpStore %73 %253
+%254 = OpLoad %ulong %72
+OpStore %74 %254
+%255 = OpLoad %ulong %73
+OpStore %75 %255
+OpBranch %51
+%47 = OpLabel
+OpBranch %43
+%48 = OpLabel
+OpBranch %36
+%49 = OpLabel
+OpBranch %29
+%50 = OpLabel
+OpBranch %22
+%51 = OpLabel
+OpBranch %15
+OpFunctionEnd
+%2 = OpFunction %ulong None %256
+%257 = OpFunctionParameter %ulong
+%258 = OpLabel
+%288 = OpVariable %_ptr_Function__arr__arr_float_uint_5_uint_6 Function
+%291 = OpVariable %_ptr_Function__struct_289 Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_float Function
 %294 = OpVariable %_ptr_Function_float Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_float Function
-%297 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_float Function
+%296 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%297 = OpVariable %_ptr_Function_float Function
 %298 = OpVariable %_ptr_Function_float Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_float Function
-%301 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%300 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%301 = OpVariable %_ptr_Function_float Function
 %302 = OpVariable %_ptr_Function_float Function
-%303 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %304 = OpVariable %_ptr_Function_float Function
-%305 = OpVariable %_ptr_Function_ulong Function
-%306 = OpVariable %_ptr_Function_float Function
+%305 = OpVariable %_ptr_Function_float Function
+%306 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %307 = OpVariable %_ptr_Function_float Function
 %308 = OpVariable %_ptr_Function_float Function
-%309 = OpVariable %_ptr_Function_float Function
-%310 = OpVariable %_ptr_Function_float Function
-%311 = OpVariable %_ptr_Function_float Function
-%312 = OpVariable %_ptr_Function_float Function
-%313 = OpVariable %_ptr_Function_float Function
-%314 = OpVariable %_ptr_Function_float Function
-%315 = OpVariable %_ptr_Function_float Function
-%316 = OpVariable %_ptr_Function_float Function
-%317 = OpVariable %_ptr_Function_float Function
-%318 = OpVariable %_ptr_Function_float Function
-%319 = OpVariable %_ptr_Function_float Function
-%320 = OpVariable %_ptr_Function_float Function
+%309 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
 %321 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%322 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%323 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%324 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%325 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%326 = OpVariable %_ptr_Function_float Function
-%327 = OpVariable %_ptr_Function_float Function
-%328 = OpVariable %_ptr_Function_float Function
-%329 = OpVariable %_ptr_Function_float Function
-%330 = OpVariable %_ptr_Function_float Function
-%331 = OpVariable %_ptr_Function_float Function
-%332 = OpVariable %_ptr_Function_float Function
-%333 = OpVariable %_ptr_Function_float Function
-%334 = OpVariable %_ptr_Function_float Function
-%335 = OpVariable %_ptr_Function_float Function
-%336 = OpVariable %_ptr_Function_float Function
-%337 = OpVariable %_ptr_Function_float Function
-%338 = OpVariable %_ptr_Function_float Function
-%339 = OpVariable %_ptr_Function_float Function
-%340 = OpVariable %_ptr_Function_float Function
-%341 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%342 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%343 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%344 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%345 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%346 = OpVariable %_ptr_Function_float Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_float Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_float Function
-%353 = OpVariable %_ptr_Function_float Function
-%354 = OpVariable %_ptr_Function_float Function
-%355 = OpVariable %_ptr_Function_float Function
-%356 = OpVariable %_ptr_Function_float Function
-%357 = OpVariable %_ptr_Function_float Function
-%358 = OpVariable %_ptr_Function_float Function
-%359 = OpVariable %_ptr_Function_float Function
-%360 = OpVariable %_ptr_Function_float Function
-%361 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%362 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%363 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%364 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%365 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%322 = OpVariable %_ptr_Function_bool Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_bool Function
+%328 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%332 = OpVariable %_ptr_Function_uint Function
+%333 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%334 = OpVariable %_ptr_Function_ulong Function
+%335 = OpVariable %_ptr_Function_uint Function
+%336 = OpVariable %_ptr_Function_ulong Function
+%337 = OpVariable %_ptr_Function_ulong Function
+%338 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%339 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_ulong Function
+%342 = OpVariable %_ptr_Function_ulong Function
+%343 = OpVariable %_ptr_Function_bool Function
+%344 = OpVariable %_ptr_Function_ulong Function
+%345 = OpVariable %_ptr_Function_ulong Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_ulong Function
+%351 = OpVariable %_ptr_Function_ulong Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_bool Function
+%354 = OpVariable %_ptr_Function_ulong Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ulong Function
+%359 = OpVariable %_ptr_Function_ulong Function
+%360 = OpVariable %_ptr_Function_ulong Function
+%361 = OpVariable %_ptr_Function_ulong Function
+%362 = OpVariable %_ptr_Function_float Function
+%363 = OpVariable %_ptr_Function_float Function
+%364 = OpVariable %_ptr_Function_float Function
+%365 = OpVariable %_ptr_Function_float Function
 %366 = OpVariable %_ptr_Function_float Function
 %367 = OpVariable %_ptr_Function_float Function
 %368 = OpVariable %_ptr_Function_float Function
@@ -390,15 +504,15 @@ OpFunctionEnd
 %374 = OpVariable %_ptr_Function_float Function
 %375 = OpVariable %_ptr_Function_float Function
 %376 = OpVariable %_ptr_Function_float Function
-%377 = OpVariable %_ptr_Function_float Function
-%378 = OpVariable %_ptr_Function_float Function
-%379 = OpVariable %_ptr_Function_float Function
-%380 = OpVariable %_ptr_Function_float Function
+%377 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%378 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%379 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%380 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %381 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%382 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%383 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%384 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%385 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%382 = OpVariable %_ptr_Function_float Function
+%383 = OpVariable %_ptr_Function_float Function
+%384 = OpVariable %_ptr_Function_float Function
+%385 = OpVariable %_ptr_Function_float Function
 %386 = OpVariable %_ptr_Function_float Function
 %387 = OpVariable %_ptr_Function_float Function
 %388 = OpVariable %_ptr_Function_float Function
@@ -410,15 +524,15 @@ OpFunctionEnd
 %394 = OpVariable %_ptr_Function_float Function
 %395 = OpVariable %_ptr_Function_float Function
 %396 = OpVariable %_ptr_Function_float Function
-%397 = OpVariable %_ptr_Function_float Function
-%398 = OpVariable %_ptr_Function_float Function
-%399 = OpVariable %_ptr_Function_float Function
-%400 = OpVariable %_ptr_Function_float Function
+%397 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%398 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%399 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%400 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %401 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%402 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%403 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%404 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%405 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%402 = OpVariable %_ptr_Function_float Function
+%403 = OpVariable %_ptr_Function_float Function
+%404 = OpVariable %_ptr_Function_float Function
+%405 = OpVariable %_ptr_Function_float Function
 %406 = OpVariable %_ptr_Function_float Function
 %407 = OpVariable %_ptr_Function_float Function
 %408 = OpVariable %_ptr_Function_float Function
@@ -430,15 +544,15 @@ OpFunctionEnd
 %414 = OpVariable %_ptr_Function_float Function
 %415 = OpVariable %_ptr_Function_float Function
 %416 = OpVariable %_ptr_Function_float Function
-%417 = OpVariable %_ptr_Function_float Function
-%418 = OpVariable %_ptr_Function_float Function
-%419 = OpVariable %_ptr_Function_float Function
-%420 = OpVariable %_ptr_Function_float Function
+%417 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%418 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%419 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%420 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %421 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%422 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%423 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%424 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%425 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%422 = OpVariable %_ptr_Function_float Function
+%423 = OpVariable %_ptr_Function_float Function
+%424 = OpVariable %_ptr_Function_float Function
+%425 = OpVariable %_ptr_Function_float Function
 %426 = OpVariable %_ptr_Function_float Function
 %427 = OpVariable %_ptr_Function_float Function
 %428 = OpVariable %_ptr_Function_float Function
@@ -450,15 +564,15 @@ OpFunctionEnd
 %434 = OpVariable %_ptr_Function_float Function
 %435 = OpVariable %_ptr_Function_float Function
 %436 = OpVariable %_ptr_Function_float Function
-%437 = OpVariable %_ptr_Function_float Function
-%438 = OpVariable %_ptr_Function_float Function
-%439 = OpVariable %_ptr_Function_float Function
-%440 = OpVariable %_ptr_Function_float Function
+%437 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%438 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%439 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%440 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %441 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%442 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%443 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%444 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%445 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%442 = OpVariable %_ptr_Function_float Function
+%443 = OpVariable %_ptr_Function_float Function
+%444 = OpVariable %_ptr_Function_float Function
+%445 = OpVariable %_ptr_Function_float Function
 %446 = OpVariable %_ptr_Function_float Function
 %447 = OpVariable %_ptr_Function_float Function
 %448 = OpVariable %_ptr_Function_float Function
@@ -470,15 +584,15 @@ OpFunctionEnd
 %454 = OpVariable %_ptr_Function_float Function
 %455 = OpVariable %_ptr_Function_float Function
 %456 = OpVariable %_ptr_Function_float Function
-%457 = OpVariable %_ptr_Function_float Function
-%458 = OpVariable %_ptr_Function_float Function
-%459 = OpVariable %_ptr_Function_float Function
-%460 = OpVariable %_ptr_Function_float Function
+%457 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%458 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%459 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%460 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %461 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%462 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%463 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%464 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%465 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%462 = OpVariable %_ptr_Function_float Function
+%463 = OpVariable %_ptr_Function_float Function
+%464 = OpVariable %_ptr_Function_float Function
+%465 = OpVariable %_ptr_Function_float Function
 %466 = OpVariable %_ptr_Function_float Function
 %467 = OpVariable %_ptr_Function_float Function
 %468 = OpVariable %_ptr_Function_float Function
@@ -490,15 +604,15 @@ OpFunctionEnd
 %474 = OpVariable %_ptr_Function_float Function
 %475 = OpVariable %_ptr_Function_float Function
 %476 = OpVariable %_ptr_Function_float Function
-%477 = OpVariable %_ptr_Function_float Function
-%478 = OpVariable %_ptr_Function_float Function
-%479 = OpVariable %_ptr_Function_float Function
-%480 = OpVariable %_ptr_Function_float Function
+%477 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%478 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%479 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%480 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %481 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%482 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%483 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%484 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%485 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%482 = OpVariable %_ptr_Function_float Function
+%483 = OpVariable %_ptr_Function_float Function
+%484 = OpVariable %_ptr_Function_float Function
+%485 = OpVariable %_ptr_Function_float Function
 %486 = OpVariable %_ptr_Function_float Function
 %487 = OpVariable %_ptr_Function_float Function
 %488 = OpVariable %_ptr_Function_float Function
@@ -510,15 +624,15 @@ OpFunctionEnd
 %494 = OpVariable %_ptr_Function_float Function
 %495 = OpVariable %_ptr_Function_float Function
 %496 = OpVariable %_ptr_Function_float Function
-%497 = OpVariable %_ptr_Function_float Function
-%498 = OpVariable %_ptr_Function_float Function
-%499 = OpVariable %_ptr_Function_float Function
-%500 = OpVariable %_ptr_Function_float Function
+%497 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%498 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%499 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%500 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %501 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%502 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%503 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%504 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%505 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%502 = OpVariable %_ptr_Function_float Function
+%503 = OpVariable %_ptr_Function_float Function
+%504 = OpVariable %_ptr_Function_float Function
+%505 = OpVariable %_ptr_Function_float Function
 %506 = OpVariable %_ptr_Function_float Function
 %507 = OpVariable %_ptr_Function_float Function
 %508 = OpVariable %_ptr_Function_float Function
@@ -530,15 +644,15 @@ OpFunctionEnd
 %514 = OpVariable %_ptr_Function_float Function
 %515 = OpVariable %_ptr_Function_float Function
 %516 = OpVariable %_ptr_Function_float Function
-%517 = OpVariable %_ptr_Function_float Function
-%518 = OpVariable %_ptr_Function_float Function
-%519 = OpVariable %_ptr_Function_float Function
-%520 = OpVariable %_ptr_Function_float Function
+%517 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%518 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%519 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%520 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %521 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%522 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%523 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%524 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%525 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%522 = OpVariable %_ptr_Function_float Function
+%523 = OpVariable %_ptr_Function_float Function
+%524 = OpVariable %_ptr_Function_float Function
+%525 = OpVariable %_ptr_Function_float Function
 %526 = OpVariable %_ptr_Function_float Function
 %527 = OpVariable %_ptr_Function_float Function
 %528 = OpVariable %_ptr_Function_float Function
@@ -550,15 +664,15 @@ OpFunctionEnd
 %534 = OpVariable %_ptr_Function_float Function
 %535 = OpVariable %_ptr_Function_float Function
 %536 = OpVariable %_ptr_Function_float Function
-%537 = OpVariable %_ptr_Function_float Function
-%538 = OpVariable %_ptr_Function_float Function
-%539 = OpVariable %_ptr_Function_float Function
-%540 = OpVariable %_ptr_Function_float Function
+%537 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%538 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%539 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%540 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %541 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%542 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%543 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%544 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%545 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%542 = OpVariable %_ptr_Function_float Function
+%543 = OpVariable %_ptr_Function_float Function
+%544 = OpVariable %_ptr_Function_float Function
+%545 = OpVariable %_ptr_Function_float Function
 %546 = OpVariable %_ptr_Function_float Function
 %547 = OpVariable %_ptr_Function_float Function
 %548 = OpVariable %_ptr_Function_float Function
@@ -570,15 +684,15 @@ OpFunctionEnd
 %554 = OpVariable %_ptr_Function_float Function
 %555 = OpVariable %_ptr_Function_float Function
 %556 = OpVariable %_ptr_Function_float Function
-%557 = OpVariable %_ptr_Function_float Function
-%558 = OpVariable %_ptr_Function_float Function
-%559 = OpVariable %_ptr_Function_float Function
-%560 = OpVariable %_ptr_Function_float Function
+%557 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%558 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%559 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%560 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %561 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%562 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%563 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%564 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%565 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%562 = OpVariable %_ptr_Function_float Function
+%563 = OpVariable %_ptr_Function_float Function
+%564 = OpVariable %_ptr_Function_float Function
+%565 = OpVariable %_ptr_Function_float Function
 %566 = OpVariable %_ptr_Function_float Function
 %567 = OpVariable %_ptr_Function_float Function
 %568 = OpVariable %_ptr_Function_float Function
@@ -590,15 +704,15 @@ OpFunctionEnd
 %574 = OpVariable %_ptr_Function_float Function
 %575 = OpVariable %_ptr_Function_float Function
 %576 = OpVariable %_ptr_Function_float Function
-%577 = OpVariable %_ptr_Function_float Function
-%578 = OpVariable %_ptr_Function_float Function
-%579 = OpVariable %_ptr_Function_float Function
-%580 = OpVariable %_ptr_Function_float Function
+%577 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%578 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%579 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%580 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %581 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%582 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%583 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%584 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%585 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%582 = OpVariable %_ptr_Function_float Function
+%583 = OpVariable %_ptr_Function_float Function
+%584 = OpVariable %_ptr_Function_float Function
+%585 = OpVariable %_ptr_Function_float Function
 %586 = OpVariable %_ptr_Function_float Function
 %587 = OpVariable %_ptr_Function_float Function
 %588 = OpVariable %_ptr_Function_float Function
@@ -610,1995 +724,1443 @@ OpFunctionEnd
 %594 = OpVariable %_ptr_Function_float Function
 %595 = OpVariable %_ptr_Function_float Function
 %596 = OpVariable %_ptr_Function_float Function
-%597 = OpVariable %_ptr_Function_float Function
-%598 = OpVariable %_ptr_Function_float Function
-%599 = OpVariable %_ptr_Function_float Function
-%600 = OpVariable %_ptr_Function_float Function
+%597 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%598 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%599 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%600 = OpVariable %_ptr_Function__arr_float_uint_5 Function
 %601 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%602 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%603 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%604 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%605 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-OpStore %107 %57
-%606 = OpFunctionCall %ulong %3
-OpStore %108 %606
-%607 = OpLoad %ulong %107
-%608 = OpConvertUToF %float %607
-OpStore %109 %608
-%610 = OpFNegate %float %float_2_25
-OpStore %110 %610
-%612 = OpFNegate %float %float_0_5
-OpStore %111 %612
-%615 = OpLoad %float %110
-%617 = OpLoad %float %111
-%613 = OpCompositeConstruct %_arr_float_uint_5 %float_1_5 %615 %float_3_75 %617 %float_6_25
-OpStore %112 %613
-%620 = OpFNegate %float %float_0_125
-OpStore %113 %620
-%622 = OpFNegate %float %float_2
-OpStore %114 %622
-%625 = OpLoad %float %113
-%627 = OpLoad %float %114
-%623 = OpCompositeConstruct %_arr_float_uint_5 %float_0_5 %float_4 %625 %float_8 %627
-OpStore %115 %623
-%628 = OpCompositeConstruct %_arr_float_uint_5 %float_1 %float_3 %float_9 %float_27 %float_81
-OpStore %116 %628
-%634 = OpLoad %_arr_float_uint_5 %112
-%635 = OpCompositeExtract %float %634 0
-OpStore %117 %635
-%636 = OpLoad %float %117
-%637 = OpLoad %float %109
-%638 = OpFAdd %float %636 %637
-OpStore %118 %638
-%639 = OpLoad %_arr_float_uint_5 %112
-%640 = OpLoad %float %118
-%641 = OpCompositeInsert %_arr_float_uint_5 %640 %639 0
-OpStore %119 %641
-%642 = OpLoad %_arr_float_uint_5 %119
-%643 = OpCompositeExtract %float %642 4
-OpStore %120 %643
-%644 = OpLoad %float %120
-%645 = OpLoad %float %109
-%646 = OpFAdd %float %644 %645
-OpStore %121 %646
-%647 = OpLoad %_arr_float_uint_5 %119
-%648 = OpLoad %float %121
-%649 = OpCompositeInsert %_arr_float_uint_5 %648 %647 4
-OpStore %122 %649
-%650 = OpLoad %_arr_float_uint_5 %115
-%651 = OpCompositeExtract %float %650 2
-OpStore %123 %651
-%652 = OpLoad %float %123
-%653 = OpLoad %float %109
-%654 = OpFAdd %float %652 %653
-OpStore %124 %654
-%655 = OpLoad %_arr_float_uint_5 %115
-%656 = OpLoad %float %124
-%657 = OpCompositeInsert %_arr_float_uint_5 %656 %655 2
-OpStore %125 %657
-OpBranch %65
-%65 = OpLabel
-%658 = OpLoad %_arr_float_uint_5 %122
-%659 = OpCompositeExtract %float %658 0
-OpStore %146 %659
-%660 = OpLoad %ulong %108
-%661 = OpLoad %float %146
-%662 = OpFunctionCall %ulong %5 %660 %661
-OpStore %147 %662
-%663 = OpLoad %_arr_float_uint_5 %122
-%664 = OpCompositeExtract %float %663 1
-OpStore %148 %664
-%665 = OpLoad %ulong %147
-%666 = OpLoad %float %148
-%667 = OpFunctionCall %ulong %5 %665 %666
-OpStore %149 %667
-%668 = OpLoad %_arr_float_uint_5 %122
-%669 = OpCompositeExtract %float %668 2
-OpStore %150 %669
-%670 = OpLoad %ulong %149
-%671 = OpLoad %float %150
-%672 = OpFunctionCall %ulong %5 %670 %671
-OpStore %151 %672
-%673 = OpLoad %_arr_float_uint_5 %122
-%674 = OpCompositeExtract %float %673 3
-OpStore %152 %674
-%675 = OpLoad %ulong %151
-%676 = OpLoad %float %152
-%677 = OpFunctionCall %ulong %5 %675 %676
-OpStore %153 %677
-%678 = OpLoad %_arr_float_uint_5 %122
-%679 = OpCompositeExtract %float %678 4
-OpStore %154 %679
-%680 = OpLoad %ulong %153
-%681 = OpLoad %float %154
-%682 = OpFunctionCall %ulong %5 %680 %681
-OpStore %155 %682
-OpBranch %66
-%66 = OpLabel
-OpBranch %73
-%73 = OpLabel
-%683 = OpLoad %_arr_float_uint_5 %125
-%684 = OpCompositeExtract %float %683 0
-OpStore %186 %684
-%685 = OpLoad %ulong %155
-%686 = OpLoad %float %186
-%687 = OpFunctionCall %ulong %5 %685 %686
-OpStore %187 %687
-%688 = OpLoad %_arr_float_uint_5 %125
-%689 = OpCompositeExtract %float %688 1
-OpStore %188 %689
-%690 = OpLoad %ulong %187
-%691 = OpLoad %float %188
-%692 = OpFunctionCall %ulong %5 %690 %691
-OpStore %189 %692
-%693 = OpLoad %_arr_float_uint_5 %125
-%694 = OpCompositeExtract %float %693 2
-OpStore %190 %694
-%695 = OpLoad %ulong %189
-%696 = OpLoad %float %190
-%697 = OpFunctionCall %ulong %5 %695 %696
-OpStore %191 %697
-%698 = OpLoad %_arr_float_uint_5 %125
-%699 = OpCompositeExtract %float %698 3
-OpStore %192 %699
-%700 = OpLoad %ulong %191
-%701 = OpLoad %float %192
-%702 = OpFunctionCall %ulong %5 %700 %701
-OpStore %193 %702
-%703 = OpLoad %_arr_float_uint_5 %125
-%704 = OpCompositeExtract %float %703 4
-OpStore %194 %704
-%705 = OpLoad %ulong %193
-%706 = OpLoad %float %194
-%707 = OpFunctionCall %ulong %5 %705 %706
-OpStore %195 %707
-OpBranch %74
-%74 = OpLabel
-%708 = OpLoad %_arr_float_uint_5 %122
-%709 = OpCompositeExtract %float %708 0
-OpStore %406 %709
-%710 = OpLoad %_arr_float_uint_5 %125
-%711 = OpCompositeExtract %float %710 0
-OpStore %407 %711
-%712 = OpLoad %float %406
-%713 = OpLoad %float %407
-%714 = OpFAdd %float %712 %713
-OpStore %408 %714
-%715 = OpLoad %_arr_float_uint_5 %122
-%716 = OpCompositeExtract %float %715 1
-OpStore %409 %716
-%717 = OpLoad %_arr_float_uint_5 %125
-%718 = OpCompositeExtract %float %717 1
-OpStore %410 %718
-%719 = OpLoad %float %409
-%720 = OpLoad %float %410
-%721 = OpFAdd %float %719 %720
-OpStore %411 %721
-%722 = OpLoad %_arr_float_uint_5 %122
-%723 = OpCompositeExtract %float %722 2
-OpStore %412 %723
-%724 = OpLoad %_arr_float_uint_5 %125
-%725 = OpCompositeExtract %float %724 2
-OpStore %413 %725
-%726 = OpLoad %float %412
-%727 = OpLoad %float %413
-%728 = OpFAdd %float %726 %727
-OpStore %414 %728
-%729 = OpLoad %_arr_float_uint_5 %122
-%730 = OpCompositeExtract %float %729 3
-OpStore %415 %730
-%731 = OpLoad %_arr_float_uint_5 %125
-%732 = OpCompositeExtract %float %731 3
-OpStore %416 %732
-%733 = OpLoad %float %415
-%734 = OpLoad %float %416
-%735 = OpFAdd %float %733 %734
-OpStore %417 %735
-%736 = OpLoad %_arr_float_uint_5 %122
-%737 = OpCompositeExtract %float %736 4
-OpStore %418 %737
-%738 = OpLoad %_arr_float_uint_5 %125
-%739 = OpCompositeExtract %float %738 4
-OpStore %419 %739
-%740 = OpLoad %float %418
-%741 = OpLoad %float %419
-%742 = OpFAdd %float %740 %741
-OpStore %420 %742
-%743 = OpLoad %_arr_float_uint_5 %122
-%744 = OpLoad %float %408
-%745 = OpCompositeInsert %_arr_float_uint_5 %744 %743 0
-OpStore %421 %745
-%746 = OpLoad %_arr_float_uint_5 %421
-%747 = OpLoad %float %411
-%748 = OpCompositeInsert %_arr_float_uint_5 %747 %746 1
-OpStore %422 %748
-%749 = OpLoad %_arr_float_uint_5 %422
-%750 = OpLoad %float %414
-%751 = OpCompositeInsert %_arr_float_uint_5 %750 %749 2
-OpStore %423 %751
-%752 = OpLoad %_arr_float_uint_5 %423
-%753 = OpLoad %float %417
-%754 = OpCompositeInsert %_arr_float_uint_5 %753 %752 3
-OpStore %424 %754
-%755 = OpLoad %_arr_float_uint_5 %424
-%756 = OpLoad %float %420
-%757 = OpCompositeInsert %_arr_float_uint_5 %756 %755 4
-OpStore %425 %757
-OpBranch %77
-%77 = OpLabel
-%758 = OpLoad %_arr_float_uint_5 %425
-%759 = OpCompositeExtract %float %758 0
-OpStore %206 %759
-%760 = OpLoad %ulong %195
-%761 = OpLoad %float %206
-%762 = OpFunctionCall %ulong %5 %760 %761
-OpStore %207 %762
-%763 = OpLoad %_arr_float_uint_5 %425
-%764 = OpCompositeExtract %float %763 1
-OpStore %208 %764
-%765 = OpLoad %ulong %207
-%766 = OpLoad %float %208
-%767 = OpFunctionCall %ulong %5 %765 %766
-OpStore %209 %767
-%768 = OpLoad %_arr_float_uint_5 %425
-%769 = OpCompositeExtract %float %768 2
-OpStore %210 %769
-%770 = OpLoad %ulong %209
-%771 = OpLoad %float %210
-%772 = OpFunctionCall %ulong %5 %770 %771
-OpStore %211 %772
-%773 = OpLoad %_arr_float_uint_5 %425
-%774 = OpCompositeExtract %float %773 3
-OpStore %212 %774
-%775 = OpLoad %ulong %211
-%776 = OpLoad %float %212
-%777 = OpFunctionCall %ulong %5 %775 %776
-OpStore %213 %777
-%778 = OpLoad %_arr_float_uint_5 %425
-%779 = OpCompositeExtract %float %778 4
-OpStore %214 %779
-%780 = OpLoad %ulong %213
-%781 = OpLoad %float %214
-%782 = OpFunctionCall %ulong %5 %780 %781
-OpStore %215 %782
-OpBranch %78
-%78 = OpLabel
-%783 = OpLoad %_arr_float_uint_5 %122
-%784 = OpCompositeExtract %float %783 0
-OpStore %446 %784
-%785 = OpLoad %_arr_float_uint_5 %125
-%786 = OpCompositeExtract %float %785 0
-OpStore %447 %786
-%787 = OpLoad %float %446
-%788 = OpLoad %float %447
-%789 = OpFSub %float %787 %788
-OpStore %448 %789
-%790 = OpLoad %_arr_float_uint_5 %122
-%791 = OpCompositeExtract %float %790 1
-OpStore %449 %791
-%792 = OpLoad %_arr_float_uint_5 %125
-%793 = OpCompositeExtract %float %792 1
-OpStore %450 %793
-%794 = OpLoad %float %449
-%795 = OpLoad %float %450
-%796 = OpFSub %float %794 %795
-OpStore %451 %796
-%797 = OpLoad %_arr_float_uint_5 %122
-%798 = OpCompositeExtract %float %797 2
-OpStore %452 %798
-%799 = OpLoad %_arr_float_uint_5 %125
-%800 = OpCompositeExtract %float %799 2
-OpStore %453 %800
-%801 = OpLoad %float %452
-%802 = OpLoad %float %453
-%803 = OpFSub %float %801 %802
-OpStore %454 %803
-%804 = OpLoad %_arr_float_uint_5 %122
-%805 = OpCompositeExtract %float %804 3
-OpStore %455 %805
-%806 = OpLoad %_arr_float_uint_5 %125
-%807 = OpCompositeExtract %float %806 3
-OpStore %456 %807
-%808 = OpLoad %float %455
-%809 = OpLoad %float %456
-%810 = OpFSub %float %808 %809
-OpStore %457 %810
-%811 = OpLoad %_arr_float_uint_5 %122
-%812 = OpCompositeExtract %float %811 4
-OpStore %458 %812
-%813 = OpLoad %_arr_float_uint_5 %125
-%814 = OpCompositeExtract %float %813 4
-OpStore %459 %814
-%815 = OpLoad %float %458
-%816 = OpLoad %float %459
-%817 = OpFSub %float %815 %816
-OpStore %460 %817
-%818 = OpLoad %_arr_float_uint_5 %122
-%819 = OpLoad %float %448
-%820 = OpCompositeInsert %_arr_float_uint_5 %819 %818 0
-OpStore %461 %820
-%821 = OpLoad %_arr_float_uint_5 %461
-%822 = OpLoad %float %451
-%823 = OpCompositeInsert %_arr_float_uint_5 %822 %821 1
-OpStore %462 %823
-%824 = OpLoad %_arr_float_uint_5 %462
-%825 = OpLoad %float %454
-%826 = OpCompositeInsert %_arr_float_uint_5 %825 %824 2
-OpStore %463 %826
-%827 = OpLoad %_arr_float_uint_5 %463
-%828 = OpLoad %float %457
-%829 = OpCompositeInsert %_arr_float_uint_5 %828 %827 3
-OpStore %464 %829
-%830 = OpLoad %_arr_float_uint_5 %464
-%831 = OpLoad %float %460
-%832 = OpCompositeInsert %_arr_float_uint_5 %831 %830 4
-OpStore %465 %832
-OpBranch %81
-%81 = OpLabel
-%833 = OpLoad %_arr_float_uint_5 %465
-%834 = OpCompositeExtract %float %833 0
-OpStore %226 %834
-%835 = OpLoad %ulong %215
-%836 = OpLoad %float %226
-%837 = OpFunctionCall %ulong %5 %835 %836
-OpStore %227 %837
-%838 = OpLoad %_arr_float_uint_5 %465
-%839 = OpCompositeExtract %float %838 1
-OpStore %228 %839
-%840 = OpLoad %ulong %227
-%841 = OpLoad %float %228
-%842 = OpFunctionCall %ulong %5 %840 %841
-OpStore %229 %842
-%843 = OpLoad %_arr_float_uint_5 %465
-%844 = OpCompositeExtract %float %843 2
-OpStore %230 %844
-%845 = OpLoad %ulong %229
-%846 = OpLoad %float %230
-%847 = OpFunctionCall %ulong %5 %845 %846
-OpStore %231 %847
-%848 = OpLoad %_arr_float_uint_5 %465
+%602 = OpVariable %_ptr_Function_float Function
+%603 = OpVariable %_ptr_Function_float Function
+%604 = OpVariable %_ptr_Function_float Function
+%605 = OpVariable %_ptr_Function_float Function
+%606 = OpVariable %_ptr_Function_float Function
+%607 = OpVariable %_ptr_Function_float Function
+%608 = OpVariable %_ptr_Function_float Function
+%609 = OpVariable %_ptr_Function_float Function
+%610 = OpVariable %_ptr_Function_float Function
+%611 = OpVariable %_ptr_Function_float Function
+%612 = OpVariable %_ptr_Function_float Function
+%613 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function_float Function
+%615 = OpVariable %_ptr_Function_float Function
+%616 = OpVariable %_ptr_Function_float Function
+%617 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%618 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%619 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%620 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%621 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%622 = OpVariable %_ptr_Function_float Function
+%623 = OpVariable %_ptr_Function_float Function
+%624 = OpVariable %_ptr_Function_float Function
+%625 = OpVariable %_ptr_Function_float Function
+%626 = OpVariable %_ptr_Function_float Function
+%627 = OpVariable %_ptr_Function_float Function
+%628 = OpVariable %_ptr_Function_float Function
+%629 = OpVariable %_ptr_Function_float Function
+%630 = OpVariable %_ptr_Function_float Function
+%631 = OpVariable %_ptr_Function_float Function
+%632 = OpVariable %_ptr_Function_float Function
+%633 = OpVariable %_ptr_Function_float Function
+%634 = OpVariable %_ptr_Function_float Function
+%635 = OpVariable %_ptr_Function_float Function
+%636 = OpVariable %_ptr_Function_float Function
+%637 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%638 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%639 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%640 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%641 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%642 = OpVariable %_ptr_Function_float Function
+%643 = OpVariable %_ptr_Function_float Function
+%644 = OpVariable %_ptr_Function_float Function
+%645 = OpVariable %_ptr_Function_float Function
+%646 = OpVariable %_ptr_Function_float Function
+%647 = OpVariable %_ptr_Function_float Function
+%648 = OpVariable %_ptr_Function_float Function
+%649 = OpVariable %_ptr_Function_float Function
+%650 = OpVariable %_ptr_Function_float Function
+%651 = OpVariable %_ptr_Function_float Function
+%652 = OpVariable %_ptr_Function_float Function
+%653 = OpVariable %_ptr_Function_float Function
+%654 = OpVariable %_ptr_Function_float Function
+%655 = OpVariable %_ptr_Function_float Function
+%656 = OpVariable %_ptr_Function_float Function
+%657 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%658 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%659 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%660 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%661 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+OpStore %292 %257
+OpBranch %265
+%265 = OpLabel
+OpBranch %266
+%266 = OpLabel
+%662 = OpLoad %ulong %292
+%663 = OpConvertUToF %float %662
+OpStore %293 %663
+%665 = OpFNegate %float %float_2_25
+OpStore %294 %665
+%667 = OpFNegate %float %float_0_5
+OpStore %295 %667
+%670 = OpLoad %float %294
+%672 = OpLoad %float %295
+%668 = OpCompositeConstruct %_arr_float_uint_5 %float_1_5 %670 %float_3_75 %672 %float_6_25
+OpStore %296 %668
+%675 = OpFNegate %float %float_0_125
+OpStore %297 %675
+%677 = OpFNegate %float %float_2
+OpStore %298 %677
+%680 = OpLoad %float %297
+%682 = OpLoad %float %298
+%678 = OpCompositeConstruct %_arr_float_uint_5 %float_0_5 %float_4 %680 %float_8 %682
+OpStore %299 %678
+%683 = OpCompositeConstruct %_arr_float_uint_5 %float_1 %float_3 %float_9 %float_27 %float_81
+OpStore %300 %683
+%689 = OpLoad %_arr_float_uint_5 %296
+%690 = OpCompositeExtract %float %689 0
+OpStore %301 %690
+%691 = OpLoad %float %301
+%692 = OpLoad %float %293
+%693 = OpFAdd %float %691 %692
+OpStore %302 %693
+%694 = OpLoad %_arr_float_uint_5 %296
+%695 = OpLoad %float %302
+%696 = OpCompositeInsert %_arr_float_uint_5 %695 %694 0
+OpStore %303 %696
+%697 = OpLoad %_arr_float_uint_5 %303
+%698 = OpCompositeExtract %float %697 4
+OpStore %304 %698
+%699 = OpLoad %float %304
+%700 = OpLoad %float %293
+%701 = OpFAdd %float %699 %700
+OpStore %305 %701
+%702 = OpLoad %_arr_float_uint_5 %303
+%703 = OpLoad %float %305
+%704 = OpCompositeInsert %_arr_float_uint_5 %703 %702 4
+OpStore %306 %704
+%705 = OpLoad %_arr_float_uint_5 %299
+%706 = OpCompositeExtract %float %705 2
+OpStore %307 %706
+%707 = OpLoad %float %307
+%708 = OpLoad %float %293
+%709 = OpFAdd %float %707 %708
+OpStore %308 %709
+%710 = OpLoad %_arr_float_uint_5 %299
+%711 = OpLoad %float %308
+%712 = OpCompositeInsert %_arr_float_uint_5 %711 %710 2
+OpStore %309 %712
+%714 = OpLoad %_arr_float_uint_5 %306
+%715 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %714
+OpStore %310 %715
+%716 = OpLoad %ulong %310
+%717 = OpLoad %_arr_float_uint_5 %309
+%718 = OpFunctionCall %ulong %1 %716 %717
+OpStore %311 %718
+%719 = OpLoad %_arr_float_uint_5 %306
+%720 = OpCompositeExtract %float %719 0
+OpStore %482 %720
+%721 = OpLoad %_arr_float_uint_5 %309
+%722 = OpCompositeExtract %float %721 0
+OpStore %483 %722
+%723 = OpLoad %float %482
+%724 = OpLoad %float %483
+%725 = OpFAdd %float %723 %724
+OpStore %484 %725
+%726 = OpLoad %_arr_float_uint_5 %306
+%727 = OpCompositeExtract %float %726 1
+OpStore %485 %727
+%728 = OpLoad %_arr_float_uint_5 %309
+%729 = OpCompositeExtract %float %728 1
+OpStore %486 %729
+%730 = OpLoad %float %485
+%731 = OpLoad %float %486
+%732 = OpFAdd %float %730 %731
+OpStore %487 %732
+%733 = OpLoad %_arr_float_uint_5 %306
+%734 = OpCompositeExtract %float %733 2
+OpStore %488 %734
+%735 = OpLoad %_arr_float_uint_5 %309
+%736 = OpCompositeExtract %float %735 2
+OpStore %489 %736
+%737 = OpLoad %float %488
+%738 = OpLoad %float %489
+%739 = OpFAdd %float %737 %738
+OpStore %490 %739
+%740 = OpLoad %_arr_float_uint_5 %306
+%741 = OpCompositeExtract %float %740 3
+OpStore %491 %741
+%742 = OpLoad %_arr_float_uint_5 %309
+%743 = OpCompositeExtract %float %742 3
+OpStore %492 %743
+%744 = OpLoad %float %491
+%745 = OpLoad %float %492
+%746 = OpFAdd %float %744 %745
+OpStore %493 %746
+%747 = OpLoad %_arr_float_uint_5 %306
+%748 = OpCompositeExtract %float %747 4
+OpStore %494 %748
+%749 = OpLoad %_arr_float_uint_5 %309
+%750 = OpCompositeExtract %float %749 4
+OpStore %495 %750
+%751 = OpLoad %float %494
+%752 = OpLoad %float %495
+%753 = OpFAdd %float %751 %752
+OpStore %496 %753
+%754 = OpLoad %_arr_float_uint_5 %306
+%755 = OpLoad %float %484
+%756 = OpCompositeInsert %_arr_float_uint_5 %755 %754 0
+OpStore %497 %756
+%757 = OpLoad %_arr_float_uint_5 %497
+%758 = OpLoad %float %487
+%759 = OpCompositeInsert %_arr_float_uint_5 %758 %757 1
+OpStore %498 %759
+%760 = OpLoad %_arr_float_uint_5 %498
+%761 = OpLoad %float %490
+%762 = OpCompositeInsert %_arr_float_uint_5 %761 %760 2
+OpStore %499 %762
+%763 = OpLoad %_arr_float_uint_5 %499
+%764 = OpLoad %float %493
+%765 = OpCompositeInsert %_arr_float_uint_5 %764 %763 3
+OpStore %500 %765
+%766 = OpLoad %_arr_float_uint_5 %500
+%767 = OpLoad %float %496
+%768 = OpCompositeInsert %_arr_float_uint_5 %767 %766 4
+OpStore %501 %768
+%769 = OpLoad %ulong %311
+%770 = OpLoad %_arr_float_uint_5 %501
+%771 = OpFunctionCall %ulong %1 %769 %770
+OpStore %312 %771
+%772 = OpLoad %_arr_float_uint_5 %306
+%773 = OpCompositeExtract %float %772 0
+OpStore %502 %773
+%774 = OpLoad %_arr_float_uint_5 %309
+%775 = OpCompositeExtract %float %774 0
+OpStore %503 %775
+%776 = OpLoad %float %502
+%777 = OpLoad %float %503
+%778 = OpFSub %float %776 %777
+OpStore %504 %778
+%779 = OpLoad %_arr_float_uint_5 %306
+%780 = OpCompositeExtract %float %779 1
+OpStore %505 %780
+%781 = OpLoad %_arr_float_uint_5 %309
+%782 = OpCompositeExtract %float %781 1
+OpStore %506 %782
+%783 = OpLoad %float %505
+%784 = OpLoad %float %506
+%785 = OpFSub %float %783 %784
+OpStore %507 %785
+%786 = OpLoad %_arr_float_uint_5 %306
+%787 = OpCompositeExtract %float %786 2
+OpStore %508 %787
+%788 = OpLoad %_arr_float_uint_5 %309
+%789 = OpCompositeExtract %float %788 2
+OpStore %509 %789
+%790 = OpLoad %float %508
+%791 = OpLoad %float %509
+%792 = OpFSub %float %790 %791
+OpStore %510 %792
+%793 = OpLoad %_arr_float_uint_5 %306
+%794 = OpCompositeExtract %float %793 3
+OpStore %511 %794
+%795 = OpLoad %_arr_float_uint_5 %309
+%796 = OpCompositeExtract %float %795 3
+OpStore %512 %796
+%797 = OpLoad %float %511
+%798 = OpLoad %float %512
+%799 = OpFSub %float %797 %798
+OpStore %513 %799
+%800 = OpLoad %_arr_float_uint_5 %306
+%801 = OpCompositeExtract %float %800 4
+OpStore %514 %801
+%802 = OpLoad %_arr_float_uint_5 %309
+%803 = OpCompositeExtract %float %802 4
+OpStore %515 %803
+%804 = OpLoad %float %514
+%805 = OpLoad %float %515
+%806 = OpFSub %float %804 %805
+OpStore %516 %806
+%807 = OpLoad %_arr_float_uint_5 %306
+%808 = OpLoad %float %504
+%809 = OpCompositeInsert %_arr_float_uint_5 %808 %807 0
+OpStore %517 %809
+%810 = OpLoad %_arr_float_uint_5 %517
+%811 = OpLoad %float %507
+%812 = OpCompositeInsert %_arr_float_uint_5 %811 %810 1
+OpStore %518 %812
+%813 = OpLoad %_arr_float_uint_5 %518
+%814 = OpLoad %float %510
+%815 = OpCompositeInsert %_arr_float_uint_5 %814 %813 2
+OpStore %519 %815
+%816 = OpLoad %_arr_float_uint_5 %519
+%817 = OpLoad %float %513
+%818 = OpCompositeInsert %_arr_float_uint_5 %817 %816 3
+OpStore %520 %818
+%819 = OpLoad %_arr_float_uint_5 %520
+%820 = OpLoad %float %516
+%821 = OpCompositeInsert %_arr_float_uint_5 %820 %819 4
+OpStore %521 %821
+%822 = OpLoad %ulong %312
+%823 = OpLoad %_arr_float_uint_5 %521
+%824 = OpFunctionCall %ulong %1 %822 %823
+OpStore %313 %824
+%825 = OpLoad %_arr_float_uint_5 %309
+%826 = OpCompositeExtract %float %825 0
+OpStore %522 %826
+%827 = OpLoad %_arr_float_uint_5 %306
+%828 = OpCompositeExtract %float %827 0
+OpStore %523 %828
+%829 = OpLoad %float %522
+%830 = OpLoad %float %523
+%831 = OpFSub %float %829 %830
+OpStore %524 %831
+%832 = OpLoad %_arr_float_uint_5 %309
+%833 = OpCompositeExtract %float %832 1
+OpStore %525 %833
+%834 = OpLoad %_arr_float_uint_5 %306
+%835 = OpCompositeExtract %float %834 1
+OpStore %526 %835
+%836 = OpLoad %float %525
+%837 = OpLoad %float %526
+%838 = OpFSub %float %836 %837
+OpStore %527 %838
+%839 = OpLoad %_arr_float_uint_5 %309
+%840 = OpCompositeExtract %float %839 2
+OpStore %528 %840
+%841 = OpLoad %_arr_float_uint_5 %306
+%842 = OpCompositeExtract %float %841 2
+OpStore %529 %842
+%843 = OpLoad %float %528
+%844 = OpLoad %float %529
+%845 = OpFSub %float %843 %844
+OpStore %530 %845
+%846 = OpLoad %_arr_float_uint_5 %309
+%847 = OpCompositeExtract %float %846 3
+OpStore %531 %847
+%848 = OpLoad %_arr_float_uint_5 %306
 %849 = OpCompositeExtract %float %848 3
-OpStore %232 %849
-%850 = OpLoad %ulong %231
-%851 = OpLoad %float %232
-%852 = OpFunctionCall %ulong %5 %850 %851
-OpStore %233 %852
-%853 = OpLoad %_arr_float_uint_5 %465
+OpStore %532 %849
+%850 = OpLoad %float %531
+%851 = OpLoad %float %532
+%852 = OpFSub %float %850 %851
+OpStore %533 %852
+%853 = OpLoad %_arr_float_uint_5 %309
 %854 = OpCompositeExtract %float %853 4
-OpStore %234 %854
-%855 = OpLoad %ulong %233
-%856 = OpLoad %float %234
-%857 = OpFunctionCall %ulong %5 %855 %856
-OpStore %235 %857
-OpBranch %82
-%82 = OpLabel
-%858 = OpLoad %_arr_float_uint_5 %125
-%859 = OpCompositeExtract %float %858 0
-OpStore %466 %859
-%860 = OpLoad %_arr_float_uint_5 %122
-%861 = OpCompositeExtract %float %860 0
-OpStore %467 %861
-%862 = OpLoad %float %466
-%863 = OpLoad %float %467
-%864 = OpFSub %float %862 %863
-OpStore %468 %864
-%865 = OpLoad %_arr_float_uint_5 %125
-%866 = OpCompositeExtract %float %865 1
-OpStore %469 %866
-%867 = OpLoad %_arr_float_uint_5 %122
-%868 = OpCompositeExtract %float %867 1
-OpStore %470 %868
-%869 = OpLoad %float %469
-%870 = OpLoad %float %470
-%871 = OpFSub %float %869 %870
-OpStore %471 %871
-%872 = OpLoad %_arr_float_uint_5 %125
-%873 = OpCompositeExtract %float %872 2
-OpStore %472 %873
-%874 = OpLoad %_arr_float_uint_5 %122
-%875 = OpCompositeExtract %float %874 2
-OpStore %473 %875
-%876 = OpLoad %float %472
-%877 = OpLoad %float %473
-%878 = OpFSub %float %876 %877
-OpStore %474 %878
-%879 = OpLoad %_arr_float_uint_5 %125
-%880 = OpCompositeExtract %float %879 3
-OpStore %475 %880
-%881 = OpLoad %_arr_float_uint_5 %122
-%882 = OpCompositeExtract %float %881 3
-OpStore %476 %882
-%883 = OpLoad %float %475
-%884 = OpLoad %float %476
-%885 = OpFSub %float %883 %884
-OpStore %477 %885
-%886 = OpLoad %_arr_float_uint_5 %125
-%887 = OpCompositeExtract %float %886 4
-OpStore %478 %887
-%888 = OpLoad %_arr_float_uint_5 %122
-%889 = OpCompositeExtract %float %888 4
-OpStore %479 %889
-%890 = OpLoad %float %478
-%891 = OpLoad %float %479
-%892 = OpFSub %float %890 %891
-OpStore %480 %892
-%893 = OpLoad %_arr_float_uint_5 %125
-%894 = OpLoad %float %468
-%895 = OpCompositeInsert %_arr_float_uint_5 %894 %893 0
-OpStore %481 %895
-%896 = OpLoad %_arr_float_uint_5 %481
-%897 = OpLoad %float %471
-%898 = OpCompositeInsert %_arr_float_uint_5 %897 %896 1
-OpStore %482 %898
-%899 = OpLoad %_arr_float_uint_5 %482
-%900 = OpLoad %float %474
-%901 = OpCompositeInsert %_arr_float_uint_5 %900 %899 2
-OpStore %483 %901
-%902 = OpLoad %_arr_float_uint_5 %483
-%903 = OpLoad %float %477
-%904 = OpCompositeInsert %_arr_float_uint_5 %903 %902 3
-OpStore %484 %904
-%905 = OpLoad %_arr_float_uint_5 %484
-%906 = OpLoad %float %480
-%907 = OpCompositeInsert %_arr_float_uint_5 %906 %905 4
-OpStore %485 %907
-OpBranch %83
-%83 = OpLabel
-%908 = OpLoad %_arr_float_uint_5 %485
-%909 = OpCompositeExtract %float %908 0
-OpStore %236 %909
-%910 = OpLoad %ulong %235
-%911 = OpLoad %float %236
-%912 = OpFunctionCall %ulong %5 %910 %911
-OpStore %237 %912
-%913 = OpLoad %_arr_float_uint_5 %485
-%914 = OpCompositeExtract %float %913 1
-OpStore %238 %914
-%915 = OpLoad %ulong %237
-%916 = OpLoad %float %238
-%917 = OpFunctionCall %ulong %5 %915 %916
-OpStore %239 %917
-%918 = OpLoad %_arr_float_uint_5 %485
-%919 = OpCompositeExtract %float %918 2
-OpStore %240 %919
-%920 = OpLoad %ulong %239
-%921 = OpLoad %float %240
-%922 = OpFunctionCall %ulong %5 %920 %921
-OpStore %241 %922
-%923 = OpLoad %_arr_float_uint_5 %485
-%924 = OpCompositeExtract %float %923 3
-OpStore %242 %924
-%925 = OpLoad %ulong %241
-%926 = OpLoad %float %242
-%927 = OpFunctionCall %ulong %5 %925 %926
-OpStore %243 %927
-%928 = OpLoad %_arr_float_uint_5 %485
-%929 = OpCompositeExtract %float %928 4
-OpStore %244 %929
-%930 = OpLoad %ulong %243
-%931 = OpLoad %float %244
-%932 = OpFunctionCall %ulong %5 %930 %931
-OpStore %245 %932
-OpBranch %84
-%84 = OpLabel
-%933 = OpLoad %_arr_float_uint_5 %122
+OpStore %534 %854
+%855 = OpLoad %_arr_float_uint_5 %306
+%856 = OpCompositeExtract %float %855 4
+OpStore %535 %856
+%857 = OpLoad %float %534
+%858 = OpLoad %float %535
+%859 = OpFSub %float %857 %858
+OpStore %536 %859
+%860 = OpLoad %_arr_float_uint_5 %309
+%861 = OpLoad %float %524
+%862 = OpCompositeInsert %_arr_float_uint_5 %861 %860 0
+OpStore %537 %862
+%863 = OpLoad %_arr_float_uint_5 %537
+%864 = OpLoad %float %527
+%865 = OpCompositeInsert %_arr_float_uint_5 %864 %863 1
+OpStore %538 %865
+%866 = OpLoad %_arr_float_uint_5 %538
+%867 = OpLoad %float %530
+%868 = OpCompositeInsert %_arr_float_uint_5 %867 %866 2
+OpStore %539 %868
+%869 = OpLoad %_arr_float_uint_5 %539
+%870 = OpLoad %float %533
+%871 = OpCompositeInsert %_arr_float_uint_5 %870 %869 3
+OpStore %540 %871
+%872 = OpLoad %_arr_float_uint_5 %540
+%873 = OpLoad %float %536
+%874 = OpCompositeInsert %_arr_float_uint_5 %873 %872 4
+OpStore %541 %874
+%875 = OpLoad %ulong %313
+%876 = OpLoad %_arr_float_uint_5 %541
+%877 = OpFunctionCall %ulong %1 %875 %876
+OpStore %314 %877
+%878 = OpLoad %_arr_float_uint_5 %306
+%879 = OpCompositeExtract %float %878 0
+OpStore %542 %879
+%880 = OpLoad %_arr_float_uint_5 %309
+%881 = OpCompositeExtract %float %880 0
+OpStore %543 %881
+%882 = OpLoad %float %542
+%883 = OpLoad %float %543
+%884 = OpFMul %float %882 %883
+OpStore %544 %884
+%885 = OpLoad %_arr_float_uint_5 %306
+%886 = OpCompositeExtract %float %885 1
+OpStore %545 %886
+%887 = OpLoad %_arr_float_uint_5 %309
+%888 = OpCompositeExtract %float %887 1
+OpStore %546 %888
+%889 = OpLoad %float %545
+%890 = OpLoad %float %546
+%891 = OpFMul %float %889 %890
+OpStore %547 %891
+%892 = OpLoad %_arr_float_uint_5 %306
+%893 = OpCompositeExtract %float %892 2
+OpStore %548 %893
+%894 = OpLoad %_arr_float_uint_5 %309
+%895 = OpCompositeExtract %float %894 2
+OpStore %549 %895
+%896 = OpLoad %float %548
+%897 = OpLoad %float %549
+%898 = OpFMul %float %896 %897
+OpStore %550 %898
+%899 = OpLoad %_arr_float_uint_5 %306
+%900 = OpCompositeExtract %float %899 3
+OpStore %551 %900
+%901 = OpLoad %_arr_float_uint_5 %309
+%902 = OpCompositeExtract %float %901 3
+OpStore %552 %902
+%903 = OpLoad %float %551
+%904 = OpLoad %float %552
+%905 = OpFMul %float %903 %904
+OpStore %553 %905
+%906 = OpLoad %_arr_float_uint_5 %306
+%907 = OpCompositeExtract %float %906 4
+OpStore %554 %907
+%908 = OpLoad %_arr_float_uint_5 %309
+%909 = OpCompositeExtract %float %908 4
+OpStore %555 %909
+%910 = OpLoad %float %554
+%911 = OpLoad %float %555
+%912 = OpFMul %float %910 %911
+OpStore %556 %912
+%913 = OpLoad %_arr_float_uint_5 %306
+%914 = OpLoad %float %544
+%915 = OpCompositeInsert %_arr_float_uint_5 %914 %913 0
+OpStore %557 %915
+%916 = OpLoad %_arr_float_uint_5 %557
+%917 = OpLoad %float %547
+%918 = OpCompositeInsert %_arr_float_uint_5 %917 %916 1
+OpStore %558 %918
+%919 = OpLoad %_arr_float_uint_5 %558
+%920 = OpLoad %float %550
+%921 = OpCompositeInsert %_arr_float_uint_5 %920 %919 2
+OpStore %559 %921
+%922 = OpLoad %_arr_float_uint_5 %559
+%923 = OpLoad %float %553
+%924 = OpCompositeInsert %_arr_float_uint_5 %923 %922 3
+OpStore %560 %924
+%925 = OpLoad %_arr_float_uint_5 %560
+%926 = OpLoad %float %556
+%927 = OpCompositeInsert %_arr_float_uint_5 %926 %925 4
+OpStore %561 %927
+%928 = OpLoad %ulong %314
+%929 = OpLoad %_arr_float_uint_5 %561
+%930 = OpFunctionCall %ulong %1 %928 %929
+OpStore %315 %930
+%931 = OpLoad %_arr_float_uint_5 %306
+%932 = OpCompositeExtract %float %931 0
+OpStore %562 %932
+%933 = OpLoad %_arr_float_uint_5 %309
 %934 = OpCompositeExtract %float %933 0
-OpStore %486 %934
-%935 = OpLoad %_arr_float_uint_5 %125
-%936 = OpCompositeExtract %float %935 0
-OpStore %487 %936
-%937 = OpLoad %float %486
-%938 = OpLoad %float %487
-%939 = OpFMul %float %937 %938
-OpStore %488 %939
-%940 = OpLoad %_arr_float_uint_5 %122
+OpStore %563 %934
+%935 = OpLoad %float %562
+%936 = OpLoad %float %563
+%937 = OpFDiv %float %935 %936
+OpStore %564 %937
+%938 = OpLoad %_arr_float_uint_5 %306
+%939 = OpCompositeExtract %float %938 1
+OpStore %565 %939
+%940 = OpLoad %_arr_float_uint_5 %309
 %941 = OpCompositeExtract %float %940 1
-OpStore %489 %941
-%942 = OpLoad %_arr_float_uint_5 %125
-%943 = OpCompositeExtract %float %942 1
-OpStore %490 %943
-%944 = OpLoad %float %489
-%945 = OpLoad %float %490
-%946 = OpFMul %float %944 %945
-OpStore %491 %946
-%947 = OpLoad %_arr_float_uint_5 %122
+OpStore %566 %941
+%942 = OpLoad %float %565
+%943 = OpLoad %float %566
+%944 = OpFDiv %float %942 %943
+OpStore %567 %944
+%945 = OpLoad %_arr_float_uint_5 %306
+%946 = OpCompositeExtract %float %945 2
+OpStore %568 %946
+%947 = OpLoad %_arr_float_uint_5 %309
 %948 = OpCompositeExtract %float %947 2
-OpStore %492 %948
-%949 = OpLoad %_arr_float_uint_5 %125
-%950 = OpCompositeExtract %float %949 2
-OpStore %493 %950
-%951 = OpLoad %float %492
-%952 = OpLoad %float %493
-%953 = OpFMul %float %951 %952
-OpStore %494 %953
-%954 = OpLoad %_arr_float_uint_5 %122
+OpStore %569 %948
+%949 = OpLoad %float %568
+%950 = OpLoad %float %569
+%951 = OpFDiv %float %949 %950
+OpStore %570 %951
+%952 = OpLoad %_arr_float_uint_5 %306
+%953 = OpCompositeExtract %float %952 3
+OpStore %571 %953
+%954 = OpLoad %_arr_float_uint_5 %309
 %955 = OpCompositeExtract %float %954 3
-OpStore %495 %955
-%956 = OpLoad %_arr_float_uint_5 %125
-%957 = OpCompositeExtract %float %956 3
-OpStore %496 %957
-%958 = OpLoad %float %495
-%959 = OpLoad %float %496
-%960 = OpFMul %float %958 %959
-OpStore %497 %960
-%961 = OpLoad %_arr_float_uint_5 %122
+OpStore %572 %955
+%956 = OpLoad %float %571
+%957 = OpLoad %float %572
+%958 = OpFDiv %float %956 %957
+OpStore %573 %958
+%959 = OpLoad %_arr_float_uint_5 %306
+%960 = OpCompositeExtract %float %959 4
+OpStore %574 %960
+%961 = OpLoad %_arr_float_uint_5 %309
 %962 = OpCompositeExtract %float %961 4
-OpStore %498 %962
-%963 = OpLoad %_arr_float_uint_5 %125
-%964 = OpCompositeExtract %float %963 4
-OpStore %499 %964
-%965 = OpLoad %float %498
-%966 = OpLoad %float %499
-%967 = OpFMul %float %965 %966
-OpStore %500 %967
-%968 = OpLoad %_arr_float_uint_5 %122
-%969 = OpLoad %float %488
-%970 = OpCompositeInsert %_arr_float_uint_5 %969 %968 0
-OpStore %501 %970
-%971 = OpLoad %_arr_float_uint_5 %501
-%972 = OpLoad %float %491
-%973 = OpCompositeInsert %_arr_float_uint_5 %972 %971 1
-OpStore %502 %973
-%974 = OpLoad %_arr_float_uint_5 %502
-%975 = OpLoad %float %494
-%976 = OpCompositeInsert %_arr_float_uint_5 %975 %974 2
-OpStore %503 %976
-%977 = OpLoad %_arr_float_uint_5 %503
-%978 = OpLoad %float %497
-%979 = OpCompositeInsert %_arr_float_uint_5 %978 %977 3
-OpStore %504 %979
-%980 = OpLoad %_arr_float_uint_5 %504
-%981 = OpLoad %float %500
-%982 = OpCompositeInsert %_arr_float_uint_5 %981 %980 4
-OpStore %505 %982
-OpBranch %85
-%85 = OpLabel
-%983 = OpLoad %_arr_float_uint_5 %505
-%984 = OpCompositeExtract %float %983 0
-OpStore %246 %984
-%985 = OpLoad %ulong %245
-%986 = OpLoad %float %246
-%987 = OpFunctionCall %ulong %5 %985 %986
-OpStore %247 %987
-%988 = OpLoad %_arr_float_uint_5 %505
-%989 = OpCompositeExtract %float %988 1
-OpStore %248 %989
-%990 = OpLoad %ulong %247
-%991 = OpLoad %float %248
-%992 = OpFunctionCall %ulong %5 %990 %991
-OpStore %249 %992
-%993 = OpLoad %_arr_float_uint_5 %505
-%994 = OpCompositeExtract %float %993 2
-OpStore %250 %994
-%995 = OpLoad %ulong %249
-%996 = OpLoad %float %250
-%997 = OpFunctionCall %ulong %5 %995 %996
-OpStore %251 %997
-%998 = OpLoad %_arr_float_uint_5 %505
-%999 = OpCompositeExtract %float %998 3
-OpStore %252 %999
-%1000 = OpLoad %ulong %251
-%1001 = OpLoad %float %252
-%1002 = OpFunctionCall %ulong %5 %1000 %1001
-OpStore %253 %1002
-%1003 = OpLoad %_arr_float_uint_5 %505
-%1004 = OpCompositeExtract %float %1003 4
-OpStore %254 %1004
-%1005 = OpLoad %ulong %253
-%1006 = OpLoad %float %254
-%1007 = OpFunctionCall %ulong %5 %1005 %1006
-OpStore %255 %1007
-OpBranch %86
-%86 = OpLabel
-%1008 = OpLoad %_arr_float_uint_5 %122
-%1009 = OpCompositeExtract %float %1008 0
-OpStore %506 %1009
-%1010 = OpLoad %_arr_float_uint_5 %125
-%1011 = OpCompositeExtract %float %1010 0
-OpStore %507 %1011
-%1012 = OpLoad %float %506
-%1013 = OpLoad %float %507
-%1014 = OpFDiv %float %1012 %1013
-OpStore %508 %1014
-%1015 = OpLoad %_arr_float_uint_5 %122
-%1016 = OpCompositeExtract %float %1015 1
-OpStore %509 %1016
-%1017 = OpLoad %_arr_float_uint_5 %125
-%1018 = OpCompositeExtract %float %1017 1
-OpStore %510 %1018
-%1019 = OpLoad %float %509
-%1020 = OpLoad %float %510
-%1021 = OpFDiv %float %1019 %1020
-OpStore %511 %1021
-%1022 = OpLoad %_arr_float_uint_5 %122
-%1023 = OpCompositeExtract %float %1022 2
-OpStore %512 %1023
-%1024 = OpLoad %_arr_float_uint_5 %125
-%1025 = OpCompositeExtract %float %1024 2
-OpStore %513 %1025
-%1026 = OpLoad %float %512
-%1027 = OpLoad %float %513
-%1028 = OpFDiv %float %1026 %1027
-OpStore %514 %1028
-%1029 = OpLoad %_arr_float_uint_5 %122
-%1030 = OpCompositeExtract %float %1029 3
-OpStore %515 %1030
-%1031 = OpLoad %_arr_float_uint_5 %125
-%1032 = OpCompositeExtract %float %1031 3
-OpStore %516 %1032
-%1033 = OpLoad %float %515
-%1034 = OpLoad %float %516
-%1035 = OpFDiv %float %1033 %1034
-OpStore %517 %1035
-%1036 = OpLoad %_arr_float_uint_5 %122
-%1037 = OpCompositeExtract %float %1036 4
-OpStore %518 %1037
-%1038 = OpLoad %_arr_float_uint_5 %125
-%1039 = OpCompositeExtract %float %1038 4
-OpStore %519 %1039
-%1040 = OpLoad %float %518
-%1041 = OpLoad %float %519
-%1042 = OpFDiv %float %1040 %1041
-OpStore %520 %1042
-%1043 = OpLoad %_arr_float_uint_5 %122
-%1044 = OpLoad %float %508
-%1045 = OpCompositeInsert %_arr_float_uint_5 %1044 %1043 0
-OpStore %521 %1045
-%1046 = OpLoad %_arr_float_uint_5 %521
-%1047 = OpLoad %float %511
-%1048 = OpCompositeInsert %_arr_float_uint_5 %1047 %1046 1
-OpStore %522 %1048
-%1049 = OpLoad %_arr_float_uint_5 %522
-%1050 = OpLoad %float %514
-%1051 = OpCompositeInsert %_arr_float_uint_5 %1050 %1049 2
-OpStore %523 %1051
-%1052 = OpLoad %_arr_float_uint_5 %523
-%1053 = OpLoad %float %517
-%1054 = OpCompositeInsert %_arr_float_uint_5 %1053 %1052 3
-OpStore %524 %1054
-%1055 = OpLoad %_arr_float_uint_5 %524
-%1056 = OpLoad %float %520
-%1057 = OpCompositeInsert %_arr_float_uint_5 %1056 %1055 4
-OpStore %525 %1057
-OpBranch %87
-%87 = OpLabel
-%1058 = OpLoad %_arr_float_uint_5 %525
-%1059 = OpCompositeExtract %float %1058 0
-OpStore %256 %1059
-%1060 = OpLoad %ulong %255
-%1061 = OpLoad %float %256
-%1062 = OpFunctionCall %ulong %5 %1060 %1061
-OpStore %257 %1062
-%1063 = OpLoad %_arr_float_uint_5 %525
-%1064 = OpCompositeExtract %float %1063 1
-OpStore %258 %1064
-%1065 = OpLoad %ulong %257
-%1066 = OpLoad %float %258
-%1067 = OpFunctionCall %ulong %5 %1065 %1066
-OpStore %259 %1067
-%1068 = OpLoad %_arr_float_uint_5 %525
-%1069 = OpCompositeExtract %float %1068 2
-OpStore %260 %1069
-%1070 = OpLoad %ulong %259
-%1071 = OpLoad %float %260
-%1072 = OpFunctionCall %ulong %5 %1070 %1071
-OpStore %261 %1072
-%1073 = OpLoad %_arr_float_uint_5 %525
-%1074 = OpCompositeExtract %float %1073 3
-OpStore %262 %1074
-%1075 = OpLoad %ulong %261
-%1076 = OpLoad %float %262
-%1077 = OpFunctionCall %ulong %5 %1075 %1076
-OpStore %263 %1077
-%1078 = OpLoad %_arr_float_uint_5 %525
-%1079 = OpCompositeExtract %float %1078 4
-OpStore %264 %1079
-%1080 = OpLoad %ulong %263
-%1081 = OpLoad %float %264
-%1082 = OpFunctionCall %ulong %5 %1080 %1081
-OpStore %265 %1082
-OpBranch %88
-%88 = OpLabel
-%1083 = OpLoad %_arr_float_uint_5 %125
-%1084 = OpCompositeExtract %float %1083 0
-OpStore %526 %1084
-%1085 = OpLoad %_arr_float_uint_5 %122
-%1086 = OpCompositeExtract %float %1085 0
-OpStore %527 %1086
-%1087 = OpLoad %float %526
-%1088 = OpLoad %float %527
-%1089 = OpFDiv %float %1087 %1088
-OpStore %528 %1089
-%1090 = OpLoad %_arr_float_uint_5 %125
-%1091 = OpCompositeExtract %float %1090 1
-OpStore %529 %1091
-%1092 = OpLoad %_arr_float_uint_5 %122
-%1093 = OpCompositeExtract %float %1092 1
-OpStore %530 %1093
-%1094 = OpLoad %float %529
-%1095 = OpLoad %float %530
-%1096 = OpFDiv %float %1094 %1095
-OpStore %531 %1096
-%1097 = OpLoad %_arr_float_uint_5 %125
-%1098 = OpCompositeExtract %float %1097 2
-OpStore %532 %1098
-%1099 = OpLoad %_arr_float_uint_5 %122
-%1100 = OpCompositeExtract %float %1099 2
-OpStore %533 %1100
-%1101 = OpLoad %float %532
-%1102 = OpLoad %float %533
-%1103 = OpFDiv %float %1101 %1102
-OpStore %534 %1103
-%1104 = OpLoad %_arr_float_uint_5 %125
-%1105 = OpCompositeExtract %float %1104 3
-OpStore %535 %1105
-%1106 = OpLoad %_arr_float_uint_5 %122
-%1107 = OpCompositeExtract %float %1106 3
-OpStore %536 %1107
-%1108 = OpLoad %float %535
-%1109 = OpLoad %float %536
-%1110 = OpFDiv %float %1108 %1109
-OpStore %537 %1110
-%1111 = OpLoad %_arr_float_uint_5 %125
-%1112 = OpCompositeExtract %float %1111 4
-OpStore %538 %1112
-%1113 = OpLoad %_arr_float_uint_5 %122
-%1114 = OpCompositeExtract %float %1113 4
-OpStore %539 %1114
-%1115 = OpLoad %float %538
-%1116 = OpLoad %float %539
-%1117 = OpFDiv %float %1115 %1116
-OpStore %540 %1117
-%1118 = OpLoad %_arr_float_uint_5 %125
-%1119 = OpLoad %float %528
-%1120 = OpCompositeInsert %_arr_float_uint_5 %1119 %1118 0
-OpStore %541 %1120
-%1121 = OpLoad %_arr_float_uint_5 %541
-%1122 = OpLoad %float %531
-%1123 = OpCompositeInsert %_arr_float_uint_5 %1122 %1121 1
-OpStore %542 %1123
-%1124 = OpLoad %_arr_float_uint_5 %542
-%1125 = OpLoad %float %534
-%1126 = OpCompositeInsert %_arr_float_uint_5 %1125 %1124 2
-OpStore %543 %1126
-%1127 = OpLoad %_arr_float_uint_5 %543
-%1128 = OpLoad %float %537
-%1129 = OpCompositeInsert %_arr_float_uint_5 %1128 %1127 3
-OpStore %544 %1129
-%1130 = OpLoad %_arr_float_uint_5 %544
-%1131 = OpLoad %float %540
-%1132 = OpCompositeInsert %_arr_float_uint_5 %1131 %1130 4
-OpStore %545 %1132
-OpBranch %89
-%89 = OpLabel
-%1133 = OpLoad %_arr_float_uint_5 %545
-%1134 = OpCompositeExtract %float %1133 0
-OpStore %266 %1134
-%1135 = OpLoad %ulong %265
-%1136 = OpLoad %float %266
-%1137 = OpFunctionCall %ulong %5 %1135 %1136
-OpStore %267 %1137
-%1138 = OpLoad %_arr_float_uint_5 %545
-%1139 = OpCompositeExtract %float %1138 1
-OpStore %268 %1139
-%1140 = OpLoad %ulong %267
-%1141 = OpLoad %float %268
-%1142 = OpFunctionCall %ulong %5 %1140 %1141
-OpStore %269 %1142
-%1143 = OpLoad %_arr_float_uint_5 %545
-%1144 = OpCompositeExtract %float %1143 2
-OpStore %270 %1144
-%1145 = OpLoad %ulong %269
-%1146 = OpLoad %float %270
-%1147 = OpFunctionCall %ulong %5 %1145 %1146
-OpStore %271 %1147
-%1148 = OpLoad %_arr_float_uint_5 %545
-%1149 = OpCompositeExtract %float %1148 3
-OpStore %272 %1149
-%1150 = OpLoad %ulong %271
-%1151 = OpLoad %float %272
-%1152 = OpFunctionCall %ulong %5 %1150 %1151
-OpStore %273 %1152
-%1153 = OpLoad %_arr_float_uint_5 %545
-%1154 = OpCompositeExtract %float %1153 4
-OpStore %274 %1154
-%1155 = OpLoad %ulong %273
-%1156 = OpLoad %float %274
-%1157 = OpFunctionCall %ulong %5 %1155 %1156
-OpStore %275 %1157
-OpBranch %90
-%90 = OpLabel
-%1158 = OpLoad %_arr_float_uint_5 %122
-%1159 = OpCompositeExtract %float %1158 0
-OpStore %546 %1159
-%1160 = OpLoad %_arr_float_uint_5 %116
-%1161 = OpCompositeExtract %float %1160 0
-OpStore %547 %1161
-%1162 = OpLoad %float %546
-%1163 = OpLoad %float %547
-%1164 = OpFMul %float %1162 %1163
-OpStore %548 %1164
-%1165 = OpLoad %_arr_float_uint_5 %122
-%1166 = OpCompositeExtract %float %1165 1
-OpStore %549 %1166
-%1167 = OpLoad %_arr_float_uint_5 %116
-%1168 = OpCompositeExtract %float %1167 1
-OpStore %550 %1168
-%1169 = OpLoad %float %549
-%1170 = OpLoad %float %550
-%1171 = OpFMul %float %1169 %1170
-OpStore %551 %1171
-%1172 = OpLoad %_arr_float_uint_5 %122
-%1173 = OpCompositeExtract %float %1172 2
-OpStore %552 %1173
-%1174 = OpLoad %_arr_float_uint_5 %116
-%1175 = OpCompositeExtract %float %1174 2
-OpStore %553 %1175
-%1176 = OpLoad %float %552
-%1177 = OpLoad %float %553
-%1178 = OpFMul %float %1176 %1177
-OpStore %554 %1178
-%1179 = OpLoad %_arr_float_uint_5 %122
-%1180 = OpCompositeExtract %float %1179 3
-OpStore %555 %1180
-%1181 = OpLoad %_arr_float_uint_5 %116
-%1182 = OpCompositeExtract %float %1181 3
-OpStore %556 %1182
-%1183 = OpLoad %float %555
-%1184 = OpLoad %float %556
-%1185 = OpFMul %float %1183 %1184
-OpStore %557 %1185
-%1186 = OpLoad %_arr_float_uint_5 %122
-%1187 = OpCompositeExtract %float %1186 4
-OpStore %558 %1187
-%1188 = OpLoad %_arr_float_uint_5 %116
-%1189 = OpCompositeExtract %float %1188 4
-OpStore %559 %1189
-%1190 = OpLoad %float %558
-%1191 = OpLoad %float %559
-%1192 = OpFMul %float %1190 %1191
-OpStore %560 %1192
-%1193 = OpLoad %_arr_float_uint_5 %122
-%1194 = OpLoad %float %548
-%1195 = OpCompositeInsert %_arr_float_uint_5 %1194 %1193 0
-OpStore %561 %1195
-%1196 = OpLoad %_arr_float_uint_5 %561
-%1197 = OpLoad %float %551
-%1198 = OpCompositeInsert %_arr_float_uint_5 %1197 %1196 1
-OpStore %562 %1198
-%1199 = OpLoad %_arr_float_uint_5 %562
-%1200 = OpLoad %float %554
-%1201 = OpCompositeInsert %_arr_float_uint_5 %1200 %1199 2
-OpStore %563 %1201
-%1202 = OpLoad %_arr_float_uint_5 %563
-%1203 = OpLoad %float %557
-%1204 = OpCompositeInsert %_arr_float_uint_5 %1203 %1202 3
-OpStore %564 %1204
-%1205 = OpLoad %_arr_float_uint_5 %564
-%1206 = OpLoad %float %560
-%1207 = OpCompositeInsert %_arr_float_uint_5 %1206 %1205 4
-OpStore %565 %1207
-OpBranch %91
-%91 = OpLabel
-%1208 = OpLoad %_arr_float_uint_5 %565
-%1209 = OpCompositeExtract %float %1208 0
-OpStore %276 %1209
-%1210 = OpLoad %ulong %275
-%1211 = OpLoad %float %276
-%1212 = OpFunctionCall %ulong %5 %1210 %1211
-OpStore %277 %1212
-%1213 = OpLoad %_arr_float_uint_5 %565
-%1214 = OpCompositeExtract %float %1213 1
-OpStore %278 %1214
-%1215 = OpLoad %ulong %277
-%1216 = OpLoad %float %278
-%1217 = OpFunctionCall %ulong %5 %1215 %1216
-OpStore %279 %1217
-%1218 = OpLoad %_arr_float_uint_5 %565
-%1219 = OpCompositeExtract %float %1218 2
-OpStore %280 %1219
-%1220 = OpLoad %ulong %279
-%1221 = OpLoad %float %280
-%1222 = OpFunctionCall %ulong %5 %1220 %1221
-OpStore %281 %1222
-%1223 = OpLoad %_arr_float_uint_5 %565
-%1224 = OpCompositeExtract %float %1223 3
-OpStore %282 %1224
-%1225 = OpLoad %ulong %281
-%1226 = OpLoad %float %282
-%1227 = OpFunctionCall %ulong %5 %1225 %1226
-OpStore %283 %1227
-%1228 = OpLoad %_arr_float_uint_5 %565
-%1229 = OpCompositeExtract %float %1228 4
-OpStore %284 %1229
-%1230 = OpLoad %ulong %283
-%1231 = OpLoad %float %284
-%1232 = OpFunctionCall %ulong %5 %1230 %1231
-OpStore %285 %1232
-OpBranch %92
-%92 = OpLabel
-%1233 = OpLoad %_arr_float_uint_5 %116
-%1234 = OpCompositeExtract %float %1233 0
-OpStore %566 %1234
-%1235 = OpLoad %_arr_float_uint_5 %125
-%1236 = OpCompositeExtract %float %1235 0
-OpStore %567 %1236
-%1237 = OpLoad %float %566
-%1238 = OpLoad %float %567
-%1239 = OpFSub %float %1237 %1238
-OpStore %568 %1239
-%1240 = OpLoad %_arr_float_uint_5 %116
-%1241 = OpCompositeExtract %float %1240 1
-OpStore %569 %1241
-%1242 = OpLoad %_arr_float_uint_5 %125
-%1243 = OpCompositeExtract %float %1242 1
-OpStore %570 %1243
-%1244 = OpLoad %float %569
-%1245 = OpLoad %float %570
-%1246 = OpFSub %float %1244 %1245
-OpStore %571 %1246
-%1247 = OpLoad %_arr_float_uint_5 %116
-%1248 = OpCompositeExtract %float %1247 2
-OpStore %572 %1248
-%1249 = OpLoad %_arr_float_uint_5 %125
-%1250 = OpCompositeExtract %float %1249 2
-OpStore %573 %1250
-%1251 = OpLoad %float %572
-%1252 = OpLoad %float %573
-%1253 = OpFSub %float %1251 %1252
-OpStore %574 %1253
-%1254 = OpLoad %_arr_float_uint_5 %116
-%1255 = OpCompositeExtract %float %1254 3
-OpStore %575 %1255
-%1256 = OpLoad %_arr_float_uint_5 %125
-%1257 = OpCompositeExtract %float %1256 3
-OpStore %576 %1257
-%1258 = OpLoad %float %575
-%1259 = OpLoad %float %576
-%1260 = OpFSub %float %1258 %1259
-OpStore %577 %1260
-%1261 = OpLoad %_arr_float_uint_5 %116
-%1262 = OpCompositeExtract %float %1261 4
-OpStore %578 %1262
-%1263 = OpLoad %_arr_float_uint_5 %125
-%1264 = OpCompositeExtract %float %1263 4
-OpStore %579 %1264
-%1265 = OpLoad %float %578
-%1266 = OpLoad %float %579
-%1267 = OpFSub %float %1265 %1266
-OpStore %580 %1267
-%1268 = OpLoad %_arr_float_uint_5 %116
-%1269 = OpLoad %float %568
-%1270 = OpCompositeInsert %_arr_float_uint_5 %1269 %1268 0
-OpStore %581 %1270
-%1271 = OpLoad %_arr_float_uint_5 %581
-%1272 = OpLoad %float %571
-%1273 = OpCompositeInsert %_arr_float_uint_5 %1272 %1271 1
-OpStore %582 %1273
-%1274 = OpLoad %_arr_float_uint_5 %582
-%1275 = OpLoad %float %574
-%1276 = OpCompositeInsert %_arr_float_uint_5 %1275 %1274 2
-OpStore %583 %1276
-%1277 = OpLoad %_arr_float_uint_5 %583
-%1278 = OpLoad %float %577
-%1279 = OpCompositeInsert %_arr_float_uint_5 %1278 %1277 3
-OpStore %584 %1279
-%1280 = OpLoad %_arr_float_uint_5 %584
-%1281 = OpLoad %float %580
-%1282 = OpCompositeInsert %_arr_float_uint_5 %1281 %1280 4
-OpStore %585 %1282
-OpBranch %93
-%93 = OpLabel
-%1283 = OpLoad %_arr_float_uint_5 %585
-%1284 = OpCompositeExtract %float %1283 0
-OpStore %286 %1284
-%1285 = OpLoad %ulong %285
-%1286 = OpLoad %float %286
-%1287 = OpFunctionCall %ulong %5 %1285 %1286
-OpStore %287 %1287
-%1288 = OpLoad %_arr_float_uint_5 %585
-%1289 = OpCompositeExtract %float %1288 1
-OpStore %288 %1289
-%1290 = OpLoad %ulong %287
-%1291 = OpLoad %float %288
-%1292 = OpFunctionCall %ulong %5 %1290 %1291
-OpStore %289 %1292
-%1293 = OpLoad %_arr_float_uint_5 %585
-%1294 = OpCompositeExtract %float %1293 2
-OpStore %290 %1294
-%1295 = OpLoad %ulong %289
-%1296 = OpLoad %float %290
-%1297 = OpFunctionCall %ulong %5 %1295 %1296
-OpStore %291 %1297
-%1298 = OpLoad %_arr_float_uint_5 %585
-%1299 = OpCompositeExtract %float %1298 3
-OpStore %292 %1299
-%1300 = OpLoad %ulong %291
-%1301 = OpLoad %float %292
-%1302 = OpFunctionCall %ulong %5 %1300 %1301
-OpStore %293 %1302
-%1303 = OpLoad %_arr_float_uint_5 %585
-%1304 = OpCompositeExtract %float %1303 4
-OpStore %294 %1304
-%1305 = OpLoad %ulong %293
-%1306 = OpLoad %float %294
-%1307 = OpFunctionCall %ulong %5 %1305 %1306
-OpStore %295 %1307
-OpBranch %94
-%94 = OpLabel
-%1308 = OpLoad %_arr_float_uint_5 %116
-%1309 = OpCompositeExtract %float %1308 0
-OpStore %586 %1309
-%1310 = OpLoad %_arr_float_uint_5 %122
-%1311 = OpCompositeExtract %float %1310 0
-OpStore %587 %1311
-%1312 = OpLoad %float %586
-%1313 = OpLoad %float %587
-%1314 = OpFDiv %float %1312 %1313
-OpStore %588 %1314
-%1315 = OpLoad %_arr_float_uint_5 %116
-%1316 = OpCompositeExtract %float %1315 1
-OpStore %589 %1316
-%1317 = OpLoad %_arr_float_uint_5 %122
-%1318 = OpCompositeExtract %float %1317 1
-OpStore %590 %1318
-%1319 = OpLoad %float %589
-%1320 = OpLoad %float %590
-%1321 = OpFDiv %float %1319 %1320
-OpStore %591 %1321
-%1322 = OpLoad %_arr_float_uint_5 %116
-%1323 = OpCompositeExtract %float %1322 2
-OpStore %592 %1323
-%1324 = OpLoad %_arr_float_uint_5 %122
-%1325 = OpCompositeExtract %float %1324 2
-OpStore %593 %1325
-%1326 = OpLoad %float %592
-%1327 = OpLoad %float %593
-%1328 = OpFDiv %float %1326 %1327
-OpStore %594 %1328
-%1329 = OpLoad %_arr_float_uint_5 %116
-%1330 = OpCompositeExtract %float %1329 3
-OpStore %595 %1330
-%1331 = OpLoad %_arr_float_uint_5 %122
-%1332 = OpCompositeExtract %float %1331 3
-OpStore %596 %1332
-%1333 = OpLoad %float %595
-%1334 = OpLoad %float %596
-%1335 = OpFDiv %float %1333 %1334
-OpStore %597 %1335
-%1336 = OpLoad %_arr_float_uint_5 %116
-%1337 = OpCompositeExtract %float %1336 4
-OpStore %598 %1337
-%1338 = OpLoad %_arr_float_uint_5 %122
-%1339 = OpCompositeExtract %float %1338 4
-OpStore %599 %1339
-%1340 = OpLoad %float %598
-%1341 = OpLoad %float %599
-%1342 = OpFDiv %float %1340 %1341
-OpStore %600 %1342
-%1343 = OpLoad %_arr_float_uint_5 %116
-%1344 = OpLoad %float %588
-%1345 = OpCompositeInsert %_arr_float_uint_5 %1344 %1343 0
-OpStore %601 %1345
-%1346 = OpLoad %_arr_float_uint_5 %601
-%1347 = OpLoad %float %591
-%1348 = OpCompositeInsert %_arr_float_uint_5 %1347 %1346 1
-OpStore %602 %1348
-%1349 = OpLoad %_arr_float_uint_5 %602
-%1350 = OpLoad %float %594
-%1351 = OpCompositeInsert %_arr_float_uint_5 %1350 %1349 2
-OpStore %603 %1351
-%1352 = OpLoad %_arr_float_uint_5 %603
-%1353 = OpLoad %float %597
-%1354 = OpCompositeInsert %_arr_float_uint_5 %1353 %1352 3
-OpStore %604 %1354
-%1355 = OpLoad %_arr_float_uint_5 %604
-%1356 = OpLoad %float %600
-%1357 = OpCompositeInsert %_arr_float_uint_5 %1356 %1355 4
-OpStore %605 %1357
-OpBranch %95
-%95 = OpLabel
-%1358 = OpLoad %_arr_float_uint_5 %605
-%1359 = OpCompositeExtract %float %1358 0
-OpStore %296 %1359
-%1360 = OpLoad %ulong %295
-%1361 = OpLoad %float %296
-%1362 = OpFunctionCall %ulong %5 %1360 %1361
-OpStore %297 %1362
-%1363 = OpLoad %_arr_float_uint_5 %605
-%1364 = OpCompositeExtract %float %1363 1
-OpStore %298 %1364
-%1365 = OpLoad %ulong %297
-%1366 = OpLoad %float %298
-%1367 = OpFunctionCall %ulong %5 %1365 %1366
-OpStore %299 %1367
-%1368 = OpLoad %_arr_float_uint_5 %605
-%1369 = OpCompositeExtract %float %1368 2
-OpStore %300 %1369
-%1370 = OpLoad %ulong %299
-%1371 = OpLoad %float %300
-%1372 = OpFunctionCall %ulong %5 %1370 %1371
-OpStore %301 %1372
-%1373 = OpLoad %_arr_float_uint_5 %605
-%1374 = OpCompositeExtract %float %1373 3
-OpStore %302 %1374
-%1375 = OpLoad %ulong %301
-%1376 = OpLoad %float %302
-%1377 = OpFunctionCall %ulong %5 %1375 %1376
-OpStore %303 %1377
-%1378 = OpLoad %_arr_float_uint_5 %605
-%1379 = OpCompositeExtract %float %1378 4
-OpStore %304 %1379
-%1380 = OpLoad %ulong %303
-%1381 = OpLoad %float %304
-%1382 = OpFunctionCall %ulong %5 %1380 %1381
-OpStore %305 %1382
-OpBranch %96
-%96 = OpLabel
-%1383 = OpCompositeConstruct %_arr_float_uint_5 %float_0 %float_0 %float_0 %float_0 %float_0
-OpStore %126 %1383
-%1385 = OpLoad %ulong %305
-OpStore %141 %1385
-%1386 = OpLoad %_arr_float_uint_5 %122
-OpStore %142 %1386
-%1387 = OpLoad %_arr_float_uint_5 %126
-OpStore %143 %1387
-OpStore %144 %ulong_0
-OpBranch %59
-%59 = OpLabel
-%1389 = OpLoad %ulong %144
-%1391 = OpULessThan %bool %1389 %ulong_6
-OpStore %128 %1391
-%1392 = OpLoad %bool %128
-OpLoopMerge %61 %98 None
-OpBranchConditional %1392 %60 %61
-%61 = OpLabel
-OpStore %103 %1393
-%1395 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_0
-%1396 = OpLoad %_arr_float_uint_5 %142
-OpStore %1395 %1396
-%1397 = OpLoad %_arr_float_uint_5 %142
-%1398 = OpCompositeExtract %float %1397 0
-OpStore %326 %1398
-%1399 = OpLoad %_arr_float_uint_5 %125
-%1400 = OpCompositeExtract %float %1399 0
-OpStore %327 %1400
-%1401 = OpLoad %float %326
-%1402 = OpLoad %float %327
-%1403 = OpFAdd %float %1401 %1402
-OpStore %328 %1403
-%1404 = OpLoad %_arr_float_uint_5 %142
-%1405 = OpCompositeExtract %float %1404 1
-OpStore %329 %1405
-%1406 = OpLoad %_arr_float_uint_5 %125
-%1407 = OpCompositeExtract %float %1406 1
-OpStore %330 %1407
-%1408 = OpLoad %float %329
-%1409 = OpLoad %float %330
-%1410 = OpFAdd %float %1408 %1409
-OpStore %331 %1410
-%1411 = OpLoad %_arr_float_uint_5 %142
-%1412 = OpCompositeExtract %float %1411 2
-OpStore %332 %1412
-%1413 = OpLoad %_arr_float_uint_5 %125
-%1414 = OpCompositeExtract %float %1413 2
-OpStore %333 %1414
-%1415 = OpLoad %float %332
-%1416 = OpLoad %float %333
-%1417 = OpFAdd %float %1415 %1416
-OpStore %334 %1417
-%1418 = OpLoad %_arr_float_uint_5 %142
-%1419 = OpCompositeExtract %float %1418 3
-OpStore %335 %1419
-%1420 = OpLoad %_arr_float_uint_5 %125
-%1421 = OpCompositeExtract %float %1420 3
-OpStore %336 %1421
-%1422 = OpLoad %float %335
-%1423 = OpLoad %float %336
-%1424 = OpFAdd %float %1422 %1423
-OpStore %337 %1424
-%1425 = OpLoad %_arr_float_uint_5 %142
-%1426 = OpCompositeExtract %float %1425 4
-OpStore %338 %1426
-%1427 = OpLoad %_arr_float_uint_5 %125
-%1428 = OpCompositeExtract %float %1427 4
-OpStore %339 %1428
-%1429 = OpLoad %float %338
-%1430 = OpLoad %float %339
-%1431 = OpFAdd %float %1429 %1430
-OpStore %340 %1431
-%1432 = OpLoad %_arr_float_uint_5 %142
-%1433 = OpLoad %float %328
-%1434 = OpCompositeInsert %_arr_float_uint_5 %1433 %1432 0
-OpStore %341 %1434
-%1435 = OpLoad %_arr_float_uint_5 %341
-%1436 = OpLoad %float %331
-%1437 = OpCompositeInsert %_arr_float_uint_5 %1436 %1435 1
-OpStore %342 %1437
-%1438 = OpLoad %_arr_float_uint_5 %342
-%1439 = OpLoad %float %334
-%1440 = OpCompositeInsert %_arr_float_uint_5 %1439 %1438 2
-OpStore %343 %1440
-%1441 = OpLoad %_arr_float_uint_5 %343
-%1442 = OpLoad %float %337
-%1443 = OpCompositeInsert %_arr_float_uint_5 %1442 %1441 3
-OpStore %344 %1443
-%1444 = OpLoad %_arr_float_uint_5 %344
-%1445 = OpLoad %float %340
-%1446 = OpCompositeInsert %_arr_float_uint_5 %1445 %1444 4
-OpStore %345 %1446
-%1448 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_1
-%1449 = OpLoad %_arr_float_uint_5 %345
-OpStore %1448 %1449
-%1450 = OpLoad %_arr_float_uint_5 %142
-%1451 = OpCompositeExtract %float %1450 0
-OpStore %346 %1451
-%1452 = OpLoad %_arr_float_uint_5 %116
-%1453 = OpCompositeExtract %float %1452 0
-OpStore %347 %1453
-%1454 = OpLoad %float %346
-%1455 = OpLoad %float %347
-%1456 = OpFMul %float %1454 %1455
-OpStore %348 %1456
-%1457 = OpLoad %_arr_float_uint_5 %142
-%1458 = OpCompositeExtract %float %1457 1
-OpStore %349 %1458
-%1459 = OpLoad %_arr_float_uint_5 %116
-%1460 = OpCompositeExtract %float %1459 1
-OpStore %350 %1460
-%1461 = OpLoad %float %349
-%1462 = OpLoad %float %350
-%1463 = OpFMul %float %1461 %1462
-OpStore %351 %1463
-%1464 = OpLoad %_arr_float_uint_5 %142
-%1465 = OpCompositeExtract %float %1464 2
-OpStore %352 %1465
-%1466 = OpLoad %_arr_float_uint_5 %116
-%1467 = OpCompositeExtract %float %1466 2
-OpStore %353 %1467
-%1468 = OpLoad %float %352
-%1469 = OpLoad %float %353
-%1470 = OpFMul %float %1468 %1469
-OpStore %354 %1470
-%1471 = OpLoad %_arr_float_uint_5 %142
-%1472 = OpCompositeExtract %float %1471 3
-OpStore %355 %1472
-%1473 = OpLoad %_arr_float_uint_5 %116
-%1474 = OpCompositeExtract %float %1473 3
-OpStore %356 %1474
-%1475 = OpLoad %float %355
-%1476 = OpLoad %float %356
-%1477 = OpFMul %float %1475 %1476
-OpStore %357 %1477
-%1478 = OpLoad %_arr_float_uint_5 %142
-%1479 = OpCompositeExtract %float %1478 4
-OpStore %358 %1479
-%1480 = OpLoad %_arr_float_uint_5 %116
-%1481 = OpCompositeExtract %float %1480 4
-OpStore %359 %1481
-%1482 = OpLoad %float %358
-%1483 = OpLoad %float %359
-%1484 = OpFMul %float %1482 %1483
-OpStore %360 %1484
-%1485 = OpLoad %_arr_float_uint_5 %142
-%1486 = OpLoad %float %348
-%1487 = OpCompositeInsert %_arr_float_uint_5 %1486 %1485 0
-OpStore %361 %1487
-%1488 = OpLoad %_arr_float_uint_5 %361
-%1489 = OpLoad %float %351
-%1490 = OpCompositeInsert %_arr_float_uint_5 %1489 %1488 1
-OpStore %362 %1490
-%1491 = OpLoad %_arr_float_uint_5 %362
-%1492 = OpLoad %float %354
-%1493 = OpCompositeInsert %_arr_float_uint_5 %1492 %1491 2
-OpStore %363 %1493
-%1494 = OpLoad %_arr_float_uint_5 %363
-%1495 = OpLoad %float %357
-%1496 = OpCompositeInsert %_arr_float_uint_5 %1495 %1494 3
-OpStore %364 %1496
-%1497 = OpLoad %_arr_float_uint_5 %364
-%1498 = OpLoad %float %360
-%1499 = OpCompositeInsert %_arr_float_uint_5 %1498 %1497 4
-OpStore %365 %1499
-%1501 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_2
-%1502 = OpLoad %_arr_float_uint_5 %365
-OpStore %1501 %1502
-%1504 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_3
-%1505 = OpLoad %_arr_float_uint_5 %143
-OpStore %1504 %1505
-%1506 = OpLoad %_arr_float_uint_5 %125
-%1507 = OpCompositeExtract %float %1506 0
-OpStore %366 %1507
-%1508 = OpLoad %_arr_float_uint_5 %142
-%1509 = OpCompositeExtract %float %1508 0
-OpStore %367 %1509
-%1510 = OpLoad %float %366
-%1511 = OpLoad %float %367
-%1512 = OpFSub %float %1510 %1511
-OpStore %368 %1512
-%1513 = OpLoad %_arr_float_uint_5 %125
-%1514 = OpCompositeExtract %float %1513 1
-OpStore %369 %1514
-%1515 = OpLoad %_arr_float_uint_5 %142
-%1516 = OpCompositeExtract %float %1515 1
-OpStore %370 %1516
-%1517 = OpLoad %float %369
-%1518 = OpLoad %float %370
-%1519 = OpFSub %float %1517 %1518
-OpStore %371 %1519
-%1520 = OpLoad %_arr_float_uint_5 %125
-%1521 = OpCompositeExtract %float %1520 2
-OpStore %372 %1521
-%1522 = OpLoad %_arr_float_uint_5 %142
-%1523 = OpCompositeExtract %float %1522 2
-OpStore %373 %1523
-%1524 = OpLoad %float %372
-%1525 = OpLoad %float %373
-%1526 = OpFSub %float %1524 %1525
-OpStore %374 %1526
-%1527 = OpLoad %_arr_float_uint_5 %125
-%1528 = OpCompositeExtract %float %1527 3
-OpStore %375 %1528
-%1529 = OpLoad %_arr_float_uint_5 %142
-%1530 = OpCompositeExtract %float %1529 3
-OpStore %376 %1530
-%1531 = OpLoad %float %375
-%1532 = OpLoad %float %376
-%1533 = OpFSub %float %1531 %1532
-OpStore %377 %1533
-%1534 = OpLoad %_arr_float_uint_5 %125
-%1535 = OpCompositeExtract %float %1534 4
-OpStore %378 %1535
-%1536 = OpLoad %_arr_float_uint_5 %142
-%1537 = OpCompositeExtract %float %1536 4
-OpStore %379 %1537
-%1538 = OpLoad %float %378
-%1539 = OpLoad %float %379
-%1540 = OpFSub %float %1538 %1539
-OpStore %380 %1540
-%1541 = OpLoad %_arr_float_uint_5 %125
-%1542 = OpLoad %float %368
-%1543 = OpCompositeInsert %_arr_float_uint_5 %1542 %1541 0
-OpStore %381 %1543
-%1544 = OpLoad %_arr_float_uint_5 %381
-%1545 = OpLoad %float %371
-%1546 = OpCompositeInsert %_arr_float_uint_5 %1545 %1544 1
-OpStore %382 %1546
-%1547 = OpLoad %_arr_float_uint_5 %382
-%1548 = OpLoad %float %374
-%1549 = OpCompositeInsert %_arr_float_uint_5 %1548 %1547 2
-OpStore %383 %1549
-%1550 = OpLoad %_arr_float_uint_5 %383
-%1551 = OpLoad %float %377
-%1552 = OpCompositeInsert %_arr_float_uint_5 %1551 %1550 3
-OpStore %384 %1552
-%1553 = OpLoad %_arr_float_uint_5 %384
-%1554 = OpLoad %float %380
-%1555 = OpCompositeInsert %_arr_float_uint_5 %1554 %1553 4
-OpStore %385 %1555
-%1557 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_4
-%1558 = OpLoad %_arr_float_uint_5 %385
-OpStore %1557 %1558
-%1559 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_5
-%1560 = OpLoad %_arr_float_uint_5 %125
-OpStore %1559 %1560
-%1561 = OpLoad %ulong %141
-OpStore %140 %1561
-OpStore %145 %ulong_0
-OpBranch %62
-%62 = OpLabel
-%1562 = OpLoad %ulong %145
-%1563 = OpULessThan %bool %1562 %ulong_6
-OpStore %130 %1563
-%1564 = OpLoad %bool %130
-OpLoopMerge %64 %97 None
-OpBranchConditional %1564 %63 %64
-%64 = OpLabel
-OpStore %106 %1565
-%1566 = OpAccessChain %_ptr_Function_uint %106 %uint_0
-OpStore %1566 %uint_4294967295
-%1568 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %uint_2
-%1569 = OpLoad %_arr_float_uint_5 %1568
-OpStore %133 %1569
-%1570 = OpAccessChain %_ptr_Function__arr_float_uint_5 %106 %uint_1
-%1571 = OpLoad %_arr_float_uint_5 %133
-OpStore %1570 %1571
-%1572 = OpAccessChain %_ptr_Function_uint %106 %uint_2
-OpStore %1572 %uint_305419896
-%1574 = OpLoad %uint %1566
-OpStore %135 %1574
-%1575 = OpLoad %ulong %140
-%1576 = OpLoad %uint %135
-%1577 = OpFunctionCall %ulong %4 %1575 %1576
-OpStore %136 %1577
-%1578 = OpLoad %_arr_float_uint_5 %1570
-OpStore %137 %1578
-OpBranch %71
-%71 = OpLabel
-%1579 = OpLoad %_arr_float_uint_5 %137
-%1580 = OpCompositeExtract %float %1579 0
-OpStore %176 %1580
-%1581 = OpLoad %ulong %136
-%1582 = OpLoad %float %176
-%1583 = OpFunctionCall %ulong %5 %1581 %1582
-OpStore %177 %1583
-%1584 = OpLoad %_arr_float_uint_5 %137
-%1585 = OpCompositeExtract %float %1584 1
-OpStore %178 %1585
-%1586 = OpLoad %ulong %177
-%1587 = OpLoad %float %178
-%1588 = OpFunctionCall %ulong %5 %1586 %1587
-OpStore %179 %1588
-%1589 = OpLoad %_arr_float_uint_5 %137
-%1590 = OpCompositeExtract %float %1589 2
-OpStore %180 %1590
-%1591 = OpLoad %ulong %179
-%1592 = OpLoad %float %180
-%1593 = OpFunctionCall %ulong %5 %1591 %1592
-OpStore %181 %1593
-%1594 = OpLoad %_arr_float_uint_5 %137
-%1595 = OpCompositeExtract %float %1594 3
-OpStore %182 %1595
-%1596 = OpLoad %ulong %181
-%1597 = OpLoad %float %182
-%1598 = OpFunctionCall %ulong %5 %1596 %1597
-OpStore %183 %1598
-%1599 = OpLoad %_arr_float_uint_5 %137
-%1600 = OpCompositeExtract %float %1599 4
-OpStore %184 %1600
-%1601 = OpLoad %ulong %183
-%1602 = OpLoad %float %184
-%1603 = OpFunctionCall %ulong %5 %1601 %1602
-OpStore %185 %1603
-OpBranch %72
-%72 = OpLabel
-%1604 = OpAccessChain %_ptr_Function_uint %106 %uint_2
-%1605 = OpLoad %uint %1604
-OpStore %138 %1605
-%1606 = OpLoad %ulong %185
-%1607 = OpLoad %uint %138
-%1608 = OpFunctionCall %ulong %4 %1606 %1607
-OpStore %139 %1608
-%1609 = OpLoad %ulong %139
-OpReturnValue %1609
-%63 = OpLabel
-%1610 = OpLoad %ulong %145
-%1611 = OpAccessChain %_ptr_Function__arr_float_uint_5 %103 %1610
-%1612 = OpLoad %_arr_float_uint_5 %1611
-OpStore %131 %1612
-OpBranch %69
-%69 = OpLabel
-%1613 = OpLoad %_arr_float_uint_5 %131
-%1614 = OpCompositeExtract %float %1613 0
-OpStore %166 %1614
-%1615 = OpLoad %ulong %140
-%1616 = OpLoad %float %166
-%1617 = OpFunctionCall %ulong %5 %1615 %1616
-OpStore %167 %1617
-%1618 = OpLoad %_arr_float_uint_5 %131
-%1619 = OpCompositeExtract %float %1618 1
-OpStore %168 %1619
-%1620 = OpLoad %ulong %167
-%1621 = OpLoad %float %168
-%1622 = OpFunctionCall %ulong %5 %1620 %1621
-OpStore %169 %1622
-%1623 = OpLoad %_arr_float_uint_5 %131
-%1624 = OpCompositeExtract %float %1623 2
-OpStore %170 %1624
-%1625 = OpLoad %ulong %169
-%1626 = OpLoad %float %170
-%1627 = OpFunctionCall %ulong %5 %1625 %1626
-OpStore %171 %1627
-%1628 = OpLoad %_arr_float_uint_5 %131
-%1629 = OpCompositeExtract %float %1628 3
-OpStore %172 %1629
-%1630 = OpLoad %ulong %171
-%1631 = OpLoad %float %172
-%1632 = OpFunctionCall %ulong %5 %1630 %1631
-OpStore %173 %1632
-%1633 = OpLoad %_arr_float_uint_5 %131
-%1634 = OpCompositeExtract %float %1633 4
-OpStore %174 %1634
-%1635 = OpLoad %ulong %173
-%1636 = OpLoad %float %174
-%1637 = OpFunctionCall %ulong %5 %1635 %1636
-OpStore %175 %1637
-OpBranch %70
-%70 = OpLabel
-%1638 = OpLoad %ulong %145
-%1640 = OpIAdd %ulong %1638 %ulong_1
-OpStore %132 %1640
-%1641 = OpLoad %ulong %175
-OpStore %140 %1641
-%1642 = OpLoad %ulong %132
-OpStore %145 %1642
-OpBranch %97
-%60 = OpLabel
-%1643 = OpLoad %_arr_float_uint_5 %142
-%1644 = OpCompositeExtract %float %1643 0
-OpStore %306 %1644
-%1645 = OpLoad %_arr_float_uint_5 %116
-%1646 = OpCompositeExtract %float %1645 0
-OpStore %307 %1646
-%1647 = OpLoad %float %306
-%1648 = OpLoad %float %307
-%1649 = OpFMul %float %1647 %1648
-OpStore %308 %1649
-%1650 = OpLoad %_arr_float_uint_5 %142
-%1651 = OpCompositeExtract %float %1650 1
-OpStore %309 %1651
-%1652 = OpLoad %_arr_float_uint_5 %116
-%1653 = OpCompositeExtract %float %1652 1
-OpStore %310 %1653
-%1654 = OpLoad %float %309
-%1655 = OpLoad %float %310
-%1656 = OpFMul %float %1654 %1655
-OpStore %311 %1656
-%1657 = OpLoad %_arr_float_uint_5 %142
-%1658 = OpCompositeExtract %float %1657 2
-OpStore %312 %1658
-%1659 = OpLoad %_arr_float_uint_5 %116
-%1660 = OpCompositeExtract %float %1659 2
-OpStore %313 %1660
-%1661 = OpLoad %float %312
-%1662 = OpLoad %float %313
-%1663 = OpFMul %float %1661 %1662
-OpStore %314 %1663
-%1664 = OpLoad %_arr_float_uint_5 %142
-%1665 = OpCompositeExtract %float %1664 3
-OpStore %315 %1665
-%1666 = OpLoad %_arr_float_uint_5 %116
-%1667 = OpCompositeExtract %float %1666 3
-OpStore %316 %1667
-%1668 = OpLoad %float %315
-%1669 = OpLoad %float %316
-%1670 = OpFMul %float %1668 %1669
-OpStore %317 %1670
-%1671 = OpLoad %_arr_float_uint_5 %142
-%1672 = OpCompositeExtract %float %1671 4
-OpStore %318 %1672
-%1673 = OpLoad %_arr_float_uint_5 %116
-%1674 = OpCompositeExtract %float %1673 4
-OpStore %319 %1674
-%1675 = OpLoad %float %318
-%1676 = OpLoad %float %319
-%1677 = OpFMul %float %1675 %1676
-OpStore %320 %1677
-%1678 = OpLoad %_arr_float_uint_5 %142
-%1679 = OpLoad %float %308
-%1680 = OpCompositeInsert %_arr_float_uint_5 %1679 %1678 0
-OpStore %321 %1680
-%1681 = OpLoad %_arr_float_uint_5 %321
-%1682 = OpLoad %float %311
-%1683 = OpCompositeInsert %_arr_float_uint_5 %1682 %1681 1
-OpStore %322 %1683
-%1684 = OpLoad %_arr_float_uint_5 %322
-%1685 = OpLoad %float %314
-%1686 = OpCompositeInsert %_arr_float_uint_5 %1685 %1684 2
-OpStore %323 %1686
-%1687 = OpLoad %_arr_float_uint_5 %323
-%1688 = OpLoad %float %317
-%1689 = OpCompositeInsert %_arr_float_uint_5 %1688 %1687 3
-OpStore %324 %1689
-%1690 = OpLoad %_arr_float_uint_5 %324
-%1691 = OpLoad %float %320
-%1692 = OpCompositeInsert %_arr_float_uint_5 %1691 %1690 4
-OpStore %325 %1692
-OpBranch %67
-%67 = OpLabel
-%1693 = OpLoad %_arr_float_uint_5 %325
-%1694 = OpCompositeExtract %float %1693 0
-OpStore %156 %1694
-%1695 = OpLoad %ulong %141
-%1696 = OpLoad %float %156
-%1697 = OpFunctionCall %ulong %5 %1695 %1696
-OpStore %157 %1697
-%1698 = OpLoad %_arr_float_uint_5 %325
-%1699 = OpCompositeExtract %float %1698 1
-OpStore %158 %1699
-%1700 = OpLoad %ulong %157
-%1701 = OpLoad %float %158
-%1702 = OpFunctionCall %ulong %5 %1700 %1701
-OpStore %159 %1702
-%1703 = OpLoad %_arr_float_uint_5 %325
-%1704 = OpCompositeExtract %float %1703 2
-OpStore %160 %1704
-%1705 = OpLoad %ulong %159
-%1706 = OpLoad %float %160
-%1707 = OpFunctionCall %ulong %5 %1705 %1706
-OpStore %161 %1707
-%1708 = OpLoad %_arr_float_uint_5 %325
-%1709 = OpCompositeExtract %float %1708 3
-OpStore %162 %1709
-%1710 = OpLoad %ulong %161
-%1711 = OpLoad %float %162
-%1712 = OpFunctionCall %ulong %5 %1710 %1711
-OpStore %163 %1712
-%1713 = OpLoad %_arr_float_uint_5 %325
-%1714 = OpCompositeExtract %float %1713 4
-OpStore %164 %1714
-%1715 = OpLoad %ulong %163
-%1716 = OpLoad %float %164
-%1717 = OpFunctionCall %ulong %5 %1715 %1716
-OpStore %165 %1717
-OpBranch %68
-%68 = OpLabel
-%1718 = OpLoad %_arr_float_uint_5 %143
-%1719 = OpCompositeExtract %float %1718 0
-OpStore %386 %1719
-%1720 = OpLoad %_arr_float_uint_5 %325
-%1721 = OpCompositeExtract %float %1720 0
-OpStore %387 %1721
-%1722 = OpLoad %float %386
-%1723 = OpLoad %float %387
-%1724 = OpFAdd %float %1722 %1723
-OpStore %388 %1724
-%1725 = OpLoad %_arr_float_uint_5 %143
-%1726 = OpCompositeExtract %float %1725 1
-OpStore %389 %1726
-%1727 = OpLoad %_arr_float_uint_5 %325
-%1728 = OpCompositeExtract %float %1727 1
-OpStore %390 %1728
-%1729 = OpLoad %float %389
-%1730 = OpLoad %float %390
-%1731 = OpFAdd %float %1729 %1730
-OpStore %391 %1731
-%1732 = OpLoad %_arr_float_uint_5 %143
-%1733 = OpCompositeExtract %float %1732 2
-OpStore %392 %1733
-%1734 = OpLoad %_arr_float_uint_5 %325
-%1735 = OpCompositeExtract %float %1734 2
-OpStore %393 %1735
-%1736 = OpLoad %float %392
-%1737 = OpLoad %float %393
-%1738 = OpFAdd %float %1736 %1737
-OpStore %394 %1738
-%1739 = OpLoad %_arr_float_uint_5 %143
-%1740 = OpCompositeExtract %float %1739 3
-OpStore %395 %1740
-%1741 = OpLoad %_arr_float_uint_5 %325
-%1742 = OpCompositeExtract %float %1741 3
-OpStore %396 %1742
-%1743 = OpLoad %float %395
-%1744 = OpLoad %float %396
-%1745 = OpFAdd %float %1743 %1744
-OpStore %397 %1745
-%1746 = OpLoad %_arr_float_uint_5 %143
-%1747 = OpCompositeExtract %float %1746 4
-OpStore %398 %1747
-%1748 = OpLoad %_arr_float_uint_5 %325
-%1749 = OpCompositeExtract %float %1748 4
-OpStore %399 %1749
-%1750 = OpLoad %float %398
-%1751 = OpLoad %float %399
-%1752 = OpFAdd %float %1750 %1751
-OpStore %400 %1752
-%1753 = OpLoad %_arr_float_uint_5 %143
-%1754 = OpLoad %float %388
-%1755 = OpCompositeInsert %_arr_float_uint_5 %1754 %1753 0
-OpStore %401 %1755
-%1756 = OpLoad %_arr_float_uint_5 %401
-%1757 = OpLoad %float %391
-%1758 = OpCompositeInsert %_arr_float_uint_5 %1757 %1756 1
-OpStore %402 %1758
-%1759 = OpLoad %_arr_float_uint_5 %402
-%1760 = OpLoad %float %394
-%1761 = OpCompositeInsert %_arr_float_uint_5 %1760 %1759 2
-OpStore %403 %1761
-%1762 = OpLoad %_arr_float_uint_5 %403
-%1763 = OpLoad %float %397
-%1764 = OpCompositeInsert %_arr_float_uint_5 %1763 %1762 3
-OpStore %404 %1764
-%1765 = OpLoad %_arr_float_uint_5 %404
-%1766 = OpLoad %float %400
-%1767 = OpCompositeInsert %_arr_float_uint_5 %1766 %1765 4
-OpStore %405 %1767
-OpBranch %75
-%75 = OpLabel
-%1768 = OpLoad %_arr_float_uint_5 %405
-%1769 = OpCompositeExtract %float %1768 0
-OpStore %196 %1769
-%1770 = OpLoad %ulong %165
-%1771 = OpLoad %float %196
-%1772 = OpFunctionCall %ulong %5 %1770 %1771
-OpStore %197 %1772
-%1773 = OpLoad %_arr_float_uint_5 %405
-%1774 = OpCompositeExtract %float %1773 1
-OpStore %198 %1774
-%1775 = OpLoad %ulong %197
-%1776 = OpLoad %float %198
-%1777 = OpFunctionCall %ulong %5 %1775 %1776
-OpStore %199 %1777
-%1778 = OpLoad %_arr_float_uint_5 %405
-%1779 = OpCompositeExtract %float %1778 2
-OpStore %200 %1779
-%1780 = OpLoad %ulong %199
-%1781 = OpLoad %float %200
-%1782 = OpFunctionCall %ulong %5 %1780 %1781
-OpStore %201 %1782
-%1783 = OpLoad %_arr_float_uint_5 %405
-%1784 = OpCompositeExtract %float %1783 3
-OpStore %202 %1784
-%1785 = OpLoad %ulong %201
-%1786 = OpLoad %float %202
-%1787 = OpFunctionCall %ulong %5 %1785 %1786
-OpStore %203 %1787
-%1788 = OpLoad %_arr_float_uint_5 %405
-%1789 = OpCompositeExtract %float %1788 4
-OpStore %204 %1789
-%1790 = OpLoad %ulong %203
-%1791 = OpLoad %float %204
-%1792 = OpFunctionCall %ulong %5 %1790 %1791
-OpStore %205 %1792
-OpBranch %76
-%76 = OpLabel
-%1793 = OpLoad %_arr_float_uint_5 %142
-%1794 = OpCompositeExtract %float %1793 0
-OpStore %426 %1794
-%1795 = OpLoad %_arr_float_uint_5 %125
-%1796 = OpCompositeExtract %float %1795 0
-OpStore %427 %1796
-%1797 = OpLoad %float %426
-%1798 = OpLoad %float %427
-%1799 = OpFSub %float %1797 %1798
-OpStore %428 %1799
-%1800 = OpLoad %_arr_float_uint_5 %142
-%1801 = OpCompositeExtract %float %1800 1
-OpStore %429 %1801
-%1802 = OpLoad %_arr_float_uint_5 %125
-%1803 = OpCompositeExtract %float %1802 1
-OpStore %430 %1803
-%1804 = OpLoad %float %429
-%1805 = OpLoad %float %430
-%1806 = OpFSub %float %1804 %1805
-OpStore %431 %1806
-%1807 = OpLoad %_arr_float_uint_5 %142
-%1808 = OpCompositeExtract %float %1807 2
-OpStore %432 %1808
-%1809 = OpLoad %_arr_float_uint_5 %125
-%1810 = OpCompositeExtract %float %1809 2
-OpStore %433 %1810
-%1811 = OpLoad %float %432
-%1812 = OpLoad %float %433
-%1813 = OpFSub %float %1811 %1812
-OpStore %434 %1813
-%1814 = OpLoad %_arr_float_uint_5 %142
-%1815 = OpCompositeExtract %float %1814 3
-OpStore %435 %1815
-%1816 = OpLoad %_arr_float_uint_5 %125
-%1817 = OpCompositeExtract %float %1816 3
-OpStore %436 %1817
-%1818 = OpLoad %float %435
-%1819 = OpLoad %float %436
-%1820 = OpFSub %float %1818 %1819
-OpStore %437 %1820
-%1821 = OpLoad %_arr_float_uint_5 %142
-%1822 = OpCompositeExtract %float %1821 4
-OpStore %438 %1822
-%1823 = OpLoad %_arr_float_uint_5 %125
-%1824 = OpCompositeExtract %float %1823 4
-OpStore %439 %1824
-%1825 = OpLoad %float %438
-%1826 = OpLoad %float %439
-%1827 = OpFSub %float %1825 %1826
-OpStore %440 %1827
-%1828 = OpLoad %_arr_float_uint_5 %142
-%1829 = OpLoad %float %428
-%1830 = OpCompositeInsert %_arr_float_uint_5 %1829 %1828 0
-OpStore %441 %1830
-%1831 = OpLoad %_arr_float_uint_5 %441
-%1832 = OpLoad %float %431
-%1833 = OpCompositeInsert %_arr_float_uint_5 %1832 %1831 1
-OpStore %442 %1833
-%1834 = OpLoad %_arr_float_uint_5 %442
-%1835 = OpLoad %float %434
-%1836 = OpCompositeInsert %_arr_float_uint_5 %1835 %1834 2
-OpStore %443 %1836
-%1837 = OpLoad %_arr_float_uint_5 %443
-%1838 = OpLoad %float %437
-%1839 = OpCompositeInsert %_arr_float_uint_5 %1838 %1837 3
-OpStore %444 %1839
-%1840 = OpLoad %_arr_float_uint_5 %444
-%1841 = OpLoad %float %440
-%1842 = OpCompositeInsert %_arr_float_uint_5 %1841 %1840 4
-OpStore %445 %1842
-OpBranch %79
-%79 = OpLabel
-%1843 = OpLoad %_arr_float_uint_5 %445
-%1844 = OpCompositeExtract %float %1843 0
-OpStore %216 %1844
-%1845 = OpLoad %ulong %205
-%1846 = OpLoad %float %216
-%1847 = OpFunctionCall %ulong %5 %1845 %1846
-OpStore %217 %1847
-%1848 = OpLoad %_arr_float_uint_5 %445
-%1849 = OpCompositeExtract %float %1848 1
-OpStore %218 %1849
-%1850 = OpLoad %ulong %217
-%1851 = OpLoad %float %218
-%1852 = OpFunctionCall %ulong %5 %1850 %1851
-OpStore %219 %1852
-%1853 = OpLoad %_arr_float_uint_5 %445
-%1854 = OpCompositeExtract %float %1853 2
-OpStore %220 %1854
-%1855 = OpLoad %ulong %219
-%1856 = OpLoad %float %220
-%1857 = OpFunctionCall %ulong %5 %1855 %1856
-OpStore %221 %1857
-%1858 = OpLoad %_arr_float_uint_5 %445
-%1859 = OpCompositeExtract %float %1858 3
-OpStore %222 %1859
-%1860 = OpLoad %ulong %221
-%1861 = OpLoad %float %222
-%1862 = OpFunctionCall %ulong %5 %1860 %1861
-OpStore %223 %1862
-%1863 = OpLoad %_arr_float_uint_5 %445
-%1864 = OpCompositeExtract %float %1863 4
-OpStore %224 %1864
-%1865 = OpLoad %ulong %223
-%1866 = OpLoad %float %224
-%1867 = OpFunctionCall %ulong %5 %1865 %1866
-OpStore %225 %1867
-OpBranch %80
-%80 = OpLabel
-%1868 = OpLoad %ulong %144
-%1869 = OpIAdd %ulong %1868 %ulong_1
-OpStore %129 %1869
-%1870 = OpLoad %ulong %225
-OpStore %141 %1870
-%1871 = OpLoad %_arr_float_uint_5 %445
-OpStore %142 %1871
-%1872 = OpLoad %_arr_float_uint_5 %405
-OpStore %143 %1872
-%1873 = OpLoad %ulong %129
-OpStore %144 %1873
-OpBranch %98
-%97 = OpLabel
-OpBranch %62
-%98 = OpLabel
-OpBranch %59
-OpFunctionEnd
-%3 = OpFunction %ulong None %1874
-%1875 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %1877
-%1878 = OpFunctionParameter %ulong
-%1879 = OpFunctionParameter %uint
-%1880 = OpLabel
-%1887 = OpVariable %_ptr_Function_ulong Function
-%1888 = OpVariable %_ptr_Function_uint Function
-%1889 = OpVariable %_ptr_Function_ulong Function
-%1890 = OpVariable %_ptr_Function_bool Function
-%1891 = OpVariable %_ptr_Function_ulong Function
-%1892 = OpVariable %_ptr_Function_ulong Function
-%1893 = OpVariable %_ptr_Function_ulong Function
-%1894 = OpVariable %_ptr_Function_ulong Function
-%1895 = OpVariable %_ptr_Function_ulong Function
-%1896 = OpVariable %_ptr_Function_ulong Function
-%1897 = OpVariable %_ptr_Function_ulong Function
-%1898 = OpVariable %_ptr_Function_ulong Function
-OpStore %1887 %1878
-OpStore %1888 %1879
-%1899 = OpLoad %uint %1888
-%1900 = OpUConvert %ulong %1899
-OpStore %1889 %1900
-OpBranch %1881
-%1881 = OpLabel
-%1901 = OpLoad %ulong %1887
-OpStore %1897 %1901
-OpStore %1898 %ulong_0
-OpBranch %1882
-%1882 = OpLabel
-%1902 = OpLoad %ulong %1898
-%1904 = OpULessThan %bool %1902 %ulong_8
-OpStore %1890 %1904
-%1905 = OpLoad %bool %1890
-OpLoopMerge %1884 %1886 None
-OpBranchConditional %1905 %1883 %1884
-%1884 = OpLabel
-OpBranch %1885
-%1885 = OpLabel
-%1906 = OpLoad %ulong %1897
-OpReturnValue %1906
-%1883 = OpLabel
-%1907 = OpLoad %ulong %1898
-%1908 = OpIMul %ulong %1907 %ulong_8
-OpStore %1891 %1908
-%1909 = OpLoad %ulong %1889
-%1910 = OpLoad %ulong %1891
-%1911 = OpShiftRightLogical %ulong %1909 %1910
-OpStore %1892 %1911
-%1912 = OpLoad %ulong %1892
-%1914 = OpBitwiseAnd %ulong %1912 %ulong_255
-OpStore %1893 %1914
-%1915 = OpLoad %ulong %1897
-%1916 = OpLoad %ulong %1893
-%1917 = OpBitwiseXor %ulong %1915 %1916
-OpStore %1894 %1917
-%1918 = OpLoad %ulong %1894
-%1920 = OpIMul %ulong %1918 %ulong_1099511628211
-OpStore %1895 %1920
-%1921 = OpLoad %ulong %1898
-%1922 = OpIAdd %ulong %1921 %ulong_1
-OpStore %1896 %1922
-%1923 = OpLoad %ulong %1895
-OpStore %1897 %1923
-%1924 = OpLoad %ulong %1896
-OpStore %1898 %1924
-OpBranch %1886
-%1886 = OpLabel
-OpBranch %1882
-OpFunctionEnd
-%5 = OpFunction %ulong None %1925
-%1926 = OpFunctionParameter %ulong
-%1927 = OpFunctionParameter %float
-%1928 = OpLabel
-%1935 = OpVariable %_ptr_Function_ulong Function
-%1936 = OpVariable %_ptr_Function_float Function
-%1937 = OpVariable %_ptr_Function_uint Function
-%1938 = OpVariable %_ptr_Function_ulong Function
-%1939 = OpVariable %_ptr_Function_bool Function
-%1940 = OpVariable %_ptr_Function_ulong Function
-%1941 = OpVariable %_ptr_Function_ulong Function
-%1942 = OpVariable %_ptr_Function_ulong Function
-%1943 = OpVariable %_ptr_Function_ulong Function
-%1944 = OpVariable %_ptr_Function_ulong Function
-%1945 = OpVariable %_ptr_Function_ulong Function
-%1946 = OpVariable %_ptr_Function_ulong Function
-%1947 = OpVariable %_ptr_Function_ulong Function
-OpStore %1935 %1926
-OpStore %1936 %1927
-%1948 = OpLoad %float %1936
-%1949 = OpBitcast %uint %1948
-OpStore %1937 %1949
-%1950 = OpLoad %uint %1937
-%1951 = OpUConvert %ulong %1950
-OpStore %1938 %1951
-OpBranch %1929
-%1929 = OpLabel
-%1952 = OpLoad %ulong %1935
-OpStore %1946 %1952
-OpStore %1947 %ulong_0
-OpBranch %1930
-%1930 = OpLabel
-%1953 = OpLoad %ulong %1947
-%1954 = OpULessThan %bool %1953 %ulong_8
-OpStore %1939 %1954
-%1955 = OpLoad %bool %1939
-OpLoopMerge %1932 %1934 None
-OpBranchConditional %1955 %1931 %1932
-%1932 = OpLabel
-OpBranch %1933
-%1933 = OpLabel
-%1956 = OpLoad %ulong %1946
-OpReturnValue %1956
-%1931 = OpLabel
-%1957 = OpLoad %ulong %1947
-%1958 = OpIMul %ulong %1957 %ulong_8
-OpStore %1940 %1958
-%1959 = OpLoad %ulong %1938
-%1960 = OpLoad %ulong %1940
-%1961 = OpShiftRightLogical %ulong %1959 %1960
-OpStore %1941 %1961
-%1962 = OpLoad %ulong %1941
-%1963 = OpBitwiseAnd %ulong %1962 %ulong_255
-OpStore %1942 %1963
-%1964 = OpLoad %ulong %1946
-%1965 = OpLoad %ulong %1942
-%1966 = OpBitwiseXor %ulong %1964 %1965
-OpStore %1943 %1966
-%1967 = OpLoad %ulong %1943
-%1968 = OpIMul %ulong %1967 %ulong_1099511628211
-OpStore %1944 %1968
-%1969 = OpLoad %ulong %1947
-%1970 = OpIAdd %ulong %1969 %ulong_1
-OpStore %1945 %1970
-%1971 = OpLoad %ulong %1944
-OpStore %1946 %1971
-%1972 = OpLoad %ulong %1945
-OpStore %1947 %1972
-OpBranch %1934
-%1934 = OpLabel
-OpBranch %1930
+OpStore %575 %962
+%963 = OpLoad %float %574
+%964 = OpLoad %float %575
+%965 = OpFDiv %float %963 %964
+OpStore %576 %965
+%966 = OpLoad %_arr_float_uint_5 %306
+%967 = OpLoad %float %564
+%968 = OpCompositeInsert %_arr_float_uint_5 %967 %966 0
+OpStore %577 %968
+%969 = OpLoad %_arr_float_uint_5 %577
+%970 = OpLoad %float %567
+%971 = OpCompositeInsert %_arr_float_uint_5 %970 %969 1
+OpStore %578 %971
+%972 = OpLoad %_arr_float_uint_5 %578
+%973 = OpLoad %float %570
+%974 = OpCompositeInsert %_arr_float_uint_5 %973 %972 2
+OpStore %579 %974
+%975 = OpLoad %_arr_float_uint_5 %579
+%976 = OpLoad %float %573
+%977 = OpCompositeInsert %_arr_float_uint_5 %976 %975 3
+OpStore %580 %977
+%978 = OpLoad %_arr_float_uint_5 %580
+%979 = OpLoad %float %576
+%980 = OpCompositeInsert %_arr_float_uint_5 %979 %978 4
+OpStore %581 %980
+%981 = OpLoad %ulong %315
+%982 = OpLoad %_arr_float_uint_5 %581
+%983 = OpFunctionCall %ulong %1 %981 %982
+OpStore %316 %983
+%984 = OpLoad %_arr_float_uint_5 %309
+%985 = OpCompositeExtract %float %984 0
+OpStore %582 %985
+%986 = OpLoad %_arr_float_uint_5 %306
+%987 = OpCompositeExtract %float %986 0
+OpStore %583 %987
+%988 = OpLoad %float %582
+%989 = OpLoad %float %583
+%990 = OpFDiv %float %988 %989
+OpStore %584 %990
+%991 = OpLoad %_arr_float_uint_5 %309
+%992 = OpCompositeExtract %float %991 1
+OpStore %585 %992
+%993 = OpLoad %_arr_float_uint_5 %306
+%994 = OpCompositeExtract %float %993 1
+OpStore %586 %994
+%995 = OpLoad %float %585
+%996 = OpLoad %float %586
+%997 = OpFDiv %float %995 %996
+OpStore %587 %997
+%998 = OpLoad %_arr_float_uint_5 %309
+%999 = OpCompositeExtract %float %998 2
+OpStore %588 %999
+%1000 = OpLoad %_arr_float_uint_5 %306
+%1001 = OpCompositeExtract %float %1000 2
+OpStore %589 %1001
+%1002 = OpLoad %float %588
+%1003 = OpLoad %float %589
+%1004 = OpFDiv %float %1002 %1003
+OpStore %590 %1004
+%1005 = OpLoad %_arr_float_uint_5 %309
+%1006 = OpCompositeExtract %float %1005 3
+OpStore %591 %1006
+%1007 = OpLoad %_arr_float_uint_5 %306
+%1008 = OpCompositeExtract %float %1007 3
+OpStore %592 %1008
+%1009 = OpLoad %float %591
+%1010 = OpLoad %float %592
+%1011 = OpFDiv %float %1009 %1010
+OpStore %593 %1011
+%1012 = OpLoad %_arr_float_uint_5 %309
+%1013 = OpCompositeExtract %float %1012 4
+OpStore %594 %1013
+%1014 = OpLoad %_arr_float_uint_5 %306
+%1015 = OpCompositeExtract %float %1014 4
+OpStore %595 %1015
+%1016 = OpLoad %float %594
+%1017 = OpLoad %float %595
+%1018 = OpFDiv %float %1016 %1017
+OpStore %596 %1018
+%1019 = OpLoad %_arr_float_uint_5 %309
+%1020 = OpLoad %float %584
+%1021 = OpCompositeInsert %_arr_float_uint_5 %1020 %1019 0
+OpStore %597 %1021
+%1022 = OpLoad %_arr_float_uint_5 %597
+%1023 = OpLoad %float %587
+%1024 = OpCompositeInsert %_arr_float_uint_5 %1023 %1022 1
+OpStore %598 %1024
+%1025 = OpLoad %_arr_float_uint_5 %598
+%1026 = OpLoad %float %590
+%1027 = OpCompositeInsert %_arr_float_uint_5 %1026 %1025 2
+OpStore %599 %1027
+%1028 = OpLoad %_arr_float_uint_5 %599
+%1029 = OpLoad %float %593
+%1030 = OpCompositeInsert %_arr_float_uint_5 %1029 %1028 3
+OpStore %600 %1030
+%1031 = OpLoad %_arr_float_uint_5 %600
+%1032 = OpLoad %float %596
+%1033 = OpCompositeInsert %_arr_float_uint_5 %1032 %1031 4
+OpStore %601 %1033
+%1034 = OpLoad %ulong %316
+%1035 = OpLoad %_arr_float_uint_5 %601
+%1036 = OpFunctionCall %ulong %1 %1034 %1035
+OpStore %317 %1036
+%1037 = OpLoad %_arr_float_uint_5 %306
+%1038 = OpCompositeExtract %float %1037 0
+OpStore %602 %1038
+%1039 = OpLoad %_arr_float_uint_5 %300
+%1040 = OpCompositeExtract %float %1039 0
+OpStore %603 %1040
+%1041 = OpLoad %float %602
+%1042 = OpLoad %float %603
+%1043 = OpFMul %float %1041 %1042
+OpStore %604 %1043
+%1044 = OpLoad %_arr_float_uint_5 %306
+%1045 = OpCompositeExtract %float %1044 1
+OpStore %605 %1045
+%1046 = OpLoad %_arr_float_uint_5 %300
+%1047 = OpCompositeExtract %float %1046 1
+OpStore %606 %1047
+%1048 = OpLoad %float %605
+%1049 = OpLoad %float %606
+%1050 = OpFMul %float %1048 %1049
+OpStore %607 %1050
+%1051 = OpLoad %_arr_float_uint_5 %306
+%1052 = OpCompositeExtract %float %1051 2
+OpStore %608 %1052
+%1053 = OpLoad %_arr_float_uint_5 %300
+%1054 = OpCompositeExtract %float %1053 2
+OpStore %609 %1054
+%1055 = OpLoad %float %608
+%1056 = OpLoad %float %609
+%1057 = OpFMul %float %1055 %1056
+OpStore %610 %1057
+%1058 = OpLoad %_arr_float_uint_5 %306
+%1059 = OpCompositeExtract %float %1058 3
+OpStore %611 %1059
+%1060 = OpLoad %_arr_float_uint_5 %300
+%1061 = OpCompositeExtract %float %1060 3
+OpStore %612 %1061
+%1062 = OpLoad %float %611
+%1063 = OpLoad %float %612
+%1064 = OpFMul %float %1062 %1063
+OpStore %613 %1064
+%1065 = OpLoad %_arr_float_uint_5 %306
+%1066 = OpCompositeExtract %float %1065 4
+OpStore %614 %1066
+%1067 = OpLoad %_arr_float_uint_5 %300
+%1068 = OpCompositeExtract %float %1067 4
+OpStore %615 %1068
+%1069 = OpLoad %float %614
+%1070 = OpLoad %float %615
+%1071 = OpFMul %float %1069 %1070
+OpStore %616 %1071
+%1072 = OpLoad %_arr_float_uint_5 %306
+%1073 = OpLoad %float %604
+%1074 = OpCompositeInsert %_arr_float_uint_5 %1073 %1072 0
+OpStore %617 %1074
+%1075 = OpLoad %_arr_float_uint_5 %617
+%1076 = OpLoad %float %607
+%1077 = OpCompositeInsert %_arr_float_uint_5 %1076 %1075 1
+OpStore %618 %1077
+%1078 = OpLoad %_arr_float_uint_5 %618
+%1079 = OpLoad %float %610
+%1080 = OpCompositeInsert %_arr_float_uint_5 %1079 %1078 2
+OpStore %619 %1080
+%1081 = OpLoad %_arr_float_uint_5 %619
+%1082 = OpLoad %float %613
+%1083 = OpCompositeInsert %_arr_float_uint_5 %1082 %1081 3
+OpStore %620 %1083
+%1084 = OpLoad %_arr_float_uint_5 %620
+%1085 = OpLoad %float %616
+%1086 = OpCompositeInsert %_arr_float_uint_5 %1085 %1084 4
+OpStore %621 %1086
+%1087 = OpLoad %ulong %317
+%1088 = OpLoad %_arr_float_uint_5 %621
+%1089 = OpFunctionCall %ulong %1 %1087 %1088
+OpStore %318 %1089
+%1090 = OpLoad %_arr_float_uint_5 %300
+%1091 = OpCompositeExtract %float %1090 0
+OpStore %622 %1091
+%1092 = OpLoad %_arr_float_uint_5 %309
+%1093 = OpCompositeExtract %float %1092 0
+OpStore %623 %1093
+%1094 = OpLoad %float %622
+%1095 = OpLoad %float %623
+%1096 = OpFSub %float %1094 %1095
+OpStore %624 %1096
+%1097 = OpLoad %_arr_float_uint_5 %300
+%1098 = OpCompositeExtract %float %1097 1
+OpStore %625 %1098
+%1099 = OpLoad %_arr_float_uint_5 %309
+%1100 = OpCompositeExtract %float %1099 1
+OpStore %626 %1100
+%1101 = OpLoad %float %625
+%1102 = OpLoad %float %626
+%1103 = OpFSub %float %1101 %1102
+OpStore %627 %1103
+%1104 = OpLoad %_arr_float_uint_5 %300
+%1105 = OpCompositeExtract %float %1104 2
+OpStore %628 %1105
+%1106 = OpLoad %_arr_float_uint_5 %309
+%1107 = OpCompositeExtract %float %1106 2
+OpStore %629 %1107
+%1108 = OpLoad %float %628
+%1109 = OpLoad %float %629
+%1110 = OpFSub %float %1108 %1109
+OpStore %630 %1110
+%1111 = OpLoad %_arr_float_uint_5 %300
+%1112 = OpCompositeExtract %float %1111 3
+OpStore %631 %1112
+%1113 = OpLoad %_arr_float_uint_5 %309
+%1114 = OpCompositeExtract %float %1113 3
+OpStore %632 %1114
+%1115 = OpLoad %float %631
+%1116 = OpLoad %float %632
+%1117 = OpFSub %float %1115 %1116
+OpStore %633 %1117
+%1118 = OpLoad %_arr_float_uint_5 %300
+%1119 = OpCompositeExtract %float %1118 4
+OpStore %634 %1119
+%1120 = OpLoad %_arr_float_uint_5 %309
+%1121 = OpCompositeExtract %float %1120 4
+OpStore %635 %1121
+%1122 = OpLoad %float %634
+%1123 = OpLoad %float %635
+%1124 = OpFSub %float %1122 %1123
+OpStore %636 %1124
+%1125 = OpLoad %_arr_float_uint_5 %300
+%1126 = OpLoad %float %624
+%1127 = OpCompositeInsert %_arr_float_uint_5 %1126 %1125 0
+OpStore %637 %1127
+%1128 = OpLoad %_arr_float_uint_5 %637
+%1129 = OpLoad %float %627
+%1130 = OpCompositeInsert %_arr_float_uint_5 %1129 %1128 1
+OpStore %638 %1130
+%1131 = OpLoad %_arr_float_uint_5 %638
+%1132 = OpLoad %float %630
+%1133 = OpCompositeInsert %_arr_float_uint_5 %1132 %1131 2
+OpStore %639 %1133
+%1134 = OpLoad %_arr_float_uint_5 %639
+%1135 = OpLoad %float %633
+%1136 = OpCompositeInsert %_arr_float_uint_5 %1135 %1134 3
+OpStore %640 %1136
+%1137 = OpLoad %_arr_float_uint_5 %640
+%1138 = OpLoad %float %636
+%1139 = OpCompositeInsert %_arr_float_uint_5 %1138 %1137 4
+OpStore %641 %1139
+%1140 = OpLoad %ulong %318
+%1141 = OpLoad %_arr_float_uint_5 %641
+%1142 = OpFunctionCall %ulong %1 %1140 %1141
+OpStore %319 %1142
+%1143 = OpLoad %_arr_float_uint_5 %300
+%1144 = OpCompositeExtract %float %1143 0
+OpStore %642 %1144
+%1145 = OpLoad %_arr_float_uint_5 %306
+%1146 = OpCompositeExtract %float %1145 0
+OpStore %643 %1146
+%1147 = OpLoad %float %642
+%1148 = OpLoad %float %643
+%1149 = OpFDiv %float %1147 %1148
+OpStore %644 %1149
+%1150 = OpLoad %_arr_float_uint_5 %300
+%1151 = OpCompositeExtract %float %1150 1
+OpStore %645 %1151
+%1152 = OpLoad %_arr_float_uint_5 %306
+%1153 = OpCompositeExtract %float %1152 1
+OpStore %646 %1153
+%1154 = OpLoad %float %645
+%1155 = OpLoad %float %646
+%1156 = OpFDiv %float %1154 %1155
+OpStore %647 %1156
+%1157 = OpLoad %_arr_float_uint_5 %300
+%1158 = OpCompositeExtract %float %1157 2
+OpStore %648 %1158
+%1159 = OpLoad %_arr_float_uint_5 %306
+%1160 = OpCompositeExtract %float %1159 2
+OpStore %649 %1160
+%1161 = OpLoad %float %648
+%1162 = OpLoad %float %649
+%1163 = OpFDiv %float %1161 %1162
+OpStore %650 %1163
+%1164 = OpLoad %_arr_float_uint_5 %300
+%1165 = OpCompositeExtract %float %1164 3
+OpStore %651 %1165
+%1166 = OpLoad %_arr_float_uint_5 %306
+%1167 = OpCompositeExtract %float %1166 3
+OpStore %652 %1167
+%1168 = OpLoad %float %651
+%1169 = OpLoad %float %652
+%1170 = OpFDiv %float %1168 %1169
+OpStore %653 %1170
+%1171 = OpLoad %_arr_float_uint_5 %300
+%1172 = OpCompositeExtract %float %1171 4
+OpStore %654 %1172
+%1173 = OpLoad %_arr_float_uint_5 %306
+%1174 = OpCompositeExtract %float %1173 4
+OpStore %655 %1174
+%1175 = OpLoad %float %654
+%1176 = OpLoad %float %655
+%1177 = OpFDiv %float %1175 %1176
+OpStore %656 %1177
+%1178 = OpLoad %_arr_float_uint_5 %300
+%1179 = OpLoad %float %644
+%1180 = OpCompositeInsert %_arr_float_uint_5 %1179 %1178 0
+OpStore %657 %1180
+%1181 = OpLoad %_arr_float_uint_5 %657
+%1182 = OpLoad %float %647
+%1183 = OpCompositeInsert %_arr_float_uint_5 %1182 %1181 1
+OpStore %658 %1183
+%1184 = OpLoad %_arr_float_uint_5 %658
+%1185 = OpLoad %float %650
+%1186 = OpCompositeInsert %_arr_float_uint_5 %1185 %1184 2
+OpStore %659 %1186
+%1187 = OpLoad %_arr_float_uint_5 %659
+%1188 = OpLoad %float %653
+%1189 = OpCompositeInsert %_arr_float_uint_5 %1188 %1187 3
+OpStore %660 %1189
+%1190 = OpLoad %_arr_float_uint_5 %660
+%1191 = OpLoad %float %656
+%1192 = OpCompositeInsert %_arr_float_uint_5 %1191 %1190 4
+OpStore %661 %1192
+%1193 = OpLoad %ulong %319
+%1194 = OpLoad %_arr_float_uint_5 %661
+%1195 = OpFunctionCall %ulong %1 %1193 %1194
+OpStore %320 %1195
+%1196 = OpCompositeConstruct %_arr_float_uint_5 %float_0 %float_0 %float_0 %float_0 %float_0
+OpStore %321 %1196
+%1198 = OpLoad %ulong %320
+OpStore %337 %1198
+%1199 = OpLoad %_arr_float_uint_5 %306
+OpStore %338 %1199
+%1200 = OpLoad %_arr_float_uint_5 %321
+OpStore %339 %1200
+OpStore %340 %ulong_0
+OpBranch %259
+%259 = OpLabel
+%1201 = OpLoad %ulong %340
+%1203 = OpULessThan %bool %1201 %ulong_6
+OpStore %322 %1203
+%1204 = OpLoad %bool %322
+OpLoopMerge %261 %284 None
+OpBranchConditional %1204 %260 %261
+%261 = OpLabel
+OpStore %288 %1205
+%1207 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_0
+%1208 = OpLoad %_arr_float_uint_5 %338
+OpStore %1207 %1208
+%1209 = OpLoad %_arr_float_uint_5 %338
+%1210 = OpCompositeExtract %float %1209 0
+OpStore %422 %1210
+%1211 = OpLoad %_arr_float_uint_5 %309
+%1212 = OpCompositeExtract %float %1211 0
+OpStore %423 %1212
+%1213 = OpLoad %float %422
+%1214 = OpLoad %float %423
+%1215 = OpFAdd %float %1213 %1214
+OpStore %424 %1215
+%1216 = OpLoad %_arr_float_uint_5 %338
+%1217 = OpCompositeExtract %float %1216 1
+OpStore %425 %1217
+%1218 = OpLoad %_arr_float_uint_5 %309
+%1219 = OpCompositeExtract %float %1218 1
+OpStore %426 %1219
+%1220 = OpLoad %float %425
+%1221 = OpLoad %float %426
+%1222 = OpFAdd %float %1220 %1221
+OpStore %427 %1222
+%1223 = OpLoad %_arr_float_uint_5 %338
+%1224 = OpCompositeExtract %float %1223 2
+OpStore %428 %1224
+%1225 = OpLoad %_arr_float_uint_5 %309
+%1226 = OpCompositeExtract %float %1225 2
+OpStore %429 %1226
+%1227 = OpLoad %float %428
+%1228 = OpLoad %float %429
+%1229 = OpFAdd %float %1227 %1228
+OpStore %430 %1229
+%1230 = OpLoad %_arr_float_uint_5 %338
+%1231 = OpCompositeExtract %float %1230 3
+OpStore %431 %1231
+%1232 = OpLoad %_arr_float_uint_5 %309
+%1233 = OpCompositeExtract %float %1232 3
+OpStore %432 %1233
+%1234 = OpLoad %float %431
+%1235 = OpLoad %float %432
+%1236 = OpFAdd %float %1234 %1235
+OpStore %433 %1236
+%1237 = OpLoad %_arr_float_uint_5 %338
+%1238 = OpCompositeExtract %float %1237 4
+OpStore %434 %1238
+%1239 = OpLoad %_arr_float_uint_5 %309
+%1240 = OpCompositeExtract %float %1239 4
+OpStore %435 %1240
+%1241 = OpLoad %float %434
+%1242 = OpLoad %float %435
+%1243 = OpFAdd %float %1241 %1242
+OpStore %436 %1243
+%1244 = OpLoad %_arr_float_uint_5 %338
+%1245 = OpLoad %float %424
+%1246 = OpCompositeInsert %_arr_float_uint_5 %1245 %1244 0
+OpStore %437 %1246
+%1247 = OpLoad %_arr_float_uint_5 %437
+%1248 = OpLoad %float %427
+%1249 = OpCompositeInsert %_arr_float_uint_5 %1248 %1247 1
+OpStore %438 %1249
+%1250 = OpLoad %_arr_float_uint_5 %438
+%1251 = OpLoad %float %430
+%1252 = OpCompositeInsert %_arr_float_uint_5 %1251 %1250 2
+OpStore %439 %1252
+%1253 = OpLoad %_arr_float_uint_5 %439
+%1254 = OpLoad %float %433
+%1255 = OpCompositeInsert %_arr_float_uint_5 %1254 %1253 3
+OpStore %440 %1255
+%1256 = OpLoad %_arr_float_uint_5 %440
+%1257 = OpLoad %float %436
+%1258 = OpCompositeInsert %_arr_float_uint_5 %1257 %1256 4
+OpStore %441 %1258
+%1260 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_1
+%1261 = OpLoad %_arr_float_uint_5 %441
+OpStore %1260 %1261
+%1262 = OpLoad %_arr_float_uint_5 %338
+%1263 = OpCompositeExtract %float %1262 0
+OpStore %442 %1263
+%1264 = OpLoad %_arr_float_uint_5 %300
+%1265 = OpCompositeExtract %float %1264 0
+OpStore %443 %1265
+%1266 = OpLoad %float %442
+%1267 = OpLoad %float %443
+%1268 = OpFMul %float %1266 %1267
+OpStore %444 %1268
+%1269 = OpLoad %_arr_float_uint_5 %338
+%1270 = OpCompositeExtract %float %1269 1
+OpStore %445 %1270
+%1271 = OpLoad %_arr_float_uint_5 %300
+%1272 = OpCompositeExtract %float %1271 1
+OpStore %446 %1272
+%1273 = OpLoad %float %445
+%1274 = OpLoad %float %446
+%1275 = OpFMul %float %1273 %1274
+OpStore %447 %1275
+%1276 = OpLoad %_arr_float_uint_5 %338
+%1277 = OpCompositeExtract %float %1276 2
+OpStore %448 %1277
+%1278 = OpLoad %_arr_float_uint_5 %300
+%1279 = OpCompositeExtract %float %1278 2
+OpStore %449 %1279
+%1280 = OpLoad %float %448
+%1281 = OpLoad %float %449
+%1282 = OpFMul %float %1280 %1281
+OpStore %450 %1282
+%1283 = OpLoad %_arr_float_uint_5 %338
+%1284 = OpCompositeExtract %float %1283 3
+OpStore %451 %1284
+%1285 = OpLoad %_arr_float_uint_5 %300
+%1286 = OpCompositeExtract %float %1285 3
+OpStore %452 %1286
+%1287 = OpLoad %float %451
+%1288 = OpLoad %float %452
+%1289 = OpFMul %float %1287 %1288
+OpStore %453 %1289
+%1290 = OpLoad %_arr_float_uint_5 %338
+%1291 = OpCompositeExtract %float %1290 4
+OpStore %454 %1291
+%1292 = OpLoad %_arr_float_uint_5 %300
+%1293 = OpCompositeExtract %float %1292 4
+OpStore %455 %1293
+%1294 = OpLoad %float %454
+%1295 = OpLoad %float %455
+%1296 = OpFMul %float %1294 %1295
+OpStore %456 %1296
+%1297 = OpLoad %_arr_float_uint_5 %338
+%1298 = OpLoad %float %444
+%1299 = OpCompositeInsert %_arr_float_uint_5 %1298 %1297 0
+OpStore %457 %1299
+%1300 = OpLoad %_arr_float_uint_5 %457
+%1301 = OpLoad %float %447
+%1302 = OpCompositeInsert %_arr_float_uint_5 %1301 %1300 1
+OpStore %458 %1302
+%1303 = OpLoad %_arr_float_uint_5 %458
+%1304 = OpLoad %float %450
+%1305 = OpCompositeInsert %_arr_float_uint_5 %1304 %1303 2
+OpStore %459 %1305
+%1306 = OpLoad %_arr_float_uint_5 %459
+%1307 = OpLoad %float %453
+%1308 = OpCompositeInsert %_arr_float_uint_5 %1307 %1306 3
+OpStore %460 %1308
+%1309 = OpLoad %_arr_float_uint_5 %460
+%1310 = OpLoad %float %456
+%1311 = OpCompositeInsert %_arr_float_uint_5 %1310 %1309 4
+OpStore %461 %1311
+%1313 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_2
+%1314 = OpLoad %_arr_float_uint_5 %461
+OpStore %1313 %1314
+%1316 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_3
+%1317 = OpLoad %_arr_float_uint_5 %339
+OpStore %1316 %1317
+%1318 = OpLoad %_arr_float_uint_5 %309
+%1319 = OpCompositeExtract %float %1318 0
+OpStore %462 %1319
+%1320 = OpLoad %_arr_float_uint_5 %338
+%1321 = OpCompositeExtract %float %1320 0
+OpStore %463 %1321
+%1322 = OpLoad %float %462
+%1323 = OpLoad %float %463
+%1324 = OpFSub %float %1322 %1323
+OpStore %464 %1324
+%1325 = OpLoad %_arr_float_uint_5 %309
+%1326 = OpCompositeExtract %float %1325 1
+OpStore %465 %1326
+%1327 = OpLoad %_arr_float_uint_5 %338
+%1328 = OpCompositeExtract %float %1327 1
+OpStore %466 %1328
+%1329 = OpLoad %float %465
+%1330 = OpLoad %float %466
+%1331 = OpFSub %float %1329 %1330
+OpStore %467 %1331
+%1332 = OpLoad %_arr_float_uint_5 %309
+%1333 = OpCompositeExtract %float %1332 2
+OpStore %468 %1333
+%1334 = OpLoad %_arr_float_uint_5 %338
+%1335 = OpCompositeExtract %float %1334 2
+OpStore %469 %1335
+%1336 = OpLoad %float %468
+%1337 = OpLoad %float %469
+%1338 = OpFSub %float %1336 %1337
+OpStore %470 %1338
+%1339 = OpLoad %_arr_float_uint_5 %309
+%1340 = OpCompositeExtract %float %1339 3
+OpStore %471 %1340
+%1341 = OpLoad %_arr_float_uint_5 %338
+%1342 = OpCompositeExtract %float %1341 3
+OpStore %472 %1342
+%1343 = OpLoad %float %471
+%1344 = OpLoad %float %472
+%1345 = OpFSub %float %1343 %1344
+OpStore %473 %1345
+%1346 = OpLoad %_arr_float_uint_5 %309
+%1347 = OpCompositeExtract %float %1346 4
+OpStore %474 %1347
+%1348 = OpLoad %_arr_float_uint_5 %338
+%1349 = OpCompositeExtract %float %1348 4
+OpStore %475 %1349
+%1350 = OpLoad %float %474
+%1351 = OpLoad %float %475
+%1352 = OpFSub %float %1350 %1351
+OpStore %476 %1352
+%1353 = OpLoad %_arr_float_uint_5 %309
+%1354 = OpLoad %float %464
+%1355 = OpCompositeInsert %_arr_float_uint_5 %1354 %1353 0
+OpStore %477 %1355
+%1356 = OpLoad %_arr_float_uint_5 %477
+%1357 = OpLoad %float %467
+%1358 = OpCompositeInsert %_arr_float_uint_5 %1357 %1356 1
+OpStore %478 %1358
+%1359 = OpLoad %_arr_float_uint_5 %478
+%1360 = OpLoad %float %470
+%1361 = OpCompositeInsert %_arr_float_uint_5 %1360 %1359 2
+OpStore %479 %1361
+%1362 = OpLoad %_arr_float_uint_5 %479
+%1363 = OpLoad %float %473
+%1364 = OpCompositeInsert %_arr_float_uint_5 %1363 %1362 3
+OpStore %480 %1364
+%1365 = OpLoad %_arr_float_uint_5 %480
+%1366 = OpLoad %float %476
+%1367 = OpCompositeInsert %_arr_float_uint_5 %1366 %1365 4
+OpStore %481 %1367
+%1369 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_4
+%1370 = OpLoad %_arr_float_uint_5 %481
+OpStore %1369 %1370
+%1371 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_5
+%1372 = OpLoad %_arr_float_uint_5 %309
+OpStore %1371 %1372
+%1373 = OpLoad %ulong %337
+OpStore %336 %1373
+OpStore %341 %ulong_0
+OpBranch %262
+%262 = OpLabel
+%1374 = OpLoad %ulong %341
+%1375 = OpULessThan %bool %1374 %ulong_6
+OpStore %327 %1375
+%1376 = OpLoad %bool %327
+OpLoopMerge %264 %283 None
+OpBranchConditional %1376 %263 %264
+%264 = OpLabel
+OpStore %291 %1377
+%1378 = OpAccessChain %_ptr_Function_uint %291 %uint_0
+OpStore %1378 %uint_4294967295
+%1380 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %uint_2
+%1381 = OpLoad %_arr_float_uint_5 %1380
+OpStore %331 %1381
+%1382 = OpAccessChain %_ptr_Function__arr_float_uint_5 %291 %uint_1
+%1383 = OpLoad %_arr_float_uint_5 %331
+OpStore %1382 %1383
+%1384 = OpAccessChain %_ptr_Function_uint %291 %uint_2
+OpStore %1384 %uint_305419896
+%1386 = OpLoad %uint %1378
+OpStore %332 %1386
+OpBranch %267
+%267 = OpLabel
+%1387 = OpLoad %uint %332
+%1388 = OpUConvert %ulong %1387
+OpStore %342 %1388
+OpBranch %269
+%269 = OpLabel
+%1389 = OpLoad %ulong %336
+OpStore %350 %1389
+OpStore %351 %ulong_0
+OpBranch %270
+%270 = OpLabel
+%1390 = OpLoad %ulong %351
+%1391 = OpULessThan %bool %1390 %ulong_8
+OpStore %343 %1391
+%1392 = OpLoad %bool %343
+OpLoopMerge %272 %282 None
+OpBranchConditional %1392 %271 %272
+%272 = OpLabel
+OpBranch %273
+%273 = OpLabel
+OpBranch %268
+%268 = OpLabel
+%1393 = OpAccessChain %_ptr_Function__arr_float_uint_5 %291 %uint_1
+%1394 = OpLoad %_arr_float_uint_5 %1393
+OpStore %333 %1394
+%1395 = OpLoad %ulong %350
+%1396 = OpLoad %_arr_float_uint_5 %333
+%1397 = OpFunctionCall %ulong %1 %1395 %1396
+OpStore %334 %1397
+%1398 = OpAccessChain %_ptr_Function_uint %291 %uint_2
+%1399 = OpLoad %uint %1398
+OpStore %335 %1399
+OpBranch %274
+%274 = OpLabel
+%1400 = OpLoad %uint %335
+%1401 = OpUConvert %ulong %1400
+OpStore %352 %1401
+OpBranch %276
+%276 = OpLabel
+%1402 = OpLoad %ulong %334
+OpStore %360 %1402
+OpStore %361 %ulong_0
+OpBranch %277
+%277 = OpLabel
+%1403 = OpLoad %ulong %361
+%1404 = OpULessThan %bool %1403 %ulong_8
+OpStore %353 %1404
+%1405 = OpLoad %bool %353
+OpLoopMerge %279 %281 None
+OpBranchConditional %1405 %278 %279
+%279 = OpLabel
+OpBranch %280
+%280 = OpLabel
+OpBranch %275
+%275 = OpLabel
+%1406 = OpLoad %ulong %360
+OpReturnValue %1406
+%278 = OpLabel
+%1407 = OpLoad %ulong %361
+%1408 = OpIMul %ulong %1407 %ulong_8
+OpStore %354 %1408
+%1409 = OpLoad %ulong %352
+%1410 = OpLoad %ulong %354
+%1411 = OpShiftRightLogical %ulong %1409 %1410
+OpStore %355 %1411
+%1412 = OpLoad %ulong %355
+%1413 = OpBitwiseAnd %ulong %1412 %ulong_255
+OpStore %356 %1413
+%1414 = OpLoad %ulong %360
+%1415 = OpLoad %ulong %356
+%1416 = OpBitwiseXor %ulong %1414 %1415
+OpStore %357 %1416
+%1417 = OpLoad %ulong %357
+%1418 = OpIMul %ulong %1417 %ulong_1099511628211
+OpStore %358 %1418
+%1419 = OpLoad %ulong %361
+%1420 = OpIAdd %ulong %1419 %ulong_1
+OpStore %359 %1420
+%1421 = OpLoad %ulong %358
+OpStore %360 %1421
+%1422 = OpLoad %ulong %359
+OpStore %361 %1422
+OpBranch %281
+%271 = OpLabel
+%1423 = OpLoad %ulong %351
+%1424 = OpIMul %ulong %1423 %ulong_8
+OpStore %344 %1424
+%1425 = OpLoad %ulong %342
+%1426 = OpLoad %ulong %344
+%1427 = OpShiftRightLogical %ulong %1425 %1426
+OpStore %345 %1427
+%1428 = OpLoad %ulong %345
+%1429 = OpBitwiseAnd %ulong %1428 %ulong_255
+OpStore %346 %1429
+%1430 = OpLoad %ulong %350
+%1431 = OpLoad %ulong %346
+%1432 = OpBitwiseXor %ulong %1430 %1431
+OpStore %347 %1432
+%1433 = OpLoad %ulong %347
+%1434 = OpIMul %ulong %1433 %ulong_1099511628211
+OpStore %348 %1434
+%1435 = OpLoad %ulong %351
+%1436 = OpIAdd %ulong %1435 %ulong_1
+OpStore %349 %1436
+%1437 = OpLoad %ulong %348
+OpStore %350 %1437
+%1438 = OpLoad %ulong %349
+OpStore %351 %1438
+OpBranch %282
+%263 = OpLabel
+%1439 = OpLoad %ulong %341
+%1440 = OpAccessChain %_ptr_Function__arr_float_uint_5 %288 %1439
+%1441 = OpLoad %_arr_float_uint_5 %1440
+OpStore %328 %1441
+%1442 = OpLoad %ulong %336
+%1443 = OpLoad %_arr_float_uint_5 %328
+%1444 = OpFunctionCall %ulong %1 %1442 %1443
+OpStore %329 %1444
+%1445 = OpLoad %ulong %341
+%1446 = OpIAdd %ulong %1445 %ulong_1
+OpStore %330 %1446
+%1447 = OpLoad %ulong %329
+OpStore %336 %1447
+%1448 = OpLoad %ulong %330
+OpStore %341 %1448
+OpBranch %283
+%260 = OpLabel
+%1449 = OpLoad %_arr_float_uint_5 %338
+%1450 = OpCompositeExtract %float %1449 0
+OpStore %362 %1450
+%1451 = OpLoad %_arr_float_uint_5 %300
+%1452 = OpCompositeExtract %float %1451 0
+OpStore %363 %1452
+%1453 = OpLoad %float %362
+%1454 = OpLoad %float %363
+%1455 = OpFMul %float %1453 %1454
+OpStore %364 %1455
+%1456 = OpLoad %_arr_float_uint_5 %338
+%1457 = OpCompositeExtract %float %1456 1
+OpStore %365 %1457
+%1458 = OpLoad %_arr_float_uint_5 %300
+%1459 = OpCompositeExtract %float %1458 1
+OpStore %366 %1459
+%1460 = OpLoad %float %365
+%1461 = OpLoad %float %366
+%1462 = OpFMul %float %1460 %1461
+OpStore %367 %1462
+%1463 = OpLoad %_arr_float_uint_5 %338
+%1464 = OpCompositeExtract %float %1463 2
+OpStore %368 %1464
+%1465 = OpLoad %_arr_float_uint_5 %300
+%1466 = OpCompositeExtract %float %1465 2
+OpStore %369 %1466
+%1467 = OpLoad %float %368
+%1468 = OpLoad %float %369
+%1469 = OpFMul %float %1467 %1468
+OpStore %370 %1469
+%1470 = OpLoad %_arr_float_uint_5 %338
+%1471 = OpCompositeExtract %float %1470 3
+OpStore %371 %1471
+%1472 = OpLoad %_arr_float_uint_5 %300
+%1473 = OpCompositeExtract %float %1472 3
+OpStore %372 %1473
+%1474 = OpLoad %float %371
+%1475 = OpLoad %float %372
+%1476 = OpFMul %float %1474 %1475
+OpStore %373 %1476
+%1477 = OpLoad %_arr_float_uint_5 %338
+%1478 = OpCompositeExtract %float %1477 4
+OpStore %374 %1478
+%1479 = OpLoad %_arr_float_uint_5 %300
+%1480 = OpCompositeExtract %float %1479 4
+OpStore %375 %1480
+%1481 = OpLoad %float %374
+%1482 = OpLoad %float %375
+%1483 = OpFMul %float %1481 %1482
+OpStore %376 %1483
+%1484 = OpLoad %_arr_float_uint_5 %338
+%1485 = OpLoad %float %364
+%1486 = OpCompositeInsert %_arr_float_uint_5 %1485 %1484 0
+OpStore %377 %1486
+%1487 = OpLoad %_arr_float_uint_5 %377
+%1488 = OpLoad %float %367
+%1489 = OpCompositeInsert %_arr_float_uint_5 %1488 %1487 1
+OpStore %378 %1489
+%1490 = OpLoad %_arr_float_uint_5 %378
+%1491 = OpLoad %float %370
+%1492 = OpCompositeInsert %_arr_float_uint_5 %1491 %1490 2
+OpStore %379 %1492
+%1493 = OpLoad %_arr_float_uint_5 %379
+%1494 = OpLoad %float %373
+%1495 = OpCompositeInsert %_arr_float_uint_5 %1494 %1493 3
+OpStore %380 %1495
+%1496 = OpLoad %_arr_float_uint_5 %380
+%1497 = OpLoad %float %376
+%1498 = OpCompositeInsert %_arr_float_uint_5 %1497 %1496 4
+OpStore %381 %1498
+%1499 = OpLoad %ulong %337
+%1500 = OpLoad %_arr_float_uint_5 %381
+%1501 = OpFunctionCall %ulong %1 %1499 %1500
+OpStore %323 %1501
+%1502 = OpLoad %_arr_float_uint_5 %339
+%1503 = OpCompositeExtract %float %1502 0
+OpStore %382 %1503
+%1504 = OpLoad %_arr_float_uint_5 %381
+%1505 = OpCompositeExtract %float %1504 0
+OpStore %383 %1505
+%1506 = OpLoad %float %382
+%1507 = OpLoad %float %383
+%1508 = OpFAdd %float %1506 %1507
+OpStore %384 %1508
+%1509 = OpLoad %_arr_float_uint_5 %339
+%1510 = OpCompositeExtract %float %1509 1
+OpStore %385 %1510
+%1511 = OpLoad %_arr_float_uint_5 %381
+%1512 = OpCompositeExtract %float %1511 1
+OpStore %386 %1512
+%1513 = OpLoad %float %385
+%1514 = OpLoad %float %386
+%1515 = OpFAdd %float %1513 %1514
+OpStore %387 %1515
+%1516 = OpLoad %_arr_float_uint_5 %339
+%1517 = OpCompositeExtract %float %1516 2
+OpStore %388 %1517
+%1518 = OpLoad %_arr_float_uint_5 %381
+%1519 = OpCompositeExtract %float %1518 2
+OpStore %389 %1519
+%1520 = OpLoad %float %388
+%1521 = OpLoad %float %389
+%1522 = OpFAdd %float %1520 %1521
+OpStore %390 %1522
+%1523 = OpLoad %_arr_float_uint_5 %339
+%1524 = OpCompositeExtract %float %1523 3
+OpStore %391 %1524
+%1525 = OpLoad %_arr_float_uint_5 %381
+%1526 = OpCompositeExtract %float %1525 3
+OpStore %392 %1526
+%1527 = OpLoad %float %391
+%1528 = OpLoad %float %392
+%1529 = OpFAdd %float %1527 %1528
+OpStore %393 %1529
+%1530 = OpLoad %_arr_float_uint_5 %339
+%1531 = OpCompositeExtract %float %1530 4
+OpStore %394 %1531
+%1532 = OpLoad %_arr_float_uint_5 %381
+%1533 = OpCompositeExtract %float %1532 4
+OpStore %395 %1533
+%1534 = OpLoad %float %394
+%1535 = OpLoad %float %395
+%1536 = OpFAdd %float %1534 %1535
+OpStore %396 %1536
+%1537 = OpLoad %_arr_float_uint_5 %339
+%1538 = OpLoad %float %384
+%1539 = OpCompositeInsert %_arr_float_uint_5 %1538 %1537 0
+OpStore %397 %1539
+%1540 = OpLoad %_arr_float_uint_5 %397
+%1541 = OpLoad %float %387
+%1542 = OpCompositeInsert %_arr_float_uint_5 %1541 %1540 1
+OpStore %398 %1542
+%1543 = OpLoad %_arr_float_uint_5 %398
+%1544 = OpLoad %float %390
+%1545 = OpCompositeInsert %_arr_float_uint_5 %1544 %1543 2
+OpStore %399 %1545
+%1546 = OpLoad %_arr_float_uint_5 %399
+%1547 = OpLoad %float %393
+%1548 = OpCompositeInsert %_arr_float_uint_5 %1547 %1546 3
+OpStore %400 %1548
+%1549 = OpLoad %_arr_float_uint_5 %400
+%1550 = OpLoad %float %396
+%1551 = OpCompositeInsert %_arr_float_uint_5 %1550 %1549 4
+OpStore %401 %1551
+%1552 = OpLoad %ulong %323
+%1553 = OpLoad %_arr_float_uint_5 %401
+%1554 = OpFunctionCall %ulong %1 %1552 %1553
+OpStore %324 %1554
+%1555 = OpLoad %_arr_float_uint_5 %338
+%1556 = OpCompositeExtract %float %1555 0
+OpStore %402 %1556
+%1557 = OpLoad %_arr_float_uint_5 %309
+%1558 = OpCompositeExtract %float %1557 0
+OpStore %403 %1558
+%1559 = OpLoad %float %402
+%1560 = OpLoad %float %403
+%1561 = OpFSub %float %1559 %1560
+OpStore %404 %1561
+%1562 = OpLoad %_arr_float_uint_5 %338
+%1563 = OpCompositeExtract %float %1562 1
+OpStore %405 %1563
+%1564 = OpLoad %_arr_float_uint_5 %309
+%1565 = OpCompositeExtract %float %1564 1
+OpStore %406 %1565
+%1566 = OpLoad %float %405
+%1567 = OpLoad %float %406
+%1568 = OpFSub %float %1566 %1567
+OpStore %407 %1568
+%1569 = OpLoad %_arr_float_uint_5 %338
+%1570 = OpCompositeExtract %float %1569 2
+OpStore %408 %1570
+%1571 = OpLoad %_arr_float_uint_5 %309
+%1572 = OpCompositeExtract %float %1571 2
+OpStore %409 %1572
+%1573 = OpLoad %float %408
+%1574 = OpLoad %float %409
+%1575 = OpFSub %float %1573 %1574
+OpStore %410 %1575
+%1576 = OpLoad %_arr_float_uint_5 %338
+%1577 = OpCompositeExtract %float %1576 3
+OpStore %411 %1577
+%1578 = OpLoad %_arr_float_uint_5 %309
+%1579 = OpCompositeExtract %float %1578 3
+OpStore %412 %1579
+%1580 = OpLoad %float %411
+%1581 = OpLoad %float %412
+%1582 = OpFSub %float %1580 %1581
+OpStore %413 %1582
+%1583 = OpLoad %_arr_float_uint_5 %338
+%1584 = OpCompositeExtract %float %1583 4
+OpStore %414 %1584
+%1585 = OpLoad %_arr_float_uint_5 %309
+%1586 = OpCompositeExtract %float %1585 4
+OpStore %415 %1586
+%1587 = OpLoad %float %414
+%1588 = OpLoad %float %415
+%1589 = OpFSub %float %1587 %1588
+OpStore %416 %1589
+%1590 = OpLoad %_arr_float_uint_5 %338
+%1591 = OpLoad %float %404
+%1592 = OpCompositeInsert %_arr_float_uint_5 %1591 %1590 0
+OpStore %417 %1592
+%1593 = OpLoad %_arr_float_uint_5 %417
+%1594 = OpLoad %float %407
+%1595 = OpCompositeInsert %_arr_float_uint_5 %1594 %1593 1
+OpStore %418 %1595
+%1596 = OpLoad %_arr_float_uint_5 %418
+%1597 = OpLoad %float %410
+%1598 = OpCompositeInsert %_arr_float_uint_5 %1597 %1596 2
+OpStore %419 %1598
+%1599 = OpLoad %_arr_float_uint_5 %419
+%1600 = OpLoad %float %413
+%1601 = OpCompositeInsert %_arr_float_uint_5 %1600 %1599 3
+OpStore %420 %1601
+%1602 = OpLoad %_arr_float_uint_5 %420
+%1603 = OpLoad %float %416
+%1604 = OpCompositeInsert %_arr_float_uint_5 %1603 %1602 4
+OpStore %421 %1604
+%1605 = OpLoad %ulong %324
+%1606 = OpLoad %_arr_float_uint_5 %421
+%1607 = OpFunctionCall %ulong %1 %1605 %1606
+OpStore %325 %1607
+%1608 = OpLoad %ulong %340
+%1609 = OpIAdd %ulong %1608 %ulong_1
+OpStore %326 %1609
+%1610 = OpLoad %ulong %325
+OpStore %337 %1610
+%1611 = OpLoad %_arr_float_uint_5 %421
+OpStore %338 %1611
+%1612 = OpLoad %_arr_float_uint_5 %401
+OpStore %339 %1612
+%1613 = OpLoad %ulong %326
+OpStore %340 %1613
+OpBranch %284
+%281 = OpLabel
+OpBranch %277
+%282 = OpLabel
+OpBranch %270
+%283 = OpLabel
+OpBranch %262
+%284 = OpLabel
+OpBranch %259
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f32x8.dis
+++ b/test/golden/spirv/vec/vec_f32x8.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 2873
+; Bound: 2295
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,19 +14,24 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x8.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_8 = OpConstant %uint 8
 %_arr_float_uint_8 = OpTypeArray %float %uint_8
-%11 = OpTypeFunction %ulong %ulong %_arr_float_uint_8
+%8 = OpTypeFunction %ulong %ulong %_arr_float_uint_8
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
 %_ptr_Function_float = OpTypePointer Function %float
-%77 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%394 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr__arr_float_uint_8_uint_4 = OpTypeArray %_arr_float_uint_8 %uint_4
 %_ptr_Function__arr__arr_float_uint_8_uint_4 = OpTypePointer Function %_arr__arr_float_uint_8_uint_4
-%_struct_125 = OpTypeStruct %uint %_arr_float_uint_8 %uint
-%_ptr_Function__struct_125 = OpTypePointer Function %_struct_125
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
+%_struct_427 = OpTypeStruct %uint %_arr_float_uint_8 %uint
+%_ptr_Function__struct_427 = OpTypePointer Function %_struct_427
 %float_2_25 = OpConstant %float 2.25
 %float_0_5 = OpConstant %float 0.5
 %float_8_125 = OpConstant %float 8.125
@@ -50,490 +55,662 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f32x8.checksum" Export
 %float_243 = OpConstant %float 243
 %float_729 = OpConstant %float 729
 %float_2187 = OpConstant %float 2187
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%2122 = OpConstantNull %_arr__arr_float_uint_8_uint_4
+%1790 = OpConstantNull %_arr__arr_float_uint_8_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%2300 = OpConstantNull %_struct_125
+%1968 = OpConstantNull %_struct_427
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%2774 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%2777 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%2825 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_float_uint_8
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_float Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_float Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_float Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_float Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_float Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_float Function
-%35 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%36 = OpLoad %_arr_float_uint_8 %18
-%37 = OpCompositeExtract %float %36 0
-OpStore %20 %37
-%38 = OpLoad %ulong %16
-%39 = OpLoad %float %20
-%40 = OpFunctionCall %ulong %5 %38 %39
-OpStore %21 %40
-%41 = OpLoad %_arr_float_uint_8 %18
-%42 = OpCompositeExtract %float %41 1
-OpStore %22 %42
-%43 = OpLoad %ulong %21
-%44 = OpLoad %float %22
-%45 = OpFunctionCall %ulong %5 %43 %44
-OpStore %23 %45
-%46 = OpLoad %_arr_float_uint_8 %18
-%47 = OpCompositeExtract %float %46 2
-OpStore %24 %47
-%48 = OpLoad %ulong %23
-%49 = OpLoad %float %24
-%50 = OpFunctionCall %ulong %5 %48 %49
-OpStore %25 %50
-%51 = OpLoad %_arr_float_uint_8 %18
-%52 = OpCompositeExtract %float %51 3
-OpStore %26 %52
-%53 = OpLoad %ulong %25
-%54 = OpLoad %float %26
-%55 = OpFunctionCall %ulong %5 %53 %54
-OpStore %27 %55
-%56 = OpLoad %_arr_float_uint_8 %18
-%57 = OpCompositeExtract %float %56 4
-OpStore %28 %57
-%58 = OpLoad %ulong %27
-%59 = OpLoad %float %28
-%60 = OpFunctionCall %ulong %5 %58 %59
-OpStore %29 %60
-%61 = OpLoad %_arr_float_uint_8 %18
-%62 = OpCompositeExtract %float %61 5
-OpStore %30 %62
-%63 = OpLoad %ulong %29
-%64 = OpLoad %float %30
-%65 = OpFunctionCall %ulong %5 %63 %64
-OpStore %31 %65
-%66 = OpLoad %_arr_float_uint_8 %18
-%67 = OpCompositeExtract %float %66 6
-OpStore %32 %67
-%68 = OpLoad %ulong %31
-%69 = OpLoad %float %32
-%70 = OpFunctionCall %ulong %5 %68 %69
-OpStore %33 %70
-%71 = OpLoad %_arr_float_uint_8 %18
-%72 = OpCompositeExtract %float %71 7
-OpStore %34 %72
-%73 = OpLoad %ulong %33
-%74 = OpLoad %float %34
-%75 = OpFunctionCall %ulong %5 %73 %74
-OpStore %35 %75
-%76 = OpLoad %ulong %35
-OpReturnValue %76
-OpFunctionEnd
-%2 = OpFunction %ulong None %77
-%78 = OpFunctionParameter %ulong
-%79 = OpLabel
-%124 = OpVariable %_ptr_Function__arr__arr_float_uint_8_uint_4 Function
-%127 = OpVariable %_ptr_Function__struct_125 Function
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %_arr_float_uint_8
+%11 = OpLabel
+%78 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%82 = OpVariable %_ptr_Function_float Function
+%83 = OpVariable %_ptr_Function_float Function
+%84 = OpVariable %_ptr_Function_float Function
+%85 = OpVariable %_ptr_Function_float Function
+%86 = OpVariable %_ptr_Function_float Function
+%87 = OpVariable %_ptr_Function_float Function
+%88 = OpVariable %_ptr_Function_float Function
+%89 = OpVariable %_ptr_Function_float Function
+%91 = OpVariable %_ptr_Function_uint Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_bool Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_ulong Function
+%103 = OpVariable %_ptr_Function_uint Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_bool Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_uint Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_bool Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_bool Function
 %128 = OpVariable %_ptr_Function_ulong Function
 %129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_float Function
-%131 = OpVariable %_ptr_Function_float Function
-%132 = OpVariable %_ptr_Function_float Function
-%133 = OpVariable %_ptr_Function_float Function
-%134 = OpVariable %_ptr_Function_float Function
-%135 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%136 = OpVariable %_ptr_Function_float Function
-%137 = OpVariable %_ptr_Function_float Function
-%138 = OpVariable %_ptr_Function_float Function
-%139 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%140 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%141 = OpVariable %_ptr_Function_float Function
-%142 = OpVariable %_ptr_Function_float Function
-%143 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%144 = OpVariable %_ptr_Function_float Function
-%145 = OpVariable %_ptr_Function_float Function
-%146 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%147 = OpVariable %_ptr_Function_float Function
-%148 = OpVariable %_ptr_Function_float Function
-%149 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%150 = OpVariable %_ptr_Function_float Function
-%151 = OpVariable %_ptr_Function_float Function
-%152 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%153 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%155 = OpVariable %_ptr_Function_bool Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_ulong Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_bool Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_uint Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_bool Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
 %156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_bool Function
-%158 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_uint Function
 %159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%162 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_bool Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_ulong Function
 %163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%165 = OpVariable %_ptr_Function_uint Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%170 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%171 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_uint Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_bool Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_float Function
+%173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_float Function
+%175 = OpVariable %_ptr_Function_ulong Function
 %176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_float Function
+%177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_float Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_float Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_float Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_float Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_float Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_float Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_float Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_float Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_float Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_float Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_float Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_float Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_float Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_float Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_float Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_float Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_float Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_float Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_float Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_float Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_float Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_float Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_float Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_float Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_float Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_float Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_float Function
-%242 = OpVariable %_ptr_Function_ulong Function
-%243 = OpVariable %_ptr_Function_float Function
-%244 = OpVariable %_ptr_Function_ulong Function
-%245 = OpVariable %_ptr_Function_float Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_float Function
-%248 = OpVariable %_ptr_Function_ulong Function
-%249 = OpVariable %_ptr_Function_float Function
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_float Function
-%252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_float Function
-%254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_float Function
-%256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_float Function
-%258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_float Function
-%260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_float Function
-%262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_float Function
-%264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_float Function
-%266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_float Function
-%268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_float Function
-%270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_float Function
-%272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_float Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_float Function
-%276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_float Function
-%278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_float Function
-%280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_float Function
-%282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_float Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_float Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_float Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_float Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_float Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_float Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_float Function
-%296 = OpVariable %_ptr_Function_ulong Function
-%297 = OpVariable %_ptr_Function_float Function
-%298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_float Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_float Function
-%302 = OpVariable %_ptr_Function_ulong Function
-%303 = OpVariable %_ptr_Function_float Function
-%304 = OpVariable %_ptr_Function_ulong Function
-%305 = OpVariable %_ptr_Function_float Function
-%306 = OpVariable %_ptr_Function_ulong Function
-%307 = OpVariable %_ptr_Function_float Function
-%308 = OpVariable %_ptr_Function_ulong Function
-%309 = OpVariable %_ptr_Function_float Function
-%310 = OpVariable %_ptr_Function_ulong Function
-%311 = OpVariable %_ptr_Function_float Function
-%312 = OpVariable %_ptr_Function_ulong Function
-%313 = OpVariable %_ptr_Function_float Function
-%314 = OpVariable %_ptr_Function_ulong Function
-%315 = OpVariable %_ptr_Function_float Function
-%316 = OpVariable %_ptr_Function_ulong Function
-%317 = OpVariable %_ptr_Function_float Function
-%318 = OpVariable %_ptr_Function_ulong Function
-%319 = OpVariable %_ptr_Function_float Function
-%320 = OpVariable %_ptr_Function_ulong Function
-%321 = OpVariable %_ptr_Function_float Function
-%322 = OpVariable %_ptr_Function_ulong Function
-%323 = OpVariable %_ptr_Function_float Function
-%324 = OpVariable %_ptr_Function_ulong Function
-%325 = OpVariable %_ptr_Function_float Function
-%326 = OpVariable %_ptr_Function_ulong Function
-%327 = OpVariable %_ptr_Function_float Function
-%328 = OpVariable %_ptr_Function_ulong Function
-%329 = OpVariable %_ptr_Function_float Function
-%330 = OpVariable %_ptr_Function_ulong Function
-%331 = OpVariable %_ptr_Function_float Function
-%332 = OpVariable %_ptr_Function_ulong Function
-%333 = OpVariable %_ptr_Function_float Function
-%334 = OpVariable %_ptr_Function_ulong Function
-%335 = OpVariable %_ptr_Function_float Function
-%336 = OpVariable %_ptr_Function_ulong Function
-%337 = OpVariable %_ptr_Function_float Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_float Function
-%340 = OpVariable %_ptr_Function_ulong Function
-%341 = OpVariable %_ptr_Function_float Function
-%342 = OpVariable %_ptr_Function_ulong Function
-%343 = OpVariable %_ptr_Function_float Function
-%344 = OpVariable %_ptr_Function_ulong Function
-%345 = OpVariable %_ptr_Function_float Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_float Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_float Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_float Function
-%358 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_float Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_float Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_float Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_float Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_float Function
-%368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_float Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_float Function
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_float Function
-%374 = OpVariable %_ptr_Function_ulong Function
-%375 = OpVariable %_ptr_Function_float Function
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_float Function
-%378 = OpVariable %_ptr_Function_ulong Function
-%379 = OpVariable %_ptr_Function_float Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_float Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_float Function
-%384 = OpVariable %_ptr_Function_ulong Function
-%385 = OpVariable %_ptr_Function_float Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_float Function
-%388 = OpVariable %_ptr_Function_ulong Function
-%389 = OpVariable %_ptr_Function_float Function
-%390 = OpVariable %_ptr_Function_ulong Function
-%391 = OpVariable %_ptr_Function_float Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_float Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_float Function
-%396 = OpVariable %_ptr_Function_ulong Function
-%397 = OpVariable %_ptr_Function_float Function
-%398 = OpVariable %_ptr_Function_ulong Function
-%399 = OpVariable %_ptr_Function_float Function
-%400 = OpVariable %_ptr_Function_ulong Function
-%401 = OpVariable %_ptr_Function_float Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_float Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_float Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_float Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_float Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_float Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_float Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_float Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_float Function
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_float Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_float Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_float Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_float Function
-%426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_float Function
-%428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_float Function
-%430 = OpVariable %_ptr_Function_float Function
+%179 = OpVariable %_ptr_Function_ulong Function
+OpStore %78 %9
+OpStore %80 %10
+%180 = OpLoad %_arr_float_uint_8 %80
+%181 = OpCompositeExtract %float %180 0
+OpStore %82 %181
+OpBranch %12
+%12 = OpLabel
+%182 = OpLoad %float %82
+%183 = OpBitcast %uint %182
+OpStore %91 %183
+%184 = OpLoad %uint %91
+%185 = OpUConvert %ulong %184
+OpStore %92 %185
+OpBranch %14
+%14 = OpLabel
+%186 = OpLoad %ulong %78
+OpStore %101 %186
+OpStore %102 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%188 = OpLoad %ulong %102
+%190 = OpULessThan %bool %188 %ulong_8
+OpStore %94 %190
+%191 = OpLoad %bool %94
+OpLoopMerge %17 %75 None
+OpBranchConditional %191 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%192 = OpLoad %_arr_float_uint_8 %80
+%193 = OpCompositeExtract %float %192 1
+OpStore %83 %193
+OpBranch %19
+%19 = OpLabel
+%194 = OpLoad %float %83
+%195 = OpBitcast %uint %194
+OpStore %103 %195
+%196 = OpLoad %uint %103
+%197 = OpUConvert %ulong %196
+OpStore %104 %197
+OpBranch %21
+%21 = OpLabel
+%198 = OpLoad %ulong %101
+OpStore %112 %198
+OpStore %113 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%199 = OpLoad %ulong %113
+%200 = OpULessThan %bool %199 %ulong_8
+OpStore %105 %200
+%201 = OpLoad %bool %105
+OpLoopMerge %24 %74 None
+OpBranchConditional %201 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%202 = OpLoad %_arr_float_uint_8 %80
+%203 = OpCompositeExtract %float %202 2
+OpStore %84 %203
+OpBranch %26
+%26 = OpLabel
+%204 = OpLoad %float %84
+%205 = OpBitcast %uint %204
+OpStore %114 %205
+%206 = OpLoad %uint %114
+%207 = OpUConvert %ulong %206
+OpStore %115 %207
+OpBranch %28
+%28 = OpLabel
+%208 = OpLoad %ulong %112
+OpStore %123 %208
+OpStore %124 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%209 = OpLoad %ulong %124
+%210 = OpULessThan %bool %209 %ulong_8
+OpStore %116 %210
+%211 = OpLoad %bool %116
+OpLoopMerge %31 %73 None
+OpBranchConditional %211 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%212 = OpLoad %_arr_float_uint_8 %80
+%213 = OpCompositeExtract %float %212 3
+OpStore %85 %213
+OpBranch %33
+%33 = OpLabel
+%214 = OpLoad %float %85
+%215 = OpBitcast %uint %214
+OpStore %125 %215
+%216 = OpLoad %uint %125
+%217 = OpUConvert %ulong %216
+OpStore %126 %217
+OpBranch %35
+%35 = OpLabel
+%218 = OpLoad %ulong %123
+OpStore %134 %218
+OpStore %135 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%219 = OpLoad %ulong %135
+%220 = OpULessThan %bool %219 %ulong_8
+OpStore %127 %220
+%221 = OpLoad %bool %127
+OpLoopMerge %38 %72 None
+OpBranchConditional %221 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%222 = OpLoad %_arr_float_uint_8 %80
+%223 = OpCompositeExtract %float %222 4
+OpStore %86 %223
+OpBranch %40
+%40 = OpLabel
+%224 = OpLoad %float %86
+%225 = OpBitcast %uint %224
+OpStore %136 %225
+%226 = OpLoad %uint %136
+%227 = OpUConvert %ulong %226
+OpStore %137 %227
+OpBranch %42
+%42 = OpLabel
+%228 = OpLoad %ulong %134
+OpStore %145 %228
+OpStore %146 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%229 = OpLoad %ulong %146
+%230 = OpULessThan %bool %229 %ulong_8
+OpStore %138 %230
+%231 = OpLoad %bool %138
+OpLoopMerge %45 %71 None
+OpBranchConditional %231 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%232 = OpLoad %_arr_float_uint_8 %80
+%233 = OpCompositeExtract %float %232 5
+OpStore %87 %233
+OpBranch %47
+%47 = OpLabel
+%234 = OpLoad %float %87
+%235 = OpBitcast %uint %234
+OpStore %147 %235
+%236 = OpLoad %uint %147
+%237 = OpUConvert %ulong %236
+OpStore %148 %237
+OpBranch %49
+%49 = OpLabel
+%238 = OpLoad %ulong %145
+OpStore %156 %238
+OpStore %157 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%239 = OpLoad %ulong %157
+%240 = OpULessThan %bool %239 %ulong_8
+OpStore %149 %240
+%241 = OpLoad %bool %149
+OpLoopMerge %52 %70 None
+OpBranchConditional %241 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%242 = OpLoad %_arr_float_uint_8 %80
+%243 = OpCompositeExtract %float %242 6
+OpStore %88 %243
+OpBranch %54
+%54 = OpLabel
+%244 = OpLoad %float %88
+%245 = OpBitcast %uint %244
+OpStore %158 %245
+%246 = OpLoad %uint %158
+%247 = OpUConvert %ulong %246
+OpStore %159 %247
+OpBranch %56
+%56 = OpLabel
+%248 = OpLoad %ulong %156
+OpStore %167 %248
+OpStore %168 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%249 = OpLoad %ulong %168
+%250 = OpULessThan %bool %249 %ulong_8
+OpStore %160 %250
+%251 = OpLoad %bool %160
+OpLoopMerge %59 %69 None
+OpBranchConditional %251 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%252 = OpLoad %_arr_float_uint_8 %80
+%253 = OpCompositeExtract %float %252 7
+OpStore %89 %253
+OpBranch %61
+%61 = OpLabel
+%254 = OpLoad %float %89
+%255 = OpBitcast %uint %254
+OpStore %169 %255
+%256 = OpLoad %uint %169
+%257 = OpUConvert %ulong %256
+OpStore %170 %257
+OpBranch %63
+%63 = OpLabel
+%258 = OpLoad %ulong %167
+OpStore %178 %258
+OpStore %179 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%259 = OpLoad %ulong %179
+%260 = OpULessThan %bool %259 %ulong_8
+OpStore %171 %260
+%261 = OpLoad %bool %171
+OpLoopMerge %66 %68 None
+OpBranchConditional %261 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%262 = OpLoad %ulong %178
+OpReturnValue %262
+%65 = OpLabel
+%263 = OpLoad %ulong %179
+%264 = OpIMul %ulong %263 %ulong_8
+OpStore %172 %264
+%265 = OpLoad %ulong %170
+%266 = OpLoad %ulong %172
+%267 = OpShiftRightLogical %ulong %265 %266
+OpStore %173 %267
+%268 = OpLoad %ulong %173
+%270 = OpBitwiseAnd %ulong %268 %ulong_255
+OpStore %174 %270
+%271 = OpLoad %ulong %178
+%272 = OpLoad %ulong %174
+%273 = OpBitwiseXor %ulong %271 %272
+OpStore %175 %273
+%274 = OpLoad %ulong %175
+%276 = OpIMul %ulong %274 %ulong_1099511628211
+OpStore %176 %276
+%277 = OpLoad %ulong %179
+%279 = OpIAdd %ulong %277 %ulong_1
+OpStore %177 %279
+%280 = OpLoad %ulong %176
+OpStore %178 %280
+%281 = OpLoad %ulong %177
+OpStore %179 %281
+OpBranch %68
+%58 = OpLabel
+%282 = OpLoad %ulong %168
+%283 = OpIMul %ulong %282 %ulong_8
+OpStore %161 %283
+%284 = OpLoad %ulong %159
+%285 = OpLoad %ulong %161
+%286 = OpShiftRightLogical %ulong %284 %285
+OpStore %162 %286
+%287 = OpLoad %ulong %162
+%288 = OpBitwiseAnd %ulong %287 %ulong_255
+OpStore %163 %288
+%289 = OpLoad %ulong %167
+%290 = OpLoad %ulong %163
+%291 = OpBitwiseXor %ulong %289 %290
+OpStore %164 %291
+%292 = OpLoad %ulong %164
+%293 = OpIMul %ulong %292 %ulong_1099511628211
+OpStore %165 %293
+%294 = OpLoad %ulong %168
+%295 = OpIAdd %ulong %294 %ulong_1
+OpStore %166 %295
+%296 = OpLoad %ulong %165
+OpStore %167 %296
+%297 = OpLoad %ulong %166
+OpStore %168 %297
+OpBranch %69
+%51 = OpLabel
+%298 = OpLoad %ulong %157
+%299 = OpIMul %ulong %298 %ulong_8
+OpStore %150 %299
+%300 = OpLoad %ulong %148
+%301 = OpLoad %ulong %150
+%302 = OpShiftRightLogical %ulong %300 %301
+OpStore %151 %302
+%303 = OpLoad %ulong %151
+%304 = OpBitwiseAnd %ulong %303 %ulong_255
+OpStore %152 %304
+%305 = OpLoad %ulong %156
+%306 = OpLoad %ulong %152
+%307 = OpBitwiseXor %ulong %305 %306
+OpStore %153 %307
+%308 = OpLoad %ulong %153
+%309 = OpIMul %ulong %308 %ulong_1099511628211
+OpStore %154 %309
+%310 = OpLoad %ulong %157
+%311 = OpIAdd %ulong %310 %ulong_1
+OpStore %155 %311
+%312 = OpLoad %ulong %154
+OpStore %156 %312
+%313 = OpLoad %ulong %155
+OpStore %157 %313
+OpBranch %70
+%44 = OpLabel
+%314 = OpLoad %ulong %146
+%315 = OpIMul %ulong %314 %ulong_8
+OpStore %139 %315
+%316 = OpLoad %ulong %137
+%317 = OpLoad %ulong %139
+%318 = OpShiftRightLogical %ulong %316 %317
+OpStore %140 %318
+%319 = OpLoad %ulong %140
+%320 = OpBitwiseAnd %ulong %319 %ulong_255
+OpStore %141 %320
+%321 = OpLoad %ulong %145
+%322 = OpLoad %ulong %141
+%323 = OpBitwiseXor %ulong %321 %322
+OpStore %142 %323
+%324 = OpLoad %ulong %142
+%325 = OpIMul %ulong %324 %ulong_1099511628211
+OpStore %143 %325
+%326 = OpLoad %ulong %146
+%327 = OpIAdd %ulong %326 %ulong_1
+OpStore %144 %327
+%328 = OpLoad %ulong %143
+OpStore %145 %328
+%329 = OpLoad %ulong %144
+OpStore %146 %329
+OpBranch %71
+%37 = OpLabel
+%330 = OpLoad %ulong %135
+%331 = OpIMul %ulong %330 %ulong_8
+OpStore %128 %331
+%332 = OpLoad %ulong %126
+%333 = OpLoad %ulong %128
+%334 = OpShiftRightLogical %ulong %332 %333
+OpStore %129 %334
+%335 = OpLoad %ulong %129
+%336 = OpBitwiseAnd %ulong %335 %ulong_255
+OpStore %130 %336
+%337 = OpLoad %ulong %134
+%338 = OpLoad %ulong %130
+%339 = OpBitwiseXor %ulong %337 %338
+OpStore %131 %339
+%340 = OpLoad %ulong %131
+%341 = OpIMul %ulong %340 %ulong_1099511628211
+OpStore %132 %341
+%342 = OpLoad %ulong %135
+%343 = OpIAdd %ulong %342 %ulong_1
+OpStore %133 %343
+%344 = OpLoad %ulong %132
+OpStore %134 %344
+%345 = OpLoad %ulong %133
+OpStore %135 %345
+OpBranch %72
+%30 = OpLabel
+%346 = OpLoad %ulong %124
+%347 = OpIMul %ulong %346 %ulong_8
+OpStore %117 %347
+%348 = OpLoad %ulong %115
+%349 = OpLoad %ulong %117
+%350 = OpShiftRightLogical %ulong %348 %349
+OpStore %118 %350
+%351 = OpLoad %ulong %118
+%352 = OpBitwiseAnd %ulong %351 %ulong_255
+OpStore %119 %352
+%353 = OpLoad %ulong %123
+%354 = OpLoad %ulong %119
+%355 = OpBitwiseXor %ulong %353 %354
+OpStore %120 %355
+%356 = OpLoad %ulong %120
+%357 = OpIMul %ulong %356 %ulong_1099511628211
+OpStore %121 %357
+%358 = OpLoad %ulong %124
+%359 = OpIAdd %ulong %358 %ulong_1
+OpStore %122 %359
+%360 = OpLoad %ulong %121
+OpStore %123 %360
+%361 = OpLoad %ulong %122
+OpStore %124 %361
+OpBranch %73
+%23 = OpLabel
+%362 = OpLoad %ulong %113
+%363 = OpIMul %ulong %362 %ulong_8
+OpStore %106 %363
+%364 = OpLoad %ulong %104
+%365 = OpLoad %ulong %106
+%366 = OpShiftRightLogical %ulong %364 %365
+OpStore %107 %366
+%367 = OpLoad %ulong %107
+%368 = OpBitwiseAnd %ulong %367 %ulong_255
+OpStore %108 %368
+%369 = OpLoad %ulong %112
+%370 = OpLoad %ulong %108
+%371 = OpBitwiseXor %ulong %369 %370
+OpStore %109 %371
+%372 = OpLoad %ulong %109
+%373 = OpIMul %ulong %372 %ulong_1099511628211
+OpStore %110 %373
+%374 = OpLoad %ulong %113
+%375 = OpIAdd %ulong %374 %ulong_1
+OpStore %111 %375
+%376 = OpLoad %ulong %110
+OpStore %112 %376
+%377 = OpLoad %ulong %111
+OpStore %113 %377
+OpBranch %74
+%16 = OpLabel
+%378 = OpLoad %ulong %102
+%379 = OpIMul %ulong %378 %ulong_8
+OpStore %95 %379
+%380 = OpLoad %ulong %92
+%381 = OpLoad %ulong %95
+%382 = OpShiftRightLogical %ulong %380 %381
+OpStore %96 %382
+%383 = OpLoad %ulong %96
+%384 = OpBitwiseAnd %ulong %383 %ulong_255
+OpStore %97 %384
+%385 = OpLoad %ulong %101
+%386 = OpLoad %ulong %97
+%387 = OpBitwiseXor %ulong %385 %386
+OpStore %98 %387
+%388 = OpLoad %ulong %98
+%389 = OpIMul %ulong %388 %ulong_1099511628211
+OpStore %99 %389
+%390 = OpLoad %ulong %102
+%391 = OpIAdd %ulong %390 %ulong_1
+OpStore %100 %391
+%392 = OpLoad %ulong %99
+OpStore %101 %392
+%393 = OpLoad %ulong %100
+OpStore %102 %393
+OpBranch %75
+%68 = OpLabel
+OpBranch %64
+%69 = OpLabel
+OpBranch %57
+%70 = OpLabel
+OpBranch %50
+%71 = OpLabel
+OpBranch %43
+%72 = OpLabel
+OpBranch %36
+%73 = OpLabel
+OpBranch %29
+%74 = OpLabel
+OpBranch %22
+%75 = OpLabel
+OpBranch %15
+OpFunctionEnd
+%2 = OpFunction %ulong None %394
+%395 = OpFunctionParameter %ulong
+%396 = OpLabel
+%426 = OpVariable %_ptr_Function__arr__arr_float_uint_8_uint_4 Function
+%429 = OpVariable %_ptr_Function__struct_427 Function
+%430 = OpVariable %_ptr_Function_ulong Function
 %431 = OpVariable %_ptr_Function_float Function
 %432 = OpVariable %_ptr_Function_float Function
 %433 = OpVariable %_ptr_Function_float Function
 %434 = OpVariable %_ptr_Function_float Function
 %435 = OpVariable %_ptr_Function_float Function
-%436 = OpVariable %_ptr_Function_float Function
+%436 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %437 = OpVariable %_ptr_Function_float Function
 %438 = OpVariable %_ptr_Function_float Function
 %439 = OpVariable %_ptr_Function_float Function
-%440 = OpVariable %_ptr_Function_float Function
-%441 = OpVariable %_ptr_Function_float Function
+%440 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%441 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %442 = OpVariable %_ptr_Function_float Function
 %443 = OpVariable %_ptr_Function_float Function
-%444 = OpVariable %_ptr_Function_float Function
+%444 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %445 = OpVariable %_ptr_Function_float Function
 %446 = OpVariable %_ptr_Function_float Function
-%447 = OpVariable %_ptr_Function_float Function
+%447 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %448 = OpVariable %_ptr_Function_float Function
 %449 = OpVariable %_ptr_Function_float Function
-%450 = OpVariable %_ptr_Function_float Function
+%450 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %451 = OpVariable %_ptr_Function_float Function
 %452 = OpVariable %_ptr_Function_float Function
 %453 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%454 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%455 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%456 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%457 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%458 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%459 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%460 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%461 = OpVariable %_ptr_Function_float Function
-%462 = OpVariable %_ptr_Function_float Function
-%463 = OpVariable %_ptr_Function_float Function
-%464 = OpVariable %_ptr_Function_float Function
-%465 = OpVariable %_ptr_Function_float Function
-%466 = OpVariable %_ptr_Function_float Function
-%467 = OpVariable %_ptr_Function_float Function
-%468 = OpVariable %_ptr_Function_float Function
-%469 = OpVariable %_ptr_Function_float Function
-%470 = OpVariable %_ptr_Function_float Function
-%471 = OpVariable %_ptr_Function_float Function
-%472 = OpVariable %_ptr_Function_float Function
-%473 = OpVariable %_ptr_Function_float Function
-%474 = OpVariable %_ptr_Function_float Function
-%475 = OpVariable %_ptr_Function_float Function
-%476 = OpVariable %_ptr_Function_float Function
-%477 = OpVariable %_ptr_Function_float Function
-%478 = OpVariable %_ptr_Function_float Function
-%479 = OpVariable %_ptr_Function_float Function
-%480 = OpVariable %_ptr_Function_float Function
-%481 = OpVariable %_ptr_Function_float Function
-%482 = OpVariable %_ptr_Function_float Function
-%483 = OpVariable %_ptr_Function_float Function
-%484 = OpVariable %_ptr_Function_float Function
-%485 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%486 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%487 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%488 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%489 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%490 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%491 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%492 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%493 = OpVariable %_ptr_Function_float Function
-%494 = OpVariable %_ptr_Function_float Function
-%495 = OpVariable %_ptr_Function_float Function
-%496 = OpVariable %_ptr_Function_float Function
-%497 = OpVariable %_ptr_Function_float Function
-%498 = OpVariable %_ptr_Function_float Function
-%499 = OpVariable %_ptr_Function_float Function
-%500 = OpVariable %_ptr_Function_float Function
-%501 = OpVariable %_ptr_Function_float Function
-%502 = OpVariable %_ptr_Function_float Function
-%503 = OpVariable %_ptr_Function_float Function
-%504 = OpVariable %_ptr_Function_float Function
-%505 = OpVariable %_ptr_Function_float Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%466 = OpVariable %_ptr_Function_bool Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_bool Function
+%472 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_ulong Function
+%475 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%476 = OpVariable %_ptr_Function_uint Function
+%477 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_uint Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%483 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_ulong Function
+%487 = OpVariable %_ptr_Function_bool Function
+%488 = OpVariable %_ptr_Function_ulong Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_ulong Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_bool Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_ulong Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_ulong Function
+%505 = OpVariable %_ptr_Function_ulong Function
 %506 = OpVariable %_ptr_Function_float Function
 %507 = OpVariable %_ptr_Function_float Function
 %508 = OpVariable %_ptr_Function_float Function
@@ -545,27 +722,27 @@ OpFunctionEnd
 %514 = OpVariable %_ptr_Function_float Function
 %515 = OpVariable %_ptr_Function_float Function
 %516 = OpVariable %_ptr_Function_float Function
-%517 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%518 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%519 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%520 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%521 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%522 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%523 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%524 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%517 = OpVariable %_ptr_Function_float Function
+%518 = OpVariable %_ptr_Function_float Function
+%519 = OpVariable %_ptr_Function_float Function
+%520 = OpVariable %_ptr_Function_float Function
+%521 = OpVariable %_ptr_Function_float Function
+%522 = OpVariable %_ptr_Function_float Function
+%523 = OpVariable %_ptr_Function_float Function
+%524 = OpVariable %_ptr_Function_float Function
 %525 = OpVariable %_ptr_Function_float Function
 %526 = OpVariable %_ptr_Function_float Function
 %527 = OpVariable %_ptr_Function_float Function
 %528 = OpVariable %_ptr_Function_float Function
 %529 = OpVariable %_ptr_Function_float Function
-%530 = OpVariable %_ptr_Function_float Function
-%531 = OpVariable %_ptr_Function_float Function
-%532 = OpVariable %_ptr_Function_float Function
-%533 = OpVariable %_ptr_Function_float Function
-%534 = OpVariable %_ptr_Function_float Function
-%535 = OpVariable %_ptr_Function_float Function
-%536 = OpVariable %_ptr_Function_float Function
-%537 = OpVariable %_ptr_Function_float Function
+%530 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%531 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%532 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%533 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%534 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%535 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%536 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%537 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %538 = OpVariable %_ptr_Function_float Function
 %539 = OpVariable %_ptr_Function_float Function
 %540 = OpVariable %_ptr_Function_float Function
@@ -577,27 +754,27 @@ OpFunctionEnd
 %546 = OpVariable %_ptr_Function_float Function
 %547 = OpVariable %_ptr_Function_float Function
 %548 = OpVariable %_ptr_Function_float Function
-%549 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%550 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%551 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%552 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%553 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%554 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%555 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%556 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%549 = OpVariable %_ptr_Function_float Function
+%550 = OpVariable %_ptr_Function_float Function
+%551 = OpVariable %_ptr_Function_float Function
+%552 = OpVariable %_ptr_Function_float Function
+%553 = OpVariable %_ptr_Function_float Function
+%554 = OpVariable %_ptr_Function_float Function
+%555 = OpVariable %_ptr_Function_float Function
+%556 = OpVariable %_ptr_Function_float Function
 %557 = OpVariable %_ptr_Function_float Function
 %558 = OpVariable %_ptr_Function_float Function
 %559 = OpVariable %_ptr_Function_float Function
 %560 = OpVariable %_ptr_Function_float Function
 %561 = OpVariable %_ptr_Function_float Function
-%562 = OpVariable %_ptr_Function_float Function
-%563 = OpVariable %_ptr_Function_float Function
-%564 = OpVariable %_ptr_Function_float Function
-%565 = OpVariable %_ptr_Function_float Function
-%566 = OpVariable %_ptr_Function_float Function
-%567 = OpVariable %_ptr_Function_float Function
-%568 = OpVariable %_ptr_Function_float Function
-%569 = OpVariable %_ptr_Function_float Function
+%562 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%563 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%564 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%565 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%566 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%567 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%568 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%569 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %570 = OpVariable %_ptr_Function_float Function
 %571 = OpVariable %_ptr_Function_float Function
 %572 = OpVariable %_ptr_Function_float Function
@@ -609,27 +786,27 @@ OpFunctionEnd
 %578 = OpVariable %_ptr_Function_float Function
 %579 = OpVariable %_ptr_Function_float Function
 %580 = OpVariable %_ptr_Function_float Function
-%581 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%582 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%583 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%584 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%585 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%586 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%587 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%588 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%581 = OpVariable %_ptr_Function_float Function
+%582 = OpVariable %_ptr_Function_float Function
+%583 = OpVariable %_ptr_Function_float Function
+%584 = OpVariable %_ptr_Function_float Function
+%585 = OpVariable %_ptr_Function_float Function
+%586 = OpVariable %_ptr_Function_float Function
+%587 = OpVariable %_ptr_Function_float Function
+%588 = OpVariable %_ptr_Function_float Function
 %589 = OpVariable %_ptr_Function_float Function
 %590 = OpVariable %_ptr_Function_float Function
 %591 = OpVariable %_ptr_Function_float Function
 %592 = OpVariable %_ptr_Function_float Function
 %593 = OpVariable %_ptr_Function_float Function
-%594 = OpVariable %_ptr_Function_float Function
-%595 = OpVariable %_ptr_Function_float Function
-%596 = OpVariable %_ptr_Function_float Function
-%597 = OpVariable %_ptr_Function_float Function
-%598 = OpVariable %_ptr_Function_float Function
-%599 = OpVariable %_ptr_Function_float Function
-%600 = OpVariable %_ptr_Function_float Function
-%601 = OpVariable %_ptr_Function_float Function
+%594 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%595 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%596 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%597 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%598 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%599 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%600 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%601 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %602 = OpVariable %_ptr_Function_float Function
 %603 = OpVariable %_ptr_Function_float Function
 %604 = OpVariable %_ptr_Function_float Function
@@ -641,27 +818,27 @@ OpFunctionEnd
 %610 = OpVariable %_ptr_Function_float Function
 %611 = OpVariable %_ptr_Function_float Function
 %612 = OpVariable %_ptr_Function_float Function
-%613 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%614 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%615 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%616 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%617 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%618 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%619 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%620 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%613 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function_float Function
+%615 = OpVariable %_ptr_Function_float Function
+%616 = OpVariable %_ptr_Function_float Function
+%617 = OpVariable %_ptr_Function_float Function
+%618 = OpVariable %_ptr_Function_float Function
+%619 = OpVariable %_ptr_Function_float Function
+%620 = OpVariable %_ptr_Function_float Function
 %621 = OpVariable %_ptr_Function_float Function
 %622 = OpVariable %_ptr_Function_float Function
 %623 = OpVariable %_ptr_Function_float Function
 %624 = OpVariable %_ptr_Function_float Function
 %625 = OpVariable %_ptr_Function_float Function
-%626 = OpVariable %_ptr_Function_float Function
-%627 = OpVariable %_ptr_Function_float Function
-%628 = OpVariable %_ptr_Function_float Function
-%629 = OpVariable %_ptr_Function_float Function
-%630 = OpVariable %_ptr_Function_float Function
-%631 = OpVariable %_ptr_Function_float Function
-%632 = OpVariable %_ptr_Function_float Function
-%633 = OpVariable %_ptr_Function_float Function
+%626 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%627 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%628 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%629 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%630 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%631 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%632 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%633 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %634 = OpVariable %_ptr_Function_float Function
 %635 = OpVariable %_ptr_Function_float Function
 %636 = OpVariable %_ptr_Function_float Function
@@ -673,27 +850,27 @@ OpFunctionEnd
 %642 = OpVariable %_ptr_Function_float Function
 %643 = OpVariable %_ptr_Function_float Function
 %644 = OpVariable %_ptr_Function_float Function
-%645 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%646 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%647 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%648 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%649 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%650 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%651 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%652 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%645 = OpVariable %_ptr_Function_float Function
+%646 = OpVariable %_ptr_Function_float Function
+%647 = OpVariable %_ptr_Function_float Function
+%648 = OpVariable %_ptr_Function_float Function
+%649 = OpVariable %_ptr_Function_float Function
+%650 = OpVariable %_ptr_Function_float Function
+%651 = OpVariable %_ptr_Function_float Function
+%652 = OpVariable %_ptr_Function_float Function
 %653 = OpVariable %_ptr_Function_float Function
 %654 = OpVariable %_ptr_Function_float Function
 %655 = OpVariable %_ptr_Function_float Function
 %656 = OpVariable %_ptr_Function_float Function
 %657 = OpVariable %_ptr_Function_float Function
-%658 = OpVariable %_ptr_Function_float Function
-%659 = OpVariable %_ptr_Function_float Function
-%660 = OpVariable %_ptr_Function_float Function
-%661 = OpVariable %_ptr_Function_float Function
-%662 = OpVariable %_ptr_Function_float Function
-%663 = OpVariable %_ptr_Function_float Function
-%664 = OpVariable %_ptr_Function_float Function
-%665 = OpVariable %_ptr_Function_float Function
+%658 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%659 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%660 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%661 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%662 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%663 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%664 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%665 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %666 = OpVariable %_ptr_Function_float Function
 %667 = OpVariable %_ptr_Function_float Function
 %668 = OpVariable %_ptr_Function_float Function
@@ -705,27 +882,27 @@ OpFunctionEnd
 %674 = OpVariable %_ptr_Function_float Function
 %675 = OpVariable %_ptr_Function_float Function
 %676 = OpVariable %_ptr_Function_float Function
-%677 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%678 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%679 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%680 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%681 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%682 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%683 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%684 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%677 = OpVariable %_ptr_Function_float Function
+%678 = OpVariable %_ptr_Function_float Function
+%679 = OpVariable %_ptr_Function_float Function
+%680 = OpVariable %_ptr_Function_float Function
+%681 = OpVariable %_ptr_Function_float Function
+%682 = OpVariable %_ptr_Function_float Function
+%683 = OpVariable %_ptr_Function_float Function
+%684 = OpVariable %_ptr_Function_float Function
 %685 = OpVariable %_ptr_Function_float Function
 %686 = OpVariable %_ptr_Function_float Function
 %687 = OpVariable %_ptr_Function_float Function
 %688 = OpVariable %_ptr_Function_float Function
 %689 = OpVariable %_ptr_Function_float Function
-%690 = OpVariable %_ptr_Function_float Function
-%691 = OpVariable %_ptr_Function_float Function
-%692 = OpVariable %_ptr_Function_float Function
-%693 = OpVariable %_ptr_Function_float Function
-%694 = OpVariable %_ptr_Function_float Function
-%695 = OpVariable %_ptr_Function_float Function
-%696 = OpVariable %_ptr_Function_float Function
-%697 = OpVariable %_ptr_Function_float Function
+%690 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%691 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%692 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%693 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%694 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%695 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%696 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%697 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %698 = OpVariable %_ptr_Function_float Function
 %699 = OpVariable %_ptr_Function_float Function
 %700 = OpVariable %_ptr_Function_float Function
@@ -737,27 +914,27 @@ OpFunctionEnd
 %706 = OpVariable %_ptr_Function_float Function
 %707 = OpVariable %_ptr_Function_float Function
 %708 = OpVariable %_ptr_Function_float Function
-%709 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%710 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%711 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%712 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%713 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%714 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%715 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%716 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%709 = OpVariable %_ptr_Function_float Function
+%710 = OpVariable %_ptr_Function_float Function
+%711 = OpVariable %_ptr_Function_float Function
+%712 = OpVariable %_ptr_Function_float Function
+%713 = OpVariable %_ptr_Function_float Function
+%714 = OpVariable %_ptr_Function_float Function
+%715 = OpVariable %_ptr_Function_float Function
+%716 = OpVariable %_ptr_Function_float Function
 %717 = OpVariable %_ptr_Function_float Function
 %718 = OpVariable %_ptr_Function_float Function
 %719 = OpVariable %_ptr_Function_float Function
 %720 = OpVariable %_ptr_Function_float Function
 %721 = OpVariable %_ptr_Function_float Function
-%722 = OpVariable %_ptr_Function_float Function
-%723 = OpVariable %_ptr_Function_float Function
-%724 = OpVariable %_ptr_Function_float Function
-%725 = OpVariable %_ptr_Function_float Function
-%726 = OpVariable %_ptr_Function_float Function
-%727 = OpVariable %_ptr_Function_float Function
-%728 = OpVariable %_ptr_Function_float Function
-%729 = OpVariable %_ptr_Function_float Function
+%722 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%723 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%724 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%725 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%726 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%727 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%728 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%729 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %730 = OpVariable %_ptr_Function_float Function
 %731 = OpVariable %_ptr_Function_float Function
 %732 = OpVariable %_ptr_Function_float Function
@@ -769,27 +946,27 @@ OpFunctionEnd
 %738 = OpVariable %_ptr_Function_float Function
 %739 = OpVariable %_ptr_Function_float Function
 %740 = OpVariable %_ptr_Function_float Function
-%741 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%742 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%743 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%744 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%745 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%746 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%747 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%748 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%741 = OpVariable %_ptr_Function_float Function
+%742 = OpVariable %_ptr_Function_float Function
+%743 = OpVariable %_ptr_Function_float Function
+%744 = OpVariable %_ptr_Function_float Function
+%745 = OpVariable %_ptr_Function_float Function
+%746 = OpVariable %_ptr_Function_float Function
+%747 = OpVariable %_ptr_Function_float Function
+%748 = OpVariable %_ptr_Function_float Function
 %749 = OpVariable %_ptr_Function_float Function
 %750 = OpVariable %_ptr_Function_float Function
 %751 = OpVariable %_ptr_Function_float Function
 %752 = OpVariable %_ptr_Function_float Function
 %753 = OpVariable %_ptr_Function_float Function
-%754 = OpVariable %_ptr_Function_float Function
-%755 = OpVariable %_ptr_Function_float Function
-%756 = OpVariable %_ptr_Function_float Function
-%757 = OpVariable %_ptr_Function_float Function
-%758 = OpVariable %_ptr_Function_float Function
-%759 = OpVariable %_ptr_Function_float Function
-%760 = OpVariable %_ptr_Function_float Function
-%761 = OpVariable %_ptr_Function_float Function
+%754 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%755 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%756 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%757 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%758 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%759 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%760 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%761 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %762 = OpVariable %_ptr_Function_float Function
 %763 = OpVariable %_ptr_Function_float Function
 %764 = OpVariable %_ptr_Function_float Function
@@ -801,27 +978,27 @@ OpFunctionEnd
 %770 = OpVariable %_ptr_Function_float Function
 %771 = OpVariable %_ptr_Function_float Function
 %772 = OpVariable %_ptr_Function_float Function
-%773 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%774 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%775 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%776 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%777 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%778 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%779 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%780 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%773 = OpVariable %_ptr_Function_float Function
+%774 = OpVariable %_ptr_Function_float Function
+%775 = OpVariable %_ptr_Function_float Function
+%776 = OpVariable %_ptr_Function_float Function
+%777 = OpVariable %_ptr_Function_float Function
+%778 = OpVariable %_ptr_Function_float Function
+%779 = OpVariable %_ptr_Function_float Function
+%780 = OpVariable %_ptr_Function_float Function
 %781 = OpVariable %_ptr_Function_float Function
 %782 = OpVariable %_ptr_Function_float Function
 %783 = OpVariable %_ptr_Function_float Function
 %784 = OpVariable %_ptr_Function_float Function
 %785 = OpVariable %_ptr_Function_float Function
-%786 = OpVariable %_ptr_Function_float Function
-%787 = OpVariable %_ptr_Function_float Function
-%788 = OpVariable %_ptr_Function_float Function
-%789 = OpVariable %_ptr_Function_float Function
-%790 = OpVariable %_ptr_Function_float Function
-%791 = OpVariable %_ptr_Function_float Function
-%792 = OpVariable %_ptr_Function_float Function
-%793 = OpVariable %_ptr_Function_float Function
+%786 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%787 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%788 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%789 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%790 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%791 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%792 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%793 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %794 = OpVariable %_ptr_Function_float Function
 %795 = OpVariable %_ptr_Function_float Function
 %796 = OpVariable %_ptr_Function_float Function
@@ -833,27 +1010,27 @@ OpFunctionEnd
 %802 = OpVariable %_ptr_Function_float Function
 %803 = OpVariable %_ptr_Function_float Function
 %804 = OpVariable %_ptr_Function_float Function
-%805 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%806 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%807 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%808 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%809 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%810 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%811 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%812 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%805 = OpVariable %_ptr_Function_float Function
+%806 = OpVariable %_ptr_Function_float Function
+%807 = OpVariable %_ptr_Function_float Function
+%808 = OpVariable %_ptr_Function_float Function
+%809 = OpVariable %_ptr_Function_float Function
+%810 = OpVariable %_ptr_Function_float Function
+%811 = OpVariable %_ptr_Function_float Function
+%812 = OpVariable %_ptr_Function_float Function
 %813 = OpVariable %_ptr_Function_float Function
 %814 = OpVariable %_ptr_Function_float Function
 %815 = OpVariable %_ptr_Function_float Function
 %816 = OpVariable %_ptr_Function_float Function
 %817 = OpVariable %_ptr_Function_float Function
-%818 = OpVariable %_ptr_Function_float Function
-%819 = OpVariable %_ptr_Function_float Function
-%820 = OpVariable %_ptr_Function_float Function
-%821 = OpVariable %_ptr_Function_float Function
-%822 = OpVariable %_ptr_Function_float Function
-%823 = OpVariable %_ptr_Function_float Function
-%824 = OpVariable %_ptr_Function_float Function
-%825 = OpVariable %_ptr_Function_float Function
+%818 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%819 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%820 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%821 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%822 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%823 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%824 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%825 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %826 = OpVariable %_ptr_Function_float Function
 %827 = OpVariable %_ptr_Function_float Function
 %828 = OpVariable %_ptr_Function_float Function
@@ -865,27 +1042,27 @@ OpFunctionEnd
 %834 = OpVariable %_ptr_Function_float Function
 %835 = OpVariable %_ptr_Function_float Function
 %836 = OpVariable %_ptr_Function_float Function
-%837 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%838 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%839 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%840 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%841 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%842 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%843 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%844 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%837 = OpVariable %_ptr_Function_float Function
+%838 = OpVariable %_ptr_Function_float Function
+%839 = OpVariable %_ptr_Function_float Function
+%840 = OpVariable %_ptr_Function_float Function
+%841 = OpVariable %_ptr_Function_float Function
+%842 = OpVariable %_ptr_Function_float Function
+%843 = OpVariable %_ptr_Function_float Function
+%844 = OpVariable %_ptr_Function_float Function
 %845 = OpVariable %_ptr_Function_float Function
 %846 = OpVariable %_ptr_Function_float Function
 %847 = OpVariable %_ptr_Function_float Function
 %848 = OpVariable %_ptr_Function_float Function
 %849 = OpVariable %_ptr_Function_float Function
-%850 = OpVariable %_ptr_Function_float Function
-%851 = OpVariable %_ptr_Function_float Function
-%852 = OpVariable %_ptr_Function_float Function
-%853 = OpVariable %_ptr_Function_float Function
-%854 = OpVariable %_ptr_Function_float Function
-%855 = OpVariable %_ptr_Function_float Function
-%856 = OpVariable %_ptr_Function_float Function
-%857 = OpVariable %_ptr_Function_float Function
+%850 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%851 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%852 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%853 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%854 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%855 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%856 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%857 = OpVariable %_ptr_Function__arr_float_uint_8 Function
 %858 = OpVariable %_ptr_Function_float Function
 %859 = OpVariable %_ptr_Function_float Function
 %860 = OpVariable %_ptr_Function_float Function
@@ -897,2862 +1074,1995 @@ OpFunctionEnd
 %866 = OpVariable %_ptr_Function_float Function
 %867 = OpVariable %_ptr_Function_float Function
 %868 = OpVariable %_ptr_Function_float Function
-%869 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%870 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%871 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%872 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%873 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%874 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%875 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-%876 = OpVariable %_ptr_Function__arr_float_uint_8 Function
-OpStore %128 %78
-%877 = OpFunctionCall %ulong %3
-OpStore %129 %877
-%878 = OpLoad %ulong %128
-%879 = OpConvertUToF %float %878
-OpStore %130 %879
-%881 = OpFNegate %float %float_2_25
-OpStore %131 %881
-%883 = OpFNegate %float %float_0_5
-OpStore %132 %883
-%885 = OpFNegate %float %float_8_125
-OpStore %133 %885
-%887 = OpFNegate %float %float_16
-OpStore %134 %887
-%890 = OpLoad %float %131
-%892 = OpLoad %float %132
-%894 = OpLoad %float %133
-%896 = OpLoad %float %134
-%888 = OpCompositeConstruct %_arr_float_uint_8 %float_1_5 %890 %float_3_75 %892 %float_6_25 %894 %float_0_75 %896
-OpStore %135 %888
-%898 = OpFNegate %float %float_0_125
-OpStore %136 %898
-%900 = OpFNegate %float %float_2
-OpStore %137 %900
-%902 = OpFNegate %float %float_32
-OpStore %138 %902
-%905 = OpLoad %float %136
-%907 = OpLoad %float %137
-%909 = OpLoad %float %138
-%903 = OpCompositeConstruct %_arr_float_uint_8 %float_0_5 %float_4 %905 %float_8 %907 %float_1_25 %909 %float_0_0625
-OpStore %139 %903
-%911 = OpCompositeConstruct %_arr_float_uint_8 %float_1 %float_3 %float_9 %float_27 %float_81 %float_243 %float_729 %float_2187
-OpStore %140 %911
-%920 = OpLoad %_arr_float_uint_8 %135
-%921 = OpCompositeExtract %float %920 0
-OpStore %141 %921
-%922 = OpLoad %float %141
-%923 = OpLoad %float %130
-%924 = OpFAdd %float %922 %923
-OpStore %142 %924
-%925 = OpLoad %_arr_float_uint_8 %135
-%926 = OpLoad %float %142
-%927 = OpCompositeInsert %_arr_float_uint_8 %926 %925 0
-OpStore %143 %927
-%928 = OpLoad %_arr_float_uint_8 %143
-%929 = OpCompositeExtract %float %928 7
-OpStore %144 %929
-%930 = OpLoad %float %144
-%931 = OpLoad %float %130
-%932 = OpFAdd %float %930 %931
-OpStore %145 %932
-%933 = OpLoad %_arr_float_uint_8 %143
-%934 = OpLoad %float %145
-%935 = OpCompositeInsert %_arr_float_uint_8 %934 %933 7
-OpStore %146 %935
-%936 = OpLoad %_arr_float_uint_8 %139
-%937 = OpCompositeExtract %float %936 3
-OpStore %147 %937
-%938 = OpLoad %float %147
-%939 = OpLoad %float %130
-%940 = OpFAdd %float %938 %939
-OpStore %148 %940
-%941 = OpLoad %_arr_float_uint_8 %139
-%942 = OpLoad %float %148
-%943 = OpCompositeInsert %_arr_float_uint_8 %942 %941 3
-OpStore %149 %943
-%944 = OpLoad %_arr_float_uint_8 %149
-%945 = OpCompositeExtract %float %944 4
-OpStore %150 %945
-%946 = OpLoad %float %150
-%947 = OpLoad %float %130
-%948 = OpFAdd %float %946 %947
-OpStore %151 %948
-%949 = OpLoad %_arr_float_uint_8 %149
-%950 = OpLoad %float %151
-%951 = OpCompositeInsert %_arr_float_uint_8 %950 %949 4
-OpStore %152 %951
-OpBranch %86
-%86 = OpLabel
-%952 = OpLoad %_arr_float_uint_8 %146
-%953 = OpCompositeExtract %float %952 0
-OpStore %173 %953
-%954 = OpLoad %ulong %129
-%955 = OpLoad %float %173
-%956 = OpFunctionCall %ulong %5 %954 %955
-OpStore %174 %956
-%957 = OpLoad %_arr_float_uint_8 %146
-%958 = OpCompositeExtract %float %957 1
-OpStore %175 %958
-%959 = OpLoad %ulong %174
-%960 = OpLoad %float %175
-%961 = OpFunctionCall %ulong %5 %959 %960
-OpStore %176 %961
-%962 = OpLoad %_arr_float_uint_8 %146
-%963 = OpCompositeExtract %float %962 2
-OpStore %177 %963
-%964 = OpLoad %ulong %176
-%965 = OpLoad %float %177
-%966 = OpFunctionCall %ulong %5 %964 %965
-OpStore %178 %966
-%967 = OpLoad %_arr_float_uint_8 %146
-%968 = OpCompositeExtract %float %967 3
-OpStore %179 %968
-%969 = OpLoad %ulong %178
-%970 = OpLoad %float %179
-%971 = OpFunctionCall %ulong %5 %969 %970
-OpStore %180 %971
-%972 = OpLoad %_arr_float_uint_8 %146
-%973 = OpCompositeExtract %float %972 4
-OpStore %181 %973
-%974 = OpLoad %ulong %180
-%975 = OpLoad %float %181
-%976 = OpFunctionCall %ulong %5 %974 %975
-OpStore %182 %976
-%977 = OpLoad %_arr_float_uint_8 %146
-%978 = OpCompositeExtract %float %977 5
-OpStore %183 %978
-%979 = OpLoad %ulong %182
-%980 = OpLoad %float %183
-%981 = OpFunctionCall %ulong %5 %979 %980
-OpStore %184 %981
-%982 = OpLoad %_arr_float_uint_8 %146
-%983 = OpCompositeExtract %float %982 6
-OpStore %185 %983
-%984 = OpLoad %ulong %184
-%985 = OpLoad %float %185
-%986 = OpFunctionCall %ulong %5 %984 %985
-OpStore %186 %986
-%987 = OpLoad %_arr_float_uint_8 %146
-%988 = OpCompositeExtract %float %987 7
-OpStore %187 %988
-%989 = OpLoad %ulong %186
-%990 = OpLoad %float %187
-%991 = OpFunctionCall %ulong %5 %989 %990
-OpStore %188 %991
-OpBranch %87
-%87 = OpLabel
-OpBranch %94
-%94 = OpLabel
-%992 = OpLoad %_arr_float_uint_8 %152
-%993 = OpCompositeExtract %float %992 0
-OpStore %237 %993
-%994 = OpLoad %ulong %188
-%995 = OpLoad %float %237
-%996 = OpFunctionCall %ulong %5 %994 %995
-OpStore %238 %996
-%997 = OpLoad %_arr_float_uint_8 %152
-%998 = OpCompositeExtract %float %997 1
-OpStore %239 %998
-%999 = OpLoad %ulong %238
-%1000 = OpLoad %float %239
-%1001 = OpFunctionCall %ulong %5 %999 %1000
-OpStore %240 %1001
-%1002 = OpLoad %_arr_float_uint_8 %152
-%1003 = OpCompositeExtract %float %1002 2
-OpStore %241 %1003
-%1004 = OpLoad %ulong %240
-%1005 = OpLoad %float %241
-%1006 = OpFunctionCall %ulong %5 %1004 %1005
-OpStore %242 %1006
-%1007 = OpLoad %_arr_float_uint_8 %152
-%1008 = OpCompositeExtract %float %1007 3
-OpStore %243 %1008
-%1009 = OpLoad %ulong %242
-%1010 = OpLoad %float %243
-%1011 = OpFunctionCall %ulong %5 %1009 %1010
-OpStore %244 %1011
-%1012 = OpLoad %_arr_float_uint_8 %152
-%1013 = OpCompositeExtract %float %1012 4
-OpStore %245 %1013
-%1014 = OpLoad %ulong %244
-%1015 = OpLoad %float %245
-%1016 = OpFunctionCall %ulong %5 %1014 %1015
-OpStore %246 %1016
-%1017 = OpLoad %_arr_float_uint_8 %152
-%1018 = OpCompositeExtract %float %1017 5
-OpStore %247 %1018
-%1019 = OpLoad %ulong %246
-%1020 = OpLoad %float %247
-%1021 = OpFunctionCall %ulong %5 %1019 %1020
-OpStore %248 %1021
-%1022 = OpLoad %_arr_float_uint_8 %152
-%1023 = OpCompositeExtract %float %1022 6
-OpStore %249 %1023
-%1024 = OpLoad %ulong %248
-%1025 = OpLoad %float %249
-%1026 = OpFunctionCall %ulong %5 %1024 %1025
-OpStore %250 %1026
-%1027 = OpLoad %_arr_float_uint_8 %152
-%1028 = OpCompositeExtract %float %1027 7
-OpStore %251 %1028
-%1029 = OpLoad %ulong %250
-%1030 = OpLoad %float %251
-%1031 = OpFunctionCall %ulong %5 %1029 %1030
-OpStore %252 %1031
-OpBranch %95
-%95 = OpLabel
-%1032 = OpLoad %_arr_float_uint_8 %146
-%1033 = OpCompositeExtract %float %1032 0
-OpStore %557 %1033
-%1034 = OpLoad %_arr_float_uint_8 %152
+%869 = OpVariable %_ptr_Function_float Function
+%870 = OpVariable %_ptr_Function_float Function
+%871 = OpVariable %_ptr_Function_float Function
+%872 = OpVariable %_ptr_Function_float Function
+%873 = OpVariable %_ptr_Function_float Function
+%874 = OpVariable %_ptr_Function_float Function
+%875 = OpVariable %_ptr_Function_float Function
+%876 = OpVariable %_ptr_Function_float Function
+%877 = OpVariable %_ptr_Function_float Function
+%878 = OpVariable %_ptr_Function_float Function
+%879 = OpVariable %_ptr_Function_float Function
+%880 = OpVariable %_ptr_Function_float Function
+%881 = OpVariable %_ptr_Function_float Function
+%882 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%883 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%884 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%885 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%886 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%887 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%888 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%889 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%890 = OpVariable %_ptr_Function_float Function
+%891 = OpVariable %_ptr_Function_float Function
+%892 = OpVariable %_ptr_Function_float Function
+%893 = OpVariable %_ptr_Function_float Function
+%894 = OpVariable %_ptr_Function_float Function
+%895 = OpVariable %_ptr_Function_float Function
+%896 = OpVariable %_ptr_Function_float Function
+%897 = OpVariable %_ptr_Function_float Function
+%898 = OpVariable %_ptr_Function_float Function
+%899 = OpVariable %_ptr_Function_float Function
+%900 = OpVariable %_ptr_Function_float Function
+%901 = OpVariable %_ptr_Function_float Function
+%902 = OpVariable %_ptr_Function_float Function
+%903 = OpVariable %_ptr_Function_float Function
+%904 = OpVariable %_ptr_Function_float Function
+%905 = OpVariable %_ptr_Function_float Function
+%906 = OpVariable %_ptr_Function_float Function
+%907 = OpVariable %_ptr_Function_float Function
+%908 = OpVariable %_ptr_Function_float Function
+%909 = OpVariable %_ptr_Function_float Function
+%910 = OpVariable %_ptr_Function_float Function
+%911 = OpVariable %_ptr_Function_float Function
+%912 = OpVariable %_ptr_Function_float Function
+%913 = OpVariable %_ptr_Function_float Function
+%914 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%915 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%916 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%917 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%918 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%919 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%920 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%921 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%922 = OpVariable %_ptr_Function_float Function
+%923 = OpVariable %_ptr_Function_float Function
+%924 = OpVariable %_ptr_Function_float Function
+%925 = OpVariable %_ptr_Function_float Function
+%926 = OpVariable %_ptr_Function_float Function
+%927 = OpVariable %_ptr_Function_float Function
+%928 = OpVariable %_ptr_Function_float Function
+%929 = OpVariable %_ptr_Function_float Function
+%930 = OpVariable %_ptr_Function_float Function
+%931 = OpVariable %_ptr_Function_float Function
+%932 = OpVariable %_ptr_Function_float Function
+%933 = OpVariable %_ptr_Function_float Function
+%934 = OpVariable %_ptr_Function_float Function
+%935 = OpVariable %_ptr_Function_float Function
+%936 = OpVariable %_ptr_Function_float Function
+%937 = OpVariable %_ptr_Function_float Function
+%938 = OpVariable %_ptr_Function_float Function
+%939 = OpVariable %_ptr_Function_float Function
+%940 = OpVariable %_ptr_Function_float Function
+%941 = OpVariable %_ptr_Function_float Function
+%942 = OpVariable %_ptr_Function_float Function
+%943 = OpVariable %_ptr_Function_float Function
+%944 = OpVariable %_ptr_Function_float Function
+%945 = OpVariable %_ptr_Function_float Function
+%946 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%947 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%948 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%949 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%950 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%951 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%952 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%953 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+OpStore %430 %395
+OpBranch %403
+%403 = OpLabel
+OpBranch %404
+%404 = OpLabel
+%954 = OpLoad %ulong %430
+%955 = OpConvertUToF %float %954
+OpStore %431 %955
+%957 = OpFNegate %float %float_2_25
+OpStore %432 %957
+%959 = OpFNegate %float %float_0_5
+OpStore %433 %959
+%961 = OpFNegate %float %float_8_125
+OpStore %434 %961
+%963 = OpFNegate %float %float_16
+OpStore %435 %963
+%966 = OpLoad %float %432
+%968 = OpLoad %float %433
+%970 = OpLoad %float %434
+%972 = OpLoad %float %435
+%964 = OpCompositeConstruct %_arr_float_uint_8 %float_1_5 %966 %float_3_75 %968 %float_6_25 %970 %float_0_75 %972
+OpStore %436 %964
+%974 = OpFNegate %float %float_0_125
+OpStore %437 %974
+%976 = OpFNegate %float %float_2
+OpStore %438 %976
+%978 = OpFNegate %float %float_32
+OpStore %439 %978
+%981 = OpLoad %float %437
+%983 = OpLoad %float %438
+%985 = OpLoad %float %439
+%979 = OpCompositeConstruct %_arr_float_uint_8 %float_0_5 %float_4 %981 %float_8 %983 %float_1_25 %985 %float_0_0625
+OpStore %440 %979
+%987 = OpCompositeConstruct %_arr_float_uint_8 %float_1 %float_3 %float_9 %float_27 %float_81 %float_243 %float_729 %float_2187
+OpStore %441 %987
+%996 = OpLoad %_arr_float_uint_8 %436
+%997 = OpCompositeExtract %float %996 0
+OpStore %442 %997
+%998 = OpLoad %float %442
+%999 = OpLoad %float %431
+%1000 = OpFAdd %float %998 %999
+OpStore %443 %1000
+%1001 = OpLoad %_arr_float_uint_8 %436
+%1002 = OpLoad %float %443
+%1003 = OpCompositeInsert %_arr_float_uint_8 %1002 %1001 0
+OpStore %444 %1003
+%1004 = OpLoad %_arr_float_uint_8 %444
+%1005 = OpCompositeExtract %float %1004 7
+OpStore %445 %1005
+%1006 = OpLoad %float %445
+%1007 = OpLoad %float %431
+%1008 = OpFAdd %float %1006 %1007
+OpStore %446 %1008
+%1009 = OpLoad %_arr_float_uint_8 %444
+%1010 = OpLoad %float %446
+%1011 = OpCompositeInsert %_arr_float_uint_8 %1010 %1009 7
+OpStore %447 %1011
+%1012 = OpLoad %_arr_float_uint_8 %440
+%1013 = OpCompositeExtract %float %1012 3
+OpStore %448 %1013
+%1014 = OpLoad %float %448
+%1015 = OpLoad %float %431
+%1016 = OpFAdd %float %1014 %1015
+OpStore %449 %1016
+%1017 = OpLoad %_arr_float_uint_8 %440
+%1018 = OpLoad %float %449
+%1019 = OpCompositeInsert %_arr_float_uint_8 %1018 %1017 3
+OpStore %450 %1019
+%1020 = OpLoad %_arr_float_uint_8 %450
+%1021 = OpCompositeExtract %float %1020 4
+OpStore %451 %1021
+%1022 = OpLoad %float %451
+%1023 = OpLoad %float %431
+%1024 = OpFAdd %float %1022 %1023
+OpStore %452 %1024
+%1025 = OpLoad %_arr_float_uint_8 %450
+%1026 = OpLoad %float %452
+%1027 = OpCompositeInsert %_arr_float_uint_8 %1026 %1025 4
+OpStore %453 %1027
+%1029 = OpLoad %_arr_float_uint_8 %447
+%1030 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %1029
+OpStore %454 %1030
+%1031 = OpLoad %ulong %454
+%1032 = OpLoad %_arr_float_uint_8 %453
+%1033 = OpFunctionCall %ulong %1 %1031 %1032
+OpStore %455 %1033
+%1034 = OpLoad %_arr_float_uint_8 %447
 %1035 = OpCompositeExtract %float %1034 0
-OpStore %558 %1035
-%1036 = OpLoad %float %557
-%1037 = OpLoad %float %558
-%1038 = OpFAdd %float %1036 %1037
-OpStore %559 %1038
-%1039 = OpLoad %_arr_float_uint_8 %146
-%1040 = OpCompositeExtract %float %1039 1
-OpStore %560 %1040
-%1041 = OpLoad %_arr_float_uint_8 %152
+OpStore %666 %1035
+%1036 = OpLoad %_arr_float_uint_8 %453
+%1037 = OpCompositeExtract %float %1036 0
+OpStore %667 %1037
+%1038 = OpLoad %float %666
+%1039 = OpLoad %float %667
+%1040 = OpFAdd %float %1038 %1039
+OpStore %668 %1040
+%1041 = OpLoad %_arr_float_uint_8 %447
 %1042 = OpCompositeExtract %float %1041 1
-OpStore %561 %1042
-%1043 = OpLoad %float %560
-%1044 = OpLoad %float %561
-%1045 = OpFAdd %float %1043 %1044
-OpStore %562 %1045
-%1046 = OpLoad %_arr_float_uint_8 %146
-%1047 = OpCompositeExtract %float %1046 2
-OpStore %563 %1047
-%1048 = OpLoad %_arr_float_uint_8 %152
+OpStore %669 %1042
+%1043 = OpLoad %_arr_float_uint_8 %453
+%1044 = OpCompositeExtract %float %1043 1
+OpStore %670 %1044
+%1045 = OpLoad %float %669
+%1046 = OpLoad %float %670
+%1047 = OpFAdd %float %1045 %1046
+OpStore %671 %1047
+%1048 = OpLoad %_arr_float_uint_8 %447
 %1049 = OpCompositeExtract %float %1048 2
-OpStore %564 %1049
-%1050 = OpLoad %float %563
-%1051 = OpLoad %float %564
-%1052 = OpFAdd %float %1050 %1051
-OpStore %565 %1052
-%1053 = OpLoad %_arr_float_uint_8 %146
-%1054 = OpCompositeExtract %float %1053 3
-OpStore %566 %1054
-%1055 = OpLoad %_arr_float_uint_8 %152
+OpStore %672 %1049
+%1050 = OpLoad %_arr_float_uint_8 %453
+%1051 = OpCompositeExtract %float %1050 2
+OpStore %673 %1051
+%1052 = OpLoad %float %672
+%1053 = OpLoad %float %673
+%1054 = OpFAdd %float %1052 %1053
+OpStore %674 %1054
+%1055 = OpLoad %_arr_float_uint_8 %447
 %1056 = OpCompositeExtract %float %1055 3
-OpStore %567 %1056
-%1057 = OpLoad %float %566
-%1058 = OpLoad %float %567
-%1059 = OpFAdd %float %1057 %1058
-OpStore %568 %1059
-%1060 = OpLoad %_arr_float_uint_8 %146
-%1061 = OpCompositeExtract %float %1060 4
-OpStore %569 %1061
-%1062 = OpLoad %_arr_float_uint_8 %152
+OpStore %675 %1056
+%1057 = OpLoad %_arr_float_uint_8 %453
+%1058 = OpCompositeExtract %float %1057 3
+OpStore %676 %1058
+%1059 = OpLoad %float %675
+%1060 = OpLoad %float %676
+%1061 = OpFAdd %float %1059 %1060
+OpStore %677 %1061
+%1062 = OpLoad %_arr_float_uint_8 %447
 %1063 = OpCompositeExtract %float %1062 4
-OpStore %570 %1063
-%1064 = OpLoad %float %569
-%1065 = OpLoad %float %570
-%1066 = OpFAdd %float %1064 %1065
-OpStore %571 %1066
-%1067 = OpLoad %_arr_float_uint_8 %146
-%1068 = OpCompositeExtract %float %1067 5
-OpStore %572 %1068
-%1069 = OpLoad %_arr_float_uint_8 %152
+OpStore %678 %1063
+%1064 = OpLoad %_arr_float_uint_8 %453
+%1065 = OpCompositeExtract %float %1064 4
+OpStore %679 %1065
+%1066 = OpLoad %float %678
+%1067 = OpLoad %float %679
+%1068 = OpFAdd %float %1066 %1067
+OpStore %680 %1068
+%1069 = OpLoad %_arr_float_uint_8 %447
 %1070 = OpCompositeExtract %float %1069 5
-OpStore %573 %1070
-%1071 = OpLoad %float %572
-%1072 = OpLoad %float %573
-%1073 = OpFAdd %float %1071 %1072
-OpStore %574 %1073
-%1074 = OpLoad %_arr_float_uint_8 %146
-%1075 = OpCompositeExtract %float %1074 6
-OpStore %575 %1075
-%1076 = OpLoad %_arr_float_uint_8 %152
+OpStore %681 %1070
+%1071 = OpLoad %_arr_float_uint_8 %453
+%1072 = OpCompositeExtract %float %1071 5
+OpStore %682 %1072
+%1073 = OpLoad %float %681
+%1074 = OpLoad %float %682
+%1075 = OpFAdd %float %1073 %1074
+OpStore %683 %1075
+%1076 = OpLoad %_arr_float_uint_8 %447
 %1077 = OpCompositeExtract %float %1076 6
-OpStore %576 %1077
-%1078 = OpLoad %float %575
-%1079 = OpLoad %float %576
-%1080 = OpFAdd %float %1078 %1079
-OpStore %577 %1080
-%1081 = OpLoad %_arr_float_uint_8 %146
-%1082 = OpCompositeExtract %float %1081 7
-OpStore %578 %1082
-%1083 = OpLoad %_arr_float_uint_8 %152
+OpStore %684 %1077
+%1078 = OpLoad %_arr_float_uint_8 %453
+%1079 = OpCompositeExtract %float %1078 6
+OpStore %685 %1079
+%1080 = OpLoad %float %684
+%1081 = OpLoad %float %685
+%1082 = OpFAdd %float %1080 %1081
+OpStore %686 %1082
+%1083 = OpLoad %_arr_float_uint_8 %447
 %1084 = OpCompositeExtract %float %1083 7
-OpStore %579 %1084
-%1085 = OpLoad %float %578
-%1086 = OpLoad %float %579
-%1087 = OpFAdd %float %1085 %1086
-OpStore %580 %1087
-%1088 = OpLoad %_arr_float_uint_8 %146
-%1089 = OpLoad %float %559
-%1090 = OpCompositeInsert %_arr_float_uint_8 %1089 %1088 0
-OpStore %581 %1090
-%1091 = OpLoad %_arr_float_uint_8 %581
-%1092 = OpLoad %float %562
-%1093 = OpCompositeInsert %_arr_float_uint_8 %1092 %1091 1
-OpStore %582 %1093
-%1094 = OpLoad %_arr_float_uint_8 %582
-%1095 = OpLoad %float %565
-%1096 = OpCompositeInsert %_arr_float_uint_8 %1095 %1094 2
-OpStore %583 %1096
-%1097 = OpLoad %_arr_float_uint_8 %583
-%1098 = OpLoad %float %568
-%1099 = OpCompositeInsert %_arr_float_uint_8 %1098 %1097 3
-OpStore %584 %1099
-%1100 = OpLoad %_arr_float_uint_8 %584
-%1101 = OpLoad %float %571
-%1102 = OpCompositeInsert %_arr_float_uint_8 %1101 %1100 4
-OpStore %585 %1102
-%1103 = OpLoad %_arr_float_uint_8 %585
-%1104 = OpLoad %float %574
-%1105 = OpCompositeInsert %_arr_float_uint_8 %1104 %1103 5
-OpStore %586 %1105
-%1106 = OpLoad %_arr_float_uint_8 %586
-%1107 = OpLoad %float %577
-%1108 = OpCompositeInsert %_arr_float_uint_8 %1107 %1106 6
-OpStore %587 %1108
-%1109 = OpLoad %_arr_float_uint_8 %587
-%1110 = OpLoad %float %580
-%1111 = OpCompositeInsert %_arr_float_uint_8 %1110 %1109 7
-OpStore %588 %1111
-OpBranch %98
-%98 = OpLabel
-%1112 = OpLoad %_arr_float_uint_8 %588
-%1113 = OpCompositeExtract %float %1112 0
-OpStore %269 %1113
-%1114 = OpLoad %ulong %252
-%1115 = OpLoad %float %269
-%1116 = OpFunctionCall %ulong %5 %1114 %1115
-OpStore %270 %1116
-%1117 = OpLoad %_arr_float_uint_8 %588
-%1118 = OpCompositeExtract %float %1117 1
-OpStore %271 %1118
-%1119 = OpLoad %ulong %270
-%1120 = OpLoad %float %271
-%1121 = OpFunctionCall %ulong %5 %1119 %1120
-OpStore %272 %1121
-%1122 = OpLoad %_arr_float_uint_8 %588
-%1123 = OpCompositeExtract %float %1122 2
-OpStore %273 %1123
-%1124 = OpLoad %ulong %272
-%1125 = OpLoad %float %273
-%1126 = OpFunctionCall %ulong %5 %1124 %1125
-OpStore %274 %1126
-%1127 = OpLoad %_arr_float_uint_8 %588
-%1128 = OpCompositeExtract %float %1127 3
-OpStore %275 %1128
-%1129 = OpLoad %ulong %274
-%1130 = OpLoad %float %275
-%1131 = OpFunctionCall %ulong %5 %1129 %1130
-OpStore %276 %1131
-%1132 = OpLoad %_arr_float_uint_8 %588
-%1133 = OpCompositeExtract %float %1132 4
-OpStore %277 %1133
-%1134 = OpLoad %ulong %276
-%1135 = OpLoad %float %277
-%1136 = OpFunctionCall %ulong %5 %1134 %1135
-OpStore %278 %1136
-%1137 = OpLoad %_arr_float_uint_8 %588
-%1138 = OpCompositeExtract %float %1137 5
-OpStore %279 %1138
-%1139 = OpLoad %ulong %278
-%1140 = OpLoad %float %279
-%1141 = OpFunctionCall %ulong %5 %1139 %1140
-OpStore %280 %1141
-%1142 = OpLoad %_arr_float_uint_8 %588
-%1143 = OpCompositeExtract %float %1142 6
-OpStore %281 %1143
-%1144 = OpLoad %ulong %280
-%1145 = OpLoad %float %281
-%1146 = OpFunctionCall %ulong %5 %1144 %1145
-OpStore %282 %1146
-%1147 = OpLoad %_arr_float_uint_8 %588
-%1148 = OpCompositeExtract %float %1147 7
-OpStore %283 %1148
-%1149 = OpLoad %ulong %282
-%1150 = OpLoad %float %283
-%1151 = OpFunctionCall %ulong %5 %1149 %1150
-OpStore %284 %1151
-OpBranch %99
-%99 = OpLabel
-%1152 = OpLoad %_arr_float_uint_8 %146
-%1153 = OpCompositeExtract %float %1152 0
-OpStore %621 %1153
-%1154 = OpLoad %_arr_float_uint_8 %152
-%1155 = OpCompositeExtract %float %1154 0
-OpStore %622 %1155
-%1156 = OpLoad %float %621
-%1157 = OpLoad %float %622
+OpStore %687 %1084
+%1085 = OpLoad %_arr_float_uint_8 %453
+%1086 = OpCompositeExtract %float %1085 7
+OpStore %688 %1086
+%1087 = OpLoad %float %687
+%1088 = OpLoad %float %688
+%1089 = OpFAdd %float %1087 %1088
+OpStore %689 %1089
+%1090 = OpLoad %_arr_float_uint_8 %447
+%1091 = OpLoad %float %668
+%1092 = OpCompositeInsert %_arr_float_uint_8 %1091 %1090 0
+OpStore %690 %1092
+%1093 = OpLoad %_arr_float_uint_8 %690
+%1094 = OpLoad %float %671
+%1095 = OpCompositeInsert %_arr_float_uint_8 %1094 %1093 1
+OpStore %691 %1095
+%1096 = OpLoad %_arr_float_uint_8 %691
+%1097 = OpLoad %float %674
+%1098 = OpCompositeInsert %_arr_float_uint_8 %1097 %1096 2
+OpStore %692 %1098
+%1099 = OpLoad %_arr_float_uint_8 %692
+%1100 = OpLoad %float %677
+%1101 = OpCompositeInsert %_arr_float_uint_8 %1100 %1099 3
+OpStore %693 %1101
+%1102 = OpLoad %_arr_float_uint_8 %693
+%1103 = OpLoad %float %680
+%1104 = OpCompositeInsert %_arr_float_uint_8 %1103 %1102 4
+OpStore %694 %1104
+%1105 = OpLoad %_arr_float_uint_8 %694
+%1106 = OpLoad %float %683
+%1107 = OpCompositeInsert %_arr_float_uint_8 %1106 %1105 5
+OpStore %695 %1107
+%1108 = OpLoad %_arr_float_uint_8 %695
+%1109 = OpLoad %float %686
+%1110 = OpCompositeInsert %_arr_float_uint_8 %1109 %1108 6
+OpStore %696 %1110
+%1111 = OpLoad %_arr_float_uint_8 %696
+%1112 = OpLoad %float %689
+%1113 = OpCompositeInsert %_arr_float_uint_8 %1112 %1111 7
+OpStore %697 %1113
+%1114 = OpLoad %ulong %455
+%1115 = OpLoad %_arr_float_uint_8 %697
+%1116 = OpFunctionCall %ulong %1 %1114 %1115
+OpStore %456 %1116
+%1117 = OpLoad %_arr_float_uint_8 %447
+%1118 = OpCompositeExtract %float %1117 0
+OpStore %698 %1118
+%1119 = OpLoad %_arr_float_uint_8 %453
+%1120 = OpCompositeExtract %float %1119 0
+OpStore %699 %1120
+%1121 = OpLoad %float %698
+%1122 = OpLoad %float %699
+%1123 = OpFSub %float %1121 %1122
+OpStore %700 %1123
+%1124 = OpLoad %_arr_float_uint_8 %447
+%1125 = OpCompositeExtract %float %1124 1
+OpStore %701 %1125
+%1126 = OpLoad %_arr_float_uint_8 %453
+%1127 = OpCompositeExtract %float %1126 1
+OpStore %702 %1127
+%1128 = OpLoad %float %701
+%1129 = OpLoad %float %702
+%1130 = OpFSub %float %1128 %1129
+OpStore %703 %1130
+%1131 = OpLoad %_arr_float_uint_8 %447
+%1132 = OpCompositeExtract %float %1131 2
+OpStore %704 %1132
+%1133 = OpLoad %_arr_float_uint_8 %453
+%1134 = OpCompositeExtract %float %1133 2
+OpStore %705 %1134
+%1135 = OpLoad %float %704
+%1136 = OpLoad %float %705
+%1137 = OpFSub %float %1135 %1136
+OpStore %706 %1137
+%1138 = OpLoad %_arr_float_uint_8 %447
+%1139 = OpCompositeExtract %float %1138 3
+OpStore %707 %1139
+%1140 = OpLoad %_arr_float_uint_8 %453
+%1141 = OpCompositeExtract %float %1140 3
+OpStore %708 %1141
+%1142 = OpLoad %float %707
+%1143 = OpLoad %float %708
+%1144 = OpFSub %float %1142 %1143
+OpStore %709 %1144
+%1145 = OpLoad %_arr_float_uint_8 %447
+%1146 = OpCompositeExtract %float %1145 4
+OpStore %710 %1146
+%1147 = OpLoad %_arr_float_uint_8 %453
+%1148 = OpCompositeExtract %float %1147 4
+OpStore %711 %1148
+%1149 = OpLoad %float %710
+%1150 = OpLoad %float %711
+%1151 = OpFSub %float %1149 %1150
+OpStore %712 %1151
+%1152 = OpLoad %_arr_float_uint_8 %447
+%1153 = OpCompositeExtract %float %1152 5
+OpStore %713 %1153
+%1154 = OpLoad %_arr_float_uint_8 %453
+%1155 = OpCompositeExtract %float %1154 5
+OpStore %714 %1155
+%1156 = OpLoad %float %713
+%1157 = OpLoad %float %714
 %1158 = OpFSub %float %1156 %1157
-OpStore %623 %1158
-%1159 = OpLoad %_arr_float_uint_8 %146
-%1160 = OpCompositeExtract %float %1159 1
-OpStore %624 %1160
-%1161 = OpLoad %_arr_float_uint_8 %152
-%1162 = OpCompositeExtract %float %1161 1
-OpStore %625 %1162
-%1163 = OpLoad %float %624
-%1164 = OpLoad %float %625
+OpStore %715 %1158
+%1159 = OpLoad %_arr_float_uint_8 %447
+%1160 = OpCompositeExtract %float %1159 6
+OpStore %716 %1160
+%1161 = OpLoad %_arr_float_uint_8 %453
+%1162 = OpCompositeExtract %float %1161 6
+OpStore %717 %1162
+%1163 = OpLoad %float %716
+%1164 = OpLoad %float %717
 %1165 = OpFSub %float %1163 %1164
-OpStore %626 %1165
-%1166 = OpLoad %_arr_float_uint_8 %146
-%1167 = OpCompositeExtract %float %1166 2
-OpStore %627 %1167
-%1168 = OpLoad %_arr_float_uint_8 %152
-%1169 = OpCompositeExtract %float %1168 2
-OpStore %628 %1169
-%1170 = OpLoad %float %627
-%1171 = OpLoad %float %628
+OpStore %718 %1165
+%1166 = OpLoad %_arr_float_uint_8 %447
+%1167 = OpCompositeExtract %float %1166 7
+OpStore %719 %1167
+%1168 = OpLoad %_arr_float_uint_8 %453
+%1169 = OpCompositeExtract %float %1168 7
+OpStore %720 %1169
+%1170 = OpLoad %float %719
+%1171 = OpLoad %float %720
 %1172 = OpFSub %float %1170 %1171
-OpStore %629 %1172
-%1173 = OpLoad %_arr_float_uint_8 %146
-%1174 = OpCompositeExtract %float %1173 3
-OpStore %630 %1174
-%1175 = OpLoad %_arr_float_uint_8 %152
-%1176 = OpCompositeExtract %float %1175 3
-OpStore %631 %1176
-%1177 = OpLoad %float %630
-%1178 = OpLoad %float %631
-%1179 = OpFSub %float %1177 %1178
-OpStore %632 %1179
-%1180 = OpLoad %_arr_float_uint_8 %146
-%1181 = OpCompositeExtract %float %1180 4
-OpStore %633 %1181
-%1182 = OpLoad %_arr_float_uint_8 %152
-%1183 = OpCompositeExtract %float %1182 4
-OpStore %634 %1183
-%1184 = OpLoad %float %633
-%1185 = OpLoad %float %634
-%1186 = OpFSub %float %1184 %1185
-OpStore %635 %1186
-%1187 = OpLoad %_arr_float_uint_8 %146
-%1188 = OpCompositeExtract %float %1187 5
-OpStore %636 %1188
-%1189 = OpLoad %_arr_float_uint_8 %152
-%1190 = OpCompositeExtract %float %1189 5
-OpStore %637 %1190
-%1191 = OpLoad %float %636
-%1192 = OpLoad %float %637
-%1193 = OpFSub %float %1191 %1192
-OpStore %638 %1193
-%1194 = OpLoad %_arr_float_uint_8 %146
-%1195 = OpCompositeExtract %float %1194 6
-OpStore %639 %1195
-%1196 = OpLoad %_arr_float_uint_8 %152
-%1197 = OpCompositeExtract %float %1196 6
-OpStore %640 %1197
-%1198 = OpLoad %float %639
-%1199 = OpLoad %float %640
-%1200 = OpFSub %float %1198 %1199
-OpStore %641 %1200
-%1201 = OpLoad %_arr_float_uint_8 %146
-%1202 = OpCompositeExtract %float %1201 7
-OpStore %642 %1202
-%1203 = OpLoad %_arr_float_uint_8 %152
-%1204 = OpCompositeExtract %float %1203 7
-OpStore %643 %1204
-%1205 = OpLoad %float %642
-%1206 = OpLoad %float %643
-%1207 = OpFSub %float %1205 %1206
-OpStore %644 %1207
-%1208 = OpLoad %_arr_float_uint_8 %146
-%1209 = OpLoad %float %623
-%1210 = OpCompositeInsert %_arr_float_uint_8 %1209 %1208 0
-OpStore %645 %1210
-%1211 = OpLoad %_arr_float_uint_8 %645
-%1212 = OpLoad %float %626
-%1213 = OpCompositeInsert %_arr_float_uint_8 %1212 %1211 1
-OpStore %646 %1213
-%1214 = OpLoad %_arr_float_uint_8 %646
-%1215 = OpLoad %float %629
-%1216 = OpCompositeInsert %_arr_float_uint_8 %1215 %1214 2
-OpStore %647 %1216
-%1217 = OpLoad %_arr_float_uint_8 %647
-%1218 = OpLoad %float %632
-%1219 = OpCompositeInsert %_arr_float_uint_8 %1218 %1217 3
-OpStore %648 %1219
-%1220 = OpLoad %_arr_float_uint_8 %648
-%1221 = OpLoad %float %635
-%1222 = OpCompositeInsert %_arr_float_uint_8 %1221 %1220 4
-OpStore %649 %1222
-%1223 = OpLoad %_arr_float_uint_8 %649
-%1224 = OpLoad %float %638
-%1225 = OpCompositeInsert %_arr_float_uint_8 %1224 %1223 5
-OpStore %650 %1225
-%1226 = OpLoad %_arr_float_uint_8 %650
-%1227 = OpLoad %float %641
-%1228 = OpCompositeInsert %_arr_float_uint_8 %1227 %1226 6
-OpStore %651 %1228
-%1229 = OpLoad %_arr_float_uint_8 %651
-%1230 = OpLoad %float %644
-%1231 = OpCompositeInsert %_arr_float_uint_8 %1230 %1229 7
-OpStore %652 %1231
-OpBranch %102
-%102 = OpLabel
-%1232 = OpLoad %_arr_float_uint_8 %652
-%1233 = OpCompositeExtract %float %1232 0
-OpStore %301 %1233
-%1234 = OpLoad %ulong %284
-%1235 = OpLoad %float %301
-%1236 = OpFunctionCall %ulong %5 %1234 %1235
-OpStore %302 %1236
-%1237 = OpLoad %_arr_float_uint_8 %652
-%1238 = OpCompositeExtract %float %1237 1
-OpStore %303 %1238
-%1239 = OpLoad %ulong %302
-%1240 = OpLoad %float %303
-%1241 = OpFunctionCall %ulong %5 %1239 %1240
-OpStore %304 %1241
-%1242 = OpLoad %_arr_float_uint_8 %652
-%1243 = OpCompositeExtract %float %1242 2
-OpStore %305 %1243
-%1244 = OpLoad %ulong %304
-%1245 = OpLoad %float %305
-%1246 = OpFunctionCall %ulong %5 %1244 %1245
-OpStore %306 %1246
-%1247 = OpLoad %_arr_float_uint_8 %652
-%1248 = OpCompositeExtract %float %1247 3
-OpStore %307 %1248
-%1249 = OpLoad %ulong %306
-%1250 = OpLoad %float %307
-%1251 = OpFunctionCall %ulong %5 %1249 %1250
-OpStore %308 %1251
-%1252 = OpLoad %_arr_float_uint_8 %652
-%1253 = OpCompositeExtract %float %1252 4
-OpStore %309 %1253
-%1254 = OpLoad %ulong %308
-%1255 = OpLoad %float %309
-%1256 = OpFunctionCall %ulong %5 %1254 %1255
-OpStore %310 %1256
-%1257 = OpLoad %_arr_float_uint_8 %652
-%1258 = OpCompositeExtract %float %1257 5
-OpStore %311 %1258
-%1259 = OpLoad %ulong %310
-%1260 = OpLoad %float %311
-%1261 = OpFunctionCall %ulong %5 %1259 %1260
-OpStore %312 %1261
-%1262 = OpLoad %_arr_float_uint_8 %652
-%1263 = OpCompositeExtract %float %1262 6
-OpStore %313 %1263
-%1264 = OpLoad %ulong %312
-%1265 = OpLoad %float %313
-%1266 = OpFunctionCall %ulong %5 %1264 %1265
-OpStore %314 %1266
-%1267 = OpLoad %_arr_float_uint_8 %652
-%1268 = OpCompositeExtract %float %1267 7
-OpStore %315 %1268
-%1269 = OpLoad %ulong %314
-%1270 = OpLoad %float %315
-%1271 = OpFunctionCall %ulong %5 %1269 %1270
-OpStore %316 %1271
-OpBranch %103
-%103 = OpLabel
-%1272 = OpLoad %_arr_float_uint_8 %152
-%1273 = OpCompositeExtract %float %1272 0
-OpStore %653 %1273
-%1274 = OpLoad %_arr_float_uint_8 %146
-%1275 = OpCompositeExtract %float %1274 0
-OpStore %654 %1275
-%1276 = OpLoad %float %653
-%1277 = OpLoad %float %654
-%1278 = OpFSub %float %1276 %1277
-OpStore %655 %1278
-%1279 = OpLoad %_arr_float_uint_8 %152
-%1280 = OpCompositeExtract %float %1279 1
-OpStore %656 %1280
-%1281 = OpLoad %_arr_float_uint_8 %146
-%1282 = OpCompositeExtract %float %1281 1
-OpStore %657 %1282
-%1283 = OpLoad %float %656
-%1284 = OpLoad %float %657
-%1285 = OpFSub %float %1283 %1284
-OpStore %658 %1285
-%1286 = OpLoad %_arr_float_uint_8 %152
-%1287 = OpCompositeExtract %float %1286 2
-OpStore %659 %1287
-%1288 = OpLoad %_arr_float_uint_8 %146
-%1289 = OpCompositeExtract %float %1288 2
-OpStore %660 %1289
-%1290 = OpLoad %float %659
-%1291 = OpLoad %float %660
-%1292 = OpFSub %float %1290 %1291
-OpStore %661 %1292
-%1293 = OpLoad %_arr_float_uint_8 %152
-%1294 = OpCompositeExtract %float %1293 3
-OpStore %662 %1294
-%1295 = OpLoad %_arr_float_uint_8 %146
-%1296 = OpCompositeExtract %float %1295 3
-OpStore %663 %1296
-%1297 = OpLoad %float %662
-%1298 = OpLoad %float %663
-%1299 = OpFSub %float %1297 %1298
-OpStore %664 %1299
-%1300 = OpLoad %_arr_float_uint_8 %152
-%1301 = OpCompositeExtract %float %1300 4
-OpStore %665 %1301
-%1302 = OpLoad %_arr_float_uint_8 %146
-%1303 = OpCompositeExtract %float %1302 4
-OpStore %666 %1303
-%1304 = OpLoad %float %665
-%1305 = OpLoad %float %666
-%1306 = OpFSub %float %1304 %1305
-OpStore %667 %1306
-%1307 = OpLoad %_arr_float_uint_8 %152
-%1308 = OpCompositeExtract %float %1307 5
-OpStore %668 %1308
-%1309 = OpLoad %_arr_float_uint_8 %146
-%1310 = OpCompositeExtract %float %1309 5
-OpStore %669 %1310
-%1311 = OpLoad %float %668
-%1312 = OpLoad %float %669
-%1313 = OpFSub %float %1311 %1312
-OpStore %670 %1313
-%1314 = OpLoad %_arr_float_uint_8 %152
-%1315 = OpCompositeExtract %float %1314 6
-OpStore %671 %1315
-%1316 = OpLoad %_arr_float_uint_8 %146
-%1317 = OpCompositeExtract %float %1316 6
-OpStore %672 %1317
-%1318 = OpLoad %float %671
-%1319 = OpLoad %float %672
-%1320 = OpFSub %float %1318 %1319
-OpStore %673 %1320
-%1321 = OpLoad %_arr_float_uint_8 %152
-%1322 = OpCompositeExtract %float %1321 7
-OpStore %674 %1322
-%1323 = OpLoad %_arr_float_uint_8 %146
-%1324 = OpCompositeExtract %float %1323 7
-OpStore %675 %1324
-%1325 = OpLoad %float %674
-%1326 = OpLoad %float %675
-%1327 = OpFSub %float %1325 %1326
-OpStore %676 %1327
-%1328 = OpLoad %_arr_float_uint_8 %152
-%1329 = OpLoad %float %655
-%1330 = OpCompositeInsert %_arr_float_uint_8 %1329 %1328 0
-OpStore %677 %1330
-%1331 = OpLoad %_arr_float_uint_8 %677
-%1332 = OpLoad %float %658
-%1333 = OpCompositeInsert %_arr_float_uint_8 %1332 %1331 1
-OpStore %678 %1333
-%1334 = OpLoad %_arr_float_uint_8 %678
-%1335 = OpLoad %float %661
-%1336 = OpCompositeInsert %_arr_float_uint_8 %1335 %1334 2
-OpStore %679 %1336
-%1337 = OpLoad %_arr_float_uint_8 %679
-%1338 = OpLoad %float %664
-%1339 = OpCompositeInsert %_arr_float_uint_8 %1338 %1337 3
-OpStore %680 %1339
-%1340 = OpLoad %_arr_float_uint_8 %680
-%1341 = OpLoad %float %667
-%1342 = OpCompositeInsert %_arr_float_uint_8 %1341 %1340 4
-OpStore %681 %1342
-%1343 = OpLoad %_arr_float_uint_8 %681
-%1344 = OpLoad %float %670
-%1345 = OpCompositeInsert %_arr_float_uint_8 %1344 %1343 5
-OpStore %682 %1345
-%1346 = OpLoad %_arr_float_uint_8 %682
-%1347 = OpLoad %float %673
-%1348 = OpCompositeInsert %_arr_float_uint_8 %1347 %1346 6
-OpStore %683 %1348
-%1349 = OpLoad %_arr_float_uint_8 %683
-%1350 = OpLoad %float %676
-%1351 = OpCompositeInsert %_arr_float_uint_8 %1350 %1349 7
-OpStore %684 %1351
-OpBranch %104
-%104 = OpLabel
-%1352 = OpLoad %_arr_float_uint_8 %684
-%1353 = OpCompositeExtract %float %1352 0
-OpStore %317 %1353
-%1354 = OpLoad %ulong %316
-%1355 = OpLoad %float %317
-%1356 = OpFunctionCall %ulong %5 %1354 %1355
-OpStore %318 %1356
-%1357 = OpLoad %_arr_float_uint_8 %684
-%1358 = OpCompositeExtract %float %1357 1
-OpStore %319 %1358
-%1359 = OpLoad %ulong %318
-%1360 = OpLoad %float %319
-%1361 = OpFunctionCall %ulong %5 %1359 %1360
-OpStore %320 %1361
-%1362 = OpLoad %_arr_float_uint_8 %684
-%1363 = OpCompositeExtract %float %1362 2
-OpStore %321 %1363
-%1364 = OpLoad %ulong %320
-%1365 = OpLoad %float %321
-%1366 = OpFunctionCall %ulong %5 %1364 %1365
-OpStore %322 %1366
-%1367 = OpLoad %_arr_float_uint_8 %684
-%1368 = OpCompositeExtract %float %1367 3
-OpStore %323 %1368
-%1369 = OpLoad %ulong %322
-%1370 = OpLoad %float %323
-%1371 = OpFunctionCall %ulong %5 %1369 %1370
-OpStore %324 %1371
-%1372 = OpLoad %_arr_float_uint_8 %684
-%1373 = OpCompositeExtract %float %1372 4
-OpStore %325 %1373
-%1374 = OpLoad %ulong %324
-%1375 = OpLoad %float %325
-%1376 = OpFunctionCall %ulong %5 %1374 %1375
-OpStore %326 %1376
-%1377 = OpLoad %_arr_float_uint_8 %684
-%1378 = OpCompositeExtract %float %1377 5
-OpStore %327 %1378
-%1379 = OpLoad %ulong %326
-%1380 = OpLoad %float %327
-%1381 = OpFunctionCall %ulong %5 %1379 %1380
-OpStore %328 %1381
-%1382 = OpLoad %_arr_float_uint_8 %684
-%1383 = OpCompositeExtract %float %1382 6
-OpStore %329 %1383
-%1384 = OpLoad %ulong %328
-%1385 = OpLoad %float %329
-%1386 = OpFunctionCall %ulong %5 %1384 %1385
-OpStore %330 %1386
-%1387 = OpLoad %_arr_float_uint_8 %684
-%1388 = OpCompositeExtract %float %1387 7
-OpStore %331 %1388
-%1389 = OpLoad %ulong %330
-%1390 = OpLoad %float %331
-%1391 = OpFunctionCall %ulong %5 %1389 %1390
-OpStore %332 %1391
-OpBranch %105
-%105 = OpLabel
-%1392 = OpLoad %_arr_float_uint_8 %146
-%1393 = OpCompositeExtract %float %1392 0
-OpStore %685 %1393
-%1394 = OpLoad %_arr_float_uint_8 %152
-%1395 = OpCompositeExtract %float %1394 0
-OpStore %686 %1395
-%1396 = OpLoad %float %685
-%1397 = OpLoad %float %686
-%1398 = OpFMul %float %1396 %1397
-OpStore %687 %1398
-%1399 = OpLoad %_arr_float_uint_8 %146
-%1400 = OpCompositeExtract %float %1399 1
-OpStore %688 %1400
-%1401 = OpLoad %_arr_float_uint_8 %152
-%1402 = OpCompositeExtract %float %1401 1
-OpStore %689 %1402
-%1403 = OpLoad %float %688
-%1404 = OpLoad %float %689
-%1405 = OpFMul %float %1403 %1404
-OpStore %690 %1405
-%1406 = OpLoad %_arr_float_uint_8 %146
-%1407 = OpCompositeExtract %float %1406 2
-OpStore %691 %1407
-%1408 = OpLoad %_arr_float_uint_8 %152
-%1409 = OpCompositeExtract %float %1408 2
-OpStore %692 %1409
-%1410 = OpLoad %float %691
-%1411 = OpLoad %float %692
-%1412 = OpFMul %float %1410 %1411
-OpStore %693 %1412
-%1413 = OpLoad %_arr_float_uint_8 %146
-%1414 = OpCompositeExtract %float %1413 3
-OpStore %694 %1414
-%1415 = OpLoad %_arr_float_uint_8 %152
-%1416 = OpCompositeExtract %float %1415 3
-OpStore %695 %1416
-%1417 = OpLoad %float %694
-%1418 = OpLoad %float %695
-%1419 = OpFMul %float %1417 %1418
-OpStore %696 %1419
-%1420 = OpLoad %_arr_float_uint_8 %146
-%1421 = OpCompositeExtract %float %1420 4
-OpStore %697 %1421
-%1422 = OpLoad %_arr_float_uint_8 %152
-%1423 = OpCompositeExtract %float %1422 4
-OpStore %698 %1423
-%1424 = OpLoad %float %697
-%1425 = OpLoad %float %698
-%1426 = OpFMul %float %1424 %1425
-OpStore %699 %1426
-%1427 = OpLoad %_arr_float_uint_8 %146
-%1428 = OpCompositeExtract %float %1427 5
-OpStore %700 %1428
-%1429 = OpLoad %_arr_float_uint_8 %152
-%1430 = OpCompositeExtract %float %1429 5
-OpStore %701 %1430
-%1431 = OpLoad %float %700
-%1432 = OpLoad %float %701
-%1433 = OpFMul %float %1431 %1432
-OpStore %702 %1433
-%1434 = OpLoad %_arr_float_uint_8 %146
-%1435 = OpCompositeExtract %float %1434 6
-OpStore %703 %1435
-%1436 = OpLoad %_arr_float_uint_8 %152
-%1437 = OpCompositeExtract %float %1436 6
-OpStore %704 %1437
-%1438 = OpLoad %float %703
-%1439 = OpLoad %float %704
-%1440 = OpFMul %float %1438 %1439
-OpStore %705 %1440
-%1441 = OpLoad %_arr_float_uint_8 %146
-%1442 = OpCompositeExtract %float %1441 7
-OpStore %706 %1442
-%1443 = OpLoad %_arr_float_uint_8 %152
-%1444 = OpCompositeExtract %float %1443 7
-OpStore %707 %1444
-%1445 = OpLoad %float %706
-%1446 = OpLoad %float %707
-%1447 = OpFMul %float %1445 %1446
-OpStore %708 %1447
-%1448 = OpLoad %_arr_float_uint_8 %146
-%1449 = OpLoad %float %687
-%1450 = OpCompositeInsert %_arr_float_uint_8 %1449 %1448 0
-OpStore %709 %1450
-%1451 = OpLoad %_arr_float_uint_8 %709
-%1452 = OpLoad %float %690
-%1453 = OpCompositeInsert %_arr_float_uint_8 %1452 %1451 1
-OpStore %710 %1453
-%1454 = OpLoad %_arr_float_uint_8 %710
-%1455 = OpLoad %float %693
-%1456 = OpCompositeInsert %_arr_float_uint_8 %1455 %1454 2
-OpStore %711 %1456
-%1457 = OpLoad %_arr_float_uint_8 %711
-%1458 = OpLoad %float %696
-%1459 = OpCompositeInsert %_arr_float_uint_8 %1458 %1457 3
-OpStore %712 %1459
-%1460 = OpLoad %_arr_float_uint_8 %712
-%1461 = OpLoad %float %699
-%1462 = OpCompositeInsert %_arr_float_uint_8 %1461 %1460 4
-OpStore %713 %1462
-%1463 = OpLoad %_arr_float_uint_8 %713
-%1464 = OpLoad %float %702
-%1465 = OpCompositeInsert %_arr_float_uint_8 %1464 %1463 5
-OpStore %714 %1465
-%1466 = OpLoad %_arr_float_uint_8 %714
-%1467 = OpLoad %float %705
-%1468 = OpCompositeInsert %_arr_float_uint_8 %1467 %1466 6
-OpStore %715 %1468
-%1469 = OpLoad %_arr_float_uint_8 %715
-%1470 = OpLoad %float %708
-%1471 = OpCompositeInsert %_arr_float_uint_8 %1470 %1469 7
-OpStore %716 %1471
-OpBranch %106
-%106 = OpLabel
-%1472 = OpLoad %_arr_float_uint_8 %716
-%1473 = OpCompositeExtract %float %1472 0
-OpStore %333 %1473
-%1474 = OpLoad %ulong %332
-%1475 = OpLoad %float %333
-%1476 = OpFunctionCall %ulong %5 %1474 %1475
-OpStore %334 %1476
-%1477 = OpLoad %_arr_float_uint_8 %716
-%1478 = OpCompositeExtract %float %1477 1
-OpStore %335 %1478
-%1479 = OpLoad %ulong %334
-%1480 = OpLoad %float %335
-%1481 = OpFunctionCall %ulong %5 %1479 %1480
-OpStore %336 %1481
-%1482 = OpLoad %_arr_float_uint_8 %716
-%1483 = OpCompositeExtract %float %1482 2
-OpStore %337 %1483
-%1484 = OpLoad %ulong %336
-%1485 = OpLoad %float %337
-%1486 = OpFunctionCall %ulong %5 %1484 %1485
-OpStore %338 %1486
-%1487 = OpLoad %_arr_float_uint_8 %716
-%1488 = OpCompositeExtract %float %1487 3
-OpStore %339 %1488
-%1489 = OpLoad %ulong %338
-%1490 = OpLoad %float %339
-%1491 = OpFunctionCall %ulong %5 %1489 %1490
-OpStore %340 %1491
-%1492 = OpLoad %_arr_float_uint_8 %716
-%1493 = OpCompositeExtract %float %1492 4
-OpStore %341 %1493
-%1494 = OpLoad %ulong %340
-%1495 = OpLoad %float %341
-%1496 = OpFunctionCall %ulong %5 %1494 %1495
-OpStore %342 %1496
-%1497 = OpLoad %_arr_float_uint_8 %716
-%1498 = OpCompositeExtract %float %1497 5
-OpStore %343 %1498
-%1499 = OpLoad %ulong %342
-%1500 = OpLoad %float %343
-%1501 = OpFunctionCall %ulong %5 %1499 %1500
-OpStore %344 %1501
-%1502 = OpLoad %_arr_float_uint_8 %716
-%1503 = OpCompositeExtract %float %1502 6
-OpStore %345 %1503
-%1504 = OpLoad %ulong %344
-%1505 = OpLoad %float %345
-%1506 = OpFunctionCall %ulong %5 %1504 %1505
-OpStore %346 %1506
-%1507 = OpLoad %_arr_float_uint_8 %716
-%1508 = OpCompositeExtract %float %1507 7
-OpStore %347 %1508
-%1509 = OpLoad %ulong %346
-%1510 = OpLoad %float %347
-%1511 = OpFunctionCall %ulong %5 %1509 %1510
-OpStore %348 %1511
-OpBranch %107
-%107 = OpLabel
-%1512 = OpLoad %_arr_float_uint_8 %146
-%1513 = OpCompositeExtract %float %1512 0
-OpStore %717 %1513
-%1514 = OpLoad %_arr_float_uint_8 %152
-%1515 = OpCompositeExtract %float %1514 0
-OpStore %718 %1515
-%1516 = OpLoad %float %717
-%1517 = OpLoad %float %718
-%1518 = OpFDiv %float %1516 %1517
-OpStore %719 %1518
-%1519 = OpLoad %_arr_float_uint_8 %146
-%1520 = OpCompositeExtract %float %1519 1
-OpStore %720 %1520
-%1521 = OpLoad %_arr_float_uint_8 %152
-%1522 = OpCompositeExtract %float %1521 1
-OpStore %721 %1522
-%1523 = OpLoad %float %720
-%1524 = OpLoad %float %721
-%1525 = OpFDiv %float %1523 %1524
-OpStore %722 %1525
-%1526 = OpLoad %_arr_float_uint_8 %146
-%1527 = OpCompositeExtract %float %1526 2
-OpStore %723 %1527
-%1528 = OpLoad %_arr_float_uint_8 %152
-%1529 = OpCompositeExtract %float %1528 2
-OpStore %724 %1529
-%1530 = OpLoad %float %723
-%1531 = OpLoad %float %724
-%1532 = OpFDiv %float %1530 %1531
-OpStore %725 %1532
-%1533 = OpLoad %_arr_float_uint_8 %146
-%1534 = OpCompositeExtract %float %1533 3
-OpStore %726 %1534
-%1535 = OpLoad %_arr_float_uint_8 %152
-%1536 = OpCompositeExtract %float %1535 3
-OpStore %727 %1536
-%1537 = OpLoad %float %726
-%1538 = OpLoad %float %727
-%1539 = OpFDiv %float %1537 %1538
-OpStore %728 %1539
-%1540 = OpLoad %_arr_float_uint_8 %146
-%1541 = OpCompositeExtract %float %1540 4
-OpStore %729 %1541
-%1542 = OpLoad %_arr_float_uint_8 %152
-%1543 = OpCompositeExtract %float %1542 4
-OpStore %730 %1543
-%1544 = OpLoad %float %729
-%1545 = OpLoad %float %730
-%1546 = OpFDiv %float %1544 %1545
-OpStore %731 %1546
-%1547 = OpLoad %_arr_float_uint_8 %146
-%1548 = OpCompositeExtract %float %1547 5
-OpStore %732 %1548
-%1549 = OpLoad %_arr_float_uint_8 %152
-%1550 = OpCompositeExtract %float %1549 5
-OpStore %733 %1550
-%1551 = OpLoad %float %732
-%1552 = OpLoad %float %733
-%1553 = OpFDiv %float %1551 %1552
-OpStore %734 %1553
-%1554 = OpLoad %_arr_float_uint_8 %146
-%1555 = OpCompositeExtract %float %1554 6
-OpStore %735 %1555
-%1556 = OpLoad %_arr_float_uint_8 %152
-%1557 = OpCompositeExtract %float %1556 6
-OpStore %736 %1557
-%1558 = OpLoad %float %735
-%1559 = OpLoad %float %736
-%1560 = OpFDiv %float %1558 %1559
-OpStore %737 %1560
-%1561 = OpLoad %_arr_float_uint_8 %146
-%1562 = OpCompositeExtract %float %1561 7
-OpStore %738 %1562
-%1563 = OpLoad %_arr_float_uint_8 %152
-%1564 = OpCompositeExtract %float %1563 7
-OpStore %739 %1564
-%1565 = OpLoad %float %738
-%1566 = OpLoad %float %739
-%1567 = OpFDiv %float %1565 %1566
-OpStore %740 %1567
-%1568 = OpLoad %_arr_float_uint_8 %146
-%1569 = OpLoad %float %719
-%1570 = OpCompositeInsert %_arr_float_uint_8 %1569 %1568 0
-OpStore %741 %1570
-%1571 = OpLoad %_arr_float_uint_8 %741
-%1572 = OpLoad %float %722
-%1573 = OpCompositeInsert %_arr_float_uint_8 %1572 %1571 1
-OpStore %742 %1573
-%1574 = OpLoad %_arr_float_uint_8 %742
-%1575 = OpLoad %float %725
-%1576 = OpCompositeInsert %_arr_float_uint_8 %1575 %1574 2
-OpStore %743 %1576
-%1577 = OpLoad %_arr_float_uint_8 %743
-%1578 = OpLoad %float %728
-%1579 = OpCompositeInsert %_arr_float_uint_8 %1578 %1577 3
-OpStore %744 %1579
-%1580 = OpLoad %_arr_float_uint_8 %744
-%1581 = OpLoad %float %731
-%1582 = OpCompositeInsert %_arr_float_uint_8 %1581 %1580 4
-OpStore %745 %1582
-%1583 = OpLoad %_arr_float_uint_8 %745
-%1584 = OpLoad %float %734
-%1585 = OpCompositeInsert %_arr_float_uint_8 %1584 %1583 5
-OpStore %746 %1585
-%1586 = OpLoad %_arr_float_uint_8 %746
-%1587 = OpLoad %float %737
-%1588 = OpCompositeInsert %_arr_float_uint_8 %1587 %1586 6
-OpStore %747 %1588
-%1589 = OpLoad %_arr_float_uint_8 %747
-%1590 = OpLoad %float %740
-%1591 = OpCompositeInsert %_arr_float_uint_8 %1590 %1589 7
-OpStore %748 %1591
-OpBranch %108
-%108 = OpLabel
-%1592 = OpLoad %_arr_float_uint_8 %748
-%1593 = OpCompositeExtract %float %1592 0
-OpStore %349 %1593
-%1594 = OpLoad %ulong %348
-%1595 = OpLoad %float %349
-%1596 = OpFunctionCall %ulong %5 %1594 %1595
-OpStore %350 %1596
-%1597 = OpLoad %_arr_float_uint_8 %748
-%1598 = OpCompositeExtract %float %1597 1
-OpStore %351 %1598
-%1599 = OpLoad %ulong %350
-%1600 = OpLoad %float %351
-%1601 = OpFunctionCall %ulong %5 %1599 %1600
-OpStore %352 %1601
-%1602 = OpLoad %_arr_float_uint_8 %748
-%1603 = OpCompositeExtract %float %1602 2
-OpStore %353 %1603
-%1604 = OpLoad %ulong %352
-%1605 = OpLoad %float %353
-%1606 = OpFunctionCall %ulong %5 %1604 %1605
-OpStore %354 %1606
-%1607 = OpLoad %_arr_float_uint_8 %748
-%1608 = OpCompositeExtract %float %1607 3
-OpStore %355 %1608
-%1609 = OpLoad %ulong %354
-%1610 = OpLoad %float %355
-%1611 = OpFunctionCall %ulong %5 %1609 %1610
-OpStore %356 %1611
-%1612 = OpLoad %_arr_float_uint_8 %748
-%1613 = OpCompositeExtract %float %1612 4
-OpStore %357 %1613
-%1614 = OpLoad %ulong %356
-%1615 = OpLoad %float %357
-%1616 = OpFunctionCall %ulong %5 %1614 %1615
-OpStore %358 %1616
-%1617 = OpLoad %_arr_float_uint_8 %748
-%1618 = OpCompositeExtract %float %1617 5
-OpStore %359 %1618
-%1619 = OpLoad %ulong %358
-%1620 = OpLoad %float %359
-%1621 = OpFunctionCall %ulong %5 %1619 %1620
-OpStore %360 %1621
-%1622 = OpLoad %_arr_float_uint_8 %748
-%1623 = OpCompositeExtract %float %1622 6
-OpStore %361 %1623
-%1624 = OpLoad %ulong %360
-%1625 = OpLoad %float %361
-%1626 = OpFunctionCall %ulong %5 %1624 %1625
-OpStore %362 %1626
-%1627 = OpLoad %_arr_float_uint_8 %748
-%1628 = OpCompositeExtract %float %1627 7
-OpStore %363 %1628
-%1629 = OpLoad %ulong %362
-%1630 = OpLoad %float %363
-%1631 = OpFunctionCall %ulong %5 %1629 %1630
-OpStore %364 %1631
-OpBranch %109
-%109 = OpLabel
-%1632 = OpLoad %_arr_float_uint_8 %152
-%1633 = OpCompositeExtract %float %1632 0
-OpStore %749 %1633
-%1634 = OpLoad %_arr_float_uint_8 %146
-%1635 = OpCompositeExtract %float %1634 0
-OpStore %750 %1635
-%1636 = OpLoad %float %749
-%1637 = OpLoad %float %750
-%1638 = OpFDiv %float %1636 %1637
-OpStore %751 %1638
-%1639 = OpLoad %_arr_float_uint_8 %152
-%1640 = OpCompositeExtract %float %1639 1
-OpStore %752 %1640
-%1641 = OpLoad %_arr_float_uint_8 %146
-%1642 = OpCompositeExtract %float %1641 1
-OpStore %753 %1642
-%1643 = OpLoad %float %752
-%1644 = OpLoad %float %753
-%1645 = OpFDiv %float %1643 %1644
-OpStore %754 %1645
-%1646 = OpLoad %_arr_float_uint_8 %152
-%1647 = OpCompositeExtract %float %1646 2
-OpStore %755 %1647
-%1648 = OpLoad %_arr_float_uint_8 %146
-%1649 = OpCompositeExtract %float %1648 2
-OpStore %756 %1649
-%1650 = OpLoad %float %755
-%1651 = OpLoad %float %756
-%1652 = OpFDiv %float %1650 %1651
-OpStore %757 %1652
-%1653 = OpLoad %_arr_float_uint_8 %152
-%1654 = OpCompositeExtract %float %1653 3
-OpStore %758 %1654
-%1655 = OpLoad %_arr_float_uint_8 %146
-%1656 = OpCompositeExtract %float %1655 3
-OpStore %759 %1656
-%1657 = OpLoad %float %758
-%1658 = OpLoad %float %759
-%1659 = OpFDiv %float %1657 %1658
-OpStore %760 %1659
-%1660 = OpLoad %_arr_float_uint_8 %152
-%1661 = OpCompositeExtract %float %1660 4
-OpStore %761 %1661
-%1662 = OpLoad %_arr_float_uint_8 %146
-%1663 = OpCompositeExtract %float %1662 4
-OpStore %762 %1663
-%1664 = OpLoad %float %761
-%1665 = OpLoad %float %762
-%1666 = OpFDiv %float %1664 %1665
-OpStore %763 %1666
-%1667 = OpLoad %_arr_float_uint_8 %152
-%1668 = OpCompositeExtract %float %1667 5
-OpStore %764 %1668
-%1669 = OpLoad %_arr_float_uint_8 %146
-%1670 = OpCompositeExtract %float %1669 5
-OpStore %765 %1670
-%1671 = OpLoad %float %764
-%1672 = OpLoad %float %765
-%1673 = OpFDiv %float %1671 %1672
-OpStore %766 %1673
-%1674 = OpLoad %_arr_float_uint_8 %152
-%1675 = OpCompositeExtract %float %1674 6
-OpStore %767 %1675
-%1676 = OpLoad %_arr_float_uint_8 %146
-%1677 = OpCompositeExtract %float %1676 6
-OpStore %768 %1677
-%1678 = OpLoad %float %767
-%1679 = OpLoad %float %768
-%1680 = OpFDiv %float %1678 %1679
-OpStore %769 %1680
-%1681 = OpLoad %_arr_float_uint_8 %152
-%1682 = OpCompositeExtract %float %1681 7
-OpStore %770 %1682
-%1683 = OpLoad %_arr_float_uint_8 %146
-%1684 = OpCompositeExtract %float %1683 7
-OpStore %771 %1684
-%1685 = OpLoad %float %770
-%1686 = OpLoad %float %771
-%1687 = OpFDiv %float %1685 %1686
-OpStore %772 %1687
-%1688 = OpLoad %_arr_float_uint_8 %152
-%1689 = OpLoad %float %751
-%1690 = OpCompositeInsert %_arr_float_uint_8 %1689 %1688 0
-OpStore %773 %1690
-%1691 = OpLoad %_arr_float_uint_8 %773
-%1692 = OpLoad %float %754
-%1693 = OpCompositeInsert %_arr_float_uint_8 %1692 %1691 1
-OpStore %774 %1693
-%1694 = OpLoad %_arr_float_uint_8 %774
-%1695 = OpLoad %float %757
-%1696 = OpCompositeInsert %_arr_float_uint_8 %1695 %1694 2
-OpStore %775 %1696
-%1697 = OpLoad %_arr_float_uint_8 %775
-%1698 = OpLoad %float %760
-%1699 = OpCompositeInsert %_arr_float_uint_8 %1698 %1697 3
-OpStore %776 %1699
-%1700 = OpLoad %_arr_float_uint_8 %776
-%1701 = OpLoad %float %763
-%1702 = OpCompositeInsert %_arr_float_uint_8 %1701 %1700 4
-OpStore %777 %1702
-%1703 = OpLoad %_arr_float_uint_8 %777
-%1704 = OpLoad %float %766
-%1705 = OpCompositeInsert %_arr_float_uint_8 %1704 %1703 5
-OpStore %778 %1705
-%1706 = OpLoad %_arr_float_uint_8 %778
-%1707 = OpLoad %float %769
-%1708 = OpCompositeInsert %_arr_float_uint_8 %1707 %1706 6
-OpStore %779 %1708
-%1709 = OpLoad %_arr_float_uint_8 %779
-%1710 = OpLoad %float %772
-%1711 = OpCompositeInsert %_arr_float_uint_8 %1710 %1709 7
-OpStore %780 %1711
-OpBranch %110
-%110 = OpLabel
-%1712 = OpLoad %_arr_float_uint_8 %780
-%1713 = OpCompositeExtract %float %1712 0
-OpStore %365 %1713
-%1714 = OpLoad %ulong %364
-%1715 = OpLoad %float %365
-%1716 = OpFunctionCall %ulong %5 %1714 %1715
-OpStore %366 %1716
-%1717 = OpLoad %_arr_float_uint_8 %780
-%1718 = OpCompositeExtract %float %1717 1
-OpStore %367 %1718
-%1719 = OpLoad %ulong %366
-%1720 = OpLoad %float %367
-%1721 = OpFunctionCall %ulong %5 %1719 %1720
-OpStore %368 %1721
-%1722 = OpLoad %_arr_float_uint_8 %780
-%1723 = OpCompositeExtract %float %1722 2
-OpStore %369 %1723
-%1724 = OpLoad %ulong %368
-%1725 = OpLoad %float %369
-%1726 = OpFunctionCall %ulong %5 %1724 %1725
-OpStore %370 %1726
-%1727 = OpLoad %_arr_float_uint_8 %780
-%1728 = OpCompositeExtract %float %1727 3
-OpStore %371 %1728
-%1729 = OpLoad %ulong %370
-%1730 = OpLoad %float %371
-%1731 = OpFunctionCall %ulong %5 %1729 %1730
-OpStore %372 %1731
-%1732 = OpLoad %_arr_float_uint_8 %780
-%1733 = OpCompositeExtract %float %1732 4
-OpStore %373 %1733
-%1734 = OpLoad %ulong %372
-%1735 = OpLoad %float %373
-%1736 = OpFunctionCall %ulong %5 %1734 %1735
-OpStore %374 %1736
-%1737 = OpLoad %_arr_float_uint_8 %780
-%1738 = OpCompositeExtract %float %1737 5
-OpStore %375 %1738
-%1739 = OpLoad %ulong %374
-%1740 = OpLoad %float %375
-%1741 = OpFunctionCall %ulong %5 %1739 %1740
-OpStore %376 %1741
-%1742 = OpLoad %_arr_float_uint_8 %780
+OpStore %721 %1172
+%1173 = OpLoad %_arr_float_uint_8 %447
+%1174 = OpLoad %float %700
+%1175 = OpCompositeInsert %_arr_float_uint_8 %1174 %1173 0
+OpStore %722 %1175
+%1176 = OpLoad %_arr_float_uint_8 %722
+%1177 = OpLoad %float %703
+%1178 = OpCompositeInsert %_arr_float_uint_8 %1177 %1176 1
+OpStore %723 %1178
+%1179 = OpLoad %_arr_float_uint_8 %723
+%1180 = OpLoad %float %706
+%1181 = OpCompositeInsert %_arr_float_uint_8 %1180 %1179 2
+OpStore %724 %1181
+%1182 = OpLoad %_arr_float_uint_8 %724
+%1183 = OpLoad %float %709
+%1184 = OpCompositeInsert %_arr_float_uint_8 %1183 %1182 3
+OpStore %725 %1184
+%1185 = OpLoad %_arr_float_uint_8 %725
+%1186 = OpLoad %float %712
+%1187 = OpCompositeInsert %_arr_float_uint_8 %1186 %1185 4
+OpStore %726 %1187
+%1188 = OpLoad %_arr_float_uint_8 %726
+%1189 = OpLoad %float %715
+%1190 = OpCompositeInsert %_arr_float_uint_8 %1189 %1188 5
+OpStore %727 %1190
+%1191 = OpLoad %_arr_float_uint_8 %727
+%1192 = OpLoad %float %718
+%1193 = OpCompositeInsert %_arr_float_uint_8 %1192 %1191 6
+OpStore %728 %1193
+%1194 = OpLoad %_arr_float_uint_8 %728
+%1195 = OpLoad %float %721
+%1196 = OpCompositeInsert %_arr_float_uint_8 %1195 %1194 7
+OpStore %729 %1196
+%1197 = OpLoad %ulong %456
+%1198 = OpLoad %_arr_float_uint_8 %729
+%1199 = OpFunctionCall %ulong %1 %1197 %1198
+OpStore %457 %1199
+%1200 = OpLoad %_arr_float_uint_8 %453
+%1201 = OpCompositeExtract %float %1200 0
+OpStore %730 %1201
+%1202 = OpLoad %_arr_float_uint_8 %447
+%1203 = OpCompositeExtract %float %1202 0
+OpStore %731 %1203
+%1204 = OpLoad %float %730
+%1205 = OpLoad %float %731
+%1206 = OpFSub %float %1204 %1205
+OpStore %732 %1206
+%1207 = OpLoad %_arr_float_uint_8 %453
+%1208 = OpCompositeExtract %float %1207 1
+OpStore %733 %1208
+%1209 = OpLoad %_arr_float_uint_8 %447
+%1210 = OpCompositeExtract %float %1209 1
+OpStore %734 %1210
+%1211 = OpLoad %float %733
+%1212 = OpLoad %float %734
+%1213 = OpFSub %float %1211 %1212
+OpStore %735 %1213
+%1214 = OpLoad %_arr_float_uint_8 %453
+%1215 = OpCompositeExtract %float %1214 2
+OpStore %736 %1215
+%1216 = OpLoad %_arr_float_uint_8 %447
+%1217 = OpCompositeExtract %float %1216 2
+OpStore %737 %1217
+%1218 = OpLoad %float %736
+%1219 = OpLoad %float %737
+%1220 = OpFSub %float %1218 %1219
+OpStore %738 %1220
+%1221 = OpLoad %_arr_float_uint_8 %453
+%1222 = OpCompositeExtract %float %1221 3
+OpStore %739 %1222
+%1223 = OpLoad %_arr_float_uint_8 %447
+%1224 = OpCompositeExtract %float %1223 3
+OpStore %740 %1224
+%1225 = OpLoad %float %739
+%1226 = OpLoad %float %740
+%1227 = OpFSub %float %1225 %1226
+OpStore %741 %1227
+%1228 = OpLoad %_arr_float_uint_8 %453
+%1229 = OpCompositeExtract %float %1228 4
+OpStore %742 %1229
+%1230 = OpLoad %_arr_float_uint_8 %447
+%1231 = OpCompositeExtract %float %1230 4
+OpStore %743 %1231
+%1232 = OpLoad %float %742
+%1233 = OpLoad %float %743
+%1234 = OpFSub %float %1232 %1233
+OpStore %744 %1234
+%1235 = OpLoad %_arr_float_uint_8 %453
+%1236 = OpCompositeExtract %float %1235 5
+OpStore %745 %1236
+%1237 = OpLoad %_arr_float_uint_8 %447
+%1238 = OpCompositeExtract %float %1237 5
+OpStore %746 %1238
+%1239 = OpLoad %float %745
+%1240 = OpLoad %float %746
+%1241 = OpFSub %float %1239 %1240
+OpStore %747 %1241
+%1242 = OpLoad %_arr_float_uint_8 %453
+%1243 = OpCompositeExtract %float %1242 6
+OpStore %748 %1243
+%1244 = OpLoad %_arr_float_uint_8 %447
+%1245 = OpCompositeExtract %float %1244 6
+OpStore %749 %1245
+%1246 = OpLoad %float %748
+%1247 = OpLoad %float %749
+%1248 = OpFSub %float %1246 %1247
+OpStore %750 %1248
+%1249 = OpLoad %_arr_float_uint_8 %453
+%1250 = OpCompositeExtract %float %1249 7
+OpStore %751 %1250
+%1251 = OpLoad %_arr_float_uint_8 %447
+%1252 = OpCompositeExtract %float %1251 7
+OpStore %752 %1252
+%1253 = OpLoad %float %751
+%1254 = OpLoad %float %752
+%1255 = OpFSub %float %1253 %1254
+OpStore %753 %1255
+%1256 = OpLoad %_arr_float_uint_8 %453
+%1257 = OpLoad %float %732
+%1258 = OpCompositeInsert %_arr_float_uint_8 %1257 %1256 0
+OpStore %754 %1258
+%1259 = OpLoad %_arr_float_uint_8 %754
+%1260 = OpLoad %float %735
+%1261 = OpCompositeInsert %_arr_float_uint_8 %1260 %1259 1
+OpStore %755 %1261
+%1262 = OpLoad %_arr_float_uint_8 %755
+%1263 = OpLoad %float %738
+%1264 = OpCompositeInsert %_arr_float_uint_8 %1263 %1262 2
+OpStore %756 %1264
+%1265 = OpLoad %_arr_float_uint_8 %756
+%1266 = OpLoad %float %741
+%1267 = OpCompositeInsert %_arr_float_uint_8 %1266 %1265 3
+OpStore %757 %1267
+%1268 = OpLoad %_arr_float_uint_8 %757
+%1269 = OpLoad %float %744
+%1270 = OpCompositeInsert %_arr_float_uint_8 %1269 %1268 4
+OpStore %758 %1270
+%1271 = OpLoad %_arr_float_uint_8 %758
+%1272 = OpLoad %float %747
+%1273 = OpCompositeInsert %_arr_float_uint_8 %1272 %1271 5
+OpStore %759 %1273
+%1274 = OpLoad %_arr_float_uint_8 %759
+%1275 = OpLoad %float %750
+%1276 = OpCompositeInsert %_arr_float_uint_8 %1275 %1274 6
+OpStore %760 %1276
+%1277 = OpLoad %_arr_float_uint_8 %760
+%1278 = OpLoad %float %753
+%1279 = OpCompositeInsert %_arr_float_uint_8 %1278 %1277 7
+OpStore %761 %1279
+%1280 = OpLoad %ulong %457
+%1281 = OpLoad %_arr_float_uint_8 %761
+%1282 = OpFunctionCall %ulong %1 %1280 %1281
+OpStore %458 %1282
+%1283 = OpLoad %_arr_float_uint_8 %447
+%1284 = OpCompositeExtract %float %1283 0
+OpStore %762 %1284
+%1285 = OpLoad %_arr_float_uint_8 %453
+%1286 = OpCompositeExtract %float %1285 0
+OpStore %763 %1286
+%1287 = OpLoad %float %762
+%1288 = OpLoad %float %763
+%1289 = OpFMul %float %1287 %1288
+OpStore %764 %1289
+%1290 = OpLoad %_arr_float_uint_8 %447
+%1291 = OpCompositeExtract %float %1290 1
+OpStore %765 %1291
+%1292 = OpLoad %_arr_float_uint_8 %453
+%1293 = OpCompositeExtract %float %1292 1
+OpStore %766 %1293
+%1294 = OpLoad %float %765
+%1295 = OpLoad %float %766
+%1296 = OpFMul %float %1294 %1295
+OpStore %767 %1296
+%1297 = OpLoad %_arr_float_uint_8 %447
+%1298 = OpCompositeExtract %float %1297 2
+OpStore %768 %1298
+%1299 = OpLoad %_arr_float_uint_8 %453
+%1300 = OpCompositeExtract %float %1299 2
+OpStore %769 %1300
+%1301 = OpLoad %float %768
+%1302 = OpLoad %float %769
+%1303 = OpFMul %float %1301 %1302
+OpStore %770 %1303
+%1304 = OpLoad %_arr_float_uint_8 %447
+%1305 = OpCompositeExtract %float %1304 3
+OpStore %771 %1305
+%1306 = OpLoad %_arr_float_uint_8 %453
+%1307 = OpCompositeExtract %float %1306 3
+OpStore %772 %1307
+%1308 = OpLoad %float %771
+%1309 = OpLoad %float %772
+%1310 = OpFMul %float %1308 %1309
+OpStore %773 %1310
+%1311 = OpLoad %_arr_float_uint_8 %447
+%1312 = OpCompositeExtract %float %1311 4
+OpStore %774 %1312
+%1313 = OpLoad %_arr_float_uint_8 %453
+%1314 = OpCompositeExtract %float %1313 4
+OpStore %775 %1314
+%1315 = OpLoad %float %774
+%1316 = OpLoad %float %775
+%1317 = OpFMul %float %1315 %1316
+OpStore %776 %1317
+%1318 = OpLoad %_arr_float_uint_8 %447
+%1319 = OpCompositeExtract %float %1318 5
+OpStore %777 %1319
+%1320 = OpLoad %_arr_float_uint_8 %453
+%1321 = OpCompositeExtract %float %1320 5
+OpStore %778 %1321
+%1322 = OpLoad %float %777
+%1323 = OpLoad %float %778
+%1324 = OpFMul %float %1322 %1323
+OpStore %779 %1324
+%1325 = OpLoad %_arr_float_uint_8 %447
+%1326 = OpCompositeExtract %float %1325 6
+OpStore %780 %1326
+%1327 = OpLoad %_arr_float_uint_8 %453
+%1328 = OpCompositeExtract %float %1327 6
+OpStore %781 %1328
+%1329 = OpLoad %float %780
+%1330 = OpLoad %float %781
+%1331 = OpFMul %float %1329 %1330
+OpStore %782 %1331
+%1332 = OpLoad %_arr_float_uint_8 %447
+%1333 = OpCompositeExtract %float %1332 7
+OpStore %783 %1333
+%1334 = OpLoad %_arr_float_uint_8 %453
+%1335 = OpCompositeExtract %float %1334 7
+OpStore %784 %1335
+%1336 = OpLoad %float %783
+%1337 = OpLoad %float %784
+%1338 = OpFMul %float %1336 %1337
+OpStore %785 %1338
+%1339 = OpLoad %_arr_float_uint_8 %447
+%1340 = OpLoad %float %764
+%1341 = OpCompositeInsert %_arr_float_uint_8 %1340 %1339 0
+OpStore %786 %1341
+%1342 = OpLoad %_arr_float_uint_8 %786
+%1343 = OpLoad %float %767
+%1344 = OpCompositeInsert %_arr_float_uint_8 %1343 %1342 1
+OpStore %787 %1344
+%1345 = OpLoad %_arr_float_uint_8 %787
+%1346 = OpLoad %float %770
+%1347 = OpCompositeInsert %_arr_float_uint_8 %1346 %1345 2
+OpStore %788 %1347
+%1348 = OpLoad %_arr_float_uint_8 %788
+%1349 = OpLoad %float %773
+%1350 = OpCompositeInsert %_arr_float_uint_8 %1349 %1348 3
+OpStore %789 %1350
+%1351 = OpLoad %_arr_float_uint_8 %789
+%1352 = OpLoad %float %776
+%1353 = OpCompositeInsert %_arr_float_uint_8 %1352 %1351 4
+OpStore %790 %1353
+%1354 = OpLoad %_arr_float_uint_8 %790
+%1355 = OpLoad %float %779
+%1356 = OpCompositeInsert %_arr_float_uint_8 %1355 %1354 5
+OpStore %791 %1356
+%1357 = OpLoad %_arr_float_uint_8 %791
+%1358 = OpLoad %float %782
+%1359 = OpCompositeInsert %_arr_float_uint_8 %1358 %1357 6
+OpStore %792 %1359
+%1360 = OpLoad %_arr_float_uint_8 %792
+%1361 = OpLoad %float %785
+%1362 = OpCompositeInsert %_arr_float_uint_8 %1361 %1360 7
+OpStore %793 %1362
+%1363 = OpLoad %ulong %458
+%1364 = OpLoad %_arr_float_uint_8 %793
+%1365 = OpFunctionCall %ulong %1 %1363 %1364
+OpStore %459 %1365
+%1366 = OpLoad %_arr_float_uint_8 %447
+%1367 = OpCompositeExtract %float %1366 0
+OpStore %794 %1367
+%1368 = OpLoad %_arr_float_uint_8 %453
+%1369 = OpCompositeExtract %float %1368 0
+OpStore %795 %1369
+%1370 = OpLoad %float %794
+%1371 = OpLoad %float %795
+%1372 = OpFDiv %float %1370 %1371
+OpStore %796 %1372
+%1373 = OpLoad %_arr_float_uint_8 %447
+%1374 = OpCompositeExtract %float %1373 1
+OpStore %797 %1374
+%1375 = OpLoad %_arr_float_uint_8 %453
+%1376 = OpCompositeExtract %float %1375 1
+OpStore %798 %1376
+%1377 = OpLoad %float %797
+%1378 = OpLoad %float %798
+%1379 = OpFDiv %float %1377 %1378
+OpStore %799 %1379
+%1380 = OpLoad %_arr_float_uint_8 %447
+%1381 = OpCompositeExtract %float %1380 2
+OpStore %800 %1381
+%1382 = OpLoad %_arr_float_uint_8 %453
+%1383 = OpCompositeExtract %float %1382 2
+OpStore %801 %1383
+%1384 = OpLoad %float %800
+%1385 = OpLoad %float %801
+%1386 = OpFDiv %float %1384 %1385
+OpStore %802 %1386
+%1387 = OpLoad %_arr_float_uint_8 %447
+%1388 = OpCompositeExtract %float %1387 3
+OpStore %803 %1388
+%1389 = OpLoad %_arr_float_uint_8 %453
+%1390 = OpCompositeExtract %float %1389 3
+OpStore %804 %1390
+%1391 = OpLoad %float %803
+%1392 = OpLoad %float %804
+%1393 = OpFDiv %float %1391 %1392
+OpStore %805 %1393
+%1394 = OpLoad %_arr_float_uint_8 %447
+%1395 = OpCompositeExtract %float %1394 4
+OpStore %806 %1395
+%1396 = OpLoad %_arr_float_uint_8 %453
+%1397 = OpCompositeExtract %float %1396 4
+OpStore %807 %1397
+%1398 = OpLoad %float %806
+%1399 = OpLoad %float %807
+%1400 = OpFDiv %float %1398 %1399
+OpStore %808 %1400
+%1401 = OpLoad %_arr_float_uint_8 %447
+%1402 = OpCompositeExtract %float %1401 5
+OpStore %809 %1402
+%1403 = OpLoad %_arr_float_uint_8 %453
+%1404 = OpCompositeExtract %float %1403 5
+OpStore %810 %1404
+%1405 = OpLoad %float %809
+%1406 = OpLoad %float %810
+%1407 = OpFDiv %float %1405 %1406
+OpStore %811 %1407
+%1408 = OpLoad %_arr_float_uint_8 %447
+%1409 = OpCompositeExtract %float %1408 6
+OpStore %812 %1409
+%1410 = OpLoad %_arr_float_uint_8 %453
+%1411 = OpCompositeExtract %float %1410 6
+OpStore %813 %1411
+%1412 = OpLoad %float %812
+%1413 = OpLoad %float %813
+%1414 = OpFDiv %float %1412 %1413
+OpStore %814 %1414
+%1415 = OpLoad %_arr_float_uint_8 %447
+%1416 = OpCompositeExtract %float %1415 7
+OpStore %815 %1416
+%1417 = OpLoad %_arr_float_uint_8 %453
+%1418 = OpCompositeExtract %float %1417 7
+OpStore %816 %1418
+%1419 = OpLoad %float %815
+%1420 = OpLoad %float %816
+%1421 = OpFDiv %float %1419 %1420
+OpStore %817 %1421
+%1422 = OpLoad %_arr_float_uint_8 %447
+%1423 = OpLoad %float %796
+%1424 = OpCompositeInsert %_arr_float_uint_8 %1423 %1422 0
+OpStore %818 %1424
+%1425 = OpLoad %_arr_float_uint_8 %818
+%1426 = OpLoad %float %799
+%1427 = OpCompositeInsert %_arr_float_uint_8 %1426 %1425 1
+OpStore %819 %1427
+%1428 = OpLoad %_arr_float_uint_8 %819
+%1429 = OpLoad %float %802
+%1430 = OpCompositeInsert %_arr_float_uint_8 %1429 %1428 2
+OpStore %820 %1430
+%1431 = OpLoad %_arr_float_uint_8 %820
+%1432 = OpLoad %float %805
+%1433 = OpCompositeInsert %_arr_float_uint_8 %1432 %1431 3
+OpStore %821 %1433
+%1434 = OpLoad %_arr_float_uint_8 %821
+%1435 = OpLoad %float %808
+%1436 = OpCompositeInsert %_arr_float_uint_8 %1435 %1434 4
+OpStore %822 %1436
+%1437 = OpLoad %_arr_float_uint_8 %822
+%1438 = OpLoad %float %811
+%1439 = OpCompositeInsert %_arr_float_uint_8 %1438 %1437 5
+OpStore %823 %1439
+%1440 = OpLoad %_arr_float_uint_8 %823
+%1441 = OpLoad %float %814
+%1442 = OpCompositeInsert %_arr_float_uint_8 %1441 %1440 6
+OpStore %824 %1442
+%1443 = OpLoad %_arr_float_uint_8 %824
+%1444 = OpLoad %float %817
+%1445 = OpCompositeInsert %_arr_float_uint_8 %1444 %1443 7
+OpStore %825 %1445
+%1446 = OpLoad %ulong %459
+%1447 = OpLoad %_arr_float_uint_8 %825
+%1448 = OpFunctionCall %ulong %1 %1446 %1447
+OpStore %460 %1448
+%1449 = OpLoad %_arr_float_uint_8 %453
+%1450 = OpCompositeExtract %float %1449 0
+OpStore %826 %1450
+%1451 = OpLoad %_arr_float_uint_8 %447
+%1452 = OpCompositeExtract %float %1451 0
+OpStore %827 %1452
+%1453 = OpLoad %float %826
+%1454 = OpLoad %float %827
+%1455 = OpFDiv %float %1453 %1454
+OpStore %828 %1455
+%1456 = OpLoad %_arr_float_uint_8 %453
+%1457 = OpCompositeExtract %float %1456 1
+OpStore %829 %1457
+%1458 = OpLoad %_arr_float_uint_8 %447
+%1459 = OpCompositeExtract %float %1458 1
+OpStore %830 %1459
+%1460 = OpLoad %float %829
+%1461 = OpLoad %float %830
+%1462 = OpFDiv %float %1460 %1461
+OpStore %831 %1462
+%1463 = OpLoad %_arr_float_uint_8 %453
+%1464 = OpCompositeExtract %float %1463 2
+OpStore %832 %1464
+%1465 = OpLoad %_arr_float_uint_8 %447
+%1466 = OpCompositeExtract %float %1465 2
+OpStore %833 %1466
+%1467 = OpLoad %float %832
+%1468 = OpLoad %float %833
+%1469 = OpFDiv %float %1467 %1468
+OpStore %834 %1469
+%1470 = OpLoad %_arr_float_uint_8 %453
+%1471 = OpCompositeExtract %float %1470 3
+OpStore %835 %1471
+%1472 = OpLoad %_arr_float_uint_8 %447
+%1473 = OpCompositeExtract %float %1472 3
+OpStore %836 %1473
+%1474 = OpLoad %float %835
+%1475 = OpLoad %float %836
+%1476 = OpFDiv %float %1474 %1475
+OpStore %837 %1476
+%1477 = OpLoad %_arr_float_uint_8 %453
+%1478 = OpCompositeExtract %float %1477 4
+OpStore %838 %1478
+%1479 = OpLoad %_arr_float_uint_8 %447
+%1480 = OpCompositeExtract %float %1479 4
+OpStore %839 %1480
+%1481 = OpLoad %float %838
+%1482 = OpLoad %float %839
+%1483 = OpFDiv %float %1481 %1482
+OpStore %840 %1483
+%1484 = OpLoad %_arr_float_uint_8 %453
+%1485 = OpCompositeExtract %float %1484 5
+OpStore %841 %1485
+%1486 = OpLoad %_arr_float_uint_8 %447
+%1487 = OpCompositeExtract %float %1486 5
+OpStore %842 %1487
+%1488 = OpLoad %float %841
+%1489 = OpLoad %float %842
+%1490 = OpFDiv %float %1488 %1489
+OpStore %843 %1490
+%1491 = OpLoad %_arr_float_uint_8 %453
+%1492 = OpCompositeExtract %float %1491 6
+OpStore %844 %1492
+%1493 = OpLoad %_arr_float_uint_8 %447
+%1494 = OpCompositeExtract %float %1493 6
+OpStore %845 %1494
+%1495 = OpLoad %float %844
+%1496 = OpLoad %float %845
+%1497 = OpFDiv %float %1495 %1496
+OpStore %846 %1497
+%1498 = OpLoad %_arr_float_uint_8 %453
+%1499 = OpCompositeExtract %float %1498 7
+OpStore %847 %1499
+%1500 = OpLoad %_arr_float_uint_8 %447
+%1501 = OpCompositeExtract %float %1500 7
+OpStore %848 %1501
+%1502 = OpLoad %float %847
+%1503 = OpLoad %float %848
+%1504 = OpFDiv %float %1502 %1503
+OpStore %849 %1504
+%1505 = OpLoad %_arr_float_uint_8 %453
+%1506 = OpLoad %float %828
+%1507 = OpCompositeInsert %_arr_float_uint_8 %1506 %1505 0
+OpStore %850 %1507
+%1508 = OpLoad %_arr_float_uint_8 %850
+%1509 = OpLoad %float %831
+%1510 = OpCompositeInsert %_arr_float_uint_8 %1509 %1508 1
+OpStore %851 %1510
+%1511 = OpLoad %_arr_float_uint_8 %851
+%1512 = OpLoad %float %834
+%1513 = OpCompositeInsert %_arr_float_uint_8 %1512 %1511 2
+OpStore %852 %1513
+%1514 = OpLoad %_arr_float_uint_8 %852
+%1515 = OpLoad %float %837
+%1516 = OpCompositeInsert %_arr_float_uint_8 %1515 %1514 3
+OpStore %853 %1516
+%1517 = OpLoad %_arr_float_uint_8 %853
+%1518 = OpLoad %float %840
+%1519 = OpCompositeInsert %_arr_float_uint_8 %1518 %1517 4
+OpStore %854 %1519
+%1520 = OpLoad %_arr_float_uint_8 %854
+%1521 = OpLoad %float %843
+%1522 = OpCompositeInsert %_arr_float_uint_8 %1521 %1520 5
+OpStore %855 %1522
+%1523 = OpLoad %_arr_float_uint_8 %855
+%1524 = OpLoad %float %846
+%1525 = OpCompositeInsert %_arr_float_uint_8 %1524 %1523 6
+OpStore %856 %1525
+%1526 = OpLoad %_arr_float_uint_8 %856
+%1527 = OpLoad %float %849
+%1528 = OpCompositeInsert %_arr_float_uint_8 %1527 %1526 7
+OpStore %857 %1528
+%1529 = OpLoad %ulong %460
+%1530 = OpLoad %_arr_float_uint_8 %857
+%1531 = OpFunctionCall %ulong %1 %1529 %1530
+OpStore %461 %1531
+%1532 = OpLoad %_arr_float_uint_8 %447
+%1533 = OpCompositeExtract %float %1532 0
+OpStore %858 %1533
+%1534 = OpLoad %_arr_float_uint_8 %441
+%1535 = OpCompositeExtract %float %1534 0
+OpStore %859 %1535
+%1536 = OpLoad %float %858
+%1537 = OpLoad %float %859
+%1538 = OpFMul %float %1536 %1537
+OpStore %860 %1538
+%1539 = OpLoad %_arr_float_uint_8 %447
+%1540 = OpCompositeExtract %float %1539 1
+OpStore %861 %1540
+%1541 = OpLoad %_arr_float_uint_8 %441
+%1542 = OpCompositeExtract %float %1541 1
+OpStore %862 %1542
+%1543 = OpLoad %float %861
+%1544 = OpLoad %float %862
+%1545 = OpFMul %float %1543 %1544
+OpStore %863 %1545
+%1546 = OpLoad %_arr_float_uint_8 %447
+%1547 = OpCompositeExtract %float %1546 2
+OpStore %864 %1547
+%1548 = OpLoad %_arr_float_uint_8 %441
+%1549 = OpCompositeExtract %float %1548 2
+OpStore %865 %1549
+%1550 = OpLoad %float %864
+%1551 = OpLoad %float %865
+%1552 = OpFMul %float %1550 %1551
+OpStore %866 %1552
+%1553 = OpLoad %_arr_float_uint_8 %447
+%1554 = OpCompositeExtract %float %1553 3
+OpStore %867 %1554
+%1555 = OpLoad %_arr_float_uint_8 %441
+%1556 = OpCompositeExtract %float %1555 3
+OpStore %868 %1556
+%1557 = OpLoad %float %867
+%1558 = OpLoad %float %868
+%1559 = OpFMul %float %1557 %1558
+OpStore %869 %1559
+%1560 = OpLoad %_arr_float_uint_8 %447
+%1561 = OpCompositeExtract %float %1560 4
+OpStore %870 %1561
+%1562 = OpLoad %_arr_float_uint_8 %441
+%1563 = OpCompositeExtract %float %1562 4
+OpStore %871 %1563
+%1564 = OpLoad %float %870
+%1565 = OpLoad %float %871
+%1566 = OpFMul %float %1564 %1565
+OpStore %872 %1566
+%1567 = OpLoad %_arr_float_uint_8 %447
+%1568 = OpCompositeExtract %float %1567 5
+OpStore %873 %1568
+%1569 = OpLoad %_arr_float_uint_8 %441
+%1570 = OpCompositeExtract %float %1569 5
+OpStore %874 %1570
+%1571 = OpLoad %float %873
+%1572 = OpLoad %float %874
+%1573 = OpFMul %float %1571 %1572
+OpStore %875 %1573
+%1574 = OpLoad %_arr_float_uint_8 %447
+%1575 = OpCompositeExtract %float %1574 6
+OpStore %876 %1575
+%1576 = OpLoad %_arr_float_uint_8 %441
+%1577 = OpCompositeExtract %float %1576 6
+OpStore %877 %1577
+%1578 = OpLoad %float %876
+%1579 = OpLoad %float %877
+%1580 = OpFMul %float %1578 %1579
+OpStore %878 %1580
+%1581 = OpLoad %_arr_float_uint_8 %447
+%1582 = OpCompositeExtract %float %1581 7
+OpStore %879 %1582
+%1583 = OpLoad %_arr_float_uint_8 %441
+%1584 = OpCompositeExtract %float %1583 7
+OpStore %880 %1584
+%1585 = OpLoad %float %879
+%1586 = OpLoad %float %880
+%1587 = OpFMul %float %1585 %1586
+OpStore %881 %1587
+%1588 = OpLoad %_arr_float_uint_8 %447
+%1589 = OpLoad %float %860
+%1590 = OpCompositeInsert %_arr_float_uint_8 %1589 %1588 0
+OpStore %882 %1590
+%1591 = OpLoad %_arr_float_uint_8 %882
+%1592 = OpLoad %float %863
+%1593 = OpCompositeInsert %_arr_float_uint_8 %1592 %1591 1
+OpStore %883 %1593
+%1594 = OpLoad %_arr_float_uint_8 %883
+%1595 = OpLoad %float %866
+%1596 = OpCompositeInsert %_arr_float_uint_8 %1595 %1594 2
+OpStore %884 %1596
+%1597 = OpLoad %_arr_float_uint_8 %884
+%1598 = OpLoad %float %869
+%1599 = OpCompositeInsert %_arr_float_uint_8 %1598 %1597 3
+OpStore %885 %1599
+%1600 = OpLoad %_arr_float_uint_8 %885
+%1601 = OpLoad %float %872
+%1602 = OpCompositeInsert %_arr_float_uint_8 %1601 %1600 4
+OpStore %886 %1602
+%1603 = OpLoad %_arr_float_uint_8 %886
+%1604 = OpLoad %float %875
+%1605 = OpCompositeInsert %_arr_float_uint_8 %1604 %1603 5
+OpStore %887 %1605
+%1606 = OpLoad %_arr_float_uint_8 %887
+%1607 = OpLoad %float %878
+%1608 = OpCompositeInsert %_arr_float_uint_8 %1607 %1606 6
+OpStore %888 %1608
+%1609 = OpLoad %_arr_float_uint_8 %888
+%1610 = OpLoad %float %881
+%1611 = OpCompositeInsert %_arr_float_uint_8 %1610 %1609 7
+OpStore %889 %1611
+%1612 = OpLoad %ulong %461
+%1613 = OpLoad %_arr_float_uint_8 %889
+%1614 = OpFunctionCall %ulong %1 %1612 %1613
+OpStore %462 %1614
+%1615 = OpLoad %_arr_float_uint_8 %441
+%1616 = OpCompositeExtract %float %1615 0
+OpStore %890 %1616
+%1617 = OpLoad %_arr_float_uint_8 %453
+%1618 = OpCompositeExtract %float %1617 0
+OpStore %891 %1618
+%1619 = OpLoad %float %890
+%1620 = OpLoad %float %891
+%1621 = OpFSub %float %1619 %1620
+OpStore %892 %1621
+%1622 = OpLoad %_arr_float_uint_8 %441
+%1623 = OpCompositeExtract %float %1622 1
+OpStore %893 %1623
+%1624 = OpLoad %_arr_float_uint_8 %453
+%1625 = OpCompositeExtract %float %1624 1
+OpStore %894 %1625
+%1626 = OpLoad %float %893
+%1627 = OpLoad %float %894
+%1628 = OpFSub %float %1626 %1627
+OpStore %895 %1628
+%1629 = OpLoad %_arr_float_uint_8 %441
+%1630 = OpCompositeExtract %float %1629 2
+OpStore %896 %1630
+%1631 = OpLoad %_arr_float_uint_8 %453
+%1632 = OpCompositeExtract %float %1631 2
+OpStore %897 %1632
+%1633 = OpLoad %float %896
+%1634 = OpLoad %float %897
+%1635 = OpFSub %float %1633 %1634
+OpStore %898 %1635
+%1636 = OpLoad %_arr_float_uint_8 %441
+%1637 = OpCompositeExtract %float %1636 3
+OpStore %899 %1637
+%1638 = OpLoad %_arr_float_uint_8 %453
+%1639 = OpCompositeExtract %float %1638 3
+OpStore %900 %1639
+%1640 = OpLoad %float %899
+%1641 = OpLoad %float %900
+%1642 = OpFSub %float %1640 %1641
+OpStore %901 %1642
+%1643 = OpLoad %_arr_float_uint_8 %441
+%1644 = OpCompositeExtract %float %1643 4
+OpStore %902 %1644
+%1645 = OpLoad %_arr_float_uint_8 %453
+%1646 = OpCompositeExtract %float %1645 4
+OpStore %903 %1646
+%1647 = OpLoad %float %902
+%1648 = OpLoad %float %903
+%1649 = OpFSub %float %1647 %1648
+OpStore %904 %1649
+%1650 = OpLoad %_arr_float_uint_8 %441
+%1651 = OpCompositeExtract %float %1650 5
+OpStore %905 %1651
+%1652 = OpLoad %_arr_float_uint_8 %453
+%1653 = OpCompositeExtract %float %1652 5
+OpStore %906 %1653
+%1654 = OpLoad %float %905
+%1655 = OpLoad %float %906
+%1656 = OpFSub %float %1654 %1655
+OpStore %907 %1656
+%1657 = OpLoad %_arr_float_uint_8 %441
+%1658 = OpCompositeExtract %float %1657 6
+OpStore %908 %1658
+%1659 = OpLoad %_arr_float_uint_8 %453
+%1660 = OpCompositeExtract %float %1659 6
+OpStore %909 %1660
+%1661 = OpLoad %float %908
+%1662 = OpLoad %float %909
+%1663 = OpFSub %float %1661 %1662
+OpStore %910 %1663
+%1664 = OpLoad %_arr_float_uint_8 %441
+%1665 = OpCompositeExtract %float %1664 7
+OpStore %911 %1665
+%1666 = OpLoad %_arr_float_uint_8 %453
+%1667 = OpCompositeExtract %float %1666 7
+OpStore %912 %1667
+%1668 = OpLoad %float %911
+%1669 = OpLoad %float %912
+%1670 = OpFSub %float %1668 %1669
+OpStore %913 %1670
+%1671 = OpLoad %_arr_float_uint_8 %441
+%1672 = OpLoad %float %892
+%1673 = OpCompositeInsert %_arr_float_uint_8 %1672 %1671 0
+OpStore %914 %1673
+%1674 = OpLoad %_arr_float_uint_8 %914
+%1675 = OpLoad %float %895
+%1676 = OpCompositeInsert %_arr_float_uint_8 %1675 %1674 1
+OpStore %915 %1676
+%1677 = OpLoad %_arr_float_uint_8 %915
+%1678 = OpLoad %float %898
+%1679 = OpCompositeInsert %_arr_float_uint_8 %1678 %1677 2
+OpStore %916 %1679
+%1680 = OpLoad %_arr_float_uint_8 %916
+%1681 = OpLoad %float %901
+%1682 = OpCompositeInsert %_arr_float_uint_8 %1681 %1680 3
+OpStore %917 %1682
+%1683 = OpLoad %_arr_float_uint_8 %917
+%1684 = OpLoad %float %904
+%1685 = OpCompositeInsert %_arr_float_uint_8 %1684 %1683 4
+OpStore %918 %1685
+%1686 = OpLoad %_arr_float_uint_8 %918
+%1687 = OpLoad %float %907
+%1688 = OpCompositeInsert %_arr_float_uint_8 %1687 %1686 5
+OpStore %919 %1688
+%1689 = OpLoad %_arr_float_uint_8 %919
+%1690 = OpLoad %float %910
+%1691 = OpCompositeInsert %_arr_float_uint_8 %1690 %1689 6
+OpStore %920 %1691
+%1692 = OpLoad %_arr_float_uint_8 %920
+%1693 = OpLoad %float %913
+%1694 = OpCompositeInsert %_arr_float_uint_8 %1693 %1692 7
+OpStore %921 %1694
+%1695 = OpLoad %ulong %462
+%1696 = OpLoad %_arr_float_uint_8 %921
+%1697 = OpFunctionCall %ulong %1 %1695 %1696
+OpStore %463 %1697
+%1698 = OpLoad %_arr_float_uint_8 %441
+%1699 = OpCompositeExtract %float %1698 0
+OpStore %922 %1699
+%1700 = OpLoad %_arr_float_uint_8 %447
+%1701 = OpCompositeExtract %float %1700 0
+OpStore %923 %1701
+%1702 = OpLoad %float %922
+%1703 = OpLoad %float %923
+%1704 = OpFDiv %float %1702 %1703
+OpStore %924 %1704
+%1705 = OpLoad %_arr_float_uint_8 %441
+%1706 = OpCompositeExtract %float %1705 1
+OpStore %925 %1706
+%1707 = OpLoad %_arr_float_uint_8 %447
+%1708 = OpCompositeExtract %float %1707 1
+OpStore %926 %1708
+%1709 = OpLoad %float %925
+%1710 = OpLoad %float %926
+%1711 = OpFDiv %float %1709 %1710
+OpStore %927 %1711
+%1712 = OpLoad %_arr_float_uint_8 %441
+%1713 = OpCompositeExtract %float %1712 2
+OpStore %928 %1713
+%1714 = OpLoad %_arr_float_uint_8 %447
+%1715 = OpCompositeExtract %float %1714 2
+OpStore %929 %1715
+%1716 = OpLoad %float %928
+%1717 = OpLoad %float %929
+%1718 = OpFDiv %float %1716 %1717
+OpStore %930 %1718
+%1719 = OpLoad %_arr_float_uint_8 %441
+%1720 = OpCompositeExtract %float %1719 3
+OpStore %931 %1720
+%1721 = OpLoad %_arr_float_uint_8 %447
+%1722 = OpCompositeExtract %float %1721 3
+OpStore %932 %1722
+%1723 = OpLoad %float %931
+%1724 = OpLoad %float %932
+%1725 = OpFDiv %float %1723 %1724
+OpStore %933 %1725
+%1726 = OpLoad %_arr_float_uint_8 %441
+%1727 = OpCompositeExtract %float %1726 4
+OpStore %934 %1727
+%1728 = OpLoad %_arr_float_uint_8 %447
+%1729 = OpCompositeExtract %float %1728 4
+OpStore %935 %1729
+%1730 = OpLoad %float %934
+%1731 = OpLoad %float %935
+%1732 = OpFDiv %float %1730 %1731
+OpStore %936 %1732
+%1733 = OpLoad %_arr_float_uint_8 %441
+%1734 = OpCompositeExtract %float %1733 5
+OpStore %937 %1734
+%1735 = OpLoad %_arr_float_uint_8 %447
+%1736 = OpCompositeExtract %float %1735 5
+OpStore %938 %1736
+%1737 = OpLoad %float %937
+%1738 = OpLoad %float %938
+%1739 = OpFDiv %float %1737 %1738
+OpStore %939 %1739
+%1740 = OpLoad %_arr_float_uint_8 %441
+%1741 = OpCompositeExtract %float %1740 6
+OpStore %940 %1741
+%1742 = OpLoad %_arr_float_uint_8 %447
 %1743 = OpCompositeExtract %float %1742 6
-OpStore %377 %1743
-%1744 = OpLoad %ulong %376
-%1745 = OpLoad %float %377
-%1746 = OpFunctionCall %ulong %5 %1744 %1745
-OpStore %378 %1746
-%1747 = OpLoad %_arr_float_uint_8 %780
+OpStore %941 %1743
+%1744 = OpLoad %float %940
+%1745 = OpLoad %float %941
+%1746 = OpFDiv %float %1744 %1745
+OpStore %942 %1746
+%1747 = OpLoad %_arr_float_uint_8 %441
 %1748 = OpCompositeExtract %float %1747 7
-OpStore %379 %1748
-%1749 = OpLoad %ulong %378
-%1750 = OpLoad %float %379
-%1751 = OpFunctionCall %ulong %5 %1749 %1750
-OpStore %380 %1751
-OpBranch %111
-%111 = OpLabel
-%1752 = OpLoad %_arr_float_uint_8 %146
-%1753 = OpCompositeExtract %float %1752 0
-OpStore %781 %1753
-%1754 = OpLoad %_arr_float_uint_8 %140
-%1755 = OpCompositeExtract %float %1754 0
-OpStore %782 %1755
-%1756 = OpLoad %float %781
-%1757 = OpLoad %float %782
-%1758 = OpFMul %float %1756 %1757
-OpStore %783 %1758
-%1759 = OpLoad %_arr_float_uint_8 %146
-%1760 = OpCompositeExtract %float %1759 1
-OpStore %784 %1760
-%1761 = OpLoad %_arr_float_uint_8 %140
-%1762 = OpCompositeExtract %float %1761 1
-OpStore %785 %1762
-%1763 = OpLoad %float %784
-%1764 = OpLoad %float %785
-%1765 = OpFMul %float %1763 %1764
-OpStore %786 %1765
-%1766 = OpLoad %_arr_float_uint_8 %146
-%1767 = OpCompositeExtract %float %1766 2
-OpStore %787 %1767
-%1768 = OpLoad %_arr_float_uint_8 %140
-%1769 = OpCompositeExtract %float %1768 2
-OpStore %788 %1769
-%1770 = OpLoad %float %787
-%1771 = OpLoad %float %788
-%1772 = OpFMul %float %1770 %1771
-OpStore %789 %1772
-%1773 = OpLoad %_arr_float_uint_8 %146
-%1774 = OpCompositeExtract %float %1773 3
-OpStore %790 %1774
-%1775 = OpLoad %_arr_float_uint_8 %140
-%1776 = OpCompositeExtract %float %1775 3
-OpStore %791 %1776
-%1777 = OpLoad %float %790
-%1778 = OpLoad %float %791
-%1779 = OpFMul %float %1777 %1778
-OpStore %792 %1779
-%1780 = OpLoad %_arr_float_uint_8 %146
-%1781 = OpCompositeExtract %float %1780 4
-OpStore %793 %1781
-%1782 = OpLoad %_arr_float_uint_8 %140
-%1783 = OpCompositeExtract %float %1782 4
-OpStore %794 %1783
-%1784 = OpLoad %float %793
-%1785 = OpLoad %float %794
-%1786 = OpFMul %float %1784 %1785
-OpStore %795 %1786
-%1787 = OpLoad %_arr_float_uint_8 %146
-%1788 = OpCompositeExtract %float %1787 5
-OpStore %796 %1788
-%1789 = OpLoad %_arr_float_uint_8 %140
-%1790 = OpCompositeExtract %float %1789 5
-OpStore %797 %1790
-%1791 = OpLoad %float %796
-%1792 = OpLoad %float %797
-%1793 = OpFMul %float %1791 %1792
-OpStore %798 %1793
-%1794 = OpLoad %_arr_float_uint_8 %146
-%1795 = OpCompositeExtract %float %1794 6
-OpStore %799 %1795
-%1796 = OpLoad %_arr_float_uint_8 %140
-%1797 = OpCompositeExtract %float %1796 6
-OpStore %800 %1797
-%1798 = OpLoad %float %799
-%1799 = OpLoad %float %800
-%1800 = OpFMul %float %1798 %1799
-OpStore %801 %1800
-%1801 = OpLoad %_arr_float_uint_8 %146
-%1802 = OpCompositeExtract %float %1801 7
-OpStore %802 %1802
-%1803 = OpLoad %_arr_float_uint_8 %140
-%1804 = OpCompositeExtract %float %1803 7
-OpStore %803 %1804
-%1805 = OpLoad %float %802
-%1806 = OpLoad %float %803
-%1807 = OpFMul %float %1805 %1806
-OpStore %804 %1807
-%1808 = OpLoad %_arr_float_uint_8 %146
-%1809 = OpLoad %float %783
-%1810 = OpCompositeInsert %_arr_float_uint_8 %1809 %1808 0
-OpStore %805 %1810
-%1811 = OpLoad %_arr_float_uint_8 %805
-%1812 = OpLoad %float %786
-%1813 = OpCompositeInsert %_arr_float_uint_8 %1812 %1811 1
-OpStore %806 %1813
-%1814 = OpLoad %_arr_float_uint_8 %806
-%1815 = OpLoad %float %789
-%1816 = OpCompositeInsert %_arr_float_uint_8 %1815 %1814 2
-OpStore %807 %1816
-%1817 = OpLoad %_arr_float_uint_8 %807
-%1818 = OpLoad %float %792
-%1819 = OpCompositeInsert %_arr_float_uint_8 %1818 %1817 3
-OpStore %808 %1819
-%1820 = OpLoad %_arr_float_uint_8 %808
-%1821 = OpLoad %float %795
-%1822 = OpCompositeInsert %_arr_float_uint_8 %1821 %1820 4
-OpStore %809 %1822
-%1823 = OpLoad %_arr_float_uint_8 %809
-%1824 = OpLoad %float %798
-%1825 = OpCompositeInsert %_arr_float_uint_8 %1824 %1823 5
-OpStore %810 %1825
-%1826 = OpLoad %_arr_float_uint_8 %810
-%1827 = OpLoad %float %801
-%1828 = OpCompositeInsert %_arr_float_uint_8 %1827 %1826 6
-OpStore %811 %1828
-%1829 = OpLoad %_arr_float_uint_8 %811
-%1830 = OpLoad %float %804
-%1831 = OpCompositeInsert %_arr_float_uint_8 %1830 %1829 7
-OpStore %812 %1831
-OpBranch %112
-%112 = OpLabel
-%1832 = OpLoad %_arr_float_uint_8 %812
-%1833 = OpCompositeExtract %float %1832 0
-OpStore %381 %1833
-%1834 = OpLoad %ulong %380
-%1835 = OpLoad %float %381
-%1836 = OpFunctionCall %ulong %5 %1834 %1835
-OpStore %382 %1836
-%1837 = OpLoad %_arr_float_uint_8 %812
-%1838 = OpCompositeExtract %float %1837 1
-OpStore %383 %1838
-%1839 = OpLoad %ulong %382
-%1840 = OpLoad %float %383
-%1841 = OpFunctionCall %ulong %5 %1839 %1840
-OpStore %384 %1841
-%1842 = OpLoad %_arr_float_uint_8 %812
-%1843 = OpCompositeExtract %float %1842 2
-OpStore %385 %1843
-%1844 = OpLoad %ulong %384
-%1845 = OpLoad %float %385
-%1846 = OpFunctionCall %ulong %5 %1844 %1845
-OpStore %386 %1846
-%1847 = OpLoad %_arr_float_uint_8 %812
-%1848 = OpCompositeExtract %float %1847 3
-OpStore %387 %1848
-%1849 = OpLoad %ulong %386
-%1850 = OpLoad %float %387
-%1851 = OpFunctionCall %ulong %5 %1849 %1850
-OpStore %388 %1851
-%1852 = OpLoad %_arr_float_uint_8 %812
-%1853 = OpCompositeExtract %float %1852 4
-OpStore %389 %1853
-%1854 = OpLoad %ulong %388
-%1855 = OpLoad %float %389
-%1856 = OpFunctionCall %ulong %5 %1854 %1855
-OpStore %390 %1856
-%1857 = OpLoad %_arr_float_uint_8 %812
-%1858 = OpCompositeExtract %float %1857 5
-OpStore %391 %1858
-%1859 = OpLoad %ulong %390
-%1860 = OpLoad %float %391
-%1861 = OpFunctionCall %ulong %5 %1859 %1860
-OpStore %392 %1861
-%1862 = OpLoad %_arr_float_uint_8 %812
-%1863 = OpCompositeExtract %float %1862 6
-OpStore %393 %1863
-%1864 = OpLoad %ulong %392
-%1865 = OpLoad %float %393
-%1866 = OpFunctionCall %ulong %5 %1864 %1865
-OpStore %394 %1866
-%1867 = OpLoad %_arr_float_uint_8 %812
-%1868 = OpCompositeExtract %float %1867 7
-OpStore %395 %1868
-%1869 = OpLoad %ulong %394
-%1870 = OpLoad %float %395
-%1871 = OpFunctionCall %ulong %5 %1869 %1870
-OpStore %396 %1871
-OpBranch %113
-%113 = OpLabel
-%1872 = OpLoad %_arr_float_uint_8 %140
-%1873 = OpCompositeExtract %float %1872 0
-OpStore %813 %1873
-%1874 = OpLoad %_arr_float_uint_8 %152
-%1875 = OpCompositeExtract %float %1874 0
-OpStore %814 %1875
-%1876 = OpLoad %float %813
-%1877 = OpLoad %float %814
-%1878 = OpFSub %float %1876 %1877
-OpStore %815 %1878
-%1879 = OpLoad %_arr_float_uint_8 %140
-%1880 = OpCompositeExtract %float %1879 1
-OpStore %816 %1880
-%1881 = OpLoad %_arr_float_uint_8 %152
-%1882 = OpCompositeExtract %float %1881 1
-OpStore %817 %1882
-%1883 = OpLoad %float %816
-%1884 = OpLoad %float %817
-%1885 = OpFSub %float %1883 %1884
-OpStore %818 %1885
-%1886 = OpLoad %_arr_float_uint_8 %140
-%1887 = OpCompositeExtract %float %1886 2
-OpStore %819 %1887
-%1888 = OpLoad %_arr_float_uint_8 %152
-%1889 = OpCompositeExtract %float %1888 2
-OpStore %820 %1889
-%1890 = OpLoad %float %819
-%1891 = OpLoad %float %820
-%1892 = OpFSub %float %1890 %1891
-OpStore %821 %1892
-%1893 = OpLoad %_arr_float_uint_8 %140
-%1894 = OpCompositeExtract %float %1893 3
-OpStore %822 %1894
-%1895 = OpLoad %_arr_float_uint_8 %152
-%1896 = OpCompositeExtract %float %1895 3
-OpStore %823 %1896
-%1897 = OpLoad %float %822
-%1898 = OpLoad %float %823
-%1899 = OpFSub %float %1897 %1898
-OpStore %824 %1899
-%1900 = OpLoad %_arr_float_uint_8 %140
-%1901 = OpCompositeExtract %float %1900 4
-OpStore %825 %1901
-%1902 = OpLoad %_arr_float_uint_8 %152
-%1903 = OpCompositeExtract %float %1902 4
-OpStore %826 %1903
-%1904 = OpLoad %float %825
-%1905 = OpLoad %float %826
-%1906 = OpFSub %float %1904 %1905
-OpStore %827 %1906
-%1907 = OpLoad %_arr_float_uint_8 %140
-%1908 = OpCompositeExtract %float %1907 5
-OpStore %828 %1908
-%1909 = OpLoad %_arr_float_uint_8 %152
-%1910 = OpCompositeExtract %float %1909 5
-OpStore %829 %1910
-%1911 = OpLoad %float %828
-%1912 = OpLoad %float %829
-%1913 = OpFSub %float %1911 %1912
-OpStore %830 %1913
-%1914 = OpLoad %_arr_float_uint_8 %140
-%1915 = OpCompositeExtract %float %1914 6
-OpStore %831 %1915
-%1916 = OpLoad %_arr_float_uint_8 %152
-%1917 = OpCompositeExtract %float %1916 6
-OpStore %832 %1917
-%1918 = OpLoad %float %831
-%1919 = OpLoad %float %832
-%1920 = OpFSub %float %1918 %1919
-OpStore %833 %1920
-%1921 = OpLoad %_arr_float_uint_8 %140
-%1922 = OpCompositeExtract %float %1921 7
-OpStore %834 %1922
-%1923 = OpLoad %_arr_float_uint_8 %152
-%1924 = OpCompositeExtract %float %1923 7
-OpStore %835 %1924
-%1925 = OpLoad %float %834
-%1926 = OpLoad %float %835
-%1927 = OpFSub %float %1925 %1926
-OpStore %836 %1927
-%1928 = OpLoad %_arr_float_uint_8 %140
-%1929 = OpLoad %float %815
-%1930 = OpCompositeInsert %_arr_float_uint_8 %1929 %1928 0
-OpStore %837 %1930
-%1931 = OpLoad %_arr_float_uint_8 %837
-%1932 = OpLoad %float %818
-%1933 = OpCompositeInsert %_arr_float_uint_8 %1932 %1931 1
-OpStore %838 %1933
-%1934 = OpLoad %_arr_float_uint_8 %838
-%1935 = OpLoad %float %821
-%1936 = OpCompositeInsert %_arr_float_uint_8 %1935 %1934 2
-OpStore %839 %1936
-%1937 = OpLoad %_arr_float_uint_8 %839
-%1938 = OpLoad %float %824
-%1939 = OpCompositeInsert %_arr_float_uint_8 %1938 %1937 3
-OpStore %840 %1939
-%1940 = OpLoad %_arr_float_uint_8 %840
-%1941 = OpLoad %float %827
-%1942 = OpCompositeInsert %_arr_float_uint_8 %1941 %1940 4
-OpStore %841 %1942
-%1943 = OpLoad %_arr_float_uint_8 %841
-%1944 = OpLoad %float %830
-%1945 = OpCompositeInsert %_arr_float_uint_8 %1944 %1943 5
-OpStore %842 %1945
-%1946 = OpLoad %_arr_float_uint_8 %842
-%1947 = OpLoad %float %833
-%1948 = OpCompositeInsert %_arr_float_uint_8 %1947 %1946 6
-OpStore %843 %1948
-%1949 = OpLoad %_arr_float_uint_8 %843
-%1950 = OpLoad %float %836
-%1951 = OpCompositeInsert %_arr_float_uint_8 %1950 %1949 7
-OpStore %844 %1951
-OpBranch %114
-%114 = OpLabel
-%1952 = OpLoad %_arr_float_uint_8 %844
-%1953 = OpCompositeExtract %float %1952 0
-OpStore %397 %1953
-%1954 = OpLoad %ulong %396
-%1955 = OpLoad %float %397
-%1956 = OpFunctionCall %ulong %5 %1954 %1955
-OpStore %398 %1956
-%1957 = OpLoad %_arr_float_uint_8 %844
-%1958 = OpCompositeExtract %float %1957 1
-OpStore %399 %1958
-%1959 = OpLoad %ulong %398
-%1960 = OpLoad %float %399
-%1961 = OpFunctionCall %ulong %5 %1959 %1960
-OpStore %400 %1961
-%1962 = OpLoad %_arr_float_uint_8 %844
-%1963 = OpCompositeExtract %float %1962 2
-OpStore %401 %1963
-%1964 = OpLoad %ulong %400
-%1965 = OpLoad %float %401
-%1966 = OpFunctionCall %ulong %5 %1964 %1965
-OpStore %402 %1966
-%1967 = OpLoad %_arr_float_uint_8 %844
-%1968 = OpCompositeExtract %float %1967 3
-OpStore %403 %1968
-%1969 = OpLoad %ulong %402
-%1970 = OpLoad %float %403
-%1971 = OpFunctionCall %ulong %5 %1969 %1970
-OpStore %404 %1971
-%1972 = OpLoad %_arr_float_uint_8 %844
-%1973 = OpCompositeExtract %float %1972 4
-OpStore %405 %1973
-%1974 = OpLoad %ulong %404
-%1975 = OpLoad %float %405
-%1976 = OpFunctionCall %ulong %5 %1974 %1975
-OpStore %406 %1976
-%1977 = OpLoad %_arr_float_uint_8 %844
-%1978 = OpCompositeExtract %float %1977 5
-OpStore %407 %1978
-%1979 = OpLoad %ulong %406
-%1980 = OpLoad %float %407
-%1981 = OpFunctionCall %ulong %5 %1979 %1980
-OpStore %408 %1981
-%1982 = OpLoad %_arr_float_uint_8 %844
-%1983 = OpCompositeExtract %float %1982 6
-OpStore %409 %1983
-%1984 = OpLoad %ulong %408
-%1985 = OpLoad %float %409
-%1986 = OpFunctionCall %ulong %5 %1984 %1985
-OpStore %410 %1986
-%1987 = OpLoad %_arr_float_uint_8 %844
-%1988 = OpCompositeExtract %float %1987 7
-OpStore %411 %1988
-%1989 = OpLoad %ulong %410
-%1990 = OpLoad %float %411
-%1991 = OpFunctionCall %ulong %5 %1989 %1990
-OpStore %412 %1991
-OpBranch %115
-%115 = OpLabel
-%1992 = OpLoad %_arr_float_uint_8 %140
-%1993 = OpCompositeExtract %float %1992 0
-OpStore %845 %1993
-%1994 = OpLoad %_arr_float_uint_8 %146
-%1995 = OpCompositeExtract %float %1994 0
-OpStore %846 %1995
-%1996 = OpLoad %float %845
-%1997 = OpLoad %float %846
-%1998 = OpFDiv %float %1996 %1997
-OpStore %847 %1998
-%1999 = OpLoad %_arr_float_uint_8 %140
-%2000 = OpCompositeExtract %float %1999 1
-OpStore %848 %2000
-%2001 = OpLoad %_arr_float_uint_8 %146
-%2002 = OpCompositeExtract %float %2001 1
-OpStore %849 %2002
-%2003 = OpLoad %float %848
-%2004 = OpLoad %float %849
-%2005 = OpFDiv %float %2003 %2004
-OpStore %850 %2005
-%2006 = OpLoad %_arr_float_uint_8 %140
-%2007 = OpCompositeExtract %float %2006 2
-OpStore %851 %2007
-%2008 = OpLoad %_arr_float_uint_8 %146
-%2009 = OpCompositeExtract %float %2008 2
-OpStore %852 %2009
-%2010 = OpLoad %float %851
-%2011 = OpLoad %float %852
-%2012 = OpFDiv %float %2010 %2011
-OpStore %853 %2012
-%2013 = OpLoad %_arr_float_uint_8 %140
-%2014 = OpCompositeExtract %float %2013 3
-OpStore %854 %2014
-%2015 = OpLoad %_arr_float_uint_8 %146
-%2016 = OpCompositeExtract %float %2015 3
-OpStore %855 %2016
-%2017 = OpLoad %float %854
-%2018 = OpLoad %float %855
-%2019 = OpFDiv %float %2017 %2018
-OpStore %856 %2019
-%2020 = OpLoad %_arr_float_uint_8 %140
-%2021 = OpCompositeExtract %float %2020 4
-OpStore %857 %2021
-%2022 = OpLoad %_arr_float_uint_8 %146
-%2023 = OpCompositeExtract %float %2022 4
-OpStore %858 %2023
-%2024 = OpLoad %float %857
-%2025 = OpLoad %float %858
-%2026 = OpFDiv %float %2024 %2025
-OpStore %859 %2026
-%2027 = OpLoad %_arr_float_uint_8 %140
-%2028 = OpCompositeExtract %float %2027 5
-OpStore %860 %2028
-%2029 = OpLoad %_arr_float_uint_8 %146
-%2030 = OpCompositeExtract %float %2029 5
-OpStore %861 %2030
-%2031 = OpLoad %float %860
-%2032 = OpLoad %float %861
-%2033 = OpFDiv %float %2031 %2032
-OpStore %862 %2033
-%2034 = OpLoad %_arr_float_uint_8 %140
-%2035 = OpCompositeExtract %float %2034 6
-OpStore %863 %2035
-%2036 = OpLoad %_arr_float_uint_8 %146
-%2037 = OpCompositeExtract %float %2036 6
-OpStore %864 %2037
-%2038 = OpLoad %float %863
-%2039 = OpLoad %float %864
-%2040 = OpFDiv %float %2038 %2039
-OpStore %865 %2040
-%2041 = OpLoad %_arr_float_uint_8 %140
-%2042 = OpCompositeExtract %float %2041 7
-OpStore %866 %2042
-%2043 = OpLoad %_arr_float_uint_8 %146
-%2044 = OpCompositeExtract %float %2043 7
-OpStore %867 %2044
-%2045 = OpLoad %float %866
-%2046 = OpLoad %float %867
-%2047 = OpFDiv %float %2045 %2046
-OpStore %868 %2047
-%2048 = OpLoad %_arr_float_uint_8 %140
-%2049 = OpLoad %float %847
-%2050 = OpCompositeInsert %_arr_float_uint_8 %2049 %2048 0
-OpStore %869 %2050
-%2051 = OpLoad %_arr_float_uint_8 %869
-%2052 = OpLoad %float %850
-%2053 = OpCompositeInsert %_arr_float_uint_8 %2052 %2051 1
-OpStore %870 %2053
-%2054 = OpLoad %_arr_float_uint_8 %870
-%2055 = OpLoad %float %853
-%2056 = OpCompositeInsert %_arr_float_uint_8 %2055 %2054 2
-OpStore %871 %2056
-%2057 = OpLoad %_arr_float_uint_8 %871
-%2058 = OpLoad %float %856
-%2059 = OpCompositeInsert %_arr_float_uint_8 %2058 %2057 3
-OpStore %872 %2059
-%2060 = OpLoad %_arr_float_uint_8 %872
-%2061 = OpLoad %float %859
-%2062 = OpCompositeInsert %_arr_float_uint_8 %2061 %2060 4
-OpStore %873 %2062
-%2063 = OpLoad %_arr_float_uint_8 %873
-%2064 = OpLoad %float %862
-%2065 = OpCompositeInsert %_arr_float_uint_8 %2064 %2063 5
-OpStore %874 %2065
-%2066 = OpLoad %_arr_float_uint_8 %874
-%2067 = OpLoad %float %865
-%2068 = OpCompositeInsert %_arr_float_uint_8 %2067 %2066 6
-OpStore %875 %2068
-%2069 = OpLoad %_arr_float_uint_8 %875
-%2070 = OpLoad %float %868
-%2071 = OpCompositeInsert %_arr_float_uint_8 %2070 %2069 7
-OpStore %876 %2071
-OpBranch %116
-%116 = OpLabel
-%2072 = OpLoad %_arr_float_uint_8 %876
-%2073 = OpCompositeExtract %float %2072 0
-OpStore %413 %2073
-%2074 = OpLoad %ulong %412
-%2075 = OpLoad %float %413
-%2076 = OpFunctionCall %ulong %5 %2074 %2075
-OpStore %414 %2076
-%2077 = OpLoad %_arr_float_uint_8 %876
-%2078 = OpCompositeExtract %float %2077 1
-OpStore %415 %2078
-%2079 = OpLoad %ulong %414
-%2080 = OpLoad %float %415
-%2081 = OpFunctionCall %ulong %5 %2079 %2080
-OpStore %416 %2081
-%2082 = OpLoad %_arr_float_uint_8 %876
-%2083 = OpCompositeExtract %float %2082 2
-OpStore %417 %2083
-%2084 = OpLoad %ulong %416
-%2085 = OpLoad %float %417
-%2086 = OpFunctionCall %ulong %5 %2084 %2085
-OpStore %418 %2086
-%2087 = OpLoad %_arr_float_uint_8 %876
-%2088 = OpCompositeExtract %float %2087 3
-OpStore %419 %2088
-%2089 = OpLoad %ulong %418
-%2090 = OpLoad %float %419
-%2091 = OpFunctionCall %ulong %5 %2089 %2090
-OpStore %420 %2091
-%2092 = OpLoad %_arr_float_uint_8 %876
-%2093 = OpCompositeExtract %float %2092 4
-OpStore %421 %2093
-%2094 = OpLoad %ulong %420
-%2095 = OpLoad %float %421
-%2096 = OpFunctionCall %ulong %5 %2094 %2095
-OpStore %422 %2096
-%2097 = OpLoad %_arr_float_uint_8 %876
-%2098 = OpCompositeExtract %float %2097 5
-OpStore %423 %2098
-%2099 = OpLoad %ulong %422
-%2100 = OpLoad %float %423
-%2101 = OpFunctionCall %ulong %5 %2099 %2100
-OpStore %424 %2101
-%2102 = OpLoad %_arr_float_uint_8 %876
-%2103 = OpCompositeExtract %float %2102 6
-OpStore %425 %2103
-%2104 = OpLoad %ulong %424
-%2105 = OpLoad %float %425
-%2106 = OpFunctionCall %ulong %5 %2104 %2105
-OpStore %426 %2106
-%2107 = OpLoad %_arr_float_uint_8 %876
-%2108 = OpCompositeExtract %float %2107 7
-OpStore %427 %2108
-%2109 = OpLoad %ulong %426
-%2110 = OpLoad %float %427
-%2111 = OpFunctionCall %ulong %5 %2109 %2110
-OpStore %428 %2111
-OpBranch %117
-%117 = OpLabel
-%2112 = OpCompositeConstruct %_arr_float_uint_8 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0
-OpStore %153 %2112
-%2114 = OpLoad %ulong %428
-OpStore %168 %2114
-%2115 = OpLoad %_arr_float_uint_8 %146
-OpStore %169 %2115
-%2116 = OpLoad %_arr_float_uint_8 %153
-OpStore %170 %2116
-OpStore %171 %ulong_0
-OpBranch %80
-%80 = OpLabel
-%2118 = OpLoad %ulong %171
-%2120 = OpULessThan %bool %2118 %ulong_6
-OpStore %155 %2120
-%2121 = OpLoad %bool %155
-OpLoopMerge %82 %119 None
-OpBranchConditional %2121 %81 %82
-%82 = OpLabel
-OpStore %124 %2122
-%2124 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %uint_0
-%2125 = OpLoad %_arr_float_uint_8 %169
-OpStore %2124 %2125
-%2126 = OpLoad %_arr_float_uint_8 %169
-%2127 = OpCompositeExtract %float %2126 0
-OpStore %461 %2127
-%2128 = OpLoad %_arr_float_uint_8 %152
-%2129 = OpCompositeExtract %float %2128 0
-OpStore %462 %2129
-%2130 = OpLoad %float %461
-%2131 = OpLoad %float %462
-%2132 = OpFAdd %float %2130 %2131
-OpStore %463 %2132
-%2133 = OpLoad %_arr_float_uint_8 %169
-%2134 = OpCompositeExtract %float %2133 1
-OpStore %464 %2134
-%2135 = OpLoad %_arr_float_uint_8 %152
-%2136 = OpCompositeExtract %float %2135 1
-OpStore %465 %2136
-%2137 = OpLoad %float %464
-%2138 = OpLoad %float %465
-%2139 = OpFAdd %float %2137 %2138
-OpStore %466 %2139
-%2140 = OpLoad %_arr_float_uint_8 %169
-%2141 = OpCompositeExtract %float %2140 2
-OpStore %467 %2141
-%2142 = OpLoad %_arr_float_uint_8 %152
-%2143 = OpCompositeExtract %float %2142 2
-OpStore %468 %2143
-%2144 = OpLoad %float %467
-%2145 = OpLoad %float %468
-%2146 = OpFAdd %float %2144 %2145
-OpStore %469 %2146
-%2147 = OpLoad %_arr_float_uint_8 %169
-%2148 = OpCompositeExtract %float %2147 3
-OpStore %470 %2148
-%2149 = OpLoad %_arr_float_uint_8 %152
-%2150 = OpCompositeExtract %float %2149 3
-OpStore %471 %2150
-%2151 = OpLoad %float %470
-%2152 = OpLoad %float %471
-%2153 = OpFAdd %float %2151 %2152
-OpStore %472 %2153
-%2154 = OpLoad %_arr_float_uint_8 %169
-%2155 = OpCompositeExtract %float %2154 4
-OpStore %473 %2155
-%2156 = OpLoad %_arr_float_uint_8 %152
-%2157 = OpCompositeExtract %float %2156 4
-OpStore %474 %2157
-%2158 = OpLoad %float %473
-%2159 = OpLoad %float %474
-%2160 = OpFAdd %float %2158 %2159
-OpStore %475 %2160
-%2161 = OpLoad %_arr_float_uint_8 %169
-%2162 = OpCompositeExtract %float %2161 5
-OpStore %476 %2162
-%2163 = OpLoad %_arr_float_uint_8 %152
-%2164 = OpCompositeExtract %float %2163 5
-OpStore %477 %2164
-%2165 = OpLoad %float %476
-%2166 = OpLoad %float %477
-%2167 = OpFAdd %float %2165 %2166
-OpStore %478 %2167
-%2168 = OpLoad %_arr_float_uint_8 %169
-%2169 = OpCompositeExtract %float %2168 6
-OpStore %479 %2169
-%2170 = OpLoad %_arr_float_uint_8 %152
-%2171 = OpCompositeExtract %float %2170 6
-OpStore %480 %2171
-%2172 = OpLoad %float %479
-%2173 = OpLoad %float %480
-%2174 = OpFAdd %float %2172 %2173
-OpStore %481 %2174
-%2175 = OpLoad %_arr_float_uint_8 %169
-%2176 = OpCompositeExtract %float %2175 7
-OpStore %482 %2176
-%2177 = OpLoad %_arr_float_uint_8 %152
-%2178 = OpCompositeExtract %float %2177 7
-OpStore %483 %2178
-%2179 = OpLoad %float %482
-%2180 = OpLoad %float %483
-%2181 = OpFAdd %float %2179 %2180
-OpStore %484 %2181
-%2182 = OpLoad %_arr_float_uint_8 %169
-%2183 = OpLoad %float %463
-%2184 = OpCompositeInsert %_arr_float_uint_8 %2183 %2182 0
-OpStore %485 %2184
-%2185 = OpLoad %_arr_float_uint_8 %485
-%2186 = OpLoad %float %466
-%2187 = OpCompositeInsert %_arr_float_uint_8 %2186 %2185 1
-OpStore %486 %2187
-%2188 = OpLoad %_arr_float_uint_8 %486
-%2189 = OpLoad %float %469
-%2190 = OpCompositeInsert %_arr_float_uint_8 %2189 %2188 2
-OpStore %487 %2190
-%2191 = OpLoad %_arr_float_uint_8 %487
-%2192 = OpLoad %float %472
-%2193 = OpCompositeInsert %_arr_float_uint_8 %2192 %2191 3
-OpStore %488 %2193
-%2194 = OpLoad %_arr_float_uint_8 %488
-%2195 = OpLoad %float %475
-%2196 = OpCompositeInsert %_arr_float_uint_8 %2195 %2194 4
-OpStore %489 %2196
-%2197 = OpLoad %_arr_float_uint_8 %489
-%2198 = OpLoad %float %478
-%2199 = OpCompositeInsert %_arr_float_uint_8 %2198 %2197 5
-OpStore %490 %2199
-%2200 = OpLoad %_arr_float_uint_8 %490
-%2201 = OpLoad %float %481
-%2202 = OpCompositeInsert %_arr_float_uint_8 %2201 %2200 6
-OpStore %491 %2202
-%2203 = OpLoad %_arr_float_uint_8 %491
-%2204 = OpLoad %float %484
-%2205 = OpCompositeInsert %_arr_float_uint_8 %2204 %2203 7
-OpStore %492 %2205
-%2207 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %uint_1
-%2208 = OpLoad %_arr_float_uint_8 %492
-OpStore %2207 %2208
-%2209 = OpLoad %_arr_float_uint_8 %169
-%2210 = OpCompositeExtract %float %2209 0
-OpStore %493 %2210
-%2211 = OpLoad %_arr_float_uint_8 %140
-%2212 = OpCompositeExtract %float %2211 0
-OpStore %494 %2212
-%2213 = OpLoad %float %493
-%2214 = OpLoad %float %494
-%2215 = OpFMul %float %2213 %2214
-OpStore %495 %2215
-%2216 = OpLoad %_arr_float_uint_8 %169
-%2217 = OpCompositeExtract %float %2216 1
-OpStore %496 %2217
-%2218 = OpLoad %_arr_float_uint_8 %140
-%2219 = OpCompositeExtract %float %2218 1
-OpStore %497 %2219
-%2220 = OpLoad %float %496
-%2221 = OpLoad %float %497
-%2222 = OpFMul %float %2220 %2221
-OpStore %498 %2222
-%2223 = OpLoad %_arr_float_uint_8 %169
-%2224 = OpCompositeExtract %float %2223 2
-OpStore %499 %2224
-%2225 = OpLoad %_arr_float_uint_8 %140
-%2226 = OpCompositeExtract %float %2225 2
-OpStore %500 %2226
-%2227 = OpLoad %float %499
-%2228 = OpLoad %float %500
-%2229 = OpFMul %float %2227 %2228
-OpStore %501 %2229
-%2230 = OpLoad %_arr_float_uint_8 %169
-%2231 = OpCompositeExtract %float %2230 3
-OpStore %502 %2231
-%2232 = OpLoad %_arr_float_uint_8 %140
-%2233 = OpCompositeExtract %float %2232 3
-OpStore %503 %2233
-%2234 = OpLoad %float %502
-%2235 = OpLoad %float %503
-%2236 = OpFMul %float %2234 %2235
-OpStore %504 %2236
-%2237 = OpLoad %_arr_float_uint_8 %169
-%2238 = OpCompositeExtract %float %2237 4
-OpStore %505 %2238
-%2239 = OpLoad %_arr_float_uint_8 %140
-%2240 = OpCompositeExtract %float %2239 4
-OpStore %506 %2240
-%2241 = OpLoad %float %505
-%2242 = OpLoad %float %506
-%2243 = OpFMul %float %2241 %2242
-OpStore %507 %2243
-%2244 = OpLoad %_arr_float_uint_8 %169
-%2245 = OpCompositeExtract %float %2244 5
-OpStore %508 %2245
-%2246 = OpLoad %_arr_float_uint_8 %140
-%2247 = OpCompositeExtract %float %2246 5
-OpStore %509 %2247
-%2248 = OpLoad %float %508
-%2249 = OpLoad %float %509
-%2250 = OpFMul %float %2248 %2249
-OpStore %510 %2250
-%2251 = OpLoad %_arr_float_uint_8 %169
-%2252 = OpCompositeExtract %float %2251 6
-OpStore %511 %2252
-%2253 = OpLoad %_arr_float_uint_8 %140
-%2254 = OpCompositeExtract %float %2253 6
-OpStore %512 %2254
-%2255 = OpLoad %float %511
-%2256 = OpLoad %float %512
-%2257 = OpFMul %float %2255 %2256
-OpStore %513 %2257
-%2258 = OpLoad %_arr_float_uint_8 %169
-%2259 = OpCompositeExtract %float %2258 7
-OpStore %514 %2259
-%2260 = OpLoad %_arr_float_uint_8 %140
-%2261 = OpCompositeExtract %float %2260 7
-OpStore %515 %2261
-%2262 = OpLoad %float %514
-%2263 = OpLoad %float %515
-%2264 = OpFMul %float %2262 %2263
-OpStore %516 %2264
-%2265 = OpLoad %_arr_float_uint_8 %169
-%2266 = OpLoad %float %495
-%2267 = OpCompositeInsert %_arr_float_uint_8 %2266 %2265 0
-OpStore %517 %2267
-%2268 = OpLoad %_arr_float_uint_8 %517
-%2269 = OpLoad %float %498
-%2270 = OpCompositeInsert %_arr_float_uint_8 %2269 %2268 1
-OpStore %518 %2270
-%2271 = OpLoad %_arr_float_uint_8 %518
-%2272 = OpLoad %float %501
-%2273 = OpCompositeInsert %_arr_float_uint_8 %2272 %2271 2
-OpStore %519 %2273
-%2274 = OpLoad %_arr_float_uint_8 %519
-%2275 = OpLoad %float %504
-%2276 = OpCompositeInsert %_arr_float_uint_8 %2275 %2274 3
-OpStore %520 %2276
-%2277 = OpLoad %_arr_float_uint_8 %520
-%2278 = OpLoad %float %507
-%2279 = OpCompositeInsert %_arr_float_uint_8 %2278 %2277 4
-OpStore %521 %2279
-%2280 = OpLoad %_arr_float_uint_8 %521
-%2281 = OpLoad %float %510
-%2282 = OpCompositeInsert %_arr_float_uint_8 %2281 %2280 5
-OpStore %522 %2282
-%2283 = OpLoad %_arr_float_uint_8 %522
-%2284 = OpLoad %float %513
-%2285 = OpCompositeInsert %_arr_float_uint_8 %2284 %2283 6
-OpStore %523 %2285
-%2286 = OpLoad %_arr_float_uint_8 %523
-%2287 = OpLoad %float %516
-%2288 = OpCompositeInsert %_arr_float_uint_8 %2287 %2286 7
-OpStore %524 %2288
-%2290 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %uint_2
-%2291 = OpLoad %_arr_float_uint_8 %524
-OpStore %2290 %2291
-%2293 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %uint_3
-%2294 = OpLoad %_arr_float_uint_8 %170
-OpStore %2293 %2294
-%2295 = OpLoad %ulong %168
-OpStore %167 %2295
-OpStore %172 %ulong_0
-OpBranch %83
-%83 = OpLabel
-%2296 = OpLoad %ulong %172
-%2298 = OpULessThan %bool %2296 %ulong_4
-OpStore %157 %2298
-%2299 = OpLoad %bool %157
-OpLoopMerge %85 %118 None
-OpBranchConditional %2299 %84 %85
-%85 = OpLabel
-OpStore %127 %2300
-%2301 = OpAccessChain %_ptr_Function_uint %127 %uint_0
-OpStore %2301 %uint_4294967295
-%2303 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %uint_2
-%2304 = OpLoad %_arr_float_uint_8 %2303
-OpStore %160 %2304
-%2305 = OpAccessChain %_ptr_Function__arr_float_uint_8 %127 %uint_1
-%2306 = OpLoad %_arr_float_uint_8 %160
-OpStore %2305 %2306
-%2307 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-OpStore %2307 %uint_305419896
-%2309 = OpLoad %uint %2301
-OpStore %162 %2309
-%2310 = OpLoad %ulong %167
-%2311 = OpLoad %uint %162
-%2312 = OpFunctionCall %ulong %4 %2310 %2311
-OpStore %163 %2312
-%2313 = OpLoad %_arr_float_uint_8 %2305
-OpStore %164 %2313
-OpBranch %92
-%92 = OpLabel
-%2314 = OpLoad %_arr_float_uint_8 %164
-%2315 = OpCompositeExtract %float %2314 0
-OpStore %221 %2315
-%2316 = OpLoad %ulong %163
-%2317 = OpLoad %float %221
-%2318 = OpFunctionCall %ulong %5 %2316 %2317
-OpStore %222 %2318
-%2319 = OpLoad %_arr_float_uint_8 %164
-%2320 = OpCompositeExtract %float %2319 1
-OpStore %223 %2320
-%2321 = OpLoad %ulong %222
-%2322 = OpLoad %float %223
-%2323 = OpFunctionCall %ulong %5 %2321 %2322
-OpStore %224 %2323
-%2324 = OpLoad %_arr_float_uint_8 %164
-%2325 = OpCompositeExtract %float %2324 2
-OpStore %225 %2325
-%2326 = OpLoad %ulong %224
-%2327 = OpLoad %float %225
-%2328 = OpFunctionCall %ulong %5 %2326 %2327
-OpStore %226 %2328
-%2329 = OpLoad %_arr_float_uint_8 %164
-%2330 = OpCompositeExtract %float %2329 3
-OpStore %227 %2330
-%2331 = OpLoad %ulong %226
-%2332 = OpLoad %float %227
-%2333 = OpFunctionCall %ulong %5 %2331 %2332
-OpStore %228 %2333
-%2334 = OpLoad %_arr_float_uint_8 %164
-%2335 = OpCompositeExtract %float %2334 4
-OpStore %229 %2335
-%2336 = OpLoad %ulong %228
-%2337 = OpLoad %float %229
-%2338 = OpFunctionCall %ulong %5 %2336 %2337
-OpStore %230 %2338
-%2339 = OpLoad %_arr_float_uint_8 %164
-%2340 = OpCompositeExtract %float %2339 5
-OpStore %231 %2340
-%2341 = OpLoad %ulong %230
-%2342 = OpLoad %float %231
-%2343 = OpFunctionCall %ulong %5 %2341 %2342
-OpStore %232 %2343
-%2344 = OpLoad %_arr_float_uint_8 %164
-%2345 = OpCompositeExtract %float %2344 6
-OpStore %233 %2345
-%2346 = OpLoad %ulong %232
-%2347 = OpLoad %float %233
-%2348 = OpFunctionCall %ulong %5 %2346 %2347
-OpStore %234 %2348
-%2349 = OpLoad %_arr_float_uint_8 %164
-%2350 = OpCompositeExtract %float %2349 7
-OpStore %235 %2350
-%2351 = OpLoad %ulong %234
-%2352 = OpLoad %float %235
-%2353 = OpFunctionCall %ulong %5 %2351 %2352
-OpStore %236 %2353
-OpBranch %93
-%93 = OpLabel
-%2354 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-%2355 = OpLoad %uint %2354
-OpStore %165 %2355
-%2356 = OpLoad %ulong %236
-%2357 = OpLoad %uint %165
-%2358 = OpFunctionCall %ulong %4 %2356 %2357
-OpStore %166 %2358
-%2359 = OpLoad %ulong %166
-OpReturnValue %2359
-%84 = OpLabel
-%2360 = OpLoad %ulong %172
-%2361 = OpAccessChain %_ptr_Function__arr_float_uint_8 %124 %2360
-%2362 = OpLoad %_arr_float_uint_8 %2361
-OpStore %158 %2362
-OpBranch %90
-%90 = OpLabel
-%2363 = OpLoad %_arr_float_uint_8 %158
-%2364 = OpCompositeExtract %float %2363 0
-OpStore %205 %2364
-%2365 = OpLoad %ulong %167
-%2366 = OpLoad %float %205
-%2367 = OpFunctionCall %ulong %5 %2365 %2366
-OpStore %206 %2367
-%2368 = OpLoad %_arr_float_uint_8 %158
-%2369 = OpCompositeExtract %float %2368 1
-OpStore %207 %2369
-%2370 = OpLoad %ulong %206
-%2371 = OpLoad %float %207
-%2372 = OpFunctionCall %ulong %5 %2370 %2371
-OpStore %208 %2372
-%2373 = OpLoad %_arr_float_uint_8 %158
-%2374 = OpCompositeExtract %float %2373 2
-OpStore %209 %2374
-%2375 = OpLoad %ulong %208
-%2376 = OpLoad %float %209
-%2377 = OpFunctionCall %ulong %5 %2375 %2376
-OpStore %210 %2377
-%2378 = OpLoad %_arr_float_uint_8 %158
-%2379 = OpCompositeExtract %float %2378 3
-OpStore %211 %2379
-%2380 = OpLoad %ulong %210
-%2381 = OpLoad %float %211
-%2382 = OpFunctionCall %ulong %5 %2380 %2381
-OpStore %212 %2382
-%2383 = OpLoad %_arr_float_uint_8 %158
-%2384 = OpCompositeExtract %float %2383 4
-OpStore %213 %2384
-%2385 = OpLoad %ulong %212
-%2386 = OpLoad %float %213
-%2387 = OpFunctionCall %ulong %5 %2385 %2386
-OpStore %214 %2387
-%2388 = OpLoad %_arr_float_uint_8 %158
-%2389 = OpCompositeExtract %float %2388 5
-OpStore %215 %2389
-%2390 = OpLoad %ulong %214
-%2391 = OpLoad %float %215
-%2392 = OpFunctionCall %ulong %5 %2390 %2391
-OpStore %216 %2392
-%2393 = OpLoad %_arr_float_uint_8 %158
-%2394 = OpCompositeExtract %float %2393 6
-OpStore %217 %2394
-%2395 = OpLoad %ulong %216
-%2396 = OpLoad %float %217
-%2397 = OpFunctionCall %ulong %5 %2395 %2396
-OpStore %218 %2397
-%2398 = OpLoad %_arr_float_uint_8 %158
-%2399 = OpCompositeExtract %float %2398 7
-OpStore %219 %2399
-%2400 = OpLoad %ulong %218
-%2401 = OpLoad %float %219
-%2402 = OpFunctionCall %ulong %5 %2400 %2401
-OpStore %220 %2402
-OpBranch %91
-%91 = OpLabel
-%2403 = OpLoad %ulong %172
-%2405 = OpIAdd %ulong %2403 %ulong_1
-OpStore %159 %2405
-%2406 = OpLoad %ulong %220
-OpStore %167 %2406
-%2407 = OpLoad %ulong %159
-OpStore %172 %2407
-OpBranch %118
-%81 = OpLabel
-%2408 = OpLoad %_arr_float_uint_8 %169
-%2409 = OpCompositeExtract %float %2408 0
-OpStore %429 %2409
-%2410 = OpLoad %_arr_float_uint_8 %140
-%2411 = OpCompositeExtract %float %2410 0
-OpStore %430 %2411
-%2412 = OpLoad %float %429
-%2413 = OpLoad %float %430
-%2414 = OpFMul %float %2412 %2413
-OpStore %431 %2414
-%2415 = OpLoad %_arr_float_uint_8 %169
-%2416 = OpCompositeExtract %float %2415 1
-OpStore %432 %2416
-%2417 = OpLoad %_arr_float_uint_8 %140
-%2418 = OpCompositeExtract %float %2417 1
-OpStore %433 %2418
-%2419 = OpLoad %float %432
-%2420 = OpLoad %float %433
-%2421 = OpFMul %float %2419 %2420
-OpStore %434 %2421
-%2422 = OpLoad %_arr_float_uint_8 %169
-%2423 = OpCompositeExtract %float %2422 2
-OpStore %435 %2423
-%2424 = OpLoad %_arr_float_uint_8 %140
-%2425 = OpCompositeExtract %float %2424 2
-OpStore %436 %2425
-%2426 = OpLoad %float %435
-%2427 = OpLoad %float %436
-%2428 = OpFMul %float %2426 %2427
-OpStore %437 %2428
-%2429 = OpLoad %_arr_float_uint_8 %169
-%2430 = OpCompositeExtract %float %2429 3
-OpStore %438 %2430
-%2431 = OpLoad %_arr_float_uint_8 %140
-%2432 = OpCompositeExtract %float %2431 3
-OpStore %439 %2432
-%2433 = OpLoad %float %438
-%2434 = OpLoad %float %439
-%2435 = OpFMul %float %2433 %2434
-OpStore %440 %2435
-%2436 = OpLoad %_arr_float_uint_8 %169
-%2437 = OpCompositeExtract %float %2436 4
-OpStore %441 %2437
-%2438 = OpLoad %_arr_float_uint_8 %140
-%2439 = OpCompositeExtract %float %2438 4
-OpStore %442 %2439
-%2440 = OpLoad %float %441
-%2441 = OpLoad %float %442
-%2442 = OpFMul %float %2440 %2441
-OpStore %443 %2442
-%2443 = OpLoad %_arr_float_uint_8 %169
-%2444 = OpCompositeExtract %float %2443 5
-OpStore %444 %2444
-%2445 = OpLoad %_arr_float_uint_8 %140
-%2446 = OpCompositeExtract %float %2445 5
-OpStore %445 %2446
-%2447 = OpLoad %float %444
-%2448 = OpLoad %float %445
-%2449 = OpFMul %float %2447 %2448
-OpStore %446 %2449
-%2450 = OpLoad %_arr_float_uint_8 %169
-%2451 = OpCompositeExtract %float %2450 6
-OpStore %447 %2451
-%2452 = OpLoad %_arr_float_uint_8 %140
-%2453 = OpCompositeExtract %float %2452 6
-OpStore %448 %2453
-%2454 = OpLoad %float %447
-%2455 = OpLoad %float %448
-%2456 = OpFMul %float %2454 %2455
-OpStore %449 %2456
-%2457 = OpLoad %_arr_float_uint_8 %169
-%2458 = OpCompositeExtract %float %2457 7
-OpStore %450 %2458
-%2459 = OpLoad %_arr_float_uint_8 %140
-%2460 = OpCompositeExtract %float %2459 7
-OpStore %451 %2460
-%2461 = OpLoad %float %450
-%2462 = OpLoad %float %451
-%2463 = OpFMul %float %2461 %2462
-OpStore %452 %2463
-%2464 = OpLoad %_arr_float_uint_8 %169
-%2465 = OpLoad %float %431
-%2466 = OpCompositeInsert %_arr_float_uint_8 %2465 %2464 0
-OpStore %453 %2466
-%2467 = OpLoad %_arr_float_uint_8 %453
-%2468 = OpLoad %float %434
-%2469 = OpCompositeInsert %_arr_float_uint_8 %2468 %2467 1
-OpStore %454 %2469
-%2470 = OpLoad %_arr_float_uint_8 %454
-%2471 = OpLoad %float %437
-%2472 = OpCompositeInsert %_arr_float_uint_8 %2471 %2470 2
-OpStore %455 %2472
-%2473 = OpLoad %_arr_float_uint_8 %455
-%2474 = OpLoad %float %440
-%2475 = OpCompositeInsert %_arr_float_uint_8 %2474 %2473 3
-OpStore %456 %2475
-%2476 = OpLoad %_arr_float_uint_8 %456
-%2477 = OpLoad %float %443
-%2478 = OpCompositeInsert %_arr_float_uint_8 %2477 %2476 4
-OpStore %457 %2478
-%2479 = OpLoad %_arr_float_uint_8 %457
-%2480 = OpLoad %float %446
-%2481 = OpCompositeInsert %_arr_float_uint_8 %2480 %2479 5
-OpStore %458 %2481
-%2482 = OpLoad %_arr_float_uint_8 %458
-%2483 = OpLoad %float %449
-%2484 = OpCompositeInsert %_arr_float_uint_8 %2483 %2482 6
-OpStore %459 %2484
-%2485 = OpLoad %_arr_float_uint_8 %459
-%2486 = OpLoad %float %452
-%2487 = OpCompositeInsert %_arr_float_uint_8 %2486 %2485 7
-OpStore %460 %2487
-OpBranch %88
-%88 = OpLabel
-%2488 = OpLoad %_arr_float_uint_8 %460
-%2489 = OpCompositeExtract %float %2488 0
-OpStore %189 %2489
-%2490 = OpLoad %ulong %168
-%2491 = OpLoad %float %189
-%2492 = OpFunctionCall %ulong %5 %2490 %2491
-OpStore %190 %2492
-%2493 = OpLoad %_arr_float_uint_8 %460
-%2494 = OpCompositeExtract %float %2493 1
-OpStore %191 %2494
-%2495 = OpLoad %ulong %190
-%2496 = OpLoad %float %191
-%2497 = OpFunctionCall %ulong %5 %2495 %2496
-OpStore %192 %2497
-%2498 = OpLoad %_arr_float_uint_8 %460
-%2499 = OpCompositeExtract %float %2498 2
-OpStore %193 %2499
-%2500 = OpLoad %ulong %192
-%2501 = OpLoad %float %193
-%2502 = OpFunctionCall %ulong %5 %2500 %2501
-OpStore %194 %2502
-%2503 = OpLoad %_arr_float_uint_8 %460
-%2504 = OpCompositeExtract %float %2503 3
-OpStore %195 %2504
-%2505 = OpLoad %ulong %194
-%2506 = OpLoad %float %195
-%2507 = OpFunctionCall %ulong %5 %2505 %2506
-OpStore %196 %2507
-%2508 = OpLoad %_arr_float_uint_8 %460
-%2509 = OpCompositeExtract %float %2508 4
-OpStore %197 %2509
-%2510 = OpLoad %ulong %196
-%2511 = OpLoad %float %197
-%2512 = OpFunctionCall %ulong %5 %2510 %2511
-OpStore %198 %2512
-%2513 = OpLoad %_arr_float_uint_8 %460
-%2514 = OpCompositeExtract %float %2513 5
-OpStore %199 %2514
-%2515 = OpLoad %ulong %198
-%2516 = OpLoad %float %199
-%2517 = OpFunctionCall %ulong %5 %2515 %2516
-OpStore %200 %2517
-%2518 = OpLoad %_arr_float_uint_8 %460
-%2519 = OpCompositeExtract %float %2518 6
-OpStore %201 %2519
-%2520 = OpLoad %ulong %200
-%2521 = OpLoad %float %201
-%2522 = OpFunctionCall %ulong %5 %2520 %2521
-OpStore %202 %2522
-%2523 = OpLoad %_arr_float_uint_8 %460
-%2524 = OpCompositeExtract %float %2523 7
-OpStore %203 %2524
-%2525 = OpLoad %ulong %202
-%2526 = OpLoad %float %203
-%2527 = OpFunctionCall %ulong %5 %2525 %2526
-OpStore %204 %2527
-OpBranch %89
-%89 = OpLabel
-%2528 = OpLoad %_arr_float_uint_8 %170
-%2529 = OpCompositeExtract %float %2528 0
-OpStore %525 %2529
-%2530 = OpLoad %_arr_float_uint_8 %460
-%2531 = OpCompositeExtract %float %2530 0
-OpStore %526 %2531
-%2532 = OpLoad %float %525
-%2533 = OpLoad %float %526
-%2534 = OpFAdd %float %2532 %2533
-OpStore %527 %2534
-%2535 = OpLoad %_arr_float_uint_8 %170
-%2536 = OpCompositeExtract %float %2535 1
-OpStore %528 %2536
-%2537 = OpLoad %_arr_float_uint_8 %460
-%2538 = OpCompositeExtract %float %2537 1
-OpStore %529 %2538
-%2539 = OpLoad %float %528
-%2540 = OpLoad %float %529
-%2541 = OpFAdd %float %2539 %2540
-OpStore %530 %2541
-%2542 = OpLoad %_arr_float_uint_8 %170
-%2543 = OpCompositeExtract %float %2542 2
-OpStore %531 %2543
-%2544 = OpLoad %_arr_float_uint_8 %460
-%2545 = OpCompositeExtract %float %2544 2
-OpStore %532 %2545
-%2546 = OpLoad %float %531
-%2547 = OpLoad %float %532
-%2548 = OpFAdd %float %2546 %2547
-OpStore %533 %2548
-%2549 = OpLoad %_arr_float_uint_8 %170
-%2550 = OpCompositeExtract %float %2549 3
-OpStore %534 %2550
-%2551 = OpLoad %_arr_float_uint_8 %460
-%2552 = OpCompositeExtract %float %2551 3
-OpStore %535 %2552
-%2553 = OpLoad %float %534
-%2554 = OpLoad %float %535
-%2555 = OpFAdd %float %2553 %2554
-OpStore %536 %2555
-%2556 = OpLoad %_arr_float_uint_8 %170
-%2557 = OpCompositeExtract %float %2556 4
-OpStore %537 %2557
-%2558 = OpLoad %_arr_float_uint_8 %460
-%2559 = OpCompositeExtract %float %2558 4
-OpStore %538 %2559
-%2560 = OpLoad %float %537
-%2561 = OpLoad %float %538
-%2562 = OpFAdd %float %2560 %2561
-OpStore %539 %2562
-%2563 = OpLoad %_arr_float_uint_8 %170
-%2564 = OpCompositeExtract %float %2563 5
-OpStore %540 %2564
-%2565 = OpLoad %_arr_float_uint_8 %460
-%2566 = OpCompositeExtract %float %2565 5
-OpStore %541 %2566
-%2567 = OpLoad %float %540
-%2568 = OpLoad %float %541
-%2569 = OpFAdd %float %2567 %2568
-OpStore %542 %2569
-%2570 = OpLoad %_arr_float_uint_8 %170
-%2571 = OpCompositeExtract %float %2570 6
-OpStore %543 %2571
-%2572 = OpLoad %_arr_float_uint_8 %460
-%2573 = OpCompositeExtract %float %2572 6
-OpStore %544 %2573
-%2574 = OpLoad %float %543
-%2575 = OpLoad %float %544
-%2576 = OpFAdd %float %2574 %2575
-OpStore %545 %2576
-%2577 = OpLoad %_arr_float_uint_8 %170
-%2578 = OpCompositeExtract %float %2577 7
-OpStore %546 %2578
-%2579 = OpLoad %_arr_float_uint_8 %460
-%2580 = OpCompositeExtract %float %2579 7
-OpStore %547 %2580
-%2581 = OpLoad %float %546
-%2582 = OpLoad %float %547
-%2583 = OpFAdd %float %2581 %2582
-OpStore %548 %2583
-%2584 = OpLoad %_arr_float_uint_8 %170
-%2585 = OpLoad %float %527
-%2586 = OpCompositeInsert %_arr_float_uint_8 %2585 %2584 0
-OpStore %549 %2586
-%2587 = OpLoad %_arr_float_uint_8 %549
-%2588 = OpLoad %float %530
-%2589 = OpCompositeInsert %_arr_float_uint_8 %2588 %2587 1
-OpStore %550 %2589
-%2590 = OpLoad %_arr_float_uint_8 %550
-%2591 = OpLoad %float %533
-%2592 = OpCompositeInsert %_arr_float_uint_8 %2591 %2590 2
-OpStore %551 %2592
-%2593 = OpLoad %_arr_float_uint_8 %551
-%2594 = OpLoad %float %536
-%2595 = OpCompositeInsert %_arr_float_uint_8 %2594 %2593 3
-OpStore %552 %2595
-%2596 = OpLoad %_arr_float_uint_8 %552
-%2597 = OpLoad %float %539
-%2598 = OpCompositeInsert %_arr_float_uint_8 %2597 %2596 4
-OpStore %553 %2598
-%2599 = OpLoad %_arr_float_uint_8 %553
-%2600 = OpLoad %float %542
-%2601 = OpCompositeInsert %_arr_float_uint_8 %2600 %2599 5
-OpStore %554 %2601
-%2602 = OpLoad %_arr_float_uint_8 %554
-%2603 = OpLoad %float %545
-%2604 = OpCompositeInsert %_arr_float_uint_8 %2603 %2602 6
-OpStore %555 %2604
-%2605 = OpLoad %_arr_float_uint_8 %555
-%2606 = OpLoad %float %548
-%2607 = OpCompositeInsert %_arr_float_uint_8 %2606 %2605 7
-OpStore %556 %2607
-OpBranch %96
-%96 = OpLabel
-%2608 = OpLoad %_arr_float_uint_8 %556
-%2609 = OpCompositeExtract %float %2608 0
-OpStore %253 %2609
-%2610 = OpLoad %ulong %204
-%2611 = OpLoad %float %253
-%2612 = OpFunctionCall %ulong %5 %2610 %2611
-OpStore %254 %2612
-%2613 = OpLoad %_arr_float_uint_8 %556
-%2614 = OpCompositeExtract %float %2613 1
-OpStore %255 %2614
-%2615 = OpLoad %ulong %254
-%2616 = OpLoad %float %255
-%2617 = OpFunctionCall %ulong %5 %2615 %2616
-OpStore %256 %2617
-%2618 = OpLoad %_arr_float_uint_8 %556
-%2619 = OpCompositeExtract %float %2618 2
-OpStore %257 %2619
-%2620 = OpLoad %ulong %256
-%2621 = OpLoad %float %257
-%2622 = OpFunctionCall %ulong %5 %2620 %2621
-OpStore %258 %2622
-%2623 = OpLoad %_arr_float_uint_8 %556
-%2624 = OpCompositeExtract %float %2623 3
-OpStore %259 %2624
-%2625 = OpLoad %ulong %258
-%2626 = OpLoad %float %259
-%2627 = OpFunctionCall %ulong %5 %2625 %2626
-OpStore %260 %2627
-%2628 = OpLoad %_arr_float_uint_8 %556
-%2629 = OpCompositeExtract %float %2628 4
-OpStore %261 %2629
-%2630 = OpLoad %ulong %260
-%2631 = OpLoad %float %261
-%2632 = OpFunctionCall %ulong %5 %2630 %2631
-OpStore %262 %2632
-%2633 = OpLoad %_arr_float_uint_8 %556
-%2634 = OpCompositeExtract %float %2633 5
-OpStore %263 %2634
-%2635 = OpLoad %ulong %262
-%2636 = OpLoad %float %263
-%2637 = OpFunctionCall %ulong %5 %2635 %2636
-OpStore %264 %2637
-%2638 = OpLoad %_arr_float_uint_8 %556
-%2639 = OpCompositeExtract %float %2638 6
-OpStore %265 %2639
-%2640 = OpLoad %ulong %264
-%2641 = OpLoad %float %265
-%2642 = OpFunctionCall %ulong %5 %2640 %2641
-OpStore %266 %2642
-%2643 = OpLoad %_arr_float_uint_8 %556
-%2644 = OpCompositeExtract %float %2643 7
-OpStore %267 %2644
-%2645 = OpLoad %ulong %266
-%2646 = OpLoad %float %267
-%2647 = OpFunctionCall %ulong %5 %2645 %2646
-OpStore %268 %2647
-OpBranch %97
-%97 = OpLabel
-%2648 = OpLoad %_arr_float_uint_8 %169
-%2649 = OpCompositeExtract %float %2648 0
-OpStore %589 %2649
-%2650 = OpLoad %_arr_float_uint_8 %152
-%2651 = OpCompositeExtract %float %2650 0
-OpStore %590 %2651
-%2652 = OpLoad %float %589
-%2653 = OpLoad %float %590
-%2654 = OpFSub %float %2652 %2653
-OpStore %591 %2654
-%2655 = OpLoad %_arr_float_uint_8 %169
-%2656 = OpCompositeExtract %float %2655 1
-OpStore %592 %2656
-%2657 = OpLoad %_arr_float_uint_8 %152
-%2658 = OpCompositeExtract %float %2657 1
-OpStore %593 %2658
-%2659 = OpLoad %float %592
-%2660 = OpLoad %float %593
-%2661 = OpFSub %float %2659 %2660
-OpStore %594 %2661
-%2662 = OpLoad %_arr_float_uint_8 %169
-%2663 = OpCompositeExtract %float %2662 2
-OpStore %595 %2663
-%2664 = OpLoad %_arr_float_uint_8 %152
-%2665 = OpCompositeExtract %float %2664 2
-OpStore %596 %2665
-%2666 = OpLoad %float %595
-%2667 = OpLoad %float %596
-%2668 = OpFSub %float %2666 %2667
-OpStore %597 %2668
-%2669 = OpLoad %_arr_float_uint_8 %169
-%2670 = OpCompositeExtract %float %2669 3
-OpStore %598 %2670
-%2671 = OpLoad %_arr_float_uint_8 %152
-%2672 = OpCompositeExtract %float %2671 3
-OpStore %599 %2672
-%2673 = OpLoad %float %598
-%2674 = OpLoad %float %599
-%2675 = OpFSub %float %2673 %2674
-OpStore %600 %2675
-%2676 = OpLoad %_arr_float_uint_8 %169
-%2677 = OpCompositeExtract %float %2676 4
-OpStore %601 %2677
-%2678 = OpLoad %_arr_float_uint_8 %152
-%2679 = OpCompositeExtract %float %2678 4
-OpStore %602 %2679
-%2680 = OpLoad %float %601
-%2681 = OpLoad %float %602
-%2682 = OpFSub %float %2680 %2681
-OpStore %603 %2682
-%2683 = OpLoad %_arr_float_uint_8 %169
-%2684 = OpCompositeExtract %float %2683 5
-OpStore %604 %2684
-%2685 = OpLoad %_arr_float_uint_8 %152
-%2686 = OpCompositeExtract %float %2685 5
-OpStore %605 %2686
-%2687 = OpLoad %float %604
-%2688 = OpLoad %float %605
-%2689 = OpFSub %float %2687 %2688
-OpStore %606 %2689
-%2690 = OpLoad %_arr_float_uint_8 %169
-%2691 = OpCompositeExtract %float %2690 6
-OpStore %607 %2691
-%2692 = OpLoad %_arr_float_uint_8 %152
-%2693 = OpCompositeExtract %float %2692 6
-OpStore %608 %2693
-%2694 = OpLoad %float %607
-%2695 = OpLoad %float %608
-%2696 = OpFSub %float %2694 %2695
-OpStore %609 %2696
-%2697 = OpLoad %_arr_float_uint_8 %169
-%2698 = OpCompositeExtract %float %2697 7
-OpStore %610 %2698
-%2699 = OpLoad %_arr_float_uint_8 %152
-%2700 = OpCompositeExtract %float %2699 7
-OpStore %611 %2700
-%2701 = OpLoad %float %610
-%2702 = OpLoad %float %611
-%2703 = OpFSub %float %2701 %2702
-OpStore %612 %2703
-%2704 = OpLoad %_arr_float_uint_8 %169
-%2705 = OpLoad %float %591
-%2706 = OpCompositeInsert %_arr_float_uint_8 %2705 %2704 0
-OpStore %613 %2706
-%2707 = OpLoad %_arr_float_uint_8 %613
-%2708 = OpLoad %float %594
-%2709 = OpCompositeInsert %_arr_float_uint_8 %2708 %2707 1
-OpStore %614 %2709
-%2710 = OpLoad %_arr_float_uint_8 %614
-%2711 = OpLoad %float %597
-%2712 = OpCompositeInsert %_arr_float_uint_8 %2711 %2710 2
-OpStore %615 %2712
-%2713 = OpLoad %_arr_float_uint_8 %615
-%2714 = OpLoad %float %600
-%2715 = OpCompositeInsert %_arr_float_uint_8 %2714 %2713 3
-OpStore %616 %2715
-%2716 = OpLoad %_arr_float_uint_8 %616
-%2717 = OpLoad %float %603
-%2718 = OpCompositeInsert %_arr_float_uint_8 %2717 %2716 4
-OpStore %617 %2718
-%2719 = OpLoad %_arr_float_uint_8 %617
-%2720 = OpLoad %float %606
-%2721 = OpCompositeInsert %_arr_float_uint_8 %2720 %2719 5
-OpStore %618 %2721
-%2722 = OpLoad %_arr_float_uint_8 %618
-%2723 = OpLoad %float %609
-%2724 = OpCompositeInsert %_arr_float_uint_8 %2723 %2722 6
-OpStore %619 %2724
-%2725 = OpLoad %_arr_float_uint_8 %619
-%2726 = OpLoad %float %612
-%2727 = OpCompositeInsert %_arr_float_uint_8 %2726 %2725 7
-OpStore %620 %2727
-OpBranch %100
-%100 = OpLabel
-%2728 = OpLoad %_arr_float_uint_8 %620
-%2729 = OpCompositeExtract %float %2728 0
-OpStore %285 %2729
-%2730 = OpLoad %ulong %268
-%2731 = OpLoad %float %285
-%2732 = OpFunctionCall %ulong %5 %2730 %2731
-OpStore %286 %2732
-%2733 = OpLoad %_arr_float_uint_8 %620
-%2734 = OpCompositeExtract %float %2733 1
-OpStore %287 %2734
-%2735 = OpLoad %ulong %286
-%2736 = OpLoad %float %287
-%2737 = OpFunctionCall %ulong %5 %2735 %2736
-OpStore %288 %2737
-%2738 = OpLoad %_arr_float_uint_8 %620
-%2739 = OpCompositeExtract %float %2738 2
-OpStore %289 %2739
-%2740 = OpLoad %ulong %288
-%2741 = OpLoad %float %289
-%2742 = OpFunctionCall %ulong %5 %2740 %2741
-OpStore %290 %2742
-%2743 = OpLoad %_arr_float_uint_8 %620
-%2744 = OpCompositeExtract %float %2743 3
-OpStore %291 %2744
-%2745 = OpLoad %ulong %290
-%2746 = OpLoad %float %291
-%2747 = OpFunctionCall %ulong %5 %2745 %2746
-OpStore %292 %2747
-%2748 = OpLoad %_arr_float_uint_8 %620
-%2749 = OpCompositeExtract %float %2748 4
-OpStore %293 %2749
-%2750 = OpLoad %ulong %292
-%2751 = OpLoad %float %293
-%2752 = OpFunctionCall %ulong %5 %2750 %2751
-OpStore %294 %2752
-%2753 = OpLoad %_arr_float_uint_8 %620
-%2754 = OpCompositeExtract %float %2753 5
-OpStore %295 %2754
-%2755 = OpLoad %ulong %294
-%2756 = OpLoad %float %295
-%2757 = OpFunctionCall %ulong %5 %2755 %2756
-OpStore %296 %2757
-%2758 = OpLoad %_arr_float_uint_8 %620
-%2759 = OpCompositeExtract %float %2758 6
-OpStore %297 %2759
-%2760 = OpLoad %ulong %296
-%2761 = OpLoad %float %297
-%2762 = OpFunctionCall %ulong %5 %2760 %2761
-OpStore %298 %2762
-%2763 = OpLoad %_arr_float_uint_8 %620
-%2764 = OpCompositeExtract %float %2763 7
-OpStore %299 %2764
-%2765 = OpLoad %ulong %298
-%2766 = OpLoad %float %299
-%2767 = OpFunctionCall %ulong %5 %2765 %2766
-OpStore %300 %2767
-OpBranch %101
-%101 = OpLabel
-%2768 = OpLoad %ulong %171
-%2769 = OpIAdd %ulong %2768 %ulong_1
-OpStore %156 %2769
-%2770 = OpLoad %ulong %300
-OpStore %168 %2770
-%2771 = OpLoad %_arr_float_uint_8 %620
-OpStore %169 %2771
-%2772 = OpLoad %_arr_float_uint_8 %556
-OpStore %170 %2772
-%2773 = OpLoad %ulong %156
-OpStore %171 %2773
-OpBranch %119
-%118 = OpLabel
-OpBranch %83
-%119 = OpLabel
-OpBranch %80
-OpFunctionEnd
-%3 = OpFunction %ulong None %2774
-%2775 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %2777
-%2778 = OpFunctionParameter %ulong
-%2779 = OpFunctionParameter %uint
-%2780 = OpLabel
-%2787 = OpVariable %_ptr_Function_ulong Function
-%2788 = OpVariable %_ptr_Function_uint Function
-%2789 = OpVariable %_ptr_Function_ulong Function
-%2790 = OpVariable %_ptr_Function_bool Function
-%2791 = OpVariable %_ptr_Function_ulong Function
-%2792 = OpVariable %_ptr_Function_ulong Function
-%2793 = OpVariable %_ptr_Function_ulong Function
-%2794 = OpVariable %_ptr_Function_ulong Function
-%2795 = OpVariable %_ptr_Function_ulong Function
-%2796 = OpVariable %_ptr_Function_ulong Function
-%2797 = OpVariable %_ptr_Function_ulong Function
-%2798 = OpVariable %_ptr_Function_ulong Function
-OpStore %2787 %2778
-OpStore %2788 %2779
-%2799 = OpLoad %uint %2788
-%2800 = OpUConvert %ulong %2799
-OpStore %2789 %2800
-OpBranch %2781
-%2781 = OpLabel
-%2801 = OpLoad %ulong %2787
-OpStore %2797 %2801
-OpStore %2798 %ulong_0
-OpBranch %2782
-%2782 = OpLabel
-%2802 = OpLoad %ulong %2798
-%2804 = OpULessThan %bool %2802 %ulong_8
-OpStore %2790 %2804
-%2805 = OpLoad %bool %2790
-OpLoopMerge %2784 %2786 None
-OpBranchConditional %2805 %2783 %2784
-%2784 = OpLabel
-OpBranch %2785
-%2785 = OpLabel
-%2806 = OpLoad %ulong %2797
-OpReturnValue %2806
-%2783 = OpLabel
-%2807 = OpLoad %ulong %2798
-%2808 = OpIMul %ulong %2807 %ulong_8
-OpStore %2791 %2808
-%2809 = OpLoad %ulong %2789
-%2810 = OpLoad %ulong %2791
-%2811 = OpShiftRightLogical %ulong %2809 %2810
-OpStore %2792 %2811
-%2812 = OpLoad %ulong %2792
-%2814 = OpBitwiseAnd %ulong %2812 %ulong_255
-OpStore %2793 %2814
-%2815 = OpLoad %ulong %2797
-%2816 = OpLoad %ulong %2793
-%2817 = OpBitwiseXor %ulong %2815 %2816
-OpStore %2794 %2817
-%2818 = OpLoad %ulong %2794
-%2820 = OpIMul %ulong %2818 %ulong_1099511628211
-OpStore %2795 %2820
-%2821 = OpLoad %ulong %2798
-%2822 = OpIAdd %ulong %2821 %ulong_1
-OpStore %2796 %2822
-%2823 = OpLoad %ulong %2795
-OpStore %2797 %2823
-%2824 = OpLoad %ulong %2796
-OpStore %2798 %2824
-OpBranch %2786
-%2786 = OpLabel
-OpBranch %2782
-OpFunctionEnd
-%5 = OpFunction %ulong None %2825
-%2826 = OpFunctionParameter %ulong
-%2827 = OpFunctionParameter %float
-%2828 = OpLabel
-%2835 = OpVariable %_ptr_Function_ulong Function
-%2836 = OpVariable %_ptr_Function_float Function
-%2837 = OpVariable %_ptr_Function_uint Function
-%2838 = OpVariable %_ptr_Function_ulong Function
-%2839 = OpVariable %_ptr_Function_bool Function
-%2840 = OpVariable %_ptr_Function_ulong Function
-%2841 = OpVariable %_ptr_Function_ulong Function
-%2842 = OpVariable %_ptr_Function_ulong Function
-%2843 = OpVariable %_ptr_Function_ulong Function
-%2844 = OpVariable %_ptr_Function_ulong Function
-%2845 = OpVariable %_ptr_Function_ulong Function
-%2846 = OpVariable %_ptr_Function_ulong Function
-%2847 = OpVariable %_ptr_Function_ulong Function
-OpStore %2835 %2826
-OpStore %2836 %2827
-%2848 = OpLoad %float %2836
-%2849 = OpBitcast %uint %2848
-OpStore %2837 %2849
-%2850 = OpLoad %uint %2837
-%2851 = OpUConvert %ulong %2850
-OpStore %2838 %2851
-OpBranch %2829
-%2829 = OpLabel
-%2852 = OpLoad %ulong %2835
-OpStore %2846 %2852
-OpStore %2847 %ulong_0
-OpBranch %2830
-%2830 = OpLabel
-%2853 = OpLoad %ulong %2847
-%2854 = OpULessThan %bool %2853 %ulong_8
-OpStore %2839 %2854
-%2855 = OpLoad %bool %2839
-OpLoopMerge %2832 %2834 None
-OpBranchConditional %2855 %2831 %2832
-%2832 = OpLabel
-OpBranch %2833
-%2833 = OpLabel
-%2856 = OpLoad %ulong %2846
-OpReturnValue %2856
-%2831 = OpLabel
-%2857 = OpLoad %ulong %2847
-%2858 = OpIMul %ulong %2857 %ulong_8
-OpStore %2840 %2858
-%2859 = OpLoad %ulong %2838
-%2860 = OpLoad %ulong %2840
-%2861 = OpShiftRightLogical %ulong %2859 %2860
-OpStore %2841 %2861
-%2862 = OpLoad %ulong %2841
-%2863 = OpBitwiseAnd %ulong %2862 %ulong_255
-OpStore %2842 %2863
-%2864 = OpLoad %ulong %2846
-%2865 = OpLoad %ulong %2842
-%2866 = OpBitwiseXor %ulong %2864 %2865
-OpStore %2843 %2866
-%2867 = OpLoad %ulong %2843
-%2868 = OpIMul %ulong %2867 %ulong_1099511628211
-OpStore %2844 %2868
-%2869 = OpLoad %ulong %2847
-%2870 = OpIAdd %ulong %2869 %ulong_1
-OpStore %2845 %2870
-%2871 = OpLoad %ulong %2844
-OpStore %2846 %2871
-%2872 = OpLoad %ulong %2845
-OpStore %2847 %2872
-OpBranch %2834
-%2834 = OpLabel
-OpBranch %2830
+OpStore %943 %1748
+%1749 = OpLoad %_arr_float_uint_8 %447
+%1750 = OpCompositeExtract %float %1749 7
+OpStore %944 %1750
+%1751 = OpLoad %float %943
+%1752 = OpLoad %float %944
+%1753 = OpFDiv %float %1751 %1752
+OpStore %945 %1753
+%1754 = OpLoad %_arr_float_uint_8 %441
+%1755 = OpLoad %float %924
+%1756 = OpCompositeInsert %_arr_float_uint_8 %1755 %1754 0
+OpStore %946 %1756
+%1757 = OpLoad %_arr_float_uint_8 %946
+%1758 = OpLoad %float %927
+%1759 = OpCompositeInsert %_arr_float_uint_8 %1758 %1757 1
+OpStore %947 %1759
+%1760 = OpLoad %_arr_float_uint_8 %947
+%1761 = OpLoad %float %930
+%1762 = OpCompositeInsert %_arr_float_uint_8 %1761 %1760 2
+OpStore %948 %1762
+%1763 = OpLoad %_arr_float_uint_8 %948
+%1764 = OpLoad %float %933
+%1765 = OpCompositeInsert %_arr_float_uint_8 %1764 %1763 3
+OpStore %949 %1765
+%1766 = OpLoad %_arr_float_uint_8 %949
+%1767 = OpLoad %float %936
+%1768 = OpCompositeInsert %_arr_float_uint_8 %1767 %1766 4
+OpStore %950 %1768
+%1769 = OpLoad %_arr_float_uint_8 %950
+%1770 = OpLoad %float %939
+%1771 = OpCompositeInsert %_arr_float_uint_8 %1770 %1769 5
+OpStore %951 %1771
+%1772 = OpLoad %_arr_float_uint_8 %951
+%1773 = OpLoad %float %942
+%1774 = OpCompositeInsert %_arr_float_uint_8 %1773 %1772 6
+OpStore %952 %1774
+%1775 = OpLoad %_arr_float_uint_8 %952
+%1776 = OpLoad %float %945
+%1777 = OpCompositeInsert %_arr_float_uint_8 %1776 %1775 7
+OpStore %953 %1777
+%1778 = OpLoad %ulong %463
+%1779 = OpLoad %_arr_float_uint_8 %953
+%1780 = OpFunctionCall %ulong %1 %1778 %1779
+OpStore %464 %1780
+%1781 = OpCompositeConstruct %_arr_float_uint_8 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0 %float_0
+OpStore %465 %1781
+%1783 = OpLoad %ulong %464
+OpStore %481 %1783
+%1784 = OpLoad %_arr_float_uint_8 %447
+OpStore %482 %1784
+%1785 = OpLoad %_arr_float_uint_8 %465
+OpStore %483 %1785
+OpStore %484 %ulong_0
+OpBranch %397
+%397 = OpLabel
+%1786 = OpLoad %ulong %484
+%1788 = OpULessThan %bool %1786 %ulong_6
+OpStore %466 %1788
+%1789 = OpLoad %bool %466
+OpLoopMerge %399 %422 None
+OpBranchConditional %1789 %398 %399
+%399 = OpLabel
+OpStore %426 %1790
+%1792 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %uint_0
+%1793 = OpLoad %_arr_float_uint_8 %482
+OpStore %1792 %1793
+%1794 = OpLoad %_arr_float_uint_8 %482
+%1795 = OpCompositeExtract %float %1794 0
+OpStore %602 %1795
+%1796 = OpLoad %_arr_float_uint_8 %453
+%1797 = OpCompositeExtract %float %1796 0
+OpStore %603 %1797
+%1798 = OpLoad %float %602
+%1799 = OpLoad %float %603
+%1800 = OpFAdd %float %1798 %1799
+OpStore %604 %1800
+%1801 = OpLoad %_arr_float_uint_8 %482
+%1802 = OpCompositeExtract %float %1801 1
+OpStore %605 %1802
+%1803 = OpLoad %_arr_float_uint_8 %453
+%1804 = OpCompositeExtract %float %1803 1
+OpStore %606 %1804
+%1805 = OpLoad %float %605
+%1806 = OpLoad %float %606
+%1807 = OpFAdd %float %1805 %1806
+OpStore %607 %1807
+%1808 = OpLoad %_arr_float_uint_8 %482
+%1809 = OpCompositeExtract %float %1808 2
+OpStore %608 %1809
+%1810 = OpLoad %_arr_float_uint_8 %453
+%1811 = OpCompositeExtract %float %1810 2
+OpStore %609 %1811
+%1812 = OpLoad %float %608
+%1813 = OpLoad %float %609
+%1814 = OpFAdd %float %1812 %1813
+OpStore %610 %1814
+%1815 = OpLoad %_arr_float_uint_8 %482
+%1816 = OpCompositeExtract %float %1815 3
+OpStore %611 %1816
+%1817 = OpLoad %_arr_float_uint_8 %453
+%1818 = OpCompositeExtract %float %1817 3
+OpStore %612 %1818
+%1819 = OpLoad %float %611
+%1820 = OpLoad %float %612
+%1821 = OpFAdd %float %1819 %1820
+OpStore %613 %1821
+%1822 = OpLoad %_arr_float_uint_8 %482
+%1823 = OpCompositeExtract %float %1822 4
+OpStore %614 %1823
+%1824 = OpLoad %_arr_float_uint_8 %453
+%1825 = OpCompositeExtract %float %1824 4
+OpStore %615 %1825
+%1826 = OpLoad %float %614
+%1827 = OpLoad %float %615
+%1828 = OpFAdd %float %1826 %1827
+OpStore %616 %1828
+%1829 = OpLoad %_arr_float_uint_8 %482
+%1830 = OpCompositeExtract %float %1829 5
+OpStore %617 %1830
+%1831 = OpLoad %_arr_float_uint_8 %453
+%1832 = OpCompositeExtract %float %1831 5
+OpStore %618 %1832
+%1833 = OpLoad %float %617
+%1834 = OpLoad %float %618
+%1835 = OpFAdd %float %1833 %1834
+OpStore %619 %1835
+%1836 = OpLoad %_arr_float_uint_8 %482
+%1837 = OpCompositeExtract %float %1836 6
+OpStore %620 %1837
+%1838 = OpLoad %_arr_float_uint_8 %453
+%1839 = OpCompositeExtract %float %1838 6
+OpStore %621 %1839
+%1840 = OpLoad %float %620
+%1841 = OpLoad %float %621
+%1842 = OpFAdd %float %1840 %1841
+OpStore %622 %1842
+%1843 = OpLoad %_arr_float_uint_8 %482
+%1844 = OpCompositeExtract %float %1843 7
+OpStore %623 %1844
+%1845 = OpLoad %_arr_float_uint_8 %453
+%1846 = OpCompositeExtract %float %1845 7
+OpStore %624 %1846
+%1847 = OpLoad %float %623
+%1848 = OpLoad %float %624
+%1849 = OpFAdd %float %1847 %1848
+OpStore %625 %1849
+%1850 = OpLoad %_arr_float_uint_8 %482
+%1851 = OpLoad %float %604
+%1852 = OpCompositeInsert %_arr_float_uint_8 %1851 %1850 0
+OpStore %626 %1852
+%1853 = OpLoad %_arr_float_uint_8 %626
+%1854 = OpLoad %float %607
+%1855 = OpCompositeInsert %_arr_float_uint_8 %1854 %1853 1
+OpStore %627 %1855
+%1856 = OpLoad %_arr_float_uint_8 %627
+%1857 = OpLoad %float %610
+%1858 = OpCompositeInsert %_arr_float_uint_8 %1857 %1856 2
+OpStore %628 %1858
+%1859 = OpLoad %_arr_float_uint_8 %628
+%1860 = OpLoad %float %613
+%1861 = OpCompositeInsert %_arr_float_uint_8 %1860 %1859 3
+OpStore %629 %1861
+%1862 = OpLoad %_arr_float_uint_8 %629
+%1863 = OpLoad %float %616
+%1864 = OpCompositeInsert %_arr_float_uint_8 %1863 %1862 4
+OpStore %630 %1864
+%1865 = OpLoad %_arr_float_uint_8 %630
+%1866 = OpLoad %float %619
+%1867 = OpCompositeInsert %_arr_float_uint_8 %1866 %1865 5
+OpStore %631 %1867
+%1868 = OpLoad %_arr_float_uint_8 %631
+%1869 = OpLoad %float %622
+%1870 = OpCompositeInsert %_arr_float_uint_8 %1869 %1868 6
+OpStore %632 %1870
+%1871 = OpLoad %_arr_float_uint_8 %632
+%1872 = OpLoad %float %625
+%1873 = OpCompositeInsert %_arr_float_uint_8 %1872 %1871 7
+OpStore %633 %1873
+%1875 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %uint_1
+%1876 = OpLoad %_arr_float_uint_8 %633
+OpStore %1875 %1876
+%1877 = OpLoad %_arr_float_uint_8 %482
+%1878 = OpCompositeExtract %float %1877 0
+OpStore %634 %1878
+%1879 = OpLoad %_arr_float_uint_8 %441
+%1880 = OpCompositeExtract %float %1879 0
+OpStore %635 %1880
+%1881 = OpLoad %float %634
+%1882 = OpLoad %float %635
+%1883 = OpFMul %float %1881 %1882
+OpStore %636 %1883
+%1884 = OpLoad %_arr_float_uint_8 %482
+%1885 = OpCompositeExtract %float %1884 1
+OpStore %637 %1885
+%1886 = OpLoad %_arr_float_uint_8 %441
+%1887 = OpCompositeExtract %float %1886 1
+OpStore %638 %1887
+%1888 = OpLoad %float %637
+%1889 = OpLoad %float %638
+%1890 = OpFMul %float %1888 %1889
+OpStore %639 %1890
+%1891 = OpLoad %_arr_float_uint_8 %482
+%1892 = OpCompositeExtract %float %1891 2
+OpStore %640 %1892
+%1893 = OpLoad %_arr_float_uint_8 %441
+%1894 = OpCompositeExtract %float %1893 2
+OpStore %641 %1894
+%1895 = OpLoad %float %640
+%1896 = OpLoad %float %641
+%1897 = OpFMul %float %1895 %1896
+OpStore %642 %1897
+%1898 = OpLoad %_arr_float_uint_8 %482
+%1899 = OpCompositeExtract %float %1898 3
+OpStore %643 %1899
+%1900 = OpLoad %_arr_float_uint_8 %441
+%1901 = OpCompositeExtract %float %1900 3
+OpStore %644 %1901
+%1902 = OpLoad %float %643
+%1903 = OpLoad %float %644
+%1904 = OpFMul %float %1902 %1903
+OpStore %645 %1904
+%1905 = OpLoad %_arr_float_uint_8 %482
+%1906 = OpCompositeExtract %float %1905 4
+OpStore %646 %1906
+%1907 = OpLoad %_arr_float_uint_8 %441
+%1908 = OpCompositeExtract %float %1907 4
+OpStore %647 %1908
+%1909 = OpLoad %float %646
+%1910 = OpLoad %float %647
+%1911 = OpFMul %float %1909 %1910
+OpStore %648 %1911
+%1912 = OpLoad %_arr_float_uint_8 %482
+%1913 = OpCompositeExtract %float %1912 5
+OpStore %649 %1913
+%1914 = OpLoad %_arr_float_uint_8 %441
+%1915 = OpCompositeExtract %float %1914 5
+OpStore %650 %1915
+%1916 = OpLoad %float %649
+%1917 = OpLoad %float %650
+%1918 = OpFMul %float %1916 %1917
+OpStore %651 %1918
+%1919 = OpLoad %_arr_float_uint_8 %482
+%1920 = OpCompositeExtract %float %1919 6
+OpStore %652 %1920
+%1921 = OpLoad %_arr_float_uint_8 %441
+%1922 = OpCompositeExtract %float %1921 6
+OpStore %653 %1922
+%1923 = OpLoad %float %652
+%1924 = OpLoad %float %653
+%1925 = OpFMul %float %1923 %1924
+OpStore %654 %1925
+%1926 = OpLoad %_arr_float_uint_8 %482
+%1927 = OpCompositeExtract %float %1926 7
+OpStore %655 %1927
+%1928 = OpLoad %_arr_float_uint_8 %441
+%1929 = OpCompositeExtract %float %1928 7
+OpStore %656 %1929
+%1930 = OpLoad %float %655
+%1931 = OpLoad %float %656
+%1932 = OpFMul %float %1930 %1931
+OpStore %657 %1932
+%1933 = OpLoad %_arr_float_uint_8 %482
+%1934 = OpLoad %float %636
+%1935 = OpCompositeInsert %_arr_float_uint_8 %1934 %1933 0
+OpStore %658 %1935
+%1936 = OpLoad %_arr_float_uint_8 %658
+%1937 = OpLoad %float %639
+%1938 = OpCompositeInsert %_arr_float_uint_8 %1937 %1936 1
+OpStore %659 %1938
+%1939 = OpLoad %_arr_float_uint_8 %659
+%1940 = OpLoad %float %642
+%1941 = OpCompositeInsert %_arr_float_uint_8 %1940 %1939 2
+OpStore %660 %1941
+%1942 = OpLoad %_arr_float_uint_8 %660
+%1943 = OpLoad %float %645
+%1944 = OpCompositeInsert %_arr_float_uint_8 %1943 %1942 3
+OpStore %661 %1944
+%1945 = OpLoad %_arr_float_uint_8 %661
+%1946 = OpLoad %float %648
+%1947 = OpCompositeInsert %_arr_float_uint_8 %1946 %1945 4
+OpStore %662 %1947
+%1948 = OpLoad %_arr_float_uint_8 %662
+%1949 = OpLoad %float %651
+%1950 = OpCompositeInsert %_arr_float_uint_8 %1949 %1948 5
+OpStore %663 %1950
+%1951 = OpLoad %_arr_float_uint_8 %663
+%1952 = OpLoad %float %654
+%1953 = OpCompositeInsert %_arr_float_uint_8 %1952 %1951 6
+OpStore %664 %1953
+%1954 = OpLoad %_arr_float_uint_8 %664
+%1955 = OpLoad %float %657
+%1956 = OpCompositeInsert %_arr_float_uint_8 %1955 %1954 7
+OpStore %665 %1956
+%1958 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %uint_2
+%1959 = OpLoad %_arr_float_uint_8 %665
+OpStore %1958 %1959
+%1961 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %uint_3
+%1962 = OpLoad %_arr_float_uint_8 %483
+OpStore %1961 %1962
+%1963 = OpLoad %ulong %481
+OpStore %480 %1963
+OpStore %485 %ulong_0
+OpBranch %400
+%400 = OpLabel
+%1964 = OpLoad %ulong %485
+%1966 = OpULessThan %bool %1964 %ulong_4
+OpStore %471 %1966
+%1967 = OpLoad %bool %471
+OpLoopMerge %402 %421 None
+OpBranchConditional %1967 %401 %402
+%402 = OpLabel
+OpStore %429 %1968
+%1969 = OpAccessChain %_ptr_Function_uint %429 %uint_0
+OpStore %1969 %uint_4294967295
+%1971 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %uint_2
+%1972 = OpLoad %_arr_float_uint_8 %1971
+OpStore %475 %1972
+%1973 = OpAccessChain %_ptr_Function__arr_float_uint_8 %429 %uint_1
+%1974 = OpLoad %_arr_float_uint_8 %475
+OpStore %1973 %1974
+%1975 = OpAccessChain %_ptr_Function_uint %429 %uint_2
+OpStore %1975 %uint_305419896
+%1977 = OpLoad %uint %1969
+OpStore %476 %1977
+OpBranch %405
+%405 = OpLabel
+%1978 = OpLoad %uint %476
+%1979 = OpUConvert %ulong %1978
+OpStore %486 %1979
+OpBranch %407
+%407 = OpLabel
+%1980 = OpLoad %ulong %480
+OpStore %494 %1980
+OpStore %495 %ulong_0
+OpBranch %408
+%408 = OpLabel
+%1981 = OpLoad %ulong %495
+%1982 = OpULessThan %bool %1981 %ulong_8
+OpStore %487 %1982
+%1983 = OpLoad %bool %487
+OpLoopMerge %410 %420 None
+OpBranchConditional %1983 %409 %410
+%410 = OpLabel
+OpBranch %411
+%411 = OpLabel
+OpBranch %406
+%406 = OpLabel
+%1984 = OpAccessChain %_ptr_Function__arr_float_uint_8 %429 %uint_1
+%1985 = OpLoad %_arr_float_uint_8 %1984
+OpStore %477 %1985
+%1986 = OpLoad %ulong %494
+%1987 = OpLoad %_arr_float_uint_8 %477
+%1988 = OpFunctionCall %ulong %1 %1986 %1987
+OpStore %478 %1988
+%1989 = OpAccessChain %_ptr_Function_uint %429 %uint_2
+%1990 = OpLoad %uint %1989
+OpStore %479 %1990
+OpBranch %412
+%412 = OpLabel
+%1991 = OpLoad %uint %479
+%1992 = OpUConvert %ulong %1991
+OpStore %496 %1992
+OpBranch %414
+%414 = OpLabel
+%1993 = OpLoad %ulong %478
+OpStore %504 %1993
+OpStore %505 %ulong_0
+OpBranch %415
+%415 = OpLabel
+%1994 = OpLoad %ulong %505
+%1995 = OpULessThan %bool %1994 %ulong_8
+OpStore %497 %1995
+%1996 = OpLoad %bool %497
+OpLoopMerge %417 %419 None
+OpBranchConditional %1996 %416 %417
+%417 = OpLabel
+OpBranch %418
+%418 = OpLabel
+OpBranch %413
+%413 = OpLabel
+%1997 = OpLoad %ulong %504
+OpReturnValue %1997
+%416 = OpLabel
+%1998 = OpLoad %ulong %505
+%1999 = OpIMul %ulong %1998 %ulong_8
+OpStore %498 %1999
+%2000 = OpLoad %ulong %496
+%2001 = OpLoad %ulong %498
+%2002 = OpShiftRightLogical %ulong %2000 %2001
+OpStore %499 %2002
+%2003 = OpLoad %ulong %499
+%2004 = OpBitwiseAnd %ulong %2003 %ulong_255
+OpStore %500 %2004
+%2005 = OpLoad %ulong %504
+%2006 = OpLoad %ulong %500
+%2007 = OpBitwiseXor %ulong %2005 %2006
+OpStore %501 %2007
+%2008 = OpLoad %ulong %501
+%2009 = OpIMul %ulong %2008 %ulong_1099511628211
+OpStore %502 %2009
+%2010 = OpLoad %ulong %505
+%2011 = OpIAdd %ulong %2010 %ulong_1
+OpStore %503 %2011
+%2012 = OpLoad %ulong %502
+OpStore %504 %2012
+%2013 = OpLoad %ulong %503
+OpStore %505 %2013
+OpBranch %419
+%409 = OpLabel
+%2014 = OpLoad %ulong %495
+%2015 = OpIMul %ulong %2014 %ulong_8
+OpStore %488 %2015
+%2016 = OpLoad %ulong %486
+%2017 = OpLoad %ulong %488
+%2018 = OpShiftRightLogical %ulong %2016 %2017
+OpStore %489 %2018
+%2019 = OpLoad %ulong %489
+%2020 = OpBitwiseAnd %ulong %2019 %ulong_255
+OpStore %490 %2020
+%2021 = OpLoad %ulong %494
+%2022 = OpLoad %ulong %490
+%2023 = OpBitwiseXor %ulong %2021 %2022
+OpStore %491 %2023
+%2024 = OpLoad %ulong %491
+%2025 = OpIMul %ulong %2024 %ulong_1099511628211
+OpStore %492 %2025
+%2026 = OpLoad %ulong %495
+%2027 = OpIAdd %ulong %2026 %ulong_1
+OpStore %493 %2027
+%2028 = OpLoad %ulong %492
+OpStore %494 %2028
+%2029 = OpLoad %ulong %493
+OpStore %495 %2029
+OpBranch %420
+%401 = OpLabel
+%2030 = OpLoad %ulong %485
+%2031 = OpAccessChain %_ptr_Function__arr_float_uint_8 %426 %2030
+%2032 = OpLoad %_arr_float_uint_8 %2031
+OpStore %472 %2032
+%2033 = OpLoad %ulong %480
+%2034 = OpLoad %_arr_float_uint_8 %472
+%2035 = OpFunctionCall %ulong %1 %2033 %2034
+OpStore %473 %2035
+%2036 = OpLoad %ulong %485
+%2037 = OpIAdd %ulong %2036 %ulong_1
+OpStore %474 %2037
+%2038 = OpLoad %ulong %473
+OpStore %480 %2038
+%2039 = OpLoad %ulong %474
+OpStore %485 %2039
+OpBranch %421
+%398 = OpLabel
+%2040 = OpLoad %_arr_float_uint_8 %482
+%2041 = OpCompositeExtract %float %2040 0
+OpStore %506 %2041
+%2042 = OpLoad %_arr_float_uint_8 %441
+%2043 = OpCompositeExtract %float %2042 0
+OpStore %507 %2043
+%2044 = OpLoad %float %506
+%2045 = OpLoad %float %507
+%2046 = OpFMul %float %2044 %2045
+OpStore %508 %2046
+%2047 = OpLoad %_arr_float_uint_8 %482
+%2048 = OpCompositeExtract %float %2047 1
+OpStore %509 %2048
+%2049 = OpLoad %_arr_float_uint_8 %441
+%2050 = OpCompositeExtract %float %2049 1
+OpStore %510 %2050
+%2051 = OpLoad %float %509
+%2052 = OpLoad %float %510
+%2053 = OpFMul %float %2051 %2052
+OpStore %511 %2053
+%2054 = OpLoad %_arr_float_uint_8 %482
+%2055 = OpCompositeExtract %float %2054 2
+OpStore %512 %2055
+%2056 = OpLoad %_arr_float_uint_8 %441
+%2057 = OpCompositeExtract %float %2056 2
+OpStore %513 %2057
+%2058 = OpLoad %float %512
+%2059 = OpLoad %float %513
+%2060 = OpFMul %float %2058 %2059
+OpStore %514 %2060
+%2061 = OpLoad %_arr_float_uint_8 %482
+%2062 = OpCompositeExtract %float %2061 3
+OpStore %515 %2062
+%2063 = OpLoad %_arr_float_uint_8 %441
+%2064 = OpCompositeExtract %float %2063 3
+OpStore %516 %2064
+%2065 = OpLoad %float %515
+%2066 = OpLoad %float %516
+%2067 = OpFMul %float %2065 %2066
+OpStore %517 %2067
+%2068 = OpLoad %_arr_float_uint_8 %482
+%2069 = OpCompositeExtract %float %2068 4
+OpStore %518 %2069
+%2070 = OpLoad %_arr_float_uint_8 %441
+%2071 = OpCompositeExtract %float %2070 4
+OpStore %519 %2071
+%2072 = OpLoad %float %518
+%2073 = OpLoad %float %519
+%2074 = OpFMul %float %2072 %2073
+OpStore %520 %2074
+%2075 = OpLoad %_arr_float_uint_8 %482
+%2076 = OpCompositeExtract %float %2075 5
+OpStore %521 %2076
+%2077 = OpLoad %_arr_float_uint_8 %441
+%2078 = OpCompositeExtract %float %2077 5
+OpStore %522 %2078
+%2079 = OpLoad %float %521
+%2080 = OpLoad %float %522
+%2081 = OpFMul %float %2079 %2080
+OpStore %523 %2081
+%2082 = OpLoad %_arr_float_uint_8 %482
+%2083 = OpCompositeExtract %float %2082 6
+OpStore %524 %2083
+%2084 = OpLoad %_arr_float_uint_8 %441
+%2085 = OpCompositeExtract %float %2084 6
+OpStore %525 %2085
+%2086 = OpLoad %float %524
+%2087 = OpLoad %float %525
+%2088 = OpFMul %float %2086 %2087
+OpStore %526 %2088
+%2089 = OpLoad %_arr_float_uint_8 %482
+%2090 = OpCompositeExtract %float %2089 7
+OpStore %527 %2090
+%2091 = OpLoad %_arr_float_uint_8 %441
+%2092 = OpCompositeExtract %float %2091 7
+OpStore %528 %2092
+%2093 = OpLoad %float %527
+%2094 = OpLoad %float %528
+%2095 = OpFMul %float %2093 %2094
+OpStore %529 %2095
+%2096 = OpLoad %_arr_float_uint_8 %482
+%2097 = OpLoad %float %508
+%2098 = OpCompositeInsert %_arr_float_uint_8 %2097 %2096 0
+OpStore %530 %2098
+%2099 = OpLoad %_arr_float_uint_8 %530
+%2100 = OpLoad %float %511
+%2101 = OpCompositeInsert %_arr_float_uint_8 %2100 %2099 1
+OpStore %531 %2101
+%2102 = OpLoad %_arr_float_uint_8 %531
+%2103 = OpLoad %float %514
+%2104 = OpCompositeInsert %_arr_float_uint_8 %2103 %2102 2
+OpStore %532 %2104
+%2105 = OpLoad %_arr_float_uint_8 %532
+%2106 = OpLoad %float %517
+%2107 = OpCompositeInsert %_arr_float_uint_8 %2106 %2105 3
+OpStore %533 %2107
+%2108 = OpLoad %_arr_float_uint_8 %533
+%2109 = OpLoad %float %520
+%2110 = OpCompositeInsert %_arr_float_uint_8 %2109 %2108 4
+OpStore %534 %2110
+%2111 = OpLoad %_arr_float_uint_8 %534
+%2112 = OpLoad %float %523
+%2113 = OpCompositeInsert %_arr_float_uint_8 %2112 %2111 5
+OpStore %535 %2113
+%2114 = OpLoad %_arr_float_uint_8 %535
+%2115 = OpLoad %float %526
+%2116 = OpCompositeInsert %_arr_float_uint_8 %2115 %2114 6
+OpStore %536 %2116
+%2117 = OpLoad %_arr_float_uint_8 %536
+%2118 = OpLoad %float %529
+%2119 = OpCompositeInsert %_arr_float_uint_8 %2118 %2117 7
+OpStore %537 %2119
+%2120 = OpLoad %ulong %481
+%2121 = OpLoad %_arr_float_uint_8 %537
+%2122 = OpFunctionCall %ulong %1 %2120 %2121
+OpStore %467 %2122
+%2123 = OpLoad %_arr_float_uint_8 %483
+%2124 = OpCompositeExtract %float %2123 0
+OpStore %538 %2124
+%2125 = OpLoad %_arr_float_uint_8 %537
+%2126 = OpCompositeExtract %float %2125 0
+OpStore %539 %2126
+%2127 = OpLoad %float %538
+%2128 = OpLoad %float %539
+%2129 = OpFAdd %float %2127 %2128
+OpStore %540 %2129
+%2130 = OpLoad %_arr_float_uint_8 %483
+%2131 = OpCompositeExtract %float %2130 1
+OpStore %541 %2131
+%2132 = OpLoad %_arr_float_uint_8 %537
+%2133 = OpCompositeExtract %float %2132 1
+OpStore %542 %2133
+%2134 = OpLoad %float %541
+%2135 = OpLoad %float %542
+%2136 = OpFAdd %float %2134 %2135
+OpStore %543 %2136
+%2137 = OpLoad %_arr_float_uint_8 %483
+%2138 = OpCompositeExtract %float %2137 2
+OpStore %544 %2138
+%2139 = OpLoad %_arr_float_uint_8 %537
+%2140 = OpCompositeExtract %float %2139 2
+OpStore %545 %2140
+%2141 = OpLoad %float %544
+%2142 = OpLoad %float %545
+%2143 = OpFAdd %float %2141 %2142
+OpStore %546 %2143
+%2144 = OpLoad %_arr_float_uint_8 %483
+%2145 = OpCompositeExtract %float %2144 3
+OpStore %547 %2145
+%2146 = OpLoad %_arr_float_uint_8 %537
+%2147 = OpCompositeExtract %float %2146 3
+OpStore %548 %2147
+%2148 = OpLoad %float %547
+%2149 = OpLoad %float %548
+%2150 = OpFAdd %float %2148 %2149
+OpStore %549 %2150
+%2151 = OpLoad %_arr_float_uint_8 %483
+%2152 = OpCompositeExtract %float %2151 4
+OpStore %550 %2152
+%2153 = OpLoad %_arr_float_uint_8 %537
+%2154 = OpCompositeExtract %float %2153 4
+OpStore %551 %2154
+%2155 = OpLoad %float %550
+%2156 = OpLoad %float %551
+%2157 = OpFAdd %float %2155 %2156
+OpStore %552 %2157
+%2158 = OpLoad %_arr_float_uint_8 %483
+%2159 = OpCompositeExtract %float %2158 5
+OpStore %553 %2159
+%2160 = OpLoad %_arr_float_uint_8 %537
+%2161 = OpCompositeExtract %float %2160 5
+OpStore %554 %2161
+%2162 = OpLoad %float %553
+%2163 = OpLoad %float %554
+%2164 = OpFAdd %float %2162 %2163
+OpStore %555 %2164
+%2165 = OpLoad %_arr_float_uint_8 %483
+%2166 = OpCompositeExtract %float %2165 6
+OpStore %556 %2166
+%2167 = OpLoad %_arr_float_uint_8 %537
+%2168 = OpCompositeExtract %float %2167 6
+OpStore %557 %2168
+%2169 = OpLoad %float %556
+%2170 = OpLoad %float %557
+%2171 = OpFAdd %float %2169 %2170
+OpStore %558 %2171
+%2172 = OpLoad %_arr_float_uint_8 %483
+%2173 = OpCompositeExtract %float %2172 7
+OpStore %559 %2173
+%2174 = OpLoad %_arr_float_uint_8 %537
+%2175 = OpCompositeExtract %float %2174 7
+OpStore %560 %2175
+%2176 = OpLoad %float %559
+%2177 = OpLoad %float %560
+%2178 = OpFAdd %float %2176 %2177
+OpStore %561 %2178
+%2179 = OpLoad %_arr_float_uint_8 %483
+%2180 = OpLoad %float %540
+%2181 = OpCompositeInsert %_arr_float_uint_8 %2180 %2179 0
+OpStore %562 %2181
+%2182 = OpLoad %_arr_float_uint_8 %562
+%2183 = OpLoad %float %543
+%2184 = OpCompositeInsert %_arr_float_uint_8 %2183 %2182 1
+OpStore %563 %2184
+%2185 = OpLoad %_arr_float_uint_8 %563
+%2186 = OpLoad %float %546
+%2187 = OpCompositeInsert %_arr_float_uint_8 %2186 %2185 2
+OpStore %564 %2187
+%2188 = OpLoad %_arr_float_uint_8 %564
+%2189 = OpLoad %float %549
+%2190 = OpCompositeInsert %_arr_float_uint_8 %2189 %2188 3
+OpStore %565 %2190
+%2191 = OpLoad %_arr_float_uint_8 %565
+%2192 = OpLoad %float %552
+%2193 = OpCompositeInsert %_arr_float_uint_8 %2192 %2191 4
+OpStore %566 %2193
+%2194 = OpLoad %_arr_float_uint_8 %566
+%2195 = OpLoad %float %555
+%2196 = OpCompositeInsert %_arr_float_uint_8 %2195 %2194 5
+OpStore %567 %2196
+%2197 = OpLoad %_arr_float_uint_8 %567
+%2198 = OpLoad %float %558
+%2199 = OpCompositeInsert %_arr_float_uint_8 %2198 %2197 6
+OpStore %568 %2199
+%2200 = OpLoad %_arr_float_uint_8 %568
+%2201 = OpLoad %float %561
+%2202 = OpCompositeInsert %_arr_float_uint_8 %2201 %2200 7
+OpStore %569 %2202
+%2203 = OpLoad %ulong %467
+%2204 = OpLoad %_arr_float_uint_8 %569
+%2205 = OpFunctionCall %ulong %1 %2203 %2204
+OpStore %468 %2205
+%2206 = OpLoad %_arr_float_uint_8 %482
+%2207 = OpCompositeExtract %float %2206 0
+OpStore %570 %2207
+%2208 = OpLoad %_arr_float_uint_8 %453
+%2209 = OpCompositeExtract %float %2208 0
+OpStore %571 %2209
+%2210 = OpLoad %float %570
+%2211 = OpLoad %float %571
+%2212 = OpFSub %float %2210 %2211
+OpStore %572 %2212
+%2213 = OpLoad %_arr_float_uint_8 %482
+%2214 = OpCompositeExtract %float %2213 1
+OpStore %573 %2214
+%2215 = OpLoad %_arr_float_uint_8 %453
+%2216 = OpCompositeExtract %float %2215 1
+OpStore %574 %2216
+%2217 = OpLoad %float %573
+%2218 = OpLoad %float %574
+%2219 = OpFSub %float %2217 %2218
+OpStore %575 %2219
+%2220 = OpLoad %_arr_float_uint_8 %482
+%2221 = OpCompositeExtract %float %2220 2
+OpStore %576 %2221
+%2222 = OpLoad %_arr_float_uint_8 %453
+%2223 = OpCompositeExtract %float %2222 2
+OpStore %577 %2223
+%2224 = OpLoad %float %576
+%2225 = OpLoad %float %577
+%2226 = OpFSub %float %2224 %2225
+OpStore %578 %2226
+%2227 = OpLoad %_arr_float_uint_8 %482
+%2228 = OpCompositeExtract %float %2227 3
+OpStore %579 %2228
+%2229 = OpLoad %_arr_float_uint_8 %453
+%2230 = OpCompositeExtract %float %2229 3
+OpStore %580 %2230
+%2231 = OpLoad %float %579
+%2232 = OpLoad %float %580
+%2233 = OpFSub %float %2231 %2232
+OpStore %581 %2233
+%2234 = OpLoad %_arr_float_uint_8 %482
+%2235 = OpCompositeExtract %float %2234 4
+OpStore %582 %2235
+%2236 = OpLoad %_arr_float_uint_8 %453
+%2237 = OpCompositeExtract %float %2236 4
+OpStore %583 %2237
+%2238 = OpLoad %float %582
+%2239 = OpLoad %float %583
+%2240 = OpFSub %float %2238 %2239
+OpStore %584 %2240
+%2241 = OpLoad %_arr_float_uint_8 %482
+%2242 = OpCompositeExtract %float %2241 5
+OpStore %585 %2242
+%2243 = OpLoad %_arr_float_uint_8 %453
+%2244 = OpCompositeExtract %float %2243 5
+OpStore %586 %2244
+%2245 = OpLoad %float %585
+%2246 = OpLoad %float %586
+%2247 = OpFSub %float %2245 %2246
+OpStore %587 %2247
+%2248 = OpLoad %_arr_float_uint_8 %482
+%2249 = OpCompositeExtract %float %2248 6
+OpStore %588 %2249
+%2250 = OpLoad %_arr_float_uint_8 %453
+%2251 = OpCompositeExtract %float %2250 6
+OpStore %589 %2251
+%2252 = OpLoad %float %588
+%2253 = OpLoad %float %589
+%2254 = OpFSub %float %2252 %2253
+OpStore %590 %2254
+%2255 = OpLoad %_arr_float_uint_8 %482
+%2256 = OpCompositeExtract %float %2255 7
+OpStore %591 %2256
+%2257 = OpLoad %_arr_float_uint_8 %453
+%2258 = OpCompositeExtract %float %2257 7
+OpStore %592 %2258
+%2259 = OpLoad %float %591
+%2260 = OpLoad %float %592
+%2261 = OpFSub %float %2259 %2260
+OpStore %593 %2261
+%2262 = OpLoad %_arr_float_uint_8 %482
+%2263 = OpLoad %float %572
+%2264 = OpCompositeInsert %_arr_float_uint_8 %2263 %2262 0
+OpStore %594 %2264
+%2265 = OpLoad %_arr_float_uint_8 %594
+%2266 = OpLoad %float %575
+%2267 = OpCompositeInsert %_arr_float_uint_8 %2266 %2265 1
+OpStore %595 %2267
+%2268 = OpLoad %_arr_float_uint_8 %595
+%2269 = OpLoad %float %578
+%2270 = OpCompositeInsert %_arr_float_uint_8 %2269 %2268 2
+OpStore %596 %2270
+%2271 = OpLoad %_arr_float_uint_8 %596
+%2272 = OpLoad %float %581
+%2273 = OpCompositeInsert %_arr_float_uint_8 %2272 %2271 3
+OpStore %597 %2273
+%2274 = OpLoad %_arr_float_uint_8 %597
+%2275 = OpLoad %float %584
+%2276 = OpCompositeInsert %_arr_float_uint_8 %2275 %2274 4
+OpStore %598 %2276
+%2277 = OpLoad %_arr_float_uint_8 %598
+%2278 = OpLoad %float %587
+%2279 = OpCompositeInsert %_arr_float_uint_8 %2278 %2277 5
+OpStore %599 %2279
+%2280 = OpLoad %_arr_float_uint_8 %599
+%2281 = OpLoad %float %590
+%2282 = OpCompositeInsert %_arr_float_uint_8 %2281 %2280 6
+OpStore %600 %2282
+%2283 = OpLoad %_arr_float_uint_8 %600
+%2284 = OpLoad %float %593
+%2285 = OpCompositeInsert %_arr_float_uint_8 %2284 %2283 7
+OpStore %601 %2285
+%2286 = OpLoad %ulong %468
+%2287 = OpLoad %_arr_float_uint_8 %601
+%2288 = OpFunctionCall %ulong %1 %2286 %2287
+OpStore %469 %2288
+%2289 = OpLoad %ulong %484
+%2290 = OpIAdd %ulong %2289 %ulong_1
+OpStore %470 %2290
+%2291 = OpLoad %ulong %469
+OpStore %481 %2291
+%2292 = OpLoad %_arr_float_uint_8 %601
+OpStore %482 %2292
+%2293 = OpLoad %_arr_float_uint_8 %569
+OpStore %483 %2293
+%2294 = OpLoad %ulong %470
+OpStore %484 %2294
+OpBranch %422
+%419 = OpLabel
+OpBranch %415
+%420 = OpLabel
+OpBranch %408
+%421 = OpLabel
+OpBranch %400
+%422 = OpLabel
+OpBranch %397
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_f64x2.dis
+++ b/test/golden/spirv/vec/vec_f64x2.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 583
+; Bound: 440
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -13,19 +13,24 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f64x2.checksum" Export
 %ulong = OpTypeInt 64 0
 %double = OpTypeFloat 64
 %v2double = OpTypeVector %double 2
-%9 = OpTypeFunction %ulong %ulong %v2double
+%6 = OpTypeFunction %ulong %ulong %v2double
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v2double = OpTypePointer Function %v2double
 %_ptr_Function_double = OpTypePointer Function %double
-%33 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%109 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %uint_4 = OpConstant %uint 4
 %_arr_v2double_uint_4 = OpTypeArray %v2double %uint_4
 %_ptr_Function__arr_v2double_uint_4 = OpTypePointer Function %_arr_v2double_uint_4
-%_struct_82 = OpTypeStruct %uint %v2double %uint
-%_ptr_Function__struct_82 = OpTypePointer Function %_struct_82
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_143 = OpTypeStruct %uint %v2double %uint
+%_ptr_Function__struct_143 = OpTypePointer Function %_struct_143
 %_ptr_Function_uint = OpTypePointer Function %uint
 %double_1_5 = OpConstant %double 1.5
 %double_n2_25 = OpConstant %double -2.25
@@ -33,785 +38,590 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_f64x2.checksum" Export
 %double_4 = OpConstant %double 4
 %double_1 = OpConstant %double 1
 %double_27 = OpConstant %double 27
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %double_0 = OpConstant %double 0
-%ulong_0 = OpConstant %ulong 0
 %ulong_6 = OpConstant %ulong 6
-%370 = OpConstantNull %_arr_v2double_uint_4
+%320 = OpConstantNull %_arr_v2double_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%394 = OpConstantNull %_struct_82
+%344 = OpConstantNull %_struct_143
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%487 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%490 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%538 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v2double
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v2double
+%9 = OpLabel
+%28 = OpVariable %_ptr_Function_ulong Function
+%30 = OpVariable %_ptr_Function_v2double Function
+%32 = OpVariable %_ptr_Function_double Function
+%33 = OpVariable %_ptr_Function_double Function
+%34 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_bool Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%38 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_bool Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%53 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_ulong Function
+OpStore %28 %7
+OpStore %30 %8
+%55 = OpLoad %v2double %30
+%56 = OpCompositeExtract %double %55 0
+OpStore %32 %56
+OpBranch %10
+%10 = OpLabel
+%57 = OpLoad %double %32
+%58 = OpBitcast %ulong %57
+OpStore %34 %58
+OpBranch %12
 %12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v2double Function
-%18 = OpVariable %_ptr_Function_double Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_double Function
-%21 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%22 = OpLoad %v2double %16
-%23 = OpCompositeExtract %double %22 0
-OpStore %18 %23
-%24 = OpLoad %ulong %14
-%25 = OpLoad %double %18
-%26 = OpFunctionCall %ulong %5 %24 %25
-OpStore %19 %26
-%27 = OpLoad %v2double %16
-%28 = OpCompositeExtract %double %27 1
-OpStore %20 %28
-%29 = OpLoad %ulong %19
-%30 = OpLoad %double %20
-%31 = OpFunctionCall %ulong %5 %29 %30
-OpStore %21 %31
-%32 = OpLoad %ulong %21
-OpReturnValue %32
+%59 = OpLoad %ulong %28
+OpStore %43 %59
+OpStore %44 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%61 = OpLoad %ulong %44
+%63 = OpULessThan %bool %61 %ulong_8
+OpStore %36 %63
+%64 = OpLoad %bool %36
+OpLoopMerge %15 %25 None
+OpBranchConditional %64 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%65 = OpLoad %v2double %30
+%66 = OpCompositeExtract %double %65 1
+OpStore %33 %66
+OpBranch %17
+%17 = OpLabel
+%67 = OpLoad %double %33
+%68 = OpBitcast %ulong %67
+OpStore %45 %68
+OpBranch %19
+%19 = OpLabel
+%69 = OpLoad %ulong %43
+OpStore %53 %69
+OpStore %54 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%70 = OpLoad %ulong %54
+%71 = OpULessThan %bool %70 %ulong_8
+OpStore %46 %71
+%72 = OpLoad %bool %46
+OpLoopMerge %22 %24 None
+OpBranchConditional %72 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%73 = OpLoad %ulong %53
+OpReturnValue %73
+%21 = OpLabel
+%74 = OpLoad %ulong %54
+%75 = OpIMul %ulong %74 %ulong_8
+OpStore %47 %75
+%76 = OpLoad %ulong %45
+%77 = OpLoad %ulong %47
+%78 = OpShiftRightLogical %ulong %76 %77
+OpStore %48 %78
+%79 = OpLoad %ulong %48
+%81 = OpBitwiseAnd %ulong %79 %ulong_255
+OpStore %49 %81
+%82 = OpLoad %ulong %53
+%83 = OpLoad %ulong %49
+%84 = OpBitwiseXor %ulong %82 %83
+OpStore %50 %84
+%85 = OpLoad %ulong %50
+%87 = OpIMul %ulong %85 %ulong_1099511628211
+OpStore %51 %87
+%88 = OpLoad %ulong %54
+%90 = OpIAdd %ulong %88 %ulong_1
+OpStore %52 %90
+%91 = OpLoad %ulong %51
+OpStore %53 %91
+%92 = OpLoad %ulong %52
+OpStore %54 %92
+OpBranch %24
+%14 = OpLabel
+%93 = OpLoad %ulong %44
+%94 = OpIMul %ulong %93 %ulong_8
+OpStore %37 %94
+%95 = OpLoad %ulong %34
+%96 = OpLoad %ulong %37
+%97 = OpShiftRightLogical %ulong %95 %96
+OpStore %38 %97
+%98 = OpLoad %ulong %38
+%99 = OpBitwiseAnd %ulong %98 %ulong_255
+OpStore %39 %99
+%100 = OpLoad %ulong %43
+%101 = OpLoad %ulong %39
+%102 = OpBitwiseXor %ulong %100 %101
+OpStore %40 %102
+%103 = OpLoad %ulong %40
+%104 = OpIMul %ulong %103 %ulong_1099511628211
+OpStore %41 %104
+%105 = OpLoad %ulong %44
+%106 = OpIAdd %ulong %105 %ulong_1
+OpStore %42 %106
+%107 = OpLoad %ulong %41
+OpStore %43 %107
+%108 = OpLoad %ulong %42
+OpStore %44 %108
+OpBranch %25
+%24 = OpLabel
+OpBranch %20
+%25 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %33
-%34 = OpFunctionParameter %ulong
-%35 = OpLabel
-%81 = OpVariable %_ptr_Function__arr_v2double_uint_4 Function
-%84 = OpVariable %_ptr_Function__struct_82 Function
-%85 = OpVariable %_ptr_Function_ulong Function
-%86 = OpVariable %_ptr_Function_ulong Function
-%87 = OpVariable %_ptr_Function_double Function
-%88 = OpVariable %_ptr_Function_v2double Function
-%89 = OpVariable %_ptr_Function_v2double Function
-%90 = OpVariable %_ptr_Function_v2double Function
-%91 = OpVariable %_ptr_Function_double Function
-%92 = OpVariable %_ptr_Function_double Function
-%93 = OpVariable %_ptr_Function_v2double Function
-%94 = OpVariable %_ptr_Function_double Function
-%95 = OpVariable %_ptr_Function_double Function
-%96 = OpVariable %_ptr_Function_v2double Function
-%97 = OpVariable %_ptr_Function_v2double Function
-%98 = OpVariable %_ptr_Function_v2double Function
-%99 = OpVariable %_ptr_Function_v2double Function
-%100 = OpVariable %_ptr_Function_v2double Function
-%101 = OpVariable %_ptr_Function_v2double Function
-%102 = OpVariable %_ptr_Function_v2double Function
-%103 = OpVariable %_ptr_Function_v2double Function
-%104 = OpVariable %_ptr_Function_v2double Function
-%105 = OpVariable %_ptr_Function_v2double Function
-%106 = OpVariable %_ptr_Function_v2double Function
-%108 = OpVariable %_ptr_Function_bool Function
-%109 = OpVariable %_ptr_Function_v2double Function
-%110 = OpVariable %_ptr_Function_v2double Function
-%111 = OpVariable %_ptr_Function_v2double Function
-%112 = OpVariable %_ptr_Function_ulong Function
-%113 = OpVariable %_ptr_Function_v2double Function
-%114 = OpVariable %_ptr_Function_v2double Function
-%115 = OpVariable %_ptr_Function_bool Function
-%116 = OpVariable %_ptr_Function_v2double Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%118 = OpVariable %_ptr_Function_v2double Function
-%120 = OpVariable %_ptr_Function_uint Function
-%121 = OpVariable %_ptr_Function_ulong Function
-%122 = OpVariable %_ptr_Function_v2double Function
-%123 = OpVariable %_ptr_Function_uint Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_ulong Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_v2double Function
-%128 = OpVariable %_ptr_Function_v2double Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_double Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_double Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_double Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_double Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_double Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_double Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_double Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_double Function
+%2 = OpFunction %ulong None %109
+%110 = OpFunctionParameter %ulong
+%111 = OpLabel
+%142 = OpVariable %_ptr_Function__arr_v2double_uint_4 Function
+%145 = OpVariable %_ptr_Function__struct_143 Function
 %146 = OpVariable %_ptr_Function_ulong Function
 %147 = OpVariable %_ptr_Function_double Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_double Function
-%150 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_v2double Function
+%149 = OpVariable %_ptr_Function_v2double Function
+%150 = OpVariable %_ptr_Function_v2double Function
 %151 = OpVariable %_ptr_Function_double Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_double Function
-%154 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_double Function
+%153 = OpVariable %_ptr_Function_v2double Function
+%154 = OpVariable %_ptr_Function_double Function
 %155 = OpVariable %_ptr_Function_double Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_double Function
+%156 = OpVariable %_ptr_Function_v2double Function
+%157 = OpVariable %_ptr_Function_ulong Function
 %158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_double Function
+%159 = OpVariable %_ptr_Function_v2double Function
 %160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_double Function
+%161 = OpVariable %_ptr_Function_v2double Function
 %162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_double Function
+%163 = OpVariable %_ptr_Function_v2double Function
 %164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_double Function
+%165 = OpVariable %_ptr_Function_v2double Function
 %166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_double Function
+%167 = OpVariable %_ptr_Function_v2double Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_double Function
+%169 = OpVariable %_ptr_Function_v2double Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_double Function
+%171 = OpVariable %_ptr_Function_v2double Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_double Function
+%173 = OpVariable %_ptr_Function_v2double Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_double Function
+%175 = OpVariable %_ptr_Function_v2double Function
 %176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_double Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_double Function
+%177 = OpVariable %_ptr_Function_v2double Function
+%178 = OpVariable %_ptr_Function_bool Function
+%179 = OpVariable %_ptr_Function_v2double Function
 %180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_double Function
+%181 = OpVariable %_ptr_Function_v2double Function
 %182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_double Function
+%183 = OpVariable %_ptr_Function_v2double Function
 %184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_double Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_double Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_double Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_v2double Function
+%187 = OpVariable %_ptr_Function_v2double Function
+%188 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_v2double Function
 %190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_double Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_double Function
-%194 = OpVariable %_ptr_Function_ulong Function
-OpStore %85 %34
-%195 = OpFunctionCall %ulong %3
-OpStore %86 %195
-%196 = OpLoad %ulong %85
-%197 = OpConvertUToF %double %196
-OpStore %87 %197
-%198 = OpCompositeConstruct %v2double %double_1_5 %double_n2_25
-OpStore %88 %198
-%201 = OpCompositeConstruct %v2double %double_0_5 %double_4
-OpStore %89 %201
-%204 = OpCompositeConstruct %v2double %double_1 %double_27
-OpStore %90 %204
-%207 = OpLoad %v2double %88
-%208 = OpCompositeExtract %double %207 0
-OpStore %91 %208
-%209 = OpLoad %double %91
-%210 = OpLoad %double %87
-%211 = OpFAdd %double %209 %210
-OpStore %92 %211
-%212 = OpLoad %v2double %88
-%213 = OpLoad %double %92
-%214 = OpCompositeInsert %v2double %213 %212 0
-OpStore %93 %214
-%215 = OpLoad %v2double %89
-%216 = OpCompositeExtract %double %215 1
-OpStore %94 %216
-%217 = OpLoad %double %94
-%218 = OpLoad %double %87
-%219 = OpFAdd %double %217 %218
-OpStore %95 %219
-%220 = OpLoad %v2double %89
-%221 = OpLoad %double %95
-%222 = OpCompositeInsert %v2double %221 %220 1
-OpStore %96 %222
-OpBranch %42
-%42 = OpLabel
-%223 = OpLoad %v2double %93
-%224 = OpCompositeExtract %double %223 0
-OpStore %131 %224
-%225 = OpLoad %ulong %86
-%226 = OpLoad %double %131
-%227 = OpFunctionCall %ulong %5 %225 %226
-OpStore %132 %227
-%228 = OpLoad %v2double %93
-%229 = OpCompositeExtract %double %228 1
-OpStore %133 %229
-%230 = OpLoad %ulong %132
-%231 = OpLoad %double %133
-%232 = OpFunctionCall %ulong %5 %230 %231
-OpStore %134 %232
-OpBranch %43
-%43 = OpLabel
-OpBranch %50
-%50 = OpLabel
-%233 = OpLoad %v2double %96
-%234 = OpCompositeExtract %double %233 0
-OpStore %147 %234
-%235 = OpLoad %ulong %134
-%236 = OpLoad %double %147
-%237 = OpFunctionCall %ulong %5 %235 %236
-OpStore %148 %237
-%238 = OpLoad %v2double %96
-%239 = OpCompositeExtract %double %238 1
-OpStore %149 %239
-%240 = OpLoad %ulong %148
-%241 = OpLoad %double %149
-%242 = OpFunctionCall %ulong %5 %240 %241
-OpStore %150 %242
-OpBranch %51
-%51 = OpLabel
-%243 = OpLoad %v2double %93
-%244 = OpLoad %v2double %96
-%245 = OpFAdd %v2double %243 %244
-OpStore %97 %245
-OpBranch %54
-%54 = OpLabel
-%246 = OpLoad %v2double %97
-%247 = OpCompositeExtract %double %246 0
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_v2double Function
+%194 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_v2double Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_uint Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_v2double Function
+%201 = OpVariable %_ptr_Function_v2double Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_bool Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_bool Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+OpStore %146 %110
+OpBranch %118
+%118 = OpLabel
+OpBranch %119
+%119 = OpLabel
+%224 = OpLoad %ulong %146
+%225 = OpConvertUToF %double %224
+OpStore %147 %225
+%226 = OpCompositeConstruct %v2double %double_1_5 %double_n2_25
+OpStore %148 %226
+%229 = OpCompositeConstruct %v2double %double_0_5 %double_4
+OpStore %149 %229
+%232 = OpCompositeConstruct %v2double %double_1 %double_27
+OpStore %150 %232
+%235 = OpLoad %v2double %148
+%236 = OpCompositeExtract %double %235 0
+OpStore %151 %236
+%237 = OpLoad %double %151
+%238 = OpLoad %double %147
+%239 = OpFAdd %double %237 %238
+OpStore %152 %239
+%240 = OpLoad %v2double %148
+%241 = OpLoad %double %152
+%242 = OpCompositeInsert %v2double %241 %240 0
+OpStore %153 %242
+%243 = OpLoad %v2double %149
+%244 = OpCompositeExtract %double %243 1
+OpStore %154 %244
+%245 = OpLoad %double %154
+%246 = OpLoad %double %147
+%247 = OpFAdd %double %245 %246
 OpStore %155 %247
-%248 = OpLoad %ulong %150
+%248 = OpLoad %v2double %149
 %249 = OpLoad %double %155
-%250 = OpFunctionCall %ulong %5 %248 %249
+%250 = OpCompositeInsert %v2double %249 %248 1
 OpStore %156 %250
-%251 = OpLoad %v2double %97
-%252 = OpCompositeExtract %double %251 1
-OpStore %157 %252
-%253 = OpLoad %ulong %156
-%254 = OpLoad %double %157
-%255 = OpFunctionCall %ulong %5 %253 %254
-OpStore %158 %255
-OpBranch %55
-%55 = OpLabel
-%256 = OpLoad %v2double %93
-%257 = OpLoad %v2double %96
-%258 = OpFSub %v2double %256 %257
-OpStore %98 %258
-OpBranch %58
-%58 = OpLabel
-%259 = OpLoad %v2double %98
-%260 = OpCompositeExtract %double %259 0
-OpStore %163 %260
-%261 = OpLoad %ulong %158
-%262 = OpLoad %double %163
-%263 = OpFunctionCall %ulong %5 %261 %262
-OpStore %164 %263
-%264 = OpLoad %v2double %98
-%265 = OpCompositeExtract %double %264 1
-OpStore %165 %265
-%266 = OpLoad %ulong %164
-%267 = OpLoad %double %165
-%268 = OpFunctionCall %ulong %5 %266 %267
-OpStore %166 %268
-OpBranch %59
-%59 = OpLabel
-%269 = OpLoad %v2double %96
-%270 = OpLoad %v2double %93
+%252 = OpLoad %v2double %153
+%253 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %252
+OpStore %157 %253
+%254 = OpLoad %ulong %157
+%255 = OpLoad %v2double %156
+%256 = OpFunctionCall %ulong %1 %254 %255
+OpStore %158 %256
+%257 = OpLoad %v2double %153
+%258 = OpLoad %v2double %156
+%259 = OpFAdd %v2double %257 %258
+OpStore %159 %259
+%260 = OpLoad %ulong %158
+%261 = OpLoad %v2double %159
+%262 = OpFunctionCall %ulong %1 %260 %261
+OpStore %160 %262
+%263 = OpLoad %v2double %153
+%264 = OpLoad %v2double %156
+%265 = OpFSub %v2double %263 %264
+OpStore %161 %265
+%266 = OpLoad %ulong %160
+%267 = OpLoad %v2double %161
+%268 = OpFunctionCall %ulong %1 %266 %267
+OpStore %162 %268
+%269 = OpLoad %v2double %156
+%270 = OpLoad %v2double %153
 %271 = OpFSub %v2double %269 %270
-OpStore %99 %271
-OpBranch %60
-%60 = OpLabel
-%272 = OpLoad %v2double %99
-%273 = OpCompositeExtract %double %272 0
-OpStore %167 %273
-%274 = OpLoad %ulong %166
-%275 = OpLoad %double %167
-%276 = OpFunctionCall %ulong %5 %274 %275
-OpStore %168 %276
-%277 = OpLoad %v2double %99
-%278 = OpCompositeExtract %double %277 1
-OpStore %169 %278
-%279 = OpLoad %ulong %168
-%280 = OpLoad %double %169
-%281 = OpFunctionCall %ulong %5 %279 %280
-OpStore %170 %281
-OpBranch %61
-%61 = OpLabel
-%282 = OpLoad %v2double %93
-%283 = OpLoad %v2double %96
-%284 = OpFMul %v2double %282 %283
-OpStore %100 %284
-OpBranch %62
-%62 = OpLabel
-%285 = OpLoad %v2double %100
-%286 = OpCompositeExtract %double %285 0
-OpStore %171 %286
-%287 = OpLoad %ulong %170
-%288 = OpLoad %double %171
-%289 = OpFunctionCall %ulong %5 %287 %288
-OpStore %172 %289
-%290 = OpLoad %v2double %100
-%291 = OpCompositeExtract %double %290 1
-OpStore %173 %291
-%292 = OpLoad %ulong %172
-%293 = OpLoad %double %173
-%294 = OpFunctionCall %ulong %5 %292 %293
-OpStore %174 %294
-OpBranch %63
-%63 = OpLabel
-%295 = OpLoad %v2double %93
-%296 = OpLoad %v2double %96
-%297 = OpFDiv %v2double %295 %296
-OpStore %101 %297
-OpBranch %64
-%64 = OpLabel
-%298 = OpLoad %v2double %101
-%299 = OpCompositeExtract %double %298 0
-OpStore %175 %299
-%300 = OpLoad %ulong %174
-%301 = OpLoad %double %175
-%302 = OpFunctionCall %ulong %5 %300 %301
-OpStore %176 %302
-%303 = OpLoad %v2double %101
-%304 = OpCompositeExtract %double %303 1
-OpStore %177 %304
-%305 = OpLoad %ulong %176
-%306 = OpLoad %double %177
-%307 = OpFunctionCall %ulong %5 %305 %306
-OpStore %178 %307
-OpBranch %65
-%65 = OpLabel
-%308 = OpLoad %v2double %96
-%309 = OpLoad %v2double %93
-%310 = OpFDiv %v2double %308 %309
-OpStore %102 %310
-OpBranch %66
-%66 = OpLabel
-%311 = OpLoad %v2double %102
-%312 = OpCompositeExtract %double %311 0
-OpStore %179 %312
-%313 = OpLoad %ulong %178
-%314 = OpLoad %double %179
-%315 = OpFunctionCall %ulong %5 %313 %314
-OpStore %180 %315
-%316 = OpLoad %v2double %102
-%317 = OpCompositeExtract %double %316 1
-OpStore %181 %317
-%318 = OpLoad %ulong %180
-%319 = OpLoad %double %181
-%320 = OpFunctionCall %ulong %5 %318 %319
-OpStore %182 %320
-OpBranch %67
-%67 = OpLabel
-%321 = OpLoad %v2double %93
-%322 = OpLoad %v2double %90
-%323 = OpFMul %v2double %321 %322
-OpStore %103 %323
-OpBranch %68
-%68 = OpLabel
-%324 = OpLoad %v2double %103
-%325 = OpCompositeExtract %double %324 0
-OpStore %183 %325
-%326 = OpLoad %ulong %182
-%327 = OpLoad %double %183
-%328 = OpFunctionCall %ulong %5 %326 %327
-OpStore %184 %328
-%329 = OpLoad %v2double %103
-%330 = OpCompositeExtract %double %329 1
-OpStore %185 %330
-%331 = OpLoad %ulong %184
-%332 = OpLoad %double %185
-%333 = OpFunctionCall %ulong %5 %331 %332
-OpStore %186 %333
-OpBranch %69
-%69 = OpLabel
-%334 = OpLoad %v2double %90
-%335 = OpLoad %v2double %96
-%336 = OpFSub %v2double %334 %335
-OpStore %104 %336
-OpBranch %70
-%70 = OpLabel
-%337 = OpLoad %v2double %104
-%338 = OpCompositeExtract %double %337 0
-OpStore %187 %338
-%339 = OpLoad %ulong %186
-%340 = OpLoad %double %187
-%341 = OpFunctionCall %ulong %5 %339 %340
-OpStore %188 %341
-%342 = OpLoad %v2double %104
-%343 = OpCompositeExtract %double %342 1
-OpStore %189 %343
-%344 = OpLoad %ulong %188
-%345 = OpLoad %double %189
-%346 = OpFunctionCall %ulong %5 %344 %345
-OpStore %190 %346
-OpBranch %71
-%71 = OpLabel
-%347 = OpLoad %v2double %90
-%348 = OpLoad %v2double %93
-%349 = OpFDiv %v2double %347 %348
-OpStore %105 %349
-OpBranch %72
-%72 = OpLabel
-%350 = OpLoad %v2double %105
-%351 = OpCompositeExtract %double %350 0
-OpStore %191 %351
-%352 = OpLoad %ulong %190
-%353 = OpLoad %double %191
-%354 = OpFunctionCall %ulong %5 %352 %353
-OpStore %192 %354
-%355 = OpLoad %v2double %105
-%356 = OpCompositeExtract %double %355 1
-OpStore %193 %356
-%357 = OpLoad %ulong %192
-%358 = OpLoad %double %193
-%359 = OpFunctionCall %ulong %5 %357 %358
-OpStore %194 %359
-OpBranch %73
-%73 = OpLabel
-%360 = OpCompositeConstruct %v2double %double_0 %double_0
-OpStore %106 %360
-%362 = OpLoad %ulong %194
-OpStore %126 %362
-%363 = OpLoad %v2double %93
-OpStore %127 %363
-%364 = OpLoad %v2double %106
-OpStore %128 %364
-OpStore %129 %ulong_0
-OpBranch %36
-%36 = OpLabel
-%366 = OpLoad %ulong %129
-%368 = OpULessThan %bool %366 %ulong_6
-OpStore %108 %368
-%369 = OpLoad %bool %108
-OpLoopMerge %38 %75 None
-OpBranchConditional %369 %37 %38
-%38 = OpLabel
-OpStore %81 %370
-%372 = OpAccessChain %_ptr_Function_v2double %81 %uint_0
-%373 = OpLoad %v2double %127
-OpStore %372 %373
-%374 = OpLoad %v2double %127
-%375 = OpLoad %v2double %96
-%376 = OpFAdd %v2double %374 %375
-OpStore %113 %376
-%378 = OpAccessChain %_ptr_Function_v2double %81 %uint_1
-%379 = OpLoad %v2double %113
-OpStore %378 %379
-%380 = OpLoad %v2double %127
-%381 = OpLoad %v2double %90
-%382 = OpFMul %v2double %380 %381
-OpStore %114 %382
-%384 = OpAccessChain %_ptr_Function_v2double %81 %uint_2
-%385 = OpLoad %v2double %114
-OpStore %384 %385
-%387 = OpAccessChain %_ptr_Function_v2double %81 %uint_3
-%388 = OpLoad %v2double %128
-OpStore %387 %388
-%389 = OpLoad %ulong %126
-OpStore %125 %389
-OpStore %130 %ulong_0
-OpBranch %39
-%39 = OpLabel
-%390 = OpLoad %ulong %130
-%392 = OpULessThan %bool %390 %ulong_4
-OpStore %115 %392
-%393 = OpLoad %bool %115
-OpLoopMerge %41 %74 None
-OpBranchConditional %393 %40 %41
-%41 = OpLabel
-OpStore %84 %394
-%395 = OpAccessChain %_ptr_Function_uint %84 %uint_0
-OpStore %395 %uint_4294967295
-%397 = OpAccessChain %_ptr_Function_v2double %81 %uint_2
-%398 = OpLoad %v2double %397
-OpStore %118 %398
-%399 = OpAccessChain %_ptr_Function_v2double %84 %uint_1
-%400 = OpLoad %v2double %118
-OpStore %399 %400
-%401 = OpAccessChain %_ptr_Function_uint %84 %uint_2
-OpStore %401 %uint_305419896
-%403 = OpLoad %uint %395
-OpStore %120 %403
-%404 = OpLoad %ulong %125
-%405 = OpLoad %uint %120
-%406 = OpFunctionCall %ulong %4 %404 %405
-OpStore %121 %406
-%407 = OpLoad %v2double %399
-OpStore %122 %407
-OpBranch %48
-%48 = OpLabel
-%408 = OpLoad %v2double %122
-%409 = OpCompositeExtract %double %408 0
-OpStore %143 %409
-%410 = OpLoad %ulong %121
-%411 = OpLoad %double %143
-%412 = OpFunctionCall %ulong %5 %410 %411
-OpStore %144 %412
-%413 = OpLoad %v2double %122
-%414 = OpCompositeExtract %double %413 1
-OpStore %145 %414
-%415 = OpLoad %ulong %144
-%416 = OpLoad %double %145
-%417 = OpFunctionCall %ulong %5 %415 %416
-OpStore %146 %417
-OpBranch %49
-%49 = OpLabel
-%418 = OpAccessChain %_ptr_Function_uint %84 %uint_2
-%419 = OpLoad %uint %418
-OpStore %123 %419
-%420 = OpLoad %ulong %146
-%421 = OpLoad %uint %123
-%422 = OpFunctionCall %ulong %4 %420 %421
-OpStore %124 %422
-%423 = OpLoad %ulong %124
-OpReturnValue %423
-%40 = OpLabel
-%424 = OpLoad %ulong %130
-%425 = OpAccessChain %_ptr_Function_v2double %81 %424
-%426 = OpLoad %v2double %425
-OpStore %116 %426
-OpBranch %46
-%46 = OpLabel
-%427 = OpLoad %v2double %116
-%428 = OpCompositeExtract %double %427 0
-OpStore %139 %428
-%429 = OpLoad %ulong %125
-%430 = OpLoad %double %139
-%431 = OpFunctionCall %ulong %5 %429 %430
-OpStore %140 %431
-%432 = OpLoad %v2double %116
-%433 = OpCompositeExtract %double %432 1
-OpStore %141 %433
-%434 = OpLoad %ulong %140
-%435 = OpLoad %double %141
-%436 = OpFunctionCall %ulong %5 %434 %435
-OpStore %142 %436
-OpBranch %47
-%47 = OpLabel
-%437 = OpLoad %ulong %130
-%439 = OpIAdd %ulong %437 %ulong_1
-OpStore %117 %439
-%440 = OpLoad %ulong %142
-OpStore %125 %440
-%441 = OpLoad %ulong %117
-OpStore %130 %441
-OpBranch %74
-%37 = OpLabel
-%442 = OpLoad %v2double %127
-%443 = OpLoad %v2double %90
-%444 = OpFMul %v2double %442 %443
-OpStore %109 %444
-OpBranch %44
-%44 = OpLabel
-%445 = OpLoad %v2double %109
-%446 = OpCompositeExtract %double %445 0
-OpStore %135 %446
-%447 = OpLoad %ulong %126
-%448 = OpLoad %double %135
-%449 = OpFunctionCall %ulong %5 %447 %448
-OpStore %136 %449
-%450 = OpLoad %v2double %109
-%451 = OpCompositeExtract %double %450 1
-OpStore %137 %451
-%452 = OpLoad %ulong %136
-%453 = OpLoad %double %137
-%454 = OpFunctionCall %ulong %5 %452 %453
-OpStore %138 %454
-OpBranch %45
-%45 = OpLabel
-%455 = OpLoad %v2double %128
-%456 = OpLoad %v2double %109
-%457 = OpFAdd %v2double %455 %456
-OpStore %110 %457
-OpBranch %52
-%52 = OpLabel
-%458 = OpLoad %v2double %110
-%459 = OpCompositeExtract %double %458 0
-OpStore %151 %459
-%460 = OpLoad %ulong %138
-%461 = OpLoad %double %151
-%462 = OpFunctionCall %ulong %5 %460 %461
-OpStore %152 %462
-%463 = OpLoad %v2double %110
-%464 = OpCompositeExtract %double %463 1
-OpStore %153 %464
-%465 = OpLoad %ulong %152
-%466 = OpLoad %double %153
-%467 = OpFunctionCall %ulong %5 %465 %466
-OpStore %154 %467
-OpBranch %53
-%53 = OpLabel
-%468 = OpLoad %v2double %127
-%469 = OpLoad %v2double %96
-%470 = OpFSub %v2double %468 %469
-OpStore %111 %470
-OpBranch %56
-%56 = OpLabel
-%471 = OpLoad %v2double %111
-%472 = OpCompositeExtract %double %471 0
-OpStore %159 %472
-%473 = OpLoad %ulong %154
-%474 = OpLoad %double %159
-%475 = OpFunctionCall %ulong %5 %473 %474
-OpStore %160 %475
-%476 = OpLoad %v2double %111
-%477 = OpCompositeExtract %double %476 1
-OpStore %161 %477
-%478 = OpLoad %ulong %160
-%479 = OpLoad %double %161
-%480 = OpFunctionCall %ulong %5 %478 %479
-OpStore %162 %480
-OpBranch %57
-%57 = OpLabel
-%481 = OpLoad %ulong %129
-%482 = OpIAdd %ulong %481 %ulong_1
-OpStore %112 %482
-%483 = OpLoad %ulong %162
-OpStore %126 %483
-%484 = OpLoad %v2double %111
-OpStore %127 %484
-%485 = OpLoad %v2double %110
-OpStore %128 %485
-%486 = OpLoad %ulong %112
-OpStore %129 %486
-OpBranch %75
-%74 = OpLabel
-OpBranch %39
-%75 = OpLabel
-OpBranch %36
-OpFunctionEnd
-%3 = OpFunction %ulong None %487
-%488 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %490
-%491 = OpFunctionParameter %ulong
-%492 = OpFunctionParameter %uint
-%493 = OpLabel
-%500 = OpVariable %_ptr_Function_ulong Function
-%501 = OpVariable %_ptr_Function_uint Function
-%502 = OpVariable %_ptr_Function_ulong Function
-%503 = OpVariable %_ptr_Function_bool Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_ulong Function
-OpStore %500 %491
-OpStore %501 %492
-%512 = OpLoad %uint %501
-%513 = OpUConvert %ulong %512
-OpStore %502 %513
-OpBranch %494
-%494 = OpLabel
-%514 = OpLoad %ulong %500
-OpStore %510 %514
-OpStore %511 %ulong_0
-OpBranch %495
-%495 = OpLabel
-%515 = OpLoad %ulong %511
-%517 = OpULessThan %bool %515 %ulong_8
-OpStore %503 %517
-%518 = OpLoad %bool %503
-OpLoopMerge %497 %499 None
-OpBranchConditional %518 %496 %497
-%497 = OpLabel
-OpBranch %498
-%498 = OpLabel
-%519 = OpLoad %ulong %510
-OpReturnValue %519
-%496 = OpLabel
-%520 = OpLoad %ulong %511
-%521 = OpIMul %ulong %520 %ulong_8
-OpStore %504 %521
-%522 = OpLoad %ulong %502
-%523 = OpLoad %ulong %504
-%524 = OpShiftRightLogical %ulong %522 %523
-OpStore %505 %524
-%525 = OpLoad %ulong %505
-%527 = OpBitwiseAnd %ulong %525 %ulong_255
-OpStore %506 %527
-%528 = OpLoad %ulong %510
-%529 = OpLoad %ulong %506
-%530 = OpBitwiseXor %ulong %528 %529
-OpStore %507 %530
-%531 = OpLoad %ulong %507
-%533 = OpIMul %ulong %531 %ulong_1099511628211
-OpStore %508 %533
-%534 = OpLoad %ulong %511
-%535 = OpIAdd %ulong %534 %ulong_1
-OpStore %509 %535
-%536 = OpLoad %ulong %508
-OpStore %510 %536
-%537 = OpLoad %ulong %509
-OpStore %511 %537
-OpBranch %499
-%499 = OpLabel
-OpBranch %495
-OpFunctionEnd
-%5 = OpFunction %ulong None %538
-%539 = OpFunctionParameter %ulong
-%540 = OpFunctionParameter %double
-%541 = OpLabel
-%548 = OpVariable %_ptr_Function_ulong Function
-%549 = OpVariable %_ptr_Function_double Function
-%550 = OpVariable %_ptr_Function_ulong Function
-%551 = OpVariable %_ptr_Function_bool Function
-%552 = OpVariable %_ptr_Function_ulong Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_ulong Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_ulong Function
-%558 = OpVariable %_ptr_Function_ulong Function
-%559 = OpVariable %_ptr_Function_ulong Function
-OpStore %548 %539
-OpStore %549 %540
-%560 = OpLoad %double %549
-%561 = OpBitcast %ulong %560
-OpStore %550 %561
-OpBranch %542
-%542 = OpLabel
-%562 = OpLoad %ulong %548
-OpStore %558 %562
-OpStore %559 %ulong_0
-OpBranch %543
-%543 = OpLabel
-%563 = OpLoad %ulong %559
-%564 = OpULessThan %bool %563 %ulong_8
-OpStore %551 %564
-%565 = OpLoad %bool %551
-OpLoopMerge %545 %547 None
-OpBranchConditional %565 %544 %545
-%545 = OpLabel
-OpBranch %546
-%546 = OpLabel
-%566 = OpLoad %ulong %558
-OpReturnValue %566
-%544 = OpLabel
-%567 = OpLoad %ulong %559
-%568 = OpIMul %ulong %567 %ulong_8
-OpStore %552 %568
-%569 = OpLoad %ulong %550
-%570 = OpLoad %ulong %552
-%571 = OpShiftRightLogical %ulong %569 %570
-OpStore %553 %571
-%572 = OpLoad %ulong %553
-%573 = OpBitwiseAnd %ulong %572 %ulong_255
-OpStore %554 %573
-%574 = OpLoad %ulong %558
-%575 = OpLoad %ulong %554
-%576 = OpBitwiseXor %ulong %574 %575
-OpStore %555 %576
-%577 = OpLoad %ulong %555
-%578 = OpIMul %ulong %577 %ulong_1099511628211
-OpStore %556 %578
-%579 = OpLoad %ulong %559
-%580 = OpIAdd %ulong %579 %ulong_1
-OpStore %557 %580
-%581 = OpLoad %ulong %556
-OpStore %558 %581
-%582 = OpLoad %ulong %557
-OpStore %559 %582
-OpBranch %547
-%547 = OpLabel
-OpBranch %543
+OpStore %163 %271
+%272 = OpLoad %ulong %162
+%273 = OpLoad %v2double %163
+%274 = OpFunctionCall %ulong %1 %272 %273
+OpStore %164 %274
+%275 = OpLoad %v2double %153
+%276 = OpLoad %v2double %156
+%277 = OpFMul %v2double %275 %276
+OpStore %165 %277
+%278 = OpLoad %ulong %164
+%279 = OpLoad %v2double %165
+%280 = OpFunctionCall %ulong %1 %278 %279
+OpStore %166 %280
+%281 = OpLoad %v2double %153
+%282 = OpLoad %v2double %156
+%283 = OpFDiv %v2double %281 %282
+OpStore %167 %283
+%284 = OpLoad %ulong %166
+%285 = OpLoad %v2double %167
+%286 = OpFunctionCall %ulong %1 %284 %285
+OpStore %168 %286
+%287 = OpLoad %v2double %156
+%288 = OpLoad %v2double %153
+%289 = OpFDiv %v2double %287 %288
+OpStore %169 %289
+%290 = OpLoad %ulong %168
+%291 = OpLoad %v2double %169
+%292 = OpFunctionCall %ulong %1 %290 %291
+OpStore %170 %292
+%293 = OpLoad %v2double %153
+%294 = OpLoad %v2double %150
+%295 = OpFMul %v2double %293 %294
+OpStore %171 %295
+%296 = OpLoad %ulong %170
+%297 = OpLoad %v2double %171
+%298 = OpFunctionCall %ulong %1 %296 %297
+OpStore %172 %298
+%299 = OpLoad %v2double %150
+%300 = OpLoad %v2double %156
+%301 = OpFSub %v2double %299 %300
+OpStore %173 %301
+%302 = OpLoad %ulong %172
+%303 = OpLoad %v2double %173
+%304 = OpFunctionCall %ulong %1 %302 %303
+OpStore %174 %304
+%305 = OpLoad %v2double %150
+%306 = OpLoad %v2double %153
+%307 = OpFDiv %v2double %305 %306
+OpStore %175 %307
+%308 = OpLoad %ulong %174
+%309 = OpLoad %v2double %175
+%310 = OpFunctionCall %ulong %1 %308 %309
+OpStore %176 %310
+%311 = OpCompositeConstruct %v2double %double_0 %double_0
+OpStore %177 %311
+%313 = OpLoad %ulong %176
+OpStore %199 %313
+%314 = OpLoad %v2double %153
+OpStore %200 %314
+%315 = OpLoad %v2double %177
+OpStore %201 %315
+OpStore %202 %ulong_0
+OpBranch %112
+%112 = OpLabel
+%316 = OpLoad %ulong %202
+%318 = OpULessThan %bool %316 %ulong_6
+OpStore %178 %318
+%319 = OpLoad %bool %178
+OpLoopMerge %114 %137 None
+OpBranchConditional %319 %113 %114
+%114 = OpLabel
+OpStore %142 %320
+%322 = OpAccessChain %_ptr_Function_v2double %142 %uint_0
+%323 = OpLoad %v2double %200
+OpStore %322 %323
+%324 = OpLoad %v2double %200
+%325 = OpLoad %v2double %156
+%326 = OpFAdd %v2double %324 %325
+OpStore %186 %326
+%328 = OpAccessChain %_ptr_Function_v2double %142 %uint_1
+%329 = OpLoad %v2double %186
+OpStore %328 %329
+%330 = OpLoad %v2double %200
+%331 = OpLoad %v2double %150
+%332 = OpFMul %v2double %330 %331
+OpStore %187 %332
+%334 = OpAccessChain %_ptr_Function_v2double %142 %uint_2
+%335 = OpLoad %v2double %187
+OpStore %334 %335
+%337 = OpAccessChain %_ptr_Function_v2double %142 %uint_3
+%338 = OpLoad %v2double %201
+OpStore %337 %338
+%339 = OpLoad %ulong %199
+OpStore %198 %339
+OpStore %203 %ulong_0
+OpBranch %115
+%115 = OpLabel
+%340 = OpLoad %ulong %203
+%342 = OpULessThan %bool %340 %ulong_4
+OpStore %188 %342
+%343 = OpLoad %bool %188
+OpLoopMerge %117 %136 None
+OpBranchConditional %343 %116 %117
+%117 = OpLabel
+OpStore %145 %344
+%345 = OpAccessChain %_ptr_Function_uint %145 %uint_0
+OpStore %345 %uint_4294967295
+%347 = OpAccessChain %_ptr_Function_v2double %142 %uint_2
+%348 = OpLoad %v2double %347
+OpStore %192 %348
+%349 = OpAccessChain %_ptr_Function_v2double %145 %uint_1
+%350 = OpLoad %v2double %192
+OpStore %349 %350
+%351 = OpAccessChain %_ptr_Function_uint %145 %uint_2
+OpStore %351 %uint_305419896
+%353 = OpLoad %uint %345
+OpStore %194 %353
+OpBranch %120
+%120 = OpLabel
+%354 = OpLoad %uint %194
+%355 = OpUConvert %ulong %354
+OpStore %204 %355
+OpBranch %122
+%122 = OpLabel
+%356 = OpLoad %ulong %198
+OpStore %212 %356
+OpStore %213 %ulong_0
+OpBranch %123
+%123 = OpLabel
+%357 = OpLoad %ulong %213
+%358 = OpULessThan %bool %357 %ulong_8
+OpStore %205 %358
+%359 = OpLoad %bool %205
+OpLoopMerge %125 %135 None
+OpBranchConditional %359 %124 %125
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%360 = OpAccessChain %_ptr_Function_v2double %145 %uint_1
+%361 = OpLoad %v2double %360
+OpStore %195 %361
+%362 = OpLoad %ulong %212
+%363 = OpLoad %v2double %195
+%364 = OpFunctionCall %ulong %1 %362 %363
+OpStore %196 %364
+%365 = OpAccessChain %_ptr_Function_uint %145 %uint_2
+%366 = OpLoad %uint %365
+OpStore %197 %366
+OpBranch %127
+%127 = OpLabel
+%367 = OpLoad %uint %197
+%368 = OpUConvert %ulong %367
+OpStore %214 %368
+OpBranch %129
+%129 = OpLabel
+%369 = OpLoad %ulong %196
+OpStore %222 %369
+OpStore %223 %ulong_0
+OpBranch %130
+%130 = OpLabel
+%370 = OpLoad %ulong %223
+%371 = OpULessThan %bool %370 %ulong_8
+OpStore %215 %371
+%372 = OpLoad %bool %215
+OpLoopMerge %132 %134 None
+OpBranchConditional %372 %131 %132
+%132 = OpLabel
+OpBranch %133
+%133 = OpLabel
+OpBranch %128
+%128 = OpLabel
+%373 = OpLoad %ulong %222
+OpReturnValue %373
+%131 = OpLabel
+%374 = OpLoad %ulong %223
+%375 = OpIMul %ulong %374 %ulong_8
+OpStore %216 %375
+%376 = OpLoad %ulong %214
+%377 = OpLoad %ulong %216
+%378 = OpShiftRightLogical %ulong %376 %377
+OpStore %217 %378
+%379 = OpLoad %ulong %217
+%380 = OpBitwiseAnd %ulong %379 %ulong_255
+OpStore %218 %380
+%381 = OpLoad %ulong %222
+%382 = OpLoad %ulong %218
+%383 = OpBitwiseXor %ulong %381 %382
+OpStore %219 %383
+%384 = OpLoad %ulong %219
+%385 = OpIMul %ulong %384 %ulong_1099511628211
+OpStore %220 %385
+%386 = OpLoad %ulong %223
+%387 = OpIAdd %ulong %386 %ulong_1
+OpStore %221 %387
+%388 = OpLoad %ulong %220
+OpStore %222 %388
+%389 = OpLoad %ulong %221
+OpStore %223 %389
+OpBranch %134
+%124 = OpLabel
+%390 = OpLoad %ulong %213
+%391 = OpIMul %ulong %390 %ulong_8
+OpStore %206 %391
+%392 = OpLoad %ulong %204
+%393 = OpLoad %ulong %206
+%394 = OpShiftRightLogical %ulong %392 %393
+OpStore %207 %394
+%395 = OpLoad %ulong %207
+%396 = OpBitwiseAnd %ulong %395 %ulong_255
+OpStore %208 %396
+%397 = OpLoad %ulong %212
+%398 = OpLoad %ulong %208
+%399 = OpBitwiseXor %ulong %397 %398
+OpStore %209 %399
+%400 = OpLoad %ulong %209
+%401 = OpIMul %ulong %400 %ulong_1099511628211
+OpStore %210 %401
+%402 = OpLoad %ulong %213
+%403 = OpIAdd %ulong %402 %ulong_1
+OpStore %211 %403
+%404 = OpLoad %ulong %210
+OpStore %212 %404
+%405 = OpLoad %ulong %211
+OpStore %213 %405
+OpBranch %135
+%116 = OpLabel
+%406 = OpLoad %ulong %203
+%407 = OpAccessChain %_ptr_Function_v2double %142 %406
+%408 = OpLoad %v2double %407
+OpStore %189 %408
+%409 = OpLoad %ulong %198
+%410 = OpLoad %v2double %189
+%411 = OpFunctionCall %ulong %1 %409 %410
+OpStore %190 %411
+%412 = OpLoad %ulong %203
+%413 = OpIAdd %ulong %412 %ulong_1
+OpStore %191 %413
+%414 = OpLoad %ulong %190
+OpStore %198 %414
+%415 = OpLoad %ulong %191
+OpStore %203 %415
+OpBranch %136
+%113 = OpLabel
+%416 = OpLoad %v2double %200
+%417 = OpLoad %v2double %150
+%418 = OpFMul %v2double %416 %417
+OpStore %179 %418
+%419 = OpLoad %ulong %199
+%420 = OpLoad %v2double %179
+%421 = OpFunctionCall %ulong %1 %419 %420
+OpStore %180 %421
+%422 = OpLoad %v2double %201
+%423 = OpLoad %v2double %179
+%424 = OpFAdd %v2double %422 %423
+OpStore %181 %424
+%425 = OpLoad %ulong %180
+%426 = OpLoad %v2double %181
+%427 = OpFunctionCall %ulong %1 %425 %426
+OpStore %182 %427
+%428 = OpLoad %v2double %200
+%429 = OpLoad %v2double %156
+%430 = OpFSub %v2double %428 %429
+OpStore %183 %430
+%431 = OpLoad %ulong %182
+%432 = OpLoad %v2double %183
+%433 = OpFunctionCall %ulong %1 %431 %432
+OpStore %184 %433
+%434 = OpLoad %ulong %202
+%435 = OpIAdd %ulong %434 %ulong_1
+OpStore %185 %435
+%436 = OpLoad %ulong %184
+OpStore %199 %436
+%437 = OpLoad %v2double %183
+OpStore %200 %437
+%438 = OpLoad %v2double %181
+OpStore %201 %438
+%439 = OpLoad %ulong %185
+OpStore %202 %439
+OpBranch %137
+%134 = OpLabel
+OpBranch %130
+%135 = OpLabel
+OpBranch %123
+%136 = OpLabel
+OpBranch %115
+%137 = OpLabel
+OpBranch %112
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_i16x4.dis
+++ b/test/golden/spirv/vec/vec_i16x4.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 920
+; Bound: 621
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,20 +14,25 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i16x4.checksum" Export
 %ulong = OpTypeInt 64 0
 %ushort = OpTypeInt 16 0
 %v4ushort = OpTypeVector %ushort 4
-%9 = OpTypeFunction %ulong %ulong %v4ushort
+%6 = OpTypeFunction %ulong %ulong %v4ushort
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4ushort = OpTypePointer Function %v4ushort
 %_ptr_Function_ushort = OpTypePointer Function %ushort
-%47 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%195 = OpTypeFunction %ulong %ulong
 %uchar = OpTypeInt 8 0
 %uint = OpTypeInt 32 0
 %uint_6 = OpConstant %uint 6
 %_arr_v4ushort_uint_6 = OpTypeArray %v4ushort %uint_6
 %_ptr_Function__arr_v4ushort_uint_6 = OpTypePointer Function %_arr_v4ushort_uint_6
-%_struct_97 = OpTypeStruct %uchar %v4ushort %uchar
-%_ptr_Function__struct_97 = OpTypePointer Function %_struct_97
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_230 = OpTypeStruct %uchar %v4ushort %uchar
+%_ptr_Function__struct_230 = OpTypePointer Function %_struct_230
 %_ptr_Function_uchar = OpTypePointer Function %uchar
 %ushort_1001 = OpConstant %ushort 1001
 %ushort_64433 = OpConstant %ushort 64433
@@ -42,1208 +47,832 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i16x4.checksum" Export
 %ushort_3 = OpConstant %ushort 3
 %ushort_4 = OpConstant %ushort 4
 %ushort_0 = OpConstant %ushort 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%625 = OpConstantNull %_arr_v4ushort_uint_6
+%486 = OpConstantNull %_arr_v4ushort_uint_6
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %uint_4 = OpConstant %uint 4
 %uint_5 = OpConstant %uint 5
-%657 = OpConstantNull %_struct_97
+%518 = OpConstantNull %_struct_230
 %uchar_219 = OpConstant %uchar 219
 %uchar_173 = OpConstant %uchar 173
-%ulong_1 = OpConstant %ulong 1
-%824 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%827 = OpTypeFunction %ulong %ulong %uchar
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%875 = OpTypeFunction %ulong %ulong %ushort
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v4ushort
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v4ushort
+%9 = OpLabel
+%44 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_v4ushort Function
+%48 = OpVariable %_ptr_Function_ushort Function
+%49 = OpVariable %_ptr_Function_ushort Function
+%50 = OpVariable %_ptr_Function_ushort Function
+%51 = OpVariable %_ptr_Function_ushort Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_bool Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_bool Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_bool Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_bool Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+OpStore %44 %7
+OpStore %46 %8
+%93 = OpLoad %v4ushort %46
+%94 = OpCompositeExtract %ushort %93 0
+OpStore %48 %94
+OpBranch %10
+%10 = OpLabel
+%95 = OpLoad %ushort %48
+%96 = OpSConvert %ulong %95
+OpStore %52 %96
+OpBranch %12
 %12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v4ushort Function
-%18 = OpVariable %_ptr_Function_ushort Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_ushort Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%26 = OpLoad %v4ushort %16
-%27 = OpCompositeExtract %ushort %26 0
-OpStore %18 %27
-%28 = OpLoad %ulong %14
-%29 = OpLoad %ushort %18
-%30 = OpFunctionCall %ulong %5 %28 %29
-OpStore %19 %30
-%31 = OpLoad %v4ushort %16
-%32 = OpCompositeExtract %ushort %31 1
-OpStore %20 %32
-%33 = OpLoad %ulong %19
-%34 = OpLoad %ushort %20
-%35 = OpFunctionCall %ulong %5 %33 %34
-OpStore %21 %35
-%36 = OpLoad %v4ushort %16
-%37 = OpCompositeExtract %ushort %36 2
-OpStore %22 %37
-%38 = OpLoad %ulong %21
-%39 = OpLoad %ushort %22
-%40 = OpFunctionCall %ulong %5 %38 %39
-OpStore %23 %40
-%41 = OpLoad %v4ushort %16
-%42 = OpCompositeExtract %ushort %41 3
-OpStore %24 %42
-%43 = OpLoad %ulong %23
-%44 = OpLoad %ushort %24
-%45 = OpFunctionCall %ulong %5 %43 %44
-OpStore %25 %45
-%46 = OpLoad %ulong %25
-OpReturnValue %46
+%97 = OpLoad %ulong %44
+OpStore %61 %97
+OpStore %62 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%99 = OpLoad %ulong %62
+%101 = OpULessThan %bool %99 %ulong_8
+OpStore %54 %101
+%102 = OpLoad %bool %54
+OpLoopMerge %15 %41 None
+OpBranchConditional %102 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%103 = OpLoad %v4ushort %46
+%104 = OpCompositeExtract %ushort %103 1
+OpStore %49 %104
+OpBranch %17
+%17 = OpLabel
+%105 = OpLoad %ushort %49
+%106 = OpSConvert %ulong %105
+OpStore %63 %106
+OpBranch %19
+%19 = OpLabel
+%107 = OpLoad %ulong %61
+OpStore %71 %107
+OpStore %72 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%108 = OpLoad %ulong %72
+%109 = OpULessThan %bool %108 %ulong_8
+OpStore %64 %109
+%110 = OpLoad %bool %64
+OpLoopMerge %22 %40 None
+OpBranchConditional %110 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%111 = OpLoad %v4ushort %46
+%112 = OpCompositeExtract %ushort %111 2
+OpStore %50 %112
+OpBranch %24
+%24 = OpLabel
+%113 = OpLoad %ushort %50
+%114 = OpSConvert %ulong %113
+OpStore %73 %114
+OpBranch %26
+%26 = OpLabel
+%115 = OpLoad %ulong %71
+OpStore %81 %115
+OpStore %82 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%116 = OpLoad %ulong %82
+%117 = OpULessThan %bool %116 %ulong_8
+OpStore %74 %117
+%118 = OpLoad %bool %74
+OpLoopMerge %29 %39 None
+OpBranchConditional %118 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%119 = OpLoad %v4ushort %46
+%120 = OpCompositeExtract %ushort %119 3
+OpStore %51 %120
+OpBranch %31
+%31 = OpLabel
+%121 = OpLoad %ushort %51
+%122 = OpSConvert %ulong %121
+OpStore %83 %122
+OpBranch %33
+%33 = OpLabel
+%123 = OpLoad %ulong %81
+OpStore %91 %123
+OpStore %92 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%124 = OpLoad %ulong %92
+%125 = OpULessThan %bool %124 %ulong_8
+OpStore %84 %125
+%126 = OpLoad %bool %84
+OpLoopMerge %36 %38 None
+OpBranchConditional %126 %35 %36
+%36 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%127 = OpLoad %ulong %91
+OpReturnValue %127
+%35 = OpLabel
+%128 = OpLoad %ulong %92
+%129 = OpIMul %ulong %128 %ulong_8
+OpStore %85 %129
+%130 = OpLoad %ulong %83
+%131 = OpLoad %ulong %85
+%132 = OpShiftRightLogical %ulong %130 %131
+OpStore %86 %132
+%133 = OpLoad %ulong %86
+%135 = OpBitwiseAnd %ulong %133 %ulong_255
+OpStore %87 %135
+%136 = OpLoad %ulong %91
+%137 = OpLoad %ulong %87
+%138 = OpBitwiseXor %ulong %136 %137
+OpStore %88 %138
+%139 = OpLoad %ulong %88
+%141 = OpIMul %ulong %139 %ulong_1099511628211
+OpStore %89 %141
+%142 = OpLoad %ulong %92
+%144 = OpIAdd %ulong %142 %ulong_1
+OpStore %90 %144
+%145 = OpLoad %ulong %89
+OpStore %91 %145
+%146 = OpLoad %ulong %90
+OpStore %92 %146
+OpBranch %38
+%28 = OpLabel
+%147 = OpLoad %ulong %82
+%148 = OpIMul %ulong %147 %ulong_8
+OpStore %75 %148
+%149 = OpLoad %ulong %73
+%150 = OpLoad %ulong %75
+%151 = OpShiftRightLogical %ulong %149 %150
+OpStore %76 %151
+%152 = OpLoad %ulong %76
+%153 = OpBitwiseAnd %ulong %152 %ulong_255
+OpStore %77 %153
+%154 = OpLoad %ulong %81
+%155 = OpLoad %ulong %77
+%156 = OpBitwiseXor %ulong %154 %155
+OpStore %78 %156
+%157 = OpLoad %ulong %78
+%158 = OpIMul %ulong %157 %ulong_1099511628211
+OpStore %79 %158
+%159 = OpLoad %ulong %82
+%160 = OpIAdd %ulong %159 %ulong_1
+OpStore %80 %160
+%161 = OpLoad %ulong %79
+OpStore %81 %161
+%162 = OpLoad %ulong %80
+OpStore %82 %162
+OpBranch %39
+%21 = OpLabel
+%163 = OpLoad %ulong %72
+%164 = OpIMul %ulong %163 %ulong_8
+OpStore %65 %164
+%165 = OpLoad %ulong %63
+%166 = OpLoad %ulong %65
+%167 = OpShiftRightLogical %ulong %165 %166
+OpStore %66 %167
+%168 = OpLoad %ulong %66
+%169 = OpBitwiseAnd %ulong %168 %ulong_255
+OpStore %67 %169
+%170 = OpLoad %ulong %71
+%171 = OpLoad %ulong %67
+%172 = OpBitwiseXor %ulong %170 %171
+OpStore %68 %172
+%173 = OpLoad %ulong %68
+%174 = OpIMul %ulong %173 %ulong_1099511628211
+OpStore %69 %174
+%175 = OpLoad %ulong %72
+%176 = OpIAdd %ulong %175 %ulong_1
+OpStore %70 %176
+%177 = OpLoad %ulong %69
+OpStore %71 %177
+%178 = OpLoad %ulong %70
+OpStore %72 %178
+OpBranch %40
+%14 = OpLabel
+%179 = OpLoad %ulong %62
+%180 = OpIMul %ulong %179 %ulong_8
+OpStore %55 %180
+%181 = OpLoad %ulong %52
+%182 = OpLoad %ulong %55
+%183 = OpShiftRightLogical %ulong %181 %182
+OpStore %56 %183
+%184 = OpLoad %ulong %56
+%185 = OpBitwiseAnd %ulong %184 %ulong_255
+OpStore %57 %185
+%186 = OpLoad %ulong %61
+%187 = OpLoad %ulong %57
+%188 = OpBitwiseXor %ulong %186 %187
+OpStore %58 %188
+%189 = OpLoad %ulong %58
+%190 = OpIMul %ulong %189 %ulong_1099511628211
+OpStore %59 %190
+%191 = OpLoad %ulong %62
+%192 = OpIAdd %ulong %191 %ulong_1
+OpStore %60 %192
+%193 = OpLoad %ulong %59
+OpStore %61 %193
+%194 = OpLoad %ulong %60
+OpStore %62 %194
+OpBranch %41
+%38 = OpLabel
+OpBranch %34
+%39 = OpLabel
+OpBranch %27
+%40 = OpLabel
+OpBranch %20
+%41 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %47
-%48 = OpFunctionParameter %ulong
-%49 = OpLabel
-%96 = OpVariable %_ptr_Function__arr_v4ushort_uint_6 Function
-%99 = OpVariable %_ptr_Function__struct_97 Function
-%100 = OpVariable %_ptr_Function_ulong Function
-%101 = OpVariable %_ptr_Function_ulong Function
-%102 = OpVariable %_ptr_Function_ushort Function
-%103 = OpVariable %_ptr_Function_v4ushort Function
-%104 = OpVariable %_ptr_Function_v4ushort Function
-%105 = OpVariable %_ptr_Function_v4ushort Function
-%106 = OpVariable %_ptr_Function_v4ushort Function
-%107 = OpVariable %_ptr_Function_ushort Function
-%108 = OpVariable %_ptr_Function_ushort Function
-%109 = OpVariable %_ptr_Function_v4ushort Function
-%110 = OpVariable %_ptr_Function_ushort Function
-%111 = OpVariable %_ptr_Function_ushort Function
-%112 = OpVariable %_ptr_Function_v4ushort Function
-%113 = OpVariable %_ptr_Function_ushort Function
-%114 = OpVariable %_ptr_Function_ushort Function
-%115 = OpVariable %_ptr_Function_v4ushort Function
-%116 = OpVariable %_ptr_Function_ushort Function
-%117 = OpVariable %_ptr_Function_ushort Function
-%118 = OpVariable %_ptr_Function_v4ushort Function
-%119 = OpVariable %_ptr_Function_v4ushort Function
-%120 = OpVariable %_ptr_Function_v4ushort Function
-%121 = OpVariable %_ptr_Function_v4ushort Function
-%122 = OpVariable %_ptr_Function_v4ushort Function
-%123 = OpVariable %_ptr_Function_v4ushort Function
-%124 = OpVariable %_ptr_Function_v4ushort Function
-%125 = OpVariable %_ptr_Function_v4ushort Function
-%126 = OpVariable %_ptr_Function_v4ushort Function
-%127 = OpVariable %_ptr_Function_v4ushort Function
-%128 = OpVariable %_ptr_Function_v4ushort Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_v4ushort Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_v4ushort Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_v4ushort Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_v4ushort Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_v4ushort Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_v4ushort Function
-%141 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_bool Function
-%144 = OpVariable %_ptr_Function_v4ushort Function
-%145 = OpVariable %_ptr_Function_v4ushort Function
-%146 = OpVariable %_ptr_Function_v4ushort Function
-%147 = OpVariable %_ptr_Function_v4ushort Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_v4ushort Function
-%150 = OpVariable %_ptr_Function_v4ushort Function
-%151 = OpVariable %_ptr_Function_v4ushort Function
-%152 = OpVariable %_ptr_Function_bool Function
-%153 = OpVariable %_ptr_Function_v4ushort Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_v4ushort Function
-%157 = OpVariable %_ptr_Function_uchar Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_v4ushort Function
-%160 = OpVariable %_ptr_Function_uchar Function
-%161 = OpVariable %_ptr_Function_ulong Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_v4ushort Function
-%165 = OpVariable %_ptr_Function_v4ushort Function
-%166 = OpVariable %_ptr_Function_v4ushort Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ushort Function
-%170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ushort Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ushort Function
-%174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ushort Function
-%176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ushort Function
-%178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ushort Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ushort Function
-%182 = OpVariable %_ptr_Function_ulong Function
-%183 = OpVariable %_ptr_Function_ushort Function
-%184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ushort Function
-%186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ushort Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ushort Function
-%190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ushort Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ushort Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ushort Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ushort Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ushort Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ushort Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ushort Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ushort Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ushort Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_ushort Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_ushort Function
-%212 = OpVariable %_ptr_Function_ulong Function
-%213 = OpVariable %_ptr_Function_ushort Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_ushort Function
-%216 = OpVariable %_ptr_Function_ulong Function
-%217 = OpVariable %_ptr_Function_ushort Function
-%218 = OpVariable %_ptr_Function_ulong Function
-%219 = OpVariable %_ptr_Function_ushort Function
-%220 = OpVariable %_ptr_Function_ulong Function
-%221 = OpVariable %_ptr_Function_ushort Function
-%222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_ushort Function
-%224 = OpVariable %_ptr_Function_ulong Function
-%225 = OpVariable %_ptr_Function_ushort Function
-%226 = OpVariable %_ptr_Function_ulong Function
-%227 = OpVariable %_ptr_Function_ushort Function
-%228 = OpVariable %_ptr_Function_ulong Function
-%229 = OpVariable %_ptr_Function_ushort Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_ushort Function
-%232 = OpVariable %_ptr_Function_ulong Function
-%233 = OpVariable %_ptr_Function_ushort Function
-%234 = OpVariable %_ptr_Function_ulong Function
-%235 = OpVariable %_ptr_Function_ushort Function
-%236 = OpVariable %_ptr_Function_ulong Function
-%237 = OpVariable %_ptr_Function_ushort Function
-%238 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %195
+%196 = OpFunctionParameter %ulong
+%197 = OpLabel
+%229 = OpVariable %_ptr_Function__arr_v4ushort_uint_6 Function
+%232 = OpVariable %_ptr_Function__struct_230 Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ushort Function
+%235 = OpVariable %_ptr_Function_v4ushort Function
+%236 = OpVariable %_ptr_Function_v4ushort Function
+%237 = OpVariable %_ptr_Function_v4ushort Function
+%238 = OpVariable %_ptr_Function_v4ushort Function
 %239 = OpVariable %_ptr_Function_ushort Function
-%240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_ushort Function
-%242 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ushort Function
+%241 = OpVariable %_ptr_Function_v4ushort Function
+%242 = OpVariable %_ptr_Function_ushort Function
 %243 = OpVariable %_ptr_Function_ushort Function
-%244 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_v4ushort Function
 %245 = OpVariable %_ptr_Function_ushort Function
-%246 = OpVariable %_ptr_Function_ulong Function
-%247 = OpVariable %_ptr_Function_ushort Function
-%248 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ushort Function
+%247 = OpVariable %_ptr_Function_v4ushort Function
+%248 = OpVariable %_ptr_Function_ushort Function
 %249 = OpVariable %_ptr_Function_ushort Function
-%250 = OpVariable %_ptr_Function_ulong Function
-%251 = OpVariable %_ptr_Function_ushort Function
+%250 = OpVariable %_ptr_Function_v4ushort Function
+%251 = OpVariable %_ptr_Function_ulong Function
 %252 = OpVariable %_ptr_Function_ulong Function
-%253 = OpVariable %_ptr_Function_ushort Function
+%253 = OpVariable %_ptr_Function_v4ushort Function
 %254 = OpVariable %_ptr_Function_ulong Function
-%255 = OpVariable %_ptr_Function_ushort Function
+%255 = OpVariable %_ptr_Function_v4ushort Function
 %256 = OpVariable %_ptr_Function_ulong Function
-%257 = OpVariable %_ptr_Function_ushort Function
+%257 = OpVariable %_ptr_Function_v4ushort Function
 %258 = OpVariable %_ptr_Function_ulong Function
-%259 = OpVariable %_ptr_Function_ushort Function
+%259 = OpVariable %_ptr_Function_v4ushort Function
 %260 = OpVariable %_ptr_Function_ulong Function
-%261 = OpVariable %_ptr_Function_ushort Function
+%261 = OpVariable %_ptr_Function_v4ushort Function
 %262 = OpVariable %_ptr_Function_ulong Function
-%263 = OpVariable %_ptr_Function_ushort Function
+%263 = OpVariable %_ptr_Function_v4ushort Function
 %264 = OpVariable %_ptr_Function_ulong Function
-%265 = OpVariable %_ptr_Function_ushort Function
+%265 = OpVariable %_ptr_Function_v4ushort Function
 %266 = OpVariable %_ptr_Function_ulong Function
-%267 = OpVariable %_ptr_Function_ushort Function
+%267 = OpVariable %_ptr_Function_v4ushort Function
 %268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_ushort Function
+%269 = OpVariable %_ptr_Function_v4ushort Function
 %270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function_ushort Function
+%271 = OpVariable %_ptr_Function_v4ushort Function
 %272 = OpVariable %_ptr_Function_ulong Function
-%273 = OpVariable %_ptr_Function_ushort Function
+%273 = OpVariable %_ptr_Function_v4ushort Function
 %274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function_ushort Function
+%275 = OpVariable %_ptr_Function_v4ushort Function
 %276 = OpVariable %_ptr_Function_ulong Function
-%277 = OpVariable %_ptr_Function_ushort Function
+%277 = OpVariable %_ptr_Function_v4ushort Function
 %278 = OpVariable %_ptr_Function_ulong Function
-%279 = OpVariable %_ptr_Function_ushort Function
+%279 = OpVariable %_ptr_Function_v4ushort Function
 %280 = OpVariable %_ptr_Function_ulong Function
-%281 = OpVariable %_ptr_Function_ushort Function
+%281 = OpVariable %_ptr_Function_v4ushort Function
 %282 = OpVariable %_ptr_Function_ulong Function
-%283 = OpVariable %_ptr_Function_ushort Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_ushort Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_ushort Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_ushort Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_ushort Function
+%283 = OpVariable %_ptr_Function_bool Function
+%284 = OpVariable %_ptr_Function_v4ushort Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_v4ushort Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_v4ushort Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_v4ushort Function
+%291 = OpVariable %_ptr_Function_ulong Function
 %292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_ushort Function
-%294 = OpVariable %_ptr_Function_ulong Function
-%295 = OpVariable %_ptr_Function_ushort Function
-%296 = OpVariable %_ptr_Function_ulong Function
-OpStore %100 %48
-%297 = OpFunctionCall %ulong %3
-OpStore %101 %297
-%298 = OpLoad %ulong %100
-%299 = OpUConvert %ushort %298
-OpStore %102 %299
-%300 = OpCompositeConstruct %v4ushort %ushort_1001 %ushort_64433 %ushort_1207 %ushort_64235
-OpStore %103 %300
-%305 = OpCompositeConstruct %v4ushort %ushort_13 %ushort_65525 %ushort_9 %ushort_65529
-OpStore %104 %305
-%310 = OpCompositeConstruct %v4ushort %ushort_1 %ushort_2 %ushort_3 %ushort_4
-OpStore %105 %310
-%315 = OpCompositeConstruct %v4ushort %ushort_0 %ushort_0 %ushort_0 %ushort_0
-OpStore %106 %315
-%317 = OpLoad %v4ushort %103
-%318 = OpCompositeExtract %ushort %317 0
-OpStore %107 %318
-%319 = OpLoad %ushort %107
-%320 = OpLoad %ushort %102
-%321 = OpIAdd %ushort %319 %320
-OpStore %108 %321
-%322 = OpLoad %v4ushort %103
-%323 = OpLoad %ushort %108
-%324 = OpCompositeInsert %v4ushort %323 %322 0
-OpStore %109 %324
-%325 = OpLoad %v4ushort %109
-%326 = OpCompositeExtract %ushort %325 3
-OpStore %110 %326
-%327 = OpLoad %ushort %110
-%328 = OpLoad %ushort %102
-%329 = OpIAdd %ushort %327 %328
-OpStore %111 %329
-%330 = OpLoad %v4ushort %109
-%331 = OpLoad %ushort %111
-%332 = OpCompositeInsert %v4ushort %331 %330 3
-OpStore %112 %332
-%333 = OpLoad %v4ushort %104
-%334 = OpCompositeExtract %ushort %333 1
-OpStore %113 %334
-%335 = OpLoad %ushort %113
-%336 = OpLoad %ushort %102
-%337 = OpIAdd %ushort %335 %336
-OpStore %114 %337
-%338 = OpLoad %v4ushort %104
-%339 = OpLoad %ushort %114
-%340 = OpCompositeInsert %v4ushort %339 %338 1
-OpStore %115 %340
-%341 = OpLoad %v4ushort %115
-%342 = OpCompositeExtract %ushort %341 2
-OpStore %116 %342
-%343 = OpLoad %ushort %116
-%344 = OpLoad %ushort %102
-%345 = OpIAdd %ushort %343 %344
-OpStore %117 %345
-%346 = OpLoad %v4ushort %115
-%347 = OpLoad %ushort %117
-%348 = OpCompositeInsert %v4ushort %347 %346 2
-OpStore %118 %348
-OpBranch %56
-%56 = OpLabel
-%349 = OpLoad %v4ushort %112
-%350 = OpCompositeExtract %ushort %349 0
-OpStore %169 %350
-%351 = OpLoad %ulong %101
-%352 = OpLoad %ushort %169
-%353 = OpFunctionCall %ulong %5 %351 %352
-OpStore %170 %353
-%354 = OpLoad %v4ushort %112
-%355 = OpCompositeExtract %ushort %354 1
-OpStore %171 %355
-%356 = OpLoad %ulong %170
-%357 = OpLoad %ushort %171
-%358 = OpFunctionCall %ulong %5 %356 %357
-OpStore %172 %358
-%359 = OpLoad %v4ushort %112
-%360 = OpCompositeExtract %ushort %359 2
-OpStore %173 %360
-%361 = OpLoad %ulong %172
-%362 = OpLoad %ushort %173
-%363 = OpFunctionCall %ulong %5 %361 %362
-OpStore %174 %363
-%364 = OpLoad %v4ushort %112
-%365 = OpCompositeExtract %ushort %364 3
-OpStore %175 %365
-%366 = OpLoad %ulong %174
-%367 = OpLoad %ushort %175
-%368 = OpFunctionCall %ulong %5 %366 %367
-OpStore %176 %368
-OpBranch %57
-%57 = OpLabel
-OpBranch %64
-%64 = OpLabel
-%369 = OpLoad %v4ushort %118
-%370 = OpCompositeExtract %ushort %369 0
-OpStore %201 %370
-%371 = OpLoad %ulong %176
-%372 = OpLoad %ushort %201
-%373 = OpFunctionCall %ulong %5 %371 %372
-OpStore %202 %373
-%374 = OpLoad %v4ushort %118
-%375 = OpCompositeExtract %ushort %374 1
-OpStore %203 %375
-%376 = OpLoad %ulong %202
-%377 = OpLoad %ushort %203
-%378 = OpFunctionCall %ulong %5 %376 %377
-OpStore %204 %378
-%379 = OpLoad %v4ushort %118
-%380 = OpCompositeExtract %ushort %379 2
-OpStore %205 %380
-%381 = OpLoad %ulong %204
-%382 = OpLoad %ushort %205
-%383 = OpFunctionCall %ulong %5 %381 %382
-OpStore %206 %383
-%384 = OpLoad %v4ushort %118
-%385 = OpCompositeExtract %ushort %384 3
-OpStore %207 %385
-%386 = OpLoad %ulong %206
-%387 = OpLoad %ushort %207
-%388 = OpFunctionCall %ulong %5 %386 %387
-OpStore %208 %388
-OpBranch %65
-%65 = OpLabel
-%389 = OpLoad %v4ushort %112
-%390 = OpLoad %v4ushort %118
-%391 = OpIAdd %v4ushort %389 %390
-OpStore %119 %391
-OpBranch %68
-%68 = OpLabel
-%392 = OpLoad %v4ushort %119
-%393 = OpCompositeExtract %ushort %392 0
-OpStore %217 %393
-%394 = OpLoad %ulong %208
-%395 = OpLoad %ushort %217
-%396 = OpFunctionCall %ulong %5 %394 %395
-OpStore %218 %396
-%397 = OpLoad %v4ushort %119
-%398 = OpCompositeExtract %ushort %397 1
-OpStore %219 %398
-%399 = OpLoad %ulong %218
-%400 = OpLoad %ushort %219
-%401 = OpFunctionCall %ulong %5 %399 %400
-OpStore %220 %401
-%402 = OpLoad %v4ushort %119
-%403 = OpCompositeExtract %ushort %402 2
-OpStore %221 %403
-%404 = OpLoad %ulong %220
-%405 = OpLoad %ushort %221
-%406 = OpFunctionCall %ulong %5 %404 %405
-OpStore %222 %406
-%407 = OpLoad %v4ushort %119
-%408 = OpCompositeExtract %ushort %407 3
-OpStore %223 %408
-%409 = OpLoad %ulong %222
-%410 = OpLoad %ushort %223
-%411 = OpFunctionCall %ulong %5 %409 %410
-OpStore %224 %411
-OpBranch %69
-%69 = OpLabel
-%412 = OpLoad %v4ushort %112
-%413 = OpLoad %v4ushort %118
-%414 = OpISub %v4ushort %412 %413
-OpStore %120 %414
-OpBranch %72
-%72 = OpLabel
-%415 = OpLoad %v4ushort %120
-%416 = OpCompositeExtract %ushort %415 0
-OpStore %233 %416
-%417 = OpLoad %ulong %224
-%418 = OpLoad %ushort %233
-%419 = OpFunctionCall %ulong %5 %417 %418
-OpStore %234 %419
-%420 = OpLoad %v4ushort %120
-%421 = OpCompositeExtract %ushort %420 1
-OpStore %235 %421
-%422 = OpLoad %ulong %234
-%423 = OpLoad %ushort %235
-%424 = OpFunctionCall %ulong %5 %422 %423
-OpStore %236 %424
-%425 = OpLoad %v4ushort %120
-%426 = OpCompositeExtract %ushort %425 2
-OpStore %237 %426
-%427 = OpLoad %ulong %236
-%428 = OpLoad %ushort %237
-%429 = OpFunctionCall %ulong %5 %427 %428
-OpStore %238 %429
-%430 = OpLoad %v4ushort %120
-%431 = OpCompositeExtract %ushort %430 3
-OpStore %239 %431
-%432 = OpLoad %ulong %238
-%433 = OpLoad %ushort %239
-%434 = OpFunctionCall %ulong %5 %432 %433
-OpStore %240 %434
-OpBranch %73
-%73 = OpLabel
-%435 = OpLoad %v4ushort %118
-%436 = OpLoad %v4ushort %112
-%437 = OpISub %v4ushort %435 %436
-OpStore %121 %437
-OpBranch %76
-%76 = OpLabel
-%438 = OpLoad %v4ushort %121
-%439 = OpCompositeExtract %ushort %438 0
-OpStore %249 %439
-%440 = OpLoad %ulong %240
-%441 = OpLoad %ushort %249
-%442 = OpFunctionCall %ulong %5 %440 %441
-OpStore %250 %442
-%443 = OpLoad %v4ushort %121
-%444 = OpCompositeExtract %ushort %443 1
-OpStore %251 %444
-%445 = OpLoad %ulong %250
-%446 = OpLoad %ushort %251
-%447 = OpFunctionCall %ulong %5 %445 %446
-OpStore %252 %447
-%448 = OpLoad %v4ushort %121
-%449 = OpCompositeExtract %ushort %448 2
-OpStore %253 %449
-%450 = OpLoad %ulong %252
-%451 = OpLoad %ushort %253
-%452 = OpFunctionCall %ulong %5 %450 %451
-OpStore %254 %452
-%453 = OpLoad %v4ushort %121
-%454 = OpCompositeExtract %ushort %453 3
-OpStore %255 %454
-%455 = OpLoad %ulong %254
-%456 = OpLoad %ushort %255
-%457 = OpFunctionCall %ulong %5 %455 %456
-OpStore %256 %457
-OpBranch %77
-%77 = OpLabel
-%458 = OpLoad %v4ushort %112
-%459 = OpLoad %v4ushort %118
-%460 = OpIMul %v4ushort %458 %459
-OpStore %122 %460
-OpBranch %78
-%78 = OpLabel
-%461 = OpLoad %v4ushort %122
-%462 = OpCompositeExtract %ushort %461 0
-OpStore %257 %462
-%463 = OpLoad %ulong %256
-%464 = OpLoad %ushort %257
-%465 = OpFunctionCall %ulong %5 %463 %464
-OpStore %258 %465
-%466 = OpLoad %v4ushort %122
-%467 = OpCompositeExtract %ushort %466 1
-OpStore %259 %467
-%468 = OpLoad %ulong %258
-%469 = OpLoad %ushort %259
-%470 = OpFunctionCall %ulong %5 %468 %469
-OpStore %260 %470
-%471 = OpLoad %v4ushort %122
-%472 = OpCompositeExtract %ushort %471 2
-OpStore %261 %472
-%473 = OpLoad %ulong %260
-%474 = OpLoad %ushort %261
-%475 = OpFunctionCall %ulong %5 %473 %474
-OpStore %262 %475
-%476 = OpLoad %v4ushort %122
-%477 = OpCompositeExtract %ushort %476 3
-OpStore %263 %477
-%478 = OpLoad %ulong %262
-%479 = OpLoad %ushort %263
-%480 = OpFunctionCall %ulong %5 %478 %479
-OpStore %264 %480
-OpBranch %79
-%79 = OpLabel
-%481 = OpLoad %v4ushort %112
-%482 = OpLoad %v4ushort %105
-%483 = OpIMul %v4ushort %481 %482
-OpStore %123 %483
-OpBranch %80
-%80 = OpLabel
-%484 = OpLoad %v4ushort %123
-%485 = OpCompositeExtract %ushort %484 0
-OpStore %265 %485
-%486 = OpLoad %ulong %264
-%487 = OpLoad %ushort %265
-%488 = OpFunctionCall %ulong %5 %486 %487
-OpStore %266 %488
-%489 = OpLoad %v4ushort %123
-%490 = OpCompositeExtract %ushort %489 1
-OpStore %267 %490
-%491 = OpLoad %ulong %266
-%492 = OpLoad %ushort %267
-%493 = OpFunctionCall %ulong %5 %491 %492
-OpStore %268 %493
-%494 = OpLoad %v4ushort %123
-%495 = OpCompositeExtract %ushort %494 2
-OpStore %269 %495
-%496 = OpLoad %ulong %268
-%497 = OpLoad %ushort %269
-%498 = OpFunctionCall %ulong %5 %496 %497
-OpStore %270 %498
-%499 = OpLoad %v4ushort %123
-%500 = OpCompositeExtract %ushort %499 3
-OpStore %271 %500
-%501 = OpLoad %ulong %270
-%502 = OpLoad %ushort %271
-%503 = OpFunctionCall %ulong %5 %501 %502
-OpStore %272 %503
-OpBranch %81
-%81 = OpLabel
-%504 = OpLoad %v4ushort %118
-%505 = OpLoad %v4ushort %105
-%506 = OpIMul %v4ushort %504 %505
-OpStore %124 %506
-OpBranch %82
-%82 = OpLabel
-%507 = OpLoad %v4ushort %124
-%508 = OpCompositeExtract %ushort %507 0
-OpStore %273 %508
-%509 = OpLoad %ulong %272
-%510 = OpLoad %ushort %273
-%511 = OpFunctionCall %ulong %5 %509 %510
-OpStore %274 %511
-%512 = OpLoad %v4ushort %124
-%513 = OpCompositeExtract %ushort %512 1
-OpStore %275 %513
-%514 = OpLoad %ulong %274
-%515 = OpLoad %ushort %275
-%516 = OpFunctionCall %ulong %5 %514 %515
-OpStore %276 %516
-%517 = OpLoad %v4ushort %124
-%518 = OpCompositeExtract %ushort %517 2
-OpStore %277 %518
-%519 = OpLoad %ulong %276
-%520 = OpLoad %ushort %277
-%521 = OpFunctionCall %ulong %5 %519 %520
-OpStore %278 %521
-%522 = OpLoad %v4ushort %124
-%523 = OpCompositeExtract %ushort %522 3
-OpStore %279 %523
-%524 = OpLoad %ulong %278
-%525 = OpLoad %ushort %279
-%526 = OpFunctionCall %ulong %5 %524 %525
-OpStore %280 %526
-OpBranch %83
-%83 = OpLabel
-%527 = OpLoad %v4ushort %112
-%528 = OpLoad %v4ushort %118
-%529 = OpIAdd %v4ushort %527 %528
-OpStore %125 %529
-%530 = OpLoad %v4ushort %125
-%531 = OpLoad %v4ushort %105
-%532 = OpIMul %v4ushort %530 %531
-OpStore %126 %532
-OpBranch %84
-%84 = OpLabel
-%533 = OpLoad %v4ushort %126
-%534 = OpCompositeExtract %ushort %533 0
-OpStore %281 %534
-%535 = OpLoad %ulong %280
-%536 = OpLoad %ushort %281
-%537 = OpFunctionCall %ulong %5 %535 %536
-OpStore %282 %537
-%538 = OpLoad %v4ushort %126
-%539 = OpCompositeExtract %ushort %538 1
-OpStore %283 %539
-%540 = OpLoad %ulong %282
-%541 = OpLoad %ushort %283
-%542 = OpFunctionCall %ulong %5 %540 %541
-OpStore %284 %542
-%543 = OpLoad %v4ushort %126
-%544 = OpCompositeExtract %ushort %543 2
-OpStore %285 %544
-%545 = OpLoad %ulong %284
-%546 = OpLoad %ushort %285
-%547 = OpFunctionCall %ulong %5 %545 %546
-OpStore %286 %547
-%548 = OpLoad %v4ushort %126
-%549 = OpCompositeExtract %ushort %548 3
-OpStore %287 %549
-%550 = OpLoad %ulong %286
-%551 = OpLoad %ushort %287
-%552 = OpFunctionCall %ulong %5 %550 %551
-OpStore %288 %552
-OpBranch %85
-%85 = OpLabel
-%553 = OpLoad %v4ushort %106
-%554 = OpLoad %v4ushort %112
-%555 = OpISub %v4ushort %553 %554
-OpStore %127 %555
-OpBranch %86
-%86 = OpLabel
-%556 = OpLoad %v4ushort %127
-%557 = OpCompositeExtract %ushort %556 0
-OpStore %289 %557
-%558 = OpLoad %ulong %288
-%559 = OpLoad %ushort %289
-%560 = OpFunctionCall %ulong %5 %558 %559
-OpStore %290 %560
-%561 = OpLoad %v4ushort %127
-%562 = OpCompositeExtract %ushort %561 1
-OpStore %291 %562
-%563 = OpLoad %ulong %290
-%564 = OpLoad %ushort %291
-%565 = OpFunctionCall %ulong %5 %563 %564
-OpStore %292 %565
-%566 = OpLoad %v4ushort %127
-%567 = OpCompositeExtract %ushort %566 2
-OpStore %293 %567
-%568 = OpLoad %ulong %292
-%569 = OpLoad %ushort %293
-%570 = OpFunctionCall %ulong %5 %568 %569
-OpStore %294 %570
-%571 = OpLoad %v4ushort %127
-%572 = OpCompositeExtract %ushort %571 3
-OpStore %295 %572
-%573 = OpLoad %ulong %294
-%574 = OpLoad %ushort %295
-%575 = OpFunctionCall %ulong %5 %573 %574
-OpStore %296 %575
-OpBranch %87
-%87 = OpLabel
-%576 = OpLoad %v4ushort %106
-%577 = OpLoad %v4ushort %118
-%578 = OpISub %v4ushort %576 %577
-OpStore %128 %578
-%579 = OpLoad %ulong %296
-%580 = OpLoad %v4ushort %128
-%581 = OpFunctionCall %ulong %1 %579 %580
-OpStore %129 %581
-%582 = OpLoad %v4ushort %112
-%583 = OpLoad %v4ushort %118
-%584 = OpBitwiseAnd %v4ushort %582 %583
-OpStore %130 %584
-%585 = OpLoad %ulong %129
-%586 = OpLoad %v4ushort %130
-%587 = OpFunctionCall %ulong %1 %585 %586
-OpStore %131 %587
-%588 = OpLoad %v4ushort %112
-%589 = OpLoad %v4ushort %118
-%590 = OpBitwiseOr %v4ushort %588 %589
-OpStore %132 %590
-%591 = OpLoad %ulong %131
-%592 = OpLoad %v4ushort %132
-%593 = OpFunctionCall %ulong %1 %591 %592
-OpStore %133 %593
-%594 = OpLoad %v4ushort %112
-%595 = OpLoad %v4ushort %118
-%596 = OpBitwiseXor %v4ushort %594 %595
-OpStore %134 %596
-%597 = OpLoad %ulong %133
-%598 = OpLoad %v4ushort %134
-%599 = OpFunctionCall %ulong %1 %597 %598
-OpStore %135 %599
-%600 = OpLoad %v4ushort %112
-%601 = OpNot %v4ushort %600
-OpStore %136 %601
-%602 = OpLoad %ulong %135
-%603 = OpLoad %v4ushort %136
-%604 = OpFunctionCall %ulong %1 %602 %603
-OpStore %137 %604
-%605 = OpLoad %v4ushort %118
-%606 = OpNot %v4ushort %605
-OpStore %138 %606
-%607 = OpLoad %ulong %137
-%608 = OpLoad %v4ushort %138
-%609 = OpFunctionCall %ulong %1 %607 %608
-OpStore %139 %609
-%610 = OpLoad %v4ushort %130
-%611 = OpLoad %v4ushort %132
-%612 = OpBitwiseXor %v4ushort %610 %611
-OpStore %140 %612
-%613 = OpLoad %ulong %139
-%614 = OpLoad %v4ushort %140
-%615 = OpFunctionCall %ulong %1 %613 %614
-OpStore %141 %615
-%616 = OpLoad %ulong %141
-OpStore %163 %616
-%617 = OpLoad %v4ushort %112
-OpStore %164 %617
-%618 = OpLoad %v4ushort %106
-OpStore %165 %618
-%619 = OpLoad %v4ushort %106
-OpStore %166 %619
-OpStore %167 %ulong_0
-OpBranch %50
-%50 = OpLabel
-%621 = OpLoad %ulong %167
-%623 = OpULessThan %bool %621 %ulong_6
-OpStore %143 %623
-%624 = OpLoad %bool %143
-OpLoopMerge %52 %89 None
-OpBranchConditional %624 %51 %52
-%52 = OpLabel
-OpStore %96 %625
-%627 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_0
-%628 = OpLoad %v4ushort %164
-OpStore %627 %628
-%629 = OpLoad %v4ushort %164
-%630 = OpLoad %v4ushort %118
-%631 = OpIAdd %v4ushort %629 %630
-OpStore %149 %631
-%633 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_1
-%634 = OpLoad %v4ushort %149
-OpStore %633 %634
-%635 = OpLoad %v4ushort %164
-%636 = OpLoad %v4ushort %105
-%637 = OpIMul %v4ushort %635 %636
-OpStore %150 %637
-%639 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_2
-%640 = OpLoad %v4ushort %150
-OpStore %639 %640
-%642 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_3
-%643 = OpLoad %v4ushort %165
-OpStore %642 %643
-%645 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_4
-%646 = OpLoad %v4ushort %166
-OpStore %645 %646
-%647 = OpLoad %v4ushort %164
-%648 = OpLoad %v4ushort %118
-%649 = OpBitwiseXor %v4ushort %647 %648
-OpStore %151 %649
-%651 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_5
-%652 = OpLoad %v4ushort %151
-OpStore %651 %652
-%653 = OpLoad %ulong %163
-OpStore %162 %653
-OpStore %168 %ulong_0
-OpBranch %53
-%53 = OpLabel
-%654 = OpLoad %ulong %168
-%655 = OpULessThan %bool %654 %ulong_6
-OpStore %152 %655
-%656 = OpLoad %bool %152
-OpLoopMerge %55 %88 None
-OpBranchConditional %656 %54 %55
-%55 = OpLabel
-OpStore %99 %657
-%658 = OpAccessChain %_ptr_Function_uchar %99 %uint_0
-OpStore %658 %uchar_219
-%660 = OpAccessChain %_ptr_Function_v4ushort %96 %uint_2
-%661 = OpLoad %v4ushort %660
-OpStore %155 %661
-%662 = OpAccessChain %_ptr_Function_v4ushort %99 %uint_1
-%663 = OpLoad %v4ushort %155
-OpStore %662 %663
-%664 = OpAccessChain %_ptr_Function_uchar %99 %uint_2
-OpStore %664 %uchar_173
-%666 = OpLoad %uchar %658
-OpStore %157 %666
-%667 = OpLoad %ulong %162
-%668 = OpLoad %uchar %157
-%669 = OpFunctionCall %ulong %4 %667 %668
-OpStore %158 %669
-%670 = OpLoad %v4ushort %662
-OpStore %159 %670
-OpBranch %62
-%62 = OpLabel
-%671 = OpLoad %v4ushort %159
-%672 = OpCompositeExtract %ushort %671 0
-OpStore %193 %672
-%673 = OpLoad %ulong %158
-%674 = OpLoad %ushort %193
-%675 = OpFunctionCall %ulong %5 %673 %674
-OpStore %194 %675
-%676 = OpLoad %v4ushort %159
-%677 = OpCompositeExtract %ushort %676 1
-OpStore %195 %677
-%678 = OpLoad %ulong %194
-%679 = OpLoad %ushort %195
-%680 = OpFunctionCall %ulong %5 %678 %679
-OpStore %196 %680
-%681 = OpLoad %v4ushort %159
-%682 = OpCompositeExtract %ushort %681 2
-OpStore %197 %682
-%683 = OpLoad %ulong %196
-%684 = OpLoad %ushort %197
-%685 = OpFunctionCall %ulong %5 %683 %684
-OpStore %198 %685
-%686 = OpLoad %v4ushort %159
-%687 = OpCompositeExtract %ushort %686 3
-OpStore %199 %687
-%688 = OpLoad %ulong %198
-%689 = OpLoad %ushort %199
-%690 = OpFunctionCall %ulong %5 %688 %689
-OpStore %200 %690
-OpBranch %63
-%63 = OpLabel
-%691 = OpAccessChain %_ptr_Function_uchar %99 %uint_2
-%692 = OpLoad %uchar %691
-OpStore %160 %692
-%693 = OpLoad %ulong %200
-%694 = OpLoad %uchar %160
-%695 = OpFunctionCall %ulong %4 %693 %694
-OpStore %161 %695
-%696 = OpLoad %ulong %161
-OpReturnValue %696
-%54 = OpLabel
-%697 = OpLoad %ulong %168
-%698 = OpAccessChain %_ptr_Function_v4ushort %96 %697
-%699 = OpLoad %v4ushort %698
-OpStore %153 %699
-OpBranch %60
-%60 = OpLabel
-%700 = OpLoad %v4ushort %153
-%701 = OpCompositeExtract %ushort %700 0
-OpStore %185 %701
-%702 = OpLoad %ulong %162
-%703 = OpLoad %ushort %185
-%704 = OpFunctionCall %ulong %5 %702 %703
-OpStore %186 %704
-%705 = OpLoad %v4ushort %153
-%706 = OpCompositeExtract %ushort %705 1
-OpStore %187 %706
-%707 = OpLoad %ulong %186
-%708 = OpLoad %ushort %187
-%709 = OpFunctionCall %ulong %5 %707 %708
-OpStore %188 %709
-%710 = OpLoad %v4ushort %153
-%711 = OpCompositeExtract %ushort %710 2
-OpStore %189 %711
-%712 = OpLoad %ulong %188
-%713 = OpLoad %ushort %189
-%714 = OpFunctionCall %ulong %5 %712 %713
-OpStore %190 %714
-%715 = OpLoad %v4ushort %153
-%716 = OpCompositeExtract %ushort %715 3
-OpStore %191 %716
-%717 = OpLoad %ulong %190
-%718 = OpLoad %ushort %191
-%719 = OpFunctionCall %ulong %5 %717 %718
-OpStore %192 %719
-OpBranch %61
-%61 = OpLabel
-%720 = OpLoad %ulong %168
-%722 = OpIAdd %ulong %720 %ulong_1
-OpStore %154 %722
-%723 = OpLoad %ulong %192
-OpStore %162 %723
-%724 = OpLoad %ulong %154
-OpStore %168 %724
-OpBranch %88
-%51 = OpLabel
-%725 = OpLoad %v4ushort %164
-%726 = OpLoad %v4ushort %105
-%727 = OpIMul %v4ushort %725 %726
-OpStore %144 %727
-OpBranch %58
-%58 = OpLabel
-%728 = OpLoad %v4ushort %144
-%729 = OpCompositeExtract %ushort %728 0
-OpStore %177 %729
-%730 = OpLoad %ulong %163
-%731 = OpLoad %ushort %177
-%732 = OpFunctionCall %ulong %5 %730 %731
-OpStore %178 %732
-%733 = OpLoad %v4ushort %144
-%734 = OpCompositeExtract %ushort %733 1
-OpStore %179 %734
-%735 = OpLoad %ulong %178
-%736 = OpLoad %ushort %179
-%737 = OpFunctionCall %ulong %5 %735 %736
-OpStore %180 %737
-%738 = OpLoad %v4ushort %144
-%739 = OpCompositeExtract %ushort %738 2
-OpStore %181 %739
-%740 = OpLoad %ulong %180
-%741 = OpLoad %ushort %181
-%742 = OpFunctionCall %ulong %5 %740 %741
-OpStore %182 %742
-%743 = OpLoad %v4ushort %144
-%744 = OpCompositeExtract %ushort %743 3
-OpStore %183 %744
-%745 = OpLoad %ulong %182
-%746 = OpLoad %ushort %183
-%747 = OpFunctionCall %ulong %5 %745 %746
-OpStore %184 %747
-OpBranch %59
-%59 = OpLabel
-%748 = OpLoad %v4ushort %165
-%749 = OpLoad %v4ushort %144
-%750 = OpBitwiseXor %v4ushort %748 %749
-OpStore %145 %750
-OpBranch %66
-%66 = OpLabel
-%751 = OpLoad %v4ushort %145
-%752 = OpCompositeExtract %ushort %751 0
-OpStore %209 %752
-%753 = OpLoad %ulong %184
-%754 = OpLoad %ushort %209
-%755 = OpFunctionCall %ulong %5 %753 %754
-OpStore %210 %755
-%756 = OpLoad %v4ushort %145
-%757 = OpCompositeExtract %ushort %756 1
-OpStore %211 %757
-%758 = OpLoad %ulong %210
-%759 = OpLoad %ushort %211
-%760 = OpFunctionCall %ulong %5 %758 %759
-OpStore %212 %760
-%761 = OpLoad %v4ushort %145
-%762 = OpCompositeExtract %ushort %761 2
-OpStore %213 %762
-%763 = OpLoad %ulong %212
-%764 = OpLoad %ushort %213
-%765 = OpFunctionCall %ulong %5 %763 %764
-OpStore %214 %765
-%766 = OpLoad %v4ushort %145
-%767 = OpCompositeExtract %ushort %766 3
-OpStore %215 %767
-%768 = OpLoad %ulong %214
-%769 = OpLoad %ushort %215
-%770 = OpFunctionCall %ulong %5 %768 %769
-OpStore %216 %770
-OpBranch %67
-%67 = OpLabel
-%771 = OpLoad %v4ushort %166
-%772 = OpLoad %v4ushort %164
-%773 = OpIAdd %v4ushort %771 %772
-OpStore %146 %773
-OpBranch %70
-%70 = OpLabel
-%774 = OpLoad %v4ushort %146
-%775 = OpCompositeExtract %ushort %774 0
-OpStore %225 %775
-%776 = OpLoad %ulong %216
-%777 = OpLoad %ushort %225
-%778 = OpFunctionCall %ulong %5 %776 %777
-OpStore %226 %778
-%779 = OpLoad %v4ushort %146
-%780 = OpCompositeExtract %ushort %779 1
-OpStore %227 %780
-%781 = OpLoad %ulong %226
-%782 = OpLoad %ushort %227
-%783 = OpFunctionCall %ulong %5 %781 %782
-OpStore %228 %783
-%784 = OpLoad %v4ushort %146
-%785 = OpCompositeExtract %ushort %784 2
-OpStore %229 %785
-%786 = OpLoad %ulong %228
-%787 = OpLoad %ushort %229
-%788 = OpFunctionCall %ulong %5 %786 %787
-OpStore %230 %788
-%789 = OpLoad %v4ushort %146
-%790 = OpCompositeExtract %ushort %789 3
-OpStore %231 %790
-%791 = OpLoad %ulong %230
-%792 = OpLoad %ushort %231
-%793 = OpFunctionCall %ulong %5 %791 %792
-OpStore %232 %793
-OpBranch %71
-%71 = OpLabel
-%794 = OpLoad %v4ushort %164
-%795 = OpLoad %v4ushort %118
-%796 = OpIAdd %v4ushort %794 %795
-OpStore %147 %796
-OpBranch %74
-%74 = OpLabel
-%797 = OpLoad %v4ushort %147
-%798 = OpCompositeExtract %ushort %797 0
-OpStore %241 %798
-%799 = OpLoad %ulong %232
-%800 = OpLoad %ushort %241
-%801 = OpFunctionCall %ulong %5 %799 %800
-OpStore %242 %801
-%802 = OpLoad %v4ushort %147
-%803 = OpCompositeExtract %ushort %802 1
-OpStore %243 %803
-%804 = OpLoad %ulong %242
-%805 = OpLoad %ushort %243
-%806 = OpFunctionCall %ulong %5 %804 %805
-OpStore %244 %806
-%807 = OpLoad %v4ushort %147
-%808 = OpCompositeExtract %ushort %807 2
-OpStore %245 %808
-%809 = OpLoad %ulong %244
-%810 = OpLoad %ushort %245
-%811 = OpFunctionCall %ulong %5 %809 %810
-OpStore %246 %811
-%812 = OpLoad %v4ushort %147
-%813 = OpCompositeExtract %ushort %812 3
-OpStore %247 %813
-%814 = OpLoad %ulong %246
-%815 = OpLoad %ushort %247
-%816 = OpFunctionCall %ulong %5 %814 %815
-OpStore %248 %816
-OpBranch %75
-%75 = OpLabel
-%817 = OpLoad %ulong %167
-%818 = OpIAdd %ulong %817 %ulong_1
-OpStore %148 %818
-%819 = OpLoad %ulong %248
-OpStore %163 %819
-%820 = OpLoad %v4ushort %147
-OpStore %164 %820
-%821 = OpLoad %v4ushort %145
-OpStore %165 %821
-%822 = OpLoad %v4ushort %146
-OpStore %166 %822
-%823 = OpLoad %ulong %148
-OpStore %167 %823
-OpBranch %89
-%88 = OpLabel
-OpBranch %53
-%89 = OpLabel
-OpBranch %50
-OpFunctionEnd
-%3 = OpFunction %ulong None %824
-%825 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %827
-%828 = OpFunctionParameter %ulong
-%829 = OpFunctionParameter %uchar
-%830 = OpLabel
-%837 = OpVariable %_ptr_Function_ulong Function
-%838 = OpVariable %_ptr_Function_uchar Function
-%839 = OpVariable %_ptr_Function_ulong Function
-%840 = OpVariable %_ptr_Function_bool Function
-%841 = OpVariable %_ptr_Function_ulong Function
-%842 = OpVariable %_ptr_Function_ulong Function
-%843 = OpVariable %_ptr_Function_ulong Function
-%844 = OpVariable %_ptr_Function_ulong Function
-%845 = OpVariable %_ptr_Function_ulong Function
-%846 = OpVariable %_ptr_Function_ulong Function
-%847 = OpVariable %_ptr_Function_ulong Function
-%848 = OpVariable %_ptr_Function_ulong Function
-OpStore %837 %828
-OpStore %838 %829
-%849 = OpLoad %uchar %838
-%850 = OpUConvert %ulong %849
-OpStore %839 %850
-OpBranch %831
-%831 = OpLabel
-%851 = OpLoad %ulong %837
-OpStore %847 %851
-OpStore %848 %ulong_0
-OpBranch %832
-%832 = OpLabel
-%852 = OpLoad %ulong %848
-%854 = OpULessThan %bool %852 %ulong_8
-OpStore %840 %854
-%855 = OpLoad %bool %840
-OpLoopMerge %834 %836 None
-OpBranchConditional %855 %833 %834
-%834 = OpLabel
-OpBranch %835
-%835 = OpLabel
-%856 = OpLoad %ulong %847
-OpReturnValue %856
-%833 = OpLabel
-%857 = OpLoad %ulong %848
-%858 = OpIMul %ulong %857 %ulong_8
-OpStore %841 %858
-%859 = OpLoad %ulong %839
-%860 = OpLoad %ulong %841
-%861 = OpShiftRightLogical %ulong %859 %860
-OpStore %842 %861
-%862 = OpLoad %ulong %842
-%864 = OpBitwiseAnd %ulong %862 %ulong_255
-OpStore %843 %864
-%865 = OpLoad %ulong %847
-%866 = OpLoad %ulong %843
-%867 = OpBitwiseXor %ulong %865 %866
-OpStore %844 %867
-%868 = OpLoad %ulong %844
-%870 = OpIMul %ulong %868 %ulong_1099511628211
-OpStore %845 %870
-%871 = OpLoad %ulong %848
-%872 = OpIAdd %ulong %871 %ulong_1
-OpStore %846 %872
-%873 = OpLoad %ulong %845
-OpStore %847 %873
-%874 = OpLoad %ulong %846
-OpStore %848 %874
-OpBranch %836
-%836 = OpLabel
-OpBranch %832
-OpFunctionEnd
-%5 = OpFunction %ulong None %875
-%876 = OpFunctionParameter %ulong
-%877 = OpFunctionParameter %ushort
-%878 = OpLabel
-%885 = OpVariable %_ptr_Function_ulong Function
-%886 = OpVariable %_ptr_Function_ushort Function
-%887 = OpVariable %_ptr_Function_ulong Function
-%888 = OpVariable %_ptr_Function_bool Function
-%889 = OpVariable %_ptr_Function_ulong Function
-%890 = OpVariable %_ptr_Function_ulong Function
-%891 = OpVariable %_ptr_Function_ulong Function
-%892 = OpVariable %_ptr_Function_ulong Function
-%893 = OpVariable %_ptr_Function_ulong Function
-%894 = OpVariable %_ptr_Function_ulong Function
-%895 = OpVariable %_ptr_Function_ulong Function
-%896 = OpVariable %_ptr_Function_ulong Function
-OpStore %885 %876
-OpStore %886 %877
-%897 = OpLoad %ushort %886
-%898 = OpSConvert %ulong %897
-OpStore %887 %898
-OpBranch %879
-%879 = OpLabel
-%899 = OpLoad %ulong %885
-OpStore %895 %899
-OpStore %896 %ulong_0
-OpBranch %880
-%880 = OpLabel
-%900 = OpLoad %ulong %896
-%901 = OpULessThan %bool %900 %ulong_8
-OpStore %888 %901
-%902 = OpLoad %bool %888
-OpLoopMerge %882 %884 None
-OpBranchConditional %902 %881 %882
-%882 = OpLabel
-OpBranch %883
-%883 = OpLabel
-%903 = OpLoad %ulong %895
-OpReturnValue %903
-%881 = OpLabel
-%904 = OpLoad %ulong %896
-%905 = OpIMul %ulong %904 %ulong_8
-OpStore %889 %905
-%906 = OpLoad %ulong %887
-%907 = OpLoad %ulong %889
-%908 = OpShiftRightLogical %ulong %906 %907
-OpStore %890 %908
-%909 = OpLoad %ulong %890
-%910 = OpBitwiseAnd %ulong %909 %ulong_255
-OpStore %891 %910
-%911 = OpLoad %ulong %895
-%912 = OpLoad %ulong %891
-%913 = OpBitwiseXor %ulong %911 %912
-OpStore %892 %913
-%914 = OpLoad %ulong %892
-%915 = OpIMul %ulong %914 %ulong_1099511628211
-OpStore %893 %915
-%916 = OpLoad %ulong %896
-%917 = OpIAdd %ulong %916 %ulong_1
-OpStore %894 %917
-%918 = OpLoad %ulong %893
-OpStore %895 %918
-%919 = OpLoad %ulong %894
-OpStore %896 %919
-OpBranch %884
-%884 = OpLabel
-OpBranch %880
+%293 = OpVariable %_ptr_Function_v4ushort Function
+%294 = OpVariable %_ptr_Function_v4ushort Function
+%295 = OpVariable %_ptr_Function_v4ushort Function
+%296 = OpVariable %_ptr_Function_bool Function
+%297 = OpVariable %_ptr_Function_v4ushort Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_v4ushort Function
+%302 = OpVariable %_ptr_Function_uchar Function
+%303 = OpVariable %_ptr_Function_v4ushort Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_uchar Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_v4ushort Function
+%309 = OpVariable %_ptr_Function_v4ushort Function
+%310 = OpVariable %_ptr_Function_v4ushort Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_bool Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_bool Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_ulong Function
+%330 = OpVariable %_ptr_Function_ulong Function
+%331 = OpVariable %_ptr_Function_ulong Function
+%332 = OpVariable %_ptr_Function_ulong Function
+OpStore %233 %196
+OpBranch %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%333 = OpLoad %ulong %233
+%334 = OpUConvert %ushort %333
+OpStore %234 %334
+%335 = OpCompositeConstruct %v4ushort %ushort_1001 %ushort_64433 %ushort_1207 %ushort_64235
+OpStore %235 %335
+%340 = OpCompositeConstruct %v4ushort %ushort_13 %ushort_65525 %ushort_9 %ushort_65529
+OpStore %236 %340
+%345 = OpCompositeConstruct %v4ushort %ushort_1 %ushort_2 %ushort_3 %ushort_4
+OpStore %237 %345
+%350 = OpCompositeConstruct %v4ushort %ushort_0 %ushort_0 %ushort_0 %ushort_0
+OpStore %238 %350
+%352 = OpLoad %v4ushort %235
+%353 = OpCompositeExtract %ushort %352 0
+OpStore %239 %353
+%354 = OpLoad %ushort %239
+%355 = OpLoad %ushort %234
+%356 = OpIAdd %ushort %354 %355
+OpStore %240 %356
+%357 = OpLoad %v4ushort %235
+%358 = OpLoad %ushort %240
+%359 = OpCompositeInsert %v4ushort %358 %357 0
+OpStore %241 %359
+%360 = OpLoad %v4ushort %241
+%361 = OpCompositeExtract %ushort %360 3
+OpStore %242 %361
+%362 = OpLoad %ushort %242
+%363 = OpLoad %ushort %234
+%364 = OpIAdd %ushort %362 %363
+OpStore %243 %364
+%365 = OpLoad %v4ushort %241
+%366 = OpLoad %ushort %243
+%367 = OpCompositeInsert %v4ushort %366 %365 3
+OpStore %244 %367
+%368 = OpLoad %v4ushort %236
+%369 = OpCompositeExtract %ushort %368 1
+OpStore %245 %369
+%370 = OpLoad %ushort %245
+%371 = OpLoad %ushort %234
+%372 = OpIAdd %ushort %370 %371
+OpStore %246 %372
+%373 = OpLoad %v4ushort %236
+%374 = OpLoad %ushort %246
+%375 = OpCompositeInsert %v4ushort %374 %373 1
+OpStore %247 %375
+%376 = OpLoad %v4ushort %247
+%377 = OpCompositeExtract %ushort %376 2
+OpStore %248 %377
+%378 = OpLoad %ushort %248
+%379 = OpLoad %ushort %234
+%380 = OpIAdd %ushort %378 %379
+OpStore %249 %380
+%381 = OpLoad %v4ushort %247
+%382 = OpLoad %ushort %249
+%383 = OpCompositeInsert %v4ushort %382 %381 2
+OpStore %250 %383
+%385 = OpLoad %v4ushort %244
+%386 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %385
+OpStore %251 %386
+%387 = OpLoad %ulong %251
+%388 = OpLoad %v4ushort %250
+%389 = OpFunctionCall %ulong %1 %387 %388
+OpStore %252 %389
+%390 = OpLoad %v4ushort %244
+%391 = OpLoad %v4ushort %250
+%392 = OpIAdd %v4ushort %390 %391
+OpStore %253 %392
+%393 = OpLoad %ulong %252
+%394 = OpLoad %v4ushort %253
+%395 = OpFunctionCall %ulong %1 %393 %394
+OpStore %254 %395
+%396 = OpLoad %v4ushort %244
+%397 = OpLoad %v4ushort %250
+%398 = OpISub %v4ushort %396 %397
+OpStore %255 %398
+%399 = OpLoad %ulong %254
+%400 = OpLoad %v4ushort %255
+%401 = OpFunctionCall %ulong %1 %399 %400
+OpStore %256 %401
+%402 = OpLoad %v4ushort %250
+%403 = OpLoad %v4ushort %244
+%404 = OpISub %v4ushort %402 %403
+OpStore %257 %404
+%405 = OpLoad %ulong %256
+%406 = OpLoad %v4ushort %257
+%407 = OpFunctionCall %ulong %1 %405 %406
+OpStore %258 %407
+%408 = OpLoad %v4ushort %244
+%409 = OpLoad %v4ushort %250
+%410 = OpIMul %v4ushort %408 %409
+OpStore %259 %410
+%411 = OpLoad %ulong %258
+%412 = OpLoad %v4ushort %259
+%413 = OpFunctionCall %ulong %1 %411 %412
+OpStore %260 %413
+%414 = OpLoad %v4ushort %244
+%415 = OpLoad %v4ushort %237
+%416 = OpIMul %v4ushort %414 %415
+OpStore %261 %416
+%417 = OpLoad %ulong %260
+%418 = OpLoad %v4ushort %261
+%419 = OpFunctionCall %ulong %1 %417 %418
+OpStore %262 %419
+%420 = OpLoad %v4ushort %250
+%421 = OpLoad %v4ushort %237
+%422 = OpIMul %v4ushort %420 %421
+OpStore %263 %422
+%423 = OpLoad %ulong %262
+%424 = OpLoad %v4ushort %263
+%425 = OpFunctionCall %ulong %1 %423 %424
+OpStore %264 %425
+%426 = OpLoad %v4ushort %253
+%427 = OpLoad %v4ushort %237
+%428 = OpIMul %v4ushort %426 %427
+OpStore %265 %428
+%429 = OpLoad %ulong %264
+%430 = OpLoad %v4ushort %265
+%431 = OpFunctionCall %ulong %1 %429 %430
+OpStore %266 %431
+%432 = OpLoad %v4ushort %238
+%433 = OpLoad %v4ushort %244
+%434 = OpISub %v4ushort %432 %433
+OpStore %267 %434
+%435 = OpLoad %ulong %266
+%436 = OpLoad %v4ushort %267
+%437 = OpFunctionCall %ulong %1 %435 %436
+OpStore %268 %437
+%438 = OpLoad %v4ushort %238
+%439 = OpLoad %v4ushort %250
+%440 = OpISub %v4ushort %438 %439
+OpStore %269 %440
+%441 = OpLoad %ulong %268
+%442 = OpLoad %v4ushort %269
+%443 = OpFunctionCall %ulong %1 %441 %442
+OpStore %270 %443
+%444 = OpLoad %v4ushort %244
+%445 = OpLoad %v4ushort %250
+%446 = OpBitwiseAnd %v4ushort %444 %445
+OpStore %271 %446
+%447 = OpLoad %ulong %270
+%448 = OpLoad %v4ushort %271
+%449 = OpFunctionCall %ulong %1 %447 %448
+OpStore %272 %449
+%450 = OpLoad %v4ushort %244
+%451 = OpLoad %v4ushort %250
+%452 = OpBitwiseOr %v4ushort %450 %451
+OpStore %273 %452
+%453 = OpLoad %ulong %272
+%454 = OpLoad %v4ushort %273
+%455 = OpFunctionCall %ulong %1 %453 %454
+OpStore %274 %455
+%456 = OpLoad %v4ushort %244
+%457 = OpLoad %v4ushort %250
+%458 = OpBitwiseXor %v4ushort %456 %457
+OpStore %275 %458
+%459 = OpLoad %ulong %274
+%460 = OpLoad %v4ushort %275
+%461 = OpFunctionCall %ulong %1 %459 %460
+OpStore %276 %461
+%462 = OpLoad %v4ushort %244
+%463 = OpNot %v4ushort %462
+OpStore %277 %463
+%464 = OpLoad %ulong %276
+%465 = OpLoad %v4ushort %277
+%466 = OpFunctionCall %ulong %1 %464 %465
+OpStore %278 %466
+%467 = OpLoad %v4ushort %250
+%468 = OpNot %v4ushort %467
+OpStore %279 %468
+%469 = OpLoad %ulong %278
+%470 = OpLoad %v4ushort %279
+%471 = OpFunctionCall %ulong %1 %469 %470
+OpStore %280 %471
+%472 = OpLoad %v4ushort %271
+%473 = OpLoad %v4ushort %273
+%474 = OpBitwiseXor %v4ushort %472 %473
+OpStore %281 %474
+%475 = OpLoad %ulong %280
+%476 = OpLoad %v4ushort %281
+%477 = OpFunctionCall %ulong %1 %475 %476
+OpStore %282 %477
+%478 = OpLoad %ulong %282
+OpStore %307 %478
+%479 = OpLoad %v4ushort %244
+OpStore %308 %479
+%480 = OpLoad %v4ushort %238
+OpStore %309 %480
+%481 = OpLoad %v4ushort %238
+OpStore %310 %481
+OpStore %311 %ulong_0
+OpBranch %198
+%198 = OpLabel
+%482 = OpLoad %ulong %311
+%484 = OpULessThan %bool %482 %ulong_6
+OpStore %283 %484
+%485 = OpLoad %bool %283
+OpLoopMerge %200 %223 None
+OpBranchConditional %485 %199 %200
+%200 = OpLabel
+OpStore %229 %486
+%488 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_0
+%489 = OpLoad %v4ushort %308
+OpStore %488 %489
+%490 = OpLoad %v4ushort %308
+%491 = OpLoad %v4ushort %250
+%492 = OpIAdd %v4ushort %490 %491
+OpStore %293 %492
+%494 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_1
+%495 = OpLoad %v4ushort %293
+OpStore %494 %495
+%496 = OpLoad %v4ushort %308
+%497 = OpLoad %v4ushort %237
+%498 = OpIMul %v4ushort %496 %497
+OpStore %294 %498
+%500 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_2
+%501 = OpLoad %v4ushort %294
+OpStore %500 %501
+%503 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_3
+%504 = OpLoad %v4ushort %309
+OpStore %503 %504
+%506 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_4
+%507 = OpLoad %v4ushort %310
+OpStore %506 %507
+%508 = OpLoad %v4ushort %308
+%509 = OpLoad %v4ushort %250
+%510 = OpBitwiseXor %v4ushort %508 %509
+OpStore %295 %510
+%512 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_5
+%513 = OpLoad %v4ushort %295
+OpStore %512 %513
+%514 = OpLoad %ulong %307
+OpStore %306 %514
+OpStore %312 %ulong_0
+OpBranch %201
+%201 = OpLabel
+%515 = OpLoad %ulong %312
+%516 = OpULessThan %bool %515 %ulong_6
+OpStore %296 %516
+%517 = OpLoad %bool %296
+OpLoopMerge %203 %222 None
+OpBranchConditional %517 %202 %203
+%203 = OpLabel
+OpStore %232 %518
+%519 = OpAccessChain %_ptr_Function_uchar %232 %uint_0
+OpStore %519 %uchar_219
+%521 = OpAccessChain %_ptr_Function_v4ushort %229 %uint_2
+%522 = OpLoad %v4ushort %521
+OpStore %300 %522
+%523 = OpAccessChain %_ptr_Function_v4ushort %232 %uint_1
+%524 = OpLoad %v4ushort %300
+OpStore %523 %524
+%525 = OpAccessChain %_ptr_Function_uchar %232 %uint_2
+OpStore %525 %uchar_173
+%527 = OpLoad %uchar %519
+OpStore %302 %527
+OpBranch %206
+%206 = OpLabel
+%528 = OpLoad %uchar %302
+%529 = OpUConvert %ulong %528
+OpStore %313 %529
+OpBranch %208
+%208 = OpLabel
+%530 = OpLoad %ulong %306
+OpStore %321 %530
+OpStore %322 %ulong_0
+OpBranch %209
+%209 = OpLabel
+%531 = OpLoad %ulong %322
+%532 = OpULessThan %bool %531 %ulong_8
+OpStore %314 %532
+%533 = OpLoad %bool %314
+OpLoopMerge %211 %221 None
+OpBranchConditional %533 %210 %211
+%211 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpBranch %207
+%207 = OpLabel
+%534 = OpAccessChain %_ptr_Function_v4ushort %232 %uint_1
+%535 = OpLoad %v4ushort %534
+OpStore %303 %535
+%536 = OpLoad %ulong %321
+%537 = OpLoad %v4ushort %303
+%538 = OpFunctionCall %ulong %1 %536 %537
+OpStore %304 %538
+%539 = OpAccessChain %_ptr_Function_uchar %232 %uint_2
+%540 = OpLoad %uchar %539
+OpStore %305 %540
+OpBranch %213
+%213 = OpLabel
+%541 = OpLoad %uchar %305
+%542 = OpUConvert %ulong %541
+OpStore %323 %542
+OpBranch %215
+%215 = OpLabel
+%543 = OpLoad %ulong %304
+OpStore %331 %543
+OpStore %332 %ulong_0
+OpBranch %216
+%216 = OpLabel
+%544 = OpLoad %ulong %332
+%545 = OpULessThan %bool %544 %ulong_8
+OpStore %324 %545
+%546 = OpLoad %bool %324
+OpLoopMerge %218 %220 None
+OpBranchConditional %546 %217 %218
+%218 = OpLabel
+OpBranch %219
+%219 = OpLabel
+OpBranch %214
+%214 = OpLabel
+%547 = OpLoad %ulong %331
+OpReturnValue %547
+%217 = OpLabel
+%548 = OpLoad %ulong %332
+%549 = OpIMul %ulong %548 %ulong_8
+OpStore %325 %549
+%550 = OpLoad %ulong %323
+%551 = OpLoad %ulong %325
+%552 = OpShiftRightLogical %ulong %550 %551
+OpStore %326 %552
+%553 = OpLoad %ulong %326
+%554 = OpBitwiseAnd %ulong %553 %ulong_255
+OpStore %327 %554
+%555 = OpLoad %ulong %331
+%556 = OpLoad %ulong %327
+%557 = OpBitwiseXor %ulong %555 %556
+OpStore %328 %557
+%558 = OpLoad %ulong %328
+%559 = OpIMul %ulong %558 %ulong_1099511628211
+OpStore %329 %559
+%560 = OpLoad %ulong %332
+%561 = OpIAdd %ulong %560 %ulong_1
+OpStore %330 %561
+%562 = OpLoad %ulong %329
+OpStore %331 %562
+%563 = OpLoad %ulong %330
+OpStore %332 %563
+OpBranch %220
+%210 = OpLabel
+%564 = OpLoad %ulong %322
+%565 = OpIMul %ulong %564 %ulong_8
+OpStore %315 %565
+%566 = OpLoad %ulong %313
+%567 = OpLoad %ulong %315
+%568 = OpShiftRightLogical %ulong %566 %567
+OpStore %316 %568
+%569 = OpLoad %ulong %316
+%570 = OpBitwiseAnd %ulong %569 %ulong_255
+OpStore %317 %570
+%571 = OpLoad %ulong %321
+%572 = OpLoad %ulong %317
+%573 = OpBitwiseXor %ulong %571 %572
+OpStore %318 %573
+%574 = OpLoad %ulong %318
+%575 = OpIMul %ulong %574 %ulong_1099511628211
+OpStore %319 %575
+%576 = OpLoad %ulong %322
+%577 = OpIAdd %ulong %576 %ulong_1
+OpStore %320 %577
+%578 = OpLoad %ulong %319
+OpStore %321 %578
+%579 = OpLoad %ulong %320
+OpStore %322 %579
+OpBranch %221
+%202 = OpLabel
+%580 = OpLoad %ulong %312
+%581 = OpAccessChain %_ptr_Function_v4ushort %229 %580
+%582 = OpLoad %v4ushort %581
+OpStore %297 %582
+%583 = OpLoad %ulong %306
+%584 = OpLoad %v4ushort %297
+%585 = OpFunctionCall %ulong %1 %583 %584
+OpStore %298 %585
+%586 = OpLoad %ulong %312
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %299 %587
+%588 = OpLoad %ulong %298
+OpStore %306 %588
+%589 = OpLoad %ulong %299
+OpStore %312 %589
+OpBranch %222
+%199 = OpLabel
+%590 = OpLoad %v4ushort %308
+%591 = OpLoad %v4ushort %237
+%592 = OpIMul %v4ushort %590 %591
+OpStore %284 %592
+%593 = OpLoad %ulong %307
+%594 = OpLoad %v4ushort %284
+%595 = OpFunctionCall %ulong %1 %593 %594
+OpStore %285 %595
+%596 = OpLoad %v4ushort %309
+%597 = OpLoad %v4ushort %284
+%598 = OpBitwiseXor %v4ushort %596 %597
+OpStore %286 %598
+%599 = OpLoad %ulong %285
+%600 = OpLoad %v4ushort %286
+%601 = OpFunctionCall %ulong %1 %599 %600
+OpStore %287 %601
+%602 = OpLoad %v4ushort %310
+%603 = OpLoad %v4ushort %308
+%604 = OpIAdd %v4ushort %602 %603
+OpStore %288 %604
+%605 = OpLoad %ulong %287
+%606 = OpLoad %v4ushort %288
+%607 = OpFunctionCall %ulong %1 %605 %606
+OpStore %289 %607
+%608 = OpLoad %v4ushort %308
+%609 = OpLoad %v4ushort %250
+%610 = OpIAdd %v4ushort %608 %609
+OpStore %290 %610
+%611 = OpLoad %ulong %289
+%612 = OpLoad %v4ushort %290
+%613 = OpFunctionCall %ulong %1 %611 %612
+OpStore %291 %613
+%614 = OpLoad %ulong %311
+%615 = OpIAdd %ulong %614 %ulong_1
+OpStore %292 %615
+%616 = OpLoad %ulong %291
+OpStore %307 %616
+%617 = OpLoad %v4ushort %290
+OpStore %308 %617
+%618 = OpLoad %v4ushort %286
+OpStore %309 %618
+%619 = OpLoad %v4ushort %288
+OpStore %310 %619
+%620 = OpLoad %ulong %292
+OpStore %311 %620
+OpBranch %223
+%220 = OpLabel
+OpBranch %216
+%221 = OpLabel
+OpBranch %209
+%222 = OpLabel
+OpBranch %201
+%223 = OpLabel
+OpBranch %198
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_i16x8.dis
+++ b/test/golden/spirv/vec/vec_i16x8.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 3711
+; Bound: 3000
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,18 +15,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i16x8.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_8 = OpConstant %uint 8
 %_arr_ushort_uint_8 = OpTypeArray %ushort %uint_8
-%11 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
+%8 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_ushort_uint_8 = OpTypePointer Function %_arr_ushort_uint_8
 %_ptr_Function_ushort = OpTypePointer Function %ushort
-%77 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%369 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr__arr_ushort_uint_8_uint_4 = OpTypeArray %_arr_ushort_uint_8 %uint_4
 %_ptr_Function__arr__arr_ushort_uint_8_uint_4 = OpTypePointer Function %_arr__arr_ushort_uint_8_uint_4
-%_struct_125 = OpTypeStruct %uint %_arr_ushort_uint_8 %uint
-%_ptr_Function__struct_125 = OpTypePointer Function %_struct_125
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_402 = OpTypeStruct %uint %_arr_ushort_uint_8 %uint
+%_ptr_Function__struct_402 = OpTypePointer Function %_struct_402
 %_ptr_Function_uint = OpTypePointer Function %uint
 %ushort_1001 = OpConstant %ushort 1001
 %ushort_64433 = OpConstant %ushort 64433
@@ -51,477 +56,641 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i16x8.checksum" Export
 %ushort_7 = OpConstant %ushort 7
 %ushort_8 = OpConstant %ushort 8
 %ushort_0 = OpConstant %ushort 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%2842 = OpConstantNull %_arr__arr_ushort_uint_8_uint_4
+%2411 = OpConstantNull %_arr__arr_ushort_uint_8_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%3020 = OpConstantNull %_struct_125
+%2589 = OpConstantNull %_struct_402
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%3615 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%3618 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%3666 = OpTypeFunction %ulong %ulong %ushort
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_ushort_uint_8
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%20 = OpVariable %_ptr_Function_ushort Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ushort Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ushort Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ushort Function
-%35 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%36 = OpLoad %_arr_ushort_uint_8 %18
-%37 = OpCompositeExtract %ushort %36 0
-OpStore %20 %37
-%38 = OpLoad %ulong %16
-%39 = OpLoad %ushort %20
-%40 = OpFunctionCall %ulong %5 %38 %39
-OpStore %21 %40
-%41 = OpLoad %_arr_ushort_uint_8 %18
-%42 = OpCompositeExtract %ushort %41 1
-OpStore %22 %42
-%43 = OpLoad %ulong %21
-%44 = OpLoad %ushort %22
-%45 = OpFunctionCall %ulong %5 %43 %44
-OpStore %23 %45
-%46 = OpLoad %_arr_ushort_uint_8 %18
-%47 = OpCompositeExtract %ushort %46 2
-OpStore %24 %47
-%48 = OpLoad %ulong %23
-%49 = OpLoad %ushort %24
-%50 = OpFunctionCall %ulong %5 %48 %49
-OpStore %25 %50
-%51 = OpLoad %_arr_ushort_uint_8 %18
-%52 = OpCompositeExtract %ushort %51 3
-OpStore %26 %52
-%53 = OpLoad %ulong %25
-%54 = OpLoad %ushort %26
-%55 = OpFunctionCall %ulong %5 %53 %54
-OpStore %27 %55
-%56 = OpLoad %_arr_ushort_uint_8 %18
-%57 = OpCompositeExtract %ushort %56 4
-OpStore %28 %57
-%58 = OpLoad %ulong %27
-%59 = OpLoad %ushort %28
-%60 = OpFunctionCall %ulong %5 %58 %59
-OpStore %29 %60
-%61 = OpLoad %_arr_ushort_uint_8 %18
-%62 = OpCompositeExtract %ushort %61 5
-OpStore %30 %62
-%63 = OpLoad %ulong %29
-%64 = OpLoad %ushort %30
-%65 = OpFunctionCall %ulong %5 %63 %64
-OpStore %31 %65
-%66 = OpLoad %_arr_ushort_uint_8 %18
-%67 = OpCompositeExtract %ushort %66 6
-OpStore %32 %67
-%68 = OpLoad %ulong %31
-%69 = OpLoad %ushort %32
-%70 = OpFunctionCall %ulong %5 %68 %69
-OpStore %33 %70
-%71 = OpLoad %_arr_ushort_uint_8 %18
-%72 = OpCompositeExtract %ushort %71 7
-OpStore %34 %72
-%73 = OpLoad %ulong %33
-%74 = OpLoad %ushort %34
-%75 = OpFunctionCall %ulong %5 %73 %74
-OpStore %35 %75
-%76 = OpLoad %ulong %35
-OpReturnValue %76
-OpFunctionEnd
-%2 = OpFunction %ulong None %77
-%78 = OpFunctionParameter %ulong
-%79 = OpLabel
-%124 = OpVariable %_ptr_Function__arr__arr_ushort_uint_8_uint_4 Function
-%127 = OpVariable %_ptr_Function__struct_125 Function
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %_arr_ushort_uint_8
+%11 = OpLabel
+%78 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%82 = OpVariable %_ptr_Function_ushort Function
+%83 = OpVariable %_ptr_Function_ushort Function
+%84 = OpVariable %_ptr_Function_ushort Function
+%85 = OpVariable %_ptr_Function_ushort Function
+%86 = OpVariable %_ptr_Function_ushort Function
+%87 = OpVariable %_ptr_Function_ushort Function
+%88 = OpVariable %_ptr_Function_ushort Function
+%89 = OpVariable %_ptr_Function_ushort Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_bool Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_bool Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_bool Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
 %129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_ushort Function
-%131 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%132 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%133 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%134 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%135 = OpVariable %_ptr_Function_ushort Function
-%136 = OpVariable %_ptr_Function_ushort Function
-%137 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%138 = OpVariable %_ptr_Function_ushort Function
-%139 = OpVariable %_ptr_Function_ushort Function
-%140 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%141 = OpVariable %_ptr_Function_ushort Function
-%142 = OpVariable %_ptr_Function_ushort Function
-%143 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%144 = OpVariable %_ptr_Function_ushort Function
-%145 = OpVariable %_ptr_Function_ushort Function
-%146 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_bool Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_bool Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
 %147 = OpVariable %_ptr_Function_ulong Function
 %148 = OpVariable %_ptr_Function_ulong Function
 %149 = OpVariable %_ptr_Function_ulong Function
 %150 = OpVariable %_ptr_Function_ulong Function
 %151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_bool Function
 %153 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
 %156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_bool Function
-%158 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%162 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
 %163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%165 = OpVariable %_ptr_Function_uint Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%170 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%171 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ushort Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ushort Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ushort Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ushort Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ushort Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ushort Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ushort Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ushort Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ushort Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ushort Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ushort Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ushort Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ushort Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ushort Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ushort Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ushort Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ushort Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ushort Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ushort Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ushort Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ushort Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ushort Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ushort Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ushort Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ushort Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ushort Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ushort Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ushort Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ushort Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ushort Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ushort Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ushort Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ushort Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_ushort Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ushort Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ushort Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ushort Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_ushort Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ushort Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_ushort Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ushort Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ushort Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ushort Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ushort Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ushort Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ushort Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ushort Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ushort Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ushort Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ushort Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ushort Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_ushort Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_ushort Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_ushort Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ushort Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_ushort Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ushort Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_ushort Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_ushort Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ushort Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ushort Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_ushort Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ushort Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_ushort Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ushort Function
-%303 = OpVariable %_ptr_Function_ulong Function
-%304 = OpVariable %_ptr_Function_ushort Function
-%305 = OpVariable %_ptr_Function_ulong Function
-%306 = OpVariable %_ptr_Function_ushort Function
-%307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_ushort Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_ushort Function
-%311 = OpVariable %_ptr_Function_ulong Function
-%312 = OpVariable %_ptr_Function_ushort Function
-%313 = OpVariable %_ptr_Function_ulong Function
-%314 = OpVariable %_ptr_Function_ushort Function
-%315 = OpVariable %_ptr_Function_ulong Function
-%316 = OpVariable %_ptr_Function_ushort Function
-%317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_ushort Function
-%319 = OpVariable %_ptr_Function_ulong Function
-%320 = OpVariable %_ptr_Function_ushort Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_ushort Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_ushort Function
-%325 = OpVariable %_ptr_Function_ulong Function
-%326 = OpVariable %_ptr_Function_ushort Function
-%327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_ushort Function
-%329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_ushort Function
-%331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_ushort Function
-%333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_ushort Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ushort Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ushort Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ushort Function
-%341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_ushort Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_ushort Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_ushort Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ushort Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_ushort Function
-%351 = OpVariable %_ptr_Function_ulong Function
-%352 = OpVariable %_ptr_Function_ushort Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_ushort Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_ushort Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_ushort Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_ushort Function
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_ushort Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_ushort Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_ushort Function
-%367 = OpVariable %_ptr_Function_ulong Function
-%368 = OpVariable %_ptr_Function_ushort Function
-%369 = OpVariable %_ptr_Function_ulong Function
-%370 = OpVariable %_ptr_Function_ushort Function
-%371 = OpVariable %_ptr_Function_ulong Function
-%372 = OpVariable %_ptr_Function_ushort Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_ushort Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_ushort Function
-%377 = OpVariable %_ptr_Function_ulong Function
-%378 = OpVariable %_ptr_Function_ushort Function
-%379 = OpVariable %_ptr_Function_ulong Function
-%380 = OpVariable %_ptr_Function_ushort Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_ushort Function
-%383 = OpVariable %_ptr_Function_ulong Function
-%384 = OpVariable %_ptr_Function_ushort Function
-%385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_ushort Function
-%387 = OpVariable %_ptr_Function_ulong Function
-%388 = OpVariable %_ptr_Function_ushort Function
-%389 = OpVariable %_ptr_Function_ulong Function
-%390 = OpVariable %_ptr_Function_ushort Function
-%391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_ushort Function
-%393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_ushort Function
-%395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_ushort Function
-%397 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_ushort Function
-%399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_ushort Function
-%401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_ushort Function
-%403 = OpVariable %_ptr_Function_ulong Function
-%404 = OpVariable %_ptr_Function_ushort Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+OpStore %78 %9
+OpStore %80 %10
+%171 = OpLoad %_arr_ushort_uint_8 %80
+%172 = OpCompositeExtract %ushort %171 0
+OpStore %82 %172
+OpBranch %12
+%12 = OpLabel
+%173 = OpLoad %ushort %82
+%174 = OpSConvert %ulong %173
+OpStore %90 %174
+OpBranch %14
+%14 = OpLabel
+%175 = OpLoad %ulong %78
+OpStore %99 %175
+OpStore %100 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%177 = OpLoad %ulong %100
+%179 = OpULessThan %bool %177 %ulong_8
+OpStore %92 %179
+%180 = OpLoad %bool %92
+OpLoopMerge %17 %75 None
+OpBranchConditional %180 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%181 = OpLoad %_arr_ushort_uint_8 %80
+%182 = OpCompositeExtract %ushort %181 1
+OpStore %83 %182
+OpBranch %19
+%19 = OpLabel
+%183 = OpLoad %ushort %83
+%184 = OpSConvert %ulong %183
+OpStore %101 %184
+OpBranch %21
+%21 = OpLabel
+%185 = OpLoad %ulong %99
+OpStore %109 %185
+OpStore %110 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%186 = OpLoad %ulong %110
+%187 = OpULessThan %bool %186 %ulong_8
+OpStore %102 %187
+%188 = OpLoad %bool %102
+OpLoopMerge %24 %74 None
+OpBranchConditional %188 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%189 = OpLoad %_arr_ushort_uint_8 %80
+%190 = OpCompositeExtract %ushort %189 2
+OpStore %84 %190
+OpBranch %26
+%26 = OpLabel
+%191 = OpLoad %ushort %84
+%192 = OpSConvert %ulong %191
+OpStore %111 %192
+OpBranch %28
+%28 = OpLabel
+%193 = OpLoad %ulong %109
+OpStore %119 %193
+OpStore %120 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%194 = OpLoad %ulong %120
+%195 = OpULessThan %bool %194 %ulong_8
+OpStore %112 %195
+%196 = OpLoad %bool %112
+OpLoopMerge %31 %73 None
+OpBranchConditional %196 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%197 = OpLoad %_arr_ushort_uint_8 %80
+%198 = OpCompositeExtract %ushort %197 3
+OpStore %85 %198
+OpBranch %33
+%33 = OpLabel
+%199 = OpLoad %ushort %85
+%200 = OpSConvert %ulong %199
+OpStore %121 %200
+OpBranch %35
+%35 = OpLabel
+%201 = OpLoad %ulong %119
+OpStore %129 %201
+OpStore %130 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%202 = OpLoad %ulong %130
+%203 = OpULessThan %bool %202 %ulong_8
+OpStore %122 %203
+%204 = OpLoad %bool %122
+OpLoopMerge %38 %72 None
+OpBranchConditional %204 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%205 = OpLoad %_arr_ushort_uint_8 %80
+%206 = OpCompositeExtract %ushort %205 4
+OpStore %86 %206
+OpBranch %40
+%40 = OpLabel
+%207 = OpLoad %ushort %86
+%208 = OpSConvert %ulong %207
+OpStore %131 %208
+OpBranch %42
+%42 = OpLabel
+%209 = OpLoad %ulong %129
+OpStore %139 %209
+OpStore %140 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%210 = OpLoad %ulong %140
+%211 = OpULessThan %bool %210 %ulong_8
+OpStore %132 %211
+%212 = OpLoad %bool %132
+OpLoopMerge %45 %71 None
+OpBranchConditional %212 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%213 = OpLoad %_arr_ushort_uint_8 %80
+%214 = OpCompositeExtract %ushort %213 5
+OpStore %87 %214
+OpBranch %47
+%47 = OpLabel
+%215 = OpLoad %ushort %87
+%216 = OpSConvert %ulong %215
+OpStore %141 %216
+OpBranch %49
+%49 = OpLabel
+%217 = OpLoad %ulong %139
+OpStore %149 %217
+OpStore %150 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%218 = OpLoad %ulong %150
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %142 %219
+%220 = OpLoad %bool %142
+OpLoopMerge %52 %70 None
+OpBranchConditional %220 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%221 = OpLoad %_arr_ushort_uint_8 %80
+%222 = OpCompositeExtract %ushort %221 6
+OpStore %88 %222
+OpBranch %54
+%54 = OpLabel
+%223 = OpLoad %ushort %88
+%224 = OpSConvert %ulong %223
+OpStore %151 %224
+OpBranch %56
+%56 = OpLabel
+%225 = OpLoad %ulong %149
+OpStore %159 %225
+OpStore %160 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%226 = OpLoad %ulong %160
+%227 = OpULessThan %bool %226 %ulong_8
+OpStore %152 %227
+%228 = OpLoad %bool %152
+OpLoopMerge %59 %69 None
+OpBranchConditional %228 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%229 = OpLoad %_arr_ushort_uint_8 %80
+%230 = OpCompositeExtract %ushort %229 7
+OpStore %89 %230
+OpBranch %61
+%61 = OpLabel
+%231 = OpLoad %ushort %89
+%232 = OpSConvert %ulong %231
+OpStore %161 %232
+OpBranch %63
+%63 = OpLabel
+%233 = OpLoad %ulong %159
+OpStore %169 %233
+OpStore %170 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%234 = OpLoad %ulong %170
+%235 = OpULessThan %bool %234 %ulong_8
+OpStore %162 %235
+%236 = OpLoad %bool %162
+OpLoopMerge %66 %68 None
+OpBranchConditional %236 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%237 = OpLoad %ulong %169
+OpReturnValue %237
+%65 = OpLabel
+%238 = OpLoad %ulong %170
+%239 = OpIMul %ulong %238 %ulong_8
+OpStore %163 %239
+%240 = OpLoad %ulong %161
+%241 = OpLoad %ulong %163
+%242 = OpShiftRightLogical %ulong %240 %241
+OpStore %164 %242
+%243 = OpLoad %ulong %164
+%245 = OpBitwiseAnd %ulong %243 %ulong_255
+OpStore %165 %245
+%246 = OpLoad %ulong %169
+%247 = OpLoad %ulong %165
+%248 = OpBitwiseXor %ulong %246 %247
+OpStore %166 %248
+%249 = OpLoad %ulong %166
+%251 = OpIMul %ulong %249 %ulong_1099511628211
+OpStore %167 %251
+%252 = OpLoad %ulong %170
+%254 = OpIAdd %ulong %252 %ulong_1
+OpStore %168 %254
+%255 = OpLoad %ulong %167
+OpStore %169 %255
+%256 = OpLoad %ulong %168
+OpStore %170 %256
+OpBranch %68
+%58 = OpLabel
+%257 = OpLoad %ulong %160
+%258 = OpIMul %ulong %257 %ulong_8
+OpStore %153 %258
+%259 = OpLoad %ulong %151
+%260 = OpLoad %ulong %153
+%261 = OpShiftRightLogical %ulong %259 %260
+OpStore %154 %261
+%262 = OpLoad %ulong %154
+%263 = OpBitwiseAnd %ulong %262 %ulong_255
+OpStore %155 %263
+%264 = OpLoad %ulong %159
+%265 = OpLoad %ulong %155
+%266 = OpBitwiseXor %ulong %264 %265
+OpStore %156 %266
+%267 = OpLoad %ulong %156
+%268 = OpIMul %ulong %267 %ulong_1099511628211
+OpStore %157 %268
+%269 = OpLoad %ulong %160
+%270 = OpIAdd %ulong %269 %ulong_1
+OpStore %158 %270
+%271 = OpLoad %ulong %157
+OpStore %159 %271
+%272 = OpLoad %ulong %158
+OpStore %160 %272
+OpBranch %69
+%51 = OpLabel
+%273 = OpLoad %ulong %150
+%274 = OpIMul %ulong %273 %ulong_8
+OpStore %143 %274
+%275 = OpLoad %ulong %141
+%276 = OpLoad %ulong %143
+%277 = OpShiftRightLogical %ulong %275 %276
+OpStore %144 %277
+%278 = OpLoad %ulong %144
+%279 = OpBitwiseAnd %ulong %278 %ulong_255
+OpStore %145 %279
+%280 = OpLoad %ulong %149
+%281 = OpLoad %ulong %145
+%282 = OpBitwiseXor %ulong %280 %281
+OpStore %146 %282
+%283 = OpLoad %ulong %146
+%284 = OpIMul %ulong %283 %ulong_1099511628211
+OpStore %147 %284
+%285 = OpLoad %ulong %150
+%286 = OpIAdd %ulong %285 %ulong_1
+OpStore %148 %286
+%287 = OpLoad %ulong %147
+OpStore %149 %287
+%288 = OpLoad %ulong %148
+OpStore %150 %288
+OpBranch %70
+%44 = OpLabel
+%289 = OpLoad %ulong %140
+%290 = OpIMul %ulong %289 %ulong_8
+OpStore %133 %290
+%291 = OpLoad %ulong %131
+%292 = OpLoad %ulong %133
+%293 = OpShiftRightLogical %ulong %291 %292
+OpStore %134 %293
+%294 = OpLoad %ulong %134
+%295 = OpBitwiseAnd %ulong %294 %ulong_255
+OpStore %135 %295
+%296 = OpLoad %ulong %139
+%297 = OpLoad %ulong %135
+%298 = OpBitwiseXor %ulong %296 %297
+OpStore %136 %298
+%299 = OpLoad %ulong %136
+%300 = OpIMul %ulong %299 %ulong_1099511628211
+OpStore %137 %300
+%301 = OpLoad %ulong %140
+%302 = OpIAdd %ulong %301 %ulong_1
+OpStore %138 %302
+%303 = OpLoad %ulong %137
+OpStore %139 %303
+%304 = OpLoad %ulong %138
+OpStore %140 %304
+OpBranch %71
+%37 = OpLabel
+%305 = OpLoad %ulong %130
+%306 = OpIMul %ulong %305 %ulong_8
+OpStore %123 %306
+%307 = OpLoad %ulong %121
+%308 = OpLoad %ulong %123
+%309 = OpShiftRightLogical %ulong %307 %308
+OpStore %124 %309
+%310 = OpLoad %ulong %124
+%311 = OpBitwiseAnd %ulong %310 %ulong_255
+OpStore %125 %311
+%312 = OpLoad %ulong %129
+%313 = OpLoad %ulong %125
+%314 = OpBitwiseXor %ulong %312 %313
+OpStore %126 %314
+%315 = OpLoad %ulong %126
+%316 = OpIMul %ulong %315 %ulong_1099511628211
+OpStore %127 %316
+%317 = OpLoad %ulong %130
+%318 = OpIAdd %ulong %317 %ulong_1
+OpStore %128 %318
+%319 = OpLoad %ulong %127
+OpStore %129 %319
+%320 = OpLoad %ulong %128
+OpStore %130 %320
+OpBranch %72
+%30 = OpLabel
+%321 = OpLoad %ulong %120
+%322 = OpIMul %ulong %321 %ulong_8
+OpStore %113 %322
+%323 = OpLoad %ulong %111
+%324 = OpLoad %ulong %113
+%325 = OpShiftRightLogical %ulong %323 %324
+OpStore %114 %325
+%326 = OpLoad %ulong %114
+%327 = OpBitwiseAnd %ulong %326 %ulong_255
+OpStore %115 %327
+%328 = OpLoad %ulong %119
+%329 = OpLoad %ulong %115
+%330 = OpBitwiseXor %ulong %328 %329
+OpStore %116 %330
+%331 = OpLoad %ulong %116
+%332 = OpIMul %ulong %331 %ulong_1099511628211
+OpStore %117 %332
+%333 = OpLoad %ulong %120
+%334 = OpIAdd %ulong %333 %ulong_1
+OpStore %118 %334
+%335 = OpLoad %ulong %117
+OpStore %119 %335
+%336 = OpLoad %ulong %118
+OpStore %120 %336
+OpBranch %73
+%23 = OpLabel
+%337 = OpLoad %ulong %110
+%338 = OpIMul %ulong %337 %ulong_8
+OpStore %103 %338
+%339 = OpLoad %ulong %101
+%340 = OpLoad %ulong %103
+%341 = OpShiftRightLogical %ulong %339 %340
+OpStore %104 %341
+%342 = OpLoad %ulong %104
+%343 = OpBitwiseAnd %ulong %342 %ulong_255
+OpStore %105 %343
+%344 = OpLoad %ulong %109
+%345 = OpLoad %ulong %105
+%346 = OpBitwiseXor %ulong %344 %345
+OpStore %106 %346
+%347 = OpLoad %ulong %106
+%348 = OpIMul %ulong %347 %ulong_1099511628211
+OpStore %107 %348
+%349 = OpLoad %ulong %110
+%350 = OpIAdd %ulong %349 %ulong_1
+OpStore %108 %350
+%351 = OpLoad %ulong %107
+OpStore %109 %351
+%352 = OpLoad %ulong %108
+OpStore %110 %352
+OpBranch %74
+%16 = OpLabel
+%353 = OpLoad %ulong %100
+%354 = OpIMul %ulong %353 %ulong_8
+OpStore %93 %354
+%355 = OpLoad %ulong %90
+%356 = OpLoad %ulong %93
+%357 = OpShiftRightLogical %ulong %355 %356
+OpStore %94 %357
+%358 = OpLoad %ulong %94
+%359 = OpBitwiseAnd %ulong %358 %ulong_255
+OpStore %95 %359
+%360 = OpLoad %ulong %99
+%361 = OpLoad %ulong %95
+%362 = OpBitwiseXor %ulong %360 %361
+OpStore %96 %362
+%363 = OpLoad %ulong %96
+%364 = OpIMul %ulong %363 %ulong_1099511628211
+OpStore %97 %364
+%365 = OpLoad %ulong %100
+%366 = OpIAdd %ulong %365 %ulong_1
+OpStore %98 %366
+%367 = OpLoad %ulong %97
+OpStore %99 %367
+%368 = OpLoad %ulong %98
+OpStore %100 %368
+OpBranch %75
+%68 = OpLabel
+OpBranch %64
+%69 = OpLabel
+OpBranch %57
+%70 = OpLabel
+OpBranch %50
+%71 = OpLabel
+OpBranch %43
+%72 = OpLabel
+OpBranch %36
+%73 = OpLabel
+OpBranch %29
+%74 = OpLabel
+OpBranch %22
+%75 = OpLabel
+OpBranch %15
+OpFunctionEnd
+%2 = OpFunction %ulong None %369
+%370 = OpFunctionParameter %ulong
+%371 = OpLabel
+%401 = OpVariable %_ptr_Function__arr__arr_ushort_uint_8_uint_4 Function
+%404 = OpVariable %_ptr_Function__struct_402 Function
 %405 = OpVariable %_ptr_Function_ulong Function
 %406 = OpVariable %_ptr_Function_ushort Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_ushort Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_ushort Function
-%411 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%408 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%409 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%410 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%411 = OpVariable %_ptr_Function_ushort Function
 %412 = OpVariable %_ptr_Function_ushort Function
-%413 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %414 = OpVariable %_ptr_Function_ushort Function
-%415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_ushort Function
-%417 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ushort Function
+%416 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%417 = OpVariable %_ptr_Function_ushort Function
 %418 = OpVariable %_ptr_Function_ushort Function
-%419 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %420 = OpVariable %_ptr_Function_ushort Function
-%421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_ushort Function
+%421 = OpVariable %_ptr_Function_ushort Function
+%422 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ushort Function
+%424 = OpVariable %_ptr_Function_ulong Function
 %425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_ushort Function
+%426 = OpVariable %_ptr_Function_ulong Function
 %427 = OpVariable %_ptr_Function_ulong Function
-%428 = OpVariable %_ptr_Function_ushort Function
+%428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_ulong Function
-%430 = OpVariable %_ptr_Function_ushort Function
-%431 = OpVariable %_ptr_Function_ushort Function
-%432 = OpVariable %_ptr_Function_ushort Function
-%433 = OpVariable %_ptr_Function_ushort Function
-%434 = OpVariable %_ptr_Function_ushort Function
-%435 = OpVariable %_ptr_Function_ushort Function
-%436 = OpVariable %_ptr_Function_ushort Function
-%437 = OpVariable %_ptr_Function_ushort Function
-%438 = OpVariable %_ptr_Function_ushort Function
-%439 = OpVariable %_ptr_Function_ushort Function
-%440 = OpVariable %_ptr_Function_ushort Function
-%441 = OpVariable %_ptr_Function_ushort Function
-%442 = OpVariable %_ptr_Function_ushort Function
-%443 = OpVariable %_ptr_Function_ushort Function
-%444 = OpVariable %_ptr_Function_ushort Function
-%445 = OpVariable %_ptr_Function_ushort Function
-%446 = OpVariable %_ptr_Function_ushort Function
-%447 = OpVariable %_ptr_Function_ushort Function
-%448 = OpVariable %_ptr_Function_ushort Function
-%449 = OpVariable %_ptr_Function_ushort Function
-%450 = OpVariable %_ptr_Function_ushort Function
-%451 = OpVariable %_ptr_Function_ushort Function
-%452 = OpVariable %_ptr_Function_ushort Function
-%453 = OpVariable %_ptr_Function_ushort Function
-%454 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%455 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%456 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%457 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_bool Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_bool Function
+%447 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%452 = OpVariable %_ptr_Function_uint Function
+%453 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_uint Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
 %458 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %459 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %460 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%461 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%462 = OpVariable %_ptr_Function_ushort Function
-%463 = OpVariable %_ptr_Function_ushort Function
-%464 = OpVariable %_ptr_Function_ushort Function
-%465 = OpVariable %_ptr_Function_ushort Function
-%466 = OpVariable %_ptr_Function_ushort Function
-%467 = OpVariable %_ptr_Function_ushort Function
-%468 = OpVariable %_ptr_Function_ushort Function
-%469 = OpVariable %_ptr_Function_ushort Function
-%470 = OpVariable %_ptr_Function_ushort Function
-%471 = OpVariable %_ptr_Function_ushort Function
-%472 = OpVariable %_ptr_Function_ushort Function
-%473 = OpVariable %_ptr_Function_ushort Function
-%474 = OpVariable %_ptr_Function_ushort Function
-%475 = OpVariable %_ptr_Function_ushort Function
-%476 = OpVariable %_ptr_Function_ushort Function
-%477 = OpVariable %_ptr_Function_ushort Function
-%478 = OpVariable %_ptr_Function_ushort Function
-%479 = OpVariable %_ptr_Function_ushort Function
-%480 = OpVariable %_ptr_Function_ushort Function
-%481 = OpVariable %_ptr_Function_ushort Function
-%482 = OpVariable %_ptr_Function_ushort Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_bool Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
 %483 = OpVariable %_ptr_Function_ushort Function
 %484 = OpVariable %_ptr_Function_ushort Function
 %485 = OpVariable %_ptr_Function_ushort Function
-%486 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%487 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%488 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%489 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%490 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%491 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%492 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%493 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%486 = OpVariable %_ptr_Function_ushort Function
+%487 = OpVariable %_ptr_Function_ushort Function
+%488 = OpVariable %_ptr_Function_ushort Function
+%489 = OpVariable %_ptr_Function_ushort Function
+%490 = OpVariable %_ptr_Function_ushort Function
+%491 = OpVariable %_ptr_Function_ushort Function
+%492 = OpVariable %_ptr_Function_ushort Function
+%493 = OpVariable %_ptr_Function_ushort Function
 %494 = OpVariable %_ptr_Function_ushort Function
 %495 = OpVariable %_ptr_Function_ushort Function
 %496 = OpVariable %_ptr_Function_ushort Function
@@ -535,25 +704,25 @@ OpFunctionEnd
 %504 = OpVariable %_ptr_Function_ushort Function
 %505 = OpVariable %_ptr_Function_ushort Function
 %506 = OpVariable %_ptr_Function_ushort Function
-%507 = OpVariable %_ptr_Function_ushort Function
-%508 = OpVariable %_ptr_Function_ushort Function
-%509 = OpVariable %_ptr_Function_ushort Function
-%510 = OpVariable %_ptr_Function_ushort Function
-%511 = OpVariable %_ptr_Function_ushort Function
-%512 = OpVariable %_ptr_Function_ushort Function
-%513 = OpVariable %_ptr_Function_ushort Function
-%514 = OpVariable %_ptr_Function_ushort Function
+%507 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%508 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%509 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%510 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%511 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%512 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%513 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%514 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %515 = OpVariable %_ptr_Function_ushort Function
 %516 = OpVariable %_ptr_Function_ushort Function
 %517 = OpVariable %_ptr_Function_ushort Function
-%518 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%519 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%520 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%521 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%522 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%523 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%524 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%525 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%518 = OpVariable %_ptr_Function_ushort Function
+%519 = OpVariable %_ptr_Function_ushort Function
+%520 = OpVariable %_ptr_Function_ushort Function
+%521 = OpVariable %_ptr_Function_ushort Function
+%522 = OpVariable %_ptr_Function_ushort Function
+%523 = OpVariable %_ptr_Function_ushort Function
+%524 = OpVariable %_ptr_Function_ushort Function
+%525 = OpVariable %_ptr_Function_ushort Function
 %526 = OpVariable %_ptr_Function_ushort Function
 %527 = OpVariable %_ptr_Function_ushort Function
 %528 = OpVariable %_ptr_Function_ushort Function
@@ -567,25 +736,25 @@ OpFunctionEnd
 %536 = OpVariable %_ptr_Function_ushort Function
 %537 = OpVariable %_ptr_Function_ushort Function
 %538 = OpVariable %_ptr_Function_ushort Function
-%539 = OpVariable %_ptr_Function_ushort Function
-%540 = OpVariable %_ptr_Function_ushort Function
-%541 = OpVariable %_ptr_Function_ushort Function
-%542 = OpVariable %_ptr_Function_ushort Function
-%543 = OpVariable %_ptr_Function_ushort Function
-%544 = OpVariable %_ptr_Function_ushort Function
-%545 = OpVariable %_ptr_Function_ushort Function
-%546 = OpVariable %_ptr_Function_ushort Function
+%539 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%540 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%541 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%542 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%543 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%544 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%545 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%546 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %547 = OpVariable %_ptr_Function_ushort Function
 %548 = OpVariable %_ptr_Function_ushort Function
 %549 = OpVariable %_ptr_Function_ushort Function
-%550 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%551 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%552 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%553 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%554 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%555 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%556 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%557 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%550 = OpVariable %_ptr_Function_ushort Function
+%551 = OpVariable %_ptr_Function_ushort Function
+%552 = OpVariable %_ptr_Function_ushort Function
+%553 = OpVariable %_ptr_Function_ushort Function
+%554 = OpVariable %_ptr_Function_ushort Function
+%555 = OpVariable %_ptr_Function_ushort Function
+%556 = OpVariable %_ptr_Function_ushort Function
+%557 = OpVariable %_ptr_Function_ushort Function
 %558 = OpVariable %_ptr_Function_ushort Function
 %559 = OpVariable %_ptr_Function_ushort Function
 %560 = OpVariable %_ptr_Function_ushort Function
@@ -599,25 +768,25 @@ OpFunctionEnd
 %568 = OpVariable %_ptr_Function_ushort Function
 %569 = OpVariable %_ptr_Function_ushort Function
 %570 = OpVariable %_ptr_Function_ushort Function
-%571 = OpVariable %_ptr_Function_ushort Function
-%572 = OpVariable %_ptr_Function_ushort Function
-%573 = OpVariable %_ptr_Function_ushort Function
-%574 = OpVariable %_ptr_Function_ushort Function
-%575 = OpVariable %_ptr_Function_ushort Function
-%576 = OpVariable %_ptr_Function_ushort Function
-%577 = OpVariable %_ptr_Function_ushort Function
-%578 = OpVariable %_ptr_Function_ushort Function
+%571 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%572 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%573 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%574 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%575 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%576 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%577 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%578 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %579 = OpVariable %_ptr_Function_ushort Function
 %580 = OpVariable %_ptr_Function_ushort Function
 %581 = OpVariable %_ptr_Function_ushort Function
-%582 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%583 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%584 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%585 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%586 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%587 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%588 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%589 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%582 = OpVariable %_ptr_Function_ushort Function
+%583 = OpVariable %_ptr_Function_ushort Function
+%584 = OpVariable %_ptr_Function_ushort Function
+%585 = OpVariable %_ptr_Function_ushort Function
+%586 = OpVariable %_ptr_Function_ushort Function
+%587 = OpVariable %_ptr_Function_ushort Function
+%588 = OpVariable %_ptr_Function_ushort Function
+%589 = OpVariable %_ptr_Function_ushort Function
 %590 = OpVariable %_ptr_Function_ushort Function
 %591 = OpVariable %_ptr_Function_ushort Function
 %592 = OpVariable %_ptr_Function_ushort Function
@@ -631,25 +800,25 @@ OpFunctionEnd
 %600 = OpVariable %_ptr_Function_ushort Function
 %601 = OpVariable %_ptr_Function_ushort Function
 %602 = OpVariable %_ptr_Function_ushort Function
-%603 = OpVariable %_ptr_Function_ushort Function
-%604 = OpVariable %_ptr_Function_ushort Function
-%605 = OpVariable %_ptr_Function_ushort Function
-%606 = OpVariable %_ptr_Function_ushort Function
-%607 = OpVariable %_ptr_Function_ushort Function
-%608 = OpVariable %_ptr_Function_ushort Function
-%609 = OpVariable %_ptr_Function_ushort Function
-%610 = OpVariable %_ptr_Function_ushort Function
+%603 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%604 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%605 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%606 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%607 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%608 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%609 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%610 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %611 = OpVariable %_ptr_Function_ushort Function
 %612 = OpVariable %_ptr_Function_ushort Function
 %613 = OpVariable %_ptr_Function_ushort Function
-%614 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%615 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%616 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%617 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%618 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%619 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%620 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%621 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%614 = OpVariable %_ptr_Function_ushort Function
+%615 = OpVariable %_ptr_Function_ushort Function
+%616 = OpVariable %_ptr_Function_ushort Function
+%617 = OpVariable %_ptr_Function_ushort Function
+%618 = OpVariable %_ptr_Function_ushort Function
+%619 = OpVariable %_ptr_Function_ushort Function
+%620 = OpVariable %_ptr_Function_ushort Function
+%621 = OpVariable %_ptr_Function_ushort Function
 %622 = OpVariable %_ptr_Function_ushort Function
 %623 = OpVariable %_ptr_Function_ushort Function
 %624 = OpVariable %_ptr_Function_ushort Function
@@ -663,25 +832,25 @@ OpFunctionEnd
 %632 = OpVariable %_ptr_Function_ushort Function
 %633 = OpVariable %_ptr_Function_ushort Function
 %634 = OpVariable %_ptr_Function_ushort Function
-%635 = OpVariable %_ptr_Function_ushort Function
-%636 = OpVariable %_ptr_Function_ushort Function
-%637 = OpVariable %_ptr_Function_ushort Function
-%638 = OpVariable %_ptr_Function_ushort Function
-%639 = OpVariable %_ptr_Function_ushort Function
-%640 = OpVariable %_ptr_Function_ushort Function
-%641 = OpVariable %_ptr_Function_ushort Function
-%642 = OpVariable %_ptr_Function_ushort Function
+%635 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%636 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%637 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%638 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%639 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%640 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%641 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%642 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %643 = OpVariable %_ptr_Function_ushort Function
 %644 = OpVariable %_ptr_Function_ushort Function
 %645 = OpVariable %_ptr_Function_ushort Function
-%646 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%647 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%648 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%649 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%650 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%651 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%652 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%653 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%646 = OpVariable %_ptr_Function_ushort Function
+%647 = OpVariable %_ptr_Function_ushort Function
+%648 = OpVariable %_ptr_Function_ushort Function
+%649 = OpVariable %_ptr_Function_ushort Function
+%650 = OpVariable %_ptr_Function_ushort Function
+%651 = OpVariable %_ptr_Function_ushort Function
+%652 = OpVariable %_ptr_Function_ushort Function
+%653 = OpVariable %_ptr_Function_ushort Function
 %654 = OpVariable %_ptr_Function_ushort Function
 %655 = OpVariable %_ptr_Function_ushort Function
 %656 = OpVariable %_ptr_Function_ushort Function
@@ -695,25 +864,25 @@ OpFunctionEnd
 %664 = OpVariable %_ptr_Function_ushort Function
 %665 = OpVariable %_ptr_Function_ushort Function
 %666 = OpVariable %_ptr_Function_ushort Function
-%667 = OpVariable %_ptr_Function_ushort Function
-%668 = OpVariable %_ptr_Function_ushort Function
-%669 = OpVariable %_ptr_Function_ushort Function
-%670 = OpVariable %_ptr_Function_ushort Function
-%671 = OpVariable %_ptr_Function_ushort Function
-%672 = OpVariable %_ptr_Function_ushort Function
-%673 = OpVariable %_ptr_Function_ushort Function
-%674 = OpVariable %_ptr_Function_ushort Function
+%667 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%668 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%669 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%670 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%671 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%672 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%673 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%674 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %675 = OpVariable %_ptr_Function_ushort Function
 %676 = OpVariable %_ptr_Function_ushort Function
 %677 = OpVariable %_ptr_Function_ushort Function
-%678 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%679 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%680 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%681 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%682 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%683 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%684 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%685 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%678 = OpVariable %_ptr_Function_ushort Function
+%679 = OpVariable %_ptr_Function_ushort Function
+%680 = OpVariable %_ptr_Function_ushort Function
+%681 = OpVariable %_ptr_Function_ushort Function
+%682 = OpVariable %_ptr_Function_ushort Function
+%683 = OpVariable %_ptr_Function_ushort Function
+%684 = OpVariable %_ptr_Function_ushort Function
+%685 = OpVariable %_ptr_Function_ushort Function
 %686 = OpVariable %_ptr_Function_ushort Function
 %687 = OpVariable %_ptr_Function_ushort Function
 %688 = OpVariable %_ptr_Function_ushort Function
@@ -727,25 +896,25 @@ OpFunctionEnd
 %696 = OpVariable %_ptr_Function_ushort Function
 %697 = OpVariable %_ptr_Function_ushort Function
 %698 = OpVariable %_ptr_Function_ushort Function
-%699 = OpVariable %_ptr_Function_ushort Function
-%700 = OpVariable %_ptr_Function_ushort Function
-%701 = OpVariable %_ptr_Function_ushort Function
-%702 = OpVariable %_ptr_Function_ushort Function
-%703 = OpVariable %_ptr_Function_ushort Function
-%704 = OpVariable %_ptr_Function_ushort Function
-%705 = OpVariable %_ptr_Function_ushort Function
-%706 = OpVariable %_ptr_Function_ushort Function
+%699 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%700 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%701 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%702 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%703 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%704 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%705 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%706 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %707 = OpVariable %_ptr_Function_ushort Function
 %708 = OpVariable %_ptr_Function_ushort Function
 %709 = OpVariable %_ptr_Function_ushort Function
-%710 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%711 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%712 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%713 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%714 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%715 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%716 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%717 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%710 = OpVariable %_ptr_Function_ushort Function
+%711 = OpVariable %_ptr_Function_ushort Function
+%712 = OpVariable %_ptr_Function_ushort Function
+%713 = OpVariable %_ptr_Function_ushort Function
+%714 = OpVariable %_ptr_Function_ushort Function
+%715 = OpVariable %_ptr_Function_ushort Function
+%716 = OpVariable %_ptr_Function_ushort Function
+%717 = OpVariable %_ptr_Function_ushort Function
 %718 = OpVariable %_ptr_Function_ushort Function
 %719 = OpVariable %_ptr_Function_ushort Function
 %720 = OpVariable %_ptr_Function_ushort Function
@@ -759,25 +928,25 @@ OpFunctionEnd
 %728 = OpVariable %_ptr_Function_ushort Function
 %729 = OpVariable %_ptr_Function_ushort Function
 %730 = OpVariable %_ptr_Function_ushort Function
-%731 = OpVariable %_ptr_Function_ushort Function
-%732 = OpVariable %_ptr_Function_ushort Function
-%733 = OpVariable %_ptr_Function_ushort Function
-%734 = OpVariable %_ptr_Function_ushort Function
-%735 = OpVariable %_ptr_Function_ushort Function
-%736 = OpVariable %_ptr_Function_ushort Function
-%737 = OpVariable %_ptr_Function_ushort Function
-%738 = OpVariable %_ptr_Function_ushort Function
+%731 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%732 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%733 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%734 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%735 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%736 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%737 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%738 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %739 = OpVariable %_ptr_Function_ushort Function
 %740 = OpVariable %_ptr_Function_ushort Function
 %741 = OpVariable %_ptr_Function_ushort Function
-%742 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%743 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%744 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%745 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%746 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%747 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%748 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%749 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%742 = OpVariable %_ptr_Function_ushort Function
+%743 = OpVariable %_ptr_Function_ushort Function
+%744 = OpVariable %_ptr_Function_ushort Function
+%745 = OpVariable %_ptr_Function_ushort Function
+%746 = OpVariable %_ptr_Function_ushort Function
+%747 = OpVariable %_ptr_Function_ushort Function
+%748 = OpVariable %_ptr_Function_ushort Function
+%749 = OpVariable %_ptr_Function_ushort Function
 %750 = OpVariable %_ptr_Function_ushort Function
 %751 = OpVariable %_ptr_Function_ushort Function
 %752 = OpVariable %_ptr_Function_ushort Function
@@ -791,25 +960,25 @@ OpFunctionEnd
 %760 = OpVariable %_ptr_Function_ushort Function
 %761 = OpVariable %_ptr_Function_ushort Function
 %762 = OpVariable %_ptr_Function_ushort Function
-%763 = OpVariable %_ptr_Function_ushort Function
-%764 = OpVariable %_ptr_Function_ushort Function
-%765 = OpVariable %_ptr_Function_ushort Function
-%766 = OpVariable %_ptr_Function_ushort Function
-%767 = OpVariable %_ptr_Function_ushort Function
-%768 = OpVariable %_ptr_Function_ushort Function
-%769 = OpVariable %_ptr_Function_ushort Function
-%770 = OpVariable %_ptr_Function_ushort Function
+%763 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%764 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%765 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%766 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%767 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%768 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%769 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%770 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %771 = OpVariable %_ptr_Function_ushort Function
 %772 = OpVariable %_ptr_Function_ushort Function
 %773 = OpVariable %_ptr_Function_ushort Function
-%774 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%775 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%776 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%777 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%778 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%779 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%780 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%781 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%774 = OpVariable %_ptr_Function_ushort Function
+%775 = OpVariable %_ptr_Function_ushort Function
+%776 = OpVariable %_ptr_Function_ushort Function
+%777 = OpVariable %_ptr_Function_ushort Function
+%778 = OpVariable %_ptr_Function_ushort Function
+%779 = OpVariable %_ptr_Function_ushort Function
+%780 = OpVariable %_ptr_Function_ushort Function
+%781 = OpVariable %_ptr_Function_ushort Function
 %782 = OpVariable %_ptr_Function_ushort Function
 %783 = OpVariable %_ptr_Function_ushort Function
 %784 = OpVariable %_ptr_Function_ushort Function
@@ -823,25 +992,25 @@ OpFunctionEnd
 %792 = OpVariable %_ptr_Function_ushort Function
 %793 = OpVariable %_ptr_Function_ushort Function
 %794 = OpVariable %_ptr_Function_ushort Function
-%795 = OpVariable %_ptr_Function_ushort Function
-%796 = OpVariable %_ptr_Function_ushort Function
-%797 = OpVariable %_ptr_Function_ushort Function
-%798 = OpVariable %_ptr_Function_ushort Function
-%799 = OpVariable %_ptr_Function_ushort Function
-%800 = OpVariable %_ptr_Function_ushort Function
-%801 = OpVariable %_ptr_Function_ushort Function
-%802 = OpVariable %_ptr_Function_ushort Function
+%795 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%796 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%797 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%798 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%799 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%800 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%801 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%802 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %803 = OpVariable %_ptr_Function_ushort Function
 %804 = OpVariable %_ptr_Function_ushort Function
 %805 = OpVariable %_ptr_Function_ushort Function
-%806 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%807 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%808 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%809 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%810 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%811 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%812 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%813 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%806 = OpVariable %_ptr_Function_ushort Function
+%807 = OpVariable %_ptr_Function_ushort Function
+%808 = OpVariable %_ptr_Function_ushort Function
+%809 = OpVariable %_ptr_Function_ushort Function
+%810 = OpVariable %_ptr_Function_ushort Function
+%811 = OpVariable %_ptr_Function_ushort Function
+%812 = OpVariable %_ptr_Function_ushort Function
+%813 = OpVariable %_ptr_Function_ushort Function
 %814 = OpVariable %_ptr_Function_ushort Function
 %815 = OpVariable %_ptr_Function_ushort Function
 %816 = OpVariable %_ptr_Function_ushort Function
@@ -855,25 +1024,25 @@ OpFunctionEnd
 %824 = OpVariable %_ptr_Function_ushort Function
 %825 = OpVariable %_ptr_Function_ushort Function
 %826 = OpVariable %_ptr_Function_ushort Function
-%827 = OpVariable %_ptr_Function_ushort Function
-%828 = OpVariable %_ptr_Function_ushort Function
-%829 = OpVariable %_ptr_Function_ushort Function
-%830 = OpVariable %_ptr_Function_ushort Function
-%831 = OpVariable %_ptr_Function_ushort Function
-%832 = OpVariable %_ptr_Function_ushort Function
-%833 = OpVariable %_ptr_Function_ushort Function
-%834 = OpVariable %_ptr_Function_ushort Function
+%827 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%828 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%829 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%830 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%831 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%832 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%833 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%834 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %835 = OpVariable %_ptr_Function_ushort Function
 %836 = OpVariable %_ptr_Function_ushort Function
 %837 = OpVariable %_ptr_Function_ushort Function
-%838 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%839 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%840 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%841 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%842 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%843 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%844 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%845 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%838 = OpVariable %_ptr_Function_ushort Function
+%839 = OpVariable %_ptr_Function_ushort Function
+%840 = OpVariable %_ptr_Function_ushort Function
+%841 = OpVariable %_ptr_Function_ushort Function
+%842 = OpVariable %_ptr_Function_ushort Function
+%843 = OpVariable %_ptr_Function_ushort Function
+%844 = OpVariable %_ptr_Function_ushort Function
+%845 = OpVariable %_ptr_Function_ushort Function
 %846 = OpVariable %_ptr_Function_ushort Function
 %847 = OpVariable %_ptr_Function_ushort Function
 %848 = OpVariable %_ptr_Function_ushort Function
@@ -887,25 +1056,25 @@ OpFunctionEnd
 %856 = OpVariable %_ptr_Function_ushort Function
 %857 = OpVariable %_ptr_Function_ushort Function
 %858 = OpVariable %_ptr_Function_ushort Function
-%859 = OpVariable %_ptr_Function_ushort Function
-%860 = OpVariable %_ptr_Function_ushort Function
-%861 = OpVariable %_ptr_Function_ushort Function
-%862 = OpVariable %_ptr_Function_ushort Function
-%863 = OpVariable %_ptr_Function_ushort Function
-%864 = OpVariable %_ptr_Function_ushort Function
-%865 = OpVariable %_ptr_Function_ushort Function
-%866 = OpVariable %_ptr_Function_ushort Function
+%859 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%860 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%861 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%862 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%863 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%864 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%865 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%866 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %867 = OpVariable %_ptr_Function_ushort Function
 %868 = OpVariable %_ptr_Function_ushort Function
 %869 = OpVariable %_ptr_Function_ushort Function
-%870 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%871 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%872 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%873 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%874 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%875 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%876 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%877 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%870 = OpVariable %_ptr_Function_ushort Function
+%871 = OpVariable %_ptr_Function_ushort Function
+%872 = OpVariable %_ptr_Function_ushort Function
+%873 = OpVariable %_ptr_Function_ushort Function
+%874 = OpVariable %_ptr_Function_ushort Function
+%875 = OpVariable %_ptr_Function_ushort Function
+%876 = OpVariable %_ptr_Function_ushort Function
+%877 = OpVariable %_ptr_Function_ushort Function
 %878 = OpVariable %_ptr_Function_ushort Function
 %879 = OpVariable %_ptr_Function_ushort Function
 %880 = OpVariable %_ptr_Function_ushort Function
@@ -919,25 +1088,25 @@ OpFunctionEnd
 %888 = OpVariable %_ptr_Function_ushort Function
 %889 = OpVariable %_ptr_Function_ushort Function
 %890 = OpVariable %_ptr_Function_ushort Function
-%891 = OpVariable %_ptr_Function_ushort Function
-%892 = OpVariable %_ptr_Function_ushort Function
-%893 = OpVariable %_ptr_Function_ushort Function
-%894 = OpVariable %_ptr_Function_ushort Function
-%895 = OpVariable %_ptr_Function_ushort Function
-%896 = OpVariable %_ptr_Function_ushort Function
-%897 = OpVariable %_ptr_Function_ushort Function
-%898 = OpVariable %_ptr_Function_ushort Function
+%891 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%892 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%893 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%894 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%895 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%896 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%897 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%898 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %899 = OpVariable %_ptr_Function_ushort Function
 %900 = OpVariable %_ptr_Function_ushort Function
 %901 = OpVariable %_ptr_Function_ushort Function
-%902 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%903 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%904 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%905 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%906 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%907 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%908 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%909 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%902 = OpVariable %_ptr_Function_ushort Function
+%903 = OpVariable %_ptr_Function_ushort Function
+%904 = OpVariable %_ptr_Function_ushort Function
+%905 = OpVariable %_ptr_Function_ushort Function
+%906 = OpVariable %_ptr_Function_ushort Function
+%907 = OpVariable %_ptr_Function_ushort Function
+%908 = OpVariable %_ptr_Function_ushort Function
+%909 = OpVariable %_ptr_Function_ushort Function
 %910 = OpVariable %_ptr_Function_ushort Function
 %911 = OpVariable %_ptr_Function_ushort Function
 %912 = OpVariable %_ptr_Function_ushort Function
@@ -951,25 +1120,25 @@ OpFunctionEnd
 %920 = OpVariable %_ptr_Function_ushort Function
 %921 = OpVariable %_ptr_Function_ushort Function
 %922 = OpVariable %_ptr_Function_ushort Function
-%923 = OpVariable %_ptr_Function_ushort Function
-%924 = OpVariable %_ptr_Function_ushort Function
-%925 = OpVariable %_ptr_Function_ushort Function
-%926 = OpVariable %_ptr_Function_ushort Function
-%927 = OpVariable %_ptr_Function_ushort Function
-%928 = OpVariable %_ptr_Function_ushort Function
-%929 = OpVariable %_ptr_Function_ushort Function
-%930 = OpVariable %_ptr_Function_ushort Function
+%923 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%924 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%925 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%926 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%927 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%928 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%929 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%930 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %931 = OpVariable %_ptr_Function_ushort Function
 %932 = OpVariable %_ptr_Function_ushort Function
 %933 = OpVariable %_ptr_Function_ushort Function
-%934 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%935 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%936 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%937 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%938 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%939 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%940 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%941 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%934 = OpVariable %_ptr_Function_ushort Function
+%935 = OpVariable %_ptr_Function_ushort Function
+%936 = OpVariable %_ptr_Function_ushort Function
+%937 = OpVariable %_ptr_Function_ushort Function
+%938 = OpVariable %_ptr_Function_ushort Function
+%939 = OpVariable %_ptr_Function_ushort Function
+%940 = OpVariable %_ptr_Function_ushort Function
+%941 = OpVariable %_ptr_Function_ushort Function
 %942 = OpVariable %_ptr_Function_ushort Function
 %943 = OpVariable %_ptr_Function_ushort Function
 %944 = OpVariable %_ptr_Function_ushort Function
@@ -983,25 +1152,25 @@ OpFunctionEnd
 %952 = OpVariable %_ptr_Function_ushort Function
 %953 = OpVariable %_ptr_Function_ushort Function
 %954 = OpVariable %_ptr_Function_ushort Function
-%955 = OpVariable %_ptr_Function_ushort Function
-%956 = OpVariable %_ptr_Function_ushort Function
-%957 = OpVariable %_ptr_Function_ushort Function
-%958 = OpVariable %_ptr_Function_ushort Function
-%959 = OpVariable %_ptr_Function_ushort Function
-%960 = OpVariable %_ptr_Function_ushort Function
-%961 = OpVariable %_ptr_Function_ushort Function
-%962 = OpVariable %_ptr_Function_ushort Function
+%955 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%956 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%957 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%958 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%959 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%960 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%961 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%962 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %963 = OpVariable %_ptr_Function_ushort Function
 %964 = OpVariable %_ptr_Function_ushort Function
 %965 = OpVariable %_ptr_Function_ushort Function
-%966 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%967 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%968 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%969 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%970 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%971 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%972 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%973 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%966 = OpVariable %_ptr_Function_ushort Function
+%967 = OpVariable %_ptr_Function_ushort Function
+%968 = OpVariable %_ptr_Function_ushort Function
+%969 = OpVariable %_ptr_Function_ushort Function
+%970 = OpVariable %_ptr_Function_ushort Function
+%971 = OpVariable %_ptr_Function_ushort Function
+%972 = OpVariable %_ptr_Function_ushort Function
+%973 = OpVariable %_ptr_Function_ushort Function
 %974 = OpVariable %_ptr_Function_ushort Function
 %975 = OpVariable %_ptr_Function_ushort Function
 %976 = OpVariable %_ptr_Function_ushort Function
@@ -1015,25 +1184,25 @@ OpFunctionEnd
 %984 = OpVariable %_ptr_Function_ushort Function
 %985 = OpVariable %_ptr_Function_ushort Function
 %986 = OpVariable %_ptr_Function_ushort Function
-%987 = OpVariable %_ptr_Function_ushort Function
-%988 = OpVariable %_ptr_Function_ushort Function
-%989 = OpVariable %_ptr_Function_ushort Function
-%990 = OpVariable %_ptr_Function_ushort Function
-%991 = OpVariable %_ptr_Function_ushort Function
-%992 = OpVariable %_ptr_Function_ushort Function
-%993 = OpVariable %_ptr_Function_ushort Function
-%994 = OpVariable %_ptr_Function_ushort Function
+%987 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%988 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%989 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%990 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%991 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%992 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%993 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%994 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %995 = OpVariable %_ptr_Function_ushort Function
 %996 = OpVariable %_ptr_Function_ushort Function
 %997 = OpVariable %_ptr_Function_ushort Function
-%998 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%999 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1000 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1001 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1002 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1003 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1004 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1005 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%998 = OpVariable %_ptr_Function_ushort Function
+%999 = OpVariable %_ptr_Function_ushort Function
+%1000 = OpVariable %_ptr_Function_ushort Function
+%1001 = OpVariable %_ptr_Function_ushort Function
+%1002 = OpVariable %_ptr_Function_ushort Function
+%1003 = OpVariable %_ptr_Function_ushort Function
+%1004 = OpVariable %_ptr_Function_ushort Function
+%1005 = OpVariable %_ptr_Function_ushort Function
 %1006 = OpVariable %_ptr_Function_ushort Function
 %1007 = OpVariable %_ptr_Function_ushort Function
 %1008 = OpVariable %_ptr_Function_ushort Function
@@ -1047,25 +1216,25 @@ OpFunctionEnd
 %1016 = OpVariable %_ptr_Function_ushort Function
 %1017 = OpVariable %_ptr_Function_ushort Function
 %1018 = OpVariable %_ptr_Function_ushort Function
-%1019 = OpVariable %_ptr_Function_ushort Function
-%1020 = OpVariable %_ptr_Function_ushort Function
-%1021 = OpVariable %_ptr_Function_ushort Function
-%1022 = OpVariable %_ptr_Function_ushort Function
-%1023 = OpVariable %_ptr_Function_ushort Function
-%1024 = OpVariable %_ptr_Function_ushort Function
-%1025 = OpVariable %_ptr_Function_ushort Function
-%1026 = OpVariable %_ptr_Function_ushort Function
+%1019 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1020 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1021 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1022 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1023 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1024 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1025 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1026 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1027 = OpVariable %_ptr_Function_ushort Function
 %1028 = OpVariable %_ptr_Function_ushort Function
 %1029 = OpVariable %_ptr_Function_ushort Function
-%1030 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1031 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1032 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1033 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1034 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1035 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1036 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1037 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1030 = OpVariable %_ptr_Function_ushort Function
+%1031 = OpVariable %_ptr_Function_ushort Function
+%1032 = OpVariable %_ptr_Function_ushort Function
+%1033 = OpVariable %_ptr_Function_ushort Function
+%1034 = OpVariable %_ptr_Function_ushort Function
+%1035 = OpVariable %_ptr_Function_ushort Function
+%1036 = OpVariable %_ptr_Function_ushort Function
+%1037 = OpVariable %_ptr_Function_ushort Function
 %1038 = OpVariable %_ptr_Function_ushort Function
 %1039 = OpVariable %_ptr_Function_ushort Function
 %1040 = OpVariable %_ptr_Function_ushort Function
@@ -1079,17 +1248,17 @@ OpFunctionEnd
 %1048 = OpVariable %_ptr_Function_ushort Function
 %1049 = OpVariable %_ptr_Function_ushort Function
 %1050 = OpVariable %_ptr_Function_ushort Function
-%1051 = OpVariable %_ptr_Function_ushort Function
-%1052 = OpVariable %_ptr_Function_ushort Function
-%1053 = OpVariable %_ptr_Function_ushort Function
+%1051 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1052 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1053 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1054 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1055 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1056 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1057 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1058 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1059 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1060 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1061 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1059 = OpVariable %_ptr_Function_ushort Function
+%1060 = OpVariable %_ptr_Function_ushort Function
+%1061 = OpVariable %_ptr_Function_ushort Function
 %1062 = OpVariable %_ptr_Function_ushort Function
 %1063 = OpVariable %_ptr_Function_ushort Function
 %1064 = OpVariable %_ptr_Function_ushort Function
@@ -1103,17 +1272,17 @@ OpFunctionEnd
 %1072 = OpVariable %_ptr_Function_ushort Function
 %1073 = OpVariable %_ptr_Function_ushort Function
 %1074 = OpVariable %_ptr_Function_ushort Function
-%1075 = OpVariable %_ptr_Function_ushort Function
-%1076 = OpVariable %_ptr_Function_ushort Function
-%1077 = OpVariable %_ptr_Function_ushort Function
+%1075 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1076 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1077 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1078 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1079 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1080 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1081 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1082 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1083 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1084 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1085 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1083 = OpVariable %_ptr_Function_ushort Function
+%1084 = OpVariable %_ptr_Function_ushort Function
+%1085 = OpVariable %_ptr_Function_ushort Function
 %1086 = OpVariable %_ptr_Function_ushort Function
 %1087 = OpVariable %_ptr_Function_ushort Function
 %1088 = OpVariable %_ptr_Function_ushort Function
@@ -1127,3712 +1296,2681 @@ OpFunctionEnd
 %1096 = OpVariable %_ptr_Function_ushort Function
 %1097 = OpVariable %_ptr_Function_ushort Function
 %1098 = OpVariable %_ptr_Function_ushort Function
-%1099 = OpVariable %_ptr_Function_ushort Function
-%1100 = OpVariable %_ptr_Function_ushort Function
-%1101 = OpVariable %_ptr_Function_ushort Function
-%1102 = OpVariable %_ptr_Function_ushort Function
-%1103 = OpVariable %_ptr_Function_ushort Function
-%1104 = OpVariable %_ptr_Function_ushort Function
-%1105 = OpVariable %_ptr_Function_ushort Function
-%1106 = OpVariable %_ptr_Function_ushort Function
+%1099 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1100 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1101 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1102 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1103 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1104 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1105 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1106 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1107 = OpVariable %_ptr_Function_ushort Function
 %1108 = OpVariable %_ptr_Function_ushort Function
 %1109 = OpVariable %_ptr_Function_ushort Function
-%1110 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1111 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1112 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1113 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1114 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1115 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1116 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1117 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-OpStore %128 %78
-%1118 = OpFunctionCall %ulong %3
-OpStore %129 %1118
-%1119 = OpLoad %ulong %128
-%1120 = OpUConvert %ushort %1119
-OpStore %130 %1120
-%1121 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1001 %ushort_64433 %ushort_1207 %ushort_64235 %ushort_1409 %ushort_64025 %ushort_1601 %ushort_63827
-OpStore %131 %1121
-%1130 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_13 %ushort_65525 %ushort_9 %ushort_65529 %ushort_5 %ushort_65533 %ushort_2 %ushort_65535
-OpStore %132 %1130
-%1139 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_2 %ushort_3 %ushort_4 %ushort_5 %ushort_6 %ushort_7 %ushort_8
-OpStore %133 %1139
-%1146 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0
-OpStore %134 %1146
-%1148 = OpLoad %_arr_ushort_uint_8 %131
-%1149 = OpCompositeExtract %ushort %1148 0
-OpStore %135 %1149
-%1150 = OpLoad %ushort %135
-%1151 = OpLoad %ushort %130
-%1152 = OpIAdd %ushort %1150 %1151
-OpStore %136 %1152
-%1153 = OpLoad %_arr_ushort_uint_8 %131
-%1154 = OpLoad %ushort %136
-%1155 = OpCompositeInsert %_arr_ushort_uint_8 %1154 %1153 0
-OpStore %137 %1155
-%1156 = OpLoad %_arr_ushort_uint_8 %137
-%1157 = OpCompositeExtract %ushort %1156 6
-OpStore %138 %1157
-%1158 = OpLoad %ushort %138
-%1159 = OpLoad %ushort %130
-%1160 = OpIAdd %ushort %1158 %1159
-OpStore %139 %1160
-%1161 = OpLoad %_arr_ushort_uint_8 %137
-%1162 = OpLoad %ushort %139
-%1163 = OpCompositeInsert %_arr_ushort_uint_8 %1162 %1161 6
-OpStore %140 %1163
-%1164 = OpLoad %_arr_ushort_uint_8 %132
-%1165 = OpCompositeExtract %ushort %1164 2
-OpStore %141 %1165
-%1166 = OpLoad %ushort %141
-%1167 = OpLoad %ushort %130
-%1168 = OpIAdd %ushort %1166 %1167
-OpStore %142 %1168
-%1169 = OpLoad %_arr_ushort_uint_8 %132
-%1170 = OpLoad %ushort %142
-%1171 = OpCompositeInsert %_arr_ushort_uint_8 %1170 %1169 2
-OpStore %143 %1171
-%1172 = OpLoad %_arr_ushort_uint_8 %143
-%1173 = OpCompositeExtract %ushort %1172 7
-OpStore %144 %1173
-%1174 = OpLoad %ushort %144
-%1175 = OpLoad %ushort %130
-%1176 = OpIAdd %ushort %1174 %1175
-OpStore %145 %1176
-%1177 = OpLoad %_arr_ushort_uint_8 %143
-%1178 = OpLoad %ushort %145
-%1179 = OpCompositeInsert %_arr_ushort_uint_8 %1178 %1177 7
-OpStore %146 %1179
-OpBranch %86
-%86 = OpLabel
-%1180 = OpLoad %_arr_ushort_uint_8 %140
-%1181 = OpCompositeExtract %ushort %1180 0
-OpStore %174 %1181
-%1182 = OpLoad %ulong %129
-%1183 = OpLoad %ushort %174
-%1184 = OpFunctionCall %ulong %5 %1182 %1183
-OpStore %175 %1184
-%1185 = OpLoad %_arr_ushort_uint_8 %140
-%1186 = OpCompositeExtract %ushort %1185 1
-OpStore %176 %1186
-%1187 = OpLoad %ulong %175
-%1188 = OpLoad %ushort %176
-%1189 = OpFunctionCall %ulong %5 %1187 %1188
-OpStore %177 %1189
-%1190 = OpLoad %_arr_ushort_uint_8 %140
-%1191 = OpCompositeExtract %ushort %1190 2
-OpStore %178 %1191
-%1192 = OpLoad %ulong %177
-%1193 = OpLoad %ushort %178
-%1194 = OpFunctionCall %ulong %5 %1192 %1193
-OpStore %179 %1194
-%1195 = OpLoad %_arr_ushort_uint_8 %140
-%1196 = OpCompositeExtract %ushort %1195 3
-OpStore %180 %1196
-%1197 = OpLoad %ulong %179
-%1198 = OpLoad %ushort %180
-%1199 = OpFunctionCall %ulong %5 %1197 %1198
-OpStore %181 %1199
-%1200 = OpLoad %_arr_ushort_uint_8 %140
-%1201 = OpCompositeExtract %ushort %1200 4
-OpStore %182 %1201
-%1202 = OpLoad %ulong %181
-%1203 = OpLoad %ushort %182
-%1204 = OpFunctionCall %ulong %5 %1202 %1203
-OpStore %183 %1204
-%1205 = OpLoad %_arr_ushort_uint_8 %140
-%1206 = OpCompositeExtract %ushort %1205 5
-OpStore %184 %1206
-%1207 = OpLoad %ulong %183
-%1208 = OpLoad %ushort %184
-%1209 = OpFunctionCall %ulong %5 %1207 %1208
-OpStore %185 %1209
-%1210 = OpLoad %_arr_ushort_uint_8 %140
-%1211 = OpCompositeExtract %ushort %1210 6
-OpStore %186 %1211
-%1212 = OpLoad %ulong %185
-%1213 = OpLoad %ushort %186
-%1214 = OpFunctionCall %ulong %5 %1212 %1213
-OpStore %187 %1214
-%1215 = OpLoad %_arr_ushort_uint_8 %140
-%1216 = OpCompositeExtract %ushort %1215 7
-OpStore %188 %1216
-%1217 = OpLoad %ulong %187
-%1218 = OpLoad %ushort %188
-%1219 = OpFunctionCall %ulong %5 %1217 %1218
-OpStore %189 %1219
-OpBranch %87
-%87 = OpLabel
-OpBranch %94
-%94 = OpLabel
-%1220 = OpLoad %_arr_ushort_uint_8 %146
-%1221 = OpCompositeExtract %ushort %1220 0
-OpStore %238 %1221
-%1222 = OpLoad %ulong %189
-%1223 = OpLoad %ushort %238
-%1224 = OpFunctionCall %ulong %5 %1222 %1223
-OpStore %239 %1224
-%1225 = OpLoad %_arr_ushort_uint_8 %146
-%1226 = OpCompositeExtract %ushort %1225 1
-OpStore %240 %1226
-%1227 = OpLoad %ulong %239
-%1228 = OpLoad %ushort %240
-%1229 = OpFunctionCall %ulong %5 %1227 %1228
-OpStore %241 %1229
-%1230 = OpLoad %_arr_ushort_uint_8 %146
-%1231 = OpCompositeExtract %ushort %1230 2
-OpStore %242 %1231
-%1232 = OpLoad %ulong %241
-%1233 = OpLoad %ushort %242
-%1234 = OpFunctionCall %ulong %5 %1232 %1233
-OpStore %243 %1234
-%1235 = OpLoad %_arr_ushort_uint_8 %146
-%1236 = OpCompositeExtract %ushort %1235 3
-OpStore %244 %1236
-%1237 = OpLoad %ulong %243
-%1238 = OpLoad %ushort %244
-%1239 = OpFunctionCall %ulong %5 %1237 %1238
-OpStore %245 %1239
-%1240 = OpLoad %_arr_ushort_uint_8 %146
-%1241 = OpCompositeExtract %ushort %1240 4
-OpStore %246 %1241
-%1242 = OpLoad %ulong %245
-%1243 = OpLoad %ushort %246
-%1244 = OpFunctionCall %ulong %5 %1242 %1243
-OpStore %247 %1244
-%1245 = OpLoad %_arr_ushort_uint_8 %146
-%1246 = OpCompositeExtract %ushort %1245 5
-OpStore %248 %1246
-%1247 = OpLoad %ulong %247
-%1248 = OpLoad %ushort %248
-%1249 = OpFunctionCall %ulong %5 %1247 %1248
-OpStore %249 %1249
-%1250 = OpLoad %_arr_ushort_uint_8 %146
+%1110 = OpVariable %_ptr_Function_ushort Function
+%1111 = OpVariable %_ptr_Function_ushort Function
+%1112 = OpVariable %_ptr_Function_ushort Function
+%1113 = OpVariable %_ptr_Function_ushort Function
+%1114 = OpVariable %_ptr_Function_ushort Function
+%1115 = OpVariable %_ptr_Function_ushort Function
+%1116 = OpVariable %_ptr_Function_ushort Function
+%1117 = OpVariable %_ptr_Function_ushort Function
+%1118 = OpVariable %_ptr_Function_ushort Function
+%1119 = OpVariable %_ptr_Function_ushort Function
+%1120 = OpVariable %_ptr_Function_ushort Function
+%1121 = OpVariable %_ptr_Function_ushort Function
+%1122 = OpVariable %_ptr_Function_ushort Function
+%1123 = OpVariable %_ptr_Function_ushort Function
+%1124 = OpVariable %_ptr_Function_ushort Function
+%1125 = OpVariable %_ptr_Function_ushort Function
+%1126 = OpVariable %_ptr_Function_ushort Function
+%1127 = OpVariable %_ptr_Function_ushort Function
+%1128 = OpVariable %_ptr_Function_ushort Function
+%1129 = OpVariable %_ptr_Function_ushort Function
+%1130 = OpVariable %_ptr_Function_ushort Function
+%1131 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1132 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1133 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1134 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1135 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1136 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1137 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1138 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+OpStore %405 %370
+OpBranch %378
+%378 = OpLabel
+OpBranch %379
+%379 = OpLabel
+%1139 = OpLoad %ulong %405
+%1140 = OpUConvert %ushort %1139
+OpStore %406 %1140
+%1141 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1001 %ushort_64433 %ushort_1207 %ushort_64235 %ushort_1409 %ushort_64025 %ushort_1601 %ushort_63827
+OpStore %407 %1141
+%1150 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_13 %ushort_65525 %ushort_9 %ushort_65529 %ushort_5 %ushort_65533 %ushort_2 %ushort_65535
+OpStore %408 %1150
+%1159 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_2 %ushort_3 %ushort_4 %ushort_5 %ushort_6 %ushort_7 %ushort_8
+OpStore %409 %1159
+%1166 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0
+OpStore %410 %1166
+%1168 = OpLoad %_arr_ushort_uint_8 %407
+%1169 = OpCompositeExtract %ushort %1168 0
+OpStore %411 %1169
+%1170 = OpLoad %ushort %411
+%1171 = OpLoad %ushort %406
+%1172 = OpIAdd %ushort %1170 %1171
+OpStore %412 %1172
+%1173 = OpLoad %_arr_ushort_uint_8 %407
+%1174 = OpLoad %ushort %412
+%1175 = OpCompositeInsert %_arr_ushort_uint_8 %1174 %1173 0
+OpStore %413 %1175
+%1176 = OpLoad %_arr_ushort_uint_8 %413
+%1177 = OpCompositeExtract %ushort %1176 6
+OpStore %414 %1177
+%1178 = OpLoad %ushort %414
+%1179 = OpLoad %ushort %406
+%1180 = OpIAdd %ushort %1178 %1179
+OpStore %415 %1180
+%1181 = OpLoad %_arr_ushort_uint_8 %413
+%1182 = OpLoad %ushort %415
+%1183 = OpCompositeInsert %_arr_ushort_uint_8 %1182 %1181 6
+OpStore %416 %1183
+%1184 = OpLoad %_arr_ushort_uint_8 %408
+%1185 = OpCompositeExtract %ushort %1184 2
+OpStore %417 %1185
+%1186 = OpLoad %ushort %417
+%1187 = OpLoad %ushort %406
+%1188 = OpIAdd %ushort %1186 %1187
+OpStore %418 %1188
+%1189 = OpLoad %_arr_ushort_uint_8 %408
+%1190 = OpLoad %ushort %418
+%1191 = OpCompositeInsert %_arr_ushort_uint_8 %1190 %1189 2
+OpStore %419 %1191
+%1192 = OpLoad %_arr_ushort_uint_8 %419
+%1193 = OpCompositeExtract %ushort %1192 7
+OpStore %420 %1193
+%1194 = OpLoad %ushort %420
+%1195 = OpLoad %ushort %406
+%1196 = OpIAdd %ushort %1194 %1195
+OpStore %421 %1196
+%1197 = OpLoad %_arr_ushort_uint_8 %419
+%1198 = OpLoad %ushort %421
+%1199 = OpCompositeInsert %_arr_ushort_uint_8 %1198 %1197 7
+OpStore %422 %1199
+%1201 = OpLoad %_arr_ushort_uint_8 %416
+%1202 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %1201
+OpStore %423 %1202
+%1203 = OpLoad %ulong %423
+%1204 = OpLoad %_arr_ushort_uint_8 %422
+%1205 = OpFunctionCall %ulong %1 %1203 %1204
+OpStore %424 %1205
+%1206 = OpLoad %_arr_ushort_uint_8 %416
+%1207 = OpCompositeExtract %ushort %1206 0
+OpStore %675 %1207
+%1208 = OpLoad %_arr_ushort_uint_8 %422
+%1209 = OpCompositeExtract %ushort %1208 0
+OpStore %676 %1209
+%1210 = OpLoad %ushort %675
+%1211 = OpLoad %ushort %676
+%1212 = OpIAdd %ushort %1210 %1211
+OpStore %677 %1212
+%1213 = OpLoad %_arr_ushort_uint_8 %416
+%1214 = OpCompositeExtract %ushort %1213 1
+OpStore %678 %1214
+%1215 = OpLoad %_arr_ushort_uint_8 %422
+%1216 = OpCompositeExtract %ushort %1215 1
+OpStore %679 %1216
+%1217 = OpLoad %ushort %678
+%1218 = OpLoad %ushort %679
+%1219 = OpIAdd %ushort %1217 %1218
+OpStore %680 %1219
+%1220 = OpLoad %_arr_ushort_uint_8 %416
+%1221 = OpCompositeExtract %ushort %1220 2
+OpStore %681 %1221
+%1222 = OpLoad %_arr_ushort_uint_8 %422
+%1223 = OpCompositeExtract %ushort %1222 2
+OpStore %682 %1223
+%1224 = OpLoad %ushort %681
+%1225 = OpLoad %ushort %682
+%1226 = OpIAdd %ushort %1224 %1225
+OpStore %683 %1226
+%1227 = OpLoad %_arr_ushort_uint_8 %416
+%1228 = OpCompositeExtract %ushort %1227 3
+OpStore %684 %1228
+%1229 = OpLoad %_arr_ushort_uint_8 %422
+%1230 = OpCompositeExtract %ushort %1229 3
+OpStore %685 %1230
+%1231 = OpLoad %ushort %684
+%1232 = OpLoad %ushort %685
+%1233 = OpIAdd %ushort %1231 %1232
+OpStore %686 %1233
+%1234 = OpLoad %_arr_ushort_uint_8 %416
+%1235 = OpCompositeExtract %ushort %1234 4
+OpStore %687 %1235
+%1236 = OpLoad %_arr_ushort_uint_8 %422
+%1237 = OpCompositeExtract %ushort %1236 4
+OpStore %688 %1237
+%1238 = OpLoad %ushort %687
+%1239 = OpLoad %ushort %688
+%1240 = OpIAdd %ushort %1238 %1239
+OpStore %689 %1240
+%1241 = OpLoad %_arr_ushort_uint_8 %416
+%1242 = OpCompositeExtract %ushort %1241 5
+OpStore %690 %1242
+%1243 = OpLoad %_arr_ushort_uint_8 %422
+%1244 = OpCompositeExtract %ushort %1243 5
+OpStore %691 %1244
+%1245 = OpLoad %ushort %690
+%1246 = OpLoad %ushort %691
+%1247 = OpIAdd %ushort %1245 %1246
+OpStore %692 %1247
+%1248 = OpLoad %_arr_ushort_uint_8 %416
+%1249 = OpCompositeExtract %ushort %1248 6
+OpStore %693 %1249
+%1250 = OpLoad %_arr_ushort_uint_8 %422
 %1251 = OpCompositeExtract %ushort %1250 6
-OpStore %250 %1251
-%1252 = OpLoad %ulong %249
-%1253 = OpLoad %ushort %250
-%1254 = OpFunctionCall %ulong %5 %1252 %1253
-OpStore %251 %1254
-%1255 = OpLoad %_arr_ushort_uint_8 %146
+OpStore %694 %1251
+%1252 = OpLoad %ushort %693
+%1253 = OpLoad %ushort %694
+%1254 = OpIAdd %ushort %1252 %1253
+OpStore %695 %1254
+%1255 = OpLoad %_arr_ushort_uint_8 %416
 %1256 = OpCompositeExtract %ushort %1255 7
-OpStore %252 %1256
-%1257 = OpLoad %ulong %251
-%1258 = OpLoad %ushort %252
-%1259 = OpFunctionCall %ulong %5 %1257 %1258
-OpStore %253 %1259
-OpBranch %95
-%95 = OpLabel
-%1260 = OpLoad %_arr_ushort_uint_8 %140
-%1261 = OpCompositeExtract %ushort %1260 0
-OpStore %558 %1261
-%1262 = OpLoad %_arr_ushort_uint_8 %146
-%1263 = OpCompositeExtract %ushort %1262 0
-OpStore %559 %1263
-%1264 = OpLoad %ushort %558
-%1265 = OpLoad %ushort %559
-%1266 = OpIAdd %ushort %1264 %1265
-OpStore %560 %1266
-%1267 = OpLoad %_arr_ushort_uint_8 %140
-%1268 = OpCompositeExtract %ushort %1267 1
-OpStore %561 %1268
-%1269 = OpLoad %_arr_ushort_uint_8 %146
-%1270 = OpCompositeExtract %ushort %1269 1
-OpStore %562 %1270
-%1271 = OpLoad %ushort %561
-%1272 = OpLoad %ushort %562
-%1273 = OpIAdd %ushort %1271 %1272
-OpStore %563 %1273
-%1274 = OpLoad %_arr_ushort_uint_8 %140
-%1275 = OpCompositeExtract %ushort %1274 2
-OpStore %564 %1275
-%1276 = OpLoad %_arr_ushort_uint_8 %146
-%1277 = OpCompositeExtract %ushort %1276 2
-OpStore %565 %1277
-%1278 = OpLoad %ushort %564
-%1279 = OpLoad %ushort %565
-%1280 = OpIAdd %ushort %1278 %1279
-OpStore %566 %1280
-%1281 = OpLoad %_arr_ushort_uint_8 %140
-%1282 = OpCompositeExtract %ushort %1281 3
-OpStore %567 %1282
-%1283 = OpLoad %_arr_ushort_uint_8 %146
-%1284 = OpCompositeExtract %ushort %1283 3
-OpStore %568 %1284
-%1285 = OpLoad %ushort %567
-%1286 = OpLoad %ushort %568
-%1287 = OpIAdd %ushort %1285 %1286
-OpStore %569 %1287
-%1288 = OpLoad %_arr_ushort_uint_8 %140
-%1289 = OpCompositeExtract %ushort %1288 4
-OpStore %570 %1289
-%1290 = OpLoad %_arr_ushort_uint_8 %146
-%1291 = OpCompositeExtract %ushort %1290 4
-OpStore %571 %1291
-%1292 = OpLoad %ushort %570
-%1293 = OpLoad %ushort %571
-%1294 = OpIAdd %ushort %1292 %1293
-OpStore %572 %1294
-%1295 = OpLoad %_arr_ushort_uint_8 %140
-%1296 = OpCompositeExtract %ushort %1295 5
-OpStore %573 %1296
-%1297 = OpLoad %_arr_ushort_uint_8 %146
-%1298 = OpCompositeExtract %ushort %1297 5
-OpStore %574 %1298
-%1299 = OpLoad %ushort %573
-%1300 = OpLoad %ushort %574
-%1301 = OpIAdd %ushort %1299 %1300
-OpStore %575 %1301
-%1302 = OpLoad %_arr_ushort_uint_8 %140
-%1303 = OpCompositeExtract %ushort %1302 6
-OpStore %576 %1303
-%1304 = OpLoad %_arr_ushort_uint_8 %146
-%1305 = OpCompositeExtract %ushort %1304 6
-OpStore %577 %1305
-%1306 = OpLoad %ushort %576
-%1307 = OpLoad %ushort %577
-%1308 = OpIAdd %ushort %1306 %1307
-OpStore %578 %1308
-%1309 = OpLoad %_arr_ushort_uint_8 %140
-%1310 = OpCompositeExtract %ushort %1309 7
-OpStore %579 %1310
-%1311 = OpLoad %_arr_ushort_uint_8 %146
-%1312 = OpCompositeExtract %ushort %1311 7
-OpStore %580 %1312
-%1313 = OpLoad %ushort %579
-%1314 = OpLoad %ushort %580
-%1315 = OpIAdd %ushort %1313 %1314
-OpStore %581 %1315
-%1316 = OpLoad %_arr_ushort_uint_8 %140
-%1317 = OpLoad %ushort %560
-%1318 = OpCompositeInsert %_arr_ushort_uint_8 %1317 %1316 0
-OpStore %582 %1318
-%1319 = OpLoad %_arr_ushort_uint_8 %582
-%1320 = OpLoad %ushort %563
-%1321 = OpCompositeInsert %_arr_ushort_uint_8 %1320 %1319 1
-OpStore %583 %1321
-%1322 = OpLoad %_arr_ushort_uint_8 %583
-%1323 = OpLoad %ushort %566
-%1324 = OpCompositeInsert %_arr_ushort_uint_8 %1323 %1322 2
-OpStore %584 %1324
-%1325 = OpLoad %_arr_ushort_uint_8 %584
-%1326 = OpLoad %ushort %569
-%1327 = OpCompositeInsert %_arr_ushort_uint_8 %1326 %1325 3
-OpStore %585 %1327
-%1328 = OpLoad %_arr_ushort_uint_8 %585
-%1329 = OpLoad %ushort %572
-%1330 = OpCompositeInsert %_arr_ushort_uint_8 %1329 %1328 4
-OpStore %586 %1330
-%1331 = OpLoad %_arr_ushort_uint_8 %586
-%1332 = OpLoad %ushort %575
-%1333 = OpCompositeInsert %_arr_ushort_uint_8 %1332 %1331 5
-OpStore %587 %1333
-%1334 = OpLoad %_arr_ushort_uint_8 %587
-%1335 = OpLoad %ushort %578
-%1336 = OpCompositeInsert %_arr_ushort_uint_8 %1335 %1334 6
-OpStore %588 %1336
-%1337 = OpLoad %_arr_ushort_uint_8 %588
-%1338 = OpLoad %ushort %581
-%1339 = OpCompositeInsert %_arr_ushort_uint_8 %1338 %1337 7
-OpStore %589 %1339
-OpBranch %98
-%98 = OpLabel
-%1340 = OpLoad %_arr_ushort_uint_8 %589
-%1341 = OpCompositeExtract %ushort %1340 0
-OpStore %270 %1341
-%1342 = OpLoad %ulong %253
-%1343 = OpLoad %ushort %270
-%1344 = OpFunctionCall %ulong %5 %1342 %1343
-OpStore %271 %1344
-%1345 = OpLoad %_arr_ushort_uint_8 %589
-%1346 = OpCompositeExtract %ushort %1345 1
-OpStore %272 %1346
-%1347 = OpLoad %ulong %271
-%1348 = OpLoad %ushort %272
-%1349 = OpFunctionCall %ulong %5 %1347 %1348
-OpStore %273 %1349
-%1350 = OpLoad %_arr_ushort_uint_8 %589
-%1351 = OpCompositeExtract %ushort %1350 2
-OpStore %274 %1351
-%1352 = OpLoad %ulong %273
-%1353 = OpLoad %ushort %274
-%1354 = OpFunctionCall %ulong %5 %1352 %1353
-OpStore %275 %1354
-%1355 = OpLoad %_arr_ushort_uint_8 %589
-%1356 = OpCompositeExtract %ushort %1355 3
-OpStore %276 %1356
-%1357 = OpLoad %ulong %275
-%1358 = OpLoad %ushort %276
-%1359 = OpFunctionCall %ulong %5 %1357 %1358
-OpStore %277 %1359
-%1360 = OpLoad %_arr_ushort_uint_8 %589
-%1361 = OpCompositeExtract %ushort %1360 4
-OpStore %278 %1361
-%1362 = OpLoad %ulong %277
-%1363 = OpLoad %ushort %278
-%1364 = OpFunctionCall %ulong %5 %1362 %1363
-OpStore %279 %1364
-%1365 = OpLoad %_arr_ushort_uint_8 %589
-%1366 = OpCompositeExtract %ushort %1365 5
-OpStore %280 %1366
-%1367 = OpLoad %ulong %279
-%1368 = OpLoad %ushort %280
-%1369 = OpFunctionCall %ulong %5 %1367 %1368
-OpStore %281 %1369
-%1370 = OpLoad %_arr_ushort_uint_8 %589
-%1371 = OpCompositeExtract %ushort %1370 6
-OpStore %282 %1371
-%1372 = OpLoad %ulong %281
-%1373 = OpLoad %ushort %282
-%1374 = OpFunctionCall %ulong %5 %1372 %1373
-OpStore %283 %1374
-%1375 = OpLoad %_arr_ushort_uint_8 %589
-%1376 = OpCompositeExtract %ushort %1375 7
-OpStore %284 %1376
-%1377 = OpLoad %ulong %283
-%1378 = OpLoad %ushort %284
-%1379 = OpFunctionCall %ulong %5 %1377 %1378
-OpStore %285 %1379
-OpBranch %99
-%99 = OpLabel
-%1380 = OpLoad %_arr_ushort_uint_8 %140
-%1381 = OpCompositeExtract %ushort %1380 0
-OpStore %622 %1381
-%1382 = OpLoad %_arr_ushort_uint_8 %146
-%1383 = OpCompositeExtract %ushort %1382 0
-OpStore %623 %1383
-%1384 = OpLoad %ushort %622
-%1385 = OpLoad %ushort %623
-%1386 = OpISub %ushort %1384 %1385
-OpStore %624 %1386
-%1387 = OpLoad %_arr_ushort_uint_8 %140
-%1388 = OpCompositeExtract %ushort %1387 1
-OpStore %625 %1388
-%1389 = OpLoad %_arr_ushort_uint_8 %146
-%1390 = OpCompositeExtract %ushort %1389 1
-OpStore %626 %1390
-%1391 = OpLoad %ushort %625
-%1392 = OpLoad %ushort %626
-%1393 = OpISub %ushort %1391 %1392
-OpStore %627 %1393
-%1394 = OpLoad %_arr_ushort_uint_8 %140
-%1395 = OpCompositeExtract %ushort %1394 2
-OpStore %628 %1395
-%1396 = OpLoad %_arr_ushort_uint_8 %146
-%1397 = OpCompositeExtract %ushort %1396 2
-OpStore %629 %1397
-%1398 = OpLoad %ushort %628
-%1399 = OpLoad %ushort %629
-%1400 = OpISub %ushort %1398 %1399
-OpStore %630 %1400
-%1401 = OpLoad %_arr_ushort_uint_8 %140
-%1402 = OpCompositeExtract %ushort %1401 3
-OpStore %631 %1402
-%1403 = OpLoad %_arr_ushort_uint_8 %146
-%1404 = OpCompositeExtract %ushort %1403 3
-OpStore %632 %1404
-%1405 = OpLoad %ushort %631
-%1406 = OpLoad %ushort %632
-%1407 = OpISub %ushort %1405 %1406
-OpStore %633 %1407
-%1408 = OpLoad %_arr_ushort_uint_8 %140
-%1409 = OpCompositeExtract %ushort %1408 4
-OpStore %634 %1409
-%1410 = OpLoad %_arr_ushort_uint_8 %146
-%1411 = OpCompositeExtract %ushort %1410 4
-OpStore %635 %1411
-%1412 = OpLoad %ushort %634
-%1413 = OpLoad %ushort %635
-%1414 = OpISub %ushort %1412 %1413
-OpStore %636 %1414
-%1415 = OpLoad %_arr_ushort_uint_8 %140
-%1416 = OpCompositeExtract %ushort %1415 5
-OpStore %637 %1416
-%1417 = OpLoad %_arr_ushort_uint_8 %146
-%1418 = OpCompositeExtract %ushort %1417 5
-OpStore %638 %1418
-%1419 = OpLoad %ushort %637
-%1420 = OpLoad %ushort %638
-%1421 = OpISub %ushort %1419 %1420
-OpStore %639 %1421
-%1422 = OpLoad %_arr_ushort_uint_8 %140
-%1423 = OpCompositeExtract %ushort %1422 6
-OpStore %640 %1423
-%1424 = OpLoad %_arr_ushort_uint_8 %146
-%1425 = OpCompositeExtract %ushort %1424 6
-OpStore %641 %1425
-%1426 = OpLoad %ushort %640
-%1427 = OpLoad %ushort %641
-%1428 = OpISub %ushort %1426 %1427
-OpStore %642 %1428
-%1429 = OpLoad %_arr_ushort_uint_8 %140
-%1430 = OpCompositeExtract %ushort %1429 7
-OpStore %643 %1430
-%1431 = OpLoad %_arr_ushort_uint_8 %146
-%1432 = OpCompositeExtract %ushort %1431 7
-OpStore %644 %1432
-%1433 = OpLoad %ushort %643
-%1434 = OpLoad %ushort %644
-%1435 = OpISub %ushort %1433 %1434
-OpStore %645 %1435
-%1436 = OpLoad %_arr_ushort_uint_8 %140
-%1437 = OpLoad %ushort %624
-%1438 = OpCompositeInsert %_arr_ushort_uint_8 %1437 %1436 0
-OpStore %646 %1438
-%1439 = OpLoad %_arr_ushort_uint_8 %646
-%1440 = OpLoad %ushort %627
-%1441 = OpCompositeInsert %_arr_ushort_uint_8 %1440 %1439 1
-OpStore %647 %1441
-%1442 = OpLoad %_arr_ushort_uint_8 %647
-%1443 = OpLoad %ushort %630
-%1444 = OpCompositeInsert %_arr_ushort_uint_8 %1443 %1442 2
-OpStore %648 %1444
-%1445 = OpLoad %_arr_ushort_uint_8 %648
-%1446 = OpLoad %ushort %633
-%1447 = OpCompositeInsert %_arr_ushort_uint_8 %1446 %1445 3
-OpStore %649 %1447
-%1448 = OpLoad %_arr_ushort_uint_8 %649
-%1449 = OpLoad %ushort %636
-%1450 = OpCompositeInsert %_arr_ushort_uint_8 %1449 %1448 4
-OpStore %650 %1450
-%1451 = OpLoad %_arr_ushort_uint_8 %650
-%1452 = OpLoad %ushort %639
-%1453 = OpCompositeInsert %_arr_ushort_uint_8 %1452 %1451 5
-OpStore %651 %1453
-%1454 = OpLoad %_arr_ushort_uint_8 %651
-%1455 = OpLoad %ushort %642
-%1456 = OpCompositeInsert %_arr_ushort_uint_8 %1455 %1454 6
-OpStore %652 %1456
-%1457 = OpLoad %_arr_ushort_uint_8 %652
-%1458 = OpLoad %ushort %645
-%1459 = OpCompositeInsert %_arr_ushort_uint_8 %1458 %1457 7
-OpStore %653 %1459
-OpBranch %102
-%102 = OpLabel
-%1460 = OpLoad %_arr_ushort_uint_8 %653
-%1461 = OpCompositeExtract %ushort %1460 0
-OpStore %302 %1461
-%1462 = OpLoad %ulong %285
-%1463 = OpLoad %ushort %302
-%1464 = OpFunctionCall %ulong %5 %1462 %1463
-OpStore %303 %1464
-%1465 = OpLoad %_arr_ushort_uint_8 %653
-%1466 = OpCompositeExtract %ushort %1465 1
-OpStore %304 %1466
-%1467 = OpLoad %ulong %303
-%1468 = OpLoad %ushort %304
-%1469 = OpFunctionCall %ulong %5 %1467 %1468
-OpStore %305 %1469
-%1470 = OpLoad %_arr_ushort_uint_8 %653
-%1471 = OpCompositeExtract %ushort %1470 2
-OpStore %306 %1471
-%1472 = OpLoad %ulong %305
-%1473 = OpLoad %ushort %306
-%1474 = OpFunctionCall %ulong %5 %1472 %1473
-OpStore %307 %1474
-%1475 = OpLoad %_arr_ushort_uint_8 %653
-%1476 = OpCompositeExtract %ushort %1475 3
-OpStore %308 %1476
-%1477 = OpLoad %ulong %307
-%1478 = OpLoad %ushort %308
-%1479 = OpFunctionCall %ulong %5 %1477 %1478
-OpStore %309 %1479
-%1480 = OpLoad %_arr_ushort_uint_8 %653
-%1481 = OpCompositeExtract %ushort %1480 4
-OpStore %310 %1481
-%1482 = OpLoad %ulong %309
-%1483 = OpLoad %ushort %310
-%1484 = OpFunctionCall %ulong %5 %1482 %1483
-OpStore %311 %1484
-%1485 = OpLoad %_arr_ushort_uint_8 %653
-%1486 = OpCompositeExtract %ushort %1485 5
-OpStore %312 %1486
-%1487 = OpLoad %ulong %311
-%1488 = OpLoad %ushort %312
-%1489 = OpFunctionCall %ulong %5 %1487 %1488
-OpStore %313 %1489
-%1490 = OpLoad %_arr_ushort_uint_8 %653
-%1491 = OpCompositeExtract %ushort %1490 6
-OpStore %314 %1491
-%1492 = OpLoad %ulong %313
-%1493 = OpLoad %ushort %314
-%1494 = OpFunctionCall %ulong %5 %1492 %1493
-OpStore %315 %1494
-%1495 = OpLoad %_arr_ushort_uint_8 %653
-%1496 = OpCompositeExtract %ushort %1495 7
-OpStore %316 %1496
-%1497 = OpLoad %ulong %315
-%1498 = OpLoad %ushort %316
-%1499 = OpFunctionCall %ulong %5 %1497 %1498
-OpStore %317 %1499
-OpBranch %103
-%103 = OpLabel
-%1500 = OpLoad %_arr_ushort_uint_8 %146
-%1501 = OpCompositeExtract %ushort %1500 0
-OpStore %686 %1501
-%1502 = OpLoad %_arr_ushort_uint_8 %140
-%1503 = OpCompositeExtract %ushort %1502 0
-OpStore %687 %1503
-%1504 = OpLoad %ushort %686
-%1505 = OpLoad %ushort %687
-%1506 = OpISub %ushort %1504 %1505
-OpStore %688 %1506
-%1507 = OpLoad %_arr_ushort_uint_8 %146
-%1508 = OpCompositeExtract %ushort %1507 1
-OpStore %689 %1508
-%1509 = OpLoad %_arr_ushort_uint_8 %140
-%1510 = OpCompositeExtract %ushort %1509 1
-OpStore %690 %1510
-%1511 = OpLoad %ushort %689
-%1512 = OpLoad %ushort %690
-%1513 = OpISub %ushort %1511 %1512
-OpStore %691 %1513
-%1514 = OpLoad %_arr_ushort_uint_8 %146
-%1515 = OpCompositeExtract %ushort %1514 2
-OpStore %692 %1515
-%1516 = OpLoad %_arr_ushort_uint_8 %140
-%1517 = OpCompositeExtract %ushort %1516 2
-OpStore %693 %1517
-%1518 = OpLoad %ushort %692
-%1519 = OpLoad %ushort %693
-%1520 = OpISub %ushort %1518 %1519
-OpStore %694 %1520
-%1521 = OpLoad %_arr_ushort_uint_8 %146
-%1522 = OpCompositeExtract %ushort %1521 3
-OpStore %695 %1522
-%1523 = OpLoad %_arr_ushort_uint_8 %140
-%1524 = OpCompositeExtract %ushort %1523 3
-OpStore %696 %1524
-%1525 = OpLoad %ushort %695
-%1526 = OpLoad %ushort %696
-%1527 = OpISub %ushort %1525 %1526
-OpStore %697 %1527
-%1528 = OpLoad %_arr_ushort_uint_8 %146
-%1529 = OpCompositeExtract %ushort %1528 4
-OpStore %698 %1529
-%1530 = OpLoad %_arr_ushort_uint_8 %140
-%1531 = OpCompositeExtract %ushort %1530 4
-OpStore %699 %1531
-%1532 = OpLoad %ushort %698
-%1533 = OpLoad %ushort %699
-%1534 = OpISub %ushort %1532 %1533
-OpStore %700 %1534
-%1535 = OpLoad %_arr_ushort_uint_8 %146
-%1536 = OpCompositeExtract %ushort %1535 5
-OpStore %701 %1536
-%1537 = OpLoad %_arr_ushort_uint_8 %140
-%1538 = OpCompositeExtract %ushort %1537 5
-OpStore %702 %1538
-%1539 = OpLoad %ushort %701
-%1540 = OpLoad %ushort %702
-%1541 = OpISub %ushort %1539 %1540
-OpStore %703 %1541
-%1542 = OpLoad %_arr_ushort_uint_8 %146
-%1543 = OpCompositeExtract %ushort %1542 6
-OpStore %704 %1543
-%1544 = OpLoad %_arr_ushort_uint_8 %140
-%1545 = OpCompositeExtract %ushort %1544 6
-OpStore %705 %1545
-%1546 = OpLoad %ushort %704
-%1547 = OpLoad %ushort %705
-%1548 = OpISub %ushort %1546 %1547
-OpStore %706 %1548
-%1549 = OpLoad %_arr_ushort_uint_8 %146
-%1550 = OpCompositeExtract %ushort %1549 7
-OpStore %707 %1550
-%1551 = OpLoad %_arr_ushort_uint_8 %140
-%1552 = OpCompositeExtract %ushort %1551 7
-OpStore %708 %1552
-%1553 = OpLoad %ushort %707
-%1554 = OpLoad %ushort %708
-%1555 = OpISub %ushort %1553 %1554
-OpStore %709 %1555
-%1556 = OpLoad %_arr_ushort_uint_8 %146
-%1557 = OpLoad %ushort %688
-%1558 = OpCompositeInsert %_arr_ushort_uint_8 %1557 %1556 0
-OpStore %710 %1558
-%1559 = OpLoad %_arr_ushort_uint_8 %710
-%1560 = OpLoad %ushort %691
-%1561 = OpCompositeInsert %_arr_ushort_uint_8 %1560 %1559 1
-OpStore %711 %1561
-%1562 = OpLoad %_arr_ushort_uint_8 %711
-%1563 = OpLoad %ushort %694
-%1564 = OpCompositeInsert %_arr_ushort_uint_8 %1563 %1562 2
-OpStore %712 %1564
-%1565 = OpLoad %_arr_ushort_uint_8 %712
-%1566 = OpLoad %ushort %697
-%1567 = OpCompositeInsert %_arr_ushort_uint_8 %1566 %1565 3
-OpStore %713 %1567
-%1568 = OpLoad %_arr_ushort_uint_8 %713
-%1569 = OpLoad %ushort %700
-%1570 = OpCompositeInsert %_arr_ushort_uint_8 %1569 %1568 4
-OpStore %714 %1570
-%1571 = OpLoad %_arr_ushort_uint_8 %714
-%1572 = OpLoad %ushort %703
-%1573 = OpCompositeInsert %_arr_ushort_uint_8 %1572 %1571 5
-OpStore %715 %1573
-%1574 = OpLoad %_arr_ushort_uint_8 %715
-%1575 = OpLoad %ushort %706
-%1576 = OpCompositeInsert %_arr_ushort_uint_8 %1575 %1574 6
-OpStore %716 %1576
-%1577 = OpLoad %_arr_ushort_uint_8 %716
-%1578 = OpLoad %ushort %709
-%1579 = OpCompositeInsert %_arr_ushort_uint_8 %1578 %1577 7
-OpStore %717 %1579
-OpBranch %106
-%106 = OpLabel
-%1580 = OpLoad %_arr_ushort_uint_8 %717
-%1581 = OpCompositeExtract %ushort %1580 0
-OpStore %334 %1581
-%1582 = OpLoad %ulong %317
-%1583 = OpLoad %ushort %334
-%1584 = OpFunctionCall %ulong %5 %1582 %1583
-OpStore %335 %1584
-%1585 = OpLoad %_arr_ushort_uint_8 %717
-%1586 = OpCompositeExtract %ushort %1585 1
-OpStore %336 %1586
-%1587 = OpLoad %ulong %335
-%1588 = OpLoad %ushort %336
-%1589 = OpFunctionCall %ulong %5 %1587 %1588
-OpStore %337 %1589
-%1590 = OpLoad %_arr_ushort_uint_8 %717
-%1591 = OpCompositeExtract %ushort %1590 2
-OpStore %338 %1591
-%1592 = OpLoad %ulong %337
-%1593 = OpLoad %ushort %338
-%1594 = OpFunctionCall %ulong %5 %1592 %1593
-OpStore %339 %1594
-%1595 = OpLoad %_arr_ushort_uint_8 %717
-%1596 = OpCompositeExtract %ushort %1595 3
-OpStore %340 %1596
-%1597 = OpLoad %ulong %339
-%1598 = OpLoad %ushort %340
-%1599 = OpFunctionCall %ulong %5 %1597 %1598
-OpStore %341 %1599
-%1600 = OpLoad %_arr_ushort_uint_8 %717
-%1601 = OpCompositeExtract %ushort %1600 4
-OpStore %342 %1601
-%1602 = OpLoad %ulong %341
-%1603 = OpLoad %ushort %342
-%1604 = OpFunctionCall %ulong %5 %1602 %1603
-OpStore %343 %1604
-%1605 = OpLoad %_arr_ushort_uint_8 %717
-%1606 = OpCompositeExtract %ushort %1605 5
-OpStore %344 %1606
-%1607 = OpLoad %ulong %343
-%1608 = OpLoad %ushort %344
-%1609 = OpFunctionCall %ulong %5 %1607 %1608
-OpStore %345 %1609
-%1610 = OpLoad %_arr_ushort_uint_8 %717
-%1611 = OpCompositeExtract %ushort %1610 6
-OpStore %346 %1611
-%1612 = OpLoad %ulong %345
-%1613 = OpLoad %ushort %346
-%1614 = OpFunctionCall %ulong %5 %1612 %1613
-OpStore %347 %1614
-%1615 = OpLoad %_arr_ushort_uint_8 %717
-%1616 = OpCompositeExtract %ushort %1615 7
-OpStore %348 %1616
-%1617 = OpLoad %ulong %347
-%1618 = OpLoad %ushort %348
-%1619 = OpFunctionCall %ulong %5 %1617 %1618
-OpStore %349 %1619
-OpBranch %107
-%107 = OpLabel
-%1620 = OpLoad %_arr_ushort_uint_8 %140
-%1621 = OpCompositeExtract %ushort %1620 0
-OpStore %718 %1621
-%1622 = OpLoad %_arr_ushort_uint_8 %146
-%1623 = OpCompositeExtract %ushort %1622 0
-OpStore %719 %1623
-%1624 = OpLoad %ushort %718
-%1625 = OpLoad %ushort %719
-%1626 = OpIMul %ushort %1624 %1625
-OpStore %720 %1626
-%1627 = OpLoad %_arr_ushort_uint_8 %140
-%1628 = OpCompositeExtract %ushort %1627 1
-OpStore %721 %1628
-%1629 = OpLoad %_arr_ushort_uint_8 %146
-%1630 = OpCompositeExtract %ushort %1629 1
-OpStore %722 %1630
-%1631 = OpLoad %ushort %721
-%1632 = OpLoad %ushort %722
-%1633 = OpIMul %ushort %1631 %1632
-OpStore %723 %1633
-%1634 = OpLoad %_arr_ushort_uint_8 %140
-%1635 = OpCompositeExtract %ushort %1634 2
-OpStore %724 %1635
-%1636 = OpLoad %_arr_ushort_uint_8 %146
-%1637 = OpCompositeExtract %ushort %1636 2
-OpStore %725 %1637
-%1638 = OpLoad %ushort %724
-%1639 = OpLoad %ushort %725
-%1640 = OpIMul %ushort %1638 %1639
-OpStore %726 %1640
-%1641 = OpLoad %_arr_ushort_uint_8 %140
-%1642 = OpCompositeExtract %ushort %1641 3
-OpStore %727 %1642
-%1643 = OpLoad %_arr_ushort_uint_8 %146
-%1644 = OpCompositeExtract %ushort %1643 3
-OpStore %728 %1644
-%1645 = OpLoad %ushort %727
-%1646 = OpLoad %ushort %728
-%1647 = OpIMul %ushort %1645 %1646
-OpStore %729 %1647
-%1648 = OpLoad %_arr_ushort_uint_8 %140
-%1649 = OpCompositeExtract %ushort %1648 4
-OpStore %730 %1649
-%1650 = OpLoad %_arr_ushort_uint_8 %146
-%1651 = OpCompositeExtract %ushort %1650 4
-OpStore %731 %1651
-%1652 = OpLoad %ushort %730
-%1653 = OpLoad %ushort %731
-%1654 = OpIMul %ushort %1652 %1653
-OpStore %732 %1654
-%1655 = OpLoad %_arr_ushort_uint_8 %140
-%1656 = OpCompositeExtract %ushort %1655 5
-OpStore %733 %1656
-%1657 = OpLoad %_arr_ushort_uint_8 %146
-%1658 = OpCompositeExtract %ushort %1657 5
-OpStore %734 %1658
-%1659 = OpLoad %ushort %733
-%1660 = OpLoad %ushort %734
-%1661 = OpIMul %ushort %1659 %1660
-OpStore %735 %1661
-%1662 = OpLoad %_arr_ushort_uint_8 %140
-%1663 = OpCompositeExtract %ushort %1662 6
-OpStore %736 %1663
-%1664 = OpLoad %_arr_ushort_uint_8 %146
-%1665 = OpCompositeExtract %ushort %1664 6
-OpStore %737 %1665
-%1666 = OpLoad %ushort %736
-%1667 = OpLoad %ushort %737
-%1668 = OpIMul %ushort %1666 %1667
-OpStore %738 %1668
-%1669 = OpLoad %_arr_ushort_uint_8 %140
-%1670 = OpCompositeExtract %ushort %1669 7
-OpStore %739 %1670
-%1671 = OpLoad %_arr_ushort_uint_8 %146
-%1672 = OpCompositeExtract %ushort %1671 7
-OpStore %740 %1672
-%1673 = OpLoad %ushort %739
-%1674 = OpLoad %ushort %740
-%1675 = OpIMul %ushort %1673 %1674
-OpStore %741 %1675
-%1676 = OpLoad %_arr_ushort_uint_8 %140
-%1677 = OpLoad %ushort %720
-%1678 = OpCompositeInsert %_arr_ushort_uint_8 %1677 %1676 0
-OpStore %742 %1678
-%1679 = OpLoad %_arr_ushort_uint_8 %742
-%1680 = OpLoad %ushort %723
-%1681 = OpCompositeInsert %_arr_ushort_uint_8 %1680 %1679 1
-OpStore %743 %1681
-%1682 = OpLoad %_arr_ushort_uint_8 %743
-%1683 = OpLoad %ushort %726
-%1684 = OpCompositeInsert %_arr_ushort_uint_8 %1683 %1682 2
-OpStore %744 %1684
-%1685 = OpLoad %_arr_ushort_uint_8 %744
-%1686 = OpLoad %ushort %729
-%1687 = OpCompositeInsert %_arr_ushort_uint_8 %1686 %1685 3
-OpStore %745 %1687
-%1688 = OpLoad %_arr_ushort_uint_8 %745
-%1689 = OpLoad %ushort %732
-%1690 = OpCompositeInsert %_arr_ushort_uint_8 %1689 %1688 4
-OpStore %746 %1690
-%1691 = OpLoad %_arr_ushort_uint_8 %746
-%1692 = OpLoad %ushort %735
-%1693 = OpCompositeInsert %_arr_ushort_uint_8 %1692 %1691 5
-OpStore %747 %1693
-%1694 = OpLoad %_arr_ushort_uint_8 %747
-%1695 = OpLoad %ushort %738
-%1696 = OpCompositeInsert %_arr_ushort_uint_8 %1695 %1694 6
-OpStore %748 %1696
-%1697 = OpLoad %_arr_ushort_uint_8 %748
-%1698 = OpLoad %ushort %741
-%1699 = OpCompositeInsert %_arr_ushort_uint_8 %1698 %1697 7
-OpStore %749 %1699
-OpBranch %108
-%108 = OpLabel
-%1700 = OpLoad %_arr_ushort_uint_8 %749
-%1701 = OpCompositeExtract %ushort %1700 0
-OpStore %350 %1701
-%1702 = OpLoad %ulong %349
-%1703 = OpLoad %ushort %350
-%1704 = OpFunctionCall %ulong %5 %1702 %1703
-OpStore %351 %1704
-%1705 = OpLoad %_arr_ushort_uint_8 %749
-%1706 = OpCompositeExtract %ushort %1705 1
-OpStore %352 %1706
-%1707 = OpLoad %ulong %351
-%1708 = OpLoad %ushort %352
-%1709 = OpFunctionCall %ulong %5 %1707 %1708
-OpStore %353 %1709
-%1710 = OpLoad %_arr_ushort_uint_8 %749
-%1711 = OpCompositeExtract %ushort %1710 2
-OpStore %354 %1711
-%1712 = OpLoad %ulong %353
-%1713 = OpLoad %ushort %354
-%1714 = OpFunctionCall %ulong %5 %1712 %1713
-OpStore %355 %1714
-%1715 = OpLoad %_arr_ushort_uint_8 %749
-%1716 = OpCompositeExtract %ushort %1715 3
-OpStore %356 %1716
-%1717 = OpLoad %ulong %355
-%1718 = OpLoad %ushort %356
-%1719 = OpFunctionCall %ulong %5 %1717 %1718
-OpStore %357 %1719
-%1720 = OpLoad %_arr_ushort_uint_8 %749
-%1721 = OpCompositeExtract %ushort %1720 4
-OpStore %358 %1721
-%1722 = OpLoad %ulong %357
-%1723 = OpLoad %ushort %358
-%1724 = OpFunctionCall %ulong %5 %1722 %1723
-OpStore %359 %1724
-%1725 = OpLoad %_arr_ushort_uint_8 %749
-%1726 = OpCompositeExtract %ushort %1725 5
-OpStore %360 %1726
-%1727 = OpLoad %ulong %359
-%1728 = OpLoad %ushort %360
-%1729 = OpFunctionCall %ulong %5 %1727 %1728
-OpStore %361 %1729
-%1730 = OpLoad %_arr_ushort_uint_8 %749
-%1731 = OpCompositeExtract %ushort %1730 6
-OpStore %362 %1731
-%1732 = OpLoad %ulong %361
-%1733 = OpLoad %ushort %362
-%1734 = OpFunctionCall %ulong %5 %1732 %1733
-OpStore %363 %1734
-%1735 = OpLoad %_arr_ushort_uint_8 %749
-%1736 = OpCompositeExtract %ushort %1735 7
-OpStore %364 %1736
-%1737 = OpLoad %ulong %363
-%1738 = OpLoad %ushort %364
-%1739 = OpFunctionCall %ulong %5 %1737 %1738
-OpStore %365 %1739
-OpBranch %109
-%109 = OpLabel
-%1740 = OpLoad %_arr_ushort_uint_8 %140
-%1741 = OpCompositeExtract %ushort %1740 0
-OpStore %750 %1741
-%1742 = OpLoad %_arr_ushort_uint_8 %133
-%1743 = OpCompositeExtract %ushort %1742 0
-OpStore %751 %1743
-%1744 = OpLoad %ushort %750
-%1745 = OpLoad %ushort %751
-%1746 = OpIMul %ushort %1744 %1745
-OpStore %752 %1746
-%1747 = OpLoad %_arr_ushort_uint_8 %140
-%1748 = OpCompositeExtract %ushort %1747 1
-OpStore %753 %1748
-%1749 = OpLoad %_arr_ushort_uint_8 %133
-%1750 = OpCompositeExtract %ushort %1749 1
-OpStore %754 %1750
-%1751 = OpLoad %ushort %753
-%1752 = OpLoad %ushort %754
-%1753 = OpIMul %ushort %1751 %1752
-OpStore %755 %1753
-%1754 = OpLoad %_arr_ushort_uint_8 %140
-%1755 = OpCompositeExtract %ushort %1754 2
-OpStore %756 %1755
-%1756 = OpLoad %_arr_ushort_uint_8 %133
-%1757 = OpCompositeExtract %ushort %1756 2
-OpStore %757 %1757
-%1758 = OpLoad %ushort %756
-%1759 = OpLoad %ushort %757
-%1760 = OpIMul %ushort %1758 %1759
-OpStore %758 %1760
-%1761 = OpLoad %_arr_ushort_uint_8 %140
-%1762 = OpCompositeExtract %ushort %1761 3
-OpStore %759 %1762
-%1763 = OpLoad %_arr_ushort_uint_8 %133
-%1764 = OpCompositeExtract %ushort %1763 3
-OpStore %760 %1764
-%1765 = OpLoad %ushort %759
-%1766 = OpLoad %ushort %760
-%1767 = OpIMul %ushort %1765 %1766
-OpStore %761 %1767
-%1768 = OpLoad %_arr_ushort_uint_8 %140
-%1769 = OpCompositeExtract %ushort %1768 4
-OpStore %762 %1769
-%1770 = OpLoad %_arr_ushort_uint_8 %133
-%1771 = OpCompositeExtract %ushort %1770 4
-OpStore %763 %1771
-%1772 = OpLoad %ushort %762
-%1773 = OpLoad %ushort %763
-%1774 = OpIMul %ushort %1772 %1773
-OpStore %764 %1774
-%1775 = OpLoad %_arr_ushort_uint_8 %140
-%1776 = OpCompositeExtract %ushort %1775 5
-OpStore %765 %1776
-%1777 = OpLoad %_arr_ushort_uint_8 %133
-%1778 = OpCompositeExtract %ushort %1777 5
-OpStore %766 %1778
-%1779 = OpLoad %ushort %765
-%1780 = OpLoad %ushort %766
-%1781 = OpIMul %ushort %1779 %1780
-OpStore %767 %1781
-%1782 = OpLoad %_arr_ushort_uint_8 %140
-%1783 = OpCompositeExtract %ushort %1782 6
-OpStore %768 %1783
-%1784 = OpLoad %_arr_ushort_uint_8 %133
-%1785 = OpCompositeExtract %ushort %1784 6
-OpStore %769 %1785
-%1786 = OpLoad %ushort %768
-%1787 = OpLoad %ushort %769
-%1788 = OpIMul %ushort %1786 %1787
-OpStore %770 %1788
-%1789 = OpLoad %_arr_ushort_uint_8 %140
-%1790 = OpCompositeExtract %ushort %1789 7
-OpStore %771 %1790
-%1791 = OpLoad %_arr_ushort_uint_8 %133
-%1792 = OpCompositeExtract %ushort %1791 7
-OpStore %772 %1792
-%1793 = OpLoad %ushort %771
-%1794 = OpLoad %ushort %772
-%1795 = OpIMul %ushort %1793 %1794
-OpStore %773 %1795
-%1796 = OpLoad %_arr_ushort_uint_8 %140
-%1797 = OpLoad %ushort %752
-%1798 = OpCompositeInsert %_arr_ushort_uint_8 %1797 %1796 0
-OpStore %774 %1798
-%1799 = OpLoad %_arr_ushort_uint_8 %774
-%1800 = OpLoad %ushort %755
-%1801 = OpCompositeInsert %_arr_ushort_uint_8 %1800 %1799 1
-OpStore %775 %1801
-%1802 = OpLoad %_arr_ushort_uint_8 %775
-%1803 = OpLoad %ushort %758
-%1804 = OpCompositeInsert %_arr_ushort_uint_8 %1803 %1802 2
-OpStore %776 %1804
-%1805 = OpLoad %_arr_ushort_uint_8 %776
-%1806 = OpLoad %ushort %761
-%1807 = OpCompositeInsert %_arr_ushort_uint_8 %1806 %1805 3
-OpStore %777 %1807
-%1808 = OpLoad %_arr_ushort_uint_8 %777
-%1809 = OpLoad %ushort %764
-%1810 = OpCompositeInsert %_arr_ushort_uint_8 %1809 %1808 4
-OpStore %778 %1810
-%1811 = OpLoad %_arr_ushort_uint_8 %778
-%1812 = OpLoad %ushort %767
-%1813 = OpCompositeInsert %_arr_ushort_uint_8 %1812 %1811 5
-OpStore %779 %1813
-%1814 = OpLoad %_arr_ushort_uint_8 %779
-%1815 = OpLoad %ushort %770
-%1816 = OpCompositeInsert %_arr_ushort_uint_8 %1815 %1814 6
-OpStore %780 %1816
-%1817 = OpLoad %_arr_ushort_uint_8 %780
-%1818 = OpLoad %ushort %773
-%1819 = OpCompositeInsert %_arr_ushort_uint_8 %1818 %1817 7
-OpStore %781 %1819
-OpBranch %110
-%110 = OpLabel
-%1820 = OpLoad %_arr_ushort_uint_8 %781
-%1821 = OpCompositeExtract %ushort %1820 0
-OpStore %366 %1821
-%1822 = OpLoad %ulong %365
-%1823 = OpLoad %ushort %366
-%1824 = OpFunctionCall %ulong %5 %1822 %1823
-OpStore %367 %1824
-%1825 = OpLoad %_arr_ushort_uint_8 %781
-%1826 = OpCompositeExtract %ushort %1825 1
-OpStore %368 %1826
-%1827 = OpLoad %ulong %367
-%1828 = OpLoad %ushort %368
-%1829 = OpFunctionCall %ulong %5 %1827 %1828
-OpStore %369 %1829
-%1830 = OpLoad %_arr_ushort_uint_8 %781
-%1831 = OpCompositeExtract %ushort %1830 2
-OpStore %370 %1831
-%1832 = OpLoad %ulong %369
-%1833 = OpLoad %ushort %370
-%1834 = OpFunctionCall %ulong %5 %1832 %1833
-OpStore %371 %1834
-%1835 = OpLoad %_arr_ushort_uint_8 %781
-%1836 = OpCompositeExtract %ushort %1835 3
-OpStore %372 %1836
-%1837 = OpLoad %ulong %371
-%1838 = OpLoad %ushort %372
-%1839 = OpFunctionCall %ulong %5 %1837 %1838
-OpStore %373 %1839
-%1840 = OpLoad %_arr_ushort_uint_8 %781
-%1841 = OpCompositeExtract %ushort %1840 4
-OpStore %374 %1841
-%1842 = OpLoad %ulong %373
-%1843 = OpLoad %ushort %374
-%1844 = OpFunctionCall %ulong %5 %1842 %1843
-OpStore %375 %1844
-%1845 = OpLoad %_arr_ushort_uint_8 %781
-%1846 = OpCompositeExtract %ushort %1845 5
-OpStore %376 %1846
-%1847 = OpLoad %ulong %375
-%1848 = OpLoad %ushort %376
-%1849 = OpFunctionCall %ulong %5 %1847 %1848
-OpStore %377 %1849
-%1850 = OpLoad %_arr_ushort_uint_8 %781
-%1851 = OpCompositeExtract %ushort %1850 6
-OpStore %378 %1851
-%1852 = OpLoad %ulong %377
-%1853 = OpLoad %ushort %378
-%1854 = OpFunctionCall %ulong %5 %1852 %1853
-OpStore %379 %1854
-%1855 = OpLoad %_arr_ushort_uint_8 %781
-%1856 = OpCompositeExtract %ushort %1855 7
-OpStore %380 %1856
-%1857 = OpLoad %ulong %379
-%1858 = OpLoad %ushort %380
-%1859 = OpFunctionCall %ulong %5 %1857 %1858
-OpStore %381 %1859
-OpBranch %111
-%111 = OpLabel
-%1860 = OpLoad %_arr_ushort_uint_8 %146
-%1861 = OpCompositeExtract %ushort %1860 0
-OpStore %782 %1861
-%1862 = OpLoad %_arr_ushort_uint_8 %133
-%1863 = OpCompositeExtract %ushort %1862 0
-OpStore %783 %1863
-%1864 = OpLoad %ushort %782
-%1865 = OpLoad %ushort %783
-%1866 = OpIMul %ushort %1864 %1865
-OpStore %784 %1866
-%1867 = OpLoad %_arr_ushort_uint_8 %146
-%1868 = OpCompositeExtract %ushort %1867 1
-OpStore %785 %1868
-%1869 = OpLoad %_arr_ushort_uint_8 %133
-%1870 = OpCompositeExtract %ushort %1869 1
-OpStore %786 %1870
-%1871 = OpLoad %ushort %785
-%1872 = OpLoad %ushort %786
-%1873 = OpIMul %ushort %1871 %1872
-OpStore %787 %1873
-%1874 = OpLoad %_arr_ushort_uint_8 %146
-%1875 = OpCompositeExtract %ushort %1874 2
-OpStore %788 %1875
-%1876 = OpLoad %_arr_ushort_uint_8 %133
-%1877 = OpCompositeExtract %ushort %1876 2
-OpStore %789 %1877
-%1878 = OpLoad %ushort %788
-%1879 = OpLoad %ushort %789
-%1880 = OpIMul %ushort %1878 %1879
-OpStore %790 %1880
-%1881 = OpLoad %_arr_ushort_uint_8 %146
-%1882 = OpCompositeExtract %ushort %1881 3
-OpStore %791 %1882
-%1883 = OpLoad %_arr_ushort_uint_8 %133
-%1884 = OpCompositeExtract %ushort %1883 3
-OpStore %792 %1884
-%1885 = OpLoad %ushort %791
-%1886 = OpLoad %ushort %792
-%1887 = OpIMul %ushort %1885 %1886
-OpStore %793 %1887
-%1888 = OpLoad %_arr_ushort_uint_8 %146
-%1889 = OpCompositeExtract %ushort %1888 4
-OpStore %794 %1889
-%1890 = OpLoad %_arr_ushort_uint_8 %133
-%1891 = OpCompositeExtract %ushort %1890 4
-OpStore %795 %1891
-%1892 = OpLoad %ushort %794
-%1893 = OpLoad %ushort %795
-%1894 = OpIMul %ushort %1892 %1893
-OpStore %796 %1894
-%1895 = OpLoad %_arr_ushort_uint_8 %146
-%1896 = OpCompositeExtract %ushort %1895 5
-OpStore %797 %1896
-%1897 = OpLoad %_arr_ushort_uint_8 %133
-%1898 = OpCompositeExtract %ushort %1897 5
-OpStore %798 %1898
-%1899 = OpLoad %ushort %797
-%1900 = OpLoad %ushort %798
-%1901 = OpIMul %ushort %1899 %1900
-OpStore %799 %1901
-%1902 = OpLoad %_arr_ushort_uint_8 %146
-%1903 = OpCompositeExtract %ushort %1902 6
-OpStore %800 %1903
-%1904 = OpLoad %_arr_ushort_uint_8 %133
-%1905 = OpCompositeExtract %ushort %1904 6
-OpStore %801 %1905
-%1906 = OpLoad %ushort %800
-%1907 = OpLoad %ushort %801
-%1908 = OpIMul %ushort %1906 %1907
-OpStore %802 %1908
-%1909 = OpLoad %_arr_ushort_uint_8 %146
-%1910 = OpCompositeExtract %ushort %1909 7
-OpStore %803 %1910
-%1911 = OpLoad %_arr_ushort_uint_8 %133
-%1912 = OpCompositeExtract %ushort %1911 7
-OpStore %804 %1912
-%1913 = OpLoad %ushort %803
-%1914 = OpLoad %ushort %804
-%1915 = OpIMul %ushort %1913 %1914
-OpStore %805 %1915
-%1916 = OpLoad %_arr_ushort_uint_8 %146
-%1917 = OpLoad %ushort %784
-%1918 = OpCompositeInsert %_arr_ushort_uint_8 %1917 %1916 0
-OpStore %806 %1918
-%1919 = OpLoad %_arr_ushort_uint_8 %806
-%1920 = OpLoad %ushort %787
-%1921 = OpCompositeInsert %_arr_ushort_uint_8 %1920 %1919 1
-OpStore %807 %1921
-%1922 = OpLoad %_arr_ushort_uint_8 %807
-%1923 = OpLoad %ushort %790
-%1924 = OpCompositeInsert %_arr_ushort_uint_8 %1923 %1922 2
-OpStore %808 %1924
-%1925 = OpLoad %_arr_ushort_uint_8 %808
-%1926 = OpLoad %ushort %793
-%1927 = OpCompositeInsert %_arr_ushort_uint_8 %1926 %1925 3
-OpStore %809 %1927
-%1928 = OpLoad %_arr_ushort_uint_8 %809
-%1929 = OpLoad %ushort %796
-%1930 = OpCompositeInsert %_arr_ushort_uint_8 %1929 %1928 4
-OpStore %810 %1930
-%1931 = OpLoad %_arr_ushort_uint_8 %810
-%1932 = OpLoad %ushort %799
-%1933 = OpCompositeInsert %_arr_ushort_uint_8 %1932 %1931 5
-OpStore %811 %1933
-%1934 = OpLoad %_arr_ushort_uint_8 %811
-%1935 = OpLoad %ushort %802
-%1936 = OpCompositeInsert %_arr_ushort_uint_8 %1935 %1934 6
-OpStore %812 %1936
-%1937 = OpLoad %_arr_ushort_uint_8 %812
-%1938 = OpLoad %ushort %805
-%1939 = OpCompositeInsert %_arr_ushort_uint_8 %1938 %1937 7
-OpStore %813 %1939
-OpBranch %112
-%112 = OpLabel
-%1940 = OpLoad %_arr_ushort_uint_8 %813
-%1941 = OpCompositeExtract %ushort %1940 0
-OpStore %382 %1941
-%1942 = OpLoad %ulong %381
-%1943 = OpLoad %ushort %382
-%1944 = OpFunctionCall %ulong %5 %1942 %1943
-OpStore %383 %1944
-%1945 = OpLoad %_arr_ushort_uint_8 %813
-%1946 = OpCompositeExtract %ushort %1945 1
-OpStore %384 %1946
-%1947 = OpLoad %ulong %383
-%1948 = OpLoad %ushort %384
-%1949 = OpFunctionCall %ulong %5 %1947 %1948
-OpStore %385 %1949
-%1950 = OpLoad %_arr_ushort_uint_8 %813
-%1951 = OpCompositeExtract %ushort %1950 2
-OpStore %386 %1951
-%1952 = OpLoad %ulong %385
-%1953 = OpLoad %ushort %386
-%1954 = OpFunctionCall %ulong %5 %1952 %1953
-OpStore %387 %1954
-%1955 = OpLoad %_arr_ushort_uint_8 %813
-%1956 = OpCompositeExtract %ushort %1955 3
-OpStore %388 %1956
-%1957 = OpLoad %ulong %387
-%1958 = OpLoad %ushort %388
-%1959 = OpFunctionCall %ulong %5 %1957 %1958
-OpStore %389 %1959
-%1960 = OpLoad %_arr_ushort_uint_8 %813
-%1961 = OpCompositeExtract %ushort %1960 4
-OpStore %390 %1961
-%1962 = OpLoad %ulong %389
-%1963 = OpLoad %ushort %390
-%1964 = OpFunctionCall %ulong %5 %1962 %1963
-OpStore %391 %1964
-%1965 = OpLoad %_arr_ushort_uint_8 %813
-%1966 = OpCompositeExtract %ushort %1965 5
-OpStore %392 %1966
-%1967 = OpLoad %ulong %391
-%1968 = OpLoad %ushort %392
-%1969 = OpFunctionCall %ulong %5 %1967 %1968
-OpStore %393 %1969
-%1970 = OpLoad %_arr_ushort_uint_8 %813
-%1971 = OpCompositeExtract %ushort %1970 6
-OpStore %394 %1971
-%1972 = OpLoad %ulong %393
-%1973 = OpLoad %ushort %394
-%1974 = OpFunctionCall %ulong %5 %1972 %1973
-OpStore %395 %1974
-%1975 = OpLoad %_arr_ushort_uint_8 %813
-%1976 = OpCompositeExtract %ushort %1975 7
-OpStore %396 %1976
-%1977 = OpLoad %ulong %395
-%1978 = OpLoad %ushort %396
-%1979 = OpFunctionCall %ulong %5 %1977 %1978
-OpStore %397 %1979
-OpBranch %113
-%113 = OpLabel
-%1980 = OpLoad %_arr_ushort_uint_8 %140
-%1981 = OpCompositeExtract %ushort %1980 0
-OpStore %814 %1981
-%1982 = OpLoad %_arr_ushort_uint_8 %146
-%1983 = OpCompositeExtract %ushort %1982 0
-OpStore %815 %1983
-%1984 = OpLoad %ushort %814
-%1985 = OpLoad %ushort %815
-%1986 = OpIAdd %ushort %1984 %1985
-OpStore %816 %1986
-%1987 = OpLoad %_arr_ushort_uint_8 %140
-%1988 = OpCompositeExtract %ushort %1987 1
-OpStore %817 %1988
-%1989 = OpLoad %_arr_ushort_uint_8 %146
-%1990 = OpCompositeExtract %ushort %1989 1
-OpStore %818 %1990
-%1991 = OpLoad %ushort %817
-%1992 = OpLoad %ushort %818
-%1993 = OpIAdd %ushort %1991 %1992
-OpStore %819 %1993
-%1994 = OpLoad %_arr_ushort_uint_8 %140
-%1995 = OpCompositeExtract %ushort %1994 2
-OpStore %820 %1995
-%1996 = OpLoad %_arr_ushort_uint_8 %146
-%1997 = OpCompositeExtract %ushort %1996 2
-OpStore %821 %1997
-%1998 = OpLoad %ushort %820
-%1999 = OpLoad %ushort %821
-%2000 = OpIAdd %ushort %1998 %1999
-OpStore %822 %2000
-%2001 = OpLoad %_arr_ushort_uint_8 %140
-%2002 = OpCompositeExtract %ushort %2001 3
-OpStore %823 %2002
-%2003 = OpLoad %_arr_ushort_uint_8 %146
-%2004 = OpCompositeExtract %ushort %2003 3
-OpStore %824 %2004
-%2005 = OpLoad %ushort %823
-%2006 = OpLoad %ushort %824
-%2007 = OpIAdd %ushort %2005 %2006
-OpStore %825 %2007
-%2008 = OpLoad %_arr_ushort_uint_8 %140
-%2009 = OpCompositeExtract %ushort %2008 4
-OpStore %826 %2009
-%2010 = OpLoad %_arr_ushort_uint_8 %146
-%2011 = OpCompositeExtract %ushort %2010 4
-OpStore %827 %2011
-%2012 = OpLoad %ushort %826
-%2013 = OpLoad %ushort %827
-%2014 = OpIAdd %ushort %2012 %2013
-OpStore %828 %2014
-%2015 = OpLoad %_arr_ushort_uint_8 %140
-%2016 = OpCompositeExtract %ushort %2015 5
-OpStore %829 %2016
-%2017 = OpLoad %_arr_ushort_uint_8 %146
-%2018 = OpCompositeExtract %ushort %2017 5
-OpStore %830 %2018
-%2019 = OpLoad %ushort %829
-%2020 = OpLoad %ushort %830
-%2021 = OpIAdd %ushort %2019 %2020
-OpStore %831 %2021
-%2022 = OpLoad %_arr_ushort_uint_8 %140
-%2023 = OpCompositeExtract %ushort %2022 6
-OpStore %832 %2023
-%2024 = OpLoad %_arr_ushort_uint_8 %146
-%2025 = OpCompositeExtract %ushort %2024 6
-OpStore %833 %2025
-%2026 = OpLoad %ushort %832
-%2027 = OpLoad %ushort %833
-%2028 = OpIAdd %ushort %2026 %2027
-OpStore %834 %2028
-%2029 = OpLoad %_arr_ushort_uint_8 %140
-%2030 = OpCompositeExtract %ushort %2029 7
-OpStore %835 %2030
-%2031 = OpLoad %_arr_ushort_uint_8 %146
-%2032 = OpCompositeExtract %ushort %2031 7
-OpStore %836 %2032
-%2033 = OpLoad %ushort %835
-%2034 = OpLoad %ushort %836
-%2035 = OpIAdd %ushort %2033 %2034
-OpStore %837 %2035
-%2036 = OpLoad %_arr_ushort_uint_8 %140
-%2037 = OpLoad %ushort %816
-%2038 = OpCompositeInsert %_arr_ushort_uint_8 %2037 %2036 0
-OpStore %838 %2038
-%2039 = OpLoad %_arr_ushort_uint_8 %838
-%2040 = OpLoad %ushort %819
-%2041 = OpCompositeInsert %_arr_ushort_uint_8 %2040 %2039 1
-OpStore %839 %2041
-%2042 = OpLoad %_arr_ushort_uint_8 %839
-%2043 = OpLoad %ushort %822
-%2044 = OpCompositeInsert %_arr_ushort_uint_8 %2043 %2042 2
-OpStore %840 %2044
-%2045 = OpLoad %_arr_ushort_uint_8 %840
-%2046 = OpLoad %ushort %825
-%2047 = OpCompositeInsert %_arr_ushort_uint_8 %2046 %2045 3
-OpStore %841 %2047
-%2048 = OpLoad %_arr_ushort_uint_8 %841
-%2049 = OpLoad %ushort %828
-%2050 = OpCompositeInsert %_arr_ushort_uint_8 %2049 %2048 4
-OpStore %842 %2050
-%2051 = OpLoad %_arr_ushort_uint_8 %842
-%2052 = OpLoad %ushort %831
-%2053 = OpCompositeInsert %_arr_ushort_uint_8 %2052 %2051 5
-OpStore %843 %2053
-%2054 = OpLoad %_arr_ushort_uint_8 %843
-%2055 = OpLoad %ushort %834
-%2056 = OpCompositeInsert %_arr_ushort_uint_8 %2055 %2054 6
-OpStore %844 %2056
-%2057 = OpLoad %_arr_ushort_uint_8 %844
-%2058 = OpLoad %ushort %837
-%2059 = OpCompositeInsert %_arr_ushort_uint_8 %2058 %2057 7
-OpStore %845 %2059
-%2060 = OpLoad %_arr_ushort_uint_8 %845
-%2061 = OpCompositeExtract %ushort %2060 0
-OpStore %846 %2061
-%2062 = OpLoad %_arr_ushort_uint_8 %133
-%2063 = OpCompositeExtract %ushort %2062 0
-OpStore %847 %2063
-%2064 = OpLoad %ushort %846
-%2065 = OpLoad %ushort %847
-%2066 = OpIMul %ushort %2064 %2065
-OpStore %848 %2066
-%2067 = OpLoad %_arr_ushort_uint_8 %845
-%2068 = OpCompositeExtract %ushort %2067 1
-OpStore %849 %2068
-%2069 = OpLoad %_arr_ushort_uint_8 %133
-%2070 = OpCompositeExtract %ushort %2069 1
-OpStore %850 %2070
-%2071 = OpLoad %ushort %849
-%2072 = OpLoad %ushort %850
-%2073 = OpIMul %ushort %2071 %2072
-OpStore %851 %2073
-%2074 = OpLoad %_arr_ushort_uint_8 %845
-%2075 = OpCompositeExtract %ushort %2074 2
-OpStore %852 %2075
-%2076 = OpLoad %_arr_ushort_uint_8 %133
-%2077 = OpCompositeExtract %ushort %2076 2
-OpStore %853 %2077
-%2078 = OpLoad %ushort %852
-%2079 = OpLoad %ushort %853
-%2080 = OpIMul %ushort %2078 %2079
-OpStore %854 %2080
-%2081 = OpLoad %_arr_ushort_uint_8 %845
-%2082 = OpCompositeExtract %ushort %2081 3
-OpStore %855 %2082
-%2083 = OpLoad %_arr_ushort_uint_8 %133
-%2084 = OpCompositeExtract %ushort %2083 3
-OpStore %856 %2084
-%2085 = OpLoad %ushort %855
-%2086 = OpLoad %ushort %856
-%2087 = OpIMul %ushort %2085 %2086
-OpStore %857 %2087
-%2088 = OpLoad %_arr_ushort_uint_8 %845
-%2089 = OpCompositeExtract %ushort %2088 4
-OpStore %858 %2089
-%2090 = OpLoad %_arr_ushort_uint_8 %133
-%2091 = OpCompositeExtract %ushort %2090 4
-OpStore %859 %2091
-%2092 = OpLoad %ushort %858
-%2093 = OpLoad %ushort %859
-%2094 = OpIMul %ushort %2092 %2093
-OpStore %860 %2094
-%2095 = OpLoad %_arr_ushort_uint_8 %845
-%2096 = OpCompositeExtract %ushort %2095 5
-OpStore %861 %2096
-%2097 = OpLoad %_arr_ushort_uint_8 %133
-%2098 = OpCompositeExtract %ushort %2097 5
-OpStore %862 %2098
-%2099 = OpLoad %ushort %861
-%2100 = OpLoad %ushort %862
-%2101 = OpIMul %ushort %2099 %2100
-OpStore %863 %2101
-%2102 = OpLoad %_arr_ushort_uint_8 %845
-%2103 = OpCompositeExtract %ushort %2102 6
-OpStore %864 %2103
-%2104 = OpLoad %_arr_ushort_uint_8 %133
-%2105 = OpCompositeExtract %ushort %2104 6
-OpStore %865 %2105
-%2106 = OpLoad %ushort %864
-%2107 = OpLoad %ushort %865
-%2108 = OpIMul %ushort %2106 %2107
-OpStore %866 %2108
-%2109 = OpLoad %_arr_ushort_uint_8 %845
-%2110 = OpCompositeExtract %ushort %2109 7
-OpStore %867 %2110
-%2111 = OpLoad %_arr_ushort_uint_8 %133
-%2112 = OpCompositeExtract %ushort %2111 7
-OpStore %868 %2112
-%2113 = OpLoad %ushort %867
-%2114 = OpLoad %ushort %868
-%2115 = OpIMul %ushort %2113 %2114
-OpStore %869 %2115
-%2116 = OpLoad %_arr_ushort_uint_8 %845
-%2117 = OpLoad %ushort %848
-%2118 = OpCompositeInsert %_arr_ushort_uint_8 %2117 %2116 0
-OpStore %870 %2118
-%2119 = OpLoad %_arr_ushort_uint_8 %870
-%2120 = OpLoad %ushort %851
-%2121 = OpCompositeInsert %_arr_ushort_uint_8 %2120 %2119 1
-OpStore %871 %2121
-%2122 = OpLoad %_arr_ushort_uint_8 %871
-%2123 = OpLoad %ushort %854
-%2124 = OpCompositeInsert %_arr_ushort_uint_8 %2123 %2122 2
-OpStore %872 %2124
-%2125 = OpLoad %_arr_ushort_uint_8 %872
-%2126 = OpLoad %ushort %857
-%2127 = OpCompositeInsert %_arr_ushort_uint_8 %2126 %2125 3
-OpStore %873 %2127
-%2128 = OpLoad %_arr_ushort_uint_8 %873
-%2129 = OpLoad %ushort %860
-%2130 = OpCompositeInsert %_arr_ushort_uint_8 %2129 %2128 4
-OpStore %874 %2130
-%2131 = OpLoad %_arr_ushort_uint_8 %874
-%2132 = OpLoad %ushort %863
-%2133 = OpCompositeInsert %_arr_ushort_uint_8 %2132 %2131 5
-OpStore %875 %2133
-%2134 = OpLoad %_arr_ushort_uint_8 %875
-%2135 = OpLoad %ushort %866
-%2136 = OpCompositeInsert %_arr_ushort_uint_8 %2135 %2134 6
-OpStore %876 %2136
-%2137 = OpLoad %_arr_ushort_uint_8 %876
-%2138 = OpLoad %ushort %869
-%2139 = OpCompositeInsert %_arr_ushort_uint_8 %2138 %2137 7
-OpStore %877 %2139
-OpBranch %114
-%114 = OpLabel
-%2140 = OpLoad %_arr_ushort_uint_8 %877
-%2141 = OpCompositeExtract %ushort %2140 0
-OpStore %398 %2141
-%2142 = OpLoad %ulong %397
-%2143 = OpLoad %ushort %398
-%2144 = OpFunctionCall %ulong %5 %2142 %2143
-OpStore %399 %2144
-%2145 = OpLoad %_arr_ushort_uint_8 %877
-%2146 = OpCompositeExtract %ushort %2145 1
-OpStore %400 %2146
-%2147 = OpLoad %ulong %399
-%2148 = OpLoad %ushort %400
-%2149 = OpFunctionCall %ulong %5 %2147 %2148
-OpStore %401 %2149
-%2150 = OpLoad %_arr_ushort_uint_8 %877
-%2151 = OpCompositeExtract %ushort %2150 2
-OpStore %402 %2151
-%2152 = OpLoad %ulong %401
-%2153 = OpLoad %ushort %402
-%2154 = OpFunctionCall %ulong %5 %2152 %2153
-OpStore %403 %2154
-%2155 = OpLoad %_arr_ushort_uint_8 %877
-%2156 = OpCompositeExtract %ushort %2155 3
-OpStore %404 %2156
-%2157 = OpLoad %ulong %403
-%2158 = OpLoad %ushort %404
-%2159 = OpFunctionCall %ulong %5 %2157 %2158
-OpStore %405 %2159
-%2160 = OpLoad %_arr_ushort_uint_8 %877
-%2161 = OpCompositeExtract %ushort %2160 4
-OpStore %406 %2161
-%2162 = OpLoad %ulong %405
-%2163 = OpLoad %ushort %406
-%2164 = OpFunctionCall %ulong %5 %2162 %2163
-OpStore %407 %2164
-%2165 = OpLoad %_arr_ushort_uint_8 %877
-%2166 = OpCompositeExtract %ushort %2165 5
-OpStore %408 %2166
-%2167 = OpLoad %ulong %407
-%2168 = OpLoad %ushort %408
-%2169 = OpFunctionCall %ulong %5 %2167 %2168
-OpStore %409 %2169
-%2170 = OpLoad %_arr_ushort_uint_8 %877
-%2171 = OpCompositeExtract %ushort %2170 6
-OpStore %410 %2171
-%2172 = OpLoad %ulong %409
-%2173 = OpLoad %ushort %410
-%2174 = OpFunctionCall %ulong %5 %2172 %2173
-OpStore %411 %2174
-%2175 = OpLoad %_arr_ushort_uint_8 %877
-%2176 = OpCompositeExtract %ushort %2175 7
-OpStore %412 %2176
-%2177 = OpLoad %ulong %411
-%2178 = OpLoad %ushort %412
-%2179 = OpFunctionCall %ulong %5 %2177 %2178
-OpStore %413 %2179
-OpBranch %115
-%115 = OpLabel
-%2180 = OpLoad %_arr_ushort_uint_8 %134
-%2181 = OpCompositeExtract %ushort %2180 0
-OpStore %878 %2181
-%2182 = OpLoad %_arr_ushort_uint_8 %140
-%2183 = OpCompositeExtract %ushort %2182 0
-OpStore %879 %2183
-%2184 = OpLoad %ushort %878
-%2185 = OpLoad %ushort %879
-%2186 = OpISub %ushort %2184 %2185
-OpStore %880 %2186
-%2187 = OpLoad %_arr_ushort_uint_8 %134
-%2188 = OpCompositeExtract %ushort %2187 1
-OpStore %881 %2188
-%2189 = OpLoad %_arr_ushort_uint_8 %140
-%2190 = OpCompositeExtract %ushort %2189 1
-OpStore %882 %2190
-%2191 = OpLoad %ushort %881
-%2192 = OpLoad %ushort %882
-%2193 = OpISub %ushort %2191 %2192
-OpStore %883 %2193
-%2194 = OpLoad %_arr_ushort_uint_8 %134
-%2195 = OpCompositeExtract %ushort %2194 2
-OpStore %884 %2195
-%2196 = OpLoad %_arr_ushort_uint_8 %140
-%2197 = OpCompositeExtract %ushort %2196 2
-OpStore %885 %2197
-%2198 = OpLoad %ushort %884
-%2199 = OpLoad %ushort %885
-%2200 = OpISub %ushort %2198 %2199
-OpStore %886 %2200
-%2201 = OpLoad %_arr_ushort_uint_8 %134
-%2202 = OpCompositeExtract %ushort %2201 3
-OpStore %887 %2202
-%2203 = OpLoad %_arr_ushort_uint_8 %140
-%2204 = OpCompositeExtract %ushort %2203 3
-OpStore %888 %2204
-%2205 = OpLoad %ushort %887
-%2206 = OpLoad %ushort %888
-%2207 = OpISub %ushort %2205 %2206
-OpStore %889 %2207
-%2208 = OpLoad %_arr_ushort_uint_8 %134
-%2209 = OpCompositeExtract %ushort %2208 4
-OpStore %890 %2209
-%2210 = OpLoad %_arr_ushort_uint_8 %140
-%2211 = OpCompositeExtract %ushort %2210 4
-OpStore %891 %2211
-%2212 = OpLoad %ushort %890
-%2213 = OpLoad %ushort %891
-%2214 = OpISub %ushort %2212 %2213
-OpStore %892 %2214
-%2215 = OpLoad %_arr_ushort_uint_8 %134
-%2216 = OpCompositeExtract %ushort %2215 5
-OpStore %893 %2216
-%2217 = OpLoad %_arr_ushort_uint_8 %140
-%2218 = OpCompositeExtract %ushort %2217 5
-OpStore %894 %2218
-%2219 = OpLoad %ushort %893
-%2220 = OpLoad %ushort %894
-%2221 = OpISub %ushort %2219 %2220
-OpStore %895 %2221
-%2222 = OpLoad %_arr_ushort_uint_8 %134
-%2223 = OpCompositeExtract %ushort %2222 6
-OpStore %896 %2223
-%2224 = OpLoad %_arr_ushort_uint_8 %140
-%2225 = OpCompositeExtract %ushort %2224 6
-OpStore %897 %2225
-%2226 = OpLoad %ushort %896
-%2227 = OpLoad %ushort %897
-%2228 = OpISub %ushort %2226 %2227
-OpStore %898 %2228
-%2229 = OpLoad %_arr_ushort_uint_8 %134
-%2230 = OpCompositeExtract %ushort %2229 7
-OpStore %899 %2230
-%2231 = OpLoad %_arr_ushort_uint_8 %140
-%2232 = OpCompositeExtract %ushort %2231 7
-OpStore %900 %2232
-%2233 = OpLoad %ushort %899
-%2234 = OpLoad %ushort %900
-%2235 = OpISub %ushort %2233 %2234
-OpStore %901 %2235
-%2236 = OpLoad %_arr_ushort_uint_8 %134
-%2237 = OpLoad %ushort %880
-%2238 = OpCompositeInsert %_arr_ushort_uint_8 %2237 %2236 0
-OpStore %902 %2238
-%2239 = OpLoad %_arr_ushort_uint_8 %902
-%2240 = OpLoad %ushort %883
-%2241 = OpCompositeInsert %_arr_ushort_uint_8 %2240 %2239 1
-OpStore %903 %2241
-%2242 = OpLoad %_arr_ushort_uint_8 %903
-%2243 = OpLoad %ushort %886
-%2244 = OpCompositeInsert %_arr_ushort_uint_8 %2243 %2242 2
-OpStore %904 %2244
-%2245 = OpLoad %_arr_ushort_uint_8 %904
-%2246 = OpLoad %ushort %889
-%2247 = OpCompositeInsert %_arr_ushort_uint_8 %2246 %2245 3
-OpStore %905 %2247
-%2248 = OpLoad %_arr_ushort_uint_8 %905
-%2249 = OpLoad %ushort %892
-%2250 = OpCompositeInsert %_arr_ushort_uint_8 %2249 %2248 4
-OpStore %906 %2250
-%2251 = OpLoad %_arr_ushort_uint_8 %906
-%2252 = OpLoad %ushort %895
-%2253 = OpCompositeInsert %_arr_ushort_uint_8 %2252 %2251 5
-OpStore %907 %2253
-%2254 = OpLoad %_arr_ushort_uint_8 %907
-%2255 = OpLoad %ushort %898
-%2256 = OpCompositeInsert %_arr_ushort_uint_8 %2255 %2254 6
-OpStore %908 %2256
-%2257 = OpLoad %_arr_ushort_uint_8 %908
-%2258 = OpLoad %ushort %901
-%2259 = OpCompositeInsert %_arr_ushort_uint_8 %2258 %2257 7
-OpStore %909 %2259
-OpBranch %116
-%116 = OpLabel
-%2260 = OpLoad %_arr_ushort_uint_8 %909
-%2261 = OpCompositeExtract %ushort %2260 0
-OpStore %414 %2261
-%2262 = OpLoad %ulong %413
-%2263 = OpLoad %ushort %414
-%2264 = OpFunctionCall %ulong %5 %2262 %2263
-OpStore %415 %2264
-%2265 = OpLoad %_arr_ushort_uint_8 %909
+OpStore %696 %1256
+%1257 = OpLoad %_arr_ushort_uint_8 %422
+%1258 = OpCompositeExtract %ushort %1257 7
+OpStore %697 %1258
+%1259 = OpLoad %ushort %696
+%1260 = OpLoad %ushort %697
+%1261 = OpIAdd %ushort %1259 %1260
+OpStore %698 %1261
+%1262 = OpLoad %_arr_ushort_uint_8 %416
+%1263 = OpLoad %ushort %677
+%1264 = OpCompositeInsert %_arr_ushort_uint_8 %1263 %1262 0
+OpStore %699 %1264
+%1265 = OpLoad %_arr_ushort_uint_8 %699
+%1266 = OpLoad %ushort %680
+%1267 = OpCompositeInsert %_arr_ushort_uint_8 %1266 %1265 1
+OpStore %700 %1267
+%1268 = OpLoad %_arr_ushort_uint_8 %700
+%1269 = OpLoad %ushort %683
+%1270 = OpCompositeInsert %_arr_ushort_uint_8 %1269 %1268 2
+OpStore %701 %1270
+%1271 = OpLoad %_arr_ushort_uint_8 %701
+%1272 = OpLoad %ushort %686
+%1273 = OpCompositeInsert %_arr_ushort_uint_8 %1272 %1271 3
+OpStore %702 %1273
+%1274 = OpLoad %_arr_ushort_uint_8 %702
+%1275 = OpLoad %ushort %689
+%1276 = OpCompositeInsert %_arr_ushort_uint_8 %1275 %1274 4
+OpStore %703 %1276
+%1277 = OpLoad %_arr_ushort_uint_8 %703
+%1278 = OpLoad %ushort %692
+%1279 = OpCompositeInsert %_arr_ushort_uint_8 %1278 %1277 5
+OpStore %704 %1279
+%1280 = OpLoad %_arr_ushort_uint_8 %704
+%1281 = OpLoad %ushort %695
+%1282 = OpCompositeInsert %_arr_ushort_uint_8 %1281 %1280 6
+OpStore %705 %1282
+%1283 = OpLoad %_arr_ushort_uint_8 %705
+%1284 = OpLoad %ushort %698
+%1285 = OpCompositeInsert %_arr_ushort_uint_8 %1284 %1283 7
+OpStore %706 %1285
+%1286 = OpLoad %ulong %424
+%1287 = OpLoad %_arr_ushort_uint_8 %706
+%1288 = OpFunctionCall %ulong %1 %1286 %1287
+OpStore %425 %1288
+%1289 = OpLoad %_arr_ushort_uint_8 %416
+%1290 = OpCompositeExtract %ushort %1289 0
+OpStore %707 %1290
+%1291 = OpLoad %_arr_ushort_uint_8 %422
+%1292 = OpCompositeExtract %ushort %1291 0
+OpStore %708 %1292
+%1293 = OpLoad %ushort %707
+%1294 = OpLoad %ushort %708
+%1295 = OpISub %ushort %1293 %1294
+OpStore %709 %1295
+%1296 = OpLoad %_arr_ushort_uint_8 %416
+%1297 = OpCompositeExtract %ushort %1296 1
+OpStore %710 %1297
+%1298 = OpLoad %_arr_ushort_uint_8 %422
+%1299 = OpCompositeExtract %ushort %1298 1
+OpStore %711 %1299
+%1300 = OpLoad %ushort %710
+%1301 = OpLoad %ushort %711
+%1302 = OpISub %ushort %1300 %1301
+OpStore %712 %1302
+%1303 = OpLoad %_arr_ushort_uint_8 %416
+%1304 = OpCompositeExtract %ushort %1303 2
+OpStore %713 %1304
+%1305 = OpLoad %_arr_ushort_uint_8 %422
+%1306 = OpCompositeExtract %ushort %1305 2
+OpStore %714 %1306
+%1307 = OpLoad %ushort %713
+%1308 = OpLoad %ushort %714
+%1309 = OpISub %ushort %1307 %1308
+OpStore %715 %1309
+%1310 = OpLoad %_arr_ushort_uint_8 %416
+%1311 = OpCompositeExtract %ushort %1310 3
+OpStore %716 %1311
+%1312 = OpLoad %_arr_ushort_uint_8 %422
+%1313 = OpCompositeExtract %ushort %1312 3
+OpStore %717 %1313
+%1314 = OpLoad %ushort %716
+%1315 = OpLoad %ushort %717
+%1316 = OpISub %ushort %1314 %1315
+OpStore %718 %1316
+%1317 = OpLoad %_arr_ushort_uint_8 %416
+%1318 = OpCompositeExtract %ushort %1317 4
+OpStore %719 %1318
+%1319 = OpLoad %_arr_ushort_uint_8 %422
+%1320 = OpCompositeExtract %ushort %1319 4
+OpStore %720 %1320
+%1321 = OpLoad %ushort %719
+%1322 = OpLoad %ushort %720
+%1323 = OpISub %ushort %1321 %1322
+OpStore %721 %1323
+%1324 = OpLoad %_arr_ushort_uint_8 %416
+%1325 = OpCompositeExtract %ushort %1324 5
+OpStore %722 %1325
+%1326 = OpLoad %_arr_ushort_uint_8 %422
+%1327 = OpCompositeExtract %ushort %1326 5
+OpStore %723 %1327
+%1328 = OpLoad %ushort %722
+%1329 = OpLoad %ushort %723
+%1330 = OpISub %ushort %1328 %1329
+OpStore %724 %1330
+%1331 = OpLoad %_arr_ushort_uint_8 %416
+%1332 = OpCompositeExtract %ushort %1331 6
+OpStore %725 %1332
+%1333 = OpLoad %_arr_ushort_uint_8 %422
+%1334 = OpCompositeExtract %ushort %1333 6
+OpStore %726 %1334
+%1335 = OpLoad %ushort %725
+%1336 = OpLoad %ushort %726
+%1337 = OpISub %ushort %1335 %1336
+OpStore %727 %1337
+%1338 = OpLoad %_arr_ushort_uint_8 %416
+%1339 = OpCompositeExtract %ushort %1338 7
+OpStore %728 %1339
+%1340 = OpLoad %_arr_ushort_uint_8 %422
+%1341 = OpCompositeExtract %ushort %1340 7
+OpStore %729 %1341
+%1342 = OpLoad %ushort %728
+%1343 = OpLoad %ushort %729
+%1344 = OpISub %ushort %1342 %1343
+OpStore %730 %1344
+%1345 = OpLoad %_arr_ushort_uint_8 %416
+%1346 = OpLoad %ushort %709
+%1347 = OpCompositeInsert %_arr_ushort_uint_8 %1346 %1345 0
+OpStore %731 %1347
+%1348 = OpLoad %_arr_ushort_uint_8 %731
+%1349 = OpLoad %ushort %712
+%1350 = OpCompositeInsert %_arr_ushort_uint_8 %1349 %1348 1
+OpStore %732 %1350
+%1351 = OpLoad %_arr_ushort_uint_8 %732
+%1352 = OpLoad %ushort %715
+%1353 = OpCompositeInsert %_arr_ushort_uint_8 %1352 %1351 2
+OpStore %733 %1353
+%1354 = OpLoad %_arr_ushort_uint_8 %733
+%1355 = OpLoad %ushort %718
+%1356 = OpCompositeInsert %_arr_ushort_uint_8 %1355 %1354 3
+OpStore %734 %1356
+%1357 = OpLoad %_arr_ushort_uint_8 %734
+%1358 = OpLoad %ushort %721
+%1359 = OpCompositeInsert %_arr_ushort_uint_8 %1358 %1357 4
+OpStore %735 %1359
+%1360 = OpLoad %_arr_ushort_uint_8 %735
+%1361 = OpLoad %ushort %724
+%1362 = OpCompositeInsert %_arr_ushort_uint_8 %1361 %1360 5
+OpStore %736 %1362
+%1363 = OpLoad %_arr_ushort_uint_8 %736
+%1364 = OpLoad %ushort %727
+%1365 = OpCompositeInsert %_arr_ushort_uint_8 %1364 %1363 6
+OpStore %737 %1365
+%1366 = OpLoad %_arr_ushort_uint_8 %737
+%1367 = OpLoad %ushort %730
+%1368 = OpCompositeInsert %_arr_ushort_uint_8 %1367 %1366 7
+OpStore %738 %1368
+%1369 = OpLoad %ulong %425
+%1370 = OpLoad %_arr_ushort_uint_8 %738
+%1371 = OpFunctionCall %ulong %1 %1369 %1370
+OpStore %426 %1371
+%1372 = OpLoad %_arr_ushort_uint_8 %422
+%1373 = OpCompositeExtract %ushort %1372 0
+OpStore %739 %1373
+%1374 = OpLoad %_arr_ushort_uint_8 %416
+%1375 = OpCompositeExtract %ushort %1374 0
+OpStore %740 %1375
+%1376 = OpLoad %ushort %739
+%1377 = OpLoad %ushort %740
+%1378 = OpISub %ushort %1376 %1377
+OpStore %741 %1378
+%1379 = OpLoad %_arr_ushort_uint_8 %422
+%1380 = OpCompositeExtract %ushort %1379 1
+OpStore %742 %1380
+%1381 = OpLoad %_arr_ushort_uint_8 %416
+%1382 = OpCompositeExtract %ushort %1381 1
+OpStore %743 %1382
+%1383 = OpLoad %ushort %742
+%1384 = OpLoad %ushort %743
+%1385 = OpISub %ushort %1383 %1384
+OpStore %744 %1385
+%1386 = OpLoad %_arr_ushort_uint_8 %422
+%1387 = OpCompositeExtract %ushort %1386 2
+OpStore %745 %1387
+%1388 = OpLoad %_arr_ushort_uint_8 %416
+%1389 = OpCompositeExtract %ushort %1388 2
+OpStore %746 %1389
+%1390 = OpLoad %ushort %745
+%1391 = OpLoad %ushort %746
+%1392 = OpISub %ushort %1390 %1391
+OpStore %747 %1392
+%1393 = OpLoad %_arr_ushort_uint_8 %422
+%1394 = OpCompositeExtract %ushort %1393 3
+OpStore %748 %1394
+%1395 = OpLoad %_arr_ushort_uint_8 %416
+%1396 = OpCompositeExtract %ushort %1395 3
+OpStore %749 %1396
+%1397 = OpLoad %ushort %748
+%1398 = OpLoad %ushort %749
+%1399 = OpISub %ushort %1397 %1398
+OpStore %750 %1399
+%1400 = OpLoad %_arr_ushort_uint_8 %422
+%1401 = OpCompositeExtract %ushort %1400 4
+OpStore %751 %1401
+%1402 = OpLoad %_arr_ushort_uint_8 %416
+%1403 = OpCompositeExtract %ushort %1402 4
+OpStore %752 %1403
+%1404 = OpLoad %ushort %751
+%1405 = OpLoad %ushort %752
+%1406 = OpISub %ushort %1404 %1405
+OpStore %753 %1406
+%1407 = OpLoad %_arr_ushort_uint_8 %422
+%1408 = OpCompositeExtract %ushort %1407 5
+OpStore %754 %1408
+%1409 = OpLoad %_arr_ushort_uint_8 %416
+%1410 = OpCompositeExtract %ushort %1409 5
+OpStore %755 %1410
+%1411 = OpLoad %ushort %754
+%1412 = OpLoad %ushort %755
+%1413 = OpISub %ushort %1411 %1412
+OpStore %756 %1413
+%1414 = OpLoad %_arr_ushort_uint_8 %422
+%1415 = OpCompositeExtract %ushort %1414 6
+OpStore %757 %1415
+%1416 = OpLoad %_arr_ushort_uint_8 %416
+%1417 = OpCompositeExtract %ushort %1416 6
+OpStore %758 %1417
+%1418 = OpLoad %ushort %757
+%1419 = OpLoad %ushort %758
+%1420 = OpISub %ushort %1418 %1419
+OpStore %759 %1420
+%1421 = OpLoad %_arr_ushort_uint_8 %422
+%1422 = OpCompositeExtract %ushort %1421 7
+OpStore %760 %1422
+%1423 = OpLoad %_arr_ushort_uint_8 %416
+%1424 = OpCompositeExtract %ushort %1423 7
+OpStore %761 %1424
+%1425 = OpLoad %ushort %760
+%1426 = OpLoad %ushort %761
+%1427 = OpISub %ushort %1425 %1426
+OpStore %762 %1427
+%1428 = OpLoad %_arr_ushort_uint_8 %422
+%1429 = OpLoad %ushort %741
+%1430 = OpCompositeInsert %_arr_ushort_uint_8 %1429 %1428 0
+OpStore %763 %1430
+%1431 = OpLoad %_arr_ushort_uint_8 %763
+%1432 = OpLoad %ushort %744
+%1433 = OpCompositeInsert %_arr_ushort_uint_8 %1432 %1431 1
+OpStore %764 %1433
+%1434 = OpLoad %_arr_ushort_uint_8 %764
+%1435 = OpLoad %ushort %747
+%1436 = OpCompositeInsert %_arr_ushort_uint_8 %1435 %1434 2
+OpStore %765 %1436
+%1437 = OpLoad %_arr_ushort_uint_8 %765
+%1438 = OpLoad %ushort %750
+%1439 = OpCompositeInsert %_arr_ushort_uint_8 %1438 %1437 3
+OpStore %766 %1439
+%1440 = OpLoad %_arr_ushort_uint_8 %766
+%1441 = OpLoad %ushort %753
+%1442 = OpCompositeInsert %_arr_ushort_uint_8 %1441 %1440 4
+OpStore %767 %1442
+%1443 = OpLoad %_arr_ushort_uint_8 %767
+%1444 = OpLoad %ushort %756
+%1445 = OpCompositeInsert %_arr_ushort_uint_8 %1444 %1443 5
+OpStore %768 %1445
+%1446 = OpLoad %_arr_ushort_uint_8 %768
+%1447 = OpLoad %ushort %759
+%1448 = OpCompositeInsert %_arr_ushort_uint_8 %1447 %1446 6
+OpStore %769 %1448
+%1449 = OpLoad %_arr_ushort_uint_8 %769
+%1450 = OpLoad %ushort %762
+%1451 = OpCompositeInsert %_arr_ushort_uint_8 %1450 %1449 7
+OpStore %770 %1451
+%1452 = OpLoad %ulong %426
+%1453 = OpLoad %_arr_ushort_uint_8 %770
+%1454 = OpFunctionCall %ulong %1 %1452 %1453
+OpStore %427 %1454
+%1455 = OpLoad %_arr_ushort_uint_8 %416
+%1456 = OpCompositeExtract %ushort %1455 0
+OpStore %771 %1456
+%1457 = OpLoad %_arr_ushort_uint_8 %422
+%1458 = OpCompositeExtract %ushort %1457 0
+OpStore %772 %1458
+%1459 = OpLoad %ushort %771
+%1460 = OpLoad %ushort %772
+%1461 = OpIMul %ushort %1459 %1460
+OpStore %773 %1461
+%1462 = OpLoad %_arr_ushort_uint_8 %416
+%1463 = OpCompositeExtract %ushort %1462 1
+OpStore %774 %1463
+%1464 = OpLoad %_arr_ushort_uint_8 %422
+%1465 = OpCompositeExtract %ushort %1464 1
+OpStore %775 %1465
+%1466 = OpLoad %ushort %774
+%1467 = OpLoad %ushort %775
+%1468 = OpIMul %ushort %1466 %1467
+OpStore %776 %1468
+%1469 = OpLoad %_arr_ushort_uint_8 %416
+%1470 = OpCompositeExtract %ushort %1469 2
+OpStore %777 %1470
+%1471 = OpLoad %_arr_ushort_uint_8 %422
+%1472 = OpCompositeExtract %ushort %1471 2
+OpStore %778 %1472
+%1473 = OpLoad %ushort %777
+%1474 = OpLoad %ushort %778
+%1475 = OpIMul %ushort %1473 %1474
+OpStore %779 %1475
+%1476 = OpLoad %_arr_ushort_uint_8 %416
+%1477 = OpCompositeExtract %ushort %1476 3
+OpStore %780 %1477
+%1478 = OpLoad %_arr_ushort_uint_8 %422
+%1479 = OpCompositeExtract %ushort %1478 3
+OpStore %781 %1479
+%1480 = OpLoad %ushort %780
+%1481 = OpLoad %ushort %781
+%1482 = OpIMul %ushort %1480 %1481
+OpStore %782 %1482
+%1483 = OpLoad %_arr_ushort_uint_8 %416
+%1484 = OpCompositeExtract %ushort %1483 4
+OpStore %783 %1484
+%1485 = OpLoad %_arr_ushort_uint_8 %422
+%1486 = OpCompositeExtract %ushort %1485 4
+OpStore %784 %1486
+%1487 = OpLoad %ushort %783
+%1488 = OpLoad %ushort %784
+%1489 = OpIMul %ushort %1487 %1488
+OpStore %785 %1489
+%1490 = OpLoad %_arr_ushort_uint_8 %416
+%1491 = OpCompositeExtract %ushort %1490 5
+OpStore %786 %1491
+%1492 = OpLoad %_arr_ushort_uint_8 %422
+%1493 = OpCompositeExtract %ushort %1492 5
+OpStore %787 %1493
+%1494 = OpLoad %ushort %786
+%1495 = OpLoad %ushort %787
+%1496 = OpIMul %ushort %1494 %1495
+OpStore %788 %1496
+%1497 = OpLoad %_arr_ushort_uint_8 %416
+%1498 = OpCompositeExtract %ushort %1497 6
+OpStore %789 %1498
+%1499 = OpLoad %_arr_ushort_uint_8 %422
+%1500 = OpCompositeExtract %ushort %1499 6
+OpStore %790 %1500
+%1501 = OpLoad %ushort %789
+%1502 = OpLoad %ushort %790
+%1503 = OpIMul %ushort %1501 %1502
+OpStore %791 %1503
+%1504 = OpLoad %_arr_ushort_uint_8 %416
+%1505 = OpCompositeExtract %ushort %1504 7
+OpStore %792 %1505
+%1506 = OpLoad %_arr_ushort_uint_8 %422
+%1507 = OpCompositeExtract %ushort %1506 7
+OpStore %793 %1507
+%1508 = OpLoad %ushort %792
+%1509 = OpLoad %ushort %793
+%1510 = OpIMul %ushort %1508 %1509
+OpStore %794 %1510
+%1511 = OpLoad %_arr_ushort_uint_8 %416
+%1512 = OpLoad %ushort %773
+%1513 = OpCompositeInsert %_arr_ushort_uint_8 %1512 %1511 0
+OpStore %795 %1513
+%1514 = OpLoad %_arr_ushort_uint_8 %795
+%1515 = OpLoad %ushort %776
+%1516 = OpCompositeInsert %_arr_ushort_uint_8 %1515 %1514 1
+OpStore %796 %1516
+%1517 = OpLoad %_arr_ushort_uint_8 %796
+%1518 = OpLoad %ushort %779
+%1519 = OpCompositeInsert %_arr_ushort_uint_8 %1518 %1517 2
+OpStore %797 %1519
+%1520 = OpLoad %_arr_ushort_uint_8 %797
+%1521 = OpLoad %ushort %782
+%1522 = OpCompositeInsert %_arr_ushort_uint_8 %1521 %1520 3
+OpStore %798 %1522
+%1523 = OpLoad %_arr_ushort_uint_8 %798
+%1524 = OpLoad %ushort %785
+%1525 = OpCompositeInsert %_arr_ushort_uint_8 %1524 %1523 4
+OpStore %799 %1525
+%1526 = OpLoad %_arr_ushort_uint_8 %799
+%1527 = OpLoad %ushort %788
+%1528 = OpCompositeInsert %_arr_ushort_uint_8 %1527 %1526 5
+OpStore %800 %1528
+%1529 = OpLoad %_arr_ushort_uint_8 %800
+%1530 = OpLoad %ushort %791
+%1531 = OpCompositeInsert %_arr_ushort_uint_8 %1530 %1529 6
+OpStore %801 %1531
+%1532 = OpLoad %_arr_ushort_uint_8 %801
+%1533 = OpLoad %ushort %794
+%1534 = OpCompositeInsert %_arr_ushort_uint_8 %1533 %1532 7
+OpStore %802 %1534
+%1535 = OpLoad %ulong %427
+%1536 = OpLoad %_arr_ushort_uint_8 %802
+%1537 = OpFunctionCall %ulong %1 %1535 %1536
+OpStore %428 %1537
+%1538 = OpLoad %_arr_ushort_uint_8 %416
+%1539 = OpCompositeExtract %ushort %1538 0
+OpStore %803 %1539
+%1540 = OpLoad %_arr_ushort_uint_8 %409
+%1541 = OpCompositeExtract %ushort %1540 0
+OpStore %804 %1541
+%1542 = OpLoad %ushort %803
+%1543 = OpLoad %ushort %804
+%1544 = OpIMul %ushort %1542 %1543
+OpStore %805 %1544
+%1545 = OpLoad %_arr_ushort_uint_8 %416
+%1546 = OpCompositeExtract %ushort %1545 1
+OpStore %806 %1546
+%1547 = OpLoad %_arr_ushort_uint_8 %409
+%1548 = OpCompositeExtract %ushort %1547 1
+OpStore %807 %1548
+%1549 = OpLoad %ushort %806
+%1550 = OpLoad %ushort %807
+%1551 = OpIMul %ushort %1549 %1550
+OpStore %808 %1551
+%1552 = OpLoad %_arr_ushort_uint_8 %416
+%1553 = OpCompositeExtract %ushort %1552 2
+OpStore %809 %1553
+%1554 = OpLoad %_arr_ushort_uint_8 %409
+%1555 = OpCompositeExtract %ushort %1554 2
+OpStore %810 %1555
+%1556 = OpLoad %ushort %809
+%1557 = OpLoad %ushort %810
+%1558 = OpIMul %ushort %1556 %1557
+OpStore %811 %1558
+%1559 = OpLoad %_arr_ushort_uint_8 %416
+%1560 = OpCompositeExtract %ushort %1559 3
+OpStore %812 %1560
+%1561 = OpLoad %_arr_ushort_uint_8 %409
+%1562 = OpCompositeExtract %ushort %1561 3
+OpStore %813 %1562
+%1563 = OpLoad %ushort %812
+%1564 = OpLoad %ushort %813
+%1565 = OpIMul %ushort %1563 %1564
+OpStore %814 %1565
+%1566 = OpLoad %_arr_ushort_uint_8 %416
+%1567 = OpCompositeExtract %ushort %1566 4
+OpStore %815 %1567
+%1568 = OpLoad %_arr_ushort_uint_8 %409
+%1569 = OpCompositeExtract %ushort %1568 4
+OpStore %816 %1569
+%1570 = OpLoad %ushort %815
+%1571 = OpLoad %ushort %816
+%1572 = OpIMul %ushort %1570 %1571
+OpStore %817 %1572
+%1573 = OpLoad %_arr_ushort_uint_8 %416
+%1574 = OpCompositeExtract %ushort %1573 5
+OpStore %818 %1574
+%1575 = OpLoad %_arr_ushort_uint_8 %409
+%1576 = OpCompositeExtract %ushort %1575 5
+OpStore %819 %1576
+%1577 = OpLoad %ushort %818
+%1578 = OpLoad %ushort %819
+%1579 = OpIMul %ushort %1577 %1578
+OpStore %820 %1579
+%1580 = OpLoad %_arr_ushort_uint_8 %416
+%1581 = OpCompositeExtract %ushort %1580 6
+OpStore %821 %1581
+%1582 = OpLoad %_arr_ushort_uint_8 %409
+%1583 = OpCompositeExtract %ushort %1582 6
+OpStore %822 %1583
+%1584 = OpLoad %ushort %821
+%1585 = OpLoad %ushort %822
+%1586 = OpIMul %ushort %1584 %1585
+OpStore %823 %1586
+%1587 = OpLoad %_arr_ushort_uint_8 %416
+%1588 = OpCompositeExtract %ushort %1587 7
+OpStore %824 %1588
+%1589 = OpLoad %_arr_ushort_uint_8 %409
+%1590 = OpCompositeExtract %ushort %1589 7
+OpStore %825 %1590
+%1591 = OpLoad %ushort %824
+%1592 = OpLoad %ushort %825
+%1593 = OpIMul %ushort %1591 %1592
+OpStore %826 %1593
+%1594 = OpLoad %_arr_ushort_uint_8 %416
+%1595 = OpLoad %ushort %805
+%1596 = OpCompositeInsert %_arr_ushort_uint_8 %1595 %1594 0
+OpStore %827 %1596
+%1597 = OpLoad %_arr_ushort_uint_8 %827
+%1598 = OpLoad %ushort %808
+%1599 = OpCompositeInsert %_arr_ushort_uint_8 %1598 %1597 1
+OpStore %828 %1599
+%1600 = OpLoad %_arr_ushort_uint_8 %828
+%1601 = OpLoad %ushort %811
+%1602 = OpCompositeInsert %_arr_ushort_uint_8 %1601 %1600 2
+OpStore %829 %1602
+%1603 = OpLoad %_arr_ushort_uint_8 %829
+%1604 = OpLoad %ushort %814
+%1605 = OpCompositeInsert %_arr_ushort_uint_8 %1604 %1603 3
+OpStore %830 %1605
+%1606 = OpLoad %_arr_ushort_uint_8 %830
+%1607 = OpLoad %ushort %817
+%1608 = OpCompositeInsert %_arr_ushort_uint_8 %1607 %1606 4
+OpStore %831 %1608
+%1609 = OpLoad %_arr_ushort_uint_8 %831
+%1610 = OpLoad %ushort %820
+%1611 = OpCompositeInsert %_arr_ushort_uint_8 %1610 %1609 5
+OpStore %832 %1611
+%1612 = OpLoad %_arr_ushort_uint_8 %832
+%1613 = OpLoad %ushort %823
+%1614 = OpCompositeInsert %_arr_ushort_uint_8 %1613 %1612 6
+OpStore %833 %1614
+%1615 = OpLoad %_arr_ushort_uint_8 %833
+%1616 = OpLoad %ushort %826
+%1617 = OpCompositeInsert %_arr_ushort_uint_8 %1616 %1615 7
+OpStore %834 %1617
+%1618 = OpLoad %ulong %428
+%1619 = OpLoad %_arr_ushort_uint_8 %834
+%1620 = OpFunctionCall %ulong %1 %1618 %1619
+OpStore %429 %1620
+%1621 = OpLoad %_arr_ushort_uint_8 %422
+%1622 = OpCompositeExtract %ushort %1621 0
+OpStore %835 %1622
+%1623 = OpLoad %_arr_ushort_uint_8 %409
+%1624 = OpCompositeExtract %ushort %1623 0
+OpStore %836 %1624
+%1625 = OpLoad %ushort %835
+%1626 = OpLoad %ushort %836
+%1627 = OpIMul %ushort %1625 %1626
+OpStore %837 %1627
+%1628 = OpLoad %_arr_ushort_uint_8 %422
+%1629 = OpCompositeExtract %ushort %1628 1
+OpStore %838 %1629
+%1630 = OpLoad %_arr_ushort_uint_8 %409
+%1631 = OpCompositeExtract %ushort %1630 1
+OpStore %839 %1631
+%1632 = OpLoad %ushort %838
+%1633 = OpLoad %ushort %839
+%1634 = OpIMul %ushort %1632 %1633
+OpStore %840 %1634
+%1635 = OpLoad %_arr_ushort_uint_8 %422
+%1636 = OpCompositeExtract %ushort %1635 2
+OpStore %841 %1636
+%1637 = OpLoad %_arr_ushort_uint_8 %409
+%1638 = OpCompositeExtract %ushort %1637 2
+OpStore %842 %1638
+%1639 = OpLoad %ushort %841
+%1640 = OpLoad %ushort %842
+%1641 = OpIMul %ushort %1639 %1640
+OpStore %843 %1641
+%1642 = OpLoad %_arr_ushort_uint_8 %422
+%1643 = OpCompositeExtract %ushort %1642 3
+OpStore %844 %1643
+%1644 = OpLoad %_arr_ushort_uint_8 %409
+%1645 = OpCompositeExtract %ushort %1644 3
+OpStore %845 %1645
+%1646 = OpLoad %ushort %844
+%1647 = OpLoad %ushort %845
+%1648 = OpIMul %ushort %1646 %1647
+OpStore %846 %1648
+%1649 = OpLoad %_arr_ushort_uint_8 %422
+%1650 = OpCompositeExtract %ushort %1649 4
+OpStore %847 %1650
+%1651 = OpLoad %_arr_ushort_uint_8 %409
+%1652 = OpCompositeExtract %ushort %1651 4
+OpStore %848 %1652
+%1653 = OpLoad %ushort %847
+%1654 = OpLoad %ushort %848
+%1655 = OpIMul %ushort %1653 %1654
+OpStore %849 %1655
+%1656 = OpLoad %_arr_ushort_uint_8 %422
+%1657 = OpCompositeExtract %ushort %1656 5
+OpStore %850 %1657
+%1658 = OpLoad %_arr_ushort_uint_8 %409
+%1659 = OpCompositeExtract %ushort %1658 5
+OpStore %851 %1659
+%1660 = OpLoad %ushort %850
+%1661 = OpLoad %ushort %851
+%1662 = OpIMul %ushort %1660 %1661
+OpStore %852 %1662
+%1663 = OpLoad %_arr_ushort_uint_8 %422
+%1664 = OpCompositeExtract %ushort %1663 6
+OpStore %853 %1664
+%1665 = OpLoad %_arr_ushort_uint_8 %409
+%1666 = OpCompositeExtract %ushort %1665 6
+OpStore %854 %1666
+%1667 = OpLoad %ushort %853
+%1668 = OpLoad %ushort %854
+%1669 = OpIMul %ushort %1667 %1668
+OpStore %855 %1669
+%1670 = OpLoad %_arr_ushort_uint_8 %422
+%1671 = OpCompositeExtract %ushort %1670 7
+OpStore %856 %1671
+%1672 = OpLoad %_arr_ushort_uint_8 %409
+%1673 = OpCompositeExtract %ushort %1672 7
+OpStore %857 %1673
+%1674 = OpLoad %ushort %856
+%1675 = OpLoad %ushort %857
+%1676 = OpIMul %ushort %1674 %1675
+OpStore %858 %1676
+%1677 = OpLoad %_arr_ushort_uint_8 %422
+%1678 = OpLoad %ushort %837
+%1679 = OpCompositeInsert %_arr_ushort_uint_8 %1678 %1677 0
+OpStore %859 %1679
+%1680 = OpLoad %_arr_ushort_uint_8 %859
+%1681 = OpLoad %ushort %840
+%1682 = OpCompositeInsert %_arr_ushort_uint_8 %1681 %1680 1
+OpStore %860 %1682
+%1683 = OpLoad %_arr_ushort_uint_8 %860
+%1684 = OpLoad %ushort %843
+%1685 = OpCompositeInsert %_arr_ushort_uint_8 %1684 %1683 2
+OpStore %861 %1685
+%1686 = OpLoad %_arr_ushort_uint_8 %861
+%1687 = OpLoad %ushort %846
+%1688 = OpCompositeInsert %_arr_ushort_uint_8 %1687 %1686 3
+OpStore %862 %1688
+%1689 = OpLoad %_arr_ushort_uint_8 %862
+%1690 = OpLoad %ushort %849
+%1691 = OpCompositeInsert %_arr_ushort_uint_8 %1690 %1689 4
+OpStore %863 %1691
+%1692 = OpLoad %_arr_ushort_uint_8 %863
+%1693 = OpLoad %ushort %852
+%1694 = OpCompositeInsert %_arr_ushort_uint_8 %1693 %1692 5
+OpStore %864 %1694
+%1695 = OpLoad %_arr_ushort_uint_8 %864
+%1696 = OpLoad %ushort %855
+%1697 = OpCompositeInsert %_arr_ushort_uint_8 %1696 %1695 6
+OpStore %865 %1697
+%1698 = OpLoad %_arr_ushort_uint_8 %865
+%1699 = OpLoad %ushort %858
+%1700 = OpCompositeInsert %_arr_ushort_uint_8 %1699 %1698 7
+OpStore %866 %1700
+%1701 = OpLoad %ulong %429
+%1702 = OpLoad %_arr_ushort_uint_8 %866
+%1703 = OpFunctionCall %ulong %1 %1701 %1702
+OpStore %430 %1703
+%1704 = OpLoad %_arr_ushort_uint_8 %706
+%1705 = OpCompositeExtract %ushort %1704 0
+OpStore %867 %1705
+%1706 = OpLoad %_arr_ushort_uint_8 %409
+%1707 = OpCompositeExtract %ushort %1706 0
+OpStore %868 %1707
+%1708 = OpLoad %ushort %867
+%1709 = OpLoad %ushort %868
+%1710 = OpIMul %ushort %1708 %1709
+OpStore %869 %1710
+%1711 = OpLoad %_arr_ushort_uint_8 %706
+%1712 = OpCompositeExtract %ushort %1711 1
+OpStore %870 %1712
+%1713 = OpLoad %_arr_ushort_uint_8 %409
+%1714 = OpCompositeExtract %ushort %1713 1
+OpStore %871 %1714
+%1715 = OpLoad %ushort %870
+%1716 = OpLoad %ushort %871
+%1717 = OpIMul %ushort %1715 %1716
+OpStore %872 %1717
+%1718 = OpLoad %_arr_ushort_uint_8 %706
+%1719 = OpCompositeExtract %ushort %1718 2
+OpStore %873 %1719
+%1720 = OpLoad %_arr_ushort_uint_8 %409
+%1721 = OpCompositeExtract %ushort %1720 2
+OpStore %874 %1721
+%1722 = OpLoad %ushort %873
+%1723 = OpLoad %ushort %874
+%1724 = OpIMul %ushort %1722 %1723
+OpStore %875 %1724
+%1725 = OpLoad %_arr_ushort_uint_8 %706
+%1726 = OpCompositeExtract %ushort %1725 3
+OpStore %876 %1726
+%1727 = OpLoad %_arr_ushort_uint_8 %409
+%1728 = OpCompositeExtract %ushort %1727 3
+OpStore %877 %1728
+%1729 = OpLoad %ushort %876
+%1730 = OpLoad %ushort %877
+%1731 = OpIMul %ushort %1729 %1730
+OpStore %878 %1731
+%1732 = OpLoad %_arr_ushort_uint_8 %706
+%1733 = OpCompositeExtract %ushort %1732 4
+OpStore %879 %1733
+%1734 = OpLoad %_arr_ushort_uint_8 %409
+%1735 = OpCompositeExtract %ushort %1734 4
+OpStore %880 %1735
+%1736 = OpLoad %ushort %879
+%1737 = OpLoad %ushort %880
+%1738 = OpIMul %ushort %1736 %1737
+OpStore %881 %1738
+%1739 = OpLoad %_arr_ushort_uint_8 %706
+%1740 = OpCompositeExtract %ushort %1739 5
+OpStore %882 %1740
+%1741 = OpLoad %_arr_ushort_uint_8 %409
+%1742 = OpCompositeExtract %ushort %1741 5
+OpStore %883 %1742
+%1743 = OpLoad %ushort %882
+%1744 = OpLoad %ushort %883
+%1745 = OpIMul %ushort %1743 %1744
+OpStore %884 %1745
+%1746 = OpLoad %_arr_ushort_uint_8 %706
+%1747 = OpCompositeExtract %ushort %1746 6
+OpStore %885 %1747
+%1748 = OpLoad %_arr_ushort_uint_8 %409
+%1749 = OpCompositeExtract %ushort %1748 6
+OpStore %886 %1749
+%1750 = OpLoad %ushort %885
+%1751 = OpLoad %ushort %886
+%1752 = OpIMul %ushort %1750 %1751
+OpStore %887 %1752
+%1753 = OpLoad %_arr_ushort_uint_8 %706
+%1754 = OpCompositeExtract %ushort %1753 7
+OpStore %888 %1754
+%1755 = OpLoad %_arr_ushort_uint_8 %409
+%1756 = OpCompositeExtract %ushort %1755 7
+OpStore %889 %1756
+%1757 = OpLoad %ushort %888
+%1758 = OpLoad %ushort %889
+%1759 = OpIMul %ushort %1757 %1758
+OpStore %890 %1759
+%1760 = OpLoad %_arr_ushort_uint_8 %706
+%1761 = OpLoad %ushort %869
+%1762 = OpCompositeInsert %_arr_ushort_uint_8 %1761 %1760 0
+OpStore %891 %1762
+%1763 = OpLoad %_arr_ushort_uint_8 %891
+%1764 = OpLoad %ushort %872
+%1765 = OpCompositeInsert %_arr_ushort_uint_8 %1764 %1763 1
+OpStore %892 %1765
+%1766 = OpLoad %_arr_ushort_uint_8 %892
+%1767 = OpLoad %ushort %875
+%1768 = OpCompositeInsert %_arr_ushort_uint_8 %1767 %1766 2
+OpStore %893 %1768
+%1769 = OpLoad %_arr_ushort_uint_8 %893
+%1770 = OpLoad %ushort %878
+%1771 = OpCompositeInsert %_arr_ushort_uint_8 %1770 %1769 3
+OpStore %894 %1771
+%1772 = OpLoad %_arr_ushort_uint_8 %894
+%1773 = OpLoad %ushort %881
+%1774 = OpCompositeInsert %_arr_ushort_uint_8 %1773 %1772 4
+OpStore %895 %1774
+%1775 = OpLoad %_arr_ushort_uint_8 %895
+%1776 = OpLoad %ushort %884
+%1777 = OpCompositeInsert %_arr_ushort_uint_8 %1776 %1775 5
+OpStore %896 %1777
+%1778 = OpLoad %_arr_ushort_uint_8 %896
+%1779 = OpLoad %ushort %887
+%1780 = OpCompositeInsert %_arr_ushort_uint_8 %1779 %1778 6
+OpStore %897 %1780
+%1781 = OpLoad %_arr_ushort_uint_8 %897
+%1782 = OpLoad %ushort %890
+%1783 = OpCompositeInsert %_arr_ushort_uint_8 %1782 %1781 7
+OpStore %898 %1783
+%1784 = OpLoad %ulong %430
+%1785 = OpLoad %_arr_ushort_uint_8 %898
+%1786 = OpFunctionCall %ulong %1 %1784 %1785
+OpStore %431 %1786
+%1787 = OpLoad %_arr_ushort_uint_8 %410
+%1788 = OpCompositeExtract %ushort %1787 0
+OpStore %899 %1788
+%1789 = OpLoad %_arr_ushort_uint_8 %416
+%1790 = OpCompositeExtract %ushort %1789 0
+OpStore %900 %1790
+%1791 = OpLoad %ushort %899
+%1792 = OpLoad %ushort %900
+%1793 = OpISub %ushort %1791 %1792
+OpStore %901 %1793
+%1794 = OpLoad %_arr_ushort_uint_8 %410
+%1795 = OpCompositeExtract %ushort %1794 1
+OpStore %902 %1795
+%1796 = OpLoad %_arr_ushort_uint_8 %416
+%1797 = OpCompositeExtract %ushort %1796 1
+OpStore %903 %1797
+%1798 = OpLoad %ushort %902
+%1799 = OpLoad %ushort %903
+%1800 = OpISub %ushort %1798 %1799
+OpStore %904 %1800
+%1801 = OpLoad %_arr_ushort_uint_8 %410
+%1802 = OpCompositeExtract %ushort %1801 2
+OpStore %905 %1802
+%1803 = OpLoad %_arr_ushort_uint_8 %416
+%1804 = OpCompositeExtract %ushort %1803 2
+OpStore %906 %1804
+%1805 = OpLoad %ushort %905
+%1806 = OpLoad %ushort %906
+%1807 = OpISub %ushort %1805 %1806
+OpStore %907 %1807
+%1808 = OpLoad %_arr_ushort_uint_8 %410
+%1809 = OpCompositeExtract %ushort %1808 3
+OpStore %908 %1809
+%1810 = OpLoad %_arr_ushort_uint_8 %416
+%1811 = OpCompositeExtract %ushort %1810 3
+OpStore %909 %1811
+%1812 = OpLoad %ushort %908
+%1813 = OpLoad %ushort %909
+%1814 = OpISub %ushort %1812 %1813
+OpStore %910 %1814
+%1815 = OpLoad %_arr_ushort_uint_8 %410
+%1816 = OpCompositeExtract %ushort %1815 4
+OpStore %911 %1816
+%1817 = OpLoad %_arr_ushort_uint_8 %416
+%1818 = OpCompositeExtract %ushort %1817 4
+OpStore %912 %1818
+%1819 = OpLoad %ushort %911
+%1820 = OpLoad %ushort %912
+%1821 = OpISub %ushort %1819 %1820
+OpStore %913 %1821
+%1822 = OpLoad %_arr_ushort_uint_8 %410
+%1823 = OpCompositeExtract %ushort %1822 5
+OpStore %914 %1823
+%1824 = OpLoad %_arr_ushort_uint_8 %416
+%1825 = OpCompositeExtract %ushort %1824 5
+OpStore %915 %1825
+%1826 = OpLoad %ushort %914
+%1827 = OpLoad %ushort %915
+%1828 = OpISub %ushort %1826 %1827
+OpStore %916 %1828
+%1829 = OpLoad %_arr_ushort_uint_8 %410
+%1830 = OpCompositeExtract %ushort %1829 6
+OpStore %917 %1830
+%1831 = OpLoad %_arr_ushort_uint_8 %416
+%1832 = OpCompositeExtract %ushort %1831 6
+OpStore %918 %1832
+%1833 = OpLoad %ushort %917
+%1834 = OpLoad %ushort %918
+%1835 = OpISub %ushort %1833 %1834
+OpStore %919 %1835
+%1836 = OpLoad %_arr_ushort_uint_8 %410
+%1837 = OpCompositeExtract %ushort %1836 7
+OpStore %920 %1837
+%1838 = OpLoad %_arr_ushort_uint_8 %416
+%1839 = OpCompositeExtract %ushort %1838 7
+OpStore %921 %1839
+%1840 = OpLoad %ushort %920
+%1841 = OpLoad %ushort %921
+%1842 = OpISub %ushort %1840 %1841
+OpStore %922 %1842
+%1843 = OpLoad %_arr_ushort_uint_8 %410
+%1844 = OpLoad %ushort %901
+%1845 = OpCompositeInsert %_arr_ushort_uint_8 %1844 %1843 0
+OpStore %923 %1845
+%1846 = OpLoad %_arr_ushort_uint_8 %923
+%1847 = OpLoad %ushort %904
+%1848 = OpCompositeInsert %_arr_ushort_uint_8 %1847 %1846 1
+OpStore %924 %1848
+%1849 = OpLoad %_arr_ushort_uint_8 %924
+%1850 = OpLoad %ushort %907
+%1851 = OpCompositeInsert %_arr_ushort_uint_8 %1850 %1849 2
+OpStore %925 %1851
+%1852 = OpLoad %_arr_ushort_uint_8 %925
+%1853 = OpLoad %ushort %910
+%1854 = OpCompositeInsert %_arr_ushort_uint_8 %1853 %1852 3
+OpStore %926 %1854
+%1855 = OpLoad %_arr_ushort_uint_8 %926
+%1856 = OpLoad %ushort %913
+%1857 = OpCompositeInsert %_arr_ushort_uint_8 %1856 %1855 4
+OpStore %927 %1857
+%1858 = OpLoad %_arr_ushort_uint_8 %927
+%1859 = OpLoad %ushort %916
+%1860 = OpCompositeInsert %_arr_ushort_uint_8 %1859 %1858 5
+OpStore %928 %1860
+%1861 = OpLoad %_arr_ushort_uint_8 %928
+%1862 = OpLoad %ushort %919
+%1863 = OpCompositeInsert %_arr_ushort_uint_8 %1862 %1861 6
+OpStore %929 %1863
+%1864 = OpLoad %_arr_ushort_uint_8 %929
+%1865 = OpLoad %ushort %922
+%1866 = OpCompositeInsert %_arr_ushort_uint_8 %1865 %1864 7
+OpStore %930 %1866
+%1867 = OpLoad %ulong %431
+%1868 = OpLoad %_arr_ushort_uint_8 %930
+%1869 = OpFunctionCall %ulong %1 %1867 %1868
+OpStore %432 %1869
+%1870 = OpLoad %_arr_ushort_uint_8 %410
+%1871 = OpCompositeExtract %ushort %1870 0
+OpStore %931 %1871
+%1872 = OpLoad %_arr_ushort_uint_8 %422
+%1873 = OpCompositeExtract %ushort %1872 0
+OpStore %932 %1873
+%1874 = OpLoad %ushort %931
+%1875 = OpLoad %ushort %932
+%1876 = OpISub %ushort %1874 %1875
+OpStore %933 %1876
+%1877 = OpLoad %_arr_ushort_uint_8 %410
+%1878 = OpCompositeExtract %ushort %1877 1
+OpStore %934 %1878
+%1879 = OpLoad %_arr_ushort_uint_8 %422
+%1880 = OpCompositeExtract %ushort %1879 1
+OpStore %935 %1880
+%1881 = OpLoad %ushort %934
+%1882 = OpLoad %ushort %935
+%1883 = OpISub %ushort %1881 %1882
+OpStore %936 %1883
+%1884 = OpLoad %_arr_ushort_uint_8 %410
+%1885 = OpCompositeExtract %ushort %1884 2
+OpStore %937 %1885
+%1886 = OpLoad %_arr_ushort_uint_8 %422
+%1887 = OpCompositeExtract %ushort %1886 2
+OpStore %938 %1887
+%1888 = OpLoad %ushort %937
+%1889 = OpLoad %ushort %938
+%1890 = OpISub %ushort %1888 %1889
+OpStore %939 %1890
+%1891 = OpLoad %_arr_ushort_uint_8 %410
+%1892 = OpCompositeExtract %ushort %1891 3
+OpStore %940 %1892
+%1893 = OpLoad %_arr_ushort_uint_8 %422
+%1894 = OpCompositeExtract %ushort %1893 3
+OpStore %941 %1894
+%1895 = OpLoad %ushort %940
+%1896 = OpLoad %ushort %941
+%1897 = OpISub %ushort %1895 %1896
+OpStore %942 %1897
+%1898 = OpLoad %_arr_ushort_uint_8 %410
+%1899 = OpCompositeExtract %ushort %1898 4
+OpStore %943 %1899
+%1900 = OpLoad %_arr_ushort_uint_8 %422
+%1901 = OpCompositeExtract %ushort %1900 4
+OpStore %944 %1901
+%1902 = OpLoad %ushort %943
+%1903 = OpLoad %ushort %944
+%1904 = OpISub %ushort %1902 %1903
+OpStore %945 %1904
+%1905 = OpLoad %_arr_ushort_uint_8 %410
+%1906 = OpCompositeExtract %ushort %1905 5
+OpStore %946 %1906
+%1907 = OpLoad %_arr_ushort_uint_8 %422
+%1908 = OpCompositeExtract %ushort %1907 5
+OpStore %947 %1908
+%1909 = OpLoad %ushort %946
+%1910 = OpLoad %ushort %947
+%1911 = OpISub %ushort %1909 %1910
+OpStore %948 %1911
+%1912 = OpLoad %_arr_ushort_uint_8 %410
+%1913 = OpCompositeExtract %ushort %1912 6
+OpStore %949 %1913
+%1914 = OpLoad %_arr_ushort_uint_8 %422
+%1915 = OpCompositeExtract %ushort %1914 6
+OpStore %950 %1915
+%1916 = OpLoad %ushort %949
+%1917 = OpLoad %ushort %950
+%1918 = OpISub %ushort %1916 %1917
+OpStore %951 %1918
+%1919 = OpLoad %_arr_ushort_uint_8 %410
+%1920 = OpCompositeExtract %ushort %1919 7
+OpStore %952 %1920
+%1921 = OpLoad %_arr_ushort_uint_8 %422
+%1922 = OpCompositeExtract %ushort %1921 7
+OpStore %953 %1922
+%1923 = OpLoad %ushort %952
+%1924 = OpLoad %ushort %953
+%1925 = OpISub %ushort %1923 %1924
+OpStore %954 %1925
+%1926 = OpLoad %_arr_ushort_uint_8 %410
+%1927 = OpLoad %ushort %933
+%1928 = OpCompositeInsert %_arr_ushort_uint_8 %1927 %1926 0
+OpStore %955 %1928
+%1929 = OpLoad %_arr_ushort_uint_8 %955
+%1930 = OpLoad %ushort %936
+%1931 = OpCompositeInsert %_arr_ushort_uint_8 %1930 %1929 1
+OpStore %956 %1931
+%1932 = OpLoad %_arr_ushort_uint_8 %956
+%1933 = OpLoad %ushort %939
+%1934 = OpCompositeInsert %_arr_ushort_uint_8 %1933 %1932 2
+OpStore %957 %1934
+%1935 = OpLoad %_arr_ushort_uint_8 %957
+%1936 = OpLoad %ushort %942
+%1937 = OpCompositeInsert %_arr_ushort_uint_8 %1936 %1935 3
+OpStore %958 %1937
+%1938 = OpLoad %_arr_ushort_uint_8 %958
+%1939 = OpLoad %ushort %945
+%1940 = OpCompositeInsert %_arr_ushort_uint_8 %1939 %1938 4
+OpStore %959 %1940
+%1941 = OpLoad %_arr_ushort_uint_8 %959
+%1942 = OpLoad %ushort %948
+%1943 = OpCompositeInsert %_arr_ushort_uint_8 %1942 %1941 5
+OpStore %960 %1943
+%1944 = OpLoad %_arr_ushort_uint_8 %960
+%1945 = OpLoad %ushort %951
+%1946 = OpCompositeInsert %_arr_ushort_uint_8 %1945 %1944 6
+OpStore %961 %1946
+%1947 = OpLoad %_arr_ushort_uint_8 %961
+%1948 = OpLoad %ushort %954
+%1949 = OpCompositeInsert %_arr_ushort_uint_8 %1948 %1947 7
+OpStore %962 %1949
+%1950 = OpLoad %ulong %432
+%1951 = OpLoad %_arr_ushort_uint_8 %962
+%1952 = OpFunctionCall %ulong %1 %1950 %1951
+OpStore %433 %1952
+%1953 = OpLoad %_arr_ushort_uint_8 %416
+%1954 = OpCompositeExtract %ushort %1953 0
+OpStore %963 %1954
+%1955 = OpLoad %_arr_ushort_uint_8 %422
+%1956 = OpCompositeExtract %ushort %1955 0
+OpStore %964 %1956
+%1957 = OpLoad %ushort %963
+%1958 = OpLoad %ushort %964
+%1959 = OpBitwiseAnd %ushort %1957 %1958
+OpStore %965 %1959
+%1960 = OpLoad %_arr_ushort_uint_8 %416
+%1961 = OpCompositeExtract %ushort %1960 1
+OpStore %966 %1961
+%1962 = OpLoad %_arr_ushort_uint_8 %422
+%1963 = OpCompositeExtract %ushort %1962 1
+OpStore %967 %1963
+%1964 = OpLoad %ushort %966
+%1965 = OpLoad %ushort %967
+%1966 = OpBitwiseAnd %ushort %1964 %1965
+OpStore %968 %1966
+%1967 = OpLoad %_arr_ushort_uint_8 %416
+%1968 = OpCompositeExtract %ushort %1967 2
+OpStore %969 %1968
+%1969 = OpLoad %_arr_ushort_uint_8 %422
+%1970 = OpCompositeExtract %ushort %1969 2
+OpStore %970 %1970
+%1971 = OpLoad %ushort %969
+%1972 = OpLoad %ushort %970
+%1973 = OpBitwiseAnd %ushort %1971 %1972
+OpStore %971 %1973
+%1974 = OpLoad %_arr_ushort_uint_8 %416
+%1975 = OpCompositeExtract %ushort %1974 3
+OpStore %972 %1975
+%1976 = OpLoad %_arr_ushort_uint_8 %422
+%1977 = OpCompositeExtract %ushort %1976 3
+OpStore %973 %1977
+%1978 = OpLoad %ushort %972
+%1979 = OpLoad %ushort %973
+%1980 = OpBitwiseAnd %ushort %1978 %1979
+OpStore %974 %1980
+%1981 = OpLoad %_arr_ushort_uint_8 %416
+%1982 = OpCompositeExtract %ushort %1981 4
+OpStore %975 %1982
+%1983 = OpLoad %_arr_ushort_uint_8 %422
+%1984 = OpCompositeExtract %ushort %1983 4
+OpStore %976 %1984
+%1985 = OpLoad %ushort %975
+%1986 = OpLoad %ushort %976
+%1987 = OpBitwiseAnd %ushort %1985 %1986
+OpStore %977 %1987
+%1988 = OpLoad %_arr_ushort_uint_8 %416
+%1989 = OpCompositeExtract %ushort %1988 5
+OpStore %978 %1989
+%1990 = OpLoad %_arr_ushort_uint_8 %422
+%1991 = OpCompositeExtract %ushort %1990 5
+OpStore %979 %1991
+%1992 = OpLoad %ushort %978
+%1993 = OpLoad %ushort %979
+%1994 = OpBitwiseAnd %ushort %1992 %1993
+OpStore %980 %1994
+%1995 = OpLoad %_arr_ushort_uint_8 %416
+%1996 = OpCompositeExtract %ushort %1995 6
+OpStore %981 %1996
+%1997 = OpLoad %_arr_ushort_uint_8 %422
+%1998 = OpCompositeExtract %ushort %1997 6
+OpStore %982 %1998
+%1999 = OpLoad %ushort %981
+%2000 = OpLoad %ushort %982
+%2001 = OpBitwiseAnd %ushort %1999 %2000
+OpStore %983 %2001
+%2002 = OpLoad %_arr_ushort_uint_8 %416
+%2003 = OpCompositeExtract %ushort %2002 7
+OpStore %984 %2003
+%2004 = OpLoad %_arr_ushort_uint_8 %422
+%2005 = OpCompositeExtract %ushort %2004 7
+OpStore %985 %2005
+%2006 = OpLoad %ushort %984
+%2007 = OpLoad %ushort %985
+%2008 = OpBitwiseAnd %ushort %2006 %2007
+OpStore %986 %2008
+%2009 = OpLoad %_arr_ushort_uint_8 %416
+%2010 = OpLoad %ushort %965
+%2011 = OpCompositeInsert %_arr_ushort_uint_8 %2010 %2009 0
+OpStore %987 %2011
+%2012 = OpLoad %_arr_ushort_uint_8 %987
+%2013 = OpLoad %ushort %968
+%2014 = OpCompositeInsert %_arr_ushort_uint_8 %2013 %2012 1
+OpStore %988 %2014
+%2015 = OpLoad %_arr_ushort_uint_8 %988
+%2016 = OpLoad %ushort %971
+%2017 = OpCompositeInsert %_arr_ushort_uint_8 %2016 %2015 2
+OpStore %989 %2017
+%2018 = OpLoad %_arr_ushort_uint_8 %989
+%2019 = OpLoad %ushort %974
+%2020 = OpCompositeInsert %_arr_ushort_uint_8 %2019 %2018 3
+OpStore %990 %2020
+%2021 = OpLoad %_arr_ushort_uint_8 %990
+%2022 = OpLoad %ushort %977
+%2023 = OpCompositeInsert %_arr_ushort_uint_8 %2022 %2021 4
+OpStore %991 %2023
+%2024 = OpLoad %_arr_ushort_uint_8 %991
+%2025 = OpLoad %ushort %980
+%2026 = OpCompositeInsert %_arr_ushort_uint_8 %2025 %2024 5
+OpStore %992 %2026
+%2027 = OpLoad %_arr_ushort_uint_8 %992
+%2028 = OpLoad %ushort %983
+%2029 = OpCompositeInsert %_arr_ushort_uint_8 %2028 %2027 6
+OpStore %993 %2029
+%2030 = OpLoad %_arr_ushort_uint_8 %993
+%2031 = OpLoad %ushort %986
+%2032 = OpCompositeInsert %_arr_ushort_uint_8 %2031 %2030 7
+OpStore %994 %2032
+%2033 = OpLoad %ulong %433
+%2034 = OpLoad %_arr_ushort_uint_8 %994
+%2035 = OpFunctionCall %ulong %1 %2033 %2034
+OpStore %434 %2035
+%2036 = OpLoad %_arr_ushort_uint_8 %416
+%2037 = OpCompositeExtract %ushort %2036 0
+OpStore %995 %2037
+%2038 = OpLoad %_arr_ushort_uint_8 %422
+%2039 = OpCompositeExtract %ushort %2038 0
+OpStore %996 %2039
+%2040 = OpLoad %ushort %995
+%2041 = OpLoad %ushort %996
+%2042 = OpBitwiseOr %ushort %2040 %2041
+OpStore %997 %2042
+%2043 = OpLoad %_arr_ushort_uint_8 %416
+%2044 = OpCompositeExtract %ushort %2043 1
+OpStore %998 %2044
+%2045 = OpLoad %_arr_ushort_uint_8 %422
+%2046 = OpCompositeExtract %ushort %2045 1
+OpStore %999 %2046
+%2047 = OpLoad %ushort %998
+%2048 = OpLoad %ushort %999
+%2049 = OpBitwiseOr %ushort %2047 %2048
+OpStore %1000 %2049
+%2050 = OpLoad %_arr_ushort_uint_8 %416
+%2051 = OpCompositeExtract %ushort %2050 2
+OpStore %1001 %2051
+%2052 = OpLoad %_arr_ushort_uint_8 %422
+%2053 = OpCompositeExtract %ushort %2052 2
+OpStore %1002 %2053
+%2054 = OpLoad %ushort %1001
+%2055 = OpLoad %ushort %1002
+%2056 = OpBitwiseOr %ushort %2054 %2055
+OpStore %1003 %2056
+%2057 = OpLoad %_arr_ushort_uint_8 %416
+%2058 = OpCompositeExtract %ushort %2057 3
+OpStore %1004 %2058
+%2059 = OpLoad %_arr_ushort_uint_8 %422
+%2060 = OpCompositeExtract %ushort %2059 3
+OpStore %1005 %2060
+%2061 = OpLoad %ushort %1004
+%2062 = OpLoad %ushort %1005
+%2063 = OpBitwiseOr %ushort %2061 %2062
+OpStore %1006 %2063
+%2064 = OpLoad %_arr_ushort_uint_8 %416
+%2065 = OpCompositeExtract %ushort %2064 4
+OpStore %1007 %2065
+%2066 = OpLoad %_arr_ushort_uint_8 %422
+%2067 = OpCompositeExtract %ushort %2066 4
+OpStore %1008 %2067
+%2068 = OpLoad %ushort %1007
+%2069 = OpLoad %ushort %1008
+%2070 = OpBitwiseOr %ushort %2068 %2069
+OpStore %1009 %2070
+%2071 = OpLoad %_arr_ushort_uint_8 %416
+%2072 = OpCompositeExtract %ushort %2071 5
+OpStore %1010 %2072
+%2073 = OpLoad %_arr_ushort_uint_8 %422
+%2074 = OpCompositeExtract %ushort %2073 5
+OpStore %1011 %2074
+%2075 = OpLoad %ushort %1010
+%2076 = OpLoad %ushort %1011
+%2077 = OpBitwiseOr %ushort %2075 %2076
+OpStore %1012 %2077
+%2078 = OpLoad %_arr_ushort_uint_8 %416
+%2079 = OpCompositeExtract %ushort %2078 6
+OpStore %1013 %2079
+%2080 = OpLoad %_arr_ushort_uint_8 %422
+%2081 = OpCompositeExtract %ushort %2080 6
+OpStore %1014 %2081
+%2082 = OpLoad %ushort %1013
+%2083 = OpLoad %ushort %1014
+%2084 = OpBitwiseOr %ushort %2082 %2083
+OpStore %1015 %2084
+%2085 = OpLoad %_arr_ushort_uint_8 %416
+%2086 = OpCompositeExtract %ushort %2085 7
+OpStore %1016 %2086
+%2087 = OpLoad %_arr_ushort_uint_8 %422
+%2088 = OpCompositeExtract %ushort %2087 7
+OpStore %1017 %2088
+%2089 = OpLoad %ushort %1016
+%2090 = OpLoad %ushort %1017
+%2091 = OpBitwiseOr %ushort %2089 %2090
+OpStore %1018 %2091
+%2092 = OpLoad %_arr_ushort_uint_8 %416
+%2093 = OpLoad %ushort %997
+%2094 = OpCompositeInsert %_arr_ushort_uint_8 %2093 %2092 0
+OpStore %1019 %2094
+%2095 = OpLoad %_arr_ushort_uint_8 %1019
+%2096 = OpLoad %ushort %1000
+%2097 = OpCompositeInsert %_arr_ushort_uint_8 %2096 %2095 1
+OpStore %1020 %2097
+%2098 = OpLoad %_arr_ushort_uint_8 %1020
+%2099 = OpLoad %ushort %1003
+%2100 = OpCompositeInsert %_arr_ushort_uint_8 %2099 %2098 2
+OpStore %1021 %2100
+%2101 = OpLoad %_arr_ushort_uint_8 %1021
+%2102 = OpLoad %ushort %1006
+%2103 = OpCompositeInsert %_arr_ushort_uint_8 %2102 %2101 3
+OpStore %1022 %2103
+%2104 = OpLoad %_arr_ushort_uint_8 %1022
+%2105 = OpLoad %ushort %1009
+%2106 = OpCompositeInsert %_arr_ushort_uint_8 %2105 %2104 4
+OpStore %1023 %2106
+%2107 = OpLoad %_arr_ushort_uint_8 %1023
+%2108 = OpLoad %ushort %1012
+%2109 = OpCompositeInsert %_arr_ushort_uint_8 %2108 %2107 5
+OpStore %1024 %2109
+%2110 = OpLoad %_arr_ushort_uint_8 %1024
+%2111 = OpLoad %ushort %1015
+%2112 = OpCompositeInsert %_arr_ushort_uint_8 %2111 %2110 6
+OpStore %1025 %2112
+%2113 = OpLoad %_arr_ushort_uint_8 %1025
+%2114 = OpLoad %ushort %1018
+%2115 = OpCompositeInsert %_arr_ushort_uint_8 %2114 %2113 7
+OpStore %1026 %2115
+%2116 = OpLoad %ulong %434
+%2117 = OpLoad %_arr_ushort_uint_8 %1026
+%2118 = OpFunctionCall %ulong %1 %2116 %2117
+OpStore %435 %2118
+%2119 = OpLoad %_arr_ushort_uint_8 %416
+%2120 = OpCompositeExtract %ushort %2119 0
+OpStore %1027 %2120
+%2121 = OpLoad %_arr_ushort_uint_8 %422
+%2122 = OpCompositeExtract %ushort %2121 0
+OpStore %1028 %2122
+%2123 = OpLoad %ushort %1027
+%2124 = OpLoad %ushort %1028
+%2125 = OpBitwiseXor %ushort %2123 %2124
+OpStore %1029 %2125
+%2126 = OpLoad %_arr_ushort_uint_8 %416
+%2127 = OpCompositeExtract %ushort %2126 1
+OpStore %1030 %2127
+%2128 = OpLoad %_arr_ushort_uint_8 %422
+%2129 = OpCompositeExtract %ushort %2128 1
+OpStore %1031 %2129
+%2130 = OpLoad %ushort %1030
+%2131 = OpLoad %ushort %1031
+%2132 = OpBitwiseXor %ushort %2130 %2131
+OpStore %1032 %2132
+%2133 = OpLoad %_arr_ushort_uint_8 %416
+%2134 = OpCompositeExtract %ushort %2133 2
+OpStore %1033 %2134
+%2135 = OpLoad %_arr_ushort_uint_8 %422
+%2136 = OpCompositeExtract %ushort %2135 2
+OpStore %1034 %2136
+%2137 = OpLoad %ushort %1033
+%2138 = OpLoad %ushort %1034
+%2139 = OpBitwiseXor %ushort %2137 %2138
+OpStore %1035 %2139
+%2140 = OpLoad %_arr_ushort_uint_8 %416
+%2141 = OpCompositeExtract %ushort %2140 3
+OpStore %1036 %2141
+%2142 = OpLoad %_arr_ushort_uint_8 %422
+%2143 = OpCompositeExtract %ushort %2142 3
+OpStore %1037 %2143
+%2144 = OpLoad %ushort %1036
+%2145 = OpLoad %ushort %1037
+%2146 = OpBitwiseXor %ushort %2144 %2145
+OpStore %1038 %2146
+%2147 = OpLoad %_arr_ushort_uint_8 %416
+%2148 = OpCompositeExtract %ushort %2147 4
+OpStore %1039 %2148
+%2149 = OpLoad %_arr_ushort_uint_8 %422
+%2150 = OpCompositeExtract %ushort %2149 4
+OpStore %1040 %2150
+%2151 = OpLoad %ushort %1039
+%2152 = OpLoad %ushort %1040
+%2153 = OpBitwiseXor %ushort %2151 %2152
+OpStore %1041 %2153
+%2154 = OpLoad %_arr_ushort_uint_8 %416
+%2155 = OpCompositeExtract %ushort %2154 5
+OpStore %1042 %2155
+%2156 = OpLoad %_arr_ushort_uint_8 %422
+%2157 = OpCompositeExtract %ushort %2156 5
+OpStore %1043 %2157
+%2158 = OpLoad %ushort %1042
+%2159 = OpLoad %ushort %1043
+%2160 = OpBitwiseXor %ushort %2158 %2159
+OpStore %1044 %2160
+%2161 = OpLoad %_arr_ushort_uint_8 %416
+%2162 = OpCompositeExtract %ushort %2161 6
+OpStore %1045 %2162
+%2163 = OpLoad %_arr_ushort_uint_8 %422
+%2164 = OpCompositeExtract %ushort %2163 6
+OpStore %1046 %2164
+%2165 = OpLoad %ushort %1045
+%2166 = OpLoad %ushort %1046
+%2167 = OpBitwiseXor %ushort %2165 %2166
+OpStore %1047 %2167
+%2168 = OpLoad %_arr_ushort_uint_8 %416
+%2169 = OpCompositeExtract %ushort %2168 7
+OpStore %1048 %2169
+%2170 = OpLoad %_arr_ushort_uint_8 %422
+%2171 = OpCompositeExtract %ushort %2170 7
+OpStore %1049 %2171
+%2172 = OpLoad %ushort %1048
+%2173 = OpLoad %ushort %1049
+%2174 = OpBitwiseXor %ushort %2172 %2173
+OpStore %1050 %2174
+%2175 = OpLoad %_arr_ushort_uint_8 %416
+%2176 = OpLoad %ushort %1029
+%2177 = OpCompositeInsert %_arr_ushort_uint_8 %2176 %2175 0
+OpStore %1051 %2177
+%2178 = OpLoad %_arr_ushort_uint_8 %1051
+%2179 = OpLoad %ushort %1032
+%2180 = OpCompositeInsert %_arr_ushort_uint_8 %2179 %2178 1
+OpStore %1052 %2180
+%2181 = OpLoad %_arr_ushort_uint_8 %1052
+%2182 = OpLoad %ushort %1035
+%2183 = OpCompositeInsert %_arr_ushort_uint_8 %2182 %2181 2
+OpStore %1053 %2183
+%2184 = OpLoad %_arr_ushort_uint_8 %1053
+%2185 = OpLoad %ushort %1038
+%2186 = OpCompositeInsert %_arr_ushort_uint_8 %2185 %2184 3
+OpStore %1054 %2186
+%2187 = OpLoad %_arr_ushort_uint_8 %1054
+%2188 = OpLoad %ushort %1041
+%2189 = OpCompositeInsert %_arr_ushort_uint_8 %2188 %2187 4
+OpStore %1055 %2189
+%2190 = OpLoad %_arr_ushort_uint_8 %1055
+%2191 = OpLoad %ushort %1044
+%2192 = OpCompositeInsert %_arr_ushort_uint_8 %2191 %2190 5
+OpStore %1056 %2192
+%2193 = OpLoad %_arr_ushort_uint_8 %1056
+%2194 = OpLoad %ushort %1047
+%2195 = OpCompositeInsert %_arr_ushort_uint_8 %2194 %2193 6
+OpStore %1057 %2195
+%2196 = OpLoad %_arr_ushort_uint_8 %1057
+%2197 = OpLoad %ushort %1050
+%2198 = OpCompositeInsert %_arr_ushort_uint_8 %2197 %2196 7
+OpStore %1058 %2198
+%2199 = OpLoad %ulong %435
+%2200 = OpLoad %_arr_ushort_uint_8 %1058
+%2201 = OpFunctionCall %ulong %1 %2199 %2200
+OpStore %436 %2201
+%2202 = OpLoad %_arr_ushort_uint_8 %416
+%2203 = OpCompositeExtract %ushort %2202 0
+OpStore %1059 %2203
+%2204 = OpLoad %ushort %1059
+%2205 = OpNot %ushort %2204
+OpStore %1060 %2205
+%2206 = OpLoad %_arr_ushort_uint_8 %416
+%2207 = OpCompositeExtract %ushort %2206 1
+OpStore %1061 %2207
+%2208 = OpLoad %ushort %1061
+%2209 = OpNot %ushort %2208
+OpStore %1062 %2209
+%2210 = OpLoad %_arr_ushort_uint_8 %416
+%2211 = OpCompositeExtract %ushort %2210 2
+OpStore %1063 %2211
+%2212 = OpLoad %ushort %1063
+%2213 = OpNot %ushort %2212
+OpStore %1064 %2213
+%2214 = OpLoad %_arr_ushort_uint_8 %416
+%2215 = OpCompositeExtract %ushort %2214 3
+OpStore %1065 %2215
+%2216 = OpLoad %ushort %1065
+%2217 = OpNot %ushort %2216
+OpStore %1066 %2217
+%2218 = OpLoad %_arr_ushort_uint_8 %416
+%2219 = OpCompositeExtract %ushort %2218 4
+OpStore %1067 %2219
+%2220 = OpLoad %ushort %1067
+%2221 = OpNot %ushort %2220
+OpStore %1068 %2221
+%2222 = OpLoad %_arr_ushort_uint_8 %416
+%2223 = OpCompositeExtract %ushort %2222 5
+OpStore %1069 %2223
+%2224 = OpLoad %ushort %1069
+%2225 = OpNot %ushort %2224
+OpStore %1070 %2225
+%2226 = OpLoad %_arr_ushort_uint_8 %416
+%2227 = OpCompositeExtract %ushort %2226 6
+OpStore %1071 %2227
+%2228 = OpLoad %ushort %1071
+%2229 = OpNot %ushort %2228
+OpStore %1072 %2229
+%2230 = OpLoad %_arr_ushort_uint_8 %416
+%2231 = OpCompositeExtract %ushort %2230 7
+OpStore %1073 %2231
+%2232 = OpLoad %ushort %1073
+%2233 = OpNot %ushort %2232
+OpStore %1074 %2233
+%2234 = OpLoad %_arr_ushort_uint_8 %416
+%2235 = OpLoad %ushort %1060
+%2236 = OpCompositeInsert %_arr_ushort_uint_8 %2235 %2234 0
+OpStore %1075 %2236
+%2237 = OpLoad %_arr_ushort_uint_8 %1075
+%2238 = OpLoad %ushort %1062
+%2239 = OpCompositeInsert %_arr_ushort_uint_8 %2238 %2237 1
+OpStore %1076 %2239
+%2240 = OpLoad %_arr_ushort_uint_8 %1076
+%2241 = OpLoad %ushort %1064
+%2242 = OpCompositeInsert %_arr_ushort_uint_8 %2241 %2240 2
+OpStore %1077 %2242
+%2243 = OpLoad %_arr_ushort_uint_8 %1077
+%2244 = OpLoad %ushort %1066
+%2245 = OpCompositeInsert %_arr_ushort_uint_8 %2244 %2243 3
+OpStore %1078 %2245
+%2246 = OpLoad %_arr_ushort_uint_8 %1078
+%2247 = OpLoad %ushort %1068
+%2248 = OpCompositeInsert %_arr_ushort_uint_8 %2247 %2246 4
+OpStore %1079 %2248
+%2249 = OpLoad %_arr_ushort_uint_8 %1079
+%2250 = OpLoad %ushort %1070
+%2251 = OpCompositeInsert %_arr_ushort_uint_8 %2250 %2249 5
+OpStore %1080 %2251
+%2252 = OpLoad %_arr_ushort_uint_8 %1080
+%2253 = OpLoad %ushort %1072
+%2254 = OpCompositeInsert %_arr_ushort_uint_8 %2253 %2252 6
+OpStore %1081 %2254
+%2255 = OpLoad %_arr_ushort_uint_8 %1081
+%2256 = OpLoad %ushort %1074
+%2257 = OpCompositeInsert %_arr_ushort_uint_8 %2256 %2255 7
+OpStore %1082 %2257
+%2258 = OpLoad %ulong %436
+%2259 = OpLoad %_arr_ushort_uint_8 %1082
+%2260 = OpFunctionCall %ulong %1 %2258 %2259
+OpStore %437 %2260
+%2261 = OpLoad %_arr_ushort_uint_8 %422
+%2262 = OpCompositeExtract %ushort %2261 0
+OpStore %1083 %2262
+%2263 = OpLoad %ushort %1083
+%2264 = OpNot %ushort %2263
+OpStore %1084 %2264
+%2265 = OpLoad %_arr_ushort_uint_8 %422
 %2266 = OpCompositeExtract %ushort %2265 1
-OpStore %416 %2266
-%2267 = OpLoad %ulong %415
-%2268 = OpLoad %ushort %416
-%2269 = OpFunctionCall %ulong %5 %2267 %2268
-OpStore %417 %2269
-%2270 = OpLoad %_arr_ushort_uint_8 %909
-%2271 = OpCompositeExtract %ushort %2270 2
-OpStore %418 %2271
-%2272 = OpLoad %ulong %417
-%2273 = OpLoad %ushort %418
-%2274 = OpFunctionCall %ulong %5 %2272 %2273
-OpStore %419 %2274
-%2275 = OpLoad %_arr_ushort_uint_8 %909
-%2276 = OpCompositeExtract %ushort %2275 3
-OpStore %420 %2276
-%2277 = OpLoad %ulong %419
-%2278 = OpLoad %ushort %420
-%2279 = OpFunctionCall %ulong %5 %2277 %2278
-OpStore %421 %2279
-%2280 = OpLoad %_arr_ushort_uint_8 %909
-%2281 = OpCompositeExtract %ushort %2280 4
-OpStore %422 %2281
-%2282 = OpLoad %ulong %421
-%2283 = OpLoad %ushort %422
-%2284 = OpFunctionCall %ulong %5 %2282 %2283
-OpStore %423 %2284
-%2285 = OpLoad %_arr_ushort_uint_8 %909
-%2286 = OpCompositeExtract %ushort %2285 5
-OpStore %424 %2286
-%2287 = OpLoad %ulong %423
-%2288 = OpLoad %ushort %424
-%2289 = OpFunctionCall %ulong %5 %2287 %2288
-OpStore %425 %2289
-%2290 = OpLoad %_arr_ushort_uint_8 %909
-%2291 = OpCompositeExtract %ushort %2290 6
-OpStore %426 %2291
-%2292 = OpLoad %ulong %425
-%2293 = OpLoad %ushort %426
-%2294 = OpFunctionCall %ulong %5 %2292 %2293
-OpStore %427 %2294
-%2295 = OpLoad %_arr_ushort_uint_8 %909
-%2296 = OpCompositeExtract %ushort %2295 7
-OpStore %428 %2296
-%2297 = OpLoad %ulong %427
-%2298 = OpLoad %ushort %428
-%2299 = OpFunctionCall %ulong %5 %2297 %2298
-OpStore %429 %2299
-OpBranch %117
-%117 = OpLabel
-%2300 = OpLoad %_arr_ushort_uint_8 %134
-%2301 = OpCompositeExtract %ushort %2300 0
-OpStore %910 %2301
-%2302 = OpLoad %_arr_ushort_uint_8 %146
-%2303 = OpCompositeExtract %ushort %2302 0
-OpStore %911 %2303
-%2304 = OpLoad %ushort %910
-%2305 = OpLoad %ushort %911
-%2306 = OpISub %ushort %2304 %2305
-OpStore %912 %2306
-%2307 = OpLoad %_arr_ushort_uint_8 %134
-%2308 = OpCompositeExtract %ushort %2307 1
-OpStore %913 %2308
-%2309 = OpLoad %_arr_ushort_uint_8 %146
-%2310 = OpCompositeExtract %ushort %2309 1
-OpStore %914 %2310
-%2311 = OpLoad %ushort %913
-%2312 = OpLoad %ushort %914
-%2313 = OpISub %ushort %2311 %2312
-OpStore %915 %2313
-%2314 = OpLoad %_arr_ushort_uint_8 %134
-%2315 = OpCompositeExtract %ushort %2314 2
-OpStore %916 %2315
-%2316 = OpLoad %_arr_ushort_uint_8 %146
-%2317 = OpCompositeExtract %ushort %2316 2
-OpStore %917 %2317
-%2318 = OpLoad %ushort %916
-%2319 = OpLoad %ushort %917
-%2320 = OpISub %ushort %2318 %2319
-OpStore %918 %2320
-%2321 = OpLoad %_arr_ushort_uint_8 %134
-%2322 = OpCompositeExtract %ushort %2321 3
-OpStore %919 %2322
-%2323 = OpLoad %_arr_ushort_uint_8 %146
-%2324 = OpCompositeExtract %ushort %2323 3
-OpStore %920 %2324
-%2325 = OpLoad %ushort %919
-%2326 = OpLoad %ushort %920
-%2327 = OpISub %ushort %2325 %2326
-OpStore %921 %2327
-%2328 = OpLoad %_arr_ushort_uint_8 %134
-%2329 = OpCompositeExtract %ushort %2328 4
-OpStore %922 %2329
-%2330 = OpLoad %_arr_ushort_uint_8 %146
-%2331 = OpCompositeExtract %ushort %2330 4
-OpStore %923 %2331
-%2332 = OpLoad %ushort %922
-%2333 = OpLoad %ushort %923
-%2334 = OpISub %ushort %2332 %2333
-OpStore %924 %2334
-%2335 = OpLoad %_arr_ushort_uint_8 %134
-%2336 = OpCompositeExtract %ushort %2335 5
-OpStore %925 %2336
-%2337 = OpLoad %_arr_ushort_uint_8 %146
-%2338 = OpCompositeExtract %ushort %2337 5
-OpStore %926 %2338
-%2339 = OpLoad %ushort %925
-%2340 = OpLoad %ushort %926
-%2341 = OpISub %ushort %2339 %2340
-OpStore %927 %2341
-%2342 = OpLoad %_arr_ushort_uint_8 %134
-%2343 = OpCompositeExtract %ushort %2342 6
-OpStore %928 %2343
-%2344 = OpLoad %_arr_ushort_uint_8 %146
-%2345 = OpCompositeExtract %ushort %2344 6
-OpStore %929 %2345
-%2346 = OpLoad %ushort %928
-%2347 = OpLoad %ushort %929
-%2348 = OpISub %ushort %2346 %2347
-OpStore %930 %2348
-%2349 = OpLoad %_arr_ushort_uint_8 %134
-%2350 = OpCompositeExtract %ushort %2349 7
-OpStore %931 %2350
-%2351 = OpLoad %_arr_ushort_uint_8 %146
-%2352 = OpCompositeExtract %ushort %2351 7
-OpStore %932 %2352
-%2353 = OpLoad %ushort %931
-%2354 = OpLoad %ushort %932
-%2355 = OpISub %ushort %2353 %2354
-OpStore %933 %2355
-%2356 = OpLoad %_arr_ushort_uint_8 %134
-%2357 = OpLoad %ushort %912
-%2358 = OpCompositeInsert %_arr_ushort_uint_8 %2357 %2356 0
-OpStore %934 %2358
-%2359 = OpLoad %_arr_ushort_uint_8 %934
-%2360 = OpLoad %ushort %915
-%2361 = OpCompositeInsert %_arr_ushort_uint_8 %2360 %2359 1
-OpStore %935 %2361
-%2362 = OpLoad %_arr_ushort_uint_8 %935
-%2363 = OpLoad %ushort %918
-%2364 = OpCompositeInsert %_arr_ushort_uint_8 %2363 %2362 2
-OpStore %936 %2364
-%2365 = OpLoad %_arr_ushort_uint_8 %936
-%2366 = OpLoad %ushort %921
-%2367 = OpCompositeInsert %_arr_ushort_uint_8 %2366 %2365 3
-OpStore %937 %2367
-%2368 = OpLoad %_arr_ushort_uint_8 %937
-%2369 = OpLoad %ushort %924
-%2370 = OpCompositeInsert %_arr_ushort_uint_8 %2369 %2368 4
-OpStore %938 %2370
-%2371 = OpLoad %_arr_ushort_uint_8 %938
-%2372 = OpLoad %ushort %927
-%2373 = OpCompositeInsert %_arr_ushort_uint_8 %2372 %2371 5
-OpStore %939 %2373
-%2374 = OpLoad %_arr_ushort_uint_8 %939
-%2375 = OpLoad %ushort %930
-%2376 = OpCompositeInsert %_arr_ushort_uint_8 %2375 %2374 6
-OpStore %940 %2376
-%2377 = OpLoad %_arr_ushort_uint_8 %940
-%2378 = OpLoad %ushort %933
-%2379 = OpCompositeInsert %_arr_ushort_uint_8 %2378 %2377 7
-OpStore %941 %2379
-%2380 = OpLoad %ulong %429
-%2381 = OpLoad %_arr_ushort_uint_8 %941
-%2382 = OpFunctionCall %ulong %1 %2380 %2381
-OpStore %147 %2382
-%2383 = OpLoad %_arr_ushort_uint_8 %140
-%2384 = OpCompositeExtract %ushort %2383 0
-OpStore %942 %2384
-%2385 = OpLoad %_arr_ushort_uint_8 %146
-%2386 = OpCompositeExtract %ushort %2385 0
-OpStore %943 %2386
-%2387 = OpLoad %ushort %942
-%2388 = OpLoad %ushort %943
-%2389 = OpBitwiseAnd %ushort %2387 %2388
-OpStore %944 %2389
-%2390 = OpLoad %_arr_ushort_uint_8 %140
-%2391 = OpCompositeExtract %ushort %2390 1
-OpStore %945 %2391
-%2392 = OpLoad %_arr_ushort_uint_8 %146
-%2393 = OpCompositeExtract %ushort %2392 1
-OpStore %946 %2393
-%2394 = OpLoad %ushort %945
-%2395 = OpLoad %ushort %946
-%2396 = OpBitwiseAnd %ushort %2394 %2395
-OpStore %947 %2396
-%2397 = OpLoad %_arr_ushort_uint_8 %140
-%2398 = OpCompositeExtract %ushort %2397 2
-OpStore %948 %2398
-%2399 = OpLoad %_arr_ushort_uint_8 %146
-%2400 = OpCompositeExtract %ushort %2399 2
-OpStore %949 %2400
-%2401 = OpLoad %ushort %948
-%2402 = OpLoad %ushort %949
-%2403 = OpBitwiseAnd %ushort %2401 %2402
-OpStore %950 %2403
-%2404 = OpLoad %_arr_ushort_uint_8 %140
-%2405 = OpCompositeExtract %ushort %2404 3
-OpStore %951 %2405
-%2406 = OpLoad %_arr_ushort_uint_8 %146
-%2407 = OpCompositeExtract %ushort %2406 3
-OpStore %952 %2407
-%2408 = OpLoad %ushort %951
-%2409 = OpLoad %ushort %952
-%2410 = OpBitwiseAnd %ushort %2408 %2409
-OpStore %953 %2410
-%2411 = OpLoad %_arr_ushort_uint_8 %140
-%2412 = OpCompositeExtract %ushort %2411 4
-OpStore %954 %2412
-%2413 = OpLoad %_arr_ushort_uint_8 %146
-%2414 = OpCompositeExtract %ushort %2413 4
-OpStore %955 %2414
-%2415 = OpLoad %ushort %954
-%2416 = OpLoad %ushort %955
-%2417 = OpBitwiseAnd %ushort %2415 %2416
-OpStore %956 %2417
-%2418 = OpLoad %_arr_ushort_uint_8 %140
-%2419 = OpCompositeExtract %ushort %2418 5
-OpStore %957 %2419
-%2420 = OpLoad %_arr_ushort_uint_8 %146
-%2421 = OpCompositeExtract %ushort %2420 5
-OpStore %958 %2421
-%2422 = OpLoad %ushort %957
-%2423 = OpLoad %ushort %958
-%2424 = OpBitwiseAnd %ushort %2422 %2423
-OpStore %959 %2424
-%2425 = OpLoad %_arr_ushort_uint_8 %140
-%2426 = OpCompositeExtract %ushort %2425 6
-OpStore %960 %2426
-%2427 = OpLoad %_arr_ushort_uint_8 %146
-%2428 = OpCompositeExtract %ushort %2427 6
-OpStore %961 %2428
-%2429 = OpLoad %ushort %960
-%2430 = OpLoad %ushort %961
-%2431 = OpBitwiseAnd %ushort %2429 %2430
-OpStore %962 %2431
-%2432 = OpLoad %_arr_ushort_uint_8 %140
-%2433 = OpCompositeExtract %ushort %2432 7
-OpStore %963 %2433
-%2434 = OpLoad %_arr_ushort_uint_8 %146
-%2435 = OpCompositeExtract %ushort %2434 7
-OpStore %964 %2435
-%2436 = OpLoad %ushort %963
-%2437 = OpLoad %ushort %964
-%2438 = OpBitwiseAnd %ushort %2436 %2437
-OpStore %965 %2438
-%2439 = OpLoad %_arr_ushort_uint_8 %140
-%2440 = OpLoad %ushort %944
-%2441 = OpCompositeInsert %_arr_ushort_uint_8 %2440 %2439 0
-OpStore %966 %2441
-%2442 = OpLoad %_arr_ushort_uint_8 %966
-%2443 = OpLoad %ushort %947
-%2444 = OpCompositeInsert %_arr_ushort_uint_8 %2443 %2442 1
-OpStore %967 %2444
-%2445 = OpLoad %_arr_ushort_uint_8 %967
-%2446 = OpLoad %ushort %950
-%2447 = OpCompositeInsert %_arr_ushort_uint_8 %2446 %2445 2
-OpStore %968 %2447
-%2448 = OpLoad %_arr_ushort_uint_8 %968
-%2449 = OpLoad %ushort %953
-%2450 = OpCompositeInsert %_arr_ushort_uint_8 %2449 %2448 3
-OpStore %969 %2450
-%2451 = OpLoad %_arr_ushort_uint_8 %969
-%2452 = OpLoad %ushort %956
-%2453 = OpCompositeInsert %_arr_ushort_uint_8 %2452 %2451 4
-OpStore %970 %2453
-%2454 = OpLoad %_arr_ushort_uint_8 %970
-%2455 = OpLoad %ushort %959
-%2456 = OpCompositeInsert %_arr_ushort_uint_8 %2455 %2454 5
-OpStore %971 %2456
-%2457 = OpLoad %_arr_ushort_uint_8 %971
-%2458 = OpLoad %ushort %962
-%2459 = OpCompositeInsert %_arr_ushort_uint_8 %2458 %2457 6
-OpStore %972 %2459
-%2460 = OpLoad %_arr_ushort_uint_8 %972
-%2461 = OpLoad %ushort %965
-%2462 = OpCompositeInsert %_arr_ushort_uint_8 %2461 %2460 7
-OpStore %973 %2462
-%2463 = OpLoad %ulong %147
-%2464 = OpLoad %_arr_ushort_uint_8 %973
-%2465 = OpFunctionCall %ulong %1 %2463 %2464
-OpStore %148 %2465
-%2466 = OpLoad %_arr_ushort_uint_8 %140
-%2467 = OpCompositeExtract %ushort %2466 0
-OpStore %974 %2467
-%2468 = OpLoad %_arr_ushort_uint_8 %146
-%2469 = OpCompositeExtract %ushort %2468 0
-OpStore %975 %2469
-%2470 = OpLoad %ushort %974
-%2471 = OpLoad %ushort %975
-%2472 = OpBitwiseOr %ushort %2470 %2471
-OpStore %976 %2472
-%2473 = OpLoad %_arr_ushort_uint_8 %140
-%2474 = OpCompositeExtract %ushort %2473 1
-OpStore %977 %2474
-%2475 = OpLoad %_arr_ushort_uint_8 %146
-%2476 = OpCompositeExtract %ushort %2475 1
-OpStore %978 %2476
-%2477 = OpLoad %ushort %977
-%2478 = OpLoad %ushort %978
-%2479 = OpBitwiseOr %ushort %2477 %2478
-OpStore %979 %2479
-%2480 = OpLoad %_arr_ushort_uint_8 %140
-%2481 = OpCompositeExtract %ushort %2480 2
-OpStore %980 %2481
-%2482 = OpLoad %_arr_ushort_uint_8 %146
-%2483 = OpCompositeExtract %ushort %2482 2
-OpStore %981 %2483
-%2484 = OpLoad %ushort %980
-%2485 = OpLoad %ushort %981
-%2486 = OpBitwiseOr %ushort %2484 %2485
-OpStore %982 %2486
-%2487 = OpLoad %_arr_ushort_uint_8 %140
-%2488 = OpCompositeExtract %ushort %2487 3
-OpStore %983 %2488
-%2489 = OpLoad %_arr_ushort_uint_8 %146
-%2490 = OpCompositeExtract %ushort %2489 3
-OpStore %984 %2490
-%2491 = OpLoad %ushort %983
-%2492 = OpLoad %ushort %984
-%2493 = OpBitwiseOr %ushort %2491 %2492
-OpStore %985 %2493
-%2494 = OpLoad %_arr_ushort_uint_8 %140
-%2495 = OpCompositeExtract %ushort %2494 4
-OpStore %986 %2495
-%2496 = OpLoad %_arr_ushort_uint_8 %146
-%2497 = OpCompositeExtract %ushort %2496 4
-OpStore %987 %2497
-%2498 = OpLoad %ushort %986
-%2499 = OpLoad %ushort %987
-%2500 = OpBitwiseOr %ushort %2498 %2499
-OpStore %988 %2500
-%2501 = OpLoad %_arr_ushort_uint_8 %140
-%2502 = OpCompositeExtract %ushort %2501 5
-OpStore %989 %2502
-%2503 = OpLoad %_arr_ushort_uint_8 %146
-%2504 = OpCompositeExtract %ushort %2503 5
-OpStore %990 %2504
-%2505 = OpLoad %ushort %989
-%2506 = OpLoad %ushort %990
-%2507 = OpBitwiseOr %ushort %2505 %2506
-OpStore %991 %2507
-%2508 = OpLoad %_arr_ushort_uint_8 %140
-%2509 = OpCompositeExtract %ushort %2508 6
-OpStore %992 %2509
-%2510 = OpLoad %_arr_ushort_uint_8 %146
-%2511 = OpCompositeExtract %ushort %2510 6
-OpStore %993 %2511
-%2512 = OpLoad %ushort %992
-%2513 = OpLoad %ushort %993
-%2514 = OpBitwiseOr %ushort %2512 %2513
-OpStore %994 %2514
-%2515 = OpLoad %_arr_ushort_uint_8 %140
-%2516 = OpCompositeExtract %ushort %2515 7
-OpStore %995 %2516
-%2517 = OpLoad %_arr_ushort_uint_8 %146
-%2518 = OpCompositeExtract %ushort %2517 7
-OpStore %996 %2518
-%2519 = OpLoad %ushort %995
-%2520 = OpLoad %ushort %996
-%2521 = OpBitwiseOr %ushort %2519 %2520
-OpStore %997 %2521
-%2522 = OpLoad %_arr_ushort_uint_8 %140
-%2523 = OpLoad %ushort %976
-%2524 = OpCompositeInsert %_arr_ushort_uint_8 %2523 %2522 0
-OpStore %998 %2524
-%2525 = OpLoad %_arr_ushort_uint_8 %998
-%2526 = OpLoad %ushort %979
-%2527 = OpCompositeInsert %_arr_ushort_uint_8 %2526 %2525 1
-OpStore %999 %2527
-%2528 = OpLoad %_arr_ushort_uint_8 %999
-%2529 = OpLoad %ushort %982
-%2530 = OpCompositeInsert %_arr_ushort_uint_8 %2529 %2528 2
-OpStore %1000 %2530
-%2531 = OpLoad %_arr_ushort_uint_8 %1000
-%2532 = OpLoad %ushort %985
-%2533 = OpCompositeInsert %_arr_ushort_uint_8 %2532 %2531 3
-OpStore %1001 %2533
-%2534 = OpLoad %_arr_ushort_uint_8 %1001
-%2535 = OpLoad %ushort %988
-%2536 = OpCompositeInsert %_arr_ushort_uint_8 %2535 %2534 4
-OpStore %1002 %2536
-%2537 = OpLoad %_arr_ushort_uint_8 %1002
-%2538 = OpLoad %ushort %991
-%2539 = OpCompositeInsert %_arr_ushort_uint_8 %2538 %2537 5
-OpStore %1003 %2539
-%2540 = OpLoad %_arr_ushort_uint_8 %1003
-%2541 = OpLoad %ushort %994
-%2542 = OpCompositeInsert %_arr_ushort_uint_8 %2541 %2540 6
-OpStore %1004 %2542
-%2543 = OpLoad %_arr_ushort_uint_8 %1004
-%2544 = OpLoad %ushort %997
-%2545 = OpCompositeInsert %_arr_ushort_uint_8 %2544 %2543 7
-OpStore %1005 %2545
-%2546 = OpLoad %ulong %148
-%2547 = OpLoad %_arr_ushort_uint_8 %1005
-%2548 = OpFunctionCall %ulong %1 %2546 %2547
-OpStore %149 %2548
-%2549 = OpLoad %_arr_ushort_uint_8 %140
-%2550 = OpCompositeExtract %ushort %2549 0
-OpStore %1006 %2550
-%2551 = OpLoad %_arr_ushort_uint_8 %146
-%2552 = OpCompositeExtract %ushort %2551 0
-OpStore %1007 %2552
-%2553 = OpLoad %ushort %1006
-%2554 = OpLoad %ushort %1007
-%2555 = OpBitwiseXor %ushort %2553 %2554
-OpStore %1008 %2555
-%2556 = OpLoad %_arr_ushort_uint_8 %140
-%2557 = OpCompositeExtract %ushort %2556 1
-OpStore %1009 %2557
-%2558 = OpLoad %_arr_ushort_uint_8 %146
-%2559 = OpCompositeExtract %ushort %2558 1
-OpStore %1010 %2559
-%2560 = OpLoad %ushort %1009
-%2561 = OpLoad %ushort %1010
-%2562 = OpBitwiseXor %ushort %2560 %2561
-OpStore %1011 %2562
-%2563 = OpLoad %_arr_ushort_uint_8 %140
-%2564 = OpCompositeExtract %ushort %2563 2
-OpStore %1012 %2564
-%2565 = OpLoad %_arr_ushort_uint_8 %146
-%2566 = OpCompositeExtract %ushort %2565 2
-OpStore %1013 %2566
-%2567 = OpLoad %ushort %1012
-%2568 = OpLoad %ushort %1013
-%2569 = OpBitwiseXor %ushort %2567 %2568
-OpStore %1014 %2569
-%2570 = OpLoad %_arr_ushort_uint_8 %140
-%2571 = OpCompositeExtract %ushort %2570 3
-OpStore %1015 %2571
-%2572 = OpLoad %_arr_ushort_uint_8 %146
-%2573 = OpCompositeExtract %ushort %2572 3
-OpStore %1016 %2573
-%2574 = OpLoad %ushort %1015
-%2575 = OpLoad %ushort %1016
-%2576 = OpBitwiseXor %ushort %2574 %2575
-OpStore %1017 %2576
-%2577 = OpLoad %_arr_ushort_uint_8 %140
-%2578 = OpCompositeExtract %ushort %2577 4
-OpStore %1018 %2578
-%2579 = OpLoad %_arr_ushort_uint_8 %146
-%2580 = OpCompositeExtract %ushort %2579 4
-OpStore %1019 %2580
-%2581 = OpLoad %ushort %1018
-%2582 = OpLoad %ushort %1019
-%2583 = OpBitwiseXor %ushort %2581 %2582
-OpStore %1020 %2583
-%2584 = OpLoad %_arr_ushort_uint_8 %140
-%2585 = OpCompositeExtract %ushort %2584 5
-OpStore %1021 %2585
-%2586 = OpLoad %_arr_ushort_uint_8 %146
-%2587 = OpCompositeExtract %ushort %2586 5
-OpStore %1022 %2587
-%2588 = OpLoad %ushort %1021
-%2589 = OpLoad %ushort %1022
-%2590 = OpBitwiseXor %ushort %2588 %2589
-OpStore %1023 %2590
-%2591 = OpLoad %_arr_ushort_uint_8 %140
-%2592 = OpCompositeExtract %ushort %2591 6
-OpStore %1024 %2592
-%2593 = OpLoad %_arr_ushort_uint_8 %146
-%2594 = OpCompositeExtract %ushort %2593 6
-OpStore %1025 %2594
-%2595 = OpLoad %ushort %1024
-%2596 = OpLoad %ushort %1025
-%2597 = OpBitwiseXor %ushort %2595 %2596
-OpStore %1026 %2597
-%2598 = OpLoad %_arr_ushort_uint_8 %140
-%2599 = OpCompositeExtract %ushort %2598 7
-OpStore %1027 %2599
-%2600 = OpLoad %_arr_ushort_uint_8 %146
-%2601 = OpCompositeExtract %ushort %2600 7
-OpStore %1028 %2601
-%2602 = OpLoad %ushort %1027
-%2603 = OpLoad %ushort %1028
-%2604 = OpBitwiseXor %ushort %2602 %2603
-OpStore %1029 %2604
-%2605 = OpLoad %_arr_ushort_uint_8 %140
-%2606 = OpLoad %ushort %1008
-%2607 = OpCompositeInsert %_arr_ushort_uint_8 %2606 %2605 0
-OpStore %1030 %2607
-%2608 = OpLoad %_arr_ushort_uint_8 %1030
-%2609 = OpLoad %ushort %1011
-%2610 = OpCompositeInsert %_arr_ushort_uint_8 %2609 %2608 1
-OpStore %1031 %2610
-%2611 = OpLoad %_arr_ushort_uint_8 %1031
-%2612 = OpLoad %ushort %1014
-%2613 = OpCompositeInsert %_arr_ushort_uint_8 %2612 %2611 2
-OpStore %1032 %2613
-%2614 = OpLoad %_arr_ushort_uint_8 %1032
-%2615 = OpLoad %ushort %1017
-%2616 = OpCompositeInsert %_arr_ushort_uint_8 %2615 %2614 3
-OpStore %1033 %2616
-%2617 = OpLoad %_arr_ushort_uint_8 %1033
-%2618 = OpLoad %ushort %1020
-%2619 = OpCompositeInsert %_arr_ushort_uint_8 %2618 %2617 4
-OpStore %1034 %2619
-%2620 = OpLoad %_arr_ushort_uint_8 %1034
-%2621 = OpLoad %ushort %1023
-%2622 = OpCompositeInsert %_arr_ushort_uint_8 %2621 %2620 5
-OpStore %1035 %2622
-%2623 = OpLoad %_arr_ushort_uint_8 %1035
-%2624 = OpLoad %ushort %1026
-%2625 = OpCompositeInsert %_arr_ushort_uint_8 %2624 %2623 6
-OpStore %1036 %2625
-%2626 = OpLoad %_arr_ushort_uint_8 %1036
-%2627 = OpLoad %ushort %1029
-%2628 = OpCompositeInsert %_arr_ushort_uint_8 %2627 %2626 7
-OpStore %1037 %2628
-%2629 = OpLoad %ulong %149
-%2630 = OpLoad %_arr_ushort_uint_8 %1037
-%2631 = OpFunctionCall %ulong %1 %2629 %2630
-OpStore %150 %2631
-%2632 = OpLoad %_arr_ushort_uint_8 %140
-%2633 = OpCompositeExtract %ushort %2632 0
-OpStore %1038 %2633
-%2634 = OpLoad %ushort %1038
-%2635 = OpNot %ushort %2634
-OpStore %1039 %2635
-%2636 = OpLoad %_arr_ushort_uint_8 %140
-%2637 = OpCompositeExtract %ushort %2636 1
-OpStore %1040 %2637
-%2638 = OpLoad %ushort %1040
-%2639 = OpNot %ushort %2638
-OpStore %1041 %2639
-%2640 = OpLoad %_arr_ushort_uint_8 %140
-%2641 = OpCompositeExtract %ushort %2640 2
-OpStore %1042 %2641
-%2642 = OpLoad %ushort %1042
-%2643 = OpNot %ushort %2642
-OpStore %1043 %2643
-%2644 = OpLoad %_arr_ushort_uint_8 %140
-%2645 = OpCompositeExtract %ushort %2644 3
-OpStore %1044 %2645
-%2646 = OpLoad %ushort %1044
-%2647 = OpNot %ushort %2646
-OpStore %1045 %2647
-%2648 = OpLoad %_arr_ushort_uint_8 %140
-%2649 = OpCompositeExtract %ushort %2648 4
-OpStore %1046 %2649
-%2650 = OpLoad %ushort %1046
-%2651 = OpNot %ushort %2650
-OpStore %1047 %2651
-%2652 = OpLoad %_arr_ushort_uint_8 %140
-%2653 = OpCompositeExtract %ushort %2652 5
-OpStore %1048 %2653
-%2654 = OpLoad %ushort %1048
-%2655 = OpNot %ushort %2654
-OpStore %1049 %2655
-%2656 = OpLoad %_arr_ushort_uint_8 %140
-%2657 = OpCompositeExtract %ushort %2656 6
-OpStore %1050 %2657
-%2658 = OpLoad %ushort %1050
-%2659 = OpNot %ushort %2658
-OpStore %1051 %2659
-%2660 = OpLoad %_arr_ushort_uint_8 %140
-%2661 = OpCompositeExtract %ushort %2660 7
-OpStore %1052 %2661
-%2662 = OpLoad %ushort %1052
-%2663 = OpNot %ushort %2662
-OpStore %1053 %2663
-%2664 = OpLoad %_arr_ushort_uint_8 %140
-%2665 = OpLoad %ushort %1039
-%2666 = OpCompositeInsert %_arr_ushort_uint_8 %2665 %2664 0
-OpStore %1054 %2666
-%2667 = OpLoad %_arr_ushort_uint_8 %1054
-%2668 = OpLoad %ushort %1041
-%2669 = OpCompositeInsert %_arr_ushort_uint_8 %2668 %2667 1
-OpStore %1055 %2669
-%2670 = OpLoad %_arr_ushort_uint_8 %1055
-%2671 = OpLoad %ushort %1043
-%2672 = OpCompositeInsert %_arr_ushort_uint_8 %2671 %2670 2
-OpStore %1056 %2672
-%2673 = OpLoad %_arr_ushort_uint_8 %1056
-%2674 = OpLoad %ushort %1045
-%2675 = OpCompositeInsert %_arr_ushort_uint_8 %2674 %2673 3
-OpStore %1057 %2675
-%2676 = OpLoad %_arr_ushort_uint_8 %1057
-%2677 = OpLoad %ushort %1047
-%2678 = OpCompositeInsert %_arr_ushort_uint_8 %2677 %2676 4
-OpStore %1058 %2678
-%2679 = OpLoad %_arr_ushort_uint_8 %1058
-%2680 = OpLoad %ushort %1049
-%2681 = OpCompositeInsert %_arr_ushort_uint_8 %2680 %2679 5
-OpStore %1059 %2681
-%2682 = OpLoad %_arr_ushort_uint_8 %1059
-%2683 = OpLoad %ushort %1051
-%2684 = OpCompositeInsert %_arr_ushort_uint_8 %2683 %2682 6
-OpStore %1060 %2684
-%2685 = OpLoad %_arr_ushort_uint_8 %1060
-%2686 = OpLoad %ushort %1053
-%2687 = OpCompositeInsert %_arr_ushort_uint_8 %2686 %2685 7
-OpStore %1061 %2687
-%2688 = OpLoad %ulong %150
-%2689 = OpLoad %_arr_ushort_uint_8 %1061
-%2690 = OpFunctionCall %ulong %1 %2688 %2689
-OpStore %151 %2690
-%2691 = OpLoad %_arr_ushort_uint_8 %146
-%2692 = OpCompositeExtract %ushort %2691 0
-OpStore %1062 %2692
-%2693 = OpLoad %ushort %1062
-%2694 = OpNot %ushort %2693
-OpStore %1063 %2694
-%2695 = OpLoad %_arr_ushort_uint_8 %146
-%2696 = OpCompositeExtract %ushort %2695 1
-OpStore %1064 %2696
-%2697 = OpLoad %ushort %1064
-%2698 = OpNot %ushort %2697
-OpStore %1065 %2698
-%2699 = OpLoad %_arr_ushort_uint_8 %146
-%2700 = OpCompositeExtract %ushort %2699 2
-OpStore %1066 %2700
-%2701 = OpLoad %ushort %1066
-%2702 = OpNot %ushort %2701
-OpStore %1067 %2702
-%2703 = OpLoad %_arr_ushort_uint_8 %146
-%2704 = OpCompositeExtract %ushort %2703 3
-OpStore %1068 %2704
-%2705 = OpLoad %ushort %1068
-%2706 = OpNot %ushort %2705
-OpStore %1069 %2706
-%2707 = OpLoad %_arr_ushort_uint_8 %146
-%2708 = OpCompositeExtract %ushort %2707 4
-OpStore %1070 %2708
-%2709 = OpLoad %ushort %1070
-%2710 = OpNot %ushort %2709
-OpStore %1071 %2710
-%2711 = OpLoad %_arr_ushort_uint_8 %146
-%2712 = OpCompositeExtract %ushort %2711 5
-OpStore %1072 %2712
-%2713 = OpLoad %ushort %1072
-%2714 = OpNot %ushort %2713
-OpStore %1073 %2714
-%2715 = OpLoad %_arr_ushort_uint_8 %146
-%2716 = OpCompositeExtract %ushort %2715 6
-OpStore %1074 %2716
-%2717 = OpLoad %ushort %1074
-%2718 = OpNot %ushort %2717
-OpStore %1075 %2718
-%2719 = OpLoad %_arr_ushort_uint_8 %146
-%2720 = OpCompositeExtract %ushort %2719 7
-OpStore %1076 %2720
-%2721 = OpLoad %ushort %1076
-%2722 = OpNot %ushort %2721
-OpStore %1077 %2722
-%2723 = OpLoad %_arr_ushort_uint_8 %146
-%2724 = OpLoad %ushort %1063
-%2725 = OpCompositeInsert %_arr_ushort_uint_8 %2724 %2723 0
-OpStore %1078 %2725
-%2726 = OpLoad %_arr_ushort_uint_8 %1078
-%2727 = OpLoad %ushort %1065
-%2728 = OpCompositeInsert %_arr_ushort_uint_8 %2727 %2726 1
-OpStore %1079 %2728
-%2729 = OpLoad %_arr_ushort_uint_8 %1079
-%2730 = OpLoad %ushort %1067
-%2731 = OpCompositeInsert %_arr_ushort_uint_8 %2730 %2729 2
-OpStore %1080 %2731
-%2732 = OpLoad %_arr_ushort_uint_8 %1080
-%2733 = OpLoad %ushort %1069
-%2734 = OpCompositeInsert %_arr_ushort_uint_8 %2733 %2732 3
-OpStore %1081 %2734
-%2735 = OpLoad %_arr_ushort_uint_8 %1081
-%2736 = OpLoad %ushort %1071
-%2737 = OpCompositeInsert %_arr_ushort_uint_8 %2736 %2735 4
-OpStore %1082 %2737
-%2738 = OpLoad %_arr_ushort_uint_8 %1082
-%2739 = OpLoad %ushort %1073
-%2740 = OpCompositeInsert %_arr_ushort_uint_8 %2739 %2738 5
-OpStore %1083 %2740
-%2741 = OpLoad %_arr_ushort_uint_8 %1083
-%2742 = OpLoad %ushort %1075
-%2743 = OpCompositeInsert %_arr_ushort_uint_8 %2742 %2741 6
-OpStore %1084 %2743
-%2744 = OpLoad %_arr_ushort_uint_8 %1084
-%2745 = OpLoad %ushort %1077
-%2746 = OpCompositeInsert %_arr_ushort_uint_8 %2745 %2744 7
-OpStore %1085 %2746
-%2747 = OpLoad %ulong %151
-%2748 = OpLoad %_arr_ushort_uint_8 %1085
-%2749 = OpFunctionCall %ulong %1 %2747 %2748
-OpStore %152 %2749
-%2750 = OpLoad %_arr_ushort_uint_8 %973
-%2751 = OpCompositeExtract %ushort %2750 0
-OpStore %1086 %2751
-%2752 = OpLoad %_arr_ushort_uint_8 %1005
-%2753 = OpCompositeExtract %ushort %2752 0
-OpStore %1087 %2753
-%2754 = OpLoad %ushort %1086
-%2755 = OpLoad %ushort %1087
-%2756 = OpBitwiseXor %ushort %2754 %2755
-OpStore %1088 %2756
-%2757 = OpLoad %_arr_ushort_uint_8 %973
-%2758 = OpCompositeExtract %ushort %2757 1
-OpStore %1089 %2758
-%2759 = OpLoad %_arr_ushort_uint_8 %1005
-%2760 = OpCompositeExtract %ushort %2759 1
-OpStore %1090 %2760
-%2761 = OpLoad %ushort %1089
-%2762 = OpLoad %ushort %1090
-%2763 = OpBitwiseXor %ushort %2761 %2762
-OpStore %1091 %2763
-%2764 = OpLoad %_arr_ushort_uint_8 %973
-%2765 = OpCompositeExtract %ushort %2764 2
-OpStore %1092 %2765
-%2766 = OpLoad %_arr_ushort_uint_8 %1005
-%2767 = OpCompositeExtract %ushort %2766 2
-OpStore %1093 %2767
-%2768 = OpLoad %ushort %1092
-%2769 = OpLoad %ushort %1093
-%2770 = OpBitwiseXor %ushort %2768 %2769
-OpStore %1094 %2770
-%2771 = OpLoad %_arr_ushort_uint_8 %973
-%2772 = OpCompositeExtract %ushort %2771 3
-OpStore %1095 %2772
-%2773 = OpLoad %_arr_ushort_uint_8 %1005
-%2774 = OpCompositeExtract %ushort %2773 3
-OpStore %1096 %2774
-%2775 = OpLoad %ushort %1095
-%2776 = OpLoad %ushort %1096
-%2777 = OpBitwiseXor %ushort %2775 %2776
-OpStore %1097 %2777
-%2778 = OpLoad %_arr_ushort_uint_8 %973
-%2779 = OpCompositeExtract %ushort %2778 4
-OpStore %1098 %2779
-%2780 = OpLoad %_arr_ushort_uint_8 %1005
-%2781 = OpCompositeExtract %ushort %2780 4
-OpStore %1099 %2781
-%2782 = OpLoad %ushort %1098
-%2783 = OpLoad %ushort %1099
-%2784 = OpBitwiseXor %ushort %2782 %2783
-OpStore %1100 %2784
-%2785 = OpLoad %_arr_ushort_uint_8 %973
-%2786 = OpCompositeExtract %ushort %2785 5
-OpStore %1101 %2786
-%2787 = OpLoad %_arr_ushort_uint_8 %1005
-%2788 = OpCompositeExtract %ushort %2787 5
-OpStore %1102 %2788
-%2789 = OpLoad %ushort %1101
-%2790 = OpLoad %ushort %1102
-%2791 = OpBitwiseXor %ushort %2789 %2790
-OpStore %1103 %2791
-%2792 = OpLoad %_arr_ushort_uint_8 %973
-%2793 = OpCompositeExtract %ushort %2792 6
-OpStore %1104 %2793
-%2794 = OpLoad %_arr_ushort_uint_8 %1005
-%2795 = OpCompositeExtract %ushort %2794 6
-OpStore %1105 %2795
-%2796 = OpLoad %ushort %1104
-%2797 = OpLoad %ushort %1105
-%2798 = OpBitwiseXor %ushort %2796 %2797
-OpStore %1106 %2798
-%2799 = OpLoad %_arr_ushort_uint_8 %973
-%2800 = OpCompositeExtract %ushort %2799 7
-OpStore %1107 %2800
-%2801 = OpLoad %_arr_ushort_uint_8 %1005
-%2802 = OpCompositeExtract %ushort %2801 7
-OpStore %1108 %2802
-%2803 = OpLoad %ushort %1107
-%2804 = OpLoad %ushort %1108
-%2805 = OpBitwiseXor %ushort %2803 %2804
-OpStore %1109 %2805
-%2806 = OpLoad %_arr_ushort_uint_8 %973
-%2807 = OpLoad %ushort %1088
-%2808 = OpCompositeInsert %_arr_ushort_uint_8 %2807 %2806 0
-OpStore %1110 %2808
-%2809 = OpLoad %_arr_ushort_uint_8 %1110
-%2810 = OpLoad %ushort %1091
-%2811 = OpCompositeInsert %_arr_ushort_uint_8 %2810 %2809 1
-OpStore %1111 %2811
-%2812 = OpLoad %_arr_ushort_uint_8 %1111
-%2813 = OpLoad %ushort %1094
-%2814 = OpCompositeInsert %_arr_ushort_uint_8 %2813 %2812 2
-OpStore %1112 %2814
-%2815 = OpLoad %_arr_ushort_uint_8 %1112
-%2816 = OpLoad %ushort %1097
-%2817 = OpCompositeInsert %_arr_ushort_uint_8 %2816 %2815 3
-OpStore %1113 %2817
-%2818 = OpLoad %_arr_ushort_uint_8 %1113
-%2819 = OpLoad %ushort %1100
-%2820 = OpCompositeInsert %_arr_ushort_uint_8 %2819 %2818 4
-OpStore %1114 %2820
-%2821 = OpLoad %_arr_ushort_uint_8 %1114
-%2822 = OpLoad %ushort %1103
-%2823 = OpCompositeInsert %_arr_ushort_uint_8 %2822 %2821 5
-OpStore %1115 %2823
-%2824 = OpLoad %_arr_ushort_uint_8 %1115
-%2825 = OpLoad %ushort %1106
-%2826 = OpCompositeInsert %_arr_ushort_uint_8 %2825 %2824 6
-OpStore %1116 %2826
-%2827 = OpLoad %_arr_ushort_uint_8 %1116
-%2828 = OpLoad %ushort %1109
-%2829 = OpCompositeInsert %_arr_ushort_uint_8 %2828 %2827 7
-OpStore %1117 %2829
-%2830 = OpLoad %ulong %152
-%2831 = OpLoad %_arr_ushort_uint_8 %1117
-%2832 = OpFunctionCall %ulong %1 %2830 %2831
-OpStore %153 %2832
-%2833 = OpLoad %ulong %153
-OpStore %168 %2833
-%2834 = OpLoad %_arr_ushort_uint_8 %140
-OpStore %169 %2834
-%2835 = OpLoad %_arr_ushort_uint_8 %134
-OpStore %170 %2835
-%2836 = OpLoad %_arr_ushort_uint_8 %134
-OpStore %171 %2836
-OpStore %172 %ulong_0
-OpBranch %80
-%80 = OpLabel
-%2838 = OpLoad %ulong %172
-%2840 = OpULessThan %bool %2838 %ulong_6
-OpStore %155 %2840
-%2841 = OpLoad %bool %155
-OpLoopMerge %82 %119 None
-OpBranchConditional %2841 %81 %82
-%82 = OpLabel
-OpStore %124 %2842
-%2844 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_0
-%2845 = OpLoad %_arr_ushort_uint_8 %169
-OpStore %2844 %2845
-%2846 = OpLoad %_arr_ushort_uint_8 %169
-%2847 = OpCompositeExtract %ushort %2846 0
-OpStore %462 %2847
-%2848 = OpLoad %_arr_ushort_uint_8 %146
-%2849 = OpCompositeExtract %ushort %2848 0
-OpStore %463 %2849
-%2850 = OpLoad %ushort %462
-%2851 = OpLoad %ushort %463
-%2852 = OpIAdd %ushort %2850 %2851
-OpStore %464 %2852
-%2853 = OpLoad %_arr_ushort_uint_8 %169
-%2854 = OpCompositeExtract %ushort %2853 1
-OpStore %465 %2854
-%2855 = OpLoad %_arr_ushort_uint_8 %146
-%2856 = OpCompositeExtract %ushort %2855 1
-OpStore %466 %2856
-%2857 = OpLoad %ushort %465
-%2858 = OpLoad %ushort %466
-%2859 = OpIAdd %ushort %2857 %2858
-OpStore %467 %2859
-%2860 = OpLoad %_arr_ushort_uint_8 %169
-%2861 = OpCompositeExtract %ushort %2860 2
-OpStore %468 %2861
-%2862 = OpLoad %_arr_ushort_uint_8 %146
-%2863 = OpCompositeExtract %ushort %2862 2
-OpStore %469 %2863
-%2864 = OpLoad %ushort %468
-%2865 = OpLoad %ushort %469
-%2866 = OpIAdd %ushort %2864 %2865
-OpStore %470 %2866
-%2867 = OpLoad %_arr_ushort_uint_8 %169
-%2868 = OpCompositeExtract %ushort %2867 3
-OpStore %471 %2868
-%2869 = OpLoad %_arr_ushort_uint_8 %146
-%2870 = OpCompositeExtract %ushort %2869 3
-OpStore %472 %2870
-%2871 = OpLoad %ushort %471
-%2872 = OpLoad %ushort %472
-%2873 = OpIAdd %ushort %2871 %2872
-OpStore %473 %2873
-%2874 = OpLoad %_arr_ushort_uint_8 %169
-%2875 = OpCompositeExtract %ushort %2874 4
-OpStore %474 %2875
-%2876 = OpLoad %_arr_ushort_uint_8 %146
-%2877 = OpCompositeExtract %ushort %2876 4
-OpStore %475 %2877
-%2878 = OpLoad %ushort %474
-%2879 = OpLoad %ushort %475
-%2880 = OpIAdd %ushort %2878 %2879
-OpStore %476 %2880
-%2881 = OpLoad %_arr_ushort_uint_8 %169
-%2882 = OpCompositeExtract %ushort %2881 5
-OpStore %477 %2882
-%2883 = OpLoad %_arr_ushort_uint_8 %146
-%2884 = OpCompositeExtract %ushort %2883 5
-OpStore %478 %2884
-%2885 = OpLoad %ushort %477
-%2886 = OpLoad %ushort %478
-%2887 = OpIAdd %ushort %2885 %2886
-OpStore %479 %2887
-%2888 = OpLoad %_arr_ushort_uint_8 %169
-%2889 = OpCompositeExtract %ushort %2888 6
-OpStore %480 %2889
-%2890 = OpLoad %_arr_ushort_uint_8 %146
-%2891 = OpCompositeExtract %ushort %2890 6
-OpStore %481 %2891
-%2892 = OpLoad %ushort %480
-%2893 = OpLoad %ushort %481
-%2894 = OpIAdd %ushort %2892 %2893
-OpStore %482 %2894
-%2895 = OpLoad %_arr_ushort_uint_8 %169
-%2896 = OpCompositeExtract %ushort %2895 7
-OpStore %483 %2896
-%2897 = OpLoad %_arr_ushort_uint_8 %146
-%2898 = OpCompositeExtract %ushort %2897 7
-OpStore %484 %2898
-%2899 = OpLoad %ushort %483
-%2900 = OpLoad %ushort %484
-%2901 = OpIAdd %ushort %2899 %2900
-OpStore %485 %2901
-%2902 = OpLoad %_arr_ushort_uint_8 %169
-%2903 = OpLoad %ushort %464
-%2904 = OpCompositeInsert %_arr_ushort_uint_8 %2903 %2902 0
-OpStore %486 %2904
-%2905 = OpLoad %_arr_ushort_uint_8 %486
-%2906 = OpLoad %ushort %467
-%2907 = OpCompositeInsert %_arr_ushort_uint_8 %2906 %2905 1
-OpStore %487 %2907
-%2908 = OpLoad %_arr_ushort_uint_8 %487
-%2909 = OpLoad %ushort %470
-%2910 = OpCompositeInsert %_arr_ushort_uint_8 %2909 %2908 2
-OpStore %488 %2910
-%2911 = OpLoad %_arr_ushort_uint_8 %488
-%2912 = OpLoad %ushort %473
-%2913 = OpCompositeInsert %_arr_ushort_uint_8 %2912 %2911 3
-OpStore %489 %2913
-%2914 = OpLoad %_arr_ushort_uint_8 %489
-%2915 = OpLoad %ushort %476
-%2916 = OpCompositeInsert %_arr_ushort_uint_8 %2915 %2914 4
-OpStore %490 %2916
-%2917 = OpLoad %_arr_ushort_uint_8 %490
-%2918 = OpLoad %ushort %479
-%2919 = OpCompositeInsert %_arr_ushort_uint_8 %2918 %2917 5
-OpStore %491 %2919
-%2920 = OpLoad %_arr_ushort_uint_8 %491
-%2921 = OpLoad %ushort %482
-%2922 = OpCompositeInsert %_arr_ushort_uint_8 %2921 %2920 6
-OpStore %492 %2922
-%2923 = OpLoad %_arr_ushort_uint_8 %492
-%2924 = OpLoad %ushort %485
-%2925 = OpCompositeInsert %_arr_ushort_uint_8 %2924 %2923 7
-OpStore %493 %2925
-%2927 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_1
-%2928 = OpLoad %_arr_ushort_uint_8 %493
-OpStore %2927 %2928
-%2929 = OpLoad %_arr_ushort_uint_8 %169
-%2930 = OpCompositeExtract %ushort %2929 0
-OpStore %494 %2930
-%2931 = OpLoad %_arr_ushort_uint_8 %133
-%2932 = OpCompositeExtract %ushort %2931 0
-OpStore %495 %2932
-%2933 = OpLoad %ushort %494
-%2934 = OpLoad %ushort %495
-%2935 = OpIMul %ushort %2933 %2934
-OpStore %496 %2935
-%2936 = OpLoad %_arr_ushort_uint_8 %169
-%2937 = OpCompositeExtract %ushort %2936 1
-OpStore %497 %2937
-%2938 = OpLoad %_arr_ushort_uint_8 %133
-%2939 = OpCompositeExtract %ushort %2938 1
-OpStore %498 %2939
-%2940 = OpLoad %ushort %497
-%2941 = OpLoad %ushort %498
-%2942 = OpIMul %ushort %2940 %2941
-OpStore %499 %2942
-%2943 = OpLoad %_arr_ushort_uint_8 %169
-%2944 = OpCompositeExtract %ushort %2943 2
-OpStore %500 %2944
-%2945 = OpLoad %_arr_ushort_uint_8 %133
-%2946 = OpCompositeExtract %ushort %2945 2
-OpStore %501 %2946
-%2947 = OpLoad %ushort %500
-%2948 = OpLoad %ushort %501
-%2949 = OpIMul %ushort %2947 %2948
-OpStore %502 %2949
-%2950 = OpLoad %_arr_ushort_uint_8 %169
-%2951 = OpCompositeExtract %ushort %2950 3
-OpStore %503 %2951
-%2952 = OpLoad %_arr_ushort_uint_8 %133
-%2953 = OpCompositeExtract %ushort %2952 3
-OpStore %504 %2953
-%2954 = OpLoad %ushort %503
-%2955 = OpLoad %ushort %504
-%2956 = OpIMul %ushort %2954 %2955
-OpStore %505 %2956
-%2957 = OpLoad %_arr_ushort_uint_8 %169
-%2958 = OpCompositeExtract %ushort %2957 4
-OpStore %506 %2958
-%2959 = OpLoad %_arr_ushort_uint_8 %133
-%2960 = OpCompositeExtract %ushort %2959 4
-OpStore %507 %2960
-%2961 = OpLoad %ushort %506
-%2962 = OpLoad %ushort %507
-%2963 = OpIMul %ushort %2961 %2962
-OpStore %508 %2963
-%2964 = OpLoad %_arr_ushort_uint_8 %169
-%2965 = OpCompositeExtract %ushort %2964 5
-OpStore %509 %2965
-%2966 = OpLoad %_arr_ushort_uint_8 %133
-%2967 = OpCompositeExtract %ushort %2966 5
-OpStore %510 %2967
-%2968 = OpLoad %ushort %509
-%2969 = OpLoad %ushort %510
-%2970 = OpIMul %ushort %2968 %2969
-OpStore %511 %2970
-%2971 = OpLoad %_arr_ushort_uint_8 %169
-%2972 = OpCompositeExtract %ushort %2971 6
-OpStore %512 %2972
-%2973 = OpLoad %_arr_ushort_uint_8 %133
-%2974 = OpCompositeExtract %ushort %2973 6
-OpStore %513 %2974
-%2975 = OpLoad %ushort %512
-%2976 = OpLoad %ushort %513
-%2977 = OpIMul %ushort %2975 %2976
-OpStore %514 %2977
-%2978 = OpLoad %_arr_ushort_uint_8 %169
-%2979 = OpCompositeExtract %ushort %2978 7
-OpStore %515 %2979
-%2980 = OpLoad %_arr_ushort_uint_8 %133
-%2981 = OpCompositeExtract %ushort %2980 7
-OpStore %516 %2981
-%2982 = OpLoad %ushort %515
-%2983 = OpLoad %ushort %516
-%2984 = OpIMul %ushort %2982 %2983
-OpStore %517 %2984
-%2985 = OpLoad %_arr_ushort_uint_8 %169
-%2986 = OpLoad %ushort %496
-%2987 = OpCompositeInsert %_arr_ushort_uint_8 %2986 %2985 0
-OpStore %518 %2987
-%2988 = OpLoad %_arr_ushort_uint_8 %518
-%2989 = OpLoad %ushort %499
-%2990 = OpCompositeInsert %_arr_ushort_uint_8 %2989 %2988 1
-OpStore %519 %2990
-%2991 = OpLoad %_arr_ushort_uint_8 %519
-%2992 = OpLoad %ushort %502
-%2993 = OpCompositeInsert %_arr_ushort_uint_8 %2992 %2991 2
-OpStore %520 %2993
-%2994 = OpLoad %_arr_ushort_uint_8 %520
-%2995 = OpLoad %ushort %505
-%2996 = OpCompositeInsert %_arr_ushort_uint_8 %2995 %2994 3
-OpStore %521 %2996
-%2997 = OpLoad %_arr_ushort_uint_8 %521
-%2998 = OpLoad %ushort %508
-%2999 = OpCompositeInsert %_arr_ushort_uint_8 %2998 %2997 4
-OpStore %522 %2999
-%3000 = OpLoad %_arr_ushort_uint_8 %522
-%3001 = OpLoad %ushort %511
-%3002 = OpCompositeInsert %_arr_ushort_uint_8 %3001 %3000 5
-OpStore %523 %3002
-%3003 = OpLoad %_arr_ushort_uint_8 %523
-%3004 = OpLoad %ushort %514
-%3005 = OpCompositeInsert %_arr_ushort_uint_8 %3004 %3003 6
-OpStore %524 %3005
-%3006 = OpLoad %_arr_ushort_uint_8 %524
-%3007 = OpLoad %ushort %517
-%3008 = OpCompositeInsert %_arr_ushort_uint_8 %3007 %3006 7
-OpStore %525 %3008
-%3010 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_2
-%3011 = OpLoad %_arr_ushort_uint_8 %525
-OpStore %3010 %3011
-%3013 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_3
-%3014 = OpLoad %_arr_ushort_uint_8 %170
-OpStore %3013 %3014
-%3015 = OpLoad %ulong %168
-OpStore %167 %3015
-OpStore %173 %ulong_0
-OpBranch %83
-%83 = OpLabel
-%3016 = OpLoad %ulong %173
-%3018 = OpULessThan %bool %3016 %ulong_4
-OpStore %157 %3018
-%3019 = OpLoad %bool %157
-OpLoopMerge %85 %118 None
-OpBranchConditional %3019 %84 %85
-%85 = OpLabel
-OpStore %127 %3020
-%3021 = OpAccessChain %_ptr_Function_uint %127 %uint_0
-OpStore %3021 %uint_4294967295
-%3023 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_2
-%3024 = OpLoad %_arr_ushort_uint_8 %3023
-OpStore %160 %3024
-%3025 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %127 %uint_1
-%3026 = OpLoad %_arr_ushort_uint_8 %160
-OpStore %3025 %3026
-%3027 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-OpStore %3027 %uint_305419896
-%3029 = OpLoad %uint %3021
-OpStore %162 %3029
-%3030 = OpLoad %ulong %167
-%3031 = OpLoad %uint %162
-%3032 = OpFunctionCall %ulong %4 %3030 %3031
-OpStore %163 %3032
-%3033 = OpLoad %_arr_ushort_uint_8 %3025
-OpStore %164 %3033
-OpBranch %92
-%92 = OpLabel
-%3034 = OpLoad %_arr_ushort_uint_8 %164
-%3035 = OpCompositeExtract %ushort %3034 0
-OpStore %222 %3035
-%3036 = OpLoad %ulong %163
-%3037 = OpLoad %ushort %222
-%3038 = OpFunctionCall %ulong %5 %3036 %3037
-OpStore %223 %3038
-%3039 = OpLoad %_arr_ushort_uint_8 %164
-%3040 = OpCompositeExtract %ushort %3039 1
-OpStore %224 %3040
-%3041 = OpLoad %ulong %223
-%3042 = OpLoad %ushort %224
-%3043 = OpFunctionCall %ulong %5 %3041 %3042
-OpStore %225 %3043
-%3044 = OpLoad %_arr_ushort_uint_8 %164
-%3045 = OpCompositeExtract %ushort %3044 2
-OpStore %226 %3045
-%3046 = OpLoad %ulong %225
-%3047 = OpLoad %ushort %226
-%3048 = OpFunctionCall %ulong %5 %3046 %3047
-OpStore %227 %3048
-%3049 = OpLoad %_arr_ushort_uint_8 %164
-%3050 = OpCompositeExtract %ushort %3049 3
-OpStore %228 %3050
-%3051 = OpLoad %ulong %227
-%3052 = OpLoad %ushort %228
-%3053 = OpFunctionCall %ulong %5 %3051 %3052
-OpStore %229 %3053
-%3054 = OpLoad %_arr_ushort_uint_8 %164
-%3055 = OpCompositeExtract %ushort %3054 4
-OpStore %230 %3055
-%3056 = OpLoad %ulong %229
-%3057 = OpLoad %ushort %230
-%3058 = OpFunctionCall %ulong %5 %3056 %3057
-OpStore %231 %3058
-%3059 = OpLoad %_arr_ushort_uint_8 %164
-%3060 = OpCompositeExtract %ushort %3059 5
-OpStore %232 %3060
-%3061 = OpLoad %ulong %231
-%3062 = OpLoad %ushort %232
-%3063 = OpFunctionCall %ulong %5 %3061 %3062
-OpStore %233 %3063
-%3064 = OpLoad %_arr_ushort_uint_8 %164
-%3065 = OpCompositeExtract %ushort %3064 6
-OpStore %234 %3065
-%3066 = OpLoad %ulong %233
-%3067 = OpLoad %ushort %234
-%3068 = OpFunctionCall %ulong %5 %3066 %3067
-OpStore %235 %3068
-%3069 = OpLoad %_arr_ushort_uint_8 %164
-%3070 = OpCompositeExtract %ushort %3069 7
-OpStore %236 %3070
-%3071 = OpLoad %ulong %235
-%3072 = OpLoad %ushort %236
-%3073 = OpFunctionCall %ulong %5 %3071 %3072
-OpStore %237 %3073
-OpBranch %93
-%93 = OpLabel
-%3074 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-%3075 = OpLoad %uint %3074
-OpStore %165 %3075
-%3076 = OpLoad %ulong %237
-%3077 = OpLoad %uint %165
-%3078 = OpFunctionCall %ulong %4 %3076 %3077
-OpStore %166 %3078
-%3079 = OpLoad %ulong %166
-OpReturnValue %3079
-%84 = OpLabel
-%3080 = OpLoad %ulong %173
-%3081 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %3080
-%3082 = OpLoad %_arr_ushort_uint_8 %3081
-OpStore %158 %3082
-OpBranch %90
-%90 = OpLabel
-%3083 = OpLoad %_arr_ushort_uint_8 %158
-%3084 = OpCompositeExtract %ushort %3083 0
-OpStore %206 %3084
-%3085 = OpLoad %ulong %167
-%3086 = OpLoad %ushort %206
-%3087 = OpFunctionCall %ulong %5 %3085 %3086
-OpStore %207 %3087
-%3088 = OpLoad %_arr_ushort_uint_8 %158
-%3089 = OpCompositeExtract %ushort %3088 1
-OpStore %208 %3089
-%3090 = OpLoad %ulong %207
-%3091 = OpLoad %ushort %208
-%3092 = OpFunctionCall %ulong %5 %3090 %3091
-OpStore %209 %3092
-%3093 = OpLoad %_arr_ushort_uint_8 %158
-%3094 = OpCompositeExtract %ushort %3093 2
-OpStore %210 %3094
-%3095 = OpLoad %ulong %209
-%3096 = OpLoad %ushort %210
-%3097 = OpFunctionCall %ulong %5 %3095 %3096
-OpStore %211 %3097
-%3098 = OpLoad %_arr_ushort_uint_8 %158
-%3099 = OpCompositeExtract %ushort %3098 3
-OpStore %212 %3099
-%3100 = OpLoad %ulong %211
-%3101 = OpLoad %ushort %212
-%3102 = OpFunctionCall %ulong %5 %3100 %3101
-OpStore %213 %3102
-%3103 = OpLoad %_arr_ushort_uint_8 %158
-%3104 = OpCompositeExtract %ushort %3103 4
-OpStore %214 %3104
-%3105 = OpLoad %ulong %213
-%3106 = OpLoad %ushort %214
-%3107 = OpFunctionCall %ulong %5 %3105 %3106
-OpStore %215 %3107
-%3108 = OpLoad %_arr_ushort_uint_8 %158
-%3109 = OpCompositeExtract %ushort %3108 5
-OpStore %216 %3109
-%3110 = OpLoad %ulong %215
-%3111 = OpLoad %ushort %216
-%3112 = OpFunctionCall %ulong %5 %3110 %3111
-OpStore %217 %3112
-%3113 = OpLoad %_arr_ushort_uint_8 %158
-%3114 = OpCompositeExtract %ushort %3113 6
-OpStore %218 %3114
-%3115 = OpLoad %ulong %217
-%3116 = OpLoad %ushort %218
-%3117 = OpFunctionCall %ulong %5 %3115 %3116
-OpStore %219 %3117
-%3118 = OpLoad %_arr_ushort_uint_8 %158
-%3119 = OpCompositeExtract %ushort %3118 7
-OpStore %220 %3119
-%3120 = OpLoad %ulong %219
-%3121 = OpLoad %ushort %220
-%3122 = OpFunctionCall %ulong %5 %3120 %3121
-OpStore %221 %3122
-OpBranch %91
-%91 = OpLabel
-%3123 = OpLoad %ulong %173
-%3125 = OpIAdd %ulong %3123 %ulong_1
-OpStore %159 %3125
-%3126 = OpLoad %ulong %221
-OpStore %167 %3126
-%3127 = OpLoad %ulong %159
-OpStore %173 %3127
-OpBranch %118
-%81 = OpLabel
-%3128 = OpLoad %_arr_ushort_uint_8 %169
-%3129 = OpCompositeExtract %ushort %3128 0
-OpStore %430 %3129
-%3130 = OpLoad %_arr_ushort_uint_8 %133
-%3131 = OpCompositeExtract %ushort %3130 0
-OpStore %431 %3131
-%3132 = OpLoad %ushort %430
-%3133 = OpLoad %ushort %431
-%3134 = OpIMul %ushort %3132 %3133
-OpStore %432 %3134
-%3135 = OpLoad %_arr_ushort_uint_8 %169
-%3136 = OpCompositeExtract %ushort %3135 1
-OpStore %433 %3136
-%3137 = OpLoad %_arr_ushort_uint_8 %133
-%3138 = OpCompositeExtract %ushort %3137 1
-OpStore %434 %3138
-%3139 = OpLoad %ushort %433
-%3140 = OpLoad %ushort %434
-%3141 = OpIMul %ushort %3139 %3140
-OpStore %435 %3141
-%3142 = OpLoad %_arr_ushort_uint_8 %169
-%3143 = OpCompositeExtract %ushort %3142 2
-OpStore %436 %3143
-%3144 = OpLoad %_arr_ushort_uint_8 %133
-%3145 = OpCompositeExtract %ushort %3144 2
-OpStore %437 %3145
-%3146 = OpLoad %ushort %436
-%3147 = OpLoad %ushort %437
-%3148 = OpIMul %ushort %3146 %3147
-OpStore %438 %3148
-%3149 = OpLoad %_arr_ushort_uint_8 %169
-%3150 = OpCompositeExtract %ushort %3149 3
-OpStore %439 %3150
-%3151 = OpLoad %_arr_ushort_uint_8 %133
-%3152 = OpCompositeExtract %ushort %3151 3
-OpStore %440 %3152
-%3153 = OpLoad %ushort %439
-%3154 = OpLoad %ushort %440
-%3155 = OpIMul %ushort %3153 %3154
-OpStore %441 %3155
-%3156 = OpLoad %_arr_ushort_uint_8 %169
-%3157 = OpCompositeExtract %ushort %3156 4
-OpStore %442 %3157
-%3158 = OpLoad %_arr_ushort_uint_8 %133
-%3159 = OpCompositeExtract %ushort %3158 4
-OpStore %443 %3159
-%3160 = OpLoad %ushort %442
-%3161 = OpLoad %ushort %443
-%3162 = OpIMul %ushort %3160 %3161
-OpStore %444 %3162
-%3163 = OpLoad %_arr_ushort_uint_8 %169
-%3164 = OpCompositeExtract %ushort %3163 5
-OpStore %445 %3164
-%3165 = OpLoad %_arr_ushort_uint_8 %133
-%3166 = OpCompositeExtract %ushort %3165 5
-OpStore %446 %3166
-%3167 = OpLoad %ushort %445
-%3168 = OpLoad %ushort %446
-%3169 = OpIMul %ushort %3167 %3168
-OpStore %447 %3169
-%3170 = OpLoad %_arr_ushort_uint_8 %169
-%3171 = OpCompositeExtract %ushort %3170 6
-OpStore %448 %3171
-%3172 = OpLoad %_arr_ushort_uint_8 %133
-%3173 = OpCompositeExtract %ushort %3172 6
-OpStore %449 %3173
-%3174 = OpLoad %ushort %448
-%3175 = OpLoad %ushort %449
-%3176 = OpIMul %ushort %3174 %3175
-OpStore %450 %3176
-%3177 = OpLoad %_arr_ushort_uint_8 %169
-%3178 = OpCompositeExtract %ushort %3177 7
-OpStore %451 %3178
-%3179 = OpLoad %_arr_ushort_uint_8 %133
-%3180 = OpCompositeExtract %ushort %3179 7
-OpStore %452 %3180
-%3181 = OpLoad %ushort %451
-%3182 = OpLoad %ushort %452
-%3183 = OpIMul %ushort %3181 %3182
-OpStore %453 %3183
-%3184 = OpLoad %_arr_ushort_uint_8 %169
-%3185 = OpLoad %ushort %432
-%3186 = OpCompositeInsert %_arr_ushort_uint_8 %3185 %3184 0
-OpStore %454 %3186
-%3187 = OpLoad %_arr_ushort_uint_8 %454
-%3188 = OpLoad %ushort %435
-%3189 = OpCompositeInsert %_arr_ushort_uint_8 %3188 %3187 1
-OpStore %455 %3189
-%3190 = OpLoad %_arr_ushort_uint_8 %455
-%3191 = OpLoad %ushort %438
-%3192 = OpCompositeInsert %_arr_ushort_uint_8 %3191 %3190 2
-OpStore %456 %3192
-%3193 = OpLoad %_arr_ushort_uint_8 %456
-%3194 = OpLoad %ushort %441
-%3195 = OpCompositeInsert %_arr_ushort_uint_8 %3194 %3193 3
-OpStore %457 %3195
-%3196 = OpLoad %_arr_ushort_uint_8 %457
-%3197 = OpLoad %ushort %444
-%3198 = OpCompositeInsert %_arr_ushort_uint_8 %3197 %3196 4
-OpStore %458 %3198
-%3199 = OpLoad %_arr_ushort_uint_8 %458
-%3200 = OpLoad %ushort %447
-%3201 = OpCompositeInsert %_arr_ushort_uint_8 %3200 %3199 5
-OpStore %459 %3201
-%3202 = OpLoad %_arr_ushort_uint_8 %459
-%3203 = OpLoad %ushort %450
-%3204 = OpCompositeInsert %_arr_ushort_uint_8 %3203 %3202 6
-OpStore %460 %3204
-%3205 = OpLoad %_arr_ushort_uint_8 %460
-%3206 = OpLoad %ushort %453
-%3207 = OpCompositeInsert %_arr_ushort_uint_8 %3206 %3205 7
-OpStore %461 %3207
-OpBranch %88
-%88 = OpLabel
-%3208 = OpLoad %_arr_ushort_uint_8 %461
-%3209 = OpCompositeExtract %ushort %3208 0
-OpStore %190 %3209
-%3210 = OpLoad %ulong %168
-%3211 = OpLoad %ushort %190
-%3212 = OpFunctionCall %ulong %5 %3210 %3211
-OpStore %191 %3212
-%3213 = OpLoad %_arr_ushort_uint_8 %461
-%3214 = OpCompositeExtract %ushort %3213 1
-OpStore %192 %3214
-%3215 = OpLoad %ulong %191
-%3216 = OpLoad %ushort %192
-%3217 = OpFunctionCall %ulong %5 %3215 %3216
-OpStore %193 %3217
-%3218 = OpLoad %_arr_ushort_uint_8 %461
-%3219 = OpCompositeExtract %ushort %3218 2
-OpStore %194 %3219
-%3220 = OpLoad %ulong %193
-%3221 = OpLoad %ushort %194
-%3222 = OpFunctionCall %ulong %5 %3220 %3221
-OpStore %195 %3222
-%3223 = OpLoad %_arr_ushort_uint_8 %461
-%3224 = OpCompositeExtract %ushort %3223 3
-OpStore %196 %3224
-%3225 = OpLoad %ulong %195
-%3226 = OpLoad %ushort %196
-%3227 = OpFunctionCall %ulong %5 %3225 %3226
-OpStore %197 %3227
-%3228 = OpLoad %_arr_ushort_uint_8 %461
-%3229 = OpCompositeExtract %ushort %3228 4
-OpStore %198 %3229
-%3230 = OpLoad %ulong %197
-%3231 = OpLoad %ushort %198
-%3232 = OpFunctionCall %ulong %5 %3230 %3231
-OpStore %199 %3232
-%3233 = OpLoad %_arr_ushort_uint_8 %461
-%3234 = OpCompositeExtract %ushort %3233 5
-OpStore %200 %3234
-%3235 = OpLoad %ulong %199
-%3236 = OpLoad %ushort %200
-%3237 = OpFunctionCall %ulong %5 %3235 %3236
-OpStore %201 %3237
-%3238 = OpLoad %_arr_ushort_uint_8 %461
-%3239 = OpCompositeExtract %ushort %3238 6
-OpStore %202 %3239
-%3240 = OpLoad %ulong %201
-%3241 = OpLoad %ushort %202
-%3242 = OpFunctionCall %ulong %5 %3240 %3241
-OpStore %203 %3242
-%3243 = OpLoad %_arr_ushort_uint_8 %461
-%3244 = OpCompositeExtract %ushort %3243 7
-OpStore %204 %3244
-%3245 = OpLoad %ulong %203
-%3246 = OpLoad %ushort %204
-%3247 = OpFunctionCall %ulong %5 %3245 %3246
-OpStore %205 %3247
-OpBranch %89
-%89 = OpLabel
-%3248 = OpLoad %_arr_ushort_uint_8 %170
-%3249 = OpCompositeExtract %ushort %3248 0
-OpStore %526 %3249
-%3250 = OpLoad %_arr_ushort_uint_8 %461
-%3251 = OpCompositeExtract %ushort %3250 0
-OpStore %527 %3251
-%3252 = OpLoad %ushort %526
-%3253 = OpLoad %ushort %527
-%3254 = OpBitwiseXor %ushort %3252 %3253
-OpStore %528 %3254
-%3255 = OpLoad %_arr_ushort_uint_8 %170
-%3256 = OpCompositeExtract %ushort %3255 1
-OpStore %529 %3256
-%3257 = OpLoad %_arr_ushort_uint_8 %461
-%3258 = OpCompositeExtract %ushort %3257 1
-OpStore %530 %3258
-%3259 = OpLoad %ushort %529
-%3260 = OpLoad %ushort %530
-%3261 = OpBitwiseXor %ushort %3259 %3260
-OpStore %531 %3261
-%3262 = OpLoad %_arr_ushort_uint_8 %170
-%3263 = OpCompositeExtract %ushort %3262 2
-OpStore %532 %3263
-%3264 = OpLoad %_arr_ushort_uint_8 %461
-%3265 = OpCompositeExtract %ushort %3264 2
-OpStore %533 %3265
-%3266 = OpLoad %ushort %532
-%3267 = OpLoad %ushort %533
-%3268 = OpBitwiseXor %ushort %3266 %3267
-OpStore %534 %3268
-%3269 = OpLoad %_arr_ushort_uint_8 %170
-%3270 = OpCompositeExtract %ushort %3269 3
-OpStore %535 %3270
-%3271 = OpLoad %_arr_ushort_uint_8 %461
-%3272 = OpCompositeExtract %ushort %3271 3
-OpStore %536 %3272
-%3273 = OpLoad %ushort %535
-%3274 = OpLoad %ushort %536
-%3275 = OpBitwiseXor %ushort %3273 %3274
-OpStore %537 %3275
-%3276 = OpLoad %_arr_ushort_uint_8 %170
-%3277 = OpCompositeExtract %ushort %3276 4
-OpStore %538 %3277
-%3278 = OpLoad %_arr_ushort_uint_8 %461
-%3279 = OpCompositeExtract %ushort %3278 4
-OpStore %539 %3279
-%3280 = OpLoad %ushort %538
-%3281 = OpLoad %ushort %539
-%3282 = OpBitwiseXor %ushort %3280 %3281
-OpStore %540 %3282
-%3283 = OpLoad %_arr_ushort_uint_8 %170
-%3284 = OpCompositeExtract %ushort %3283 5
-OpStore %541 %3284
-%3285 = OpLoad %_arr_ushort_uint_8 %461
-%3286 = OpCompositeExtract %ushort %3285 5
-OpStore %542 %3286
-%3287 = OpLoad %ushort %541
-%3288 = OpLoad %ushort %542
-%3289 = OpBitwiseXor %ushort %3287 %3288
-OpStore %543 %3289
-%3290 = OpLoad %_arr_ushort_uint_8 %170
-%3291 = OpCompositeExtract %ushort %3290 6
-OpStore %544 %3291
-%3292 = OpLoad %_arr_ushort_uint_8 %461
-%3293 = OpCompositeExtract %ushort %3292 6
-OpStore %545 %3293
-%3294 = OpLoad %ushort %544
-%3295 = OpLoad %ushort %545
-%3296 = OpBitwiseXor %ushort %3294 %3295
-OpStore %546 %3296
-%3297 = OpLoad %_arr_ushort_uint_8 %170
-%3298 = OpCompositeExtract %ushort %3297 7
-OpStore %547 %3298
-%3299 = OpLoad %_arr_ushort_uint_8 %461
-%3300 = OpCompositeExtract %ushort %3299 7
-OpStore %548 %3300
-%3301 = OpLoad %ushort %547
-%3302 = OpLoad %ushort %548
-%3303 = OpBitwiseXor %ushort %3301 %3302
-OpStore %549 %3303
-%3304 = OpLoad %_arr_ushort_uint_8 %170
-%3305 = OpLoad %ushort %528
-%3306 = OpCompositeInsert %_arr_ushort_uint_8 %3305 %3304 0
-OpStore %550 %3306
-%3307 = OpLoad %_arr_ushort_uint_8 %550
-%3308 = OpLoad %ushort %531
-%3309 = OpCompositeInsert %_arr_ushort_uint_8 %3308 %3307 1
-OpStore %551 %3309
-%3310 = OpLoad %_arr_ushort_uint_8 %551
-%3311 = OpLoad %ushort %534
-%3312 = OpCompositeInsert %_arr_ushort_uint_8 %3311 %3310 2
-OpStore %552 %3312
-%3313 = OpLoad %_arr_ushort_uint_8 %552
-%3314 = OpLoad %ushort %537
-%3315 = OpCompositeInsert %_arr_ushort_uint_8 %3314 %3313 3
-OpStore %553 %3315
-%3316 = OpLoad %_arr_ushort_uint_8 %553
-%3317 = OpLoad %ushort %540
-%3318 = OpCompositeInsert %_arr_ushort_uint_8 %3317 %3316 4
-OpStore %554 %3318
-%3319 = OpLoad %_arr_ushort_uint_8 %554
-%3320 = OpLoad %ushort %543
-%3321 = OpCompositeInsert %_arr_ushort_uint_8 %3320 %3319 5
-OpStore %555 %3321
-%3322 = OpLoad %_arr_ushort_uint_8 %555
-%3323 = OpLoad %ushort %546
-%3324 = OpCompositeInsert %_arr_ushort_uint_8 %3323 %3322 6
-OpStore %556 %3324
-%3325 = OpLoad %_arr_ushort_uint_8 %556
-%3326 = OpLoad %ushort %549
-%3327 = OpCompositeInsert %_arr_ushort_uint_8 %3326 %3325 7
-OpStore %557 %3327
-OpBranch %96
-%96 = OpLabel
-%3328 = OpLoad %_arr_ushort_uint_8 %557
-%3329 = OpCompositeExtract %ushort %3328 0
-OpStore %254 %3329
-%3330 = OpLoad %ulong %205
-%3331 = OpLoad %ushort %254
-%3332 = OpFunctionCall %ulong %5 %3330 %3331
-OpStore %255 %3332
-%3333 = OpLoad %_arr_ushort_uint_8 %557
-%3334 = OpCompositeExtract %ushort %3333 1
-OpStore %256 %3334
-%3335 = OpLoad %ulong %255
-%3336 = OpLoad %ushort %256
-%3337 = OpFunctionCall %ulong %5 %3335 %3336
-OpStore %257 %3337
-%3338 = OpLoad %_arr_ushort_uint_8 %557
-%3339 = OpCompositeExtract %ushort %3338 2
-OpStore %258 %3339
-%3340 = OpLoad %ulong %257
-%3341 = OpLoad %ushort %258
-%3342 = OpFunctionCall %ulong %5 %3340 %3341
-OpStore %259 %3342
-%3343 = OpLoad %_arr_ushort_uint_8 %557
-%3344 = OpCompositeExtract %ushort %3343 3
-OpStore %260 %3344
-%3345 = OpLoad %ulong %259
-%3346 = OpLoad %ushort %260
-%3347 = OpFunctionCall %ulong %5 %3345 %3346
-OpStore %261 %3347
-%3348 = OpLoad %_arr_ushort_uint_8 %557
-%3349 = OpCompositeExtract %ushort %3348 4
-OpStore %262 %3349
-%3350 = OpLoad %ulong %261
-%3351 = OpLoad %ushort %262
-%3352 = OpFunctionCall %ulong %5 %3350 %3351
-OpStore %263 %3352
-%3353 = OpLoad %_arr_ushort_uint_8 %557
-%3354 = OpCompositeExtract %ushort %3353 5
-OpStore %264 %3354
-%3355 = OpLoad %ulong %263
-%3356 = OpLoad %ushort %264
-%3357 = OpFunctionCall %ulong %5 %3355 %3356
-OpStore %265 %3357
-%3358 = OpLoad %_arr_ushort_uint_8 %557
-%3359 = OpCompositeExtract %ushort %3358 6
-OpStore %266 %3359
-%3360 = OpLoad %ulong %265
-%3361 = OpLoad %ushort %266
-%3362 = OpFunctionCall %ulong %5 %3360 %3361
-OpStore %267 %3362
-%3363 = OpLoad %_arr_ushort_uint_8 %557
-%3364 = OpCompositeExtract %ushort %3363 7
-OpStore %268 %3364
-%3365 = OpLoad %ulong %267
-%3366 = OpLoad %ushort %268
-%3367 = OpFunctionCall %ulong %5 %3365 %3366
-OpStore %269 %3367
-OpBranch %97
-%97 = OpLabel
-%3368 = OpLoad %_arr_ushort_uint_8 %171
-%3369 = OpCompositeExtract %ushort %3368 0
-OpStore %590 %3369
-%3370 = OpLoad %_arr_ushort_uint_8 %169
-%3371 = OpCompositeExtract %ushort %3370 0
-OpStore %591 %3371
-%3372 = OpLoad %ushort %590
-%3373 = OpLoad %ushort %591
-%3374 = OpIAdd %ushort %3372 %3373
-OpStore %592 %3374
-%3375 = OpLoad %_arr_ushort_uint_8 %171
-%3376 = OpCompositeExtract %ushort %3375 1
-OpStore %593 %3376
-%3377 = OpLoad %_arr_ushort_uint_8 %169
-%3378 = OpCompositeExtract %ushort %3377 1
-OpStore %594 %3378
-%3379 = OpLoad %ushort %593
-%3380 = OpLoad %ushort %594
-%3381 = OpIAdd %ushort %3379 %3380
-OpStore %595 %3381
-%3382 = OpLoad %_arr_ushort_uint_8 %171
-%3383 = OpCompositeExtract %ushort %3382 2
-OpStore %596 %3383
-%3384 = OpLoad %_arr_ushort_uint_8 %169
-%3385 = OpCompositeExtract %ushort %3384 2
-OpStore %597 %3385
-%3386 = OpLoad %ushort %596
-%3387 = OpLoad %ushort %597
-%3388 = OpIAdd %ushort %3386 %3387
-OpStore %598 %3388
-%3389 = OpLoad %_arr_ushort_uint_8 %171
-%3390 = OpCompositeExtract %ushort %3389 3
-OpStore %599 %3390
-%3391 = OpLoad %_arr_ushort_uint_8 %169
-%3392 = OpCompositeExtract %ushort %3391 3
-OpStore %600 %3392
-%3393 = OpLoad %ushort %599
-%3394 = OpLoad %ushort %600
-%3395 = OpIAdd %ushort %3393 %3394
-OpStore %601 %3395
-%3396 = OpLoad %_arr_ushort_uint_8 %171
-%3397 = OpCompositeExtract %ushort %3396 4
-OpStore %602 %3397
-%3398 = OpLoad %_arr_ushort_uint_8 %169
-%3399 = OpCompositeExtract %ushort %3398 4
-OpStore %603 %3399
-%3400 = OpLoad %ushort %602
-%3401 = OpLoad %ushort %603
-%3402 = OpIAdd %ushort %3400 %3401
-OpStore %604 %3402
-%3403 = OpLoad %_arr_ushort_uint_8 %171
-%3404 = OpCompositeExtract %ushort %3403 5
-OpStore %605 %3404
-%3405 = OpLoad %_arr_ushort_uint_8 %169
-%3406 = OpCompositeExtract %ushort %3405 5
-OpStore %606 %3406
-%3407 = OpLoad %ushort %605
-%3408 = OpLoad %ushort %606
-%3409 = OpIAdd %ushort %3407 %3408
-OpStore %607 %3409
-%3410 = OpLoad %_arr_ushort_uint_8 %171
-%3411 = OpCompositeExtract %ushort %3410 6
-OpStore %608 %3411
-%3412 = OpLoad %_arr_ushort_uint_8 %169
-%3413 = OpCompositeExtract %ushort %3412 6
-OpStore %609 %3413
-%3414 = OpLoad %ushort %608
-%3415 = OpLoad %ushort %609
-%3416 = OpIAdd %ushort %3414 %3415
-OpStore %610 %3416
-%3417 = OpLoad %_arr_ushort_uint_8 %171
-%3418 = OpCompositeExtract %ushort %3417 7
-OpStore %611 %3418
-%3419 = OpLoad %_arr_ushort_uint_8 %169
-%3420 = OpCompositeExtract %ushort %3419 7
-OpStore %612 %3420
-%3421 = OpLoad %ushort %611
-%3422 = OpLoad %ushort %612
-%3423 = OpIAdd %ushort %3421 %3422
-OpStore %613 %3423
-%3424 = OpLoad %_arr_ushort_uint_8 %171
-%3425 = OpLoad %ushort %592
-%3426 = OpCompositeInsert %_arr_ushort_uint_8 %3425 %3424 0
-OpStore %614 %3426
-%3427 = OpLoad %_arr_ushort_uint_8 %614
-%3428 = OpLoad %ushort %595
-%3429 = OpCompositeInsert %_arr_ushort_uint_8 %3428 %3427 1
-OpStore %615 %3429
-%3430 = OpLoad %_arr_ushort_uint_8 %615
-%3431 = OpLoad %ushort %598
-%3432 = OpCompositeInsert %_arr_ushort_uint_8 %3431 %3430 2
-OpStore %616 %3432
-%3433 = OpLoad %_arr_ushort_uint_8 %616
-%3434 = OpLoad %ushort %601
-%3435 = OpCompositeInsert %_arr_ushort_uint_8 %3434 %3433 3
-OpStore %617 %3435
-%3436 = OpLoad %_arr_ushort_uint_8 %617
-%3437 = OpLoad %ushort %604
-%3438 = OpCompositeInsert %_arr_ushort_uint_8 %3437 %3436 4
-OpStore %618 %3438
-%3439 = OpLoad %_arr_ushort_uint_8 %618
-%3440 = OpLoad %ushort %607
-%3441 = OpCompositeInsert %_arr_ushort_uint_8 %3440 %3439 5
-OpStore %619 %3441
-%3442 = OpLoad %_arr_ushort_uint_8 %619
-%3443 = OpLoad %ushort %610
-%3444 = OpCompositeInsert %_arr_ushort_uint_8 %3443 %3442 6
-OpStore %620 %3444
-%3445 = OpLoad %_arr_ushort_uint_8 %620
-%3446 = OpLoad %ushort %613
-%3447 = OpCompositeInsert %_arr_ushort_uint_8 %3446 %3445 7
-OpStore %621 %3447
-OpBranch %100
-%100 = OpLabel
-%3448 = OpLoad %_arr_ushort_uint_8 %621
-%3449 = OpCompositeExtract %ushort %3448 0
-OpStore %286 %3449
-%3450 = OpLoad %ulong %269
-%3451 = OpLoad %ushort %286
-%3452 = OpFunctionCall %ulong %5 %3450 %3451
-OpStore %287 %3452
-%3453 = OpLoad %_arr_ushort_uint_8 %621
-%3454 = OpCompositeExtract %ushort %3453 1
-OpStore %288 %3454
-%3455 = OpLoad %ulong %287
-%3456 = OpLoad %ushort %288
-%3457 = OpFunctionCall %ulong %5 %3455 %3456
-OpStore %289 %3457
-%3458 = OpLoad %_arr_ushort_uint_8 %621
-%3459 = OpCompositeExtract %ushort %3458 2
-OpStore %290 %3459
-%3460 = OpLoad %ulong %289
-%3461 = OpLoad %ushort %290
-%3462 = OpFunctionCall %ulong %5 %3460 %3461
-OpStore %291 %3462
-%3463 = OpLoad %_arr_ushort_uint_8 %621
-%3464 = OpCompositeExtract %ushort %3463 3
-OpStore %292 %3464
-%3465 = OpLoad %ulong %291
-%3466 = OpLoad %ushort %292
-%3467 = OpFunctionCall %ulong %5 %3465 %3466
-OpStore %293 %3467
-%3468 = OpLoad %_arr_ushort_uint_8 %621
-%3469 = OpCompositeExtract %ushort %3468 4
-OpStore %294 %3469
-%3470 = OpLoad %ulong %293
-%3471 = OpLoad %ushort %294
-%3472 = OpFunctionCall %ulong %5 %3470 %3471
-OpStore %295 %3472
-%3473 = OpLoad %_arr_ushort_uint_8 %621
-%3474 = OpCompositeExtract %ushort %3473 5
-OpStore %296 %3474
-%3475 = OpLoad %ulong %295
-%3476 = OpLoad %ushort %296
-%3477 = OpFunctionCall %ulong %5 %3475 %3476
-OpStore %297 %3477
-%3478 = OpLoad %_arr_ushort_uint_8 %621
-%3479 = OpCompositeExtract %ushort %3478 6
-OpStore %298 %3479
-%3480 = OpLoad %ulong %297
-%3481 = OpLoad %ushort %298
-%3482 = OpFunctionCall %ulong %5 %3480 %3481
-OpStore %299 %3482
-%3483 = OpLoad %_arr_ushort_uint_8 %621
-%3484 = OpCompositeExtract %ushort %3483 7
-OpStore %300 %3484
-%3485 = OpLoad %ulong %299
-%3486 = OpLoad %ushort %300
-%3487 = OpFunctionCall %ulong %5 %3485 %3486
-OpStore %301 %3487
-OpBranch %101
-%101 = OpLabel
-%3488 = OpLoad %_arr_ushort_uint_8 %169
-%3489 = OpCompositeExtract %ushort %3488 0
-OpStore %654 %3489
-%3490 = OpLoad %_arr_ushort_uint_8 %146
-%3491 = OpCompositeExtract %ushort %3490 0
-OpStore %655 %3491
-%3492 = OpLoad %ushort %654
-%3493 = OpLoad %ushort %655
-%3494 = OpIAdd %ushort %3492 %3493
-OpStore %656 %3494
-%3495 = OpLoad %_arr_ushort_uint_8 %169
-%3496 = OpCompositeExtract %ushort %3495 1
-OpStore %657 %3496
-%3497 = OpLoad %_arr_ushort_uint_8 %146
-%3498 = OpCompositeExtract %ushort %3497 1
-OpStore %658 %3498
-%3499 = OpLoad %ushort %657
-%3500 = OpLoad %ushort %658
-%3501 = OpIAdd %ushort %3499 %3500
-OpStore %659 %3501
-%3502 = OpLoad %_arr_ushort_uint_8 %169
-%3503 = OpCompositeExtract %ushort %3502 2
-OpStore %660 %3503
-%3504 = OpLoad %_arr_ushort_uint_8 %146
-%3505 = OpCompositeExtract %ushort %3504 2
-OpStore %661 %3505
-%3506 = OpLoad %ushort %660
-%3507 = OpLoad %ushort %661
-%3508 = OpIAdd %ushort %3506 %3507
-OpStore %662 %3508
-%3509 = OpLoad %_arr_ushort_uint_8 %169
-%3510 = OpCompositeExtract %ushort %3509 3
-OpStore %663 %3510
-%3511 = OpLoad %_arr_ushort_uint_8 %146
-%3512 = OpCompositeExtract %ushort %3511 3
-OpStore %664 %3512
-%3513 = OpLoad %ushort %663
-%3514 = OpLoad %ushort %664
-%3515 = OpIAdd %ushort %3513 %3514
-OpStore %665 %3515
-%3516 = OpLoad %_arr_ushort_uint_8 %169
-%3517 = OpCompositeExtract %ushort %3516 4
-OpStore %666 %3517
-%3518 = OpLoad %_arr_ushort_uint_8 %146
-%3519 = OpCompositeExtract %ushort %3518 4
-OpStore %667 %3519
-%3520 = OpLoad %ushort %666
-%3521 = OpLoad %ushort %667
-%3522 = OpIAdd %ushort %3520 %3521
-OpStore %668 %3522
-%3523 = OpLoad %_arr_ushort_uint_8 %169
-%3524 = OpCompositeExtract %ushort %3523 5
-OpStore %669 %3524
-%3525 = OpLoad %_arr_ushort_uint_8 %146
-%3526 = OpCompositeExtract %ushort %3525 5
-OpStore %670 %3526
-%3527 = OpLoad %ushort %669
-%3528 = OpLoad %ushort %670
-%3529 = OpIAdd %ushort %3527 %3528
-OpStore %671 %3529
-%3530 = OpLoad %_arr_ushort_uint_8 %169
-%3531 = OpCompositeExtract %ushort %3530 6
-OpStore %672 %3531
-%3532 = OpLoad %_arr_ushort_uint_8 %146
-%3533 = OpCompositeExtract %ushort %3532 6
-OpStore %673 %3533
-%3534 = OpLoad %ushort %672
-%3535 = OpLoad %ushort %673
-%3536 = OpIAdd %ushort %3534 %3535
-OpStore %674 %3536
-%3537 = OpLoad %_arr_ushort_uint_8 %169
-%3538 = OpCompositeExtract %ushort %3537 7
-OpStore %675 %3538
-%3539 = OpLoad %_arr_ushort_uint_8 %146
-%3540 = OpCompositeExtract %ushort %3539 7
-OpStore %676 %3540
-%3541 = OpLoad %ushort %675
-%3542 = OpLoad %ushort %676
-%3543 = OpIAdd %ushort %3541 %3542
-OpStore %677 %3543
-%3544 = OpLoad %_arr_ushort_uint_8 %169
-%3545 = OpLoad %ushort %656
-%3546 = OpCompositeInsert %_arr_ushort_uint_8 %3545 %3544 0
-OpStore %678 %3546
-%3547 = OpLoad %_arr_ushort_uint_8 %678
-%3548 = OpLoad %ushort %659
-%3549 = OpCompositeInsert %_arr_ushort_uint_8 %3548 %3547 1
-OpStore %679 %3549
-%3550 = OpLoad %_arr_ushort_uint_8 %679
-%3551 = OpLoad %ushort %662
-%3552 = OpCompositeInsert %_arr_ushort_uint_8 %3551 %3550 2
-OpStore %680 %3552
-%3553 = OpLoad %_arr_ushort_uint_8 %680
-%3554 = OpLoad %ushort %665
-%3555 = OpCompositeInsert %_arr_ushort_uint_8 %3554 %3553 3
-OpStore %681 %3555
-%3556 = OpLoad %_arr_ushort_uint_8 %681
-%3557 = OpLoad %ushort %668
-%3558 = OpCompositeInsert %_arr_ushort_uint_8 %3557 %3556 4
-OpStore %682 %3558
-%3559 = OpLoad %_arr_ushort_uint_8 %682
-%3560 = OpLoad %ushort %671
-%3561 = OpCompositeInsert %_arr_ushort_uint_8 %3560 %3559 5
-OpStore %683 %3561
-%3562 = OpLoad %_arr_ushort_uint_8 %683
-%3563 = OpLoad %ushort %674
-%3564 = OpCompositeInsert %_arr_ushort_uint_8 %3563 %3562 6
-OpStore %684 %3564
-%3565 = OpLoad %_arr_ushort_uint_8 %684
-%3566 = OpLoad %ushort %677
-%3567 = OpCompositeInsert %_arr_ushort_uint_8 %3566 %3565 7
-OpStore %685 %3567
-OpBranch %104
-%104 = OpLabel
-%3568 = OpLoad %_arr_ushort_uint_8 %685
-%3569 = OpCompositeExtract %ushort %3568 0
-OpStore %318 %3569
-%3570 = OpLoad %ulong %301
-%3571 = OpLoad %ushort %318
-%3572 = OpFunctionCall %ulong %5 %3570 %3571
-OpStore %319 %3572
-%3573 = OpLoad %_arr_ushort_uint_8 %685
-%3574 = OpCompositeExtract %ushort %3573 1
-OpStore %320 %3574
-%3575 = OpLoad %ulong %319
-%3576 = OpLoad %ushort %320
-%3577 = OpFunctionCall %ulong %5 %3575 %3576
-OpStore %321 %3577
-%3578 = OpLoad %_arr_ushort_uint_8 %685
-%3579 = OpCompositeExtract %ushort %3578 2
-OpStore %322 %3579
-%3580 = OpLoad %ulong %321
-%3581 = OpLoad %ushort %322
-%3582 = OpFunctionCall %ulong %5 %3580 %3581
-OpStore %323 %3582
-%3583 = OpLoad %_arr_ushort_uint_8 %685
-%3584 = OpCompositeExtract %ushort %3583 3
-OpStore %324 %3584
-%3585 = OpLoad %ulong %323
-%3586 = OpLoad %ushort %324
-%3587 = OpFunctionCall %ulong %5 %3585 %3586
-OpStore %325 %3587
-%3588 = OpLoad %_arr_ushort_uint_8 %685
-%3589 = OpCompositeExtract %ushort %3588 4
-OpStore %326 %3589
-%3590 = OpLoad %ulong %325
-%3591 = OpLoad %ushort %326
-%3592 = OpFunctionCall %ulong %5 %3590 %3591
-OpStore %327 %3592
-%3593 = OpLoad %_arr_ushort_uint_8 %685
-%3594 = OpCompositeExtract %ushort %3593 5
-OpStore %328 %3594
-%3595 = OpLoad %ulong %327
-%3596 = OpLoad %ushort %328
-%3597 = OpFunctionCall %ulong %5 %3595 %3596
-OpStore %329 %3597
-%3598 = OpLoad %_arr_ushort_uint_8 %685
-%3599 = OpCompositeExtract %ushort %3598 6
-OpStore %330 %3599
-%3600 = OpLoad %ulong %329
-%3601 = OpLoad %ushort %330
-%3602 = OpFunctionCall %ulong %5 %3600 %3601
-OpStore %331 %3602
-%3603 = OpLoad %_arr_ushort_uint_8 %685
-%3604 = OpCompositeExtract %ushort %3603 7
-OpStore %332 %3604
-%3605 = OpLoad %ulong %331
-%3606 = OpLoad %ushort %332
-%3607 = OpFunctionCall %ulong %5 %3605 %3606
-OpStore %333 %3607
-OpBranch %105
-%105 = OpLabel
-%3608 = OpLoad %ulong %172
-%3609 = OpIAdd %ulong %3608 %ulong_1
-OpStore %156 %3609
-%3610 = OpLoad %ulong %333
-OpStore %168 %3610
-%3611 = OpLoad %_arr_ushort_uint_8 %685
-OpStore %169 %3611
-%3612 = OpLoad %_arr_ushort_uint_8 %557
-OpStore %170 %3612
-%3613 = OpLoad %_arr_ushort_uint_8 %621
-OpStore %171 %3613
-%3614 = OpLoad %ulong %156
-OpStore %172 %3614
-OpBranch %119
-%118 = OpLabel
-OpBranch %83
-%119 = OpLabel
-OpBranch %80
-OpFunctionEnd
-%3 = OpFunction %ulong None %3615
-%3616 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %3618
-%3619 = OpFunctionParameter %ulong
-%3620 = OpFunctionParameter %uint
-%3621 = OpLabel
-%3628 = OpVariable %_ptr_Function_ulong Function
-%3629 = OpVariable %_ptr_Function_uint Function
-%3630 = OpVariable %_ptr_Function_ulong Function
-%3631 = OpVariable %_ptr_Function_bool Function
-%3632 = OpVariable %_ptr_Function_ulong Function
-%3633 = OpVariable %_ptr_Function_ulong Function
-%3634 = OpVariable %_ptr_Function_ulong Function
-%3635 = OpVariable %_ptr_Function_ulong Function
-%3636 = OpVariable %_ptr_Function_ulong Function
-%3637 = OpVariable %_ptr_Function_ulong Function
-%3638 = OpVariable %_ptr_Function_ulong Function
-%3639 = OpVariable %_ptr_Function_ulong Function
-OpStore %3628 %3619
-OpStore %3629 %3620
-%3640 = OpLoad %uint %3629
-%3641 = OpUConvert %ulong %3640
-OpStore %3630 %3641
-OpBranch %3622
-%3622 = OpLabel
-%3642 = OpLoad %ulong %3628
-OpStore %3638 %3642
-OpStore %3639 %ulong_0
-OpBranch %3623
-%3623 = OpLabel
-%3643 = OpLoad %ulong %3639
-%3645 = OpULessThan %bool %3643 %ulong_8
-OpStore %3631 %3645
-%3646 = OpLoad %bool %3631
-OpLoopMerge %3625 %3627 None
-OpBranchConditional %3646 %3624 %3625
-%3625 = OpLabel
-OpBranch %3626
-%3626 = OpLabel
-%3647 = OpLoad %ulong %3638
-OpReturnValue %3647
-%3624 = OpLabel
-%3648 = OpLoad %ulong %3639
-%3649 = OpIMul %ulong %3648 %ulong_8
-OpStore %3632 %3649
-%3650 = OpLoad %ulong %3630
-%3651 = OpLoad %ulong %3632
-%3652 = OpShiftRightLogical %ulong %3650 %3651
-OpStore %3633 %3652
-%3653 = OpLoad %ulong %3633
-%3655 = OpBitwiseAnd %ulong %3653 %ulong_255
-OpStore %3634 %3655
-%3656 = OpLoad %ulong %3638
-%3657 = OpLoad %ulong %3634
-%3658 = OpBitwiseXor %ulong %3656 %3657
-OpStore %3635 %3658
-%3659 = OpLoad %ulong %3635
-%3661 = OpIMul %ulong %3659 %ulong_1099511628211
-OpStore %3636 %3661
-%3662 = OpLoad %ulong %3639
-%3663 = OpIAdd %ulong %3662 %ulong_1
-OpStore %3637 %3663
-%3664 = OpLoad %ulong %3636
-OpStore %3638 %3664
-%3665 = OpLoad %ulong %3637
-OpStore %3639 %3665
-OpBranch %3627
-%3627 = OpLabel
-OpBranch %3623
-OpFunctionEnd
-%5 = OpFunction %ulong None %3666
-%3667 = OpFunctionParameter %ulong
-%3668 = OpFunctionParameter %ushort
-%3669 = OpLabel
-%3676 = OpVariable %_ptr_Function_ulong Function
-%3677 = OpVariable %_ptr_Function_ushort Function
-%3678 = OpVariable %_ptr_Function_ulong Function
-%3679 = OpVariable %_ptr_Function_bool Function
-%3680 = OpVariable %_ptr_Function_ulong Function
-%3681 = OpVariable %_ptr_Function_ulong Function
-%3682 = OpVariable %_ptr_Function_ulong Function
-%3683 = OpVariable %_ptr_Function_ulong Function
-%3684 = OpVariable %_ptr_Function_ulong Function
-%3685 = OpVariable %_ptr_Function_ulong Function
-%3686 = OpVariable %_ptr_Function_ulong Function
-%3687 = OpVariable %_ptr_Function_ulong Function
-OpStore %3676 %3667
-OpStore %3677 %3668
-%3688 = OpLoad %ushort %3677
-%3689 = OpSConvert %ulong %3688
-OpStore %3678 %3689
-OpBranch %3670
-%3670 = OpLabel
-%3690 = OpLoad %ulong %3676
-OpStore %3686 %3690
-OpStore %3687 %ulong_0
-OpBranch %3671
-%3671 = OpLabel
-%3691 = OpLoad %ulong %3687
-%3692 = OpULessThan %bool %3691 %ulong_8
-OpStore %3679 %3692
-%3693 = OpLoad %bool %3679
-OpLoopMerge %3673 %3675 None
-OpBranchConditional %3693 %3672 %3673
-%3673 = OpLabel
-OpBranch %3674
-%3674 = OpLabel
-%3694 = OpLoad %ulong %3686
-OpReturnValue %3694
-%3672 = OpLabel
-%3695 = OpLoad %ulong %3687
-%3696 = OpIMul %ulong %3695 %ulong_8
-OpStore %3680 %3696
-%3697 = OpLoad %ulong %3678
-%3698 = OpLoad %ulong %3680
-%3699 = OpShiftRightLogical %ulong %3697 %3698
-OpStore %3681 %3699
-%3700 = OpLoad %ulong %3681
-%3701 = OpBitwiseAnd %ulong %3700 %ulong_255
-OpStore %3682 %3701
-%3702 = OpLoad %ulong %3686
-%3703 = OpLoad %ulong %3682
-%3704 = OpBitwiseXor %ulong %3702 %3703
-OpStore %3683 %3704
-%3705 = OpLoad %ulong %3683
-%3706 = OpIMul %ulong %3705 %ulong_1099511628211
-OpStore %3684 %3706
-%3707 = OpLoad %ulong %3687
-%3708 = OpIAdd %ulong %3707 %ulong_1
-OpStore %3685 %3708
-%3709 = OpLoad %ulong %3684
-OpStore %3686 %3709
-%3710 = OpLoad %ulong %3685
-OpStore %3687 %3710
-OpBranch %3675
-%3675 = OpLabel
-OpBranch %3671
+OpStore %1085 %2266
+%2267 = OpLoad %ushort %1085
+%2268 = OpNot %ushort %2267
+OpStore %1086 %2268
+%2269 = OpLoad %_arr_ushort_uint_8 %422
+%2270 = OpCompositeExtract %ushort %2269 2
+OpStore %1087 %2270
+%2271 = OpLoad %ushort %1087
+%2272 = OpNot %ushort %2271
+OpStore %1088 %2272
+%2273 = OpLoad %_arr_ushort_uint_8 %422
+%2274 = OpCompositeExtract %ushort %2273 3
+OpStore %1089 %2274
+%2275 = OpLoad %ushort %1089
+%2276 = OpNot %ushort %2275
+OpStore %1090 %2276
+%2277 = OpLoad %_arr_ushort_uint_8 %422
+%2278 = OpCompositeExtract %ushort %2277 4
+OpStore %1091 %2278
+%2279 = OpLoad %ushort %1091
+%2280 = OpNot %ushort %2279
+OpStore %1092 %2280
+%2281 = OpLoad %_arr_ushort_uint_8 %422
+%2282 = OpCompositeExtract %ushort %2281 5
+OpStore %1093 %2282
+%2283 = OpLoad %ushort %1093
+%2284 = OpNot %ushort %2283
+OpStore %1094 %2284
+%2285 = OpLoad %_arr_ushort_uint_8 %422
+%2286 = OpCompositeExtract %ushort %2285 6
+OpStore %1095 %2286
+%2287 = OpLoad %ushort %1095
+%2288 = OpNot %ushort %2287
+OpStore %1096 %2288
+%2289 = OpLoad %_arr_ushort_uint_8 %422
+%2290 = OpCompositeExtract %ushort %2289 7
+OpStore %1097 %2290
+%2291 = OpLoad %ushort %1097
+%2292 = OpNot %ushort %2291
+OpStore %1098 %2292
+%2293 = OpLoad %_arr_ushort_uint_8 %422
+%2294 = OpLoad %ushort %1084
+%2295 = OpCompositeInsert %_arr_ushort_uint_8 %2294 %2293 0
+OpStore %1099 %2295
+%2296 = OpLoad %_arr_ushort_uint_8 %1099
+%2297 = OpLoad %ushort %1086
+%2298 = OpCompositeInsert %_arr_ushort_uint_8 %2297 %2296 1
+OpStore %1100 %2298
+%2299 = OpLoad %_arr_ushort_uint_8 %1100
+%2300 = OpLoad %ushort %1088
+%2301 = OpCompositeInsert %_arr_ushort_uint_8 %2300 %2299 2
+OpStore %1101 %2301
+%2302 = OpLoad %_arr_ushort_uint_8 %1101
+%2303 = OpLoad %ushort %1090
+%2304 = OpCompositeInsert %_arr_ushort_uint_8 %2303 %2302 3
+OpStore %1102 %2304
+%2305 = OpLoad %_arr_ushort_uint_8 %1102
+%2306 = OpLoad %ushort %1092
+%2307 = OpCompositeInsert %_arr_ushort_uint_8 %2306 %2305 4
+OpStore %1103 %2307
+%2308 = OpLoad %_arr_ushort_uint_8 %1103
+%2309 = OpLoad %ushort %1094
+%2310 = OpCompositeInsert %_arr_ushort_uint_8 %2309 %2308 5
+OpStore %1104 %2310
+%2311 = OpLoad %_arr_ushort_uint_8 %1104
+%2312 = OpLoad %ushort %1096
+%2313 = OpCompositeInsert %_arr_ushort_uint_8 %2312 %2311 6
+OpStore %1105 %2313
+%2314 = OpLoad %_arr_ushort_uint_8 %1105
+%2315 = OpLoad %ushort %1098
+%2316 = OpCompositeInsert %_arr_ushort_uint_8 %2315 %2314 7
+OpStore %1106 %2316
+%2317 = OpLoad %ulong %437
+%2318 = OpLoad %_arr_ushort_uint_8 %1106
+%2319 = OpFunctionCall %ulong %1 %2317 %2318
+OpStore %438 %2319
+%2320 = OpLoad %_arr_ushort_uint_8 %994
+%2321 = OpCompositeExtract %ushort %2320 0
+OpStore %1107 %2321
+%2322 = OpLoad %_arr_ushort_uint_8 %1026
+%2323 = OpCompositeExtract %ushort %2322 0
+OpStore %1108 %2323
+%2324 = OpLoad %ushort %1107
+%2325 = OpLoad %ushort %1108
+%2326 = OpBitwiseXor %ushort %2324 %2325
+OpStore %1109 %2326
+%2327 = OpLoad %_arr_ushort_uint_8 %994
+%2328 = OpCompositeExtract %ushort %2327 1
+OpStore %1110 %2328
+%2329 = OpLoad %_arr_ushort_uint_8 %1026
+%2330 = OpCompositeExtract %ushort %2329 1
+OpStore %1111 %2330
+%2331 = OpLoad %ushort %1110
+%2332 = OpLoad %ushort %1111
+%2333 = OpBitwiseXor %ushort %2331 %2332
+OpStore %1112 %2333
+%2334 = OpLoad %_arr_ushort_uint_8 %994
+%2335 = OpCompositeExtract %ushort %2334 2
+OpStore %1113 %2335
+%2336 = OpLoad %_arr_ushort_uint_8 %1026
+%2337 = OpCompositeExtract %ushort %2336 2
+OpStore %1114 %2337
+%2338 = OpLoad %ushort %1113
+%2339 = OpLoad %ushort %1114
+%2340 = OpBitwiseXor %ushort %2338 %2339
+OpStore %1115 %2340
+%2341 = OpLoad %_arr_ushort_uint_8 %994
+%2342 = OpCompositeExtract %ushort %2341 3
+OpStore %1116 %2342
+%2343 = OpLoad %_arr_ushort_uint_8 %1026
+%2344 = OpCompositeExtract %ushort %2343 3
+OpStore %1117 %2344
+%2345 = OpLoad %ushort %1116
+%2346 = OpLoad %ushort %1117
+%2347 = OpBitwiseXor %ushort %2345 %2346
+OpStore %1118 %2347
+%2348 = OpLoad %_arr_ushort_uint_8 %994
+%2349 = OpCompositeExtract %ushort %2348 4
+OpStore %1119 %2349
+%2350 = OpLoad %_arr_ushort_uint_8 %1026
+%2351 = OpCompositeExtract %ushort %2350 4
+OpStore %1120 %2351
+%2352 = OpLoad %ushort %1119
+%2353 = OpLoad %ushort %1120
+%2354 = OpBitwiseXor %ushort %2352 %2353
+OpStore %1121 %2354
+%2355 = OpLoad %_arr_ushort_uint_8 %994
+%2356 = OpCompositeExtract %ushort %2355 5
+OpStore %1122 %2356
+%2357 = OpLoad %_arr_ushort_uint_8 %1026
+%2358 = OpCompositeExtract %ushort %2357 5
+OpStore %1123 %2358
+%2359 = OpLoad %ushort %1122
+%2360 = OpLoad %ushort %1123
+%2361 = OpBitwiseXor %ushort %2359 %2360
+OpStore %1124 %2361
+%2362 = OpLoad %_arr_ushort_uint_8 %994
+%2363 = OpCompositeExtract %ushort %2362 6
+OpStore %1125 %2363
+%2364 = OpLoad %_arr_ushort_uint_8 %1026
+%2365 = OpCompositeExtract %ushort %2364 6
+OpStore %1126 %2365
+%2366 = OpLoad %ushort %1125
+%2367 = OpLoad %ushort %1126
+%2368 = OpBitwiseXor %ushort %2366 %2367
+OpStore %1127 %2368
+%2369 = OpLoad %_arr_ushort_uint_8 %994
+%2370 = OpCompositeExtract %ushort %2369 7
+OpStore %1128 %2370
+%2371 = OpLoad %_arr_ushort_uint_8 %1026
+%2372 = OpCompositeExtract %ushort %2371 7
+OpStore %1129 %2372
+%2373 = OpLoad %ushort %1128
+%2374 = OpLoad %ushort %1129
+%2375 = OpBitwiseXor %ushort %2373 %2374
+OpStore %1130 %2375
+%2376 = OpLoad %_arr_ushort_uint_8 %994
+%2377 = OpLoad %ushort %1109
+%2378 = OpCompositeInsert %_arr_ushort_uint_8 %2377 %2376 0
+OpStore %1131 %2378
+%2379 = OpLoad %_arr_ushort_uint_8 %1131
+%2380 = OpLoad %ushort %1112
+%2381 = OpCompositeInsert %_arr_ushort_uint_8 %2380 %2379 1
+OpStore %1132 %2381
+%2382 = OpLoad %_arr_ushort_uint_8 %1132
+%2383 = OpLoad %ushort %1115
+%2384 = OpCompositeInsert %_arr_ushort_uint_8 %2383 %2382 2
+OpStore %1133 %2384
+%2385 = OpLoad %_arr_ushort_uint_8 %1133
+%2386 = OpLoad %ushort %1118
+%2387 = OpCompositeInsert %_arr_ushort_uint_8 %2386 %2385 3
+OpStore %1134 %2387
+%2388 = OpLoad %_arr_ushort_uint_8 %1134
+%2389 = OpLoad %ushort %1121
+%2390 = OpCompositeInsert %_arr_ushort_uint_8 %2389 %2388 4
+OpStore %1135 %2390
+%2391 = OpLoad %_arr_ushort_uint_8 %1135
+%2392 = OpLoad %ushort %1124
+%2393 = OpCompositeInsert %_arr_ushort_uint_8 %2392 %2391 5
+OpStore %1136 %2393
+%2394 = OpLoad %_arr_ushort_uint_8 %1136
+%2395 = OpLoad %ushort %1127
+%2396 = OpCompositeInsert %_arr_ushort_uint_8 %2395 %2394 6
+OpStore %1137 %2396
+%2397 = OpLoad %_arr_ushort_uint_8 %1137
+%2398 = OpLoad %ushort %1130
+%2399 = OpCompositeInsert %_arr_ushort_uint_8 %2398 %2397 7
+OpStore %1138 %2399
+%2400 = OpLoad %ulong %438
+%2401 = OpLoad %_arr_ushort_uint_8 %1138
+%2402 = OpFunctionCall %ulong %1 %2400 %2401
+OpStore %439 %2402
+%2403 = OpLoad %ulong %439
+OpStore %457 %2403
+%2404 = OpLoad %_arr_ushort_uint_8 %416
+OpStore %458 %2404
+%2405 = OpLoad %_arr_ushort_uint_8 %410
+OpStore %459 %2405
+%2406 = OpLoad %_arr_ushort_uint_8 %410
+OpStore %460 %2406
+OpStore %461 %ulong_0
+OpBranch %372
+%372 = OpLabel
+%2407 = OpLoad %ulong %461
+%2409 = OpULessThan %bool %2407 %ulong_6
+OpStore %440 %2409
+%2410 = OpLoad %bool %440
+OpLoopMerge %374 %397 None
+OpBranchConditional %2410 %373 %374
+%374 = OpLabel
+OpStore %401 %2411
+%2413 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_0
+%2414 = OpLoad %_arr_ushort_uint_8 %458
+OpStore %2413 %2414
+%2415 = OpLoad %_arr_ushort_uint_8 %458
+%2416 = OpCompositeExtract %ushort %2415 0
+OpStore %611 %2416
+%2417 = OpLoad %_arr_ushort_uint_8 %422
+%2418 = OpCompositeExtract %ushort %2417 0
+OpStore %612 %2418
+%2419 = OpLoad %ushort %611
+%2420 = OpLoad %ushort %612
+%2421 = OpIAdd %ushort %2419 %2420
+OpStore %613 %2421
+%2422 = OpLoad %_arr_ushort_uint_8 %458
+%2423 = OpCompositeExtract %ushort %2422 1
+OpStore %614 %2423
+%2424 = OpLoad %_arr_ushort_uint_8 %422
+%2425 = OpCompositeExtract %ushort %2424 1
+OpStore %615 %2425
+%2426 = OpLoad %ushort %614
+%2427 = OpLoad %ushort %615
+%2428 = OpIAdd %ushort %2426 %2427
+OpStore %616 %2428
+%2429 = OpLoad %_arr_ushort_uint_8 %458
+%2430 = OpCompositeExtract %ushort %2429 2
+OpStore %617 %2430
+%2431 = OpLoad %_arr_ushort_uint_8 %422
+%2432 = OpCompositeExtract %ushort %2431 2
+OpStore %618 %2432
+%2433 = OpLoad %ushort %617
+%2434 = OpLoad %ushort %618
+%2435 = OpIAdd %ushort %2433 %2434
+OpStore %619 %2435
+%2436 = OpLoad %_arr_ushort_uint_8 %458
+%2437 = OpCompositeExtract %ushort %2436 3
+OpStore %620 %2437
+%2438 = OpLoad %_arr_ushort_uint_8 %422
+%2439 = OpCompositeExtract %ushort %2438 3
+OpStore %621 %2439
+%2440 = OpLoad %ushort %620
+%2441 = OpLoad %ushort %621
+%2442 = OpIAdd %ushort %2440 %2441
+OpStore %622 %2442
+%2443 = OpLoad %_arr_ushort_uint_8 %458
+%2444 = OpCompositeExtract %ushort %2443 4
+OpStore %623 %2444
+%2445 = OpLoad %_arr_ushort_uint_8 %422
+%2446 = OpCompositeExtract %ushort %2445 4
+OpStore %624 %2446
+%2447 = OpLoad %ushort %623
+%2448 = OpLoad %ushort %624
+%2449 = OpIAdd %ushort %2447 %2448
+OpStore %625 %2449
+%2450 = OpLoad %_arr_ushort_uint_8 %458
+%2451 = OpCompositeExtract %ushort %2450 5
+OpStore %626 %2451
+%2452 = OpLoad %_arr_ushort_uint_8 %422
+%2453 = OpCompositeExtract %ushort %2452 5
+OpStore %627 %2453
+%2454 = OpLoad %ushort %626
+%2455 = OpLoad %ushort %627
+%2456 = OpIAdd %ushort %2454 %2455
+OpStore %628 %2456
+%2457 = OpLoad %_arr_ushort_uint_8 %458
+%2458 = OpCompositeExtract %ushort %2457 6
+OpStore %629 %2458
+%2459 = OpLoad %_arr_ushort_uint_8 %422
+%2460 = OpCompositeExtract %ushort %2459 6
+OpStore %630 %2460
+%2461 = OpLoad %ushort %629
+%2462 = OpLoad %ushort %630
+%2463 = OpIAdd %ushort %2461 %2462
+OpStore %631 %2463
+%2464 = OpLoad %_arr_ushort_uint_8 %458
+%2465 = OpCompositeExtract %ushort %2464 7
+OpStore %632 %2465
+%2466 = OpLoad %_arr_ushort_uint_8 %422
+%2467 = OpCompositeExtract %ushort %2466 7
+OpStore %633 %2467
+%2468 = OpLoad %ushort %632
+%2469 = OpLoad %ushort %633
+%2470 = OpIAdd %ushort %2468 %2469
+OpStore %634 %2470
+%2471 = OpLoad %_arr_ushort_uint_8 %458
+%2472 = OpLoad %ushort %613
+%2473 = OpCompositeInsert %_arr_ushort_uint_8 %2472 %2471 0
+OpStore %635 %2473
+%2474 = OpLoad %_arr_ushort_uint_8 %635
+%2475 = OpLoad %ushort %616
+%2476 = OpCompositeInsert %_arr_ushort_uint_8 %2475 %2474 1
+OpStore %636 %2476
+%2477 = OpLoad %_arr_ushort_uint_8 %636
+%2478 = OpLoad %ushort %619
+%2479 = OpCompositeInsert %_arr_ushort_uint_8 %2478 %2477 2
+OpStore %637 %2479
+%2480 = OpLoad %_arr_ushort_uint_8 %637
+%2481 = OpLoad %ushort %622
+%2482 = OpCompositeInsert %_arr_ushort_uint_8 %2481 %2480 3
+OpStore %638 %2482
+%2483 = OpLoad %_arr_ushort_uint_8 %638
+%2484 = OpLoad %ushort %625
+%2485 = OpCompositeInsert %_arr_ushort_uint_8 %2484 %2483 4
+OpStore %639 %2485
+%2486 = OpLoad %_arr_ushort_uint_8 %639
+%2487 = OpLoad %ushort %628
+%2488 = OpCompositeInsert %_arr_ushort_uint_8 %2487 %2486 5
+OpStore %640 %2488
+%2489 = OpLoad %_arr_ushort_uint_8 %640
+%2490 = OpLoad %ushort %631
+%2491 = OpCompositeInsert %_arr_ushort_uint_8 %2490 %2489 6
+OpStore %641 %2491
+%2492 = OpLoad %_arr_ushort_uint_8 %641
+%2493 = OpLoad %ushort %634
+%2494 = OpCompositeInsert %_arr_ushort_uint_8 %2493 %2492 7
+OpStore %642 %2494
+%2496 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_1
+%2497 = OpLoad %_arr_ushort_uint_8 %642
+OpStore %2496 %2497
+%2498 = OpLoad %_arr_ushort_uint_8 %458
+%2499 = OpCompositeExtract %ushort %2498 0
+OpStore %643 %2499
+%2500 = OpLoad %_arr_ushort_uint_8 %409
+%2501 = OpCompositeExtract %ushort %2500 0
+OpStore %644 %2501
+%2502 = OpLoad %ushort %643
+%2503 = OpLoad %ushort %644
+%2504 = OpIMul %ushort %2502 %2503
+OpStore %645 %2504
+%2505 = OpLoad %_arr_ushort_uint_8 %458
+%2506 = OpCompositeExtract %ushort %2505 1
+OpStore %646 %2506
+%2507 = OpLoad %_arr_ushort_uint_8 %409
+%2508 = OpCompositeExtract %ushort %2507 1
+OpStore %647 %2508
+%2509 = OpLoad %ushort %646
+%2510 = OpLoad %ushort %647
+%2511 = OpIMul %ushort %2509 %2510
+OpStore %648 %2511
+%2512 = OpLoad %_arr_ushort_uint_8 %458
+%2513 = OpCompositeExtract %ushort %2512 2
+OpStore %649 %2513
+%2514 = OpLoad %_arr_ushort_uint_8 %409
+%2515 = OpCompositeExtract %ushort %2514 2
+OpStore %650 %2515
+%2516 = OpLoad %ushort %649
+%2517 = OpLoad %ushort %650
+%2518 = OpIMul %ushort %2516 %2517
+OpStore %651 %2518
+%2519 = OpLoad %_arr_ushort_uint_8 %458
+%2520 = OpCompositeExtract %ushort %2519 3
+OpStore %652 %2520
+%2521 = OpLoad %_arr_ushort_uint_8 %409
+%2522 = OpCompositeExtract %ushort %2521 3
+OpStore %653 %2522
+%2523 = OpLoad %ushort %652
+%2524 = OpLoad %ushort %653
+%2525 = OpIMul %ushort %2523 %2524
+OpStore %654 %2525
+%2526 = OpLoad %_arr_ushort_uint_8 %458
+%2527 = OpCompositeExtract %ushort %2526 4
+OpStore %655 %2527
+%2528 = OpLoad %_arr_ushort_uint_8 %409
+%2529 = OpCompositeExtract %ushort %2528 4
+OpStore %656 %2529
+%2530 = OpLoad %ushort %655
+%2531 = OpLoad %ushort %656
+%2532 = OpIMul %ushort %2530 %2531
+OpStore %657 %2532
+%2533 = OpLoad %_arr_ushort_uint_8 %458
+%2534 = OpCompositeExtract %ushort %2533 5
+OpStore %658 %2534
+%2535 = OpLoad %_arr_ushort_uint_8 %409
+%2536 = OpCompositeExtract %ushort %2535 5
+OpStore %659 %2536
+%2537 = OpLoad %ushort %658
+%2538 = OpLoad %ushort %659
+%2539 = OpIMul %ushort %2537 %2538
+OpStore %660 %2539
+%2540 = OpLoad %_arr_ushort_uint_8 %458
+%2541 = OpCompositeExtract %ushort %2540 6
+OpStore %661 %2541
+%2542 = OpLoad %_arr_ushort_uint_8 %409
+%2543 = OpCompositeExtract %ushort %2542 6
+OpStore %662 %2543
+%2544 = OpLoad %ushort %661
+%2545 = OpLoad %ushort %662
+%2546 = OpIMul %ushort %2544 %2545
+OpStore %663 %2546
+%2547 = OpLoad %_arr_ushort_uint_8 %458
+%2548 = OpCompositeExtract %ushort %2547 7
+OpStore %664 %2548
+%2549 = OpLoad %_arr_ushort_uint_8 %409
+%2550 = OpCompositeExtract %ushort %2549 7
+OpStore %665 %2550
+%2551 = OpLoad %ushort %664
+%2552 = OpLoad %ushort %665
+%2553 = OpIMul %ushort %2551 %2552
+OpStore %666 %2553
+%2554 = OpLoad %_arr_ushort_uint_8 %458
+%2555 = OpLoad %ushort %645
+%2556 = OpCompositeInsert %_arr_ushort_uint_8 %2555 %2554 0
+OpStore %667 %2556
+%2557 = OpLoad %_arr_ushort_uint_8 %667
+%2558 = OpLoad %ushort %648
+%2559 = OpCompositeInsert %_arr_ushort_uint_8 %2558 %2557 1
+OpStore %668 %2559
+%2560 = OpLoad %_arr_ushort_uint_8 %668
+%2561 = OpLoad %ushort %651
+%2562 = OpCompositeInsert %_arr_ushort_uint_8 %2561 %2560 2
+OpStore %669 %2562
+%2563 = OpLoad %_arr_ushort_uint_8 %669
+%2564 = OpLoad %ushort %654
+%2565 = OpCompositeInsert %_arr_ushort_uint_8 %2564 %2563 3
+OpStore %670 %2565
+%2566 = OpLoad %_arr_ushort_uint_8 %670
+%2567 = OpLoad %ushort %657
+%2568 = OpCompositeInsert %_arr_ushort_uint_8 %2567 %2566 4
+OpStore %671 %2568
+%2569 = OpLoad %_arr_ushort_uint_8 %671
+%2570 = OpLoad %ushort %660
+%2571 = OpCompositeInsert %_arr_ushort_uint_8 %2570 %2569 5
+OpStore %672 %2571
+%2572 = OpLoad %_arr_ushort_uint_8 %672
+%2573 = OpLoad %ushort %663
+%2574 = OpCompositeInsert %_arr_ushort_uint_8 %2573 %2572 6
+OpStore %673 %2574
+%2575 = OpLoad %_arr_ushort_uint_8 %673
+%2576 = OpLoad %ushort %666
+%2577 = OpCompositeInsert %_arr_ushort_uint_8 %2576 %2575 7
+OpStore %674 %2577
+%2579 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_2
+%2580 = OpLoad %_arr_ushort_uint_8 %674
+OpStore %2579 %2580
+%2582 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_3
+%2583 = OpLoad %_arr_ushort_uint_8 %459
+OpStore %2582 %2583
+%2584 = OpLoad %ulong %457
+OpStore %456 %2584
+OpStore %462 %ulong_0
+OpBranch %375
+%375 = OpLabel
+%2585 = OpLoad %ulong %462
+%2587 = OpULessThan %bool %2585 %ulong_4
+OpStore %446 %2587
+%2588 = OpLoad %bool %446
+OpLoopMerge %377 %396 None
+OpBranchConditional %2588 %376 %377
+%377 = OpLabel
+OpStore %404 %2589
+%2590 = OpAccessChain %_ptr_Function_uint %404 %uint_0
+OpStore %2590 %uint_4294967295
+%2592 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_2
+%2593 = OpLoad %_arr_ushort_uint_8 %2592
+OpStore %450 %2593
+%2594 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %404 %uint_1
+%2595 = OpLoad %_arr_ushort_uint_8 %450
+OpStore %2594 %2595
+%2596 = OpAccessChain %_ptr_Function_uint %404 %uint_2
+OpStore %2596 %uint_305419896
+%2598 = OpLoad %uint %2590
+OpStore %452 %2598
+OpBranch %380
+%380 = OpLabel
+%2599 = OpLoad %uint %452
+%2600 = OpUConvert %ulong %2599
+OpStore %463 %2600
+OpBranch %382
+%382 = OpLabel
+%2601 = OpLoad %ulong %456
+OpStore %471 %2601
+OpStore %472 %ulong_0
+OpBranch %383
+%383 = OpLabel
+%2602 = OpLoad %ulong %472
+%2603 = OpULessThan %bool %2602 %ulong_8
+OpStore %464 %2603
+%2604 = OpLoad %bool %464
+OpLoopMerge %385 %395 None
+OpBranchConditional %2604 %384 %385
+%385 = OpLabel
+OpBranch %386
+%386 = OpLabel
+OpBranch %381
+%381 = OpLabel
+%2605 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %404 %uint_1
+%2606 = OpLoad %_arr_ushort_uint_8 %2605
+OpStore %453 %2606
+%2607 = OpLoad %ulong %471
+%2608 = OpLoad %_arr_ushort_uint_8 %453
+%2609 = OpFunctionCall %ulong %1 %2607 %2608
+OpStore %454 %2609
+%2610 = OpAccessChain %_ptr_Function_uint %404 %uint_2
+%2611 = OpLoad %uint %2610
+OpStore %455 %2611
+OpBranch %387
+%387 = OpLabel
+%2612 = OpLoad %uint %455
+%2613 = OpUConvert %ulong %2612
+OpStore %473 %2613
+OpBranch %389
+%389 = OpLabel
+%2614 = OpLoad %ulong %454
+OpStore %481 %2614
+OpStore %482 %ulong_0
+OpBranch %390
+%390 = OpLabel
+%2615 = OpLoad %ulong %482
+%2616 = OpULessThan %bool %2615 %ulong_8
+OpStore %474 %2616
+%2617 = OpLoad %bool %474
+OpLoopMerge %392 %394 None
+OpBranchConditional %2617 %391 %392
+%392 = OpLabel
+OpBranch %393
+%393 = OpLabel
+OpBranch %388
+%388 = OpLabel
+%2618 = OpLoad %ulong %481
+OpReturnValue %2618
+%391 = OpLabel
+%2619 = OpLoad %ulong %482
+%2620 = OpIMul %ulong %2619 %ulong_8
+OpStore %475 %2620
+%2621 = OpLoad %ulong %473
+%2622 = OpLoad %ulong %475
+%2623 = OpShiftRightLogical %ulong %2621 %2622
+OpStore %476 %2623
+%2624 = OpLoad %ulong %476
+%2625 = OpBitwiseAnd %ulong %2624 %ulong_255
+OpStore %477 %2625
+%2626 = OpLoad %ulong %481
+%2627 = OpLoad %ulong %477
+%2628 = OpBitwiseXor %ulong %2626 %2627
+OpStore %478 %2628
+%2629 = OpLoad %ulong %478
+%2630 = OpIMul %ulong %2629 %ulong_1099511628211
+OpStore %479 %2630
+%2631 = OpLoad %ulong %482
+%2632 = OpIAdd %ulong %2631 %ulong_1
+OpStore %480 %2632
+%2633 = OpLoad %ulong %479
+OpStore %481 %2633
+%2634 = OpLoad %ulong %480
+OpStore %482 %2634
+OpBranch %394
+%384 = OpLabel
+%2635 = OpLoad %ulong %472
+%2636 = OpIMul %ulong %2635 %ulong_8
+OpStore %465 %2636
+%2637 = OpLoad %ulong %463
+%2638 = OpLoad %ulong %465
+%2639 = OpShiftRightLogical %ulong %2637 %2638
+OpStore %466 %2639
+%2640 = OpLoad %ulong %466
+%2641 = OpBitwiseAnd %ulong %2640 %ulong_255
+OpStore %467 %2641
+%2642 = OpLoad %ulong %471
+%2643 = OpLoad %ulong %467
+%2644 = OpBitwiseXor %ulong %2642 %2643
+OpStore %468 %2644
+%2645 = OpLoad %ulong %468
+%2646 = OpIMul %ulong %2645 %ulong_1099511628211
+OpStore %469 %2646
+%2647 = OpLoad %ulong %472
+%2648 = OpIAdd %ulong %2647 %ulong_1
+OpStore %470 %2648
+%2649 = OpLoad %ulong %469
+OpStore %471 %2649
+%2650 = OpLoad %ulong %470
+OpStore %472 %2650
+OpBranch %395
+%376 = OpLabel
+%2651 = OpLoad %ulong %462
+%2652 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %2651
+%2653 = OpLoad %_arr_ushort_uint_8 %2652
+OpStore %447 %2653
+%2654 = OpLoad %ulong %456
+%2655 = OpLoad %_arr_ushort_uint_8 %447
+%2656 = OpFunctionCall %ulong %1 %2654 %2655
+OpStore %448 %2656
+%2657 = OpLoad %ulong %462
+%2658 = OpIAdd %ulong %2657 %ulong_1
+OpStore %449 %2658
+%2659 = OpLoad %ulong %448
+OpStore %456 %2659
+%2660 = OpLoad %ulong %449
+OpStore %462 %2660
+OpBranch %396
+%373 = OpLabel
+%2661 = OpLoad %_arr_ushort_uint_8 %458
+%2662 = OpCompositeExtract %ushort %2661 0
+OpStore %483 %2662
+%2663 = OpLoad %_arr_ushort_uint_8 %409
+%2664 = OpCompositeExtract %ushort %2663 0
+OpStore %484 %2664
+%2665 = OpLoad %ushort %483
+%2666 = OpLoad %ushort %484
+%2667 = OpIMul %ushort %2665 %2666
+OpStore %485 %2667
+%2668 = OpLoad %_arr_ushort_uint_8 %458
+%2669 = OpCompositeExtract %ushort %2668 1
+OpStore %486 %2669
+%2670 = OpLoad %_arr_ushort_uint_8 %409
+%2671 = OpCompositeExtract %ushort %2670 1
+OpStore %487 %2671
+%2672 = OpLoad %ushort %486
+%2673 = OpLoad %ushort %487
+%2674 = OpIMul %ushort %2672 %2673
+OpStore %488 %2674
+%2675 = OpLoad %_arr_ushort_uint_8 %458
+%2676 = OpCompositeExtract %ushort %2675 2
+OpStore %489 %2676
+%2677 = OpLoad %_arr_ushort_uint_8 %409
+%2678 = OpCompositeExtract %ushort %2677 2
+OpStore %490 %2678
+%2679 = OpLoad %ushort %489
+%2680 = OpLoad %ushort %490
+%2681 = OpIMul %ushort %2679 %2680
+OpStore %491 %2681
+%2682 = OpLoad %_arr_ushort_uint_8 %458
+%2683 = OpCompositeExtract %ushort %2682 3
+OpStore %492 %2683
+%2684 = OpLoad %_arr_ushort_uint_8 %409
+%2685 = OpCompositeExtract %ushort %2684 3
+OpStore %493 %2685
+%2686 = OpLoad %ushort %492
+%2687 = OpLoad %ushort %493
+%2688 = OpIMul %ushort %2686 %2687
+OpStore %494 %2688
+%2689 = OpLoad %_arr_ushort_uint_8 %458
+%2690 = OpCompositeExtract %ushort %2689 4
+OpStore %495 %2690
+%2691 = OpLoad %_arr_ushort_uint_8 %409
+%2692 = OpCompositeExtract %ushort %2691 4
+OpStore %496 %2692
+%2693 = OpLoad %ushort %495
+%2694 = OpLoad %ushort %496
+%2695 = OpIMul %ushort %2693 %2694
+OpStore %497 %2695
+%2696 = OpLoad %_arr_ushort_uint_8 %458
+%2697 = OpCompositeExtract %ushort %2696 5
+OpStore %498 %2697
+%2698 = OpLoad %_arr_ushort_uint_8 %409
+%2699 = OpCompositeExtract %ushort %2698 5
+OpStore %499 %2699
+%2700 = OpLoad %ushort %498
+%2701 = OpLoad %ushort %499
+%2702 = OpIMul %ushort %2700 %2701
+OpStore %500 %2702
+%2703 = OpLoad %_arr_ushort_uint_8 %458
+%2704 = OpCompositeExtract %ushort %2703 6
+OpStore %501 %2704
+%2705 = OpLoad %_arr_ushort_uint_8 %409
+%2706 = OpCompositeExtract %ushort %2705 6
+OpStore %502 %2706
+%2707 = OpLoad %ushort %501
+%2708 = OpLoad %ushort %502
+%2709 = OpIMul %ushort %2707 %2708
+OpStore %503 %2709
+%2710 = OpLoad %_arr_ushort_uint_8 %458
+%2711 = OpCompositeExtract %ushort %2710 7
+OpStore %504 %2711
+%2712 = OpLoad %_arr_ushort_uint_8 %409
+%2713 = OpCompositeExtract %ushort %2712 7
+OpStore %505 %2713
+%2714 = OpLoad %ushort %504
+%2715 = OpLoad %ushort %505
+%2716 = OpIMul %ushort %2714 %2715
+OpStore %506 %2716
+%2717 = OpLoad %_arr_ushort_uint_8 %458
+%2718 = OpLoad %ushort %485
+%2719 = OpCompositeInsert %_arr_ushort_uint_8 %2718 %2717 0
+OpStore %507 %2719
+%2720 = OpLoad %_arr_ushort_uint_8 %507
+%2721 = OpLoad %ushort %488
+%2722 = OpCompositeInsert %_arr_ushort_uint_8 %2721 %2720 1
+OpStore %508 %2722
+%2723 = OpLoad %_arr_ushort_uint_8 %508
+%2724 = OpLoad %ushort %491
+%2725 = OpCompositeInsert %_arr_ushort_uint_8 %2724 %2723 2
+OpStore %509 %2725
+%2726 = OpLoad %_arr_ushort_uint_8 %509
+%2727 = OpLoad %ushort %494
+%2728 = OpCompositeInsert %_arr_ushort_uint_8 %2727 %2726 3
+OpStore %510 %2728
+%2729 = OpLoad %_arr_ushort_uint_8 %510
+%2730 = OpLoad %ushort %497
+%2731 = OpCompositeInsert %_arr_ushort_uint_8 %2730 %2729 4
+OpStore %511 %2731
+%2732 = OpLoad %_arr_ushort_uint_8 %511
+%2733 = OpLoad %ushort %500
+%2734 = OpCompositeInsert %_arr_ushort_uint_8 %2733 %2732 5
+OpStore %512 %2734
+%2735 = OpLoad %_arr_ushort_uint_8 %512
+%2736 = OpLoad %ushort %503
+%2737 = OpCompositeInsert %_arr_ushort_uint_8 %2736 %2735 6
+OpStore %513 %2737
+%2738 = OpLoad %_arr_ushort_uint_8 %513
+%2739 = OpLoad %ushort %506
+%2740 = OpCompositeInsert %_arr_ushort_uint_8 %2739 %2738 7
+OpStore %514 %2740
+%2741 = OpLoad %ulong %457
+%2742 = OpLoad %_arr_ushort_uint_8 %514
+%2743 = OpFunctionCall %ulong %1 %2741 %2742
+OpStore %441 %2743
+%2744 = OpLoad %_arr_ushort_uint_8 %459
+%2745 = OpCompositeExtract %ushort %2744 0
+OpStore %515 %2745
+%2746 = OpLoad %_arr_ushort_uint_8 %514
+%2747 = OpCompositeExtract %ushort %2746 0
+OpStore %516 %2747
+%2748 = OpLoad %ushort %515
+%2749 = OpLoad %ushort %516
+%2750 = OpBitwiseXor %ushort %2748 %2749
+OpStore %517 %2750
+%2751 = OpLoad %_arr_ushort_uint_8 %459
+%2752 = OpCompositeExtract %ushort %2751 1
+OpStore %518 %2752
+%2753 = OpLoad %_arr_ushort_uint_8 %514
+%2754 = OpCompositeExtract %ushort %2753 1
+OpStore %519 %2754
+%2755 = OpLoad %ushort %518
+%2756 = OpLoad %ushort %519
+%2757 = OpBitwiseXor %ushort %2755 %2756
+OpStore %520 %2757
+%2758 = OpLoad %_arr_ushort_uint_8 %459
+%2759 = OpCompositeExtract %ushort %2758 2
+OpStore %521 %2759
+%2760 = OpLoad %_arr_ushort_uint_8 %514
+%2761 = OpCompositeExtract %ushort %2760 2
+OpStore %522 %2761
+%2762 = OpLoad %ushort %521
+%2763 = OpLoad %ushort %522
+%2764 = OpBitwiseXor %ushort %2762 %2763
+OpStore %523 %2764
+%2765 = OpLoad %_arr_ushort_uint_8 %459
+%2766 = OpCompositeExtract %ushort %2765 3
+OpStore %524 %2766
+%2767 = OpLoad %_arr_ushort_uint_8 %514
+%2768 = OpCompositeExtract %ushort %2767 3
+OpStore %525 %2768
+%2769 = OpLoad %ushort %524
+%2770 = OpLoad %ushort %525
+%2771 = OpBitwiseXor %ushort %2769 %2770
+OpStore %526 %2771
+%2772 = OpLoad %_arr_ushort_uint_8 %459
+%2773 = OpCompositeExtract %ushort %2772 4
+OpStore %527 %2773
+%2774 = OpLoad %_arr_ushort_uint_8 %514
+%2775 = OpCompositeExtract %ushort %2774 4
+OpStore %528 %2775
+%2776 = OpLoad %ushort %527
+%2777 = OpLoad %ushort %528
+%2778 = OpBitwiseXor %ushort %2776 %2777
+OpStore %529 %2778
+%2779 = OpLoad %_arr_ushort_uint_8 %459
+%2780 = OpCompositeExtract %ushort %2779 5
+OpStore %530 %2780
+%2781 = OpLoad %_arr_ushort_uint_8 %514
+%2782 = OpCompositeExtract %ushort %2781 5
+OpStore %531 %2782
+%2783 = OpLoad %ushort %530
+%2784 = OpLoad %ushort %531
+%2785 = OpBitwiseXor %ushort %2783 %2784
+OpStore %532 %2785
+%2786 = OpLoad %_arr_ushort_uint_8 %459
+%2787 = OpCompositeExtract %ushort %2786 6
+OpStore %533 %2787
+%2788 = OpLoad %_arr_ushort_uint_8 %514
+%2789 = OpCompositeExtract %ushort %2788 6
+OpStore %534 %2789
+%2790 = OpLoad %ushort %533
+%2791 = OpLoad %ushort %534
+%2792 = OpBitwiseXor %ushort %2790 %2791
+OpStore %535 %2792
+%2793 = OpLoad %_arr_ushort_uint_8 %459
+%2794 = OpCompositeExtract %ushort %2793 7
+OpStore %536 %2794
+%2795 = OpLoad %_arr_ushort_uint_8 %514
+%2796 = OpCompositeExtract %ushort %2795 7
+OpStore %537 %2796
+%2797 = OpLoad %ushort %536
+%2798 = OpLoad %ushort %537
+%2799 = OpBitwiseXor %ushort %2797 %2798
+OpStore %538 %2799
+%2800 = OpLoad %_arr_ushort_uint_8 %459
+%2801 = OpLoad %ushort %517
+%2802 = OpCompositeInsert %_arr_ushort_uint_8 %2801 %2800 0
+OpStore %539 %2802
+%2803 = OpLoad %_arr_ushort_uint_8 %539
+%2804 = OpLoad %ushort %520
+%2805 = OpCompositeInsert %_arr_ushort_uint_8 %2804 %2803 1
+OpStore %540 %2805
+%2806 = OpLoad %_arr_ushort_uint_8 %540
+%2807 = OpLoad %ushort %523
+%2808 = OpCompositeInsert %_arr_ushort_uint_8 %2807 %2806 2
+OpStore %541 %2808
+%2809 = OpLoad %_arr_ushort_uint_8 %541
+%2810 = OpLoad %ushort %526
+%2811 = OpCompositeInsert %_arr_ushort_uint_8 %2810 %2809 3
+OpStore %542 %2811
+%2812 = OpLoad %_arr_ushort_uint_8 %542
+%2813 = OpLoad %ushort %529
+%2814 = OpCompositeInsert %_arr_ushort_uint_8 %2813 %2812 4
+OpStore %543 %2814
+%2815 = OpLoad %_arr_ushort_uint_8 %543
+%2816 = OpLoad %ushort %532
+%2817 = OpCompositeInsert %_arr_ushort_uint_8 %2816 %2815 5
+OpStore %544 %2817
+%2818 = OpLoad %_arr_ushort_uint_8 %544
+%2819 = OpLoad %ushort %535
+%2820 = OpCompositeInsert %_arr_ushort_uint_8 %2819 %2818 6
+OpStore %545 %2820
+%2821 = OpLoad %_arr_ushort_uint_8 %545
+%2822 = OpLoad %ushort %538
+%2823 = OpCompositeInsert %_arr_ushort_uint_8 %2822 %2821 7
+OpStore %546 %2823
+%2824 = OpLoad %ulong %441
+%2825 = OpLoad %_arr_ushort_uint_8 %546
+%2826 = OpFunctionCall %ulong %1 %2824 %2825
+OpStore %442 %2826
+%2827 = OpLoad %_arr_ushort_uint_8 %460
+%2828 = OpCompositeExtract %ushort %2827 0
+OpStore %547 %2828
+%2829 = OpLoad %_arr_ushort_uint_8 %458
+%2830 = OpCompositeExtract %ushort %2829 0
+OpStore %548 %2830
+%2831 = OpLoad %ushort %547
+%2832 = OpLoad %ushort %548
+%2833 = OpIAdd %ushort %2831 %2832
+OpStore %549 %2833
+%2834 = OpLoad %_arr_ushort_uint_8 %460
+%2835 = OpCompositeExtract %ushort %2834 1
+OpStore %550 %2835
+%2836 = OpLoad %_arr_ushort_uint_8 %458
+%2837 = OpCompositeExtract %ushort %2836 1
+OpStore %551 %2837
+%2838 = OpLoad %ushort %550
+%2839 = OpLoad %ushort %551
+%2840 = OpIAdd %ushort %2838 %2839
+OpStore %552 %2840
+%2841 = OpLoad %_arr_ushort_uint_8 %460
+%2842 = OpCompositeExtract %ushort %2841 2
+OpStore %553 %2842
+%2843 = OpLoad %_arr_ushort_uint_8 %458
+%2844 = OpCompositeExtract %ushort %2843 2
+OpStore %554 %2844
+%2845 = OpLoad %ushort %553
+%2846 = OpLoad %ushort %554
+%2847 = OpIAdd %ushort %2845 %2846
+OpStore %555 %2847
+%2848 = OpLoad %_arr_ushort_uint_8 %460
+%2849 = OpCompositeExtract %ushort %2848 3
+OpStore %556 %2849
+%2850 = OpLoad %_arr_ushort_uint_8 %458
+%2851 = OpCompositeExtract %ushort %2850 3
+OpStore %557 %2851
+%2852 = OpLoad %ushort %556
+%2853 = OpLoad %ushort %557
+%2854 = OpIAdd %ushort %2852 %2853
+OpStore %558 %2854
+%2855 = OpLoad %_arr_ushort_uint_8 %460
+%2856 = OpCompositeExtract %ushort %2855 4
+OpStore %559 %2856
+%2857 = OpLoad %_arr_ushort_uint_8 %458
+%2858 = OpCompositeExtract %ushort %2857 4
+OpStore %560 %2858
+%2859 = OpLoad %ushort %559
+%2860 = OpLoad %ushort %560
+%2861 = OpIAdd %ushort %2859 %2860
+OpStore %561 %2861
+%2862 = OpLoad %_arr_ushort_uint_8 %460
+%2863 = OpCompositeExtract %ushort %2862 5
+OpStore %562 %2863
+%2864 = OpLoad %_arr_ushort_uint_8 %458
+%2865 = OpCompositeExtract %ushort %2864 5
+OpStore %563 %2865
+%2866 = OpLoad %ushort %562
+%2867 = OpLoad %ushort %563
+%2868 = OpIAdd %ushort %2866 %2867
+OpStore %564 %2868
+%2869 = OpLoad %_arr_ushort_uint_8 %460
+%2870 = OpCompositeExtract %ushort %2869 6
+OpStore %565 %2870
+%2871 = OpLoad %_arr_ushort_uint_8 %458
+%2872 = OpCompositeExtract %ushort %2871 6
+OpStore %566 %2872
+%2873 = OpLoad %ushort %565
+%2874 = OpLoad %ushort %566
+%2875 = OpIAdd %ushort %2873 %2874
+OpStore %567 %2875
+%2876 = OpLoad %_arr_ushort_uint_8 %460
+%2877 = OpCompositeExtract %ushort %2876 7
+OpStore %568 %2877
+%2878 = OpLoad %_arr_ushort_uint_8 %458
+%2879 = OpCompositeExtract %ushort %2878 7
+OpStore %569 %2879
+%2880 = OpLoad %ushort %568
+%2881 = OpLoad %ushort %569
+%2882 = OpIAdd %ushort %2880 %2881
+OpStore %570 %2882
+%2883 = OpLoad %_arr_ushort_uint_8 %460
+%2884 = OpLoad %ushort %549
+%2885 = OpCompositeInsert %_arr_ushort_uint_8 %2884 %2883 0
+OpStore %571 %2885
+%2886 = OpLoad %_arr_ushort_uint_8 %571
+%2887 = OpLoad %ushort %552
+%2888 = OpCompositeInsert %_arr_ushort_uint_8 %2887 %2886 1
+OpStore %572 %2888
+%2889 = OpLoad %_arr_ushort_uint_8 %572
+%2890 = OpLoad %ushort %555
+%2891 = OpCompositeInsert %_arr_ushort_uint_8 %2890 %2889 2
+OpStore %573 %2891
+%2892 = OpLoad %_arr_ushort_uint_8 %573
+%2893 = OpLoad %ushort %558
+%2894 = OpCompositeInsert %_arr_ushort_uint_8 %2893 %2892 3
+OpStore %574 %2894
+%2895 = OpLoad %_arr_ushort_uint_8 %574
+%2896 = OpLoad %ushort %561
+%2897 = OpCompositeInsert %_arr_ushort_uint_8 %2896 %2895 4
+OpStore %575 %2897
+%2898 = OpLoad %_arr_ushort_uint_8 %575
+%2899 = OpLoad %ushort %564
+%2900 = OpCompositeInsert %_arr_ushort_uint_8 %2899 %2898 5
+OpStore %576 %2900
+%2901 = OpLoad %_arr_ushort_uint_8 %576
+%2902 = OpLoad %ushort %567
+%2903 = OpCompositeInsert %_arr_ushort_uint_8 %2902 %2901 6
+OpStore %577 %2903
+%2904 = OpLoad %_arr_ushort_uint_8 %577
+%2905 = OpLoad %ushort %570
+%2906 = OpCompositeInsert %_arr_ushort_uint_8 %2905 %2904 7
+OpStore %578 %2906
+%2907 = OpLoad %ulong %442
+%2908 = OpLoad %_arr_ushort_uint_8 %578
+%2909 = OpFunctionCall %ulong %1 %2907 %2908
+OpStore %443 %2909
+%2910 = OpLoad %_arr_ushort_uint_8 %458
+%2911 = OpCompositeExtract %ushort %2910 0
+OpStore %579 %2911
+%2912 = OpLoad %_arr_ushort_uint_8 %422
+%2913 = OpCompositeExtract %ushort %2912 0
+OpStore %580 %2913
+%2914 = OpLoad %ushort %579
+%2915 = OpLoad %ushort %580
+%2916 = OpIAdd %ushort %2914 %2915
+OpStore %581 %2916
+%2917 = OpLoad %_arr_ushort_uint_8 %458
+%2918 = OpCompositeExtract %ushort %2917 1
+OpStore %582 %2918
+%2919 = OpLoad %_arr_ushort_uint_8 %422
+%2920 = OpCompositeExtract %ushort %2919 1
+OpStore %583 %2920
+%2921 = OpLoad %ushort %582
+%2922 = OpLoad %ushort %583
+%2923 = OpIAdd %ushort %2921 %2922
+OpStore %584 %2923
+%2924 = OpLoad %_arr_ushort_uint_8 %458
+%2925 = OpCompositeExtract %ushort %2924 2
+OpStore %585 %2925
+%2926 = OpLoad %_arr_ushort_uint_8 %422
+%2927 = OpCompositeExtract %ushort %2926 2
+OpStore %586 %2927
+%2928 = OpLoad %ushort %585
+%2929 = OpLoad %ushort %586
+%2930 = OpIAdd %ushort %2928 %2929
+OpStore %587 %2930
+%2931 = OpLoad %_arr_ushort_uint_8 %458
+%2932 = OpCompositeExtract %ushort %2931 3
+OpStore %588 %2932
+%2933 = OpLoad %_arr_ushort_uint_8 %422
+%2934 = OpCompositeExtract %ushort %2933 3
+OpStore %589 %2934
+%2935 = OpLoad %ushort %588
+%2936 = OpLoad %ushort %589
+%2937 = OpIAdd %ushort %2935 %2936
+OpStore %590 %2937
+%2938 = OpLoad %_arr_ushort_uint_8 %458
+%2939 = OpCompositeExtract %ushort %2938 4
+OpStore %591 %2939
+%2940 = OpLoad %_arr_ushort_uint_8 %422
+%2941 = OpCompositeExtract %ushort %2940 4
+OpStore %592 %2941
+%2942 = OpLoad %ushort %591
+%2943 = OpLoad %ushort %592
+%2944 = OpIAdd %ushort %2942 %2943
+OpStore %593 %2944
+%2945 = OpLoad %_arr_ushort_uint_8 %458
+%2946 = OpCompositeExtract %ushort %2945 5
+OpStore %594 %2946
+%2947 = OpLoad %_arr_ushort_uint_8 %422
+%2948 = OpCompositeExtract %ushort %2947 5
+OpStore %595 %2948
+%2949 = OpLoad %ushort %594
+%2950 = OpLoad %ushort %595
+%2951 = OpIAdd %ushort %2949 %2950
+OpStore %596 %2951
+%2952 = OpLoad %_arr_ushort_uint_8 %458
+%2953 = OpCompositeExtract %ushort %2952 6
+OpStore %597 %2953
+%2954 = OpLoad %_arr_ushort_uint_8 %422
+%2955 = OpCompositeExtract %ushort %2954 6
+OpStore %598 %2955
+%2956 = OpLoad %ushort %597
+%2957 = OpLoad %ushort %598
+%2958 = OpIAdd %ushort %2956 %2957
+OpStore %599 %2958
+%2959 = OpLoad %_arr_ushort_uint_8 %458
+%2960 = OpCompositeExtract %ushort %2959 7
+OpStore %600 %2960
+%2961 = OpLoad %_arr_ushort_uint_8 %422
+%2962 = OpCompositeExtract %ushort %2961 7
+OpStore %601 %2962
+%2963 = OpLoad %ushort %600
+%2964 = OpLoad %ushort %601
+%2965 = OpIAdd %ushort %2963 %2964
+OpStore %602 %2965
+%2966 = OpLoad %_arr_ushort_uint_8 %458
+%2967 = OpLoad %ushort %581
+%2968 = OpCompositeInsert %_arr_ushort_uint_8 %2967 %2966 0
+OpStore %603 %2968
+%2969 = OpLoad %_arr_ushort_uint_8 %603
+%2970 = OpLoad %ushort %584
+%2971 = OpCompositeInsert %_arr_ushort_uint_8 %2970 %2969 1
+OpStore %604 %2971
+%2972 = OpLoad %_arr_ushort_uint_8 %604
+%2973 = OpLoad %ushort %587
+%2974 = OpCompositeInsert %_arr_ushort_uint_8 %2973 %2972 2
+OpStore %605 %2974
+%2975 = OpLoad %_arr_ushort_uint_8 %605
+%2976 = OpLoad %ushort %590
+%2977 = OpCompositeInsert %_arr_ushort_uint_8 %2976 %2975 3
+OpStore %606 %2977
+%2978 = OpLoad %_arr_ushort_uint_8 %606
+%2979 = OpLoad %ushort %593
+%2980 = OpCompositeInsert %_arr_ushort_uint_8 %2979 %2978 4
+OpStore %607 %2980
+%2981 = OpLoad %_arr_ushort_uint_8 %607
+%2982 = OpLoad %ushort %596
+%2983 = OpCompositeInsert %_arr_ushort_uint_8 %2982 %2981 5
+OpStore %608 %2983
+%2984 = OpLoad %_arr_ushort_uint_8 %608
+%2985 = OpLoad %ushort %599
+%2986 = OpCompositeInsert %_arr_ushort_uint_8 %2985 %2984 6
+OpStore %609 %2986
+%2987 = OpLoad %_arr_ushort_uint_8 %609
+%2988 = OpLoad %ushort %602
+%2989 = OpCompositeInsert %_arr_ushort_uint_8 %2988 %2987 7
+OpStore %610 %2989
+%2990 = OpLoad %ulong %443
+%2991 = OpLoad %_arr_ushort_uint_8 %610
+%2992 = OpFunctionCall %ulong %1 %2990 %2991
+OpStore %444 %2992
+%2993 = OpLoad %ulong %461
+%2994 = OpIAdd %ulong %2993 %ulong_1
+OpStore %445 %2994
+%2995 = OpLoad %ulong %444
+OpStore %457 %2995
+%2996 = OpLoad %_arr_ushort_uint_8 %610
+OpStore %458 %2996
+%2997 = OpLoad %_arr_ushort_uint_8 %546
+OpStore %459 %2997
+%2998 = OpLoad %_arr_ushort_uint_8 %578
+OpStore %460 %2998
+%2999 = OpLoad %ulong %445
+OpStore %461 %2999
+OpBranch %397
+%394 = OpLabel
+OpBranch %390
+%395 = OpLabel
+OpBranch %383
+%396 = OpLabel
+OpBranch %375
+%397 = OpLabel
+OpBranch %372
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_i32x4.dis
+++ b/test/golden/spirv/vec/vec_i32x4.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 900
+; Bound: 602
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,18 +12,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i32x4.checksum" Export
 %ulong = OpTypeInt 64 0
 %uint = OpTypeInt 32 0
 %v4uint = OpTypeVector %uint 4
-%9 = OpTypeFunction %ulong %ulong %v4uint
+%6 = OpTypeFunction %ulong %ulong %v4uint
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4uint = OpTypePointer Function %v4uint
 %_ptr_Function_uint = OpTypePointer Function %uint
-%47 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%195 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr_v4uint_uint_4 = OpTypeArray %v4uint %uint_4
 %_ptr_Function__arr_v4uint_uint_4 = OpTypePointer Function %_arr_v4uint_uint_4
-%_struct_95 = OpTypeStruct %uint %v4uint %uint
-%_ptr_Function__struct_95 = OpTypePointer Function %_struct_95
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_228 = OpTypeStruct %uint %v4uint %uint
+%_ptr_Function__struct_228 = OpTypePointer Function %_struct_228
 %uint_10007 = OpConstant %uint 10007
 %uint_4294947285 = OpConstant %uint 4294947285
 %uint_30013 = OpConstant %uint 30013
@@ -36,1187 +41,812 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i32x4.checksum" Export
 %uint_9 = OpConstant %uint 9
 %uint_27 = OpConstant %uint 27
 %uint_0 = OpConstant %uint 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%618 = OpConstantNull %_arr_v4uint_uint_4
+%479 = OpConstantNull %_arr_v4uint_uint_4
 %uint_2 = OpConstant %uint 2
 %ulong_4 = OpConstant %ulong 4
-%639 = OpConstantNull %_struct_95
+%500 = OpConstantNull %_struct_228
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%805 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%808 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %9
-%10 = OpFunctionParameter %ulong
-%11 = OpFunctionParameter %v4uint
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v4uint
+%9 = OpLabel
+%44 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_v4uint Function
+%48 = OpVariable %_ptr_Function_uint Function
+%49 = OpVariable %_ptr_Function_uint Function
+%50 = OpVariable %_ptr_Function_uint Function
+%51 = OpVariable %_ptr_Function_uint Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_bool Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_bool Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_bool Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_bool Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+OpStore %44 %7
+OpStore %46 %8
+%93 = OpLoad %v4uint %46
+%94 = OpCompositeExtract %uint %93 0
+OpStore %48 %94
+OpBranch %10
+%10 = OpLabel
+%95 = OpLoad %uint %48
+%96 = OpSConvert %ulong %95
+OpStore %52 %96
+OpBranch %12
 %12 = OpLabel
-%14 = OpVariable %_ptr_Function_ulong Function
-%16 = OpVariable %_ptr_Function_v4uint Function
-%18 = OpVariable %_ptr_Function_uint Function
-%19 = OpVariable %_ptr_Function_ulong Function
-%20 = OpVariable %_ptr_Function_uint Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uint Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_uint Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %14 %10
-OpStore %16 %11
-%26 = OpLoad %v4uint %16
-%27 = OpCompositeExtract %uint %26 0
-OpStore %18 %27
-%28 = OpLoad %ulong %14
-%29 = OpLoad %uint %18
-%30 = OpFunctionCall %ulong %5 %28 %29
-OpStore %19 %30
-%31 = OpLoad %v4uint %16
-%32 = OpCompositeExtract %uint %31 1
-OpStore %20 %32
-%33 = OpLoad %ulong %19
-%34 = OpLoad %uint %20
-%35 = OpFunctionCall %ulong %5 %33 %34
-OpStore %21 %35
-%36 = OpLoad %v4uint %16
-%37 = OpCompositeExtract %uint %36 2
-OpStore %22 %37
-%38 = OpLoad %ulong %21
-%39 = OpLoad %uint %22
-%40 = OpFunctionCall %ulong %5 %38 %39
-OpStore %23 %40
-%41 = OpLoad %v4uint %16
-%42 = OpCompositeExtract %uint %41 3
-OpStore %24 %42
-%43 = OpLoad %ulong %23
-%44 = OpLoad %uint %24
-%45 = OpFunctionCall %ulong %5 %43 %44
-OpStore %25 %45
-%46 = OpLoad %ulong %25
-OpReturnValue %46
+%97 = OpLoad %ulong %44
+OpStore %61 %97
+OpStore %62 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%99 = OpLoad %ulong %62
+%101 = OpULessThan %bool %99 %ulong_8
+OpStore %54 %101
+%102 = OpLoad %bool %54
+OpLoopMerge %15 %41 None
+OpBranchConditional %102 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
+%11 = OpLabel
+%103 = OpLoad %v4uint %46
+%104 = OpCompositeExtract %uint %103 1
+OpStore %49 %104
+OpBranch %17
+%17 = OpLabel
+%105 = OpLoad %uint %49
+%106 = OpSConvert %ulong %105
+OpStore %63 %106
+OpBranch %19
+%19 = OpLabel
+%107 = OpLoad %ulong %61
+OpStore %71 %107
+OpStore %72 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%108 = OpLoad %ulong %72
+%109 = OpULessThan %bool %108 %ulong_8
+OpStore %64 %109
+%110 = OpLoad %bool %64
+OpLoopMerge %22 %40 None
+OpBranchConditional %110 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%111 = OpLoad %v4uint %46
+%112 = OpCompositeExtract %uint %111 2
+OpStore %50 %112
+OpBranch %24
+%24 = OpLabel
+%113 = OpLoad %uint %50
+%114 = OpSConvert %ulong %113
+OpStore %73 %114
+OpBranch %26
+%26 = OpLabel
+%115 = OpLoad %ulong %71
+OpStore %81 %115
+OpStore %82 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%116 = OpLoad %ulong %82
+%117 = OpULessThan %bool %116 %ulong_8
+OpStore %74 %117
+%118 = OpLoad %bool %74
+OpLoopMerge %29 %39 None
+OpBranchConditional %118 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%119 = OpLoad %v4uint %46
+%120 = OpCompositeExtract %uint %119 3
+OpStore %51 %120
+OpBranch %31
+%31 = OpLabel
+%121 = OpLoad %uint %51
+%122 = OpSConvert %ulong %121
+OpStore %83 %122
+OpBranch %33
+%33 = OpLabel
+%123 = OpLoad %ulong %81
+OpStore %91 %123
+OpStore %92 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%124 = OpLoad %ulong %92
+%125 = OpULessThan %bool %124 %ulong_8
+OpStore %84 %125
+%126 = OpLoad %bool %84
+OpLoopMerge %36 %38 None
+OpBranchConditional %126 %35 %36
+%36 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%127 = OpLoad %ulong %91
+OpReturnValue %127
+%35 = OpLabel
+%128 = OpLoad %ulong %92
+%129 = OpIMul %ulong %128 %ulong_8
+OpStore %85 %129
+%130 = OpLoad %ulong %83
+%131 = OpLoad %ulong %85
+%132 = OpShiftRightLogical %ulong %130 %131
+OpStore %86 %132
+%133 = OpLoad %ulong %86
+%135 = OpBitwiseAnd %ulong %133 %ulong_255
+OpStore %87 %135
+%136 = OpLoad %ulong %91
+%137 = OpLoad %ulong %87
+%138 = OpBitwiseXor %ulong %136 %137
+OpStore %88 %138
+%139 = OpLoad %ulong %88
+%141 = OpIMul %ulong %139 %ulong_1099511628211
+OpStore %89 %141
+%142 = OpLoad %ulong %92
+%144 = OpIAdd %ulong %142 %ulong_1
+OpStore %90 %144
+%145 = OpLoad %ulong %89
+OpStore %91 %145
+%146 = OpLoad %ulong %90
+OpStore %92 %146
+OpBranch %38
+%28 = OpLabel
+%147 = OpLoad %ulong %82
+%148 = OpIMul %ulong %147 %ulong_8
+OpStore %75 %148
+%149 = OpLoad %ulong %73
+%150 = OpLoad %ulong %75
+%151 = OpShiftRightLogical %ulong %149 %150
+OpStore %76 %151
+%152 = OpLoad %ulong %76
+%153 = OpBitwiseAnd %ulong %152 %ulong_255
+OpStore %77 %153
+%154 = OpLoad %ulong %81
+%155 = OpLoad %ulong %77
+%156 = OpBitwiseXor %ulong %154 %155
+OpStore %78 %156
+%157 = OpLoad %ulong %78
+%158 = OpIMul %ulong %157 %ulong_1099511628211
+OpStore %79 %158
+%159 = OpLoad %ulong %82
+%160 = OpIAdd %ulong %159 %ulong_1
+OpStore %80 %160
+%161 = OpLoad %ulong %79
+OpStore %81 %161
+%162 = OpLoad %ulong %80
+OpStore %82 %162
+OpBranch %39
+%21 = OpLabel
+%163 = OpLoad %ulong %72
+%164 = OpIMul %ulong %163 %ulong_8
+OpStore %65 %164
+%165 = OpLoad %ulong %63
+%166 = OpLoad %ulong %65
+%167 = OpShiftRightLogical %ulong %165 %166
+OpStore %66 %167
+%168 = OpLoad %ulong %66
+%169 = OpBitwiseAnd %ulong %168 %ulong_255
+OpStore %67 %169
+%170 = OpLoad %ulong %71
+%171 = OpLoad %ulong %67
+%172 = OpBitwiseXor %ulong %170 %171
+OpStore %68 %172
+%173 = OpLoad %ulong %68
+%174 = OpIMul %ulong %173 %ulong_1099511628211
+OpStore %69 %174
+%175 = OpLoad %ulong %72
+%176 = OpIAdd %ulong %175 %ulong_1
+OpStore %70 %176
+%177 = OpLoad %ulong %69
+OpStore %71 %177
+%178 = OpLoad %ulong %70
+OpStore %72 %178
+OpBranch %40
+%14 = OpLabel
+%179 = OpLoad %ulong %62
+%180 = OpIMul %ulong %179 %ulong_8
+OpStore %55 %180
+%181 = OpLoad %ulong %52
+%182 = OpLoad %ulong %55
+%183 = OpShiftRightLogical %ulong %181 %182
+OpStore %56 %183
+%184 = OpLoad %ulong %56
+%185 = OpBitwiseAnd %ulong %184 %ulong_255
+OpStore %57 %185
+%186 = OpLoad %ulong %61
+%187 = OpLoad %ulong %57
+%188 = OpBitwiseXor %ulong %186 %187
+OpStore %58 %188
+%189 = OpLoad %ulong %58
+%190 = OpIMul %ulong %189 %ulong_1099511628211
+OpStore %59 %190
+%191 = OpLoad %ulong %62
+%192 = OpIAdd %ulong %191 %ulong_1
+OpStore %60 %192
+%193 = OpLoad %ulong %59
+OpStore %61 %193
+%194 = OpLoad %ulong %60
+OpStore %62 %194
+OpBranch %41
+%38 = OpLabel
+OpBranch %34
+%39 = OpLabel
+OpBranch %27
+%40 = OpLabel
+OpBranch %20
+%41 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %47
-%48 = OpFunctionParameter %ulong
-%49 = OpLabel
-%94 = OpVariable %_ptr_Function__arr_v4uint_uint_4 Function
-%97 = OpVariable %_ptr_Function__struct_95 Function
-%98 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_uint Function
-%101 = OpVariable %_ptr_Function_v4uint Function
-%102 = OpVariable %_ptr_Function_v4uint Function
-%103 = OpVariable %_ptr_Function_v4uint Function
-%104 = OpVariable %_ptr_Function_v4uint Function
-%105 = OpVariable %_ptr_Function_uint Function
-%106 = OpVariable %_ptr_Function_uint Function
-%107 = OpVariable %_ptr_Function_v4uint Function
-%108 = OpVariable %_ptr_Function_uint Function
-%109 = OpVariable %_ptr_Function_uint Function
-%110 = OpVariable %_ptr_Function_v4uint Function
-%111 = OpVariable %_ptr_Function_uint Function
-%112 = OpVariable %_ptr_Function_uint Function
-%113 = OpVariable %_ptr_Function_v4uint Function
-%114 = OpVariable %_ptr_Function_uint Function
-%115 = OpVariable %_ptr_Function_uint Function
-%116 = OpVariable %_ptr_Function_v4uint Function
-%117 = OpVariable %_ptr_Function_v4uint Function
-%118 = OpVariable %_ptr_Function_v4uint Function
-%119 = OpVariable %_ptr_Function_v4uint Function
-%120 = OpVariable %_ptr_Function_v4uint Function
-%121 = OpVariable %_ptr_Function_v4uint Function
-%122 = OpVariable %_ptr_Function_v4uint Function
-%123 = OpVariable %_ptr_Function_v4uint Function
-%124 = OpVariable %_ptr_Function_v4uint Function
-%125 = OpVariable %_ptr_Function_v4uint Function
-%126 = OpVariable %_ptr_Function_v4uint Function
-%127 = OpVariable %_ptr_Function_ulong Function
-%128 = OpVariable %_ptr_Function_v4uint Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_v4uint Function
-%131 = OpVariable %_ptr_Function_ulong Function
-%132 = OpVariable %_ptr_Function_v4uint Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_v4uint Function
-%135 = OpVariable %_ptr_Function_ulong Function
-%136 = OpVariable %_ptr_Function_v4uint Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_v4uint Function
-%139 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_bool Function
-%142 = OpVariable %_ptr_Function_v4uint Function
-%143 = OpVariable %_ptr_Function_v4uint Function
-%144 = OpVariable %_ptr_Function_v4uint Function
-%145 = OpVariable %_ptr_Function_v4uint Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_v4uint Function
-%148 = OpVariable %_ptr_Function_v4uint Function
-%149 = OpVariable %_ptr_Function_bool Function
-%150 = OpVariable %_ptr_Function_v4uint Function
-%151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_v4uint Function
-%153 = OpVariable %_ptr_Function_uint Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_v4uint Function
-%156 = OpVariable %_ptr_Function_uint Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function_v4uint Function
-%161 = OpVariable %_ptr_Function_v4uint Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_uint Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_uint Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_uint Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_uint Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_uint Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_uint Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_uint Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_uint Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_uint Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_uint Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_uint Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_uint Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_uint Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_uint Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_uint Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_uint Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_uint Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_uint Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_uint Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_uint Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_uint Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_uint Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_uint Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_uint Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_uint Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_uint Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_uint Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_uint Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_uint Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_uint Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_uint Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_uint Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_uint Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_uint Function
+%2 = OpFunction %ulong None %195
+%196 = OpFunctionParameter %ulong
+%197 = OpLabel
+%227 = OpVariable %_ptr_Function__arr_v4uint_uint_4 Function
+%230 = OpVariable %_ptr_Function__struct_228 Function
 %231 = OpVariable %_ptr_Function_ulong Function
 %232 = OpVariable %_ptr_Function_uint Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_uint Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_uint Function
-%237 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_v4uint Function
+%234 = OpVariable %_ptr_Function_v4uint Function
+%235 = OpVariable %_ptr_Function_v4uint Function
+%236 = OpVariable %_ptr_Function_v4uint Function
+%237 = OpVariable %_ptr_Function_uint Function
 %238 = OpVariable %_ptr_Function_uint Function
-%239 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_v4uint Function
 %240 = OpVariable %_ptr_Function_uint Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_uint Function
-%243 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_uint Function
+%242 = OpVariable %_ptr_Function_v4uint Function
+%243 = OpVariable %_ptr_Function_uint Function
 %244 = OpVariable %_ptr_Function_uint Function
-%245 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_v4uint Function
 %246 = OpVariable %_ptr_Function_uint Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_uint Function
+%247 = OpVariable %_ptr_Function_uint Function
+%248 = OpVariable %_ptr_Function_v4uint Function
 %249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_uint Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_uint Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_uint Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_uint Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_uint Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_uint Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_uint Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_uint Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_uint Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_uint Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_uint Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_uint Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_uint Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_uint Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_uint Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_uint Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_uint Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_v4uint Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_v4uint Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_v4uint Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_v4uint Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_v4uint Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_v4uint Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_v4uint Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_v4uint Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_v4uint Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_v4uint Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_v4uint Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_v4uint Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_v4uint Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_v4uint Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_v4uint Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_bool Function
+%282 = OpVariable %_ptr_Function_v4uint Function
 %283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_uint Function
+%284 = OpVariable %_ptr_Function_v4uint Function
 %285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_uint Function
+%286 = OpVariable %_ptr_Function_v4uint Function
 %287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_v4uint Function
 %289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_uint Function
-%291 = OpVariable %_ptr_Function_ulong Function
-OpStore %98 %48
-%292 = OpFunctionCall %ulong %3
-OpStore %99 %292
-%293 = OpLoad %ulong %98
-%294 = OpUConvert %uint %293
-OpStore %100 %294
-%295 = OpCompositeConstruct %v4uint %uint_10007 %uint_4294947285 %uint_30013 %uint_4294934528
-OpStore %101 %295
-%300 = OpCompositeConstruct %v4uint %uint_4294967289 %uint_131 %uint_4294966287 %uint_3
-OpStore %102 %300
-%305 = OpCompositeConstruct %v4uint %uint_1 %uint_3 %uint_9 %uint_27
-OpStore %103 %305
-%309 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
-OpStore %104 %309
-%311 = OpLoad %v4uint %101
-%312 = OpCompositeExtract %uint %311 0
-OpStore %105 %312
-%313 = OpLoad %uint %105
-%314 = OpLoad %uint %100
-%315 = OpIAdd %uint %313 %314
-OpStore %106 %315
-%316 = OpLoad %v4uint %101
-%317 = OpLoad %uint %106
-%318 = OpCompositeInsert %v4uint %317 %316 0
-OpStore %107 %318
-%319 = OpLoad %v4uint %107
-%320 = OpCompositeExtract %uint %319 2
-OpStore %108 %320
-%321 = OpLoad %uint %108
-%322 = OpLoad %uint %100
-%323 = OpIAdd %uint %321 %322
-OpStore %109 %323
-%324 = OpLoad %v4uint %107
-%325 = OpLoad %uint %109
-%326 = OpCompositeInsert %v4uint %325 %324 2
-OpStore %110 %326
-%327 = OpLoad %v4uint %102
-%328 = OpCompositeExtract %uint %327 1
-OpStore %111 %328
-%329 = OpLoad %uint %111
-%330 = OpLoad %uint %100
-%331 = OpIAdd %uint %329 %330
-OpStore %112 %331
-%332 = OpLoad %v4uint %102
-%333 = OpLoad %uint %112
-%334 = OpCompositeInsert %v4uint %333 %332 1
-OpStore %113 %334
-%335 = OpLoad %v4uint %113
-%336 = OpCompositeExtract %uint %335 3
-OpStore %114 %336
-%337 = OpLoad %uint %114
-%338 = OpLoad %uint %100
-%339 = OpIAdd %uint %337 %338
-OpStore %115 %339
-%340 = OpLoad %v4uint %113
-%341 = OpLoad %uint %115
-%342 = OpCompositeInsert %v4uint %341 %340 3
-OpStore %116 %342
-OpBranch %56
-%56 = OpLabel
-%343 = OpLoad %v4uint %110
-%344 = OpCompositeExtract %uint %343 0
-OpStore %164 %344
-%345 = OpLoad %ulong %99
-%346 = OpLoad %uint %164
-%347 = OpFunctionCall %ulong %5 %345 %346
-OpStore %165 %347
-%348 = OpLoad %v4uint %110
-%349 = OpCompositeExtract %uint %348 1
-OpStore %166 %349
-%350 = OpLoad %ulong %165
-%351 = OpLoad %uint %166
-%352 = OpFunctionCall %ulong %5 %350 %351
-OpStore %167 %352
-%353 = OpLoad %v4uint %110
-%354 = OpCompositeExtract %uint %353 2
-OpStore %168 %354
-%355 = OpLoad %ulong %167
-%356 = OpLoad %uint %168
-%357 = OpFunctionCall %ulong %5 %355 %356
-OpStore %169 %357
-%358 = OpLoad %v4uint %110
-%359 = OpCompositeExtract %uint %358 3
-OpStore %170 %359
-%360 = OpLoad %ulong %169
-%361 = OpLoad %uint %170
-%362 = OpFunctionCall %ulong %5 %360 %361
-OpStore %171 %362
-OpBranch %57
-%57 = OpLabel
-OpBranch %64
-%64 = OpLabel
-%363 = OpLoad %v4uint %116
-%364 = OpCompositeExtract %uint %363 0
-OpStore %196 %364
-%365 = OpLoad %ulong %171
-%366 = OpLoad %uint %196
-%367 = OpFunctionCall %ulong %5 %365 %366
-OpStore %197 %367
-%368 = OpLoad %v4uint %116
-%369 = OpCompositeExtract %uint %368 1
-OpStore %198 %369
-%370 = OpLoad %ulong %197
-%371 = OpLoad %uint %198
-%372 = OpFunctionCall %ulong %5 %370 %371
-OpStore %199 %372
-%373 = OpLoad %v4uint %116
-%374 = OpCompositeExtract %uint %373 2
-OpStore %200 %374
-%375 = OpLoad %ulong %199
-%376 = OpLoad %uint %200
-%377 = OpFunctionCall %ulong %5 %375 %376
-OpStore %201 %377
-%378 = OpLoad %v4uint %116
-%379 = OpCompositeExtract %uint %378 3
-OpStore %202 %379
-%380 = OpLoad %ulong %201
-%381 = OpLoad %uint %202
-%382 = OpFunctionCall %ulong %5 %380 %381
-OpStore %203 %382
-OpBranch %65
-%65 = OpLabel
-%383 = OpLoad %v4uint %110
-%384 = OpLoad %v4uint %116
-%385 = OpIAdd %v4uint %383 %384
-OpStore %117 %385
-OpBranch %68
-%68 = OpLabel
-%386 = OpLoad %v4uint %117
-%387 = OpCompositeExtract %uint %386 0
-OpStore %212 %387
-%388 = OpLoad %ulong %203
-%389 = OpLoad %uint %212
-%390 = OpFunctionCall %ulong %5 %388 %389
-OpStore %213 %390
-%391 = OpLoad %v4uint %117
-%392 = OpCompositeExtract %uint %391 1
-OpStore %214 %392
-%393 = OpLoad %ulong %213
-%394 = OpLoad %uint %214
-%395 = OpFunctionCall %ulong %5 %393 %394
-OpStore %215 %395
-%396 = OpLoad %v4uint %117
-%397 = OpCompositeExtract %uint %396 2
-OpStore %216 %397
-%398 = OpLoad %ulong %215
-%399 = OpLoad %uint %216
-%400 = OpFunctionCall %ulong %5 %398 %399
-OpStore %217 %400
-%401 = OpLoad %v4uint %117
-%402 = OpCompositeExtract %uint %401 3
-OpStore %218 %402
-%403 = OpLoad %ulong %217
-%404 = OpLoad %uint %218
-%405 = OpFunctionCall %ulong %5 %403 %404
-OpStore %219 %405
-OpBranch %69
-%69 = OpLabel
-%406 = OpLoad %v4uint %110
-%407 = OpLoad %v4uint %116
-%408 = OpISub %v4uint %406 %407
-OpStore %118 %408
-OpBranch %72
-%72 = OpLabel
-%409 = OpLoad %v4uint %118
-%410 = OpCompositeExtract %uint %409 0
-OpStore %228 %410
-%411 = OpLoad %ulong %219
-%412 = OpLoad %uint %228
-%413 = OpFunctionCall %ulong %5 %411 %412
-OpStore %229 %413
-%414 = OpLoad %v4uint %118
-%415 = OpCompositeExtract %uint %414 1
-OpStore %230 %415
-%416 = OpLoad %ulong %229
-%417 = OpLoad %uint %230
-%418 = OpFunctionCall %ulong %5 %416 %417
-OpStore %231 %418
-%419 = OpLoad %v4uint %118
-%420 = OpCompositeExtract %uint %419 2
-OpStore %232 %420
-%421 = OpLoad %ulong %231
-%422 = OpLoad %uint %232
-%423 = OpFunctionCall %ulong %5 %421 %422
-OpStore %233 %423
-%424 = OpLoad %v4uint %118
-%425 = OpCompositeExtract %uint %424 3
-OpStore %234 %425
-%426 = OpLoad %ulong %233
-%427 = OpLoad %uint %234
-%428 = OpFunctionCall %ulong %5 %426 %427
-OpStore %235 %428
-OpBranch %73
-%73 = OpLabel
-%429 = OpLoad %v4uint %116
-%430 = OpLoad %v4uint %110
-%431 = OpISub %v4uint %429 %430
-OpStore %119 %431
-OpBranch %76
-%76 = OpLabel
-%432 = OpLoad %v4uint %119
-%433 = OpCompositeExtract %uint %432 0
-OpStore %244 %433
-%434 = OpLoad %ulong %235
-%435 = OpLoad %uint %244
-%436 = OpFunctionCall %ulong %5 %434 %435
-OpStore %245 %436
-%437 = OpLoad %v4uint %119
-%438 = OpCompositeExtract %uint %437 1
-OpStore %246 %438
-%439 = OpLoad %ulong %245
-%440 = OpLoad %uint %246
-%441 = OpFunctionCall %ulong %5 %439 %440
-OpStore %247 %441
-%442 = OpLoad %v4uint %119
-%443 = OpCompositeExtract %uint %442 2
-OpStore %248 %443
-%444 = OpLoad %ulong %247
-%445 = OpLoad %uint %248
-%446 = OpFunctionCall %ulong %5 %444 %445
-OpStore %249 %446
-%447 = OpLoad %v4uint %119
-%448 = OpCompositeExtract %uint %447 3
-OpStore %250 %448
-%449 = OpLoad %ulong %249
-%450 = OpLoad %uint %250
-%451 = OpFunctionCall %ulong %5 %449 %450
-OpStore %251 %451
-OpBranch %77
-%77 = OpLabel
-%452 = OpLoad %v4uint %110
-%453 = OpLoad %v4uint %116
-%454 = OpIMul %v4uint %452 %453
-OpStore %120 %454
-OpBranch %78
-%78 = OpLabel
-%455 = OpLoad %v4uint %120
-%456 = OpCompositeExtract %uint %455 0
-OpStore %252 %456
-%457 = OpLoad %ulong %251
-%458 = OpLoad %uint %252
-%459 = OpFunctionCall %ulong %5 %457 %458
-OpStore %253 %459
-%460 = OpLoad %v4uint %120
-%461 = OpCompositeExtract %uint %460 1
-OpStore %254 %461
-%462 = OpLoad %ulong %253
-%463 = OpLoad %uint %254
-%464 = OpFunctionCall %ulong %5 %462 %463
-OpStore %255 %464
-%465 = OpLoad %v4uint %120
-%466 = OpCompositeExtract %uint %465 2
-OpStore %256 %466
-%467 = OpLoad %ulong %255
-%468 = OpLoad %uint %256
-%469 = OpFunctionCall %ulong %5 %467 %468
-OpStore %257 %469
-%470 = OpLoad %v4uint %120
-%471 = OpCompositeExtract %uint %470 3
-OpStore %258 %471
-%472 = OpLoad %ulong %257
-%473 = OpLoad %uint %258
-%474 = OpFunctionCall %ulong %5 %472 %473
-OpStore %259 %474
-OpBranch %79
-%79 = OpLabel
-%475 = OpLoad %v4uint %110
-%476 = OpLoad %v4uint %103
-%477 = OpIMul %v4uint %475 %476
-OpStore %121 %477
-OpBranch %80
-%80 = OpLabel
-%478 = OpLoad %v4uint %121
-%479 = OpCompositeExtract %uint %478 0
-OpStore %260 %479
-%480 = OpLoad %ulong %259
-%481 = OpLoad %uint %260
-%482 = OpFunctionCall %ulong %5 %480 %481
-OpStore %261 %482
-%483 = OpLoad %v4uint %121
-%484 = OpCompositeExtract %uint %483 1
-OpStore %262 %484
-%485 = OpLoad %ulong %261
-%486 = OpLoad %uint %262
-%487 = OpFunctionCall %ulong %5 %485 %486
-OpStore %263 %487
-%488 = OpLoad %v4uint %121
-%489 = OpCompositeExtract %uint %488 2
-OpStore %264 %489
-%490 = OpLoad %ulong %263
-%491 = OpLoad %uint %264
-%492 = OpFunctionCall %ulong %5 %490 %491
-OpStore %265 %492
-%493 = OpLoad %v4uint %121
-%494 = OpCompositeExtract %uint %493 3
-OpStore %266 %494
-%495 = OpLoad %ulong %265
-%496 = OpLoad %uint %266
-%497 = OpFunctionCall %ulong %5 %495 %496
-OpStore %267 %497
-OpBranch %81
-%81 = OpLabel
-%498 = OpLoad %v4uint %116
-%499 = OpLoad %v4uint %103
-%500 = OpIMul %v4uint %498 %499
-OpStore %122 %500
-OpBranch %82
-%82 = OpLabel
-%501 = OpLoad %v4uint %122
-%502 = OpCompositeExtract %uint %501 0
-OpStore %268 %502
-%503 = OpLoad %ulong %267
-%504 = OpLoad %uint %268
-%505 = OpFunctionCall %ulong %5 %503 %504
-OpStore %269 %505
-%506 = OpLoad %v4uint %122
-%507 = OpCompositeExtract %uint %506 1
-OpStore %270 %507
-%508 = OpLoad %ulong %269
-%509 = OpLoad %uint %270
-%510 = OpFunctionCall %ulong %5 %508 %509
-OpStore %271 %510
-%511 = OpLoad %v4uint %122
-%512 = OpCompositeExtract %uint %511 2
-OpStore %272 %512
-%513 = OpLoad %ulong %271
-%514 = OpLoad %uint %272
-%515 = OpFunctionCall %ulong %5 %513 %514
-OpStore %273 %515
-%516 = OpLoad %v4uint %122
-%517 = OpCompositeExtract %uint %516 3
-OpStore %274 %517
-%518 = OpLoad %ulong %273
-%519 = OpLoad %uint %274
-%520 = OpFunctionCall %ulong %5 %518 %519
-OpStore %275 %520
-OpBranch %83
-%83 = OpLabel
-%521 = OpLoad %v4uint %110
-%522 = OpLoad %v4uint %116
-%523 = OpIAdd %v4uint %521 %522
-OpStore %123 %523
-%524 = OpLoad %v4uint %123
-%525 = OpLoad %v4uint %103
-%526 = OpIMul %v4uint %524 %525
-OpStore %124 %526
-OpBranch %84
-%84 = OpLabel
-%527 = OpLoad %v4uint %124
-%528 = OpCompositeExtract %uint %527 0
-OpStore %276 %528
-%529 = OpLoad %ulong %275
-%530 = OpLoad %uint %276
-%531 = OpFunctionCall %ulong %5 %529 %530
-OpStore %277 %531
-%532 = OpLoad %v4uint %124
-%533 = OpCompositeExtract %uint %532 1
-OpStore %278 %533
-%534 = OpLoad %ulong %277
-%535 = OpLoad %uint %278
-%536 = OpFunctionCall %ulong %5 %534 %535
-OpStore %279 %536
-%537 = OpLoad %v4uint %124
-%538 = OpCompositeExtract %uint %537 2
-OpStore %280 %538
-%539 = OpLoad %ulong %279
-%540 = OpLoad %uint %280
-%541 = OpFunctionCall %ulong %5 %539 %540
-OpStore %281 %541
-%542 = OpLoad %v4uint %124
-%543 = OpCompositeExtract %uint %542 3
-OpStore %282 %543
-%544 = OpLoad %ulong %281
-%545 = OpLoad %uint %282
-%546 = OpFunctionCall %ulong %5 %544 %545
-OpStore %283 %546
-OpBranch %85
-%85 = OpLabel
-%547 = OpLoad %v4uint %104
-%548 = OpLoad %v4uint %110
-%549 = OpISub %v4uint %547 %548
-OpStore %125 %549
-OpBranch %86
-%86 = OpLabel
-%550 = OpLoad %v4uint %125
-%551 = OpCompositeExtract %uint %550 0
-OpStore %284 %551
-%552 = OpLoad %ulong %283
-%553 = OpLoad %uint %284
-%554 = OpFunctionCall %ulong %5 %552 %553
-OpStore %285 %554
-%555 = OpLoad %v4uint %125
-%556 = OpCompositeExtract %uint %555 1
-OpStore %286 %556
-%557 = OpLoad %ulong %285
-%558 = OpLoad %uint %286
-%559 = OpFunctionCall %ulong %5 %557 %558
-OpStore %287 %559
-%560 = OpLoad %v4uint %125
-%561 = OpCompositeExtract %uint %560 2
-OpStore %288 %561
-%562 = OpLoad %ulong %287
-%563 = OpLoad %uint %288
-%564 = OpFunctionCall %ulong %5 %562 %563
-OpStore %289 %564
-%565 = OpLoad %v4uint %125
-%566 = OpCompositeExtract %uint %565 3
-OpStore %290 %566
-%567 = OpLoad %ulong %289
-%568 = OpLoad %uint %290
-%569 = OpFunctionCall %ulong %5 %567 %568
-OpStore %291 %569
-OpBranch %87
-%87 = OpLabel
-%570 = OpLoad %v4uint %104
-%571 = OpLoad %v4uint %116
-%572 = OpISub %v4uint %570 %571
-OpStore %126 %572
-%573 = OpLoad %ulong %291
-%574 = OpLoad %v4uint %126
-%575 = OpFunctionCall %ulong %1 %573 %574
-OpStore %127 %575
-%576 = OpLoad %v4uint %110
-%577 = OpLoad %v4uint %116
-%578 = OpBitwiseAnd %v4uint %576 %577
-OpStore %128 %578
-%579 = OpLoad %ulong %127
-%580 = OpLoad %v4uint %128
-%581 = OpFunctionCall %ulong %1 %579 %580
-OpStore %129 %581
-%582 = OpLoad %v4uint %110
-%583 = OpLoad %v4uint %116
-%584 = OpBitwiseOr %v4uint %582 %583
-OpStore %130 %584
-%585 = OpLoad %ulong %129
-%586 = OpLoad %v4uint %130
-%587 = OpFunctionCall %ulong %1 %585 %586
-OpStore %131 %587
-%588 = OpLoad %v4uint %110
-%589 = OpLoad %v4uint %116
-%590 = OpBitwiseXor %v4uint %588 %589
-OpStore %132 %590
-%591 = OpLoad %ulong %131
-%592 = OpLoad %v4uint %132
-%593 = OpFunctionCall %ulong %1 %591 %592
-OpStore %133 %593
-%594 = OpLoad %v4uint %110
-%595 = OpNot %v4uint %594
-OpStore %134 %595
-%596 = OpLoad %ulong %133
-%597 = OpLoad %v4uint %134
-%598 = OpFunctionCall %ulong %1 %596 %597
-OpStore %135 %598
-%599 = OpLoad %v4uint %116
-%600 = OpNot %v4uint %599
-OpStore %136 %600
-%601 = OpLoad %ulong %135
-%602 = OpLoad %v4uint %136
-%603 = OpFunctionCall %ulong %1 %601 %602
-OpStore %137 %603
-%604 = OpLoad %v4uint %128
-%605 = OpLoad %v4uint %130
-%606 = OpBitwiseXor %v4uint %604 %605
-OpStore %138 %606
-%607 = OpLoad %ulong %137
-%608 = OpLoad %v4uint %138
-%609 = OpFunctionCall %ulong %1 %607 %608
-OpStore %139 %609
-%610 = OpLoad %ulong %139
-OpStore %159 %610
-%611 = OpLoad %v4uint %110
-OpStore %160 %611
-%612 = OpLoad %v4uint %104
-OpStore %161 %612
-OpStore %162 %ulong_0
-OpBranch %50
-%50 = OpLabel
-%614 = OpLoad %ulong %162
-%616 = OpULessThan %bool %614 %ulong_6
-OpStore %141 %616
-%617 = OpLoad %bool %141
-OpLoopMerge %52 %89 None
-OpBranchConditional %617 %51 %52
-%52 = OpLabel
-OpStore %94 %618
-%619 = OpAccessChain %_ptr_Function_v4uint %94 %uint_0
-%620 = OpLoad %v4uint %160
-OpStore %619 %620
-%621 = OpLoad %v4uint %160
-%622 = OpLoad %v4uint %116
-%623 = OpIAdd %v4uint %621 %622
-OpStore %147 %623
-%624 = OpAccessChain %_ptr_Function_v4uint %94 %uint_1
-%625 = OpLoad %v4uint %147
-OpStore %624 %625
-%626 = OpLoad %v4uint %160
-%627 = OpLoad %v4uint %103
-%628 = OpIMul %v4uint %626 %627
-OpStore %148 %628
-%630 = OpAccessChain %_ptr_Function_v4uint %94 %uint_2
-%631 = OpLoad %v4uint %148
-OpStore %630 %631
-%632 = OpAccessChain %_ptr_Function_v4uint %94 %uint_3
-%633 = OpLoad %v4uint %161
-OpStore %632 %633
-%634 = OpLoad %ulong %159
-OpStore %158 %634
-OpStore %163 %ulong_0
-OpBranch %53
-%53 = OpLabel
-%635 = OpLoad %ulong %163
-%637 = OpULessThan %bool %635 %ulong_4
-OpStore %149 %637
-%638 = OpLoad %bool %149
-OpLoopMerge %55 %88 None
-OpBranchConditional %638 %54 %55
-%55 = OpLabel
-OpStore %97 %639
-%640 = OpAccessChain %_ptr_Function_uint %97 %uint_0
-OpStore %640 %uint_4294967295
-%642 = OpAccessChain %_ptr_Function_v4uint %94 %uint_2
-%643 = OpLoad %v4uint %642
-OpStore %152 %643
-%644 = OpAccessChain %_ptr_Function_v4uint %97 %uint_1
-%645 = OpLoad %v4uint %152
-OpStore %644 %645
-%646 = OpAccessChain %_ptr_Function_uint %97 %uint_2
-OpStore %646 %uint_305419896
-%648 = OpLoad %uint %640
-OpStore %153 %648
-%649 = OpLoad %ulong %158
-%650 = OpLoad %uint %153
-%651 = OpFunctionCall %ulong %4 %649 %650
-OpStore %154 %651
-%652 = OpLoad %v4uint %644
-OpStore %155 %652
-OpBranch %62
-%62 = OpLabel
-%653 = OpLoad %v4uint %155
-%654 = OpCompositeExtract %uint %653 0
-OpStore %188 %654
-%655 = OpLoad %ulong %154
-%656 = OpLoad %uint %188
-%657 = OpFunctionCall %ulong %5 %655 %656
-OpStore %189 %657
-%658 = OpLoad %v4uint %155
-%659 = OpCompositeExtract %uint %658 1
-OpStore %190 %659
-%660 = OpLoad %ulong %189
-%661 = OpLoad %uint %190
-%662 = OpFunctionCall %ulong %5 %660 %661
-OpStore %191 %662
-%663 = OpLoad %v4uint %155
-%664 = OpCompositeExtract %uint %663 2
-OpStore %192 %664
-%665 = OpLoad %ulong %191
-%666 = OpLoad %uint %192
-%667 = OpFunctionCall %ulong %5 %665 %666
-OpStore %193 %667
-%668 = OpLoad %v4uint %155
-%669 = OpCompositeExtract %uint %668 3
-OpStore %194 %669
-%670 = OpLoad %ulong %193
-%671 = OpLoad %uint %194
-%672 = OpFunctionCall %ulong %5 %670 %671
-OpStore %195 %672
-OpBranch %63
-%63 = OpLabel
-%673 = OpAccessChain %_ptr_Function_uint %97 %uint_2
-%674 = OpLoad %uint %673
-OpStore %156 %674
-%675 = OpLoad %ulong %195
-%676 = OpLoad %uint %156
-%677 = OpFunctionCall %ulong %4 %675 %676
-OpStore %157 %677
-%678 = OpLoad %ulong %157
-OpReturnValue %678
-%54 = OpLabel
-%679 = OpLoad %ulong %163
-%680 = OpAccessChain %_ptr_Function_v4uint %94 %679
-%681 = OpLoad %v4uint %680
-OpStore %150 %681
-OpBranch %60
-%60 = OpLabel
-%682 = OpLoad %v4uint %150
-%683 = OpCompositeExtract %uint %682 0
-OpStore %180 %683
-%684 = OpLoad %ulong %158
-%685 = OpLoad %uint %180
-%686 = OpFunctionCall %ulong %5 %684 %685
-OpStore %181 %686
-%687 = OpLoad %v4uint %150
-%688 = OpCompositeExtract %uint %687 1
-OpStore %182 %688
-%689 = OpLoad %ulong %181
-%690 = OpLoad %uint %182
-%691 = OpFunctionCall %ulong %5 %689 %690
-OpStore %183 %691
-%692 = OpLoad %v4uint %150
-%693 = OpCompositeExtract %uint %692 2
-OpStore %184 %693
-%694 = OpLoad %ulong %183
-%695 = OpLoad %uint %184
-%696 = OpFunctionCall %ulong %5 %694 %695
-OpStore %185 %696
-%697 = OpLoad %v4uint %150
-%698 = OpCompositeExtract %uint %697 3
-OpStore %186 %698
-%699 = OpLoad %ulong %185
-%700 = OpLoad %uint %186
-%701 = OpFunctionCall %ulong %5 %699 %700
-OpStore %187 %701
-OpBranch %61
-%61 = OpLabel
-%702 = OpLoad %ulong %163
-%704 = OpIAdd %ulong %702 %ulong_1
-OpStore %151 %704
-%705 = OpLoad %ulong %187
-OpStore %158 %705
-%706 = OpLoad %ulong %151
-OpStore %163 %706
-OpBranch %88
-%51 = OpLabel
-%707 = OpLoad %v4uint %160
-%708 = OpLoad %v4uint %103
-%709 = OpIMul %v4uint %707 %708
-OpStore %142 %709
-OpBranch %58
-%58 = OpLabel
-%710 = OpLoad %v4uint %142
-%711 = OpCompositeExtract %uint %710 0
-OpStore %172 %711
-%712 = OpLoad %ulong %159
-%713 = OpLoad %uint %172
-%714 = OpFunctionCall %ulong %5 %712 %713
-OpStore %173 %714
-%715 = OpLoad %v4uint %142
-%716 = OpCompositeExtract %uint %715 1
-OpStore %174 %716
-%717 = OpLoad %ulong %173
-%718 = OpLoad %uint %174
-%719 = OpFunctionCall %ulong %5 %717 %718
-OpStore %175 %719
-%720 = OpLoad %v4uint %142
-%721 = OpCompositeExtract %uint %720 2
-OpStore %176 %721
-%722 = OpLoad %ulong %175
-%723 = OpLoad %uint %176
-%724 = OpFunctionCall %ulong %5 %722 %723
-OpStore %177 %724
-%725 = OpLoad %v4uint %142
-%726 = OpCompositeExtract %uint %725 3
-OpStore %178 %726
-%727 = OpLoad %ulong %177
-%728 = OpLoad %uint %178
-%729 = OpFunctionCall %ulong %5 %727 %728
-OpStore %179 %729
-OpBranch %59
-%59 = OpLabel
-%730 = OpLoad %v4uint %161
-%731 = OpLoad %v4uint %142
-%732 = OpIAdd %v4uint %730 %731
-OpStore %143 %732
-OpBranch %66
-%66 = OpLabel
-%733 = OpLoad %v4uint %143
-%734 = OpCompositeExtract %uint %733 0
-OpStore %204 %734
-%735 = OpLoad %ulong %179
-%736 = OpLoad %uint %204
-%737 = OpFunctionCall %ulong %5 %735 %736
-OpStore %205 %737
-%738 = OpLoad %v4uint %143
-%739 = OpCompositeExtract %uint %738 1
-OpStore %206 %739
-%740 = OpLoad %ulong %205
-%741 = OpLoad %uint %206
-%742 = OpFunctionCall %ulong %5 %740 %741
-OpStore %207 %742
-%743 = OpLoad %v4uint %143
-%744 = OpCompositeExtract %uint %743 2
-OpStore %208 %744
-%745 = OpLoad %ulong %207
-%746 = OpLoad %uint %208
-%747 = OpFunctionCall %ulong %5 %745 %746
-OpStore %209 %747
-%748 = OpLoad %v4uint %143
-%749 = OpCompositeExtract %uint %748 3
-OpStore %210 %749
-%750 = OpLoad %ulong %209
-%751 = OpLoad %uint %210
-%752 = OpFunctionCall %ulong %5 %750 %751
-OpStore %211 %752
-OpBranch %67
-%67 = OpLabel
-%753 = OpLoad %v4uint %143
-%754 = OpLoad %v4uint %116
-%755 = OpBitwiseXor %v4uint %753 %754
-OpStore %144 %755
-OpBranch %70
-%70 = OpLabel
-%756 = OpLoad %v4uint %144
-%757 = OpCompositeExtract %uint %756 0
-OpStore %220 %757
-%758 = OpLoad %ulong %211
-%759 = OpLoad %uint %220
-%760 = OpFunctionCall %ulong %5 %758 %759
-OpStore %221 %760
-%761 = OpLoad %v4uint %144
-%762 = OpCompositeExtract %uint %761 1
-OpStore %222 %762
-%763 = OpLoad %ulong %221
-%764 = OpLoad %uint %222
-%765 = OpFunctionCall %ulong %5 %763 %764
-OpStore %223 %765
-%766 = OpLoad %v4uint %144
-%767 = OpCompositeExtract %uint %766 2
-OpStore %224 %767
-%768 = OpLoad %ulong %223
-%769 = OpLoad %uint %224
-%770 = OpFunctionCall %ulong %5 %768 %769
-OpStore %225 %770
-%771 = OpLoad %v4uint %144
-%772 = OpCompositeExtract %uint %771 3
-OpStore %226 %772
-%773 = OpLoad %ulong %225
-%774 = OpLoad %uint %226
-%775 = OpFunctionCall %ulong %5 %773 %774
-OpStore %227 %775
-OpBranch %71
-%71 = OpLabel
-%776 = OpLoad %v4uint %160
-%777 = OpLoad %v4uint %116
-%778 = OpIAdd %v4uint %776 %777
-OpStore %145 %778
-OpBranch %74
-%74 = OpLabel
-%779 = OpLoad %v4uint %145
-%780 = OpCompositeExtract %uint %779 0
-OpStore %236 %780
-%781 = OpLoad %ulong %227
-%782 = OpLoad %uint %236
-%783 = OpFunctionCall %ulong %5 %781 %782
-OpStore %237 %783
-%784 = OpLoad %v4uint %145
-%785 = OpCompositeExtract %uint %784 1
-OpStore %238 %785
-%786 = OpLoad %ulong %237
-%787 = OpLoad %uint %238
-%788 = OpFunctionCall %ulong %5 %786 %787
-OpStore %239 %788
-%789 = OpLoad %v4uint %145
-%790 = OpCompositeExtract %uint %789 2
-OpStore %240 %790
-%791 = OpLoad %ulong %239
-%792 = OpLoad %uint %240
-%793 = OpFunctionCall %ulong %5 %791 %792
-OpStore %241 %793
-%794 = OpLoad %v4uint %145
-%795 = OpCompositeExtract %uint %794 3
-OpStore %242 %795
-%796 = OpLoad %ulong %241
-%797 = OpLoad %uint %242
-%798 = OpFunctionCall %ulong %5 %796 %797
-OpStore %243 %798
-OpBranch %75
-%75 = OpLabel
-%799 = OpLoad %ulong %162
-%800 = OpIAdd %ulong %799 %ulong_1
-OpStore %146 %800
-%801 = OpLoad %ulong %243
-OpStore %159 %801
-%802 = OpLoad %v4uint %145
-OpStore %160 %802
-%803 = OpLoad %v4uint %144
-OpStore %161 %803
-%804 = OpLoad %ulong %146
-OpStore %162 %804
-OpBranch %89
-%88 = OpLabel
-OpBranch %53
-%89 = OpLabel
-OpBranch %50
-OpFunctionEnd
-%3 = OpFunction %ulong None %805
-%806 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %808
-%809 = OpFunctionParameter %ulong
-%810 = OpFunctionParameter %uint
-%811 = OpLabel
-%818 = OpVariable %_ptr_Function_ulong Function
-%819 = OpVariable %_ptr_Function_uint Function
-%820 = OpVariable %_ptr_Function_ulong Function
-%821 = OpVariable %_ptr_Function_bool Function
-%822 = OpVariable %_ptr_Function_ulong Function
-%823 = OpVariable %_ptr_Function_ulong Function
-%824 = OpVariable %_ptr_Function_ulong Function
-%825 = OpVariable %_ptr_Function_ulong Function
-%826 = OpVariable %_ptr_Function_ulong Function
-%827 = OpVariable %_ptr_Function_ulong Function
-%828 = OpVariable %_ptr_Function_ulong Function
-%829 = OpVariable %_ptr_Function_ulong Function
-OpStore %818 %809
-OpStore %819 %810
-%830 = OpLoad %uint %819
-%831 = OpUConvert %ulong %830
-OpStore %820 %831
-OpBranch %812
-%812 = OpLabel
-%832 = OpLoad %ulong %818
-OpStore %828 %832
-OpStore %829 %ulong_0
-OpBranch %813
-%813 = OpLabel
-%833 = OpLoad %ulong %829
-%835 = OpULessThan %bool %833 %ulong_8
-OpStore %821 %835
-%836 = OpLoad %bool %821
-OpLoopMerge %815 %817 None
-OpBranchConditional %836 %814 %815
-%815 = OpLabel
-OpBranch %816
-%816 = OpLabel
-%837 = OpLoad %ulong %828
-OpReturnValue %837
-%814 = OpLabel
-%838 = OpLoad %ulong %829
-%839 = OpIMul %ulong %838 %ulong_8
-OpStore %822 %839
-%840 = OpLoad %ulong %820
-%841 = OpLoad %ulong %822
-%842 = OpShiftRightLogical %ulong %840 %841
-OpStore %823 %842
-%843 = OpLoad %ulong %823
-%845 = OpBitwiseAnd %ulong %843 %ulong_255
-OpStore %824 %845
-%846 = OpLoad %ulong %828
-%847 = OpLoad %ulong %824
-%848 = OpBitwiseXor %ulong %846 %847
-OpStore %825 %848
-%849 = OpLoad %ulong %825
-%851 = OpIMul %ulong %849 %ulong_1099511628211
-OpStore %826 %851
-%852 = OpLoad %ulong %829
-%853 = OpIAdd %ulong %852 %ulong_1
-OpStore %827 %853
-%854 = OpLoad %ulong %826
-OpStore %828 %854
-%855 = OpLoad %ulong %827
-OpStore %829 %855
-OpBranch %817
-%817 = OpLabel
-OpBranch %813
-OpFunctionEnd
-%5 = OpFunction %ulong None %808
-%856 = OpFunctionParameter %ulong
-%857 = OpFunctionParameter %uint
-%858 = OpLabel
-%865 = OpVariable %_ptr_Function_ulong Function
-%866 = OpVariable %_ptr_Function_uint Function
-%867 = OpVariable %_ptr_Function_ulong Function
-%868 = OpVariable %_ptr_Function_bool Function
-%869 = OpVariable %_ptr_Function_ulong Function
-%870 = OpVariable %_ptr_Function_ulong Function
-%871 = OpVariable %_ptr_Function_ulong Function
-%872 = OpVariable %_ptr_Function_ulong Function
-%873 = OpVariable %_ptr_Function_ulong Function
-%874 = OpVariable %_ptr_Function_ulong Function
-%875 = OpVariable %_ptr_Function_ulong Function
-%876 = OpVariable %_ptr_Function_ulong Function
-OpStore %865 %856
-OpStore %866 %857
-%877 = OpLoad %uint %866
-%878 = OpSConvert %ulong %877
-OpStore %867 %878
-OpBranch %859
-%859 = OpLabel
-%879 = OpLoad %ulong %865
-OpStore %875 %879
-OpStore %876 %ulong_0
-OpBranch %860
-%860 = OpLabel
-%880 = OpLoad %ulong %876
-%881 = OpULessThan %bool %880 %ulong_8
-OpStore %868 %881
-%882 = OpLoad %bool %868
-OpLoopMerge %862 %864 None
-OpBranchConditional %882 %861 %862
-%862 = OpLabel
-OpBranch %863
-%863 = OpLabel
-%883 = OpLoad %ulong %875
-OpReturnValue %883
-%861 = OpLabel
-%884 = OpLoad %ulong %876
-%885 = OpIMul %ulong %884 %ulong_8
-OpStore %869 %885
-%886 = OpLoad %ulong %867
-%887 = OpLoad %ulong %869
-%888 = OpShiftRightLogical %ulong %886 %887
-OpStore %870 %888
-%889 = OpLoad %ulong %870
-%890 = OpBitwiseAnd %ulong %889 %ulong_255
-OpStore %871 %890
-%891 = OpLoad %ulong %875
-%892 = OpLoad %ulong %871
-%893 = OpBitwiseXor %ulong %891 %892
-OpStore %872 %893
-%894 = OpLoad %ulong %872
-%895 = OpIMul %ulong %894 %ulong_1099511628211
-OpStore %873 %895
-%896 = OpLoad %ulong %876
-%897 = OpIAdd %ulong %896 %ulong_1
-OpStore %874 %897
-%898 = OpLoad %ulong %873
-OpStore %875 %898
-%899 = OpLoad %ulong %874
-OpStore %876 %899
-OpBranch %864
-%864 = OpLabel
-OpBranch %860
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_v4uint Function
+%292 = OpVariable %_ptr_Function_v4uint Function
+%293 = OpVariable %_ptr_Function_bool Function
+%294 = OpVariable %_ptr_Function_v4uint Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_v4uint Function
+%298 = OpVariable %_ptr_Function_uint Function
+%299 = OpVariable %_ptr_Function_v4uint Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_uint Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_v4uint Function
+%305 = OpVariable %_ptr_Function_v4uint Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_bool Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_bool Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+OpStore %231 %196
+OpBranch %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%328 = OpLoad %ulong %231
+%329 = OpUConvert %uint %328
+OpStore %232 %329
+%330 = OpCompositeConstruct %v4uint %uint_10007 %uint_4294947285 %uint_30013 %uint_4294934528
+OpStore %233 %330
+%335 = OpCompositeConstruct %v4uint %uint_4294967289 %uint_131 %uint_4294966287 %uint_3
+OpStore %234 %335
+%340 = OpCompositeConstruct %v4uint %uint_1 %uint_3 %uint_9 %uint_27
+OpStore %235 %340
+%344 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+OpStore %236 %344
+%346 = OpLoad %v4uint %233
+%347 = OpCompositeExtract %uint %346 0
+OpStore %237 %347
+%348 = OpLoad %uint %237
+%349 = OpLoad %uint %232
+%350 = OpIAdd %uint %348 %349
+OpStore %238 %350
+%351 = OpLoad %v4uint %233
+%352 = OpLoad %uint %238
+%353 = OpCompositeInsert %v4uint %352 %351 0
+OpStore %239 %353
+%354 = OpLoad %v4uint %239
+%355 = OpCompositeExtract %uint %354 2
+OpStore %240 %355
+%356 = OpLoad %uint %240
+%357 = OpLoad %uint %232
+%358 = OpIAdd %uint %356 %357
+OpStore %241 %358
+%359 = OpLoad %v4uint %239
+%360 = OpLoad %uint %241
+%361 = OpCompositeInsert %v4uint %360 %359 2
+OpStore %242 %361
+%362 = OpLoad %v4uint %234
+%363 = OpCompositeExtract %uint %362 1
+OpStore %243 %363
+%364 = OpLoad %uint %243
+%365 = OpLoad %uint %232
+%366 = OpIAdd %uint %364 %365
+OpStore %244 %366
+%367 = OpLoad %v4uint %234
+%368 = OpLoad %uint %244
+%369 = OpCompositeInsert %v4uint %368 %367 1
+OpStore %245 %369
+%370 = OpLoad %v4uint %245
+%371 = OpCompositeExtract %uint %370 3
+OpStore %246 %371
+%372 = OpLoad %uint %246
+%373 = OpLoad %uint %232
+%374 = OpIAdd %uint %372 %373
+OpStore %247 %374
+%375 = OpLoad %v4uint %245
+%376 = OpLoad %uint %247
+%377 = OpCompositeInsert %v4uint %376 %375 3
+OpStore %248 %377
+%379 = OpLoad %v4uint %242
+%380 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %379
+OpStore %249 %380
+%381 = OpLoad %ulong %249
+%382 = OpLoad %v4uint %248
+%383 = OpFunctionCall %ulong %1 %381 %382
+OpStore %250 %383
+%384 = OpLoad %v4uint %242
+%385 = OpLoad %v4uint %248
+%386 = OpIAdd %v4uint %384 %385
+OpStore %251 %386
+%387 = OpLoad %ulong %250
+%388 = OpLoad %v4uint %251
+%389 = OpFunctionCall %ulong %1 %387 %388
+OpStore %252 %389
+%390 = OpLoad %v4uint %242
+%391 = OpLoad %v4uint %248
+%392 = OpISub %v4uint %390 %391
+OpStore %253 %392
+%393 = OpLoad %ulong %252
+%394 = OpLoad %v4uint %253
+%395 = OpFunctionCall %ulong %1 %393 %394
+OpStore %254 %395
+%396 = OpLoad %v4uint %248
+%397 = OpLoad %v4uint %242
+%398 = OpISub %v4uint %396 %397
+OpStore %255 %398
+%399 = OpLoad %ulong %254
+%400 = OpLoad %v4uint %255
+%401 = OpFunctionCall %ulong %1 %399 %400
+OpStore %256 %401
+%402 = OpLoad %v4uint %242
+%403 = OpLoad %v4uint %248
+%404 = OpIMul %v4uint %402 %403
+OpStore %257 %404
+%405 = OpLoad %ulong %256
+%406 = OpLoad %v4uint %257
+%407 = OpFunctionCall %ulong %1 %405 %406
+OpStore %258 %407
+%408 = OpLoad %v4uint %242
+%409 = OpLoad %v4uint %235
+%410 = OpIMul %v4uint %408 %409
+OpStore %259 %410
+%411 = OpLoad %ulong %258
+%412 = OpLoad %v4uint %259
+%413 = OpFunctionCall %ulong %1 %411 %412
+OpStore %260 %413
+%414 = OpLoad %v4uint %248
+%415 = OpLoad %v4uint %235
+%416 = OpIMul %v4uint %414 %415
+OpStore %261 %416
+%417 = OpLoad %ulong %260
+%418 = OpLoad %v4uint %261
+%419 = OpFunctionCall %ulong %1 %417 %418
+OpStore %262 %419
+%420 = OpLoad %v4uint %251
+%421 = OpLoad %v4uint %235
+%422 = OpIMul %v4uint %420 %421
+OpStore %263 %422
+%423 = OpLoad %ulong %262
+%424 = OpLoad %v4uint %263
+%425 = OpFunctionCall %ulong %1 %423 %424
+OpStore %264 %425
+%426 = OpLoad %v4uint %236
+%427 = OpLoad %v4uint %242
+%428 = OpISub %v4uint %426 %427
+OpStore %265 %428
+%429 = OpLoad %ulong %264
+%430 = OpLoad %v4uint %265
+%431 = OpFunctionCall %ulong %1 %429 %430
+OpStore %266 %431
+%432 = OpLoad %v4uint %236
+%433 = OpLoad %v4uint %248
+%434 = OpISub %v4uint %432 %433
+OpStore %267 %434
+%435 = OpLoad %ulong %266
+%436 = OpLoad %v4uint %267
+%437 = OpFunctionCall %ulong %1 %435 %436
+OpStore %268 %437
+%438 = OpLoad %v4uint %242
+%439 = OpLoad %v4uint %248
+%440 = OpBitwiseAnd %v4uint %438 %439
+OpStore %269 %440
+%441 = OpLoad %ulong %268
+%442 = OpLoad %v4uint %269
+%443 = OpFunctionCall %ulong %1 %441 %442
+OpStore %270 %443
+%444 = OpLoad %v4uint %242
+%445 = OpLoad %v4uint %248
+%446 = OpBitwiseOr %v4uint %444 %445
+OpStore %271 %446
+%447 = OpLoad %ulong %270
+%448 = OpLoad %v4uint %271
+%449 = OpFunctionCall %ulong %1 %447 %448
+OpStore %272 %449
+%450 = OpLoad %v4uint %242
+%451 = OpLoad %v4uint %248
+%452 = OpBitwiseXor %v4uint %450 %451
+OpStore %273 %452
+%453 = OpLoad %ulong %272
+%454 = OpLoad %v4uint %273
+%455 = OpFunctionCall %ulong %1 %453 %454
+OpStore %274 %455
+%456 = OpLoad %v4uint %242
+%457 = OpNot %v4uint %456
+OpStore %275 %457
+%458 = OpLoad %ulong %274
+%459 = OpLoad %v4uint %275
+%460 = OpFunctionCall %ulong %1 %458 %459
+OpStore %276 %460
+%461 = OpLoad %v4uint %248
+%462 = OpNot %v4uint %461
+OpStore %277 %462
+%463 = OpLoad %ulong %276
+%464 = OpLoad %v4uint %277
+%465 = OpFunctionCall %ulong %1 %463 %464
+OpStore %278 %465
+%466 = OpLoad %v4uint %269
+%467 = OpLoad %v4uint %271
+%468 = OpBitwiseXor %v4uint %466 %467
+OpStore %279 %468
+%469 = OpLoad %ulong %278
+%470 = OpLoad %v4uint %279
+%471 = OpFunctionCall %ulong %1 %469 %470
+OpStore %280 %471
+%472 = OpLoad %ulong %280
+OpStore %303 %472
+%473 = OpLoad %v4uint %242
+OpStore %304 %473
+%474 = OpLoad %v4uint %236
+OpStore %305 %474
+OpStore %306 %ulong_0
+OpBranch %198
+%198 = OpLabel
+%475 = OpLoad %ulong %306
+%477 = OpULessThan %bool %475 %ulong_6
+OpStore %281 %477
+%478 = OpLoad %bool %281
+OpLoopMerge %200 %223 None
+OpBranchConditional %478 %199 %200
+%200 = OpLabel
+OpStore %227 %479
+%480 = OpAccessChain %_ptr_Function_v4uint %227 %uint_0
+%481 = OpLoad %v4uint %304
+OpStore %480 %481
+%482 = OpLoad %v4uint %304
+%483 = OpLoad %v4uint %248
+%484 = OpIAdd %v4uint %482 %483
+OpStore %291 %484
+%485 = OpAccessChain %_ptr_Function_v4uint %227 %uint_1
+%486 = OpLoad %v4uint %291
+OpStore %485 %486
+%487 = OpLoad %v4uint %304
+%488 = OpLoad %v4uint %235
+%489 = OpIMul %v4uint %487 %488
+OpStore %292 %489
+%491 = OpAccessChain %_ptr_Function_v4uint %227 %uint_2
+%492 = OpLoad %v4uint %292
+OpStore %491 %492
+%493 = OpAccessChain %_ptr_Function_v4uint %227 %uint_3
+%494 = OpLoad %v4uint %305
+OpStore %493 %494
+%495 = OpLoad %ulong %303
+OpStore %302 %495
+OpStore %307 %ulong_0
+OpBranch %201
+%201 = OpLabel
+%496 = OpLoad %ulong %307
+%498 = OpULessThan %bool %496 %ulong_4
+OpStore %293 %498
+%499 = OpLoad %bool %293
+OpLoopMerge %203 %222 None
+OpBranchConditional %499 %202 %203
+%203 = OpLabel
+OpStore %230 %500
+%501 = OpAccessChain %_ptr_Function_uint %230 %uint_0
+OpStore %501 %uint_4294967295
+%503 = OpAccessChain %_ptr_Function_v4uint %227 %uint_2
+%504 = OpLoad %v4uint %503
+OpStore %297 %504
+%505 = OpAccessChain %_ptr_Function_v4uint %230 %uint_1
+%506 = OpLoad %v4uint %297
+OpStore %505 %506
+%507 = OpAccessChain %_ptr_Function_uint %230 %uint_2
+OpStore %507 %uint_305419896
+%509 = OpLoad %uint %501
+OpStore %298 %509
+OpBranch %206
+%206 = OpLabel
+%510 = OpLoad %uint %298
+%511 = OpUConvert %ulong %510
+OpStore %308 %511
+OpBranch %208
+%208 = OpLabel
+%512 = OpLoad %ulong %302
+OpStore %316 %512
+OpStore %317 %ulong_0
+OpBranch %209
+%209 = OpLabel
+%513 = OpLoad %ulong %317
+%514 = OpULessThan %bool %513 %ulong_8
+OpStore %309 %514
+%515 = OpLoad %bool %309
+OpLoopMerge %211 %221 None
+OpBranchConditional %515 %210 %211
+%211 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpBranch %207
+%207 = OpLabel
+%516 = OpAccessChain %_ptr_Function_v4uint %230 %uint_1
+%517 = OpLoad %v4uint %516
+OpStore %299 %517
+%518 = OpLoad %ulong %316
+%519 = OpLoad %v4uint %299
+%520 = OpFunctionCall %ulong %1 %518 %519
+OpStore %300 %520
+%521 = OpAccessChain %_ptr_Function_uint %230 %uint_2
+%522 = OpLoad %uint %521
+OpStore %301 %522
+OpBranch %213
+%213 = OpLabel
+%523 = OpLoad %uint %301
+%524 = OpUConvert %ulong %523
+OpStore %318 %524
+OpBranch %215
+%215 = OpLabel
+%525 = OpLoad %ulong %300
+OpStore %326 %525
+OpStore %327 %ulong_0
+OpBranch %216
+%216 = OpLabel
+%526 = OpLoad %ulong %327
+%527 = OpULessThan %bool %526 %ulong_8
+OpStore %319 %527
+%528 = OpLoad %bool %319
+OpLoopMerge %218 %220 None
+OpBranchConditional %528 %217 %218
+%218 = OpLabel
+OpBranch %219
+%219 = OpLabel
+OpBranch %214
+%214 = OpLabel
+%529 = OpLoad %ulong %326
+OpReturnValue %529
+%217 = OpLabel
+%530 = OpLoad %ulong %327
+%531 = OpIMul %ulong %530 %ulong_8
+OpStore %320 %531
+%532 = OpLoad %ulong %318
+%533 = OpLoad %ulong %320
+%534 = OpShiftRightLogical %ulong %532 %533
+OpStore %321 %534
+%535 = OpLoad %ulong %321
+%536 = OpBitwiseAnd %ulong %535 %ulong_255
+OpStore %322 %536
+%537 = OpLoad %ulong %326
+%538 = OpLoad %ulong %322
+%539 = OpBitwiseXor %ulong %537 %538
+OpStore %323 %539
+%540 = OpLoad %ulong %323
+%541 = OpIMul %ulong %540 %ulong_1099511628211
+OpStore %324 %541
+%542 = OpLoad %ulong %327
+%543 = OpIAdd %ulong %542 %ulong_1
+OpStore %325 %543
+%544 = OpLoad %ulong %324
+OpStore %326 %544
+%545 = OpLoad %ulong %325
+OpStore %327 %545
+OpBranch %220
+%210 = OpLabel
+%546 = OpLoad %ulong %317
+%547 = OpIMul %ulong %546 %ulong_8
+OpStore %310 %547
+%548 = OpLoad %ulong %308
+%549 = OpLoad %ulong %310
+%550 = OpShiftRightLogical %ulong %548 %549
+OpStore %311 %550
+%551 = OpLoad %ulong %311
+%552 = OpBitwiseAnd %ulong %551 %ulong_255
+OpStore %312 %552
+%553 = OpLoad %ulong %316
+%554 = OpLoad %ulong %312
+%555 = OpBitwiseXor %ulong %553 %554
+OpStore %313 %555
+%556 = OpLoad %ulong %313
+%557 = OpIMul %ulong %556 %ulong_1099511628211
+OpStore %314 %557
+%558 = OpLoad %ulong %317
+%559 = OpIAdd %ulong %558 %ulong_1
+OpStore %315 %559
+%560 = OpLoad %ulong %314
+OpStore %316 %560
+%561 = OpLoad %ulong %315
+OpStore %317 %561
+OpBranch %221
+%202 = OpLabel
+%562 = OpLoad %ulong %307
+%563 = OpAccessChain %_ptr_Function_v4uint %227 %562
+%564 = OpLoad %v4uint %563
+OpStore %294 %564
+%565 = OpLoad %ulong %302
+%566 = OpLoad %v4uint %294
+%567 = OpFunctionCall %ulong %1 %565 %566
+OpStore %295 %567
+%568 = OpLoad %ulong %307
+%569 = OpIAdd %ulong %568 %ulong_1
+OpStore %296 %569
+%570 = OpLoad %ulong %295
+OpStore %302 %570
+%571 = OpLoad %ulong %296
+OpStore %307 %571
+OpBranch %222
+%199 = OpLabel
+%572 = OpLoad %v4uint %304
+%573 = OpLoad %v4uint %235
+%574 = OpIMul %v4uint %572 %573
+OpStore %282 %574
+%575 = OpLoad %ulong %303
+%576 = OpLoad %v4uint %282
+%577 = OpFunctionCall %ulong %1 %575 %576
+OpStore %283 %577
+%578 = OpLoad %v4uint %305
+%579 = OpLoad %v4uint %282
+%580 = OpIAdd %v4uint %578 %579
+OpStore %284 %580
+%581 = OpLoad %ulong %283
+%582 = OpLoad %v4uint %284
+%583 = OpFunctionCall %ulong %1 %581 %582
+OpStore %285 %583
+%584 = OpLoad %v4uint %284
+%585 = OpLoad %v4uint %248
+%586 = OpBitwiseXor %v4uint %584 %585
+OpStore %286 %586
+%587 = OpLoad %ulong %285
+%588 = OpLoad %v4uint %286
+%589 = OpFunctionCall %ulong %1 %587 %588
+OpStore %287 %589
+%590 = OpLoad %v4uint %304
+%591 = OpLoad %v4uint %248
+%592 = OpIAdd %v4uint %590 %591
+OpStore %288 %592
+%593 = OpLoad %ulong %287
+%594 = OpLoad %v4uint %288
+%595 = OpFunctionCall %ulong %1 %593 %594
+OpStore %289 %595
+%596 = OpLoad %ulong %306
+%597 = OpIAdd %ulong %596 %ulong_1
+OpStore %290 %597
+%598 = OpLoad %ulong %289
+OpStore %303 %598
+%599 = OpLoad %v4uint %288
+OpStore %304 %599
+%600 = OpLoad %v4uint %286
+OpStore %305 %600
+%601 = OpLoad %ulong %290
+OpStore %306 %601
+OpBranch %223
+%220 = OpLabel
+OpBranch %216
+%221 = OpLabel
+OpBranch %209
+%222 = OpLabel
+OpBranch %201
+%223 = OpLabel
+OpBranch %198
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_i64x2.dis
+++ b/test/golden/spirv/vec/vec_i64x2.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 634
+; Bound: 484
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,872 +11,673 @@ OpDecorate %1 LinkageAttributes "corpus.cases.vec.vec_i64x2.fold_vec" Export
 OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i64x2.checksum" Export
 %ulong = OpTypeInt 64 0
 %v2ulong = OpTypeVector %ulong 2
-%8 = OpTypeFunction %ulong %ulong %v2ulong
+%5 = OpTypeFunction %ulong %ulong %v2ulong
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v2ulong = OpTypePointer Function %v2ulong
-%31 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%101 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %uint_4 = OpConstant %uint 4
 %_arr_v2ulong_uint_4 = OpTypeArray %v2ulong %uint_4
 %_ptr_Function__arr_v2ulong_uint_4 = OpTypePointer Function %_arr_v2ulong_uint_4
-%_struct_80 = OpTypeStruct %uint %v2ulong %uint
-%_ptr_Function__struct_80 = OpTypePointer Function %_struct_80
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_135 = OpTypeStruct %uint %v2ulong %uint
+%_ptr_Function__struct_135 = OpTypePointer Function %_struct_135
 %_ptr_Function_uint = OpTypePointer Function %uint
 %ulong_1000000007 = OpConstant %ulong 1000000007
 %ulong_18446744071709551605 = OpConstant %ulong 18446744071709551605
 %ulong_3000000019 = OpConstant %ulong 3000000019
 %ulong_18446744069709551579 = OpConstant %ulong 18446744069709551579
-%ulong_1 = OpConstant %ulong 1
 %ulong_3 = OpConstant %ulong 3
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%411 = OpConstantNull %_arr_v2ulong_uint_4
+%357 = OpConstantNull %_arr_v2ulong_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%435 = OpConstantNull %_struct_80
+%381 = OpConstantNull %_struct_135
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%541 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%544 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%592 = OpTypeFunction %ulong %ulong %ulong
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpFunctionParameter %v2ulong
+%1 = OpFunction %ulong None %5
+%6 = OpFunctionParameter %ulong
+%7 = OpFunctionParameter %v2ulong
+%8 = OpLabel
+%27 = OpVariable %_ptr_Function_ulong Function
+%29 = OpVariable %_ptr_Function_v2ulong Function
+%30 = OpVariable %_ptr_Function_ulong Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_bool Function
+%34 = OpVariable %_ptr_Function_ulong Function
+%35 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_ulong Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%38 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_bool Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+%47 = OpVariable %_ptr_Function_ulong Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%49 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_ulong Function
+OpStore %27 %6
+OpStore %29 %7
+%51 = OpLoad %v2ulong %29
+%52 = OpCompositeExtract %ulong %51 0
+OpStore %30 %52
+OpBranch %9
+%9 = OpLabel
+OpBranch %11
 %11 = OpLabel
-%13 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_v2ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-OpStore %15 %10
-%20 = OpLoad %v2ulong %15
-%21 = OpCompositeExtract %ulong %20 0
-OpStore %16 %21
-%22 = OpLoad %ulong %13
-%23 = OpLoad %ulong %16
-%24 = OpFunctionCall %ulong %5 %22 %23
-OpStore %17 %24
-%25 = OpLoad %v2ulong %15
-%26 = OpCompositeExtract %ulong %25 1
-OpStore %18 %26
-%27 = OpLoad %ulong %17
-%28 = OpLoad %ulong %18
-%29 = OpFunctionCall %ulong %5 %27 %28
-OpStore %19 %29
-%30 = OpLoad %ulong %19
-OpReturnValue %30
+%53 = OpLoad %ulong %27
+OpStore %40 %53
+OpStore %41 %ulong_0
+OpBranch %12
+%12 = OpLabel
+%55 = OpLoad %ulong %41
+%57 = OpULessThan %bool %55 %ulong_8
+OpStore %33 %57
+%58 = OpLoad %bool %33
+OpLoopMerge %14 %24 None
+OpBranchConditional %58 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%59 = OpLoad %v2ulong %29
+%60 = OpCompositeExtract %ulong %59 1
+OpStore %31 %60
+OpBranch %16
+%16 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%61 = OpLoad %ulong %40
+OpStore %49 %61
+OpStore %50 %ulong_0
+OpBranch %19
+%19 = OpLabel
+%62 = OpLoad %ulong %50
+%63 = OpULessThan %bool %62 %ulong_8
+OpStore %42 %63
+%64 = OpLoad %bool %42
+OpLoopMerge %21 %23 None
+OpBranchConditional %64 %20 %21
+%21 = OpLabel
+OpBranch %22
+%22 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%65 = OpLoad %ulong %49
+OpReturnValue %65
+%20 = OpLabel
+%66 = OpLoad %ulong %50
+%67 = OpIMul %ulong %66 %ulong_8
+OpStore %43 %67
+%68 = OpLoad %ulong %31
+%69 = OpLoad %ulong %43
+%70 = OpShiftRightLogical %ulong %68 %69
+OpStore %44 %70
+%71 = OpLoad %ulong %44
+%73 = OpBitwiseAnd %ulong %71 %ulong_255
+OpStore %45 %73
+%74 = OpLoad %ulong %49
+%75 = OpLoad %ulong %45
+%76 = OpBitwiseXor %ulong %74 %75
+OpStore %46 %76
+%77 = OpLoad %ulong %46
+%79 = OpIMul %ulong %77 %ulong_1099511628211
+OpStore %47 %79
+%80 = OpLoad %ulong %50
+%82 = OpIAdd %ulong %80 %ulong_1
+OpStore %48 %82
+%83 = OpLoad %ulong %47
+OpStore %49 %83
+%84 = OpLoad %ulong %48
+OpStore %50 %84
+OpBranch %23
+%13 = OpLabel
+%85 = OpLoad %ulong %41
+%86 = OpIMul %ulong %85 %ulong_8
+OpStore %34 %86
+%87 = OpLoad %ulong %30
+%88 = OpLoad %ulong %34
+%89 = OpShiftRightLogical %ulong %87 %88
+OpStore %35 %89
+%90 = OpLoad %ulong %35
+%91 = OpBitwiseAnd %ulong %90 %ulong_255
+OpStore %36 %91
+%92 = OpLoad %ulong %40
+%93 = OpLoad %ulong %36
+%94 = OpBitwiseXor %ulong %92 %93
+OpStore %37 %94
+%95 = OpLoad %ulong %37
+%96 = OpIMul %ulong %95 %ulong_1099511628211
+OpStore %38 %96
+%97 = OpLoad %ulong %41
+%98 = OpIAdd %ulong %97 %ulong_1
+OpStore %39 %98
+%99 = OpLoad %ulong %38
+OpStore %40 %99
+%100 = OpLoad %ulong %39
+OpStore %41 %100
+OpBranch %24
+%23 = OpLabel
+OpBranch %19
+%24 = OpLabel
+OpBranch %12
 OpFunctionEnd
-%2 = OpFunction %ulong None %31
-%32 = OpFunctionParameter %ulong
-%33 = OpLabel
-%79 = OpVariable %_ptr_Function__arr_v2ulong_uint_4 Function
-%82 = OpVariable %_ptr_Function__struct_80 Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_v2ulong Function
-%86 = OpVariable %_ptr_Function_v2ulong Function
-%87 = OpVariable %_ptr_Function_v2ulong Function
-%88 = OpVariable %_ptr_Function_v2ulong Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_v2ulong Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_v2ulong Function
-%95 = OpVariable %_ptr_Function_v2ulong Function
-%96 = OpVariable %_ptr_Function_v2ulong Function
-%97 = OpVariable %_ptr_Function_v2ulong Function
-%98 = OpVariable %_ptr_Function_v2ulong Function
-%99 = OpVariable %_ptr_Function_v2ulong Function
-%100 = OpVariable %_ptr_Function_v2ulong Function
-%101 = OpVariable %_ptr_Function_v2ulong Function
-%102 = OpVariable %_ptr_Function_v2ulong Function
-%103 = OpVariable %_ptr_Function_v2ulong Function
-%104 = OpVariable %_ptr_Function_v2ulong Function
-%105 = OpVariable %_ptr_Function_ulong Function
-%106 = OpVariable %_ptr_Function_v2ulong Function
-%107 = OpVariable %_ptr_Function_ulong Function
-%108 = OpVariable %_ptr_Function_v2ulong Function
-%109 = OpVariable %_ptr_Function_ulong Function
-%110 = OpVariable %_ptr_Function_v2ulong Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_v2ulong Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_v2ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_v2ulong Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_bool Function
-%120 = OpVariable %_ptr_Function_v2ulong Function
-%121 = OpVariable %_ptr_Function_v2ulong Function
-%122 = OpVariable %_ptr_Function_v2ulong Function
-%123 = OpVariable %_ptr_Function_v2ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_v2ulong Function
-%126 = OpVariable %_ptr_Function_v2ulong Function
-%127 = OpVariable %_ptr_Function_bool Function
-%128 = OpVariable %_ptr_Function_v2ulong Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_v2ulong Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_v2ulong Function
-%135 = OpVariable %_ptr_Function_uint Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_ulong Function
+%2 = OpFunction %ulong None %101
+%102 = OpFunctionParameter %ulong
+%103 = OpLabel
+%134 = OpVariable %_ptr_Function__arr_v2ulong_uint_4 Function
+%137 = OpVariable %_ptr_Function__struct_135 Function
 %138 = OpVariable %_ptr_Function_ulong Function
 %139 = OpVariable %_ptr_Function_v2ulong Function
 %140 = OpVariable %_ptr_Function_v2ulong Function
 %141 = OpVariable %_ptr_Function_v2ulong Function
-%142 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_v2ulong Function
 %143 = OpVariable %_ptr_Function_ulong Function
 %144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_v2ulong Function
 %146 = OpVariable %_ptr_Function_ulong Function
 %147 = OpVariable %_ptr_Function_ulong Function
-%148 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_v2ulong Function
 %149 = OpVariable %_ptr_Function_ulong Function
 %150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_v2ulong Function
 %152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_v2ulong Function
 %154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_v2ulong Function
 %156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_v2ulong Function
 %158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_v2ulong Function
 %160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_v2ulong Function
 %162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_v2ulong Function
 %164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_v2ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_v2ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_v2ulong Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_v2ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_v2ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_v2ulong Function
 %176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_v2ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
-%179 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_v2ulong Function
 %180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_v2ulong Function
 %183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_v2ulong Function
 %185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_v2ulong Function
 %187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_v2ulong Function
 %189 = OpVariable %_ptr_Function_ulong Function
 %190 = OpVariable %_ptr_Function_ulong Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_v2ulong Function
+%192 = OpVariable %_ptr_Function_v2ulong Function
+%193 = OpVariable %_ptr_Function_bool Function
+%194 = OpVariable %_ptr_Function_v2ulong Function
 %195 = OpVariable %_ptr_Function_ulong Function
 %196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_v2ulong Function
+%199 = OpVariable %_ptr_Function_uint Function
+%200 = OpVariable %_ptr_Function_v2ulong Function
 %201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_uint Function
 %203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-OpStore %83 %32
-%208 = OpFunctionCall %ulong %3
-OpStore %84 %208
-%209 = OpCompositeConstruct %v2ulong %ulong_1000000007 %ulong_18446744071709551605
-OpStore %85 %209
-%212 = OpCompositeConstruct %v2ulong %ulong_3000000019 %ulong_18446744069709551579
-OpStore %86 %212
-%215 = OpCompositeConstruct %v2ulong %ulong_1 %ulong_3
-OpStore %87 %215
-%218 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_0
-OpStore %88 %218
-%220 = OpLoad %v2ulong %85
-%221 = OpCompositeExtract %ulong %220 0
-OpStore %89 %221
-%222 = OpLoad %ulong %89
-%223 = OpLoad %ulong %83
-%224 = OpIAdd %ulong %222 %223
-OpStore %90 %224
-%225 = OpLoad %v2ulong %85
-%226 = OpLoad %ulong %90
-%227 = OpCompositeInsert %v2ulong %226 %225 0
-OpStore %91 %227
-%228 = OpLoad %v2ulong %86
-%229 = OpCompositeExtract %ulong %228 1
-OpStore %92 %229
-%230 = OpLoad %ulong %92
-%231 = OpLoad %ulong %83
-%232 = OpIAdd %ulong %230 %231
-OpStore %93 %232
-%233 = OpLoad %v2ulong %86
-%234 = OpLoad %ulong %93
-%235 = OpCompositeInsert %v2ulong %234 %233 1
-OpStore %94 %235
-OpBranch %40
-%40 = OpLabel
-%236 = OpLoad %v2ulong %91
-%237 = OpCompositeExtract %ulong %236 0
-OpStore %144 %237
-%238 = OpLoad %ulong %84
-%239 = OpLoad %ulong %144
-%240 = OpFunctionCall %ulong %5 %238 %239
-OpStore %145 %240
-%241 = OpLoad %v2ulong %91
-%242 = OpCompositeExtract %ulong %241 1
-OpStore %146 %242
-%243 = OpLoad %ulong %145
-%244 = OpLoad %ulong %146
-%245 = OpFunctionCall %ulong %5 %243 %244
-OpStore %147 %245
-OpBranch %41
-%41 = OpLabel
-OpBranch %48
-%48 = OpLabel
-%246 = OpLoad %v2ulong %94
-%247 = OpCompositeExtract %ulong %246 0
-OpStore %160 %247
-%248 = OpLoad %ulong %147
-%249 = OpLoad %ulong %160
-%250 = OpFunctionCall %ulong %5 %248 %249
-OpStore %161 %250
-%251 = OpLoad %v2ulong %94
-%252 = OpCompositeExtract %ulong %251 1
-OpStore %162 %252
-%253 = OpLoad %ulong %161
-%254 = OpLoad %ulong %162
-%255 = OpFunctionCall %ulong %5 %253 %254
-OpStore %163 %255
-OpBranch %49
-%49 = OpLabel
-%256 = OpLoad %v2ulong %91
-%257 = OpLoad %v2ulong %94
-%258 = OpIAdd %v2ulong %256 %257
-OpStore %95 %258
-OpBranch %52
-%52 = OpLabel
-%259 = OpLoad %v2ulong %95
-%260 = OpCompositeExtract %ulong %259 0
-OpStore %168 %260
-%261 = OpLoad %ulong %163
-%262 = OpLoad %ulong %168
-%263 = OpFunctionCall %ulong %5 %261 %262
-OpStore %169 %263
-%264 = OpLoad %v2ulong %95
-%265 = OpCompositeExtract %ulong %264 1
-OpStore %170 %265
-%266 = OpLoad %ulong %169
-%267 = OpLoad %ulong %170
-%268 = OpFunctionCall %ulong %5 %266 %267
-OpStore %171 %268
-OpBranch %53
-%53 = OpLabel
-%269 = OpLoad %v2ulong %91
-%270 = OpLoad %v2ulong %94
-%271 = OpISub %v2ulong %269 %270
-OpStore %96 %271
-OpBranch %56
-%56 = OpLabel
-%272 = OpLoad %v2ulong %96
-%273 = OpCompositeExtract %ulong %272 0
-OpStore %176 %273
-%274 = OpLoad %ulong %171
-%275 = OpLoad %ulong %176
-%276 = OpFunctionCall %ulong %5 %274 %275
-OpStore %177 %276
-%277 = OpLoad %v2ulong %96
-%278 = OpCompositeExtract %ulong %277 1
-OpStore %178 %278
-%279 = OpLoad %ulong %177
-%280 = OpLoad %ulong %178
-%281 = OpFunctionCall %ulong %5 %279 %280
-OpStore %179 %281
-OpBranch %57
-%57 = OpLabel
-%282 = OpLoad %v2ulong %94
-%283 = OpLoad %v2ulong %91
-%284 = OpISub %v2ulong %282 %283
-OpStore %97 %284
-OpBranch %60
-%60 = OpLabel
-%285 = OpLoad %v2ulong %97
-%286 = OpCompositeExtract %ulong %285 0
-OpStore %184 %286
-%287 = OpLoad %ulong %179
-%288 = OpLoad %ulong %184
-%289 = OpFunctionCall %ulong %5 %287 %288
-OpStore %185 %289
-%290 = OpLoad %v2ulong %97
-%291 = OpCompositeExtract %ulong %290 1
-OpStore %186 %291
-%292 = OpLoad %ulong %185
-%293 = OpLoad %ulong %186
-%294 = OpFunctionCall %ulong %5 %292 %293
-OpStore %187 %294
-OpBranch %61
-%61 = OpLabel
-%295 = OpLoad %v2ulong %91
-%296 = OpLoad %v2ulong %94
-%297 = OpIMul %v2ulong %295 %296
-OpStore %98 %297
-OpBranch %62
-%62 = OpLabel
-%298 = OpLoad %v2ulong %98
-%299 = OpCompositeExtract %ulong %298 0
-OpStore %188 %299
-%300 = OpLoad %ulong %187
-%301 = OpLoad %ulong %188
-%302 = OpFunctionCall %ulong %5 %300 %301
-OpStore %189 %302
-%303 = OpLoad %v2ulong %98
-%304 = OpCompositeExtract %ulong %303 1
-OpStore %190 %304
-%305 = OpLoad %ulong %189
-%306 = OpLoad %ulong %190
-%307 = OpFunctionCall %ulong %5 %305 %306
-OpStore %191 %307
-OpBranch %63
-%63 = OpLabel
-%308 = OpLoad %v2ulong %91
-%309 = OpLoad %v2ulong %87
-%310 = OpIMul %v2ulong %308 %309
-OpStore %99 %310
-OpBranch %64
-%64 = OpLabel
-%311 = OpLoad %v2ulong %99
-%312 = OpCompositeExtract %ulong %311 0
-OpStore %192 %312
-%313 = OpLoad %ulong %191
-%314 = OpLoad %ulong %192
-%315 = OpFunctionCall %ulong %5 %313 %314
-OpStore %193 %315
-%316 = OpLoad %v2ulong %99
-%317 = OpCompositeExtract %ulong %316 1
-OpStore %194 %317
-%318 = OpLoad %ulong %193
-%319 = OpLoad %ulong %194
-%320 = OpFunctionCall %ulong %5 %318 %319
-OpStore %195 %320
-OpBranch %65
-%65 = OpLabel
-%321 = OpLoad %v2ulong %94
-%322 = OpLoad %v2ulong %87
-%323 = OpIMul %v2ulong %321 %322
-OpStore %100 %323
-OpBranch %66
-%66 = OpLabel
-%324 = OpLoad %v2ulong %100
-%325 = OpCompositeExtract %ulong %324 0
-OpStore %196 %325
-%326 = OpLoad %ulong %195
-%327 = OpLoad %ulong %196
-%328 = OpFunctionCall %ulong %5 %326 %327
-OpStore %197 %328
-%329 = OpLoad %v2ulong %100
-%330 = OpCompositeExtract %ulong %329 1
-OpStore %198 %330
-%331 = OpLoad %ulong %197
-%332 = OpLoad %ulong %198
-%333 = OpFunctionCall %ulong %5 %331 %332
-OpStore %199 %333
-OpBranch %67
-%67 = OpLabel
-%334 = OpLoad %v2ulong %91
-%335 = OpLoad %v2ulong %94
-%336 = OpIAdd %v2ulong %334 %335
-OpStore %101 %336
-%337 = OpLoad %v2ulong %101
-%338 = OpLoad %v2ulong %87
-%339 = OpIMul %v2ulong %337 %338
-OpStore %102 %339
-OpBranch %68
-%68 = OpLabel
-%340 = OpLoad %v2ulong %102
-%341 = OpCompositeExtract %ulong %340 0
-OpStore %200 %341
-%342 = OpLoad %ulong %199
-%343 = OpLoad %ulong %200
-%344 = OpFunctionCall %ulong %5 %342 %343
-OpStore %201 %344
-%345 = OpLoad %v2ulong %102
-%346 = OpCompositeExtract %ulong %345 1
-OpStore %202 %346
-%347 = OpLoad %ulong %201
-%348 = OpLoad %ulong %202
-%349 = OpFunctionCall %ulong %5 %347 %348
-OpStore %203 %349
-OpBranch %69
-%69 = OpLabel
-%350 = OpLoad %v2ulong %88
-%351 = OpLoad %v2ulong %91
-%352 = OpISub %v2ulong %350 %351
-OpStore %103 %352
-OpBranch %70
-%70 = OpLabel
-%353 = OpLoad %v2ulong %103
-%354 = OpCompositeExtract %ulong %353 0
-OpStore %204 %354
-%355 = OpLoad %ulong %203
-%356 = OpLoad %ulong %204
-%357 = OpFunctionCall %ulong %5 %355 %356
-OpStore %205 %357
-%358 = OpLoad %v2ulong %103
-%359 = OpCompositeExtract %ulong %358 1
-OpStore %206 %359
-%360 = OpLoad %ulong %205
-%361 = OpLoad %ulong %206
-%362 = OpFunctionCall %ulong %5 %360 %361
-OpStore %207 %362
-OpBranch %71
-%71 = OpLabel
-%363 = OpLoad %v2ulong %88
-%364 = OpLoad %v2ulong %94
-%365 = OpISub %v2ulong %363 %364
-OpStore %104 %365
-%366 = OpLoad %ulong %207
-%367 = OpLoad %v2ulong %104
-%368 = OpFunctionCall %ulong %1 %366 %367
-OpStore %105 %368
-%369 = OpLoad %v2ulong %91
-%370 = OpLoad %v2ulong %94
-%371 = OpBitwiseAnd %v2ulong %369 %370
-OpStore %106 %371
-%372 = OpLoad %ulong %105
-%373 = OpLoad %v2ulong %106
-%374 = OpFunctionCall %ulong %1 %372 %373
-OpStore %107 %374
-%375 = OpLoad %v2ulong %91
-%376 = OpLoad %v2ulong %94
-%377 = OpBitwiseOr %v2ulong %375 %376
-OpStore %108 %377
-%378 = OpLoad %ulong %107
-%379 = OpLoad %v2ulong %108
-%380 = OpFunctionCall %ulong %1 %378 %379
-OpStore %109 %380
-%381 = OpLoad %v2ulong %91
-%382 = OpLoad %v2ulong %94
-%383 = OpBitwiseXor %v2ulong %381 %382
-OpStore %110 %383
-%384 = OpLoad %ulong %109
-%385 = OpLoad %v2ulong %110
-%386 = OpFunctionCall %ulong %1 %384 %385
-OpStore %111 %386
-%387 = OpLoad %v2ulong %91
-%388 = OpNot %v2ulong %387
-OpStore %112 %388
-%389 = OpLoad %ulong %111
-%390 = OpLoad %v2ulong %112
-%391 = OpFunctionCall %ulong %1 %389 %390
-OpStore %113 %391
-%392 = OpLoad %v2ulong %94
-%393 = OpNot %v2ulong %392
-OpStore %114 %393
-%394 = OpLoad %ulong %113
-%395 = OpLoad %v2ulong %114
-%396 = OpFunctionCall %ulong %1 %394 %395
-OpStore %115 %396
-%397 = OpLoad %v2ulong %106
-%398 = OpLoad %v2ulong %108
-%399 = OpBitwiseXor %v2ulong %397 %398
-OpStore %116 %399
-%400 = OpLoad %ulong %115
-%401 = OpLoad %v2ulong %116
-%402 = OpFunctionCall %ulong %1 %400 %401
-OpStore %117 %402
-%403 = OpLoad %ulong %117
-OpStore %138 %403
-%404 = OpLoad %v2ulong %91
-OpStore %139 %404
-%405 = OpLoad %v2ulong %88
-OpStore %140 %405
-%406 = OpLoad %v2ulong %88
-OpStore %141 %406
-OpStore %142 %ulong_0
-OpBranch %34
-%34 = OpLabel
-%407 = OpLoad %ulong %142
-%409 = OpULessThan %bool %407 %ulong_6
-OpStore %119 %409
-%410 = OpLoad %bool %119
-OpLoopMerge %36 %73 None
-OpBranchConditional %410 %35 %36
-%36 = OpLabel
-OpStore %79 %411
-%413 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_0
-%414 = OpLoad %v2ulong %139
-OpStore %413 %414
-%415 = OpLoad %v2ulong %139
-%416 = OpLoad %v2ulong %94
-%417 = OpIAdd %v2ulong %415 %416
-OpStore %125 %417
-%419 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_1
-%420 = OpLoad %v2ulong %125
-OpStore %419 %420
-%421 = OpLoad %v2ulong %139
-%422 = OpLoad %v2ulong %87
-%423 = OpIMul %v2ulong %421 %422
-OpStore %126 %423
-%425 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_2
-%426 = OpLoad %v2ulong %126
-OpStore %425 %426
-%428 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_3
-%429 = OpLoad %v2ulong %140
-OpStore %428 %429
-%430 = OpLoad %ulong %138
-OpStore %137 %430
-OpStore %143 %ulong_0
-OpBranch %37
-%37 = OpLabel
-%431 = OpLoad %ulong %143
-%433 = OpULessThan %bool %431 %ulong_4
-OpStore %127 %433
-%434 = OpLoad %bool %127
-OpLoopMerge %39 %72 None
-OpBranchConditional %434 %38 %39
-%39 = OpLabel
-OpStore %82 %435
-%436 = OpAccessChain %_ptr_Function_uint %82 %uint_0
-OpStore %436 %uint_4294967295
-%438 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_2
-%439 = OpLoad %v2ulong %438
-OpStore %130 %439
-%440 = OpAccessChain %_ptr_Function_v2ulong %82 %uint_1
-%441 = OpLoad %v2ulong %130
-OpStore %440 %441
-%442 = OpAccessChain %_ptr_Function_uint %82 %uint_2
-OpStore %442 %uint_305419896
-%444 = OpLoad %uint %436
-OpStore %132 %444
-%445 = OpLoad %ulong %137
-%446 = OpLoad %uint %132
-%447 = OpFunctionCall %ulong %4 %445 %446
-OpStore %133 %447
-%448 = OpLoad %v2ulong %440
-OpStore %134 %448
-OpBranch %46
-%46 = OpLabel
-%449 = OpLoad %v2ulong %134
-%450 = OpCompositeExtract %ulong %449 0
-OpStore %156 %450
-%451 = OpLoad %ulong %133
-%452 = OpLoad %ulong %156
-%453 = OpFunctionCall %ulong %5 %451 %452
-OpStore %157 %453
-%454 = OpLoad %v2ulong %134
-%455 = OpCompositeExtract %ulong %454 1
-OpStore %158 %455
-%456 = OpLoad %ulong %157
-%457 = OpLoad %ulong %158
-%458 = OpFunctionCall %ulong %5 %456 %457
-OpStore %159 %458
-OpBranch %47
-%47 = OpLabel
-%459 = OpAccessChain %_ptr_Function_uint %82 %uint_2
-%460 = OpLoad %uint %459
-OpStore %135 %460
-%461 = OpLoad %ulong %159
-%462 = OpLoad %uint %135
-%463 = OpFunctionCall %ulong %4 %461 %462
-OpStore %136 %463
-%464 = OpLoad %ulong %136
-OpReturnValue %464
-%38 = OpLabel
-%465 = OpLoad %ulong %143
-%466 = OpAccessChain %_ptr_Function_v2ulong %79 %465
-%467 = OpLoad %v2ulong %466
-OpStore %128 %467
-OpBranch %44
-%44 = OpLabel
-%468 = OpLoad %v2ulong %128
-%469 = OpCompositeExtract %ulong %468 0
-OpStore %152 %469
-%470 = OpLoad %ulong %137
-%471 = OpLoad %ulong %152
-%472 = OpFunctionCall %ulong %5 %470 %471
-OpStore %153 %472
-%473 = OpLoad %v2ulong %128
-%474 = OpCompositeExtract %ulong %473 1
-OpStore %154 %474
-%475 = OpLoad %ulong %153
-%476 = OpLoad %ulong %154
-%477 = OpFunctionCall %ulong %5 %475 %476
-OpStore %155 %477
-OpBranch %45
-%45 = OpLabel
-%478 = OpLoad %ulong %143
-%479 = OpIAdd %ulong %478 %ulong_1
-OpStore %129 %479
-%480 = OpLoad %ulong %155
-OpStore %137 %480
-%481 = OpLoad %ulong %129
-OpStore %143 %481
-OpBranch %72
-%35 = OpLabel
-%482 = OpLoad %v2ulong %139
-%483 = OpLoad %v2ulong %87
-%484 = OpIMul %v2ulong %482 %483
-OpStore %120 %484
-OpBranch %42
-%42 = OpLabel
-%485 = OpLoad %v2ulong %120
-%486 = OpCompositeExtract %ulong %485 0
-OpStore %148 %486
-%487 = OpLoad %ulong %138
-%488 = OpLoad %ulong %148
-%489 = OpFunctionCall %ulong %5 %487 %488
-OpStore %149 %489
-%490 = OpLoad %v2ulong %120
-%491 = OpCompositeExtract %ulong %490 1
-OpStore %150 %491
-%492 = OpLoad %ulong %149
-%493 = OpLoad %ulong %150
-%494 = OpFunctionCall %ulong %5 %492 %493
-OpStore %151 %494
-OpBranch %43
-%43 = OpLabel
-%495 = OpLoad %v2ulong %140
-%496 = OpLoad %v2ulong %120
-%497 = OpBitwiseXor %v2ulong %495 %496
-OpStore %121 %497
-OpBranch %50
-%50 = OpLabel
-%498 = OpLoad %v2ulong %121
-%499 = OpCompositeExtract %ulong %498 0
-OpStore %164 %499
-%500 = OpLoad %ulong %151
-%501 = OpLoad %ulong %164
-%502 = OpFunctionCall %ulong %5 %500 %501
-OpStore %165 %502
-%503 = OpLoad %v2ulong %121
-%504 = OpCompositeExtract %ulong %503 1
-OpStore %166 %504
-%505 = OpLoad %ulong %165
-%506 = OpLoad %ulong %166
-%507 = OpFunctionCall %ulong %5 %505 %506
-OpStore %167 %507
-OpBranch %51
-%51 = OpLabel
-%508 = OpLoad %v2ulong %141
-%509 = OpLoad %v2ulong %139
-%510 = OpIAdd %v2ulong %508 %509
-OpStore %122 %510
-OpBranch %54
-%54 = OpLabel
-%511 = OpLoad %v2ulong %122
-%512 = OpCompositeExtract %ulong %511 0
-OpStore %172 %512
-%513 = OpLoad %ulong %167
-%514 = OpLoad %ulong %172
-%515 = OpFunctionCall %ulong %5 %513 %514
-OpStore %173 %515
-%516 = OpLoad %v2ulong %122
-%517 = OpCompositeExtract %ulong %516 1
-OpStore %174 %517
-%518 = OpLoad %ulong %173
-%519 = OpLoad %ulong %174
-%520 = OpFunctionCall %ulong %5 %518 %519
-OpStore %175 %520
-OpBranch %55
-%55 = OpLabel
-%521 = OpLoad %v2ulong %139
-%522 = OpLoad %v2ulong %94
-%523 = OpIAdd %v2ulong %521 %522
-OpStore %123 %523
-OpBranch %58
-%58 = OpLabel
-%524 = OpLoad %v2ulong %123
-%525 = OpCompositeExtract %ulong %524 0
-OpStore %180 %525
-%526 = OpLoad %ulong %175
-%527 = OpLoad %ulong %180
-%528 = OpFunctionCall %ulong %5 %526 %527
-OpStore %181 %528
-%529 = OpLoad %v2ulong %123
-%530 = OpCompositeExtract %ulong %529 1
-OpStore %182 %530
-%531 = OpLoad %ulong %181
-%532 = OpLoad %ulong %182
-%533 = OpFunctionCall %ulong %5 %531 %532
-OpStore %183 %533
-OpBranch %59
-%59 = OpLabel
-%534 = OpLoad %ulong %142
-%535 = OpIAdd %ulong %534 %ulong_1
-OpStore %124 %535
-%536 = OpLoad %ulong %183
-OpStore %138 %536
-%537 = OpLoad %v2ulong %123
-OpStore %139 %537
-%538 = OpLoad %v2ulong %121
-OpStore %140 %538
-%539 = OpLoad %v2ulong %122
-OpStore %141 %539
-%540 = OpLoad %ulong %124
-OpStore %142 %540
-OpBranch %73
-%72 = OpLabel
-OpBranch %37
-%73 = OpLabel
-OpBranch %34
-OpFunctionEnd
-%3 = OpFunction %ulong None %541
-%542 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %544
-%545 = OpFunctionParameter %ulong
-%546 = OpFunctionParameter %uint
-%547 = OpLabel
-%554 = OpVariable %_ptr_Function_ulong Function
-%555 = OpVariable %_ptr_Function_uint Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_bool Function
-%558 = OpVariable %_ptr_Function_ulong Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_ulong Function
-%561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_ulong Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_ulong Function
-%565 = OpVariable %_ptr_Function_ulong Function
-OpStore %554 %545
-OpStore %555 %546
-%566 = OpLoad %uint %555
-%567 = OpUConvert %ulong %566
-OpStore %556 %567
-OpBranch %548
-%548 = OpLabel
-%568 = OpLoad %ulong %554
-OpStore %564 %568
-OpStore %565 %ulong_0
-OpBranch %549
-%549 = OpLabel
-%569 = OpLoad %ulong %565
-%571 = OpULessThan %bool %569 %ulong_8
-OpStore %557 %571
-%572 = OpLoad %bool %557
-OpLoopMerge %551 %553 None
-OpBranchConditional %572 %550 %551
-%551 = OpLabel
-OpBranch %552
-%552 = OpLabel
-%573 = OpLoad %ulong %564
-OpReturnValue %573
-%550 = OpLabel
-%574 = OpLoad %ulong %565
-%575 = OpIMul %ulong %574 %ulong_8
-OpStore %558 %575
-%576 = OpLoad %ulong %556
-%577 = OpLoad %ulong %558
-%578 = OpShiftRightLogical %ulong %576 %577
-OpStore %559 %578
-%579 = OpLoad %ulong %559
-%581 = OpBitwiseAnd %ulong %579 %ulong_255
-OpStore %560 %581
-%582 = OpLoad %ulong %564
-%583 = OpLoad %ulong %560
-%584 = OpBitwiseXor %ulong %582 %583
-OpStore %561 %584
-%585 = OpLoad %ulong %561
-%587 = OpIMul %ulong %585 %ulong_1099511628211
-OpStore %562 %587
-%588 = OpLoad %ulong %565
-%589 = OpIAdd %ulong %588 %ulong_1
-OpStore %563 %589
-%590 = OpLoad %ulong %562
-OpStore %564 %590
-%591 = OpLoad %ulong %563
-OpStore %565 %591
-OpBranch %553
-%553 = OpLabel
-OpBranch %549
-OpFunctionEnd
-%5 = OpFunction %ulong None %592
-%593 = OpFunctionParameter %ulong
-%594 = OpFunctionParameter %ulong
-%595 = OpLabel
-%602 = OpVariable %_ptr_Function_ulong Function
-%603 = OpVariable %_ptr_Function_ulong Function
-%604 = OpVariable %_ptr_Function_bool Function
-%605 = OpVariable %_ptr_Function_ulong Function
-%606 = OpVariable %_ptr_Function_ulong Function
-%607 = OpVariable %_ptr_Function_ulong Function
-%608 = OpVariable %_ptr_Function_ulong Function
-%609 = OpVariable %_ptr_Function_ulong Function
-%610 = OpVariable %_ptr_Function_ulong Function
-%611 = OpVariable %_ptr_Function_ulong Function
-%612 = OpVariable %_ptr_Function_ulong Function
-OpStore %602 %593
-OpStore %603 %594
-OpBranch %596
-%596 = OpLabel
-%613 = OpLoad %ulong %602
-OpStore %611 %613
-OpStore %612 %ulong_0
-OpBranch %597
-%597 = OpLabel
-%614 = OpLoad %ulong %612
-%615 = OpULessThan %bool %614 %ulong_8
-OpStore %604 %615
-%616 = OpLoad %bool %604
-OpLoopMerge %599 %601 None
-OpBranchConditional %616 %598 %599
-%599 = OpLabel
-OpBranch %600
-%600 = OpLabel
-%617 = OpLoad %ulong %611
-OpReturnValue %617
-%598 = OpLabel
-%618 = OpLoad %ulong %612
-%619 = OpIMul %ulong %618 %ulong_8
-OpStore %605 %619
-%620 = OpLoad %ulong %603
-%621 = OpLoad %ulong %605
-%622 = OpShiftRightLogical %ulong %620 %621
-OpStore %606 %622
-%623 = OpLoad %ulong %606
-%624 = OpBitwiseAnd %ulong %623 %ulong_255
-OpStore %607 %624
-%625 = OpLoad %ulong %611
-%626 = OpLoad %ulong %607
-%627 = OpBitwiseXor %ulong %625 %626
-OpStore %608 %627
-%628 = OpLoad %ulong %608
-%629 = OpIMul %ulong %628 %ulong_1099511628211
-OpStore %609 %629
-%630 = OpLoad %ulong %612
-%631 = OpIAdd %ulong %630 %ulong_1
-OpStore %610 %631
-%632 = OpLoad %ulong %609
-OpStore %611 %632
-%633 = OpLoad %ulong %610
-OpStore %612 %633
-OpBranch %601
-%601 = OpLabel
-OpBranch %597
+%205 = OpVariable %_ptr_Function_v2ulong Function
+%206 = OpVariable %_ptr_Function_v2ulong Function
+%207 = OpVariable %_ptr_Function_v2ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_bool Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_bool Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+OpStore %138 %102
+OpBranch %110
+%110 = OpLabel
+OpBranch %111
+%111 = OpLabel
+%230 = OpCompositeConstruct %v2ulong %ulong_1000000007 %ulong_18446744071709551605
+OpStore %139 %230
+%233 = OpCompositeConstruct %v2ulong %ulong_3000000019 %ulong_18446744069709551579
+OpStore %140 %233
+%236 = OpCompositeConstruct %v2ulong %ulong_1 %ulong_3
+OpStore %141 %236
+%238 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_0
+OpStore %142 %238
+%239 = OpLoad %v2ulong %139
+%240 = OpCompositeExtract %ulong %239 0
+OpStore %143 %240
+%241 = OpLoad %ulong %143
+%242 = OpLoad %ulong %138
+%243 = OpIAdd %ulong %241 %242
+OpStore %144 %243
+%244 = OpLoad %v2ulong %139
+%245 = OpLoad %ulong %144
+%246 = OpCompositeInsert %v2ulong %245 %244 0
+OpStore %145 %246
+%247 = OpLoad %v2ulong %140
+%248 = OpCompositeExtract %ulong %247 1
+OpStore %146 %248
+%249 = OpLoad %ulong %146
+%250 = OpLoad %ulong %138
+%251 = OpIAdd %ulong %249 %250
+OpStore %147 %251
+%252 = OpLoad %v2ulong %140
+%253 = OpLoad %ulong %147
+%254 = OpCompositeInsert %v2ulong %253 %252 1
+OpStore %148 %254
+%256 = OpLoad %v2ulong %145
+%257 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %256
+OpStore %149 %257
+%258 = OpLoad %ulong %149
+%259 = OpLoad %v2ulong %148
+%260 = OpFunctionCall %ulong %1 %258 %259
+OpStore %150 %260
+%261 = OpLoad %v2ulong %145
+%262 = OpLoad %v2ulong %148
+%263 = OpIAdd %v2ulong %261 %262
+OpStore %151 %263
+%264 = OpLoad %ulong %150
+%265 = OpLoad %v2ulong %151
+%266 = OpFunctionCall %ulong %1 %264 %265
+OpStore %152 %266
+%267 = OpLoad %v2ulong %145
+%268 = OpLoad %v2ulong %148
+%269 = OpISub %v2ulong %267 %268
+OpStore %153 %269
+%270 = OpLoad %ulong %152
+%271 = OpLoad %v2ulong %153
+%272 = OpFunctionCall %ulong %1 %270 %271
+OpStore %154 %272
+%273 = OpLoad %v2ulong %148
+%274 = OpLoad %v2ulong %145
+%275 = OpISub %v2ulong %273 %274
+OpStore %155 %275
+%276 = OpLoad %ulong %154
+%277 = OpLoad %v2ulong %155
+%278 = OpFunctionCall %ulong %1 %276 %277
+OpStore %156 %278
+%279 = OpLoad %v2ulong %145
+%280 = OpLoad %v2ulong %148
+%281 = OpIMul %v2ulong %279 %280
+OpStore %157 %281
+%282 = OpLoad %ulong %156
+%283 = OpLoad %v2ulong %157
+%284 = OpFunctionCall %ulong %1 %282 %283
+OpStore %158 %284
+%285 = OpLoad %v2ulong %145
+%286 = OpLoad %v2ulong %141
+%287 = OpIMul %v2ulong %285 %286
+OpStore %159 %287
+%288 = OpLoad %ulong %158
+%289 = OpLoad %v2ulong %159
+%290 = OpFunctionCall %ulong %1 %288 %289
+OpStore %160 %290
+%291 = OpLoad %v2ulong %148
+%292 = OpLoad %v2ulong %141
+%293 = OpIMul %v2ulong %291 %292
+OpStore %161 %293
+%294 = OpLoad %ulong %160
+%295 = OpLoad %v2ulong %161
+%296 = OpFunctionCall %ulong %1 %294 %295
+OpStore %162 %296
+%297 = OpLoad %v2ulong %151
+%298 = OpLoad %v2ulong %141
+%299 = OpIMul %v2ulong %297 %298
+OpStore %163 %299
+%300 = OpLoad %ulong %162
+%301 = OpLoad %v2ulong %163
+%302 = OpFunctionCall %ulong %1 %300 %301
+OpStore %164 %302
+%303 = OpLoad %v2ulong %142
+%304 = OpLoad %v2ulong %145
+%305 = OpISub %v2ulong %303 %304
+OpStore %165 %305
+%306 = OpLoad %ulong %164
+%307 = OpLoad %v2ulong %165
+%308 = OpFunctionCall %ulong %1 %306 %307
+OpStore %166 %308
+%309 = OpLoad %v2ulong %142
+%310 = OpLoad %v2ulong %148
+%311 = OpISub %v2ulong %309 %310
+OpStore %167 %311
+%312 = OpLoad %ulong %166
+%313 = OpLoad %v2ulong %167
+%314 = OpFunctionCall %ulong %1 %312 %313
+OpStore %168 %314
+%315 = OpLoad %v2ulong %145
+%316 = OpLoad %v2ulong %148
+%317 = OpBitwiseAnd %v2ulong %315 %316
+OpStore %169 %317
+%318 = OpLoad %ulong %168
+%319 = OpLoad %v2ulong %169
+%320 = OpFunctionCall %ulong %1 %318 %319
+OpStore %170 %320
+%321 = OpLoad %v2ulong %145
+%322 = OpLoad %v2ulong %148
+%323 = OpBitwiseOr %v2ulong %321 %322
+OpStore %171 %323
+%324 = OpLoad %ulong %170
+%325 = OpLoad %v2ulong %171
+%326 = OpFunctionCall %ulong %1 %324 %325
+OpStore %172 %326
+%327 = OpLoad %v2ulong %145
+%328 = OpLoad %v2ulong %148
+%329 = OpBitwiseXor %v2ulong %327 %328
+OpStore %173 %329
+%330 = OpLoad %ulong %172
+%331 = OpLoad %v2ulong %173
+%332 = OpFunctionCall %ulong %1 %330 %331
+OpStore %174 %332
+%333 = OpLoad %v2ulong %145
+%334 = OpNot %v2ulong %333
+OpStore %175 %334
+%335 = OpLoad %ulong %174
+%336 = OpLoad %v2ulong %175
+%337 = OpFunctionCall %ulong %1 %335 %336
+OpStore %176 %337
+%338 = OpLoad %v2ulong %148
+%339 = OpNot %v2ulong %338
+OpStore %177 %339
+%340 = OpLoad %ulong %176
+%341 = OpLoad %v2ulong %177
+%342 = OpFunctionCall %ulong %1 %340 %341
+OpStore %178 %342
+%343 = OpLoad %v2ulong %169
+%344 = OpLoad %v2ulong %171
+%345 = OpBitwiseXor %v2ulong %343 %344
+OpStore %179 %345
+%346 = OpLoad %ulong %178
+%347 = OpLoad %v2ulong %179
+%348 = OpFunctionCall %ulong %1 %346 %347
+OpStore %180 %348
+%349 = OpLoad %ulong %180
+OpStore %204 %349
+%350 = OpLoad %v2ulong %145
+OpStore %205 %350
+%351 = OpLoad %v2ulong %142
+OpStore %206 %351
+%352 = OpLoad %v2ulong %142
+OpStore %207 %352
+OpStore %208 %ulong_0
+OpBranch %104
+%104 = OpLabel
+%353 = OpLoad %ulong %208
+%355 = OpULessThan %bool %353 %ulong_6
+OpStore %181 %355
+%356 = OpLoad %bool %181
+OpLoopMerge %106 %129 None
+OpBranchConditional %356 %105 %106
+%106 = OpLabel
+OpStore %134 %357
+%359 = OpAccessChain %_ptr_Function_v2ulong %134 %uint_0
+%360 = OpLoad %v2ulong %205
+OpStore %359 %360
+%361 = OpLoad %v2ulong %205
+%362 = OpLoad %v2ulong %148
+%363 = OpIAdd %v2ulong %361 %362
+OpStore %191 %363
+%365 = OpAccessChain %_ptr_Function_v2ulong %134 %uint_1
+%366 = OpLoad %v2ulong %191
+OpStore %365 %366
+%367 = OpLoad %v2ulong %205
+%368 = OpLoad %v2ulong %141
+%369 = OpIMul %v2ulong %367 %368
+OpStore %192 %369
+%371 = OpAccessChain %_ptr_Function_v2ulong %134 %uint_2
+%372 = OpLoad %v2ulong %192
+OpStore %371 %372
+%374 = OpAccessChain %_ptr_Function_v2ulong %134 %uint_3
+%375 = OpLoad %v2ulong %206
+OpStore %374 %375
+%376 = OpLoad %ulong %204
+OpStore %203 %376
+OpStore %209 %ulong_0
+OpBranch %107
+%107 = OpLabel
+%377 = OpLoad %ulong %209
+%379 = OpULessThan %bool %377 %ulong_4
+OpStore %193 %379
+%380 = OpLoad %bool %193
+OpLoopMerge %109 %128 None
+OpBranchConditional %380 %108 %109
+%109 = OpLabel
+OpStore %137 %381
+%382 = OpAccessChain %_ptr_Function_uint %137 %uint_0
+OpStore %382 %uint_4294967295
+%384 = OpAccessChain %_ptr_Function_v2ulong %134 %uint_2
+%385 = OpLoad %v2ulong %384
+OpStore %197 %385
+%386 = OpAccessChain %_ptr_Function_v2ulong %137 %uint_1
+%387 = OpLoad %v2ulong %197
+OpStore %386 %387
+%388 = OpAccessChain %_ptr_Function_uint %137 %uint_2
+OpStore %388 %uint_305419896
+%390 = OpLoad %uint %382
+OpStore %199 %390
+OpBranch %112
+%112 = OpLabel
+%391 = OpLoad %uint %199
+%392 = OpUConvert %ulong %391
+OpStore %210 %392
+OpBranch %114
+%114 = OpLabel
+%393 = OpLoad %ulong %203
+OpStore %218 %393
+OpStore %219 %ulong_0
+OpBranch %115
+%115 = OpLabel
+%394 = OpLoad %ulong %219
+%395 = OpULessThan %bool %394 %ulong_8
+OpStore %211 %395
+%396 = OpLoad %bool %211
+OpLoopMerge %117 %127 None
+OpBranchConditional %396 %116 %117
+%117 = OpLabel
+OpBranch %118
+%118 = OpLabel
+OpBranch %113
+%113 = OpLabel
+%397 = OpAccessChain %_ptr_Function_v2ulong %137 %uint_1
+%398 = OpLoad %v2ulong %397
+OpStore %200 %398
+%399 = OpLoad %ulong %218
+%400 = OpLoad %v2ulong %200
+%401 = OpFunctionCall %ulong %1 %399 %400
+OpStore %201 %401
+%402 = OpAccessChain %_ptr_Function_uint %137 %uint_2
+%403 = OpLoad %uint %402
+OpStore %202 %403
+OpBranch %119
+%119 = OpLabel
+%404 = OpLoad %uint %202
+%405 = OpUConvert %ulong %404
+OpStore %220 %405
+OpBranch %121
+%121 = OpLabel
+%406 = OpLoad %ulong %201
+OpStore %228 %406
+OpStore %229 %ulong_0
+OpBranch %122
+%122 = OpLabel
+%407 = OpLoad %ulong %229
+%408 = OpULessThan %bool %407 %ulong_8
+OpStore %221 %408
+%409 = OpLoad %bool %221
+OpLoopMerge %124 %126 None
+OpBranchConditional %409 %123 %124
+%124 = OpLabel
+OpBranch %125
+%125 = OpLabel
+OpBranch %120
+%120 = OpLabel
+%410 = OpLoad %ulong %228
+OpReturnValue %410
+%123 = OpLabel
+%411 = OpLoad %ulong %229
+%412 = OpIMul %ulong %411 %ulong_8
+OpStore %222 %412
+%413 = OpLoad %ulong %220
+%414 = OpLoad %ulong %222
+%415 = OpShiftRightLogical %ulong %413 %414
+OpStore %223 %415
+%416 = OpLoad %ulong %223
+%417 = OpBitwiseAnd %ulong %416 %ulong_255
+OpStore %224 %417
+%418 = OpLoad %ulong %228
+%419 = OpLoad %ulong %224
+%420 = OpBitwiseXor %ulong %418 %419
+OpStore %225 %420
+%421 = OpLoad %ulong %225
+%422 = OpIMul %ulong %421 %ulong_1099511628211
+OpStore %226 %422
+%423 = OpLoad %ulong %229
+%424 = OpIAdd %ulong %423 %ulong_1
+OpStore %227 %424
+%425 = OpLoad %ulong %226
+OpStore %228 %425
+%426 = OpLoad %ulong %227
+OpStore %229 %426
+OpBranch %126
+%116 = OpLabel
+%427 = OpLoad %ulong %219
+%428 = OpIMul %ulong %427 %ulong_8
+OpStore %212 %428
+%429 = OpLoad %ulong %210
+%430 = OpLoad %ulong %212
+%431 = OpShiftRightLogical %ulong %429 %430
+OpStore %213 %431
+%432 = OpLoad %ulong %213
+%433 = OpBitwiseAnd %ulong %432 %ulong_255
+OpStore %214 %433
+%434 = OpLoad %ulong %218
+%435 = OpLoad %ulong %214
+%436 = OpBitwiseXor %ulong %434 %435
+OpStore %215 %436
+%437 = OpLoad %ulong %215
+%438 = OpIMul %ulong %437 %ulong_1099511628211
+OpStore %216 %438
+%439 = OpLoad %ulong %219
+%440 = OpIAdd %ulong %439 %ulong_1
+OpStore %217 %440
+%441 = OpLoad %ulong %216
+OpStore %218 %441
+%442 = OpLoad %ulong %217
+OpStore %219 %442
+OpBranch %127
+%108 = OpLabel
+%443 = OpLoad %ulong %209
+%444 = OpAccessChain %_ptr_Function_v2ulong %134 %443
+%445 = OpLoad %v2ulong %444
+OpStore %194 %445
+%446 = OpLoad %ulong %203
+%447 = OpLoad %v2ulong %194
+%448 = OpFunctionCall %ulong %1 %446 %447
+OpStore %195 %448
+%449 = OpLoad %ulong %209
+%450 = OpIAdd %ulong %449 %ulong_1
+OpStore %196 %450
+%451 = OpLoad %ulong %195
+OpStore %203 %451
+%452 = OpLoad %ulong %196
+OpStore %209 %452
+OpBranch %128
+%105 = OpLabel
+%453 = OpLoad %v2ulong %205
+%454 = OpLoad %v2ulong %141
+%455 = OpIMul %v2ulong %453 %454
+OpStore %182 %455
+%456 = OpLoad %ulong %204
+%457 = OpLoad %v2ulong %182
+%458 = OpFunctionCall %ulong %1 %456 %457
+OpStore %183 %458
+%459 = OpLoad %v2ulong %206
+%460 = OpLoad %v2ulong %182
+%461 = OpBitwiseXor %v2ulong %459 %460
+OpStore %184 %461
+%462 = OpLoad %ulong %183
+%463 = OpLoad %v2ulong %184
+%464 = OpFunctionCall %ulong %1 %462 %463
+OpStore %185 %464
+%465 = OpLoad %v2ulong %207
+%466 = OpLoad %v2ulong %205
+%467 = OpIAdd %v2ulong %465 %466
+OpStore %186 %467
+%468 = OpLoad %ulong %185
+%469 = OpLoad %v2ulong %186
+%470 = OpFunctionCall %ulong %1 %468 %469
+OpStore %187 %470
+%471 = OpLoad %v2ulong %205
+%472 = OpLoad %v2ulong %148
+%473 = OpIAdd %v2ulong %471 %472
+OpStore %188 %473
+%474 = OpLoad %ulong %187
+%475 = OpLoad %v2ulong %188
+%476 = OpFunctionCall %ulong %1 %474 %475
+OpStore %189 %476
+%477 = OpLoad %ulong %208
+%478 = OpIAdd %ulong %477 %ulong_1
+OpStore %190 %478
+%479 = OpLoad %ulong %189
+OpStore %204 %479
+%480 = OpLoad %v2ulong %188
+OpStore %205 %480
+%481 = OpLoad %v2ulong %184
+OpStore %206 %481
+%482 = OpLoad %v2ulong %186
+OpStore %207 %482
+%483 = OpLoad %ulong %190
+OpStore %208 %483
+OpBranch %129
+%126 = OpLabel
+OpBranch %122
+%127 = OpLabel
+OpBranch %115
+%128 = OpLabel
+OpBranch %107
+%129 = OpLabel
+OpBranch %104
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_i8x16.dis
+++ b/test/golden/spirv/vec/vec_i8x16.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 5074
+; Bound: 5607
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,18 +15,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i8x16.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
-%11 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%9 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%133 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%714 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr__arr_uchar_uint_16_uint_4 = OpTypeArray %_arr_uchar_uint_16 %uint_4
 %_ptr_Function__arr__arr_uchar_uint_16_uint_4 = OpTypePointer Function %_arr__arr_uchar_uint_16_uint_4
-%_struct_149 = OpTypeStruct %uint %_arr_uchar_uint_16 %uint
-%_ptr_Function__struct_149 = OpTypePointer Function %_struct_149
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_735 = OpTypeStruct %uint %_arr_uchar_uint_16 %uint
+%_ptr_Function__struct_735 = OpTypePointer Function %_struct_735
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uchar_247 = OpConstant %uchar 247
 %uchar_7 = OpConstant %uchar 7
@@ -47,209 +52,52 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_i8x16.checksum" Export
 %uchar_249 = OpConstant %uchar 249
 %uchar_5 = OpConstant %uchar 5
 %uchar_0 = OpConstant %uchar 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_3 = OpConstant %ulong 3
-%3948 = OpConstantNull %_arr__arr_uchar_uint_16_uint_4
+%4532 = OpConstantNull %_arr__arr_uchar_uint_16_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%4286 = OpConstantNull %_struct_149
+%4870 = OpConstantNull %_struct_735
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%4978 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%4981 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%5029 = OpTypeFunction %ulong %ulong %uchar
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_uchar_uint_16
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%20 = OpVariable %_ptr_Function_uchar Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uchar Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_uchar Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uchar Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uchar Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uchar Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uchar Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_uchar Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uchar Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uchar Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_uchar Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_uchar Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uchar Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uchar Function
-%51 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%52 = OpLoad %_arr_uchar_uint_16 %18
-%53 = OpCompositeExtract %uchar %52 0
-OpStore %20 %53
-%54 = OpLoad %ulong %16
-%55 = OpLoad %uchar %20
-%56 = OpFunctionCall %ulong %5 %54 %55
-OpStore %21 %56
-%57 = OpLoad %_arr_uchar_uint_16 %18
-%58 = OpCompositeExtract %uchar %57 1
-OpStore %22 %58
-%59 = OpLoad %ulong %21
-%60 = OpLoad %uchar %22
-%61 = OpFunctionCall %ulong %5 %59 %60
-OpStore %23 %61
-%62 = OpLoad %_arr_uchar_uint_16 %18
-%63 = OpCompositeExtract %uchar %62 2
-OpStore %24 %63
-%64 = OpLoad %ulong %23
-%65 = OpLoad %uchar %24
-%66 = OpFunctionCall %ulong %5 %64 %65
-OpStore %25 %66
-%67 = OpLoad %_arr_uchar_uint_16 %18
-%68 = OpCompositeExtract %uchar %67 3
-OpStore %26 %68
-%69 = OpLoad %ulong %25
-%70 = OpLoad %uchar %26
-%71 = OpFunctionCall %ulong %5 %69 %70
-OpStore %27 %71
-%72 = OpLoad %_arr_uchar_uint_16 %18
-%73 = OpCompositeExtract %uchar %72 4
-OpStore %28 %73
-%74 = OpLoad %ulong %27
-%75 = OpLoad %uchar %28
-%76 = OpFunctionCall %ulong %5 %74 %75
-OpStore %29 %76
-%77 = OpLoad %_arr_uchar_uint_16 %18
-%78 = OpCompositeExtract %uchar %77 5
-OpStore %30 %78
-%79 = OpLoad %ulong %29
-%80 = OpLoad %uchar %30
-%81 = OpFunctionCall %ulong %5 %79 %80
-OpStore %31 %81
-%82 = OpLoad %_arr_uchar_uint_16 %18
-%83 = OpCompositeExtract %uchar %82 6
-OpStore %32 %83
-%84 = OpLoad %ulong %31
-%85 = OpLoad %uchar %32
-%86 = OpFunctionCall %ulong %5 %84 %85
-OpStore %33 %86
-%87 = OpLoad %_arr_uchar_uint_16 %18
-%88 = OpCompositeExtract %uchar %87 7
-OpStore %34 %88
-%89 = OpLoad %ulong %33
-%90 = OpLoad %uchar %34
-%91 = OpFunctionCall %ulong %5 %89 %90
-OpStore %35 %91
-%92 = OpLoad %_arr_uchar_uint_16 %18
-%93 = OpCompositeExtract %uchar %92 8
-OpStore %36 %93
-%94 = OpLoad %ulong %35
-%95 = OpLoad %uchar %36
-%96 = OpFunctionCall %ulong %5 %94 %95
-OpStore %37 %96
-%97 = OpLoad %_arr_uchar_uint_16 %18
-%98 = OpCompositeExtract %uchar %97 9
-OpStore %38 %98
-%99 = OpLoad %ulong %37
-%100 = OpLoad %uchar %38
-%101 = OpFunctionCall %ulong %5 %99 %100
-OpStore %39 %101
-%102 = OpLoad %_arr_uchar_uint_16 %18
-%103 = OpCompositeExtract %uchar %102 10
-OpStore %40 %103
-%104 = OpLoad %ulong %39
-%105 = OpLoad %uchar %40
-%106 = OpFunctionCall %ulong %5 %104 %105
-OpStore %41 %106
-%107 = OpLoad %_arr_uchar_uint_16 %18
-%108 = OpCompositeExtract %uchar %107 11
-OpStore %42 %108
-%109 = OpLoad %ulong %41
-%110 = OpLoad %uchar %42
-%111 = OpFunctionCall %ulong %5 %109 %110
-OpStore %43 %111
-%112 = OpLoad %_arr_uchar_uint_16 %18
-%113 = OpCompositeExtract %uchar %112 12
-OpStore %44 %113
-%114 = OpLoad %ulong %43
-%115 = OpLoad %uchar %44
-%116 = OpFunctionCall %ulong %5 %114 %115
-OpStore %45 %116
-%117 = OpLoad %_arr_uchar_uint_16 %18
-%118 = OpCompositeExtract %uchar %117 13
-OpStore %46 %118
-%119 = OpLoad %ulong %45
-%120 = OpLoad %uchar %46
-%121 = OpFunctionCall %ulong %5 %119 %120
-OpStore %47 %121
-%122 = OpLoad %_arr_uchar_uint_16 %18
-%123 = OpCompositeExtract %uchar %122 14
-OpStore %48 %123
-%124 = OpLoad %ulong %47
-%125 = OpLoad %uchar %48
-%126 = OpFunctionCall %ulong %5 %124 %125
-OpStore %49 %126
-%127 = OpLoad %_arr_uchar_uint_16 %18
-%128 = OpCompositeExtract %uchar %127 15
-OpStore %50 %128
-%129 = OpLoad %ulong %49
-%130 = OpLoad %uchar %50
-%131 = OpFunctionCall %ulong %5 %129 %130
-OpStore %51 %131
-%132 = OpLoad %ulong %51
-OpReturnValue %132
-OpFunctionEnd
-%2 = OpFunction %ulong None %133
-%134 = OpFunctionParameter %ulong
-%135 = OpLabel
-%148 = OpVariable %_ptr_Function__arr__arr_uchar_uint_16_uint_4 Function
-%151 = OpVariable %_ptr_Function__struct_149 Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
+%5567 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %_arr_uchar_uint_16
+%12 = OpLabel
+%143 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%147 = OpVariable %_ptr_Function_uchar Function
+%148 = OpVariable %_ptr_Function_uchar Function
+%149 = OpVariable %_ptr_Function_uchar Function
+%150 = OpVariable %_ptr_Function_uchar Function
+%151 = OpVariable %_ptr_Function_uchar Function
+%152 = OpVariable %_ptr_Function_uchar Function
+%153 = OpVariable %_ptr_Function_uchar Function
 %154 = OpVariable %_ptr_Function_uchar Function
-%155 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%156 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%157 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%158 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%155 = OpVariable %_ptr_Function_uchar Function
+%156 = OpVariable %_ptr_Function_uchar Function
+%157 = OpVariable %_ptr_Function_uchar Function
+%158 = OpVariable %_ptr_Function_uchar Function
 %159 = OpVariable %_ptr_Function_uchar Function
 %160 = OpVariable %_ptr_Function_uchar Function
-%161 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%161 = OpVariable %_ptr_Function_uchar Function
 %162 = OpVariable %_ptr_Function_uchar Function
-%163 = OpVariable %_ptr_Function_uchar Function
-%164 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%165 = OpVariable %_ptr_Function_uchar Function
-%166 = OpVariable %_ptr_Function_uchar Function
-%167 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%168 = OpVariable %_ptr_Function_uchar Function
-%169 = OpVariable %_ptr_Function_uchar Function
-%170 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_bool Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
 %171 = OpVariable %_ptr_Function_ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
 %173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_bool Function
 %176 = OpVariable %_ptr_Function_ulong Function
 %177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
@@ -259,619 +107,1080 @@ OpFunctionEnd
 %182 = OpVariable %_ptr_Function_ulong Function
 %183 = OpVariable %_ptr_Function_ulong Function
 %184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_bool Function
 %186 = OpVariable %_ptr_Function_ulong Function
 %187 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_bool Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
 %190 = OpVariable %_ptr_Function_ulong Function
 %191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
 %193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
 %195 = OpVariable %_ptr_Function_bool Function
-%196 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%196 = OpVariable %_ptr_Function_ulong Function
 %197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%201 = OpVariable %_ptr_Function_uint Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_uint Function
+%205 = OpVariable %_ptr_Function_bool Function
 %206 = OpVariable %_ptr_Function_ulong Function
 %207 = OpVariable %_ptr_Function_ulong Function
 %208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%210 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%211 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
 %212 = OpVariable %_ptr_Function_ulong Function
 %213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_uchar Function
-%215 = OpVariable %_ptr_Function_uchar Function
-%216 = OpVariable %_ptr_Function_uchar Function
-%217 = OpVariable %_ptr_Function_uchar Function
-%218 = OpVariable %_ptr_Function_uchar Function
-%219 = OpVariable %_ptr_Function_uchar Function
-%220 = OpVariable %_ptr_Function_uchar Function
-%221 = OpVariable %_ptr_Function_uchar Function
-%222 = OpVariable %_ptr_Function_uchar Function
-%223 = OpVariable %_ptr_Function_uchar Function
-%224 = OpVariable %_ptr_Function_uchar Function
-%225 = OpVariable %_ptr_Function_uchar Function
-%226 = OpVariable %_ptr_Function_uchar Function
-%227 = OpVariable %_ptr_Function_uchar Function
-%228 = OpVariable %_ptr_Function_uchar Function
-%229 = OpVariable %_ptr_Function_uchar Function
-%230 = OpVariable %_ptr_Function_uchar Function
-%231 = OpVariable %_ptr_Function_uchar Function
-%232 = OpVariable %_ptr_Function_uchar Function
-%233 = OpVariable %_ptr_Function_uchar Function
-%234 = OpVariable %_ptr_Function_uchar Function
-%235 = OpVariable %_ptr_Function_uchar Function
-%236 = OpVariable %_ptr_Function_uchar Function
-%237 = OpVariable %_ptr_Function_uchar Function
-%238 = OpVariable %_ptr_Function_uchar Function
-%239 = OpVariable %_ptr_Function_uchar Function
-%240 = OpVariable %_ptr_Function_uchar Function
-%241 = OpVariable %_ptr_Function_uchar Function
-%242 = OpVariable %_ptr_Function_uchar Function
-%243 = OpVariable %_ptr_Function_uchar Function
-%244 = OpVariable %_ptr_Function_uchar Function
-%245 = OpVariable %_ptr_Function_uchar Function
-%246 = OpVariable %_ptr_Function_uchar Function
-%247 = OpVariable %_ptr_Function_uchar Function
-%248 = OpVariable %_ptr_Function_uchar Function
-%249 = OpVariable %_ptr_Function_uchar Function
-%250 = OpVariable %_ptr_Function_uchar Function
-%251 = OpVariable %_ptr_Function_uchar Function
-%252 = OpVariable %_ptr_Function_uchar Function
-%253 = OpVariable %_ptr_Function_uchar Function
-%254 = OpVariable %_ptr_Function_uchar Function
-%255 = OpVariable %_ptr_Function_uchar Function
-%256 = OpVariable %_ptr_Function_uchar Function
-%257 = OpVariable %_ptr_Function_uchar Function
-%258 = OpVariable %_ptr_Function_uchar Function
-%259 = OpVariable %_ptr_Function_uchar Function
-%260 = OpVariable %_ptr_Function_uchar Function
-%261 = OpVariable %_ptr_Function_uchar Function
-%262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%270 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%271 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%272 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%273 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%274 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%275 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%276 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%277 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%278 = OpVariable %_ptr_Function_uchar Function
-%279 = OpVariable %_ptr_Function_uchar Function
-%280 = OpVariable %_ptr_Function_uchar Function
-%281 = OpVariable %_ptr_Function_uchar Function
-%282 = OpVariable %_ptr_Function_uchar Function
-%283 = OpVariable %_ptr_Function_uchar Function
-%284 = OpVariable %_ptr_Function_uchar Function
-%285 = OpVariable %_ptr_Function_uchar Function
-%286 = OpVariable %_ptr_Function_uchar Function
-%287 = OpVariable %_ptr_Function_uchar Function
-%288 = OpVariable %_ptr_Function_uchar Function
-%289 = OpVariable %_ptr_Function_uchar Function
-%290 = OpVariable %_ptr_Function_uchar Function
-%291 = OpVariable %_ptr_Function_uchar Function
-%292 = OpVariable %_ptr_Function_uchar Function
-%293 = OpVariable %_ptr_Function_uchar Function
-%294 = OpVariable %_ptr_Function_uchar Function
-%295 = OpVariable %_ptr_Function_uchar Function
-%296 = OpVariable %_ptr_Function_uchar Function
-%297 = OpVariable %_ptr_Function_uchar Function
-%298 = OpVariable %_ptr_Function_uchar Function
-%299 = OpVariable %_ptr_Function_uchar Function
-%300 = OpVariable %_ptr_Function_uchar Function
-%301 = OpVariable %_ptr_Function_uchar Function
-%302 = OpVariable %_ptr_Function_uchar Function
-%303 = OpVariable %_ptr_Function_uchar Function
-%304 = OpVariable %_ptr_Function_uchar Function
-%305 = OpVariable %_ptr_Function_uchar Function
-%306 = OpVariable %_ptr_Function_uchar Function
-%307 = OpVariable %_ptr_Function_uchar Function
-%308 = OpVariable %_ptr_Function_uchar Function
-%309 = OpVariable %_ptr_Function_uchar Function
-%310 = OpVariable %_ptr_Function_uchar Function
-%311 = OpVariable %_ptr_Function_uchar Function
-%312 = OpVariable %_ptr_Function_uchar Function
-%313 = OpVariable %_ptr_Function_uchar Function
-%314 = OpVariable %_ptr_Function_uchar Function
-%315 = OpVariable %_ptr_Function_uchar Function
-%316 = OpVariable %_ptr_Function_uchar Function
-%317 = OpVariable %_ptr_Function_uchar Function
-%318 = OpVariable %_ptr_Function_uchar Function
-%319 = OpVariable %_ptr_Function_uchar Function
-%320 = OpVariable %_ptr_Function_uchar Function
-%321 = OpVariable %_ptr_Function_uchar Function
-%322 = OpVariable %_ptr_Function_uchar Function
-%323 = OpVariable %_ptr_Function_uchar Function
-%324 = OpVariable %_ptr_Function_uchar Function
-%325 = OpVariable %_ptr_Function_uchar Function
-%326 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%327 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%328 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%329 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%330 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%331 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%332 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%333 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%334 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%335 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%336 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%337 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%338 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%339 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%340 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%341 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%342 = OpVariable %_ptr_Function_uchar Function
-%343 = OpVariable %_ptr_Function_uchar Function
-%344 = OpVariable %_ptr_Function_uchar Function
-%345 = OpVariable %_ptr_Function_uchar Function
-%346 = OpVariable %_ptr_Function_uchar Function
-%347 = OpVariable %_ptr_Function_uchar Function
-%348 = OpVariable %_ptr_Function_uchar Function
-%349 = OpVariable %_ptr_Function_uchar Function
-%350 = OpVariable %_ptr_Function_uchar Function
-%351 = OpVariable %_ptr_Function_uchar Function
-%352 = OpVariable %_ptr_Function_uchar Function
-%353 = OpVariable %_ptr_Function_uchar Function
-%354 = OpVariable %_ptr_Function_uchar Function
-%355 = OpVariable %_ptr_Function_uchar Function
-%356 = OpVariable %_ptr_Function_uchar Function
-%357 = OpVariable %_ptr_Function_uchar Function
-%358 = OpVariable %_ptr_Function_uchar Function
-%359 = OpVariable %_ptr_Function_uchar Function
-%360 = OpVariable %_ptr_Function_uchar Function
-%361 = OpVariable %_ptr_Function_uchar Function
-%362 = OpVariable %_ptr_Function_uchar Function
-%363 = OpVariable %_ptr_Function_uchar Function
-%364 = OpVariable %_ptr_Function_uchar Function
-%365 = OpVariable %_ptr_Function_uchar Function
-%366 = OpVariable %_ptr_Function_uchar Function
-%367 = OpVariable %_ptr_Function_uchar Function
-%368 = OpVariable %_ptr_Function_uchar Function
-%369 = OpVariable %_ptr_Function_uchar Function
-%370 = OpVariable %_ptr_Function_uchar Function
-%371 = OpVariable %_ptr_Function_uchar Function
-%372 = OpVariable %_ptr_Function_uchar Function
-%373 = OpVariable %_ptr_Function_uchar Function
-%374 = OpVariable %_ptr_Function_uchar Function
-%375 = OpVariable %_ptr_Function_uchar Function
-%376 = OpVariable %_ptr_Function_uchar Function
-%377 = OpVariable %_ptr_Function_uchar Function
-%378 = OpVariable %_ptr_Function_uchar Function
-%379 = OpVariable %_ptr_Function_uchar Function
-%380 = OpVariable %_ptr_Function_uchar Function
-%381 = OpVariable %_ptr_Function_uchar Function
-%382 = OpVariable %_ptr_Function_uchar Function
-%383 = OpVariable %_ptr_Function_uchar Function
-%384 = OpVariable %_ptr_Function_uchar Function
-%385 = OpVariable %_ptr_Function_uchar Function
-%386 = OpVariable %_ptr_Function_uchar Function
-%387 = OpVariable %_ptr_Function_uchar Function
-%388 = OpVariable %_ptr_Function_uchar Function
-%389 = OpVariable %_ptr_Function_uchar Function
-%390 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%391 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%392 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%393 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%394 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%395 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%396 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%397 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%398 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%399 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%400 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%401 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%402 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%403 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%404 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%405 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%406 = OpVariable %_ptr_Function_uchar Function
-%407 = OpVariable %_ptr_Function_uchar Function
-%408 = OpVariable %_ptr_Function_uchar Function
-%409 = OpVariable %_ptr_Function_uchar Function
-%410 = OpVariable %_ptr_Function_uchar Function
-%411 = OpVariable %_ptr_Function_uchar Function
-%412 = OpVariable %_ptr_Function_uchar Function
-%413 = OpVariable %_ptr_Function_uchar Function
-%414 = OpVariable %_ptr_Function_uchar Function
-%415 = OpVariable %_ptr_Function_uchar Function
-%416 = OpVariable %_ptr_Function_uchar Function
-%417 = OpVariable %_ptr_Function_uchar Function
-%418 = OpVariable %_ptr_Function_uchar Function
-%419 = OpVariable %_ptr_Function_uchar Function
-%420 = OpVariable %_ptr_Function_uchar Function
-%421 = OpVariable %_ptr_Function_uchar Function
-%422 = OpVariable %_ptr_Function_uchar Function
-%423 = OpVariable %_ptr_Function_uchar Function
-%424 = OpVariable %_ptr_Function_uchar Function
-%425 = OpVariable %_ptr_Function_uchar Function
-%426 = OpVariable %_ptr_Function_uchar Function
-%427 = OpVariable %_ptr_Function_uchar Function
-%428 = OpVariable %_ptr_Function_uchar Function
-%429 = OpVariable %_ptr_Function_uchar Function
-%430 = OpVariable %_ptr_Function_uchar Function
-%431 = OpVariable %_ptr_Function_uchar Function
-%432 = OpVariable %_ptr_Function_uchar Function
-%433 = OpVariable %_ptr_Function_uchar Function
-%434 = OpVariable %_ptr_Function_uchar Function
-%435 = OpVariable %_ptr_Function_uchar Function
-%436 = OpVariable %_ptr_Function_uchar Function
-%437 = OpVariable %_ptr_Function_uchar Function
-%438 = OpVariable %_ptr_Function_uchar Function
-%439 = OpVariable %_ptr_Function_uchar Function
-%440 = OpVariable %_ptr_Function_uchar Function
-%441 = OpVariable %_ptr_Function_uchar Function
-%442 = OpVariable %_ptr_Function_uchar Function
-%443 = OpVariable %_ptr_Function_uchar Function
-%444 = OpVariable %_ptr_Function_uchar Function
-%445 = OpVariable %_ptr_Function_uchar Function
-%446 = OpVariable %_ptr_Function_uchar Function
-%447 = OpVariable %_ptr_Function_uchar Function
-%448 = OpVariable %_ptr_Function_uchar Function
-%449 = OpVariable %_ptr_Function_uchar Function
-%450 = OpVariable %_ptr_Function_uchar Function
-%451 = OpVariable %_ptr_Function_uchar Function
-%452 = OpVariable %_ptr_Function_uchar Function
-%453 = OpVariable %_ptr_Function_uchar Function
-%454 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%455 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%456 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%457 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%458 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%459 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%460 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%461 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%462 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%463 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%464 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%465 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%466 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%467 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%468 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%469 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%470 = OpVariable %_ptr_Function_uchar Function
-%471 = OpVariable %_ptr_Function_uchar Function
-%472 = OpVariable %_ptr_Function_uchar Function
-%473 = OpVariable %_ptr_Function_uchar Function
-%474 = OpVariable %_ptr_Function_uchar Function
-%475 = OpVariable %_ptr_Function_uchar Function
-%476 = OpVariable %_ptr_Function_uchar Function
-%477 = OpVariable %_ptr_Function_uchar Function
-%478 = OpVariable %_ptr_Function_uchar Function
-%479 = OpVariable %_ptr_Function_uchar Function
-%480 = OpVariable %_ptr_Function_uchar Function
-%481 = OpVariable %_ptr_Function_uchar Function
-%482 = OpVariable %_ptr_Function_uchar Function
-%483 = OpVariable %_ptr_Function_uchar Function
-%484 = OpVariable %_ptr_Function_uchar Function
-%485 = OpVariable %_ptr_Function_uchar Function
-%486 = OpVariable %_ptr_Function_uchar Function
-%487 = OpVariable %_ptr_Function_uchar Function
-%488 = OpVariable %_ptr_Function_uchar Function
-%489 = OpVariable %_ptr_Function_uchar Function
-%490 = OpVariable %_ptr_Function_uchar Function
-%491 = OpVariable %_ptr_Function_uchar Function
-%492 = OpVariable %_ptr_Function_uchar Function
-%493 = OpVariable %_ptr_Function_uchar Function
-%494 = OpVariable %_ptr_Function_uchar Function
-%495 = OpVariable %_ptr_Function_uchar Function
-%496 = OpVariable %_ptr_Function_uchar Function
-%497 = OpVariable %_ptr_Function_uchar Function
-%498 = OpVariable %_ptr_Function_uchar Function
-%499 = OpVariable %_ptr_Function_uchar Function
-%500 = OpVariable %_ptr_Function_uchar Function
-%501 = OpVariable %_ptr_Function_uchar Function
-%502 = OpVariable %_ptr_Function_uchar Function
-%503 = OpVariable %_ptr_Function_uchar Function
-%504 = OpVariable %_ptr_Function_uchar Function
-%505 = OpVariable %_ptr_Function_uchar Function
-%506 = OpVariable %_ptr_Function_uchar Function
-%507 = OpVariable %_ptr_Function_uchar Function
-%508 = OpVariable %_ptr_Function_uchar Function
-%509 = OpVariable %_ptr_Function_uchar Function
-%510 = OpVariable %_ptr_Function_uchar Function
-%511 = OpVariable %_ptr_Function_uchar Function
-%512 = OpVariable %_ptr_Function_uchar Function
-%513 = OpVariable %_ptr_Function_uchar Function
-%514 = OpVariable %_ptr_Function_uchar Function
-%515 = OpVariable %_ptr_Function_uchar Function
-%516 = OpVariable %_ptr_Function_uchar Function
-%517 = OpVariable %_ptr_Function_uchar Function
-%518 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%519 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%520 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%521 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%522 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%523 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%524 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%525 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%526 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%527 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%528 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%529 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%530 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%531 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%532 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%533 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%534 = OpVariable %_ptr_Function_uchar Function
-%535 = OpVariable %_ptr_Function_uchar Function
-%536 = OpVariable %_ptr_Function_uchar Function
-%537 = OpVariable %_ptr_Function_uchar Function
-%538 = OpVariable %_ptr_Function_uchar Function
-%539 = OpVariable %_ptr_Function_uchar Function
-%540 = OpVariable %_ptr_Function_uchar Function
-%541 = OpVariable %_ptr_Function_uchar Function
-%542 = OpVariable %_ptr_Function_uchar Function
-%543 = OpVariable %_ptr_Function_uchar Function
-%544 = OpVariable %_ptr_Function_uchar Function
-%545 = OpVariable %_ptr_Function_uchar Function
-%546 = OpVariable %_ptr_Function_uchar Function
-%547 = OpVariable %_ptr_Function_uchar Function
-%548 = OpVariable %_ptr_Function_uchar Function
-%549 = OpVariable %_ptr_Function_uchar Function
-%550 = OpVariable %_ptr_Function_uchar Function
-%551 = OpVariable %_ptr_Function_uchar Function
-%552 = OpVariable %_ptr_Function_uchar Function
-%553 = OpVariable %_ptr_Function_uchar Function
-%554 = OpVariable %_ptr_Function_uchar Function
-%555 = OpVariable %_ptr_Function_uchar Function
-%556 = OpVariable %_ptr_Function_uchar Function
-%557 = OpVariable %_ptr_Function_uchar Function
-%558 = OpVariable %_ptr_Function_uchar Function
-%559 = OpVariable %_ptr_Function_uchar Function
-%560 = OpVariable %_ptr_Function_uchar Function
-%561 = OpVariable %_ptr_Function_uchar Function
-%562 = OpVariable %_ptr_Function_uchar Function
-%563 = OpVariable %_ptr_Function_uchar Function
-%564 = OpVariable %_ptr_Function_uchar Function
-%565 = OpVariable %_ptr_Function_uchar Function
-%566 = OpVariable %_ptr_Function_uchar Function
-%567 = OpVariable %_ptr_Function_uchar Function
-%568 = OpVariable %_ptr_Function_uchar Function
-%569 = OpVariable %_ptr_Function_uchar Function
-%570 = OpVariable %_ptr_Function_uchar Function
-%571 = OpVariable %_ptr_Function_uchar Function
-%572 = OpVariable %_ptr_Function_uchar Function
-%573 = OpVariable %_ptr_Function_uchar Function
-%574 = OpVariable %_ptr_Function_uchar Function
-%575 = OpVariable %_ptr_Function_uchar Function
-%576 = OpVariable %_ptr_Function_uchar Function
-%577 = OpVariable %_ptr_Function_uchar Function
-%578 = OpVariable %_ptr_Function_uchar Function
-%579 = OpVariable %_ptr_Function_uchar Function
-%580 = OpVariable %_ptr_Function_uchar Function
-%581 = OpVariable %_ptr_Function_uchar Function
-%582 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%583 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%584 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%585 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%586 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%587 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%588 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%589 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%590 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%591 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%592 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%593 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%594 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%595 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%596 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%597 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%598 = OpVariable %_ptr_Function_uchar Function
-%599 = OpVariable %_ptr_Function_uchar Function
-%600 = OpVariable %_ptr_Function_uchar Function
-%601 = OpVariable %_ptr_Function_uchar Function
-%602 = OpVariable %_ptr_Function_uchar Function
-%603 = OpVariable %_ptr_Function_uchar Function
-%604 = OpVariable %_ptr_Function_uchar Function
-%605 = OpVariable %_ptr_Function_uchar Function
-%606 = OpVariable %_ptr_Function_uchar Function
-%607 = OpVariable %_ptr_Function_uchar Function
-%608 = OpVariable %_ptr_Function_uchar Function
-%609 = OpVariable %_ptr_Function_uchar Function
-%610 = OpVariable %_ptr_Function_uchar Function
-%611 = OpVariable %_ptr_Function_uchar Function
-%612 = OpVariable %_ptr_Function_uchar Function
-%613 = OpVariable %_ptr_Function_uchar Function
-%614 = OpVariable %_ptr_Function_uchar Function
-%615 = OpVariable %_ptr_Function_uchar Function
-%616 = OpVariable %_ptr_Function_uchar Function
-%617 = OpVariable %_ptr_Function_uchar Function
-%618 = OpVariable %_ptr_Function_uchar Function
-%619 = OpVariable %_ptr_Function_uchar Function
-%620 = OpVariable %_ptr_Function_uchar Function
-%621 = OpVariable %_ptr_Function_uchar Function
-%622 = OpVariable %_ptr_Function_uchar Function
-%623 = OpVariable %_ptr_Function_uchar Function
-%624 = OpVariable %_ptr_Function_uchar Function
-%625 = OpVariable %_ptr_Function_uchar Function
-%626 = OpVariable %_ptr_Function_uchar Function
-%627 = OpVariable %_ptr_Function_uchar Function
-%628 = OpVariable %_ptr_Function_uchar Function
-%629 = OpVariable %_ptr_Function_uchar Function
-%630 = OpVariable %_ptr_Function_uchar Function
-%631 = OpVariable %_ptr_Function_uchar Function
-%632 = OpVariable %_ptr_Function_uchar Function
-%633 = OpVariable %_ptr_Function_uchar Function
-%634 = OpVariable %_ptr_Function_uchar Function
-%635 = OpVariable %_ptr_Function_uchar Function
-%636 = OpVariable %_ptr_Function_uchar Function
-%637 = OpVariable %_ptr_Function_uchar Function
-%638 = OpVariable %_ptr_Function_uchar Function
-%639 = OpVariable %_ptr_Function_uchar Function
-%640 = OpVariable %_ptr_Function_uchar Function
-%641 = OpVariable %_ptr_Function_uchar Function
-%642 = OpVariable %_ptr_Function_uchar Function
-%643 = OpVariable %_ptr_Function_uchar Function
-%644 = OpVariable %_ptr_Function_uchar Function
-%645 = OpVariable %_ptr_Function_uchar Function
-%646 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%647 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%648 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%649 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%650 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%651 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%652 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%653 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%654 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%655 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%656 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%657 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%658 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%659 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%660 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%661 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%662 = OpVariable %_ptr_Function_uchar Function
-%663 = OpVariable %_ptr_Function_uchar Function
-%664 = OpVariable %_ptr_Function_uchar Function
-%665 = OpVariable %_ptr_Function_uchar Function
-%666 = OpVariable %_ptr_Function_uchar Function
-%667 = OpVariable %_ptr_Function_uchar Function
-%668 = OpVariable %_ptr_Function_uchar Function
-%669 = OpVariable %_ptr_Function_uchar Function
-%670 = OpVariable %_ptr_Function_uchar Function
-%671 = OpVariable %_ptr_Function_uchar Function
-%672 = OpVariable %_ptr_Function_uchar Function
-%673 = OpVariable %_ptr_Function_uchar Function
-%674 = OpVariable %_ptr_Function_uchar Function
-%675 = OpVariable %_ptr_Function_uchar Function
-%676 = OpVariable %_ptr_Function_uchar Function
-%677 = OpVariable %_ptr_Function_uchar Function
-%678 = OpVariable %_ptr_Function_uchar Function
-%679 = OpVariable %_ptr_Function_uchar Function
-%680 = OpVariable %_ptr_Function_uchar Function
-%681 = OpVariable %_ptr_Function_uchar Function
-%682 = OpVariable %_ptr_Function_uchar Function
-%683 = OpVariable %_ptr_Function_uchar Function
-%684 = OpVariable %_ptr_Function_uchar Function
-%685 = OpVariable %_ptr_Function_uchar Function
-%686 = OpVariable %_ptr_Function_uchar Function
-%687 = OpVariable %_ptr_Function_uchar Function
-%688 = OpVariable %_ptr_Function_uchar Function
-%689 = OpVariable %_ptr_Function_uchar Function
-%690 = OpVariable %_ptr_Function_uchar Function
-%691 = OpVariable %_ptr_Function_uchar Function
-%692 = OpVariable %_ptr_Function_uchar Function
-%693 = OpVariable %_ptr_Function_uchar Function
-%694 = OpVariable %_ptr_Function_uchar Function
-%695 = OpVariable %_ptr_Function_uchar Function
-%696 = OpVariable %_ptr_Function_uchar Function
-%697 = OpVariable %_ptr_Function_uchar Function
-%698 = OpVariable %_ptr_Function_uchar Function
-%699 = OpVariable %_ptr_Function_uchar Function
-%700 = OpVariable %_ptr_Function_uchar Function
-%701 = OpVariable %_ptr_Function_uchar Function
-%702 = OpVariable %_ptr_Function_uchar Function
-%703 = OpVariable %_ptr_Function_uchar Function
-%704 = OpVariable %_ptr_Function_uchar Function
-%705 = OpVariable %_ptr_Function_uchar Function
-%706 = OpVariable %_ptr_Function_uchar Function
-%707 = OpVariable %_ptr_Function_uchar Function
-%708 = OpVariable %_ptr_Function_uchar Function
-%709 = OpVariable %_ptr_Function_uchar Function
-%710 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%711 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%712 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%713 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%714 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%715 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%716 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%717 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%718 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%719 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%720 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%721 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%722 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%723 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%724 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%725 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%726 = OpVariable %_ptr_Function_uchar Function
-%727 = OpVariable %_ptr_Function_uchar Function
-%728 = OpVariable %_ptr_Function_uchar Function
-%729 = OpVariable %_ptr_Function_uchar Function
-%730 = OpVariable %_ptr_Function_uchar Function
-%731 = OpVariable %_ptr_Function_uchar Function
-%732 = OpVariable %_ptr_Function_uchar Function
-%733 = OpVariable %_ptr_Function_uchar Function
-%734 = OpVariable %_ptr_Function_uchar Function
-%735 = OpVariable %_ptr_Function_uchar Function
-%736 = OpVariable %_ptr_Function_uchar Function
-%737 = OpVariable %_ptr_Function_uchar Function
-%738 = OpVariable %_ptr_Function_uchar Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_bool Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_bool Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_bool Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_bool Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_bool Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_bool Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_bool Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_bool Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+OpStore %143 %10
+OpStore %145 %11
+%324 = OpLoad %_arr_uchar_uint_16 %145
+%325 = OpCompositeExtract %uchar %324 0
+OpStore %147 %325
+OpBranch %13
+%13 = OpLabel
+%326 = OpLoad %uchar %147
+%327 = OpSConvert %ulong %326
+OpStore %163 %327
+OpBranch %15
+%15 = OpLabel
+%328 = OpLoad %ulong %143
+OpStore %172 %328
+OpStore %173 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%330 = OpLoad %ulong %173
+%332 = OpULessThan %bool %330 %ulong_8
+OpStore %165 %332
+%333 = OpLoad %bool %165
+OpLoopMerge %18 %140 None
+OpBranchConditional %333 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%334 = OpLoad %_arr_uchar_uint_16 %145
+%335 = OpCompositeExtract %uchar %334 1
+OpStore %148 %335
+OpBranch %20
+%20 = OpLabel
+%336 = OpLoad %uchar %148
+%337 = OpSConvert %ulong %336
+OpStore %174 %337
+OpBranch %22
+%22 = OpLabel
+%338 = OpLoad %ulong %172
+OpStore %182 %338
+OpStore %183 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%339 = OpLoad %ulong %183
+%340 = OpULessThan %bool %339 %ulong_8
+OpStore %175 %340
+%341 = OpLoad %bool %175
+OpLoopMerge %25 %139 None
+OpBranchConditional %341 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%342 = OpLoad %_arr_uchar_uint_16 %145
+%343 = OpCompositeExtract %uchar %342 2
+OpStore %149 %343
+OpBranch %27
+%27 = OpLabel
+%344 = OpLoad %uchar %149
+%345 = OpSConvert %ulong %344
+OpStore %184 %345
+OpBranch %29
+%29 = OpLabel
+%346 = OpLoad %ulong %182
+OpStore %192 %346
+OpStore %193 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%347 = OpLoad %ulong %193
+%348 = OpULessThan %bool %347 %ulong_8
+OpStore %185 %348
+%349 = OpLoad %bool %185
+OpLoopMerge %32 %138 None
+OpBranchConditional %349 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%350 = OpLoad %_arr_uchar_uint_16 %145
+%351 = OpCompositeExtract %uchar %350 3
+OpStore %150 %351
+OpBranch %34
+%34 = OpLabel
+%352 = OpLoad %uchar %150
+%353 = OpSConvert %ulong %352
+OpStore %194 %353
+OpBranch %36
+%36 = OpLabel
+%354 = OpLoad %ulong %192
+OpStore %202 %354
+OpStore %203 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%355 = OpLoad %ulong %203
+%356 = OpULessThan %bool %355 %ulong_8
+OpStore %195 %356
+%357 = OpLoad %bool %195
+OpLoopMerge %39 %137 None
+OpBranchConditional %357 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%358 = OpLoad %_arr_uchar_uint_16 %145
+%359 = OpCompositeExtract %uchar %358 4
+OpStore %151 %359
+OpBranch %41
+%41 = OpLabel
+%360 = OpLoad %uchar %151
+%361 = OpSConvert %ulong %360
+OpStore %204 %361
+OpBranch %43
+%43 = OpLabel
+%362 = OpLoad %ulong %202
+OpStore %212 %362
+OpStore %213 %ulong_0
+OpBranch %44
+%44 = OpLabel
+%363 = OpLoad %ulong %213
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %205 %364
+%365 = OpLoad %bool %205
+OpLoopMerge %46 %136 None
+OpBranchConditional %365 %45 %46
+%46 = OpLabel
+OpBranch %47
+%47 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%366 = OpLoad %_arr_uchar_uint_16 %145
+%367 = OpCompositeExtract %uchar %366 5
+OpStore %152 %367
+OpBranch %48
+%48 = OpLabel
+%368 = OpLoad %uchar %152
+%369 = OpSConvert %ulong %368
+OpStore %214 %369
+OpBranch %50
+%50 = OpLabel
+%370 = OpLoad %ulong %212
+OpStore %222 %370
+OpStore %223 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%371 = OpLoad %ulong %223
+%372 = OpULessThan %bool %371 %ulong_8
+OpStore %215 %372
+%373 = OpLoad %bool %215
+OpLoopMerge %53 %135 None
+OpBranchConditional %373 %52 %53
+%53 = OpLabel
+OpBranch %54
+%54 = OpLabel
+OpBranch %49
+%49 = OpLabel
+%374 = OpLoad %_arr_uchar_uint_16 %145
+%375 = OpCompositeExtract %uchar %374 6
+OpStore %153 %375
+OpBranch %55
+%55 = OpLabel
+%376 = OpLoad %uchar %153
+%377 = OpSConvert %ulong %376
+OpStore %224 %377
+OpBranch %57
+%57 = OpLabel
+%378 = OpLoad %ulong %222
+OpStore %232 %378
+OpStore %233 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%379 = OpLoad %ulong %233
+%380 = OpULessThan %bool %379 %ulong_8
+OpStore %225 %380
+%381 = OpLoad %bool %225
+OpLoopMerge %60 %134 None
+OpBranchConditional %381 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %56
+%56 = OpLabel
+%382 = OpLoad %_arr_uchar_uint_16 %145
+%383 = OpCompositeExtract %uchar %382 7
+OpStore %154 %383
+OpBranch %62
+%62 = OpLabel
+%384 = OpLoad %uchar %154
+%385 = OpSConvert %ulong %384
+OpStore %234 %385
+OpBranch %64
+%64 = OpLabel
+%386 = OpLoad %ulong %232
+OpStore %242 %386
+OpStore %243 %ulong_0
+OpBranch %65
+%65 = OpLabel
+%387 = OpLoad %ulong %243
+%388 = OpULessThan %bool %387 %ulong_8
+OpStore %235 %388
+%389 = OpLoad %bool %235
+OpLoopMerge %67 %133 None
+OpBranchConditional %389 %66 %67
+%67 = OpLabel
+OpBranch %68
+%68 = OpLabel
+OpBranch %63
+%63 = OpLabel
+%390 = OpLoad %_arr_uchar_uint_16 %145
+%391 = OpCompositeExtract %uchar %390 8
+OpStore %155 %391
+OpBranch %69
+%69 = OpLabel
+%392 = OpLoad %uchar %155
+%393 = OpSConvert %ulong %392
+OpStore %244 %393
+OpBranch %71
+%71 = OpLabel
+%394 = OpLoad %ulong %242
+OpStore %252 %394
+OpStore %253 %ulong_0
+OpBranch %72
+%72 = OpLabel
+%395 = OpLoad %ulong %253
+%396 = OpULessThan %bool %395 %ulong_8
+OpStore %245 %396
+%397 = OpLoad %bool %245
+OpLoopMerge %74 %132 None
+OpBranchConditional %397 %73 %74
+%74 = OpLabel
+OpBranch %75
+%75 = OpLabel
+OpBranch %70
+%70 = OpLabel
+%398 = OpLoad %_arr_uchar_uint_16 %145
+%399 = OpCompositeExtract %uchar %398 9
+OpStore %156 %399
+OpBranch %76
+%76 = OpLabel
+%400 = OpLoad %uchar %156
+%401 = OpSConvert %ulong %400
+OpStore %254 %401
+OpBranch %78
+%78 = OpLabel
+%402 = OpLoad %ulong %252
+OpStore %262 %402
+OpStore %263 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%403 = OpLoad %ulong %263
+%404 = OpULessThan %bool %403 %ulong_8
+OpStore %255 %404
+%405 = OpLoad %bool %255
+OpLoopMerge %81 %131 None
+OpBranchConditional %405 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%406 = OpLoad %_arr_uchar_uint_16 %145
+%407 = OpCompositeExtract %uchar %406 10
+OpStore %157 %407
+OpBranch %83
+%83 = OpLabel
+%408 = OpLoad %uchar %157
+%409 = OpSConvert %ulong %408
+OpStore %264 %409
+OpBranch %85
+%85 = OpLabel
+%410 = OpLoad %ulong %262
+OpStore %272 %410
+OpStore %273 %ulong_0
+OpBranch %86
+%86 = OpLabel
+%411 = OpLoad %ulong %273
+%412 = OpULessThan %bool %411 %ulong_8
+OpStore %265 %412
+%413 = OpLoad %bool %265
+OpLoopMerge %88 %130 None
+OpBranchConditional %413 %87 %88
+%88 = OpLabel
+OpBranch %89
+%89 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%414 = OpLoad %_arr_uchar_uint_16 %145
+%415 = OpCompositeExtract %uchar %414 11
+OpStore %158 %415
+OpBranch %90
+%90 = OpLabel
+%416 = OpLoad %uchar %158
+%417 = OpSConvert %ulong %416
+OpStore %274 %417
+OpBranch %92
+%92 = OpLabel
+%418 = OpLoad %ulong %272
+OpStore %282 %418
+OpStore %283 %ulong_0
+OpBranch %93
+%93 = OpLabel
+%419 = OpLoad %ulong %283
+%420 = OpULessThan %bool %419 %ulong_8
+OpStore %275 %420
+%421 = OpLoad %bool %275
+OpLoopMerge %95 %129 None
+OpBranchConditional %421 %94 %95
+%95 = OpLabel
+OpBranch %96
+%96 = OpLabel
+OpBranch %91
+%91 = OpLabel
+%422 = OpLoad %_arr_uchar_uint_16 %145
+%423 = OpCompositeExtract %uchar %422 12
+OpStore %159 %423
+OpBranch %97
+%97 = OpLabel
+%424 = OpLoad %uchar %159
+%425 = OpSConvert %ulong %424
+OpStore %284 %425
+OpBranch %99
+%99 = OpLabel
+%426 = OpLoad %ulong %282
+OpStore %292 %426
+OpStore %293 %ulong_0
+OpBranch %100
+%100 = OpLabel
+%427 = OpLoad %ulong %293
+%428 = OpULessThan %bool %427 %ulong_8
+OpStore %285 %428
+%429 = OpLoad %bool %285
+OpLoopMerge %102 %128 None
+OpBranchConditional %429 %101 %102
+%102 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%430 = OpLoad %_arr_uchar_uint_16 %145
+%431 = OpCompositeExtract %uchar %430 13
+OpStore %160 %431
+OpBranch %104
+%104 = OpLabel
+%432 = OpLoad %uchar %160
+%433 = OpSConvert %ulong %432
+OpStore %294 %433
+OpBranch %106
+%106 = OpLabel
+%434 = OpLoad %ulong %292
+OpStore %302 %434
+OpStore %303 %ulong_0
+OpBranch %107
+%107 = OpLabel
+%435 = OpLoad %ulong %303
+%436 = OpULessThan %bool %435 %ulong_8
+OpStore %295 %436
+%437 = OpLoad %bool %295
+OpLoopMerge %109 %127 None
+OpBranchConditional %437 %108 %109
+%109 = OpLabel
+OpBranch %110
+%110 = OpLabel
+OpBranch %105
+%105 = OpLabel
+%438 = OpLoad %_arr_uchar_uint_16 %145
+%439 = OpCompositeExtract %uchar %438 14
+OpStore %161 %439
+OpBranch %111
+%111 = OpLabel
+%440 = OpLoad %uchar %161
+%441 = OpSConvert %ulong %440
+OpStore %304 %441
+OpBranch %113
+%113 = OpLabel
+%442 = OpLoad %ulong %302
+OpStore %312 %442
+OpStore %313 %ulong_0
+OpBranch %114
+%114 = OpLabel
+%443 = OpLoad %ulong %313
+%444 = OpULessThan %bool %443 %ulong_8
+OpStore %305 %444
+%445 = OpLoad %bool %305
+OpLoopMerge %116 %126 None
+OpBranchConditional %445 %115 %116
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
+OpBranch %112
+%112 = OpLabel
+%446 = OpLoad %_arr_uchar_uint_16 %145
+%447 = OpCompositeExtract %uchar %446 15
+OpStore %162 %447
+OpBranch %118
+%118 = OpLabel
+%448 = OpLoad %uchar %162
+%449 = OpSConvert %ulong %448
+OpStore %314 %449
+OpBranch %120
+%120 = OpLabel
+%450 = OpLoad %ulong %312
+OpStore %322 %450
+OpStore %323 %ulong_0
+OpBranch %121
+%121 = OpLabel
+%451 = OpLoad %ulong %323
+%452 = OpULessThan %bool %451 %ulong_8
+OpStore %315 %452
+%453 = OpLoad %bool %315
+OpLoopMerge %123 %125 None
+OpBranchConditional %453 %122 %123
+%123 = OpLabel
+OpBranch %124
+%124 = OpLabel
+OpBranch %119
+%119 = OpLabel
+%454 = OpLoad %ulong %322
+OpReturnValue %454
+%122 = OpLabel
+%455 = OpLoad %ulong %323
+%456 = OpIMul %ulong %455 %ulong_8
+OpStore %316 %456
+%457 = OpLoad %ulong %314
+%458 = OpLoad %ulong %316
+%459 = OpShiftRightLogical %ulong %457 %458
+OpStore %317 %459
+%460 = OpLoad %ulong %317
+%462 = OpBitwiseAnd %ulong %460 %ulong_255
+OpStore %318 %462
+%463 = OpLoad %ulong %322
+%464 = OpLoad %ulong %318
+%465 = OpBitwiseXor %ulong %463 %464
+OpStore %319 %465
+%466 = OpLoad %ulong %319
+%468 = OpIMul %ulong %466 %ulong_1099511628211
+OpStore %320 %468
+%469 = OpLoad %ulong %323
+%471 = OpIAdd %ulong %469 %ulong_1
+OpStore %321 %471
+%472 = OpLoad %ulong %320
+OpStore %322 %472
+%473 = OpLoad %ulong %321
+OpStore %323 %473
+OpBranch %125
+%115 = OpLabel
+%474 = OpLoad %ulong %313
+%475 = OpIMul %ulong %474 %ulong_8
+OpStore %306 %475
+%476 = OpLoad %ulong %304
+%477 = OpLoad %ulong %306
+%478 = OpShiftRightLogical %ulong %476 %477
+OpStore %307 %478
+%479 = OpLoad %ulong %307
+%480 = OpBitwiseAnd %ulong %479 %ulong_255
+OpStore %308 %480
+%481 = OpLoad %ulong %312
+%482 = OpLoad %ulong %308
+%483 = OpBitwiseXor %ulong %481 %482
+OpStore %309 %483
+%484 = OpLoad %ulong %309
+%485 = OpIMul %ulong %484 %ulong_1099511628211
+OpStore %310 %485
+%486 = OpLoad %ulong %313
+%487 = OpIAdd %ulong %486 %ulong_1
+OpStore %311 %487
+%488 = OpLoad %ulong %310
+OpStore %312 %488
+%489 = OpLoad %ulong %311
+OpStore %313 %489
+OpBranch %126
+%108 = OpLabel
+%490 = OpLoad %ulong %303
+%491 = OpIMul %ulong %490 %ulong_8
+OpStore %296 %491
+%492 = OpLoad %ulong %294
+%493 = OpLoad %ulong %296
+%494 = OpShiftRightLogical %ulong %492 %493
+OpStore %297 %494
+%495 = OpLoad %ulong %297
+%496 = OpBitwiseAnd %ulong %495 %ulong_255
+OpStore %298 %496
+%497 = OpLoad %ulong %302
+%498 = OpLoad %ulong %298
+%499 = OpBitwiseXor %ulong %497 %498
+OpStore %299 %499
+%500 = OpLoad %ulong %299
+%501 = OpIMul %ulong %500 %ulong_1099511628211
+OpStore %300 %501
+%502 = OpLoad %ulong %303
+%503 = OpIAdd %ulong %502 %ulong_1
+OpStore %301 %503
+%504 = OpLoad %ulong %300
+OpStore %302 %504
+%505 = OpLoad %ulong %301
+OpStore %303 %505
+OpBranch %127
+%101 = OpLabel
+%506 = OpLoad %ulong %293
+%507 = OpIMul %ulong %506 %ulong_8
+OpStore %286 %507
+%508 = OpLoad %ulong %284
+%509 = OpLoad %ulong %286
+%510 = OpShiftRightLogical %ulong %508 %509
+OpStore %287 %510
+%511 = OpLoad %ulong %287
+%512 = OpBitwiseAnd %ulong %511 %ulong_255
+OpStore %288 %512
+%513 = OpLoad %ulong %292
+%514 = OpLoad %ulong %288
+%515 = OpBitwiseXor %ulong %513 %514
+OpStore %289 %515
+%516 = OpLoad %ulong %289
+%517 = OpIMul %ulong %516 %ulong_1099511628211
+OpStore %290 %517
+%518 = OpLoad %ulong %293
+%519 = OpIAdd %ulong %518 %ulong_1
+OpStore %291 %519
+%520 = OpLoad %ulong %290
+OpStore %292 %520
+%521 = OpLoad %ulong %291
+OpStore %293 %521
+OpBranch %128
+%94 = OpLabel
+%522 = OpLoad %ulong %283
+%523 = OpIMul %ulong %522 %ulong_8
+OpStore %276 %523
+%524 = OpLoad %ulong %274
+%525 = OpLoad %ulong %276
+%526 = OpShiftRightLogical %ulong %524 %525
+OpStore %277 %526
+%527 = OpLoad %ulong %277
+%528 = OpBitwiseAnd %ulong %527 %ulong_255
+OpStore %278 %528
+%529 = OpLoad %ulong %282
+%530 = OpLoad %ulong %278
+%531 = OpBitwiseXor %ulong %529 %530
+OpStore %279 %531
+%532 = OpLoad %ulong %279
+%533 = OpIMul %ulong %532 %ulong_1099511628211
+OpStore %280 %533
+%534 = OpLoad %ulong %283
+%535 = OpIAdd %ulong %534 %ulong_1
+OpStore %281 %535
+%536 = OpLoad %ulong %280
+OpStore %282 %536
+%537 = OpLoad %ulong %281
+OpStore %283 %537
+OpBranch %129
+%87 = OpLabel
+%538 = OpLoad %ulong %273
+%539 = OpIMul %ulong %538 %ulong_8
+OpStore %266 %539
+%540 = OpLoad %ulong %264
+%541 = OpLoad %ulong %266
+%542 = OpShiftRightLogical %ulong %540 %541
+OpStore %267 %542
+%543 = OpLoad %ulong %267
+%544 = OpBitwiseAnd %ulong %543 %ulong_255
+OpStore %268 %544
+%545 = OpLoad %ulong %272
+%546 = OpLoad %ulong %268
+%547 = OpBitwiseXor %ulong %545 %546
+OpStore %269 %547
+%548 = OpLoad %ulong %269
+%549 = OpIMul %ulong %548 %ulong_1099511628211
+OpStore %270 %549
+%550 = OpLoad %ulong %273
+%551 = OpIAdd %ulong %550 %ulong_1
+OpStore %271 %551
+%552 = OpLoad %ulong %270
+OpStore %272 %552
+%553 = OpLoad %ulong %271
+OpStore %273 %553
+OpBranch %130
+%80 = OpLabel
+%554 = OpLoad %ulong %263
+%555 = OpIMul %ulong %554 %ulong_8
+OpStore %256 %555
+%556 = OpLoad %ulong %254
+%557 = OpLoad %ulong %256
+%558 = OpShiftRightLogical %ulong %556 %557
+OpStore %257 %558
+%559 = OpLoad %ulong %257
+%560 = OpBitwiseAnd %ulong %559 %ulong_255
+OpStore %258 %560
+%561 = OpLoad %ulong %262
+%562 = OpLoad %ulong %258
+%563 = OpBitwiseXor %ulong %561 %562
+OpStore %259 %563
+%564 = OpLoad %ulong %259
+%565 = OpIMul %ulong %564 %ulong_1099511628211
+OpStore %260 %565
+%566 = OpLoad %ulong %263
+%567 = OpIAdd %ulong %566 %ulong_1
+OpStore %261 %567
+%568 = OpLoad %ulong %260
+OpStore %262 %568
+%569 = OpLoad %ulong %261
+OpStore %263 %569
+OpBranch %131
+%73 = OpLabel
+%570 = OpLoad %ulong %253
+%571 = OpIMul %ulong %570 %ulong_8
+OpStore %246 %571
+%572 = OpLoad %ulong %244
+%573 = OpLoad %ulong %246
+%574 = OpShiftRightLogical %ulong %572 %573
+OpStore %247 %574
+%575 = OpLoad %ulong %247
+%576 = OpBitwiseAnd %ulong %575 %ulong_255
+OpStore %248 %576
+%577 = OpLoad %ulong %252
+%578 = OpLoad %ulong %248
+%579 = OpBitwiseXor %ulong %577 %578
+OpStore %249 %579
+%580 = OpLoad %ulong %249
+%581 = OpIMul %ulong %580 %ulong_1099511628211
+OpStore %250 %581
+%582 = OpLoad %ulong %253
+%583 = OpIAdd %ulong %582 %ulong_1
+OpStore %251 %583
+%584 = OpLoad %ulong %250
+OpStore %252 %584
+%585 = OpLoad %ulong %251
+OpStore %253 %585
+OpBranch %132
+%66 = OpLabel
+%586 = OpLoad %ulong %243
+%587 = OpIMul %ulong %586 %ulong_8
+OpStore %236 %587
+%588 = OpLoad %ulong %234
+%589 = OpLoad %ulong %236
+%590 = OpShiftRightLogical %ulong %588 %589
+OpStore %237 %590
+%591 = OpLoad %ulong %237
+%592 = OpBitwiseAnd %ulong %591 %ulong_255
+OpStore %238 %592
+%593 = OpLoad %ulong %242
+%594 = OpLoad %ulong %238
+%595 = OpBitwiseXor %ulong %593 %594
+OpStore %239 %595
+%596 = OpLoad %ulong %239
+%597 = OpIMul %ulong %596 %ulong_1099511628211
+OpStore %240 %597
+%598 = OpLoad %ulong %243
+%599 = OpIAdd %ulong %598 %ulong_1
+OpStore %241 %599
+%600 = OpLoad %ulong %240
+OpStore %242 %600
+%601 = OpLoad %ulong %241
+OpStore %243 %601
+OpBranch %133
+%59 = OpLabel
+%602 = OpLoad %ulong %233
+%603 = OpIMul %ulong %602 %ulong_8
+OpStore %226 %603
+%604 = OpLoad %ulong %224
+%605 = OpLoad %ulong %226
+%606 = OpShiftRightLogical %ulong %604 %605
+OpStore %227 %606
+%607 = OpLoad %ulong %227
+%608 = OpBitwiseAnd %ulong %607 %ulong_255
+OpStore %228 %608
+%609 = OpLoad %ulong %232
+%610 = OpLoad %ulong %228
+%611 = OpBitwiseXor %ulong %609 %610
+OpStore %229 %611
+%612 = OpLoad %ulong %229
+%613 = OpIMul %ulong %612 %ulong_1099511628211
+OpStore %230 %613
+%614 = OpLoad %ulong %233
+%615 = OpIAdd %ulong %614 %ulong_1
+OpStore %231 %615
+%616 = OpLoad %ulong %230
+OpStore %232 %616
+%617 = OpLoad %ulong %231
+OpStore %233 %617
+OpBranch %134
+%52 = OpLabel
+%618 = OpLoad %ulong %223
+%619 = OpIMul %ulong %618 %ulong_8
+OpStore %216 %619
+%620 = OpLoad %ulong %214
+%621 = OpLoad %ulong %216
+%622 = OpShiftRightLogical %ulong %620 %621
+OpStore %217 %622
+%623 = OpLoad %ulong %217
+%624 = OpBitwiseAnd %ulong %623 %ulong_255
+OpStore %218 %624
+%625 = OpLoad %ulong %222
+%626 = OpLoad %ulong %218
+%627 = OpBitwiseXor %ulong %625 %626
+OpStore %219 %627
+%628 = OpLoad %ulong %219
+%629 = OpIMul %ulong %628 %ulong_1099511628211
+OpStore %220 %629
+%630 = OpLoad %ulong %223
+%631 = OpIAdd %ulong %630 %ulong_1
+OpStore %221 %631
+%632 = OpLoad %ulong %220
+OpStore %222 %632
+%633 = OpLoad %ulong %221
+OpStore %223 %633
+OpBranch %135
+%45 = OpLabel
+%634 = OpLoad %ulong %213
+%635 = OpIMul %ulong %634 %ulong_8
+OpStore %206 %635
+%636 = OpLoad %ulong %204
+%637 = OpLoad %ulong %206
+%638 = OpShiftRightLogical %ulong %636 %637
+OpStore %207 %638
+%639 = OpLoad %ulong %207
+%640 = OpBitwiseAnd %ulong %639 %ulong_255
+OpStore %208 %640
+%641 = OpLoad %ulong %212
+%642 = OpLoad %ulong %208
+%643 = OpBitwiseXor %ulong %641 %642
+OpStore %209 %643
+%644 = OpLoad %ulong %209
+%645 = OpIMul %ulong %644 %ulong_1099511628211
+OpStore %210 %645
+%646 = OpLoad %ulong %213
+%647 = OpIAdd %ulong %646 %ulong_1
+OpStore %211 %647
+%648 = OpLoad %ulong %210
+OpStore %212 %648
+%649 = OpLoad %ulong %211
+OpStore %213 %649
+OpBranch %136
+%38 = OpLabel
+%650 = OpLoad %ulong %203
+%651 = OpIMul %ulong %650 %ulong_8
+OpStore %196 %651
+%652 = OpLoad %ulong %194
+%653 = OpLoad %ulong %196
+%654 = OpShiftRightLogical %ulong %652 %653
+OpStore %197 %654
+%655 = OpLoad %ulong %197
+%656 = OpBitwiseAnd %ulong %655 %ulong_255
+OpStore %198 %656
+%657 = OpLoad %ulong %202
+%658 = OpLoad %ulong %198
+%659 = OpBitwiseXor %ulong %657 %658
+OpStore %199 %659
+%660 = OpLoad %ulong %199
+%661 = OpIMul %ulong %660 %ulong_1099511628211
+OpStore %200 %661
+%662 = OpLoad %ulong %203
+%663 = OpIAdd %ulong %662 %ulong_1
+OpStore %201 %663
+%664 = OpLoad %ulong %200
+OpStore %202 %664
+%665 = OpLoad %ulong %201
+OpStore %203 %665
+OpBranch %137
+%31 = OpLabel
+%666 = OpLoad %ulong %193
+%667 = OpIMul %ulong %666 %ulong_8
+OpStore %186 %667
+%668 = OpLoad %ulong %184
+%669 = OpLoad %ulong %186
+%670 = OpShiftRightLogical %ulong %668 %669
+OpStore %187 %670
+%671 = OpLoad %ulong %187
+%672 = OpBitwiseAnd %ulong %671 %ulong_255
+OpStore %188 %672
+%673 = OpLoad %ulong %192
+%674 = OpLoad %ulong %188
+%675 = OpBitwiseXor %ulong %673 %674
+OpStore %189 %675
+%676 = OpLoad %ulong %189
+%677 = OpIMul %ulong %676 %ulong_1099511628211
+OpStore %190 %677
+%678 = OpLoad %ulong %193
+%679 = OpIAdd %ulong %678 %ulong_1
+OpStore %191 %679
+%680 = OpLoad %ulong %190
+OpStore %192 %680
+%681 = OpLoad %ulong %191
+OpStore %193 %681
+OpBranch %138
+%24 = OpLabel
+%682 = OpLoad %ulong %183
+%683 = OpIMul %ulong %682 %ulong_8
+OpStore %176 %683
+%684 = OpLoad %ulong %174
+%685 = OpLoad %ulong %176
+%686 = OpShiftRightLogical %ulong %684 %685
+OpStore %177 %686
+%687 = OpLoad %ulong %177
+%688 = OpBitwiseAnd %ulong %687 %ulong_255
+OpStore %178 %688
+%689 = OpLoad %ulong %182
+%690 = OpLoad %ulong %178
+%691 = OpBitwiseXor %ulong %689 %690
+OpStore %179 %691
+%692 = OpLoad %ulong %179
+%693 = OpIMul %ulong %692 %ulong_1099511628211
+OpStore %180 %693
+%694 = OpLoad %ulong %183
+%695 = OpIAdd %ulong %694 %ulong_1
+OpStore %181 %695
+%696 = OpLoad %ulong %180
+OpStore %182 %696
+%697 = OpLoad %ulong %181
+OpStore %183 %697
+OpBranch %139
+%17 = OpLabel
+%698 = OpLoad %ulong %173
+%699 = OpIMul %ulong %698 %ulong_8
+OpStore %166 %699
+%700 = OpLoad %ulong %163
+%701 = OpLoad %ulong %166
+%702 = OpShiftRightLogical %ulong %700 %701
+OpStore %167 %702
+%703 = OpLoad %ulong %167
+%704 = OpBitwiseAnd %ulong %703 %ulong_255
+OpStore %168 %704
+%705 = OpLoad %ulong %172
+%706 = OpLoad %ulong %168
+%707 = OpBitwiseXor %ulong %705 %706
+OpStore %169 %707
+%708 = OpLoad %ulong %169
+%709 = OpIMul %ulong %708 %ulong_1099511628211
+OpStore %170 %709
+%710 = OpLoad %ulong %173
+%711 = OpIAdd %ulong %710 %ulong_1
+OpStore %171 %711
+%712 = OpLoad %ulong %170
+OpStore %172 %712
+%713 = OpLoad %ulong %171
+OpStore %173 %713
+OpBranch %140
+%125 = OpLabel
+OpBranch %121
+%126 = OpLabel
+OpBranch %114
+%127 = OpLabel
+OpBranch %107
+%128 = OpLabel
+OpBranch %100
+%129 = OpLabel
+OpBranch %93
+%130 = OpLabel
+OpBranch %86
+%131 = OpLabel
+OpBranch %79
+%132 = OpLabel
+OpBranch %72
+%133 = OpLabel
+OpBranch %65
+%134 = OpLabel
+OpBranch %58
+%135 = OpLabel
+OpBranch %51
+%136 = OpLabel
+OpBranch %44
+%137 = OpLabel
+OpBranch %37
+%138 = OpLabel
+OpBranch %30
+%139 = OpLabel
+OpBranch %23
+%140 = OpLabel
+OpBranch %16
+OpFunctionEnd
+%2 = OpFunction %ulong None %714
+%715 = OpFunctionParameter %ulong
+%716 = OpLabel
+%734 = OpVariable %_ptr_Function__arr__arr_uchar_uint_16_uint_4 Function
+%737 = OpVariable %_ptr_Function__struct_735 Function
+%738 = OpVariable %_ptr_Function_ulong Function
 %739 = OpVariable %_ptr_Function_uchar Function
-%740 = OpVariable %_ptr_Function_uchar Function
-%741 = OpVariable %_ptr_Function_uchar Function
-%742 = OpVariable %_ptr_Function_uchar Function
-%743 = OpVariable %_ptr_Function_uchar Function
+%740 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%741 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%742 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%743 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %744 = OpVariable %_ptr_Function_uchar Function
 %745 = OpVariable %_ptr_Function_uchar Function
-%746 = OpVariable %_ptr_Function_uchar Function
+%746 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %747 = OpVariable %_ptr_Function_uchar Function
 %748 = OpVariable %_ptr_Function_uchar Function
-%749 = OpVariable %_ptr_Function_uchar Function
+%749 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %750 = OpVariable %_ptr_Function_uchar Function
 %751 = OpVariable %_ptr_Function_uchar Function
-%752 = OpVariable %_ptr_Function_uchar Function
+%752 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %753 = OpVariable %_ptr_Function_uchar Function
 %754 = OpVariable %_ptr_Function_uchar Function
-%755 = OpVariable %_ptr_Function_uchar Function
-%756 = OpVariable %_ptr_Function_uchar Function
-%757 = OpVariable %_ptr_Function_uchar Function
-%758 = OpVariable %_ptr_Function_uchar Function
-%759 = OpVariable %_ptr_Function_uchar Function
-%760 = OpVariable %_ptr_Function_uchar Function
-%761 = OpVariable %_ptr_Function_uchar Function
-%762 = OpVariable %_ptr_Function_uchar Function
-%763 = OpVariable %_ptr_Function_uchar Function
-%764 = OpVariable %_ptr_Function_uchar Function
-%765 = OpVariable %_ptr_Function_uchar Function
-%766 = OpVariable %_ptr_Function_uchar Function
-%767 = OpVariable %_ptr_Function_uchar Function
-%768 = OpVariable %_ptr_Function_uchar Function
-%769 = OpVariable %_ptr_Function_uchar Function
-%770 = OpVariable %_ptr_Function_uchar Function
-%771 = OpVariable %_ptr_Function_uchar Function
-%772 = OpVariable %_ptr_Function_uchar Function
-%773 = OpVariable %_ptr_Function_uchar Function
-%774 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%775 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%776 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%777 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%778 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%779 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%755 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_bool Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_bool Function
 %780 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%781 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%782 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
 %783 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%784 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%785 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%785 = OpVariable %_ptr_Function_uint Function
 %786 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%787 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%788 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%789 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%790 = OpVariable %_ptr_Function_uchar Function
-%791 = OpVariable %_ptr_Function_uchar Function
-%792 = OpVariable %_ptr_Function_uchar Function
-%793 = OpVariable %_ptr_Function_uchar Function
-%794 = OpVariable %_ptr_Function_uchar Function
-%795 = OpVariable %_ptr_Function_uchar Function
-%796 = OpVariable %_ptr_Function_uchar Function
-%797 = OpVariable %_ptr_Function_uchar Function
-%798 = OpVariable %_ptr_Function_uchar Function
-%799 = OpVariable %_ptr_Function_uchar Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_uint Function
+%789 = OpVariable %_ptr_Function_ulong Function
+%790 = OpVariable %_ptr_Function_ulong Function
+%791 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%792 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%793 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%794 = OpVariable %_ptr_Function_ulong Function
+%795 = OpVariable %_ptr_Function_ulong Function
+%796 = OpVariable %_ptr_Function_ulong Function
+%797 = OpVariable %_ptr_Function_ulong Function
+%798 = OpVariable %_ptr_Function_ulong Function
+%799 = OpVariable %_ptr_Function_ulong Function
 %800 = OpVariable %_ptr_Function_uchar Function
 %801 = OpVariable %_ptr_Function_uchar Function
 %802 = OpVariable %_ptr_Function_uchar Function
@@ -910,32 +1219,32 @@ OpFunctionEnd
 %835 = OpVariable %_ptr_Function_uchar Function
 %836 = OpVariable %_ptr_Function_uchar Function
 %837 = OpVariable %_ptr_Function_uchar Function
-%838 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%839 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%840 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%841 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%842 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%843 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%844 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%845 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%846 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%847 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%838 = OpVariable %_ptr_Function_uchar Function
+%839 = OpVariable %_ptr_Function_uchar Function
+%840 = OpVariable %_ptr_Function_uchar Function
+%841 = OpVariable %_ptr_Function_uchar Function
+%842 = OpVariable %_ptr_Function_uchar Function
+%843 = OpVariable %_ptr_Function_uchar Function
+%844 = OpVariable %_ptr_Function_uchar Function
+%845 = OpVariable %_ptr_Function_uchar Function
+%846 = OpVariable %_ptr_Function_uchar Function
+%847 = OpVariable %_ptr_Function_uchar Function
 %848 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %849 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %850 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %851 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %852 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %853 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%854 = OpVariable %_ptr_Function_uchar Function
-%855 = OpVariable %_ptr_Function_uchar Function
-%856 = OpVariable %_ptr_Function_uchar Function
-%857 = OpVariable %_ptr_Function_uchar Function
-%858 = OpVariable %_ptr_Function_uchar Function
-%859 = OpVariable %_ptr_Function_uchar Function
-%860 = OpVariable %_ptr_Function_uchar Function
-%861 = OpVariable %_ptr_Function_uchar Function
-%862 = OpVariable %_ptr_Function_uchar Function
-%863 = OpVariable %_ptr_Function_uchar Function
+%854 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%855 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%856 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%857 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%858 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%859 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%860 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%861 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%862 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%863 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %864 = OpVariable %_ptr_Function_uchar Function
 %865 = OpVariable %_ptr_Function_uchar Function
 %866 = OpVariable %_ptr_Function_uchar Function
@@ -974,32 +1283,32 @@ OpFunctionEnd
 %899 = OpVariable %_ptr_Function_uchar Function
 %900 = OpVariable %_ptr_Function_uchar Function
 %901 = OpVariable %_ptr_Function_uchar Function
-%902 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%903 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%904 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%905 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%906 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%907 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%908 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%909 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%910 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%911 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%902 = OpVariable %_ptr_Function_uchar Function
+%903 = OpVariable %_ptr_Function_uchar Function
+%904 = OpVariable %_ptr_Function_uchar Function
+%905 = OpVariable %_ptr_Function_uchar Function
+%906 = OpVariable %_ptr_Function_uchar Function
+%907 = OpVariable %_ptr_Function_uchar Function
+%908 = OpVariable %_ptr_Function_uchar Function
+%909 = OpVariable %_ptr_Function_uchar Function
+%910 = OpVariable %_ptr_Function_uchar Function
+%911 = OpVariable %_ptr_Function_uchar Function
 %912 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %913 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %914 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %915 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %916 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %917 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%918 = OpVariable %_ptr_Function_uchar Function
-%919 = OpVariable %_ptr_Function_uchar Function
-%920 = OpVariable %_ptr_Function_uchar Function
-%921 = OpVariable %_ptr_Function_uchar Function
-%922 = OpVariable %_ptr_Function_uchar Function
-%923 = OpVariable %_ptr_Function_uchar Function
-%924 = OpVariable %_ptr_Function_uchar Function
-%925 = OpVariable %_ptr_Function_uchar Function
-%926 = OpVariable %_ptr_Function_uchar Function
-%927 = OpVariable %_ptr_Function_uchar Function
+%918 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%919 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%920 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%921 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%922 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%923 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%924 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%925 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%926 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%927 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %928 = OpVariable %_ptr_Function_uchar Function
 %929 = OpVariable %_ptr_Function_uchar Function
 %930 = OpVariable %_ptr_Function_uchar Function
@@ -1038,32 +1347,32 @@ OpFunctionEnd
 %963 = OpVariable %_ptr_Function_uchar Function
 %964 = OpVariable %_ptr_Function_uchar Function
 %965 = OpVariable %_ptr_Function_uchar Function
-%966 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%967 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%968 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%969 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%970 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%971 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%972 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%973 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%974 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%975 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%966 = OpVariable %_ptr_Function_uchar Function
+%967 = OpVariable %_ptr_Function_uchar Function
+%968 = OpVariable %_ptr_Function_uchar Function
+%969 = OpVariable %_ptr_Function_uchar Function
+%970 = OpVariable %_ptr_Function_uchar Function
+%971 = OpVariable %_ptr_Function_uchar Function
+%972 = OpVariable %_ptr_Function_uchar Function
+%973 = OpVariable %_ptr_Function_uchar Function
+%974 = OpVariable %_ptr_Function_uchar Function
+%975 = OpVariable %_ptr_Function_uchar Function
 %976 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %977 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %978 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %979 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %980 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %981 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%982 = OpVariable %_ptr_Function_uchar Function
-%983 = OpVariable %_ptr_Function_uchar Function
-%984 = OpVariable %_ptr_Function_uchar Function
-%985 = OpVariable %_ptr_Function_uchar Function
-%986 = OpVariable %_ptr_Function_uchar Function
-%987 = OpVariable %_ptr_Function_uchar Function
-%988 = OpVariable %_ptr_Function_uchar Function
-%989 = OpVariable %_ptr_Function_uchar Function
-%990 = OpVariable %_ptr_Function_uchar Function
-%991 = OpVariable %_ptr_Function_uchar Function
+%982 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%983 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%984 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%985 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%986 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%987 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%988 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%989 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%990 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%991 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %992 = OpVariable %_ptr_Function_uchar Function
 %993 = OpVariable %_ptr_Function_uchar Function
 %994 = OpVariable %_ptr_Function_uchar Function
@@ -1086,22 +1395,22 @@ OpFunctionEnd
 %1011 = OpVariable %_ptr_Function_uchar Function
 %1012 = OpVariable %_ptr_Function_uchar Function
 %1013 = OpVariable %_ptr_Function_uchar Function
-%1014 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1015 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1016 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1017 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1018 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1019 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1020 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1021 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1022 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1023 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1024 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1025 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1026 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1027 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1028 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1029 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1014 = OpVariable %_ptr_Function_uchar Function
+%1015 = OpVariable %_ptr_Function_uchar Function
+%1016 = OpVariable %_ptr_Function_uchar Function
+%1017 = OpVariable %_ptr_Function_uchar Function
+%1018 = OpVariable %_ptr_Function_uchar Function
+%1019 = OpVariable %_ptr_Function_uchar Function
+%1020 = OpVariable %_ptr_Function_uchar Function
+%1021 = OpVariable %_ptr_Function_uchar Function
+%1022 = OpVariable %_ptr_Function_uchar Function
+%1023 = OpVariable %_ptr_Function_uchar Function
+%1024 = OpVariable %_ptr_Function_uchar Function
+%1025 = OpVariable %_ptr_Function_uchar Function
+%1026 = OpVariable %_ptr_Function_uchar Function
+%1027 = OpVariable %_ptr_Function_uchar Function
+%1028 = OpVariable %_ptr_Function_uchar Function
+%1029 = OpVariable %_ptr_Function_uchar Function
 %1030 = OpVariable %_ptr_Function_uchar Function
 %1031 = OpVariable %_ptr_Function_uchar Function
 %1032 = OpVariable %_ptr_Function_uchar Function
@@ -1112,44 +1421,44 @@ OpFunctionEnd
 %1037 = OpVariable %_ptr_Function_uchar Function
 %1038 = OpVariable %_ptr_Function_uchar Function
 %1039 = OpVariable %_ptr_Function_uchar Function
-%1040 = OpVariable %_ptr_Function_uchar Function
-%1041 = OpVariable %_ptr_Function_uchar Function
-%1042 = OpVariable %_ptr_Function_uchar Function
-%1043 = OpVariable %_ptr_Function_uchar Function
-%1044 = OpVariable %_ptr_Function_uchar Function
-%1045 = OpVariable %_ptr_Function_uchar Function
-%1046 = OpVariable %_ptr_Function_uchar Function
-%1047 = OpVariable %_ptr_Function_uchar Function
-%1048 = OpVariable %_ptr_Function_uchar Function
-%1049 = OpVariable %_ptr_Function_uchar Function
-%1050 = OpVariable %_ptr_Function_uchar Function
-%1051 = OpVariable %_ptr_Function_uchar Function
-%1052 = OpVariable %_ptr_Function_uchar Function
-%1053 = OpVariable %_ptr_Function_uchar Function
-%1054 = OpVariable %_ptr_Function_uchar Function
-%1055 = OpVariable %_ptr_Function_uchar Function
+%1040 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1041 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1042 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1043 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1044 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1045 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1046 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1047 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1048 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1049 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1050 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1051 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1052 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1053 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1054 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1055 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1056 = OpVariable %_ptr_Function_uchar Function
 %1057 = OpVariable %_ptr_Function_uchar Function
 %1058 = OpVariable %_ptr_Function_uchar Function
 %1059 = OpVariable %_ptr_Function_uchar Function
 %1060 = OpVariable %_ptr_Function_uchar Function
 %1061 = OpVariable %_ptr_Function_uchar Function
-%1062 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1063 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1064 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1065 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1066 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1067 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1068 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1069 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1070 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1071 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1072 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1073 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1074 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1075 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1076 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1077 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1062 = OpVariable %_ptr_Function_uchar Function
+%1063 = OpVariable %_ptr_Function_uchar Function
+%1064 = OpVariable %_ptr_Function_uchar Function
+%1065 = OpVariable %_ptr_Function_uchar Function
+%1066 = OpVariable %_ptr_Function_uchar Function
+%1067 = OpVariable %_ptr_Function_uchar Function
+%1068 = OpVariable %_ptr_Function_uchar Function
+%1069 = OpVariable %_ptr_Function_uchar Function
+%1070 = OpVariable %_ptr_Function_uchar Function
+%1071 = OpVariable %_ptr_Function_uchar Function
+%1072 = OpVariable %_ptr_Function_uchar Function
+%1073 = OpVariable %_ptr_Function_uchar Function
+%1074 = OpVariable %_ptr_Function_uchar Function
+%1075 = OpVariable %_ptr_Function_uchar Function
+%1076 = OpVariable %_ptr_Function_uchar Function
+%1077 = OpVariable %_ptr_Function_uchar Function
 %1078 = OpVariable %_ptr_Function_uchar Function
 %1079 = OpVariable %_ptr_Function_uchar Function
 %1080 = OpVariable %_ptr_Function_uchar Function
@@ -1176,44 +1485,44 @@ OpFunctionEnd
 %1101 = OpVariable %_ptr_Function_uchar Function
 %1102 = OpVariable %_ptr_Function_uchar Function
 %1103 = OpVariable %_ptr_Function_uchar Function
-%1104 = OpVariable %_ptr_Function_uchar Function
-%1105 = OpVariable %_ptr_Function_uchar Function
-%1106 = OpVariable %_ptr_Function_uchar Function
-%1107 = OpVariable %_ptr_Function_uchar Function
-%1108 = OpVariable %_ptr_Function_uchar Function
-%1109 = OpVariable %_ptr_Function_uchar Function
-%1110 = OpVariable %_ptr_Function_uchar Function
-%1111 = OpVariable %_ptr_Function_uchar Function
-%1112 = OpVariable %_ptr_Function_uchar Function
-%1113 = OpVariable %_ptr_Function_uchar Function
-%1114 = OpVariable %_ptr_Function_uchar Function
-%1115 = OpVariable %_ptr_Function_uchar Function
-%1116 = OpVariable %_ptr_Function_uchar Function
-%1117 = OpVariable %_ptr_Function_uchar Function
-%1118 = OpVariable %_ptr_Function_uchar Function
-%1119 = OpVariable %_ptr_Function_uchar Function
+%1104 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1105 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1106 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1107 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1108 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1109 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1110 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1111 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1112 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1113 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1114 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1115 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1116 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1117 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1118 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1119 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1120 = OpVariable %_ptr_Function_uchar Function
 %1121 = OpVariable %_ptr_Function_uchar Function
 %1122 = OpVariable %_ptr_Function_uchar Function
 %1123 = OpVariable %_ptr_Function_uchar Function
 %1124 = OpVariable %_ptr_Function_uchar Function
 %1125 = OpVariable %_ptr_Function_uchar Function
-%1126 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1127 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1128 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1129 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1130 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1131 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1132 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1133 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1134 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1135 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1136 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1137 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1138 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1139 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1140 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1141 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1126 = OpVariable %_ptr_Function_uchar Function
+%1127 = OpVariable %_ptr_Function_uchar Function
+%1128 = OpVariable %_ptr_Function_uchar Function
+%1129 = OpVariable %_ptr_Function_uchar Function
+%1130 = OpVariable %_ptr_Function_uchar Function
+%1131 = OpVariable %_ptr_Function_uchar Function
+%1132 = OpVariable %_ptr_Function_uchar Function
+%1133 = OpVariable %_ptr_Function_uchar Function
+%1134 = OpVariable %_ptr_Function_uchar Function
+%1135 = OpVariable %_ptr_Function_uchar Function
+%1136 = OpVariable %_ptr_Function_uchar Function
+%1137 = OpVariable %_ptr_Function_uchar Function
+%1138 = OpVariable %_ptr_Function_uchar Function
+%1139 = OpVariable %_ptr_Function_uchar Function
+%1140 = OpVariable %_ptr_Function_uchar Function
+%1141 = OpVariable %_ptr_Function_uchar Function
 %1142 = OpVariable %_ptr_Function_uchar Function
 %1143 = OpVariable %_ptr_Function_uchar Function
 %1144 = OpVariable %_ptr_Function_uchar Function
@@ -1240,44 +1549,44 @@ OpFunctionEnd
 %1165 = OpVariable %_ptr_Function_uchar Function
 %1166 = OpVariable %_ptr_Function_uchar Function
 %1167 = OpVariable %_ptr_Function_uchar Function
-%1168 = OpVariable %_ptr_Function_uchar Function
-%1169 = OpVariable %_ptr_Function_uchar Function
-%1170 = OpVariable %_ptr_Function_uchar Function
-%1171 = OpVariable %_ptr_Function_uchar Function
-%1172 = OpVariable %_ptr_Function_uchar Function
-%1173 = OpVariable %_ptr_Function_uchar Function
-%1174 = OpVariable %_ptr_Function_uchar Function
-%1175 = OpVariable %_ptr_Function_uchar Function
-%1176 = OpVariable %_ptr_Function_uchar Function
-%1177 = OpVariable %_ptr_Function_uchar Function
-%1178 = OpVariable %_ptr_Function_uchar Function
-%1179 = OpVariable %_ptr_Function_uchar Function
-%1180 = OpVariable %_ptr_Function_uchar Function
-%1181 = OpVariable %_ptr_Function_uchar Function
-%1182 = OpVariable %_ptr_Function_uchar Function
-%1183 = OpVariable %_ptr_Function_uchar Function
+%1168 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1169 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1170 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1171 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1172 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1173 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1174 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1175 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1176 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1177 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1178 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1179 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1180 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1181 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1182 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1183 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1184 = OpVariable %_ptr_Function_uchar Function
 %1185 = OpVariable %_ptr_Function_uchar Function
 %1186 = OpVariable %_ptr_Function_uchar Function
 %1187 = OpVariable %_ptr_Function_uchar Function
 %1188 = OpVariable %_ptr_Function_uchar Function
 %1189 = OpVariable %_ptr_Function_uchar Function
-%1190 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1191 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1192 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1193 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1194 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1195 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1196 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1197 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1198 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1199 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1200 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1201 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1202 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1203 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1204 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1205 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1190 = OpVariable %_ptr_Function_uchar Function
+%1191 = OpVariable %_ptr_Function_uchar Function
+%1192 = OpVariable %_ptr_Function_uchar Function
+%1193 = OpVariable %_ptr_Function_uchar Function
+%1194 = OpVariable %_ptr_Function_uchar Function
+%1195 = OpVariable %_ptr_Function_uchar Function
+%1196 = OpVariable %_ptr_Function_uchar Function
+%1197 = OpVariable %_ptr_Function_uchar Function
+%1198 = OpVariable %_ptr_Function_uchar Function
+%1199 = OpVariable %_ptr_Function_uchar Function
+%1200 = OpVariable %_ptr_Function_uchar Function
+%1201 = OpVariable %_ptr_Function_uchar Function
+%1202 = OpVariable %_ptr_Function_uchar Function
+%1203 = OpVariable %_ptr_Function_uchar Function
+%1204 = OpVariable %_ptr_Function_uchar Function
+%1205 = OpVariable %_ptr_Function_uchar Function
 %1206 = OpVariable %_ptr_Function_uchar Function
 %1207 = OpVariable %_ptr_Function_uchar Function
 %1208 = OpVariable %_ptr_Function_uchar Function
@@ -1304,44 +1613,44 @@ OpFunctionEnd
 %1229 = OpVariable %_ptr_Function_uchar Function
 %1230 = OpVariable %_ptr_Function_uchar Function
 %1231 = OpVariable %_ptr_Function_uchar Function
-%1232 = OpVariable %_ptr_Function_uchar Function
-%1233 = OpVariable %_ptr_Function_uchar Function
-%1234 = OpVariable %_ptr_Function_uchar Function
-%1235 = OpVariable %_ptr_Function_uchar Function
-%1236 = OpVariable %_ptr_Function_uchar Function
-%1237 = OpVariable %_ptr_Function_uchar Function
-%1238 = OpVariable %_ptr_Function_uchar Function
-%1239 = OpVariable %_ptr_Function_uchar Function
-%1240 = OpVariable %_ptr_Function_uchar Function
-%1241 = OpVariable %_ptr_Function_uchar Function
-%1242 = OpVariable %_ptr_Function_uchar Function
-%1243 = OpVariable %_ptr_Function_uchar Function
-%1244 = OpVariable %_ptr_Function_uchar Function
-%1245 = OpVariable %_ptr_Function_uchar Function
-%1246 = OpVariable %_ptr_Function_uchar Function
-%1247 = OpVariable %_ptr_Function_uchar Function
+%1232 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1233 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1234 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1235 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1236 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1237 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1238 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1239 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1240 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1241 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1242 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1243 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1244 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1245 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1246 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1247 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1248 = OpVariable %_ptr_Function_uchar Function
 %1249 = OpVariable %_ptr_Function_uchar Function
 %1250 = OpVariable %_ptr_Function_uchar Function
 %1251 = OpVariable %_ptr_Function_uchar Function
 %1252 = OpVariable %_ptr_Function_uchar Function
 %1253 = OpVariable %_ptr_Function_uchar Function
-%1254 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1255 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1256 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1257 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1258 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1259 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1260 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1261 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1254 = OpVariable %_ptr_Function_uchar Function
+%1255 = OpVariable %_ptr_Function_uchar Function
+%1256 = OpVariable %_ptr_Function_uchar Function
+%1257 = OpVariable %_ptr_Function_uchar Function
+%1258 = OpVariable %_ptr_Function_uchar Function
+%1259 = OpVariable %_ptr_Function_uchar Function
+%1260 = OpVariable %_ptr_Function_uchar Function
+%1261 = OpVariable %_ptr_Function_uchar Function
+%1262 = OpVariable %_ptr_Function_uchar Function
+%1263 = OpVariable %_ptr_Function_uchar Function
+%1264 = OpVariable %_ptr_Function_uchar Function
+%1265 = OpVariable %_ptr_Function_uchar Function
+%1266 = OpVariable %_ptr_Function_uchar Function
+%1267 = OpVariable %_ptr_Function_uchar Function
+%1268 = OpVariable %_ptr_Function_uchar Function
+%1269 = OpVariable %_ptr_Function_uchar Function
 %1270 = OpVariable %_ptr_Function_uchar Function
 %1271 = OpVariable %_ptr_Function_uchar Function
 %1272 = OpVariable %_ptr_Function_uchar Function
@@ -1368,44 +1677,44 @@ OpFunctionEnd
 %1293 = OpVariable %_ptr_Function_uchar Function
 %1294 = OpVariable %_ptr_Function_uchar Function
 %1295 = OpVariable %_ptr_Function_uchar Function
-%1296 = OpVariable %_ptr_Function_uchar Function
-%1297 = OpVariable %_ptr_Function_uchar Function
-%1298 = OpVariable %_ptr_Function_uchar Function
-%1299 = OpVariable %_ptr_Function_uchar Function
-%1300 = OpVariable %_ptr_Function_uchar Function
-%1301 = OpVariable %_ptr_Function_uchar Function
-%1302 = OpVariable %_ptr_Function_uchar Function
-%1303 = OpVariable %_ptr_Function_uchar Function
-%1304 = OpVariable %_ptr_Function_uchar Function
-%1305 = OpVariable %_ptr_Function_uchar Function
-%1306 = OpVariable %_ptr_Function_uchar Function
-%1307 = OpVariable %_ptr_Function_uchar Function
-%1308 = OpVariable %_ptr_Function_uchar Function
-%1309 = OpVariable %_ptr_Function_uchar Function
-%1310 = OpVariable %_ptr_Function_uchar Function
-%1311 = OpVariable %_ptr_Function_uchar Function
+%1296 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1297 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1298 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1299 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1300 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1301 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1302 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1303 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1304 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1305 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1306 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1307 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1308 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1309 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1310 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1311 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1312 = OpVariable %_ptr_Function_uchar Function
 %1313 = OpVariable %_ptr_Function_uchar Function
 %1314 = OpVariable %_ptr_Function_uchar Function
 %1315 = OpVariable %_ptr_Function_uchar Function
 %1316 = OpVariable %_ptr_Function_uchar Function
 %1317 = OpVariable %_ptr_Function_uchar Function
-%1318 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1319 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1320 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1321 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1322 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1323 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1324 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1325 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1326 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1327 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1328 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1329 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1330 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1331 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1332 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1333 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1318 = OpVariable %_ptr_Function_uchar Function
+%1319 = OpVariable %_ptr_Function_uchar Function
+%1320 = OpVariable %_ptr_Function_uchar Function
+%1321 = OpVariable %_ptr_Function_uchar Function
+%1322 = OpVariable %_ptr_Function_uchar Function
+%1323 = OpVariable %_ptr_Function_uchar Function
+%1324 = OpVariable %_ptr_Function_uchar Function
+%1325 = OpVariable %_ptr_Function_uchar Function
+%1326 = OpVariable %_ptr_Function_uchar Function
+%1327 = OpVariable %_ptr_Function_uchar Function
+%1328 = OpVariable %_ptr_Function_uchar Function
+%1329 = OpVariable %_ptr_Function_uchar Function
+%1330 = OpVariable %_ptr_Function_uchar Function
+%1331 = OpVariable %_ptr_Function_uchar Function
+%1332 = OpVariable %_ptr_Function_uchar Function
+%1333 = OpVariable %_ptr_Function_uchar Function
 %1334 = OpVariable %_ptr_Function_uchar Function
 %1335 = OpVariable %_ptr_Function_uchar Function
 %1336 = OpVariable %_ptr_Function_uchar Function
@@ -1432,44 +1741,44 @@ OpFunctionEnd
 %1357 = OpVariable %_ptr_Function_uchar Function
 %1358 = OpVariable %_ptr_Function_uchar Function
 %1359 = OpVariable %_ptr_Function_uchar Function
-%1360 = OpVariable %_ptr_Function_uchar Function
-%1361 = OpVariable %_ptr_Function_uchar Function
-%1362 = OpVariable %_ptr_Function_uchar Function
-%1363 = OpVariable %_ptr_Function_uchar Function
-%1364 = OpVariable %_ptr_Function_uchar Function
-%1365 = OpVariable %_ptr_Function_uchar Function
-%1366 = OpVariable %_ptr_Function_uchar Function
-%1367 = OpVariable %_ptr_Function_uchar Function
-%1368 = OpVariable %_ptr_Function_uchar Function
-%1369 = OpVariable %_ptr_Function_uchar Function
-%1370 = OpVariable %_ptr_Function_uchar Function
-%1371 = OpVariable %_ptr_Function_uchar Function
-%1372 = OpVariable %_ptr_Function_uchar Function
-%1373 = OpVariable %_ptr_Function_uchar Function
-%1374 = OpVariable %_ptr_Function_uchar Function
-%1375 = OpVariable %_ptr_Function_uchar Function
+%1360 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1361 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1362 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1363 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1364 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1365 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1366 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1367 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1368 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1369 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1370 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1371 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1372 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1373 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1374 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1375 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1376 = OpVariable %_ptr_Function_uchar Function
 %1377 = OpVariable %_ptr_Function_uchar Function
 %1378 = OpVariable %_ptr_Function_uchar Function
 %1379 = OpVariable %_ptr_Function_uchar Function
 %1380 = OpVariable %_ptr_Function_uchar Function
 %1381 = OpVariable %_ptr_Function_uchar Function
-%1382 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1383 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1384 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1385 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1386 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1387 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1388 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1389 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1390 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1391 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1392 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1393 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1394 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1395 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1396 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1397 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1382 = OpVariable %_ptr_Function_uchar Function
+%1383 = OpVariable %_ptr_Function_uchar Function
+%1384 = OpVariable %_ptr_Function_uchar Function
+%1385 = OpVariable %_ptr_Function_uchar Function
+%1386 = OpVariable %_ptr_Function_uchar Function
+%1387 = OpVariable %_ptr_Function_uchar Function
+%1388 = OpVariable %_ptr_Function_uchar Function
+%1389 = OpVariable %_ptr_Function_uchar Function
+%1390 = OpVariable %_ptr_Function_uchar Function
+%1391 = OpVariable %_ptr_Function_uchar Function
+%1392 = OpVariable %_ptr_Function_uchar Function
+%1393 = OpVariable %_ptr_Function_uchar Function
+%1394 = OpVariable %_ptr_Function_uchar Function
+%1395 = OpVariable %_ptr_Function_uchar Function
+%1396 = OpVariable %_ptr_Function_uchar Function
+%1397 = OpVariable %_ptr_Function_uchar Function
 %1398 = OpVariable %_ptr_Function_uchar Function
 %1399 = OpVariable %_ptr_Function_uchar Function
 %1400 = OpVariable %_ptr_Function_uchar Function
@@ -1496,44 +1805,44 @@ OpFunctionEnd
 %1421 = OpVariable %_ptr_Function_uchar Function
 %1422 = OpVariable %_ptr_Function_uchar Function
 %1423 = OpVariable %_ptr_Function_uchar Function
-%1424 = OpVariable %_ptr_Function_uchar Function
-%1425 = OpVariable %_ptr_Function_uchar Function
-%1426 = OpVariable %_ptr_Function_uchar Function
-%1427 = OpVariable %_ptr_Function_uchar Function
-%1428 = OpVariable %_ptr_Function_uchar Function
-%1429 = OpVariable %_ptr_Function_uchar Function
-%1430 = OpVariable %_ptr_Function_uchar Function
-%1431 = OpVariable %_ptr_Function_uchar Function
-%1432 = OpVariable %_ptr_Function_uchar Function
-%1433 = OpVariable %_ptr_Function_uchar Function
-%1434 = OpVariable %_ptr_Function_uchar Function
-%1435 = OpVariable %_ptr_Function_uchar Function
-%1436 = OpVariable %_ptr_Function_uchar Function
-%1437 = OpVariable %_ptr_Function_uchar Function
-%1438 = OpVariable %_ptr_Function_uchar Function
-%1439 = OpVariable %_ptr_Function_uchar Function
+%1424 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1425 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1426 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1427 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1428 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1429 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1430 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1431 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1432 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1433 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1434 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1435 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1436 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1437 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1438 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1439 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1440 = OpVariable %_ptr_Function_uchar Function
 %1441 = OpVariable %_ptr_Function_uchar Function
 %1442 = OpVariable %_ptr_Function_uchar Function
 %1443 = OpVariable %_ptr_Function_uchar Function
 %1444 = OpVariable %_ptr_Function_uchar Function
 %1445 = OpVariable %_ptr_Function_uchar Function
-%1446 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1447 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1448 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1449 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1450 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1451 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1452 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1453 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1454 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1455 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1456 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1457 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1458 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1459 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1460 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1461 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1446 = OpVariable %_ptr_Function_uchar Function
+%1447 = OpVariable %_ptr_Function_uchar Function
+%1448 = OpVariable %_ptr_Function_uchar Function
+%1449 = OpVariable %_ptr_Function_uchar Function
+%1450 = OpVariable %_ptr_Function_uchar Function
+%1451 = OpVariable %_ptr_Function_uchar Function
+%1452 = OpVariable %_ptr_Function_uchar Function
+%1453 = OpVariable %_ptr_Function_uchar Function
+%1454 = OpVariable %_ptr_Function_uchar Function
+%1455 = OpVariable %_ptr_Function_uchar Function
+%1456 = OpVariable %_ptr_Function_uchar Function
+%1457 = OpVariable %_ptr_Function_uchar Function
+%1458 = OpVariable %_ptr_Function_uchar Function
+%1459 = OpVariable %_ptr_Function_uchar Function
+%1460 = OpVariable %_ptr_Function_uchar Function
+%1461 = OpVariable %_ptr_Function_uchar Function
 %1462 = OpVariable %_ptr_Function_uchar Function
 %1463 = OpVariable %_ptr_Function_uchar Function
 %1464 = OpVariable %_ptr_Function_uchar Function
@@ -1560,5010 +1869,5533 @@ OpFunctionEnd
 %1485 = OpVariable %_ptr_Function_uchar Function
 %1486 = OpVariable %_ptr_Function_uchar Function
 %1487 = OpVariable %_ptr_Function_uchar Function
-%1488 = OpVariable %_ptr_Function_uchar Function
-%1489 = OpVariable %_ptr_Function_uchar Function
-%1490 = OpVariable %_ptr_Function_uchar Function
-%1491 = OpVariable %_ptr_Function_uchar Function
-%1492 = OpVariable %_ptr_Function_uchar Function
-%1493 = OpVariable %_ptr_Function_uchar Function
-%1494 = OpVariable %_ptr_Function_uchar Function
-%1495 = OpVariable %_ptr_Function_uchar Function
-%1496 = OpVariable %_ptr_Function_uchar Function
-%1497 = OpVariable %_ptr_Function_uchar Function
-%1498 = OpVariable %_ptr_Function_uchar Function
-%1499 = OpVariable %_ptr_Function_uchar Function
-%1500 = OpVariable %_ptr_Function_uchar Function
-%1501 = OpVariable %_ptr_Function_uchar Function
-%1502 = OpVariable %_ptr_Function_uchar Function
-%1503 = OpVariable %_ptr_Function_uchar Function
+%1488 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1489 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1490 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1491 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1492 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1493 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1494 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1495 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1496 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1497 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1498 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1499 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1500 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1501 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1502 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1503 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1504 = OpVariable %_ptr_Function_uchar Function
 %1505 = OpVariable %_ptr_Function_uchar Function
 %1506 = OpVariable %_ptr_Function_uchar Function
 %1507 = OpVariable %_ptr_Function_uchar Function
 %1508 = OpVariable %_ptr_Function_uchar Function
 %1509 = OpVariable %_ptr_Function_uchar Function
-%1510 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1511 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1512 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1513 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1514 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1515 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1516 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1517 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1518 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1519 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1520 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1521 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1522 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1523 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1524 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1525 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-OpStore %152 %134
-%1526 = OpFunctionCall %ulong %3
-OpStore %153 %1526
-%1527 = OpLoad %ulong %152
-%1528 = OpUConvert %uchar %1527
-OpStore %154 %1528
-%1529 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_247 %uchar_7 %uchar_251 %uchar_3 %uchar_255 %uchar_2 %uchar_252 %uchar_6 %uchar_248 %uchar_9 %uchar_253 %uchar_1 %uchar_254 %uchar_4 %uchar_250 %uchar_8
-OpStore %155 %1529
-%1546 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_2 %uchar_253 %uchar_4 %uchar_251 %uchar_6 %uchar_249 %uchar_8 %uchar_247 %uchar_1 %uchar_254 %uchar_3 %uchar_252 %uchar_5 %uchar_250 %uchar_7 %uchar_255
-OpStore %156 %1546
-%1549 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2
-OpStore %157 %1549
-%1550 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0
-OpStore %158 %1550
-%1552 = OpLoad %_arr_uchar_uint_16 %155
-%1553 = OpCompositeExtract %uchar %1552 0
-OpStore %159 %1553
-%1554 = OpLoad %uchar %159
-%1555 = OpLoad %uchar %154
-%1556 = OpIAdd %uchar %1554 %1555
-OpStore %160 %1556
-%1557 = OpLoad %_arr_uchar_uint_16 %155
-%1558 = OpLoad %uchar %160
-%1559 = OpCompositeInsert %_arr_uchar_uint_16 %1558 %1557 0
-OpStore %161 %1559
-%1560 = OpLoad %_arr_uchar_uint_16 %161
-%1561 = OpCompositeExtract %uchar %1560 7
-OpStore %162 %1561
-%1562 = OpLoad %uchar %162
-%1563 = OpLoad %uchar %154
-%1564 = OpIAdd %uchar %1562 %1563
-OpStore %163 %1564
-%1565 = OpLoad %_arr_uchar_uint_16 %161
-%1566 = OpLoad %uchar %163
-%1567 = OpCompositeInsert %_arr_uchar_uint_16 %1566 %1565 7
-OpStore %164 %1567
-%1568 = OpLoad %_arr_uchar_uint_16 %156
-%1569 = OpCompositeExtract %uchar %1568 3
-OpStore %165 %1569
-%1570 = OpLoad %uchar %165
-%1571 = OpLoad %uchar %154
-%1572 = OpIAdd %uchar %1570 %1571
-OpStore %166 %1572
-%1573 = OpLoad %_arr_uchar_uint_16 %156
-%1574 = OpLoad %uchar %166
-%1575 = OpCompositeInsert %_arr_uchar_uint_16 %1574 %1573 3
-OpStore %167 %1575
-%1576 = OpLoad %_arr_uchar_uint_16 %167
-%1577 = OpCompositeExtract %uchar %1576 12
-OpStore %168 %1577
-%1578 = OpLoad %uchar %168
-%1579 = OpLoad %uchar %154
-%1580 = OpIAdd %uchar %1578 %1579
-OpStore %169 %1580
-%1581 = OpLoad %_arr_uchar_uint_16 %167
-%1582 = OpLoad %uchar %169
-%1583 = OpCompositeInsert %_arr_uchar_uint_16 %1582 %1581 12
-OpStore %170 %1583
-%1584 = OpLoad %ulong %153
-%1585 = OpLoad %_arr_uchar_uint_16 %164
-%1586 = OpFunctionCall %ulong %1 %1584 %1585
-OpStore %171 %1586
-%1587 = OpLoad %ulong %171
-%1588 = OpLoad %_arr_uchar_uint_16 %170
-%1589 = OpFunctionCall %ulong %1 %1587 %1588
-OpStore %172 %1589
-%1590 = OpLoad %_arr_uchar_uint_16 %164
-%1591 = OpCompositeExtract %uchar %1590 0
-OpStore %214 %1591
-%1592 = OpLoad %_arr_uchar_uint_16 %170
-%1593 = OpCompositeExtract %uchar %1592 0
-OpStore %215 %1593
-%1594 = OpLoad %uchar %214
-%1595 = OpLoad %uchar %215
-%1596 = OpIAdd %uchar %1594 %1595
-OpStore %216 %1596
-%1597 = OpLoad %_arr_uchar_uint_16 %164
-%1598 = OpCompositeExtract %uchar %1597 1
-OpStore %217 %1598
-%1599 = OpLoad %_arr_uchar_uint_16 %170
-%1600 = OpCompositeExtract %uchar %1599 1
-OpStore %218 %1600
-%1601 = OpLoad %uchar %217
-%1602 = OpLoad %uchar %218
-%1603 = OpIAdd %uchar %1601 %1602
-OpStore %219 %1603
-%1604 = OpLoad %_arr_uchar_uint_16 %164
-%1605 = OpCompositeExtract %uchar %1604 2
-OpStore %220 %1605
-%1606 = OpLoad %_arr_uchar_uint_16 %170
-%1607 = OpCompositeExtract %uchar %1606 2
-OpStore %221 %1607
-%1608 = OpLoad %uchar %220
-%1609 = OpLoad %uchar %221
-%1610 = OpIAdd %uchar %1608 %1609
-OpStore %222 %1610
-%1611 = OpLoad %_arr_uchar_uint_16 %164
-%1612 = OpCompositeExtract %uchar %1611 3
-OpStore %223 %1612
-%1613 = OpLoad %_arr_uchar_uint_16 %170
-%1614 = OpCompositeExtract %uchar %1613 3
-OpStore %224 %1614
-%1615 = OpLoad %uchar %223
-%1616 = OpLoad %uchar %224
-%1617 = OpIAdd %uchar %1615 %1616
-OpStore %225 %1617
-%1618 = OpLoad %_arr_uchar_uint_16 %164
-%1619 = OpCompositeExtract %uchar %1618 4
-OpStore %226 %1619
-%1620 = OpLoad %_arr_uchar_uint_16 %170
-%1621 = OpCompositeExtract %uchar %1620 4
-OpStore %227 %1621
-%1622 = OpLoad %uchar %226
-%1623 = OpLoad %uchar %227
-%1624 = OpIAdd %uchar %1622 %1623
-OpStore %228 %1624
-%1625 = OpLoad %_arr_uchar_uint_16 %164
-%1626 = OpCompositeExtract %uchar %1625 5
-OpStore %229 %1626
-%1627 = OpLoad %_arr_uchar_uint_16 %170
-%1628 = OpCompositeExtract %uchar %1627 5
-OpStore %230 %1628
-%1629 = OpLoad %uchar %229
-%1630 = OpLoad %uchar %230
-%1631 = OpIAdd %uchar %1629 %1630
-OpStore %231 %1631
-%1632 = OpLoad %_arr_uchar_uint_16 %164
-%1633 = OpCompositeExtract %uchar %1632 6
-OpStore %232 %1633
-%1634 = OpLoad %_arr_uchar_uint_16 %170
-%1635 = OpCompositeExtract %uchar %1634 6
-OpStore %233 %1635
-%1636 = OpLoad %uchar %232
-%1637 = OpLoad %uchar %233
-%1638 = OpIAdd %uchar %1636 %1637
-OpStore %234 %1638
-%1639 = OpLoad %_arr_uchar_uint_16 %164
-%1640 = OpCompositeExtract %uchar %1639 7
-OpStore %235 %1640
-%1641 = OpLoad %_arr_uchar_uint_16 %170
-%1642 = OpCompositeExtract %uchar %1641 7
-OpStore %236 %1642
-%1643 = OpLoad %uchar %235
-%1644 = OpLoad %uchar %236
-%1645 = OpIAdd %uchar %1643 %1644
-OpStore %237 %1645
-%1646 = OpLoad %_arr_uchar_uint_16 %164
-%1647 = OpCompositeExtract %uchar %1646 8
-OpStore %238 %1647
-%1648 = OpLoad %_arr_uchar_uint_16 %170
-%1649 = OpCompositeExtract %uchar %1648 8
-OpStore %239 %1649
-%1650 = OpLoad %uchar %238
-%1651 = OpLoad %uchar %239
-%1652 = OpIAdd %uchar %1650 %1651
-OpStore %240 %1652
-%1653 = OpLoad %_arr_uchar_uint_16 %164
-%1654 = OpCompositeExtract %uchar %1653 9
-OpStore %241 %1654
-%1655 = OpLoad %_arr_uchar_uint_16 %170
-%1656 = OpCompositeExtract %uchar %1655 9
-OpStore %242 %1656
-%1657 = OpLoad %uchar %241
-%1658 = OpLoad %uchar %242
-%1659 = OpIAdd %uchar %1657 %1658
-OpStore %243 %1659
-%1660 = OpLoad %_arr_uchar_uint_16 %164
-%1661 = OpCompositeExtract %uchar %1660 10
-OpStore %244 %1661
-%1662 = OpLoad %_arr_uchar_uint_16 %170
-%1663 = OpCompositeExtract %uchar %1662 10
-OpStore %245 %1663
-%1664 = OpLoad %uchar %244
-%1665 = OpLoad %uchar %245
-%1666 = OpIAdd %uchar %1664 %1665
-OpStore %246 %1666
-%1667 = OpLoad %_arr_uchar_uint_16 %164
-%1668 = OpCompositeExtract %uchar %1667 11
-OpStore %247 %1668
-%1669 = OpLoad %_arr_uchar_uint_16 %170
-%1670 = OpCompositeExtract %uchar %1669 11
-OpStore %248 %1670
-%1671 = OpLoad %uchar %247
-%1672 = OpLoad %uchar %248
-%1673 = OpIAdd %uchar %1671 %1672
-OpStore %249 %1673
-%1674 = OpLoad %_arr_uchar_uint_16 %164
-%1675 = OpCompositeExtract %uchar %1674 12
-OpStore %250 %1675
-%1676 = OpLoad %_arr_uchar_uint_16 %170
-%1677 = OpCompositeExtract %uchar %1676 12
-OpStore %251 %1677
-%1678 = OpLoad %uchar %250
-%1679 = OpLoad %uchar %251
-%1680 = OpIAdd %uchar %1678 %1679
-OpStore %252 %1680
-%1681 = OpLoad %_arr_uchar_uint_16 %164
-%1682 = OpCompositeExtract %uchar %1681 13
-OpStore %253 %1682
-%1683 = OpLoad %_arr_uchar_uint_16 %170
-%1684 = OpCompositeExtract %uchar %1683 13
-OpStore %254 %1684
-%1685 = OpLoad %uchar %253
-%1686 = OpLoad %uchar %254
-%1687 = OpIAdd %uchar %1685 %1686
-OpStore %255 %1687
-%1688 = OpLoad %_arr_uchar_uint_16 %164
-%1689 = OpCompositeExtract %uchar %1688 14
-OpStore %256 %1689
-%1690 = OpLoad %_arr_uchar_uint_16 %170
-%1691 = OpCompositeExtract %uchar %1690 14
-OpStore %257 %1691
-%1692 = OpLoad %uchar %256
-%1693 = OpLoad %uchar %257
-%1694 = OpIAdd %uchar %1692 %1693
-OpStore %258 %1694
-%1695 = OpLoad %_arr_uchar_uint_16 %164
-%1696 = OpCompositeExtract %uchar %1695 15
-OpStore %259 %1696
-%1697 = OpLoad %_arr_uchar_uint_16 %170
-%1698 = OpCompositeExtract %uchar %1697 15
-OpStore %260 %1698
-%1699 = OpLoad %uchar %259
-%1700 = OpLoad %uchar %260
-%1701 = OpIAdd %uchar %1699 %1700
-OpStore %261 %1701
-%1702 = OpLoad %_arr_uchar_uint_16 %164
-%1703 = OpLoad %uchar %216
-%1704 = OpCompositeInsert %_arr_uchar_uint_16 %1703 %1702 0
-OpStore %262 %1704
-%1705 = OpLoad %_arr_uchar_uint_16 %262
-%1706 = OpLoad %uchar %219
-%1707 = OpCompositeInsert %_arr_uchar_uint_16 %1706 %1705 1
-OpStore %263 %1707
-%1708 = OpLoad %_arr_uchar_uint_16 %263
-%1709 = OpLoad %uchar %222
-%1710 = OpCompositeInsert %_arr_uchar_uint_16 %1709 %1708 2
-OpStore %264 %1710
-%1711 = OpLoad %_arr_uchar_uint_16 %264
-%1712 = OpLoad %uchar %225
-%1713 = OpCompositeInsert %_arr_uchar_uint_16 %1712 %1711 3
-OpStore %265 %1713
-%1714 = OpLoad %_arr_uchar_uint_16 %265
-%1715 = OpLoad %uchar %228
-%1716 = OpCompositeInsert %_arr_uchar_uint_16 %1715 %1714 4
-OpStore %266 %1716
-%1717 = OpLoad %_arr_uchar_uint_16 %266
-%1718 = OpLoad %uchar %231
-%1719 = OpCompositeInsert %_arr_uchar_uint_16 %1718 %1717 5
-OpStore %267 %1719
-%1720 = OpLoad %_arr_uchar_uint_16 %267
-%1721 = OpLoad %uchar %234
-%1722 = OpCompositeInsert %_arr_uchar_uint_16 %1721 %1720 6
-OpStore %268 %1722
-%1723 = OpLoad %_arr_uchar_uint_16 %268
-%1724 = OpLoad %uchar %237
-%1725 = OpCompositeInsert %_arr_uchar_uint_16 %1724 %1723 7
-OpStore %269 %1725
-%1726 = OpLoad %_arr_uchar_uint_16 %269
-%1727 = OpLoad %uchar %240
-%1728 = OpCompositeInsert %_arr_uchar_uint_16 %1727 %1726 8
-OpStore %270 %1728
-%1729 = OpLoad %_arr_uchar_uint_16 %270
-%1730 = OpLoad %uchar %243
-%1731 = OpCompositeInsert %_arr_uchar_uint_16 %1730 %1729 9
-OpStore %271 %1731
-%1732 = OpLoad %_arr_uchar_uint_16 %271
-%1733 = OpLoad %uchar %246
-%1734 = OpCompositeInsert %_arr_uchar_uint_16 %1733 %1732 10
-OpStore %272 %1734
-%1735 = OpLoad %_arr_uchar_uint_16 %272
-%1736 = OpLoad %uchar %249
-%1737 = OpCompositeInsert %_arr_uchar_uint_16 %1736 %1735 11
-OpStore %273 %1737
-%1738 = OpLoad %_arr_uchar_uint_16 %273
-%1739 = OpLoad %uchar %252
-%1740 = OpCompositeInsert %_arr_uchar_uint_16 %1739 %1738 12
-OpStore %274 %1740
-%1741 = OpLoad %_arr_uchar_uint_16 %274
-%1742 = OpLoad %uchar %255
-%1743 = OpCompositeInsert %_arr_uchar_uint_16 %1742 %1741 13
-OpStore %275 %1743
-%1744 = OpLoad %_arr_uchar_uint_16 %275
-%1745 = OpLoad %uchar %258
-%1746 = OpCompositeInsert %_arr_uchar_uint_16 %1745 %1744 14
-OpStore %276 %1746
-%1747 = OpLoad %_arr_uchar_uint_16 %276
-%1748 = OpLoad %uchar %261
-%1749 = OpCompositeInsert %_arr_uchar_uint_16 %1748 %1747 15
-OpStore %277 %1749
-%1750 = OpLoad %ulong %172
-%1751 = OpLoad %_arr_uchar_uint_16 %277
-%1752 = OpFunctionCall %ulong %1 %1750 %1751
-OpStore %173 %1752
-%1753 = OpLoad %_arr_uchar_uint_16 %164
-%1754 = OpCompositeExtract %uchar %1753 0
-OpStore %278 %1754
-%1755 = OpLoad %_arr_uchar_uint_16 %170
-%1756 = OpCompositeExtract %uchar %1755 0
-OpStore %279 %1756
-%1757 = OpLoad %uchar %278
-%1758 = OpLoad %uchar %279
-%1759 = OpISub %uchar %1757 %1758
-OpStore %280 %1759
-%1760 = OpLoad %_arr_uchar_uint_16 %164
-%1761 = OpCompositeExtract %uchar %1760 1
-OpStore %281 %1761
-%1762 = OpLoad %_arr_uchar_uint_16 %170
-%1763 = OpCompositeExtract %uchar %1762 1
-OpStore %282 %1763
-%1764 = OpLoad %uchar %281
-%1765 = OpLoad %uchar %282
-%1766 = OpISub %uchar %1764 %1765
-OpStore %283 %1766
-%1767 = OpLoad %_arr_uchar_uint_16 %164
-%1768 = OpCompositeExtract %uchar %1767 2
-OpStore %284 %1768
-%1769 = OpLoad %_arr_uchar_uint_16 %170
-%1770 = OpCompositeExtract %uchar %1769 2
-OpStore %285 %1770
-%1771 = OpLoad %uchar %284
-%1772 = OpLoad %uchar %285
-%1773 = OpISub %uchar %1771 %1772
-OpStore %286 %1773
-%1774 = OpLoad %_arr_uchar_uint_16 %164
-%1775 = OpCompositeExtract %uchar %1774 3
-OpStore %287 %1775
-%1776 = OpLoad %_arr_uchar_uint_16 %170
-%1777 = OpCompositeExtract %uchar %1776 3
-OpStore %288 %1777
-%1778 = OpLoad %uchar %287
-%1779 = OpLoad %uchar %288
-%1780 = OpISub %uchar %1778 %1779
-OpStore %289 %1780
-%1781 = OpLoad %_arr_uchar_uint_16 %164
-%1782 = OpCompositeExtract %uchar %1781 4
-OpStore %290 %1782
-%1783 = OpLoad %_arr_uchar_uint_16 %170
-%1784 = OpCompositeExtract %uchar %1783 4
-OpStore %291 %1784
-%1785 = OpLoad %uchar %290
-%1786 = OpLoad %uchar %291
-%1787 = OpISub %uchar %1785 %1786
-OpStore %292 %1787
-%1788 = OpLoad %_arr_uchar_uint_16 %164
-%1789 = OpCompositeExtract %uchar %1788 5
-OpStore %293 %1789
-%1790 = OpLoad %_arr_uchar_uint_16 %170
-%1791 = OpCompositeExtract %uchar %1790 5
-OpStore %294 %1791
-%1792 = OpLoad %uchar %293
-%1793 = OpLoad %uchar %294
-%1794 = OpISub %uchar %1792 %1793
-OpStore %295 %1794
-%1795 = OpLoad %_arr_uchar_uint_16 %164
-%1796 = OpCompositeExtract %uchar %1795 6
-OpStore %296 %1796
-%1797 = OpLoad %_arr_uchar_uint_16 %170
-%1798 = OpCompositeExtract %uchar %1797 6
-OpStore %297 %1798
-%1799 = OpLoad %uchar %296
-%1800 = OpLoad %uchar %297
-%1801 = OpISub %uchar %1799 %1800
-OpStore %298 %1801
-%1802 = OpLoad %_arr_uchar_uint_16 %164
-%1803 = OpCompositeExtract %uchar %1802 7
-OpStore %299 %1803
-%1804 = OpLoad %_arr_uchar_uint_16 %170
-%1805 = OpCompositeExtract %uchar %1804 7
-OpStore %300 %1805
-%1806 = OpLoad %uchar %299
-%1807 = OpLoad %uchar %300
-%1808 = OpISub %uchar %1806 %1807
-OpStore %301 %1808
-%1809 = OpLoad %_arr_uchar_uint_16 %164
-%1810 = OpCompositeExtract %uchar %1809 8
-OpStore %302 %1810
-%1811 = OpLoad %_arr_uchar_uint_16 %170
-%1812 = OpCompositeExtract %uchar %1811 8
-OpStore %303 %1812
-%1813 = OpLoad %uchar %302
-%1814 = OpLoad %uchar %303
-%1815 = OpISub %uchar %1813 %1814
-OpStore %304 %1815
-%1816 = OpLoad %_arr_uchar_uint_16 %164
-%1817 = OpCompositeExtract %uchar %1816 9
-OpStore %305 %1817
-%1818 = OpLoad %_arr_uchar_uint_16 %170
-%1819 = OpCompositeExtract %uchar %1818 9
-OpStore %306 %1819
-%1820 = OpLoad %uchar %305
-%1821 = OpLoad %uchar %306
-%1822 = OpISub %uchar %1820 %1821
-OpStore %307 %1822
-%1823 = OpLoad %_arr_uchar_uint_16 %164
-%1824 = OpCompositeExtract %uchar %1823 10
-OpStore %308 %1824
-%1825 = OpLoad %_arr_uchar_uint_16 %170
-%1826 = OpCompositeExtract %uchar %1825 10
-OpStore %309 %1826
-%1827 = OpLoad %uchar %308
-%1828 = OpLoad %uchar %309
-%1829 = OpISub %uchar %1827 %1828
-OpStore %310 %1829
-%1830 = OpLoad %_arr_uchar_uint_16 %164
-%1831 = OpCompositeExtract %uchar %1830 11
-OpStore %311 %1831
-%1832 = OpLoad %_arr_uchar_uint_16 %170
-%1833 = OpCompositeExtract %uchar %1832 11
-OpStore %312 %1833
-%1834 = OpLoad %uchar %311
-%1835 = OpLoad %uchar %312
-%1836 = OpISub %uchar %1834 %1835
-OpStore %313 %1836
-%1837 = OpLoad %_arr_uchar_uint_16 %164
-%1838 = OpCompositeExtract %uchar %1837 12
-OpStore %314 %1838
-%1839 = OpLoad %_arr_uchar_uint_16 %170
-%1840 = OpCompositeExtract %uchar %1839 12
-OpStore %315 %1840
-%1841 = OpLoad %uchar %314
-%1842 = OpLoad %uchar %315
-%1843 = OpISub %uchar %1841 %1842
-OpStore %316 %1843
-%1844 = OpLoad %_arr_uchar_uint_16 %164
-%1845 = OpCompositeExtract %uchar %1844 13
-OpStore %317 %1845
-%1846 = OpLoad %_arr_uchar_uint_16 %170
-%1847 = OpCompositeExtract %uchar %1846 13
-OpStore %318 %1847
-%1848 = OpLoad %uchar %317
-%1849 = OpLoad %uchar %318
-%1850 = OpISub %uchar %1848 %1849
-OpStore %319 %1850
-%1851 = OpLoad %_arr_uchar_uint_16 %164
-%1852 = OpCompositeExtract %uchar %1851 14
-OpStore %320 %1852
-%1853 = OpLoad %_arr_uchar_uint_16 %170
-%1854 = OpCompositeExtract %uchar %1853 14
-OpStore %321 %1854
-%1855 = OpLoad %uchar %320
-%1856 = OpLoad %uchar %321
-%1857 = OpISub %uchar %1855 %1856
-OpStore %322 %1857
-%1858 = OpLoad %_arr_uchar_uint_16 %164
-%1859 = OpCompositeExtract %uchar %1858 15
-OpStore %323 %1859
-%1860 = OpLoad %_arr_uchar_uint_16 %170
-%1861 = OpCompositeExtract %uchar %1860 15
-OpStore %324 %1861
-%1862 = OpLoad %uchar %323
-%1863 = OpLoad %uchar %324
-%1864 = OpISub %uchar %1862 %1863
-OpStore %325 %1864
-%1865 = OpLoad %_arr_uchar_uint_16 %164
-%1866 = OpLoad %uchar %280
-%1867 = OpCompositeInsert %_arr_uchar_uint_16 %1866 %1865 0
-OpStore %326 %1867
-%1868 = OpLoad %_arr_uchar_uint_16 %326
-%1869 = OpLoad %uchar %283
-%1870 = OpCompositeInsert %_arr_uchar_uint_16 %1869 %1868 1
-OpStore %327 %1870
-%1871 = OpLoad %_arr_uchar_uint_16 %327
-%1872 = OpLoad %uchar %286
-%1873 = OpCompositeInsert %_arr_uchar_uint_16 %1872 %1871 2
-OpStore %328 %1873
-%1874 = OpLoad %_arr_uchar_uint_16 %328
-%1875 = OpLoad %uchar %289
-%1876 = OpCompositeInsert %_arr_uchar_uint_16 %1875 %1874 3
-OpStore %329 %1876
-%1877 = OpLoad %_arr_uchar_uint_16 %329
-%1878 = OpLoad %uchar %292
-%1879 = OpCompositeInsert %_arr_uchar_uint_16 %1878 %1877 4
-OpStore %330 %1879
-%1880 = OpLoad %_arr_uchar_uint_16 %330
-%1881 = OpLoad %uchar %295
-%1882 = OpCompositeInsert %_arr_uchar_uint_16 %1881 %1880 5
-OpStore %331 %1882
-%1883 = OpLoad %_arr_uchar_uint_16 %331
-%1884 = OpLoad %uchar %298
-%1885 = OpCompositeInsert %_arr_uchar_uint_16 %1884 %1883 6
-OpStore %332 %1885
-%1886 = OpLoad %_arr_uchar_uint_16 %332
-%1887 = OpLoad %uchar %301
-%1888 = OpCompositeInsert %_arr_uchar_uint_16 %1887 %1886 7
-OpStore %333 %1888
-%1889 = OpLoad %_arr_uchar_uint_16 %333
-%1890 = OpLoad %uchar %304
-%1891 = OpCompositeInsert %_arr_uchar_uint_16 %1890 %1889 8
-OpStore %334 %1891
-%1892 = OpLoad %_arr_uchar_uint_16 %334
-%1893 = OpLoad %uchar %307
-%1894 = OpCompositeInsert %_arr_uchar_uint_16 %1893 %1892 9
-OpStore %335 %1894
-%1895 = OpLoad %_arr_uchar_uint_16 %335
-%1896 = OpLoad %uchar %310
-%1897 = OpCompositeInsert %_arr_uchar_uint_16 %1896 %1895 10
-OpStore %336 %1897
-%1898 = OpLoad %_arr_uchar_uint_16 %336
-%1899 = OpLoad %uchar %313
-%1900 = OpCompositeInsert %_arr_uchar_uint_16 %1899 %1898 11
-OpStore %337 %1900
-%1901 = OpLoad %_arr_uchar_uint_16 %337
-%1902 = OpLoad %uchar %316
-%1903 = OpCompositeInsert %_arr_uchar_uint_16 %1902 %1901 12
-OpStore %338 %1903
-%1904 = OpLoad %_arr_uchar_uint_16 %338
-%1905 = OpLoad %uchar %319
-%1906 = OpCompositeInsert %_arr_uchar_uint_16 %1905 %1904 13
-OpStore %339 %1906
-%1907 = OpLoad %_arr_uchar_uint_16 %339
-%1908 = OpLoad %uchar %322
-%1909 = OpCompositeInsert %_arr_uchar_uint_16 %1908 %1907 14
-OpStore %340 %1909
-%1910 = OpLoad %_arr_uchar_uint_16 %340
-%1911 = OpLoad %uchar %325
-%1912 = OpCompositeInsert %_arr_uchar_uint_16 %1911 %1910 15
-OpStore %341 %1912
-%1913 = OpLoad %ulong %173
-%1914 = OpLoad %_arr_uchar_uint_16 %341
-%1915 = OpFunctionCall %ulong %1 %1913 %1914
-OpStore %174 %1915
-%1916 = OpLoad %_arr_uchar_uint_16 %170
-%1917 = OpCompositeExtract %uchar %1916 0
-OpStore %342 %1917
-%1918 = OpLoad %_arr_uchar_uint_16 %164
-%1919 = OpCompositeExtract %uchar %1918 0
-OpStore %343 %1919
-%1920 = OpLoad %uchar %342
-%1921 = OpLoad %uchar %343
-%1922 = OpISub %uchar %1920 %1921
-OpStore %344 %1922
-%1923 = OpLoad %_arr_uchar_uint_16 %170
-%1924 = OpCompositeExtract %uchar %1923 1
-OpStore %345 %1924
-%1925 = OpLoad %_arr_uchar_uint_16 %164
-%1926 = OpCompositeExtract %uchar %1925 1
-OpStore %346 %1926
-%1927 = OpLoad %uchar %345
-%1928 = OpLoad %uchar %346
-%1929 = OpISub %uchar %1927 %1928
-OpStore %347 %1929
-%1930 = OpLoad %_arr_uchar_uint_16 %170
-%1931 = OpCompositeExtract %uchar %1930 2
-OpStore %348 %1931
-%1932 = OpLoad %_arr_uchar_uint_16 %164
-%1933 = OpCompositeExtract %uchar %1932 2
-OpStore %349 %1933
-%1934 = OpLoad %uchar %348
-%1935 = OpLoad %uchar %349
-%1936 = OpISub %uchar %1934 %1935
-OpStore %350 %1936
-%1937 = OpLoad %_arr_uchar_uint_16 %170
-%1938 = OpCompositeExtract %uchar %1937 3
-OpStore %351 %1938
-%1939 = OpLoad %_arr_uchar_uint_16 %164
-%1940 = OpCompositeExtract %uchar %1939 3
-OpStore %352 %1940
-%1941 = OpLoad %uchar %351
-%1942 = OpLoad %uchar %352
-%1943 = OpISub %uchar %1941 %1942
-OpStore %353 %1943
-%1944 = OpLoad %_arr_uchar_uint_16 %170
-%1945 = OpCompositeExtract %uchar %1944 4
-OpStore %354 %1945
-%1946 = OpLoad %_arr_uchar_uint_16 %164
-%1947 = OpCompositeExtract %uchar %1946 4
-OpStore %355 %1947
-%1948 = OpLoad %uchar %354
-%1949 = OpLoad %uchar %355
-%1950 = OpISub %uchar %1948 %1949
-OpStore %356 %1950
-%1951 = OpLoad %_arr_uchar_uint_16 %170
-%1952 = OpCompositeExtract %uchar %1951 5
-OpStore %357 %1952
-%1953 = OpLoad %_arr_uchar_uint_16 %164
-%1954 = OpCompositeExtract %uchar %1953 5
-OpStore %358 %1954
-%1955 = OpLoad %uchar %357
-%1956 = OpLoad %uchar %358
-%1957 = OpISub %uchar %1955 %1956
-OpStore %359 %1957
-%1958 = OpLoad %_arr_uchar_uint_16 %170
-%1959 = OpCompositeExtract %uchar %1958 6
-OpStore %360 %1959
-%1960 = OpLoad %_arr_uchar_uint_16 %164
-%1961 = OpCompositeExtract %uchar %1960 6
-OpStore %361 %1961
-%1962 = OpLoad %uchar %360
-%1963 = OpLoad %uchar %361
-%1964 = OpISub %uchar %1962 %1963
-OpStore %362 %1964
-%1965 = OpLoad %_arr_uchar_uint_16 %170
-%1966 = OpCompositeExtract %uchar %1965 7
-OpStore %363 %1966
-%1967 = OpLoad %_arr_uchar_uint_16 %164
-%1968 = OpCompositeExtract %uchar %1967 7
-OpStore %364 %1968
-%1969 = OpLoad %uchar %363
-%1970 = OpLoad %uchar %364
-%1971 = OpISub %uchar %1969 %1970
-OpStore %365 %1971
-%1972 = OpLoad %_arr_uchar_uint_16 %170
-%1973 = OpCompositeExtract %uchar %1972 8
-OpStore %366 %1973
-%1974 = OpLoad %_arr_uchar_uint_16 %164
-%1975 = OpCompositeExtract %uchar %1974 8
-OpStore %367 %1975
-%1976 = OpLoad %uchar %366
-%1977 = OpLoad %uchar %367
-%1978 = OpISub %uchar %1976 %1977
-OpStore %368 %1978
-%1979 = OpLoad %_arr_uchar_uint_16 %170
-%1980 = OpCompositeExtract %uchar %1979 9
-OpStore %369 %1980
-%1981 = OpLoad %_arr_uchar_uint_16 %164
-%1982 = OpCompositeExtract %uchar %1981 9
-OpStore %370 %1982
-%1983 = OpLoad %uchar %369
-%1984 = OpLoad %uchar %370
-%1985 = OpISub %uchar %1983 %1984
-OpStore %371 %1985
-%1986 = OpLoad %_arr_uchar_uint_16 %170
-%1987 = OpCompositeExtract %uchar %1986 10
-OpStore %372 %1987
-%1988 = OpLoad %_arr_uchar_uint_16 %164
-%1989 = OpCompositeExtract %uchar %1988 10
-OpStore %373 %1989
-%1990 = OpLoad %uchar %372
-%1991 = OpLoad %uchar %373
-%1992 = OpISub %uchar %1990 %1991
-OpStore %374 %1992
-%1993 = OpLoad %_arr_uchar_uint_16 %170
-%1994 = OpCompositeExtract %uchar %1993 11
-OpStore %375 %1994
-%1995 = OpLoad %_arr_uchar_uint_16 %164
-%1996 = OpCompositeExtract %uchar %1995 11
-OpStore %376 %1996
-%1997 = OpLoad %uchar %375
-%1998 = OpLoad %uchar %376
-%1999 = OpISub %uchar %1997 %1998
-OpStore %377 %1999
-%2000 = OpLoad %_arr_uchar_uint_16 %170
-%2001 = OpCompositeExtract %uchar %2000 12
-OpStore %378 %2001
-%2002 = OpLoad %_arr_uchar_uint_16 %164
-%2003 = OpCompositeExtract %uchar %2002 12
-OpStore %379 %2003
-%2004 = OpLoad %uchar %378
-%2005 = OpLoad %uchar %379
-%2006 = OpISub %uchar %2004 %2005
-OpStore %380 %2006
-%2007 = OpLoad %_arr_uchar_uint_16 %170
-%2008 = OpCompositeExtract %uchar %2007 13
-OpStore %381 %2008
-%2009 = OpLoad %_arr_uchar_uint_16 %164
-%2010 = OpCompositeExtract %uchar %2009 13
-OpStore %382 %2010
-%2011 = OpLoad %uchar %381
-%2012 = OpLoad %uchar %382
-%2013 = OpISub %uchar %2011 %2012
-OpStore %383 %2013
-%2014 = OpLoad %_arr_uchar_uint_16 %170
-%2015 = OpCompositeExtract %uchar %2014 14
-OpStore %384 %2015
-%2016 = OpLoad %_arr_uchar_uint_16 %164
-%2017 = OpCompositeExtract %uchar %2016 14
-OpStore %385 %2017
-%2018 = OpLoad %uchar %384
-%2019 = OpLoad %uchar %385
-%2020 = OpISub %uchar %2018 %2019
-OpStore %386 %2020
-%2021 = OpLoad %_arr_uchar_uint_16 %170
-%2022 = OpCompositeExtract %uchar %2021 15
-OpStore %387 %2022
-%2023 = OpLoad %_arr_uchar_uint_16 %164
-%2024 = OpCompositeExtract %uchar %2023 15
-OpStore %388 %2024
-%2025 = OpLoad %uchar %387
-%2026 = OpLoad %uchar %388
-%2027 = OpISub %uchar %2025 %2026
-OpStore %389 %2027
-%2028 = OpLoad %_arr_uchar_uint_16 %170
-%2029 = OpLoad %uchar %344
-%2030 = OpCompositeInsert %_arr_uchar_uint_16 %2029 %2028 0
-OpStore %390 %2030
-%2031 = OpLoad %_arr_uchar_uint_16 %390
-%2032 = OpLoad %uchar %347
-%2033 = OpCompositeInsert %_arr_uchar_uint_16 %2032 %2031 1
-OpStore %391 %2033
-%2034 = OpLoad %_arr_uchar_uint_16 %391
-%2035 = OpLoad %uchar %350
-%2036 = OpCompositeInsert %_arr_uchar_uint_16 %2035 %2034 2
-OpStore %392 %2036
-%2037 = OpLoad %_arr_uchar_uint_16 %392
-%2038 = OpLoad %uchar %353
-%2039 = OpCompositeInsert %_arr_uchar_uint_16 %2038 %2037 3
-OpStore %393 %2039
-%2040 = OpLoad %_arr_uchar_uint_16 %393
-%2041 = OpLoad %uchar %356
-%2042 = OpCompositeInsert %_arr_uchar_uint_16 %2041 %2040 4
-OpStore %394 %2042
-%2043 = OpLoad %_arr_uchar_uint_16 %394
-%2044 = OpLoad %uchar %359
-%2045 = OpCompositeInsert %_arr_uchar_uint_16 %2044 %2043 5
-OpStore %395 %2045
-%2046 = OpLoad %_arr_uchar_uint_16 %395
-%2047 = OpLoad %uchar %362
-%2048 = OpCompositeInsert %_arr_uchar_uint_16 %2047 %2046 6
-OpStore %396 %2048
-%2049 = OpLoad %_arr_uchar_uint_16 %396
-%2050 = OpLoad %uchar %365
-%2051 = OpCompositeInsert %_arr_uchar_uint_16 %2050 %2049 7
-OpStore %397 %2051
-%2052 = OpLoad %_arr_uchar_uint_16 %397
-%2053 = OpLoad %uchar %368
-%2054 = OpCompositeInsert %_arr_uchar_uint_16 %2053 %2052 8
-OpStore %398 %2054
-%2055 = OpLoad %_arr_uchar_uint_16 %398
-%2056 = OpLoad %uchar %371
-%2057 = OpCompositeInsert %_arr_uchar_uint_16 %2056 %2055 9
-OpStore %399 %2057
-%2058 = OpLoad %_arr_uchar_uint_16 %399
-%2059 = OpLoad %uchar %374
-%2060 = OpCompositeInsert %_arr_uchar_uint_16 %2059 %2058 10
-OpStore %400 %2060
-%2061 = OpLoad %_arr_uchar_uint_16 %400
-%2062 = OpLoad %uchar %377
-%2063 = OpCompositeInsert %_arr_uchar_uint_16 %2062 %2061 11
-OpStore %401 %2063
-%2064 = OpLoad %_arr_uchar_uint_16 %401
-%2065 = OpLoad %uchar %380
-%2066 = OpCompositeInsert %_arr_uchar_uint_16 %2065 %2064 12
-OpStore %402 %2066
-%2067 = OpLoad %_arr_uchar_uint_16 %402
-%2068 = OpLoad %uchar %383
-%2069 = OpCompositeInsert %_arr_uchar_uint_16 %2068 %2067 13
-OpStore %403 %2069
-%2070 = OpLoad %_arr_uchar_uint_16 %403
-%2071 = OpLoad %uchar %386
-%2072 = OpCompositeInsert %_arr_uchar_uint_16 %2071 %2070 14
-OpStore %404 %2072
-%2073 = OpLoad %_arr_uchar_uint_16 %404
-%2074 = OpLoad %uchar %389
-%2075 = OpCompositeInsert %_arr_uchar_uint_16 %2074 %2073 15
-OpStore %405 %2075
-%2076 = OpLoad %ulong %174
-%2077 = OpLoad %_arr_uchar_uint_16 %405
-%2078 = OpFunctionCall %ulong %1 %2076 %2077
-OpStore %175 %2078
-%2079 = OpLoad %_arr_uchar_uint_16 %164
-%2080 = OpCompositeExtract %uchar %2079 0
-OpStore %406 %2080
-%2081 = OpLoad %_arr_uchar_uint_16 %170
-%2082 = OpCompositeExtract %uchar %2081 0
-OpStore %407 %2082
-%2083 = OpLoad %uchar %406
-%2084 = OpLoad %uchar %407
-%2085 = OpIMul %uchar %2083 %2084
-OpStore %408 %2085
-%2086 = OpLoad %_arr_uchar_uint_16 %164
-%2087 = OpCompositeExtract %uchar %2086 1
-OpStore %409 %2087
-%2088 = OpLoad %_arr_uchar_uint_16 %170
-%2089 = OpCompositeExtract %uchar %2088 1
-OpStore %410 %2089
-%2090 = OpLoad %uchar %409
-%2091 = OpLoad %uchar %410
-%2092 = OpIMul %uchar %2090 %2091
-OpStore %411 %2092
-%2093 = OpLoad %_arr_uchar_uint_16 %164
-%2094 = OpCompositeExtract %uchar %2093 2
-OpStore %412 %2094
-%2095 = OpLoad %_arr_uchar_uint_16 %170
-%2096 = OpCompositeExtract %uchar %2095 2
-OpStore %413 %2096
-%2097 = OpLoad %uchar %412
-%2098 = OpLoad %uchar %413
-%2099 = OpIMul %uchar %2097 %2098
-OpStore %414 %2099
-%2100 = OpLoad %_arr_uchar_uint_16 %164
-%2101 = OpCompositeExtract %uchar %2100 3
-OpStore %415 %2101
-%2102 = OpLoad %_arr_uchar_uint_16 %170
-%2103 = OpCompositeExtract %uchar %2102 3
-OpStore %416 %2103
-%2104 = OpLoad %uchar %415
-%2105 = OpLoad %uchar %416
-%2106 = OpIMul %uchar %2104 %2105
-OpStore %417 %2106
-%2107 = OpLoad %_arr_uchar_uint_16 %164
-%2108 = OpCompositeExtract %uchar %2107 4
-OpStore %418 %2108
-%2109 = OpLoad %_arr_uchar_uint_16 %170
-%2110 = OpCompositeExtract %uchar %2109 4
-OpStore %419 %2110
-%2111 = OpLoad %uchar %418
-%2112 = OpLoad %uchar %419
-%2113 = OpIMul %uchar %2111 %2112
-OpStore %420 %2113
-%2114 = OpLoad %_arr_uchar_uint_16 %164
-%2115 = OpCompositeExtract %uchar %2114 5
-OpStore %421 %2115
-%2116 = OpLoad %_arr_uchar_uint_16 %170
-%2117 = OpCompositeExtract %uchar %2116 5
-OpStore %422 %2117
-%2118 = OpLoad %uchar %421
-%2119 = OpLoad %uchar %422
-%2120 = OpIMul %uchar %2118 %2119
-OpStore %423 %2120
-%2121 = OpLoad %_arr_uchar_uint_16 %164
-%2122 = OpCompositeExtract %uchar %2121 6
-OpStore %424 %2122
-%2123 = OpLoad %_arr_uchar_uint_16 %170
-%2124 = OpCompositeExtract %uchar %2123 6
-OpStore %425 %2124
-%2125 = OpLoad %uchar %424
-%2126 = OpLoad %uchar %425
-%2127 = OpIMul %uchar %2125 %2126
-OpStore %426 %2127
-%2128 = OpLoad %_arr_uchar_uint_16 %164
-%2129 = OpCompositeExtract %uchar %2128 7
-OpStore %427 %2129
-%2130 = OpLoad %_arr_uchar_uint_16 %170
-%2131 = OpCompositeExtract %uchar %2130 7
-OpStore %428 %2131
-%2132 = OpLoad %uchar %427
-%2133 = OpLoad %uchar %428
-%2134 = OpIMul %uchar %2132 %2133
-OpStore %429 %2134
-%2135 = OpLoad %_arr_uchar_uint_16 %164
-%2136 = OpCompositeExtract %uchar %2135 8
-OpStore %430 %2136
-%2137 = OpLoad %_arr_uchar_uint_16 %170
-%2138 = OpCompositeExtract %uchar %2137 8
-OpStore %431 %2138
-%2139 = OpLoad %uchar %430
-%2140 = OpLoad %uchar %431
-%2141 = OpIMul %uchar %2139 %2140
-OpStore %432 %2141
-%2142 = OpLoad %_arr_uchar_uint_16 %164
-%2143 = OpCompositeExtract %uchar %2142 9
-OpStore %433 %2143
-%2144 = OpLoad %_arr_uchar_uint_16 %170
-%2145 = OpCompositeExtract %uchar %2144 9
-OpStore %434 %2145
-%2146 = OpLoad %uchar %433
-%2147 = OpLoad %uchar %434
-%2148 = OpIMul %uchar %2146 %2147
-OpStore %435 %2148
-%2149 = OpLoad %_arr_uchar_uint_16 %164
-%2150 = OpCompositeExtract %uchar %2149 10
-OpStore %436 %2150
-%2151 = OpLoad %_arr_uchar_uint_16 %170
-%2152 = OpCompositeExtract %uchar %2151 10
-OpStore %437 %2152
-%2153 = OpLoad %uchar %436
-%2154 = OpLoad %uchar %437
-%2155 = OpIMul %uchar %2153 %2154
-OpStore %438 %2155
-%2156 = OpLoad %_arr_uchar_uint_16 %164
-%2157 = OpCompositeExtract %uchar %2156 11
-OpStore %439 %2157
-%2158 = OpLoad %_arr_uchar_uint_16 %170
-%2159 = OpCompositeExtract %uchar %2158 11
-OpStore %440 %2159
-%2160 = OpLoad %uchar %439
-%2161 = OpLoad %uchar %440
-%2162 = OpIMul %uchar %2160 %2161
-OpStore %441 %2162
-%2163 = OpLoad %_arr_uchar_uint_16 %164
-%2164 = OpCompositeExtract %uchar %2163 12
-OpStore %442 %2164
-%2165 = OpLoad %_arr_uchar_uint_16 %170
-%2166 = OpCompositeExtract %uchar %2165 12
-OpStore %443 %2166
-%2167 = OpLoad %uchar %442
-%2168 = OpLoad %uchar %443
-%2169 = OpIMul %uchar %2167 %2168
-OpStore %444 %2169
-%2170 = OpLoad %_arr_uchar_uint_16 %164
-%2171 = OpCompositeExtract %uchar %2170 13
-OpStore %445 %2171
-%2172 = OpLoad %_arr_uchar_uint_16 %170
-%2173 = OpCompositeExtract %uchar %2172 13
-OpStore %446 %2173
-%2174 = OpLoad %uchar %445
-%2175 = OpLoad %uchar %446
-%2176 = OpIMul %uchar %2174 %2175
-OpStore %447 %2176
-%2177 = OpLoad %_arr_uchar_uint_16 %164
-%2178 = OpCompositeExtract %uchar %2177 14
-OpStore %448 %2178
-%2179 = OpLoad %_arr_uchar_uint_16 %170
-%2180 = OpCompositeExtract %uchar %2179 14
-OpStore %449 %2180
-%2181 = OpLoad %uchar %448
-%2182 = OpLoad %uchar %449
-%2183 = OpIMul %uchar %2181 %2182
-OpStore %450 %2183
-%2184 = OpLoad %_arr_uchar_uint_16 %164
-%2185 = OpCompositeExtract %uchar %2184 15
-OpStore %451 %2185
-%2186 = OpLoad %_arr_uchar_uint_16 %170
-%2187 = OpCompositeExtract %uchar %2186 15
-OpStore %452 %2187
-%2188 = OpLoad %uchar %451
-%2189 = OpLoad %uchar %452
-%2190 = OpIMul %uchar %2188 %2189
-OpStore %453 %2190
-%2191 = OpLoad %_arr_uchar_uint_16 %164
-%2192 = OpLoad %uchar %408
-%2193 = OpCompositeInsert %_arr_uchar_uint_16 %2192 %2191 0
-OpStore %454 %2193
-%2194 = OpLoad %_arr_uchar_uint_16 %454
-%2195 = OpLoad %uchar %411
-%2196 = OpCompositeInsert %_arr_uchar_uint_16 %2195 %2194 1
-OpStore %455 %2196
-%2197 = OpLoad %_arr_uchar_uint_16 %455
-%2198 = OpLoad %uchar %414
-%2199 = OpCompositeInsert %_arr_uchar_uint_16 %2198 %2197 2
-OpStore %456 %2199
-%2200 = OpLoad %_arr_uchar_uint_16 %456
-%2201 = OpLoad %uchar %417
-%2202 = OpCompositeInsert %_arr_uchar_uint_16 %2201 %2200 3
-OpStore %457 %2202
-%2203 = OpLoad %_arr_uchar_uint_16 %457
-%2204 = OpLoad %uchar %420
-%2205 = OpCompositeInsert %_arr_uchar_uint_16 %2204 %2203 4
-OpStore %458 %2205
-%2206 = OpLoad %_arr_uchar_uint_16 %458
-%2207 = OpLoad %uchar %423
-%2208 = OpCompositeInsert %_arr_uchar_uint_16 %2207 %2206 5
-OpStore %459 %2208
-%2209 = OpLoad %_arr_uchar_uint_16 %459
-%2210 = OpLoad %uchar %426
-%2211 = OpCompositeInsert %_arr_uchar_uint_16 %2210 %2209 6
-OpStore %460 %2211
-%2212 = OpLoad %_arr_uchar_uint_16 %460
-%2213 = OpLoad %uchar %429
-%2214 = OpCompositeInsert %_arr_uchar_uint_16 %2213 %2212 7
-OpStore %461 %2214
-%2215 = OpLoad %_arr_uchar_uint_16 %461
-%2216 = OpLoad %uchar %432
-%2217 = OpCompositeInsert %_arr_uchar_uint_16 %2216 %2215 8
-OpStore %462 %2217
-%2218 = OpLoad %_arr_uchar_uint_16 %462
-%2219 = OpLoad %uchar %435
-%2220 = OpCompositeInsert %_arr_uchar_uint_16 %2219 %2218 9
-OpStore %463 %2220
-%2221 = OpLoad %_arr_uchar_uint_16 %463
-%2222 = OpLoad %uchar %438
-%2223 = OpCompositeInsert %_arr_uchar_uint_16 %2222 %2221 10
-OpStore %464 %2223
-%2224 = OpLoad %_arr_uchar_uint_16 %464
-%2225 = OpLoad %uchar %441
-%2226 = OpCompositeInsert %_arr_uchar_uint_16 %2225 %2224 11
-OpStore %465 %2226
-%2227 = OpLoad %_arr_uchar_uint_16 %465
-%2228 = OpLoad %uchar %444
-%2229 = OpCompositeInsert %_arr_uchar_uint_16 %2228 %2227 12
-OpStore %466 %2229
-%2230 = OpLoad %_arr_uchar_uint_16 %466
-%2231 = OpLoad %uchar %447
-%2232 = OpCompositeInsert %_arr_uchar_uint_16 %2231 %2230 13
-OpStore %467 %2232
-%2233 = OpLoad %_arr_uchar_uint_16 %467
-%2234 = OpLoad %uchar %450
-%2235 = OpCompositeInsert %_arr_uchar_uint_16 %2234 %2233 14
-OpStore %468 %2235
-%2236 = OpLoad %_arr_uchar_uint_16 %468
-%2237 = OpLoad %uchar %453
-%2238 = OpCompositeInsert %_arr_uchar_uint_16 %2237 %2236 15
-OpStore %469 %2238
-%2239 = OpLoad %ulong %175
-%2240 = OpLoad %_arr_uchar_uint_16 %469
-%2241 = OpFunctionCall %ulong %1 %2239 %2240
-OpStore %176 %2241
-%2242 = OpLoad %_arr_uchar_uint_16 %164
-%2243 = OpCompositeExtract %uchar %2242 0
-OpStore %470 %2243
-%2244 = OpLoad %_arr_uchar_uint_16 %157
-%2245 = OpCompositeExtract %uchar %2244 0
-OpStore %471 %2245
-%2246 = OpLoad %uchar %470
-%2247 = OpLoad %uchar %471
-%2248 = OpIMul %uchar %2246 %2247
-OpStore %472 %2248
-%2249 = OpLoad %_arr_uchar_uint_16 %164
-%2250 = OpCompositeExtract %uchar %2249 1
-OpStore %473 %2250
-%2251 = OpLoad %_arr_uchar_uint_16 %157
-%2252 = OpCompositeExtract %uchar %2251 1
-OpStore %474 %2252
-%2253 = OpLoad %uchar %473
-%2254 = OpLoad %uchar %474
-%2255 = OpIMul %uchar %2253 %2254
-OpStore %475 %2255
-%2256 = OpLoad %_arr_uchar_uint_16 %164
-%2257 = OpCompositeExtract %uchar %2256 2
-OpStore %476 %2257
-%2258 = OpLoad %_arr_uchar_uint_16 %157
-%2259 = OpCompositeExtract %uchar %2258 2
-OpStore %477 %2259
-%2260 = OpLoad %uchar %476
-%2261 = OpLoad %uchar %477
-%2262 = OpIMul %uchar %2260 %2261
-OpStore %478 %2262
-%2263 = OpLoad %_arr_uchar_uint_16 %164
-%2264 = OpCompositeExtract %uchar %2263 3
-OpStore %479 %2264
-%2265 = OpLoad %_arr_uchar_uint_16 %157
-%2266 = OpCompositeExtract %uchar %2265 3
-OpStore %480 %2266
-%2267 = OpLoad %uchar %479
-%2268 = OpLoad %uchar %480
-%2269 = OpIMul %uchar %2267 %2268
-OpStore %481 %2269
-%2270 = OpLoad %_arr_uchar_uint_16 %164
-%2271 = OpCompositeExtract %uchar %2270 4
-OpStore %482 %2271
-%2272 = OpLoad %_arr_uchar_uint_16 %157
-%2273 = OpCompositeExtract %uchar %2272 4
-OpStore %483 %2273
-%2274 = OpLoad %uchar %482
-%2275 = OpLoad %uchar %483
-%2276 = OpIMul %uchar %2274 %2275
-OpStore %484 %2276
-%2277 = OpLoad %_arr_uchar_uint_16 %164
-%2278 = OpCompositeExtract %uchar %2277 5
-OpStore %485 %2278
-%2279 = OpLoad %_arr_uchar_uint_16 %157
-%2280 = OpCompositeExtract %uchar %2279 5
-OpStore %486 %2280
-%2281 = OpLoad %uchar %485
-%2282 = OpLoad %uchar %486
-%2283 = OpIMul %uchar %2281 %2282
-OpStore %487 %2283
-%2284 = OpLoad %_arr_uchar_uint_16 %164
-%2285 = OpCompositeExtract %uchar %2284 6
-OpStore %488 %2285
-%2286 = OpLoad %_arr_uchar_uint_16 %157
-%2287 = OpCompositeExtract %uchar %2286 6
-OpStore %489 %2287
-%2288 = OpLoad %uchar %488
-%2289 = OpLoad %uchar %489
-%2290 = OpIMul %uchar %2288 %2289
-OpStore %490 %2290
-%2291 = OpLoad %_arr_uchar_uint_16 %164
-%2292 = OpCompositeExtract %uchar %2291 7
-OpStore %491 %2292
-%2293 = OpLoad %_arr_uchar_uint_16 %157
-%2294 = OpCompositeExtract %uchar %2293 7
-OpStore %492 %2294
-%2295 = OpLoad %uchar %491
-%2296 = OpLoad %uchar %492
-%2297 = OpIMul %uchar %2295 %2296
-OpStore %493 %2297
-%2298 = OpLoad %_arr_uchar_uint_16 %164
-%2299 = OpCompositeExtract %uchar %2298 8
-OpStore %494 %2299
-%2300 = OpLoad %_arr_uchar_uint_16 %157
-%2301 = OpCompositeExtract %uchar %2300 8
-OpStore %495 %2301
-%2302 = OpLoad %uchar %494
-%2303 = OpLoad %uchar %495
-%2304 = OpIMul %uchar %2302 %2303
-OpStore %496 %2304
-%2305 = OpLoad %_arr_uchar_uint_16 %164
-%2306 = OpCompositeExtract %uchar %2305 9
-OpStore %497 %2306
-%2307 = OpLoad %_arr_uchar_uint_16 %157
-%2308 = OpCompositeExtract %uchar %2307 9
-OpStore %498 %2308
-%2309 = OpLoad %uchar %497
-%2310 = OpLoad %uchar %498
-%2311 = OpIMul %uchar %2309 %2310
-OpStore %499 %2311
-%2312 = OpLoad %_arr_uchar_uint_16 %164
-%2313 = OpCompositeExtract %uchar %2312 10
-OpStore %500 %2313
-%2314 = OpLoad %_arr_uchar_uint_16 %157
-%2315 = OpCompositeExtract %uchar %2314 10
-OpStore %501 %2315
-%2316 = OpLoad %uchar %500
-%2317 = OpLoad %uchar %501
-%2318 = OpIMul %uchar %2316 %2317
-OpStore %502 %2318
-%2319 = OpLoad %_arr_uchar_uint_16 %164
-%2320 = OpCompositeExtract %uchar %2319 11
-OpStore %503 %2320
-%2321 = OpLoad %_arr_uchar_uint_16 %157
-%2322 = OpCompositeExtract %uchar %2321 11
-OpStore %504 %2322
-%2323 = OpLoad %uchar %503
-%2324 = OpLoad %uchar %504
-%2325 = OpIMul %uchar %2323 %2324
-OpStore %505 %2325
-%2326 = OpLoad %_arr_uchar_uint_16 %164
-%2327 = OpCompositeExtract %uchar %2326 12
-OpStore %506 %2327
-%2328 = OpLoad %_arr_uchar_uint_16 %157
-%2329 = OpCompositeExtract %uchar %2328 12
-OpStore %507 %2329
-%2330 = OpLoad %uchar %506
-%2331 = OpLoad %uchar %507
-%2332 = OpIMul %uchar %2330 %2331
-OpStore %508 %2332
-%2333 = OpLoad %_arr_uchar_uint_16 %164
-%2334 = OpCompositeExtract %uchar %2333 13
-OpStore %509 %2334
-%2335 = OpLoad %_arr_uchar_uint_16 %157
-%2336 = OpCompositeExtract %uchar %2335 13
-OpStore %510 %2336
-%2337 = OpLoad %uchar %509
-%2338 = OpLoad %uchar %510
-%2339 = OpIMul %uchar %2337 %2338
-OpStore %511 %2339
-%2340 = OpLoad %_arr_uchar_uint_16 %164
-%2341 = OpCompositeExtract %uchar %2340 14
-OpStore %512 %2341
-%2342 = OpLoad %_arr_uchar_uint_16 %157
-%2343 = OpCompositeExtract %uchar %2342 14
-OpStore %513 %2343
-%2344 = OpLoad %uchar %512
-%2345 = OpLoad %uchar %513
-%2346 = OpIMul %uchar %2344 %2345
-OpStore %514 %2346
-%2347 = OpLoad %_arr_uchar_uint_16 %164
-%2348 = OpCompositeExtract %uchar %2347 15
-OpStore %515 %2348
-%2349 = OpLoad %_arr_uchar_uint_16 %157
-%2350 = OpCompositeExtract %uchar %2349 15
-OpStore %516 %2350
-%2351 = OpLoad %uchar %515
-%2352 = OpLoad %uchar %516
-%2353 = OpIMul %uchar %2351 %2352
-OpStore %517 %2353
-%2354 = OpLoad %_arr_uchar_uint_16 %164
-%2355 = OpLoad %uchar %472
-%2356 = OpCompositeInsert %_arr_uchar_uint_16 %2355 %2354 0
-OpStore %518 %2356
-%2357 = OpLoad %_arr_uchar_uint_16 %518
-%2358 = OpLoad %uchar %475
-%2359 = OpCompositeInsert %_arr_uchar_uint_16 %2358 %2357 1
-OpStore %519 %2359
-%2360 = OpLoad %_arr_uchar_uint_16 %519
-%2361 = OpLoad %uchar %478
-%2362 = OpCompositeInsert %_arr_uchar_uint_16 %2361 %2360 2
-OpStore %520 %2362
-%2363 = OpLoad %_arr_uchar_uint_16 %520
-%2364 = OpLoad %uchar %481
-%2365 = OpCompositeInsert %_arr_uchar_uint_16 %2364 %2363 3
-OpStore %521 %2365
-%2366 = OpLoad %_arr_uchar_uint_16 %521
-%2367 = OpLoad %uchar %484
-%2368 = OpCompositeInsert %_arr_uchar_uint_16 %2367 %2366 4
-OpStore %522 %2368
-%2369 = OpLoad %_arr_uchar_uint_16 %522
-%2370 = OpLoad %uchar %487
-%2371 = OpCompositeInsert %_arr_uchar_uint_16 %2370 %2369 5
-OpStore %523 %2371
-%2372 = OpLoad %_arr_uchar_uint_16 %523
-%2373 = OpLoad %uchar %490
-%2374 = OpCompositeInsert %_arr_uchar_uint_16 %2373 %2372 6
-OpStore %524 %2374
-%2375 = OpLoad %_arr_uchar_uint_16 %524
-%2376 = OpLoad %uchar %493
-%2377 = OpCompositeInsert %_arr_uchar_uint_16 %2376 %2375 7
-OpStore %525 %2377
-%2378 = OpLoad %_arr_uchar_uint_16 %525
-%2379 = OpLoad %uchar %496
-%2380 = OpCompositeInsert %_arr_uchar_uint_16 %2379 %2378 8
-OpStore %526 %2380
-%2381 = OpLoad %_arr_uchar_uint_16 %526
-%2382 = OpLoad %uchar %499
-%2383 = OpCompositeInsert %_arr_uchar_uint_16 %2382 %2381 9
-OpStore %527 %2383
-%2384 = OpLoad %_arr_uchar_uint_16 %527
-%2385 = OpLoad %uchar %502
-%2386 = OpCompositeInsert %_arr_uchar_uint_16 %2385 %2384 10
-OpStore %528 %2386
-%2387 = OpLoad %_arr_uchar_uint_16 %528
-%2388 = OpLoad %uchar %505
-%2389 = OpCompositeInsert %_arr_uchar_uint_16 %2388 %2387 11
-OpStore %529 %2389
-%2390 = OpLoad %_arr_uchar_uint_16 %529
-%2391 = OpLoad %uchar %508
-%2392 = OpCompositeInsert %_arr_uchar_uint_16 %2391 %2390 12
-OpStore %530 %2392
-%2393 = OpLoad %_arr_uchar_uint_16 %530
-%2394 = OpLoad %uchar %511
-%2395 = OpCompositeInsert %_arr_uchar_uint_16 %2394 %2393 13
-OpStore %531 %2395
-%2396 = OpLoad %_arr_uchar_uint_16 %531
-%2397 = OpLoad %uchar %514
-%2398 = OpCompositeInsert %_arr_uchar_uint_16 %2397 %2396 14
-OpStore %532 %2398
-%2399 = OpLoad %_arr_uchar_uint_16 %532
-%2400 = OpLoad %uchar %517
-%2401 = OpCompositeInsert %_arr_uchar_uint_16 %2400 %2399 15
-OpStore %533 %2401
-%2402 = OpLoad %ulong %176
-%2403 = OpLoad %_arr_uchar_uint_16 %533
-%2404 = OpFunctionCall %ulong %1 %2402 %2403
-OpStore %177 %2404
-%2405 = OpLoad %_arr_uchar_uint_16 %170
-%2406 = OpCompositeExtract %uchar %2405 0
-OpStore %534 %2406
-%2407 = OpLoad %_arr_uchar_uint_16 %157
-%2408 = OpCompositeExtract %uchar %2407 0
-OpStore %535 %2408
-%2409 = OpLoad %uchar %534
-%2410 = OpLoad %uchar %535
-%2411 = OpIMul %uchar %2409 %2410
-OpStore %536 %2411
-%2412 = OpLoad %_arr_uchar_uint_16 %170
-%2413 = OpCompositeExtract %uchar %2412 1
-OpStore %537 %2413
-%2414 = OpLoad %_arr_uchar_uint_16 %157
-%2415 = OpCompositeExtract %uchar %2414 1
-OpStore %538 %2415
-%2416 = OpLoad %uchar %537
-%2417 = OpLoad %uchar %538
-%2418 = OpIMul %uchar %2416 %2417
-OpStore %539 %2418
-%2419 = OpLoad %_arr_uchar_uint_16 %170
-%2420 = OpCompositeExtract %uchar %2419 2
-OpStore %540 %2420
-%2421 = OpLoad %_arr_uchar_uint_16 %157
-%2422 = OpCompositeExtract %uchar %2421 2
-OpStore %541 %2422
-%2423 = OpLoad %uchar %540
-%2424 = OpLoad %uchar %541
-%2425 = OpIMul %uchar %2423 %2424
-OpStore %542 %2425
-%2426 = OpLoad %_arr_uchar_uint_16 %170
-%2427 = OpCompositeExtract %uchar %2426 3
-OpStore %543 %2427
-%2428 = OpLoad %_arr_uchar_uint_16 %157
-%2429 = OpCompositeExtract %uchar %2428 3
-OpStore %544 %2429
-%2430 = OpLoad %uchar %543
-%2431 = OpLoad %uchar %544
-%2432 = OpIMul %uchar %2430 %2431
-OpStore %545 %2432
-%2433 = OpLoad %_arr_uchar_uint_16 %170
-%2434 = OpCompositeExtract %uchar %2433 4
-OpStore %546 %2434
-%2435 = OpLoad %_arr_uchar_uint_16 %157
-%2436 = OpCompositeExtract %uchar %2435 4
-OpStore %547 %2436
-%2437 = OpLoad %uchar %546
-%2438 = OpLoad %uchar %547
-%2439 = OpIMul %uchar %2437 %2438
-OpStore %548 %2439
-%2440 = OpLoad %_arr_uchar_uint_16 %170
-%2441 = OpCompositeExtract %uchar %2440 5
-OpStore %549 %2441
-%2442 = OpLoad %_arr_uchar_uint_16 %157
-%2443 = OpCompositeExtract %uchar %2442 5
-OpStore %550 %2443
-%2444 = OpLoad %uchar %549
-%2445 = OpLoad %uchar %550
-%2446 = OpIMul %uchar %2444 %2445
-OpStore %551 %2446
-%2447 = OpLoad %_arr_uchar_uint_16 %170
-%2448 = OpCompositeExtract %uchar %2447 6
-OpStore %552 %2448
-%2449 = OpLoad %_arr_uchar_uint_16 %157
-%2450 = OpCompositeExtract %uchar %2449 6
-OpStore %553 %2450
-%2451 = OpLoad %uchar %552
-%2452 = OpLoad %uchar %553
-%2453 = OpIMul %uchar %2451 %2452
-OpStore %554 %2453
-%2454 = OpLoad %_arr_uchar_uint_16 %170
-%2455 = OpCompositeExtract %uchar %2454 7
-OpStore %555 %2455
-%2456 = OpLoad %_arr_uchar_uint_16 %157
-%2457 = OpCompositeExtract %uchar %2456 7
-OpStore %556 %2457
-%2458 = OpLoad %uchar %555
-%2459 = OpLoad %uchar %556
-%2460 = OpIMul %uchar %2458 %2459
-OpStore %557 %2460
-%2461 = OpLoad %_arr_uchar_uint_16 %170
-%2462 = OpCompositeExtract %uchar %2461 8
-OpStore %558 %2462
-%2463 = OpLoad %_arr_uchar_uint_16 %157
-%2464 = OpCompositeExtract %uchar %2463 8
-OpStore %559 %2464
-%2465 = OpLoad %uchar %558
-%2466 = OpLoad %uchar %559
-%2467 = OpIMul %uchar %2465 %2466
-OpStore %560 %2467
-%2468 = OpLoad %_arr_uchar_uint_16 %170
-%2469 = OpCompositeExtract %uchar %2468 9
-OpStore %561 %2469
-%2470 = OpLoad %_arr_uchar_uint_16 %157
-%2471 = OpCompositeExtract %uchar %2470 9
-OpStore %562 %2471
-%2472 = OpLoad %uchar %561
-%2473 = OpLoad %uchar %562
-%2474 = OpIMul %uchar %2472 %2473
-OpStore %563 %2474
-%2475 = OpLoad %_arr_uchar_uint_16 %170
-%2476 = OpCompositeExtract %uchar %2475 10
-OpStore %564 %2476
-%2477 = OpLoad %_arr_uchar_uint_16 %157
-%2478 = OpCompositeExtract %uchar %2477 10
-OpStore %565 %2478
-%2479 = OpLoad %uchar %564
-%2480 = OpLoad %uchar %565
-%2481 = OpIMul %uchar %2479 %2480
-OpStore %566 %2481
-%2482 = OpLoad %_arr_uchar_uint_16 %170
-%2483 = OpCompositeExtract %uchar %2482 11
-OpStore %567 %2483
-%2484 = OpLoad %_arr_uchar_uint_16 %157
-%2485 = OpCompositeExtract %uchar %2484 11
-OpStore %568 %2485
-%2486 = OpLoad %uchar %567
-%2487 = OpLoad %uchar %568
-%2488 = OpIMul %uchar %2486 %2487
-OpStore %569 %2488
-%2489 = OpLoad %_arr_uchar_uint_16 %170
-%2490 = OpCompositeExtract %uchar %2489 12
-OpStore %570 %2490
-%2491 = OpLoad %_arr_uchar_uint_16 %157
-%2492 = OpCompositeExtract %uchar %2491 12
-OpStore %571 %2492
-%2493 = OpLoad %uchar %570
-%2494 = OpLoad %uchar %571
-%2495 = OpIMul %uchar %2493 %2494
-OpStore %572 %2495
-%2496 = OpLoad %_arr_uchar_uint_16 %170
-%2497 = OpCompositeExtract %uchar %2496 13
-OpStore %573 %2497
-%2498 = OpLoad %_arr_uchar_uint_16 %157
-%2499 = OpCompositeExtract %uchar %2498 13
-OpStore %574 %2499
-%2500 = OpLoad %uchar %573
-%2501 = OpLoad %uchar %574
-%2502 = OpIMul %uchar %2500 %2501
-OpStore %575 %2502
-%2503 = OpLoad %_arr_uchar_uint_16 %170
-%2504 = OpCompositeExtract %uchar %2503 14
-OpStore %576 %2504
-%2505 = OpLoad %_arr_uchar_uint_16 %157
-%2506 = OpCompositeExtract %uchar %2505 14
-OpStore %577 %2506
-%2507 = OpLoad %uchar %576
-%2508 = OpLoad %uchar %577
-%2509 = OpIMul %uchar %2507 %2508
-OpStore %578 %2509
-%2510 = OpLoad %_arr_uchar_uint_16 %170
-%2511 = OpCompositeExtract %uchar %2510 15
-OpStore %579 %2511
-%2512 = OpLoad %_arr_uchar_uint_16 %157
-%2513 = OpCompositeExtract %uchar %2512 15
-OpStore %580 %2513
-%2514 = OpLoad %uchar %579
-%2515 = OpLoad %uchar %580
-%2516 = OpIMul %uchar %2514 %2515
-OpStore %581 %2516
-%2517 = OpLoad %_arr_uchar_uint_16 %170
-%2518 = OpLoad %uchar %536
-%2519 = OpCompositeInsert %_arr_uchar_uint_16 %2518 %2517 0
-OpStore %582 %2519
-%2520 = OpLoad %_arr_uchar_uint_16 %582
-%2521 = OpLoad %uchar %539
-%2522 = OpCompositeInsert %_arr_uchar_uint_16 %2521 %2520 1
-OpStore %583 %2522
-%2523 = OpLoad %_arr_uchar_uint_16 %583
-%2524 = OpLoad %uchar %542
-%2525 = OpCompositeInsert %_arr_uchar_uint_16 %2524 %2523 2
-OpStore %584 %2525
-%2526 = OpLoad %_arr_uchar_uint_16 %584
-%2527 = OpLoad %uchar %545
-%2528 = OpCompositeInsert %_arr_uchar_uint_16 %2527 %2526 3
-OpStore %585 %2528
-%2529 = OpLoad %_arr_uchar_uint_16 %585
-%2530 = OpLoad %uchar %548
-%2531 = OpCompositeInsert %_arr_uchar_uint_16 %2530 %2529 4
-OpStore %586 %2531
-%2532 = OpLoad %_arr_uchar_uint_16 %586
-%2533 = OpLoad %uchar %551
-%2534 = OpCompositeInsert %_arr_uchar_uint_16 %2533 %2532 5
-OpStore %587 %2534
-%2535 = OpLoad %_arr_uchar_uint_16 %587
-%2536 = OpLoad %uchar %554
-%2537 = OpCompositeInsert %_arr_uchar_uint_16 %2536 %2535 6
-OpStore %588 %2537
-%2538 = OpLoad %_arr_uchar_uint_16 %588
-%2539 = OpLoad %uchar %557
-%2540 = OpCompositeInsert %_arr_uchar_uint_16 %2539 %2538 7
-OpStore %589 %2540
-%2541 = OpLoad %_arr_uchar_uint_16 %589
-%2542 = OpLoad %uchar %560
-%2543 = OpCompositeInsert %_arr_uchar_uint_16 %2542 %2541 8
-OpStore %590 %2543
-%2544 = OpLoad %_arr_uchar_uint_16 %590
-%2545 = OpLoad %uchar %563
-%2546 = OpCompositeInsert %_arr_uchar_uint_16 %2545 %2544 9
-OpStore %591 %2546
-%2547 = OpLoad %_arr_uchar_uint_16 %591
-%2548 = OpLoad %uchar %566
-%2549 = OpCompositeInsert %_arr_uchar_uint_16 %2548 %2547 10
-OpStore %592 %2549
-%2550 = OpLoad %_arr_uchar_uint_16 %592
-%2551 = OpLoad %uchar %569
-%2552 = OpCompositeInsert %_arr_uchar_uint_16 %2551 %2550 11
-OpStore %593 %2552
-%2553 = OpLoad %_arr_uchar_uint_16 %593
-%2554 = OpLoad %uchar %572
-%2555 = OpCompositeInsert %_arr_uchar_uint_16 %2554 %2553 12
-OpStore %594 %2555
-%2556 = OpLoad %_arr_uchar_uint_16 %594
-%2557 = OpLoad %uchar %575
-%2558 = OpCompositeInsert %_arr_uchar_uint_16 %2557 %2556 13
-OpStore %595 %2558
-%2559 = OpLoad %_arr_uchar_uint_16 %595
-%2560 = OpLoad %uchar %578
-%2561 = OpCompositeInsert %_arr_uchar_uint_16 %2560 %2559 14
-OpStore %596 %2561
-%2562 = OpLoad %_arr_uchar_uint_16 %596
-%2563 = OpLoad %uchar %581
-%2564 = OpCompositeInsert %_arr_uchar_uint_16 %2563 %2562 15
-OpStore %597 %2564
-%2565 = OpLoad %ulong %177
-%2566 = OpLoad %_arr_uchar_uint_16 %597
-%2567 = OpFunctionCall %ulong %1 %2565 %2566
-OpStore %178 %2567
-%2568 = OpLoad %_arr_uchar_uint_16 %277
-%2569 = OpCompositeExtract %uchar %2568 0
-OpStore %598 %2569
-%2570 = OpLoad %_arr_uchar_uint_16 %157
-%2571 = OpCompositeExtract %uchar %2570 0
-OpStore %599 %2571
-%2572 = OpLoad %uchar %598
-%2573 = OpLoad %uchar %599
-%2574 = OpIMul %uchar %2572 %2573
-OpStore %600 %2574
-%2575 = OpLoad %_arr_uchar_uint_16 %277
-%2576 = OpCompositeExtract %uchar %2575 1
-OpStore %601 %2576
-%2577 = OpLoad %_arr_uchar_uint_16 %157
-%2578 = OpCompositeExtract %uchar %2577 1
-OpStore %602 %2578
-%2579 = OpLoad %uchar %601
-%2580 = OpLoad %uchar %602
-%2581 = OpIMul %uchar %2579 %2580
-OpStore %603 %2581
-%2582 = OpLoad %_arr_uchar_uint_16 %277
-%2583 = OpCompositeExtract %uchar %2582 2
-OpStore %604 %2583
-%2584 = OpLoad %_arr_uchar_uint_16 %157
-%2585 = OpCompositeExtract %uchar %2584 2
-OpStore %605 %2585
-%2586 = OpLoad %uchar %604
-%2587 = OpLoad %uchar %605
-%2588 = OpIMul %uchar %2586 %2587
-OpStore %606 %2588
-%2589 = OpLoad %_arr_uchar_uint_16 %277
-%2590 = OpCompositeExtract %uchar %2589 3
-OpStore %607 %2590
-%2591 = OpLoad %_arr_uchar_uint_16 %157
-%2592 = OpCompositeExtract %uchar %2591 3
-OpStore %608 %2592
-%2593 = OpLoad %uchar %607
-%2594 = OpLoad %uchar %608
-%2595 = OpIMul %uchar %2593 %2594
-OpStore %609 %2595
-%2596 = OpLoad %_arr_uchar_uint_16 %277
-%2597 = OpCompositeExtract %uchar %2596 4
-OpStore %610 %2597
-%2598 = OpLoad %_arr_uchar_uint_16 %157
-%2599 = OpCompositeExtract %uchar %2598 4
-OpStore %611 %2599
-%2600 = OpLoad %uchar %610
-%2601 = OpLoad %uchar %611
-%2602 = OpIMul %uchar %2600 %2601
-OpStore %612 %2602
-%2603 = OpLoad %_arr_uchar_uint_16 %277
-%2604 = OpCompositeExtract %uchar %2603 5
-OpStore %613 %2604
-%2605 = OpLoad %_arr_uchar_uint_16 %157
-%2606 = OpCompositeExtract %uchar %2605 5
-OpStore %614 %2606
-%2607 = OpLoad %uchar %613
-%2608 = OpLoad %uchar %614
-%2609 = OpIMul %uchar %2607 %2608
-OpStore %615 %2609
-%2610 = OpLoad %_arr_uchar_uint_16 %277
-%2611 = OpCompositeExtract %uchar %2610 6
-OpStore %616 %2611
-%2612 = OpLoad %_arr_uchar_uint_16 %157
-%2613 = OpCompositeExtract %uchar %2612 6
-OpStore %617 %2613
-%2614 = OpLoad %uchar %616
-%2615 = OpLoad %uchar %617
-%2616 = OpIMul %uchar %2614 %2615
-OpStore %618 %2616
-%2617 = OpLoad %_arr_uchar_uint_16 %277
-%2618 = OpCompositeExtract %uchar %2617 7
-OpStore %619 %2618
-%2619 = OpLoad %_arr_uchar_uint_16 %157
-%2620 = OpCompositeExtract %uchar %2619 7
-OpStore %620 %2620
-%2621 = OpLoad %uchar %619
-%2622 = OpLoad %uchar %620
-%2623 = OpIMul %uchar %2621 %2622
-OpStore %621 %2623
-%2624 = OpLoad %_arr_uchar_uint_16 %277
-%2625 = OpCompositeExtract %uchar %2624 8
-OpStore %622 %2625
-%2626 = OpLoad %_arr_uchar_uint_16 %157
-%2627 = OpCompositeExtract %uchar %2626 8
-OpStore %623 %2627
-%2628 = OpLoad %uchar %622
-%2629 = OpLoad %uchar %623
-%2630 = OpIMul %uchar %2628 %2629
-OpStore %624 %2630
-%2631 = OpLoad %_arr_uchar_uint_16 %277
-%2632 = OpCompositeExtract %uchar %2631 9
-OpStore %625 %2632
-%2633 = OpLoad %_arr_uchar_uint_16 %157
-%2634 = OpCompositeExtract %uchar %2633 9
-OpStore %626 %2634
-%2635 = OpLoad %uchar %625
-%2636 = OpLoad %uchar %626
-%2637 = OpIMul %uchar %2635 %2636
-OpStore %627 %2637
-%2638 = OpLoad %_arr_uchar_uint_16 %277
-%2639 = OpCompositeExtract %uchar %2638 10
-OpStore %628 %2639
-%2640 = OpLoad %_arr_uchar_uint_16 %157
-%2641 = OpCompositeExtract %uchar %2640 10
-OpStore %629 %2641
-%2642 = OpLoad %uchar %628
-%2643 = OpLoad %uchar %629
-%2644 = OpIMul %uchar %2642 %2643
-OpStore %630 %2644
-%2645 = OpLoad %_arr_uchar_uint_16 %277
-%2646 = OpCompositeExtract %uchar %2645 11
-OpStore %631 %2646
-%2647 = OpLoad %_arr_uchar_uint_16 %157
-%2648 = OpCompositeExtract %uchar %2647 11
-OpStore %632 %2648
-%2649 = OpLoad %uchar %631
-%2650 = OpLoad %uchar %632
-%2651 = OpIMul %uchar %2649 %2650
-OpStore %633 %2651
-%2652 = OpLoad %_arr_uchar_uint_16 %277
-%2653 = OpCompositeExtract %uchar %2652 12
-OpStore %634 %2653
-%2654 = OpLoad %_arr_uchar_uint_16 %157
-%2655 = OpCompositeExtract %uchar %2654 12
-OpStore %635 %2655
-%2656 = OpLoad %uchar %634
-%2657 = OpLoad %uchar %635
-%2658 = OpIMul %uchar %2656 %2657
-OpStore %636 %2658
-%2659 = OpLoad %_arr_uchar_uint_16 %277
-%2660 = OpCompositeExtract %uchar %2659 13
-OpStore %637 %2660
-%2661 = OpLoad %_arr_uchar_uint_16 %157
-%2662 = OpCompositeExtract %uchar %2661 13
-OpStore %638 %2662
-%2663 = OpLoad %uchar %637
-%2664 = OpLoad %uchar %638
-%2665 = OpIMul %uchar %2663 %2664
-OpStore %639 %2665
-%2666 = OpLoad %_arr_uchar_uint_16 %277
-%2667 = OpCompositeExtract %uchar %2666 14
-OpStore %640 %2667
-%2668 = OpLoad %_arr_uchar_uint_16 %157
-%2669 = OpCompositeExtract %uchar %2668 14
-OpStore %641 %2669
-%2670 = OpLoad %uchar %640
-%2671 = OpLoad %uchar %641
-%2672 = OpIMul %uchar %2670 %2671
-OpStore %642 %2672
-%2673 = OpLoad %_arr_uchar_uint_16 %277
-%2674 = OpCompositeExtract %uchar %2673 15
-OpStore %643 %2674
-%2675 = OpLoad %_arr_uchar_uint_16 %157
-%2676 = OpCompositeExtract %uchar %2675 15
-OpStore %644 %2676
-%2677 = OpLoad %uchar %643
-%2678 = OpLoad %uchar %644
-%2679 = OpIMul %uchar %2677 %2678
-OpStore %645 %2679
-%2680 = OpLoad %_arr_uchar_uint_16 %277
-%2681 = OpLoad %uchar %600
-%2682 = OpCompositeInsert %_arr_uchar_uint_16 %2681 %2680 0
-OpStore %646 %2682
-%2683 = OpLoad %_arr_uchar_uint_16 %646
-%2684 = OpLoad %uchar %603
-%2685 = OpCompositeInsert %_arr_uchar_uint_16 %2684 %2683 1
-OpStore %647 %2685
-%2686 = OpLoad %_arr_uchar_uint_16 %647
-%2687 = OpLoad %uchar %606
-%2688 = OpCompositeInsert %_arr_uchar_uint_16 %2687 %2686 2
-OpStore %648 %2688
-%2689 = OpLoad %_arr_uchar_uint_16 %648
-%2690 = OpLoad %uchar %609
-%2691 = OpCompositeInsert %_arr_uchar_uint_16 %2690 %2689 3
-OpStore %649 %2691
-%2692 = OpLoad %_arr_uchar_uint_16 %649
-%2693 = OpLoad %uchar %612
-%2694 = OpCompositeInsert %_arr_uchar_uint_16 %2693 %2692 4
-OpStore %650 %2694
-%2695 = OpLoad %_arr_uchar_uint_16 %650
-%2696 = OpLoad %uchar %615
-%2697 = OpCompositeInsert %_arr_uchar_uint_16 %2696 %2695 5
-OpStore %651 %2697
-%2698 = OpLoad %_arr_uchar_uint_16 %651
-%2699 = OpLoad %uchar %618
-%2700 = OpCompositeInsert %_arr_uchar_uint_16 %2699 %2698 6
-OpStore %652 %2700
-%2701 = OpLoad %_arr_uchar_uint_16 %652
-%2702 = OpLoad %uchar %621
-%2703 = OpCompositeInsert %_arr_uchar_uint_16 %2702 %2701 7
-OpStore %653 %2703
-%2704 = OpLoad %_arr_uchar_uint_16 %653
-%2705 = OpLoad %uchar %624
-%2706 = OpCompositeInsert %_arr_uchar_uint_16 %2705 %2704 8
-OpStore %654 %2706
-%2707 = OpLoad %_arr_uchar_uint_16 %654
-%2708 = OpLoad %uchar %627
-%2709 = OpCompositeInsert %_arr_uchar_uint_16 %2708 %2707 9
-OpStore %655 %2709
-%2710 = OpLoad %_arr_uchar_uint_16 %655
-%2711 = OpLoad %uchar %630
-%2712 = OpCompositeInsert %_arr_uchar_uint_16 %2711 %2710 10
-OpStore %656 %2712
-%2713 = OpLoad %_arr_uchar_uint_16 %656
-%2714 = OpLoad %uchar %633
-%2715 = OpCompositeInsert %_arr_uchar_uint_16 %2714 %2713 11
-OpStore %657 %2715
-%2716 = OpLoad %_arr_uchar_uint_16 %657
-%2717 = OpLoad %uchar %636
-%2718 = OpCompositeInsert %_arr_uchar_uint_16 %2717 %2716 12
-OpStore %658 %2718
-%2719 = OpLoad %_arr_uchar_uint_16 %658
-%2720 = OpLoad %uchar %639
-%2721 = OpCompositeInsert %_arr_uchar_uint_16 %2720 %2719 13
-OpStore %659 %2721
-%2722 = OpLoad %_arr_uchar_uint_16 %659
-%2723 = OpLoad %uchar %642
-%2724 = OpCompositeInsert %_arr_uchar_uint_16 %2723 %2722 14
-OpStore %660 %2724
-%2725 = OpLoad %_arr_uchar_uint_16 %660
-%2726 = OpLoad %uchar %645
-%2727 = OpCompositeInsert %_arr_uchar_uint_16 %2726 %2725 15
-OpStore %661 %2727
-%2728 = OpLoad %ulong %178
-%2729 = OpLoad %_arr_uchar_uint_16 %661
-%2730 = OpFunctionCall %ulong %1 %2728 %2729
-OpStore %179 %2730
-%2731 = OpLoad %_arr_uchar_uint_16 %158
-%2732 = OpCompositeExtract %uchar %2731 0
-OpStore %662 %2732
-%2733 = OpLoad %_arr_uchar_uint_16 %164
-%2734 = OpCompositeExtract %uchar %2733 0
-OpStore %663 %2734
-%2735 = OpLoad %uchar %662
-%2736 = OpLoad %uchar %663
-%2737 = OpISub %uchar %2735 %2736
-OpStore %664 %2737
-%2738 = OpLoad %_arr_uchar_uint_16 %158
-%2739 = OpCompositeExtract %uchar %2738 1
-OpStore %665 %2739
-%2740 = OpLoad %_arr_uchar_uint_16 %164
-%2741 = OpCompositeExtract %uchar %2740 1
-OpStore %666 %2741
-%2742 = OpLoad %uchar %665
-%2743 = OpLoad %uchar %666
-%2744 = OpISub %uchar %2742 %2743
-OpStore %667 %2744
-%2745 = OpLoad %_arr_uchar_uint_16 %158
-%2746 = OpCompositeExtract %uchar %2745 2
-OpStore %668 %2746
-%2747 = OpLoad %_arr_uchar_uint_16 %164
-%2748 = OpCompositeExtract %uchar %2747 2
-OpStore %669 %2748
-%2749 = OpLoad %uchar %668
-%2750 = OpLoad %uchar %669
-%2751 = OpISub %uchar %2749 %2750
-OpStore %670 %2751
-%2752 = OpLoad %_arr_uchar_uint_16 %158
-%2753 = OpCompositeExtract %uchar %2752 3
-OpStore %671 %2753
-%2754 = OpLoad %_arr_uchar_uint_16 %164
-%2755 = OpCompositeExtract %uchar %2754 3
-OpStore %672 %2755
-%2756 = OpLoad %uchar %671
-%2757 = OpLoad %uchar %672
-%2758 = OpISub %uchar %2756 %2757
-OpStore %673 %2758
-%2759 = OpLoad %_arr_uchar_uint_16 %158
-%2760 = OpCompositeExtract %uchar %2759 4
-OpStore %674 %2760
-%2761 = OpLoad %_arr_uchar_uint_16 %164
-%2762 = OpCompositeExtract %uchar %2761 4
-OpStore %675 %2762
-%2763 = OpLoad %uchar %674
-%2764 = OpLoad %uchar %675
-%2765 = OpISub %uchar %2763 %2764
-OpStore %676 %2765
-%2766 = OpLoad %_arr_uchar_uint_16 %158
-%2767 = OpCompositeExtract %uchar %2766 5
-OpStore %677 %2767
-%2768 = OpLoad %_arr_uchar_uint_16 %164
-%2769 = OpCompositeExtract %uchar %2768 5
-OpStore %678 %2769
-%2770 = OpLoad %uchar %677
-%2771 = OpLoad %uchar %678
-%2772 = OpISub %uchar %2770 %2771
-OpStore %679 %2772
-%2773 = OpLoad %_arr_uchar_uint_16 %158
-%2774 = OpCompositeExtract %uchar %2773 6
-OpStore %680 %2774
-%2775 = OpLoad %_arr_uchar_uint_16 %164
-%2776 = OpCompositeExtract %uchar %2775 6
-OpStore %681 %2776
-%2777 = OpLoad %uchar %680
-%2778 = OpLoad %uchar %681
-%2779 = OpISub %uchar %2777 %2778
-OpStore %682 %2779
-%2780 = OpLoad %_arr_uchar_uint_16 %158
-%2781 = OpCompositeExtract %uchar %2780 7
-OpStore %683 %2781
-%2782 = OpLoad %_arr_uchar_uint_16 %164
-%2783 = OpCompositeExtract %uchar %2782 7
-OpStore %684 %2783
-%2784 = OpLoad %uchar %683
-%2785 = OpLoad %uchar %684
-%2786 = OpISub %uchar %2784 %2785
-OpStore %685 %2786
-%2787 = OpLoad %_arr_uchar_uint_16 %158
-%2788 = OpCompositeExtract %uchar %2787 8
-OpStore %686 %2788
-%2789 = OpLoad %_arr_uchar_uint_16 %164
-%2790 = OpCompositeExtract %uchar %2789 8
-OpStore %687 %2790
-%2791 = OpLoad %uchar %686
-%2792 = OpLoad %uchar %687
-%2793 = OpISub %uchar %2791 %2792
-OpStore %688 %2793
-%2794 = OpLoad %_arr_uchar_uint_16 %158
-%2795 = OpCompositeExtract %uchar %2794 9
-OpStore %689 %2795
-%2796 = OpLoad %_arr_uchar_uint_16 %164
-%2797 = OpCompositeExtract %uchar %2796 9
-OpStore %690 %2797
-%2798 = OpLoad %uchar %689
-%2799 = OpLoad %uchar %690
-%2800 = OpISub %uchar %2798 %2799
-OpStore %691 %2800
-%2801 = OpLoad %_arr_uchar_uint_16 %158
-%2802 = OpCompositeExtract %uchar %2801 10
-OpStore %692 %2802
-%2803 = OpLoad %_arr_uchar_uint_16 %164
-%2804 = OpCompositeExtract %uchar %2803 10
-OpStore %693 %2804
-%2805 = OpLoad %uchar %692
-%2806 = OpLoad %uchar %693
-%2807 = OpISub %uchar %2805 %2806
-OpStore %694 %2807
-%2808 = OpLoad %_arr_uchar_uint_16 %158
-%2809 = OpCompositeExtract %uchar %2808 11
-OpStore %695 %2809
-%2810 = OpLoad %_arr_uchar_uint_16 %164
-%2811 = OpCompositeExtract %uchar %2810 11
-OpStore %696 %2811
-%2812 = OpLoad %uchar %695
-%2813 = OpLoad %uchar %696
-%2814 = OpISub %uchar %2812 %2813
-OpStore %697 %2814
-%2815 = OpLoad %_arr_uchar_uint_16 %158
-%2816 = OpCompositeExtract %uchar %2815 12
-OpStore %698 %2816
-%2817 = OpLoad %_arr_uchar_uint_16 %164
-%2818 = OpCompositeExtract %uchar %2817 12
-OpStore %699 %2818
-%2819 = OpLoad %uchar %698
-%2820 = OpLoad %uchar %699
-%2821 = OpISub %uchar %2819 %2820
-OpStore %700 %2821
-%2822 = OpLoad %_arr_uchar_uint_16 %158
-%2823 = OpCompositeExtract %uchar %2822 13
-OpStore %701 %2823
-%2824 = OpLoad %_arr_uchar_uint_16 %164
-%2825 = OpCompositeExtract %uchar %2824 13
-OpStore %702 %2825
-%2826 = OpLoad %uchar %701
-%2827 = OpLoad %uchar %702
-%2828 = OpISub %uchar %2826 %2827
-OpStore %703 %2828
-%2829 = OpLoad %_arr_uchar_uint_16 %158
-%2830 = OpCompositeExtract %uchar %2829 14
-OpStore %704 %2830
-%2831 = OpLoad %_arr_uchar_uint_16 %164
-%2832 = OpCompositeExtract %uchar %2831 14
-OpStore %705 %2832
-%2833 = OpLoad %uchar %704
-%2834 = OpLoad %uchar %705
-%2835 = OpISub %uchar %2833 %2834
-OpStore %706 %2835
-%2836 = OpLoad %_arr_uchar_uint_16 %158
-%2837 = OpCompositeExtract %uchar %2836 15
-OpStore %707 %2837
-%2838 = OpLoad %_arr_uchar_uint_16 %164
-%2839 = OpCompositeExtract %uchar %2838 15
-OpStore %708 %2839
-%2840 = OpLoad %uchar %707
-%2841 = OpLoad %uchar %708
-%2842 = OpISub %uchar %2840 %2841
-OpStore %709 %2842
-%2843 = OpLoad %_arr_uchar_uint_16 %158
-%2844 = OpLoad %uchar %664
-%2845 = OpCompositeInsert %_arr_uchar_uint_16 %2844 %2843 0
-OpStore %710 %2845
-%2846 = OpLoad %_arr_uchar_uint_16 %710
-%2847 = OpLoad %uchar %667
-%2848 = OpCompositeInsert %_arr_uchar_uint_16 %2847 %2846 1
-OpStore %711 %2848
-%2849 = OpLoad %_arr_uchar_uint_16 %711
-%2850 = OpLoad %uchar %670
-%2851 = OpCompositeInsert %_arr_uchar_uint_16 %2850 %2849 2
-OpStore %712 %2851
-%2852 = OpLoad %_arr_uchar_uint_16 %712
-%2853 = OpLoad %uchar %673
-%2854 = OpCompositeInsert %_arr_uchar_uint_16 %2853 %2852 3
-OpStore %713 %2854
-%2855 = OpLoad %_arr_uchar_uint_16 %713
-%2856 = OpLoad %uchar %676
-%2857 = OpCompositeInsert %_arr_uchar_uint_16 %2856 %2855 4
-OpStore %714 %2857
-%2858 = OpLoad %_arr_uchar_uint_16 %714
-%2859 = OpLoad %uchar %679
-%2860 = OpCompositeInsert %_arr_uchar_uint_16 %2859 %2858 5
-OpStore %715 %2860
-%2861 = OpLoad %_arr_uchar_uint_16 %715
-%2862 = OpLoad %uchar %682
-%2863 = OpCompositeInsert %_arr_uchar_uint_16 %2862 %2861 6
-OpStore %716 %2863
-%2864 = OpLoad %_arr_uchar_uint_16 %716
-%2865 = OpLoad %uchar %685
-%2866 = OpCompositeInsert %_arr_uchar_uint_16 %2865 %2864 7
-OpStore %717 %2866
-%2867 = OpLoad %_arr_uchar_uint_16 %717
-%2868 = OpLoad %uchar %688
-%2869 = OpCompositeInsert %_arr_uchar_uint_16 %2868 %2867 8
-OpStore %718 %2869
-%2870 = OpLoad %_arr_uchar_uint_16 %718
-%2871 = OpLoad %uchar %691
-%2872 = OpCompositeInsert %_arr_uchar_uint_16 %2871 %2870 9
-OpStore %719 %2872
-%2873 = OpLoad %_arr_uchar_uint_16 %719
-%2874 = OpLoad %uchar %694
-%2875 = OpCompositeInsert %_arr_uchar_uint_16 %2874 %2873 10
-OpStore %720 %2875
-%2876 = OpLoad %_arr_uchar_uint_16 %720
-%2877 = OpLoad %uchar %697
-%2878 = OpCompositeInsert %_arr_uchar_uint_16 %2877 %2876 11
-OpStore %721 %2878
-%2879 = OpLoad %_arr_uchar_uint_16 %721
-%2880 = OpLoad %uchar %700
-%2881 = OpCompositeInsert %_arr_uchar_uint_16 %2880 %2879 12
-OpStore %722 %2881
-%2882 = OpLoad %_arr_uchar_uint_16 %722
-%2883 = OpLoad %uchar %703
-%2884 = OpCompositeInsert %_arr_uchar_uint_16 %2883 %2882 13
-OpStore %723 %2884
-%2885 = OpLoad %_arr_uchar_uint_16 %723
-%2886 = OpLoad %uchar %706
-%2887 = OpCompositeInsert %_arr_uchar_uint_16 %2886 %2885 14
-OpStore %724 %2887
-%2888 = OpLoad %_arr_uchar_uint_16 %724
-%2889 = OpLoad %uchar %709
-%2890 = OpCompositeInsert %_arr_uchar_uint_16 %2889 %2888 15
-OpStore %725 %2890
-%2891 = OpLoad %ulong %179
-%2892 = OpLoad %_arr_uchar_uint_16 %725
-%2893 = OpFunctionCall %ulong %1 %2891 %2892
-OpStore %180 %2893
-%2894 = OpLoad %_arr_uchar_uint_16 %158
-%2895 = OpCompositeExtract %uchar %2894 0
-OpStore %726 %2895
-%2896 = OpLoad %_arr_uchar_uint_16 %170
-%2897 = OpCompositeExtract %uchar %2896 0
-OpStore %727 %2897
-%2898 = OpLoad %uchar %726
-%2899 = OpLoad %uchar %727
-%2900 = OpISub %uchar %2898 %2899
-OpStore %728 %2900
-%2901 = OpLoad %_arr_uchar_uint_16 %158
-%2902 = OpCompositeExtract %uchar %2901 1
-OpStore %729 %2902
-%2903 = OpLoad %_arr_uchar_uint_16 %170
-%2904 = OpCompositeExtract %uchar %2903 1
-OpStore %730 %2904
-%2905 = OpLoad %uchar %729
-%2906 = OpLoad %uchar %730
-%2907 = OpISub %uchar %2905 %2906
-OpStore %731 %2907
-%2908 = OpLoad %_arr_uchar_uint_16 %158
-%2909 = OpCompositeExtract %uchar %2908 2
-OpStore %732 %2909
-%2910 = OpLoad %_arr_uchar_uint_16 %170
-%2911 = OpCompositeExtract %uchar %2910 2
-OpStore %733 %2911
-%2912 = OpLoad %uchar %732
-%2913 = OpLoad %uchar %733
-%2914 = OpISub %uchar %2912 %2913
-OpStore %734 %2914
-%2915 = OpLoad %_arr_uchar_uint_16 %158
-%2916 = OpCompositeExtract %uchar %2915 3
-OpStore %735 %2916
-%2917 = OpLoad %_arr_uchar_uint_16 %170
-%2918 = OpCompositeExtract %uchar %2917 3
-OpStore %736 %2918
-%2919 = OpLoad %uchar %735
-%2920 = OpLoad %uchar %736
-%2921 = OpISub %uchar %2919 %2920
-OpStore %737 %2921
-%2922 = OpLoad %_arr_uchar_uint_16 %158
-%2923 = OpCompositeExtract %uchar %2922 4
-OpStore %738 %2923
-%2924 = OpLoad %_arr_uchar_uint_16 %170
-%2925 = OpCompositeExtract %uchar %2924 4
-OpStore %739 %2925
-%2926 = OpLoad %uchar %738
-%2927 = OpLoad %uchar %739
-%2928 = OpISub %uchar %2926 %2927
-OpStore %740 %2928
-%2929 = OpLoad %_arr_uchar_uint_16 %158
-%2930 = OpCompositeExtract %uchar %2929 5
-OpStore %741 %2930
-%2931 = OpLoad %_arr_uchar_uint_16 %170
-%2932 = OpCompositeExtract %uchar %2931 5
-OpStore %742 %2932
-%2933 = OpLoad %uchar %741
-%2934 = OpLoad %uchar %742
-%2935 = OpISub %uchar %2933 %2934
-OpStore %743 %2935
-%2936 = OpLoad %_arr_uchar_uint_16 %158
-%2937 = OpCompositeExtract %uchar %2936 6
-OpStore %744 %2937
-%2938 = OpLoad %_arr_uchar_uint_16 %170
-%2939 = OpCompositeExtract %uchar %2938 6
-OpStore %745 %2939
-%2940 = OpLoad %uchar %744
-%2941 = OpLoad %uchar %745
-%2942 = OpISub %uchar %2940 %2941
-OpStore %746 %2942
-%2943 = OpLoad %_arr_uchar_uint_16 %158
-%2944 = OpCompositeExtract %uchar %2943 7
-OpStore %747 %2944
-%2945 = OpLoad %_arr_uchar_uint_16 %170
-%2946 = OpCompositeExtract %uchar %2945 7
-OpStore %748 %2946
-%2947 = OpLoad %uchar %747
-%2948 = OpLoad %uchar %748
-%2949 = OpISub %uchar %2947 %2948
-OpStore %749 %2949
-%2950 = OpLoad %_arr_uchar_uint_16 %158
-%2951 = OpCompositeExtract %uchar %2950 8
-OpStore %750 %2951
-%2952 = OpLoad %_arr_uchar_uint_16 %170
-%2953 = OpCompositeExtract %uchar %2952 8
-OpStore %751 %2953
-%2954 = OpLoad %uchar %750
-%2955 = OpLoad %uchar %751
-%2956 = OpISub %uchar %2954 %2955
-OpStore %752 %2956
-%2957 = OpLoad %_arr_uchar_uint_16 %158
-%2958 = OpCompositeExtract %uchar %2957 9
-OpStore %753 %2958
-%2959 = OpLoad %_arr_uchar_uint_16 %170
-%2960 = OpCompositeExtract %uchar %2959 9
-OpStore %754 %2960
-%2961 = OpLoad %uchar %753
-%2962 = OpLoad %uchar %754
-%2963 = OpISub %uchar %2961 %2962
-OpStore %755 %2963
-%2964 = OpLoad %_arr_uchar_uint_16 %158
-%2965 = OpCompositeExtract %uchar %2964 10
-OpStore %756 %2965
-%2966 = OpLoad %_arr_uchar_uint_16 %170
-%2967 = OpCompositeExtract %uchar %2966 10
-OpStore %757 %2967
-%2968 = OpLoad %uchar %756
-%2969 = OpLoad %uchar %757
-%2970 = OpISub %uchar %2968 %2969
-OpStore %758 %2970
-%2971 = OpLoad %_arr_uchar_uint_16 %158
-%2972 = OpCompositeExtract %uchar %2971 11
-OpStore %759 %2972
-%2973 = OpLoad %_arr_uchar_uint_16 %170
-%2974 = OpCompositeExtract %uchar %2973 11
-OpStore %760 %2974
-%2975 = OpLoad %uchar %759
-%2976 = OpLoad %uchar %760
-%2977 = OpISub %uchar %2975 %2976
-OpStore %761 %2977
-%2978 = OpLoad %_arr_uchar_uint_16 %158
-%2979 = OpCompositeExtract %uchar %2978 12
-OpStore %762 %2979
-%2980 = OpLoad %_arr_uchar_uint_16 %170
-%2981 = OpCompositeExtract %uchar %2980 12
-OpStore %763 %2981
-%2982 = OpLoad %uchar %762
-%2983 = OpLoad %uchar %763
-%2984 = OpISub %uchar %2982 %2983
-OpStore %764 %2984
-%2985 = OpLoad %_arr_uchar_uint_16 %158
-%2986 = OpCompositeExtract %uchar %2985 13
-OpStore %765 %2986
-%2987 = OpLoad %_arr_uchar_uint_16 %170
-%2988 = OpCompositeExtract %uchar %2987 13
-OpStore %766 %2988
-%2989 = OpLoad %uchar %765
-%2990 = OpLoad %uchar %766
-%2991 = OpISub %uchar %2989 %2990
-OpStore %767 %2991
-%2992 = OpLoad %_arr_uchar_uint_16 %158
-%2993 = OpCompositeExtract %uchar %2992 14
-OpStore %768 %2993
-%2994 = OpLoad %_arr_uchar_uint_16 %170
-%2995 = OpCompositeExtract %uchar %2994 14
-OpStore %769 %2995
-%2996 = OpLoad %uchar %768
-%2997 = OpLoad %uchar %769
-%2998 = OpISub %uchar %2996 %2997
-OpStore %770 %2998
-%2999 = OpLoad %_arr_uchar_uint_16 %158
-%3000 = OpCompositeExtract %uchar %2999 15
-OpStore %771 %3000
-%3001 = OpLoad %_arr_uchar_uint_16 %170
-%3002 = OpCompositeExtract %uchar %3001 15
-OpStore %772 %3002
-%3003 = OpLoad %uchar %771
-%3004 = OpLoad %uchar %772
-%3005 = OpISub %uchar %3003 %3004
-OpStore %773 %3005
-%3006 = OpLoad %_arr_uchar_uint_16 %158
-%3007 = OpLoad %uchar %728
-%3008 = OpCompositeInsert %_arr_uchar_uint_16 %3007 %3006 0
-OpStore %774 %3008
-%3009 = OpLoad %_arr_uchar_uint_16 %774
-%3010 = OpLoad %uchar %731
-%3011 = OpCompositeInsert %_arr_uchar_uint_16 %3010 %3009 1
-OpStore %775 %3011
-%3012 = OpLoad %_arr_uchar_uint_16 %775
-%3013 = OpLoad %uchar %734
-%3014 = OpCompositeInsert %_arr_uchar_uint_16 %3013 %3012 2
-OpStore %776 %3014
-%3015 = OpLoad %_arr_uchar_uint_16 %776
-%3016 = OpLoad %uchar %737
-%3017 = OpCompositeInsert %_arr_uchar_uint_16 %3016 %3015 3
-OpStore %777 %3017
-%3018 = OpLoad %_arr_uchar_uint_16 %777
-%3019 = OpLoad %uchar %740
-%3020 = OpCompositeInsert %_arr_uchar_uint_16 %3019 %3018 4
-OpStore %778 %3020
-%3021 = OpLoad %_arr_uchar_uint_16 %778
-%3022 = OpLoad %uchar %743
-%3023 = OpCompositeInsert %_arr_uchar_uint_16 %3022 %3021 5
-OpStore %779 %3023
-%3024 = OpLoad %_arr_uchar_uint_16 %779
-%3025 = OpLoad %uchar %746
-%3026 = OpCompositeInsert %_arr_uchar_uint_16 %3025 %3024 6
-OpStore %780 %3026
-%3027 = OpLoad %_arr_uchar_uint_16 %780
-%3028 = OpLoad %uchar %749
-%3029 = OpCompositeInsert %_arr_uchar_uint_16 %3028 %3027 7
-OpStore %781 %3029
-%3030 = OpLoad %_arr_uchar_uint_16 %781
-%3031 = OpLoad %uchar %752
-%3032 = OpCompositeInsert %_arr_uchar_uint_16 %3031 %3030 8
-OpStore %782 %3032
-%3033 = OpLoad %_arr_uchar_uint_16 %782
-%3034 = OpLoad %uchar %755
-%3035 = OpCompositeInsert %_arr_uchar_uint_16 %3034 %3033 9
-OpStore %783 %3035
-%3036 = OpLoad %_arr_uchar_uint_16 %783
-%3037 = OpLoad %uchar %758
-%3038 = OpCompositeInsert %_arr_uchar_uint_16 %3037 %3036 10
-OpStore %784 %3038
-%3039 = OpLoad %_arr_uchar_uint_16 %784
-%3040 = OpLoad %uchar %761
-%3041 = OpCompositeInsert %_arr_uchar_uint_16 %3040 %3039 11
-OpStore %785 %3041
-%3042 = OpLoad %_arr_uchar_uint_16 %785
-%3043 = OpLoad %uchar %764
-%3044 = OpCompositeInsert %_arr_uchar_uint_16 %3043 %3042 12
-OpStore %786 %3044
-%3045 = OpLoad %_arr_uchar_uint_16 %786
-%3046 = OpLoad %uchar %767
-%3047 = OpCompositeInsert %_arr_uchar_uint_16 %3046 %3045 13
-OpStore %787 %3047
-%3048 = OpLoad %_arr_uchar_uint_16 %787
-%3049 = OpLoad %uchar %770
-%3050 = OpCompositeInsert %_arr_uchar_uint_16 %3049 %3048 14
-OpStore %788 %3050
-%3051 = OpLoad %_arr_uchar_uint_16 %788
-%3052 = OpLoad %uchar %773
-%3053 = OpCompositeInsert %_arr_uchar_uint_16 %3052 %3051 15
-OpStore %789 %3053
-%3054 = OpLoad %ulong %180
-%3055 = OpLoad %_arr_uchar_uint_16 %789
-%3056 = OpFunctionCall %ulong %1 %3054 %3055
-OpStore %181 %3056
-%3057 = OpLoad %_arr_uchar_uint_16 %164
-%3058 = OpCompositeExtract %uchar %3057 0
-OpStore %790 %3058
-%3059 = OpLoad %_arr_uchar_uint_16 %170
-%3060 = OpCompositeExtract %uchar %3059 0
-OpStore %791 %3060
-%3061 = OpLoad %uchar %790
-%3062 = OpLoad %uchar %791
-%3063 = OpBitwiseAnd %uchar %3061 %3062
-OpStore %792 %3063
-%3064 = OpLoad %_arr_uchar_uint_16 %164
-%3065 = OpCompositeExtract %uchar %3064 1
-OpStore %793 %3065
-%3066 = OpLoad %_arr_uchar_uint_16 %170
-%3067 = OpCompositeExtract %uchar %3066 1
-OpStore %794 %3067
-%3068 = OpLoad %uchar %793
-%3069 = OpLoad %uchar %794
-%3070 = OpBitwiseAnd %uchar %3068 %3069
-OpStore %795 %3070
-%3071 = OpLoad %_arr_uchar_uint_16 %164
-%3072 = OpCompositeExtract %uchar %3071 2
-OpStore %796 %3072
-%3073 = OpLoad %_arr_uchar_uint_16 %170
-%3074 = OpCompositeExtract %uchar %3073 2
-OpStore %797 %3074
-%3075 = OpLoad %uchar %796
-%3076 = OpLoad %uchar %797
-%3077 = OpBitwiseAnd %uchar %3075 %3076
-OpStore %798 %3077
-%3078 = OpLoad %_arr_uchar_uint_16 %164
-%3079 = OpCompositeExtract %uchar %3078 3
-OpStore %799 %3079
-%3080 = OpLoad %_arr_uchar_uint_16 %170
-%3081 = OpCompositeExtract %uchar %3080 3
-OpStore %800 %3081
-%3082 = OpLoad %uchar %799
-%3083 = OpLoad %uchar %800
-%3084 = OpBitwiseAnd %uchar %3082 %3083
-OpStore %801 %3084
-%3085 = OpLoad %_arr_uchar_uint_16 %164
-%3086 = OpCompositeExtract %uchar %3085 4
-OpStore %802 %3086
-%3087 = OpLoad %_arr_uchar_uint_16 %170
-%3088 = OpCompositeExtract %uchar %3087 4
-OpStore %803 %3088
-%3089 = OpLoad %uchar %802
-%3090 = OpLoad %uchar %803
-%3091 = OpBitwiseAnd %uchar %3089 %3090
-OpStore %804 %3091
-%3092 = OpLoad %_arr_uchar_uint_16 %164
-%3093 = OpCompositeExtract %uchar %3092 5
-OpStore %805 %3093
-%3094 = OpLoad %_arr_uchar_uint_16 %170
-%3095 = OpCompositeExtract %uchar %3094 5
-OpStore %806 %3095
-%3096 = OpLoad %uchar %805
-%3097 = OpLoad %uchar %806
-%3098 = OpBitwiseAnd %uchar %3096 %3097
-OpStore %807 %3098
-%3099 = OpLoad %_arr_uchar_uint_16 %164
-%3100 = OpCompositeExtract %uchar %3099 6
-OpStore %808 %3100
-%3101 = OpLoad %_arr_uchar_uint_16 %170
-%3102 = OpCompositeExtract %uchar %3101 6
-OpStore %809 %3102
-%3103 = OpLoad %uchar %808
-%3104 = OpLoad %uchar %809
-%3105 = OpBitwiseAnd %uchar %3103 %3104
-OpStore %810 %3105
-%3106 = OpLoad %_arr_uchar_uint_16 %164
-%3107 = OpCompositeExtract %uchar %3106 7
-OpStore %811 %3107
-%3108 = OpLoad %_arr_uchar_uint_16 %170
-%3109 = OpCompositeExtract %uchar %3108 7
-OpStore %812 %3109
-%3110 = OpLoad %uchar %811
-%3111 = OpLoad %uchar %812
-%3112 = OpBitwiseAnd %uchar %3110 %3111
-OpStore %813 %3112
-%3113 = OpLoad %_arr_uchar_uint_16 %164
-%3114 = OpCompositeExtract %uchar %3113 8
-OpStore %814 %3114
-%3115 = OpLoad %_arr_uchar_uint_16 %170
-%3116 = OpCompositeExtract %uchar %3115 8
-OpStore %815 %3116
-%3117 = OpLoad %uchar %814
-%3118 = OpLoad %uchar %815
-%3119 = OpBitwiseAnd %uchar %3117 %3118
-OpStore %816 %3119
-%3120 = OpLoad %_arr_uchar_uint_16 %164
-%3121 = OpCompositeExtract %uchar %3120 9
-OpStore %817 %3121
-%3122 = OpLoad %_arr_uchar_uint_16 %170
-%3123 = OpCompositeExtract %uchar %3122 9
-OpStore %818 %3123
-%3124 = OpLoad %uchar %817
-%3125 = OpLoad %uchar %818
-%3126 = OpBitwiseAnd %uchar %3124 %3125
-OpStore %819 %3126
-%3127 = OpLoad %_arr_uchar_uint_16 %164
-%3128 = OpCompositeExtract %uchar %3127 10
-OpStore %820 %3128
-%3129 = OpLoad %_arr_uchar_uint_16 %170
-%3130 = OpCompositeExtract %uchar %3129 10
-OpStore %821 %3130
-%3131 = OpLoad %uchar %820
-%3132 = OpLoad %uchar %821
-%3133 = OpBitwiseAnd %uchar %3131 %3132
-OpStore %822 %3133
-%3134 = OpLoad %_arr_uchar_uint_16 %164
-%3135 = OpCompositeExtract %uchar %3134 11
-OpStore %823 %3135
-%3136 = OpLoad %_arr_uchar_uint_16 %170
-%3137 = OpCompositeExtract %uchar %3136 11
-OpStore %824 %3137
-%3138 = OpLoad %uchar %823
-%3139 = OpLoad %uchar %824
-%3140 = OpBitwiseAnd %uchar %3138 %3139
-OpStore %825 %3140
-%3141 = OpLoad %_arr_uchar_uint_16 %164
-%3142 = OpCompositeExtract %uchar %3141 12
-OpStore %826 %3142
-%3143 = OpLoad %_arr_uchar_uint_16 %170
-%3144 = OpCompositeExtract %uchar %3143 12
-OpStore %827 %3144
-%3145 = OpLoad %uchar %826
-%3146 = OpLoad %uchar %827
-%3147 = OpBitwiseAnd %uchar %3145 %3146
-OpStore %828 %3147
-%3148 = OpLoad %_arr_uchar_uint_16 %164
-%3149 = OpCompositeExtract %uchar %3148 13
-OpStore %829 %3149
-%3150 = OpLoad %_arr_uchar_uint_16 %170
-%3151 = OpCompositeExtract %uchar %3150 13
-OpStore %830 %3151
-%3152 = OpLoad %uchar %829
-%3153 = OpLoad %uchar %830
-%3154 = OpBitwiseAnd %uchar %3152 %3153
-OpStore %831 %3154
-%3155 = OpLoad %_arr_uchar_uint_16 %164
-%3156 = OpCompositeExtract %uchar %3155 14
-OpStore %832 %3156
-%3157 = OpLoad %_arr_uchar_uint_16 %170
-%3158 = OpCompositeExtract %uchar %3157 14
-OpStore %833 %3158
-%3159 = OpLoad %uchar %832
-%3160 = OpLoad %uchar %833
-%3161 = OpBitwiseAnd %uchar %3159 %3160
-OpStore %834 %3161
-%3162 = OpLoad %_arr_uchar_uint_16 %164
-%3163 = OpCompositeExtract %uchar %3162 15
-OpStore %835 %3163
-%3164 = OpLoad %_arr_uchar_uint_16 %170
-%3165 = OpCompositeExtract %uchar %3164 15
-OpStore %836 %3165
-%3166 = OpLoad %uchar %835
-%3167 = OpLoad %uchar %836
-%3168 = OpBitwiseAnd %uchar %3166 %3167
-OpStore %837 %3168
-%3169 = OpLoad %_arr_uchar_uint_16 %164
-%3170 = OpLoad %uchar %792
-%3171 = OpCompositeInsert %_arr_uchar_uint_16 %3170 %3169 0
-OpStore %838 %3171
-%3172 = OpLoad %_arr_uchar_uint_16 %838
-%3173 = OpLoad %uchar %795
-%3174 = OpCompositeInsert %_arr_uchar_uint_16 %3173 %3172 1
-OpStore %839 %3174
-%3175 = OpLoad %_arr_uchar_uint_16 %839
-%3176 = OpLoad %uchar %798
-%3177 = OpCompositeInsert %_arr_uchar_uint_16 %3176 %3175 2
-OpStore %840 %3177
-%3178 = OpLoad %_arr_uchar_uint_16 %840
-%3179 = OpLoad %uchar %801
-%3180 = OpCompositeInsert %_arr_uchar_uint_16 %3179 %3178 3
-OpStore %841 %3180
-%3181 = OpLoad %_arr_uchar_uint_16 %841
-%3182 = OpLoad %uchar %804
-%3183 = OpCompositeInsert %_arr_uchar_uint_16 %3182 %3181 4
-OpStore %842 %3183
-%3184 = OpLoad %_arr_uchar_uint_16 %842
-%3185 = OpLoad %uchar %807
-%3186 = OpCompositeInsert %_arr_uchar_uint_16 %3185 %3184 5
-OpStore %843 %3186
-%3187 = OpLoad %_arr_uchar_uint_16 %843
-%3188 = OpLoad %uchar %810
-%3189 = OpCompositeInsert %_arr_uchar_uint_16 %3188 %3187 6
-OpStore %844 %3189
-%3190 = OpLoad %_arr_uchar_uint_16 %844
-%3191 = OpLoad %uchar %813
-%3192 = OpCompositeInsert %_arr_uchar_uint_16 %3191 %3190 7
-OpStore %845 %3192
-%3193 = OpLoad %_arr_uchar_uint_16 %845
-%3194 = OpLoad %uchar %816
-%3195 = OpCompositeInsert %_arr_uchar_uint_16 %3194 %3193 8
-OpStore %846 %3195
-%3196 = OpLoad %_arr_uchar_uint_16 %846
-%3197 = OpLoad %uchar %819
-%3198 = OpCompositeInsert %_arr_uchar_uint_16 %3197 %3196 9
-OpStore %847 %3198
-%3199 = OpLoad %_arr_uchar_uint_16 %847
-%3200 = OpLoad %uchar %822
-%3201 = OpCompositeInsert %_arr_uchar_uint_16 %3200 %3199 10
-OpStore %848 %3201
-%3202 = OpLoad %_arr_uchar_uint_16 %848
-%3203 = OpLoad %uchar %825
-%3204 = OpCompositeInsert %_arr_uchar_uint_16 %3203 %3202 11
-OpStore %849 %3204
-%3205 = OpLoad %_arr_uchar_uint_16 %849
-%3206 = OpLoad %uchar %828
-%3207 = OpCompositeInsert %_arr_uchar_uint_16 %3206 %3205 12
-OpStore %850 %3207
-%3208 = OpLoad %_arr_uchar_uint_16 %850
-%3209 = OpLoad %uchar %831
-%3210 = OpCompositeInsert %_arr_uchar_uint_16 %3209 %3208 13
-OpStore %851 %3210
-%3211 = OpLoad %_arr_uchar_uint_16 %851
-%3212 = OpLoad %uchar %834
-%3213 = OpCompositeInsert %_arr_uchar_uint_16 %3212 %3211 14
-OpStore %852 %3213
-%3214 = OpLoad %_arr_uchar_uint_16 %852
-%3215 = OpLoad %uchar %837
-%3216 = OpCompositeInsert %_arr_uchar_uint_16 %3215 %3214 15
-OpStore %853 %3216
-%3217 = OpLoad %ulong %181
-%3218 = OpLoad %_arr_uchar_uint_16 %853
-%3219 = OpFunctionCall %ulong %1 %3217 %3218
-OpStore %182 %3219
-%3220 = OpLoad %_arr_uchar_uint_16 %164
-%3221 = OpCompositeExtract %uchar %3220 0
-OpStore %854 %3221
-%3222 = OpLoad %_arr_uchar_uint_16 %170
-%3223 = OpCompositeExtract %uchar %3222 0
-OpStore %855 %3223
-%3224 = OpLoad %uchar %854
-%3225 = OpLoad %uchar %855
-%3226 = OpBitwiseOr %uchar %3224 %3225
-OpStore %856 %3226
-%3227 = OpLoad %_arr_uchar_uint_16 %164
-%3228 = OpCompositeExtract %uchar %3227 1
-OpStore %857 %3228
-%3229 = OpLoad %_arr_uchar_uint_16 %170
-%3230 = OpCompositeExtract %uchar %3229 1
-OpStore %858 %3230
-%3231 = OpLoad %uchar %857
-%3232 = OpLoad %uchar %858
-%3233 = OpBitwiseOr %uchar %3231 %3232
-OpStore %859 %3233
-%3234 = OpLoad %_arr_uchar_uint_16 %164
-%3235 = OpCompositeExtract %uchar %3234 2
-OpStore %860 %3235
-%3236 = OpLoad %_arr_uchar_uint_16 %170
-%3237 = OpCompositeExtract %uchar %3236 2
-OpStore %861 %3237
-%3238 = OpLoad %uchar %860
-%3239 = OpLoad %uchar %861
-%3240 = OpBitwiseOr %uchar %3238 %3239
-OpStore %862 %3240
-%3241 = OpLoad %_arr_uchar_uint_16 %164
-%3242 = OpCompositeExtract %uchar %3241 3
-OpStore %863 %3242
-%3243 = OpLoad %_arr_uchar_uint_16 %170
-%3244 = OpCompositeExtract %uchar %3243 3
-OpStore %864 %3244
-%3245 = OpLoad %uchar %863
-%3246 = OpLoad %uchar %864
-%3247 = OpBitwiseOr %uchar %3245 %3246
-OpStore %865 %3247
-%3248 = OpLoad %_arr_uchar_uint_16 %164
-%3249 = OpCompositeExtract %uchar %3248 4
-OpStore %866 %3249
-%3250 = OpLoad %_arr_uchar_uint_16 %170
-%3251 = OpCompositeExtract %uchar %3250 4
-OpStore %867 %3251
-%3252 = OpLoad %uchar %866
-%3253 = OpLoad %uchar %867
-%3254 = OpBitwiseOr %uchar %3252 %3253
-OpStore %868 %3254
-%3255 = OpLoad %_arr_uchar_uint_16 %164
-%3256 = OpCompositeExtract %uchar %3255 5
-OpStore %869 %3256
-%3257 = OpLoad %_arr_uchar_uint_16 %170
-%3258 = OpCompositeExtract %uchar %3257 5
-OpStore %870 %3258
-%3259 = OpLoad %uchar %869
-%3260 = OpLoad %uchar %870
-%3261 = OpBitwiseOr %uchar %3259 %3260
-OpStore %871 %3261
-%3262 = OpLoad %_arr_uchar_uint_16 %164
-%3263 = OpCompositeExtract %uchar %3262 6
-OpStore %872 %3263
-%3264 = OpLoad %_arr_uchar_uint_16 %170
-%3265 = OpCompositeExtract %uchar %3264 6
-OpStore %873 %3265
-%3266 = OpLoad %uchar %872
-%3267 = OpLoad %uchar %873
-%3268 = OpBitwiseOr %uchar %3266 %3267
-OpStore %874 %3268
-%3269 = OpLoad %_arr_uchar_uint_16 %164
-%3270 = OpCompositeExtract %uchar %3269 7
-OpStore %875 %3270
-%3271 = OpLoad %_arr_uchar_uint_16 %170
-%3272 = OpCompositeExtract %uchar %3271 7
-OpStore %876 %3272
-%3273 = OpLoad %uchar %875
-%3274 = OpLoad %uchar %876
-%3275 = OpBitwiseOr %uchar %3273 %3274
-OpStore %877 %3275
-%3276 = OpLoad %_arr_uchar_uint_16 %164
-%3277 = OpCompositeExtract %uchar %3276 8
-OpStore %878 %3277
-%3278 = OpLoad %_arr_uchar_uint_16 %170
-%3279 = OpCompositeExtract %uchar %3278 8
-OpStore %879 %3279
-%3280 = OpLoad %uchar %878
-%3281 = OpLoad %uchar %879
-%3282 = OpBitwiseOr %uchar %3280 %3281
-OpStore %880 %3282
-%3283 = OpLoad %_arr_uchar_uint_16 %164
-%3284 = OpCompositeExtract %uchar %3283 9
-OpStore %881 %3284
-%3285 = OpLoad %_arr_uchar_uint_16 %170
-%3286 = OpCompositeExtract %uchar %3285 9
-OpStore %882 %3286
-%3287 = OpLoad %uchar %881
-%3288 = OpLoad %uchar %882
-%3289 = OpBitwiseOr %uchar %3287 %3288
-OpStore %883 %3289
-%3290 = OpLoad %_arr_uchar_uint_16 %164
-%3291 = OpCompositeExtract %uchar %3290 10
-OpStore %884 %3291
-%3292 = OpLoad %_arr_uchar_uint_16 %170
-%3293 = OpCompositeExtract %uchar %3292 10
-OpStore %885 %3293
-%3294 = OpLoad %uchar %884
-%3295 = OpLoad %uchar %885
-%3296 = OpBitwiseOr %uchar %3294 %3295
-OpStore %886 %3296
-%3297 = OpLoad %_arr_uchar_uint_16 %164
-%3298 = OpCompositeExtract %uchar %3297 11
-OpStore %887 %3298
-%3299 = OpLoad %_arr_uchar_uint_16 %170
-%3300 = OpCompositeExtract %uchar %3299 11
-OpStore %888 %3300
-%3301 = OpLoad %uchar %887
-%3302 = OpLoad %uchar %888
-%3303 = OpBitwiseOr %uchar %3301 %3302
-OpStore %889 %3303
-%3304 = OpLoad %_arr_uchar_uint_16 %164
-%3305 = OpCompositeExtract %uchar %3304 12
-OpStore %890 %3305
-%3306 = OpLoad %_arr_uchar_uint_16 %170
-%3307 = OpCompositeExtract %uchar %3306 12
-OpStore %891 %3307
-%3308 = OpLoad %uchar %890
-%3309 = OpLoad %uchar %891
-%3310 = OpBitwiseOr %uchar %3308 %3309
-OpStore %892 %3310
-%3311 = OpLoad %_arr_uchar_uint_16 %164
-%3312 = OpCompositeExtract %uchar %3311 13
-OpStore %893 %3312
-%3313 = OpLoad %_arr_uchar_uint_16 %170
-%3314 = OpCompositeExtract %uchar %3313 13
-OpStore %894 %3314
-%3315 = OpLoad %uchar %893
-%3316 = OpLoad %uchar %894
-%3317 = OpBitwiseOr %uchar %3315 %3316
-OpStore %895 %3317
-%3318 = OpLoad %_arr_uchar_uint_16 %164
-%3319 = OpCompositeExtract %uchar %3318 14
-OpStore %896 %3319
-%3320 = OpLoad %_arr_uchar_uint_16 %170
-%3321 = OpCompositeExtract %uchar %3320 14
-OpStore %897 %3321
-%3322 = OpLoad %uchar %896
-%3323 = OpLoad %uchar %897
-%3324 = OpBitwiseOr %uchar %3322 %3323
-OpStore %898 %3324
-%3325 = OpLoad %_arr_uchar_uint_16 %164
-%3326 = OpCompositeExtract %uchar %3325 15
-OpStore %899 %3326
-%3327 = OpLoad %_arr_uchar_uint_16 %170
-%3328 = OpCompositeExtract %uchar %3327 15
-OpStore %900 %3328
-%3329 = OpLoad %uchar %899
-%3330 = OpLoad %uchar %900
-%3331 = OpBitwiseOr %uchar %3329 %3330
-OpStore %901 %3331
-%3332 = OpLoad %_arr_uchar_uint_16 %164
-%3333 = OpLoad %uchar %856
-%3334 = OpCompositeInsert %_arr_uchar_uint_16 %3333 %3332 0
-OpStore %902 %3334
-%3335 = OpLoad %_arr_uchar_uint_16 %902
-%3336 = OpLoad %uchar %859
-%3337 = OpCompositeInsert %_arr_uchar_uint_16 %3336 %3335 1
-OpStore %903 %3337
-%3338 = OpLoad %_arr_uchar_uint_16 %903
-%3339 = OpLoad %uchar %862
-%3340 = OpCompositeInsert %_arr_uchar_uint_16 %3339 %3338 2
-OpStore %904 %3340
-%3341 = OpLoad %_arr_uchar_uint_16 %904
-%3342 = OpLoad %uchar %865
-%3343 = OpCompositeInsert %_arr_uchar_uint_16 %3342 %3341 3
-OpStore %905 %3343
-%3344 = OpLoad %_arr_uchar_uint_16 %905
-%3345 = OpLoad %uchar %868
-%3346 = OpCompositeInsert %_arr_uchar_uint_16 %3345 %3344 4
-OpStore %906 %3346
-%3347 = OpLoad %_arr_uchar_uint_16 %906
-%3348 = OpLoad %uchar %871
-%3349 = OpCompositeInsert %_arr_uchar_uint_16 %3348 %3347 5
-OpStore %907 %3349
-%3350 = OpLoad %_arr_uchar_uint_16 %907
-%3351 = OpLoad %uchar %874
-%3352 = OpCompositeInsert %_arr_uchar_uint_16 %3351 %3350 6
-OpStore %908 %3352
-%3353 = OpLoad %_arr_uchar_uint_16 %908
-%3354 = OpLoad %uchar %877
-%3355 = OpCompositeInsert %_arr_uchar_uint_16 %3354 %3353 7
-OpStore %909 %3355
-%3356 = OpLoad %_arr_uchar_uint_16 %909
-%3357 = OpLoad %uchar %880
-%3358 = OpCompositeInsert %_arr_uchar_uint_16 %3357 %3356 8
-OpStore %910 %3358
-%3359 = OpLoad %_arr_uchar_uint_16 %910
-%3360 = OpLoad %uchar %883
-%3361 = OpCompositeInsert %_arr_uchar_uint_16 %3360 %3359 9
-OpStore %911 %3361
-%3362 = OpLoad %_arr_uchar_uint_16 %911
-%3363 = OpLoad %uchar %886
-%3364 = OpCompositeInsert %_arr_uchar_uint_16 %3363 %3362 10
-OpStore %912 %3364
-%3365 = OpLoad %_arr_uchar_uint_16 %912
-%3366 = OpLoad %uchar %889
-%3367 = OpCompositeInsert %_arr_uchar_uint_16 %3366 %3365 11
-OpStore %913 %3367
-%3368 = OpLoad %_arr_uchar_uint_16 %913
-%3369 = OpLoad %uchar %892
-%3370 = OpCompositeInsert %_arr_uchar_uint_16 %3369 %3368 12
-OpStore %914 %3370
-%3371 = OpLoad %_arr_uchar_uint_16 %914
-%3372 = OpLoad %uchar %895
-%3373 = OpCompositeInsert %_arr_uchar_uint_16 %3372 %3371 13
-OpStore %915 %3373
-%3374 = OpLoad %_arr_uchar_uint_16 %915
-%3375 = OpLoad %uchar %898
-%3376 = OpCompositeInsert %_arr_uchar_uint_16 %3375 %3374 14
-OpStore %916 %3376
-%3377 = OpLoad %_arr_uchar_uint_16 %916
-%3378 = OpLoad %uchar %901
-%3379 = OpCompositeInsert %_arr_uchar_uint_16 %3378 %3377 15
-OpStore %917 %3379
-%3380 = OpLoad %ulong %182
-%3381 = OpLoad %_arr_uchar_uint_16 %917
-%3382 = OpFunctionCall %ulong %1 %3380 %3381
-OpStore %183 %3382
-%3383 = OpLoad %_arr_uchar_uint_16 %164
-%3384 = OpCompositeExtract %uchar %3383 0
-OpStore %918 %3384
-%3385 = OpLoad %_arr_uchar_uint_16 %170
-%3386 = OpCompositeExtract %uchar %3385 0
-OpStore %919 %3386
-%3387 = OpLoad %uchar %918
-%3388 = OpLoad %uchar %919
-%3389 = OpBitwiseXor %uchar %3387 %3388
-OpStore %920 %3389
-%3390 = OpLoad %_arr_uchar_uint_16 %164
-%3391 = OpCompositeExtract %uchar %3390 1
-OpStore %921 %3391
-%3392 = OpLoad %_arr_uchar_uint_16 %170
-%3393 = OpCompositeExtract %uchar %3392 1
-OpStore %922 %3393
-%3394 = OpLoad %uchar %921
-%3395 = OpLoad %uchar %922
-%3396 = OpBitwiseXor %uchar %3394 %3395
-OpStore %923 %3396
-%3397 = OpLoad %_arr_uchar_uint_16 %164
-%3398 = OpCompositeExtract %uchar %3397 2
-OpStore %924 %3398
-%3399 = OpLoad %_arr_uchar_uint_16 %170
-%3400 = OpCompositeExtract %uchar %3399 2
-OpStore %925 %3400
-%3401 = OpLoad %uchar %924
-%3402 = OpLoad %uchar %925
-%3403 = OpBitwiseXor %uchar %3401 %3402
-OpStore %926 %3403
-%3404 = OpLoad %_arr_uchar_uint_16 %164
-%3405 = OpCompositeExtract %uchar %3404 3
-OpStore %927 %3405
-%3406 = OpLoad %_arr_uchar_uint_16 %170
-%3407 = OpCompositeExtract %uchar %3406 3
-OpStore %928 %3407
-%3408 = OpLoad %uchar %927
-%3409 = OpLoad %uchar %928
-%3410 = OpBitwiseXor %uchar %3408 %3409
-OpStore %929 %3410
-%3411 = OpLoad %_arr_uchar_uint_16 %164
-%3412 = OpCompositeExtract %uchar %3411 4
-OpStore %930 %3412
-%3413 = OpLoad %_arr_uchar_uint_16 %170
-%3414 = OpCompositeExtract %uchar %3413 4
-OpStore %931 %3414
-%3415 = OpLoad %uchar %930
-%3416 = OpLoad %uchar %931
-%3417 = OpBitwiseXor %uchar %3415 %3416
-OpStore %932 %3417
-%3418 = OpLoad %_arr_uchar_uint_16 %164
-%3419 = OpCompositeExtract %uchar %3418 5
-OpStore %933 %3419
-%3420 = OpLoad %_arr_uchar_uint_16 %170
-%3421 = OpCompositeExtract %uchar %3420 5
-OpStore %934 %3421
-%3422 = OpLoad %uchar %933
-%3423 = OpLoad %uchar %934
-%3424 = OpBitwiseXor %uchar %3422 %3423
-OpStore %935 %3424
-%3425 = OpLoad %_arr_uchar_uint_16 %164
-%3426 = OpCompositeExtract %uchar %3425 6
-OpStore %936 %3426
-%3427 = OpLoad %_arr_uchar_uint_16 %170
-%3428 = OpCompositeExtract %uchar %3427 6
-OpStore %937 %3428
-%3429 = OpLoad %uchar %936
-%3430 = OpLoad %uchar %937
-%3431 = OpBitwiseXor %uchar %3429 %3430
-OpStore %938 %3431
-%3432 = OpLoad %_arr_uchar_uint_16 %164
-%3433 = OpCompositeExtract %uchar %3432 7
-OpStore %939 %3433
-%3434 = OpLoad %_arr_uchar_uint_16 %170
-%3435 = OpCompositeExtract %uchar %3434 7
-OpStore %940 %3435
-%3436 = OpLoad %uchar %939
-%3437 = OpLoad %uchar %940
-%3438 = OpBitwiseXor %uchar %3436 %3437
-OpStore %941 %3438
-%3439 = OpLoad %_arr_uchar_uint_16 %164
-%3440 = OpCompositeExtract %uchar %3439 8
-OpStore %942 %3440
-%3441 = OpLoad %_arr_uchar_uint_16 %170
-%3442 = OpCompositeExtract %uchar %3441 8
-OpStore %943 %3442
-%3443 = OpLoad %uchar %942
-%3444 = OpLoad %uchar %943
-%3445 = OpBitwiseXor %uchar %3443 %3444
-OpStore %944 %3445
-%3446 = OpLoad %_arr_uchar_uint_16 %164
-%3447 = OpCompositeExtract %uchar %3446 9
-OpStore %945 %3447
-%3448 = OpLoad %_arr_uchar_uint_16 %170
-%3449 = OpCompositeExtract %uchar %3448 9
-OpStore %946 %3449
-%3450 = OpLoad %uchar %945
-%3451 = OpLoad %uchar %946
-%3452 = OpBitwiseXor %uchar %3450 %3451
-OpStore %947 %3452
-%3453 = OpLoad %_arr_uchar_uint_16 %164
-%3454 = OpCompositeExtract %uchar %3453 10
-OpStore %948 %3454
-%3455 = OpLoad %_arr_uchar_uint_16 %170
-%3456 = OpCompositeExtract %uchar %3455 10
-OpStore %949 %3456
-%3457 = OpLoad %uchar %948
-%3458 = OpLoad %uchar %949
-%3459 = OpBitwiseXor %uchar %3457 %3458
-OpStore %950 %3459
-%3460 = OpLoad %_arr_uchar_uint_16 %164
-%3461 = OpCompositeExtract %uchar %3460 11
-OpStore %951 %3461
-%3462 = OpLoad %_arr_uchar_uint_16 %170
-%3463 = OpCompositeExtract %uchar %3462 11
-OpStore %952 %3463
-%3464 = OpLoad %uchar %951
-%3465 = OpLoad %uchar %952
-%3466 = OpBitwiseXor %uchar %3464 %3465
-OpStore %953 %3466
-%3467 = OpLoad %_arr_uchar_uint_16 %164
-%3468 = OpCompositeExtract %uchar %3467 12
-OpStore %954 %3468
-%3469 = OpLoad %_arr_uchar_uint_16 %170
-%3470 = OpCompositeExtract %uchar %3469 12
-OpStore %955 %3470
-%3471 = OpLoad %uchar %954
-%3472 = OpLoad %uchar %955
-%3473 = OpBitwiseXor %uchar %3471 %3472
-OpStore %956 %3473
-%3474 = OpLoad %_arr_uchar_uint_16 %164
-%3475 = OpCompositeExtract %uchar %3474 13
-OpStore %957 %3475
-%3476 = OpLoad %_arr_uchar_uint_16 %170
-%3477 = OpCompositeExtract %uchar %3476 13
-OpStore %958 %3477
-%3478 = OpLoad %uchar %957
-%3479 = OpLoad %uchar %958
-%3480 = OpBitwiseXor %uchar %3478 %3479
-OpStore %959 %3480
-%3481 = OpLoad %_arr_uchar_uint_16 %164
-%3482 = OpCompositeExtract %uchar %3481 14
-OpStore %960 %3482
-%3483 = OpLoad %_arr_uchar_uint_16 %170
-%3484 = OpCompositeExtract %uchar %3483 14
-OpStore %961 %3484
-%3485 = OpLoad %uchar %960
-%3486 = OpLoad %uchar %961
-%3487 = OpBitwiseXor %uchar %3485 %3486
-OpStore %962 %3487
-%3488 = OpLoad %_arr_uchar_uint_16 %164
-%3489 = OpCompositeExtract %uchar %3488 15
-OpStore %963 %3489
-%3490 = OpLoad %_arr_uchar_uint_16 %170
-%3491 = OpCompositeExtract %uchar %3490 15
-OpStore %964 %3491
-%3492 = OpLoad %uchar %963
-%3493 = OpLoad %uchar %964
-%3494 = OpBitwiseXor %uchar %3492 %3493
-OpStore %965 %3494
-%3495 = OpLoad %_arr_uchar_uint_16 %164
-%3496 = OpLoad %uchar %920
-%3497 = OpCompositeInsert %_arr_uchar_uint_16 %3496 %3495 0
-OpStore %966 %3497
-%3498 = OpLoad %_arr_uchar_uint_16 %966
-%3499 = OpLoad %uchar %923
-%3500 = OpCompositeInsert %_arr_uchar_uint_16 %3499 %3498 1
-OpStore %967 %3500
-%3501 = OpLoad %_arr_uchar_uint_16 %967
-%3502 = OpLoad %uchar %926
-%3503 = OpCompositeInsert %_arr_uchar_uint_16 %3502 %3501 2
-OpStore %968 %3503
-%3504 = OpLoad %_arr_uchar_uint_16 %968
-%3505 = OpLoad %uchar %929
-%3506 = OpCompositeInsert %_arr_uchar_uint_16 %3505 %3504 3
-OpStore %969 %3506
-%3507 = OpLoad %_arr_uchar_uint_16 %969
-%3508 = OpLoad %uchar %932
-%3509 = OpCompositeInsert %_arr_uchar_uint_16 %3508 %3507 4
-OpStore %970 %3509
-%3510 = OpLoad %_arr_uchar_uint_16 %970
-%3511 = OpLoad %uchar %935
-%3512 = OpCompositeInsert %_arr_uchar_uint_16 %3511 %3510 5
-OpStore %971 %3512
-%3513 = OpLoad %_arr_uchar_uint_16 %971
-%3514 = OpLoad %uchar %938
-%3515 = OpCompositeInsert %_arr_uchar_uint_16 %3514 %3513 6
-OpStore %972 %3515
-%3516 = OpLoad %_arr_uchar_uint_16 %972
-%3517 = OpLoad %uchar %941
-%3518 = OpCompositeInsert %_arr_uchar_uint_16 %3517 %3516 7
-OpStore %973 %3518
-%3519 = OpLoad %_arr_uchar_uint_16 %973
-%3520 = OpLoad %uchar %944
-%3521 = OpCompositeInsert %_arr_uchar_uint_16 %3520 %3519 8
-OpStore %974 %3521
-%3522 = OpLoad %_arr_uchar_uint_16 %974
-%3523 = OpLoad %uchar %947
-%3524 = OpCompositeInsert %_arr_uchar_uint_16 %3523 %3522 9
-OpStore %975 %3524
-%3525 = OpLoad %_arr_uchar_uint_16 %975
-%3526 = OpLoad %uchar %950
-%3527 = OpCompositeInsert %_arr_uchar_uint_16 %3526 %3525 10
-OpStore %976 %3527
-%3528 = OpLoad %_arr_uchar_uint_16 %976
-%3529 = OpLoad %uchar %953
-%3530 = OpCompositeInsert %_arr_uchar_uint_16 %3529 %3528 11
-OpStore %977 %3530
-%3531 = OpLoad %_arr_uchar_uint_16 %977
-%3532 = OpLoad %uchar %956
-%3533 = OpCompositeInsert %_arr_uchar_uint_16 %3532 %3531 12
-OpStore %978 %3533
-%3534 = OpLoad %_arr_uchar_uint_16 %978
-%3535 = OpLoad %uchar %959
-%3536 = OpCompositeInsert %_arr_uchar_uint_16 %3535 %3534 13
-OpStore %979 %3536
-%3537 = OpLoad %_arr_uchar_uint_16 %979
-%3538 = OpLoad %uchar %962
-%3539 = OpCompositeInsert %_arr_uchar_uint_16 %3538 %3537 14
-OpStore %980 %3539
-%3540 = OpLoad %_arr_uchar_uint_16 %980
-%3541 = OpLoad %uchar %965
-%3542 = OpCompositeInsert %_arr_uchar_uint_16 %3541 %3540 15
-OpStore %981 %3542
-%3543 = OpLoad %ulong %183
-%3544 = OpLoad %_arr_uchar_uint_16 %981
-%3545 = OpFunctionCall %ulong %1 %3543 %3544
-OpStore %184 %3545
-%3546 = OpLoad %_arr_uchar_uint_16 %164
-%3547 = OpCompositeExtract %uchar %3546 0
-OpStore %982 %3547
-%3548 = OpLoad %uchar %982
-%3549 = OpNot %uchar %3548
-OpStore %983 %3549
-%3550 = OpLoad %_arr_uchar_uint_16 %164
-%3551 = OpCompositeExtract %uchar %3550 1
-OpStore %984 %3551
-%3552 = OpLoad %uchar %984
-%3553 = OpNot %uchar %3552
-OpStore %985 %3553
-%3554 = OpLoad %_arr_uchar_uint_16 %164
-%3555 = OpCompositeExtract %uchar %3554 2
-OpStore %986 %3555
-%3556 = OpLoad %uchar %986
-%3557 = OpNot %uchar %3556
-OpStore %987 %3557
-%3558 = OpLoad %_arr_uchar_uint_16 %164
-%3559 = OpCompositeExtract %uchar %3558 3
-OpStore %988 %3559
-%3560 = OpLoad %uchar %988
-%3561 = OpNot %uchar %3560
-OpStore %989 %3561
-%3562 = OpLoad %_arr_uchar_uint_16 %164
-%3563 = OpCompositeExtract %uchar %3562 4
-OpStore %990 %3563
-%3564 = OpLoad %uchar %990
-%3565 = OpNot %uchar %3564
-OpStore %991 %3565
-%3566 = OpLoad %_arr_uchar_uint_16 %164
-%3567 = OpCompositeExtract %uchar %3566 5
-OpStore %992 %3567
-%3568 = OpLoad %uchar %992
-%3569 = OpNot %uchar %3568
-OpStore %993 %3569
-%3570 = OpLoad %_arr_uchar_uint_16 %164
-%3571 = OpCompositeExtract %uchar %3570 6
-OpStore %994 %3571
-%3572 = OpLoad %uchar %994
-%3573 = OpNot %uchar %3572
-OpStore %995 %3573
-%3574 = OpLoad %_arr_uchar_uint_16 %164
-%3575 = OpCompositeExtract %uchar %3574 7
-OpStore %996 %3575
-%3576 = OpLoad %uchar %996
-%3577 = OpNot %uchar %3576
-OpStore %997 %3577
-%3578 = OpLoad %_arr_uchar_uint_16 %164
-%3579 = OpCompositeExtract %uchar %3578 8
-OpStore %998 %3579
-%3580 = OpLoad %uchar %998
-%3581 = OpNot %uchar %3580
-OpStore %999 %3581
-%3582 = OpLoad %_arr_uchar_uint_16 %164
-%3583 = OpCompositeExtract %uchar %3582 9
-OpStore %1000 %3583
-%3584 = OpLoad %uchar %1000
-%3585 = OpNot %uchar %3584
-OpStore %1001 %3585
-%3586 = OpLoad %_arr_uchar_uint_16 %164
-%3587 = OpCompositeExtract %uchar %3586 10
-OpStore %1002 %3587
-%3588 = OpLoad %uchar %1002
-%3589 = OpNot %uchar %3588
-OpStore %1003 %3589
-%3590 = OpLoad %_arr_uchar_uint_16 %164
-%3591 = OpCompositeExtract %uchar %3590 11
-OpStore %1004 %3591
-%3592 = OpLoad %uchar %1004
-%3593 = OpNot %uchar %3592
-OpStore %1005 %3593
-%3594 = OpLoad %_arr_uchar_uint_16 %164
-%3595 = OpCompositeExtract %uchar %3594 12
-OpStore %1006 %3595
-%3596 = OpLoad %uchar %1006
-%3597 = OpNot %uchar %3596
-OpStore %1007 %3597
-%3598 = OpLoad %_arr_uchar_uint_16 %164
-%3599 = OpCompositeExtract %uchar %3598 13
-OpStore %1008 %3599
-%3600 = OpLoad %uchar %1008
-%3601 = OpNot %uchar %3600
-OpStore %1009 %3601
-%3602 = OpLoad %_arr_uchar_uint_16 %164
-%3603 = OpCompositeExtract %uchar %3602 14
-OpStore %1010 %3603
-%3604 = OpLoad %uchar %1010
-%3605 = OpNot %uchar %3604
-OpStore %1011 %3605
-%3606 = OpLoad %_arr_uchar_uint_16 %164
-%3607 = OpCompositeExtract %uchar %3606 15
-OpStore %1012 %3607
-%3608 = OpLoad %uchar %1012
-%3609 = OpNot %uchar %3608
-OpStore %1013 %3609
-%3610 = OpLoad %_arr_uchar_uint_16 %164
-%3611 = OpLoad %uchar %983
-%3612 = OpCompositeInsert %_arr_uchar_uint_16 %3611 %3610 0
-OpStore %1014 %3612
-%3613 = OpLoad %_arr_uchar_uint_16 %1014
-%3614 = OpLoad %uchar %985
-%3615 = OpCompositeInsert %_arr_uchar_uint_16 %3614 %3613 1
-OpStore %1015 %3615
-%3616 = OpLoad %_arr_uchar_uint_16 %1015
-%3617 = OpLoad %uchar %987
-%3618 = OpCompositeInsert %_arr_uchar_uint_16 %3617 %3616 2
-OpStore %1016 %3618
-%3619 = OpLoad %_arr_uchar_uint_16 %1016
-%3620 = OpLoad %uchar %989
-%3621 = OpCompositeInsert %_arr_uchar_uint_16 %3620 %3619 3
-OpStore %1017 %3621
-%3622 = OpLoad %_arr_uchar_uint_16 %1017
-%3623 = OpLoad %uchar %991
-%3624 = OpCompositeInsert %_arr_uchar_uint_16 %3623 %3622 4
-OpStore %1018 %3624
-%3625 = OpLoad %_arr_uchar_uint_16 %1018
-%3626 = OpLoad %uchar %993
-%3627 = OpCompositeInsert %_arr_uchar_uint_16 %3626 %3625 5
-OpStore %1019 %3627
-%3628 = OpLoad %_arr_uchar_uint_16 %1019
-%3629 = OpLoad %uchar %995
-%3630 = OpCompositeInsert %_arr_uchar_uint_16 %3629 %3628 6
-OpStore %1020 %3630
-%3631 = OpLoad %_arr_uchar_uint_16 %1020
-%3632 = OpLoad %uchar %997
-%3633 = OpCompositeInsert %_arr_uchar_uint_16 %3632 %3631 7
-OpStore %1021 %3633
-%3634 = OpLoad %_arr_uchar_uint_16 %1021
-%3635 = OpLoad %uchar %999
-%3636 = OpCompositeInsert %_arr_uchar_uint_16 %3635 %3634 8
-OpStore %1022 %3636
-%3637 = OpLoad %_arr_uchar_uint_16 %1022
-%3638 = OpLoad %uchar %1001
-%3639 = OpCompositeInsert %_arr_uchar_uint_16 %3638 %3637 9
-OpStore %1023 %3639
-%3640 = OpLoad %_arr_uchar_uint_16 %1023
-%3641 = OpLoad %uchar %1003
-%3642 = OpCompositeInsert %_arr_uchar_uint_16 %3641 %3640 10
-OpStore %1024 %3642
-%3643 = OpLoad %_arr_uchar_uint_16 %1024
-%3644 = OpLoad %uchar %1005
-%3645 = OpCompositeInsert %_arr_uchar_uint_16 %3644 %3643 11
-OpStore %1025 %3645
-%3646 = OpLoad %_arr_uchar_uint_16 %1025
-%3647 = OpLoad %uchar %1007
-%3648 = OpCompositeInsert %_arr_uchar_uint_16 %3647 %3646 12
-OpStore %1026 %3648
-%3649 = OpLoad %_arr_uchar_uint_16 %1026
-%3650 = OpLoad %uchar %1009
-%3651 = OpCompositeInsert %_arr_uchar_uint_16 %3650 %3649 13
-OpStore %1027 %3651
-%3652 = OpLoad %_arr_uchar_uint_16 %1027
-%3653 = OpLoad %uchar %1011
-%3654 = OpCompositeInsert %_arr_uchar_uint_16 %3653 %3652 14
-OpStore %1028 %3654
-%3655 = OpLoad %_arr_uchar_uint_16 %1028
-%3656 = OpLoad %uchar %1013
-%3657 = OpCompositeInsert %_arr_uchar_uint_16 %3656 %3655 15
-OpStore %1029 %3657
-%3658 = OpLoad %ulong %184
-%3659 = OpLoad %_arr_uchar_uint_16 %1029
-%3660 = OpFunctionCall %ulong %1 %3658 %3659
-OpStore %185 %3660
-%3661 = OpLoad %_arr_uchar_uint_16 %170
-%3662 = OpCompositeExtract %uchar %3661 0
-OpStore %1030 %3662
-%3663 = OpLoad %uchar %1030
-%3664 = OpNot %uchar %3663
-OpStore %1031 %3664
-%3665 = OpLoad %_arr_uchar_uint_16 %170
-%3666 = OpCompositeExtract %uchar %3665 1
-OpStore %1032 %3666
-%3667 = OpLoad %uchar %1032
-%3668 = OpNot %uchar %3667
-OpStore %1033 %3668
-%3669 = OpLoad %_arr_uchar_uint_16 %170
-%3670 = OpCompositeExtract %uchar %3669 2
-OpStore %1034 %3670
-%3671 = OpLoad %uchar %1034
-%3672 = OpNot %uchar %3671
-OpStore %1035 %3672
-%3673 = OpLoad %_arr_uchar_uint_16 %170
-%3674 = OpCompositeExtract %uchar %3673 3
-OpStore %1036 %3674
-%3675 = OpLoad %uchar %1036
-%3676 = OpNot %uchar %3675
-OpStore %1037 %3676
-%3677 = OpLoad %_arr_uchar_uint_16 %170
-%3678 = OpCompositeExtract %uchar %3677 4
-OpStore %1038 %3678
-%3679 = OpLoad %uchar %1038
-%3680 = OpNot %uchar %3679
-OpStore %1039 %3680
-%3681 = OpLoad %_arr_uchar_uint_16 %170
-%3682 = OpCompositeExtract %uchar %3681 5
-OpStore %1040 %3682
-%3683 = OpLoad %uchar %1040
-%3684 = OpNot %uchar %3683
-OpStore %1041 %3684
-%3685 = OpLoad %_arr_uchar_uint_16 %170
-%3686 = OpCompositeExtract %uchar %3685 6
-OpStore %1042 %3686
-%3687 = OpLoad %uchar %1042
-%3688 = OpNot %uchar %3687
-OpStore %1043 %3688
-%3689 = OpLoad %_arr_uchar_uint_16 %170
-%3690 = OpCompositeExtract %uchar %3689 7
-OpStore %1044 %3690
-%3691 = OpLoad %uchar %1044
-%3692 = OpNot %uchar %3691
-OpStore %1045 %3692
-%3693 = OpLoad %_arr_uchar_uint_16 %170
-%3694 = OpCompositeExtract %uchar %3693 8
-OpStore %1046 %3694
-%3695 = OpLoad %uchar %1046
-%3696 = OpNot %uchar %3695
-OpStore %1047 %3696
-%3697 = OpLoad %_arr_uchar_uint_16 %170
-%3698 = OpCompositeExtract %uchar %3697 9
-OpStore %1048 %3698
-%3699 = OpLoad %uchar %1048
-%3700 = OpNot %uchar %3699
-OpStore %1049 %3700
-%3701 = OpLoad %_arr_uchar_uint_16 %170
-%3702 = OpCompositeExtract %uchar %3701 10
-OpStore %1050 %3702
-%3703 = OpLoad %uchar %1050
-%3704 = OpNot %uchar %3703
-OpStore %1051 %3704
-%3705 = OpLoad %_arr_uchar_uint_16 %170
-%3706 = OpCompositeExtract %uchar %3705 11
-OpStore %1052 %3706
-%3707 = OpLoad %uchar %1052
-%3708 = OpNot %uchar %3707
-OpStore %1053 %3708
-%3709 = OpLoad %_arr_uchar_uint_16 %170
-%3710 = OpCompositeExtract %uchar %3709 12
-OpStore %1054 %3710
-%3711 = OpLoad %uchar %1054
-%3712 = OpNot %uchar %3711
-OpStore %1055 %3712
-%3713 = OpLoad %_arr_uchar_uint_16 %170
-%3714 = OpCompositeExtract %uchar %3713 13
-OpStore %1056 %3714
-%3715 = OpLoad %uchar %1056
-%3716 = OpNot %uchar %3715
-OpStore %1057 %3716
-%3717 = OpLoad %_arr_uchar_uint_16 %170
-%3718 = OpCompositeExtract %uchar %3717 14
-OpStore %1058 %3718
-%3719 = OpLoad %uchar %1058
-%3720 = OpNot %uchar %3719
-OpStore %1059 %3720
-%3721 = OpLoad %_arr_uchar_uint_16 %170
-%3722 = OpCompositeExtract %uchar %3721 15
-OpStore %1060 %3722
-%3723 = OpLoad %uchar %1060
-%3724 = OpNot %uchar %3723
-OpStore %1061 %3724
-%3725 = OpLoad %_arr_uchar_uint_16 %170
-%3726 = OpLoad %uchar %1031
-%3727 = OpCompositeInsert %_arr_uchar_uint_16 %3726 %3725 0
-OpStore %1062 %3727
-%3728 = OpLoad %_arr_uchar_uint_16 %1062
-%3729 = OpLoad %uchar %1033
-%3730 = OpCompositeInsert %_arr_uchar_uint_16 %3729 %3728 1
-OpStore %1063 %3730
-%3731 = OpLoad %_arr_uchar_uint_16 %1063
-%3732 = OpLoad %uchar %1035
-%3733 = OpCompositeInsert %_arr_uchar_uint_16 %3732 %3731 2
-OpStore %1064 %3733
-%3734 = OpLoad %_arr_uchar_uint_16 %1064
-%3735 = OpLoad %uchar %1037
-%3736 = OpCompositeInsert %_arr_uchar_uint_16 %3735 %3734 3
-OpStore %1065 %3736
-%3737 = OpLoad %_arr_uchar_uint_16 %1065
-%3738 = OpLoad %uchar %1039
-%3739 = OpCompositeInsert %_arr_uchar_uint_16 %3738 %3737 4
-OpStore %1066 %3739
-%3740 = OpLoad %_arr_uchar_uint_16 %1066
-%3741 = OpLoad %uchar %1041
-%3742 = OpCompositeInsert %_arr_uchar_uint_16 %3741 %3740 5
-OpStore %1067 %3742
-%3743 = OpLoad %_arr_uchar_uint_16 %1067
-%3744 = OpLoad %uchar %1043
-%3745 = OpCompositeInsert %_arr_uchar_uint_16 %3744 %3743 6
-OpStore %1068 %3745
-%3746 = OpLoad %_arr_uchar_uint_16 %1068
-%3747 = OpLoad %uchar %1045
-%3748 = OpCompositeInsert %_arr_uchar_uint_16 %3747 %3746 7
-OpStore %1069 %3748
-%3749 = OpLoad %_arr_uchar_uint_16 %1069
-%3750 = OpLoad %uchar %1047
-%3751 = OpCompositeInsert %_arr_uchar_uint_16 %3750 %3749 8
-OpStore %1070 %3751
-%3752 = OpLoad %_arr_uchar_uint_16 %1070
-%3753 = OpLoad %uchar %1049
-%3754 = OpCompositeInsert %_arr_uchar_uint_16 %3753 %3752 9
-OpStore %1071 %3754
-%3755 = OpLoad %_arr_uchar_uint_16 %1071
-%3756 = OpLoad %uchar %1051
-%3757 = OpCompositeInsert %_arr_uchar_uint_16 %3756 %3755 10
-OpStore %1072 %3757
-%3758 = OpLoad %_arr_uchar_uint_16 %1072
-%3759 = OpLoad %uchar %1053
-%3760 = OpCompositeInsert %_arr_uchar_uint_16 %3759 %3758 11
-OpStore %1073 %3760
-%3761 = OpLoad %_arr_uchar_uint_16 %1073
-%3762 = OpLoad %uchar %1055
-%3763 = OpCompositeInsert %_arr_uchar_uint_16 %3762 %3761 12
-OpStore %1074 %3763
-%3764 = OpLoad %_arr_uchar_uint_16 %1074
-%3765 = OpLoad %uchar %1057
-%3766 = OpCompositeInsert %_arr_uchar_uint_16 %3765 %3764 13
-OpStore %1075 %3766
-%3767 = OpLoad %_arr_uchar_uint_16 %1075
-%3768 = OpLoad %uchar %1059
-%3769 = OpCompositeInsert %_arr_uchar_uint_16 %3768 %3767 14
-OpStore %1076 %3769
-%3770 = OpLoad %_arr_uchar_uint_16 %1076
-%3771 = OpLoad %uchar %1061
-%3772 = OpCompositeInsert %_arr_uchar_uint_16 %3771 %3770 15
-OpStore %1077 %3772
-%3773 = OpLoad %ulong %185
-%3774 = OpLoad %_arr_uchar_uint_16 %1077
-%3775 = OpFunctionCall %ulong %1 %3773 %3774
-OpStore %186 %3775
-%3776 = OpLoad %_arr_uchar_uint_16 %853
-%3777 = OpCompositeExtract %uchar %3776 0
-OpStore %1078 %3777
-%3778 = OpLoad %_arr_uchar_uint_16 %917
-%3779 = OpCompositeExtract %uchar %3778 0
-OpStore %1079 %3779
-%3780 = OpLoad %uchar %1078
-%3781 = OpLoad %uchar %1079
-%3782 = OpBitwiseXor %uchar %3780 %3781
-OpStore %1080 %3782
-%3783 = OpLoad %_arr_uchar_uint_16 %853
-%3784 = OpCompositeExtract %uchar %3783 1
-OpStore %1081 %3784
-%3785 = OpLoad %_arr_uchar_uint_16 %917
-%3786 = OpCompositeExtract %uchar %3785 1
-OpStore %1082 %3786
-%3787 = OpLoad %uchar %1081
-%3788 = OpLoad %uchar %1082
-%3789 = OpBitwiseXor %uchar %3787 %3788
-OpStore %1083 %3789
-%3790 = OpLoad %_arr_uchar_uint_16 %853
-%3791 = OpCompositeExtract %uchar %3790 2
-OpStore %1084 %3791
-%3792 = OpLoad %_arr_uchar_uint_16 %917
-%3793 = OpCompositeExtract %uchar %3792 2
-OpStore %1085 %3793
-%3794 = OpLoad %uchar %1084
-%3795 = OpLoad %uchar %1085
-%3796 = OpBitwiseXor %uchar %3794 %3795
-OpStore %1086 %3796
-%3797 = OpLoad %_arr_uchar_uint_16 %853
-%3798 = OpCompositeExtract %uchar %3797 3
-OpStore %1087 %3798
-%3799 = OpLoad %_arr_uchar_uint_16 %917
-%3800 = OpCompositeExtract %uchar %3799 3
-OpStore %1088 %3800
-%3801 = OpLoad %uchar %1087
-%3802 = OpLoad %uchar %1088
-%3803 = OpBitwiseXor %uchar %3801 %3802
-OpStore %1089 %3803
-%3804 = OpLoad %_arr_uchar_uint_16 %853
-%3805 = OpCompositeExtract %uchar %3804 4
-OpStore %1090 %3805
-%3806 = OpLoad %_arr_uchar_uint_16 %917
-%3807 = OpCompositeExtract %uchar %3806 4
-OpStore %1091 %3807
-%3808 = OpLoad %uchar %1090
-%3809 = OpLoad %uchar %1091
-%3810 = OpBitwiseXor %uchar %3808 %3809
-OpStore %1092 %3810
-%3811 = OpLoad %_arr_uchar_uint_16 %853
-%3812 = OpCompositeExtract %uchar %3811 5
-OpStore %1093 %3812
-%3813 = OpLoad %_arr_uchar_uint_16 %917
-%3814 = OpCompositeExtract %uchar %3813 5
-OpStore %1094 %3814
-%3815 = OpLoad %uchar %1093
-%3816 = OpLoad %uchar %1094
-%3817 = OpBitwiseXor %uchar %3815 %3816
-OpStore %1095 %3817
-%3818 = OpLoad %_arr_uchar_uint_16 %853
-%3819 = OpCompositeExtract %uchar %3818 6
-OpStore %1096 %3819
-%3820 = OpLoad %_arr_uchar_uint_16 %917
-%3821 = OpCompositeExtract %uchar %3820 6
-OpStore %1097 %3821
-%3822 = OpLoad %uchar %1096
-%3823 = OpLoad %uchar %1097
-%3824 = OpBitwiseXor %uchar %3822 %3823
-OpStore %1098 %3824
-%3825 = OpLoad %_arr_uchar_uint_16 %853
-%3826 = OpCompositeExtract %uchar %3825 7
-OpStore %1099 %3826
-%3827 = OpLoad %_arr_uchar_uint_16 %917
-%3828 = OpCompositeExtract %uchar %3827 7
-OpStore %1100 %3828
-%3829 = OpLoad %uchar %1099
-%3830 = OpLoad %uchar %1100
-%3831 = OpBitwiseXor %uchar %3829 %3830
-OpStore %1101 %3831
-%3832 = OpLoad %_arr_uchar_uint_16 %853
-%3833 = OpCompositeExtract %uchar %3832 8
-OpStore %1102 %3833
-%3834 = OpLoad %_arr_uchar_uint_16 %917
-%3835 = OpCompositeExtract %uchar %3834 8
-OpStore %1103 %3835
-%3836 = OpLoad %uchar %1102
-%3837 = OpLoad %uchar %1103
-%3838 = OpBitwiseXor %uchar %3836 %3837
-OpStore %1104 %3838
-%3839 = OpLoad %_arr_uchar_uint_16 %853
-%3840 = OpCompositeExtract %uchar %3839 9
-OpStore %1105 %3840
-%3841 = OpLoad %_arr_uchar_uint_16 %917
-%3842 = OpCompositeExtract %uchar %3841 9
-OpStore %1106 %3842
-%3843 = OpLoad %uchar %1105
-%3844 = OpLoad %uchar %1106
-%3845 = OpBitwiseXor %uchar %3843 %3844
-OpStore %1107 %3845
-%3846 = OpLoad %_arr_uchar_uint_16 %853
-%3847 = OpCompositeExtract %uchar %3846 10
-OpStore %1108 %3847
-%3848 = OpLoad %_arr_uchar_uint_16 %917
-%3849 = OpCompositeExtract %uchar %3848 10
-OpStore %1109 %3849
-%3850 = OpLoad %uchar %1108
-%3851 = OpLoad %uchar %1109
-%3852 = OpBitwiseXor %uchar %3850 %3851
-OpStore %1110 %3852
-%3853 = OpLoad %_arr_uchar_uint_16 %853
-%3854 = OpCompositeExtract %uchar %3853 11
-OpStore %1111 %3854
-%3855 = OpLoad %_arr_uchar_uint_16 %917
-%3856 = OpCompositeExtract %uchar %3855 11
-OpStore %1112 %3856
-%3857 = OpLoad %uchar %1111
-%3858 = OpLoad %uchar %1112
-%3859 = OpBitwiseXor %uchar %3857 %3858
-OpStore %1113 %3859
-%3860 = OpLoad %_arr_uchar_uint_16 %853
-%3861 = OpCompositeExtract %uchar %3860 12
-OpStore %1114 %3861
-%3862 = OpLoad %_arr_uchar_uint_16 %917
-%3863 = OpCompositeExtract %uchar %3862 12
-OpStore %1115 %3863
-%3864 = OpLoad %uchar %1114
-%3865 = OpLoad %uchar %1115
-%3866 = OpBitwiseXor %uchar %3864 %3865
-OpStore %1116 %3866
-%3867 = OpLoad %_arr_uchar_uint_16 %853
-%3868 = OpCompositeExtract %uchar %3867 13
-OpStore %1117 %3868
-%3869 = OpLoad %_arr_uchar_uint_16 %917
-%3870 = OpCompositeExtract %uchar %3869 13
-OpStore %1118 %3870
-%3871 = OpLoad %uchar %1117
-%3872 = OpLoad %uchar %1118
-%3873 = OpBitwiseXor %uchar %3871 %3872
-OpStore %1119 %3873
-%3874 = OpLoad %_arr_uchar_uint_16 %853
-%3875 = OpCompositeExtract %uchar %3874 14
-OpStore %1120 %3875
-%3876 = OpLoad %_arr_uchar_uint_16 %917
-%3877 = OpCompositeExtract %uchar %3876 14
-OpStore %1121 %3877
-%3878 = OpLoad %uchar %1120
-%3879 = OpLoad %uchar %1121
-%3880 = OpBitwiseXor %uchar %3878 %3879
-OpStore %1122 %3880
-%3881 = OpLoad %_arr_uchar_uint_16 %853
-%3882 = OpCompositeExtract %uchar %3881 15
-OpStore %1123 %3882
-%3883 = OpLoad %_arr_uchar_uint_16 %917
-%3884 = OpCompositeExtract %uchar %3883 15
-OpStore %1124 %3884
-%3885 = OpLoad %uchar %1123
-%3886 = OpLoad %uchar %1124
-%3887 = OpBitwiseXor %uchar %3885 %3886
-OpStore %1125 %3887
-%3888 = OpLoad %_arr_uchar_uint_16 %853
-%3889 = OpLoad %uchar %1080
-%3890 = OpCompositeInsert %_arr_uchar_uint_16 %3889 %3888 0
-OpStore %1126 %3890
-%3891 = OpLoad %_arr_uchar_uint_16 %1126
-%3892 = OpLoad %uchar %1083
-%3893 = OpCompositeInsert %_arr_uchar_uint_16 %3892 %3891 1
-OpStore %1127 %3893
-%3894 = OpLoad %_arr_uchar_uint_16 %1127
-%3895 = OpLoad %uchar %1086
-%3896 = OpCompositeInsert %_arr_uchar_uint_16 %3895 %3894 2
-OpStore %1128 %3896
-%3897 = OpLoad %_arr_uchar_uint_16 %1128
-%3898 = OpLoad %uchar %1089
-%3899 = OpCompositeInsert %_arr_uchar_uint_16 %3898 %3897 3
-OpStore %1129 %3899
-%3900 = OpLoad %_arr_uchar_uint_16 %1129
-%3901 = OpLoad %uchar %1092
-%3902 = OpCompositeInsert %_arr_uchar_uint_16 %3901 %3900 4
-OpStore %1130 %3902
-%3903 = OpLoad %_arr_uchar_uint_16 %1130
-%3904 = OpLoad %uchar %1095
-%3905 = OpCompositeInsert %_arr_uchar_uint_16 %3904 %3903 5
-OpStore %1131 %3905
-%3906 = OpLoad %_arr_uchar_uint_16 %1131
-%3907 = OpLoad %uchar %1098
-%3908 = OpCompositeInsert %_arr_uchar_uint_16 %3907 %3906 6
-OpStore %1132 %3908
-%3909 = OpLoad %_arr_uchar_uint_16 %1132
-%3910 = OpLoad %uchar %1101
-%3911 = OpCompositeInsert %_arr_uchar_uint_16 %3910 %3909 7
-OpStore %1133 %3911
-%3912 = OpLoad %_arr_uchar_uint_16 %1133
-%3913 = OpLoad %uchar %1104
-%3914 = OpCompositeInsert %_arr_uchar_uint_16 %3913 %3912 8
-OpStore %1134 %3914
-%3915 = OpLoad %_arr_uchar_uint_16 %1134
-%3916 = OpLoad %uchar %1107
-%3917 = OpCompositeInsert %_arr_uchar_uint_16 %3916 %3915 9
-OpStore %1135 %3917
-%3918 = OpLoad %_arr_uchar_uint_16 %1135
-%3919 = OpLoad %uchar %1110
-%3920 = OpCompositeInsert %_arr_uchar_uint_16 %3919 %3918 10
-OpStore %1136 %3920
-%3921 = OpLoad %_arr_uchar_uint_16 %1136
-%3922 = OpLoad %uchar %1113
-%3923 = OpCompositeInsert %_arr_uchar_uint_16 %3922 %3921 11
-OpStore %1137 %3923
-%3924 = OpLoad %_arr_uchar_uint_16 %1137
-%3925 = OpLoad %uchar %1116
-%3926 = OpCompositeInsert %_arr_uchar_uint_16 %3925 %3924 12
-OpStore %1138 %3926
-%3927 = OpLoad %_arr_uchar_uint_16 %1138
-%3928 = OpLoad %uchar %1119
-%3929 = OpCompositeInsert %_arr_uchar_uint_16 %3928 %3927 13
-OpStore %1139 %3929
-%3930 = OpLoad %_arr_uchar_uint_16 %1139
-%3931 = OpLoad %uchar %1122
-%3932 = OpCompositeInsert %_arr_uchar_uint_16 %3931 %3930 14
-OpStore %1140 %3932
-%3933 = OpLoad %_arr_uchar_uint_16 %1140
-%3934 = OpLoad %uchar %1125
-%3935 = OpCompositeInsert %_arr_uchar_uint_16 %3934 %3933 15
-OpStore %1141 %3935
-%3936 = OpLoad %ulong %186
-%3937 = OpLoad %_arr_uchar_uint_16 %1141
-%3938 = OpFunctionCall %ulong %1 %3936 %3937
-OpStore %187 %3938
-%3939 = OpLoad %ulong %187
-OpStore %208 %3939
-%3940 = OpLoad %_arr_uchar_uint_16 %164
-OpStore %209 %3940
-%3941 = OpLoad %_arr_uchar_uint_16 %158
-OpStore %210 %3941
-%3942 = OpLoad %_arr_uchar_uint_16 %158
-OpStore %211 %3942
-OpStore %212 %ulong_0
-OpBranch %136
-%136 = OpLabel
-%3944 = OpLoad %ulong %212
-%3946 = OpULessThan %bool %3944 %ulong_3
-OpStore %189 %3946
-%3947 = OpLoad %bool %189
-OpLoopMerge %138 %143 None
-OpBranchConditional %3947 %137 %138
-%138 = OpLabel
-OpStore %148 %3948
-%3950 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_0
-%3951 = OpLoad %_arr_uchar_uint_16 %209
-OpStore %3950 %3951
-%3952 = OpLoad %_arr_uchar_uint_16 %209
-%3953 = OpCompositeExtract %uchar %3952 0
-OpStore %1398 %3953
-%3954 = OpLoad %_arr_uchar_uint_16 %170
-%3955 = OpCompositeExtract %uchar %3954 0
-OpStore %1399 %3955
-%3956 = OpLoad %uchar %1398
-%3957 = OpLoad %uchar %1399
-%3958 = OpIAdd %uchar %3956 %3957
-OpStore %1400 %3958
-%3959 = OpLoad %_arr_uchar_uint_16 %209
-%3960 = OpCompositeExtract %uchar %3959 1
-OpStore %1401 %3960
-%3961 = OpLoad %_arr_uchar_uint_16 %170
-%3962 = OpCompositeExtract %uchar %3961 1
-OpStore %1402 %3962
-%3963 = OpLoad %uchar %1401
-%3964 = OpLoad %uchar %1402
-%3965 = OpIAdd %uchar %3963 %3964
-OpStore %1403 %3965
-%3966 = OpLoad %_arr_uchar_uint_16 %209
-%3967 = OpCompositeExtract %uchar %3966 2
-OpStore %1404 %3967
-%3968 = OpLoad %_arr_uchar_uint_16 %170
-%3969 = OpCompositeExtract %uchar %3968 2
-OpStore %1405 %3969
-%3970 = OpLoad %uchar %1404
-%3971 = OpLoad %uchar %1405
-%3972 = OpIAdd %uchar %3970 %3971
-OpStore %1406 %3972
-%3973 = OpLoad %_arr_uchar_uint_16 %209
-%3974 = OpCompositeExtract %uchar %3973 3
-OpStore %1407 %3974
-%3975 = OpLoad %_arr_uchar_uint_16 %170
-%3976 = OpCompositeExtract %uchar %3975 3
-OpStore %1408 %3976
-%3977 = OpLoad %uchar %1407
-%3978 = OpLoad %uchar %1408
-%3979 = OpIAdd %uchar %3977 %3978
-OpStore %1409 %3979
-%3980 = OpLoad %_arr_uchar_uint_16 %209
-%3981 = OpCompositeExtract %uchar %3980 4
-OpStore %1410 %3981
-%3982 = OpLoad %_arr_uchar_uint_16 %170
-%3983 = OpCompositeExtract %uchar %3982 4
-OpStore %1411 %3983
-%3984 = OpLoad %uchar %1410
-%3985 = OpLoad %uchar %1411
-%3986 = OpIAdd %uchar %3984 %3985
-OpStore %1412 %3986
-%3987 = OpLoad %_arr_uchar_uint_16 %209
-%3988 = OpCompositeExtract %uchar %3987 5
-OpStore %1413 %3988
-%3989 = OpLoad %_arr_uchar_uint_16 %170
-%3990 = OpCompositeExtract %uchar %3989 5
-OpStore %1414 %3990
-%3991 = OpLoad %uchar %1413
-%3992 = OpLoad %uchar %1414
-%3993 = OpIAdd %uchar %3991 %3992
-OpStore %1415 %3993
-%3994 = OpLoad %_arr_uchar_uint_16 %209
-%3995 = OpCompositeExtract %uchar %3994 6
-OpStore %1416 %3995
-%3996 = OpLoad %_arr_uchar_uint_16 %170
-%3997 = OpCompositeExtract %uchar %3996 6
-OpStore %1417 %3997
-%3998 = OpLoad %uchar %1416
-%3999 = OpLoad %uchar %1417
-%4000 = OpIAdd %uchar %3998 %3999
-OpStore %1418 %4000
-%4001 = OpLoad %_arr_uchar_uint_16 %209
-%4002 = OpCompositeExtract %uchar %4001 7
-OpStore %1419 %4002
-%4003 = OpLoad %_arr_uchar_uint_16 %170
-%4004 = OpCompositeExtract %uchar %4003 7
-OpStore %1420 %4004
-%4005 = OpLoad %uchar %1419
-%4006 = OpLoad %uchar %1420
-%4007 = OpIAdd %uchar %4005 %4006
-OpStore %1421 %4007
-%4008 = OpLoad %_arr_uchar_uint_16 %209
-%4009 = OpCompositeExtract %uchar %4008 8
-OpStore %1422 %4009
-%4010 = OpLoad %_arr_uchar_uint_16 %170
-%4011 = OpCompositeExtract %uchar %4010 8
-OpStore %1423 %4011
-%4012 = OpLoad %uchar %1422
-%4013 = OpLoad %uchar %1423
-%4014 = OpIAdd %uchar %4012 %4013
-OpStore %1424 %4014
-%4015 = OpLoad %_arr_uchar_uint_16 %209
-%4016 = OpCompositeExtract %uchar %4015 9
-OpStore %1425 %4016
-%4017 = OpLoad %_arr_uchar_uint_16 %170
-%4018 = OpCompositeExtract %uchar %4017 9
-OpStore %1426 %4018
-%4019 = OpLoad %uchar %1425
-%4020 = OpLoad %uchar %1426
-%4021 = OpIAdd %uchar %4019 %4020
-OpStore %1427 %4021
-%4022 = OpLoad %_arr_uchar_uint_16 %209
-%4023 = OpCompositeExtract %uchar %4022 10
-OpStore %1428 %4023
-%4024 = OpLoad %_arr_uchar_uint_16 %170
-%4025 = OpCompositeExtract %uchar %4024 10
-OpStore %1429 %4025
-%4026 = OpLoad %uchar %1428
-%4027 = OpLoad %uchar %1429
-%4028 = OpIAdd %uchar %4026 %4027
-OpStore %1430 %4028
-%4029 = OpLoad %_arr_uchar_uint_16 %209
-%4030 = OpCompositeExtract %uchar %4029 11
-OpStore %1431 %4030
-%4031 = OpLoad %_arr_uchar_uint_16 %170
-%4032 = OpCompositeExtract %uchar %4031 11
-OpStore %1432 %4032
-%4033 = OpLoad %uchar %1431
-%4034 = OpLoad %uchar %1432
-%4035 = OpIAdd %uchar %4033 %4034
-OpStore %1433 %4035
-%4036 = OpLoad %_arr_uchar_uint_16 %209
-%4037 = OpCompositeExtract %uchar %4036 12
-OpStore %1434 %4037
-%4038 = OpLoad %_arr_uchar_uint_16 %170
-%4039 = OpCompositeExtract %uchar %4038 12
-OpStore %1435 %4039
-%4040 = OpLoad %uchar %1434
-%4041 = OpLoad %uchar %1435
-%4042 = OpIAdd %uchar %4040 %4041
-OpStore %1436 %4042
-%4043 = OpLoad %_arr_uchar_uint_16 %209
-%4044 = OpCompositeExtract %uchar %4043 13
-OpStore %1437 %4044
-%4045 = OpLoad %_arr_uchar_uint_16 %170
-%4046 = OpCompositeExtract %uchar %4045 13
-OpStore %1438 %4046
-%4047 = OpLoad %uchar %1437
-%4048 = OpLoad %uchar %1438
-%4049 = OpIAdd %uchar %4047 %4048
-OpStore %1439 %4049
-%4050 = OpLoad %_arr_uchar_uint_16 %209
-%4051 = OpCompositeExtract %uchar %4050 14
-OpStore %1440 %4051
-%4052 = OpLoad %_arr_uchar_uint_16 %170
-%4053 = OpCompositeExtract %uchar %4052 14
-OpStore %1441 %4053
-%4054 = OpLoad %uchar %1440
-%4055 = OpLoad %uchar %1441
-%4056 = OpIAdd %uchar %4054 %4055
-OpStore %1442 %4056
-%4057 = OpLoad %_arr_uchar_uint_16 %209
-%4058 = OpCompositeExtract %uchar %4057 15
-OpStore %1443 %4058
-%4059 = OpLoad %_arr_uchar_uint_16 %170
-%4060 = OpCompositeExtract %uchar %4059 15
-OpStore %1444 %4060
-%4061 = OpLoad %uchar %1443
-%4062 = OpLoad %uchar %1444
-%4063 = OpIAdd %uchar %4061 %4062
-OpStore %1445 %4063
-%4064 = OpLoad %_arr_uchar_uint_16 %209
-%4065 = OpLoad %uchar %1400
-%4066 = OpCompositeInsert %_arr_uchar_uint_16 %4065 %4064 0
-OpStore %1446 %4066
-%4067 = OpLoad %_arr_uchar_uint_16 %1446
-%4068 = OpLoad %uchar %1403
-%4069 = OpCompositeInsert %_arr_uchar_uint_16 %4068 %4067 1
-OpStore %1447 %4069
-%4070 = OpLoad %_arr_uchar_uint_16 %1447
-%4071 = OpLoad %uchar %1406
-%4072 = OpCompositeInsert %_arr_uchar_uint_16 %4071 %4070 2
-OpStore %1448 %4072
-%4073 = OpLoad %_arr_uchar_uint_16 %1448
-%4074 = OpLoad %uchar %1409
-%4075 = OpCompositeInsert %_arr_uchar_uint_16 %4074 %4073 3
-OpStore %1449 %4075
-%4076 = OpLoad %_arr_uchar_uint_16 %1449
-%4077 = OpLoad %uchar %1412
-%4078 = OpCompositeInsert %_arr_uchar_uint_16 %4077 %4076 4
-OpStore %1450 %4078
-%4079 = OpLoad %_arr_uchar_uint_16 %1450
-%4080 = OpLoad %uchar %1415
-%4081 = OpCompositeInsert %_arr_uchar_uint_16 %4080 %4079 5
-OpStore %1451 %4081
-%4082 = OpLoad %_arr_uchar_uint_16 %1451
-%4083 = OpLoad %uchar %1418
-%4084 = OpCompositeInsert %_arr_uchar_uint_16 %4083 %4082 6
-OpStore %1452 %4084
-%4085 = OpLoad %_arr_uchar_uint_16 %1452
-%4086 = OpLoad %uchar %1421
-%4087 = OpCompositeInsert %_arr_uchar_uint_16 %4086 %4085 7
-OpStore %1453 %4087
-%4088 = OpLoad %_arr_uchar_uint_16 %1453
-%4089 = OpLoad %uchar %1424
-%4090 = OpCompositeInsert %_arr_uchar_uint_16 %4089 %4088 8
-OpStore %1454 %4090
-%4091 = OpLoad %_arr_uchar_uint_16 %1454
-%4092 = OpLoad %uchar %1427
-%4093 = OpCompositeInsert %_arr_uchar_uint_16 %4092 %4091 9
-OpStore %1455 %4093
-%4094 = OpLoad %_arr_uchar_uint_16 %1455
-%4095 = OpLoad %uchar %1430
-%4096 = OpCompositeInsert %_arr_uchar_uint_16 %4095 %4094 10
-OpStore %1456 %4096
-%4097 = OpLoad %_arr_uchar_uint_16 %1456
-%4098 = OpLoad %uchar %1433
-%4099 = OpCompositeInsert %_arr_uchar_uint_16 %4098 %4097 11
-OpStore %1457 %4099
-%4100 = OpLoad %_arr_uchar_uint_16 %1457
-%4101 = OpLoad %uchar %1436
-%4102 = OpCompositeInsert %_arr_uchar_uint_16 %4101 %4100 12
-OpStore %1458 %4102
-%4103 = OpLoad %_arr_uchar_uint_16 %1458
-%4104 = OpLoad %uchar %1439
-%4105 = OpCompositeInsert %_arr_uchar_uint_16 %4104 %4103 13
-OpStore %1459 %4105
-%4106 = OpLoad %_arr_uchar_uint_16 %1459
-%4107 = OpLoad %uchar %1442
-%4108 = OpCompositeInsert %_arr_uchar_uint_16 %4107 %4106 14
-OpStore %1460 %4108
-%4109 = OpLoad %_arr_uchar_uint_16 %1460
-%4110 = OpLoad %uchar %1445
-%4111 = OpCompositeInsert %_arr_uchar_uint_16 %4110 %4109 15
-OpStore %1461 %4111
-%4113 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_1
-%4114 = OpLoad %_arr_uchar_uint_16 %1461
-OpStore %4113 %4114
-%4115 = OpLoad %_arr_uchar_uint_16 %209
-%4116 = OpCompositeExtract %uchar %4115 0
-OpStore %1462 %4116
-%4117 = OpLoad %_arr_uchar_uint_16 %157
-%4118 = OpCompositeExtract %uchar %4117 0
-OpStore %1463 %4118
-%4119 = OpLoad %uchar %1462
-%4120 = OpLoad %uchar %1463
-%4121 = OpIMul %uchar %4119 %4120
-OpStore %1464 %4121
-%4122 = OpLoad %_arr_uchar_uint_16 %209
-%4123 = OpCompositeExtract %uchar %4122 1
-OpStore %1465 %4123
-%4124 = OpLoad %_arr_uchar_uint_16 %157
-%4125 = OpCompositeExtract %uchar %4124 1
-OpStore %1466 %4125
-%4126 = OpLoad %uchar %1465
-%4127 = OpLoad %uchar %1466
-%4128 = OpIMul %uchar %4126 %4127
-OpStore %1467 %4128
-%4129 = OpLoad %_arr_uchar_uint_16 %209
-%4130 = OpCompositeExtract %uchar %4129 2
-OpStore %1468 %4130
-%4131 = OpLoad %_arr_uchar_uint_16 %157
-%4132 = OpCompositeExtract %uchar %4131 2
-OpStore %1469 %4132
-%4133 = OpLoad %uchar %1468
-%4134 = OpLoad %uchar %1469
-%4135 = OpIMul %uchar %4133 %4134
-OpStore %1470 %4135
-%4136 = OpLoad %_arr_uchar_uint_16 %209
-%4137 = OpCompositeExtract %uchar %4136 3
-OpStore %1471 %4137
-%4138 = OpLoad %_arr_uchar_uint_16 %157
-%4139 = OpCompositeExtract %uchar %4138 3
-OpStore %1472 %4139
-%4140 = OpLoad %uchar %1471
-%4141 = OpLoad %uchar %1472
-%4142 = OpIMul %uchar %4140 %4141
-OpStore %1473 %4142
-%4143 = OpLoad %_arr_uchar_uint_16 %209
-%4144 = OpCompositeExtract %uchar %4143 4
-OpStore %1474 %4144
-%4145 = OpLoad %_arr_uchar_uint_16 %157
-%4146 = OpCompositeExtract %uchar %4145 4
-OpStore %1475 %4146
-%4147 = OpLoad %uchar %1474
-%4148 = OpLoad %uchar %1475
-%4149 = OpIMul %uchar %4147 %4148
-OpStore %1476 %4149
-%4150 = OpLoad %_arr_uchar_uint_16 %209
-%4151 = OpCompositeExtract %uchar %4150 5
-OpStore %1477 %4151
-%4152 = OpLoad %_arr_uchar_uint_16 %157
-%4153 = OpCompositeExtract %uchar %4152 5
-OpStore %1478 %4153
-%4154 = OpLoad %uchar %1477
-%4155 = OpLoad %uchar %1478
-%4156 = OpIMul %uchar %4154 %4155
-OpStore %1479 %4156
-%4157 = OpLoad %_arr_uchar_uint_16 %209
-%4158 = OpCompositeExtract %uchar %4157 6
-OpStore %1480 %4158
-%4159 = OpLoad %_arr_uchar_uint_16 %157
-%4160 = OpCompositeExtract %uchar %4159 6
-OpStore %1481 %4160
-%4161 = OpLoad %uchar %1480
-%4162 = OpLoad %uchar %1481
-%4163 = OpIMul %uchar %4161 %4162
-OpStore %1482 %4163
-%4164 = OpLoad %_arr_uchar_uint_16 %209
-%4165 = OpCompositeExtract %uchar %4164 7
-OpStore %1483 %4165
-%4166 = OpLoad %_arr_uchar_uint_16 %157
-%4167 = OpCompositeExtract %uchar %4166 7
-OpStore %1484 %4167
-%4168 = OpLoad %uchar %1483
-%4169 = OpLoad %uchar %1484
-%4170 = OpIMul %uchar %4168 %4169
-OpStore %1485 %4170
-%4171 = OpLoad %_arr_uchar_uint_16 %209
-%4172 = OpCompositeExtract %uchar %4171 8
-OpStore %1486 %4172
-%4173 = OpLoad %_arr_uchar_uint_16 %157
-%4174 = OpCompositeExtract %uchar %4173 8
-OpStore %1487 %4174
-%4175 = OpLoad %uchar %1486
-%4176 = OpLoad %uchar %1487
-%4177 = OpIMul %uchar %4175 %4176
-OpStore %1488 %4177
-%4178 = OpLoad %_arr_uchar_uint_16 %209
-%4179 = OpCompositeExtract %uchar %4178 9
-OpStore %1489 %4179
-%4180 = OpLoad %_arr_uchar_uint_16 %157
-%4181 = OpCompositeExtract %uchar %4180 9
-OpStore %1490 %4181
-%4182 = OpLoad %uchar %1489
-%4183 = OpLoad %uchar %1490
-%4184 = OpIMul %uchar %4182 %4183
-OpStore %1491 %4184
-%4185 = OpLoad %_arr_uchar_uint_16 %209
-%4186 = OpCompositeExtract %uchar %4185 10
-OpStore %1492 %4186
-%4187 = OpLoad %_arr_uchar_uint_16 %157
-%4188 = OpCompositeExtract %uchar %4187 10
-OpStore %1493 %4188
-%4189 = OpLoad %uchar %1492
-%4190 = OpLoad %uchar %1493
-%4191 = OpIMul %uchar %4189 %4190
-OpStore %1494 %4191
-%4192 = OpLoad %_arr_uchar_uint_16 %209
-%4193 = OpCompositeExtract %uchar %4192 11
-OpStore %1495 %4193
-%4194 = OpLoad %_arr_uchar_uint_16 %157
-%4195 = OpCompositeExtract %uchar %4194 11
-OpStore %1496 %4195
-%4196 = OpLoad %uchar %1495
-%4197 = OpLoad %uchar %1496
-%4198 = OpIMul %uchar %4196 %4197
-OpStore %1497 %4198
-%4199 = OpLoad %_arr_uchar_uint_16 %209
-%4200 = OpCompositeExtract %uchar %4199 12
-OpStore %1498 %4200
-%4201 = OpLoad %_arr_uchar_uint_16 %157
-%4202 = OpCompositeExtract %uchar %4201 12
-OpStore %1499 %4202
-%4203 = OpLoad %uchar %1498
-%4204 = OpLoad %uchar %1499
-%4205 = OpIMul %uchar %4203 %4204
-OpStore %1500 %4205
-%4206 = OpLoad %_arr_uchar_uint_16 %209
-%4207 = OpCompositeExtract %uchar %4206 13
-OpStore %1501 %4207
-%4208 = OpLoad %_arr_uchar_uint_16 %157
-%4209 = OpCompositeExtract %uchar %4208 13
-OpStore %1502 %4209
-%4210 = OpLoad %uchar %1501
-%4211 = OpLoad %uchar %1502
-%4212 = OpIMul %uchar %4210 %4211
-OpStore %1503 %4212
-%4213 = OpLoad %_arr_uchar_uint_16 %209
-%4214 = OpCompositeExtract %uchar %4213 14
-OpStore %1504 %4214
-%4215 = OpLoad %_arr_uchar_uint_16 %157
-%4216 = OpCompositeExtract %uchar %4215 14
-OpStore %1505 %4216
-%4217 = OpLoad %uchar %1504
-%4218 = OpLoad %uchar %1505
-%4219 = OpIMul %uchar %4217 %4218
-OpStore %1506 %4219
-%4220 = OpLoad %_arr_uchar_uint_16 %209
-%4221 = OpCompositeExtract %uchar %4220 15
-OpStore %1507 %4221
-%4222 = OpLoad %_arr_uchar_uint_16 %157
-%4223 = OpCompositeExtract %uchar %4222 15
-OpStore %1508 %4223
-%4224 = OpLoad %uchar %1507
-%4225 = OpLoad %uchar %1508
-%4226 = OpIMul %uchar %4224 %4225
-OpStore %1509 %4226
-%4227 = OpLoad %_arr_uchar_uint_16 %209
-%4228 = OpLoad %uchar %1464
-%4229 = OpCompositeInsert %_arr_uchar_uint_16 %4228 %4227 0
-OpStore %1510 %4229
-%4230 = OpLoad %_arr_uchar_uint_16 %1510
-%4231 = OpLoad %uchar %1467
-%4232 = OpCompositeInsert %_arr_uchar_uint_16 %4231 %4230 1
-OpStore %1511 %4232
-%4233 = OpLoad %_arr_uchar_uint_16 %1511
-%4234 = OpLoad %uchar %1470
-%4235 = OpCompositeInsert %_arr_uchar_uint_16 %4234 %4233 2
-OpStore %1512 %4235
-%4236 = OpLoad %_arr_uchar_uint_16 %1512
-%4237 = OpLoad %uchar %1473
-%4238 = OpCompositeInsert %_arr_uchar_uint_16 %4237 %4236 3
-OpStore %1513 %4238
-%4239 = OpLoad %_arr_uchar_uint_16 %1513
-%4240 = OpLoad %uchar %1476
-%4241 = OpCompositeInsert %_arr_uchar_uint_16 %4240 %4239 4
-OpStore %1514 %4241
-%4242 = OpLoad %_arr_uchar_uint_16 %1514
-%4243 = OpLoad %uchar %1479
-%4244 = OpCompositeInsert %_arr_uchar_uint_16 %4243 %4242 5
-OpStore %1515 %4244
-%4245 = OpLoad %_arr_uchar_uint_16 %1515
-%4246 = OpLoad %uchar %1482
-%4247 = OpCompositeInsert %_arr_uchar_uint_16 %4246 %4245 6
-OpStore %1516 %4247
-%4248 = OpLoad %_arr_uchar_uint_16 %1516
-%4249 = OpLoad %uchar %1485
-%4250 = OpCompositeInsert %_arr_uchar_uint_16 %4249 %4248 7
-OpStore %1517 %4250
-%4251 = OpLoad %_arr_uchar_uint_16 %1517
-%4252 = OpLoad %uchar %1488
-%4253 = OpCompositeInsert %_arr_uchar_uint_16 %4252 %4251 8
-OpStore %1518 %4253
-%4254 = OpLoad %_arr_uchar_uint_16 %1518
-%4255 = OpLoad %uchar %1491
-%4256 = OpCompositeInsert %_arr_uchar_uint_16 %4255 %4254 9
-OpStore %1519 %4256
-%4257 = OpLoad %_arr_uchar_uint_16 %1519
-%4258 = OpLoad %uchar %1494
-%4259 = OpCompositeInsert %_arr_uchar_uint_16 %4258 %4257 10
-OpStore %1520 %4259
-%4260 = OpLoad %_arr_uchar_uint_16 %1520
-%4261 = OpLoad %uchar %1497
-%4262 = OpCompositeInsert %_arr_uchar_uint_16 %4261 %4260 11
-OpStore %1521 %4262
-%4263 = OpLoad %_arr_uchar_uint_16 %1521
-%4264 = OpLoad %uchar %1500
-%4265 = OpCompositeInsert %_arr_uchar_uint_16 %4264 %4263 12
-OpStore %1522 %4265
-%4266 = OpLoad %_arr_uchar_uint_16 %1522
-%4267 = OpLoad %uchar %1503
-%4268 = OpCompositeInsert %_arr_uchar_uint_16 %4267 %4266 13
-OpStore %1523 %4268
-%4269 = OpLoad %_arr_uchar_uint_16 %1523
-%4270 = OpLoad %uchar %1506
-%4271 = OpCompositeInsert %_arr_uchar_uint_16 %4270 %4269 14
-OpStore %1524 %4271
-%4272 = OpLoad %_arr_uchar_uint_16 %1524
-%4273 = OpLoad %uchar %1509
-%4274 = OpCompositeInsert %_arr_uchar_uint_16 %4273 %4272 15
-OpStore %1525 %4274
-%4276 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_2
-%4277 = OpLoad %_arr_uchar_uint_16 %1525
-OpStore %4276 %4277
-%4279 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_3
-%4280 = OpLoad %_arr_uchar_uint_16 %210
-OpStore %4279 %4280
-%4281 = OpLoad %ulong %208
-OpStore %207 %4281
-OpStore %213 %ulong_0
-OpBranch %139
-%139 = OpLabel
-%4282 = OpLoad %ulong %213
-%4284 = OpULessThan %bool %4282 %ulong_4
-OpStore %195 %4284
-%4285 = OpLoad %bool %195
-OpLoopMerge %141 %142 None
-OpBranchConditional %4285 %140 %141
-%141 = OpLabel
-OpStore %151 %4286
-%4287 = OpAccessChain %_ptr_Function_uint %151 %uint_0
-OpStore %4287 %uint_4294967295
-%4289 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_2
-%4290 = OpLoad %_arr_uchar_uint_16 %4289
-OpStore %199 %4290
-%4291 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %151 %uint_1
-%4292 = OpLoad %_arr_uchar_uint_16 %199
-OpStore %4291 %4292
-%4293 = OpAccessChain %_ptr_Function_uint %151 %uint_2
-OpStore %4293 %uint_305419896
-%4295 = OpLoad %uint %4287
-OpStore %201 %4295
-%4296 = OpLoad %ulong %207
-%4297 = OpLoad %uint %201
-%4298 = OpFunctionCall %ulong %4 %4296 %4297
-OpStore %202 %4298
-%4299 = OpLoad %_arr_uchar_uint_16 %4291
-OpStore %203 %4299
-%4300 = OpLoad %ulong %202
-%4301 = OpLoad %_arr_uchar_uint_16 %203
-%4302 = OpFunctionCall %ulong %1 %4300 %4301
-OpStore %204 %4302
-%4303 = OpLoad %uint %4293
-OpStore %205 %4303
-%4304 = OpLoad %ulong %204
-%4305 = OpLoad %uint %205
-%4306 = OpFunctionCall %ulong %4 %4304 %4305
-OpStore %206 %4306
-%4307 = OpLoad %ulong %206
-OpReturnValue %4307
-%140 = OpLabel
-%4308 = OpLoad %ulong %213
-%4309 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %4308
-%4310 = OpLoad %_arr_uchar_uint_16 %4309
-OpStore %196 %4310
-%4311 = OpLoad %ulong %207
-%4312 = OpLoad %_arr_uchar_uint_16 %196
-%4313 = OpFunctionCall %ulong %1 %4311 %4312
-OpStore %197 %4313
-%4314 = OpLoad %ulong %213
-%4316 = OpIAdd %ulong %4314 %ulong_1
-OpStore %198 %4316
-%4317 = OpLoad %ulong %197
-OpStore %207 %4317
-%4318 = OpLoad %ulong %198
-OpStore %213 %4318
-OpBranch %142
-%137 = OpLabel
-%4319 = OpLoad %_arr_uchar_uint_16 %209
-%4320 = OpCompositeExtract %uchar %4319 0
-OpStore %1142 %4320
-%4321 = OpLoad %_arr_uchar_uint_16 %157
-%4322 = OpCompositeExtract %uchar %4321 0
-OpStore %1143 %4322
-%4323 = OpLoad %uchar %1142
-%4324 = OpLoad %uchar %1143
-%4325 = OpIMul %uchar %4323 %4324
-OpStore %1144 %4325
-%4326 = OpLoad %_arr_uchar_uint_16 %209
-%4327 = OpCompositeExtract %uchar %4326 1
-OpStore %1145 %4327
-%4328 = OpLoad %_arr_uchar_uint_16 %157
-%4329 = OpCompositeExtract %uchar %4328 1
-OpStore %1146 %4329
-%4330 = OpLoad %uchar %1145
-%4331 = OpLoad %uchar %1146
-%4332 = OpIMul %uchar %4330 %4331
-OpStore %1147 %4332
-%4333 = OpLoad %_arr_uchar_uint_16 %209
-%4334 = OpCompositeExtract %uchar %4333 2
-OpStore %1148 %4334
-%4335 = OpLoad %_arr_uchar_uint_16 %157
-%4336 = OpCompositeExtract %uchar %4335 2
-OpStore %1149 %4336
-%4337 = OpLoad %uchar %1148
-%4338 = OpLoad %uchar %1149
-%4339 = OpIMul %uchar %4337 %4338
-OpStore %1150 %4339
-%4340 = OpLoad %_arr_uchar_uint_16 %209
-%4341 = OpCompositeExtract %uchar %4340 3
-OpStore %1151 %4341
-%4342 = OpLoad %_arr_uchar_uint_16 %157
-%4343 = OpCompositeExtract %uchar %4342 3
-OpStore %1152 %4343
-%4344 = OpLoad %uchar %1151
-%4345 = OpLoad %uchar %1152
-%4346 = OpIMul %uchar %4344 %4345
-OpStore %1153 %4346
-%4347 = OpLoad %_arr_uchar_uint_16 %209
-%4348 = OpCompositeExtract %uchar %4347 4
-OpStore %1154 %4348
-%4349 = OpLoad %_arr_uchar_uint_16 %157
-%4350 = OpCompositeExtract %uchar %4349 4
-OpStore %1155 %4350
-%4351 = OpLoad %uchar %1154
-%4352 = OpLoad %uchar %1155
-%4353 = OpIMul %uchar %4351 %4352
-OpStore %1156 %4353
-%4354 = OpLoad %_arr_uchar_uint_16 %209
-%4355 = OpCompositeExtract %uchar %4354 5
-OpStore %1157 %4355
-%4356 = OpLoad %_arr_uchar_uint_16 %157
-%4357 = OpCompositeExtract %uchar %4356 5
-OpStore %1158 %4357
-%4358 = OpLoad %uchar %1157
-%4359 = OpLoad %uchar %1158
-%4360 = OpIMul %uchar %4358 %4359
-OpStore %1159 %4360
-%4361 = OpLoad %_arr_uchar_uint_16 %209
-%4362 = OpCompositeExtract %uchar %4361 6
-OpStore %1160 %4362
-%4363 = OpLoad %_arr_uchar_uint_16 %157
-%4364 = OpCompositeExtract %uchar %4363 6
-OpStore %1161 %4364
-%4365 = OpLoad %uchar %1160
-%4366 = OpLoad %uchar %1161
-%4367 = OpIMul %uchar %4365 %4366
-OpStore %1162 %4367
-%4368 = OpLoad %_arr_uchar_uint_16 %209
-%4369 = OpCompositeExtract %uchar %4368 7
-OpStore %1163 %4369
-%4370 = OpLoad %_arr_uchar_uint_16 %157
-%4371 = OpCompositeExtract %uchar %4370 7
-OpStore %1164 %4371
-%4372 = OpLoad %uchar %1163
-%4373 = OpLoad %uchar %1164
-%4374 = OpIMul %uchar %4372 %4373
-OpStore %1165 %4374
-%4375 = OpLoad %_arr_uchar_uint_16 %209
-%4376 = OpCompositeExtract %uchar %4375 8
-OpStore %1166 %4376
-%4377 = OpLoad %_arr_uchar_uint_16 %157
-%4378 = OpCompositeExtract %uchar %4377 8
-OpStore %1167 %4378
-%4379 = OpLoad %uchar %1166
-%4380 = OpLoad %uchar %1167
-%4381 = OpIMul %uchar %4379 %4380
-OpStore %1168 %4381
-%4382 = OpLoad %_arr_uchar_uint_16 %209
-%4383 = OpCompositeExtract %uchar %4382 9
-OpStore %1169 %4383
-%4384 = OpLoad %_arr_uchar_uint_16 %157
-%4385 = OpCompositeExtract %uchar %4384 9
-OpStore %1170 %4385
-%4386 = OpLoad %uchar %1169
-%4387 = OpLoad %uchar %1170
-%4388 = OpIMul %uchar %4386 %4387
-OpStore %1171 %4388
-%4389 = OpLoad %_arr_uchar_uint_16 %209
-%4390 = OpCompositeExtract %uchar %4389 10
-OpStore %1172 %4390
-%4391 = OpLoad %_arr_uchar_uint_16 %157
-%4392 = OpCompositeExtract %uchar %4391 10
-OpStore %1173 %4392
-%4393 = OpLoad %uchar %1172
-%4394 = OpLoad %uchar %1173
-%4395 = OpIMul %uchar %4393 %4394
-OpStore %1174 %4395
-%4396 = OpLoad %_arr_uchar_uint_16 %209
-%4397 = OpCompositeExtract %uchar %4396 11
-OpStore %1175 %4397
-%4398 = OpLoad %_arr_uchar_uint_16 %157
-%4399 = OpCompositeExtract %uchar %4398 11
-OpStore %1176 %4399
-%4400 = OpLoad %uchar %1175
-%4401 = OpLoad %uchar %1176
-%4402 = OpIMul %uchar %4400 %4401
-OpStore %1177 %4402
-%4403 = OpLoad %_arr_uchar_uint_16 %209
-%4404 = OpCompositeExtract %uchar %4403 12
-OpStore %1178 %4404
-%4405 = OpLoad %_arr_uchar_uint_16 %157
-%4406 = OpCompositeExtract %uchar %4405 12
-OpStore %1179 %4406
-%4407 = OpLoad %uchar %1178
-%4408 = OpLoad %uchar %1179
-%4409 = OpIMul %uchar %4407 %4408
-OpStore %1180 %4409
-%4410 = OpLoad %_arr_uchar_uint_16 %209
-%4411 = OpCompositeExtract %uchar %4410 13
-OpStore %1181 %4411
-%4412 = OpLoad %_arr_uchar_uint_16 %157
-%4413 = OpCompositeExtract %uchar %4412 13
-OpStore %1182 %4413
-%4414 = OpLoad %uchar %1181
-%4415 = OpLoad %uchar %1182
-%4416 = OpIMul %uchar %4414 %4415
-OpStore %1183 %4416
-%4417 = OpLoad %_arr_uchar_uint_16 %209
-%4418 = OpCompositeExtract %uchar %4417 14
-OpStore %1184 %4418
-%4419 = OpLoad %_arr_uchar_uint_16 %157
-%4420 = OpCompositeExtract %uchar %4419 14
-OpStore %1185 %4420
-%4421 = OpLoad %uchar %1184
-%4422 = OpLoad %uchar %1185
-%4423 = OpIMul %uchar %4421 %4422
-OpStore %1186 %4423
-%4424 = OpLoad %_arr_uchar_uint_16 %209
-%4425 = OpCompositeExtract %uchar %4424 15
-OpStore %1187 %4425
-%4426 = OpLoad %_arr_uchar_uint_16 %157
-%4427 = OpCompositeExtract %uchar %4426 15
-OpStore %1188 %4427
-%4428 = OpLoad %uchar %1187
-%4429 = OpLoad %uchar %1188
-%4430 = OpIMul %uchar %4428 %4429
-OpStore %1189 %4430
-%4431 = OpLoad %_arr_uchar_uint_16 %209
-%4432 = OpLoad %uchar %1144
-%4433 = OpCompositeInsert %_arr_uchar_uint_16 %4432 %4431 0
-OpStore %1190 %4433
-%4434 = OpLoad %_arr_uchar_uint_16 %1190
-%4435 = OpLoad %uchar %1147
-%4436 = OpCompositeInsert %_arr_uchar_uint_16 %4435 %4434 1
-OpStore %1191 %4436
-%4437 = OpLoad %_arr_uchar_uint_16 %1191
-%4438 = OpLoad %uchar %1150
-%4439 = OpCompositeInsert %_arr_uchar_uint_16 %4438 %4437 2
-OpStore %1192 %4439
-%4440 = OpLoad %_arr_uchar_uint_16 %1192
-%4441 = OpLoad %uchar %1153
-%4442 = OpCompositeInsert %_arr_uchar_uint_16 %4441 %4440 3
-OpStore %1193 %4442
-%4443 = OpLoad %_arr_uchar_uint_16 %1193
-%4444 = OpLoad %uchar %1156
-%4445 = OpCompositeInsert %_arr_uchar_uint_16 %4444 %4443 4
-OpStore %1194 %4445
-%4446 = OpLoad %_arr_uchar_uint_16 %1194
-%4447 = OpLoad %uchar %1159
-%4448 = OpCompositeInsert %_arr_uchar_uint_16 %4447 %4446 5
-OpStore %1195 %4448
-%4449 = OpLoad %_arr_uchar_uint_16 %1195
-%4450 = OpLoad %uchar %1162
-%4451 = OpCompositeInsert %_arr_uchar_uint_16 %4450 %4449 6
-OpStore %1196 %4451
-%4452 = OpLoad %_arr_uchar_uint_16 %1196
-%4453 = OpLoad %uchar %1165
-%4454 = OpCompositeInsert %_arr_uchar_uint_16 %4453 %4452 7
-OpStore %1197 %4454
-%4455 = OpLoad %_arr_uchar_uint_16 %1197
-%4456 = OpLoad %uchar %1168
-%4457 = OpCompositeInsert %_arr_uchar_uint_16 %4456 %4455 8
-OpStore %1198 %4457
-%4458 = OpLoad %_arr_uchar_uint_16 %1198
-%4459 = OpLoad %uchar %1171
-%4460 = OpCompositeInsert %_arr_uchar_uint_16 %4459 %4458 9
-OpStore %1199 %4460
-%4461 = OpLoad %_arr_uchar_uint_16 %1199
-%4462 = OpLoad %uchar %1174
-%4463 = OpCompositeInsert %_arr_uchar_uint_16 %4462 %4461 10
-OpStore %1200 %4463
-%4464 = OpLoad %_arr_uchar_uint_16 %1200
-%4465 = OpLoad %uchar %1177
-%4466 = OpCompositeInsert %_arr_uchar_uint_16 %4465 %4464 11
-OpStore %1201 %4466
-%4467 = OpLoad %_arr_uchar_uint_16 %1201
-%4468 = OpLoad %uchar %1180
-%4469 = OpCompositeInsert %_arr_uchar_uint_16 %4468 %4467 12
-OpStore %1202 %4469
-%4470 = OpLoad %_arr_uchar_uint_16 %1202
-%4471 = OpLoad %uchar %1183
-%4472 = OpCompositeInsert %_arr_uchar_uint_16 %4471 %4470 13
-OpStore %1203 %4472
-%4473 = OpLoad %_arr_uchar_uint_16 %1203
-%4474 = OpLoad %uchar %1186
-%4475 = OpCompositeInsert %_arr_uchar_uint_16 %4474 %4473 14
-OpStore %1204 %4475
-%4476 = OpLoad %_arr_uchar_uint_16 %1204
-%4477 = OpLoad %uchar %1189
-%4478 = OpCompositeInsert %_arr_uchar_uint_16 %4477 %4476 15
-OpStore %1205 %4478
-%4479 = OpLoad %ulong %208
-%4480 = OpLoad %_arr_uchar_uint_16 %1205
-%4481 = OpFunctionCall %ulong %1 %4479 %4480
-OpStore %190 %4481
-%4482 = OpLoad %_arr_uchar_uint_16 %210
-%4483 = OpCompositeExtract %uchar %4482 0
-OpStore %1206 %4483
-%4484 = OpLoad %_arr_uchar_uint_16 %1205
-%4485 = OpCompositeExtract %uchar %4484 0
-OpStore %1207 %4485
-%4486 = OpLoad %uchar %1206
-%4487 = OpLoad %uchar %1207
-%4488 = OpBitwiseXor %uchar %4486 %4487
-OpStore %1208 %4488
-%4489 = OpLoad %_arr_uchar_uint_16 %210
-%4490 = OpCompositeExtract %uchar %4489 1
-OpStore %1209 %4490
-%4491 = OpLoad %_arr_uchar_uint_16 %1205
-%4492 = OpCompositeExtract %uchar %4491 1
-OpStore %1210 %4492
-%4493 = OpLoad %uchar %1209
-%4494 = OpLoad %uchar %1210
-%4495 = OpBitwiseXor %uchar %4493 %4494
-OpStore %1211 %4495
-%4496 = OpLoad %_arr_uchar_uint_16 %210
-%4497 = OpCompositeExtract %uchar %4496 2
-OpStore %1212 %4497
-%4498 = OpLoad %_arr_uchar_uint_16 %1205
-%4499 = OpCompositeExtract %uchar %4498 2
-OpStore %1213 %4499
-%4500 = OpLoad %uchar %1212
-%4501 = OpLoad %uchar %1213
-%4502 = OpBitwiseXor %uchar %4500 %4501
-OpStore %1214 %4502
-%4503 = OpLoad %_arr_uchar_uint_16 %210
-%4504 = OpCompositeExtract %uchar %4503 3
-OpStore %1215 %4504
-%4505 = OpLoad %_arr_uchar_uint_16 %1205
-%4506 = OpCompositeExtract %uchar %4505 3
-OpStore %1216 %4506
-%4507 = OpLoad %uchar %1215
-%4508 = OpLoad %uchar %1216
-%4509 = OpBitwiseXor %uchar %4507 %4508
-OpStore %1217 %4509
-%4510 = OpLoad %_arr_uchar_uint_16 %210
-%4511 = OpCompositeExtract %uchar %4510 4
-OpStore %1218 %4511
-%4512 = OpLoad %_arr_uchar_uint_16 %1205
-%4513 = OpCompositeExtract %uchar %4512 4
-OpStore %1219 %4513
-%4514 = OpLoad %uchar %1218
-%4515 = OpLoad %uchar %1219
-%4516 = OpBitwiseXor %uchar %4514 %4515
-OpStore %1220 %4516
-%4517 = OpLoad %_arr_uchar_uint_16 %210
-%4518 = OpCompositeExtract %uchar %4517 5
-OpStore %1221 %4518
-%4519 = OpLoad %_arr_uchar_uint_16 %1205
-%4520 = OpCompositeExtract %uchar %4519 5
-OpStore %1222 %4520
-%4521 = OpLoad %uchar %1221
-%4522 = OpLoad %uchar %1222
-%4523 = OpBitwiseXor %uchar %4521 %4522
-OpStore %1223 %4523
-%4524 = OpLoad %_arr_uchar_uint_16 %210
-%4525 = OpCompositeExtract %uchar %4524 6
-OpStore %1224 %4525
-%4526 = OpLoad %_arr_uchar_uint_16 %1205
-%4527 = OpCompositeExtract %uchar %4526 6
-OpStore %1225 %4527
-%4528 = OpLoad %uchar %1224
-%4529 = OpLoad %uchar %1225
-%4530 = OpBitwiseXor %uchar %4528 %4529
-OpStore %1226 %4530
-%4531 = OpLoad %_arr_uchar_uint_16 %210
-%4532 = OpCompositeExtract %uchar %4531 7
-OpStore %1227 %4532
-%4533 = OpLoad %_arr_uchar_uint_16 %1205
-%4534 = OpCompositeExtract %uchar %4533 7
-OpStore %1228 %4534
-%4535 = OpLoad %uchar %1227
-%4536 = OpLoad %uchar %1228
-%4537 = OpBitwiseXor %uchar %4535 %4536
-OpStore %1229 %4537
-%4538 = OpLoad %_arr_uchar_uint_16 %210
-%4539 = OpCompositeExtract %uchar %4538 8
-OpStore %1230 %4539
-%4540 = OpLoad %_arr_uchar_uint_16 %1205
-%4541 = OpCompositeExtract %uchar %4540 8
-OpStore %1231 %4541
-%4542 = OpLoad %uchar %1230
-%4543 = OpLoad %uchar %1231
-%4544 = OpBitwiseXor %uchar %4542 %4543
-OpStore %1232 %4544
-%4545 = OpLoad %_arr_uchar_uint_16 %210
-%4546 = OpCompositeExtract %uchar %4545 9
-OpStore %1233 %4546
-%4547 = OpLoad %_arr_uchar_uint_16 %1205
-%4548 = OpCompositeExtract %uchar %4547 9
-OpStore %1234 %4548
-%4549 = OpLoad %uchar %1233
-%4550 = OpLoad %uchar %1234
-%4551 = OpBitwiseXor %uchar %4549 %4550
-OpStore %1235 %4551
-%4552 = OpLoad %_arr_uchar_uint_16 %210
-%4553 = OpCompositeExtract %uchar %4552 10
-OpStore %1236 %4553
-%4554 = OpLoad %_arr_uchar_uint_16 %1205
-%4555 = OpCompositeExtract %uchar %4554 10
-OpStore %1237 %4555
-%4556 = OpLoad %uchar %1236
-%4557 = OpLoad %uchar %1237
-%4558 = OpBitwiseXor %uchar %4556 %4557
-OpStore %1238 %4558
-%4559 = OpLoad %_arr_uchar_uint_16 %210
-%4560 = OpCompositeExtract %uchar %4559 11
-OpStore %1239 %4560
-%4561 = OpLoad %_arr_uchar_uint_16 %1205
-%4562 = OpCompositeExtract %uchar %4561 11
-OpStore %1240 %4562
-%4563 = OpLoad %uchar %1239
-%4564 = OpLoad %uchar %1240
-%4565 = OpBitwiseXor %uchar %4563 %4564
-OpStore %1241 %4565
-%4566 = OpLoad %_arr_uchar_uint_16 %210
-%4567 = OpCompositeExtract %uchar %4566 12
-OpStore %1242 %4567
-%4568 = OpLoad %_arr_uchar_uint_16 %1205
-%4569 = OpCompositeExtract %uchar %4568 12
-OpStore %1243 %4569
-%4570 = OpLoad %uchar %1242
-%4571 = OpLoad %uchar %1243
-%4572 = OpBitwiseXor %uchar %4570 %4571
-OpStore %1244 %4572
-%4573 = OpLoad %_arr_uchar_uint_16 %210
-%4574 = OpCompositeExtract %uchar %4573 13
-OpStore %1245 %4574
-%4575 = OpLoad %_arr_uchar_uint_16 %1205
-%4576 = OpCompositeExtract %uchar %4575 13
-OpStore %1246 %4576
-%4577 = OpLoad %uchar %1245
-%4578 = OpLoad %uchar %1246
-%4579 = OpBitwiseXor %uchar %4577 %4578
-OpStore %1247 %4579
-%4580 = OpLoad %_arr_uchar_uint_16 %210
-%4581 = OpCompositeExtract %uchar %4580 14
-OpStore %1248 %4581
-%4582 = OpLoad %_arr_uchar_uint_16 %1205
-%4583 = OpCompositeExtract %uchar %4582 14
-OpStore %1249 %4583
-%4584 = OpLoad %uchar %1248
-%4585 = OpLoad %uchar %1249
-%4586 = OpBitwiseXor %uchar %4584 %4585
-OpStore %1250 %4586
-%4587 = OpLoad %_arr_uchar_uint_16 %210
-%4588 = OpCompositeExtract %uchar %4587 15
-OpStore %1251 %4588
-%4589 = OpLoad %_arr_uchar_uint_16 %1205
-%4590 = OpCompositeExtract %uchar %4589 15
-OpStore %1252 %4590
-%4591 = OpLoad %uchar %1251
-%4592 = OpLoad %uchar %1252
-%4593 = OpBitwiseXor %uchar %4591 %4592
-OpStore %1253 %4593
-%4594 = OpLoad %_arr_uchar_uint_16 %210
-%4595 = OpLoad %uchar %1208
-%4596 = OpCompositeInsert %_arr_uchar_uint_16 %4595 %4594 0
-OpStore %1254 %4596
-%4597 = OpLoad %_arr_uchar_uint_16 %1254
-%4598 = OpLoad %uchar %1211
-%4599 = OpCompositeInsert %_arr_uchar_uint_16 %4598 %4597 1
-OpStore %1255 %4599
-%4600 = OpLoad %_arr_uchar_uint_16 %1255
-%4601 = OpLoad %uchar %1214
-%4602 = OpCompositeInsert %_arr_uchar_uint_16 %4601 %4600 2
-OpStore %1256 %4602
-%4603 = OpLoad %_arr_uchar_uint_16 %1256
-%4604 = OpLoad %uchar %1217
-%4605 = OpCompositeInsert %_arr_uchar_uint_16 %4604 %4603 3
-OpStore %1257 %4605
-%4606 = OpLoad %_arr_uchar_uint_16 %1257
-%4607 = OpLoad %uchar %1220
-%4608 = OpCompositeInsert %_arr_uchar_uint_16 %4607 %4606 4
-OpStore %1258 %4608
-%4609 = OpLoad %_arr_uchar_uint_16 %1258
-%4610 = OpLoad %uchar %1223
-%4611 = OpCompositeInsert %_arr_uchar_uint_16 %4610 %4609 5
-OpStore %1259 %4611
-%4612 = OpLoad %_arr_uchar_uint_16 %1259
-%4613 = OpLoad %uchar %1226
-%4614 = OpCompositeInsert %_arr_uchar_uint_16 %4613 %4612 6
-OpStore %1260 %4614
-%4615 = OpLoad %_arr_uchar_uint_16 %1260
-%4616 = OpLoad %uchar %1229
-%4617 = OpCompositeInsert %_arr_uchar_uint_16 %4616 %4615 7
-OpStore %1261 %4617
-%4618 = OpLoad %_arr_uchar_uint_16 %1261
-%4619 = OpLoad %uchar %1232
-%4620 = OpCompositeInsert %_arr_uchar_uint_16 %4619 %4618 8
-OpStore %1262 %4620
-%4621 = OpLoad %_arr_uchar_uint_16 %1262
-%4622 = OpLoad %uchar %1235
-%4623 = OpCompositeInsert %_arr_uchar_uint_16 %4622 %4621 9
-OpStore %1263 %4623
-%4624 = OpLoad %_arr_uchar_uint_16 %1263
-%4625 = OpLoad %uchar %1238
-%4626 = OpCompositeInsert %_arr_uchar_uint_16 %4625 %4624 10
-OpStore %1264 %4626
-%4627 = OpLoad %_arr_uchar_uint_16 %1264
-%4628 = OpLoad %uchar %1241
-%4629 = OpCompositeInsert %_arr_uchar_uint_16 %4628 %4627 11
-OpStore %1265 %4629
-%4630 = OpLoad %_arr_uchar_uint_16 %1265
-%4631 = OpLoad %uchar %1244
-%4632 = OpCompositeInsert %_arr_uchar_uint_16 %4631 %4630 12
-OpStore %1266 %4632
-%4633 = OpLoad %_arr_uchar_uint_16 %1266
-%4634 = OpLoad %uchar %1247
-%4635 = OpCompositeInsert %_arr_uchar_uint_16 %4634 %4633 13
-OpStore %1267 %4635
-%4636 = OpLoad %_arr_uchar_uint_16 %1267
-%4637 = OpLoad %uchar %1250
-%4638 = OpCompositeInsert %_arr_uchar_uint_16 %4637 %4636 14
-OpStore %1268 %4638
-%4639 = OpLoad %_arr_uchar_uint_16 %1268
-%4640 = OpLoad %uchar %1253
-%4641 = OpCompositeInsert %_arr_uchar_uint_16 %4640 %4639 15
-OpStore %1269 %4641
-%4642 = OpLoad %ulong %190
-%4643 = OpLoad %_arr_uchar_uint_16 %1269
-%4644 = OpFunctionCall %ulong %1 %4642 %4643
-OpStore %191 %4644
-%4645 = OpLoad %_arr_uchar_uint_16 %211
-%4646 = OpCompositeExtract %uchar %4645 0
-OpStore %1270 %4646
-%4647 = OpLoad %_arr_uchar_uint_16 %209
-%4648 = OpCompositeExtract %uchar %4647 0
-OpStore %1271 %4648
-%4649 = OpLoad %uchar %1270
-%4650 = OpLoad %uchar %1271
-%4651 = OpIAdd %uchar %4649 %4650
-OpStore %1272 %4651
-%4652 = OpLoad %_arr_uchar_uint_16 %211
-%4653 = OpCompositeExtract %uchar %4652 1
-OpStore %1273 %4653
-%4654 = OpLoad %_arr_uchar_uint_16 %209
-%4655 = OpCompositeExtract %uchar %4654 1
-OpStore %1274 %4655
-%4656 = OpLoad %uchar %1273
-%4657 = OpLoad %uchar %1274
-%4658 = OpIAdd %uchar %4656 %4657
-OpStore %1275 %4658
-%4659 = OpLoad %_arr_uchar_uint_16 %211
-%4660 = OpCompositeExtract %uchar %4659 2
-OpStore %1276 %4660
-%4661 = OpLoad %_arr_uchar_uint_16 %209
-%4662 = OpCompositeExtract %uchar %4661 2
-OpStore %1277 %4662
-%4663 = OpLoad %uchar %1276
-%4664 = OpLoad %uchar %1277
-%4665 = OpIAdd %uchar %4663 %4664
-OpStore %1278 %4665
-%4666 = OpLoad %_arr_uchar_uint_16 %211
-%4667 = OpCompositeExtract %uchar %4666 3
-OpStore %1279 %4667
-%4668 = OpLoad %_arr_uchar_uint_16 %209
-%4669 = OpCompositeExtract %uchar %4668 3
-OpStore %1280 %4669
-%4670 = OpLoad %uchar %1279
-%4671 = OpLoad %uchar %1280
-%4672 = OpIAdd %uchar %4670 %4671
-OpStore %1281 %4672
-%4673 = OpLoad %_arr_uchar_uint_16 %211
-%4674 = OpCompositeExtract %uchar %4673 4
-OpStore %1282 %4674
-%4675 = OpLoad %_arr_uchar_uint_16 %209
-%4676 = OpCompositeExtract %uchar %4675 4
-OpStore %1283 %4676
-%4677 = OpLoad %uchar %1282
-%4678 = OpLoad %uchar %1283
-%4679 = OpIAdd %uchar %4677 %4678
-OpStore %1284 %4679
-%4680 = OpLoad %_arr_uchar_uint_16 %211
-%4681 = OpCompositeExtract %uchar %4680 5
-OpStore %1285 %4681
-%4682 = OpLoad %_arr_uchar_uint_16 %209
-%4683 = OpCompositeExtract %uchar %4682 5
-OpStore %1286 %4683
-%4684 = OpLoad %uchar %1285
-%4685 = OpLoad %uchar %1286
-%4686 = OpIAdd %uchar %4684 %4685
-OpStore %1287 %4686
-%4687 = OpLoad %_arr_uchar_uint_16 %211
-%4688 = OpCompositeExtract %uchar %4687 6
-OpStore %1288 %4688
-%4689 = OpLoad %_arr_uchar_uint_16 %209
-%4690 = OpCompositeExtract %uchar %4689 6
-OpStore %1289 %4690
-%4691 = OpLoad %uchar %1288
-%4692 = OpLoad %uchar %1289
-%4693 = OpIAdd %uchar %4691 %4692
-OpStore %1290 %4693
-%4694 = OpLoad %_arr_uchar_uint_16 %211
-%4695 = OpCompositeExtract %uchar %4694 7
-OpStore %1291 %4695
-%4696 = OpLoad %_arr_uchar_uint_16 %209
-%4697 = OpCompositeExtract %uchar %4696 7
-OpStore %1292 %4697
-%4698 = OpLoad %uchar %1291
-%4699 = OpLoad %uchar %1292
-%4700 = OpIAdd %uchar %4698 %4699
-OpStore %1293 %4700
-%4701 = OpLoad %_arr_uchar_uint_16 %211
-%4702 = OpCompositeExtract %uchar %4701 8
-OpStore %1294 %4702
-%4703 = OpLoad %_arr_uchar_uint_16 %209
-%4704 = OpCompositeExtract %uchar %4703 8
-OpStore %1295 %4704
-%4705 = OpLoad %uchar %1294
-%4706 = OpLoad %uchar %1295
-%4707 = OpIAdd %uchar %4705 %4706
-OpStore %1296 %4707
-%4708 = OpLoad %_arr_uchar_uint_16 %211
-%4709 = OpCompositeExtract %uchar %4708 9
-OpStore %1297 %4709
-%4710 = OpLoad %_arr_uchar_uint_16 %209
-%4711 = OpCompositeExtract %uchar %4710 9
-OpStore %1298 %4711
-%4712 = OpLoad %uchar %1297
-%4713 = OpLoad %uchar %1298
-%4714 = OpIAdd %uchar %4712 %4713
-OpStore %1299 %4714
-%4715 = OpLoad %_arr_uchar_uint_16 %211
-%4716 = OpCompositeExtract %uchar %4715 10
-OpStore %1300 %4716
-%4717 = OpLoad %_arr_uchar_uint_16 %209
-%4718 = OpCompositeExtract %uchar %4717 10
-OpStore %1301 %4718
-%4719 = OpLoad %uchar %1300
-%4720 = OpLoad %uchar %1301
-%4721 = OpIAdd %uchar %4719 %4720
-OpStore %1302 %4721
-%4722 = OpLoad %_arr_uchar_uint_16 %211
-%4723 = OpCompositeExtract %uchar %4722 11
-OpStore %1303 %4723
-%4724 = OpLoad %_arr_uchar_uint_16 %209
-%4725 = OpCompositeExtract %uchar %4724 11
-OpStore %1304 %4725
-%4726 = OpLoad %uchar %1303
-%4727 = OpLoad %uchar %1304
-%4728 = OpIAdd %uchar %4726 %4727
-OpStore %1305 %4728
-%4729 = OpLoad %_arr_uchar_uint_16 %211
-%4730 = OpCompositeExtract %uchar %4729 12
-OpStore %1306 %4730
-%4731 = OpLoad %_arr_uchar_uint_16 %209
-%4732 = OpCompositeExtract %uchar %4731 12
-OpStore %1307 %4732
-%4733 = OpLoad %uchar %1306
-%4734 = OpLoad %uchar %1307
-%4735 = OpIAdd %uchar %4733 %4734
-OpStore %1308 %4735
-%4736 = OpLoad %_arr_uchar_uint_16 %211
-%4737 = OpCompositeExtract %uchar %4736 13
-OpStore %1309 %4737
-%4738 = OpLoad %_arr_uchar_uint_16 %209
-%4739 = OpCompositeExtract %uchar %4738 13
-OpStore %1310 %4739
-%4740 = OpLoad %uchar %1309
-%4741 = OpLoad %uchar %1310
-%4742 = OpIAdd %uchar %4740 %4741
-OpStore %1311 %4742
-%4743 = OpLoad %_arr_uchar_uint_16 %211
-%4744 = OpCompositeExtract %uchar %4743 14
-OpStore %1312 %4744
-%4745 = OpLoad %_arr_uchar_uint_16 %209
-%4746 = OpCompositeExtract %uchar %4745 14
-OpStore %1313 %4746
-%4747 = OpLoad %uchar %1312
-%4748 = OpLoad %uchar %1313
-%4749 = OpIAdd %uchar %4747 %4748
-OpStore %1314 %4749
-%4750 = OpLoad %_arr_uchar_uint_16 %211
-%4751 = OpCompositeExtract %uchar %4750 15
-OpStore %1315 %4751
-%4752 = OpLoad %_arr_uchar_uint_16 %209
-%4753 = OpCompositeExtract %uchar %4752 15
-OpStore %1316 %4753
-%4754 = OpLoad %uchar %1315
-%4755 = OpLoad %uchar %1316
-%4756 = OpIAdd %uchar %4754 %4755
-OpStore %1317 %4756
-%4757 = OpLoad %_arr_uchar_uint_16 %211
-%4758 = OpLoad %uchar %1272
-%4759 = OpCompositeInsert %_arr_uchar_uint_16 %4758 %4757 0
-OpStore %1318 %4759
-%4760 = OpLoad %_arr_uchar_uint_16 %1318
-%4761 = OpLoad %uchar %1275
-%4762 = OpCompositeInsert %_arr_uchar_uint_16 %4761 %4760 1
-OpStore %1319 %4762
-%4763 = OpLoad %_arr_uchar_uint_16 %1319
-%4764 = OpLoad %uchar %1278
-%4765 = OpCompositeInsert %_arr_uchar_uint_16 %4764 %4763 2
-OpStore %1320 %4765
-%4766 = OpLoad %_arr_uchar_uint_16 %1320
-%4767 = OpLoad %uchar %1281
-%4768 = OpCompositeInsert %_arr_uchar_uint_16 %4767 %4766 3
-OpStore %1321 %4768
-%4769 = OpLoad %_arr_uchar_uint_16 %1321
-%4770 = OpLoad %uchar %1284
-%4771 = OpCompositeInsert %_arr_uchar_uint_16 %4770 %4769 4
-OpStore %1322 %4771
-%4772 = OpLoad %_arr_uchar_uint_16 %1322
-%4773 = OpLoad %uchar %1287
-%4774 = OpCompositeInsert %_arr_uchar_uint_16 %4773 %4772 5
-OpStore %1323 %4774
-%4775 = OpLoad %_arr_uchar_uint_16 %1323
-%4776 = OpLoad %uchar %1290
-%4777 = OpCompositeInsert %_arr_uchar_uint_16 %4776 %4775 6
-OpStore %1324 %4777
-%4778 = OpLoad %_arr_uchar_uint_16 %1324
-%4779 = OpLoad %uchar %1293
-%4780 = OpCompositeInsert %_arr_uchar_uint_16 %4779 %4778 7
-OpStore %1325 %4780
-%4781 = OpLoad %_arr_uchar_uint_16 %1325
-%4782 = OpLoad %uchar %1296
-%4783 = OpCompositeInsert %_arr_uchar_uint_16 %4782 %4781 8
-OpStore %1326 %4783
-%4784 = OpLoad %_arr_uchar_uint_16 %1326
-%4785 = OpLoad %uchar %1299
-%4786 = OpCompositeInsert %_arr_uchar_uint_16 %4785 %4784 9
-OpStore %1327 %4786
-%4787 = OpLoad %_arr_uchar_uint_16 %1327
-%4788 = OpLoad %uchar %1302
-%4789 = OpCompositeInsert %_arr_uchar_uint_16 %4788 %4787 10
-OpStore %1328 %4789
-%4790 = OpLoad %_arr_uchar_uint_16 %1328
-%4791 = OpLoad %uchar %1305
-%4792 = OpCompositeInsert %_arr_uchar_uint_16 %4791 %4790 11
-OpStore %1329 %4792
-%4793 = OpLoad %_arr_uchar_uint_16 %1329
-%4794 = OpLoad %uchar %1308
-%4795 = OpCompositeInsert %_arr_uchar_uint_16 %4794 %4793 12
-OpStore %1330 %4795
-%4796 = OpLoad %_arr_uchar_uint_16 %1330
-%4797 = OpLoad %uchar %1311
-%4798 = OpCompositeInsert %_arr_uchar_uint_16 %4797 %4796 13
-OpStore %1331 %4798
-%4799 = OpLoad %_arr_uchar_uint_16 %1331
-%4800 = OpLoad %uchar %1314
-%4801 = OpCompositeInsert %_arr_uchar_uint_16 %4800 %4799 14
-OpStore %1332 %4801
-%4802 = OpLoad %_arr_uchar_uint_16 %1332
-%4803 = OpLoad %uchar %1317
-%4804 = OpCompositeInsert %_arr_uchar_uint_16 %4803 %4802 15
-OpStore %1333 %4804
-%4805 = OpLoad %ulong %191
-%4806 = OpLoad %_arr_uchar_uint_16 %1333
-%4807 = OpFunctionCall %ulong %1 %4805 %4806
-OpStore %192 %4807
-%4808 = OpLoad %_arr_uchar_uint_16 %209
-%4809 = OpCompositeExtract %uchar %4808 0
-OpStore %1334 %4809
-%4810 = OpLoad %_arr_uchar_uint_16 %170
-%4811 = OpCompositeExtract %uchar %4810 0
-OpStore %1335 %4811
-%4812 = OpLoad %uchar %1334
-%4813 = OpLoad %uchar %1335
-%4814 = OpIAdd %uchar %4812 %4813
-OpStore %1336 %4814
-%4815 = OpLoad %_arr_uchar_uint_16 %209
-%4816 = OpCompositeExtract %uchar %4815 1
-OpStore %1337 %4816
-%4817 = OpLoad %_arr_uchar_uint_16 %170
-%4818 = OpCompositeExtract %uchar %4817 1
-OpStore %1338 %4818
-%4819 = OpLoad %uchar %1337
-%4820 = OpLoad %uchar %1338
-%4821 = OpIAdd %uchar %4819 %4820
-OpStore %1339 %4821
-%4822 = OpLoad %_arr_uchar_uint_16 %209
-%4823 = OpCompositeExtract %uchar %4822 2
-OpStore %1340 %4823
-%4824 = OpLoad %_arr_uchar_uint_16 %170
-%4825 = OpCompositeExtract %uchar %4824 2
-OpStore %1341 %4825
-%4826 = OpLoad %uchar %1340
-%4827 = OpLoad %uchar %1341
-%4828 = OpIAdd %uchar %4826 %4827
-OpStore %1342 %4828
-%4829 = OpLoad %_arr_uchar_uint_16 %209
-%4830 = OpCompositeExtract %uchar %4829 3
-OpStore %1343 %4830
-%4831 = OpLoad %_arr_uchar_uint_16 %170
-%4832 = OpCompositeExtract %uchar %4831 3
-OpStore %1344 %4832
-%4833 = OpLoad %uchar %1343
-%4834 = OpLoad %uchar %1344
-%4835 = OpIAdd %uchar %4833 %4834
-OpStore %1345 %4835
-%4836 = OpLoad %_arr_uchar_uint_16 %209
-%4837 = OpCompositeExtract %uchar %4836 4
-OpStore %1346 %4837
-%4838 = OpLoad %_arr_uchar_uint_16 %170
-%4839 = OpCompositeExtract %uchar %4838 4
-OpStore %1347 %4839
-%4840 = OpLoad %uchar %1346
-%4841 = OpLoad %uchar %1347
-%4842 = OpIAdd %uchar %4840 %4841
-OpStore %1348 %4842
-%4843 = OpLoad %_arr_uchar_uint_16 %209
-%4844 = OpCompositeExtract %uchar %4843 5
-OpStore %1349 %4844
-%4845 = OpLoad %_arr_uchar_uint_16 %170
-%4846 = OpCompositeExtract %uchar %4845 5
-OpStore %1350 %4846
-%4847 = OpLoad %uchar %1349
-%4848 = OpLoad %uchar %1350
-%4849 = OpIAdd %uchar %4847 %4848
-OpStore %1351 %4849
-%4850 = OpLoad %_arr_uchar_uint_16 %209
-%4851 = OpCompositeExtract %uchar %4850 6
-OpStore %1352 %4851
-%4852 = OpLoad %_arr_uchar_uint_16 %170
-%4853 = OpCompositeExtract %uchar %4852 6
-OpStore %1353 %4853
-%4854 = OpLoad %uchar %1352
-%4855 = OpLoad %uchar %1353
-%4856 = OpIAdd %uchar %4854 %4855
-OpStore %1354 %4856
-%4857 = OpLoad %_arr_uchar_uint_16 %209
-%4858 = OpCompositeExtract %uchar %4857 7
-OpStore %1355 %4858
-%4859 = OpLoad %_arr_uchar_uint_16 %170
-%4860 = OpCompositeExtract %uchar %4859 7
-OpStore %1356 %4860
-%4861 = OpLoad %uchar %1355
-%4862 = OpLoad %uchar %1356
-%4863 = OpIAdd %uchar %4861 %4862
-OpStore %1357 %4863
-%4864 = OpLoad %_arr_uchar_uint_16 %209
-%4865 = OpCompositeExtract %uchar %4864 8
-OpStore %1358 %4865
-%4866 = OpLoad %_arr_uchar_uint_16 %170
-%4867 = OpCompositeExtract %uchar %4866 8
-OpStore %1359 %4867
-%4868 = OpLoad %uchar %1358
-%4869 = OpLoad %uchar %1359
-%4870 = OpIAdd %uchar %4868 %4869
-OpStore %1360 %4870
-%4871 = OpLoad %_arr_uchar_uint_16 %209
-%4872 = OpCompositeExtract %uchar %4871 9
-OpStore %1361 %4872
-%4873 = OpLoad %_arr_uchar_uint_16 %170
-%4874 = OpCompositeExtract %uchar %4873 9
-OpStore %1362 %4874
-%4875 = OpLoad %uchar %1361
-%4876 = OpLoad %uchar %1362
-%4877 = OpIAdd %uchar %4875 %4876
-OpStore %1363 %4877
-%4878 = OpLoad %_arr_uchar_uint_16 %209
-%4879 = OpCompositeExtract %uchar %4878 10
-OpStore %1364 %4879
-%4880 = OpLoad %_arr_uchar_uint_16 %170
-%4881 = OpCompositeExtract %uchar %4880 10
-OpStore %1365 %4881
-%4882 = OpLoad %uchar %1364
-%4883 = OpLoad %uchar %1365
-%4884 = OpIAdd %uchar %4882 %4883
-OpStore %1366 %4884
-%4885 = OpLoad %_arr_uchar_uint_16 %209
-%4886 = OpCompositeExtract %uchar %4885 11
-OpStore %1367 %4886
-%4887 = OpLoad %_arr_uchar_uint_16 %170
-%4888 = OpCompositeExtract %uchar %4887 11
-OpStore %1368 %4888
-%4889 = OpLoad %uchar %1367
-%4890 = OpLoad %uchar %1368
-%4891 = OpIAdd %uchar %4889 %4890
-OpStore %1369 %4891
-%4892 = OpLoad %_arr_uchar_uint_16 %209
-%4893 = OpCompositeExtract %uchar %4892 12
-OpStore %1370 %4893
-%4894 = OpLoad %_arr_uchar_uint_16 %170
-%4895 = OpCompositeExtract %uchar %4894 12
-OpStore %1371 %4895
-%4896 = OpLoad %uchar %1370
-%4897 = OpLoad %uchar %1371
-%4898 = OpIAdd %uchar %4896 %4897
-OpStore %1372 %4898
-%4899 = OpLoad %_arr_uchar_uint_16 %209
-%4900 = OpCompositeExtract %uchar %4899 13
-OpStore %1373 %4900
-%4901 = OpLoad %_arr_uchar_uint_16 %170
-%4902 = OpCompositeExtract %uchar %4901 13
-OpStore %1374 %4902
-%4903 = OpLoad %uchar %1373
-%4904 = OpLoad %uchar %1374
-%4905 = OpIAdd %uchar %4903 %4904
-OpStore %1375 %4905
-%4906 = OpLoad %_arr_uchar_uint_16 %209
-%4907 = OpCompositeExtract %uchar %4906 14
-OpStore %1376 %4907
-%4908 = OpLoad %_arr_uchar_uint_16 %170
-%4909 = OpCompositeExtract %uchar %4908 14
-OpStore %1377 %4909
-%4910 = OpLoad %uchar %1376
-%4911 = OpLoad %uchar %1377
-%4912 = OpIAdd %uchar %4910 %4911
-OpStore %1378 %4912
-%4913 = OpLoad %_arr_uchar_uint_16 %209
-%4914 = OpCompositeExtract %uchar %4913 15
-OpStore %1379 %4914
-%4915 = OpLoad %_arr_uchar_uint_16 %170
-%4916 = OpCompositeExtract %uchar %4915 15
-OpStore %1380 %4916
-%4917 = OpLoad %uchar %1379
-%4918 = OpLoad %uchar %1380
-%4919 = OpIAdd %uchar %4917 %4918
-OpStore %1381 %4919
-%4920 = OpLoad %_arr_uchar_uint_16 %209
-%4921 = OpLoad %uchar %1336
-%4922 = OpCompositeInsert %_arr_uchar_uint_16 %4921 %4920 0
-OpStore %1382 %4922
-%4923 = OpLoad %_arr_uchar_uint_16 %1382
-%4924 = OpLoad %uchar %1339
-%4925 = OpCompositeInsert %_arr_uchar_uint_16 %4924 %4923 1
-OpStore %1383 %4925
-%4926 = OpLoad %_arr_uchar_uint_16 %1383
-%4927 = OpLoad %uchar %1342
-%4928 = OpCompositeInsert %_arr_uchar_uint_16 %4927 %4926 2
-OpStore %1384 %4928
-%4929 = OpLoad %_arr_uchar_uint_16 %1384
-%4930 = OpLoad %uchar %1345
-%4931 = OpCompositeInsert %_arr_uchar_uint_16 %4930 %4929 3
-OpStore %1385 %4931
-%4932 = OpLoad %_arr_uchar_uint_16 %1385
-%4933 = OpLoad %uchar %1348
-%4934 = OpCompositeInsert %_arr_uchar_uint_16 %4933 %4932 4
-OpStore %1386 %4934
-%4935 = OpLoad %_arr_uchar_uint_16 %1386
-%4936 = OpLoad %uchar %1351
-%4937 = OpCompositeInsert %_arr_uchar_uint_16 %4936 %4935 5
-OpStore %1387 %4937
-%4938 = OpLoad %_arr_uchar_uint_16 %1387
-%4939 = OpLoad %uchar %1354
-%4940 = OpCompositeInsert %_arr_uchar_uint_16 %4939 %4938 6
-OpStore %1388 %4940
-%4941 = OpLoad %_arr_uchar_uint_16 %1388
-%4942 = OpLoad %uchar %1357
-%4943 = OpCompositeInsert %_arr_uchar_uint_16 %4942 %4941 7
-OpStore %1389 %4943
-%4944 = OpLoad %_arr_uchar_uint_16 %1389
-%4945 = OpLoad %uchar %1360
-%4946 = OpCompositeInsert %_arr_uchar_uint_16 %4945 %4944 8
-OpStore %1390 %4946
-%4947 = OpLoad %_arr_uchar_uint_16 %1390
-%4948 = OpLoad %uchar %1363
-%4949 = OpCompositeInsert %_arr_uchar_uint_16 %4948 %4947 9
-OpStore %1391 %4949
-%4950 = OpLoad %_arr_uchar_uint_16 %1391
-%4951 = OpLoad %uchar %1366
-%4952 = OpCompositeInsert %_arr_uchar_uint_16 %4951 %4950 10
-OpStore %1392 %4952
-%4953 = OpLoad %_arr_uchar_uint_16 %1392
-%4954 = OpLoad %uchar %1369
-%4955 = OpCompositeInsert %_arr_uchar_uint_16 %4954 %4953 11
-OpStore %1393 %4955
-%4956 = OpLoad %_arr_uchar_uint_16 %1393
-%4957 = OpLoad %uchar %1372
-%4958 = OpCompositeInsert %_arr_uchar_uint_16 %4957 %4956 12
-OpStore %1394 %4958
-%4959 = OpLoad %_arr_uchar_uint_16 %1394
-%4960 = OpLoad %uchar %1375
-%4961 = OpCompositeInsert %_arr_uchar_uint_16 %4960 %4959 13
-OpStore %1395 %4961
-%4962 = OpLoad %_arr_uchar_uint_16 %1395
-%4963 = OpLoad %uchar %1378
-%4964 = OpCompositeInsert %_arr_uchar_uint_16 %4963 %4962 14
-OpStore %1396 %4964
-%4965 = OpLoad %_arr_uchar_uint_16 %1396
-%4966 = OpLoad %uchar %1381
-%4967 = OpCompositeInsert %_arr_uchar_uint_16 %4966 %4965 15
-OpStore %1397 %4967
-%4968 = OpLoad %ulong %192
-%4969 = OpLoad %_arr_uchar_uint_16 %1397
-%4970 = OpFunctionCall %ulong %1 %4968 %4969
-OpStore %193 %4970
-%4971 = OpLoad %ulong %212
-%4972 = OpIAdd %ulong %4971 %ulong_1
-OpStore %194 %4972
-%4973 = OpLoad %ulong %193
-OpStore %208 %4973
-%4974 = OpLoad %_arr_uchar_uint_16 %1397
-OpStore %209 %4974
-%4975 = OpLoad %_arr_uchar_uint_16 %1269
-OpStore %210 %4975
-%4976 = OpLoad %_arr_uchar_uint_16 %1333
-OpStore %211 %4976
-%4977 = OpLoad %ulong %194
-OpStore %212 %4977
-OpBranch %143
-%142 = OpLabel
-OpBranch %139
-%143 = OpLabel
-OpBranch %136
+%1510 = OpVariable %_ptr_Function_uchar Function
+%1511 = OpVariable %_ptr_Function_uchar Function
+%1512 = OpVariable %_ptr_Function_uchar Function
+%1513 = OpVariable %_ptr_Function_uchar Function
+%1514 = OpVariable %_ptr_Function_uchar Function
+%1515 = OpVariable %_ptr_Function_uchar Function
+%1516 = OpVariable %_ptr_Function_uchar Function
+%1517 = OpVariable %_ptr_Function_uchar Function
+%1518 = OpVariable %_ptr_Function_uchar Function
+%1519 = OpVariable %_ptr_Function_uchar Function
+%1520 = OpVariable %_ptr_Function_uchar Function
+%1521 = OpVariable %_ptr_Function_uchar Function
+%1522 = OpVariable %_ptr_Function_uchar Function
+%1523 = OpVariable %_ptr_Function_uchar Function
+%1524 = OpVariable %_ptr_Function_uchar Function
+%1525 = OpVariable %_ptr_Function_uchar Function
+%1526 = OpVariable %_ptr_Function_uchar Function
+%1527 = OpVariable %_ptr_Function_uchar Function
+%1528 = OpVariable %_ptr_Function_uchar Function
+%1529 = OpVariable %_ptr_Function_uchar Function
+%1530 = OpVariable %_ptr_Function_uchar Function
+%1531 = OpVariable %_ptr_Function_uchar Function
+%1532 = OpVariable %_ptr_Function_uchar Function
+%1533 = OpVariable %_ptr_Function_uchar Function
+%1534 = OpVariable %_ptr_Function_uchar Function
+%1535 = OpVariable %_ptr_Function_uchar Function
+%1536 = OpVariable %_ptr_Function_uchar Function
+%1537 = OpVariable %_ptr_Function_uchar Function
+%1538 = OpVariable %_ptr_Function_uchar Function
+%1539 = OpVariable %_ptr_Function_uchar Function
+%1540 = OpVariable %_ptr_Function_uchar Function
+%1541 = OpVariable %_ptr_Function_uchar Function
+%1542 = OpVariable %_ptr_Function_uchar Function
+%1543 = OpVariable %_ptr_Function_uchar Function
+%1544 = OpVariable %_ptr_Function_uchar Function
+%1545 = OpVariable %_ptr_Function_uchar Function
+%1546 = OpVariable %_ptr_Function_uchar Function
+%1547 = OpVariable %_ptr_Function_uchar Function
+%1548 = OpVariable %_ptr_Function_uchar Function
+%1549 = OpVariable %_ptr_Function_uchar Function
+%1550 = OpVariable %_ptr_Function_uchar Function
+%1551 = OpVariable %_ptr_Function_uchar Function
+%1552 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1553 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1554 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1555 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1556 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1557 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1558 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1559 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1560 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1561 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1562 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1563 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1564 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1565 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1566 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1567 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1568 = OpVariable %_ptr_Function_uchar Function
+%1569 = OpVariable %_ptr_Function_uchar Function
+%1570 = OpVariable %_ptr_Function_uchar Function
+%1571 = OpVariable %_ptr_Function_uchar Function
+%1572 = OpVariable %_ptr_Function_uchar Function
+%1573 = OpVariable %_ptr_Function_uchar Function
+%1574 = OpVariable %_ptr_Function_uchar Function
+%1575 = OpVariable %_ptr_Function_uchar Function
+%1576 = OpVariable %_ptr_Function_uchar Function
+%1577 = OpVariable %_ptr_Function_uchar Function
+%1578 = OpVariable %_ptr_Function_uchar Function
+%1579 = OpVariable %_ptr_Function_uchar Function
+%1580 = OpVariable %_ptr_Function_uchar Function
+%1581 = OpVariable %_ptr_Function_uchar Function
+%1582 = OpVariable %_ptr_Function_uchar Function
+%1583 = OpVariable %_ptr_Function_uchar Function
+%1584 = OpVariable %_ptr_Function_uchar Function
+%1585 = OpVariable %_ptr_Function_uchar Function
+%1586 = OpVariable %_ptr_Function_uchar Function
+%1587 = OpVariable %_ptr_Function_uchar Function
+%1588 = OpVariable %_ptr_Function_uchar Function
+%1589 = OpVariable %_ptr_Function_uchar Function
+%1590 = OpVariable %_ptr_Function_uchar Function
+%1591 = OpVariable %_ptr_Function_uchar Function
+%1592 = OpVariable %_ptr_Function_uchar Function
+%1593 = OpVariable %_ptr_Function_uchar Function
+%1594 = OpVariable %_ptr_Function_uchar Function
+%1595 = OpVariable %_ptr_Function_uchar Function
+%1596 = OpVariable %_ptr_Function_uchar Function
+%1597 = OpVariable %_ptr_Function_uchar Function
+%1598 = OpVariable %_ptr_Function_uchar Function
+%1599 = OpVariable %_ptr_Function_uchar Function
+%1600 = OpVariable %_ptr_Function_uchar Function
+%1601 = OpVariable %_ptr_Function_uchar Function
+%1602 = OpVariable %_ptr_Function_uchar Function
+%1603 = OpVariable %_ptr_Function_uchar Function
+%1604 = OpVariable %_ptr_Function_uchar Function
+%1605 = OpVariable %_ptr_Function_uchar Function
+%1606 = OpVariable %_ptr_Function_uchar Function
+%1607 = OpVariable %_ptr_Function_uchar Function
+%1608 = OpVariable %_ptr_Function_uchar Function
+%1609 = OpVariable %_ptr_Function_uchar Function
+%1610 = OpVariable %_ptr_Function_uchar Function
+%1611 = OpVariable %_ptr_Function_uchar Function
+%1612 = OpVariable %_ptr_Function_uchar Function
+%1613 = OpVariable %_ptr_Function_uchar Function
+%1614 = OpVariable %_ptr_Function_uchar Function
+%1615 = OpVariable %_ptr_Function_uchar Function
+%1616 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1617 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1618 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1619 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1620 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1621 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1622 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1623 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1624 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1625 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1626 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1627 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1628 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1629 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1630 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1631 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1632 = OpVariable %_ptr_Function_uchar Function
+%1633 = OpVariable %_ptr_Function_uchar Function
+%1634 = OpVariable %_ptr_Function_uchar Function
+%1635 = OpVariable %_ptr_Function_uchar Function
+%1636 = OpVariable %_ptr_Function_uchar Function
+%1637 = OpVariable %_ptr_Function_uchar Function
+%1638 = OpVariable %_ptr_Function_uchar Function
+%1639 = OpVariable %_ptr_Function_uchar Function
+%1640 = OpVariable %_ptr_Function_uchar Function
+%1641 = OpVariable %_ptr_Function_uchar Function
+%1642 = OpVariable %_ptr_Function_uchar Function
+%1643 = OpVariable %_ptr_Function_uchar Function
+%1644 = OpVariable %_ptr_Function_uchar Function
+%1645 = OpVariable %_ptr_Function_uchar Function
+%1646 = OpVariable %_ptr_Function_uchar Function
+%1647 = OpVariable %_ptr_Function_uchar Function
+%1648 = OpVariable %_ptr_Function_uchar Function
+%1649 = OpVariable %_ptr_Function_uchar Function
+%1650 = OpVariable %_ptr_Function_uchar Function
+%1651 = OpVariable %_ptr_Function_uchar Function
+%1652 = OpVariable %_ptr_Function_uchar Function
+%1653 = OpVariable %_ptr_Function_uchar Function
+%1654 = OpVariable %_ptr_Function_uchar Function
+%1655 = OpVariable %_ptr_Function_uchar Function
+%1656 = OpVariable %_ptr_Function_uchar Function
+%1657 = OpVariable %_ptr_Function_uchar Function
+%1658 = OpVariable %_ptr_Function_uchar Function
+%1659 = OpVariable %_ptr_Function_uchar Function
+%1660 = OpVariable %_ptr_Function_uchar Function
+%1661 = OpVariable %_ptr_Function_uchar Function
+%1662 = OpVariable %_ptr_Function_uchar Function
+%1663 = OpVariable %_ptr_Function_uchar Function
+%1664 = OpVariable %_ptr_Function_uchar Function
+%1665 = OpVariable %_ptr_Function_uchar Function
+%1666 = OpVariable %_ptr_Function_uchar Function
+%1667 = OpVariable %_ptr_Function_uchar Function
+%1668 = OpVariable %_ptr_Function_uchar Function
+%1669 = OpVariable %_ptr_Function_uchar Function
+%1670 = OpVariable %_ptr_Function_uchar Function
+%1671 = OpVariable %_ptr_Function_uchar Function
+%1672 = OpVariable %_ptr_Function_uchar Function
+%1673 = OpVariable %_ptr_Function_uchar Function
+%1674 = OpVariable %_ptr_Function_uchar Function
+%1675 = OpVariable %_ptr_Function_uchar Function
+%1676 = OpVariable %_ptr_Function_uchar Function
+%1677 = OpVariable %_ptr_Function_uchar Function
+%1678 = OpVariable %_ptr_Function_uchar Function
+%1679 = OpVariable %_ptr_Function_uchar Function
+%1680 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1681 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1682 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1683 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1684 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1685 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1686 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1687 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1688 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1689 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1690 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1691 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1692 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1693 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1694 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1695 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1696 = OpVariable %_ptr_Function_uchar Function
+%1697 = OpVariable %_ptr_Function_uchar Function
+%1698 = OpVariable %_ptr_Function_uchar Function
+%1699 = OpVariable %_ptr_Function_uchar Function
+%1700 = OpVariable %_ptr_Function_uchar Function
+%1701 = OpVariable %_ptr_Function_uchar Function
+%1702 = OpVariable %_ptr_Function_uchar Function
+%1703 = OpVariable %_ptr_Function_uchar Function
+%1704 = OpVariable %_ptr_Function_uchar Function
+%1705 = OpVariable %_ptr_Function_uchar Function
+%1706 = OpVariable %_ptr_Function_uchar Function
+%1707 = OpVariable %_ptr_Function_uchar Function
+%1708 = OpVariable %_ptr_Function_uchar Function
+%1709 = OpVariable %_ptr_Function_uchar Function
+%1710 = OpVariable %_ptr_Function_uchar Function
+%1711 = OpVariable %_ptr_Function_uchar Function
+%1712 = OpVariable %_ptr_Function_uchar Function
+%1713 = OpVariable %_ptr_Function_uchar Function
+%1714 = OpVariable %_ptr_Function_uchar Function
+%1715 = OpVariable %_ptr_Function_uchar Function
+%1716 = OpVariable %_ptr_Function_uchar Function
+%1717 = OpVariable %_ptr_Function_uchar Function
+%1718 = OpVariable %_ptr_Function_uchar Function
+%1719 = OpVariable %_ptr_Function_uchar Function
+%1720 = OpVariable %_ptr_Function_uchar Function
+%1721 = OpVariable %_ptr_Function_uchar Function
+%1722 = OpVariable %_ptr_Function_uchar Function
+%1723 = OpVariable %_ptr_Function_uchar Function
+%1724 = OpVariable %_ptr_Function_uchar Function
+%1725 = OpVariable %_ptr_Function_uchar Function
+%1726 = OpVariable %_ptr_Function_uchar Function
+%1727 = OpVariable %_ptr_Function_uchar Function
+%1728 = OpVariable %_ptr_Function_uchar Function
+%1729 = OpVariable %_ptr_Function_uchar Function
+%1730 = OpVariable %_ptr_Function_uchar Function
+%1731 = OpVariable %_ptr_Function_uchar Function
+%1732 = OpVariable %_ptr_Function_uchar Function
+%1733 = OpVariable %_ptr_Function_uchar Function
+%1734 = OpVariable %_ptr_Function_uchar Function
+%1735 = OpVariable %_ptr_Function_uchar Function
+%1736 = OpVariable %_ptr_Function_uchar Function
+%1737 = OpVariable %_ptr_Function_uchar Function
+%1738 = OpVariable %_ptr_Function_uchar Function
+%1739 = OpVariable %_ptr_Function_uchar Function
+%1740 = OpVariable %_ptr_Function_uchar Function
+%1741 = OpVariable %_ptr_Function_uchar Function
+%1742 = OpVariable %_ptr_Function_uchar Function
+%1743 = OpVariable %_ptr_Function_uchar Function
+%1744 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1745 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1746 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1747 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1748 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1749 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1750 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1751 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1752 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1753 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1754 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1755 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1756 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1757 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1758 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1759 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1760 = OpVariable %_ptr_Function_uchar Function
+%1761 = OpVariable %_ptr_Function_uchar Function
+%1762 = OpVariable %_ptr_Function_uchar Function
+%1763 = OpVariable %_ptr_Function_uchar Function
+%1764 = OpVariable %_ptr_Function_uchar Function
+%1765 = OpVariable %_ptr_Function_uchar Function
+%1766 = OpVariable %_ptr_Function_uchar Function
+%1767 = OpVariable %_ptr_Function_uchar Function
+%1768 = OpVariable %_ptr_Function_uchar Function
+%1769 = OpVariable %_ptr_Function_uchar Function
+%1770 = OpVariable %_ptr_Function_uchar Function
+%1771 = OpVariable %_ptr_Function_uchar Function
+%1772 = OpVariable %_ptr_Function_uchar Function
+%1773 = OpVariable %_ptr_Function_uchar Function
+%1774 = OpVariable %_ptr_Function_uchar Function
+%1775 = OpVariable %_ptr_Function_uchar Function
+%1776 = OpVariable %_ptr_Function_uchar Function
+%1777 = OpVariable %_ptr_Function_uchar Function
+%1778 = OpVariable %_ptr_Function_uchar Function
+%1779 = OpVariable %_ptr_Function_uchar Function
+%1780 = OpVariable %_ptr_Function_uchar Function
+%1781 = OpVariable %_ptr_Function_uchar Function
+%1782 = OpVariable %_ptr_Function_uchar Function
+%1783 = OpVariable %_ptr_Function_uchar Function
+%1784 = OpVariable %_ptr_Function_uchar Function
+%1785 = OpVariable %_ptr_Function_uchar Function
+%1786 = OpVariable %_ptr_Function_uchar Function
+%1787 = OpVariable %_ptr_Function_uchar Function
+%1788 = OpVariable %_ptr_Function_uchar Function
+%1789 = OpVariable %_ptr_Function_uchar Function
+%1790 = OpVariable %_ptr_Function_uchar Function
+%1791 = OpVariable %_ptr_Function_uchar Function
+%1792 = OpVariable %_ptr_Function_uchar Function
+%1793 = OpVariable %_ptr_Function_uchar Function
+%1794 = OpVariable %_ptr_Function_uchar Function
+%1795 = OpVariable %_ptr_Function_uchar Function
+%1796 = OpVariable %_ptr_Function_uchar Function
+%1797 = OpVariable %_ptr_Function_uchar Function
+%1798 = OpVariable %_ptr_Function_uchar Function
+%1799 = OpVariable %_ptr_Function_uchar Function
+%1800 = OpVariable %_ptr_Function_uchar Function
+%1801 = OpVariable %_ptr_Function_uchar Function
+%1802 = OpVariable %_ptr_Function_uchar Function
+%1803 = OpVariable %_ptr_Function_uchar Function
+%1804 = OpVariable %_ptr_Function_uchar Function
+%1805 = OpVariable %_ptr_Function_uchar Function
+%1806 = OpVariable %_ptr_Function_uchar Function
+%1807 = OpVariable %_ptr_Function_uchar Function
+%1808 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1809 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1810 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1811 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1812 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1813 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1814 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1815 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1816 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1817 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1818 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1819 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1820 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1821 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1822 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1823 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1824 = OpVariable %_ptr_Function_uchar Function
+%1825 = OpVariable %_ptr_Function_uchar Function
+%1826 = OpVariable %_ptr_Function_uchar Function
+%1827 = OpVariable %_ptr_Function_uchar Function
+%1828 = OpVariable %_ptr_Function_uchar Function
+%1829 = OpVariable %_ptr_Function_uchar Function
+%1830 = OpVariable %_ptr_Function_uchar Function
+%1831 = OpVariable %_ptr_Function_uchar Function
+%1832 = OpVariable %_ptr_Function_uchar Function
+%1833 = OpVariable %_ptr_Function_uchar Function
+%1834 = OpVariable %_ptr_Function_uchar Function
+%1835 = OpVariable %_ptr_Function_uchar Function
+%1836 = OpVariable %_ptr_Function_uchar Function
+%1837 = OpVariable %_ptr_Function_uchar Function
+%1838 = OpVariable %_ptr_Function_uchar Function
+%1839 = OpVariable %_ptr_Function_uchar Function
+%1840 = OpVariable %_ptr_Function_uchar Function
+%1841 = OpVariable %_ptr_Function_uchar Function
+%1842 = OpVariable %_ptr_Function_uchar Function
+%1843 = OpVariable %_ptr_Function_uchar Function
+%1844 = OpVariable %_ptr_Function_uchar Function
+%1845 = OpVariable %_ptr_Function_uchar Function
+%1846 = OpVariable %_ptr_Function_uchar Function
+%1847 = OpVariable %_ptr_Function_uchar Function
+%1848 = OpVariable %_ptr_Function_uchar Function
+%1849 = OpVariable %_ptr_Function_uchar Function
+%1850 = OpVariable %_ptr_Function_uchar Function
+%1851 = OpVariable %_ptr_Function_uchar Function
+%1852 = OpVariable %_ptr_Function_uchar Function
+%1853 = OpVariable %_ptr_Function_uchar Function
+%1854 = OpVariable %_ptr_Function_uchar Function
+%1855 = OpVariable %_ptr_Function_uchar Function
+%1856 = OpVariable %_ptr_Function_uchar Function
+%1857 = OpVariable %_ptr_Function_uchar Function
+%1858 = OpVariable %_ptr_Function_uchar Function
+%1859 = OpVariable %_ptr_Function_uchar Function
+%1860 = OpVariable %_ptr_Function_uchar Function
+%1861 = OpVariable %_ptr_Function_uchar Function
+%1862 = OpVariable %_ptr_Function_uchar Function
+%1863 = OpVariable %_ptr_Function_uchar Function
+%1864 = OpVariable %_ptr_Function_uchar Function
+%1865 = OpVariable %_ptr_Function_uchar Function
+%1866 = OpVariable %_ptr_Function_uchar Function
+%1867 = OpVariable %_ptr_Function_uchar Function
+%1868 = OpVariable %_ptr_Function_uchar Function
+%1869 = OpVariable %_ptr_Function_uchar Function
+%1870 = OpVariable %_ptr_Function_uchar Function
+%1871 = OpVariable %_ptr_Function_uchar Function
+%1872 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1873 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1874 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1875 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1876 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1877 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1878 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1879 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1880 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1881 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1882 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1883 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1884 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1885 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1886 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1887 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1888 = OpVariable %_ptr_Function_uchar Function
+%1889 = OpVariable %_ptr_Function_uchar Function
+%1890 = OpVariable %_ptr_Function_uchar Function
+%1891 = OpVariable %_ptr_Function_uchar Function
+%1892 = OpVariable %_ptr_Function_uchar Function
+%1893 = OpVariable %_ptr_Function_uchar Function
+%1894 = OpVariable %_ptr_Function_uchar Function
+%1895 = OpVariable %_ptr_Function_uchar Function
+%1896 = OpVariable %_ptr_Function_uchar Function
+%1897 = OpVariable %_ptr_Function_uchar Function
+%1898 = OpVariable %_ptr_Function_uchar Function
+%1899 = OpVariable %_ptr_Function_uchar Function
+%1900 = OpVariable %_ptr_Function_uchar Function
+%1901 = OpVariable %_ptr_Function_uchar Function
+%1902 = OpVariable %_ptr_Function_uchar Function
+%1903 = OpVariable %_ptr_Function_uchar Function
+%1904 = OpVariable %_ptr_Function_uchar Function
+%1905 = OpVariable %_ptr_Function_uchar Function
+%1906 = OpVariable %_ptr_Function_uchar Function
+%1907 = OpVariable %_ptr_Function_uchar Function
+%1908 = OpVariable %_ptr_Function_uchar Function
+%1909 = OpVariable %_ptr_Function_uchar Function
+%1910 = OpVariable %_ptr_Function_uchar Function
+%1911 = OpVariable %_ptr_Function_uchar Function
+%1912 = OpVariable %_ptr_Function_uchar Function
+%1913 = OpVariable %_ptr_Function_uchar Function
+%1914 = OpVariable %_ptr_Function_uchar Function
+%1915 = OpVariable %_ptr_Function_uchar Function
+%1916 = OpVariable %_ptr_Function_uchar Function
+%1917 = OpVariable %_ptr_Function_uchar Function
+%1918 = OpVariable %_ptr_Function_uchar Function
+%1919 = OpVariable %_ptr_Function_uchar Function
+%1920 = OpVariable %_ptr_Function_uchar Function
+%1921 = OpVariable %_ptr_Function_uchar Function
+%1922 = OpVariable %_ptr_Function_uchar Function
+%1923 = OpVariable %_ptr_Function_uchar Function
+%1924 = OpVariable %_ptr_Function_uchar Function
+%1925 = OpVariable %_ptr_Function_uchar Function
+%1926 = OpVariable %_ptr_Function_uchar Function
+%1927 = OpVariable %_ptr_Function_uchar Function
+%1928 = OpVariable %_ptr_Function_uchar Function
+%1929 = OpVariable %_ptr_Function_uchar Function
+%1930 = OpVariable %_ptr_Function_uchar Function
+%1931 = OpVariable %_ptr_Function_uchar Function
+%1932 = OpVariable %_ptr_Function_uchar Function
+%1933 = OpVariable %_ptr_Function_uchar Function
+%1934 = OpVariable %_ptr_Function_uchar Function
+%1935 = OpVariable %_ptr_Function_uchar Function
+%1936 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1937 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1938 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1939 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1940 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1941 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1942 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1943 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1944 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1945 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1946 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1947 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1948 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1949 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1950 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1951 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1952 = OpVariable %_ptr_Function_uchar Function
+%1953 = OpVariable %_ptr_Function_uchar Function
+%1954 = OpVariable %_ptr_Function_uchar Function
+%1955 = OpVariable %_ptr_Function_uchar Function
+%1956 = OpVariable %_ptr_Function_uchar Function
+%1957 = OpVariable %_ptr_Function_uchar Function
+%1958 = OpVariable %_ptr_Function_uchar Function
+%1959 = OpVariable %_ptr_Function_uchar Function
+%1960 = OpVariable %_ptr_Function_uchar Function
+%1961 = OpVariable %_ptr_Function_uchar Function
+%1962 = OpVariable %_ptr_Function_uchar Function
+%1963 = OpVariable %_ptr_Function_uchar Function
+%1964 = OpVariable %_ptr_Function_uchar Function
+%1965 = OpVariable %_ptr_Function_uchar Function
+%1966 = OpVariable %_ptr_Function_uchar Function
+%1967 = OpVariable %_ptr_Function_uchar Function
+%1968 = OpVariable %_ptr_Function_uchar Function
+%1969 = OpVariable %_ptr_Function_uchar Function
+%1970 = OpVariable %_ptr_Function_uchar Function
+%1971 = OpVariable %_ptr_Function_uchar Function
+%1972 = OpVariable %_ptr_Function_uchar Function
+%1973 = OpVariable %_ptr_Function_uchar Function
+%1974 = OpVariable %_ptr_Function_uchar Function
+%1975 = OpVariable %_ptr_Function_uchar Function
+%1976 = OpVariable %_ptr_Function_uchar Function
+%1977 = OpVariable %_ptr_Function_uchar Function
+%1978 = OpVariable %_ptr_Function_uchar Function
+%1979 = OpVariable %_ptr_Function_uchar Function
+%1980 = OpVariable %_ptr_Function_uchar Function
+%1981 = OpVariable %_ptr_Function_uchar Function
+%1982 = OpVariable %_ptr_Function_uchar Function
+%1983 = OpVariable %_ptr_Function_uchar Function
+%1984 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1985 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1986 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1987 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1988 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1989 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1990 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1991 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1992 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1993 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1994 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1995 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1996 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1997 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1998 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1999 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2000 = OpVariable %_ptr_Function_uchar Function
+%2001 = OpVariable %_ptr_Function_uchar Function
+%2002 = OpVariable %_ptr_Function_uchar Function
+%2003 = OpVariable %_ptr_Function_uchar Function
+%2004 = OpVariable %_ptr_Function_uchar Function
+%2005 = OpVariable %_ptr_Function_uchar Function
+%2006 = OpVariable %_ptr_Function_uchar Function
+%2007 = OpVariable %_ptr_Function_uchar Function
+%2008 = OpVariable %_ptr_Function_uchar Function
+%2009 = OpVariable %_ptr_Function_uchar Function
+%2010 = OpVariable %_ptr_Function_uchar Function
+%2011 = OpVariable %_ptr_Function_uchar Function
+%2012 = OpVariable %_ptr_Function_uchar Function
+%2013 = OpVariable %_ptr_Function_uchar Function
+%2014 = OpVariable %_ptr_Function_uchar Function
+%2015 = OpVariable %_ptr_Function_uchar Function
+%2016 = OpVariable %_ptr_Function_uchar Function
+%2017 = OpVariable %_ptr_Function_uchar Function
+%2018 = OpVariable %_ptr_Function_uchar Function
+%2019 = OpVariable %_ptr_Function_uchar Function
+%2020 = OpVariable %_ptr_Function_uchar Function
+%2021 = OpVariable %_ptr_Function_uchar Function
+%2022 = OpVariable %_ptr_Function_uchar Function
+%2023 = OpVariable %_ptr_Function_uchar Function
+%2024 = OpVariable %_ptr_Function_uchar Function
+%2025 = OpVariable %_ptr_Function_uchar Function
+%2026 = OpVariable %_ptr_Function_uchar Function
+%2027 = OpVariable %_ptr_Function_uchar Function
+%2028 = OpVariable %_ptr_Function_uchar Function
+%2029 = OpVariable %_ptr_Function_uchar Function
+%2030 = OpVariable %_ptr_Function_uchar Function
+%2031 = OpVariable %_ptr_Function_uchar Function
+%2032 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2033 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2034 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2035 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2036 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2037 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2038 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2039 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2040 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2041 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2042 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2043 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2044 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2045 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2046 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2047 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2048 = OpVariable %_ptr_Function_uchar Function
+%2049 = OpVariable %_ptr_Function_uchar Function
+%2050 = OpVariable %_ptr_Function_uchar Function
+%2051 = OpVariable %_ptr_Function_uchar Function
+%2052 = OpVariable %_ptr_Function_uchar Function
+%2053 = OpVariable %_ptr_Function_uchar Function
+%2054 = OpVariable %_ptr_Function_uchar Function
+%2055 = OpVariable %_ptr_Function_uchar Function
+%2056 = OpVariable %_ptr_Function_uchar Function
+%2057 = OpVariable %_ptr_Function_uchar Function
+%2058 = OpVariable %_ptr_Function_uchar Function
+%2059 = OpVariable %_ptr_Function_uchar Function
+%2060 = OpVariable %_ptr_Function_uchar Function
+%2061 = OpVariable %_ptr_Function_uchar Function
+%2062 = OpVariable %_ptr_Function_uchar Function
+%2063 = OpVariable %_ptr_Function_uchar Function
+%2064 = OpVariable %_ptr_Function_uchar Function
+%2065 = OpVariable %_ptr_Function_uchar Function
+%2066 = OpVariable %_ptr_Function_uchar Function
+%2067 = OpVariable %_ptr_Function_uchar Function
+%2068 = OpVariable %_ptr_Function_uchar Function
+%2069 = OpVariable %_ptr_Function_uchar Function
+%2070 = OpVariable %_ptr_Function_uchar Function
+%2071 = OpVariable %_ptr_Function_uchar Function
+%2072 = OpVariable %_ptr_Function_uchar Function
+%2073 = OpVariable %_ptr_Function_uchar Function
+%2074 = OpVariable %_ptr_Function_uchar Function
+%2075 = OpVariable %_ptr_Function_uchar Function
+%2076 = OpVariable %_ptr_Function_uchar Function
+%2077 = OpVariable %_ptr_Function_uchar Function
+%2078 = OpVariable %_ptr_Function_uchar Function
+%2079 = OpVariable %_ptr_Function_uchar Function
+%2080 = OpVariable %_ptr_Function_uchar Function
+%2081 = OpVariable %_ptr_Function_uchar Function
+%2082 = OpVariable %_ptr_Function_uchar Function
+%2083 = OpVariable %_ptr_Function_uchar Function
+%2084 = OpVariable %_ptr_Function_uchar Function
+%2085 = OpVariable %_ptr_Function_uchar Function
+%2086 = OpVariable %_ptr_Function_uchar Function
+%2087 = OpVariable %_ptr_Function_uchar Function
+%2088 = OpVariable %_ptr_Function_uchar Function
+%2089 = OpVariable %_ptr_Function_uchar Function
+%2090 = OpVariable %_ptr_Function_uchar Function
+%2091 = OpVariable %_ptr_Function_uchar Function
+%2092 = OpVariable %_ptr_Function_uchar Function
+%2093 = OpVariable %_ptr_Function_uchar Function
+%2094 = OpVariable %_ptr_Function_uchar Function
+%2095 = OpVariable %_ptr_Function_uchar Function
+%2096 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2097 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2098 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2099 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2100 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2101 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2102 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2103 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2104 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2105 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2106 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2107 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2108 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2109 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2110 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2111 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+OpStore %738 %715
+OpBranch %723
+%723 = OpLabel
+OpBranch %724
+%724 = OpLabel
+%2112 = OpLoad %ulong %738
+%2113 = OpUConvert %uchar %2112
+OpStore %739 %2113
+%2114 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_247 %uchar_7 %uchar_251 %uchar_3 %uchar_255 %uchar_2 %uchar_252 %uchar_6 %uchar_248 %uchar_9 %uchar_253 %uchar_1 %uchar_254 %uchar_4 %uchar_250 %uchar_8
+OpStore %740 %2114
+%2131 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_2 %uchar_253 %uchar_4 %uchar_251 %uchar_6 %uchar_249 %uchar_8 %uchar_247 %uchar_1 %uchar_254 %uchar_3 %uchar_252 %uchar_5 %uchar_250 %uchar_7 %uchar_255
+OpStore %741 %2131
+%2134 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2 %uchar_1 %uchar_2 %uchar_3 %uchar_2
+OpStore %742 %2134
+%2135 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0
+OpStore %743 %2135
+%2137 = OpLoad %_arr_uchar_uint_16 %740
+%2138 = OpCompositeExtract %uchar %2137 0
+OpStore %744 %2138
+%2139 = OpLoad %uchar %744
+%2140 = OpLoad %uchar %739
+%2141 = OpIAdd %uchar %2139 %2140
+OpStore %745 %2141
+%2142 = OpLoad %_arr_uchar_uint_16 %740
+%2143 = OpLoad %uchar %745
+%2144 = OpCompositeInsert %_arr_uchar_uint_16 %2143 %2142 0
+OpStore %746 %2144
+%2145 = OpLoad %_arr_uchar_uint_16 %746
+%2146 = OpCompositeExtract %uchar %2145 7
+OpStore %747 %2146
+%2147 = OpLoad %uchar %747
+%2148 = OpLoad %uchar %739
+%2149 = OpIAdd %uchar %2147 %2148
+OpStore %748 %2149
+%2150 = OpLoad %_arr_uchar_uint_16 %746
+%2151 = OpLoad %uchar %748
+%2152 = OpCompositeInsert %_arr_uchar_uint_16 %2151 %2150 7
+OpStore %749 %2152
+%2153 = OpLoad %_arr_uchar_uint_16 %741
+%2154 = OpCompositeExtract %uchar %2153 3
+OpStore %750 %2154
+%2155 = OpLoad %uchar %750
+%2156 = OpLoad %uchar %739
+%2157 = OpIAdd %uchar %2155 %2156
+OpStore %751 %2157
+%2158 = OpLoad %_arr_uchar_uint_16 %741
+%2159 = OpLoad %uchar %751
+%2160 = OpCompositeInsert %_arr_uchar_uint_16 %2159 %2158 3
+OpStore %752 %2160
+%2161 = OpLoad %_arr_uchar_uint_16 %752
+%2162 = OpCompositeExtract %uchar %2161 12
+OpStore %753 %2162
+%2163 = OpLoad %uchar %753
+%2164 = OpLoad %uchar %739
+%2165 = OpIAdd %uchar %2163 %2164
+OpStore %754 %2165
+%2166 = OpLoad %_arr_uchar_uint_16 %752
+%2167 = OpLoad %uchar %754
+%2168 = OpCompositeInsert %_arr_uchar_uint_16 %2167 %2166 12
+OpStore %755 %2168
+%2170 = OpLoad %_arr_uchar_uint_16 %749
+%2171 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %2170
+OpStore %756 %2171
+%2172 = OpLoad %ulong %756
+%2173 = OpLoad %_arr_uchar_uint_16 %755
+%2174 = OpFunctionCall %ulong %1 %2172 %2173
+OpStore %757 %2174
+%2175 = OpLoad %_arr_uchar_uint_16 %749
+%2176 = OpCompositeExtract %uchar %2175 0
+OpStore %1184 %2176
+%2177 = OpLoad %_arr_uchar_uint_16 %755
+%2178 = OpCompositeExtract %uchar %2177 0
+OpStore %1185 %2178
+%2179 = OpLoad %uchar %1184
+%2180 = OpLoad %uchar %1185
+%2181 = OpIAdd %uchar %2179 %2180
+OpStore %1186 %2181
+%2182 = OpLoad %_arr_uchar_uint_16 %749
+%2183 = OpCompositeExtract %uchar %2182 1
+OpStore %1187 %2183
+%2184 = OpLoad %_arr_uchar_uint_16 %755
+%2185 = OpCompositeExtract %uchar %2184 1
+OpStore %1188 %2185
+%2186 = OpLoad %uchar %1187
+%2187 = OpLoad %uchar %1188
+%2188 = OpIAdd %uchar %2186 %2187
+OpStore %1189 %2188
+%2189 = OpLoad %_arr_uchar_uint_16 %749
+%2190 = OpCompositeExtract %uchar %2189 2
+OpStore %1190 %2190
+%2191 = OpLoad %_arr_uchar_uint_16 %755
+%2192 = OpCompositeExtract %uchar %2191 2
+OpStore %1191 %2192
+%2193 = OpLoad %uchar %1190
+%2194 = OpLoad %uchar %1191
+%2195 = OpIAdd %uchar %2193 %2194
+OpStore %1192 %2195
+%2196 = OpLoad %_arr_uchar_uint_16 %749
+%2197 = OpCompositeExtract %uchar %2196 3
+OpStore %1193 %2197
+%2198 = OpLoad %_arr_uchar_uint_16 %755
+%2199 = OpCompositeExtract %uchar %2198 3
+OpStore %1194 %2199
+%2200 = OpLoad %uchar %1193
+%2201 = OpLoad %uchar %1194
+%2202 = OpIAdd %uchar %2200 %2201
+OpStore %1195 %2202
+%2203 = OpLoad %_arr_uchar_uint_16 %749
+%2204 = OpCompositeExtract %uchar %2203 4
+OpStore %1196 %2204
+%2205 = OpLoad %_arr_uchar_uint_16 %755
+%2206 = OpCompositeExtract %uchar %2205 4
+OpStore %1197 %2206
+%2207 = OpLoad %uchar %1196
+%2208 = OpLoad %uchar %1197
+%2209 = OpIAdd %uchar %2207 %2208
+OpStore %1198 %2209
+%2210 = OpLoad %_arr_uchar_uint_16 %749
+%2211 = OpCompositeExtract %uchar %2210 5
+OpStore %1199 %2211
+%2212 = OpLoad %_arr_uchar_uint_16 %755
+%2213 = OpCompositeExtract %uchar %2212 5
+OpStore %1200 %2213
+%2214 = OpLoad %uchar %1199
+%2215 = OpLoad %uchar %1200
+%2216 = OpIAdd %uchar %2214 %2215
+OpStore %1201 %2216
+%2217 = OpLoad %_arr_uchar_uint_16 %749
+%2218 = OpCompositeExtract %uchar %2217 6
+OpStore %1202 %2218
+%2219 = OpLoad %_arr_uchar_uint_16 %755
+%2220 = OpCompositeExtract %uchar %2219 6
+OpStore %1203 %2220
+%2221 = OpLoad %uchar %1202
+%2222 = OpLoad %uchar %1203
+%2223 = OpIAdd %uchar %2221 %2222
+OpStore %1204 %2223
+%2224 = OpLoad %_arr_uchar_uint_16 %749
+%2225 = OpCompositeExtract %uchar %2224 7
+OpStore %1205 %2225
+%2226 = OpLoad %_arr_uchar_uint_16 %755
+%2227 = OpCompositeExtract %uchar %2226 7
+OpStore %1206 %2227
+%2228 = OpLoad %uchar %1205
+%2229 = OpLoad %uchar %1206
+%2230 = OpIAdd %uchar %2228 %2229
+OpStore %1207 %2230
+%2231 = OpLoad %_arr_uchar_uint_16 %749
+%2232 = OpCompositeExtract %uchar %2231 8
+OpStore %1208 %2232
+%2233 = OpLoad %_arr_uchar_uint_16 %755
+%2234 = OpCompositeExtract %uchar %2233 8
+OpStore %1209 %2234
+%2235 = OpLoad %uchar %1208
+%2236 = OpLoad %uchar %1209
+%2237 = OpIAdd %uchar %2235 %2236
+OpStore %1210 %2237
+%2238 = OpLoad %_arr_uchar_uint_16 %749
+%2239 = OpCompositeExtract %uchar %2238 9
+OpStore %1211 %2239
+%2240 = OpLoad %_arr_uchar_uint_16 %755
+%2241 = OpCompositeExtract %uchar %2240 9
+OpStore %1212 %2241
+%2242 = OpLoad %uchar %1211
+%2243 = OpLoad %uchar %1212
+%2244 = OpIAdd %uchar %2242 %2243
+OpStore %1213 %2244
+%2245 = OpLoad %_arr_uchar_uint_16 %749
+%2246 = OpCompositeExtract %uchar %2245 10
+OpStore %1214 %2246
+%2247 = OpLoad %_arr_uchar_uint_16 %755
+%2248 = OpCompositeExtract %uchar %2247 10
+OpStore %1215 %2248
+%2249 = OpLoad %uchar %1214
+%2250 = OpLoad %uchar %1215
+%2251 = OpIAdd %uchar %2249 %2250
+OpStore %1216 %2251
+%2252 = OpLoad %_arr_uchar_uint_16 %749
+%2253 = OpCompositeExtract %uchar %2252 11
+OpStore %1217 %2253
+%2254 = OpLoad %_arr_uchar_uint_16 %755
+%2255 = OpCompositeExtract %uchar %2254 11
+OpStore %1218 %2255
+%2256 = OpLoad %uchar %1217
+%2257 = OpLoad %uchar %1218
+%2258 = OpIAdd %uchar %2256 %2257
+OpStore %1219 %2258
+%2259 = OpLoad %_arr_uchar_uint_16 %749
+%2260 = OpCompositeExtract %uchar %2259 12
+OpStore %1220 %2260
+%2261 = OpLoad %_arr_uchar_uint_16 %755
+%2262 = OpCompositeExtract %uchar %2261 12
+OpStore %1221 %2262
+%2263 = OpLoad %uchar %1220
+%2264 = OpLoad %uchar %1221
+%2265 = OpIAdd %uchar %2263 %2264
+OpStore %1222 %2265
+%2266 = OpLoad %_arr_uchar_uint_16 %749
+%2267 = OpCompositeExtract %uchar %2266 13
+OpStore %1223 %2267
+%2268 = OpLoad %_arr_uchar_uint_16 %755
+%2269 = OpCompositeExtract %uchar %2268 13
+OpStore %1224 %2269
+%2270 = OpLoad %uchar %1223
+%2271 = OpLoad %uchar %1224
+%2272 = OpIAdd %uchar %2270 %2271
+OpStore %1225 %2272
+%2273 = OpLoad %_arr_uchar_uint_16 %749
+%2274 = OpCompositeExtract %uchar %2273 14
+OpStore %1226 %2274
+%2275 = OpLoad %_arr_uchar_uint_16 %755
+%2276 = OpCompositeExtract %uchar %2275 14
+OpStore %1227 %2276
+%2277 = OpLoad %uchar %1226
+%2278 = OpLoad %uchar %1227
+%2279 = OpIAdd %uchar %2277 %2278
+OpStore %1228 %2279
+%2280 = OpLoad %_arr_uchar_uint_16 %749
+%2281 = OpCompositeExtract %uchar %2280 15
+OpStore %1229 %2281
+%2282 = OpLoad %_arr_uchar_uint_16 %755
+%2283 = OpCompositeExtract %uchar %2282 15
+OpStore %1230 %2283
+%2284 = OpLoad %uchar %1229
+%2285 = OpLoad %uchar %1230
+%2286 = OpIAdd %uchar %2284 %2285
+OpStore %1231 %2286
+%2287 = OpLoad %_arr_uchar_uint_16 %749
+%2288 = OpLoad %uchar %1186
+%2289 = OpCompositeInsert %_arr_uchar_uint_16 %2288 %2287 0
+OpStore %1232 %2289
+%2290 = OpLoad %_arr_uchar_uint_16 %1232
+%2291 = OpLoad %uchar %1189
+%2292 = OpCompositeInsert %_arr_uchar_uint_16 %2291 %2290 1
+OpStore %1233 %2292
+%2293 = OpLoad %_arr_uchar_uint_16 %1233
+%2294 = OpLoad %uchar %1192
+%2295 = OpCompositeInsert %_arr_uchar_uint_16 %2294 %2293 2
+OpStore %1234 %2295
+%2296 = OpLoad %_arr_uchar_uint_16 %1234
+%2297 = OpLoad %uchar %1195
+%2298 = OpCompositeInsert %_arr_uchar_uint_16 %2297 %2296 3
+OpStore %1235 %2298
+%2299 = OpLoad %_arr_uchar_uint_16 %1235
+%2300 = OpLoad %uchar %1198
+%2301 = OpCompositeInsert %_arr_uchar_uint_16 %2300 %2299 4
+OpStore %1236 %2301
+%2302 = OpLoad %_arr_uchar_uint_16 %1236
+%2303 = OpLoad %uchar %1201
+%2304 = OpCompositeInsert %_arr_uchar_uint_16 %2303 %2302 5
+OpStore %1237 %2304
+%2305 = OpLoad %_arr_uchar_uint_16 %1237
+%2306 = OpLoad %uchar %1204
+%2307 = OpCompositeInsert %_arr_uchar_uint_16 %2306 %2305 6
+OpStore %1238 %2307
+%2308 = OpLoad %_arr_uchar_uint_16 %1238
+%2309 = OpLoad %uchar %1207
+%2310 = OpCompositeInsert %_arr_uchar_uint_16 %2309 %2308 7
+OpStore %1239 %2310
+%2311 = OpLoad %_arr_uchar_uint_16 %1239
+%2312 = OpLoad %uchar %1210
+%2313 = OpCompositeInsert %_arr_uchar_uint_16 %2312 %2311 8
+OpStore %1240 %2313
+%2314 = OpLoad %_arr_uchar_uint_16 %1240
+%2315 = OpLoad %uchar %1213
+%2316 = OpCompositeInsert %_arr_uchar_uint_16 %2315 %2314 9
+OpStore %1241 %2316
+%2317 = OpLoad %_arr_uchar_uint_16 %1241
+%2318 = OpLoad %uchar %1216
+%2319 = OpCompositeInsert %_arr_uchar_uint_16 %2318 %2317 10
+OpStore %1242 %2319
+%2320 = OpLoad %_arr_uchar_uint_16 %1242
+%2321 = OpLoad %uchar %1219
+%2322 = OpCompositeInsert %_arr_uchar_uint_16 %2321 %2320 11
+OpStore %1243 %2322
+%2323 = OpLoad %_arr_uchar_uint_16 %1243
+%2324 = OpLoad %uchar %1222
+%2325 = OpCompositeInsert %_arr_uchar_uint_16 %2324 %2323 12
+OpStore %1244 %2325
+%2326 = OpLoad %_arr_uchar_uint_16 %1244
+%2327 = OpLoad %uchar %1225
+%2328 = OpCompositeInsert %_arr_uchar_uint_16 %2327 %2326 13
+OpStore %1245 %2328
+%2329 = OpLoad %_arr_uchar_uint_16 %1245
+%2330 = OpLoad %uchar %1228
+%2331 = OpCompositeInsert %_arr_uchar_uint_16 %2330 %2329 14
+OpStore %1246 %2331
+%2332 = OpLoad %_arr_uchar_uint_16 %1246
+%2333 = OpLoad %uchar %1231
+%2334 = OpCompositeInsert %_arr_uchar_uint_16 %2333 %2332 15
+OpStore %1247 %2334
+%2335 = OpLoad %ulong %757
+%2336 = OpLoad %_arr_uchar_uint_16 %1247
+%2337 = OpFunctionCall %ulong %1 %2335 %2336
+OpStore %758 %2337
+%2338 = OpLoad %_arr_uchar_uint_16 %749
+%2339 = OpCompositeExtract %uchar %2338 0
+OpStore %1248 %2339
+%2340 = OpLoad %_arr_uchar_uint_16 %755
+%2341 = OpCompositeExtract %uchar %2340 0
+OpStore %1249 %2341
+%2342 = OpLoad %uchar %1248
+%2343 = OpLoad %uchar %1249
+%2344 = OpISub %uchar %2342 %2343
+OpStore %1250 %2344
+%2345 = OpLoad %_arr_uchar_uint_16 %749
+%2346 = OpCompositeExtract %uchar %2345 1
+OpStore %1251 %2346
+%2347 = OpLoad %_arr_uchar_uint_16 %755
+%2348 = OpCompositeExtract %uchar %2347 1
+OpStore %1252 %2348
+%2349 = OpLoad %uchar %1251
+%2350 = OpLoad %uchar %1252
+%2351 = OpISub %uchar %2349 %2350
+OpStore %1253 %2351
+%2352 = OpLoad %_arr_uchar_uint_16 %749
+%2353 = OpCompositeExtract %uchar %2352 2
+OpStore %1254 %2353
+%2354 = OpLoad %_arr_uchar_uint_16 %755
+%2355 = OpCompositeExtract %uchar %2354 2
+OpStore %1255 %2355
+%2356 = OpLoad %uchar %1254
+%2357 = OpLoad %uchar %1255
+%2358 = OpISub %uchar %2356 %2357
+OpStore %1256 %2358
+%2359 = OpLoad %_arr_uchar_uint_16 %749
+%2360 = OpCompositeExtract %uchar %2359 3
+OpStore %1257 %2360
+%2361 = OpLoad %_arr_uchar_uint_16 %755
+%2362 = OpCompositeExtract %uchar %2361 3
+OpStore %1258 %2362
+%2363 = OpLoad %uchar %1257
+%2364 = OpLoad %uchar %1258
+%2365 = OpISub %uchar %2363 %2364
+OpStore %1259 %2365
+%2366 = OpLoad %_arr_uchar_uint_16 %749
+%2367 = OpCompositeExtract %uchar %2366 4
+OpStore %1260 %2367
+%2368 = OpLoad %_arr_uchar_uint_16 %755
+%2369 = OpCompositeExtract %uchar %2368 4
+OpStore %1261 %2369
+%2370 = OpLoad %uchar %1260
+%2371 = OpLoad %uchar %1261
+%2372 = OpISub %uchar %2370 %2371
+OpStore %1262 %2372
+%2373 = OpLoad %_arr_uchar_uint_16 %749
+%2374 = OpCompositeExtract %uchar %2373 5
+OpStore %1263 %2374
+%2375 = OpLoad %_arr_uchar_uint_16 %755
+%2376 = OpCompositeExtract %uchar %2375 5
+OpStore %1264 %2376
+%2377 = OpLoad %uchar %1263
+%2378 = OpLoad %uchar %1264
+%2379 = OpISub %uchar %2377 %2378
+OpStore %1265 %2379
+%2380 = OpLoad %_arr_uchar_uint_16 %749
+%2381 = OpCompositeExtract %uchar %2380 6
+OpStore %1266 %2381
+%2382 = OpLoad %_arr_uchar_uint_16 %755
+%2383 = OpCompositeExtract %uchar %2382 6
+OpStore %1267 %2383
+%2384 = OpLoad %uchar %1266
+%2385 = OpLoad %uchar %1267
+%2386 = OpISub %uchar %2384 %2385
+OpStore %1268 %2386
+%2387 = OpLoad %_arr_uchar_uint_16 %749
+%2388 = OpCompositeExtract %uchar %2387 7
+OpStore %1269 %2388
+%2389 = OpLoad %_arr_uchar_uint_16 %755
+%2390 = OpCompositeExtract %uchar %2389 7
+OpStore %1270 %2390
+%2391 = OpLoad %uchar %1269
+%2392 = OpLoad %uchar %1270
+%2393 = OpISub %uchar %2391 %2392
+OpStore %1271 %2393
+%2394 = OpLoad %_arr_uchar_uint_16 %749
+%2395 = OpCompositeExtract %uchar %2394 8
+OpStore %1272 %2395
+%2396 = OpLoad %_arr_uchar_uint_16 %755
+%2397 = OpCompositeExtract %uchar %2396 8
+OpStore %1273 %2397
+%2398 = OpLoad %uchar %1272
+%2399 = OpLoad %uchar %1273
+%2400 = OpISub %uchar %2398 %2399
+OpStore %1274 %2400
+%2401 = OpLoad %_arr_uchar_uint_16 %749
+%2402 = OpCompositeExtract %uchar %2401 9
+OpStore %1275 %2402
+%2403 = OpLoad %_arr_uchar_uint_16 %755
+%2404 = OpCompositeExtract %uchar %2403 9
+OpStore %1276 %2404
+%2405 = OpLoad %uchar %1275
+%2406 = OpLoad %uchar %1276
+%2407 = OpISub %uchar %2405 %2406
+OpStore %1277 %2407
+%2408 = OpLoad %_arr_uchar_uint_16 %749
+%2409 = OpCompositeExtract %uchar %2408 10
+OpStore %1278 %2409
+%2410 = OpLoad %_arr_uchar_uint_16 %755
+%2411 = OpCompositeExtract %uchar %2410 10
+OpStore %1279 %2411
+%2412 = OpLoad %uchar %1278
+%2413 = OpLoad %uchar %1279
+%2414 = OpISub %uchar %2412 %2413
+OpStore %1280 %2414
+%2415 = OpLoad %_arr_uchar_uint_16 %749
+%2416 = OpCompositeExtract %uchar %2415 11
+OpStore %1281 %2416
+%2417 = OpLoad %_arr_uchar_uint_16 %755
+%2418 = OpCompositeExtract %uchar %2417 11
+OpStore %1282 %2418
+%2419 = OpLoad %uchar %1281
+%2420 = OpLoad %uchar %1282
+%2421 = OpISub %uchar %2419 %2420
+OpStore %1283 %2421
+%2422 = OpLoad %_arr_uchar_uint_16 %749
+%2423 = OpCompositeExtract %uchar %2422 12
+OpStore %1284 %2423
+%2424 = OpLoad %_arr_uchar_uint_16 %755
+%2425 = OpCompositeExtract %uchar %2424 12
+OpStore %1285 %2425
+%2426 = OpLoad %uchar %1284
+%2427 = OpLoad %uchar %1285
+%2428 = OpISub %uchar %2426 %2427
+OpStore %1286 %2428
+%2429 = OpLoad %_arr_uchar_uint_16 %749
+%2430 = OpCompositeExtract %uchar %2429 13
+OpStore %1287 %2430
+%2431 = OpLoad %_arr_uchar_uint_16 %755
+%2432 = OpCompositeExtract %uchar %2431 13
+OpStore %1288 %2432
+%2433 = OpLoad %uchar %1287
+%2434 = OpLoad %uchar %1288
+%2435 = OpISub %uchar %2433 %2434
+OpStore %1289 %2435
+%2436 = OpLoad %_arr_uchar_uint_16 %749
+%2437 = OpCompositeExtract %uchar %2436 14
+OpStore %1290 %2437
+%2438 = OpLoad %_arr_uchar_uint_16 %755
+%2439 = OpCompositeExtract %uchar %2438 14
+OpStore %1291 %2439
+%2440 = OpLoad %uchar %1290
+%2441 = OpLoad %uchar %1291
+%2442 = OpISub %uchar %2440 %2441
+OpStore %1292 %2442
+%2443 = OpLoad %_arr_uchar_uint_16 %749
+%2444 = OpCompositeExtract %uchar %2443 15
+OpStore %1293 %2444
+%2445 = OpLoad %_arr_uchar_uint_16 %755
+%2446 = OpCompositeExtract %uchar %2445 15
+OpStore %1294 %2446
+%2447 = OpLoad %uchar %1293
+%2448 = OpLoad %uchar %1294
+%2449 = OpISub %uchar %2447 %2448
+OpStore %1295 %2449
+%2450 = OpLoad %_arr_uchar_uint_16 %749
+%2451 = OpLoad %uchar %1250
+%2452 = OpCompositeInsert %_arr_uchar_uint_16 %2451 %2450 0
+OpStore %1296 %2452
+%2453 = OpLoad %_arr_uchar_uint_16 %1296
+%2454 = OpLoad %uchar %1253
+%2455 = OpCompositeInsert %_arr_uchar_uint_16 %2454 %2453 1
+OpStore %1297 %2455
+%2456 = OpLoad %_arr_uchar_uint_16 %1297
+%2457 = OpLoad %uchar %1256
+%2458 = OpCompositeInsert %_arr_uchar_uint_16 %2457 %2456 2
+OpStore %1298 %2458
+%2459 = OpLoad %_arr_uchar_uint_16 %1298
+%2460 = OpLoad %uchar %1259
+%2461 = OpCompositeInsert %_arr_uchar_uint_16 %2460 %2459 3
+OpStore %1299 %2461
+%2462 = OpLoad %_arr_uchar_uint_16 %1299
+%2463 = OpLoad %uchar %1262
+%2464 = OpCompositeInsert %_arr_uchar_uint_16 %2463 %2462 4
+OpStore %1300 %2464
+%2465 = OpLoad %_arr_uchar_uint_16 %1300
+%2466 = OpLoad %uchar %1265
+%2467 = OpCompositeInsert %_arr_uchar_uint_16 %2466 %2465 5
+OpStore %1301 %2467
+%2468 = OpLoad %_arr_uchar_uint_16 %1301
+%2469 = OpLoad %uchar %1268
+%2470 = OpCompositeInsert %_arr_uchar_uint_16 %2469 %2468 6
+OpStore %1302 %2470
+%2471 = OpLoad %_arr_uchar_uint_16 %1302
+%2472 = OpLoad %uchar %1271
+%2473 = OpCompositeInsert %_arr_uchar_uint_16 %2472 %2471 7
+OpStore %1303 %2473
+%2474 = OpLoad %_arr_uchar_uint_16 %1303
+%2475 = OpLoad %uchar %1274
+%2476 = OpCompositeInsert %_arr_uchar_uint_16 %2475 %2474 8
+OpStore %1304 %2476
+%2477 = OpLoad %_arr_uchar_uint_16 %1304
+%2478 = OpLoad %uchar %1277
+%2479 = OpCompositeInsert %_arr_uchar_uint_16 %2478 %2477 9
+OpStore %1305 %2479
+%2480 = OpLoad %_arr_uchar_uint_16 %1305
+%2481 = OpLoad %uchar %1280
+%2482 = OpCompositeInsert %_arr_uchar_uint_16 %2481 %2480 10
+OpStore %1306 %2482
+%2483 = OpLoad %_arr_uchar_uint_16 %1306
+%2484 = OpLoad %uchar %1283
+%2485 = OpCompositeInsert %_arr_uchar_uint_16 %2484 %2483 11
+OpStore %1307 %2485
+%2486 = OpLoad %_arr_uchar_uint_16 %1307
+%2487 = OpLoad %uchar %1286
+%2488 = OpCompositeInsert %_arr_uchar_uint_16 %2487 %2486 12
+OpStore %1308 %2488
+%2489 = OpLoad %_arr_uchar_uint_16 %1308
+%2490 = OpLoad %uchar %1289
+%2491 = OpCompositeInsert %_arr_uchar_uint_16 %2490 %2489 13
+OpStore %1309 %2491
+%2492 = OpLoad %_arr_uchar_uint_16 %1309
+%2493 = OpLoad %uchar %1292
+%2494 = OpCompositeInsert %_arr_uchar_uint_16 %2493 %2492 14
+OpStore %1310 %2494
+%2495 = OpLoad %_arr_uchar_uint_16 %1310
+%2496 = OpLoad %uchar %1295
+%2497 = OpCompositeInsert %_arr_uchar_uint_16 %2496 %2495 15
+OpStore %1311 %2497
+%2498 = OpLoad %ulong %758
+%2499 = OpLoad %_arr_uchar_uint_16 %1311
+%2500 = OpFunctionCall %ulong %1 %2498 %2499
+OpStore %759 %2500
+%2501 = OpLoad %_arr_uchar_uint_16 %755
+%2502 = OpCompositeExtract %uchar %2501 0
+OpStore %1312 %2502
+%2503 = OpLoad %_arr_uchar_uint_16 %749
+%2504 = OpCompositeExtract %uchar %2503 0
+OpStore %1313 %2504
+%2505 = OpLoad %uchar %1312
+%2506 = OpLoad %uchar %1313
+%2507 = OpISub %uchar %2505 %2506
+OpStore %1314 %2507
+%2508 = OpLoad %_arr_uchar_uint_16 %755
+%2509 = OpCompositeExtract %uchar %2508 1
+OpStore %1315 %2509
+%2510 = OpLoad %_arr_uchar_uint_16 %749
+%2511 = OpCompositeExtract %uchar %2510 1
+OpStore %1316 %2511
+%2512 = OpLoad %uchar %1315
+%2513 = OpLoad %uchar %1316
+%2514 = OpISub %uchar %2512 %2513
+OpStore %1317 %2514
+%2515 = OpLoad %_arr_uchar_uint_16 %755
+%2516 = OpCompositeExtract %uchar %2515 2
+OpStore %1318 %2516
+%2517 = OpLoad %_arr_uchar_uint_16 %749
+%2518 = OpCompositeExtract %uchar %2517 2
+OpStore %1319 %2518
+%2519 = OpLoad %uchar %1318
+%2520 = OpLoad %uchar %1319
+%2521 = OpISub %uchar %2519 %2520
+OpStore %1320 %2521
+%2522 = OpLoad %_arr_uchar_uint_16 %755
+%2523 = OpCompositeExtract %uchar %2522 3
+OpStore %1321 %2523
+%2524 = OpLoad %_arr_uchar_uint_16 %749
+%2525 = OpCompositeExtract %uchar %2524 3
+OpStore %1322 %2525
+%2526 = OpLoad %uchar %1321
+%2527 = OpLoad %uchar %1322
+%2528 = OpISub %uchar %2526 %2527
+OpStore %1323 %2528
+%2529 = OpLoad %_arr_uchar_uint_16 %755
+%2530 = OpCompositeExtract %uchar %2529 4
+OpStore %1324 %2530
+%2531 = OpLoad %_arr_uchar_uint_16 %749
+%2532 = OpCompositeExtract %uchar %2531 4
+OpStore %1325 %2532
+%2533 = OpLoad %uchar %1324
+%2534 = OpLoad %uchar %1325
+%2535 = OpISub %uchar %2533 %2534
+OpStore %1326 %2535
+%2536 = OpLoad %_arr_uchar_uint_16 %755
+%2537 = OpCompositeExtract %uchar %2536 5
+OpStore %1327 %2537
+%2538 = OpLoad %_arr_uchar_uint_16 %749
+%2539 = OpCompositeExtract %uchar %2538 5
+OpStore %1328 %2539
+%2540 = OpLoad %uchar %1327
+%2541 = OpLoad %uchar %1328
+%2542 = OpISub %uchar %2540 %2541
+OpStore %1329 %2542
+%2543 = OpLoad %_arr_uchar_uint_16 %755
+%2544 = OpCompositeExtract %uchar %2543 6
+OpStore %1330 %2544
+%2545 = OpLoad %_arr_uchar_uint_16 %749
+%2546 = OpCompositeExtract %uchar %2545 6
+OpStore %1331 %2546
+%2547 = OpLoad %uchar %1330
+%2548 = OpLoad %uchar %1331
+%2549 = OpISub %uchar %2547 %2548
+OpStore %1332 %2549
+%2550 = OpLoad %_arr_uchar_uint_16 %755
+%2551 = OpCompositeExtract %uchar %2550 7
+OpStore %1333 %2551
+%2552 = OpLoad %_arr_uchar_uint_16 %749
+%2553 = OpCompositeExtract %uchar %2552 7
+OpStore %1334 %2553
+%2554 = OpLoad %uchar %1333
+%2555 = OpLoad %uchar %1334
+%2556 = OpISub %uchar %2554 %2555
+OpStore %1335 %2556
+%2557 = OpLoad %_arr_uchar_uint_16 %755
+%2558 = OpCompositeExtract %uchar %2557 8
+OpStore %1336 %2558
+%2559 = OpLoad %_arr_uchar_uint_16 %749
+%2560 = OpCompositeExtract %uchar %2559 8
+OpStore %1337 %2560
+%2561 = OpLoad %uchar %1336
+%2562 = OpLoad %uchar %1337
+%2563 = OpISub %uchar %2561 %2562
+OpStore %1338 %2563
+%2564 = OpLoad %_arr_uchar_uint_16 %755
+%2565 = OpCompositeExtract %uchar %2564 9
+OpStore %1339 %2565
+%2566 = OpLoad %_arr_uchar_uint_16 %749
+%2567 = OpCompositeExtract %uchar %2566 9
+OpStore %1340 %2567
+%2568 = OpLoad %uchar %1339
+%2569 = OpLoad %uchar %1340
+%2570 = OpISub %uchar %2568 %2569
+OpStore %1341 %2570
+%2571 = OpLoad %_arr_uchar_uint_16 %755
+%2572 = OpCompositeExtract %uchar %2571 10
+OpStore %1342 %2572
+%2573 = OpLoad %_arr_uchar_uint_16 %749
+%2574 = OpCompositeExtract %uchar %2573 10
+OpStore %1343 %2574
+%2575 = OpLoad %uchar %1342
+%2576 = OpLoad %uchar %1343
+%2577 = OpISub %uchar %2575 %2576
+OpStore %1344 %2577
+%2578 = OpLoad %_arr_uchar_uint_16 %755
+%2579 = OpCompositeExtract %uchar %2578 11
+OpStore %1345 %2579
+%2580 = OpLoad %_arr_uchar_uint_16 %749
+%2581 = OpCompositeExtract %uchar %2580 11
+OpStore %1346 %2581
+%2582 = OpLoad %uchar %1345
+%2583 = OpLoad %uchar %1346
+%2584 = OpISub %uchar %2582 %2583
+OpStore %1347 %2584
+%2585 = OpLoad %_arr_uchar_uint_16 %755
+%2586 = OpCompositeExtract %uchar %2585 12
+OpStore %1348 %2586
+%2587 = OpLoad %_arr_uchar_uint_16 %749
+%2588 = OpCompositeExtract %uchar %2587 12
+OpStore %1349 %2588
+%2589 = OpLoad %uchar %1348
+%2590 = OpLoad %uchar %1349
+%2591 = OpISub %uchar %2589 %2590
+OpStore %1350 %2591
+%2592 = OpLoad %_arr_uchar_uint_16 %755
+%2593 = OpCompositeExtract %uchar %2592 13
+OpStore %1351 %2593
+%2594 = OpLoad %_arr_uchar_uint_16 %749
+%2595 = OpCompositeExtract %uchar %2594 13
+OpStore %1352 %2595
+%2596 = OpLoad %uchar %1351
+%2597 = OpLoad %uchar %1352
+%2598 = OpISub %uchar %2596 %2597
+OpStore %1353 %2598
+%2599 = OpLoad %_arr_uchar_uint_16 %755
+%2600 = OpCompositeExtract %uchar %2599 14
+OpStore %1354 %2600
+%2601 = OpLoad %_arr_uchar_uint_16 %749
+%2602 = OpCompositeExtract %uchar %2601 14
+OpStore %1355 %2602
+%2603 = OpLoad %uchar %1354
+%2604 = OpLoad %uchar %1355
+%2605 = OpISub %uchar %2603 %2604
+OpStore %1356 %2605
+%2606 = OpLoad %_arr_uchar_uint_16 %755
+%2607 = OpCompositeExtract %uchar %2606 15
+OpStore %1357 %2607
+%2608 = OpLoad %_arr_uchar_uint_16 %749
+%2609 = OpCompositeExtract %uchar %2608 15
+OpStore %1358 %2609
+%2610 = OpLoad %uchar %1357
+%2611 = OpLoad %uchar %1358
+%2612 = OpISub %uchar %2610 %2611
+OpStore %1359 %2612
+%2613 = OpLoad %_arr_uchar_uint_16 %755
+%2614 = OpLoad %uchar %1314
+%2615 = OpCompositeInsert %_arr_uchar_uint_16 %2614 %2613 0
+OpStore %1360 %2615
+%2616 = OpLoad %_arr_uchar_uint_16 %1360
+%2617 = OpLoad %uchar %1317
+%2618 = OpCompositeInsert %_arr_uchar_uint_16 %2617 %2616 1
+OpStore %1361 %2618
+%2619 = OpLoad %_arr_uchar_uint_16 %1361
+%2620 = OpLoad %uchar %1320
+%2621 = OpCompositeInsert %_arr_uchar_uint_16 %2620 %2619 2
+OpStore %1362 %2621
+%2622 = OpLoad %_arr_uchar_uint_16 %1362
+%2623 = OpLoad %uchar %1323
+%2624 = OpCompositeInsert %_arr_uchar_uint_16 %2623 %2622 3
+OpStore %1363 %2624
+%2625 = OpLoad %_arr_uchar_uint_16 %1363
+%2626 = OpLoad %uchar %1326
+%2627 = OpCompositeInsert %_arr_uchar_uint_16 %2626 %2625 4
+OpStore %1364 %2627
+%2628 = OpLoad %_arr_uchar_uint_16 %1364
+%2629 = OpLoad %uchar %1329
+%2630 = OpCompositeInsert %_arr_uchar_uint_16 %2629 %2628 5
+OpStore %1365 %2630
+%2631 = OpLoad %_arr_uchar_uint_16 %1365
+%2632 = OpLoad %uchar %1332
+%2633 = OpCompositeInsert %_arr_uchar_uint_16 %2632 %2631 6
+OpStore %1366 %2633
+%2634 = OpLoad %_arr_uchar_uint_16 %1366
+%2635 = OpLoad %uchar %1335
+%2636 = OpCompositeInsert %_arr_uchar_uint_16 %2635 %2634 7
+OpStore %1367 %2636
+%2637 = OpLoad %_arr_uchar_uint_16 %1367
+%2638 = OpLoad %uchar %1338
+%2639 = OpCompositeInsert %_arr_uchar_uint_16 %2638 %2637 8
+OpStore %1368 %2639
+%2640 = OpLoad %_arr_uchar_uint_16 %1368
+%2641 = OpLoad %uchar %1341
+%2642 = OpCompositeInsert %_arr_uchar_uint_16 %2641 %2640 9
+OpStore %1369 %2642
+%2643 = OpLoad %_arr_uchar_uint_16 %1369
+%2644 = OpLoad %uchar %1344
+%2645 = OpCompositeInsert %_arr_uchar_uint_16 %2644 %2643 10
+OpStore %1370 %2645
+%2646 = OpLoad %_arr_uchar_uint_16 %1370
+%2647 = OpLoad %uchar %1347
+%2648 = OpCompositeInsert %_arr_uchar_uint_16 %2647 %2646 11
+OpStore %1371 %2648
+%2649 = OpLoad %_arr_uchar_uint_16 %1371
+%2650 = OpLoad %uchar %1350
+%2651 = OpCompositeInsert %_arr_uchar_uint_16 %2650 %2649 12
+OpStore %1372 %2651
+%2652 = OpLoad %_arr_uchar_uint_16 %1372
+%2653 = OpLoad %uchar %1353
+%2654 = OpCompositeInsert %_arr_uchar_uint_16 %2653 %2652 13
+OpStore %1373 %2654
+%2655 = OpLoad %_arr_uchar_uint_16 %1373
+%2656 = OpLoad %uchar %1356
+%2657 = OpCompositeInsert %_arr_uchar_uint_16 %2656 %2655 14
+OpStore %1374 %2657
+%2658 = OpLoad %_arr_uchar_uint_16 %1374
+%2659 = OpLoad %uchar %1359
+%2660 = OpCompositeInsert %_arr_uchar_uint_16 %2659 %2658 15
+OpStore %1375 %2660
+%2661 = OpLoad %ulong %759
+%2662 = OpLoad %_arr_uchar_uint_16 %1375
+%2663 = OpFunctionCall %ulong %1 %2661 %2662
+OpStore %760 %2663
+%2664 = OpLoad %_arr_uchar_uint_16 %749
+%2665 = OpCompositeExtract %uchar %2664 0
+OpStore %1376 %2665
+%2666 = OpLoad %_arr_uchar_uint_16 %755
+%2667 = OpCompositeExtract %uchar %2666 0
+OpStore %1377 %2667
+%2668 = OpLoad %uchar %1376
+%2669 = OpLoad %uchar %1377
+%2670 = OpIMul %uchar %2668 %2669
+OpStore %1378 %2670
+%2671 = OpLoad %_arr_uchar_uint_16 %749
+%2672 = OpCompositeExtract %uchar %2671 1
+OpStore %1379 %2672
+%2673 = OpLoad %_arr_uchar_uint_16 %755
+%2674 = OpCompositeExtract %uchar %2673 1
+OpStore %1380 %2674
+%2675 = OpLoad %uchar %1379
+%2676 = OpLoad %uchar %1380
+%2677 = OpIMul %uchar %2675 %2676
+OpStore %1381 %2677
+%2678 = OpLoad %_arr_uchar_uint_16 %749
+%2679 = OpCompositeExtract %uchar %2678 2
+OpStore %1382 %2679
+%2680 = OpLoad %_arr_uchar_uint_16 %755
+%2681 = OpCompositeExtract %uchar %2680 2
+OpStore %1383 %2681
+%2682 = OpLoad %uchar %1382
+%2683 = OpLoad %uchar %1383
+%2684 = OpIMul %uchar %2682 %2683
+OpStore %1384 %2684
+%2685 = OpLoad %_arr_uchar_uint_16 %749
+%2686 = OpCompositeExtract %uchar %2685 3
+OpStore %1385 %2686
+%2687 = OpLoad %_arr_uchar_uint_16 %755
+%2688 = OpCompositeExtract %uchar %2687 3
+OpStore %1386 %2688
+%2689 = OpLoad %uchar %1385
+%2690 = OpLoad %uchar %1386
+%2691 = OpIMul %uchar %2689 %2690
+OpStore %1387 %2691
+%2692 = OpLoad %_arr_uchar_uint_16 %749
+%2693 = OpCompositeExtract %uchar %2692 4
+OpStore %1388 %2693
+%2694 = OpLoad %_arr_uchar_uint_16 %755
+%2695 = OpCompositeExtract %uchar %2694 4
+OpStore %1389 %2695
+%2696 = OpLoad %uchar %1388
+%2697 = OpLoad %uchar %1389
+%2698 = OpIMul %uchar %2696 %2697
+OpStore %1390 %2698
+%2699 = OpLoad %_arr_uchar_uint_16 %749
+%2700 = OpCompositeExtract %uchar %2699 5
+OpStore %1391 %2700
+%2701 = OpLoad %_arr_uchar_uint_16 %755
+%2702 = OpCompositeExtract %uchar %2701 5
+OpStore %1392 %2702
+%2703 = OpLoad %uchar %1391
+%2704 = OpLoad %uchar %1392
+%2705 = OpIMul %uchar %2703 %2704
+OpStore %1393 %2705
+%2706 = OpLoad %_arr_uchar_uint_16 %749
+%2707 = OpCompositeExtract %uchar %2706 6
+OpStore %1394 %2707
+%2708 = OpLoad %_arr_uchar_uint_16 %755
+%2709 = OpCompositeExtract %uchar %2708 6
+OpStore %1395 %2709
+%2710 = OpLoad %uchar %1394
+%2711 = OpLoad %uchar %1395
+%2712 = OpIMul %uchar %2710 %2711
+OpStore %1396 %2712
+%2713 = OpLoad %_arr_uchar_uint_16 %749
+%2714 = OpCompositeExtract %uchar %2713 7
+OpStore %1397 %2714
+%2715 = OpLoad %_arr_uchar_uint_16 %755
+%2716 = OpCompositeExtract %uchar %2715 7
+OpStore %1398 %2716
+%2717 = OpLoad %uchar %1397
+%2718 = OpLoad %uchar %1398
+%2719 = OpIMul %uchar %2717 %2718
+OpStore %1399 %2719
+%2720 = OpLoad %_arr_uchar_uint_16 %749
+%2721 = OpCompositeExtract %uchar %2720 8
+OpStore %1400 %2721
+%2722 = OpLoad %_arr_uchar_uint_16 %755
+%2723 = OpCompositeExtract %uchar %2722 8
+OpStore %1401 %2723
+%2724 = OpLoad %uchar %1400
+%2725 = OpLoad %uchar %1401
+%2726 = OpIMul %uchar %2724 %2725
+OpStore %1402 %2726
+%2727 = OpLoad %_arr_uchar_uint_16 %749
+%2728 = OpCompositeExtract %uchar %2727 9
+OpStore %1403 %2728
+%2729 = OpLoad %_arr_uchar_uint_16 %755
+%2730 = OpCompositeExtract %uchar %2729 9
+OpStore %1404 %2730
+%2731 = OpLoad %uchar %1403
+%2732 = OpLoad %uchar %1404
+%2733 = OpIMul %uchar %2731 %2732
+OpStore %1405 %2733
+%2734 = OpLoad %_arr_uchar_uint_16 %749
+%2735 = OpCompositeExtract %uchar %2734 10
+OpStore %1406 %2735
+%2736 = OpLoad %_arr_uchar_uint_16 %755
+%2737 = OpCompositeExtract %uchar %2736 10
+OpStore %1407 %2737
+%2738 = OpLoad %uchar %1406
+%2739 = OpLoad %uchar %1407
+%2740 = OpIMul %uchar %2738 %2739
+OpStore %1408 %2740
+%2741 = OpLoad %_arr_uchar_uint_16 %749
+%2742 = OpCompositeExtract %uchar %2741 11
+OpStore %1409 %2742
+%2743 = OpLoad %_arr_uchar_uint_16 %755
+%2744 = OpCompositeExtract %uchar %2743 11
+OpStore %1410 %2744
+%2745 = OpLoad %uchar %1409
+%2746 = OpLoad %uchar %1410
+%2747 = OpIMul %uchar %2745 %2746
+OpStore %1411 %2747
+%2748 = OpLoad %_arr_uchar_uint_16 %749
+%2749 = OpCompositeExtract %uchar %2748 12
+OpStore %1412 %2749
+%2750 = OpLoad %_arr_uchar_uint_16 %755
+%2751 = OpCompositeExtract %uchar %2750 12
+OpStore %1413 %2751
+%2752 = OpLoad %uchar %1412
+%2753 = OpLoad %uchar %1413
+%2754 = OpIMul %uchar %2752 %2753
+OpStore %1414 %2754
+%2755 = OpLoad %_arr_uchar_uint_16 %749
+%2756 = OpCompositeExtract %uchar %2755 13
+OpStore %1415 %2756
+%2757 = OpLoad %_arr_uchar_uint_16 %755
+%2758 = OpCompositeExtract %uchar %2757 13
+OpStore %1416 %2758
+%2759 = OpLoad %uchar %1415
+%2760 = OpLoad %uchar %1416
+%2761 = OpIMul %uchar %2759 %2760
+OpStore %1417 %2761
+%2762 = OpLoad %_arr_uchar_uint_16 %749
+%2763 = OpCompositeExtract %uchar %2762 14
+OpStore %1418 %2763
+%2764 = OpLoad %_arr_uchar_uint_16 %755
+%2765 = OpCompositeExtract %uchar %2764 14
+OpStore %1419 %2765
+%2766 = OpLoad %uchar %1418
+%2767 = OpLoad %uchar %1419
+%2768 = OpIMul %uchar %2766 %2767
+OpStore %1420 %2768
+%2769 = OpLoad %_arr_uchar_uint_16 %749
+%2770 = OpCompositeExtract %uchar %2769 15
+OpStore %1421 %2770
+%2771 = OpLoad %_arr_uchar_uint_16 %755
+%2772 = OpCompositeExtract %uchar %2771 15
+OpStore %1422 %2772
+%2773 = OpLoad %uchar %1421
+%2774 = OpLoad %uchar %1422
+%2775 = OpIMul %uchar %2773 %2774
+OpStore %1423 %2775
+%2776 = OpLoad %_arr_uchar_uint_16 %749
+%2777 = OpLoad %uchar %1378
+%2778 = OpCompositeInsert %_arr_uchar_uint_16 %2777 %2776 0
+OpStore %1424 %2778
+%2779 = OpLoad %_arr_uchar_uint_16 %1424
+%2780 = OpLoad %uchar %1381
+%2781 = OpCompositeInsert %_arr_uchar_uint_16 %2780 %2779 1
+OpStore %1425 %2781
+%2782 = OpLoad %_arr_uchar_uint_16 %1425
+%2783 = OpLoad %uchar %1384
+%2784 = OpCompositeInsert %_arr_uchar_uint_16 %2783 %2782 2
+OpStore %1426 %2784
+%2785 = OpLoad %_arr_uchar_uint_16 %1426
+%2786 = OpLoad %uchar %1387
+%2787 = OpCompositeInsert %_arr_uchar_uint_16 %2786 %2785 3
+OpStore %1427 %2787
+%2788 = OpLoad %_arr_uchar_uint_16 %1427
+%2789 = OpLoad %uchar %1390
+%2790 = OpCompositeInsert %_arr_uchar_uint_16 %2789 %2788 4
+OpStore %1428 %2790
+%2791 = OpLoad %_arr_uchar_uint_16 %1428
+%2792 = OpLoad %uchar %1393
+%2793 = OpCompositeInsert %_arr_uchar_uint_16 %2792 %2791 5
+OpStore %1429 %2793
+%2794 = OpLoad %_arr_uchar_uint_16 %1429
+%2795 = OpLoad %uchar %1396
+%2796 = OpCompositeInsert %_arr_uchar_uint_16 %2795 %2794 6
+OpStore %1430 %2796
+%2797 = OpLoad %_arr_uchar_uint_16 %1430
+%2798 = OpLoad %uchar %1399
+%2799 = OpCompositeInsert %_arr_uchar_uint_16 %2798 %2797 7
+OpStore %1431 %2799
+%2800 = OpLoad %_arr_uchar_uint_16 %1431
+%2801 = OpLoad %uchar %1402
+%2802 = OpCompositeInsert %_arr_uchar_uint_16 %2801 %2800 8
+OpStore %1432 %2802
+%2803 = OpLoad %_arr_uchar_uint_16 %1432
+%2804 = OpLoad %uchar %1405
+%2805 = OpCompositeInsert %_arr_uchar_uint_16 %2804 %2803 9
+OpStore %1433 %2805
+%2806 = OpLoad %_arr_uchar_uint_16 %1433
+%2807 = OpLoad %uchar %1408
+%2808 = OpCompositeInsert %_arr_uchar_uint_16 %2807 %2806 10
+OpStore %1434 %2808
+%2809 = OpLoad %_arr_uchar_uint_16 %1434
+%2810 = OpLoad %uchar %1411
+%2811 = OpCompositeInsert %_arr_uchar_uint_16 %2810 %2809 11
+OpStore %1435 %2811
+%2812 = OpLoad %_arr_uchar_uint_16 %1435
+%2813 = OpLoad %uchar %1414
+%2814 = OpCompositeInsert %_arr_uchar_uint_16 %2813 %2812 12
+OpStore %1436 %2814
+%2815 = OpLoad %_arr_uchar_uint_16 %1436
+%2816 = OpLoad %uchar %1417
+%2817 = OpCompositeInsert %_arr_uchar_uint_16 %2816 %2815 13
+OpStore %1437 %2817
+%2818 = OpLoad %_arr_uchar_uint_16 %1437
+%2819 = OpLoad %uchar %1420
+%2820 = OpCompositeInsert %_arr_uchar_uint_16 %2819 %2818 14
+OpStore %1438 %2820
+%2821 = OpLoad %_arr_uchar_uint_16 %1438
+%2822 = OpLoad %uchar %1423
+%2823 = OpCompositeInsert %_arr_uchar_uint_16 %2822 %2821 15
+OpStore %1439 %2823
+%2824 = OpLoad %ulong %760
+%2825 = OpLoad %_arr_uchar_uint_16 %1439
+%2826 = OpFunctionCall %ulong %1 %2824 %2825
+OpStore %761 %2826
+%2827 = OpLoad %_arr_uchar_uint_16 %749
+%2828 = OpCompositeExtract %uchar %2827 0
+OpStore %1440 %2828
+%2829 = OpLoad %_arr_uchar_uint_16 %742
+%2830 = OpCompositeExtract %uchar %2829 0
+OpStore %1441 %2830
+%2831 = OpLoad %uchar %1440
+%2832 = OpLoad %uchar %1441
+%2833 = OpIMul %uchar %2831 %2832
+OpStore %1442 %2833
+%2834 = OpLoad %_arr_uchar_uint_16 %749
+%2835 = OpCompositeExtract %uchar %2834 1
+OpStore %1443 %2835
+%2836 = OpLoad %_arr_uchar_uint_16 %742
+%2837 = OpCompositeExtract %uchar %2836 1
+OpStore %1444 %2837
+%2838 = OpLoad %uchar %1443
+%2839 = OpLoad %uchar %1444
+%2840 = OpIMul %uchar %2838 %2839
+OpStore %1445 %2840
+%2841 = OpLoad %_arr_uchar_uint_16 %749
+%2842 = OpCompositeExtract %uchar %2841 2
+OpStore %1446 %2842
+%2843 = OpLoad %_arr_uchar_uint_16 %742
+%2844 = OpCompositeExtract %uchar %2843 2
+OpStore %1447 %2844
+%2845 = OpLoad %uchar %1446
+%2846 = OpLoad %uchar %1447
+%2847 = OpIMul %uchar %2845 %2846
+OpStore %1448 %2847
+%2848 = OpLoad %_arr_uchar_uint_16 %749
+%2849 = OpCompositeExtract %uchar %2848 3
+OpStore %1449 %2849
+%2850 = OpLoad %_arr_uchar_uint_16 %742
+%2851 = OpCompositeExtract %uchar %2850 3
+OpStore %1450 %2851
+%2852 = OpLoad %uchar %1449
+%2853 = OpLoad %uchar %1450
+%2854 = OpIMul %uchar %2852 %2853
+OpStore %1451 %2854
+%2855 = OpLoad %_arr_uchar_uint_16 %749
+%2856 = OpCompositeExtract %uchar %2855 4
+OpStore %1452 %2856
+%2857 = OpLoad %_arr_uchar_uint_16 %742
+%2858 = OpCompositeExtract %uchar %2857 4
+OpStore %1453 %2858
+%2859 = OpLoad %uchar %1452
+%2860 = OpLoad %uchar %1453
+%2861 = OpIMul %uchar %2859 %2860
+OpStore %1454 %2861
+%2862 = OpLoad %_arr_uchar_uint_16 %749
+%2863 = OpCompositeExtract %uchar %2862 5
+OpStore %1455 %2863
+%2864 = OpLoad %_arr_uchar_uint_16 %742
+%2865 = OpCompositeExtract %uchar %2864 5
+OpStore %1456 %2865
+%2866 = OpLoad %uchar %1455
+%2867 = OpLoad %uchar %1456
+%2868 = OpIMul %uchar %2866 %2867
+OpStore %1457 %2868
+%2869 = OpLoad %_arr_uchar_uint_16 %749
+%2870 = OpCompositeExtract %uchar %2869 6
+OpStore %1458 %2870
+%2871 = OpLoad %_arr_uchar_uint_16 %742
+%2872 = OpCompositeExtract %uchar %2871 6
+OpStore %1459 %2872
+%2873 = OpLoad %uchar %1458
+%2874 = OpLoad %uchar %1459
+%2875 = OpIMul %uchar %2873 %2874
+OpStore %1460 %2875
+%2876 = OpLoad %_arr_uchar_uint_16 %749
+%2877 = OpCompositeExtract %uchar %2876 7
+OpStore %1461 %2877
+%2878 = OpLoad %_arr_uchar_uint_16 %742
+%2879 = OpCompositeExtract %uchar %2878 7
+OpStore %1462 %2879
+%2880 = OpLoad %uchar %1461
+%2881 = OpLoad %uchar %1462
+%2882 = OpIMul %uchar %2880 %2881
+OpStore %1463 %2882
+%2883 = OpLoad %_arr_uchar_uint_16 %749
+%2884 = OpCompositeExtract %uchar %2883 8
+OpStore %1464 %2884
+%2885 = OpLoad %_arr_uchar_uint_16 %742
+%2886 = OpCompositeExtract %uchar %2885 8
+OpStore %1465 %2886
+%2887 = OpLoad %uchar %1464
+%2888 = OpLoad %uchar %1465
+%2889 = OpIMul %uchar %2887 %2888
+OpStore %1466 %2889
+%2890 = OpLoad %_arr_uchar_uint_16 %749
+%2891 = OpCompositeExtract %uchar %2890 9
+OpStore %1467 %2891
+%2892 = OpLoad %_arr_uchar_uint_16 %742
+%2893 = OpCompositeExtract %uchar %2892 9
+OpStore %1468 %2893
+%2894 = OpLoad %uchar %1467
+%2895 = OpLoad %uchar %1468
+%2896 = OpIMul %uchar %2894 %2895
+OpStore %1469 %2896
+%2897 = OpLoad %_arr_uchar_uint_16 %749
+%2898 = OpCompositeExtract %uchar %2897 10
+OpStore %1470 %2898
+%2899 = OpLoad %_arr_uchar_uint_16 %742
+%2900 = OpCompositeExtract %uchar %2899 10
+OpStore %1471 %2900
+%2901 = OpLoad %uchar %1470
+%2902 = OpLoad %uchar %1471
+%2903 = OpIMul %uchar %2901 %2902
+OpStore %1472 %2903
+%2904 = OpLoad %_arr_uchar_uint_16 %749
+%2905 = OpCompositeExtract %uchar %2904 11
+OpStore %1473 %2905
+%2906 = OpLoad %_arr_uchar_uint_16 %742
+%2907 = OpCompositeExtract %uchar %2906 11
+OpStore %1474 %2907
+%2908 = OpLoad %uchar %1473
+%2909 = OpLoad %uchar %1474
+%2910 = OpIMul %uchar %2908 %2909
+OpStore %1475 %2910
+%2911 = OpLoad %_arr_uchar_uint_16 %749
+%2912 = OpCompositeExtract %uchar %2911 12
+OpStore %1476 %2912
+%2913 = OpLoad %_arr_uchar_uint_16 %742
+%2914 = OpCompositeExtract %uchar %2913 12
+OpStore %1477 %2914
+%2915 = OpLoad %uchar %1476
+%2916 = OpLoad %uchar %1477
+%2917 = OpIMul %uchar %2915 %2916
+OpStore %1478 %2917
+%2918 = OpLoad %_arr_uchar_uint_16 %749
+%2919 = OpCompositeExtract %uchar %2918 13
+OpStore %1479 %2919
+%2920 = OpLoad %_arr_uchar_uint_16 %742
+%2921 = OpCompositeExtract %uchar %2920 13
+OpStore %1480 %2921
+%2922 = OpLoad %uchar %1479
+%2923 = OpLoad %uchar %1480
+%2924 = OpIMul %uchar %2922 %2923
+OpStore %1481 %2924
+%2925 = OpLoad %_arr_uchar_uint_16 %749
+%2926 = OpCompositeExtract %uchar %2925 14
+OpStore %1482 %2926
+%2927 = OpLoad %_arr_uchar_uint_16 %742
+%2928 = OpCompositeExtract %uchar %2927 14
+OpStore %1483 %2928
+%2929 = OpLoad %uchar %1482
+%2930 = OpLoad %uchar %1483
+%2931 = OpIMul %uchar %2929 %2930
+OpStore %1484 %2931
+%2932 = OpLoad %_arr_uchar_uint_16 %749
+%2933 = OpCompositeExtract %uchar %2932 15
+OpStore %1485 %2933
+%2934 = OpLoad %_arr_uchar_uint_16 %742
+%2935 = OpCompositeExtract %uchar %2934 15
+OpStore %1486 %2935
+%2936 = OpLoad %uchar %1485
+%2937 = OpLoad %uchar %1486
+%2938 = OpIMul %uchar %2936 %2937
+OpStore %1487 %2938
+%2939 = OpLoad %_arr_uchar_uint_16 %749
+%2940 = OpLoad %uchar %1442
+%2941 = OpCompositeInsert %_arr_uchar_uint_16 %2940 %2939 0
+OpStore %1488 %2941
+%2942 = OpLoad %_arr_uchar_uint_16 %1488
+%2943 = OpLoad %uchar %1445
+%2944 = OpCompositeInsert %_arr_uchar_uint_16 %2943 %2942 1
+OpStore %1489 %2944
+%2945 = OpLoad %_arr_uchar_uint_16 %1489
+%2946 = OpLoad %uchar %1448
+%2947 = OpCompositeInsert %_arr_uchar_uint_16 %2946 %2945 2
+OpStore %1490 %2947
+%2948 = OpLoad %_arr_uchar_uint_16 %1490
+%2949 = OpLoad %uchar %1451
+%2950 = OpCompositeInsert %_arr_uchar_uint_16 %2949 %2948 3
+OpStore %1491 %2950
+%2951 = OpLoad %_arr_uchar_uint_16 %1491
+%2952 = OpLoad %uchar %1454
+%2953 = OpCompositeInsert %_arr_uchar_uint_16 %2952 %2951 4
+OpStore %1492 %2953
+%2954 = OpLoad %_arr_uchar_uint_16 %1492
+%2955 = OpLoad %uchar %1457
+%2956 = OpCompositeInsert %_arr_uchar_uint_16 %2955 %2954 5
+OpStore %1493 %2956
+%2957 = OpLoad %_arr_uchar_uint_16 %1493
+%2958 = OpLoad %uchar %1460
+%2959 = OpCompositeInsert %_arr_uchar_uint_16 %2958 %2957 6
+OpStore %1494 %2959
+%2960 = OpLoad %_arr_uchar_uint_16 %1494
+%2961 = OpLoad %uchar %1463
+%2962 = OpCompositeInsert %_arr_uchar_uint_16 %2961 %2960 7
+OpStore %1495 %2962
+%2963 = OpLoad %_arr_uchar_uint_16 %1495
+%2964 = OpLoad %uchar %1466
+%2965 = OpCompositeInsert %_arr_uchar_uint_16 %2964 %2963 8
+OpStore %1496 %2965
+%2966 = OpLoad %_arr_uchar_uint_16 %1496
+%2967 = OpLoad %uchar %1469
+%2968 = OpCompositeInsert %_arr_uchar_uint_16 %2967 %2966 9
+OpStore %1497 %2968
+%2969 = OpLoad %_arr_uchar_uint_16 %1497
+%2970 = OpLoad %uchar %1472
+%2971 = OpCompositeInsert %_arr_uchar_uint_16 %2970 %2969 10
+OpStore %1498 %2971
+%2972 = OpLoad %_arr_uchar_uint_16 %1498
+%2973 = OpLoad %uchar %1475
+%2974 = OpCompositeInsert %_arr_uchar_uint_16 %2973 %2972 11
+OpStore %1499 %2974
+%2975 = OpLoad %_arr_uchar_uint_16 %1499
+%2976 = OpLoad %uchar %1478
+%2977 = OpCompositeInsert %_arr_uchar_uint_16 %2976 %2975 12
+OpStore %1500 %2977
+%2978 = OpLoad %_arr_uchar_uint_16 %1500
+%2979 = OpLoad %uchar %1481
+%2980 = OpCompositeInsert %_arr_uchar_uint_16 %2979 %2978 13
+OpStore %1501 %2980
+%2981 = OpLoad %_arr_uchar_uint_16 %1501
+%2982 = OpLoad %uchar %1484
+%2983 = OpCompositeInsert %_arr_uchar_uint_16 %2982 %2981 14
+OpStore %1502 %2983
+%2984 = OpLoad %_arr_uchar_uint_16 %1502
+%2985 = OpLoad %uchar %1487
+%2986 = OpCompositeInsert %_arr_uchar_uint_16 %2985 %2984 15
+OpStore %1503 %2986
+%2987 = OpLoad %ulong %761
+%2988 = OpLoad %_arr_uchar_uint_16 %1503
+%2989 = OpFunctionCall %ulong %1 %2987 %2988
+OpStore %762 %2989
+%2990 = OpLoad %_arr_uchar_uint_16 %755
+%2991 = OpCompositeExtract %uchar %2990 0
+OpStore %1504 %2991
+%2992 = OpLoad %_arr_uchar_uint_16 %742
+%2993 = OpCompositeExtract %uchar %2992 0
+OpStore %1505 %2993
+%2994 = OpLoad %uchar %1504
+%2995 = OpLoad %uchar %1505
+%2996 = OpIMul %uchar %2994 %2995
+OpStore %1506 %2996
+%2997 = OpLoad %_arr_uchar_uint_16 %755
+%2998 = OpCompositeExtract %uchar %2997 1
+OpStore %1507 %2998
+%2999 = OpLoad %_arr_uchar_uint_16 %742
+%3000 = OpCompositeExtract %uchar %2999 1
+OpStore %1508 %3000
+%3001 = OpLoad %uchar %1507
+%3002 = OpLoad %uchar %1508
+%3003 = OpIMul %uchar %3001 %3002
+OpStore %1509 %3003
+%3004 = OpLoad %_arr_uchar_uint_16 %755
+%3005 = OpCompositeExtract %uchar %3004 2
+OpStore %1510 %3005
+%3006 = OpLoad %_arr_uchar_uint_16 %742
+%3007 = OpCompositeExtract %uchar %3006 2
+OpStore %1511 %3007
+%3008 = OpLoad %uchar %1510
+%3009 = OpLoad %uchar %1511
+%3010 = OpIMul %uchar %3008 %3009
+OpStore %1512 %3010
+%3011 = OpLoad %_arr_uchar_uint_16 %755
+%3012 = OpCompositeExtract %uchar %3011 3
+OpStore %1513 %3012
+%3013 = OpLoad %_arr_uchar_uint_16 %742
+%3014 = OpCompositeExtract %uchar %3013 3
+OpStore %1514 %3014
+%3015 = OpLoad %uchar %1513
+%3016 = OpLoad %uchar %1514
+%3017 = OpIMul %uchar %3015 %3016
+OpStore %1515 %3017
+%3018 = OpLoad %_arr_uchar_uint_16 %755
+%3019 = OpCompositeExtract %uchar %3018 4
+OpStore %1516 %3019
+%3020 = OpLoad %_arr_uchar_uint_16 %742
+%3021 = OpCompositeExtract %uchar %3020 4
+OpStore %1517 %3021
+%3022 = OpLoad %uchar %1516
+%3023 = OpLoad %uchar %1517
+%3024 = OpIMul %uchar %3022 %3023
+OpStore %1518 %3024
+%3025 = OpLoad %_arr_uchar_uint_16 %755
+%3026 = OpCompositeExtract %uchar %3025 5
+OpStore %1519 %3026
+%3027 = OpLoad %_arr_uchar_uint_16 %742
+%3028 = OpCompositeExtract %uchar %3027 5
+OpStore %1520 %3028
+%3029 = OpLoad %uchar %1519
+%3030 = OpLoad %uchar %1520
+%3031 = OpIMul %uchar %3029 %3030
+OpStore %1521 %3031
+%3032 = OpLoad %_arr_uchar_uint_16 %755
+%3033 = OpCompositeExtract %uchar %3032 6
+OpStore %1522 %3033
+%3034 = OpLoad %_arr_uchar_uint_16 %742
+%3035 = OpCompositeExtract %uchar %3034 6
+OpStore %1523 %3035
+%3036 = OpLoad %uchar %1522
+%3037 = OpLoad %uchar %1523
+%3038 = OpIMul %uchar %3036 %3037
+OpStore %1524 %3038
+%3039 = OpLoad %_arr_uchar_uint_16 %755
+%3040 = OpCompositeExtract %uchar %3039 7
+OpStore %1525 %3040
+%3041 = OpLoad %_arr_uchar_uint_16 %742
+%3042 = OpCompositeExtract %uchar %3041 7
+OpStore %1526 %3042
+%3043 = OpLoad %uchar %1525
+%3044 = OpLoad %uchar %1526
+%3045 = OpIMul %uchar %3043 %3044
+OpStore %1527 %3045
+%3046 = OpLoad %_arr_uchar_uint_16 %755
+%3047 = OpCompositeExtract %uchar %3046 8
+OpStore %1528 %3047
+%3048 = OpLoad %_arr_uchar_uint_16 %742
+%3049 = OpCompositeExtract %uchar %3048 8
+OpStore %1529 %3049
+%3050 = OpLoad %uchar %1528
+%3051 = OpLoad %uchar %1529
+%3052 = OpIMul %uchar %3050 %3051
+OpStore %1530 %3052
+%3053 = OpLoad %_arr_uchar_uint_16 %755
+%3054 = OpCompositeExtract %uchar %3053 9
+OpStore %1531 %3054
+%3055 = OpLoad %_arr_uchar_uint_16 %742
+%3056 = OpCompositeExtract %uchar %3055 9
+OpStore %1532 %3056
+%3057 = OpLoad %uchar %1531
+%3058 = OpLoad %uchar %1532
+%3059 = OpIMul %uchar %3057 %3058
+OpStore %1533 %3059
+%3060 = OpLoad %_arr_uchar_uint_16 %755
+%3061 = OpCompositeExtract %uchar %3060 10
+OpStore %1534 %3061
+%3062 = OpLoad %_arr_uchar_uint_16 %742
+%3063 = OpCompositeExtract %uchar %3062 10
+OpStore %1535 %3063
+%3064 = OpLoad %uchar %1534
+%3065 = OpLoad %uchar %1535
+%3066 = OpIMul %uchar %3064 %3065
+OpStore %1536 %3066
+%3067 = OpLoad %_arr_uchar_uint_16 %755
+%3068 = OpCompositeExtract %uchar %3067 11
+OpStore %1537 %3068
+%3069 = OpLoad %_arr_uchar_uint_16 %742
+%3070 = OpCompositeExtract %uchar %3069 11
+OpStore %1538 %3070
+%3071 = OpLoad %uchar %1537
+%3072 = OpLoad %uchar %1538
+%3073 = OpIMul %uchar %3071 %3072
+OpStore %1539 %3073
+%3074 = OpLoad %_arr_uchar_uint_16 %755
+%3075 = OpCompositeExtract %uchar %3074 12
+OpStore %1540 %3075
+%3076 = OpLoad %_arr_uchar_uint_16 %742
+%3077 = OpCompositeExtract %uchar %3076 12
+OpStore %1541 %3077
+%3078 = OpLoad %uchar %1540
+%3079 = OpLoad %uchar %1541
+%3080 = OpIMul %uchar %3078 %3079
+OpStore %1542 %3080
+%3081 = OpLoad %_arr_uchar_uint_16 %755
+%3082 = OpCompositeExtract %uchar %3081 13
+OpStore %1543 %3082
+%3083 = OpLoad %_arr_uchar_uint_16 %742
+%3084 = OpCompositeExtract %uchar %3083 13
+OpStore %1544 %3084
+%3085 = OpLoad %uchar %1543
+%3086 = OpLoad %uchar %1544
+%3087 = OpIMul %uchar %3085 %3086
+OpStore %1545 %3087
+%3088 = OpLoad %_arr_uchar_uint_16 %755
+%3089 = OpCompositeExtract %uchar %3088 14
+OpStore %1546 %3089
+%3090 = OpLoad %_arr_uchar_uint_16 %742
+%3091 = OpCompositeExtract %uchar %3090 14
+OpStore %1547 %3091
+%3092 = OpLoad %uchar %1546
+%3093 = OpLoad %uchar %1547
+%3094 = OpIMul %uchar %3092 %3093
+OpStore %1548 %3094
+%3095 = OpLoad %_arr_uchar_uint_16 %755
+%3096 = OpCompositeExtract %uchar %3095 15
+OpStore %1549 %3096
+%3097 = OpLoad %_arr_uchar_uint_16 %742
+%3098 = OpCompositeExtract %uchar %3097 15
+OpStore %1550 %3098
+%3099 = OpLoad %uchar %1549
+%3100 = OpLoad %uchar %1550
+%3101 = OpIMul %uchar %3099 %3100
+OpStore %1551 %3101
+%3102 = OpLoad %_arr_uchar_uint_16 %755
+%3103 = OpLoad %uchar %1506
+%3104 = OpCompositeInsert %_arr_uchar_uint_16 %3103 %3102 0
+OpStore %1552 %3104
+%3105 = OpLoad %_arr_uchar_uint_16 %1552
+%3106 = OpLoad %uchar %1509
+%3107 = OpCompositeInsert %_arr_uchar_uint_16 %3106 %3105 1
+OpStore %1553 %3107
+%3108 = OpLoad %_arr_uchar_uint_16 %1553
+%3109 = OpLoad %uchar %1512
+%3110 = OpCompositeInsert %_arr_uchar_uint_16 %3109 %3108 2
+OpStore %1554 %3110
+%3111 = OpLoad %_arr_uchar_uint_16 %1554
+%3112 = OpLoad %uchar %1515
+%3113 = OpCompositeInsert %_arr_uchar_uint_16 %3112 %3111 3
+OpStore %1555 %3113
+%3114 = OpLoad %_arr_uchar_uint_16 %1555
+%3115 = OpLoad %uchar %1518
+%3116 = OpCompositeInsert %_arr_uchar_uint_16 %3115 %3114 4
+OpStore %1556 %3116
+%3117 = OpLoad %_arr_uchar_uint_16 %1556
+%3118 = OpLoad %uchar %1521
+%3119 = OpCompositeInsert %_arr_uchar_uint_16 %3118 %3117 5
+OpStore %1557 %3119
+%3120 = OpLoad %_arr_uchar_uint_16 %1557
+%3121 = OpLoad %uchar %1524
+%3122 = OpCompositeInsert %_arr_uchar_uint_16 %3121 %3120 6
+OpStore %1558 %3122
+%3123 = OpLoad %_arr_uchar_uint_16 %1558
+%3124 = OpLoad %uchar %1527
+%3125 = OpCompositeInsert %_arr_uchar_uint_16 %3124 %3123 7
+OpStore %1559 %3125
+%3126 = OpLoad %_arr_uchar_uint_16 %1559
+%3127 = OpLoad %uchar %1530
+%3128 = OpCompositeInsert %_arr_uchar_uint_16 %3127 %3126 8
+OpStore %1560 %3128
+%3129 = OpLoad %_arr_uchar_uint_16 %1560
+%3130 = OpLoad %uchar %1533
+%3131 = OpCompositeInsert %_arr_uchar_uint_16 %3130 %3129 9
+OpStore %1561 %3131
+%3132 = OpLoad %_arr_uchar_uint_16 %1561
+%3133 = OpLoad %uchar %1536
+%3134 = OpCompositeInsert %_arr_uchar_uint_16 %3133 %3132 10
+OpStore %1562 %3134
+%3135 = OpLoad %_arr_uchar_uint_16 %1562
+%3136 = OpLoad %uchar %1539
+%3137 = OpCompositeInsert %_arr_uchar_uint_16 %3136 %3135 11
+OpStore %1563 %3137
+%3138 = OpLoad %_arr_uchar_uint_16 %1563
+%3139 = OpLoad %uchar %1542
+%3140 = OpCompositeInsert %_arr_uchar_uint_16 %3139 %3138 12
+OpStore %1564 %3140
+%3141 = OpLoad %_arr_uchar_uint_16 %1564
+%3142 = OpLoad %uchar %1545
+%3143 = OpCompositeInsert %_arr_uchar_uint_16 %3142 %3141 13
+OpStore %1565 %3143
+%3144 = OpLoad %_arr_uchar_uint_16 %1565
+%3145 = OpLoad %uchar %1548
+%3146 = OpCompositeInsert %_arr_uchar_uint_16 %3145 %3144 14
+OpStore %1566 %3146
+%3147 = OpLoad %_arr_uchar_uint_16 %1566
+%3148 = OpLoad %uchar %1551
+%3149 = OpCompositeInsert %_arr_uchar_uint_16 %3148 %3147 15
+OpStore %1567 %3149
+%3150 = OpLoad %ulong %762
+%3151 = OpLoad %_arr_uchar_uint_16 %1567
+%3152 = OpFunctionCall %ulong %1 %3150 %3151
+OpStore %763 %3152
+%3153 = OpLoad %_arr_uchar_uint_16 %1247
+%3154 = OpCompositeExtract %uchar %3153 0
+OpStore %1568 %3154
+%3155 = OpLoad %_arr_uchar_uint_16 %742
+%3156 = OpCompositeExtract %uchar %3155 0
+OpStore %1569 %3156
+%3157 = OpLoad %uchar %1568
+%3158 = OpLoad %uchar %1569
+%3159 = OpIMul %uchar %3157 %3158
+OpStore %1570 %3159
+%3160 = OpLoad %_arr_uchar_uint_16 %1247
+%3161 = OpCompositeExtract %uchar %3160 1
+OpStore %1571 %3161
+%3162 = OpLoad %_arr_uchar_uint_16 %742
+%3163 = OpCompositeExtract %uchar %3162 1
+OpStore %1572 %3163
+%3164 = OpLoad %uchar %1571
+%3165 = OpLoad %uchar %1572
+%3166 = OpIMul %uchar %3164 %3165
+OpStore %1573 %3166
+%3167 = OpLoad %_arr_uchar_uint_16 %1247
+%3168 = OpCompositeExtract %uchar %3167 2
+OpStore %1574 %3168
+%3169 = OpLoad %_arr_uchar_uint_16 %742
+%3170 = OpCompositeExtract %uchar %3169 2
+OpStore %1575 %3170
+%3171 = OpLoad %uchar %1574
+%3172 = OpLoad %uchar %1575
+%3173 = OpIMul %uchar %3171 %3172
+OpStore %1576 %3173
+%3174 = OpLoad %_arr_uchar_uint_16 %1247
+%3175 = OpCompositeExtract %uchar %3174 3
+OpStore %1577 %3175
+%3176 = OpLoad %_arr_uchar_uint_16 %742
+%3177 = OpCompositeExtract %uchar %3176 3
+OpStore %1578 %3177
+%3178 = OpLoad %uchar %1577
+%3179 = OpLoad %uchar %1578
+%3180 = OpIMul %uchar %3178 %3179
+OpStore %1579 %3180
+%3181 = OpLoad %_arr_uchar_uint_16 %1247
+%3182 = OpCompositeExtract %uchar %3181 4
+OpStore %1580 %3182
+%3183 = OpLoad %_arr_uchar_uint_16 %742
+%3184 = OpCompositeExtract %uchar %3183 4
+OpStore %1581 %3184
+%3185 = OpLoad %uchar %1580
+%3186 = OpLoad %uchar %1581
+%3187 = OpIMul %uchar %3185 %3186
+OpStore %1582 %3187
+%3188 = OpLoad %_arr_uchar_uint_16 %1247
+%3189 = OpCompositeExtract %uchar %3188 5
+OpStore %1583 %3189
+%3190 = OpLoad %_arr_uchar_uint_16 %742
+%3191 = OpCompositeExtract %uchar %3190 5
+OpStore %1584 %3191
+%3192 = OpLoad %uchar %1583
+%3193 = OpLoad %uchar %1584
+%3194 = OpIMul %uchar %3192 %3193
+OpStore %1585 %3194
+%3195 = OpLoad %_arr_uchar_uint_16 %1247
+%3196 = OpCompositeExtract %uchar %3195 6
+OpStore %1586 %3196
+%3197 = OpLoad %_arr_uchar_uint_16 %742
+%3198 = OpCompositeExtract %uchar %3197 6
+OpStore %1587 %3198
+%3199 = OpLoad %uchar %1586
+%3200 = OpLoad %uchar %1587
+%3201 = OpIMul %uchar %3199 %3200
+OpStore %1588 %3201
+%3202 = OpLoad %_arr_uchar_uint_16 %1247
+%3203 = OpCompositeExtract %uchar %3202 7
+OpStore %1589 %3203
+%3204 = OpLoad %_arr_uchar_uint_16 %742
+%3205 = OpCompositeExtract %uchar %3204 7
+OpStore %1590 %3205
+%3206 = OpLoad %uchar %1589
+%3207 = OpLoad %uchar %1590
+%3208 = OpIMul %uchar %3206 %3207
+OpStore %1591 %3208
+%3209 = OpLoad %_arr_uchar_uint_16 %1247
+%3210 = OpCompositeExtract %uchar %3209 8
+OpStore %1592 %3210
+%3211 = OpLoad %_arr_uchar_uint_16 %742
+%3212 = OpCompositeExtract %uchar %3211 8
+OpStore %1593 %3212
+%3213 = OpLoad %uchar %1592
+%3214 = OpLoad %uchar %1593
+%3215 = OpIMul %uchar %3213 %3214
+OpStore %1594 %3215
+%3216 = OpLoad %_arr_uchar_uint_16 %1247
+%3217 = OpCompositeExtract %uchar %3216 9
+OpStore %1595 %3217
+%3218 = OpLoad %_arr_uchar_uint_16 %742
+%3219 = OpCompositeExtract %uchar %3218 9
+OpStore %1596 %3219
+%3220 = OpLoad %uchar %1595
+%3221 = OpLoad %uchar %1596
+%3222 = OpIMul %uchar %3220 %3221
+OpStore %1597 %3222
+%3223 = OpLoad %_arr_uchar_uint_16 %1247
+%3224 = OpCompositeExtract %uchar %3223 10
+OpStore %1598 %3224
+%3225 = OpLoad %_arr_uchar_uint_16 %742
+%3226 = OpCompositeExtract %uchar %3225 10
+OpStore %1599 %3226
+%3227 = OpLoad %uchar %1598
+%3228 = OpLoad %uchar %1599
+%3229 = OpIMul %uchar %3227 %3228
+OpStore %1600 %3229
+%3230 = OpLoad %_arr_uchar_uint_16 %1247
+%3231 = OpCompositeExtract %uchar %3230 11
+OpStore %1601 %3231
+%3232 = OpLoad %_arr_uchar_uint_16 %742
+%3233 = OpCompositeExtract %uchar %3232 11
+OpStore %1602 %3233
+%3234 = OpLoad %uchar %1601
+%3235 = OpLoad %uchar %1602
+%3236 = OpIMul %uchar %3234 %3235
+OpStore %1603 %3236
+%3237 = OpLoad %_arr_uchar_uint_16 %1247
+%3238 = OpCompositeExtract %uchar %3237 12
+OpStore %1604 %3238
+%3239 = OpLoad %_arr_uchar_uint_16 %742
+%3240 = OpCompositeExtract %uchar %3239 12
+OpStore %1605 %3240
+%3241 = OpLoad %uchar %1604
+%3242 = OpLoad %uchar %1605
+%3243 = OpIMul %uchar %3241 %3242
+OpStore %1606 %3243
+%3244 = OpLoad %_arr_uchar_uint_16 %1247
+%3245 = OpCompositeExtract %uchar %3244 13
+OpStore %1607 %3245
+%3246 = OpLoad %_arr_uchar_uint_16 %742
+%3247 = OpCompositeExtract %uchar %3246 13
+OpStore %1608 %3247
+%3248 = OpLoad %uchar %1607
+%3249 = OpLoad %uchar %1608
+%3250 = OpIMul %uchar %3248 %3249
+OpStore %1609 %3250
+%3251 = OpLoad %_arr_uchar_uint_16 %1247
+%3252 = OpCompositeExtract %uchar %3251 14
+OpStore %1610 %3252
+%3253 = OpLoad %_arr_uchar_uint_16 %742
+%3254 = OpCompositeExtract %uchar %3253 14
+OpStore %1611 %3254
+%3255 = OpLoad %uchar %1610
+%3256 = OpLoad %uchar %1611
+%3257 = OpIMul %uchar %3255 %3256
+OpStore %1612 %3257
+%3258 = OpLoad %_arr_uchar_uint_16 %1247
+%3259 = OpCompositeExtract %uchar %3258 15
+OpStore %1613 %3259
+%3260 = OpLoad %_arr_uchar_uint_16 %742
+%3261 = OpCompositeExtract %uchar %3260 15
+OpStore %1614 %3261
+%3262 = OpLoad %uchar %1613
+%3263 = OpLoad %uchar %1614
+%3264 = OpIMul %uchar %3262 %3263
+OpStore %1615 %3264
+%3265 = OpLoad %_arr_uchar_uint_16 %1247
+%3266 = OpLoad %uchar %1570
+%3267 = OpCompositeInsert %_arr_uchar_uint_16 %3266 %3265 0
+OpStore %1616 %3267
+%3268 = OpLoad %_arr_uchar_uint_16 %1616
+%3269 = OpLoad %uchar %1573
+%3270 = OpCompositeInsert %_arr_uchar_uint_16 %3269 %3268 1
+OpStore %1617 %3270
+%3271 = OpLoad %_arr_uchar_uint_16 %1617
+%3272 = OpLoad %uchar %1576
+%3273 = OpCompositeInsert %_arr_uchar_uint_16 %3272 %3271 2
+OpStore %1618 %3273
+%3274 = OpLoad %_arr_uchar_uint_16 %1618
+%3275 = OpLoad %uchar %1579
+%3276 = OpCompositeInsert %_arr_uchar_uint_16 %3275 %3274 3
+OpStore %1619 %3276
+%3277 = OpLoad %_arr_uchar_uint_16 %1619
+%3278 = OpLoad %uchar %1582
+%3279 = OpCompositeInsert %_arr_uchar_uint_16 %3278 %3277 4
+OpStore %1620 %3279
+%3280 = OpLoad %_arr_uchar_uint_16 %1620
+%3281 = OpLoad %uchar %1585
+%3282 = OpCompositeInsert %_arr_uchar_uint_16 %3281 %3280 5
+OpStore %1621 %3282
+%3283 = OpLoad %_arr_uchar_uint_16 %1621
+%3284 = OpLoad %uchar %1588
+%3285 = OpCompositeInsert %_arr_uchar_uint_16 %3284 %3283 6
+OpStore %1622 %3285
+%3286 = OpLoad %_arr_uchar_uint_16 %1622
+%3287 = OpLoad %uchar %1591
+%3288 = OpCompositeInsert %_arr_uchar_uint_16 %3287 %3286 7
+OpStore %1623 %3288
+%3289 = OpLoad %_arr_uchar_uint_16 %1623
+%3290 = OpLoad %uchar %1594
+%3291 = OpCompositeInsert %_arr_uchar_uint_16 %3290 %3289 8
+OpStore %1624 %3291
+%3292 = OpLoad %_arr_uchar_uint_16 %1624
+%3293 = OpLoad %uchar %1597
+%3294 = OpCompositeInsert %_arr_uchar_uint_16 %3293 %3292 9
+OpStore %1625 %3294
+%3295 = OpLoad %_arr_uchar_uint_16 %1625
+%3296 = OpLoad %uchar %1600
+%3297 = OpCompositeInsert %_arr_uchar_uint_16 %3296 %3295 10
+OpStore %1626 %3297
+%3298 = OpLoad %_arr_uchar_uint_16 %1626
+%3299 = OpLoad %uchar %1603
+%3300 = OpCompositeInsert %_arr_uchar_uint_16 %3299 %3298 11
+OpStore %1627 %3300
+%3301 = OpLoad %_arr_uchar_uint_16 %1627
+%3302 = OpLoad %uchar %1606
+%3303 = OpCompositeInsert %_arr_uchar_uint_16 %3302 %3301 12
+OpStore %1628 %3303
+%3304 = OpLoad %_arr_uchar_uint_16 %1628
+%3305 = OpLoad %uchar %1609
+%3306 = OpCompositeInsert %_arr_uchar_uint_16 %3305 %3304 13
+OpStore %1629 %3306
+%3307 = OpLoad %_arr_uchar_uint_16 %1629
+%3308 = OpLoad %uchar %1612
+%3309 = OpCompositeInsert %_arr_uchar_uint_16 %3308 %3307 14
+OpStore %1630 %3309
+%3310 = OpLoad %_arr_uchar_uint_16 %1630
+%3311 = OpLoad %uchar %1615
+%3312 = OpCompositeInsert %_arr_uchar_uint_16 %3311 %3310 15
+OpStore %1631 %3312
+%3313 = OpLoad %ulong %763
+%3314 = OpLoad %_arr_uchar_uint_16 %1631
+%3315 = OpFunctionCall %ulong %1 %3313 %3314
+OpStore %764 %3315
+%3316 = OpLoad %_arr_uchar_uint_16 %743
+%3317 = OpCompositeExtract %uchar %3316 0
+OpStore %1632 %3317
+%3318 = OpLoad %_arr_uchar_uint_16 %749
+%3319 = OpCompositeExtract %uchar %3318 0
+OpStore %1633 %3319
+%3320 = OpLoad %uchar %1632
+%3321 = OpLoad %uchar %1633
+%3322 = OpISub %uchar %3320 %3321
+OpStore %1634 %3322
+%3323 = OpLoad %_arr_uchar_uint_16 %743
+%3324 = OpCompositeExtract %uchar %3323 1
+OpStore %1635 %3324
+%3325 = OpLoad %_arr_uchar_uint_16 %749
+%3326 = OpCompositeExtract %uchar %3325 1
+OpStore %1636 %3326
+%3327 = OpLoad %uchar %1635
+%3328 = OpLoad %uchar %1636
+%3329 = OpISub %uchar %3327 %3328
+OpStore %1637 %3329
+%3330 = OpLoad %_arr_uchar_uint_16 %743
+%3331 = OpCompositeExtract %uchar %3330 2
+OpStore %1638 %3331
+%3332 = OpLoad %_arr_uchar_uint_16 %749
+%3333 = OpCompositeExtract %uchar %3332 2
+OpStore %1639 %3333
+%3334 = OpLoad %uchar %1638
+%3335 = OpLoad %uchar %1639
+%3336 = OpISub %uchar %3334 %3335
+OpStore %1640 %3336
+%3337 = OpLoad %_arr_uchar_uint_16 %743
+%3338 = OpCompositeExtract %uchar %3337 3
+OpStore %1641 %3338
+%3339 = OpLoad %_arr_uchar_uint_16 %749
+%3340 = OpCompositeExtract %uchar %3339 3
+OpStore %1642 %3340
+%3341 = OpLoad %uchar %1641
+%3342 = OpLoad %uchar %1642
+%3343 = OpISub %uchar %3341 %3342
+OpStore %1643 %3343
+%3344 = OpLoad %_arr_uchar_uint_16 %743
+%3345 = OpCompositeExtract %uchar %3344 4
+OpStore %1644 %3345
+%3346 = OpLoad %_arr_uchar_uint_16 %749
+%3347 = OpCompositeExtract %uchar %3346 4
+OpStore %1645 %3347
+%3348 = OpLoad %uchar %1644
+%3349 = OpLoad %uchar %1645
+%3350 = OpISub %uchar %3348 %3349
+OpStore %1646 %3350
+%3351 = OpLoad %_arr_uchar_uint_16 %743
+%3352 = OpCompositeExtract %uchar %3351 5
+OpStore %1647 %3352
+%3353 = OpLoad %_arr_uchar_uint_16 %749
+%3354 = OpCompositeExtract %uchar %3353 5
+OpStore %1648 %3354
+%3355 = OpLoad %uchar %1647
+%3356 = OpLoad %uchar %1648
+%3357 = OpISub %uchar %3355 %3356
+OpStore %1649 %3357
+%3358 = OpLoad %_arr_uchar_uint_16 %743
+%3359 = OpCompositeExtract %uchar %3358 6
+OpStore %1650 %3359
+%3360 = OpLoad %_arr_uchar_uint_16 %749
+%3361 = OpCompositeExtract %uchar %3360 6
+OpStore %1651 %3361
+%3362 = OpLoad %uchar %1650
+%3363 = OpLoad %uchar %1651
+%3364 = OpISub %uchar %3362 %3363
+OpStore %1652 %3364
+%3365 = OpLoad %_arr_uchar_uint_16 %743
+%3366 = OpCompositeExtract %uchar %3365 7
+OpStore %1653 %3366
+%3367 = OpLoad %_arr_uchar_uint_16 %749
+%3368 = OpCompositeExtract %uchar %3367 7
+OpStore %1654 %3368
+%3369 = OpLoad %uchar %1653
+%3370 = OpLoad %uchar %1654
+%3371 = OpISub %uchar %3369 %3370
+OpStore %1655 %3371
+%3372 = OpLoad %_arr_uchar_uint_16 %743
+%3373 = OpCompositeExtract %uchar %3372 8
+OpStore %1656 %3373
+%3374 = OpLoad %_arr_uchar_uint_16 %749
+%3375 = OpCompositeExtract %uchar %3374 8
+OpStore %1657 %3375
+%3376 = OpLoad %uchar %1656
+%3377 = OpLoad %uchar %1657
+%3378 = OpISub %uchar %3376 %3377
+OpStore %1658 %3378
+%3379 = OpLoad %_arr_uchar_uint_16 %743
+%3380 = OpCompositeExtract %uchar %3379 9
+OpStore %1659 %3380
+%3381 = OpLoad %_arr_uchar_uint_16 %749
+%3382 = OpCompositeExtract %uchar %3381 9
+OpStore %1660 %3382
+%3383 = OpLoad %uchar %1659
+%3384 = OpLoad %uchar %1660
+%3385 = OpISub %uchar %3383 %3384
+OpStore %1661 %3385
+%3386 = OpLoad %_arr_uchar_uint_16 %743
+%3387 = OpCompositeExtract %uchar %3386 10
+OpStore %1662 %3387
+%3388 = OpLoad %_arr_uchar_uint_16 %749
+%3389 = OpCompositeExtract %uchar %3388 10
+OpStore %1663 %3389
+%3390 = OpLoad %uchar %1662
+%3391 = OpLoad %uchar %1663
+%3392 = OpISub %uchar %3390 %3391
+OpStore %1664 %3392
+%3393 = OpLoad %_arr_uchar_uint_16 %743
+%3394 = OpCompositeExtract %uchar %3393 11
+OpStore %1665 %3394
+%3395 = OpLoad %_arr_uchar_uint_16 %749
+%3396 = OpCompositeExtract %uchar %3395 11
+OpStore %1666 %3396
+%3397 = OpLoad %uchar %1665
+%3398 = OpLoad %uchar %1666
+%3399 = OpISub %uchar %3397 %3398
+OpStore %1667 %3399
+%3400 = OpLoad %_arr_uchar_uint_16 %743
+%3401 = OpCompositeExtract %uchar %3400 12
+OpStore %1668 %3401
+%3402 = OpLoad %_arr_uchar_uint_16 %749
+%3403 = OpCompositeExtract %uchar %3402 12
+OpStore %1669 %3403
+%3404 = OpLoad %uchar %1668
+%3405 = OpLoad %uchar %1669
+%3406 = OpISub %uchar %3404 %3405
+OpStore %1670 %3406
+%3407 = OpLoad %_arr_uchar_uint_16 %743
+%3408 = OpCompositeExtract %uchar %3407 13
+OpStore %1671 %3408
+%3409 = OpLoad %_arr_uchar_uint_16 %749
+%3410 = OpCompositeExtract %uchar %3409 13
+OpStore %1672 %3410
+%3411 = OpLoad %uchar %1671
+%3412 = OpLoad %uchar %1672
+%3413 = OpISub %uchar %3411 %3412
+OpStore %1673 %3413
+%3414 = OpLoad %_arr_uchar_uint_16 %743
+%3415 = OpCompositeExtract %uchar %3414 14
+OpStore %1674 %3415
+%3416 = OpLoad %_arr_uchar_uint_16 %749
+%3417 = OpCompositeExtract %uchar %3416 14
+OpStore %1675 %3417
+%3418 = OpLoad %uchar %1674
+%3419 = OpLoad %uchar %1675
+%3420 = OpISub %uchar %3418 %3419
+OpStore %1676 %3420
+%3421 = OpLoad %_arr_uchar_uint_16 %743
+%3422 = OpCompositeExtract %uchar %3421 15
+OpStore %1677 %3422
+%3423 = OpLoad %_arr_uchar_uint_16 %749
+%3424 = OpCompositeExtract %uchar %3423 15
+OpStore %1678 %3424
+%3425 = OpLoad %uchar %1677
+%3426 = OpLoad %uchar %1678
+%3427 = OpISub %uchar %3425 %3426
+OpStore %1679 %3427
+%3428 = OpLoad %_arr_uchar_uint_16 %743
+%3429 = OpLoad %uchar %1634
+%3430 = OpCompositeInsert %_arr_uchar_uint_16 %3429 %3428 0
+OpStore %1680 %3430
+%3431 = OpLoad %_arr_uchar_uint_16 %1680
+%3432 = OpLoad %uchar %1637
+%3433 = OpCompositeInsert %_arr_uchar_uint_16 %3432 %3431 1
+OpStore %1681 %3433
+%3434 = OpLoad %_arr_uchar_uint_16 %1681
+%3435 = OpLoad %uchar %1640
+%3436 = OpCompositeInsert %_arr_uchar_uint_16 %3435 %3434 2
+OpStore %1682 %3436
+%3437 = OpLoad %_arr_uchar_uint_16 %1682
+%3438 = OpLoad %uchar %1643
+%3439 = OpCompositeInsert %_arr_uchar_uint_16 %3438 %3437 3
+OpStore %1683 %3439
+%3440 = OpLoad %_arr_uchar_uint_16 %1683
+%3441 = OpLoad %uchar %1646
+%3442 = OpCompositeInsert %_arr_uchar_uint_16 %3441 %3440 4
+OpStore %1684 %3442
+%3443 = OpLoad %_arr_uchar_uint_16 %1684
+%3444 = OpLoad %uchar %1649
+%3445 = OpCompositeInsert %_arr_uchar_uint_16 %3444 %3443 5
+OpStore %1685 %3445
+%3446 = OpLoad %_arr_uchar_uint_16 %1685
+%3447 = OpLoad %uchar %1652
+%3448 = OpCompositeInsert %_arr_uchar_uint_16 %3447 %3446 6
+OpStore %1686 %3448
+%3449 = OpLoad %_arr_uchar_uint_16 %1686
+%3450 = OpLoad %uchar %1655
+%3451 = OpCompositeInsert %_arr_uchar_uint_16 %3450 %3449 7
+OpStore %1687 %3451
+%3452 = OpLoad %_arr_uchar_uint_16 %1687
+%3453 = OpLoad %uchar %1658
+%3454 = OpCompositeInsert %_arr_uchar_uint_16 %3453 %3452 8
+OpStore %1688 %3454
+%3455 = OpLoad %_arr_uchar_uint_16 %1688
+%3456 = OpLoad %uchar %1661
+%3457 = OpCompositeInsert %_arr_uchar_uint_16 %3456 %3455 9
+OpStore %1689 %3457
+%3458 = OpLoad %_arr_uchar_uint_16 %1689
+%3459 = OpLoad %uchar %1664
+%3460 = OpCompositeInsert %_arr_uchar_uint_16 %3459 %3458 10
+OpStore %1690 %3460
+%3461 = OpLoad %_arr_uchar_uint_16 %1690
+%3462 = OpLoad %uchar %1667
+%3463 = OpCompositeInsert %_arr_uchar_uint_16 %3462 %3461 11
+OpStore %1691 %3463
+%3464 = OpLoad %_arr_uchar_uint_16 %1691
+%3465 = OpLoad %uchar %1670
+%3466 = OpCompositeInsert %_arr_uchar_uint_16 %3465 %3464 12
+OpStore %1692 %3466
+%3467 = OpLoad %_arr_uchar_uint_16 %1692
+%3468 = OpLoad %uchar %1673
+%3469 = OpCompositeInsert %_arr_uchar_uint_16 %3468 %3467 13
+OpStore %1693 %3469
+%3470 = OpLoad %_arr_uchar_uint_16 %1693
+%3471 = OpLoad %uchar %1676
+%3472 = OpCompositeInsert %_arr_uchar_uint_16 %3471 %3470 14
+OpStore %1694 %3472
+%3473 = OpLoad %_arr_uchar_uint_16 %1694
+%3474 = OpLoad %uchar %1679
+%3475 = OpCompositeInsert %_arr_uchar_uint_16 %3474 %3473 15
+OpStore %1695 %3475
+%3476 = OpLoad %ulong %764
+%3477 = OpLoad %_arr_uchar_uint_16 %1695
+%3478 = OpFunctionCall %ulong %1 %3476 %3477
+OpStore %765 %3478
+%3479 = OpLoad %_arr_uchar_uint_16 %743
+%3480 = OpCompositeExtract %uchar %3479 0
+OpStore %1696 %3480
+%3481 = OpLoad %_arr_uchar_uint_16 %755
+%3482 = OpCompositeExtract %uchar %3481 0
+OpStore %1697 %3482
+%3483 = OpLoad %uchar %1696
+%3484 = OpLoad %uchar %1697
+%3485 = OpISub %uchar %3483 %3484
+OpStore %1698 %3485
+%3486 = OpLoad %_arr_uchar_uint_16 %743
+%3487 = OpCompositeExtract %uchar %3486 1
+OpStore %1699 %3487
+%3488 = OpLoad %_arr_uchar_uint_16 %755
+%3489 = OpCompositeExtract %uchar %3488 1
+OpStore %1700 %3489
+%3490 = OpLoad %uchar %1699
+%3491 = OpLoad %uchar %1700
+%3492 = OpISub %uchar %3490 %3491
+OpStore %1701 %3492
+%3493 = OpLoad %_arr_uchar_uint_16 %743
+%3494 = OpCompositeExtract %uchar %3493 2
+OpStore %1702 %3494
+%3495 = OpLoad %_arr_uchar_uint_16 %755
+%3496 = OpCompositeExtract %uchar %3495 2
+OpStore %1703 %3496
+%3497 = OpLoad %uchar %1702
+%3498 = OpLoad %uchar %1703
+%3499 = OpISub %uchar %3497 %3498
+OpStore %1704 %3499
+%3500 = OpLoad %_arr_uchar_uint_16 %743
+%3501 = OpCompositeExtract %uchar %3500 3
+OpStore %1705 %3501
+%3502 = OpLoad %_arr_uchar_uint_16 %755
+%3503 = OpCompositeExtract %uchar %3502 3
+OpStore %1706 %3503
+%3504 = OpLoad %uchar %1705
+%3505 = OpLoad %uchar %1706
+%3506 = OpISub %uchar %3504 %3505
+OpStore %1707 %3506
+%3507 = OpLoad %_arr_uchar_uint_16 %743
+%3508 = OpCompositeExtract %uchar %3507 4
+OpStore %1708 %3508
+%3509 = OpLoad %_arr_uchar_uint_16 %755
+%3510 = OpCompositeExtract %uchar %3509 4
+OpStore %1709 %3510
+%3511 = OpLoad %uchar %1708
+%3512 = OpLoad %uchar %1709
+%3513 = OpISub %uchar %3511 %3512
+OpStore %1710 %3513
+%3514 = OpLoad %_arr_uchar_uint_16 %743
+%3515 = OpCompositeExtract %uchar %3514 5
+OpStore %1711 %3515
+%3516 = OpLoad %_arr_uchar_uint_16 %755
+%3517 = OpCompositeExtract %uchar %3516 5
+OpStore %1712 %3517
+%3518 = OpLoad %uchar %1711
+%3519 = OpLoad %uchar %1712
+%3520 = OpISub %uchar %3518 %3519
+OpStore %1713 %3520
+%3521 = OpLoad %_arr_uchar_uint_16 %743
+%3522 = OpCompositeExtract %uchar %3521 6
+OpStore %1714 %3522
+%3523 = OpLoad %_arr_uchar_uint_16 %755
+%3524 = OpCompositeExtract %uchar %3523 6
+OpStore %1715 %3524
+%3525 = OpLoad %uchar %1714
+%3526 = OpLoad %uchar %1715
+%3527 = OpISub %uchar %3525 %3526
+OpStore %1716 %3527
+%3528 = OpLoad %_arr_uchar_uint_16 %743
+%3529 = OpCompositeExtract %uchar %3528 7
+OpStore %1717 %3529
+%3530 = OpLoad %_arr_uchar_uint_16 %755
+%3531 = OpCompositeExtract %uchar %3530 7
+OpStore %1718 %3531
+%3532 = OpLoad %uchar %1717
+%3533 = OpLoad %uchar %1718
+%3534 = OpISub %uchar %3532 %3533
+OpStore %1719 %3534
+%3535 = OpLoad %_arr_uchar_uint_16 %743
+%3536 = OpCompositeExtract %uchar %3535 8
+OpStore %1720 %3536
+%3537 = OpLoad %_arr_uchar_uint_16 %755
+%3538 = OpCompositeExtract %uchar %3537 8
+OpStore %1721 %3538
+%3539 = OpLoad %uchar %1720
+%3540 = OpLoad %uchar %1721
+%3541 = OpISub %uchar %3539 %3540
+OpStore %1722 %3541
+%3542 = OpLoad %_arr_uchar_uint_16 %743
+%3543 = OpCompositeExtract %uchar %3542 9
+OpStore %1723 %3543
+%3544 = OpLoad %_arr_uchar_uint_16 %755
+%3545 = OpCompositeExtract %uchar %3544 9
+OpStore %1724 %3545
+%3546 = OpLoad %uchar %1723
+%3547 = OpLoad %uchar %1724
+%3548 = OpISub %uchar %3546 %3547
+OpStore %1725 %3548
+%3549 = OpLoad %_arr_uchar_uint_16 %743
+%3550 = OpCompositeExtract %uchar %3549 10
+OpStore %1726 %3550
+%3551 = OpLoad %_arr_uchar_uint_16 %755
+%3552 = OpCompositeExtract %uchar %3551 10
+OpStore %1727 %3552
+%3553 = OpLoad %uchar %1726
+%3554 = OpLoad %uchar %1727
+%3555 = OpISub %uchar %3553 %3554
+OpStore %1728 %3555
+%3556 = OpLoad %_arr_uchar_uint_16 %743
+%3557 = OpCompositeExtract %uchar %3556 11
+OpStore %1729 %3557
+%3558 = OpLoad %_arr_uchar_uint_16 %755
+%3559 = OpCompositeExtract %uchar %3558 11
+OpStore %1730 %3559
+%3560 = OpLoad %uchar %1729
+%3561 = OpLoad %uchar %1730
+%3562 = OpISub %uchar %3560 %3561
+OpStore %1731 %3562
+%3563 = OpLoad %_arr_uchar_uint_16 %743
+%3564 = OpCompositeExtract %uchar %3563 12
+OpStore %1732 %3564
+%3565 = OpLoad %_arr_uchar_uint_16 %755
+%3566 = OpCompositeExtract %uchar %3565 12
+OpStore %1733 %3566
+%3567 = OpLoad %uchar %1732
+%3568 = OpLoad %uchar %1733
+%3569 = OpISub %uchar %3567 %3568
+OpStore %1734 %3569
+%3570 = OpLoad %_arr_uchar_uint_16 %743
+%3571 = OpCompositeExtract %uchar %3570 13
+OpStore %1735 %3571
+%3572 = OpLoad %_arr_uchar_uint_16 %755
+%3573 = OpCompositeExtract %uchar %3572 13
+OpStore %1736 %3573
+%3574 = OpLoad %uchar %1735
+%3575 = OpLoad %uchar %1736
+%3576 = OpISub %uchar %3574 %3575
+OpStore %1737 %3576
+%3577 = OpLoad %_arr_uchar_uint_16 %743
+%3578 = OpCompositeExtract %uchar %3577 14
+OpStore %1738 %3578
+%3579 = OpLoad %_arr_uchar_uint_16 %755
+%3580 = OpCompositeExtract %uchar %3579 14
+OpStore %1739 %3580
+%3581 = OpLoad %uchar %1738
+%3582 = OpLoad %uchar %1739
+%3583 = OpISub %uchar %3581 %3582
+OpStore %1740 %3583
+%3584 = OpLoad %_arr_uchar_uint_16 %743
+%3585 = OpCompositeExtract %uchar %3584 15
+OpStore %1741 %3585
+%3586 = OpLoad %_arr_uchar_uint_16 %755
+%3587 = OpCompositeExtract %uchar %3586 15
+OpStore %1742 %3587
+%3588 = OpLoad %uchar %1741
+%3589 = OpLoad %uchar %1742
+%3590 = OpISub %uchar %3588 %3589
+OpStore %1743 %3590
+%3591 = OpLoad %_arr_uchar_uint_16 %743
+%3592 = OpLoad %uchar %1698
+%3593 = OpCompositeInsert %_arr_uchar_uint_16 %3592 %3591 0
+OpStore %1744 %3593
+%3594 = OpLoad %_arr_uchar_uint_16 %1744
+%3595 = OpLoad %uchar %1701
+%3596 = OpCompositeInsert %_arr_uchar_uint_16 %3595 %3594 1
+OpStore %1745 %3596
+%3597 = OpLoad %_arr_uchar_uint_16 %1745
+%3598 = OpLoad %uchar %1704
+%3599 = OpCompositeInsert %_arr_uchar_uint_16 %3598 %3597 2
+OpStore %1746 %3599
+%3600 = OpLoad %_arr_uchar_uint_16 %1746
+%3601 = OpLoad %uchar %1707
+%3602 = OpCompositeInsert %_arr_uchar_uint_16 %3601 %3600 3
+OpStore %1747 %3602
+%3603 = OpLoad %_arr_uchar_uint_16 %1747
+%3604 = OpLoad %uchar %1710
+%3605 = OpCompositeInsert %_arr_uchar_uint_16 %3604 %3603 4
+OpStore %1748 %3605
+%3606 = OpLoad %_arr_uchar_uint_16 %1748
+%3607 = OpLoad %uchar %1713
+%3608 = OpCompositeInsert %_arr_uchar_uint_16 %3607 %3606 5
+OpStore %1749 %3608
+%3609 = OpLoad %_arr_uchar_uint_16 %1749
+%3610 = OpLoad %uchar %1716
+%3611 = OpCompositeInsert %_arr_uchar_uint_16 %3610 %3609 6
+OpStore %1750 %3611
+%3612 = OpLoad %_arr_uchar_uint_16 %1750
+%3613 = OpLoad %uchar %1719
+%3614 = OpCompositeInsert %_arr_uchar_uint_16 %3613 %3612 7
+OpStore %1751 %3614
+%3615 = OpLoad %_arr_uchar_uint_16 %1751
+%3616 = OpLoad %uchar %1722
+%3617 = OpCompositeInsert %_arr_uchar_uint_16 %3616 %3615 8
+OpStore %1752 %3617
+%3618 = OpLoad %_arr_uchar_uint_16 %1752
+%3619 = OpLoad %uchar %1725
+%3620 = OpCompositeInsert %_arr_uchar_uint_16 %3619 %3618 9
+OpStore %1753 %3620
+%3621 = OpLoad %_arr_uchar_uint_16 %1753
+%3622 = OpLoad %uchar %1728
+%3623 = OpCompositeInsert %_arr_uchar_uint_16 %3622 %3621 10
+OpStore %1754 %3623
+%3624 = OpLoad %_arr_uchar_uint_16 %1754
+%3625 = OpLoad %uchar %1731
+%3626 = OpCompositeInsert %_arr_uchar_uint_16 %3625 %3624 11
+OpStore %1755 %3626
+%3627 = OpLoad %_arr_uchar_uint_16 %1755
+%3628 = OpLoad %uchar %1734
+%3629 = OpCompositeInsert %_arr_uchar_uint_16 %3628 %3627 12
+OpStore %1756 %3629
+%3630 = OpLoad %_arr_uchar_uint_16 %1756
+%3631 = OpLoad %uchar %1737
+%3632 = OpCompositeInsert %_arr_uchar_uint_16 %3631 %3630 13
+OpStore %1757 %3632
+%3633 = OpLoad %_arr_uchar_uint_16 %1757
+%3634 = OpLoad %uchar %1740
+%3635 = OpCompositeInsert %_arr_uchar_uint_16 %3634 %3633 14
+OpStore %1758 %3635
+%3636 = OpLoad %_arr_uchar_uint_16 %1758
+%3637 = OpLoad %uchar %1743
+%3638 = OpCompositeInsert %_arr_uchar_uint_16 %3637 %3636 15
+OpStore %1759 %3638
+%3639 = OpLoad %ulong %765
+%3640 = OpLoad %_arr_uchar_uint_16 %1759
+%3641 = OpFunctionCall %ulong %1 %3639 %3640
+OpStore %766 %3641
+%3642 = OpLoad %_arr_uchar_uint_16 %749
+%3643 = OpCompositeExtract %uchar %3642 0
+OpStore %1760 %3643
+%3644 = OpLoad %_arr_uchar_uint_16 %755
+%3645 = OpCompositeExtract %uchar %3644 0
+OpStore %1761 %3645
+%3646 = OpLoad %uchar %1760
+%3647 = OpLoad %uchar %1761
+%3648 = OpBitwiseAnd %uchar %3646 %3647
+OpStore %1762 %3648
+%3649 = OpLoad %_arr_uchar_uint_16 %749
+%3650 = OpCompositeExtract %uchar %3649 1
+OpStore %1763 %3650
+%3651 = OpLoad %_arr_uchar_uint_16 %755
+%3652 = OpCompositeExtract %uchar %3651 1
+OpStore %1764 %3652
+%3653 = OpLoad %uchar %1763
+%3654 = OpLoad %uchar %1764
+%3655 = OpBitwiseAnd %uchar %3653 %3654
+OpStore %1765 %3655
+%3656 = OpLoad %_arr_uchar_uint_16 %749
+%3657 = OpCompositeExtract %uchar %3656 2
+OpStore %1766 %3657
+%3658 = OpLoad %_arr_uchar_uint_16 %755
+%3659 = OpCompositeExtract %uchar %3658 2
+OpStore %1767 %3659
+%3660 = OpLoad %uchar %1766
+%3661 = OpLoad %uchar %1767
+%3662 = OpBitwiseAnd %uchar %3660 %3661
+OpStore %1768 %3662
+%3663 = OpLoad %_arr_uchar_uint_16 %749
+%3664 = OpCompositeExtract %uchar %3663 3
+OpStore %1769 %3664
+%3665 = OpLoad %_arr_uchar_uint_16 %755
+%3666 = OpCompositeExtract %uchar %3665 3
+OpStore %1770 %3666
+%3667 = OpLoad %uchar %1769
+%3668 = OpLoad %uchar %1770
+%3669 = OpBitwiseAnd %uchar %3667 %3668
+OpStore %1771 %3669
+%3670 = OpLoad %_arr_uchar_uint_16 %749
+%3671 = OpCompositeExtract %uchar %3670 4
+OpStore %1772 %3671
+%3672 = OpLoad %_arr_uchar_uint_16 %755
+%3673 = OpCompositeExtract %uchar %3672 4
+OpStore %1773 %3673
+%3674 = OpLoad %uchar %1772
+%3675 = OpLoad %uchar %1773
+%3676 = OpBitwiseAnd %uchar %3674 %3675
+OpStore %1774 %3676
+%3677 = OpLoad %_arr_uchar_uint_16 %749
+%3678 = OpCompositeExtract %uchar %3677 5
+OpStore %1775 %3678
+%3679 = OpLoad %_arr_uchar_uint_16 %755
+%3680 = OpCompositeExtract %uchar %3679 5
+OpStore %1776 %3680
+%3681 = OpLoad %uchar %1775
+%3682 = OpLoad %uchar %1776
+%3683 = OpBitwiseAnd %uchar %3681 %3682
+OpStore %1777 %3683
+%3684 = OpLoad %_arr_uchar_uint_16 %749
+%3685 = OpCompositeExtract %uchar %3684 6
+OpStore %1778 %3685
+%3686 = OpLoad %_arr_uchar_uint_16 %755
+%3687 = OpCompositeExtract %uchar %3686 6
+OpStore %1779 %3687
+%3688 = OpLoad %uchar %1778
+%3689 = OpLoad %uchar %1779
+%3690 = OpBitwiseAnd %uchar %3688 %3689
+OpStore %1780 %3690
+%3691 = OpLoad %_arr_uchar_uint_16 %749
+%3692 = OpCompositeExtract %uchar %3691 7
+OpStore %1781 %3692
+%3693 = OpLoad %_arr_uchar_uint_16 %755
+%3694 = OpCompositeExtract %uchar %3693 7
+OpStore %1782 %3694
+%3695 = OpLoad %uchar %1781
+%3696 = OpLoad %uchar %1782
+%3697 = OpBitwiseAnd %uchar %3695 %3696
+OpStore %1783 %3697
+%3698 = OpLoad %_arr_uchar_uint_16 %749
+%3699 = OpCompositeExtract %uchar %3698 8
+OpStore %1784 %3699
+%3700 = OpLoad %_arr_uchar_uint_16 %755
+%3701 = OpCompositeExtract %uchar %3700 8
+OpStore %1785 %3701
+%3702 = OpLoad %uchar %1784
+%3703 = OpLoad %uchar %1785
+%3704 = OpBitwiseAnd %uchar %3702 %3703
+OpStore %1786 %3704
+%3705 = OpLoad %_arr_uchar_uint_16 %749
+%3706 = OpCompositeExtract %uchar %3705 9
+OpStore %1787 %3706
+%3707 = OpLoad %_arr_uchar_uint_16 %755
+%3708 = OpCompositeExtract %uchar %3707 9
+OpStore %1788 %3708
+%3709 = OpLoad %uchar %1787
+%3710 = OpLoad %uchar %1788
+%3711 = OpBitwiseAnd %uchar %3709 %3710
+OpStore %1789 %3711
+%3712 = OpLoad %_arr_uchar_uint_16 %749
+%3713 = OpCompositeExtract %uchar %3712 10
+OpStore %1790 %3713
+%3714 = OpLoad %_arr_uchar_uint_16 %755
+%3715 = OpCompositeExtract %uchar %3714 10
+OpStore %1791 %3715
+%3716 = OpLoad %uchar %1790
+%3717 = OpLoad %uchar %1791
+%3718 = OpBitwiseAnd %uchar %3716 %3717
+OpStore %1792 %3718
+%3719 = OpLoad %_arr_uchar_uint_16 %749
+%3720 = OpCompositeExtract %uchar %3719 11
+OpStore %1793 %3720
+%3721 = OpLoad %_arr_uchar_uint_16 %755
+%3722 = OpCompositeExtract %uchar %3721 11
+OpStore %1794 %3722
+%3723 = OpLoad %uchar %1793
+%3724 = OpLoad %uchar %1794
+%3725 = OpBitwiseAnd %uchar %3723 %3724
+OpStore %1795 %3725
+%3726 = OpLoad %_arr_uchar_uint_16 %749
+%3727 = OpCompositeExtract %uchar %3726 12
+OpStore %1796 %3727
+%3728 = OpLoad %_arr_uchar_uint_16 %755
+%3729 = OpCompositeExtract %uchar %3728 12
+OpStore %1797 %3729
+%3730 = OpLoad %uchar %1796
+%3731 = OpLoad %uchar %1797
+%3732 = OpBitwiseAnd %uchar %3730 %3731
+OpStore %1798 %3732
+%3733 = OpLoad %_arr_uchar_uint_16 %749
+%3734 = OpCompositeExtract %uchar %3733 13
+OpStore %1799 %3734
+%3735 = OpLoad %_arr_uchar_uint_16 %755
+%3736 = OpCompositeExtract %uchar %3735 13
+OpStore %1800 %3736
+%3737 = OpLoad %uchar %1799
+%3738 = OpLoad %uchar %1800
+%3739 = OpBitwiseAnd %uchar %3737 %3738
+OpStore %1801 %3739
+%3740 = OpLoad %_arr_uchar_uint_16 %749
+%3741 = OpCompositeExtract %uchar %3740 14
+OpStore %1802 %3741
+%3742 = OpLoad %_arr_uchar_uint_16 %755
+%3743 = OpCompositeExtract %uchar %3742 14
+OpStore %1803 %3743
+%3744 = OpLoad %uchar %1802
+%3745 = OpLoad %uchar %1803
+%3746 = OpBitwiseAnd %uchar %3744 %3745
+OpStore %1804 %3746
+%3747 = OpLoad %_arr_uchar_uint_16 %749
+%3748 = OpCompositeExtract %uchar %3747 15
+OpStore %1805 %3748
+%3749 = OpLoad %_arr_uchar_uint_16 %755
+%3750 = OpCompositeExtract %uchar %3749 15
+OpStore %1806 %3750
+%3751 = OpLoad %uchar %1805
+%3752 = OpLoad %uchar %1806
+%3753 = OpBitwiseAnd %uchar %3751 %3752
+OpStore %1807 %3753
+%3754 = OpLoad %_arr_uchar_uint_16 %749
+%3755 = OpLoad %uchar %1762
+%3756 = OpCompositeInsert %_arr_uchar_uint_16 %3755 %3754 0
+OpStore %1808 %3756
+%3757 = OpLoad %_arr_uchar_uint_16 %1808
+%3758 = OpLoad %uchar %1765
+%3759 = OpCompositeInsert %_arr_uchar_uint_16 %3758 %3757 1
+OpStore %1809 %3759
+%3760 = OpLoad %_arr_uchar_uint_16 %1809
+%3761 = OpLoad %uchar %1768
+%3762 = OpCompositeInsert %_arr_uchar_uint_16 %3761 %3760 2
+OpStore %1810 %3762
+%3763 = OpLoad %_arr_uchar_uint_16 %1810
+%3764 = OpLoad %uchar %1771
+%3765 = OpCompositeInsert %_arr_uchar_uint_16 %3764 %3763 3
+OpStore %1811 %3765
+%3766 = OpLoad %_arr_uchar_uint_16 %1811
+%3767 = OpLoad %uchar %1774
+%3768 = OpCompositeInsert %_arr_uchar_uint_16 %3767 %3766 4
+OpStore %1812 %3768
+%3769 = OpLoad %_arr_uchar_uint_16 %1812
+%3770 = OpLoad %uchar %1777
+%3771 = OpCompositeInsert %_arr_uchar_uint_16 %3770 %3769 5
+OpStore %1813 %3771
+%3772 = OpLoad %_arr_uchar_uint_16 %1813
+%3773 = OpLoad %uchar %1780
+%3774 = OpCompositeInsert %_arr_uchar_uint_16 %3773 %3772 6
+OpStore %1814 %3774
+%3775 = OpLoad %_arr_uchar_uint_16 %1814
+%3776 = OpLoad %uchar %1783
+%3777 = OpCompositeInsert %_arr_uchar_uint_16 %3776 %3775 7
+OpStore %1815 %3777
+%3778 = OpLoad %_arr_uchar_uint_16 %1815
+%3779 = OpLoad %uchar %1786
+%3780 = OpCompositeInsert %_arr_uchar_uint_16 %3779 %3778 8
+OpStore %1816 %3780
+%3781 = OpLoad %_arr_uchar_uint_16 %1816
+%3782 = OpLoad %uchar %1789
+%3783 = OpCompositeInsert %_arr_uchar_uint_16 %3782 %3781 9
+OpStore %1817 %3783
+%3784 = OpLoad %_arr_uchar_uint_16 %1817
+%3785 = OpLoad %uchar %1792
+%3786 = OpCompositeInsert %_arr_uchar_uint_16 %3785 %3784 10
+OpStore %1818 %3786
+%3787 = OpLoad %_arr_uchar_uint_16 %1818
+%3788 = OpLoad %uchar %1795
+%3789 = OpCompositeInsert %_arr_uchar_uint_16 %3788 %3787 11
+OpStore %1819 %3789
+%3790 = OpLoad %_arr_uchar_uint_16 %1819
+%3791 = OpLoad %uchar %1798
+%3792 = OpCompositeInsert %_arr_uchar_uint_16 %3791 %3790 12
+OpStore %1820 %3792
+%3793 = OpLoad %_arr_uchar_uint_16 %1820
+%3794 = OpLoad %uchar %1801
+%3795 = OpCompositeInsert %_arr_uchar_uint_16 %3794 %3793 13
+OpStore %1821 %3795
+%3796 = OpLoad %_arr_uchar_uint_16 %1821
+%3797 = OpLoad %uchar %1804
+%3798 = OpCompositeInsert %_arr_uchar_uint_16 %3797 %3796 14
+OpStore %1822 %3798
+%3799 = OpLoad %_arr_uchar_uint_16 %1822
+%3800 = OpLoad %uchar %1807
+%3801 = OpCompositeInsert %_arr_uchar_uint_16 %3800 %3799 15
+OpStore %1823 %3801
+%3802 = OpLoad %ulong %766
+%3803 = OpLoad %_arr_uchar_uint_16 %1823
+%3804 = OpFunctionCall %ulong %1 %3802 %3803
+OpStore %767 %3804
+%3805 = OpLoad %_arr_uchar_uint_16 %749
+%3806 = OpCompositeExtract %uchar %3805 0
+OpStore %1824 %3806
+%3807 = OpLoad %_arr_uchar_uint_16 %755
+%3808 = OpCompositeExtract %uchar %3807 0
+OpStore %1825 %3808
+%3809 = OpLoad %uchar %1824
+%3810 = OpLoad %uchar %1825
+%3811 = OpBitwiseOr %uchar %3809 %3810
+OpStore %1826 %3811
+%3812 = OpLoad %_arr_uchar_uint_16 %749
+%3813 = OpCompositeExtract %uchar %3812 1
+OpStore %1827 %3813
+%3814 = OpLoad %_arr_uchar_uint_16 %755
+%3815 = OpCompositeExtract %uchar %3814 1
+OpStore %1828 %3815
+%3816 = OpLoad %uchar %1827
+%3817 = OpLoad %uchar %1828
+%3818 = OpBitwiseOr %uchar %3816 %3817
+OpStore %1829 %3818
+%3819 = OpLoad %_arr_uchar_uint_16 %749
+%3820 = OpCompositeExtract %uchar %3819 2
+OpStore %1830 %3820
+%3821 = OpLoad %_arr_uchar_uint_16 %755
+%3822 = OpCompositeExtract %uchar %3821 2
+OpStore %1831 %3822
+%3823 = OpLoad %uchar %1830
+%3824 = OpLoad %uchar %1831
+%3825 = OpBitwiseOr %uchar %3823 %3824
+OpStore %1832 %3825
+%3826 = OpLoad %_arr_uchar_uint_16 %749
+%3827 = OpCompositeExtract %uchar %3826 3
+OpStore %1833 %3827
+%3828 = OpLoad %_arr_uchar_uint_16 %755
+%3829 = OpCompositeExtract %uchar %3828 3
+OpStore %1834 %3829
+%3830 = OpLoad %uchar %1833
+%3831 = OpLoad %uchar %1834
+%3832 = OpBitwiseOr %uchar %3830 %3831
+OpStore %1835 %3832
+%3833 = OpLoad %_arr_uchar_uint_16 %749
+%3834 = OpCompositeExtract %uchar %3833 4
+OpStore %1836 %3834
+%3835 = OpLoad %_arr_uchar_uint_16 %755
+%3836 = OpCompositeExtract %uchar %3835 4
+OpStore %1837 %3836
+%3837 = OpLoad %uchar %1836
+%3838 = OpLoad %uchar %1837
+%3839 = OpBitwiseOr %uchar %3837 %3838
+OpStore %1838 %3839
+%3840 = OpLoad %_arr_uchar_uint_16 %749
+%3841 = OpCompositeExtract %uchar %3840 5
+OpStore %1839 %3841
+%3842 = OpLoad %_arr_uchar_uint_16 %755
+%3843 = OpCompositeExtract %uchar %3842 5
+OpStore %1840 %3843
+%3844 = OpLoad %uchar %1839
+%3845 = OpLoad %uchar %1840
+%3846 = OpBitwiseOr %uchar %3844 %3845
+OpStore %1841 %3846
+%3847 = OpLoad %_arr_uchar_uint_16 %749
+%3848 = OpCompositeExtract %uchar %3847 6
+OpStore %1842 %3848
+%3849 = OpLoad %_arr_uchar_uint_16 %755
+%3850 = OpCompositeExtract %uchar %3849 6
+OpStore %1843 %3850
+%3851 = OpLoad %uchar %1842
+%3852 = OpLoad %uchar %1843
+%3853 = OpBitwiseOr %uchar %3851 %3852
+OpStore %1844 %3853
+%3854 = OpLoad %_arr_uchar_uint_16 %749
+%3855 = OpCompositeExtract %uchar %3854 7
+OpStore %1845 %3855
+%3856 = OpLoad %_arr_uchar_uint_16 %755
+%3857 = OpCompositeExtract %uchar %3856 7
+OpStore %1846 %3857
+%3858 = OpLoad %uchar %1845
+%3859 = OpLoad %uchar %1846
+%3860 = OpBitwiseOr %uchar %3858 %3859
+OpStore %1847 %3860
+%3861 = OpLoad %_arr_uchar_uint_16 %749
+%3862 = OpCompositeExtract %uchar %3861 8
+OpStore %1848 %3862
+%3863 = OpLoad %_arr_uchar_uint_16 %755
+%3864 = OpCompositeExtract %uchar %3863 8
+OpStore %1849 %3864
+%3865 = OpLoad %uchar %1848
+%3866 = OpLoad %uchar %1849
+%3867 = OpBitwiseOr %uchar %3865 %3866
+OpStore %1850 %3867
+%3868 = OpLoad %_arr_uchar_uint_16 %749
+%3869 = OpCompositeExtract %uchar %3868 9
+OpStore %1851 %3869
+%3870 = OpLoad %_arr_uchar_uint_16 %755
+%3871 = OpCompositeExtract %uchar %3870 9
+OpStore %1852 %3871
+%3872 = OpLoad %uchar %1851
+%3873 = OpLoad %uchar %1852
+%3874 = OpBitwiseOr %uchar %3872 %3873
+OpStore %1853 %3874
+%3875 = OpLoad %_arr_uchar_uint_16 %749
+%3876 = OpCompositeExtract %uchar %3875 10
+OpStore %1854 %3876
+%3877 = OpLoad %_arr_uchar_uint_16 %755
+%3878 = OpCompositeExtract %uchar %3877 10
+OpStore %1855 %3878
+%3879 = OpLoad %uchar %1854
+%3880 = OpLoad %uchar %1855
+%3881 = OpBitwiseOr %uchar %3879 %3880
+OpStore %1856 %3881
+%3882 = OpLoad %_arr_uchar_uint_16 %749
+%3883 = OpCompositeExtract %uchar %3882 11
+OpStore %1857 %3883
+%3884 = OpLoad %_arr_uchar_uint_16 %755
+%3885 = OpCompositeExtract %uchar %3884 11
+OpStore %1858 %3885
+%3886 = OpLoad %uchar %1857
+%3887 = OpLoad %uchar %1858
+%3888 = OpBitwiseOr %uchar %3886 %3887
+OpStore %1859 %3888
+%3889 = OpLoad %_arr_uchar_uint_16 %749
+%3890 = OpCompositeExtract %uchar %3889 12
+OpStore %1860 %3890
+%3891 = OpLoad %_arr_uchar_uint_16 %755
+%3892 = OpCompositeExtract %uchar %3891 12
+OpStore %1861 %3892
+%3893 = OpLoad %uchar %1860
+%3894 = OpLoad %uchar %1861
+%3895 = OpBitwiseOr %uchar %3893 %3894
+OpStore %1862 %3895
+%3896 = OpLoad %_arr_uchar_uint_16 %749
+%3897 = OpCompositeExtract %uchar %3896 13
+OpStore %1863 %3897
+%3898 = OpLoad %_arr_uchar_uint_16 %755
+%3899 = OpCompositeExtract %uchar %3898 13
+OpStore %1864 %3899
+%3900 = OpLoad %uchar %1863
+%3901 = OpLoad %uchar %1864
+%3902 = OpBitwiseOr %uchar %3900 %3901
+OpStore %1865 %3902
+%3903 = OpLoad %_arr_uchar_uint_16 %749
+%3904 = OpCompositeExtract %uchar %3903 14
+OpStore %1866 %3904
+%3905 = OpLoad %_arr_uchar_uint_16 %755
+%3906 = OpCompositeExtract %uchar %3905 14
+OpStore %1867 %3906
+%3907 = OpLoad %uchar %1866
+%3908 = OpLoad %uchar %1867
+%3909 = OpBitwiseOr %uchar %3907 %3908
+OpStore %1868 %3909
+%3910 = OpLoad %_arr_uchar_uint_16 %749
+%3911 = OpCompositeExtract %uchar %3910 15
+OpStore %1869 %3911
+%3912 = OpLoad %_arr_uchar_uint_16 %755
+%3913 = OpCompositeExtract %uchar %3912 15
+OpStore %1870 %3913
+%3914 = OpLoad %uchar %1869
+%3915 = OpLoad %uchar %1870
+%3916 = OpBitwiseOr %uchar %3914 %3915
+OpStore %1871 %3916
+%3917 = OpLoad %_arr_uchar_uint_16 %749
+%3918 = OpLoad %uchar %1826
+%3919 = OpCompositeInsert %_arr_uchar_uint_16 %3918 %3917 0
+OpStore %1872 %3919
+%3920 = OpLoad %_arr_uchar_uint_16 %1872
+%3921 = OpLoad %uchar %1829
+%3922 = OpCompositeInsert %_arr_uchar_uint_16 %3921 %3920 1
+OpStore %1873 %3922
+%3923 = OpLoad %_arr_uchar_uint_16 %1873
+%3924 = OpLoad %uchar %1832
+%3925 = OpCompositeInsert %_arr_uchar_uint_16 %3924 %3923 2
+OpStore %1874 %3925
+%3926 = OpLoad %_arr_uchar_uint_16 %1874
+%3927 = OpLoad %uchar %1835
+%3928 = OpCompositeInsert %_arr_uchar_uint_16 %3927 %3926 3
+OpStore %1875 %3928
+%3929 = OpLoad %_arr_uchar_uint_16 %1875
+%3930 = OpLoad %uchar %1838
+%3931 = OpCompositeInsert %_arr_uchar_uint_16 %3930 %3929 4
+OpStore %1876 %3931
+%3932 = OpLoad %_arr_uchar_uint_16 %1876
+%3933 = OpLoad %uchar %1841
+%3934 = OpCompositeInsert %_arr_uchar_uint_16 %3933 %3932 5
+OpStore %1877 %3934
+%3935 = OpLoad %_arr_uchar_uint_16 %1877
+%3936 = OpLoad %uchar %1844
+%3937 = OpCompositeInsert %_arr_uchar_uint_16 %3936 %3935 6
+OpStore %1878 %3937
+%3938 = OpLoad %_arr_uchar_uint_16 %1878
+%3939 = OpLoad %uchar %1847
+%3940 = OpCompositeInsert %_arr_uchar_uint_16 %3939 %3938 7
+OpStore %1879 %3940
+%3941 = OpLoad %_arr_uchar_uint_16 %1879
+%3942 = OpLoad %uchar %1850
+%3943 = OpCompositeInsert %_arr_uchar_uint_16 %3942 %3941 8
+OpStore %1880 %3943
+%3944 = OpLoad %_arr_uchar_uint_16 %1880
+%3945 = OpLoad %uchar %1853
+%3946 = OpCompositeInsert %_arr_uchar_uint_16 %3945 %3944 9
+OpStore %1881 %3946
+%3947 = OpLoad %_arr_uchar_uint_16 %1881
+%3948 = OpLoad %uchar %1856
+%3949 = OpCompositeInsert %_arr_uchar_uint_16 %3948 %3947 10
+OpStore %1882 %3949
+%3950 = OpLoad %_arr_uchar_uint_16 %1882
+%3951 = OpLoad %uchar %1859
+%3952 = OpCompositeInsert %_arr_uchar_uint_16 %3951 %3950 11
+OpStore %1883 %3952
+%3953 = OpLoad %_arr_uchar_uint_16 %1883
+%3954 = OpLoad %uchar %1862
+%3955 = OpCompositeInsert %_arr_uchar_uint_16 %3954 %3953 12
+OpStore %1884 %3955
+%3956 = OpLoad %_arr_uchar_uint_16 %1884
+%3957 = OpLoad %uchar %1865
+%3958 = OpCompositeInsert %_arr_uchar_uint_16 %3957 %3956 13
+OpStore %1885 %3958
+%3959 = OpLoad %_arr_uchar_uint_16 %1885
+%3960 = OpLoad %uchar %1868
+%3961 = OpCompositeInsert %_arr_uchar_uint_16 %3960 %3959 14
+OpStore %1886 %3961
+%3962 = OpLoad %_arr_uchar_uint_16 %1886
+%3963 = OpLoad %uchar %1871
+%3964 = OpCompositeInsert %_arr_uchar_uint_16 %3963 %3962 15
+OpStore %1887 %3964
+%3965 = OpLoad %ulong %767
+%3966 = OpLoad %_arr_uchar_uint_16 %1887
+%3967 = OpFunctionCall %ulong %1 %3965 %3966
+OpStore %768 %3967
+%3968 = OpLoad %_arr_uchar_uint_16 %749
+%3969 = OpCompositeExtract %uchar %3968 0
+OpStore %1888 %3969
+%3970 = OpLoad %_arr_uchar_uint_16 %755
+%3971 = OpCompositeExtract %uchar %3970 0
+OpStore %1889 %3971
+%3972 = OpLoad %uchar %1888
+%3973 = OpLoad %uchar %1889
+%3974 = OpBitwiseXor %uchar %3972 %3973
+OpStore %1890 %3974
+%3975 = OpLoad %_arr_uchar_uint_16 %749
+%3976 = OpCompositeExtract %uchar %3975 1
+OpStore %1891 %3976
+%3977 = OpLoad %_arr_uchar_uint_16 %755
+%3978 = OpCompositeExtract %uchar %3977 1
+OpStore %1892 %3978
+%3979 = OpLoad %uchar %1891
+%3980 = OpLoad %uchar %1892
+%3981 = OpBitwiseXor %uchar %3979 %3980
+OpStore %1893 %3981
+%3982 = OpLoad %_arr_uchar_uint_16 %749
+%3983 = OpCompositeExtract %uchar %3982 2
+OpStore %1894 %3983
+%3984 = OpLoad %_arr_uchar_uint_16 %755
+%3985 = OpCompositeExtract %uchar %3984 2
+OpStore %1895 %3985
+%3986 = OpLoad %uchar %1894
+%3987 = OpLoad %uchar %1895
+%3988 = OpBitwiseXor %uchar %3986 %3987
+OpStore %1896 %3988
+%3989 = OpLoad %_arr_uchar_uint_16 %749
+%3990 = OpCompositeExtract %uchar %3989 3
+OpStore %1897 %3990
+%3991 = OpLoad %_arr_uchar_uint_16 %755
+%3992 = OpCompositeExtract %uchar %3991 3
+OpStore %1898 %3992
+%3993 = OpLoad %uchar %1897
+%3994 = OpLoad %uchar %1898
+%3995 = OpBitwiseXor %uchar %3993 %3994
+OpStore %1899 %3995
+%3996 = OpLoad %_arr_uchar_uint_16 %749
+%3997 = OpCompositeExtract %uchar %3996 4
+OpStore %1900 %3997
+%3998 = OpLoad %_arr_uchar_uint_16 %755
+%3999 = OpCompositeExtract %uchar %3998 4
+OpStore %1901 %3999
+%4000 = OpLoad %uchar %1900
+%4001 = OpLoad %uchar %1901
+%4002 = OpBitwiseXor %uchar %4000 %4001
+OpStore %1902 %4002
+%4003 = OpLoad %_arr_uchar_uint_16 %749
+%4004 = OpCompositeExtract %uchar %4003 5
+OpStore %1903 %4004
+%4005 = OpLoad %_arr_uchar_uint_16 %755
+%4006 = OpCompositeExtract %uchar %4005 5
+OpStore %1904 %4006
+%4007 = OpLoad %uchar %1903
+%4008 = OpLoad %uchar %1904
+%4009 = OpBitwiseXor %uchar %4007 %4008
+OpStore %1905 %4009
+%4010 = OpLoad %_arr_uchar_uint_16 %749
+%4011 = OpCompositeExtract %uchar %4010 6
+OpStore %1906 %4011
+%4012 = OpLoad %_arr_uchar_uint_16 %755
+%4013 = OpCompositeExtract %uchar %4012 6
+OpStore %1907 %4013
+%4014 = OpLoad %uchar %1906
+%4015 = OpLoad %uchar %1907
+%4016 = OpBitwiseXor %uchar %4014 %4015
+OpStore %1908 %4016
+%4017 = OpLoad %_arr_uchar_uint_16 %749
+%4018 = OpCompositeExtract %uchar %4017 7
+OpStore %1909 %4018
+%4019 = OpLoad %_arr_uchar_uint_16 %755
+%4020 = OpCompositeExtract %uchar %4019 7
+OpStore %1910 %4020
+%4021 = OpLoad %uchar %1909
+%4022 = OpLoad %uchar %1910
+%4023 = OpBitwiseXor %uchar %4021 %4022
+OpStore %1911 %4023
+%4024 = OpLoad %_arr_uchar_uint_16 %749
+%4025 = OpCompositeExtract %uchar %4024 8
+OpStore %1912 %4025
+%4026 = OpLoad %_arr_uchar_uint_16 %755
+%4027 = OpCompositeExtract %uchar %4026 8
+OpStore %1913 %4027
+%4028 = OpLoad %uchar %1912
+%4029 = OpLoad %uchar %1913
+%4030 = OpBitwiseXor %uchar %4028 %4029
+OpStore %1914 %4030
+%4031 = OpLoad %_arr_uchar_uint_16 %749
+%4032 = OpCompositeExtract %uchar %4031 9
+OpStore %1915 %4032
+%4033 = OpLoad %_arr_uchar_uint_16 %755
+%4034 = OpCompositeExtract %uchar %4033 9
+OpStore %1916 %4034
+%4035 = OpLoad %uchar %1915
+%4036 = OpLoad %uchar %1916
+%4037 = OpBitwiseXor %uchar %4035 %4036
+OpStore %1917 %4037
+%4038 = OpLoad %_arr_uchar_uint_16 %749
+%4039 = OpCompositeExtract %uchar %4038 10
+OpStore %1918 %4039
+%4040 = OpLoad %_arr_uchar_uint_16 %755
+%4041 = OpCompositeExtract %uchar %4040 10
+OpStore %1919 %4041
+%4042 = OpLoad %uchar %1918
+%4043 = OpLoad %uchar %1919
+%4044 = OpBitwiseXor %uchar %4042 %4043
+OpStore %1920 %4044
+%4045 = OpLoad %_arr_uchar_uint_16 %749
+%4046 = OpCompositeExtract %uchar %4045 11
+OpStore %1921 %4046
+%4047 = OpLoad %_arr_uchar_uint_16 %755
+%4048 = OpCompositeExtract %uchar %4047 11
+OpStore %1922 %4048
+%4049 = OpLoad %uchar %1921
+%4050 = OpLoad %uchar %1922
+%4051 = OpBitwiseXor %uchar %4049 %4050
+OpStore %1923 %4051
+%4052 = OpLoad %_arr_uchar_uint_16 %749
+%4053 = OpCompositeExtract %uchar %4052 12
+OpStore %1924 %4053
+%4054 = OpLoad %_arr_uchar_uint_16 %755
+%4055 = OpCompositeExtract %uchar %4054 12
+OpStore %1925 %4055
+%4056 = OpLoad %uchar %1924
+%4057 = OpLoad %uchar %1925
+%4058 = OpBitwiseXor %uchar %4056 %4057
+OpStore %1926 %4058
+%4059 = OpLoad %_arr_uchar_uint_16 %749
+%4060 = OpCompositeExtract %uchar %4059 13
+OpStore %1927 %4060
+%4061 = OpLoad %_arr_uchar_uint_16 %755
+%4062 = OpCompositeExtract %uchar %4061 13
+OpStore %1928 %4062
+%4063 = OpLoad %uchar %1927
+%4064 = OpLoad %uchar %1928
+%4065 = OpBitwiseXor %uchar %4063 %4064
+OpStore %1929 %4065
+%4066 = OpLoad %_arr_uchar_uint_16 %749
+%4067 = OpCompositeExtract %uchar %4066 14
+OpStore %1930 %4067
+%4068 = OpLoad %_arr_uchar_uint_16 %755
+%4069 = OpCompositeExtract %uchar %4068 14
+OpStore %1931 %4069
+%4070 = OpLoad %uchar %1930
+%4071 = OpLoad %uchar %1931
+%4072 = OpBitwiseXor %uchar %4070 %4071
+OpStore %1932 %4072
+%4073 = OpLoad %_arr_uchar_uint_16 %749
+%4074 = OpCompositeExtract %uchar %4073 15
+OpStore %1933 %4074
+%4075 = OpLoad %_arr_uchar_uint_16 %755
+%4076 = OpCompositeExtract %uchar %4075 15
+OpStore %1934 %4076
+%4077 = OpLoad %uchar %1933
+%4078 = OpLoad %uchar %1934
+%4079 = OpBitwiseXor %uchar %4077 %4078
+OpStore %1935 %4079
+%4080 = OpLoad %_arr_uchar_uint_16 %749
+%4081 = OpLoad %uchar %1890
+%4082 = OpCompositeInsert %_arr_uchar_uint_16 %4081 %4080 0
+OpStore %1936 %4082
+%4083 = OpLoad %_arr_uchar_uint_16 %1936
+%4084 = OpLoad %uchar %1893
+%4085 = OpCompositeInsert %_arr_uchar_uint_16 %4084 %4083 1
+OpStore %1937 %4085
+%4086 = OpLoad %_arr_uchar_uint_16 %1937
+%4087 = OpLoad %uchar %1896
+%4088 = OpCompositeInsert %_arr_uchar_uint_16 %4087 %4086 2
+OpStore %1938 %4088
+%4089 = OpLoad %_arr_uchar_uint_16 %1938
+%4090 = OpLoad %uchar %1899
+%4091 = OpCompositeInsert %_arr_uchar_uint_16 %4090 %4089 3
+OpStore %1939 %4091
+%4092 = OpLoad %_arr_uchar_uint_16 %1939
+%4093 = OpLoad %uchar %1902
+%4094 = OpCompositeInsert %_arr_uchar_uint_16 %4093 %4092 4
+OpStore %1940 %4094
+%4095 = OpLoad %_arr_uchar_uint_16 %1940
+%4096 = OpLoad %uchar %1905
+%4097 = OpCompositeInsert %_arr_uchar_uint_16 %4096 %4095 5
+OpStore %1941 %4097
+%4098 = OpLoad %_arr_uchar_uint_16 %1941
+%4099 = OpLoad %uchar %1908
+%4100 = OpCompositeInsert %_arr_uchar_uint_16 %4099 %4098 6
+OpStore %1942 %4100
+%4101 = OpLoad %_arr_uchar_uint_16 %1942
+%4102 = OpLoad %uchar %1911
+%4103 = OpCompositeInsert %_arr_uchar_uint_16 %4102 %4101 7
+OpStore %1943 %4103
+%4104 = OpLoad %_arr_uchar_uint_16 %1943
+%4105 = OpLoad %uchar %1914
+%4106 = OpCompositeInsert %_arr_uchar_uint_16 %4105 %4104 8
+OpStore %1944 %4106
+%4107 = OpLoad %_arr_uchar_uint_16 %1944
+%4108 = OpLoad %uchar %1917
+%4109 = OpCompositeInsert %_arr_uchar_uint_16 %4108 %4107 9
+OpStore %1945 %4109
+%4110 = OpLoad %_arr_uchar_uint_16 %1945
+%4111 = OpLoad %uchar %1920
+%4112 = OpCompositeInsert %_arr_uchar_uint_16 %4111 %4110 10
+OpStore %1946 %4112
+%4113 = OpLoad %_arr_uchar_uint_16 %1946
+%4114 = OpLoad %uchar %1923
+%4115 = OpCompositeInsert %_arr_uchar_uint_16 %4114 %4113 11
+OpStore %1947 %4115
+%4116 = OpLoad %_arr_uchar_uint_16 %1947
+%4117 = OpLoad %uchar %1926
+%4118 = OpCompositeInsert %_arr_uchar_uint_16 %4117 %4116 12
+OpStore %1948 %4118
+%4119 = OpLoad %_arr_uchar_uint_16 %1948
+%4120 = OpLoad %uchar %1929
+%4121 = OpCompositeInsert %_arr_uchar_uint_16 %4120 %4119 13
+OpStore %1949 %4121
+%4122 = OpLoad %_arr_uchar_uint_16 %1949
+%4123 = OpLoad %uchar %1932
+%4124 = OpCompositeInsert %_arr_uchar_uint_16 %4123 %4122 14
+OpStore %1950 %4124
+%4125 = OpLoad %_arr_uchar_uint_16 %1950
+%4126 = OpLoad %uchar %1935
+%4127 = OpCompositeInsert %_arr_uchar_uint_16 %4126 %4125 15
+OpStore %1951 %4127
+%4128 = OpLoad %ulong %768
+%4129 = OpLoad %_arr_uchar_uint_16 %1951
+%4130 = OpFunctionCall %ulong %1 %4128 %4129
+OpStore %769 %4130
+%4131 = OpLoad %_arr_uchar_uint_16 %749
+%4132 = OpCompositeExtract %uchar %4131 0
+OpStore %1952 %4132
+%4133 = OpLoad %uchar %1952
+%4134 = OpNot %uchar %4133
+OpStore %1953 %4134
+%4135 = OpLoad %_arr_uchar_uint_16 %749
+%4136 = OpCompositeExtract %uchar %4135 1
+OpStore %1954 %4136
+%4137 = OpLoad %uchar %1954
+%4138 = OpNot %uchar %4137
+OpStore %1955 %4138
+%4139 = OpLoad %_arr_uchar_uint_16 %749
+%4140 = OpCompositeExtract %uchar %4139 2
+OpStore %1956 %4140
+%4141 = OpLoad %uchar %1956
+%4142 = OpNot %uchar %4141
+OpStore %1957 %4142
+%4143 = OpLoad %_arr_uchar_uint_16 %749
+%4144 = OpCompositeExtract %uchar %4143 3
+OpStore %1958 %4144
+%4145 = OpLoad %uchar %1958
+%4146 = OpNot %uchar %4145
+OpStore %1959 %4146
+%4147 = OpLoad %_arr_uchar_uint_16 %749
+%4148 = OpCompositeExtract %uchar %4147 4
+OpStore %1960 %4148
+%4149 = OpLoad %uchar %1960
+%4150 = OpNot %uchar %4149
+OpStore %1961 %4150
+%4151 = OpLoad %_arr_uchar_uint_16 %749
+%4152 = OpCompositeExtract %uchar %4151 5
+OpStore %1962 %4152
+%4153 = OpLoad %uchar %1962
+%4154 = OpNot %uchar %4153
+OpStore %1963 %4154
+%4155 = OpLoad %_arr_uchar_uint_16 %749
+%4156 = OpCompositeExtract %uchar %4155 6
+OpStore %1964 %4156
+%4157 = OpLoad %uchar %1964
+%4158 = OpNot %uchar %4157
+OpStore %1965 %4158
+%4159 = OpLoad %_arr_uchar_uint_16 %749
+%4160 = OpCompositeExtract %uchar %4159 7
+OpStore %1966 %4160
+%4161 = OpLoad %uchar %1966
+%4162 = OpNot %uchar %4161
+OpStore %1967 %4162
+%4163 = OpLoad %_arr_uchar_uint_16 %749
+%4164 = OpCompositeExtract %uchar %4163 8
+OpStore %1968 %4164
+%4165 = OpLoad %uchar %1968
+%4166 = OpNot %uchar %4165
+OpStore %1969 %4166
+%4167 = OpLoad %_arr_uchar_uint_16 %749
+%4168 = OpCompositeExtract %uchar %4167 9
+OpStore %1970 %4168
+%4169 = OpLoad %uchar %1970
+%4170 = OpNot %uchar %4169
+OpStore %1971 %4170
+%4171 = OpLoad %_arr_uchar_uint_16 %749
+%4172 = OpCompositeExtract %uchar %4171 10
+OpStore %1972 %4172
+%4173 = OpLoad %uchar %1972
+%4174 = OpNot %uchar %4173
+OpStore %1973 %4174
+%4175 = OpLoad %_arr_uchar_uint_16 %749
+%4176 = OpCompositeExtract %uchar %4175 11
+OpStore %1974 %4176
+%4177 = OpLoad %uchar %1974
+%4178 = OpNot %uchar %4177
+OpStore %1975 %4178
+%4179 = OpLoad %_arr_uchar_uint_16 %749
+%4180 = OpCompositeExtract %uchar %4179 12
+OpStore %1976 %4180
+%4181 = OpLoad %uchar %1976
+%4182 = OpNot %uchar %4181
+OpStore %1977 %4182
+%4183 = OpLoad %_arr_uchar_uint_16 %749
+%4184 = OpCompositeExtract %uchar %4183 13
+OpStore %1978 %4184
+%4185 = OpLoad %uchar %1978
+%4186 = OpNot %uchar %4185
+OpStore %1979 %4186
+%4187 = OpLoad %_arr_uchar_uint_16 %749
+%4188 = OpCompositeExtract %uchar %4187 14
+OpStore %1980 %4188
+%4189 = OpLoad %uchar %1980
+%4190 = OpNot %uchar %4189
+OpStore %1981 %4190
+%4191 = OpLoad %_arr_uchar_uint_16 %749
+%4192 = OpCompositeExtract %uchar %4191 15
+OpStore %1982 %4192
+%4193 = OpLoad %uchar %1982
+%4194 = OpNot %uchar %4193
+OpStore %1983 %4194
+%4195 = OpLoad %_arr_uchar_uint_16 %749
+%4196 = OpLoad %uchar %1953
+%4197 = OpCompositeInsert %_arr_uchar_uint_16 %4196 %4195 0
+OpStore %1984 %4197
+%4198 = OpLoad %_arr_uchar_uint_16 %1984
+%4199 = OpLoad %uchar %1955
+%4200 = OpCompositeInsert %_arr_uchar_uint_16 %4199 %4198 1
+OpStore %1985 %4200
+%4201 = OpLoad %_arr_uchar_uint_16 %1985
+%4202 = OpLoad %uchar %1957
+%4203 = OpCompositeInsert %_arr_uchar_uint_16 %4202 %4201 2
+OpStore %1986 %4203
+%4204 = OpLoad %_arr_uchar_uint_16 %1986
+%4205 = OpLoad %uchar %1959
+%4206 = OpCompositeInsert %_arr_uchar_uint_16 %4205 %4204 3
+OpStore %1987 %4206
+%4207 = OpLoad %_arr_uchar_uint_16 %1987
+%4208 = OpLoad %uchar %1961
+%4209 = OpCompositeInsert %_arr_uchar_uint_16 %4208 %4207 4
+OpStore %1988 %4209
+%4210 = OpLoad %_arr_uchar_uint_16 %1988
+%4211 = OpLoad %uchar %1963
+%4212 = OpCompositeInsert %_arr_uchar_uint_16 %4211 %4210 5
+OpStore %1989 %4212
+%4213 = OpLoad %_arr_uchar_uint_16 %1989
+%4214 = OpLoad %uchar %1965
+%4215 = OpCompositeInsert %_arr_uchar_uint_16 %4214 %4213 6
+OpStore %1990 %4215
+%4216 = OpLoad %_arr_uchar_uint_16 %1990
+%4217 = OpLoad %uchar %1967
+%4218 = OpCompositeInsert %_arr_uchar_uint_16 %4217 %4216 7
+OpStore %1991 %4218
+%4219 = OpLoad %_arr_uchar_uint_16 %1991
+%4220 = OpLoad %uchar %1969
+%4221 = OpCompositeInsert %_arr_uchar_uint_16 %4220 %4219 8
+OpStore %1992 %4221
+%4222 = OpLoad %_arr_uchar_uint_16 %1992
+%4223 = OpLoad %uchar %1971
+%4224 = OpCompositeInsert %_arr_uchar_uint_16 %4223 %4222 9
+OpStore %1993 %4224
+%4225 = OpLoad %_arr_uchar_uint_16 %1993
+%4226 = OpLoad %uchar %1973
+%4227 = OpCompositeInsert %_arr_uchar_uint_16 %4226 %4225 10
+OpStore %1994 %4227
+%4228 = OpLoad %_arr_uchar_uint_16 %1994
+%4229 = OpLoad %uchar %1975
+%4230 = OpCompositeInsert %_arr_uchar_uint_16 %4229 %4228 11
+OpStore %1995 %4230
+%4231 = OpLoad %_arr_uchar_uint_16 %1995
+%4232 = OpLoad %uchar %1977
+%4233 = OpCompositeInsert %_arr_uchar_uint_16 %4232 %4231 12
+OpStore %1996 %4233
+%4234 = OpLoad %_arr_uchar_uint_16 %1996
+%4235 = OpLoad %uchar %1979
+%4236 = OpCompositeInsert %_arr_uchar_uint_16 %4235 %4234 13
+OpStore %1997 %4236
+%4237 = OpLoad %_arr_uchar_uint_16 %1997
+%4238 = OpLoad %uchar %1981
+%4239 = OpCompositeInsert %_arr_uchar_uint_16 %4238 %4237 14
+OpStore %1998 %4239
+%4240 = OpLoad %_arr_uchar_uint_16 %1998
+%4241 = OpLoad %uchar %1983
+%4242 = OpCompositeInsert %_arr_uchar_uint_16 %4241 %4240 15
+OpStore %1999 %4242
+%4243 = OpLoad %ulong %769
+%4244 = OpLoad %_arr_uchar_uint_16 %1999
+%4245 = OpFunctionCall %ulong %1 %4243 %4244
+OpStore %770 %4245
+%4246 = OpLoad %_arr_uchar_uint_16 %755
+%4247 = OpCompositeExtract %uchar %4246 0
+OpStore %2000 %4247
+%4248 = OpLoad %uchar %2000
+%4249 = OpNot %uchar %4248
+OpStore %2001 %4249
+%4250 = OpLoad %_arr_uchar_uint_16 %755
+%4251 = OpCompositeExtract %uchar %4250 1
+OpStore %2002 %4251
+%4252 = OpLoad %uchar %2002
+%4253 = OpNot %uchar %4252
+OpStore %2003 %4253
+%4254 = OpLoad %_arr_uchar_uint_16 %755
+%4255 = OpCompositeExtract %uchar %4254 2
+OpStore %2004 %4255
+%4256 = OpLoad %uchar %2004
+%4257 = OpNot %uchar %4256
+OpStore %2005 %4257
+%4258 = OpLoad %_arr_uchar_uint_16 %755
+%4259 = OpCompositeExtract %uchar %4258 3
+OpStore %2006 %4259
+%4260 = OpLoad %uchar %2006
+%4261 = OpNot %uchar %4260
+OpStore %2007 %4261
+%4262 = OpLoad %_arr_uchar_uint_16 %755
+%4263 = OpCompositeExtract %uchar %4262 4
+OpStore %2008 %4263
+%4264 = OpLoad %uchar %2008
+%4265 = OpNot %uchar %4264
+OpStore %2009 %4265
+%4266 = OpLoad %_arr_uchar_uint_16 %755
+%4267 = OpCompositeExtract %uchar %4266 5
+OpStore %2010 %4267
+%4268 = OpLoad %uchar %2010
+%4269 = OpNot %uchar %4268
+OpStore %2011 %4269
+%4270 = OpLoad %_arr_uchar_uint_16 %755
+%4271 = OpCompositeExtract %uchar %4270 6
+OpStore %2012 %4271
+%4272 = OpLoad %uchar %2012
+%4273 = OpNot %uchar %4272
+OpStore %2013 %4273
+%4274 = OpLoad %_arr_uchar_uint_16 %755
+%4275 = OpCompositeExtract %uchar %4274 7
+OpStore %2014 %4275
+%4276 = OpLoad %uchar %2014
+%4277 = OpNot %uchar %4276
+OpStore %2015 %4277
+%4278 = OpLoad %_arr_uchar_uint_16 %755
+%4279 = OpCompositeExtract %uchar %4278 8
+OpStore %2016 %4279
+%4280 = OpLoad %uchar %2016
+%4281 = OpNot %uchar %4280
+OpStore %2017 %4281
+%4282 = OpLoad %_arr_uchar_uint_16 %755
+%4283 = OpCompositeExtract %uchar %4282 9
+OpStore %2018 %4283
+%4284 = OpLoad %uchar %2018
+%4285 = OpNot %uchar %4284
+OpStore %2019 %4285
+%4286 = OpLoad %_arr_uchar_uint_16 %755
+%4287 = OpCompositeExtract %uchar %4286 10
+OpStore %2020 %4287
+%4288 = OpLoad %uchar %2020
+%4289 = OpNot %uchar %4288
+OpStore %2021 %4289
+%4290 = OpLoad %_arr_uchar_uint_16 %755
+%4291 = OpCompositeExtract %uchar %4290 11
+OpStore %2022 %4291
+%4292 = OpLoad %uchar %2022
+%4293 = OpNot %uchar %4292
+OpStore %2023 %4293
+%4294 = OpLoad %_arr_uchar_uint_16 %755
+%4295 = OpCompositeExtract %uchar %4294 12
+OpStore %2024 %4295
+%4296 = OpLoad %uchar %2024
+%4297 = OpNot %uchar %4296
+OpStore %2025 %4297
+%4298 = OpLoad %_arr_uchar_uint_16 %755
+%4299 = OpCompositeExtract %uchar %4298 13
+OpStore %2026 %4299
+%4300 = OpLoad %uchar %2026
+%4301 = OpNot %uchar %4300
+OpStore %2027 %4301
+%4302 = OpLoad %_arr_uchar_uint_16 %755
+%4303 = OpCompositeExtract %uchar %4302 14
+OpStore %2028 %4303
+%4304 = OpLoad %uchar %2028
+%4305 = OpNot %uchar %4304
+OpStore %2029 %4305
+%4306 = OpLoad %_arr_uchar_uint_16 %755
+%4307 = OpCompositeExtract %uchar %4306 15
+OpStore %2030 %4307
+%4308 = OpLoad %uchar %2030
+%4309 = OpNot %uchar %4308
+OpStore %2031 %4309
+%4310 = OpLoad %_arr_uchar_uint_16 %755
+%4311 = OpLoad %uchar %2001
+%4312 = OpCompositeInsert %_arr_uchar_uint_16 %4311 %4310 0
+OpStore %2032 %4312
+%4313 = OpLoad %_arr_uchar_uint_16 %2032
+%4314 = OpLoad %uchar %2003
+%4315 = OpCompositeInsert %_arr_uchar_uint_16 %4314 %4313 1
+OpStore %2033 %4315
+%4316 = OpLoad %_arr_uchar_uint_16 %2033
+%4317 = OpLoad %uchar %2005
+%4318 = OpCompositeInsert %_arr_uchar_uint_16 %4317 %4316 2
+OpStore %2034 %4318
+%4319 = OpLoad %_arr_uchar_uint_16 %2034
+%4320 = OpLoad %uchar %2007
+%4321 = OpCompositeInsert %_arr_uchar_uint_16 %4320 %4319 3
+OpStore %2035 %4321
+%4322 = OpLoad %_arr_uchar_uint_16 %2035
+%4323 = OpLoad %uchar %2009
+%4324 = OpCompositeInsert %_arr_uchar_uint_16 %4323 %4322 4
+OpStore %2036 %4324
+%4325 = OpLoad %_arr_uchar_uint_16 %2036
+%4326 = OpLoad %uchar %2011
+%4327 = OpCompositeInsert %_arr_uchar_uint_16 %4326 %4325 5
+OpStore %2037 %4327
+%4328 = OpLoad %_arr_uchar_uint_16 %2037
+%4329 = OpLoad %uchar %2013
+%4330 = OpCompositeInsert %_arr_uchar_uint_16 %4329 %4328 6
+OpStore %2038 %4330
+%4331 = OpLoad %_arr_uchar_uint_16 %2038
+%4332 = OpLoad %uchar %2015
+%4333 = OpCompositeInsert %_arr_uchar_uint_16 %4332 %4331 7
+OpStore %2039 %4333
+%4334 = OpLoad %_arr_uchar_uint_16 %2039
+%4335 = OpLoad %uchar %2017
+%4336 = OpCompositeInsert %_arr_uchar_uint_16 %4335 %4334 8
+OpStore %2040 %4336
+%4337 = OpLoad %_arr_uchar_uint_16 %2040
+%4338 = OpLoad %uchar %2019
+%4339 = OpCompositeInsert %_arr_uchar_uint_16 %4338 %4337 9
+OpStore %2041 %4339
+%4340 = OpLoad %_arr_uchar_uint_16 %2041
+%4341 = OpLoad %uchar %2021
+%4342 = OpCompositeInsert %_arr_uchar_uint_16 %4341 %4340 10
+OpStore %2042 %4342
+%4343 = OpLoad %_arr_uchar_uint_16 %2042
+%4344 = OpLoad %uchar %2023
+%4345 = OpCompositeInsert %_arr_uchar_uint_16 %4344 %4343 11
+OpStore %2043 %4345
+%4346 = OpLoad %_arr_uchar_uint_16 %2043
+%4347 = OpLoad %uchar %2025
+%4348 = OpCompositeInsert %_arr_uchar_uint_16 %4347 %4346 12
+OpStore %2044 %4348
+%4349 = OpLoad %_arr_uchar_uint_16 %2044
+%4350 = OpLoad %uchar %2027
+%4351 = OpCompositeInsert %_arr_uchar_uint_16 %4350 %4349 13
+OpStore %2045 %4351
+%4352 = OpLoad %_arr_uchar_uint_16 %2045
+%4353 = OpLoad %uchar %2029
+%4354 = OpCompositeInsert %_arr_uchar_uint_16 %4353 %4352 14
+OpStore %2046 %4354
+%4355 = OpLoad %_arr_uchar_uint_16 %2046
+%4356 = OpLoad %uchar %2031
+%4357 = OpCompositeInsert %_arr_uchar_uint_16 %4356 %4355 15
+OpStore %2047 %4357
+%4358 = OpLoad %ulong %770
+%4359 = OpLoad %_arr_uchar_uint_16 %2047
+%4360 = OpFunctionCall %ulong %1 %4358 %4359
+OpStore %771 %4360
+%4361 = OpLoad %_arr_uchar_uint_16 %1823
+%4362 = OpCompositeExtract %uchar %4361 0
+OpStore %2048 %4362
+%4363 = OpLoad %_arr_uchar_uint_16 %1887
+%4364 = OpCompositeExtract %uchar %4363 0
+OpStore %2049 %4364
+%4365 = OpLoad %uchar %2048
+%4366 = OpLoad %uchar %2049
+%4367 = OpBitwiseXor %uchar %4365 %4366
+OpStore %2050 %4367
+%4368 = OpLoad %_arr_uchar_uint_16 %1823
+%4369 = OpCompositeExtract %uchar %4368 1
+OpStore %2051 %4369
+%4370 = OpLoad %_arr_uchar_uint_16 %1887
+%4371 = OpCompositeExtract %uchar %4370 1
+OpStore %2052 %4371
+%4372 = OpLoad %uchar %2051
+%4373 = OpLoad %uchar %2052
+%4374 = OpBitwiseXor %uchar %4372 %4373
+OpStore %2053 %4374
+%4375 = OpLoad %_arr_uchar_uint_16 %1823
+%4376 = OpCompositeExtract %uchar %4375 2
+OpStore %2054 %4376
+%4377 = OpLoad %_arr_uchar_uint_16 %1887
+%4378 = OpCompositeExtract %uchar %4377 2
+OpStore %2055 %4378
+%4379 = OpLoad %uchar %2054
+%4380 = OpLoad %uchar %2055
+%4381 = OpBitwiseXor %uchar %4379 %4380
+OpStore %2056 %4381
+%4382 = OpLoad %_arr_uchar_uint_16 %1823
+%4383 = OpCompositeExtract %uchar %4382 3
+OpStore %2057 %4383
+%4384 = OpLoad %_arr_uchar_uint_16 %1887
+%4385 = OpCompositeExtract %uchar %4384 3
+OpStore %2058 %4385
+%4386 = OpLoad %uchar %2057
+%4387 = OpLoad %uchar %2058
+%4388 = OpBitwiseXor %uchar %4386 %4387
+OpStore %2059 %4388
+%4389 = OpLoad %_arr_uchar_uint_16 %1823
+%4390 = OpCompositeExtract %uchar %4389 4
+OpStore %2060 %4390
+%4391 = OpLoad %_arr_uchar_uint_16 %1887
+%4392 = OpCompositeExtract %uchar %4391 4
+OpStore %2061 %4392
+%4393 = OpLoad %uchar %2060
+%4394 = OpLoad %uchar %2061
+%4395 = OpBitwiseXor %uchar %4393 %4394
+OpStore %2062 %4395
+%4396 = OpLoad %_arr_uchar_uint_16 %1823
+%4397 = OpCompositeExtract %uchar %4396 5
+OpStore %2063 %4397
+%4398 = OpLoad %_arr_uchar_uint_16 %1887
+%4399 = OpCompositeExtract %uchar %4398 5
+OpStore %2064 %4399
+%4400 = OpLoad %uchar %2063
+%4401 = OpLoad %uchar %2064
+%4402 = OpBitwiseXor %uchar %4400 %4401
+OpStore %2065 %4402
+%4403 = OpLoad %_arr_uchar_uint_16 %1823
+%4404 = OpCompositeExtract %uchar %4403 6
+OpStore %2066 %4404
+%4405 = OpLoad %_arr_uchar_uint_16 %1887
+%4406 = OpCompositeExtract %uchar %4405 6
+OpStore %2067 %4406
+%4407 = OpLoad %uchar %2066
+%4408 = OpLoad %uchar %2067
+%4409 = OpBitwiseXor %uchar %4407 %4408
+OpStore %2068 %4409
+%4410 = OpLoad %_arr_uchar_uint_16 %1823
+%4411 = OpCompositeExtract %uchar %4410 7
+OpStore %2069 %4411
+%4412 = OpLoad %_arr_uchar_uint_16 %1887
+%4413 = OpCompositeExtract %uchar %4412 7
+OpStore %2070 %4413
+%4414 = OpLoad %uchar %2069
+%4415 = OpLoad %uchar %2070
+%4416 = OpBitwiseXor %uchar %4414 %4415
+OpStore %2071 %4416
+%4417 = OpLoad %_arr_uchar_uint_16 %1823
+%4418 = OpCompositeExtract %uchar %4417 8
+OpStore %2072 %4418
+%4419 = OpLoad %_arr_uchar_uint_16 %1887
+%4420 = OpCompositeExtract %uchar %4419 8
+OpStore %2073 %4420
+%4421 = OpLoad %uchar %2072
+%4422 = OpLoad %uchar %2073
+%4423 = OpBitwiseXor %uchar %4421 %4422
+OpStore %2074 %4423
+%4424 = OpLoad %_arr_uchar_uint_16 %1823
+%4425 = OpCompositeExtract %uchar %4424 9
+OpStore %2075 %4425
+%4426 = OpLoad %_arr_uchar_uint_16 %1887
+%4427 = OpCompositeExtract %uchar %4426 9
+OpStore %2076 %4427
+%4428 = OpLoad %uchar %2075
+%4429 = OpLoad %uchar %2076
+%4430 = OpBitwiseXor %uchar %4428 %4429
+OpStore %2077 %4430
+%4431 = OpLoad %_arr_uchar_uint_16 %1823
+%4432 = OpCompositeExtract %uchar %4431 10
+OpStore %2078 %4432
+%4433 = OpLoad %_arr_uchar_uint_16 %1887
+%4434 = OpCompositeExtract %uchar %4433 10
+OpStore %2079 %4434
+%4435 = OpLoad %uchar %2078
+%4436 = OpLoad %uchar %2079
+%4437 = OpBitwiseXor %uchar %4435 %4436
+OpStore %2080 %4437
+%4438 = OpLoad %_arr_uchar_uint_16 %1823
+%4439 = OpCompositeExtract %uchar %4438 11
+OpStore %2081 %4439
+%4440 = OpLoad %_arr_uchar_uint_16 %1887
+%4441 = OpCompositeExtract %uchar %4440 11
+OpStore %2082 %4441
+%4442 = OpLoad %uchar %2081
+%4443 = OpLoad %uchar %2082
+%4444 = OpBitwiseXor %uchar %4442 %4443
+OpStore %2083 %4444
+%4445 = OpLoad %_arr_uchar_uint_16 %1823
+%4446 = OpCompositeExtract %uchar %4445 12
+OpStore %2084 %4446
+%4447 = OpLoad %_arr_uchar_uint_16 %1887
+%4448 = OpCompositeExtract %uchar %4447 12
+OpStore %2085 %4448
+%4449 = OpLoad %uchar %2084
+%4450 = OpLoad %uchar %2085
+%4451 = OpBitwiseXor %uchar %4449 %4450
+OpStore %2086 %4451
+%4452 = OpLoad %_arr_uchar_uint_16 %1823
+%4453 = OpCompositeExtract %uchar %4452 13
+OpStore %2087 %4453
+%4454 = OpLoad %_arr_uchar_uint_16 %1887
+%4455 = OpCompositeExtract %uchar %4454 13
+OpStore %2088 %4455
+%4456 = OpLoad %uchar %2087
+%4457 = OpLoad %uchar %2088
+%4458 = OpBitwiseXor %uchar %4456 %4457
+OpStore %2089 %4458
+%4459 = OpLoad %_arr_uchar_uint_16 %1823
+%4460 = OpCompositeExtract %uchar %4459 14
+OpStore %2090 %4460
+%4461 = OpLoad %_arr_uchar_uint_16 %1887
+%4462 = OpCompositeExtract %uchar %4461 14
+OpStore %2091 %4462
+%4463 = OpLoad %uchar %2090
+%4464 = OpLoad %uchar %2091
+%4465 = OpBitwiseXor %uchar %4463 %4464
+OpStore %2092 %4465
+%4466 = OpLoad %_arr_uchar_uint_16 %1823
+%4467 = OpCompositeExtract %uchar %4466 15
+OpStore %2093 %4467
+%4468 = OpLoad %_arr_uchar_uint_16 %1887
+%4469 = OpCompositeExtract %uchar %4468 15
+OpStore %2094 %4469
+%4470 = OpLoad %uchar %2093
+%4471 = OpLoad %uchar %2094
+%4472 = OpBitwiseXor %uchar %4470 %4471
+OpStore %2095 %4472
+%4473 = OpLoad %_arr_uchar_uint_16 %1823
+%4474 = OpLoad %uchar %2050
+%4475 = OpCompositeInsert %_arr_uchar_uint_16 %4474 %4473 0
+OpStore %2096 %4475
+%4476 = OpLoad %_arr_uchar_uint_16 %2096
+%4477 = OpLoad %uchar %2053
+%4478 = OpCompositeInsert %_arr_uchar_uint_16 %4477 %4476 1
+OpStore %2097 %4478
+%4479 = OpLoad %_arr_uchar_uint_16 %2097
+%4480 = OpLoad %uchar %2056
+%4481 = OpCompositeInsert %_arr_uchar_uint_16 %4480 %4479 2
+OpStore %2098 %4481
+%4482 = OpLoad %_arr_uchar_uint_16 %2098
+%4483 = OpLoad %uchar %2059
+%4484 = OpCompositeInsert %_arr_uchar_uint_16 %4483 %4482 3
+OpStore %2099 %4484
+%4485 = OpLoad %_arr_uchar_uint_16 %2099
+%4486 = OpLoad %uchar %2062
+%4487 = OpCompositeInsert %_arr_uchar_uint_16 %4486 %4485 4
+OpStore %2100 %4487
+%4488 = OpLoad %_arr_uchar_uint_16 %2100
+%4489 = OpLoad %uchar %2065
+%4490 = OpCompositeInsert %_arr_uchar_uint_16 %4489 %4488 5
+OpStore %2101 %4490
+%4491 = OpLoad %_arr_uchar_uint_16 %2101
+%4492 = OpLoad %uchar %2068
+%4493 = OpCompositeInsert %_arr_uchar_uint_16 %4492 %4491 6
+OpStore %2102 %4493
+%4494 = OpLoad %_arr_uchar_uint_16 %2102
+%4495 = OpLoad %uchar %2071
+%4496 = OpCompositeInsert %_arr_uchar_uint_16 %4495 %4494 7
+OpStore %2103 %4496
+%4497 = OpLoad %_arr_uchar_uint_16 %2103
+%4498 = OpLoad %uchar %2074
+%4499 = OpCompositeInsert %_arr_uchar_uint_16 %4498 %4497 8
+OpStore %2104 %4499
+%4500 = OpLoad %_arr_uchar_uint_16 %2104
+%4501 = OpLoad %uchar %2077
+%4502 = OpCompositeInsert %_arr_uchar_uint_16 %4501 %4500 9
+OpStore %2105 %4502
+%4503 = OpLoad %_arr_uchar_uint_16 %2105
+%4504 = OpLoad %uchar %2080
+%4505 = OpCompositeInsert %_arr_uchar_uint_16 %4504 %4503 10
+OpStore %2106 %4505
+%4506 = OpLoad %_arr_uchar_uint_16 %2106
+%4507 = OpLoad %uchar %2083
+%4508 = OpCompositeInsert %_arr_uchar_uint_16 %4507 %4506 11
+OpStore %2107 %4508
+%4509 = OpLoad %_arr_uchar_uint_16 %2107
+%4510 = OpLoad %uchar %2086
+%4511 = OpCompositeInsert %_arr_uchar_uint_16 %4510 %4509 12
+OpStore %2108 %4511
+%4512 = OpLoad %_arr_uchar_uint_16 %2108
+%4513 = OpLoad %uchar %2089
+%4514 = OpCompositeInsert %_arr_uchar_uint_16 %4513 %4512 13
+OpStore %2109 %4514
+%4515 = OpLoad %_arr_uchar_uint_16 %2109
+%4516 = OpLoad %uchar %2092
+%4517 = OpCompositeInsert %_arr_uchar_uint_16 %4516 %4515 14
+OpStore %2110 %4517
+%4518 = OpLoad %_arr_uchar_uint_16 %2110
+%4519 = OpLoad %uchar %2095
+%4520 = OpCompositeInsert %_arr_uchar_uint_16 %4519 %4518 15
+OpStore %2111 %4520
+%4521 = OpLoad %ulong %771
+%4522 = OpLoad %_arr_uchar_uint_16 %2111
+%4523 = OpFunctionCall %ulong %1 %4521 %4522
+OpStore %772 %4523
+%4524 = OpLoad %ulong %772
+OpStore %790 %4524
+%4525 = OpLoad %_arr_uchar_uint_16 %749
+OpStore %791 %4525
+%4526 = OpLoad %_arr_uchar_uint_16 %743
+OpStore %792 %4526
+%4527 = OpLoad %_arr_uchar_uint_16 %743
+OpStore %793 %4527
+OpStore %794 %ulong_0
+OpBranch %717
+%717 = OpLabel
+%4528 = OpLoad %ulong %794
+%4530 = OpULessThan %bool %4528 %ulong_3
+OpStore %773 %4530
+%4531 = OpLoad %bool %773
+OpLoopMerge %719 %730 None
+OpBranchConditional %4531 %718 %719
+%719 = OpLabel
+OpStore %734 %4532
+%4534 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_0
+%4535 = OpLoad %_arr_uchar_uint_16 %791
+OpStore %4534 %4535
+%4536 = OpLoad %_arr_uchar_uint_16 %791
+%4537 = OpCompositeExtract %uchar %4536 0
+OpStore %1056 %4537
+%4538 = OpLoad %_arr_uchar_uint_16 %755
+%4539 = OpCompositeExtract %uchar %4538 0
+OpStore %1057 %4539
+%4540 = OpLoad %uchar %1056
+%4541 = OpLoad %uchar %1057
+%4542 = OpIAdd %uchar %4540 %4541
+OpStore %1058 %4542
+%4543 = OpLoad %_arr_uchar_uint_16 %791
+%4544 = OpCompositeExtract %uchar %4543 1
+OpStore %1059 %4544
+%4545 = OpLoad %_arr_uchar_uint_16 %755
+%4546 = OpCompositeExtract %uchar %4545 1
+OpStore %1060 %4546
+%4547 = OpLoad %uchar %1059
+%4548 = OpLoad %uchar %1060
+%4549 = OpIAdd %uchar %4547 %4548
+OpStore %1061 %4549
+%4550 = OpLoad %_arr_uchar_uint_16 %791
+%4551 = OpCompositeExtract %uchar %4550 2
+OpStore %1062 %4551
+%4552 = OpLoad %_arr_uchar_uint_16 %755
+%4553 = OpCompositeExtract %uchar %4552 2
+OpStore %1063 %4553
+%4554 = OpLoad %uchar %1062
+%4555 = OpLoad %uchar %1063
+%4556 = OpIAdd %uchar %4554 %4555
+OpStore %1064 %4556
+%4557 = OpLoad %_arr_uchar_uint_16 %791
+%4558 = OpCompositeExtract %uchar %4557 3
+OpStore %1065 %4558
+%4559 = OpLoad %_arr_uchar_uint_16 %755
+%4560 = OpCompositeExtract %uchar %4559 3
+OpStore %1066 %4560
+%4561 = OpLoad %uchar %1065
+%4562 = OpLoad %uchar %1066
+%4563 = OpIAdd %uchar %4561 %4562
+OpStore %1067 %4563
+%4564 = OpLoad %_arr_uchar_uint_16 %791
+%4565 = OpCompositeExtract %uchar %4564 4
+OpStore %1068 %4565
+%4566 = OpLoad %_arr_uchar_uint_16 %755
+%4567 = OpCompositeExtract %uchar %4566 4
+OpStore %1069 %4567
+%4568 = OpLoad %uchar %1068
+%4569 = OpLoad %uchar %1069
+%4570 = OpIAdd %uchar %4568 %4569
+OpStore %1070 %4570
+%4571 = OpLoad %_arr_uchar_uint_16 %791
+%4572 = OpCompositeExtract %uchar %4571 5
+OpStore %1071 %4572
+%4573 = OpLoad %_arr_uchar_uint_16 %755
+%4574 = OpCompositeExtract %uchar %4573 5
+OpStore %1072 %4574
+%4575 = OpLoad %uchar %1071
+%4576 = OpLoad %uchar %1072
+%4577 = OpIAdd %uchar %4575 %4576
+OpStore %1073 %4577
+%4578 = OpLoad %_arr_uchar_uint_16 %791
+%4579 = OpCompositeExtract %uchar %4578 6
+OpStore %1074 %4579
+%4580 = OpLoad %_arr_uchar_uint_16 %755
+%4581 = OpCompositeExtract %uchar %4580 6
+OpStore %1075 %4581
+%4582 = OpLoad %uchar %1074
+%4583 = OpLoad %uchar %1075
+%4584 = OpIAdd %uchar %4582 %4583
+OpStore %1076 %4584
+%4585 = OpLoad %_arr_uchar_uint_16 %791
+%4586 = OpCompositeExtract %uchar %4585 7
+OpStore %1077 %4586
+%4587 = OpLoad %_arr_uchar_uint_16 %755
+%4588 = OpCompositeExtract %uchar %4587 7
+OpStore %1078 %4588
+%4589 = OpLoad %uchar %1077
+%4590 = OpLoad %uchar %1078
+%4591 = OpIAdd %uchar %4589 %4590
+OpStore %1079 %4591
+%4592 = OpLoad %_arr_uchar_uint_16 %791
+%4593 = OpCompositeExtract %uchar %4592 8
+OpStore %1080 %4593
+%4594 = OpLoad %_arr_uchar_uint_16 %755
+%4595 = OpCompositeExtract %uchar %4594 8
+OpStore %1081 %4595
+%4596 = OpLoad %uchar %1080
+%4597 = OpLoad %uchar %1081
+%4598 = OpIAdd %uchar %4596 %4597
+OpStore %1082 %4598
+%4599 = OpLoad %_arr_uchar_uint_16 %791
+%4600 = OpCompositeExtract %uchar %4599 9
+OpStore %1083 %4600
+%4601 = OpLoad %_arr_uchar_uint_16 %755
+%4602 = OpCompositeExtract %uchar %4601 9
+OpStore %1084 %4602
+%4603 = OpLoad %uchar %1083
+%4604 = OpLoad %uchar %1084
+%4605 = OpIAdd %uchar %4603 %4604
+OpStore %1085 %4605
+%4606 = OpLoad %_arr_uchar_uint_16 %791
+%4607 = OpCompositeExtract %uchar %4606 10
+OpStore %1086 %4607
+%4608 = OpLoad %_arr_uchar_uint_16 %755
+%4609 = OpCompositeExtract %uchar %4608 10
+OpStore %1087 %4609
+%4610 = OpLoad %uchar %1086
+%4611 = OpLoad %uchar %1087
+%4612 = OpIAdd %uchar %4610 %4611
+OpStore %1088 %4612
+%4613 = OpLoad %_arr_uchar_uint_16 %791
+%4614 = OpCompositeExtract %uchar %4613 11
+OpStore %1089 %4614
+%4615 = OpLoad %_arr_uchar_uint_16 %755
+%4616 = OpCompositeExtract %uchar %4615 11
+OpStore %1090 %4616
+%4617 = OpLoad %uchar %1089
+%4618 = OpLoad %uchar %1090
+%4619 = OpIAdd %uchar %4617 %4618
+OpStore %1091 %4619
+%4620 = OpLoad %_arr_uchar_uint_16 %791
+%4621 = OpCompositeExtract %uchar %4620 12
+OpStore %1092 %4621
+%4622 = OpLoad %_arr_uchar_uint_16 %755
+%4623 = OpCompositeExtract %uchar %4622 12
+OpStore %1093 %4623
+%4624 = OpLoad %uchar %1092
+%4625 = OpLoad %uchar %1093
+%4626 = OpIAdd %uchar %4624 %4625
+OpStore %1094 %4626
+%4627 = OpLoad %_arr_uchar_uint_16 %791
+%4628 = OpCompositeExtract %uchar %4627 13
+OpStore %1095 %4628
+%4629 = OpLoad %_arr_uchar_uint_16 %755
+%4630 = OpCompositeExtract %uchar %4629 13
+OpStore %1096 %4630
+%4631 = OpLoad %uchar %1095
+%4632 = OpLoad %uchar %1096
+%4633 = OpIAdd %uchar %4631 %4632
+OpStore %1097 %4633
+%4634 = OpLoad %_arr_uchar_uint_16 %791
+%4635 = OpCompositeExtract %uchar %4634 14
+OpStore %1098 %4635
+%4636 = OpLoad %_arr_uchar_uint_16 %755
+%4637 = OpCompositeExtract %uchar %4636 14
+OpStore %1099 %4637
+%4638 = OpLoad %uchar %1098
+%4639 = OpLoad %uchar %1099
+%4640 = OpIAdd %uchar %4638 %4639
+OpStore %1100 %4640
+%4641 = OpLoad %_arr_uchar_uint_16 %791
+%4642 = OpCompositeExtract %uchar %4641 15
+OpStore %1101 %4642
+%4643 = OpLoad %_arr_uchar_uint_16 %755
+%4644 = OpCompositeExtract %uchar %4643 15
+OpStore %1102 %4644
+%4645 = OpLoad %uchar %1101
+%4646 = OpLoad %uchar %1102
+%4647 = OpIAdd %uchar %4645 %4646
+OpStore %1103 %4647
+%4648 = OpLoad %_arr_uchar_uint_16 %791
+%4649 = OpLoad %uchar %1058
+%4650 = OpCompositeInsert %_arr_uchar_uint_16 %4649 %4648 0
+OpStore %1104 %4650
+%4651 = OpLoad %_arr_uchar_uint_16 %1104
+%4652 = OpLoad %uchar %1061
+%4653 = OpCompositeInsert %_arr_uchar_uint_16 %4652 %4651 1
+OpStore %1105 %4653
+%4654 = OpLoad %_arr_uchar_uint_16 %1105
+%4655 = OpLoad %uchar %1064
+%4656 = OpCompositeInsert %_arr_uchar_uint_16 %4655 %4654 2
+OpStore %1106 %4656
+%4657 = OpLoad %_arr_uchar_uint_16 %1106
+%4658 = OpLoad %uchar %1067
+%4659 = OpCompositeInsert %_arr_uchar_uint_16 %4658 %4657 3
+OpStore %1107 %4659
+%4660 = OpLoad %_arr_uchar_uint_16 %1107
+%4661 = OpLoad %uchar %1070
+%4662 = OpCompositeInsert %_arr_uchar_uint_16 %4661 %4660 4
+OpStore %1108 %4662
+%4663 = OpLoad %_arr_uchar_uint_16 %1108
+%4664 = OpLoad %uchar %1073
+%4665 = OpCompositeInsert %_arr_uchar_uint_16 %4664 %4663 5
+OpStore %1109 %4665
+%4666 = OpLoad %_arr_uchar_uint_16 %1109
+%4667 = OpLoad %uchar %1076
+%4668 = OpCompositeInsert %_arr_uchar_uint_16 %4667 %4666 6
+OpStore %1110 %4668
+%4669 = OpLoad %_arr_uchar_uint_16 %1110
+%4670 = OpLoad %uchar %1079
+%4671 = OpCompositeInsert %_arr_uchar_uint_16 %4670 %4669 7
+OpStore %1111 %4671
+%4672 = OpLoad %_arr_uchar_uint_16 %1111
+%4673 = OpLoad %uchar %1082
+%4674 = OpCompositeInsert %_arr_uchar_uint_16 %4673 %4672 8
+OpStore %1112 %4674
+%4675 = OpLoad %_arr_uchar_uint_16 %1112
+%4676 = OpLoad %uchar %1085
+%4677 = OpCompositeInsert %_arr_uchar_uint_16 %4676 %4675 9
+OpStore %1113 %4677
+%4678 = OpLoad %_arr_uchar_uint_16 %1113
+%4679 = OpLoad %uchar %1088
+%4680 = OpCompositeInsert %_arr_uchar_uint_16 %4679 %4678 10
+OpStore %1114 %4680
+%4681 = OpLoad %_arr_uchar_uint_16 %1114
+%4682 = OpLoad %uchar %1091
+%4683 = OpCompositeInsert %_arr_uchar_uint_16 %4682 %4681 11
+OpStore %1115 %4683
+%4684 = OpLoad %_arr_uchar_uint_16 %1115
+%4685 = OpLoad %uchar %1094
+%4686 = OpCompositeInsert %_arr_uchar_uint_16 %4685 %4684 12
+OpStore %1116 %4686
+%4687 = OpLoad %_arr_uchar_uint_16 %1116
+%4688 = OpLoad %uchar %1097
+%4689 = OpCompositeInsert %_arr_uchar_uint_16 %4688 %4687 13
+OpStore %1117 %4689
+%4690 = OpLoad %_arr_uchar_uint_16 %1117
+%4691 = OpLoad %uchar %1100
+%4692 = OpCompositeInsert %_arr_uchar_uint_16 %4691 %4690 14
+OpStore %1118 %4692
+%4693 = OpLoad %_arr_uchar_uint_16 %1118
+%4694 = OpLoad %uchar %1103
+%4695 = OpCompositeInsert %_arr_uchar_uint_16 %4694 %4693 15
+OpStore %1119 %4695
+%4697 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_1
+%4698 = OpLoad %_arr_uchar_uint_16 %1119
+OpStore %4697 %4698
+%4699 = OpLoad %_arr_uchar_uint_16 %791
+%4700 = OpCompositeExtract %uchar %4699 0
+OpStore %1120 %4700
+%4701 = OpLoad %_arr_uchar_uint_16 %742
+%4702 = OpCompositeExtract %uchar %4701 0
+OpStore %1121 %4702
+%4703 = OpLoad %uchar %1120
+%4704 = OpLoad %uchar %1121
+%4705 = OpIMul %uchar %4703 %4704
+OpStore %1122 %4705
+%4706 = OpLoad %_arr_uchar_uint_16 %791
+%4707 = OpCompositeExtract %uchar %4706 1
+OpStore %1123 %4707
+%4708 = OpLoad %_arr_uchar_uint_16 %742
+%4709 = OpCompositeExtract %uchar %4708 1
+OpStore %1124 %4709
+%4710 = OpLoad %uchar %1123
+%4711 = OpLoad %uchar %1124
+%4712 = OpIMul %uchar %4710 %4711
+OpStore %1125 %4712
+%4713 = OpLoad %_arr_uchar_uint_16 %791
+%4714 = OpCompositeExtract %uchar %4713 2
+OpStore %1126 %4714
+%4715 = OpLoad %_arr_uchar_uint_16 %742
+%4716 = OpCompositeExtract %uchar %4715 2
+OpStore %1127 %4716
+%4717 = OpLoad %uchar %1126
+%4718 = OpLoad %uchar %1127
+%4719 = OpIMul %uchar %4717 %4718
+OpStore %1128 %4719
+%4720 = OpLoad %_arr_uchar_uint_16 %791
+%4721 = OpCompositeExtract %uchar %4720 3
+OpStore %1129 %4721
+%4722 = OpLoad %_arr_uchar_uint_16 %742
+%4723 = OpCompositeExtract %uchar %4722 3
+OpStore %1130 %4723
+%4724 = OpLoad %uchar %1129
+%4725 = OpLoad %uchar %1130
+%4726 = OpIMul %uchar %4724 %4725
+OpStore %1131 %4726
+%4727 = OpLoad %_arr_uchar_uint_16 %791
+%4728 = OpCompositeExtract %uchar %4727 4
+OpStore %1132 %4728
+%4729 = OpLoad %_arr_uchar_uint_16 %742
+%4730 = OpCompositeExtract %uchar %4729 4
+OpStore %1133 %4730
+%4731 = OpLoad %uchar %1132
+%4732 = OpLoad %uchar %1133
+%4733 = OpIMul %uchar %4731 %4732
+OpStore %1134 %4733
+%4734 = OpLoad %_arr_uchar_uint_16 %791
+%4735 = OpCompositeExtract %uchar %4734 5
+OpStore %1135 %4735
+%4736 = OpLoad %_arr_uchar_uint_16 %742
+%4737 = OpCompositeExtract %uchar %4736 5
+OpStore %1136 %4737
+%4738 = OpLoad %uchar %1135
+%4739 = OpLoad %uchar %1136
+%4740 = OpIMul %uchar %4738 %4739
+OpStore %1137 %4740
+%4741 = OpLoad %_arr_uchar_uint_16 %791
+%4742 = OpCompositeExtract %uchar %4741 6
+OpStore %1138 %4742
+%4743 = OpLoad %_arr_uchar_uint_16 %742
+%4744 = OpCompositeExtract %uchar %4743 6
+OpStore %1139 %4744
+%4745 = OpLoad %uchar %1138
+%4746 = OpLoad %uchar %1139
+%4747 = OpIMul %uchar %4745 %4746
+OpStore %1140 %4747
+%4748 = OpLoad %_arr_uchar_uint_16 %791
+%4749 = OpCompositeExtract %uchar %4748 7
+OpStore %1141 %4749
+%4750 = OpLoad %_arr_uchar_uint_16 %742
+%4751 = OpCompositeExtract %uchar %4750 7
+OpStore %1142 %4751
+%4752 = OpLoad %uchar %1141
+%4753 = OpLoad %uchar %1142
+%4754 = OpIMul %uchar %4752 %4753
+OpStore %1143 %4754
+%4755 = OpLoad %_arr_uchar_uint_16 %791
+%4756 = OpCompositeExtract %uchar %4755 8
+OpStore %1144 %4756
+%4757 = OpLoad %_arr_uchar_uint_16 %742
+%4758 = OpCompositeExtract %uchar %4757 8
+OpStore %1145 %4758
+%4759 = OpLoad %uchar %1144
+%4760 = OpLoad %uchar %1145
+%4761 = OpIMul %uchar %4759 %4760
+OpStore %1146 %4761
+%4762 = OpLoad %_arr_uchar_uint_16 %791
+%4763 = OpCompositeExtract %uchar %4762 9
+OpStore %1147 %4763
+%4764 = OpLoad %_arr_uchar_uint_16 %742
+%4765 = OpCompositeExtract %uchar %4764 9
+OpStore %1148 %4765
+%4766 = OpLoad %uchar %1147
+%4767 = OpLoad %uchar %1148
+%4768 = OpIMul %uchar %4766 %4767
+OpStore %1149 %4768
+%4769 = OpLoad %_arr_uchar_uint_16 %791
+%4770 = OpCompositeExtract %uchar %4769 10
+OpStore %1150 %4770
+%4771 = OpLoad %_arr_uchar_uint_16 %742
+%4772 = OpCompositeExtract %uchar %4771 10
+OpStore %1151 %4772
+%4773 = OpLoad %uchar %1150
+%4774 = OpLoad %uchar %1151
+%4775 = OpIMul %uchar %4773 %4774
+OpStore %1152 %4775
+%4776 = OpLoad %_arr_uchar_uint_16 %791
+%4777 = OpCompositeExtract %uchar %4776 11
+OpStore %1153 %4777
+%4778 = OpLoad %_arr_uchar_uint_16 %742
+%4779 = OpCompositeExtract %uchar %4778 11
+OpStore %1154 %4779
+%4780 = OpLoad %uchar %1153
+%4781 = OpLoad %uchar %1154
+%4782 = OpIMul %uchar %4780 %4781
+OpStore %1155 %4782
+%4783 = OpLoad %_arr_uchar_uint_16 %791
+%4784 = OpCompositeExtract %uchar %4783 12
+OpStore %1156 %4784
+%4785 = OpLoad %_arr_uchar_uint_16 %742
+%4786 = OpCompositeExtract %uchar %4785 12
+OpStore %1157 %4786
+%4787 = OpLoad %uchar %1156
+%4788 = OpLoad %uchar %1157
+%4789 = OpIMul %uchar %4787 %4788
+OpStore %1158 %4789
+%4790 = OpLoad %_arr_uchar_uint_16 %791
+%4791 = OpCompositeExtract %uchar %4790 13
+OpStore %1159 %4791
+%4792 = OpLoad %_arr_uchar_uint_16 %742
+%4793 = OpCompositeExtract %uchar %4792 13
+OpStore %1160 %4793
+%4794 = OpLoad %uchar %1159
+%4795 = OpLoad %uchar %1160
+%4796 = OpIMul %uchar %4794 %4795
+OpStore %1161 %4796
+%4797 = OpLoad %_arr_uchar_uint_16 %791
+%4798 = OpCompositeExtract %uchar %4797 14
+OpStore %1162 %4798
+%4799 = OpLoad %_arr_uchar_uint_16 %742
+%4800 = OpCompositeExtract %uchar %4799 14
+OpStore %1163 %4800
+%4801 = OpLoad %uchar %1162
+%4802 = OpLoad %uchar %1163
+%4803 = OpIMul %uchar %4801 %4802
+OpStore %1164 %4803
+%4804 = OpLoad %_arr_uchar_uint_16 %791
+%4805 = OpCompositeExtract %uchar %4804 15
+OpStore %1165 %4805
+%4806 = OpLoad %_arr_uchar_uint_16 %742
+%4807 = OpCompositeExtract %uchar %4806 15
+OpStore %1166 %4807
+%4808 = OpLoad %uchar %1165
+%4809 = OpLoad %uchar %1166
+%4810 = OpIMul %uchar %4808 %4809
+OpStore %1167 %4810
+%4811 = OpLoad %_arr_uchar_uint_16 %791
+%4812 = OpLoad %uchar %1122
+%4813 = OpCompositeInsert %_arr_uchar_uint_16 %4812 %4811 0
+OpStore %1168 %4813
+%4814 = OpLoad %_arr_uchar_uint_16 %1168
+%4815 = OpLoad %uchar %1125
+%4816 = OpCompositeInsert %_arr_uchar_uint_16 %4815 %4814 1
+OpStore %1169 %4816
+%4817 = OpLoad %_arr_uchar_uint_16 %1169
+%4818 = OpLoad %uchar %1128
+%4819 = OpCompositeInsert %_arr_uchar_uint_16 %4818 %4817 2
+OpStore %1170 %4819
+%4820 = OpLoad %_arr_uchar_uint_16 %1170
+%4821 = OpLoad %uchar %1131
+%4822 = OpCompositeInsert %_arr_uchar_uint_16 %4821 %4820 3
+OpStore %1171 %4822
+%4823 = OpLoad %_arr_uchar_uint_16 %1171
+%4824 = OpLoad %uchar %1134
+%4825 = OpCompositeInsert %_arr_uchar_uint_16 %4824 %4823 4
+OpStore %1172 %4825
+%4826 = OpLoad %_arr_uchar_uint_16 %1172
+%4827 = OpLoad %uchar %1137
+%4828 = OpCompositeInsert %_arr_uchar_uint_16 %4827 %4826 5
+OpStore %1173 %4828
+%4829 = OpLoad %_arr_uchar_uint_16 %1173
+%4830 = OpLoad %uchar %1140
+%4831 = OpCompositeInsert %_arr_uchar_uint_16 %4830 %4829 6
+OpStore %1174 %4831
+%4832 = OpLoad %_arr_uchar_uint_16 %1174
+%4833 = OpLoad %uchar %1143
+%4834 = OpCompositeInsert %_arr_uchar_uint_16 %4833 %4832 7
+OpStore %1175 %4834
+%4835 = OpLoad %_arr_uchar_uint_16 %1175
+%4836 = OpLoad %uchar %1146
+%4837 = OpCompositeInsert %_arr_uchar_uint_16 %4836 %4835 8
+OpStore %1176 %4837
+%4838 = OpLoad %_arr_uchar_uint_16 %1176
+%4839 = OpLoad %uchar %1149
+%4840 = OpCompositeInsert %_arr_uchar_uint_16 %4839 %4838 9
+OpStore %1177 %4840
+%4841 = OpLoad %_arr_uchar_uint_16 %1177
+%4842 = OpLoad %uchar %1152
+%4843 = OpCompositeInsert %_arr_uchar_uint_16 %4842 %4841 10
+OpStore %1178 %4843
+%4844 = OpLoad %_arr_uchar_uint_16 %1178
+%4845 = OpLoad %uchar %1155
+%4846 = OpCompositeInsert %_arr_uchar_uint_16 %4845 %4844 11
+OpStore %1179 %4846
+%4847 = OpLoad %_arr_uchar_uint_16 %1179
+%4848 = OpLoad %uchar %1158
+%4849 = OpCompositeInsert %_arr_uchar_uint_16 %4848 %4847 12
+OpStore %1180 %4849
+%4850 = OpLoad %_arr_uchar_uint_16 %1180
+%4851 = OpLoad %uchar %1161
+%4852 = OpCompositeInsert %_arr_uchar_uint_16 %4851 %4850 13
+OpStore %1181 %4852
+%4853 = OpLoad %_arr_uchar_uint_16 %1181
+%4854 = OpLoad %uchar %1164
+%4855 = OpCompositeInsert %_arr_uchar_uint_16 %4854 %4853 14
+OpStore %1182 %4855
+%4856 = OpLoad %_arr_uchar_uint_16 %1182
+%4857 = OpLoad %uchar %1167
+%4858 = OpCompositeInsert %_arr_uchar_uint_16 %4857 %4856 15
+OpStore %1183 %4858
+%4860 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_2
+%4861 = OpLoad %_arr_uchar_uint_16 %1183
+OpStore %4860 %4861
+%4863 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_3
+%4864 = OpLoad %_arr_uchar_uint_16 %792
+OpStore %4863 %4864
+%4865 = OpLoad %ulong %790
+OpStore %789 %4865
+OpStore %795 %ulong_0
+OpBranch %720
+%720 = OpLabel
+%4866 = OpLoad %ulong %795
+%4868 = OpULessThan %bool %4866 %ulong_4
+OpStore %779 %4868
+%4869 = OpLoad %bool %779
+OpLoopMerge %722 %729 None
+OpBranchConditional %4869 %721 %722
+%722 = OpLabel
+OpStore %737 %4870
+%4871 = OpAccessChain %_ptr_Function_uint %737 %uint_0
+OpStore %4871 %uint_4294967295
+%4873 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_2
+%4874 = OpLoad %_arr_uchar_uint_16 %4873
+OpStore %783 %4874
+%4875 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %737 %uint_1
+%4876 = OpLoad %_arr_uchar_uint_16 %783
+OpStore %4875 %4876
+%4877 = OpAccessChain %_ptr_Function_uint %737 %uint_2
+OpStore %4877 %uint_305419896
+%4879 = OpLoad %uint %4871
+OpStore %785 %4879
+OpBranch %725
+%725 = OpLabel
+%4880 = OpLoad %uint %785
+%4881 = OpUConvert %ulong %4880
+OpStore %796 %4881
+%4882 = OpLoad %ulong %789
+%4883 = OpLoad %ulong %796
+%4884 = OpFunctionCall %ulong %3 %4882 %4883
+OpStore %797 %4884
+OpBranch %726
+%726 = OpLabel
+%4885 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %737 %uint_1
+%4886 = OpLoad %_arr_uchar_uint_16 %4885
+OpStore %786 %4886
+%4887 = OpLoad %ulong %797
+%4888 = OpLoad %_arr_uchar_uint_16 %786
+%4889 = OpFunctionCall %ulong %1 %4887 %4888
+OpStore %787 %4889
+%4890 = OpAccessChain %_ptr_Function_uint %737 %uint_2
+%4891 = OpLoad %uint %4890
+OpStore %788 %4891
+OpBranch %727
+%727 = OpLabel
+%4892 = OpLoad %uint %788
+%4893 = OpUConvert %ulong %4892
+OpStore %798 %4893
+%4894 = OpLoad %ulong %787
+%4895 = OpLoad %ulong %798
+%4896 = OpFunctionCall %ulong %3 %4894 %4895
+OpStore %799 %4896
+OpBranch %728
+%728 = OpLabel
+%4897 = OpLoad %ulong %799
+OpReturnValue %4897
+%721 = OpLabel
+%4898 = OpLoad %ulong %795
+%4899 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %4898
+%4900 = OpLoad %_arr_uchar_uint_16 %4899
+OpStore %780 %4900
+%4901 = OpLoad %ulong %789
+%4902 = OpLoad %_arr_uchar_uint_16 %780
+%4903 = OpFunctionCall %ulong %1 %4901 %4902
+OpStore %781 %4903
+%4904 = OpLoad %ulong %795
+%4905 = OpIAdd %ulong %4904 %ulong_1
+OpStore %782 %4905
+%4906 = OpLoad %ulong %781
+OpStore %789 %4906
+%4907 = OpLoad %ulong %782
+OpStore %795 %4907
+OpBranch %729
+%718 = OpLabel
+%4908 = OpLoad %_arr_uchar_uint_16 %791
+%4909 = OpCompositeExtract %uchar %4908 0
+OpStore %800 %4909
+%4910 = OpLoad %_arr_uchar_uint_16 %742
+%4911 = OpCompositeExtract %uchar %4910 0
+OpStore %801 %4911
+%4912 = OpLoad %uchar %800
+%4913 = OpLoad %uchar %801
+%4914 = OpIMul %uchar %4912 %4913
+OpStore %802 %4914
+%4915 = OpLoad %_arr_uchar_uint_16 %791
+%4916 = OpCompositeExtract %uchar %4915 1
+OpStore %803 %4916
+%4917 = OpLoad %_arr_uchar_uint_16 %742
+%4918 = OpCompositeExtract %uchar %4917 1
+OpStore %804 %4918
+%4919 = OpLoad %uchar %803
+%4920 = OpLoad %uchar %804
+%4921 = OpIMul %uchar %4919 %4920
+OpStore %805 %4921
+%4922 = OpLoad %_arr_uchar_uint_16 %791
+%4923 = OpCompositeExtract %uchar %4922 2
+OpStore %806 %4923
+%4924 = OpLoad %_arr_uchar_uint_16 %742
+%4925 = OpCompositeExtract %uchar %4924 2
+OpStore %807 %4925
+%4926 = OpLoad %uchar %806
+%4927 = OpLoad %uchar %807
+%4928 = OpIMul %uchar %4926 %4927
+OpStore %808 %4928
+%4929 = OpLoad %_arr_uchar_uint_16 %791
+%4930 = OpCompositeExtract %uchar %4929 3
+OpStore %809 %4930
+%4931 = OpLoad %_arr_uchar_uint_16 %742
+%4932 = OpCompositeExtract %uchar %4931 3
+OpStore %810 %4932
+%4933 = OpLoad %uchar %809
+%4934 = OpLoad %uchar %810
+%4935 = OpIMul %uchar %4933 %4934
+OpStore %811 %4935
+%4936 = OpLoad %_arr_uchar_uint_16 %791
+%4937 = OpCompositeExtract %uchar %4936 4
+OpStore %812 %4937
+%4938 = OpLoad %_arr_uchar_uint_16 %742
+%4939 = OpCompositeExtract %uchar %4938 4
+OpStore %813 %4939
+%4940 = OpLoad %uchar %812
+%4941 = OpLoad %uchar %813
+%4942 = OpIMul %uchar %4940 %4941
+OpStore %814 %4942
+%4943 = OpLoad %_arr_uchar_uint_16 %791
+%4944 = OpCompositeExtract %uchar %4943 5
+OpStore %815 %4944
+%4945 = OpLoad %_arr_uchar_uint_16 %742
+%4946 = OpCompositeExtract %uchar %4945 5
+OpStore %816 %4946
+%4947 = OpLoad %uchar %815
+%4948 = OpLoad %uchar %816
+%4949 = OpIMul %uchar %4947 %4948
+OpStore %817 %4949
+%4950 = OpLoad %_arr_uchar_uint_16 %791
+%4951 = OpCompositeExtract %uchar %4950 6
+OpStore %818 %4951
+%4952 = OpLoad %_arr_uchar_uint_16 %742
+%4953 = OpCompositeExtract %uchar %4952 6
+OpStore %819 %4953
+%4954 = OpLoad %uchar %818
+%4955 = OpLoad %uchar %819
+%4956 = OpIMul %uchar %4954 %4955
+OpStore %820 %4956
+%4957 = OpLoad %_arr_uchar_uint_16 %791
+%4958 = OpCompositeExtract %uchar %4957 7
+OpStore %821 %4958
+%4959 = OpLoad %_arr_uchar_uint_16 %742
+%4960 = OpCompositeExtract %uchar %4959 7
+OpStore %822 %4960
+%4961 = OpLoad %uchar %821
+%4962 = OpLoad %uchar %822
+%4963 = OpIMul %uchar %4961 %4962
+OpStore %823 %4963
+%4964 = OpLoad %_arr_uchar_uint_16 %791
+%4965 = OpCompositeExtract %uchar %4964 8
+OpStore %824 %4965
+%4966 = OpLoad %_arr_uchar_uint_16 %742
+%4967 = OpCompositeExtract %uchar %4966 8
+OpStore %825 %4967
+%4968 = OpLoad %uchar %824
+%4969 = OpLoad %uchar %825
+%4970 = OpIMul %uchar %4968 %4969
+OpStore %826 %4970
+%4971 = OpLoad %_arr_uchar_uint_16 %791
+%4972 = OpCompositeExtract %uchar %4971 9
+OpStore %827 %4972
+%4973 = OpLoad %_arr_uchar_uint_16 %742
+%4974 = OpCompositeExtract %uchar %4973 9
+OpStore %828 %4974
+%4975 = OpLoad %uchar %827
+%4976 = OpLoad %uchar %828
+%4977 = OpIMul %uchar %4975 %4976
+OpStore %829 %4977
+%4978 = OpLoad %_arr_uchar_uint_16 %791
+%4979 = OpCompositeExtract %uchar %4978 10
+OpStore %830 %4979
+%4980 = OpLoad %_arr_uchar_uint_16 %742
+%4981 = OpCompositeExtract %uchar %4980 10
+OpStore %831 %4981
+%4982 = OpLoad %uchar %830
+%4983 = OpLoad %uchar %831
+%4984 = OpIMul %uchar %4982 %4983
+OpStore %832 %4984
+%4985 = OpLoad %_arr_uchar_uint_16 %791
+%4986 = OpCompositeExtract %uchar %4985 11
+OpStore %833 %4986
+%4987 = OpLoad %_arr_uchar_uint_16 %742
+%4988 = OpCompositeExtract %uchar %4987 11
+OpStore %834 %4988
+%4989 = OpLoad %uchar %833
+%4990 = OpLoad %uchar %834
+%4991 = OpIMul %uchar %4989 %4990
+OpStore %835 %4991
+%4992 = OpLoad %_arr_uchar_uint_16 %791
+%4993 = OpCompositeExtract %uchar %4992 12
+OpStore %836 %4993
+%4994 = OpLoad %_arr_uchar_uint_16 %742
+%4995 = OpCompositeExtract %uchar %4994 12
+OpStore %837 %4995
+%4996 = OpLoad %uchar %836
+%4997 = OpLoad %uchar %837
+%4998 = OpIMul %uchar %4996 %4997
+OpStore %838 %4998
+%4999 = OpLoad %_arr_uchar_uint_16 %791
+%5000 = OpCompositeExtract %uchar %4999 13
+OpStore %839 %5000
+%5001 = OpLoad %_arr_uchar_uint_16 %742
+%5002 = OpCompositeExtract %uchar %5001 13
+OpStore %840 %5002
+%5003 = OpLoad %uchar %839
+%5004 = OpLoad %uchar %840
+%5005 = OpIMul %uchar %5003 %5004
+OpStore %841 %5005
+%5006 = OpLoad %_arr_uchar_uint_16 %791
+%5007 = OpCompositeExtract %uchar %5006 14
+OpStore %842 %5007
+%5008 = OpLoad %_arr_uchar_uint_16 %742
+%5009 = OpCompositeExtract %uchar %5008 14
+OpStore %843 %5009
+%5010 = OpLoad %uchar %842
+%5011 = OpLoad %uchar %843
+%5012 = OpIMul %uchar %5010 %5011
+OpStore %844 %5012
+%5013 = OpLoad %_arr_uchar_uint_16 %791
+%5014 = OpCompositeExtract %uchar %5013 15
+OpStore %845 %5014
+%5015 = OpLoad %_arr_uchar_uint_16 %742
+%5016 = OpCompositeExtract %uchar %5015 15
+OpStore %846 %5016
+%5017 = OpLoad %uchar %845
+%5018 = OpLoad %uchar %846
+%5019 = OpIMul %uchar %5017 %5018
+OpStore %847 %5019
+%5020 = OpLoad %_arr_uchar_uint_16 %791
+%5021 = OpLoad %uchar %802
+%5022 = OpCompositeInsert %_arr_uchar_uint_16 %5021 %5020 0
+OpStore %848 %5022
+%5023 = OpLoad %_arr_uchar_uint_16 %848
+%5024 = OpLoad %uchar %805
+%5025 = OpCompositeInsert %_arr_uchar_uint_16 %5024 %5023 1
+OpStore %849 %5025
+%5026 = OpLoad %_arr_uchar_uint_16 %849
+%5027 = OpLoad %uchar %808
+%5028 = OpCompositeInsert %_arr_uchar_uint_16 %5027 %5026 2
+OpStore %850 %5028
+%5029 = OpLoad %_arr_uchar_uint_16 %850
+%5030 = OpLoad %uchar %811
+%5031 = OpCompositeInsert %_arr_uchar_uint_16 %5030 %5029 3
+OpStore %851 %5031
+%5032 = OpLoad %_arr_uchar_uint_16 %851
+%5033 = OpLoad %uchar %814
+%5034 = OpCompositeInsert %_arr_uchar_uint_16 %5033 %5032 4
+OpStore %852 %5034
+%5035 = OpLoad %_arr_uchar_uint_16 %852
+%5036 = OpLoad %uchar %817
+%5037 = OpCompositeInsert %_arr_uchar_uint_16 %5036 %5035 5
+OpStore %853 %5037
+%5038 = OpLoad %_arr_uchar_uint_16 %853
+%5039 = OpLoad %uchar %820
+%5040 = OpCompositeInsert %_arr_uchar_uint_16 %5039 %5038 6
+OpStore %854 %5040
+%5041 = OpLoad %_arr_uchar_uint_16 %854
+%5042 = OpLoad %uchar %823
+%5043 = OpCompositeInsert %_arr_uchar_uint_16 %5042 %5041 7
+OpStore %855 %5043
+%5044 = OpLoad %_arr_uchar_uint_16 %855
+%5045 = OpLoad %uchar %826
+%5046 = OpCompositeInsert %_arr_uchar_uint_16 %5045 %5044 8
+OpStore %856 %5046
+%5047 = OpLoad %_arr_uchar_uint_16 %856
+%5048 = OpLoad %uchar %829
+%5049 = OpCompositeInsert %_arr_uchar_uint_16 %5048 %5047 9
+OpStore %857 %5049
+%5050 = OpLoad %_arr_uchar_uint_16 %857
+%5051 = OpLoad %uchar %832
+%5052 = OpCompositeInsert %_arr_uchar_uint_16 %5051 %5050 10
+OpStore %858 %5052
+%5053 = OpLoad %_arr_uchar_uint_16 %858
+%5054 = OpLoad %uchar %835
+%5055 = OpCompositeInsert %_arr_uchar_uint_16 %5054 %5053 11
+OpStore %859 %5055
+%5056 = OpLoad %_arr_uchar_uint_16 %859
+%5057 = OpLoad %uchar %838
+%5058 = OpCompositeInsert %_arr_uchar_uint_16 %5057 %5056 12
+OpStore %860 %5058
+%5059 = OpLoad %_arr_uchar_uint_16 %860
+%5060 = OpLoad %uchar %841
+%5061 = OpCompositeInsert %_arr_uchar_uint_16 %5060 %5059 13
+OpStore %861 %5061
+%5062 = OpLoad %_arr_uchar_uint_16 %861
+%5063 = OpLoad %uchar %844
+%5064 = OpCompositeInsert %_arr_uchar_uint_16 %5063 %5062 14
+OpStore %862 %5064
+%5065 = OpLoad %_arr_uchar_uint_16 %862
+%5066 = OpLoad %uchar %847
+%5067 = OpCompositeInsert %_arr_uchar_uint_16 %5066 %5065 15
+OpStore %863 %5067
+%5068 = OpLoad %ulong %790
+%5069 = OpLoad %_arr_uchar_uint_16 %863
+%5070 = OpFunctionCall %ulong %1 %5068 %5069
+OpStore %774 %5070
+%5071 = OpLoad %_arr_uchar_uint_16 %792
+%5072 = OpCompositeExtract %uchar %5071 0
+OpStore %864 %5072
+%5073 = OpLoad %_arr_uchar_uint_16 %863
+%5074 = OpCompositeExtract %uchar %5073 0
+OpStore %865 %5074
+%5075 = OpLoad %uchar %864
+%5076 = OpLoad %uchar %865
+%5077 = OpBitwiseXor %uchar %5075 %5076
+OpStore %866 %5077
+%5078 = OpLoad %_arr_uchar_uint_16 %792
+%5079 = OpCompositeExtract %uchar %5078 1
+OpStore %867 %5079
+%5080 = OpLoad %_arr_uchar_uint_16 %863
+%5081 = OpCompositeExtract %uchar %5080 1
+OpStore %868 %5081
+%5082 = OpLoad %uchar %867
+%5083 = OpLoad %uchar %868
+%5084 = OpBitwiseXor %uchar %5082 %5083
+OpStore %869 %5084
+%5085 = OpLoad %_arr_uchar_uint_16 %792
+%5086 = OpCompositeExtract %uchar %5085 2
+OpStore %870 %5086
+%5087 = OpLoad %_arr_uchar_uint_16 %863
+%5088 = OpCompositeExtract %uchar %5087 2
+OpStore %871 %5088
+%5089 = OpLoad %uchar %870
+%5090 = OpLoad %uchar %871
+%5091 = OpBitwiseXor %uchar %5089 %5090
+OpStore %872 %5091
+%5092 = OpLoad %_arr_uchar_uint_16 %792
+%5093 = OpCompositeExtract %uchar %5092 3
+OpStore %873 %5093
+%5094 = OpLoad %_arr_uchar_uint_16 %863
+%5095 = OpCompositeExtract %uchar %5094 3
+OpStore %874 %5095
+%5096 = OpLoad %uchar %873
+%5097 = OpLoad %uchar %874
+%5098 = OpBitwiseXor %uchar %5096 %5097
+OpStore %875 %5098
+%5099 = OpLoad %_arr_uchar_uint_16 %792
+%5100 = OpCompositeExtract %uchar %5099 4
+OpStore %876 %5100
+%5101 = OpLoad %_arr_uchar_uint_16 %863
+%5102 = OpCompositeExtract %uchar %5101 4
+OpStore %877 %5102
+%5103 = OpLoad %uchar %876
+%5104 = OpLoad %uchar %877
+%5105 = OpBitwiseXor %uchar %5103 %5104
+OpStore %878 %5105
+%5106 = OpLoad %_arr_uchar_uint_16 %792
+%5107 = OpCompositeExtract %uchar %5106 5
+OpStore %879 %5107
+%5108 = OpLoad %_arr_uchar_uint_16 %863
+%5109 = OpCompositeExtract %uchar %5108 5
+OpStore %880 %5109
+%5110 = OpLoad %uchar %879
+%5111 = OpLoad %uchar %880
+%5112 = OpBitwiseXor %uchar %5110 %5111
+OpStore %881 %5112
+%5113 = OpLoad %_arr_uchar_uint_16 %792
+%5114 = OpCompositeExtract %uchar %5113 6
+OpStore %882 %5114
+%5115 = OpLoad %_arr_uchar_uint_16 %863
+%5116 = OpCompositeExtract %uchar %5115 6
+OpStore %883 %5116
+%5117 = OpLoad %uchar %882
+%5118 = OpLoad %uchar %883
+%5119 = OpBitwiseXor %uchar %5117 %5118
+OpStore %884 %5119
+%5120 = OpLoad %_arr_uchar_uint_16 %792
+%5121 = OpCompositeExtract %uchar %5120 7
+OpStore %885 %5121
+%5122 = OpLoad %_arr_uchar_uint_16 %863
+%5123 = OpCompositeExtract %uchar %5122 7
+OpStore %886 %5123
+%5124 = OpLoad %uchar %885
+%5125 = OpLoad %uchar %886
+%5126 = OpBitwiseXor %uchar %5124 %5125
+OpStore %887 %5126
+%5127 = OpLoad %_arr_uchar_uint_16 %792
+%5128 = OpCompositeExtract %uchar %5127 8
+OpStore %888 %5128
+%5129 = OpLoad %_arr_uchar_uint_16 %863
+%5130 = OpCompositeExtract %uchar %5129 8
+OpStore %889 %5130
+%5131 = OpLoad %uchar %888
+%5132 = OpLoad %uchar %889
+%5133 = OpBitwiseXor %uchar %5131 %5132
+OpStore %890 %5133
+%5134 = OpLoad %_arr_uchar_uint_16 %792
+%5135 = OpCompositeExtract %uchar %5134 9
+OpStore %891 %5135
+%5136 = OpLoad %_arr_uchar_uint_16 %863
+%5137 = OpCompositeExtract %uchar %5136 9
+OpStore %892 %5137
+%5138 = OpLoad %uchar %891
+%5139 = OpLoad %uchar %892
+%5140 = OpBitwiseXor %uchar %5138 %5139
+OpStore %893 %5140
+%5141 = OpLoad %_arr_uchar_uint_16 %792
+%5142 = OpCompositeExtract %uchar %5141 10
+OpStore %894 %5142
+%5143 = OpLoad %_arr_uchar_uint_16 %863
+%5144 = OpCompositeExtract %uchar %5143 10
+OpStore %895 %5144
+%5145 = OpLoad %uchar %894
+%5146 = OpLoad %uchar %895
+%5147 = OpBitwiseXor %uchar %5145 %5146
+OpStore %896 %5147
+%5148 = OpLoad %_arr_uchar_uint_16 %792
+%5149 = OpCompositeExtract %uchar %5148 11
+OpStore %897 %5149
+%5150 = OpLoad %_arr_uchar_uint_16 %863
+%5151 = OpCompositeExtract %uchar %5150 11
+OpStore %898 %5151
+%5152 = OpLoad %uchar %897
+%5153 = OpLoad %uchar %898
+%5154 = OpBitwiseXor %uchar %5152 %5153
+OpStore %899 %5154
+%5155 = OpLoad %_arr_uchar_uint_16 %792
+%5156 = OpCompositeExtract %uchar %5155 12
+OpStore %900 %5156
+%5157 = OpLoad %_arr_uchar_uint_16 %863
+%5158 = OpCompositeExtract %uchar %5157 12
+OpStore %901 %5158
+%5159 = OpLoad %uchar %900
+%5160 = OpLoad %uchar %901
+%5161 = OpBitwiseXor %uchar %5159 %5160
+OpStore %902 %5161
+%5162 = OpLoad %_arr_uchar_uint_16 %792
+%5163 = OpCompositeExtract %uchar %5162 13
+OpStore %903 %5163
+%5164 = OpLoad %_arr_uchar_uint_16 %863
+%5165 = OpCompositeExtract %uchar %5164 13
+OpStore %904 %5165
+%5166 = OpLoad %uchar %903
+%5167 = OpLoad %uchar %904
+%5168 = OpBitwiseXor %uchar %5166 %5167
+OpStore %905 %5168
+%5169 = OpLoad %_arr_uchar_uint_16 %792
+%5170 = OpCompositeExtract %uchar %5169 14
+OpStore %906 %5170
+%5171 = OpLoad %_arr_uchar_uint_16 %863
+%5172 = OpCompositeExtract %uchar %5171 14
+OpStore %907 %5172
+%5173 = OpLoad %uchar %906
+%5174 = OpLoad %uchar %907
+%5175 = OpBitwiseXor %uchar %5173 %5174
+OpStore %908 %5175
+%5176 = OpLoad %_arr_uchar_uint_16 %792
+%5177 = OpCompositeExtract %uchar %5176 15
+OpStore %909 %5177
+%5178 = OpLoad %_arr_uchar_uint_16 %863
+%5179 = OpCompositeExtract %uchar %5178 15
+OpStore %910 %5179
+%5180 = OpLoad %uchar %909
+%5181 = OpLoad %uchar %910
+%5182 = OpBitwiseXor %uchar %5180 %5181
+OpStore %911 %5182
+%5183 = OpLoad %_arr_uchar_uint_16 %792
+%5184 = OpLoad %uchar %866
+%5185 = OpCompositeInsert %_arr_uchar_uint_16 %5184 %5183 0
+OpStore %912 %5185
+%5186 = OpLoad %_arr_uchar_uint_16 %912
+%5187 = OpLoad %uchar %869
+%5188 = OpCompositeInsert %_arr_uchar_uint_16 %5187 %5186 1
+OpStore %913 %5188
+%5189 = OpLoad %_arr_uchar_uint_16 %913
+%5190 = OpLoad %uchar %872
+%5191 = OpCompositeInsert %_arr_uchar_uint_16 %5190 %5189 2
+OpStore %914 %5191
+%5192 = OpLoad %_arr_uchar_uint_16 %914
+%5193 = OpLoad %uchar %875
+%5194 = OpCompositeInsert %_arr_uchar_uint_16 %5193 %5192 3
+OpStore %915 %5194
+%5195 = OpLoad %_arr_uchar_uint_16 %915
+%5196 = OpLoad %uchar %878
+%5197 = OpCompositeInsert %_arr_uchar_uint_16 %5196 %5195 4
+OpStore %916 %5197
+%5198 = OpLoad %_arr_uchar_uint_16 %916
+%5199 = OpLoad %uchar %881
+%5200 = OpCompositeInsert %_arr_uchar_uint_16 %5199 %5198 5
+OpStore %917 %5200
+%5201 = OpLoad %_arr_uchar_uint_16 %917
+%5202 = OpLoad %uchar %884
+%5203 = OpCompositeInsert %_arr_uchar_uint_16 %5202 %5201 6
+OpStore %918 %5203
+%5204 = OpLoad %_arr_uchar_uint_16 %918
+%5205 = OpLoad %uchar %887
+%5206 = OpCompositeInsert %_arr_uchar_uint_16 %5205 %5204 7
+OpStore %919 %5206
+%5207 = OpLoad %_arr_uchar_uint_16 %919
+%5208 = OpLoad %uchar %890
+%5209 = OpCompositeInsert %_arr_uchar_uint_16 %5208 %5207 8
+OpStore %920 %5209
+%5210 = OpLoad %_arr_uchar_uint_16 %920
+%5211 = OpLoad %uchar %893
+%5212 = OpCompositeInsert %_arr_uchar_uint_16 %5211 %5210 9
+OpStore %921 %5212
+%5213 = OpLoad %_arr_uchar_uint_16 %921
+%5214 = OpLoad %uchar %896
+%5215 = OpCompositeInsert %_arr_uchar_uint_16 %5214 %5213 10
+OpStore %922 %5215
+%5216 = OpLoad %_arr_uchar_uint_16 %922
+%5217 = OpLoad %uchar %899
+%5218 = OpCompositeInsert %_arr_uchar_uint_16 %5217 %5216 11
+OpStore %923 %5218
+%5219 = OpLoad %_arr_uchar_uint_16 %923
+%5220 = OpLoad %uchar %902
+%5221 = OpCompositeInsert %_arr_uchar_uint_16 %5220 %5219 12
+OpStore %924 %5221
+%5222 = OpLoad %_arr_uchar_uint_16 %924
+%5223 = OpLoad %uchar %905
+%5224 = OpCompositeInsert %_arr_uchar_uint_16 %5223 %5222 13
+OpStore %925 %5224
+%5225 = OpLoad %_arr_uchar_uint_16 %925
+%5226 = OpLoad %uchar %908
+%5227 = OpCompositeInsert %_arr_uchar_uint_16 %5226 %5225 14
+OpStore %926 %5227
+%5228 = OpLoad %_arr_uchar_uint_16 %926
+%5229 = OpLoad %uchar %911
+%5230 = OpCompositeInsert %_arr_uchar_uint_16 %5229 %5228 15
+OpStore %927 %5230
+%5231 = OpLoad %ulong %774
+%5232 = OpLoad %_arr_uchar_uint_16 %927
+%5233 = OpFunctionCall %ulong %1 %5231 %5232
+OpStore %775 %5233
+%5234 = OpLoad %_arr_uchar_uint_16 %793
+%5235 = OpCompositeExtract %uchar %5234 0
+OpStore %928 %5235
+%5236 = OpLoad %_arr_uchar_uint_16 %791
+%5237 = OpCompositeExtract %uchar %5236 0
+OpStore %929 %5237
+%5238 = OpLoad %uchar %928
+%5239 = OpLoad %uchar %929
+%5240 = OpIAdd %uchar %5238 %5239
+OpStore %930 %5240
+%5241 = OpLoad %_arr_uchar_uint_16 %793
+%5242 = OpCompositeExtract %uchar %5241 1
+OpStore %931 %5242
+%5243 = OpLoad %_arr_uchar_uint_16 %791
+%5244 = OpCompositeExtract %uchar %5243 1
+OpStore %932 %5244
+%5245 = OpLoad %uchar %931
+%5246 = OpLoad %uchar %932
+%5247 = OpIAdd %uchar %5245 %5246
+OpStore %933 %5247
+%5248 = OpLoad %_arr_uchar_uint_16 %793
+%5249 = OpCompositeExtract %uchar %5248 2
+OpStore %934 %5249
+%5250 = OpLoad %_arr_uchar_uint_16 %791
+%5251 = OpCompositeExtract %uchar %5250 2
+OpStore %935 %5251
+%5252 = OpLoad %uchar %934
+%5253 = OpLoad %uchar %935
+%5254 = OpIAdd %uchar %5252 %5253
+OpStore %936 %5254
+%5255 = OpLoad %_arr_uchar_uint_16 %793
+%5256 = OpCompositeExtract %uchar %5255 3
+OpStore %937 %5256
+%5257 = OpLoad %_arr_uchar_uint_16 %791
+%5258 = OpCompositeExtract %uchar %5257 3
+OpStore %938 %5258
+%5259 = OpLoad %uchar %937
+%5260 = OpLoad %uchar %938
+%5261 = OpIAdd %uchar %5259 %5260
+OpStore %939 %5261
+%5262 = OpLoad %_arr_uchar_uint_16 %793
+%5263 = OpCompositeExtract %uchar %5262 4
+OpStore %940 %5263
+%5264 = OpLoad %_arr_uchar_uint_16 %791
+%5265 = OpCompositeExtract %uchar %5264 4
+OpStore %941 %5265
+%5266 = OpLoad %uchar %940
+%5267 = OpLoad %uchar %941
+%5268 = OpIAdd %uchar %5266 %5267
+OpStore %942 %5268
+%5269 = OpLoad %_arr_uchar_uint_16 %793
+%5270 = OpCompositeExtract %uchar %5269 5
+OpStore %943 %5270
+%5271 = OpLoad %_arr_uchar_uint_16 %791
+%5272 = OpCompositeExtract %uchar %5271 5
+OpStore %944 %5272
+%5273 = OpLoad %uchar %943
+%5274 = OpLoad %uchar %944
+%5275 = OpIAdd %uchar %5273 %5274
+OpStore %945 %5275
+%5276 = OpLoad %_arr_uchar_uint_16 %793
+%5277 = OpCompositeExtract %uchar %5276 6
+OpStore %946 %5277
+%5278 = OpLoad %_arr_uchar_uint_16 %791
+%5279 = OpCompositeExtract %uchar %5278 6
+OpStore %947 %5279
+%5280 = OpLoad %uchar %946
+%5281 = OpLoad %uchar %947
+%5282 = OpIAdd %uchar %5280 %5281
+OpStore %948 %5282
+%5283 = OpLoad %_arr_uchar_uint_16 %793
+%5284 = OpCompositeExtract %uchar %5283 7
+OpStore %949 %5284
+%5285 = OpLoad %_arr_uchar_uint_16 %791
+%5286 = OpCompositeExtract %uchar %5285 7
+OpStore %950 %5286
+%5287 = OpLoad %uchar %949
+%5288 = OpLoad %uchar %950
+%5289 = OpIAdd %uchar %5287 %5288
+OpStore %951 %5289
+%5290 = OpLoad %_arr_uchar_uint_16 %793
+%5291 = OpCompositeExtract %uchar %5290 8
+OpStore %952 %5291
+%5292 = OpLoad %_arr_uchar_uint_16 %791
+%5293 = OpCompositeExtract %uchar %5292 8
+OpStore %953 %5293
+%5294 = OpLoad %uchar %952
+%5295 = OpLoad %uchar %953
+%5296 = OpIAdd %uchar %5294 %5295
+OpStore %954 %5296
+%5297 = OpLoad %_arr_uchar_uint_16 %793
+%5298 = OpCompositeExtract %uchar %5297 9
+OpStore %955 %5298
+%5299 = OpLoad %_arr_uchar_uint_16 %791
+%5300 = OpCompositeExtract %uchar %5299 9
+OpStore %956 %5300
+%5301 = OpLoad %uchar %955
+%5302 = OpLoad %uchar %956
+%5303 = OpIAdd %uchar %5301 %5302
+OpStore %957 %5303
+%5304 = OpLoad %_arr_uchar_uint_16 %793
+%5305 = OpCompositeExtract %uchar %5304 10
+OpStore %958 %5305
+%5306 = OpLoad %_arr_uchar_uint_16 %791
+%5307 = OpCompositeExtract %uchar %5306 10
+OpStore %959 %5307
+%5308 = OpLoad %uchar %958
+%5309 = OpLoad %uchar %959
+%5310 = OpIAdd %uchar %5308 %5309
+OpStore %960 %5310
+%5311 = OpLoad %_arr_uchar_uint_16 %793
+%5312 = OpCompositeExtract %uchar %5311 11
+OpStore %961 %5312
+%5313 = OpLoad %_arr_uchar_uint_16 %791
+%5314 = OpCompositeExtract %uchar %5313 11
+OpStore %962 %5314
+%5315 = OpLoad %uchar %961
+%5316 = OpLoad %uchar %962
+%5317 = OpIAdd %uchar %5315 %5316
+OpStore %963 %5317
+%5318 = OpLoad %_arr_uchar_uint_16 %793
+%5319 = OpCompositeExtract %uchar %5318 12
+OpStore %964 %5319
+%5320 = OpLoad %_arr_uchar_uint_16 %791
+%5321 = OpCompositeExtract %uchar %5320 12
+OpStore %965 %5321
+%5322 = OpLoad %uchar %964
+%5323 = OpLoad %uchar %965
+%5324 = OpIAdd %uchar %5322 %5323
+OpStore %966 %5324
+%5325 = OpLoad %_arr_uchar_uint_16 %793
+%5326 = OpCompositeExtract %uchar %5325 13
+OpStore %967 %5326
+%5327 = OpLoad %_arr_uchar_uint_16 %791
+%5328 = OpCompositeExtract %uchar %5327 13
+OpStore %968 %5328
+%5329 = OpLoad %uchar %967
+%5330 = OpLoad %uchar %968
+%5331 = OpIAdd %uchar %5329 %5330
+OpStore %969 %5331
+%5332 = OpLoad %_arr_uchar_uint_16 %793
+%5333 = OpCompositeExtract %uchar %5332 14
+OpStore %970 %5333
+%5334 = OpLoad %_arr_uchar_uint_16 %791
+%5335 = OpCompositeExtract %uchar %5334 14
+OpStore %971 %5335
+%5336 = OpLoad %uchar %970
+%5337 = OpLoad %uchar %971
+%5338 = OpIAdd %uchar %5336 %5337
+OpStore %972 %5338
+%5339 = OpLoad %_arr_uchar_uint_16 %793
+%5340 = OpCompositeExtract %uchar %5339 15
+OpStore %973 %5340
+%5341 = OpLoad %_arr_uchar_uint_16 %791
+%5342 = OpCompositeExtract %uchar %5341 15
+OpStore %974 %5342
+%5343 = OpLoad %uchar %973
+%5344 = OpLoad %uchar %974
+%5345 = OpIAdd %uchar %5343 %5344
+OpStore %975 %5345
+%5346 = OpLoad %_arr_uchar_uint_16 %793
+%5347 = OpLoad %uchar %930
+%5348 = OpCompositeInsert %_arr_uchar_uint_16 %5347 %5346 0
+OpStore %976 %5348
+%5349 = OpLoad %_arr_uchar_uint_16 %976
+%5350 = OpLoad %uchar %933
+%5351 = OpCompositeInsert %_arr_uchar_uint_16 %5350 %5349 1
+OpStore %977 %5351
+%5352 = OpLoad %_arr_uchar_uint_16 %977
+%5353 = OpLoad %uchar %936
+%5354 = OpCompositeInsert %_arr_uchar_uint_16 %5353 %5352 2
+OpStore %978 %5354
+%5355 = OpLoad %_arr_uchar_uint_16 %978
+%5356 = OpLoad %uchar %939
+%5357 = OpCompositeInsert %_arr_uchar_uint_16 %5356 %5355 3
+OpStore %979 %5357
+%5358 = OpLoad %_arr_uchar_uint_16 %979
+%5359 = OpLoad %uchar %942
+%5360 = OpCompositeInsert %_arr_uchar_uint_16 %5359 %5358 4
+OpStore %980 %5360
+%5361 = OpLoad %_arr_uchar_uint_16 %980
+%5362 = OpLoad %uchar %945
+%5363 = OpCompositeInsert %_arr_uchar_uint_16 %5362 %5361 5
+OpStore %981 %5363
+%5364 = OpLoad %_arr_uchar_uint_16 %981
+%5365 = OpLoad %uchar %948
+%5366 = OpCompositeInsert %_arr_uchar_uint_16 %5365 %5364 6
+OpStore %982 %5366
+%5367 = OpLoad %_arr_uchar_uint_16 %982
+%5368 = OpLoad %uchar %951
+%5369 = OpCompositeInsert %_arr_uchar_uint_16 %5368 %5367 7
+OpStore %983 %5369
+%5370 = OpLoad %_arr_uchar_uint_16 %983
+%5371 = OpLoad %uchar %954
+%5372 = OpCompositeInsert %_arr_uchar_uint_16 %5371 %5370 8
+OpStore %984 %5372
+%5373 = OpLoad %_arr_uchar_uint_16 %984
+%5374 = OpLoad %uchar %957
+%5375 = OpCompositeInsert %_arr_uchar_uint_16 %5374 %5373 9
+OpStore %985 %5375
+%5376 = OpLoad %_arr_uchar_uint_16 %985
+%5377 = OpLoad %uchar %960
+%5378 = OpCompositeInsert %_arr_uchar_uint_16 %5377 %5376 10
+OpStore %986 %5378
+%5379 = OpLoad %_arr_uchar_uint_16 %986
+%5380 = OpLoad %uchar %963
+%5381 = OpCompositeInsert %_arr_uchar_uint_16 %5380 %5379 11
+OpStore %987 %5381
+%5382 = OpLoad %_arr_uchar_uint_16 %987
+%5383 = OpLoad %uchar %966
+%5384 = OpCompositeInsert %_arr_uchar_uint_16 %5383 %5382 12
+OpStore %988 %5384
+%5385 = OpLoad %_arr_uchar_uint_16 %988
+%5386 = OpLoad %uchar %969
+%5387 = OpCompositeInsert %_arr_uchar_uint_16 %5386 %5385 13
+OpStore %989 %5387
+%5388 = OpLoad %_arr_uchar_uint_16 %989
+%5389 = OpLoad %uchar %972
+%5390 = OpCompositeInsert %_arr_uchar_uint_16 %5389 %5388 14
+OpStore %990 %5390
+%5391 = OpLoad %_arr_uchar_uint_16 %990
+%5392 = OpLoad %uchar %975
+%5393 = OpCompositeInsert %_arr_uchar_uint_16 %5392 %5391 15
+OpStore %991 %5393
+%5394 = OpLoad %ulong %775
+%5395 = OpLoad %_arr_uchar_uint_16 %991
+%5396 = OpFunctionCall %ulong %1 %5394 %5395
+OpStore %776 %5396
+%5397 = OpLoad %_arr_uchar_uint_16 %791
+%5398 = OpCompositeExtract %uchar %5397 0
+OpStore %992 %5398
+%5399 = OpLoad %_arr_uchar_uint_16 %755
+%5400 = OpCompositeExtract %uchar %5399 0
+OpStore %993 %5400
+%5401 = OpLoad %uchar %992
+%5402 = OpLoad %uchar %993
+%5403 = OpIAdd %uchar %5401 %5402
+OpStore %994 %5403
+%5404 = OpLoad %_arr_uchar_uint_16 %791
+%5405 = OpCompositeExtract %uchar %5404 1
+OpStore %995 %5405
+%5406 = OpLoad %_arr_uchar_uint_16 %755
+%5407 = OpCompositeExtract %uchar %5406 1
+OpStore %996 %5407
+%5408 = OpLoad %uchar %995
+%5409 = OpLoad %uchar %996
+%5410 = OpIAdd %uchar %5408 %5409
+OpStore %997 %5410
+%5411 = OpLoad %_arr_uchar_uint_16 %791
+%5412 = OpCompositeExtract %uchar %5411 2
+OpStore %998 %5412
+%5413 = OpLoad %_arr_uchar_uint_16 %755
+%5414 = OpCompositeExtract %uchar %5413 2
+OpStore %999 %5414
+%5415 = OpLoad %uchar %998
+%5416 = OpLoad %uchar %999
+%5417 = OpIAdd %uchar %5415 %5416
+OpStore %1000 %5417
+%5418 = OpLoad %_arr_uchar_uint_16 %791
+%5419 = OpCompositeExtract %uchar %5418 3
+OpStore %1001 %5419
+%5420 = OpLoad %_arr_uchar_uint_16 %755
+%5421 = OpCompositeExtract %uchar %5420 3
+OpStore %1002 %5421
+%5422 = OpLoad %uchar %1001
+%5423 = OpLoad %uchar %1002
+%5424 = OpIAdd %uchar %5422 %5423
+OpStore %1003 %5424
+%5425 = OpLoad %_arr_uchar_uint_16 %791
+%5426 = OpCompositeExtract %uchar %5425 4
+OpStore %1004 %5426
+%5427 = OpLoad %_arr_uchar_uint_16 %755
+%5428 = OpCompositeExtract %uchar %5427 4
+OpStore %1005 %5428
+%5429 = OpLoad %uchar %1004
+%5430 = OpLoad %uchar %1005
+%5431 = OpIAdd %uchar %5429 %5430
+OpStore %1006 %5431
+%5432 = OpLoad %_arr_uchar_uint_16 %791
+%5433 = OpCompositeExtract %uchar %5432 5
+OpStore %1007 %5433
+%5434 = OpLoad %_arr_uchar_uint_16 %755
+%5435 = OpCompositeExtract %uchar %5434 5
+OpStore %1008 %5435
+%5436 = OpLoad %uchar %1007
+%5437 = OpLoad %uchar %1008
+%5438 = OpIAdd %uchar %5436 %5437
+OpStore %1009 %5438
+%5439 = OpLoad %_arr_uchar_uint_16 %791
+%5440 = OpCompositeExtract %uchar %5439 6
+OpStore %1010 %5440
+%5441 = OpLoad %_arr_uchar_uint_16 %755
+%5442 = OpCompositeExtract %uchar %5441 6
+OpStore %1011 %5442
+%5443 = OpLoad %uchar %1010
+%5444 = OpLoad %uchar %1011
+%5445 = OpIAdd %uchar %5443 %5444
+OpStore %1012 %5445
+%5446 = OpLoad %_arr_uchar_uint_16 %791
+%5447 = OpCompositeExtract %uchar %5446 7
+OpStore %1013 %5447
+%5448 = OpLoad %_arr_uchar_uint_16 %755
+%5449 = OpCompositeExtract %uchar %5448 7
+OpStore %1014 %5449
+%5450 = OpLoad %uchar %1013
+%5451 = OpLoad %uchar %1014
+%5452 = OpIAdd %uchar %5450 %5451
+OpStore %1015 %5452
+%5453 = OpLoad %_arr_uchar_uint_16 %791
+%5454 = OpCompositeExtract %uchar %5453 8
+OpStore %1016 %5454
+%5455 = OpLoad %_arr_uchar_uint_16 %755
+%5456 = OpCompositeExtract %uchar %5455 8
+OpStore %1017 %5456
+%5457 = OpLoad %uchar %1016
+%5458 = OpLoad %uchar %1017
+%5459 = OpIAdd %uchar %5457 %5458
+OpStore %1018 %5459
+%5460 = OpLoad %_arr_uchar_uint_16 %791
+%5461 = OpCompositeExtract %uchar %5460 9
+OpStore %1019 %5461
+%5462 = OpLoad %_arr_uchar_uint_16 %755
+%5463 = OpCompositeExtract %uchar %5462 9
+OpStore %1020 %5463
+%5464 = OpLoad %uchar %1019
+%5465 = OpLoad %uchar %1020
+%5466 = OpIAdd %uchar %5464 %5465
+OpStore %1021 %5466
+%5467 = OpLoad %_arr_uchar_uint_16 %791
+%5468 = OpCompositeExtract %uchar %5467 10
+OpStore %1022 %5468
+%5469 = OpLoad %_arr_uchar_uint_16 %755
+%5470 = OpCompositeExtract %uchar %5469 10
+OpStore %1023 %5470
+%5471 = OpLoad %uchar %1022
+%5472 = OpLoad %uchar %1023
+%5473 = OpIAdd %uchar %5471 %5472
+OpStore %1024 %5473
+%5474 = OpLoad %_arr_uchar_uint_16 %791
+%5475 = OpCompositeExtract %uchar %5474 11
+OpStore %1025 %5475
+%5476 = OpLoad %_arr_uchar_uint_16 %755
+%5477 = OpCompositeExtract %uchar %5476 11
+OpStore %1026 %5477
+%5478 = OpLoad %uchar %1025
+%5479 = OpLoad %uchar %1026
+%5480 = OpIAdd %uchar %5478 %5479
+OpStore %1027 %5480
+%5481 = OpLoad %_arr_uchar_uint_16 %791
+%5482 = OpCompositeExtract %uchar %5481 12
+OpStore %1028 %5482
+%5483 = OpLoad %_arr_uchar_uint_16 %755
+%5484 = OpCompositeExtract %uchar %5483 12
+OpStore %1029 %5484
+%5485 = OpLoad %uchar %1028
+%5486 = OpLoad %uchar %1029
+%5487 = OpIAdd %uchar %5485 %5486
+OpStore %1030 %5487
+%5488 = OpLoad %_arr_uchar_uint_16 %791
+%5489 = OpCompositeExtract %uchar %5488 13
+OpStore %1031 %5489
+%5490 = OpLoad %_arr_uchar_uint_16 %755
+%5491 = OpCompositeExtract %uchar %5490 13
+OpStore %1032 %5491
+%5492 = OpLoad %uchar %1031
+%5493 = OpLoad %uchar %1032
+%5494 = OpIAdd %uchar %5492 %5493
+OpStore %1033 %5494
+%5495 = OpLoad %_arr_uchar_uint_16 %791
+%5496 = OpCompositeExtract %uchar %5495 14
+OpStore %1034 %5496
+%5497 = OpLoad %_arr_uchar_uint_16 %755
+%5498 = OpCompositeExtract %uchar %5497 14
+OpStore %1035 %5498
+%5499 = OpLoad %uchar %1034
+%5500 = OpLoad %uchar %1035
+%5501 = OpIAdd %uchar %5499 %5500
+OpStore %1036 %5501
+%5502 = OpLoad %_arr_uchar_uint_16 %791
+%5503 = OpCompositeExtract %uchar %5502 15
+OpStore %1037 %5503
+%5504 = OpLoad %_arr_uchar_uint_16 %755
+%5505 = OpCompositeExtract %uchar %5504 15
+OpStore %1038 %5505
+%5506 = OpLoad %uchar %1037
+%5507 = OpLoad %uchar %1038
+%5508 = OpIAdd %uchar %5506 %5507
+OpStore %1039 %5508
+%5509 = OpLoad %_arr_uchar_uint_16 %791
+%5510 = OpLoad %uchar %994
+%5511 = OpCompositeInsert %_arr_uchar_uint_16 %5510 %5509 0
+OpStore %1040 %5511
+%5512 = OpLoad %_arr_uchar_uint_16 %1040
+%5513 = OpLoad %uchar %997
+%5514 = OpCompositeInsert %_arr_uchar_uint_16 %5513 %5512 1
+OpStore %1041 %5514
+%5515 = OpLoad %_arr_uchar_uint_16 %1041
+%5516 = OpLoad %uchar %1000
+%5517 = OpCompositeInsert %_arr_uchar_uint_16 %5516 %5515 2
+OpStore %1042 %5517
+%5518 = OpLoad %_arr_uchar_uint_16 %1042
+%5519 = OpLoad %uchar %1003
+%5520 = OpCompositeInsert %_arr_uchar_uint_16 %5519 %5518 3
+OpStore %1043 %5520
+%5521 = OpLoad %_arr_uchar_uint_16 %1043
+%5522 = OpLoad %uchar %1006
+%5523 = OpCompositeInsert %_arr_uchar_uint_16 %5522 %5521 4
+OpStore %1044 %5523
+%5524 = OpLoad %_arr_uchar_uint_16 %1044
+%5525 = OpLoad %uchar %1009
+%5526 = OpCompositeInsert %_arr_uchar_uint_16 %5525 %5524 5
+OpStore %1045 %5526
+%5527 = OpLoad %_arr_uchar_uint_16 %1045
+%5528 = OpLoad %uchar %1012
+%5529 = OpCompositeInsert %_arr_uchar_uint_16 %5528 %5527 6
+OpStore %1046 %5529
+%5530 = OpLoad %_arr_uchar_uint_16 %1046
+%5531 = OpLoad %uchar %1015
+%5532 = OpCompositeInsert %_arr_uchar_uint_16 %5531 %5530 7
+OpStore %1047 %5532
+%5533 = OpLoad %_arr_uchar_uint_16 %1047
+%5534 = OpLoad %uchar %1018
+%5535 = OpCompositeInsert %_arr_uchar_uint_16 %5534 %5533 8
+OpStore %1048 %5535
+%5536 = OpLoad %_arr_uchar_uint_16 %1048
+%5537 = OpLoad %uchar %1021
+%5538 = OpCompositeInsert %_arr_uchar_uint_16 %5537 %5536 9
+OpStore %1049 %5538
+%5539 = OpLoad %_arr_uchar_uint_16 %1049
+%5540 = OpLoad %uchar %1024
+%5541 = OpCompositeInsert %_arr_uchar_uint_16 %5540 %5539 10
+OpStore %1050 %5541
+%5542 = OpLoad %_arr_uchar_uint_16 %1050
+%5543 = OpLoad %uchar %1027
+%5544 = OpCompositeInsert %_arr_uchar_uint_16 %5543 %5542 11
+OpStore %1051 %5544
+%5545 = OpLoad %_arr_uchar_uint_16 %1051
+%5546 = OpLoad %uchar %1030
+%5547 = OpCompositeInsert %_arr_uchar_uint_16 %5546 %5545 12
+OpStore %1052 %5547
+%5548 = OpLoad %_arr_uchar_uint_16 %1052
+%5549 = OpLoad %uchar %1033
+%5550 = OpCompositeInsert %_arr_uchar_uint_16 %5549 %5548 13
+OpStore %1053 %5550
+%5551 = OpLoad %_arr_uchar_uint_16 %1053
+%5552 = OpLoad %uchar %1036
+%5553 = OpCompositeInsert %_arr_uchar_uint_16 %5552 %5551 14
+OpStore %1054 %5553
+%5554 = OpLoad %_arr_uchar_uint_16 %1054
+%5555 = OpLoad %uchar %1039
+%5556 = OpCompositeInsert %_arr_uchar_uint_16 %5555 %5554 15
+OpStore %1055 %5556
+%5557 = OpLoad %ulong %776
+%5558 = OpLoad %_arr_uchar_uint_16 %1055
+%5559 = OpFunctionCall %ulong %1 %5557 %5558
+OpStore %777 %5559
+%5560 = OpLoad %ulong %794
+%5561 = OpIAdd %ulong %5560 %ulong_1
+OpStore %778 %5561
+%5562 = OpLoad %ulong %777
+OpStore %790 %5562
+%5563 = OpLoad %_arr_uchar_uint_16 %1055
+OpStore %791 %5563
+%5564 = OpLoad %_arr_uchar_uint_16 %927
+OpStore %792 %5564
+%5565 = OpLoad %_arr_uchar_uint_16 %991
+OpStore %793 %5565
+%5566 = OpLoad %ulong %778
+OpStore %794 %5566
+OpBranch %730
+%729 = OpLabel
+OpBranch %720
+%730 = OpLabel
+OpBranch %717
 OpFunctionEnd
-%3 = OpFunction %ulong None %4978
-%4979 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %4981
-%4982 = OpFunctionParameter %ulong
-%4983 = OpFunctionParameter %uint
-%4984 = OpLabel
-%4991 = OpVariable %_ptr_Function_ulong Function
-%4992 = OpVariable %_ptr_Function_uint Function
-%4993 = OpVariable %_ptr_Function_ulong Function
-%4994 = OpVariable %_ptr_Function_bool Function
-%4995 = OpVariable %_ptr_Function_ulong Function
-%4996 = OpVariable %_ptr_Function_ulong Function
-%4997 = OpVariable %_ptr_Function_ulong Function
-%4998 = OpVariable %_ptr_Function_ulong Function
-%4999 = OpVariable %_ptr_Function_ulong Function
-%5000 = OpVariable %_ptr_Function_ulong Function
-%5001 = OpVariable %_ptr_Function_ulong Function
-%5002 = OpVariable %_ptr_Function_ulong Function
-OpStore %4991 %4982
-OpStore %4992 %4983
-%5003 = OpLoad %uint %4992
-%5004 = OpUConvert %ulong %5003
-OpStore %4993 %5004
-OpBranch %4985
-%4985 = OpLabel
-%5005 = OpLoad %ulong %4991
-OpStore %5001 %5005
-OpStore %5002 %ulong_0
-OpBranch %4986
-%4986 = OpLabel
-%5006 = OpLoad %ulong %5002
-%5008 = OpULessThan %bool %5006 %ulong_8
-OpStore %4994 %5008
-%5009 = OpLoad %bool %4994
-OpLoopMerge %4988 %4990 None
-OpBranchConditional %5009 %4987 %4988
-%4988 = OpLabel
-OpBranch %4989
-%4989 = OpLabel
-%5010 = OpLoad %ulong %5001
-OpReturnValue %5010
-%4987 = OpLabel
-%5011 = OpLoad %ulong %5002
-%5012 = OpIMul %ulong %5011 %ulong_8
-OpStore %4995 %5012
-%5013 = OpLoad %ulong %4993
-%5014 = OpLoad %ulong %4995
-%5015 = OpShiftRightLogical %ulong %5013 %5014
-OpStore %4996 %5015
-%5016 = OpLoad %ulong %4996
-%5018 = OpBitwiseAnd %ulong %5016 %ulong_255
-OpStore %4997 %5018
-%5019 = OpLoad %ulong %5001
-%5020 = OpLoad %ulong %4997
-%5021 = OpBitwiseXor %ulong %5019 %5020
-OpStore %4998 %5021
-%5022 = OpLoad %ulong %4998
-%5024 = OpIMul %ulong %5022 %ulong_1099511628211
-OpStore %4999 %5024
-%5025 = OpLoad %ulong %5002
-%5026 = OpIAdd %ulong %5025 %ulong_1
-OpStore %5000 %5026
-%5027 = OpLoad %ulong %4999
-OpStore %5001 %5027
-%5028 = OpLoad %ulong %5000
-OpStore %5002 %5028
-OpBranch %4990
-%4990 = OpLabel
-OpBranch %4986
-OpFunctionEnd
-%5 = OpFunction %ulong None %5029
-%5030 = OpFunctionParameter %ulong
-%5031 = OpFunctionParameter %uchar
-%5032 = OpLabel
-%5039 = OpVariable %_ptr_Function_ulong Function
-%5040 = OpVariable %_ptr_Function_uchar Function
-%5041 = OpVariable %_ptr_Function_ulong Function
-%5042 = OpVariable %_ptr_Function_bool Function
-%5043 = OpVariable %_ptr_Function_ulong Function
-%5044 = OpVariable %_ptr_Function_ulong Function
-%5045 = OpVariable %_ptr_Function_ulong Function
-%5046 = OpVariable %_ptr_Function_ulong Function
-%5047 = OpVariable %_ptr_Function_ulong Function
-%5048 = OpVariable %_ptr_Function_ulong Function
-%5049 = OpVariable %_ptr_Function_ulong Function
-%5050 = OpVariable %_ptr_Function_ulong Function
-OpStore %5039 %5030
-OpStore %5040 %5031
-%5051 = OpLoad %uchar %5040
-%5052 = OpSConvert %ulong %5051
-OpStore %5041 %5052
-OpBranch %5033
-%5033 = OpLabel
-%5053 = OpLoad %ulong %5039
-OpStore %5049 %5053
-OpStore %5050 %ulong_0
-OpBranch %5034
-%5034 = OpLabel
-%5054 = OpLoad %ulong %5050
-%5055 = OpULessThan %bool %5054 %ulong_8
-OpStore %5042 %5055
-%5056 = OpLoad %bool %5042
-OpLoopMerge %5036 %5038 None
-OpBranchConditional %5056 %5035 %5036
-%5036 = OpLabel
-OpBranch %5037
-%5037 = OpLabel
-%5057 = OpLoad %ulong %5049
-OpReturnValue %5057
-%5035 = OpLabel
-%5058 = OpLoad %ulong %5050
-%5059 = OpIMul %ulong %5058 %ulong_8
-OpStore %5043 %5059
-%5060 = OpLoad %ulong %5041
-%5061 = OpLoad %ulong %5043
-%5062 = OpShiftRightLogical %ulong %5060 %5061
-OpStore %5044 %5062
-%5063 = OpLoad %ulong %5044
-%5064 = OpBitwiseAnd %ulong %5063 %ulong_255
-OpStore %5045 %5064
-%5065 = OpLoad %ulong %5049
-%5066 = OpLoad %ulong %5045
-%5067 = OpBitwiseXor %ulong %5065 %5066
-OpStore %5046 %5067
-%5068 = OpLoad %ulong %5046
-%5069 = OpIMul %ulong %5068 %ulong_1099511628211
-OpStore %5047 %5069
-%5070 = OpLoad %ulong %5050
-%5071 = OpIAdd %ulong %5070 %ulong_1
-OpStore %5048 %5071
-%5072 = OpLoad %ulong %5047
-OpStore %5049 %5072
-%5073 = OpLoad %ulong %5048
-OpStore %5050 %5073
-OpBranch %5038
-%5038 = OpLabel
-OpBranch %5034
+%3 = OpFunction %ulong None %5567
+%5568 = OpFunctionParameter %ulong
+%5569 = OpFunctionParameter %ulong
+%5570 = OpLabel
+%5575 = OpVariable %_ptr_Function_ulong Function
+%5576 = OpVariable %_ptr_Function_ulong Function
+%5577 = OpVariable %_ptr_Function_bool Function
+%5578 = OpVariable %_ptr_Function_ulong Function
+%5579 = OpVariable %_ptr_Function_ulong Function
+%5580 = OpVariable %_ptr_Function_ulong Function
+%5581 = OpVariable %_ptr_Function_ulong Function
+%5582 = OpVariable %_ptr_Function_ulong Function
+%5583 = OpVariable %_ptr_Function_ulong Function
+%5584 = OpVariable %_ptr_Function_ulong Function
+%5585 = OpVariable %_ptr_Function_ulong Function
+OpStore %5575 %5568
+OpStore %5576 %5569
+%5586 = OpLoad %ulong %5575
+OpStore %5584 %5586
+OpStore %5585 %ulong_0
+OpBranch %5571
+%5571 = OpLabel
+%5587 = OpLoad %ulong %5585
+%5588 = OpULessThan %bool %5587 %ulong_8
+OpStore %5577 %5588
+%5589 = OpLoad %bool %5577
+OpLoopMerge %5573 %5574 None
+OpBranchConditional %5589 %5572 %5573
+%5573 = OpLabel
+%5590 = OpLoad %ulong %5584
+OpReturnValue %5590
+%5572 = OpLabel
+%5591 = OpLoad %ulong %5585
+%5592 = OpIMul %ulong %5591 %ulong_8
+OpStore %5578 %5592
+%5593 = OpLoad %ulong %5576
+%5594 = OpLoad %ulong %5578
+%5595 = OpShiftRightLogical %ulong %5593 %5594
+OpStore %5579 %5595
+%5596 = OpLoad %ulong %5579
+%5597 = OpBitwiseAnd %ulong %5596 %ulong_255
+OpStore %5580 %5597
+%5598 = OpLoad %ulong %5584
+%5599 = OpLoad %ulong %5580
+%5600 = OpBitwiseXor %ulong %5598 %5599
+OpStore %5581 %5600
+%5601 = OpLoad %ulong %5581
+%5602 = OpIMul %ulong %5601 %ulong_1099511628211
+OpStore %5582 %5602
+%5603 = OpLoad %ulong %5585
+%5604 = OpIAdd %ulong %5603 %ulong_1
+OpStore %5583 %5604
+%5605 = OpLoad %ulong %5582
+OpStore %5584 %5605
+%5606 = OpLoad %ulong %5583
+OpStore %5585 %5606
+OpBranch %5574
+%5574 = OpLabel
+OpBranch %5571
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_lane_ops.dis
+++ b/test/golden/spirv/vec/vec_lane_ops.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 2171
+; Bound: 2204
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -17,42 +17,50 @@ OpDecorate %5 LinkageAttributes "corpus.cases.vec.vec_lane_ops.checksum" Export
 %ulong = OpTypeInt 64 0
 %uint = OpTypeInt 32 0
 %v4uint = OpTypeVector %uint 4
-%14 = OpTypeFunction %ulong %ulong %v4uint
+%10 = OpTypeFunction %ulong %ulong %v4uint
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4uint = OpTypePointer Function %v4uint
 %_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %float = OpTypeFloat 32
 %v4float = OpTypeVector %float 4
-%54 = OpTypeFunction %ulong %ulong %v4float
+%201 = OpTypeFunction %ulong %ulong %v4float
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_float = OpTypePointer Function %float
 %double = OpTypeFloat 64
 %v2double = OpTypeVector %double 2
-%93 = OpTypeFunction %ulong %ulong %v2double
+%396 = OpTypeFunction %ulong %ulong %v2double
 %_ptr_Function_v2double = OpTypePointer Function %v2double
 %_ptr_Function_double = OpTypePointer Function %double
 %uchar = OpTypeInt 8 0
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
-%119 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%494 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%240 = OpTypeFunction %ulong %ulong
+%881 = OpTypeFunction %ulong %ulong
 %uint_286331153 = OpConstant %uint 286331153
 %uint_572662306 = OpConstant %uint 572662306
 %uint_858993459 = OpConstant %uint 858993459
 %uint_1145324612 = OpConstant %uint 1145324612
-%830 = OpConstantNull %v4uint
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%1302 = OpConstantNull %v4uint
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %float_2_25 = OpConstant %float 2.25
 %float_0_5 = OpConstant %float 0.5
 %float_1_5 = OpConstant %float 1.5
 %float_3_75 = OpConstant %float 3.75
-%1287 = OpConstantNull %v4float
+%1543 = OpConstantNull %v4float
 %double_1_5 = OpConstant %double 1.5
 %double_n2_25 = OpConstant %double -2.25
-%1446 = OpConstantNull %v2double
+%1653 = OpConstantNull %v2double
 %uchar_247 = OpConstant %uchar 247
 %uchar_7 = OpConstant %uchar 7
 %uchar_251 = OpConstant %uchar 251
@@ -69,2863 +77,3016 @@ OpDecorate %5 LinkageAttributes "corpus.cases.vec.vec_lane_ops.checksum" Export
 %uchar_4 = OpConstant %uchar 4
 %uchar_250 = OpConstant %uchar 250
 %uchar_8 = OpConstant %uchar 8
-%1532 = OpConstantNull %_arr_uchar_uint_16
-%1978 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1981 = OpTypeFunction %ulong %ulong %uint
-%bool = OpTypeBool
-%_ptr_Function_bool = OpTypePointer Function %bool
-%ulong_0 = OpConstant %ulong 0
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%ulong_1 = OpConstant %ulong 1
-%2033 = OpTypeFunction %ulong %ulong %uchar
-%2078 = OpTypeFunction %ulong %ulong %float
-%2126 = OpTypeFunction %ulong %ulong %double
-%1 = OpFunction %ulong None %14
-%15 = OpFunctionParameter %ulong
-%16 = OpFunctionParameter %v4uint
-%17 = OpLabel
-%19 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_v4uint Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_uint Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_uint Function
-%28 = OpVariable %_ptr_Function_ulong Function
-%29 = OpVariable %_ptr_Function_uint Function
-%30 = OpVariable %_ptr_Function_ulong Function
-OpStore %19 %15
-OpStore %21 %16
-%31 = OpLoad %v4uint %21
-%32 = OpCompositeExtract %uint %31 0
-OpStore %23 %32
-%33 = OpLoad %ulong %19
-%34 = OpLoad %uint %23
-%35 = OpFunctionCall %ulong %7 %33 %34
-OpStore %24 %35
-%36 = OpLoad %v4uint %21
-%37 = OpCompositeExtract %uint %36 1
-OpStore %25 %37
-%38 = OpLoad %ulong %24
-%39 = OpLoad %uint %25
-%40 = OpFunctionCall %ulong %7 %38 %39
-OpStore %26 %40
-%41 = OpLoad %v4uint %21
-%42 = OpCompositeExtract %uint %41 2
-OpStore %27 %42
-%43 = OpLoad %ulong %26
-%44 = OpLoad %uint %27
-%45 = OpFunctionCall %ulong %7 %43 %44
-OpStore %28 %45
-%46 = OpLoad %v4uint %21
-%47 = OpCompositeExtract %uint %46 3
-OpStore %29 %47
-%48 = OpLoad %ulong %28
-%49 = OpLoad %uint %29
-%50 = OpFunctionCall %ulong %7 %48 %49
-OpStore %30 %50
-%51 = OpLoad %ulong %30
-OpReturnValue %51
-OpFunctionEnd
-%2 = OpFunction %ulong None %54
-%55 = OpFunctionParameter %ulong
-%56 = OpFunctionParameter %v4float
-%57 = OpLabel
-%58 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_v4float Function
-%62 = OpVariable %_ptr_Function_float Function
+%1718 = OpConstantNull %_arr_uchar_uint_16
+%2164 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %10
+%11 = OpFunctionParameter %ulong
+%12 = OpFunctionParameter %v4uint
+%13 = OpLabel
+%48 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_v4uint Function
+%52 = OpVariable %_ptr_Function_uint Function
+%53 = OpVariable %_ptr_Function_uint Function
+%54 = OpVariable %_ptr_Function_uint Function
+%55 = OpVariable %_ptr_Function_uint Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_bool Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
 %63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_float Function
+%64 = OpVariable %_ptr_Function_ulong Function
 %65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_float Function
+%66 = OpVariable %_ptr_Function_ulong Function
 %67 = OpVariable %_ptr_Function_ulong Function
-%68 = OpVariable %_ptr_Function_float Function
+%68 = OpVariable %_ptr_Function_bool Function
 %69 = OpVariable %_ptr_Function_ulong Function
-OpStore %58 %55
-OpStore %60 %56
-%70 = OpLoad %v4float %60
-%71 = OpCompositeExtract %float %70 0
-OpStore %62 %71
-%72 = OpLoad %ulong %58
-%73 = OpLoad %float %62
-%74 = OpFunctionCall %ulong %9 %72 %73
-OpStore %63 %74
-%75 = OpLoad %v4float %60
-%76 = OpCompositeExtract %float %75 1
-OpStore %64 %76
-%77 = OpLoad %ulong %63
-%78 = OpLoad %float %64
-%79 = OpFunctionCall %ulong %9 %77 %78
-OpStore %65 %79
-%80 = OpLoad %v4float %60
-%81 = OpCompositeExtract %float %80 2
-OpStore %66 %81
-%82 = OpLoad %ulong %65
-%83 = OpLoad %float %66
-%84 = OpFunctionCall %ulong %9 %82 %83
-OpStore %67 %84
-%85 = OpLoad %v4float %60
-%86 = OpCompositeExtract %float %85 3
-OpStore %68 %86
-%87 = OpLoad %ulong %67
-%88 = OpLoad %float %68
-%89 = OpFunctionCall %ulong %9 %87 %88
-OpStore %69 %89
-%90 = OpLoad %ulong %69
-OpReturnValue %90
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_bool Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_bool Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+OpStore %48 %11
+OpStore %50 %12
+%97 = OpLoad %v4uint %50
+%98 = OpCompositeExtract %uint %97 0
+OpStore %52 %98
+OpBranch %14
+%14 = OpLabel
+%99 = OpLoad %uint %52
+%100 = OpUConvert %ulong %99
+OpStore %56 %100
+OpBranch %16
+%16 = OpLabel
+%101 = OpLoad %ulong %48
+OpStore %65 %101
+OpStore %66 %ulong_0
+OpBranch %17
+%17 = OpLabel
+%103 = OpLoad %ulong %66
+%105 = OpULessThan %bool %103 %ulong_8
+OpStore %58 %105
+%106 = OpLoad %bool %58
+OpLoopMerge %19 %45 None
+OpBranchConditional %106 %18 %19
+%19 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%107 = OpLoad %v4uint %50
+%108 = OpCompositeExtract %uint %107 1
+OpStore %53 %108
+OpBranch %21
+%21 = OpLabel
+%109 = OpLoad %uint %53
+%110 = OpUConvert %ulong %109
+OpStore %67 %110
+OpBranch %23
+%23 = OpLabel
+%111 = OpLoad %ulong %65
+OpStore %75 %111
+OpStore %76 %ulong_0
+OpBranch %24
+%24 = OpLabel
+%112 = OpLoad %ulong %76
+%113 = OpULessThan %bool %112 %ulong_8
+OpStore %68 %113
+%114 = OpLoad %bool %68
+OpLoopMerge %26 %44 None
+OpBranchConditional %114 %25 %26
+%26 = OpLabel
+OpBranch %27
+%27 = OpLabel
+OpBranch %22
+%22 = OpLabel
+%115 = OpLoad %v4uint %50
+%116 = OpCompositeExtract %uint %115 2
+OpStore %54 %116
+OpBranch %28
+%28 = OpLabel
+%117 = OpLoad %uint %54
+%118 = OpUConvert %ulong %117
+OpStore %77 %118
+OpBranch %30
+%30 = OpLabel
+%119 = OpLoad %ulong %75
+OpStore %85 %119
+OpStore %86 %ulong_0
+OpBranch %31
+%31 = OpLabel
+%120 = OpLoad %ulong %86
+%121 = OpULessThan %bool %120 %ulong_8
+OpStore %78 %121
+%122 = OpLoad %bool %78
+OpLoopMerge %33 %43 None
+OpBranchConditional %122 %32 %33
+%33 = OpLabel
+OpBranch %34
+%34 = OpLabel
+OpBranch %29
+%29 = OpLabel
+%123 = OpLoad %v4uint %50
+%124 = OpCompositeExtract %uint %123 3
+OpStore %55 %124
+OpBranch %35
+%35 = OpLabel
+%125 = OpLoad %uint %55
+%126 = OpUConvert %ulong %125
+OpStore %87 %126
+OpBranch %37
+%37 = OpLabel
+%127 = OpLoad %ulong %85
+OpStore %95 %127
+OpStore %96 %ulong_0
+OpBranch %38
+%38 = OpLabel
+%128 = OpLoad %ulong %96
+%129 = OpULessThan %bool %128 %ulong_8
+OpStore %88 %129
+%130 = OpLoad %bool %88
+OpLoopMerge %40 %42 None
+OpBranchConditional %130 %39 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+OpBranch %36
+%36 = OpLabel
+%131 = OpLoad %ulong %95
+OpReturnValue %131
+%39 = OpLabel
+%132 = OpLoad %ulong %96
+%133 = OpIMul %ulong %132 %ulong_8
+OpStore %89 %133
+%134 = OpLoad %ulong %87
+%135 = OpLoad %ulong %89
+%136 = OpShiftRightLogical %ulong %134 %135
+OpStore %90 %136
+%137 = OpLoad %ulong %90
+%139 = OpBitwiseAnd %ulong %137 %ulong_255
+OpStore %91 %139
+%140 = OpLoad %ulong %95
+%141 = OpLoad %ulong %91
+%142 = OpBitwiseXor %ulong %140 %141
+OpStore %92 %142
+%143 = OpLoad %ulong %92
+%145 = OpIMul %ulong %143 %ulong_1099511628211
+OpStore %93 %145
+%146 = OpLoad %ulong %96
+%148 = OpIAdd %ulong %146 %ulong_1
+OpStore %94 %148
+%149 = OpLoad %ulong %93
+OpStore %95 %149
+%150 = OpLoad %ulong %94
+OpStore %96 %150
+OpBranch %42
+%32 = OpLabel
+%151 = OpLoad %ulong %86
+%152 = OpIMul %ulong %151 %ulong_8
+OpStore %79 %152
+%153 = OpLoad %ulong %77
+%154 = OpLoad %ulong %79
+%155 = OpShiftRightLogical %ulong %153 %154
+OpStore %80 %155
+%156 = OpLoad %ulong %80
+%157 = OpBitwiseAnd %ulong %156 %ulong_255
+OpStore %81 %157
+%158 = OpLoad %ulong %85
+%159 = OpLoad %ulong %81
+%160 = OpBitwiseXor %ulong %158 %159
+OpStore %82 %160
+%161 = OpLoad %ulong %82
+%162 = OpIMul %ulong %161 %ulong_1099511628211
+OpStore %83 %162
+%163 = OpLoad %ulong %86
+%164 = OpIAdd %ulong %163 %ulong_1
+OpStore %84 %164
+%165 = OpLoad %ulong %83
+OpStore %85 %165
+%166 = OpLoad %ulong %84
+OpStore %86 %166
+OpBranch %43
+%25 = OpLabel
+%167 = OpLoad %ulong %76
+%168 = OpIMul %ulong %167 %ulong_8
+OpStore %69 %168
+%169 = OpLoad %ulong %67
+%170 = OpLoad %ulong %69
+%171 = OpShiftRightLogical %ulong %169 %170
+OpStore %70 %171
+%172 = OpLoad %ulong %70
+%173 = OpBitwiseAnd %ulong %172 %ulong_255
+OpStore %71 %173
+%174 = OpLoad %ulong %75
+%175 = OpLoad %ulong %71
+%176 = OpBitwiseXor %ulong %174 %175
+OpStore %72 %176
+%177 = OpLoad %ulong %72
+%178 = OpIMul %ulong %177 %ulong_1099511628211
+OpStore %73 %178
+%179 = OpLoad %ulong %76
+%180 = OpIAdd %ulong %179 %ulong_1
+OpStore %74 %180
+%181 = OpLoad %ulong %73
+OpStore %75 %181
+%182 = OpLoad %ulong %74
+OpStore %76 %182
+OpBranch %44
+%18 = OpLabel
+%183 = OpLoad %ulong %66
+%184 = OpIMul %ulong %183 %ulong_8
+OpStore %59 %184
+%185 = OpLoad %ulong %56
+%186 = OpLoad %ulong %59
+%187 = OpShiftRightLogical %ulong %185 %186
+OpStore %60 %187
+%188 = OpLoad %ulong %60
+%189 = OpBitwiseAnd %ulong %188 %ulong_255
+OpStore %61 %189
+%190 = OpLoad %ulong %65
+%191 = OpLoad %ulong %61
+%192 = OpBitwiseXor %ulong %190 %191
+OpStore %62 %192
+%193 = OpLoad %ulong %62
+%194 = OpIMul %ulong %193 %ulong_1099511628211
+OpStore %63 %194
+%195 = OpLoad %ulong %66
+%196 = OpIAdd %ulong %195 %ulong_1
+OpStore %64 %196
+%197 = OpLoad %ulong %63
+OpStore %65 %197
+%198 = OpLoad %ulong %64
+OpStore %66 %198
+OpBranch %45
+%42 = OpLabel
+OpBranch %38
+%43 = OpLabel
+OpBranch %31
+%44 = OpLabel
+OpBranch %24
+%45 = OpLabel
+OpBranch %17
 OpFunctionEnd
-%3 = OpFunction %ulong None %93
-%94 = OpFunctionParameter %ulong
-%95 = OpFunctionParameter %v2double
-%96 = OpLabel
-%97 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_v2double Function
-%101 = OpVariable %_ptr_Function_double Function
-%102 = OpVariable %_ptr_Function_ulong Function
-%103 = OpVariable %_ptr_Function_double Function
-%104 = OpVariable %_ptr_Function_ulong Function
-OpStore %97 %94
-OpStore %99 %95
-%105 = OpLoad %v2double %99
-%106 = OpCompositeExtract %double %105 0
-OpStore %101 %106
-%107 = OpLoad %ulong %97
-%108 = OpLoad %double %101
-%109 = OpFunctionCall %ulong %10 %107 %108
-OpStore %102 %109
-%110 = OpLoad %v2double %99
-%111 = OpCompositeExtract %double %110 1
-OpStore %103 %111
-%112 = OpLoad %ulong %102
-%113 = OpLoad %double %103
-%114 = OpFunctionCall %ulong %10 %112 %113
-OpStore %104 %114
-%115 = OpLoad %ulong %104
-OpReturnValue %115
+%2 = OpFunction %ulong None %201
+%202 = OpFunctionParameter %ulong
+%203 = OpFunctionParameter %v4float
+%204 = OpLabel
+%237 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_v4float Function
+%241 = OpVariable %_ptr_Function_float Function
+%242 = OpVariable %_ptr_Function_float Function
+%243 = OpVariable %_ptr_Function_float Function
+%244 = OpVariable %_ptr_Function_float Function
+%245 = OpVariable %_ptr_Function_uint Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_bool Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_uint Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_bool Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_uint Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_bool Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_uint Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_bool Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+OpStore %237 %202
+OpStore %239 %203
+%289 = OpLoad %v4float %239
+%290 = OpCompositeExtract %float %289 0
+OpStore %241 %290
+OpBranch %205
+%205 = OpLabel
+%291 = OpLoad %float %241
+%292 = OpBitcast %uint %291
+OpStore %245 %292
+%293 = OpLoad %uint %245
+%294 = OpUConvert %ulong %293
+OpStore %246 %294
+OpBranch %207
+%207 = OpLabel
+%295 = OpLoad %ulong %237
+OpStore %254 %295
+OpStore %255 %ulong_0
+OpBranch %208
+%208 = OpLabel
+%296 = OpLoad %ulong %255
+%297 = OpULessThan %bool %296 %ulong_8
+OpStore %247 %297
+%298 = OpLoad %bool %247
+OpLoopMerge %210 %236 None
+OpBranchConditional %298 %209 %210
+%210 = OpLabel
+OpBranch %211
+%211 = OpLabel
+OpBranch %206
+%206 = OpLabel
+%299 = OpLoad %v4float %239
+%300 = OpCompositeExtract %float %299 1
+OpStore %242 %300
+OpBranch %212
+%212 = OpLabel
+%301 = OpLoad %float %242
+%302 = OpBitcast %uint %301
+OpStore %256 %302
+%303 = OpLoad %uint %256
+%304 = OpUConvert %ulong %303
+OpStore %257 %304
+OpBranch %214
+%214 = OpLabel
+%305 = OpLoad %ulong %254
+OpStore %265 %305
+OpStore %266 %ulong_0
+OpBranch %215
+%215 = OpLabel
+%306 = OpLoad %ulong %266
+%307 = OpULessThan %bool %306 %ulong_8
+OpStore %258 %307
+%308 = OpLoad %bool %258
+OpLoopMerge %217 %235 None
+OpBranchConditional %308 %216 %217
+%217 = OpLabel
+OpBranch %218
+%218 = OpLabel
+OpBranch %213
+%213 = OpLabel
+%309 = OpLoad %v4float %239
+%310 = OpCompositeExtract %float %309 2
+OpStore %243 %310
+OpBranch %219
+%219 = OpLabel
+%311 = OpLoad %float %243
+%312 = OpBitcast %uint %311
+OpStore %267 %312
+%313 = OpLoad %uint %267
+%314 = OpUConvert %ulong %313
+OpStore %268 %314
+OpBranch %221
+%221 = OpLabel
+%315 = OpLoad %ulong %265
+OpStore %276 %315
+OpStore %277 %ulong_0
+OpBranch %222
+%222 = OpLabel
+%316 = OpLoad %ulong %277
+%317 = OpULessThan %bool %316 %ulong_8
+OpStore %269 %317
+%318 = OpLoad %bool %269
+OpLoopMerge %224 %234 None
+OpBranchConditional %318 %223 %224
+%224 = OpLabel
+OpBranch %225
+%225 = OpLabel
+OpBranch %220
+%220 = OpLabel
+%319 = OpLoad %v4float %239
+%320 = OpCompositeExtract %float %319 3
+OpStore %244 %320
+OpBranch %226
+%226 = OpLabel
+%321 = OpLoad %float %244
+%322 = OpBitcast %uint %321
+OpStore %278 %322
+%323 = OpLoad %uint %278
+%324 = OpUConvert %ulong %323
+OpStore %279 %324
+OpBranch %228
+%228 = OpLabel
+%325 = OpLoad %ulong %276
+OpStore %287 %325
+OpStore %288 %ulong_0
+OpBranch %229
+%229 = OpLabel
+%326 = OpLoad %ulong %288
+%327 = OpULessThan %bool %326 %ulong_8
+OpStore %280 %327
+%328 = OpLoad %bool %280
+OpLoopMerge %231 %233 None
+OpBranchConditional %328 %230 %231
+%231 = OpLabel
+OpBranch %232
+%232 = OpLabel
+OpBranch %227
+%227 = OpLabel
+%329 = OpLoad %ulong %287
+OpReturnValue %329
+%230 = OpLabel
+%330 = OpLoad %ulong %288
+%331 = OpIMul %ulong %330 %ulong_8
+OpStore %281 %331
+%332 = OpLoad %ulong %279
+%333 = OpLoad %ulong %281
+%334 = OpShiftRightLogical %ulong %332 %333
+OpStore %282 %334
+%335 = OpLoad %ulong %282
+%336 = OpBitwiseAnd %ulong %335 %ulong_255
+OpStore %283 %336
+%337 = OpLoad %ulong %287
+%338 = OpLoad %ulong %283
+%339 = OpBitwiseXor %ulong %337 %338
+OpStore %284 %339
+%340 = OpLoad %ulong %284
+%341 = OpIMul %ulong %340 %ulong_1099511628211
+OpStore %285 %341
+%342 = OpLoad %ulong %288
+%343 = OpIAdd %ulong %342 %ulong_1
+OpStore %286 %343
+%344 = OpLoad %ulong %285
+OpStore %287 %344
+%345 = OpLoad %ulong %286
+OpStore %288 %345
+OpBranch %233
+%223 = OpLabel
+%346 = OpLoad %ulong %277
+%347 = OpIMul %ulong %346 %ulong_8
+OpStore %270 %347
+%348 = OpLoad %ulong %268
+%349 = OpLoad %ulong %270
+%350 = OpShiftRightLogical %ulong %348 %349
+OpStore %271 %350
+%351 = OpLoad %ulong %271
+%352 = OpBitwiseAnd %ulong %351 %ulong_255
+OpStore %272 %352
+%353 = OpLoad %ulong %276
+%354 = OpLoad %ulong %272
+%355 = OpBitwiseXor %ulong %353 %354
+OpStore %273 %355
+%356 = OpLoad %ulong %273
+%357 = OpIMul %ulong %356 %ulong_1099511628211
+OpStore %274 %357
+%358 = OpLoad %ulong %277
+%359 = OpIAdd %ulong %358 %ulong_1
+OpStore %275 %359
+%360 = OpLoad %ulong %274
+OpStore %276 %360
+%361 = OpLoad %ulong %275
+OpStore %277 %361
+OpBranch %234
+%216 = OpLabel
+%362 = OpLoad %ulong %266
+%363 = OpIMul %ulong %362 %ulong_8
+OpStore %259 %363
+%364 = OpLoad %ulong %257
+%365 = OpLoad %ulong %259
+%366 = OpShiftRightLogical %ulong %364 %365
+OpStore %260 %366
+%367 = OpLoad %ulong %260
+%368 = OpBitwiseAnd %ulong %367 %ulong_255
+OpStore %261 %368
+%369 = OpLoad %ulong %265
+%370 = OpLoad %ulong %261
+%371 = OpBitwiseXor %ulong %369 %370
+OpStore %262 %371
+%372 = OpLoad %ulong %262
+%373 = OpIMul %ulong %372 %ulong_1099511628211
+OpStore %263 %373
+%374 = OpLoad %ulong %266
+%375 = OpIAdd %ulong %374 %ulong_1
+OpStore %264 %375
+%376 = OpLoad %ulong %263
+OpStore %265 %376
+%377 = OpLoad %ulong %264
+OpStore %266 %377
+OpBranch %235
+%209 = OpLabel
+%378 = OpLoad %ulong %255
+%379 = OpIMul %ulong %378 %ulong_8
+OpStore %248 %379
+%380 = OpLoad %ulong %246
+%381 = OpLoad %ulong %248
+%382 = OpShiftRightLogical %ulong %380 %381
+OpStore %249 %382
+%383 = OpLoad %ulong %249
+%384 = OpBitwiseAnd %ulong %383 %ulong_255
+OpStore %250 %384
+%385 = OpLoad %ulong %254
+%386 = OpLoad %ulong %250
+%387 = OpBitwiseXor %ulong %385 %386
+OpStore %251 %387
+%388 = OpLoad %ulong %251
+%389 = OpIMul %ulong %388 %ulong_1099511628211
+OpStore %252 %389
+%390 = OpLoad %ulong %255
+%391 = OpIAdd %ulong %390 %ulong_1
+OpStore %253 %391
+%392 = OpLoad %ulong %252
+OpStore %254 %392
+%393 = OpLoad %ulong %253
+OpStore %255 %393
+OpBranch %236
+%233 = OpLabel
+OpBranch %229
+%234 = OpLabel
+OpBranch %222
+%235 = OpLabel
+OpBranch %215
+%236 = OpLabel
+OpBranch %208
 OpFunctionEnd
-%4 = OpFunction %ulong None %119
-%120 = OpFunctionParameter %ulong
-%121 = OpFunctionParameter %_arr_uchar_uint_16
-%122 = OpLabel
-%123 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%127 = OpVariable %_ptr_Function_uchar Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_uchar Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_uchar Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_uchar Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_uchar Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_uchar Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_uchar Function
-%140 = OpVariable %_ptr_Function_ulong Function
-%141 = OpVariable %_ptr_Function_uchar Function
-%142 = OpVariable %_ptr_Function_ulong Function
-%143 = OpVariable %_ptr_Function_uchar Function
-%144 = OpVariable %_ptr_Function_ulong Function
-%145 = OpVariable %_ptr_Function_uchar Function
-%146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_uchar Function
-%148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_uchar Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_uchar Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_uchar Function
-%154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_uchar Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_uchar Function
-%158 = OpVariable %_ptr_Function_ulong Function
-OpStore %123 %120
-OpStore %125 %121
-%159 = OpLoad %_arr_uchar_uint_16 %125
-%160 = OpCompositeExtract %uchar %159 0
-OpStore %127 %160
-%161 = OpLoad %ulong %123
-%162 = OpLoad %uchar %127
-%163 = OpFunctionCall %ulong %8 %161 %162
-OpStore %128 %163
-%164 = OpLoad %_arr_uchar_uint_16 %125
-%165 = OpCompositeExtract %uchar %164 1
-OpStore %129 %165
-%166 = OpLoad %ulong %128
-%167 = OpLoad %uchar %129
-%168 = OpFunctionCall %ulong %8 %166 %167
-OpStore %130 %168
-%169 = OpLoad %_arr_uchar_uint_16 %125
-%170 = OpCompositeExtract %uchar %169 2
-OpStore %131 %170
-%171 = OpLoad %ulong %130
-%172 = OpLoad %uchar %131
-%173 = OpFunctionCall %ulong %8 %171 %172
-OpStore %132 %173
-%174 = OpLoad %_arr_uchar_uint_16 %125
-%175 = OpCompositeExtract %uchar %174 3
-OpStore %133 %175
-%176 = OpLoad %ulong %132
-%177 = OpLoad %uchar %133
-%178 = OpFunctionCall %ulong %8 %176 %177
-OpStore %134 %178
-%179 = OpLoad %_arr_uchar_uint_16 %125
-%180 = OpCompositeExtract %uchar %179 4
-OpStore %135 %180
-%181 = OpLoad %ulong %134
-%182 = OpLoad %uchar %135
-%183 = OpFunctionCall %ulong %8 %181 %182
-OpStore %136 %183
-%184 = OpLoad %_arr_uchar_uint_16 %125
-%185 = OpCompositeExtract %uchar %184 5
-OpStore %137 %185
-%186 = OpLoad %ulong %136
-%187 = OpLoad %uchar %137
-%188 = OpFunctionCall %ulong %8 %186 %187
-OpStore %138 %188
-%189 = OpLoad %_arr_uchar_uint_16 %125
-%190 = OpCompositeExtract %uchar %189 6
-OpStore %139 %190
-%191 = OpLoad %ulong %138
-%192 = OpLoad %uchar %139
-%193 = OpFunctionCall %ulong %8 %191 %192
-OpStore %140 %193
-%194 = OpLoad %_arr_uchar_uint_16 %125
-%195 = OpCompositeExtract %uchar %194 7
-OpStore %141 %195
-%196 = OpLoad %ulong %140
-%197 = OpLoad %uchar %141
-%198 = OpFunctionCall %ulong %8 %196 %197
-OpStore %142 %198
-%199 = OpLoad %_arr_uchar_uint_16 %125
-%200 = OpCompositeExtract %uchar %199 8
-OpStore %143 %200
-%201 = OpLoad %ulong %142
-%202 = OpLoad %uchar %143
-%203 = OpFunctionCall %ulong %8 %201 %202
-OpStore %144 %203
-%204 = OpLoad %_arr_uchar_uint_16 %125
-%205 = OpCompositeExtract %uchar %204 9
-OpStore %145 %205
-%206 = OpLoad %ulong %144
-%207 = OpLoad %uchar %145
-%208 = OpFunctionCall %ulong %8 %206 %207
-OpStore %146 %208
-%209 = OpLoad %_arr_uchar_uint_16 %125
-%210 = OpCompositeExtract %uchar %209 10
-OpStore %147 %210
-%211 = OpLoad %ulong %146
-%212 = OpLoad %uchar %147
-%213 = OpFunctionCall %ulong %8 %211 %212
-OpStore %148 %213
-%214 = OpLoad %_arr_uchar_uint_16 %125
-%215 = OpCompositeExtract %uchar %214 11
-OpStore %149 %215
-%216 = OpLoad %ulong %148
-%217 = OpLoad %uchar %149
-%218 = OpFunctionCall %ulong %8 %216 %217
-OpStore %150 %218
-%219 = OpLoad %_arr_uchar_uint_16 %125
-%220 = OpCompositeExtract %uchar %219 12
-OpStore %151 %220
-%221 = OpLoad %ulong %150
-%222 = OpLoad %uchar %151
-%223 = OpFunctionCall %ulong %8 %221 %222
-OpStore %152 %223
-%224 = OpLoad %_arr_uchar_uint_16 %125
-%225 = OpCompositeExtract %uchar %224 13
-OpStore %153 %225
-%226 = OpLoad %ulong %152
-%227 = OpLoad %uchar %153
-%228 = OpFunctionCall %ulong %8 %226 %227
-OpStore %154 %228
-%229 = OpLoad %_arr_uchar_uint_16 %125
-%230 = OpCompositeExtract %uchar %229 14
-OpStore %155 %230
-%231 = OpLoad %ulong %154
-%232 = OpLoad %uchar %155
-%233 = OpFunctionCall %ulong %8 %231 %232
-OpStore %156 %233
-%234 = OpLoad %_arr_uchar_uint_16 %125
-%235 = OpCompositeExtract %uchar %234 15
-OpStore %157 %235
-%236 = OpLoad %ulong %156
-%237 = OpLoad %uchar %157
-%238 = OpFunctionCall %ulong %8 %236 %237
-OpStore %158 %238
-%239 = OpLoad %ulong %158
-OpReturnValue %239
-OpFunctionEnd
-%5 = OpFunction %ulong None %240
-%241 = OpFunctionParameter %ulong
-%242 = OpLabel
-%281 = OpVariable %_ptr_Function_v4uint Function
-%282 = OpVariable %_ptr_Function_v4uint Function
-%283 = OpVariable %_ptr_Function_v4uint Function
-%284 = OpVariable %_ptr_Function_v4uint Function
-%285 = OpVariable %_ptr_Function_v4uint Function
-%286 = OpVariable %_ptr_Function_v4float Function
-%287 = OpVariable %_ptr_Function_v4float Function
-%288 = OpVariable %_ptr_Function_v2double Function
-%289 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_uint Function
-%293 = OpVariable %_ptr_Function_float Function
-%294 = OpVariable %_ptr_Function_double Function
-%295 = OpVariable %_ptr_Function_uchar Function
-%296 = OpVariable %_ptr_Function_v4uint Function
-%297 = OpVariable %_ptr_Function_uint Function
-%298 = OpVariable %_ptr_Function_uint Function
-%299 = OpVariable %_ptr_Function_v4uint Function
-%300 = OpVariable %_ptr_Function_uint Function
-%301 = OpVariable %_ptr_Function_uint Function
-%302 = OpVariable %_ptr_Function_v4uint Function
-%303 = OpVariable %_ptr_Function_uint Function
-%304 = OpVariable %_ptr_Function_v4uint Function
-%305 = OpVariable %_ptr_Function_v4uint Function
-%306 = OpVariable %_ptr_Function_uint Function
-%307 = OpVariable %_ptr_Function_v4uint Function
-%308 = OpVariable %_ptr_Function_v4uint Function
-%309 = OpVariable %_ptr_Function_uint Function
-%310 = OpVariable %_ptr_Function_v4uint Function
-%311 = OpVariable %_ptr_Function_v4uint Function
-%312 = OpVariable %_ptr_Function_uint Function
-%313 = OpVariable %_ptr_Function_v4uint Function
-%314 = OpVariable %_ptr_Function_v4uint Function
-%315 = OpVariable %_ptr_Function_v4uint Function
-%316 = OpVariable %_ptr_Function_uint Function
-%317 = OpVariable %_ptr_Function_v4uint Function
-%318 = OpVariable %_ptr_Function_v4uint Function
-%319 = OpVariable %_ptr_Function_uint Function
-%320 = OpVariable %_ptr_Function_v4uint Function
-%321 = OpVariable %_ptr_Function_v4uint Function
-%322 = OpVariable %_ptr_Function_uint Function
-%323 = OpVariable %_ptr_Function_v4uint Function
-%324 = OpVariable %_ptr_Function_v4uint Function
-%325 = OpVariable %_ptr_Function_uint Function
-%326 = OpVariable %_ptr_Function_v4uint Function
-%327 = OpVariable %_ptr_Function_v4uint Function
-%328 = OpVariable %_ptr_Function_v4uint Function
-%329 = OpVariable %_ptr_Function_uint Function
-%330 = OpVariable %_ptr_Function_v4uint Function
-%331 = OpVariable %_ptr_Function_v4uint Function
-%332 = OpVariable %_ptr_Function_uint Function
-%333 = OpVariable %_ptr_Function_v4uint Function
-%334 = OpVariable %_ptr_Function_v4uint Function
-%335 = OpVariable %_ptr_Function_uint Function
-%336 = OpVariable %_ptr_Function_v4uint Function
-%337 = OpVariable %_ptr_Function_v4uint Function
-%338 = OpVariable %_ptr_Function_uint Function
-%339 = OpVariable %_ptr_Function_v4uint Function
-%340 = OpVariable %_ptr_Function_v4uint Function
-%341 = OpVariable %_ptr_Function_v4uint Function
-%342 = OpVariable %_ptr_Function_uint Function
-%343 = OpVariable %_ptr_Function_v4uint Function
-%344 = OpVariable %_ptr_Function_v4uint Function
-%345 = OpVariable %_ptr_Function_v4uint Function
-%346 = OpVariable %_ptr_Function_v4uint Function
-%347 = OpVariable %_ptr_Function_v4uint Function
-%348 = OpVariable %_ptr_Function_v4uint Function
-%349 = OpVariable %_ptr_Function_v4uint Function
-%350 = OpVariable %_ptr_Function_v4uint Function
-%351 = OpVariable %_ptr_Function_v4uint Function
-%352 = OpVariable %_ptr_Function_uint Function
-%353 = OpVariable %_ptr_Function_v4uint Function
-%354 = OpVariable %_ptr_Function_v4uint Function
-%355 = OpVariable %_ptr_Function_v4uint Function
-%356 = OpVariable %_ptr_Function_uint Function
-%357 = OpVariable %_ptr_Function_v4uint Function
-%358 = OpVariable %_ptr_Function_uint Function
-%359 = OpVariable %_ptr_Function_v4uint Function
-%360 = OpVariable %_ptr_Function_v4uint Function
-%361 = OpVariable %_ptr_Function_uint Function
-%362 = OpVariable %_ptr_Function_uint Function
-%363 = OpVariable %_ptr_Function_v4uint Function
-%364 = OpVariable %_ptr_Function_uint Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_uint Function
-%367 = OpVariable %_ptr_Function_uint Function
-%368 = OpVariable %_ptr_Function_v4uint Function
-%369 = OpVariable %_ptr_Function_uint Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_uint Function
-%372 = OpVariable %_ptr_Function_uint Function
-%373 = OpVariable %_ptr_Function_v4uint Function
-%374 = OpVariable %_ptr_Function_uint Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_uint Function
-%377 = OpVariable %_ptr_Function_uint Function
-%378 = OpVariable %_ptr_Function_v4uint Function
-%379 = OpVariable %_ptr_Function_uint Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_v4uint Function
-%382 = OpVariable %_ptr_Function_v4uint Function
-%383 = OpVariable %_ptr_Function_v4uint Function
-%384 = OpVariable %_ptr_Function_v4uint Function
-%385 = OpVariable %_ptr_Function_v4uint Function
-%386 = OpVariable %_ptr_Function_v4uint Function
-%387 = OpVariable %_ptr_Function_v4uint Function
-%388 = OpVariable %_ptr_Function_v4uint Function
-%389 = OpVariable %_ptr_Function_v4uint Function
-%390 = OpVariable %_ptr_Function_float Function
-%391 = OpVariable %_ptr_Function_float Function
-%392 = OpVariable %_ptr_Function_v4float Function
-%393 = OpVariable %_ptr_Function_float Function
-%394 = OpVariable %_ptr_Function_float Function
-%395 = OpVariable %_ptr_Function_v4float Function
-%396 = OpVariable %_ptr_Function_float Function
-%397 = OpVariable %_ptr_Function_v4float Function
-%398 = OpVariable %_ptr_Function_v4float Function
-%399 = OpVariable %_ptr_Function_float Function
-%400 = OpVariable %_ptr_Function_v4float Function
-%401 = OpVariable %_ptr_Function_v4float Function
-%402 = OpVariable %_ptr_Function_float Function
-%403 = OpVariable %_ptr_Function_v4float Function
-%404 = OpVariable %_ptr_Function_v4float Function
-%405 = OpVariable %_ptr_Function_float Function
-%406 = OpVariable %_ptr_Function_v4float Function
-%407 = OpVariable %_ptr_Function_v4float Function
-%408 = OpVariable %_ptr_Function_v4float Function
-%409 = OpVariable %_ptr_Function_float Function
-%410 = OpVariable %_ptr_Function_v4float Function
-%411 = OpVariable %_ptr_Function_v4float Function
-%412 = OpVariable %_ptr_Function_v4float Function
-%413 = OpVariable %_ptr_Function_float Function
-%414 = OpVariable %_ptr_Function_v4float Function
-%415 = OpVariable %_ptr_Function_v4float Function
-%416 = OpVariable %_ptr_Function_float Function
-%417 = OpVariable %_ptr_Function_v4float Function
-%418 = OpVariable %_ptr_Function_v4float Function
-%419 = OpVariable %_ptr_Function_v4float Function
-%420 = OpVariable %_ptr_Function_float Function
-%421 = OpVariable %_ptr_Function_v4float Function
-%422 = OpVariable %_ptr_Function_v4float Function
-%423 = OpVariable %_ptr_Function_v4float Function
-%424 = OpVariable %_ptr_Function_v4float Function
-%425 = OpVariable %_ptr_Function_v4float Function
-%426 = OpVariable %_ptr_Function_v4float Function
-%427 = OpVariable %_ptr_Function_float Function
-%428 = OpVariable %_ptr_Function_v4float Function
-%429 = OpVariable %_ptr_Function_float Function
-%430 = OpVariable %_ptr_Function_float Function
+%3 = OpFunction %ulong None %396
+%397 = OpFunctionParameter %ulong
+%398 = OpFunctionParameter %v2double
+%399 = OpLabel
+%416 = OpVariable %_ptr_Function_ulong Function
+%418 = OpVariable %_ptr_Function_v2double Function
+%420 = OpVariable %_ptr_Function_double Function
+%421 = OpVariable %_ptr_Function_double Function
+%422 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_bool Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_ulong Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
 %431 = OpVariable %_ptr_Function_ulong Function
-%432 = OpVariable %_ptr_Function_float Function
-%433 = OpVariable %_ptr_Function_v4float Function
-%434 = OpVariable %_ptr_Function_float Function
-%435 = OpVariable %_ptr_Function_float Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_bool Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
 %436 = OpVariable %_ptr_Function_ulong Function
-%437 = OpVariable %_ptr_Function_v2double Function
-%438 = OpVariable %_ptr_Function_double Function
-%439 = OpVariable %_ptr_Function_double Function
-%440 = OpVariable %_ptr_Function_v2double Function
-%441 = OpVariable %_ptr_Function_double Function
-%442 = OpVariable %_ptr_Function_v2double Function
-%443 = OpVariable %_ptr_Function_v2double Function
-%444 = OpVariable %_ptr_Function_double Function
-%445 = OpVariable %_ptr_Function_v2double Function
-%446 = OpVariable %_ptr_Function_v2double Function
-%447 = OpVariable %_ptr_Function_v2double Function
-%448 = OpVariable %_ptr_Function_v2double Function
-%449 = OpVariable %_ptr_Function_v2double Function
-%450 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%451 = OpVariable %_ptr_Function_uchar Function
-%452 = OpVariable %_ptr_Function_uchar Function
-%453 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%454 = OpVariable %_ptr_Function_uchar Function
-%455 = OpVariable %_ptr_Function_uchar Function
-%456 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_uchar Function
-%459 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%460 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%461 = OpVariable %_ptr_Function_uchar Function
-%462 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%463 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%464 = OpVariable %_ptr_Function_uchar Function
-%465 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%466 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%467 = OpVariable %_ptr_Function_uchar Function
-%468 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%469 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%470 = OpVariable %_ptr_Function_uchar Function
-%471 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%472 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%473 = OpVariable %_ptr_Function_uchar Function
-%474 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%475 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%476 = OpVariable %_ptr_Function_uchar Function
-%477 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%478 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%479 = OpVariable %_ptr_Function_uchar Function
-%480 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%481 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%482 = OpVariable %_ptr_Function_uchar Function
-%483 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%484 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%485 = OpVariable %_ptr_Function_uchar Function
-%486 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%487 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%488 = OpVariable %_ptr_Function_uchar Function
-%489 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%490 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%491 = OpVariable %_ptr_Function_uchar Function
-%492 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%493 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%494 = OpVariable %_ptr_Function_uchar Function
-%495 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%496 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%497 = OpVariable %_ptr_Function_uchar Function
-%498 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%499 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%500 = OpVariable %_ptr_Function_uchar Function
-%501 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%502 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%503 = OpVariable %_ptr_Function_uchar Function
-%504 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%505 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%506 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%509 = OpVariable %_ptr_Function_ulong Function
-%510 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_uint Function
-%513 = OpVariable %_ptr_Function_ulong Function
-%514 = OpVariable %_ptr_Function_uint Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_uint Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_uint Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_uint Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_uint Function
-%523 = OpVariable %_ptr_Function_ulong Function
-%524 = OpVariable %_ptr_Function_uint Function
-%525 = OpVariable %_ptr_Function_ulong Function
-%526 = OpVariable %_ptr_Function_uint Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_uint Function
-%529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_uint Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_uint Function
-%533 = OpVariable %_ptr_Function_ulong Function
-%534 = OpVariable %_ptr_Function_uint Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_uint Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_uint Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_uint Function
-%541 = OpVariable %_ptr_Function_ulong Function
-%542 = OpVariable %_ptr_Function_uint Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_uint Function
-%545 = OpVariable %_ptr_Function_ulong Function
-%546 = OpVariable %_ptr_Function_uint Function
-%547 = OpVariable %_ptr_Function_ulong Function
-%548 = OpVariable %_ptr_Function_uint Function
-%549 = OpVariable %_ptr_Function_ulong Function
-%550 = OpVariable %_ptr_Function_uint Function
-%551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_uint Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_uint Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_uint Function
-%557 = OpVariable %_ptr_Function_ulong Function
-%558 = OpVariable %_ptr_Function_uint Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_uint Function
-%561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_uint Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_uint Function
-%565 = OpVariable %_ptr_Function_ulong Function
-%566 = OpVariable %_ptr_Function_uint Function
-%567 = OpVariable %_ptr_Function_ulong Function
-%568 = OpVariable %_ptr_Function_uint Function
-%569 = OpVariable %_ptr_Function_ulong Function
-%570 = OpVariable %_ptr_Function_uint Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_uint Function
-%573 = OpVariable %_ptr_Function_ulong Function
-%574 = OpVariable %_ptr_Function_uint Function
-%575 = OpVariable %_ptr_Function_ulong Function
-%576 = OpVariable %_ptr_Function_uint Function
-%577 = OpVariable %_ptr_Function_ulong Function
-%578 = OpVariable %_ptr_Function_uint Function
-%579 = OpVariable %_ptr_Function_ulong Function
-%580 = OpVariable %_ptr_Function_uint Function
-%581 = OpVariable %_ptr_Function_ulong Function
-%582 = OpVariable %_ptr_Function_uint Function
-%583 = OpVariable %_ptr_Function_ulong Function
-%584 = OpVariable %_ptr_Function_uint Function
-%585 = OpVariable %_ptr_Function_ulong Function
-%586 = OpVariable %_ptr_Function_uint Function
-%587 = OpVariable %_ptr_Function_ulong Function
-%588 = OpVariable %_ptr_Function_uint Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+OpStore %416 %397
+OpStore %418 %398
+%442 = OpLoad %v2double %418
+%443 = OpCompositeExtract %double %442 0
+OpStore %420 %443
+OpBranch %400
+%400 = OpLabel
+%444 = OpLoad %double %420
+%445 = OpBitcast %ulong %444
+OpStore %422 %445
+OpBranch %402
+%402 = OpLabel
+%446 = OpLoad %ulong %416
+OpStore %430 %446
+OpStore %431 %ulong_0
+OpBranch %403
+%403 = OpLabel
+%447 = OpLoad %ulong %431
+%448 = OpULessThan %bool %447 %ulong_8
+OpStore %423 %448
+%449 = OpLoad %bool %423
+OpLoopMerge %405 %415 None
+OpBranchConditional %449 %404 %405
+%405 = OpLabel
+OpBranch %406
+%406 = OpLabel
+OpBranch %401
+%401 = OpLabel
+%450 = OpLoad %v2double %418
+%451 = OpCompositeExtract %double %450 1
+OpStore %421 %451
+OpBranch %407
+%407 = OpLabel
+%452 = OpLoad %double %421
+%453 = OpBitcast %ulong %452
+OpStore %432 %453
+OpBranch %409
+%409 = OpLabel
+%454 = OpLoad %ulong %430
+OpStore %440 %454
+OpStore %441 %ulong_0
+OpBranch %410
+%410 = OpLabel
+%455 = OpLoad %ulong %441
+%456 = OpULessThan %bool %455 %ulong_8
+OpStore %433 %456
+%457 = OpLoad %bool %433
+OpLoopMerge %412 %414 None
+OpBranchConditional %457 %411 %412
+%412 = OpLabel
+OpBranch %413
+%413 = OpLabel
+OpBranch %408
+%408 = OpLabel
+%458 = OpLoad %ulong %440
+OpReturnValue %458
+%411 = OpLabel
+%459 = OpLoad %ulong %441
+%460 = OpIMul %ulong %459 %ulong_8
+OpStore %434 %460
+%461 = OpLoad %ulong %432
+%462 = OpLoad %ulong %434
+%463 = OpShiftRightLogical %ulong %461 %462
+OpStore %435 %463
+%464 = OpLoad %ulong %435
+%465 = OpBitwiseAnd %ulong %464 %ulong_255
+OpStore %436 %465
+%466 = OpLoad %ulong %440
+%467 = OpLoad %ulong %436
+%468 = OpBitwiseXor %ulong %466 %467
+OpStore %437 %468
+%469 = OpLoad %ulong %437
+%470 = OpIMul %ulong %469 %ulong_1099511628211
+OpStore %438 %470
+%471 = OpLoad %ulong %441
+%472 = OpIAdd %ulong %471 %ulong_1
+OpStore %439 %472
+%473 = OpLoad %ulong %438
+OpStore %440 %473
+%474 = OpLoad %ulong %439
+OpStore %441 %474
+OpBranch %414
+%404 = OpLabel
+%475 = OpLoad %ulong %431
+%476 = OpIMul %ulong %475 %ulong_8
+OpStore %424 %476
+%477 = OpLoad %ulong %422
+%478 = OpLoad %ulong %424
+%479 = OpShiftRightLogical %ulong %477 %478
+OpStore %425 %479
+%480 = OpLoad %ulong %425
+%481 = OpBitwiseAnd %ulong %480 %ulong_255
+OpStore %426 %481
+%482 = OpLoad %ulong %430
+%483 = OpLoad %ulong %426
+%484 = OpBitwiseXor %ulong %482 %483
+OpStore %427 %484
+%485 = OpLoad %ulong %427
+%486 = OpIMul %ulong %485 %ulong_1099511628211
+OpStore %428 %486
+%487 = OpLoad %ulong %431
+%488 = OpIAdd %ulong %487 %ulong_1
+OpStore %429 %488
+%489 = OpLoad %ulong %428
+OpStore %430 %489
+%490 = OpLoad %ulong %429
+OpStore %431 %490
+OpBranch %415
+%414 = OpLabel
+OpBranch %410
+%415 = OpLabel
+OpBranch %403
+OpFunctionEnd
+%4 = OpFunction %ulong None %494
+%495 = OpFunctionParameter %ulong
+%496 = OpFunctionParameter %_arr_uchar_uint_16
+%497 = OpLabel
+%566 = OpVariable %_ptr_Function_ulong Function
+%568 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%570 = OpVariable %_ptr_Function_uchar Function
+%571 = OpVariable %_ptr_Function_uchar Function
+%572 = OpVariable %_ptr_Function_uchar Function
+%573 = OpVariable %_ptr_Function_uchar Function
+%574 = OpVariable %_ptr_Function_uchar Function
+%575 = OpVariable %_ptr_Function_uchar Function
+%576 = OpVariable %_ptr_Function_uchar Function
+%577 = OpVariable %_ptr_Function_uchar Function
+%578 = OpVariable %_ptr_Function_uchar Function
+%579 = OpVariable %_ptr_Function_uchar Function
+%580 = OpVariable %_ptr_Function_uchar Function
+%581 = OpVariable %_ptr_Function_uchar Function
+%582 = OpVariable %_ptr_Function_uchar Function
+%583 = OpVariable %_ptr_Function_uchar Function
+%584 = OpVariable %_ptr_Function_uchar Function
+%585 = OpVariable %_ptr_Function_uchar Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_bool Function
+%588 = OpVariable %_ptr_Function_ulong Function
 %589 = OpVariable %_ptr_Function_ulong Function
-%590 = OpVariable %_ptr_Function_uint Function
+%590 = OpVariable %_ptr_Function_ulong Function
 %591 = OpVariable %_ptr_Function_ulong Function
-%592 = OpVariable %_ptr_Function_uint Function
+%592 = OpVariable %_ptr_Function_ulong Function
 %593 = OpVariable %_ptr_Function_ulong Function
-%594 = OpVariable %_ptr_Function_uint Function
+%594 = OpVariable %_ptr_Function_ulong Function
 %595 = OpVariable %_ptr_Function_ulong Function
-%596 = OpVariable %_ptr_Function_uint Function
-%597 = OpVariable %_ptr_Function_ulong Function
-%598 = OpVariable %_ptr_Function_uint Function
+%596 = OpVariable %_ptr_Function_ulong Function
+%597 = OpVariable %_ptr_Function_bool Function
+%598 = OpVariable %_ptr_Function_ulong Function
 %599 = OpVariable %_ptr_Function_ulong Function
-%600 = OpVariable %_ptr_Function_uint Function
+%600 = OpVariable %_ptr_Function_ulong Function
 %601 = OpVariable %_ptr_Function_ulong Function
-%602 = OpVariable %_ptr_Function_uint Function
+%602 = OpVariable %_ptr_Function_ulong Function
 %603 = OpVariable %_ptr_Function_ulong Function
-%604 = OpVariable %_ptr_Function_uint Function
+%604 = OpVariable %_ptr_Function_ulong Function
 %605 = OpVariable %_ptr_Function_ulong Function
-%606 = OpVariable %_ptr_Function_uint Function
-%607 = OpVariable %_ptr_Function_ulong Function
-%608 = OpVariable %_ptr_Function_float Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_bool Function
+%608 = OpVariable %_ptr_Function_ulong Function
 %609 = OpVariable %_ptr_Function_ulong Function
-%610 = OpVariable %_ptr_Function_float Function
+%610 = OpVariable %_ptr_Function_ulong Function
 %611 = OpVariable %_ptr_Function_ulong Function
-%612 = OpVariable %_ptr_Function_float Function
+%612 = OpVariable %_ptr_Function_ulong Function
 %613 = OpVariable %_ptr_Function_ulong Function
-%614 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function_ulong Function
 %615 = OpVariable %_ptr_Function_ulong Function
-%616 = OpVariable %_ptr_Function_float Function
-%617 = OpVariable %_ptr_Function_ulong Function
-%618 = OpVariable %_ptr_Function_float Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_bool Function
+%618 = OpVariable %_ptr_Function_ulong Function
 %619 = OpVariable %_ptr_Function_ulong Function
-%620 = OpVariable %_ptr_Function_float Function
+%620 = OpVariable %_ptr_Function_ulong Function
 %621 = OpVariable %_ptr_Function_ulong Function
-%622 = OpVariable %_ptr_Function_float Function
+%622 = OpVariable %_ptr_Function_ulong Function
 %623 = OpVariable %_ptr_Function_ulong Function
-%624 = OpVariable %_ptr_Function_float Function
+%624 = OpVariable %_ptr_Function_ulong Function
 %625 = OpVariable %_ptr_Function_ulong Function
-%626 = OpVariable %_ptr_Function_float Function
-%627 = OpVariable %_ptr_Function_ulong Function
-%628 = OpVariable %_ptr_Function_float Function
+%626 = OpVariable %_ptr_Function_ulong Function
+%627 = OpVariable %_ptr_Function_bool Function
+%628 = OpVariable %_ptr_Function_ulong Function
 %629 = OpVariable %_ptr_Function_ulong Function
-%630 = OpVariable %_ptr_Function_float Function
+%630 = OpVariable %_ptr_Function_ulong Function
 %631 = OpVariable %_ptr_Function_ulong Function
-%632 = OpVariable %_ptr_Function_float Function
+%632 = OpVariable %_ptr_Function_ulong Function
 %633 = OpVariable %_ptr_Function_ulong Function
-%634 = OpVariable %_ptr_Function_float Function
+%634 = OpVariable %_ptr_Function_ulong Function
 %635 = OpVariable %_ptr_Function_ulong Function
-%636 = OpVariable %_ptr_Function_float Function
-%637 = OpVariable %_ptr_Function_ulong Function
-%638 = OpVariable %_ptr_Function_float Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function_bool Function
+%638 = OpVariable %_ptr_Function_ulong Function
 %639 = OpVariable %_ptr_Function_ulong Function
-%640 = OpVariable %_ptr_Function_double Function
+%640 = OpVariable %_ptr_Function_ulong Function
 %641 = OpVariable %_ptr_Function_ulong Function
-%642 = OpVariable %_ptr_Function_double Function
+%642 = OpVariable %_ptr_Function_ulong Function
 %643 = OpVariable %_ptr_Function_ulong Function
-%644 = OpVariable %_ptr_Function_double Function
+%644 = OpVariable %_ptr_Function_ulong Function
 %645 = OpVariable %_ptr_Function_ulong Function
-%646 = OpVariable %_ptr_Function_double Function
+%646 = OpVariable %_ptr_Function_ulong Function
 %647 = OpVariable %_ptr_Function_ulong Function
-%648 = OpVariable %_ptr_Function_double Function
+%648 = OpVariable %_ptr_Function_ulong Function
 %649 = OpVariable %_ptr_Function_ulong Function
-%650 = OpVariable %_ptr_Function_double Function
+%650 = OpVariable %_ptr_Function_ulong Function
 %651 = OpVariable %_ptr_Function_ulong Function
-%652 = OpVariable %_ptr_Function_uchar Function
-%653 = OpVariable %_ptr_Function_uchar Function
-%654 = OpVariable %_ptr_Function_uchar Function
-%655 = OpVariable %_ptr_Function_uchar Function
-%656 = OpVariable %_ptr_Function_uchar Function
-%657 = OpVariable %_ptr_Function_uchar Function
-%658 = OpVariable %_ptr_Function_uchar Function
-%659 = OpVariable %_ptr_Function_uchar Function
-%660 = OpVariable %_ptr_Function_uchar Function
-%661 = OpVariable %_ptr_Function_uchar Function
-%662 = OpVariable %_ptr_Function_uchar Function
-%663 = OpVariable %_ptr_Function_uchar Function
-%664 = OpVariable %_ptr_Function_uchar Function
-%665 = OpVariable %_ptr_Function_uchar Function
-%666 = OpVariable %_ptr_Function_uchar Function
-%667 = OpVariable %_ptr_Function_uchar Function
-%668 = OpVariable %_ptr_Function_uchar Function
-%669 = OpVariable %_ptr_Function_uchar Function
-%670 = OpVariable %_ptr_Function_uchar Function
-%671 = OpVariable %_ptr_Function_uchar Function
-%672 = OpVariable %_ptr_Function_uchar Function
-%673 = OpVariable %_ptr_Function_uchar Function
-%674 = OpVariable %_ptr_Function_uchar Function
-%675 = OpVariable %_ptr_Function_uchar Function
-%676 = OpVariable %_ptr_Function_uchar Function
-%677 = OpVariable %_ptr_Function_uchar Function
-%678 = OpVariable %_ptr_Function_uchar Function
-%679 = OpVariable %_ptr_Function_uchar Function
-%680 = OpVariable %_ptr_Function_uchar Function
-%681 = OpVariable %_ptr_Function_uchar Function
-%682 = OpVariable %_ptr_Function_uchar Function
-%683 = OpVariable %_ptr_Function_uchar Function
-%684 = OpVariable %_ptr_Function_uchar Function
-%685 = OpVariable %_ptr_Function_uchar Function
-%686 = OpVariable %_ptr_Function_uchar Function
-%687 = OpVariable %_ptr_Function_uchar Function
-%688 = OpVariable %_ptr_Function_uchar Function
-%689 = OpVariable %_ptr_Function_uchar Function
-%690 = OpVariable %_ptr_Function_uchar Function
-%691 = OpVariable %_ptr_Function_uchar Function
-%692 = OpVariable %_ptr_Function_uchar Function
-%693 = OpVariable %_ptr_Function_uchar Function
-%694 = OpVariable %_ptr_Function_uchar Function
-%695 = OpVariable %_ptr_Function_uchar Function
-%696 = OpVariable %_ptr_Function_uchar Function
-%697 = OpVariable %_ptr_Function_uchar Function
-%698 = OpVariable %_ptr_Function_uchar Function
-%699 = OpVariable %_ptr_Function_uchar Function
-%700 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%701 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%702 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%703 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%704 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%705 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%706 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%707 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%708 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%709 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%710 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%711 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%712 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%713 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%714 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%715 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%716 = OpVariable %_ptr_Function_uchar Function
-%717 = OpVariable %_ptr_Function_uchar Function
-%718 = OpVariable %_ptr_Function_uchar Function
-%719 = OpVariable %_ptr_Function_uchar Function
-%720 = OpVariable %_ptr_Function_uchar Function
-%721 = OpVariable %_ptr_Function_uchar Function
-%722 = OpVariable %_ptr_Function_uchar Function
-%723 = OpVariable %_ptr_Function_uchar Function
-%724 = OpVariable %_ptr_Function_uchar Function
-%725 = OpVariable %_ptr_Function_uchar Function
-%726 = OpVariable %_ptr_Function_uchar Function
-%727 = OpVariable %_ptr_Function_uchar Function
-%728 = OpVariable %_ptr_Function_uchar Function
-%729 = OpVariable %_ptr_Function_uchar Function
-%730 = OpVariable %_ptr_Function_uchar Function
-%731 = OpVariable %_ptr_Function_uchar Function
-%732 = OpVariable %_ptr_Function_uchar Function
-%733 = OpVariable %_ptr_Function_uchar Function
-%734 = OpVariable %_ptr_Function_uchar Function
-%735 = OpVariable %_ptr_Function_uchar Function
-%736 = OpVariable %_ptr_Function_uchar Function
-%737 = OpVariable %_ptr_Function_uchar Function
-%738 = OpVariable %_ptr_Function_uchar Function
-%739 = OpVariable %_ptr_Function_uchar Function
-%740 = OpVariable %_ptr_Function_uchar Function
-%741 = OpVariable %_ptr_Function_uchar Function
-%742 = OpVariable %_ptr_Function_uchar Function
-%743 = OpVariable %_ptr_Function_uchar Function
-%744 = OpVariable %_ptr_Function_uchar Function
-%745 = OpVariable %_ptr_Function_uchar Function
-%746 = OpVariable %_ptr_Function_uchar Function
-%747 = OpVariable %_ptr_Function_uchar Function
-%748 = OpVariable %_ptr_Function_uchar Function
-%749 = OpVariable %_ptr_Function_uchar Function
-%750 = OpVariable %_ptr_Function_uchar Function
-%751 = OpVariable %_ptr_Function_uchar Function
-%752 = OpVariable %_ptr_Function_uchar Function
-%753 = OpVariable %_ptr_Function_uchar Function
-%754 = OpVariable %_ptr_Function_uchar Function
-%755 = OpVariable %_ptr_Function_uchar Function
-%756 = OpVariable %_ptr_Function_uchar Function
-%757 = OpVariable %_ptr_Function_uchar Function
-%758 = OpVariable %_ptr_Function_uchar Function
-%759 = OpVariable %_ptr_Function_uchar Function
-%760 = OpVariable %_ptr_Function_uchar Function
-%761 = OpVariable %_ptr_Function_uchar Function
-%762 = OpVariable %_ptr_Function_uchar Function
-%763 = OpVariable %_ptr_Function_uchar Function
-%764 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%765 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%766 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%767 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%768 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%769 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%770 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%771 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%772 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%773 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%774 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%775 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%776 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%777 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%778 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%779 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-OpStore %290 %241
-%780 = OpFunctionCall %ulong %6
-OpStore %291 %780
-%781 = OpLoad %ulong %290
-%782 = OpUConvert %uint %781
-OpStore %292 %782
-%783 = OpLoad %ulong %290
-%784 = OpConvertUToF %float %783
-OpStore %293 %784
-%785 = OpLoad %ulong %290
-%786 = OpConvertUToF %double %785
-OpStore %294 %786
-%787 = OpLoad %ulong %290
-%788 = OpUConvert %uchar %787
-OpStore %295 %788
-%789 = OpCompositeConstruct %v4uint %uint_286331153 %uint_572662306 %uint_858993459 %uint_1145324612
-OpStore %296 %789
-%794 = OpLoad %v4uint %296
-%795 = OpCompositeExtract %uint %794 0
-OpStore %297 %795
-%796 = OpLoad %uint %297
-%797 = OpLoad %uint %292
-%798 = OpIAdd %uint %796 %797
-OpStore %298 %798
-%799 = OpLoad %v4uint %296
-%800 = OpLoad %uint %298
-%801 = OpCompositeInsert %v4uint %800 %799 0
-OpStore %299 %801
-%802 = OpLoad %v4uint %299
-%803 = OpCompositeExtract %uint %802 3
-OpStore %300 %803
-%804 = OpLoad %uint %300
-%805 = OpLoad %uint %292
-%806 = OpIAdd %uint %804 %805
-OpStore %301 %806
-%807 = OpLoad %v4uint %299
-%808 = OpLoad %uint %301
-%809 = OpCompositeInsert %v4uint %808 %807 3
-OpStore %302 %809
-OpBranch %243
-%243 = OpLabel
-%810 = OpLoad %v4uint %302
-%811 = OpCompositeExtract %uint %810 0
-OpStore %512 %811
-%812 = OpLoad %ulong %291
-%813 = OpLoad %uint %512
-%814 = OpFunctionCall %ulong %7 %812 %813
-OpStore %513 %814
-%815 = OpLoad %v4uint %302
-%816 = OpCompositeExtract %uint %815 1
-OpStore %514 %816
-%817 = OpLoad %ulong %513
-%818 = OpLoad %uint %514
-%819 = OpFunctionCall %ulong %7 %817 %818
-OpStore %515 %819
-%820 = OpLoad %v4uint %302
-%821 = OpCompositeExtract %uint %820 2
-OpStore %516 %821
-%822 = OpLoad %ulong %515
-%823 = OpLoad %uint %516
-%824 = OpFunctionCall %ulong %7 %822 %823
-OpStore %517 %824
-%825 = OpLoad %v4uint %302
-%826 = OpCompositeExtract %uint %825 3
-OpStore %518 %826
-%827 = OpLoad %ulong %517
-%828 = OpLoad %uint %518
-%829 = OpFunctionCall %ulong %7 %827 %828
-OpStore %519 %829
-OpBranch %244
-%244 = OpLabel
-OpStore %281 %830
-%831 = OpLoad %v4uint %302
-%832 = OpCompositeExtract %uint %831 3
-OpStore %303 %832
-%833 = OpLoad %v4uint %281
-OpStore %304 %833
-%834 = OpLoad %v4uint %304
-%835 = OpLoad %uint %303
-%836 = OpCompositeInsert %v4uint %835 %834 0
-OpStore %305 %836
-%837 = OpLoad %v4uint %305
-OpStore %281 %837
-%838 = OpLoad %v4uint %302
-%839 = OpCompositeExtract %uint %838 2
-OpStore %306 %839
-%840 = OpLoad %v4uint %281
-OpStore %307 %840
-%841 = OpLoad %v4uint %307
-%842 = OpLoad %uint %306
-%843 = OpCompositeInsert %v4uint %842 %841 1
-OpStore %308 %843
-%844 = OpLoad %v4uint %308
-OpStore %281 %844
-%845 = OpLoad %v4uint %302
-%846 = OpCompositeExtract %uint %845 1
-OpStore %309 %846
-%847 = OpLoad %v4uint %281
-OpStore %310 %847
-%848 = OpLoad %v4uint %310
-%849 = OpLoad %uint %309
-%850 = OpCompositeInsert %v4uint %849 %848 2
-OpStore %311 %850
-%851 = OpLoad %v4uint %311
-OpStore %281 %851
-%852 = OpLoad %v4uint %302
-%853 = OpCompositeExtract %uint %852 0
-OpStore %312 %853
-%854 = OpLoad %v4uint %281
-OpStore %313 %854
-%855 = OpLoad %v4uint %313
-%856 = OpLoad %uint %312
-%857 = OpCompositeInsert %v4uint %856 %855 3
-OpStore %314 %857
-%858 = OpLoad %v4uint %314
-OpStore %281 %858
-%859 = OpLoad %v4uint %281
-OpStore %315 %859
-OpBranch %245
-%245 = OpLabel
-%860 = OpLoad %v4uint %315
-%861 = OpCompositeExtract %uint %860 0
-OpStore %520 %861
-%862 = OpLoad %ulong %519
-%863 = OpLoad %uint %520
-%864 = OpFunctionCall %ulong %7 %862 %863
-OpStore %521 %864
-%865 = OpLoad %v4uint %315
-%866 = OpCompositeExtract %uint %865 1
-OpStore %522 %866
-%867 = OpLoad %ulong %521
-%868 = OpLoad %uint %522
-%869 = OpFunctionCall %ulong %7 %867 %868
-OpStore %523 %869
-%870 = OpLoad %v4uint %315
-%871 = OpCompositeExtract %uint %870 2
-OpStore %524 %871
-%872 = OpLoad %ulong %523
-%873 = OpLoad %uint %524
-%874 = OpFunctionCall %ulong %7 %872 %873
-OpStore %525 %874
-%875 = OpLoad %v4uint %315
-%876 = OpCompositeExtract %uint %875 3
-OpStore %526 %876
-%877 = OpLoad %ulong %525
-%878 = OpLoad %uint %526
-%879 = OpFunctionCall %ulong %7 %877 %878
-OpStore %527 %879
-OpBranch %246
-%246 = OpLabel
-OpStore %282 %830
-%880 = OpLoad %v4uint %302
-%881 = OpCompositeExtract %uint %880 1
-OpStore %316 %881
-%882 = OpLoad %v4uint %282
-OpStore %317 %882
-%883 = OpLoad %v4uint %317
-%884 = OpLoad %uint %316
-%885 = OpCompositeInsert %v4uint %884 %883 0
-OpStore %318 %885
-%886 = OpLoad %v4uint %318
-OpStore %282 %886
-%887 = OpLoad %v4uint %302
-%888 = OpCompositeExtract %uint %887 2
-OpStore %319 %888
-%889 = OpLoad %v4uint %282
-OpStore %320 %889
-%890 = OpLoad %v4uint %320
-%891 = OpLoad %uint %319
-%892 = OpCompositeInsert %v4uint %891 %890 1
-OpStore %321 %892
-%893 = OpLoad %v4uint %321
-OpStore %282 %893
-%894 = OpLoad %v4uint %302
-%895 = OpCompositeExtract %uint %894 3
-OpStore %322 %895
-%896 = OpLoad %v4uint %282
-OpStore %323 %896
-%897 = OpLoad %v4uint %323
-%898 = OpLoad %uint %322
-%899 = OpCompositeInsert %v4uint %898 %897 2
-OpStore %324 %899
-%900 = OpLoad %v4uint %324
-OpStore %282 %900
-%901 = OpLoad %v4uint %302
-%902 = OpCompositeExtract %uint %901 0
-OpStore %325 %902
-%903 = OpLoad %v4uint %282
-OpStore %326 %903
-%904 = OpLoad %v4uint %326
-%905 = OpLoad %uint %325
-%906 = OpCompositeInsert %v4uint %905 %904 3
-OpStore %327 %906
-%907 = OpLoad %v4uint %327
-OpStore %282 %907
-%908 = OpLoad %v4uint %282
-OpStore %328 %908
-OpBranch %247
-%247 = OpLabel
-%909 = OpLoad %v4uint %328
-%910 = OpCompositeExtract %uint %909 0
-OpStore %528 %910
-%911 = OpLoad %ulong %527
-%912 = OpLoad %uint %528
-%913 = OpFunctionCall %ulong %7 %911 %912
-OpStore %529 %913
-%914 = OpLoad %v4uint %328
-%915 = OpCompositeExtract %uint %914 1
-OpStore %530 %915
-%916 = OpLoad %ulong %529
-%917 = OpLoad %uint %530
-%918 = OpFunctionCall %ulong %7 %916 %917
-OpStore %531 %918
-%919 = OpLoad %v4uint %328
-%920 = OpCompositeExtract %uint %919 2
-OpStore %532 %920
-%921 = OpLoad %ulong %531
-%922 = OpLoad %uint %532
-%923 = OpFunctionCall %ulong %7 %921 %922
-OpStore %533 %923
-%924 = OpLoad %v4uint %328
-%925 = OpCompositeExtract %uint %924 3
-OpStore %534 %925
-%926 = OpLoad %ulong %533
-%927 = OpLoad %uint %534
-%928 = OpFunctionCall %ulong %7 %926 %927
-OpStore %535 %928
-OpBranch %248
-%248 = OpLabel
-OpStore %283 %830
-%929 = OpLoad %v4uint %302
-%930 = OpCompositeExtract %uint %929 2
-OpStore %329 %930
-%931 = OpLoad %v4uint %283
-OpStore %330 %931
-%932 = OpLoad %v4uint %330
-%933 = OpLoad %uint %329
-%934 = OpCompositeInsert %v4uint %933 %932 0
-OpStore %331 %934
-%935 = OpLoad %v4uint %331
-OpStore %283 %935
-%936 = OpLoad %v4uint %302
-%937 = OpCompositeExtract %uint %936 3
-OpStore %332 %937
-%938 = OpLoad %v4uint %283
-OpStore %333 %938
-%939 = OpLoad %v4uint %333
-%940 = OpLoad %uint %332
-%941 = OpCompositeInsert %v4uint %940 %939 1
-OpStore %334 %941
-%942 = OpLoad %v4uint %334
-OpStore %283 %942
-%943 = OpLoad %v4uint %302
-%944 = OpCompositeExtract %uint %943 0
-OpStore %335 %944
-%945 = OpLoad %v4uint %283
-OpStore %336 %945
-%946 = OpLoad %v4uint %336
-%947 = OpLoad %uint %335
-%948 = OpCompositeInsert %v4uint %947 %946 2
-OpStore %337 %948
-%949 = OpLoad %v4uint %337
-OpStore %283 %949
-%950 = OpLoad %v4uint %302
-%951 = OpCompositeExtract %uint %950 1
-OpStore %338 %951
-%952 = OpLoad %v4uint %283
-OpStore %339 %952
-%953 = OpLoad %v4uint %339
-%954 = OpLoad %uint %338
-%955 = OpCompositeInsert %v4uint %954 %953 3
-OpStore %340 %955
-%956 = OpLoad %v4uint %340
-OpStore %283 %956
-%957 = OpLoad %v4uint %283
-OpStore %341 %957
-OpBranch %249
-%249 = OpLabel
-%958 = OpLoad %v4uint %341
-%959 = OpCompositeExtract %uint %958 0
-OpStore %536 %959
-%960 = OpLoad %ulong %535
-%961 = OpLoad %uint %536
-%962 = OpFunctionCall %ulong %7 %960 %961
-OpStore %537 %962
-%963 = OpLoad %v4uint %341
-%964 = OpCompositeExtract %uint %963 1
-OpStore %538 %964
-%965 = OpLoad %ulong %537
-%966 = OpLoad %uint %538
-%967 = OpFunctionCall %ulong %7 %965 %966
-OpStore %539 %967
-%968 = OpLoad %v4uint %341
-%969 = OpCompositeExtract %uint %968 2
-OpStore %540 %969
-%970 = OpLoad %ulong %539
-%971 = OpLoad %uint %540
-%972 = OpFunctionCall %ulong %7 %970 %971
-OpStore %541 %972
-%973 = OpLoad %v4uint %341
-%974 = OpCompositeExtract %uint %973 3
-OpStore %542 %974
-%975 = OpLoad %ulong %541
-%976 = OpLoad %uint %542
-%977 = OpFunctionCall %ulong %7 %975 %976
-OpStore %543 %977
-OpBranch %250
-%250 = OpLabel
-OpStore %284 %830
-%978 = OpLoad %v4uint %302
-%979 = OpCompositeExtract %uint %978 2
-OpStore %342 %979
-%980 = OpLoad %v4uint %284
-OpStore %343 %980
-%981 = OpLoad %v4uint %343
-%982 = OpLoad %uint %342
-%983 = OpCompositeInsert %v4uint %982 %981 0
-OpStore %344 %983
-%984 = OpLoad %v4uint %344
-OpStore %284 %984
-%985 = OpLoad %v4uint %284
-OpStore %345 %985
-%986 = OpLoad %v4uint %345
-%987 = OpLoad %uint %342
-%988 = OpCompositeInsert %v4uint %987 %986 1
-OpStore %346 %988
-%989 = OpLoad %v4uint %346
-OpStore %284 %989
-%990 = OpLoad %v4uint %284
-OpStore %347 %990
-%991 = OpLoad %v4uint %347
-%992 = OpLoad %uint %342
-%993 = OpCompositeInsert %v4uint %992 %991 2
-OpStore %348 %993
-%994 = OpLoad %v4uint %348
-OpStore %284 %994
-%995 = OpLoad %v4uint %284
-OpStore %349 %995
-%996 = OpLoad %v4uint %349
-%997 = OpLoad %uint %342
-%998 = OpCompositeInsert %v4uint %997 %996 3
-OpStore %350 %998
-%999 = OpLoad %v4uint %350
-OpStore %284 %999
-%1000 = OpLoad %v4uint %284
-OpStore %351 %1000
-OpBranch %251
-%251 = OpLabel
-%1001 = OpLoad %v4uint %351
-%1002 = OpCompositeExtract %uint %1001 0
-OpStore %544 %1002
-%1003 = OpLoad %ulong %543
-%1004 = OpLoad %uint %544
-%1005 = OpFunctionCall %ulong %7 %1003 %1004
-OpStore %545 %1005
-%1006 = OpLoad %v4uint %351
-%1007 = OpCompositeExtract %uint %1006 1
-OpStore %546 %1007
-%1008 = OpLoad %ulong %545
-%1009 = OpLoad %uint %546
-%1010 = OpFunctionCall %ulong %7 %1008 %1009
-OpStore %547 %1010
-%1011 = OpLoad %v4uint %351
-%1012 = OpCompositeExtract %uint %1011 2
-OpStore %548 %1012
-%1013 = OpLoad %ulong %547
-%1014 = OpLoad %uint %548
-%1015 = OpFunctionCall %ulong %7 %1013 %1014
-OpStore %549 %1015
-%1016 = OpLoad %v4uint %351
-%1017 = OpCompositeExtract %uint %1016 3
-OpStore %550 %1017
-%1018 = OpLoad %ulong %549
-%1019 = OpLoad %uint %550
-%1020 = OpFunctionCall %ulong %7 %1018 %1019
-OpStore %551 %1020
-OpBranch %252
-%252 = OpLabel
-OpStore %285 %830
-%1021 = OpLoad %v4uint %302
-%1022 = OpCompositeExtract %uint %1021 0
-OpStore %352 %1022
-%1023 = OpLoad %v4uint %285
-OpStore %353 %1023
-%1024 = OpLoad %v4uint %353
-%1025 = OpLoad %uint %352
-%1026 = OpCompositeInsert %v4uint %1025 %1024 1
-OpStore %354 %1026
-%1027 = OpLoad %v4uint %354
-OpStore %285 %1027
-%1028 = OpLoad %v4uint %285
-OpStore %355 %1028
-OpBranch %253
-%253 = OpLabel
-%1029 = OpLoad %v4uint %355
-%1030 = OpCompositeExtract %uint %1029 0
-OpStore %552 %1030
-%1031 = OpLoad %ulong %551
-%1032 = OpLoad %uint %552
-%1033 = OpFunctionCall %ulong %7 %1031 %1032
-OpStore %553 %1033
-%1034 = OpLoad %v4uint %355
-%1035 = OpCompositeExtract %uint %1034 1
-OpStore %554 %1035
-%1036 = OpLoad %ulong %553
-%1037 = OpLoad %uint %554
-%1038 = OpFunctionCall %ulong %7 %1036 %1037
-OpStore %555 %1038
-%1039 = OpLoad %v4uint %355
-%1040 = OpCompositeExtract %uint %1039 2
-OpStore %556 %1040
-%1041 = OpLoad %ulong %555
-%1042 = OpLoad %uint %556
-%1043 = OpFunctionCall %ulong %7 %1041 %1042
-OpStore %557 %1043
-%1044 = OpLoad %v4uint %355
-%1045 = OpCompositeExtract %uint %1044 3
-OpStore %558 %1045
-%1046 = OpLoad %ulong %557
-%1047 = OpLoad %uint %558
-%1048 = OpFunctionCall %ulong %7 %1046 %1047
-OpStore %559 %1048
-OpBranch %254
-%254 = OpLabel
-%1049 = OpLoad %v4uint %302
-%1050 = OpCompositeExtract %uint %1049 0
-OpStore %356 %1050
-%1051 = OpLoad %v4uint %302
-%1052 = OpLoad %uint %356
-%1053 = OpCompositeInsert %v4uint %1052 %1051 1
-OpStore %357 %1053
-%1054 = OpLoad %v4uint %302
-%1055 = OpCompositeExtract %uint %1054 3
-OpStore %358 %1055
-%1056 = OpLoad %v4uint %357
-%1057 = OpLoad %uint %358
-%1058 = OpCompositeInsert %v4uint %1057 %1056 1
-OpStore %359 %1058
-OpBranch %255
-%255 = OpLabel
-%1059 = OpLoad %v4uint %359
-%1060 = OpCompositeExtract %uint %1059 0
-OpStore %560 %1060
-%1061 = OpLoad %ulong %559
-%1062 = OpLoad %uint %560
-%1063 = OpFunctionCall %ulong %7 %1061 %1062
-OpStore %561 %1063
-%1064 = OpLoad %v4uint %359
-%1065 = OpCompositeExtract %uint %1064 1
-OpStore %562 %1065
-%1066 = OpLoad %ulong %561
-%1067 = OpLoad %uint %562
-%1068 = OpFunctionCall %ulong %7 %1066 %1067
-OpStore %563 %1068
-%1069 = OpLoad %v4uint %359
-%1070 = OpCompositeExtract %uint %1069 2
-OpStore %564 %1070
-%1071 = OpLoad %ulong %563
-%1072 = OpLoad %uint %564
-%1073 = OpFunctionCall %ulong %7 %1071 %1072
-OpStore %565 %1073
-%1074 = OpLoad %v4uint %359
-%1075 = OpCompositeExtract %uint %1074 3
-OpStore %566 %1075
-%1076 = OpLoad %ulong %565
-%1077 = OpLoad %uint %566
-%1078 = OpFunctionCall %ulong %7 %1076 %1077
-OpStore %567 %1078
-OpBranch %256
-%256 = OpLabel
-%1079 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
-OpStore %360 %1079
-%1081 = OpLoad %v4uint %302
-%1082 = OpCompositeExtract %uint %1081 0
-OpStore %361 %1082
-%1083 = OpLoad %uint %361
-%1085 = OpIAdd %uint %1083 %uint_1
-OpStore %362 %1085
-%1086 = OpLoad %v4uint %360
-%1087 = OpLoad %uint %362
-%1088 = OpCompositeInsert %v4uint %1087 %1086 0
-OpStore %363 %1088
-%1089 = OpLoad %v4uint %363
-%1090 = OpCompositeExtract %uint %1089 0
-OpStore %364 %1090
-%1091 = OpLoad %ulong %567
-%1092 = OpLoad %uint %364
-%1093 = OpFunctionCall %ulong %7 %1091 %1092
-OpStore %365 %1093
-%1094 = OpLoad %v4uint %302
-%1095 = OpCompositeExtract %uint %1094 1
-OpStore %366 %1095
-%1096 = OpLoad %uint %364
-%1097 = OpLoad %uint %366
-%1098 = OpIAdd %uint %1096 %1097
-OpStore %367 %1098
-%1099 = OpLoad %v4uint %363
-%1100 = OpLoad %uint %367
-%1101 = OpCompositeInsert %v4uint %1100 %1099 1
-OpStore %368 %1101
-%1102 = OpLoad %v4uint %368
-%1103 = OpCompositeExtract %uint %1102 1
-OpStore %369 %1103
-%1104 = OpLoad %ulong %365
-%1105 = OpLoad %uint %369
-%1106 = OpFunctionCall %ulong %7 %1104 %1105
-OpStore %370 %1106
-%1107 = OpLoad %v4uint %302
-%1108 = OpCompositeExtract %uint %1107 2
-OpStore %371 %1108
-%1109 = OpLoad %uint %369
-%1110 = OpLoad %uint %371
-%1111 = OpBitwiseXor %uint %1109 %1110
-OpStore %372 %1111
-%1112 = OpLoad %v4uint %368
-%1113 = OpLoad %uint %372
-%1114 = OpCompositeInsert %v4uint %1113 %1112 2
-OpStore %373 %1114
-%1115 = OpLoad %v4uint %373
-%1116 = OpCompositeExtract %uint %1115 2
-OpStore %374 %1116
-%1117 = OpLoad %ulong %370
-%1118 = OpLoad %uint %374
-%1119 = OpFunctionCall %ulong %7 %1117 %1118
-OpStore %375 %1119
-%1120 = OpLoad %v4uint %302
-%1121 = OpCompositeExtract %uint %1120 3
-OpStore %376 %1121
-%1122 = OpLoad %uint %374
-%1123 = OpLoad %uint %376
-%1124 = OpISub %uint %1122 %1123
-OpStore %377 %1124
-%1125 = OpLoad %v4uint %373
-%1126 = OpLoad %uint %377
-%1127 = OpCompositeInsert %v4uint %1126 %1125 3
-OpStore %378 %1127
-%1128 = OpLoad %v4uint %378
-%1129 = OpCompositeExtract %uint %1128 3
-OpStore %379 %1129
-%1130 = OpLoad %ulong %375
-%1131 = OpLoad %uint %379
-%1132 = OpFunctionCall %ulong %7 %1130 %1131
-OpStore %380 %1132
-OpBranch %257
-%257 = OpLabel
-%1133 = OpLoad %v4uint %378
-%1134 = OpCompositeExtract %uint %1133 0
-OpStore %568 %1134
-%1135 = OpLoad %ulong %380
-%1136 = OpLoad %uint %568
-%1137 = OpFunctionCall %ulong %7 %1135 %1136
-OpStore %569 %1137
-%1138 = OpLoad %v4uint %378
-%1139 = OpCompositeExtract %uint %1138 1
-OpStore %570 %1139
-%1140 = OpLoad %ulong %569
-%1141 = OpLoad %uint %570
-%1142 = OpFunctionCall %ulong %7 %1140 %1141
-OpStore %571 %1142
-%1143 = OpLoad %v4uint %378
-%1144 = OpCompositeExtract %uint %1143 2
-OpStore %572 %1144
-%1145 = OpLoad %ulong %571
-%1146 = OpLoad %uint %572
-%1147 = OpFunctionCall %ulong %7 %1145 %1146
-OpStore %573 %1147
-%1148 = OpLoad %v4uint %378
-%1149 = OpCompositeExtract %uint %1148 3
-OpStore %574 %1149
-%1150 = OpLoad %ulong %573
-%1151 = OpLoad %uint %574
-%1152 = OpFunctionCall %ulong %7 %1150 %1151
-OpStore %575 %1152
-OpBranch %258
-%258 = OpLabel
-%1153 = OpLoad %v4uint %281
-OpStore %381 %1153
-%1154 = OpLoad %v4uint %381
-%1155 = OpLoad %v4uint %302
-%1156 = OpIAdd %v4uint %1154 %1155
-OpStore %382 %1156
-OpBranch %259
-%259 = OpLabel
-%1157 = OpLoad %v4uint %382
-%1158 = OpCompositeExtract %uint %1157 0
-OpStore %576 %1158
-%1159 = OpLoad %ulong %575
-%1160 = OpLoad %uint %576
-%1161 = OpFunctionCall %ulong %7 %1159 %1160
-OpStore %577 %1161
-%1162 = OpLoad %v4uint %382
-%1163 = OpCompositeExtract %uint %1162 1
-OpStore %578 %1163
-%1164 = OpLoad %ulong %577
-%1165 = OpLoad %uint %578
-%1166 = OpFunctionCall %ulong %7 %1164 %1165
-OpStore %579 %1166
-%1167 = OpLoad %v4uint %382
-%1168 = OpCompositeExtract %uint %1167 2
-OpStore %580 %1168
-%1169 = OpLoad %ulong %579
-%1170 = OpLoad %uint %580
-%1171 = OpFunctionCall %ulong %7 %1169 %1170
-OpStore %581 %1171
-%1172 = OpLoad %v4uint %382
-%1173 = OpCompositeExtract %uint %1172 3
-OpStore %582 %1173
-%1174 = OpLoad %ulong %581
-%1175 = OpLoad %uint %582
-%1176 = OpFunctionCall %ulong %7 %1174 %1175
-OpStore %583 %1176
-OpBranch %260
-%260 = OpLabel
-%1177 = OpLoad %v4uint %282
-OpStore %383 %1177
-%1178 = OpLoad %v4uint %383
-%1179 = OpLoad %v4uint %302
-%1180 = OpISub %v4uint %1178 %1179
-OpStore %384 %1180
-OpBranch %261
-%261 = OpLabel
-%1181 = OpLoad %v4uint %384
-%1182 = OpCompositeExtract %uint %1181 0
-OpStore %584 %1182
-%1183 = OpLoad %ulong %583
-%1184 = OpLoad %uint %584
-%1185 = OpFunctionCall %ulong %7 %1183 %1184
-OpStore %585 %1185
-%1186 = OpLoad %v4uint %384
-%1187 = OpCompositeExtract %uint %1186 1
-OpStore %586 %1187
-%1188 = OpLoad %ulong %585
-%1189 = OpLoad %uint %586
-%1190 = OpFunctionCall %ulong %7 %1188 %1189
-OpStore %587 %1190
-%1191 = OpLoad %v4uint %384
-%1192 = OpCompositeExtract %uint %1191 2
-OpStore %588 %1192
-%1193 = OpLoad %ulong %587
-%1194 = OpLoad %uint %588
-%1195 = OpFunctionCall %ulong %7 %1193 %1194
-OpStore %589 %1195
-%1196 = OpLoad %v4uint %384
-%1197 = OpCompositeExtract %uint %1196 3
-OpStore %590 %1197
-%1198 = OpLoad %ulong %589
-%1199 = OpLoad %uint %590
-%1200 = OpFunctionCall %ulong %7 %1198 %1199
-OpStore %591 %1200
-OpBranch %262
-%262 = OpLabel
-%1201 = OpLoad %v4uint %283
-OpStore %385 %1201
-%1202 = OpLoad %v4uint %385
-%1203 = OpLoad %v4uint %302
-%1204 = OpIMul %v4uint %1202 %1203
-OpStore %386 %1204
-OpBranch %263
-%263 = OpLabel
-%1205 = OpLoad %v4uint %386
-%1206 = OpCompositeExtract %uint %1205 0
-OpStore %592 %1206
-%1207 = OpLoad %ulong %591
-%1208 = OpLoad %uint %592
-%1209 = OpFunctionCall %ulong %7 %1207 %1208
-OpStore %593 %1209
-%1210 = OpLoad %v4uint %386
-%1211 = OpCompositeExtract %uint %1210 1
-OpStore %594 %1211
-%1212 = OpLoad %ulong %593
-%1213 = OpLoad %uint %594
-%1214 = OpFunctionCall %ulong %7 %1212 %1213
-OpStore %595 %1214
-%1215 = OpLoad %v4uint %386
-%1216 = OpCompositeExtract %uint %1215 2
-OpStore %596 %1216
-%1217 = OpLoad %ulong %595
-%1218 = OpLoad %uint %596
-%1219 = OpFunctionCall %ulong %7 %1217 %1218
-OpStore %597 %1219
-%1220 = OpLoad %v4uint %386
-%1221 = OpCompositeExtract %uint %1220 3
-OpStore %598 %1221
-%1222 = OpLoad %ulong %597
-%1223 = OpLoad %uint %598
-%1224 = OpFunctionCall %ulong %7 %1222 %1223
-OpStore %599 %1224
-OpBranch %264
-%264 = OpLabel
-%1225 = OpLoad %v4uint %281
-OpStore %387 %1225
-%1226 = OpLoad %v4uint %282
-OpStore %388 %1226
-%1227 = OpLoad %v4uint %387
-%1228 = OpLoad %v4uint %388
-%1229 = OpBitwiseXor %v4uint %1227 %1228
-OpStore %389 %1229
-OpBranch %265
-%265 = OpLabel
-%1230 = OpLoad %v4uint %389
-%1231 = OpCompositeExtract %uint %1230 0
-OpStore %600 %1231
-%1232 = OpLoad %ulong %599
-%1233 = OpLoad %uint %600
-%1234 = OpFunctionCall %ulong %7 %1232 %1233
-OpStore %601 %1234
-%1235 = OpLoad %v4uint %389
-%1236 = OpCompositeExtract %uint %1235 1
-OpStore %602 %1236
-%1237 = OpLoad %ulong %601
-%1238 = OpLoad %uint %602
-%1239 = OpFunctionCall %ulong %7 %1237 %1238
-OpStore %603 %1239
-%1240 = OpLoad %v4uint %389
-%1241 = OpCompositeExtract %uint %1240 2
-OpStore %604 %1241
-%1242 = OpLoad %ulong %603
-%1243 = OpLoad %uint %604
-%1244 = OpFunctionCall %ulong %7 %1242 %1243
-OpStore %605 %1244
-%1245 = OpLoad %v4uint %389
-%1246 = OpCompositeExtract %uint %1245 3
-OpStore %606 %1246
-%1247 = OpLoad %ulong %605
-%1248 = OpLoad %uint %606
-%1249 = OpFunctionCall %ulong %7 %1247 %1248
-OpStore %607 %1249
-OpBranch %266
-%266 = OpLabel
-%1251 = OpFNegate %float %float_2_25
-OpStore %390 %1251
-%1253 = OpFNegate %float %float_0_5
-OpStore %391 %1253
-%1256 = OpLoad %float %390
-%1258 = OpLoad %float %391
-%1254 = OpCompositeConstruct %v4float %float_1_5 %1256 %float_3_75 %1258
-OpStore %392 %1254
-%1259 = OpLoad %v4float %392
-%1260 = OpCompositeExtract %float %1259 1
-OpStore %393 %1260
-%1261 = OpLoad %float %393
-%1262 = OpLoad %float %293
-%1263 = OpFAdd %float %1261 %1262
-OpStore %394 %1263
-%1264 = OpLoad %v4float %392
-%1265 = OpLoad %float %394
-%1266 = OpCompositeInsert %v4float %1265 %1264 1
-OpStore %395 %1266
-OpBranch %267
-%267 = OpLabel
-%1267 = OpLoad %v4float %395
-%1268 = OpCompositeExtract %float %1267 0
-OpStore %608 %1268
-%1269 = OpLoad %ulong %607
-%1270 = OpLoad %float %608
-%1271 = OpFunctionCall %ulong %9 %1269 %1270
-OpStore %609 %1271
-%1272 = OpLoad %v4float %395
-%1273 = OpCompositeExtract %float %1272 1
-OpStore %610 %1273
-%1274 = OpLoad %ulong %609
-%1275 = OpLoad %float %610
-%1276 = OpFunctionCall %ulong %9 %1274 %1275
-OpStore %611 %1276
-%1277 = OpLoad %v4float %395
-%1278 = OpCompositeExtract %float %1277 2
-OpStore %612 %1278
-%1279 = OpLoad %ulong %611
-%1280 = OpLoad %float %612
-%1281 = OpFunctionCall %ulong %9 %1279 %1280
-OpStore %613 %1281
-%1282 = OpLoad %v4float %395
-%1283 = OpCompositeExtract %float %1282 3
-OpStore %614 %1283
-%1284 = OpLoad %ulong %613
-%1285 = OpLoad %float %614
-%1286 = OpFunctionCall %ulong %9 %1284 %1285
-OpStore %615 %1286
-OpBranch %268
-%268 = OpLabel
-OpStore %286 %1287
-%1288 = OpLoad %v4float %395
-%1289 = OpCompositeExtract %float %1288 3
-OpStore %396 %1289
-%1290 = OpLoad %v4float %286
-OpStore %397 %1290
-%1291 = OpLoad %v4float %397
-%1292 = OpLoad %float %396
-%1293 = OpCompositeInsert %v4float %1292 %1291 0
-OpStore %398 %1293
-%1294 = OpLoad %v4float %398
-OpStore %286 %1294
-%1295 = OpLoad %v4float %395
-%1296 = OpCompositeExtract %float %1295 2
-OpStore %399 %1296
-%1297 = OpLoad %v4float %286
-OpStore %400 %1297
-%1298 = OpLoad %v4float %400
-%1299 = OpLoad %float %399
-%1300 = OpCompositeInsert %v4float %1299 %1298 1
-OpStore %401 %1300
-%1301 = OpLoad %v4float %401
-OpStore %286 %1301
-%1302 = OpLoad %v4float %395
-%1303 = OpCompositeExtract %float %1302 1
-OpStore %402 %1303
-%1304 = OpLoad %v4float %286
-OpStore %403 %1304
-%1305 = OpLoad %v4float %403
-%1306 = OpLoad %float %402
-%1307 = OpCompositeInsert %v4float %1306 %1305 2
-OpStore %404 %1307
-%1308 = OpLoad %v4float %404
-OpStore %286 %1308
-%1309 = OpLoad %v4float %395
-%1310 = OpCompositeExtract %float %1309 0
-OpStore %405 %1310
-%1311 = OpLoad %v4float %286
-OpStore %406 %1311
-%1312 = OpLoad %v4float %406
-%1313 = OpLoad %float %405
-%1314 = OpCompositeInsert %v4float %1313 %1312 3
-OpStore %407 %1314
-%1315 = OpLoad %v4float %407
-OpStore %286 %1315
-%1316 = OpLoad %v4float %286
-OpStore %408 %1316
-OpBranch %269
-%269 = OpLabel
-%1317 = OpLoad %v4float %408
-%1318 = OpCompositeExtract %float %1317 0
-OpStore %616 %1318
-%1319 = OpLoad %ulong %615
-%1320 = OpLoad %float %616
-%1321 = OpFunctionCall %ulong %9 %1319 %1320
-OpStore %617 %1321
-%1322 = OpLoad %v4float %408
-%1323 = OpCompositeExtract %float %1322 1
-OpStore %618 %1323
-%1324 = OpLoad %ulong %617
-%1325 = OpLoad %float %618
-%1326 = OpFunctionCall %ulong %9 %1324 %1325
-OpStore %619 %1326
-%1327 = OpLoad %v4float %408
-%1328 = OpCompositeExtract %float %1327 2
-OpStore %620 %1328
-%1329 = OpLoad %ulong %619
-%1330 = OpLoad %float %620
-%1331 = OpFunctionCall %ulong %9 %1329 %1330
-OpStore %621 %1331
-%1332 = OpLoad %v4float %408
-%1333 = OpCompositeExtract %float %1332 3
-OpStore %622 %1333
-%1334 = OpLoad %ulong %621
-%1335 = OpLoad %float %622
-%1336 = OpFunctionCall %ulong %9 %1334 %1335
-OpStore %623 %1336
-OpBranch %270
-%270 = OpLabel
-OpStore %287 %1287
-%1337 = OpLoad %v4float %395
-%1338 = OpCompositeExtract %float %1337 0
-OpStore %409 %1338
-%1339 = OpLoad %v4float %287
-OpStore %410 %1339
-%1340 = OpLoad %v4float %410
-%1341 = OpLoad %float %409
-%1342 = OpCompositeInsert %v4float %1341 %1340 0
-OpStore %411 %1342
-%1343 = OpLoad %v4float %411
-OpStore %287 %1343
-%1344 = OpLoad %v4float %286
-OpStore %412 %1344
-%1345 = OpLoad %v4float %412
-%1346 = OpCompositeExtract %float %1345 1
-OpStore %413 %1346
-%1347 = OpLoad %v4float %287
-OpStore %414 %1347
-%1348 = OpLoad %v4float %414
-%1349 = OpLoad %float %413
-%1350 = OpCompositeInsert %v4float %1349 %1348 1
-OpStore %415 %1350
-%1351 = OpLoad %v4float %415
-OpStore %287 %1351
-%1352 = OpLoad %v4float %395
-%1353 = OpCompositeExtract %float %1352 2
-OpStore %416 %1353
-%1354 = OpLoad %v4float %287
-OpStore %417 %1354
-%1355 = OpLoad %v4float %417
-%1356 = OpLoad %float %416
-%1357 = OpCompositeInsert %v4float %1356 %1355 2
-OpStore %418 %1357
-%1358 = OpLoad %v4float %418
-OpStore %287 %1358
-%1359 = OpLoad %v4float %286
-OpStore %419 %1359
-%1360 = OpLoad %v4float %419
-%1361 = OpCompositeExtract %float %1360 3
-OpStore %420 %1361
-%1362 = OpLoad %v4float %287
-OpStore %421 %1362
-%1363 = OpLoad %v4float %421
-%1364 = OpLoad %float %420
-%1365 = OpCompositeInsert %v4float %1364 %1363 3
-OpStore %422 %1365
-%1366 = OpLoad %v4float %422
-OpStore %287 %1366
-%1367 = OpLoad %v4float %287
-OpStore %423 %1367
-OpBranch %271
-%271 = OpLabel
-%1368 = OpLoad %v4float %423
-%1369 = OpCompositeExtract %float %1368 0
-OpStore %624 %1369
-%1370 = OpLoad %ulong %623
-%1371 = OpLoad %float %624
-%1372 = OpFunctionCall %ulong %9 %1370 %1371
-OpStore %625 %1372
-%1373 = OpLoad %v4float %423
-%1374 = OpCompositeExtract %float %1373 1
-OpStore %626 %1374
-%1375 = OpLoad %ulong %625
-%1376 = OpLoad %float %626
-%1377 = OpFunctionCall %ulong %9 %1375 %1376
-OpStore %627 %1377
-%1378 = OpLoad %v4float %423
-%1379 = OpCompositeExtract %float %1378 2
-OpStore %628 %1379
-%1380 = OpLoad %ulong %627
-%1381 = OpLoad %float %628
-%1382 = OpFunctionCall %ulong %9 %1380 %1381
-OpStore %629 %1382
-%1383 = OpLoad %v4float %423
-%1384 = OpCompositeExtract %float %1383 3
-OpStore %630 %1384
-%1385 = OpLoad %ulong %629
-%1386 = OpLoad %float %630
-%1387 = OpFunctionCall %ulong %9 %1385 %1386
-OpStore %631 %1387
-OpBranch %272
-%272 = OpLabel
-%1388 = OpLoad %v4float %287
-OpStore %424 %1388
-%1389 = OpLoad %v4float %286
-OpStore %425 %1389
-%1390 = OpLoad %v4float %424
-%1391 = OpLoad %v4float %425
-%1392 = OpFMul %v4float %1390 %1391
-OpStore %426 %1392
-OpBranch %273
-%273 = OpLabel
-%1393 = OpLoad %v4float %426
-%1394 = OpCompositeExtract %float %1393 0
-OpStore %632 %1394
-%1395 = OpLoad %ulong %631
-%1396 = OpLoad %float %632
-%1397 = OpFunctionCall %ulong %9 %1395 %1396
-OpStore %633 %1397
-%1398 = OpLoad %v4float %426
-%1399 = OpCompositeExtract %float %1398 1
-OpStore %634 %1399
-%1400 = OpLoad %ulong %633
-%1401 = OpLoad %float %634
-%1402 = OpFunctionCall %ulong %9 %1400 %1401
-OpStore %635 %1402
-%1403 = OpLoad %v4float %426
-%1404 = OpCompositeExtract %float %1403 2
-OpStore %636 %1404
-%1405 = OpLoad %ulong %635
-%1406 = OpLoad %float %636
-%1407 = OpFunctionCall %ulong %9 %1405 %1406
-OpStore %637 %1407
-%1408 = OpLoad %v4float %426
-%1409 = OpCompositeExtract %float %1408 3
-OpStore %638 %1409
-%1410 = OpLoad %ulong %637
-%1411 = OpLoad %float %638
-%1412 = OpFunctionCall %ulong %9 %1410 %1411
-OpStore %639 %1412
-OpBranch %274
-%274 = OpLabel
-%1413 = OpLoad %v4float %395
-%1414 = OpCompositeExtract %float %1413 0
-OpStore %427 %1414
-%1415 = OpLoad %v4float %286
-OpStore %428 %1415
-%1416 = OpLoad %v4float %428
-%1417 = OpCompositeExtract %float %1416 0
-OpStore %429 %1417
-%1418 = OpLoad %float %427
-%1419 = OpLoad %float %429
-%1420 = OpFSub %float %1418 %1419
-OpStore %430 %1420
-%1421 = OpLoad %ulong %639
-%1422 = OpLoad %float %430
-%1423 = OpFunctionCall %ulong %9 %1421 %1422
-OpStore %431 %1423
-%1424 = OpLoad %v4float %395
-%1425 = OpCompositeExtract %float %1424 3
-OpStore %432 %1425
-%1426 = OpLoad %v4float %286
-OpStore %433 %1426
-%1427 = OpLoad %v4float %433
-%1428 = OpCompositeExtract %float %1427 3
-OpStore %434 %1428
-%1429 = OpLoad %float %432
-%1430 = OpLoad %float %434
-%1431 = OpFSub %float %1429 %1430
-OpStore %435 %1431
-%1432 = OpLoad %ulong %431
-%1433 = OpLoad %float %435
-%1434 = OpFunctionCall %ulong %9 %1432 %1433
-OpStore %436 %1434
-%1435 = OpCompositeConstruct %v2double %double_1_5 %double_n2_25
-OpStore %437 %1435
-%1438 = OpLoad %v2double %437
-%1439 = OpCompositeExtract %double %1438 0
-OpStore %438 %1439
-%1440 = OpLoad %double %438
-%1441 = OpLoad %double %294
-%1442 = OpFAdd %double %1440 %1441
-OpStore %439 %1442
-%1443 = OpLoad %v2double %437
-%1444 = OpLoad %double %439
-%1445 = OpCompositeInsert %v2double %1444 %1443 0
-OpStore %440 %1445
-OpStore %288 %1446
-%1447 = OpLoad %v2double %440
-%1448 = OpCompositeExtract %double %1447 1
-OpStore %441 %1448
-%1449 = OpLoad %v2double %288
-OpStore %442 %1449
-%1450 = OpLoad %v2double %442
-%1451 = OpLoad %double %441
-%1452 = OpCompositeInsert %v2double %1451 %1450 0
-OpStore %443 %1452
-%1453 = OpLoad %v2double %443
-OpStore %288 %1453
-%1454 = OpLoad %v2double %440
-%1455 = OpCompositeExtract %double %1454 0
-OpStore %444 %1455
-%1456 = OpLoad %v2double %288
-OpStore %445 %1456
-%1457 = OpLoad %v2double %445
-%1458 = OpLoad %double %444
-%1459 = OpCompositeInsert %v2double %1458 %1457 1
-OpStore %446 %1459
-%1460 = OpLoad %v2double %446
-OpStore %288 %1460
-OpBranch %275
-%275 = OpLabel
-%1461 = OpLoad %v2double %440
-%1462 = OpCompositeExtract %double %1461 0
-OpStore %640 %1462
-%1463 = OpLoad %ulong %436
-%1464 = OpLoad %double %640
-%1465 = OpFunctionCall %ulong %10 %1463 %1464
-OpStore %641 %1465
-%1466 = OpLoad %v2double %440
-%1467 = OpCompositeExtract %double %1466 1
-OpStore %642 %1467
-%1468 = OpLoad %ulong %641
-%1469 = OpLoad %double %642
-%1470 = OpFunctionCall %ulong %10 %1468 %1469
-OpStore %643 %1470
-OpBranch %276
-%276 = OpLabel
-%1471 = OpLoad %v2double %288
-OpStore %447 %1471
-OpBranch %277
-%277 = OpLabel
-%1472 = OpLoad %v2double %447
-%1473 = OpCompositeExtract %double %1472 0
-OpStore %644 %1473
-%1474 = OpLoad %ulong %643
-%1475 = OpLoad %double %644
-%1476 = OpFunctionCall %ulong %10 %1474 %1475
-OpStore %645 %1476
-%1477 = OpLoad %v2double %447
-%1478 = OpCompositeExtract %double %1477 1
-OpStore %646 %1478
-%1479 = OpLoad %ulong %645
-%1480 = OpLoad %double %646
-%1481 = OpFunctionCall %ulong %10 %1479 %1480
-OpStore %647 %1481
-OpBranch %278
-%278 = OpLabel
-%1482 = OpLoad %v2double %288
-OpStore %448 %1482
-%1483 = OpLoad %v2double %448
-%1484 = OpLoad %v2double %440
-%1485 = OpFSub %v2double %1483 %1484
-OpStore %449 %1485
-OpBranch %279
-%279 = OpLabel
-%1486 = OpLoad %v2double %449
-%1487 = OpCompositeExtract %double %1486 0
-OpStore %648 %1487
-%1488 = OpLoad %ulong %647
-%1489 = OpLoad %double %648
-%1490 = OpFunctionCall %ulong %10 %1488 %1489
-OpStore %649 %1490
-%1491 = OpLoad %v2double %449
-%1492 = OpCompositeExtract %double %1491 1
-OpStore %650 %1492
-%1493 = OpLoad %ulong %649
-%1494 = OpLoad %double %650
-%1495 = OpFunctionCall %ulong %10 %1493 %1494
-OpStore %651 %1495
-OpBranch %280
-%280 = OpLabel
-%1496 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_247 %uchar_7 %uchar_251 %uchar_3 %uchar_255 %uchar_2 %uchar_252 %uchar_6 %uchar_248 %uchar_9 %uchar_253 %uchar_1 %uchar_254 %uchar_4 %uchar_250 %uchar_8
-OpStore %450 %1496
-%1513 = OpLoad %_arr_uchar_uint_16 %450
-%1514 = OpCompositeExtract %uchar %1513 0
-OpStore %451 %1514
-%1515 = OpLoad %uchar %451
-%1516 = OpLoad %uchar %295
-%1517 = OpIAdd %uchar %1515 %1516
-OpStore %452 %1517
-%1518 = OpLoad %_arr_uchar_uint_16 %450
-%1519 = OpLoad %uchar %452
-%1520 = OpCompositeInsert %_arr_uchar_uint_16 %1519 %1518 0
-OpStore %453 %1520
-%1521 = OpLoad %_arr_uchar_uint_16 %453
-%1522 = OpCompositeExtract %uchar %1521 15
-OpStore %454 %1522
-%1523 = OpLoad %uchar %454
-%1524 = OpLoad %uchar %295
-%1525 = OpIAdd %uchar %1523 %1524
-OpStore %455 %1525
-%1526 = OpLoad %_arr_uchar_uint_16 %453
-%1527 = OpLoad %uchar %455
-%1528 = OpCompositeInsert %_arr_uchar_uint_16 %1527 %1526 15
-OpStore %456 %1528
-%1529 = OpLoad %ulong %651
-%1530 = OpLoad %_arr_uchar_uint_16 %456
-%1531 = OpFunctionCall %ulong %4 %1529 %1530
-OpStore %457 %1531
-OpStore %289 %1532
-%1533 = OpLoad %_arr_uchar_uint_16 %456
-%1534 = OpCompositeExtract %uchar %1533 15
-OpStore %458 %1534
-%1535 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %459 %1535
-%1536 = OpLoad %_arr_uchar_uint_16 %459
-%1537 = OpLoad %uchar %458
-%1538 = OpCompositeInsert %_arr_uchar_uint_16 %1537 %1536 0
-OpStore %460 %1538
-%1539 = OpLoad %_arr_uchar_uint_16 %460
-OpStore %289 %1539
-%1540 = OpLoad %_arr_uchar_uint_16 %456
-%1541 = OpCompositeExtract %uchar %1540 14
-OpStore %461 %1541
-%1542 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %462 %1542
-%1543 = OpLoad %_arr_uchar_uint_16 %462
-%1544 = OpLoad %uchar %461
-%1545 = OpCompositeInsert %_arr_uchar_uint_16 %1544 %1543 1
-OpStore %463 %1545
-%1546 = OpLoad %_arr_uchar_uint_16 %463
-OpStore %289 %1546
-%1547 = OpLoad %_arr_uchar_uint_16 %456
-%1548 = OpCompositeExtract %uchar %1547 13
-OpStore %464 %1548
-%1549 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %465 %1549
-%1550 = OpLoad %_arr_uchar_uint_16 %465
-%1551 = OpLoad %uchar %464
-%1552 = OpCompositeInsert %_arr_uchar_uint_16 %1551 %1550 2
-OpStore %466 %1552
-%1553 = OpLoad %_arr_uchar_uint_16 %466
-OpStore %289 %1553
-%1554 = OpLoad %_arr_uchar_uint_16 %456
-%1555 = OpCompositeExtract %uchar %1554 12
-OpStore %467 %1555
-%1556 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %468 %1556
-%1557 = OpLoad %_arr_uchar_uint_16 %468
-%1558 = OpLoad %uchar %467
-%1559 = OpCompositeInsert %_arr_uchar_uint_16 %1558 %1557 3
-OpStore %469 %1559
-%1560 = OpLoad %_arr_uchar_uint_16 %469
-OpStore %289 %1560
-%1561 = OpLoad %_arr_uchar_uint_16 %456
-%1562 = OpCompositeExtract %uchar %1561 11
-OpStore %470 %1562
-%1563 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %471 %1563
-%1564 = OpLoad %_arr_uchar_uint_16 %471
-%1565 = OpLoad %uchar %470
-%1566 = OpCompositeInsert %_arr_uchar_uint_16 %1565 %1564 4
-OpStore %472 %1566
-%1567 = OpLoad %_arr_uchar_uint_16 %472
-OpStore %289 %1567
-%1568 = OpLoad %_arr_uchar_uint_16 %456
-%1569 = OpCompositeExtract %uchar %1568 10
-OpStore %473 %1569
-%1570 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %474 %1570
-%1571 = OpLoad %_arr_uchar_uint_16 %474
-%1572 = OpLoad %uchar %473
-%1573 = OpCompositeInsert %_arr_uchar_uint_16 %1572 %1571 5
-OpStore %475 %1573
-%1574 = OpLoad %_arr_uchar_uint_16 %475
-OpStore %289 %1574
-%1575 = OpLoad %_arr_uchar_uint_16 %456
-%1576 = OpCompositeExtract %uchar %1575 9
-OpStore %476 %1576
-%1577 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %477 %1577
-%1578 = OpLoad %_arr_uchar_uint_16 %477
-%1579 = OpLoad %uchar %476
-%1580 = OpCompositeInsert %_arr_uchar_uint_16 %1579 %1578 6
-OpStore %478 %1580
-%1581 = OpLoad %_arr_uchar_uint_16 %478
-OpStore %289 %1581
-%1582 = OpLoad %_arr_uchar_uint_16 %456
-%1583 = OpCompositeExtract %uchar %1582 8
-OpStore %479 %1583
-%1584 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %480 %1584
-%1585 = OpLoad %_arr_uchar_uint_16 %480
-%1586 = OpLoad %uchar %479
-%1587 = OpCompositeInsert %_arr_uchar_uint_16 %1586 %1585 7
-OpStore %481 %1587
-%1588 = OpLoad %_arr_uchar_uint_16 %481
-OpStore %289 %1588
-%1589 = OpLoad %_arr_uchar_uint_16 %456
-%1590 = OpCompositeExtract %uchar %1589 7
-OpStore %482 %1590
-%1591 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %483 %1591
-%1592 = OpLoad %_arr_uchar_uint_16 %483
-%1593 = OpLoad %uchar %482
-%1594 = OpCompositeInsert %_arr_uchar_uint_16 %1593 %1592 8
-OpStore %484 %1594
-%1595 = OpLoad %_arr_uchar_uint_16 %484
-OpStore %289 %1595
-%1596 = OpLoad %_arr_uchar_uint_16 %456
-%1597 = OpCompositeExtract %uchar %1596 6
-OpStore %485 %1597
-%1598 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %486 %1598
-%1599 = OpLoad %_arr_uchar_uint_16 %486
-%1600 = OpLoad %uchar %485
-%1601 = OpCompositeInsert %_arr_uchar_uint_16 %1600 %1599 9
-OpStore %487 %1601
-%1602 = OpLoad %_arr_uchar_uint_16 %487
-OpStore %289 %1602
-%1603 = OpLoad %_arr_uchar_uint_16 %456
-%1604 = OpCompositeExtract %uchar %1603 5
-OpStore %488 %1604
-%1605 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %489 %1605
-%1606 = OpLoad %_arr_uchar_uint_16 %489
-%1607 = OpLoad %uchar %488
-%1608 = OpCompositeInsert %_arr_uchar_uint_16 %1607 %1606 10
-OpStore %490 %1608
-%1609 = OpLoad %_arr_uchar_uint_16 %490
-OpStore %289 %1609
-%1610 = OpLoad %_arr_uchar_uint_16 %456
-%1611 = OpCompositeExtract %uchar %1610 4
-OpStore %491 %1611
-%1612 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %492 %1612
-%1613 = OpLoad %_arr_uchar_uint_16 %492
-%1614 = OpLoad %uchar %491
-%1615 = OpCompositeInsert %_arr_uchar_uint_16 %1614 %1613 11
-OpStore %493 %1615
-%1616 = OpLoad %_arr_uchar_uint_16 %493
-OpStore %289 %1616
-%1617 = OpLoad %_arr_uchar_uint_16 %456
-%1618 = OpCompositeExtract %uchar %1617 3
-OpStore %494 %1618
-%1619 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %495 %1619
-%1620 = OpLoad %_arr_uchar_uint_16 %495
-%1621 = OpLoad %uchar %494
-%1622 = OpCompositeInsert %_arr_uchar_uint_16 %1621 %1620 12
-OpStore %496 %1622
-%1623 = OpLoad %_arr_uchar_uint_16 %496
-OpStore %289 %1623
-%1624 = OpLoad %_arr_uchar_uint_16 %456
-%1625 = OpCompositeExtract %uchar %1624 2
-OpStore %497 %1625
-%1626 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %498 %1626
-%1627 = OpLoad %_arr_uchar_uint_16 %498
-%1628 = OpLoad %uchar %497
-%1629 = OpCompositeInsert %_arr_uchar_uint_16 %1628 %1627 13
-OpStore %499 %1629
-%1630 = OpLoad %_arr_uchar_uint_16 %499
-OpStore %289 %1630
-%1631 = OpLoad %_arr_uchar_uint_16 %456
-%1632 = OpCompositeExtract %uchar %1631 1
-OpStore %500 %1632
-%1633 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %501 %1633
-%1634 = OpLoad %_arr_uchar_uint_16 %501
-%1635 = OpLoad %uchar %500
-%1636 = OpCompositeInsert %_arr_uchar_uint_16 %1635 %1634 14
-OpStore %502 %1636
-%1637 = OpLoad %_arr_uchar_uint_16 %502
-OpStore %289 %1637
-%1638 = OpLoad %_arr_uchar_uint_16 %456
-%1639 = OpCompositeExtract %uchar %1638 0
-OpStore %503 %1639
-%1640 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %504 %1640
-%1641 = OpLoad %_arr_uchar_uint_16 %504
-%1642 = OpLoad %uchar %503
-%1643 = OpCompositeInsert %_arr_uchar_uint_16 %1642 %1641 15
-OpStore %505 %1643
-%1644 = OpLoad %_arr_uchar_uint_16 %505
-OpStore %289 %1644
-%1645 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %506 %1645
-%1646 = OpLoad %ulong %457
-%1647 = OpLoad %_arr_uchar_uint_16 %506
-%1648 = OpFunctionCall %ulong %4 %1646 %1647
-OpStore %507 %1648
-%1649 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %508 %1649
-%1650 = OpLoad %_arr_uchar_uint_16 %508
-%1651 = OpCompositeExtract %uchar %1650 0
-OpStore %652 %1651
-%1652 = OpLoad %_arr_uchar_uint_16 %456
-%1653 = OpCompositeExtract %uchar %1652 0
-OpStore %653 %1653
-%1654 = OpLoad %uchar %652
-%1655 = OpLoad %uchar %653
-%1656 = OpIAdd %uchar %1654 %1655
-OpStore %654 %1656
-%1657 = OpLoad %_arr_uchar_uint_16 %508
-%1658 = OpCompositeExtract %uchar %1657 1
-OpStore %655 %1658
-%1659 = OpLoad %_arr_uchar_uint_16 %456
-%1660 = OpCompositeExtract %uchar %1659 1
-OpStore %656 %1660
-%1661 = OpLoad %uchar %655
-%1662 = OpLoad %uchar %656
-%1663 = OpIAdd %uchar %1661 %1662
-OpStore %657 %1663
-%1664 = OpLoad %_arr_uchar_uint_16 %508
-%1665 = OpCompositeExtract %uchar %1664 2
-OpStore %658 %1665
-%1666 = OpLoad %_arr_uchar_uint_16 %456
-%1667 = OpCompositeExtract %uchar %1666 2
-OpStore %659 %1667
-%1668 = OpLoad %uchar %658
-%1669 = OpLoad %uchar %659
-%1670 = OpIAdd %uchar %1668 %1669
-OpStore %660 %1670
-%1671 = OpLoad %_arr_uchar_uint_16 %508
-%1672 = OpCompositeExtract %uchar %1671 3
-OpStore %661 %1672
-%1673 = OpLoad %_arr_uchar_uint_16 %456
-%1674 = OpCompositeExtract %uchar %1673 3
-OpStore %662 %1674
-%1675 = OpLoad %uchar %661
-%1676 = OpLoad %uchar %662
-%1677 = OpIAdd %uchar %1675 %1676
-OpStore %663 %1677
-%1678 = OpLoad %_arr_uchar_uint_16 %508
-%1679 = OpCompositeExtract %uchar %1678 4
-OpStore %664 %1679
-%1680 = OpLoad %_arr_uchar_uint_16 %456
-%1681 = OpCompositeExtract %uchar %1680 4
-OpStore %665 %1681
-%1682 = OpLoad %uchar %664
-%1683 = OpLoad %uchar %665
-%1684 = OpIAdd %uchar %1682 %1683
-OpStore %666 %1684
-%1685 = OpLoad %_arr_uchar_uint_16 %508
-%1686 = OpCompositeExtract %uchar %1685 5
-OpStore %667 %1686
-%1687 = OpLoad %_arr_uchar_uint_16 %456
-%1688 = OpCompositeExtract %uchar %1687 5
-OpStore %668 %1688
-%1689 = OpLoad %uchar %667
-%1690 = OpLoad %uchar %668
-%1691 = OpIAdd %uchar %1689 %1690
-OpStore %669 %1691
-%1692 = OpLoad %_arr_uchar_uint_16 %508
-%1693 = OpCompositeExtract %uchar %1692 6
-OpStore %670 %1693
-%1694 = OpLoad %_arr_uchar_uint_16 %456
-%1695 = OpCompositeExtract %uchar %1694 6
-OpStore %671 %1695
-%1696 = OpLoad %uchar %670
-%1697 = OpLoad %uchar %671
-%1698 = OpIAdd %uchar %1696 %1697
-OpStore %672 %1698
-%1699 = OpLoad %_arr_uchar_uint_16 %508
-%1700 = OpCompositeExtract %uchar %1699 7
-OpStore %673 %1700
-%1701 = OpLoad %_arr_uchar_uint_16 %456
-%1702 = OpCompositeExtract %uchar %1701 7
-OpStore %674 %1702
-%1703 = OpLoad %uchar %673
-%1704 = OpLoad %uchar %674
-%1705 = OpIAdd %uchar %1703 %1704
-OpStore %675 %1705
-%1706 = OpLoad %_arr_uchar_uint_16 %508
-%1707 = OpCompositeExtract %uchar %1706 8
-OpStore %676 %1707
-%1708 = OpLoad %_arr_uchar_uint_16 %456
-%1709 = OpCompositeExtract %uchar %1708 8
-OpStore %677 %1709
-%1710 = OpLoad %uchar %676
-%1711 = OpLoad %uchar %677
-%1712 = OpIAdd %uchar %1710 %1711
-OpStore %678 %1712
-%1713 = OpLoad %_arr_uchar_uint_16 %508
-%1714 = OpCompositeExtract %uchar %1713 9
-OpStore %679 %1714
-%1715 = OpLoad %_arr_uchar_uint_16 %456
-%1716 = OpCompositeExtract %uchar %1715 9
-OpStore %680 %1716
-%1717 = OpLoad %uchar %679
-%1718 = OpLoad %uchar %680
-%1719 = OpIAdd %uchar %1717 %1718
-OpStore %681 %1719
-%1720 = OpLoad %_arr_uchar_uint_16 %508
-%1721 = OpCompositeExtract %uchar %1720 10
-OpStore %682 %1721
-%1722 = OpLoad %_arr_uchar_uint_16 %456
-%1723 = OpCompositeExtract %uchar %1722 10
-OpStore %683 %1723
-%1724 = OpLoad %uchar %682
-%1725 = OpLoad %uchar %683
-%1726 = OpIAdd %uchar %1724 %1725
-OpStore %684 %1726
-%1727 = OpLoad %_arr_uchar_uint_16 %508
-%1728 = OpCompositeExtract %uchar %1727 11
-OpStore %685 %1728
-%1729 = OpLoad %_arr_uchar_uint_16 %456
-%1730 = OpCompositeExtract %uchar %1729 11
-OpStore %686 %1730
-%1731 = OpLoad %uchar %685
-%1732 = OpLoad %uchar %686
-%1733 = OpIAdd %uchar %1731 %1732
-OpStore %687 %1733
-%1734 = OpLoad %_arr_uchar_uint_16 %508
-%1735 = OpCompositeExtract %uchar %1734 12
-OpStore %688 %1735
-%1736 = OpLoad %_arr_uchar_uint_16 %456
-%1737 = OpCompositeExtract %uchar %1736 12
-OpStore %689 %1737
-%1738 = OpLoad %uchar %688
-%1739 = OpLoad %uchar %689
-%1740 = OpIAdd %uchar %1738 %1739
-OpStore %690 %1740
-%1741 = OpLoad %_arr_uchar_uint_16 %508
-%1742 = OpCompositeExtract %uchar %1741 13
-OpStore %691 %1742
-%1743 = OpLoad %_arr_uchar_uint_16 %456
-%1744 = OpCompositeExtract %uchar %1743 13
-OpStore %692 %1744
-%1745 = OpLoad %uchar %691
-%1746 = OpLoad %uchar %692
-%1747 = OpIAdd %uchar %1745 %1746
-OpStore %693 %1747
-%1748 = OpLoad %_arr_uchar_uint_16 %508
-%1749 = OpCompositeExtract %uchar %1748 14
-OpStore %694 %1749
-%1750 = OpLoad %_arr_uchar_uint_16 %456
-%1751 = OpCompositeExtract %uchar %1750 14
-OpStore %695 %1751
-%1752 = OpLoad %uchar %694
-%1753 = OpLoad %uchar %695
-%1754 = OpIAdd %uchar %1752 %1753
-OpStore %696 %1754
-%1755 = OpLoad %_arr_uchar_uint_16 %508
-%1756 = OpCompositeExtract %uchar %1755 15
-OpStore %697 %1756
-%1757 = OpLoad %_arr_uchar_uint_16 %456
-%1758 = OpCompositeExtract %uchar %1757 15
-OpStore %698 %1758
-%1759 = OpLoad %uchar %697
-%1760 = OpLoad %uchar %698
-%1761 = OpIAdd %uchar %1759 %1760
-OpStore %699 %1761
-%1762 = OpLoad %_arr_uchar_uint_16 %508
-%1763 = OpLoad %uchar %654
-%1764 = OpCompositeInsert %_arr_uchar_uint_16 %1763 %1762 0
-OpStore %700 %1764
-%1765 = OpLoad %_arr_uchar_uint_16 %700
-%1766 = OpLoad %uchar %657
-%1767 = OpCompositeInsert %_arr_uchar_uint_16 %1766 %1765 1
-OpStore %701 %1767
-%1768 = OpLoad %_arr_uchar_uint_16 %701
-%1769 = OpLoad %uchar %660
-%1770 = OpCompositeInsert %_arr_uchar_uint_16 %1769 %1768 2
-OpStore %702 %1770
-%1771 = OpLoad %_arr_uchar_uint_16 %702
-%1772 = OpLoad %uchar %663
-%1773 = OpCompositeInsert %_arr_uchar_uint_16 %1772 %1771 3
-OpStore %703 %1773
-%1774 = OpLoad %_arr_uchar_uint_16 %703
-%1775 = OpLoad %uchar %666
-%1776 = OpCompositeInsert %_arr_uchar_uint_16 %1775 %1774 4
-OpStore %704 %1776
-%1777 = OpLoad %_arr_uchar_uint_16 %704
-%1778 = OpLoad %uchar %669
-%1779 = OpCompositeInsert %_arr_uchar_uint_16 %1778 %1777 5
-OpStore %705 %1779
-%1780 = OpLoad %_arr_uchar_uint_16 %705
-%1781 = OpLoad %uchar %672
-%1782 = OpCompositeInsert %_arr_uchar_uint_16 %1781 %1780 6
-OpStore %706 %1782
-%1783 = OpLoad %_arr_uchar_uint_16 %706
-%1784 = OpLoad %uchar %675
-%1785 = OpCompositeInsert %_arr_uchar_uint_16 %1784 %1783 7
-OpStore %707 %1785
-%1786 = OpLoad %_arr_uchar_uint_16 %707
-%1787 = OpLoad %uchar %678
-%1788 = OpCompositeInsert %_arr_uchar_uint_16 %1787 %1786 8
-OpStore %708 %1788
-%1789 = OpLoad %_arr_uchar_uint_16 %708
-%1790 = OpLoad %uchar %681
-%1791 = OpCompositeInsert %_arr_uchar_uint_16 %1790 %1789 9
-OpStore %709 %1791
-%1792 = OpLoad %_arr_uchar_uint_16 %709
-%1793 = OpLoad %uchar %684
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+OpStore %566 %495
+OpStore %568 %496
+%666 = OpLoad %_arr_uchar_uint_16 %568
+%667 = OpCompositeExtract %uchar %666 0
+OpStore %570 %667
+OpBranch %498
+%498 = OpLabel
+%668 = OpLoad %uchar %570
+%669 = OpSConvert %ulong %668
+OpStore %586 %669
+OpBranch %500
+%500 = OpLabel
+%670 = OpLoad %ulong %566
+OpStore %594 %670
+OpStore %595 %ulong_0
+OpBranch %501
+%501 = OpLabel
+%671 = OpLoad %ulong %595
+%672 = OpULessThan %bool %671 %ulong_8
+OpStore %587 %672
+%673 = OpLoad %bool %587
+OpLoopMerge %503 %565 None
+OpBranchConditional %673 %502 %503
+%503 = OpLabel
+OpBranch %504
+%504 = OpLabel
+OpBranch %499
+%499 = OpLabel
+%674 = OpLoad %_arr_uchar_uint_16 %568
+%675 = OpCompositeExtract %uchar %674 1
+OpStore %571 %675
+OpBranch %505
+%505 = OpLabel
+%676 = OpLoad %uchar %571
+%677 = OpSConvert %ulong %676
+OpStore %596 %677
+OpBranch %507
+%507 = OpLabel
+%678 = OpLoad %ulong %594
+OpStore %604 %678
+OpStore %605 %ulong_0
+OpBranch %508
+%508 = OpLabel
+%679 = OpLoad %ulong %605
+%680 = OpULessThan %bool %679 %ulong_8
+OpStore %597 %680
+%681 = OpLoad %bool %597
+OpLoopMerge %510 %564 None
+OpBranchConditional %681 %509 %510
+%510 = OpLabel
+OpBranch %511
+%511 = OpLabel
+OpBranch %506
+%506 = OpLabel
+%682 = OpLoad %_arr_uchar_uint_16 %568
+%683 = OpCompositeExtract %uchar %682 2
+OpStore %572 %683
+OpBranch %512
+%512 = OpLabel
+%684 = OpLoad %uchar %572
+%685 = OpSConvert %ulong %684
+OpStore %606 %685
+OpBranch %514
+%514 = OpLabel
+%686 = OpLoad %ulong %604
+OpStore %614 %686
+OpStore %615 %ulong_0
+OpBranch %515
+%515 = OpLabel
+%687 = OpLoad %ulong %615
+%688 = OpULessThan %bool %687 %ulong_8
+OpStore %607 %688
+%689 = OpLoad %bool %607
+OpLoopMerge %517 %563 None
+OpBranchConditional %689 %516 %517
+%517 = OpLabel
+OpBranch %518
+%518 = OpLabel
+OpBranch %513
+%513 = OpLabel
+%690 = OpLoad %_arr_uchar_uint_16 %568
+%691 = OpCompositeExtract %uchar %690 3
+OpStore %573 %691
+OpBranch %519
+%519 = OpLabel
+%692 = OpLoad %uchar %573
+%693 = OpSConvert %ulong %692
+OpStore %616 %693
+OpBranch %521
+%521 = OpLabel
+%694 = OpLoad %ulong %614
+OpStore %624 %694
+OpStore %625 %ulong_0
+OpBranch %522
+%522 = OpLabel
+%695 = OpLoad %ulong %625
+%696 = OpULessThan %bool %695 %ulong_8
+OpStore %617 %696
+%697 = OpLoad %bool %617
+OpLoopMerge %524 %562 None
+OpBranchConditional %697 %523 %524
+%524 = OpLabel
+OpBranch %525
+%525 = OpLabel
+OpBranch %520
+%520 = OpLabel
+%698 = OpLoad %_arr_uchar_uint_16 %568
+%699 = OpCompositeExtract %uchar %698 4
+OpStore %574 %699
+OpBranch %526
+%526 = OpLabel
+%700 = OpLoad %uchar %574
+%701 = OpSConvert %ulong %700
+OpStore %626 %701
+OpBranch %528
+%528 = OpLabel
+%702 = OpLoad %ulong %624
+OpStore %634 %702
+OpStore %635 %ulong_0
+OpBranch %529
+%529 = OpLabel
+%703 = OpLoad %ulong %635
+%704 = OpULessThan %bool %703 %ulong_8
+OpStore %627 %704
+%705 = OpLoad %bool %627
+OpLoopMerge %531 %561 None
+OpBranchConditional %705 %530 %531
+%531 = OpLabel
+OpBranch %532
+%532 = OpLabel
+OpBranch %527
+%527 = OpLabel
+%706 = OpLoad %_arr_uchar_uint_16 %568
+%707 = OpCompositeExtract %uchar %706 5
+OpStore %575 %707
+OpBranch %533
+%533 = OpLabel
+%708 = OpLoad %uchar %575
+%709 = OpSConvert %ulong %708
+OpStore %636 %709
+OpBranch %535
+%535 = OpLabel
+%710 = OpLoad %ulong %634
+OpStore %644 %710
+OpStore %645 %ulong_0
+OpBranch %536
+%536 = OpLabel
+%711 = OpLoad %ulong %645
+%712 = OpULessThan %bool %711 %ulong_8
+OpStore %637 %712
+%713 = OpLoad %bool %637
+OpLoopMerge %538 %560 None
+OpBranchConditional %713 %537 %538
+%538 = OpLabel
+OpBranch %539
+%539 = OpLabel
+OpBranch %534
+%534 = OpLabel
+%714 = OpLoad %_arr_uchar_uint_16 %568
+%715 = OpCompositeExtract %uchar %714 6
+OpStore %576 %715
+OpBranch %540
+%540 = OpLabel
+%716 = OpLoad %uchar %576
+%717 = OpSConvert %ulong %716
+OpStore %646 %717
+%718 = OpLoad %ulong %644
+%719 = OpLoad %ulong %646
+%720 = OpFunctionCall %ulong %6 %718 %719
+OpStore %647 %720
+OpBranch %541
+%541 = OpLabel
+%721 = OpLoad %_arr_uchar_uint_16 %568
+%722 = OpCompositeExtract %uchar %721 7
+OpStore %577 %722
+OpBranch %542
+%542 = OpLabel
+%723 = OpLoad %uchar %577
+%724 = OpSConvert %ulong %723
+OpStore %648 %724
+%725 = OpLoad %ulong %647
+%726 = OpLoad %ulong %648
+%727 = OpFunctionCall %ulong %6 %725 %726
+OpStore %649 %727
+OpBranch %543
+%543 = OpLabel
+%728 = OpLoad %_arr_uchar_uint_16 %568
+%729 = OpCompositeExtract %uchar %728 8
+OpStore %578 %729
+OpBranch %544
+%544 = OpLabel
+%730 = OpLoad %uchar %578
+%731 = OpSConvert %ulong %730
+OpStore %650 %731
+%732 = OpLoad %ulong %649
+%733 = OpLoad %ulong %650
+%734 = OpFunctionCall %ulong %6 %732 %733
+OpStore %651 %734
+OpBranch %545
+%545 = OpLabel
+%735 = OpLoad %_arr_uchar_uint_16 %568
+%736 = OpCompositeExtract %uchar %735 9
+OpStore %579 %736
+OpBranch %546
+%546 = OpLabel
+%737 = OpLoad %uchar %579
+%738 = OpSConvert %ulong %737
+OpStore %652 %738
+%739 = OpLoad %ulong %651
+%740 = OpLoad %ulong %652
+%741 = OpFunctionCall %ulong %6 %739 %740
+OpStore %653 %741
+OpBranch %547
+%547 = OpLabel
+%742 = OpLoad %_arr_uchar_uint_16 %568
+%743 = OpCompositeExtract %uchar %742 10
+OpStore %580 %743
+OpBranch %548
+%548 = OpLabel
+%744 = OpLoad %uchar %580
+%745 = OpSConvert %ulong %744
+OpStore %654 %745
+%746 = OpLoad %ulong %653
+%747 = OpLoad %ulong %654
+%748 = OpFunctionCall %ulong %6 %746 %747
+OpStore %655 %748
+OpBranch %549
+%549 = OpLabel
+%749 = OpLoad %_arr_uchar_uint_16 %568
+%750 = OpCompositeExtract %uchar %749 11
+OpStore %581 %750
+OpBranch %550
+%550 = OpLabel
+%751 = OpLoad %uchar %581
+%752 = OpSConvert %ulong %751
+OpStore %656 %752
+%753 = OpLoad %ulong %655
+%754 = OpLoad %ulong %656
+%755 = OpFunctionCall %ulong %6 %753 %754
+OpStore %657 %755
+OpBranch %551
+%551 = OpLabel
+%756 = OpLoad %_arr_uchar_uint_16 %568
+%757 = OpCompositeExtract %uchar %756 12
+OpStore %582 %757
+OpBranch %552
+%552 = OpLabel
+%758 = OpLoad %uchar %582
+%759 = OpSConvert %ulong %758
+OpStore %658 %759
+%760 = OpLoad %ulong %657
+%761 = OpLoad %ulong %658
+%762 = OpFunctionCall %ulong %6 %760 %761
+OpStore %659 %762
+OpBranch %553
+%553 = OpLabel
+%763 = OpLoad %_arr_uchar_uint_16 %568
+%764 = OpCompositeExtract %uchar %763 13
+OpStore %583 %764
+OpBranch %554
+%554 = OpLabel
+%765 = OpLoad %uchar %583
+%766 = OpSConvert %ulong %765
+OpStore %660 %766
+%767 = OpLoad %ulong %659
+%768 = OpLoad %ulong %660
+%769 = OpFunctionCall %ulong %6 %767 %768
+OpStore %661 %769
+OpBranch %555
+%555 = OpLabel
+%770 = OpLoad %_arr_uchar_uint_16 %568
+%771 = OpCompositeExtract %uchar %770 14
+OpStore %584 %771
+OpBranch %556
+%556 = OpLabel
+%772 = OpLoad %uchar %584
+%773 = OpSConvert %ulong %772
+OpStore %662 %773
+%774 = OpLoad %ulong %661
+%775 = OpLoad %ulong %662
+%776 = OpFunctionCall %ulong %6 %774 %775
+OpStore %663 %776
+OpBranch %557
+%557 = OpLabel
+%777 = OpLoad %_arr_uchar_uint_16 %568
+%778 = OpCompositeExtract %uchar %777 15
+OpStore %585 %778
+OpBranch %558
+%558 = OpLabel
+%779 = OpLoad %uchar %585
+%780 = OpSConvert %ulong %779
+OpStore %664 %780
+%781 = OpLoad %ulong %663
+%782 = OpLoad %ulong %664
+%783 = OpFunctionCall %ulong %6 %781 %782
+OpStore %665 %783
+OpBranch %559
+%559 = OpLabel
+%784 = OpLoad %ulong %665
+OpReturnValue %784
+%537 = OpLabel
+%785 = OpLoad %ulong %645
+%786 = OpIMul %ulong %785 %ulong_8
+OpStore %638 %786
+%787 = OpLoad %ulong %636
+%788 = OpLoad %ulong %638
+%789 = OpShiftRightLogical %ulong %787 %788
+OpStore %639 %789
+%790 = OpLoad %ulong %639
+%791 = OpBitwiseAnd %ulong %790 %ulong_255
+OpStore %640 %791
+%792 = OpLoad %ulong %644
+%793 = OpLoad %ulong %640
+%794 = OpBitwiseXor %ulong %792 %793
+OpStore %641 %794
+%795 = OpLoad %ulong %641
+%796 = OpIMul %ulong %795 %ulong_1099511628211
+OpStore %642 %796
+%797 = OpLoad %ulong %645
+%798 = OpIAdd %ulong %797 %ulong_1
+OpStore %643 %798
+%799 = OpLoad %ulong %642
+OpStore %644 %799
+%800 = OpLoad %ulong %643
+OpStore %645 %800
+OpBranch %560
+%530 = OpLabel
+%801 = OpLoad %ulong %635
+%802 = OpIMul %ulong %801 %ulong_8
+OpStore %628 %802
+%803 = OpLoad %ulong %626
+%804 = OpLoad %ulong %628
+%805 = OpShiftRightLogical %ulong %803 %804
+OpStore %629 %805
+%806 = OpLoad %ulong %629
+%807 = OpBitwiseAnd %ulong %806 %ulong_255
+OpStore %630 %807
+%808 = OpLoad %ulong %634
+%809 = OpLoad %ulong %630
+%810 = OpBitwiseXor %ulong %808 %809
+OpStore %631 %810
+%811 = OpLoad %ulong %631
+%812 = OpIMul %ulong %811 %ulong_1099511628211
+OpStore %632 %812
+%813 = OpLoad %ulong %635
+%814 = OpIAdd %ulong %813 %ulong_1
+OpStore %633 %814
+%815 = OpLoad %ulong %632
+OpStore %634 %815
+%816 = OpLoad %ulong %633
+OpStore %635 %816
+OpBranch %561
+%523 = OpLabel
+%817 = OpLoad %ulong %625
+%818 = OpIMul %ulong %817 %ulong_8
+OpStore %618 %818
+%819 = OpLoad %ulong %616
+%820 = OpLoad %ulong %618
+%821 = OpShiftRightLogical %ulong %819 %820
+OpStore %619 %821
+%822 = OpLoad %ulong %619
+%823 = OpBitwiseAnd %ulong %822 %ulong_255
+OpStore %620 %823
+%824 = OpLoad %ulong %624
+%825 = OpLoad %ulong %620
+%826 = OpBitwiseXor %ulong %824 %825
+OpStore %621 %826
+%827 = OpLoad %ulong %621
+%828 = OpIMul %ulong %827 %ulong_1099511628211
+OpStore %622 %828
+%829 = OpLoad %ulong %625
+%830 = OpIAdd %ulong %829 %ulong_1
+OpStore %623 %830
+%831 = OpLoad %ulong %622
+OpStore %624 %831
+%832 = OpLoad %ulong %623
+OpStore %625 %832
+OpBranch %562
+%516 = OpLabel
+%833 = OpLoad %ulong %615
+%834 = OpIMul %ulong %833 %ulong_8
+OpStore %608 %834
+%835 = OpLoad %ulong %606
+%836 = OpLoad %ulong %608
+%837 = OpShiftRightLogical %ulong %835 %836
+OpStore %609 %837
+%838 = OpLoad %ulong %609
+%839 = OpBitwiseAnd %ulong %838 %ulong_255
+OpStore %610 %839
+%840 = OpLoad %ulong %614
+%841 = OpLoad %ulong %610
+%842 = OpBitwiseXor %ulong %840 %841
+OpStore %611 %842
+%843 = OpLoad %ulong %611
+%844 = OpIMul %ulong %843 %ulong_1099511628211
+OpStore %612 %844
+%845 = OpLoad %ulong %615
+%846 = OpIAdd %ulong %845 %ulong_1
+OpStore %613 %846
+%847 = OpLoad %ulong %612
+OpStore %614 %847
+%848 = OpLoad %ulong %613
+OpStore %615 %848
+OpBranch %563
+%509 = OpLabel
+%849 = OpLoad %ulong %605
+%850 = OpIMul %ulong %849 %ulong_8
+OpStore %598 %850
+%851 = OpLoad %ulong %596
+%852 = OpLoad %ulong %598
+%853 = OpShiftRightLogical %ulong %851 %852
+OpStore %599 %853
+%854 = OpLoad %ulong %599
+%855 = OpBitwiseAnd %ulong %854 %ulong_255
+OpStore %600 %855
+%856 = OpLoad %ulong %604
+%857 = OpLoad %ulong %600
+%858 = OpBitwiseXor %ulong %856 %857
+OpStore %601 %858
+%859 = OpLoad %ulong %601
+%860 = OpIMul %ulong %859 %ulong_1099511628211
+OpStore %602 %860
+%861 = OpLoad %ulong %605
+%862 = OpIAdd %ulong %861 %ulong_1
+OpStore %603 %862
+%863 = OpLoad %ulong %602
+OpStore %604 %863
+%864 = OpLoad %ulong %603
+OpStore %605 %864
+OpBranch %564
+%502 = OpLabel
+%865 = OpLoad %ulong %595
+%866 = OpIMul %ulong %865 %ulong_8
+OpStore %588 %866
+%867 = OpLoad %ulong %586
+%868 = OpLoad %ulong %588
+%869 = OpShiftRightLogical %ulong %867 %868
+OpStore %589 %869
+%870 = OpLoad %ulong %589
+%871 = OpBitwiseAnd %ulong %870 %ulong_255
+OpStore %590 %871
+%872 = OpLoad %ulong %594
+%873 = OpLoad %ulong %590
+%874 = OpBitwiseXor %ulong %872 %873
+OpStore %591 %874
+%875 = OpLoad %ulong %591
+%876 = OpIMul %ulong %875 %ulong_1099511628211
+OpStore %592 %876
+%877 = OpLoad %ulong %595
+%878 = OpIAdd %ulong %877 %ulong_1
+OpStore %593 %878
+%879 = OpLoad %ulong %592
+OpStore %594 %879
+%880 = OpLoad %ulong %593
+OpStore %595 %880
+OpBranch %565
+%560 = OpLabel
+OpBranch %536
+%561 = OpLabel
+OpBranch %529
+%562 = OpLabel
+OpBranch %522
+%563 = OpLabel
+OpBranch %515
+%564 = OpLabel
+OpBranch %508
+%565 = OpLabel
+OpBranch %501
+OpFunctionEnd
+%5 = OpFunction %ulong None %881
+%882 = OpFunctionParameter %ulong
+%883 = OpLabel
+%898 = OpVariable %_ptr_Function_v4uint Function
+%899 = OpVariable %_ptr_Function_v4uint Function
+%900 = OpVariable %_ptr_Function_v4uint Function
+%901 = OpVariable %_ptr_Function_v4uint Function
+%902 = OpVariable %_ptr_Function_v4uint Function
+%903 = OpVariable %_ptr_Function_v4float Function
+%904 = OpVariable %_ptr_Function_v4float Function
+%905 = OpVariable %_ptr_Function_v2double Function
+%906 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%907 = OpVariable %_ptr_Function_ulong Function
+%908 = OpVariable %_ptr_Function_uint Function
+%909 = OpVariable %_ptr_Function_float Function
+%910 = OpVariable %_ptr_Function_double Function
+%911 = OpVariable %_ptr_Function_uchar Function
+%912 = OpVariable %_ptr_Function_v4uint Function
+%913 = OpVariable %_ptr_Function_uint Function
+%914 = OpVariable %_ptr_Function_uint Function
+%915 = OpVariable %_ptr_Function_v4uint Function
+%916 = OpVariable %_ptr_Function_uint Function
+%917 = OpVariable %_ptr_Function_uint Function
+%918 = OpVariable %_ptr_Function_v4uint Function
+%919 = OpVariable %_ptr_Function_ulong Function
+%920 = OpVariable %_ptr_Function_uint Function
+%921 = OpVariable %_ptr_Function_v4uint Function
+%922 = OpVariable %_ptr_Function_v4uint Function
+%923 = OpVariable %_ptr_Function_uint Function
+%924 = OpVariable %_ptr_Function_v4uint Function
+%925 = OpVariable %_ptr_Function_v4uint Function
+%926 = OpVariable %_ptr_Function_uint Function
+%927 = OpVariable %_ptr_Function_v4uint Function
+%928 = OpVariable %_ptr_Function_v4uint Function
+%929 = OpVariable %_ptr_Function_uint Function
+%930 = OpVariable %_ptr_Function_v4uint Function
+%931 = OpVariable %_ptr_Function_v4uint Function
+%932 = OpVariable %_ptr_Function_v4uint Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_v4uint Function
+%935 = OpVariable %_ptr_Function_v4uint Function
+%936 = OpVariable %_ptr_Function_v4uint Function
+%937 = OpVariable %_ptr_Function_v4uint Function
+%938 = OpVariable %_ptr_Function_v4uint Function
+%939 = OpVariable %_ptr_Function_v4uint Function
+%940 = OpVariable %_ptr_Function_v4uint Function
+%941 = OpVariable %_ptr_Function_v4uint Function
+%942 = OpVariable %_ptr_Function_v4uint Function
+%943 = OpVariable %_ptr_Function_ulong Function
+%944 = OpVariable %_ptr_Function_v4uint Function
+%945 = OpVariable %_ptr_Function_v4uint Function
+%946 = OpVariable %_ptr_Function_v4uint Function
+%947 = OpVariable %_ptr_Function_v4uint Function
+%948 = OpVariable %_ptr_Function_v4uint Function
+%949 = OpVariable %_ptr_Function_v4uint Function
+%950 = OpVariable %_ptr_Function_v4uint Function
+%951 = OpVariable %_ptr_Function_v4uint Function
+%952 = OpVariable %_ptr_Function_v4uint Function
+%953 = OpVariable %_ptr_Function_ulong Function
+%954 = OpVariable %_ptr_Function_v4uint Function
+%955 = OpVariable %_ptr_Function_v4uint Function
+%956 = OpVariable %_ptr_Function_v4uint Function
+%957 = OpVariable %_ptr_Function_v4uint Function
+%958 = OpVariable %_ptr_Function_v4uint Function
+%959 = OpVariable %_ptr_Function_v4uint Function
+%960 = OpVariable %_ptr_Function_v4uint Function
+%961 = OpVariable %_ptr_Function_v4uint Function
+%962 = OpVariable %_ptr_Function_v4uint Function
+%963 = OpVariable %_ptr_Function_ulong Function
+%964 = OpVariable %_ptr_Function_v4uint Function
+%965 = OpVariable %_ptr_Function_v4uint Function
+%966 = OpVariable %_ptr_Function_v4uint Function
+%967 = OpVariable %_ptr_Function_ulong Function
+%968 = OpVariable %_ptr_Function_v4uint Function
+%969 = OpVariable %_ptr_Function_v4uint Function
+%970 = OpVariable %_ptr_Function_ulong Function
+%971 = OpVariable %_ptr_Function_v4uint Function
+%972 = OpVariable %_ptr_Function_uint Function
+%973 = OpVariable %_ptr_Function_v4uint Function
+%974 = OpVariable %_ptr_Function_uint Function
+%975 = OpVariable %_ptr_Function_uint Function
+%976 = OpVariable %_ptr_Function_uint Function
+%977 = OpVariable %_ptr_Function_uint Function
+%978 = OpVariable %_ptr_Function_v4uint Function
+%979 = OpVariable %_ptr_Function_uint Function
+%980 = OpVariable %_ptr_Function_uint Function
+%981 = OpVariable %_ptr_Function_uint Function
+%982 = OpVariable %_ptr_Function_uint Function
+%983 = OpVariable %_ptr_Function_v4uint Function
+%984 = OpVariable %_ptr_Function_uint Function
+%985 = OpVariable %_ptr_Function_uint Function
+%986 = OpVariable %_ptr_Function_uint Function
+%987 = OpVariable %_ptr_Function_uint Function
+%988 = OpVariable %_ptr_Function_v4uint Function
+%989 = OpVariable %_ptr_Function_uint Function
+%990 = OpVariable %_ptr_Function_ulong Function
+%991 = OpVariable %_ptr_Function_v4uint Function
+%992 = OpVariable %_ptr_Function_v4uint Function
+%993 = OpVariable %_ptr_Function_ulong Function
+%994 = OpVariable %_ptr_Function_v4uint Function
+%995 = OpVariable %_ptr_Function_v4uint Function
+%996 = OpVariable %_ptr_Function_ulong Function
+%997 = OpVariable %_ptr_Function_v4uint Function
+%998 = OpVariable %_ptr_Function_v4uint Function
+%999 = OpVariable %_ptr_Function_ulong Function
+%1000 = OpVariable %_ptr_Function_v4uint Function
+%1001 = OpVariable %_ptr_Function_v4uint Function
+%1002 = OpVariable %_ptr_Function_v4uint Function
+%1003 = OpVariable %_ptr_Function_ulong Function
+%1004 = OpVariable %_ptr_Function_float Function
+%1005 = OpVariable %_ptr_Function_float Function
+%1006 = OpVariable %_ptr_Function_v4float Function
+%1007 = OpVariable %_ptr_Function_float Function
+%1008 = OpVariable %_ptr_Function_float Function
+%1009 = OpVariable %_ptr_Function_v4float Function
+%1010 = OpVariable %_ptr_Function_ulong Function
+%1011 = OpVariable %_ptr_Function_float Function
+%1012 = OpVariable %_ptr_Function_v4float Function
+%1013 = OpVariable %_ptr_Function_v4float Function
+%1014 = OpVariable %_ptr_Function_float Function
+%1015 = OpVariable %_ptr_Function_v4float Function
+%1016 = OpVariable %_ptr_Function_v4float Function
+%1017 = OpVariable %_ptr_Function_float Function
+%1018 = OpVariable %_ptr_Function_v4float Function
+%1019 = OpVariable %_ptr_Function_v4float Function
+%1020 = OpVariable %_ptr_Function_float Function
+%1021 = OpVariable %_ptr_Function_v4float Function
+%1022 = OpVariable %_ptr_Function_v4float Function
+%1023 = OpVariable %_ptr_Function_v4float Function
+%1024 = OpVariable %_ptr_Function_ulong Function
+%1025 = OpVariable %_ptr_Function_v4float Function
+%1026 = OpVariable %_ptr_Function_v4float Function
+%1027 = OpVariable %_ptr_Function_v4float Function
+%1028 = OpVariable %_ptr_Function_float Function
+%1029 = OpVariable %_ptr_Function_v4float Function
+%1030 = OpVariable %_ptr_Function_v4float Function
+%1031 = OpVariable %_ptr_Function_v4float Function
+%1032 = OpVariable %_ptr_Function_v4float Function
+%1033 = OpVariable %_ptr_Function_v4float Function
+%1034 = OpVariable %_ptr_Function_float Function
+%1035 = OpVariable %_ptr_Function_v4float Function
+%1036 = OpVariable %_ptr_Function_v4float Function
+%1037 = OpVariable %_ptr_Function_v4float Function
+%1038 = OpVariable %_ptr_Function_ulong Function
+%1039 = OpVariable %_ptr_Function_v4float Function
+%1040 = OpVariable %_ptr_Function_v4float Function
+%1041 = OpVariable %_ptr_Function_v4float Function
+%1042 = OpVariable %_ptr_Function_ulong Function
+%1043 = OpVariable %_ptr_Function_v4float Function
+%1044 = OpVariable %_ptr_Function_float Function
+%1045 = OpVariable %_ptr_Function_float Function
+%1046 = OpVariable %_ptr_Function_float Function
+%1047 = OpVariable %_ptr_Function_v4float Function
+%1048 = OpVariable %_ptr_Function_float Function
+%1049 = OpVariable %_ptr_Function_float Function
+%1050 = OpVariable %_ptr_Function_v2double Function
+%1051 = OpVariable %_ptr_Function_double Function
+%1052 = OpVariable %_ptr_Function_double Function
+%1053 = OpVariable %_ptr_Function_v2double Function
+%1054 = OpVariable %_ptr_Function_double Function
+%1055 = OpVariable %_ptr_Function_v2double Function
+%1056 = OpVariable %_ptr_Function_v2double Function
+%1057 = OpVariable %_ptr_Function_double Function
+%1058 = OpVariable %_ptr_Function_v2double Function
+%1059 = OpVariable %_ptr_Function_v2double Function
+%1060 = OpVariable %_ptr_Function_ulong Function
+%1061 = OpVariable %_ptr_Function_v2double Function
+%1062 = OpVariable %_ptr_Function_ulong Function
+%1063 = OpVariable %_ptr_Function_v2double Function
+%1064 = OpVariable %_ptr_Function_v2double Function
+%1065 = OpVariable %_ptr_Function_ulong Function
+%1066 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1067 = OpVariable %_ptr_Function_uchar Function
+%1068 = OpVariable %_ptr_Function_uchar Function
+%1069 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1070 = OpVariable %_ptr_Function_uchar Function
+%1071 = OpVariable %_ptr_Function_uchar Function
+%1072 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1073 = OpVariable %_ptr_Function_ulong Function
+%1074 = OpVariable %_ptr_Function_uchar Function
+%1075 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1076 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1077 = OpVariable %_ptr_Function_uchar Function
+%1078 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1079 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1080 = OpVariable %_ptr_Function_uchar Function
+%1081 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1082 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1083 = OpVariable %_ptr_Function_uchar Function
+%1084 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1085 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1086 = OpVariable %_ptr_Function_uchar Function
+%1087 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1088 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1089 = OpVariable %_ptr_Function_uchar Function
+%1090 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1091 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1092 = OpVariable %_ptr_Function_uchar Function
+%1093 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1094 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1095 = OpVariable %_ptr_Function_uchar Function
+%1096 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1097 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1098 = OpVariable %_ptr_Function_uchar Function
+%1099 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1100 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1101 = OpVariable %_ptr_Function_uchar Function
+%1102 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1103 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1104 = OpVariable %_ptr_Function_uchar Function
+%1105 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1106 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1107 = OpVariable %_ptr_Function_uchar Function
+%1108 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1109 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1110 = OpVariable %_ptr_Function_uchar Function
+%1111 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1112 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1113 = OpVariable %_ptr_Function_uchar Function
+%1114 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1115 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1116 = OpVariable %_ptr_Function_uchar Function
+%1117 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1118 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1119 = OpVariable %_ptr_Function_uchar Function
+%1120 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1121 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1122 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1123 = OpVariable %_ptr_Function_ulong Function
+%1124 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1125 = OpVariable %_ptr_Function_ulong Function
+%1126 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1127 = OpVariable %_ptr_Function_ulong Function
+%1128 = OpVariable %_ptr_Function_ulong Function
+%1129 = OpVariable %_ptr_Function_ulong Function
+%1130 = OpVariable %_ptr_Function_ulong Function
+%1131 = OpVariable %_ptr_Function_ulong Function
+%1132 = OpVariable %_ptr_Function_ulong Function
+%1133 = OpVariable %_ptr_Function_ulong Function
+%1134 = OpVariable %_ptr_Function_ulong Function
+%1135 = OpVariable %_ptr_Function_ulong Function
+%1136 = OpVariable %_ptr_Function_uint Function
+%1137 = OpVariable %_ptr_Function_ulong Function
+%1138 = OpVariable %_ptr_Function_ulong Function
+%1139 = OpVariable %_ptr_Function_uint Function
+%1140 = OpVariable %_ptr_Function_ulong Function
+%1141 = OpVariable %_ptr_Function_ulong Function
+%1142 = OpVariable %_ptr_Function_uchar Function
+%1143 = OpVariable %_ptr_Function_uchar Function
+%1144 = OpVariable %_ptr_Function_uchar Function
+%1145 = OpVariable %_ptr_Function_uchar Function
+%1146 = OpVariable %_ptr_Function_uchar Function
+%1147 = OpVariable %_ptr_Function_uchar Function
+%1148 = OpVariable %_ptr_Function_uchar Function
+%1149 = OpVariable %_ptr_Function_uchar Function
+%1150 = OpVariable %_ptr_Function_uchar Function
+%1151 = OpVariable %_ptr_Function_uchar Function
+%1152 = OpVariable %_ptr_Function_uchar Function
+%1153 = OpVariable %_ptr_Function_uchar Function
+%1154 = OpVariable %_ptr_Function_uchar Function
+%1155 = OpVariable %_ptr_Function_uchar Function
+%1156 = OpVariable %_ptr_Function_uchar Function
+%1157 = OpVariable %_ptr_Function_uchar Function
+%1158 = OpVariable %_ptr_Function_uchar Function
+%1159 = OpVariable %_ptr_Function_uchar Function
+%1160 = OpVariable %_ptr_Function_uchar Function
+%1161 = OpVariable %_ptr_Function_uchar Function
+%1162 = OpVariable %_ptr_Function_uchar Function
+%1163 = OpVariable %_ptr_Function_uchar Function
+%1164 = OpVariable %_ptr_Function_uchar Function
+%1165 = OpVariable %_ptr_Function_uchar Function
+%1166 = OpVariable %_ptr_Function_uchar Function
+%1167 = OpVariable %_ptr_Function_uchar Function
+%1168 = OpVariable %_ptr_Function_uchar Function
+%1169 = OpVariable %_ptr_Function_uchar Function
+%1170 = OpVariable %_ptr_Function_uchar Function
+%1171 = OpVariable %_ptr_Function_uchar Function
+%1172 = OpVariable %_ptr_Function_uchar Function
+%1173 = OpVariable %_ptr_Function_uchar Function
+%1174 = OpVariable %_ptr_Function_uchar Function
+%1175 = OpVariable %_ptr_Function_uchar Function
+%1176 = OpVariable %_ptr_Function_uchar Function
+%1177 = OpVariable %_ptr_Function_uchar Function
+%1178 = OpVariable %_ptr_Function_uchar Function
+%1179 = OpVariable %_ptr_Function_uchar Function
+%1180 = OpVariable %_ptr_Function_uchar Function
+%1181 = OpVariable %_ptr_Function_uchar Function
+%1182 = OpVariable %_ptr_Function_uchar Function
+%1183 = OpVariable %_ptr_Function_uchar Function
+%1184 = OpVariable %_ptr_Function_uchar Function
+%1185 = OpVariable %_ptr_Function_uchar Function
+%1186 = OpVariable %_ptr_Function_uchar Function
+%1187 = OpVariable %_ptr_Function_uchar Function
+%1188 = OpVariable %_ptr_Function_uchar Function
+%1189 = OpVariable %_ptr_Function_uchar Function
+%1190 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1191 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1192 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1193 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1194 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1195 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1196 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1197 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1198 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1199 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1200 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1201 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1202 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1203 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1204 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1205 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1206 = OpVariable %_ptr_Function_uchar Function
+%1207 = OpVariable %_ptr_Function_uchar Function
+%1208 = OpVariable %_ptr_Function_uchar Function
+%1209 = OpVariable %_ptr_Function_uchar Function
+%1210 = OpVariable %_ptr_Function_uchar Function
+%1211 = OpVariable %_ptr_Function_uchar Function
+%1212 = OpVariable %_ptr_Function_uchar Function
+%1213 = OpVariable %_ptr_Function_uchar Function
+%1214 = OpVariable %_ptr_Function_uchar Function
+%1215 = OpVariable %_ptr_Function_uchar Function
+%1216 = OpVariable %_ptr_Function_uchar Function
+%1217 = OpVariable %_ptr_Function_uchar Function
+%1218 = OpVariable %_ptr_Function_uchar Function
+%1219 = OpVariable %_ptr_Function_uchar Function
+%1220 = OpVariable %_ptr_Function_uchar Function
+%1221 = OpVariable %_ptr_Function_uchar Function
+%1222 = OpVariable %_ptr_Function_uchar Function
+%1223 = OpVariable %_ptr_Function_uchar Function
+%1224 = OpVariable %_ptr_Function_uchar Function
+%1225 = OpVariable %_ptr_Function_uchar Function
+%1226 = OpVariable %_ptr_Function_uchar Function
+%1227 = OpVariable %_ptr_Function_uchar Function
+%1228 = OpVariable %_ptr_Function_uchar Function
+%1229 = OpVariable %_ptr_Function_uchar Function
+%1230 = OpVariable %_ptr_Function_uchar Function
+%1231 = OpVariable %_ptr_Function_uchar Function
+%1232 = OpVariable %_ptr_Function_uchar Function
+%1233 = OpVariable %_ptr_Function_uchar Function
+%1234 = OpVariable %_ptr_Function_uchar Function
+%1235 = OpVariable %_ptr_Function_uchar Function
+%1236 = OpVariable %_ptr_Function_uchar Function
+%1237 = OpVariable %_ptr_Function_uchar Function
+%1238 = OpVariable %_ptr_Function_uchar Function
+%1239 = OpVariable %_ptr_Function_uchar Function
+%1240 = OpVariable %_ptr_Function_uchar Function
+%1241 = OpVariable %_ptr_Function_uchar Function
+%1242 = OpVariable %_ptr_Function_uchar Function
+%1243 = OpVariable %_ptr_Function_uchar Function
+%1244 = OpVariable %_ptr_Function_uchar Function
+%1245 = OpVariable %_ptr_Function_uchar Function
+%1246 = OpVariable %_ptr_Function_uchar Function
+%1247 = OpVariable %_ptr_Function_uchar Function
+%1248 = OpVariable %_ptr_Function_uchar Function
+%1249 = OpVariable %_ptr_Function_uchar Function
+%1250 = OpVariable %_ptr_Function_uchar Function
+%1251 = OpVariable %_ptr_Function_uchar Function
+%1252 = OpVariable %_ptr_Function_uchar Function
+%1253 = OpVariable %_ptr_Function_uchar Function
+%1254 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1255 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1256 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1257 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1258 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1259 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1260 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1261 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+OpStore %907 %882
+OpBranch %884
+%884 = OpLabel
+OpBranch %885
+%885 = OpLabel
+%1270 = OpLoad %ulong %907
+%1271 = OpUConvert %uint %1270
+OpStore %908 %1271
+%1272 = OpLoad %ulong %907
+%1273 = OpConvertUToF %float %1272
+OpStore %909 %1273
+%1274 = OpLoad %ulong %907
+%1275 = OpConvertUToF %double %1274
+OpStore %910 %1275
+%1276 = OpLoad %ulong %907
+%1277 = OpUConvert %uchar %1276
+OpStore %911 %1277
+%1278 = OpCompositeConstruct %v4uint %uint_286331153 %uint_572662306 %uint_858993459 %uint_1145324612
+OpStore %912 %1278
+%1283 = OpLoad %v4uint %912
+%1284 = OpCompositeExtract %uint %1283 0
+OpStore %913 %1284
+%1285 = OpLoad %uint %913
+%1286 = OpLoad %uint %908
+%1287 = OpIAdd %uint %1285 %1286
+OpStore %914 %1287
+%1288 = OpLoad %v4uint %912
+%1289 = OpLoad %uint %914
+%1290 = OpCompositeInsert %v4uint %1289 %1288 0
+OpStore %915 %1290
+%1291 = OpLoad %v4uint %915
+%1292 = OpCompositeExtract %uint %1291 3
+OpStore %916 %1292
+%1293 = OpLoad %uint %916
+%1294 = OpLoad %uint %908
+%1295 = OpIAdd %uint %1293 %1294
+OpStore %917 %1295
+%1296 = OpLoad %v4uint %915
+%1297 = OpLoad %uint %917
+%1298 = OpCompositeInsert %v4uint %1297 %1296 3
+OpStore %918 %1298
+%1300 = OpLoad %v4uint %918
+%1301 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %1300
+OpStore %919 %1301
+OpStore %898 %1302
+%1303 = OpLoad %v4uint %918
+%1304 = OpCompositeExtract %uint %1303 3
+OpStore %920 %1304
+%1305 = OpLoad %v4uint %898
+OpStore %921 %1305
+%1306 = OpLoad %v4uint %921
+%1307 = OpLoad %uint %920
+%1308 = OpCompositeInsert %v4uint %1307 %1306 0
+OpStore %922 %1308
+%1309 = OpLoad %v4uint %922
+OpStore %898 %1309
+%1310 = OpLoad %v4uint %918
+%1311 = OpCompositeExtract %uint %1310 2
+OpStore %923 %1311
+%1312 = OpLoad %v4uint %898
+OpStore %924 %1312
+%1313 = OpLoad %v4uint %924
+%1314 = OpLoad %uint %923
+%1315 = OpCompositeInsert %v4uint %1314 %1313 1
+OpStore %925 %1315
+%1316 = OpLoad %v4uint %925
+OpStore %898 %1316
+%1317 = OpLoad %v4uint %918
+%1318 = OpCompositeExtract %uint %1317 1
+OpStore %926 %1318
+%1319 = OpLoad %v4uint %898
+OpStore %927 %1319
+%1320 = OpLoad %v4uint %927
+%1321 = OpLoad %uint %926
+%1322 = OpCompositeInsert %v4uint %1321 %1320 2
+OpStore %928 %1322
+%1323 = OpLoad %v4uint %928
+OpStore %898 %1323
+%1324 = OpLoad %v4uint %918
+%1325 = OpCompositeExtract %uint %1324 0
+OpStore %929 %1325
+%1326 = OpLoad %v4uint %898
+OpStore %930 %1326
+%1327 = OpLoad %v4uint %930
+%1328 = OpLoad %uint %929
+%1329 = OpCompositeInsert %v4uint %1328 %1327 3
+OpStore %931 %1329
+%1330 = OpLoad %v4uint %931
+OpStore %898 %1330
+%1331 = OpLoad %v4uint %898
+OpStore %932 %1331
+%1332 = OpLoad %ulong %919
+%1333 = OpLoad %v4uint %932
+%1334 = OpFunctionCall %ulong %1 %1332 %1333
+OpStore %933 %1334
+OpStore %899 %1302
+%1335 = OpLoad %v4uint %899
+OpStore %934 %1335
+%1336 = OpLoad %v4uint %934
+%1337 = OpLoad %uint %926
+%1338 = OpCompositeInsert %v4uint %1337 %1336 0
+OpStore %935 %1338
+%1339 = OpLoad %v4uint %935
+OpStore %899 %1339
+%1340 = OpLoad %v4uint %899
+OpStore %936 %1340
+%1341 = OpLoad %v4uint %936
+%1342 = OpLoad %uint %923
+%1343 = OpCompositeInsert %v4uint %1342 %1341 1
+OpStore %937 %1343
+%1344 = OpLoad %v4uint %937
+OpStore %899 %1344
+%1345 = OpLoad %v4uint %899
+OpStore %938 %1345
+%1346 = OpLoad %v4uint %938
+%1347 = OpLoad %uint %920
+%1348 = OpCompositeInsert %v4uint %1347 %1346 2
+OpStore %939 %1348
+%1349 = OpLoad %v4uint %939
+OpStore %899 %1349
+%1350 = OpLoad %v4uint %899
+OpStore %940 %1350
+%1351 = OpLoad %v4uint %940
+%1352 = OpLoad %uint %929
+%1353 = OpCompositeInsert %v4uint %1352 %1351 3
+OpStore %941 %1353
+%1354 = OpLoad %v4uint %941
+OpStore %899 %1354
+%1355 = OpLoad %v4uint %899
+OpStore %942 %1355
+%1356 = OpLoad %ulong %933
+%1357 = OpLoad %v4uint %942
+%1358 = OpFunctionCall %ulong %1 %1356 %1357
+OpStore %943 %1358
+OpStore %900 %1302
+%1359 = OpLoad %v4uint %900
+OpStore %944 %1359
+%1360 = OpLoad %v4uint %944
+%1361 = OpLoad %uint %923
+%1362 = OpCompositeInsert %v4uint %1361 %1360 0
+OpStore %945 %1362
+%1363 = OpLoad %v4uint %945
+OpStore %900 %1363
+%1364 = OpLoad %v4uint %900
+OpStore %946 %1364
+%1365 = OpLoad %v4uint %946
+%1366 = OpLoad %uint %920
+%1367 = OpCompositeInsert %v4uint %1366 %1365 1
+OpStore %947 %1367
+%1368 = OpLoad %v4uint %947
+OpStore %900 %1368
+%1369 = OpLoad %v4uint %900
+OpStore %948 %1369
+%1370 = OpLoad %v4uint %948
+%1371 = OpLoad %uint %929
+%1372 = OpCompositeInsert %v4uint %1371 %1370 2
+OpStore %949 %1372
+%1373 = OpLoad %v4uint %949
+OpStore %900 %1373
+%1374 = OpLoad %v4uint %900
+OpStore %950 %1374
+%1375 = OpLoad %v4uint %950
+%1376 = OpLoad %uint %926
+%1377 = OpCompositeInsert %v4uint %1376 %1375 3
+OpStore %951 %1377
+%1378 = OpLoad %v4uint %951
+OpStore %900 %1378
+%1379 = OpLoad %v4uint %900
+OpStore %952 %1379
+%1380 = OpLoad %ulong %943
+%1381 = OpLoad %v4uint %952
+%1382 = OpFunctionCall %ulong %1 %1380 %1381
+OpStore %953 %1382
+OpStore %901 %1302
+%1383 = OpLoad %v4uint %901
+OpStore %954 %1383
+%1384 = OpLoad %v4uint %954
+%1385 = OpLoad %uint %923
+%1386 = OpCompositeInsert %v4uint %1385 %1384 0
+OpStore %955 %1386
+%1387 = OpLoad %v4uint %955
+OpStore %901 %1387
+%1388 = OpLoad %v4uint %901
+OpStore %956 %1388
+%1389 = OpLoad %v4uint %956
+%1390 = OpLoad %uint %923
+%1391 = OpCompositeInsert %v4uint %1390 %1389 1
+OpStore %957 %1391
+%1392 = OpLoad %v4uint %957
+OpStore %901 %1392
+%1393 = OpLoad %v4uint %901
+OpStore %958 %1393
+%1394 = OpLoad %v4uint %958
+%1395 = OpLoad %uint %923
+%1396 = OpCompositeInsert %v4uint %1395 %1394 2
+OpStore %959 %1396
+%1397 = OpLoad %v4uint %959
+OpStore %901 %1397
+%1398 = OpLoad %v4uint %901
+OpStore %960 %1398
+%1399 = OpLoad %v4uint %960
+%1400 = OpLoad %uint %923
+%1401 = OpCompositeInsert %v4uint %1400 %1399 3
+OpStore %961 %1401
+%1402 = OpLoad %v4uint %961
+OpStore %901 %1402
+%1403 = OpLoad %v4uint %901
+OpStore %962 %1403
+%1404 = OpLoad %ulong %953
+%1405 = OpLoad %v4uint %962
+%1406 = OpFunctionCall %ulong %1 %1404 %1405
+OpStore %963 %1406
+OpStore %902 %1302
+%1407 = OpLoad %v4uint %902
+OpStore %964 %1407
+%1408 = OpLoad %v4uint %964
+%1409 = OpLoad %uint %929
+%1410 = OpCompositeInsert %v4uint %1409 %1408 1
+OpStore %965 %1410
+%1411 = OpLoad %v4uint %965
+OpStore %902 %1411
+%1412 = OpLoad %v4uint %902
+OpStore %966 %1412
+%1413 = OpLoad %ulong %963
+%1414 = OpLoad %v4uint %966
+%1415 = OpFunctionCall %ulong %1 %1413 %1414
+OpStore %967 %1415
+%1416 = OpLoad %v4uint %918
+%1417 = OpLoad %uint %929
+%1418 = OpCompositeInsert %v4uint %1417 %1416 1
+OpStore %968 %1418
+%1419 = OpLoad %v4uint %968
+%1420 = OpLoad %uint %920
+%1421 = OpCompositeInsert %v4uint %1420 %1419 1
+OpStore %969 %1421
+%1422 = OpLoad %ulong %967
+%1423 = OpLoad %v4uint %969
+%1424 = OpFunctionCall %ulong %1 %1422 %1423
+OpStore %970 %1424
+%1425 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+OpStore %971 %1425
+%1427 = OpLoad %uint %929
+%1429 = OpIAdd %uint %1427 %uint_1
+OpStore %972 %1429
+%1430 = OpLoad %v4uint %971
+%1431 = OpLoad %uint %972
+%1432 = OpCompositeInsert %v4uint %1431 %1430 0
+OpStore %973 %1432
+%1433 = OpLoad %v4uint %973
+%1434 = OpCompositeExtract %uint %1433 0
+OpStore %974 %1434
+OpBranch %886
+%886 = OpLabel
+%1435 = OpLoad %uint %974
+%1436 = OpUConvert %ulong %1435
+OpStore %1128 %1436
+%1437 = OpLoad %ulong %970
+%1438 = OpLoad %ulong %1128
+%1439 = OpFunctionCall %ulong %6 %1437 %1438
+OpStore %1129 %1439
+OpBranch %887
+%887 = OpLabel
+%1440 = OpLoad %v4uint %973
+%1441 = OpCompositeExtract %uint %1440 0
+OpStore %975 %1441
+%1442 = OpLoad %v4uint %918
+%1443 = OpCompositeExtract %uint %1442 1
+OpStore %976 %1443
+%1444 = OpLoad %uint %975
+%1445 = OpLoad %uint %976
+%1446 = OpIAdd %uint %1444 %1445
+OpStore %977 %1446
+%1447 = OpLoad %v4uint %973
+%1448 = OpLoad %uint %977
+%1449 = OpCompositeInsert %v4uint %1448 %1447 1
+OpStore %978 %1449
+%1450 = OpLoad %v4uint %978
+%1451 = OpCompositeExtract %uint %1450 1
+OpStore %979 %1451
+OpBranch %888
+%888 = OpLabel
+%1452 = OpLoad %uint %979
+%1453 = OpUConvert %ulong %1452
+OpStore %1130 %1453
+%1454 = OpLoad %ulong %1129
+%1455 = OpLoad %ulong %1130
+%1456 = OpFunctionCall %ulong %6 %1454 %1455
+OpStore %1131 %1456
+OpBranch %889
+%889 = OpLabel
+%1457 = OpLoad %v4uint %978
+%1458 = OpCompositeExtract %uint %1457 1
+OpStore %980 %1458
+%1459 = OpLoad %v4uint %918
+%1460 = OpCompositeExtract %uint %1459 2
+OpStore %981 %1460
+%1461 = OpLoad %uint %980
+%1462 = OpLoad %uint %981
+%1463 = OpBitwiseXor %uint %1461 %1462
+OpStore %982 %1463
+%1464 = OpLoad %v4uint %978
+%1465 = OpLoad %uint %982
+%1466 = OpCompositeInsert %v4uint %1465 %1464 2
+OpStore %983 %1466
+%1467 = OpLoad %v4uint %983
+%1468 = OpCompositeExtract %uint %1467 2
+OpStore %984 %1468
+OpBranch %890
+%890 = OpLabel
+%1469 = OpLoad %uint %984
+%1470 = OpUConvert %ulong %1469
+OpStore %1132 %1470
+%1471 = OpLoad %ulong %1131
+%1472 = OpLoad %ulong %1132
+%1473 = OpFunctionCall %ulong %6 %1471 %1472
+OpStore %1133 %1473
+OpBranch %891
+%891 = OpLabel
+%1474 = OpLoad %v4uint %983
+%1475 = OpCompositeExtract %uint %1474 2
+OpStore %985 %1475
+%1476 = OpLoad %v4uint %918
+%1477 = OpCompositeExtract %uint %1476 3
+OpStore %986 %1477
+%1478 = OpLoad %uint %985
+%1479 = OpLoad %uint %986
+%1480 = OpISub %uint %1478 %1479
+OpStore %987 %1480
+%1481 = OpLoad %v4uint %983
+%1482 = OpLoad %uint %987
+%1483 = OpCompositeInsert %v4uint %1482 %1481 3
+OpStore %988 %1483
+%1484 = OpLoad %v4uint %988
+%1485 = OpCompositeExtract %uint %1484 3
+OpStore %989 %1485
+OpBranch %892
+%892 = OpLabel
+%1486 = OpLoad %uint %989
+%1487 = OpUConvert %ulong %1486
+OpStore %1134 %1487
+%1488 = OpLoad %ulong %1133
+%1489 = OpLoad %ulong %1134
+%1490 = OpFunctionCall %ulong %6 %1488 %1489
+OpStore %1135 %1490
+OpBranch %893
+%893 = OpLabel
+%1491 = OpLoad %ulong %1135
+%1492 = OpLoad %v4uint %988
+%1493 = OpFunctionCall %ulong %1 %1491 %1492
+OpStore %990 %1493
+%1494 = OpLoad %v4uint %898
+OpStore %991 %1494
+%1495 = OpLoad %v4uint %991
+%1496 = OpLoad %v4uint %918
+%1497 = OpIAdd %v4uint %1495 %1496
+OpStore %992 %1497
+%1498 = OpLoad %ulong %990
+%1499 = OpLoad %v4uint %992
+%1500 = OpFunctionCall %ulong %1 %1498 %1499
+OpStore %993 %1500
+%1501 = OpLoad %v4uint %899
+OpStore %994 %1501
+%1502 = OpLoad %v4uint %994
+%1503 = OpLoad %v4uint %918
+%1504 = OpISub %v4uint %1502 %1503
+OpStore %995 %1504
+%1505 = OpLoad %ulong %993
+%1506 = OpLoad %v4uint %995
+%1507 = OpFunctionCall %ulong %1 %1505 %1506
+OpStore %996 %1507
+%1508 = OpLoad %v4uint %900
+OpStore %997 %1508
+%1509 = OpLoad %v4uint %997
+%1510 = OpLoad %v4uint %918
+%1511 = OpIMul %v4uint %1509 %1510
+OpStore %998 %1511
+%1512 = OpLoad %ulong %996
+%1513 = OpLoad %v4uint %998
+%1514 = OpFunctionCall %ulong %1 %1512 %1513
+OpStore %999 %1514
+%1515 = OpLoad %v4uint %898
+OpStore %1000 %1515
+%1516 = OpLoad %v4uint %899
+OpStore %1001 %1516
+%1517 = OpLoad %v4uint %1000
+%1518 = OpLoad %v4uint %1001
+%1519 = OpBitwiseXor %v4uint %1517 %1518
+OpStore %1002 %1519
+%1520 = OpLoad %ulong %999
+%1521 = OpLoad %v4uint %1002
+%1522 = OpFunctionCall %ulong %1 %1520 %1521
+OpStore %1003 %1522
+%1524 = OpFNegate %float %float_2_25
+OpStore %1004 %1524
+%1526 = OpFNegate %float %float_0_5
+OpStore %1005 %1526
+%1529 = OpLoad %float %1004
+%1531 = OpLoad %float %1005
+%1527 = OpCompositeConstruct %v4float %float_1_5 %1529 %float_3_75 %1531
+OpStore %1006 %1527
+%1532 = OpLoad %v4float %1006
+%1533 = OpCompositeExtract %float %1532 1
+OpStore %1007 %1533
+%1534 = OpLoad %float %1007
+%1535 = OpLoad %float %909
+%1536 = OpFAdd %float %1534 %1535
+OpStore %1008 %1536
+%1537 = OpLoad %v4float %1006
+%1538 = OpLoad %float %1008
+%1539 = OpCompositeInsert %v4float %1538 %1537 1
+OpStore %1009 %1539
+%1540 = OpLoad %ulong %1003
+%1541 = OpLoad %v4float %1009
+%1542 = OpFunctionCall %ulong %2 %1540 %1541
+OpStore %1010 %1542
+OpStore %903 %1543
+%1544 = OpLoad %v4float %1009
+%1545 = OpCompositeExtract %float %1544 3
+OpStore %1011 %1545
+%1546 = OpLoad %v4float %903
+OpStore %1012 %1546
+%1547 = OpLoad %v4float %1012
+%1548 = OpLoad %float %1011
+%1549 = OpCompositeInsert %v4float %1548 %1547 0
+OpStore %1013 %1549
+%1550 = OpLoad %v4float %1013
+OpStore %903 %1550
+%1551 = OpLoad %v4float %1009
+%1552 = OpCompositeExtract %float %1551 2
+OpStore %1014 %1552
+%1553 = OpLoad %v4float %903
+OpStore %1015 %1553
+%1554 = OpLoad %v4float %1015
+%1555 = OpLoad %float %1014
+%1556 = OpCompositeInsert %v4float %1555 %1554 1
+OpStore %1016 %1556
+%1557 = OpLoad %v4float %1016
+OpStore %903 %1557
+%1558 = OpLoad %v4float %1009
+%1559 = OpCompositeExtract %float %1558 1
+OpStore %1017 %1559
+%1560 = OpLoad %v4float %903
+OpStore %1018 %1560
+%1561 = OpLoad %v4float %1018
+%1562 = OpLoad %float %1017
+%1563 = OpCompositeInsert %v4float %1562 %1561 2
+OpStore %1019 %1563
+%1564 = OpLoad %v4float %1019
+OpStore %903 %1564
+%1565 = OpLoad %v4float %1009
+%1566 = OpCompositeExtract %float %1565 0
+OpStore %1020 %1566
+%1567 = OpLoad %v4float %903
+OpStore %1021 %1567
+%1568 = OpLoad %v4float %1021
+%1569 = OpLoad %float %1020
+%1570 = OpCompositeInsert %v4float %1569 %1568 3
+OpStore %1022 %1570
+%1571 = OpLoad %v4float %1022
+OpStore %903 %1571
+%1572 = OpLoad %v4float %903
+OpStore %1023 %1572
+%1573 = OpLoad %ulong %1010
+%1574 = OpLoad %v4float %1023
+%1575 = OpFunctionCall %ulong %2 %1573 %1574
+OpStore %1024 %1575
+OpStore %904 %1543
+%1576 = OpLoad %v4float %904
+OpStore %1025 %1576
+%1577 = OpLoad %v4float %1025
+%1578 = OpLoad %float %1020
+%1579 = OpCompositeInsert %v4float %1578 %1577 0
+OpStore %1026 %1579
+%1580 = OpLoad %v4float %1026
+OpStore %904 %1580
+%1581 = OpLoad %v4float %903
+OpStore %1027 %1581
+%1582 = OpLoad %v4float %1027
+%1583 = OpCompositeExtract %float %1582 1
+OpStore %1028 %1583
+%1584 = OpLoad %v4float %904
+OpStore %1029 %1584
+%1585 = OpLoad %v4float %1029
+%1586 = OpLoad %float %1028
+%1587 = OpCompositeInsert %v4float %1586 %1585 1
+OpStore %1030 %1587
+%1588 = OpLoad %v4float %1030
+OpStore %904 %1588
+%1589 = OpLoad %v4float %904
+OpStore %1031 %1589
+%1590 = OpLoad %v4float %1031
+%1591 = OpLoad %float %1014
+%1592 = OpCompositeInsert %v4float %1591 %1590 2
+OpStore %1032 %1592
+%1593 = OpLoad %v4float %1032
+OpStore %904 %1593
+%1594 = OpLoad %v4float %903
+OpStore %1033 %1594
+%1595 = OpLoad %v4float %1033
+%1596 = OpCompositeExtract %float %1595 3
+OpStore %1034 %1596
+%1597 = OpLoad %v4float %904
+OpStore %1035 %1597
+%1598 = OpLoad %v4float %1035
+%1599 = OpLoad %float %1034
+%1600 = OpCompositeInsert %v4float %1599 %1598 3
+OpStore %1036 %1600
+%1601 = OpLoad %v4float %1036
+OpStore %904 %1601
+%1602 = OpLoad %v4float %904
+OpStore %1037 %1602
+%1603 = OpLoad %ulong %1024
+%1604 = OpLoad %v4float %1037
+%1605 = OpFunctionCall %ulong %2 %1603 %1604
+OpStore %1038 %1605
+%1606 = OpLoad %v4float %904
+OpStore %1039 %1606
+%1607 = OpLoad %v4float %903
+OpStore %1040 %1607
+%1608 = OpLoad %v4float %1039
+%1609 = OpLoad %v4float %1040
+%1610 = OpFMul %v4float %1608 %1609
+OpStore %1041 %1610
+%1611 = OpLoad %ulong %1038
+%1612 = OpLoad %v4float %1041
+%1613 = OpFunctionCall %ulong %2 %1611 %1612
+OpStore %1042 %1613
+%1614 = OpLoad %v4float %903
+OpStore %1043 %1614
+%1615 = OpLoad %v4float %1043
+%1616 = OpCompositeExtract %float %1615 0
+OpStore %1044 %1616
+%1617 = OpLoad %float %1020
+%1618 = OpLoad %float %1044
+%1619 = OpFSub %float %1617 %1618
+OpStore %1045 %1619
+OpBranch %894
+%894 = OpLabel
+%1620 = OpLoad %float %1045
+%1621 = OpBitcast %uint %1620
+OpStore %1136 %1621
+%1622 = OpLoad %uint %1136
+%1623 = OpUConvert %ulong %1622
+OpStore %1137 %1623
+%1624 = OpLoad %ulong %1042
+%1625 = OpLoad %ulong %1137
+%1626 = OpFunctionCall %ulong %6 %1624 %1625
+OpStore %1138 %1626
+OpBranch %895
+%895 = OpLabel
+%1627 = OpLoad %v4float %1009
+%1628 = OpCompositeExtract %float %1627 3
+OpStore %1046 %1628
+%1629 = OpLoad %v4float %903
+OpStore %1047 %1629
+%1630 = OpLoad %v4float %1047
+%1631 = OpCompositeExtract %float %1630 3
+OpStore %1048 %1631
+%1632 = OpLoad %float %1046
+%1633 = OpLoad %float %1048
+%1634 = OpFSub %float %1632 %1633
+OpStore %1049 %1634
+OpBranch %896
+%896 = OpLabel
+%1635 = OpLoad %float %1049
+%1636 = OpBitcast %uint %1635
+OpStore %1139 %1636
+%1637 = OpLoad %uint %1139
+%1638 = OpUConvert %ulong %1637
+OpStore %1140 %1638
+%1639 = OpLoad %ulong %1138
+%1640 = OpLoad %ulong %1140
+%1641 = OpFunctionCall %ulong %6 %1639 %1640
+OpStore %1141 %1641
+OpBranch %897
+%897 = OpLabel
+%1642 = OpCompositeConstruct %v2double %double_1_5 %double_n2_25
+OpStore %1050 %1642
+%1645 = OpLoad %v2double %1050
+%1646 = OpCompositeExtract %double %1645 0
+OpStore %1051 %1646
+%1647 = OpLoad %double %1051
+%1648 = OpLoad %double %910
+%1649 = OpFAdd %double %1647 %1648
+OpStore %1052 %1649
+%1650 = OpLoad %v2double %1050
+%1651 = OpLoad %double %1052
+%1652 = OpCompositeInsert %v2double %1651 %1650 0
+OpStore %1053 %1652
+OpStore %905 %1653
+%1654 = OpLoad %v2double %1053
+%1655 = OpCompositeExtract %double %1654 1
+OpStore %1054 %1655
+%1656 = OpLoad %v2double %905
+OpStore %1055 %1656
+%1657 = OpLoad %v2double %1055
+%1658 = OpLoad %double %1054
+%1659 = OpCompositeInsert %v2double %1658 %1657 0
+OpStore %1056 %1659
+%1660 = OpLoad %v2double %1056
+OpStore %905 %1660
+%1661 = OpLoad %v2double %1053
+%1662 = OpCompositeExtract %double %1661 0
+OpStore %1057 %1662
+%1663 = OpLoad %v2double %905
+OpStore %1058 %1663
+%1664 = OpLoad %v2double %1058
+%1665 = OpLoad %double %1057
+%1666 = OpCompositeInsert %v2double %1665 %1664 1
+OpStore %1059 %1666
+%1667 = OpLoad %v2double %1059
+OpStore %905 %1667
+%1668 = OpLoad %ulong %1141
+%1669 = OpLoad %v2double %1053
+%1670 = OpFunctionCall %ulong %3 %1668 %1669
+OpStore %1060 %1670
+%1671 = OpLoad %v2double %905
+OpStore %1061 %1671
+%1672 = OpLoad %ulong %1060
+%1673 = OpLoad %v2double %1061
+%1674 = OpFunctionCall %ulong %3 %1672 %1673
+OpStore %1062 %1674
+%1675 = OpLoad %v2double %905
+OpStore %1063 %1675
+%1676 = OpLoad %v2double %1063
+%1677 = OpLoad %v2double %1053
+%1678 = OpFSub %v2double %1676 %1677
+OpStore %1064 %1678
+%1679 = OpLoad %ulong %1062
+%1680 = OpLoad %v2double %1064
+%1681 = OpFunctionCall %ulong %3 %1679 %1680
+OpStore %1065 %1681
+%1682 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_247 %uchar_7 %uchar_251 %uchar_3 %uchar_255 %uchar_2 %uchar_252 %uchar_6 %uchar_248 %uchar_9 %uchar_253 %uchar_1 %uchar_254 %uchar_4 %uchar_250 %uchar_8
+OpStore %1066 %1682
+%1699 = OpLoad %_arr_uchar_uint_16 %1066
+%1700 = OpCompositeExtract %uchar %1699 0
+OpStore %1067 %1700
+%1701 = OpLoad %uchar %1067
+%1702 = OpLoad %uchar %911
+%1703 = OpIAdd %uchar %1701 %1702
+OpStore %1068 %1703
+%1704 = OpLoad %_arr_uchar_uint_16 %1066
+%1705 = OpLoad %uchar %1068
+%1706 = OpCompositeInsert %_arr_uchar_uint_16 %1705 %1704 0
+OpStore %1069 %1706
+%1707 = OpLoad %_arr_uchar_uint_16 %1069
+%1708 = OpCompositeExtract %uchar %1707 15
+OpStore %1070 %1708
+%1709 = OpLoad %uchar %1070
+%1710 = OpLoad %uchar %911
+%1711 = OpIAdd %uchar %1709 %1710
+OpStore %1071 %1711
+%1712 = OpLoad %_arr_uchar_uint_16 %1069
+%1713 = OpLoad %uchar %1071
+%1714 = OpCompositeInsert %_arr_uchar_uint_16 %1713 %1712 15
+OpStore %1072 %1714
+%1715 = OpLoad %ulong %1065
+%1716 = OpLoad %_arr_uchar_uint_16 %1072
+%1717 = OpFunctionCall %ulong %4 %1715 %1716
+OpStore %1073 %1717
+OpStore %906 %1718
+%1719 = OpLoad %_arr_uchar_uint_16 %1072
+%1720 = OpCompositeExtract %uchar %1719 15
+OpStore %1074 %1720
+%1721 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1075 %1721
+%1722 = OpLoad %_arr_uchar_uint_16 %1075
+%1723 = OpLoad %uchar %1074
+%1724 = OpCompositeInsert %_arr_uchar_uint_16 %1723 %1722 0
+OpStore %1076 %1724
+%1725 = OpLoad %_arr_uchar_uint_16 %1076
+OpStore %906 %1725
+%1726 = OpLoad %_arr_uchar_uint_16 %1072
+%1727 = OpCompositeExtract %uchar %1726 14
+OpStore %1077 %1727
+%1728 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1078 %1728
+%1729 = OpLoad %_arr_uchar_uint_16 %1078
+%1730 = OpLoad %uchar %1077
+%1731 = OpCompositeInsert %_arr_uchar_uint_16 %1730 %1729 1
+OpStore %1079 %1731
+%1732 = OpLoad %_arr_uchar_uint_16 %1079
+OpStore %906 %1732
+%1733 = OpLoad %_arr_uchar_uint_16 %1072
+%1734 = OpCompositeExtract %uchar %1733 13
+OpStore %1080 %1734
+%1735 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1081 %1735
+%1736 = OpLoad %_arr_uchar_uint_16 %1081
+%1737 = OpLoad %uchar %1080
+%1738 = OpCompositeInsert %_arr_uchar_uint_16 %1737 %1736 2
+OpStore %1082 %1738
+%1739 = OpLoad %_arr_uchar_uint_16 %1082
+OpStore %906 %1739
+%1740 = OpLoad %_arr_uchar_uint_16 %1072
+%1741 = OpCompositeExtract %uchar %1740 12
+OpStore %1083 %1741
+%1742 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1084 %1742
+%1743 = OpLoad %_arr_uchar_uint_16 %1084
+%1744 = OpLoad %uchar %1083
+%1745 = OpCompositeInsert %_arr_uchar_uint_16 %1744 %1743 3
+OpStore %1085 %1745
+%1746 = OpLoad %_arr_uchar_uint_16 %1085
+OpStore %906 %1746
+%1747 = OpLoad %_arr_uchar_uint_16 %1072
+%1748 = OpCompositeExtract %uchar %1747 11
+OpStore %1086 %1748
+%1749 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1087 %1749
+%1750 = OpLoad %_arr_uchar_uint_16 %1087
+%1751 = OpLoad %uchar %1086
+%1752 = OpCompositeInsert %_arr_uchar_uint_16 %1751 %1750 4
+OpStore %1088 %1752
+%1753 = OpLoad %_arr_uchar_uint_16 %1088
+OpStore %906 %1753
+%1754 = OpLoad %_arr_uchar_uint_16 %1072
+%1755 = OpCompositeExtract %uchar %1754 10
+OpStore %1089 %1755
+%1756 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1090 %1756
+%1757 = OpLoad %_arr_uchar_uint_16 %1090
+%1758 = OpLoad %uchar %1089
+%1759 = OpCompositeInsert %_arr_uchar_uint_16 %1758 %1757 5
+OpStore %1091 %1759
+%1760 = OpLoad %_arr_uchar_uint_16 %1091
+OpStore %906 %1760
+%1761 = OpLoad %_arr_uchar_uint_16 %1072
+%1762 = OpCompositeExtract %uchar %1761 9
+OpStore %1092 %1762
+%1763 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1093 %1763
+%1764 = OpLoad %_arr_uchar_uint_16 %1093
+%1765 = OpLoad %uchar %1092
+%1766 = OpCompositeInsert %_arr_uchar_uint_16 %1765 %1764 6
+OpStore %1094 %1766
+%1767 = OpLoad %_arr_uchar_uint_16 %1094
+OpStore %906 %1767
+%1768 = OpLoad %_arr_uchar_uint_16 %1072
+%1769 = OpCompositeExtract %uchar %1768 8
+OpStore %1095 %1769
+%1770 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1096 %1770
+%1771 = OpLoad %_arr_uchar_uint_16 %1096
+%1772 = OpLoad %uchar %1095
+%1773 = OpCompositeInsert %_arr_uchar_uint_16 %1772 %1771 7
+OpStore %1097 %1773
+%1774 = OpLoad %_arr_uchar_uint_16 %1097
+OpStore %906 %1774
+%1775 = OpLoad %_arr_uchar_uint_16 %1072
+%1776 = OpCompositeExtract %uchar %1775 7
+OpStore %1098 %1776
+%1777 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1099 %1777
+%1778 = OpLoad %_arr_uchar_uint_16 %1099
+%1779 = OpLoad %uchar %1098
+%1780 = OpCompositeInsert %_arr_uchar_uint_16 %1779 %1778 8
+OpStore %1100 %1780
+%1781 = OpLoad %_arr_uchar_uint_16 %1100
+OpStore %906 %1781
+%1782 = OpLoad %_arr_uchar_uint_16 %1072
+%1783 = OpCompositeExtract %uchar %1782 6
+OpStore %1101 %1783
+%1784 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1102 %1784
+%1785 = OpLoad %_arr_uchar_uint_16 %1102
+%1786 = OpLoad %uchar %1101
+%1787 = OpCompositeInsert %_arr_uchar_uint_16 %1786 %1785 9
+OpStore %1103 %1787
+%1788 = OpLoad %_arr_uchar_uint_16 %1103
+OpStore %906 %1788
+%1789 = OpLoad %_arr_uchar_uint_16 %1072
+%1790 = OpCompositeExtract %uchar %1789 5
+OpStore %1104 %1790
+%1791 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1105 %1791
+%1792 = OpLoad %_arr_uchar_uint_16 %1105
+%1793 = OpLoad %uchar %1104
 %1794 = OpCompositeInsert %_arr_uchar_uint_16 %1793 %1792 10
-OpStore %710 %1794
-%1795 = OpLoad %_arr_uchar_uint_16 %710
-%1796 = OpLoad %uchar %687
-%1797 = OpCompositeInsert %_arr_uchar_uint_16 %1796 %1795 11
-OpStore %711 %1797
-%1798 = OpLoad %_arr_uchar_uint_16 %711
-%1799 = OpLoad %uchar %690
-%1800 = OpCompositeInsert %_arr_uchar_uint_16 %1799 %1798 12
-OpStore %712 %1800
-%1801 = OpLoad %_arr_uchar_uint_16 %712
-%1802 = OpLoad %uchar %693
-%1803 = OpCompositeInsert %_arr_uchar_uint_16 %1802 %1801 13
-OpStore %713 %1803
-%1804 = OpLoad %_arr_uchar_uint_16 %713
-%1805 = OpLoad %uchar %696
-%1806 = OpCompositeInsert %_arr_uchar_uint_16 %1805 %1804 14
-OpStore %714 %1806
-%1807 = OpLoad %_arr_uchar_uint_16 %714
-%1808 = OpLoad %uchar %699
-%1809 = OpCompositeInsert %_arr_uchar_uint_16 %1808 %1807 15
-OpStore %715 %1809
-%1810 = OpLoad %ulong %507
-%1811 = OpLoad %_arr_uchar_uint_16 %715
-%1812 = OpFunctionCall %ulong %4 %1810 %1811
-OpStore %509 %1812
-%1813 = OpLoad %_arr_uchar_uint_16 %289
-OpStore %510 %1813
-%1814 = OpLoad %_arr_uchar_uint_16 %510
-%1815 = OpCompositeExtract %uchar %1814 0
-OpStore %716 %1815
-%1816 = OpLoad %_arr_uchar_uint_16 %456
-%1817 = OpCompositeExtract %uchar %1816 0
-OpStore %717 %1817
-%1818 = OpLoad %uchar %716
-%1819 = OpLoad %uchar %717
-%1820 = OpBitwiseXor %uchar %1818 %1819
-OpStore %718 %1820
-%1821 = OpLoad %_arr_uchar_uint_16 %510
-%1822 = OpCompositeExtract %uchar %1821 1
-OpStore %719 %1822
-%1823 = OpLoad %_arr_uchar_uint_16 %456
-%1824 = OpCompositeExtract %uchar %1823 1
-OpStore %720 %1824
-%1825 = OpLoad %uchar %719
-%1826 = OpLoad %uchar %720
-%1827 = OpBitwiseXor %uchar %1825 %1826
-OpStore %721 %1827
-%1828 = OpLoad %_arr_uchar_uint_16 %510
-%1829 = OpCompositeExtract %uchar %1828 2
-OpStore %722 %1829
-%1830 = OpLoad %_arr_uchar_uint_16 %456
-%1831 = OpCompositeExtract %uchar %1830 2
-OpStore %723 %1831
-%1832 = OpLoad %uchar %722
-%1833 = OpLoad %uchar %723
-%1834 = OpBitwiseXor %uchar %1832 %1833
-OpStore %724 %1834
-%1835 = OpLoad %_arr_uchar_uint_16 %510
-%1836 = OpCompositeExtract %uchar %1835 3
-OpStore %725 %1836
-%1837 = OpLoad %_arr_uchar_uint_16 %456
-%1838 = OpCompositeExtract %uchar %1837 3
-OpStore %726 %1838
-%1839 = OpLoad %uchar %725
-%1840 = OpLoad %uchar %726
-%1841 = OpBitwiseXor %uchar %1839 %1840
-OpStore %727 %1841
-%1842 = OpLoad %_arr_uchar_uint_16 %510
-%1843 = OpCompositeExtract %uchar %1842 4
-OpStore %728 %1843
-%1844 = OpLoad %_arr_uchar_uint_16 %456
-%1845 = OpCompositeExtract %uchar %1844 4
-OpStore %729 %1845
-%1846 = OpLoad %uchar %728
-%1847 = OpLoad %uchar %729
-%1848 = OpBitwiseXor %uchar %1846 %1847
-OpStore %730 %1848
-%1849 = OpLoad %_arr_uchar_uint_16 %510
-%1850 = OpCompositeExtract %uchar %1849 5
-OpStore %731 %1850
-%1851 = OpLoad %_arr_uchar_uint_16 %456
-%1852 = OpCompositeExtract %uchar %1851 5
-OpStore %732 %1852
-%1853 = OpLoad %uchar %731
-%1854 = OpLoad %uchar %732
-%1855 = OpBitwiseXor %uchar %1853 %1854
-OpStore %733 %1855
-%1856 = OpLoad %_arr_uchar_uint_16 %510
-%1857 = OpCompositeExtract %uchar %1856 6
-OpStore %734 %1857
-%1858 = OpLoad %_arr_uchar_uint_16 %456
-%1859 = OpCompositeExtract %uchar %1858 6
-OpStore %735 %1859
-%1860 = OpLoad %uchar %734
-%1861 = OpLoad %uchar %735
-%1862 = OpBitwiseXor %uchar %1860 %1861
-OpStore %736 %1862
-%1863 = OpLoad %_arr_uchar_uint_16 %510
-%1864 = OpCompositeExtract %uchar %1863 7
-OpStore %737 %1864
-%1865 = OpLoad %_arr_uchar_uint_16 %456
-%1866 = OpCompositeExtract %uchar %1865 7
-OpStore %738 %1866
-%1867 = OpLoad %uchar %737
-%1868 = OpLoad %uchar %738
-%1869 = OpBitwiseXor %uchar %1867 %1868
-OpStore %739 %1869
-%1870 = OpLoad %_arr_uchar_uint_16 %510
-%1871 = OpCompositeExtract %uchar %1870 8
-OpStore %740 %1871
-%1872 = OpLoad %_arr_uchar_uint_16 %456
-%1873 = OpCompositeExtract %uchar %1872 8
-OpStore %741 %1873
-%1874 = OpLoad %uchar %740
-%1875 = OpLoad %uchar %741
-%1876 = OpBitwiseXor %uchar %1874 %1875
-OpStore %742 %1876
-%1877 = OpLoad %_arr_uchar_uint_16 %510
-%1878 = OpCompositeExtract %uchar %1877 9
-OpStore %743 %1878
-%1879 = OpLoad %_arr_uchar_uint_16 %456
-%1880 = OpCompositeExtract %uchar %1879 9
-OpStore %744 %1880
-%1881 = OpLoad %uchar %743
-%1882 = OpLoad %uchar %744
-%1883 = OpBitwiseXor %uchar %1881 %1882
-OpStore %745 %1883
-%1884 = OpLoad %_arr_uchar_uint_16 %510
-%1885 = OpCompositeExtract %uchar %1884 10
-OpStore %746 %1885
-%1886 = OpLoad %_arr_uchar_uint_16 %456
-%1887 = OpCompositeExtract %uchar %1886 10
-OpStore %747 %1887
-%1888 = OpLoad %uchar %746
-%1889 = OpLoad %uchar %747
-%1890 = OpBitwiseXor %uchar %1888 %1889
-OpStore %748 %1890
-%1891 = OpLoad %_arr_uchar_uint_16 %510
-%1892 = OpCompositeExtract %uchar %1891 11
-OpStore %749 %1892
-%1893 = OpLoad %_arr_uchar_uint_16 %456
-%1894 = OpCompositeExtract %uchar %1893 11
-OpStore %750 %1894
-%1895 = OpLoad %uchar %749
-%1896 = OpLoad %uchar %750
-%1897 = OpBitwiseXor %uchar %1895 %1896
-OpStore %751 %1897
-%1898 = OpLoad %_arr_uchar_uint_16 %510
-%1899 = OpCompositeExtract %uchar %1898 12
-OpStore %752 %1899
-%1900 = OpLoad %_arr_uchar_uint_16 %456
-%1901 = OpCompositeExtract %uchar %1900 12
-OpStore %753 %1901
-%1902 = OpLoad %uchar %752
-%1903 = OpLoad %uchar %753
-%1904 = OpBitwiseXor %uchar %1902 %1903
-OpStore %754 %1904
-%1905 = OpLoad %_arr_uchar_uint_16 %510
-%1906 = OpCompositeExtract %uchar %1905 13
-OpStore %755 %1906
-%1907 = OpLoad %_arr_uchar_uint_16 %456
-%1908 = OpCompositeExtract %uchar %1907 13
-OpStore %756 %1908
-%1909 = OpLoad %uchar %755
-%1910 = OpLoad %uchar %756
-%1911 = OpBitwiseXor %uchar %1909 %1910
-OpStore %757 %1911
-%1912 = OpLoad %_arr_uchar_uint_16 %510
-%1913 = OpCompositeExtract %uchar %1912 14
-OpStore %758 %1913
-%1914 = OpLoad %_arr_uchar_uint_16 %456
-%1915 = OpCompositeExtract %uchar %1914 14
-OpStore %759 %1915
-%1916 = OpLoad %uchar %758
-%1917 = OpLoad %uchar %759
-%1918 = OpBitwiseXor %uchar %1916 %1917
-OpStore %760 %1918
-%1919 = OpLoad %_arr_uchar_uint_16 %510
-%1920 = OpCompositeExtract %uchar %1919 15
-OpStore %761 %1920
-%1921 = OpLoad %_arr_uchar_uint_16 %456
-%1922 = OpCompositeExtract %uchar %1921 15
-OpStore %762 %1922
-%1923 = OpLoad %uchar %761
-%1924 = OpLoad %uchar %762
-%1925 = OpBitwiseXor %uchar %1923 %1924
-OpStore %763 %1925
-%1926 = OpLoad %_arr_uchar_uint_16 %510
-%1927 = OpLoad %uchar %718
-%1928 = OpCompositeInsert %_arr_uchar_uint_16 %1927 %1926 0
-OpStore %764 %1928
-%1929 = OpLoad %_arr_uchar_uint_16 %764
-%1930 = OpLoad %uchar %721
-%1931 = OpCompositeInsert %_arr_uchar_uint_16 %1930 %1929 1
-OpStore %765 %1931
-%1932 = OpLoad %_arr_uchar_uint_16 %765
-%1933 = OpLoad %uchar %724
-%1934 = OpCompositeInsert %_arr_uchar_uint_16 %1933 %1932 2
-OpStore %766 %1934
-%1935 = OpLoad %_arr_uchar_uint_16 %766
-%1936 = OpLoad %uchar %727
-%1937 = OpCompositeInsert %_arr_uchar_uint_16 %1936 %1935 3
-OpStore %767 %1937
-%1938 = OpLoad %_arr_uchar_uint_16 %767
-%1939 = OpLoad %uchar %730
-%1940 = OpCompositeInsert %_arr_uchar_uint_16 %1939 %1938 4
-OpStore %768 %1940
-%1941 = OpLoad %_arr_uchar_uint_16 %768
-%1942 = OpLoad %uchar %733
-%1943 = OpCompositeInsert %_arr_uchar_uint_16 %1942 %1941 5
-OpStore %769 %1943
-%1944 = OpLoad %_arr_uchar_uint_16 %769
-%1945 = OpLoad %uchar %736
-%1946 = OpCompositeInsert %_arr_uchar_uint_16 %1945 %1944 6
-OpStore %770 %1946
-%1947 = OpLoad %_arr_uchar_uint_16 %770
-%1948 = OpLoad %uchar %739
-%1949 = OpCompositeInsert %_arr_uchar_uint_16 %1948 %1947 7
-OpStore %771 %1949
-%1950 = OpLoad %_arr_uchar_uint_16 %771
-%1951 = OpLoad %uchar %742
-%1952 = OpCompositeInsert %_arr_uchar_uint_16 %1951 %1950 8
-OpStore %772 %1952
-%1953 = OpLoad %_arr_uchar_uint_16 %772
-%1954 = OpLoad %uchar %745
-%1955 = OpCompositeInsert %_arr_uchar_uint_16 %1954 %1953 9
-OpStore %773 %1955
-%1956 = OpLoad %_arr_uchar_uint_16 %773
-%1957 = OpLoad %uchar %748
-%1958 = OpCompositeInsert %_arr_uchar_uint_16 %1957 %1956 10
-OpStore %774 %1958
-%1959 = OpLoad %_arr_uchar_uint_16 %774
-%1960 = OpLoad %uchar %751
-%1961 = OpCompositeInsert %_arr_uchar_uint_16 %1960 %1959 11
-OpStore %775 %1961
-%1962 = OpLoad %_arr_uchar_uint_16 %775
-%1963 = OpLoad %uchar %754
-%1964 = OpCompositeInsert %_arr_uchar_uint_16 %1963 %1962 12
-OpStore %776 %1964
-%1965 = OpLoad %_arr_uchar_uint_16 %776
-%1966 = OpLoad %uchar %757
-%1967 = OpCompositeInsert %_arr_uchar_uint_16 %1966 %1965 13
-OpStore %777 %1967
-%1968 = OpLoad %_arr_uchar_uint_16 %777
-%1969 = OpLoad %uchar %760
-%1970 = OpCompositeInsert %_arr_uchar_uint_16 %1969 %1968 14
-OpStore %778 %1970
-%1971 = OpLoad %_arr_uchar_uint_16 %778
-%1972 = OpLoad %uchar %763
-%1973 = OpCompositeInsert %_arr_uchar_uint_16 %1972 %1971 15
-OpStore %779 %1973
-%1974 = OpLoad %ulong %509
-%1975 = OpLoad %_arr_uchar_uint_16 %779
-%1976 = OpFunctionCall %ulong %4 %1974 %1975
-OpStore %511 %1976
-%1977 = OpLoad %ulong %511
-OpReturnValue %1977
+OpStore %1106 %1794
+%1795 = OpLoad %_arr_uchar_uint_16 %1106
+OpStore %906 %1795
+%1796 = OpLoad %_arr_uchar_uint_16 %1072
+%1797 = OpCompositeExtract %uchar %1796 4
+OpStore %1107 %1797
+%1798 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1108 %1798
+%1799 = OpLoad %_arr_uchar_uint_16 %1108
+%1800 = OpLoad %uchar %1107
+%1801 = OpCompositeInsert %_arr_uchar_uint_16 %1800 %1799 11
+OpStore %1109 %1801
+%1802 = OpLoad %_arr_uchar_uint_16 %1109
+OpStore %906 %1802
+%1803 = OpLoad %_arr_uchar_uint_16 %1072
+%1804 = OpCompositeExtract %uchar %1803 3
+OpStore %1110 %1804
+%1805 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1111 %1805
+%1806 = OpLoad %_arr_uchar_uint_16 %1111
+%1807 = OpLoad %uchar %1110
+%1808 = OpCompositeInsert %_arr_uchar_uint_16 %1807 %1806 12
+OpStore %1112 %1808
+%1809 = OpLoad %_arr_uchar_uint_16 %1112
+OpStore %906 %1809
+%1810 = OpLoad %_arr_uchar_uint_16 %1072
+%1811 = OpCompositeExtract %uchar %1810 2
+OpStore %1113 %1811
+%1812 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1114 %1812
+%1813 = OpLoad %_arr_uchar_uint_16 %1114
+%1814 = OpLoad %uchar %1113
+%1815 = OpCompositeInsert %_arr_uchar_uint_16 %1814 %1813 13
+OpStore %1115 %1815
+%1816 = OpLoad %_arr_uchar_uint_16 %1115
+OpStore %906 %1816
+%1817 = OpLoad %_arr_uchar_uint_16 %1072
+%1818 = OpCompositeExtract %uchar %1817 1
+OpStore %1116 %1818
+%1819 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1117 %1819
+%1820 = OpLoad %_arr_uchar_uint_16 %1117
+%1821 = OpLoad %uchar %1116
+%1822 = OpCompositeInsert %_arr_uchar_uint_16 %1821 %1820 14
+OpStore %1118 %1822
+%1823 = OpLoad %_arr_uchar_uint_16 %1118
+OpStore %906 %1823
+%1824 = OpLoad %_arr_uchar_uint_16 %1072
+%1825 = OpCompositeExtract %uchar %1824 0
+OpStore %1119 %1825
+%1826 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1120 %1826
+%1827 = OpLoad %_arr_uchar_uint_16 %1120
+%1828 = OpLoad %uchar %1119
+%1829 = OpCompositeInsert %_arr_uchar_uint_16 %1828 %1827 15
+OpStore %1121 %1829
+%1830 = OpLoad %_arr_uchar_uint_16 %1121
+OpStore %906 %1830
+%1831 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1122 %1831
+%1832 = OpLoad %ulong %1073
+%1833 = OpLoad %_arr_uchar_uint_16 %1122
+%1834 = OpFunctionCall %ulong %4 %1832 %1833
+OpStore %1123 %1834
+%1835 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1124 %1835
+%1836 = OpLoad %_arr_uchar_uint_16 %1124
+%1837 = OpCompositeExtract %uchar %1836 0
+OpStore %1142 %1837
+%1838 = OpLoad %_arr_uchar_uint_16 %1072
+%1839 = OpCompositeExtract %uchar %1838 0
+OpStore %1143 %1839
+%1840 = OpLoad %uchar %1142
+%1841 = OpLoad %uchar %1143
+%1842 = OpIAdd %uchar %1840 %1841
+OpStore %1144 %1842
+%1843 = OpLoad %_arr_uchar_uint_16 %1124
+%1844 = OpCompositeExtract %uchar %1843 1
+OpStore %1145 %1844
+%1845 = OpLoad %_arr_uchar_uint_16 %1072
+%1846 = OpCompositeExtract %uchar %1845 1
+OpStore %1146 %1846
+%1847 = OpLoad %uchar %1145
+%1848 = OpLoad %uchar %1146
+%1849 = OpIAdd %uchar %1847 %1848
+OpStore %1147 %1849
+%1850 = OpLoad %_arr_uchar_uint_16 %1124
+%1851 = OpCompositeExtract %uchar %1850 2
+OpStore %1148 %1851
+%1852 = OpLoad %_arr_uchar_uint_16 %1072
+%1853 = OpCompositeExtract %uchar %1852 2
+OpStore %1149 %1853
+%1854 = OpLoad %uchar %1148
+%1855 = OpLoad %uchar %1149
+%1856 = OpIAdd %uchar %1854 %1855
+OpStore %1150 %1856
+%1857 = OpLoad %_arr_uchar_uint_16 %1124
+%1858 = OpCompositeExtract %uchar %1857 3
+OpStore %1151 %1858
+%1859 = OpLoad %_arr_uchar_uint_16 %1072
+%1860 = OpCompositeExtract %uchar %1859 3
+OpStore %1152 %1860
+%1861 = OpLoad %uchar %1151
+%1862 = OpLoad %uchar %1152
+%1863 = OpIAdd %uchar %1861 %1862
+OpStore %1153 %1863
+%1864 = OpLoad %_arr_uchar_uint_16 %1124
+%1865 = OpCompositeExtract %uchar %1864 4
+OpStore %1154 %1865
+%1866 = OpLoad %_arr_uchar_uint_16 %1072
+%1867 = OpCompositeExtract %uchar %1866 4
+OpStore %1155 %1867
+%1868 = OpLoad %uchar %1154
+%1869 = OpLoad %uchar %1155
+%1870 = OpIAdd %uchar %1868 %1869
+OpStore %1156 %1870
+%1871 = OpLoad %_arr_uchar_uint_16 %1124
+%1872 = OpCompositeExtract %uchar %1871 5
+OpStore %1157 %1872
+%1873 = OpLoad %_arr_uchar_uint_16 %1072
+%1874 = OpCompositeExtract %uchar %1873 5
+OpStore %1158 %1874
+%1875 = OpLoad %uchar %1157
+%1876 = OpLoad %uchar %1158
+%1877 = OpIAdd %uchar %1875 %1876
+OpStore %1159 %1877
+%1878 = OpLoad %_arr_uchar_uint_16 %1124
+%1879 = OpCompositeExtract %uchar %1878 6
+OpStore %1160 %1879
+%1880 = OpLoad %_arr_uchar_uint_16 %1072
+%1881 = OpCompositeExtract %uchar %1880 6
+OpStore %1161 %1881
+%1882 = OpLoad %uchar %1160
+%1883 = OpLoad %uchar %1161
+%1884 = OpIAdd %uchar %1882 %1883
+OpStore %1162 %1884
+%1885 = OpLoad %_arr_uchar_uint_16 %1124
+%1886 = OpCompositeExtract %uchar %1885 7
+OpStore %1163 %1886
+%1887 = OpLoad %_arr_uchar_uint_16 %1072
+%1888 = OpCompositeExtract %uchar %1887 7
+OpStore %1164 %1888
+%1889 = OpLoad %uchar %1163
+%1890 = OpLoad %uchar %1164
+%1891 = OpIAdd %uchar %1889 %1890
+OpStore %1165 %1891
+%1892 = OpLoad %_arr_uchar_uint_16 %1124
+%1893 = OpCompositeExtract %uchar %1892 8
+OpStore %1166 %1893
+%1894 = OpLoad %_arr_uchar_uint_16 %1072
+%1895 = OpCompositeExtract %uchar %1894 8
+OpStore %1167 %1895
+%1896 = OpLoad %uchar %1166
+%1897 = OpLoad %uchar %1167
+%1898 = OpIAdd %uchar %1896 %1897
+OpStore %1168 %1898
+%1899 = OpLoad %_arr_uchar_uint_16 %1124
+%1900 = OpCompositeExtract %uchar %1899 9
+OpStore %1169 %1900
+%1901 = OpLoad %_arr_uchar_uint_16 %1072
+%1902 = OpCompositeExtract %uchar %1901 9
+OpStore %1170 %1902
+%1903 = OpLoad %uchar %1169
+%1904 = OpLoad %uchar %1170
+%1905 = OpIAdd %uchar %1903 %1904
+OpStore %1171 %1905
+%1906 = OpLoad %_arr_uchar_uint_16 %1124
+%1907 = OpCompositeExtract %uchar %1906 10
+OpStore %1172 %1907
+%1908 = OpLoad %_arr_uchar_uint_16 %1072
+%1909 = OpCompositeExtract %uchar %1908 10
+OpStore %1173 %1909
+%1910 = OpLoad %uchar %1172
+%1911 = OpLoad %uchar %1173
+%1912 = OpIAdd %uchar %1910 %1911
+OpStore %1174 %1912
+%1913 = OpLoad %_arr_uchar_uint_16 %1124
+%1914 = OpCompositeExtract %uchar %1913 11
+OpStore %1175 %1914
+%1915 = OpLoad %_arr_uchar_uint_16 %1072
+%1916 = OpCompositeExtract %uchar %1915 11
+OpStore %1176 %1916
+%1917 = OpLoad %uchar %1175
+%1918 = OpLoad %uchar %1176
+%1919 = OpIAdd %uchar %1917 %1918
+OpStore %1177 %1919
+%1920 = OpLoad %_arr_uchar_uint_16 %1124
+%1921 = OpCompositeExtract %uchar %1920 12
+OpStore %1178 %1921
+%1922 = OpLoad %_arr_uchar_uint_16 %1072
+%1923 = OpCompositeExtract %uchar %1922 12
+OpStore %1179 %1923
+%1924 = OpLoad %uchar %1178
+%1925 = OpLoad %uchar %1179
+%1926 = OpIAdd %uchar %1924 %1925
+OpStore %1180 %1926
+%1927 = OpLoad %_arr_uchar_uint_16 %1124
+%1928 = OpCompositeExtract %uchar %1927 13
+OpStore %1181 %1928
+%1929 = OpLoad %_arr_uchar_uint_16 %1072
+%1930 = OpCompositeExtract %uchar %1929 13
+OpStore %1182 %1930
+%1931 = OpLoad %uchar %1181
+%1932 = OpLoad %uchar %1182
+%1933 = OpIAdd %uchar %1931 %1932
+OpStore %1183 %1933
+%1934 = OpLoad %_arr_uchar_uint_16 %1124
+%1935 = OpCompositeExtract %uchar %1934 14
+OpStore %1184 %1935
+%1936 = OpLoad %_arr_uchar_uint_16 %1072
+%1937 = OpCompositeExtract %uchar %1936 14
+OpStore %1185 %1937
+%1938 = OpLoad %uchar %1184
+%1939 = OpLoad %uchar %1185
+%1940 = OpIAdd %uchar %1938 %1939
+OpStore %1186 %1940
+%1941 = OpLoad %_arr_uchar_uint_16 %1124
+%1942 = OpCompositeExtract %uchar %1941 15
+OpStore %1187 %1942
+%1943 = OpLoad %_arr_uchar_uint_16 %1072
+%1944 = OpCompositeExtract %uchar %1943 15
+OpStore %1188 %1944
+%1945 = OpLoad %uchar %1187
+%1946 = OpLoad %uchar %1188
+%1947 = OpIAdd %uchar %1945 %1946
+OpStore %1189 %1947
+%1948 = OpLoad %_arr_uchar_uint_16 %1124
+%1949 = OpLoad %uchar %1144
+%1950 = OpCompositeInsert %_arr_uchar_uint_16 %1949 %1948 0
+OpStore %1190 %1950
+%1951 = OpLoad %_arr_uchar_uint_16 %1190
+%1952 = OpLoad %uchar %1147
+%1953 = OpCompositeInsert %_arr_uchar_uint_16 %1952 %1951 1
+OpStore %1191 %1953
+%1954 = OpLoad %_arr_uchar_uint_16 %1191
+%1955 = OpLoad %uchar %1150
+%1956 = OpCompositeInsert %_arr_uchar_uint_16 %1955 %1954 2
+OpStore %1192 %1956
+%1957 = OpLoad %_arr_uchar_uint_16 %1192
+%1958 = OpLoad %uchar %1153
+%1959 = OpCompositeInsert %_arr_uchar_uint_16 %1958 %1957 3
+OpStore %1193 %1959
+%1960 = OpLoad %_arr_uchar_uint_16 %1193
+%1961 = OpLoad %uchar %1156
+%1962 = OpCompositeInsert %_arr_uchar_uint_16 %1961 %1960 4
+OpStore %1194 %1962
+%1963 = OpLoad %_arr_uchar_uint_16 %1194
+%1964 = OpLoad %uchar %1159
+%1965 = OpCompositeInsert %_arr_uchar_uint_16 %1964 %1963 5
+OpStore %1195 %1965
+%1966 = OpLoad %_arr_uchar_uint_16 %1195
+%1967 = OpLoad %uchar %1162
+%1968 = OpCompositeInsert %_arr_uchar_uint_16 %1967 %1966 6
+OpStore %1196 %1968
+%1969 = OpLoad %_arr_uchar_uint_16 %1196
+%1970 = OpLoad %uchar %1165
+%1971 = OpCompositeInsert %_arr_uchar_uint_16 %1970 %1969 7
+OpStore %1197 %1971
+%1972 = OpLoad %_arr_uchar_uint_16 %1197
+%1973 = OpLoad %uchar %1168
+%1974 = OpCompositeInsert %_arr_uchar_uint_16 %1973 %1972 8
+OpStore %1198 %1974
+%1975 = OpLoad %_arr_uchar_uint_16 %1198
+%1976 = OpLoad %uchar %1171
+%1977 = OpCompositeInsert %_arr_uchar_uint_16 %1976 %1975 9
+OpStore %1199 %1977
+%1978 = OpLoad %_arr_uchar_uint_16 %1199
+%1979 = OpLoad %uchar %1174
+%1980 = OpCompositeInsert %_arr_uchar_uint_16 %1979 %1978 10
+OpStore %1200 %1980
+%1981 = OpLoad %_arr_uchar_uint_16 %1200
+%1982 = OpLoad %uchar %1177
+%1983 = OpCompositeInsert %_arr_uchar_uint_16 %1982 %1981 11
+OpStore %1201 %1983
+%1984 = OpLoad %_arr_uchar_uint_16 %1201
+%1985 = OpLoad %uchar %1180
+%1986 = OpCompositeInsert %_arr_uchar_uint_16 %1985 %1984 12
+OpStore %1202 %1986
+%1987 = OpLoad %_arr_uchar_uint_16 %1202
+%1988 = OpLoad %uchar %1183
+%1989 = OpCompositeInsert %_arr_uchar_uint_16 %1988 %1987 13
+OpStore %1203 %1989
+%1990 = OpLoad %_arr_uchar_uint_16 %1203
+%1991 = OpLoad %uchar %1186
+%1992 = OpCompositeInsert %_arr_uchar_uint_16 %1991 %1990 14
+OpStore %1204 %1992
+%1993 = OpLoad %_arr_uchar_uint_16 %1204
+%1994 = OpLoad %uchar %1189
+%1995 = OpCompositeInsert %_arr_uchar_uint_16 %1994 %1993 15
+OpStore %1205 %1995
+%1996 = OpLoad %ulong %1123
+%1997 = OpLoad %_arr_uchar_uint_16 %1205
+%1998 = OpFunctionCall %ulong %4 %1996 %1997
+OpStore %1125 %1998
+%1999 = OpLoad %_arr_uchar_uint_16 %906
+OpStore %1126 %1999
+%2000 = OpLoad %_arr_uchar_uint_16 %1126
+%2001 = OpCompositeExtract %uchar %2000 0
+OpStore %1206 %2001
+%2002 = OpLoad %_arr_uchar_uint_16 %1072
+%2003 = OpCompositeExtract %uchar %2002 0
+OpStore %1207 %2003
+%2004 = OpLoad %uchar %1206
+%2005 = OpLoad %uchar %1207
+%2006 = OpBitwiseXor %uchar %2004 %2005
+OpStore %1208 %2006
+%2007 = OpLoad %_arr_uchar_uint_16 %1126
+%2008 = OpCompositeExtract %uchar %2007 1
+OpStore %1209 %2008
+%2009 = OpLoad %_arr_uchar_uint_16 %1072
+%2010 = OpCompositeExtract %uchar %2009 1
+OpStore %1210 %2010
+%2011 = OpLoad %uchar %1209
+%2012 = OpLoad %uchar %1210
+%2013 = OpBitwiseXor %uchar %2011 %2012
+OpStore %1211 %2013
+%2014 = OpLoad %_arr_uchar_uint_16 %1126
+%2015 = OpCompositeExtract %uchar %2014 2
+OpStore %1212 %2015
+%2016 = OpLoad %_arr_uchar_uint_16 %1072
+%2017 = OpCompositeExtract %uchar %2016 2
+OpStore %1213 %2017
+%2018 = OpLoad %uchar %1212
+%2019 = OpLoad %uchar %1213
+%2020 = OpBitwiseXor %uchar %2018 %2019
+OpStore %1214 %2020
+%2021 = OpLoad %_arr_uchar_uint_16 %1126
+%2022 = OpCompositeExtract %uchar %2021 3
+OpStore %1215 %2022
+%2023 = OpLoad %_arr_uchar_uint_16 %1072
+%2024 = OpCompositeExtract %uchar %2023 3
+OpStore %1216 %2024
+%2025 = OpLoad %uchar %1215
+%2026 = OpLoad %uchar %1216
+%2027 = OpBitwiseXor %uchar %2025 %2026
+OpStore %1217 %2027
+%2028 = OpLoad %_arr_uchar_uint_16 %1126
+%2029 = OpCompositeExtract %uchar %2028 4
+OpStore %1218 %2029
+%2030 = OpLoad %_arr_uchar_uint_16 %1072
+%2031 = OpCompositeExtract %uchar %2030 4
+OpStore %1219 %2031
+%2032 = OpLoad %uchar %1218
+%2033 = OpLoad %uchar %1219
+%2034 = OpBitwiseXor %uchar %2032 %2033
+OpStore %1220 %2034
+%2035 = OpLoad %_arr_uchar_uint_16 %1126
+%2036 = OpCompositeExtract %uchar %2035 5
+OpStore %1221 %2036
+%2037 = OpLoad %_arr_uchar_uint_16 %1072
+%2038 = OpCompositeExtract %uchar %2037 5
+OpStore %1222 %2038
+%2039 = OpLoad %uchar %1221
+%2040 = OpLoad %uchar %1222
+%2041 = OpBitwiseXor %uchar %2039 %2040
+OpStore %1223 %2041
+%2042 = OpLoad %_arr_uchar_uint_16 %1126
+%2043 = OpCompositeExtract %uchar %2042 6
+OpStore %1224 %2043
+%2044 = OpLoad %_arr_uchar_uint_16 %1072
+%2045 = OpCompositeExtract %uchar %2044 6
+OpStore %1225 %2045
+%2046 = OpLoad %uchar %1224
+%2047 = OpLoad %uchar %1225
+%2048 = OpBitwiseXor %uchar %2046 %2047
+OpStore %1226 %2048
+%2049 = OpLoad %_arr_uchar_uint_16 %1126
+%2050 = OpCompositeExtract %uchar %2049 7
+OpStore %1227 %2050
+%2051 = OpLoad %_arr_uchar_uint_16 %1072
+%2052 = OpCompositeExtract %uchar %2051 7
+OpStore %1228 %2052
+%2053 = OpLoad %uchar %1227
+%2054 = OpLoad %uchar %1228
+%2055 = OpBitwiseXor %uchar %2053 %2054
+OpStore %1229 %2055
+%2056 = OpLoad %_arr_uchar_uint_16 %1126
+%2057 = OpCompositeExtract %uchar %2056 8
+OpStore %1230 %2057
+%2058 = OpLoad %_arr_uchar_uint_16 %1072
+%2059 = OpCompositeExtract %uchar %2058 8
+OpStore %1231 %2059
+%2060 = OpLoad %uchar %1230
+%2061 = OpLoad %uchar %1231
+%2062 = OpBitwiseXor %uchar %2060 %2061
+OpStore %1232 %2062
+%2063 = OpLoad %_arr_uchar_uint_16 %1126
+%2064 = OpCompositeExtract %uchar %2063 9
+OpStore %1233 %2064
+%2065 = OpLoad %_arr_uchar_uint_16 %1072
+%2066 = OpCompositeExtract %uchar %2065 9
+OpStore %1234 %2066
+%2067 = OpLoad %uchar %1233
+%2068 = OpLoad %uchar %1234
+%2069 = OpBitwiseXor %uchar %2067 %2068
+OpStore %1235 %2069
+%2070 = OpLoad %_arr_uchar_uint_16 %1126
+%2071 = OpCompositeExtract %uchar %2070 10
+OpStore %1236 %2071
+%2072 = OpLoad %_arr_uchar_uint_16 %1072
+%2073 = OpCompositeExtract %uchar %2072 10
+OpStore %1237 %2073
+%2074 = OpLoad %uchar %1236
+%2075 = OpLoad %uchar %1237
+%2076 = OpBitwiseXor %uchar %2074 %2075
+OpStore %1238 %2076
+%2077 = OpLoad %_arr_uchar_uint_16 %1126
+%2078 = OpCompositeExtract %uchar %2077 11
+OpStore %1239 %2078
+%2079 = OpLoad %_arr_uchar_uint_16 %1072
+%2080 = OpCompositeExtract %uchar %2079 11
+OpStore %1240 %2080
+%2081 = OpLoad %uchar %1239
+%2082 = OpLoad %uchar %1240
+%2083 = OpBitwiseXor %uchar %2081 %2082
+OpStore %1241 %2083
+%2084 = OpLoad %_arr_uchar_uint_16 %1126
+%2085 = OpCompositeExtract %uchar %2084 12
+OpStore %1242 %2085
+%2086 = OpLoad %_arr_uchar_uint_16 %1072
+%2087 = OpCompositeExtract %uchar %2086 12
+OpStore %1243 %2087
+%2088 = OpLoad %uchar %1242
+%2089 = OpLoad %uchar %1243
+%2090 = OpBitwiseXor %uchar %2088 %2089
+OpStore %1244 %2090
+%2091 = OpLoad %_arr_uchar_uint_16 %1126
+%2092 = OpCompositeExtract %uchar %2091 13
+OpStore %1245 %2092
+%2093 = OpLoad %_arr_uchar_uint_16 %1072
+%2094 = OpCompositeExtract %uchar %2093 13
+OpStore %1246 %2094
+%2095 = OpLoad %uchar %1245
+%2096 = OpLoad %uchar %1246
+%2097 = OpBitwiseXor %uchar %2095 %2096
+OpStore %1247 %2097
+%2098 = OpLoad %_arr_uchar_uint_16 %1126
+%2099 = OpCompositeExtract %uchar %2098 14
+OpStore %1248 %2099
+%2100 = OpLoad %_arr_uchar_uint_16 %1072
+%2101 = OpCompositeExtract %uchar %2100 14
+OpStore %1249 %2101
+%2102 = OpLoad %uchar %1248
+%2103 = OpLoad %uchar %1249
+%2104 = OpBitwiseXor %uchar %2102 %2103
+OpStore %1250 %2104
+%2105 = OpLoad %_arr_uchar_uint_16 %1126
+%2106 = OpCompositeExtract %uchar %2105 15
+OpStore %1251 %2106
+%2107 = OpLoad %_arr_uchar_uint_16 %1072
+%2108 = OpCompositeExtract %uchar %2107 15
+OpStore %1252 %2108
+%2109 = OpLoad %uchar %1251
+%2110 = OpLoad %uchar %1252
+%2111 = OpBitwiseXor %uchar %2109 %2110
+OpStore %1253 %2111
+%2112 = OpLoad %_arr_uchar_uint_16 %1126
+%2113 = OpLoad %uchar %1208
+%2114 = OpCompositeInsert %_arr_uchar_uint_16 %2113 %2112 0
+OpStore %1254 %2114
+%2115 = OpLoad %_arr_uchar_uint_16 %1254
+%2116 = OpLoad %uchar %1211
+%2117 = OpCompositeInsert %_arr_uchar_uint_16 %2116 %2115 1
+OpStore %1255 %2117
+%2118 = OpLoad %_arr_uchar_uint_16 %1255
+%2119 = OpLoad %uchar %1214
+%2120 = OpCompositeInsert %_arr_uchar_uint_16 %2119 %2118 2
+OpStore %1256 %2120
+%2121 = OpLoad %_arr_uchar_uint_16 %1256
+%2122 = OpLoad %uchar %1217
+%2123 = OpCompositeInsert %_arr_uchar_uint_16 %2122 %2121 3
+OpStore %1257 %2123
+%2124 = OpLoad %_arr_uchar_uint_16 %1257
+%2125 = OpLoad %uchar %1220
+%2126 = OpCompositeInsert %_arr_uchar_uint_16 %2125 %2124 4
+OpStore %1258 %2126
+%2127 = OpLoad %_arr_uchar_uint_16 %1258
+%2128 = OpLoad %uchar %1223
+%2129 = OpCompositeInsert %_arr_uchar_uint_16 %2128 %2127 5
+OpStore %1259 %2129
+%2130 = OpLoad %_arr_uchar_uint_16 %1259
+%2131 = OpLoad %uchar %1226
+%2132 = OpCompositeInsert %_arr_uchar_uint_16 %2131 %2130 6
+OpStore %1260 %2132
+%2133 = OpLoad %_arr_uchar_uint_16 %1260
+%2134 = OpLoad %uchar %1229
+%2135 = OpCompositeInsert %_arr_uchar_uint_16 %2134 %2133 7
+OpStore %1261 %2135
+%2136 = OpLoad %_arr_uchar_uint_16 %1261
+%2137 = OpLoad %uchar %1232
+%2138 = OpCompositeInsert %_arr_uchar_uint_16 %2137 %2136 8
+OpStore %1262 %2138
+%2139 = OpLoad %_arr_uchar_uint_16 %1262
+%2140 = OpLoad %uchar %1235
+%2141 = OpCompositeInsert %_arr_uchar_uint_16 %2140 %2139 9
+OpStore %1263 %2141
+%2142 = OpLoad %_arr_uchar_uint_16 %1263
+%2143 = OpLoad %uchar %1238
+%2144 = OpCompositeInsert %_arr_uchar_uint_16 %2143 %2142 10
+OpStore %1264 %2144
+%2145 = OpLoad %_arr_uchar_uint_16 %1264
+%2146 = OpLoad %uchar %1241
+%2147 = OpCompositeInsert %_arr_uchar_uint_16 %2146 %2145 11
+OpStore %1265 %2147
+%2148 = OpLoad %_arr_uchar_uint_16 %1265
+%2149 = OpLoad %uchar %1244
+%2150 = OpCompositeInsert %_arr_uchar_uint_16 %2149 %2148 12
+OpStore %1266 %2150
+%2151 = OpLoad %_arr_uchar_uint_16 %1266
+%2152 = OpLoad %uchar %1247
+%2153 = OpCompositeInsert %_arr_uchar_uint_16 %2152 %2151 13
+OpStore %1267 %2153
+%2154 = OpLoad %_arr_uchar_uint_16 %1267
+%2155 = OpLoad %uchar %1250
+%2156 = OpCompositeInsert %_arr_uchar_uint_16 %2155 %2154 14
+OpStore %1268 %2156
+%2157 = OpLoad %_arr_uchar_uint_16 %1268
+%2158 = OpLoad %uchar %1253
+%2159 = OpCompositeInsert %_arr_uchar_uint_16 %2158 %2157 15
+OpStore %1269 %2159
+%2160 = OpLoad %ulong %1125
+%2161 = OpLoad %_arr_uchar_uint_16 %1269
+%2162 = OpFunctionCall %ulong %4 %2160 %2161
+OpStore %1127 %2162
+%2163 = OpLoad %ulong %1127
+OpReturnValue %2163
 OpFunctionEnd
-%6 = OpFunction %ulong None %1978
-%1979 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%7 = OpFunction %ulong None %1981
-%1982 = OpFunctionParameter %ulong
-%1983 = OpFunctionParameter %uint
-%1984 = OpLabel
-%1992 = OpVariable %_ptr_Function_ulong Function
-%1993 = OpVariable %_ptr_Function_uint Function
-%1994 = OpVariable %_ptr_Function_ulong Function
-%1996 = OpVariable %_ptr_Function_bool Function
-%1997 = OpVariable %_ptr_Function_ulong Function
-%1998 = OpVariable %_ptr_Function_ulong Function
-%1999 = OpVariable %_ptr_Function_ulong Function
-%2000 = OpVariable %_ptr_Function_ulong Function
-%2001 = OpVariable %_ptr_Function_ulong Function
-%2002 = OpVariable %_ptr_Function_ulong Function
-%2003 = OpVariable %_ptr_Function_ulong Function
-%2004 = OpVariable %_ptr_Function_ulong Function
-OpStore %1992 %1982
-OpStore %1993 %1983
-%2005 = OpLoad %uint %1993
-%2006 = OpUConvert %ulong %2005
-OpStore %1994 %2006
-OpBranch %1985
-%1985 = OpLabel
-%2007 = OpLoad %ulong %1992
-OpStore %2003 %2007
-OpStore %2004 %ulong_0
-OpBranch %1986
-%1986 = OpLabel
-%2009 = OpLoad %ulong %2004
-%2011 = OpULessThan %bool %2009 %ulong_8
-OpStore %1996 %2011
-%2012 = OpLoad %bool %1996
-OpLoopMerge %1988 %1990 None
-OpBranchConditional %2012 %1987 %1988
-%1988 = OpLabel
-OpBranch %1989
-%1989 = OpLabel
-%2013 = OpLoad %ulong %2003
-OpReturnValue %2013
-%1987 = OpLabel
-%2014 = OpLoad %ulong %2004
-%2015 = OpIMul %ulong %2014 %ulong_8
-OpStore %1997 %2015
-%2016 = OpLoad %ulong %1994
-%2017 = OpLoad %ulong %1997
-%2018 = OpShiftRightLogical %ulong %2016 %2017
-OpStore %1998 %2018
-%2019 = OpLoad %ulong %1998
-%2021 = OpBitwiseAnd %ulong %2019 %ulong_255
-OpStore %1999 %2021
-%2022 = OpLoad %ulong %2003
-%2023 = OpLoad %ulong %1999
-%2024 = OpBitwiseXor %ulong %2022 %2023
-OpStore %2000 %2024
-%2025 = OpLoad %ulong %2000
-%2027 = OpIMul %ulong %2025 %ulong_1099511628211
-OpStore %2001 %2027
-%2028 = OpLoad %ulong %2004
-%2030 = OpIAdd %ulong %2028 %ulong_1
-OpStore %2002 %2030
-%2031 = OpLoad %ulong %2001
-OpStore %2003 %2031
-%2032 = OpLoad %ulong %2002
-OpStore %2004 %2032
-OpBranch %1990
-%1990 = OpLabel
-OpBranch %1986
-OpFunctionEnd
-%8 = OpFunction %ulong None %2033
-%2034 = OpFunctionParameter %ulong
-%2035 = OpFunctionParameter %uchar
-%2036 = OpLabel
-%2043 = OpVariable %_ptr_Function_ulong Function
-%2044 = OpVariable %_ptr_Function_uchar Function
-%2045 = OpVariable %_ptr_Function_ulong Function
-%2046 = OpVariable %_ptr_Function_bool Function
-%2047 = OpVariable %_ptr_Function_ulong Function
-%2048 = OpVariable %_ptr_Function_ulong Function
-%2049 = OpVariable %_ptr_Function_ulong Function
-%2050 = OpVariable %_ptr_Function_ulong Function
-%2051 = OpVariable %_ptr_Function_ulong Function
-%2052 = OpVariable %_ptr_Function_ulong Function
-%2053 = OpVariable %_ptr_Function_ulong Function
-%2054 = OpVariable %_ptr_Function_ulong Function
-OpStore %2043 %2034
-OpStore %2044 %2035
-%2055 = OpLoad %uchar %2044
-%2056 = OpSConvert %ulong %2055
-OpStore %2045 %2056
-OpBranch %2037
-%2037 = OpLabel
-%2057 = OpLoad %ulong %2043
-OpStore %2053 %2057
-OpStore %2054 %ulong_0
-OpBranch %2038
-%2038 = OpLabel
-%2058 = OpLoad %ulong %2054
-%2059 = OpULessThan %bool %2058 %ulong_8
-OpStore %2046 %2059
-%2060 = OpLoad %bool %2046
-OpLoopMerge %2040 %2042 None
-OpBranchConditional %2060 %2039 %2040
-%2040 = OpLabel
-OpBranch %2041
-%2041 = OpLabel
-%2061 = OpLoad %ulong %2053
-OpReturnValue %2061
-%2039 = OpLabel
-%2062 = OpLoad %ulong %2054
-%2063 = OpIMul %ulong %2062 %ulong_8
-OpStore %2047 %2063
-%2064 = OpLoad %ulong %2045
-%2065 = OpLoad %ulong %2047
-%2066 = OpShiftRightLogical %ulong %2064 %2065
-OpStore %2048 %2066
-%2067 = OpLoad %ulong %2048
-%2068 = OpBitwiseAnd %ulong %2067 %ulong_255
-OpStore %2049 %2068
-%2069 = OpLoad %ulong %2053
-%2070 = OpLoad %ulong %2049
-%2071 = OpBitwiseXor %ulong %2069 %2070
-OpStore %2050 %2071
-%2072 = OpLoad %ulong %2050
-%2073 = OpIMul %ulong %2072 %ulong_1099511628211
-OpStore %2051 %2073
-%2074 = OpLoad %ulong %2054
-%2075 = OpIAdd %ulong %2074 %ulong_1
-OpStore %2052 %2075
-%2076 = OpLoad %ulong %2051
-OpStore %2053 %2076
-%2077 = OpLoad %ulong %2052
-OpStore %2054 %2077
-OpBranch %2042
-%2042 = OpLabel
-OpBranch %2038
-OpFunctionEnd
-%9 = OpFunction %ulong None %2078
-%2079 = OpFunctionParameter %ulong
-%2080 = OpFunctionParameter %float
-%2081 = OpLabel
-%2088 = OpVariable %_ptr_Function_ulong Function
-%2089 = OpVariable %_ptr_Function_float Function
-%2090 = OpVariable %_ptr_Function_uint Function
-%2091 = OpVariable %_ptr_Function_ulong Function
-%2092 = OpVariable %_ptr_Function_bool Function
-%2093 = OpVariable %_ptr_Function_ulong Function
-%2094 = OpVariable %_ptr_Function_ulong Function
-%2095 = OpVariable %_ptr_Function_ulong Function
-%2096 = OpVariable %_ptr_Function_ulong Function
-%2097 = OpVariable %_ptr_Function_ulong Function
-%2098 = OpVariable %_ptr_Function_ulong Function
-%2099 = OpVariable %_ptr_Function_ulong Function
-%2100 = OpVariable %_ptr_Function_ulong Function
-OpStore %2088 %2079
-OpStore %2089 %2080
-%2101 = OpLoad %float %2089
-%2102 = OpBitcast %uint %2101
-OpStore %2090 %2102
-%2103 = OpLoad %uint %2090
-%2104 = OpUConvert %ulong %2103
-OpStore %2091 %2104
-OpBranch %2082
-%2082 = OpLabel
-%2105 = OpLoad %ulong %2088
-OpStore %2099 %2105
-OpStore %2100 %ulong_0
-OpBranch %2083
-%2083 = OpLabel
-%2106 = OpLoad %ulong %2100
-%2107 = OpULessThan %bool %2106 %ulong_8
-OpStore %2092 %2107
-%2108 = OpLoad %bool %2092
-OpLoopMerge %2085 %2087 None
-OpBranchConditional %2108 %2084 %2085
-%2085 = OpLabel
-OpBranch %2086
-%2086 = OpLabel
-%2109 = OpLoad %ulong %2099
-OpReturnValue %2109
-%2084 = OpLabel
-%2110 = OpLoad %ulong %2100
-%2111 = OpIMul %ulong %2110 %ulong_8
-OpStore %2093 %2111
-%2112 = OpLoad %ulong %2091
-%2113 = OpLoad %ulong %2093
-%2114 = OpShiftRightLogical %ulong %2112 %2113
-OpStore %2094 %2114
-%2115 = OpLoad %ulong %2094
-%2116 = OpBitwiseAnd %ulong %2115 %ulong_255
-OpStore %2095 %2116
-%2117 = OpLoad %ulong %2099
-%2118 = OpLoad %ulong %2095
-%2119 = OpBitwiseXor %ulong %2117 %2118
-OpStore %2096 %2119
-%2120 = OpLoad %ulong %2096
-%2121 = OpIMul %ulong %2120 %ulong_1099511628211
-OpStore %2097 %2121
-%2122 = OpLoad %ulong %2100
-%2123 = OpIAdd %ulong %2122 %ulong_1
-OpStore %2098 %2123
-%2124 = OpLoad %ulong %2097
-OpStore %2099 %2124
-%2125 = OpLoad %ulong %2098
-OpStore %2100 %2125
-OpBranch %2087
-%2087 = OpLabel
-OpBranch %2083
-OpFunctionEnd
-%10 = OpFunction %ulong None %2126
-%2127 = OpFunctionParameter %ulong
-%2128 = OpFunctionParameter %double
-%2129 = OpLabel
-%2136 = OpVariable %_ptr_Function_ulong Function
-%2137 = OpVariable %_ptr_Function_double Function
-%2138 = OpVariable %_ptr_Function_ulong Function
-%2139 = OpVariable %_ptr_Function_bool Function
-%2140 = OpVariable %_ptr_Function_ulong Function
-%2141 = OpVariable %_ptr_Function_ulong Function
-%2142 = OpVariable %_ptr_Function_ulong Function
-%2143 = OpVariable %_ptr_Function_ulong Function
-%2144 = OpVariable %_ptr_Function_ulong Function
-%2145 = OpVariable %_ptr_Function_ulong Function
-%2146 = OpVariable %_ptr_Function_ulong Function
-%2147 = OpVariable %_ptr_Function_ulong Function
-OpStore %2136 %2127
-OpStore %2137 %2128
-%2148 = OpLoad %double %2137
-%2149 = OpBitcast %ulong %2148
-OpStore %2138 %2149
-OpBranch %2130
-%2130 = OpLabel
-%2150 = OpLoad %ulong %2136
-OpStore %2146 %2150
-OpStore %2147 %ulong_0
-OpBranch %2131
-%2131 = OpLabel
-%2151 = OpLoad %ulong %2147
-%2152 = OpULessThan %bool %2151 %ulong_8
-OpStore %2139 %2152
-%2153 = OpLoad %bool %2139
-OpLoopMerge %2133 %2135 None
-OpBranchConditional %2153 %2132 %2133
-%2133 = OpLabel
-OpBranch %2134
-%2134 = OpLabel
-%2154 = OpLoad %ulong %2146
-OpReturnValue %2154
-%2132 = OpLabel
-%2155 = OpLoad %ulong %2147
-%2156 = OpIMul %ulong %2155 %ulong_8
-OpStore %2140 %2156
-%2157 = OpLoad %ulong %2138
-%2158 = OpLoad %ulong %2140
-%2159 = OpShiftRightLogical %ulong %2157 %2158
-OpStore %2141 %2159
-%2160 = OpLoad %ulong %2141
-%2161 = OpBitwiseAnd %ulong %2160 %ulong_255
-OpStore %2142 %2161
-%2162 = OpLoad %ulong %2146
-%2163 = OpLoad %ulong %2142
-%2164 = OpBitwiseXor %ulong %2162 %2163
-OpStore %2143 %2164
-%2165 = OpLoad %ulong %2143
-%2166 = OpIMul %ulong %2165 %ulong_1099511628211
-OpStore %2144 %2166
-%2167 = OpLoad %ulong %2147
-%2168 = OpIAdd %ulong %2167 %ulong_1
-OpStore %2145 %2168
-%2169 = OpLoad %ulong %2144
-OpStore %2146 %2169
-%2170 = OpLoad %ulong %2145
-OpStore %2147 %2170
-OpBranch %2135
-%2135 = OpLabel
-OpBranch %2131
+%6 = OpFunction %ulong None %2164
+%2165 = OpFunctionParameter %ulong
+%2166 = OpFunctionParameter %ulong
+%2167 = OpLabel
+%2172 = OpVariable %_ptr_Function_ulong Function
+%2173 = OpVariable %_ptr_Function_ulong Function
+%2174 = OpVariable %_ptr_Function_bool Function
+%2175 = OpVariable %_ptr_Function_ulong Function
+%2176 = OpVariable %_ptr_Function_ulong Function
+%2177 = OpVariable %_ptr_Function_ulong Function
+%2178 = OpVariable %_ptr_Function_ulong Function
+%2179 = OpVariable %_ptr_Function_ulong Function
+%2180 = OpVariable %_ptr_Function_ulong Function
+%2181 = OpVariable %_ptr_Function_ulong Function
+%2182 = OpVariable %_ptr_Function_ulong Function
+OpStore %2172 %2165
+OpStore %2173 %2166
+%2183 = OpLoad %ulong %2172
+OpStore %2181 %2183
+OpStore %2182 %ulong_0
+OpBranch %2168
+%2168 = OpLabel
+%2184 = OpLoad %ulong %2182
+%2185 = OpULessThan %bool %2184 %ulong_8
+OpStore %2174 %2185
+%2186 = OpLoad %bool %2174
+OpLoopMerge %2170 %2171 None
+OpBranchConditional %2186 %2169 %2170
+%2170 = OpLabel
+%2187 = OpLoad %ulong %2181
+OpReturnValue %2187
+%2169 = OpLabel
+%2188 = OpLoad %ulong %2182
+%2189 = OpIMul %ulong %2188 %ulong_8
+OpStore %2175 %2189
+%2190 = OpLoad %ulong %2173
+%2191 = OpLoad %ulong %2175
+%2192 = OpShiftRightLogical %ulong %2190 %2191
+OpStore %2176 %2192
+%2193 = OpLoad %ulong %2176
+%2194 = OpBitwiseAnd %ulong %2193 %ulong_255
+OpStore %2177 %2194
+%2195 = OpLoad %ulong %2181
+%2196 = OpLoad %ulong %2177
+%2197 = OpBitwiseXor %ulong %2195 %2196
+OpStore %2178 %2197
+%2198 = OpLoad %ulong %2178
+%2199 = OpIMul %ulong %2198 %ulong_1099511628211
+OpStore %2179 %2199
+%2200 = OpLoad %ulong %2182
+%2201 = OpIAdd %ulong %2200 %ulong_1
+OpStore %2180 %2201
+%2202 = OpLoad %ulong %2179
+OpStore %2181 %2202
+%2203 = OpLoad %ulong %2180
+OpStore %2182 %2203
+OpBranch %2171
+%2171 = OpLabel
+OpBranch %2168
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_mem.dis
+++ b/test/golden/spirv/vec/vec_mem.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1224
+; Bound: 1358
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,50 +14,55 @@ OpDecorate %3 LinkageAttributes "corpus.cases.vec.vec_mem.checksum" Export
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v3float = OpTypeVector %float 3
-%11 = OpTypeFunction %ulong %ulong %v3float
+%8 = OpTypeFunction %ulong %ulong %v3float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v3float = OpTypePointer Function %v3float
 %_ptr_Function_float = OpTypePointer Function %float
-%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
 %uint_5 = OpConstant %uint 5
 %_arr_float_uint_5 = OpTypeArray %float %uint_5
-%45 = OpTypeFunction %ulong %ulong %_arr_float_uint_5
+%167 = OpTypeFunction %ulong %ulong %_arr_float_uint_5
 %_ptr_Function__arr_float_uint_5 = OpTypePointer Function %_arr_float_uint_5
-%88 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%405 = OpTypeFunction %ulong %ulong
 %uchar = OpTypeInt 8 0
+%_struct_510 = OpTypeStruct %v3float %uint
+%uint_4 = OpConstant %uint 4
+%_arr__struct_510_uint_4 = OpTypeArray %_struct_510 %uint_4
+%_ptr_Function__arr__struct_510_uint_4 = OpTypePointer Function %_arr__struct_510_uint_4
+%_struct_515 = OpTypeStruct %uchar %v3float %uchar
+%_ptr_Function__struct_515 = OpTypePointer Function %_struct_515
+%_struct_519 = OpTypeStruct %uint %_arr_float_uint_5 %uint
+%_ptr_Function__struct_519 = OpTypePointer Function %_struct_519
 %uint_7 = OpConstant %uint 7
 %_arr_v3float_uint_7 = OpTypeArray %v3float %uint_7
 %_ptr_Function__arr_v3float_uint_7 = OpTypePointer Function %_arr_v3float_uint_7
-%_struct_158 = OpTypeStruct %v3float %uint
-%uint_4 = OpConstant %uint 4
-%_arr__struct_158_uint_4 = OpTypeArray %_struct_158 %uint_4
-%_ptr_Function__arr__struct_158_uint_4 = OpTypePointer Function %_arr__struct_158_uint_4
-%_struct_163 = OpTypeStruct %uchar %v3float %uchar
-%_ptr_Function__struct_163 = OpTypePointer Function %_struct_163
-%_struct_167 = OpTypeStruct %uint %_arr_float_uint_5 %uint
-%_ptr_Function__struct_167 = OpTypePointer Function %_struct_167
-%uint_3 = OpConstant %uint 3
-%_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
-%_struct_174 = OpTypeStruct %uint %_arr_v3float_uint_3 %uint
-%_ptr_Function__struct_174 = OpTypePointer Function %_struct_174
 %_arr__arr_float_uint_5_uint_5 = OpTypeArray %_arr_float_uint_5 %uint_5
 %_ptr_Function__arr__arr_float_uint_5_uint_5 = OpTypePointer Function %_arr__arr_float_uint_5_uint_5
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_uint = OpTypePointer Function %uint
+%uint_3 = OpConstant %uint 3
+%_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
+%_struct_533 = OpTypeStruct %uint %_arr_v3float_uint_3 %uint
+%_ptr_Function__struct_533 = OpTypePointer Function %_struct_533
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%433 = OpConstantNull %_arr_v3float_uint_7
-%ulong_0 = OpConstant %ulong 0
+%760 = OpConstantNull %_arr_v3float_uint_7
 %ulong_7 = OpConstant %ulong 7
-%443 = OpConstantNull %_arr__struct_158_uint_4
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%769 = OpConstantNull %_arr__struct_510_uint_4
 %ulong_4 = OpConstant %ulong 4
-%452 = OpConstantNull %_struct_163
+%778 = OpConstantNull %_struct_515
 %uint_0 = OpConstant %uint 0
 %uchar_219 = OpConstant %uchar 219
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uchar_173 = OpConstant %uchar 173
-%552 = OpConstantNull %_struct_174
+%860 = OpConstantNull %_struct_533
 %uint_4294967295 = OpConstant %uint 4294967295
 %_ptr_Function__arr_v3float_uint_3 = OpTypePointer Function %_arr_v3float_uint_3
 %uint_6 = OpConstant %uint 6
@@ -66,1630 +71,1913 @@ OpDecorate %3 LinkageAttributes "corpus.cases.vec.vec_mem.checksum" Export
 %float_2 = OpConstant %float 2
 %float_4 = OpConstant %float 4
 %float_8 = OpConstant %float 8
-%684 = OpConstantNull %_arr__arr_float_uint_5_uint_5
+%934 = OpConstantNull %_arr__arr_float_uint_5_uint_5
 %ulong_5 = OpConstant %ulong 5
-%693 = OpConstantNull %_struct_167
-%ulong_1 = OpConstant %ulong 1
-%907 = OpConstantNull %_arr_float_uint_5
+%943 = OpConstantNull %_struct_519
+%1084 = OpConstantNull %_arr_float_uint_5
 %float_1_25 = OpConstant %float 1.25
 %float_100 = OpConstant %float 100
 %float_7_5 = OpConstant %float 7.5
 %float_0 = OpConstant %float 0
-%_ptr_Function__struct_158 = OpTypePointer Function %_struct_158
+%_ptr_Function__struct_510 = OpTypePointer Function %_struct_510
 %uint_2863311530 = OpConstant %uint 2863311530
-%1050 = OpConstantNull %v3float
-%1080 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1083 = OpTypeFunction %ulong %ulong %uchar
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1131 = OpTypeFunction %ulong %ulong %uint
-%1176 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %v3float
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_v3float Function
-%20 = OpVariable %_ptr_Function_float Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_float Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_float Function
-%25 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%26 = OpLoad %v3float %18
-%27 = OpCompositeExtract %float %26 0
-OpStore %20 %27
-%28 = OpLoad %ulong %16
-%29 = OpLoad %float %20
-%30 = OpFunctionCall %ulong %7 %28 %29
-OpStore %21 %30
-%31 = OpLoad %v3float %18
-%32 = OpCompositeExtract %float %31 1
-OpStore %22 %32
-%33 = OpLoad %ulong %21
-%34 = OpLoad %float %22
-%35 = OpFunctionCall %ulong %7 %33 %34
-OpStore %23 %35
-%36 = OpLoad %v3float %18
-%37 = OpCompositeExtract %float %36 2
-OpStore %24 %37
-%38 = OpLoad %ulong %23
-%39 = OpLoad %float %24
-%40 = OpFunctionCall %ulong %7 %38 %39
-OpStore %25 %40
-%41 = OpLoad %ulong %25
-OpReturnValue %41
-OpFunctionEnd
-%2 = OpFunction %ulong None %45
-%46 = OpFunctionParameter %ulong
-%47 = OpFunctionParameter %_arr_float_uint_5
-%48 = OpLabel
-%49 = OpVariable %_ptr_Function_ulong Function
-%51 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%52 = OpVariable %_ptr_Function_float Function
+%1288 = OpConstantNull %v3float
+%1318 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %v3float
+%11 = OpLabel
+%39 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_v3float Function
+%43 = OpVariable %_ptr_Function_float Function
+%44 = OpVariable %_ptr_Function_float Function
+%45 = OpVariable %_ptr_Function_float Function
+%47 = OpVariable %_ptr_Function_uint Function
+%48 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_bool Function
+%51 = OpVariable %_ptr_Function_ulong Function
+%52 = OpVariable %_ptr_Function_ulong Function
 %53 = OpVariable %_ptr_Function_ulong Function
-%54 = OpVariable %_ptr_Function_float Function
+%54 = OpVariable %_ptr_Function_ulong Function
 %55 = OpVariable %_ptr_Function_ulong Function
-%56 = OpVariable %_ptr_Function_float Function
+%56 = OpVariable %_ptr_Function_ulong Function
 %57 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_float Function
-%59 = OpVariable %_ptr_Function_ulong Function
-%60 = OpVariable %_ptr_Function_float Function
-%61 = OpVariable %_ptr_Function_ulong Function
-OpStore %49 %46
-OpStore %51 %47
-%62 = OpLoad %_arr_float_uint_5 %51
-%63 = OpCompositeExtract %float %62 0
-OpStore %52 %63
-%64 = OpLoad %ulong %49
-%65 = OpLoad %float %52
-%66 = OpFunctionCall %ulong %7 %64 %65
-OpStore %53 %66
-%67 = OpLoad %_arr_float_uint_5 %51
-%68 = OpCompositeExtract %float %67 1
-OpStore %54 %68
-%69 = OpLoad %ulong %53
-%70 = OpLoad %float %54
-%71 = OpFunctionCall %ulong %7 %69 %70
-OpStore %55 %71
-%72 = OpLoad %_arr_float_uint_5 %51
-%73 = OpCompositeExtract %float %72 2
-OpStore %56 %73
-%74 = OpLoad %ulong %55
-%75 = OpLoad %float %56
-%76 = OpFunctionCall %ulong %7 %74 %75
-OpStore %57 %76
-%77 = OpLoad %_arr_float_uint_5 %51
-%78 = OpCompositeExtract %float %77 3
-OpStore %58 %78
-%79 = OpLoad %ulong %57
-%80 = OpLoad %float %58
-%81 = OpFunctionCall %ulong %7 %79 %80
-OpStore %59 %81
-%82 = OpLoad %_arr_float_uint_5 %51
-%83 = OpCompositeExtract %float %82 4
-OpStore %60 %83
-%84 = OpLoad %ulong %59
-%85 = OpLoad %float %60
-%86 = OpFunctionCall %ulong %7 %84 %85
-OpStore %61 %86
-%87 = OpLoad %ulong %61
-OpReturnValue %87
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_uint Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_bool Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_uint Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_bool Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+OpStore %39 %9
+OpStore %41 %10
+%81 = OpLoad %v3float %41
+%82 = OpCompositeExtract %float %81 0
+OpStore %43 %82
+OpBranch %12
+%12 = OpLabel
+%83 = OpLoad %float %43
+%84 = OpBitcast %uint %83
+OpStore %47 %84
+%85 = OpLoad %uint %47
+%86 = OpUConvert %ulong %85
+OpStore %48 %86
+OpBranch %14
+%14 = OpLabel
+%87 = OpLoad %ulong %39
+OpStore %57 %87
+OpStore %58 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%89 = OpLoad %ulong %58
+%91 = OpULessThan %bool %89 %ulong_8
+OpStore %50 %91
+%92 = OpLoad %bool %50
+OpLoopMerge %17 %35 None
+OpBranchConditional %92 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%93 = OpLoad %v3float %41
+%94 = OpCompositeExtract %float %93 1
+OpStore %44 %94
+OpBranch %19
+%19 = OpLabel
+%95 = OpLoad %float %44
+%96 = OpBitcast %uint %95
+OpStore %59 %96
+%97 = OpLoad %uint %59
+%98 = OpUConvert %ulong %97
+OpStore %60 %98
+OpBranch %21
+%21 = OpLabel
+%99 = OpLoad %ulong %57
+OpStore %68 %99
+OpStore %69 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%100 = OpLoad %ulong %69
+%101 = OpULessThan %bool %100 %ulong_8
+OpStore %61 %101
+%102 = OpLoad %bool %61
+OpLoopMerge %24 %34 None
+OpBranchConditional %102 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%103 = OpLoad %v3float %41
+%104 = OpCompositeExtract %float %103 2
+OpStore %45 %104
+OpBranch %26
+%26 = OpLabel
+%105 = OpLoad %float %45
+%106 = OpBitcast %uint %105
+OpStore %70 %106
+%107 = OpLoad %uint %70
+%108 = OpUConvert %ulong %107
+OpStore %71 %108
+OpBranch %28
+%28 = OpLabel
+%109 = OpLoad %ulong %68
+OpStore %79 %109
+OpStore %80 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%110 = OpLoad %ulong %80
+%111 = OpULessThan %bool %110 %ulong_8
+OpStore %72 %111
+%112 = OpLoad %bool %72
+OpLoopMerge %31 %33 None
+OpBranchConditional %112 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%113 = OpLoad %ulong %79
+OpReturnValue %113
+%30 = OpLabel
+%114 = OpLoad %ulong %80
+%115 = OpIMul %ulong %114 %ulong_8
+OpStore %73 %115
+%116 = OpLoad %ulong %71
+%117 = OpLoad %ulong %73
+%118 = OpShiftRightLogical %ulong %116 %117
+OpStore %74 %118
+%119 = OpLoad %ulong %74
+%121 = OpBitwiseAnd %ulong %119 %ulong_255
+OpStore %75 %121
+%122 = OpLoad %ulong %79
+%123 = OpLoad %ulong %75
+%124 = OpBitwiseXor %ulong %122 %123
+OpStore %76 %124
+%125 = OpLoad %ulong %76
+%127 = OpIMul %ulong %125 %ulong_1099511628211
+OpStore %77 %127
+%128 = OpLoad %ulong %80
+%130 = OpIAdd %ulong %128 %ulong_1
+OpStore %78 %130
+%131 = OpLoad %ulong %77
+OpStore %79 %131
+%132 = OpLoad %ulong %78
+OpStore %80 %132
+OpBranch %33
+%23 = OpLabel
+%133 = OpLoad %ulong %69
+%134 = OpIMul %ulong %133 %ulong_8
+OpStore %62 %134
+%135 = OpLoad %ulong %60
+%136 = OpLoad %ulong %62
+%137 = OpShiftRightLogical %ulong %135 %136
+OpStore %63 %137
+%138 = OpLoad %ulong %63
+%139 = OpBitwiseAnd %ulong %138 %ulong_255
+OpStore %64 %139
+%140 = OpLoad %ulong %68
+%141 = OpLoad %ulong %64
+%142 = OpBitwiseXor %ulong %140 %141
+OpStore %65 %142
+%143 = OpLoad %ulong %65
+%144 = OpIMul %ulong %143 %ulong_1099511628211
+OpStore %66 %144
+%145 = OpLoad %ulong %69
+%146 = OpIAdd %ulong %145 %ulong_1
+OpStore %67 %146
+%147 = OpLoad %ulong %66
+OpStore %68 %147
+%148 = OpLoad %ulong %67
+OpStore %69 %148
+OpBranch %34
+%16 = OpLabel
+%149 = OpLoad %ulong %58
+%150 = OpIMul %ulong %149 %ulong_8
+OpStore %51 %150
+%151 = OpLoad %ulong %48
+%152 = OpLoad %ulong %51
+%153 = OpShiftRightLogical %ulong %151 %152
+OpStore %52 %153
+%154 = OpLoad %ulong %52
+%155 = OpBitwiseAnd %ulong %154 %ulong_255
+OpStore %53 %155
+%156 = OpLoad %ulong %57
+%157 = OpLoad %ulong %53
+%158 = OpBitwiseXor %ulong %156 %157
+OpStore %54 %158
+%159 = OpLoad %ulong %54
+%160 = OpIMul %ulong %159 %ulong_1099511628211
+OpStore %55 %160
+%161 = OpLoad %ulong %58
+%162 = OpIAdd %ulong %161 %ulong_1
+OpStore %56 %162
+%163 = OpLoad %ulong %55
+OpStore %57 %163
+%164 = OpLoad %ulong %56
+OpStore %58 %164
+OpBranch %35
+%33 = OpLabel
+OpBranch %29
+%34 = OpLabel
+OpBranch %22
+%35 = OpLabel
+OpBranch %15
 OpFunctionEnd
-%3 = OpFunction %ulong None %88
-%89 = OpFunctionParameter %ulong
-%90 = OpLabel
-%156 = OpVariable %_ptr_Function__arr_v3float_uint_7 Function
-%157 = OpVariable %_ptr_Function_v3float Function
-%162 = OpVariable %_ptr_Function__arr__struct_158_uint_4 Function
-%165 = OpVariable %_ptr_Function__struct_163 Function
-%166 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%169 = OpVariable %_ptr_Function__struct_167 Function
-%170 = OpVariable %_ptr_Function__struct_163 Function
-%171 = OpVariable %_ptr_Function__struct_163 Function
-%176 = OpVariable %_ptr_Function__struct_174 Function
-%179 = OpVariable %_ptr_Function__arr__arr_float_uint_5_uint_5 Function
-%180 = OpVariable %_ptr_Function_ulong Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_float Function
-%184 = OpVariable %_ptr_Function_bool Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_float Function
-%187 = OpVariable %_ptr_Function_v3float Function
-%188 = OpVariable %_ptr_Function_v3float Function
-%189 = OpVariable %_ptr_Function_float Function
-%190 = OpVariable %_ptr_Function_v3float Function
-%191 = OpVariable %_ptr_Function_v3float Function
-%192 = OpVariable %_ptr_Function_float Function
-%193 = OpVariable %_ptr_Function_v3float Function
-%194 = OpVariable %_ptr_Function_v3float Function
-%195 = OpVariable %_ptr_Function_v3float Function
-%196 = OpVariable %_ptr_Function_ulong Function
-%197 = OpVariable %_ptr_Function_bool Function
-%198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function_v3float Function
-%200 = OpVariable %_ptr_Function_bool Function
-%201 = OpVariable %_ptr_Function_v3float Function
-%203 = OpVariable %_ptr_Function_uint Function
-%204 = OpVariable %_ptr_Function_uint Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_bool Function
-%207 = OpVariable %_ptr_Function_v3float Function
-%208 = OpVariable %_ptr_Function_uint Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ulong Function
-%211 = OpVariable %_ptr_Function_v3float Function
-%213 = OpVariable %_ptr_Function_uchar Function
-%214 = OpVariable %_ptr_Function_ulong Function
-%215 = OpVariable %_ptr_Function_v3float Function
-%216 = OpVariable %_ptr_Function_uchar Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_v3float Function
-%219 = OpVariable %_ptr_Function_v3float Function
-%220 = OpVariable %_ptr_Function_v3float Function
-%221 = OpVariable %_ptr_Function_uchar Function
+%2 = OpFunction %ulong None %167
+%168 = OpFunctionParameter %ulong
+%169 = OpFunctionParameter %_arr_float_uint_5
+%170 = OpLabel
+%211 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%214 = OpVariable %_ptr_Function_float Function
+%215 = OpVariable %_ptr_Function_float Function
+%216 = OpVariable %_ptr_Function_float Function
+%217 = OpVariable %_ptr_Function_float Function
+%218 = OpVariable %_ptr_Function_float Function
+%219 = OpVariable %_ptr_Function_uint Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_bool Function
 %222 = OpVariable %_ptr_Function_ulong Function
-%223 = OpVariable %_ptr_Function_v3float Function
-%224 = OpVariable %_ptr_Function_uchar Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
 %225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_uchar Function
+%226 = OpVariable %_ptr_Function_ulong Function
 %227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_v3float Function
-%229 = OpVariable %_ptr_Function_uchar Function
-%230 = OpVariable %_ptr_Function_ulong Function
-%231 = OpVariable %_ptr_Function_v3float Function
-%232 = OpVariable %_ptr_Function_v3float Function
-%233 = OpVariable %_ptr_Function_v3float Function
-%234 = OpVariable %_ptr_Function_uint Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_uint Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_bool Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
 %235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_bool Function
-%237 = OpVariable %_ptr_Function_v3float Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
 %238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_uint Function
+%239 = OpVariable %_ptr_Function_ulong Function
 %240 = OpVariable %_ptr_Function_ulong Function
-%241 = OpVariable %_ptr_Function_v3float Function
-%242 = OpVariable %_ptr_Function_v3float Function
-%243 = OpVariable %_ptr_Function_v3float Function
-%244 = OpVariable %_ptr_Function_v3float Function
-%245 = OpVariable %_ptr_Function_v3float Function
-%246 = OpVariable %_ptr_Function_v3float Function
-%247 = OpVariable %_ptr_Function_v3float Function
-%248 = OpVariable %_ptr_Function_v3float Function
-%249 = OpVariable %_ptr_Function_v3float Function
-%250 = OpVariable %_ptr_Function_bool Function
-%251 = OpVariable %_ptr_Function_float Function
-%252 = OpVariable %_ptr_Function_float Function
-%253 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%254 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%255 = OpVariable %_ptr_Function_float Function
-%256 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%257 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%258 = OpVariable %_ptr_Function_float Function
-%259 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%260 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%261 = OpVariable %_ptr_Function_float Function
-%262 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%263 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%264 = OpVariable %_ptr_Function_float Function
-%265 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%266 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%267 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%241 = OpVariable %_ptr_Function_uint Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_bool Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_uint Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_bool Function
+%255 = OpVariable %_ptr_Function_ulong Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_uint Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_bool Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
 %268 = OpVariable %_ptr_Function_ulong Function
-%269 = OpVariable %_ptr_Function_bool Function
+%269 = OpVariable %_ptr_Function_ulong Function
 %270 = OpVariable %_ptr_Function_ulong Function
-%271 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%272 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%273 = OpVariable %_ptr_Function_uint Function
-%274 = OpVariable %_ptr_Function_ulong Function
-%275 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%276 = OpVariable %_ptr_Function_uint Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%279 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%280 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%281 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%282 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_ulong Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ulong Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_ulong Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_ulong Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ulong Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_float Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_float Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_float Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_float Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_float Function
-%303 = OpVariable %_ptr_Function_ulong Function
-%304 = OpVariable %_ptr_Function_float Function
-%305 = OpVariable %_ptr_Function_ulong Function
-%306 = OpVariable %_ptr_Function_float Function
-%307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_float Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_float Function
-%311 = OpVariable %_ptr_Function_ulong Function
-%312 = OpVariable %_ptr_Function_float Function
-%313 = OpVariable %_ptr_Function_ulong Function
-%314 = OpVariable %_ptr_Function_float Function
-%315 = OpVariable %_ptr_Function_ulong Function
-%316 = OpVariable %_ptr_Function_float Function
-%317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_float Function
-%319 = OpVariable %_ptr_Function_ulong Function
-%320 = OpVariable %_ptr_Function_float Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_float Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_float Function
-%325 = OpVariable %_ptr_Function_ulong Function
-%326 = OpVariable %_ptr_Function_float Function
-%327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_float Function
-%329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_float Function
-%331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_float Function
-%333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_float Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_float Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_float Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_float Function
-%341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_float Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_float Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_float Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_float Function
-%351 = OpVariable %_ptr_Function_ulong Function
-%352 = OpVariable %_ptr_Function_float Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_float Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_float Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_float Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_float Function
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_float Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_float Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_float Function
-%367 = OpVariable %_ptr_Function_ulong Function
-%368 = OpVariable %_ptr_Function_float Function
-%369 = OpVariable %_ptr_Function_ulong Function
-%370 = OpVariable %_ptr_Function_float Function
-%371 = OpVariable %_ptr_Function_ulong Function
-%372 = OpVariable %_ptr_Function_float Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_float Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_float Function
-%377 = OpVariable %_ptr_Function_ulong Function
-%378 = OpVariable %_ptr_Function_float Function
-%379 = OpVariable %_ptr_Function_ulong Function
-%380 = OpVariable %_ptr_Function_float Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_float Function
-%383 = OpVariable %_ptr_Function_ulong Function
-%384 = OpVariable %_ptr_Function_float Function
-%385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_float Function
-%387 = OpVariable %_ptr_Function_ulong Function
-%388 = OpVariable %_ptr_Function_float Function
-%389 = OpVariable %_ptr_Function_ulong Function
-%390 = OpVariable %_ptr_Function_float Function
-%391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_float Function
-%393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_float Function
-%395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_float Function
-%397 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_float Function
-%399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_float Function
-%401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_float Function
-%403 = OpVariable %_ptr_Function_ulong Function
-%404 = OpVariable %_ptr_Function_float Function
-%405 = OpVariable %_ptr_Function_ulong Function
-%406 = OpVariable %_ptr_Function_float Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_float Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_float Function
-%411 = OpVariable %_ptr_Function_float Function
-%412 = OpVariable %_ptr_Function_float Function
-%413 = OpVariable %_ptr_Function_float Function
-%414 = OpVariable %_ptr_Function_float Function
-%415 = OpVariable %_ptr_Function_float Function
-%416 = OpVariable %_ptr_Function_float Function
-%417 = OpVariable %_ptr_Function_float Function
-%418 = OpVariable %_ptr_Function_float Function
-%419 = OpVariable %_ptr_Function_float Function
-%420 = OpVariable %_ptr_Function_float Function
-%421 = OpVariable %_ptr_Function_float Function
-%422 = OpVariable %_ptr_Function_float Function
-%423 = OpVariable %_ptr_Function_float Function
-%424 = OpVariable %_ptr_Function_float Function
-%425 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%426 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%427 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%428 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-%429 = OpVariable %_ptr_Function__arr_float_uint_5 Function
-OpStore %180 %89
-%430 = OpFunctionCall %ulong %4
-OpStore %181 %430
-%431 = OpLoad %ulong %180
-%432 = OpConvertUToF %float %431
-OpStore %182 %432
-OpStore %156 %433
-OpStore %287 %ulong_0
-OpBranch %91
-%91 = OpLabel
-%435 = OpLoad %ulong %287
-%437 = OpULessThan %bool %435 %ulong_7
-OpStore %184 %437
-%438 = OpLoad %bool %184
-OpLoopMerge %93 %150 None
-OpBranchConditional %438 %92 %93
-%93 = OpLabel
-%439 = OpLoad %ulong %181
-OpStore %286 %439
-OpStore %288 %ulong_7
-OpBranch %94
-%94 = OpLabel
-%440 = OpLoad %ulong %288
-%441 = OpULessThan %bool %ulong_0 %440
-OpStore %197 %441
-%442 = OpLoad %bool %197
-OpLoopMerge %96 %149 None
-OpBranchConditional %442 %95 %96
-%96 = OpLabel
-OpStore %162 %443
-OpStore %290 %ulong_0
-OpBranch %97
-%97 = OpLabel
-%444 = OpLoad %ulong %290
-%446 = OpULessThan %bool %444 %ulong_4
-OpStore %200 %446
-%447 = OpLoad %bool %200
-OpLoopMerge %99 %148 None
-OpBranchConditional %447 %98 %99
-%99 = OpLabel
-%448 = OpLoad %ulong %286
-OpStore %285 %448
-OpStore %289 %ulong_0
-OpBranch %100
-%100 = OpLabel
-%449 = OpLoad %ulong %289
-%450 = OpULessThan %bool %449 %ulong_4
-OpStore %206 %450
-%451 = OpLoad %bool %206
-OpLoopMerge %102 %147 None
-OpBranchConditional %451 %101 %102
-%102 = OpLabel
-OpStore %165 %452
-%454 = OpAccessChain %_ptr_Function_uchar %165 %uint_0
-OpStore %454 %uchar_219
-%456 = OpAccessChain %_ptr_Function_v3float %156 %uint_5
-%457 = OpLoad %v3float %456
-OpStore %211 %457
-%459 = OpAccessChain %_ptr_Function_v3float %165 %uint_1
-%460 = OpLoad %v3float %211
-OpStore %459 %460
-%462 = OpAccessChain %_ptr_Function_uchar %165 %uint_2
-OpStore %462 %uchar_173
-%464 = OpLoad %uchar %454
-OpStore %213 %464
-%465 = OpLoad %ulong %285
-%466 = OpLoad %uchar %213
-%467 = OpFunctionCall %ulong %5 %465 %466
-OpStore %214 %467
-%468 = OpLoad %v3float %459
-OpStore %215 %468
-OpBranch %116
-%116 = OpLabel
-%469 = OpLoad %v3float %215
-%470 = OpCompositeExtract %float %469 0
-OpStore %306 %470
-%471 = OpLoad %ulong %214
-%472 = OpLoad %float %306
-%473 = OpFunctionCall %ulong %7 %471 %472
-OpStore %307 %473
-%474 = OpLoad %v3float %215
-%475 = OpCompositeExtract %float %474 1
-OpStore %308 %475
-%476 = OpLoad %ulong %307
-%477 = OpLoad %float %308
-%478 = OpFunctionCall %ulong %7 %476 %477
-OpStore %309 %478
-%479 = OpLoad %v3float %215
-%480 = OpCompositeExtract %float %479 2
-OpStore %310 %480
-%481 = OpLoad %ulong %309
-%482 = OpLoad %float %310
-%483 = OpFunctionCall %ulong %7 %481 %482
-OpStore %311 %483
-OpBranch %117
-%117 = OpLabel
-%484 = OpAccessChain %_ptr_Function_uchar %165 %uint_2
-%485 = OpLoad %uchar %484
-OpStore %216 %485
-%486 = OpLoad %ulong %311
-%487 = OpLoad %uchar %216
-%488 = OpFunctionCall %ulong %5 %486 %487
-OpStore %217 %488
-%489 = OpLoad %_struct_163 %165
-OpStore %171 %489
-%490 = OpLoad %_struct_163 %171
-OpStore %170 %490
-%491 = OpAccessChain %_ptr_Function_v3float %170 %uint_1
-%492 = OpLoad %v3float %491
-OpStore %218 %492
-%493 = OpAccessChain %_ptr_Function_v3float %156 %uint_1
-%494 = OpLoad %v3float %493
-OpStore %219 %494
-%495 = OpLoad %v3float %218
-%496 = OpLoad %v3float %219
-%497 = OpFAdd %v3float %495 %496
-OpStore %220 %497
-%498 = OpLoad %v3float %220
-OpStore %491 %498
-%499 = OpAccessChain %_ptr_Function_uchar %170 %uint_0
-%500 = OpLoad %uchar %499
-OpStore %221 %500
-%501 = OpLoad %ulong %217
-%502 = OpLoad %uchar %221
-%503 = OpFunctionCall %ulong %5 %501 %502
-OpStore %222 %503
-%504 = OpLoad %v3float %491
-OpStore %223 %504
-OpBranch %126
-%126 = OpLabel
-%505 = OpLoad %v3float %223
-%506 = OpCompositeExtract %float %505 0
-OpStore %344 %506
-%507 = OpLoad %ulong %222
-%508 = OpLoad %float %344
-%509 = OpFunctionCall %ulong %7 %507 %508
-OpStore %345 %509
-%510 = OpLoad %v3float %223
-%511 = OpCompositeExtract %float %510 1
-OpStore %346 %511
-%512 = OpLoad %ulong %345
-%513 = OpLoad %float %346
-%514 = OpFunctionCall %ulong %7 %512 %513
-OpStore %347 %514
-%515 = OpLoad %v3float %223
-%516 = OpCompositeExtract %float %515 2
-OpStore %348 %516
-%517 = OpLoad %ulong %347
-%518 = OpLoad %float %348
-%519 = OpFunctionCall %ulong %7 %517 %518
-OpStore %349 %519
-OpBranch %127
-%127 = OpLabel
-%520 = OpAccessChain %_ptr_Function_uchar %170 %uint_2
-%521 = OpLoad %uchar %520
-OpStore %224 %521
-%522 = OpLoad %ulong %349
-%523 = OpLoad %uchar %224
-%524 = OpFunctionCall %ulong %5 %522 %523
-OpStore %225 %524
-%525 = OpAccessChain %_ptr_Function_uchar %165 %uint_0
-%526 = OpLoad %uchar %525
-OpStore %226 %526
-%527 = OpLoad %ulong %225
-%528 = OpLoad %uchar %226
-%529 = OpFunctionCall %ulong %5 %527 %528
-OpStore %227 %529
-%530 = OpAccessChain %_ptr_Function_v3float %165 %uint_1
-%531 = OpLoad %v3float %530
-OpStore %228 %531
-OpBranch %132
-%132 = OpLabel
-%532 = OpLoad %v3float %228
-%533 = OpCompositeExtract %float %532 0
-OpStore %366 %533
-%534 = OpLoad %ulong %227
-%535 = OpLoad %float %366
-%536 = OpFunctionCall %ulong %7 %534 %535
-OpStore %367 %536
-%537 = OpLoad %v3float %228
-%538 = OpCompositeExtract %float %537 1
-OpStore %368 %538
-%539 = OpLoad %ulong %367
-%540 = OpLoad %float %368
-%541 = OpFunctionCall %ulong %7 %539 %540
-OpStore %369 %541
-%542 = OpLoad %v3float %228
-%543 = OpCompositeExtract %float %542 2
-OpStore %370 %543
-%544 = OpLoad %ulong %369
-%545 = OpLoad %float %370
-%546 = OpFunctionCall %ulong %7 %544 %545
-OpStore %371 %546
-OpBranch %133
-%133 = OpLabel
-%547 = OpAccessChain %_ptr_Function_uchar %165 %uint_2
-%548 = OpLoad %uchar %547
-OpStore %229 %548
-%549 = OpLoad %ulong %371
-%550 = OpLoad %uchar %229
-%551 = OpFunctionCall %ulong %5 %549 %550
-OpStore %230 %551
-OpStore %176 %552
-%553 = OpAccessChain %_ptr_Function_uint %176 %uint_0
-OpStore %553 %uint_4294967295
-%555 = OpAccessChain %_ptr_Function_v3float %156 %uint_0
-%556 = OpLoad %v3float %555
-OpStore %231 %556
-%558 = OpAccessChain %_ptr_Function__arr_v3float_uint_3 %176 %uint_1
-%559 = OpAccessChain %_ptr_Function_v3float %558 %uint_0
-%560 = OpLoad %v3float %231
-OpStore %559 %560
-%561 = OpAccessChain %_ptr_Function_v3float %156 %uint_3
-%562 = OpLoad %v3float %561
-OpStore %232 %562
-%563 = OpAccessChain %_ptr_Function_v3float %558 %uint_1
-%564 = OpLoad %v3float %232
-OpStore %563 %564
-%566 = OpAccessChain %_ptr_Function_v3float %156 %uint_6
-%567 = OpLoad %v3float %566
-OpStore %233 %567
-%568 = OpAccessChain %_ptr_Function_v3float %558 %uint_2
-%569 = OpLoad %v3float %233
-OpStore %568 %569
-%570 = OpAccessChain %_ptr_Function_uint %176 %uint_2
-OpStore %570 %uint_305419896
-%572 = OpLoad %uint %553
-OpStore %234 %572
-%573 = OpLoad %ulong %230
-%574 = OpLoad %uint %234
-%575 = OpFunctionCall %ulong %6 %573 %574
-OpStore %235 %575
-%576 = OpLoad %ulong %235
-OpStore %284 %576
-OpStore %291 %ulong_0
-OpBranch %103
-%103 = OpLabel
-%577 = OpLoad %ulong %291
-%579 = OpULessThan %bool %577 %ulong_3
-OpStore %236 %579
-%580 = OpLoad %bool %236
-OpLoopMerge %105 %146 None
-OpBranchConditional %580 %104 %105
-%105 = OpLabel
-%581 = OpAccessChain %_ptr_Function_uint %176 %uint_2
-%582 = OpLoad %uint %581
-OpStore %239 %582
-%583 = OpLoad %ulong %284
-%584 = OpLoad %uint %239
-%585 = OpFunctionCall %ulong %6 %583 %584
-OpStore %240 %585
-%586 = OpAccessChain %_ptr_Function_v3float %156 %uint_2
-%587 = OpLoad %v3float %586
-OpStore %241 %587
-%588 = OpAccessChain %_ptr_Function_v3float %156 %uint_4
-%589 = OpLoad %v3float %588
-OpStore %242 %589
-%590 = OpLoad %v3float %241
-%591 = OpLoad %v3float %242
-%592 = OpFAdd %v3float %590 %591
-OpStore %243 %592
-OpBranch %120
-%120 = OpLabel
-%593 = OpLoad %v3float %243
-%594 = OpCompositeExtract %float %593 0
-OpStore %318 %594
-%595 = OpLoad %ulong %240
-%596 = OpLoad %float %318
-%597 = OpFunctionCall %ulong %7 %595 %596
-OpStore %319 %597
-%598 = OpLoad %v3float %243
-%599 = OpCompositeExtract %float %598 1
-OpStore %320 %599
-%600 = OpLoad %ulong %319
-%601 = OpLoad %float %320
-%602 = OpFunctionCall %ulong %7 %600 %601
-OpStore %321 %602
-%603 = OpLoad %v3float %243
-%604 = OpCompositeExtract %float %603 2
-OpStore %322 %604
-%605 = OpLoad %ulong %321
-%606 = OpLoad %float %322
-%607 = OpFunctionCall %ulong %7 %605 %606
-OpStore %323 %607
-OpBranch %121
-%121 = OpLabel
-OpBranch %128
-%128 = OpLabel
-%608 = OpLoad %v3float %243
-%609 = OpCompositeExtract %float %608 0
-OpStore %350 %609
-%610 = OpLoad %ulong %323
-%611 = OpLoad %float %350
-%612 = OpFunctionCall %ulong %7 %610 %611
-OpStore %351 %612
-%613 = OpLoad %v3float %243
-%614 = OpCompositeExtract %float %613 1
-OpStore %352 %614
-%615 = OpLoad %ulong %351
-%616 = OpLoad %float %352
-%617 = OpFunctionCall %ulong %7 %615 %616
-OpStore %353 %617
-%618 = OpLoad %v3float %243
-%619 = OpCompositeExtract %float %618 2
-OpStore %354 %619
-%620 = OpLoad %ulong %353
-%621 = OpLoad %float %354
-%622 = OpFunctionCall %ulong %7 %620 %621
-OpStore %355 %622
-OpBranch %129
-%129 = OpLabel
-%623 = OpAccessChain %_ptr_Function_v3float %156 %uint_3
-%624 = OpLoad %v3float %623
-OpStore %244 %624
-%625 = OpCompositeConstruct %v3float %float_2 %float_4 %float_8
-OpStore %245 %625
-%629 = OpLoad %v3float %244
-%630 = OpLoad %v3float %245
-%631 = OpFMul %v3float %629 %630
-OpStore %246 %631
-%632 = OpLoad %v3float %246
-OpStore %623 %632
-%633 = OpAccessChain %_ptr_Function_v3float %156 %uint_2
-%634 = OpLoad %v3float %633
-OpStore %247 %634
-OpBranch %134
-%134 = OpLabel
-%635 = OpLoad %v3float %247
-%636 = OpCompositeExtract %float %635 0
-OpStore %372 %636
-%637 = OpLoad %ulong %355
-%638 = OpLoad %float %372
-%639 = OpFunctionCall %ulong %7 %637 %638
-OpStore %373 %639
-%640 = OpLoad %v3float %247
-%641 = OpCompositeExtract %float %640 1
-OpStore %374 %641
-%642 = OpLoad %ulong %373
-%643 = OpLoad %float %374
-%644 = OpFunctionCall %ulong %7 %642 %643
-OpStore %375 %644
-%645 = OpLoad %v3float %247
-%646 = OpCompositeExtract %float %645 2
-OpStore %376 %646
-%647 = OpLoad %ulong %375
-%648 = OpLoad %float %376
-%649 = OpFunctionCall %ulong %7 %647 %648
-OpStore %377 %649
-OpBranch %135
-%135 = OpLabel
-%650 = OpAccessChain %_ptr_Function_v3float %156 %uint_3
-%651 = OpLoad %v3float %650
-OpStore %248 %651
-OpBranch %138
-%138 = OpLabel
-%652 = OpLoad %v3float %248
-%653 = OpCompositeExtract %float %652 0
-OpStore %388 %653
-%654 = OpLoad %ulong %377
-%655 = OpLoad %float %388
-%656 = OpFunctionCall %ulong %7 %654 %655
-OpStore %389 %656
-%657 = OpLoad %v3float %248
-%658 = OpCompositeExtract %float %657 1
-OpStore %390 %658
-%659 = OpLoad %ulong %389
-%660 = OpLoad %float %390
-%661 = OpFunctionCall %ulong %7 %659 %660
-OpStore %391 %661
-%662 = OpLoad %v3float %248
-%663 = OpCompositeExtract %float %662 2
-OpStore %392 %663
-%664 = OpLoad %ulong %391
-%665 = OpLoad %float %392
-%666 = OpFunctionCall %ulong %7 %664 %665
-OpStore %393 %666
-OpBranch %139
-%139 = OpLabel
-%667 = OpAccessChain %_ptr_Function_v3float %156 %uint_4
-%668 = OpLoad %v3float %667
-OpStore %249 %668
-OpBranch %142
-%142 = OpLabel
-%669 = OpLoad %v3float %249
-%670 = OpCompositeExtract %float %669 0
-OpStore %404 %670
-%671 = OpLoad %ulong %393
-%672 = OpLoad %float %404
-%673 = OpFunctionCall %ulong %7 %671 %672
-OpStore %405 %673
-%674 = OpLoad %v3float %249
-%675 = OpCompositeExtract %float %674 1
-OpStore %406 %675
-%676 = OpLoad %ulong %405
-%677 = OpLoad %float %406
-%678 = OpFunctionCall %ulong %7 %676 %677
-OpStore %407 %678
-%679 = OpLoad %v3float %249
-%680 = OpCompositeExtract %float %679 2
-OpStore %408 %680
-%681 = OpLoad %ulong %407
-%682 = OpLoad %float %408
-%683 = OpFunctionCall %ulong %7 %681 %682
-OpStore %409 %683
-OpBranch %143
-%143 = OpLabel
-OpStore %179 %684
-OpStore %293 %ulong_0
-OpBranch %106
-%106 = OpLabel
-%685 = OpLoad %ulong %293
-%687 = OpULessThan %bool %685 %ulong_5
-OpStore %250 %687
-%688 = OpLoad %bool %250
-OpLoopMerge %108 %145 None
-OpBranchConditional %688 %107 %108
-%108 = OpLabel
-%689 = OpLoad %ulong %409
-OpStore %283 %689
-OpStore %292 %ulong_5
-OpBranch %109
-%109 = OpLabel
-%690 = OpLoad %ulong %292
-%691 = OpULessThan %bool %ulong_0 %690
-OpStore %269 %691
-%692 = OpLoad %bool %269
-OpLoopMerge %111 %144 None
-OpBranchConditional %692 %110 %111
-%111 = OpLabel
-OpStore %169 %693
-%694 = OpAccessChain %_ptr_Function_uint %169 %uint_0
-OpStore %694 %uint_4294967295
-%695 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_3
-%696 = OpLoad %_arr_float_uint_5 %695
-OpStore %272 %696
-%697 = OpAccessChain %_ptr_Function__arr_float_uint_5 %169 %uint_1
-%698 = OpLoad %_arr_float_uint_5 %272
-OpStore %697 %698
-%699 = OpAccessChain %_ptr_Function_uint %169 %uint_2
-OpStore %699 %uint_305419896
-%700 = OpLoad %uint %694
-OpStore %273 %700
-%701 = OpLoad %ulong %283
-%702 = OpLoad %uint %273
-%703 = OpFunctionCall %ulong %6 %701 %702
-OpStore %274 %703
-%704 = OpLoad %_arr_float_uint_5 %697
-OpStore %275 %704
-OpBranch %124
-%124 = OpLabel
-%705 = OpLoad %_arr_float_uint_5 %275
-%706 = OpCompositeExtract %float %705 0
-OpStore %334 %706
-%707 = OpLoad %ulong %274
-%708 = OpLoad %float %334
-%709 = OpFunctionCall %ulong %7 %707 %708
-OpStore %335 %709
-%710 = OpLoad %_arr_float_uint_5 %275
-%711 = OpCompositeExtract %float %710 1
-OpStore %336 %711
-%712 = OpLoad %ulong %335
-%713 = OpLoad %float %336
-%714 = OpFunctionCall %ulong %7 %712 %713
-OpStore %337 %714
-%715 = OpLoad %_arr_float_uint_5 %275
-%716 = OpCompositeExtract %float %715 2
-OpStore %338 %716
-%717 = OpLoad %ulong %337
-%718 = OpLoad %float %338
-%719 = OpFunctionCall %ulong %7 %717 %718
-OpStore %339 %719
-%720 = OpLoad %_arr_float_uint_5 %275
-%721 = OpCompositeExtract %float %720 3
-OpStore %340 %721
-%722 = OpLoad %ulong %339
-%723 = OpLoad %float %340
-%724 = OpFunctionCall %ulong %7 %722 %723
-OpStore %341 %724
-%725 = OpLoad %_arr_float_uint_5 %275
-%726 = OpCompositeExtract %float %725 4
-OpStore %342 %726
-%727 = OpLoad %ulong %341
-%728 = OpLoad %float %342
-%729 = OpFunctionCall %ulong %7 %727 %728
-OpStore %343 %729
-OpBranch %125
-%125 = OpLabel
-%730 = OpAccessChain %_ptr_Function_uint %169 %uint_2
-%731 = OpLoad %uint %730
-OpStore %276 %731
-%732 = OpLoad %ulong %343
-%733 = OpLoad %uint %276
-%734 = OpFunctionCall %ulong %6 %732 %733
-OpStore %277 %734
-%735 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_1
-%736 = OpLoad %_arr_float_uint_5 %735
-OpStore %278 %736
-%737 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_4
-%738 = OpLoad %_arr_float_uint_5 %737
-OpStore %279 %738
-%739 = OpLoad %_arr_float_uint_5 %278
-%740 = OpCompositeExtract %float %739 0
-OpStore %410 %740
-%741 = OpLoad %_arr_float_uint_5 %279
-%742 = OpCompositeExtract %float %741 0
-OpStore %411 %742
-%743 = OpLoad %float %410
-%744 = OpLoad %float %411
-%745 = OpFAdd %float %743 %744
-OpStore %412 %745
-%746 = OpLoad %_arr_float_uint_5 %278
-%747 = OpCompositeExtract %float %746 1
-OpStore %413 %747
-%748 = OpLoad %_arr_float_uint_5 %279
-%749 = OpCompositeExtract %float %748 1
-OpStore %414 %749
-%750 = OpLoad %float %413
-%751 = OpLoad %float %414
-%752 = OpFAdd %float %750 %751
-OpStore %415 %752
-%753 = OpLoad %_arr_float_uint_5 %278
-%754 = OpCompositeExtract %float %753 2
-OpStore %416 %754
-%755 = OpLoad %_arr_float_uint_5 %279
-%756 = OpCompositeExtract %float %755 2
-OpStore %417 %756
-%757 = OpLoad %float %416
-%758 = OpLoad %float %417
-%759 = OpFAdd %float %757 %758
-OpStore %418 %759
-%760 = OpLoad %_arr_float_uint_5 %278
-%761 = OpCompositeExtract %float %760 3
-OpStore %419 %761
-%762 = OpLoad %_arr_float_uint_5 %279
-%763 = OpCompositeExtract %float %762 3
-OpStore %420 %763
-%764 = OpLoad %float %419
-%765 = OpLoad %float %420
-%766 = OpFAdd %float %764 %765
-OpStore %421 %766
-%767 = OpLoad %_arr_float_uint_5 %278
-%768 = OpCompositeExtract %float %767 4
-OpStore %422 %768
-%769 = OpLoad %_arr_float_uint_5 %279
-%770 = OpCompositeExtract %float %769 4
-OpStore %423 %770
-%771 = OpLoad %float %422
-%772 = OpLoad %float %423
-%773 = OpFAdd %float %771 %772
-OpStore %424 %773
-%774 = OpLoad %_arr_float_uint_5 %278
-%775 = OpLoad %float %412
-%776 = OpCompositeInsert %_arr_float_uint_5 %775 %774 0
-OpStore %425 %776
-%777 = OpLoad %_arr_float_uint_5 %425
-%778 = OpLoad %float %415
-%779 = OpCompositeInsert %_arr_float_uint_5 %778 %777 1
-OpStore %426 %779
-%780 = OpLoad %_arr_float_uint_5 %426
-%781 = OpLoad %float %418
-%782 = OpCompositeInsert %_arr_float_uint_5 %781 %780 2
-OpStore %427 %782
-%783 = OpLoad %_arr_float_uint_5 %427
-%784 = OpLoad %float %421
-%785 = OpCompositeInsert %_arr_float_uint_5 %784 %783 3
-OpStore %428 %785
-%786 = OpLoad %_arr_float_uint_5 %428
-%787 = OpLoad %float %424
-%788 = OpCompositeInsert %_arr_float_uint_5 %787 %786 4
-OpStore %429 %788
-%789 = OpLoad %_arr_float_uint_5 %429
-OpStore %735 %789
-%790 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_0
-%791 = OpLoad %_arr_float_uint_5 %790
-OpStore %280 %791
-OpBranch %130
-%130 = OpLabel
-%792 = OpLoad %_arr_float_uint_5 %280
-%793 = OpCompositeExtract %float %792 0
-OpStore %356 %793
-%794 = OpLoad %ulong %277
-%795 = OpLoad %float %356
-%796 = OpFunctionCall %ulong %7 %794 %795
-OpStore %357 %796
-%797 = OpLoad %_arr_float_uint_5 %280
-%798 = OpCompositeExtract %float %797 1
-OpStore %358 %798
-%799 = OpLoad %ulong %357
-%800 = OpLoad %float %358
-%801 = OpFunctionCall %ulong %7 %799 %800
-OpStore %359 %801
-%802 = OpLoad %_arr_float_uint_5 %280
-%803 = OpCompositeExtract %float %802 2
-OpStore %360 %803
-%804 = OpLoad %ulong %359
-%805 = OpLoad %float %360
-%806 = OpFunctionCall %ulong %7 %804 %805
-OpStore %361 %806
-%807 = OpLoad %_arr_float_uint_5 %280
-%808 = OpCompositeExtract %float %807 3
-OpStore %362 %808
-%809 = OpLoad %ulong %361
-%810 = OpLoad %float %362
-%811 = OpFunctionCall %ulong %7 %809 %810
-OpStore %363 %811
-%812 = OpLoad %_arr_float_uint_5 %280
-%813 = OpCompositeExtract %float %812 4
-OpStore %364 %813
-%814 = OpLoad %ulong %363
-%815 = OpLoad %float %364
-%816 = OpFunctionCall %ulong %7 %814 %815
-OpStore %365 %816
-OpBranch %131
-%131 = OpLabel
-%817 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_1
-%818 = OpLoad %_arr_float_uint_5 %817
-OpStore %281 %818
-OpBranch %136
-%136 = OpLabel
-%819 = OpLoad %_arr_float_uint_5 %281
-%820 = OpCompositeExtract %float %819 0
-OpStore %378 %820
-%821 = OpLoad %ulong %365
-%822 = OpLoad %float %378
-%823 = OpFunctionCall %ulong %7 %821 %822
-OpStore %379 %823
-%824 = OpLoad %_arr_float_uint_5 %281
-%825 = OpCompositeExtract %float %824 1
-OpStore %380 %825
-%826 = OpLoad %ulong %379
-%827 = OpLoad %float %380
-%828 = OpFunctionCall %ulong %7 %826 %827
-OpStore %381 %828
-%829 = OpLoad %_arr_float_uint_5 %281
-%830 = OpCompositeExtract %float %829 2
-OpStore %382 %830
-%831 = OpLoad %ulong %381
-%832 = OpLoad %float %382
-%833 = OpFunctionCall %ulong %7 %831 %832
-OpStore %383 %833
-%834 = OpLoad %_arr_float_uint_5 %281
-%835 = OpCompositeExtract %float %834 3
-OpStore %384 %835
-%836 = OpLoad %ulong %383
-%837 = OpLoad %float %384
-%838 = OpFunctionCall %ulong %7 %836 %837
-OpStore %385 %838
-%839 = OpLoad %_arr_float_uint_5 %281
-%840 = OpCompositeExtract %float %839 4
-OpStore %386 %840
-%841 = OpLoad %ulong %385
-%842 = OpLoad %float %386
-%843 = OpFunctionCall %ulong %7 %841 %842
-OpStore %387 %843
-OpBranch %137
-%137 = OpLabel
-%844 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %uint_2
-%845 = OpLoad %_arr_float_uint_5 %844
-OpStore %282 %845
-OpBranch %140
-%140 = OpLabel
-%846 = OpLoad %_arr_float_uint_5 %282
-%847 = OpCompositeExtract %float %846 0
-OpStore %394 %847
-%848 = OpLoad %ulong %387
-%849 = OpLoad %float %394
-%850 = OpFunctionCall %ulong %7 %848 %849
-OpStore %395 %850
-%851 = OpLoad %_arr_float_uint_5 %282
-%852 = OpCompositeExtract %float %851 1
-OpStore %396 %852
-%853 = OpLoad %ulong %395
-%854 = OpLoad %float %396
-%855 = OpFunctionCall %ulong %7 %853 %854
-OpStore %397 %855
-%856 = OpLoad %_arr_float_uint_5 %282
-%857 = OpCompositeExtract %float %856 2
-OpStore %398 %857
-%858 = OpLoad %ulong %397
-%859 = OpLoad %float %398
-%860 = OpFunctionCall %ulong %7 %858 %859
-OpStore %399 %860
-%861 = OpLoad %_arr_float_uint_5 %282
-%862 = OpCompositeExtract %float %861 3
-OpStore %400 %862
-%863 = OpLoad %ulong %399
-%864 = OpLoad %float %400
-%865 = OpFunctionCall %ulong %7 %863 %864
-OpStore %401 %865
-%866 = OpLoad %_arr_float_uint_5 %282
-%867 = OpCompositeExtract %float %866 4
-OpStore %402 %867
-%868 = OpLoad %ulong %401
-%869 = OpLoad %float %402
-%870 = OpFunctionCall %ulong %7 %868 %869
-OpStore %403 %870
-OpBranch %141
-%141 = OpLabel
-%871 = OpLoad %ulong %403
-OpReturnValue %871
-%110 = OpLabel
-%872 = OpLoad %ulong %292
-%874 = OpISub %ulong %872 %ulong_1
-OpStore %270 %874
-%875 = OpLoad %ulong %270
-%876 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %875
-%877 = OpLoad %_arr_float_uint_5 %876
-OpStore %271 %877
-OpBranch %122
-%122 = OpLabel
-%878 = OpLoad %_arr_float_uint_5 %271
-%879 = OpCompositeExtract %float %878 0
-OpStore %324 %879
-%880 = OpLoad %ulong %283
-%881 = OpLoad %float %324
-%882 = OpFunctionCall %ulong %7 %880 %881
-OpStore %325 %882
-%883 = OpLoad %_arr_float_uint_5 %271
-%884 = OpCompositeExtract %float %883 1
-OpStore %326 %884
-%885 = OpLoad %ulong %325
-%886 = OpLoad %float %326
-%887 = OpFunctionCall %ulong %7 %885 %886
-OpStore %327 %887
-%888 = OpLoad %_arr_float_uint_5 %271
-%889 = OpCompositeExtract %float %888 2
-OpStore %328 %889
-%890 = OpLoad %ulong %327
-%891 = OpLoad %float %328
-%892 = OpFunctionCall %ulong %7 %890 %891
-OpStore %329 %892
-%893 = OpLoad %_arr_float_uint_5 %271
-%894 = OpCompositeExtract %float %893 3
-OpStore %330 %894
-%895 = OpLoad %ulong %329
-%896 = OpLoad %float %330
-%897 = OpFunctionCall %ulong %7 %895 %896
-OpStore %331 %897
-%898 = OpLoad %_arr_float_uint_5 %271
-%899 = OpCompositeExtract %float %898 4
-OpStore %332 %899
-%900 = OpLoad %ulong %331
-%901 = OpLoad %float %332
-%902 = OpFunctionCall %ulong %7 %900 %901
-OpStore %333 %902
-OpBranch %123
-%123 = OpLabel
-%903 = OpLoad %ulong %333
-OpStore %283 %903
-%904 = OpLoad %ulong %270
-OpStore %292 %904
-OpBranch %144
-%107 = OpLabel
-%905 = OpLoad %ulong %293
-%906 = OpConvertUToF %float %905
-OpStore %251 %906
-OpStore %166 %907
-%908 = OpLoad %float %251
-%909 = OpLoad %float %182
-%910 = OpFAdd %float %908 %909
-OpStore %252 %910
-%911 = OpLoad %_arr_float_uint_5 %166
-OpStore %253 %911
-%912 = OpLoad %_arr_float_uint_5 %253
-%913 = OpLoad %float %252
-%914 = OpCompositeInsert %_arr_float_uint_5 %913 %912 0
-OpStore %254 %914
-%915 = OpLoad %_arr_float_uint_5 %254
-OpStore %166 %915
-%916 = OpLoad %float %251
-%918 = OpFSub %float %916 %float_1_25
-OpStore %255 %918
-%919 = OpLoad %_arr_float_uint_5 %166
-OpStore %256 %919
-%920 = OpLoad %_arr_float_uint_5 %256
-%921 = OpLoad %float %255
-%922 = OpCompositeInsert %_arr_float_uint_5 %921 %920 1
-OpStore %257 %922
-%923 = OpLoad %_arr_float_uint_5 %257
-OpStore %166 %923
-%925 = OpLoad %float %251
-%926 = OpFSub %float %float_100 %925
-OpStore %258 %926
-%927 = OpLoad %_arr_float_uint_5 %166
-OpStore %259 %927
-%928 = OpLoad %_arr_float_uint_5 %259
-%929 = OpLoad %float %258
-%930 = OpCompositeInsert %_arr_float_uint_5 %929 %928 2
-OpStore %260 %930
-%931 = OpLoad %_arr_float_uint_5 %260
-OpStore %166 %931
-%932 = OpLoad %float %251
-%934 = OpFAdd %float %932 %float_7_5
-OpStore %261 %934
-%935 = OpLoad %_arr_float_uint_5 %166
-OpStore %262 %935
-%936 = OpLoad %_arr_float_uint_5 %262
-%937 = OpLoad %float %261
-%938 = OpCompositeInsert %_arr_float_uint_5 %937 %936 3
-OpStore %263 %938
-%939 = OpLoad %_arr_float_uint_5 %263
-OpStore %166 %939
-%941 = OpLoad %float %251
-%942 = OpFSub %float %float_0 %941
-OpStore %264 %942
-%943 = OpLoad %_arr_float_uint_5 %166
-OpStore %265 %943
-%944 = OpLoad %_arr_float_uint_5 %265
-%945 = OpLoad %float %264
-%946 = OpCompositeInsert %_arr_float_uint_5 %945 %944 4
-OpStore %266 %946
-%947 = OpLoad %_arr_float_uint_5 %266
-OpStore %166 %947
-%948 = OpLoad %_arr_float_uint_5 %166
-OpStore %267 %948
-%949 = OpLoad %ulong %293
-%950 = OpAccessChain %_ptr_Function__arr_float_uint_5 %179 %949
-%951 = OpLoad %_arr_float_uint_5 %267
-OpStore %950 %951
-%952 = OpLoad %ulong %293
-%953 = OpIAdd %ulong %952 %ulong_1
-OpStore %268 %953
-%954 = OpLoad %ulong %268
-OpStore %293 %954
-OpBranch %145
-%104 = OpLabel
-%955 = OpAccessChain %_ptr_Function__arr_v3float_uint_3 %176 %uint_1
-%956 = OpLoad %ulong %291
-%957 = OpAccessChain %_ptr_Function_v3float %955 %956
-%958 = OpLoad %v3float %957
-OpStore %237 %958
-OpBranch %118
-%118 = OpLabel
-%959 = OpLoad %v3float %237
-%960 = OpCompositeExtract %float %959 0
-OpStore %312 %960
-%961 = OpLoad %ulong %284
-%962 = OpLoad %float %312
-%963 = OpFunctionCall %ulong %7 %961 %962
-OpStore %313 %963
-%964 = OpLoad %v3float %237
-%965 = OpCompositeExtract %float %964 1
-OpStore %314 %965
-%966 = OpLoad %ulong %313
-%967 = OpLoad %float %314
-%968 = OpFunctionCall %ulong %7 %966 %967
-OpStore %315 %968
-%969 = OpLoad %v3float %237
-%970 = OpCompositeExtract %float %969 2
-OpStore %316 %970
-%971 = OpLoad %ulong %315
-%972 = OpLoad %float %316
-%973 = OpFunctionCall %ulong %7 %971 %972
-OpStore %317 %973
-OpBranch %119
-%119 = OpLabel
-%974 = OpLoad %ulong %291
-%975 = OpIAdd %ulong %974 %ulong_1
-OpStore %238 %975
-%976 = OpLoad %ulong %317
-OpStore %284 %976
-%977 = OpLoad %ulong %238
-OpStore %291 %977
-OpBranch %146
-%101 = OpLabel
-%978 = OpLoad %ulong %289
-%980 = OpAccessChain %_ptr_Function__struct_158 %162 %978
-%981 = OpAccessChain %_ptr_Function_v3float %980 %uint_0
-%982 = OpLoad %v3float %981
-OpStore %207 %982
-OpBranch %114
-%114 = OpLabel
-%983 = OpLoad %v3float %207
-%984 = OpCompositeExtract %float %983 0
-OpStore %300 %984
-%985 = OpLoad %ulong %285
-%986 = OpLoad %float %300
-%987 = OpFunctionCall %ulong %7 %985 %986
-OpStore %301 %987
-%988 = OpLoad %v3float %207
-%989 = OpCompositeExtract %float %988 1
-OpStore %302 %989
-%990 = OpLoad %ulong %301
-%991 = OpLoad %float %302
-%992 = OpFunctionCall %ulong %7 %990 %991
-OpStore %303 %992
-%993 = OpLoad %v3float %207
-%994 = OpCompositeExtract %float %993 2
-OpStore %304 %994
-%995 = OpLoad %ulong %303
-%996 = OpLoad %float %304
-%997 = OpFunctionCall %ulong %7 %995 %996
-OpStore %305 %997
-OpBranch %115
-%115 = OpLabel
-%998 = OpLoad %ulong %289
-%999 = OpAccessChain %_ptr_Function__struct_158 %162 %998
-%1000 = OpAccessChain %_ptr_Function_uint %999 %uint_1
-%1001 = OpLoad %uint %1000
-OpStore %208 %1001
-%1002 = OpLoad %ulong %305
-%1003 = OpLoad %uint %208
-%1004 = OpFunctionCall %ulong %6 %1002 %1003
-OpStore %209 %1004
-%1005 = OpLoad %ulong %289
-%1006 = OpIAdd %ulong %1005 %ulong_1
-OpStore %210 %1006
-%1007 = OpLoad %ulong %209
-OpStore %285 %1007
-%1008 = OpLoad %ulong %210
-OpStore %289 %1008
-OpBranch %147
-%98 = OpLabel
-%1009 = OpLoad %ulong %290
-%1010 = OpAccessChain %_ptr_Function_v3float %156 %1009
-%1011 = OpLoad %v3float %1010
-OpStore %201 %1011
-%1012 = OpLoad %ulong %290
-%1013 = OpAccessChain %_ptr_Function__struct_158 %162 %1012
-%1014 = OpAccessChain %_ptr_Function_v3float %1013 %uint_0
-%1015 = OpLoad %v3float %201
-OpStore %1014 %1015
-%1016 = OpLoad %ulong %290
-%1017 = OpUConvert %uint %1016
-OpStore %203 %1017
-%1019 = OpLoad %uint %203
-%1020 = OpISub %uint %uint_2863311530 %1019
-OpStore %204 %1020
-%1021 = OpAccessChain %_ptr_Function_uint %1013 %uint_1
-%1022 = OpLoad %uint %204
-OpStore %1021 %1022
-%1023 = OpLoad %ulong %290
-%1024 = OpIAdd %ulong %1023 %ulong_1
-OpStore %205 %1024
-%1025 = OpLoad %ulong %205
-OpStore %290 %1025
-OpBranch %148
-%95 = OpLabel
-%1026 = OpLoad %ulong %288
-%1027 = OpISub %ulong %1026 %ulong_1
-OpStore %198 %1027
-%1028 = OpLoad %ulong %198
-%1029 = OpAccessChain %_ptr_Function_v3float %156 %1028
-%1030 = OpLoad %v3float %1029
-OpStore %199 %1030
-OpBranch %112
-%112 = OpLabel
-%1031 = OpLoad %v3float %199
-%1032 = OpCompositeExtract %float %1031 0
-OpStore %294 %1032
-%1033 = OpLoad %ulong %286
-%1034 = OpLoad %float %294
-%1035 = OpFunctionCall %ulong %7 %1033 %1034
-OpStore %295 %1035
-%1036 = OpLoad %v3float %199
-%1037 = OpCompositeExtract %float %1036 1
-OpStore %296 %1037
-%1038 = OpLoad %ulong %295
-%1039 = OpLoad %float %296
-%1040 = OpFunctionCall %ulong %7 %1038 %1039
-OpStore %297 %1040
-%1041 = OpLoad %v3float %199
-%1042 = OpCompositeExtract %float %1041 2
-OpStore %298 %1042
-%1043 = OpLoad %ulong %297
-%1044 = OpLoad %float %298
-%1045 = OpFunctionCall %ulong %7 %1043 %1044
-OpStore %299 %1045
-OpBranch %113
-%113 = OpLabel
-%1046 = OpLoad %ulong %299
-OpStore %286 %1046
-%1047 = OpLoad %ulong %198
-OpStore %288 %1047
-OpBranch %149
-%92 = OpLabel
-%1048 = OpLoad %ulong %287
-%1049 = OpConvertUToF %float %1048
-OpStore %185 %1049
-OpStore %157 %1050
-%1051 = OpLoad %float %185
-%1052 = OpLoad %float %182
-%1053 = OpFAdd %float %1051 %1052
-OpStore %186 %1053
-%1054 = OpLoad %v3float %157
-OpStore %187 %1054
-%1055 = OpLoad %v3float %187
-%1056 = OpLoad %float %186
-%1057 = OpCompositeInsert %v3float %1056 %1055 0
-OpStore %188 %1057
-%1058 = OpLoad %v3float %188
-OpStore %157 %1058
-%1059 = OpLoad %float %185
-%1060 = OpFSub %float %1059 %float_1_25
-OpStore %189 %1060
-%1061 = OpLoad %v3float %157
-OpStore %190 %1061
-%1062 = OpLoad %v3float %190
-%1063 = OpLoad %float %189
-%1064 = OpCompositeInsert %v3float %1063 %1062 1
-OpStore %191 %1064
-%1065 = OpLoad %v3float %191
-OpStore %157 %1065
-%1066 = OpLoad %float %185
-%1067 = OpFSub %float %float_100 %1066
-OpStore %192 %1067
-%1068 = OpLoad %v3float %157
-OpStore %193 %1068
-%1069 = OpLoad %v3float %193
-%1070 = OpLoad %float %192
-%1071 = OpCompositeInsert %v3float %1070 %1069 2
-OpStore %194 %1071
-%1072 = OpLoad %v3float %194
-OpStore %157 %1072
-%1073 = OpLoad %v3float %157
-OpStore %195 %1073
-%1074 = OpLoad %ulong %287
-%1075 = OpAccessChain %_ptr_Function_v3float %156 %1074
-%1076 = OpLoad %v3float %195
-OpStore %1075 %1076
-%1077 = OpLoad %ulong %287
-%1078 = OpIAdd %ulong %1077 %ulong_1
-OpStore %196 %1078
-%1079 = OpLoad %ulong %196
-OpStore %287 %1079
-OpBranch %150
-%144 = OpLabel
-OpBranch %109
-%145 = OpLabel
-OpBranch %106
-%146 = OpLabel
-OpBranch %103
-%147 = OpLabel
-OpBranch %100
-%148 = OpLabel
-OpBranch %97
-%149 = OpLabel
-OpBranch %94
-%150 = OpLabel
-OpBranch %91
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+OpStore %211 %168
+OpStore %213 %169
+%274 = OpLoad %_arr_float_uint_5 %213
+%275 = OpCompositeExtract %float %274 0
+OpStore %214 %275
+OpBranch %171
+%171 = OpLabel
+%276 = OpLoad %float %214
+%277 = OpBitcast %uint %276
+OpStore %219 %277
+%278 = OpLoad %uint %219
+%279 = OpUConvert %ulong %278
+OpStore %220 %279
+OpBranch %173
+%173 = OpLabel
+%280 = OpLoad %ulong %211
+OpStore %228 %280
+OpStore %229 %ulong_0
+OpBranch %174
+%174 = OpLabel
+%281 = OpLoad %ulong %229
+%282 = OpULessThan %bool %281 %ulong_8
+OpStore %221 %282
+%283 = OpLoad %bool %221
+OpLoopMerge %176 %210 None
+OpBranchConditional %283 %175 %176
+%176 = OpLabel
+OpBranch %177
+%177 = OpLabel
+OpBranch %172
+%172 = OpLabel
+%284 = OpLoad %_arr_float_uint_5 %213
+%285 = OpCompositeExtract %float %284 1
+OpStore %215 %285
+OpBranch %178
+%178 = OpLabel
+%286 = OpLoad %float %215
+%287 = OpBitcast %uint %286
+OpStore %230 %287
+%288 = OpLoad %uint %230
+%289 = OpUConvert %ulong %288
+OpStore %231 %289
+OpBranch %180
+%180 = OpLabel
+%290 = OpLoad %ulong %228
+OpStore %239 %290
+OpStore %240 %ulong_0
+OpBranch %181
+%181 = OpLabel
+%291 = OpLoad %ulong %240
+%292 = OpULessThan %bool %291 %ulong_8
+OpStore %232 %292
+%293 = OpLoad %bool %232
+OpLoopMerge %183 %209 None
+OpBranchConditional %293 %182 %183
+%183 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %179
+%179 = OpLabel
+%294 = OpLoad %_arr_float_uint_5 %213
+%295 = OpCompositeExtract %float %294 2
+OpStore %216 %295
+OpBranch %185
+%185 = OpLabel
+%296 = OpLoad %float %216
+%297 = OpBitcast %uint %296
+OpStore %241 %297
+%298 = OpLoad %uint %241
+%299 = OpUConvert %ulong %298
+OpStore %242 %299
+OpBranch %187
+%187 = OpLabel
+%300 = OpLoad %ulong %239
+OpStore %250 %300
+OpStore %251 %ulong_0
+OpBranch %188
+%188 = OpLabel
+%301 = OpLoad %ulong %251
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %243 %302
+%303 = OpLoad %bool %243
+OpLoopMerge %190 %208 None
+OpBranchConditional %303 %189 %190
+%190 = OpLabel
+OpBranch %191
+%191 = OpLabel
+OpBranch %186
+%186 = OpLabel
+%304 = OpLoad %_arr_float_uint_5 %213
+%305 = OpCompositeExtract %float %304 3
+OpStore %217 %305
+OpBranch %192
+%192 = OpLabel
+%306 = OpLoad %float %217
+%307 = OpBitcast %uint %306
+OpStore %252 %307
+%308 = OpLoad %uint %252
+%309 = OpUConvert %ulong %308
+OpStore %253 %309
+OpBranch %194
+%194 = OpLabel
+%310 = OpLoad %ulong %250
+OpStore %261 %310
+OpStore %262 %ulong_0
+OpBranch %195
+%195 = OpLabel
+%311 = OpLoad %ulong %262
+%312 = OpULessThan %bool %311 %ulong_8
+OpStore %254 %312
+%313 = OpLoad %bool %254
+OpLoopMerge %197 %207 None
+OpBranchConditional %313 %196 %197
+%197 = OpLabel
+OpBranch %198
+%198 = OpLabel
+OpBranch %193
+%193 = OpLabel
+%314 = OpLoad %_arr_float_uint_5 %213
+%315 = OpCompositeExtract %float %314 4
+OpStore %218 %315
+OpBranch %199
+%199 = OpLabel
+%316 = OpLoad %float %218
+%317 = OpBitcast %uint %316
+OpStore %263 %317
+%318 = OpLoad %uint %263
+%319 = OpUConvert %ulong %318
+OpStore %264 %319
+OpBranch %201
+%201 = OpLabel
+%320 = OpLoad %ulong %261
+OpStore %272 %320
+OpStore %273 %ulong_0
+OpBranch %202
+%202 = OpLabel
+%321 = OpLoad %ulong %273
+%322 = OpULessThan %bool %321 %ulong_8
+OpStore %265 %322
+%323 = OpLoad %bool %265
+OpLoopMerge %204 %206 None
+OpBranchConditional %323 %203 %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+OpBranch %200
+%200 = OpLabel
+%324 = OpLoad %ulong %272
+OpReturnValue %324
+%203 = OpLabel
+%325 = OpLoad %ulong %273
+%326 = OpIMul %ulong %325 %ulong_8
+OpStore %266 %326
+%327 = OpLoad %ulong %264
+%328 = OpLoad %ulong %266
+%329 = OpShiftRightLogical %ulong %327 %328
+OpStore %267 %329
+%330 = OpLoad %ulong %267
+%331 = OpBitwiseAnd %ulong %330 %ulong_255
+OpStore %268 %331
+%332 = OpLoad %ulong %272
+%333 = OpLoad %ulong %268
+%334 = OpBitwiseXor %ulong %332 %333
+OpStore %269 %334
+%335 = OpLoad %ulong %269
+%336 = OpIMul %ulong %335 %ulong_1099511628211
+OpStore %270 %336
+%337 = OpLoad %ulong %273
+%338 = OpIAdd %ulong %337 %ulong_1
+OpStore %271 %338
+%339 = OpLoad %ulong %270
+OpStore %272 %339
+%340 = OpLoad %ulong %271
+OpStore %273 %340
+OpBranch %206
+%196 = OpLabel
+%341 = OpLoad %ulong %262
+%342 = OpIMul %ulong %341 %ulong_8
+OpStore %255 %342
+%343 = OpLoad %ulong %253
+%344 = OpLoad %ulong %255
+%345 = OpShiftRightLogical %ulong %343 %344
+OpStore %256 %345
+%346 = OpLoad %ulong %256
+%347 = OpBitwiseAnd %ulong %346 %ulong_255
+OpStore %257 %347
+%348 = OpLoad %ulong %261
+%349 = OpLoad %ulong %257
+%350 = OpBitwiseXor %ulong %348 %349
+OpStore %258 %350
+%351 = OpLoad %ulong %258
+%352 = OpIMul %ulong %351 %ulong_1099511628211
+OpStore %259 %352
+%353 = OpLoad %ulong %262
+%354 = OpIAdd %ulong %353 %ulong_1
+OpStore %260 %354
+%355 = OpLoad %ulong %259
+OpStore %261 %355
+%356 = OpLoad %ulong %260
+OpStore %262 %356
+OpBranch %207
+%189 = OpLabel
+%357 = OpLoad %ulong %251
+%358 = OpIMul %ulong %357 %ulong_8
+OpStore %244 %358
+%359 = OpLoad %ulong %242
+%360 = OpLoad %ulong %244
+%361 = OpShiftRightLogical %ulong %359 %360
+OpStore %245 %361
+%362 = OpLoad %ulong %245
+%363 = OpBitwiseAnd %ulong %362 %ulong_255
+OpStore %246 %363
+%364 = OpLoad %ulong %250
+%365 = OpLoad %ulong %246
+%366 = OpBitwiseXor %ulong %364 %365
+OpStore %247 %366
+%367 = OpLoad %ulong %247
+%368 = OpIMul %ulong %367 %ulong_1099511628211
+OpStore %248 %368
+%369 = OpLoad %ulong %251
+%370 = OpIAdd %ulong %369 %ulong_1
+OpStore %249 %370
+%371 = OpLoad %ulong %248
+OpStore %250 %371
+%372 = OpLoad %ulong %249
+OpStore %251 %372
+OpBranch %208
+%182 = OpLabel
+%373 = OpLoad %ulong %240
+%374 = OpIMul %ulong %373 %ulong_8
+OpStore %233 %374
+%375 = OpLoad %ulong %231
+%376 = OpLoad %ulong %233
+%377 = OpShiftRightLogical %ulong %375 %376
+OpStore %234 %377
+%378 = OpLoad %ulong %234
+%379 = OpBitwiseAnd %ulong %378 %ulong_255
+OpStore %235 %379
+%380 = OpLoad %ulong %239
+%381 = OpLoad %ulong %235
+%382 = OpBitwiseXor %ulong %380 %381
+OpStore %236 %382
+%383 = OpLoad %ulong %236
+%384 = OpIMul %ulong %383 %ulong_1099511628211
+OpStore %237 %384
+%385 = OpLoad %ulong %240
+%386 = OpIAdd %ulong %385 %ulong_1
+OpStore %238 %386
+%387 = OpLoad %ulong %237
+OpStore %239 %387
+%388 = OpLoad %ulong %238
+OpStore %240 %388
+OpBranch %209
+%175 = OpLabel
+%389 = OpLoad %ulong %229
+%390 = OpIMul %ulong %389 %ulong_8
+OpStore %222 %390
+%391 = OpLoad %ulong %220
+%392 = OpLoad %ulong %222
+%393 = OpShiftRightLogical %ulong %391 %392
+OpStore %223 %393
+%394 = OpLoad %ulong %223
+%395 = OpBitwiseAnd %ulong %394 %ulong_255
+OpStore %224 %395
+%396 = OpLoad %ulong %228
+%397 = OpLoad %ulong %224
+%398 = OpBitwiseXor %ulong %396 %397
+OpStore %225 %398
+%399 = OpLoad %ulong %225
+%400 = OpIMul %ulong %399 %ulong_1099511628211
+OpStore %226 %400
+%401 = OpLoad %ulong %229
+%402 = OpIAdd %ulong %401 %ulong_1
+OpStore %227 %402
+%403 = OpLoad %ulong %226
+OpStore %228 %403
+%404 = OpLoad %ulong %227
+OpStore %229 %404
+OpBranch %210
+%206 = OpLabel
+OpBranch %202
+%207 = OpLabel
+OpBranch %195
+%208 = OpLabel
+OpBranch %188
+%209 = OpLabel
+OpBranch %181
+%210 = OpLabel
+OpBranch %174
 OpFunctionEnd
-%4 = OpFunction %ulong None %1080
-%1081 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%3 = OpFunction %ulong None %405
+%406 = OpFunctionParameter %ulong
+%407 = OpLabel
+%509 = OpVariable %_ptr_Function_v3float Function
+%514 = OpVariable %_ptr_Function__arr__struct_510_uint_4 Function
+%517 = OpVariable %_ptr_Function__struct_515 Function
+%518 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%521 = OpVariable %_ptr_Function__struct_519 Function
+%525 = OpVariable %_ptr_Function__arr_v3float_uint_7 Function
+%528 = OpVariable %_ptr_Function__arr__arr_float_uint_5_uint_5 Function
+%529 = OpVariable %_ptr_Function__struct_515 Function
+%530 = OpVariable %_ptr_Function__struct_515 Function
+%535 = OpVariable %_ptr_Function__struct_533 Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_float Function
+%538 = OpVariable %_ptr_Function_bool Function
+%539 = OpVariable %_ptr_Function_float Function
+%540 = OpVariable %_ptr_Function_float Function
+%541 = OpVariable %_ptr_Function_v3float Function
+%542 = OpVariable %_ptr_Function_v3float Function
+%543 = OpVariable %_ptr_Function_float Function
+%544 = OpVariable %_ptr_Function_v3float Function
+%545 = OpVariable %_ptr_Function_v3float Function
+%546 = OpVariable %_ptr_Function_float Function
+%547 = OpVariable %_ptr_Function_v3float Function
+%548 = OpVariable %_ptr_Function_v3float Function
+%549 = OpVariable %_ptr_Function_v3float Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_bool Function
+%552 = OpVariable %_ptr_Function_ulong Function
+%553 = OpVariable %_ptr_Function_v3float Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_bool Function
+%556 = OpVariable %_ptr_Function_v3float Function
+%557 = OpVariable %_ptr_Function_uint Function
+%558 = OpVariable %_ptr_Function_uint Function
+%559 = OpVariable %_ptr_Function_ulong Function
+%560 = OpVariable %_ptr_Function_bool Function
+%561 = OpVariable %_ptr_Function_v3float Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_uint Function
+%564 = OpVariable %_ptr_Function_ulong Function
+%565 = OpVariable %_ptr_Function_v3float Function
+%567 = OpVariable %_ptr_Function_uchar Function
+%568 = OpVariable %_ptr_Function_v3float Function
+%569 = OpVariable %_ptr_Function_ulong Function
+%570 = OpVariable %_ptr_Function_uchar Function
+%571 = OpVariable %_ptr_Function_v3float Function
+%572 = OpVariable %_ptr_Function_v3float Function
+%573 = OpVariable %_ptr_Function_v3float Function
+%574 = OpVariable %_ptr_Function_uchar Function
+%575 = OpVariable %_ptr_Function_v3float Function
+%576 = OpVariable %_ptr_Function_ulong Function
+%577 = OpVariable %_ptr_Function_uchar Function
+%578 = OpVariable %_ptr_Function_uchar Function
+%579 = OpVariable %_ptr_Function_v3float Function
+%580 = OpVariable %_ptr_Function_ulong Function
+%581 = OpVariable %_ptr_Function_uchar Function
+%582 = OpVariable %_ptr_Function_v3float Function
+%583 = OpVariable %_ptr_Function_v3float Function
+%584 = OpVariable %_ptr_Function_v3float Function
+%585 = OpVariable %_ptr_Function_uint Function
+%586 = OpVariable %_ptr_Function_bool Function
+%587 = OpVariable %_ptr_Function_v3float Function
+%588 = OpVariable %_ptr_Function_ulong Function
+%589 = OpVariable %_ptr_Function_ulong Function
+%590 = OpVariable %_ptr_Function_uint Function
+%591 = OpVariable %_ptr_Function_v3float Function
+%592 = OpVariable %_ptr_Function_v3float Function
+%593 = OpVariable %_ptr_Function_v3float Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_ulong Function
+%596 = OpVariable %_ptr_Function_v3float Function
+%597 = OpVariable %_ptr_Function_v3float Function
+%598 = OpVariable %_ptr_Function_v3float Function
+%599 = OpVariable %_ptr_Function_v3float Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_v3float Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_v3float Function
+%604 = OpVariable %_ptr_Function_ulong Function
+%605 = OpVariable %_ptr_Function_bool Function
+%606 = OpVariable %_ptr_Function_float Function
+%607 = OpVariable %_ptr_Function_float Function
+%608 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%609 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%610 = OpVariable %_ptr_Function_float Function
+%611 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%612 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%613 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%615 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%616 = OpVariable %_ptr_Function_float Function
+%617 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%618 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%619 = OpVariable %_ptr_Function_float Function
+%620 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%621 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%622 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%623 = OpVariable %_ptr_Function_ulong Function
+%624 = OpVariable %_ptr_Function_bool Function
+%625 = OpVariable %_ptr_Function_ulong Function
+%626 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%627 = OpVariable %_ptr_Function_ulong Function
+%628 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%629 = OpVariable %_ptr_Function_uint Function
+%630 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_uint Function
+%633 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%634 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%635 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%636 = OpVariable %_ptr_Function_ulong Function
+%637 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%638 = OpVariable %_ptr_Function_ulong Function
+%639 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%640 = OpVariable %_ptr_Function_ulong Function
+%641 = OpVariable %_ptr_Function_ulong Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_ulong Function
+%644 = OpVariable %_ptr_Function_ulong Function
+%645 = OpVariable %_ptr_Function_ulong Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_ulong Function
+%648 = OpVariable %_ptr_Function_ulong Function
+%649 = OpVariable %_ptr_Function_ulong Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_ulong Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_ulong Function
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_bool Function
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_bool Function
+%666 = OpVariable %_ptr_Function_ulong Function
+%667 = OpVariable %_ptr_Function_ulong Function
+%668 = OpVariable %_ptr_Function_ulong Function
+%669 = OpVariable %_ptr_Function_ulong Function
+%670 = OpVariable %_ptr_Function_ulong Function
+%671 = OpVariable %_ptr_Function_ulong Function
+%672 = OpVariable %_ptr_Function_ulong Function
+%673 = OpVariable %_ptr_Function_ulong Function
+%674 = OpVariable %_ptr_Function_ulong Function
+%675 = OpVariable %_ptr_Function_bool Function
+%676 = OpVariable %_ptr_Function_ulong Function
+%677 = OpVariable %_ptr_Function_ulong Function
+%678 = OpVariable %_ptr_Function_ulong Function
+%679 = OpVariable %_ptr_Function_ulong Function
+%680 = OpVariable %_ptr_Function_ulong Function
+%681 = OpVariable %_ptr_Function_ulong Function
+%682 = OpVariable %_ptr_Function_ulong Function
+%683 = OpVariable %_ptr_Function_ulong Function
+%684 = OpVariable %_ptr_Function_bool Function
+%685 = OpVariable %_ptr_Function_ulong Function
+%686 = OpVariable %_ptr_Function_ulong Function
+%687 = OpVariable %_ptr_Function_ulong Function
+%688 = OpVariable %_ptr_Function_ulong Function
+%689 = OpVariable %_ptr_Function_ulong Function
+%690 = OpVariable %_ptr_Function_ulong Function
+%691 = OpVariable %_ptr_Function_ulong Function
+%692 = OpVariable %_ptr_Function_ulong Function
+%693 = OpVariable %_ptr_Function_ulong Function
+%694 = OpVariable %_ptr_Function_bool Function
+%695 = OpVariable %_ptr_Function_ulong Function
+%696 = OpVariable %_ptr_Function_ulong Function
+%697 = OpVariable %_ptr_Function_ulong Function
+%698 = OpVariable %_ptr_Function_ulong Function
+%699 = OpVariable %_ptr_Function_ulong Function
+%700 = OpVariable %_ptr_Function_ulong Function
+%701 = OpVariable %_ptr_Function_ulong Function
+%702 = OpVariable %_ptr_Function_ulong Function
+%703 = OpVariable %_ptr_Function_ulong Function
+%704 = OpVariable %_ptr_Function_bool Function
+%705 = OpVariable %_ptr_Function_ulong Function
+%706 = OpVariable %_ptr_Function_ulong Function
+%707 = OpVariable %_ptr_Function_ulong Function
+%708 = OpVariable %_ptr_Function_ulong Function
+%709 = OpVariable %_ptr_Function_ulong Function
+%710 = OpVariable %_ptr_Function_ulong Function
+%711 = OpVariable %_ptr_Function_ulong Function
+%712 = OpVariable %_ptr_Function_ulong Function
+%713 = OpVariable %_ptr_Function_bool Function
+%714 = OpVariable %_ptr_Function_ulong Function
+%715 = OpVariable %_ptr_Function_ulong Function
+%716 = OpVariable %_ptr_Function_ulong Function
+%717 = OpVariable %_ptr_Function_ulong Function
+%718 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_ulong Function
+%720 = OpVariable %_ptr_Function_ulong Function
+%721 = OpVariable %_ptr_Function_ulong Function
+%722 = OpVariable %_ptr_Function_ulong Function
+%723 = OpVariable %_ptr_Function_bool Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_ulong Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_ulong Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_float Function
+%739 = OpVariable %_ptr_Function_float Function
+%740 = OpVariable %_ptr_Function_float Function
+%741 = OpVariable %_ptr_Function_float Function
+%742 = OpVariable %_ptr_Function_float Function
+%743 = OpVariable %_ptr_Function_float Function
+%744 = OpVariable %_ptr_Function_float Function
+%745 = OpVariable %_ptr_Function_float Function
+%746 = OpVariable %_ptr_Function_float Function
+%747 = OpVariable %_ptr_Function_float Function
+%748 = OpVariable %_ptr_Function_float Function
+%749 = OpVariable %_ptr_Function_float Function
+%750 = OpVariable %_ptr_Function_float Function
+%751 = OpVariable %_ptr_Function_float Function
+%752 = OpVariable %_ptr_Function_float Function
+%753 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%754 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%755 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%756 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+%757 = OpVariable %_ptr_Function__arr_float_uint_5 Function
+OpStore %536 %406
+OpBranch %429
+%429 = OpLabel
+OpBranch %430
+%430 = OpLabel
+%758 = OpLoad %ulong %536
+%759 = OpConvertUToF %float %758
+OpStore %537 %759
+OpStore %525 %760
+OpStore %645 %ulong_0
+OpBranch %408
+%408 = OpLabel
+%761 = OpLoad %ulong %645
+%763 = OpULessThan %bool %761 %ulong_7
+OpStore %538 %763
+%764 = OpLoad %bool %538
+OpLoopMerge %410 %507 None
+OpBranchConditional %764 %409 %410
+%410 = OpLabel
+OpStore %644 %ulong_14695981039346656037
+OpStore %646 %ulong_7
+OpBranch %411
+%411 = OpLabel
+%766 = OpLoad %ulong %646
+%767 = OpULessThan %bool %ulong_0 %766
+OpStore %551 %767
+%768 = OpLoad %bool %551
+OpLoopMerge %413 %506 None
+OpBranchConditional %768 %412 %413
+%413 = OpLabel
+OpStore %514 %769
+OpStore %648 %ulong_0
+OpBranch %414
+%414 = OpLabel
+%770 = OpLoad %ulong %648
+%772 = OpULessThan %bool %770 %ulong_4
+OpStore %555 %772
+%773 = OpLoad %bool %555
+OpLoopMerge %416 %505 None
+OpBranchConditional %773 %415 %416
+%416 = OpLabel
+%774 = OpLoad %ulong %644
+OpStore %643 %774
+OpStore %647 %ulong_0
+OpBranch %417
+%417 = OpLabel
+%775 = OpLoad %ulong %647
+%776 = OpULessThan %bool %775 %ulong_4
+OpStore %560 %776
+%777 = OpLoad %bool %560
+OpLoopMerge %419 %504 None
+OpBranchConditional %777 %418 %419
+%419 = OpLabel
+OpStore %517 %778
+%780 = OpAccessChain %_ptr_Function_uchar %517 %uint_0
+OpStore %780 %uchar_219
+%782 = OpAccessChain %_ptr_Function_v3float %525 %uint_5
+%783 = OpLoad %v3float %782
+OpStore %565 %783
+%785 = OpAccessChain %_ptr_Function_v3float %517 %uint_1
+%786 = OpLoad %v3float %565
+OpStore %785 %786
+%788 = OpAccessChain %_ptr_Function_uchar %517 %uint_2
+OpStore %788 %uchar_173
+%790 = OpLoad %uchar %780
+OpStore %567 %790
+OpBranch %433
+%433 = OpLabel
+%791 = OpLoad %uchar %567
+%792 = OpUConvert %ulong %791
+OpStore %653 %792
+OpBranch %444
+%444 = OpLabel
+%793 = OpLoad %ulong %643
+OpStore %672 %793
+OpStore %673 %ulong_0
+OpBranch %445
+%445 = OpLabel
+%794 = OpLoad %ulong %673
+%795 = OpULessThan %bool %794 %ulong_8
+OpStore %665 %795
+%796 = OpLoad %bool %665
+OpLoopMerge %447 %503 None
+OpBranchConditional %796 %446 %447
+%447 = OpLabel
+OpBranch %448
+%448 = OpLabel
+OpBranch %434
+%434 = OpLabel
+%797 = OpAccessChain %_ptr_Function_v3float %517 %uint_1
+%798 = OpLoad %v3float %797
+OpStore %568 %798
+%799 = OpLoad %ulong %672
+%800 = OpLoad %v3float %568
+%801 = OpFunctionCall %ulong %1 %799 %800
+OpStore %569 %801
+%802 = OpAccessChain %_ptr_Function_uchar %517 %uint_2
+%803 = OpLoad %uchar %802
+OpStore %570 %803
+OpBranch %449
+%449 = OpLabel
+%804 = OpLoad %uchar %570
+%805 = OpUConvert %ulong %804
+OpStore %674 %805
+OpBranch %463
+%463 = OpLabel
+%806 = OpLoad %ulong %569
+OpStore %701 %806
+OpStore %702 %ulong_0
+OpBranch %464
+%464 = OpLabel
+%807 = OpLoad %ulong %702
+%808 = OpULessThan %bool %807 %ulong_8
+OpStore %694 %808
+%809 = OpLoad %bool %694
+OpLoopMerge %466 %501 None
+OpBranchConditional %809 %465 %466
+%466 = OpLabel
+OpBranch %467
+%467 = OpLabel
+OpBranch %450
+%450 = OpLabel
+%810 = OpLoad %_struct_515 %517
+OpStore %530 %810
+%811 = OpLoad %_struct_515 %530
+OpStore %529 %811
+%812 = OpAccessChain %_ptr_Function_v3float %529 %uint_1
+%813 = OpLoad %v3float %812
+OpStore %571 %813
+%814 = OpAccessChain %_ptr_Function_v3float %525 %uint_1
+%815 = OpLoad %v3float %814
+OpStore %572 %815
+%816 = OpLoad %v3float %571
+%817 = OpLoad %v3float %572
+%818 = OpFAdd %v3float %816 %817
+OpStore %573 %818
+%819 = OpLoad %v3float %573
+OpStore %812 %819
+%820 = OpAccessChain %_ptr_Function_uchar %529 %uint_0
+%821 = OpLoad %uchar %820
+OpStore %574 %821
+OpBranch %468
+%468 = OpLabel
+%822 = OpLoad %uchar %574
+%823 = OpUConvert %ulong %822
+OpStore %703 %823
+OpBranch %475
+%475 = OpLabel
+%824 = OpLoad %ulong %701
+OpStore %720 %824
+OpStore %721 %ulong_0
+OpBranch %476
+%476 = OpLabel
+%825 = OpLoad %ulong %721
+%826 = OpULessThan %bool %825 %ulong_8
+OpStore %713 %826
+%827 = OpLoad %bool %713
+OpLoopMerge %478 %500 None
+OpBranchConditional %827 %477 %478
+%478 = OpLabel
+OpBranch %479
+%479 = OpLabel
+OpBranch %469
+%469 = OpLabel
+%828 = OpAccessChain %_ptr_Function_v3float %529 %uint_1
+%829 = OpLoad %v3float %828
+OpStore %575 %829
+%830 = OpLoad %ulong %720
+%831 = OpLoad %v3float %575
+%832 = OpFunctionCall %ulong %1 %830 %831
+OpStore %576 %832
+%833 = OpAccessChain %_ptr_Function_uchar %529 %uint_2
+%834 = OpLoad %uchar %833
+OpStore %577 %834
+OpBranch %480
+%480 = OpLabel
+%835 = OpLoad %uchar %577
+%836 = OpUConvert %ulong %835
+OpStore %722 %836
+OpBranch %482
+%482 = OpLabel
+%837 = OpLoad %ulong %576
+OpStore %730 %837
+OpStore %731 %ulong_0
+OpBranch %483
+%483 = OpLabel
+%838 = OpLoad %ulong %731
+%839 = OpULessThan %bool %838 %ulong_8
+OpStore %723 %839
+%840 = OpLoad %bool %723
+OpLoopMerge %485 %499 None
+OpBranchConditional %840 %484 %485
+%485 = OpLabel
+OpBranch %486
+%486 = OpLabel
+OpBranch %481
+%481 = OpLabel
+%841 = OpAccessChain %_ptr_Function_uchar %517 %uint_0
+%842 = OpLoad %uchar %841
+OpStore %578 %842
+OpBranch %487
+%487 = OpLabel
+%843 = OpLoad %uchar %578
+%844 = OpUConvert %ulong %843
+OpStore %732 %844
+%845 = OpLoad %ulong %730
+%846 = OpLoad %ulong %732
+%847 = OpFunctionCall %ulong %4 %845 %846
+OpStore %733 %847
+OpBranch %488
+%488 = OpLabel
+%848 = OpAccessChain %_ptr_Function_v3float %517 %uint_1
+%849 = OpLoad %v3float %848
+OpStore %579 %849
+%850 = OpLoad %ulong %733
+%851 = OpLoad %v3float %579
+%852 = OpFunctionCall %ulong %1 %850 %851
+OpStore %580 %852
+%853 = OpAccessChain %_ptr_Function_uchar %517 %uint_2
+%854 = OpLoad %uchar %853
+OpStore %581 %854
+OpBranch %489
+%489 = OpLabel
+%855 = OpLoad %uchar %581
+%856 = OpUConvert %ulong %855
+OpStore %734 %856
+%857 = OpLoad %ulong %580
+%858 = OpLoad %ulong %734
+%859 = OpFunctionCall %ulong %4 %857 %858
+OpStore %735 %859
+OpBranch %490
+%490 = OpLabel
+OpStore %535 %860
+%861 = OpAccessChain %_ptr_Function_uint %535 %uint_0
+OpStore %861 %uint_4294967295
+%863 = OpAccessChain %_ptr_Function_v3float %525 %uint_0
+%864 = OpLoad %v3float %863
+OpStore %582 %864
+%866 = OpAccessChain %_ptr_Function__arr_v3float_uint_3 %535 %uint_1
+%867 = OpAccessChain %_ptr_Function_v3float %866 %uint_0
+%868 = OpLoad %v3float %582
+OpStore %867 %868
+%869 = OpAccessChain %_ptr_Function_v3float %525 %uint_3
+%870 = OpLoad %v3float %869
+OpStore %583 %870
+%871 = OpAccessChain %_ptr_Function_v3float %866 %uint_1
+%872 = OpLoad %v3float %583
+OpStore %871 %872
+%874 = OpAccessChain %_ptr_Function_v3float %525 %uint_6
+%875 = OpLoad %v3float %874
+OpStore %584 %875
+%876 = OpAccessChain %_ptr_Function_v3float %866 %uint_2
+%877 = OpLoad %v3float %584
+OpStore %876 %877
+%878 = OpAccessChain %_ptr_Function_uint %535 %uint_2
+OpStore %878 %uint_305419896
+%880 = OpLoad %uint %861
+OpStore %585 %880
+OpBranch %491
+%491 = OpLabel
+%881 = OpLoad %uint %585
+%882 = OpUConvert %ulong %881
+OpStore %736 %882
+%883 = OpLoad %ulong %735
+%884 = OpLoad %ulong %736
+%885 = OpFunctionCall %ulong %4 %883 %884
+OpStore %737 %885
+OpBranch %492
+%492 = OpLabel
+%886 = OpLoad %ulong %737
+OpStore %642 %886
+OpStore %649 %ulong_0
+OpBranch %420
+%420 = OpLabel
+%887 = OpLoad %ulong %649
+%889 = OpULessThan %bool %887 %ulong_3
+OpStore %586 %889
+%890 = OpLoad %bool %586
+OpLoopMerge %422 %498 None
+OpBranchConditional %890 %421 %422
+%422 = OpLabel
+%891 = OpAccessChain %_ptr_Function_uint %535 %uint_2
+%892 = OpLoad %uint %891
+OpStore %590 %892
+OpBranch %435
+%435 = OpLabel
+%893 = OpLoad %uint %590
+%894 = OpUConvert %ulong %893
+OpStore %654 %894
+OpBranch %451
+%451 = OpLabel
+%895 = OpLoad %ulong %642
+OpStore %682 %895
+OpStore %683 %ulong_0
+OpBranch %452
+%452 = OpLabel
+%896 = OpLoad %ulong %683
+%897 = OpULessThan %bool %896 %ulong_8
+OpStore %675 %897
+%898 = OpLoad %bool %675
+OpLoopMerge %454 %497 None
+OpBranchConditional %898 %453 %454
+%454 = OpLabel
+OpBranch %455
+%455 = OpLabel
+OpBranch %436
+%436 = OpLabel
+%899 = OpAccessChain %_ptr_Function_v3float %525 %uint_2
+%900 = OpLoad %v3float %899
+OpStore %591 %900
+%901 = OpAccessChain %_ptr_Function_v3float %525 %uint_4
+%902 = OpLoad %v3float %901
+OpStore %592 %902
+%903 = OpLoad %v3float %591
+%904 = OpLoad %v3float %592
+%905 = OpFAdd %v3float %903 %904
+OpStore %593 %905
+%906 = OpLoad %ulong %682
+%907 = OpLoad %v3float %593
+%908 = OpFunctionCall %ulong %1 %906 %907
+OpStore %594 %908
+%909 = OpLoad %ulong %594
+%910 = OpLoad %v3float %593
+%911 = OpFunctionCall %ulong %1 %909 %910
+OpStore %595 %911
+%912 = OpAccessChain %_ptr_Function_v3float %525 %uint_3
+%913 = OpLoad %v3float %912
+OpStore %596 %913
+%914 = OpCompositeConstruct %v3float %float_2 %float_4 %float_8
+OpStore %597 %914
+%918 = OpLoad %v3float %596
+%919 = OpLoad %v3float %597
+%920 = OpFMul %v3float %918 %919
+OpStore %598 %920
+%921 = OpLoad %v3float %598
+OpStore %912 %921
+%922 = OpLoad %v3float %899
+OpStore %599 %922
+%923 = OpLoad %ulong %595
+%924 = OpLoad %v3float %599
+%925 = OpFunctionCall %ulong %1 %923 %924
+OpStore %600 %925
+%926 = OpLoad %v3float %912
+OpStore %601 %926
+%927 = OpLoad %ulong %600
+%928 = OpLoad %v3float %601
+%929 = OpFunctionCall %ulong %1 %927 %928
+OpStore %602 %929
+%930 = OpLoad %v3float %901
+OpStore %603 %930
+%931 = OpLoad %ulong %602
+%932 = OpLoad %v3float %603
+%933 = OpFunctionCall %ulong %1 %931 %932
+OpStore %604 %933
+OpStore %528 %934
+OpStore %651 %ulong_0
+OpBranch %423
+%423 = OpLabel
+%935 = OpLoad %ulong %651
+%937 = OpULessThan %bool %935 %ulong_5
+OpStore %605 %937
+%938 = OpLoad %bool %605
+OpLoopMerge %425 %496 None
+OpBranchConditional %938 %424 %425
+%425 = OpLabel
+%939 = OpLoad %ulong %604
+OpStore %641 %939
+OpStore %650 %ulong_5
+OpBranch %426
+%426 = OpLabel
+%940 = OpLoad %ulong %650
+%941 = OpULessThan %bool %ulong_0 %940
+OpStore %624 %941
+%942 = OpLoad %bool %624
+OpLoopMerge %428 %495 None
+OpBranchConditional %942 %427 %428
+%428 = OpLabel
+OpStore %521 %943
+%944 = OpAccessChain %_ptr_Function_uint %521 %uint_0
+OpStore %944 %uint_4294967295
+%945 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %uint_3
+%946 = OpLoad %_arr_float_uint_5 %945
+OpStore %628 %946
+%947 = OpAccessChain %_ptr_Function__arr_float_uint_5 %521 %uint_1
+%948 = OpLoad %_arr_float_uint_5 %628
+OpStore %947 %948
+%949 = OpAccessChain %_ptr_Function_uint %521 %uint_2
+OpStore %949 %uint_305419896
+%950 = OpLoad %uint %944
+OpStore %629 %950
+OpBranch %437
+%437 = OpLabel
+%951 = OpLoad %uint %629
+%952 = OpUConvert %ulong %951
+OpStore %655 %952
+OpBranch %456
+%456 = OpLabel
+%953 = OpLoad %ulong %641
+OpStore %691 %953
+OpStore %692 %ulong_0
+OpBranch %457
+%457 = OpLabel
+%954 = OpLoad %ulong %692
+%955 = OpULessThan %bool %954 %ulong_8
+OpStore %684 %955
+%956 = OpLoad %bool %684
+OpLoopMerge %459 %494 None
+OpBranchConditional %956 %458 %459
+%459 = OpLabel
+OpBranch %460
+%460 = OpLabel
+OpBranch %438
+%438 = OpLabel
+%957 = OpAccessChain %_ptr_Function__arr_float_uint_5 %521 %uint_1
+%958 = OpLoad %_arr_float_uint_5 %957
+OpStore %630 %958
+%959 = OpLoad %ulong %691
+%960 = OpLoad %_arr_float_uint_5 %630
+%961 = OpFunctionCall %ulong %2 %959 %960
+OpStore %631 %961
+%962 = OpAccessChain %_ptr_Function_uint %521 %uint_2
+%963 = OpLoad %uint %962
+OpStore %632 %963
+OpBranch %461
+%461 = OpLabel
+%964 = OpLoad %uint %632
+%965 = OpUConvert %ulong %964
+OpStore %693 %965
+OpBranch %470
+%470 = OpLabel
+%966 = OpLoad %ulong %631
+OpStore %711 %966
+OpStore %712 %ulong_0
+OpBranch %471
+%471 = OpLabel
+%967 = OpLoad %ulong %712
+%968 = OpULessThan %bool %967 %ulong_8
+OpStore %704 %968
+%969 = OpLoad %bool %704
+OpLoopMerge %473 %493 None
+OpBranchConditional %969 %472 %473
+%473 = OpLabel
+OpBranch %474
+%474 = OpLabel
+OpBranch %462
+%462 = OpLabel
+%970 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %uint_1
+%971 = OpLoad %_arr_float_uint_5 %970
+OpStore %633 %971
+%972 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %uint_4
+%973 = OpLoad %_arr_float_uint_5 %972
+OpStore %634 %973
+%974 = OpLoad %_arr_float_uint_5 %633
+%975 = OpCompositeExtract %float %974 0
+OpStore %738 %975
+%976 = OpLoad %_arr_float_uint_5 %634
+%977 = OpCompositeExtract %float %976 0
+OpStore %739 %977
+%978 = OpLoad %float %738
+%979 = OpLoad %float %739
+%980 = OpFAdd %float %978 %979
+OpStore %740 %980
+%981 = OpLoad %_arr_float_uint_5 %633
+%982 = OpCompositeExtract %float %981 1
+OpStore %741 %982
+%983 = OpLoad %_arr_float_uint_5 %634
+%984 = OpCompositeExtract %float %983 1
+OpStore %742 %984
+%985 = OpLoad %float %741
+%986 = OpLoad %float %742
+%987 = OpFAdd %float %985 %986
+OpStore %743 %987
+%988 = OpLoad %_arr_float_uint_5 %633
+%989 = OpCompositeExtract %float %988 2
+OpStore %744 %989
+%990 = OpLoad %_arr_float_uint_5 %634
+%991 = OpCompositeExtract %float %990 2
+OpStore %745 %991
+%992 = OpLoad %float %744
+%993 = OpLoad %float %745
+%994 = OpFAdd %float %992 %993
+OpStore %746 %994
+%995 = OpLoad %_arr_float_uint_5 %633
+%996 = OpCompositeExtract %float %995 3
+OpStore %747 %996
+%997 = OpLoad %_arr_float_uint_5 %634
+%998 = OpCompositeExtract %float %997 3
+OpStore %748 %998
+%999 = OpLoad %float %747
+%1000 = OpLoad %float %748
+%1001 = OpFAdd %float %999 %1000
+OpStore %749 %1001
+%1002 = OpLoad %_arr_float_uint_5 %633
+%1003 = OpCompositeExtract %float %1002 4
+OpStore %750 %1003
+%1004 = OpLoad %_arr_float_uint_5 %634
+%1005 = OpCompositeExtract %float %1004 4
+OpStore %751 %1005
+%1006 = OpLoad %float %750
+%1007 = OpLoad %float %751
+%1008 = OpFAdd %float %1006 %1007
+OpStore %752 %1008
+%1009 = OpLoad %_arr_float_uint_5 %633
+%1010 = OpLoad %float %740
+%1011 = OpCompositeInsert %_arr_float_uint_5 %1010 %1009 0
+OpStore %753 %1011
+%1012 = OpLoad %_arr_float_uint_5 %753
+%1013 = OpLoad %float %743
+%1014 = OpCompositeInsert %_arr_float_uint_5 %1013 %1012 1
+OpStore %754 %1014
+%1015 = OpLoad %_arr_float_uint_5 %754
+%1016 = OpLoad %float %746
+%1017 = OpCompositeInsert %_arr_float_uint_5 %1016 %1015 2
+OpStore %755 %1017
+%1018 = OpLoad %_arr_float_uint_5 %755
+%1019 = OpLoad %float %749
+%1020 = OpCompositeInsert %_arr_float_uint_5 %1019 %1018 3
+OpStore %756 %1020
+%1021 = OpLoad %_arr_float_uint_5 %756
+%1022 = OpLoad %float %752
+%1023 = OpCompositeInsert %_arr_float_uint_5 %1022 %1021 4
+OpStore %757 %1023
+%1024 = OpLoad %_arr_float_uint_5 %757
+OpStore %970 %1024
+%1025 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %uint_0
+%1026 = OpLoad %_arr_float_uint_5 %1025
+OpStore %635 %1026
+%1027 = OpLoad %ulong %711
+%1028 = OpLoad %_arr_float_uint_5 %635
+%1029 = OpFunctionCall %ulong %2 %1027 %1028
+OpStore %636 %1029
+%1030 = OpLoad %_arr_float_uint_5 %970
+OpStore %637 %1030
+%1031 = OpLoad %ulong %636
+%1032 = OpLoad %_arr_float_uint_5 %637
+%1033 = OpFunctionCall %ulong %2 %1031 %1032
+OpStore %638 %1033
+%1034 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %uint_2
+%1035 = OpLoad %_arr_float_uint_5 %1034
+OpStore %639 %1035
+%1036 = OpLoad %ulong %638
+%1037 = OpLoad %_arr_float_uint_5 %639
+%1038 = OpFunctionCall %ulong %2 %1036 %1037
+OpStore %640 %1038
+%1039 = OpLoad %ulong %640
+OpReturnValue %1039
+%472 = OpLabel
+%1040 = OpLoad %ulong %712
+%1041 = OpIMul %ulong %1040 %ulong_8
+OpStore %705 %1041
+%1042 = OpLoad %ulong %693
+%1043 = OpLoad %ulong %705
+%1044 = OpShiftRightLogical %ulong %1042 %1043
+OpStore %706 %1044
+%1045 = OpLoad %ulong %706
+%1046 = OpBitwiseAnd %ulong %1045 %ulong_255
+OpStore %707 %1046
+%1047 = OpLoad %ulong %711
+%1048 = OpLoad %ulong %707
+%1049 = OpBitwiseXor %ulong %1047 %1048
+OpStore %708 %1049
+%1050 = OpLoad %ulong %708
+%1051 = OpIMul %ulong %1050 %ulong_1099511628211
+OpStore %709 %1051
+%1052 = OpLoad %ulong %712
+%1053 = OpIAdd %ulong %1052 %ulong_1
+OpStore %710 %1053
+%1054 = OpLoad %ulong %709
+OpStore %711 %1054
+%1055 = OpLoad %ulong %710
+OpStore %712 %1055
+OpBranch %493
+%458 = OpLabel
+%1056 = OpLoad %ulong %692
+%1057 = OpIMul %ulong %1056 %ulong_8
+OpStore %685 %1057
+%1058 = OpLoad %ulong %655
+%1059 = OpLoad %ulong %685
+%1060 = OpShiftRightLogical %ulong %1058 %1059
+OpStore %686 %1060
+%1061 = OpLoad %ulong %686
+%1062 = OpBitwiseAnd %ulong %1061 %ulong_255
+OpStore %687 %1062
+%1063 = OpLoad %ulong %691
+%1064 = OpLoad %ulong %687
+%1065 = OpBitwiseXor %ulong %1063 %1064
+OpStore %688 %1065
+%1066 = OpLoad %ulong %688
+%1067 = OpIMul %ulong %1066 %ulong_1099511628211
+OpStore %689 %1067
+%1068 = OpLoad %ulong %692
+%1069 = OpIAdd %ulong %1068 %ulong_1
+OpStore %690 %1069
+%1070 = OpLoad %ulong %689
+OpStore %691 %1070
+%1071 = OpLoad %ulong %690
+OpStore %692 %1071
+OpBranch %494
+%427 = OpLabel
+%1072 = OpLoad %ulong %650
+%1073 = OpISub %ulong %1072 %ulong_1
+OpStore %625 %1073
+%1074 = OpLoad %ulong %625
+%1075 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %1074
+%1076 = OpLoad %_arr_float_uint_5 %1075
+OpStore %626 %1076
+%1077 = OpLoad %ulong %641
+%1078 = OpLoad %_arr_float_uint_5 %626
+%1079 = OpFunctionCall %ulong %2 %1077 %1078
+OpStore %627 %1079
+%1080 = OpLoad %ulong %627
+OpStore %641 %1080
+%1081 = OpLoad %ulong %625
+OpStore %650 %1081
+OpBranch %495
+%424 = OpLabel
+%1082 = OpLoad %ulong %651
+%1083 = OpConvertUToF %float %1082
+OpStore %606 %1083
+OpStore %518 %1084
+%1085 = OpLoad %float %606
+%1086 = OpLoad %float %537
+%1087 = OpFAdd %float %1085 %1086
+OpStore %607 %1087
+%1088 = OpLoad %_arr_float_uint_5 %518
+OpStore %608 %1088
+%1089 = OpLoad %_arr_float_uint_5 %608
+%1090 = OpLoad %float %607
+%1091 = OpCompositeInsert %_arr_float_uint_5 %1090 %1089 0
+OpStore %609 %1091
+%1092 = OpLoad %_arr_float_uint_5 %609
+OpStore %518 %1092
+%1093 = OpLoad %float %606
+%1095 = OpFSub %float %1093 %float_1_25
+OpStore %610 %1095
+%1096 = OpLoad %_arr_float_uint_5 %518
+OpStore %611 %1096
+%1097 = OpLoad %_arr_float_uint_5 %611
+%1098 = OpLoad %float %610
+%1099 = OpCompositeInsert %_arr_float_uint_5 %1098 %1097 1
+OpStore %612 %1099
+%1100 = OpLoad %_arr_float_uint_5 %612
+OpStore %518 %1100
+%1102 = OpLoad %float %606
+%1103 = OpFSub %float %float_100 %1102
+OpStore %613 %1103
+%1104 = OpLoad %_arr_float_uint_5 %518
+OpStore %614 %1104
+%1105 = OpLoad %_arr_float_uint_5 %614
+%1106 = OpLoad %float %613
+%1107 = OpCompositeInsert %_arr_float_uint_5 %1106 %1105 2
+OpStore %615 %1107
+%1108 = OpLoad %_arr_float_uint_5 %615
+OpStore %518 %1108
+%1109 = OpLoad %float %606
+%1111 = OpFAdd %float %1109 %float_7_5
+OpStore %616 %1111
+%1112 = OpLoad %_arr_float_uint_5 %518
+OpStore %617 %1112
+%1113 = OpLoad %_arr_float_uint_5 %617
+%1114 = OpLoad %float %616
+%1115 = OpCompositeInsert %_arr_float_uint_5 %1114 %1113 3
+OpStore %618 %1115
+%1116 = OpLoad %_arr_float_uint_5 %618
+OpStore %518 %1116
+%1118 = OpLoad %float %606
+%1119 = OpFSub %float %float_0 %1118
+OpStore %619 %1119
+%1120 = OpLoad %_arr_float_uint_5 %518
+OpStore %620 %1120
+%1121 = OpLoad %_arr_float_uint_5 %620
+%1122 = OpLoad %float %619
+%1123 = OpCompositeInsert %_arr_float_uint_5 %1122 %1121 4
+OpStore %621 %1123
+%1124 = OpLoad %_arr_float_uint_5 %621
+OpStore %518 %1124
+%1125 = OpLoad %_arr_float_uint_5 %518
+OpStore %622 %1125
+%1126 = OpLoad %ulong %651
+%1127 = OpAccessChain %_ptr_Function__arr_float_uint_5 %528 %1126
+%1128 = OpLoad %_arr_float_uint_5 %622
+OpStore %1127 %1128
+%1129 = OpLoad %ulong %651
+%1130 = OpIAdd %ulong %1129 %ulong_1
+OpStore %623 %1130
+%1131 = OpLoad %ulong %623
+OpStore %651 %1131
+OpBranch %496
+%453 = OpLabel
+%1132 = OpLoad %ulong %683
+%1133 = OpIMul %ulong %1132 %ulong_8
+OpStore %676 %1133
+%1134 = OpLoad %ulong %654
+%1135 = OpLoad %ulong %676
+%1136 = OpShiftRightLogical %ulong %1134 %1135
+OpStore %677 %1136
+%1137 = OpLoad %ulong %677
+%1138 = OpBitwiseAnd %ulong %1137 %ulong_255
+OpStore %678 %1138
+%1139 = OpLoad %ulong %682
+%1140 = OpLoad %ulong %678
+%1141 = OpBitwiseXor %ulong %1139 %1140
+OpStore %679 %1141
+%1142 = OpLoad %ulong %679
+%1143 = OpIMul %ulong %1142 %ulong_1099511628211
+OpStore %680 %1143
+%1144 = OpLoad %ulong %683
+%1145 = OpIAdd %ulong %1144 %ulong_1
+OpStore %681 %1145
+%1146 = OpLoad %ulong %680
+OpStore %682 %1146
+%1147 = OpLoad %ulong %681
+OpStore %683 %1147
+OpBranch %497
+%421 = OpLabel
+%1148 = OpAccessChain %_ptr_Function__arr_v3float_uint_3 %535 %uint_1
+%1149 = OpLoad %ulong %649
+%1150 = OpAccessChain %_ptr_Function_v3float %1148 %1149
+%1151 = OpLoad %v3float %1150
+OpStore %587 %1151
+%1152 = OpLoad %ulong %642
+%1153 = OpLoad %v3float %587
+%1154 = OpFunctionCall %ulong %1 %1152 %1153
+OpStore %588 %1154
+%1155 = OpLoad %ulong %649
+%1156 = OpIAdd %ulong %1155 %ulong_1
+OpStore %589 %1156
+%1157 = OpLoad %ulong %588
+OpStore %642 %1157
+%1158 = OpLoad %ulong %589
+OpStore %649 %1158
+OpBranch %498
+%484 = OpLabel
+%1159 = OpLoad %ulong %731
+%1160 = OpIMul %ulong %1159 %ulong_8
+OpStore %724 %1160
+%1161 = OpLoad %ulong %722
+%1162 = OpLoad %ulong %724
+%1163 = OpShiftRightLogical %ulong %1161 %1162
+OpStore %725 %1163
+%1164 = OpLoad %ulong %725
+%1165 = OpBitwiseAnd %ulong %1164 %ulong_255
+OpStore %726 %1165
+%1166 = OpLoad %ulong %730
+%1167 = OpLoad %ulong %726
+%1168 = OpBitwiseXor %ulong %1166 %1167
+OpStore %727 %1168
+%1169 = OpLoad %ulong %727
+%1170 = OpIMul %ulong %1169 %ulong_1099511628211
+OpStore %728 %1170
+%1171 = OpLoad %ulong %731
+%1172 = OpIAdd %ulong %1171 %ulong_1
+OpStore %729 %1172
+%1173 = OpLoad %ulong %728
+OpStore %730 %1173
+%1174 = OpLoad %ulong %729
+OpStore %731 %1174
+OpBranch %499
+%477 = OpLabel
+%1175 = OpLoad %ulong %721
+%1176 = OpIMul %ulong %1175 %ulong_8
+OpStore %714 %1176
+%1177 = OpLoad %ulong %703
+%1178 = OpLoad %ulong %714
+%1179 = OpShiftRightLogical %ulong %1177 %1178
+OpStore %715 %1179
+%1180 = OpLoad %ulong %715
+%1181 = OpBitwiseAnd %ulong %1180 %ulong_255
+OpStore %716 %1181
+%1182 = OpLoad %ulong %720
+%1183 = OpLoad %ulong %716
+%1184 = OpBitwiseXor %ulong %1182 %1183
+OpStore %717 %1184
+%1185 = OpLoad %ulong %717
+%1186 = OpIMul %ulong %1185 %ulong_1099511628211
+OpStore %718 %1186
+%1187 = OpLoad %ulong %721
+%1188 = OpIAdd %ulong %1187 %ulong_1
+OpStore %719 %1188
+%1189 = OpLoad %ulong %718
+OpStore %720 %1189
+%1190 = OpLoad %ulong %719
+OpStore %721 %1190
+OpBranch %500
+%465 = OpLabel
+%1191 = OpLoad %ulong %702
+%1192 = OpIMul %ulong %1191 %ulong_8
+OpStore %695 %1192
+%1193 = OpLoad %ulong %674
+%1194 = OpLoad %ulong %695
+%1195 = OpShiftRightLogical %ulong %1193 %1194
+OpStore %696 %1195
+%1196 = OpLoad %ulong %696
+%1197 = OpBitwiseAnd %ulong %1196 %ulong_255
+OpStore %697 %1197
+%1198 = OpLoad %ulong %701
+%1199 = OpLoad %ulong %697
+%1200 = OpBitwiseXor %ulong %1198 %1199
+OpStore %698 %1200
+%1201 = OpLoad %ulong %698
+%1202 = OpIMul %ulong %1201 %ulong_1099511628211
+OpStore %699 %1202
+%1203 = OpLoad %ulong %702
+%1204 = OpIAdd %ulong %1203 %ulong_1
+OpStore %700 %1204
+%1205 = OpLoad %ulong %699
+OpStore %701 %1205
+%1206 = OpLoad %ulong %700
+OpStore %702 %1206
+OpBranch %501
+%446 = OpLabel
+%1207 = OpLoad %ulong %673
+%1208 = OpIMul %ulong %1207 %ulong_8
+OpStore %666 %1208
+%1209 = OpLoad %ulong %653
+%1210 = OpLoad %ulong %666
+%1211 = OpShiftRightLogical %ulong %1209 %1210
+OpStore %667 %1211
+%1212 = OpLoad %ulong %667
+%1213 = OpBitwiseAnd %ulong %1212 %ulong_255
+OpStore %668 %1213
+%1214 = OpLoad %ulong %672
+%1215 = OpLoad %ulong %668
+%1216 = OpBitwiseXor %ulong %1214 %1215
+OpStore %669 %1216
+%1217 = OpLoad %ulong %669
+%1218 = OpIMul %ulong %1217 %ulong_1099511628211
+OpStore %670 %1218
+%1219 = OpLoad %ulong %673
+%1220 = OpIAdd %ulong %1219 %ulong_1
+OpStore %671 %1220
+%1221 = OpLoad %ulong %670
+OpStore %672 %1221
+%1222 = OpLoad %ulong %671
+OpStore %673 %1222
+OpBranch %503
+%418 = OpLabel
+%1223 = OpLoad %ulong %647
+%1225 = OpAccessChain %_ptr_Function__struct_510 %514 %1223
+%1226 = OpAccessChain %_ptr_Function_v3float %1225 %uint_0
+%1227 = OpLoad %v3float %1226
+OpStore %561 %1227
+%1228 = OpLoad %ulong %643
+%1229 = OpLoad %v3float %561
+%1230 = OpFunctionCall %ulong %1 %1228 %1229
+OpStore %562 %1230
+%1231 = OpAccessChain %_ptr_Function_uint %1225 %uint_1
+%1232 = OpLoad %uint %1231
+OpStore %563 %1232
+OpBranch %431
+%431 = OpLabel
+%1233 = OpLoad %uint %563
+%1234 = OpUConvert %ulong %1233
+OpStore %652 %1234
+OpBranch %439
+%439 = OpLabel
+%1235 = OpLoad %ulong %562
+OpStore %663 %1235
+OpStore %664 %ulong_0
+OpBranch %440
+%440 = OpLabel
+%1236 = OpLoad %ulong %664
+%1237 = OpULessThan %bool %1236 %ulong_8
+OpStore %656 %1237
+%1238 = OpLoad %bool %656
+OpLoopMerge %442 %502 None
+OpBranchConditional %1238 %441 %442
+%442 = OpLabel
+OpBranch %443
+%443 = OpLabel
+OpBranch %432
+%432 = OpLabel
+%1239 = OpLoad %ulong %647
+%1240 = OpIAdd %ulong %1239 %ulong_1
+OpStore %564 %1240
+%1241 = OpLoad %ulong %663
+OpStore %643 %1241
+%1242 = OpLoad %ulong %564
+OpStore %647 %1242
+OpBranch %504
+%441 = OpLabel
+%1243 = OpLoad %ulong %664
+%1244 = OpIMul %ulong %1243 %ulong_8
+OpStore %657 %1244
+%1245 = OpLoad %ulong %652
+%1246 = OpLoad %ulong %657
+%1247 = OpShiftRightLogical %ulong %1245 %1246
+OpStore %658 %1247
+%1248 = OpLoad %ulong %658
+%1249 = OpBitwiseAnd %ulong %1248 %ulong_255
+OpStore %659 %1249
+%1250 = OpLoad %ulong %663
+%1251 = OpLoad %ulong %659
+%1252 = OpBitwiseXor %ulong %1250 %1251
+OpStore %660 %1252
+%1253 = OpLoad %ulong %660
+%1254 = OpIMul %ulong %1253 %ulong_1099511628211
+OpStore %661 %1254
+%1255 = OpLoad %ulong %664
+%1256 = OpIAdd %ulong %1255 %ulong_1
+OpStore %662 %1256
+%1257 = OpLoad %ulong %661
+OpStore %663 %1257
+%1258 = OpLoad %ulong %662
+OpStore %664 %1258
+OpBranch %502
+%415 = OpLabel
+%1259 = OpLoad %ulong %648
+%1260 = OpAccessChain %_ptr_Function_v3float %525 %1259
+%1261 = OpLoad %v3float %1260
+OpStore %556 %1261
+%1262 = OpLoad %ulong %648
+%1263 = OpAccessChain %_ptr_Function__struct_510 %514 %1262
+%1264 = OpAccessChain %_ptr_Function_v3float %1263 %uint_0
+%1265 = OpLoad %v3float %556
+OpStore %1264 %1265
+%1266 = OpLoad %ulong %648
+%1267 = OpUConvert %uint %1266
+OpStore %557 %1267
+%1269 = OpLoad %uint %557
+%1270 = OpISub %uint %uint_2863311530 %1269
+OpStore %558 %1270
+%1271 = OpAccessChain %_ptr_Function_uint %1263 %uint_1
+%1272 = OpLoad %uint %558
+OpStore %1271 %1272
+%1273 = OpLoad %ulong %648
+%1274 = OpIAdd %ulong %1273 %ulong_1
+OpStore %559 %1274
+%1275 = OpLoad %ulong %559
+OpStore %648 %1275
+OpBranch %505
+%412 = OpLabel
+%1276 = OpLoad %ulong %646
+%1277 = OpISub %ulong %1276 %ulong_1
+OpStore %552 %1277
+%1278 = OpLoad %ulong %552
+%1279 = OpAccessChain %_ptr_Function_v3float %525 %1278
+%1280 = OpLoad %v3float %1279
+OpStore %553 %1280
+%1281 = OpLoad %ulong %644
+%1282 = OpLoad %v3float %553
+%1283 = OpFunctionCall %ulong %1 %1281 %1282
+OpStore %554 %1283
+%1284 = OpLoad %ulong %554
+OpStore %644 %1284
+%1285 = OpLoad %ulong %552
+OpStore %646 %1285
+OpBranch %506
+%409 = OpLabel
+%1286 = OpLoad %ulong %645
+%1287 = OpConvertUToF %float %1286
+OpStore %539 %1287
+OpStore %509 %1288
+%1289 = OpLoad %float %539
+%1290 = OpLoad %float %537
+%1291 = OpFAdd %float %1289 %1290
+OpStore %540 %1291
+%1292 = OpLoad %v3float %509
+OpStore %541 %1292
+%1293 = OpLoad %v3float %541
+%1294 = OpLoad %float %540
+%1295 = OpCompositeInsert %v3float %1294 %1293 0
+OpStore %542 %1295
+%1296 = OpLoad %v3float %542
+OpStore %509 %1296
+%1297 = OpLoad %float %539
+%1298 = OpFSub %float %1297 %float_1_25
+OpStore %543 %1298
+%1299 = OpLoad %v3float %509
+OpStore %544 %1299
+%1300 = OpLoad %v3float %544
+%1301 = OpLoad %float %543
+%1302 = OpCompositeInsert %v3float %1301 %1300 1
+OpStore %545 %1302
+%1303 = OpLoad %v3float %545
+OpStore %509 %1303
+%1304 = OpLoad %float %539
+%1305 = OpFSub %float %float_100 %1304
+OpStore %546 %1305
+%1306 = OpLoad %v3float %509
+OpStore %547 %1306
+%1307 = OpLoad %v3float %547
+%1308 = OpLoad %float %546
+%1309 = OpCompositeInsert %v3float %1308 %1307 2
+OpStore %548 %1309
+%1310 = OpLoad %v3float %548
+OpStore %509 %1310
+%1311 = OpLoad %v3float %509
+OpStore %549 %1311
+%1312 = OpLoad %ulong %645
+%1313 = OpAccessChain %_ptr_Function_v3float %525 %1312
+%1314 = OpLoad %v3float %549
+OpStore %1313 %1314
+%1315 = OpLoad %ulong %645
+%1316 = OpIAdd %ulong %1315 %ulong_1
+OpStore %550 %1316
+%1317 = OpLoad %ulong %550
+OpStore %645 %1317
+OpBranch %507
+%493 = OpLabel
+OpBranch %471
+%494 = OpLabel
+OpBranch %457
+%495 = OpLabel
+OpBranch %426
+%496 = OpLabel
+OpBranch %423
+%497 = OpLabel
+OpBranch %452
+%498 = OpLabel
+OpBranch %420
+%499 = OpLabel
+OpBranch %483
+%500 = OpLabel
+OpBranch %476
+%501 = OpLabel
+OpBranch %464
+%502 = OpLabel
+OpBranch %440
+%503 = OpLabel
+OpBranch %445
+%504 = OpLabel
+OpBranch %417
+%505 = OpLabel
+OpBranch %414
+%506 = OpLabel
+OpBranch %411
+%507 = OpLabel
+OpBranch %408
 OpFunctionEnd
-%5 = OpFunction %ulong None %1083
-%1084 = OpFunctionParameter %ulong
-%1085 = OpFunctionParameter %uchar
-%1086 = OpLabel
-%1093 = OpVariable %_ptr_Function_ulong Function
-%1094 = OpVariable %_ptr_Function_uchar Function
-%1095 = OpVariable %_ptr_Function_ulong Function
-%1096 = OpVariable %_ptr_Function_bool Function
-%1097 = OpVariable %_ptr_Function_ulong Function
-%1098 = OpVariable %_ptr_Function_ulong Function
-%1099 = OpVariable %_ptr_Function_ulong Function
-%1100 = OpVariable %_ptr_Function_ulong Function
-%1101 = OpVariable %_ptr_Function_ulong Function
-%1102 = OpVariable %_ptr_Function_ulong Function
-%1103 = OpVariable %_ptr_Function_ulong Function
-%1104 = OpVariable %_ptr_Function_ulong Function
-OpStore %1093 %1084
-OpStore %1094 %1085
-%1105 = OpLoad %uchar %1094
-%1106 = OpUConvert %ulong %1105
-OpStore %1095 %1106
-OpBranch %1087
-%1087 = OpLabel
-%1107 = OpLoad %ulong %1093
-OpStore %1103 %1107
-OpStore %1104 %ulong_0
-OpBranch %1088
-%1088 = OpLabel
-%1108 = OpLoad %ulong %1104
-%1110 = OpULessThan %bool %1108 %ulong_8
-OpStore %1096 %1110
-%1111 = OpLoad %bool %1096
-OpLoopMerge %1090 %1092 None
-OpBranchConditional %1111 %1089 %1090
-%1090 = OpLabel
-OpBranch %1091
-%1091 = OpLabel
-%1112 = OpLoad %ulong %1103
-OpReturnValue %1112
-%1089 = OpLabel
-%1113 = OpLoad %ulong %1104
-%1114 = OpIMul %ulong %1113 %ulong_8
-OpStore %1097 %1114
-%1115 = OpLoad %ulong %1095
-%1116 = OpLoad %ulong %1097
-%1117 = OpShiftRightLogical %ulong %1115 %1116
-OpStore %1098 %1117
-%1118 = OpLoad %ulong %1098
-%1120 = OpBitwiseAnd %ulong %1118 %ulong_255
-OpStore %1099 %1120
-%1121 = OpLoad %ulong %1103
-%1122 = OpLoad %ulong %1099
-%1123 = OpBitwiseXor %ulong %1121 %1122
-OpStore %1100 %1123
-%1124 = OpLoad %ulong %1100
-%1126 = OpIMul %ulong %1124 %ulong_1099511628211
-OpStore %1101 %1126
-%1127 = OpLoad %ulong %1104
-%1128 = OpIAdd %ulong %1127 %ulong_1
-OpStore %1102 %1128
-%1129 = OpLoad %ulong %1101
-OpStore %1103 %1129
-%1130 = OpLoad %ulong %1102
-OpStore %1104 %1130
-OpBranch %1092
-%1092 = OpLabel
-OpBranch %1088
-OpFunctionEnd
-%6 = OpFunction %ulong None %1131
-%1132 = OpFunctionParameter %ulong
-%1133 = OpFunctionParameter %uint
-%1134 = OpLabel
-%1141 = OpVariable %_ptr_Function_ulong Function
-%1142 = OpVariable %_ptr_Function_uint Function
-%1143 = OpVariable %_ptr_Function_ulong Function
-%1144 = OpVariable %_ptr_Function_bool Function
-%1145 = OpVariable %_ptr_Function_ulong Function
-%1146 = OpVariable %_ptr_Function_ulong Function
-%1147 = OpVariable %_ptr_Function_ulong Function
-%1148 = OpVariable %_ptr_Function_ulong Function
-%1149 = OpVariable %_ptr_Function_ulong Function
-%1150 = OpVariable %_ptr_Function_ulong Function
-%1151 = OpVariable %_ptr_Function_ulong Function
-%1152 = OpVariable %_ptr_Function_ulong Function
-OpStore %1141 %1132
-OpStore %1142 %1133
-%1153 = OpLoad %uint %1142
-%1154 = OpUConvert %ulong %1153
-OpStore %1143 %1154
-OpBranch %1135
-%1135 = OpLabel
-%1155 = OpLoad %ulong %1141
-OpStore %1151 %1155
-OpStore %1152 %ulong_0
-OpBranch %1136
-%1136 = OpLabel
-%1156 = OpLoad %ulong %1152
-%1157 = OpULessThan %bool %1156 %ulong_8
-OpStore %1144 %1157
-%1158 = OpLoad %bool %1144
-OpLoopMerge %1138 %1140 None
-OpBranchConditional %1158 %1137 %1138
-%1138 = OpLabel
-OpBranch %1139
-%1139 = OpLabel
-%1159 = OpLoad %ulong %1151
-OpReturnValue %1159
-%1137 = OpLabel
-%1160 = OpLoad %ulong %1152
-%1161 = OpIMul %ulong %1160 %ulong_8
-OpStore %1145 %1161
-%1162 = OpLoad %ulong %1143
-%1163 = OpLoad %ulong %1145
-%1164 = OpShiftRightLogical %ulong %1162 %1163
-OpStore %1146 %1164
-%1165 = OpLoad %ulong %1146
-%1166 = OpBitwiseAnd %ulong %1165 %ulong_255
-OpStore %1147 %1166
-%1167 = OpLoad %ulong %1151
-%1168 = OpLoad %ulong %1147
-%1169 = OpBitwiseXor %ulong %1167 %1168
-OpStore %1148 %1169
-%1170 = OpLoad %ulong %1148
-%1171 = OpIMul %ulong %1170 %ulong_1099511628211
-OpStore %1149 %1171
-%1172 = OpLoad %ulong %1152
-%1173 = OpIAdd %ulong %1172 %ulong_1
-OpStore %1150 %1173
-%1174 = OpLoad %ulong %1149
-OpStore %1151 %1174
-%1175 = OpLoad %ulong %1150
-OpStore %1152 %1175
-OpBranch %1140
-%1140 = OpLabel
-OpBranch %1136
-OpFunctionEnd
-%7 = OpFunction %ulong None %1176
-%1177 = OpFunctionParameter %ulong
-%1178 = OpFunctionParameter %float
-%1179 = OpLabel
-%1186 = OpVariable %_ptr_Function_ulong Function
-%1187 = OpVariable %_ptr_Function_float Function
-%1188 = OpVariable %_ptr_Function_uint Function
-%1189 = OpVariable %_ptr_Function_ulong Function
-%1190 = OpVariable %_ptr_Function_bool Function
-%1191 = OpVariable %_ptr_Function_ulong Function
-%1192 = OpVariable %_ptr_Function_ulong Function
-%1193 = OpVariable %_ptr_Function_ulong Function
-%1194 = OpVariable %_ptr_Function_ulong Function
-%1195 = OpVariable %_ptr_Function_ulong Function
-%1196 = OpVariable %_ptr_Function_ulong Function
-%1197 = OpVariable %_ptr_Function_ulong Function
-%1198 = OpVariable %_ptr_Function_ulong Function
-OpStore %1186 %1177
-OpStore %1187 %1178
-%1199 = OpLoad %float %1187
-%1200 = OpBitcast %uint %1199
-OpStore %1188 %1200
-%1201 = OpLoad %uint %1188
-%1202 = OpUConvert %ulong %1201
-OpStore %1189 %1202
-OpBranch %1180
-%1180 = OpLabel
-%1203 = OpLoad %ulong %1186
-OpStore %1197 %1203
-OpStore %1198 %ulong_0
-OpBranch %1181
-%1181 = OpLabel
-%1204 = OpLoad %ulong %1198
-%1205 = OpULessThan %bool %1204 %ulong_8
-OpStore %1190 %1205
-%1206 = OpLoad %bool %1190
-OpLoopMerge %1183 %1185 None
-OpBranchConditional %1206 %1182 %1183
-%1183 = OpLabel
-OpBranch %1184
-%1184 = OpLabel
-%1207 = OpLoad %ulong %1197
-OpReturnValue %1207
-%1182 = OpLabel
-%1208 = OpLoad %ulong %1198
-%1209 = OpIMul %ulong %1208 %ulong_8
-OpStore %1191 %1209
-%1210 = OpLoad %ulong %1189
-%1211 = OpLoad %ulong %1191
-%1212 = OpShiftRightLogical %ulong %1210 %1211
-OpStore %1192 %1212
-%1213 = OpLoad %ulong %1192
-%1214 = OpBitwiseAnd %ulong %1213 %ulong_255
-OpStore %1193 %1214
-%1215 = OpLoad %ulong %1197
-%1216 = OpLoad %ulong %1193
-%1217 = OpBitwiseXor %ulong %1215 %1216
-OpStore %1194 %1217
-%1218 = OpLoad %ulong %1194
-%1219 = OpIMul %ulong %1218 %ulong_1099511628211
-OpStore %1195 %1219
-%1220 = OpLoad %ulong %1198
-%1221 = OpIAdd %ulong %1220 %ulong_1
-OpStore %1196 %1221
-%1222 = OpLoad %ulong %1195
-OpStore %1197 %1222
-%1223 = OpLoad %ulong %1196
-OpStore %1198 %1223
-OpBranch %1185
-%1185 = OpLabel
-OpBranch %1181
+%4 = OpFunction %ulong None %1318
+%1319 = OpFunctionParameter %ulong
+%1320 = OpFunctionParameter %ulong
+%1321 = OpLabel
+%1326 = OpVariable %_ptr_Function_ulong Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_bool Function
+%1329 = OpVariable %_ptr_Function_ulong Function
+%1330 = OpVariable %_ptr_Function_ulong Function
+%1331 = OpVariable %_ptr_Function_ulong Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_ulong Function
+%1334 = OpVariable %_ptr_Function_ulong Function
+%1335 = OpVariable %_ptr_Function_ulong Function
+%1336 = OpVariable %_ptr_Function_ulong Function
+OpStore %1326 %1319
+OpStore %1327 %1320
+%1337 = OpLoad %ulong %1326
+OpStore %1335 %1337
+OpStore %1336 %ulong_0
+OpBranch %1322
+%1322 = OpLabel
+%1338 = OpLoad %ulong %1336
+%1339 = OpULessThan %bool %1338 %ulong_8
+OpStore %1328 %1339
+%1340 = OpLoad %bool %1328
+OpLoopMerge %1324 %1325 None
+OpBranchConditional %1340 %1323 %1324
+%1324 = OpLabel
+%1341 = OpLoad %ulong %1335
+OpReturnValue %1341
+%1323 = OpLabel
+%1342 = OpLoad %ulong %1336
+%1343 = OpIMul %ulong %1342 %ulong_8
+OpStore %1329 %1343
+%1344 = OpLoad %ulong %1327
+%1345 = OpLoad %ulong %1329
+%1346 = OpShiftRightLogical %ulong %1344 %1345
+OpStore %1330 %1346
+%1347 = OpLoad %ulong %1330
+%1348 = OpBitwiseAnd %ulong %1347 %ulong_255
+OpStore %1331 %1348
+%1349 = OpLoad %ulong %1335
+%1350 = OpLoad %ulong %1331
+%1351 = OpBitwiseXor %ulong %1349 %1350
+OpStore %1332 %1351
+%1352 = OpLoad %ulong %1332
+%1353 = OpIMul %ulong %1352 %ulong_1099511628211
+OpStore %1333 %1353
+%1354 = OpLoad %ulong %1336
+%1355 = OpIAdd %ulong %1354 %ulong_1
+OpStore %1334 %1355
+%1356 = OpLoad %ulong %1333
+OpStore %1335 %1356
+%1357 = OpLoad %ulong %1334
+OpStore %1336 %1357
+OpBranch %1325
+%1325 = OpLabel
+OpBranch %1322
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_scalar_mix.dis
+++ b/test/golden/spirv/vec/vec_scalar_mix.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1200
+; Bound: 1526
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -14,18 +14,23 @@ OpDecorate %4 LinkageAttributes "corpus.cases.vec.vec_scalar_mix.checksum" Expor
 %ulong = OpTypeInt 64 0
 %float = OpTypeFloat 32
 %v4float = OpTypeVector %float 4
-%12 = OpTypeFunction %ulong %ulong %v4float
+%9 = OpTypeFunction %ulong %ulong %v4float
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4float = OpTypePointer Function %v4float
 %_ptr_Function_float = OpTypePointer Function %float
-%uint = OpTypeInt 32 0
-%v4uint = OpTypeVector %uint 4
-%52 = OpTypeFunction %ulong %ulong %v4uint
-%_ptr_Function_v4uint = OpTypePointer Function %v4uint
 %_ptr_Function_uint = OpTypePointer Function %uint
-%123 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
 %_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%v4uint = OpTypeVector %uint 4
+%213 = OpTypeFunction %ulong %ulong %v4uint
+%_ptr_Function_v4uint = OpTypePointer Function %v4uint
+%571 = OpTypeFunction %ulong %ulong
 %float_2_25 = OpConstant %float 2.25
 %float_0_5 = OpConstant %float 0.5
 %float_1_5 = OpConstant %float 1.5
@@ -33,1617 +38,2168 @@ OpDecorate %4 LinkageAttributes "corpus.cases.vec.vec_scalar_mix.checksum" Expor
 %float_0_125 = OpConstant %float 0.125
 %float_4 = OpConstant %float 4
 %float_8 = OpConstant %float 8
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %float_0 = OpConstant %float 0
 %uint_7 = OpConstant %uint 7
 %uint_4294967283 = OpConstant %uint 4294967283
 %uint_21 = OpConstant %uint 21
 %uint_4294967265 = OpConstant %uint 4294967265
-%676 = OpConstantNull %v4float
-%758 = OpConstantNull %v4uint
+%1165 = OpConstantNull %v4float
+%1213 = OpConstantNull %v4uint
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_1 = OpConstant %uint 1
 %uint_2863311530 = OpConstant %uint 2863311530
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_0 = OpConstant %ulong 0
 %ulong_4 = OpConstant %ulong 4
 %float_1_25 = OpConstant %float 1.25
-%ulong_1 = OpConstant %ulong 1
-%1057 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1060 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1152 = OpTypeFunction %ulong %ulong %float
-%1 = OpFunction %ulong None %12
-%13 = OpFunctionParameter %ulong
-%14 = OpFunctionParameter %v4float
-%15 = OpLabel
-%17 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_v4float Function
-%21 = OpVariable %_ptr_Function_float Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_float Function
-%24 = OpVariable %_ptr_Function_ulong Function
-%25 = OpVariable %_ptr_Function_float Function
-%26 = OpVariable %_ptr_Function_ulong Function
-%27 = OpVariable %_ptr_Function_float Function
-%28 = OpVariable %_ptr_Function_ulong Function
-OpStore %17 %13
-OpStore %19 %14
-%29 = OpLoad %v4float %19
-%30 = OpCompositeExtract %float %29 0
-OpStore %21 %30
-%31 = OpLoad %ulong %17
-%32 = OpLoad %float %21
-%33 = OpFunctionCall %ulong %8 %31 %32
-OpStore %22 %33
-%34 = OpLoad %v4float %19
-%35 = OpCompositeExtract %float %34 1
-OpStore %23 %35
-%36 = OpLoad %ulong %22
-%37 = OpLoad %float %23
-%38 = OpFunctionCall %ulong %8 %36 %37
-OpStore %24 %38
-%39 = OpLoad %v4float %19
-%40 = OpCompositeExtract %float %39 2
-OpStore %25 %40
-%41 = OpLoad %ulong %24
-%42 = OpLoad %float %25
-%43 = OpFunctionCall %ulong %8 %41 %42
-OpStore %26 %43
-%44 = OpLoad %v4float %19
-%45 = OpCompositeExtract %float %44 3
-OpStore %27 %45
-%46 = OpLoad %ulong %26
-%47 = OpLoad %float %27
-%48 = OpFunctionCall %ulong %8 %46 %47
-OpStore %28 %48
-%49 = OpLoad %ulong %28
-OpReturnValue %49
-OpFunctionEnd
-%2 = OpFunction %ulong None %52
-%53 = OpFunctionParameter %ulong
-%54 = OpFunctionParameter %v4uint
-%55 = OpLabel
-%56 = OpVariable %_ptr_Function_ulong Function
-%58 = OpVariable %_ptr_Function_v4uint Function
-%60 = OpVariable %_ptr_Function_uint Function
+%1486 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %v4float
+%12 = OpLabel
+%48 = OpVariable %_ptr_Function_ulong Function
+%50 = OpVariable %_ptr_Function_v4float Function
+%52 = OpVariable %_ptr_Function_float Function
+%53 = OpVariable %_ptr_Function_float Function
+%54 = OpVariable %_ptr_Function_float Function
+%55 = OpVariable %_ptr_Function_float Function
+%57 = OpVariable %_ptr_Function_uint Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_bool Function
 %61 = OpVariable %_ptr_Function_ulong Function
-%62 = OpVariable %_ptr_Function_uint Function
+%62 = OpVariable %_ptr_Function_ulong Function
 %63 = OpVariable %_ptr_Function_ulong Function
-%64 = OpVariable %_ptr_Function_uint Function
+%64 = OpVariable %_ptr_Function_ulong Function
 %65 = OpVariable %_ptr_Function_ulong Function
-%66 = OpVariable %_ptr_Function_uint Function
+%66 = OpVariable %_ptr_Function_ulong Function
 %67 = OpVariable %_ptr_Function_ulong Function
-OpStore %56 %53
-OpStore %58 %54
-%68 = OpLoad %v4uint %58
-%69 = OpCompositeExtract %uint %68 0
-OpStore %60 %69
-%70 = OpLoad %ulong %56
-%71 = OpLoad %uint %60
-%72 = OpFunctionCall %ulong %7 %70 %71
-OpStore %61 %72
-%73 = OpLoad %v4uint %58
-%74 = OpCompositeExtract %uint %73 1
-OpStore %62 %74
-%75 = OpLoad %ulong %61
-%76 = OpLoad %uint %62
-%77 = OpFunctionCall %ulong %7 %75 %76
-OpStore %63 %77
-%78 = OpLoad %v4uint %58
-%79 = OpCompositeExtract %uint %78 2
-OpStore %64 %79
-%80 = OpLoad %ulong %63
-%81 = OpLoad %uint %64
-%82 = OpFunctionCall %ulong %7 %80 %81
-OpStore %65 %82
-%83 = OpLoad %v4uint %58
-%84 = OpCompositeExtract %uint %83 3
-OpStore %66 %84
-%85 = OpLoad %ulong %65
-%86 = OpLoad %uint %66
-%87 = OpFunctionCall %ulong %7 %85 %86
-OpStore %67 %87
-%88 = OpLoad %ulong %67
-OpReturnValue %88
-OpFunctionEnd
-%3 = OpFunction %ulong None %52
-%89 = OpFunctionParameter %ulong
-%90 = OpFunctionParameter %v4uint
-%91 = OpLabel
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_uint Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_bool Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_ulong Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_uint Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_bool Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_ulong Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_uint Function
 %92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_v4uint Function
-%94 = OpVariable %_ptr_Function_uint Function
+%93 = OpVariable %_ptr_Function_bool Function
+%94 = OpVariable %_ptr_Function_ulong Function
 %95 = OpVariable %_ptr_Function_ulong Function
-%96 = OpVariable %_ptr_Function_uint Function
+%96 = OpVariable %_ptr_Function_ulong Function
 %97 = OpVariable %_ptr_Function_ulong Function
-%98 = OpVariable %_ptr_Function_uint Function
+%98 = OpVariable %_ptr_Function_ulong Function
 %99 = OpVariable %_ptr_Function_ulong Function
-%100 = OpVariable %_ptr_Function_uint Function
+%100 = OpVariable %_ptr_Function_ulong Function
 %101 = OpVariable %_ptr_Function_ulong Function
-OpStore %92 %89
-OpStore %93 %90
-%102 = OpLoad %v4uint %93
-%103 = OpCompositeExtract %uint %102 0
-OpStore %94 %103
-%104 = OpLoad %ulong %92
-%105 = OpLoad %uint %94
-%106 = OpFunctionCall %ulong %6 %104 %105
-OpStore %95 %106
-%107 = OpLoad %v4uint %93
-%108 = OpCompositeExtract %uint %107 1
-OpStore %96 %108
-%109 = OpLoad %ulong %95
-%110 = OpLoad %uint %96
-%111 = OpFunctionCall %ulong %6 %109 %110
-OpStore %97 %111
-%112 = OpLoad %v4uint %93
-%113 = OpCompositeExtract %uint %112 2
-OpStore %98 %113
-%114 = OpLoad %ulong %97
-%115 = OpLoad %uint %98
-%116 = OpFunctionCall %ulong %6 %114 %115
-OpStore %99 %116
-%117 = OpLoad %v4uint %93
-%118 = OpCompositeExtract %uint %117 3
-OpStore %100 %118
-%119 = OpLoad %ulong %99
-%120 = OpLoad %uint %100
-%121 = OpFunctionCall %ulong %6 %119 %120
-OpStore %101 %121
-%122 = OpLoad %ulong %101
-OpReturnValue %122
+OpStore %48 %10
+OpStore %50 %11
+%102 = OpLoad %v4float %50
+%103 = OpCompositeExtract %float %102 0
+OpStore %52 %103
+OpBranch %13
+%13 = OpLabel
+%104 = OpLoad %float %52
+%105 = OpBitcast %uint %104
+OpStore %57 %105
+%106 = OpLoad %uint %57
+%107 = OpUConvert %ulong %106
+OpStore %58 %107
+OpBranch %15
+%15 = OpLabel
+%108 = OpLoad %ulong %48
+OpStore %67 %108
+OpStore %68 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%110 = OpLoad %ulong %68
+%112 = OpULessThan %bool %110 %ulong_8
+OpStore %60 %112
+%113 = OpLoad %bool %60
+OpLoopMerge %18 %44 None
+OpBranchConditional %113 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%114 = OpLoad %v4float %50
+%115 = OpCompositeExtract %float %114 1
+OpStore %53 %115
+OpBranch %20
+%20 = OpLabel
+%116 = OpLoad %float %53
+%117 = OpBitcast %uint %116
+OpStore %69 %117
+%118 = OpLoad %uint %69
+%119 = OpUConvert %ulong %118
+OpStore %70 %119
+OpBranch %22
+%22 = OpLabel
+%120 = OpLoad %ulong %67
+OpStore %78 %120
+OpStore %79 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%121 = OpLoad %ulong %79
+%122 = OpULessThan %bool %121 %ulong_8
+OpStore %71 %122
+%123 = OpLoad %bool %71
+OpLoopMerge %25 %43 None
+OpBranchConditional %123 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%124 = OpLoad %v4float %50
+%125 = OpCompositeExtract %float %124 2
+OpStore %54 %125
+OpBranch %27
+%27 = OpLabel
+%126 = OpLoad %float %54
+%127 = OpBitcast %uint %126
+OpStore %80 %127
+%128 = OpLoad %uint %80
+%129 = OpUConvert %ulong %128
+OpStore %81 %129
+OpBranch %29
+%29 = OpLabel
+%130 = OpLoad %ulong %78
+OpStore %89 %130
+OpStore %90 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%131 = OpLoad %ulong %90
+%132 = OpULessThan %bool %131 %ulong_8
+OpStore %82 %132
+%133 = OpLoad %bool %82
+OpLoopMerge %32 %42 None
+OpBranchConditional %133 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%134 = OpLoad %v4float %50
+%135 = OpCompositeExtract %float %134 3
+OpStore %55 %135
+OpBranch %34
+%34 = OpLabel
+%136 = OpLoad %float %55
+%137 = OpBitcast %uint %136
+OpStore %91 %137
+%138 = OpLoad %uint %91
+%139 = OpUConvert %ulong %138
+OpStore %92 %139
+OpBranch %36
+%36 = OpLabel
+%140 = OpLoad %ulong %89
+OpStore %100 %140
+OpStore %101 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%141 = OpLoad %ulong %101
+%142 = OpULessThan %bool %141 %ulong_8
+OpStore %93 %142
+%143 = OpLoad %bool %93
+OpLoopMerge %39 %41 None
+OpBranchConditional %143 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%144 = OpLoad %ulong %100
+OpReturnValue %144
+%38 = OpLabel
+%145 = OpLoad %ulong %101
+%146 = OpIMul %ulong %145 %ulong_8
+OpStore %94 %146
+%147 = OpLoad %ulong %92
+%148 = OpLoad %ulong %94
+%149 = OpShiftRightLogical %ulong %147 %148
+OpStore %95 %149
+%150 = OpLoad %ulong %95
+%152 = OpBitwiseAnd %ulong %150 %ulong_255
+OpStore %96 %152
+%153 = OpLoad %ulong %100
+%154 = OpLoad %ulong %96
+%155 = OpBitwiseXor %ulong %153 %154
+OpStore %97 %155
+%156 = OpLoad %ulong %97
+%158 = OpIMul %ulong %156 %ulong_1099511628211
+OpStore %98 %158
+%159 = OpLoad %ulong %101
+%161 = OpIAdd %ulong %159 %ulong_1
+OpStore %99 %161
+%162 = OpLoad %ulong %98
+OpStore %100 %162
+%163 = OpLoad %ulong %99
+OpStore %101 %163
+OpBranch %41
+%31 = OpLabel
+%164 = OpLoad %ulong %90
+%165 = OpIMul %ulong %164 %ulong_8
+OpStore %83 %165
+%166 = OpLoad %ulong %81
+%167 = OpLoad %ulong %83
+%168 = OpShiftRightLogical %ulong %166 %167
+OpStore %84 %168
+%169 = OpLoad %ulong %84
+%170 = OpBitwiseAnd %ulong %169 %ulong_255
+OpStore %85 %170
+%171 = OpLoad %ulong %89
+%172 = OpLoad %ulong %85
+%173 = OpBitwiseXor %ulong %171 %172
+OpStore %86 %173
+%174 = OpLoad %ulong %86
+%175 = OpIMul %ulong %174 %ulong_1099511628211
+OpStore %87 %175
+%176 = OpLoad %ulong %90
+%177 = OpIAdd %ulong %176 %ulong_1
+OpStore %88 %177
+%178 = OpLoad %ulong %87
+OpStore %89 %178
+%179 = OpLoad %ulong %88
+OpStore %90 %179
+OpBranch %42
+%24 = OpLabel
+%180 = OpLoad %ulong %79
+%181 = OpIMul %ulong %180 %ulong_8
+OpStore %72 %181
+%182 = OpLoad %ulong %70
+%183 = OpLoad %ulong %72
+%184 = OpShiftRightLogical %ulong %182 %183
+OpStore %73 %184
+%185 = OpLoad %ulong %73
+%186 = OpBitwiseAnd %ulong %185 %ulong_255
+OpStore %74 %186
+%187 = OpLoad %ulong %78
+%188 = OpLoad %ulong %74
+%189 = OpBitwiseXor %ulong %187 %188
+OpStore %75 %189
+%190 = OpLoad %ulong %75
+%191 = OpIMul %ulong %190 %ulong_1099511628211
+OpStore %76 %191
+%192 = OpLoad %ulong %79
+%193 = OpIAdd %ulong %192 %ulong_1
+OpStore %77 %193
+%194 = OpLoad %ulong %76
+OpStore %78 %194
+%195 = OpLoad %ulong %77
+OpStore %79 %195
+OpBranch %43
+%17 = OpLabel
+%196 = OpLoad %ulong %68
+%197 = OpIMul %ulong %196 %ulong_8
+OpStore %61 %197
+%198 = OpLoad %ulong %58
+%199 = OpLoad %ulong %61
+%200 = OpShiftRightLogical %ulong %198 %199
+OpStore %62 %200
+%201 = OpLoad %ulong %62
+%202 = OpBitwiseAnd %ulong %201 %ulong_255
+OpStore %63 %202
+%203 = OpLoad %ulong %67
+%204 = OpLoad %ulong %63
+%205 = OpBitwiseXor %ulong %203 %204
+OpStore %64 %205
+%206 = OpLoad %ulong %64
+%207 = OpIMul %ulong %206 %ulong_1099511628211
+OpStore %65 %207
+%208 = OpLoad %ulong %68
+%209 = OpIAdd %ulong %208 %ulong_1
+OpStore %66 %209
+%210 = OpLoad %ulong %65
+OpStore %67 %210
+%211 = OpLoad %ulong %66
+OpStore %68 %211
+OpBranch %44
+%41 = OpLabel
+OpBranch %37
+%42 = OpLabel
+OpBranch %30
+%43 = OpLabel
+OpBranch %23
+%44 = OpLabel
+OpBranch %16
 OpFunctionEnd
-%4 = OpFunction %ulong None %123
-%124 = OpFunctionParameter %ulong
-%125 = OpLabel
-%169 = OpVariable %_ptr_Function_v4float Function
-%170 = OpVariable %_ptr_Function_v4uint Function
-%171 = OpVariable %_ptr_Function_v4uint Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_float Function
-%175 = OpVariable %_ptr_Function_uint Function
-%176 = OpVariable %_ptr_Function_float Function
-%177 = OpVariable %_ptr_Function_float Function
-%178 = OpVariable %_ptr_Function_v4float Function
-%179 = OpVariable %_ptr_Function_float Function
-%180 = OpVariable %_ptr_Function_v4float Function
-%181 = OpVariable %_ptr_Function_float Function
-%182 = OpVariable %_ptr_Function_float Function
-%183 = OpVariable %_ptr_Function_v4float Function
-%184 = OpVariable %_ptr_Function_float Function
-%185 = OpVariable %_ptr_Function_float Function
-%186 = OpVariable %_ptr_Function_v4float Function
-%187 = OpVariable %_ptr_Function_float Function
-%188 = OpVariable %_ptr_Function_float Function
-%189 = OpVariable %_ptr_Function_float Function
-%190 = OpVariable %_ptr_Function_float Function
-%191 = OpVariable %_ptr_Function_float Function
-%192 = OpVariable %_ptr_Function_float Function
-%193 = OpVariable %_ptr_Function_float Function
-%194 = OpVariable %_ptr_Function_float Function
-%195 = OpVariable %_ptr_Function_float Function
-%196 = OpVariable %_ptr_Function_float Function
-%197 = OpVariable %_ptr_Function_float Function
-%198 = OpVariable %_ptr_Function_float Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_float Function
-%204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_float Function
-%206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_float Function
-%208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function_v4float Function
-%210 = OpVariable %_ptr_Function_float Function
-%211 = OpVariable %_ptr_Function_v4float Function
-%212 = OpVariable %_ptr_Function_float Function
-%213 = OpVariable %_ptr_Function_v4float Function
-%214 = OpVariable %_ptr_Function_float Function
-%215 = OpVariable %_ptr_Function_v4float Function
-%216 = OpVariable %_ptr_Function_v4float Function
-%217 = OpVariable %_ptr_Function_float Function
-%218 = OpVariable %_ptr_Function_float Function
-%220 = OpVariable %_ptr_Function_bool Function
-%221 = OpVariable %_ptr_Function_float Function
-%222 = OpVariable %_ptr_Function_float Function
-%223 = OpVariable %_ptr_Function_bool Function
-%224 = OpVariable %_ptr_Function_float Function
-%225 = OpVariable %_ptr_Function_float Function
-%226 = OpVariable %_ptr_Function_bool Function
-%227 = OpVariable %_ptr_Function_float Function
-%228 = OpVariable %_ptr_Function_float Function
-%229 = OpVariable %_ptr_Function_float Function
-%230 = OpVariable %_ptr_Function_bool Function
-%231 = OpVariable %_ptr_Function_float Function
-%232 = OpVariable %_ptr_Function_float Function
-%233 = OpVariable %_ptr_Function_bool Function
-%234 = OpVariable %_ptr_Function_float Function
-%235 = OpVariable %_ptr_Function_float Function
-%236 = OpVariable %_ptr_Function_bool Function
-%237 = OpVariable %_ptr_Function_float Function
-%238 = OpVariable %_ptr_Function_ulong Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_float Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_v4uint Function
-%243 = OpVariable %_ptr_Function_uint Function
-%244 = OpVariable %_ptr_Function_uint Function
-%245 = OpVariable %_ptr_Function_uint Function
-%246 = OpVariable %_ptr_Function_v4uint Function
-%247 = OpVariable %_ptr_Function_uint Function
-%248 = OpVariable %_ptr_Function_float Function
-%249 = OpVariable %_ptr_Function_v4float Function
-%250 = OpVariable %_ptr_Function_v4float Function
-%251 = OpVariable %_ptr_Function_uint Function
-%252 = OpVariable %_ptr_Function_float Function
-%253 = OpVariable %_ptr_Function_v4float Function
-%254 = OpVariable %_ptr_Function_v4float Function
+%2 = OpFunction %ulong None %213
+%214 = OpFunctionParameter %ulong
+%215 = OpFunctionParameter %v4uint
+%216 = OpLabel
+%249 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_v4uint Function
+%252 = OpVariable %_ptr_Function_uint Function
+%253 = OpVariable %_ptr_Function_uint Function
+%254 = OpVariable %_ptr_Function_uint Function
 %255 = OpVariable %_ptr_Function_uint Function
-%256 = OpVariable %_ptr_Function_float Function
-%257 = OpVariable %_ptr_Function_v4float Function
-%258 = OpVariable %_ptr_Function_v4float Function
-%259 = OpVariable %_ptr_Function_uint Function
-%260 = OpVariable %_ptr_Function_float Function
-%261 = OpVariable %_ptr_Function_v4float Function
-%262 = OpVariable %_ptr_Function_v4float Function
-%263 = OpVariable %_ptr_Function_v4float Function
-%264 = OpVariable %_ptr_Function_v4float Function
-%265 = OpVariable %_ptr_Function_v4float Function
-%266 = OpVariable %_ptr_Function_v4float Function
-%267 = OpVariable %_ptr_Function_float Function
-%268 = OpVariable %_ptr_Function_float Function
-%269 = OpVariable %_ptr_Function_uint Function
-%270 = OpVariable %_ptr_Function_v4uint Function
-%271 = OpVariable %_ptr_Function_v4uint Function
-%272 = OpVariable %_ptr_Function_v4float Function
-%273 = OpVariable %_ptr_Function_float Function
-%274 = OpVariable %_ptr_Function_float Function
-%275 = OpVariable %_ptr_Function_uint Function
-%276 = OpVariable %_ptr_Function_v4uint Function
-%277 = OpVariable %_ptr_Function_v4uint Function
-%278 = OpVariable %_ptr_Function_v4float Function
-%279 = OpVariable %_ptr_Function_float Function
-%280 = OpVariable %_ptr_Function_float Function
-%281 = OpVariable %_ptr_Function_uint Function
-%282 = OpVariable %_ptr_Function_v4uint Function
-%283 = OpVariable %_ptr_Function_v4uint Function
-%284 = OpVariable %_ptr_Function_v4float Function
-%285 = OpVariable %_ptr_Function_float Function
-%286 = OpVariable %_ptr_Function_float Function
-%287 = OpVariable %_ptr_Function_uint Function
-%288 = OpVariable %_ptr_Function_v4uint Function
-%289 = OpVariable %_ptr_Function_v4uint Function
-%290 = OpVariable %_ptr_Function_v4uint Function
-%291 = OpVariable %_ptr_Function_v4uint Function
-%292 = OpVariable %_ptr_Function_v4uint Function
-%293 = OpVariable %_ptr_Function_v4uint Function
-%294 = OpVariable %_ptr_Function_v4uint Function
-%295 = OpVariable %_ptr_Function_v4uint Function
-%296 = OpVariable %_ptr_Function_uint Function
-%297 = OpVariable %_ptr_Function_uint Function
-%298 = OpVariable %_ptr_Function_v4uint Function
-%299 = OpVariable %_ptr_Function_uint Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_uint Function
-%302 = OpVariable %_ptr_Function_uint Function
-%303 = OpVariable %_ptr_Function_ulong Function
-%304 = OpVariable %_ptr_Function_uint Function
-%305 = OpVariable %_ptr_Function_uint Function
-%306 = OpVariable %_ptr_Function_ulong Function
-%307 = OpVariable %_ptr_Function_uint Function
-%308 = OpVariable %_ptr_Function_uint Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_v4uint Function
-%311 = OpVariable %_ptr_Function_v4uint Function
-%312 = OpVariable %_ptr_Function_uint Function
-%313 = OpVariable %_ptr_Function_v4uint Function
-%314 = OpVariable %_ptr_Function_v4uint Function
-%315 = OpVariable %_ptr_Function_uint Function
-%316 = OpVariable %_ptr_Function_v4uint Function
-%317 = OpVariable %_ptr_Function_v4uint Function
-%318 = OpVariable %_ptr_Function_uint Function
-%319 = OpVariable %_ptr_Function_v4uint Function
-%320 = OpVariable %_ptr_Function_v4uint Function
-%321 = OpVariable %_ptr_Function_v4uint Function
-%322 = OpVariable %_ptr_Function_v4uint Function
-%323 = OpVariable %_ptr_Function_v4uint Function
-%324 = OpVariable %_ptr_Function_bool Function
-%325 = OpVariable %_ptr_Function_float Function
-%326 = OpVariable %_ptr_Function_float Function
-%327 = OpVariable %_ptr_Function_float Function
-%328 = OpVariable %_ptr_Function_float Function
-%329 = OpVariable %_ptr_Function_float Function
-%330 = OpVariable %_ptr_Function_float Function
-%331 = OpVariable %_ptr_Function_float Function
-%332 = OpVariable %_ptr_Function_float Function
-%333 = OpVariable %_ptr_Function_v4float Function
-%334 = OpVariable %_ptr_Function_v4float Function
-%335 = OpVariable %_ptr_Function_v4float Function
-%336 = OpVariable %_ptr_Function_v4float Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ulong Function
-%339 = OpVariable %_ptr_Function_float Function
-%340 = OpVariable %_ptr_Function_float Function
-%341 = OpVariable %_ptr_Function_float Function
-%342 = OpVariable %_ptr_Function_float Function
-%343 = OpVariable %_ptr_Function_float Function
-%344 = OpVariable %_ptr_Function_float Function
-%345 = OpVariable %_ptr_Function_v4float Function
-%346 = OpVariable %_ptr_Function_ulong Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_ulong Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_ulong Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_ulong Function
-%353 = OpVariable %_ptr_Function_float Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_float Function
-%356 = OpVariable %_ptr_Function_ulong Function
-%357 = OpVariable %_ptr_Function_float Function
-%358 = OpVariable %_ptr_Function_ulong Function
-%359 = OpVariable %_ptr_Function_float Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_float Function
-%362 = OpVariable %_ptr_Function_ulong Function
-%363 = OpVariable %_ptr_Function_float Function
-%364 = OpVariable %_ptr_Function_ulong Function
-%365 = OpVariable %_ptr_Function_float Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_float Function
-%368 = OpVariable %_ptr_Function_ulong Function
-%369 = OpVariable %_ptr_Function_float Function
-%370 = OpVariable %_ptr_Function_ulong Function
-%371 = OpVariable %_ptr_Function_float Function
-%372 = OpVariable %_ptr_Function_ulong Function
-%373 = OpVariable %_ptr_Function_float Function
-%374 = OpVariable %_ptr_Function_ulong Function
-%375 = OpVariable %_ptr_Function_float Function
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_float Function
-%378 = OpVariable %_ptr_Function_ulong Function
-%379 = OpVariable %_ptr_Function_float Function
-%380 = OpVariable %_ptr_Function_ulong Function
-%381 = OpVariable %_ptr_Function_float Function
-%382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_float Function
-%384 = OpVariable %_ptr_Function_ulong Function
-%385 = OpVariable %_ptr_Function_float Function
-%386 = OpVariable %_ptr_Function_ulong Function
-%387 = OpVariable %_ptr_Function_uint Function
-%388 = OpVariable %_ptr_Function_ulong Function
-%389 = OpVariable %_ptr_Function_uint Function
-%390 = OpVariable %_ptr_Function_ulong Function
-%391 = OpVariable %_ptr_Function_uint Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_uint Function
-%394 = OpVariable %_ptr_Function_ulong Function
-%395 = OpVariable %_ptr_Function_uint Function
-%396 = OpVariable %_ptr_Function_ulong Function
-%397 = OpVariable %_ptr_Function_uint Function
-%398 = OpVariable %_ptr_Function_ulong Function
-%399 = OpVariable %_ptr_Function_uint Function
-%400 = OpVariable %_ptr_Function_ulong Function
-%401 = OpVariable %_ptr_Function_uint Function
-%402 = OpVariable %_ptr_Function_ulong Function
-%403 = OpVariable %_ptr_Function_uint Function
-%404 = OpVariable %_ptr_Function_ulong Function
-%405 = OpVariable %_ptr_Function_uint Function
-%406 = OpVariable %_ptr_Function_ulong Function
-%407 = OpVariable %_ptr_Function_uint Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_uint Function
-%410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_uint Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_uint Function
-%414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_uint Function
-%416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_uint Function
-%418 = OpVariable %_ptr_Function_ulong Function
-%419 = OpVariable %_ptr_Function_uint Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_uint Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_uint Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_uint Function
-%426 = OpVariable %_ptr_Function_ulong Function
-OpStore %172 %124
-%427 = OpFunctionCall %ulong %5
-OpStore %173 %427
-%428 = OpLoad %ulong %172
-%429 = OpConvertUToF %float %428
-OpStore %174 %429
-%430 = OpLoad %ulong %172
-%431 = OpUConvert %uint %430
-OpStore %175 %431
-%433 = OpFNegate %float %float_2_25
-OpStore %176 %433
-%435 = OpFNegate %float %float_0_5
-OpStore %177 %435
-%438 = OpLoad %float %176
-%440 = OpLoad %float %177
-%436 = OpCompositeConstruct %v4float %float_1_5 %438 %float_3_75 %440
-OpStore %178 %436
-%442 = OpFNegate %float %float_0_125
-OpStore %179 %442
-%445 = OpLoad %float %179
-%443 = OpCompositeConstruct %v4float %float_0_5 %float_4 %445 %float_8
-OpStore %180 %443
-%447 = OpLoad %v4float %178
-%448 = OpCompositeExtract %float %447 0
-OpStore %181 %448
-%449 = OpLoad %float %181
-%450 = OpLoad %float %174
-%451 = OpFAdd %float %449 %450
-OpStore %182 %451
-%452 = OpLoad %v4float %178
-%453 = OpLoad %float %182
-%454 = OpCompositeInsert %v4float %453 %452 0
-OpStore %183 %454
-%455 = OpLoad %v4float %180
-%456 = OpCompositeExtract %float %455 2
-OpStore %184 %456
-%457 = OpLoad %float %184
-%458 = OpLoad %float %174
-%459 = OpFAdd %float %457 %458
-OpStore %185 %459
-%460 = OpLoad %v4float %180
-%461 = OpLoad %float %185
-%462 = OpCompositeInsert %v4float %461 %460 2
-OpStore %186 %462
-%463 = OpLoad %v4float %183
-%464 = OpCompositeExtract %float %463 0
-OpStore %187 %464
-%465 = OpLoad %v4float %186
-%466 = OpCompositeExtract %float %465 0
-OpStore %188 %466
-%467 = OpLoad %float %187
-%468 = OpLoad %float %188
-%469 = OpFMul %float %467 %468
-OpStore %189 %469
-%470 = OpLoad %v4float %183
-%471 = OpCompositeExtract %float %470 1
-OpStore %190 %471
-%472 = OpLoad %v4float %186
-%473 = OpCompositeExtract %float %472 1
-OpStore %191 %473
-%474 = OpLoad %float %190
-%475 = OpLoad %float %191
-%476 = OpFMul %float %474 %475
-OpStore %192 %476
-%477 = OpLoad %v4float %183
-%478 = OpCompositeExtract %float %477 2
-OpStore %193 %478
-%479 = OpLoad %v4float %186
-%480 = OpCompositeExtract %float %479 2
-OpStore %194 %480
-%481 = OpLoad %float %193
-%482 = OpLoad %float %194
-%483 = OpFMul %float %481 %482
-OpStore %195 %483
-%484 = OpLoad %v4float %183
-%485 = OpCompositeExtract %float %484 3
-OpStore %196 %485
-%486 = OpLoad %v4float %186
-%487 = OpCompositeExtract %float %486 3
-OpStore %197 %487
-%488 = OpLoad %float %196
-%489 = OpLoad %float %197
-%490 = OpFMul %float %488 %489
-OpStore %198 %490
-%491 = OpLoad %ulong %173
-%492 = OpLoad %float %189
-%493 = OpFunctionCall %ulong %8 %491 %492
-OpStore %199 %493
-%494 = OpLoad %ulong %199
-%495 = OpLoad %float %192
-%496 = OpFunctionCall %ulong %8 %494 %495
-OpStore %200 %496
-%497 = OpLoad %ulong %200
-%498 = OpLoad %float %195
-%499 = OpFunctionCall %ulong %8 %497 %498
-OpStore %201 %499
-%500 = OpLoad %ulong %201
-%501 = OpLoad %float %198
-%502 = OpFunctionCall %ulong %8 %500 %501
-OpStore %202 %502
-%503 = OpLoad %float %189
-%504 = OpLoad %float %192
-%505 = OpFAdd %float %503 %504
-OpStore %203 %505
-%506 = OpLoad %ulong %202
-%507 = OpLoad %float %203
-%508 = OpFunctionCall %ulong %8 %506 %507
-OpStore %204 %508
-%509 = OpLoad %float %203
-%510 = OpLoad %float %195
-%511 = OpFAdd %float %509 %510
-OpStore %205 %511
-%512 = OpLoad %ulong %204
-%513 = OpLoad %float %205
-%514 = OpFunctionCall %ulong %8 %512 %513
-OpStore %206 %514
-%515 = OpLoad %float %205
-%516 = OpLoad %float %198
-%517 = OpFAdd %float %515 %516
-OpStore %207 %517
-%518 = OpLoad %ulong %206
-%519 = OpLoad %float %207
-%520 = OpFunctionCall %ulong %8 %518 %519
-OpStore %208 %520
-%521 = OpLoad %v4float %183
-%522 = OpLoad %float %207
-%523 = OpCompositeInsert %v4float %522 %521 0
-OpStore %209 %523
-%524 = OpLoad %float %196
-%525 = OpLoad %float %188
-%526 = OpFSub %float %524 %525
-OpStore %210 %526
-%527 = OpLoad %v4float %209
-%528 = OpLoad %float %210
-%529 = OpCompositeInsert %v4float %528 %527 1
-OpStore %211 %529
-%530 = OpLoad %float %191
-%531 = OpLoad %float %193
-%532 = OpFAdd %float %530 %531
-OpStore %212 %532
-%533 = OpLoad %v4float %211
-%534 = OpLoad %float %212
-%535 = OpCompositeInsert %v4float %534 %533 2
-OpStore %213 %535
-%537 = OpLoad %float %190
-%538 = OpFSub %float %float_0 %537
-OpStore %214 %538
-%539 = OpLoad %v4float %213
-%540 = OpLoad %float %214
-%541 = OpCompositeInsert %v4float %540 %539 3
-OpStore %215 %541
-OpBranch %147
-%147 = OpLabel
-%542 = OpLoad %v4float %215
-%543 = OpCompositeExtract %float %542 0
-OpStore %347 %543
-%544 = OpLoad %ulong %208
-%545 = OpLoad %float %347
-%546 = OpFunctionCall %ulong %8 %544 %545
-OpStore %348 %546
-%547 = OpLoad %v4float %215
-%548 = OpCompositeExtract %float %547 1
-OpStore %349 %548
-%549 = OpLoad %ulong %348
-%550 = OpLoad %float %349
-%551 = OpFunctionCall %ulong %8 %549 %550
-OpStore %350 %551
-%552 = OpLoad %v4float %215
-%553 = OpCompositeExtract %float %552 2
-OpStore %351 %553
-%554 = OpLoad %ulong %350
-%555 = OpLoad %float %351
-%556 = OpFunctionCall %ulong %8 %554 %555
-OpStore %352 %556
-%557 = OpLoad %v4float %215
-%558 = OpCompositeExtract %float %557 3
-OpStore %353 %558
-%559 = OpLoad %ulong %352
-%560 = OpLoad %float %353
-%561 = OpFunctionCall %ulong %8 %559 %560
-OpStore %354 %561
-OpBranch %148
-%148 = OpLabel
-%562 = OpLoad %v4float %215
-%563 = OpLoad %v4float %186
-%564 = OpFMul %v4float %562 %563
-OpStore %216 %564
-OpBranch %153
-%153 = OpLabel
-%565 = OpLoad %v4float %216
-%566 = OpCompositeExtract %float %565 0
-OpStore %371 %566
-%567 = OpLoad %ulong %354
-%568 = OpLoad %float %371
-%569 = OpFunctionCall %ulong %8 %567 %568
-OpStore %372 %569
-%570 = OpLoad %v4float %216
-%571 = OpCompositeExtract %float %570 1
-OpStore %373 %571
-%572 = OpLoad %ulong %372
-%573 = OpLoad %float %373
-%574 = OpFunctionCall %ulong %8 %572 %573
-OpStore %374 %574
-%575 = OpLoad %v4float %216
-%576 = OpCompositeExtract %float %575 2
-OpStore %375 %576
-%577 = OpLoad %ulong %374
-%578 = OpLoad %float %375
-%579 = OpFunctionCall %ulong %8 %577 %578
-OpStore %376 %579
-%580 = OpLoad %v4float %216
-%581 = OpCompositeExtract %float %580 3
-OpStore %377 %581
-%582 = OpLoad %ulong %376
-%583 = OpLoad %float %377
-%584 = OpFunctionCall %ulong %8 %582 %583
-OpStore %378 %584
-OpBranch %154
-%154 = OpLabel
-%585 = OpLoad %v4float %183
-%586 = OpCompositeExtract %float %585 0
-OpStore %217 %586
-%587 = OpLoad %v4float %183
-%588 = OpCompositeExtract %float %587 1
-OpStore %218 %588
-%589 = OpLoad %float %217
-%590 = OpLoad %float %218
-%591 = OpFOrdLessThan %bool %589 %590
-OpStore %220 %591
-%592 = OpLoad %bool %220
-OpSelectionMerge %128 None
-OpBranchConditional %592 %126 %127
-%127 = OpLabel
-%593 = OpLoad %float %217
-OpStore %341 %593
-OpBranch %128
-%126 = OpLabel
-%594 = OpLoad %v4float %183
-%595 = OpCompositeExtract %float %594 1
-OpStore %221 %595
-%596 = OpLoad %float %221
-OpStore %341 %596
-OpBranch %128
-%128 = OpLabel
-%597 = OpLoad %v4float %183
-%598 = OpCompositeExtract %float %597 2
-OpStore %222 %598
-%599 = OpLoad %float %341
-%600 = OpLoad %float %222
-%601 = OpFOrdLessThan %bool %599 %600
-OpStore %223 %601
-%602 = OpLoad %bool %223
-OpSelectionMerge %131 None
-OpBranchConditional %602 %129 %130
-%130 = OpLabel
-%603 = OpLoad %float %341
-OpStore %340 %603
-OpBranch %131
-%129 = OpLabel
-%604 = OpLoad %v4float %183
-%605 = OpCompositeExtract %float %604 2
-OpStore %224 %605
-%606 = OpLoad %float %224
-OpStore %340 %606
-OpBranch %131
-%131 = OpLabel
-%607 = OpLoad %v4float %183
-%608 = OpCompositeExtract %float %607 3
-OpStore %225 %608
-%609 = OpLoad %float %340
-%610 = OpLoad %float %225
-%611 = OpFOrdLessThan %bool %609 %610
-OpStore %226 %611
-%612 = OpLoad %bool %226
-OpSelectionMerge %134 None
-OpBranchConditional %612 %132 %133
-%133 = OpLabel
-%613 = OpLoad %float %340
-OpStore %339 %613
-OpBranch %134
-%132 = OpLabel
-%614 = OpLoad %v4float %183
-%615 = OpCompositeExtract %float %614 3
-OpStore %227 %615
-%616 = OpLoad %float %227
-OpStore %339 %616
-OpBranch %134
-%134 = OpLabel
-%617 = OpLoad %v4float %183
-%618 = OpCompositeExtract %float %617 0
-OpStore %228 %618
-%619 = OpLoad %v4float %183
-%620 = OpCompositeExtract %float %619 1
-OpStore %229 %620
-%621 = OpLoad %float %229
-%622 = OpLoad %float %228
-%623 = OpFOrdLessThan %bool %621 %622
-OpStore %230 %623
-%624 = OpLoad %bool %230
-OpSelectionMerge %137 None
-OpBranchConditional %624 %135 %136
-%136 = OpLabel
-%625 = OpLoad %float %228
-OpStore %344 %625
-OpBranch %137
-%135 = OpLabel
-%626 = OpLoad %v4float %183
-%627 = OpCompositeExtract %float %626 1
-OpStore %231 %627
-%628 = OpLoad %float %231
-OpStore %344 %628
-OpBranch %137
-%137 = OpLabel
-%629 = OpLoad %v4float %183
-%630 = OpCompositeExtract %float %629 2
-OpStore %232 %630
-%631 = OpLoad %float %232
-%632 = OpLoad %float %344
-%633 = OpFOrdLessThan %bool %631 %632
-OpStore %233 %633
-%634 = OpLoad %bool %233
-OpSelectionMerge %140 None
-OpBranchConditional %634 %138 %139
-%139 = OpLabel
-%635 = OpLoad %float %344
-OpStore %343 %635
-OpBranch %140
-%138 = OpLabel
-%636 = OpLoad %v4float %183
-%637 = OpCompositeExtract %float %636 2
-OpStore %234 %637
-%638 = OpLoad %float %234
-OpStore %343 %638
-OpBranch %140
-%140 = OpLabel
-%639 = OpLoad %v4float %183
-%640 = OpCompositeExtract %float %639 3
-OpStore %235 %640
-%641 = OpLoad %float %235
-%642 = OpLoad %float %343
-%643 = OpFOrdLessThan %bool %641 %642
-OpStore %236 %643
-%644 = OpLoad %bool %236
-OpSelectionMerge %143 None
-OpBranchConditional %644 %141 %142
-%142 = OpLabel
-%645 = OpLoad %float %343
-OpStore %342 %645
-OpBranch %143
-%141 = OpLabel
-%646 = OpLoad %v4float %183
-%647 = OpCompositeExtract %float %646 3
-OpStore %237 %647
-%648 = OpLoad %float %237
-OpStore %342 %648
-OpBranch %143
-%143 = OpLabel
-%649 = OpLoad %ulong %378
-%650 = OpLoad %float %339
-%651 = OpFunctionCall %ulong %8 %649 %650
-OpStore %238 %651
-%652 = OpLoad %ulong %238
-%653 = OpLoad %float %342
-%654 = OpFunctionCall %ulong %8 %652 %653
-OpStore %239 %654
-%655 = OpLoad %float %339
-%656 = OpLoad %float %342
-%657 = OpFSub %float %655 %656
-OpStore %240 %657
-%658 = OpLoad %ulong %239
-%659 = OpLoad %float %240
-%660 = OpFunctionCall %ulong %8 %658 %659
-OpStore %241 %660
-%661 = OpCompositeConstruct %v4uint %uint_7 %uint_4294967283 %uint_21 %uint_4294967265
-OpStore %242 %661
-%666 = OpLoad %v4uint %242
-%667 = OpCompositeExtract %uint %666 1
-OpStore %243 %667
-%668 = OpLoad %ulong %172
-%669 = OpUConvert %uint %668
-OpStore %244 %669
-%670 = OpLoad %uint %243
-%671 = OpLoad %uint %244
-%672 = OpIAdd %uint %670 %671
-OpStore %245 %672
-%673 = OpLoad %v4uint %242
-%674 = OpLoad %uint %245
-%675 = OpCompositeInsert %v4uint %674 %673 1
-OpStore %246 %675
-OpStore %169 %676
-%677 = OpLoad %v4uint %246
-%678 = OpCompositeExtract %uint %677 0
-OpStore %247 %678
-%679 = OpLoad %uint %247
-%680 = OpConvertSToF %float %679
-OpStore %248 %680
-%681 = OpLoad %v4float %169
-OpStore %249 %681
-%682 = OpLoad %v4float %249
-%683 = OpLoad %float %248
-%684 = OpCompositeInsert %v4float %683 %682 0
-OpStore %250 %684
-%685 = OpLoad %v4float %250
-OpStore %169 %685
-%686 = OpLoad %v4uint %246
-%687 = OpCompositeExtract %uint %686 1
-OpStore %251 %687
-%688 = OpLoad %uint %251
-%689 = OpConvertSToF %float %688
-OpStore %252 %689
-%690 = OpLoad %v4float %169
-OpStore %253 %690
-%691 = OpLoad %v4float %253
-%692 = OpLoad %float %252
-%693 = OpCompositeInsert %v4float %692 %691 1
-OpStore %254 %693
-%694 = OpLoad %v4float %254
-OpStore %169 %694
-%695 = OpLoad %v4uint %246
-%696 = OpCompositeExtract %uint %695 2
-OpStore %255 %696
-%697 = OpLoad %uint %255
-%698 = OpConvertSToF %float %697
-OpStore %256 %698
-%699 = OpLoad %v4float %169
-OpStore %257 %699
-%700 = OpLoad %v4float %257
-%701 = OpLoad %float %256
-%702 = OpCompositeInsert %v4float %701 %700 2
-OpStore %258 %702
-%703 = OpLoad %v4float %258
-OpStore %169 %703
-%704 = OpLoad %v4uint %246
-%705 = OpCompositeExtract %uint %704 3
-OpStore %259 %705
-%706 = OpLoad %uint %259
-%707 = OpConvertSToF %float %706
-OpStore %260 %707
-%708 = OpLoad %v4float %169
-OpStore %261 %708
-%709 = OpLoad %v4float %261
-%710 = OpLoad %float %260
-%711 = OpCompositeInsert %v4float %710 %709 3
-OpStore %262 %711
-%712 = OpLoad %v4float %262
-OpStore %169 %712
-%713 = OpLoad %v4float %169
-OpStore %263 %713
-OpBranch %149
-%149 = OpLabel
-%714 = OpLoad %v4float %263
-%715 = OpCompositeExtract %float %714 0
-OpStore %355 %715
-%716 = OpLoad %ulong %241
-%717 = OpLoad %float %355
-%718 = OpFunctionCall %ulong %8 %716 %717
-OpStore %356 %718
-%719 = OpLoad %v4float %263
-%720 = OpCompositeExtract %float %719 1
-OpStore %357 %720
-%721 = OpLoad %ulong %356
-%722 = OpLoad %float %357
-%723 = OpFunctionCall %ulong %8 %721 %722
-OpStore %358 %723
-%724 = OpLoad %v4float %263
-%725 = OpCompositeExtract %float %724 2
-OpStore %359 %725
-%726 = OpLoad %ulong %358
-%727 = OpLoad %float %359
-%728 = OpFunctionCall %ulong %8 %726 %727
-OpStore %360 %728
-%729 = OpLoad %v4float %263
-%730 = OpCompositeExtract %float %729 3
-OpStore %361 %730
-%731 = OpLoad %ulong %360
-%732 = OpLoad %float %361
-%733 = OpFunctionCall %ulong %8 %731 %732
-OpStore %362 %733
-OpBranch %150
-%150 = OpLabel
-%734 = OpLoad %v4float %169
-OpStore %264 %734
-%735 = OpLoad %v4float %264
-%736 = OpLoad %v4float %183
-%737 = OpFMul %v4float %735 %736
-OpStore %265 %737
-OpBranch %155
-%155 = OpLabel
-%738 = OpLoad %v4float %265
-%739 = OpCompositeExtract %float %738 0
-OpStore %379 %739
-%740 = OpLoad %ulong %362
-%741 = OpLoad %float %379
-%742 = OpFunctionCall %ulong %8 %740 %741
-OpStore %380 %742
-%743 = OpLoad %v4float %265
-%744 = OpCompositeExtract %float %743 1
-OpStore %381 %744
-%745 = OpLoad %ulong %380
-%746 = OpLoad %float %381
-%747 = OpFunctionCall %ulong %8 %745 %746
-OpStore %382 %747
-%748 = OpLoad %v4float %265
-%749 = OpCompositeExtract %float %748 2
-OpStore %383 %749
-%750 = OpLoad %ulong %382
-%751 = OpLoad %float %383
-%752 = OpFunctionCall %ulong %8 %750 %751
-OpStore %384 %752
-%753 = OpLoad %v4float %265
-%754 = OpCompositeExtract %float %753 3
-OpStore %385 %754
-%755 = OpLoad %ulong %384
-%756 = OpLoad %float %385
-%757 = OpFunctionCall %ulong %8 %755 %756
-OpStore %386 %757
-OpBranch %156
-%156 = OpLabel
-OpStore %170 %758
-%759 = OpLoad %v4float %169
-OpStore %266 %759
-%760 = OpLoad %v4float %266
-%761 = OpCompositeExtract %float %760 0
-OpStore %267 %761
-%762 = OpLoad %float %267
-%763 = OpFMul %float %762 %float_4
-OpStore %268 %763
-%764 = OpLoad %float %268
-%765 = OpConvertFToS %uint %764
-OpStore %269 %765
-%766 = OpLoad %v4uint %170
-OpStore %270 %766
-%767 = OpLoad %v4uint %270
-%768 = OpLoad %uint %269
-%769 = OpCompositeInsert %v4uint %768 %767 0
-OpStore %271 %769
-%770 = OpLoad %v4uint %271
-OpStore %170 %770
-%771 = OpLoad %v4float %169
-OpStore %272 %771
-%772 = OpLoad %v4float %272
-%773 = OpCompositeExtract %float %772 1
-OpStore %273 %773
-%774 = OpLoad %float %273
-%775 = OpFMul %float %774 %float_4
-OpStore %274 %775
-%776 = OpLoad %float %274
-%777 = OpConvertFToS %uint %776
-OpStore %275 %777
-%778 = OpLoad %v4uint %170
-OpStore %276 %778
-%779 = OpLoad %v4uint %276
-%780 = OpLoad %uint %275
-%781 = OpCompositeInsert %v4uint %780 %779 1
-OpStore %277 %781
-%782 = OpLoad %v4uint %277
-OpStore %170 %782
-%783 = OpLoad %v4float %169
-OpStore %278 %783
-%784 = OpLoad %v4float %278
-%785 = OpCompositeExtract %float %784 2
-OpStore %279 %785
-%786 = OpLoad %float %279
-%787 = OpFMul %float %786 %float_4
-OpStore %280 %787
-%788 = OpLoad %float %280
-%789 = OpConvertFToS %uint %788
-OpStore %281 %789
-%790 = OpLoad %v4uint %170
-OpStore %282 %790
-%791 = OpLoad %v4uint %282
-%792 = OpLoad %uint %281
-%793 = OpCompositeInsert %v4uint %792 %791 2
-OpStore %283 %793
-%794 = OpLoad %v4uint %283
-OpStore %170 %794
-%795 = OpLoad %v4float %169
-OpStore %284 %795
-%796 = OpLoad %v4float %284
-%797 = OpCompositeExtract %float %796 3
-OpStore %285 %797
-%798 = OpLoad %float %285
-%799 = OpFMul %float %798 %float_4
-OpStore %286 %799
-%800 = OpLoad %float %286
-%801 = OpConvertFToS %uint %800
-OpStore %287 %801
-%802 = OpLoad %v4uint %170
-OpStore %288 %802
-%803 = OpLoad %v4uint %288
-%804 = OpLoad %uint %287
-%805 = OpCompositeInsert %v4uint %804 %803 3
-OpStore %289 %805
-%806 = OpLoad %v4uint %289
-OpStore %170 %806
-%807 = OpLoad %v4uint %170
-OpStore %290 %807
-OpBranch %157
-%157 = OpLabel
-%808 = OpLoad %v4uint %290
-%809 = OpCompositeExtract %uint %808 0
-OpStore %387 %809
-%810 = OpLoad %ulong %386
-%811 = OpLoad %uint %387
-%812 = OpFunctionCall %ulong %7 %810 %811
-OpStore %388 %812
-%813 = OpLoad %v4uint %290
-%814 = OpCompositeExtract %uint %813 1
-OpStore %389 %814
-%815 = OpLoad %ulong %388
-%816 = OpLoad %uint %389
-%817 = OpFunctionCall %ulong %7 %815 %816
-OpStore %390 %817
-%818 = OpLoad %v4uint %290
-%819 = OpCompositeExtract %uint %818 2
-OpStore %391 %819
-%820 = OpLoad %ulong %390
-%821 = OpLoad %uint %391
-%822 = OpFunctionCall %ulong %7 %820 %821
-OpStore %392 %822
-%823 = OpLoad %v4uint %290
-%824 = OpCompositeExtract %uint %823 3
-OpStore %393 %824
-%825 = OpLoad %ulong %392
-%826 = OpLoad %uint %393
-%827 = OpFunctionCall %ulong %7 %825 %826
-OpStore %394 %827
-OpBranch %158
-%158 = OpLabel
-%828 = OpLoad %v4uint %170
-OpStore %291 %828
-%829 = OpLoad %v4uint %291
-%830 = OpLoad %v4uint %246
-%831 = OpIMul %v4uint %829 %830
-OpStore %292 %831
-OpBranch %159
-%159 = OpLabel
-%832 = OpLoad %v4uint %292
-%833 = OpCompositeExtract %uint %832 0
-OpStore %395 %833
-%834 = OpLoad %ulong %394
-%835 = OpLoad %uint %395
-%836 = OpFunctionCall %ulong %7 %834 %835
-OpStore %396 %836
-%837 = OpLoad %v4uint %292
-%838 = OpCompositeExtract %uint %837 1
-OpStore %397 %838
-%839 = OpLoad %ulong %396
-%840 = OpLoad %uint %397
-%841 = OpFunctionCall %ulong %7 %839 %840
-OpStore %398 %841
-%842 = OpLoad %v4uint %292
-%843 = OpCompositeExtract %uint %842 2
-OpStore %399 %843
-%844 = OpLoad %ulong %398
-%845 = OpLoad %uint %399
-%846 = OpFunctionCall %ulong %7 %844 %845
-OpStore %400 %846
-%847 = OpLoad %v4uint %292
-%848 = OpCompositeExtract %uint %847 3
-OpStore %401 %848
-%849 = OpLoad %ulong %400
-%850 = OpLoad %uint %401
-%851 = OpFunctionCall %ulong %7 %849 %850
-OpStore %402 %851
-OpBranch %160
-%160 = OpLabel
-%852 = OpLoad %v4uint %170
-OpStore %293 %852
-%853 = OpLoad %v4uint %293
-%854 = OpLoad %v4uint %246
-%855 = OpISub %v4uint %853 %854
-OpStore %294 %855
-OpBranch %161
-%161 = OpLabel
-%856 = OpLoad %v4uint %294
-%857 = OpCompositeExtract %uint %856 0
-OpStore %403 %857
-%858 = OpLoad %ulong %402
-%859 = OpLoad %uint %403
-%860 = OpFunctionCall %ulong %7 %858 %859
-OpStore %404 %860
-%861 = OpLoad %v4uint %294
-%862 = OpCompositeExtract %uint %861 1
-OpStore %405 %862
-%863 = OpLoad %ulong %404
-%864 = OpLoad %uint %405
-%865 = OpFunctionCall %ulong %7 %863 %864
-OpStore %406 %865
-%866 = OpLoad %v4uint %294
-%867 = OpCompositeExtract %uint %866 2
-OpStore %407 %867
-%868 = OpLoad %ulong %406
-%869 = OpLoad %uint %407
-%870 = OpFunctionCall %ulong %7 %868 %869
-OpStore %408 %870
-%871 = OpLoad %v4uint %294
-%872 = OpCompositeExtract %uint %871 3
-OpStore %409 %872
-%873 = OpLoad %ulong %408
-%874 = OpLoad %uint %409
-%875 = OpFunctionCall %ulong %7 %873 %874
-OpStore %410 %875
-OpBranch %162
-%162 = OpLabel
-%876 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_1 %uint_2863311530 %uint_305419896
-OpStore %295 %876
-%881 = OpLoad %v4uint %295
-%882 = OpCompositeExtract %uint %881 3
-OpStore %296 %882
-%883 = OpLoad %uint %296
-%884 = OpLoad %uint %175
-%885 = OpIAdd %uint %883 %884
-OpStore %297 %885
-%886 = OpLoad %v4uint %295
-%887 = OpLoad %uint %297
-%888 = OpCompositeInsert %v4uint %887 %886 3
-OpStore %298 %888
-%889 = OpLoad %v4uint %298
-%890 = OpCompositeExtract %uint %889 0
-OpStore %299 %890
-%891 = OpLoad %ulong %410
-%892 = OpLoad %uint %299
-%893 = OpFunctionCall %ulong %6 %891 %892
-OpStore %300 %893
-%894 = OpLoad %v4uint %298
-%895 = OpCompositeExtract %uint %894 1
-OpStore %301 %895
-%896 = OpLoad %uint %299
-%897 = OpLoad %uint %301
-%898 = OpBitwiseXor %uint %896 %897
-OpStore %302 %898
-%899 = OpLoad %ulong %300
-%900 = OpLoad %uint %302
-%901 = OpFunctionCall %ulong %6 %899 %900
-OpStore %303 %901
-%902 = OpLoad %v4uint %298
-%903 = OpCompositeExtract %uint %902 2
-OpStore %304 %903
-%904 = OpLoad %uint %302
-%905 = OpLoad %uint %304
-%906 = OpIMul %uint %904 %905
-OpStore %305 %906
-%907 = OpLoad %ulong %303
-%908 = OpLoad %uint %305
-%909 = OpFunctionCall %ulong %6 %907 %908
-OpStore %306 %909
-%910 = OpLoad %v4uint %298
-%911 = OpCompositeExtract %uint %910 3
-OpStore %307 %911
-%912 = OpLoad %uint %305
-%913 = OpLoad %uint %307
-%914 = OpISub %uint %912 %913
-OpStore %308 %914
-%915 = OpLoad %ulong %306
-%916 = OpLoad %uint %308
-%917 = OpFunctionCall %ulong %6 %915 %916
-OpStore %309 %917
-OpStore %171 %758
-%918 = OpLoad %v4uint %171
-OpStore %310 %918
-%919 = OpLoad %v4uint %310
-%920 = OpLoad %uint %308
-%921 = OpCompositeInsert %v4uint %920 %919 0
-OpStore %311 %921
-%922 = OpLoad %v4uint %311
-OpStore %171 %922
-%923 = OpLoad %uint %308
-%924 = OpLoad %uint %299
-%925 = OpBitwiseXor %uint %923 %924
-OpStore %312 %925
-%926 = OpLoad %v4uint %171
-OpStore %313 %926
-%927 = OpLoad %v4uint %313
-%928 = OpLoad %uint %312
-%929 = OpCompositeInsert %v4uint %928 %927 1
-OpStore %314 %929
-%930 = OpLoad %v4uint %314
-OpStore %171 %930
-%931 = OpLoad %uint %308
-%932 = OpLoad %uint %301
-%933 = OpIAdd %uint %931 %932
-OpStore %315 %933
-%934 = OpLoad %v4uint %171
-OpStore %316 %934
-%935 = OpLoad %v4uint %316
-%936 = OpLoad %uint %315
-%937 = OpCompositeInsert %v4uint %936 %935 2
-OpStore %317 %937
-%938 = OpLoad %v4uint %317
-OpStore %171 %938
-%939 = OpLoad %uint %308
-%940 = OpLoad %uint %304
-%941 = OpISub %uint %939 %940
-OpStore %318 %941
-%942 = OpLoad %v4uint %171
-OpStore %319 %942
-%943 = OpLoad %v4uint %319
-%944 = OpLoad %uint %318
-%945 = OpCompositeInsert %v4uint %944 %943 3
-OpStore %320 %945
-%946 = OpLoad %v4uint %320
-OpStore %171 %946
-%947 = OpLoad %v4uint %171
-OpStore %321 %947
-OpBranch %163
-%163 = OpLabel
-%948 = OpLoad %v4uint %321
-%949 = OpCompositeExtract %uint %948 0
-OpStore %411 %949
-%950 = OpLoad %ulong %309
-%951 = OpLoad %uint %411
-%952 = OpFunctionCall %ulong %6 %950 %951
-OpStore %412 %952
-%953 = OpLoad %v4uint %321
-%954 = OpCompositeExtract %uint %953 1
-OpStore %413 %954
-%955 = OpLoad %ulong %412
-%956 = OpLoad %uint %413
-%957 = OpFunctionCall %ulong %6 %955 %956
-OpStore %414 %957
-%958 = OpLoad %v4uint %321
-%959 = OpCompositeExtract %uint %958 2
-OpStore %415 %959
-%960 = OpLoad %ulong %414
-%961 = OpLoad %uint %415
-%962 = OpFunctionCall %ulong %6 %960 %961
-OpStore %416 %962
-%963 = OpLoad %v4uint %321
-%964 = OpCompositeExtract %uint %963 3
-OpStore %417 %964
-%965 = OpLoad %ulong %416
-%966 = OpLoad %uint %417
-%967 = OpFunctionCall %ulong %6 %965 %966
-OpStore %418 %967
-OpBranch %164
-%164 = OpLabel
-%968 = OpLoad %v4uint %171
-OpStore %322 %968
-%969 = OpLoad %v4uint %322
-%970 = OpLoad %v4uint %298
-%971 = OpIAdd %v4uint %969 %970
-OpStore %323 %971
-OpBranch %165
-%165 = OpLabel
-%972 = OpLoad %v4uint %323
-%973 = OpCompositeExtract %uint %972 0
-OpStore %419 %973
-%974 = OpLoad %ulong %418
-%975 = OpLoad %uint %419
-%976 = OpFunctionCall %ulong %6 %974 %975
-OpStore %420 %976
-%977 = OpLoad %v4uint %323
-%978 = OpCompositeExtract %uint %977 1
-OpStore %421 %978
-%979 = OpLoad %ulong %420
-%980 = OpLoad %uint %421
-%981 = OpFunctionCall %ulong %6 %979 %980
-OpStore %422 %981
-%982 = OpLoad %v4uint %323
-%983 = OpCompositeExtract %uint %982 2
-OpStore %423 %983
-%984 = OpLoad %ulong %422
-%985 = OpLoad %uint %423
-%986 = OpFunctionCall %ulong %6 %984 %985
-OpStore %424 %986
-%987 = OpLoad %v4uint %323
-%988 = OpCompositeExtract %uint %987 3
-OpStore %425 %988
-%989 = OpLoad %ulong %424
-%990 = OpLoad %uint %425
-%991 = OpFunctionCall %ulong %6 %989 %990
-OpStore %426 %991
-OpBranch %166
-%166 = OpLabel
-%992 = OpLoad %ulong %426
-OpStore %338 %992
-%993 = OpLoad %v4float %183
-OpStore %345 %993
-OpStore %346 %ulong_0
-OpBranch %144
-%144 = OpLabel
-%995 = OpLoad %ulong %346
-%997 = OpULessThan %bool %995 %ulong_4
-OpStore %324 %997
-%998 = OpLoad %bool %324
-OpLoopMerge %146 %167 None
-OpBranchConditional %998 %145 %146
-%146 = OpLabel
-%999 = OpLoad %ulong %338
-OpReturnValue %999
-%145 = OpLabel
-%1000 = OpLoad %v4float %345
-%1001 = OpCompositeExtract %float %1000 0
-OpStore %325 %1001
-%1002 = OpLoad %v4float %345
-%1003 = OpCompositeExtract %float %1002 3
-OpStore %326 %1003
-%1004 = OpLoad %float %325
-%1005 = OpLoad %float %326
-%1006 = OpFAdd %float %1004 %1005
-OpStore %327 %1006
-%1007 = OpLoad %v4float %345
-%1008 = OpCompositeExtract %float %1007 1
-OpStore %328 %1008
-%1009 = OpLoad %v4float %345
-%1010 = OpCompositeExtract %float %1009 2
-OpStore %329 %1010
-%1011 = OpLoad %float %328
-%1012 = OpLoad %float %329
-%1013 = OpFSub %float %1011 %1012
-OpStore %330 %1013
-%1014 = OpLoad %float %329
-%1015 = OpFMul %float %1014 %float_0_5
-OpStore %331 %1015
-%1016 = OpLoad %float %326
-%1018 = OpFAdd %float %1016 %float_1_25
-OpStore %332 %1018
-%1019 = OpLoad %v4float %345
-%1020 = OpLoad %float %327
-%1021 = OpCompositeInsert %v4float %1020 %1019 0
-OpStore %333 %1021
-%1022 = OpLoad %v4float %333
-%1023 = OpLoad %float %330
-%1024 = OpCompositeInsert %v4float %1023 %1022 1
-OpStore %334 %1024
-%1025 = OpLoad %v4float %334
-%1026 = OpLoad %float %331
-%1027 = OpCompositeInsert %v4float %1026 %1025 2
-OpStore %335 %1027
-%1028 = OpLoad %v4float %335
-%1029 = OpLoad %float %332
-%1030 = OpCompositeInsert %v4float %1029 %1028 3
-OpStore %336 %1030
-OpBranch %151
-%151 = OpLabel
-%1031 = OpLoad %v4float %336
-%1032 = OpCompositeExtract %float %1031 0
-OpStore %363 %1032
-%1033 = OpLoad %ulong %338
-%1034 = OpLoad %float %363
-%1035 = OpFunctionCall %ulong %8 %1033 %1034
-OpStore %364 %1035
-%1036 = OpLoad %v4float %336
-%1037 = OpCompositeExtract %float %1036 1
-OpStore %365 %1037
-%1038 = OpLoad %ulong %364
-%1039 = OpLoad %float %365
-%1040 = OpFunctionCall %ulong %8 %1038 %1039
-OpStore %366 %1040
-%1041 = OpLoad %v4float %336
-%1042 = OpCompositeExtract %float %1041 2
-OpStore %367 %1042
-%1043 = OpLoad %ulong %366
-%1044 = OpLoad %float %367
-%1045 = OpFunctionCall %ulong %8 %1043 %1044
-OpStore %368 %1045
-%1046 = OpLoad %v4float %336
-%1047 = OpCompositeExtract %float %1046 3
-OpStore %369 %1047
-%1048 = OpLoad %ulong %368
-%1049 = OpLoad %float %369
-%1050 = OpFunctionCall %ulong %8 %1048 %1049
-OpStore %370 %1050
-OpBranch %152
-%152 = OpLabel
-%1051 = OpLoad %ulong %346
-%1053 = OpIAdd %ulong %1051 %ulong_1
-OpStore %337 %1053
-%1054 = OpLoad %ulong %370
-OpStore %338 %1054
-%1055 = OpLoad %v4float %336
-OpStore %345 %1055
-%1056 = OpLoad %ulong %337
-OpStore %346 %1056
-OpBranch %167
-%167 = OpLabel
-OpBranch %144
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_bool Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_ulong Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_bool Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_ulong Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_bool Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_bool Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+OpStore %249 %214
+OpStore %251 %215
+%296 = OpLoad %v4uint %251
+%297 = OpCompositeExtract %uint %296 0
+OpStore %252 %297
+OpBranch %217
+%217 = OpLabel
+%298 = OpLoad %uint %252
+%299 = OpSConvert %ulong %298
+OpStore %256 %299
+OpBranch %219
+%219 = OpLabel
+%300 = OpLoad %ulong %249
+OpStore %264 %300
+OpStore %265 %ulong_0
+OpBranch %220
+%220 = OpLabel
+%301 = OpLoad %ulong %265
+%302 = OpULessThan %bool %301 %ulong_8
+OpStore %257 %302
+%303 = OpLoad %bool %257
+OpLoopMerge %222 %248 None
+OpBranchConditional %303 %221 %222
+%222 = OpLabel
+OpBranch %223
+%223 = OpLabel
+OpBranch %218
+%218 = OpLabel
+%304 = OpLoad %v4uint %251
+%305 = OpCompositeExtract %uint %304 1
+OpStore %253 %305
+OpBranch %224
+%224 = OpLabel
+%306 = OpLoad %uint %253
+%307 = OpSConvert %ulong %306
+OpStore %266 %307
+OpBranch %226
+%226 = OpLabel
+%308 = OpLoad %ulong %264
+OpStore %274 %308
+OpStore %275 %ulong_0
+OpBranch %227
+%227 = OpLabel
+%309 = OpLoad %ulong %275
+%310 = OpULessThan %bool %309 %ulong_8
+OpStore %267 %310
+%311 = OpLoad %bool %267
+OpLoopMerge %229 %247 None
+OpBranchConditional %311 %228 %229
+%229 = OpLabel
+OpBranch %230
+%230 = OpLabel
+OpBranch %225
+%225 = OpLabel
+%312 = OpLoad %v4uint %251
+%313 = OpCompositeExtract %uint %312 2
+OpStore %254 %313
+OpBranch %231
+%231 = OpLabel
+%314 = OpLoad %uint %254
+%315 = OpSConvert %ulong %314
+OpStore %276 %315
+OpBranch %233
+%233 = OpLabel
+%316 = OpLoad %ulong %274
+OpStore %284 %316
+OpStore %285 %ulong_0
+OpBranch %234
+%234 = OpLabel
+%317 = OpLoad %ulong %285
+%318 = OpULessThan %bool %317 %ulong_8
+OpStore %277 %318
+%319 = OpLoad %bool %277
+OpLoopMerge %236 %246 None
+OpBranchConditional %319 %235 %236
+%236 = OpLabel
+OpBranch %237
+%237 = OpLabel
+OpBranch %232
+%232 = OpLabel
+%320 = OpLoad %v4uint %251
+%321 = OpCompositeExtract %uint %320 3
+OpStore %255 %321
+OpBranch %238
+%238 = OpLabel
+%322 = OpLoad %uint %255
+%323 = OpSConvert %ulong %322
+OpStore %286 %323
+OpBranch %240
+%240 = OpLabel
+%324 = OpLoad %ulong %284
+OpStore %294 %324
+OpStore %295 %ulong_0
+OpBranch %241
+%241 = OpLabel
+%325 = OpLoad %ulong %295
+%326 = OpULessThan %bool %325 %ulong_8
+OpStore %287 %326
+%327 = OpLoad %bool %287
+OpLoopMerge %243 %245 None
+OpBranchConditional %327 %242 %243
+%243 = OpLabel
+OpBranch %244
+%244 = OpLabel
+OpBranch %239
+%239 = OpLabel
+%328 = OpLoad %ulong %294
+OpReturnValue %328
+%242 = OpLabel
+%329 = OpLoad %ulong %295
+%330 = OpIMul %ulong %329 %ulong_8
+OpStore %288 %330
+%331 = OpLoad %ulong %286
+%332 = OpLoad %ulong %288
+%333 = OpShiftRightLogical %ulong %331 %332
+OpStore %289 %333
+%334 = OpLoad %ulong %289
+%335 = OpBitwiseAnd %ulong %334 %ulong_255
+OpStore %290 %335
+%336 = OpLoad %ulong %294
+%337 = OpLoad %ulong %290
+%338 = OpBitwiseXor %ulong %336 %337
+OpStore %291 %338
+%339 = OpLoad %ulong %291
+%340 = OpIMul %ulong %339 %ulong_1099511628211
+OpStore %292 %340
+%341 = OpLoad %ulong %295
+%342 = OpIAdd %ulong %341 %ulong_1
+OpStore %293 %342
+%343 = OpLoad %ulong %292
+OpStore %294 %343
+%344 = OpLoad %ulong %293
+OpStore %295 %344
+OpBranch %245
+%235 = OpLabel
+%345 = OpLoad %ulong %285
+%346 = OpIMul %ulong %345 %ulong_8
+OpStore %278 %346
+%347 = OpLoad %ulong %276
+%348 = OpLoad %ulong %278
+%349 = OpShiftRightLogical %ulong %347 %348
+OpStore %279 %349
+%350 = OpLoad %ulong %279
+%351 = OpBitwiseAnd %ulong %350 %ulong_255
+OpStore %280 %351
+%352 = OpLoad %ulong %284
+%353 = OpLoad %ulong %280
+%354 = OpBitwiseXor %ulong %352 %353
+OpStore %281 %354
+%355 = OpLoad %ulong %281
+%356 = OpIMul %ulong %355 %ulong_1099511628211
+OpStore %282 %356
+%357 = OpLoad %ulong %285
+%358 = OpIAdd %ulong %357 %ulong_1
+OpStore %283 %358
+%359 = OpLoad %ulong %282
+OpStore %284 %359
+%360 = OpLoad %ulong %283
+OpStore %285 %360
+OpBranch %246
+%228 = OpLabel
+%361 = OpLoad %ulong %275
+%362 = OpIMul %ulong %361 %ulong_8
+OpStore %268 %362
+%363 = OpLoad %ulong %266
+%364 = OpLoad %ulong %268
+%365 = OpShiftRightLogical %ulong %363 %364
+OpStore %269 %365
+%366 = OpLoad %ulong %269
+%367 = OpBitwiseAnd %ulong %366 %ulong_255
+OpStore %270 %367
+%368 = OpLoad %ulong %274
+%369 = OpLoad %ulong %270
+%370 = OpBitwiseXor %ulong %368 %369
+OpStore %271 %370
+%371 = OpLoad %ulong %271
+%372 = OpIMul %ulong %371 %ulong_1099511628211
+OpStore %272 %372
+%373 = OpLoad %ulong %275
+%374 = OpIAdd %ulong %373 %ulong_1
+OpStore %273 %374
+%375 = OpLoad %ulong %272
+OpStore %274 %375
+%376 = OpLoad %ulong %273
+OpStore %275 %376
+OpBranch %247
+%221 = OpLabel
+%377 = OpLoad %ulong %265
+%378 = OpIMul %ulong %377 %ulong_8
+OpStore %258 %378
+%379 = OpLoad %ulong %256
+%380 = OpLoad %ulong %258
+%381 = OpShiftRightLogical %ulong %379 %380
+OpStore %259 %381
+%382 = OpLoad %ulong %259
+%383 = OpBitwiseAnd %ulong %382 %ulong_255
+OpStore %260 %383
+%384 = OpLoad %ulong %264
+%385 = OpLoad %ulong %260
+%386 = OpBitwiseXor %ulong %384 %385
+OpStore %261 %386
+%387 = OpLoad %ulong %261
+%388 = OpIMul %ulong %387 %ulong_1099511628211
+OpStore %262 %388
+%389 = OpLoad %ulong %265
+%390 = OpIAdd %ulong %389 %ulong_1
+OpStore %263 %390
+%391 = OpLoad %ulong %262
+OpStore %264 %391
+%392 = OpLoad %ulong %263
+OpStore %265 %392
+OpBranch %248
+%245 = OpLabel
+OpBranch %241
+%246 = OpLabel
+OpBranch %234
+%247 = OpLabel
+OpBranch %227
+%248 = OpLabel
+OpBranch %220
 OpFunctionEnd
-%5 = OpFunction %ulong None %1057
-%1058 = OpLabel
-OpReturnValue %ulong_14695981039346656037
+%3 = OpFunction %ulong None %213
+%393 = OpFunctionParameter %ulong
+%394 = OpFunctionParameter %v4uint
+%395 = OpLabel
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_v4uint Function
+%430 = OpVariable %_ptr_Function_uint Function
+%431 = OpVariable %_ptr_Function_uint Function
+%432 = OpVariable %_ptr_Function_uint Function
+%433 = OpVariable %_ptr_Function_uint Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_bool Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_bool Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_bool Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_bool Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+OpStore %428 %393
+OpStore %429 %394
+%474 = OpLoad %v4uint %429
+%475 = OpCompositeExtract %uint %474 0
+OpStore %430 %475
+OpBranch %396
+%396 = OpLabel
+%476 = OpLoad %uint %430
+%477 = OpUConvert %ulong %476
+OpStore %434 %477
+OpBranch %398
+%398 = OpLabel
+%478 = OpLoad %ulong %428
+OpStore %442 %478
+OpStore %443 %ulong_0
+OpBranch %399
+%399 = OpLabel
+%479 = OpLoad %ulong %443
+%480 = OpULessThan %bool %479 %ulong_8
+OpStore %435 %480
+%481 = OpLoad %bool %435
+OpLoopMerge %401 %427 None
+OpBranchConditional %481 %400 %401
+%401 = OpLabel
+OpBranch %402
+%402 = OpLabel
+OpBranch %397
+%397 = OpLabel
+%482 = OpLoad %v4uint %429
+%483 = OpCompositeExtract %uint %482 1
+OpStore %431 %483
+OpBranch %403
+%403 = OpLabel
+%484 = OpLoad %uint %431
+%485 = OpUConvert %ulong %484
+OpStore %444 %485
+OpBranch %405
+%405 = OpLabel
+%486 = OpLoad %ulong %442
+OpStore %452 %486
+OpStore %453 %ulong_0
+OpBranch %406
+%406 = OpLabel
+%487 = OpLoad %ulong %453
+%488 = OpULessThan %bool %487 %ulong_8
+OpStore %445 %488
+%489 = OpLoad %bool %445
+OpLoopMerge %408 %426 None
+OpBranchConditional %489 %407 %408
+%408 = OpLabel
+OpBranch %409
+%409 = OpLabel
+OpBranch %404
+%404 = OpLabel
+%490 = OpLoad %v4uint %429
+%491 = OpCompositeExtract %uint %490 2
+OpStore %432 %491
+OpBranch %410
+%410 = OpLabel
+%492 = OpLoad %uint %432
+%493 = OpUConvert %ulong %492
+OpStore %454 %493
+OpBranch %412
+%412 = OpLabel
+%494 = OpLoad %ulong %452
+OpStore %462 %494
+OpStore %463 %ulong_0
+OpBranch %413
+%413 = OpLabel
+%495 = OpLoad %ulong %463
+%496 = OpULessThan %bool %495 %ulong_8
+OpStore %455 %496
+%497 = OpLoad %bool %455
+OpLoopMerge %415 %425 None
+OpBranchConditional %497 %414 %415
+%415 = OpLabel
+OpBranch %416
+%416 = OpLabel
+OpBranch %411
+%411 = OpLabel
+%498 = OpLoad %v4uint %429
+%499 = OpCompositeExtract %uint %498 3
+OpStore %433 %499
+OpBranch %417
+%417 = OpLabel
+%500 = OpLoad %uint %433
+%501 = OpUConvert %ulong %500
+OpStore %464 %501
+OpBranch %419
+%419 = OpLabel
+%502 = OpLoad %ulong %462
+OpStore %472 %502
+OpStore %473 %ulong_0
+OpBranch %420
+%420 = OpLabel
+%503 = OpLoad %ulong %473
+%504 = OpULessThan %bool %503 %ulong_8
+OpStore %465 %504
+%505 = OpLoad %bool %465
+OpLoopMerge %422 %424 None
+OpBranchConditional %505 %421 %422
+%422 = OpLabel
+OpBranch %423
+%423 = OpLabel
+OpBranch %418
+%418 = OpLabel
+%506 = OpLoad %ulong %472
+OpReturnValue %506
+%421 = OpLabel
+%507 = OpLoad %ulong %473
+%508 = OpIMul %ulong %507 %ulong_8
+OpStore %466 %508
+%509 = OpLoad %ulong %464
+%510 = OpLoad %ulong %466
+%511 = OpShiftRightLogical %ulong %509 %510
+OpStore %467 %511
+%512 = OpLoad %ulong %467
+%513 = OpBitwiseAnd %ulong %512 %ulong_255
+OpStore %468 %513
+%514 = OpLoad %ulong %472
+%515 = OpLoad %ulong %468
+%516 = OpBitwiseXor %ulong %514 %515
+OpStore %469 %516
+%517 = OpLoad %ulong %469
+%518 = OpIMul %ulong %517 %ulong_1099511628211
+OpStore %470 %518
+%519 = OpLoad %ulong %473
+%520 = OpIAdd %ulong %519 %ulong_1
+OpStore %471 %520
+%521 = OpLoad %ulong %470
+OpStore %472 %521
+%522 = OpLoad %ulong %471
+OpStore %473 %522
+OpBranch %424
+%414 = OpLabel
+%523 = OpLoad %ulong %463
+%524 = OpIMul %ulong %523 %ulong_8
+OpStore %456 %524
+%525 = OpLoad %ulong %454
+%526 = OpLoad %ulong %456
+%527 = OpShiftRightLogical %ulong %525 %526
+OpStore %457 %527
+%528 = OpLoad %ulong %457
+%529 = OpBitwiseAnd %ulong %528 %ulong_255
+OpStore %458 %529
+%530 = OpLoad %ulong %462
+%531 = OpLoad %ulong %458
+%532 = OpBitwiseXor %ulong %530 %531
+OpStore %459 %532
+%533 = OpLoad %ulong %459
+%534 = OpIMul %ulong %533 %ulong_1099511628211
+OpStore %460 %534
+%535 = OpLoad %ulong %463
+%536 = OpIAdd %ulong %535 %ulong_1
+OpStore %461 %536
+%537 = OpLoad %ulong %460
+OpStore %462 %537
+%538 = OpLoad %ulong %461
+OpStore %463 %538
+OpBranch %425
+%407 = OpLabel
+%539 = OpLoad %ulong %453
+%540 = OpIMul %ulong %539 %ulong_8
+OpStore %446 %540
+%541 = OpLoad %ulong %444
+%542 = OpLoad %ulong %446
+%543 = OpShiftRightLogical %ulong %541 %542
+OpStore %447 %543
+%544 = OpLoad %ulong %447
+%545 = OpBitwiseAnd %ulong %544 %ulong_255
+OpStore %448 %545
+%546 = OpLoad %ulong %452
+%547 = OpLoad %ulong %448
+%548 = OpBitwiseXor %ulong %546 %547
+OpStore %449 %548
+%549 = OpLoad %ulong %449
+%550 = OpIMul %ulong %549 %ulong_1099511628211
+OpStore %450 %550
+%551 = OpLoad %ulong %453
+%552 = OpIAdd %ulong %551 %ulong_1
+OpStore %451 %552
+%553 = OpLoad %ulong %450
+OpStore %452 %553
+%554 = OpLoad %ulong %451
+OpStore %453 %554
+OpBranch %426
+%400 = OpLabel
+%555 = OpLoad %ulong %443
+%556 = OpIMul %ulong %555 %ulong_8
+OpStore %436 %556
+%557 = OpLoad %ulong %434
+%558 = OpLoad %ulong %436
+%559 = OpShiftRightLogical %ulong %557 %558
+OpStore %437 %559
+%560 = OpLoad %ulong %437
+%561 = OpBitwiseAnd %ulong %560 %ulong_255
+OpStore %438 %561
+%562 = OpLoad %ulong %442
+%563 = OpLoad %ulong %438
+%564 = OpBitwiseXor %ulong %562 %563
+OpStore %439 %564
+%565 = OpLoad %ulong %439
+%566 = OpIMul %ulong %565 %ulong_1099511628211
+OpStore %440 %566
+%567 = OpLoad %ulong %443
+%568 = OpIAdd %ulong %567 %ulong_1
+OpStore %441 %568
+%569 = OpLoad %ulong %440
+OpStore %442 %569
+%570 = OpLoad %ulong %441
+OpStore %443 %570
+OpBranch %427
+%424 = OpLabel
+OpBranch %420
+%425 = OpLabel
+OpBranch %413
+%426 = OpLabel
+OpBranch %406
+%427 = OpLabel
+OpBranch %399
 OpFunctionEnd
-%6 = OpFunction %ulong None %1060
-%1061 = OpFunctionParameter %ulong
-%1062 = OpFunctionParameter %uint
-%1063 = OpLabel
-%1070 = OpVariable %_ptr_Function_ulong Function
-%1071 = OpVariable %_ptr_Function_uint Function
-%1072 = OpVariable %_ptr_Function_ulong Function
-%1073 = OpVariable %_ptr_Function_bool Function
-%1074 = OpVariable %_ptr_Function_ulong Function
-%1075 = OpVariable %_ptr_Function_ulong Function
-%1076 = OpVariable %_ptr_Function_ulong Function
-%1077 = OpVariable %_ptr_Function_ulong Function
-%1078 = OpVariable %_ptr_Function_ulong Function
-%1079 = OpVariable %_ptr_Function_ulong Function
-%1080 = OpVariable %_ptr_Function_ulong Function
-%1081 = OpVariable %_ptr_Function_ulong Function
-OpStore %1070 %1061
-OpStore %1071 %1062
-%1082 = OpLoad %uint %1071
-%1083 = OpUConvert %ulong %1082
-OpStore %1072 %1083
-OpBranch %1064
-%1064 = OpLabel
-%1084 = OpLoad %ulong %1070
-OpStore %1080 %1084
-OpStore %1081 %ulong_0
-OpBranch %1065
-%1065 = OpLabel
-%1085 = OpLoad %ulong %1081
-%1087 = OpULessThan %bool %1085 %ulong_8
-OpStore %1073 %1087
-%1088 = OpLoad %bool %1073
-OpLoopMerge %1067 %1069 None
-OpBranchConditional %1088 %1066 %1067
-%1067 = OpLabel
-OpBranch %1068
-%1068 = OpLabel
-%1089 = OpLoad %ulong %1080
-OpReturnValue %1089
-%1066 = OpLabel
-%1090 = OpLoad %ulong %1081
-%1091 = OpIMul %ulong %1090 %ulong_8
-OpStore %1074 %1091
-%1092 = OpLoad %ulong %1072
-%1093 = OpLoad %ulong %1074
-%1094 = OpShiftRightLogical %ulong %1092 %1093
-OpStore %1075 %1094
-%1095 = OpLoad %ulong %1075
-%1097 = OpBitwiseAnd %ulong %1095 %ulong_255
-OpStore %1076 %1097
-%1098 = OpLoad %ulong %1080
-%1099 = OpLoad %ulong %1076
-%1100 = OpBitwiseXor %ulong %1098 %1099
-OpStore %1077 %1100
-%1101 = OpLoad %ulong %1077
-%1103 = OpIMul %ulong %1101 %ulong_1099511628211
-OpStore %1078 %1103
-%1104 = OpLoad %ulong %1081
-%1105 = OpIAdd %ulong %1104 %ulong_1
-OpStore %1079 %1105
-%1106 = OpLoad %ulong %1078
-OpStore %1080 %1106
-%1107 = OpLoad %ulong %1079
-OpStore %1081 %1107
-OpBranch %1069
-%1069 = OpLabel
-OpBranch %1065
+%4 = OpFunction %ulong None %571
+%572 = OpFunctionParameter %ulong
+%573 = OpLabel
+%650 = OpVariable %_ptr_Function_v4float Function
+%651 = OpVariable %_ptr_Function_v4uint Function
+%652 = OpVariable %_ptr_Function_v4uint Function
+%653 = OpVariable %_ptr_Function_ulong Function
+%654 = OpVariable %_ptr_Function_float Function
+%655 = OpVariable %_ptr_Function_uint Function
+%656 = OpVariable %_ptr_Function_float Function
+%657 = OpVariable %_ptr_Function_float Function
+%658 = OpVariable %_ptr_Function_v4float Function
+%659 = OpVariable %_ptr_Function_float Function
+%660 = OpVariable %_ptr_Function_v4float Function
+%661 = OpVariable %_ptr_Function_float Function
+%662 = OpVariable %_ptr_Function_float Function
+%663 = OpVariable %_ptr_Function_v4float Function
+%664 = OpVariable %_ptr_Function_float Function
+%665 = OpVariable %_ptr_Function_float Function
+%666 = OpVariable %_ptr_Function_v4float Function
+%667 = OpVariable %_ptr_Function_float Function
+%668 = OpVariable %_ptr_Function_float Function
+%669 = OpVariable %_ptr_Function_float Function
+%670 = OpVariable %_ptr_Function_float Function
+%671 = OpVariable %_ptr_Function_float Function
+%672 = OpVariable %_ptr_Function_float Function
+%673 = OpVariable %_ptr_Function_float Function
+%674 = OpVariable %_ptr_Function_float Function
+%675 = OpVariable %_ptr_Function_float Function
+%676 = OpVariable %_ptr_Function_float Function
+%677 = OpVariable %_ptr_Function_float Function
+%678 = OpVariable %_ptr_Function_float Function
+%679 = OpVariable %_ptr_Function_float Function
+%680 = OpVariable %_ptr_Function_float Function
+%681 = OpVariable %_ptr_Function_float Function
+%682 = OpVariable %_ptr_Function_v4float Function
+%683 = OpVariable %_ptr_Function_float Function
+%684 = OpVariable %_ptr_Function_float Function
+%685 = OpVariable %_ptr_Function_float Function
+%686 = OpVariable %_ptr_Function_v4float Function
+%687 = OpVariable %_ptr_Function_float Function
+%688 = OpVariable %_ptr_Function_float Function
+%689 = OpVariable %_ptr_Function_float Function
+%690 = OpVariable %_ptr_Function_v4float Function
+%691 = OpVariable %_ptr_Function_float Function
+%692 = OpVariable %_ptr_Function_float Function
+%693 = OpVariable %_ptr_Function_v4float Function
+%694 = OpVariable %_ptr_Function_ulong Function
+%695 = OpVariable %_ptr_Function_v4float Function
+%696 = OpVariable %_ptr_Function_ulong Function
+%697 = OpVariable %_ptr_Function_float Function
+%698 = OpVariable %_ptr_Function_bool Function
+%699 = OpVariable %_ptr_Function_float Function
+%700 = OpVariable %_ptr_Function_float Function
+%701 = OpVariable %_ptr_Function_bool Function
+%702 = OpVariable %_ptr_Function_float Function
+%703 = OpVariable %_ptr_Function_float Function
+%704 = OpVariable %_ptr_Function_bool Function
+%705 = OpVariable %_ptr_Function_float Function
+%706 = OpVariable %_ptr_Function_float Function
+%707 = OpVariable %_ptr_Function_float Function
+%708 = OpVariable %_ptr_Function_bool Function
+%709 = OpVariable %_ptr_Function_float Function
+%710 = OpVariable %_ptr_Function_float Function
+%711 = OpVariable %_ptr_Function_bool Function
+%712 = OpVariable %_ptr_Function_float Function
+%713 = OpVariable %_ptr_Function_float Function
+%714 = OpVariable %_ptr_Function_bool Function
+%715 = OpVariable %_ptr_Function_float Function
+%716 = OpVariable %_ptr_Function_float Function
+%717 = OpVariable %_ptr_Function_v4uint Function
+%718 = OpVariable %_ptr_Function_uint Function
+%719 = OpVariable %_ptr_Function_uint Function
+%720 = OpVariable %_ptr_Function_uint Function
+%721 = OpVariable %_ptr_Function_v4uint Function
+%722 = OpVariable %_ptr_Function_uint Function
+%723 = OpVariable %_ptr_Function_float Function
+%724 = OpVariable %_ptr_Function_v4float Function
+%725 = OpVariable %_ptr_Function_v4float Function
+%726 = OpVariable %_ptr_Function_uint Function
+%727 = OpVariable %_ptr_Function_float Function
+%728 = OpVariable %_ptr_Function_v4float Function
+%729 = OpVariable %_ptr_Function_v4float Function
+%730 = OpVariable %_ptr_Function_uint Function
+%731 = OpVariable %_ptr_Function_float Function
+%732 = OpVariable %_ptr_Function_v4float Function
+%733 = OpVariable %_ptr_Function_v4float Function
+%734 = OpVariable %_ptr_Function_uint Function
+%735 = OpVariable %_ptr_Function_float Function
+%736 = OpVariable %_ptr_Function_v4float Function
+%737 = OpVariable %_ptr_Function_v4float Function
+%738 = OpVariable %_ptr_Function_v4float Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_v4float Function
+%741 = OpVariable %_ptr_Function_v4float Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_v4float Function
+%744 = OpVariable %_ptr_Function_float Function
+%745 = OpVariable %_ptr_Function_float Function
+%746 = OpVariable %_ptr_Function_uint Function
+%747 = OpVariable %_ptr_Function_v4uint Function
+%748 = OpVariable %_ptr_Function_v4uint Function
+%749 = OpVariable %_ptr_Function_v4float Function
+%750 = OpVariable %_ptr_Function_float Function
+%751 = OpVariable %_ptr_Function_float Function
+%752 = OpVariable %_ptr_Function_uint Function
+%753 = OpVariable %_ptr_Function_v4uint Function
+%754 = OpVariable %_ptr_Function_v4uint Function
+%755 = OpVariable %_ptr_Function_v4float Function
+%756 = OpVariable %_ptr_Function_float Function
+%757 = OpVariable %_ptr_Function_float Function
+%758 = OpVariable %_ptr_Function_uint Function
+%759 = OpVariable %_ptr_Function_v4uint Function
+%760 = OpVariable %_ptr_Function_v4uint Function
+%761 = OpVariable %_ptr_Function_v4float Function
+%762 = OpVariable %_ptr_Function_float Function
+%763 = OpVariable %_ptr_Function_float Function
+%764 = OpVariable %_ptr_Function_uint Function
+%765 = OpVariable %_ptr_Function_v4uint Function
+%766 = OpVariable %_ptr_Function_v4uint Function
+%767 = OpVariable %_ptr_Function_v4uint Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_v4uint Function
+%770 = OpVariable %_ptr_Function_v4uint Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_v4uint Function
+%773 = OpVariable %_ptr_Function_v4uint Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_v4uint Function
+%776 = OpVariable %_ptr_Function_uint Function
+%777 = OpVariable %_ptr_Function_uint Function
+%778 = OpVariable %_ptr_Function_v4uint Function
+%779 = OpVariable %_ptr_Function_uint Function
+%780 = OpVariable %_ptr_Function_uint Function
+%781 = OpVariable %_ptr_Function_uint Function
+%782 = OpVariable %_ptr_Function_uint Function
+%783 = OpVariable %_ptr_Function_uint Function
+%784 = OpVariable %_ptr_Function_uint Function
+%785 = OpVariable %_ptr_Function_uint Function
+%786 = OpVariable %_ptr_Function_v4uint Function
+%787 = OpVariable %_ptr_Function_v4uint Function
+%788 = OpVariable %_ptr_Function_uint Function
+%789 = OpVariable %_ptr_Function_uint Function
+%790 = OpVariable %_ptr_Function_v4uint Function
+%791 = OpVariable %_ptr_Function_v4uint Function
+%792 = OpVariable %_ptr_Function_uint Function
+%793 = OpVariable %_ptr_Function_uint Function
+%794 = OpVariable %_ptr_Function_v4uint Function
+%795 = OpVariable %_ptr_Function_v4uint Function
+%796 = OpVariable %_ptr_Function_uint Function
+%797 = OpVariable %_ptr_Function_uint Function
+%798 = OpVariable %_ptr_Function_v4uint Function
+%799 = OpVariable %_ptr_Function_v4uint Function
+%800 = OpVariable %_ptr_Function_v4uint Function
+%801 = OpVariable %_ptr_Function_ulong Function
+%802 = OpVariable %_ptr_Function_v4uint Function
+%803 = OpVariable %_ptr_Function_v4uint Function
+%804 = OpVariable %_ptr_Function_ulong Function
+%805 = OpVariable %_ptr_Function_bool Function
+%806 = OpVariable %_ptr_Function_float Function
+%807 = OpVariable %_ptr_Function_float Function
+%808 = OpVariable %_ptr_Function_float Function
+%809 = OpVariable %_ptr_Function_float Function
+%810 = OpVariable %_ptr_Function_float Function
+%811 = OpVariable %_ptr_Function_float Function
+%812 = OpVariable %_ptr_Function_float Function
+%813 = OpVariable %_ptr_Function_float Function
+%814 = OpVariable %_ptr_Function_v4float Function
+%815 = OpVariable %_ptr_Function_v4float Function
+%816 = OpVariable %_ptr_Function_v4float Function
+%817 = OpVariable %_ptr_Function_v4float Function
+%818 = OpVariable %_ptr_Function_ulong Function
+%819 = OpVariable %_ptr_Function_ulong Function
+%820 = OpVariable %_ptr_Function_ulong Function
+%821 = OpVariable %_ptr_Function_float Function
+%822 = OpVariable %_ptr_Function_float Function
+%823 = OpVariable %_ptr_Function_float Function
+%824 = OpVariable %_ptr_Function_float Function
+%825 = OpVariable %_ptr_Function_float Function
+%826 = OpVariable %_ptr_Function_float Function
+%827 = OpVariable %_ptr_Function_v4float Function
+%828 = OpVariable %_ptr_Function_ulong Function
+%829 = OpVariable %_ptr_Function_uint Function
+%830 = OpVariable %_ptr_Function_ulong Function
+%831 = OpVariable %_ptr_Function_uint Function
+%832 = OpVariable %_ptr_Function_ulong Function
+%833 = OpVariable %_ptr_Function_bool Function
+%834 = OpVariable %_ptr_Function_ulong Function
+%835 = OpVariable %_ptr_Function_ulong Function
+%836 = OpVariable %_ptr_Function_ulong Function
+%837 = OpVariable %_ptr_Function_ulong Function
+%838 = OpVariable %_ptr_Function_ulong Function
+%839 = OpVariable %_ptr_Function_ulong Function
+%840 = OpVariable %_ptr_Function_ulong Function
+%841 = OpVariable %_ptr_Function_ulong Function
+%842 = OpVariable %_ptr_Function_uint Function
+%843 = OpVariable %_ptr_Function_ulong Function
+%844 = OpVariable %_ptr_Function_bool Function
+%845 = OpVariable %_ptr_Function_ulong Function
+%846 = OpVariable %_ptr_Function_ulong Function
+%847 = OpVariable %_ptr_Function_ulong Function
+%848 = OpVariable %_ptr_Function_ulong Function
+%849 = OpVariable %_ptr_Function_ulong Function
+%850 = OpVariable %_ptr_Function_ulong Function
+%851 = OpVariable %_ptr_Function_ulong Function
+%852 = OpVariable %_ptr_Function_ulong Function
+%853 = OpVariable %_ptr_Function_uint Function
+%854 = OpVariable %_ptr_Function_ulong Function
+%855 = OpVariable %_ptr_Function_bool Function
+%856 = OpVariable %_ptr_Function_ulong Function
+%857 = OpVariable %_ptr_Function_ulong Function
+%858 = OpVariable %_ptr_Function_ulong Function
+%859 = OpVariable %_ptr_Function_ulong Function
+%860 = OpVariable %_ptr_Function_ulong Function
+%861 = OpVariable %_ptr_Function_ulong Function
+%862 = OpVariable %_ptr_Function_ulong Function
+%863 = OpVariable %_ptr_Function_ulong Function
+%864 = OpVariable %_ptr_Function_uint Function
+%865 = OpVariable %_ptr_Function_ulong Function
+%866 = OpVariable %_ptr_Function_ulong Function
+%867 = OpVariable %_ptr_Function_bool Function
+%868 = OpVariable %_ptr_Function_ulong Function
+%869 = OpVariable %_ptr_Function_ulong Function
+%870 = OpVariable %_ptr_Function_ulong Function
+%871 = OpVariable %_ptr_Function_ulong Function
+%872 = OpVariable %_ptr_Function_ulong Function
+%873 = OpVariable %_ptr_Function_ulong Function
+%874 = OpVariable %_ptr_Function_ulong Function
+%875 = OpVariable %_ptr_Function_ulong Function
+%876 = OpVariable %_ptr_Function_uint Function
+%877 = OpVariable %_ptr_Function_ulong Function
+%878 = OpVariable %_ptr_Function_ulong Function
+%879 = OpVariable %_ptr_Function_ulong Function
+%880 = OpVariable %_ptr_Function_ulong Function
+%881 = OpVariable %_ptr_Function_uint Function
+%882 = OpVariable %_ptr_Function_ulong Function
+%883 = OpVariable %_ptr_Function_ulong Function
+%884 = OpVariable %_ptr_Function_ulong Function
+%885 = OpVariable %_ptr_Function_ulong Function
+%886 = OpVariable %_ptr_Function_uint Function
+%887 = OpVariable %_ptr_Function_ulong Function
+%888 = OpVariable %_ptr_Function_ulong Function
+%889 = OpVariable %_ptr_Function_ulong Function
+%890 = OpVariable %_ptr_Function_ulong Function
+%891 = OpVariable %_ptr_Function_uint Function
+%892 = OpVariable %_ptr_Function_ulong Function
+%893 = OpVariable %_ptr_Function_ulong Function
+%894 = OpVariable %_ptr_Function_ulong Function
+%895 = OpVariable %_ptr_Function_ulong Function
+%896 = OpVariable %_ptr_Function_uint Function
+%897 = OpVariable %_ptr_Function_ulong Function
+%898 = OpVariable %_ptr_Function_ulong Function
+OpStore %653 %572
+OpBranch %595
+%595 = OpLabel
+OpBranch %596
+%596 = OpLabel
+%899 = OpLoad %ulong %653
+%900 = OpConvertUToF %float %899
+OpStore %654 %900
+%901 = OpLoad %ulong %653
+%902 = OpUConvert %uint %901
+OpStore %655 %902
+%904 = OpFNegate %float %float_2_25
+OpStore %656 %904
+%906 = OpFNegate %float %float_0_5
+OpStore %657 %906
+%909 = OpLoad %float %656
+%911 = OpLoad %float %657
+%907 = OpCompositeConstruct %v4float %float_1_5 %909 %float_3_75 %911
+OpStore %658 %907
+%913 = OpFNegate %float %float_0_125
+OpStore %659 %913
+%916 = OpLoad %float %659
+%914 = OpCompositeConstruct %v4float %float_0_5 %float_4 %916 %float_8
+OpStore %660 %914
+%918 = OpLoad %v4float %658
+%919 = OpCompositeExtract %float %918 0
+OpStore %661 %919
+%920 = OpLoad %float %661
+%921 = OpLoad %float %654
+%922 = OpFAdd %float %920 %921
+OpStore %662 %922
+%923 = OpLoad %v4float %658
+%924 = OpLoad %float %662
+%925 = OpCompositeInsert %v4float %924 %923 0
+OpStore %663 %925
+%926 = OpLoad %v4float %660
+%927 = OpCompositeExtract %float %926 2
+OpStore %664 %927
+%928 = OpLoad %float %664
+%929 = OpLoad %float %654
+%930 = OpFAdd %float %928 %929
+OpStore %665 %930
+%931 = OpLoad %v4float %660
+%932 = OpLoad %float %665
+%933 = OpCompositeInsert %v4float %932 %931 2
+OpStore %666 %933
+%934 = OpLoad %v4float %663
+%935 = OpCompositeExtract %float %934 0
+OpStore %667 %935
+%936 = OpLoad %v4float %666
+%937 = OpCompositeExtract %float %936 0
+OpStore %668 %937
+%938 = OpLoad %float %667
+%939 = OpLoad %float %668
+%940 = OpFMul %float %938 %939
+OpStore %669 %940
+%941 = OpLoad %v4float %663
+%942 = OpCompositeExtract %float %941 1
+OpStore %670 %942
+%943 = OpLoad %v4float %666
+%944 = OpCompositeExtract %float %943 1
+OpStore %671 %944
+%945 = OpLoad %float %670
+%946 = OpLoad %float %671
+%947 = OpFMul %float %945 %946
+OpStore %672 %947
+%948 = OpLoad %v4float %663
+%949 = OpCompositeExtract %float %948 2
+OpStore %673 %949
+%950 = OpLoad %v4float %666
+%951 = OpCompositeExtract %float %950 2
+OpStore %674 %951
+%952 = OpLoad %float %673
+%953 = OpLoad %float %674
+%954 = OpFMul %float %952 %953
+OpStore %675 %954
+%955 = OpLoad %v4float %663
+%956 = OpCompositeExtract %float %955 3
+OpStore %676 %956
+%957 = OpLoad %v4float %666
+%958 = OpCompositeExtract %float %957 3
+OpStore %677 %958
+%959 = OpLoad %float %676
+%960 = OpLoad %float %677
+%961 = OpFMul %float %959 %960
+OpStore %678 %961
+OpBranch %599
+%599 = OpLabel
+%962 = OpLoad %float %669
+%963 = OpBitcast %uint %962
+OpStore %831 %963
+%964 = OpLoad %uint %831
+%965 = OpUConvert %ulong %964
+OpStore %832 %965
+OpBranch %608
+%608 = OpLabel
+OpStore %851 %ulong_14695981039346656037
+OpStore %852 %ulong_0
+OpBranch %609
+%609 = OpLabel
+%967 = OpLoad %ulong %852
+%968 = OpULessThan %bool %967 %ulong_8
+OpStore %844 %968
+%969 = OpLoad %bool %844
+OpLoopMerge %611 %649 None
+OpBranchConditional %969 %610 %611
+%611 = OpLabel
+OpBranch %612
+%612 = OpLabel
+OpBranch %600
+%600 = OpLabel
+OpBranch %613
+%613 = OpLabel
+%970 = OpLoad %float %672
+%971 = OpBitcast %uint %970
+OpStore %853 %971
+%972 = OpLoad %uint %853
+%973 = OpUConvert %ulong %972
+OpStore %854 %973
+OpBranch %622
+%622 = OpLabel
+%974 = OpLoad %ulong %851
+OpStore %874 %974
+OpStore %875 %ulong_0
+OpBranch %623
+%623 = OpLabel
+%975 = OpLoad %ulong %875
+%976 = OpULessThan %bool %975 %ulong_8
+OpStore %867 %976
+%977 = OpLoad %bool %867
+OpLoopMerge %625 %648 None
+OpBranchConditional %977 %624 %625
+%625 = OpLabel
+OpBranch %626
+%626 = OpLabel
+OpBranch %614
+%614 = OpLabel
+OpBranch %627
+%627 = OpLabel
+%978 = OpLoad %float %675
+%979 = OpBitcast %uint %978
+OpStore %876 %979
+%980 = OpLoad %uint %876
+%981 = OpUConvert %ulong %980
+OpStore %877 %981
+%982 = OpLoad %ulong %874
+%983 = OpLoad %ulong %877
+%984 = OpFunctionCall %ulong %5 %982 %983
+OpStore %878 %984
+OpBranch %628
+%628 = OpLabel
+OpBranch %631
+%631 = OpLabel
+%985 = OpLoad %float %678
+%986 = OpBitcast %uint %985
+OpStore %881 %986
+%987 = OpLoad %uint %881
+%988 = OpUConvert %ulong %987
+OpStore %882 %988
+%989 = OpLoad %ulong %878
+%990 = OpLoad %ulong %882
+%991 = OpFunctionCall %ulong %5 %989 %990
+OpStore %883 %991
+OpBranch %632
+%632 = OpLabel
+%992 = OpLoad %float %669
+%993 = OpLoad %float %672
+%994 = OpFAdd %float %992 %993
+OpStore %679 %994
+OpBranch %635
+%635 = OpLabel
+%995 = OpLoad %float %679
+%996 = OpBitcast %uint %995
+OpStore %886 %996
+%997 = OpLoad %uint %886
+%998 = OpUConvert %ulong %997
+OpStore %887 %998
+%999 = OpLoad %ulong %883
+%1000 = OpLoad %ulong %887
+%1001 = OpFunctionCall %ulong %5 %999 %1000
+OpStore %888 %1001
+OpBranch %636
+%636 = OpLabel
+%1002 = OpLoad %float %679
+%1003 = OpLoad %float %675
+%1004 = OpFAdd %float %1002 %1003
+OpStore %680 %1004
+OpBranch %639
+%639 = OpLabel
+%1005 = OpLoad %float %680
+%1006 = OpBitcast %uint %1005
+OpStore %891 %1006
+%1007 = OpLoad %uint %891
+%1008 = OpUConvert %ulong %1007
+OpStore %892 %1008
+%1009 = OpLoad %ulong %888
+%1010 = OpLoad %ulong %892
+%1011 = OpFunctionCall %ulong %5 %1009 %1010
+OpStore %893 %1011
+OpBranch %640
+%640 = OpLabel
+%1012 = OpLoad %float %680
+%1013 = OpLoad %float %678
+%1014 = OpFAdd %float %1012 %1013
+OpStore %681 %1014
+OpBranch %643
+%643 = OpLabel
+%1015 = OpLoad %float %681
+%1016 = OpBitcast %uint %1015
+OpStore %896 %1016
+%1017 = OpLoad %uint %896
+%1018 = OpUConvert %ulong %1017
+OpStore %897 %1018
+%1019 = OpLoad %ulong %893
+%1020 = OpLoad %ulong %897
+%1021 = OpFunctionCall %ulong %5 %1019 %1020
+OpStore %898 %1021
+OpBranch %644
+%644 = OpLabel
+%1022 = OpLoad %v4float %663
+%1023 = OpLoad %float %681
+%1024 = OpCompositeInsert %v4float %1023 %1022 0
+OpStore %682 %1024
+%1025 = OpLoad %v4float %663
+%1026 = OpCompositeExtract %float %1025 3
+OpStore %683 %1026
+%1027 = OpLoad %v4float %666
+%1028 = OpCompositeExtract %float %1027 0
+OpStore %684 %1028
+%1029 = OpLoad %float %683
+%1030 = OpLoad %float %684
+%1031 = OpFSub %float %1029 %1030
+OpStore %685 %1031
+%1032 = OpLoad %v4float %682
+%1033 = OpLoad %float %685
+%1034 = OpCompositeInsert %v4float %1033 %1032 1
+OpStore %686 %1034
+%1035 = OpLoad %v4float %666
+%1036 = OpCompositeExtract %float %1035 1
+OpStore %687 %1036
+%1037 = OpLoad %v4float %663
+%1038 = OpCompositeExtract %float %1037 2
+OpStore %688 %1038
+%1039 = OpLoad %float %687
+%1040 = OpLoad %float %688
+%1041 = OpFAdd %float %1039 %1040
+OpStore %689 %1041
+%1042 = OpLoad %v4float %686
+%1043 = OpLoad %float %689
+%1044 = OpCompositeInsert %v4float %1043 %1042 2
+OpStore %690 %1044
+%1045 = OpLoad %v4float %663
+%1046 = OpCompositeExtract %float %1045 1
+OpStore %691 %1046
+%1048 = OpLoad %float %691
+%1049 = OpFSub %float %float_0 %1048
+OpStore %692 %1049
+%1050 = OpLoad %v4float %690
+%1051 = OpLoad %float %692
+%1052 = OpCompositeInsert %v4float %1051 %1050 3
+OpStore %693 %1052
+%1053 = OpLoad %ulong %898
+%1054 = OpLoad %v4float %693
+%1055 = OpFunctionCall %ulong %1 %1053 %1054
+OpStore %694 %1055
+%1056 = OpLoad %v4float %693
+%1057 = OpLoad %v4float %666
+%1058 = OpFMul %v4float %1056 %1057
+OpStore %695 %1058
+%1059 = OpLoad %ulong %694
+%1060 = OpLoad %v4float %695
+%1061 = OpFunctionCall %ulong %1 %1059 %1060
+OpStore %696 %1061
+%1062 = OpLoad %v4float %663
+%1063 = OpCompositeExtract %float %1062 0
+OpStore %697 %1063
+%1064 = OpLoad %float %697
+%1065 = OpLoad %float %691
+%1066 = OpFOrdLessThan %bool %1064 %1065
+OpStore %698 %1066
+%1067 = OpLoad %bool %698
+OpSelectionMerge %576 None
+OpBranchConditional %1067 %574 %575
+%575 = OpLabel
+%1068 = OpLoad %float %697
+OpStore %823 %1068
+OpBranch %576
+%574 = OpLabel
+%1069 = OpLoad %v4float %663
+%1070 = OpCompositeExtract %float %1069 1
+OpStore %699 %1070
+%1071 = OpLoad %float %699
+OpStore %823 %1071
+OpBranch %576
+%576 = OpLabel
+%1072 = OpLoad %v4float %663
+%1073 = OpCompositeExtract %float %1072 2
+OpStore %700 %1073
+%1074 = OpLoad %float %823
+%1075 = OpLoad %float %700
+%1076 = OpFOrdLessThan %bool %1074 %1075
+OpStore %701 %1076
+%1077 = OpLoad %bool %701
+OpSelectionMerge %579 None
+OpBranchConditional %1077 %577 %578
+%578 = OpLabel
+%1078 = OpLoad %float %823
+OpStore %822 %1078
+OpBranch %579
+%577 = OpLabel
+%1079 = OpLoad %v4float %663
+%1080 = OpCompositeExtract %float %1079 2
+OpStore %702 %1080
+%1081 = OpLoad %float %702
+OpStore %822 %1081
+OpBranch %579
+%579 = OpLabel
+%1082 = OpLoad %v4float %663
+%1083 = OpCompositeExtract %float %1082 3
+OpStore %703 %1083
+%1084 = OpLoad %float %822
+%1085 = OpLoad %float %703
+%1086 = OpFOrdLessThan %bool %1084 %1085
+OpStore %704 %1086
+%1087 = OpLoad %bool %704
+OpSelectionMerge %582 None
+OpBranchConditional %1087 %580 %581
+%581 = OpLabel
+%1088 = OpLoad %float %822
+OpStore %821 %1088
+OpBranch %582
+%580 = OpLabel
+%1089 = OpLoad %v4float %663
+%1090 = OpCompositeExtract %float %1089 3
+OpStore %705 %1090
+%1091 = OpLoad %float %705
+OpStore %821 %1091
+OpBranch %582
+%582 = OpLabel
+%1092 = OpLoad %v4float %663
+%1093 = OpCompositeExtract %float %1092 0
+OpStore %706 %1093
+%1094 = OpLoad %v4float %663
+%1095 = OpCompositeExtract %float %1094 1
+OpStore %707 %1095
+%1096 = OpLoad %float %707
+%1097 = OpLoad %float %706
+%1098 = OpFOrdLessThan %bool %1096 %1097
+OpStore %708 %1098
+%1099 = OpLoad %bool %708
+OpSelectionMerge %585 None
+OpBranchConditional %1099 %583 %584
+%584 = OpLabel
+%1100 = OpLoad %float %706
+OpStore %826 %1100
+OpBranch %585
+%583 = OpLabel
+%1101 = OpLoad %v4float %663
+%1102 = OpCompositeExtract %float %1101 1
+OpStore %709 %1102
+%1103 = OpLoad %float %709
+OpStore %826 %1103
+OpBranch %585
+%585 = OpLabel
+%1104 = OpLoad %v4float %663
+%1105 = OpCompositeExtract %float %1104 2
+OpStore %710 %1105
+%1106 = OpLoad %float %710
+%1107 = OpLoad %float %826
+%1108 = OpFOrdLessThan %bool %1106 %1107
+OpStore %711 %1108
+%1109 = OpLoad %bool %711
+OpSelectionMerge %588 None
+OpBranchConditional %1109 %586 %587
+%587 = OpLabel
+%1110 = OpLoad %float %826
+OpStore %825 %1110
+OpBranch %588
+%586 = OpLabel
+%1111 = OpLoad %v4float %663
+%1112 = OpCompositeExtract %float %1111 2
+OpStore %712 %1112
+%1113 = OpLoad %float %712
+OpStore %825 %1113
+OpBranch %588
+%588 = OpLabel
+%1114 = OpLoad %v4float %663
+%1115 = OpCompositeExtract %float %1114 3
+OpStore %713 %1115
+%1116 = OpLoad %float %713
+%1117 = OpLoad %float %825
+%1118 = OpFOrdLessThan %bool %1116 %1117
+OpStore %714 %1118
+%1119 = OpLoad %bool %714
+OpSelectionMerge %591 None
+OpBranchConditional %1119 %589 %590
+%590 = OpLabel
+%1120 = OpLoad %float %825
+OpStore %824 %1120
+OpBranch %591
+%589 = OpLabel
+%1121 = OpLoad %v4float %663
+%1122 = OpCompositeExtract %float %1121 3
+OpStore %715 %1122
+%1123 = OpLoad %float %715
+OpStore %824 %1123
+OpBranch %591
+%591 = OpLabel
+OpBranch %597
+%597 = OpLabel
+%1124 = OpLoad %float %821
+%1125 = OpBitcast %uint %1124
+OpStore %829 %1125
+%1126 = OpLoad %uint %829
+%1127 = OpUConvert %ulong %1126
+OpStore %830 %1127
+OpBranch %601
+%601 = OpLabel
+%1128 = OpLoad %ulong %696
+OpStore %840 %1128
+OpStore %841 %ulong_0
+OpBranch %602
+%602 = OpLabel
+%1129 = OpLoad %ulong %841
+%1130 = OpULessThan %bool %1129 %ulong_8
+OpStore %833 %1130
+%1131 = OpLoad %bool %833
+OpLoopMerge %604 %647 None
+OpBranchConditional %1131 %603 %604
+%604 = OpLabel
+OpBranch %605
+%605 = OpLabel
+OpBranch %598
+%598 = OpLabel
+OpBranch %606
+%606 = OpLabel
+%1132 = OpLoad %float %824
+%1133 = OpBitcast %uint %1132
+OpStore %842 %1133
+%1134 = OpLoad %uint %842
+%1135 = OpUConvert %ulong %1134
+OpStore %843 %1135
+OpBranch %615
+%615 = OpLabel
+%1136 = OpLoad %ulong %840
+OpStore %862 %1136
+OpStore %863 %ulong_0
+OpBranch %616
+%616 = OpLabel
+%1137 = OpLoad %ulong %863
+%1138 = OpULessThan %bool %1137 %ulong_8
+OpStore %855 %1138
+%1139 = OpLoad %bool %855
+OpLoopMerge %618 %646 None
+OpBranchConditional %1139 %617 %618
+%618 = OpLabel
+OpBranch %619
+%619 = OpLabel
+OpBranch %607
+%607 = OpLabel
+%1140 = OpLoad %float %821
+%1141 = OpLoad %float %824
+%1142 = OpFSub %float %1140 %1141
+OpStore %716 %1142
+OpBranch %620
+%620 = OpLabel
+%1143 = OpLoad %float %716
+%1144 = OpBitcast %uint %1143
+OpStore %864 %1144
+%1145 = OpLoad %uint %864
+%1146 = OpUConvert %ulong %1145
+OpStore %865 %1146
+%1147 = OpLoad %ulong %862
+%1148 = OpLoad %ulong %865
+%1149 = OpFunctionCall %ulong %5 %1147 %1148
+OpStore %866 %1149
+OpBranch %621
+%621 = OpLabel
+%1150 = OpCompositeConstruct %v4uint %uint_7 %uint_4294967283 %uint_21 %uint_4294967265
+OpStore %717 %1150
+%1155 = OpLoad %v4uint %717
+%1156 = OpCompositeExtract %uint %1155 1
+OpStore %718 %1156
+%1157 = OpLoad %ulong %653
+%1158 = OpUConvert %uint %1157
+OpStore %719 %1158
+%1159 = OpLoad %uint %718
+%1160 = OpLoad %uint %719
+%1161 = OpIAdd %uint %1159 %1160
+OpStore %720 %1161
+%1162 = OpLoad %v4uint %717
+%1163 = OpLoad %uint %720
+%1164 = OpCompositeInsert %v4uint %1163 %1162 1
+OpStore %721 %1164
+OpStore %650 %1165
+%1166 = OpLoad %v4uint %721
+%1167 = OpCompositeExtract %uint %1166 0
+OpStore %722 %1167
+%1168 = OpLoad %uint %722
+%1169 = OpConvertSToF %float %1168
+OpStore %723 %1169
+%1170 = OpLoad %v4float %650
+OpStore %724 %1170
+%1171 = OpLoad %v4float %724
+%1172 = OpLoad %float %723
+%1173 = OpCompositeInsert %v4float %1172 %1171 0
+OpStore %725 %1173
+%1174 = OpLoad %v4float %725
+OpStore %650 %1174
+%1175 = OpLoad %v4uint %721
+%1176 = OpCompositeExtract %uint %1175 1
+OpStore %726 %1176
+%1177 = OpLoad %uint %726
+%1178 = OpConvertSToF %float %1177
+OpStore %727 %1178
+%1179 = OpLoad %v4float %650
+OpStore %728 %1179
+%1180 = OpLoad %v4float %728
+%1181 = OpLoad %float %727
+%1182 = OpCompositeInsert %v4float %1181 %1180 1
+OpStore %729 %1182
+%1183 = OpLoad %v4float %729
+OpStore %650 %1183
+%1184 = OpLoad %v4uint %721
+%1185 = OpCompositeExtract %uint %1184 2
+OpStore %730 %1185
+%1186 = OpLoad %uint %730
+%1187 = OpConvertSToF %float %1186
+OpStore %731 %1187
+%1188 = OpLoad %v4float %650
+OpStore %732 %1188
+%1189 = OpLoad %v4float %732
+%1190 = OpLoad %float %731
+%1191 = OpCompositeInsert %v4float %1190 %1189 2
+OpStore %733 %1191
+%1192 = OpLoad %v4float %733
+OpStore %650 %1192
+%1193 = OpLoad %v4uint %721
+%1194 = OpCompositeExtract %uint %1193 3
+OpStore %734 %1194
+%1195 = OpLoad %uint %734
+%1196 = OpConvertSToF %float %1195
+OpStore %735 %1196
+%1197 = OpLoad %v4float %650
+OpStore %736 %1197
+%1198 = OpLoad %v4float %736
+%1199 = OpLoad %float %735
+%1200 = OpCompositeInsert %v4float %1199 %1198 3
+OpStore %737 %1200
+%1201 = OpLoad %v4float %737
+OpStore %650 %1201
+%1202 = OpLoad %v4float %650
+OpStore %738 %1202
+%1203 = OpLoad %ulong %866
+%1204 = OpLoad %v4float %738
+%1205 = OpFunctionCall %ulong %1 %1203 %1204
+OpStore %739 %1205
+%1206 = OpLoad %v4float %650
+OpStore %740 %1206
+%1207 = OpLoad %v4float %740
+%1208 = OpLoad %v4float %663
+%1209 = OpFMul %v4float %1207 %1208
+OpStore %741 %1209
+%1210 = OpLoad %ulong %739
+%1211 = OpLoad %v4float %741
+%1212 = OpFunctionCall %ulong %1 %1210 %1211
+OpStore %742 %1212
+OpStore %651 %1213
+%1214 = OpLoad %v4float %650
+OpStore %743 %1214
+%1215 = OpLoad %v4float %743
+%1216 = OpCompositeExtract %float %1215 0
+OpStore %744 %1216
+%1217 = OpLoad %float %744
+%1218 = OpFMul %float %1217 %float_4
+OpStore %745 %1218
+%1219 = OpLoad %float %745
+%1220 = OpConvertFToS %uint %1219
+OpStore %746 %1220
+%1221 = OpLoad %v4uint %651
+OpStore %747 %1221
+%1222 = OpLoad %v4uint %747
+%1223 = OpLoad %uint %746
+%1224 = OpCompositeInsert %v4uint %1223 %1222 0
+OpStore %748 %1224
+%1225 = OpLoad %v4uint %748
+OpStore %651 %1225
+%1226 = OpLoad %v4float %650
+OpStore %749 %1226
+%1227 = OpLoad %v4float %749
+%1228 = OpCompositeExtract %float %1227 1
+OpStore %750 %1228
+%1229 = OpLoad %float %750
+%1230 = OpFMul %float %1229 %float_4
+OpStore %751 %1230
+%1231 = OpLoad %float %751
+%1232 = OpConvertFToS %uint %1231
+OpStore %752 %1232
+%1233 = OpLoad %v4uint %651
+OpStore %753 %1233
+%1234 = OpLoad %v4uint %753
+%1235 = OpLoad %uint %752
+%1236 = OpCompositeInsert %v4uint %1235 %1234 1
+OpStore %754 %1236
+%1237 = OpLoad %v4uint %754
+OpStore %651 %1237
+%1238 = OpLoad %v4float %650
+OpStore %755 %1238
+%1239 = OpLoad %v4float %755
+%1240 = OpCompositeExtract %float %1239 2
+OpStore %756 %1240
+%1241 = OpLoad %float %756
+%1242 = OpFMul %float %1241 %float_4
+OpStore %757 %1242
+%1243 = OpLoad %float %757
+%1244 = OpConvertFToS %uint %1243
+OpStore %758 %1244
+%1245 = OpLoad %v4uint %651
+OpStore %759 %1245
+%1246 = OpLoad %v4uint %759
+%1247 = OpLoad %uint %758
+%1248 = OpCompositeInsert %v4uint %1247 %1246 2
+OpStore %760 %1248
+%1249 = OpLoad %v4uint %760
+OpStore %651 %1249
+%1250 = OpLoad %v4float %650
+OpStore %761 %1250
+%1251 = OpLoad %v4float %761
+%1252 = OpCompositeExtract %float %1251 3
+OpStore %762 %1252
+%1253 = OpLoad %float %762
+%1254 = OpFMul %float %1253 %float_4
+OpStore %763 %1254
+%1255 = OpLoad %float %763
+%1256 = OpConvertFToS %uint %1255
+OpStore %764 %1256
+%1257 = OpLoad %v4uint %651
+OpStore %765 %1257
+%1258 = OpLoad %v4uint %765
+%1259 = OpLoad %uint %764
+%1260 = OpCompositeInsert %v4uint %1259 %1258 3
+OpStore %766 %1260
+%1261 = OpLoad %v4uint %766
+OpStore %651 %1261
+%1262 = OpLoad %v4uint %651
+OpStore %767 %1262
+%1263 = OpLoad %ulong %742
+%1264 = OpLoad %v4uint %767
+%1265 = OpFunctionCall %ulong %2 %1263 %1264
+OpStore %768 %1265
+%1266 = OpLoad %v4uint %651
+OpStore %769 %1266
+%1267 = OpLoad %v4uint %769
+%1268 = OpLoad %v4uint %721
+%1269 = OpIMul %v4uint %1267 %1268
+OpStore %770 %1269
+%1270 = OpLoad %ulong %768
+%1271 = OpLoad %v4uint %770
+%1272 = OpFunctionCall %ulong %2 %1270 %1271
+OpStore %771 %1272
+%1273 = OpLoad %v4uint %651
+OpStore %772 %1273
+%1274 = OpLoad %v4uint %772
+%1275 = OpLoad %v4uint %721
+%1276 = OpISub %v4uint %1274 %1275
+OpStore %773 %1276
+%1277 = OpLoad %ulong %771
+%1278 = OpLoad %v4uint %773
+%1279 = OpFunctionCall %ulong %2 %1277 %1278
+OpStore %774 %1279
+%1280 = OpCompositeConstruct %v4uint %uint_4294967295 %uint_1 %uint_2863311530 %uint_305419896
+OpStore %775 %1280
+%1285 = OpLoad %v4uint %775
+%1286 = OpCompositeExtract %uint %1285 3
+OpStore %776 %1286
+%1287 = OpLoad %uint %776
+%1288 = OpLoad %uint %655
+%1289 = OpIAdd %uint %1287 %1288
+OpStore %777 %1289
+%1290 = OpLoad %v4uint %775
+%1291 = OpLoad %uint %777
+%1292 = OpCompositeInsert %v4uint %1291 %1290 3
+OpStore %778 %1292
+%1293 = OpLoad %v4uint %778
+%1294 = OpCompositeExtract %uint %1293 0
+OpStore %779 %1294
+OpBranch %629
+%629 = OpLabel
+%1295 = OpLoad %uint %779
+%1296 = OpUConvert %ulong %1295
+OpStore %879 %1296
+%1297 = OpLoad %ulong %774
+%1298 = OpLoad %ulong %879
+%1299 = OpFunctionCall %ulong %5 %1297 %1298
+OpStore %880 %1299
+OpBranch %630
+%630 = OpLabel
+%1300 = OpLoad %v4uint %778
+%1301 = OpCompositeExtract %uint %1300 1
+OpStore %780 %1301
+%1302 = OpLoad %uint %779
+%1303 = OpLoad %uint %780
+%1304 = OpBitwiseXor %uint %1302 %1303
+OpStore %781 %1304
+OpBranch %633
+%633 = OpLabel
+%1305 = OpLoad %uint %781
+%1306 = OpUConvert %ulong %1305
+OpStore %884 %1306
+%1307 = OpLoad %ulong %880
+%1308 = OpLoad %ulong %884
+%1309 = OpFunctionCall %ulong %5 %1307 %1308
+OpStore %885 %1309
+OpBranch %634
+%634 = OpLabel
+%1310 = OpLoad %v4uint %778
+%1311 = OpCompositeExtract %uint %1310 2
+OpStore %782 %1311
+%1312 = OpLoad %uint %781
+%1313 = OpLoad %uint %782
+%1314 = OpIMul %uint %1312 %1313
+OpStore %783 %1314
+OpBranch %637
+%637 = OpLabel
+%1315 = OpLoad %uint %783
+%1316 = OpUConvert %ulong %1315
+OpStore %889 %1316
+%1317 = OpLoad %ulong %885
+%1318 = OpLoad %ulong %889
+%1319 = OpFunctionCall %ulong %5 %1317 %1318
+OpStore %890 %1319
+OpBranch %638
+%638 = OpLabel
+%1320 = OpLoad %v4uint %778
+%1321 = OpCompositeExtract %uint %1320 3
+OpStore %784 %1321
+%1322 = OpLoad %uint %783
+%1323 = OpLoad %uint %784
+%1324 = OpISub %uint %1322 %1323
+OpStore %785 %1324
+OpBranch %641
+%641 = OpLabel
+%1325 = OpLoad %uint %785
+%1326 = OpUConvert %ulong %1325
+OpStore %894 %1326
+%1327 = OpLoad %ulong %890
+%1328 = OpLoad %ulong %894
+%1329 = OpFunctionCall %ulong %5 %1327 %1328
+OpStore %895 %1329
+OpBranch %642
+%642 = OpLabel
+OpStore %652 %1213
+%1330 = OpLoad %v4uint %652
+OpStore %786 %1330
+%1331 = OpLoad %v4uint %786
+%1332 = OpLoad %uint %785
+%1333 = OpCompositeInsert %v4uint %1332 %1331 0
+OpStore %787 %1333
+%1334 = OpLoad %v4uint %787
+OpStore %652 %1334
+%1335 = OpLoad %v4uint %778
+%1336 = OpCompositeExtract %uint %1335 0
+OpStore %788 %1336
+%1337 = OpLoad %uint %785
+%1338 = OpLoad %uint %788
+%1339 = OpBitwiseXor %uint %1337 %1338
+OpStore %789 %1339
+%1340 = OpLoad %v4uint %652
+OpStore %790 %1340
+%1341 = OpLoad %v4uint %790
+%1342 = OpLoad %uint %789
+%1343 = OpCompositeInsert %v4uint %1342 %1341 1
+OpStore %791 %1343
+%1344 = OpLoad %v4uint %791
+OpStore %652 %1344
+%1345 = OpLoad %v4uint %778
+%1346 = OpCompositeExtract %uint %1345 1
+OpStore %792 %1346
+%1347 = OpLoad %uint %785
+%1348 = OpLoad %uint %792
+%1349 = OpIAdd %uint %1347 %1348
+OpStore %793 %1349
+%1350 = OpLoad %v4uint %652
+OpStore %794 %1350
+%1351 = OpLoad %v4uint %794
+%1352 = OpLoad %uint %793
+%1353 = OpCompositeInsert %v4uint %1352 %1351 2
+OpStore %795 %1353
+%1354 = OpLoad %v4uint %795
+OpStore %652 %1354
+%1355 = OpLoad %v4uint %778
+%1356 = OpCompositeExtract %uint %1355 2
+OpStore %796 %1356
+%1357 = OpLoad %uint %785
+%1358 = OpLoad %uint %796
+%1359 = OpISub %uint %1357 %1358
+OpStore %797 %1359
+%1360 = OpLoad %v4uint %652
+OpStore %798 %1360
+%1361 = OpLoad %v4uint %798
+%1362 = OpLoad %uint %797
+%1363 = OpCompositeInsert %v4uint %1362 %1361 3
+OpStore %799 %1363
+%1364 = OpLoad %v4uint %799
+OpStore %652 %1364
+%1365 = OpLoad %v4uint %652
+OpStore %800 %1365
+%1366 = OpLoad %ulong %895
+%1367 = OpLoad %v4uint %800
+%1368 = OpFunctionCall %ulong %3 %1366 %1367
+OpStore %801 %1368
+%1369 = OpLoad %v4uint %652
+OpStore %802 %1369
+%1370 = OpLoad %v4uint %802
+%1371 = OpLoad %v4uint %778
+%1372 = OpIAdd %v4uint %1370 %1371
+OpStore %803 %1372
+%1373 = OpLoad %ulong %801
+%1374 = OpLoad %v4uint %803
+%1375 = OpFunctionCall %ulong %3 %1373 %1374
+OpStore %804 %1375
+%1376 = OpLoad %ulong %804
+OpStore %820 %1376
+%1377 = OpLoad %v4float %663
+OpStore %827 %1377
+OpStore %828 %ulong_0
+OpBranch %592
+%592 = OpLabel
+%1378 = OpLoad %ulong %828
+%1380 = OpULessThan %bool %1378 %ulong_4
+OpStore %805 %1380
+%1381 = OpLoad %bool %805
+OpLoopMerge %594 %645 None
+OpBranchConditional %1381 %593 %594
+%594 = OpLabel
+%1382 = OpLoad %ulong %820
+OpReturnValue %1382
+%593 = OpLabel
+%1383 = OpLoad %v4float %827
+%1384 = OpCompositeExtract %float %1383 0
+OpStore %806 %1384
+%1385 = OpLoad %v4float %827
+%1386 = OpCompositeExtract %float %1385 3
+OpStore %807 %1386
+%1387 = OpLoad %float %806
+%1388 = OpLoad %float %807
+%1389 = OpFAdd %float %1387 %1388
+OpStore %808 %1389
+%1390 = OpLoad %v4float %827
+%1391 = OpCompositeExtract %float %1390 1
+OpStore %809 %1391
+%1392 = OpLoad %v4float %827
+%1393 = OpCompositeExtract %float %1392 2
+OpStore %810 %1393
+%1394 = OpLoad %float %809
+%1395 = OpLoad %float %810
+%1396 = OpFSub %float %1394 %1395
+OpStore %811 %1396
+%1397 = OpLoad %float %810
+%1398 = OpFMul %float %1397 %float_0_5
+OpStore %812 %1398
+%1399 = OpLoad %float %807
+%1401 = OpFAdd %float %1399 %float_1_25
+OpStore %813 %1401
+%1402 = OpLoad %v4float %827
+%1403 = OpLoad %float %808
+%1404 = OpCompositeInsert %v4float %1403 %1402 0
+OpStore %814 %1404
+%1405 = OpLoad %v4float %814
+%1406 = OpLoad %float %811
+%1407 = OpCompositeInsert %v4float %1406 %1405 1
+OpStore %815 %1407
+%1408 = OpLoad %v4float %815
+%1409 = OpLoad %float %812
+%1410 = OpCompositeInsert %v4float %1409 %1408 2
+OpStore %816 %1410
+%1411 = OpLoad %v4float %816
+%1412 = OpLoad %float %813
+%1413 = OpCompositeInsert %v4float %1412 %1411 3
+OpStore %817 %1413
+%1414 = OpLoad %ulong %820
+%1415 = OpLoad %v4float %817
+%1416 = OpFunctionCall %ulong %1 %1414 %1415
+OpStore %818 %1416
+%1417 = OpLoad %ulong %828
+%1418 = OpIAdd %ulong %1417 %ulong_1
+OpStore %819 %1418
+%1419 = OpLoad %ulong %818
+OpStore %820 %1419
+%1420 = OpLoad %v4float %817
+OpStore %827 %1420
+%1421 = OpLoad %ulong %819
+OpStore %828 %1421
+OpBranch %645
+%617 = OpLabel
+%1422 = OpLoad %ulong %863
+%1423 = OpIMul %ulong %1422 %ulong_8
+OpStore %856 %1423
+%1424 = OpLoad %ulong %843
+%1425 = OpLoad %ulong %856
+%1426 = OpShiftRightLogical %ulong %1424 %1425
+OpStore %857 %1426
+%1427 = OpLoad %ulong %857
+%1428 = OpBitwiseAnd %ulong %1427 %ulong_255
+OpStore %858 %1428
+%1429 = OpLoad %ulong %862
+%1430 = OpLoad %ulong %858
+%1431 = OpBitwiseXor %ulong %1429 %1430
+OpStore %859 %1431
+%1432 = OpLoad %ulong %859
+%1433 = OpIMul %ulong %1432 %ulong_1099511628211
+OpStore %860 %1433
+%1434 = OpLoad %ulong %863
+%1435 = OpIAdd %ulong %1434 %ulong_1
+OpStore %861 %1435
+%1436 = OpLoad %ulong %860
+OpStore %862 %1436
+%1437 = OpLoad %ulong %861
+OpStore %863 %1437
+OpBranch %646
+%603 = OpLabel
+%1438 = OpLoad %ulong %841
+%1439 = OpIMul %ulong %1438 %ulong_8
+OpStore %834 %1439
+%1440 = OpLoad %ulong %830
+%1441 = OpLoad %ulong %834
+%1442 = OpShiftRightLogical %ulong %1440 %1441
+OpStore %835 %1442
+%1443 = OpLoad %ulong %835
+%1444 = OpBitwiseAnd %ulong %1443 %ulong_255
+OpStore %836 %1444
+%1445 = OpLoad %ulong %840
+%1446 = OpLoad %ulong %836
+%1447 = OpBitwiseXor %ulong %1445 %1446
+OpStore %837 %1447
+%1448 = OpLoad %ulong %837
+%1449 = OpIMul %ulong %1448 %ulong_1099511628211
+OpStore %838 %1449
+%1450 = OpLoad %ulong %841
+%1451 = OpIAdd %ulong %1450 %ulong_1
+OpStore %839 %1451
+%1452 = OpLoad %ulong %838
+OpStore %840 %1452
+%1453 = OpLoad %ulong %839
+OpStore %841 %1453
+OpBranch %647
+%624 = OpLabel
+%1454 = OpLoad %ulong %875
+%1455 = OpIMul %ulong %1454 %ulong_8
+OpStore %868 %1455
+%1456 = OpLoad %ulong %854
+%1457 = OpLoad %ulong %868
+%1458 = OpShiftRightLogical %ulong %1456 %1457
+OpStore %869 %1458
+%1459 = OpLoad %ulong %869
+%1460 = OpBitwiseAnd %ulong %1459 %ulong_255
+OpStore %870 %1460
+%1461 = OpLoad %ulong %874
+%1462 = OpLoad %ulong %870
+%1463 = OpBitwiseXor %ulong %1461 %1462
+OpStore %871 %1463
+%1464 = OpLoad %ulong %871
+%1465 = OpIMul %ulong %1464 %ulong_1099511628211
+OpStore %872 %1465
+%1466 = OpLoad %ulong %875
+%1467 = OpIAdd %ulong %1466 %ulong_1
+OpStore %873 %1467
+%1468 = OpLoad %ulong %872
+OpStore %874 %1468
+%1469 = OpLoad %ulong %873
+OpStore %875 %1469
+OpBranch %648
+%610 = OpLabel
+%1470 = OpLoad %ulong %852
+%1471 = OpIMul %ulong %1470 %ulong_8
+OpStore %845 %1471
+%1472 = OpLoad %ulong %832
+%1473 = OpLoad %ulong %845
+%1474 = OpShiftRightLogical %ulong %1472 %1473
+OpStore %846 %1474
+%1475 = OpLoad %ulong %846
+%1476 = OpBitwiseAnd %ulong %1475 %ulong_255
+OpStore %847 %1476
+%1477 = OpLoad %ulong %851
+%1478 = OpLoad %ulong %847
+%1479 = OpBitwiseXor %ulong %1477 %1478
+OpStore %848 %1479
+%1480 = OpLoad %ulong %848
+%1481 = OpIMul %ulong %1480 %ulong_1099511628211
+OpStore %849 %1481
+%1482 = OpLoad %ulong %852
+%1483 = OpIAdd %ulong %1482 %ulong_1
+OpStore %850 %1483
+%1484 = OpLoad %ulong %849
+OpStore %851 %1484
+%1485 = OpLoad %ulong %850
+OpStore %852 %1485
+OpBranch %649
+%645 = OpLabel
+OpBranch %592
+%646 = OpLabel
+OpBranch %616
+%647 = OpLabel
+OpBranch %602
+%648 = OpLabel
+OpBranch %623
+%649 = OpLabel
+OpBranch %609
 OpFunctionEnd
-%7 = OpFunction %ulong None %1060
-%1108 = OpFunctionParameter %ulong
-%1109 = OpFunctionParameter %uint
-%1110 = OpLabel
-%1117 = OpVariable %_ptr_Function_ulong Function
-%1118 = OpVariable %_ptr_Function_uint Function
-%1119 = OpVariable %_ptr_Function_ulong Function
-%1120 = OpVariable %_ptr_Function_bool Function
-%1121 = OpVariable %_ptr_Function_ulong Function
-%1122 = OpVariable %_ptr_Function_ulong Function
-%1123 = OpVariable %_ptr_Function_ulong Function
-%1124 = OpVariable %_ptr_Function_ulong Function
-%1125 = OpVariable %_ptr_Function_ulong Function
-%1126 = OpVariable %_ptr_Function_ulong Function
-%1127 = OpVariable %_ptr_Function_ulong Function
-%1128 = OpVariable %_ptr_Function_ulong Function
-OpStore %1117 %1108
-OpStore %1118 %1109
-%1129 = OpLoad %uint %1118
-%1130 = OpSConvert %ulong %1129
-OpStore %1119 %1130
-OpBranch %1111
-%1111 = OpLabel
-%1131 = OpLoad %ulong %1117
-OpStore %1127 %1131
-OpStore %1128 %ulong_0
-OpBranch %1112
-%1112 = OpLabel
-%1132 = OpLoad %ulong %1128
-%1133 = OpULessThan %bool %1132 %ulong_8
-OpStore %1120 %1133
-%1134 = OpLoad %bool %1120
-OpLoopMerge %1114 %1116 None
-OpBranchConditional %1134 %1113 %1114
-%1114 = OpLabel
-OpBranch %1115
-%1115 = OpLabel
-%1135 = OpLoad %ulong %1127
-OpReturnValue %1135
-%1113 = OpLabel
-%1136 = OpLoad %ulong %1128
-%1137 = OpIMul %ulong %1136 %ulong_8
-OpStore %1121 %1137
-%1138 = OpLoad %ulong %1119
-%1139 = OpLoad %ulong %1121
-%1140 = OpShiftRightLogical %ulong %1138 %1139
-OpStore %1122 %1140
-%1141 = OpLoad %ulong %1122
-%1142 = OpBitwiseAnd %ulong %1141 %ulong_255
-OpStore %1123 %1142
-%1143 = OpLoad %ulong %1127
-%1144 = OpLoad %ulong %1123
-%1145 = OpBitwiseXor %ulong %1143 %1144
-OpStore %1124 %1145
-%1146 = OpLoad %ulong %1124
-%1147 = OpIMul %ulong %1146 %ulong_1099511628211
-OpStore %1125 %1147
-%1148 = OpLoad %ulong %1128
-%1149 = OpIAdd %ulong %1148 %ulong_1
-OpStore %1126 %1149
-%1150 = OpLoad %ulong %1125
-OpStore %1127 %1150
-%1151 = OpLoad %ulong %1126
-OpStore %1128 %1151
-OpBranch %1116
-%1116 = OpLabel
-OpBranch %1112
-OpFunctionEnd
-%8 = OpFunction %ulong None %1152
-%1153 = OpFunctionParameter %ulong
-%1154 = OpFunctionParameter %float
-%1155 = OpLabel
-%1162 = OpVariable %_ptr_Function_ulong Function
-%1163 = OpVariable %_ptr_Function_float Function
-%1164 = OpVariable %_ptr_Function_uint Function
-%1165 = OpVariable %_ptr_Function_ulong Function
-%1166 = OpVariable %_ptr_Function_bool Function
-%1167 = OpVariable %_ptr_Function_ulong Function
-%1168 = OpVariable %_ptr_Function_ulong Function
-%1169 = OpVariable %_ptr_Function_ulong Function
-%1170 = OpVariable %_ptr_Function_ulong Function
-%1171 = OpVariable %_ptr_Function_ulong Function
-%1172 = OpVariable %_ptr_Function_ulong Function
-%1173 = OpVariable %_ptr_Function_ulong Function
-%1174 = OpVariable %_ptr_Function_ulong Function
-OpStore %1162 %1153
-OpStore %1163 %1154
-%1175 = OpLoad %float %1163
-%1176 = OpBitcast %uint %1175
-OpStore %1164 %1176
-%1177 = OpLoad %uint %1164
-%1178 = OpUConvert %ulong %1177
-OpStore %1165 %1178
-OpBranch %1156
-%1156 = OpLabel
-%1179 = OpLoad %ulong %1162
-OpStore %1173 %1179
-OpStore %1174 %ulong_0
-OpBranch %1157
-%1157 = OpLabel
-%1180 = OpLoad %ulong %1174
-%1181 = OpULessThan %bool %1180 %ulong_8
-OpStore %1166 %1181
-%1182 = OpLoad %bool %1166
-OpLoopMerge %1159 %1161 None
-OpBranchConditional %1182 %1158 %1159
-%1159 = OpLabel
-OpBranch %1160
-%1160 = OpLabel
-%1183 = OpLoad %ulong %1173
-OpReturnValue %1183
-%1158 = OpLabel
-%1184 = OpLoad %ulong %1174
-%1185 = OpIMul %ulong %1184 %ulong_8
-OpStore %1167 %1185
-%1186 = OpLoad %ulong %1165
-%1187 = OpLoad %ulong %1167
-%1188 = OpShiftRightLogical %ulong %1186 %1187
-OpStore %1168 %1188
-%1189 = OpLoad %ulong %1168
-%1190 = OpBitwiseAnd %ulong %1189 %ulong_255
-OpStore %1169 %1190
-%1191 = OpLoad %ulong %1173
-%1192 = OpLoad %ulong %1169
-%1193 = OpBitwiseXor %ulong %1191 %1192
-OpStore %1170 %1193
-%1194 = OpLoad %ulong %1170
-%1195 = OpIMul %ulong %1194 %ulong_1099511628211
-OpStore %1171 %1195
-%1196 = OpLoad %ulong %1174
-%1197 = OpIAdd %ulong %1196 %ulong_1
-OpStore %1172 %1197
-%1198 = OpLoad %ulong %1171
-OpStore %1173 %1198
-%1199 = OpLoad %ulong %1172
-OpStore %1174 %1199
-OpBranch %1161
-%1161 = OpLabel
-OpBranch %1157
+%5 = OpFunction %ulong None %1486
+%1487 = OpFunctionParameter %ulong
+%1488 = OpFunctionParameter %ulong
+%1489 = OpLabel
+%1494 = OpVariable %_ptr_Function_ulong Function
+%1495 = OpVariable %_ptr_Function_ulong Function
+%1496 = OpVariable %_ptr_Function_bool Function
+%1497 = OpVariable %_ptr_Function_ulong Function
+%1498 = OpVariable %_ptr_Function_ulong Function
+%1499 = OpVariable %_ptr_Function_ulong Function
+%1500 = OpVariable %_ptr_Function_ulong Function
+%1501 = OpVariable %_ptr_Function_ulong Function
+%1502 = OpVariable %_ptr_Function_ulong Function
+%1503 = OpVariable %_ptr_Function_ulong Function
+%1504 = OpVariable %_ptr_Function_ulong Function
+OpStore %1494 %1487
+OpStore %1495 %1488
+%1505 = OpLoad %ulong %1494
+OpStore %1503 %1505
+OpStore %1504 %ulong_0
+OpBranch %1490
+%1490 = OpLabel
+%1506 = OpLoad %ulong %1504
+%1507 = OpULessThan %bool %1506 %ulong_8
+OpStore %1496 %1507
+%1508 = OpLoad %bool %1496
+OpLoopMerge %1492 %1493 None
+OpBranchConditional %1508 %1491 %1492
+%1492 = OpLabel
+%1509 = OpLoad %ulong %1503
+OpReturnValue %1509
+%1491 = OpLabel
+%1510 = OpLoad %ulong %1504
+%1511 = OpIMul %ulong %1510 %ulong_8
+OpStore %1497 %1511
+%1512 = OpLoad %ulong %1495
+%1513 = OpLoad %ulong %1497
+%1514 = OpShiftRightLogical %ulong %1512 %1513
+OpStore %1498 %1514
+%1515 = OpLoad %ulong %1498
+%1516 = OpBitwiseAnd %ulong %1515 %ulong_255
+OpStore %1499 %1516
+%1517 = OpLoad %ulong %1503
+%1518 = OpLoad %ulong %1499
+%1519 = OpBitwiseXor %ulong %1517 %1518
+OpStore %1500 %1519
+%1520 = OpLoad %ulong %1500
+%1521 = OpIMul %ulong %1520 %ulong_1099511628211
+OpStore %1501 %1521
+%1522 = OpLoad %ulong %1504
+%1523 = OpIAdd %ulong %1522 %ulong_1
+OpStore %1502 %1523
+%1524 = OpLoad %ulong %1501
+OpStore %1503 %1524
+%1525 = OpLoad %ulong %1502
+OpStore %1504 %1525
+OpBranch %1493
+%1493 = OpLabel
+OpBranch %1490
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_u16x8.dis
+++ b/test/golden/spirv/vec/vec_u16x8.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 3710
+; Bound: 2999
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,18 +15,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u16x8.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_8 = OpConstant %uint 8
 %_arr_ushort_uint_8 = OpTypeArray %ushort %uint_8
-%11 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
+%8 = OpTypeFunction %ulong %ulong %_arr_ushort_uint_8
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_ushort_uint_8 = OpTypePointer Function %_arr_ushort_uint_8
 %_ptr_Function_ushort = OpTypePointer Function %ushort
-%77 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%369 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr__arr_ushort_uint_8_uint_4 = OpTypeArray %_arr_ushort_uint_8 %uint_4
 %_ptr_Function__arr__arr_ushort_uint_8_uint_4 = OpTypePointer Function %_arr__arr_ushort_uint_8_uint_4
-%_struct_125 = OpTypeStruct %uint %_arr_ushort_uint_8 %uint
-%_ptr_Function__struct_125 = OpTypePointer Function %_struct_125
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_402 = OpTypeStruct %uint %_arr_ushort_uint_8 %uint
+%_ptr_Function__struct_402 = OpTypePointer Function %_struct_402
 %_ptr_Function_uint = OpTypePointer Function %uint
 %ushort_65520 = OpConstant %ushort 65520
 %ushort_1 = OpConstant %ushort 1
@@ -50,477 +55,641 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u16x8.checksum" Export
 %ushort_729 = OpConstant %ushort 729
 %ushort_2187 = OpConstant %ushort 2187
 %ushort_0 = OpConstant %ushort 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%2841 = OpConstantNull %_arr__arr_ushort_uint_8_uint_4
+%2410 = OpConstantNull %_arr__arr_ushort_uint_8_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%3019 = OpConstantNull %_struct_125
+%2588 = OpConstantNull %_struct_402
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%3614 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%3617 = OpTypeFunction %ulong %ulong %ushort
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%3665 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_ushort_uint_8
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%20 = OpVariable %_ptr_Function_ushort Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_ushort Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_ushort Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_ushort Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_ushort Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_ushort Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_ushort Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_ushort Function
-%35 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%36 = OpLoad %_arr_ushort_uint_8 %18
-%37 = OpCompositeExtract %ushort %36 0
-OpStore %20 %37
-%38 = OpLoad %ulong %16
-%39 = OpLoad %ushort %20
-%40 = OpFunctionCall %ulong %4 %38 %39
-OpStore %21 %40
-%41 = OpLoad %_arr_ushort_uint_8 %18
-%42 = OpCompositeExtract %ushort %41 1
-OpStore %22 %42
-%43 = OpLoad %ulong %21
-%44 = OpLoad %ushort %22
-%45 = OpFunctionCall %ulong %4 %43 %44
-OpStore %23 %45
-%46 = OpLoad %_arr_ushort_uint_8 %18
-%47 = OpCompositeExtract %ushort %46 2
-OpStore %24 %47
-%48 = OpLoad %ulong %23
-%49 = OpLoad %ushort %24
-%50 = OpFunctionCall %ulong %4 %48 %49
-OpStore %25 %50
-%51 = OpLoad %_arr_ushort_uint_8 %18
-%52 = OpCompositeExtract %ushort %51 3
-OpStore %26 %52
-%53 = OpLoad %ulong %25
-%54 = OpLoad %ushort %26
-%55 = OpFunctionCall %ulong %4 %53 %54
-OpStore %27 %55
-%56 = OpLoad %_arr_ushort_uint_8 %18
-%57 = OpCompositeExtract %ushort %56 4
-OpStore %28 %57
-%58 = OpLoad %ulong %27
-%59 = OpLoad %ushort %28
-%60 = OpFunctionCall %ulong %4 %58 %59
-OpStore %29 %60
-%61 = OpLoad %_arr_ushort_uint_8 %18
-%62 = OpCompositeExtract %ushort %61 5
-OpStore %30 %62
-%63 = OpLoad %ulong %29
-%64 = OpLoad %ushort %30
-%65 = OpFunctionCall %ulong %4 %63 %64
-OpStore %31 %65
-%66 = OpLoad %_arr_ushort_uint_8 %18
-%67 = OpCompositeExtract %ushort %66 6
-OpStore %32 %67
-%68 = OpLoad %ulong %31
-%69 = OpLoad %ushort %32
-%70 = OpFunctionCall %ulong %4 %68 %69
-OpStore %33 %70
-%71 = OpLoad %_arr_ushort_uint_8 %18
-%72 = OpCompositeExtract %ushort %71 7
-OpStore %34 %72
-%73 = OpLoad %ulong %33
-%74 = OpLoad %ushort %34
-%75 = OpFunctionCall %ulong %4 %73 %74
-OpStore %35 %75
-%76 = OpLoad %ulong %35
-OpReturnValue %76
-OpFunctionEnd
-%2 = OpFunction %ulong None %77
-%78 = OpFunctionParameter %ulong
-%79 = OpLabel
-%124 = OpVariable %_ptr_Function__arr__arr_ushort_uint_8_uint_4 Function
-%127 = OpVariable %_ptr_Function__struct_125 Function
+%1 = OpFunction %ulong None %8
+%9 = OpFunctionParameter %ulong
+%10 = OpFunctionParameter %_arr_ushort_uint_8
+%11 = OpLabel
+%78 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%82 = OpVariable %_ptr_Function_ushort Function
+%83 = OpVariable %_ptr_Function_ushort Function
+%84 = OpVariable %_ptr_Function_ushort Function
+%85 = OpVariable %_ptr_Function_ushort Function
+%86 = OpVariable %_ptr_Function_ushort Function
+%87 = OpVariable %_ptr_Function_ushort Function
+%88 = OpVariable %_ptr_Function_ushort Function
+%89 = OpVariable %_ptr_Function_ushort Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_bool Function
+%93 = OpVariable %_ptr_Function_ulong Function
+%94 = OpVariable %_ptr_Function_ulong Function
+%95 = OpVariable %_ptr_Function_ulong Function
+%96 = OpVariable %_ptr_Function_ulong Function
+%97 = OpVariable %_ptr_Function_ulong Function
+%98 = OpVariable %_ptr_Function_ulong Function
+%99 = OpVariable %_ptr_Function_ulong Function
+%100 = OpVariable %_ptr_Function_ulong Function
+%101 = OpVariable %_ptr_Function_ulong Function
+%102 = OpVariable %_ptr_Function_bool Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_ulong Function
+%106 = OpVariable %_ptr_Function_ulong Function
+%107 = OpVariable %_ptr_Function_ulong Function
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_ulong Function
+%110 = OpVariable %_ptr_Function_ulong Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_bool Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ulong Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ulong Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_bool Function
+%123 = OpVariable %_ptr_Function_ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_ulong Function
+%127 = OpVariable %_ptr_Function_ulong Function
 %128 = OpVariable %_ptr_Function_ulong Function
 %129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_ushort Function
-%131 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%132 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%133 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%134 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%135 = OpVariable %_ptr_Function_ushort Function
-%136 = OpVariable %_ptr_Function_ushort Function
-%137 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%138 = OpVariable %_ptr_Function_ushort Function
-%139 = OpVariable %_ptr_Function_ushort Function
-%140 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%141 = OpVariable %_ptr_Function_ushort Function
-%142 = OpVariable %_ptr_Function_ushort Function
-%143 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%144 = OpVariable %_ptr_Function_ushort Function
-%145 = OpVariable %_ptr_Function_ushort Function
-%146 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%130 = OpVariable %_ptr_Function_ulong Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_bool Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_ulong Function
+%142 = OpVariable %_ptr_Function_bool Function
+%143 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
 %147 = OpVariable %_ptr_Function_ulong Function
 %148 = OpVariable %_ptr_Function_ulong Function
 %149 = OpVariable %_ptr_Function_ulong Function
 %150 = OpVariable %_ptr_Function_ulong Function
 %151 = OpVariable %_ptr_Function_ulong Function
-%152 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_bool Function
 %153 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_bool Function
+%154 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
 %156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_bool Function
-%158 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
 %159 = OpVariable %_ptr_Function_ulong Function
-%160 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%162 = OpVariable %_ptr_Function_uint Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
 %163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%165 = OpVariable %_ptr_Function_uint Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
 %167 = OpVariable %_ptr_Function_ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%170 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%171 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_ushort Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_ushort Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ushort Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ushort Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ushort Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ushort Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_ushort Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ushort Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ushort Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_ushort Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ushort Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ushort Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ushort Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_ushort Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ushort Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_ushort Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_ushort Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_ushort Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_ushort Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_ushort Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_ushort Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_ushort Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_ushort Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_ushort Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_ushort Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_ushort Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_ushort Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_ushort Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_ushort Function
-%231 = OpVariable %_ptr_Function_ulong Function
-%232 = OpVariable %_ptr_Function_ushort Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_ushort Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_ushort Function
-%237 = OpVariable %_ptr_Function_ulong Function
-%238 = OpVariable %_ptr_Function_ushort Function
-%239 = OpVariable %_ptr_Function_ulong Function
-%240 = OpVariable %_ptr_Function_ushort Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_ushort Function
-%243 = OpVariable %_ptr_Function_ulong Function
-%244 = OpVariable %_ptr_Function_ushort Function
-%245 = OpVariable %_ptr_Function_ulong Function
-%246 = OpVariable %_ptr_Function_ushort Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_ushort Function
-%249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_ushort Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_ushort Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_ushort Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_ushort Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_ushort Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_ushort Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_ushort Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_ushort Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_ushort Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_ushort Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_ushort Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_ushort Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_ushort Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_ushort Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_ushort Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_ushort Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_ushort Function
-%283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_ushort Function
-%285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_ushort Function
-%287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_ushort Function
-%289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_ushort Function
-%291 = OpVariable %_ptr_Function_ulong Function
-%292 = OpVariable %_ptr_Function_ushort Function
-%293 = OpVariable %_ptr_Function_ulong Function
-%294 = OpVariable %_ptr_Function_ushort Function
-%295 = OpVariable %_ptr_Function_ulong Function
-%296 = OpVariable %_ptr_Function_ushort Function
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ushort Function
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_ushort Function
-%301 = OpVariable %_ptr_Function_ulong Function
-%302 = OpVariable %_ptr_Function_ushort Function
-%303 = OpVariable %_ptr_Function_ulong Function
-%304 = OpVariable %_ptr_Function_ushort Function
-%305 = OpVariable %_ptr_Function_ulong Function
-%306 = OpVariable %_ptr_Function_ushort Function
-%307 = OpVariable %_ptr_Function_ulong Function
-%308 = OpVariable %_ptr_Function_ushort Function
-%309 = OpVariable %_ptr_Function_ulong Function
-%310 = OpVariable %_ptr_Function_ushort Function
-%311 = OpVariable %_ptr_Function_ulong Function
-%312 = OpVariable %_ptr_Function_ushort Function
-%313 = OpVariable %_ptr_Function_ulong Function
-%314 = OpVariable %_ptr_Function_ushort Function
-%315 = OpVariable %_ptr_Function_ulong Function
-%316 = OpVariable %_ptr_Function_ushort Function
-%317 = OpVariable %_ptr_Function_ulong Function
-%318 = OpVariable %_ptr_Function_ushort Function
-%319 = OpVariable %_ptr_Function_ulong Function
-%320 = OpVariable %_ptr_Function_ushort Function
-%321 = OpVariable %_ptr_Function_ulong Function
-%322 = OpVariable %_ptr_Function_ushort Function
-%323 = OpVariable %_ptr_Function_ulong Function
-%324 = OpVariable %_ptr_Function_ushort Function
-%325 = OpVariable %_ptr_Function_ulong Function
-%326 = OpVariable %_ptr_Function_ushort Function
-%327 = OpVariable %_ptr_Function_ulong Function
-%328 = OpVariable %_ptr_Function_ushort Function
-%329 = OpVariable %_ptr_Function_ulong Function
-%330 = OpVariable %_ptr_Function_ushort Function
-%331 = OpVariable %_ptr_Function_ulong Function
-%332 = OpVariable %_ptr_Function_ushort Function
-%333 = OpVariable %_ptr_Function_ulong Function
-%334 = OpVariable %_ptr_Function_ushort Function
-%335 = OpVariable %_ptr_Function_ulong Function
-%336 = OpVariable %_ptr_Function_ushort Function
-%337 = OpVariable %_ptr_Function_ulong Function
-%338 = OpVariable %_ptr_Function_ushort Function
-%339 = OpVariable %_ptr_Function_ulong Function
-%340 = OpVariable %_ptr_Function_ushort Function
-%341 = OpVariable %_ptr_Function_ulong Function
-%342 = OpVariable %_ptr_Function_ushort Function
-%343 = OpVariable %_ptr_Function_ulong Function
-%344 = OpVariable %_ptr_Function_ushort Function
-%345 = OpVariable %_ptr_Function_ulong Function
-%346 = OpVariable %_ptr_Function_ushort Function
-%347 = OpVariable %_ptr_Function_ulong Function
-%348 = OpVariable %_ptr_Function_ushort Function
-%349 = OpVariable %_ptr_Function_ulong Function
-%350 = OpVariable %_ptr_Function_ushort Function
-%351 = OpVariable %_ptr_Function_ulong Function
-%352 = OpVariable %_ptr_Function_ushort Function
-%353 = OpVariable %_ptr_Function_ulong Function
-%354 = OpVariable %_ptr_Function_ushort Function
-%355 = OpVariable %_ptr_Function_ulong Function
-%356 = OpVariable %_ptr_Function_ushort Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_ushort Function
-%359 = OpVariable %_ptr_Function_ulong Function
-%360 = OpVariable %_ptr_Function_ushort Function
-%361 = OpVariable %_ptr_Function_ulong Function
-%362 = OpVariable %_ptr_Function_ushort Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_ushort Function
-%365 = OpVariable %_ptr_Function_ulong Function
-%366 = OpVariable %_ptr_Function_ushort Function
-%367 = OpVariable %_ptr_Function_ulong Function
-%368 = OpVariable %_ptr_Function_ushort Function
-%369 = OpVariable %_ptr_Function_ulong Function
-%370 = OpVariable %_ptr_Function_ushort Function
-%371 = OpVariable %_ptr_Function_ulong Function
-%372 = OpVariable %_ptr_Function_ushort Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_ushort Function
-%375 = OpVariable %_ptr_Function_ulong Function
-%376 = OpVariable %_ptr_Function_ushort Function
-%377 = OpVariable %_ptr_Function_ulong Function
-%378 = OpVariable %_ptr_Function_ushort Function
-%379 = OpVariable %_ptr_Function_ulong Function
-%380 = OpVariable %_ptr_Function_ushort Function
-%381 = OpVariable %_ptr_Function_ulong Function
-%382 = OpVariable %_ptr_Function_ushort Function
-%383 = OpVariable %_ptr_Function_ulong Function
-%384 = OpVariable %_ptr_Function_ushort Function
-%385 = OpVariable %_ptr_Function_ulong Function
-%386 = OpVariable %_ptr_Function_ushort Function
-%387 = OpVariable %_ptr_Function_ulong Function
-%388 = OpVariable %_ptr_Function_ushort Function
-%389 = OpVariable %_ptr_Function_ulong Function
-%390 = OpVariable %_ptr_Function_ushort Function
-%391 = OpVariable %_ptr_Function_ulong Function
-%392 = OpVariable %_ptr_Function_ushort Function
-%393 = OpVariable %_ptr_Function_ulong Function
-%394 = OpVariable %_ptr_Function_ushort Function
-%395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_ushort Function
-%397 = OpVariable %_ptr_Function_ulong Function
-%398 = OpVariable %_ptr_Function_ushort Function
-%399 = OpVariable %_ptr_Function_ulong Function
-%400 = OpVariable %_ptr_Function_ushort Function
-%401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_ushort Function
-%403 = OpVariable %_ptr_Function_ulong Function
-%404 = OpVariable %_ptr_Function_ushort Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+OpStore %78 %9
+OpStore %80 %10
+%171 = OpLoad %_arr_ushort_uint_8 %80
+%172 = OpCompositeExtract %ushort %171 0
+OpStore %82 %172
+OpBranch %12
+%12 = OpLabel
+%173 = OpLoad %ushort %82
+%174 = OpUConvert %ulong %173
+OpStore %90 %174
+OpBranch %14
+%14 = OpLabel
+%175 = OpLoad %ulong %78
+OpStore %99 %175
+OpStore %100 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%177 = OpLoad %ulong %100
+%179 = OpULessThan %bool %177 %ulong_8
+OpStore %92 %179
+%180 = OpLoad %bool %92
+OpLoopMerge %17 %75 None
+OpBranchConditional %180 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%181 = OpLoad %_arr_ushort_uint_8 %80
+%182 = OpCompositeExtract %ushort %181 1
+OpStore %83 %182
+OpBranch %19
+%19 = OpLabel
+%183 = OpLoad %ushort %83
+%184 = OpUConvert %ulong %183
+OpStore %101 %184
+OpBranch %21
+%21 = OpLabel
+%185 = OpLoad %ulong %99
+OpStore %109 %185
+OpStore %110 %ulong_0
+OpBranch %22
+%22 = OpLabel
+%186 = OpLoad %ulong %110
+%187 = OpULessThan %bool %186 %ulong_8
+OpStore %102 %187
+%188 = OpLoad %bool %102
+OpLoopMerge %24 %74 None
+OpBranchConditional %188 %23 %24
+%24 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%189 = OpLoad %_arr_ushort_uint_8 %80
+%190 = OpCompositeExtract %ushort %189 2
+OpStore %84 %190
+OpBranch %26
+%26 = OpLabel
+%191 = OpLoad %ushort %84
+%192 = OpUConvert %ulong %191
+OpStore %111 %192
+OpBranch %28
+%28 = OpLabel
+%193 = OpLoad %ulong %109
+OpStore %119 %193
+OpStore %120 %ulong_0
+OpBranch %29
+%29 = OpLabel
+%194 = OpLoad %ulong %120
+%195 = OpULessThan %bool %194 %ulong_8
+OpStore %112 %195
+%196 = OpLoad %bool %112
+OpLoopMerge %31 %73 None
+OpBranchConditional %196 %30 %31
+%31 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpBranch %27
+%27 = OpLabel
+%197 = OpLoad %_arr_ushort_uint_8 %80
+%198 = OpCompositeExtract %ushort %197 3
+OpStore %85 %198
+OpBranch %33
+%33 = OpLabel
+%199 = OpLoad %ushort %85
+%200 = OpUConvert %ulong %199
+OpStore %121 %200
+OpBranch %35
+%35 = OpLabel
+%201 = OpLoad %ulong %119
+OpStore %129 %201
+OpStore %130 %ulong_0
+OpBranch %36
+%36 = OpLabel
+%202 = OpLoad %ulong %130
+%203 = OpULessThan %bool %202 %ulong_8
+OpStore %122 %203
+%204 = OpLoad %bool %122
+OpLoopMerge %38 %72 None
+OpBranchConditional %204 %37 %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpBranch %34
+%34 = OpLabel
+%205 = OpLoad %_arr_ushort_uint_8 %80
+%206 = OpCompositeExtract %ushort %205 4
+OpStore %86 %206
+OpBranch %40
+%40 = OpLabel
+%207 = OpLoad %ushort %86
+%208 = OpUConvert %ulong %207
+OpStore %131 %208
+OpBranch %42
+%42 = OpLabel
+%209 = OpLoad %ulong %129
+OpStore %139 %209
+OpStore %140 %ulong_0
+OpBranch %43
+%43 = OpLabel
+%210 = OpLoad %ulong %140
+%211 = OpULessThan %bool %210 %ulong_8
+OpStore %132 %211
+%212 = OpLoad %bool %132
+OpLoopMerge %45 %71 None
+OpBranchConditional %212 %44 %45
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%213 = OpLoad %_arr_ushort_uint_8 %80
+%214 = OpCompositeExtract %ushort %213 5
+OpStore %87 %214
+OpBranch %47
+%47 = OpLabel
+%215 = OpLoad %ushort %87
+%216 = OpUConvert %ulong %215
+OpStore %141 %216
+OpBranch %49
+%49 = OpLabel
+%217 = OpLoad %ulong %139
+OpStore %149 %217
+OpStore %150 %ulong_0
+OpBranch %50
+%50 = OpLabel
+%218 = OpLoad %ulong %150
+%219 = OpULessThan %bool %218 %ulong_8
+OpStore %142 %219
+%220 = OpLoad %bool %142
+OpLoopMerge %52 %70 None
+OpBranchConditional %220 %51 %52
+%52 = OpLabel
+OpBranch %53
+%53 = OpLabel
+OpBranch %48
+%48 = OpLabel
+%221 = OpLoad %_arr_ushort_uint_8 %80
+%222 = OpCompositeExtract %ushort %221 6
+OpStore %88 %222
+OpBranch %54
+%54 = OpLabel
+%223 = OpLoad %ushort %88
+%224 = OpUConvert %ulong %223
+OpStore %151 %224
+OpBranch %56
+%56 = OpLabel
+%225 = OpLoad %ulong %149
+OpStore %159 %225
+OpStore %160 %ulong_0
+OpBranch %57
+%57 = OpLabel
+%226 = OpLoad %ulong %160
+%227 = OpULessThan %bool %226 %ulong_8
+OpStore %152 %227
+%228 = OpLoad %bool %152
+OpLoopMerge %59 %69 None
+OpBranchConditional %228 %58 %59
+%59 = OpLabel
+OpBranch %60
+%60 = OpLabel
+OpBranch %55
+%55 = OpLabel
+%229 = OpLoad %_arr_ushort_uint_8 %80
+%230 = OpCompositeExtract %ushort %229 7
+OpStore %89 %230
+OpBranch %61
+%61 = OpLabel
+%231 = OpLoad %ushort %89
+%232 = OpUConvert %ulong %231
+OpStore %161 %232
+OpBranch %63
+%63 = OpLabel
+%233 = OpLoad %ulong %159
+OpStore %169 %233
+OpStore %170 %ulong_0
+OpBranch %64
+%64 = OpLabel
+%234 = OpLoad %ulong %170
+%235 = OpULessThan %bool %234 %ulong_8
+OpStore %162 %235
+%236 = OpLoad %bool %162
+OpLoopMerge %66 %68 None
+OpBranchConditional %236 %65 %66
+%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%237 = OpLoad %ulong %169
+OpReturnValue %237
+%65 = OpLabel
+%238 = OpLoad %ulong %170
+%239 = OpIMul %ulong %238 %ulong_8
+OpStore %163 %239
+%240 = OpLoad %ulong %161
+%241 = OpLoad %ulong %163
+%242 = OpShiftRightLogical %ulong %240 %241
+OpStore %164 %242
+%243 = OpLoad %ulong %164
+%245 = OpBitwiseAnd %ulong %243 %ulong_255
+OpStore %165 %245
+%246 = OpLoad %ulong %169
+%247 = OpLoad %ulong %165
+%248 = OpBitwiseXor %ulong %246 %247
+OpStore %166 %248
+%249 = OpLoad %ulong %166
+%251 = OpIMul %ulong %249 %ulong_1099511628211
+OpStore %167 %251
+%252 = OpLoad %ulong %170
+%254 = OpIAdd %ulong %252 %ulong_1
+OpStore %168 %254
+%255 = OpLoad %ulong %167
+OpStore %169 %255
+%256 = OpLoad %ulong %168
+OpStore %170 %256
+OpBranch %68
+%58 = OpLabel
+%257 = OpLoad %ulong %160
+%258 = OpIMul %ulong %257 %ulong_8
+OpStore %153 %258
+%259 = OpLoad %ulong %151
+%260 = OpLoad %ulong %153
+%261 = OpShiftRightLogical %ulong %259 %260
+OpStore %154 %261
+%262 = OpLoad %ulong %154
+%263 = OpBitwiseAnd %ulong %262 %ulong_255
+OpStore %155 %263
+%264 = OpLoad %ulong %159
+%265 = OpLoad %ulong %155
+%266 = OpBitwiseXor %ulong %264 %265
+OpStore %156 %266
+%267 = OpLoad %ulong %156
+%268 = OpIMul %ulong %267 %ulong_1099511628211
+OpStore %157 %268
+%269 = OpLoad %ulong %160
+%270 = OpIAdd %ulong %269 %ulong_1
+OpStore %158 %270
+%271 = OpLoad %ulong %157
+OpStore %159 %271
+%272 = OpLoad %ulong %158
+OpStore %160 %272
+OpBranch %69
+%51 = OpLabel
+%273 = OpLoad %ulong %150
+%274 = OpIMul %ulong %273 %ulong_8
+OpStore %143 %274
+%275 = OpLoad %ulong %141
+%276 = OpLoad %ulong %143
+%277 = OpShiftRightLogical %ulong %275 %276
+OpStore %144 %277
+%278 = OpLoad %ulong %144
+%279 = OpBitwiseAnd %ulong %278 %ulong_255
+OpStore %145 %279
+%280 = OpLoad %ulong %149
+%281 = OpLoad %ulong %145
+%282 = OpBitwiseXor %ulong %280 %281
+OpStore %146 %282
+%283 = OpLoad %ulong %146
+%284 = OpIMul %ulong %283 %ulong_1099511628211
+OpStore %147 %284
+%285 = OpLoad %ulong %150
+%286 = OpIAdd %ulong %285 %ulong_1
+OpStore %148 %286
+%287 = OpLoad %ulong %147
+OpStore %149 %287
+%288 = OpLoad %ulong %148
+OpStore %150 %288
+OpBranch %70
+%44 = OpLabel
+%289 = OpLoad %ulong %140
+%290 = OpIMul %ulong %289 %ulong_8
+OpStore %133 %290
+%291 = OpLoad %ulong %131
+%292 = OpLoad %ulong %133
+%293 = OpShiftRightLogical %ulong %291 %292
+OpStore %134 %293
+%294 = OpLoad %ulong %134
+%295 = OpBitwiseAnd %ulong %294 %ulong_255
+OpStore %135 %295
+%296 = OpLoad %ulong %139
+%297 = OpLoad %ulong %135
+%298 = OpBitwiseXor %ulong %296 %297
+OpStore %136 %298
+%299 = OpLoad %ulong %136
+%300 = OpIMul %ulong %299 %ulong_1099511628211
+OpStore %137 %300
+%301 = OpLoad %ulong %140
+%302 = OpIAdd %ulong %301 %ulong_1
+OpStore %138 %302
+%303 = OpLoad %ulong %137
+OpStore %139 %303
+%304 = OpLoad %ulong %138
+OpStore %140 %304
+OpBranch %71
+%37 = OpLabel
+%305 = OpLoad %ulong %130
+%306 = OpIMul %ulong %305 %ulong_8
+OpStore %123 %306
+%307 = OpLoad %ulong %121
+%308 = OpLoad %ulong %123
+%309 = OpShiftRightLogical %ulong %307 %308
+OpStore %124 %309
+%310 = OpLoad %ulong %124
+%311 = OpBitwiseAnd %ulong %310 %ulong_255
+OpStore %125 %311
+%312 = OpLoad %ulong %129
+%313 = OpLoad %ulong %125
+%314 = OpBitwiseXor %ulong %312 %313
+OpStore %126 %314
+%315 = OpLoad %ulong %126
+%316 = OpIMul %ulong %315 %ulong_1099511628211
+OpStore %127 %316
+%317 = OpLoad %ulong %130
+%318 = OpIAdd %ulong %317 %ulong_1
+OpStore %128 %318
+%319 = OpLoad %ulong %127
+OpStore %129 %319
+%320 = OpLoad %ulong %128
+OpStore %130 %320
+OpBranch %72
+%30 = OpLabel
+%321 = OpLoad %ulong %120
+%322 = OpIMul %ulong %321 %ulong_8
+OpStore %113 %322
+%323 = OpLoad %ulong %111
+%324 = OpLoad %ulong %113
+%325 = OpShiftRightLogical %ulong %323 %324
+OpStore %114 %325
+%326 = OpLoad %ulong %114
+%327 = OpBitwiseAnd %ulong %326 %ulong_255
+OpStore %115 %327
+%328 = OpLoad %ulong %119
+%329 = OpLoad %ulong %115
+%330 = OpBitwiseXor %ulong %328 %329
+OpStore %116 %330
+%331 = OpLoad %ulong %116
+%332 = OpIMul %ulong %331 %ulong_1099511628211
+OpStore %117 %332
+%333 = OpLoad %ulong %120
+%334 = OpIAdd %ulong %333 %ulong_1
+OpStore %118 %334
+%335 = OpLoad %ulong %117
+OpStore %119 %335
+%336 = OpLoad %ulong %118
+OpStore %120 %336
+OpBranch %73
+%23 = OpLabel
+%337 = OpLoad %ulong %110
+%338 = OpIMul %ulong %337 %ulong_8
+OpStore %103 %338
+%339 = OpLoad %ulong %101
+%340 = OpLoad %ulong %103
+%341 = OpShiftRightLogical %ulong %339 %340
+OpStore %104 %341
+%342 = OpLoad %ulong %104
+%343 = OpBitwiseAnd %ulong %342 %ulong_255
+OpStore %105 %343
+%344 = OpLoad %ulong %109
+%345 = OpLoad %ulong %105
+%346 = OpBitwiseXor %ulong %344 %345
+OpStore %106 %346
+%347 = OpLoad %ulong %106
+%348 = OpIMul %ulong %347 %ulong_1099511628211
+OpStore %107 %348
+%349 = OpLoad %ulong %110
+%350 = OpIAdd %ulong %349 %ulong_1
+OpStore %108 %350
+%351 = OpLoad %ulong %107
+OpStore %109 %351
+%352 = OpLoad %ulong %108
+OpStore %110 %352
+OpBranch %74
+%16 = OpLabel
+%353 = OpLoad %ulong %100
+%354 = OpIMul %ulong %353 %ulong_8
+OpStore %93 %354
+%355 = OpLoad %ulong %90
+%356 = OpLoad %ulong %93
+%357 = OpShiftRightLogical %ulong %355 %356
+OpStore %94 %357
+%358 = OpLoad %ulong %94
+%359 = OpBitwiseAnd %ulong %358 %ulong_255
+OpStore %95 %359
+%360 = OpLoad %ulong %99
+%361 = OpLoad %ulong %95
+%362 = OpBitwiseXor %ulong %360 %361
+OpStore %96 %362
+%363 = OpLoad %ulong %96
+%364 = OpIMul %ulong %363 %ulong_1099511628211
+OpStore %97 %364
+%365 = OpLoad %ulong %100
+%366 = OpIAdd %ulong %365 %ulong_1
+OpStore %98 %366
+%367 = OpLoad %ulong %97
+OpStore %99 %367
+%368 = OpLoad %ulong %98
+OpStore %100 %368
+OpBranch %75
+%68 = OpLabel
+OpBranch %64
+%69 = OpLabel
+OpBranch %57
+%70 = OpLabel
+OpBranch %50
+%71 = OpLabel
+OpBranch %43
+%72 = OpLabel
+OpBranch %36
+%73 = OpLabel
+OpBranch %29
+%74 = OpLabel
+OpBranch %22
+%75 = OpLabel
+OpBranch %15
+OpFunctionEnd
+%2 = OpFunction %ulong None %369
+%370 = OpFunctionParameter %ulong
+%371 = OpLabel
+%401 = OpVariable %_ptr_Function__arr__arr_ushort_uint_8_uint_4 Function
+%404 = OpVariable %_ptr_Function__struct_402 Function
 %405 = OpVariable %_ptr_Function_ulong Function
 %406 = OpVariable %_ptr_Function_ushort Function
-%407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_ushort Function
-%409 = OpVariable %_ptr_Function_ulong Function
-%410 = OpVariable %_ptr_Function_ushort Function
-%411 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%408 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%409 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%410 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%411 = OpVariable %_ptr_Function_ushort Function
 %412 = OpVariable %_ptr_Function_ushort Function
-%413 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %414 = OpVariable %_ptr_Function_ushort Function
-%415 = OpVariable %_ptr_Function_ulong Function
-%416 = OpVariable %_ptr_Function_ushort Function
-%417 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_ushort Function
+%416 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%417 = OpVariable %_ptr_Function_ushort Function
 %418 = OpVariable %_ptr_Function_ushort Function
-%419 = OpVariable %_ptr_Function_ulong Function
+%419 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %420 = OpVariable %_ptr_Function_ushort Function
-%421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_ushort Function
+%421 = OpVariable %_ptr_Function_ushort Function
+%422 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ushort Function
+%424 = OpVariable %_ptr_Function_ulong Function
 %425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_ushort Function
+%426 = OpVariable %_ptr_Function_ulong Function
 %427 = OpVariable %_ptr_Function_ulong Function
-%428 = OpVariable %_ptr_Function_ushort Function
+%428 = OpVariable %_ptr_Function_ulong Function
 %429 = OpVariable %_ptr_Function_ulong Function
-%430 = OpVariable %_ptr_Function_ushort Function
-%431 = OpVariable %_ptr_Function_ushort Function
-%432 = OpVariable %_ptr_Function_ushort Function
-%433 = OpVariable %_ptr_Function_ushort Function
-%434 = OpVariable %_ptr_Function_ushort Function
-%435 = OpVariable %_ptr_Function_ushort Function
-%436 = OpVariable %_ptr_Function_ushort Function
-%437 = OpVariable %_ptr_Function_ushort Function
-%438 = OpVariable %_ptr_Function_ushort Function
-%439 = OpVariable %_ptr_Function_ushort Function
-%440 = OpVariable %_ptr_Function_ushort Function
-%441 = OpVariable %_ptr_Function_ushort Function
-%442 = OpVariable %_ptr_Function_ushort Function
-%443 = OpVariable %_ptr_Function_ushort Function
-%444 = OpVariable %_ptr_Function_ushort Function
-%445 = OpVariable %_ptr_Function_ushort Function
-%446 = OpVariable %_ptr_Function_ushort Function
-%447 = OpVariable %_ptr_Function_ushort Function
-%448 = OpVariable %_ptr_Function_ushort Function
-%449 = OpVariable %_ptr_Function_ushort Function
-%450 = OpVariable %_ptr_Function_ushort Function
-%451 = OpVariable %_ptr_Function_ushort Function
-%452 = OpVariable %_ptr_Function_ushort Function
-%453 = OpVariable %_ptr_Function_ushort Function
-%454 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%455 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%456 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%457 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_ulong Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_bool Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_bool Function
+%447 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%452 = OpVariable %_ptr_Function_uint Function
+%453 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_uint Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_ulong Function
 %458 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %459 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %460 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%461 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%462 = OpVariable %_ptr_Function_ushort Function
-%463 = OpVariable %_ptr_Function_ushort Function
-%464 = OpVariable %_ptr_Function_ushort Function
-%465 = OpVariable %_ptr_Function_ushort Function
-%466 = OpVariable %_ptr_Function_ushort Function
-%467 = OpVariable %_ptr_Function_ushort Function
-%468 = OpVariable %_ptr_Function_ushort Function
-%469 = OpVariable %_ptr_Function_ushort Function
-%470 = OpVariable %_ptr_Function_ushort Function
-%471 = OpVariable %_ptr_Function_ushort Function
-%472 = OpVariable %_ptr_Function_ushort Function
-%473 = OpVariable %_ptr_Function_ushort Function
-%474 = OpVariable %_ptr_Function_ushort Function
-%475 = OpVariable %_ptr_Function_ushort Function
-%476 = OpVariable %_ptr_Function_ushort Function
-%477 = OpVariable %_ptr_Function_ushort Function
-%478 = OpVariable %_ptr_Function_ushort Function
-%479 = OpVariable %_ptr_Function_ushort Function
-%480 = OpVariable %_ptr_Function_ushort Function
-%481 = OpVariable %_ptr_Function_ushort Function
-%482 = OpVariable %_ptr_Function_ushort Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_ulong Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_ulong Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_bool Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_ulong Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_ulong Function
 %483 = OpVariable %_ptr_Function_ushort Function
 %484 = OpVariable %_ptr_Function_ushort Function
 %485 = OpVariable %_ptr_Function_ushort Function
-%486 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%487 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%488 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%489 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%490 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%491 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%492 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%493 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%486 = OpVariable %_ptr_Function_ushort Function
+%487 = OpVariable %_ptr_Function_ushort Function
+%488 = OpVariable %_ptr_Function_ushort Function
+%489 = OpVariable %_ptr_Function_ushort Function
+%490 = OpVariable %_ptr_Function_ushort Function
+%491 = OpVariable %_ptr_Function_ushort Function
+%492 = OpVariable %_ptr_Function_ushort Function
+%493 = OpVariable %_ptr_Function_ushort Function
 %494 = OpVariable %_ptr_Function_ushort Function
 %495 = OpVariable %_ptr_Function_ushort Function
 %496 = OpVariable %_ptr_Function_ushort Function
@@ -534,25 +703,25 @@ OpFunctionEnd
 %504 = OpVariable %_ptr_Function_ushort Function
 %505 = OpVariable %_ptr_Function_ushort Function
 %506 = OpVariable %_ptr_Function_ushort Function
-%507 = OpVariable %_ptr_Function_ushort Function
-%508 = OpVariable %_ptr_Function_ushort Function
-%509 = OpVariable %_ptr_Function_ushort Function
-%510 = OpVariable %_ptr_Function_ushort Function
-%511 = OpVariable %_ptr_Function_ushort Function
-%512 = OpVariable %_ptr_Function_ushort Function
-%513 = OpVariable %_ptr_Function_ushort Function
-%514 = OpVariable %_ptr_Function_ushort Function
+%507 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%508 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%509 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%510 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%511 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%512 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%513 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%514 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %515 = OpVariable %_ptr_Function_ushort Function
 %516 = OpVariable %_ptr_Function_ushort Function
 %517 = OpVariable %_ptr_Function_ushort Function
-%518 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%519 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%520 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%521 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%522 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%523 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%524 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%525 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%518 = OpVariable %_ptr_Function_ushort Function
+%519 = OpVariable %_ptr_Function_ushort Function
+%520 = OpVariable %_ptr_Function_ushort Function
+%521 = OpVariable %_ptr_Function_ushort Function
+%522 = OpVariable %_ptr_Function_ushort Function
+%523 = OpVariable %_ptr_Function_ushort Function
+%524 = OpVariable %_ptr_Function_ushort Function
+%525 = OpVariable %_ptr_Function_ushort Function
 %526 = OpVariable %_ptr_Function_ushort Function
 %527 = OpVariable %_ptr_Function_ushort Function
 %528 = OpVariable %_ptr_Function_ushort Function
@@ -566,25 +735,25 @@ OpFunctionEnd
 %536 = OpVariable %_ptr_Function_ushort Function
 %537 = OpVariable %_ptr_Function_ushort Function
 %538 = OpVariable %_ptr_Function_ushort Function
-%539 = OpVariable %_ptr_Function_ushort Function
-%540 = OpVariable %_ptr_Function_ushort Function
-%541 = OpVariable %_ptr_Function_ushort Function
-%542 = OpVariable %_ptr_Function_ushort Function
-%543 = OpVariable %_ptr_Function_ushort Function
-%544 = OpVariable %_ptr_Function_ushort Function
-%545 = OpVariable %_ptr_Function_ushort Function
-%546 = OpVariable %_ptr_Function_ushort Function
+%539 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%540 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%541 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%542 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%543 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%544 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%545 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%546 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %547 = OpVariable %_ptr_Function_ushort Function
 %548 = OpVariable %_ptr_Function_ushort Function
 %549 = OpVariable %_ptr_Function_ushort Function
-%550 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%551 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%552 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%553 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%554 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%555 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%556 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%557 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%550 = OpVariable %_ptr_Function_ushort Function
+%551 = OpVariable %_ptr_Function_ushort Function
+%552 = OpVariable %_ptr_Function_ushort Function
+%553 = OpVariable %_ptr_Function_ushort Function
+%554 = OpVariable %_ptr_Function_ushort Function
+%555 = OpVariable %_ptr_Function_ushort Function
+%556 = OpVariable %_ptr_Function_ushort Function
+%557 = OpVariable %_ptr_Function_ushort Function
 %558 = OpVariable %_ptr_Function_ushort Function
 %559 = OpVariable %_ptr_Function_ushort Function
 %560 = OpVariable %_ptr_Function_ushort Function
@@ -598,25 +767,25 @@ OpFunctionEnd
 %568 = OpVariable %_ptr_Function_ushort Function
 %569 = OpVariable %_ptr_Function_ushort Function
 %570 = OpVariable %_ptr_Function_ushort Function
-%571 = OpVariable %_ptr_Function_ushort Function
-%572 = OpVariable %_ptr_Function_ushort Function
-%573 = OpVariable %_ptr_Function_ushort Function
-%574 = OpVariable %_ptr_Function_ushort Function
-%575 = OpVariable %_ptr_Function_ushort Function
-%576 = OpVariable %_ptr_Function_ushort Function
-%577 = OpVariable %_ptr_Function_ushort Function
-%578 = OpVariable %_ptr_Function_ushort Function
+%571 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%572 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%573 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%574 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%575 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%576 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%577 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%578 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %579 = OpVariable %_ptr_Function_ushort Function
 %580 = OpVariable %_ptr_Function_ushort Function
 %581 = OpVariable %_ptr_Function_ushort Function
-%582 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%583 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%584 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%585 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%586 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%587 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%588 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%589 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%582 = OpVariable %_ptr_Function_ushort Function
+%583 = OpVariable %_ptr_Function_ushort Function
+%584 = OpVariable %_ptr_Function_ushort Function
+%585 = OpVariable %_ptr_Function_ushort Function
+%586 = OpVariable %_ptr_Function_ushort Function
+%587 = OpVariable %_ptr_Function_ushort Function
+%588 = OpVariable %_ptr_Function_ushort Function
+%589 = OpVariable %_ptr_Function_ushort Function
 %590 = OpVariable %_ptr_Function_ushort Function
 %591 = OpVariable %_ptr_Function_ushort Function
 %592 = OpVariable %_ptr_Function_ushort Function
@@ -630,25 +799,25 @@ OpFunctionEnd
 %600 = OpVariable %_ptr_Function_ushort Function
 %601 = OpVariable %_ptr_Function_ushort Function
 %602 = OpVariable %_ptr_Function_ushort Function
-%603 = OpVariable %_ptr_Function_ushort Function
-%604 = OpVariable %_ptr_Function_ushort Function
-%605 = OpVariable %_ptr_Function_ushort Function
-%606 = OpVariable %_ptr_Function_ushort Function
-%607 = OpVariable %_ptr_Function_ushort Function
-%608 = OpVariable %_ptr_Function_ushort Function
-%609 = OpVariable %_ptr_Function_ushort Function
-%610 = OpVariable %_ptr_Function_ushort Function
+%603 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%604 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%605 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%606 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%607 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%608 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%609 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%610 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %611 = OpVariable %_ptr_Function_ushort Function
 %612 = OpVariable %_ptr_Function_ushort Function
 %613 = OpVariable %_ptr_Function_ushort Function
-%614 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%615 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%616 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%617 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%618 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%619 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%620 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%621 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%614 = OpVariable %_ptr_Function_ushort Function
+%615 = OpVariable %_ptr_Function_ushort Function
+%616 = OpVariable %_ptr_Function_ushort Function
+%617 = OpVariable %_ptr_Function_ushort Function
+%618 = OpVariable %_ptr_Function_ushort Function
+%619 = OpVariable %_ptr_Function_ushort Function
+%620 = OpVariable %_ptr_Function_ushort Function
+%621 = OpVariable %_ptr_Function_ushort Function
 %622 = OpVariable %_ptr_Function_ushort Function
 %623 = OpVariable %_ptr_Function_ushort Function
 %624 = OpVariable %_ptr_Function_ushort Function
@@ -662,25 +831,25 @@ OpFunctionEnd
 %632 = OpVariable %_ptr_Function_ushort Function
 %633 = OpVariable %_ptr_Function_ushort Function
 %634 = OpVariable %_ptr_Function_ushort Function
-%635 = OpVariable %_ptr_Function_ushort Function
-%636 = OpVariable %_ptr_Function_ushort Function
-%637 = OpVariable %_ptr_Function_ushort Function
-%638 = OpVariable %_ptr_Function_ushort Function
-%639 = OpVariable %_ptr_Function_ushort Function
-%640 = OpVariable %_ptr_Function_ushort Function
-%641 = OpVariable %_ptr_Function_ushort Function
-%642 = OpVariable %_ptr_Function_ushort Function
+%635 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%636 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%637 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%638 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%639 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%640 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%641 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%642 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %643 = OpVariable %_ptr_Function_ushort Function
 %644 = OpVariable %_ptr_Function_ushort Function
 %645 = OpVariable %_ptr_Function_ushort Function
-%646 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%647 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%648 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%649 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%650 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%651 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%652 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%653 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%646 = OpVariable %_ptr_Function_ushort Function
+%647 = OpVariable %_ptr_Function_ushort Function
+%648 = OpVariable %_ptr_Function_ushort Function
+%649 = OpVariable %_ptr_Function_ushort Function
+%650 = OpVariable %_ptr_Function_ushort Function
+%651 = OpVariable %_ptr_Function_ushort Function
+%652 = OpVariable %_ptr_Function_ushort Function
+%653 = OpVariable %_ptr_Function_ushort Function
 %654 = OpVariable %_ptr_Function_ushort Function
 %655 = OpVariable %_ptr_Function_ushort Function
 %656 = OpVariable %_ptr_Function_ushort Function
@@ -694,25 +863,25 @@ OpFunctionEnd
 %664 = OpVariable %_ptr_Function_ushort Function
 %665 = OpVariable %_ptr_Function_ushort Function
 %666 = OpVariable %_ptr_Function_ushort Function
-%667 = OpVariable %_ptr_Function_ushort Function
-%668 = OpVariable %_ptr_Function_ushort Function
-%669 = OpVariable %_ptr_Function_ushort Function
-%670 = OpVariable %_ptr_Function_ushort Function
-%671 = OpVariable %_ptr_Function_ushort Function
-%672 = OpVariable %_ptr_Function_ushort Function
-%673 = OpVariable %_ptr_Function_ushort Function
-%674 = OpVariable %_ptr_Function_ushort Function
+%667 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%668 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%669 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%670 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%671 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%672 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%673 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%674 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %675 = OpVariable %_ptr_Function_ushort Function
 %676 = OpVariable %_ptr_Function_ushort Function
 %677 = OpVariable %_ptr_Function_ushort Function
-%678 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%679 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%680 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%681 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%682 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%683 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%684 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%685 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%678 = OpVariable %_ptr_Function_ushort Function
+%679 = OpVariable %_ptr_Function_ushort Function
+%680 = OpVariable %_ptr_Function_ushort Function
+%681 = OpVariable %_ptr_Function_ushort Function
+%682 = OpVariable %_ptr_Function_ushort Function
+%683 = OpVariable %_ptr_Function_ushort Function
+%684 = OpVariable %_ptr_Function_ushort Function
+%685 = OpVariable %_ptr_Function_ushort Function
 %686 = OpVariable %_ptr_Function_ushort Function
 %687 = OpVariable %_ptr_Function_ushort Function
 %688 = OpVariable %_ptr_Function_ushort Function
@@ -726,25 +895,25 @@ OpFunctionEnd
 %696 = OpVariable %_ptr_Function_ushort Function
 %697 = OpVariable %_ptr_Function_ushort Function
 %698 = OpVariable %_ptr_Function_ushort Function
-%699 = OpVariable %_ptr_Function_ushort Function
-%700 = OpVariable %_ptr_Function_ushort Function
-%701 = OpVariable %_ptr_Function_ushort Function
-%702 = OpVariable %_ptr_Function_ushort Function
-%703 = OpVariable %_ptr_Function_ushort Function
-%704 = OpVariable %_ptr_Function_ushort Function
-%705 = OpVariable %_ptr_Function_ushort Function
-%706 = OpVariable %_ptr_Function_ushort Function
+%699 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%700 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%701 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%702 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%703 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%704 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%705 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%706 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %707 = OpVariable %_ptr_Function_ushort Function
 %708 = OpVariable %_ptr_Function_ushort Function
 %709 = OpVariable %_ptr_Function_ushort Function
-%710 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%711 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%712 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%713 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%714 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%715 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%716 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%717 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%710 = OpVariable %_ptr_Function_ushort Function
+%711 = OpVariable %_ptr_Function_ushort Function
+%712 = OpVariable %_ptr_Function_ushort Function
+%713 = OpVariable %_ptr_Function_ushort Function
+%714 = OpVariable %_ptr_Function_ushort Function
+%715 = OpVariable %_ptr_Function_ushort Function
+%716 = OpVariable %_ptr_Function_ushort Function
+%717 = OpVariable %_ptr_Function_ushort Function
 %718 = OpVariable %_ptr_Function_ushort Function
 %719 = OpVariable %_ptr_Function_ushort Function
 %720 = OpVariable %_ptr_Function_ushort Function
@@ -758,25 +927,25 @@ OpFunctionEnd
 %728 = OpVariable %_ptr_Function_ushort Function
 %729 = OpVariable %_ptr_Function_ushort Function
 %730 = OpVariable %_ptr_Function_ushort Function
-%731 = OpVariable %_ptr_Function_ushort Function
-%732 = OpVariable %_ptr_Function_ushort Function
-%733 = OpVariable %_ptr_Function_ushort Function
-%734 = OpVariable %_ptr_Function_ushort Function
-%735 = OpVariable %_ptr_Function_ushort Function
-%736 = OpVariable %_ptr_Function_ushort Function
-%737 = OpVariable %_ptr_Function_ushort Function
-%738 = OpVariable %_ptr_Function_ushort Function
+%731 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%732 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%733 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%734 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%735 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%736 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%737 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%738 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %739 = OpVariable %_ptr_Function_ushort Function
 %740 = OpVariable %_ptr_Function_ushort Function
 %741 = OpVariable %_ptr_Function_ushort Function
-%742 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%743 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%744 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%745 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%746 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%747 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%748 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%749 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%742 = OpVariable %_ptr_Function_ushort Function
+%743 = OpVariable %_ptr_Function_ushort Function
+%744 = OpVariable %_ptr_Function_ushort Function
+%745 = OpVariable %_ptr_Function_ushort Function
+%746 = OpVariable %_ptr_Function_ushort Function
+%747 = OpVariable %_ptr_Function_ushort Function
+%748 = OpVariable %_ptr_Function_ushort Function
+%749 = OpVariable %_ptr_Function_ushort Function
 %750 = OpVariable %_ptr_Function_ushort Function
 %751 = OpVariable %_ptr_Function_ushort Function
 %752 = OpVariable %_ptr_Function_ushort Function
@@ -790,25 +959,25 @@ OpFunctionEnd
 %760 = OpVariable %_ptr_Function_ushort Function
 %761 = OpVariable %_ptr_Function_ushort Function
 %762 = OpVariable %_ptr_Function_ushort Function
-%763 = OpVariable %_ptr_Function_ushort Function
-%764 = OpVariable %_ptr_Function_ushort Function
-%765 = OpVariable %_ptr_Function_ushort Function
-%766 = OpVariable %_ptr_Function_ushort Function
-%767 = OpVariable %_ptr_Function_ushort Function
-%768 = OpVariable %_ptr_Function_ushort Function
-%769 = OpVariable %_ptr_Function_ushort Function
-%770 = OpVariable %_ptr_Function_ushort Function
+%763 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%764 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%765 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%766 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%767 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%768 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%769 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%770 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %771 = OpVariable %_ptr_Function_ushort Function
 %772 = OpVariable %_ptr_Function_ushort Function
 %773 = OpVariable %_ptr_Function_ushort Function
-%774 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%775 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%776 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%777 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%778 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%779 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%780 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%781 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%774 = OpVariable %_ptr_Function_ushort Function
+%775 = OpVariable %_ptr_Function_ushort Function
+%776 = OpVariable %_ptr_Function_ushort Function
+%777 = OpVariable %_ptr_Function_ushort Function
+%778 = OpVariable %_ptr_Function_ushort Function
+%779 = OpVariable %_ptr_Function_ushort Function
+%780 = OpVariable %_ptr_Function_ushort Function
+%781 = OpVariable %_ptr_Function_ushort Function
 %782 = OpVariable %_ptr_Function_ushort Function
 %783 = OpVariable %_ptr_Function_ushort Function
 %784 = OpVariable %_ptr_Function_ushort Function
@@ -822,25 +991,25 @@ OpFunctionEnd
 %792 = OpVariable %_ptr_Function_ushort Function
 %793 = OpVariable %_ptr_Function_ushort Function
 %794 = OpVariable %_ptr_Function_ushort Function
-%795 = OpVariable %_ptr_Function_ushort Function
-%796 = OpVariable %_ptr_Function_ushort Function
-%797 = OpVariable %_ptr_Function_ushort Function
-%798 = OpVariable %_ptr_Function_ushort Function
-%799 = OpVariable %_ptr_Function_ushort Function
-%800 = OpVariable %_ptr_Function_ushort Function
-%801 = OpVariable %_ptr_Function_ushort Function
-%802 = OpVariable %_ptr_Function_ushort Function
+%795 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%796 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%797 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%798 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%799 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%800 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%801 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%802 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %803 = OpVariable %_ptr_Function_ushort Function
 %804 = OpVariable %_ptr_Function_ushort Function
 %805 = OpVariable %_ptr_Function_ushort Function
-%806 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%807 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%808 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%809 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%810 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%811 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%812 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%813 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%806 = OpVariable %_ptr_Function_ushort Function
+%807 = OpVariable %_ptr_Function_ushort Function
+%808 = OpVariable %_ptr_Function_ushort Function
+%809 = OpVariable %_ptr_Function_ushort Function
+%810 = OpVariable %_ptr_Function_ushort Function
+%811 = OpVariable %_ptr_Function_ushort Function
+%812 = OpVariable %_ptr_Function_ushort Function
+%813 = OpVariable %_ptr_Function_ushort Function
 %814 = OpVariable %_ptr_Function_ushort Function
 %815 = OpVariable %_ptr_Function_ushort Function
 %816 = OpVariable %_ptr_Function_ushort Function
@@ -854,25 +1023,25 @@ OpFunctionEnd
 %824 = OpVariable %_ptr_Function_ushort Function
 %825 = OpVariable %_ptr_Function_ushort Function
 %826 = OpVariable %_ptr_Function_ushort Function
-%827 = OpVariable %_ptr_Function_ushort Function
-%828 = OpVariable %_ptr_Function_ushort Function
-%829 = OpVariable %_ptr_Function_ushort Function
-%830 = OpVariable %_ptr_Function_ushort Function
-%831 = OpVariable %_ptr_Function_ushort Function
-%832 = OpVariable %_ptr_Function_ushort Function
-%833 = OpVariable %_ptr_Function_ushort Function
-%834 = OpVariable %_ptr_Function_ushort Function
+%827 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%828 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%829 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%830 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%831 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%832 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%833 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%834 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %835 = OpVariable %_ptr_Function_ushort Function
 %836 = OpVariable %_ptr_Function_ushort Function
 %837 = OpVariable %_ptr_Function_ushort Function
-%838 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%839 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%840 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%841 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%842 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%843 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%844 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%845 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%838 = OpVariable %_ptr_Function_ushort Function
+%839 = OpVariable %_ptr_Function_ushort Function
+%840 = OpVariable %_ptr_Function_ushort Function
+%841 = OpVariable %_ptr_Function_ushort Function
+%842 = OpVariable %_ptr_Function_ushort Function
+%843 = OpVariable %_ptr_Function_ushort Function
+%844 = OpVariable %_ptr_Function_ushort Function
+%845 = OpVariable %_ptr_Function_ushort Function
 %846 = OpVariable %_ptr_Function_ushort Function
 %847 = OpVariable %_ptr_Function_ushort Function
 %848 = OpVariable %_ptr_Function_ushort Function
@@ -886,25 +1055,25 @@ OpFunctionEnd
 %856 = OpVariable %_ptr_Function_ushort Function
 %857 = OpVariable %_ptr_Function_ushort Function
 %858 = OpVariable %_ptr_Function_ushort Function
-%859 = OpVariable %_ptr_Function_ushort Function
-%860 = OpVariable %_ptr_Function_ushort Function
-%861 = OpVariable %_ptr_Function_ushort Function
-%862 = OpVariable %_ptr_Function_ushort Function
-%863 = OpVariable %_ptr_Function_ushort Function
-%864 = OpVariable %_ptr_Function_ushort Function
-%865 = OpVariable %_ptr_Function_ushort Function
-%866 = OpVariable %_ptr_Function_ushort Function
+%859 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%860 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%861 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%862 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%863 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%864 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%865 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%866 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %867 = OpVariable %_ptr_Function_ushort Function
 %868 = OpVariable %_ptr_Function_ushort Function
 %869 = OpVariable %_ptr_Function_ushort Function
-%870 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%871 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%872 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%873 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%874 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%875 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%876 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%877 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%870 = OpVariable %_ptr_Function_ushort Function
+%871 = OpVariable %_ptr_Function_ushort Function
+%872 = OpVariable %_ptr_Function_ushort Function
+%873 = OpVariable %_ptr_Function_ushort Function
+%874 = OpVariable %_ptr_Function_ushort Function
+%875 = OpVariable %_ptr_Function_ushort Function
+%876 = OpVariable %_ptr_Function_ushort Function
+%877 = OpVariable %_ptr_Function_ushort Function
 %878 = OpVariable %_ptr_Function_ushort Function
 %879 = OpVariable %_ptr_Function_ushort Function
 %880 = OpVariable %_ptr_Function_ushort Function
@@ -918,25 +1087,25 @@ OpFunctionEnd
 %888 = OpVariable %_ptr_Function_ushort Function
 %889 = OpVariable %_ptr_Function_ushort Function
 %890 = OpVariable %_ptr_Function_ushort Function
-%891 = OpVariable %_ptr_Function_ushort Function
-%892 = OpVariable %_ptr_Function_ushort Function
-%893 = OpVariable %_ptr_Function_ushort Function
-%894 = OpVariable %_ptr_Function_ushort Function
-%895 = OpVariable %_ptr_Function_ushort Function
-%896 = OpVariable %_ptr_Function_ushort Function
-%897 = OpVariable %_ptr_Function_ushort Function
-%898 = OpVariable %_ptr_Function_ushort Function
+%891 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%892 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%893 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%894 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%895 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%896 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%897 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%898 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %899 = OpVariable %_ptr_Function_ushort Function
 %900 = OpVariable %_ptr_Function_ushort Function
 %901 = OpVariable %_ptr_Function_ushort Function
-%902 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%903 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%904 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%905 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%906 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%907 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%908 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%909 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%902 = OpVariable %_ptr_Function_ushort Function
+%903 = OpVariable %_ptr_Function_ushort Function
+%904 = OpVariable %_ptr_Function_ushort Function
+%905 = OpVariable %_ptr_Function_ushort Function
+%906 = OpVariable %_ptr_Function_ushort Function
+%907 = OpVariable %_ptr_Function_ushort Function
+%908 = OpVariable %_ptr_Function_ushort Function
+%909 = OpVariable %_ptr_Function_ushort Function
 %910 = OpVariable %_ptr_Function_ushort Function
 %911 = OpVariable %_ptr_Function_ushort Function
 %912 = OpVariable %_ptr_Function_ushort Function
@@ -950,25 +1119,25 @@ OpFunctionEnd
 %920 = OpVariable %_ptr_Function_ushort Function
 %921 = OpVariable %_ptr_Function_ushort Function
 %922 = OpVariable %_ptr_Function_ushort Function
-%923 = OpVariable %_ptr_Function_ushort Function
-%924 = OpVariable %_ptr_Function_ushort Function
-%925 = OpVariable %_ptr_Function_ushort Function
-%926 = OpVariable %_ptr_Function_ushort Function
-%927 = OpVariable %_ptr_Function_ushort Function
-%928 = OpVariable %_ptr_Function_ushort Function
-%929 = OpVariable %_ptr_Function_ushort Function
-%930 = OpVariable %_ptr_Function_ushort Function
+%923 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%924 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%925 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%926 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%927 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%928 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%929 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%930 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %931 = OpVariable %_ptr_Function_ushort Function
 %932 = OpVariable %_ptr_Function_ushort Function
 %933 = OpVariable %_ptr_Function_ushort Function
-%934 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%935 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%936 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%937 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%938 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%939 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%940 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%941 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%934 = OpVariable %_ptr_Function_ushort Function
+%935 = OpVariable %_ptr_Function_ushort Function
+%936 = OpVariable %_ptr_Function_ushort Function
+%937 = OpVariable %_ptr_Function_ushort Function
+%938 = OpVariable %_ptr_Function_ushort Function
+%939 = OpVariable %_ptr_Function_ushort Function
+%940 = OpVariable %_ptr_Function_ushort Function
+%941 = OpVariable %_ptr_Function_ushort Function
 %942 = OpVariable %_ptr_Function_ushort Function
 %943 = OpVariable %_ptr_Function_ushort Function
 %944 = OpVariable %_ptr_Function_ushort Function
@@ -982,25 +1151,25 @@ OpFunctionEnd
 %952 = OpVariable %_ptr_Function_ushort Function
 %953 = OpVariable %_ptr_Function_ushort Function
 %954 = OpVariable %_ptr_Function_ushort Function
-%955 = OpVariable %_ptr_Function_ushort Function
-%956 = OpVariable %_ptr_Function_ushort Function
-%957 = OpVariable %_ptr_Function_ushort Function
-%958 = OpVariable %_ptr_Function_ushort Function
-%959 = OpVariable %_ptr_Function_ushort Function
-%960 = OpVariable %_ptr_Function_ushort Function
-%961 = OpVariable %_ptr_Function_ushort Function
-%962 = OpVariable %_ptr_Function_ushort Function
+%955 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%956 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%957 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%958 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%959 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%960 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%961 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%962 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %963 = OpVariable %_ptr_Function_ushort Function
 %964 = OpVariable %_ptr_Function_ushort Function
 %965 = OpVariable %_ptr_Function_ushort Function
-%966 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%967 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%968 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%969 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%970 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%971 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%972 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%973 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%966 = OpVariable %_ptr_Function_ushort Function
+%967 = OpVariable %_ptr_Function_ushort Function
+%968 = OpVariable %_ptr_Function_ushort Function
+%969 = OpVariable %_ptr_Function_ushort Function
+%970 = OpVariable %_ptr_Function_ushort Function
+%971 = OpVariable %_ptr_Function_ushort Function
+%972 = OpVariable %_ptr_Function_ushort Function
+%973 = OpVariable %_ptr_Function_ushort Function
 %974 = OpVariable %_ptr_Function_ushort Function
 %975 = OpVariable %_ptr_Function_ushort Function
 %976 = OpVariable %_ptr_Function_ushort Function
@@ -1014,25 +1183,25 @@ OpFunctionEnd
 %984 = OpVariable %_ptr_Function_ushort Function
 %985 = OpVariable %_ptr_Function_ushort Function
 %986 = OpVariable %_ptr_Function_ushort Function
-%987 = OpVariable %_ptr_Function_ushort Function
-%988 = OpVariable %_ptr_Function_ushort Function
-%989 = OpVariable %_ptr_Function_ushort Function
-%990 = OpVariable %_ptr_Function_ushort Function
-%991 = OpVariable %_ptr_Function_ushort Function
-%992 = OpVariable %_ptr_Function_ushort Function
-%993 = OpVariable %_ptr_Function_ushort Function
-%994 = OpVariable %_ptr_Function_ushort Function
+%987 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%988 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%989 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%990 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%991 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%992 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%993 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%994 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %995 = OpVariable %_ptr_Function_ushort Function
 %996 = OpVariable %_ptr_Function_ushort Function
 %997 = OpVariable %_ptr_Function_ushort Function
-%998 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%999 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1000 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1001 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1002 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1003 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1004 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1005 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%998 = OpVariable %_ptr_Function_ushort Function
+%999 = OpVariable %_ptr_Function_ushort Function
+%1000 = OpVariable %_ptr_Function_ushort Function
+%1001 = OpVariable %_ptr_Function_ushort Function
+%1002 = OpVariable %_ptr_Function_ushort Function
+%1003 = OpVariable %_ptr_Function_ushort Function
+%1004 = OpVariable %_ptr_Function_ushort Function
+%1005 = OpVariable %_ptr_Function_ushort Function
 %1006 = OpVariable %_ptr_Function_ushort Function
 %1007 = OpVariable %_ptr_Function_ushort Function
 %1008 = OpVariable %_ptr_Function_ushort Function
@@ -1046,25 +1215,25 @@ OpFunctionEnd
 %1016 = OpVariable %_ptr_Function_ushort Function
 %1017 = OpVariable %_ptr_Function_ushort Function
 %1018 = OpVariable %_ptr_Function_ushort Function
-%1019 = OpVariable %_ptr_Function_ushort Function
-%1020 = OpVariable %_ptr_Function_ushort Function
-%1021 = OpVariable %_ptr_Function_ushort Function
-%1022 = OpVariable %_ptr_Function_ushort Function
-%1023 = OpVariable %_ptr_Function_ushort Function
-%1024 = OpVariable %_ptr_Function_ushort Function
-%1025 = OpVariable %_ptr_Function_ushort Function
-%1026 = OpVariable %_ptr_Function_ushort Function
+%1019 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1020 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1021 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1022 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1023 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1024 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1025 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1026 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1027 = OpVariable %_ptr_Function_ushort Function
 %1028 = OpVariable %_ptr_Function_ushort Function
 %1029 = OpVariable %_ptr_Function_ushort Function
-%1030 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1031 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1032 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1033 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1034 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1035 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1036 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1037 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1030 = OpVariable %_ptr_Function_ushort Function
+%1031 = OpVariable %_ptr_Function_ushort Function
+%1032 = OpVariable %_ptr_Function_ushort Function
+%1033 = OpVariable %_ptr_Function_ushort Function
+%1034 = OpVariable %_ptr_Function_ushort Function
+%1035 = OpVariable %_ptr_Function_ushort Function
+%1036 = OpVariable %_ptr_Function_ushort Function
+%1037 = OpVariable %_ptr_Function_ushort Function
 %1038 = OpVariable %_ptr_Function_ushort Function
 %1039 = OpVariable %_ptr_Function_ushort Function
 %1040 = OpVariable %_ptr_Function_ushort Function
@@ -1078,17 +1247,17 @@ OpFunctionEnd
 %1048 = OpVariable %_ptr_Function_ushort Function
 %1049 = OpVariable %_ptr_Function_ushort Function
 %1050 = OpVariable %_ptr_Function_ushort Function
-%1051 = OpVariable %_ptr_Function_ushort Function
-%1052 = OpVariable %_ptr_Function_ushort Function
-%1053 = OpVariable %_ptr_Function_ushort Function
+%1051 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1052 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1053 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1054 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1055 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1056 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1057 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1058 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1059 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1060 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1061 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1059 = OpVariable %_ptr_Function_ushort Function
+%1060 = OpVariable %_ptr_Function_ushort Function
+%1061 = OpVariable %_ptr_Function_ushort Function
 %1062 = OpVariable %_ptr_Function_ushort Function
 %1063 = OpVariable %_ptr_Function_ushort Function
 %1064 = OpVariable %_ptr_Function_ushort Function
@@ -1102,17 +1271,17 @@ OpFunctionEnd
 %1072 = OpVariable %_ptr_Function_ushort Function
 %1073 = OpVariable %_ptr_Function_ushort Function
 %1074 = OpVariable %_ptr_Function_ushort Function
-%1075 = OpVariable %_ptr_Function_ushort Function
-%1076 = OpVariable %_ptr_Function_ushort Function
-%1077 = OpVariable %_ptr_Function_ushort Function
+%1075 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1076 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1077 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1078 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1079 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1080 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1081 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1082 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1083 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1084 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1085 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1083 = OpVariable %_ptr_Function_ushort Function
+%1084 = OpVariable %_ptr_Function_ushort Function
+%1085 = OpVariable %_ptr_Function_ushort Function
 %1086 = OpVariable %_ptr_Function_ushort Function
 %1087 = OpVariable %_ptr_Function_ushort Function
 %1088 = OpVariable %_ptr_Function_ushort Function
@@ -1126,3712 +1295,2681 @@ OpFunctionEnd
 %1096 = OpVariable %_ptr_Function_ushort Function
 %1097 = OpVariable %_ptr_Function_ushort Function
 %1098 = OpVariable %_ptr_Function_ushort Function
-%1099 = OpVariable %_ptr_Function_ushort Function
-%1100 = OpVariable %_ptr_Function_ushort Function
-%1101 = OpVariable %_ptr_Function_ushort Function
-%1102 = OpVariable %_ptr_Function_ushort Function
-%1103 = OpVariable %_ptr_Function_ushort Function
-%1104 = OpVariable %_ptr_Function_ushort Function
-%1105 = OpVariable %_ptr_Function_ushort Function
-%1106 = OpVariable %_ptr_Function_ushort Function
+%1099 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1100 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1101 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1102 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1103 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1104 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1105 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1106 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
 %1107 = OpVariable %_ptr_Function_ushort Function
 %1108 = OpVariable %_ptr_Function_ushort Function
 %1109 = OpVariable %_ptr_Function_ushort Function
-%1110 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1111 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1112 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1113 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1114 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1115 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1116 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-%1117 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
-OpStore %128 %78
-%1118 = OpFunctionCall %ulong %3
-OpStore %129 %1118
-%1119 = OpLoad %ulong %128
-%1120 = OpUConvert %ushort %1119
-OpStore %130 %1120
-%1121 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_65520 %ushort_1 %ushort_32768 %ushort_65535 %ushort_4097 %ushort_2 %ushort_40000 %ushort_12345
-OpStore %131 %1121
-%1130 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_17 %ushort_65535 %ushort_32769 %ushort_1 %ushort_60000 %ushort_30000 %ushort_25537 %ushort_54321
-OpStore %132 %1130
-%1137 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_3 %ushort_9 %ushort_27 %ushort_81 %ushort_243 %ushort_729 %ushort_2187
-OpStore %133 %1137
-%1145 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0
-OpStore %134 %1145
-%1147 = OpLoad %_arr_ushort_uint_8 %131
-%1148 = OpCompositeExtract %ushort %1147 0
-OpStore %135 %1148
-%1149 = OpLoad %ushort %135
-%1150 = OpLoad %ushort %130
-%1151 = OpIAdd %ushort %1149 %1150
-OpStore %136 %1151
-%1152 = OpLoad %_arr_ushort_uint_8 %131
-%1153 = OpLoad %ushort %136
-%1154 = OpCompositeInsert %_arr_ushort_uint_8 %1153 %1152 0
-OpStore %137 %1154
-%1155 = OpLoad %_arr_ushort_uint_8 %137
-%1156 = OpCompositeExtract %ushort %1155 6
-OpStore %138 %1156
-%1157 = OpLoad %ushort %138
-%1158 = OpLoad %ushort %130
-%1159 = OpIAdd %ushort %1157 %1158
-OpStore %139 %1159
-%1160 = OpLoad %_arr_ushort_uint_8 %137
-%1161 = OpLoad %ushort %139
-%1162 = OpCompositeInsert %_arr_ushort_uint_8 %1161 %1160 6
-OpStore %140 %1162
-%1163 = OpLoad %_arr_ushort_uint_8 %132
-%1164 = OpCompositeExtract %ushort %1163 2
-OpStore %141 %1164
-%1165 = OpLoad %ushort %141
-%1166 = OpLoad %ushort %130
-%1167 = OpIAdd %ushort %1165 %1166
-OpStore %142 %1167
-%1168 = OpLoad %_arr_ushort_uint_8 %132
-%1169 = OpLoad %ushort %142
-%1170 = OpCompositeInsert %_arr_ushort_uint_8 %1169 %1168 2
-OpStore %143 %1170
-%1171 = OpLoad %_arr_ushort_uint_8 %143
-%1172 = OpCompositeExtract %ushort %1171 7
-OpStore %144 %1172
-%1173 = OpLoad %ushort %144
-%1174 = OpLoad %ushort %130
-%1175 = OpIAdd %ushort %1173 %1174
-OpStore %145 %1175
-%1176 = OpLoad %_arr_ushort_uint_8 %143
-%1177 = OpLoad %ushort %145
-%1178 = OpCompositeInsert %_arr_ushort_uint_8 %1177 %1176 7
-OpStore %146 %1178
-OpBranch %86
-%86 = OpLabel
-%1179 = OpLoad %_arr_ushort_uint_8 %140
-%1180 = OpCompositeExtract %ushort %1179 0
-OpStore %174 %1180
-%1181 = OpLoad %ulong %129
-%1182 = OpLoad %ushort %174
-%1183 = OpFunctionCall %ulong %4 %1181 %1182
-OpStore %175 %1183
-%1184 = OpLoad %_arr_ushort_uint_8 %140
-%1185 = OpCompositeExtract %ushort %1184 1
-OpStore %176 %1185
-%1186 = OpLoad %ulong %175
-%1187 = OpLoad %ushort %176
-%1188 = OpFunctionCall %ulong %4 %1186 %1187
-OpStore %177 %1188
-%1189 = OpLoad %_arr_ushort_uint_8 %140
-%1190 = OpCompositeExtract %ushort %1189 2
-OpStore %178 %1190
-%1191 = OpLoad %ulong %177
-%1192 = OpLoad %ushort %178
-%1193 = OpFunctionCall %ulong %4 %1191 %1192
-OpStore %179 %1193
-%1194 = OpLoad %_arr_ushort_uint_8 %140
-%1195 = OpCompositeExtract %ushort %1194 3
-OpStore %180 %1195
-%1196 = OpLoad %ulong %179
-%1197 = OpLoad %ushort %180
-%1198 = OpFunctionCall %ulong %4 %1196 %1197
-OpStore %181 %1198
-%1199 = OpLoad %_arr_ushort_uint_8 %140
-%1200 = OpCompositeExtract %ushort %1199 4
-OpStore %182 %1200
-%1201 = OpLoad %ulong %181
-%1202 = OpLoad %ushort %182
-%1203 = OpFunctionCall %ulong %4 %1201 %1202
-OpStore %183 %1203
-%1204 = OpLoad %_arr_ushort_uint_8 %140
-%1205 = OpCompositeExtract %ushort %1204 5
-OpStore %184 %1205
-%1206 = OpLoad %ulong %183
-%1207 = OpLoad %ushort %184
-%1208 = OpFunctionCall %ulong %4 %1206 %1207
-OpStore %185 %1208
-%1209 = OpLoad %_arr_ushort_uint_8 %140
-%1210 = OpCompositeExtract %ushort %1209 6
-OpStore %186 %1210
-%1211 = OpLoad %ulong %185
-%1212 = OpLoad %ushort %186
-%1213 = OpFunctionCall %ulong %4 %1211 %1212
-OpStore %187 %1213
-%1214 = OpLoad %_arr_ushort_uint_8 %140
-%1215 = OpCompositeExtract %ushort %1214 7
-OpStore %188 %1215
-%1216 = OpLoad %ulong %187
-%1217 = OpLoad %ushort %188
-%1218 = OpFunctionCall %ulong %4 %1216 %1217
-OpStore %189 %1218
-OpBranch %87
-%87 = OpLabel
-OpBranch %94
-%94 = OpLabel
-%1219 = OpLoad %_arr_ushort_uint_8 %146
-%1220 = OpCompositeExtract %ushort %1219 0
-OpStore %238 %1220
-%1221 = OpLoad %ulong %189
-%1222 = OpLoad %ushort %238
-%1223 = OpFunctionCall %ulong %4 %1221 %1222
-OpStore %239 %1223
-%1224 = OpLoad %_arr_ushort_uint_8 %146
-%1225 = OpCompositeExtract %ushort %1224 1
-OpStore %240 %1225
-%1226 = OpLoad %ulong %239
-%1227 = OpLoad %ushort %240
-%1228 = OpFunctionCall %ulong %4 %1226 %1227
-OpStore %241 %1228
-%1229 = OpLoad %_arr_ushort_uint_8 %146
-%1230 = OpCompositeExtract %ushort %1229 2
-OpStore %242 %1230
-%1231 = OpLoad %ulong %241
-%1232 = OpLoad %ushort %242
-%1233 = OpFunctionCall %ulong %4 %1231 %1232
-OpStore %243 %1233
-%1234 = OpLoad %_arr_ushort_uint_8 %146
-%1235 = OpCompositeExtract %ushort %1234 3
-OpStore %244 %1235
-%1236 = OpLoad %ulong %243
-%1237 = OpLoad %ushort %244
-%1238 = OpFunctionCall %ulong %4 %1236 %1237
-OpStore %245 %1238
-%1239 = OpLoad %_arr_ushort_uint_8 %146
-%1240 = OpCompositeExtract %ushort %1239 4
-OpStore %246 %1240
-%1241 = OpLoad %ulong %245
-%1242 = OpLoad %ushort %246
-%1243 = OpFunctionCall %ulong %4 %1241 %1242
-OpStore %247 %1243
-%1244 = OpLoad %_arr_ushort_uint_8 %146
-%1245 = OpCompositeExtract %ushort %1244 5
-OpStore %248 %1245
-%1246 = OpLoad %ulong %247
-%1247 = OpLoad %ushort %248
-%1248 = OpFunctionCall %ulong %4 %1246 %1247
-OpStore %249 %1248
-%1249 = OpLoad %_arr_ushort_uint_8 %146
+%1110 = OpVariable %_ptr_Function_ushort Function
+%1111 = OpVariable %_ptr_Function_ushort Function
+%1112 = OpVariable %_ptr_Function_ushort Function
+%1113 = OpVariable %_ptr_Function_ushort Function
+%1114 = OpVariable %_ptr_Function_ushort Function
+%1115 = OpVariable %_ptr_Function_ushort Function
+%1116 = OpVariable %_ptr_Function_ushort Function
+%1117 = OpVariable %_ptr_Function_ushort Function
+%1118 = OpVariable %_ptr_Function_ushort Function
+%1119 = OpVariable %_ptr_Function_ushort Function
+%1120 = OpVariable %_ptr_Function_ushort Function
+%1121 = OpVariable %_ptr_Function_ushort Function
+%1122 = OpVariable %_ptr_Function_ushort Function
+%1123 = OpVariable %_ptr_Function_ushort Function
+%1124 = OpVariable %_ptr_Function_ushort Function
+%1125 = OpVariable %_ptr_Function_ushort Function
+%1126 = OpVariable %_ptr_Function_ushort Function
+%1127 = OpVariable %_ptr_Function_ushort Function
+%1128 = OpVariable %_ptr_Function_ushort Function
+%1129 = OpVariable %_ptr_Function_ushort Function
+%1130 = OpVariable %_ptr_Function_ushort Function
+%1131 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1132 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1133 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1134 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1135 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1136 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1137 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+%1138 = OpVariable %_ptr_Function__arr_ushort_uint_8 Function
+OpStore %405 %370
+OpBranch %378
+%378 = OpLabel
+OpBranch %379
+%379 = OpLabel
+%1139 = OpLoad %ulong %405
+%1140 = OpUConvert %ushort %1139
+OpStore %406 %1140
+%1141 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_65520 %ushort_1 %ushort_32768 %ushort_65535 %ushort_4097 %ushort_2 %ushort_40000 %ushort_12345
+OpStore %407 %1141
+%1150 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_17 %ushort_65535 %ushort_32769 %ushort_1 %ushort_60000 %ushort_30000 %ushort_25537 %ushort_54321
+OpStore %408 %1150
+%1157 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_1 %ushort_3 %ushort_9 %ushort_27 %ushort_81 %ushort_243 %ushort_729 %ushort_2187
+OpStore %409 %1157
+%1165 = OpCompositeConstruct %_arr_ushort_uint_8 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0 %ushort_0
+OpStore %410 %1165
+%1167 = OpLoad %_arr_ushort_uint_8 %407
+%1168 = OpCompositeExtract %ushort %1167 0
+OpStore %411 %1168
+%1169 = OpLoad %ushort %411
+%1170 = OpLoad %ushort %406
+%1171 = OpIAdd %ushort %1169 %1170
+OpStore %412 %1171
+%1172 = OpLoad %_arr_ushort_uint_8 %407
+%1173 = OpLoad %ushort %412
+%1174 = OpCompositeInsert %_arr_ushort_uint_8 %1173 %1172 0
+OpStore %413 %1174
+%1175 = OpLoad %_arr_ushort_uint_8 %413
+%1176 = OpCompositeExtract %ushort %1175 6
+OpStore %414 %1176
+%1177 = OpLoad %ushort %414
+%1178 = OpLoad %ushort %406
+%1179 = OpIAdd %ushort %1177 %1178
+OpStore %415 %1179
+%1180 = OpLoad %_arr_ushort_uint_8 %413
+%1181 = OpLoad %ushort %415
+%1182 = OpCompositeInsert %_arr_ushort_uint_8 %1181 %1180 6
+OpStore %416 %1182
+%1183 = OpLoad %_arr_ushort_uint_8 %408
+%1184 = OpCompositeExtract %ushort %1183 2
+OpStore %417 %1184
+%1185 = OpLoad %ushort %417
+%1186 = OpLoad %ushort %406
+%1187 = OpIAdd %ushort %1185 %1186
+OpStore %418 %1187
+%1188 = OpLoad %_arr_ushort_uint_8 %408
+%1189 = OpLoad %ushort %418
+%1190 = OpCompositeInsert %_arr_ushort_uint_8 %1189 %1188 2
+OpStore %419 %1190
+%1191 = OpLoad %_arr_ushort_uint_8 %419
+%1192 = OpCompositeExtract %ushort %1191 7
+OpStore %420 %1192
+%1193 = OpLoad %ushort %420
+%1194 = OpLoad %ushort %406
+%1195 = OpIAdd %ushort %1193 %1194
+OpStore %421 %1195
+%1196 = OpLoad %_arr_ushort_uint_8 %419
+%1197 = OpLoad %ushort %421
+%1198 = OpCompositeInsert %_arr_ushort_uint_8 %1197 %1196 7
+OpStore %422 %1198
+%1200 = OpLoad %_arr_ushort_uint_8 %416
+%1201 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %1200
+OpStore %423 %1201
+%1202 = OpLoad %ulong %423
+%1203 = OpLoad %_arr_ushort_uint_8 %422
+%1204 = OpFunctionCall %ulong %1 %1202 %1203
+OpStore %424 %1204
+%1205 = OpLoad %_arr_ushort_uint_8 %416
+%1206 = OpCompositeExtract %ushort %1205 0
+OpStore %675 %1206
+%1207 = OpLoad %_arr_ushort_uint_8 %422
+%1208 = OpCompositeExtract %ushort %1207 0
+OpStore %676 %1208
+%1209 = OpLoad %ushort %675
+%1210 = OpLoad %ushort %676
+%1211 = OpIAdd %ushort %1209 %1210
+OpStore %677 %1211
+%1212 = OpLoad %_arr_ushort_uint_8 %416
+%1213 = OpCompositeExtract %ushort %1212 1
+OpStore %678 %1213
+%1214 = OpLoad %_arr_ushort_uint_8 %422
+%1215 = OpCompositeExtract %ushort %1214 1
+OpStore %679 %1215
+%1216 = OpLoad %ushort %678
+%1217 = OpLoad %ushort %679
+%1218 = OpIAdd %ushort %1216 %1217
+OpStore %680 %1218
+%1219 = OpLoad %_arr_ushort_uint_8 %416
+%1220 = OpCompositeExtract %ushort %1219 2
+OpStore %681 %1220
+%1221 = OpLoad %_arr_ushort_uint_8 %422
+%1222 = OpCompositeExtract %ushort %1221 2
+OpStore %682 %1222
+%1223 = OpLoad %ushort %681
+%1224 = OpLoad %ushort %682
+%1225 = OpIAdd %ushort %1223 %1224
+OpStore %683 %1225
+%1226 = OpLoad %_arr_ushort_uint_8 %416
+%1227 = OpCompositeExtract %ushort %1226 3
+OpStore %684 %1227
+%1228 = OpLoad %_arr_ushort_uint_8 %422
+%1229 = OpCompositeExtract %ushort %1228 3
+OpStore %685 %1229
+%1230 = OpLoad %ushort %684
+%1231 = OpLoad %ushort %685
+%1232 = OpIAdd %ushort %1230 %1231
+OpStore %686 %1232
+%1233 = OpLoad %_arr_ushort_uint_8 %416
+%1234 = OpCompositeExtract %ushort %1233 4
+OpStore %687 %1234
+%1235 = OpLoad %_arr_ushort_uint_8 %422
+%1236 = OpCompositeExtract %ushort %1235 4
+OpStore %688 %1236
+%1237 = OpLoad %ushort %687
+%1238 = OpLoad %ushort %688
+%1239 = OpIAdd %ushort %1237 %1238
+OpStore %689 %1239
+%1240 = OpLoad %_arr_ushort_uint_8 %416
+%1241 = OpCompositeExtract %ushort %1240 5
+OpStore %690 %1241
+%1242 = OpLoad %_arr_ushort_uint_8 %422
+%1243 = OpCompositeExtract %ushort %1242 5
+OpStore %691 %1243
+%1244 = OpLoad %ushort %690
+%1245 = OpLoad %ushort %691
+%1246 = OpIAdd %ushort %1244 %1245
+OpStore %692 %1246
+%1247 = OpLoad %_arr_ushort_uint_8 %416
+%1248 = OpCompositeExtract %ushort %1247 6
+OpStore %693 %1248
+%1249 = OpLoad %_arr_ushort_uint_8 %422
 %1250 = OpCompositeExtract %ushort %1249 6
-OpStore %250 %1250
-%1251 = OpLoad %ulong %249
-%1252 = OpLoad %ushort %250
-%1253 = OpFunctionCall %ulong %4 %1251 %1252
-OpStore %251 %1253
-%1254 = OpLoad %_arr_ushort_uint_8 %146
+OpStore %694 %1250
+%1251 = OpLoad %ushort %693
+%1252 = OpLoad %ushort %694
+%1253 = OpIAdd %ushort %1251 %1252
+OpStore %695 %1253
+%1254 = OpLoad %_arr_ushort_uint_8 %416
 %1255 = OpCompositeExtract %ushort %1254 7
-OpStore %252 %1255
-%1256 = OpLoad %ulong %251
-%1257 = OpLoad %ushort %252
-%1258 = OpFunctionCall %ulong %4 %1256 %1257
-OpStore %253 %1258
-OpBranch %95
-%95 = OpLabel
-%1259 = OpLoad %_arr_ushort_uint_8 %140
-%1260 = OpCompositeExtract %ushort %1259 0
-OpStore %558 %1260
-%1261 = OpLoad %_arr_ushort_uint_8 %146
-%1262 = OpCompositeExtract %ushort %1261 0
-OpStore %559 %1262
-%1263 = OpLoad %ushort %558
-%1264 = OpLoad %ushort %559
-%1265 = OpIAdd %ushort %1263 %1264
-OpStore %560 %1265
-%1266 = OpLoad %_arr_ushort_uint_8 %140
-%1267 = OpCompositeExtract %ushort %1266 1
-OpStore %561 %1267
-%1268 = OpLoad %_arr_ushort_uint_8 %146
-%1269 = OpCompositeExtract %ushort %1268 1
-OpStore %562 %1269
-%1270 = OpLoad %ushort %561
-%1271 = OpLoad %ushort %562
-%1272 = OpIAdd %ushort %1270 %1271
-OpStore %563 %1272
-%1273 = OpLoad %_arr_ushort_uint_8 %140
-%1274 = OpCompositeExtract %ushort %1273 2
-OpStore %564 %1274
-%1275 = OpLoad %_arr_ushort_uint_8 %146
-%1276 = OpCompositeExtract %ushort %1275 2
-OpStore %565 %1276
-%1277 = OpLoad %ushort %564
-%1278 = OpLoad %ushort %565
-%1279 = OpIAdd %ushort %1277 %1278
-OpStore %566 %1279
-%1280 = OpLoad %_arr_ushort_uint_8 %140
-%1281 = OpCompositeExtract %ushort %1280 3
-OpStore %567 %1281
-%1282 = OpLoad %_arr_ushort_uint_8 %146
-%1283 = OpCompositeExtract %ushort %1282 3
-OpStore %568 %1283
-%1284 = OpLoad %ushort %567
-%1285 = OpLoad %ushort %568
-%1286 = OpIAdd %ushort %1284 %1285
-OpStore %569 %1286
-%1287 = OpLoad %_arr_ushort_uint_8 %140
-%1288 = OpCompositeExtract %ushort %1287 4
-OpStore %570 %1288
-%1289 = OpLoad %_arr_ushort_uint_8 %146
-%1290 = OpCompositeExtract %ushort %1289 4
-OpStore %571 %1290
-%1291 = OpLoad %ushort %570
-%1292 = OpLoad %ushort %571
-%1293 = OpIAdd %ushort %1291 %1292
-OpStore %572 %1293
-%1294 = OpLoad %_arr_ushort_uint_8 %140
-%1295 = OpCompositeExtract %ushort %1294 5
-OpStore %573 %1295
-%1296 = OpLoad %_arr_ushort_uint_8 %146
-%1297 = OpCompositeExtract %ushort %1296 5
-OpStore %574 %1297
-%1298 = OpLoad %ushort %573
-%1299 = OpLoad %ushort %574
-%1300 = OpIAdd %ushort %1298 %1299
-OpStore %575 %1300
-%1301 = OpLoad %_arr_ushort_uint_8 %140
-%1302 = OpCompositeExtract %ushort %1301 6
-OpStore %576 %1302
-%1303 = OpLoad %_arr_ushort_uint_8 %146
-%1304 = OpCompositeExtract %ushort %1303 6
-OpStore %577 %1304
-%1305 = OpLoad %ushort %576
-%1306 = OpLoad %ushort %577
-%1307 = OpIAdd %ushort %1305 %1306
-OpStore %578 %1307
-%1308 = OpLoad %_arr_ushort_uint_8 %140
-%1309 = OpCompositeExtract %ushort %1308 7
-OpStore %579 %1309
-%1310 = OpLoad %_arr_ushort_uint_8 %146
-%1311 = OpCompositeExtract %ushort %1310 7
-OpStore %580 %1311
-%1312 = OpLoad %ushort %579
-%1313 = OpLoad %ushort %580
-%1314 = OpIAdd %ushort %1312 %1313
-OpStore %581 %1314
-%1315 = OpLoad %_arr_ushort_uint_8 %140
-%1316 = OpLoad %ushort %560
-%1317 = OpCompositeInsert %_arr_ushort_uint_8 %1316 %1315 0
-OpStore %582 %1317
-%1318 = OpLoad %_arr_ushort_uint_8 %582
-%1319 = OpLoad %ushort %563
-%1320 = OpCompositeInsert %_arr_ushort_uint_8 %1319 %1318 1
-OpStore %583 %1320
-%1321 = OpLoad %_arr_ushort_uint_8 %583
-%1322 = OpLoad %ushort %566
-%1323 = OpCompositeInsert %_arr_ushort_uint_8 %1322 %1321 2
-OpStore %584 %1323
-%1324 = OpLoad %_arr_ushort_uint_8 %584
-%1325 = OpLoad %ushort %569
-%1326 = OpCompositeInsert %_arr_ushort_uint_8 %1325 %1324 3
-OpStore %585 %1326
-%1327 = OpLoad %_arr_ushort_uint_8 %585
-%1328 = OpLoad %ushort %572
-%1329 = OpCompositeInsert %_arr_ushort_uint_8 %1328 %1327 4
-OpStore %586 %1329
-%1330 = OpLoad %_arr_ushort_uint_8 %586
-%1331 = OpLoad %ushort %575
-%1332 = OpCompositeInsert %_arr_ushort_uint_8 %1331 %1330 5
-OpStore %587 %1332
-%1333 = OpLoad %_arr_ushort_uint_8 %587
-%1334 = OpLoad %ushort %578
-%1335 = OpCompositeInsert %_arr_ushort_uint_8 %1334 %1333 6
-OpStore %588 %1335
-%1336 = OpLoad %_arr_ushort_uint_8 %588
-%1337 = OpLoad %ushort %581
-%1338 = OpCompositeInsert %_arr_ushort_uint_8 %1337 %1336 7
-OpStore %589 %1338
-OpBranch %98
-%98 = OpLabel
-%1339 = OpLoad %_arr_ushort_uint_8 %589
-%1340 = OpCompositeExtract %ushort %1339 0
-OpStore %270 %1340
-%1341 = OpLoad %ulong %253
-%1342 = OpLoad %ushort %270
-%1343 = OpFunctionCall %ulong %4 %1341 %1342
-OpStore %271 %1343
-%1344 = OpLoad %_arr_ushort_uint_8 %589
-%1345 = OpCompositeExtract %ushort %1344 1
-OpStore %272 %1345
-%1346 = OpLoad %ulong %271
-%1347 = OpLoad %ushort %272
-%1348 = OpFunctionCall %ulong %4 %1346 %1347
-OpStore %273 %1348
-%1349 = OpLoad %_arr_ushort_uint_8 %589
-%1350 = OpCompositeExtract %ushort %1349 2
-OpStore %274 %1350
-%1351 = OpLoad %ulong %273
-%1352 = OpLoad %ushort %274
-%1353 = OpFunctionCall %ulong %4 %1351 %1352
-OpStore %275 %1353
-%1354 = OpLoad %_arr_ushort_uint_8 %589
-%1355 = OpCompositeExtract %ushort %1354 3
-OpStore %276 %1355
-%1356 = OpLoad %ulong %275
-%1357 = OpLoad %ushort %276
-%1358 = OpFunctionCall %ulong %4 %1356 %1357
-OpStore %277 %1358
-%1359 = OpLoad %_arr_ushort_uint_8 %589
-%1360 = OpCompositeExtract %ushort %1359 4
-OpStore %278 %1360
-%1361 = OpLoad %ulong %277
-%1362 = OpLoad %ushort %278
-%1363 = OpFunctionCall %ulong %4 %1361 %1362
-OpStore %279 %1363
-%1364 = OpLoad %_arr_ushort_uint_8 %589
-%1365 = OpCompositeExtract %ushort %1364 5
-OpStore %280 %1365
-%1366 = OpLoad %ulong %279
-%1367 = OpLoad %ushort %280
-%1368 = OpFunctionCall %ulong %4 %1366 %1367
-OpStore %281 %1368
-%1369 = OpLoad %_arr_ushort_uint_8 %589
-%1370 = OpCompositeExtract %ushort %1369 6
-OpStore %282 %1370
-%1371 = OpLoad %ulong %281
-%1372 = OpLoad %ushort %282
-%1373 = OpFunctionCall %ulong %4 %1371 %1372
-OpStore %283 %1373
-%1374 = OpLoad %_arr_ushort_uint_8 %589
-%1375 = OpCompositeExtract %ushort %1374 7
-OpStore %284 %1375
-%1376 = OpLoad %ulong %283
-%1377 = OpLoad %ushort %284
-%1378 = OpFunctionCall %ulong %4 %1376 %1377
-OpStore %285 %1378
-OpBranch %99
-%99 = OpLabel
-%1379 = OpLoad %_arr_ushort_uint_8 %140
-%1380 = OpCompositeExtract %ushort %1379 0
-OpStore %622 %1380
-%1381 = OpLoad %_arr_ushort_uint_8 %146
-%1382 = OpCompositeExtract %ushort %1381 0
-OpStore %623 %1382
-%1383 = OpLoad %ushort %622
-%1384 = OpLoad %ushort %623
-%1385 = OpISub %ushort %1383 %1384
-OpStore %624 %1385
-%1386 = OpLoad %_arr_ushort_uint_8 %140
-%1387 = OpCompositeExtract %ushort %1386 1
-OpStore %625 %1387
-%1388 = OpLoad %_arr_ushort_uint_8 %146
-%1389 = OpCompositeExtract %ushort %1388 1
-OpStore %626 %1389
-%1390 = OpLoad %ushort %625
-%1391 = OpLoad %ushort %626
-%1392 = OpISub %ushort %1390 %1391
-OpStore %627 %1392
-%1393 = OpLoad %_arr_ushort_uint_8 %140
-%1394 = OpCompositeExtract %ushort %1393 2
-OpStore %628 %1394
-%1395 = OpLoad %_arr_ushort_uint_8 %146
-%1396 = OpCompositeExtract %ushort %1395 2
-OpStore %629 %1396
-%1397 = OpLoad %ushort %628
-%1398 = OpLoad %ushort %629
-%1399 = OpISub %ushort %1397 %1398
-OpStore %630 %1399
-%1400 = OpLoad %_arr_ushort_uint_8 %140
-%1401 = OpCompositeExtract %ushort %1400 3
-OpStore %631 %1401
-%1402 = OpLoad %_arr_ushort_uint_8 %146
-%1403 = OpCompositeExtract %ushort %1402 3
-OpStore %632 %1403
-%1404 = OpLoad %ushort %631
-%1405 = OpLoad %ushort %632
-%1406 = OpISub %ushort %1404 %1405
-OpStore %633 %1406
-%1407 = OpLoad %_arr_ushort_uint_8 %140
-%1408 = OpCompositeExtract %ushort %1407 4
-OpStore %634 %1408
-%1409 = OpLoad %_arr_ushort_uint_8 %146
-%1410 = OpCompositeExtract %ushort %1409 4
-OpStore %635 %1410
-%1411 = OpLoad %ushort %634
-%1412 = OpLoad %ushort %635
-%1413 = OpISub %ushort %1411 %1412
-OpStore %636 %1413
-%1414 = OpLoad %_arr_ushort_uint_8 %140
-%1415 = OpCompositeExtract %ushort %1414 5
-OpStore %637 %1415
-%1416 = OpLoad %_arr_ushort_uint_8 %146
-%1417 = OpCompositeExtract %ushort %1416 5
-OpStore %638 %1417
-%1418 = OpLoad %ushort %637
-%1419 = OpLoad %ushort %638
-%1420 = OpISub %ushort %1418 %1419
-OpStore %639 %1420
-%1421 = OpLoad %_arr_ushort_uint_8 %140
-%1422 = OpCompositeExtract %ushort %1421 6
-OpStore %640 %1422
-%1423 = OpLoad %_arr_ushort_uint_8 %146
-%1424 = OpCompositeExtract %ushort %1423 6
-OpStore %641 %1424
-%1425 = OpLoad %ushort %640
-%1426 = OpLoad %ushort %641
-%1427 = OpISub %ushort %1425 %1426
-OpStore %642 %1427
-%1428 = OpLoad %_arr_ushort_uint_8 %140
-%1429 = OpCompositeExtract %ushort %1428 7
-OpStore %643 %1429
-%1430 = OpLoad %_arr_ushort_uint_8 %146
-%1431 = OpCompositeExtract %ushort %1430 7
-OpStore %644 %1431
-%1432 = OpLoad %ushort %643
-%1433 = OpLoad %ushort %644
-%1434 = OpISub %ushort %1432 %1433
-OpStore %645 %1434
-%1435 = OpLoad %_arr_ushort_uint_8 %140
-%1436 = OpLoad %ushort %624
-%1437 = OpCompositeInsert %_arr_ushort_uint_8 %1436 %1435 0
-OpStore %646 %1437
-%1438 = OpLoad %_arr_ushort_uint_8 %646
-%1439 = OpLoad %ushort %627
-%1440 = OpCompositeInsert %_arr_ushort_uint_8 %1439 %1438 1
-OpStore %647 %1440
-%1441 = OpLoad %_arr_ushort_uint_8 %647
-%1442 = OpLoad %ushort %630
-%1443 = OpCompositeInsert %_arr_ushort_uint_8 %1442 %1441 2
-OpStore %648 %1443
-%1444 = OpLoad %_arr_ushort_uint_8 %648
-%1445 = OpLoad %ushort %633
-%1446 = OpCompositeInsert %_arr_ushort_uint_8 %1445 %1444 3
-OpStore %649 %1446
-%1447 = OpLoad %_arr_ushort_uint_8 %649
-%1448 = OpLoad %ushort %636
-%1449 = OpCompositeInsert %_arr_ushort_uint_8 %1448 %1447 4
-OpStore %650 %1449
-%1450 = OpLoad %_arr_ushort_uint_8 %650
-%1451 = OpLoad %ushort %639
-%1452 = OpCompositeInsert %_arr_ushort_uint_8 %1451 %1450 5
-OpStore %651 %1452
-%1453 = OpLoad %_arr_ushort_uint_8 %651
-%1454 = OpLoad %ushort %642
-%1455 = OpCompositeInsert %_arr_ushort_uint_8 %1454 %1453 6
-OpStore %652 %1455
-%1456 = OpLoad %_arr_ushort_uint_8 %652
-%1457 = OpLoad %ushort %645
-%1458 = OpCompositeInsert %_arr_ushort_uint_8 %1457 %1456 7
-OpStore %653 %1458
-OpBranch %102
-%102 = OpLabel
-%1459 = OpLoad %_arr_ushort_uint_8 %653
-%1460 = OpCompositeExtract %ushort %1459 0
-OpStore %302 %1460
-%1461 = OpLoad %ulong %285
-%1462 = OpLoad %ushort %302
-%1463 = OpFunctionCall %ulong %4 %1461 %1462
-OpStore %303 %1463
-%1464 = OpLoad %_arr_ushort_uint_8 %653
-%1465 = OpCompositeExtract %ushort %1464 1
-OpStore %304 %1465
-%1466 = OpLoad %ulong %303
-%1467 = OpLoad %ushort %304
-%1468 = OpFunctionCall %ulong %4 %1466 %1467
-OpStore %305 %1468
-%1469 = OpLoad %_arr_ushort_uint_8 %653
-%1470 = OpCompositeExtract %ushort %1469 2
-OpStore %306 %1470
-%1471 = OpLoad %ulong %305
-%1472 = OpLoad %ushort %306
-%1473 = OpFunctionCall %ulong %4 %1471 %1472
-OpStore %307 %1473
-%1474 = OpLoad %_arr_ushort_uint_8 %653
-%1475 = OpCompositeExtract %ushort %1474 3
-OpStore %308 %1475
-%1476 = OpLoad %ulong %307
-%1477 = OpLoad %ushort %308
-%1478 = OpFunctionCall %ulong %4 %1476 %1477
-OpStore %309 %1478
-%1479 = OpLoad %_arr_ushort_uint_8 %653
-%1480 = OpCompositeExtract %ushort %1479 4
-OpStore %310 %1480
-%1481 = OpLoad %ulong %309
-%1482 = OpLoad %ushort %310
-%1483 = OpFunctionCall %ulong %4 %1481 %1482
-OpStore %311 %1483
-%1484 = OpLoad %_arr_ushort_uint_8 %653
-%1485 = OpCompositeExtract %ushort %1484 5
-OpStore %312 %1485
-%1486 = OpLoad %ulong %311
-%1487 = OpLoad %ushort %312
-%1488 = OpFunctionCall %ulong %4 %1486 %1487
-OpStore %313 %1488
-%1489 = OpLoad %_arr_ushort_uint_8 %653
-%1490 = OpCompositeExtract %ushort %1489 6
-OpStore %314 %1490
-%1491 = OpLoad %ulong %313
-%1492 = OpLoad %ushort %314
-%1493 = OpFunctionCall %ulong %4 %1491 %1492
-OpStore %315 %1493
-%1494 = OpLoad %_arr_ushort_uint_8 %653
-%1495 = OpCompositeExtract %ushort %1494 7
-OpStore %316 %1495
-%1496 = OpLoad %ulong %315
-%1497 = OpLoad %ushort %316
-%1498 = OpFunctionCall %ulong %4 %1496 %1497
-OpStore %317 %1498
-OpBranch %103
-%103 = OpLabel
-%1499 = OpLoad %_arr_ushort_uint_8 %146
-%1500 = OpCompositeExtract %ushort %1499 0
-OpStore %686 %1500
-%1501 = OpLoad %_arr_ushort_uint_8 %140
-%1502 = OpCompositeExtract %ushort %1501 0
-OpStore %687 %1502
-%1503 = OpLoad %ushort %686
-%1504 = OpLoad %ushort %687
-%1505 = OpISub %ushort %1503 %1504
-OpStore %688 %1505
-%1506 = OpLoad %_arr_ushort_uint_8 %146
-%1507 = OpCompositeExtract %ushort %1506 1
-OpStore %689 %1507
-%1508 = OpLoad %_arr_ushort_uint_8 %140
-%1509 = OpCompositeExtract %ushort %1508 1
-OpStore %690 %1509
-%1510 = OpLoad %ushort %689
-%1511 = OpLoad %ushort %690
-%1512 = OpISub %ushort %1510 %1511
-OpStore %691 %1512
-%1513 = OpLoad %_arr_ushort_uint_8 %146
-%1514 = OpCompositeExtract %ushort %1513 2
-OpStore %692 %1514
-%1515 = OpLoad %_arr_ushort_uint_8 %140
-%1516 = OpCompositeExtract %ushort %1515 2
-OpStore %693 %1516
-%1517 = OpLoad %ushort %692
-%1518 = OpLoad %ushort %693
-%1519 = OpISub %ushort %1517 %1518
-OpStore %694 %1519
-%1520 = OpLoad %_arr_ushort_uint_8 %146
-%1521 = OpCompositeExtract %ushort %1520 3
-OpStore %695 %1521
-%1522 = OpLoad %_arr_ushort_uint_8 %140
-%1523 = OpCompositeExtract %ushort %1522 3
-OpStore %696 %1523
-%1524 = OpLoad %ushort %695
-%1525 = OpLoad %ushort %696
-%1526 = OpISub %ushort %1524 %1525
-OpStore %697 %1526
-%1527 = OpLoad %_arr_ushort_uint_8 %146
-%1528 = OpCompositeExtract %ushort %1527 4
-OpStore %698 %1528
-%1529 = OpLoad %_arr_ushort_uint_8 %140
-%1530 = OpCompositeExtract %ushort %1529 4
-OpStore %699 %1530
-%1531 = OpLoad %ushort %698
-%1532 = OpLoad %ushort %699
-%1533 = OpISub %ushort %1531 %1532
-OpStore %700 %1533
-%1534 = OpLoad %_arr_ushort_uint_8 %146
-%1535 = OpCompositeExtract %ushort %1534 5
-OpStore %701 %1535
-%1536 = OpLoad %_arr_ushort_uint_8 %140
-%1537 = OpCompositeExtract %ushort %1536 5
-OpStore %702 %1537
-%1538 = OpLoad %ushort %701
-%1539 = OpLoad %ushort %702
-%1540 = OpISub %ushort %1538 %1539
-OpStore %703 %1540
-%1541 = OpLoad %_arr_ushort_uint_8 %146
-%1542 = OpCompositeExtract %ushort %1541 6
-OpStore %704 %1542
-%1543 = OpLoad %_arr_ushort_uint_8 %140
-%1544 = OpCompositeExtract %ushort %1543 6
-OpStore %705 %1544
-%1545 = OpLoad %ushort %704
-%1546 = OpLoad %ushort %705
-%1547 = OpISub %ushort %1545 %1546
-OpStore %706 %1547
-%1548 = OpLoad %_arr_ushort_uint_8 %146
-%1549 = OpCompositeExtract %ushort %1548 7
-OpStore %707 %1549
-%1550 = OpLoad %_arr_ushort_uint_8 %140
-%1551 = OpCompositeExtract %ushort %1550 7
-OpStore %708 %1551
-%1552 = OpLoad %ushort %707
-%1553 = OpLoad %ushort %708
-%1554 = OpISub %ushort %1552 %1553
-OpStore %709 %1554
-%1555 = OpLoad %_arr_ushort_uint_8 %146
-%1556 = OpLoad %ushort %688
-%1557 = OpCompositeInsert %_arr_ushort_uint_8 %1556 %1555 0
-OpStore %710 %1557
-%1558 = OpLoad %_arr_ushort_uint_8 %710
-%1559 = OpLoad %ushort %691
-%1560 = OpCompositeInsert %_arr_ushort_uint_8 %1559 %1558 1
-OpStore %711 %1560
-%1561 = OpLoad %_arr_ushort_uint_8 %711
-%1562 = OpLoad %ushort %694
-%1563 = OpCompositeInsert %_arr_ushort_uint_8 %1562 %1561 2
-OpStore %712 %1563
-%1564 = OpLoad %_arr_ushort_uint_8 %712
-%1565 = OpLoad %ushort %697
-%1566 = OpCompositeInsert %_arr_ushort_uint_8 %1565 %1564 3
-OpStore %713 %1566
-%1567 = OpLoad %_arr_ushort_uint_8 %713
-%1568 = OpLoad %ushort %700
-%1569 = OpCompositeInsert %_arr_ushort_uint_8 %1568 %1567 4
-OpStore %714 %1569
-%1570 = OpLoad %_arr_ushort_uint_8 %714
-%1571 = OpLoad %ushort %703
-%1572 = OpCompositeInsert %_arr_ushort_uint_8 %1571 %1570 5
-OpStore %715 %1572
-%1573 = OpLoad %_arr_ushort_uint_8 %715
-%1574 = OpLoad %ushort %706
-%1575 = OpCompositeInsert %_arr_ushort_uint_8 %1574 %1573 6
-OpStore %716 %1575
-%1576 = OpLoad %_arr_ushort_uint_8 %716
-%1577 = OpLoad %ushort %709
-%1578 = OpCompositeInsert %_arr_ushort_uint_8 %1577 %1576 7
-OpStore %717 %1578
-OpBranch %106
-%106 = OpLabel
-%1579 = OpLoad %_arr_ushort_uint_8 %717
-%1580 = OpCompositeExtract %ushort %1579 0
-OpStore %334 %1580
-%1581 = OpLoad %ulong %317
-%1582 = OpLoad %ushort %334
-%1583 = OpFunctionCall %ulong %4 %1581 %1582
-OpStore %335 %1583
-%1584 = OpLoad %_arr_ushort_uint_8 %717
-%1585 = OpCompositeExtract %ushort %1584 1
-OpStore %336 %1585
-%1586 = OpLoad %ulong %335
-%1587 = OpLoad %ushort %336
-%1588 = OpFunctionCall %ulong %4 %1586 %1587
-OpStore %337 %1588
-%1589 = OpLoad %_arr_ushort_uint_8 %717
-%1590 = OpCompositeExtract %ushort %1589 2
-OpStore %338 %1590
-%1591 = OpLoad %ulong %337
-%1592 = OpLoad %ushort %338
-%1593 = OpFunctionCall %ulong %4 %1591 %1592
-OpStore %339 %1593
-%1594 = OpLoad %_arr_ushort_uint_8 %717
-%1595 = OpCompositeExtract %ushort %1594 3
-OpStore %340 %1595
-%1596 = OpLoad %ulong %339
-%1597 = OpLoad %ushort %340
-%1598 = OpFunctionCall %ulong %4 %1596 %1597
-OpStore %341 %1598
-%1599 = OpLoad %_arr_ushort_uint_8 %717
-%1600 = OpCompositeExtract %ushort %1599 4
-OpStore %342 %1600
-%1601 = OpLoad %ulong %341
-%1602 = OpLoad %ushort %342
-%1603 = OpFunctionCall %ulong %4 %1601 %1602
-OpStore %343 %1603
-%1604 = OpLoad %_arr_ushort_uint_8 %717
-%1605 = OpCompositeExtract %ushort %1604 5
-OpStore %344 %1605
-%1606 = OpLoad %ulong %343
-%1607 = OpLoad %ushort %344
-%1608 = OpFunctionCall %ulong %4 %1606 %1607
-OpStore %345 %1608
-%1609 = OpLoad %_arr_ushort_uint_8 %717
-%1610 = OpCompositeExtract %ushort %1609 6
-OpStore %346 %1610
-%1611 = OpLoad %ulong %345
-%1612 = OpLoad %ushort %346
-%1613 = OpFunctionCall %ulong %4 %1611 %1612
-OpStore %347 %1613
-%1614 = OpLoad %_arr_ushort_uint_8 %717
-%1615 = OpCompositeExtract %ushort %1614 7
-OpStore %348 %1615
-%1616 = OpLoad %ulong %347
-%1617 = OpLoad %ushort %348
-%1618 = OpFunctionCall %ulong %4 %1616 %1617
-OpStore %349 %1618
-OpBranch %107
-%107 = OpLabel
-%1619 = OpLoad %_arr_ushort_uint_8 %140
-%1620 = OpCompositeExtract %ushort %1619 0
-OpStore %718 %1620
-%1621 = OpLoad %_arr_ushort_uint_8 %146
-%1622 = OpCompositeExtract %ushort %1621 0
-OpStore %719 %1622
-%1623 = OpLoad %ushort %718
-%1624 = OpLoad %ushort %719
-%1625 = OpIMul %ushort %1623 %1624
-OpStore %720 %1625
-%1626 = OpLoad %_arr_ushort_uint_8 %140
-%1627 = OpCompositeExtract %ushort %1626 1
-OpStore %721 %1627
-%1628 = OpLoad %_arr_ushort_uint_8 %146
-%1629 = OpCompositeExtract %ushort %1628 1
-OpStore %722 %1629
-%1630 = OpLoad %ushort %721
-%1631 = OpLoad %ushort %722
-%1632 = OpIMul %ushort %1630 %1631
-OpStore %723 %1632
-%1633 = OpLoad %_arr_ushort_uint_8 %140
-%1634 = OpCompositeExtract %ushort %1633 2
-OpStore %724 %1634
-%1635 = OpLoad %_arr_ushort_uint_8 %146
-%1636 = OpCompositeExtract %ushort %1635 2
-OpStore %725 %1636
-%1637 = OpLoad %ushort %724
-%1638 = OpLoad %ushort %725
-%1639 = OpIMul %ushort %1637 %1638
-OpStore %726 %1639
-%1640 = OpLoad %_arr_ushort_uint_8 %140
-%1641 = OpCompositeExtract %ushort %1640 3
-OpStore %727 %1641
-%1642 = OpLoad %_arr_ushort_uint_8 %146
-%1643 = OpCompositeExtract %ushort %1642 3
-OpStore %728 %1643
-%1644 = OpLoad %ushort %727
-%1645 = OpLoad %ushort %728
-%1646 = OpIMul %ushort %1644 %1645
-OpStore %729 %1646
-%1647 = OpLoad %_arr_ushort_uint_8 %140
-%1648 = OpCompositeExtract %ushort %1647 4
-OpStore %730 %1648
-%1649 = OpLoad %_arr_ushort_uint_8 %146
-%1650 = OpCompositeExtract %ushort %1649 4
-OpStore %731 %1650
-%1651 = OpLoad %ushort %730
-%1652 = OpLoad %ushort %731
-%1653 = OpIMul %ushort %1651 %1652
-OpStore %732 %1653
-%1654 = OpLoad %_arr_ushort_uint_8 %140
-%1655 = OpCompositeExtract %ushort %1654 5
-OpStore %733 %1655
-%1656 = OpLoad %_arr_ushort_uint_8 %146
-%1657 = OpCompositeExtract %ushort %1656 5
-OpStore %734 %1657
-%1658 = OpLoad %ushort %733
-%1659 = OpLoad %ushort %734
-%1660 = OpIMul %ushort %1658 %1659
-OpStore %735 %1660
-%1661 = OpLoad %_arr_ushort_uint_8 %140
-%1662 = OpCompositeExtract %ushort %1661 6
-OpStore %736 %1662
-%1663 = OpLoad %_arr_ushort_uint_8 %146
-%1664 = OpCompositeExtract %ushort %1663 6
-OpStore %737 %1664
-%1665 = OpLoad %ushort %736
-%1666 = OpLoad %ushort %737
-%1667 = OpIMul %ushort %1665 %1666
-OpStore %738 %1667
-%1668 = OpLoad %_arr_ushort_uint_8 %140
-%1669 = OpCompositeExtract %ushort %1668 7
-OpStore %739 %1669
-%1670 = OpLoad %_arr_ushort_uint_8 %146
-%1671 = OpCompositeExtract %ushort %1670 7
-OpStore %740 %1671
-%1672 = OpLoad %ushort %739
-%1673 = OpLoad %ushort %740
-%1674 = OpIMul %ushort %1672 %1673
-OpStore %741 %1674
-%1675 = OpLoad %_arr_ushort_uint_8 %140
-%1676 = OpLoad %ushort %720
-%1677 = OpCompositeInsert %_arr_ushort_uint_8 %1676 %1675 0
-OpStore %742 %1677
-%1678 = OpLoad %_arr_ushort_uint_8 %742
-%1679 = OpLoad %ushort %723
-%1680 = OpCompositeInsert %_arr_ushort_uint_8 %1679 %1678 1
-OpStore %743 %1680
-%1681 = OpLoad %_arr_ushort_uint_8 %743
-%1682 = OpLoad %ushort %726
-%1683 = OpCompositeInsert %_arr_ushort_uint_8 %1682 %1681 2
-OpStore %744 %1683
-%1684 = OpLoad %_arr_ushort_uint_8 %744
-%1685 = OpLoad %ushort %729
-%1686 = OpCompositeInsert %_arr_ushort_uint_8 %1685 %1684 3
-OpStore %745 %1686
-%1687 = OpLoad %_arr_ushort_uint_8 %745
-%1688 = OpLoad %ushort %732
-%1689 = OpCompositeInsert %_arr_ushort_uint_8 %1688 %1687 4
-OpStore %746 %1689
-%1690 = OpLoad %_arr_ushort_uint_8 %746
-%1691 = OpLoad %ushort %735
-%1692 = OpCompositeInsert %_arr_ushort_uint_8 %1691 %1690 5
-OpStore %747 %1692
-%1693 = OpLoad %_arr_ushort_uint_8 %747
-%1694 = OpLoad %ushort %738
-%1695 = OpCompositeInsert %_arr_ushort_uint_8 %1694 %1693 6
-OpStore %748 %1695
-%1696 = OpLoad %_arr_ushort_uint_8 %748
-%1697 = OpLoad %ushort %741
-%1698 = OpCompositeInsert %_arr_ushort_uint_8 %1697 %1696 7
-OpStore %749 %1698
-OpBranch %108
-%108 = OpLabel
-%1699 = OpLoad %_arr_ushort_uint_8 %749
-%1700 = OpCompositeExtract %ushort %1699 0
-OpStore %350 %1700
-%1701 = OpLoad %ulong %349
-%1702 = OpLoad %ushort %350
-%1703 = OpFunctionCall %ulong %4 %1701 %1702
-OpStore %351 %1703
-%1704 = OpLoad %_arr_ushort_uint_8 %749
-%1705 = OpCompositeExtract %ushort %1704 1
-OpStore %352 %1705
-%1706 = OpLoad %ulong %351
-%1707 = OpLoad %ushort %352
-%1708 = OpFunctionCall %ulong %4 %1706 %1707
-OpStore %353 %1708
-%1709 = OpLoad %_arr_ushort_uint_8 %749
-%1710 = OpCompositeExtract %ushort %1709 2
-OpStore %354 %1710
-%1711 = OpLoad %ulong %353
-%1712 = OpLoad %ushort %354
-%1713 = OpFunctionCall %ulong %4 %1711 %1712
-OpStore %355 %1713
-%1714 = OpLoad %_arr_ushort_uint_8 %749
-%1715 = OpCompositeExtract %ushort %1714 3
-OpStore %356 %1715
-%1716 = OpLoad %ulong %355
-%1717 = OpLoad %ushort %356
-%1718 = OpFunctionCall %ulong %4 %1716 %1717
-OpStore %357 %1718
-%1719 = OpLoad %_arr_ushort_uint_8 %749
-%1720 = OpCompositeExtract %ushort %1719 4
-OpStore %358 %1720
-%1721 = OpLoad %ulong %357
-%1722 = OpLoad %ushort %358
-%1723 = OpFunctionCall %ulong %4 %1721 %1722
-OpStore %359 %1723
-%1724 = OpLoad %_arr_ushort_uint_8 %749
-%1725 = OpCompositeExtract %ushort %1724 5
-OpStore %360 %1725
-%1726 = OpLoad %ulong %359
-%1727 = OpLoad %ushort %360
-%1728 = OpFunctionCall %ulong %4 %1726 %1727
-OpStore %361 %1728
-%1729 = OpLoad %_arr_ushort_uint_8 %749
-%1730 = OpCompositeExtract %ushort %1729 6
-OpStore %362 %1730
-%1731 = OpLoad %ulong %361
-%1732 = OpLoad %ushort %362
-%1733 = OpFunctionCall %ulong %4 %1731 %1732
-OpStore %363 %1733
-%1734 = OpLoad %_arr_ushort_uint_8 %749
-%1735 = OpCompositeExtract %ushort %1734 7
-OpStore %364 %1735
-%1736 = OpLoad %ulong %363
-%1737 = OpLoad %ushort %364
-%1738 = OpFunctionCall %ulong %4 %1736 %1737
-OpStore %365 %1738
-OpBranch %109
-%109 = OpLabel
-%1739 = OpLoad %_arr_ushort_uint_8 %140
-%1740 = OpCompositeExtract %ushort %1739 0
-OpStore %750 %1740
-%1741 = OpLoad %_arr_ushort_uint_8 %133
-%1742 = OpCompositeExtract %ushort %1741 0
-OpStore %751 %1742
-%1743 = OpLoad %ushort %750
-%1744 = OpLoad %ushort %751
-%1745 = OpIMul %ushort %1743 %1744
-OpStore %752 %1745
-%1746 = OpLoad %_arr_ushort_uint_8 %140
-%1747 = OpCompositeExtract %ushort %1746 1
-OpStore %753 %1747
-%1748 = OpLoad %_arr_ushort_uint_8 %133
-%1749 = OpCompositeExtract %ushort %1748 1
-OpStore %754 %1749
-%1750 = OpLoad %ushort %753
-%1751 = OpLoad %ushort %754
-%1752 = OpIMul %ushort %1750 %1751
-OpStore %755 %1752
-%1753 = OpLoad %_arr_ushort_uint_8 %140
-%1754 = OpCompositeExtract %ushort %1753 2
-OpStore %756 %1754
-%1755 = OpLoad %_arr_ushort_uint_8 %133
-%1756 = OpCompositeExtract %ushort %1755 2
-OpStore %757 %1756
-%1757 = OpLoad %ushort %756
-%1758 = OpLoad %ushort %757
-%1759 = OpIMul %ushort %1757 %1758
-OpStore %758 %1759
-%1760 = OpLoad %_arr_ushort_uint_8 %140
-%1761 = OpCompositeExtract %ushort %1760 3
-OpStore %759 %1761
-%1762 = OpLoad %_arr_ushort_uint_8 %133
-%1763 = OpCompositeExtract %ushort %1762 3
-OpStore %760 %1763
-%1764 = OpLoad %ushort %759
-%1765 = OpLoad %ushort %760
-%1766 = OpIMul %ushort %1764 %1765
-OpStore %761 %1766
-%1767 = OpLoad %_arr_ushort_uint_8 %140
-%1768 = OpCompositeExtract %ushort %1767 4
-OpStore %762 %1768
-%1769 = OpLoad %_arr_ushort_uint_8 %133
-%1770 = OpCompositeExtract %ushort %1769 4
-OpStore %763 %1770
-%1771 = OpLoad %ushort %762
-%1772 = OpLoad %ushort %763
-%1773 = OpIMul %ushort %1771 %1772
-OpStore %764 %1773
-%1774 = OpLoad %_arr_ushort_uint_8 %140
-%1775 = OpCompositeExtract %ushort %1774 5
-OpStore %765 %1775
-%1776 = OpLoad %_arr_ushort_uint_8 %133
-%1777 = OpCompositeExtract %ushort %1776 5
-OpStore %766 %1777
-%1778 = OpLoad %ushort %765
-%1779 = OpLoad %ushort %766
-%1780 = OpIMul %ushort %1778 %1779
-OpStore %767 %1780
-%1781 = OpLoad %_arr_ushort_uint_8 %140
-%1782 = OpCompositeExtract %ushort %1781 6
-OpStore %768 %1782
-%1783 = OpLoad %_arr_ushort_uint_8 %133
-%1784 = OpCompositeExtract %ushort %1783 6
-OpStore %769 %1784
-%1785 = OpLoad %ushort %768
-%1786 = OpLoad %ushort %769
-%1787 = OpIMul %ushort %1785 %1786
-OpStore %770 %1787
-%1788 = OpLoad %_arr_ushort_uint_8 %140
-%1789 = OpCompositeExtract %ushort %1788 7
-OpStore %771 %1789
-%1790 = OpLoad %_arr_ushort_uint_8 %133
-%1791 = OpCompositeExtract %ushort %1790 7
-OpStore %772 %1791
-%1792 = OpLoad %ushort %771
-%1793 = OpLoad %ushort %772
-%1794 = OpIMul %ushort %1792 %1793
-OpStore %773 %1794
-%1795 = OpLoad %_arr_ushort_uint_8 %140
-%1796 = OpLoad %ushort %752
-%1797 = OpCompositeInsert %_arr_ushort_uint_8 %1796 %1795 0
-OpStore %774 %1797
-%1798 = OpLoad %_arr_ushort_uint_8 %774
-%1799 = OpLoad %ushort %755
-%1800 = OpCompositeInsert %_arr_ushort_uint_8 %1799 %1798 1
-OpStore %775 %1800
-%1801 = OpLoad %_arr_ushort_uint_8 %775
-%1802 = OpLoad %ushort %758
-%1803 = OpCompositeInsert %_arr_ushort_uint_8 %1802 %1801 2
-OpStore %776 %1803
-%1804 = OpLoad %_arr_ushort_uint_8 %776
-%1805 = OpLoad %ushort %761
-%1806 = OpCompositeInsert %_arr_ushort_uint_8 %1805 %1804 3
-OpStore %777 %1806
-%1807 = OpLoad %_arr_ushort_uint_8 %777
-%1808 = OpLoad %ushort %764
-%1809 = OpCompositeInsert %_arr_ushort_uint_8 %1808 %1807 4
-OpStore %778 %1809
-%1810 = OpLoad %_arr_ushort_uint_8 %778
-%1811 = OpLoad %ushort %767
-%1812 = OpCompositeInsert %_arr_ushort_uint_8 %1811 %1810 5
-OpStore %779 %1812
-%1813 = OpLoad %_arr_ushort_uint_8 %779
-%1814 = OpLoad %ushort %770
-%1815 = OpCompositeInsert %_arr_ushort_uint_8 %1814 %1813 6
-OpStore %780 %1815
-%1816 = OpLoad %_arr_ushort_uint_8 %780
-%1817 = OpLoad %ushort %773
-%1818 = OpCompositeInsert %_arr_ushort_uint_8 %1817 %1816 7
-OpStore %781 %1818
-OpBranch %110
-%110 = OpLabel
-%1819 = OpLoad %_arr_ushort_uint_8 %781
-%1820 = OpCompositeExtract %ushort %1819 0
-OpStore %366 %1820
-%1821 = OpLoad %ulong %365
-%1822 = OpLoad %ushort %366
-%1823 = OpFunctionCall %ulong %4 %1821 %1822
-OpStore %367 %1823
-%1824 = OpLoad %_arr_ushort_uint_8 %781
-%1825 = OpCompositeExtract %ushort %1824 1
-OpStore %368 %1825
-%1826 = OpLoad %ulong %367
-%1827 = OpLoad %ushort %368
-%1828 = OpFunctionCall %ulong %4 %1826 %1827
-OpStore %369 %1828
-%1829 = OpLoad %_arr_ushort_uint_8 %781
-%1830 = OpCompositeExtract %ushort %1829 2
-OpStore %370 %1830
-%1831 = OpLoad %ulong %369
-%1832 = OpLoad %ushort %370
-%1833 = OpFunctionCall %ulong %4 %1831 %1832
-OpStore %371 %1833
-%1834 = OpLoad %_arr_ushort_uint_8 %781
-%1835 = OpCompositeExtract %ushort %1834 3
-OpStore %372 %1835
-%1836 = OpLoad %ulong %371
-%1837 = OpLoad %ushort %372
-%1838 = OpFunctionCall %ulong %4 %1836 %1837
-OpStore %373 %1838
-%1839 = OpLoad %_arr_ushort_uint_8 %781
-%1840 = OpCompositeExtract %ushort %1839 4
-OpStore %374 %1840
-%1841 = OpLoad %ulong %373
-%1842 = OpLoad %ushort %374
-%1843 = OpFunctionCall %ulong %4 %1841 %1842
-OpStore %375 %1843
-%1844 = OpLoad %_arr_ushort_uint_8 %781
-%1845 = OpCompositeExtract %ushort %1844 5
-OpStore %376 %1845
-%1846 = OpLoad %ulong %375
-%1847 = OpLoad %ushort %376
-%1848 = OpFunctionCall %ulong %4 %1846 %1847
-OpStore %377 %1848
-%1849 = OpLoad %_arr_ushort_uint_8 %781
-%1850 = OpCompositeExtract %ushort %1849 6
-OpStore %378 %1850
-%1851 = OpLoad %ulong %377
-%1852 = OpLoad %ushort %378
-%1853 = OpFunctionCall %ulong %4 %1851 %1852
-OpStore %379 %1853
-%1854 = OpLoad %_arr_ushort_uint_8 %781
-%1855 = OpCompositeExtract %ushort %1854 7
-OpStore %380 %1855
-%1856 = OpLoad %ulong %379
-%1857 = OpLoad %ushort %380
-%1858 = OpFunctionCall %ulong %4 %1856 %1857
-OpStore %381 %1858
-OpBranch %111
-%111 = OpLabel
-%1859 = OpLoad %_arr_ushort_uint_8 %146
-%1860 = OpCompositeExtract %ushort %1859 0
-OpStore %782 %1860
-%1861 = OpLoad %_arr_ushort_uint_8 %133
-%1862 = OpCompositeExtract %ushort %1861 0
-OpStore %783 %1862
-%1863 = OpLoad %ushort %782
-%1864 = OpLoad %ushort %783
-%1865 = OpIMul %ushort %1863 %1864
-OpStore %784 %1865
-%1866 = OpLoad %_arr_ushort_uint_8 %146
-%1867 = OpCompositeExtract %ushort %1866 1
-OpStore %785 %1867
-%1868 = OpLoad %_arr_ushort_uint_8 %133
-%1869 = OpCompositeExtract %ushort %1868 1
-OpStore %786 %1869
-%1870 = OpLoad %ushort %785
-%1871 = OpLoad %ushort %786
-%1872 = OpIMul %ushort %1870 %1871
-OpStore %787 %1872
-%1873 = OpLoad %_arr_ushort_uint_8 %146
-%1874 = OpCompositeExtract %ushort %1873 2
-OpStore %788 %1874
-%1875 = OpLoad %_arr_ushort_uint_8 %133
-%1876 = OpCompositeExtract %ushort %1875 2
-OpStore %789 %1876
-%1877 = OpLoad %ushort %788
-%1878 = OpLoad %ushort %789
-%1879 = OpIMul %ushort %1877 %1878
-OpStore %790 %1879
-%1880 = OpLoad %_arr_ushort_uint_8 %146
-%1881 = OpCompositeExtract %ushort %1880 3
-OpStore %791 %1881
-%1882 = OpLoad %_arr_ushort_uint_8 %133
-%1883 = OpCompositeExtract %ushort %1882 3
-OpStore %792 %1883
-%1884 = OpLoad %ushort %791
-%1885 = OpLoad %ushort %792
-%1886 = OpIMul %ushort %1884 %1885
-OpStore %793 %1886
-%1887 = OpLoad %_arr_ushort_uint_8 %146
-%1888 = OpCompositeExtract %ushort %1887 4
-OpStore %794 %1888
-%1889 = OpLoad %_arr_ushort_uint_8 %133
-%1890 = OpCompositeExtract %ushort %1889 4
-OpStore %795 %1890
-%1891 = OpLoad %ushort %794
-%1892 = OpLoad %ushort %795
-%1893 = OpIMul %ushort %1891 %1892
-OpStore %796 %1893
-%1894 = OpLoad %_arr_ushort_uint_8 %146
-%1895 = OpCompositeExtract %ushort %1894 5
-OpStore %797 %1895
-%1896 = OpLoad %_arr_ushort_uint_8 %133
-%1897 = OpCompositeExtract %ushort %1896 5
-OpStore %798 %1897
-%1898 = OpLoad %ushort %797
-%1899 = OpLoad %ushort %798
-%1900 = OpIMul %ushort %1898 %1899
-OpStore %799 %1900
-%1901 = OpLoad %_arr_ushort_uint_8 %146
-%1902 = OpCompositeExtract %ushort %1901 6
-OpStore %800 %1902
-%1903 = OpLoad %_arr_ushort_uint_8 %133
-%1904 = OpCompositeExtract %ushort %1903 6
-OpStore %801 %1904
-%1905 = OpLoad %ushort %800
-%1906 = OpLoad %ushort %801
-%1907 = OpIMul %ushort %1905 %1906
-OpStore %802 %1907
-%1908 = OpLoad %_arr_ushort_uint_8 %146
-%1909 = OpCompositeExtract %ushort %1908 7
-OpStore %803 %1909
-%1910 = OpLoad %_arr_ushort_uint_8 %133
-%1911 = OpCompositeExtract %ushort %1910 7
-OpStore %804 %1911
-%1912 = OpLoad %ushort %803
-%1913 = OpLoad %ushort %804
-%1914 = OpIMul %ushort %1912 %1913
-OpStore %805 %1914
-%1915 = OpLoad %_arr_ushort_uint_8 %146
-%1916 = OpLoad %ushort %784
-%1917 = OpCompositeInsert %_arr_ushort_uint_8 %1916 %1915 0
-OpStore %806 %1917
-%1918 = OpLoad %_arr_ushort_uint_8 %806
-%1919 = OpLoad %ushort %787
-%1920 = OpCompositeInsert %_arr_ushort_uint_8 %1919 %1918 1
-OpStore %807 %1920
-%1921 = OpLoad %_arr_ushort_uint_8 %807
-%1922 = OpLoad %ushort %790
-%1923 = OpCompositeInsert %_arr_ushort_uint_8 %1922 %1921 2
-OpStore %808 %1923
-%1924 = OpLoad %_arr_ushort_uint_8 %808
-%1925 = OpLoad %ushort %793
-%1926 = OpCompositeInsert %_arr_ushort_uint_8 %1925 %1924 3
-OpStore %809 %1926
-%1927 = OpLoad %_arr_ushort_uint_8 %809
-%1928 = OpLoad %ushort %796
-%1929 = OpCompositeInsert %_arr_ushort_uint_8 %1928 %1927 4
-OpStore %810 %1929
-%1930 = OpLoad %_arr_ushort_uint_8 %810
-%1931 = OpLoad %ushort %799
-%1932 = OpCompositeInsert %_arr_ushort_uint_8 %1931 %1930 5
-OpStore %811 %1932
-%1933 = OpLoad %_arr_ushort_uint_8 %811
-%1934 = OpLoad %ushort %802
-%1935 = OpCompositeInsert %_arr_ushort_uint_8 %1934 %1933 6
-OpStore %812 %1935
-%1936 = OpLoad %_arr_ushort_uint_8 %812
-%1937 = OpLoad %ushort %805
-%1938 = OpCompositeInsert %_arr_ushort_uint_8 %1937 %1936 7
-OpStore %813 %1938
-OpBranch %112
-%112 = OpLabel
-%1939 = OpLoad %_arr_ushort_uint_8 %813
-%1940 = OpCompositeExtract %ushort %1939 0
-OpStore %382 %1940
-%1941 = OpLoad %ulong %381
-%1942 = OpLoad %ushort %382
-%1943 = OpFunctionCall %ulong %4 %1941 %1942
-OpStore %383 %1943
-%1944 = OpLoad %_arr_ushort_uint_8 %813
-%1945 = OpCompositeExtract %ushort %1944 1
-OpStore %384 %1945
-%1946 = OpLoad %ulong %383
-%1947 = OpLoad %ushort %384
-%1948 = OpFunctionCall %ulong %4 %1946 %1947
-OpStore %385 %1948
-%1949 = OpLoad %_arr_ushort_uint_8 %813
-%1950 = OpCompositeExtract %ushort %1949 2
-OpStore %386 %1950
-%1951 = OpLoad %ulong %385
-%1952 = OpLoad %ushort %386
-%1953 = OpFunctionCall %ulong %4 %1951 %1952
-OpStore %387 %1953
-%1954 = OpLoad %_arr_ushort_uint_8 %813
-%1955 = OpCompositeExtract %ushort %1954 3
-OpStore %388 %1955
-%1956 = OpLoad %ulong %387
-%1957 = OpLoad %ushort %388
-%1958 = OpFunctionCall %ulong %4 %1956 %1957
-OpStore %389 %1958
-%1959 = OpLoad %_arr_ushort_uint_8 %813
-%1960 = OpCompositeExtract %ushort %1959 4
-OpStore %390 %1960
-%1961 = OpLoad %ulong %389
-%1962 = OpLoad %ushort %390
-%1963 = OpFunctionCall %ulong %4 %1961 %1962
-OpStore %391 %1963
-%1964 = OpLoad %_arr_ushort_uint_8 %813
-%1965 = OpCompositeExtract %ushort %1964 5
-OpStore %392 %1965
-%1966 = OpLoad %ulong %391
-%1967 = OpLoad %ushort %392
-%1968 = OpFunctionCall %ulong %4 %1966 %1967
-OpStore %393 %1968
-%1969 = OpLoad %_arr_ushort_uint_8 %813
-%1970 = OpCompositeExtract %ushort %1969 6
-OpStore %394 %1970
-%1971 = OpLoad %ulong %393
-%1972 = OpLoad %ushort %394
-%1973 = OpFunctionCall %ulong %4 %1971 %1972
-OpStore %395 %1973
-%1974 = OpLoad %_arr_ushort_uint_8 %813
-%1975 = OpCompositeExtract %ushort %1974 7
-OpStore %396 %1975
-%1976 = OpLoad %ulong %395
-%1977 = OpLoad %ushort %396
-%1978 = OpFunctionCall %ulong %4 %1976 %1977
-OpStore %397 %1978
-OpBranch %113
-%113 = OpLabel
-%1979 = OpLoad %_arr_ushort_uint_8 %140
-%1980 = OpCompositeExtract %ushort %1979 0
-OpStore %814 %1980
-%1981 = OpLoad %_arr_ushort_uint_8 %146
-%1982 = OpCompositeExtract %ushort %1981 0
-OpStore %815 %1982
-%1983 = OpLoad %ushort %814
-%1984 = OpLoad %ushort %815
-%1985 = OpIAdd %ushort %1983 %1984
-OpStore %816 %1985
-%1986 = OpLoad %_arr_ushort_uint_8 %140
-%1987 = OpCompositeExtract %ushort %1986 1
-OpStore %817 %1987
-%1988 = OpLoad %_arr_ushort_uint_8 %146
-%1989 = OpCompositeExtract %ushort %1988 1
-OpStore %818 %1989
-%1990 = OpLoad %ushort %817
-%1991 = OpLoad %ushort %818
-%1992 = OpIAdd %ushort %1990 %1991
-OpStore %819 %1992
-%1993 = OpLoad %_arr_ushort_uint_8 %140
-%1994 = OpCompositeExtract %ushort %1993 2
-OpStore %820 %1994
-%1995 = OpLoad %_arr_ushort_uint_8 %146
-%1996 = OpCompositeExtract %ushort %1995 2
-OpStore %821 %1996
-%1997 = OpLoad %ushort %820
-%1998 = OpLoad %ushort %821
-%1999 = OpIAdd %ushort %1997 %1998
-OpStore %822 %1999
-%2000 = OpLoad %_arr_ushort_uint_8 %140
-%2001 = OpCompositeExtract %ushort %2000 3
-OpStore %823 %2001
-%2002 = OpLoad %_arr_ushort_uint_8 %146
-%2003 = OpCompositeExtract %ushort %2002 3
-OpStore %824 %2003
-%2004 = OpLoad %ushort %823
-%2005 = OpLoad %ushort %824
-%2006 = OpIAdd %ushort %2004 %2005
-OpStore %825 %2006
-%2007 = OpLoad %_arr_ushort_uint_8 %140
-%2008 = OpCompositeExtract %ushort %2007 4
-OpStore %826 %2008
-%2009 = OpLoad %_arr_ushort_uint_8 %146
-%2010 = OpCompositeExtract %ushort %2009 4
-OpStore %827 %2010
-%2011 = OpLoad %ushort %826
-%2012 = OpLoad %ushort %827
-%2013 = OpIAdd %ushort %2011 %2012
-OpStore %828 %2013
-%2014 = OpLoad %_arr_ushort_uint_8 %140
-%2015 = OpCompositeExtract %ushort %2014 5
-OpStore %829 %2015
-%2016 = OpLoad %_arr_ushort_uint_8 %146
-%2017 = OpCompositeExtract %ushort %2016 5
-OpStore %830 %2017
-%2018 = OpLoad %ushort %829
-%2019 = OpLoad %ushort %830
-%2020 = OpIAdd %ushort %2018 %2019
-OpStore %831 %2020
-%2021 = OpLoad %_arr_ushort_uint_8 %140
-%2022 = OpCompositeExtract %ushort %2021 6
-OpStore %832 %2022
-%2023 = OpLoad %_arr_ushort_uint_8 %146
-%2024 = OpCompositeExtract %ushort %2023 6
-OpStore %833 %2024
-%2025 = OpLoad %ushort %832
-%2026 = OpLoad %ushort %833
-%2027 = OpIAdd %ushort %2025 %2026
-OpStore %834 %2027
-%2028 = OpLoad %_arr_ushort_uint_8 %140
-%2029 = OpCompositeExtract %ushort %2028 7
-OpStore %835 %2029
-%2030 = OpLoad %_arr_ushort_uint_8 %146
-%2031 = OpCompositeExtract %ushort %2030 7
-OpStore %836 %2031
-%2032 = OpLoad %ushort %835
-%2033 = OpLoad %ushort %836
-%2034 = OpIAdd %ushort %2032 %2033
-OpStore %837 %2034
-%2035 = OpLoad %_arr_ushort_uint_8 %140
-%2036 = OpLoad %ushort %816
-%2037 = OpCompositeInsert %_arr_ushort_uint_8 %2036 %2035 0
-OpStore %838 %2037
-%2038 = OpLoad %_arr_ushort_uint_8 %838
-%2039 = OpLoad %ushort %819
-%2040 = OpCompositeInsert %_arr_ushort_uint_8 %2039 %2038 1
-OpStore %839 %2040
-%2041 = OpLoad %_arr_ushort_uint_8 %839
-%2042 = OpLoad %ushort %822
-%2043 = OpCompositeInsert %_arr_ushort_uint_8 %2042 %2041 2
-OpStore %840 %2043
-%2044 = OpLoad %_arr_ushort_uint_8 %840
-%2045 = OpLoad %ushort %825
-%2046 = OpCompositeInsert %_arr_ushort_uint_8 %2045 %2044 3
-OpStore %841 %2046
-%2047 = OpLoad %_arr_ushort_uint_8 %841
-%2048 = OpLoad %ushort %828
-%2049 = OpCompositeInsert %_arr_ushort_uint_8 %2048 %2047 4
-OpStore %842 %2049
-%2050 = OpLoad %_arr_ushort_uint_8 %842
-%2051 = OpLoad %ushort %831
-%2052 = OpCompositeInsert %_arr_ushort_uint_8 %2051 %2050 5
-OpStore %843 %2052
-%2053 = OpLoad %_arr_ushort_uint_8 %843
-%2054 = OpLoad %ushort %834
-%2055 = OpCompositeInsert %_arr_ushort_uint_8 %2054 %2053 6
-OpStore %844 %2055
-%2056 = OpLoad %_arr_ushort_uint_8 %844
-%2057 = OpLoad %ushort %837
-%2058 = OpCompositeInsert %_arr_ushort_uint_8 %2057 %2056 7
-OpStore %845 %2058
-%2059 = OpLoad %_arr_ushort_uint_8 %845
-%2060 = OpCompositeExtract %ushort %2059 0
-OpStore %846 %2060
-%2061 = OpLoad %_arr_ushort_uint_8 %133
-%2062 = OpCompositeExtract %ushort %2061 0
-OpStore %847 %2062
-%2063 = OpLoad %ushort %846
-%2064 = OpLoad %ushort %847
-%2065 = OpIMul %ushort %2063 %2064
-OpStore %848 %2065
-%2066 = OpLoad %_arr_ushort_uint_8 %845
-%2067 = OpCompositeExtract %ushort %2066 1
-OpStore %849 %2067
-%2068 = OpLoad %_arr_ushort_uint_8 %133
-%2069 = OpCompositeExtract %ushort %2068 1
-OpStore %850 %2069
-%2070 = OpLoad %ushort %849
-%2071 = OpLoad %ushort %850
-%2072 = OpIMul %ushort %2070 %2071
-OpStore %851 %2072
-%2073 = OpLoad %_arr_ushort_uint_8 %845
-%2074 = OpCompositeExtract %ushort %2073 2
-OpStore %852 %2074
-%2075 = OpLoad %_arr_ushort_uint_8 %133
-%2076 = OpCompositeExtract %ushort %2075 2
-OpStore %853 %2076
-%2077 = OpLoad %ushort %852
-%2078 = OpLoad %ushort %853
-%2079 = OpIMul %ushort %2077 %2078
-OpStore %854 %2079
-%2080 = OpLoad %_arr_ushort_uint_8 %845
-%2081 = OpCompositeExtract %ushort %2080 3
-OpStore %855 %2081
-%2082 = OpLoad %_arr_ushort_uint_8 %133
-%2083 = OpCompositeExtract %ushort %2082 3
-OpStore %856 %2083
-%2084 = OpLoad %ushort %855
-%2085 = OpLoad %ushort %856
-%2086 = OpIMul %ushort %2084 %2085
-OpStore %857 %2086
-%2087 = OpLoad %_arr_ushort_uint_8 %845
-%2088 = OpCompositeExtract %ushort %2087 4
-OpStore %858 %2088
-%2089 = OpLoad %_arr_ushort_uint_8 %133
-%2090 = OpCompositeExtract %ushort %2089 4
-OpStore %859 %2090
-%2091 = OpLoad %ushort %858
-%2092 = OpLoad %ushort %859
-%2093 = OpIMul %ushort %2091 %2092
-OpStore %860 %2093
-%2094 = OpLoad %_arr_ushort_uint_8 %845
-%2095 = OpCompositeExtract %ushort %2094 5
-OpStore %861 %2095
-%2096 = OpLoad %_arr_ushort_uint_8 %133
-%2097 = OpCompositeExtract %ushort %2096 5
-OpStore %862 %2097
-%2098 = OpLoad %ushort %861
-%2099 = OpLoad %ushort %862
-%2100 = OpIMul %ushort %2098 %2099
-OpStore %863 %2100
-%2101 = OpLoad %_arr_ushort_uint_8 %845
-%2102 = OpCompositeExtract %ushort %2101 6
-OpStore %864 %2102
-%2103 = OpLoad %_arr_ushort_uint_8 %133
-%2104 = OpCompositeExtract %ushort %2103 6
-OpStore %865 %2104
-%2105 = OpLoad %ushort %864
-%2106 = OpLoad %ushort %865
-%2107 = OpIMul %ushort %2105 %2106
-OpStore %866 %2107
-%2108 = OpLoad %_arr_ushort_uint_8 %845
-%2109 = OpCompositeExtract %ushort %2108 7
-OpStore %867 %2109
-%2110 = OpLoad %_arr_ushort_uint_8 %133
-%2111 = OpCompositeExtract %ushort %2110 7
-OpStore %868 %2111
-%2112 = OpLoad %ushort %867
-%2113 = OpLoad %ushort %868
-%2114 = OpIMul %ushort %2112 %2113
-OpStore %869 %2114
-%2115 = OpLoad %_arr_ushort_uint_8 %845
-%2116 = OpLoad %ushort %848
-%2117 = OpCompositeInsert %_arr_ushort_uint_8 %2116 %2115 0
-OpStore %870 %2117
-%2118 = OpLoad %_arr_ushort_uint_8 %870
-%2119 = OpLoad %ushort %851
-%2120 = OpCompositeInsert %_arr_ushort_uint_8 %2119 %2118 1
-OpStore %871 %2120
-%2121 = OpLoad %_arr_ushort_uint_8 %871
-%2122 = OpLoad %ushort %854
-%2123 = OpCompositeInsert %_arr_ushort_uint_8 %2122 %2121 2
-OpStore %872 %2123
-%2124 = OpLoad %_arr_ushort_uint_8 %872
-%2125 = OpLoad %ushort %857
-%2126 = OpCompositeInsert %_arr_ushort_uint_8 %2125 %2124 3
-OpStore %873 %2126
-%2127 = OpLoad %_arr_ushort_uint_8 %873
-%2128 = OpLoad %ushort %860
-%2129 = OpCompositeInsert %_arr_ushort_uint_8 %2128 %2127 4
-OpStore %874 %2129
-%2130 = OpLoad %_arr_ushort_uint_8 %874
-%2131 = OpLoad %ushort %863
-%2132 = OpCompositeInsert %_arr_ushort_uint_8 %2131 %2130 5
-OpStore %875 %2132
-%2133 = OpLoad %_arr_ushort_uint_8 %875
-%2134 = OpLoad %ushort %866
-%2135 = OpCompositeInsert %_arr_ushort_uint_8 %2134 %2133 6
-OpStore %876 %2135
-%2136 = OpLoad %_arr_ushort_uint_8 %876
-%2137 = OpLoad %ushort %869
-%2138 = OpCompositeInsert %_arr_ushort_uint_8 %2137 %2136 7
-OpStore %877 %2138
-OpBranch %114
-%114 = OpLabel
-%2139 = OpLoad %_arr_ushort_uint_8 %877
-%2140 = OpCompositeExtract %ushort %2139 0
-OpStore %398 %2140
-%2141 = OpLoad %ulong %397
-%2142 = OpLoad %ushort %398
-%2143 = OpFunctionCall %ulong %4 %2141 %2142
-OpStore %399 %2143
-%2144 = OpLoad %_arr_ushort_uint_8 %877
-%2145 = OpCompositeExtract %ushort %2144 1
-OpStore %400 %2145
-%2146 = OpLoad %ulong %399
-%2147 = OpLoad %ushort %400
-%2148 = OpFunctionCall %ulong %4 %2146 %2147
-OpStore %401 %2148
-%2149 = OpLoad %_arr_ushort_uint_8 %877
-%2150 = OpCompositeExtract %ushort %2149 2
-OpStore %402 %2150
-%2151 = OpLoad %ulong %401
-%2152 = OpLoad %ushort %402
-%2153 = OpFunctionCall %ulong %4 %2151 %2152
-OpStore %403 %2153
-%2154 = OpLoad %_arr_ushort_uint_8 %877
-%2155 = OpCompositeExtract %ushort %2154 3
-OpStore %404 %2155
-%2156 = OpLoad %ulong %403
-%2157 = OpLoad %ushort %404
-%2158 = OpFunctionCall %ulong %4 %2156 %2157
-OpStore %405 %2158
-%2159 = OpLoad %_arr_ushort_uint_8 %877
-%2160 = OpCompositeExtract %ushort %2159 4
-OpStore %406 %2160
-%2161 = OpLoad %ulong %405
-%2162 = OpLoad %ushort %406
-%2163 = OpFunctionCall %ulong %4 %2161 %2162
-OpStore %407 %2163
-%2164 = OpLoad %_arr_ushort_uint_8 %877
-%2165 = OpCompositeExtract %ushort %2164 5
-OpStore %408 %2165
-%2166 = OpLoad %ulong %407
-%2167 = OpLoad %ushort %408
-%2168 = OpFunctionCall %ulong %4 %2166 %2167
-OpStore %409 %2168
-%2169 = OpLoad %_arr_ushort_uint_8 %877
-%2170 = OpCompositeExtract %ushort %2169 6
-OpStore %410 %2170
-%2171 = OpLoad %ulong %409
-%2172 = OpLoad %ushort %410
-%2173 = OpFunctionCall %ulong %4 %2171 %2172
-OpStore %411 %2173
-%2174 = OpLoad %_arr_ushort_uint_8 %877
-%2175 = OpCompositeExtract %ushort %2174 7
-OpStore %412 %2175
-%2176 = OpLoad %ulong %411
-%2177 = OpLoad %ushort %412
-%2178 = OpFunctionCall %ulong %4 %2176 %2177
-OpStore %413 %2178
-OpBranch %115
-%115 = OpLabel
-%2179 = OpLoad %_arr_ushort_uint_8 %134
-%2180 = OpCompositeExtract %ushort %2179 0
-OpStore %878 %2180
-%2181 = OpLoad %_arr_ushort_uint_8 %140
-%2182 = OpCompositeExtract %ushort %2181 0
-OpStore %879 %2182
-%2183 = OpLoad %ushort %878
-%2184 = OpLoad %ushort %879
-%2185 = OpISub %ushort %2183 %2184
-OpStore %880 %2185
-%2186 = OpLoad %_arr_ushort_uint_8 %134
-%2187 = OpCompositeExtract %ushort %2186 1
-OpStore %881 %2187
-%2188 = OpLoad %_arr_ushort_uint_8 %140
-%2189 = OpCompositeExtract %ushort %2188 1
-OpStore %882 %2189
-%2190 = OpLoad %ushort %881
-%2191 = OpLoad %ushort %882
-%2192 = OpISub %ushort %2190 %2191
-OpStore %883 %2192
-%2193 = OpLoad %_arr_ushort_uint_8 %134
-%2194 = OpCompositeExtract %ushort %2193 2
-OpStore %884 %2194
-%2195 = OpLoad %_arr_ushort_uint_8 %140
-%2196 = OpCompositeExtract %ushort %2195 2
-OpStore %885 %2196
-%2197 = OpLoad %ushort %884
-%2198 = OpLoad %ushort %885
-%2199 = OpISub %ushort %2197 %2198
-OpStore %886 %2199
-%2200 = OpLoad %_arr_ushort_uint_8 %134
-%2201 = OpCompositeExtract %ushort %2200 3
-OpStore %887 %2201
-%2202 = OpLoad %_arr_ushort_uint_8 %140
-%2203 = OpCompositeExtract %ushort %2202 3
-OpStore %888 %2203
-%2204 = OpLoad %ushort %887
-%2205 = OpLoad %ushort %888
-%2206 = OpISub %ushort %2204 %2205
-OpStore %889 %2206
-%2207 = OpLoad %_arr_ushort_uint_8 %134
-%2208 = OpCompositeExtract %ushort %2207 4
-OpStore %890 %2208
-%2209 = OpLoad %_arr_ushort_uint_8 %140
-%2210 = OpCompositeExtract %ushort %2209 4
-OpStore %891 %2210
-%2211 = OpLoad %ushort %890
-%2212 = OpLoad %ushort %891
-%2213 = OpISub %ushort %2211 %2212
-OpStore %892 %2213
-%2214 = OpLoad %_arr_ushort_uint_8 %134
-%2215 = OpCompositeExtract %ushort %2214 5
-OpStore %893 %2215
-%2216 = OpLoad %_arr_ushort_uint_8 %140
-%2217 = OpCompositeExtract %ushort %2216 5
-OpStore %894 %2217
-%2218 = OpLoad %ushort %893
-%2219 = OpLoad %ushort %894
-%2220 = OpISub %ushort %2218 %2219
-OpStore %895 %2220
-%2221 = OpLoad %_arr_ushort_uint_8 %134
-%2222 = OpCompositeExtract %ushort %2221 6
-OpStore %896 %2222
-%2223 = OpLoad %_arr_ushort_uint_8 %140
-%2224 = OpCompositeExtract %ushort %2223 6
-OpStore %897 %2224
-%2225 = OpLoad %ushort %896
-%2226 = OpLoad %ushort %897
-%2227 = OpISub %ushort %2225 %2226
-OpStore %898 %2227
-%2228 = OpLoad %_arr_ushort_uint_8 %134
-%2229 = OpCompositeExtract %ushort %2228 7
-OpStore %899 %2229
-%2230 = OpLoad %_arr_ushort_uint_8 %140
-%2231 = OpCompositeExtract %ushort %2230 7
-OpStore %900 %2231
-%2232 = OpLoad %ushort %899
-%2233 = OpLoad %ushort %900
-%2234 = OpISub %ushort %2232 %2233
-OpStore %901 %2234
-%2235 = OpLoad %_arr_ushort_uint_8 %134
-%2236 = OpLoad %ushort %880
-%2237 = OpCompositeInsert %_arr_ushort_uint_8 %2236 %2235 0
-OpStore %902 %2237
-%2238 = OpLoad %_arr_ushort_uint_8 %902
-%2239 = OpLoad %ushort %883
-%2240 = OpCompositeInsert %_arr_ushort_uint_8 %2239 %2238 1
-OpStore %903 %2240
-%2241 = OpLoad %_arr_ushort_uint_8 %903
-%2242 = OpLoad %ushort %886
-%2243 = OpCompositeInsert %_arr_ushort_uint_8 %2242 %2241 2
-OpStore %904 %2243
-%2244 = OpLoad %_arr_ushort_uint_8 %904
-%2245 = OpLoad %ushort %889
-%2246 = OpCompositeInsert %_arr_ushort_uint_8 %2245 %2244 3
-OpStore %905 %2246
-%2247 = OpLoad %_arr_ushort_uint_8 %905
-%2248 = OpLoad %ushort %892
-%2249 = OpCompositeInsert %_arr_ushort_uint_8 %2248 %2247 4
-OpStore %906 %2249
-%2250 = OpLoad %_arr_ushort_uint_8 %906
-%2251 = OpLoad %ushort %895
-%2252 = OpCompositeInsert %_arr_ushort_uint_8 %2251 %2250 5
-OpStore %907 %2252
-%2253 = OpLoad %_arr_ushort_uint_8 %907
-%2254 = OpLoad %ushort %898
-%2255 = OpCompositeInsert %_arr_ushort_uint_8 %2254 %2253 6
-OpStore %908 %2255
-%2256 = OpLoad %_arr_ushort_uint_8 %908
-%2257 = OpLoad %ushort %901
-%2258 = OpCompositeInsert %_arr_ushort_uint_8 %2257 %2256 7
-OpStore %909 %2258
-OpBranch %116
-%116 = OpLabel
-%2259 = OpLoad %_arr_ushort_uint_8 %909
-%2260 = OpCompositeExtract %ushort %2259 0
-OpStore %414 %2260
-%2261 = OpLoad %ulong %413
-%2262 = OpLoad %ushort %414
-%2263 = OpFunctionCall %ulong %4 %2261 %2262
-OpStore %415 %2263
-%2264 = OpLoad %_arr_ushort_uint_8 %909
+OpStore %696 %1255
+%1256 = OpLoad %_arr_ushort_uint_8 %422
+%1257 = OpCompositeExtract %ushort %1256 7
+OpStore %697 %1257
+%1258 = OpLoad %ushort %696
+%1259 = OpLoad %ushort %697
+%1260 = OpIAdd %ushort %1258 %1259
+OpStore %698 %1260
+%1261 = OpLoad %_arr_ushort_uint_8 %416
+%1262 = OpLoad %ushort %677
+%1263 = OpCompositeInsert %_arr_ushort_uint_8 %1262 %1261 0
+OpStore %699 %1263
+%1264 = OpLoad %_arr_ushort_uint_8 %699
+%1265 = OpLoad %ushort %680
+%1266 = OpCompositeInsert %_arr_ushort_uint_8 %1265 %1264 1
+OpStore %700 %1266
+%1267 = OpLoad %_arr_ushort_uint_8 %700
+%1268 = OpLoad %ushort %683
+%1269 = OpCompositeInsert %_arr_ushort_uint_8 %1268 %1267 2
+OpStore %701 %1269
+%1270 = OpLoad %_arr_ushort_uint_8 %701
+%1271 = OpLoad %ushort %686
+%1272 = OpCompositeInsert %_arr_ushort_uint_8 %1271 %1270 3
+OpStore %702 %1272
+%1273 = OpLoad %_arr_ushort_uint_8 %702
+%1274 = OpLoad %ushort %689
+%1275 = OpCompositeInsert %_arr_ushort_uint_8 %1274 %1273 4
+OpStore %703 %1275
+%1276 = OpLoad %_arr_ushort_uint_8 %703
+%1277 = OpLoad %ushort %692
+%1278 = OpCompositeInsert %_arr_ushort_uint_8 %1277 %1276 5
+OpStore %704 %1278
+%1279 = OpLoad %_arr_ushort_uint_8 %704
+%1280 = OpLoad %ushort %695
+%1281 = OpCompositeInsert %_arr_ushort_uint_8 %1280 %1279 6
+OpStore %705 %1281
+%1282 = OpLoad %_arr_ushort_uint_8 %705
+%1283 = OpLoad %ushort %698
+%1284 = OpCompositeInsert %_arr_ushort_uint_8 %1283 %1282 7
+OpStore %706 %1284
+%1285 = OpLoad %ulong %424
+%1286 = OpLoad %_arr_ushort_uint_8 %706
+%1287 = OpFunctionCall %ulong %1 %1285 %1286
+OpStore %425 %1287
+%1288 = OpLoad %_arr_ushort_uint_8 %416
+%1289 = OpCompositeExtract %ushort %1288 0
+OpStore %707 %1289
+%1290 = OpLoad %_arr_ushort_uint_8 %422
+%1291 = OpCompositeExtract %ushort %1290 0
+OpStore %708 %1291
+%1292 = OpLoad %ushort %707
+%1293 = OpLoad %ushort %708
+%1294 = OpISub %ushort %1292 %1293
+OpStore %709 %1294
+%1295 = OpLoad %_arr_ushort_uint_8 %416
+%1296 = OpCompositeExtract %ushort %1295 1
+OpStore %710 %1296
+%1297 = OpLoad %_arr_ushort_uint_8 %422
+%1298 = OpCompositeExtract %ushort %1297 1
+OpStore %711 %1298
+%1299 = OpLoad %ushort %710
+%1300 = OpLoad %ushort %711
+%1301 = OpISub %ushort %1299 %1300
+OpStore %712 %1301
+%1302 = OpLoad %_arr_ushort_uint_8 %416
+%1303 = OpCompositeExtract %ushort %1302 2
+OpStore %713 %1303
+%1304 = OpLoad %_arr_ushort_uint_8 %422
+%1305 = OpCompositeExtract %ushort %1304 2
+OpStore %714 %1305
+%1306 = OpLoad %ushort %713
+%1307 = OpLoad %ushort %714
+%1308 = OpISub %ushort %1306 %1307
+OpStore %715 %1308
+%1309 = OpLoad %_arr_ushort_uint_8 %416
+%1310 = OpCompositeExtract %ushort %1309 3
+OpStore %716 %1310
+%1311 = OpLoad %_arr_ushort_uint_8 %422
+%1312 = OpCompositeExtract %ushort %1311 3
+OpStore %717 %1312
+%1313 = OpLoad %ushort %716
+%1314 = OpLoad %ushort %717
+%1315 = OpISub %ushort %1313 %1314
+OpStore %718 %1315
+%1316 = OpLoad %_arr_ushort_uint_8 %416
+%1317 = OpCompositeExtract %ushort %1316 4
+OpStore %719 %1317
+%1318 = OpLoad %_arr_ushort_uint_8 %422
+%1319 = OpCompositeExtract %ushort %1318 4
+OpStore %720 %1319
+%1320 = OpLoad %ushort %719
+%1321 = OpLoad %ushort %720
+%1322 = OpISub %ushort %1320 %1321
+OpStore %721 %1322
+%1323 = OpLoad %_arr_ushort_uint_8 %416
+%1324 = OpCompositeExtract %ushort %1323 5
+OpStore %722 %1324
+%1325 = OpLoad %_arr_ushort_uint_8 %422
+%1326 = OpCompositeExtract %ushort %1325 5
+OpStore %723 %1326
+%1327 = OpLoad %ushort %722
+%1328 = OpLoad %ushort %723
+%1329 = OpISub %ushort %1327 %1328
+OpStore %724 %1329
+%1330 = OpLoad %_arr_ushort_uint_8 %416
+%1331 = OpCompositeExtract %ushort %1330 6
+OpStore %725 %1331
+%1332 = OpLoad %_arr_ushort_uint_8 %422
+%1333 = OpCompositeExtract %ushort %1332 6
+OpStore %726 %1333
+%1334 = OpLoad %ushort %725
+%1335 = OpLoad %ushort %726
+%1336 = OpISub %ushort %1334 %1335
+OpStore %727 %1336
+%1337 = OpLoad %_arr_ushort_uint_8 %416
+%1338 = OpCompositeExtract %ushort %1337 7
+OpStore %728 %1338
+%1339 = OpLoad %_arr_ushort_uint_8 %422
+%1340 = OpCompositeExtract %ushort %1339 7
+OpStore %729 %1340
+%1341 = OpLoad %ushort %728
+%1342 = OpLoad %ushort %729
+%1343 = OpISub %ushort %1341 %1342
+OpStore %730 %1343
+%1344 = OpLoad %_arr_ushort_uint_8 %416
+%1345 = OpLoad %ushort %709
+%1346 = OpCompositeInsert %_arr_ushort_uint_8 %1345 %1344 0
+OpStore %731 %1346
+%1347 = OpLoad %_arr_ushort_uint_8 %731
+%1348 = OpLoad %ushort %712
+%1349 = OpCompositeInsert %_arr_ushort_uint_8 %1348 %1347 1
+OpStore %732 %1349
+%1350 = OpLoad %_arr_ushort_uint_8 %732
+%1351 = OpLoad %ushort %715
+%1352 = OpCompositeInsert %_arr_ushort_uint_8 %1351 %1350 2
+OpStore %733 %1352
+%1353 = OpLoad %_arr_ushort_uint_8 %733
+%1354 = OpLoad %ushort %718
+%1355 = OpCompositeInsert %_arr_ushort_uint_8 %1354 %1353 3
+OpStore %734 %1355
+%1356 = OpLoad %_arr_ushort_uint_8 %734
+%1357 = OpLoad %ushort %721
+%1358 = OpCompositeInsert %_arr_ushort_uint_8 %1357 %1356 4
+OpStore %735 %1358
+%1359 = OpLoad %_arr_ushort_uint_8 %735
+%1360 = OpLoad %ushort %724
+%1361 = OpCompositeInsert %_arr_ushort_uint_8 %1360 %1359 5
+OpStore %736 %1361
+%1362 = OpLoad %_arr_ushort_uint_8 %736
+%1363 = OpLoad %ushort %727
+%1364 = OpCompositeInsert %_arr_ushort_uint_8 %1363 %1362 6
+OpStore %737 %1364
+%1365 = OpLoad %_arr_ushort_uint_8 %737
+%1366 = OpLoad %ushort %730
+%1367 = OpCompositeInsert %_arr_ushort_uint_8 %1366 %1365 7
+OpStore %738 %1367
+%1368 = OpLoad %ulong %425
+%1369 = OpLoad %_arr_ushort_uint_8 %738
+%1370 = OpFunctionCall %ulong %1 %1368 %1369
+OpStore %426 %1370
+%1371 = OpLoad %_arr_ushort_uint_8 %422
+%1372 = OpCompositeExtract %ushort %1371 0
+OpStore %739 %1372
+%1373 = OpLoad %_arr_ushort_uint_8 %416
+%1374 = OpCompositeExtract %ushort %1373 0
+OpStore %740 %1374
+%1375 = OpLoad %ushort %739
+%1376 = OpLoad %ushort %740
+%1377 = OpISub %ushort %1375 %1376
+OpStore %741 %1377
+%1378 = OpLoad %_arr_ushort_uint_8 %422
+%1379 = OpCompositeExtract %ushort %1378 1
+OpStore %742 %1379
+%1380 = OpLoad %_arr_ushort_uint_8 %416
+%1381 = OpCompositeExtract %ushort %1380 1
+OpStore %743 %1381
+%1382 = OpLoad %ushort %742
+%1383 = OpLoad %ushort %743
+%1384 = OpISub %ushort %1382 %1383
+OpStore %744 %1384
+%1385 = OpLoad %_arr_ushort_uint_8 %422
+%1386 = OpCompositeExtract %ushort %1385 2
+OpStore %745 %1386
+%1387 = OpLoad %_arr_ushort_uint_8 %416
+%1388 = OpCompositeExtract %ushort %1387 2
+OpStore %746 %1388
+%1389 = OpLoad %ushort %745
+%1390 = OpLoad %ushort %746
+%1391 = OpISub %ushort %1389 %1390
+OpStore %747 %1391
+%1392 = OpLoad %_arr_ushort_uint_8 %422
+%1393 = OpCompositeExtract %ushort %1392 3
+OpStore %748 %1393
+%1394 = OpLoad %_arr_ushort_uint_8 %416
+%1395 = OpCompositeExtract %ushort %1394 3
+OpStore %749 %1395
+%1396 = OpLoad %ushort %748
+%1397 = OpLoad %ushort %749
+%1398 = OpISub %ushort %1396 %1397
+OpStore %750 %1398
+%1399 = OpLoad %_arr_ushort_uint_8 %422
+%1400 = OpCompositeExtract %ushort %1399 4
+OpStore %751 %1400
+%1401 = OpLoad %_arr_ushort_uint_8 %416
+%1402 = OpCompositeExtract %ushort %1401 4
+OpStore %752 %1402
+%1403 = OpLoad %ushort %751
+%1404 = OpLoad %ushort %752
+%1405 = OpISub %ushort %1403 %1404
+OpStore %753 %1405
+%1406 = OpLoad %_arr_ushort_uint_8 %422
+%1407 = OpCompositeExtract %ushort %1406 5
+OpStore %754 %1407
+%1408 = OpLoad %_arr_ushort_uint_8 %416
+%1409 = OpCompositeExtract %ushort %1408 5
+OpStore %755 %1409
+%1410 = OpLoad %ushort %754
+%1411 = OpLoad %ushort %755
+%1412 = OpISub %ushort %1410 %1411
+OpStore %756 %1412
+%1413 = OpLoad %_arr_ushort_uint_8 %422
+%1414 = OpCompositeExtract %ushort %1413 6
+OpStore %757 %1414
+%1415 = OpLoad %_arr_ushort_uint_8 %416
+%1416 = OpCompositeExtract %ushort %1415 6
+OpStore %758 %1416
+%1417 = OpLoad %ushort %757
+%1418 = OpLoad %ushort %758
+%1419 = OpISub %ushort %1417 %1418
+OpStore %759 %1419
+%1420 = OpLoad %_arr_ushort_uint_8 %422
+%1421 = OpCompositeExtract %ushort %1420 7
+OpStore %760 %1421
+%1422 = OpLoad %_arr_ushort_uint_8 %416
+%1423 = OpCompositeExtract %ushort %1422 7
+OpStore %761 %1423
+%1424 = OpLoad %ushort %760
+%1425 = OpLoad %ushort %761
+%1426 = OpISub %ushort %1424 %1425
+OpStore %762 %1426
+%1427 = OpLoad %_arr_ushort_uint_8 %422
+%1428 = OpLoad %ushort %741
+%1429 = OpCompositeInsert %_arr_ushort_uint_8 %1428 %1427 0
+OpStore %763 %1429
+%1430 = OpLoad %_arr_ushort_uint_8 %763
+%1431 = OpLoad %ushort %744
+%1432 = OpCompositeInsert %_arr_ushort_uint_8 %1431 %1430 1
+OpStore %764 %1432
+%1433 = OpLoad %_arr_ushort_uint_8 %764
+%1434 = OpLoad %ushort %747
+%1435 = OpCompositeInsert %_arr_ushort_uint_8 %1434 %1433 2
+OpStore %765 %1435
+%1436 = OpLoad %_arr_ushort_uint_8 %765
+%1437 = OpLoad %ushort %750
+%1438 = OpCompositeInsert %_arr_ushort_uint_8 %1437 %1436 3
+OpStore %766 %1438
+%1439 = OpLoad %_arr_ushort_uint_8 %766
+%1440 = OpLoad %ushort %753
+%1441 = OpCompositeInsert %_arr_ushort_uint_8 %1440 %1439 4
+OpStore %767 %1441
+%1442 = OpLoad %_arr_ushort_uint_8 %767
+%1443 = OpLoad %ushort %756
+%1444 = OpCompositeInsert %_arr_ushort_uint_8 %1443 %1442 5
+OpStore %768 %1444
+%1445 = OpLoad %_arr_ushort_uint_8 %768
+%1446 = OpLoad %ushort %759
+%1447 = OpCompositeInsert %_arr_ushort_uint_8 %1446 %1445 6
+OpStore %769 %1447
+%1448 = OpLoad %_arr_ushort_uint_8 %769
+%1449 = OpLoad %ushort %762
+%1450 = OpCompositeInsert %_arr_ushort_uint_8 %1449 %1448 7
+OpStore %770 %1450
+%1451 = OpLoad %ulong %426
+%1452 = OpLoad %_arr_ushort_uint_8 %770
+%1453 = OpFunctionCall %ulong %1 %1451 %1452
+OpStore %427 %1453
+%1454 = OpLoad %_arr_ushort_uint_8 %416
+%1455 = OpCompositeExtract %ushort %1454 0
+OpStore %771 %1455
+%1456 = OpLoad %_arr_ushort_uint_8 %422
+%1457 = OpCompositeExtract %ushort %1456 0
+OpStore %772 %1457
+%1458 = OpLoad %ushort %771
+%1459 = OpLoad %ushort %772
+%1460 = OpIMul %ushort %1458 %1459
+OpStore %773 %1460
+%1461 = OpLoad %_arr_ushort_uint_8 %416
+%1462 = OpCompositeExtract %ushort %1461 1
+OpStore %774 %1462
+%1463 = OpLoad %_arr_ushort_uint_8 %422
+%1464 = OpCompositeExtract %ushort %1463 1
+OpStore %775 %1464
+%1465 = OpLoad %ushort %774
+%1466 = OpLoad %ushort %775
+%1467 = OpIMul %ushort %1465 %1466
+OpStore %776 %1467
+%1468 = OpLoad %_arr_ushort_uint_8 %416
+%1469 = OpCompositeExtract %ushort %1468 2
+OpStore %777 %1469
+%1470 = OpLoad %_arr_ushort_uint_8 %422
+%1471 = OpCompositeExtract %ushort %1470 2
+OpStore %778 %1471
+%1472 = OpLoad %ushort %777
+%1473 = OpLoad %ushort %778
+%1474 = OpIMul %ushort %1472 %1473
+OpStore %779 %1474
+%1475 = OpLoad %_arr_ushort_uint_8 %416
+%1476 = OpCompositeExtract %ushort %1475 3
+OpStore %780 %1476
+%1477 = OpLoad %_arr_ushort_uint_8 %422
+%1478 = OpCompositeExtract %ushort %1477 3
+OpStore %781 %1478
+%1479 = OpLoad %ushort %780
+%1480 = OpLoad %ushort %781
+%1481 = OpIMul %ushort %1479 %1480
+OpStore %782 %1481
+%1482 = OpLoad %_arr_ushort_uint_8 %416
+%1483 = OpCompositeExtract %ushort %1482 4
+OpStore %783 %1483
+%1484 = OpLoad %_arr_ushort_uint_8 %422
+%1485 = OpCompositeExtract %ushort %1484 4
+OpStore %784 %1485
+%1486 = OpLoad %ushort %783
+%1487 = OpLoad %ushort %784
+%1488 = OpIMul %ushort %1486 %1487
+OpStore %785 %1488
+%1489 = OpLoad %_arr_ushort_uint_8 %416
+%1490 = OpCompositeExtract %ushort %1489 5
+OpStore %786 %1490
+%1491 = OpLoad %_arr_ushort_uint_8 %422
+%1492 = OpCompositeExtract %ushort %1491 5
+OpStore %787 %1492
+%1493 = OpLoad %ushort %786
+%1494 = OpLoad %ushort %787
+%1495 = OpIMul %ushort %1493 %1494
+OpStore %788 %1495
+%1496 = OpLoad %_arr_ushort_uint_8 %416
+%1497 = OpCompositeExtract %ushort %1496 6
+OpStore %789 %1497
+%1498 = OpLoad %_arr_ushort_uint_8 %422
+%1499 = OpCompositeExtract %ushort %1498 6
+OpStore %790 %1499
+%1500 = OpLoad %ushort %789
+%1501 = OpLoad %ushort %790
+%1502 = OpIMul %ushort %1500 %1501
+OpStore %791 %1502
+%1503 = OpLoad %_arr_ushort_uint_8 %416
+%1504 = OpCompositeExtract %ushort %1503 7
+OpStore %792 %1504
+%1505 = OpLoad %_arr_ushort_uint_8 %422
+%1506 = OpCompositeExtract %ushort %1505 7
+OpStore %793 %1506
+%1507 = OpLoad %ushort %792
+%1508 = OpLoad %ushort %793
+%1509 = OpIMul %ushort %1507 %1508
+OpStore %794 %1509
+%1510 = OpLoad %_arr_ushort_uint_8 %416
+%1511 = OpLoad %ushort %773
+%1512 = OpCompositeInsert %_arr_ushort_uint_8 %1511 %1510 0
+OpStore %795 %1512
+%1513 = OpLoad %_arr_ushort_uint_8 %795
+%1514 = OpLoad %ushort %776
+%1515 = OpCompositeInsert %_arr_ushort_uint_8 %1514 %1513 1
+OpStore %796 %1515
+%1516 = OpLoad %_arr_ushort_uint_8 %796
+%1517 = OpLoad %ushort %779
+%1518 = OpCompositeInsert %_arr_ushort_uint_8 %1517 %1516 2
+OpStore %797 %1518
+%1519 = OpLoad %_arr_ushort_uint_8 %797
+%1520 = OpLoad %ushort %782
+%1521 = OpCompositeInsert %_arr_ushort_uint_8 %1520 %1519 3
+OpStore %798 %1521
+%1522 = OpLoad %_arr_ushort_uint_8 %798
+%1523 = OpLoad %ushort %785
+%1524 = OpCompositeInsert %_arr_ushort_uint_8 %1523 %1522 4
+OpStore %799 %1524
+%1525 = OpLoad %_arr_ushort_uint_8 %799
+%1526 = OpLoad %ushort %788
+%1527 = OpCompositeInsert %_arr_ushort_uint_8 %1526 %1525 5
+OpStore %800 %1527
+%1528 = OpLoad %_arr_ushort_uint_8 %800
+%1529 = OpLoad %ushort %791
+%1530 = OpCompositeInsert %_arr_ushort_uint_8 %1529 %1528 6
+OpStore %801 %1530
+%1531 = OpLoad %_arr_ushort_uint_8 %801
+%1532 = OpLoad %ushort %794
+%1533 = OpCompositeInsert %_arr_ushort_uint_8 %1532 %1531 7
+OpStore %802 %1533
+%1534 = OpLoad %ulong %427
+%1535 = OpLoad %_arr_ushort_uint_8 %802
+%1536 = OpFunctionCall %ulong %1 %1534 %1535
+OpStore %428 %1536
+%1537 = OpLoad %_arr_ushort_uint_8 %416
+%1538 = OpCompositeExtract %ushort %1537 0
+OpStore %803 %1538
+%1539 = OpLoad %_arr_ushort_uint_8 %409
+%1540 = OpCompositeExtract %ushort %1539 0
+OpStore %804 %1540
+%1541 = OpLoad %ushort %803
+%1542 = OpLoad %ushort %804
+%1543 = OpIMul %ushort %1541 %1542
+OpStore %805 %1543
+%1544 = OpLoad %_arr_ushort_uint_8 %416
+%1545 = OpCompositeExtract %ushort %1544 1
+OpStore %806 %1545
+%1546 = OpLoad %_arr_ushort_uint_8 %409
+%1547 = OpCompositeExtract %ushort %1546 1
+OpStore %807 %1547
+%1548 = OpLoad %ushort %806
+%1549 = OpLoad %ushort %807
+%1550 = OpIMul %ushort %1548 %1549
+OpStore %808 %1550
+%1551 = OpLoad %_arr_ushort_uint_8 %416
+%1552 = OpCompositeExtract %ushort %1551 2
+OpStore %809 %1552
+%1553 = OpLoad %_arr_ushort_uint_8 %409
+%1554 = OpCompositeExtract %ushort %1553 2
+OpStore %810 %1554
+%1555 = OpLoad %ushort %809
+%1556 = OpLoad %ushort %810
+%1557 = OpIMul %ushort %1555 %1556
+OpStore %811 %1557
+%1558 = OpLoad %_arr_ushort_uint_8 %416
+%1559 = OpCompositeExtract %ushort %1558 3
+OpStore %812 %1559
+%1560 = OpLoad %_arr_ushort_uint_8 %409
+%1561 = OpCompositeExtract %ushort %1560 3
+OpStore %813 %1561
+%1562 = OpLoad %ushort %812
+%1563 = OpLoad %ushort %813
+%1564 = OpIMul %ushort %1562 %1563
+OpStore %814 %1564
+%1565 = OpLoad %_arr_ushort_uint_8 %416
+%1566 = OpCompositeExtract %ushort %1565 4
+OpStore %815 %1566
+%1567 = OpLoad %_arr_ushort_uint_8 %409
+%1568 = OpCompositeExtract %ushort %1567 4
+OpStore %816 %1568
+%1569 = OpLoad %ushort %815
+%1570 = OpLoad %ushort %816
+%1571 = OpIMul %ushort %1569 %1570
+OpStore %817 %1571
+%1572 = OpLoad %_arr_ushort_uint_8 %416
+%1573 = OpCompositeExtract %ushort %1572 5
+OpStore %818 %1573
+%1574 = OpLoad %_arr_ushort_uint_8 %409
+%1575 = OpCompositeExtract %ushort %1574 5
+OpStore %819 %1575
+%1576 = OpLoad %ushort %818
+%1577 = OpLoad %ushort %819
+%1578 = OpIMul %ushort %1576 %1577
+OpStore %820 %1578
+%1579 = OpLoad %_arr_ushort_uint_8 %416
+%1580 = OpCompositeExtract %ushort %1579 6
+OpStore %821 %1580
+%1581 = OpLoad %_arr_ushort_uint_8 %409
+%1582 = OpCompositeExtract %ushort %1581 6
+OpStore %822 %1582
+%1583 = OpLoad %ushort %821
+%1584 = OpLoad %ushort %822
+%1585 = OpIMul %ushort %1583 %1584
+OpStore %823 %1585
+%1586 = OpLoad %_arr_ushort_uint_8 %416
+%1587 = OpCompositeExtract %ushort %1586 7
+OpStore %824 %1587
+%1588 = OpLoad %_arr_ushort_uint_8 %409
+%1589 = OpCompositeExtract %ushort %1588 7
+OpStore %825 %1589
+%1590 = OpLoad %ushort %824
+%1591 = OpLoad %ushort %825
+%1592 = OpIMul %ushort %1590 %1591
+OpStore %826 %1592
+%1593 = OpLoad %_arr_ushort_uint_8 %416
+%1594 = OpLoad %ushort %805
+%1595 = OpCompositeInsert %_arr_ushort_uint_8 %1594 %1593 0
+OpStore %827 %1595
+%1596 = OpLoad %_arr_ushort_uint_8 %827
+%1597 = OpLoad %ushort %808
+%1598 = OpCompositeInsert %_arr_ushort_uint_8 %1597 %1596 1
+OpStore %828 %1598
+%1599 = OpLoad %_arr_ushort_uint_8 %828
+%1600 = OpLoad %ushort %811
+%1601 = OpCompositeInsert %_arr_ushort_uint_8 %1600 %1599 2
+OpStore %829 %1601
+%1602 = OpLoad %_arr_ushort_uint_8 %829
+%1603 = OpLoad %ushort %814
+%1604 = OpCompositeInsert %_arr_ushort_uint_8 %1603 %1602 3
+OpStore %830 %1604
+%1605 = OpLoad %_arr_ushort_uint_8 %830
+%1606 = OpLoad %ushort %817
+%1607 = OpCompositeInsert %_arr_ushort_uint_8 %1606 %1605 4
+OpStore %831 %1607
+%1608 = OpLoad %_arr_ushort_uint_8 %831
+%1609 = OpLoad %ushort %820
+%1610 = OpCompositeInsert %_arr_ushort_uint_8 %1609 %1608 5
+OpStore %832 %1610
+%1611 = OpLoad %_arr_ushort_uint_8 %832
+%1612 = OpLoad %ushort %823
+%1613 = OpCompositeInsert %_arr_ushort_uint_8 %1612 %1611 6
+OpStore %833 %1613
+%1614 = OpLoad %_arr_ushort_uint_8 %833
+%1615 = OpLoad %ushort %826
+%1616 = OpCompositeInsert %_arr_ushort_uint_8 %1615 %1614 7
+OpStore %834 %1616
+%1617 = OpLoad %ulong %428
+%1618 = OpLoad %_arr_ushort_uint_8 %834
+%1619 = OpFunctionCall %ulong %1 %1617 %1618
+OpStore %429 %1619
+%1620 = OpLoad %_arr_ushort_uint_8 %422
+%1621 = OpCompositeExtract %ushort %1620 0
+OpStore %835 %1621
+%1622 = OpLoad %_arr_ushort_uint_8 %409
+%1623 = OpCompositeExtract %ushort %1622 0
+OpStore %836 %1623
+%1624 = OpLoad %ushort %835
+%1625 = OpLoad %ushort %836
+%1626 = OpIMul %ushort %1624 %1625
+OpStore %837 %1626
+%1627 = OpLoad %_arr_ushort_uint_8 %422
+%1628 = OpCompositeExtract %ushort %1627 1
+OpStore %838 %1628
+%1629 = OpLoad %_arr_ushort_uint_8 %409
+%1630 = OpCompositeExtract %ushort %1629 1
+OpStore %839 %1630
+%1631 = OpLoad %ushort %838
+%1632 = OpLoad %ushort %839
+%1633 = OpIMul %ushort %1631 %1632
+OpStore %840 %1633
+%1634 = OpLoad %_arr_ushort_uint_8 %422
+%1635 = OpCompositeExtract %ushort %1634 2
+OpStore %841 %1635
+%1636 = OpLoad %_arr_ushort_uint_8 %409
+%1637 = OpCompositeExtract %ushort %1636 2
+OpStore %842 %1637
+%1638 = OpLoad %ushort %841
+%1639 = OpLoad %ushort %842
+%1640 = OpIMul %ushort %1638 %1639
+OpStore %843 %1640
+%1641 = OpLoad %_arr_ushort_uint_8 %422
+%1642 = OpCompositeExtract %ushort %1641 3
+OpStore %844 %1642
+%1643 = OpLoad %_arr_ushort_uint_8 %409
+%1644 = OpCompositeExtract %ushort %1643 3
+OpStore %845 %1644
+%1645 = OpLoad %ushort %844
+%1646 = OpLoad %ushort %845
+%1647 = OpIMul %ushort %1645 %1646
+OpStore %846 %1647
+%1648 = OpLoad %_arr_ushort_uint_8 %422
+%1649 = OpCompositeExtract %ushort %1648 4
+OpStore %847 %1649
+%1650 = OpLoad %_arr_ushort_uint_8 %409
+%1651 = OpCompositeExtract %ushort %1650 4
+OpStore %848 %1651
+%1652 = OpLoad %ushort %847
+%1653 = OpLoad %ushort %848
+%1654 = OpIMul %ushort %1652 %1653
+OpStore %849 %1654
+%1655 = OpLoad %_arr_ushort_uint_8 %422
+%1656 = OpCompositeExtract %ushort %1655 5
+OpStore %850 %1656
+%1657 = OpLoad %_arr_ushort_uint_8 %409
+%1658 = OpCompositeExtract %ushort %1657 5
+OpStore %851 %1658
+%1659 = OpLoad %ushort %850
+%1660 = OpLoad %ushort %851
+%1661 = OpIMul %ushort %1659 %1660
+OpStore %852 %1661
+%1662 = OpLoad %_arr_ushort_uint_8 %422
+%1663 = OpCompositeExtract %ushort %1662 6
+OpStore %853 %1663
+%1664 = OpLoad %_arr_ushort_uint_8 %409
+%1665 = OpCompositeExtract %ushort %1664 6
+OpStore %854 %1665
+%1666 = OpLoad %ushort %853
+%1667 = OpLoad %ushort %854
+%1668 = OpIMul %ushort %1666 %1667
+OpStore %855 %1668
+%1669 = OpLoad %_arr_ushort_uint_8 %422
+%1670 = OpCompositeExtract %ushort %1669 7
+OpStore %856 %1670
+%1671 = OpLoad %_arr_ushort_uint_8 %409
+%1672 = OpCompositeExtract %ushort %1671 7
+OpStore %857 %1672
+%1673 = OpLoad %ushort %856
+%1674 = OpLoad %ushort %857
+%1675 = OpIMul %ushort %1673 %1674
+OpStore %858 %1675
+%1676 = OpLoad %_arr_ushort_uint_8 %422
+%1677 = OpLoad %ushort %837
+%1678 = OpCompositeInsert %_arr_ushort_uint_8 %1677 %1676 0
+OpStore %859 %1678
+%1679 = OpLoad %_arr_ushort_uint_8 %859
+%1680 = OpLoad %ushort %840
+%1681 = OpCompositeInsert %_arr_ushort_uint_8 %1680 %1679 1
+OpStore %860 %1681
+%1682 = OpLoad %_arr_ushort_uint_8 %860
+%1683 = OpLoad %ushort %843
+%1684 = OpCompositeInsert %_arr_ushort_uint_8 %1683 %1682 2
+OpStore %861 %1684
+%1685 = OpLoad %_arr_ushort_uint_8 %861
+%1686 = OpLoad %ushort %846
+%1687 = OpCompositeInsert %_arr_ushort_uint_8 %1686 %1685 3
+OpStore %862 %1687
+%1688 = OpLoad %_arr_ushort_uint_8 %862
+%1689 = OpLoad %ushort %849
+%1690 = OpCompositeInsert %_arr_ushort_uint_8 %1689 %1688 4
+OpStore %863 %1690
+%1691 = OpLoad %_arr_ushort_uint_8 %863
+%1692 = OpLoad %ushort %852
+%1693 = OpCompositeInsert %_arr_ushort_uint_8 %1692 %1691 5
+OpStore %864 %1693
+%1694 = OpLoad %_arr_ushort_uint_8 %864
+%1695 = OpLoad %ushort %855
+%1696 = OpCompositeInsert %_arr_ushort_uint_8 %1695 %1694 6
+OpStore %865 %1696
+%1697 = OpLoad %_arr_ushort_uint_8 %865
+%1698 = OpLoad %ushort %858
+%1699 = OpCompositeInsert %_arr_ushort_uint_8 %1698 %1697 7
+OpStore %866 %1699
+%1700 = OpLoad %ulong %429
+%1701 = OpLoad %_arr_ushort_uint_8 %866
+%1702 = OpFunctionCall %ulong %1 %1700 %1701
+OpStore %430 %1702
+%1703 = OpLoad %_arr_ushort_uint_8 %706
+%1704 = OpCompositeExtract %ushort %1703 0
+OpStore %867 %1704
+%1705 = OpLoad %_arr_ushort_uint_8 %409
+%1706 = OpCompositeExtract %ushort %1705 0
+OpStore %868 %1706
+%1707 = OpLoad %ushort %867
+%1708 = OpLoad %ushort %868
+%1709 = OpIMul %ushort %1707 %1708
+OpStore %869 %1709
+%1710 = OpLoad %_arr_ushort_uint_8 %706
+%1711 = OpCompositeExtract %ushort %1710 1
+OpStore %870 %1711
+%1712 = OpLoad %_arr_ushort_uint_8 %409
+%1713 = OpCompositeExtract %ushort %1712 1
+OpStore %871 %1713
+%1714 = OpLoad %ushort %870
+%1715 = OpLoad %ushort %871
+%1716 = OpIMul %ushort %1714 %1715
+OpStore %872 %1716
+%1717 = OpLoad %_arr_ushort_uint_8 %706
+%1718 = OpCompositeExtract %ushort %1717 2
+OpStore %873 %1718
+%1719 = OpLoad %_arr_ushort_uint_8 %409
+%1720 = OpCompositeExtract %ushort %1719 2
+OpStore %874 %1720
+%1721 = OpLoad %ushort %873
+%1722 = OpLoad %ushort %874
+%1723 = OpIMul %ushort %1721 %1722
+OpStore %875 %1723
+%1724 = OpLoad %_arr_ushort_uint_8 %706
+%1725 = OpCompositeExtract %ushort %1724 3
+OpStore %876 %1725
+%1726 = OpLoad %_arr_ushort_uint_8 %409
+%1727 = OpCompositeExtract %ushort %1726 3
+OpStore %877 %1727
+%1728 = OpLoad %ushort %876
+%1729 = OpLoad %ushort %877
+%1730 = OpIMul %ushort %1728 %1729
+OpStore %878 %1730
+%1731 = OpLoad %_arr_ushort_uint_8 %706
+%1732 = OpCompositeExtract %ushort %1731 4
+OpStore %879 %1732
+%1733 = OpLoad %_arr_ushort_uint_8 %409
+%1734 = OpCompositeExtract %ushort %1733 4
+OpStore %880 %1734
+%1735 = OpLoad %ushort %879
+%1736 = OpLoad %ushort %880
+%1737 = OpIMul %ushort %1735 %1736
+OpStore %881 %1737
+%1738 = OpLoad %_arr_ushort_uint_8 %706
+%1739 = OpCompositeExtract %ushort %1738 5
+OpStore %882 %1739
+%1740 = OpLoad %_arr_ushort_uint_8 %409
+%1741 = OpCompositeExtract %ushort %1740 5
+OpStore %883 %1741
+%1742 = OpLoad %ushort %882
+%1743 = OpLoad %ushort %883
+%1744 = OpIMul %ushort %1742 %1743
+OpStore %884 %1744
+%1745 = OpLoad %_arr_ushort_uint_8 %706
+%1746 = OpCompositeExtract %ushort %1745 6
+OpStore %885 %1746
+%1747 = OpLoad %_arr_ushort_uint_8 %409
+%1748 = OpCompositeExtract %ushort %1747 6
+OpStore %886 %1748
+%1749 = OpLoad %ushort %885
+%1750 = OpLoad %ushort %886
+%1751 = OpIMul %ushort %1749 %1750
+OpStore %887 %1751
+%1752 = OpLoad %_arr_ushort_uint_8 %706
+%1753 = OpCompositeExtract %ushort %1752 7
+OpStore %888 %1753
+%1754 = OpLoad %_arr_ushort_uint_8 %409
+%1755 = OpCompositeExtract %ushort %1754 7
+OpStore %889 %1755
+%1756 = OpLoad %ushort %888
+%1757 = OpLoad %ushort %889
+%1758 = OpIMul %ushort %1756 %1757
+OpStore %890 %1758
+%1759 = OpLoad %_arr_ushort_uint_8 %706
+%1760 = OpLoad %ushort %869
+%1761 = OpCompositeInsert %_arr_ushort_uint_8 %1760 %1759 0
+OpStore %891 %1761
+%1762 = OpLoad %_arr_ushort_uint_8 %891
+%1763 = OpLoad %ushort %872
+%1764 = OpCompositeInsert %_arr_ushort_uint_8 %1763 %1762 1
+OpStore %892 %1764
+%1765 = OpLoad %_arr_ushort_uint_8 %892
+%1766 = OpLoad %ushort %875
+%1767 = OpCompositeInsert %_arr_ushort_uint_8 %1766 %1765 2
+OpStore %893 %1767
+%1768 = OpLoad %_arr_ushort_uint_8 %893
+%1769 = OpLoad %ushort %878
+%1770 = OpCompositeInsert %_arr_ushort_uint_8 %1769 %1768 3
+OpStore %894 %1770
+%1771 = OpLoad %_arr_ushort_uint_8 %894
+%1772 = OpLoad %ushort %881
+%1773 = OpCompositeInsert %_arr_ushort_uint_8 %1772 %1771 4
+OpStore %895 %1773
+%1774 = OpLoad %_arr_ushort_uint_8 %895
+%1775 = OpLoad %ushort %884
+%1776 = OpCompositeInsert %_arr_ushort_uint_8 %1775 %1774 5
+OpStore %896 %1776
+%1777 = OpLoad %_arr_ushort_uint_8 %896
+%1778 = OpLoad %ushort %887
+%1779 = OpCompositeInsert %_arr_ushort_uint_8 %1778 %1777 6
+OpStore %897 %1779
+%1780 = OpLoad %_arr_ushort_uint_8 %897
+%1781 = OpLoad %ushort %890
+%1782 = OpCompositeInsert %_arr_ushort_uint_8 %1781 %1780 7
+OpStore %898 %1782
+%1783 = OpLoad %ulong %430
+%1784 = OpLoad %_arr_ushort_uint_8 %898
+%1785 = OpFunctionCall %ulong %1 %1783 %1784
+OpStore %431 %1785
+%1786 = OpLoad %_arr_ushort_uint_8 %410
+%1787 = OpCompositeExtract %ushort %1786 0
+OpStore %899 %1787
+%1788 = OpLoad %_arr_ushort_uint_8 %416
+%1789 = OpCompositeExtract %ushort %1788 0
+OpStore %900 %1789
+%1790 = OpLoad %ushort %899
+%1791 = OpLoad %ushort %900
+%1792 = OpISub %ushort %1790 %1791
+OpStore %901 %1792
+%1793 = OpLoad %_arr_ushort_uint_8 %410
+%1794 = OpCompositeExtract %ushort %1793 1
+OpStore %902 %1794
+%1795 = OpLoad %_arr_ushort_uint_8 %416
+%1796 = OpCompositeExtract %ushort %1795 1
+OpStore %903 %1796
+%1797 = OpLoad %ushort %902
+%1798 = OpLoad %ushort %903
+%1799 = OpISub %ushort %1797 %1798
+OpStore %904 %1799
+%1800 = OpLoad %_arr_ushort_uint_8 %410
+%1801 = OpCompositeExtract %ushort %1800 2
+OpStore %905 %1801
+%1802 = OpLoad %_arr_ushort_uint_8 %416
+%1803 = OpCompositeExtract %ushort %1802 2
+OpStore %906 %1803
+%1804 = OpLoad %ushort %905
+%1805 = OpLoad %ushort %906
+%1806 = OpISub %ushort %1804 %1805
+OpStore %907 %1806
+%1807 = OpLoad %_arr_ushort_uint_8 %410
+%1808 = OpCompositeExtract %ushort %1807 3
+OpStore %908 %1808
+%1809 = OpLoad %_arr_ushort_uint_8 %416
+%1810 = OpCompositeExtract %ushort %1809 3
+OpStore %909 %1810
+%1811 = OpLoad %ushort %908
+%1812 = OpLoad %ushort %909
+%1813 = OpISub %ushort %1811 %1812
+OpStore %910 %1813
+%1814 = OpLoad %_arr_ushort_uint_8 %410
+%1815 = OpCompositeExtract %ushort %1814 4
+OpStore %911 %1815
+%1816 = OpLoad %_arr_ushort_uint_8 %416
+%1817 = OpCompositeExtract %ushort %1816 4
+OpStore %912 %1817
+%1818 = OpLoad %ushort %911
+%1819 = OpLoad %ushort %912
+%1820 = OpISub %ushort %1818 %1819
+OpStore %913 %1820
+%1821 = OpLoad %_arr_ushort_uint_8 %410
+%1822 = OpCompositeExtract %ushort %1821 5
+OpStore %914 %1822
+%1823 = OpLoad %_arr_ushort_uint_8 %416
+%1824 = OpCompositeExtract %ushort %1823 5
+OpStore %915 %1824
+%1825 = OpLoad %ushort %914
+%1826 = OpLoad %ushort %915
+%1827 = OpISub %ushort %1825 %1826
+OpStore %916 %1827
+%1828 = OpLoad %_arr_ushort_uint_8 %410
+%1829 = OpCompositeExtract %ushort %1828 6
+OpStore %917 %1829
+%1830 = OpLoad %_arr_ushort_uint_8 %416
+%1831 = OpCompositeExtract %ushort %1830 6
+OpStore %918 %1831
+%1832 = OpLoad %ushort %917
+%1833 = OpLoad %ushort %918
+%1834 = OpISub %ushort %1832 %1833
+OpStore %919 %1834
+%1835 = OpLoad %_arr_ushort_uint_8 %410
+%1836 = OpCompositeExtract %ushort %1835 7
+OpStore %920 %1836
+%1837 = OpLoad %_arr_ushort_uint_8 %416
+%1838 = OpCompositeExtract %ushort %1837 7
+OpStore %921 %1838
+%1839 = OpLoad %ushort %920
+%1840 = OpLoad %ushort %921
+%1841 = OpISub %ushort %1839 %1840
+OpStore %922 %1841
+%1842 = OpLoad %_arr_ushort_uint_8 %410
+%1843 = OpLoad %ushort %901
+%1844 = OpCompositeInsert %_arr_ushort_uint_8 %1843 %1842 0
+OpStore %923 %1844
+%1845 = OpLoad %_arr_ushort_uint_8 %923
+%1846 = OpLoad %ushort %904
+%1847 = OpCompositeInsert %_arr_ushort_uint_8 %1846 %1845 1
+OpStore %924 %1847
+%1848 = OpLoad %_arr_ushort_uint_8 %924
+%1849 = OpLoad %ushort %907
+%1850 = OpCompositeInsert %_arr_ushort_uint_8 %1849 %1848 2
+OpStore %925 %1850
+%1851 = OpLoad %_arr_ushort_uint_8 %925
+%1852 = OpLoad %ushort %910
+%1853 = OpCompositeInsert %_arr_ushort_uint_8 %1852 %1851 3
+OpStore %926 %1853
+%1854 = OpLoad %_arr_ushort_uint_8 %926
+%1855 = OpLoad %ushort %913
+%1856 = OpCompositeInsert %_arr_ushort_uint_8 %1855 %1854 4
+OpStore %927 %1856
+%1857 = OpLoad %_arr_ushort_uint_8 %927
+%1858 = OpLoad %ushort %916
+%1859 = OpCompositeInsert %_arr_ushort_uint_8 %1858 %1857 5
+OpStore %928 %1859
+%1860 = OpLoad %_arr_ushort_uint_8 %928
+%1861 = OpLoad %ushort %919
+%1862 = OpCompositeInsert %_arr_ushort_uint_8 %1861 %1860 6
+OpStore %929 %1862
+%1863 = OpLoad %_arr_ushort_uint_8 %929
+%1864 = OpLoad %ushort %922
+%1865 = OpCompositeInsert %_arr_ushort_uint_8 %1864 %1863 7
+OpStore %930 %1865
+%1866 = OpLoad %ulong %431
+%1867 = OpLoad %_arr_ushort_uint_8 %930
+%1868 = OpFunctionCall %ulong %1 %1866 %1867
+OpStore %432 %1868
+%1869 = OpLoad %_arr_ushort_uint_8 %410
+%1870 = OpCompositeExtract %ushort %1869 0
+OpStore %931 %1870
+%1871 = OpLoad %_arr_ushort_uint_8 %422
+%1872 = OpCompositeExtract %ushort %1871 0
+OpStore %932 %1872
+%1873 = OpLoad %ushort %931
+%1874 = OpLoad %ushort %932
+%1875 = OpISub %ushort %1873 %1874
+OpStore %933 %1875
+%1876 = OpLoad %_arr_ushort_uint_8 %410
+%1877 = OpCompositeExtract %ushort %1876 1
+OpStore %934 %1877
+%1878 = OpLoad %_arr_ushort_uint_8 %422
+%1879 = OpCompositeExtract %ushort %1878 1
+OpStore %935 %1879
+%1880 = OpLoad %ushort %934
+%1881 = OpLoad %ushort %935
+%1882 = OpISub %ushort %1880 %1881
+OpStore %936 %1882
+%1883 = OpLoad %_arr_ushort_uint_8 %410
+%1884 = OpCompositeExtract %ushort %1883 2
+OpStore %937 %1884
+%1885 = OpLoad %_arr_ushort_uint_8 %422
+%1886 = OpCompositeExtract %ushort %1885 2
+OpStore %938 %1886
+%1887 = OpLoad %ushort %937
+%1888 = OpLoad %ushort %938
+%1889 = OpISub %ushort %1887 %1888
+OpStore %939 %1889
+%1890 = OpLoad %_arr_ushort_uint_8 %410
+%1891 = OpCompositeExtract %ushort %1890 3
+OpStore %940 %1891
+%1892 = OpLoad %_arr_ushort_uint_8 %422
+%1893 = OpCompositeExtract %ushort %1892 3
+OpStore %941 %1893
+%1894 = OpLoad %ushort %940
+%1895 = OpLoad %ushort %941
+%1896 = OpISub %ushort %1894 %1895
+OpStore %942 %1896
+%1897 = OpLoad %_arr_ushort_uint_8 %410
+%1898 = OpCompositeExtract %ushort %1897 4
+OpStore %943 %1898
+%1899 = OpLoad %_arr_ushort_uint_8 %422
+%1900 = OpCompositeExtract %ushort %1899 4
+OpStore %944 %1900
+%1901 = OpLoad %ushort %943
+%1902 = OpLoad %ushort %944
+%1903 = OpISub %ushort %1901 %1902
+OpStore %945 %1903
+%1904 = OpLoad %_arr_ushort_uint_8 %410
+%1905 = OpCompositeExtract %ushort %1904 5
+OpStore %946 %1905
+%1906 = OpLoad %_arr_ushort_uint_8 %422
+%1907 = OpCompositeExtract %ushort %1906 5
+OpStore %947 %1907
+%1908 = OpLoad %ushort %946
+%1909 = OpLoad %ushort %947
+%1910 = OpISub %ushort %1908 %1909
+OpStore %948 %1910
+%1911 = OpLoad %_arr_ushort_uint_8 %410
+%1912 = OpCompositeExtract %ushort %1911 6
+OpStore %949 %1912
+%1913 = OpLoad %_arr_ushort_uint_8 %422
+%1914 = OpCompositeExtract %ushort %1913 6
+OpStore %950 %1914
+%1915 = OpLoad %ushort %949
+%1916 = OpLoad %ushort %950
+%1917 = OpISub %ushort %1915 %1916
+OpStore %951 %1917
+%1918 = OpLoad %_arr_ushort_uint_8 %410
+%1919 = OpCompositeExtract %ushort %1918 7
+OpStore %952 %1919
+%1920 = OpLoad %_arr_ushort_uint_8 %422
+%1921 = OpCompositeExtract %ushort %1920 7
+OpStore %953 %1921
+%1922 = OpLoad %ushort %952
+%1923 = OpLoad %ushort %953
+%1924 = OpISub %ushort %1922 %1923
+OpStore %954 %1924
+%1925 = OpLoad %_arr_ushort_uint_8 %410
+%1926 = OpLoad %ushort %933
+%1927 = OpCompositeInsert %_arr_ushort_uint_8 %1926 %1925 0
+OpStore %955 %1927
+%1928 = OpLoad %_arr_ushort_uint_8 %955
+%1929 = OpLoad %ushort %936
+%1930 = OpCompositeInsert %_arr_ushort_uint_8 %1929 %1928 1
+OpStore %956 %1930
+%1931 = OpLoad %_arr_ushort_uint_8 %956
+%1932 = OpLoad %ushort %939
+%1933 = OpCompositeInsert %_arr_ushort_uint_8 %1932 %1931 2
+OpStore %957 %1933
+%1934 = OpLoad %_arr_ushort_uint_8 %957
+%1935 = OpLoad %ushort %942
+%1936 = OpCompositeInsert %_arr_ushort_uint_8 %1935 %1934 3
+OpStore %958 %1936
+%1937 = OpLoad %_arr_ushort_uint_8 %958
+%1938 = OpLoad %ushort %945
+%1939 = OpCompositeInsert %_arr_ushort_uint_8 %1938 %1937 4
+OpStore %959 %1939
+%1940 = OpLoad %_arr_ushort_uint_8 %959
+%1941 = OpLoad %ushort %948
+%1942 = OpCompositeInsert %_arr_ushort_uint_8 %1941 %1940 5
+OpStore %960 %1942
+%1943 = OpLoad %_arr_ushort_uint_8 %960
+%1944 = OpLoad %ushort %951
+%1945 = OpCompositeInsert %_arr_ushort_uint_8 %1944 %1943 6
+OpStore %961 %1945
+%1946 = OpLoad %_arr_ushort_uint_8 %961
+%1947 = OpLoad %ushort %954
+%1948 = OpCompositeInsert %_arr_ushort_uint_8 %1947 %1946 7
+OpStore %962 %1948
+%1949 = OpLoad %ulong %432
+%1950 = OpLoad %_arr_ushort_uint_8 %962
+%1951 = OpFunctionCall %ulong %1 %1949 %1950
+OpStore %433 %1951
+%1952 = OpLoad %_arr_ushort_uint_8 %416
+%1953 = OpCompositeExtract %ushort %1952 0
+OpStore %963 %1953
+%1954 = OpLoad %_arr_ushort_uint_8 %422
+%1955 = OpCompositeExtract %ushort %1954 0
+OpStore %964 %1955
+%1956 = OpLoad %ushort %963
+%1957 = OpLoad %ushort %964
+%1958 = OpBitwiseAnd %ushort %1956 %1957
+OpStore %965 %1958
+%1959 = OpLoad %_arr_ushort_uint_8 %416
+%1960 = OpCompositeExtract %ushort %1959 1
+OpStore %966 %1960
+%1961 = OpLoad %_arr_ushort_uint_8 %422
+%1962 = OpCompositeExtract %ushort %1961 1
+OpStore %967 %1962
+%1963 = OpLoad %ushort %966
+%1964 = OpLoad %ushort %967
+%1965 = OpBitwiseAnd %ushort %1963 %1964
+OpStore %968 %1965
+%1966 = OpLoad %_arr_ushort_uint_8 %416
+%1967 = OpCompositeExtract %ushort %1966 2
+OpStore %969 %1967
+%1968 = OpLoad %_arr_ushort_uint_8 %422
+%1969 = OpCompositeExtract %ushort %1968 2
+OpStore %970 %1969
+%1970 = OpLoad %ushort %969
+%1971 = OpLoad %ushort %970
+%1972 = OpBitwiseAnd %ushort %1970 %1971
+OpStore %971 %1972
+%1973 = OpLoad %_arr_ushort_uint_8 %416
+%1974 = OpCompositeExtract %ushort %1973 3
+OpStore %972 %1974
+%1975 = OpLoad %_arr_ushort_uint_8 %422
+%1976 = OpCompositeExtract %ushort %1975 3
+OpStore %973 %1976
+%1977 = OpLoad %ushort %972
+%1978 = OpLoad %ushort %973
+%1979 = OpBitwiseAnd %ushort %1977 %1978
+OpStore %974 %1979
+%1980 = OpLoad %_arr_ushort_uint_8 %416
+%1981 = OpCompositeExtract %ushort %1980 4
+OpStore %975 %1981
+%1982 = OpLoad %_arr_ushort_uint_8 %422
+%1983 = OpCompositeExtract %ushort %1982 4
+OpStore %976 %1983
+%1984 = OpLoad %ushort %975
+%1985 = OpLoad %ushort %976
+%1986 = OpBitwiseAnd %ushort %1984 %1985
+OpStore %977 %1986
+%1987 = OpLoad %_arr_ushort_uint_8 %416
+%1988 = OpCompositeExtract %ushort %1987 5
+OpStore %978 %1988
+%1989 = OpLoad %_arr_ushort_uint_8 %422
+%1990 = OpCompositeExtract %ushort %1989 5
+OpStore %979 %1990
+%1991 = OpLoad %ushort %978
+%1992 = OpLoad %ushort %979
+%1993 = OpBitwiseAnd %ushort %1991 %1992
+OpStore %980 %1993
+%1994 = OpLoad %_arr_ushort_uint_8 %416
+%1995 = OpCompositeExtract %ushort %1994 6
+OpStore %981 %1995
+%1996 = OpLoad %_arr_ushort_uint_8 %422
+%1997 = OpCompositeExtract %ushort %1996 6
+OpStore %982 %1997
+%1998 = OpLoad %ushort %981
+%1999 = OpLoad %ushort %982
+%2000 = OpBitwiseAnd %ushort %1998 %1999
+OpStore %983 %2000
+%2001 = OpLoad %_arr_ushort_uint_8 %416
+%2002 = OpCompositeExtract %ushort %2001 7
+OpStore %984 %2002
+%2003 = OpLoad %_arr_ushort_uint_8 %422
+%2004 = OpCompositeExtract %ushort %2003 7
+OpStore %985 %2004
+%2005 = OpLoad %ushort %984
+%2006 = OpLoad %ushort %985
+%2007 = OpBitwiseAnd %ushort %2005 %2006
+OpStore %986 %2007
+%2008 = OpLoad %_arr_ushort_uint_8 %416
+%2009 = OpLoad %ushort %965
+%2010 = OpCompositeInsert %_arr_ushort_uint_8 %2009 %2008 0
+OpStore %987 %2010
+%2011 = OpLoad %_arr_ushort_uint_8 %987
+%2012 = OpLoad %ushort %968
+%2013 = OpCompositeInsert %_arr_ushort_uint_8 %2012 %2011 1
+OpStore %988 %2013
+%2014 = OpLoad %_arr_ushort_uint_8 %988
+%2015 = OpLoad %ushort %971
+%2016 = OpCompositeInsert %_arr_ushort_uint_8 %2015 %2014 2
+OpStore %989 %2016
+%2017 = OpLoad %_arr_ushort_uint_8 %989
+%2018 = OpLoad %ushort %974
+%2019 = OpCompositeInsert %_arr_ushort_uint_8 %2018 %2017 3
+OpStore %990 %2019
+%2020 = OpLoad %_arr_ushort_uint_8 %990
+%2021 = OpLoad %ushort %977
+%2022 = OpCompositeInsert %_arr_ushort_uint_8 %2021 %2020 4
+OpStore %991 %2022
+%2023 = OpLoad %_arr_ushort_uint_8 %991
+%2024 = OpLoad %ushort %980
+%2025 = OpCompositeInsert %_arr_ushort_uint_8 %2024 %2023 5
+OpStore %992 %2025
+%2026 = OpLoad %_arr_ushort_uint_8 %992
+%2027 = OpLoad %ushort %983
+%2028 = OpCompositeInsert %_arr_ushort_uint_8 %2027 %2026 6
+OpStore %993 %2028
+%2029 = OpLoad %_arr_ushort_uint_8 %993
+%2030 = OpLoad %ushort %986
+%2031 = OpCompositeInsert %_arr_ushort_uint_8 %2030 %2029 7
+OpStore %994 %2031
+%2032 = OpLoad %ulong %433
+%2033 = OpLoad %_arr_ushort_uint_8 %994
+%2034 = OpFunctionCall %ulong %1 %2032 %2033
+OpStore %434 %2034
+%2035 = OpLoad %_arr_ushort_uint_8 %416
+%2036 = OpCompositeExtract %ushort %2035 0
+OpStore %995 %2036
+%2037 = OpLoad %_arr_ushort_uint_8 %422
+%2038 = OpCompositeExtract %ushort %2037 0
+OpStore %996 %2038
+%2039 = OpLoad %ushort %995
+%2040 = OpLoad %ushort %996
+%2041 = OpBitwiseOr %ushort %2039 %2040
+OpStore %997 %2041
+%2042 = OpLoad %_arr_ushort_uint_8 %416
+%2043 = OpCompositeExtract %ushort %2042 1
+OpStore %998 %2043
+%2044 = OpLoad %_arr_ushort_uint_8 %422
+%2045 = OpCompositeExtract %ushort %2044 1
+OpStore %999 %2045
+%2046 = OpLoad %ushort %998
+%2047 = OpLoad %ushort %999
+%2048 = OpBitwiseOr %ushort %2046 %2047
+OpStore %1000 %2048
+%2049 = OpLoad %_arr_ushort_uint_8 %416
+%2050 = OpCompositeExtract %ushort %2049 2
+OpStore %1001 %2050
+%2051 = OpLoad %_arr_ushort_uint_8 %422
+%2052 = OpCompositeExtract %ushort %2051 2
+OpStore %1002 %2052
+%2053 = OpLoad %ushort %1001
+%2054 = OpLoad %ushort %1002
+%2055 = OpBitwiseOr %ushort %2053 %2054
+OpStore %1003 %2055
+%2056 = OpLoad %_arr_ushort_uint_8 %416
+%2057 = OpCompositeExtract %ushort %2056 3
+OpStore %1004 %2057
+%2058 = OpLoad %_arr_ushort_uint_8 %422
+%2059 = OpCompositeExtract %ushort %2058 3
+OpStore %1005 %2059
+%2060 = OpLoad %ushort %1004
+%2061 = OpLoad %ushort %1005
+%2062 = OpBitwiseOr %ushort %2060 %2061
+OpStore %1006 %2062
+%2063 = OpLoad %_arr_ushort_uint_8 %416
+%2064 = OpCompositeExtract %ushort %2063 4
+OpStore %1007 %2064
+%2065 = OpLoad %_arr_ushort_uint_8 %422
+%2066 = OpCompositeExtract %ushort %2065 4
+OpStore %1008 %2066
+%2067 = OpLoad %ushort %1007
+%2068 = OpLoad %ushort %1008
+%2069 = OpBitwiseOr %ushort %2067 %2068
+OpStore %1009 %2069
+%2070 = OpLoad %_arr_ushort_uint_8 %416
+%2071 = OpCompositeExtract %ushort %2070 5
+OpStore %1010 %2071
+%2072 = OpLoad %_arr_ushort_uint_8 %422
+%2073 = OpCompositeExtract %ushort %2072 5
+OpStore %1011 %2073
+%2074 = OpLoad %ushort %1010
+%2075 = OpLoad %ushort %1011
+%2076 = OpBitwiseOr %ushort %2074 %2075
+OpStore %1012 %2076
+%2077 = OpLoad %_arr_ushort_uint_8 %416
+%2078 = OpCompositeExtract %ushort %2077 6
+OpStore %1013 %2078
+%2079 = OpLoad %_arr_ushort_uint_8 %422
+%2080 = OpCompositeExtract %ushort %2079 6
+OpStore %1014 %2080
+%2081 = OpLoad %ushort %1013
+%2082 = OpLoad %ushort %1014
+%2083 = OpBitwiseOr %ushort %2081 %2082
+OpStore %1015 %2083
+%2084 = OpLoad %_arr_ushort_uint_8 %416
+%2085 = OpCompositeExtract %ushort %2084 7
+OpStore %1016 %2085
+%2086 = OpLoad %_arr_ushort_uint_8 %422
+%2087 = OpCompositeExtract %ushort %2086 7
+OpStore %1017 %2087
+%2088 = OpLoad %ushort %1016
+%2089 = OpLoad %ushort %1017
+%2090 = OpBitwiseOr %ushort %2088 %2089
+OpStore %1018 %2090
+%2091 = OpLoad %_arr_ushort_uint_8 %416
+%2092 = OpLoad %ushort %997
+%2093 = OpCompositeInsert %_arr_ushort_uint_8 %2092 %2091 0
+OpStore %1019 %2093
+%2094 = OpLoad %_arr_ushort_uint_8 %1019
+%2095 = OpLoad %ushort %1000
+%2096 = OpCompositeInsert %_arr_ushort_uint_8 %2095 %2094 1
+OpStore %1020 %2096
+%2097 = OpLoad %_arr_ushort_uint_8 %1020
+%2098 = OpLoad %ushort %1003
+%2099 = OpCompositeInsert %_arr_ushort_uint_8 %2098 %2097 2
+OpStore %1021 %2099
+%2100 = OpLoad %_arr_ushort_uint_8 %1021
+%2101 = OpLoad %ushort %1006
+%2102 = OpCompositeInsert %_arr_ushort_uint_8 %2101 %2100 3
+OpStore %1022 %2102
+%2103 = OpLoad %_arr_ushort_uint_8 %1022
+%2104 = OpLoad %ushort %1009
+%2105 = OpCompositeInsert %_arr_ushort_uint_8 %2104 %2103 4
+OpStore %1023 %2105
+%2106 = OpLoad %_arr_ushort_uint_8 %1023
+%2107 = OpLoad %ushort %1012
+%2108 = OpCompositeInsert %_arr_ushort_uint_8 %2107 %2106 5
+OpStore %1024 %2108
+%2109 = OpLoad %_arr_ushort_uint_8 %1024
+%2110 = OpLoad %ushort %1015
+%2111 = OpCompositeInsert %_arr_ushort_uint_8 %2110 %2109 6
+OpStore %1025 %2111
+%2112 = OpLoad %_arr_ushort_uint_8 %1025
+%2113 = OpLoad %ushort %1018
+%2114 = OpCompositeInsert %_arr_ushort_uint_8 %2113 %2112 7
+OpStore %1026 %2114
+%2115 = OpLoad %ulong %434
+%2116 = OpLoad %_arr_ushort_uint_8 %1026
+%2117 = OpFunctionCall %ulong %1 %2115 %2116
+OpStore %435 %2117
+%2118 = OpLoad %_arr_ushort_uint_8 %416
+%2119 = OpCompositeExtract %ushort %2118 0
+OpStore %1027 %2119
+%2120 = OpLoad %_arr_ushort_uint_8 %422
+%2121 = OpCompositeExtract %ushort %2120 0
+OpStore %1028 %2121
+%2122 = OpLoad %ushort %1027
+%2123 = OpLoad %ushort %1028
+%2124 = OpBitwiseXor %ushort %2122 %2123
+OpStore %1029 %2124
+%2125 = OpLoad %_arr_ushort_uint_8 %416
+%2126 = OpCompositeExtract %ushort %2125 1
+OpStore %1030 %2126
+%2127 = OpLoad %_arr_ushort_uint_8 %422
+%2128 = OpCompositeExtract %ushort %2127 1
+OpStore %1031 %2128
+%2129 = OpLoad %ushort %1030
+%2130 = OpLoad %ushort %1031
+%2131 = OpBitwiseXor %ushort %2129 %2130
+OpStore %1032 %2131
+%2132 = OpLoad %_arr_ushort_uint_8 %416
+%2133 = OpCompositeExtract %ushort %2132 2
+OpStore %1033 %2133
+%2134 = OpLoad %_arr_ushort_uint_8 %422
+%2135 = OpCompositeExtract %ushort %2134 2
+OpStore %1034 %2135
+%2136 = OpLoad %ushort %1033
+%2137 = OpLoad %ushort %1034
+%2138 = OpBitwiseXor %ushort %2136 %2137
+OpStore %1035 %2138
+%2139 = OpLoad %_arr_ushort_uint_8 %416
+%2140 = OpCompositeExtract %ushort %2139 3
+OpStore %1036 %2140
+%2141 = OpLoad %_arr_ushort_uint_8 %422
+%2142 = OpCompositeExtract %ushort %2141 3
+OpStore %1037 %2142
+%2143 = OpLoad %ushort %1036
+%2144 = OpLoad %ushort %1037
+%2145 = OpBitwiseXor %ushort %2143 %2144
+OpStore %1038 %2145
+%2146 = OpLoad %_arr_ushort_uint_8 %416
+%2147 = OpCompositeExtract %ushort %2146 4
+OpStore %1039 %2147
+%2148 = OpLoad %_arr_ushort_uint_8 %422
+%2149 = OpCompositeExtract %ushort %2148 4
+OpStore %1040 %2149
+%2150 = OpLoad %ushort %1039
+%2151 = OpLoad %ushort %1040
+%2152 = OpBitwiseXor %ushort %2150 %2151
+OpStore %1041 %2152
+%2153 = OpLoad %_arr_ushort_uint_8 %416
+%2154 = OpCompositeExtract %ushort %2153 5
+OpStore %1042 %2154
+%2155 = OpLoad %_arr_ushort_uint_8 %422
+%2156 = OpCompositeExtract %ushort %2155 5
+OpStore %1043 %2156
+%2157 = OpLoad %ushort %1042
+%2158 = OpLoad %ushort %1043
+%2159 = OpBitwiseXor %ushort %2157 %2158
+OpStore %1044 %2159
+%2160 = OpLoad %_arr_ushort_uint_8 %416
+%2161 = OpCompositeExtract %ushort %2160 6
+OpStore %1045 %2161
+%2162 = OpLoad %_arr_ushort_uint_8 %422
+%2163 = OpCompositeExtract %ushort %2162 6
+OpStore %1046 %2163
+%2164 = OpLoad %ushort %1045
+%2165 = OpLoad %ushort %1046
+%2166 = OpBitwiseXor %ushort %2164 %2165
+OpStore %1047 %2166
+%2167 = OpLoad %_arr_ushort_uint_8 %416
+%2168 = OpCompositeExtract %ushort %2167 7
+OpStore %1048 %2168
+%2169 = OpLoad %_arr_ushort_uint_8 %422
+%2170 = OpCompositeExtract %ushort %2169 7
+OpStore %1049 %2170
+%2171 = OpLoad %ushort %1048
+%2172 = OpLoad %ushort %1049
+%2173 = OpBitwiseXor %ushort %2171 %2172
+OpStore %1050 %2173
+%2174 = OpLoad %_arr_ushort_uint_8 %416
+%2175 = OpLoad %ushort %1029
+%2176 = OpCompositeInsert %_arr_ushort_uint_8 %2175 %2174 0
+OpStore %1051 %2176
+%2177 = OpLoad %_arr_ushort_uint_8 %1051
+%2178 = OpLoad %ushort %1032
+%2179 = OpCompositeInsert %_arr_ushort_uint_8 %2178 %2177 1
+OpStore %1052 %2179
+%2180 = OpLoad %_arr_ushort_uint_8 %1052
+%2181 = OpLoad %ushort %1035
+%2182 = OpCompositeInsert %_arr_ushort_uint_8 %2181 %2180 2
+OpStore %1053 %2182
+%2183 = OpLoad %_arr_ushort_uint_8 %1053
+%2184 = OpLoad %ushort %1038
+%2185 = OpCompositeInsert %_arr_ushort_uint_8 %2184 %2183 3
+OpStore %1054 %2185
+%2186 = OpLoad %_arr_ushort_uint_8 %1054
+%2187 = OpLoad %ushort %1041
+%2188 = OpCompositeInsert %_arr_ushort_uint_8 %2187 %2186 4
+OpStore %1055 %2188
+%2189 = OpLoad %_arr_ushort_uint_8 %1055
+%2190 = OpLoad %ushort %1044
+%2191 = OpCompositeInsert %_arr_ushort_uint_8 %2190 %2189 5
+OpStore %1056 %2191
+%2192 = OpLoad %_arr_ushort_uint_8 %1056
+%2193 = OpLoad %ushort %1047
+%2194 = OpCompositeInsert %_arr_ushort_uint_8 %2193 %2192 6
+OpStore %1057 %2194
+%2195 = OpLoad %_arr_ushort_uint_8 %1057
+%2196 = OpLoad %ushort %1050
+%2197 = OpCompositeInsert %_arr_ushort_uint_8 %2196 %2195 7
+OpStore %1058 %2197
+%2198 = OpLoad %ulong %435
+%2199 = OpLoad %_arr_ushort_uint_8 %1058
+%2200 = OpFunctionCall %ulong %1 %2198 %2199
+OpStore %436 %2200
+%2201 = OpLoad %_arr_ushort_uint_8 %416
+%2202 = OpCompositeExtract %ushort %2201 0
+OpStore %1059 %2202
+%2203 = OpLoad %ushort %1059
+%2204 = OpNot %ushort %2203
+OpStore %1060 %2204
+%2205 = OpLoad %_arr_ushort_uint_8 %416
+%2206 = OpCompositeExtract %ushort %2205 1
+OpStore %1061 %2206
+%2207 = OpLoad %ushort %1061
+%2208 = OpNot %ushort %2207
+OpStore %1062 %2208
+%2209 = OpLoad %_arr_ushort_uint_8 %416
+%2210 = OpCompositeExtract %ushort %2209 2
+OpStore %1063 %2210
+%2211 = OpLoad %ushort %1063
+%2212 = OpNot %ushort %2211
+OpStore %1064 %2212
+%2213 = OpLoad %_arr_ushort_uint_8 %416
+%2214 = OpCompositeExtract %ushort %2213 3
+OpStore %1065 %2214
+%2215 = OpLoad %ushort %1065
+%2216 = OpNot %ushort %2215
+OpStore %1066 %2216
+%2217 = OpLoad %_arr_ushort_uint_8 %416
+%2218 = OpCompositeExtract %ushort %2217 4
+OpStore %1067 %2218
+%2219 = OpLoad %ushort %1067
+%2220 = OpNot %ushort %2219
+OpStore %1068 %2220
+%2221 = OpLoad %_arr_ushort_uint_8 %416
+%2222 = OpCompositeExtract %ushort %2221 5
+OpStore %1069 %2222
+%2223 = OpLoad %ushort %1069
+%2224 = OpNot %ushort %2223
+OpStore %1070 %2224
+%2225 = OpLoad %_arr_ushort_uint_8 %416
+%2226 = OpCompositeExtract %ushort %2225 6
+OpStore %1071 %2226
+%2227 = OpLoad %ushort %1071
+%2228 = OpNot %ushort %2227
+OpStore %1072 %2228
+%2229 = OpLoad %_arr_ushort_uint_8 %416
+%2230 = OpCompositeExtract %ushort %2229 7
+OpStore %1073 %2230
+%2231 = OpLoad %ushort %1073
+%2232 = OpNot %ushort %2231
+OpStore %1074 %2232
+%2233 = OpLoad %_arr_ushort_uint_8 %416
+%2234 = OpLoad %ushort %1060
+%2235 = OpCompositeInsert %_arr_ushort_uint_8 %2234 %2233 0
+OpStore %1075 %2235
+%2236 = OpLoad %_arr_ushort_uint_8 %1075
+%2237 = OpLoad %ushort %1062
+%2238 = OpCompositeInsert %_arr_ushort_uint_8 %2237 %2236 1
+OpStore %1076 %2238
+%2239 = OpLoad %_arr_ushort_uint_8 %1076
+%2240 = OpLoad %ushort %1064
+%2241 = OpCompositeInsert %_arr_ushort_uint_8 %2240 %2239 2
+OpStore %1077 %2241
+%2242 = OpLoad %_arr_ushort_uint_8 %1077
+%2243 = OpLoad %ushort %1066
+%2244 = OpCompositeInsert %_arr_ushort_uint_8 %2243 %2242 3
+OpStore %1078 %2244
+%2245 = OpLoad %_arr_ushort_uint_8 %1078
+%2246 = OpLoad %ushort %1068
+%2247 = OpCompositeInsert %_arr_ushort_uint_8 %2246 %2245 4
+OpStore %1079 %2247
+%2248 = OpLoad %_arr_ushort_uint_8 %1079
+%2249 = OpLoad %ushort %1070
+%2250 = OpCompositeInsert %_arr_ushort_uint_8 %2249 %2248 5
+OpStore %1080 %2250
+%2251 = OpLoad %_arr_ushort_uint_8 %1080
+%2252 = OpLoad %ushort %1072
+%2253 = OpCompositeInsert %_arr_ushort_uint_8 %2252 %2251 6
+OpStore %1081 %2253
+%2254 = OpLoad %_arr_ushort_uint_8 %1081
+%2255 = OpLoad %ushort %1074
+%2256 = OpCompositeInsert %_arr_ushort_uint_8 %2255 %2254 7
+OpStore %1082 %2256
+%2257 = OpLoad %ulong %436
+%2258 = OpLoad %_arr_ushort_uint_8 %1082
+%2259 = OpFunctionCall %ulong %1 %2257 %2258
+OpStore %437 %2259
+%2260 = OpLoad %_arr_ushort_uint_8 %422
+%2261 = OpCompositeExtract %ushort %2260 0
+OpStore %1083 %2261
+%2262 = OpLoad %ushort %1083
+%2263 = OpNot %ushort %2262
+OpStore %1084 %2263
+%2264 = OpLoad %_arr_ushort_uint_8 %422
 %2265 = OpCompositeExtract %ushort %2264 1
-OpStore %416 %2265
-%2266 = OpLoad %ulong %415
-%2267 = OpLoad %ushort %416
-%2268 = OpFunctionCall %ulong %4 %2266 %2267
-OpStore %417 %2268
-%2269 = OpLoad %_arr_ushort_uint_8 %909
-%2270 = OpCompositeExtract %ushort %2269 2
-OpStore %418 %2270
-%2271 = OpLoad %ulong %417
-%2272 = OpLoad %ushort %418
-%2273 = OpFunctionCall %ulong %4 %2271 %2272
-OpStore %419 %2273
-%2274 = OpLoad %_arr_ushort_uint_8 %909
-%2275 = OpCompositeExtract %ushort %2274 3
-OpStore %420 %2275
-%2276 = OpLoad %ulong %419
-%2277 = OpLoad %ushort %420
-%2278 = OpFunctionCall %ulong %4 %2276 %2277
-OpStore %421 %2278
-%2279 = OpLoad %_arr_ushort_uint_8 %909
-%2280 = OpCompositeExtract %ushort %2279 4
-OpStore %422 %2280
-%2281 = OpLoad %ulong %421
-%2282 = OpLoad %ushort %422
-%2283 = OpFunctionCall %ulong %4 %2281 %2282
-OpStore %423 %2283
-%2284 = OpLoad %_arr_ushort_uint_8 %909
-%2285 = OpCompositeExtract %ushort %2284 5
-OpStore %424 %2285
-%2286 = OpLoad %ulong %423
-%2287 = OpLoad %ushort %424
-%2288 = OpFunctionCall %ulong %4 %2286 %2287
-OpStore %425 %2288
-%2289 = OpLoad %_arr_ushort_uint_8 %909
-%2290 = OpCompositeExtract %ushort %2289 6
-OpStore %426 %2290
-%2291 = OpLoad %ulong %425
-%2292 = OpLoad %ushort %426
-%2293 = OpFunctionCall %ulong %4 %2291 %2292
-OpStore %427 %2293
-%2294 = OpLoad %_arr_ushort_uint_8 %909
-%2295 = OpCompositeExtract %ushort %2294 7
-OpStore %428 %2295
-%2296 = OpLoad %ulong %427
-%2297 = OpLoad %ushort %428
-%2298 = OpFunctionCall %ulong %4 %2296 %2297
-OpStore %429 %2298
-OpBranch %117
-%117 = OpLabel
-%2299 = OpLoad %_arr_ushort_uint_8 %134
-%2300 = OpCompositeExtract %ushort %2299 0
-OpStore %910 %2300
-%2301 = OpLoad %_arr_ushort_uint_8 %146
-%2302 = OpCompositeExtract %ushort %2301 0
-OpStore %911 %2302
-%2303 = OpLoad %ushort %910
-%2304 = OpLoad %ushort %911
-%2305 = OpISub %ushort %2303 %2304
-OpStore %912 %2305
-%2306 = OpLoad %_arr_ushort_uint_8 %134
-%2307 = OpCompositeExtract %ushort %2306 1
-OpStore %913 %2307
-%2308 = OpLoad %_arr_ushort_uint_8 %146
-%2309 = OpCompositeExtract %ushort %2308 1
-OpStore %914 %2309
-%2310 = OpLoad %ushort %913
-%2311 = OpLoad %ushort %914
-%2312 = OpISub %ushort %2310 %2311
-OpStore %915 %2312
-%2313 = OpLoad %_arr_ushort_uint_8 %134
-%2314 = OpCompositeExtract %ushort %2313 2
-OpStore %916 %2314
-%2315 = OpLoad %_arr_ushort_uint_8 %146
-%2316 = OpCompositeExtract %ushort %2315 2
-OpStore %917 %2316
-%2317 = OpLoad %ushort %916
-%2318 = OpLoad %ushort %917
-%2319 = OpISub %ushort %2317 %2318
-OpStore %918 %2319
-%2320 = OpLoad %_arr_ushort_uint_8 %134
-%2321 = OpCompositeExtract %ushort %2320 3
-OpStore %919 %2321
-%2322 = OpLoad %_arr_ushort_uint_8 %146
-%2323 = OpCompositeExtract %ushort %2322 3
-OpStore %920 %2323
-%2324 = OpLoad %ushort %919
-%2325 = OpLoad %ushort %920
-%2326 = OpISub %ushort %2324 %2325
-OpStore %921 %2326
-%2327 = OpLoad %_arr_ushort_uint_8 %134
-%2328 = OpCompositeExtract %ushort %2327 4
-OpStore %922 %2328
-%2329 = OpLoad %_arr_ushort_uint_8 %146
-%2330 = OpCompositeExtract %ushort %2329 4
-OpStore %923 %2330
-%2331 = OpLoad %ushort %922
-%2332 = OpLoad %ushort %923
-%2333 = OpISub %ushort %2331 %2332
-OpStore %924 %2333
-%2334 = OpLoad %_arr_ushort_uint_8 %134
-%2335 = OpCompositeExtract %ushort %2334 5
-OpStore %925 %2335
-%2336 = OpLoad %_arr_ushort_uint_8 %146
-%2337 = OpCompositeExtract %ushort %2336 5
-OpStore %926 %2337
-%2338 = OpLoad %ushort %925
-%2339 = OpLoad %ushort %926
-%2340 = OpISub %ushort %2338 %2339
-OpStore %927 %2340
-%2341 = OpLoad %_arr_ushort_uint_8 %134
-%2342 = OpCompositeExtract %ushort %2341 6
-OpStore %928 %2342
-%2343 = OpLoad %_arr_ushort_uint_8 %146
-%2344 = OpCompositeExtract %ushort %2343 6
-OpStore %929 %2344
-%2345 = OpLoad %ushort %928
-%2346 = OpLoad %ushort %929
-%2347 = OpISub %ushort %2345 %2346
-OpStore %930 %2347
-%2348 = OpLoad %_arr_ushort_uint_8 %134
-%2349 = OpCompositeExtract %ushort %2348 7
-OpStore %931 %2349
-%2350 = OpLoad %_arr_ushort_uint_8 %146
-%2351 = OpCompositeExtract %ushort %2350 7
-OpStore %932 %2351
-%2352 = OpLoad %ushort %931
-%2353 = OpLoad %ushort %932
-%2354 = OpISub %ushort %2352 %2353
-OpStore %933 %2354
-%2355 = OpLoad %_arr_ushort_uint_8 %134
-%2356 = OpLoad %ushort %912
-%2357 = OpCompositeInsert %_arr_ushort_uint_8 %2356 %2355 0
-OpStore %934 %2357
-%2358 = OpLoad %_arr_ushort_uint_8 %934
-%2359 = OpLoad %ushort %915
-%2360 = OpCompositeInsert %_arr_ushort_uint_8 %2359 %2358 1
-OpStore %935 %2360
-%2361 = OpLoad %_arr_ushort_uint_8 %935
-%2362 = OpLoad %ushort %918
-%2363 = OpCompositeInsert %_arr_ushort_uint_8 %2362 %2361 2
-OpStore %936 %2363
-%2364 = OpLoad %_arr_ushort_uint_8 %936
-%2365 = OpLoad %ushort %921
-%2366 = OpCompositeInsert %_arr_ushort_uint_8 %2365 %2364 3
-OpStore %937 %2366
-%2367 = OpLoad %_arr_ushort_uint_8 %937
-%2368 = OpLoad %ushort %924
-%2369 = OpCompositeInsert %_arr_ushort_uint_8 %2368 %2367 4
-OpStore %938 %2369
-%2370 = OpLoad %_arr_ushort_uint_8 %938
-%2371 = OpLoad %ushort %927
-%2372 = OpCompositeInsert %_arr_ushort_uint_8 %2371 %2370 5
-OpStore %939 %2372
-%2373 = OpLoad %_arr_ushort_uint_8 %939
-%2374 = OpLoad %ushort %930
-%2375 = OpCompositeInsert %_arr_ushort_uint_8 %2374 %2373 6
-OpStore %940 %2375
-%2376 = OpLoad %_arr_ushort_uint_8 %940
-%2377 = OpLoad %ushort %933
-%2378 = OpCompositeInsert %_arr_ushort_uint_8 %2377 %2376 7
-OpStore %941 %2378
-%2379 = OpLoad %ulong %429
-%2380 = OpLoad %_arr_ushort_uint_8 %941
-%2381 = OpFunctionCall %ulong %1 %2379 %2380
-OpStore %147 %2381
-%2382 = OpLoad %_arr_ushort_uint_8 %140
-%2383 = OpCompositeExtract %ushort %2382 0
-OpStore %942 %2383
-%2384 = OpLoad %_arr_ushort_uint_8 %146
-%2385 = OpCompositeExtract %ushort %2384 0
-OpStore %943 %2385
-%2386 = OpLoad %ushort %942
-%2387 = OpLoad %ushort %943
-%2388 = OpBitwiseAnd %ushort %2386 %2387
-OpStore %944 %2388
-%2389 = OpLoad %_arr_ushort_uint_8 %140
-%2390 = OpCompositeExtract %ushort %2389 1
-OpStore %945 %2390
-%2391 = OpLoad %_arr_ushort_uint_8 %146
-%2392 = OpCompositeExtract %ushort %2391 1
-OpStore %946 %2392
-%2393 = OpLoad %ushort %945
-%2394 = OpLoad %ushort %946
-%2395 = OpBitwiseAnd %ushort %2393 %2394
-OpStore %947 %2395
-%2396 = OpLoad %_arr_ushort_uint_8 %140
-%2397 = OpCompositeExtract %ushort %2396 2
-OpStore %948 %2397
-%2398 = OpLoad %_arr_ushort_uint_8 %146
-%2399 = OpCompositeExtract %ushort %2398 2
-OpStore %949 %2399
-%2400 = OpLoad %ushort %948
-%2401 = OpLoad %ushort %949
-%2402 = OpBitwiseAnd %ushort %2400 %2401
-OpStore %950 %2402
-%2403 = OpLoad %_arr_ushort_uint_8 %140
-%2404 = OpCompositeExtract %ushort %2403 3
-OpStore %951 %2404
-%2405 = OpLoad %_arr_ushort_uint_8 %146
-%2406 = OpCompositeExtract %ushort %2405 3
-OpStore %952 %2406
-%2407 = OpLoad %ushort %951
-%2408 = OpLoad %ushort %952
-%2409 = OpBitwiseAnd %ushort %2407 %2408
-OpStore %953 %2409
-%2410 = OpLoad %_arr_ushort_uint_8 %140
-%2411 = OpCompositeExtract %ushort %2410 4
-OpStore %954 %2411
-%2412 = OpLoad %_arr_ushort_uint_8 %146
-%2413 = OpCompositeExtract %ushort %2412 4
-OpStore %955 %2413
-%2414 = OpLoad %ushort %954
-%2415 = OpLoad %ushort %955
-%2416 = OpBitwiseAnd %ushort %2414 %2415
-OpStore %956 %2416
-%2417 = OpLoad %_arr_ushort_uint_8 %140
-%2418 = OpCompositeExtract %ushort %2417 5
-OpStore %957 %2418
-%2419 = OpLoad %_arr_ushort_uint_8 %146
-%2420 = OpCompositeExtract %ushort %2419 5
-OpStore %958 %2420
-%2421 = OpLoad %ushort %957
-%2422 = OpLoad %ushort %958
-%2423 = OpBitwiseAnd %ushort %2421 %2422
-OpStore %959 %2423
-%2424 = OpLoad %_arr_ushort_uint_8 %140
-%2425 = OpCompositeExtract %ushort %2424 6
-OpStore %960 %2425
-%2426 = OpLoad %_arr_ushort_uint_8 %146
-%2427 = OpCompositeExtract %ushort %2426 6
-OpStore %961 %2427
-%2428 = OpLoad %ushort %960
-%2429 = OpLoad %ushort %961
-%2430 = OpBitwiseAnd %ushort %2428 %2429
-OpStore %962 %2430
-%2431 = OpLoad %_arr_ushort_uint_8 %140
-%2432 = OpCompositeExtract %ushort %2431 7
-OpStore %963 %2432
-%2433 = OpLoad %_arr_ushort_uint_8 %146
-%2434 = OpCompositeExtract %ushort %2433 7
-OpStore %964 %2434
-%2435 = OpLoad %ushort %963
-%2436 = OpLoad %ushort %964
-%2437 = OpBitwiseAnd %ushort %2435 %2436
-OpStore %965 %2437
-%2438 = OpLoad %_arr_ushort_uint_8 %140
-%2439 = OpLoad %ushort %944
-%2440 = OpCompositeInsert %_arr_ushort_uint_8 %2439 %2438 0
-OpStore %966 %2440
-%2441 = OpLoad %_arr_ushort_uint_8 %966
-%2442 = OpLoad %ushort %947
-%2443 = OpCompositeInsert %_arr_ushort_uint_8 %2442 %2441 1
-OpStore %967 %2443
-%2444 = OpLoad %_arr_ushort_uint_8 %967
-%2445 = OpLoad %ushort %950
-%2446 = OpCompositeInsert %_arr_ushort_uint_8 %2445 %2444 2
-OpStore %968 %2446
-%2447 = OpLoad %_arr_ushort_uint_8 %968
-%2448 = OpLoad %ushort %953
-%2449 = OpCompositeInsert %_arr_ushort_uint_8 %2448 %2447 3
-OpStore %969 %2449
-%2450 = OpLoad %_arr_ushort_uint_8 %969
-%2451 = OpLoad %ushort %956
-%2452 = OpCompositeInsert %_arr_ushort_uint_8 %2451 %2450 4
-OpStore %970 %2452
-%2453 = OpLoad %_arr_ushort_uint_8 %970
-%2454 = OpLoad %ushort %959
-%2455 = OpCompositeInsert %_arr_ushort_uint_8 %2454 %2453 5
-OpStore %971 %2455
-%2456 = OpLoad %_arr_ushort_uint_8 %971
-%2457 = OpLoad %ushort %962
-%2458 = OpCompositeInsert %_arr_ushort_uint_8 %2457 %2456 6
-OpStore %972 %2458
-%2459 = OpLoad %_arr_ushort_uint_8 %972
-%2460 = OpLoad %ushort %965
-%2461 = OpCompositeInsert %_arr_ushort_uint_8 %2460 %2459 7
-OpStore %973 %2461
-%2462 = OpLoad %ulong %147
-%2463 = OpLoad %_arr_ushort_uint_8 %973
-%2464 = OpFunctionCall %ulong %1 %2462 %2463
-OpStore %148 %2464
-%2465 = OpLoad %_arr_ushort_uint_8 %140
-%2466 = OpCompositeExtract %ushort %2465 0
-OpStore %974 %2466
-%2467 = OpLoad %_arr_ushort_uint_8 %146
-%2468 = OpCompositeExtract %ushort %2467 0
-OpStore %975 %2468
-%2469 = OpLoad %ushort %974
-%2470 = OpLoad %ushort %975
-%2471 = OpBitwiseOr %ushort %2469 %2470
-OpStore %976 %2471
-%2472 = OpLoad %_arr_ushort_uint_8 %140
-%2473 = OpCompositeExtract %ushort %2472 1
-OpStore %977 %2473
-%2474 = OpLoad %_arr_ushort_uint_8 %146
-%2475 = OpCompositeExtract %ushort %2474 1
-OpStore %978 %2475
-%2476 = OpLoad %ushort %977
-%2477 = OpLoad %ushort %978
-%2478 = OpBitwiseOr %ushort %2476 %2477
-OpStore %979 %2478
-%2479 = OpLoad %_arr_ushort_uint_8 %140
-%2480 = OpCompositeExtract %ushort %2479 2
-OpStore %980 %2480
-%2481 = OpLoad %_arr_ushort_uint_8 %146
-%2482 = OpCompositeExtract %ushort %2481 2
-OpStore %981 %2482
-%2483 = OpLoad %ushort %980
-%2484 = OpLoad %ushort %981
-%2485 = OpBitwiseOr %ushort %2483 %2484
-OpStore %982 %2485
-%2486 = OpLoad %_arr_ushort_uint_8 %140
-%2487 = OpCompositeExtract %ushort %2486 3
-OpStore %983 %2487
-%2488 = OpLoad %_arr_ushort_uint_8 %146
-%2489 = OpCompositeExtract %ushort %2488 3
-OpStore %984 %2489
-%2490 = OpLoad %ushort %983
-%2491 = OpLoad %ushort %984
-%2492 = OpBitwiseOr %ushort %2490 %2491
-OpStore %985 %2492
-%2493 = OpLoad %_arr_ushort_uint_8 %140
-%2494 = OpCompositeExtract %ushort %2493 4
-OpStore %986 %2494
-%2495 = OpLoad %_arr_ushort_uint_8 %146
-%2496 = OpCompositeExtract %ushort %2495 4
-OpStore %987 %2496
-%2497 = OpLoad %ushort %986
-%2498 = OpLoad %ushort %987
-%2499 = OpBitwiseOr %ushort %2497 %2498
-OpStore %988 %2499
-%2500 = OpLoad %_arr_ushort_uint_8 %140
-%2501 = OpCompositeExtract %ushort %2500 5
-OpStore %989 %2501
-%2502 = OpLoad %_arr_ushort_uint_8 %146
-%2503 = OpCompositeExtract %ushort %2502 5
-OpStore %990 %2503
-%2504 = OpLoad %ushort %989
-%2505 = OpLoad %ushort %990
-%2506 = OpBitwiseOr %ushort %2504 %2505
-OpStore %991 %2506
-%2507 = OpLoad %_arr_ushort_uint_8 %140
-%2508 = OpCompositeExtract %ushort %2507 6
-OpStore %992 %2508
-%2509 = OpLoad %_arr_ushort_uint_8 %146
-%2510 = OpCompositeExtract %ushort %2509 6
-OpStore %993 %2510
-%2511 = OpLoad %ushort %992
-%2512 = OpLoad %ushort %993
-%2513 = OpBitwiseOr %ushort %2511 %2512
-OpStore %994 %2513
-%2514 = OpLoad %_arr_ushort_uint_8 %140
-%2515 = OpCompositeExtract %ushort %2514 7
-OpStore %995 %2515
-%2516 = OpLoad %_arr_ushort_uint_8 %146
-%2517 = OpCompositeExtract %ushort %2516 7
-OpStore %996 %2517
-%2518 = OpLoad %ushort %995
-%2519 = OpLoad %ushort %996
-%2520 = OpBitwiseOr %ushort %2518 %2519
-OpStore %997 %2520
-%2521 = OpLoad %_arr_ushort_uint_8 %140
-%2522 = OpLoad %ushort %976
-%2523 = OpCompositeInsert %_arr_ushort_uint_8 %2522 %2521 0
-OpStore %998 %2523
-%2524 = OpLoad %_arr_ushort_uint_8 %998
-%2525 = OpLoad %ushort %979
-%2526 = OpCompositeInsert %_arr_ushort_uint_8 %2525 %2524 1
-OpStore %999 %2526
-%2527 = OpLoad %_arr_ushort_uint_8 %999
-%2528 = OpLoad %ushort %982
-%2529 = OpCompositeInsert %_arr_ushort_uint_8 %2528 %2527 2
-OpStore %1000 %2529
-%2530 = OpLoad %_arr_ushort_uint_8 %1000
-%2531 = OpLoad %ushort %985
-%2532 = OpCompositeInsert %_arr_ushort_uint_8 %2531 %2530 3
-OpStore %1001 %2532
-%2533 = OpLoad %_arr_ushort_uint_8 %1001
-%2534 = OpLoad %ushort %988
-%2535 = OpCompositeInsert %_arr_ushort_uint_8 %2534 %2533 4
-OpStore %1002 %2535
-%2536 = OpLoad %_arr_ushort_uint_8 %1002
-%2537 = OpLoad %ushort %991
-%2538 = OpCompositeInsert %_arr_ushort_uint_8 %2537 %2536 5
-OpStore %1003 %2538
-%2539 = OpLoad %_arr_ushort_uint_8 %1003
-%2540 = OpLoad %ushort %994
-%2541 = OpCompositeInsert %_arr_ushort_uint_8 %2540 %2539 6
-OpStore %1004 %2541
-%2542 = OpLoad %_arr_ushort_uint_8 %1004
-%2543 = OpLoad %ushort %997
-%2544 = OpCompositeInsert %_arr_ushort_uint_8 %2543 %2542 7
-OpStore %1005 %2544
-%2545 = OpLoad %ulong %148
-%2546 = OpLoad %_arr_ushort_uint_8 %1005
-%2547 = OpFunctionCall %ulong %1 %2545 %2546
-OpStore %149 %2547
-%2548 = OpLoad %_arr_ushort_uint_8 %140
-%2549 = OpCompositeExtract %ushort %2548 0
-OpStore %1006 %2549
-%2550 = OpLoad %_arr_ushort_uint_8 %146
-%2551 = OpCompositeExtract %ushort %2550 0
-OpStore %1007 %2551
-%2552 = OpLoad %ushort %1006
-%2553 = OpLoad %ushort %1007
-%2554 = OpBitwiseXor %ushort %2552 %2553
-OpStore %1008 %2554
-%2555 = OpLoad %_arr_ushort_uint_8 %140
-%2556 = OpCompositeExtract %ushort %2555 1
-OpStore %1009 %2556
-%2557 = OpLoad %_arr_ushort_uint_8 %146
-%2558 = OpCompositeExtract %ushort %2557 1
-OpStore %1010 %2558
-%2559 = OpLoad %ushort %1009
-%2560 = OpLoad %ushort %1010
-%2561 = OpBitwiseXor %ushort %2559 %2560
-OpStore %1011 %2561
-%2562 = OpLoad %_arr_ushort_uint_8 %140
-%2563 = OpCompositeExtract %ushort %2562 2
-OpStore %1012 %2563
-%2564 = OpLoad %_arr_ushort_uint_8 %146
-%2565 = OpCompositeExtract %ushort %2564 2
-OpStore %1013 %2565
-%2566 = OpLoad %ushort %1012
-%2567 = OpLoad %ushort %1013
-%2568 = OpBitwiseXor %ushort %2566 %2567
-OpStore %1014 %2568
-%2569 = OpLoad %_arr_ushort_uint_8 %140
-%2570 = OpCompositeExtract %ushort %2569 3
-OpStore %1015 %2570
-%2571 = OpLoad %_arr_ushort_uint_8 %146
-%2572 = OpCompositeExtract %ushort %2571 3
-OpStore %1016 %2572
-%2573 = OpLoad %ushort %1015
-%2574 = OpLoad %ushort %1016
-%2575 = OpBitwiseXor %ushort %2573 %2574
-OpStore %1017 %2575
-%2576 = OpLoad %_arr_ushort_uint_8 %140
-%2577 = OpCompositeExtract %ushort %2576 4
-OpStore %1018 %2577
-%2578 = OpLoad %_arr_ushort_uint_8 %146
-%2579 = OpCompositeExtract %ushort %2578 4
-OpStore %1019 %2579
-%2580 = OpLoad %ushort %1018
-%2581 = OpLoad %ushort %1019
-%2582 = OpBitwiseXor %ushort %2580 %2581
-OpStore %1020 %2582
-%2583 = OpLoad %_arr_ushort_uint_8 %140
-%2584 = OpCompositeExtract %ushort %2583 5
-OpStore %1021 %2584
-%2585 = OpLoad %_arr_ushort_uint_8 %146
-%2586 = OpCompositeExtract %ushort %2585 5
-OpStore %1022 %2586
-%2587 = OpLoad %ushort %1021
-%2588 = OpLoad %ushort %1022
-%2589 = OpBitwiseXor %ushort %2587 %2588
-OpStore %1023 %2589
-%2590 = OpLoad %_arr_ushort_uint_8 %140
-%2591 = OpCompositeExtract %ushort %2590 6
-OpStore %1024 %2591
-%2592 = OpLoad %_arr_ushort_uint_8 %146
-%2593 = OpCompositeExtract %ushort %2592 6
-OpStore %1025 %2593
-%2594 = OpLoad %ushort %1024
-%2595 = OpLoad %ushort %1025
-%2596 = OpBitwiseXor %ushort %2594 %2595
-OpStore %1026 %2596
-%2597 = OpLoad %_arr_ushort_uint_8 %140
-%2598 = OpCompositeExtract %ushort %2597 7
-OpStore %1027 %2598
-%2599 = OpLoad %_arr_ushort_uint_8 %146
-%2600 = OpCompositeExtract %ushort %2599 7
-OpStore %1028 %2600
-%2601 = OpLoad %ushort %1027
-%2602 = OpLoad %ushort %1028
-%2603 = OpBitwiseXor %ushort %2601 %2602
-OpStore %1029 %2603
-%2604 = OpLoad %_arr_ushort_uint_8 %140
-%2605 = OpLoad %ushort %1008
-%2606 = OpCompositeInsert %_arr_ushort_uint_8 %2605 %2604 0
-OpStore %1030 %2606
-%2607 = OpLoad %_arr_ushort_uint_8 %1030
-%2608 = OpLoad %ushort %1011
-%2609 = OpCompositeInsert %_arr_ushort_uint_8 %2608 %2607 1
-OpStore %1031 %2609
-%2610 = OpLoad %_arr_ushort_uint_8 %1031
-%2611 = OpLoad %ushort %1014
-%2612 = OpCompositeInsert %_arr_ushort_uint_8 %2611 %2610 2
-OpStore %1032 %2612
-%2613 = OpLoad %_arr_ushort_uint_8 %1032
-%2614 = OpLoad %ushort %1017
-%2615 = OpCompositeInsert %_arr_ushort_uint_8 %2614 %2613 3
-OpStore %1033 %2615
-%2616 = OpLoad %_arr_ushort_uint_8 %1033
-%2617 = OpLoad %ushort %1020
-%2618 = OpCompositeInsert %_arr_ushort_uint_8 %2617 %2616 4
-OpStore %1034 %2618
-%2619 = OpLoad %_arr_ushort_uint_8 %1034
-%2620 = OpLoad %ushort %1023
-%2621 = OpCompositeInsert %_arr_ushort_uint_8 %2620 %2619 5
-OpStore %1035 %2621
-%2622 = OpLoad %_arr_ushort_uint_8 %1035
-%2623 = OpLoad %ushort %1026
-%2624 = OpCompositeInsert %_arr_ushort_uint_8 %2623 %2622 6
-OpStore %1036 %2624
-%2625 = OpLoad %_arr_ushort_uint_8 %1036
-%2626 = OpLoad %ushort %1029
-%2627 = OpCompositeInsert %_arr_ushort_uint_8 %2626 %2625 7
-OpStore %1037 %2627
-%2628 = OpLoad %ulong %149
-%2629 = OpLoad %_arr_ushort_uint_8 %1037
-%2630 = OpFunctionCall %ulong %1 %2628 %2629
-OpStore %150 %2630
-%2631 = OpLoad %_arr_ushort_uint_8 %140
-%2632 = OpCompositeExtract %ushort %2631 0
-OpStore %1038 %2632
-%2633 = OpLoad %ushort %1038
-%2634 = OpNot %ushort %2633
-OpStore %1039 %2634
-%2635 = OpLoad %_arr_ushort_uint_8 %140
-%2636 = OpCompositeExtract %ushort %2635 1
-OpStore %1040 %2636
-%2637 = OpLoad %ushort %1040
-%2638 = OpNot %ushort %2637
-OpStore %1041 %2638
-%2639 = OpLoad %_arr_ushort_uint_8 %140
-%2640 = OpCompositeExtract %ushort %2639 2
-OpStore %1042 %2640
-%2641 = OpLoad %ushort %1042
-%2642 = OpNot %ushort %2641
-OpStore %1043 %2642
-%2643 = OpLoad %_arr_ushort_uint_8 %140
-%2644 = OpCompositeExtract %ushort %2643 3
-OpStore %1044 %2644
-%2645 = OpLoad %ushort %1044
-%2646 = OpNot %ushort %2645
-OpStore %1045 %2646
-%2647 = OpLoad %_arr_ushort_uint_8 %140
-%2648 = OpCompositeExtract %ushort %2647 4
-OpStore %1046 %2648
-%2649 = OpLoad %ushort %1046
-%2650 = OpNot %ushort %2649
-OpStore %1047 %2650
-%2651 = OpLoad %_arr_ushort_uint_8 %140
-%2652 = OpCompositeExtract %ushort %2651 5
-OpStore %1048 %2652
-%2653 = OpLoad %ushort %1048
-%2654 = OpNot %ushort %2653
-OpStore %1049 %2654
-%2655 = OpLoad %_arr_ushort_uint_8 %140
-%2656 = OpCompositeExtract %ushort %2655 6
-OpStore %1050 %2656
-%2657 = OpLoad %ushort %1050
-%2658 = OpNot %ushort %2657
-OpStore %1051 %2658
-%2659 = OpLoad %_arr_ushort_uint_8 %140
-%2660 = OpCompositeExtract %ushort %2659 7
-OpStore %1052 %2660
-%2661 = OpLoad %ushort %1052
-%2662 = OpNot %ushort %2661
-OpStore %1053 %2662
-%2663 = OpLoad %_arr_ushort_uint_8 %140
-%2664 = OpLoad %ushort %1039
-%2665 = OpCompositeInsert %_arr_ushort_uint_8 %2664 %2663 0
-OpStore %1054 %2665
-%2666 = OpLoad %_arr_ushort_uint_8 %1054
-%2667 = OpLoad %ushort %1041
-%2668 = OpCompositeInsert %_arr_ushort_uint_8 %2667 %2666 1
-OpStore %1055 %2668
-%2669 = OpLoad %_arr_ushort_uint_8 %1055
-%2670 = OpLoad %ushort %1043
-%2671 = OpCompositeInsert %_arr_ushort_uint_8 %2670 %2669 2
-OpStore %1056 %2671
-%2672 = OpLoad %_arr_ushort_uint_8 %1056
-%2673 = OpLoad %ushort %1045
-%2674 = OpCompositeInsert %_arr_ushort_uint_8 %2673 %2672 3
-OpStore %1057 %2674
-%2675 = OpLoad %_arr_ushort_uint_8 %1057
-%2676 = OpLoad %ushort %1047
-%2677 = OpCompositeInsert %_arr_ushort_uint_8 %2676 %2675 4
-OpStore %1058 %2677
-%2678 = OpLoad %_arr_ushort_uint_8 %1058
-%2679 = OpLoad %ushort %1049
-%2680 = OpCompositeInsert %_arr_ushort_uint_8 %2679 %2678 5
-OpStore %1059 %2680
-%2681 = OpLoad %_arr_ushort_uint_8 %1059
-%2682 = OpLoad %ushort %1051
-%2683 = OpCompositeInsert %_arr_ushort_uint_8 %2682 %2681 6
-OpStore %1060 %2683
-%2684 = OpLoad %_arr_ushort_uint_8 %1060
-%2685 = OpLoad %ushort %1053
-%2686 = OpCompositeInsert %_arr_ushort_uint_8 %2685 %2684 7
-OpStore %1061 %2686
-%2687 = OpLoad %ulong %150
-%2688 = OpLoad %_arr_ushort_uint_8 %1061
-%2689 = OpFunctionCall %ulong %1 %2687 %2688
-OpStore %151 %2689
-%2690 = OpLoad %_arr_ushort_uint_8 %146
-%2691 = OpCompositeExtract %ushort %2690 0
-OpStore %1062 %2691
-%2692 = OpLoad %ushort %1062
-%2693 = OpNot %ushort %2692
-OpStore %1063 %2693
-%2694 = OpLoad %_arr_ushort_uint_8 %146
-%2695 = OpCompositeExtract %ushort %2694 1
-OpStore %1064 %2695
-%2696 = OpLoad %ushort %1064
-%2697 = OpNot %ushort %2696
-OpStore %1065 %2697
-%2698 = OpLoad %_arr_ushort_uint_8 %146
-%2699 = OpCompositeExtract %ushort %2698 2
-OpStore %1066 %2699
-%2700 = OpLoad %ushort %1066
-%2701 = OpNot %ushort %2700
-OpStore %1067 %2701
-%2702 = OpLoad %_arr_ushort_uint_8 %146
-%2703 = OpCompositeExtract %ushort %2702 3
-OpStore %1068 %2703
-%2704 = OpLoad %ushort %1068
-%2705 = OpNot %ushort %2704
-OpStore %1069 %2705
-%2706 = OpLoad %_arr_ushort_uint_8 %146
-%2707 = OpCompositeExtract %ushort %2706 4
-OpStore %1070 %2707
-%2708 = OpLoad %ushort %1070
-%2709 = OpNot %ushort %2708
-OpStore %1071 %2709
-%2710 = OpLoad %_arr_ushort_uint_8 %146
-%2711 = OpCompositeExtract %ushort %2710 5
-OpStore %1072 %2711
-%2712 = OpLoad %ushort %1072
-%2713 = OpNot %ushort %2712
-OpStore %1073 %2713
-%2714 = OpLoad %_arr_ushort_uint_8 %146
-%2715 = OpCompositeExtract %ushort %2714 6
-OpStore %1074 %2715
-%2716 = OpLoad %ushort %1074
-%2717 = OpNot %ushort %2716
-OpStore %1075 %2717
-%2718 = OpLoad %_arr_ushort_uint_8 %146
-%2719 = OpCompositeExtract %ushort %2718 7
-OpStore %1076 %2719
-%2720 = OpLoad %ushort %1076
-%2721 = OpNot %ushort %2720
-OpStore %1077 %2721
-%2722 = OpLoad %_arr_ushort_uint_8 %146
-%2723 = OpLoad %ushort %1063
-%2724 = OpCompositeInsert %_arr_ushort_uint_8 %2723 %2722 0
-OpStore %1078 %2724
-%2725 = OpLoad %_arr_ushort_uint_8 %1078
-%2726 = OpLoad %ushort %1065
-%2727 = OpCompositeInsert %_arr_ushort_uint_8 %2726 %2725 1
-OpStore %1079 %2727
-%2728 = OpLoad %_arr_ushort_uint_8 %1079
-%2729 = OpLoad %ushort %1067
-%2730 = OpCompositeInsert %_arr_ushort_uint_8 %2729 %2728 2
-OpStore %1080 %2730
-%2731 = OpLoad %_arr_ushort_uint_8 %1080
-%2732 = OpLoad %ushort %1069
-%2733 = OpCompositeInsert %_arr_ushort_uint_8 %2732 %2731 3
-OpStore %1081 %2733
-%2734 = OpLoad %_arr_ushort_uint_8 %1081
-%2735 = OpLoad %ushort %1071
-%2736 = OpCompositeInsert %_arr_ushort_uint_8 %2735 %2734 4
-OpStore %1082 %2736
-%2737 = OpLoad %_arr_ushort_uint_8 %1082
-%2738 = OpLoad %ushort %1073
-%2739 = OpCompositeInsert %_arr_ushort_uint_8 %2738 %2737 5
-OpStore %1083 %2739
-%2740 = OpLoad %_arr_ushort_uint_8 %1083
-%2741 = OpLoad %ushort %1075
-%2742 = OpCompositeInsert %_arr_ushort_uint_8 %2741 %2740 6
-OpStore %1084 %2742
-%2743 = OpLoad %_arr_ushort_uint_8 %1084
-%2744 = OpLoad %ushort %1077
-%2745 = OpCompositeInsert %_arr_ushort_uint_8 %2744 %2743 7
-OpStore %1085 %2745
-%2746 = OpLoad %ulong %151
-%2747 = OpLoad %_arr_ushort_uint_8 %1085
-%2748 = OpFunctionCall %ulong %1 %2746 %2747
-OpStore %152 %2748
-%2749 = OpLoad %_arr_ushort_uint_8 %973
-%2750 = OpCompositeExtract %ushort %2749 0
-OpStore %1086 %2750
-%2751 = OpLoad %_arr_ushort_uint_8 %1005
-%2752 = OpCompositeExtract %ushort %2751 0
-OpStore %1087 %2752
-%2753 = OpLoad %ushort %1086
-%2754 = OpLoad %ushort %1087
-%2755 = OpBitwiseXor %ushort %2753 %2754
-OpStore %1088 %2755
-%2756 = OpLoad %_arr_ushort_uint_8 %973
-%2757 = OpCompositeExtract %ushort %2756 1
-OpStore %1089 %2757
-%2758 = OpLoad %_arr_ushort_uint_8 %1005
-%2759 = OpCompositeExtract %ushort %2758 1
-OpStore %1090 %2759
-%2760 = OpLoad %ushort %1089
-%2761 = OpLoad %ushort %1090
-%2762 = OpBitwiseXor %ushort %2760 %2761
-OpStore %1091 %2762
-%2763 = OpLoad %_arr_ushort_uint_8 %973
-%2764 = OpCompositeExtract %ushort %2763 2
-OpStore %1092 %2764
-%2765 = OpLoad %_arr_ushort_uint_8 %1005
-%2766 = OpCompositeExtract %ushort %2765 2
-OpStore %1093 %2766
-%2767 = OpLoad %ushort %1092
-%2768 = OpLoad %ushort %1093
-%2769 = OpBitwiseXor %ushort %2767 %2768
-OpStore %1094 %2769
-%2770 = OpLoad %_arr_ushort_uint_8 %973
-%2771 = OpCompositeExtract %ushort %2770 3
-OpStore %1095 %2771
-%2772 = OpLoad %_arr_ushort_uint_8 %1005
-%2773 = OpCompositeExtract %ushort %2772 3
-OpStore %1096 %2773
-%2774 = OpLoad %ushort %1095
-%2775 = OpLoad %ushort %1096
-%2776 = OpBitwiseXor %ushort %2774 %2775
-OpStore %1097 %2776
-%2777 = OpLoad %_arr_ushort_uint_8 %973
-%2778 = OpCompositeExtract %ushort %2777 4
-OpStore %1098 %2778
-%2779 = OpLoad %_arr_ushort_uint_8 %1005
-%2780 = OpCompositeExtract %ushort %2779 4
-OpStore %1099 %2780
-%2781 = OpLoad %ushort %1098
-%2782 = OpLoad %ushort %1099
-%2783 = OpBitwiseXor %ushort %2781 %2782
-OpStore %1100 %2783
-%2784 = OpLoad %_arr_ushort_uint_8 %973
-%2785 = OpCompositeExtract %ushort %2784 5
-OpStore %1101 %2785
-%2786 = OpLoad %_arr_ushort_uint_8 %1005
-%2787 = OpCompositeExtract %ushort %2786 5
-OpStore %1102 %2787
-%2788 = OpLoad %ushort %1101
-%2789 = OpLoad %ushort %1102
-%2790 = OpBitwiseXor %ushort %2788 %2789
-OpStore %1103 %2790
-%2791 = OpLoad %_arr_ushort_uint_8 %973
-%2792 = OpCompositeExtract %ushort %2791 6
-OpStore %1104 %2792
-%2793 = OpLoad %_arr_ushort_uint_8 %1005
-%2794 = OpCompositeExtract %ushort %2793 6
-OpStore %1105 %2794
-%2795 = OpLoad %ushort %1104
-%2796 = OpLoad %ushort %1105
-%2797 = OpBitwiseXor %ushort %2795 %2796
-OpStore %1106 %2797
-%2798 = OpLoad %_arr_ushort_uint_8 %973
-%2799 = OpCompositeExtract %ushort %2798 7
-OpStore %1107 %2799
-%2800 = OpLoad %_arr_ushort_uint_8 %1005
-%2801 = OpCompositeExtract %ushort %2800 7
-OpStore %1108 %2801
-%2802 = OpLoad %ushort %1107
-%2803 = OpLoad %ushort %1108
-%2804 = OpBitwiseXor %ushort %2802 %2803
-OpStore %1109 %2804
-%2805 = OpLoad %_arr_ushort_uint_8 %973
-%2806 = OpLoad %ushort %1088
-%2807 = OpCompositeInsert %_arr_ushort_uint_8 %2806 %2805 0
-OpStore %1110 %2807
-%2808 = OpLoad %_arr_ushort_uint_8 %1110
-%2809 = OpLoad %ushort %1091
-%2810 = OpCompositeInsert %_arr_ushort_uint_8 %2809 %2808 1
-OpStore %1111 %2810
-%2811 = OpLoad %_arr_ushort_uint_8 %1111
-%2812 = OpLoad %ushort %1094
-%2813 = OpCompositeInsert %_arr_ushort_uint_8 %2812 %2811 2
-OpStore %1112 %2813
-%2814 = OpLoad %_arr_ushort_uint_8 %1112
-%2815 = OpLoad %ushort %1097
-%2816 = OpCompositeInsert %_arr_ushort_uint_8 %2815 %2814 3
-OpStore %1113 %2816
-%2817 = OpLoad %_arr_ushort_uint_8 %1113
-%2818 = OpLoad %ushort %1100
-%2819 = OpCompositeInsert %_arr_ushort_uint_8 %2818 %2817 4
-OpStore %1114 %2819
-%2820 = OpLoad %_arr_ushort_uint_8 %1114
-%2821 = OpLoad %ushort %1103
-%2822 = OpCompositeInsert %_arr_ushort_uint_8 %2821 %2820 5
-OpStore %1115 %2822
-%2823 = OpLoad %_arr_ushort_uint_8 %1115
-%2824 = OpLoad %ushort %1106
-%2825 = OpCompositeInsert %_arr_ushort_uint_8 %2824 %2823 6
-OpStore %1116 %2825
-%2826 = OpLoad %_arr_ushort_uint_8 %1116
-%2827 = OpLoad %ushort %1109
-%2828 = OpCompositeInsert %_arr_ushort_uint_8 %2827 %2826 7
-OpStore %1117 %2828
-%2829 = OpLoad %ulong %152
-%2830 = OpLoad %_arr_ushort_uint_8 %1117
-%2831 = OpFunctionCall %ulong %1 %2829 %2830
-OpStore %153 %2831
-%2832 = OpLoad %ulong %153
-OpStore %168 %2832
-%2833 = OpLoad %_arr_ushort_uint_8 %140
-OpStore %169 %2833
-%2834 = OpLoad %_arr_ushort_uint_8 %134
-OpStore %170 %2834
-%2835 = OpLoad %_arr_ushort_uint_8 %134
-OpStore %171 %2835
-OpStore %172 %ulong_0
-OpBranch %80
-%80 = OpLabel
-%2837 = OpLoad %ulong %172
-%2839 = OpULessThan %bool %2837 %ulong_6
-OpStore %155 %2839
-%2840 = OpLoad %bool %155
-OpLoopMerge %82 %119 None
-OpBranchConditional %2840 %81 %82
-%82 = OpLabel
-OpStore %124 %2841
-%2843 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_0
-%2844 = OpLoad %_arr_ushort_uint_8 %169
-OpStore %2843 %2844
-%2845 = OpLoad %_arr_ushort_uint_8 %169
-%2846 = OpCompositeExtract %ushort %2845 0
-OpStore %462 %2846
-%2847 = OpLoad %_arr_ushort_uint_8 %146
-%2848 = OpCompositeExtract %ushort %2847 0
-OpStore %463 %2848
-%2849 = OpLoad %ushort %462
-%2850 = OpLoad %ushort %463
-%2851 = OpIAdd %ushort %2849 %2850
-OpStore %464 %2851
-%2852 = OpLoad %_arr_ushort_uint_8 %169
-%2853 = OpCompositeExtract %ushort %2852 1
-OpStore %465 %2853
-%2854 = OpLoad %_arr_ushort_uint_8 %146
-%2855 = OpCompositeExtract %ushort %2854 1
-OpStore %466 %2855
-%2856 = OpLoad %ushort %465
-%2857 = OpLoad %ushort %466
-%2858 = OpIAdd %ushort %2856 %2857
-OpStore %467 %2858
-%2859 = OpLoad %_arr_ushort_uint_8 %169
-%2860 = OpCompositeExtract %ushort %2859 2
-OpStore %468 %2860
-%2861 = OpLoad %_arr_ushort_uint_8 %146
-%2862 = OpCompositeExtract %ushort %2861 2
-OpStore %469 %2862
-%2863 = OpLoad %ushort %468
-%2864 = OpLoad %ushort %469
-%2865 = OpIAdd %ushort %2863 %2864
-OpStore %470 %2865
-%2866 = OpLoad %_arr_ushort_uint_8 %169
-%2867 = OpCompositeExtract %ushort %2866 3
-OpStore %471 %2867
-%2868 = OpLoad %_arr_ushort_uint_8 %146
-%2869 = OpCompositeExtract %ushort %2868 3
-OpStore %472 %2869
-%2870 = OpLoad %ushort %471
-%2871 = OpLoad %ushort %472
-%2872 = OpIAdd %ushort %2870 %2871
-OpStore %473 %2872
-%2873 = OpLoad %_arr_ushort_uint_8 %169
-%2874 = OpCompositeExtract %ushort %2873 4
-OpStore %474 %2874
-%2875 = OpLoad %_arr_ushort_uint_8 %146
-%2876 = OpCompositeExtract %ushort %2875 4
-OpStore %475 %2876
-%2877 = OpLoad %ushort %474
-%2878 = OpLoad %ushort %475
-%2879 = OpIAdd %ushort %2877 %2878
-OpStore %476 %2879
-%2880 = OpLoad %_arr_ushort_uint_8 %169
-%2881 = OpCompositeExtract %ushort %2880 5
-OpStore %477 %2881
-%2882 = OpLoad %_arr_ushort_uint_8 %146
-%2883 = OpCompositeExtract %ushort %2882 5
-OpStore %478 %2883
-%2884 = OpLoad %ushort %477
-%2885 = OpLoad %ushort %478
-%2886 = OpIAdd %ushort %2884 %2885
-OpStore %479 %2886
-%2887 = OpLoad %_arr_ushort_uint_8 %169
-%2888 = OpCompositeExtract %ushort %2887 6
-OpStore %480 %2888
-%2889 = OpLoad %_arr_ushort_uint_8 %146
-%2890 = OpCompositeExtract %ushort %2889 6
-OpStore %481 %2890
-%2891 = OpLoad %ushort %480
-%2892 = OpLoad %ushort %481
-%2893 = OpIAdd %ushort %2891 %2892
-OpStore %482 %2893
-%2894 = OpLoad %_arr_ushort_uint_8 %169
-%2895 = OpCompositeExtract %ushort %2894 7
-OpStore %483 %2895
-%2896 = OpLoad %_arr_ushort_uint_8 %146
-%2897 = OpCompositeExtract %ushort %2896 7
-OpStore %484 %2897
-%2898 = OpLoad %ushort %483
-%2899 = OpLoad %ushort %484
-%2900 = OpIAdd %ushort %2898 %2899
-OpStore %485 %2900
-%2901 = OpLoad %_arr_ushort_uint_8 %169
-%2902 = OpLoad %ushort %464
-%2903 = OpCompositeInsert %_arr_ushort_uint_8 %2902 %2901 0
-OpStore %486 %2903
-%2904 = OpLoad %_arr_ushort_uint_8 %486
-%2905 = OpLoad %ushort %467
-%2906 = OpCompositeInsert %_arr_ushort_uint_8 %2905 %2904 1
-OpStore %487 %2906
-%2907 = OpLoad %_arr_ushort_uint_8 %487
-%2908 = OpLoad %ushort %470
-%2909 = OpCompositeInsert %_arr_ushort_uint_8 %2908 %2907 2
-OpStore %488 %2909
-%2910 = OpLoad %_arr_ushort_uint_8 %488
-%2911 = OpLoad %ushort %473
-%2912 = OpCompositeInsert %_arr_ushort_uint_8 %2911 %2910 3
-OpStore %489 %2912
-%2913 = OpLoad %_arr_ushort_uint_8 %489
-%2914 = OpLoad %ushort %476
-%2915 = OpCompositeInsert %_arr_ushort_uint_8 %2914 %2913 4
-OpStore %490 %2915
-%2916 = OpLoad %_arr_ushort_uint_8 %490
-%2917 = OpLoad %ushort %479
-%2918 = OpCompositeInsert %_arr_ushort_uint_8 %2917 %2916 5
-OpStore %491 %2918
-%2919 = OpLoad %_arr_ushort_uint_8 %491
-%2920 = OpLoad %ushort %482
-%2921 = OpCompositeInsert %_arr_ushort_uint_8 %2920 %2919 6
-OpStore %492 %2921
-%2922 = OpLoad %_arr_ushort_uint_8 %492
-%2923 = OpLoad %ushort %485
-%2924 = OpCompositeInsert %_arr_ushort_uint_8 %2923 %2922 7
-OpStore %493 %2924
-%2926 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_1
-%2927 = OpLoad %_arr_ushort_uint_8 %493
-OpStore %2926 %2927
-%2928 = OpLoad %_arr_ushort_uint_8 %169
-%2929 = OpCompositeExtract %ushort %2928 0
-OpStore %494 %2929
-%2930 = OpLoad %_arr_ushort_uint_8 %133
-%2931 = OpCompositeExtract %ushort %2930 0
-OpStore %495 %2931
-%2932 = OpLoad %ushort %494
-%2933 = OpLoad %ushort %495
-%2934 = OpIMul %ushort %2932 %2933
-OpStore %496 %2934
-%2935 = OpLoad %_arr_ushort_uint_8 %169
-%2936 = OpCompositeExtract %ushort %2935 1
-OpStore %497 %2936
-%2937 = OpLoad %_arr_ushort_uint_8 %133
-%2938 = OpCompositeExtract %ushort %2937 1
-OpStore %498 %2938
-%2939 = OpLoad %ushort %497
-%2940 = OpLoad %ushort %498
-%2941 = OpIMul %ushort %2939 %2940
-OpStore %499 %2941
-%2942 = OpLoad %_arr_ushort_uint_8 %169
-%2943 = OpCompositeExtract %ushort %2942 2
-OpStore %500 %2943
-%2944 = OpLoad %_arr_ushort_uint_8 %133
-%2945 = OpCompositeExtract %ushort %2944 2
-OpStore %501 %2945
-%2946 = OpLoad %ushort %500
-%2947 = OpLoad %ushort %501
-%2948 = OpIMul %ushort %2946 %2947
-OpStore %502 %2948
-%2949 = OpLoad %_arr_ushort_uint_8 %169
-%2950 = OpCompositeExtract %ushort %2949 3
-OpStore %503 %2950
-%2951 = OpLoad %_arr_ushort_uint_8 %133
-%2952 = OpCompositeExtract %ushort %2951 3
-OpStore %504 %2952
-%2953 = OpLoad %ushort %503
-%2954 = OpLoad %ushort %504
-%2955 = OpIMul %ushort %2953 %2954
-OpStore %505 %2955
-%2956 = OpLoad %_arr_ushort_uint_8 %169
-%2957 = OpCompositeExtract %ushort %2956 4
-OpStore %506 %2957
-%2958 = OpLoad %_arr_ushort_uint_8 %133
-%2959 = OpCompositeExtract %ushort %2958 4
-OpStore %507 %2959
-%2960 = OpLoad %ushort %506
-%2961 = OpLoad %ushort %507
-%2962 = OpIMul %ushort %2960 %2961
-OpStore %508 %2962
-%2963 = OpLoad %_arr_ushort_uint_8 %169
-%2964 = OpCompositeExtract %ushort %2963 5
-OpStore %509 %2964
-%2965 = OpLoad %_arr_ushort_uint_8 %133
-%2966 = OpCompositeExtract %ushort %2965 5
-OpStore %510 %2966
-%2967 = OpLoad %ushort %509
-%2968 = OpLoad %ushort %510
-%2969 = OpIMul %ushort %2967 %2968
-OpStore %511 %2969
-%2970 = OpLoad %_arr_ushort_uint_8 %169
-%2971 = OpCompositeExtract %ushort %2970 6
-OpStore %512 %2971
-%2972 = OpLoad %_arr_ushort_uint_8 %133
-%2973 = OpCompositeExtract %ushort %2972 6
-OpStore %513 %2973
-%2974 = OpLoad %ushort %512
-%2975 = OpLoad %ushort %513
-%2976 = OpIMul %ushort %2974 %2975
-OpStore %514 %2976
-%2977 = OpLoad %_arr_ushort_uint_8 %169
-%2978 = OpCompositeExtract %ushort %2977 7
-OpStore %515 %2978
-%2979 = OpLoad %_arr_ushort_uint_8 %133
-%2980 = OpCompositeExtract %ushort %2979 7
-OpStore %516 %2980
-%2981 = OpLoad %ushort %515
-%2982 = OpLoad %ushort %516
-%2983 = OpIMul %ushort %2981 %2982
-OpStore %517 %2983
-%2984 = OpLoad %_arr_ushort_uint_8 %169
-%2985 = OpLoad %ushort %496
-%2986 = OpCompositeInsert %_arr_ushort_uint_8 %2985 %2984 0
-OpStore %518 %2986
-%2987 = OpLoad %_arr_ushort_uint_8 %518
-%2988 = OpLoad %ushort %499
-%2989 = OpCompositeInsert %_arr_ushort_uint_8 %2988 %2987 1
-OpStore %519 %2989
-%2990 = OpLoad %_arr_ushort_uint_8 %519
-%2991 = OpLoad %ushort %502
-%2992 = OpCompositeInsert %_arr_ushort_uint_8 %2991 %2990 2
-OpStore %520 %2992
-%2993 = OpLoad %_arr_ushort_uint_8 %520
-%2994 = OpLoad %ushort %505
-%2995 = OpCompositeInsert %_arr_ushort_uint_8 %2994 %2993 3
-OpStore %521 %2995
-%2996 = OpLoad %_arr_ushort_uint_8 %521
-%2997 = OpLoad %ushort %508
-%2998 = OpCompositeInsert %_arr_ushort_uint_8 %2997 %2996 4
-OpStore %522 %2998
-%2999 = OpLoad %_arr_ushort_uint_8 %522
-%3000 = OpLoad %ushort %511
-%3001 = OpCompositeInsert %_arr_ushort_uint_8 %3000 %2999 5
-OpStore %523 %3001
-%3002 = OpLoad %_arr_ushort_uint_8 %523
-%3003 = OpLoad %ushort %514
-%3004 = OpCompositeInsert %_arr_ushort_uint_8 %3003 %3002 6
-OpStore %524 %3004
-%3005 = OpLoad %_arr_ushort_uint_8 %524
-%3006 = OpLoad %ushort %517
-%3007 = OpCompositeInsert %_arr_ushort_uint_8 %3006 %3005 7
-OpStore %525 %3007
-%3009 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_2
-%3010 = OpLoad %_arr_ushort_uint_8 %525
-OpStore %3009 %3010
-%3012 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_3
-%3013 = OpLoad %_arr_ushort_uint_8 %170
-OpStore %3012 %3013
-%3014 = OpLoad %ulong %168
-OpStore %167 %3014
-OpStore %173 %ulong_0
-OpBranch %83
-%83 = OpLabel
-%3015 = OpLoad %ulong %173
-%3017 = OpULessThan %bool %3015 %ulong_4
-OpStore %157 %3017
-%3018 = OpLoad %bool %157
-OpLoopMerge %85 %118 None
-OpBranchConditional %3018 %84 %85
-%85 = OpLabel
-OpStore %127 %3019
-%3020 = OpAccessChain %_ptr_Function_uint %127 %uint_0
-OpStore %3020 %uint_4294967295
-%3022 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %uint_2
-%3023 = OpLoad %_arr_ushort_uint_8 %3022
-OpStore %160 %3023
-%3024 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %127 %uint_1
-%3025 = OpLoad %_arr_ushort_uint_8 %160
-OpStore %3024 %3025
-%3026 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-OpStore %3026 %uint_305419896
-%3028 = OpLoad %uint %3020
-OpStore %162 %3028
-%3029 = OpLoad %ulong %167
-%3030 = OpLoad %uint %162
-%3031 = OpFunctionCall %ulong %5 %3029 %3030
-OpStore %163 %3031
-%3032 = OpLoad %_arr_ushort_uint_8 %3024
-OpStore %164 %3032
-OpBranch %92
-%92 = OpLabel
-%3033 = OpLoad %_arr_ushort_uint_8 %164
-%3034 = OpCompositeExtract %ushort %3033 0
-OpStore %222 %3034
-%3035 = OpLoad %ulong %163
-%3036 = OpLoad %ushort %222
-%3037 = OpFunctionCall %ulong %4 %3035 %3036
-OpStore %223 %3037
-%3038 = OpLoad %_arr_ushort_uint_8 %164
-%3039 = OpCompositeExtract %ushort %3038 1
-OpStore %224 %3039
-%3040 = OpLoad %ulong %223
-%3041 = OpLoad %ushort %224
-%3042 = OpFunctionCall %ulong %4 %3040 %3041
-OpStore %225 %3042
-%3043 = OpLoad %_arr_ushort_uint_8 %164
-%3044 = OpCompositeExtract %ushort %3043 2
-OpStore %226 %3044
-%3045 = OpLoad %ulong %225
-%3046 = OpLoad %ushort %226
-%3047 = OpFunctionCall %ulong %4 %3045 %3046
-OpStore %227 %3047
-%3048 = OpLoad %_arr_ushort_uint_8 %164
-%3049 = OpCompositeExtract %ushort %3048 3
-OpStore %228 %3049
-%3050 = OpLoad %ulong %227
-%3051 = OpLoad %ushort %228
-%3052 = OpFunctionCall %ulong %4 %3050 %3051
-OpStore %229 %3052
-%3053 = OpLoad %_arr_ushort_uint_8 %164
-%3054 = OpCompositeExtract %ushort %3053 4
-OpStore %230 %3054
-%3055 = OpLoad %ulong %229
-%3056 = OpLoad %ushort %230
-%3057 = OpFunctionCall %ulong %4 %3055 %3056
-OpStore %231 %3057
-%3058 = OpLoad %_arr_ushort_uint_8 %164
-%3059 = OpCompositeExtract %ushort %3058 5
-OpStore %232 %3059
-%3060 = OpLoad %ulong %231
-%3061 = OpLoad %ushort %232
-%3062 = OpFunctionCall %ulong %4 %3060 %3061
-OpStore %233 %3062
-%3063 = OpLoad %_arr_ushort_uint_8 %164
-%3064 = OpCompositeExtract %ushort %3063 6
-OpStore %234 %3064
-%3065 = OpLoad %ulong %233
-%3066 = OpLoad %ushort %234
-%3067 = OpFunctionCall %ulong %4 %3065 %3066
-OpStore %235 %3067
-%3068 = OpLoad %_arr_ushort_uint_8 %164
-%3069 = OpCompositeExtract %ushort %3068 7
-OpStore %236 %3069
-%3070 = OpLoad %ulong %235
-%3071 = OpLoad %ushort %236
-%3072 = OpFunctionCall %ulong %4 %3070 %3071
-OpStore %237 %3072
-OpBranch %93
-%93 = OpLabel
-%3073 = OpAccessChain %_ptr_Function_uint %127 %uint_2
-%3074 = OpLoad %uint %3073
-OpStore %165 %3074
-%3075 = OpLoad %ulong %237
-%3076 = OpLoad %uint %165
-%3077 = OpFunctionCall %ulong %5 %3075 %3076
-OpStore %166 %3077
-%3078 = OpLoad %ulong %166
-OpReturnValue %3078
-%84 = OpLabel
-%3079 = OpLoad %ulong %173
-%3080 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %124 %3079
-%3081 = OpLoad %_arr_ushort_uint_8 %3080
-OpStore %158 %3081
-OpBranch %90
-%90 = OpLabel
-%3082 = OpLoad %_arr_ushort_uint_8 %158
-%3083 = OpCompositeExtract %ushort %3082 0
-OpStore %206 %3083
-%3084 = OpLoad %ulong %167
-%3085 = OpLoad %ushort %206
-%3086 = OpFunctionCall %ulong %4 %3084 %3085
-OpStore %207 %3086
-%3087 = OpLoad %_arr_ushort_uint_8 %158
-%3088 = OpCompositeExtract %ushort %3087 1
-OpStore %208 %3088
-%3089 = OpLoad %ulong %207
-%3090 = OpLoad %ushort %208
-%3091 = OpFunctionCall %ulong %4 %3089 %3090
-OpStore %209 %3091
-%3092 = OpLoad %_arr_ushort_uint_8 %158
-%3093 = OpCompositeExtract %ushort %3092 2
-OpStore %210 %3093
-%3094 = OpLoad %ulong %209
-%3095 = OpLoad %ushort %210
-%3096 = OpFunctionCall %ulong %4 %3094 %3095
-OpStore %211 %3096
-%3097 = OpLoad %_arr_ushort_uint_8 %158
-%3098 = OpCompositeExtract %ushort %3097 3
-OpStore %212 %3098
-%3099 = OpLoad %ulong %211
-%3100 = OpLoad %ushort %212
-%3101 = OpFunctionCall %ulong %4 %3099 %3100
-OpStore %213 %3101
-%3102 = OpLoad %_arr_ushort_uint_8 %158
-%3103 = OpCompositeExtract %ushort %3102 4
-OpStore %214 %3103
-%3104 = OpLoad %ulong %213
-%3105 = OpLoad %ushort %214
-%3106 = OpFunctionCall %ulong %4 %3104 %3105
-OpStore %215 %3106
-%3107 = OpLoad %_arr_ushort_uint_8 %158
-%3108 = OpCompositeExtract %ushort %3107 5
-OpStore %216 %3108
-%3109 = OpLoad %ulong %215
-%3110 = OpLoad %ushort %216
-%3111 = OpFunctionCall %ulong %4 %3109 %3110
-OpStore %217 %3111
-%3112 = OpLoad %_arr_ushort_uint_8 %158
-%3113 = OpCompositeExtract %ushort %3112 6
-OpStore %218 %3113
-%3114 = OpLoad %ulong %217
-%3115 = OpLoad %ushort %218
-%3116 = OpFunctionCall %ulong %4 %3114 %3115
-OpStore %219 %3116
-%3117 = OpLoad %_arr_ushort_uint_8 %158
-%3118 = OpCompositeExtract %ushort %3117 7
-OpStore %220 %3118
-%3119 = OpLoad %ulong %219
-%3120 = OpLoad %ushort %220
-%3121 = OpFunctionCall %ulong %4 %3119 %3120
-OpStore %221 %3121
-OpBranch %91
-%91 = OpLabel
-%3122 = OpLoad %ulong %173
-%3124 = OpIAdd %ulong %3122 %ulong_1
-OpStore %159 %3124
-%3125 = OpLoad %ulong %221
-OpStore %167 %3125
-%3126 = OpLoad %ulong %159
-OpStore %173 %3126
-OpBranch %118
-%81 = OpLabel
-%3127 = OpLoad %_arr_ushort_uint_8 %169
-%3128 = OpCompositeExtract %ushort %3127 0
-OpStore %430 %3128
-%3129 = OpLoad %_arr_ushort_uint_8 %133
-%3130 = OpCompositeExtract %ushort %3129 0
-OpStore %431 %3130
-%3131 = OpLoad %ushort %430
-%3132 = OpLoad %ushort %431
-%3133 = OpIMul %ushort %3131 %3132
-OpStore %432 %3133
-%3134 = OpLoad %_arr_ushort_uint_8 %169
-%3135 = OpCompositeExtract %ushort %3134 1
-OpStore %433 %3135
-%3136 = OpLoad %_arr_ushort_uint_8 %133
-%3137 = OpCompositeExtract %ushort %3136 1
-OpStore %434 %3137
-%3138 = OpLoad %ushort %433
-%3139 = OpLoad %ushort %434
-%3140 = OpIMul %ushort %3138 %3139
-OpStore %435 %3140
-%3141 = OpLoad %_arr_ushort_uint_8 %169
-%3142 = OpCompositeExtract %ushort %3141 2
-OpStore %436 %3142
-%3143 = OpLoad %_arr_ushort_uint_8 %133
-%3144 = OpCompositeExtract %ushort %3143 2
-OpStore %437 %3144
-%3145 = OpLoad %ushort %436
-%3146 = OpLoad %ushort %437
-%3147 = OpIMul %ushort %3145 %3146
-OpStore %438 %3147
-%3148 = OpLoad %_arr_ushort_uint_8 %169
-%3149 = OpCompositeExtract %ushort %3148 3
-OpStore %439 %3149
-%3150 = OpLoad %_arr_ushort_uint_8 %133
-%3151 = OpCompositeExtract %ushort %3150 3
-OpStore %440 %3151
-%3152 = OpLoad %ushort %439
-%3153 = OpLoad %ushort %440
-%3154 = OpIMul %ushort %3152 %3153
-OpStore %441 %3154
-%3155 = OpLoad %_arr_ushort_uint_8 %169
-%3156 = OpCompositeExtract %ushort %3155 4
-OpStore %442 %3156
-%3157 = OpLoad %_arr_ushort_uint_8 %133
-%3158 = OpCompositeExtract %ushort %3157 4
-OpStore %443 %3158
-%3159 = OpLoad %ushort %442
-%3160 = OpLoad %ushort %443
-%3161 = OpIMul %ushort %3159 %3160
-OpStore %444 %3161
-%3162 = OpLoad %_arr_ushort_uint_8 %169
-%3163 = OpCompositeExtract %ushort %3162 5
-OpStore %445 %3163
-%3164 = OpLoad %_arr_ushort_uint_8 %133
-%3165 = OpCompositeExtract %ushort %3164 5
-OpStore %446 %3165
-%3166 = OpLoad %ushort %445
-%3167 = OpLoad %ushort %446
-%3168 = OpIMul %ushort %3166 %3167
-OpStore %447 %3168
-%3169 = OpLoad %_arr_ushort_uint_8 %169
-%3170 = OpCompositeExtract %ushort %3169 6
-OpStore %448 %3170
-%3171 = OpLoad %_arr_ushort_uint_8 %133
-%3172 = OpCompositeExtract %ushort %3171 6
-OpStore %449 %3172
-%3173 = OpLoad %ushort %448
-%3174 = OpLoad %ushort %449
-%3175 = OpIMul %ushort %3173 %3174
-OpStore %450 %3175
-%3176 = OpLoad %_arr_ushort_uint_8 %169
-%3177 = OpCompositeExtract %ushort %3176 7
-OpStore %451 %3177
-%3178 = OpLoad %_arr_ushort_uint_8 %133
-%3179 = OpCompositeExtract %ushort %3178 7
-OpStore %452 %3179
-%3180 = OpLoad %ushort %451
-%3181 = OpLoad %ushort %452
-%3182 = OpIMul %ushort %3180 %3181
-OpStore %453 %3182
-%3183 = OpLoad %_arr_ushort_uint_8 %169
-%3184 = OpLoad %ushort %432
-%3185 = OpCompositeInsert %_arr_ushort_uint_8 %3184 %3183 0
-OpStore %454 %3185
-%3186 = OpLoad %_arr_ushort_uint_8 %454
-%3187 = OpLoad %ushort %435
-%3188 = OpCompositeInsert %_arr_ushort_uint_8 %3187 %3186 1
-OpStore %455 %3188
-%3189 = OpLoad %_arr_ushort_uint_8 %455
-%3190 = OpLoad %ushort %438
-%3191 = OpCompositeInsert %_arr_ushort_uint_8 %3190 %3189 2
-OpStore %456 %3191
-%3192 = OpLoad %_arr_ushort_uint_8 %456
-%3193 = OpLoad %ushort %441
-%3194 = OpCompositeInsert %_arr_ushort_uint_8 %3193 %3192 3
-OpStore %457 %3194
-%3195 = OpLoad %_arr_ushort_uint_8 %457
-%3196 = OpLoad %ushort %444
-%3197 = OpCompositeInsert %_arr_ushort_uint_8 %3196 %3195 4
-OpStore %458 %3197
-%3198 = OpLoad %_arr_ushort_uint_8 %458
-%3199 = OpLoad %ushort %447
-%3200 = OpCompositeInsert %_arr_ushort_uint_8 %3199 %3198 5
-OpStore %459 %3200
-%3201 = OpLoad %_arr_ushort_uint_8 %459
-%3202 = OpLoad %ushort %450
-%3203 = OpCompositeInsert %_arr_ushort_uint_8 %3202 %3201 6
-OpStore %460 %3203
-%3204 = OpLoad %_arr_ushort_uint_8 %460
-%3205 = OpLoad %ushort %453
-%3206 = OpCompositeInsert %_arr_ushort_uint_8 %3205 %3204 7
-OpStore %461 %3206
-OpBranch %88
-%88 = OpLabel
-%3207 = OpLoad %_arr_ushort_uint_8 %461
-%3208 = OpCompositeExtract %ushort %3207 0
-OpStore %190 %3208
-%3209 = OpLoad %ulong %168
-%3210 = OpLoad %ushort %190
-%3211 = OpFunctionCall %ulong %4 %3209 %3210
-OpStore %191 %3211
-%3212 = OpLoad %_arr_ushort_uint_8 %461
-%3213 = OpCompositeExtract %ushort %3212 1
-OpStore %192 %3213
-%3214 = OpLoad %ulong %191
-%3215 = OpLoad %ushort %192
-%3216 = OpFunctionCall %ulong %4 %3214 %3215
-OpStore %193 %3216
-%3217 = OpLoad %_arr_ushort_uint_8 %461
-%3218 = OpCompositeExtract %ushort %3217 2
-OpStore %194 %3218
-%3219 = OpLoad %ulong %193
-%3220 = OpLoad %ushort %194
-%3221 = OpFunctionCall %ulong %4 %3219 %3220
-OpStore %195 %3221
-%3222 = OpLoad %_arr_ushort_uint_8 %461
-%3223 = OpCompositeExtract %ushort %3222 3
-OpStore %196 %3223
-%3224 = OpLoad %ulong %195
-%3225 = OpLoad %ushort %196
-%3226 = OpFunctionCall %ulong %4 %3224 %3225
-OpStore %197 %3226
-%3227 = OpLoad %_arr_ushort_uint_8 %461
-%3228 = OpCompositeExtract %ushort %3227 4
-OpStore %198 %3228
-%3229 = OpLoad %ulong %197
-%3230 = OpLoad %ushort %198
-%3231 = OpFunctionCall %ulong %4 %3229 %3230
-OpStore %199 %3231
-%3232 = OpLoad %_arr_ushort_uint_8 %461
-%3233 = OpCompositeExtract %ushort %3232 5
-OpStore %200 %3233
-%3234 = OpLoad %ulong %199
-%3235 = OpLoad %ushort %200
-%3236 = OpFunctionCall %ulong %4 %3234 %3235
-OpStore %201 %3236
-%3237 = OpLoad %_arr_ushort_uint_8 %461
-%3238 = OpCompositeExtract %ushort %3237 6
-OpStore %202 %3238
-%3239 = OpLoad %ulong %201
-%3240 = OpLoad %ushort %202
-%3241 = OpFunctionCall %ulong %4 %3239 %3240
-OpStore %203 %3241
-%3242 = OpLoad %_arr_ushort_uint_8 %461
-%3243 = OpCompositeExtract %ushort %3242 7
-OpStore %204 %3243
-%3244 = OpLoad %ulong %203
-%3245 = OpLoad %ushort %204
-%3246 = OpFunctionCall %ulong %4 %3244 %3245
-OpStore %205 %3246
-OpBranch %89
-%89 = OpLabel
-%3247 = OpLoad %_arr_ushort_uint_8 %170
-%3248 = OpCompositeExtract %ushort %3247 0
-OpStore %526 %3248
-%3249 = OpLoad %_arr_ushort_uint_8 %461
-%3250 = OpCompositeExtract %ushort %3249 0
-OpStore %527 %3250
-%3251 = OpLoad %ushort %526
-%3252 = OpLoad %ushort %527
-%3253 = OpBitwiseXor %ushort %3251 %3252
-OpStore %528 %3253
-%3254 = OpLoad %_arr_ushort_uint_8 %170
-%3255 = OpCompositeExtract %ushort %3254 1
-OpStore %529 %3255
-%3256 = OpLoad %_arr_ushort_uint_8 %461
-%3257 = OpCompositeExtract %ushort %3256 1
-OpStore %530 %3257
-%3258 = OpLoad %ushort %529
-%3259 = OpLoad %ushort %530
-%3260 = OpBitwiseXor %ushort %3258 %3259
-OpStore %531 %3260
-%3261 = OpLoad %_arr_ushort_uint_8 %170
-%3262 = OpCompositeExtract %ushort %3261 2
-OpStore %532 %3262
-%3263 = OpLoad %_arr_ushort_uint_8 %461
-%3264 = OpCompositeExtract %ushort %3263 2
-OpStore %533 %3264
-%3265 = OpLoad %ushort %532
-%3266 = OpLoad %ushort %533
-%3267 = OpBitwiseXor %ushort %3265 %3266
-OpStore %534 %3267
-%3268 = OpLoad %_arr_ushort_uint_8 %170
-%3269 = OpCompositeExtract %ushort %3268 3
-OpStore %535 %3269
-%3270 = OpLoad %_arr_ushort_uint_8 %461
-%3271 = OpCompositeExtract %ushort %3270 3
-OpStore %536 %3271
-%3272 = OpLoad %ushort %535
-%3273 = OpLoad %ushort %536
-%3274 = OpBitwiseXor %ushort %3272 %3273
-OpStore %537 %3274
-%3275 = OpLoad %_arr_ushort_uint_8 %170
-%3276 = OpCompositeExtract %ushort %3275 4
-OpStore %538 %3276
-%3277 = OpLoad %_arr_ushort_uint_8 %461
-%3278 = OpCompositeExtract %ushort %3277 4
-OpStore %539 %3278
-%3279 = OpLoad %ushort %538
-%3280 = OpLoad %ushort %539
-%3281 = OpBitwiseXor %ushort %3279 %3280
-OpStore %540 %3281
-%3282 = OpLoad %_arr_ushort_uint_8 %170
-%3283 = OpCompositeExtract %ushort %3282 5
-OpStore %541 %3283
-%3284 = OpLoad %_arr_ushort_uint_8 %461
-%3285 = OpCompositeExtract %ushort %3284 5
-OpStore %542 %3285
-%3286 = OpLoad %ushort %541
-%3287 = OpLoad %ushort %542
-%3288 = OpBitwiseXor %ushort %3286 %3287
-OpStore %543 %3288
-%3289 = OpLoad %_arr_ushort_uint_8 %170
-%3290 = OpCompositeExtract %ushort %3289 6
-OpStore %544 %3290
-%3291 = OpLoad %_arr_ushort_uint_8 %461
-%3292 = OpCompositeExtract %ushort %3291 6
-OpStore %545 %3292
-%3293 = OpLoad %ushort %544
-%3294 = OpLoad %ushort %545
-%3295 = OpBitwiseXor %ushort %3293 %3294
-OpStore %546 %3295
-%3296 = OpLoad %_arr_ushort_uint_8 %170
-%3297 = OpCompositeExtract %ushort %3296 7
-OpStore %547 %3297
-%3298 = OpLoad %_arr_ushort_uint_8 %461
-%3299 = OpCompositeExtract %ushort %3298 7
-OpStore %548 %3299
-%3300 = OpLoad %ushort %547
-%3301 = OpLoad %ushort %548
-%3302 = OpBitwiseXor %ushort %3300 %3301
-OpStore %549 %3302
-%3303 = OpLoad %_arr_ushort_uint_8 %170
-%3304 = OpLoad %ushort %528
-%3305 = OpCompositeInsert %_arr_ushort_uint_8 %3304 %3303 0
-OpStore %550 %3305
-%3306 = OpLoad %_arr_ushort_uint_8 %550
-%3307 = OpLoad %ushort %531
-%3308 = OpCompositeInsert %_arr_ushort_uint_8 %3307 %3306 1
-OpStore %551 %3308
-%3309 = OpLoad %_arr_ushort_uint_8 %551
-%3310 = OpLoad %ushort %534
-%3311 = OpCompositeInsert %_arr_ushort_uint_8 %3310 %3309 2
-OpStore %552 %3311
-%3312 = OpLoad %_arr_ushort_uint_8 %552
-%3313 = OpLoad %ushort %537
-%3314 = OpCompositeInsert %_arr_ushort_uint_8 %3313 %3312 3
-OpStore %553 %3314
-%3315 = OpLoad %_arr_ushort_uint_8 %553
-%3316 = OpLoad %ushort %540
-%3317 = OpCompositeInsert %_arr_ushort_uint_8 %3316 %3315 4
-OpStore %554 %3317
-%3318 = OpLoad %_arr_ushort_uint_8 %554
-%3319 = OpLoad %ushort %543
-%3320 = OpCompositeInsert %_arr_ushort_uint_8 %3319 %3318 5
-OpStore %555 %3320
-%3321 = OpLoad %_arr_ushort_uint_8 %555
-%3322 = OpLoad %ushort %546
-%3323 = OpCompositeInsert %_arr_ushort_uint_8 %3322 %3321 6
-OpStore %556 %3323
-%3324 = OpLoad %_arr_ushort_uint_8 %556
-%3325 = OpLoad %ushort %549
-%3326 = OpCompositeInsert %_arr_ushort_uint_8 %3325 %3324 7
-OpStore %557 %3326
-OpBranch %96
-%96 = OpLabel
-%3327 = OpLoad %_arr_ushort_uint_8 %557
-%3328 = OpCompositeExtract %ushort %3327 0
-OpStore %254 %3328
-%3329 = OpLoad %ulong %205
-%3330 = OpLoad %ushort %254
-%3331 = OpFunctionCall %ulong %4 %3329 %3330
-OpStore %255 %3331
-%3332 = OpLoad %_arr_ushort_uint_8 %557
-%3333 = OpCompositeExtract %ushort %3332 1
-OpStore %256 %3333
-%3334 = OpLoad %ulong %255
-%3335 = OpLoad %ushort %256
-%3336 = OpFunctionCall %ulong %4 %3334 %3335
-OpStore %257 %3336
-%3337 = OpLoad %_arr_ushort_uint_8 %557
-%3338 = OpCompositeExtract %ushort %3337 2
-OpStore %258 %3338
-%3339 = OpLoad %ulong %257
-%3340 = OpLoad %ushort %258
-%3341 = OpFunctionCall %ulong %4 %3339 %3340
-OpStore %259 %3341
-%3342 = OpLoad %_arr_ushort_uint_8 %557
-%3343 = OpCompositeExtract %ushort %3342 3
-OpStore %260 %3343
-%3344 = OpLoad %ulong %259
-%3345 = OpLoad %ushort %260
-%3346 = OpFunctionCall %ulong %4 %3344 %3345
-OpStore %261 %3346
-%3347 = OpLoad %_arr_ushort_uint_8 %557
-%3348 = OpCompositeExtract %ushort %3347 4
-OpStore %262 %3348
-%3349 = OpLoad %ulong %261
-%3350 = OpLoad %ushort %262
-%3351 = OpFunctionCall %ulong %4 %3349 %3350
-OpStore %263 %3351
-%3352 = OpLoad %_arr_ushort_uint_8 %557
-%3353 = OpCompositeExtract %ushort %3352 5
-OpStore %264 %3353
-%3354 = OpLoad %ulong %263
-%3355 = OpLoad %ushort %264
-%3356 = OpFunctionCall %ulong %4 %3354 %3355
-OpStore %265 %3356
-%3357 = OpLoad %_arr_ushort_uint_8 %557
-%3358 = OpCompositeExtract %ushort %3357 6
-OpStore %266 %3358
-%3359 = OpLoad %ulong %265
-%3360 = OpLoad %ushort %266
-%3361 = OpFunctionCall %ulong %4 %3359 %3360
-OpStore %267 %3361
-%3362 = OpLoad %_arr_ushort_uint_8 %557
-%3363 = OpCompositeExtract %ushort %3362 7
-OpStore %268 %3363
-%3364 = OpLoad %ulong %267
-%3365 = OpLoad %ushort %268
-%3366 = OpFunctionCall %ulong %4 %3364 %3365
-OpStore %269 %3366
-OpBranch %97
-%97 = OpLabel
-%3367 = OpLoad %_arr_ushort_uint_8 %171
-%3368 = OpCompositeExtract %ushort %3367 0
-OpStore %590 %3368
-%3369 = OpLoad %_arr_ushort_uint_8 %169
-%3370 = OpCompositeExtract %ushort %3369 0
-OpStore %591 %3370
-%3371 = OpLoad %ushort %590
-%3372 = OpLoad %ushort %591
-%3373 = OpIAdd %ushort %3371 %3372
-OpStore %592 %3373
-%3374 = OpLoad %_arr_ushort_uint_8 %171
-%3375 = OpCompositeExtract %ushort %3374 1
-OpStore %593 %3375
-%3376 = OpLoad %_arr_ushort_uint_8 %169
-%3377 = OpCompositeExtract %ushort %3376 1
-OpStore %594 %3377
-%3378 = OpLoad %ushort %593
-%3379 = OpLoad %ushort %594
-%3380 = OpIAdd %ushort %3378 %3379
-OpStore %595 %3380
-%3381 = OpLoad %_arr_ushort_uint_8 %171
-%3382 = OpCompositeExtract %ushort %3381 2
-OpStore %596 %3382
-%3383 = OpLoad %_arr_ushort_uint_8 %169
-%3384 = OpCompositeExtract %ushort %3383 2
-OpStore %597 %3384
-%3385 = OpLoad %ushort %596
-%3386 = OpLoad %ushort %597
-%3387 = OpIAdd %ushort %3385 %3386
-OpStore %598 %3387
-%3388 = OpLoad %_arr_ushort_uint_8 %171
-%3389 = OpCompositeExtract %ushort %3388 3
-OpStore %599 %3389
-%3390 = OpLoad %_arr_ushort_uint_8 %169
-%3391 = OpCompositeExtract %ushort %3390 3
-OpStore %600 %3391
-%3392 = OpLoad %ushort %599
-%3393 = OpLoad %ushort %600
-%3394 = OpIAdd %ushort %3392 %3393
-OpStore %601 %3394
-%3395 = OpLoad %_arr_ushort_uint_8 %171
-%3396 = OpCompositeExtract %ushort %3395 4
-OpStore %602 %3396
-%3397 = OpLoad %_arr_ushort_uint_8 %169
-%3398 = OpCompositeExtract %ushort %3397 4
-OpStore %603 %3398
-%3399 = OpLoad %ushort %602
-%3400 = OpLoad %ushort %603
-%3401 = OpIAdd %ushort %3399 %3400
-OpStore %604 %3401
-%3402 = OpLoad %_arr_ushort_uint_8 %171
-%3403 = OpCompositeExtract %ushort %3402 5
-OpStore %605 %3403
-%3404 = OpLoad %_arr_ushort_uint_8 %169
-%3405 = OpCompositeExtract %ushort %3404 5
-OpStore %606 %3405
-%3406 = OpLoad %ushort %605
-%3407 = OpLoad %ushort %606
-%3408 = OpIAdd %ushort %3406 %3407
-OpStore %607 %3408
-%3409 = OpLoad %_arr_ushort_uint_8 %171
-%3410 = OpCompositeExtract %ushort %3409 6
-OpStore %608 %3410
-%3411 = OpLoad %_arr_ushort_uint_8 %169
-%3412 = OpCompositeExtract %ushort %3411 6
-OpStore %609 %3412
-%3413 = OpLoad %ushort %608
-%3414 = OpLoad %ushort %609
-%3415 = OpIAdd %ushort %3413 %3414
-OpStore %610 %3415
-%3416 = OpLoad %_arr_ushort_uint_8 %171
-%3417 = OpCompositeExtract %ushort %3416 7
-OpStore %611 %3417
-%3418 = OpLoad %_arr_ushort_uint_8 %169
-%3419 = OpCompositeExtract %ushort %3418 7
-OpStore %612 %3419
-%3420 = OpLoad %ushort %611
-%3421 = OpLoad %ushort %612
-%3422 = OpIAdd %ushort %3420 %3421
-OpStore %613 %3422
-%3423 = OpLoad %_arr_ushort_uint_8 %171
-%3424 = OpLoad %ushort %592
-%3425 = OpCompositeInsert %_arr_ushort_uint_8 %3424 %3423 0
-OpStore %614 %3425
-%3426 = OpLoad %_arr_ushort_uint_8 %614
-%3427 = OpLoad %ushort %595
-%3428 = OpCompositeInsert %_arr_ushort_uint_8 %3427 %3426 1
-OpStore %615 %3428
-%3429 = OpLoad %_arr_ushort_uint_8 %615
-%3430 = OpLoad %ushort %598
-%3431 = OpCompositeInsert %_arr_ushort_uint_8 %3430 %3429 2
-OpStore %616 %3431
-%3432 = OpLoad %_arr_ushort_uint_8 %616
-%3433 = OpLoad %ushort %601
-%3434 = OpCompositeInsert %_arr_ushort_uint_8 %3433 %3432 3
-OpStore %617 %3434
-%3435 = OpLoad %_arr_ushort_uint_8 %617
-%3436 = OpLoad %ushort %604
-%3437 = OpCompositeInsert %_arr_ushort_uint_8 %3436 %3435 4
-OpStore %618 %3437
-%3438 = OpLoad %_arr_ushort_uint_8 %618
-%3439 = OpLoad %ushort %607
-%3440 = OpCompositeInsert %_arr_ushort_uint_8 %3439 %3438 5
-OpStore %619 %3440
-%3441 = OpLoad %_arr_ushort_uint_8 %619
-%3442 = OpLoad %ushort %610
-%3443 = OpCompositeInsert %_arr_ushort_uint_8 %3442 %3441 6
-OpStore %620 %3443
-%3444 = OpLoad %_arr_ushort_uint_8 %620
-%3445 = OpLoad %ushort %613
-%3446 = OpCompositeInsert %_arr_ushort_uint_8 %3445 %3444 7
-OpStore %621 %3446
-OpBranch %100
-%100 = OpLabel
-%3447 = OpLoad %_arr_ushort_uint_8 %621
-%3448 = OpCompositeExtract %ushort %3447 0
-OpStore %286 %3448
-%3449 = OpLoad %ulong %269
-%3450 = OpLoad %ushort %286
-%3451 = OpFunctionCall %ulong %4 %3449 %3450
-OpStore %287 %3451
-%3452 = OpLoad %_arr_ushort_uint_8 %621
-%3453 = OpCompositeExtract %ushort %3452 1
-OpStore %288 %3453
-%3454 = OpLoad %ulong %287
-%3455 = OpLoad %ushort %288
-%3456 = OpFunctionCall %ulong %4 %3454 %3455
-OpStore %289 %3456
-%3457 = OpLoad %_arr_ushort_uint_8 %621
-%3458 = OpCompositeExtract %ushort %3457 2
-OpStore %290 %3458
-%3459 = OpLoad %ulong %289
-%3460 = OpLoad %ushort %290
-%3461 = OpFunctionCall %ulong %4 %3459 %3460
-OpStore %291 %3461
-%3462 = OpLoad %_arr_ushort_uint_8 %621
-%3463 = OpCompositeExtract %ushort %3462 3
-OpStore %292 %3463
-%3464 = OpLoad %ulong %291
-%3465 = OpLoad %ushort %292
-%3466 = OpFunctionCall %ulong %4 %3464 %3465
-OpStore %293 %3466
-%3467 = OpLoad %_arr_ushort_uint_8 %621
-%3468 = OpCompositeExtract %ushort %3467 4
-OpStore %294 %3468
-%3469 = OpLoad %ulong %293
-%3470 = OpLoad %ushort %294
-%3471 = OpFunctionCall %ulong %4 %3469 %3470
-OpStore %295 %3471
-%3472 = OpLoad %_arr_ushort_uint_8 %621
-%3473 = OpCompositeExtract %ushort %3472 5
-OpStore %296 %3473
-%3474 = OpLoad %ulong %295
-%3475 = OpLoad %ushort %296
-%3476 = OpFunctionCall %ulong %4 %3474 %3475
-OpStore %297 %3476
-%3477 = OpLoad %_arr_ushort_uint_8 %621
-%3478 = OpCompositeExtract %ushort %3477 6
-OpStore %298 %3478
-%3479 = OpLoad %ulong %297
-%3480 = OpLoad %ushort %298
-%3481 = OpFunctionCall %ulong %4 %3479 %3480
-OpStore %299 %3481
-%3482 = OpLoad %_arr_ushort_uint_8 %621
-%3483 = OpCompositeExtract %ushort %3482 7
-OpStore %300 %3483
-%3484 = OpLoad %ulong %299
-%3485 = OpLoad %ushort %300
-%3486 = OpFunctionCall %ulong %4 %3484 %3485
-OpStore %301 %3486
-OpBranch %101
-%101 = OpLabel
-%3487 = OpLoad %_arr_ushort_uint_8 %169
-%3488 = OpCompositeExtract %ushort %3487 0
-OpStore %654 %3488
-%3489 = OpLoad %_arr_ushort_uint_8 %146
-%3490 = OpCompositeExtract %ushort %3489 0
-OpStore %655 %3490
-%3491 = OpLoad %ushort %654
-%3492 = OpLoad %ushort %655
-%3493 = OpIAdd %ushort %3491 %3492
-OpStore %656 %3493
-%3494 = OpLoad %_arr_ushort_uint_8 %169
-%3495 = OpCompositeExtract %ushort %3494 1
-OpStore %657 %3495
-%3496 = OpLoad %_arr_ushort_uint_8 %146
-%3497 = OpCompositeExtract %ushort %3496 1
-OpStore %658 %3497
-%3498 = OpLoad %ushort %657
-%3499 = OpLoad %ushort %658
-%3500 = OpIAdd %ushort %3498 %3499
-OpStore %659 %3500
-%3501 = OpLoad %_arr_ushort_uint_8 %169
-%3502 = OpCompositeExtract %ushort %3501 2
-OpStore %660 %3502
-%3503 = OpLoad %_arr_ushort_uint_8 %146
-%3504 = OpCompositeExtract %ushort %3503 2
-OpStore %661 %3504
-%3505 = OpLoad %ushort %660
-%3506 = OpLoad %ushort %661
-%3507 = OpIAdd %ushort %3505 %3506
-OpStore %662 %3507
-%3508 = OpLoad %_arr_ushort_uint_8 %169
-%3509 = OpCompositeExtract %ushort %3508 3
-OpStore %663 %3509
-%3510 = OpLoad %_arr_ushort_uint_8 %146
-%3511 = OpCompositeExtract %ushort %3510 3
-OpStore %664 %3511
-%3512 = OpLoad %ushort %663
-%3513 = OpLoad %ushort %664
-%3514 = OpIAdd %ushort %3512 %3513
-OpStore %665 %3514
-%3515 = OpLoad %_arr_ushort_uint_8 %169
-%3516 = OpCompositeExtract %ushort %3515 4
-OpStore %666 %3516
-%3517 = OpLoad %_arr_ushort_uint_8 %146
-%3518 = OpCompositeExtract %ushort %3517 4
-OpStore %667 %3518
-%3519 = OpLoad %ushort %666
-%3520 = OpLoad %ushort %667
-%3521 = OpIAdd %ushort %3519 %3520
-OpStore %668 %3521
-%3522 = OpLoad %_arr_ushort_uint_8 %169
-%3523 = OpCompositeExtract %ushort %3522 5
-OpStore %669 %3523
-%3524 = OpLoad %_arr_ushort_uint_8 %146
-%3525 = OpCompositeExtract %ushort %3524 5
-OpStore %670 %3525
-%3526 = OpLoad %ushort %669
-%3527 = OpLoad %ushort %670
-%3528 = OpIAdd %ushort %3526 %3527
-OpStore %671 %3528
-%3529 = OpLoad %_arr_ushort_uint_8 %169
-%3530 = OpCompositeExtract %ushort %3529 6
-OpStore %672 %3530
-%3531 = OpLoad %_arr_ushort_uint_8 %146
-%3532 = OpCompositeExtract %ushort %3531 6
-OpStore %673 %3532
-%3533 = OpLoad %ushort %672
-%3534 = OpLoad %ushort %673
-%3535 = OpIAdd %ushort %3533 %3534
-OpStore %674 %3535
-%3536 = OpLoad %_arr_ushort_uint_8 %169
-%3537 = OpCompositeExtract %ushort %3536 7
-OpStore %675 %3537
-%3538 = OpLoad %_arr_ushort_uint_8 %146
-%3539 = OpCompositeExtract %ushort %3538 7
-OpStore %676 %3539
-%3540 = OpLoad %ushort %675
-%3541 = OpLoad %ushort %676
-%3542 = OpIAdd %ushort %3540 %3541
-OpStore %677 %3542
-%3543 = OpLoad %_arr_ushort_uint_8 %169
-%3544 = OpLoad %ushort %656
-%3545 = OpCompositeInsert %_arr_ushort_uint_8 %3544 %3543 0
-OpStore %678 %3545
-%3546 = OpLoad %_arr_ushort_uint_8 %678
-%3547 = OpLoad %ushort %659
-%3548 = OpCompositeInsert %_arr_ushort_uint_8 %3547 %3546 1
-OpStore %679 %3548
-%3549 = OpLoad %_arr_ushort_uint_8 %679
-%3550 = OpLoad %ushort %662
-%3551 = OpCompositeInsert %_arr_ushort_uint_8 %3550 %3549 2
-OpStore %680 %3551
-%3552 = OpLoad %_arr_ushort_uint_8 %680
-%3553 = OpLoad %ushort %665
-%3554 = OpCompositeInsert %_arr_ushort_uint_8 %3553 %3552 3
-OpStore %681 %3554
-%3555 = OpLoad %_arr_ushort_uint_8 %681
-%3556 = OpLoad %ushort %668
-%3557 = OpCompositeInsert %_arr_ushort_uint_8 %3556 %3555 4
-OpStore %682 %3557
-%3558 = OpLoad %_arr_ushort_uint_8 %682
-%3559 = OpLoad %ushort %671
-%3560 = OpCompositeInsert %_arr_ushort_uint_8 %3559 %3558 5
-OpStore %683 %3560
-%3561 = OpLoad %_arr_ushort_uint_8 %683
-%3562 = OpLoad %ushort %674
-%3563 = OpCompositeInsert %_arr_ushort_uint_8 %3562 %3561 6
-OpStore %684 %3563
-%3564 = OpLoad %_arr_ushort_uint_8 %684
-%3565 = OpLoad %ushort %677
-%3566 = OpCompositeInsert %_arr_ushort_uint_8 %3565 %3564 7
-OpStore %685 %3566
-OpBranch %104
-%104 = OpLabel
-%3567 = OpLoad %_arr_ushort_uint_8 %685
-%3568 = OpCompositeExtract %ushort %3567 0
-OpStore %318 %3568
-%3569 = OpLoad %ulong %301
-%3570 = OpLoad %ushort %318
-%3571 = OpFunctionCall %ulong %4 %3569 %3570
-OpStore %319 %3571
-%3572 = OpLoad %_arr_ushort_uint_8 %685
-%3573 = OpCompositeExtract %ushort %3572 1
-OpStore %320 %3573
-%3574 = OpLoad %ulong %319
-%3575 = OpLoad %ushort %320
-%3576 = OpFunctionCall %ulong %4 %3574 %3575
-OpStore %321 %3576
-%3577 = OpLoad %_arr_ushort_uint_8 %685
-%3578 = OpCompositeExtract %ushort %3577 2
-OpStore %322 %3578
-%3579 = OpLoad %ulong %321
-%3580 = OpLoad %ushort %322
-%3581 = OpFunctionCall %ulong %4 %3579 %3580
-OpStore %323 %3581
-%3582 = OpLoad %_arr_ushort_uint_8 %685
-%3583 = OpCompositeExtract %ushort %3582 3
-OpStore %324 %3583
-%3584 = OpLoad %ulong %323
-%3585 = OpLoad %ushort %324
-%3586 = OpFunctionCall %ulong %4 %3584 %3585
-OpStore %325 %3586
-%3587 = OpLoad %_arr_ushort_uint_8 %685
-%3588 = OpCompositeExtract %ushort %3587 4
-OpStore %326 %3588
-%3589 = OpLoad %ulong %325
-%3590 = OpLoad %ushort %326
-%3591 = OpFunctionCall %ulong %4 %3589 %3590
-OpStore %327 %3591
-%3592 = OpLoad %_arr_ushort_uint_8 %685
-%3593 = OpCompositeExtract %ushort %3592 5
-OpStore %328 %3593
-%3594 = OpLoad %ulong %327
-%3595 = OpLoad %ushort %328
-%3596 = OpFunctionCall %ulong %4 %3594 %3595
-OpStore %329 %3596
-%3597 = OpLoad %_arr_ushort_uint_8 %685
-%3598 = OpCompositeExtract %ushort %3597 6
-OpStore %330 %3598
-%3599 = OpLoad %ulong %329
-%3600 = OpLoad %ushort %330
-%3601 = OpFunctionCall %ulong %4 %3599 %3600
-OpStore %331 %3601
-%3602 = OpLoad %_arr_ushort_uint_8 %685
-%3603 = OpCompositeExtract %ushort %3602 7
-OpStore %332 %3603
-%3604 = OpLoad %ulong %331
-%3605 = OpLoad %ushort %332
-%3606 = OpFunctionCall %ulong %4 %3604 %3605
-OpStore %333 %3606
-OpBranch %105
-%105 = OpLabel
-%3607 = OpLoad %ulong %172
-%3608 = OpIAdd %ulong %3607 %ulong_1
-OpStore %156 %3608
-%3609 = OpLoad %ulong %333
-OpStore %168 %3609
-%3610 = OpLoad %_arr_ushort_uint_8 %685
-OpStore %169 %3610
-%3611 = OpLoad %_arr_ushort_uint_8 %557
-OpStore %170 %3611
-%3612 = OpLoad %_arr_ushort_uint_8 %621
-OpStore %171 %3612
-%3613 = OpLoad %ulong %156
-OpStore %172 %3613
-OpBranch %119
-%118 = OpLabel
-OpBranch %83
-%119 = OpLabel
-OpBranch %80
-OpFunctionEnd
-%3 = OpFunction %ulong None %3614
-%3615 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %3617
-%3618 = OpFunctionParameter %ulong
-%3619 = OpFunctionParameter %ushort
-%3620 = OpLabel
-%3627 = OpVariable %_ptr_Function_ulong Function
-%3628 = OpVariable %_ptr_Function_ushort Function
-%3629 = OpVariable %_ptr_Function_ulong Function
-%3630 = OpVariable %_ptr_Function_bool Function
-%3631 = OpVariable %_ptr_Function_ulong Function
-%3632 = OpVariable %_ptr_Function_ulong Function
-%3633 = OpVariable %_ptr_Function_ulong Function
-%3634 = OpVariable %_ptr_Function_ulong Function
-%3635 = OpVariable %_ptr_Function_ulong Function
-%3636 = OpVariable %_ptr_Function_ulong Function
-%3637 = OpVariable %_ptr_Function_ulong Function
-%3638 = OpVariable %_ptr_Function_ulong Function
-OpStore %3627 %3618
-OpStore %3628 %3619
-%3639 = OpLoad %ushort %3628
-%3640 = OpUConvert %ulong %3639
-OpStore %3629 %3640
-OpBranch %3621
-%3621 = OpLabel
-%3641 = OpLoad %ulong %3627
-OpStore %3637 %3641
-OpStore %3638 %ulong_0
-OpBranch %3622
-%3622 = OpLabel
-%3642 = OpLoad %ulong %3638
-%3644 = OpULessThan %bool %3642 %ulong_8
-OpStore %3630 %3644
-%3645 = OpLoad %bool %3630
-OpLoopMerge %3624 %3626 None
-OpBranchConditional %3645 %3623 %3624
-%3624 = OpLabel
-OpBranch %3625
-%3625 = OpLabel
-%3646 = OpLoad %ulong %3637
-OpReturnValue %3646
-%3623 = OpLabel
-%3647 = OpLoad %ulong %3638
-%3648 = OpIMul %ulong %3647 %ulong_8
-OpStore %3631 %3648
-%3649 = OpLoad %ulong %3629
-%3650 = OpLoad %ulong %3631
-%3651 = OpShiftRightLogical %ulong %3649 %3650
-OpStore %3632 %3651
-%3652 = OpLoad %ulong %3632
-%3654 = OpBitwiseAnd %ulong %3652 %ulong_255
-OpStore %3633 %3654
-%3655 = OpLoad %ulong %3637
-%3656 = OpLoad %ulong %3633
-%3657 = OpBitwiseXor %ulong %3655 %3656
-OpStore %3634 %3657
-%3658 = OpLoad %ulong %3634
-%3660 = OpIMul %ulong %3658 %ulong_1099511628211
-OpStore %3635 %3660
-%3661 = OpLoad %ulong %3638
-%3662 = OpIAdd %ulong %3661 %ulong_1
-OpStore %3636 %3662
-%3663 = OpLoad %ulong %3635
-OpStore %3637 %3663
-%3664 = OpLoad %ulong %3636
-OpStore %3638 %3664
-OpBranch %3626
-%3626 = OpLabel
-OpBranch %3622
-OpFunctionEnd
-%5 = OpFunction %ulong None %3665
-%3666 = OpFunctionParameter %ulong
-%3667 = OpFunctionParameter %uint
-%3668 = OpLabel
-%3675 = OpVariable %_ptr_Function_ulong Function
-%3676 = OpVariable %_ptr_Function_uint Function
-%3677 = OpVariable %_ptr_Function_ulong Function
-%3678 = OpVariable %_ptr_Function_bool Function
-%3679 = OpVariable %_ptr_Function_ulong Function
-%3680 = OpVariable %_ptr_Function_ulong Function
-%3681 = OpVariable %_ptr_Function_ulong Function
-%3682 = OpVariable %_ptr_Function_ulong Function
-%3683 = OpVariable %_ptr_Function_ulong Function
-%3684 = OpVariable %_ptr_Function_ulong Function
-%3685 = OpVariable %_ptr_Function_ulong Function
-%3686 = OpVariable %_ptr_Function_ulong Function
-OpStore %3675 %3666
-OpStore %3676 %3667
-%3687 = OpLoad %uint %3676
-%3688 = OpUConvert %ulong %3687
-OpStore %3677 %3688
-OpBranch %3669
-%3669 = OpLabel
-%3689 = OpLoad %ulong %3675
-OpStore %3685 %3689
-OpStore %3686 %ulong_0
-OpBranch %3670
-%3670 = OpLabel
-%3690 = OpLoad %ulong %3686
-%3691 = OpULessThan %bool %3690 %ulong_8
-OpStore %3678 %3691
-%3692 = OpLoad %bool %3678
-OpLoopMerge %3672 %3674 None
-OpBranchConditional %3692 %3671 %3672
-%3672 = OpLabel
-OpBranch %3673
-%3673 = OpLabel
-%3693 = OpLoad %ulong %3685
-OpReturnValue %3693
-%3671 = OpLabel
-%3694 = OpLoad %ulong %3686
-%3695 = OpIMul %ulong %3694 %ulong_8
-OpStore %3679 %3695
-%3696 = OpLoad %ulong %3677
-%3697 = OpLoad %ulong %3679
-%3698 = OpShiftRightLogical %ulong %3696 %3697
-OpStore %3680 %3698
-%3699 = OpLoad %ulong %3680
-%3700 = OpBitwiseAnd %ulong %3699 %ulong_255
-OpStore %3681 %3700
-%3701 = OpLoad %ulong %3685
-%3702 = OpLoad %ulong %3681
-%3703 = OpBitwiseXor %ulong %3701 %3702
-OpStore %3682 %3703
-%3704 = OpLoad %ulong %3682
-%3705 = OpIMul %ulong %3704 %ulong_1099511628211
-OpStore %3683 %3705
-%3706 = OpLoad %ulong %3686
-%3707 = OpIAdd %ulong %3706 %ulong_1
-OpStore %3684 %3707
-%3708 = OpLoad %ulong %3683
-OpStore %3685 %3708
-%3709 = OpLoad %ulong %3684
-OpStore %3686 %3709
-OpBranch %3674
-%3674 = OpLabel
-OpBranch %3670
+OpStore %1085 %2265
+%2266 = OpLoad %ushort %1085
+%2267 = OpNot %ushort %2266
+OpStore %1086 %2267
+%2268 = OpLoad %_arr_ushort_uint_8 %422
+%2269 = OpCompositeExtract %ushort %2268 2
+OpStore %1087 %2269
+%2270 = OpLoad %ushort %1087
+%2271 = OpNot %ushort %2270
+OpStore %1088 %2271
+%2272 = OpLoad %_arr_ushort_uint_8 %422
+%2273 = OpCompositeExtract %ushort %2272 3
+OpStore %1089 %2273
+%2274 = OpLoad %ushort %1089
+%2275 = OpNot %ushort %2274
+OpStore %1090 %2275
+%2276 = OpLoad %_arr_ushort_uint_8 %422
+%2277 = OpCompositeExtract %ushort %2276 4
+OpStore %1091 %2277
+%2278 = OpLoad %ushort %1091
+%2279 = OpNot %ushort %2278
+OpStore %1092 %2279
+%2280 = OpLoad %_arr_ushort_uint_8 %422
+%2281 = OpCompositeExtract %ushort %2280 5
+OpStore %1093 %2281
+%2282 = OpLoad %ushort %1093
+%2283 = OpNot %ushort %2282
+OpStore %1094 %2283
+%2284 = OpLoad %_arr_ushort_uint_8 %422
+%2285 = OpCompositeExtract %ushort %2284 6
+OpStore %1095 %2285
+%2286 = OpLoad %ushort %1095
+%2287 = OpNot %ushort %2286
+OpStore %1096 %2287
+%2288 = OpLoad %_arr_ushort_uint_8 %422
+%2289 = OpCompositeExtract %ushort %2288 7
+OpStore %1097 %2289
+%2290 = OpLoad %ushort %1097
+%2291 = OpNot %ushort %2290
+OpStore %1098 %2291
+%2292 = OpLoad %_arr_ushort_uint_8 %422
+%2293 = OpLoad %ushort %1084
+%2294 = OpCompositeInsert %_arr_ushort_uint_8 %2293 %2292 0
+OpStore %1099 %2294
+%2295 = OpLoad %_arr_ushort_uint_8 %1099
+%2296 = OpLoad %ushort %1086
+%2297 = OpCompositeInsert %_arr_ushort_uint_8 %2296 %2295 1
+OpStore %1100 %2297
+%2298 = OpLoad %_arr_ushort_uint_8 %1100
+%2299 = OpLoad %ushort %1088
+%2300 = OpCompositeInsert %_arr_ushort_uint_8 %2299 %2298 2
+OpStore %1101 %2300
+%2301 = OpLoad %_arr_ushort_uint_8 %1101
+%2302 = OpLoad %ushort %1090
+%2303 = OpCompositeInsert %_arr_ushort_uint_8 %2302 %2301 3
+OpStore %1102 %2303
+%2304 = OpLoad %_arr_ushort_uint_8 %1102
+%2305 = OpLoad %ushort %1092
+%2306 = OpCompositeInsert %_arr_ushort_uint_8 %2305 %2304 4
+OpStore %1103 %2306
+%2307 = OpLoad %_arr_ushort_uint_8 %1103
+%2308 = OpLoad %ushort %1094
+%2309 = OpCompositeInsert %_arr_ushort_uint_8 %2308 %2307 5
+OpStore %1104 %2309
+%2310 = OpLoad %_arr_ushort_uint_8 %1104
+%2311 = OpLoad %ushort %1096
+%2312 = OpCompositeInsert %_arr_ushort_uint_8 %2311 %2310 6
+OpStore %1105 %2312
+%2313 = OpLoad %_arr_ushort_uint_8 %1105
+%2314 = OpLoad %ushort %1098
+%2315 = OpCompositeInsert %_arr_ushort_uint_8 %2314 %2313 7
+OpStore %1106 %2315
+%2316 = OpLoad %ulong %437
+%2317 = OpLoad %_arr_ushort_uint_8 %1106
+%2318 = OpFunctionCall %ulong %1 %2316 %2317
+OpStore %438 %2318
+%2319 = OpLoad %_arr_ushort_uint_8 %994
+%2320 = OpCompositeExtract %ushort %2319 0
+OpStore %1107 %2320
+%2321 = OpLoad %_arr_ushort_uint_8 %1026
+%2322 = OpCompositeExtract %ushort %2321 0
+OpStore %1108 %2322
+%2323 = OpLoad %ushort %1107
+%2324 = OpLoad %ushort %1108
+%2325 = OpBitwiseXor %ushort %2323 %2324
+OpStore %1109 %2325
+%2326 = OpLoad %_arr_ushort_uint_8 %994
+%2327 = OpCompositeExtract %ushort %2326 1
+OpStore %1110 %2327
+%2328 = OpLoad %_arr_ushort_uint_8 %1026
+%2329 = OpCompositeExtract %ushort %2328 1
+OpStore %1111 %2329
+%2330 = OpLoad %ushort %1110
+%2331 = OpLoad %ushort %1111
+%2332 = OpBitwiseXor %ushort %2330 %2331
+OpStore %1112 %2332
+%2333 = OpLoad %_arr_ushort_uint_8 %994
+%2334 = OpCompositeExtract %ushort %2333 2
+OpStore %1113 %2334
+%2335 = OpLoad %_arr_ushort_uint_8 %1026
+%2336 = OpCompositeExtract %ushort %2335 2
+OpStore %1114 %2336
+%2337 = OpLoad %ushort %1113
+%2338 = OpLoad %ushort %1114
+%2339 = OpBitwiseXor %ushort %2337 %2338
+OpStore %1115 %2339
+%2340 = OpLoad %_arr_ushort_uint_8 %994
+%2341 = OpCompositeExtract %ushort %2340 3
+OpStore %1116 %2341
+%2342 = OpLoad %_arr_ushort_uint_8 %1026
+%2343 = OpCompositeExtract %ushort %2342 3
+OpStore %1117 %2343
+%2344 = OpLoad %ushort %1116
+%2345 = OpLoad %ushort %1117
+%2346 = OpBitwiseXor %ushort %2344 %2345
+OpStore %1118 %2346
+%2347 = OpLoad %_arr_ushort_uint_8 %994
+%2348 = OpCompositeExtract %ushort %2347 4
+OpStore %1119 %2348
+%2349 = OpLoad %_arr_ushort_uint_8 %1026
+%2350 = OpCompositeExtract %ushort %2349 4
+OpStore %1120 %2350
+%2351 = OpLoad %ushort %1119
+%2352 = OpLoad %ushort %1120
+%2353 = OpBitwiseXor %ushort %2351 %2352
+OpStore %1121 %2353
+%2354 = OpLoad %_arr_ushort_uint_8 %994
+%2355 = OpCompositeExtract %ushort %2354 5
+OpStore %1122 %2355
+%2356 = OpLoad %_arr_ushort_uint_8 %1026
+%2357 = OpCompositeExtract %ushort %2356 5
+OpStore %1123 %2357
+%2358 = OpLoad %ushort %1122
+%2359 = OpLoad %ushort %1123
+%2360 = OpBitwiseXor %ushort %2358 %2359
+OpStore %1124 %2360
+%2361 = OpLoad %_arr_ushort_uint_8 %994
+%2362 = OpCompositeExtract %ushort %2361 6
+OpStore %1125 %2362
+%2363 = OpLoad %_arr_ushort_uint_8 %1026
+%2364 = OpCompositeExtract %ushort %2363 6
+OpStore %1126 %2364
+%2365 = OpLoad %ushort %1125
+%2366 = OpLoad %ushort %1126
+%2367 = OpBitwiseXor %ushort %2365 %2366
+OpStore %1127 %2367
+%2368 = OpLoad %_arr_ushort_uint_8 %994
+%2369 = OpCompositeExtract %ushort %2368 7
+OpStore %1128 %2369
+%2370 = OpLoad %_arr_ushort_uint_8 %1026
+%2371 = OpCompositeExtract %ushort %2370 7
+OpStore %1129 %2371
+%2372 = OpLoad %ushort %1128
+%2373 = OpLoad %ushort %1129
+%2374 = OpBitwiseXor %ushort %2372 %2373
+OpStore %1130 %2374
+%2375 = OpLoad %_arr_ushort_uint_8 %994
+%2376 = OpLoad %ushort %1109
+%2377 = OpCompositeInsert %_arr_ushort_uint_8 %2376 %2375 0
+OpStore %1131 %2377
+%2378 = OpLoad %_arr_ushort_uint_8 %1131
+%2379 = OpLoad %ushort %1112
+%2380 = OpCompositeInsert %_arr_ushort_uint_8 %2379 %2378 1
+OpStore %1132 %2380
+%2381 = OpLoad %_arr_ushort_uint_8 %1132
+%2382 = OpLoad %ushort %1115
+%2383 = OpCompositeInsert %_arr_ushort_uint_8 %2382 %2381 2
+OpStore %1133 %2383
+%2384 = OpLoad %_arr_ushort_uint_8 %1133
+%2385 = OpLoad %ushort %1118
+%2386 = OpCompositeInsert %_arr_ushort_uint_8 %2385 %2384 3
+OpStore %1134 %2386
+%2387 = OpLoad %_arr_ushort_uint_8 %1134
+%2388 = OpLoad %ushort %1121
+%2389 = OpCompositeInsert %_arr_ushort_uint_8 %2388 %2387 4
+OpStore %1135 %2389
+%2390 = OpLoad %_arr_ushort_uint_8 %1135
+%2391 = OpLoad %ushort %1124
+%2392 = OpCompositeInsert %_arr_ushort_uint_8 %2391 %2390 5
+OpStore %1136 %2392
+%2393 = OpLoad %_arr_ushort_uint_8 %1136
+%2394 = OpLoad %ushort %1127
+%2395 = OpCompositeInsert %_arr_ushort_uint_8 %2394 %2393 6
+OpStore %1137 %2395
+%2396 = OpLoad %_arr_ushort_uint_8 %1137
+%2397 = OpLoad %ushort %1130
+%2398 = OpCompositeInsert %_arr_ushort_uint_8 %2397 %2396 7
+OpStore %1138 %2398
+%2399 = OpLoad %ulong %438
+%2400 = OpLoad %_arr_ushort_uint_8 %1138
+%2401 = OpFunctionCall %ulong %1 %2399 %2400
+OpStore %439 %2401
+%2402 = OpLoad %ulong %439
+OpStore %457 %2402
+%2403 = OpLoad %_arr_ushort_uint_8 %416
+OpStore %458 %2403
+%2404 = OpLoad %_arr_ushort_uint_8 %410
+OpStore %459 %2404
+%2405 = OpLoad %_arr_ushort_uint_8 %410
+OpStore %460 %2405
+OpStore %461 %ulong_0
+OpBranch %372
+%372 = OpLabel
+%2406 = OpLoad %ulong %461
+%2408 = OpULessThan %bool %2406 %ulong_6
+OpStore %440 %2408
+%2409 = OpLoad %bool %440
+OpLoopMerge %374 %397 None
+OpBranchConditional %2409 %373 %374
+%374 = OpLabel
+OpStore %401 %2410
+%2412 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_0
+%2413 = OpLoad %_arr_ushort_uint_8 %458
+OpStore %2412 %2413
+%2414 = OpLoad %_arr_ushort_uint_8 %458
+%2415 = OpCompositeExtract %ushort %2414 0
+OpStore %611 %2415
+%2416 = OpLoad %_arr_ushort_uint_8 %422
+%2417 = OpCompositeExtract %ushort %2416 0
+OpStore %612 %2417
+%2418 = OpLoad %ushort %611
+%2419 = OpLoad %ushort %612
+%2420 = OpIAdd %ushort %2418 %2419
+OpStore %613 %2420
+%2421 = OpLoad %_arr_ushort_uint_8 %458
+%2422 = OpCompositeExtract %ushort %2421 1
+OpStore %614 %2422
+%2423 = OpLoad %_arr_ushort_uint_8 %422
+%2424 = OpCompositeExtract %ushort %2423 1
+OpStore %615 %2424
+%2425 = OpLoad %ushort %614
+%2426 = OpLoad %ushort %615
+%2427 = OpIAdd %ushort %2425 %2426
+OpStore %616 %2427
+%2428 = OpLoad %_arr_ushort_uint_8 %458
+%2429 = OpCompositeExtract %ushort %2428 2
+OpStore %617 %2429
+%2430 = OpLoad %_arr_ushort_uint_8 %422
+%2431 = OpCompositeExtract %ushort %2430 2
+OpStore %618 %2431
+%2432 = OpLoad %ushort %617
+%2433 = OpLoad %ushort %618
+%2434 = OpIAdd %ushort %2432 %2433
+OpStore %619 %2434
+%2435 = OpLoad %_arr_ushort_uint_8 %458
+%2436 = OpCompositeExtract %ushort %2435 3
+OpStore %620 %2436
+%2437 = OpLoad %_arr_ushort_uint_8 %422
+%2438 = OpCompositeExtract %ushort %2437 3
+OpStore %621 %2438
+%2439 = OpLoad %ushort %620
+%2440 = OpLoad %ushort %621
+%2441 = OpIAdd %ushort %2439 %2440
+OpStore %622 %2441
+%2442 = OpLoad %_arr_ushort_uint_8 %458
+%2443 = OpCompositeExtract %ushort %2442 4
+OpStore %623 %2443
+%2444 = OpLoad %_arr_ushort_uint_8 %422
+%2445 = OpCompositeExtract %ushort %2444 4
+OpStore %624 %2445
+%2446 = OpLoad %ushort %623
+%2447 = OpLoad %ushort %624
+%2448 = OpIAdd %ushort %2446 %2447
+OpStore %625 %2448
+%2449 = OpLoad %_arr_ushort_uint_8 %458
+%2450 = OpCompositeExtract %ushort %2449 5
+OpStore %626 %2450
+%2451 = OpLoad %_arr_ushort_uint_8 %422
+%2452 = OpCompositeExtract %ushort %2451 5
+OpStore %627 %2452
+%2453 = OpLoad %ushort %626
+%2454 = OpLoad %ushort %627
+%2455 = OpIAdd %ushort %2453 %2454
+OpStore %628 %2455
+%2456 = OpLoad %_arr_ushort_uint_8 %458
+%2457 = OpCompositeExtract %ushort %2456 6
+OpStore %629 %2457
+%2458 = OpLoad %_arr_ushort_uint_8 %422
+%2459 = OpCompositeExtract %ushort %2458 6
+OpStore %630 %2459
+%2460 = OpLoad %ushort %629
+%2461 = OpLoad %ushort %630
+%2462 = OpIAdd %ushort %2460 %2461
+OpStore %631 %2462
+%2463 = OpLoad %_arr_ushort_uint_8 %458
+%2464 = OpCompositeExtract %ushort %2463 7
+OpStore %632 %2464
+%2465 = OpLoad %_arr_ushort_uint_8 %422
+%2466 = OpCompositeExtract %ushort %2465 7
+OpStore %633 %2466
+%2467 = OpLoad %ushort %632
+%2468 = OpLoad %ushort %633
+%2469 = OpIAdd %ushort %2467 %2468
+OpStore %634 %2469
+%2470 = OpLoad %_arr_ushort_uint_8 %458
+%2471 = OpLoad %ushort %613
+%2472 = OpCompositeInsert %_arr_ushort_uint_8 %2471 %2470 0
+OpStore %635 %2472
+%2473 = OpLoad %_arr_ushort_uint_8 %635
+%2474 = OpLoad %ushort %616
+%2475 = OpCompositeInsert %_arr_ushort_uint_8 %2474 %2473 1
+OpStore %636 %2475
+%2476 = OpLoad %_arr_ushort_uint_8 %636
+%2477 = OpLoad %ushort %619
+%2478 = OpCompositeInsert %_arr_ushort_uint_8 %2477 %2476 2
+OpStore %637 %2478
+%2479 = OpLoad %_arr_ushort_uint_8 %637
+%2480 = OpLoad %ushort %622
+%2481 = OpCompositeInsert %_arr_ushort_uint_8 %2480 %2479 3
+OpStore %638 %2481
+%2482 = OpLoad %_arr_ushort_uint_8 %638
+%2483 = OpLoad %ushort %625
+%2484 = OpCompositeInsert %_arr_ushort_uint_8 %2483 %2482 4
+OpStore %639 %2484
+%2485 = OpLoad %_arr_ushort_uint_8 %639
+%2486 = OpLoad %ushort %628
+%2487 = OpCompositeInsert %_arr_ushort_uint_8 %2486 %2485 5
+OpStore %640 %2487
+%2488 = OpLoad %_arr_ushort_uint_8 %640
+%2489 = OpLoad %ushort %631
+%2490 = OpCompositeInsert %_arr_ushort_uint_8 %2489 %2488 6
+OpStore %641 %2490
+%2491 = OpLoad %_arr_ushort_uint_8 %641
+%2492 = OpLoad %ushort %634
+%2493 = OpCompositeInsert %_arr_ushort_uint_8 %2492 %2491 7
+OpStore %642 %2493
+%2495 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_1
+%2496 = OpLoad %_arr_ushort_uint_8 %642
+OpStore %2495 %2496
+%2497 = OpLoad %_arr_ushort_uint_8 %458
+%2498 = OpCompositeExtract %ushort %2497 0
+OpStore %643 %2498
+%2499 = OpLoad %_arr_ushort_uint_8 %409
+%2500 = OpCompositeExtract %ushort %2499 0
+OpStore %644 %2500
+%2501 = OpLoad %ushort %643
+%2502 = OpLoad %ushort %644
+%2503 = OpIMul %ushort %2501 %2502
+OpStore %645 %2503
+%2504 = OpLoad %_arr_ushort_uint_8 %458
+%2505 = OpCompositeExtract %ushort %2504 1
+OpStore %646 %2505
+%2506 = OpLoad %_arr_ushort_uint_8 %409
+%2507 = OpCompositeExtract %ushort %2506 1
+OpStore %647 %2507
+%2508 = OpLoad %ushort %646
+%2509 = OpLoad %ushort %647
+%2510 = OpIMul %ushort %2508 %2509
+OpStore %648 %2510
+%2511 = OpLoad %_arr_ushort_uint_8 %458
+%2512 = OpCompositeExtract %ushort %2511 2
+OpStore %649 %2512
+%2513 = OpLoad %_arr_ushort_uint_8 %409
+%2514 = OpCompositeExtract %ushort %2513 2
+OpStore %650 %2514
+%2515 = OpLoad %ushort %649
+%2516 = OpLoad %ushort %650
+%2517 = OpIMul %ushort %2515 %2516
+OpStore %651 %2517
+%2518 = OpLoad %_arr_ushort_uint_8 %458
+%2519 = OpCompositeExtract %ushort %2518 3
+OpStore %652 %2519
+%2520 = OpLoad %_arr_ushort_uint_8 %409
+%2521 = OpCompositeExtract %ushort %2520 3
+OpStore %653 %2521
+%2522 = OpLoad %ushort %652
+%2523 = OpLoad %ushort %653
+%2524 = OpIMul %ushort %2522 %2523
+OpStore %654 %2524
+%2525 = OpLoad %_arr_ushort_uint_8 %458
+%2526 = OpCompositeExtract %ushort %2525 4
+OpStore %655 %2526
+%2527 = OpLoad %_arr_ushort_uint_8 %409
+%2528 = OpCompositeExtract %ushort %2527 4
+OpStore %656 %2528
+%2529 = OpLoad %ushort %655
+%2530 = OpLoad %ushort %656
+%2531 = OpIMul %ushort %2529 %2530
+OpStore %657 %2531
+%2532 = OpLoad %_arr_ushort_uint_8 %458
+%2533 = OpCompositeExtract %ushort %2532 5
+OpStore %658 %2533
+%2534 = OpLoad %_arr_ushort_uint_8 %409
+%2535 = OpCompositeExtract %ushort %2534 5
+OpStore %659 %2535
+%2536 = OpLoad %ushort %658
+%2537 = OpLoad %ushort %659
+%2538 = OpIMul %ushort %2536 %2537
+OpStore %660 %2538
+%2539 = OpLoad %_arr_ushort_uint_8 %458
+%2540 = OpCompositeExtract %ushort %2539 6
+OpStore %661 %2540
+%2541 = OpLoad %_arr_ushort_uint_8 %409
+%2542 = OpCompositeExtract %ushort %2541 6
+OpStore %662 %2542
+%2543 = OpLoad %ushort %661
+%2544 = OpLoad %ushort %662
+%2545 = OpIMul %ushort %2543 %2544
+OpStore %663 %2545
+%2546 = OpLoad %_arr_ushort_uint_8 %458
+%2547 = OpCompositeExtract %ushort %2546 7
+OpStore %664 %2547
+%2548 = OpLoad %_arr_ushort_uint_8 %409
+%2549 = OpCompositeExtract %ushort %2548 7
+OpStore %665 %2549
+%2550 = OpLoad %ushort %664
+%2551 = OpLoad %ushort %665
+%2552 = OpIMul %ushort %2550 %2551
+OpStore %666 %2552
+%2553 = OpLoad %_arr_ushort_uint_8 %458
+%2554 = OpLoad %ushort %645
+%2555 = OpCompositeInsert %_arr_ushort_uint_8 %2554 %2553 0
+OpStore %667 %2555
+%2556 = OpLoad %_arr_ushort_uint_8 %667
+%2557 = OpLoad %ushort %648
+%2558 = OpCompositeInsert %_arr_ushort_uint_8 %2557 %2556 1
+OpStore %668 %2558
+%2559 = OpLoad %_arr_ushort_uint_8 %668
+%2560 = OpLoad %ushort %651
+%2561 = OpCompositeInsert %_arr_ushort_uint_8 %2560 %2559 2
+OpStore %669 %2561
+%2562 = OpLoad %_arr_ushort_uint_8 %669
+%2563 = OpLoad %ushort %654
+%2564 = OpCompositeInsert %_arr_ushort_uint_8 %2563 %2562 3
+OpStore %670 %2564
+%2565 = OpLoad %_arr_ushort_uint_8 %670
+%2566 = OpLoad %ushort %657
+%2567 = OpCompositeInsert %_arr_ushort_uint_8 %2566 %2565 4
+OpStore %671 %2567
+%2568 = OpLoad %_arr_ushort_uint_8 %671
+%2569 = OpLoad %ushort %660
+%2570 = OpCompositeInsert %_arr_ushort_uint_8 %2569 %2568 5
+OpStore %672 %2570
+%2571 = OpLoad %_arr_ushort_uint_8 %672
+%2572 = OpLoad %ushort %663
+%2573 = OpCompositeInsert %_arr_ushort_uint_8 %2572 %2571 6
+OpStore %673 %2573
+%2574 = OpLoad %_arr_ushort_uint_8 %673
+%2575 = OpLoad %ushort %666
+%2576 = OpCompositeInsert %_arr_ushort_uint_8 %2575 %2574 7
+OpStore %674 %2576
+%2578 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_2
+%2579 = OpLoad %_arr_ushort_uint_8 %674
+OpStore %2578 %2579
+%2581 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_3
+%2582 = OpLoad %_arr_ushort_uint_8 %459
+OpStore %2581 %2582
+%2583 = OpLoad %ulong %457
+OpStore %456 %2583
+OpStore %462 %ulong_0
+OpBranch %375
+%375 = OpLabel
+%2584 = OpLoad %ulong %462
+%2586 = OpULessThan %bool %2584 %ulong_4
+OpStore %446 %2586
+%2587 = OpLoad %bool %446
+OpLoopMerge %377 %396 None
+OpBranchConditional %2587 %376 %377
+%377 = OpLabel
+OpStore %404 %2588
+%2589 = OpAccessChain %_ptr_Function_uint %404 %uint_0
+OpStore %2589 %uint_4294967295
+%2591 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %uint_2
+%2592 = OpLoad %_arr_ushort_uint_8 %2591
+OpStore %450 %2592
+%2593 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %404 %uint_1
+%2594 = OpLoad %_arr_ushort_uint_8 %450
+OpStore %2593 %2594
+%2595 = OpAccessChain %_ptr_Function_uint %404 %uint_2
+OpStore %2595 %uint_305419896
+%2597 = OpLoad %uint %2589
+OpStore %452 %2597
+OpBranch %380
+%380 = OpLabel
+%2598 = OpLoad %uint %452
+%2599 = OpUConvert %ulong %2598
+OpStore %463 %2599
+OpBranch %382
+%382 = OpLabel
+%2600 = OpLoad %ulong %456
+OpStore %471 %2600
+OpStore %472 %ulong_0
+OpBranch %383
+%383 = OpLabel
+%2601 = OpLoad %ulong %472
+%2602 = OpULessThan %bool %2601 %ulong_8
+OpStore %464 %2602
+%2603 = OpLoad %bool %464
+OpLoopMerge %385 %395 None
+OpBranchConditional %2603 %384 %385
+%385 = OpLabel
+OpBranch %386
+%386 = OpLabel
+OpBranch %381
+%381 = OpLabel
+%2604 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %404 %uint_1
+%2605 = OpLoad %_arr_ushort_uint_8 %2604
+OpStore %453 %2605
+%2606 = OpLoad %ulong %471
+%2607 = OpLoad %_arr_ushort_uint_8 %453
+%2608 = OpFunctionCall %ulong %1 %2606 %2607
+OpStore %454 %2608
+%2609 = OpAccessChain %_ptr_Function_uint %404 %uint_2
+%2610 = OpLoad %uint %2609
+OpStore %455 %2610
+OpBranch %387
+%387 = OpLabel
+%2611 = OpLoad %uint %455
+%2612 = OpUConvert %ulong %2611
+OpStore %473 %2612
+OpBranch %389
+%389 = OpLabel
+%2613 = OpLoad %ulong %454
+OpStore %481 %2613
+OpStore %482 %ulong_0
+OpBranch %390
+%390 = OpLabel
+%2614 = OpLoad %ulong %482
+%2615 = OpULessThan %bool %2614 %ulong_8
+OpStore %474 %2615
+%2616 = OpLoad %bool %474
+OpLoopMerge %392 %394 None
+OpBranchConditional %2616 %391 %392
+%392 = OpLabel
+OpBranch %393
+%393 = OpLabel
+OpBranch %388
+%388 = OpLabel
+%2617 = OpLoad %ulong %481
+OpReturnValue %2617
+%391 = OpLabel
+%2618 = OpLoad %ulong %482
+%2619 = OpIMul %ulong %2618 %ulong_8
+OpStore %475 %2619
+%2620 = OpLoad %ulong %473
+%2621 = OpLoad %ulong %475
+%2622 = OpShiftRightLogical %ulong %2620 %2621
+OpStore %476 %2622
+%2623 = OpLoad %ulong %476
+%2624 = OpBitwiseAnd %ulong %2623 %ulong_255
+OpStore %477 %2624
+%2625 = OpLoad %ulong %481
+%2626 = OpLoad %ulong %477
+%2627 = OpBitwiseXor %ulong %2625 %2626
+OpStore %478 %2627
+%2628 = OpLoad %ulong %478
+%2629 = OpIMul %ulong %2628 %ulong_1099511628211
+OpStore %479 %2629
+%2630 = OpLoad %ulong %482
+%2631 = OpIAdd %ulong %2630 %ulong_1
+OpStore %480 %2631
+%2632 = OpLoad %ulong %479
+OpStore %481 %2632
+%2633 = OpLoad %ulong %480
+OpStore %482 %2633
+OpBranch %394
+%384 = OpLabel
+%2634 = OpLoad %ulong %472
+%2635 = OpIMul %ulong %2634 %ulong_8
+OpStore %465 %2635
+%2636 = OpLoad %ulong %463
+%2637 = OpLoad %ulong %465
+%2638 = OpShiftRightLogical %ulong %2636 %2637
+OpStore %466 %2638
+%2639 = OpLoad %ulong %466
+%2640 = OpBitwiseAnd %ulong %2639 %ulong_255
+OpStore %467 %2640
+%2641 = OpLoad %ulong %471
+%2642 = OpLoad %ulong %467
+%2643 = OpBitwiseXor %ulong %2641 %2642
+OpStore %468 %2643
+%2644 = OpLoad %ulong %468
+%2645 = OpIMul %ulong %2644 %ulong_1099511628211
+OpStore %469 %2645
+%2646 = OpLoad %ulong %472
+%2647 = OpIAdd %ulong %2646 %ulong_1
+OpStore %470 %2647
+%2648 = OpLoad %ulong %469
+OpStore %471 %2648
+%2649 = OpLoad %ulong %470
+OpStore %472 %2649
+OpBranch %395
+%376 = OpLabel
+%2650 = OpLoad %ulong %462
+%2651 = OpAccessChain %_ptr_Function__arr_ushort_uint_8 %401 %2650
+%2652 = OpLoad %_arr_ushort_uint_8 %2651
+OpStore %447 %2652
+%2653 = OpLoad %ulong %456
+%2654 = OpLoad %_arr_ushort_uint_8 %447
+%2655 = OpFunctionCall %ulong %1 %2653 %2654
+OpStore %448 %2655
+%2656 = OpLoad %ulong %462
+%2657 = OpIAdd %ulong %2656 %ulong_1
+OpStore %449 %2657
+%2658 = OpLoad %ulong %448
+OpStore %456 %2658
+%2659 = OpLoad %ulong %449
+OpStore %462 %2659
+OpBranch %396
+%373 = OpLabel
+%2660 = OpLoad %_arr_ushort_uint_8 %458
+%2661 = OpCompositeExtract %ushort %2660 0
+OpStore %483 %2661
+%2662 = OpLoad %_arr_ushort_uint_8 %409
+%2663 = OpCompositeExtract %ushort %2662 0
+OpStore %484 %2663
+%2664 = OpLoad %ushort %483
+%2665 = OpLoad %ushort %484
+%2666 = OpIMul %ushort %2664 %2665
+OpStore %485 %2666
+%2667 = OpLoad %_arr_ushort_uint_8 %458
+%2668 = OpCompositeExtract %ushort %2667 1
+OpStore %486 %2668
+%2669 = OpLoad %_arr_ushort_uint_8 %409
+%2670 = OpCompositeExtract %ushort %2669 1
+OpStore %487 %2670
+%2671 = OpLoad %ushort %486
+%2672 = OpLoad %ushort %487
+%2673 = OpIMul %ushort %2671 %2672
+OpStore %488 %2673
+%2674 = OpLoad %_arr_ushort_uint_8 %458
+%2675 = OpCompositeExtract %ushort %2674 2
+OpStore %489 %2675
+%2676 = OpLoad %_arr_ushort_uint_8 %409
+%2677 = OpCompositeExtract %ushort %2676 2
+OpStore %490 %2677
+%2678 = OpLoad %ushort %489
+%2679 = OpLoad %ushort %490
+%2680 = OpIMul %ushort %2678 %2679
+OpStore %491 %2680
+%2681 = OpLoad %_arr_ushort_uint_8 %458
+%2682 = OpCompositeExtract %ushort %2681 3
+OpStore %492 %2682
+%2683 = OpLoad %_arr_ushort_uint_8 %409
+%2684 = OpCompositeExtract %ushort %2683 3
+OpStore %493 %2684
+%2685 = OpLoad %ushort %492
+%2686 = OpLoad %ushort %493
+%2687 = OpIMul %ushort %2685 %2686
+OpStore %494 %2687
+%2688 = OpLoad %_arr_ushort_uint_8 %458
+%2689 = OpCompositeExtract %ushort %2688 4
+OpStore %495 %2689
+%2690 = OpLoad %_arr_ushort_uint_8 %409
+%2691 = OpCompositeExtract %ushort %2690 4
+OpStore %496 %2691
+%2692 = OpLoad %ushort %495
+%2693 = OpLoad %ushort %496
+%2694 = OpIMul %ushort %2692 %2693
+OpStore %497 %2694
+%2695 = OpLoad %_arr_ushort_uint_8 %458
+%2696 = OpCompositeExtract %ushort %2695 5
+OpStore %498 %2696
+%2697 = OpLoad %_arr_ushort_uint_8 %409
+%2698 = OpCompositeExtract %ushort %2697 5
+OpStore %499 %2698
+%2699 = OpLoad %ushort %498
+%2700 = OpLoad %ushort %499
+%2701 = OpIMul %ushort %2699 %2700
+OpStore %500 %2701
+%2702 = OpLoad %_arr_ushort_uint_8 %458
+%2703 = OpCompositeExtract %ushort %2702 6
+OpStore %501 %2703
+%2704 = OpLoad %_arr_ushort_uint_8 %409
+%2705 = OpCompositeExtract %ushort %2704 6
+OpStore %502 %2705
+%2706 = OpLoad %ushort %501
+%2707 = OpLoad %ushort %502
+%2708 = OpIMul %ushort %2706 %2707
+OpStore %503 %2708
+%2709 = OpLoad %_arr_ushort_uint_8 %458
+%2710 = OpCompositeExtract %ushort %2709 7
+OpStore %504 %2710
+%2711 = OpLoad %_arr_ushort_uint_8 %409
+%2712 = OpCompositeExtract %ushort %2711 7
+OpStore %505 %2712
+%2713 = OpLoad %ushort %504
+%2714 = OpLoad %ushort %505
+%2715 = OpIMul %ushort %2713 %2714
+OpStore %506 %2715
+%2716 = OpLoad %_arr_ushort_uint_8 %458
+%2717 = OpLoad %ushort %485
+%2718 = OpCompositeInsert %_arr_ushort_uint_8 %2717 %2716 0
+OpStore %507 %2718
+%2719 = OpLoad %_arr_ushort_uint_8 %507
+%2720 = OpLoad %ushort %488
+%2721 = OpCompositeInsert %_arr_ushort_uint_8 %2720 %2719 1
+OpStore %508 %2721
+%2722 = OpLoad %_arr_ushort_uint_8 %508
+%2723 = OpLoad %ushort %491
+%2724 = OpCompositeInsert %_arr_ushort_uint_8 %2723 %2722 2
+OpStore %509 %2724
+%2725 = OpLoad %_arr_ushort_uint_8 %509
+%2726 = OpLoad %ushort %494
+%2727 = OpCompositeInsert %_arr_ushort_uint_8 %2726 %2725 3
+OpStore %510 %2727
+%2728 = OpLoad %_arr_ushort_uint_8 %510
+%2729 = OpLoad %ushort %497
+%2730 = OpCompositeInsert %_arr_ushort_uint_8 %2729 %2728 4
+OpStore %511 %2730
+%2731 = OpLoad %_arr_ushort_uint_8 %511
+%2732 = OpLoad %ushort %500
+%2733 = OpCompositeInsert %_arr_ushort_uint_8 %2732 %2731 5
+OpStore %512 %2733
+%2734 = OpLoad %_arr_ushort_uint_8 %512
+%2735 = OpLoad %ushort %503
+%2736 = OpCompositeInsert %_arr_ushort_uint_8 %2735 %2734 6
+OpStore %513 %2736
+%2737 = OpLoad %_arr_ushort_uint_8 %513
+%2738 = OpLoad %ushort %506
+%2739 = OpCompositeInsert %_arr_ushort_uint_8 %2738 %2737 7
+OpStore %514 %2739
+%2740 = OpLoad %ulong %457
+%2741 = OpLoad %_arr_ushort_uint_8 %514
+%2742 = OpFunctionCall %ulong %1 %2740 %2741
+OpStore %441 %2742
+%2743 = OpLoad %_arr_ushort_uint_8 %459
+%2744 = OpCompositeExtract %ushort %2743 0
+OpStore %515 %2744
+%2745 = OpLoad %_arr_ushort_uint_8 %514
+%2746 = OpCompositeExtract %ushort %2745 0
+OpStore %516 %2746
+%2747 = OpLoad %ushort %515
+%2748 = OpLoad %ushort %516
+%2749 = OpBitwiseXor %ushort %2747 %2748
+OpStore %517 %2749
+%2750 = OpLoad %_arr_ushort_uint_8 %459
+%2751 = OpCompositeExtract %ushort %2750 1
+OpStore %518 %2751
+%2752 = OpLoad %_arr_ushort_uint_8 %514
+%2753 = OpCompositeExtract %ushort %2752 1
+OpStore %519 %2753
+%2754 = OpLoad %ushort %518
+%2755 = OpLoad %ushort %519
+%2756 = OpBitwiseXor %ushort %2754 %2755
+OpStore %520 %2756
+%2757 = OpLoad %_arr_ushort_uint_8 %459
+%2758 = OpCompositeExtract %ushort %2757 2
+OpStore %521 %2758
+%2759 = OpLoad %_arr_ushort_uint_8 %514
+%2760 = OpCompositeExtract %ushort %2759 2
+OpStore %522 %2760
+%2761 = OpLoad %ushort %521
+%2762 = OpLoad %ushort %522
+%2763 = OpBitwiseXor %ushort %2761 %2762
+OpStore %523 %2763
+%2764 = OpLoad %_arr_ushort_uint_8 %459
+%2765 = OpCompositeExtract %ushort %2764 3
+OpStore %524 %2765
+%2766 = OpLoad %_arr_ushort_uint_8 %514
+%2767 = OpCompositeExtract %ushort %2766 3
+OpStore %525 %2767
+%2768 = OpLoad %ushort %524
+%2769 = OpLoad %ushort %525
+%2770 = OpBitwiseXor %ushort %2768 %2769
+OpStore %526 %2770
+%2771 = OpLoad %_arr_ushort_uint_8 %459
+%2772 = OpCompositeExtract %ushort %2771 4
+OpStore %527 %2772
+%2773 = OpLoad %_arr_ushort_uint_8 %514
+%2774 = OpCompositeExtract %ushort %2773 4
+OpStore %528 %2774
+%2775 = OpLoad %ushort %527
+%2776 = OpLoad %ushort %528
+%2777 = OpBitwiseXor %ushort %2775 %2776
+OpStore %529 %2777
+%2778 = OpLoad %_arr_ushort_uint_8 %459
+%2779 = OpCompositeExtract %ushort %2778 5
+OpStore %530 %2779
+%2780 = OpLoad %_arr_ushort_uint_8 %514
+%2781 = OpCompositeExtract %ushort %2780 5
+OpStore %531 %2781
+%2782 = OpLoad %ushort %530
+%2783 = OpLoad %ushort %531
+%2784 = OpBitwiseXor %ushort %2782 %2783
+OpStore %532 %2784
+%2785 = OpLoad %_arr_ushort_uint_8 %459
+%2786 = OpCompositeExtract %ushort %2785 6
+OpStore %533 %2786
+%2787 = OpLoad %_arr_ushort_uint_8 %514
+%2788 = OpCompositeExtract %ushort %2787 6
+OpStore %534 %2788
+%2789 = OpLoad %ushort %533
+%2790 = OpLoad %ushort %534
+%2791 = OpBitwiseXor %ushort %2789 %2790
+OpStore %535 %2791
+%2792 = OpLoad %_arr_ushort_uint_8 %459
+%2793 = OpCompositeExtract %ushort %2792 7
+OpStore %536 %2793
+%2794 = OpLoad %_arr_ushort_uint_8 %514
+%2795 = OpCompositeExtract %ushort %2794 7
+OpStore %537 %2795
+%2796 = OpLoad %ushort %536
+%2797 = OpLoad %ushort %537
+%2798 = OpBitwiseXor %ushort %2796 %2797
+OpStore %538 %2798
+%2799 = OpLoad %_arr_ushort_uint_8 %459
+%2800 = OpLoad %ushort %517
+%2801 = OpCompositeInsert %_arr_ushort_uint_8 %2800 %2799 0
+OpStore %539 %2801
+%2802 = OpLoad %_arr_ushort_uint_8 %539
+%2803 = OpLoad %ushort %520
+%2804 = OpCompositeInsert %_arr_ushort_uint_8 %2803 %2802 1
+OpStore %540 %2804
+%2805 = OpLoad %_arr_ushort_uint_8 %540
+%2806 = OpLoad %ushort %523
+%2807 = OpCompositeInsert %_arr_ushort_uint_8 %2806 %2805 2
+OpStore %541 %2807
+%2808 = OpLoad %_arr_ushort_uint_8 %541
+%2809 = OpLoad %ushort %526
+%2810 = OpCompositeInsert %_arr_ushort_uint_8 %2809 %2808 3
+OpStore %542 %2810
+%2811 = OpLoad %_arr_ushort_uint_8 %542
+%2812 = OpLoad %ushort %529
+%2813 = OpCompositeInsert %_arr_ushort_uint_8 %2812 %2811 4
+OpStore %543 %2813
+%2814 = OpLoad %_arr_ushort_uint_8 %543
+%2815 = OpLoad %ushort %532
+%2816 = OpCompositeInsert %_arr_ushort_uint_8 %2815 %2814 5
+OpStore %544 %2816
+%2817 = OpLoad %_arr_ushort_uint_8 %544
+%2818 = OpLoad %ushort %535
+%2819 = OpCompositeInsert %_arr_ushort_uint_8 %2818 %2817 6
+OpStore %545 %2819
+%2820 = OpLoad %_arr_ushort_uint_8 %545
+%2821 = OpLoad %ushort %538
+%2822 = OpCompositeInsert %_arr_ushort_uint_8 %2821 %2820 7
+OpStore %546 %2822
+%2823 = OpLoad %ulong %441
+%2824 = OpLoad %_arr_ushort_uint_8 %546
+%2825 = OpFunctionCall %ulong %1 %2823 %2824
+OpStore %442 %2825
+%2826 = OpLoad %_arr_ushort_uint_8 %460
+%2827 = OpCompositeExtract %ushort %2826 0
+OpStore %547 %2827
+%2828 = OpLoad %_arr_ushort_uint_8 %458
+%2829 = OpCompositeExtract %ushort %2828 0
+OpStore %548 %2829
+%2830 = OpLoad %ushort %547
+%2831 = OpLoad %ushort %548
+%2832 = OpIAdd %ushort %2830 %2831
+OpStore %549 %2832
+%2833 = OpLoad %_arr_ushort_uint_8 %460
+%2834 = OpCompositeExtract %ushort %2833 1
+OpStore %550 %2834
+%2835 = OpLoad %_arr_ushort_uint_8 %458
+%2836 = OpCompositeExtract %ushort %2835 1
+OpStore %551 %2836
+%2837 = OpLoad %ushort %550
+%2838 = OpLoad %ushort %551
+%2839 = OpIAdd %ushort %2837 %2838
+OpStore %552 %2839
+%2840 = OpLoad %_arr_ushort_uint_8 %460
+%2841 = OpCompositeExtract %ushort %2840 2
+OpStore %553 %2841
+%2842 = OpLoad %_arr_ushort_uint_8 %458
+%2843 = OpCompositeExtract %ushort %2842 2
+OpStore %554 %2843
+%2844 = OpLoad %ushort %553
+%2845 = OpLoad %ushort %554
+%2846 = OpIAdd %ushort %2844 %2845
+OpStore %555 %2846
+%2847 = OpLoad %_arr_ushort_uint_8 %460
+%2848 = OpCompositeExtract %ushort %2847 3
+OpStore %556 %2848
+%2849 = OpLoad %_arr_ushort_uint_8 %458
+%2850 = OpCompositeExtract %ushort %2849 3
+OpStore %557 %2850
+%2851 = OpLoad %ushort %556
+%2852 = OpLoad %ushort %557
+%2853 = OpIAdd %ushort %2851 %2852
+OpStore %558 %2853
+%2854 = OpLoad %_arr_ushort_uint_8 %460
+%2855 = OpCompositeExtract %ushort %2854 4
+OpStore %559 %2855
+%2856 = OpLoad %_arr_ushort_uint_8 %458
+%2857 = OpCompositeExtract %ushort %2856 4
+OpStore %560 %2857
+%2858 = OpLoad %ushort %559
+%2859 = OpLoad %ushort %560
+%2860 = OpIAdd %ushort %2858 %2859
+OpStore %561 %2860
+%2861 = OpLoad %_arr_ushort_uint_8 %460
+%2862 = OpCompositeExtract %ushort %2861 5
+OpStore %562 %2862
+%2863 = OpLoad %_arr_ushort_uint_8 %458
+%2864 = OpCompositeExtract %ushort %2863 5
+OpStore %563 %2864
+%2865 = OpLoad %ushort %562
+%2866 = OpLoad %ushort %563
+%2867 = OpIAdd %ushort %2865 %2866
+OpStore %564 %2867
+%2868 = OpLoad %_arr_ushort_uint_8 %460
+%2869 = OpCompositeExtract %ushort %2868 6
+OpStore %565 %2869
+%2870 = OpLoad %_arr_ushort_uint_8 %458
+%2871 = OpCompositeExtract %ushort %2870 6
+OpStore %566 %2871
+%2872 = OpLoad %ushort %565
+%2873 = OpLoad %ushort %566
+%2874 = OpIAdd %ushort %2872 %2873
+OpStore %567 %2874
+%2875 = OpLoad %_arr_ushort_uint_8 %460
+%2876 = OpCompositeExtract %ushort %2875 7
+OpStore %568 %2876
+%2877 = OpLoad %_arr_ushort_uint_8 %458
+%2878 = OpCompositeExtract %ushort %2877 7
+OpStore %569 %2878
+%2879 = OpLoad %ushort %568
+%2880 = OpLoad %ushort %569
+%2881 = OpIAdd %ushort %2879 %2880
+OpStore %570 %2881
+%2882 = OpLoad %_arr_ushort_uint_8 %460
+%2883 = OpLoad %ushort %549
+%2884 = OpCompositeInsert %_arr_ushort_uint_8 %2883 %2882 0
+OpStore %571 %2884
+%2885 = OpLoad %_arr_ushort_uint_8 %571
+%2886 = OpLoad %ushort %552
+%2887 = OpCompositeInsert %_arr_ushort_uint_8 %2886 %2885 1
+OpStore %572 %2887
+%2888 = OpLoad %_arr_ushort_uint_8 %572
+%2889 = OpLoad %ushort %555
+%2890 = OpCompositeInsert %_arr_ushort_uint_8 %2889 %2888 2
+OpStore %573 %2890
+%2891 = OpLoad %_arr_ushort_uint_8 %573
+%2892 = OpLoad %ushort %558
+%2893 = OpCompositeInsert %_arr_ushort_uint_8 %2892 %2891 3
+OpStore %574 %2893
+%2894 = OpLoad %_arr_ushort_uint_8 %574
+%2895 = OpLoad %ushort %561
+%2896 = OpCompositeInsert %_arr_ushort_uint_8 %2895 %2894 4
+OpStore %575 %2896
+%2897 = OpLoad %_arr_ushort_uint_8 %575
+%2898 = OpLoad %ushort %564
+%2899 = OpCompositeInsert %_arr_ushort_uint_8 %2898 %2897 5
+OpStore %576 %2899
+%2900 = OpLoad %_arr_ushort_uint_8 %576
+%2901 = OpLoad %ushort %567
+%2902 = OpCompositeInsert %_arr_ushort_uint_8 %2901 %2900 6
+OpStore %577 %2902
+%2903 = OpLoad %_arr_ushort_uint_8 %577
+%2904 = OpLoad %ushort %570
+%2905 = OpCompositeInsert %_arr_ushort_uint_8 %2904 %2903 7
+OpStore %578 %2905
+%2906 = OpLoad %ulong %442
+%2907 = OpLoad %_arr_ushort_uint_8 %578
+%2908 = OpFunctionCall %ulong %1 %2906 %2907
+OpStore %443 %2908
+%2909 = OpLoad %_arr_ushort_uint_8 %458
+%2910 = OpCompositeExtract %ushort %2909 0
+OpStore %579 %2910
+%2911 = OpLoad %_arr_ushort_uint_8 %422
+%2912 = OpCompositeExtract %ushort %2911 0
+OpStore %580 %2912
+%2913 = OpLoad %ushort %579
+%2914 = OpLoad %ushort %580
+%2915 = OpIAdd %ushort %2913 %2914
+OpStore %581 %2915
+%2916 = OpLoad %_arr_ushort_uint_8 %458
+%2917 = OpCompositeExtract %ushort %2916 1
+OpStore %582 %2917
+%2918 = OpLoad %_arr_ushort_uint_8 %422
+%2919 = OpCompositeExtract %ushort %2918 1
+OpStore %583 %2919
+%2920 = OpLoad %ushort %582
+%2921 = OpLoad %ushort %583
+%2922 = OpIAdd %ushort %2920 %2921
+OpStore %584 %2922
+%2923 = OpLoad %_arr_ushort_uint_8 %458
+%2924 = OpCompositeExtract %ushort %2923 2
+OpStore %585 %2924
+%2925 = OpLoad %_arr_ushort_uint_8 %422
+%2926 = OpCompositeExtract %ushort %2925 2
+OpStore %586 %2926
+%2927 = OpLoad %ushort %585
+%2928 = OpLoad %ushort %586
+%2929 = OpIAdd %ushort %2927 %2928
+OpStore %587 %2929
+%2930 = OpLoad %_arr_ushort_uint_8 %458
+%2931 = OpCompositeExtract %ushort %2930 3
+OpStore %588 %2931
+%2932 = OpLoad %_arr_ushort_uint_8 %422
+%2933 = OpCompositeExtract %ushort %2932 3
+OpStore %589 %2933
+%2934 = OpLoad %ushort %588
+%2935 = OpLoad %ushort %589
+%2936 = OpIAdd %ushort %2934 %2935
+OpStore %590 %2936
+%2937 = OpLoad %_arr_ushort_uint_8 %458
+%2938 = OpCompositeExtract %ushort %2937 4
+OpStore %591 %2938
+%2939 = OpLoad %_arr_ushort_uint_8 %422
+%2940 = OpCompositeExtract %ushort %2939 4
+OpStore %592 %2940
+%2941 = OpLoad %ushort %591
+%2942 = OpLoad %ushort %592
+%2943 = OpIAdd %ushort %2941 %2942
+OpStore %593 %2943
+%2944 = OpLoad %_arr_ushort_uint_8 %458
+%2945 = OpCompositeExtract %ushort %2944 5
+OpStore %594 %2945
+%2946 = OpLoad %_arr_ushort_uint_8 %422
+%2947 = OpCompositeExtract %ushort %2946 5
+OpStore %595 %2947
+%2948 = OpLoad %ushort %594
+%2949 = OpLoad %ushort %595
+%2950 = OpIAdd %ushort %2948 %2949
+OpStore %596 %2950
+%2951 = OpLoad %_arr_ushort_uint_8 %458
+%2952 = OpCompositeExtract %ushort %2951 6
+OpStore %597 %2952
+%2953 = OpLoad %_arr_ushort_uint_8 %422
+%2954 = OpCompositeExtract %ushort %2953 6
+OpStore %598 %2954
+%2955 = OpLoad %ushort %597
+%2956 = OpLoad %ushort %598
+%2957 = OpIAdd %ushort %2955 %2956
+OpStore %599 %2957
+%2958 = OpLoad %_arr_ushort_uint_8 %458
+%2959 = OpCompositeExtract %ushort %2958 7
+OpStore %600 %2959
+%2960 = OpLoad %_arr_ushort_uint_8 %422
+%2961 = OpCompositeExtract %ushort %2960 7
+OpStore %601 %2961
+%2962 = OpLoad %ushort %600
+%2963 = OpLoad %ushort %601
+%2964 = OpIAdd %ushort %2962 %2963
+OpStore %602 %2964
+%2965 = OpLoad %_arr_ushort_uint_8 %458
+%2966 = OpLoad %ushort %581
+%2967 = OpCompositeInsert %_arr_ushort_uint_8 %2966 %2965 0
+OpStore %603 %2967
+%2968 = OpLoad %_arr_ushort_uint_8 %603
+%2969 = OpLoad %ushort %584
+%2970 = OpCompositeInsert %_arr_ushort_uint_8 %2969 %2968 1
+OpStore %604 %2970
+%2971 = OpLoad %_arr_ushort_uint_8 %604
+%2972 = OpLoad %ushort %587
+%2973 = OpCompositeInsert %_arr_ushort_uint_8 %2972 %2971 2
+OpStore %605 %2973
+%2974 = OpLoad %_arr_ushort_uint_8 %605
+%2975 = OpLoad %ushort %590
+%2976 = OpCompositeInsert %_arr_ushort_uint_8 %2975 %2974 3
+OpStore %606 %2976
+%2977 = OpLoad %_arr_ushort_uint_8 %606
+%2978 = OpLoad %ushort %593
+%2979 = OpCompositeInsert %_arr_ushort_uint_8 %2978 %2977 4
+OpStore %607 %2979
+%2980 = OpLoad %_arr_ushort_uint_8 %607
+%2981 = OpLoad %ushort %596
+%2982 = OpCompositeInsert %_arr_ushort_uint_8 %2981 %2980 5
+OpStore %608 %2982
+%2983 = OpLoad %_arr_ushort_uint_8 %608
+%2984 = OpLoad %ushort %599
+%2985 = OpCompositeInsert %_arr_ushort_uint_8 %2984 %2983 6
+OpStore %609 %2985
+%2986 = OpLoad %_arr_ushort_uint_8 %609
+%2987 = OpLoad %ushort %602
+%2988 = OpCompositeInsert %_arr_ushort_uint_8 %2987 %2986 7
+OpStore %610 %2988
+%2989 = OpLoad %ulong %443
+%2990 = OpLoad %_arr_ushort_uint_8 %610
+%2991 = OpFunctionCall %ulong %1 %2989 %2990
+OpStore %444 %2991
+%2992 = OpLoad %ulong %461
+%2993 = OpIAdd %ulong %2992 %ulong_1
+OpStore %445 %2993
+%2994 = OpLoad %ulong %444
+OpStore %457 %2994
+%2995 = OpLoad %_arr_ushort_uint_8 %610
+OpStore %458 %2995
+%2996 = OpLoad %_arr_ushort_uint_8 %546
+OpStore %459 %2996
+%2997 = OpLoad %_arr_ushort_uint_8 %578
+OpStore %460 %2997
+%2998 = OpLoad %ulong %445
+OpStore %461 %2998
+OpBranch %397
+%394 = OpLabel
+OpBranch %390
+%395 = OpLabel
+OpBranch %383
+%396 = OpLabel
+OpBranch %375
+%397 = OpLabel
+OpBranch %372
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_u32x4.dis
+++ b/test/golden/spirv/vec/vec_u32x4.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 855
+; Bound: 602
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -12,18 +12,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u32x4.checksum" Export
 %ulong = OpTypeInt 64 0
 %uint = OpTypeInt 32 0
 %v4uint = OpTypeVector %uint 4
-%8 = OpTypeFunction %ulong %ulong %v4uint
+%6 = OpTypeFunction %ulong %ulong %v4uint
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v4uint = OpTypePointer Function %v4uint
 %_ptr_Function_uint = OpTypePointer Function %uint
-%46 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%195 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr_v4uint_uint_4 = OpTypeArray %v4uint %uint_4
 %_ptr_Function__arr_v4uint_uint_4 = OpTypePointer Function %_arr_v4uint_uint_4
-%_struct_94 = OpTypeStruct %uint %v4uint %uint
-%_ptr_Function__struct_94 = OpTypePointer Function %_struct_94
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_228 = OpTypeStruct %uint %v4uint %uint
+%_ptr_Function__struct_228 = OpTypePointer Function %_struct_228
 %uint_4294967280 = OpConstant %uint 4294967280
 %uint_1 = OpConstant %uint 1
 %uint_2147483648 = OpConstant %uint 2147483648
@@ -35,1122 +40,815 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u32x4.checksum" Export
 %uint_9 = OpConstant %uint 9
 %uint_27 = OpConstant %uint 27
 %uint_0 = OpConstant %uint 0
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%618 = OpConstantNull %_arr_v4uint_uint_4
+%480 = OpConstantNull %_arr_v4uint_uint_4
 %uint_2 = OpConstant %uint 2
 %ulong_4 = OpConstant %ulong 4
-%639 = OpConstantNull %_struct_94
-%ulong_1 = OpConstant %ulong 1
-%804 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%807 = OpTypeFunction %ulong %ulong %uint
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpFunctionParameter %v4uint
+%501 = OpConstantNull %_struct_228
+%1 = OpFunction %ulong None %6
+%7 = OpFunctionParameter %ulong
+%8 = OpFunctionParameter %v4uint
+%9 = OpLabel
+%44 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_v4uint Function
+%48 = OpVariable %_ptr_Function_uint Function
+%49 = OpVariable %_ptr_Function_uint Function
+%50 = OpVariable %_ptr_Function_uint Function
+%51 = OpVariable %_ptr_Function_uint Function
+%52 = OpVariable %_ptr_Function_ulong Function
+%54 = OpVariable %_ptr_Function_bool Function
+%55 = OpVariable %_ptr_Function_ulong Function
+%56 = OpVariable %_ptr_Function_ulong Function
+%57 = OpVariable %_ptr_Function_ulong Function
+%58 = OpVariable %_ptr_Function_ulong Function
+%59 = OpVariable %_ptr_Function_ulong Function
+%60 = OpVariable %_ptr_Function_ulong Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_bool Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%67 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ulong Function
+%69 = OpVariable %_ptr_Function_ulong Function
+%70 = OpVariable %_ptr_Function_ulong Function
+%71 = OpVariable %_ptr_Function_ulong Function
+%72 = OpVariable %_ptr_Function_ulong Function
+%73 = OpVariable %_ptr_Function_ulong Function
+%74 = OpVariable %_ptr_Function_bool Function
+%75 = OpVariable %_ptr_Function_ulong Function
+%76 = OpVariable %_ptr_Function_ulong Function
+%77 = OpVariable %_ptr_Function_ulong Function
+%78 = OpVariable %_ptr_Function_ulong Function
+%79 = OpVariable %_ptr_Function_ulong Function
+%80 = OpVariable %_ptr_Function_ulong Function
+%81 = OpVariable %_ptr_Function_ulong Function
+%82 = OpVariable %_ptr_Function_ulong Function
+%83 = OpVariable %_ptr_Function_ulong Function
+%84 = OpVariable %_ptr_Function_bool Function
+%85 = OpVariable %_ptr_Function_ulong Function
+%86 = OpVariable %_ptr_Function_ulong Function
+%87 = OpVariable %_ptr_Function_ulong Function
+%88 = OpVariable %_ptr_Function_ulong Function
+%89 = OpVariable %_ptr_Function_ulong Function
+%90 = OpVariable %_ptr_Function_ulong Function
+%91 = OpVariable %_ptr_Function_ulong Function
+%92 = OpVariable %_ptr_Function_ulong Function
+OpStore %44 %7
+OpStore %46 %8
+%93 = OpLoad %v4uint %46
+%94 = OpCompositeExtract %uint %93 0
+OpStore %48 %94
+OpBranch %10
+%10 = OpLabel
+%95 = OpLoad %uint %48
+%96 = OpUConvert %ulong %95
+OpStore %52 %96
+OpBranch %12
+%12 = OpLabel
+%97 = OpLoad %ulong %44
+OpStore %61 %97
+OpStore %62 %ulong_0
+OpBranch %13
+%13 = OpLabel
+%99 = OpLoad %ulong %62
+%101 = OpULessThan %bool %99 %ulong_8
+OpStore %54 %101
+%102 = OpLoad %bool %54
+OpLoopMerge %15 %41 None
+OpBranchConditional %102 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+OpBranch %11
 %11 = OpLabel
-%13 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_v4uint Function
-%17 = OpVariable %_ptr_Function_uint Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_uint Function
-%20 = OpVariable %_ptr_Function_ulong Function
-%21 = OpVariable %_ptr_Function_uint Function
-%22 = OpVariable %_ptr_Function_ulong Function
-%23 = OpVariable %_ptr_Function_uint Function
-%24 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-OpStore %15 %10
-%25 = OpLoad %v4uint %15
-%26 = OpCompositeExtract %uint %25 0
-OpStore %17 %26
-%27 = OpLoad %ulong %13
-%28 = OpLoad %uint %17
-%29 = OpFunctionCall %ulong %4 %27 %28
-OpStore %18 %29
-%30 = OpLoad %v4uint %15
-%31 = OpCompositeExtract %uint %30 1
-OpStore %19 %31
-%32 = OpLoad %ulong %18
-%33 = OpLoad %uint %19
-%34 = OpFunctionCall %ulong %4 %32 %33
-OpStore %20 %34
-%35 = OpLoad %v4uint %15
-%36 = OpCompositeExtract %uint %35 2
-OpStore %21 %36
-%37 = OpLoad %ulong %20
-%38 = OpLoad %uint %21
-%39 = OpFunctionCall %ulong %4 %37 %38
-OpStore %22 %39
-%40 = OpLoad %v4uint %15
-%41 = OpCompositeExtract %uint %40 3
-OpStore %23 %41
-%42 = OpLoad %ulong %22
-%43 = OpLoad %uint %23
-%44 = OpFunctionCall %ulong %4 %42 %43
-OpStore %24 %44
-%45 = OpLoad %ulong %24
-OpReturnValue %45
+%103 = OpLoad %v4uint %46
+%104 = OpCompositeExtract %uint %103 1
+OpStore %49 %104
+OpBranch %17
+%17 = OpLabel
+%105 = OpLoad %uint %49
+%106 = OpUConvert %ulong %105
+OpStore %63 %106
+OpBranch %19
+%19 = OpLabel
+%107 = OpLoad %ulong %61
+OpStore %71 %107
+OpStore %72 %ulong_0
+OpBranch %20
+%20 = OpLabel
+%108 = OpLoad %ulong %72
+%109 = OpULessThan %bool %108 %ulong_8
+OpStore %64 %109
+%110 = OpLoad %bool %64
+OpLoopMerge %22 %40 None
+OpBranchConditional %110 %21 %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%111 = OpLoad %v4uint %46
+%112 = OpCompositeExtract %uint %111 2
+OpStore %50 %112
+OpBranch %24
+%24 = OpLabel
+%113 = OpLoad %uint %50
+%114 = OpUConvert %ulong %113
+OpStore %73 %114
+OpBranch %26
+%26 = OpLabel
+%115 = OpLoad %ulong %71
+OpStore %81 %115
+OpStore %82 %ulong_0
+OpBranch %27
+%27 = OpLabel
+%116 = OpLoad %ulong %82
+%117 = OpULessThan %bool %116 %ulong_8
+OpStore %74 %117
+%118 = OpLoad %bool %74
+OpLoopMerge %29 %39 None
+OpBranchConditional %118 %28 %29
+%29 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%119 = OpLoad %v4uint %46
+%120 = OpCompositeExtract %uint %119 3
+OpStore %51 %120
+OpBranch %31
+%31 = OpLabel
+%121 = OpLoad %uint %51
+%122 = OpUConvert %ulong %121
+OpStore %83 %122
+OpBranch %33
+%33 = OpLabel
+%123 = OpLoad %ulong %81
+OpStore %91 %123
+OpStore %92 %ulong_0
+OpBranch %34
+%34 = OpLabel
+%124 = OpLoad %ulong %92
+%125 = OpULessThan %bool %124 %ulong_8
+OpStore %84 %125
+%126 = OpLoad %bool %84
+OpLoopMerge %36 %38 None
+OpBranchConditional %126 %35 %36
+%36 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%127 = OpLoad %ulong %91
+OpReturnValue %127
+%35 = OpLabel
+%128 = OpLoad %ulong %92
+%129 = OpIMul %ulong %128 %ulong_8
+OpStore %85 %129
+%130 = OpLoad %ulong %83
+%131 = OpLoad %ulong %85
+%132 = OpShiftRightLogical %ulong %130 %131
+OpStore %86 %132
+%133 = OpLoad %ulong %86
+%135 = OpBitwiseAnd %ulong %133 %ulong_255
+OpStore %87 %135
+%136 = OpLoad %ulong %91
+%137 = OpLoad %ulong %87
+%138 = OpBitwiseXor %ulong %136 %137
+OpStore %88 %138
+%139 = OpLoad %ulong %88
+%141 = OpIMul %ulong %139 %ulong_1099511628211
+OpStore %89 %141
+%142 = OpLoad %ulong %92
+%144 = OpIAdd %ulong %142 %ulong_1
+OpStore %90 %144
+%145 = OpLoad %ulong %89
+OpStore %91 %145
+%146 = OpLoad %ulong %90
+OpStore %92 %146
+OpBranch %38
+%28 = OpLabel
+%147 = OpLoad %ulong %82
+%148 = OpIMul %ulong %147 %ulong_8
+OpStore %75 %148
+%149 = OpLoad %ulong %73
+%150 = OpLoad %ulong %75
+%151 = OpShiftRightLogical %ulong %149 %150
+OpStore %76 %151
+%152 = OpLoad %ulong %76
+%153 = OpBitwiseAnd %ulong %152 %ulong_255
+OpStore %77 %153
+%154 = OpLoad %ulong %81
+%155 = OpLoad %ulong %77
+%156 = OpBitwiseXor %ulong %154 %155
+OpStore %78 %156
+%157 = OpLoad %ulong %78
+%158 = OpIMul %ulong %157 %ulong_1099511628211
+OpStore %79 %158
+%159 = OpLoad %ulong %82
+%160 = OpIAdd %ulong %159 %ulong_1
+OpStore %80 %160
+%161 = OpLoad %ulong %79
+OpStore %81 %161
+%162 = OpLoad %ulong %80
+OpStore %82 %162
+OpBranch %39
+%21 = OpLabel
+%163 = OpLoad %ulong %72
+%164 = OpIMul %ulong %163 %ulong_8
+OpStore %65 %164
+%165 = OpLoad %ulong %63
+%166 = OpLoad %ulong %65
+%167 = OpShiftRightLogical %ulong %165 %166
+OpStore %66 %167
+%168 = OpLoad %ulong %66
+%169 = OpBitwiseAnd %ulong %168 %ulong_255
+OpStore %67 %169
+%170 = OpLoad %ulong %71
+%171 = OpLoad %ulong %67
+%172 = OpBitwiseXor %ulong %170 %171
+OpStore %68 %172
+%173 = OpLoad %ulong %68
+%174 = OpIMul %ulong %173 %ulong_1099511628211
+OpStore %69 %174
+%175 = OpLoad %ulong %72
+%176 = OpIAdd %ulong %175 %ulong_1
+OpStore %70 %176
+%177 = OpLoad %ulong %69
+OpStore %71 %177
+%178 = OpLoad %ulong %70
+OpStore %72 %178
+OpBranch %40
+%14 = OpLabel
+%179 = OpLoad %ulong %62
+%180 = OpIMul %ulong %179 %ulong_8
+OpStore %55 %180
+%181 = OpLoad %ulong %52
+%182 = OpLoad %ulong %55
+%183 = OpShiftRightLogical %ulong %181 %182
+OpStore %56 %183
+%184 = OpLoad %ulong %56
+%185 = OpBitwiseAnd %ulong %184 %ulong_255
+OpStore %57 %185
+%186 = OpLoad %ulong %61
+%187 = OpLoad %ulong %57
+%188 = OpBitwiseXor %ulong %186 %187
+OpStore %58 %188
+%189 = OpLoad %ulong %58
+%190 = OpIMul %ulong %189 %ulong_1099511628211
+OpStore %59 %190
+%191 = OpLoad %ulong %62
+%192 = OpIAdd %ulong %191 %ulong_1
+OpStore %60 %192
+%193 = OpLoad %ulong %59
+OpStore %61 %193
+%194 = OpLoad %ulong %60
+OpStore %62 %194
+OpBranch %41
+%38 = OpLabel
+OpBranch %34
+%39 = OpLabel
+OpBranch %27
+%40 = OpLabel
+OpBranch %20
+%41 = OpLabel
+OpBranch %13
 OpFunctionEnd
-%2 = OpFunction %ulong None %46
-%47 = OpFunctionParameter %ulong
-%48 = OpLabel
-%93 = OpVariable %_ptr_Function__arr_v4uint_uint_4 Function
-%96 = OpVariable %_ptr_Function__struct_94 Function
-%97 = OpVariable %_ptr_Function_ulong Function
-%98 = OpVariable %_ptr_Function_ulong Function
-%99 = OpVariable %_ptr_Function_uint Function
-%100 = OpVariable %_ptr_Function_v4uint Function
-%101 = OpVariable %_ptr_Function_v4uint Function
-%102 = OpVariable %_ptr_Function_v4uint Function
-%103 = OpVariable %_ptr_Function_v4uint Function
-%104 = OpVariable %_ptr_Function_uint Function
-%105 = OpVariable %_ptr_Function_uint Function
-%106 = OpVariable %_ptr_Function_v4uint Function
-%107 = OpVariable %_ptr_Function_uint Function
-%108 = OpVariable %_ptr_Function_uint Function
-%109 = OpVariable %_ptr_Function_v4uint Function
-%110 = OpVariable %_ptr_Function_uint Function
-%111 = OpVariable %_ptr_Function_uint Function
-%112 = OpVariable %_ptr_Function_v4uint Function
-%113 = OpVariable %_ptr_Function_uint Function
-%114 = OpVariable %_ptr_Function_uint Function
-%115 = OpVariable %_ptr_Function_v4uint Function
-%116 = OpVariable %_ptr_Function_v4uint Function
-%117 = OpVariable %_ptr_Function_v4uint Function
-%118 = OpVariable %_ptr_Function_v4uint Function
-%119 = OpVariable %_ptr_Function_v4uint Function
-%120 = OpVariable %_ptr_Function_v4uint Function
-%121 = OpVariable %_ptr_Function_v4uint Function
-%122 = OpVariable %_ptr_Function_v4uint Function
-%123 = OpVariable %_ptr_Function_v4uint Function
-%124 = OpVariable %_ptr_Function_v4uint Function
-%125 = OpVariable %_ptr_Function_v4uint Function
-%126 = OpVariable %_ptr_Function_ulong Function
-%127 = OpVariable %_ptr_Function_v4uint Function
-%128 = OpVariable %_ptr_Function_ulong Function
-%129 = OpVariable %_ptr_Function_v4uint Function
-%130 = OpVariable %_ptr_Function_ulong Function
-%131 = OpVariable %_ptr_Function_v4uint Function
-%132 = OpVariable %_ptr_Function_ulong Function
-%133 = OpVariable %_ptr_Function_v4uint Function
-%134 = OpVariable %_ptr_Function_ulong Function
-%135 = OpVariable %_ptr_Function_v4uint Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_v4uint Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%140 = OpVariable %_ptr_Function_bool Function
-%141 = OpVariable %_ptr_Function_v4uint Function
-%142 = OpVariable %_ptr_Function_v4uint Function
-%143 = OpVariable %_ptr_Function_v4uint Function
-%144 = OpVariable %_ptr_Function_v4uint Function
-%145 = OpVariable %_ptr_Function_ulong Function
-%146 = OpVariable %_ptr_Function_v4uint Function
-%147 = OpVariable %_ptr_Function_v4uint Function
-%148 = OpVariable %_ptr_Function_bool Function
-%149 = OpVariable %_ptr_Function_v4uint Function
-%150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_v4uint Function
-%152 = OpVariable %_ptr_Function_uint Function
-%153 = OpVariable %_ptr_Function_ulong Function
-%154 = OpVariable %_ptr_Function_v4uint Function
-%155 = OpVariable %_ptr_Function_uint Function
-%156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
-%158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_v4uint Function
-%160 = OpVariable %_ptr_Function_v4uint Function
-%161 = OpVariable %_ptr_Function_v4uint Function
-%162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
-%164 = OpVariable %_ptr_Function_uint Function
-%165 = OpVariable %_ptr_Function_ulong Function
-%166 = OpVariable %_ptr_Function_uint Function
-%167 = OpVariable %_ptr_Function_ulong Function
-%168 = OpVariable %_ptr_Function_uint Function
-%169 = OpVariable %_ptr_Function_ulong Function
-%170 = OpVariable %_ptr_Function_uint Function
-%171 = OpVariable %_ptr_Function_ulong Function
-%172 = OpVariable %_ptr_Function_uint Function
-%173 = OpVariable %_ptr_Function_ulong Function
-%174 = OpVariable %_ptr_Function_uint Function
-%175 = OpVariable %_ptr_Function_ulong Function
-%176 = OpVariable %_ptr_Function_uint Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_uint Function
-%179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_uint Function
-%181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_uint Function
-%183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_uint Function
-%185 = OpVariable %_ptr_Function_ulong Function
-%186 = OpVariable %_ptr_Function_uint Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_uint Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_uint Function
-%191 = OpVariable %_ptr_Function_ulong Function
-%192 = OpVariable %_ptr_Function_uint Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_uint Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_uint Function
-%197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_uint Function
-%199 = OpVariable %_ptr_Function_ulong Function
-%200 = OpVariable %_ptr_Function_uint Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_uint Function
-%203 = OpVariable %_ptr_Function_ulong Function
-%204 = OpVariable %_ptr_Function_uint Function
-%205 = OpVariable %_ptr_Function_ulong Function
-%206 = OpVariable %_ptr_Function_uint Function
-%207 = OpVariable %_ptr_Function_ulong Function
-%208 = OpVariable %_ptr_Function_uint Function
-%209 = OpVariable %_ptr_Function_ulong Function
-%210 = OpVariable %_ptr_Function_uint Function
-%211 = OpVariable %_ptr_Function_ulong Function
-%212 = OpVariable %_ptr_Function_uint Function
-%213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_uint Function
-%215 = OpVariable %_ptr_Function_ulong Function
-%216 = OpVariable %_ptr_Function_uint Function
-%217 = OpVariable %_ptr_Function_ulong Function
-%218 = OpVariable %_ptr_Function_uint Function
-%219 = OpVariable %_ptr_Function_ulong Function
-%220 = OpVariable %_ptr_Function_uint Function
-%221 = OpVariable %_ptr_Function_ulong Function
-%222 = OpVariable %_ptr_Function_uint Function
-%223 = OpVariable %_ptr_Function_ulong Function
-%224 = OpVariable %_ptr_Function_uint Function
-%225 = OpVariable %_ptr_Function_ulong Function
-%226 = OpVariable %_ptr_Function_uint Function
-%227 = OpVariable %_ptr_Function_ulong Function
-%228 = OpVariable %_ptr_Function_uint Function
-%229 = OpVariable %_ptr_Function_ulong Function
-%230 = OpVariable %_ptr_Function_uint Function
+%2 = OpFunction %ulong None %195
+%196 = OpFunctionParameter %ulong
+%197 = OpLabel
+%227 = OpVariable %_ptr_Function__arr_v4uint_uint_4 Function
+%230 = OpVariable %_ptr_Function__struct_228 Function
 %231 = OpVariable %_ptr_Function_ulong Function
 %232 = OpVariable %_ptr_Function_uint Function
-%233 = OpVariable %_ptr_Function_ulong Function
-%234 = OpVariable %_ptr_Function_uint Function
-%235 = OpVariable %_ptr_Function_ulong Function
-%236 = OpVariable %_ptr_Function_uint Function
-%237 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_v4uint Function
+%234 = OpVariable %_ptr_Function_v4uint Function
+%235 = OpVariable %_ptr_Function_v4uint Function
+%236 = OpVariable %_ptr_Function_v4uint Function
+%237 = OpVariable %_ptr_Function_uint Function
 %238 = OpVariable %_ptr_Function_uint Function
-%239 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_v4uint Function
 %240 = OpVariable %_ptr_Function_uint Function
-%241 = OpVariable %_ptr_Function_ulong Function
-%242 = OpVariable %_ptr_Function_uint Function
-%243 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_uint Function
+%242 = OpVariable %_ptr_Function_v4uint Function
+%243 = OpVariable %_ptr_Function_uint Function
 %244 = OpVariable %_ptr_Function_uint Function
-%245 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_v4uint Function
 %246 = OpVariable %_ptr_Function_uint Function
-%247 = OpVariable %_ptr_Function_ulong Function
-%248 = OpVariable %_ptr_Function_uint Function
+%247 = OpVariable %_ptr_Function_uint Function
+%248 = OpVariable %_ptr_Function_v4uint Function
 %249 = OpVariable %_ptr_Function_ulong Function
-%250 = OpVariable %_ptr_Function_uint Function
-%251 = OpVariable %_ptr_Function_ulong Function
-%252 = OpVariable %_ptr_Function_uint Function
-%253 = OpVariable %_ptr_Function_ulong Function
-%254 = OpVariable %_ptr_Function_uint Function
-%255 = OpVariable %_ptr_Function_ulong Function
-%256 = OpVariable %_ptr_Function_uint Function
-%257 = OpVariable %_ptr_Function_ulong Function
-%258 = OpVariable %_ptr_Function_uint Function
-%259 = OpVariable %_ptr_Function_ulong Function
-%260 = OpVariable %_ptr_Function_uint Function
-%261 = OpVariable %_ptr_Function_ulong Function
-%262 = OpVariable %_ptr_Function_uint Function
-%263 = OpVariable %_ptr_Function_ulong Function
-%264 = OpVariable %_ptr_Function_uint Function
-%265 = OpVariable %_ptr_Function_ulong Function
-%266 = OpVariable %_ptr_Function_uint Function
-%267 = OpVariable %_ptr_Function_ulong Function
-%268 = OpVariable %_ptr_Function_uint Function
-%269 = OpVariable %_ptr_Function_ulong Function
-%270 = OpVariable %_ptr_Function_uint Function
-%271 = OpVariable %_ptr_Function_ulong Function
-%272 = OpVariable %_ptr_Function_uint Function
-%273 = OpVariable %_ptr_Function_ulong Function
-%274 = OpVariable %_ptr_Function_uint Function
-%275 = OpVariable %_ptr_Function_ulong Function
-%276 = OpVariable %_ptr_Function_uint Function
-%277 = OpVariable %_ptr_Function_ulong Function
-%278 = OpVariable %_ptr_Function_uint Function
-%279 = OpVariable %_ptr_Function_ulong Function
-%280 = OpVariable %_ptr_Function_uint Function
-%281 = OpVariable %_ptr_Function_ulong Function
-%282 = OpVariable %_ptr_Function_uint Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_v4uint Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_v4uint Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_v4uint Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_v4uint Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_v4uint Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_v4uint Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_v4uint Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_v4uint Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_v4uint Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_v4uint Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_v4uint Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_v4uint Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_v4uint Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_v4uint Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_v4uint Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_bool Function
+%282 = OpVariable %_ptr_Function_v4uint Function
 %283 = OpVariable %_ptr_Function_ulong Function
-%284 = OpVariable %_ptr_Function_uint Function
+%284 = OpVariable %_ptr_Function_v4uint Function
 %285 = OpVariable %_ptr_Function_ulong Function
-%286 = OpVariable %_ptr_Function_uint Function
+%286 = OpVariable %_ptr_Function_v4uint Function
 %287 = OpVariable %_ptr_Function_ulong Function
-%288 = OpVariable %_ptr_Function_uint Function
+%288 = OpVariable %_ptr_Function_v4uint Function
 %289 = OpVariable %_ptr_Function_ulong Function
-%290 = OpVariable %_ptr_Function_uint Function
-%291 = OpVariable %_ptr_Function_ulong Function
-OpStore %97 %47
-%292 = OpFunctionCall %ulong %3
-OpStore %98 %292
-%293 = OpLoad %ulong %97
-%294 = OpUConvert %uint %293
-OpStore %99 %294
-%295 = OpCompositeConstruct %v4uint %uint_4294967280 %uint_1 %uint_2147483648 %uint_305419896
-OpStore %100 %295
-%300 = OpCompositeConstruct %v4uint %uint_17 %uint_4294967295 %uint_2147483649 %uint_1
-OpStore %101 %300
-%304 = OpCompositeConstruct %v4uint %uint_1 %uint_3 %uint_9 %uint_27
-OpStore %102 %304
-%308 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
-OpStore %103 %308
-%310 = OpLoad %v4uint %100
-%311 = OpCompositeExtract %uint %310 0
-OpStore %104 %311
-%312 = OpLoad %uint %104
-%313 = OpLoad %uint %99
-%314 = OpIAdd %uint %312 %313
-OpStore %105 %314
-%315 = OpLoad %v4uint %100
-%316 = OpLoad %uint %105
-%317 = OpCompositeInsert %v4uint %316 %315 0
-OpStore %106 %317
-%318 = OpLoad %v4uint %106
-%319 = OpCompositeExtract %uint %318 2
-OpStore %107 %319
-%320 = OpLoad %uint %107
-%321 = OpLoad %uint %99
-%322 = OpIAdd %uint %320 %321
-OpStore %108 %322
-%323 = OpLoad %v4uint %106
-%324 = OpLoad %uint %108
-%325 = OpCompositeInsert %v4uint %324 %323 2
-OpStore %109 %325
-%326 = OpLoad %v4uint %101
-%327 = OpCompositeExtract %uint %326 1
-OpStore %110 %327
-%328 = OpLoad %uint %110
-%329 = OpLoad %uint %99
-%330 = OpIAdd %uint %328 %329
-OpStore %111 %330
-%331 = OpLoad %v4uint %101
-%332 = OpLoad %uint %111
-%333 = OpCompositeInsert %v4uint %332 %331 1
-OpStore %112 %333
-%334 = OpLoad %v4uint %112
-%335 = OpCompositeExtract %uint %334 3
-OpStore %113 %335
-%336 = OpLoad %uint %113
-%337 = OpLoad %uint %99
-%338 = OpIAdd %uint %336 %337
-OpStore %114 %338
-%339 = OpLoad %v4uint %112
-%340 = OpLoad %uint %114
-%341 = OpCompositeInsert %v4uint %340 %339 3
-OpStore %115 %341
-OpBranch %55
-%55 = OpLabel
-%342 = OpLoad %v4uint %109
-%343 = OpCompositeExtract %uint %342 0
-OpStore %164 %343
-%344 = OpLoad %ulong %98
-%345 = OpLoad %uint %164
-%346 = OpFunctionCall %ulong %4 %344 %345
-OpStore %165 %346
-%347 = OpLoad %v4uint %109
-%348 = OpCompositeExtract %uint %347 1
-OpStore %166 %348
-%349 = OpLoad %ulong %165
-%350 = OpLoad %uint %166
-%351 = OpFunctionCall %ulong %4 %349 %350
-OpStore %167 %351
-%352 = OpLoad %v4uint %109
-%353 = OpCompositeExtract %uint %352 2
-OpStore %168 %353
-%354 = OpLoad %ulong %167
-%355 = OpLoad %uint %168
-%356 = OpFunctionCall %ulong %4 %354 %355
-OpStore %169 %356
-%357 = OpLoad %v4uint %109
-%358 = OpCompositeExtract %uint %357 3
-OpStore %170 %358
-%359 = OpLoad %ulong %169
-%360 = OpLoad %uint %170
-%361 = OpFunctionCall %ulong %4 %359 %360
-OpStore %171 %361
-OpBranch %56
-%56 = OpLabel
-OpBranch %63
-%63 = OpLabel
-%362 = OpLoad %v4uint %115
-%363 = OpCompositeExtract %uint %362 0
-OpStore %196 %363
-%364 = OpLoad %ulong %171
-%365 = OpLoad %uint %196
-%366 = OpFunctionCall %ulong %4 %364 %365
-OpStore %197 %366
-%367 = OpLoad %v4uint %115
-%368 = OpCompositeExtract %uint %367 1
-OpStore %198 %368
-%369 = OpLoad %ulong %197
-%370 = OpLoad %uint %198
-%371 = OpFunctionCall %ulong %4 %369 %370
-OpStore %199 %371
-%372 = OpLoad %v4uint %115
-%373 = OpCompositeExtract %uint %372 2
-OpStore %200 %373
-%374 = OpLoad %ulong %199
-%375 = OpLoad %uint %200
-%376 = OpFunctionCall %ulong %4 %374 %375
-OpStore %201 %376
-%377 = OpLoad %v4uint %115
-%378 = OpCompositeExtract %uint %377 3
-OpStore %202 %378
-%379 = OpLoad %ulong %201
-%380 = OpLoad %uint %202
-%381 = OpFunctionCall %ulong %4 %379 %380
-OpStore %203 %381
-OpBranch %64
-%64 = OpLabel
-%382 = OpLoad %v4uint %109
-%383 = OpLoad %v4uint %115
-%384 = OpIAdd %v4uint %382 %383
-OpStore %116 %384
-OpBranch %67
-%67 = OpLabel
-%385 = OpLoad %v4uint %116
-%386 = OpCompositeExtract %uint %385 0
-OpStore %212 %386
-%387 = OpLoad %ulong %203
-%388 = OpLoad %uint %212
-%389 = OpFunctionCall %ulong %4 %387 %388
-OpStore %213 %389
-%390 = OpLoad %v4uint %116
-%391 = OpCompositeExtract %uint %390 1
-OpStore %214 %391
-%392 = OpLoad %ulong %213
-%393 = OpLoad %uint %214
-%394 = OpFunctionCall %ulong %4 %392 %393
-OpStore %215 %394
-%395 = OpLoad %v4uint %116
-%396 = OpCompositeExtract %uint %395 2
-OpStore %216 %396
-%397 = OpLoad %ulong %215
-%398 = OpLoad %uint %216
-%399 = OpFunctionCall %ulong %4 %397 %398
-OpStore %217 %399
-%400 = OpLoad %v4uint %116
-%401 = OpCompositeExtract %uint %400 3
-OpStore %218 %401
-%402 = OpLoad %ulong %217
-%403 = OpLoad %uint %218
-%404 = OpFunctionCall %ulong %4 %402 %403
-OpStore %219 %404
-OpBranch %68
-%68 = OpLabel
-%405 = OpLoad %v4uint %109
-%406 = OpLoad %v4uint %115
-%407 = OpISub %v4uint %405 %406
-OpStore %117 %407
-OpBranch %71
-%71 = OpLabel
-%408 = OpLoad %v4uint %117
-%409 = OpCompositeExtract %uint %408 0
-OpStore %228 %409
-%410 = OpLoad %ulong %219
-%411 = OpLoad %uint %228
-%412 = OpFunctionCall %ulong %4 %410 %411
-OpStore %229 %412
-%413 = OpLoad %v4uint %117
-%414 = OpCompositeExtract %uint %413 1
-OpStore %230 %414
-%415 = OpLoad %ulong %229
-%416 = OpLoad %uint %230
-%417 = OpFunctionCall %ulong %4 %415 %416
-OpStore %231 %417
-%418 = OpLoad %v4uint %117
-%419 = OpCompositeExtract %uint %418 2
-OpStore %232 %419
-%420 = OpLoad %ulong %231
-%421 = OpLoad %uint %232
-%422 = OpFunctionCall %ulong %4 %420 %421
-OpStore %233 %422
-%423 = OpLoad %v4uint %117
-%424 = OpCompositeExtract %uint %423 3
-OpStore %234 %424
-%425 = OpLoad %ulong %233
-%426 = OpLoad %uint %234
-%427 = OpFunctionCall %ulong %4 %425 %426
-OpStore %235 %427
-OpBranch %72
-%72 = OpLabel
-%428 = OpLoad %v4uint %115
-%429 = OpLoad %v4uint %109
-%430 = OpISub %v4uint %428 %429
-OpStore %118 %430
-OpBranch %75
-%75 = OpLabel
-%431 = OpLoad %v4uint %118
-%432 = OpCompositeExtract %uint %431 0
-OpStore %244 %432
-%433 = OpLoad %ulong %235
-%434 = OpLoad %uint %244
-%435 = OpFunctionCall %ulong %4 %433 %434
-OpStore %245 %435
-%436 = OpLoad %v4uint %118
-%437 = OpCompositeExtract %uint %436 1
-OpStore %246 %437
-%438 = OpLoad %ulong %245
-%439 = OpLoad %uint %246
-%440 = OpFunctionCall %ulong %4 %438 %439
-OpStore %247 %440
-%441 = OpLoad %v4uint %118
-%442 = OpCompositeExtract %uint %441 2
-OpStore %248 %442
-%443 = OpLoad %ulong %247
-%444 = OpLoad %uint %248
-%445 = OpFunctionCall %ulong %4 %443 %444
-OpStore %249 %445
-%446 = OpLoad %v4uint %118
-%447 = OpCompositeExtract %uint %446 3
-OpStore %250 %447
-%448 = OpLoad %ulong %249
-%449 = OpLoad %uint %250
-%450 = OpFunctionCall %ulong %4 %448 %449
-OpStore %251 %450
-OpBranch %76
-%76 = OpLabel
-%451 = OpLoad %v4uint %109
-%452 = OpLoad %v4uint %115
-%453 = OpIMul %v4uint %451 %452
-OpStore %119 %453
-OpBranch %77
-%77 = OpLabel
-%454 = OpLoad %v4uint %119
-%455 = OpCompositeExtract %uint %454 0
-OpStore %252 %455
-%456 = OpLoad %ulong %251
-%457 = OpLoad %uint %252
-%458 = OpFunctionCall %ulong %4 %456 %457
-OpStore %253 %458
-%459 = OpLoad %v4uint %119
-%460 = OpCompositeExtract %uint %459 1
-OpStore %254 %460
-%461 = OpLoad %ulong %253
-%462 = OpLoad %uint %254
-%463 = OpFunctionCall %ulong %4 %461 %462
-OpStore %255 %463
-%464 = OpLoad %v4uint %119
-%465 = OpCompositeExtract %uint %464 2
-OpStore %256 %465
-%466 = OpLoad %ulong %255
-%467 = OpLoad %uint %256
-%468 = OpFunctionCall %ulong %4 %466 %467
-OpStore %257 %468
-%469 = OpLoad %v4uint %119
-%470 = OpCompositeExtract %uint %469 3
-OpStore %258 %470
-%471 = OpLoad %ulong %257
-%472 = OpLoad %uint %258
-%473 = OpFunctionCall %ulong %4 %471 %472
-OpStore %259 %473
-OpBranch %78
-%78 = OpLabel
-%474 = OpLoad %v4uint %109
-%475 = OpLoad %v4uint %102
-%476 = OpIMul %v4uint %474 %475
-OpStore %120 %476
-OpBranch %79
-%79 = OpLabel
-%477 = OpLoad %v4uint %120
-%478 = OpCompositeExtract %uint %477 0
-OpStore %260 %478
-%479 = OpLoad %ulong %259
-%480 = OpLoad %uint %260
-%481 = OpFunctionCall %ulong %4 %479 %480
-OpStore %261 %481
-%482 = OpLoad %v4uint %120
-%483 = OpCompositeExtract %uint %482 1
-OpStore %262 %483
-%484 = OpLoad %ulong %261
-%485 = OpLoad %uint %262
-%486 = OpFunctionCall %ulong %4 %484 %485
-OpStore %263 %486
-%487 = OpLoad %v4uint %120
-%488 = OpCompositeExtract %uint %487 2
-OpStore %264 %488
-%489 = OpLoad %ulong %263
-%490 = OpLoad %uint %264
-%491 = OpFunctionCall %ulong %4 %489 %490
-OpStore %265 %491
-%492 = OpLoad %v4uint %120
-%493 = OpCompositeExtract %uint %492 3
-OpStore %266 %493
-%494 = OpLoad %ulong %265
-%495 = OpLoad %uint %266
-%496 = OpFunctionCall %ulong %4 %494 %495
-OpStore %267 %496
-OpBranch %80
-%80 = OpLabel
-%497 = OpLoad %v4uint %115
-%498 = OpLoad %v4uint %102
-%499 = OpIMul %v4uint %497 %498
-OpStore %121 %499
-OpBranch %81
-%81 = OpLabel
-%500 = OpLoad %v4uint %121
-%501 = OpCompositeExtract %uint %500 0
-OpStore %268 %501
-%502 = OpLoad %ulong %267
-%503 = OpLoad %uint %268
-%504 = OpFunctionCall %ulong %4 %502 %503
-OpStore %269 %504
-%505 = OpLoad %v4uint %121
-%506 = OpCompositeExtract %uint %505 1
-OpStore %270 %506
-%507 = OpLoad %ulong %269
-%508 = OpLoad %uint %270
-%509 = OpFunctionCall %ulong %4 %507 %508
-OpStore %271 %509
-%510 = OpLoad %v4uint %121
-%511 = OpCompositeExtract %uint %510 2
-OpStore %272 %511
-%512 = OpLoad %ulong %271
-%513 = OpLoad %uint %272
-%514 = OpFunctionCall %ulong %4 %512 %513
-OpStore %273 %514
-%515 = OpLoad %v4uint %121
-%516 = OpCompositeExtract %uint %515 3
-OpStore %274 %516
-%517 = OpLoad %ulong %273
-%518 = OpLoad %uint %274
-%519 = OpFunctionCall %ulong %4 %517 %518
-OpStore %275 %519
-OpBranch %82
-%82 = OpLabel
-%520 = OpLoad %v4uint %109
-%521 = OpLoad %v4uint %115
-%522 = OpIAdd %v4uint %520 %521
-OpStore %122 %522
-%523 = OpLoad %v4uint %122
-%524 = OpLoad %v4uint %102
-%525 = OpIMul %v4uint %523 %524
-OpStore %123 %525
-OpBranch %83
-%83 = OpLabel
-%526 = OpLoad %v4uint %123
-%527 = OpCompositeExtract %uint %526 0
-OpStore %276 %527
-%528 = OpLoad %ulong %275
-%529 = OpLoad %uint %276
-%530 = OpFunctionCall %ulong %4 %528 %529
-OpStore %277 %530
-%531 = OpLoad %v4uint %123
-%532 = OpCompositeExtract %uint %531 1
-OpStore %278 %532
-%533 = OpLoad %ulong %277
-%534 = OpLoad %uint %278
-%535 = OpFunctionCall %ulong %4 %533 %534
-OpStore %279 %535
-%536 = OpLoad %v4uint %123
-%537 = OpCompositeExtract %uint %536 2
-OpStore %280 %537
-%538 = OpLoad %ulong %279
-%539 = OpLoad %uint %280
-%540 = OpFunctionCall %ulong %4 %538 %539
-OpStore %281 %540
-%541 = OpLoad %v4uint %123
-%542 = OpCompositeExtract %uint %541 3
-OpStore %282 %542
-%543 = OpLoad %ulong %281
-%544 = OpLoad %uint %282
-%545 = OpFunctionCall %ulong %4 %543 %544
-OpStore %283 %545
-OpBranch %84
-%84 = OpLabel
-%546 = OpLoad %v4uint %103
-%547 = OpLoad %v4uint %109
-%548 = OpISub %v4uint %546 %547
-OpStore %124 %548
-OpBranch %85
-%85 = OpLabel
-%549 = OpLoad %v4uint %124
-%550 = OpCompositeExtract %uint %549 0
-OpStore %284 %550
-%551 = OpLoad %ulong %283
-%552 = OpLoad %uint %284
-%553 = OpFunctionCall %ulong %4 %551 %552
-OpStore %285 %553
-%554 = OpLoad %v4uint %124
-%555 = OpCompositeExtract %uint %554 1
-OpStore %286 %555
-%556 = OpLoad %ulong %285
-%557 = OpLoad %uint %286
-%558 = OpFunctionCall %ulong %4 %556 %557
-OpStore %287 %558
-%559 = OpLoad %v4uint %124
-%560 = OpCompositeExtract %uint %559 2
-OpStore %288 %560
-%561 = OpLoad %ulong %287
-%562 = OpLoad %uint %288
-%563 = OpFunctionCall %ulong %4 %561 %562
-OpStore %289 %563
-%564 = OpLoad %v4uint %124
-%565 = OpCompositeExtract %uint %564 3
-OpStore %290 %565
-%566 = OpLoad %ulong %289
-%567 = OpLoad %uint %290
-%568 = OpFunctionCall %ulong %4 %566 %567
-OpStore %291 %568
-OpBranch %86
-%86 = OpLabel
-%569 = OpLoad %v4uint %103
-%570 = OpLoad %v4uint %115
-%571 = OpISub %v4uint %569 %570
-OpStore %125 %571
-%572 = OpLoad %ulong %291
-%573 = OpLoad %v4uint %125
-%574 = OpFunctionCall %ulong %1 %572 %573
-OpStore %126 %574
-%575 = OpLoad %v4uint %109
-%576 = OpLoad %v4uint %115
-%577 = OpBitwiseAnd %v4uint %575 %576
-OpStore %127 %577
-%578 = OpLoad %ulong %126
-%579 = OpLoad %v4uint %127
-%580 = OpFunctionCall %ulong %1 %578 %579
-OpStore %128 %580
-%581 = OpLoad %v4uint %109
-%582 = OpLoad %v4uint %115
-%583 = OpBitwiseOr %v4uint %581 %582
-OpStore %129 %583
-%584 = OpLoad %ulong %128
-%585 = OpLoad %v4uint %129
-%586 = OpFunctionCall %ulong %1 %584 %585
-OpStore %130 %586
-%587 = OpLoad %v4uint %109
-%588 = OpLoad %v4uint %115
-%589 = OpBitwiseXor %v4uint %587 %588
-OpStore %131 %589
-%590 = OpLoad %ulong %130
-%591 = OpLoad %v4uint %131
-%592 = OpFunctionCall %ulong %1 %590 %591
-OpStore %132 %592
-%593 = OpLoad %v4uint %109
-%594 = OpNot %v4uint %593
-OpStore %133 %594
-%595 = OpLoad %ulong %132
-%596 = OpLoad %v4uint %133
-%597 = OpFunctionCall %ulong %1 %595 %596
-OpStore %134 %597
-%598 = OpLoad %v4uint %115
-%599 = OpNot %v4uint %598
-OpStore %135 %599
-%600 = OpLoad %ulong %134
-%601 = OpLoad %v4uint %135
-%602 = OpFunctionCall %ulong %1 %600 %601
-OpStore %136 %602
-%603 = OpLoad %v4uint %127
-%604 = OpLoad %v4uint %129
-%605 = OpBitwiseXor %v4uint %603 %604
-OpStore %137 %605
-%606 = OpLoad %ulong %136
-%607 = OpLoad %v4uint %137
-%608 = OpFunctionCall %ulong %1 %606 %607
-OpStore %138 %608
-%609 = OpLoad %ulong %138
-OpStore %158 %609
-%610 = OpLoad %v4uint %109
-OpStore %159 %610
-%611 = OpLoad %v4uint %103
-OpStore %160 %611
-%612 = OpLoad %v4uint %103
-OpStore %161 %612
-OpStore %162 %ulong_0
-OpBranch %49
-%49 = OpLabel
-%614 = OpLoad %ulong %162
-%616 = OpULessThan %bool %614 %ulong_6
-OpStore %140 %616
-%617 = OpLoad %bool %140
-OpLoopMerge %51 %88 None
-OpBranchConditional %617 %50 %51
-%51 = OpLabel
-OpStore %93 %618
-%619 = OpAccessChain %_ptr_Function_v4uint %93 %uint_0
-%620 = OpLoad %v4uint %159
-OpStore %619 %620
-%621 = OpLoad %v4uint %159
-%622 = OpLoad %v4uint %115
-%623 = OpIAdd %v4uint %621 %622
-OpStore %146 %623
-%624 = OpAccessChain %_ptr_Function_v4uint %93 %uint_1
-%625 = OpLoad %v4uint %146
-OpStore %624 %625
-%626 = OpLoad %v4uint %159
-%627 = OpLoad %v4uint %102
-%628 = OpIMul %v4uint %626 %627
-OpStore %147 %628
-%630 = OpAccessChain %_ptr_Function_v4uint %93 %uint_2
-%631 = OpLoad %v4uint %147
-OpStore %630 %631
-%632 = OpAccessChain %_ptr_Function_v4uint %93 %uint_3
-%633 = OpLoad %v4uint %160
-OpStore %632 %633
-%634 = OpLoad %ulong %158
-OpStore %157 %634
-OpStore %163 %ulong_0
-OpBranch %52
-%52 = OpLabel
-%635 = OpLoad %ulong %163
-%637 = OpULessThan %bool %635 %ulong_4
-OpStore %148 %637
-%638 = OpLoad %bool %148
-OpLoopMerge %54 %87 None
-OpBranchConditional %638 %53 %54
-%54 = OpLabel
-OpStore %96 %639
-%640 = OpAccessChain %_ptr_Function_uint %96 %uint_0
-OpStore %640 %uint_4294967295
-%641 = OpAccessChain %_ptr_Function_v4uint %93 %uint_2
-%642 = OpLoad %v4uint %641
-OpStore %151 %642
-%643 = OpAccessChain %_ptr_Function_v4uint %96 %uint_1
-%644 = OpLoad %v4uint %151
-OpStore %643 %644
-%645 = OpAccessChain %_ptr_Function_uint %96 %uint_2
-OpStore %645 %uint_305419896
-%646 = OpLoad %uint %640
-OpStore %152 %646
-%647 = OpLoad %ulong %157
-%648 = OpLoad %uint %152
-%649 = OpFunctionCall %ulong %4 %647 %648
-OpStore %153 %649
-%650 = OpLoad %v4uint %643
-OpStore %154 %650
-OpBranch %61
-%61 = OpLabel
-%651 = OpLoad %v4uint %154
-%652 = OpCompositeExtract %uint %651 0
-OpStore %188 %652
-%653 = OpLoad %ulong %153
-%654 = OpLoad %uint %188
-%655 = OpFunctionCall %ulong %4 %653 %654
-OpStore %189 %655
-%656 = OpLoad %v4uint %154
-%657 = OpCompositeExtract %uint %656 1
-OpStore %190 %657
-%658 = OpLoad %ulong %189
-%659 = OpLoad %uint %190
-%660 = OpFunctionCall %ulong %4 %658 %659
-OpStore %191 %660
-%661 = OpLoad %v4uint %154
-%662 = OpCompositeExtract %uint %661 2
-OpStore %192 %662
-%663 = OpLoad %ulong %191
-%664 = OpLoad %uint %192
-%665 = OpFunctionCall %ulong %4 %663 %664
-OpStore %193 %665
-%666 = OpLoad %v4uint %154
-%667 = OpCompositeExtract %uint %666 3
-OpStore %194 %667
-%668 = OpLoad %ulong %193
-%669 = OpLoad %uint %194
-%670 = OpFunctionCall %ulong %4 %668 %669
-OpStore %195 %670
-OpBranch %62
-%62 = OpLabel
-%671 = OpAccessChain %_ptr_Function_uint %96 %uint_2
-%672 = OpLoad %uint %671
-OpStore %155 %672
-%673 = OpLoad %ulong %195
-%674 = OpLoad %uint %155
-%675 = OpFunctionCall %ulong %4 %673 %674
-OpStore %156 %675
-%676 = OpLoad %ulong %156
-OpReturnValue %676
-%53 = OpLabel
-%677 = OpLoad %ulong %163
-%678 = OpAccessChain %_ptr_Function_v4uint %93 %677
-%679 = OpLoad %v4uint %678
-OpStore %149 %679
-OpBranch %59
-%59 = OpLabel
-%680 = OpLoad %v4uint %149
-%681 = OpCompositeExtract %uint %680 0
-OpStore %180 %681
-%682 = OpLoad %ulong %157
-%683 = OpLoad %uint %180
-%684 = OpFunctionCall %ulong %4 %682 %683
-OpStore %181 %684
-%685 = OpLoad %v4uint %149
-%686 = OpCompositeExtract %uint %685 1
-OpStore %182 %686
-%687 = OpLoad %ulong %181
-%688 = OpLoad %uint %182
-%689 = OpFunctionCall %ulong %4 %687 %688
-OpStore %183 %689
-%690 = OpLoad %v4uint %149
-%691 = OpCompositeExtract %uint %690 2
-OpStore %184 %691
-%692 = OpLoad %ulong %183
-%693 = OpLoad %uint %184
-%694 = OpFunctionCall %ulong %4 %692 %693
-OpStore %185 %694
-%695 = OpLoad %v4uint %149
-%696 = OpCompositeExtract %uint %695 3
-OpStore %186 %696
-%697 = OpLoad %ulong %185
-%698 = OpLoad %uint %186
-%699 = OpFunctionCall %ulong %4 %697 %698
-OpStore %187 %699
-OpBranch %60
-%60 = OpLabel
-%700 = OpLoad %ulong %163
-%702 = OpIAdd %ulong %700 %ulong_1
-OpStore %150 %702
-%703 = OpLoad %ulong %187
-OpStore %157 %703
-%704 = OpLoad %ulong %150
-OpStore %163 %704
-OpBranch %87
-%50 = OpLabel
-%705 = OpLoad %v4uint %159
-%706 = OpLoad %v4uint %102
-%707 = OpIMul %v4uint %705 %706
-OpStore %141 %707
-OpBranch %57
-%57 = OpLabel
-%708 = OpLoad %v4uint %141
-%709 = OpCompositeExtract %uint %708 0
-OpStore %172 %709
-%710 = OpLoad %ulong %158
-%711 = OpLoad %uint %172
-%712 = OpFunctionCall %ulong %4 %710 %711
-OpStore %173 %712
-%713 = OpLoad %v4uint %141
-%714 = OpCompositeExtract %uint %713 1
-OpStore %174 %714
-%715 = OpLoad %ulong %173
-%716 = OpLoad %uint %174
-%717 = OpFunctionCall %ulong %4 %715 %716
-OpStore %175 %717
-%718 = OpLoad %v4uint %141
-%719 = OpCompositeExtract %uint %718 2
-OpStore %176 %719
-%720 = OpLoad %ulong %175
-%721 = OpLoad %uint %176
-%722 = OpFunctionCall %ulong %4 %720 %721
-OpStore %177 %722
-%723 = OpLoad %v4uint %141
-%724 = OpCompositeExtract %uint %723 3
-OpStore %178 %724
-%725 = OpLoad %ulong %177
-%726 = OpLoad %uint %178
-%727 = OpFunctionCall %ulong %4 %725 %726
-OpStore %179 %727
-OpBranch %58
-%58 = OpLabel
-%728 = OpLoad %v4uint %160
-%729 = OpLoad %v4uint %141
-%730 = OpBitwiseXor %v4uint %728 %729
-OpStore %142 %730
-OpBranch %65
-%65 = OpLabel
-%731 = OpLoad %v4uint %142
-%732 = OpCompositeExtract %uint %731 0
-OpStore %204 %732
-%733 = OpLoad %ulong %179
-%734 = OpLoad %uint %204
-%735 = OpFunctionCall %ulong %4 %733 %734
-OpStore %205 %735
-%736 = OpLoad %v4uint %142
-%737 = OpCompositeExtract %uint %736 1
-OpStore %206 %737
-%738 = OpLoad %ulong %205
-%739 = OpLoad %uint %206
-%740 = OpFunctionCall %ulong %4 %738 %739
-OpStore %207 %740
-%741 = OpLoad %v4uint %142
-%742 = OpCompositeExtract %uint %741 2
-OpStore %208 %742
-%743 = OpLoad %ulong %207
-%744 = OpLoad %uint %208
-%745 = OpFunctionCall %ulong %4 %743 %744
-OpStore %209 %745
-%746 = OpLoad %v4uint %142
-%747 = OpCompositeExtract %uint %746 3
-OpStore %210 %747
-%748 = OpLoad %ulong %209
-%749 = OpLoad %uint %210
-%750 = OpFunctionCall %ulong %4 %748 %749
-OpStore %211 %750
-OpBranch %66
-%66 = OpLabel
-%751 = OpLoad %v4uint %161
-%752 = OpLoad %v4uint %159
-%753 = OpIAdd %v4uint %751 %752
-OpStore %143 %753
-OpBranch %69
-%69 = OpLabel
-%754 = OpLoad %v4uint %143
-%755 = OpCompositeExtract %uint %754 0
-OpStore %220 %755
-%756 = OpLoad %ulong %211
-%757 = OpLoad %uint %220
-%758 = OpFunctionCall %ulong %4 %756 %757
-OpStore %221 %758
-%759 = OpLoad %v4uint %143
-%760 = OpCompositeExtract %uint %759 1
-OpStore %222 %760
-%761 = OpLoad %ulong %221
-%762 = OpLoad %uint %222
-%763 = OpFunctionCall %ulong %4 %761 %762
-OpStore %223 %763
-%764 = OpLoad %v4uint %143
-%765 = OpCompositeExtract %uint %764 2
-OpStore %224 %765
-%766 = OpLoad %ulong %223
-%767 = OpLoad %uint %224
-%768 = OpFunctionCall %ulong %4 %766 %767
-OpStore %225 %768
-%769 = OpLoad %v4uint %143
-%770 = OpCompositeExtract %uint %769 3
-OpStore %226 %770
-%771 = OpLoad %ulong %225
-%772 = OpLoad %uint %226
-%773 = OpFunctionCall %ulong %4 %771 %772
-OpStore %227 %773
-OpBranch %70
-%70 = OpLabel
-%774 = OpLoad %v4uint %159
-%775 = OpLoad %v4uint %115
-%776 = OpIAdd %v4uint %774 %775
-OpStore %144 %776
-OpBranch %73
-%73 = OpLabel
-%777 = OpLoad %v4uint %144
-%778 = OpCompositeExtract %uint %777 0
-OpStore %236 %778
-%779 = OpLoad %ulong %227
-%780 = OpLoad %uint %236
-%781 = OpFunctionCall %ulong %4 %779 %780
-OpStore %237 %781
-%782 = OpLoad %v4uint %144
-%783 = OpCompositeExtract %uint %782 1
-OpStore %238 %783
-%784 = OpLoad %ulong %237
-%785 = OpLoad %uint %238
-%786 = OpFunctionCall %ulong %4 %784 %785
-OpStore %239 %786
-%787 = OpLoad %v4uint %144
-%788 = OpCompositeExtract %uint %787 2
-OpStore %240 %788
-%789 = OpLoad %ulong %239
-%790 = OpLoad %uint %240
-%791 = OpFunctionCall %ulong %4 %789 %790
-OpStore %241 %791
-%792 = OpLoad %v4uint %144
-%793 = OpCompositeExtract %uint %792 3
-OpStore %242 %793
-%794 = OpLoad %ulong %241
-%795 = OpLoad %uint %242
-%796 = OpFunctionCall %ulong %4 %794 %795
-OpStore %243 %796
-OpBranch %74
-%74 = OpLabel
-%797 = OpLoad %ulong %162
-%798 = OpIAdd %ulong %797 %ulong_1
-OpStore %145 %798
-%799 = OpLoad %ulong %243
-OpStore %158 %799
-%800 = OpLoad %v4uint %144
-OpStore %159 %800
-%801 = OpLoad %v4uint %142
-OpStore %160 %801
-%802 = OpLoad %v4uint %143
-OpStore %161 %802
-%803 = OpLoad %ulong %145
-OpStore %162 %803
-OpBranch %88
-%87 = OpLabel
-OpBranch %52
-%88 = OpLabel
-OpBranch %49
-OpFunctionEnd
-%3 = OpFunction %ulong None %804
-%805 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %807
-%808 = OpFunctionParameter %ulong
-%809 = OpFunctionParameter %uint
-%810 = OpLabel
-%817 = OpVariable %_ptr_Function_ulong Function
-%818 = OpVariable %_ptr_Function_uint Function
-%819 = OpVariable %_ptr_Function_ulong Function
-%820 = OpVariable %_ptr_Function_bool Function
-%821 = OpVariable %_ptr_Function_ulong Function
-%822 = OpVariable %_ptr_Function_ulong Function
-%823 = OpVariable %_ptr_Function_ulong Function
-%824 = OpVariable %_ptr_Function_ulong Function
-%825 = OpVariable %_ptr_Function_ulong Function
-%826 = OpVariable %_ptr_Function_ulong Function
-%827 = OpVariable %_ptr_Function_ulong Function
-%828 = OpVariable %_ptr_Function_ulong Function
-OpStore %817 %808
-OpStore %818 %809
-%829 = OpLoad %uint %818
-%830 = OpUConvert %ulong %829
-OpStore %819 %830
-OpBranch %811
-%811 = OpLabel
-%831 = OpLoad %ulong %817
-OpStore %827 %831
-OpStore %828 %ulong_0
-OpBranch %812
-%812 = OpLabel
-%832 = OpLoad %ulong %828
-%834 = OpULessThan %bool %832 %ulong_8
-OpStore %820 %834
-%835 = OpLoad %bool %820
-OpLoopMerge %814 %816 None
-OpBranchConditional %835 %813 %814
-%814 = OpLabel
-OpBranch %815
-%815 = OpLabel
-%836 = OpLoad %ulong %827
-OpReturnValue %836
-%813 = OpLabel
-%837 = OpLoad %ulong %828
-%838 = OpIMul %ulong %837 %ulong_8
-OpStore %821 %838
-%839 = OpLoad %ulong %819
-%840 = OpLoad %ulong %821
-%841 = OpShiftRightLogical %ulong %839 %840
-OpStore %822 %841
-%842 = OpLoad %ulong %822
-%844 = OpBitwiseAnd %ulong %842 %ulong_255
-OpStore %823 %844
-%845 = OpLoad %ulong %827
-%846 = OpLoad %ulong %823
-%847 = OpBitwiseXor %ulong %845 %846
-OpStore %824 %847
-%848 = OpLoad %ulong %824
-%850 = OpIMul %ulong %848 %ulong_1099511628211
-OpStore %825 %850
-%851 = OpLoad %ulong %828
-%852 = OpIAdd %ulong %851 %ulong_1
-OpStore %826 %852
-%853 = OpLoad %ulong %825
-OpStore %827 %853
-%854 = OpLoad %ulong %826
-OpStore %828 %854
-OpBranch %816
-%816 = OpLabel
-OpBranch %812
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_v4uint Function
+%292 = OpVariable %_ptr_Function_v4uint Function
+%293 = OpVariable %_ptr_Function_bool Function
+%294 = OpVariable %_ptr_Function_v4uint Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_v4uint Function
+%298 = OpVariable %_ptr_Function_uint Function
+%299 = OpVariable %_ptr_Function_v4uint Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_uint Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_v4uint Function
+%305 = OpVariable %_ptr_Function_v4uint Function
+%306 = OpVariable %_ptr_Function_v4uint Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_bool Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_bool Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_ulong Function
+%328 = OpVariable %_ptr_Function_ulong Function
+OpStore %231 %196
+OpBranch %204
+%204 = OpLabel
+OpBranch %205
+%205 = OpLabel
+%329 = OpLoad %ulong %231
+%330 = OpUConvert %uint %329
+OpStore %232 %330
+%331 = OpCompositeConstruct %v4uint %uint_4294967280 %uint_1 %uint_2147483648 %uint_305419896
+OpStore %233 %331
+%336 = OpCompositeConstruct %v4uint %uint_17 %uint_4294967295 %uint_2147483649 %uint_1
+OpStore %234 %336
+%340 = OpCompositeConstruct %v4uint %uint_1 %uint_3 %uint_9 %uint_27
+OpStore %235 %340
+%344 = OpCompositeConstruct %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+OpStore %236 %344
+%346 = OpLoad %v4uint %233
+%347 = OpCompositeExtract %uint %346 0
+OpStore %237 %347
+%348 = OpLoad %uint %237
+%349 = OpLoad %uint %232
+%350 = OpIAdd %uint %348 %349
+OpStore %238 %350
+%351 = OpLoad %v4uint %233
+%352 = OpLoad %uint %238
+%353 = OpCompositeInsert %v4uint %352 %351 0
+OpStore %239 %353
+%354 = OpLoad %v4uint %239
+%355 = OpCompositeExtract %uint %354 2
+OpStore %240 %355
+%356 = OpLoad %uint %240
+%357 = OpLoad %uint %232
+%358 = OpIAdd %uint %356 %357
+OpStore %241 %358
+%359 = OpLoad %v4uint %239
+%360 = OpLoad %uint %241
+%361 = OpCompositeInsert %v4uint %360 %359 2
+OpStore %242 %361
+%362 = OpLoad %v4uint %234
+%363 = OpCompositeExtract %uint %362 1
+OpStore %243 %363
+%364 = OpLoad %uint %243
+%365 = OpLoad %uint %232
+%366 = OpIAdd %uint %364 %365
+OpStore %244 %366
+%367 = OpLoad %v4uint %234
+%368 = OpLoad %uint %244
+%369 = OpCompositeInsert %v4uint %368 %367 1
+OpStore %245 %369
+%370 = OpLoad %v4uint %245
+%371 = OpCompositeExtract %uint %370 3
+OpStore %246 %371
+%372 = OpLoad %uint %246
+%373 = OpLoad %uint %232
+%374 = OpIAdd %uint %372 %373
+OpStore %247 %374
+%375 = OpLoad %v4uint %245
+%376 = OpLoad %uint %247
+%377 = OpCompositeInsert %v4uint %376 %375 3
+OpStore %248 %377
+%379 = OpLoad %v4uint %242
+%380 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %379
+OpStore %249 %380
+%381 = OpLoad %ulong %249
+%382 = OpLoad %v4uint %248
+%383 = OpFunctionCall %ulong %1 %381 %382
+OpStore %250 %383
+%384 = OpLoad %v4uint %242
+%385 = OpLoad %v4uint %248
+%386 = OpIAdd %v4uint %384 %385
+OpStore %251 %386
+%387 = OpLoad %ulong %250
+%388 = OpLoad %v4uint %251
+%389 = OpFunctionCall %ulong %1 %387 %388
+OpStore %252 %389
+%390 = OpLoad %v4uint %242
+%391 = OpLoad %v4uint %248
+%392 = OpISub %v4uint %390 %391
+OpStore %253 %392
+%393 = OpLoad %ulong %252
+%394 = OpLoad %v4uint %253
+%395 = OpFunctionCall %ulong %1 %393 %394
+OpStore %254 %395
+%396 = OpLoad %v4uint %248
+%397 = OpLoad %v4uint %242
+%398 = OpISub %v4uint %396 %397
+OpStore %255 %398
+%399 = OpLoad %ulong %254
+%400 = OpLoad %v4uint %255
+%401 = OpFunctionCall %ulong %1 %399 %400
+OpStore %256 %401
+%402 = OpLoad %v4uint %242
+%403 = OpLoad %v4uint %248
+%404 = OpIMul %v4uint %402 %403
+OpStore %257 %404
+%405 = OpLoad %ulong %256
+%406 = OpLoad %v4uint %257
+%407 = OpFunctionCall %ulong %1 %405 %406
+OpStore %258 %407
+%408 = OpLoad %v4uint %242
+%409 = OpLoad %v4uint %235
+%410 = OpIMul %v4uint %408 %409
+OpStore %259 %410
+%411 = OpLoad %ulong %258
+%412 = OpLoad %v4uint %259
+%413 = OpFunctionCall %ulong %1 %411 %412
+OpStore %260 %413
+%414 = OpLoad %v4uint %248
+%415 = OpLoad %v4uint %235
+%416 = OpIMul %v4uint %414 %415
+OpStore %261 %416
+%417 = OpLoad %ulong %260
+%418 = OpLoad %v4uint %261
+%419 = OpFunctionCall %ulong %1 %417 %418
+OpStore %262 %419
+%420 = OpLoad %v4uint %251
+%421 = OpLoad %v4uint %235
+%422 = OpIMul %v4uint %420 %421
+OpStore %263 %422
+%423 = OpLoad %ulong %262
+%424 = OpLoad %v4uint %263
+%425 = OpFunctionCall %ulong %1 %423 %424
+OpStore %264 %425
+%426 = OpLoad %v4uint %236
+%427 = OpLoad %v4uint %242
+%428 = OpISub %v4uint %426 %427
+OpStore %265 %428
+%429 = OpLoad %ulong %264
+%430 = OpLoad %v4uint %265
+%431 = OpFunctionCall %ulong %1 %429 %430
+OpStore %266 %431
+%432 = OpLoad %v4uint %236
+%433 = OpLoad %v4uint %248
+%434 = OpISub %v4uint %432 %433
+OpStore %267 %434
+%435 = OpLoad %ulong %266
+%436 = OpLoad %v4uint %267
+%437 = OpFunctionCall %ulong %1 %435 %436
+OpStore %268 %437
+%438 = OpLoad %v4uint %242
+%439 = OpLoad %v4uint %248
+%440 = OpBitwiseAnd %v4uint %438 %439
+OpStore %269 %440
+%441 = OpLoad %ulong %268
+%442 = OpLoad %v4uint %269
+%443 = OpFunctionCall %ulong %1 %441 %442
+OpStore %270 %443
+%444 = OpLoad %v4uint %242
+%445 = OpLoad %v4uint %248
+%446 = OpBitwiseOr %v4uint %444 %445
+OpStore %271 %446
+%447 = OpLoad %ulong %270
+%448 = OpLoad %v4uint %271
+%449 = OpFunctionCall %ulong %1 %447 %448
+OpStore %272 %449
+%450 = OpLoad %v4uint %242
+%451 = OpLoad %v4uint %248
+%452 = OpBitwiseXor %v4uint %450 %451
+OpStore %273 %452
+%453 = OpLoad %ulong %272
+%454 = OpLoad %v4uint %273
+%455 = OpFunctionCall %ulong %1 %453 %454
+OpStore %274 %455
+%456 = OpLoad %v4uint %242
+%457 = OpNot %v4uint %456
+OpStore %275 %457
+%458 = OpLoad %ulong %274
+%459 = OpLoad %v4uint %275
+%460 = OpFunctionCall %ulong %1 %458 %459
+OpStore %276 %460
+%461 = OpLoad %v4uint %248
+%462 = OpNot %v4uint %461
+OpStore %277 %462
+%463 = OpLoad %ulong %276
+%464 = OpLoad %v4uint %277
+%465 = OpFunctionCall %ulong %1 %463 %464
+OpStore %278 %465
+%466 = OpLoad %v4uint %269
+%467 = OpLoad %v4uint %271
+%468 = OpBitwiseXor %v4uint %466 %467
+OpStore %279 %468
+%469 = OpLoad %ulong %278
+%470 = OpLoad %v4uint %279
+%471 = OpFunctionCall %ulong %1 %469 %470
+OpStore %280 %471
+%472 = OpLoad %ulong %280
+OpStore %303 %472
+%473 = OpLoad %v4uint %242
+OpStore %304 %473
+%474 = OpLoad %v4uint %236
+OpStore %305 %474
+%475 = OpLoad %v4uint %236
+OpStore %306 %475
+OpStore %307 %ulong_0
+OpBranch %198
+%198 = OpLabel
+%476 = OpLoad %ulong %307
+%478 = OpULessThan %bool %476 %ulong_6
+OpStore %281 %478
+%479 = OpLoad %bool %281
+OpLoopMerge %200 %223 None
+OpBranchConditional %479 %199 %200
+%200 = OpLabel
+OpStore %227 %480
+%481 = OpAccessChain %_ptr_Function_v4uint %227 %uint_0
+%482 = OpLoad %v4uint %304
+OpStore %481 %482
+%483 = OpLoad %v4uint %304
+%484 = OpLoad %v4uint %248
+%485 = OpIAdd %v4uint %483 %484
+OpStore %291 %485
+%486 = OpAccessChain %_ptr_Function_v4uint %227 %uint_1
+%487 = OpLoad %v4uint %291
+OpStore %486 %487
+%488 = OpLoad %v4uint %304
+%489 = OpLoad %v4uint %235
+%490 = OpIMul %v4uint %488 %489
+OpStore %292 %490
+%492 = OpAccessChain %_ptr_Function_v4uint %227 %uint_2
+%493 = OpLoad %v4uint %292
+OpStore %492 %493
+%494 = OpAccessChain %_ptr_Function_v4uint %227 %uint_3
+%495 = OpLoad %v4uint %305
+OpStore %494 %495
+%496 = OpLoad %ulong %303
+OpStore %302 %496
+OpStore %308 %ulong_0
+OpBranch %201
+%201 = OpLabel
+%497 = OpLoad %ulong %308
+%499 = OpULessThan %bool %497 %ulong_4
+OpStore %293 %499
+%500 = OpLoad %bool %293
+OpLoopMerge %203 %222 None
+OpBranchConditional %500 %202 %203
+%203 = OpLabel
+OpStore %230 %501
+%502 = OpAccessChain %_ptr_Function_uint %230 %uint_0
+OpStore %502 %uint_4294967295
+%503 = OpAccessChain %_ptr_Function_v4uint %227 %uint_2
+%504 = OpLoad %v4uint %503
+OpStore %297 %504
+%505 = OpAccessChain %_ptr_Function_v4uint %230 %uint_1
+%506 = OpLoad %v4uint %297
+OpStore %505 %506
+%507 = OpAccessChain %_ptr_Function_uint %230 %uint_2
+OpStore %507 %uint_305419896
+%508 = OpLoad %uint %502
+OpStore %298 %508
+OpBranch %206
+%206 = OpLabel
+%509 = OpLoad %uint %298
+%510 = OpUConvert %ulong %509
+OpStore %309 %510
+OpBranch %208
+%208 = OpLabel
+%511 = OpLoad %ulong %302
+OpStore %317 %511
+OpStore %318 %ulong_0
+OpBranch %209
+%209 = OpLabel
+%512 = OpLoad %ulong %318
+%513 = OpULessThan %bool %512 %ulong_8
+OpStore %310 %513
+%514 = OpLoad %bool %310
+OpLoopMerge %211 %221 None
+OpBranchConditional %514 %210 %211
+%211 = OpLabel
+OpBranch %212
+%212 = OpLabel
+OpBranch %207
+%207 = OpLabel
+%515 = OpAccessChain %_ptr_Function_v4uint %230 %uint_1
+%516 = OpLoad %v4uint %515
+OpStore %299 %516
+%517 = OpLoad %ulong %317
+%518 = OpLoad %v4uint %299
+%519 = OpFunctionCall %ulong %1 %517 %518
+OpStore %300 %519
+%520 = OpAccessChain %_ptr_Function_uint %230 %uint_2
+%521 = OpLoad %uint %520
+OpStore %301 %521
+OpBranch %213
+%213 = OpLabel
+%522 = OpLoad %uint %301
+%523 = OpUConvert %ulong %522
+OpStore %319 %523
+OpBranch %215
+%215 = OpLabel
+%524 = OpLoad %ulong %300
+OpStore %327 %524
+OpStore %328 %ulong_0
+OpBranch %216
+%216 = OpLabel
+%525 = OpLoad %ulong %328
+%526 = OpULessThan %bool %525 %ulong_8
+OpStore %320 %526
+%527 = OpLoad %bool %320
+OpLoopMerge %218 %220 None
+OpBranchConditional %527 %217 %218
+%218 = OpLabel
+OpBranch %219
+%219 = OpLabel
+OpBranch %214
+%214 = OpLabel
+%528 = OpLoad %ulong %327
+OpReturnValue %528
+%217 = OpLabel
+%529 = OpLoad %ulong %328
+%530 = OpIMul %ulong %529 %ulong_8
+OpStore %321 %530
+%531 = OpLoad %ulong %319
+%532 = OpLoad %ulong %321
+%533 = OpShiftRightLogical %ulong %531 %532
+OpStore %322 %533
+%534 = OpLoad %ulong %322
+%535 = OpBitwiseAnd %ulong %534 %ulong_255
+OpStore %323 %535
+%536 = OpLoad %ulong %327
+%537 = OpLoad %ulong %323
+%538 = OpBitwiseXor %ulong %536 %537
+OpStore %324 %538
+%539 = OpLoad %ulong %324
+%540 = OpIMul %ulong %539 %ulong_1099511628211
+OpStore %325 %540
+%541 = OpLoad %ulong %328
+%542 = OpIAdd %ulong %541 %ulong_1
+OpStore %326 %542
+%543 = OpLoad %ulong %325
+OpStore %327 %543
+%544 = OpLoad %ulong %326
+OpStore %328 %544
+OpBranch %220
+%210 = OpLabel
+%545 = OpLoad %ulong %318
+%546 = OpIMul %ulong %545 %ulong_8
+OpStore %311 %546
+%547 = OpLoad %ulong %309
+%548 = OpLoad %ulong %311
+%549 = OpShiftRightLogical %ulong %547 %548
+OpStore %312 %549
+%550 = OpLoad %ulong %312
+%551 = OpBitwiseAnd %ulong %550 %ulong_255
+OpStore %313 %551
+%552 = OpLoad %ulong %317
+%553 = OpLoad %ulong %313
+%554 = OpBitwiseXor %ulong %552 %553
+OpStore %314 %554
+%555 = OpLoad %ulong %314
+%556 = OpIMul %ulong %555 %ulong_1099511628211
+OpStore %315 %556
+%557 = OpLoad %ulong %318
+%558 = OpIAdd %ulong %557 %ulong_1
+OpStore %316 %558
+%559 = OpLoad %ulong %315
+OpStore %317 %559
+%560 = OpLoad %ulong %316
+OpStore %318 %560
+OpBranch %221
+%202 = OpLabel
+%561 = OpLoad %ulong %308
+%562 = OpAccessChain %_ptr_Function_v4uint %227 %561
+%563 = OpLoad %v4uint %562
+OpStore %294 %563
+%564 = OpLoad %ulong %302
+%565 = OpLoad %v4uint %294
+%566 = OpFunctionCall %ulong %1 %564 %565
+OpStore %295 %566
+%567 = OpLoad %ulong %308
+%568 = OpIAdd %ulong %567 %ulong_1
+OpStore %296 %568
+%569 = OpLoad %ulong %295
+OpStore %302 %569
+%570 = OpLoad %ulong %296
+OpStore %308 %570
+OpBranch %222
+%199 = OpLabel
+%571 = OpLoad %v4uint %304
+%572 = OpLoad %v4uint %235
+%573 = OpIMul %v4uint %571 %572
+OpStore %282 %573
+%574 = OpLoad %ulong %303
+%575 = OpLoad %v4uint %282
+%576 = OpFunctionCall %ulong %1 %574 %575
+OpStore %283 %576
+%577 = OpLoad %v4uint %305
+%578 = OpLoad %v4uint %282
+%579 = OpBitwiseXor %v4uint %577 %578
+OpStore %284 %579
+%580 = OpLoad %ulong %283
+%581 = OpLoad %v4uint %284
+%582 = OpFunctionCall %ulong %1 %580 %581
+OpStore %285 %582
+%583 = OpLoad %v4uint %306
+%584 = OpLoad %v4uint %304
+%585 = OpIAdd %v4uint %583 %584
+OpStore %286 %585
+%586 = OpLoad %ulong %285
+%587 = OpLoad %v4uint %286
+%588 = OpFunctionCall %ulong %1 %586 %587
+OpStore %287 %588
+%589 = OpLoad %v4uint %304
+%590 = OpLoad %v4uint %248
+%591 = OpIAdd %v4uint %589 %590
+OpStore %288 %591
+%592 = OpLoad %ulong %287
+%593 = OpLoad %v4uint %288
+%594 = OpFunctionCall %ulong %1 %592 %593
+OpStore %289 %594
+%595 = OpLoad %ulong %307
+%596 = OpIAdd %ulong %595 %ulong_1
+OpStore %290 %596
+%597 = OpLoad %ulong %289
+OpStore %303 %597
+%598 = OpLoad %v4uint %288
+OpStore %304 %598
+%599 = OpLoad %v4uint %284
+OpStore %305 %599
+%600 = OpLoad %v4uint %286
+OpStore %306 %600
+%601 = OpLoad %ulong %290
+OpStore %307 %601
+OpBranch %223
+%220 = OpLabel
+OpBranch %216
+%221 = OpLabel
+OpBranch %209
+%222 = OpLabel
+OpBranch %201
+%223 = OpLabel
+OpBranch %198
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_u64x2.dis
+++ b/test/golden/spirv/vec/vec_u64x2.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 632
+; Bound: 480
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -11,868 +11,665 @@ OpDecorate %1 LinkageAttributes "corpus.cases.vec.vec_u64x2.fold_vec" Export
 OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u64x2.checksum" Export
 %ulong = OpTypeInt 64 0
 %v2ulong = OpTypeVector %ulong 2
-%8 = OpTypeFunction %ulong %ulong %v2ulong
+%5 = OpTypeFunction %ulong %ulong %v2ulong
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function_v2ulong = OpTypePointer Function %v2ulong
-%31 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%97 = OpTypeFunction %ulong %ulong
 %uint = OpTypeInt 32 0
 %uint_4 = OpConstant %uint 4
 %_arr_v2ulong_uint_4 = OpTypeArray %v2ulong %uint_4
 %_ptr_Function__arr_v2ulong_uint_4 = OpTypePointer Function %_arr_v2ulong_uint_4
-%_struct_80 = OpTypeStruct %uint %v2ulong %uint
-%_ptr_Function__struct_80 = OpTypePointer Function %_struct_80
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_131 = OpTypeStruct %uint %v2ulong %uint
+%_ptr_Function__struct_131 = OpTypePointer Function %_struct_131
 %_ptr_Function_uint = OpTypePointer Function %uint
 %ulong_18446744073709551600 = OpConstant %ulong 18446744073709551600
 %ulong_305419896 = OpConstant %ulong 305419896
 %ulong_17 = OpConstant %ulong 17
 %ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
-%ulong_1 = OpConstant %ulong 1
 %ulong_27 = OpConstant %ulong 27
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%411 = OpConstantNull %_arr_v2ulong_uint_4
+%353 = OpConstantNull %_arr_v2ulong_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%435 = OpConstantNull %_struct_80
+%377 = OpConstantNull %_struct_131
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%541 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%544 = OpTypeFunction %ulong %ulong %ulong
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%587 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %8
-%9 = OpFunctionParameter %ulong
-%10 = OpFunctionParameter %v2ulong
+%1 = OpFunction %ulong None %5
+%6 = OpFunctionParameter %ulong
+%7 = OpFunctionParameter %v2ulong
+%8 = OpLabel
+%23 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_v2ulong Function
+%26 = OpVariable %_ptr_Function_ulong Function
+%27 = OpVariable %_ptr_Function_ulong Function
+%29 = OpVariable %_ptr_Function_bool Function
+%30 = OpVariable %_ptr_Function_ulong Function
+%31 = OpVariable %_ptr_Function_ulong Function
+%32 = OpVariable %_ptr_Function_ulong Function
+%33 = OpVariable %_ptr_Function_ulong Function
+%34 = OpVariable %_ptr_Function_ulong Function
+%35 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_ulong Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%38 = OpVariable %_ptr_Function_bool Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%42 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_ulong Function
+%44 = OpVariable %_ptr_Function_ulong Function
+%45 = OpVariable %_ptr_Function_ulong Function
+%46 = OpVariable %_ptr_Function_ulong Function
+OpStore %23 %6
+OpStore %25 %7
+%47 = OpLoad %v2ulong %25
+%48 = OpCompositeExtract %ulong %47 0
+OpStore %26 %48
+OpBranch %9
+%9 = OpLabel
+%49 = OpLoad %ulong %23
+OpStore %36 %49
+OpStore %37 %ulong_0
+OpBranch %10
+%10 = OpLabel
+%51 = OpLoad %ulong %37
+%53 = OpULessThan %bool %51 %ulong_8
+OpStore %29 %53
+%54 = OpLoad %bool %29
+OpLoopMerge %12 %20 None
+OpBranchConditional %54 %11 %12
+%12 = OpLabel
+OpBranch %13
+%13 = OpLabel
+%55 = OpLoad %v2ulong %25
+%56 = OpCompositeExtract %ulong %55 1
+OpStore %27 %56
+OpBranch %14
+%14 = OpLabel
+%57 = OpLoad %ulong %36
+OpStore %45 %57
+OpStore %46 %ulong_0
+OpBranch %15
+%15 = OpLabel
+%58 = OpLoad %ulong %46
+%59 = OpULessThan %bool %58 %ulong_8
+OpStore %38 %59
+%60 = OpLoad %bool %38
+OpLoopMerge %17 %19 None
+OpBranchConditional %60 %16 %17
+%17 = OpLabel
+OpBranch %18
+%18 = OpLabel
+%61 = OpLoad %ulong %45
+OpReturnValue %61
+%16 = OpLabel
+%62 = OpLoad %ulong %46
+%63 = OpIMul %ulong %62 %ulong_8
+OpStore %39 %63
+%64 = OpLoad %ulong %27
+%65 = OpLoad %ulong %39
+%66 = OpShiftRightLogical %ulong %64 %65
+OpStore %40 %66
+%67 = OpLoad %ulong %40
+%69 = OpBitwiseAnd %ulong %67 %ulong_255
+OpStore %41 %69
+%70 = OpLoad %ulong %45
+%71 = OpLoad %ulong %41
+%72 = OpBitwiseXor %ulong %70 %71
+OpStore %42 %72
+%73 = OpLoad %ulong %42
+%75 = OpIMul %ulong %73 %ulong_1099511628211
+OpStore %43 %75
+%76 = OpLoad %ulong %46
+%78 = OpIAdd %ulong %76 %ulong_1
+OpStore %44 %78
+%79 = OpLoad %ulong %43
+OpStore %45 %79
+%80 = OpLoad %ulong %44
+OpStore %46 %80
+OpBranch %19
 %11 = OpLabel
-%13 = OpVariable %_ptr_Function_ulong Function
-%15 = OpVariable %_ptr_Function_v2ulong Function
-%16 = OpVariable %_ptr_Function_ulong Function
-%17 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function_ulong Function
-%19 = OpVariable %_ptr_Function_ulong Function
-OpStore %13 %9
-OpStore %15 %10
-%20 = OpLoad %v2ulong %15
-%21 = OpCompositeExtract %ulong %20 0
-OpStore %16 %21
-%22 = OpLoad %ulong %13
-%23 = OpLoad %ulong %16
-%24 = OpFunctionCall %ulong %4 %22 %23
-OpStore %17 %24
-%25 = OpLoad %v2ulong %15
-%26 = OpCompositeExtract %ulong %25 1
-OpStore %18 %26
-%27 = OpLoad %ulong %17
-%28 = OpLoad %ulong %18
-%29 = OpFunctionCall %ulong %4 %27 %28
-OpStore %19 %29
-%30 = OpLoad %ulong %19
-OpReturnValue %30
+%81 = OpLoad %ulong %37
+%82 = OpIMul %ulong %81 %ulong_8
+OpStore %30 %82
+%83 = OpLoad %ulong %26
+%84 = OpLoad %ulong %30
+%85 = OpShiftRightLogical %ulong %83 %84
+OpStore %31 %85
+%86 = OpLoad %ulong %31
+%87 = OpBitwiseAnd %ulong %86 %ulong_255
+OpStore %32 %87
+%88 = OpLoad %ulong %36
+%89 = OpLoad %ulong %32
+%90 = OpBitwiseXor %ulong %88 %89
+OpStore %33 %90
+%91 = OpLoad %ulong %33
+%92 = OpIMul %ulong %91 %ulong_1099511628211
+OpStore %34 %92
+%93 = OpLoad %ulong %37
+%94 = OpIAdd %ulong %93 %ulong_1
+OpStore %35 %94
+%95 = OpLoad %ulong %34
+OpStore %36 %95
+%96 = OpLoad %ulong %35
+OpStore %37 %96
+OpBranch %20
+%19 = OpLabel
+OpBranch %15
+%20 = OpLabel
+OpBranch %10
 OpFunctionEnd
-%2 = OpFunction %ulong None %31
-%32 = OpFunctionParameter %ulong
-%33 = OpLabel
-%79 = OpVariable %_ptr_Function__arr_v2ulong_uint_4 Function
-%82 = OpVariable %_ptr_Function__struct_80 Function
-%83 = OpVariable %_ptr_Function_ulong Function
-%84 = OpVariable %_ptr_Function_ulong Function
-%85 = OpVariable %_ptr_Function_v2ulong Function
-%86 = OpVariable %_ptr_Function_v2ulong Function
-%87 = OpVariable %_ptr_Function_v2ulong Function
-%88 = OpVariable %_ptr_Function_v2ulong Function
-%89 = OpVariable %_ptr_Function_ulong Function
-%90 = OpVariable %_ptr_Function_ulong Function
-%91 = OpVariable %_ptr_Function_v2ulong Function
-%92 = OpVariable %_ptr_Function_ulong Function
-%93 = OpVariable %_ptr_Function_ulong Function
-%94 = OpVariable %_ptr_Function_v2ulong Function
-%95 = OpVariable %_ptr_Function_v2ulong Function
-%96 = OpVariable %_ptr_Function_v2ulong Function
-%97 = OpVariable %_ptr_Function_v2ulong Function
-%98 = OpVariable %_ptr_Function_v2ulong Function
-%99 = OpVariable %_ptr_Function_v2ulong Function
-%100 = OpVariable %_ptr_Function_v2ulong Function
-%101 = OpVariable %_ptr_Function_v2ulong Function
-%102 = OpVariable %_ptr_Function_v2ulong Function
-%103 = OpVariable %_ptr_Function_v2ulong Function
-%104 = OpVariable %_ptr_Function_v2ulong Function
-%105 = OpVariable %_ptr_Function_ulong Function
-%106 = OpVariable %_ptr_Function_v2ulong Function
-%107 = OpVariable %_ptr_Function_ulong Function
-%108 = OpVariable %_ptr_Function_v2ulong Function
-%109 = OpVariable %_ptr_Function_ulong Function
-%110 = OpVariable %_ptr_Function_v2ulong Function
-%111 = OpVariable %_ptr_Function_ulong Function
-%112 = OpVariable %_ptr_Function_v2ulong Function
-%113 = OpVariable %_ptr_Function_ulong Function
-%114 = OpVariable %_ptr_Function_v2ulong Function
-%115 = OpVariable %_ptr_Function_ulong Function
-%116 = OpVariable %_ptr_Function_v2ulong Function
-%117 = OpVariable %_ptr_Function_ulong Function
-%119 = OpVariable %_ptr_Function_bool Function
-%120 = OpVariable %_ptr_Function_v2ulong Function
-%121 = OpVariable %_ptr_Function_v2ulong Function
-%122 = OpVariable %_ptr_Function_v2ulong Function
-%123 = OpVariable %_ptr_Function_v2ulong Function
-%124 = OpVariable %_ptr_Function_ulong Function
-%125 = OpVariable %_ptr_Function_v2ulong Function
-%126 = OpVariable %_ptr_Function_v2ulong Function
-%127 = OpVariable %_ptr_Function_bool Function
-%128 = OpVariable %_ptr_Function_v2ulong Function
-%129 = OpVariable %_ptr_Function_ulong Function
-%130 = OpVariable %_ptr_Function_v2ulong Function
-%132 = OpVariable %_ptr_Function_uint Function
-%133 = OpVariable %_ptr_Function_ulong Function
-%134 = OpVariable %_ptr_Function_v2ulong Function
-%135 = OpVariable %_ptr_Function_uint Function
-%136 = OpVariable %_ptr_Function_ulong Function
-%137 = OpVariable %_ptr_Function_ulong Function
-%138 = OpVariable %_ptr_Function_ulong Function
-%139 = OpVariable %_ptr_Function_v2ulong Function
-%140 = OpVariable %_ptr_Function_v2ulong Function
+%2 = OpFunction %ulong None %97
+%98 = OpFunctionParameter %ulong
+%99 = OpLabel
+%130 = OpVariable %_ptr_Function__arr_v2ulong_uint_4 Function
+%133 = OpVariable %_ptr_Function__struct_131 Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_v2ulong Function
+%136 = OpVariable %_ptr_Function_v2ulong Function
+%137 = OpVariable %_ptr_Function_v2ulong Function
+%138 = OpVariable %_ptr_Function_v2ulong Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_ulong Function
 %141 = OpVariable %_ptr_Function_v2ulong Function
 %142 = OpVariable %_ptr_Function_ulong Function
 %143 = OpVariable %_ptr_Function_ulong Function
-%144 = OpVariable %_ptr_Function_ulong Function
+%144 = OpVariable %_ptr_Function_v2ulong Function
 %145 = OpVariable %_ptr_Function_ulong Function
 %146 = OpVariable %_ptr_Function_ulong Function
-%147 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_v2ulong Function
 %148 = OpVariable %_ptr_Function_ulong Function
-%149 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_v2ulong Function
 %150 = OpVariable %_ptr_Function_ulong Function
-%151 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_v2ulong Function
 %152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_v2ulong Function
 %154 = OpVariable %_ptr_Function_ulong Function
-%155 = OpVariable %_ptr_Function_ulong Function
+%155 = OpVariable %_ptr_Function_v2ulong Function
 %156 = OpVariable %_ptr_Function_ulong Function
-%157 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_v2ulong Function
 %158 = OpVariable %_ptr_Function_ulong Function
-%159 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_v2ulong Function
 %160 = OpVariable %_ptr_Function_ulong Function
-%161 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_v2ulong Function
 %162 = OpVariable %_ptr_Function_ulong Function
-%163 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_v2ulong Function
 %164 = OpVariable %_ptr_Function_ulong Function
-%165 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_v2ulong Function
 %166 = OpVariable %_ptr_Function_ulong Function
-%167 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_v2ulong Function
 %168 = OpVariable %_ptr_Function_ulong Function
-%169 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_v2ulong Function
 %170 = OpVariable %_ptr_Function_ulong Function
-%171 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_v2ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
-%173 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_v2ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_v2ulong Function
 %176 = OpVariable %_ptr_Function_ulong Function
-%177 = OpVariable %_ptr_Function_ulong Function
-%178 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_bool Function
+%178 = OpVariable %_ptr_Function_v2ulong Function
 %179 = OpVariable %_ptr_Function_ulong Function
-%180 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_v2ulong Function
 %181 = OpVariable %_ptr_Function_ulong Function
-%182 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_v2ulong Function
 %183 = OpVariable %_ptr_Function_ulong Function
-%184 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_v2ulong Function
 %185 = OpVariable %_ptr_Function_ulong Function
 %186 = OpVariable %_ptr_Function_ulong Function
-%187 = OpVariable %_ptr_Function_ulong Function
-%188 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_ulong Function
-%190 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_v2ulong Function
+%188 = OpVariable %_ptr_Function_v2ulong Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_v2ulong Function
 %191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
-%193 = OpVariable %_ptr_Function_ulong Function
-%194 = OpVariable %_ptr_Function_ulong Function
-%195 = OpVariable %_ptr_Function_ulong Function
-%196 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_v2ulong Function
+%195 = OpVariable %_ptr_Function_uint Function
+%196 = OpVariable %_ptr_Function_v2ulong Function
 %197 = OpVariable %_ptr_Function_ulong Function
-%198 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_uint Function
 %199 = OpVariable %_ptr_Function_ulong Function
 %200 = OpVariable %_ptr_Function_ulong Function
-%201 = OpVariable %_ptr_Function_ulong Function
-%202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_v2ulong Function
+%202 = OpVariable %_ptr_Function_v2ulong Function
+%203 = OpVariable %_ptr_Function_v2ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
 %205 = OpVariable %_ptr_Function_ulong Function
 %206 = OpVariable %_ptr_Function_ulong Function
-%207 = OpVariable %_ptr_Function_ulong Function
-OpStore %83 %32
-%208 = OpFunctionCall %ulong %3
-OpStore %84 %208
-%209 = OpCompositeConstruct %v2ulong %ulong_18446744073709551600 %ulong_305419896
-OpStore %85 %209
-%212 = OpCompositeConstruct %v2ulong %ulong_17 %ulong_18446744073709551615
-OpStore %86 %212
-%215 = OpCompositeConstruct %v2ulong %ulong_1 %ulong_27
-OpStore %87 %215
-%218 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_0
-OpStore %88 %218
-%220 = OpLoad %v2ulong %85
-%221 = OpCompositeExtract %ulong %220 0
-OpStore %89 %221
-%222 = OpLoad %ulong %89
-%223 = OpLoad %ulong %83
-%224 = OpIAdd %ulong %222 %223
-OpStore %90 %224
-%225 = OpLoad %v2ulong %85
-%226 = OpLoad %ulong %90
-%227 = OpCompositeInsert %v2ulong %226 %225 0
-OpStore %91 %227
-%228 = OpLoad %v2ulong %86
-%229 = OpCompositeExtract %ulong %228 1
-OpStore %92 %229
-%230 = OpLoad %ulong %92
-%231 = OpLoad %ulong %83
-%232 = OpIAdd %ulong %230 %231
-OpStore %93 %232
-%233 = OpLoad %v2ulong %86
-%234 = OpLoad %ulong %93
-%235 = OpCompositeInsert %v2ulong %234 %233 1
-OpStore %94 %235
-OpBranch %40
-%40 = OpLabel
-%236 = OpLoad %v2ulong %91
-%237 = OpCompositeExtract %ulong %236 0
-OpStore %144 %237
-%238 = OpLoad %ulong %84
-%239 = OpLoad %ulong %144
-%240 = OpFunctionCall %ulong %4 %238 %239
-OpStore %145 %240
-%241 = OpLoad %v2ulong %91
-%242 = OpCompositeExtract %ulong %241 1
-OpStore %146 %242
-%243 = OpLoad %ulong %145
-%244 = OpLoad %ulong %146
-%245 = OpFunctionCall %ulong %4 %243 %244
-OpStore %147 %245
-OpBranch %41
-%41 = OpLabel
-OpBranch %48
-%48 = OpLabel
-%246 = OpLoad %v2ulong %94
-%247 = OpCompositeExtract %ulong %246 0
-OpStore %160 %247
-%248 = OpLoad %ulong %147
-%249 = OpLoad %ulong %160
-%250 = OpFunctionCall %ulong %4 %248 %249
-OpStore %161 %250
-%251 = OpLoad %v2ulong %94
-%252 = OpCompositeExtract %ulong %251 1
-OpStore %162 %252
-%253 = OpLoad %ulong %161
-%254 = OpLoad %ulong %162
-%255 = OpFunctionCall %ulong %4 %253 %254
-OpStore %163 %255
-OpBranch %49
-%49 = OpLabel
-%256 = OpLoad %v2ulong %91
-%257 = OpLoad %v2ulong %94
-%258 = OpIAdd %v2ulong %256 %257
-OpStore %95 %258
-OpBranch %52
-%52 = OpLabel
-%259 = OpLoad %v2ulong %95
-%260 = OpCompositeExtract %ulong %259 0
-OpStore %168 %260
-%261 = OpLoad %ulong %163
-%262 = OpLoad %ulong %168
-%263 = OpFunctionCall %ulong %4 %261 %262
-OpStore %169 %263
-%264 = OpLoad %v2ulong %95
-%265 = OpCompositeExtract %ulong %264 1
-OpStore %170 %265
-%266 = OpLoad %ulong %169
-%267 = OpLoad %ulong %170
-%268 = OpFunctionCall %ulong %4 %266 %267
-OpStore %171 %268
-OpBranch %53
-%53 = OpLabel
-%269 = OpLoad %v2ulong %91
-%270 = OpLoad %v2ulong %94
+%207 = OpVariable %_ptr_Function_bool Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_bool Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+OpStore %134 %98
+OpBranch %106
+%106 = OpLabel
+OpBranch %107
+%107 = OpLabel
+%226 = OpCompositeConstruct %v2ulong %ulong_18446744073709551600 %ulong_305419896
+OpStore %135 %226
+%229 = OpCompositeConstruct %v2ulong %ulong_17 %ulong_18446744073709551615
+OpStore %136 %229
+%232 = OpCompositeConstruct %v2ulong %ulong_1 %ulong_27
+OpStore %137 %232
+%234 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_0
+OpStore %138 %234
+%235 = OpLoad %v2ulong %135
+%236 = OpCompositeExtract %ulong %235 0
+OpStore %139 %236
+%237 = OpLoad %ulong %139
+%238 = OpLoad %ulong %134
+%239 = OpIAdd %ulong %237 %238
+OpStore %140 %239
+%240 = OpLoad %v2ulong %135
+%241 = OpLoad %ulong %140
+%242 = OpCompositeInsert %v2ulong %241 %240 0
+OpStore %141 %242
+%243 = OpLoad %v2ulong %136
+%244 = OpCompositeExtract %ulong %243 1
+OpStore %142 %244
+%245 = OpLoad %ulong %142
+%246 = OpLoad %ulong %134
+%247 = OpIAdd %ulong %245 %246
+OpStore %143 %247
+%248 = OpLoad %v2ulong %136
+%249 = OpLoad %ulong %143
+%250 = OpCompositeInsert %v2ulong %249 %248 1
+OpStore %144 %250
+%252 = OpLoad %v2ulong %141
+%253 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %252
+OpStore %145 %253
+%254 = OpLoad %ulong %145
+%255 = OpLoad %v2ulong %144
+%256 = OpFunctionCall %ulong %1 %254 %255
+OpStore %146 %256
+%257 = OpLoad %v2ulong %141
+%258 = OpLoad %v2ulong %144
+%259 = OpIAdd %v2ulong %257 %258
+OpStore %147 %259
+%260 = OpLoad %ulong %146
+%261 = OpLoad %v2ulong %147
+%262 = OpFunctionCall %ulong %1 %260 %261
+OpStore %148 %262
+%263 = OpLoad %v2ulong %141
+%264 = OpLoad %v2ulong %144
+%265 = OpISub %v2ulong %263 %264
+OpStore %149 %265
+%266 = OpLoad %ulong %148
+%267 = OpLoad %v2ulong %149
+%268 = OpFunctionCall %ulong %1 %266 %267
+OpStore %150 %268
+%269 = OpLoad %v2ulong %144
+%270 = OpLoad %v2ulong %141
 %271 = OpISub %v2ulong %269 %270
-OpStore %96 %271
-OpBranch %56
-%56 = OpLabel
-%272 = OpLoad %v2ulong %96
-%273 = OpCompositeExtract %ulong %272 0
-OpStore %176 %273
-%274 = OpLoad %ulong %171
-%275 = OpLoad %ulong %176
-%276 = OpFunctionCall %ulong %4 %274 %275
-OpStore %177 %276
-%277 = OpLoad %v2ulong %96
-%278 = OpCompositeExtract %ulong %277 1
-OpStore %178 %278
-%279 = OpLoad %ulong %177
-%280 = OpLoad %ulong %178
-%281 = OpFunctionCall %ulong %4 %279 %280
-OpStore %179 %281
-OpBranch %57
-%57 = OpLabel
-%282 = OpLoad %v2ulong %94
-%283 = OpLoad %v2ulong %91
-%284 = OpISub %v2ulong %282 %283
-OpStore %97 %284
-OpBranch %60
-%60 = OpLabel
-%285 = OpLoad %v2ulong %97
-%286 = OpCompositeExtract %ulong %285 0
-OpStore %184 %286
-%287 = OpLoad %ulong %179
-%288 = OpLoad %ulong %184
-%289 = OpFunctionCall %ulong %4 %287 %288
-OpStore %185 %289
-%290 = OpLoad %v2ulong %97
-%291 = OpCompositeExtract %ulong %290 1
-OpStore %186 %291
-%292 = OpLoad %ulong %185
-%293 = OpLoad %ulong %186
-%294 = OpFunctionCall %ulong %4 %292 %293
-OpStore %187 %294
-OpBranch %61
-%61 = OpLabel
-%295 = OpLoad %v2ulong %91
-%296 = OpLoad %v2ulong %94
-%297 = OpIMul %v2ulong %295 %296
-OpStore %98 %297
-OpBranch %62
-%62 = OpLabel
-%298 = OpLoad %v2ulong %98
-%299 = OpCompositeExtract %ulong %298 0
-OpStore %188 %299
-%300 = OpLoad %ulong %187
-%301 = OpLoad %ulong %188
-%302 = OpFunctionCall %ulong %4 %300 %301
-OpStore %189 %302
-%303 = OpLoad %v2ulong %98
-%304 = OpCompositeExtract %ulong %303 1
-OpStore %190 %304
-%305 = OpLoad %ulong %189
-%306 = OpLoad %ulong %190
-%307 = OpFunctionCall %ulong %4 %305 %306
-OpStore %191 %307
-OpBranch %63
-%63 = OpLabel
-%308 = OpLoad %v2ulong %91
-%309 = OpLoad %v2ulong %87
-%310 = OpIMul %v2ulong %308 %309
-OpStore %99 %310
-OpBranch %64
-%64 = OpLabel
-%311 = OpLoad %v2ulong %99
-%312 = OpCompositeExtract %ulong %311 0
-OpStore %192 %312
-%313 = OpLoad %ulong %191
-%314 = OpLoad %ulong %192
-%315 = OpFunctionCall %ulong %4 %313 %314
-OpStore %193 %315
-%316 = OpLoad %v2ulong %99
-%317 = OpCompositeExtract %ulong %316 1
-OpStore %194 %317
-%318 = OpLoad %ulong %193
-%319 = OpLoad %ulong %194
-%320 = OpFunctionCall %ulong %4 %318 %319
-OpStore %195 %320
-OpBranch %65
-%65 = OpLabel
-%321 = OpLoad %v2ulong %94
-%322 = OpLoad %v2ulong %87
-%323 = OpIMul %v2ulong %321 %322
-OpStore %100 %323
-OpBranch %66
-%66 = OpLabel
-%324 = OpLoad %v2ulong %100
-%325 = OpCompositeExtract %ulong %324 0
-OpStore %196 %325
-%326 = OpLoad %ulong %195
-%327 = OpLoad %ulong %196
-%328 = OpFunctionCall %ulong %4 %326 %327
-OpStore %197 %328
-%329 = OpLoad %v2ulong %100
-%330 = OpCompositeExtract %ulong %329 1
-OpStore %198 %330
-%331 = OpLoad %ulong %197
-%332 = OpLoad %ulong %198
-%333 = OpFunctionCall %ulong %4 %331 %332
-OpStore %199 %333
-OpBranch %67
-%67 = OpLabel
-%334 = OpLoad %v2ulong %91
-%335 = OpLoad %v2ulong %94
-%336 = OpIAdd %v2ulong %334 %335
-OpStore %101 %336
-%337 = OpLoad %v2ulong %101
-%338 = OpLoad %v2ulong %87
-%339 = OpIMul %v2ulong %337 %338
-OpStore %102 %339
-OpBranch %68
-%68 = OpLabel
-%340 = OpLoad %v2ulong %102
-%341 = OpCompositeExtract %ulong %340 0
-OpStore %200 %341
-%342 = OpLoad %ulong %199
-%343 = OpLoad %ulong %200
-%344 = OpFunctionCall %ulong %4 %342 %343
-OpStore %201 %344
-%345 = OpLoad %v2ulong %102
-%346 = OpCompositeExtract %ulong %345 1
-OpStore %202 %346
-%347 = OpLoad %ulong %201
-%348 = OpLoad %ulong %202
-%349 = OpFunctionCall %ulong %4 %347 %348
-OpStore %203 %349
-OpBranch %69
-%69 = OpLabel
-%350 = OpLoad %v2ulong %88
-%351 = OpLoad %v2ulong %91
-%352 = OpISub %v2ulong %350 %351
-OpStore %103 %352
-OpBranch %70
-%70 = OpLabel
-%353 = OpLoad %v2ulong %103
-%354 = OpCompositeExtract %ulong %353 0
-OpStore %204 %354
-%355 = OpLoad %ulong %203
-%356 = OpLoad %ulong %204
-%357 = OpFunctionCall %ulong %4 %355 %356
-OpStore %205 %357
-%358 = OpLoad %v2ulong %103
-%359 = OpCompositeExtract %ulong %358 1
-OpStore %206 %359
-%360 = OpLoad %ulong %205
-%361 = OpLoad %ulong %206
-%362 = OpFunctionCall %ulong %4 %360 %361
-OpStore %207 %362
-OpBranch %71
-%71 = OpLabel
-%363 = OpLoad %v2ulong %88
-%364 = OpLoad %v2ulong %94
-%365 = OpISub %v2ulong %363 %364
-OpStore %104 %365
-%366 = OpLoad %ulong %207
-%367 = OpLoad %v2ulong %104
-%368 = OpFunctionCall %ulong %1 %366 %367
-OpStore %105 %368
-%369 = OpLoad %v2ulong %91
-%370 = OpLoad %v2ulong %94
-%371 = OpBitwiseAnd %v2ulong %369 %370
-OpStore %106 %371
-%372 = OpLoad %ulong %105
-%373 = OpLoad %v2ulong %106
-%374 = OpFunctionCall %ulong %1 %372 %373
-OpStore %107 %374
-%375 = OpLoad %v2ulong %91
-%376 = OpLoad %v2ulong %94
-%377 = OpBitwiseOr %v2ulong %375 %376
-OpStore %108 %377
-%378 = OpLoad %ulong %107
-%379 = OpLoad %v2ulong %108
-%380 = OpFunctionCall %ulong %1 %378 %379
-OpStore %109 %380
-%381 = OpLoad %v2ulong %91
-%382 = OpLoad %v2ulong %94
-%383 = OpBitwiseXor %v2ulong %381 %382
-OpStore %110 %383
-%384 = OpLoad %ulong %109
-%385 = OpLoad %v2ulong %110
-%386 = OpFunctionCall %ulong %1 %384 %385
-OpStore %111 %386
-%387 = OpLoad %v2ulong %91
-%388 = OpNot %v2ulong %387
-OpStore %112 %388
-%389 = OpLoad %ulong %111
-%390 = OpLoad %v2ulong %112
-%391 = OpFunctionCall %ulong %1 %389 %390
-OpStore %113 %391
-%392 = OpLoad %v2ulong %94
-%393 = OpNot %v2ulong %392
-OpStore %114 %393
-%394 = OpLoad %ulong %113
-%395 = OpLoad %v2ulong %114
-%396 = OpFunctionCall %ulong %1 %394 %395
-OpStore %115 %396
-%397 = OpLoad %v2ulong %106
-%398 = OpLoad %v2ulong %108
-%399 = OpBitwiseXor %v2ulong %397 %398
-OpStore %116 %399
-%400 = OpLoad %ulong %115
-%401 = OpLoad %v2ulong %116
-%402 = OpFunctionCall %ulong %1 %400 %401
-OpStore %117 %402
-%403 = OpLoad %ulong %117
-OpStore %138 %403
-%404 = OpLoad %v2ulong %91
-OpStore %139 %404
-%405 = OpLoad %v2ulong %88
-OpStore %140 %405
-%406 = OpLoad %v2ulong %88
-OpStore %141 %406
-OpStore %142 %ulong_0
-OpBranch %34
-%34 = OpLabel
-%407 = OpLoad %ulong %142
-%409 = OpULessThan %bool %407 %ulong_6
-OpStore %119 %409
-%410 = OpLoad %bool %119
-OpLoopMerge %36 %73 None
-OpBranchConditional %410 %35 %36
-%36 = OpLabel
-OpStore %79 %411
-%413 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_0
-%414 = OpLoad %v2ulong %139
-OpStore %413 %414
-%415 = OpLoad %v2ulong %139
-%416 = OpLoad %v2ulong %94
-%417 = OpIAdd %v2ulong %415 %416
-OpStore %125 %417
-%419 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_1
-%420 = OpLoad %v2ulong %125
-OpStore %419 %420
-%421 = OpLoad %v2ulong %139
-%422 = OpLoad %v2ulong %87
-%423 = OpIMul %v2ulong %421 %422
-OpStore %126 %423
-%425 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_2
-%426 = OpLoad %v2ulong %126
-OpStore %425 %426
-%428 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_3
-%429 = OpLoad %v2ulong %140
-OpStore %428 %429
-%430 = OpLoad %ulong %138
-OpStore %137 %430
-OpStore %143 %ulong_0
-OpBranch %37
-%37 = OpLabel
-%431 = OpLoad %ulong %143
-%433 = OpULessThan %bool %431 %ulong_4
-OpStore %127 %433
-%434 = OpLoad %bool %127
-OpLoopMerge %39 %72 None
-OpBranchConditional %434 %38 %39
-%39 = OpLabel
-OpStore %82 %435
-%436 = OpAccessChain %_ptr_Function_uint %82 %uint_0
-OpStore %436 %uint_4294967295
-%438 = OpAccessChain %_ptr_Function_v2ulong %79 %uint_2
-%439 = OpLoad %v2ulong %438
-OpStore %130 %439
-%440 = OpAccessChain %_ptr_Function_v2ulong %82 %uint_1
-%441 = OpLoad %v2ulong %130
-OpStore %440 %441
-%442 = OpAccessChain %_ptr_Function_uint %82 %uint_2
-OpStore %442 %uint_305419896
-%444 = OpLoad %uint %436
-OpStore %132 %444
-%445 = OpLoad %ulong %137
-%446 = OpLoad %uint %132
-%447 = OpFunctionCall %ulong %5 %445 %446
-OpStore %133 %447
-%448 = OpLoad %v2ulong %440
-OpStore %134 %448
-OpBranch %46
-%46 = OpLabel
-%449 = OpLoad %v2ulong %134
-%450 = OpCompositeExtract %ulong %449 0
-OpStore %156 %450
-%451 = OpLoad %ulong %133
-%452 = OpLoad %ulong %156
-%453 = OpFunctionCall %ulong %4 %451 %452
-OpStore %157 %453
-%454 = OpLoad %v2ulong %134
-%455 = OpCompositeExtract %ulong %454 1
-OpStore %158 %455
-%456 = OpLoad %ulong %157
-%457 = OpLoad %ulong %158
-%458 = OpFunctionCall %ulong %4 %456 %457
-OpStore %159 %458
-OpBranch %47
-%47 = OpLabel
-%459 = OpAccessChain %_ptr_Function_uint %82 %uint_2
-%460 = OpLoad %uint %459
-OpStore %135 %460
-%461 = OpLoad %ulong %159
-%462 = OpLoad %uint %135
-%463 = OpFunctionCall %ulong %5 %461 %462
-OpStore %136 %463
-%464 = OpLoad %ulong %136
-OpReturnValue %464
-%38 = OpLabel
-%465 = OpLoad %ulong %143
-%466 = OpAccessChain %_ptr_Function_v2ulong %79 %465
-%467 = OpLoad %v2ulong %466
-OpStore %128 %467
-OpBranch %44
-%44 = OpLabel
-%468 = OpLoad %v2ulong %128
-%469 = OpCompositeExtract %ulong %468 0
-OpStore %152 %469
-%470 = OpLoad %ulong %137
-%471 = OpLoad %ulong %152
-%472 = OpFunctionCall %ulong %4 %470 %471
-OpStore %153 %472
-%473 = OpLoad %v2ulong %128
-%474 = OpCompositeExtract %ulong %473 1
-OpStore %154 %474
-%475 = OpLoad %ulong %153
-%476 = OpLoad %ulong %154
-%477 = OpFunctionCall %ulong %4 %475 %476
-OpStore %155 %477
-OpBranch %45
-%45 = OpLabel
-%478 = OpLoad %ulong %143
-%479 = OpIAdd %ulong %478 %ulong_1
-OpStore %129 %479
-%480 = OpLoad %ulong %155
-OpStore %137 %480
-%481 = OpLoad %ulong %129
-OpStore %143 %481
-OpBranch %72
-%35 = OpLabel
-%482 = OpLoad %v2ulong %139
-%483 = OpLoad %v2ulong %87
-%484 = OpIMul %v2ulong %482 %483
-OpStore %120 %484
-OpBranch %42
-%42 = OpLabel
-%485 = OpLoad %v2ulong %120
-%486 = OpCompositeExtract %ulong %485 0
-OpStore %148 %486
-%487 = OpLoad %ulong %138
-%488 = OpLoad %ulong %148
-%489 = OpFunctionCall %ulong %4 %487 %488
-OpStore %149 %489
-%490 = OpLoad %v2ulong %120
-%491 = OpCompositeExtract %ulong %490 1
-OpStore %150 %491
-%492 = OpLoad %ulong %149
-%493 = OpLoad %ulong %150
-%494 = OpFunctionCall %ulong %4 %492 %493
-OpStore %151 %494
-OpBranch %43
-%43 = OpLabel
-%495 = OpLoad %v2ulong %140
-%496 = OpLoad %v2ulong %120
-%497 = OpBitwiseXor %v2ulong %495 %496
-OpStore %121 %497
-OpBranch %50
-%50 = OpLabel
-%498 = OpLoad %v2ulong %121
-%499 = OpCompositeExtract %ulong %498 0
-OpStore %164 %499
-%500 = OpLoad %ulong %151
-%501 = OpLoad %ulong %164
-%502 = OpFunctionCall %ulong %4 %500 %501
-OpStore %165 %502
-%503 = OpLoad %v2ulong %121
-%504 = OpCompositeExtract %ulong %503 1
-OpStore %166 %504
-%505 = OpLoad %ulong %165
-%506 = OpLoad %ulong %166
-%507 = OpFunctionCall %ulong %4 %505 %506
-OpStore %167 %507
-OpBranch %51
-%51 = OpLabel
-%508 = OpLoad %v2ulong %141
-%509 = OpLoad %v2ulong %139
-%510 = OpIAdd %v2ulong %508 %509
-OpStore %122 %510
-OpBranch %54
-%54 = OpLabel
-%511 = OpLoad %v2ulong %122
-%512 = OpCompositeExtract %ulong %511 0
-OpStore %172 %512
-%513 = OpLoad %ulong %167
-%514 = OpLoad %ulong %172
-%515 = OpFunctionCall %ulong %4 %513 %514
-OpStore %173 %515
-%516 = OpLoad %v2ulong %122
-%517 = OpCompositeExtract %ulong %516 1
-OpStore %174 %517
-%518 = OpLoad %ulong %173
-%519 = OpLoad %ulong %174
-%520 = OpFunctionCall %ulong %4 %518 %519
-OpStore %175 %520
-OpBranch %55
-%55 = OpLabel
-%521 = OpLoad %v2ulong %139
-%522 = OpLoad %v2ulong %94
-%523 = OpIAdd %v2ulong %521 %522
-OpStore %123 %523
-OpBranch %58
-%58 = OpLabel
-%524 = OpLoad %v2ulong %123
-%525 = OpCompositeExtract %ulong %524 0
-OpStore %180 %525
-%526 = OpLoad %ulong %175
-%527 = OpLoad %ulong %180
-%528 = OpFunctionCall %ulong %4 %526 %527
-OpStore %181 %528
-%529 = OpLoad %v2ulong %123
-%530 = OpCompositeExtract %ulong %529 1
-OpStore %182 %530
-%531 = OpLoad %ulong %181
-%532 = OpLoad %ulong %182
-%533 = OpFunctionCall %ulong %4 %531 %532
-OpStore %183 %533
-OpBranch %59
-%59 = OpLabel
-%534 = OpLoad %ulong %142
-%535 = OpIAdd %ulong %534 %ulong_1
-OpStore %124 %535
-%536 = OpLoad %ulong %183
-OpStore %138 %536
-%537 = OpLoad %v2ulong %123
-OpStore %139 %537
-%538 = OpLoad %v2ulong %121
-OpStore %140 %538
-%539 = OpLoad %v2ulong %122
-OpStore %141 %539
-%540 = OpLoad %ulong %124
-OpStore %142 %540
-OpBranch %73
-%72 = OpLabel
-OpBranch %37
-%73 = OpLabel
-OpBranch %34
-OpFunctionEnd
-%3 = OpFunction %ulong None %541
-%542 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %544
-%545 = OpFunctionParameter %ulong
-%546 = OpFunctionParameter %ulong
-%547 = OpLabel
-%552 = OpVariable %_ptr_Function_ulong Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_bool Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_ulong Function
-%558 = OpVariable %_ptr_Function_ulong Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_ulong Function
-%561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_ulong Function
-OpStore %552 %545
-OpStore %553 %546
-%563 = OpLoad %ulong %552
-OpStore %561 %563
-OpStore %562 %ulong_0
-OpBranch %548
-%548 = OpLabel
-%564 = OpLoad %ulong %562
-%566 = OpULessThan %bool %564 %ulong_8
-OpStore %554 %566
-%567 = OpLoad %bool %554
-OpLoopMerge %550 %551 None
-OpBranchConditional %567 %549 %550
-%550 = OpLabel
-%568 = OpLoad %ulong %561
-OpReturnValue %568
-%549 = OpLabel
-%569 = OpLoad %ulong %562
-%570 = OpIMul %ulong %569 %ulong_8
-OpStore %555 %570
-%571 = OpLoad %ulong %553
-%572 = OpLoad %ulong %555
-%573 = OpShiftRightLogical %ulong %571 %572
-OpStore %556 %573
-%574 = OpLoad %ulong %556
-%576 = OpBitwiseAnd %ulong %574 %ulong_255
-OpStore %557 %576
-%577 = OpLoad %ulong %561
-%578 = OpLoad %ulong %557
-%579 = OpBitwiseXor %ulong %577 %578
-OpStore %558 %579
-%580 = OpLoad %ulong %558
-%582 = OpIMul %ulong %580 %ulong_1099511628211
-OpStore %559 %582
-%583 = OpLoad %ulong %562
-%584 = OpIAdd %ulong %583 %ulong_1
-OpStore %560 %584
-%585 = OpLoad %ulong %559
-OpStore %561 %585
-%586 = OpLoad %ulong %560
-OpStore %562 %586
-OpBranch %551
-%551 = OpLabel
-OpBranch %548
-OpFunctionEnd
-%5 = OpFunction %ulong None %587
-%588 = OpFunctionParameter %ulong
-%589 = OpFunctionParameter %uint
-%590 = OpLabel
-%597 = OpVariable %_ptr_Function_ulong Function
-%598 = OpVariable %_ptr_Function_uint Function
-%599 = OpVariable %_ptr_Function_ulong Function
-%600 = OpVariable %_ptr_Function_bool Function
-%601 = OpVariable %_ptr_Function_ulong Function
-%602 = OpVariable %_ptr_Function_ulong Function
-%603 = OpVariable %_ptr_Function_ulong Function
-%604 = OpVariable %_ptr_Function_ulong Function
-%605 = OpVariable %_ptr_Function_ulong Function
-%606 = OpVariable %_ptr_Function_ulong Function
-%607 = OpVariable %_ptr_Function_ulong Function
-%608 = OpVariable %_ptr_Function_ulong Function
-OpStore %597 %588
-OpStore %598 %589
-%609 = OpLoad %uint %598
-%610 = OpUConvert %ulong %609
-OpStore %599 %610
-OpBranch %591
-%591 = OpLabel
-%611 = OpLoad %ulong %597
-OpStore %607 %611
-OpStore %608 %ulong_0
-OpBranch %592
-%592 = OpLabel
-%612 = OpLoad %ulong %608
-%613 = OpULessThan %bool %612 %ulong_8
-OpStore %600 %613
-%614 = OpLoad %bool %600
-OpLoopMerge %594 %596 None
-OpBranchConditional %614 %593 %594
-%594 = OpLabel
-OpBranch %595
-%595 = OpLabel
-%615 = OpLoad %ulong %607
-OpReturnValue %615
-%593 = OpLabel
-%616 = OpLoad %ulong %608
-%617 = OpIMul %ulong %616 %ulong_8
-OpStore %601 %617
-%618 = OpLoad %ulong %599
-%619 = OpLoad %ulong %601
-%620 = OpShiftRightLogical %ulong %618 %619
-OpStore %602 %620
-%621 = OpLoad %ulong %602
-%622 = OpBitwiseAnd %ulong %621 %ulong_255
-OpStore %603 %622
-%623 = OpLoad %ulong %607
-%624 = OpLoad %ulong %603
-%625 = OpBitwiseXor %ulong %623 %624
-OpStore %604 %625
-%626 = OpLoad %ulong %604
-%627 = OpIMul %ulong %626 %ulong_1099511628211
-OpStore %605 %627
-%628 = OpLoad %ulong %608
-%629 = OpIAdd %ulong %628 %ulong_1
-OpStore %606 %629
-%630 = OpLoad %ulong %605
-OpStore %607 %630
-%631 = OpLoad %ulong %606
-OpStore %608 %631
-OpBranch %596
-%596 = OpLabel
-OpBranch %592
+OpStore %151 %271
+%272 = OpLoad %ulong %150
+%273 = OpLoad %v2ulong %151
+%274 = OpFunctionCall %ulong %1 %272 %273
+OpStore %152 %274
+%275 = OpLoad %v2ulong %141
+%276 = OpLoad %v2ulong %144
+%277 = OpIMul %v2ulong %275 %276
+OpStore %153 %277
+%278 = OpLoad %ulong %152
+%279 = OpLoad %v2ulong %153
+%280 = OpFunctionCall %ulong %1 %278 %279
+OpStore %154 %280
+%281 = OpLoad %v2ulong %141
+%282 = OpLoad %v2ulong %137
+%283 = OpIMul %v2ulong %281 %282
+OpStore %155 %283
+%284 = OpLoad %ulong %154
+%285 = OpLoad %v2ulong %155
+%286 = OpFunctionCall %ulong %1 %284 %285
+OpStore %156 %286
+%287 = OpLoad %v2ulong %144
+%288 = OpLoad %v2ulong %137
+%289 = OpIMul %v2ulong %287 %288
+OpStore %157 %289
+%290 = OpLoad %ulong %156
+%291 = OpLoad %v2ulong %157
+%292 = OpFunctionCall %ulong %1 %290 %291
+OpStore %158 %292
+%293 = OpLoad %v2ulong %147
+%294 = OpLoad %v2ulong %137
+%295 = OpIMul %v2ulong %293 %294
+OpStore %159 %295
+%296 = OpLoad %ulong %158
+%297 = OpLoad %v2ulong %159
+%298 = OpFunctionCall %ulong %1 %296 %297
+OpStore %160 %298
+%299 = OpLoad %v2ulong %138
+%300 = OpLoad %v2ulong %141
+%301 = OpISub %v2ulong %299 %300
+OpStore %161 %301
+%302 = OpLoad %ulong %160
+%303 = OpLoad %v2ulong %161
+%304 = OpFunctionCall %ulong %1 %302 %303
+OpStore %162 %304
+%305 = OpLoad %v2ulong %138
+%306 = OpLoad %v2ulong %144
+%307 = OpISub %v2ulong %305 %306
+OpStore %163 %307
+%308 = OpLoad %ulong %162
+%309 = OpLoad %v2ulong %163
+%310 = OpFunctionCall %ulong %1 %308 %309
+OpStore %164 %310
+%311 = OpLoad %v2ulong %141
+%312 = OpLoad %v2ulong %144
+%313 = OpBitwiseAnd %v2ulong %311 %312
+OpStore %165 %313
+%314 = OpLoad %ulong %164
+%315 = OpLoad %v2ulong %165
+%316 = OpFunctionCall %ulong %1 %314 %315
+OpStore %166 %316
+%317 = OpLoad %v2ulong %141
+%318 = OpLoad %v2ulong %144
+%319 = OpBitwiseOr %v2ulong %317 %318
+OpStore %167 %319
+%320 = OpLoad %ulong %166
+%321 = OpLoad %v2ulong %167
+%322 = OpFunctionCall %ulong %1 %320 %321
+OpStore %168 %322
+%323 = OpLoad %v2ulong %141
+%324 = OpLoad %v2ulong %144
+%325 = OpBitwiseXor %v2ulong %323 %324
+OpStore %169 %325
+%326 = OpLoad %ulong %168
+%327 = OpLoad %v2ulong %169
+%328 = OpFunctionCall %ulong %1 %326 %327
+OpStore %170 %328
+%329 = OpLoad %v2ulong %141
+%330 = OpNot %v2ulong %329
+OpStore %171 %330
+%331 = OpLoad %ulong %170
+%332 = OpLoad %v2ulong %171
+%333 = OpFunctionCall %ulong %1 %331 %332
+OpStore %172 %333
+%334 = OpLoad %v2ulong %144
+%335 = OpNot %v2ulong %334
+OpStore %173 %335
+%336 = OpLoad %ulong %172
+%337 = OpLoad %v2ulong %173
+%338 = OpFunctionCall %ulong %1 %336 %337
+OpStore %174 %338
+%339 = OpLoad %v2ulong %165
+%340 = OpLoad %v2ulong %167
+%341 = OpBitwiseXor %v2ulong %339 %340
+OpStore %175 %341
+%342 = OpLoad %ulong %174
+%343 = OpLoad %v2ulong %175
+%344 = OpFunctionCall %ulong %1 %342 %343
+OpStore %176 %344
+%345 = OpLoad %ulong %176
+OpStore %200 %345
+%346 = OpLoad %v2ulong %141
+OpStore %201 %346
+%347 = OpLoad %v2ulong %138
+OpStore %202 %347
+%348 = OpLoad %v2ulong %138
+OpStore %203 %348
+OpStore %204 %ulong_0
+OpBranch %100
+%100 = OpLabel
+%349 = OpLoad %ulong %204
+%351 = OpULessThan %bool %349 %ulong_6
+OpStore %177 %351
+%352 = OpLoad %bool %177
+OpLoopMerge %102 %125 None
+OpBranchConditional %352 %101 %102
+%102 = OpLabel
+OpStore %130 %353
+%355 = OpAccessChain %_ptr_Function_v2ulong %130 %uint_0
+%356 = OpLoad %v2ulong %201
+OpStore %355 %356
+%357 = OpLoad %v2ulong %201
+%358 = OpLoad %v2ulong %144
+%359 = OpIAdd %v2ulong %357 %358
+OpStore %187 %359
+%361 = OpAccessChain %_ptr_Function_v2ulong %130 %uint_1
+%362 = OpLoad %v2ulong %187
+OpStore %361 %362
+%363 = OpLoad %v2ulong %201
+%364 = OpLoad %v2ulong %137
+%365 = OpIMul %v2ulong %363 %364
+OpStore %188 %365
+%367 = OpAccessChain %_ptr_Function_v2ulong %130 %uint_2
+%368 = OpLoad %v2ulong %188
+OpStore %367 %368
+%370 = OpAccessChain %_ptr_Function_v2ulong %130 %uint_3
+%371 = OpLoad %v2ulong %202
+OpStore %370 %371
+%372 = OpLoad %ulong %200
+OpStore %199 %372
+OpStore %205 %ulong_0
+OpBranch %103
+%103 = OpLabel
+%373 = OpLoad %ulong %205
+%375 = OpULessThan %bool %373 %ulong_4
+OpStore %189 %375
+%376 = OpLoad %bool %189
+OpLoopMerge %105 %124 None
+OpBranchConditional %376 %104 %105
+%105 = OpLabel
+OpStore %133 %377
+%378 = OpAccessChain %_ptr_Function_uint %133 %uint_0
+OpStore %378 %uint_4294967295
+%380 = OpAccessChain %_ptr_Function_v2ulong %130 %uint_2
+%381 = OpLoad %v2ulong %380
+OpStore %193 %381
+%382 = OpAccessChain %_ptr_Function_v2ulong %133 %uint_1
+%383 = OpLoad %v2ulong %193
+OpStore %382 %383
+%384 = OpAccessChain %_ptr_Function_uint %133 %uint_2
+OpStore %384 %uint_305419896
+%386 = OpLoad %uint %378
+OpStore %195 %386
+OpBranch %108
+%108 = OpLabel
+%387 = OpLoad %uint %195
+%388 = OpUConvert %ulong %387
+OpStore %206 %388
+OpBranch %110
+%110 = OpLabel
+%389 = OpLoad %ulong %199
+OpStore %214 %389
+OpStore %215 %ulong_0
+OpBranch %111
+%111 = OpLabel
+%390 = OpLoad %ulong %215
+%391 = OpULessThan %bool %390 %ulong_8
+OpStore %207 %391
+%392 = OpLoad %bool %207
+OpLoopMerge %113 %123 None
+OpBranchConditional %392 %112 %113
+%113 = OpLabel
+OpBranch %114
+%114 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%393 = OpAccessChain %_ptr_Function_v2ulong %133 %uint_1
+%394 = OpLoad %v2ulong %393
+OpStore %196 %394
+%395 = OpLoad %ulong %214
+%396 = OpLoad %v2ulong %196
+%397 = OpFunctionCall %ulong %1 %395 %396
+OpStore %197 %397
+%398 = OpAccessChain %_ptr_Function_uint %133 %uint_2
+%399 = OpLoad %uint %398
+OpStore %198 %399
+OpBranch %115
+%115 = OpLabel
+%400 = OpLoad %uint %198
+%401 = OpUConvert %ulong %400
+OpStore %216 %401
+OpBranch %117
+%117 = OpLabel
+%402 = OpLoad %ulong %197
+OpStore %224 %402
+OpStore %225 %ulong_0
+OpBranch %118
+%118 = OpLabel
+%403 = OpLoad %ulong %225
+%404 = OpULessThan %bool %403 %ulong_8
+OpStore %217 %404
+%405 = OpLoad %bool %217
+OpLoopMerge %120 %122 None
+OpBranchConditional %405 %119 %120
+%120 = OpLabel
+OpBranch %121
+%121 = OpLabel
+OpBranch %116
+%116 = OpLabel
+%406 = OpLoad %ulong %224
+OpReturnValue %406
+%119 = OpLabel
+%407 = OpLoad %ulong %225
+%408 = OpIMul %ulong %407 %ulong_8
+OpStore %218 %408
+%409 = OpLoad %ulong %216
+%410 = OpLoad %ulong %218
+%411 = OpShiftRightLogical %ulong %409 %410
+OpStore %219 %411
+%412 = OpLoad %ulong %219
+%413 = OpBitwiseAnd %ulong %412 %ulong_255
+OpStore %220 %413
+%414 = OpLoad %ulong %224
+%415 = OpLoad %ulong %220
+%416 = OpBitwiseXor %ulong %414 %415
+OpStore %221 %416
+%417 = OpLoad %ulong %221
+%418 = OpIMul %ulong %417 %ulong_1099511628211
+OpStore %222 %418
+%419 = OpLoad %ulong %225
+%420 = OpIAdd %ulong %419 %ulong_1
+OpStore %223 %420
+%421 = OpLoad %ulong %222
+OpStore %224 %421
+%422 = OpLoad %ulong %223
+OpStore %225 %422
+OpBranch %122
+%112 = OpLabel
+%423 = OpLoad %ulong %215
+%424 = OpIMul %ulong %423 %ulong_8
+OpStore %208 %424
+%425 = OpLoad %ulong %206
+%426 = OpLoad %ulong %208
+%427 = OpShiftRightLogical %ulong %425 %426
+OpStore %209 %427
+%428 = OpLoad %ulong %209
+%429 = OpBitwiseAnd %ulong %428 %ulong_255
+OpStore %210 %429
+%430 = OpLoad %ulong %214
+%431 = OpLoad %ulong %210
+%432 = OpBitwiseXor %ulong %430 %431
+OpStore %211 %432
+%433 = OpLoad %ulong %211
+%434 = OpIMul %ulong %433 %ulong_1099511628211
+OpStore %212 %434
+%435 = OpLoad %ulong %215
+%436 = OpIAdd %ulong %435 %ulong_1
+OpStore %213 %436
+%437 = OpLoad %ulong %212
+OpStore %214 %437
+%438 = OpLoad %ulong %213
+OpStore %215 %438
+OpBranch %123
+%104 = OpLabel
+%439 = OpLoad %ulong %205
+%440 = OpAccessChain %_ptr_Function_v2ulong %130 %439
+%441 = OpLoad %v2ulong %440
+OpStore %190 %441
+%442 = OpLoad %ulong %199
+%443 = OpLoad %v2ulong %190
+%444 = OpFunctionCall %ulong %1 %442 %443
+OpStore %191 %444
+%445 = OpLoad %ulong %205
+%446 = OpIAdd %ulong %445 %ulong_1
+OpStore %192 %446
+%447 = OpLoad %ulong %191
+OpStore %199 %447
+%448 = OpLoad %ulong %192
+OpStore %205 %448
+OpBranch %124
+%101 = OpLabel
+%449 = OpLoad %v2ulong %201
+%450 = OpLoad %v2ulong %137
+%451 = OpIMul %v2ulong %449 %450
+OpStore %178 %451
+%452 = OpLoad %ulong %200
+%453 = OpLoad %v2ulong %178
+%454 = OpFunctionCall %ulong %1 %452 %453
+OpStore %179 %454
+%455 = OpLoad %v2ulong %202
+%456 = OpLoad %v2ulong %178
+%457 = OpBitwiseXor %v2ulong %455 %456
+OpStore %180 %457
+%458 = OpLoad %ulong %179
+%459 = OpLoad %v2ulong %180
+%460 = OpFunctionCall %ulong %1 %458 %459
+OpStore %181 %460
+%461 = OpLoad %v2ulong %203
+%462 = OpLoad %v2ulong %201
+%463 = OpIAdd %v2ulong %461 %462
+OpStore %182 %463
+%464 = OpLoad %ulong %181
+%465 = OpLoad %v2ulong %182
+%466 = OpFunctionCall %ulong %1 %464 %465
+OpStore %183 %466
+%467 = OpLoad %v2ulong %201
+%468 = OpLoad %v2ulong %144
+%469 = OpIAdd %v2ulong %467 %468
+OpStore %184 %469
+%470 = OpLoad %ulong %183
+%471 = OpLoad %v2ulong %184
+%472 = OpFunctionCall %ulong %1 %470 %471
+OpStore %185 %472
+%473 = OpLoad %ulong %204
+%474 = OpIAdd %ulong %473 %ulong_1
+OpStore %186 %474
+%475 = OpLoad %ulong %185
+OpStore %200 %475
+%476 = OpLoad %v2ulong %184
+OpStore %201 %476
+%477 = OpLoad %v2ulong %180
+OpStore %202 %477
+%478 = OpLoad %v2ulong %182
+OpStore %203 %478
+%479 = OpLoad %ulong %186
+OpStore %204 %479
+OpBranch %125
+%122 = OpLabel
+OpBranch %118
+%123 = OpLabel
+OpBranch %111
+%124 = OpLabel
+OpBranch %103
+%125 = OpLabel
+OpBranch %100
 OpFunctionEnd

--- a/test/golden/spirv/vec/vec_u8x16.dis
+++ b/test/golden/spirv/vec/vec_u8x16.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 5091
+; Bound: 5624
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -15,18 +15,23 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u8x16.checksum" Export
 %uint = OpTypeInt 32 0
 %uint_16 = OpConstant %uint 16
 %_arr_uchar_uint_16 = OpTypeArray %uchar %uint_16
-%11 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%9 = OpTypeFunction %ulong %ulong %_arr_uchar_uint_16
+%bool = OpTypeBool
 %_ptr_Function_ulong = OpTypePointer Function %ulong
 %_ptr_Function__arr_uchar_uint_16 = OpTypePointer Function %_arr_uchar_uint_16
 %_ptr_Function_uchar = OpTypePointer Function %uchar
-%133 = OpTypeFunction %ulong %ulong
-%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%714 = OpTypeFunction %ulong %ulong
 %uint_4 = OpConstant %uint 4
 %_arr__arr_uchar_uint_16_uint_4 = OpTypeArray %_arr_uchar_uint_16 %uint_4
 %_ptr_Function__arr__arr_uchar_uint_16_uint_4 = OpTypePointer Function %_arr__arr_uchar_uint_16_uint_4
-%_struct_149 = OpTypeStruct %uint %_arr_uchar_uint_16 %uint
-%_ptr_Function__struct_149 = OpTypePointer Function %_struct_149
-%_ptr_Function_bool = OpTypePointer Function %bool
+%_struct_735 = OpTypeStruct %uint %_arr_uchar_uint_16 %uint
+%_ptr_Function__struct_735 = OpTypePointer Function %_struct_735
 %_ptr_Function_uint = OpTypePointer Function %uint
 %uchar_240 = OpConstant %uchar 240
 %uchar_1 = OpConstant %uchar 1
@@ -64,209 +69,52 @@ OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_u8x16.checksum" Export
 %uchar_24 = OpConstant %uchar 24
 %uchar_72 = OpConstant %uchar 72
 %uchar_216 = OpConstant %uchar 216
-%ulong_0 = OpConstant %ulong 0
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
 %ulong_6 = OpConstant %ulong 6
-%3965 = OpConstantNull %_arr__arr_uchar_uint_16_uint_4
+%4549 = OpConstantNull %_arr__arr_uchar_uint_16_uint_4
 %uint_0 = OpConstant %uint 0
 %uint_1 = OpConstant %uint 1
 %uint_2 = OpConstant %uint 2
 %uint_3 = OpConstant %uint 3
 %ulong_4 = OpConstant %ulong 4
-%4303 = OpConstantNull %_struct_149
+%4887 = OpConstantNull %_struct_735
 %uint_4294967295 = OpConstant %uint 4294967295
 %uint_305419896 = OpConstant %uint 305419896
-%ulong_1 = OpConstant %ulong 1
-%4995 = OpTypeFunction %ulong
-%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%4998 = OpTypeFunction %ulong %ulong %uchar
-%ulong_8 = OpConstant %ulong 8
-%ulong_255 = OpConstant %ulong 255
-%ulong_1099511628211 = OpConstant %ulong 1099511628211
-%5046 = OpTypeFunction %ulong %ulong %uint
-%1 = OpFunction %ulong None %11
-%12 = OpFunctionParameter %ulong
-%13 = OpFunctionParameter %_arr_uchar_uint_16
-%14 = OpLabel
-%16 = OpVariable %_ptr_Function_ulong Function
-%18 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%20 = OpVariable %_ptr_Function_uchar Function
-%21 = OpVariable %_ptr_Function_ulong Function
-%22 = OpVariable %_ptr_Function_uchar Function
-%23 = OpVariable %_ptr_Function_ulong Function
-%24 = OpVariable %_ptr_Function_uchar Function
-%25 = OpVariable %_ptr_Function_ulong Function
-%26 = OpVariable %_ptr_Function_uchar Function
-%27 = OpVariable %_ptr_Function_ulong Function
-%28 = OpVariable %_ptr_Function_uchar Function
-%29 = OpVariable %_ptr_Function_ulong Function
-%30 = OpVariable %_ptr_Function_uchar Function
-%31 = OpVariable %_ptr_Function_ulong Function
-%32 = OpVariable %_ptr_Function_uchar Function
-%33 = OpVariable %_ptr_Function_ulong Function
-%34 = OpVariable %_ptr_Function_uchar Function
-%35 = OpVariable %_ptr_Function_ulong Function
-%36 = OpVariable %_ptr_Function_uchar Function
-%37 = OpVariable %_ptr_Function_ulong Function
-%38 = OpVariable %_ptr_Function_uchar Function
-%39 = OpVariable %_ptr_Function_ulong Function
-%40 = OpVariable %_ptr_Function_uchar Function
-%41 = OpVariable %_ptr_Function_ulong Function
-%42 = OpVariable %_ptr_Function_uchar Function
-%43 = OpVariable %_ptr_Function_ulong Function
-%44 = OpVariable %_ptr_Function_uchar Function
-%45 = OpVariable %_ptr_Function_ulong Function
-%46 = OpVariable %_ptr_Function_uchar Function
-%47 = OpVariable %_ptr_Function_ulong Function
-%48 = OpVariable %_ptr_Function_uchar Function
-%49 = OpVariable %_ptr_Function_ulong Function
-%50 = OpVariable %_ptr_Function_uchar Function
-%51 = OpVariable %_ptr_Function_ulong Function
-OpStore %16 %12
-OpStore %18 %13
-%52 = OpLoad %_arr_uchar_uint_16 %18
-%53 = OpCompositeExtract %uchar %52 0
-OpStore %20 %53
-%54 = OpLoad %ulong %16
-%55 = OpLoad %uchar %20
-%56 = OpFunctionCall %ulong %4 %54 %55
-OpStore %21 %56
-%57 = OpLoad %_arr_uchar_uint_16 %18
-%58 = OpCompositeExtract %uchar %57 1
-OpStore %22 %58
-%59 = OpLoad %ulong %21
-%60 = OpLoad %uchar %22
-%61 = OpFunctionCall %ulong %4 %59 %60
-OpStore %23 %61
-%62 = OpLoad %_arr_uchar_uint_16 %18
-%63 = OpCompositeExtract %uchar %62 2
-OpStore %24 %63
-%64 = OpLoad %ulong %23
-%65 = OpLoad %uchar %24
-%66 = OpFunctionCall %ulong %4 %64 %65
-OpStore %25 %66
-%67 = OpLoad %_arr_uchar_uint_16 %18
-%68 = OpCompositeExtract %uchar %67 3
-OpStore %26 %68
-%69 = OpLoad %ulong %25
-%70 = OpLoad %uchar %26
-%71 = OpFunctionCall %ulong %4 %69 %70
-OpStore %27 %71
-%72 = OpLoad %_arr_uchar_uint_16 %18
-%73 = OpCompositeExtract %uchar %72 4
-OpStore %28 %73
-%74 = OpLoad %ulong %27
-%75 = OpLoad %uchar %28
-%76 = OpFunctionCall %ulong %4 %74 %75
-OpStore %29 %76
-%77 = OpLoad %_arr_uchar_uint_16 %18
-%78 = OpCompositeExtract %uchar %77 5
-OpStore %30 %78
-%79 = OpLoad %ulong %29
-%80 = OpLoad %uchar %30
-%81 = OpFunctionCall %ulong %4 %79 %80
-OpStore %31 %81
-%82 = OpLoad %_arr_uchar_uint_16 %18
-%83 = OpCompositeExtract %uchar %82 6
-OpStore %32 %83
-%84 = OpLoad %ulong %31
-%85 = OpLoad %uchar %32
-%86 = OpFunctionCall %ulong %4 %84 %85
-OpStore %33 %86
-%87 = OpLoad %_arr_uchar_uint_16 %18
-%88 = OpCompositeExtract %uchar %87 7
-OpStore %34 %88
-%89 = OpLoad %ulong %33
-%90 = OpLoad %uchar %34
-%91 = OpFunctionCall %ulong %4 %89 %90
-OpStore %35 %91
-%92 = OpLoad %_arr_uchar_uint_16 %18
-%93 = OpCompositeExtract %uchar %92 8
-OpStore %36 %93
-%94 = OpLoad %ulong %35
-%95 = OpLoad %uchar %36
-%96 = OpFunctionCall %ulong %4 %94 %95
-OpStore %37 %96
-%97 = OpLoad %_arr_uchar_uint_16 %18
-%98 = OpCompositeExtract %uchar %97 9
-OpStore %38 %98
-%99 = OpLoad %ulong %37
-%100 = OpLoad %uchar %38
-%101 = OpFunctionCall %ulong %4 %99 %100
-OpStore %39 %101
-%102 = OpLoad %_arr_uchar_uint_16 %18
-%103 = OpCompositeExtract %uchar %102 10
-OpStore %40 %103
-%104 = OpLoad %ulong %39
-%105 = OpLoad %uchar %40
-%106 = OpFunctionCall %ulong %4 %104 %105
-OpStore %41 %106
-%107 = OpLoad %_arr_uchar_uint_16 %18
-%108 = OpCompositeExtract %uchar %107 11
-OpStore %42 %108
-%109 = OpLoad %ulong %41
-%110 = OpLoad %uchar %42
-%111 = OpFunctionCall %ulong %4 %109 %110
-OpStore %43 %111
-%112 = OpLoad %_arr_uchar_uint_16 %18
-%113 = OpCompositeExtract %uchar %112 12
-OpStore %44 %113
-%114 = OpLoad %ulong %43
-%115 = OpLoad %uchar %44
-%116 = OpFunctionCall %ulong %4 %114 %115
-OpStore %45 %116
-%117 = OpLoad %_arr_uchar_uint_16 %18
-%118 = OpCompositeExtract %uchar %117 13
-OpStore %46 %118
-%119 = OpLoad %ulong %45
-%120 = OpLoad %uchar %46
-%121 = OpFunctionCall %ulong %4 %119 %120
-OpStore %47 %121
-%122 = OpLoad %_arr_uchar_uint_16 %18
-%123 = OpCompositeExtract %uchar %122 14
-OpStore %48 %123
-%124 = OpLoad %ulong %47
-%125 = OpLoad %uchar %48
-%126 = OpFunctionCall %ulong %4 %124 %125
-OpStore %49 %126
-%127 = OpLoad %_arr_uchar_uint_16 %18
-%128 = OpCompositeExtract %uchar %127 15
-OpStore %50 %128
-%129 = OpLoad %ulong %49
-%130 = OpLoad %uchar %50
-%131 = OpFunctionCall %ulong %4 %129 %130
-OpStore %51 %131
-%132 = OpLoad %ulong %51
-OpReturnValue %132
-OpFunctionEnd
-%2 = OpFunction %ulong None %133
-%134 = OpFunctionParameter %ulong
-%135 = OpLabel
-%148 = OpVariable %_ptr_Function__arr__arr_uchar_uint_16_uint_4 Function
-%151 = OpVariable %_ptr_Function__struct_149 Function
-%152 = OpVariable %_ptr_Function_ulong Function
-%153 = OpVariable %_ptr_Function_ulong Function
+%5584 = OpTypeFunction %ulong %ulong %ulong
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %_arr_uchar_uint_16
+%12 = OpLabel
+%143 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%147 = OpVariable %_ptr_Function_uchar Function
+%148 = OpVariable %_ptr_Function_uchar Function
+%149 = OpVariable %_ptr_Function_uchar Function
+%150 = OpVariable %_ptr_Function_uchar Function
+%151 = OpVariable %_ptr_Function_uchar Function
+%152 = OpVariable %_ptr_Function_uchar Function
+%153 = OpVariable %_ptr_Function_uchar Function
 %154 = OpVariable %_ptr_Function_uchar Function
-%155 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%156 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%157 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%158 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%155 = OpVariable %_ptr_Function_uchar Function
+%156 = OpVariable %_ptr_Function_uchar Function
+%157 = OpVariable %_ptr_Function_uchar Function
+%158 = OpVariable %_ptr_Function_uchar Function
 %159 = OpVariable %_ptr_Function_uchar Function
 %160 = OpVariable %_ptr_Function_uchar Function
-%161 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%161 = OpVariable %_ptr_Function_uchar Function
 %162 = OpVariable %_ptr_Function_uchar Function
-%163 = OpVariable %_ptr_Function_uchar Function
-%164 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%165 = OpVariable %_ptr_Function_uchar Function
-%166 = OpVariable %_ptr_Function_uchar Function
-%167 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%168 = OpVariable %_ptr_Function_uchar Function
-%169 = OpVariable %_ptr_Function_uchar Function
-%170 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_bool Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
 %171 = OpVariable %_ptr_Function_ulong Function
 %172 = OpVariable %_ptr_Function_ulong Function
 %173 = OpVariable %_ptr_Function_ulong Function
 %174 = OpVariable %_ptr_Function_ulong Function
-%175 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_bool Function
 %176 = OpVariable %_ptr_Function_ulong Function
 %177 = OpVariable %_ptr_Function_ulong Function
 %178 = OpVariable %_ptr_Function_ulong Function
@@ -276,619 +124,1080 @@ OpFunctionEnd
 %182 = OpVariable %_ptr_Function_ulong Function
 %183 = OpVariable %_ptr_Function_ulong Function
 %184 = OpVariable %_ptr_Function_ulong Function
-%185 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_bool Function
 %186 = OpVariable %_ptr_Function_ulong Function
 %187 = OpVariable %_ptr_Function_ulong Function
-%189 = OpVariable %_ptr_Function_bool Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
 %190 = OpVariable %_ptr_Function_ulong Function
 %191 = OpVariable %_ptr_Function_ulong Function
 %192 = OpVariable %_ptr_Function_ulong Function
 %193 = OpVariable %_ptr_Function_ulong Function
 %194 = OpVariable %_ptr_Function_ulong Function
 %195 = OpVariable %_ptr_Function_bool Function
-%196 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%196 = OpVariable %_ptr_Function_ulong Function
 %197 = OpVariable %_ptr_Function_ulong Function
 %198 = OpVariable %_ptr_Function_ulong Function
-%199 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%201 = OpVariable %_ptr_Function_uint Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
 %202 = OpVariable %_ptr_Function_ulong Function
-%203 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%203 = OpVariable %_ptr_Function_ulong Function
 %204 = OpVariable %_ptr_Function_ulong Function
-%205 = OpVariable %_ptr_Function_uint Function
+%205 = OpVariable %_ptr_Function_bool Function
 %206 = OpVariable %_ptr_Function_ulong Function
 %207 = OpVariable %_ptr_Function_ulong Function
 %208 = OpVariable %_ptr_Function_ulong Function
-%209 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%210 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%211 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
 %212 = OpVariable %_ptr_Function_ulong Function
 %213 = OpVariable %_ptr_Function_ulong Function
-%214 = OpVariable %_ptr_Function_uchar Function
-%215 = OpVariable %_ptr_Function_uchar Function
-%216 = OpVariable %_ptr_Function_uchar Function
-%217 = OpVariable %_ptr_Function_uchar Function
-%218 = OpVariable %_ptr_Function_uchar Function
-%219 = OpVariable %_ptr_Function_uchar Function
-%220 = OpVariable %_ptr_Function_uchar Function
-%221 = OpVariable %_ptr_Function_uchar Function
-%222 = OpVariable %_ptr_Function_uchar Function
-%223 = OpVariable %_ptr_Function_uchar Function
-%224 = OpVariable %_ptr_Function_uchar Function
-%225 = OpVariable %_ptr_Function_uchar Function
-%226 = OpVariable %_ptr_Function_uchar Function
-%227 = OpVariable %_ptr_Function_uchar Function
-%228 = OpVariable %_ptr_Function_uchar Function
-%229 = OpVariable %_ptr_Function_uchar Function
-%230 = OpVariable %_ptr_Function_uchar Function
-%231 = OpVariable %_ptr_Function_uchar Function
-%232 = OpVariable %_ptr_Function_uchar Function
-%233 = OpVariable %_ptr_Function_uchar Function
-%234 = OpVariable %_ptr_Function_uchar Function
-%235 = OpVariable %_ptr_Function_uchar Function
-%236 = OpVariable %_ptr_Function_uchar Function
-%237 = OpVariable %_ptr_Function_uchar Function
-%238 = OpVariable %_ptr_Function_uchar Function
-%239 = OpVariable %_ptr_Function_uchar Function
-%240 = OpVariable %_ptr_Function_uchar Function
-%241 = OpVariable %_ptr_Function_uchar Function
-%242 = OpVariable %_ptr_Function_uchar Function
-%243 = OpVariable %_ptr_Function_uchar Function
-%244 = OpVariable %_ptr_Function_uchar Function
-%245 = OpVariable %_ptr_Function_uchar Function
-%246 = OpVariable %_ptr_Function_uchar Function
-%247 = OpVariable %_ptr_Function_uchar Function
-%248 = OpVariable %_ptr_Function_uchar Function
-%249 = OpVariable %_ptr_Function_uchar Function
-%250 = OpVariable %_ptr_Function_uchar Function
-%251 = OpVariable %_ptr_Function_uchar Function
-%252 = OpVariable %_ptr_Function_uchar Function
-%253 = OpVariable %_ptr_Function_uchar Function
-%254 = OpVariable %_ptr_Function_uchar Function
-%255 = OpVariable %_ptr_Function_uchar Function
-%256 = OpVariable %_ptr_Function_uchar Function
-%257 = OpVariable %_ptr_Function_uchar Function
-%258 = OpVariable %_ptr_Function_uchar Function
-%259 = OpVariable %_ptr_Function_uchar Function
-%260 = OpVariable %_ptr_Function_uchar Function
-%261 = OpVariable %_ptr_Function_uchar Function
-%262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%270 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%271 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%272 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%273 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%274 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%275 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%276 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%277 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%278 = OpVariable %_ptr_Function_uchar Function
-%279 = OpVariable %_ptr_Function_uchar Function
-%280 = OpVariable %_ptr_Function_uchar Function
-%281 = OpVariable %_ptr_Function_uchar Function
-%282 = OpVariable %_ptr_Function_uchar Function
-%283 = OpVariable %_ptr_Function_uchar Function
-%284 = OpVariable %_ptr_Function_uchar Function
-%285 = OpVariable %_ptr_Function_uchar Function
-%286 = OpVariable %_ptr_Function_uchar Function
-%287 = OpVariable %_ptr_Function_uchar Function
-%288 = OpVariable %_ptr_Function_uchar Function
-%289 = OpVariable %_ptr_Function_uchar Function
-%290 = OpVariable %_ptr_Function_uchar Function
-%291 = OpVariable %_ptr_Function_uchar Function
-%292 = OpVariable %_ptr_Function_uchar Function
-%293 = OpVariable %_ptr_Function_uchar Function
-%294 = OpVariable %_ptr_Function_uchar Function
-%295 = OpVariable %_ptr_Function_uchar Function
-%296 = OpVariable %_ptr_Function_uchar Function
-%297 = OpVariable %_ptr_Function_uchar Function
-%298 = OpVariable %_ptr_Function_uchar Function
-%299 = OpVariable %_ptr_Function_uchar Function
-%300 = OpVariable %_ptr_Function_uchar Function
-%301 = OpVariable %_ptr_Function_uchar Function
-%302 = OpVariable %_ptr_Function_uchar Function
-%303 = OpVariable %_ptr_Function_uchar Function
-%304 = OpVariable %_ptr_Function_uchar Function
-%305 = OpVariable %_ptr_Function_uchar Function
-%306 = OpVariable %_ptr_Function_uchar Function
-%307 = OpVariable %_ptr_Function_uchar Function
-%308 = OpVariable %_ptr_Function_uchar Function
-%309 = OpVariable %_ptr_Function_uchar Function
-%310 = OpVariable %_ptr_Function_uchar Function
-%311 = OpVariable %_ptr_Function_uchar Function
-%312 = OpVariable %_ptr_Function_uchar Function
-%313 = OpVariable %_ptr_Function_uchar Function
-%314 = OpVariable %_ptr_Function_uchar Function
-%315 = OpVariable %_ptr_Function_uchar Function
-%316 = OpVariable %_ptr_Function_uchar Function
-%317 = OpVariable %_ptr_Function_uchar Function
-%318 = OpVariable %_ptr_Function_uchar Function
-%319 = OpVariable %_ptr_Function_uchar Function
-%320 = OpVariable %_ptr_Function_uchar Function
-%321 = OpVariable %_ptr_Function_uchar Function
-%322 = OpVariable %_ptr_Function_uchar Function
-%323 = OpVariable %_ptr_Function_uchar Function
-%324 = OpVariable %_ptr_Function_uchar Function
-%325 = OpVariable %_ptr_Function_uchar Function
-%326 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%327 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%328 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%329 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%330 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%331 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%332 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%333 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%334 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%335 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%336 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%337 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%338 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%339 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%340 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%341 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%342 = OpVariable %_ptr_Function_uchar Function
-%343 = OpVariable %_ptr_Function_uchar Function
-%344 = OpVariable %_ptr_Function_uchar Function
-%345 = OpVariable %_ptr_Function_uchar Function
-%346 = OpVariable %_ptr_Function_uchar Function
-%347 = OpVariable %_ptr_Function_uchar Function
-%348 = OpVariable %_ptr_Function_uchar Function
-%349 = OpVariable %_ptr_Function_uchar Function
-%350 = OpVariable %_ptr_Function_uchar Function
-%351 = OpVariable %_ptr_Function_uchar Function
-%352 = OpVariable %_ptr_Function_uchar Function
-%353 = OpVariable %_ptr_Function_uchar Function
-%354 = OpVariable %_ptr_Function_uchar Function
-%355 = OpVariable %_ptr_Function_uchar Function
-%356 = OpVariable %_ptr_Function_uchar Function
-%357 = OpVariable %_ptr_Function_uchar Function
-%358 = OpVariable %_ptr_Function_uchar Function
-%359 = OpVariable %_ptr_Function_uchar Function
-%360 = OpVariable %_ptr_Function_uchar Function
-%361 = OpVariable %_ptr_Function_uchar Function
-%362 = OpVariable %_ptr_Function_uchar Function
-%363 = OpVariable %_ptr_Function_uchar Function
-%364 = OpVariable %_ptr_Function_uchar Function
-%365 = OpVariable %_ptr_Function_uchar Function
-%366 = OpVariable %_ptr_Function_uchar Function
-%367 = OpVariable %_ptr_Function_uchar Function
-%368 = OpVariable %_ptr_Function_uchar Function
-%369 = OpVariable %_ptr_Function_uchar Function
-%370 = OpVariable %_ptr_Function_uchar Function
-%371 = OpVariable %_ptr_Function_uchar Function
-%372 = OpVariable %_ptr_Function_uchar Function
-%373 = OpVariable %_ptr_Function_uchar Function
-%374 = OpVariable %_ptr_Function_uchar Function
-%375 = OpVariable %_ptr_Function_uchar Function
-%376 = OpVariable %_ptr_Function_uchar Function
-%377 = OpVariable %_ptr_Function_uchar Function
-%378 = OpVariable %_ptr_Function_uchar Function
-%379 = OpVariable %_ptr_Function_uchar Function
-%380 = OpVariable %_ptr_Function_uchar Function
-%381 = OpVariable %_ptr_Function_uchar Function
-%382 = OpVariable %_ptr_Function_uchar Function
-%383 = OpVariable %_ptr_Function_uchar Function
-%384 = OpVariable %_ptr_Function_uchar Function
-%385 = OpVariable %_ptr_Function_uchar Function
-%386 = OpVariable %_ptr_Function_uchar Function
-%387 = OpVariable %_ptr_Function_uchar Function
-%388 = OpVariable %_ptr_Function_uchar Function
-%389 = OpVariable %_ptr_Function_uchar Function
-%390 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%391 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%392 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%393 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%394 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%395 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%396 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%397 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%398 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%399 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%400 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%401 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%402 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%403 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%404 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%405 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%406 = OpVariable %_ptr_Function_uchar Function
-%407 = OpVariable %_ptr_Function_uchar Function
-%408 = OpVariable %_ptr_Function_uchar Function
-%409 = OpVariable %_ptr_Function_uchar Function
-%410 = OpVariable %_ptr_Function_uchar Function
-%411 = OpVariable %_ptr_Function_uchar Function
-%412 = OpVariable %_ptr_Function_uchar Function
-%413 = OpVariable %_ptr_Function_uchar Function
-%414 = OpVariable %_ptr_Function_uchar Function
-%415 = OpVariable %_ptr_Function_uchar Function
-%416 = OpVariable %_ptr_Function_uchar Function
-%417 = OpVariable %_ptr_Function_uchar Function
-%418 = OpVariable %_ptr_Function_uchar Function
-%419 = OpVariable %_ptr_Function_uchar Function
-%420 = OpVariable %_ptr_Function_uchar Function
-%421 = OpVariable %_ptr_Function_uchar Function
-%422 = OpVariable %_ptr_Function_uchar Function
-%423 = OpVariable %_ptr_Function_uchar Function
-%424 = OpVariable %_ptr_Function_uchar Function
-%425 = OpVariable %_ptr_Function_uchar Function
-%426 = OpVariable %_ptr_Function_uchar Function
-%427 = OpVariable %_ptr_Function_uchar Function
-%428 = OpVariable %_ptr_Function_uchar Function
-%429 = OpVariable %_ptr_Function_uchar Function
-%430 = OpVariable %_ptr_Function_uchar Function
-%431 = OpVariable %_ptr_Function_uchar Function
-%432 = OpVariable %_ptr_Function_uchar Function
-%433 = OpVariable %_ptr_Function_uchar Function
-%434 = OpVariable %_ptr_Function_uchar Function
-%435 = OpVariable %_ptr_Function_uchar Function
-%436 = OpVariable %_ptr_Function_uchar Function
-%437 = OpVariable %_ptr_Function_uchar Function
-%438 = OpVariable %_ptr_Function_uchar Function
-%439 = OpVariable %_ptr_Function_uchar Function
-%440 = OpVariable %_ptr_Function_uchar Function
-%441 = OpVariable %_ptr_Function_uchar Function
-%442 = OpVariable %_ptr_Function_uchar Function
-%443 = OpVariable %_ptr_Function_uchar Function
-%444 = OpVariable %_ptr_Function_uchar Function
-%445 = OpVariable %_ptr_Function_uchar Function
-%446 = OpVariable %_ptr_Function_uchar Function
-%447 = OpVariable %_ptr_Function_uchar Function
-%448 = OpVariable %_ptr_Function_uchar Function
-%449 = OpVariable %_ptr_Function_uchar Function
-%450 = OpVariable %_ptr_Function_uchar Function
-%451 = OpVariable %_ptr_Function_uchar Function
-%452 = OpVariable %_ptr_Function_uchar Function
-%453 = OpVariable %_ptr_Function_uchar Function
-%454 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%455 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%456 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%457 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%458 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%459 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%460 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%461 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%462 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%463 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%464 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%465 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%466 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%467 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%468 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%469 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%470 = OpVariable %_ptr_Function_uchar Function
-%471 = OpVariable %_ptr_Function_uchar Function
-%472 = OpVariable %_ptr_Function_uchar Function
-%473 = OpVariable %_ptr_Function_uchar Function
-%474 = OpVariable %_ptr_Function_uchar Function
-%475 = OpVariable %_ptr_Function_uchar Function
-%476 = OpVariable %_ptr_Function_uchar Function
-%477 = OpVariable %_ptr_Function_uchar Function
-%478 = OpVariable %_ptr_Function_uchar Function
-%479 = OpVariable %_ptr_Function_uchar Function
-%480 = OpVariable %_ptr_Function_uchar Function
-%481 = OpVariable %_ptr_Function_uchar Function
-%482 = OpVariable %_ptr_Function_uchar Function
-%483 = OpVariable %_ptr_Function_uchar Function
-%484 = OpVariable %_ptr_Function_uchar Function
-%485 = OpVariable %_ptr_Function_uchar Function
-%486 = OpVariable %_ptr_Function_uchar Function
-%487 = OpVariable %_ptr_Function_uchar Function
-%488 = OpVariable %_ptr_Function_uchar Function
-%489 = OpVariable %_ptr_Function_uchar Function
-%490 = OpVariable %_ptr_Function_uchar Function
-%491 = OpVariable %_ptr_Function_uchar Function
-%492 = OpVariable %_ptr_Function_uchar Function
-%493 = OpVariable %_ptr_Function_uchar Function
-%494 = OpVariable %_ptr_Function_uchar Function
-%495 = OpVariable %_ptr_Function_uchar Function
-%496 = OpVariable %_ptr_Function_uchar Function
-%497 = OpVariable %_ptr_Function_uchar Function
-%498 = OpVariable %_ptr_Function_uchar Function
-%499 = OpVariable %_ptr_Function_uchar Function
-%500 = OpVariable %_ptr_Function_uchar Function
-%501 = OpVariable %_ptr_Function_uchar Function
-%502 = OpVariable %_ptr_Function_uchar Function
-%503 = OpVariable %_ptr_Function_uchar Function
-%504 = OpVariable %_ptr_Function_uchar Function
-%505 = OpVariable %_ptr_Function_uchar Function
-%506 = OpVariable %_ptr_Function_uchar Function
-%507 = OpVariable %_ptr_Function_uchar Function
-%508 = OpVariable %_ptr_Function_uchar Function
-%509 = OpVariable %_ptr_Function_uchar Function
-%510 = OpVariable %_ptr_Function_uchar Function
-%511 = OpVariable %_ptr_Function_uchar Function
-%512 = OpVariable %_ptr_Function_uchar Function
-%513 = OpVariable %_ptr_Function_uchar Function
-%514 = OpVariable %_ptr_Function_uchar Function
-%515 = OpVariable %_ptr_Function_uchar Function
-%516 = OpVariable %_ptr_Function_uchar Function
-%517 = OpVariable %_ptr_Function_uchar Function
-%518 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%519 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%520 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%521 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%522 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%523 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%524 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%525 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%526 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%527 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%528 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%529 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%530 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%531 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%532 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%533 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%534 = OpVariable %_ptr_Function_uchar Function
-%535 = OpVariable %_ptr_Function_uchar Function
-%536 = OpVariable %_ptr_Function_uchar Function
-%537 = OpVariable %_ptr_Function_uchar Function
-%538 = OpVariable %_ptr_Function_uchar Function
-%539 = OpVariable %_ptr_Function_uchar Function
-%540 = OpVariable %_ptr_Function_uchar Function
-%541 = OpVariable %_ptr_Function_uchar Function
-%542 = OpVariable %_ptr_Function_uchar Function
-%543 = OpVariable %_ptr_Function_uchar Function
-%544 = OpVariable %_ptr_Function_uchar Function
-%545 = OpVariable %_ptr_Function_uchar Function
-%546 = OpVariable %_ptr_Function_uchar Function
-%547 = OpVariable %_ptr_Function_uchar Function
-%548 = OpVariable %_ptr_Function_uchar Function
-%549 = OpVariable %_ptr_Function_uchar Function
-%550 = OpVariable %_ptr_Function_uchar Function
-%551 = OpVariable %_ptr_Function_uchar Function
-%552 = OpVariable %_ptr_Function_uchar Function
-%553 = OpVariable %_ptr_Function_uchar Function
-%554 = OpVariable %_ptr_Function_uchar Function
-%555 = OpVariable %_ptr_Function_uchar Function
-%556 = OpVariable %_ptr_Function_uchar Function
-%557 = OpVariable %_ptr_Function_uchar Function
-%558 = OpVariable %_ptr_Function_uchar Function
-%559 = OpVariable %_ptr_Function_uchar Function
-%560 = OpVariable %_ptr_Function_uchar Function
-%561 = OpVariable %_ptr_Function_uchar Function
-%562 = OpVariable %_ptr_Function_uchar Function
-%563 = OpVariable %_ptr_Function_uchar Function
-%564 = OpVariable %_ptr_Function_uchar Function
-%565 = OpVariable %_ptr_Function_uchar Function
-%566 = OpVariable %_ptr_Function_uchar Function
-%567 = OpVariable %_ptr_Function_uchar Function
-%568 = OpVariable %_ptr_Function_uchar Function
-%569 = OpVariable %_ptr_Function_uchar Function
-%570 = OpVariable %_ptr_Function_uchar Function
-%571 = OpVariable %_ptr_Function_uchar Function
-%572 = OpVariable %_ptr_Function_uchar Function
-%573 = OpVariable %_ptr_Function_uchar Function
-%574 = OpVariable %_ptr_Function_uchar Function
-%575 = OpVariable %_ptr_Function_uchar Function
-%576 = OpVariable %_ptr_Function_uchar Function
-%577 = OpVariable %_ptr_Function_uchar Function
-%578 = OpVariable %_ptr_Function_uchar Function
-%579 = OpVariable %_ptr_Function_uchar Function
-%580 = OpVariable %_ptr_Function_uchar Function
-%581 = OpVariable %_ptr_Function_uchar Function
-%582 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%583 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%584 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%585 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%586 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%587 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%588 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%589 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%590 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%591 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%592 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%593 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%594 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%595 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%596 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%597 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%598 = OpVariable %_ptr_Function_uchar Function
-%599 = OpVariable %_ptr_Function_uchar Function
-%600 = OpVariable %_ptr_Function_uchar Function
-%601 = OpVariable %_ptr_Function_uchar Function
-%602 = OpVariable %_ptr_Function_uchar Function
-%603 = OpVariable %_ptr_Function_uchar Function
-%604 = OpVariable %_ptr_Function_uchar Function
-%605 = OpVariable %_ptr_Function_uchar Function
-%606 = OpVariable %_ptr_Function_uchar Function
-%607 = OpVariable %_ptr_Function_uchar Function
-%608 = OpVariable %_ptr_Function_uchar Function
-%609 = OpVariable %_ptr_Function_uchar Function
-%610 = OpVariable %_ptr_Function_uchar Function
-%611 = OpVariable %_ptr_Function_uchar Function
-%612 = OpVariable %_ptr_Function_uchar Function
-%613 = OpVariable %_ptr_Function_uchar Function
-%614 = OpVariable %_ptr_Function_uchar Function
-%615 = OpVariable %_ptr_Function_uchar Function
-%616 = OpVariable %_ptr_Function_uchar Function
-%617 = OpVariable %_ptr_Function_uchar Function
-%618 = OpVariable %_ptr_Function_uchar Function
-%619 = OpVariable %_ptr_Function_uchar Function
-%620 = OpVariable %_ptr_Function_uchar Function
-%621 = OpVariable %_ptr_Function_uchar Function
-%622 = OpVariable %_ptr_Function_uchar Function
-%623 = OpVariable %_ptr_Function_uchar Function
-%624 = OpVariable %_ptr_Function_uchar Function
-%625 = OpVariable %_ptr_Function_uchar Function
-%626 = OpVariable %_ptr_Function_uchar Function
-%627 = OpVariable %_ptr_Function_uchar Function
-%628 = OpVariable %_ptr_Function_uchar Function
-%629 = OpVariable %_ptr_Function_uchar Function
-%630 = OpVariable %_ptr_Function_uchar Function
-%631 = OpVariable %_ptr_Function_uchar Function
-%632 = OpVariable %_ptr_Function_uchar Function
-%633 = OpVariable %_ptr_Function_uchar Function
-%634 = OpVariable %_ptr_Function_uchar Function
-%635 = OpVariable %_ptr_Function_uchar Function
-%636 = OpVariable %_ptr_Function_uchar Function
-%637 = OpVariable %_ptr_Function_uchar Function
-%638 = OpVariable %_ptr_Function_uchar Function
-%639 = OpVariable %_ptr_Function_uchar Function
-%640 = OpVariable %_ptr_Function_uchar Function
-%641 = OpVariable %_ptr_Function_uchar Function
-%642 = OpVariable %_ptr_Function_uchar Function
-%643 = OpVariable %_ptr_Function_uchar Function
-%644 = OpVariable %_ptr_Function_uchar Function
-%645 = OpVariable %_ptr_Function_uchar Function
-%646 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%647 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%648 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%649 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%650 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%651 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%652 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%653 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%654 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%655 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%656 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%657 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%658 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%659 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%660 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%661 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%662 = OpVariable %_ptr_Function_uchar Function
-%663 = OpVariable %_ptr_Function_uchar Function
-%664 = OpVariable %_ptr_Function_uchar Function
-%665 = OpVariable %_ptr_Function_uchar Function
-%666 = OpVariable %_ptr_Function_uchar Function
-%667 = OpVariable %_ptr_Function_uchar Function
-%668 = OpVariable %_ptr_Function_uchar Function
-%669 = OpVariable %_ptr_Function_uchar Function
-%670 = OpVariable %_ptr_Function_uchar Function
-%671 = OpVariable %_ptr_Function_uchar Function
-%672 = OpVariable %_ptr_Function_uchar Function
-%673 = OpVariable %_ptr_Function_uchar Function
-%674 = OpVariable %_ptr_Function_uchar Function
-%675 = OpVariable %_ptr_Function_uchar Function
-%676 = OpVariable %_ptr_Function_uchar Function
-%677 = OpVariable %_ptr_Function_uchar Function
-%678 = OpVariable %_ptr_Function_uchar Function
-%679 = OpVariable %_ptr_Function_uchar Function
-%680 = OpVariable %_ptr_Function_uchar Function
-%681 = OpVariable %_ptr_Function_uchar Function
-%682 = OpVariable %_ptr_Function_uchar Function
-%683 = OpVariable %_ptr_Function_uchar Function
-%684 = OpVariable %_ptr_Function_uchar Function
-%685 = OpVariable %_ptr_Function_uchar Function
-%686 = OpVariable %_ptr_Function_uchar Function
-%687 = OpVariable %_ptr_Function_uchar Function
-%688 = OpVariable %_ptr_Function_uchar Function
-%689 = OpVariable %_ptr_Function_uchar Function
-%690 = OpVariable %_ptr_Function_uchar Function
-%691 = OpVariable %_ptr_Function_uchar Function
-%692 = OpVariable %_ptr_Function_uchar Function
-%693 = OpVariable %_ptr_Function_uchar Function
-%694 = OpVariable %_ptr_Function_uchar Function
-%695 = OpVariable %_ptr_Function_uchar Function
-%696 = OpVariable %_ptr_Function_uchar Function
-%697 = OpVariable %_ptr_Function_uchar Function
-%698 = OpVariable %_ptr_Function_uchar Function
-%699 = OpVariable %_ptr_Function_uchar Function
-%700 = OpVariable %_ptr_Function_uchar Function
-%701 = OpVariable %_ptr_Function_uchar Function
-%702 = OpVariable %_ptr_Function_uchar Function
-%703 = OpVariable %_ptr_Function_uchar Function
-%704 = OpVariable %_ptr_Function_uchar Function
-%705 = OpVariable %_ptr_Function_uchar Function
-%706 = OpVariable %_ptr_Function_uchar Function
-%707 = OpVariable %_ptr_Function_uchar Function
-%708 = OpVariable %_ptr_Function_uchar Function
-%709 = OpVariable %_ptr_Function_uchar Function
-%710 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%711 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%712 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%713 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%714 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%715 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%716 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%717 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%718 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%719 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%720 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%721 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%722 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%723 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%724 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%725 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%726 = OpVariable %_ptr_Function_uchar Function
-%727 = OpVariable %_ptr_Function_uchar Function
-%728 = OpVariable %_ptr_Function_uchar Function
-%729 = OpVariable %_ptr_Function_uchar Function
-%730 = OpVariable %_ptr_Function_uchar Function
-%731 = OpVariable %_ptr_Function_uchar Function
-%732 = OpVariable %_ptr_Function_uchar Function
-%733 = OpVariable %_ptr_Function_uchar Function
-%734 = OpVariable %_ptr_Function_uchar Function
-%735 = OpVariable %_ptr_Function_uchar Function
-%736 = OpVariable %_ptr_Function_uchar Function
-%737 = OpVariable %_ptr_Function_uchar Function
-%738 = OpVariable %_ptr_Function_uchar Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_bool Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_bool Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_ulong Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_ulong Function
+%235 = OpVariable %_ptr_Function_bool Function
+%236 = OpVariable %_ptr_Function_ulong Function
+%237 = OpVariable %_ptr_Function_ulong Function
+%238 = OpVariable %_ptr_Function_ulong Function
+%239 = OpVariable %_ptr_Function_ulong Function
+%240 = OpVariable %_ptr_Function_ulong Function
+%241 = OpVariable %_ptr_Function_ulong Function
+%242 = OpVariable %_ptr_Function_ulong Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_ulong Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+%251 = OpVariable %_ptr_Function_ulong Function
+%252 = OpVariable %_ptr_Function_ulong Function
+%253 = OpVariable %_ptr_Function_ulong Function
+%254 = OpVariable %_ptr_Function_ulong Function
+%255 = OpVariable %_ptr_Function_bool Function
+%256 = OpVariable %_ptr_Function_ulong Function
+%257 = OpVariable %_ptr_Function_ulong Function
+%258 = OpVariable %_ptr_Function_ulong Function
+%259 = OpVariable %_ptr_Function_ulong Function
+%260 = OpVariable %_ptr_Function_ulong Function
+%261 = OpVariable %_ptr_Function_ulong Function
+%262 = OpVariable %_ptr_Function_ulong Function
+%263 = OpVariable %_ptr_Function_ulong Function
+%264 = OpVariable %_ptr_Function_ulong Function
+%265 = OpVariable %_ptr_Function_bool Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_bool Function
+%276 = OpVariable %_ptr_Function_ulong Function
+%277 = OpVariable %_ptr_Function_ulong Function
+%278 = OpVariable %_ptr_Function_ulong Function
+%279 = OpVariable %_ptr_Function_ulong Function
+%280 = OpVariable %_ptr_Function_ulong Function
+%281 = OpVariable %_ptr_Function_ulong Function
+%282 = OpVariable %_ptr_Function_ulong Function
+%283 = OpVariable %_ptr_Function_ulong Function
+%284 = OpVariable %_ptr_Function_ulong Function
+%285 = OpVariable %_ptr_Function_bool Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_ulong Function
+%288 = OpVariable %_ptr_Function_ulong Function
+%289 = OpVariable %_ptr_Function_ulong Function
+%290 = OpVariable %_ptr_Function_ulong Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_ulong Function
+%293 = OpVariable %_ptr_Function_ulong Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_bool Function
+%296 = OpVariable %_ptr_Function_ulong Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_ulong Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+%304 = OpVariable %_ptr_Function_ulong Function
+%305 = OpVariable %_ptr_Function_bool Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_ulong Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_bool Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+OpStore %143 %10
+OpStore %145 %11
+%324 = OpLoad %_arr_uchar_uint_16 %145
+%325 = OpCompositeExtract %uchar %324 0
+OpStore %147 %325
+OpBranch %13
+%13 = OpLabel
+%326 = OpLoad %uchar %147
+%327 = OpUConvert %ulong %326
+OpStore %163 %327
+OpBranch %15
+%15 = OpLabel
+%328 = OpLoad %ulong %143
+OpStore %172 %328
+OpStore %173 %ulong_0
+OpBranch %16
+%16 = OpLabel
+%330 = OpLoad %ulong %173
+%332 = OpULessThan %bool %330 %ulong_8
+OpStore %165 %332
+%333 = OpLoad %bool %165
+OpLoopMerge %18 %140 None
+OpBranchConditional %333 %17 %18
+%18 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%334 = OpLoad %_arr_uchar_uint_16 %145
+%335 = OpCompositeExtract %uchar %334 1
+OpStore %148 %335
+OpBranch %20
+%20 = OpLabel
+%336 = OpLoad %uchar %148
+%337 = OpUConvert %ulong %336
+OpStore %174 %337
+OpBranch %22
+%22 = OpLabel
+%338 = OpLoad %ulong %172
+OpStore %182 %338
+OpStore %183 %ulong_0
+OpBranch %23
+%23 = OpLabel
+%339 = OpLoad %ulong %183
+%340 = OpULessThan %bool %339 %ulong_8
+OpStore %175 %340
+%341 = OpLoad %bool %175
+OpLoopMerge %25 %139 None
+OpBranchConditional %341 %24 %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpBranch %21
+%21 = OpLabel
+%342 = OpLoad %_arr_uchar_uint_16 %145
+%343 = OpCompositeExtract %uchar %342 2
+OpStore %149 %343
+OpBranch %27
+%27 = OpLabel
+%344 = OpLoad %uchar %149
+%345 = OpUConvert %ulong %344
+OpStore %184 %345
+OpBranch %29
+%29 = OpLabel
+%346 = OpLoad %ulong %182
+OpStore %192 %346
+OpStore %193 %ulong_0
+OpBranch %30
+%30 = OpLabel
+%347 = OpLoad %ulong %193
+%348 = OpULessThan %bool %347 %ulong_8
+OpStore %185 %348
+%349 = OpLoad %bool %185
+OpLoopMerge %32 %138 None
+OpBranchConditional %349 %31 %32
+%32 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%350 = OpLoad %_arr_uchar_uint_16 %145
+%351 = OpCompositeExtract %uchar %350 3
+OpStore %150 %351
+OpBranch %34
+%34 = OpLabel
+%352 = OpLoad %uchar %150
+%353 = OpUConvert %ulong %352
+OpStore %194 %353
+OpBranch %36
+%36 = OpLabel
+%354 = OpLoad %ulong %192
+OpStore %202 %354
+OpStore %203 %ulong_0
+OpBranch %37
+%37 = OpLabel
+%355 = OpLoad %ulong %203
+%356 = OpULessThan %bool %355 %ulong_8
+OpStore %195 %356
+%357 = OpLoad %bool %195
+OpLoopMerge %39 %137 None
+OpBranchConditional %357 %38 %39
+%39 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%358 = OpLoad %_arr_uchar_uint_16 %145
+%359 = OpCompositeExtract %uchar %358 4
+OpStore %151 %359
+OpBranch %41
+%41 = OpLabel
+%360 = OpLoad %uchar %151
+%361 = OpUConvert %ulong %360
+OpStore %204 %361
+OpBranch %43
+%43 = OpLabel
+%362 = OpLoad %ulong %202
+OpStore %212 %362
+OpStore %213 %ulong_0
+OpBranch %44
+%44 = OpLabel
+%363 = OpLoad %ulong %213
+%364 = OpULessThan %bool %363 %ulong_8
+OpStore %205 %364
+%365 = OpLoad %bool %205
+OpLoopMerge %46 %136 None
+OpBranchConditional %365 %45 %46
+%46 = OpLabel
+OpBranch %47
+%47 = OpLabel
+OpBranch %42
+%42 = OpLabel
+%366 = OpLoad %_arr_uchar_uint_16 %145
+%367 = OpCompositeExtract %uchar %366 5
+OpStore %152 %367
+OpBranch %48
+%48 = OpLabel
+%368 = OpLoad %uchar %152
+%369 = OpUConvert %ulong %368
+OpStore %214 %369
+OpBranch %50
+%50 = OpLabel
+%370 = OpLoad %ulong %212
+OpStore %222 %370
+OpStore %223 %ulong_0
+OpBranch %51
+%51 = OpLabel
+%371 = OpLoad %ulong %223
+%372 = OpULessThan %bool %371 %ulong_8
+OpStore %215 %372
+%373 = OpLoad %bool %215
+OpLoopMerge %53 %135 None
+OpBranchConditional %373 %52 %53
+%53 = OpLabel
+OpBranch %54
+%54 = OpLabel
+OpBranch %49
+%49 = OpLabel
+%374 = OpLoad %_arr_uchar_uint_16 %145
+%375 = OpCompositeExtract %uchar %374 6
+OpStore %153 %375
+OpBranch %55
+%55 = OpLabel
+%376 = OpLoad %uchar %153
+%377 = OpUConvert %ulong %376
+OpStore %224 %377
+OpBranch %57
+%57 = OpLabel
+%378 = OpLoad %ulong %222
+OpStore %232 %378
+OpStore %233 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%379 = OpLoad %ulong %233
+%380 = OpULessThan %bool %379 %ulong_8
+OpStore %225 %380
+%381 = OpLoad %bool %225
+OpLoopMerge %60 %134 None
+OpBranchConditional %381 %59 %60
+%60 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %56
+%56 = OpLabel
+%382 = OpLoad %_arr_uchar_uint_16 %145
+%383 = OpCompositeExtract %uchar %382 7
+OpStore %154 %383
+OpBranch %62
+%62 = OpLabel
+%384 = OpLoad %uchar %154
+%385 = OpUConvert %ulong %384
+OpStore %234 %385
+OpBranch %64
+%64 = OpLabel
+%386 = OpLoad %ulong %232
+OpStore %242 %386
+OpStore %243 %ulong_0
+OpBranch %65
+%65 = OpLabel
+%387 = OpLoad %ulong %243
+%388 = OpULessThan %bool %387 %ulong_8
+OpStore %235 %388
+%389 = OpLoad %bool %235
+OpLoopMerge %67 %133 None
+OpBranchConditional %389 %66 %67
+%67 = OpLabel
+OpBranch %68
+%68 = OpLabel
+OpBranch %63
+%63 = OpLabel
+%390 = OpLoad %_arr_uchar_uint_16 %145
+%391 = OpCompositeExtract %uchar %390 8
+OpStore %155 %391
+OpBranch %69
+%69 = OpLabel
+%392 = OpLoad %uchar %155
+%393 = OpUConvert %ulong %392
+OpStore %244 %393
+OpBranch %71
+%71 = OpLabel
+%394 = OpLoad %ulong %242
+OpStore %252 %394
+OpStore %253 %ulong_0
+OpBranch %72
+%72 = OpLabel
+%395 = OpLoad %ulong %253
+%396 = OpULessThan %bool %395 %ulong_8
+OpStore %245 %396
+%397 = OpLoad %bool %245
+OpLoopMerge %74 %132 None
+OpBranchConditional %397 %73 %74
+%74 = OpLabel
+OpBranch %75
+%75 = OpLabel
+OpBranch %70
+%70 = OpLabel
+%398 = OpLoad %_arr_uchar_uint_16 %145
+%399 = OpCompositeExtract %uchar %398 9
+OpStore %156 %399
+OpBranch %76
+%76 = OpLabel
+%400 = OpLoad %uchar %156
+%401 = OpUConvert %ulong %400
+OpStore %254 %401
+OpBranch %78
+%78 = OpLabel
+%402 = OpLoad %ulong %252
+OpStore %262 %402
+OpStore %263 %ulong_0
+OpBranch %79
+%79 = OpLabel
+%403 = OpLoad %ulong %263
+%404 = OpULessThan %bool %403 %ulong_8
+OpStore %255 %404
+%405 = OpLoad %bool %255
+OpLoopMerge %81 %131 None
+OpBranchConditional %405 %80 %81
+%81 = OpLabel
+OpBranch %82
+%82 = OpLabel
+OpBranch %77
+%77 = OpLabel
+%406 = OpLoad %_arr_uchar_uint_16 %145
+%407 = OpCompositeExtract %uchar %406 10
+OpStore %157 %407
+OpBranch %83
+%83 = OpLabel
+%408 = OpLoad %uchar %157
+%409 = OpUConvert %ulong %408
+OpStore %264 %409
+OpBranch %85
+%85 = OpLabel
+%410 = OpLoad %ulong %262
+OpStore %272 %410
+OpStore %273 %ulong_0
+OpBranch %86
+%86 = OpLabel
+%411 = OpLoad %ulong %273
+%412 = OpULessThan %bool %411 %ulong_8
+OpStore %265 %412
+%413 = OpLoad %bool %265
+OpLoopMerge %88 %130 None
+OpBranchConditional %413 %87 %88
+%88 = OpLabel
+OpBranch %89
+%89 = OpLabel
+OpBranch %84
+%84 = OpLabel
+%414 = OpLoad %_arr_uchar_uint_16 %145
+%415 = OpCompositeExtract %uchar %414 11
+OpStore %158 %415
+OpBranch %90
+%90 = OpLabel
+%416 = OpLoad %uchar %158
+%417 = OpUConvert %ulong %416
+OpStore %274 %417
+OpBranch %92
+%92 = OpLabel
+%418 = OpLoad %ulong %272
+OpStore %282 %418
+OpStore %283 %ulong_0
+OpBranch %93
+%93 = OpLabel
+%419 = OpLoad %ulong %283
+%420 = OpULessThan %bool %419 %ulong_8
+OpStore %275 %420
+%421 = OpLoad %bool %275
+OpLoopMerge %95 %129 None
+OpBranchConditional %421 %94 %95
+%95 = OpLabel
+OpBranch %96
+%96 = OpLabel
+OpBranch %91
+%91 = OpLabel
+%422 = OpLoad %_arr_uchar_uint_16 %145
+%423 = OpCompositeExtract %uchar %422 12
+OpStore %159 %423
+OpBranch %97
+%97 = OpLabel
+%424 = OpLoad %uchar %159
+%425 = OpUConvert %ulong %424
+OpStore %284 %425
+OpBranch %99
+%99 = OpLabel
+%426 = OpLoad %ulong %282
+OpStore %292 %426
+OpStore %293 %ulong_0
+OpBranch %100
+%100 = OpLabel
+%427 = OpLoad %ulong %293
+%428 = OpULessThan %bool %427 %ulong_8
+OpStore %285 %428
+%429 = OpLoad %bool %285
+OpLoopMerge %102 %128 None
+OpBranchConditional %429 %101 %102
+%102 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%430 = OpLoad %_arr_uchar_uint_16 %145
+%431 = OpCompositeExtract %uchar %430 13
+OpStore %160 %431
+OpBranch %104
+%104 = OpLabel
+%432 = OpLoad %uchar %160
+%433 = OpUConvert %ulong %432
+OpStore %294 %433
+OpBranch %106
+%106 = OpLabel
+%434 = OpLoad %ulong %292
+OpStore %302 %434
+OpStore %303 %ulong_0
+OpBranch %107
+%107 = OpLabel
+%435 = OpLoad %ulong %303
+%436 = OpULessThan %bool %435 %ulong_8
+OpStore %295 %436
+%437 = OpLoad %bool %295
+OpLoopMerge %109 %127 None
+OpBranchConditional %437 %108 %109
+%109 = OpLabel
+OpBranch %110
+%110 = OpLabel
+OpBranch %105
+%105 = OpLabel
+%438 = OpLoad %_arr_uchar_uint_16 %145
+%439 = OpCompositeExtract %uchar %438 14
+OpStore %161 %439
+OpBranch %111
+%111 = OpLabel
+%440 = OpLoad %uchar %161
+%441 = OpUConvert %ulong %440
+OpStore %304 %441
+OpBranch %113
+%113 = OpLabel
+%442 = OpLoad %ulong %302
+OpStore %312 %442
+OpStore %313 %ulong_0
+OpBranch %114
+%114 = OpLabel
+%443 = OpLoad %ulong %313
+%444 = OpULessThan %bool %443 %ulong_8
+OpStore %305 %444
+%445 = OpLoad %bool %305
+OpLoopMerge %116 %126 None
+OpBranchConditional %445 %115 %116
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
+OpBranch %112
+%112 = OpLabel
+%446 = OpLoad %_arr_uchar_uint_16 %145
+%447 = OpCompositeExtract %uchar %446 15
+OpStore %162 %447
+OpBranch %118
+%118 = OpLabel
+%448 = OpLoad %uchar %162
+%449 = OpUConvert %ulong %448
+OpStore %314 %449
+OpBranch %120
+%120 = OpLabel
+%450 = OpLoad %ulong %312
+OpStore %322 %450
+OpStore %323 %ulong_0
+OpBranch %121
+%121 = OpLabel
+%451 = OpLoad %ulong %323
+%452 = OpULessThan %bool %451 %ulong_8
+OpStore %315 %452
+%453 = OpLoad %bool %315
+OpLoopMerge %123 %125 None
+OpBranchConditional %453 %122 %123
+%123 = OpLabel
+OpBranch %124
+%124 = OpLabel
+OpBranch %119
+%119 = OpLabel
+%454 = OpLoad %ulong %322
+OpReturnValue %454
+%122 = OpLabel
+%455 = OpLoad %ulong %323
+%456 = OpIMul %ulong %455 %ulong_8
+OpStore %316 %456
+%457 = OpLoad %ulong %314
+%458 = OpLoad %ulong %316
+%459 = OpShiftRightLogical %ulong %457 %458
+OpStore %317 %459
+%460 = OpLoad %ulong %317
+%462 = OpBitwiseAnd %ulong %460 %ulong_255
+OpStore %318 %462
+%463 = OpLoad %ulong %322
+%464 = OpLoad %ulong %318
+%465 = OpBitwiseXor %ulong %463 %464
+OpStore %319 %465
+%466 = OpLoad %ulong %319
+%468 = OpIMul %ulong %466 %ulong_1099511628211
+OpStore %320 %468
+%469 = OpLoad %ulong %323
+%471 = OpIAdd %ulong %469 %ulong_1
+OpStore %321 %471
+%472 = OpLoad %ulong %320
+OpStore %322 %472
+%473 = OpLoad %ulong %321
+OpStore %323 %473
+OpBranch %125
+%115 = OpLabel
+%474 = OpLoad %ulong %313
+%475 = OpIMul %ulong %474 %ulong_8
+OpStore %306 %475
+%476 = OpLoad %ulong %304
+%477 = OpLoad %ulong %306
+%478 = OpShiftRightLogical %ulong %476 %477
+OpStore %307 %478
+%479 = OpLoad %ulong %307
+%480 = OpBitwiseAnd %ulong %479 %ulong_255
+OpStore %308 %480
+%481 = OpLoad %ulong %312
+%482 = OpLoad %ulong %308
+%483 = OpBitwiseXor %ulong %481 %482
+OpStore %309 %483
+%484 = OpLoad %ulong %309
+%485 = OpIMul %ulong %484 %ulong_1099511628211
+OpStore %310 %485
+%486 = OpLoad %ulong %313
+%487 = OpIAdd %ulong %486 %ulong_1
+OpStore %311 %487
+%488 = OpLoad %ulong %310
+OpStore %312 %488
+%489 = OpLoad %ulong %311
+OpStore %313 %489
+OpBranch %126
+%108 = OpLabel
+%490 = OpLoad %ulong %303
+%491 = OpIMul %ulong %490 %ulong_8
+OpStore %296 %491
+%492 = OpLoad %ulong %294
+%493 = OpLoad %ulong %296
+%494 = OpShiftRightLogical %ulong %492 %493
+OpStore %297 %494
+%495 = OpLoad %ulong %297
+%496 = OpBitwiseAnd %ulong %495 %ulong_255
+OpStore %298 %496
+%497 = OpLoad %ulong %302
+%498 = OpLoad %ulong %298
+%499 = OpBitwiseXor %ulong %497 %498
+OpStore %299 %499
+%500 = OpLoad %ulong %299
+%501 = OpIMul %ulong %500 %ulong_1099511628211
+OpStore %300 %501
+%502 = OpLoad %ulong %303
+%503 = OpIAdd %ulong %502 %ulong_1
+OpStore %301 %503
+%504 = OpLoad %ulong %300
+OpStore %302 %504
+%505 = OpLoad %ulong %301
+OpStore %303 %505
+OpBranch %127
+%101 = OpLabel
+%506 = OpLoad %ulong %293
+%507 = OpIMul %ulong %506 %ulong_8
+OpStore %286 %507
+%508 = OpLoad %ulong %284
+%509 = OpLoad %ulong %286
+%510 = OpShiftRightLogical %ulong %508 %509
+OpStore %287 %510
+%511 = OpLoad %ulong %287
+%512 = OpBitwiseAnd %ulong %511 %ulong_255
+OpStore %288 %512
+%513 = OpLoad %ulong %292
+%514 = OpLoad %ulong %288
+%515 = OpBitwiseXor %ulong %513 %514
+OpStore %289 %515
+%516 = OpLoad %ulong %289
+%517 = OpIMul %ulong %516 %ulong_1099511628211
+OpStore %290 %517
+%518 = OpLoad %ulong %293
+%519 = OpIAdd %ulong %518 %ulong_1
+OpStore %291 %519
+%520 = OpLoad %ulong %290
+OpStore %292 %520
+%521 = OpLoad %ulong %291
+OpStore %293 %521
+OpBranch %128
+%94 = OpLabel
+%522 = OpLoad %ulong %283
+%523 = OpIMul %ulong %522 %ulong_8
+OpStore %276 %523
+%524 = OpLoad %ulong %274
+%525 = OpLoad %ulong %276
+%526 = OpShiftRightLogical %ulong %524 %525
+OpStore %277 %526
+%527 = OpLoad %ulong %277
+%528 = OpBitwiseAnd %ulong %527 %ulong_255
+OpStore %278 %528
+%529 = OpLoad %ulong %282
+%530 = OpLoad %ulong %278
+%531 = OpBitwiseXor %ulong %529 %530
+OpStore %279 %531
+%532 = OpLoad %ulong %279
+%533 = OpIMul %ulong %532 %ulong_1099511628211
+OpStore %280 %533
+%534 = OpLoad %ulong %283
+%535 = OpIAdd %ulong %534 %ulong_1
+OpStore %281 %535
+%536 = OpLoad %ulong %280
+OpStore %282 %536
+%537 = OpLoad %ulong %281
+OpStore %283 %537
+OpBranch %129
+%87 = OpLabel
+%538 = OpLoad %ulong %273
+%539 = OpIMul %ulong %538 %ulong_8
+OpStore %266 %539
+%540 = OpLoad %ulong %264
+%541 = OpLoad %ulong %266
+%542 = OpShiftRightLogical %ulong %540 %541
+OpStore %267 %542
+%543 = OpLoad %ulong %267
+%544 = OpBitwiseAnd %ulong %543 %ulong_255
+OpStore %268 %544
+%545 = OpLoad %ulong %272
+%546 = OpLoad %ulong %268
+%547 = OpBitwiseXor %ulong %545 %546
+OpStore %269 %547
+%548 = OpLoad %ulong %269
+%549 = OpIMul %ulong %548 %ulong_1099511628211
+OpStore %270 %549
+%550 = OpLoad %ulong %273
+%551 = OpIAdd %ulong %550 %ulong_1
+OpStore %271 %551
+%552 = OpLoad %ulong %270
+OpStore %272 %552
+%553 = OpLoad %ulong %271
+OpStore %273 %553
+OpBranch %130
+%80 = OpLabel
+%554 = OpLoad %ulong %263
+%555 = OpIMul %ulong %554 %ulong_8
+OpStore %256 %555
+%556 = OpLoad %ulong %254
+%557 = OpLoad %ulong %256
+%558 = OpShiftRightLogical %ulong %556 %557
+OpStore %257 %558
+%559 = OpLoad %ulong %257
+%560 = OpBitwiseAnd %ulong %559 %ulong_255
+OpStore %258 %560
+%561 = OpLoad %ulong %262
+%562 = OpLoad %ulong %258
+%563 = OpBitwiseXor %ulong %561 %562
+OpStore %259 %563
+%564 = OpLoad %ulong %259
+%565 = OpIMul %ulong %564 %ulong_1099511628211
+OpStore %260 %565
+%566 = OpLoad %ulong %263
+%567 = OpIAdd %ulong %566 %ulong_1
+OpStore %261 %567
+%568 = OpLoad %ulong %260
+OpStore %262 %568
+%569 = OpLoad %ulong %261
+OpStore %263 %569
+OpBranch %131
+%73 = OpLabel
+%570 = OpLoad %ulong %253
+%571 = OpIMul %ulong %570 %ulong_8
+OpStore %246 %571
+%572 = OpLoad %ulong %244
+%573 = OpLoad %ulong %246
+%574 = OpShiftRightLogical %ulong %572 %573
+OpStore %247 %574
+%575 = OpLoad %ulong %247
+%576 = OpBitwiseAnd %ulong %575 %ulong_255
+OpStore %248 %576
+%577 = OpLoad %ulong %252
+%578 = OpLoad %ulong %248
+%579 = OpBitwiseXor %ulong %577 %578
+OpStore %249 %579
+%580 = OpLoad %ulong %249
+%581 = OpIMul %ulong %580 %ulong_1099511628211
+OpStore %250 %581
+%582 = OpLoad %ulong %253
+%583 = OpIAdd %ulong %582 %ulong_1
+OpStore %251 %583
+%584 = OpLoad %ulong %250
+OpStore %252 %584
+%585 = OpLoad %ulong %251
+OpStore %253 %585
+OpBranch %132
+%66 = OpLabel
+%586 = OpLoad %ulong %243
+%587 = OpIMul %ulong %586 %ulong_8
+OpStore %236 %587
+%588 = OpLoad %ulong %234
+%589 = OpLoad %ulong %236
+%590 = OpShiftRightLogical %ulong %588 %589
+OpStore %237 %590
+%591 = OpLoad %ulong %237
+%592 = OpBitwiseAnd %ulong %591 %ulong_255
+OpStore %238 %592
+%593 = OpLoad %ulong %242
+%594 = OpLoad %ulong %238
+%595 = OpBitwiseXor %ulong %593 %594
+OpStore %239 %595
+%596 = OpLoad %ulong %239
+%597 = OpIMul %ulong %596 %ulong_1099511628211
+OpStore %240 %597
+%598 = OpLoad %ulong %243
+%599 = OpIAdd %ulong %598 %ulong_1
+OpStore %241 %599
+%600 = OpLoad %ulong %240
+OpStore %242 %600
+%601 = OpLoad %ulong %241
+OpStore %243 %601
+OpBranch %133
+%59 = OpLabel
+%602 = OpLoad %ulong %233
+%603 = OpIMul %ulong %602 %ulong_8
+OpStore %226 %603
+%604 = OpLoad %ulong %224
+%605 = OpLoad %ulong %226
+%606 = OpShiftRightLogical %ulong %604 %605
+OpStore %227 %606
+%607 = OpLoad %ulong %227
+%608 = OpBitwiseAnd %ulong %607 %ulong_255
+OpStore %228 %608
+%609 = OpLoad %ulong %232
+%610 = OpLoad %ulong %228
+%611 = OpBitwiseXor %ulong %609 %610
+OpStore %229 %611
+%612 = OpLoad %ulong %229
+%613 = OpIMul %ulong %612 %ulong_1099511628211
+OpStore %230 %613
+%614 = OpLoad %ulong %233
+%615 = OpIAdd %ulong %614 %ulong_1
+OpStore %231 %615
+%616 = OpLoad %ulong %230
+OpStore %232 %616
+%617 = OpLoad %ulong %231
+OpStore %233 %617
+OpBranch %134
+%52 = OpLabel
+%618 = OpLoad %ulong %223
+%619 = OpIMul %ulong %618 %ulong_8
+OpStore %216 %619
+%620 = OpLoad %ulong %214
+%621 = OpLoad %ulong %216
+%622 = OpShiftRightLogical %ulong %620 %621
+OpStore %217 %622
+%623 = OpLoad %ulong %217
+%624 = OpBitwiseAnd %ulong %623 %ulong_255
+OpStore %218 %624
+%625 = OpLoad %ulong %222
+%626 = OpLoad %ulong %218
+%627 = OpBitwiseXor %ulong %625 %626
+OpStore %219 %627
+%628 = OpLoad %ulong %219
+%629 = OpIMul %ulong %628 %ulong_1099511628211
+OpStore %220 %629
+%630 = OpLoad %ulong %223
+%631 = OpIAdd %ulong %630 %ulong_1
+OpStore %221 %631
+%632 = OpLoad %ulong %220
+OpStore %222 %632
+%633 = OpLoad %ulong %221
+OpStore %223 %633
+OpBranch %135
+%45 = OpLabel
+%634 = OpLoad %ulong %213
+%635 = OpIMul %ulong %634 %ulong_8
+OpStore %206 %635
+%636 = OpLoad %ulong %204
+%637 = OpLoad %ulong %206
+%638 = OpShiftRightLogical %ulong %636 %637
+OpStore %207 %638
+%639 = OpLoad %ulong %207
+%640 = OpBitwiseAnd %ulong %639 %ulong_255
+OpStore %208 %640
+%641 = OpLoad %ulong %212
+%642 = OpLoad %ulong %208
+%643 = OpBitwiseXor %ulong %641 %642
+OpStore %209 %643
+%644 = OpLoad %ulong %209
+%645 = OpIMul %ulong %644 %ulong_1099511628211
+OpStore %210 %645
+%646 = OpLoad %ulong %213
+%647 = OpIAdd %ulong %646 %ulong_1
+OpStore %211 %647
+%648 = OpLoad %ulong %210
+OpStore %212 %648
+%649 = OpLoad %ulong %211
+OpStore %213 %649
+OpBranch %136
+%38 = OpLabel
+%650 = OpLoad %ulong %203
+%651 = OpIMul %ulong %650 %ulong_8
+OpStore %196 %651
+%652 = OpLoad %ulong %194
+%653 = OpLoad %ulong %196
+%654 = OpShiftRightLogical %ulong %652 %653
+OpStore %197 %654
+%655 = OpLoad %ulong %197
+%656 = OpBitwiseAnd %ulong %655 %ulong_255
+OpStore %198 %656
+%657 = OpLoad %ulong %202
+%658 = OpLoad %ulong %198
+%659 = OpBitwiseXor %ulong %657 %658
+OpStore %199 %659
+%660 = OpLoad %ulong %199
+%661 = OpIMul %ulong %660 %ulong_1099511628211
+OpStore %200 %661
+%662 = OpLoad %ulong %203
+%663 = OpIAdd %ulong %662 %ulong_1
+OpStore %201 %663
+%664 = OpLoad %ulong %200
+OpStore %202 %664
+%665 = OpLoad %ulong %201
+OpStore %203 %665
+OpBranch %137
+%31 = OpLabel
+%666 = OpLoad %ulong %193
+%667 = OpIMul %ulong %666 %ulong_8
+OpStore %186 %667
+%668 = OpLoad %ulong %184
+%669 = OpLoad %ulong %186
+%670 = OpShiftRightLogical %ulong %668 %669
+OpStore %187 %670
+%671 = OpLoad %ulong %187
+%672 = OpBitwiseAnd %ulong %671 %ulong_255
+OpStore %188 %672
+%673 = OpLoad %ulong %192
+%674 = OpLoad %ulong %188
+%675 = OpBitwiseXor %ulong %673 %674
+OpStore %189 %675
+%676 = OpLoad %ulong %189
+%677 = OpIMul %ulong %676 %ulong_1099511628211
+OpStore %190 %677
+%678 = OpLoad %ulong %193
+%679 = OpIAdd %ulong %678 %ulong_1
+OpStore %191 %679
+%680 = OpLoad %ulong %190
+OpStore %192 %680
+%681 = OpLoad %ulong %191
+OpStore %193 %681
+OpBranch %138
+%24 = OpLabel
+%682 = OpLoad %ulong %183
+%683 = OpIMul %ulong %682 %ulong_8
+OpStore %176 %683
+%684 = OpLoad %ulong %174
+%685 = OpLoad %ulong %176
+%686 = OpShiftRightLogical %ulong %684 %685
+OpStore %177 %686
+%687 = OpLoad %ulong %177
+%688 = OpBitwiseAnd %ulong %687 %ulong_255
+OpStore %178 %688
+%689 = OpLoad %ulong %182
+%690 = OpLoad %ulong %178
+%691 = OpBitwiseXor %ulong %689 %690
+OpStore %179 %691
+%692 = OpLoad %ulong %179
+%693 = OpIMul %ulong %692 %ulong_1099511628211
+OpStore %180 %693
+%694 = OpLoad %ulong %183
+%695 = OpIAdd %ulong %694 %ulong_1
+OpStore %181 %695
+%696 = OpLoad %ulong %180
+OpStore %182 %696
+%697 = OpLoad %ulong %181
+OpStore %183 %697
+OpBranch %139
+%17 = OpLabel
+%698 = OpLoad %ulong %173
+%699 = OpIMul %ulong %698 %ulong_8
+OpStore %166 %699
+%700 = OpLoad %ulong %163
+%701 = OpLoad %ulong %166
+%702 = OpShiftRightLogical %ulong %700 %701
+OpStore %167 %702
+%703 = OpLoad %ulong %167
+%704 = OpBitwiseAnd %ulong %703 %ulong_255
+OpStore %168 %704
+%705 = OpLoad %ulong %172
+%706 = OpLoad %ulong %168
+%707 = OpBitwiseXor %ulong %705 %706
+OpStore %169 %707
+%708 = OpLoad %ulong %169
+%709 = OpIMul %ulong %708 %ulong_1099511628211
+OpStore %170 %709
+%710 = OpLoad %ulong %173
+%711 = OpIAdd %ulong %710 %ulong_1
+OpStore %171 %711
+%712 = OpLoad %ulong %170
+OpStore %172 %712
+%713 = OpLoad %ulong %171
+OpStore %173 %713
+OpBranch %140
+%125 = OpLabel
+OpBranch %121
+%126 = OpLabel
+OpBranch %114
+%127 = OpLabel
+OpBranch %107
+%128 = OpLabel
+OpBranch %100
+%129 = OpLabel
+OpBranch %93
+%130 = OpLabel
+OpBranch %86
+%131 = OpLabel
+OpBranch %79
+%132 = OpLabel
+OpBranch %72
+%133 = OpLabel
+OpBranch %65
+%134 = OpLabel
+OpBranch %58
+%135 = OpLabel
+OpBranch %51
+%136 = OpLabel
+OpBranch %44
+%137 = OpLabel
+OpBranch %37
+%138 = OpLabel
+OpBranch %30
+%139 = OpLabel
+OpBranch %23
+%140 = OpLabel
+OpBranch %16
+OpFunctionEnd
+%2 = OpFunction %ulong None %714
+%715 = OpFunctionParameter %ulong
+%716 = OpLabel
+%734 = OpVariable %_ptr_Function__arr__arr_uchar_uint_16_uint_4 Function
+%737 = OpVariable %_ptr_Function__struct_735 Function
+%738 = OpVariable %_ptr_Function_ulong Function
 %739 = OpVariable %_ptr_Function_uchar Function
-%740 = OpVariable %_ptr_Function_uchar Function
-%741 = OpVariable %_ptr_Function_uchar Function
-%742 = OpVariable %_ptr_Function_uchar Function
-%743 = OpVariable %_ptr_Function_uchar Function
+%740 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%741 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%742 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%743 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %744 = OpVariable %_ptr_Function_uchar Function
 %745 = OpVariable %_ptr_Function_uchar Function
-%746 = OpVariable %_ptr_Function_uchar Function
+%746 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %747 = OpVariable %_ptr_Function_uchar Function
 %748 = OpVariable %_ptr_Function_uchar Function
-%749 = OpVariable %_ptr_Function_uchar Function
+%749 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %750 = OpVariable %_ptr_Function_uchar Function
 %751 = OpVariable %_ptr_Function_uchar Function
-%752 = OpVariable %_ptr_Function_uchar Function
+%752 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %753 = OpVariable %_ptr_Function_uchar Function
 %754 = OpVariable %_ptr_Function_uchar Function
-%755 = OpVariable %_ptr_Function_uchar Function
-%756 = OpVariable %_ptr_Function_uchar Function
-%757 = OpVariable %_ptr_Function_uchar Function
-%758 = OpVariable %_ptr_Function_uchar Function
-%759 = OpVariable %_ptr_Function_uchar Function
-%760 = OpVariable %_ptr_Function_uchar Function
-%761 = OpVariable %_ptr_Function_uchar Function
-%762 = OpVariable %_ptr_Function_uchar Function
-%763 = OpVariable %_ptr_Function_uchar Function
-%764 = OpVariable %_ptr_Function_uchar Function
-%765 = OpVariable %_ptr_Function_uchar Function
-%766 = OpVariable %_ptr_Function_uchar Function
-%767 = OpVariable %_ptr_Function_uchar Function
-%768 = OpVariable %_ptr_Function_uchar Function
-%769 = OpVariable %_ptr_Function_uchar Function
-%770 = OpVariable %_ptr_Function_uchar Function
-%771 = OpVariable %_ptr_Function_uchar Function
-%772 = OpVariable %_ptr_Function_uchar Function
-%773 = OpVariable %_ptr_Function_uchar Function
-%774 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%775 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%776 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%777 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%778 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%779 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%755 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_bool Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_bool Function
 %780 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%781 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%782 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_ulong Function
 %783 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%784 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%785 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%785 = OpVariable %_ptr_Function_uint Function
 %786 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%787 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%788 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%789 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%790 = OpVariable %_ptr_Function_uchar Function
-%791 = OpVariable %_ptr_Function_uchar Function
-%792 = OpVariable %_ptr_Function_uchar Function
-%793 = OpVariable %_ptr_Function_uchar Function
-%794 = OpVariable %_ptr_Function_uchar Function
-%795 = OpVariable %_ptr_Function_uchar Function
-%796 = OpVariable %_ptr_Function_uchar Function
-%797 = OpVariable %_ptr_Function_uchar Function
-%798 = OpVariable %_ptr_Function_uchar Function
-%799 = OpVariable %_ptr_Function_uchar Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_uint Function
+%789 = OpVariable %_ptr_Function_ulong Function
+%790 = OpVariable %_ptr_Function_ulong Function
+%791 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%792 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%793 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%794 = OpVariable %_ptr_Function_ulong Function
+%795 = OpVariable %_ptr_Function_ulong Function
+%796 = OpVariable %_ptr_Function_ulong Function
+%797 = OpVariable %_ptr_Function_ulong Function
+%798 = OpVariable %_ptr_Function_ulong Function
+%799 = OpVariable %_ptr_Function_ulong Function
 %800 = OpVariable %_ptr_Function_uchar Function
 %801 = OpVariable %_ptr_Function_uchar Function
 %802 = OpVariable %_ptr_Function_uchar Function
@@ -927,32 +1236,32 @@ OpFunctionEnd
 %835 = OpVariable %_ptr_Function_uchar Function
 %836 = OpVariable %_ptr_Function_uchar Function
 %837 = OpVariable %_ptr_Function_uchar Function
-%838 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%839 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%840 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%841 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%842 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%843 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%844 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%845 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%846 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%847 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%838 = OpVariable %_ptr_Function_uchar Function
+%839 = OpVariable %_ptr_Function_uchar Function
+%840 = OpVariable %_ptr_Function_uchar Function
+%841 = OpVariable %_ptr_Function_uchar Function
+%842 = OpVariable %_ptr_Function_uchar Function
+%843 = OpVariable %_ptr_Function_uchar Function
+%844 = OpVariable %_ptr_Function_uchar Function
+%845 = OpVariable %_ptr_Function_uchar Function
+%846 = OpVariable %_ptr_Function_uchar Function
+%847 = OpVariable %_ptr_Function_uchar Function
 %848 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %849 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %850 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %851 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %852 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %853 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%854 = OpVariable %_ptr_Function_uchar Function
-%855 = OpVariable %_ptr_Function_uchar Function
-%856 = OpVariable %_ptr_Function_uchar Function
-%857 = OpVariable %_ptr_Function_uchar Function
-%858 = OpVariable %_ptr_Function_uchar Function
-%859 = OpVariable %_ptr_Function_uchar Function
-%860 = OpVariable %_ptr_Function_uchar Function
-%861 = OpVariable %_ptr_Function_uchar Function
-%862 = OpVariable %_ptr_Function_uchar Function
-%863 = OpVariable %_ptr_Function_uchar Function
+%854 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%855 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%856 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%857 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%858 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%859 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%860 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%861 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%862 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%863 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %864 = OpVariable %_ptr_Function_uchar Function
 %865 = OpVariable %_ptr_Function_uchar Function
 %866 = OpVariable %_ptr_Function_uchar Function
@@ -991,32 +1300,32 @@ OpFunctionEnd
 %899 = OpVariable %_ptr_Function_uchar Function
 %900 = OpVariable %_ptr_Function_uchar Function
 %901 = OpVariable %_ptr_Function_uchar Function
-%902 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%903 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%904 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%905 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%906 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%907 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%908 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%909 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%910 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%911 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%902 = OpVariable %_ptr_Function_uchar Function
+%903 = OpVariable %_ptr_Function_uchar Function
+%904 = OpVariable %_ptr_Function_uchar Function
+%905 = OpVariable %_ptr_Function_uchar Function
+%906 = OpVariable %_ptr_Function_uchar Function
+%907 = OpVariable %_ptr_Function_uchar Function
+%908 = OpVariable %_ptr_Function_uchar Function
+%909 = OpVariable %_ptr_Function_uchar Function
+%910 = OpVariable %_ptr_Function_uchar Function
+%911 = OpVariable %_ptr_Function_uchar Function
 %912 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %913 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %914 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %915 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %916 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %917 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%918 = OpVariable %_ptr_Function_uchar Function
-%919 = OpVariable %_ptr_Function_uchar Function
-%920 = OpVariable %_ptr_Function_uchar Function
-%921 = OpVariable %_ptr_Function_uchar Function
-%922 = OpVariable %_ptr_Function_uchar Function
-%923 = OpVariable %_ptr_Function_uchar Function
-%924 = OpVariable %_ptr_Function_uchar Function
-%925 = OpVariable %_ptr_Function_uchar Function
-%926 = OpVariable %_ptr_Function_uchar Function
-%927 = OpVariable %_ptr_Function_uchar Function
+%918 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%919 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%920 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%921 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%922 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%923 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%924 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%925 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%926 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%927 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %928 = OpVariable %_ptr_Function_uchar Function
 %929 = OpVariable %_ptr_Function_uchar Function
 %930 = OpVariable %_ptr_Function_uchar Function
@@ -1055,32 +1364,32 @@ OpFunctionEnd
 %963 = OpVariable %_ptr_Function_uchar Function
 %964 = OpVariable %_ptr_Function_uchar Function
 %965 = OpVariable %_ptr_Function_uchar Function
-%966 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%967 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%968 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%969 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%970 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%971 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%972 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%973 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%974 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%975 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%966 = OpVariable %_ptr_Function_uchar Function
+%967 = OpVariable %_ptr_Function_uchar Function
+%968 = OpVariable %_ptr_Function_uchar Function
+%969 = OpVariable %_ptr_Function_uchar Function
+%970 = OpVariable %_ptr_Function_uchar Function
+%971 = OpVariable %_ptr_Function_uchar Function
+%972 = OpVariable %_ptr_Function_uchar Function
+%973 = OpVariable %_ptr_Function_uchar Function
+%974 = OpVariable %_ptr_Function_uchar Function
+%975 = OpVariable %_ptr_Function_uchar Function
 %976 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %977 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %978 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %979 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %980 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %981 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%982 = OpVariable %_ptr_Function_uchar Function
-%983 = OpVariable %_ptr_Function_uchar Function
-%984 = OpVariable %_ptr_Function_uchar Function
-%985 = OpVariable %_ptr_Function_uchar Function
-%986 = OpVariable %_ptr_Function_uchar Function
-%987 = OpVariable %_ptr_Function_uchar Function
-%988 = OpVariable %_ptr_Function_uchar Function
-%989 = OpVariable %_ptr_Function_uchar Function
-%990 = OpVariable %_ptr_Function_uchar Function
-%991 = OpVariable %_ptr_Function_uchar Function
+%982 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%983 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%984 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%985 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%986 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%987 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%988 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%989 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%990 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%991 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %992 = OpVariable %_ptr_Function_uchar Function
 %993 = OpVariable %_ptr_Function_uchar Function
 %994 = OpVariable %_ptr_Function_uchar Function
@@ -1103,22 +1412,22 @@ OpFunctionEnd
 %1011 = OpVariable %_ptr_Function_uchar Function
 %1012 = OpVariable %_ptr_Function_uchar Function
 %1013 = OpVariable %_ptr_Function_uchar Function
-%1014 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1015 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1016 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1017 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1018 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1019 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1020 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1021 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1022 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1023 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1024 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1025 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1026 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1027 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1028 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1029 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1014 = OpVariable %_ptr_Function_uchar Function
+%1015 = OpVariable %_ptr_Function_uchar Function
+%1016 = OpVariable %_ptr_Function_uchar Function
+%1017 = OpVariable %_ptr_Function_uchar Function
+%1018 = OpVariable %_ptr_Function_uchar Function
+%1019 = OpVariable %_ptr_Function_uchar Function
+%1020 = OpVariable %_ptr_Function_uchar Function
+%1021 = OpVariable %_ptr_Function_uchar Function
+%1022 = OpVariable %_ptr_Function_uchar Function
+%1023 = OpVariable %_ptr_Function_uchar Function
+%1024 = OpVariable %_ptr_Function_uchar Function
+%1025 = OpVariable %_ptr_Function_uchar Function
+%1026 = OpVariable %_ptr_Function_uchar Function
+%1027 = OpVariable %_ptr_Function_uchar Function
+%1028 = OpVariable %_ptr_Function_uchar Function
+%1029 = OpVariable %_ptr_Function_uchar Function
 %1030 = OpVariable %_ptr_Function_uchar Function
 %1031 = OpVariable %_ptr_Function_uchar Function
 %1032 = OpVariable %_ptr_Function_uchar Function
@@ -1129,44 +1438,44 @@ OpFunctionEnd
 %1037 = OpVariable %_ptr_Function_uchar Function
 %1038 = OpVariable %_ptr_Function_uchar Function
 %1039 = OpVariable %_ptr_Function_uchar Function
-%1040 = OpVariable %_ptr_Function_uchar Function
-%1041 = OpVariable %_ptr_Function_uchar Function
-%1042 = OpVariable %_ptr_Function_uchar Function
-%1043 = OpVariable %_ptr_Function_uchar Function
-%1044 = OpVariable %_ptr_Function_uchar Function
-%1045 = OpVariable %_ptr_Function_uchar Function
-%1046 = OpVariable %_ptr_Function_uchar Function
-%1047 = OpVariable %_ptr_Function_uchar Function
-%1048 = OpVariable %_ptr_Function_uchar Function
-%1049 = OpVariable %_ptr_Function_uchar Function
-%1050 = OpVariable %_ptr_Function_uchar Function
-%1051 = OpVariable %_ptr_Function_uchar Function
-%1052 = OpVariable %_ptr_Function_uchar Function
-%1053 = OpVariable %_ptr_Function_uchar Function
-%1054 = OpVariable %_ptr_Function_uchar Function
-%1055 = OpVariable %_ptr_Function_uchar Function
+%1040 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1041 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1042 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1043 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1044 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1045 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1046 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1047 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1048 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1049 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1050 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1051 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1052 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1053 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1054 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1055 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1056 = OpVariable %_ptr_Function_uchar Function
 %1057 = OpVariable %_ptr_Function_uchar Function
 %1058 = OpVariable %_ptr_Function_uchar Function
 %1059 = OpVariable %_ptr_Function_uchar Function
 %1060 = OpVariable %_ptr_Function_uchar Function
 %1061 = OpVariable %_ptr_Function_uchar Function
-%1062 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1063 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1064 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1065 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1066 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1067 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1068 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1069 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1070 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1071 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1072 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1073 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1074 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1075 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1076 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1077 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1062 = OpVariable %_ptr_Function_uchar Function
+%1063 = OpVariable %_ptr_Function_uchar Function
+%1064 = OpVariable %_ptr_Function_uchar Function
+%1065 = OpVariable %_ptr_Function_uchar Function
+%1066 = OpVariable %_ptr_Function_uchar Function
+%1067 = OpVariable %_ptr_Function_uchar Function
+%1068 = OpVariable %_ptr_Function_uchar Function
+%1069 = OpVariable %_ptr_Function_uchar Function
+%1070 = OpVariable %_ptr_Function_uchar Function
+%1071 = OpVariable %_ptr_Function_uchar Function
+%1072 = OpVariable %_ptr_Function_uchar Function
+%1073 = OpVariable %_ptr_Function_uchar Function
+%1074 = OpVariable %_ptr_Function_uchar Function
+%1075 = OpVariable %_ptr_Function_uchar Function
+%1076 = OpVariable %_ptr_Function_uchar Function
+%1077 = OpVariable %_ptr_Function_uchar Function
 %1078 = OpVariable %_ptr_Function_uchar Function
 %1079 = OpVariable %_ptr_Function_uchar Function
 %1080 = OpVariable %_ptr_Function_uchar Function
@@ -1193,44 +1502,44 @@ OpFunctionEnd
 %1101 = OpVariable %_ptr_Function_uchar Function
 %1102 = OpVariable %_ptr_Function_uchar Function
 %1103 = OpVariable %_ptr_Function_uchar Function
-%1104 = OpVariable %_ptr_Function_uchar Function
-%1105 = OpVariable %_ptr_Function_uchar Function
-%1106 = OpVariable %_ptr_Function_uchar Function
-%1107 = OpVariable %_ptr_Function_uchar Function
-%1108 = OpVariable %_ptr_Function_uchar Function
-%1109 = OpVariable %_ptr_Function_uchar Function
-%1110 = OpVariable %_ptr_Function_uchar Function
-%1111 = OpVariable %_ptr_Function_uchar Function
-%1112 = OpVariable %_ptr_Function_uchar Function
-%1113 = OpVariable %_ptr_Function_uchar Function
-%1114 = OpVariable %_ptr_Function_uchar Function
-%1115 = OpVariable %_ptr_Function_uchar Function
-%1116 = OpVariable %_ptr_Function_uchar Function
-%1117 = OpVariable %_ptr_Function_uchar Function
-%1118 = OpVariable %_ptr_Function_uchar Function
-%1119 = OpVariable %_ptr_Function_uchar Function
+%1104 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1105 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1106 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1107 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1108 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1109 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1110 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1111 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1112 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1113 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1114 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1115 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1116 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1117 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1118 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1119 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1120 = OpVariable %_ptr_Function_uchar Function
 %1121 = OpVariable %_ptr_Function_uchar Function
 %1122 = OpVariable %_ptr_Function_uchar Function
 %1123 = OpVariable %_ptr_Function_uchar Function
 %1124 = OpVariable %_ptr_Function_uchar Function
 %1125 = OpVariable %_ptr_Function_uchar Function
-%1126 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1127 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1128 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1129 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1130 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1131 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1132 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1133 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1134 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1135 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1136 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1137 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1138 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1139 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1140 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1141 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1126 = OpVariable %_ptr_Function_uchar Function
+%1127 = OpVariable %_ptr_Function_uchar Function
+%1128 = OpVariable %_ptr_Function_uchar Function
+%1129 = OpVariable %_ptr_Function_uchar Function
+%1130 = OpVariable %_ptr_Function_uchar Function
+%1131 = OpVariable %_ptr_Function_uchar Function
+%1132 = OpVariable %_ptr_Function_uchar Function
+%1133 = OpVariable %_ptr_Function_uchar Function
+%1134 = OpVariable %_ptr_Function_uchar Function
+%1135 = OpVariable %_ptr_Function_uchar Function
+%1136 = OpVariable %_ptr_Function_uchar Function
+%1137 = OpVariable %_ptr_Function_uchar Function
+%1138 = OpVariable %_ptr_Function_uchar Function
+%1139 = OpVariable %_ptr_Function_uchar Function
+%1140 = OpVariable %_ptr_Function_uchar Function
+%1141 = OpVariable %_ptr_Function_uchar Function
 %1142 = OpVariable %_ptr_Function_uchar Function
 %1143 = OpVariable %_ptr_Function_uchar Function
 %1144 = OpVariable %_ptr_Function_uchar Function
@@ -1257,44 +1566,44 @@ OpFunctionEnd
 %1165 = OpVariable %_ptr_Function_uchar Function
 %1166 = OpVariable %_ptr_Function_uchar Function
 %1167 = OpVariable %_ptr_Function_uchar Function
-%1168 = OpVariable %_ptr_Function_uchar Function
-%1169 = OpVariable %_ptr_Function_uchar Function
-%1170 = OpVariable %_ptr_Function_uchar Function
-%1171 = OpVariable %_ptr_Function_uchar Function
-%1172 = OpVariable %_ptr_Function_uchar Function
-%1173 = OpVariable %_ptr_Function_uchar Function
-%1174 = OpVariable %_ptr_Function_uchar Function
-%1175 = OpVariable %_ptr_Function_uchar Function
-%1176 = OpVariable %_ptr_Function_uchar Function
-%1177 = OpVariable %_ptr_Function_uchar Function
-%1178 = OpVariable %_ptr_Function_uchar Function
-%1179 = OpVariable %_ptr_Function_uchar Function
-%1180 = OpVariable %_ptr_Function_uchar Function
-%1181 = OpVariable %_ptr_Function_uchar Function
-%1182 = OpVariable %_ptr_Function_uchar Function
-%1183 = OpVariable %_ptr_Function_uchar Function
+%1168 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1169 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1170 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1171 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1172 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1173 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1174 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1175 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1176 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1177 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1178 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1179 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1180 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1181 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1182 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1183 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1184 = OpVariable %_ptr_Function_uchar Function
 %1185 = OpVariable %_ptr_Function_uchar Function
 %1186 = OpVariable %_ptr_Function_uchar Function
 %1187 = OpVariable %_ptr_Function_uchar Function
 %1188 = OpVariable %_ptr_Function_uchar Function
 %1189 = OpVariable %_ptr_Function_uchar Function
-%1190 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1191 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1192 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1193 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1194 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1195 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1196 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1197 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1198 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1199 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1200 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1201 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1202 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1203 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1204 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1205 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1190 = OpVariable %_ptr_Function_uchar Function
+%1191 = OpVariable %_ptr_Function_uchar Function
+%1192 = OpVariable %_ptr_Function_uchar Function
+%1193 = OpVariable %_ptr_Function_uchar Function
+%1194 = OpVariable %_ptr_Function_uchar Function
+%1195 = OpVariable %_ptr_Function_uchar Function
+%1196 = OpVariable %_ptr_Function_uchar Function
+%1197 = OpVariable %_ptr_Function_uchar Function
+%1198 = OpVariable %_ptr_Function_uchar Function
+%1199 = OpVariable %_ptr_Function_uchar Function
+%1200 = OpVariable %_ptr_Function_uchar Function
+%1201 = OpVariable %_ptr_Function_uchar Function
+%1202 = OpVariable %_ptr_Function_uchar Function
+%1203 = OpVariable %_ptr_Function_uchar Function
+%1204 = OpVariable %_ptr_Function_uchar Function
+%1205 = OpVariable %_ptr_Function_uchar Function
 %1206 = OpVariable %_ptr_Function_uchar Function
 %1207 = OpVariable %_ptr_Function_uchar Function
 %1208 = OpVariable %_ptr_Function_uchar Function
@@ -1321,44 +1630,44 @@ OpFunctionEnd
 %1229 = OpVariable %_ptr_Function_uchar Function
 %1230 = OpVariable %_ptr_Function_uchar Function
 %1231 = OpVariable %_ptr_Function_uchar Function
-%1232 = OpVariable %_ptr_Function_uchar Function
-%1233 = OpVariable %_ptr_Function_uchar Function
-%1234 = OpVariable %_ptr_Function_uchar Function
-%1235 = OpVariable %_ptr_Function_uchar Function
-%1236 = OpVariable %_ptr_Function_uchar Function
-%1237 = OpVariable %_ptr_Function_uchar Function
-%1238 = OpVariable %_ptr_Function_uchar Function
-%1239 = OpVariable %_ptr_Function_uchar Function
-%1240 = OpVariable %_ptr_Function_uchar Function
-%1241 = OpVariable %_ptr_Function_uchar Function
-%1242 = OpVariable %_ptr_Function_uchar Function
-%1243 = OpVariable %_ptr_Function_uchar Function
-%1244 = OpVariable %_ptr_Function_uchar Function
-%1245 = OpVariable %_ptr_Function_uchar Function
-%1246 = OpVariable %_ptr_Function_uchar Function
-%1247 = OpVariable %_ptr_Function_uchar Function
+%1232 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1233 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1234 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1235 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1236 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1237 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1238 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1239 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1240 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1241 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1242 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1243 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1244 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1245 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1246 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1247 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1248 = OpVariable %_ptr_Function_uchar Function
 %1249 = OpVariable %_ptr_Function_uchar Function
 %1250 = OpVariable %_ptr_Function_uchar Function
 %1251 = OpVariable %_ptr_Function_uchar Function
 %1252 = OpVariable %_ptr_Function_uchar Function
 %1253 = OpVariable %_ptr_Function_uchar Function
-%1254 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1255 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1256 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1257 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1258 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1259 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1260 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1261 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1262 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1263 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1264 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1265 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1266 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1267 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1268 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1269 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1254 = OpVariable %_ptr_Function_uchar Function
+%1255 = OpVariable %_ptr_Function_uchar Function
+%1256 = OpVariable %_ptr_Function_uchar Function
+%1257 = OpVariable %_ptr_Function_uchar Function
+%1258 = OpVariable %_ptr_Function_uchar Function
+%1259 = OpVariable %_ptr_Function_uchar Function
+%1260 = OpVariable %_ptr_Function_uchar Function
+%1261 = OpVariable %_ptr_Function_uchar Function
+%1262 = OpVariable %_ptr_Function_uchar Function
+%1263 = OpVariable %_ptr_Function_uchar Function
+%1264 = OpVariable %_ptr_Function_uchar Function
+%1265 = OpVariable %_ptr_Function_uchar Function
+%1266 = OpVariable %_ptr_Function_uchar Function
+%1267 = OpVariable %_ptr_Function_uchar Function
+%1268 = OpVariable %_ptr_Function_uchar Function
+%1269 = OpVariable %_ptr_Function_uchar Function
 %1270 = OpVariable %_ptr_Function_uchar Function
 %1271 = OpVariable %_ptr_Function_uchar Function
 %1272 = OpVariable %_ptr_Function_uchar Function
@@ -1385,44 +1694,44 @@ OpFunctionEnd
 %1293 = OpVariable %_ptr_Function_uchar Function
 %1294 = OpVariable %_ptr_Function_uchar Function
 %1295 = OpVariable %_ptr_Function_uchar Function
-%1296 = OpVariable %_ptr_Function_uchar Function
-%1297 = OpVariable %_ptr_Function_uchar Function
-%1298 = OpVariable %_ptr_Function_uchar Function
-%1299 = OpVariable %_ptr_Function_uchar Function
-%1300 = OpVariable %_ptr_Function_uchar Function
-%1301 = OpVariable %_ptr_Function_uchar Function
-%1302 = OpVariable %_ptr_Function_uchar Function
-%1303 = OpVariable %_ptr_Function_uchar Function
-%1304 = OpVariable %_ptr_Function_uchar Function
-%1305 = OpVariable %_ptr_Function_uchar Function
-%1306 = OpVariable %_ptr_Function_uchar Function
-%1307 = OpVariable %_ptr_Function_uchar Function
-%1308 = OpVariable %_ptr_Function_uchar Function
-%1309 = OpVariable %_ptr_Function_uchar Function
-%1310 = OpVariable %_ptr_Function_uchar Function
-%1311 = OpVariable %_ptr_Function_uchar Function
+%1296 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1297 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1298 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1299 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1300 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1301 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1302 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1303 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1304 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1305 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1306 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1307 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1308 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1309 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1310 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1311 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1312 = OpVariable %_ptr_Function_uchar Function
 %1313 = OpVariable %_ptr_Function_uchar Function
 %1314 = OpVariable %_ptr_Function_uchar Function
 %1315 = OpVariable %_ptr_Function_uchar Function
 %1316 = OpVariable %_ptr_Function_uchar Function
 %1317 = OpVariable %_ptr_Function_uchar Function
-%1318 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1319 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1320 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1321 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1322 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1323 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1324 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1325 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1326 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1327 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1328 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1329 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1330 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1331 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1332 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1333 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1318 = OpVariable %_ptr_Function_uchar Function
+%1319 = OpVariable %_ptr_Function_uchar Function
+%1320 = OpVariable %_ptr_Function_uchar Function
+%1321 = OpVariable %_ptr_Function_uchar Function
+%1322 = OpVariable %_ptr_Function_uchar Function
+%1323 = OpVariable %_ptr_Function_uchar Function
+%1324 = OpVariable %_ptr_Function_uchar Function
+%1325 = OpVariable %_ptr_Function_uchar Function
+%1326 = OpVariable %_ptr_Function_uchar Function
+%1327 = OpVariable %_ptr_Function_uchar Function
+%1328 = OpVariable %_ptr_Function_uchar Function
+%1329 = OpVariable %_ptr_Function_uchar Function
+%1330 = OpVariable %_ptr_Function_uchar Function
+%1331 = OpVariable %_ptr_Function_uchar Function
+%1332 = OpVariable %_ptr_Function_uchar Function
+%1333 = OpVariable %_ptr_Function_uchar Function
 %1334 = OpVariable %_ptr_Function_uchar Function
 %1335 = OpVariable %_ptr_Function_uchar Function
 %1336 = OpVariable %_ptr_Function_uchar Function
@@ -1449,44 +1758,44 @@ OpFunctionEnd
 %1357 = OpVariable %_ptr_Function_uchar Function
 %1358 = OpVariable %_ptr_Function_uchar Function
 %1359 = OpVariable %_ptr_Function_uchar Function
-%1360 = OpVariable %_ptr_Function_uchar Function
-%1361 = OpVariable %_ptr_Function_uchar Function
-%1362 = OpVariable %_ptr_Function_uchar Function
-%1363 = OpVariable %_ptr_Function_uchar Function
-%1364 = OpVariable %_ptr_Function_uchar Function
-%1365 = OpVariable %_ptr_Function_uchar Function
-%1366 = OpVariable %_ptr_Function_uchar Function
-%1367 = OpVariable %_ptr_Function_uchar Function
-%1368 = OpVariable %_ptr_Function_uchar Function
-%1369 = OpVariable %_ptr_Function_uchar Function
-%1370 = OpVariable %_ptr_Function_uchar Function
-%1371 = OpVariable %_ptr_Function_uchar Function
-%1372 = OpVariable %_ptr_Function_uchar Function
-%1373 = OpVariable %_ptr_Function_uchar Function
-%1374 = OpVariable %_ptr_Function_uchar Function
-%1375 = OpVariable %_ptr_Function_uchar Function
+%1360 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1361 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1362 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1363 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1364 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1365 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1366 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1367 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1368 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1369 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1370 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1371 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1372 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1373 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1374 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1375 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1376 = OpVariable %_ptr_Function_uchar Function
 %1377 = OpVariable %_ptr_Function_uchar Function
 %1378 = OpVariable %_ptr_Function_uchar Function
 %1379 = OpVariable %_ptr_Function_uchar Function
 %1380 = OpVariable %_ptr_Function_uchar Function
 %1381 = OpVariable %_ptr_Function_uchar Function
-%1382 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1383 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1384 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1385 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1386 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1387 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1388 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1389 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1390 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1391 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1392 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1393 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1394 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1395 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1396 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1397 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1382 = OpVariable %_ptr_Function_uchar Function
+%1383 = OpVariable %_ptr_Function_uchar Function
+%1384 = OpVariable %_ptr_Function_uchar Function
+%1385 = OpVariable %_ptr_Function_uchar Function
+%1386 = OpVariable %_ptr_Function_uchar Function
+%1387 = OpVariable %_ptr_Function_uchar Function
+%1388 = OpVariable %_ptr_Function_uchar Function
+%1389 = OpVariable %_ptr_Function_uchar Function
+%1390 = OpVariable %_ptr_Function_uchar Function
+%1391 = OpVariable %_ptr_Function_uchar Function
+%1392 = OpVariable %_ptr_Function_uchar Function
+%1393 = OpVariable %_ptr_Function_uchar Function
+%1394 = OpVariable %_ptr_Function_uchar Function
+%1395 = OpVariable %_ptr_Function_uchar Function
+%1396 = OpVariable %_ptr_Function_uchar Function
+%1397 = OpVariable %_ptr_Function_uchar Function
 %1398 = OpVariable %_ptr_Function_uchar Function
 %1399 = OpVariable %_ptr_Function_uchar Function
 %1400 = OpVariable %_ptr_Function_uchar Function
@@ -1513,44 +1822,44 @@ OpFunctionEnd
 %1421 = OpVariable %_ptr_Function_uchar Function
 %1422 = OpVariable %_ptr_Function_uchar Function
 %1423 = OpVariable %_ptr_Function_uchar Function
-%1424 = OpVariable %_ptr_Function_uchar Function
-%1425 = OpVariable %_ptr_Function_uchar Function
-%1426 = OpVariable %_ptr_Function_uchar Function
-%1427 = OpVariable %_ptr_Function_uchar Function
-%1428 = OpVariable %_ptr_Function_uchar Function
-%1429 = OpVariable %_ptr_Function_uchar Function
-%1430 = OpVariable %_ptr_Function_uchar Function
-%1431 = OpVariable %_ptr_Function_uchar Function
-%1432 = OpVariable %_ptr_Function_uchar Function
-%1433 = OpVariable %_ptr_Function_uchar Function
-%1434 = OpVariable %_ptr_Function_uchar Function
-%1435 = OpVariable %_ptr_Function_uchar Function
-%1436 = OpVariable %_ptr_Function_uchar Function
-%1437 = OpVariable %_ptr_Function_uchar Function
-%1438 = OpVariable %_ptr_Function_uchar Function
-%1439 = OpVariable %_ptr_Function_uchar Function
+%1424 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1425 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1426 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1427 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1428 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1429 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1430 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1431 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1432 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1433 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1434 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1435 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1436 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1437 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1438 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1439 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1440 = OpVariable %_ptr_Function_uchar Function
 %1441 = OpVariable %_ptr_Function_uchar Function
 %1442 = OpVariable %_ptr_Function_uchar Function
 %1443 = OpVariable %_ptr_Function_uchar Function
 %1444 = OpVariable %_ptr_Function_uchar Function
 %1445 = OpVariable %_ptr_Function_uchar Function
-%1446 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1447 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1448 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1449 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1450 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1451 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1452 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1453 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1454 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1455 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1456 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1457 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1458 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1459 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1460 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1461 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1446 = OpVariable %_ptr_Function_uchar Function
+%1447 = OpVariable %_ptr_Function_uchar Function
+%1448 = OpVariable %_ptr_Function_uchar Function
+%1449 = OpVariable %_ptr_Function_uchar Function
+%1450 = OpVariable %_ptr_Function_uchar Function
+%1451 = OpVariable %_ptr_Function_uchar Function
+%1452 = OpVariable %_ptr_Function_uchar Function
+%1453 = OpVariable %_ptr_Function_uchar Function
+%1454 = OpVariable %_ptr_Function_uchar Function
+%1455 = OpVariable %_ptr_Function_uchar Function
+%1456 = OpVariable %_ptr_Function_uchar Function
+%1457 = OpVariable %_ptr_Function_uchar Function
+%1458 = OpVariable %_ptr_Function_uchar Function
+%1459 = OpVariable %_ptr_Function_uchar Function
+%1460 = OpVariable %_ptr_Function_uchar Function
+%1461 = OpVariable %_ptr_Function_uchar Function
 %1462 = OpVariable %_ptr_Function_uchar Function
 %1463 = OpVariable %_ptr_Function_uchar Function
 %1464 = OpVariable %_ptr_Function_uchar Function
@@ -1577,5010 +1886,5533 @@ OpFunctionEnd
 %1485 = OpVariable %_ptr_Function_uchar Function
 %1486 = OpVariable %_ptr_Function_uchar Function
 %1487 = OpVariable %_ptr_Function_uchar Function
-%1488 = OpVariable %_ptr_Function_uchar Function
-%1489 = OpVariable %_ptr_Function_uchar Function
-%1490 = OpVariable %_ptr_Function_uchar Function
-%1491 = OpVariable %_ptr_Function_uchar Function
-%1492 = OpVariable %_ptr_Function_uchar Function
-%1493 = OpVariable %_ptr_Function_uchar Function
-%1494 = OpVariable %_ptr_Function_uchar Function
-%1495 = OpVariable %_ptr_Function_uchar Function
-%1496 = OpVariable %_ptr_Function_uchar Function
-%1497 = OpVariable %_ptr_Function_uchar Function
-%1498 = OpVariable %_ptr_Function_uchar Function
-%1499 = OpVariable %_ptr_Function_uchar Function
-%1500 = OpVariable %_ptr_Function_uchar Function
-%1501 = OpVariable %_ptr_Function_uchar Function
-%1502 = OpVariable %_ptr_Function_uchar Function
-%1503 = OpVariable %_ptr_Function_uchar Function
+%1488 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1489 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1490 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1491 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1492 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1493 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1494 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1495 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1496 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1497 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1498 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1499 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1500 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1501 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1502 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1503 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
 %1504 = OpVariable %_ptr_Function_uchar Function
 %1505 = OpVariable %_ptr_Function_uchar Function
 %1506 = OpVariable %_ptr_Function_uchar Function
 %1507 = OpVariable %_ptr_Function_uchar Function
 %1508 = OpVariable %_ptr_Function_uchar Function
 %1509 = OpVariable %_ptr_Function_uchar Function
-%1510 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1511 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1512 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1513 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1514 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1515 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1516 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1517 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1518 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1519 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1520 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1521 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1522 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1523 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1524 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-%1525 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
-OpStore %152 %134
-%1526 = OpFunctionCall %ulong %3
-OpStore %153 %1526
-%1527 = OpLoad %ulong %152
-%1528 = OpUConvert %uchar %1527
-OpStore %154 %1528
-%1529 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_240 %uchar_1 %uchar_128 %uchar_255 %uchar_17 %uchar_2 %uchar_200 %uchar_99 %uchar_0 %uchar_7 %uchar_250 %uchar_33 %uchar_128 %uchar_64 %uchar_5 %uchar_199
-OpStore %155 %1529
-%1545 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_17 %uchar_255 %uchar_129 %uchar_1 %uchar_200 %uchar_100 %uchar_57 %uchar_21 %uchar_255 %uchar_3 %uchar_6 %uchar_222 %uchar_128 %uchar_192 %uchar_251 %uchar_57
-OpStore %156 %1545
-%1555 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_3 %uchar_9 %uchar_27 %uchar_2 %uchar_6 %uchar_18 %uchar_54 %uchar_4 %uchar_12 %uchar_36 %uchar_108 %uchar_8 %uchar_24 %uchar_72 %uchar_216
-OpStore %157 %1555
-%1568 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0
-OpStore %158 %1568
-%1569 = OpLoad %_arr_uchar_uint_16 %155
-%1570 = OpCompositeExtract %uchar %1569 0
-OpStore %159 %1570
-%1571 = OpLoad %uchar %159
-%1572 = OpLoad %uchar %154
-%1573 = OpIAdd %uchar %1571 %1572
-OpStore %160 %1573
-%1574 = OpLoad %_arr_uchar_uint_16 %155
-%1575 = OpLoad %uchar %160
-%1576 = OpCompositeInsert %_arr_uchar_uint_16 %1575 %1574 0
-OpStore %161 %1576
-%1577 = OpLoad %_arr_uchar_uint_16 %161
-%1578 = OpCompositeExtract %uchar %1577 7
-OpStore %162 %1578
-%1579 = OpLoad %uchar %162
-%1580 = OpLoad %uchar %154
-%1581 = OpIAdd %uchar %1579 %1580
-OpStore %163 %1581
-%1582 = OpLoad %_arr_uchar_uint_16 %161
-%1583 = OpLoad %uchar %163
-%1584 = OpCompositeInsert %_arr_uchar_uint_16 %1583 %1582 7
-OpStore %164 %1584
-%1585 = OpLoad %_arr_uchar_uint_16 %156
-%1586 = OpCompositeExtract %uchar %1585 3
-OpStore %165 %1586
-%1587 = OpLoad %uchar %165
-%1588 = OpLoad %uchar %154
-%1589 = OpIAdd %uchar %1587 %1588
-OpStore %166 %1589
-%1590 = OpLoad %_arr_uchar_uint_16 %156
-%1591 = OpLoad %uchar %166
-%1592 = OpCompositeInsert %_arr_uchar_uint_16 %1591 %1590 3
-OpStore %167 %1592
-%1593 = OpLoad %_arr_uchar_uint_16 %167
-%1594 = OpCompositeExtract %uchar %1593 12
-OpStore %168 %1594
-%1595 = OpLoad %uchar %168
-%1596 = OpLoad %uchar %154
-%1597 = OpIAdd %uchar %1595 %1596
-OpStore %169 %1597
-%1598 = OpLoad %_arr_uchar_uint_16 %167
-%1599 = OpLoad %uchar %169
-%1600 = OpCompositeInsert %_arr_uchar_uint_16 %1599 %1598 12
-OpStore %170 %1600
-%1601 = OpLoad %ulong %153
-%1602 = OpLoad %_arr_uchar_uint_16 %164
-%1603 = OpFunctionCall %ulong %1 %1601 %1602
-OpStore %171 %1603
-%1604 = OpLoad %ulong %171
-%1605 = OpLoad %_arr_uchar_uint_16 %170
-%1606 = OpFunctionCall %ulong %1 %1604 %1605
-OpStore %172 %1606
-%1607 = OpLoad %_arr_uchar_uint_16 %164
-%1608 = OpCompositeExtract %uchar %1607 0
-OpStore %214 %1608
-%1609 = OpLoad %_arr_uchar_uint_16 %170
-%1610 = OpCompositeExtract %uchar %1609 0
-OpStore %215 %1610
-%1611 = OpLoad %uchar %214
-%1612 = OpLoad %uchar %215
-%1613 = OpIAdd %uchar %1611 %1612
-OpStore %216 %1613
-%1614 = OpLoad %_arr_uchar_uint_16 %164
-%1615 = OpCompositeExtract %uchar %1614 1
-OpStore %217 %1615
-%1616 = OpLoad %_arr_uchar_uint_16 %170
-%1617 = OpCompositeExtract %uchar %1616 1
-OpStore %218 %1617
-%1618 = OpLoad %uchar %217
-%1619 = OpLoad %uchar %218
-%1620 = OpIAdd %uchar %1618 %1619
-OpStore %219 %1620
-%1621 = OpLoad %_arr_uchar_uint_16 %164
-%1622 = OpCompositeExtract %uchar %1621 2
-OpStore %220 %1622
-%1623 = OpLoad %_arr_uchar_uint_16 %170
-%1624 = OpCompositeExtract %uchar %1623 2
-OpStore %221 %1624
-%1625 = OpLoad %uchar %220
-%1626 = OpLoad %uchar %221
-%1627 = OpIAdd %uchar %1625 %1626
-OpStore %222 %1627
-%1628 = OpLoad %_arr_uchar_uint_16 %164
-%1629 = OpCompositeExtract %uchar %1628 3
-OpStore %223 %1629
-%1630 = OpLoad %_arr_uchar_uint_16 %170
-%1631 = OpCompositeExtract %uchar %1630 3
-OpStore %224 %1631
-%1632 = OpLoad %uchar %223
-%1633 = OpLoad %uchar %224
-%1634 = OpIAdd %uchar %1632 %1633
-OpStore %225 %1634
-%1635 = OpLoad %_arr_uchar_uint_16 %164
-%1636 = OpCompositeExtract %uchar %1635 4
-OpStore %226 %1636
-%1637 = OpLoad %_arr_uchar_uint_16 %170
-%1638 = OpCompositeExtract %uchar %1637 4
-OpStore %227 %1638
-%1639 = OpLoad %uchar %226
-%1640 = OpLoad %uchar %227
-%1641 = OpIAdd %uchar %1639 %1640
-OpStore %228 %1641
-%1642 = OpLoad %_arr_uchar_uint_16 %164
-%1643 = OpCompositeExtract %uchar %1642 5
-OpStore %229 %1643
-%1644 = OpLoad %_arr_uchar_uint_16 %170
-%1645 = OpCompositeExtract %uchar %1644 5
-OpStore %230 %1645
-%1646 = OpLoad %uchar %229
-%1647 = OpLoad %uchar %230
-%1648 = OpIAdd %uchar %1646 %1647
-OpStore %231 %1648
-%1649 = OpLoad %_arr_uchar_uint_16 %164
-%1650 = OpCompositeExtract %uchar %1649 6
-OpStore %232 %1650
-%1651 = OpLoad %_arr_uchar_uint_16 %170
-%1652 = OpCompositeExtract %uchar %1651 6
-OpStore %233 %1652
-%1653 = OpLoad %uchar %232
-%1654 = OpLoad %uchar %233
-%1655 = OpIAdd %uchar %1653 %1654
-OpStore %234 %1655
-%1656 = OpLoad %_arr_uchar_uint_16 %164
-%1657 = OpCompositeExtract %uchar %1656 7
-OpStore %235 %1657
-%1658 = OpLoad %_arr_uchar_uint_16 %170
-%1659 = OpCompositeExtract %uchar %1658 7
-OpStore %236 %1659
-%1660 = OpLoad %uchar %235
-%1661 = OpLoad %uchar %236
-%1662 = OpIAdd %uchar %1660 %1661
-OpStore %237 %1662
-%1663 = OpLoad %_arr_uchar_uint_16 %164
-%1664 = OpCompositeExtract %uchar %1663 8
-OpStore %238 %1664
-%1665 = OpLoad %_arr_uchar_uint_16 %170
-%1666 = OpCompositeExtract %uchar %1665 8
-OpStore %239 %1666
-%1667 = OpLoad %uchar %238
-%1668 = OpLoad %uchar %239
-%1669 = OpIAdd %uchar %1667 %1668
-OpStore %240 %1669
-%1670 = OpLoad %_arr_uchar_uint_16 %164
-%1671 = OpCompositeExtract %uchar %1670 9
-OpStore %241 %1671
-%1672 = OpLoad %_arr_uchar_uint_16 %170
-%1673 = OpCompositeExtract %uchar %1672 9
-OpStore %242 %1673
-%1674 = OpLoad %uchar %241
-%1675 = OpLoad %uchar %242
-%1676 = OpIAdd %uchar %1674 %1675
-OpStore %243 %1676
-%1677 = OpLoad %_arr_uchar_uint_16 %164
-%1678 = OpCompositeExtract %uchar %1677 10
-OpStore %244 %1678
-%1679 = OpLoad %_arr_uchar_uint_16 %170
-%1680 = OpCompositeExtract %uchar %1679 10
-OpStore %245 %1680
-%1681 = OpLoad %uchar %244
-%1682 = OpLoad %uchar %245
-%1683 = OpIAdd %uchar %1681 %1682
-OpStore %246 %1683
-%1684 = OpLoad %_arr_uchar_uint_16 %164
-%1685 = OpCompositeExtract %uchar %1684 11
-OpStore %247 %1685
-%1686 = OpLoad %_arr_uchar_uint_16 %170
-%1687 = OpCompositeExtract %uchar %1686 11
-OpStore %248 %1687
-%1688 = OpLoad %uchar %247
-%1689 = OpLoad %uchar %248
-%1690 = OpIAdd %uchar %1688 %1689
-OpStore %249 %1690
-%1691 = OpLoad %_arr_uchar_uint_16 %164
-%1692 = OpCompositeExtract %uchar %1691 12
-OpStore %250 %1692
-%1693 = OpLoad %_arr_uchar_uint_16 %170
-%1694 = OpCompositeExtract %uchar %1693 12
-OpStore %251 %1694
-%1695 = OpLoad %uchar %250
-%1696 = OpLoad %uchar %251
-%1697 = OpIAdd %uchar %1695 %1696
-OpStore %252 %1697
-%1698 = OpLoad %_arr_uchar_uint_16 %164
-%1699 = OpCompositeExtract %uchar %1698 13
-OpStore %253 %1699
-%1700 = OpLoad %_arr_uchar_uint_16 %170
-%1701 = OpCompositeExtract %uchar %1700 13
-OpStore %254 %1701
-%1702 = OpLoad %uchar %253
-%1703 = OpLoad %uchar %254
-%1704 = OpIAdd %uchar %1702 %1703
-OpStore %255 %1704
-%1705 = OpLoad %_arr_uchar_uint_16 %164
-%1706 = OpCompositeExtract %uchar %1705 14
-OpStore %256 %1706
-%1707 = OpLoad %_arr_uchar_uint_16 %170
-%1708 = OpCompositeExtract %uchar %1707 14
-OpStore %257 %1708
-%1709 = OpLoad %uchar %256
-%1710 = OpLoad %uchar %257
-%1711 = OpIAdd %uchar %1709 %1710
-OpStore %258 %1711
-%1712 = OpLoad %_arr_uchar_uint_16 %164
-%1713 = OpCompositeExtract %uchar %1712 15
-OpStore %259 %1713
-%1714 = OpLoad %_arr_uchar_uint_16 %170
-%1715 = OpCompositeExtract %uchar %1714 15
-OpStore %260 %1715
-%1716 = OpLoad %uchar %259
-%1717 = OpLoad %uchar %260
-%1718 = OpIAdd %uchar %1716 %1717
-OpStore %261 %1718
-%1719 = OpLoad %_arr_uchar_uint_16 %164
-%1720 = OpLoad %uchar %216
-%1721 = OpCompositeInsert %_arr_uchar_uint_16 %1720 %1719 0
-OpStore %262 %1721
-%1722 = OpLoad %_arr_uchar_uint_16 %262
-%1723 = OpLoad %uchar %219
-%1724 = OpCompositeInsert %_arr_uchar_uint_16 %1723 %1722 1
-OpStore %263 %1724
-%1725 = OpLoad %_arr_uchar_uint_16 %263
-%1726 = OpLoad %uchar %222
-%1727 = OpCompositeInsert %_arr_uchar_uint_16 %1726 %1725 2
-OpStore %264 %1727
-%1728 = OpLoad %_arr_uchar_uint_16 %264
-%1729 = OpLoad %uchar %225
-%1730 = OpCompositeInsert %_arr_uchar_uint_16 %1729 %1728 3
-OpStore %265 %1730
-%1731 = OpLoad %_arr_uchar_uint_16 %265
-%1732 = OpLoad %uchar %228
-%1733 = OpCompositeInsert %_arr_uchar_uint_16 %1732 %1731 4
-OpStore %266 %1733
-%1734 = OpLoad %_arr_uchar_uint_16 %266
-%1735 = OpLoad %uchar %231
-%1736 = OpCompositeInsert %_arr_uchar_uint_16 %1735 %1734 5
-OpStore %267 %1736
-%1737 = OpLoad %_arr_uchar_uint_16 %267
-%1738 = OpLoad %uchar %234
-%1739 = OpCompositeInsert %_arr_uchar_uint_16 %1738 %1737 6
-OpStore %268 %1739
-%1740 = OpLoad %_arr_uchar_uint_16 %268
-%1741 = OpLoad %uchar %237
-%1742 = OpCompositeInsert %_arr_uchar_uint_16 %1741 %1740 7
-OpStore %269 %1742
-%1743 = OpLoad %_arr_uchar_uint_16 %269
-%1744 = OpLoad %uchar %240
-%1745 = OpCompositeInsert %_arr_uchar_uint_16 %1744 %1743 8
-OpStore %270 %1745
-%1746 = OpLoad %_arr_uchar_uint_16 %270
-%1747 = OpLoad %uchar %243
-%1748 = OpCompositeInsert %_arr_uchar_uint_16 %1747 %1746 9
-OpStore %271 %1748
-%1749 = OpLoad %_arr_uchar_uint_16 %271
-%1750 = OpLoad %uchar %246
-%1751 = OpCompositeInsert %_arr_uchar_uint_16 %1750 %1749 10
-OpStore %272 %1751
-%1752 = OpLoad %_arr_uchar_uint_16 %272
-%1753 = OpLoad %uchar %249
-%1754 = OpCompositeInsert %_arr_uchar_uint_16 %1753 %1752 11
-OpStore %273 %1754
-%1755 = OpLoad %_arr_uchar_uint_16 %273
-%1756 = OpLoad %uchar %252
-%1757 = OpCompositeInsert %_arr_uchar_uint_16 %1756 %1755 12
-OpStore %274 %1757
-%1758 = OpLoad %_arr_uchar_uint_16 %274
-%1759 = OpLoad %uchar %255
-%1760 = OpCompositeInsert %_arr_uchar_uint_16 %1759 %1758 13
-OpStore %275 %1760
-%1761 = OpLoad %_arr_uchar_uint_16 %275
-%1762 = OpLoad %uchar %258
-%1763 = OpCompositeInsert %_arr_uchar_uint_16 %1762 %1761 14
-OpStore %276 %1763
-%1764 = OpLoad %_arr_uchar_uint_16 %276
-%1765 = OpLoad %uchar %261
-%1766 = OpCompositeInsert %_arr_uchar_uint_16 %1765 %1764 15
-OpStore %277 %1766
-%1767 = OpLoad %ulong %172
-%1768 = OpLoad %_arr_uchar_uint_16 %277
-%1769 = OpFunctionCall %ulong %1 %1767 %1768
-OpStore %173 %1769
-%1770 = OpLoad %_arr_uchar_uint_16 %164
-%1771 = OpCompositeExtract %uchar %1770 0
-OpStore %278 %1771
-%1772 = OpLoad %_arr_uchar_uint_16 %170
-%1773 = OpCompositeExtract %uchar %1772 0
-OpStore %279 %1773
-%1774 = OpLoad %uchar %278
-%1775 = OpLoad %uchar %279
-%1776 = OpISub %uchar %1774 %1775
-OpStore %280 %1776
-%1777 = OpLoad %_arr_uchar_uint_16 %164
-%1778 = OpCompositeExtract %uchar %1777 1
-OpStore %281 %1778
-%1779 = OpLoad %_arr_uchar_uint_16 %170
-%1780 = OpCompositeExtract %uchar %1779 1
-OpStore %282 %1780
-%1781 = OpLoad %uchar %281
-%1782 = OpLoad %uchar %282
-%1783 = OpISub %uchar %1781 %1782
-OpStore %283 %1783
-%1784 = OpLoad %_arr_uchar_uint_16 %164
-%1785 = OpCompositeExtract %uchar %1784 2
-OpStore %284 %1785
-%1786 = OpLoad %_arr_uchar_uint_16 %170
-%1787 = OpCompositeExtract %uchar %1786 2
-OpStore %285 %1787
-%1788 = OpLoad %uchar %284
-%1789 = OpLoad %uchar %285
-%1790 = OpISub %uchar %1788 %1789
-OpStore %286 %1790
-%1791 = OpLoad %_arr_uchar_uint_16 %164
-%1792 = OpCompositeExtract %uchar %1791 3
-OpStore %287 %1792
-%1793 = OpLoad %_arr_uchar_uint_16 %170
-%1794 = OpCompositeExtract %uchar %1793 3
-OpStore %288 %1794
-%1795 = OpLoad %uchar %287
-%1796 = OpLoad %uchar %288
-%1797 = OpISub %uchar %1795 %1796
-OpStore %289 %1797
-%1798 = OpLoad %_arr_uchar_uint_16 %164
-%1799 = OpCompositeExtract %uchar %1798 4
-OpStore %290 %1799
-%1800 = OpLoad %_arr_uchar_uint_16 %170
-%1801 = OpCompositeExtract %uchar %1800 4
-OpStore %291 %1801
-%1802 = OpLoad %uchar %290
-%1803 = OpLoad %uchar %291
-%1804 = OpISub %uchar %1802 %1803
-OpStore %292 %1804
-%1805 = OpLoad %_arr_uchar_uint_16 %164
-%1806 = OpCompositeExtract %uchar %1805 5
-OpStore %293 %1806
-%1807 = OpLoad %_arr_uchar_uint_16 %170
-%1808 = OpCompositeExtract %uchar %1807 5
-OpStore %294 %1808
-%1809 = OpLoad %uchar %293
-%1810 = OpLoad %uchar %294
-%1811 = OpISub %uchar %1809 %1810
-OpStore %295 %1811
-%1812 = OpLoad %_arr_uchar_uint_16 %164
-%1813 = OpCompositeExtract %uchar %1812 6
-OpStore %296 %1813
-%1814 = OpLoad %_arr_uchar_uint_16 %170
-%1815 = OpCompositeExtract %uchar %1814 6
-OpStore %297 %1815
-%1816 = OpLoad %uchar %296
-%1817 = OpLoad %uchar %297
-%1818 = OpISub %uchar %1816 %1817
-OpStore %298 %1818
-%1819 = OpLoad %_arr_uchar_uint_16 %164
-%1820 = OpCompositeExtract %uchar %1819 7
-OpStore %299 %1820
-%1821 = OpLoad %_arr_uchar_uint_16 %170
-%1822 = OpCompositeExtract %uchar %1821 7
-OpStore %300 %1822
-%1823 = OpLoad %uchar %299
-%1824 = OpLoad %uchar %300
-%1825 = OpISub %uchar %1823 %1824
-OpStore %301 %1825
-%1826 = OpLoad %_arr_uchar_uint_16 %164
-%1827 = OpCompositeExtract %uchar %1826 8
-OpStore %302 %1827
-%1828 = OpLoad %_arr_uchar_uint_16 %170
-%1829 = OpCompositeExtract %uchar %1828 8
-OpStore %303 %1829
-%1830 = OpLoad %uchar %302
-%1831 = OpLoad %uchar %303
-%1832 = OpISub %uchar %1830 %1831
-OpStore %304 %1832
-%1833 = OpLoad %_arr_uchar_uint_16 %164
-%1834 = OpCompositeExtract %uchar %1833 9
-OpStore %305 %1834
-%1835 = OpLoad %_arr_uchar_uint_16 %170
-%1836 = OpCompositeExtract %uchar %1835 9
-OpStore %306 %1836
-%1837 = OpLoad %uchar %305
-%1838 = OpLoad %uchar %306
-%1839 = OpISub %uchar %1837 %1838
-OpStore %307 %1839
-%1840 = OpLoad %_arr_uchar_uint_16 %164
-%1841 = OpCompositeExtract %uchar %1840 10
-OpStore %308 %1841
-%1842 = OpLoad %_arr_uchar_uint_16 %170
-%1843 = OpCompositeExtract %uchar %1842 10
-OpStore %309 %1843
-%1844 = OpLoad %uchar %308
-%1845 = OpLoad %uchar %309
-%1846 = OpISub %uchar %1844 %1845
-OpStore %310 %1846
-%1847 = OpLoad %_arr_uchar_uint_16 %164
-%1848 = OpCompositeExtract %uchar %1847 11
-OpStore %311 %1848
-%1849 = OpLoad %_arr_uchar_uint_16 %170
-%1850 = OpCompositeExtract %uchar %1849 11
-OpStore %312 %1850
-%1851 = OpLoad %uchar %311
-%1852 = OpLoad %uchar %312
-%1853 = OpISub %uchar %1851 %1852
-OpStore %313 %1853
-%1854 = OpLoad %_arr_uchar_uint_16 %164
-%1855 = OpCompositeExtract %uchar %1854 12
-OpStore %314 %1855
-%1856 = OpLoad %_arr_uchar_uint_16 %170
-%1857 = OpCompositeExtract %uchar %1856 12
-OpStore %315 %1857
-%1858 = OpLoad %uchar %314
-%1859 = OpLoad %uchar %315
-%1860 = OpISub %uchar %1858 %1859
-OpStore %316 %1860
-%1861 = OpLoad %_arr_uchar_uint_16 %164
-%1862 = OpCompositeExtract %uchar %1861 13
-OpStore %317 %1862
-%1863 = OpLoad %_arr_uchar_uint_16 %170
-%1864 = OpCompositeExtract %uchar %1863 13
-OpStore %318 %1864
-%1865 = OpLoad %uchar %317
-%1866 = OpLoad %uchar %318
-%1867 = OpISub %uchar %1865 %1866
-OpStore %319 %1867
-%1868 = OpLoad %_arr_uchar_uint_16 %164
-%1869 = OpCompositeExtract %uchar %1868 14
-OpStore %320 %1869
-%1870 = OpLoad %_arr_uchar_uint_16 %170
-%1871 = OpCompositeExtract %uchar %1870 14
-OpStore %321 %1871
-%1872 = OpLoad %uchar %320
-%1873 = OpLoad %uchar %321
-%1874 = OpISub %uchar %1872 %1873
-OpStore %322 %1874
-%1875 = OpLoad %_arr_uchar_uint_16 %164
-%1876 = OpCompositeExtract %uchar %1875 15
-OpStore %323 %1876
-%1877 = OpLoad %_arr_uchar_uint_16 %170
-%1878 = OpCompositeExtract %uchar %1877 15
-OpStore %324 %1878
-%1879 = OpLoad %uchar %323
-%1880 = OpLoad %uchar %324
-%1881 = OpISub %uchar %1879 %1880
-OpStore %325 %1881
-%1882 = OpLoad %_arr_uchar_uint_16 %164
-%1883 = OpLoad %uchar %280
-%1884 = OpCompositeInsert %_arr_uchar_uint_16 %1883 %1882 0
-OpStore %326 %1884
-%1885 = OpLoad %_arr_uchar_uint_16 %326
-%1886 = OpLoad %uchar %283
-%1887 = OpCompositeInsert %_arr_uchar_uint_16 %1886 %1885 1
-OpStore %327 %1887
-%1888 = OpLoad %_arr_uchar_uint_16 %327
-%1889 = OpLoad %uchar %286
-%1890 = OpCompositeInsert %_arr_uchar_uint_16 %1889 %1888 2
-OpStore %328 %1890
-%1891 = OpLoad %_arr_uchar_uint_16 %328
-%1892 = OpLoad %uchar %289
-%1893 = OpCompositeInsert %_arr_uchar_uint_16 %1892 %1891 3
-OpStore %329 %1893
-%1894 = OpLoad %_arr_uchar_uint_16 %329
-%1895 = OpLoad %uchar %292
-%1896 = OpCompositeInsert %_arr_uchar_uint_16 %1895 %1894 4
-OpStore %330 %1896
-%1897 = OpLoad %_arr_uchar_uint_16 %330
-%1898 = OpLoad %uchar %295
-%1899 = OpCompositeInsert %_arr_uchar_uint_16 %1898 %1897 5
-OpStore %331 %1899
-%1900 = OpLoad %_arr_uchar_uint_16 %331
-%1901 = OpLoad %uchar %298
-%1902 = OpCompositeInsert %_arr_uchar_uint_16 %1901 %1900 6
-OpStore %332 %1902
-%1903 = OpLoad %_arr_uchar_uint_16 %332
-%1904 = OpLoad %uchar %301
-%1905 = OpCompositeInsert %_arr_uchar_uint_16 %1904 %1903 7
-OpStore %333 %1905
-%1906 = OpLoad %_arr_uchar_uint_16 %333
-%1907 = OpLoad %uchar %304
-%1908 = OpCompositeInsert %_arr_uchar_uint_16 %1907 %1906 8
-OpStore %334 %1908
-%1909 = OpLoad %_arr_uchar_uint_16 %334
-%1910 = OpLoad %uchar %307
-%1911 = OpCompositeInsert %_arr_uchar_uint_16 %1910 %1909 9
-OpStore %335 %1911
-%1912 = OpLoad %_arr_uchar_uint_16 %335
-%1913 = OpLoad %uchar %310
-%1914 = OpCompositeInsert %_arr_uchar_uint_16 %1913 %1912 10
-OpStore %336 %1914
-%1915 = OpLoad %_arr_uchar_uint_16 %336
-%1916 = OpLoad %uchar %313
-%1917 = OpCompositeInsert %_arr_uchar_uint_16 %1916 %1915 11
-OpStore %337 %1917
-%1918 = OpLoad %_arr_uchar_uint_16 %337
-%1919 = OpLoad %uchar %316
-%1920 = OpCompositeInsert %_arr_uchar_uint_16 %1919 %1918 12
-OpStore %338 %1920
-%1921 = OpLoad %_arr_uchar_uint_16 %338
-%1922 = OpLoad %uchar %319
-%1923 = OpCompositeInsert %_arr_uchar_uint_16 %1922 %1921 13
-OpStore %339 %1923
-%1924 = OpLoad %_arr_uchar_uint_16 %339
-%1925 = OpLoad %uchar %322
-%1926 = OpCompositeInsert %_arr_uchar_uint_16 %1925 %1924 14
-OpStore %340 %1926
-%1927 = OpLoad %_arr_uchar_uint_16 %340
-%1928 = OpLoad %uchar %325
-%1929 = OpCompositeInsert %_arr_uchar_uint_16 %1928 %1927 15
-OpStore %341 %1929
-%1930 = OpLoad %ulong %173
-%1931 = OpLoad %_arr_uchar_uint_16 %341
-%1932 = OpFunctionCall %ulong %1 %1930 %1931
-OpStore %174 %1932
-%1933 = OpLoad %_arr_uchar_uint_16 %170
-%1934 = OpCompositeExtract %uchar %1933 0
-OpStore %342 %1934
-%1935 = OpLoad %_arr_uchar_uint_16 %164
-%1936 = OpCompositeExtract %uchar %1935 0
-OpStore %343 %1936
-%1937 = OpLoad %uchar %342
-%1938 = OpLoad %uchar %343
-%1939 = OpISub %uchar %1937 %1938
-OpStore %344 %1939
-%1940 = OpLoad %_arr_uchar_uint_16 %170
-%1941 = OpCompositeExtract %uchar %1940 1
-OpStore %345 %1941
-%1942 = OpLoad %_arr_uchar_uint_16 %164
-%1943 = OpCompositeExtract %uchar %1942 1
-OpStore %346 %1943
-%1944 = OpLoad %uchar %345
-%1945 = OpLoad %uchar %346
-%1946 = OpISub %uchar %1944 %1945
-OpStore %347 %1946
-%1947 = OpLoad %_arr_uchar_uint_16 %170
-%1948 = OpCompositeExtract %uchar %1947 2
-OpStore %348 %1948
-%1949 = OpLoad %_arr_uchar_uint_16 %164
-%1950 = OpCompositeExtract %uchar %1949 2
-OpStore %349 %1950
-%1951 = OpLoad %uchar %348
-%1952 = OpLoad %uchar %349
-%1953 = OpISub %uchar %1951 %1952
-OpStore %350 %1953
-%1954 = OpLoad %_arr_uchar_uint_16 %170
-%1955 = OpCompositeExtract %uchar %1954 3
-OpStore %351 %1955
-%1956 = OpLoad %_arr_uchar_uint_16 %164
-%1957 = OpCompositeExtract %uchar %1956 3
-OpStore %352 %1957
-%1958 = OpLoad %uchar %351
-%1959 = OpLoad %uchar %352
-%1960 = OpISub %uchar %1958 %1959
-OpStore %353 %1960
-%1961 = OpLoad %_arr_uchar_uint_16 %170
-%1962 = OpCompositeExtract %uchar %1961 4
-OpStore %354 %1962
-%1963 = OpLoad %_arr_uchar_uint_16 %164
-%1964 = OpCompositeExtract %uchar %1963 4
-OpStore %355 %1964
-%1965 = OpLoad %uchar %354
-%1966 = OpLoad %uchar %355
-%1967 = OpISub %uchar %1965 %1966
-OpStore %356 %1967
-%1968 = OpLoad %_arr_uchar_uint_16 %170
-%1969 = OpCompositeExtract %uchar %1968 5
-OpStore %357 %1969
-%1970 = OpLoad %_arr_uchar_uint_16 %164
-%1971 = OpCompositeExtract %uchar %1970 5
-OpStore %358 %1971
-%1972 = OpLoad %uchar %357
-%1973 = OpLoad %uchar %358
-%1974 = OpISub %uchar %1972 %1973
-OpStore %359 %1974
-%1975 = OpLoad %_arr_uchar_uint_16 %170
-%1976 = OpCompositeExtract %uchar %1975 6
-OpStore %360 %1976
-%1977 = OpLoad %_arr_uchar_uint_16 %164
-%1978 = OpCompositeExtract %uchar %1977 6
-OpStore %361 %1978
-%1979 = OpLoad %uchar %360
-%1980 = OpLoad %uchar %361
-%1981 = OpISub %uchar %1979 %1980
-OpStore %362 %1981
-%1982 = OpLoad %_arr_uchar_uint_16 %170
-%1983 = OpCompositeExtract %uchar %1982 7
-OpStore %363 %1983
-%1984 = OpLoad %_arr_uchar_uint_16 %164
-%1985 = OpCompositeExtract %uchar %1984 7
-OpStore %364 %1985
-%1986 = OpLoad %uchar %363
-%1987 = OpLoad %uchar %364
-%1988 = OpISub %uchar %1986 %1987
-OpStore %365 %1988
-%1989 = OpLoad %_arr_uchar_uint_16 %170
-%1990 = OpCompositeExtract %uchar %1989 8
-OpStore %366 %1990
-%1991 = OpLoad %_arr_uchar_uint_16 %164
-%1992 = OpCompositeExtract %uchar %1991 8
-OpStore %367 %1992
-%1993 = OpLoad %uchar %366
-%1994 = OpLoad %uchar %367
-%1995 = OpISub %uchar %1993 %1994
-OpStore %368 %1995
-%1996 = OpLoad %_arr_uchar_uint_16 %170
-%1997 = OpCompositeExtract %uchar %1996 9
-OpStore %369 %1997
-%1998 = OpLoad %_arr_uchar_uint_16 %164
-%1999 = OpCompositeExtract %uchar %1998 9
-OpStore %370 %1999
-%2000 = OpLoad %uchar %369
-%2001 = OpLoad %uchar %370
-%2002 = OpISub %uchar %2000 %2001
-OpStore %371 %2002
-%2003 = OpLoad %_arr_uchar_uint_16 %170
-%2004 = OpCompositeExtract %uchar %2003 10
-OpStore %372 %2004
-%2005 = OpLoad %_arr_uchar_uint_16 %164
-%2006 = OpCompositeExtract %uchar %2005 10
-OpStore %373 %2006
-%2007 = OpLoad %uchar %372
-%2008 = OpLoad %uchar %373
-%2009 = OpISub %uchar %2007 %2008
-OpStore %374 %2009
-%2010 = OpLoad %_arr_uchar_uint_16 %170
-%2011 = OpCompositeExtract %uchar %2010 11
-OpStore %375 %2011
-%2012 = OpLoad %_arr_uchar_uint_16 %164
-%2013 = OpCompositeExtract %uchar %2012 11
-OpStore %376 %2013
-%2014 = OpLoad %uchar %375
-%2015 = OpLoad %uchar %376
-%2016 = OpISub %uchar %2014 %2015
-OpStore %377 %2016
-%2017 = OpLoad %_arr_uchar_uint_16 %170
-%2018 = OpCompositeExtract %uchar %2017 12
-OpStore %378 %2018
-%2019 = OpLoad %_arr_uchar_uint_16 %164
-%2020 = OpCompositeExtract %uchar %2019 12
-OpStore %379 %2020
-%2021 = OpLoad %uchar %378
-%2022 = OpLoad %uchar %379
-%2023 = OpISub %uchar %2021 %2022
-OpStore %380 %2023
-%2024 = OpLoad %_arr_uchar_uint_16 %170
-%2025 = OpCompositeExtract %uchar %2024 13
-OpStore %381 %2025
-%2026 = OpLoad %_arr_uchar_uint_16 %164
-%2027 = OpCompositeExtract %uchar %2026 13
-OpStore %382 %2027
-%2028 = OpLoad %uchar %381
-%2029 = OpLoad %uchar %382
-%2030 = OpISub %uchar %2028 %2029
-OpStore %383 %2030
-%2031 = OpLoad %_arr_uchar_uint_16 %170
-%2032 = OpCompositeExtract %uchar %2031 14
-OpStore %384 %2032
-%2033 = OpLoad %_arr_uchar_uint_16 %164
-%2034 = OpCompositeExtract %uchar %2033 14
-OpStore %385 %2034
-%2035 = OpLoad %uchar %384
-%2036 = OpLoad %uchar %385
-%2037 = OpISub %uchar %2035 %2036
-OpStore %386 %2037
-%2038 = OpLoad %_arr_uchar_uint_16 %170
-%2039 = OpCompositeExtract %uchar %2038 15
-OpStore %387 %2039
-%2040 = OpLoad %_arr_uchar_uint_16 %164
-%2041 = OpCompositeExtract %uchar %2040 15
-OpStore %388 %2041
-%2042 = OpLoad %uchar %387
-%2043 = OpLoad %uchar %388
-%2044 = OpISub %uchar %2042 %2043
-OpStore %389 %2044
-%2045 = OpLoad %_arr_uchar_uint_16 %170
-%2046 = OpLoad %uchar %344
-%2047 = OpCompositeInsert %_arr_uchar_uint_16 %2046 %2045 0
-OpStore %390 %2047
-%2048 = OpLoad %_arr_uchar_uint_16 %390
-%2049 = OpLoad %uchar %347
-%2050 = OpCompositeInsert %_arr_uchar_uint_16 %2049 %2048 1
-OpStore %391 %2050
-%2051 = OpLoad %_arr_uchar_uint_16 %391
-%2052 = OpLoad %uchar %350
-%2053 = OpCompositeInsert %_arr_uchar_uint_16 %2052 %2051 2
-OpStore %392 %2053
-%2054 = OpLoad %_arr_uchar_uint_16 %392
-%2055 = OpLoad %uchar %353
-%2056 = OpCompositeInsert %_arr_uchar_uint_16 %2055 %2054 3
-OpStore %393 %2056
-%2057 = OpLoad %_arr_uchar_uint_16 %393
-%2058 = OpLoad %uchar %356
-%2059 = OpCompositeInsert %_arr_uchar_uint_16 %2058 %2057 4
-OpStore %394 %2059
-%2060 = OpLoad %_arr_uchar_uint_16 %394
-%2061 = OpLoad %uchar %359
-%2062 = OpCompositeInsert %_arr_uchar_uint_16 %2061 %2060 5
-OpStore %395 %2062
-%2063 = OpLoad %_arr_uchar_uint_16 %395
-%2064 = OpLoad %uchar %362
-%2065 = OpCompositeInsert %_arr_uchar_uint_16 %2064 %2063 6
-OpStore %396 %2065
-%2066 = OpLoad %_arr_uchar_uint_16 %396
-%2067 = OpLoad %uchar %365
-%2068 = OpCompositeInsert %_arr_uchar_uint_16 %2067 %2066 7
-OpStore %397 %2068
-%2069 = OpLoad %_arr_uchar_uint_16 %397
-%2070 = OpLoad %uchar %368
-%2071 = OpCompositeInsert %_arr_uchar_uint_16 %2070 %2069 8
-OpStore %398 %2071
-%2072 = OpLoad %_arr_uchar_uint_16 %398
-%2073 = OpLoad %uchar %371
-%2074 = OpCompositeInsert %_arr_uchar_uint_16 %2073 %2072 9
-OpStore %399 %2074
-%2075 = OpLoad %_arr_uchar_uint_16 %399
-%2076 = OpLoad %uchar %374
-%2077 = OpCompositeInsert %_arr_uchar_uint_16 %2076 %2075 10
-OpStore %400 %2077
-%2078 = OpLoad %_arr_uchar_uint_16 %400
-%2079 = OpLoad %uchar %377
-%2080 = OpCompositeInsert %_arr_uchar_uint_16 %2079 %2078 11
-OpStore %401 %2080
-%2081 = OpLoad %_arr_uchar_uint_16 %401
-%2082 = OpLoad %uchar %380
-%2083 = OpCompositeInsert %_arr_uchar_uint_16 %2082 %2081 12
-OpStore %402 %2083
-%2084 = OpLoad %_arr_uchar_uint_16 %402
-%2085 = OpLoad %uchar %383
-%2086 = OpCompositeInsert %_arr_uchar_uint_16 %2085 %2084 13
-OpStore %403 %2086
-%2087 = OpLoad %_arr_uchar_uint_16 %403
-%2088 = OpLoad %uchar %386
-%2089 = OpCompositeInsert %_arr_uchar_uint_16 %2088 %2087 14
-OpStore %404 %2089
-%2090 = OpLoad %_arr_uchar_uint_16 %404
-%2091 = OpLoad %uchar %389
-%2092 = OpCompositeInsert %_arr_uchar_uint_16 %2091 %2090 15
-OpStore %405 %2092
-%2093 = OpLoad %ulong %174
-%2094 = OpLoad %_arr_uchar_uint_16 %405
-%2095 = OpFunctionCall %ulong %1 %2093 %2094
-OpStore %175 %2095
-%2096 = OpLoad %_arr_uchar_uint_16 %164
-%2097 = OpCompositeExtract %uchar %2096 0
-OpStore %406 %2097
-%2098 = OpLoad %_arr_uchar_uint_16 %170
-%2099 = OpCompositeExtract %uchar %2098 0
-OpStore %407 %2099
-%2100 = OpLoad %uchar %406
-%2101 = OpLoad %uchar %407
-%2102 = OpIMul %uchar %2100 %2101
-OpStore %408 %2102
-%2103 = OpLoad %_arr_uchar_uint_16 %164
-%2104 = OpCompositeExtract %uchar %2103 1
-OpStore %409 %2104
-%2105 = OpLoad %_arr_uchar_uint_16 %170
-%2106 = OpCompositeExtract %uchar %2105 1
-OpStore %410 %2106
-%2107 = OpLoad %uchar %409
-%2108 = OpLoad %uchar %410
-%2109 = OpIMul %uchar %2107 %2108
-OpStore %411 %2109
-%2110 = OpLoad %_arr_uchar_uint_16 %164
-%2111 = OpCompositeExtract %uchar %2110 2
-OpStore %412 %2111
-%2112 = OpLoad %_arr_uchar_uint_16 %170
-%2113 = OpCompositeExtract %uchar %2112 2
-OpStore %413 %2113
-%2114 = OpLoad %uchar %412
-%2115 = OpLoad %uchar %413
-%2116 = OpIMul %uchar %2114 %2115
-OpStore %414 %2116
-%2117 = OpLoad %_arr_uchar_uint_16 %164
-%2118 = OpCompositeExtract %uchar %2117 3
-OpStore %415 %2118
-%2119 = OpLoad %_arr_uchar_uint_16 %170
-%2120 = OpCompositeExtract %uchar %2119 3
-OpStore %416 %2120
-%2121 = OpLoad %uchar %415
-%2122 = OpLoad %uchar %416
-%2123 = OpIMul %uchar %2121 %2122
-OpStore %417 %2123
-%2124 = OpLoad %_arr_uchar_uint_16 %164
-%2125 = OpCompositeExtract %uchar %2124 4
-OpStore %418 %2125
-%2126 = OpLoad %_arr_uchar_uint_16 %170
-%2127 = OpCompositeExtract %uchar %2126 4
-OpStore %419 %2127
-%2128 = OpLoad %uchar %418
-%2129 = OpLoad %uchar %419
-%2130 = OpIMul %uchar %2128 %2129
-OpStore %420 %2130
-%2131 = OpLoad %_arr_uchar_uint_16 %164
-%2132 = OpCompositeExtract %uchar %2131 5
-OpStore %421 %2132
-%2133 = OpLoad %_arr_uchar_uint_16 %170
-%2134 = OpCompositeExtract %uchar %2133 5
-OpStore %422 %2134
-%2135 = OpLoad %uchar %421
-%2136 = OpLoad %uchar %422
-%2137 = OpIMul %uchar %2135 %2136
-OpStore %423 %2137
-%2138 = OpLoad %_arr_uchar_uint_16 %164
-%2139 = OpCompositeExtract %uchar %2138 6
-OpStore %424 %2139
-%2140 = OpLoad %_arr_uchar_uint_16 %170
-%2141 = OpCompositeExtract %uchar %2140 6
-OpStore %425 %2141
-%2142 = OpLoad %uchar %424
-%2143 = OpLoad %uchar %425
-%2144 = OpIMul %uchar %2142 %2143
-OpStore %426 %2144
-%2145 = OpLoad %_arr_uchar_uint_16 %164
-%2146 = OpCompositeExtract %uchar %2145 7
-OpStore %427 %2146
-%2147 = OpLoad %_arr_uchar_uint_16 %170
-%2148 = OpCompositeExtract %uchar %2147 7
-OpStore %428 %2148
-%2149 = OpLoad %uchar %427
-%2150 = OpLoad %uchar %428
-%2151 = OpIMul %uchar %2149 %2150
-OpStore %429 %2151
-%2152 = OpLoad %_arr_uchar_uint_16 %164
-%2153 = OpCompositeExtract %uchar %2152 8
-OpStore %430 %2153
-%2154 = OpLoad %_arr_uchar_uint_16 %170
-%2155 = OpCompositeExtract %uchar %2154 8
-OpStore %431 %2155
-%2156 = OpLoad %uchar %430
-%2157 = OpLoad %uchar %431
-%2158 = OpIMul %uchar %2156 %2157
-OpStore %432 %2158
-%2159 = OpLoad %_arr_uchar_uint_16 %164
-%2160 = OpCompositeExtract %uchar %2159 9
-OpStore %433 %2160
-%2161 = OpLoad %_arr_uchar_uint_16 %170
-%2162 = OpCompositeExtract %uchar %2161 9
-OpStore %434 %2162
-%2163 = OpLoad %uchar %433
-%2164 = OpLoad %uchar %434
-%2165 = OpIMul %uchar %2163 %2164
-OpStore %435 %2165
-%2166 = OpLoad %_arr_uchar_uint_16 %164
-%2167 = OpCompositeExtract %uchar %2166 10
-OpStore %436 %2167
-%2168 = OpLoad %_arr_uchar_uint_16 %170
-%2169 = OpCompositeExtract %uchar %2168 10
-OpStore %437 %2169
-%2170 = OpLoad %uchar %436
-%2171 = OpLoad %uchar %437
-%2172 = OpIMul %uchar %2170 %2171
-OpStore %438 %2172
-%2173 = OpLoad %_arr_uchar_uint_16 %164
-%2174 = OpCompositeExtract %uchar %2173 11
-OpStore %439 %2174
-%2175 = OpLoad %_arr_uchar_uint_16 %170
-%2176 = OpCompositeExtract %uchar %2175 11
-OpStore %440 %2176
-%2177 = OpLoad %uchar %439
-%2178 = OpLoad %uchar %440
-%2179 = OpIMul %uchar %2177 %2178
-OpStore %441 %2179
-%2180 = OpLoad %_arr_uchar_uint_16 %164
-%2181 = OpCompositeExtract %uchar %2180 12
-OpStore %442 %2181
-%2182 = OpLoad %_arr_uchar_uint_16 %170
-%2183 = OpCompositeExtract %uchar %2182 12
-OpStore %443 %2183
-%2184 = OpLoad %uchar %442
-%2185 = OpLoad %uchar %443
-%2186 = OpIMul %uchar %2184 %2185
-OpStore %444 %2186
-%2187 = OpLoad %_arr_uchar_uint_16 %164
-%2188 = OpCompositeExtract %uchar %2187 13
-OpStore %445 %2188
-%2189 = OpLoad %_arr_uchar_uint_16 %170
-%2190 = OpCompositeExtract %uchar %2189 13
-OpStore %446 %2190
-%2191 = OpLoad %uchar %445
-%2192 = OpLoad %uchar %446
-%2193 = OpIMul %uchar %2191 %2192
-OpStore %447 %2193
-%2194 = OpLoad %_arr_uchar_uint_16 %164
-%2195 = OpCompositeExtract %uchar %2194 14
-OpStore %448 %2195
-%2196 = OpLoad %_arr_uchar_uint_16 %170
-%2197 = OpCompositeExtract %uchar %2196 14
-OpStore %449 %2197
-%2198 = OpLoad %uchar %448
-%2199 = OpLoad %uchar %449
-%2200 = OpIMul %uchar %2198 %2199
-OpStore %450 %2200
-%2201 = OpLoad %_arr_uchar_uint_16 %164
-%2202 = OpCompositeExtract %uchar %2201 15
-OpStore %451 %2202
-%2203 = OpLoad %_arr_uchar_uint_16 %170
-%2204 = OpCompositeExtract %uchar %2203 15
-OpStore %452 %2204
-%2205 = OpLoad %uchar %451
-%2206 = OpLoad %uchar %452
-%2207 = OpIMul %uchar %2205 %2206
-OpStore %453 %2207
-%2208 = OpLoad %_arr_uchar_uint_16 %164
-%2209 = OpLoad %uchar %408
-%2210 = OpCompositeInsert %_arr_uchar_uint_16 %2209 %2208 0
-OpStore %454 %2210
-%2211 = OpLoad %_arr_uchar_uint_16 %454
-%2212 = OpLoad %uchar %411
-%2213 = OpCompositeInsert %_arr_uchar_uint_16 %2212 %2211 1
-OpStore %455 %2213
-%2214 = OpLoad %_arr_uchar_uint_16 %455
-%2215 = OpLoad %uchar %414
-%2216 = OpCompositeInsert %_arr_uchar_uint_16 %2215 %2214 2
-OpStore %456 %2216
-%2217 = OpLoad %_arr_uchar_uint_16 %456
-%2218 = OpLoad %uchar %417
-%2219 = OpCompositeInsert %_arr_uchar_uint_16 %2218 %2217 3
-OpStore %457 %2219
-%2220 = OpLoad %_arr_uchar_uint_16 %457
-%2221 = OpLoad %uchar %420
-%2222 = OpCompositeInsert %_arr_uchar_uint_16 %2221 %2220 4
-OpStore %458 %2222
-%2223 = OpLoad %_arr_uchar_uint_16 %458
-%2224 = OpLoad %uchar %423
-%2225 = OpCompositeInsert %_arr_uchar_uint_16 %2224 %2223 5
-OpStore %459 %2225
-%2226 = OpLoad %_arr_uchar_uint_16 %459
-%2227 = OpLoad %uchar %426
-%2228 = OpCompositeInsert %_arr_uchar_uint_16 %2227 %2226 6
-OpStore %460 %2228
-%2229 = OpLoad %_arr_uchar_uint_16 %460
-%2230 = OpLoad %uchar %429
-%2231 = OpCompositeInsert %_arr_uchar_uint_16 %2230 %2229 7
-OpStore %461 %2231
-%2232 = OpLoad %_arr_uchar_uint_16 %461
-%2233 = OpLoad %uchar %432
-%2234 = OpCompositeInsert %_arr_uchar_uint_16 %2233 %2232 8
-OpStore %462 %2234
-%2235 = OpLoad %_arr_uchar_uint_16 %462
-%2236 = OpLoad %uchar %435
-%2237 = OpCompositeInsert %_arr_uchar_uint_16 %2236 %2235 9
-OpStore %463 %2237
-%2238 = OpLoad %_arr_uchar_uint_16 %463
-%2239 = OpLoad %uchar %438
-%2240 = OpCompositeInsert %_arr_uchar_uint_16 %2239 %2238 10
-OpStore %464 %2240
-%2241 = OpLoad %_arr_uchar_uint_16 %464
-%2242 = OpLoad %uchar %441
-%2243 = OpCompositeInsert %_arr_uchar_uint_16 %2242 %2241 11
-OpStore %465 %2243
-%2244 = OpLoad %_arr_uchar_uint_16 %465
-%2245 = OpLoad %uchar %444
-%2246 = OpCompositeInsert %_arr_uchar_uint_16 %2245 %2244 12
-OpStore %466 %2246
-%2247 = OpLoad %_arr_uchar_uint_16 %466
-%2248 = OpLoad %uchar %447
-%2249 = OpCompositeInsert %_arr_uchar_uint_16 %2248 %2247 13
-OpStore %467 %2249
-%2250 = OpLoad %_arr_uchar_uint_16 %467
-%2251 = OpLoad %uchar %450
-%2252 = OpCompositeInsert %_arr_uchar_uint_16 %2251 %2250 14
-OpStore %468 %2252
-%2253 = OpLoad %_arr_uchar_uint_16 %468
-%2254 = OpLoad %uchar %453
-%2255 = OpCompositeInsert %_arr_uchar_uint_16 %2254 %2253 15
-OpStore %469 %2255
-%2256 = OpLoad %ulong %175
-%2257 = OpLoad %_arr_uchar_uint_16 %469
-%2258 = OpFunctionCall %ulong %1 %2256 %2257
-OpStore %176 %2258
-%2259 = OpLoad %_arr_uchar_uint_16 %164
-%2260 = OpCompositeExtract %uchar %2259 0
-OpStore %470 %2260
-%2261 = OpLoad %_arr_uchar_uint_16 %157
-%2262 = OpCompositeExtract %uchar %2261 0
-OpStore %471 %2262
-%2263 = OpLoad %uchar %470
-%2264 = OpLoad %uchar %471
-%2265 = OpIMul %uchar %2263 %2264
-OpStore %472 %2265
-%2266 = OpLoad %_arr_uchar_uint_16 %164
-%2267 = OpCompositeExtract %uchar %2266 1
-OpStore %473 %2267
-%2268 = OpLoad %_arr_uchar_uint_16 %157
-%2269 = OpCompositeExtract %uchar %2268 1
-OpStore %474 %2269
-%2270 = OpLoad %uchar %473
-%2271 = OpLoad %uchar %474
-%2272 = OpIMul %uchar %2270 %2271
-OpStore %475 %2272
-%2273 = OpLoad %_arr_uchar_uint_16 %164
-%2274 = OpCompositeExtract %uchar %2273 2
-OpStore %476 %2274
-%2275 = OpLoad %_arr_uchar_uint_16 %157
-%2276 = OpCompositeExtract %uchar %2275 2
-OpStore %477 %2276
-%2277 = OpLoad %uchar %476
-%2278 = OpLoad %uchar %477
-%2279 = OpIMul %uchar %2277 %2278
-OpStore %478 %2279
-%2280 = OpLoad %_arr_uchar_uint_16 %164
-%2281 = OpCompositeExtract %uchar %2280 3
-OpStore %479 %2281
-%2282 = OpLoad %_arr_uchar_uint_16 %157
-%2283 = OpCompositeExtract %uchar %2282 3
-OpStore %480 %2283
-%2284 = OpLoad %uchar %479
-%2285 = OpLoad %uchar %480
-%2286 = OpIMul %uchar %2284 %2285
-OpStore %481 %2286
-%2287 = OpLoad %_arr_uchar_uint_16 %164
-%2288 = OpCompositeExtract %uchar %2287 4
-OpStore %482 %2288
-%2289 = OpLoad %_arr_uchar_uint_16 %157
-%2290 = OpCompositeExtract %uchar %2289 4
-OpStore %483 %2290
-%2291 = OpLoad %uchar %482
-%2292 = OpLoad %uchar %483
-%2293 = OpIMul %uchar %2291 %2292
-OpStore %484 %2293
-%2294 = OpLoad %_arr_uchar_uint_16 %164
-%2295 = OpCompositeExtract %uchar %2294 5
-OpStore %485 %2295
-%2296 = OpLoad %_arr_uchar_uint_16 %157
-%2297 = OpCompositeExtract %uchar %2296 5
-OpStore %486 %2297
-%2298 = OpLoad %uchar %485
-%2299 = OpLoad %uchar %486
-%2300 = OpIMul %uchar %2298 %2299
-OpStore %487 %2300
-%2301 = OpLoad %_arr_uchar_uint_16 %164
-%2302 = OpCompositeExtract %uchar %2301 6
-OpStore %488 %2302
-%2303 = OpLoad %_arr_uchar_uint_16 %157
-%2304 = OpCompositeExtract %uchar %2303 6
-OpStore %489 %2304
-%2305 = OpLoad %uchar %488
-%2306 = OpLoad %uchar %489
-%2307 = OpIMul %uchar %2305 %2306
-OpStore %490 %2307
-%2308 = OpLoad %_arr_uchar_uint_16 %164
-%2309 = OpCompositeExtract %uchar %2308 7
-OpStore %491 %2309
-%2310 = OpLoad %_arr_uchar_uint_16 %157
-%2311 = OpCompositeExtract %uchar %2310 7
-OpStore %492 %2311
-%2312 = OpLoad %uchar %491
-%2313 = OpLoad %uchar %492
-%2314 = OpIMul %uchar %2312 %2313
-OpStore %493 %2314
-%2315 = OpLoad %_arr_uchar_uint_16 %164
-%2316 = OpCompositeExtract %uchar %2315 8
-OpStore %494 %2316
-%2317 = OpLoad %_arr_uchar_uint_16 %157
-%2318 = OpCompositeExtract %uchar %2317 8
-OpStore %495 %2318
-%2319 = OpLoad %uchar %494
-%2320 = OpLoad %uchar %495
-%2321 = OpIMul %uchar %2319 %2320
-OpStore %496 %2321
-%2322 = OpLoad %_arr_uchar_uint_16 %164
-%2323 = OpCompositeExtract %uchar %2322 9
-OpStore %497 %2323
-%2324 = OpLoad %_arr_uchar_uint_16 %157
-%2325 = OpCompositeExtract %uchar %2324 9
-OpStore %498 %2325
-%2326 = OpLoad %uchar %497
-%2327 = OpLoad %uchar %498
-%2328 = OpIMul %uchar %2326 %2327
-OpStore %499 %2328
-%2329 = OpLoad %_arr_uchar_uint_16 %164
-%2330 = OpCompositeExtract %uchar %2329 10
-OpStore %500 %2330
-%2331 = OpLoad %_arr_uchar_uint_16 %157
-%2332 = OpCompositeExtract %uchar %2331 10
-OpStore %501 %2332
-%2333 = OpLoad %uchar %500
-%2334 = OpLoad %uchar %501
-%2335 = OpIMul %uchar %2333 %2334
-OpStore %502 %2335
-%2336 = OpLoad %_arr_uchar_uint_16 %164
-%2337 = OpCompositeExtract %uchar %2336 11
-OpStore %503 %2337
-%2338 = OpLoad %_arr_uchar_uint_16 %157
-%2339 = OpCompositeExtract %uchar %2338 11
-OpStore %504 %2339
-%2340 = OpLoad %uchar %503
-%2341 = OpLoad %uchar %504
-%2342 = OpIMul %uchar %2340 %2341
-OpStore %505 %2342
-%2343 = OpLoad %_arr_uchar_uint_16 %164
-%2344 = OpCompositeExtract %uchar %2343 12
-OpStore %506 %2344
-%2345 = OpLoad %_arr_uchar_uint_16 %157
-%2346 = OpCompositeExtract %uchar %2345 12
-OpStore %507 %2346
-%2347 = OpLoad %uchar %506
-%2348 = OpLoad %uchar %507
-%2349 = OpIMul %uchar %2347 %2348
-OpStore %508 %2349
-%2350 = OpLoad %_arr_uchar_uint_16 %164
-%2351 = OpCompositeExtract %uchar %2350 13
-OpStore %509 %2351
-%2352 = OpLoad %_arr_uchar_uint_16 %157
-%2353 = OpCompositeExtract %uchar %2352 13
-OpStore %510 %2353
-%2354 = OpLoad %uchar %509
-%2355 = OpLoad %uchar %510
-%2356 = OpIMul %uchar %2354 %2355
-OpStore %511 %2356
-%2357 = OpLoad %_arr_uchar_uint_16 %164
-%2358 = OpCompositeExtract %uchar %2357 14
-OpStore %512 %2358
-%2359 = OpLoad %_arr_uchar_uint_16 %157
-%2360 = OpCompositeExtract %uchar %2359 14
-OpStore %513 %2360
-%2361 = OpLoad %uchar %512
-%2362 = OpLoad %uchar %513
-%2363 = OpIMul %uchar %2361 %2362
-OpStore %514 %2363
-%2364 = OpLoad %_arr_uchar_uint_16 %164
-%2365 = OpCompositeExtract %uchar %2364 15
-OpStore %515 %2365
-%2366 = OpLoad %_arr_uchar_uint_16 %157
-%2367 = OpCompositeExtract %uchar %2366 15
-OpStore %516 %2367
-%2368 = OpLoad %uchar %515
-%2369 = OpLoad %uchar %516
-%2370 = OpIMul %uchar %2368 %2369
-OpStore %517 %2370
-%2371 = OpLoad %_arr_uchar_uint_16 %164
-%2372 = OpLoad %uchar %472
-%2373 = OpCompositeInsert %_arr_uchar_uint_16 %2372 %2371 0
-OpStore %518 %2373
-%2374 = OpLoad %_arr_uchar_uint_16 %518
-%2375 = OpLoad %uchar %475
-%2376 = OpCompositeInsert %_arr_uchar_uint_16 %2375 %2374 1
-OpStore %519 %2376
-%2377 = OpLoad %_arr_uchar_uint_16 %519
-%2378 = OpLoad %uchar %478
-%2379 = OpCompositeInsert %_arr_uchar_uint_16 %2378 %2377 2
-OpStore %520 %2379
-%2380 = OpLoad %_arr_uchar_uint_16 %520
-%2381 = OpLoad %uchar %481
-%2382 = OpCompositeInsert %_arr_uchar_uint_16 %2381 %2380 3
-OpStore %521 %2382
-%2383 = OpLoad %_arr_uchar_uint_16 %521
-%2384 = OpLoad %uchar %484
-%2385 = OpCompositeInsert %_arr_uchar_uint_16 %2384 %2383 4
-OpStore %522 %2385
-%2386 = OpLoad %_arr_uchar_uint_16 %522
-%2387 = OpLoad %uchar %487
-%2388 = OpCompositeInsert %_arr_uchar_uint_16 %2387 %2386 5
-OpStore %523 %2388
-%2389 = OpLoad %_arr_uchar_uint_16 %523
-%2390 = OpLoad %uchar %490
-%2391 = OpCompositeInsert %_arr_uchar_uint_16 %2390 %2389 6
-OpStore %524 %2391
-%2392 = OpLoad %_arr_uchar_uint_16 %524
-%2393 = OpLoad %uchar %493
-%2394 = OpCompositeInsert %_arr_uchar_uint_16 %2393 %2392 7
-OpStore %525 %2394
-%2395 = OpLoad %_arr_uchar_uint_16 %525
-%2396 = OpLoad %uchar %496
-%2397 = OpCompositeInsert %_arr_uchar_uint_16 %2396 %2395 8
-OpStore %526 %2397
-%2398 = OpLoad %_arr_uchar_uint_16 %526
-%2399 = OpLoad %uchar %499
-%2400 = OpCompositeInsert %_arr_uchar_uint_16 %2399 %2398 9
-OpStore %527 %2400
-%2401 = OpLoad %_arr_uchar_uint_16 %527
-%2402 = OpLoad %uchar %502
-%2403 = OpCompositeInsert %_arr_uchar_uint_16 %2402 %2401 10
-OpStore %528 %2403
-%2404 = OpLoad %_arr_uchar_uint_16 %528
-%2405 = OpLoad %uchar %505
-%2406 = OpCompositeInsert %_arr_uchar_uint_16 %2405 %2404 11
-OpStore %529 %2406
-%2407 = OpLoad %_arr_uchar_uint_16 %529
-%2408 = OpLoad %uchar %508
-%2409 = OpCompositeInsert %_arr_uchar_uint_16 %2408 %2407 12
-OpStore %530 %2409
-%2410 = OpLoad %_arr_uchar_uint_16 %530
-%2411 = OpLoad %uchar %511
-%2412 = OpCompositeInsert %_arr_uchar_uint_16 %2411 %2410 13
-OpStore %531 %2412
-%2413 = OpLoad %_arr_uchar_uint_16 %531
-%2414 = OpLoad %uchar %514
-%2415 = OpCompositeInsert %_arr_uchar_uint_16 %2414 %2413 14
-OpStore %532 %2415
-%2416 = OpLoad %_arr_uchar_uint_16 %532
-%2417 = OpLoad %uchar %517
-%2418 = OpCompositeInsert %_arr_uchar_uint_16 %2417 %2416 15
-OpStore %533 %2418
-%2419 = OpLoad %ulong %176
-%2420 = OpLoad %_arr_uchar_uint_16 %533
-%2421 = OpFunctionCall %ulong %1 %2419 %2420
-OpStore %177 %2421
-%2422 = OpLoad %_arr_uchar_uint_16 %170
-%2423 = OpCompositeExtract %uchar %2422 0
-OpStore %534 %2423
-%2424 = OpLoad %_arr_uchar_uint_16 %157
-%2425 = OpCompositeExtract %uchar %2424 0
-OpStore %535 %2425
-%2426 = OpLoad %uchar %534
-%2427 = OpLoad %uchar %535
-%2428 = OpIMul %uchar %2426 %2427
-OpStore %536 %2428
-%2429 = OpLoad %_arr_uchar_uint_16 %170
-%2430 = OpCompositeExtract %uchar %2429 1
-OpStore %537 %2430
-%2431 = OpLoad %_arr_uchar_uint_16 %157
-%2432 = OpCompositeExtract %uchar %2431 1
-OpStore %538 %2432
-%2433 = OpLoad %uchar %537
-%2434 = OpLoad %uchar %538
-%2435 = OpIMul %uchar %2433 %2434
-OpStore %539 %2435
-%2436 = OpLoad %_arr_uchar_uint_16 %170
-%2437 = OpCompositeExtract %uchar %2436 2
-OpStore %540 %2437
-%2438 = OpLoad %_arr_uchar_uint_16 %157
-%2439 = OpCompositeExtract %uchar %2438 2
-OpStore %541 %2439
-%2440 = OpLoad %uchar %540
-%2441 = OpLoad %uchar %541
-%2442 = OpIMul %uchar %2440 %2441
-OpStore %542 %2442
-%2443 = OpLoad %_arr_uchar_uint_16 %170
-%2444 = OpCompositeExtract %uchar %2443 3
-OpStore %543 %2444
-%2445 = OpLoad %_arr_uchar_uint_16 %157
-%2446 = OpCompositeExtract %uchar %2445 3
-OpStore %544 %2446
-%2447 = OpLoad %uchar %543
-%2448 = OpLoad %uchar %544
-%2449 = OpIMul %uchar %2447 %2448
-OpStore %545 %2449
-%2450 = OpLoad %_arr_uchar_uint_16 %170
-%2451 = OpCompositeExtract %uchar %2450 4
-OpStore %546 %2451
-%2452 = OpLoad %_arr_uchar_uint_16 %157
-%2453 = OpCompositeExtract %uchar %2452 4
-OpStore %547 %2453
-%2454 = OpLoad %uchar %546
-%2455 = OpLoad %uchar %547
-%2456 = OpIMul %uchar %2454 %2455
-OpStore %548 %2456
-%2457 = OpLoad %_arr_uchar_uint_16 %170
-%2458 = OpCompositeExtract %uchar %2457 5
-OpStore %549 %2458
-%2459 = OpLoad %_arr_uchar_uint_16 %157
-%2460 = OpCompositeExtract %uchar %2459 5
-OpStore %550 %2460
-%2461 = OpLoad %uchar %549
-%2462 = OpLoad %uchar %550
-%2463 = OpIMul %uchar %2461 %2462
-OpStore %551 %2463
-%2464 = OpLoad %_arr_uchar_uint_16 %170
-%2465 = OpCompositeExtract %uchar %2464 6
-OpStore %552 %2465
-%2466 = OpLoad %_arr_uchar_uint_16 %157
-%2467 = OpCompositeExtract %uchar %2466 6
-OpStore %553 %2467
-%2468 = OpLoad %uchar %552
-%2469 = OpLoad %uchar %553
-%2470 = OpIMul %uchar %2468 %2469
-OpStore %554 %2470
-%2471 = OpLoad %_arr_uchar_uint_16 %170
-%2472 = OpCompositeExtract %uchar %2471 7
-OpStore %555 %2472
-%2473 = OpLoad %_arr_uchar_uint_16 %157
-%2474 = OpCompositeExtract %uchar %2473 7
-OpStore %556 %2474
-%2475 = OpLoad %uchar %555
-%2476 = OpLoad %uchar %556
-%2477 = OpIMul %uchar %2475 %2476
-OpStore %557 %2477
-%2478 = OpLoad %_arr_uchar_uint_16 %170
-%2479 = OpCompositeExtract %uchar %2478 8
-OpStore %558 %2479
-%2480 = OpLoad %_arr_uchar_uint_16 %157
-%2481 = OpCompositeExtract %uchar %2480 8
-OpStore %559 %2481
-%2482 = OpLoad %uchar %558
-%2483 = OpLoad %uchar %559
-%2484 = OpIMul %uchar %2482 %2483
-OpStore %560 %2484
-%2485 = OpLoad %_arr_uchar_uint_16 %170
-%2486 = OpCompositeExtract %uchar %2485 9
-OpStore %561 %2486
-%2487 = OpLoad %_arr_uchar_uint_16 %157
-%2488 = OpCompositeExtract %uchar %2487 9
-OpStore %562 %2488
-%2489 = OpLoad %uchar %561
-%2490 = OpLoad %uchar %562
-%2491 = OpIMul %uchar %2489 %2490
-OpStore %563 %2491
-%2492 = OpLoad %_arr_uchar_uint_16 %170
-%2493 = OpCompositeExtract %uchar %2492 10
-OpStore %564 %2493
-%2494 = OpLoad %_arr_uchar_uint_16 %157
-%2495 = OpCompositeExtract %uchar %2494 10
-OpStore %565 %2495
-%2496 = OpLoad %uchar %564
-%2497 = OpLoad %uchar %565
-%2498 = OpIMul %uchar %2496 %2497
-OpStore %566 %2498
-%2499 = OpLoad %_arr_uchar_uint_16 %170
-%2500 = OpCompositeExtract %uchar %2499 11
-OpStore %567 %2500
-%2501 = OpLoad %_arr_uchar_uint_16 %157
-%2502 = OpCompositeExtract %uchar %2501 11
-OpStore %568 %2502
-%2503 = OpLoad %uchar %567
-%2504 = OpLoad %uchar %568
-%2505 = OpIMul %uchar %2503 %2504
-OpStore %569 %2505
-%2506 = OpLoad %_arr_uchar_uint_16 %170
-%2507 = OpCompositeExtract %uchar %2506 12
-OpStore %570 %2507
-%2508 = OpLoad %_arr_uchar_uint_16 %157
-%2509 = OpCompositeExtract %uchar %2508 12
-OpStore %571 %2509
-%2510 = OpLoad %uchar %570
-%2511 = OpLoad %uchar %571
-%2512 = OpIMul %uchar %2510 %2511
-OpStore %572 %2512
-%2513 = OpLoad %_arr_uchar_uint_16 %170
-%2514 = OpCompositeExtract %uchar %2513 13
-OpStore %573 %2514
-%2515 = OpLoad %_arr_uchar_uint_16 %157
-%2516 = OpCompositeExtract %uchar %2515 13
-OpStore %574 %2516
-%2517 = OpLoad %uchar %573
-%2518 = OpLoad %uchar %574
-%2519 = OpIMul %uchar %2517 %2518
-OpStore %575 %2519
-%2520 = OpLoad %_arr_uchar_uint_16 %170
-%2521 = OpCompositeExtract %uchar %2520 14
-OpStore %576 %2521
-%2522 = OpLoad %_arr_uchar_uint_16 %157
-%2523 = OpCompositeExtract %uchar %2522 14
-OpStore %577 %2523
-%2524 = OpLoad %uchar %576
-%2525 = OpLoad %uchar %577
-%2526 = OpIMul %uchar %2524 %2525
-OpStore %578 %2526
-%2527 = OpLoad %_arr_uchar_uint_16 %170
-%2528 = OpCompositeExtract %uchar %2527 15
-OpStore %579 %2528
-%2529 = OpLoad %_arr_uchar_uint_16 %157
-%2530 = OpCompositeExtract %uchar %2529 15
-OpStore %580 %2530
-%2531 = OpLoad %uchar %579
-%2532 = OpLoad %uchar %580
-%2533 = OpIMul %uchar %2531 %2532
-OpStore %581 %2533
-%2534 = OpLoad %_arr_uchar_uint_16 %170
-%2535 = OpLoad %uchar %536
-%2536 = OpCompositeInsert %_arr_uchar_uint_16 %2535 %2534 0
-OpStore %582 %2536
-%2537 = OpLoad %_arr_uchar_uint_16 %582
-%2538 = OpLoad %uchar %539
-%2539 = OpCompositeInsert %_arr_uchar_uint_16 %2538 %2537 1
-OpStore %583 %2539
-%2540 = OpLoad %_arr_uchar_uint_16 %583
-%2541 = OpLoad %uchar %542
-%2542 = OpCompositeInsert %_arr_uchar_uint_16 %2541 %2540 2
-OpStore %584 %2542
-%2543 = OpLoad %_arr_uchar_uint_16 %584
-%2544 = OpLoad %uchar %545
-%2545 = OpCompositeInsert %_arr_uchar_uint_16 %2544 %2543 3
-OpStore %585 %2545
-%2546 = OpLoad %_arr_uchar_uint_16 %585
-%2547 = OpLoad %uchar %548
-%2548 = OpCompositeInsert %_arr_uchar_uint_16 %2547 %2546 4
-OpStore %586 %2548
-%2549 = OpLoad %_arr_uchar_uint_16 %586
-%2550 = OpLoad %uchar %551
-%2551 = OpCompositeInsert %_arr_uchar_uint_16 %2550 %2549 5
-OpStore %587 %2551
-%2552 = OpLoad %_arr_uchar_uint_16 %587
-%2553 = OpLoad %uchar %554
-%2554 = OpCompositeInsert %_arr_uchar_uint_16 %2553 %2552 6
-OpStore %588 %2554
-%2555 = OpLoad %_arr_uchar_uint_16 %588
-%2556 = OpLoad %uchar %557
-%2557 = OpCompositeInsert %_arr_uchar_uint_16 %2556 %2555 7
-OpStore %589 %2557
-%2558 = OpLoad %_arr_uchar_uint_16 %589
-%2559 = OpLoad %uchar %560
-%2560 = OpCompositeInsert %_arr_uchar_uint_16 %2559 %2558 8
-OpStore %590 %2560
-%2561 = OpLoad %_arr_uchar_uint_16 %590
-%2562 = OpLoad %uchar %563
-%2563 = OpCompositeInsert %_arr_uchar_uint_16 %2562 %2561 9
-OpStore %591 %2563
-%2564 = OpLoad %_arr_uchar_uint_16 %591
-%2565 = OpLoad %uchar %566
-%2566 = OpCompositeInsert %_arr_uchar_uint_16 %2565 %2564 10
-OpStore %592 %2566
-%2567 = OpLoad %_arr_uchar_uint_16 %592
-%2568 = OpLoad %uchar %569
-%2569 = OpCompositeInsert %_arr_uchar_uint_16 %2568 %2567 11
-OpStore %593 %2569
-%2570 = OpLoad %_arr_uchar_uint_16 %593
-%2571 = OpLoad %uchar %572
-%2572 = OpCompositeInsert %_arr_uchar_uint_16 %2571 %2570 12
-OpStore %594 %2572
-%2573 = OpLoad %_arr_uchar_uint_16 %594
-%2574 = OpLoad %uchar %575
-%2575 = OpCompositeInsert %_arr_uchar_uint_16 %2574 %2573 13
-OpStore %595 %2575
-%2576 = OpLoad %_arr_uchar_uint_16 %595
-%2577 = OpLoad %uchar %578
-%2578 = OpCompositeInsert %_arr_uchar_uint_16 %2577 %2576 14
-OpStore %596 %2578
-%2579 = OpLoad %_arr_uchar_uint_16 %596
-%2580 = OpLoad %uchar %581
-%2581 = OpCompositeInsert %_arr_uchar_uint_16 %2580 %2579 15
-OpStore %597 %2581
-%2582 = OpLoad %ulong %177
-%2583 = OpLoad %_arr_uchar_uint_16 %597
-%2584 = OpFunctionCall %ulong %1 %2582 %2583
-OpStore %178 %2584
-%2585 = OpLoad %_arr_uchar_uint_16 %277
-%2586 = OpCompositeExtract %uchar %2585 0
-OpStore %598 %2586
-%2587 = OpLoad %_arr_uchar_uint_16 %157
-%2588 = OpCompositeExtract %uchar %2587 0
-OpStore %599 %2588
-%2589 = OpLoad %uchar %598
-%2590 = OpLoad %uchar %599
-%2591 = OpIMul %uchar %2589 %2590
-OpStore %600 %2591
-%2592 = OpLoad %_arr_uchar_uint_16 %277
-%2593 = OpCompositeExtract %uchar %2592 1
-OpStore %601 %2593
-%2594 = OpLoad %_arr_uchar_uint_16 %157
-%2595 = OpCompositeExtract %uchar %2594 1
-OpStore %602 %2595
-%2596 = OpLoad %uchar %601
-%2597 = OpLoad %uchar %602
-%2598 = OpIMul %uchar %2596 %2597
-OpStore %603 %2598
-%2599 = OpLoad %_arr_uchar_uint_16 %277
-%2600 = OpCompositeExtract %uchar %2599 2
-OpStore %604 %2600
-%2601 = OpLoad %_arr_uchar_uint_16 %157
-%2602 = OpCompositeExtract %uchar %2601 2
-OpStore %605 %2602
-%2603 = OpLoad %uchar %604
-%2604 = OpLoad %uchar %605
-%2605 = OpIMul %uchar %2603 %2604
-OpStore %606 %2605
-%2606 = OpLoad %_arr_uchar_uint_16 %277
-%2607 = OpCompositeExtract %uchar %2606 3
-OpStore %607 %2607
-%2608 = OpLoad %_arr_uchar_uint_16 %157
-%2609 = OpCompositeExtract %uchar %2608 3
-OpStore %608 %2609
-%2610 = OpLoad %uchar %607
-%2611 = OpLoad %uchar %608
-%2612 = OpIMul %uchar %2610 %2611
-OpStore %609 %2612
-%2613 = OpLoad %_arr_uchar_uint_16 %277
-%2614 = OpCompositeExtract %uchar %2613 4
-OpStore %610 %2614
-%2615 = OpLoad %_arr_uchar_uint_16 %157
-%2616 = OpCompositeExtract %uchar %2615 4
-OpStore %611 %2616
-%2617 = OpLoad %uchar %610
-%2618 = OpLoad %uchar %611
-%2619 = OpIMul %uchar %2617 %2618
-OpStore %612 %2619
-%2620 = OpLoad %_arr_uchar_uint_16 %277
-%2621 = OpCompositeExtract %uchar %2620 5
-OpStore %613 %2621
-%2622 = OpLoad %_arr_uchar_uint_16 %157
-%2623 = OpCompositeExtract %uchar %2622 5
-OpStore %614 %2623
-%2624 = OpLoad %uchar %613
-%2625 = OpLoad %uchar %614
-%2626 = OpIMul %uchar %2624 %2625
-OpStore %615 %2626
-%2627 = OpLoad %_arr_uchar_uint_16 %277
-%2628 = OpCompositeExtract %uchar %2627 6
-OpStore %616 %2628
-%2629 = OpLoad %_arr_uchar_uint_16 %157
-%2630 = OpCompositeExtract %uchar %2629 6
-OpStore %617 %2630
-%2631 = OpLoad %uchar %616
-%2632 = OpLoad %uchar %617
-%2633 = OpIMul %uchar %2631 %2632
-OpStore %618 %2633
-%2634 = OpLoad %_arr_uchar_uint_16 %277
-%2635 = OpCompositeExtract %uchar %2634 7
-OpStore %619 %2635
-%2636 = OpLoad %_arr_uchar_uint_16 %157
-%2637 = OpCompositeExtract %uchar %2636 7
-OpStore %620 %2637
-%2638 = OpLoad %uchar %619
-%2639 = OpLoad %uchar %620
-%2640 = OpIMul %uchar %2638 %2639
-OpStore %621 %2640
-%2641 = OpLoad %_arr_uchar_uint_16 %277
-%2642 = OpCompositeExtract %uchar %2641 8
-OpStore %622 %2642
-%2643 = OpLoad %_arr_uchar_uint_16 %157
-%2644 = OpCompositeExtract %uchar %2643 8
-OpStore %623 %2644
-%2645 = OpLoad %uchar %622
-%2646 = OpLoad %uchar %623
-%2647 = OpIMul %uchar %2645 %2646
-OpStore %624 %2647
-%2648 = OpLoad %_arr_uchar_uint_16 %277
-%2649 = OpCompositeExtract %uchar %2648 9
-OpStore %625 %2649
-%2650 = OpLoad %_arr_uchar_uint_16 %157
-%2651 = OpCompositeExtract %uchar %2650 9
-OpStore %626 %2651
-%2652 = OpLoad %uchar %625
-%2653 = OpLoad %uchar %626
-%2654 = OpIMul %uchar %2652 %2653
-OpStore %627 %2654
-%2655 = OpLoad %_arr_uchar_uint_16 %277
-%2656 = OpCompositeExtract %uchar %2655 10
-OpStore %628 %2656
-%2657 = OpLoad %_arr_uchar_uint_16 %157
-%2658 = OpCompositeExtract %uchar %2657 10
-OpStore %629 %2658
-%2659 = OpLoad %uchar %628
-%2660 = OpLoad %uchar %629
-%2661 = OpIMul %uchar %2659 %2660
-OpStore %630 %2661
-%2662 = OpLoad %_arr_uchar_uint_16 %277
-%2663 = OpCompositeExtract %uchar %2662 11
-OpStore %631 %2663
-%2664 = OpLoad %_arr_uchar_uint_16 %157
-%2665 = OpCompositeExtract %uchar %2664 11
-OpStore %632 %2665
-%2666 = OpLoad %uchar %631
-%2667 = OpLoad %uchar %632
-%2668 = OpIMul %uchar %2666 %2667
-OpStore %633 %2668
-%2669 = OpLoad %_arr_uchar_uint_16 %277
-%2670 = OpCompositeExtract %uchar %2669 12
-OpStore %634 %2670
-%2671 = OpLoad %_arr_uchar_uint_16 %157
-%2672 = OpCompositeExtract %uchar %2671 12
-OpStore %635 %2672
-%2673 = OpLoad %uchar %634
-%2674 = OpLoad %uchar %635
-%2675 = OpIMul %uchar %2673 %2674
-OpStore %636 %2675
-%2676 = OpLoad %_arr_uchar_uint_16 %277
-%2677 = OpCompositeExtract %uchar %2676 13
-OpStore %637 %2677
-%2678 = OpLoad %_arr_uchar_uint_16 %157
-%2679 = OpCompositeExtract %uchar %2678 13
-OpStore %638 %2679
-%2680 = OpLoad %uchar %637
-%2681 = OpLoad %uchar %638
-%2682 = OpIMul %uchar %2680 %2681
-OpStore %639 %2682
-%2683 = OpLoad %_arr_uchar_uint_16 %277
-%2684 = OpCompositeExtract %uchar %2683 14
-OpStore %640 %2684
-%2685 = OpLoad %_arr_uchar_uint_16 %157
-%2686 = OpCompositeExtract %uchar %2685 14
-OpStore %641 %2686
-%2687 = OpLoad %uchar %640
-%2688 = OpLoad %uchar %641
-%2689 = OpIMul %uchar %2687 %2688
-OpStore %642 %2689
-%2690 = OpLoad %_arr_uchar_uint_16 %277
-%2691 = OpCompositeExtract %uchar %2690 15
-OpStore %643 %2691
-%2692 = OpLoad %_arr_uchar_uint_16 %157
-%2693 = OpCompositeExtract %uchar %2692 15
-OpStore %644 %2693
-%2694 = OpLoad %uchar %643
-%2695 = OpLoad %uchar %644
-%2696 = OpIMul %uchar %2694 %2695
-OpStore %645 %2696
-%2697 = OpLoad %_arr_uchar_uint_16 %277
-%2698 = OpLoad %uchar %600
-%2699 = OpCompositeInsert %_arr_uchar_uint_16 %2698 %2697 0
-OpStore %646 %2699
-%2700 = OpLoad %_arr_uchar_uint_16 %646
-%2701 = OpLoad %uchar %603
-%2702 = OpCompositeInsert %_arr_uchar_uint_16 %2701 %2700 1
-OpStore %647 %2702
-%2703 = OpLoad %_arr_uchar_uint_16 %647
-%2704 = OpLoad %uchar %606
-%2705 = OpCompositeInsert %_arr_uchar_uint_16 %2704 %2703 2
-OpStore %648 %2705
-%2706 = OpLoad %_arr_uchar_uint_16 %648
-%2707 = OpLoad %uchar %609
-%2708 = OpCompositeInsert %_arr_uchar_uint_16 %2707 %2706 3
-OpStore %649 %2708
-%2709 = OpLoad %_arr_uchar_uint_16 %649
-%2710 = OpLoad %uchar %612
-%2711 = OpCompositeInsert %_arr_uchar_uint_16 %2710 %2709 4
-OpStore %650 %2711
-%2712 = OpLoad %_arr_uchar_uint_16 %650
-%2713 = OpLoad %uchar %615
-%2714 = OpCompositeInsert %_arr_uchar_uint_16 %2713 %2712 5
-OpStore %651 %2714
-%2715 = OpLoad %_arr_uchar_uint_16 %651
-%2716 = OpLoad %uchar %618
-%2717 = OpCompositeInsert %_arr_uchar_uint_16 %2716 %2715 6
-OpStore %652 %2717
-%2718 = OpLoad %_arr_uchar_uint_16 %652
-%2719 = OpLoad %uchar %621
-%2720 = OpCompositeInsert %_arr_uchar_uint_16 %2719 %2718 7
-OpStore %653 %2720
-%2721 = OpLoad %_arr_uchar_uint_16 %653
-%2722 = OpLoad %uchar %624
-%2723 = OpCompositeInsert %_arr_uchar_uint_16 %2722 %2721 8
-OpStore %654 %2723
-%2724 = OpLoad %_arr_uchar_uint_16 %654
-%2725 = OpLoad %uchar %627
-%2726 = OpCompositeInsert %_arr_uchar_uint_16 %2725 %2724 9
-OpStore %655 %2726
-%2727 = OpLoad %_arr_uchar_uint_16 %655
-%2728 = OpLoad %uchar %630
-%2729 = OpCompositeInsert %_arr_uchar_uint_16 %2728 %2727 10
-OpStore %656 %2729
-%2730 = OpLoad %_arr_uchar_uint_16 %656
-%2731 = OpLoad %uchar %633
-%2732 = OpCompositeInsert %_arr_uchar_uint_16 %2731 %2730 11
-OpStore %657 %2732
-%2733 = OpLoad %_arr_uchar_uint_16 %657
-%2734 = OpLoad %uchar %636
-%2735 = OpCompositeInsert %_arr_uchar_uint_16 %2734 %2733 12
-OpStore %658 %2735
-%2736 = OpLoad %_arr_uchar_uint_16 %658
-%2737 = OpLoad %uchar %639
-%2738 = OpCompositeInsert %_arr_uchar_uint_16 %2737 %2736 13
-OpStore %659 %2738
-%2739 = OpLoad %_arr_uchar_uint_16 %659
-%2740 = OpLoad %uchar %642
-%2741 = OpCompositeInsert %_arr_uchar_uint_16 %2740 %2739 14
-OpStore %660 %2741
-%2742 = OpLoad %_arr_uchar_uint_16 %660
-%2743 = OpLoad %uchar %645
-%2744 = OpCompositeInsert %_arr_uchar_uint_16 %2743 %2742 15
-OpStore %661 %2744
-%2745 = OpLoad %ulong %178
-%2746 = OpLoad %_arr_uchar_uint_16 %661
-%2747 = OpFunctionCall %ulong %1 %2745 %2746
-OpStore %179 %2747
-%2748 = OpLoad %_arr_uchar_uint_16 %158
-%2749 = OpCompositeExtract %uchar %2748 0
-OpStore %662 %2749
-%2750 = OpLoad %_arr_uchar_uint_16 %164
-%2751 = OpCompositeExtract %uchar %2750 0
-OpStore %663 %2751
-%2752 = OpLoad %uchar %662
-%2753 = OpLoad %uchar %663
-%2754 = OpISub %uchar %2752 %2753
-OpStore %664 %2754
-%2755 = OpLoad %_arr_uchar_uint_16 %158
-%2756 = OpCompositeExtract %uchar %2755 1
-OpStore %665 %2756
-%2757 = OpLoad %_arr_uchar_uint_16 %164
-%2758 = OpCompositeExtract %uchar %2757 1
-OpStore %666 %2758
-%2759 = OpLoad %uchar %665
-%2760 = OpLoad %uchar %666
-%2761 = OpISub %uchar %2759 %2760
-OpStore %667 %2761
-%2762 = OpLoad %_arr_uchar_uint_16 %158
-%2763 = OpCompositeExtract %uchar %2762 2
-OpStore %668 %2763
-%2764 = OpLoad %_arr_uchar_uint_16 %164
-%2765 = OpCompositeExtract %uchar %2764 2
-OpStore %669 %2765
-%2766 = OpLoad %uchar %668
-%2767 = OpLoad %uchar %669
-%2768 = OpISub %uchar %2766 %2767
-OpStore %670 %2768
-%2769 = OpLoad %_arr_uchar_uint_16 %158
-%2770 = OpCompositeExtract %uchar %2769 3
-OpStore %671 %2770
-%2771 = OpLoad %_arr_uchar_uint_16 %164
-%2772 = OpCompositeExtract %uchar %2771 3
-OpStore %672 %2772
-%2773 = OpLoad %uchar %671
-%2774 = OpLoad %uchar %672
-%2775 = OpISub %uchar %2773 %2774
-OpStore %673 %2775
-%2776 = OpLoad %_arr_uchar_uint_16 %158
-%2777 = OpCompositeExtract %uchar %2776 4
-OpStore %674 %2777
-%2778 = OpLoad %_arr_uchar_uint_16 %164
-%2779 = OpCompositeExtract %uchar %2778 4
-OpStore %675 %2779
-%2780 = OpLoad %uchar %674
-%2781 = OpLoad %uchar %675
-%2782 = OpISub %uchar %2780 %2781
-OpStore %676 %2782
-%2783 = OpLoad %_arr_uchar_uint_16 %158
-%2784 = OpCompositeExtract %uchar %2783 5
-OpStore %677 %2784
-%2785 = OpLoad %_arr_uchar_uint_16 %164
-%2786 = OpCompositeExtract %uchar %2785 5
-OpStore %678 %2786
-%2787 = OpLoad %uchar %677
-%2788 = OpLoad %uchar %678
-%2789 = OpISub %uchar %2787 %2788
-OpStore %679 %2789
-%2790 = OpLoad %_arr_uchar_uint_16 %158
-%2791 = OpCompositeExtract %uchar %2790 6
-OpStore %680 %2791
-%2792 = OpLoad %_arr_uchar_uint_16 %164
-%2793 = OpCompositeExtract %uchar %2792 6
-OpStore %681 %2793
-%2794 = OpLoad %uchar %680
-%2795 = OpLoad %uchar %681
-%2796 = OpISub %uchar %2794 %2795
-OpStore %682 %2796
-%2797 = OpLoad %_arr_uchar_uint_16 %158
-%2798 = OpCompositeExtract %uchar %2797 7
-OpStore %683 %2798
-%2799 = OpLoad %_arr_uchar_uint_16 %164
-%2800 = OpCompositeExtract %uchar %2799 7
-OpStore %684 %2800
-%2801 = OpLoad %uchar %683
-%2802 = OpLoad %uchar %684
-%2803 = OpISub %uchar %2801 %2802
-OpStore %685 %2803
-%2804 = OpLoad %_arr_uchar_uint_16 %158
-%2805 = OpCompositeExtract %uchar %2804 8
-OpStore %686 %2805
-%2806 = OpLoad %_arr_uchar_uint_16 %164
-%2807 = OpCompositeExtract %uchar %2806 8
-OpStore %687 %2807
-%2808 = OpLoad %uchar %686
-%2809 = OpLoad %uchar %687
-%2810 = OpISub %uchar %2808 %2809
-OpStore %688 %2810
-%2811 = OpLoad %_arr_uchar_uint_16 %158
-%2812 = OpCompositeExtract %uchar %2811 9
-OpStore %689 %2812
-%2813 = OpLoad %_arr_uchar_uint_16 %164
-%2814 = OpCompositeExtract %uchar %2813 9
-OpStore %690 %2814
-%2815 = OpLoad %uchar %689
-%2816 = OpLoad %uchar %690
-%2817 = OpISub %uchar %2815 %2816
-OpStore %691 %2817
-%2818 = OpLoad %_arr_uchar_uint_16 %158
-%2819 = OpCompositeExtract %uchar %2818 10
-OpStore %692 %2819
-%2820 = OpLoad %_arr_uchar_uint_16 %164
-%2821 = OpCompositeExtract %uchar %2820 10
-OpStore %693 %2821
-%2822 = OpLoad %uchar %692
-%2823 = OpLoad %uchar %693
-%2824 = OpISub %uchar %2822 %2823
-OpStore %694 %2824
-%2825 = OpLoad %_arr_uchar_uint_16 %158
-%2826 = OpCompositeExtract %uchar %2825 11
-OpStore %695 %2826
-%2827 = OpLoad %_arr_uchar_uint_16 %164
-%2828 = OpCompositeExtract %uchar %2827 11
-OpStore %696 %2828
-%2829 = OpLoad %uchar %695
-%2830 = OpLoad %uchar %696
-%2831 = OpISub %uchar %2829 %2830
-OpStore %697 %2831
-%2832 = OpLoad %_arr_uchar_uint_16 %158
-%2833 = OpCompositeExtract %uchar %2832 12
-OpStore %698 %2833
-%2834 = OpLoad %_arr_uchar_uint_16 %164
-%2835 = OpCompositeExtract %uchar %2834 12
-OpStore %699 %2835
-%2836 = OpLoad %uchar %698
-%2837 = OpLoad %uchar %699
-%2838 = OpISub %uchar %2836 %2837
-OpStore %700 %2838
-%2839 = OpLoad %_arr_uchar_uint_16 %158
-%2840 = OpCompositeExtract %uchar %2839 13
-OpStore %701 %2840
-%2841 = OpLoad %_arr_uchar_uint_16 %164
-%2842 = OpCompositeExtract %uchar %2841 13
-OpStore %702 %2842
-%2843 = OpLoad %uchar %701
-%2844 = OpLoad %uchar %702
-%2845 = OpISub %uchar %2843 %2844
-OpStore %703 %2845
-%2846 = OpLoad %_arr_uchar_uint_16 %158
-%2847 = OpCompositeExtract %uchar %2846 14
-OpStore %704 %2847
-%2848 = OpLoad %_arr_uchar_uint_16 %164
-%2849 = OpCompositeExtract %uchar %2848 14
-OpStore %705 %2849
-%2850 = OpLoad %uchar %704
-%2851 = OpLoad %uchar %705
-%2852 = OpISub %uchar %2850 %2851
-OpStore %706 %2852
-%2853 = OpLoad %_arr_uchar_uint_16 %158
-%2854 = OpCompositeExtract %uchar %2853 15
-OpStore %707 %2854
-%2855 = OpLoad %_arr_uchar_uint_16 %164
-%2856 = OpCompositeExtract %uchar %2855 15
-OpStore %708 %2856
-%2857 = OpLoad %uchar %707
-%2858 = OpLoad %uchar %708
-%2859 = OpISub %uchar %2857 %2858
-OpStore %709 %2859
-%2860 = OpLoad %_arr_uchar_uint_16 %158
-%2861 = OpLoad %uchar %664
-%2862 = OpCompositeInsert %_arr_uchar_uint_16 %2861 %2860 0
-OpStore %710 %2862
-%2863 = OpLoad %_arr_uchar_uint_16 %710
-%2864 = OpLoad %uchar %667
-%2865 = OpCompositeInsert %_arr_uchar_uint_16 %2864 %2863 1
-OpStore %711 %2865
-%2866 = OpLoad %_arr_uchar_uint_16 %711
-%2867 = OpLoad %uchar %670
-%2868 = OpCompositeInsert %_arr_uchar_uint_16 %2867 %2866 2
-OpStore %712 %2868
-%2869 = OpLoad %_arr_uchar_uint_16 %712
-%2870 = OpLoad %uchar %673
-%2871 = OpCompositeInsert %_arr_uchar_uint_16 %2870 %2869 3
-OpStore %713 %2871
-%2872 = OpLoad %_arr_uchar_uint_16 %713
-%2873 = OpLoad %uchar %676
-%2874 = OpCompositeInsert %_arr_uchar_uint_16 %2873 %2872 4
-OpStore %714 %2874
-%2875 = OpLoad %_arr_uchar_uint_16 %714
-%2876 = OpLoad %uchar %679
-%2877 = OpCompositeInsert %_arr_uchar_uint_16 %2876 %2875 5
-OpStore %715 %2877
-%2878 = OpLoad %_arr_uchar_uint_16 %715
-%2879 = OpLoad %uchar %682
-%2880 = OpCompositeInsert %_arr_uchar_uint_16 %2879 %2878 6
-OpStore %716 %2880
-%2881 = OpLoad %_arr_uchar_uint_16 %716
-%2882 = OpLoad %uchar %685
-%2883 = OpCompositeInsert %_arr_uchar_uint_16 %2882 %2881 7
-OpStore %717 %2883
-%2884 = OpLoad %_arr_uchar_uint_16 %717
-%2885 = OpLoad %uchar %688
-%2886 = OpCompositeInsert %_arr_uchar_uint_16 %2885 %2884 8
-OpStore %718 %2886
-%2887 = OpLoad %_arr_uchar_uint_16 %718
-%2888 = OpLoad %uchar %691
-%2889 = OpCompositeInsert %_arr_uchar_uint_16 %2888 %2887 9
-OpStore %719 %2889
-%2890 = OpLoad %_arr_uchar_uint_16 %719
-%2891 = OpLoad %uchar %694
-%2892 = OpCompositeInsert %_arr_uchar_uint_16 %2891 %2890 10
-OpStore %720 %2892
-%2893 = OpLoad %_arr_uchar_uint_16 %720
-%2894 = OpLoad %uchar %697
-%2895 = OpCompositeInsert %_arr_uchar_uint_16 %2894 %2893 11
-OpStore %721 %2895
-%2896 = OpLoad %_arr_uchar_uint_16 %721
-%2897 = OpLoad %uchar %700
-%2898 = OpCompositeInsert %_arr_uchar_uint_16 %2897 %2896 12
-OpStore %722 %2898
-%2899 = OpLoad %_arr_uchar_uint_16 %722
-%2900 = OpLoad %uchar %703
-%2901 = OpCompositeInsert %_arr_uchar_uint_16 %2900 %2899 13
-OpStore %723 %2901
-%2902 = OpLoad %_arr_uchar_uint_16 %723
-%2903 = OpLoad %uchar %706
-%2904 = OpCompositeInsert %_arr_uchar_uint_16 %2903 %2902 14
-OpStore %724 %2904
-%2905 = OpLoad %_arr_uchar_uint_16 %724
-%2906 = OpLoad %uchar %709
-%2907 = OpCompositeInsert %_arr_uchar_uint_16 %2906 %2905 15
-OpStore %725 %2907
-%2908 = OpLoad %ulong %179
-%2909 = OpLoad %_arr_uchar_uint_16 %725
-%2910 = OpFunctionCall %ulong %1 %2908 %2909
-OpStore %180 %2910
-%2911 = OpLoad %_arr_uchar_uint_16 %158
-%2912 = OpCompositeExtract %uchar %2911 0
-OpStore %726 %2912
-%2913 = OpLoad %_arr_uchar_uint_16 %170
-%2914 = OpCompositeExtract %uchar %2913 0
-OpStore %727 %2914
-%2915 = OpLoad %uchar %726
-%2916 = OpLoad %uchar %727
-%2917 = OpISub %uchar %2915 %2916
-OpStore %728 %2917
-%2918 = OpLoad %_arr_uchar_uint_16 %158
-%2919 = OpCompositeExtract %uchar %2918 1
-OpStore %729 %2919
-%2920 = OpLoad %_arr_uchar_uint_16 %170
-%2921 = OpCompositeExtract %uchar %2920 1
-OpStore %730 %2921
-%2922 = OpLoad %uchar %729
-%2923 = OpLoad %uchar %730
-%2924 = OpISub %uchar %2922 %2923
-OpStore %731 %2924
-%2925 = OpLoad %_arr_uchar_uint_16 %158
-%2926 = OpCompositeExtract %uchar %2925 2
-OpStore %732 %2926
-%2927 = OpLoad %_arr_uchar_uint_16 %170
-%2928 = OpCompositeExtract %uchar %2927 2
-OpStore %733 %2928
-%2929 = OpLoad %uchar %732
-%2930 = OpLoad %uchar %733
-%2931 = OpISub %uchar %2929 %2930
-OpStore %734 %2931
-%2932 = OpLoad %_arr_uchar_uint_16 %158
-%2933 = OpCompositeExtract %uchar %2932 3
-OpStore %735 %2933
-%2934 = OpLoad %_arr_uchar_uint_16 %170
-%2935 = OpCompositeExtract %uchar %2934 3
-OpStore %736 %2935
-%2936 = OpLoad %uchar %735
-%2937 = OpLoad %uchar %736
-%2938 = OpISub %uchar %2936 %2937
-OpStore %737 %2938
-%2939 = OpLoad %_arr_uchar_uint_16 %158
-%2940 = OpCompositeExtract %uchar %2939 4
-OpStore %738 %2940
-%2941 = OpLoad %_arr_uchar_uint_16 %170
-%2942 = OpCompositeExtract %uchar %2941 4
-OpStore %739 %2942
-%2943 = OpLoad %uchar %738
-%2944 = OpLoad %uchar %739
-%2945 = OpISub %uchar %2943 %2944
-OpStore %740 %2945
-%2946 = OpLoad %_arr_uchar_uint_16 %158
-%2947 = OpCompositeExtract %uchar %2946 5
-OpStore %741 %2947
-%2948 = OpLoad %_arr_uchar_uint_16 %170
-%2949 = OpCompositeExtract %uchar %2948 5
-OpStore %742 %2949
-%2950 = OpLoad %uchar %741
-%2951 = OpLoad %uchar %742
-%2952 = OpISub %uchar %2950 %2951
-OpStore %743 %2952
-%2953 = OpLoad %_arr_uchar_uint_16 %158
-%2954 = OpCompositeExtract %uchar %2953 6
-OpStore %744 %2954
-%2955 = OpLoad %_arr_uchar_uint_16 %170
-%2956 = OpCompositeExtract %uchar %2955 6
-OpStore %745 %2956
-%2957 = OpLoad %uchar %744
-%2958 = OpLoad %uchar %745
-%2959 = OpISub %uchar %2957 %2958
-OpStore %746 %2959
-%2960 = OpLoad %_arr_uchar_uint_16 %158
-%2961 = OpCompositeExtract %uchar %2960 7
-OpStore %747 %2961
-%2962 = OpLoad %_arr_uchar_uint_16 %170
-%2963 = OpCompositeExtract %uchar %2962 7
-OpStore %748 %2963
-%2964 = OpLoad %uchar %747
-%2965 = OpLoad %uchar %748
-%2966 = OpISub %uchar %2964 %2965
-OpStore %749 %2966
-%2967 = OpLoad %_arr_uchar_uint_16 %158
-%2968 = OpCompositeExtract %uchar %2967 8
-OpStore %750 %2968
-%2969 = OpLoad %_arr_uchar_uint_16 %170
-%2970 = OpCompositeExtract %uchar %2969 8
-OpStore %751 %2970
-%2971 = OpLoad %uchar %750
-%2972 = OpLoad %uchar %751
-%2973 = OpISub %uchar %2971 %2972
-OpStore %752 %2973
-%2974 = OpLoad %_arr_uchar_uint_16 %158
-%2975 = OpCompositeExtract %uchar %2974 9
-OpStore %753 %2975
-%2976 = OpLoad %_arr_uchar_uint_16 %170
-%2977 = OpCompositeExtract %uchar %2976 9
-OpStore %754 %2977
-%2978 = OpLoad %uchar %753
-%2979 = OpLoad %uchar %754
-%2980 = OpISub %uchar %2978 %2979
-OpStore %755 %2980
-%2981 = OpLoad %_arr_uchar_uint_16 %158
-%2982 = OpCompositeExtract %uchar %2981 10
-OpStore %756 %2982
-%2983 = OpLoad %_arr_uchar_uint_16 %170
-%2984 = OpCompositeExtract %uchar %2983 10
-OpStore %757 %2984
-%2985 = OpLoad %uchar %756
-%2986 = OpLoad %uchar %757
-%2987 = OpISub %uchar %2985 %2986
-OpStore %758 %2987
-%2988 = OpLoad %_arr_uchar_uint_16 %158
-%2989 = OpCompositeExtract %uchar %2988 11
-OpStore %759 %2989
-%2990 = OpLoad %_arr_uchar_uint_16 %170
-%2991 = OpCompositeExtract %uchar %2990 11
-OpStore %760 %2991
-%2992 = OpLoad %uchar %759
-%2993 = OpLoad %uchar %760
-%2994 = OpISub %uchar %2992 %2993
-OpStore %761 %2994
-%2995 = OpLoad %_arr_uchar_uint_16 %158
-%2996 = OpCompositeExtract %uchar %2995 12
-OpStore %762 %2996
-%2997 = OpLoad %_arr_uchar_uint_16 %170
-%2998 = OpCompositeExtract %uchar %2997 12
-OpStore %763 %2998
-%2999 = OpLoad %uchar %762
-%3000 = OpLoad %uchar %763
-%3001 = OpISub %uchar %2999 %3000
-OpStore %764 %3001
-%3002 = OpLoad %_arr_uchar_uint_16 %158
-%3003 = OpCompositeExtract %uchar %3002 13
-OpStore %765 %3003
-%3004 = OpLoad %_arr_uchar_uint_16 %170
-%3005 = OpCompositeExtract %uchar %3004 13
-OpStore %766 %3005
-%3006 = OpLoad %uchar %765
-%3007 = OpLoad %uchar %766
-%3008 = OpISub %uchar %3006 %3007
-OpStore %767 %3008
-%3009 = OpLoad %_arr_uchar_uint_16 %158
-%3010 = OpCompositeExtract %uchar %3009 14
-OpStore %768 %3010
-%3011 = OpLoad %_arr_uchar_uint_16 %170
-%3012 = OpCompositeExtract %uchar %3011 14
-OpStore %769 %3012
-%3013 = OpLoad %uchar %768
-%3014 = OpLoad %uchar %769
-%3015 = OpISub %uchar %3013 %3014
-OpStore %770 %3015
-%3016 = OpLoad %_arr_uchar_uint_16 %158
-%3017 = OpCompositeExtract %uchar %3016 15
-OpStore %771 %3017
-%3018 = OpLoad %_arr_uchar_uint_16 %170
-%3019 = OpCompositeExtract %uchar %3018 15
-OpStore %772 %3019
-%3020 = OpLoad %uchar %771
-%3021 = OpLoad %uchar %772
-%3022 = OpISub %uchar %3020 %3021
-OpStore %773 %3022
-%3023 = OpLoad %_arr_uchar_uint_16 %158
-%3024 = OpLoad %uchar %728
-%3025 = OpCompositeInsert %_arr_uchar_uint_16 %3024 %3023 0
-OpStore %774 %3025
-%3026 = OpLoad %_arr_uchar_uint_16 %774
-%3027 = OpLoad %uchar %731
-%3028 = OpCompositeInsert %_arr_uchar_uint_16 %3027 %3026 1
-OpStore %775 %3028
-%3029 = OpLoad %_arr_uchar_uint_16 %775
-%3030 = OpLoad %uchar %734
-%3031 = OpCompositeInsert %_arr_uchar_uint_16 %3030 %3029 2
-OpStore %776 %3031
-%3032 = OpLoad %_arr_uchar_uint_16 %776
-%3033 = OpLoad %uchar %737
-%3034 = OpCompositeInsert %_arr_uchar_uint_16 %3033 %3032 3
-OpStore %777 %3034
-%3035 = OpLoad %_arr_uchar_uint_16 %777
-%3036 = OpLoad %uchar %740
-%3037 = OpCompositeInsert %_arr_uchar_uint_16 %3036 %3035 4
-OpStore %778 %3037
-%3038 = OpLoad %_arr_uchar_uint_16 %778
-%3039 = OpLoad %uchar %743
-%3040 = OpCompositeInsert %_arr_uchar_uint_16 %3039 %3038 5
-OpStore %779 %3040
-%3041 = OpLoad %_arr_uchar_uint_16 %779
-%3042 = OpLoad %uchar %746
-%3043 = OpCompositeInsert %_arr_uchar_uint_16 %3042 %3041 6
-OpStore %780 %3043
-%3044 = OpLoad %_arr_uchar_uint_16 %780
-%3045 = OpLoad %uchar %749
-%3046 = OpCompositeInsert %_arr_uchar_uint_16 %3045 %3044 7
-OpStore %781 %3046
-%3047 = OpLoad %_arr_uchar_uint_16 %781
-%3048 = OpLoad %uchar %752
-%3049 = OpCompositeInsert %_arr_uchar_uint_16 %3048 %3047 8
-OpStore %782 %3049
-%3050 = OpLoad %_arr_uchar_uint_16 %782
-%3051 = OpLoad %uchar %755
-%3052 = OpCompositeInsert %_arr_uchar_uint_16 %3051 %3050 9
-OpStore %783 %3052
-%3053 = OpLoad %_arr_uchar_uint_16 %783
-%3054 = OpLoad %uchar %758
-%3055 = OpCompositeInsert %_arr_uchar_uint_16 %3054 %3053 10
-OpStore %784 %3055
-%3056 = OpLoad %_arr_uchar_uint_16 %784
-%3057 = OpLoad %uchar %761
-%3058 = OpCompositeInsert %_arr_uchar_uint_16 %3057 %3056 11
-OpStore %785 %3058
-%3059 = OpLoad %_arr_uchar_uint_16 %785
-%3060 = OpLoad %uchar %764
-%3061 = OpCompositeInsert %_arr_uchar_uint_16 %3060 %3059 12
-OpStore %786 %3061
-%3062 = OpLoad %_arr_uchar_uint_16 %786
-%3063 = OpLoad %uchar %767
-%3064 = OpCompositeInsert %_arr_uchar_uint_16 %3063 %3062 13
-OpStore %787 %3064
-%3065 = OpLoad %_arr_uchar_uint_16 %787
-%3066 = OpLoad %uchar %770
-%3067 = OpCompositeInsert %_arr_uchar_uint_16 %3066 %3065 14
-OpStore %788 %3067
-%3068 = OpLoad %_arr_uchar_uint_16 %788
-%3069 = OpLoad %uchar %773
-%3070 = OpCompositeInsert %_arr_uchar_uint_16 %3069 %3068 15
-OpStore %789 %3070
-%3071 = OpLoad %ulong %180
-%3072 = OpLoad %_arr_uchar_uint_16 %789
-%3073 = OpFunctionCall %ulong %1 %3071 %3072
-OpStore %181 %3073
-%3074 = OpLoad %_arr_uchar_uint_16 %164
-%3075 = OpCompositeExtract %uchar %3074 0
-OpStore %790 %3075
-%3076 = OpLoad %_arr_uchar_uint_16 %170
-%3077 = OpCompositeExtract %uchar %3076 0
-OpStore %791 %3077
-%3078 = OpLoad %uchar %790
-%3079 = OpLoad %uchar %791
-%3080 = OpBitwiseAnd %uchar %3078 %3079
-OpStore %792 %3080
-%3081 = OpLoad %_arr_uchar_uint_16 %164
-%3082 = OpCompositeExtract %uchar %3081 1
-OpStore %793 %3082
-%3083 = OpLoad %_arr_uchar_uint_16 %170
-%3084 = OpCompositeExtract %uchar %3083 1
-OpStore %794 %3084
-%3085 = OpLoad %uchar %793
-%3086 = OpLoad %uchar %794
-%3087 = OpBitwiseAnd %uchar %3085 %3086
-OpStore %795 %3087
-%3088 = OpLoad %_arr_uchar_uint_16 %164
-%3089 = OpCompositeExtract %uchar %3088 2
-OpStore %796 %3089
-%3090 = OpLoad %_arr_uchar_uint_16 %170
-%3091 = OpCompositeExtract %uchar %3090 2
-OpStore %797 %3091
-%3092 = OpLoad %uchar %796
-%3093 = OpLoad %uchar %797
-%3094 = OpBitwiseAnd %uchar %3092 %3093
-OpStore %798 %3094
-%3095 = OpLoad %_arr_uchar_uint_16 %164
-%3096 = OpCompositeExtract %uchar %3095 3
-OpStore %799 %3096
-%3097 = OpLoad %_arr_uchar_uint_16 %170
-%3098 = OpCompositeExtract %uchar %3097 3
-OpStore %800 %3098
-%3099 = OpLoad %uchar %799
-%3100 = OpLoad %uchar %800
-%3101 = OpBitwiseAnd %uchar %3099 %3100
-OpStore %801 %3101
-%3102 = OpLoad %_arr_uchar_uint_16 %164
-%3103 = OpCompositeExtract %uchar %3102 4
-OpStore %802 %3103
-%3104 = OpLoad %_arr_uchar_uint_16 %170
-%3105 = OpCompositeExtract %uchar %3104 4
-OpStore %803 %3105
-%3106 = OpLoad %uchar %802
-%3107 = OpLoad %uchar %803
-%3108 = OpBitwiseAnd %uchar %3106 %3107
-OpStore %804 %3108
-%3109 = OpLoad %_arr_uchar_uint_16 %164
-%3110 = OpCompositeExtract %uchar %3109 5
-OpStore %805 %3110
-%3111 = OpLoad %_arr_uchar_uint_16 %170
-%3112 = OpCompositeExtract %uchar %3111 5
-OpStore %806 %3112
-%3113 = OpLoad %uchar %805
-%3114 = OpLoad %uchar %806
-%3115 = OpBitwiseAnd %uchar %3113 %3114
-OpStore %807 %3115
-%3116 = OpLoad %_arr_uchar_uint_16 %164
-%3117 = OpCompositeExtract %uchar %3116 6
-OpStore %808 %3117
-%3118 = OpLoad %_arr_uchar_uint_16 %170
-%3119 = OpCompositeExtract %uchar %3118 6
-OpStore %809 %3119
-%3120 = OpLoad %uchar %808
-%3121 = OpLoad %uchar %809
-%3122 = OpBitwiseAnd %uchar %3120 %3121
-OpStore %810 %3122
-%3123 = OpLoad %_arr_uchar_uint_16 %164
-%3124 = OpCompositeExtract %uchar %3123 7
-OpStore %811 %3124
-%3125 = OpLoad %_arr_uchar_uint_16 %170
-%3126 = OpCompositeExtract %uchar %3125 7
-OpStore %812 %3126
-%3127 = OpLoad %uchar %811
-%3128 = OpLoad %uchar %812
-%3129 = OpBitwiseAnd %uchar %3127 %3128
-OpStore %813 %3129
-%3130 = OpLoad %_arr_uchar_uint_16 %164
-%3131 = OpCompositeExtract %uchar %3130 8
-OpStore %814 %3131
-%3132 = OpLoad %_arr_uchar_uint_16 %170
-%3133 = OpCompositeExtract %uchar %3132 8
-OpStore %815 %3133
-%3134 = OpLoad %uchar %814
-%3135 = OpLoad %uchar %815
-%3136 = OpBitwiseAnd %uchar %3134 %3135
-OpStore %816 %3136
-%3137 = OpLoad %_arr_uchar_uint_16 %164
-%3138 = OpCompositeExtract %uchar %3137 9
-OpStore %817 %3138
-%3139 = OpLoad %_arr_uchar_uint_16 %170
-%3140 = OpCompositeExtract %uchar %3139 9
-OpStore %818 %3140
-%3141 = OpLoad %uchar %817
-%3142 = OpLoad %uchar %818
-%3143 = OpBitwiseAnd %uchar %3141 %3142
-OpStore %819 %3143
-%3144 = OpLoad %_arr_uchar_uint_16 %164
-%3145 = OpCompositeExtract %uchar %3144 10
-OpStore %820 %3145
-%3146 = OpLoad %_arr_uchar_uint_16 %170
-%3147 = OpCompositeExtract %uchar %3146 10
-OpStore %821 %3147
-%3148 = OpLoad %uchar %820
-%3149 = OpLoad %uchar %821
-%3150 = OpBitwiseAnd %uchar %3148 %3149
-OpStore %822 %3150
-%3151 = OpLoad %_arr_uchar_uint_16 %164
-%3152 = OpCompositeExtract %uchar %3151 11
-OpStore %823 %3152
-%3153 = OpLoad %_arr_uchar_uint_16 %170
-%3154 = OpCompositeExtract %uchar %3153 11
-OpStore %824 %3154
-%3155 = OpLoad %uchar %823
-%3156 = OpLoad %uchar %824
-%3157 = OpBitwiseAnd %uchar %3155 %3156
-OpStore %825 %3157
-%3158 = OpLoad %_arr_uchar_uint_16 %164
-%3159 = OpCompositeExtract %uchar %3158 12
-OpStore %826 %3159
-%3160 = OpLoad %_arr_uchar_uint_16 %170
-%3161 = OpCompositeExtract %uchar %3160 12
-OpStore %827 %3161
-%3162 = OpLoad %uchar %826
-%3163 = OpLoad %uchar %827
-%3164 = OpBitwiseAnd %uchar %3162 %3163
-OpStore %828 %3164
-%3165 = OpLoad %_arr_uchar_uint_16 %164
-%3166 = OpCompositeExtract %uchar %3165 13
-OpStore %829 %3166
-%3167 = OpLoad %_arr_uchar_uint_16 %170
-%3168 = OpCompositeExtract %uchar %3167 13
-OpStore %830 %3168
-%3169 = OpLoad %uchar %829
-%3170 = OpLoad %uchar %830
-%3171 = OpBitwiseAnd %uchar %3169 %3170
-OpStore %831 %3171
-%3172 = OpLoad %_arr_uchar_uint_16 %164
-%3173 = OpCompositeExtract %uchar %3172 14
-OpStore %832 %3173
-%3174 = OpLoad %_arr_uchar_uint_16 %170
-%3175 = OpCompositeExtract %uchar %3174 14
-OpStore %833 %3175
-%3176 = OpLoad %uchar %832
-%3177 = OpLoad %uchar %833
-%3178 = OpBitwiseAnd %uchar %3176 %3177
-OpStore %834 %3178
-%3179 = OpLoad %_arr_uchar_uint_16 %164
-%3180 = OpCompositeExtract %uchar %3179 15
-OpStore %835 %3180
-%3181 = OpLoad %_arr_uchar_uint_16 %170
-%3182 = OpCompositeExtract %uchar %3181 15
-OpStore %836 %3182
-%3183 = OpLoad %uchar %835
-%3184 = OpLoad %uchar %836
-%3185 = OpBitwiseAnd %uchar %3183 %3184
-OpStore %837 %3185
-%3186 = OpLoad %_arr_uchar_uint_16 %164
-%3187 = OpLoad %uchar %792
-%3188 = OpCompositeInsert %_arr_uchar_uint_16 %3187 %3186 0
-OpStore %838 %3188
-%3189 = OpLoad %_arr_uchar_uint_16 %838
-%3190 = OpLoad %uchar %795
-%3191 = OpCompositeInsert %_arr_uchar_uint_16 %3190 %3189 1
-OpStore %839 %3191
-%3192 = OpLoad %_arr_uchar_uint_16 %839
-%3193 = OpLoad %uchar %798
-%3194 = OpCompositeInsert %_arr_uchar_uint_16 %3193 %3192 2
-OpStore %840 %3194
-%3195 = OpLoad %_arr_uchar_uint_16 %840
-%3196 = OpLoad %uchar %801
-%3197 = OpCompositeInsert %_arr_uchar_uint_16 %3196 %3195 3
-OpStore %841 %3197
-%3198 = OpLoad %_arr_uchar_uint_16 %841
-%3199 = OpLoad %uchar %804
-%3200 = OpCompositeInsert %_arr_uchar_uint_16 %3199 %3198 4
-OpStore %842 %3200
-%3201 = OpLoad %_arr_uchar_uint_16 %842
-%3202 = OpLoad %uchar %807
-%3203 = OpCompositeInsert %_arr_uchar_uint_16 %3202 %3201 5
-OpStore %843 %3203
-%3204 = OpLoad %_arr_uchar_uint_16 %843
-%3205 = OpLoad %uchar %810
-%3206 = OpCompositeInsert %_arr_uchar_uint_16 %3205 %3204 6
-OpStore %844 %3206
-%3207 = OpLoad %_arr_uchar_uint_16 %844
-%3208 = OpLoad %uchar %813
-%3209 = OpCompositeInsert %_arr_uchar_uint_16 %3208 %3207 7
-OpStore %845 %3209
-%3210 = OpLoad %_arr_uchar_uint_16 %845
-%3211 = OpLoad %uchar %816
-%3212 = OpCompositeInsert %_arr_uchar_uint_16 %3211 %3210 8
-OpStore %846 %3212
-%3213 = OpLoad %_arr_uchar_uint_16 %846
-%3214 = OpLoad %uchar %819
-%3215 = OpCompositeInsert %_arr_uchar_uint_16 %3214 %3213 9
-OpStore %847 %3215
-%3216 = OpLoad %_arr_uchar_uint_16 %847
-%3217 = OpLoad %uchar %822
-%3218 = OpCompositeInsert %_arr_uchar_uint_16 %3217 %3216 10
-OpStore %848 %3218
-%3219 = OpLoad %_arr_uchar_uint_16 %848
-%3220 = OpLoad %uchar %825
-%3221 = OpCompositeInsert %_arr_uchar_uint_16 %3220 %3219 11
-OpStore %849 %3221
-%3222 = OpLoad %_arr_uchar_uint_16 %849
-%3223 = OpLoad %uchar %828
-%3224 = OpCompositeInsert %_arr_uchar_uint_16 %3223 %3222 12
-OpStore %850 %3224
-%3225 = OpLoad %_arr_uchar_uint_16 %850
-%3226 = OpLoad %uchar %831
-%3227 = OpCompositeInsert %_arr_uchar_uint_16 %3226 %3225 13
-OpStore %851 %3227
-%3228 = OpLoad %_arr_uchar_uint_16 %851
-%3229 = OpLoad %uchar %834
-%3230 = OpCompositeInsert %_arr_uchar_uint_16 %3229 %3228 14
-OpStore %852 %3230
-%3231 = OpLoad %_arr_uchar_uint_16 %852
-%3232 = OpLoad %uchar %837
-%3233 = OpCompositeInsert %_arr_uchar_uint_16 %3232 %3231 15
-OpStore %853 %3233
-%3234 = OpLoad %ulong %181
-%3235 = OpLoad %_arr_uchar_uint_16 %853
-%3236 = OpFunctionCall %ulong %1 %3234 %3235
-OpStore %182 %3236
-%3237 = OpLoad %_arr_uchar_uint_16 %164
-%3238 = OpCompositeExtract %uchar %3237 0
-OpStore %854 %3238
-%3239 = OpLoad %_arr_uchar_uint_16 %170
-%3240 = OpCompositeExtract %uchar %3239 0
-OpStore %855 %3240
-%3241 = OpLoad %uchar %854
-%3242 = OpLoad %uchar %855
-%3243 = OpBitwiseOr %uchar %3241 %3242
-OpStore %856 %3243
-%3244 = OpLoad %_arr_uchar_uint_16 %164
-%3245 = OpCompositeExtract %uchar %3244 1
-OpStore %857 %3245
-%3246 = OpLoad %_arr_uchar_uint_16 %170
-%3247 = OpCompositeExtract %uchar %3246 1
-OpStore %858 %3247
-%3248 = OpLoad %uchar %857
-%3249 = OpLoad %uchar %858
-%3250 = OpBitwiseOr %uchar %3248 %3249
-OpStore %859 %3250
-%3251 = OpLoad %_arr_uchar_uint_16 %164
-%3252 = OpCompositeExtract %uchar %3251 2
-OpStore %860 %3252
-%3253 = OpLoad %_arr_uchar_uint_16 %170
-%3254 = OpCompositeExtract %uchar %3253 2
-OpStore %861 %3254
-%3255 = OpLoad %uchar %860
-%3256 = OpLoad %uchar %861
-%3257 = OpBitwiseOr %uchar %3255 %3256
-OpStore %862 %3257
-%3258 = OpLoad %_arr_uchar_uint_16 %164
-%3259 = OpCompositeExtract %uchar %3258 3
-OpStore %863 %3259
-%3260 = OpLoad %_arr_uchar_uint_16 %170
-%3261 = OpCompositeExtract %uchar %3260 3
-OpStore %864 %3261
-%3262 = OpLoad %uchar %863
-%3263 = OpLoad %uchar %864
-%3264 = OpBitwiseOr %uchar %3262 %3263
-OpStore %865 %3264
-%3265 = OpLoad %_arr_uchar_uint_16 %164
-%3266 = OpCompositeExtract %uchar %3265 4
-OpStore %866 %3266
-%3267 = OpLoad %_arr_uchar_uint_16 %170
-%3268 = OpCompositeExtract %uchar %3267 4
-OpStore %867 %3268
-%3269 = OpLoad %uchar %866
-%3270 = OpLoad %uchar %867
-%3271 = OpBitwiseOr %uchar %3269 %3270
-OpStore %868 %3271
-%3272 = OpLoad %_arr_uchar_uint_16 %164
-%3273 = OpCompositeExtract %uchar %3272 5
-OpStore %869 %3273
-%3274 = OpLoad %_arr_uchar_uint_16 %170
-%3275 = OpCompositeExtract %uchar %3274 5
-OpStore %870 %3275
-%3276 = OpLoad %uchar %869
-%3277 = OpLoad %uchar %870
-%3278 = OpBitwiseOr %uchar %3276 %3277
-OpStore %871 %3278
-%3279 = OpLoad %_arr_uchar_uint_16 %164
-%3280 = OpCompositeExtract %uchar %3279 6
-OpStore %872 %3280
-%3281 = OpLoad %_arr_uchar_uint_16 %170
-%3282 = OpCompositeExtract %uchar %3281 6
-OpStore %873 %3282
-%3283 = OpLoad %uchar %872
-%3284 = OpLoad %uchar %873
-%3285 = OpBitwiseOr %uchar %3283 %3284
-OpStore %874 %3285
-%3286 = OpLoad %_arr_uchar_uint_16 %164
-%3287 = OpCompositeExtract %uchar %3286 7
-OpStore %875 %3287
-%3288 = OpLoad %_arr_uchar_uint_16 %170
-%3289 = OpCompositeExtract %uchar %3288 7
-OpStore %876 %3289
-%3290 = OpLoad %uchar %875
-%3291 = OpLoad %uchar %876
-%3292 = OpBitwiseOr %uchar %3290 %3291
-OpStore %877 %3292
-%3293 = OpLoad %_arr_uchar_uint_16 %164
-%3294 = OpCompositeExtract %uchar %3293 8
-OpStore %878 %3294
-%3295 = OpLoad %_arr_uchar_uint_16 %170
-%3296 = OpCompositeExtract %uchar %3295 8
-OpStore %879 %3296
-%3297 = OpLoad %uchar %878
-%3298 = OpLoad %uchar %879
-%3299 = OpBitwiseOr %uchar %3297 %3298
-OpStore %880 %3299
-%3300 = OpLoad %_arr_uchar_uint_16 %164
-%3301 = OpCompositeExtract %uchar %3300 9
-OpStore %881 %3301
-%3302 = OpLoad %_arr_uchar_uint_16 %170
-%3303 = OpCompositeExtract %uchar %3302 9
-OpStore %882 %3303
-%3304 = OpLoad %uchar %881
-%3305 = OpLoad %uchar %882
-%3306 = OpBitwiseOr %uchar %3304 %3305
-OpStore %883 %3306
-%3307 = OpLoad %_arr_uchar_uint_16 %164
-%3308 = OpCompositeExtract %uchar %3307 10
-OpStore %884 %3308
-%3309 = OpLoad %_arr_uchar_uint_16 %170
-%3310 = OpCompositeExtract %uchar %3309 10
-OpStore %885 %3310
-%3311 = OpLoad %uchar %884
-%3312 = OpLoad %uchar %885
-%3313 = OpBitwiseOr %uchar %3311 %3312
-OpStore %886 %3313
-%3314 = OpLoad %_arr_uchar_uint_16 %164
-%3315 = OpCompositeExtract %uchar %3314 11
-OpStore %887 %3315
-%3316 = OpLoad %_arr_uchar_uint_16 %170
-%3317 = OpCompositeExtract %uchar %3316 11
-OpStore %888 %3317
-%3318 = OpLoad %uchar %887
-%3319 = OpLoad %uchar %888
-%3320 = OpBitwiseOr %uchar %3318 %3319
-OpStore %889 %3320
-%3321 = OpLoad %_arr_uchar_uint_16 %164
-%3322 = OpCompositeExtract %uchar %3321 12
-OpStore %890 %3322
-%3323 = OpLoad %_arr_uchar_uint_16 %170
-%3324 = OpCompositeExtract %uchar %3323 12
-OpStore %891 %3324
-%3325 = OpLoad %uchar %890
-%3326 = OpLoad %uchar %891
-%3327 = OpBitwiseOr %uchar %3325 %3326
-OpStore %892 %3327
-%3328 = OpLoad %_arr_uchar_uint_16 %164
-%3329 = OpCompositeExtract %uchar %3328 13
-OpStore %893 %3329
-%3330 = OpLoad %_arr_uchar_uint_16 %170
-%3331 = OpCompositeExtract %uchar %3330 13
-OpStore %894 %3331
-%3332 = OpLoad %uchar %893
-%3333 = OpLoad %uchar %894
-%3334 = OpBitwiseOr %uchar %3332 %3333
-OpStore %895 %3334
-%3335 = OpLoad %_arr_uchar_uint_16 %164
-%3336 = OpCompositeExtract %uchar %3335 14
-OpStore %896 %3336
-%3337 = OpLoad %_arr_uchar_uint_16 %170
-%3338 = OpCompositeExtract %uchar %3337 14
-OpStore %897 %3338
-%3339 = OpLoad %uchar %896
-%3340 = OpLoad %uchar %897
-%3341 = OpBitwiseOr %uchar %3339 %3340
-OpStore %898 %3341
-%3342 = OpLoad %_arr_uchar_uint_16 %164
-%3343 = OpCompositeExtract %uchar %3342 15
-OpStore %899 %3343
-%3344 = OpLoad %_arr_uchar_uint_16 %170
-%3345 = OpCompositeExtract %uchar %3344 15
-OpStore %900 %3345
-%3346 = OpLoad %uchar %899
-%3347 = OpLoad %uchar %900
-%3348 = OpBitwiseOr %uchar %3346 %3347
-OpStore %901 %3348
-%3349 = OpLoad %_arr_uchar_uint_16 %164
-%3350 = OpLoad %uchar %856
-%3351 = OpCompositeInsert %_arr_uchar_uint_16 %3350 %3349 0
-OpStore %902 %3351
-%3352 = OpLoad %_arr_uchar_uint_16 %902
-%3353 = OpLoad %uchar %859
-%3354 = OpCompositeInsert %_arr_uchar_uint_16 %3353 %3352 1
-OpStore %903 %3354
-%3355 = OpLoad %_arr_uchar_uint_16 %903
-%3356 = OpLoad %uchar %862
-%3357 = OpCompositeInsert %_arr_uchar_uint_16 %3356 %3355 2
-OpStore %904 %3357
-%3358 = OpLoad %_arr_uchar_uint_16 %904
-%3359 = OpLoad %uchar %865
-%3360 = OpCompositeInsert %_arr_uchar_uint_16 %3359 %3358 3
-OpStore %905 %3360
-%3361 = OpLoad %_arr_uchar_uint_16 %905
-%3362 = OpLoad %uchar %868
-%3363 = OpCompositeInsert %_arr_uchar_uint_16 %3362 %3361 4
-OpStore %906 %3363
-%3364 = OpLoad %_arr_uchar_uint_16 %906
-%3365 = OpLoad %uchar %871
-%3366 = OpCompositeInsert %_arr_uchar_uint_16 %3365 %3364 5
-OpStore %907 %3366
-%3367 = OpLoad %_arr_uchar_uint_16 %907
-%3368 = OpLoad %uchar %874
-%3369 = OpCompositeInsert %_arr_uchar_uint_16 %3368 %3367 6
-OpStore %908 %3369
-%3370 = OpLoad %_arr_uchar_uint_16 %908
-%3371 = OpLoad %uchar %877
-%3372 = OpCompositeInsert %_arr_uchar_uint_16 %3371 %3370 7
-OpStore %909 %3372
-%3373 = OpLoad %_arr_uchar_uint_16 %909
-%3374 = OpLoad %uchar %880
-%3375 = OpCompositeInsert %_arr_uchar_uint_16 %3374 %3373 8
-OpStore %910 %3375
-%3376 = OpLoad %_arr_uchar_uint_16 %910
-%3377 = OpLoad %uchar %883
-%3378 = OpCompositeInsert %_arr_uchar_uint_16 %3377 %3376 9
-OpStore %911 %3378
-%3379 = OpLoad %_arr_uchar_uint_16 %911
-%3380 = OpLoad %uchar %886
-%3381 = OpCompositeInsert %_arr_uchar_uint_16 %3380 %3379 10
-OpStore %912 %3381
-%3382 = OpLoad %_arr_uchar_uint_16 %912
-%3383 = OpLoad %uchar %889
-%3384 = OpCompositeInsert %_arr_uchar_uint_16 %3383 %3382 11
-OpStore %913 %3384
-%3385 = OpLoad %_arr_uchar_uint_16 %913
-%3386 = OpLoad %uchar %892
-%3387 = OpCompositeInsert %_arr_uchar_uint_16 %3386 %3385 12
-OpStore %914 %3387
-%3388 = OpLoad %_arr_uchar_uint_16 %914
-%3389 = OpLoad %uchar %895
-%3390 = OpCompositeInsert %_arr_uchar_uint_16 %3389 %3388 13
-OpStore %915 %3390
-%3391 = OpLoad %_arr_uchar_uint_16 %915
-%3392 = OpLoad %uchar %898
-%3393 = OpCompositeInsert %_arr_uchar_uint_16 %3392 %3391 14
-OpStore %916 %3393
-%3394 = OpLoad %_arr_uchar_uint_16 %916
-%3395 = OpLoad %uchar %901
-%3396 = OpCompositeInsert %_arr_uchar_uint_16 %3395 %3394 15
-OpStore %917 %3396
-%3397 = OpLoad %ulong %182
-%3398 = OpLoad %_arr_uchar_uint_16 %917
-%3399 = OpFunctionCall %ulong %1 %3397 %3398
-OpStore %183 %3399
-%3400 = OpLoad %_arr_uchar_uint_16 %164
-%3401 = OpCompositeExtract %uchar %3400 0
-OpStore %918 %3401
-%3402 = OpLoad %_arr_uchar_uint_16 %170
-%3403 = OpCompositeExtract %uchar %3402 0
-OpStore %919 %3403
-%3404 = OpLoad %uchar %918
-%3405 = OpLoad %uchar %919
-%3406 = OpBitwiseXor %uchar %3404 %3405
-OpStore %920 %3406
-%3407 = OpLoad %_arr_uchar_uint_16 %164
-%3408 = OpCompositeExtract %uchar %3407 1
-OpStore %921 %3408
-%3409 = OpLoad %_arr_uchar_uint_16 %170
-%3410 = OpCompositeExtract %uchar %3409 1
-OpStore %922 %3410
-%3411 = OpLoad %uchar %921
-%3412 = OpLoad %uchar %922
-%3413 = OpBitwiseXor %uchar %3411 %3412
-OpStore %923 %3413
-%3414 = OpLoad %_arr_uchar_uint_16 %164
-%3415 = OpCompositeExtract %uchar %3414 2
-OpStore %924 %3415
-%3416 = OpLoad %_arr_uchar_uint_16 %170
-%3417 = OpCompositeExtract %uchar %3416 2
-OpStore %925 %3417
-%3418 = OpLoad %uchar %924
-%3419 = OpLoad %uchar %925
-%3420 = OpBitwiseXor %uchar %3418 %3419
-OpStore %926 %3420
-%3421 = OpLoad %_arr_uchar_uint_16 %164
-%3422 = OpCompositeExtract %uchar %3421 3
-OpStore %927 %3422
-%3423 = OpLoad %_arr_uchar_uint_16 %170
-%3424 = OpCompositeExtract %uchar %3423 3
-OpStore %928 %3424
-%3425 = OpLoad %uchar %927
-%3426 = OpLoad %uchar %928
-%3427 = OpBitwiseXor %uchar %3425 %3426
-OpStore %929 %3427
-%3428 = OpLoad %_arr_uchar_uint_16 %164
-%3429 = OpCompositeExtract %uchar %3428 4
-OpStore %930 %3429
-%3430 = OpLoad %_arr_uchar_uint_16 %170
-%3431 = OpCompositeExtract %uchar %3430 4
-OpStore %931 %3431
-%3432 = OpLoad %uchar %930
-%3433 = OpLoad %uchar %931
-%3434 = OpBitwiseXor %uchar %3432 %3433
-OpStore %932 %3434
-%3435 = OpLoad %_arr_uchar_uint_16 %164
-%3436 = OpCompositeExtract %uchar %3435 5
-OpStore %933 %3436
-%3437 = OpLoad %_arr_uchar_uint_16 %170
-%3438 = OpCompositeExtract %uchar %3437 5
-OpStore %934 %3438
-%3439 = OpLoad %uchar %933
-%3440 = OpLoad %uchar %934
-%3441 = OpBitwiseXor %uchar %3439 %3440
-OpStore %935 %3441
-%3442 = OpLoad %_arr_uchar_uint_16 %164
-%3443 = OpCompositeExtract %uchar %3442 6
-OpStore %936 %3443
-%3444 = OpLoad %_arr_uchar_uint_16 %170
-%3445 = OpCompositeExtract %uchar %3444 6
-OpStore %937 %3445
-%3446 = OpLoad %uchar %936
-%3447 = OpLoad %uchar %937
-%3448 = OpBitwiseXor %uchar %3446 %3447
-OpStore %938 %3448
-%3449 = OpLoad %_arr_uchar_uint_16 %164
-%3450 = OpCompositeExtract %uchar %3449 7
-OpStore %939 %3450
-%3451 = OpLoad %_arr_uchar_uint_16 %170
-%3452 = OpCompositeExtract %uchar %3451 7
-OpStore %940 %3452
-%3453 = OpLoad %uchar %939
-%3454 = OpLoad %uchar %940
-%3455 = OpBitwiseXor %uchar %3453 %3454
-OpStore %941 %3455
-%3456 = OpLoad %_arr_uchar_uint_16 %164
-%3457 = OpCompositeExtract %uchar %3456 8
-OpStore %942 %3457
-%3458 = OpLoad %_arr_uchar_uint_16 %170
-%3459 = OpCompositeExtract %uchar %3458 8
-OpStore %943 %3459
-%3460 = OpLoad %uchar %942
-%3461 = OpLoad %uchar %943
-%3462 = OpBitwiseXor %uchar %3460 %3461
-OpStore %944 %3462
-%3463 = OpLoad %_arr_uchar_uint_16 %164
-%3464 = OpCompositeExtract %uchar %3463 9
-OpStore %945 %3464
-%3465 = OpLoad %_arr_uchar_uint_16 %170
-%3466 = OpCompositeExtract %uchar %3465 9
-OpStore %946 %3466
-%3467 = OpLoad %uchar %945
-%3468 = OpLoad %uchar %946
-%3469 = OpBitwiseXor %uchar %3467 %3468
-OpStore %947 %3469
-%3470 = OpLoad %_arr_uchar_uint_16 %164
-%3471 = OpCompositeExtract %uchar %3470 10
-OpStore %948 %3471
-%3472 = OpLoad %_arr_uchar_uint_16 %170
-%3473 = OpCompositeExtract %uchar %3472 10
-OpStore %949 %3473
-%3474 = OpLoad %uchar %948
-%3475 = OpLoad %uchar %949
-%3476 = OpBitwiseXor %uchar %3474 %3475
-OpStore %950 %3476
-%3477 = OpLoad %_arr_uchar_uint_16 %164
-%3478 = OpCompositeExtract %uchar %3477 11
-OpStore %951 %3478
-%3479 = OpLoad %_arr_uchar_uint_16 %170
-%3480 = OpCompositeExtract %uchar %3479 11
-OpStore %952 %3480
-%3481 = OpLoad %uchar %951
-%3482 = OpLoad %uchar %952
-%3483 = OpBitwiseXor %uchar %3481 %3482
-OpStore %953 %3483
-%3484 = OpLoad %_arr_uchar_uint_16 %164
-%3485 = OpCompositeExtract %uchar %3484 12
-OpStore %954 %3485
-%3486 = OpLoad %_arr_uchar_uint_16 %170
-%3487 = OpCompositeExtract %uchar %3486 12
-OpStore %955 %3487
-%3488 = OpLoad %uchar %954
-%3489 = OpLoad %uchar %955
-%3490 = OpBitwiseXor %uchar %3488 %3489
-OpStore %956 %3490
-%3491 = OpLoad %_arr_uchar_uint_16 %164
-%3492 = OpCompositeExtract %uchar %3491 13
-OpStore %957 %3492
-%3493 = OpLoad %_arr_uchar_uint_16 %170
-%3494 = OpCompositeExtract %uchar %3493 13
-OpStore %958 %3494
-%3495 = OpLoad %uchar %957
-%3496 = OpLoad %uchar %958
-%3497 = OpBitwiseXor %uchar %3495 %3496
-OpStore %959 %3497
-%3498 = OpLoad %_arr_uchar_uint_16 %164
-%3499 = OpCompositeExtract %uchar %3498 14
-OpStore %960 %3499
-%3500 = OpLoad %_arr_uchar_uint_16 %170
-%3501 = OpCompositeExtract %uchar %3500 14
-OpStore %961 %3501
-%3502 = OpLoad %uchar %960
-%3503 = OpLoad %uchar %961
-%3504 = OpBitwiseXor %uchar %3502 %3503
-OpStore %962 %3504
-%3505 = OpLoad %_arr_uchar_uint_16 %164
-%3506 = OpCompositeExtract %uchar %3505 15
-OpStore %963 %3506
-%3507 = OpLoad %_arr_uchar_uint_16 %170
-%3508 = OpCompositeExtract %uchar %3507 15
-OpStore %964 %3508
-%3509 = OpLoad %uchar %963
-%3510 = OpLoad %uchar %964
-%3511 = OpBitwiseXor %uchar %3509 %3510
-OpStore %965 %3511
-%3512 = OpLoad %_arr_uchar_uint_16 %164
-%3513 = OpLoad %uchar %920
-%3514 = OpCompositeInsert %_arr_uchar_uint_16 %3513 %3512 0
-OpStore %966 %3514
-%3515 = OpLoad %_arr_uchar_uint_16 %966
-%3516 = OpLoad %uchar %923
-%3517 = OpCompositeInsert %_arr_uchar_uint_16 %3516 %3515 1
-OpStore %967 %3517
-%3518 = OpLoad %_arr_uchar_uint_16 %967
-%3519 = OpLoad %uchar %926
-%3520 = OpCompositeInsert %_arr_uchar_uint_16 %3519 %3518 2
-OpStore %968 %3520
-%3521 = OpLoad %_arr_uchar_uint_16 %968
-%3522 = OpLoad %uchar %929
-%3523 = OpCompositeInsert %_arr_uchar_uint_16 %3522 %3521 3
-OpStore %969 %3523
-%3524 = OpLoad %_arr_uchar_uint_16 %969
-%3525 = OpLoad %uchar %932
-%3526 = OpCompositeInsert %_arr_uchar_uint_16 %3525 %3524 4
-OpStore %970 %3526
-%3527 = OpLoad %_arr_uchar_uint_16 %970
-%3528 = OpLoad %uchar %935
-%3529 = OpCompositeInsert %_arr_uchar_uint_16 %3528 %3527 5
-OpStore %971 %3529
-%3530 = OpLoad %_arr_uchar_uint_16 %971
-%3531 = OpLoad %uchar %938
-%3532 = OpCompositeInsert %_arr_uchar_uint_16 %3531 %3530 6
-OpStore %972 %3532
-%3533 = OpLoad %_arr_uchar_uint_16 %972
-%3534 = OpLoad %uchar %941
-%3535 = OpCompositeInsert %_arr_uchar_uint_16 %3534 %3533 7
-OpStore %973 %3535
-%3536 = OpLoad %_arr_uchar_uint_16 %973
-%3537 = OpLoad %uchar %944
-%3538 = OpCompositeInsert %_arr_uchar_uint_16 %3537 %3536 8
-OpStore %974 %3538
-%3539 = OpLoad %_arr_uchar_uint_16 %974
-%3540 = OpLoad %uchar %947
-%3541 = OpCompositeInsert %_arr_uchar_uint_16 %3540 %3539 9
-OpStore %975 %3541
-%3542 = OpLoad %_arr_uchar_uint_16 %975
-%3543 = OpLoad %uchar %950
-%3544 = OpCompositeInsert %_arr_uchar_uint_16 %3543 %3542 10
-OpStore %976 %3544
-%3545 = OpLoad %_arr_uchar_uint_16 %976
-%3546 = OpLoad %uchar %953
-%3547 = OpCompositeInsert %_arr_uchar_uint_16 %3546 %3545 11
-OpStore %977 %3547
-%3548 = OpLoad %_arr_uchar_uint_16 %977
-%3549 = OpLoad %uchar %956
-%3550 = OpCompositeInsert %_arr_uchar_uint_16 %3549 %3548 12
-OpStore %978 %3550
-%3551 = OpLoad %_arr_uchar_uint_16 %978
-%3552 = OpLoad %uchar %959
-%3553 = OpCompositeInsert %_arr_uchar_uint_16 %3552 %3551 13
-OpStore %979 %3553
-%3554 = OpLoad %_arr_uchar_uint_16 %979
-%3555 = OpLoad %uchar %962
-%3556 = OpCompositeInsert %_arr_uchar_uint_16 %3555 %3554 14
-OpStore %980 %3556
-%3557 = OpLoad %_arr_uchar_uint_16 %980
-%3558 = OpLoad %uchar %965
-%3559 = OpCompositeInsert %_arr_uchar_uint_16 %3558 %3557 15
-OpStore %981 %3559
-%3560 = OpLoad %ulong %183
-%3561 = OpLoad %_arr_uchar_uint_16 %981
-%3562 = OpFunctionCall %ulong %1 %3560 %3561
-OpStore %184 %3562
-%3563 = OpLoad %_arr_uchar_uint_16 %164
-%3564 = OpCompositeExtract %uchar %3563 0
-OpStore %982 %3564
-%3565 = OpLoad %uchar %982
-%3566 = OpNot %uchar %3565
-OpStore %983 %3566
-%3567 = OpLoad %_arr_uchar_uint_16 %164
-%3568 = OpCompositeExtract %uchar %3567 1
-OpStore %984 %3568
-%3569 = OpLoad %uchar %984
-%3570 = OpNot %uchar %3569
-OpStore %985 %3570
-%3571 = OpLoad %_arr_uchar_uint_16 %164
-%3572 = OpCompositeExtract %uchar %3571 2
-OpStore %986 %3572
-%3573 = OpLoad %uchar %986
-%3574 = OpNot %uchar %3573
-OpStore %987 %3574
-%3575 = OpLoad %_arr_uchar_uint_16 %164
-%3576 = OpCompositeExtract %uchar %3575 3
-OpStore %988 %3576
-%3577 = OpLoad %uchar %988
-%3578 = OpNot %uchar %3577
-OpStore %989 %3578
-%3579 = OpLoad %_arr_uchar_uint_16 %164
-%3580 = OpCompositeExtract %uchar %3579 4
-OpStore %990 %3580
-%3581 = OpLoad %uchar %990
-%3582 = OpNot %uchar %3581
-OpStore %991 %3582
-%3583 = OpLoad %_arr_uchar_uint_16 %164
-%3584 = OpCompositeExtract %uchar %3583 5
-OpStore %992 %3584
-%3585 = OpLoad %uchar %992
-%3586 = OpNot %uchar %3585
-OpStore %993 %3586
-%3587 = OpLoad %_arr_uchar_uint_16 %164
-%3588 = OpCompositeExtract %uchar %3587 6
-OpStore %994 %3588
-%3589 = OpLoad %uchar %994
-%3590 = OpNot %uchar %3589
-OpStore %995 %3590
-%3591 = OpLoad %_arr_uchar_uint_16 %164
-%3592 = OpCompositeExtract %uchar %3591 7
-OpStore %996 %3592
-%3593 = OpLoad %uchar %996
-%3594 = OpNot %uchar %3593
-OpStore %997 %3594
-%3595 = OpLoad %_arr_uchar_uint_16 %164
-%3596 = OpCompositeExtract %uchar %3595 8
-OpStore %998 %3596
-%3597 = OpLoad %uchar %998
-%3598 = OpNot %uchar %3597
-OpStore %999 %3598
-%3599 = OpLoad %_arr_uchar_uint_16 %164
-%3600 = OpCompositeExtract %uchar %3599 9
-OpStore %1000 %3600
-%3601 = OpLoad %uchar %1000
-%3602 = OpNot %uchar %3601
-OpStore %1001 %3602
-%3603 = OpLoad %_arr_uchar_uint_16 %164
-%3604 = OpCompositeExtract %uchar %3603 10
-OpStore %1002 %3604
-%3605 = OpLoad %uchar %1002
-%3606 = OpNot %uchar %3605
-OpStore %1003 %3606
-%3607 = OpLoad %_arr_uchar_uint_16 %164
-%3608 = OpCompositeExtract %uchar %3607 11
-OpStore %1004 %3608
-%3609 = OpLoad %uchar %1004
-%3610 = OpNot %uchar %3609
-OpStore %1005 %3610
-%3611 = OpLoad %_arr_uchar_uint_16 %164
-%3612 = OpCompositeExtract %uchar %3611 12
-OpStore %1006 %3612
-%3613 = OpLoad %uchar %1006
-%3614 = OpNot %uchar %3613
-OpStore %1007 %3614
-%3615 = OpLoad %_arr_uchar_uint_16 %164
-%3616 = OpCompositeExtract %uchar %3615 13
-OpStore %1008 %3616
-%3617 = OpLoad %uchar %1008
-%3618 = OpNot %uchar %3617
-OpStore %1009 %3618
-%3619 = OpLoad %_arr_uchar_uint_16 %164
-%3620 = OpCompositeExtract %uchar %3619 14
-OpStore %1010 %3620
-%3621 = OpLoad %uchar %1010
-%3622 = OpNot %uchar %3621
-OpStore %1011 %3622
-%3623 = OpLoad %_arr_uchar_uint_16 %164
-%3624 = OpCompositeExtract %uchar %3623 15
-OpStore %1012 %3624
-%3625 = OpLoad %uchar %1012
-%3626 = OpNot %uchar %3625
-OpStore %1013 %3626
-%3627 = OpLoad %_arr_uchar_uint_16 %164
-%3628 = OpLoad %uchar %983
-%3629 = OpCompositeInsert %_arr_uchar_uint_16 %3628 %3627 0
-OpStore %1014 %3629
-%3630 = OpLoad %_arr_uchar_uint_16 %1014
-%3631 = OpLoad %uchar %985
-%3632 = OpCompositeInsert %_arr_uchar_uint_16 %3631 %3630 1
-OpStore %1015 %3632
-%3633 = OpLoad %_arr_uchar_uint_16 %1015
-%3634 = OpLoad %uchar %987
-%3635 = OpCompositeInsert %_arr_uchar_uint_16 %3634 %3633 2
-OpStore %1016 %3635
-%3636 = OpLoad %_arr_uchar_uint_16 %1016
-%3637 = OpLoad %uchar %989
-%3638 = OpCompositeInsert %_arr_uchar_uint_16 %3637 %3636 3
-OpStore %1017 %3638
-%3639 = OpLoad %_arr_uchar_uint_16 %1017
-%3640 = OpLoad %uchar %991
-%3641 = OpCompositeInsert %_arr_uchar_uint_16 %3640 %3639 4
-OpStore %1018 %3641
-%3642 = OpLoad %_arr_uchar_uint_16 %1018
-%3643 = OpLoad %uchar %993
-%3644 = OpCompositeInsert %_arr_uchar_uint_16 %3643 %3642 5
-OpStore %1019 %3644
-%3645 = OpLoad %_arr_uchar_uint_16 %1019
-%3646 = OpLoad %uchar %995
-%3647 = OpCompositeInsert %_arr_uchar_uint_16 %3646 %3645 6
-OpStore %1020 %3647
-%3648 = OpLoad %_arr_uchar_uint_16 %1020
-%3649 = OpLoad %uchar %997
-%3650 = OpCompositeInsert %_arr_uchar_uint_16 %3649 %3648 7
-OpStore %1021 %3650
-%3651 = OpLoad %_arr_uchar_uint_16 %1021
-%3652 = OpLoad %uchar %999
-%3653 = OpCompositeInsert %_arr_uchar_uint_16 %3652 %3651 8
-OpStore %1022 %3653
-%3654 = OpLoad %_arr_uchar_uint_16 %1022
-%3655 = OpLoad %uchar %1001
-%3656 = OpCompositeInsert %_arr_uchar_uint_16 %3655 %3654 9
-OpStore %1023 %3656
-%3657 = OpLoad %_arr_uchar_uint_16 %1023
-%3658 = OpLoad %uchar %1003
-%3659 = OpCompositeInsert %_arr_uchar_uint_16 %3658 %3657 10
-OpStore %1024 %3659
-%3660 = OpLoad %_arr_uchar_uint_16 %1024
-%3661 = OpLoad %uchar %1005
-%3662 = OpCompositeInsert %_arr_uchar_uint_16 %3661 %3660 11
-OpStore %1025 %3662
-%3663 = OpLoad %_arr_uchar_uint_16 %1025
-%3664 = OpLoad %uchar %1007
-%3665 = OpCompositeInsert %_arr_uchar_uint_16 %3664 %3663 12
-OpStore %1026 %3665
-%3666 = OpLoad %_arr_uchar_uint_16 %1026
-%3667 = OpLoad %uchar %1009
-%3668 = OpCompositeInsert %_arr_uchar_uint_16 %3667 %3666 13
-OpStore %1027 %3668
-%3669 = OpLoad %_arr_uchar_uint_16 %1027
-%3670 = OpLoad %uchar %1011
-%3671 = OpCompositeInsert %_arr_uchar_uint_16 %3670 %3669 14
-OpStore %1028 %3671
-%3672 = OpLoad %_arr_uchar_uint_16 %1028
-%3673 = OpLoad %uchar %1013
-%3674 = OpCompositeInsert %_arr_uchar_uint_16 %3673 %3672 15
-OpStore %1029 %3674
-%3675 = OpLoad %ulong %184
-%3676 = OpLoad %_arr_uchar_uint_16 %1029
-%3677 = OpFunctionCall %ulong %1 %3675 %3676
-OpStore %185 %3677
-%3678 = OpLoad %_arr_uchar_uint_16 %170
-%3679 = OpCompositeExtract %uchar %3678 0
-OpStore %1030 %3679
-%3680 = OpLoad %uchar %1030
-%3681 = OpNot %uchar %3680
-OpStore %1031 %3681
-%3682 = OpLoad %_arr_uchar_uint_16 %170
-%3683 = OpCompositeExtract %uchar %3682 1
-OpStore %1032 %3683
-%3684 = OpLoad %uchar %1032
-%3685 = OpNot %uchar %3684
-OpStore %1033 %3685
-%3686 = OpLoad %_arr_uchar_uint_16 %170
-%3687 = OpCompositeExtract %uchar %3686 2
-OpStore %1034 %3687
-%3688 = OpLoad %uchar %1034
-%3689 = OpNot %uchar %3688
-OpStore %1035 %3689
-%3690 = OpLoad %_arr_uchar_uint_16 %170
-%3691 = OpCompositeExtract %uchar %3690 3
-OpStore %1036 %3691
-%3692 = OpLoad %uchar %1036
-%3693 = OpNot %uchar %3692
-OpStore %1037 %3693
-%3694 = OpLoad %_arr_uchar_uint_16 %170
-%3695 = OpCompositeExtract %uchar %3694 4
-OpStore %1038 %3695
-%3696 = OpLoad %uchar %1038
-%3697 = OpNot %uchar %3696
-OpStore %1039 %3697
-%3698 = OpLoad %_arr_uchar_uint_16 %170
-%3699 = OpCompositeExtract %uchar %3698 5
-OpStore %1040 %3699
-%3700 = OpLoad %uchar %1040
-%3701 = OpNot %uchar %3700
-OpStore %1041 %3701
-%3702 = OpLoad %_arr_uchar_uint_16 %170
-%3703 = OpCompositeExtract %uchar %3702 6
-OpStore %1042 %3703
-%3704 = OpLoad %uchar %1042
-%3705 = OpNot %uchar %3704
-OpStore %1043 %3705
-%3706 = OpLoad %_arr_uchar_uint_16 %170
-%3707 = OpCompositeExtract %uchar %3706 7
-OpStore %1044 %3707
-%3708 = OpLoad %uchar %1044
-%3709 = OpNot %uchar %3708
-OpStore %1045 %3709
-%3710 = OpLoad %_arr_uchar_uint_16 %170
-%3711 = OpCompositeExtract %uchar %3710 8
-OpStore %1046 %3711
-%3712 = OpLoad %uchar %1046
-%3713 = OpNot %uchar %3712
-OpStore %1047 %3713
-%3714 = OpLoad %_arr_uchar_uint_16 %170
-%3715 = OpCompositeExtract %uchar %3714 9
-OpStore %1048 %3715
-%3716 = OpLoad %uchar %1048
-%3717 = OpNot %uchar %3716
-OpStore %1049 %3717
-%3718 = OpLoad %_arr_uchar_uint_16 %170
-%3719 = OpCompositeExtract %uchar %3718 10
-OpStore %1050 %3719
-%3720 = OpLoad %uchar %1050
-%3721 = OpNot %uchar %3720
-OpStore %1051 %3721
-%3722 = OpLoad %_arr_uchar_uint_16 %170
-%3723 = OpCompositeExtract %uchar %3722 11
-OpStore %1052 %3723
-%3724 = OpLoad %uchar %1052
-%3725 = OpNot %uchar %3724
-OpStore %1053 %3725
-%3726 = OpLoad %_arr_uchar_uint_16 %170
-%3727 = OpCompositeExtract %uchar %3726 12
-OpStore %1054 %3727
-%3728 = OpLoad %uchar %1054
-%3729 = OpNot %uchar %3728
-OpStore %1055 %3729
-%3730 = OpLoad %_arr_uchar_uint_16 %170
-%3731 = OpCompositeExtract %uchar %3730 13
-OpStore %1056 %3731
-%3732 = OpLoad %uchar %1056
-%3733 = OpNot %uchar %3732
-OpStore %1057 %3733
-%3734 = OpLoad %_arr_uchar_uint_16 %170
-%3735 = OpCompositeExtract %uchar %3734 14
-OpStore %1058 %3735
-%3736 = OpLoad %uchar %1058
-%3737 = OpNot %uchar %3736
-OpStore %1059 %3737
-%3738 = OpLoad %_arr_uchar_uint_16 %170
-%3739 = OpCompositeExtract %uchar %3738 15
-OpStore %1060 %3739
-%3740 = OpLoad %uchar %1060
-%3741 = OpNot %uchar %3740
-OpStore %1061 %3741
-%3742 = OpLoad %_arr_uchar_uint_16 %170
-%3743 = OpLoad %uchar %1031
-%3744 = OpCompositeInsert %_arr_uchar_uint_16 %3743 %3742 0
-OpStore %1062 %3744
-%3745 = OpLoad %_arr_uchar_uint_16 %1062
-%3746 = OpLoad %uchar %1033
-%3747 = OpCompositeInsert %_arr_uchar_uint_16 %3746 %3745 1
-OpStore %1063 %3747
-%3748 = OpLoad %_arr_uchar_uint_16 %1063
-%3749 = OpLoad %uchar %1035
-%3750 = OpCompositeInsert %_arr_uchar_uint_16 %3749 %3748 2
-OpStore %1064 %3750
-%3751 = OpLoad %_arr_uchar_uint_16 %1064
-%3752 = OpLoad %uchar %1037
-%3753 = OpCompositeInsert %_arr_uchar_uint_16 %3752 %3751 3
-OpStore %1065 %3753
-%3754 = OpLoad %_arr_uchar_uint_16 %1065
-%3755 = OpLoad %uchar %1039
-%3756 = OpCompositeInsert %_arr_uchar_uint_16 %3755 %3754 4
-OpStore %1066 %3756
-%3757 = OpLoad %_arr_uchar_uint_16 %1066
-%3758 = OpLoad %uchar %1041
-%3759 = OpCompositeInsert %_arr_uchar_uint_16 %3758 %3757 5
-OpStore %1067 %3759
-%3760 = OpLoad %_arr_uchar_uint_16 %1067
-%3761 = OpLoad %uchar %1043
-%3762 = OpCompositeInsert %_arr_uchar_uint_16 %3761 %3760 6
-OpStore %1068 %3762
-%3763 = OpLoad %_arr_uchar_uint_16 %1068
-%3764 = OpLoad %uchar %1045
-%3765 = OpCompositeInsert %_arr_uchar_uint_16 %3764 %3763 7
-OpStore %1069 %3765
-%3766 = OpLoad %_arr_uchar_uint_16 %1069
-%3767 = OpLoad %uchar %1047
-%3768 = OpCompositeInsert %_arr_uchar_uint_16 %3767 %3766 8
-OpStore %1070 %3768
-%3769 = OpLoad %_arr_uchar_uint_16 %1070
-%3770 = OpLoad %uchar %1049
-%3771 = OpCompositeInsert %_arr_uchar_uint_16 %3770 %3769 9
-OpStore %1071 %3771
-%3772 = OpLoad %_arr_uchar_uint_16 %1071
-%3773 = OpLoad %uchar %1051
-%3774 = OpCompositeInsert %_arr_uchar_uint_16 %3773 %3772 10
-OpStore %1072 %3774
-%3775 = OpLoad %_arr_uchar_uint_16 %1072
-%3776 = OpLoad %uchar %1053
-%3777 = OpCompositeInsert %_arr_uchar_uint_16 %3776 %3775 11
-OpStore %1073 %3777
-%3778 = OpLoad %_arr_uchar_uint_16 %1073
-%3779 = OpLoad %uchar %1055
-%3780 = OpCompositeInsert %_arr_uchar_uint_16 %3779 %3778 12
-OpStore %1074 %3780
-%3781 = OpLoad %_arr_uchar_uint_16 %1074
-%3782 = OpLoad %uchar %1057
-%3783 = OpCompositeInsert %_arr_uchar_uint_16 %3782 %3781 13
-OpStore %1075 %3783
-%3784 = OpLoad %_arr_uchar_uint_16 %1075
-%3785 = OpLoad %uchar %1059
-%3786 = OpCompositeInsert %_arr_uchar_uint_16 %3785 %3784 14
-OpStore %1076 %3786
-%3787 = OpLoad %_arr_uchar_uint_16 %1076
-%3788 = OpLoad %uchar %1061
-%3789 = OpCompositeInsert %_arr_uchar_uint_16 %3788 %3787 15
-OpStore %1077 %3789
-%3790 = OpLoad %ulong %185
-%3791 = OpLoad %_arr_uchar_uint_16 %1077
-%3792 = OpFunctionCall %ulong %1 %3790 %3791
-OpStore %186 %3792
-%3793 = OpLoad %_arr_uchar_uint_16 %853
-%3794 = OpCompositeExtract %uchar %3793 0
-OpStore %1078 %3794
-%3795 = OpLoad %_arr_uchar_uint_16 %917
-%3796 = OpCompositeExtract %uchar %3795 0
-OpStore %1079 %3796
-%3797 = OpLoad %uchar %1078
-%3798 = OpLoad %uchar %1079
-%3799 = OpBitwiseXor %uchar %3797 %3798
-OpStore %1080 %3799
-%3800 = OpLoad %_arr_uchar_uint_16 %853
-%3801 = OpCompositeExtract %uchar %3800 1
-OpStore %1081 %3801
-%3802 = OpLoad %_arr_uchar_uint_16 %917
-%3803 = OpCompositeExtract %uchar %3802 1
-OpStore %1082 %3803
-%3804 = OpLoad %uchar %1081
-%3805 = OpLoad %uchar %1082
-%3806 = OpBitwiseXor %uchar %3804 %3805
-OpStore %1083 %3806
-%3807 = OpLoad %_arr_uchar_uint_16 %853
-%3808 = OpCompositeExtract %uchar %3807 2
-OpStore %1084 %3808
-%3809 = OpLoad %_arr_uchar_uint_16 %917
-%3810 = OpCompositeExtract %uchar %3809 2
-OpStore %1085 %3810
-%3811 = OpLoad %uchar %1084
-%3812 = OpLoad %uchar %1085
-%3813 = OpBitwiseXor %uchar %3811 %3812
-OpStore %1086 %3813
-%3814 = OpLoad %_arr_uchar_uint_16 %853
-%3815 = OpCompositeExtract %uchar %3814 3
-OpStore %1087 %3815
-%3816 = OpLoad %_arr_uchar_uint_16 %917
-%3817 = OpCompositeExtract %uchar %3816 3
-OpStore %1088 %3817
-%3818 = OpLoad %uchar %1087
-%3819 = OpLoad %uchar %1088
-%3820 = OpBitwiseXor %uchar %3818 %3819
-OpStore %1089 %3820
-%3821 = OpLoad %_arr_uchar_uint_16 %853
-%3822 = OpCompositeExtract %uchar %3821 4
-OpStore %1090 %3822
-%3823 = OpLoad %_arr_uchar_uint_16 %917
-%3824 = OpCompositeExtract %uchar %3823 4
-OpStore %1091 %3824
-%3825 = OpLoad %uchar %1090
-%3826 = OpLoad %uchar %1091
-%3827 = OpBitwiseXor %uchar %3825 %3826
-OpStore %1092 %3827
-%3828 = OpLoad %_arr_uchar_uint_16 %853
-%3829 = OpCompositeExtract %uchar %3828 5
-OpStore %1093 %3829
-%3830 = OpLoad %_arr_uchar_uint_16 %917
-%3831 = OpCompositeExtract %uchar %3830 5
-OpStore %1094 %3831
-%3832 = OpLoad %uchar %1093
-%3833 = OpLoad %uchar %1094
-%3834 = OpBitwiseXor %uchar %3832 %3833
-OpStore %1095 %3834
-%3835 = OpLoad %_arr_uchar_uint_16 %853
-%3836 = OpCompositeExtract %uchar %3835 6
-OpStore %1096 %3836
-%3837 = OpLoad %_arr_uchar_uint_16 %917
-%3838 = OpCompositeExtract %uchar %3837 6
-OpStore %1097 %3838
-%3839 = OpLoad %uchar %1096
-%3840 = OpLoad %uchar %1097
-%3841 = OpBitwiseXor %uchar %3839 %3840
-OpStore %1098 %3841
-%3842 = OpLoad %_arr_uchar_uint_16 %853
-%3843 = OpCompositeExtract %uchar %3842 7
-OpStore %1099 %3843
-%3844 = OpLoad %_arr_uchar_uint_16 %917
-%3845 = OpCompositeExtract %uchar %3844 7
-OpStore %1100 %3845
-%3846 = OpLoad %uchar %1099
-%3847 = OpLoad %uchar %1100
-%3848 = OpBitwiseXor %uchar %3846 %3847
-OpStore %1101 %3848
-%3849 = OpLoad %_arr_uchar_uint_16 %853
-%3850 = OpCompositeExtract %uchar %3849 8
-OpStore %1102 %3850
-%3851 = OpLoad %_arr_uchar_uint_16 %917
-%3852 = OpCompositeExtract %uchar %3851 8
-OpStore %1103 %3852
-%3853 = OpLoad %uchar %1102
-%3854 = OpLoad %uchar %1103
-%3855 = OpBitwiseXor %uchar %3853 %3854
-OpStore %1104 %3855
-%3856 = OpLoad %_arr_uchar_uint_16 %853
-%3857 = OpCompositeExtract %uchar %3856 9
-OpStore %1105 %3857
-%3858 = OpLoad %_arr_uchar_uint_16 %917
-%3859 = OpCompositeExtract %uchar %3858 9
-OpStore %1106 %3859
-%3860 = OpLoad %uchar %1105
-%3861 = OpLoad %uchar %1106
-%3862 = OpBitwiseXor %uchar %3860 %3861
-OpStore %1107 %3862
-%3863 = OpLoad %_arr_uchar_uint_16 %853
-%3864 = OpCompositeExtract %uchar %3863 10
-OpStore %1108 %3864
-%3865 = OpLoad %_arr_uchar_uint_16 %917
-%3866 = OpCompositeExtract %uchar %3865 10
-OpStore %1109 %3866
-%3867 = OpLoad %uchar %1108
-%3868 = OpLoad %uchar %1109
-%3869 = OpBitwiseXor %uchar %3867 %3868
-OpStore %1110 %3869
-%3870 = OpLoad %_arr_uchar_uint_16 %853
-%3871 = OpCompositeExtract %uchar %3870 11
-OpStore %1111 %3871
-%3872 = OpLoad %_arr_uchar_uint_16 %917
-%3873 = OpCompositeExtract %uchar %3872 11
-OpStore %1112 %3873
-%3874 = OpLoad %uchar %1111
-%3875 = OpLoad %uchar %1112
-%3876 = OpBitwiseXor %uchar %3874 %3875
-OpStore %1113 %3876
-%3877 = OpLoad %_arr_uchar_uint_16 %853
-%3878 = OpCompositeExtract %uchar %3877 12
-OpStore %1114 %3878
-%3879 = OpLoad %_arr_uchar_uint_16 %917
-%3880 = OpCompositeExtract %uchar %3879 12
-OpStore %1115 %3880
-%3881 = OpLoad %uchar %1114
-%3882 = OpLoad %uchar %1115
-%3883 = OpBitwiseXor %uchar %3881 %3882
-OpStore %1116 %3883
-%3884 = OpLoad %_arr_uchar_uint_16 %853
-%3885 = OpCompositeExtract %uchar %3884 13
-OpStore %1117 %3885
-%3886 = OpLoad %_arr_uchar_uint_16 %917
-%3887 = OpCompositeExtract %uchar %3886 13
-OpStore %1118 %3887
-%3888 = OpLoad %uchar %1117
-%3889 = OpLoad %uchar %1118
-%3890 = OpBitwiseXor %uchar %3888 %3889
-OpStore %1119 %3890
-%3891 = OpLoad %_arr_uchar_uint_16 %853
-%3892 = OpCompositeExtract %uchar %3891 14
-OpStore %1120 %3892
-%3893 = OpLoad %_arr_uchar_uint_16 %917
-%3894 = OpCompositeExtract %uchar %3893 14
-OpStore %1121 %3894
-%3895 = OpLoad %uchar %1120
-%3896 = OpLoad %uchar %1121
-%3897 = OpBitwiseXor %uchar %3895 %3896
-OpStore %1122 %3897
-%3898 = OpLoad %_arr_uchar_uint_16 %853
-%3899 = OpCompositeExtract %uchar %3898 15
-OpStore %1123 %3899
-%3900 = OpLoad %_arr_uchar_uint_16 %917
-%3901 = OpCompositeExtract %uchar %3900 15
-OpStore %1124 %3901
-%3902 = OpLoad %uchar %1123
-%3903 = OpLoad %uchar %1124
-%3904 = OpBitwiseXor %uchar %3902 %3903
-OpStore %1125 %3904
-%3905 = OpLoad %_arr_uchar_uint_16 %853
-%3906 = OpLoad %uchar %1080
-%3907 = OpCompositeInsert %_arr_uchar_uint_16 %3906 %3905 0
-OpStore %1126 %3907
-%3908 = OpLoad %_arr_uchar_uint_16 %1126
-%3909 = OpLoad %uchar %1083
-%3910 = OpCompositeInsert %_arr_uchar_uint_16 %3909 %3908 1
-OpStore %1127 %3910
-%3911 = OpLoad %_arr_uchar_uint_16 %1127
-%3912 = OpLoad %uchar %1086
-%3913 = OpCompositeInsert %_arr_uchar_uint_16 %3912 %3911 2
-OpStore %1128 %3913
-%3914 = OpLoad %_arr_uchar_uint_16 %1128
-%3915 = OpLoad %uchar %1089
-%3916 = OpCompositeInsert %_arr_uchar_uint_16 %3915 %3914 3
-OpStore %1129 %3916
-%3917 = OpLoad %_arr_uchar_uint_16 %1129
-%3918 = OpLoad %uchar %1092
-%3919 = OpCompositeInsert %_arr_uchar_uint_16 %3918 %3917 4
-OpStore %1130 %3919
-%3920 = OpLoad %_arr_uchar_uint_16 %1130
-%3921 = OpLoad %uchar %1095
-%3922 = OpCompositeInsert %_arr_uchar_uint_16 %3921 %3920 5
-OpStore %1131 %3922
-%3923 = OpLoad %_arr_uchar_uint_16 %1131
-%3924 = OpLoad %uchar %1098
-%3925 = OpCompositeInsert %_arr_uchar_uint_16 %3924 %3923 6
-OpStore %1132 %3925
-%3926 = OpLoad %_arr_uchar_uint_16 %1132
-%3927 = OpLoad %uchar %1101
-%3928 = OpCompositeInsert %_arr_uchar_uint_16 %3927 %3926 7
-OpStore %1133 %3928
-%3929 = OpLoad %_arr_uchar_uint_16 %1133
-%3930 = OpLoad %uchar %1104
-%3931 = OpCompositeInsert %_arr_uchar_uint_16 %3930 %3929 8
-OpStore %1134 %3931
-%3932 = OpLoad %_arr_uchar_uint_16 %1134
-%3933 = OpLoad %uchar %1107
-%3934 = OpCompositeInsert %_arr_uchar_uint_16 %3933 %3932 9
-OpStore %1135 %3934
-%3935 = OpLoad %_arr_uchar_uint_16 %1135
-%3936 = OpLoad %uchar %1110
-%3937 = OpCompositeInsert %_arr_uchar_uint_16 %3936 %3935 10
-OpStore %1136 %3937
-%3938 = OpLoad %_arr_uchar_uint_16 %1136
-%3939 = OpLoad %uchar %1113
-%3940 = OpCompositeInsert %_arr_uchar_uint_16 %3939 %3938 11
-OpStore %1137 %3940
-%3941 = OpLoad %_arr_uchar_uint_16 %1137
-%3942 = OpLoad %uchar %1116
-%3943 = OpCompositeInsert %_arr_uchar_uint_16 %3942 %3941 12
-OpStore %1138 %3943
-%3944 = OpLoad %_arr_uchar_uint_16 %1138
-%3945 = OpLoad %uchar %1119
-%3946 = OpCompositeInsert %_arr_uchar_uint_16 %3945 %3944 13
-OpStore %1139 %3946
-%3947 = OpLoad %_arr_uchar_uint_16 %1139
-%3948 = OpLoad %uchar %1122
-%3949 = OpCompositeInsert %_arr_uchar_uint_16 %3948 %3947 14
-OpStore %1140 %3949
-%3950 = OpLoad %_arr_uchar_uint_16 %1140
-%3951 = OpLoad %uchar %1125
-%3952 = OpCompositeInsert %_arr_uchar_uint_16 %3951 %3950 15
-OpStore %1141 %3952
-%3953 = OpLoad %ulong %186
-%3954 = OpLoad %_arr_uchar_uint_16 %1141
-%3955 = OpFunctionCall %ulong %1 %3953 %3954
-OpStore %187 %3955
-%3956 = OpLoad %ulong %187
-OpStore %208 %3956
-%3957 = OpLoad %_arr_uchar_uint_16 %164
-OpStore %209 %3957
-%3958 = OpLoad %_arr_uchar_uint_16 %158
-OpStore %210 %3958
-%3959 = OpLoad %_arr_uchar_uint_16 %158
-OpStore %211 %3959
-OpStore %212 %ulong_0
-OpBranch %136
-%136 = OpLabel
-%3961 = OpLoad %ulong %212
-%3963 = OpULessThan %bool %3961 %ulong_6
-OpStore %189 %3963
-%3964 = OpLoad %bool %189
-OpLoopMerge %138 %143 None
-OpBranchConditional %3964 %137 %138
-%138 = OpLabel
-OpStore %148 %3965
-%3967 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_0
-%3968 = OpLoad %_arr_uchar_uint_16 %209
-OpStore %3967 %3968
-%3969 = OpLoad %_arr_uchar_uint_16 %209
-%3970 = OpCompositeExtract %uchar %3969 0
-OpStore %1398 %3970
-%3971 = OpLoad %_arr_uchar_uint_16 %170
-%3972 = OpCompositeExtract %uchar %3971 0
-OpStore %1399 %3972
-%3973 = OpLoad %uchar %1398
-%3974 = OpLoad %uchar %1399
-%3975 = OpIAdd %uchar %3973 %3974
-OpStore %1400 %3975
-%3976 = OpLoad %_arr_uchar_uint_16 %209
-%3977 = OpCompositeExtract %uchar %3976 1
-OpStore %1401 %3977
-%3978 = OpLoad %_arr_uchar_uint_16 %170
-%3979 = OpCompositeExtract %uchar %3978 1
-OpStore %1402 %3979
-%3980 = OpLoad %uchar %1401
-%3981 = OpLoad %uchar %1402
-%3982 = OpIAdd %uchar %3980 %3981
-OpStore %1403 %3982
-%3983 = OpLoad %_arr_uchar_uint_16 %209
-%3984 = OpCompositeExtract %uchar %3983 2
-OpStore %1404 %3984
-%3985 = OpLoad %_arr_uchar_uint_16 %170
-%3986 = OpCompositeExtract %uchar %3985 2
-OpStore %1405 %3986
-%3987 = OpLoad %uchar %1404
-%3988 = OpLoad %uchar %1405
-%3989 = OpIAdd %uchar %3987 %3988
-OpStore %1406 %3989
-%3990 = OpLoad %_arr_uchar_uint_16 %209
-%3991 = OpCompositeExtract %uchar %3990 3
-OpStore %1407 %3991
-%3992 = OpLoad %_arr_uchar_uint_16 %170
-%3993 = OpCompositeExtract %uchar %3992 3
-OpStore %1408 %3993
-%3994 = OpLoad %uchar %1407
-%3995 = OpLoad %uchar %1408
-%3996 = OpIAdd %uchar %3994 %3995
-OpStore %1409 %3996
-%3997 = OpLoad %_arr_uchar_uint_16 %209
-%3998 = OpCompositeExtract %uchar %3997 4
-OpStore %1410 %3998
-%3999 = OpLoad %_arr_uchar_uint_16 %170
-%4000 = OpCompositeExtract %uchar %3999 4
-OpStore %1411 %4000
-%4001 = OpLoad %uchar %1410
-%4002 = OpLoad %uchar %1411
-%4003 = OpIAdd %uchar %4001 %4002
-OpStore %1412 %4003
-%4004 = OpLoad %_arr_uchar_uint_16 %209
-%4005 = OpCompositeExtract %uchar %4004 5
-OpStore %1413 %4005
-%4006 = OpLoad %_arr_uchar_uint_16 %170
-%4007 = OpCompositeExtract %uchar %4006 5
-OpStore %1414 %4007
-%4008 = OpLoad %uchar %1413
-%4009 = OpLoad %uchar %1414
-%4010 = OpIAdd %uchar %4008 %4009
-OpStore %1415 %4010
-%4011 = OpLoad %_arr_uchar_uint_16 %209
-%4012 = OpCompositeExtract %uchar %4011 6
-OpStore %1416 %4012
-%4013 = OpLoad %_arr_uchar_uint_16 %170
-%4014 = OpCompositeExtract %uchar %4013 6
-OpStore %1417 %4014
-%4015 = OpLoad %uchar %1416
-%4016 = OpLoad %uchar %1417
-%4017 = OpIAdd %uchar %4015 %4016
-OpStore %1418 %4017
-%4018 = OpLoad %_arr_uchar_uint_16 %209
-%4019 = OpCompositeExtract %uchar %4018 7
-OpStore %1419 %4019
-%4020 = OpLoad %_arr_uchar_uint_16 %170
-%4021 = OpCompositeExtract %uchar %4020 7
-OpStore %1420 %4021
-%4022 = OpLoad %uchar %1419
-%4023 = OpLoad %uchar %1420
-%4024 = OpIAdd %uchar %4022 %4023
-OpStore %1421 %4024
-%4025 = OpLoad %_arr_uchar_uint_16 %209
-%4026 = OpCompositeExtract %uchar %4025 8
-OpStore %1422 %4026
-%4027 = OpLoad %_arr_uchar_uint_16 %170
-%4028 = OpCompositeExtract %uchar %4027 8
-OpStore %1423 %4028
-%4029 = OpLoad %uchar %1422
-%4030 = OpLoad %uchar %1423
-%4031 = OpIAdd %uchar %4029 %4030
-OpStore %1424 %4031
-%4032 = OpLoad %_arr_uchar_uint_16 %209
-%4033 = OpCompositeExtract %uchar %4032 9
-OpStore %1425 %4033
-%4034 = OpLoad %_arr_uchar_uint_16 %170
-%4035 = OpCompositeExtract %uchar %4034 9
-OpStore %1426 %4035
-%4036 = OpLoad %uchar %1425
-%4037 = OpLoad %uchar %1426
-%4038 = OpIAdd %uchar %4036 %4037
-OpStore %1427 %4038
-%4039 = OpLoad %_arr_uchar_uint_16 %209
-%4040 = OpCompositeExtract %uchar %4039 10
-OpStore %1428 %4040
-%4041 = OpLoad %_arr_uchar_uint_16 %170
-%4042 = OpCompositeExtract %uchar %4041 10
-OpStore %1429 %4042
-%4043 = OpLoad %uchar %1428
-%4044 = OpLoad %uchar %1429
-%4045 = OpIAdd %uchar %4043 %4044
-OpStore %1430 %4045
-%4046 = OpLoad %_arr_uchar_uint_16 %209
-%4047 = OpCompositeExtract %uchar %4046 11
-OpStore %1431 %4047
-%4048 = OpLoad %_arr_uchar_uint_16 %170
-%4049 = OpCompositeExtract %uchar %4048 11
-OpStore %1432 %4049
-%4050 = OpLoad %uchar %1431
-%4051 = OpLoad %uchar %1432
-%4052 = OpIAdd %uchar %4050 %4051
-OpStore %1433 %4052
-%4053 = OpLoad %_arr_uchar_uint_16 %209
-%4054 = OpCompositeExtract %uchar %4053 12
-OpStore %1434 %4054
-%4055 = OpLoad %_arr_uchar_uint_16 %170
-%4056 = OpCompositeExtract %uchar %4055 12
-OpStore %1435 %4056
-%4057 = OpLoad %uchar %1434
-%4058 = OpLoad %uchar %1435
-%4059 = OpIAdd %uchar %4057 %4058
-OpStore %1436 %4059
-%4060 = OpLoad %_arr_uchar_uint_16 %209
-%4061 = OpCompositeExtract %uchar %4060 13
-OpStore %1437 %4061
-%4062 = OpLoad %_arr_uchar_uint_16 %170
-%4063 = OpCompositeExtract %uchar %4062 13
-OpStore %1438 %4063
-%4064 = OpLoad %uchar %1437
-%4065 = OpLoad %uchar %1438
-%4066 = OpIAdd %uchar %4064 %4065
-OpStore %1439 %4066
-%4067 = OpLoad %_arr_uchar_uint_16 %209
-%4068 = OpCompositeExtract %uchar %4067 14
-OpStore %1440 %4068
-%4069 = OpLoad %_arr_uchar_uint_16 %170
-%4070 = OpCompositeExtract %uchar %4069 14
-OpStore %1441 %4070
-%4071 = OpLoad %uchar %1440
-%4072 = OpLoad %uchar %1441
-%4073 = OpIAdd %uchar %4071 %4072
-OpStore %1442 %4073
-%4074 = OpLoad %_arr_uchar_uint_16 %209
-%4075 = OpCompositeExtract %uchar %4074 15
-OpStore %1443 %4075
-%4076 = OpLoad %_arr_uchar_uint_16 %170
-%4077 = OpCompositeExtract %uchar %4076 15
-OpStore %1444 %4077
-%4078 = OpLoad %uchar %1443
-%4079 = OpLoad %uchar %1444
-%4080 = OpIAdd %uchar %4078 %4079
-OpStore %1445 %4080
-%4081 = OpLoad %_arr_uchar_uint_16 %209
-%4082 = OpLoad %uchar %1400
-%4083 = OpCompositeInsert %_arr_uchar_uint_16 %4082 %4081 0
-OpStore %1446 %4083
-%4084 = OpLoad %_arr_uchar_uint_16 %1446
-%4085 = OpLoad %uchar %1403
-%4086 = OpCompositeInsert %_arr_uchar_uint_16 %4085 %4084 1
-OpStore %1447 %4086
-%4087 = OpLoad %_arr_uchar_uint_16 %1447
-%4088 = OpLoad %uchar %1406
-%4089 = OpCompositeInsert %_arr_uchar_uint_16 %4088 %4087 2
-OpStore %1448 %4089
-%4090 = OpLoad %_arr_uchar_uint_16 %1448
-%4091 = OpLoad %uchar %1409
-%4092 = OpCompositeInsert %_arr_uchar_uint_16 %4091 %4090 3
-OpStore %1449 %4092
-%4093 = OpLoad %_arr_uchar_uint_16 %1449
-%4094 = OpLoad %uchar %1412
-%4095 = OpCompositeInsert %_arr_uchar_uint_16 %4094 %4093 4
-OpStore %1450 %4095
-%4096 = OpLoad %_arr_uchar_uint_16 %1450
-%4097 = OpLoad %uchar %1415
-%4098 = OpCompositeInsert %_arr_uchar_uint_16 %4097 %4096 5
-OpStore %1451 %4098
-%4099 = OpLoad %_arr_uchar_uint_16 %1451
-%4100 = OpLoad %uchar %1418
-%4101 = OpCompositeInsert %_arr_uchar_uint_16 %4100 %4099 6
-OpStore %1452 %4101
-%4102 = OpLoad %_arr_uchar_uint_16 %1452
-%4103 = OpLoad %uchar %1421
-%4104 = OpCompositeInsert %_arr_uchar_uint_16 %4103 %4102 7
-OpStore %1453 %4104
-%4105 = OpLoad %_arr_uchar_uint_16 %1453
-%4106 = OpLoad %uchar %1424
-%4107 = OpCompositeInsert %_arr_uchar_uint_16 %4106 %4105 8
-OpStore %1454 %4107
-%4108 = OpLoad %_arr_uchar_uint_16 %1454
-%4109 = OpLoad %uchar %1427
-%4110 = OpCompositeInsert %_arr_uchar_uint_16 %4109 %4108 9
-OpStore %1455 %4110
-%4111 = OpLoad %_arr_uchar_uint_16 %1455
-%4112 = OpLoad %uchar %1430
-%4113 = OpCompositeInsert %_arr_uchar_uint_16 %4112 %4111 10
-OpStore %1456 %4113
-%4114 = OpLoad %_arr_uchar_uint_16 %1456
-%4115 = OpLoad %uchar %1433
-%4116 = OpCompositeInsert %_arr_uchar_uint_16 %4115 %4114 11
-OpStore %1457 %4116
-%4117 = OpLoad %_arr_uchar_uint_16 %1457
-%4118 = OpLoad %uchar %1436
-%4119 = OpCompositeInsert %_arr_uchar_uint_16 %4118 %4117 12
-OpStore %1458 %4119
-%4120 = OpLoad %_arr_uchar_uint_16 %1458
-%4121 = OpLoad %uchar %1439
-%4122 = OpCompositeInsert %_arr_uchar_uint_16 %4121 %4120 13
-OpStore %1459 %4122
-%4123 = OpLoad %_arr_uchar_uint_16 %1459
-%4124 = OpLoad %uchar %1442
-%4125 = OpCompositeInsert %_arr_uchar_uint_16 %4124 %4123 14
-OpStore %1460 %4125
-%4126 = OpLoad %_arr_uchar_uint_16 %1460
-%4127 = OpLoad %uchar %1445
-%4128 = OpCompositeInsert %_arr_uchar_uint_16 %4127 %4126 15
-OpStore %1461 %4128
-%4130 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_1
-%4131 = OpLoad %_arr_uchar_uint_16 %1461
-OpStore %4130 %4131
-%4132 = OpLoad %_arr_uchar_uint_16 %209
-%4133 = OpCompositeExtract %uchar %4132 0
-OpStore %1462 %4133
-%4134 = OpLoad %_arr_uchar_uint_16 %157
-%4135 = OpCompositeExtract %uchar %4134 0
-OpStore %1463 %4135
-%4136 = OpLoad %uchar %1462
-%4137 = OpLoad %uchar %1463
-%4138 = OpIMul %uchar %4136 %4137
-OpStore %1464 %4138
-%4139 = OpLoad %_arr_uchar_uint_16 %209
-%4140 = OpCompositeExtract %uchar %4139 1
-OpStore %1465 %4140
-%4141 = OpLoad %_arr_uchar_uint_16 %157
-%4142 = OpCompositeExtract %uchar %4141 1
-OpStore %1466 %4142
-%4143 = OpLoad %uchar %1465
-%4144 = OpLoad %uchar %1466
-%4145 = OpIMul %uchar %4143 %4144
-OpStore %1467 %4145
-%4146 = OpLoad %_arr_uchar_uint_16 %209
-%4147 = OpCompositeExtract %uchar %4146 2
-OpStore %1468 %4147
-%4148 = OpLoad %_arr_uchar_uint_16 %157
-%4149 = OpCompositeExtract %uchar %4148 2
-OpStore %1469 %4149
-%4150 = OpLoad %uchar %1468
-%4151 = OpLoad %uchar %1469
-%4152 = OpIMul %uchar %4150 %4151
-OpStore %1470 %4152
-%4153 = OpLoad %_arr_uchar_uint_16 %209
-%4154 = OpCompositeExtract %uchar %4153 3
-OpStore %1471 %4154
-%4155 = OpLoad %_arr_uchar_uint_16 %157
-%4156 = OpCompositeExtract %uchar %4155 3
-OpStore %1472 %4156
-%4157 = OpLoad %uchar %1471
-%4158 = OpLoad %uchar %1472
-%4159 = OpIMul %uchar %4157 %4158
-OpStore %1473 %4159
-%4160 = OpLoad %_arr_uchar_uint_16 %209
-%4161 = OpCompositeExtract %uchar %4160 4
-OpStore %1474 %4161
-%4162 = OpLoad %_arr_uchar_uint_16 %157
-%4163 = OpCompositeExtract %uchar %4162 4
-OpStore %1475 %4163
-%4164 = OpLoad %uchar %1474
-%4165 = OpLoad %uchar %1475
-%4166 = OpIMul %uchar %4164 %4165
-OpStore %1476 %4166
-%4167 = OpLoad %_arr_uchar_uint_16 %209
-%4168 = OpCompositeExtract %uchar %4167 5
-OpStore %1477 %4168
-%4169 = OpLoad %_arr_uchar_uint_16 %157
-%4170 = OpCompositeExtract %uchar %4169 5
-OpStore %1478 %4170
-%4171 = OpLoad %uchar %1477
-%4172 = OpLoad %uchar %1478
-%4173 = OpIMul %uchar %4171 %4172
-OpStore %1479 %4173
-%4174 = OpLoad %_arr_uchar_uint_16 %209
-%4175 = OpCompositeExtract %uchar %4174 6
-OpStore %1480 %4175
-%4176 = OpLoad %_arr_uchar_uint_16 %157
-%4177 = OpCompositeExtract %uchar %4176 6
-OpStore %1481 %4177
-%4178 = OpLoad %uchar %1480
-%4179 = OpLoad %uchar %1481
-%4180 = OpIMul %uchar %4178 %4179
-OpStore %1482 %4180
-%4181 = OpLoad %_arr_uchar_uint_16 %209
-%4182 = OpCompositeExtract %uchar %4181 7
-OpStore %1483 %4182
-%4183 = OpLoad %_arr_uchar_uint_16 %157
-%4184 = OpCompositeExtract %uchar %4183 7
-OpStore %1484 %4184
-%4185 = OpLoad %uchar %1483
-%4186 = OpLoad %uchar %1484
-%4187 = OpIMul %uchar %4185 %4186
-OpStore %1485 %4187
-%4188 = OpLoad %_arr_uchar_uint_16 %209
-%4189 = OpCompositeExtract %uchar %4188 8
-OpStore %1486 %4189
-%4190 = OpLoad %_arr_uchar_uint_16 %157
-%4191 = OpCompositeExtract %uchar %4190 8
-OpStore %1487 %4191
-%4192 = OpLoad %uchar %1486
-%4193 = OpLoad %uchar %1487
-%4194 = OpIMul %uchar %4192 %4193
-OpStore %1488 %4194
-%4195 = OpLoad %_arr_uchar_uint_16 %209
-%4196 = OpCompositeExtract %uchar %4195 9
-OpStore %1489 %4196
-%4197 = OpLoad %_arr_uchar_uint_16 %157
-%4198 = OpCompositeExtract %uchar %4197 9
-OpStore %1490 %4198
-%4199 = OpLoad %uchar %1489
-%4200 = OpLoad %uchar %1490
-%4201 = OpIMul %uchar %4199 %4200
-OpStore %1491 %4201
-%4202 = OpLoad %_arr_uchar_uint_16 %209
-%4203 = OpCompositeExtract %uchar %4202 10
-OpStore %1492 %4203
-%4204 = OpLoad %_arr_uchar_uint_16 %157
-%4205 = OpCompositeExtract %uchar %4204 10
-OpStore %1493 %4205
-%4206 = OpLoad %uchar %1492
-%4207 = OpLoad %uchar %1493
-%4208 = OpIMul %uchar %4206 %4207
-OpStore %1494 %4208
-%4209 = OpLoad %_arr_uchar_uint_16 %209
-%4210 = OpCompositeExtract %uchar %4209 11
-OpStore %1495 %4210
-%4211 = OpLoad %_arr_uchar_uint_16 %157
-%4212 = OpCompositeExtract %uchar %4211 11
-OpStore %1496 %4212
-%4213 = OpLoad %uchar %1495
-%4214 = OpLoad %uchar %1496
-%4215 = OpIMul %uchar %4213 %4214
-OpStore %1497 %4215
-%4216 = OpLoad %_arr_uchar_uint_16 %209
-%4217 = OpCompositeExtract %uchar %4216 12
-OpStore %1498 %4217
-%4218 = OpLoad %_arr_uchar_uint_16 %157
-%4219 = OpCompositeExtract %uchar %4218 12
-OpStore %1499 %4219
-%4220 = OpLoad %uchar %1498
-%4221 = OpLoad %uchar %1499
-%4222 = OpIMul %uchar %4220 %4221
-OpStore %1500 %4222
-%4223 = OpLoad %_arr_uchar_uint_16 %209
-%4224 = OpCompositeExtract %uchar %4223 13
-OpStore %1501 %4224
-%4225 = OpLoad %_arr_uchar_uint_16 %157
-%4226 = OpCompositeExtract %uchar %4225 13
-OpStore %1502 %4226
-%4227 = OpLoad %uchar %1501
-%4228 = OpLoad %uchar %1502
-%4229 = OpIMul %uchar %4227 %4228
-OpStore %1503 %4229
-%4230 = OpLoad %_arr_uchar_uint_16 %209
-%4231 = OpCompositeExtract %uchar %4230 14
-OpStore %1504 %4231
-%4232 = OpLoad %_arr_uchar_uint_16 %157
-%4233 = OpCompositeExtract %uchar %4232 14
-OpStore %1505 %4233
-%4234 = OpLoad %uchar %1504
-%4235 = OpLoad %uchar %1505
-%4236 = OpIMul %uchar %4234 %4235
-OpStore %1506 %4236
-%4237 = OpLoad %_arr_uchar_uint_16 %209
-%4238 = OpCompositeExtract %uchar %4237 15
-OpStore %1507 %4238
-%4239 = OpLoad %_arr_uchar_uint_16 %157
-%4240 = OpCompositeExtract %uchar %4239 15
-OpStore %1508 %4240
-%4241 = OpLoad %uchar %1507
-%4242 = OpLoad %uchar %1508
-%4243 = OpIMul %uchar %4241 %4242
-OpStore %1509 %4243
-%4244 = OpLoad %_arr_uchar_uint_16 %209
-%4245 = OpLoad %uchar %1464
-%4246 = OpCompositeInsert %_arr_uchar_uint_16 %4245 %4244 0
-OpStore %1510 %4246
-%4247 = OpLoad %_arr_uchar_uint_16 %1510
-%4248 = OpLoad %uchar %1467
-%4249 = OpCompositeInsert %_arr_uchar_uint_16 %4248 %4247 1
-OpStore %1511 %4249
-%4250 = OpLoad %_arr_uchar_uint_16 %1511
-%4251 = OpLoad %uchar %1470
-%4252 = OpCompositeInsert %_arr_uchar_uint_16 %4251 %4250 2
-OpStore %1512 %4252
-%4253 = OpLoad %_arr_uchar_uint_16 %1512
-%4254 = OpLoad %uchar %1473
-%4255 = OpCompositeInsert %_arr_uchar_uint_16 %4254 %4253 3
-OpStore %1513 %4255
-%4256 = OpLoad %_arr_uchar_uint_16 %1513
-%4257 = OpLoad %uchar %1476
-%4258 = OpCompositeInsert %_arr_uchar_uint_16 %4257 %4256 4
-OpStore %1514 %4258
-%4259 = OpLoad %_arr_uchar_uint_16 %1514
-%4260 = OpLoad %uchar %1479
-%4261 = OpCompositeInsert %_arr_uchar_uint_16 %4260 %4259 5
-OpStore %1515 %4261
-%4262 = OpLoad %_arr_uchar_uint_16 %1515
-%4263 = OpLoad %uchar %1482
-%4264 = OpCompositeInsert %_arr_uchar_uint_16 %4263 %4262 6
-OpStore %1516 %4264
-%4265 = OpLoad %_arr_uchar_uint_16 %1516
-%4266 = OpLoad %uchar %1485
-%4267 = OpCompositeInsert %_arr_uchar_uint_16 %4266 %4265 7
-OpStore %1517 %4267
-%4268 = OpLoad %_arr_uchar_uint_16 %1517
-%4269 = OpLoad %uchar %1488
-%4270 = OpCompositeInsert %_arr_uchar_uint_16 %4269 %4268 8
-OpStore %1518 %4270
-%4271 = OpLoad %_arr_uchar_uint_16 %1518
-%4272 = OpLoad %uchar %1491
-%4273 = OpCompositeInsert %_arr_uchar_uint_16 %4272 %4271 9
-OpStore %1519 %4273
-%4274 = OpLoad %_arr_uchar_uint_16 %1519
-%4275 = OpLoad %uchar %1494
-%4276 = OpCompositeInsert %_arr_uchar_uint_16 %4275 %4274 10
-OpStore %1520 %4276
-%4277 = OpLoad %_arr_uchar_uint_16 %1520
-%4278 = OpLoad %uchar %1497
-%4279 = OpCompositeInsert %_arr_uchar_uint_16 %4278 %4277 11
-OpStore %1521 %4279
-%4280 = OpLoad %_arr_uchar_uint_16 %1521
-%4281 = OpLoad %uchar %1500
-%4282 = OpCompositeInsert %_arr_uchar_uint_16 %4281 %4280 12
-OpStore %1522 %4282
-%4283 = OpLoad %_arr_uchar_uint_16 %1522
-%4284 = OpLoad %uchar %1503
-%4285 = OpCompositeInsert %_arr_uchar_uint_16 %4284 %4283 13
-OpStore %1523 %4285
-%4286 = OpLoad %_arr_uchar_uint_16 %1523
-%4287 = OpLoad %uchar %1506
-%4288 = OpCompositeInsert %_arr_uchar_uint_16 %4287 %4286 14
-OpStore %1524 %4288
-%4289 = OpLoad %_arr_uchar_uint_16 %1524
-%4290 = OpLoad %uchar %1509
-%4291 = OpCompositeInsert %_arr_uchar_uint_16 %4290 %4289 15
-OpStore %1525 %4291
-%4293 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_2
-%4294 = OpLoad %_arr_uchar_uint_16 %1525
-OpStore %4293 %4294
-%4296 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_3
-%4297 = OpLoad %_arr_uchar_uint_16 %210
-OpStore %4296 %4297
-%4298 = OpLoad %ulong %208
-OpStore %207 %4298
-OpStore %213 %ulong_0
-OpBranch %139
-%139 = OpLabel
-%4299 = OpLoad %ulong %213
-%4301 = OpULessThan %bool %4299 %ulong_4
-OpStore %195 %4301
-%4302 = OpLoad %bool %195
-OpLoopMerge %141 %142 None
-OpBranchConditional %4302 %140 %141
-%141 = OpLabel
-OpStore %151 %4303
-%4304 = OpAccessChain %_ptr_Function_uint %151 %uint_0
-OpStore %4304 %uint_4294967295
-%4306 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %uint_2
-%4307 = OpLoad %_arr_uchar_uint_16 %4306
-OpStore %199 %4307
-%4308 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %151 %uint_1
-%4309 = OpLoad %_arr_uchar_uint_16 %199
-OpStore %4308 %4309
-%4310 = OpAccessChain %_ptr_Function_uint %151 %uint_2
-OpStore %4310 %uint_305419896
-%4312 = OpLoad %uint %4304
-OpStore %201 %4312
-%4313 = OpLoad %ulong %207
-%4314 = OpLoad %uint %201
-%4315 = OpFunctionCall %ulong %5 %4313 %4314
-OpStore %202 %4315
-%4316 = OpLoad %_arr_uchar_uint_16 %4308
-OpStore %203 %4316
-%4317 = OpLoad %ulong %202
-%4318 = OpLoad %_arr_uchar_uint_16 %203
-%4319 = OpFunctionCall %ulong %1 %4317 %4318
-OpStore %204 %4319
-%4320 = OpLoad %uint %4310
-OpStore %205 %4320
-%4321 = OpLoad %ulong %204
-%4322 = OpLoad %uint %205
-%4323 = OpFunctionCall %ulong %5 %4321 %4322
-OpStore %206 %4323
-%4324 = OpLoad %ulong %206
-OpReturnValue %4324
-%140 = OpLabel
-%4325 = OpLoad %ulong %213
-%4326 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %148 %4325
-%4327 = OpLoad %_arr_uchar_uint_16 %4326
-OpStore %196 %4327
-%4328 = OpLoad %ulong %207
-%4329 = OpLoad %_arr_uchar_uint_16 %196
-%4330 = OpFunctionCall %ulong %1 %4328 %4329
-OpStore %197 %4330
-%4331 = OpLoad %ulong %213
-%4333 = OpIAdd %ulong %4331 %ulong_1
-OpStore %198 %4333
-%4334 = OpLoad %ulong %197
-OpStore %207 %4334
-%4335 = OpLoad %ulong %198
-OpStore %213 %4335
-OpBranch %142
-%137 = OpLabel
-%4336 = OpLoad %_arr_uchar_uint_16 %209
-%4337 = OpCompositeExtract %uchar %4336 0
-OpStore %1142 %4337
-%4338 = OpLoad %_arr_uchar_uint_16 %157
-%4339 = OpCompositeExtract %uchar %4338 0
-OpStore %1143 %4339
-%4340 = OpLoad %uchar %1142
-%4341 = OpLoad %uchar %1143
-%4342 = OpIMul %uchar %4340 %4341
-OpStore %1144 %4342
-%4343 = OpLoad %_arr_uchar_uint_16 %209
-%4344 = OpCompositeExtract %uchar %4343 1
-OpStore %1145 %4344
-%4345 = OpLoad %_arr_uchar_uint_16 %157
-%4346 = OpCompositeExtract %uchar %4345 1
-OpStore %1146 %4346
-%4347 = OpLoad %uchar %1145
-%4348 = OpLoad %uchar %1146
-%4349 = OpIMul %uchar %4347 %4348
-OpStore %1147 %4349
-%4350 = OpLoad %_arr_uchar_uint_16 %209
-%4351 = OpCompositeExtract %uchar %4350 2
-OpStore %1148 %4351
-%4352 = OpLoad %_arr_uchar_uint_16 %157
-%4353 = OpCompositeExtract %uchar %4352 2
-OpStore %1149 %4353
-%4354 = OpLoad %uchar %1148
-%4355 = OpLoad %uchar %1149
-%4356 = OpIMul %uchar %4354 %4355
-OpStore %1150 %4356
-%4357 = OpLoad %_arr_uchar_uint_16 %209
-%4358 = OpCompositeExtract %uchar %4357 3
-OpStore %1151 %4358
-%4359 = OpLoad %_arr_uchar_uint_16 %157
-%4360 = OpCompositeExtract %uchar %4359 3
-OpStore %1152 %4360
-%4361 = OpLoad %uchar %1151
-%4362 = OpLoad %uchar %1152
-%4363 = OpIMul %uchar %4361 %4362
-OpStore %1153 %4363
-%4364 = OpLoad %_arr_uchar_uint_16 %209
-%4365 = OpCompositeExtract %uchar %4364 4
-OpStore %1154 %4365
-%4366 = OpLoad %_arr_uchar_uint_16 %157
-%4367 = OpCompositeExtract %uchar %4366 4
-OpStore %1155 %4367
-%4368 = OpLoad %uchar %1154
-%4369 = OpLoad %uchar %1155
-%4370 = OpIMul %uchar %4368 %4369
-OpStore %1156 %4370
-%4371 = OpLoad %_arr_uchar_uint_16 %209
-%4372 = OpCompositeExtract %uchar %4371 5
-OpStore %1157 %4372
-%4373 = OpLoad %_arr_uchar_uint_16 %157
-%4374 = OpCompositeExtract %uchar %4373 5
-OpStore %1158 %4374
-%4375 = OpLoad %uchar %1157
-%4376 = OpLoad %uchar %1158
-%4377 = OpIMul %uchar %4375 %4376
-OpStore %1159 %4377
-%4378 = OpLoad %_arr_uchar_uint_16 %209
-%4379 = OpCompositeExtract %uchar %4378 6
-OpStore %1160 %4379
-%4380 = OpLoad %_arr_uchar_uint_16 %157
-%4381 = OpCompositeExtract %uchar %4380 6
-OpStore %1161 %4381
-%4382 = OpLoad %uchar %1160
-%4383 = OpLoad %uchar %1161
-%4384 = OpIMul %uchar %4382 %4383
-OpStore %1162 %4384
-%4385 = OpLoad %_arr_uchar_uint_16 %209
-%4386 = OpCompositeExtract %uchar %4385 7
-OpStore %1163 %4386
-%4387 = OpLoad %_arr_uchar_uint_16 %157
-%4388 = OpCompositeExtract %uchar %4387 7
-OpStore %1164 %4388
-%4389 = OpLoad %uchar %1163
-%4390 = OpLoad %uchar %1164
-%4391 = OpIMul %uchar %4389 %4390
-OpStore %1165 %4391
-%4392 = OpLoad %_arr_uchar_uint_16 %209
-%4393 = OpCompositeExtract %uchar %4392 8
-OpStore %1166 %4393
-%4394 = OpLoad %_arr_uchar_uint_16 %157
-%4395 = OpCompositeExtract %uchar %4394 8
-OpStore %1167 %4395
-%4396 = OpLoad %uchar %1166
-%4397 = OpLoad %uchar %1167
-%4398 = OpIMul %uchar %4396 %4397
-OpStore %1168 %4398
-%4399 = OpLoad %_arr_uchar_uint_16 %209
-%4400 = OpCompositeExtract %uchar %4399 9
-OpStore %1169 %4400
-%4401 = OpLoad %_arr_uchar_uint_16 %157
-%4402 = OpCompositeExtract %uchar %4401 9
-OpStore %1170 %4402
-%4403 = OpLoad %uchar %1169
-%4404 = OpLoad %uchar %1170
-%4405 = OpIMul %uchar %4403 %4404
-OpStore %1171 %4405
-%4406 = OpLoad %_arr_uchar_uint_16 %209
-%4407 = OpCompositeExtract %uchar %4406 10
-OpStore %1172 %4407
-%4408 = OpLoad %_arr_uchar_uint_16 %157
-%4409 = OpCompositeExtract %uchar %4408 10
-OpStore %1173 %4409
-%4410 = OpLoad %uchar %1172
-%4411 = OpLoad %uchar %1173
-%4412 = OpIMul %uchar %4410 %4411
-OpStore %1174 %4412
-%4413 = OpLoad %_arr_uchar_uint_16 %209
-%4414 = OpCompositeExtract %uchar %4413 11
-OpStore %1175 %4414
-%4415 = OpLoad %_arr_uchar_uint_16 %157
-%4416 = OpCompositeExtract %uchar %4415 11
-OpStore %1176 %4416
-%4417 = OpLoad %uchar %1175
-%4418 = OpLoad %uchar %1176
-%4419 = OpIMul %uchar %4417 %4418
-OpStore %1177 %4419
-%4420 = OpLoad %_arr_uchar_uint_16 %209
-%4421 = OpCompositeExtract %uchar %4420 12
-OpStore %1178 %4421
-%4422 = OpLoad %_arr_uchar_uint_16 %157
-%4423 = OpCompositeExtract %uchar %4422 12
-OpStore %1179 %4423
-%4424 = OpLoad %uchar %1178
-%4425 = OpLoad %uchar %1179
-%4426 = OpIMul %uchar %4424 %4425
-OpStore %1180 %4426
-%4427 = OpLoad %_arr_uchar_uint_16 %209
-%4428 = OpCompositeExtract %uchar %4427 13
-OpStore %1181 %4428
-%4429 = OpLoad %_arr_uchar_uint_16 %157
-%4430 = OpCompositeExtract %uchar %4429 13
-OpStore %1182 %4430
-%4431 = OpLoad %uchar %1181
-%4432 = OpLoad %uchar %1182
-%4433 = OpIMul %uchar %4431 %4432
-OpStore %1183 %4433
-%4434 = OpLoad %_arr_uchar_uint_16 %209
-%4435 = OpCompositeExtract %uchar %4434 14
-OpStore %1184 %4435
-%4436 = OpLoad %_arr_uchar_uint_16 %157
-%4437 = OpCompositeExtract %uchar %4436 14
-OpStore %1185 %4437
-%4438 = OpLoad %uchar %1184
-%4439 = OpLoad %uchar %1185
-%4440 = OpIMul %uchar %4438 %4439
-OpStore %1186 %4440
-%4441 = OpLoad %_arr_uchar_uint_16 %209
-%4442 = OpCompositeExtract %uchar %4441 15
-OpStore %1187 %4442
-%4443 = OpLoad %_arr_uchar_uint_16 %157
-%4444 = OpCompositeExtract %uchar %4443 15
-OpStore %1188 %4444
-%4445 = OpLoad %uchar %1187
-%4446 = OpLoad %uchar %1188
-%4447 = OpIMul %uchar %4445 %4446
-OpStore %1189 %4447
-%4448 = OpLoad %_arr_uchar_uint_16 %209
-%4449 = OpLoad %uchar %1144
-%4450 = OpCompositeInsert %_arr_uchar_uint_16 %4449 %4448 0
-OpStore %1190 %4450
-%4451 = OpLoad %_arr_uchar_uint_16 %1190
-%4452 = OpLoad %uchar %1147
-%4453 = OpCompositeInsert %_arr_uchar_uint_16 %4452 %4451 1
-OpStore %1191 %4453
-%4454 = OpLoad %_arr_uchar_uint_16 %1191
-%4455 = OpLoad %uchar %1150
-%4456 = OpCompositeInsert %_arr_uchar_uint_16 %4455 %4454 2
-OpStore %1192 %4456
-%4457 = OpLoad %_arr_uchar_uint_16 %1192
-%4458 = OpLoad %uchar %1153
-%4459 = OpCompositeInsert %_arr_uchar_uint_16 %4458 %4457 3
-OpStore %1193 %4459
-%4460 = OpLoad %_arr_uchar_uint_16 %1193
-%4461 = OpLoad %uchar %1156
-%4462 = OpCompositeInsert %_arr_uchar_uint_16 %4461 %4460 4
-OpStore %1194 %4462
-%4463 = OpLoad %_arr_uchar_uint_16 %1194
-%4464 = OpLoad %uchar %1159
-%4465 = OpCompositeInsert %_arr_uchar_uint_16 %4464 %4463 5
-OpStore %1195 %4465
-%4466 = OpLoad %_arr_uchar_uint_16 %1195
-%4467 = OpLoad %uchar %1162
-%4468 = OpCompositeInsert %_arr_uchar_uint_16 %4467 %4466 6
-OpStore %1196 %4468
-%4469 = OpLoad %_arr_uchar_uint_16 %1196
-%4470 = OpLoad %uchar %1165
-%4471 = OpCompositeInsert %_arr_uchar_uint_16 %4470 %4469 7
-OpStore %1197 %4471
-%4472 = OpLoad %_arr_uchar_uint_16 %1197
-%4473 = OpLoad %uchar %1168
-%4474 = OpCompositeInsert %_arr_uchar_uint_16 %4473 %4472 8
-OpStore %1198 %4474
-%4475 = OpLoad %_arr_uchar_uint_16 %1198
-%4476 = OpLoad %uchar %1171
-%4477 = OpCompositeInsert %_arr_uchar_uint_16 %4476 %4475 9
-OpStore %1199 %4477
-%4478 = OpLoad %_arr_uchar_uint_16 %1199
-%4479 = OpLoad %uchar %1174
-%4480 = OpCompositeInsert %_arr_uchar_uint_16 %4479 %4478 10
-OpStore %1200 %4480
-%4481 = OpLoad %_arr_uchar_uint_16 %1200
-%4482 = OpLoad %uchar %1177
-%4483 = OpCompositeInsert %_arr_uchar_uint_16 %4482 %4481 11
-OpStore %1201 %4483
-%4484 = OpLoad %_arr_uchar_uint_16 %1201
-%4485 = OpLoad %uchar %1180
-%4486 = OpCompositeInsert %_arr_uchar_uint_16 %4485 %4484 12
-OpStore %1202 %4486
-%4487 = OpLoad %_arr_uchar_uint_16 %1202
-%4488 = OpLoad %uchar %1183
-%4489 = OpCompositeInsert %_arr_uchar_uint_16 %4488 %4487 13
-OpStore %1203 %4489
-%4490 = OpLoad %_arr_uchar_uint_16 %1203
-%4491 = OpLoad %uchar %1186
-%4492 = OpCompositeInsert %_arr_uchar_uint_16 %4491 %4490 14
-OpStore %1204 %4492
-%4493 = OpLoad %_arr_uchar_uint_16 %1204
-%4494 = OpLoad %uchar %1189
-%4495 = OpCompositeInsert %_arr_uchar_uint_16 %4494 %4493 15
-OpStore %1205 %4495
-%4496 = OpLoad %ulong %208
-%4497 = OpLoad %_arr_uchar_uint_16 %1205
-%4498 = OpFunctionCall %ulong %1 %4496 %4497
-OpStore %190 %4498
-%4499 = OpLoad %_arr_uchar_uint_16 %210
-%4500 = OpCompositeExtract %uchar %4499 0
-OpStore %1206 %4500
-%4501 = OpLoad %_arr_uchar_uint_16 %1205
-%4502 = OpCompositeExtract %uchar %4501 0
-OpStore %1207 %4502
-%4503 = OpLoad %uchar %1206
-%4504 = OpLoad %uchar %1207
-%4505 = OpBitwiseXor %uchar %4503 %4504
-OpStore %1208 %4505
-%4506 = OpLoad %_arr_uchar_uint_16 %210
-%4507 = OpCompositeExtract %uchar %4506 1
-OpStore %1209 %4507
-%4508 = OpLoad %_arr_uchar_uint_16 %1205
-%4509 = OpCompositeExtract %uchar %4508 1
-OpStore %1210 %4509
-%4510 = OpLoad %uchar %1209
-%4511 = OpLoad %uchar %1210
-%4512 = OpBitwiseXor %uchar %4510 %4511
-OpStore %1211 %4512
-%4513 = OpLoad %_arr_uchar_uint_16 %210
-%4514 = OpCompositeExtract %uchar %4513 2
-OpStore %1212 %4514
-%4515 = OpLoad %_arr_uchar_uint_16 %1205
-%4516 = OpCompositeExtract %uchar %4515 2
-OpStore %1213 %4516
-%4517 = OpLoad %uchar %1212
-%4518 = OpLoad %uchar %1213
-%4519 = OpBitwiseXor %uchar %4517 %4518
-OpStore %1214 %4519
-%4520 = OpLoad %_arr_uchar_uint_16 %210
-%4521 = OpCompositeExtract %uchar %4520 3
-OpStore %1215 %4521
-%4522 = OpLoad %_arr_uchar_uint_16 %1205
-%4523 = OpCompositeExtract %uchar %4522 3
-OpStore %1216 %4523
-%4524 = OpLoad %uchar %1215
-%4525 = OpLoad %uchar %1216
-%4526 = OpBitwiseXor %uchar %4524 %4525
-OpStore %1217 %4526
-%4527 = OpLoad %_arr_uchar_uint_16 %210
-%4528 = OpCompositeExtract %uchar %4527 4
-OpStore %1218 %4528
-%4529 = OpLoad %_arr_uchar_uint_16 %1205
-%4530 = OpCompositeExtract %uchar %4529 4
-OpStore %1219 %4530
-%4531 = OpLoad %uchar %1218
-%4532 = OpLoad %uchar %1219
-%4533 = OpBitwiseXor %uchar %4531 %4532
-OpStore %1220 %4533
-%4534 = OpLoad %_arr_uchar_uint_16 %210
-%4535 = OpCompositeExtract %uchar %4534 5
-OpStore %1221 %4535
-%4536 = OpLoad %_arr_uchar_uint_16 %1205
-%4537 = OpCompositeExtract %uchar %4536 5
-OpStore %1222 %4537
-%4538 = OpLoad %uchar %1221
-%4539 = OpLoad %uchar %1222
-%4540 = OpBitwiseXor %uchar %4538 %4539
-OpStore %1223 %4540
-%4541 = OpLoad %_arr_uchar_uint_16 %210
-%4542 = OpCompositeExtract %uchar %4541 6
-OpStore %1224 %4542
-%4543 = OpLoad %_arr_uchar_uint_16 %1205
-%4544 = OpCompositeExtract %uchar %4543 6
-OpStore %1225 %4544
-%4545 = OpLoad %uchar %1224
-%4546 = OpLoad %uchar %1225
-%4547 = OpBitwiseXor %uchar %4545 %4546
-OpStore %1226 %4547
-%4548 = OpLoad %_arr_uchar_uint_16 %210
-%4549 = OpCompositeExtract %uchar %4548 7
-OpStore %1227 %4549
-%4550 = OpLoad %_arr_uchar_uint_16 %1205
-%4551 = OpCompositeExtract %uchar %4550 7
-OpStore %1228 %4551
-%4552 = OpLoad %uchar %1227
-%4553 = OpLoad %uchar %1228
-%4554 = OpBitwiseXor %uchar %4552 %4553
-OpStore %1229 %4554
-%4555 = OpLoad %_arr_uchar_uint_16 %210
-%4556 = OpCompositeExtract %uchar %4555 8
-OpStore %1230 %4556
-%4557 = OpLoad %_arr_uchar_uint_16 %1205
-%4558 = OpCompositeExtract %uchar %4557 8
-OpStore %1231 %4558
-%4559 = OpLoad %uchar %1230
-%4560 = OpLoad %uchar %1231
-%4561 = OpBitwiseXor %uchar %4559 %4560
-OpStore %1232 %4561
-%4562 = OpLoad %_arr_uchar_uint_16 %210
-%4563 = OpCompositeExtract %uchar %4562 9
-OpStore %1233 %4563
-%4564 = OpLoad %_arr_uchar_uint_16 %1205
-%4565 = OpCompositeExtract %uchar %4564 9
-OpStore %1234 %4565
-%4566 = OpLoad %uchar %1233
-%4567 = OpLoad %uchar %1234
-%4568 = OpBitwiseXor %uchar %4566 %4567
-OpStore %1235 %4568
-%4569 = OpLoad %_arr_uchar_uint_16 %210
-%4570 = OpCompositeExtract %uchar %4569 10
-OpStore %1236 %4570
-%4571 = OpLoad %_arr_uchar_uint_16 %1205
-%4572 = OpCompositeExtract %uchar %4571 10
-OpStore %1237 %4572
-%4573 = OpLoad %uchar %1236
-%4574 = OpLoad %uchar %1237
-%4575 = OpBitwiseXor %uchar %4573 %4574
-OpStore %1238 %4575
-%4576 = OpLoad %_arr_uchar_uint_16 %210
-%4577 = OpCompositeExtract %uchar %4576 11
-OpStore %1239 %4577
-%4578 = OpLoad %_arr_uchar_uint_16 %1205
-%4579 = OpCompositeExtract %uchar %4578 11
-OpStore %1240 %4579
-%4580 = OpLoad %uchar %1239
-%4581 = OpLoad %uchar %1240
-%4582 = OpBitwiseXor %uchar %4580 %4581
-OpStore %1241 %4582
-%4583 = OpLoad %_arr_uchar_uint_16 %210
-%4584 = OpCompositeExtract %uchar %4583 12
-OpStore %1242 %4584
-%4585 = OpLoad %_arr_uchar_uint_16 %1205
-%4586 = OpCompositeExtract %uchar %4585 12
-OpStore %1243 %4586
-%4587 = OpLoad %uchar %1242
-%4588 = OpLoad %uchar %1243
-%4589 = OpBitwiseXor %uchar %4587 %4588
-OpStore %1244 %4589
-%4590 = OpLoad %_arr_uchar_uint_16 %210
-%4591 = OpCompositeExtract %uchar %4590 13
-OpStore %1245 %4591
-%4592 = OpLoad %_arr_uchar_uint_16 %1205
-%4593 = OpCompositeExtract %uchar %4592 13
-OpStore %1246 %4593
-%4594 = OpLoad %uchar %1245
-%4595 = OpLoad %uchar %1246
-%4596 = OpBitwiseXor %uchar %4594 %4595
-OpStore %1247 %4596
-%4597 = OpLoad %_arr_uchar_uint_16 %210
-%4598 = OpCompositeExtract %uchar %4597 14
-OpStore %1248 %4598
-%4599 = OpLoad %_arr_uchar_uint_16 %1205
-%4600 = OpCompositeExtract %uchar %4599 14
-OpStore %1249 %4600
-%4601 = OpLoad %uchar %1248
-%4602 = OpLoad %uchar %1249
-%4603 = OpBitwiseXor %uchar %4601 %4602
-OpStore %1250 %4603
-%4604 = OpLoad %_arr_uchar_uint_16 %210
-%4605 = OpCompositeExtract %uchar %4604 15
-OpStore %1251 %4605
-%4606 = OpLoad %_arr_uchar_uint_16 %1205
-%4607 = OpCompositeExtract %uchar %4606 15
-OpStore %1252 %4607
-%4608 = OpLoad %uchar %1251
-%4609 = OpLoad %uchar %1252
-%4610 = OpBitwiseXor %uchar %4608 %4609
-OpStore %1253 %4610
-%4611 = OpLoad %_arr_uchar_uint_16 %210
-%4612 = OpLoad %uchar %1208
-%4613 = OpCompositeInsert %_arr_uchar_uint_16 %4612 %4611 0
-OpStore %1254 %4613
-%4614 = OpLoad %_arr_uchar_uint_16 %1254
-%4615 = OpLoad %uchar %1211
-%4616 = OpCompositeInsert %_arr_uchar_uint_16 %4615 %4614 1
-OpStore %1255 %4616
-%4617 = OpLoad %_arr_uchar_uint_16 %1255
-%4618 = OpLoad %uchar %1214
-%4619 = OpCompositeInsert %_arr_uchar_uint_16 %4618 %4617 2
-OpStore %1256 %4619
-%4620 = OpLoad %_arr_uchar_uint_16 %1256
-%4621 = OpLoad %uchar %1217
-%4622 = OpCompositeInsert %_arr_uchar_uint_16 %4621 %4620 3
-OpStore %1257 %4622
-%4623 = OpLoad %_arr_uchar_uint_16 %1257
-%4624 = OpLoad %uchar %1220
-%4625 = OpCompositeInsert %_arr_uchar_uint_16 %4624 %4623 4
-OpStore %1258 %4625
-%4626 = OpLoad %_arr_uchar_uint_16 %1258
-%4627 = OpLoad %uchar %1223
-%4628 = OpCompositeInsert %_arr_uchar_uint_16 %4627 %4626 5
-OpStore %1259 %4628
-%4629 = OpLoad %_arr_uchar_uint_16 %1259
-%4630 = OpLoad %uchar %1226
-%4631 = OpCompositeInsert %_arr_uchar_uint_16 %4630 %4629 6
-OpStore %1260 %4631
-%4632 = OpLoad %_arr_uchar_uint_16 %1260
-%4633 = OpLoad %uchar %1229
-%4634 = OpCompositeInsert %_arr_uchar_uint_16 %4633 %4632 7
-OpStore %1261 %4634
-%4635 = OpLoad %_arr_uchar_uint_16 %1261
-%4636 = OpLoad %uchar %1232
-%4637 = OpCompositeInsert %_arr_uchar_uint_16 %4636 %4635 8
-OpStore %1262 %4637
-%4638 = OpLoad %_arr_uchar_uint_16 %1262
-%4639 = OpLoad %uchar %1235
-%4640 = OpCompositeInsert %_arr_uchar_uint_16 %4639 %4638 9
-OpStore %1263 %4640
-%4641 = OpLoad %_arr_uchar_uint_16 %1263
-%4642 = OpLoad %uchar %1238
-%4643 = OpCompositeInsert %_arr_uchar_uint_16 %4642 %4641 10
-OpStore %1264 %4643
-%4644 = OpLoad %_arr_uchar_uint_16 %1264
-%4645 = OpLoad %uchar %1241
-%4646 = OpCompositeInsert %_arr_uchar_uint_16 %4645 %4644 11
-OpStore %1265 %4646
-%4647 = OpLoad %_arr_uchar_uint_16 %1265
-%4648 = OpLoad %uchar %1244
-%4649 = OpCompositeInsert %_arr_uchar_uint_16 %4648 %4647 12
-OpStore %1266 %4649
-%4650 = OpLoad %_arr_uchar_uint_16 %1266
-%4651 = OpLoad %uchar %1247
-%4652 = OpCompositeInsert %_arr_uchar_uint_16 %4651 %4650 13
-OpStore %1267 %4652
-%4653 = OpLoad %_arr_uchar_uint_16 %1267
-%4654 = OpLoad %uchar %1250
-%4655 = OpCompositeInsert %_arr_uchar_uint_16 %4654 %4653 14
-OpStore %1268 %4655
-%4656 = OpLoad %_arr_uchar_uint_16 %1268
-%4657 = OpLoad %uchar %1253
-%4658 = OpCompositeInsert %_arr_uchar_uint_16 %4657 %4656 15
-OpStore %1269 %4658
-%4659 = OpLoad %ulong %190
-%4660 = OpLoad %_arr_uchar_uint_16 %1269
-%4661 = OpFunctionCall %ulong %1 %4659 %4660
-OpStore %191 %4661
-%4662 = OpLoad %_arr_uchar_uint_16 %211
-%4663 = OpCompositeExtract %uchar %4662 0
-OpStore %1270 %4663
-%4664 = OpLoad %_arr_uchar_uint_16 %209
-%4665 = OpCompositeExtract %uchar %4664 0
-OpStore %1271 %4665
-%4666 = OpLoad %uchar %1270
-%4667 = OpLoad %uchar %1271
-%4668 = OpIAdd %uchar %4666 %4667
-OpStore %1272 %4668
-%4669 = OpLoad %_arr_uchar_uint_16 %211
-%4670 = OpCompositeExtract %uchar %4669 1
-OpStore %1273 %4670
-%4671 = OpLoad %_arr_uchar_uint_16 %209
-%4672 = OpCompositeExtract %uchar %4671 1
-OpStore %1274 %4672
-%4673 = OpLoad %uchar %1273
-%4674 = OpLoad %uchar %1274
-%4675 = OpIAdd %uchar %4673 %4674
-OpStore %1275 %4675
-%4676 = OpLoad %_arr_uchar_uint_16 %211
-%4677 = OpCompositeExtract %uchar %4676 2
-OpStore %1276 %4677
-%4678 = OpLoad %_arr_uchar_uint_16 %209
-%4679 = OpCompositeExtract %uchar %4678 2
-OpStore %1277 %4679
-%4680 = OpLoad %uchar %1276
-%4681 = OpLoad %uchar %1277
-%4682 = OpIAdd %uchar %4680 %4681
-OpStore %1278 %4682
-%4683 = OpLoad %_arr_uchar_uint_16 %211
-%4684 = OpCompositeExtract %uchar %4683 3
-OpStore %1279 %4684
-%4685 = OpLoad %_arr_uchar_uint_16 %209
-%4686 = OpCompositeExtract %uchar %4685 3
-OpStore %1280 %4686
-%4687 = OpLoad %uchar %1279
-%4688 = OpLoad %uchar %1280
-%4689 = OpIAdd %uchar %4687 %4688
-OpStore %1281 %4689
-%4690 = OpLoad %_arr_uchar_uint_16 %211
-%4691 = OpCompositeExtract %uchar %4690 4
-OpStore %1282 %4691
-%4692 = OpLoad %_arr_uchar_uint_16 %209
-%4693 = OpCompositeExtract %uchar %4692 4
-OpStore %1283 %4693
-%4694 = OpLoad %uchar %1282
-%4695 = OpLoad %uchar %1283
-%4696 = OpIAdd %uchar %4694 %4695
-OpStore %1284 %4696
-%4697 = OpLoad %_arr_uchar_uint_16 %211
-%4698 = OpCompositeExtract %uchar %4697 5
-OpStore %1285 %4698
-%4699 = OpLoad %_arr_uchar_uint_16 %209
-%4700 = OpCompositeExtract %uchar %4699 5
-OpStore %1286 %4700
-%4701 = OpLoad %uchar %1285
-%4702 = OpLoad %uchar %1286
-%4703 = OpIAdd %uchar %4701 %4702
-OpStore %1287 %4703
-%4704 = OpLoad %_arr_uchar_uint_16 %211
-%4705 = OpCompositeExtract %uchar %4704 6
-OpStore %1288 %4705
-%4706 = OpLoad %_arr_uchar_uint_16 %209
-%4707 = OpCompositeExtract %uchar %4706 6
-OpStore %1289 %4707
-%4708 = OpLoad %uchar %1288
-%4709 = OpLoad %uchar %1289
-%4710 = OpIAdd %uchar %4708 %4709
-OpStore %1290 %4710
-%4711 = OpLoad %_arr_uchar_uint_16 %211
-%4712 = OpCompositeExtract %uchar %4711 7
-OpStore %1291 %4712
-%4713 = OpLoad %_arr_uchar_uint_16 %209
-%4714 = OpCompositeExtract %uchar %4713 7
-OpStore %1292 %4714
-%4715 = OpLoad %uchar %1291
-%4716 = OpLoad %uchar %1292
-%4717 = OpIAdd %uchar %4715 %4716
-OpStore %1293 %4717
-%4718 = OpLoad %_arr_uchar_uint_16 %211
-%4719 = OpCompositeExtract %uchar %4718 8
-OpStore %1294 %4719
-%4720 = OpLoad %_arr_uchar_uint_16 %209
-%4721 = OpCompositeExtract %uchar %4720 8
-OpStore %1295 %4721
-%4722 = OpLoad %uchar %1294
-%4723 = OpLoad %uchar %1295
-%4724 = OpIAdd %uchar %4722 %4723
-OpStore %1296 %4724
-%4725 = OpLoad %_arr_uchar_uint_16 %211
-%4726 = OpCompositeExtract %uchar %4725 9
-OpStore %1297 %4726
-%4727 = OpLoad %_arr_uchar_uint_16 %209
-%4728 = OpCompositeExtract %uchar %4727 9
-OpStore %1298 %4728
-%4729 = OpLoad %uchar %1297
-%4730 = OpLoad %uchar %1298
-%4731 = OpIAdd %uchar %4729 %4730
-OpStore %1299 %4731
-%4732 = OpLoad %_arr_uchar_uint_16 %211
-%4733 = OpCompositeExtract %uchar %4732 10
-OpStore %1300 %4733
-%4734 = OpLoad %_arr_uchar_uint_16 %209
-%4735 = OpCompositeExtract %uchar %4734 10
-OpStore %1301 %4735
-%4736 = OpLoad %uchar %1300
-%4737 = OpLoad %uchar %1301
-%4738 = OpIAdd %uchar %4736 %4737
-OpStore %1302 %4738
-%4739 = OpLoad %_arr_uchar_uint_16 %211
-%4740 = OpCompositeExtract %uchar %4739 11
-OpStore %1303 %4740
-%4741 = OpLoad %_arr_uchar_uint_16 %209
-%4742 = OpCompositeExtract %uchar %4741 11
-OpStore %1304 %4742
-%4743 = OpLoad %uchar %1303
-%4744 = OpLoad %uchar %1304
-%4745 = OpIAdd %uchar %4743 %4744
-OpStore %1305 %4745
-%4746 = OpLoad %_arr_uchar_uint_16 %211
-%4747 = OpCompositeExtract %uchar %4746 12
-OpStore %1306 %4747
-%4748 = OpLoad %_arr_uchar_uint_16 %209
-%4749 = OpCompositeExtract %uchar %4748 12
-OpStore %1307 %4749
-%4750 = OpLoad %uchar %1306
-%4751 = OpLoad %uchar %1307
-%4752 = OpIAdd %uchar %4750 %4751
-OpStore %1308 %4752
-%4753 = OpLoad %_arr_uchar_uint_16 %211
-%4754 = OpCompositeExtract %uchar %4753 13
-OpStore %1309 %4754
-%4755 = OpLoad %_arr_uchar_uint_16 %209
-%4756 = OpCompositeExtract %uchar %4755 13
-OpStore %1310 %4756
-%4757 = OpLoad %uchar %1309
-%4758 = OpLoad %uchar %1310
-%4759 = OpIAdd %uchar %4757 %4758
-OpStore %1311 %4759
-%4760 = OpLoad %_arr_uchar_uint_16 %211
-%4761 = OpCompositeExtract %uchar %4760 14
-OpStore %1312 %4761
-%4762 = OpLoad %_arr_uchar_uint_16 %209
-%4763 = OpCompositeExtract %uchar %4762 14
-OpStore %1313 %4763
-%4764 = OpLoad %uchar %1312
-%4765 = OpLoad %uchar %1313
-%4766 = OpIAdd %uchar %4764 %4765
-OpStore %1314 %4766
-%4767 = OpLoad %_arr_uchar_uint_16 %211
-%4768 = OpCompositeExtract %uchar %4767 15
-OpStore %1315 %4768
-%4769 = OpLoad %_arr_uchar_uint_16 %209
-%4770 = OpCompositeExtract %uchar %4769 15
-OpStore %1316 %4770
-%4771 = OpLoad %uchar %1315
-%4772 = OpLoad %uchar %1316
-%4773 = OpIAdd %uchar %4771 %4772
-OpStore %1317 %4773
-%4774 = OpLoad %_arr_uchar_uint_16 %211
-%4775 = OpLoad %uchar %1272
-%4776 = OpCompositeInsert %_arr_uchar_uint_16 %4775 %4774 0
-OpStore %1318 %4776
-%4777 = OpLoad %_arr_uchar_uint_16 %1318
-%4778 = OpLoad %uchar %1275
-%4779 = OpCompositeInsert %_arr_uchar_uint_16 %4778 %4777 1
-OpStore %1319 %4779
-%4780 = OpLoad %_arr_uchar_uint_16 %1319
-%4781 = OpLoad %uchar %1278
-%4782 = OpCompositeInsert %_arr_uchar_uint_16 %4781 %4780 2
-OpStore %1320 %4782
-%4783 = OpLoad %_arr_uchar_uint_16 %1320
-%4784 = OpLoad %uchar %1281
-%4785 = OpCompositeInsert %_arr_uchar_uint_16 %4784 %4783 3
-OpStore %1321 %4785
-%4786 = OpLoad %_arr_uchar_uint_16 %1321
-%4787 = OpLoad %uchar %1284
-%4788 = OpCompositeInsert %_arr_uchar_uint_16 %4787 %4786 4
-OpStore %1322 %4788
-%4789 = OpLoad %_arr_uchar_uint_16 %1322
-%4790 = OpLoad %uchar %1287
-%4791 = OpCompositeInsert %_arr_uchar_uint_16 %4790 %4789 5
-OpStore %1323 %4791
-%4792 = OpLoad %_arr_uchar_uint_16 %1323
-%4793 = OpLoad %uchar %1290
-%4794 = OpCompositeInsert %_arr_uchar_uint_16 %4793 %4792 6
-OpStore %1324 %4794
-%4795 = OpLoad %_arr_uchar_uint_16 %1324
-%4796 = OpLoad %uchar %1293
-%4797 = OpCompositeInsert %_arr_uchar_uint_16 %4796 %4795 7
-OpStore %1325 %4797
-%4798 = OpLoad %_arr_uchar_uint_16 %1325
-%4799 = OpLoad %uchar %1296
-%4800 = OpCompositeInsert %_arr_uchar_uint_16 %4799 %4798 8
-OpStore %1326 %4800
-%4801 = OpLoad %_arr_uchar_uint_16 %1326
-%4802 = OpLoad %uchar %1299
-%4803 = OpCompositeInsert %_arr_uchar_uint_16 %4802 %4801 9
-OpStore %1327 %4803
-%4804 = OpLoad %_arr_uchar_uint_16 %1327
-%4805 = OpLoad %uchar %1302
-%4806 = OpCompositeInsert %_arr_uchar_uint_16 %4805 %4804 10
-OpStore %1328 %4806
-%4807 = OpLoad %_arr_uchar_uint_16 %1328
-%4808 = OpLoad %uchar %1305
-%4809 = OpCompositeInsert %_arr_uchar_uint_16 %4808 %4807 11
-OpStore %1329 %4809
-%4810 = OpLoad %_arr_uchar_uint_16 %1329
-%4811 = OpLoad %uchar %1308
-%4812 = OpCompositeInsert %_arr_uchar_uint_16 %4811 %4810 12
-OpStore %1330 %4812
-%4813 = OpLoad %_arr_uchar_uint_16 %1330
-%4814 = OpLoad %uchar %1311
-%4815 = OpCompositeInsert %_arr_uchar_uint_16 %4814 %4813 13
-OpStore %1331 %4815
-%4816 = OpLoad %_arr_uchar_uint_16 %1331
-%4817 = OpLoad %uchar %1314
-%4818 = OpCompositeInsert %_arr_uchar_uint_16 %4817 %4816 14
-OpStore %1332 %4818
-%4819 = OpLoad %_arr_uchar_uint_16 %1332
-%4820 = OpLoad %uchar %1317
-%4821 = OpCompositeInsert %_arr_uchar_uint_16 %4820 %4819 15
-OpStore %1333 %4821
-%4822 = OpLoad %ulong %191
-%4823 = OpLoad %_arr_uchar_uint_16 %1333
-%4824 = OpFunctionCall %ulong %1 %4822 %4823
-OpStore %192 %4824
-%4825 = OpLoad %_arr_uchar_uint_16 %209
-%4826 = OpCompositeExtract %uchar %4825 0
-OpStore %1334 %4826
-%4827 = OpLoad %_arr_uchar_uint_16 %170
-%4828 = OpCompositeExtract %uchar %4827 0
-OpStore %1335 %4828
-%4829 = OpLoad %uchar %1334
-%4830 = OpLoad %uchar %1335
-%4831 = OpIAdd %uchar %4829 %4830
-OpStore %1336 %4831
-%4832 = OpLoad %_arr_uchar_uint_16 %209
-%4833 = OpCompositeExtract %uchar %4832 1
-OpStore %1337 %4833
-%4834 = OpLoad %_arr_uchar_uint_16 %170
-%4835 = OpCompositeExtract %uchar %4834 1
-OpStore %1338 %4835
-%4836 = OpLoad %uchar %1337
-%4837 = OpLoad %uchar %1338
-%4838 = OpIAdd %uchar %4836 %4837
-OpStore %1339 %4838
-%4839 = OpLoad %_arr_uchar_uint_16 %209
-%4840 = OpCompositeExtract %uchar %4839 2
-OpStore %1340 %4840
-%4841 = OpLoad %_arr_uchar_uint_16 %170
-%4842 = OpCompositeExtract %uchar %4841 2
-OpStore %1341 %4842
-%4843 = OpLoad %uchar %1340
-%4844 = OpLoad %uchar %1341
-%4845 = OpIAdd %uchar %4843 %4844
-OpStore %1342 %4845
-%4846 = OpLoad %_arr_uchar_uint_16 %209
-%4847 = OpCompositeExtract %uchar %4846 3
-OpStore %1343 %4847
-%4848 = OpLoad %_arr_uchar_uint_16 %170
-%4849 = OpCompositeExtract %uchar %4848 3
-OpStore %1344 %4849
-%4850 = OpLoad %uchar %1343
-%4851 = OpLoad %uchar %1344
-%4852 = OpIAdd %uchar %4850 %4851
-OpStore %1345 %4852
-%4853 = OpLoad %_arr_uchar_uint_16 %209
-%4854 = OpCompositeExtract %uchar %4853 4
-OpStore %1346 %4854
-%4855 = OpLoad %_arr_uchar_uint_16 %170
-%4856 = OpCompositeExtract %uchar %4855 4
-OpStore %1347 %4856
-%4857 = OpLoad %uchar %1346
-%4858 = OpLoad %uchar %1347
-%4859 = OpIAdd %uchar %4857 %4858
-OpStore %1348 %4859
-%4860 = OpLoad %_arr_uchar_uint_16 %209
-%4861 = OpCompositeExtract %uchar %4860 5
-OpStore %1349 %4861
-%4862 = OpLoad %_arr_uchar_uint_16 %170
-%4863 = OpCompositeExtract %uchar %4862 5
-OpStore %1350 %4863
-%4864 = OpLoad %uchar %1349
-%4865 = OpLoad %uchar %1350
-%4866 = OpIAdd %uchar %4864 %4865
-OpStore %1351 %4866
-%4867 = OpLoad %_arr_uchar_uint_16 %209
-%4868 = OpCompositeExtract %uchar %4867 6
-OpStore %1352 %4868
-%4869 = OpLoad %_arr_uchar_uint_16 %170
-%4870 = OpCompositeExtract %uchar %4869 6
-OpStore %1353 %4870
-%4871 = OpLoad %uchar %1352
-%4872 = OpLoad %uchar %1353
-%4873 = OpIAdd %uchar %4871 %4872
-OpStore %1354 %4873
-%4874 = OpLoad %_arr_uchar_uint_16 %209
-%4875 = OpCompositeExtract %uchar %4874 7
-OpStore %1355 %4875
-%4876 = OpLoad %_arr_uchar_uint_16 %170
-%4877 = OpCompositeExtract %uchar %4876 7
-OpStore %1356 %4877
-%4878 = OpLoad %uchar %1355
-%4879 = OpLoad %uchar %1356
-%4880 = OpIAdd %uchar %4878 %4879
-OpStore %1357 %4880
-%4881 = OpLoad %_arr_uchar_uint_16 %209
-%4882 = OpCompositeExtract %uchar %4881 8
-OpStore %1358 %4882
-%4883 = OpLoad %_arr_uchar_uint_16 %170
-%4884 = OpCompositeExtract %uchar %4883 8
-OpStore %1359 %4884
-%4885 = OpLoad %uchar %1358
-%4886 = OpLoad %uchar %1359
-%4887 = OpIAdd %uchar %4885 %4886
-OpStore %1360 %4887
-%4888 = OpLoad %_arr_uchar_uint_16 %209
-%4889 = OpCompositeExtract %uchar %4888 9
-OpStore %1361 %4889
-%4890 = OpLoad %_arr_uchar_uint_16 %170
-%4891 = OpCompositeExtract %uchar %4890 9
-OpStore %1362 %4891
-%4892 = OpLoad %uchar %1361
-%4893 = OpLoad %uchar %1362
-%4894 = OpIAdd %uchar %4892 %4893
-OpStore %1363 %4894
-%4895 = OpLoad %_arr_uchar_uint_16 %209
-%4896 = OpCompositeExtract %uchar %4895 10
-OpStore %1364 %4896
-%4897 = OpLoad %_arr_uchar_uint_16 %170
-%4898 = OpCompositeExtract %uchar %4897 10
-OpStore %1365 %4898
-%4899 = OpLoad %uchar %1364
-%4900 = OpLoad %uchar %1365
-%4901 = OpIAdd %uchar %4899 %4900
-OpStore %1366 %4901
-%4902 = OpLoad %_arr_uchar_uint_16 %209
-%4903 = OpCompositeExtract %uchar %4902 11
-OpStore %1367 %4903
-%4904 = OpLoad %_arr_uchar_uint_16 %170
-%4905 = OpCompositeExtract %uchar %4904 11
-OpStore %1368 %4905
-%4906 = OpLoad %uchar %1367
-%4907 = OpLoad %uchar %1368
-%4908 = OpIAdd %uchar %4906 %4907
-OpStore %1369 %4908
-%4909 = OpLoad %_arr_uchar_uint_16 %209
-%4910 = OpCompositeExtract %uchar %4909 12
-OpStore %1370 %4910
-%4911 = OpLoad %_arr_uchar_uint_16 %170
-%4912 = OpCompositeExtract %uchar %4911 12
-OpStore %1371 %4912
-%4913 = OpLoad %uchar %1370
-%4914 = OpLoad %uchar %1371
-%4915 = OpIAdd %uchar %4913 %4914
-OpStore %1372 %4915
-%4916 = OpLoad %_arr_uchar_uint_16 %209
-%4917 = OpCompositeExtract %uchar %4916 13
-OpStore %1373 %4917
-%4918 = OpLoad %_arr_uchar_uint_16 %170
-%4919 = OpCompositeExtract %uchar %4918 13
-OpStore %1374 %4919
-%4920 = OpLoad %uchar %1373
-%4921 = OpLoad %uchar %1374
-%4922 = OpIAdd %uchar %4920 %4921
-OpStore %1375 %4922
-%4923 = OpLoad %_arr_uchar_uint_16 %209
-%4924 = OpCompositeExtract %uchar %4923 14
-OpStore %1376 %4924
-%4925 = OpLoad %_arr_uchar_uint_16 %170
-%4926 = OpCompositeExtract %uchar %4925 14
-OpStore %1377 %4926
-%4927 = OpLoad %uchar %1376
-%4928 = OpLoad %uchar %1377
-%4929 = OpIAdd %uchar %4927 %4928
-OpStore %1378 %4929
-%4930 = OpLoad %_arr_uchar_uint_16 %209
-%4931 = OpCompositeExtract %uchar %4930 15
-OpStore %1379 %4931
-%4932 = OpLoad %_arr_uchar_uint_16 %170
-%4933 = OpCompositeExtract %uchar %4932 15
-OpStore %1380 %4933
-%4934 = OpLoad %uchar %1379
-%4935 = OpLoad %uchar %1380
-%4936 = OpIAdd %uchar %4934 %4935
-OpStore %1381 %4936
-%4937 = OpLoad %_arr_uchar_uint_16 %209
-%4938 = OpLoad %uchar %1336
-%4939 = OpCompositeInsert %_arr_uchar_uint_16 %4938 %4937 0
-OpStore %1382 %4939
-%4940 = OpLoad %_arr_uchar_uint_16 %1382
-%4941 = OpLoad %uchar %1339
-%4942 = OpCompositeInsert %_arr_uchar_uint_16 %4941 %4940 1
-OpStore %1383 %4942
-%4943 = OpLoad %_arr_uchar_uint_16 %1383
-%4944 = OpLoad %uchar %1342
-%4945 = OpCompositeInsert %_arr_uchar_uint_16 %4944 %4943 2
-OpStore %1384 %4945
-%4946 = OpLoad %_arr_uchar_uint_16 %1384
-%4947 = OpLoad %uchar %1345
-%4948 = OpCompositeInsert %_arr_uchar_uint_16 %4947 %4946 3
-OpStore %1385 %4948
-%4949 = OpLoad %_arr_uchar_uint_16 %1385
-%4950 = OpLoad %uchar %1348
-%4951 = OpCompositeInsert %_arr_uchar_uint_16 %4950 %4949 4
-OpStore %1386 %4951
-%4952 = OpLoad %_arr_uchar_uint_16 %1386
-%4953 = OpLoad %uchar %1351
-%4954 = OpCompositeInsert %_arr_uchar_uint_16 %4953 %4952 5
-OpStore %1387 %4954
-%4955 = OpLoad %_arr_uchar_uint_16 %1387
-%4956 = OpLoad %uchar %1354
-%4957 = OpCompositeInsert %_arr_uchar_uint_16 %4956 %4955 6
-OpStore %1388 %4957
-%4958 = OpLoad %_arr_uchar_uint_16 %1388
-%4959 = OpLoad %uchar %1357
-%4960 = OpCompositeInsert %_arr_uchar_uint_16 %4959 %4958 7
-OpStore %1389 %4960
-%4961 = OpLoad %_arr_uchar_uint_16 %1389
-%4962 = OpLoad %uchar %1360
-%4963 = OpCompositeInsert %_arr_uchar_uint_16 %4962 %4961 8
-OpStore %1390 %4963
-%4964 = OpLoad %_arr_uchar_uint_16 %1390
-%4965 = OpLoad %uchar %1363
-%4966 = OpCompositeInsert %_arr_uchar_uint_16 %4965 %4964 9
-OpStore %1391 %4966
-%4967 = OpLoad %_arr_uchar_uint_16 %1391
-%4968 = OpLoad %uchar %1366
-%4969 = OpCompositeInsert %_arr_uchar_uint_16 %4968 %4967 10
-OpStore %1392 %4969
-%4970 = OpLoad %_arr_uchar_uint_16 %1392
-%4971 = OpLoad %uchar %1369
-%4972 = OpCompositeInsert %_arr_uchar_uint_16 %4971 %4970 11
-OpStore %1393 %4972
-%4973 = OpLoad %_arr_uchar_uint_16 %1393
-%4974 = OpLoad %uchar %1372
-%4975 = OpCompositeInsert %_arr_uchar_uint_16 %4974 %4973 12
-OpStore %1394 %4975
-%4976 = OpLoad %_arr_uchar_uint_16 %1394
-%4977 = OpLoad %uchar %1375
-%4978 = OpCompositeInsert %_arr_uchar_uint_16 %4977 %4976 13
-OpStore %1395 %4978
-%4979 = OpLoad %_arr_uchar_uint_16 %1395
-%4980 = OpLoad %uchar %1378
-%4981 = OpCompositeInsert %_arr_uchar_uint_16 %4980 %4979 14
-OpStore %1396 %4981
-%4982 = OpLoad %_arr_uchar_uint_16 %1396
-%4983 = OpLoad %uchar %1381
-%4984 = OpCompositeInsert %_arr_uchar_uint_16 %4983 %4982 15
-OpStore %1397 %4984
-%4985 = OpLoad %ulong %192
-%4986 = OpLoad %_arr_uchar_uint_16 %1397
-%4987 = OpFunctionCall %ulong %1 %4985 %4986
-OpStore %193 %4987
-%4988 = OpLoad %ulong %212
-%4989 = OpIAdd %ulong %4988 %ulong_1
-OpStore %194 %4989
-%4990 = OpLoad %ulong %193
-OpStore %208 %4990
-%4991 = OpLoad %_arr_uchar_uint_16 %1397
-OpStore %209 %4991
-%4992 = OpLoad %_arr_uchar_uint_16 %1269
-OpStore %210 %4992
-%4993 = OpLoad %_arr_uchar_uint_16 %1333
-OpStore %211 %4993
-%4994 = OpLoad %ulong %194
-OpStore %212 %4994
-OpBranch %143
-%142 = OpLabel
-OpBranch %139
-%143 = OpLabel
-OpBranch %136
+%1510 = OpVariable %_ptr_Function_uchar Function
+%1511 = OpVariable %_ptr_Function_uchar Function
+%1512 = OpVariable %_ptr_Function_uchar Function
+%1513 = OpVariable %_ptr_Function_uchar Function
+%1514 = OpVariable %_ptr_Function_uchar Function
+%1515 = OpVariable %_ptr_Function_uchar Function
+%1516 = OpVariable %_ptr_Function_uchar Function
+%1517 = OpVariable %_ptr_Function_uchar Function
+%1518 = OpVariable %_ptr_Function_uchar Function
+%1519 = OpVariable %_ptr_Function_uchar Function
+%1520 = OpVariable %_ptr_Function_uchar Function
+%1521 = OpVariable %_ptr_Function_uchar Function
+%1522 = OpVariable %_ptr_Function_uchar Function
+%1523 = OpVariable %_ptr_Function_uchar Function
+%1524 = OpVariable %_ptr_Function_uchar Function
+%1525 = OpVariable %_ptr_Function_uchar Function
+%1526 = OpVariable %_ptr_Function_uchar Function
+%1527 = OpVariable %_ptr_Function_uchar Function
+%1528 = OpVariable %_ptr_Function_uchar Function
+%1529 = OpVariable %_ptr_Function_uchar Function
+%1530 = OpVariable %_ptr_Function_uchar Function
+%1531 = OpVariable %_ptr_Function_uchar Function
+%1532 = OpVariable %_ptr_Function_uchar Function
+%1533 = OpVariable %_ptr_Function_uchar Function
+%1534 = OpVariable %_ptr_Function_uchar Function
+%1535 = OpVariable %_ptr_Function_uchar Function
+%1536 = OpVariable %_ptr_Function_uchar Function
+%1537 = OpVariable %_ptr_Function_uchar Function
+%1538 = OpVariable %_ptr_Function_uchar Function
+%1539 = OpVariable %_ptr_Function_uchar Function
+%1540 = OpVariable %_ptr_Function_uchar Function
+%1541 = OpVariable %_ptr_Function_uchar Function
+%1542 = OpVariable %_ptr_Function_uchar Function
+%1543 = OpVariable %_ptr_Function_uchar Function
+%1544 = OpVariable %_ptr_Function_uchar Function
+%1545 = OpVariable %_ptr_Function_uchar Function
+%1546 = OpVariable %_ptr_Function_uchar Function
+%1547 = OpVariable %_ptr_Function_uchar Function
+%1548 = OpVariable %_ptr_Function_uchar Function
+%1549 = OpVariable %_ptr_Function_uchar Function
+%1550 = OpVariable %_ptr_Function_uchar Function
+%1551 = OpVariable %_ptr_Function_uchar Function
+%1552 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1553 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1554 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1555 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1556 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1557 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1558 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1559 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1560 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1561 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1562 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1563 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1564 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1565 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1566 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1567 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1568 = OpVariable %_ptr_Function_uchar Function
+%1569 = OpVariable %_ptr_Function_uchar Function
+%1570 = OpVariable %_ptr_Function_uchar Function
+%1571 = OpVariable %_ptr_Function_uchar Function
+%1572 = OpVariable %_ptr_Function_uchar Function
+%1573 = OpVariable %_ptr_Function_uchar Function
+%1574 = OpVariable %_ptr_Function_uchar Function
+%1575 = OpVariable %_ptr_Function_uchar Function
+%1576 = OpVariable %_ptr_Function_uchar Function
+%1577 = OpVariable %_ptr_Function_uchar Function
+%1578 = OpVariable %_ptr_Function_uchar Function
+%1579 = OpVariable %_ptr_Function_uchar Function
+%1580 = OpVariable %_ptr_Function_uchar Function
+%1581 = OpVariable %_ptr_Function_uchar Function
+%1582 = OpVariable %_ptr_Function_uchar Function
+%1583 = OpVariable %_ptr_Function_uchar Function
+%1584 = OpVariable %_ptr_Function_uchar Function
+%1585 = OpVariable %_ptr_Function_uchar Function
+%1586 = OpVariable %_ptr_Function_uchar Function
+%1587 = OpVariable %_ptr_Function_uchar Function
+%1588 = OpVariable %_ptr_Function_uchar Function
+%1589 = OpVariable %_ptr_Function_uchar Function
+%1590 = OpVariable %_ptr_Function_uchar Function
+%1591 = OpVariable %_ptr_Function_uchar Function
+%1592 = OpVariable %_ptr_Function_uchar Function
+%1593 = OpVariable %_ptr_Function_uchar Function
+%1594 = OpVariable %_ptr_Function_uchar Function
+%1595 = OpVariable %_ptr_Function_uchar Function
+%1596 = OpVariable %_ptr_Function_uchar Function
+%1597 = OpVariable %_ptr_Function_uchar Function
+%1598 = OpVariable %_ptr_Function_uchar Function
+%1599 = OpVariable %_ptr_Function_uchar Function
+%1600 = OpVariable %_ptr_Function_uchar Function
+%1601 = OpVariable %_ptr_Function_uchar Function
+%1602 = OpVariable %_ptr_Function_uchar Function
+%1603 = OpVariable %_ptr_Function_uchar Function
+%1604 = OpVariable %_ptr_Function_uchar Function
+%1605 = OpVariable %_ptr_Function_uchar Function
+%1606 = OpVariable %_ptr_Function_uchar Function
+%1607 = OpVariable %_ptr_Function_uchar Function
+%1608 = OpVariable %_ptr_Function_uchar Function
+%1609 = OpVariable %_ptr_Function_uchar Function
+%1610 = OpVariable %_ptr_Function_uchar Function
+%1611 = OpVariable %_ptr_Function_uchar Function
+%1612 = OpVariable %_ptr_Function_uchar Function
+%1613 = OpVariable %_ptr_Function_uchar Function
+%1614 = OpVariable %_ptr_Function_uchar Function
+%1615 = OpVariable %_ptr_Function_uchar Function
+%1616 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1617 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1618 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1619 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1620 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1621 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1622 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1623 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1624 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1625 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1626 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1627 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1628 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1629 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1630 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1631 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1632 = OpVariable %_ptr_Function_uchar Function
+%1633 = OpVariable %_ptr_Function_uchar Function
+%1634 = OpVariable %_ptr_Function_uchar Function
+%1635 = OpVariable %_ptr_Function_uchar Function
+%1636 = OpVariable %_ptr_Function_uchar Function
+%1637 = OpVariable %_ptr_Function_uchar Function
+%1638 = OpVariable %_ptr_Function_uchar Function
+%1639 = OpVariable %_ptr_Function_uchar Function
+%1640 = OpVariable %_ptr_Function_uchar Function
+%1641 = OpVariable %_ptr_Function_uchar Function
+%1642 = OpVariable %_ptr_Function_uchar Function
+%1643 = OpVariable %_ptr_Function_uchar Function
+%1644 = OpVariable %_ptr_Function_uchar Function
+%1645 = OpVariable %_ptr_Function_uchar Function
+%1646 = OpVariable %_ptr_Function_uchar Function
+%1647 = OpVariable %_ptr_Function_uchar Function
+%1648 = OpVariable %_ptr_Function_uchar Function
+%1649 = OpVariable %_ptr_Function_uchar Function
+%1650 = OpVariable %_ptr_Function_uchar Function
+%1651 = OpVariable %_ptr_Function_uchar Function
+%1652 = OpVariable %_ptr_Function_uchar Function
+%1653 = OpVariable %_ptr_Function_uchar Function
+%1654 = OpVariable %_ptr_Function_uchar Function
+%1655 = OpVariable %_ptr_Function_uchar Function
+%1656 = OpVariable %_ptr_Function_uchar Function
+%1657 = OpVariable %_ptr_Function_uchar Function
+%1658 = OpVariable %_ptr_Function_uchar Function
+%1659 = OpVariable %_ptr_Function_uchar Function
+%1660 = OpVariable %_ptr_Function_uchar Function
+%1661 = OpVariable %_ptr_Function_uchar Function
+%1662 = OpVariable %_ptr_Function_uchar Function
+%1663 = OpVariable %_ptr_Function_uchar Function
+%1664 = OpVariable %_ptr_Function_uchar Function
+%1665 = OpVariable %_ptr_Function_uchar Function
+%1666 = OpVariable %_ptr_Function_uchar Function
+%1667 = OpVariable %_ptr_Function_uchar Function
+%1668 = OpVariable %_ptr_Function_uchar Function
+%1669 = OpVariable %_ptr_Function_uchar Function
+%1670 = OpVariable %_ptr_Function_uchar Function
+%1671 = OpVariable %_ptr_Function_uchar Function
+%1672 = OpVariable %_ptr_Function_uchar Function
+%1673 = OpVariable %_ptr_Function_uchar Function
+%1674 = OpVariable %_ptr_Function_uchar Function
+%1675 = OpVariable %_ptr_Function_uchar Function
+%1676 = OpVariable %_ptr_Function_uchar Function
+%1677 = OpVariable %_ptr_Function_uchar Function
+%1678 = OpVariable %_ptr_Function_uchar Function
+%1679 = OpVariable %_ptr_Function_uchar Function
+%1680 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1681 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1682 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1683 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1684 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1685 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1686 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1687 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1688 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1689 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1690 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1691 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1692 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1693 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1694 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1695 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1696 = OpVariable %_ptr_Function_uchar Function
+%1697 = OpVariable %_ptr_Function_uchar Function
+%1698 = OpVariable %_ptr_Function_uchar Function
+%1699 = OpVariable %_ptr_Function_uchar Function
+%1700 = OpVariable %_ptr_Function_uchar Function
+%1701 = OpVariable %_ptr_Function_uchar Function
+%1702 = OpVariable %_ptr_Function_uchar Function
+%1703 = OpVariable %_ptr_Function_uchar Function
+%1704 = OpVariable %_ptr_Function_uchar Function
+%1705 = OpVariable %_ptr_Function_uchar Function
+%1706 = OpVariable %_ptr_Function_uchar Function
+%1707 = OpVariable %_ptr_Function_uchar Function
+%1708 = OpVariable %_ptr_Function_uchar Function
+%1709 = OpVariable %_ptr_Function_uchar Function
+%1710 = OpVariable %_ptr_Function_uchar Function
+%1711 = OpVariable %_ptr_Function_uchar Function
+%1712 = OpVariable %_ptr_Function_uchar Function
+%1713 = OpVariable %_ptr_Function_uchar Function
+%1714 = OpVariable %_ptr_Function_uchar Function
+%1715 = OpVariable %_ptr_Function_uchar Function
+%1716 = OpVariable %_ptr_Function_uchar Function
+%1717 = OpVariable %_ptr_Function_uchar Function
+%1718 = OpVariable %_ptr_Function_uchar Function
+%1719 = OpVariable %_ptr_Function_uchar Function
+%1720 = OpVariable %_ptr_Function_uchar Function
+%1721 = OpVariable %_ptr_Function_uchar Function
+%1722 = OpVariable %_ptr_Function_uchar Function
+%1723 = OpVariable %_ptr_Function_uchar Function
+%1724 = OpVariable %_ptr_Function_uchar Function
+%1725 = OpVariable %_ptr_Function_uchar Function
+%1726 = OpVariable %_ptr_Function_uchar Function
+%1727 = OpVariable %_ptr_Function_uchar Function
+%1728 = OpVariable %_ptr_Function_uchar Function
+%1729 = OpVariable %_ptr_Function_uchar Function
+%1730 = OpVariable %_ptr_Function_uchar Function
+%1731 = OpVariable %_ptr_Function_uchar Function
+%1732 = OpVariable %_ptr_Function_uchar Function
+%1733 = OpVariable %_ptr_Function_uchar Function
+%1734 = OpVariable %_ptr_Function_uchar Function
+%1735 = OpVariable %_ptr_Function_uchar Function
+%1736 = OpVariable %_ptr_Function_uchar Function
+%1737 = OpVariable %_ptr_Function_uchar Function
+%1738 = OpVariable %_ptr_Function_uchar Function
+%1739 = OpVariable %_ptr_Function_uchar Function
+%1740 = OpVariable %_ptr_Function_uchar Function
+%1741 = OpVariable %_ptr_Function_uchar Function
+%1742 = OpVariable %_ptr_Function_uchar Function
+%1743 = OpVariable %_ptr_Function_uchar Function
+%1744 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1745 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1746 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1747 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1748 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1749 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1750 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1751 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1752 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1753 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1754 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1755 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1756 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1757 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1758 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1759 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1760 = OpVariable %_ptr_Function_uchar Function
+%1761 = OpVariable %_ptr_Function_uchar Function
+%1762 = OpVariable %_ptr_Function_uchar Function
+%1763 = OpVariable %_ptr_Function_uchar Function
+%1764 = OpVariable %_ptr_Function_uchar Function
+%1765 = OpVariable %_ptr_Function_uchar Function
+%1766 = OpVariable %_ptr_Function_uchar Function
+%1767 = OpVariable %_ptr_Function_uchar Function
+%1768 = OpVariable %_ptr_Function_uchar Function
+%1769 = OpVariable %_ptr_Function_uchar Function
+%1770 = OpVariable %_ptr_Function_uchar Function
+%1771 = OpVariable %_ptr_Function_uchar Function
+%1772 = OpVariable %_ptr_Function_uchar Function
+%1773 = OpVariable %_ptr_Function_uchar Function
+%1774 = OpVariable %_ptr_Function_uchar Function
+%1775 = OpVariable %_ptr_Function_uchar Function
+%1776 = OpVariable %_ptr_Function_uchar Function
+%1777 = OpVariable %_ptr_Function_uchar Function
+%1778 = OpVariable %_ptr_Function_uchar Function
+%1779 = OpVariable %_ptr_Function_uchar Function
+%1780 = OpVariable %_ptr_Function_uchar Function
+%1781 = OpVariable %_ptr_Function_uchar Function
+%1782 = OpVariable %_ptr_Function_uchar Function
+%1783 = OpVariable %_ptr_Function_uchar Function
+%1784 = OpVariable %_ptr_Function_uchar Function
+%1785 = OpVariable %_ptr_Function_uchar Function
+%1786 = OpVariable %_ptr_Function_uchar Function
+%1787 = OpVariable %_ptr_Function_uchar Function
+%1788 = OpVariable %_ptr_Function_uchar Function
+%1789 = OpVariable %_ptr_Function_uchar Function
+%1790 = OpVariable %_ptr_Function_uchar Function
+%1791 = OpVariable %_ptr_Function_uchar Function
+%1792 = OpVariable %_ptr_Function_uchar Function
+%1793 = OpVariable %_ptr_Function_uchar Function
+%1794 = OpVariable %_ptr_Function_uchar Function
+%1795 = OpVariable %_ptr_Function_uchar Function
+%1796 = OpVariable %_ptr_Function_uchar Function
+%1797 = OpVariable %_ptr_Function_uchar Function
+%1798 = OpVariable %_ptr_Function_uchar Function
+%1799 = OpVariable %_ptr_Function_uchar Function
+%1800 = OpVariable %_ptr_Function_uchar Function
+%1801 = OpVariable %_ptr_Function_uchar Function
+%1802 = OpVariable %_ptr_Function_uchar Function
+%1803 = OpVariable %_ptr_Function_uchar Function
+%1804 = OpVariable %_ptr_Function_uchar Function
+%1805 = OpVariable %_ptr_Function_uchar Function
+%1806 = OpVariable %_ptr_Function_uchar Function
+%1807 = OpVariable %_ptr_Function_uchar Function
+%1808 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1809 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1810 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1811 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1812 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1813 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1814 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1815 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1816 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1817 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1818 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1819 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1820 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1821 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1822 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1823 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1824 = OpVariable %_ptr_Function_uchar Function
+%1825 = OpVariable %_ptr_Function_uchar Function
+%1826 = OpVariable %_ptr_Function_uchar Function
+%1827 = OpVariable %_ptr_Function_uchar Function
+%1828 = OpVariable %_ptr_Function_uchar Function
+%1829 = OpVariable %_ptr_Function_uchar Function
+%1830 = OpVariable %_ptr_Function_uchar Function
+%1831 = OpVariable %_ptr_Function_uchar Function
+%1832 = OpVariable %_ptr_Function_uchar Function
+%1833 = OpVariable %_ptr_Function_uchar Function
+%1834 = OpVariable %_ptr_Function_uchar Function
+%1835 = OpVariable %_ptr_Function_uchar Function
+%1836 = OpVariable %_ptr_Function_uchar Function
+%1837 = OpVariable %_ptr_Function_uchar Function
+%1838 = OpVariable %_ptr_Function_uchar Function
+%1839 = OpVariable %_ptr_Function_uchar Function
+%1840 = OpVariable %_ptr_Function_uchar Function
+%1841 = OpVariable %_ptr_Function_uchar Function
+%1842 = OpVariable %_ptr_Function_uchar Function
+%1843 = OpVariable %_ptr_Function_uchar Function
+%1844 = OpVariable %_ptr_Function_uchar Function
+%1845 = OpVariable %_ptr_Function_uchar Function
+%1846 = OpVariable %_ptr_Function_uchar Function
+%1847 = OpVariable %_ptr_Function_uchar Function
+%1848 = OpVariable %_ptr_Function_uchar Function
+%1849 = OpVariable %_ptr_Function_uchar Function
+%1850 = OpVariable %_ptr_Function_uchar Function
+%1851 = OpVariable %_ptr_Function_uchar Function
+%1852 = OpVariable %_ptr_Function_uchar Function
+%1853 = OpVariable %_ptr_Function_uchar Function
+%1854 = OpVariable %_ptr_Function_uchar Function
+%1855 = OpVariable %_ptr_Function_uchar Function
+%1856 = OpVariable %_ptr_Function_uchar Function
+%1857 = OpVariable %_ptr_Function_uchar Function
+%1858 = OpVariable %_ptr_Function_uchar Function
+%1859 = OpVariable %_ptr_Function_uchar Function
+%1860 = OpVariable %_ptr_Function_uchar Function
+%1861 = OpVariable %_ptr_Function_uchar Function
+%1862 = OpVariable %_ptr_Function_uchar Function
+%1863 = OpVariable %_ptr_Function_uchar Function
+%1864 = OpVariable %_ptr_Function_uchar Function
+%1865 = OpVariable %_ptr_Function_uchar Function
+%1866 = OpVariable %_ptr_Function_uchar Function
+%1867 = OpVariable %_ptr_Function_uchar Function
+%1868 = OpVariable %_ptr_Function_uchar Function
+%1869 = OpVariable %_ptr_Function_uchar Function
+%1870 = OpVariable %_ptr_Function_uchar Function
+%1871 = OpVariable %_ptr_Function_uchar Function
+%1872 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1873 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1874 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1875 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1876 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1877 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1878 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1879 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1880 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1881 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1882 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1883 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1884 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1885 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1886 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1887 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1888 = OpVariable %_ptr_Function_uchar Function
+%1889 = OpVariable %_ptr_Function_uchar Function
+%1890 = OpVariable %_ptr_Function_uchar Function
+%1891 = OpVariable %_ptr_Function_uchar Function
+%1892 = OpVariable %_ptr_Function_uchar Function
+%1893 = OpVariable %_ptr_Function_uchar Function
+%1894 = OpVariable %_ptr_Function_uchar Function
+%1895 = OpVariable %_ptr_Function_uchar Function
+%1896 = OpVariable %_ptr_Function_uchar Function
+%1897 = OpVariable %_ptr_Function_uchar Function
+%1898 = OpVariable %_ptr_Function_uchar Function
+%1899 = OpVariable %_ptr_Function_uchar Function
+%1900 = OpVariable %_ptr_Function_uchar Function
+%1901 = OpVariable %_ptr_Function_uchar Function
+%1902 = OpVariable %_ptr_Function_uchar Function
+%1903 = OpVariable %_ptr_Function_uchar Function
+%1904 = OpVariable %_ptr_Function_uchar Function
+%1905 = OpVariable %_ptr_Function_uchar Function
+%1906 = OpVariable %_ptr_Function_uchar Function
+%1907 = OpVariable %_ptr_Function_uchar Function
+%1908 = OpVariable %_ptr_Function_uchar Function
+%1909 = OpVariable %_ptr_Function_uchar Function
+%1910 = OpVariable %_ptr_Function_uchar Function
+%1911 = OpVariable %_ptr_Function_uchar Function
+%1912 = OpVariable %_ptr_Function_uchar Function
+%1913 = OpVariable %_ptr_Function_uchar Function
+%1914 = OpVariable %_ptr_Function_uchar Function
+%1915 = OpVariable %_ptr_Function_uchar Function
+%1916 = OpVariable %_ptr_Function_uchar Function
+%1917 = OpVariable %_ptr_Function_uchar Function
+%1918 = OpVariable %_ptr_Function_uchar Function
+%1919 = OpVariable %_ptr_Function_uchar Function
+%1920 = OpVariable %_ptr_Function_uchar Function
+%1921 = OpVariable %_ptr_Function_uchar Function
+%1922 = OpVariable %_ptr_Function_uchar Function
+%1923 = OpVariable %_ptr_Function_uchar Function
+%1924 = OpVariable %_ptr_Function_uchar Function
+%1925 = OpVariable %_ptr_Function_uchar Function
+%1926 = OpVariable %_ptr_Function_uchar Function
+%1927 = OpVariable %_ptr_Function_uchar Function
+%1928 = OpVariable %_ptr_Function_uchar Function
+%1929 = OpVariable %_ptr_Function_uchar Function
+%1930 = OpVariable %_ptr_Function_uchar Function
+%1931 = OpVariable %_ptr_Function_uchar Function
+%1932 = OpVariable %_ptr_Function_uchar Function
+%1933 = OpVariable %_ptr_Function_uchar Function
+%1934 = OpVariable %_ptr_Function_uchar Function
+%1935 = OpVariable %_ptr_Function_uchar Function
+%1936 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1937 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1938 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1939 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1940 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1941 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1942 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1943 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1944 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1945 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1946 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1947 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1948 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1949 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1950 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1951 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1952 = OpVariable %_ptr_Function_uchar Function
+%1953 = OpVariable %_ptr_Function_uchar Function
+%1954 = OpVariable %_ptr_Function_uchar Function
+%1955 = OpVariable %_ptr_Function_uchar Function
+%1956 = OpVariable %_ptr_Function_uchar Function
+%1957 = OpVariable %_ptr_Function_uchar Function
+%1958 = OpVariable %_ptr_Function_uchar Function
+%1959 = OpVariable %_ptr_Function_uchar Function
+%1960 = OpVariable %_ptr_Function_uchar Function
+%1961 = OpVariable %_ptr_Function_uchar Function
+%1962 = OpVariable %_ptr_Function_uchar Function
+%1963 = OpVariable %_ptr_Function_uchar Function
+%1964 = OpVariable %_ptr_Function_uchar Function
+%1965 = OpVariable %_ptr_Function_uchar Function
+%1966 = OpVariable %_ptr_Function_uchar Function
+%1967 = OpVariable %_ptr_Function_uchar Function
+%1968 = OpVariable %_ptr_Function_uchar Function
+%1969 = OpVariable %_ptr_Function_uchar Function
+%1970 = OpVariable %_ptr_Function_uchar Function
+%1971 = OpVariable %_ptr_Function_uchar Function
+%1972 = OpVariable %_ptr_Function_uchar Function
+%1973 = OpVariable %_ptr_Function_uchar Function
+%1974 = OpVariable %_ptr_Function_uchar Function
+%1975 = OpVariable %_ptr_Function_uchar Function
+%1976 = OpVariable %_ptr_Function_uchar Function
+%1977 = OpVariable %_ptr_Function_uchar Function
+%1978 = OpVariable %_ptr_Function_uchar Function
+%1979 = OpVariable %_ptr_Function_uchar Function
+%1980 = OpVariable %_ptr_Function_uchar Function
+%1981 = OpVariable %_ptr_Function_uchar Function
+%1982 = OpVariable %_ptr_Function_uchar Function
+%1983 = OpVariable %_ptr_Function_uchar Function
+%1984 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1985 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1986 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1987 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1988 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1989 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1990 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1991 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1992 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1993 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1994 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1995 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1996 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1997 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1998 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%1999 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2000 = OpVariable %_ptr_Function_uchar Function
+%2001 = OpVariable %_ptr_Function_uchar Function
+%2002 = OpVariable %_ptr_Function_uchar Function
+%2003 = OpVariable %_ptr_Function_uchar Function
+%2004 = OpVariable %_ptr_Function_uchar Function
+%2005 = OpVariable %_ptr_Function_uchar Function
+%2006 = OpVariable %_ptr_Function_uchar Function
+%2007 = OpVariable %_ptr_Function_uchar Function
+%2008 = OpVariable %_ptr_Function_uchar Function
+%2009 = OpVariable %_ptr_Function_uchar Function
+%2010 = OpVariable %_ptr_Function_uchar Function
+%2011 = OpVariable %_ptr_Function_uchar Function
+%2012 = OpVariable %_ptr_Function_uchar Function
+%2013 = OpVariable %_ptr_Function_uchar Function
+%2014 = OpVariable %_ptr_Function_uchar Function
+%2015 = OpVariable %_ptr_Function_uchar Function
+%2016 = OpVariable %_ptr_Function_uchar Function
+%2017 = OpVariable %_ptr_Function_uchar Function
+%2018 = OpVariable %_ptr_Function_uchar Function
+%2019 = OpVariable %_ptr_Function_uchar Function
+%2020 = OpVariable %_ptr_Function_uchar Function
+%2021 = OpVariable %_ptr_Function_uchar Function
+%2022 = OpVariable %_ptr_Function_uchar Function
+%2023 = OpVariable %_ptr_Function_uchar Function
+%2024 = OpVariable %_ptr_Function_uchar Function
+%2025 = OpVariable %_ptr_Function_uchar Function
+%2026 = OpVariable %_ptr_Function_uchar Function
+%2027 = OpVariable %_ptr_Function_uchar Function
+%2028 = OpVariable %_ptr_Function_uchar Function
+%2029 = OpVariable %_ptr_Function_uchar Function
+%2030 = OpVariable %_ptr_Function_uchar Function
+%2031 = OpVariable %_ptr_Function_uchar Function
+%2032 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2033 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2034 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2035 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2036 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2037 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2038 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2039 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2040 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2041 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2042 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2043 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2044 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2045 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2046 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2047 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2048 = OpVariable %_ptr_Function_uchar Function
+%2049 = OpVariable %_ptr_Function_uchar Function
+%2050 = OpVariable %_ptr_Function_uchar Function
+%2051 = OpVariable %_ptr_Function_uchar Function
+%2052 = OpVariable %_ptr_Function_uchar Function
+%2053 = OpVariable %_ptr_Function_uchar Function
+%2054 = OpVariable %_ptr_Function_uchar Function
+%2055 = OpVariable %_ptr_Function_uchar Function
+%2056 = OpVariable %_ptr_Function_uchar Function
+%2057 = OpVariable %_ptr_Function_uchar Function
+%2058 = OpVariable %_ptr_Function_uchar Function
+%2059 = OpVariable %_ptr_Function_uchar Function
+%2060 = OpVariable %_ptr_Function_uchar Function
+%2061 = OpVariable %_ptr_Function_uchar Function
+%2062 = OpVariable %_ptr_Function_uchar Function
+%2063 = OpVariable %_ptr_Function_uchar Function
+%2064 = OpVariable %_ptr_Function_uchar Function
+%2065 = OpVariable %_ptr_Function_uchar Function
+%2066 = OpVariable %_ptr_Function_uchar Function
+%2067 = OpVariable %_ptr_Function_uchar Function
+%2068 = OpVariable %_ptr_Function_uchar Function
+%2069 = OpVariable %_ptr_Function_uchar Function
+%2070 = OpVariable %_ptr_Function_uchar Function
+%2071 = OpVariable %_ptr_Function_uchar Function
+%2072 = OpVariable %_ptr_Function_uchar Function
+%2073 = OpVariable %_ptr_Function_uchar Function
+%2074 = OpVariable %_ptr_Function_uchar Function
+%2075 = OpVariable %_ptr_Function_uchar Function
+%2076 = OpVariable %_ptr_Function_uchar Function
+%2077 = OpVariable %_ptr_Function_uchar Function
+%2078 = OpVariable %_ptr_Function_uchar Function
+%2079 = OpVariable %_ptr_Function_uchar Function
+%2080 = OpVariable %_ptr_Function_uchar Function
+%2081 = OpVariable %_ptr_Function_uchar Function
+%2082 = OpVariable %_ptr_Function_uchar Function
+%2083 = OpVariable %_ptr_Function_uchar Function
+%2084 = OpVariable %_ptr_Function_uchar Function
+%2085 = OpVariable %_ptr_Function_uchar Function
+%2086 = OpVariable %_ptr_Function_uchar Function
+%2087 = OpVariable %_ptr_Function_uchar Function
+%2088 = OpVariable %_ptr_Function_uchar Function
+%2089 = OpVariable %_ptr_Function_uchar Function
+%2090 = OpVariable %_ptr_Function_uchar Function
+%2091 = OpVariable %_ptr_Function_uchar Function
+%2092 = OpVariable %_ptr_Function_uchar Function
+%2093 = OpVariable %_ptr_Function_uchar Function
+%2094 = OpVariable %_ptr_Function_uchar Function
+%2095 = OpVariable %_ptr_Function_uchar Function
+%2096 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2097 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2098 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2099 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2100 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2101 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2102 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2103 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2104 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2105 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2106 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2107 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2108 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2109 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2110 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+%2111 = OpVariable %_ptr_Function__arr_uchar_uint_16 Function
+OpStore %738 %715
+OpBranch %723
+%723 = OpLabel
+OpBranch %724
+%724 = OpLabel
+%2112 = OpLoad %ulong %738
+%2113 = OpUConvert %uchar %2112
+OpStore %739 %2113
+%2114 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_240 %uchar_1 %uchar_128 %uchar_255 %uchar_17 %uchar_2 %uchar_200 %uchar_99 %uchar_0 %uchar_7 %uchar_250 %uchar_33 %uchar_128 %uchar_64 %uchar_5 %uchar_199
+OpStore %740 %2114
+%2130 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_17 %uchar_255 %uchar_129 %uchar_1 %uchar_200 %uchar_100 %uchar_57 %uchar_21 %uchar_255 %uchar_3 %uchar_6 %uchar_222 %uchar_128 %uchar_192 %uchar_251 %uchar_57
+OpStore %741 %2130
+%2140 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_1 %uchar_3 %uchar_9 %uchar_27 %uchar_2 %uchar_6 %uchar_18 %uchar_54 %uchar_4 %uchar_12 %uchar_36 %uchar_108 %uchar_8 %uchar_24 %uchar_72 %uchar_216
+OpStore %742 %2140
+%2153 = OpCompositeConstruct %_arr_uchar_uint_16 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0 %uchar_0
+OpStore %743 %2153
+%2154 = OpLoad %_arr_uchar_uint_16 %740
+%2155 = OpCompositeExtract %uchar %2154 0
+OpStore %744 %2155
+%2156 = OpLoad %uchar %744
+%2157 = OpLoad %uchar %739
+%2158 = OpIAdd %uchar %2156 %2157
+OpStore %745 %2158
+%2159 = OpLoad %_arr_uchar_uint_16 %740
+%2160 = OpLoad %uchar %745
+%2161 = OpCompositeInsert %_arr_uchar_uint_16 %2160 %2159 0
+OpStore %746 %2161
+%2162 = OpLoad %_arr_uchar_uint_16 %746
+%2163 = OpCompositeExtract %uchar %2162 7
+OpStore %747 %2163
+%2164 = OpLoad %uchar %747
+%2165 = OpLoad %uchar %739
+%2166 = OpIAdd %uchar %2164 %2165
+OpStore %748 %2166
+%2167 = OpLoad %_arr_uchar_uint_16 %746
+%2168 = OpLoad %uchar %748
+%2169 = OpCompositeInsert %_arr_uchar_uint_16 %2168 %2167 7
+OpStore %749 %2169
+%2170 = OpLoad %_arr_uchar_uint_16 %741
+%2171 = OpCompositeExtract %uchar %2170 3
+OpStore %750 %2171
+%2172 = OpLoad %uchar %750
+%2173 = OpLoad %uchar %739
+%2174 = OpIAdd %uchar %2172 %2173
+OpStore %751 %2174
+%2175 = OpLoad %_arr_uchar_uint_16 %741
+%2176 = OpLoad %uchar %751
+%2177 = OpCompositeInsert %_arr_uchar_uint_16 %2176 %2175 3
+OpStore %752 %2177
+%2178 = OpLoad %_arr_uchar_uint_16 %752
+%2179 = OpCompositeExtract %uchar %2178 12
+OpStore %753 %2179
+%2180 = OpLoad %uchar %753
+%2181 = OpLoad %uchar %739
+%2182 = OpIAdd %uchar %2180 %2181
+OpStore %754 %2182
+%2183 = OpLoad %_arr_uchar_uint_16 %752
+%2184 = OpLoad %uchar %754
+%2185 = OpCompositeInsert %_arr_uchar_uint_16 %2184 %2183 12
+OpStore %755 %2185
+%2187 = OpLoad %_arr_uchar_uint_16 %749
+%2188 = OpFunctionCall %ulong %1 %ulong_14695981039346656037 %2187
+OpStore %756 %2188
+%2189 = OpLoad %ulong %756
+%2190 = OpLoad %_arr_uchar_uint_16 %755
+%2191 = OpFunctionCall %ulong %1 %2189 %2190
+OpStore %757 %2191
+%2192 = OpLoad %_arr_uchar_uint_16 %749
+%2193 = OpCompositeExtract %uchar %2192 0
+OpStore %1184 %2193
+%2194 = OpLoad %_arr_uchar_uint_16 %755
+%2195 = OpCompositeExtract %uchar %2194 0
+OpStore %1185 %2195
+%2196 = OpLoad %uchar %1184
+%2197 = OpLoad %uchar %1185
+%2198 = OpIAdd %uchar %2196 %2197
+OpStore %1186 %2198
+%2199 = OpLoad %_arr_uchar_uint_16 %749
+%2200 = OpCompositeExtract %uchar %2199 1
+OpStore %1187 %2200
+%2201 = OpLoad %_arr_uchar_uint_16 %755
+%2202 = OpCompositeExtract %uchar %2201 1
+OpStore %1188 %2202
+%2203 = OpLoad %uchar %1187
+%2204 = OpLoad %uchar %1188
+%2205 = OpIAdd %uchar %2203 %2204
+OpStore %1189 %2205
+%2206 = OpLoad %_arr_uchar_uint_16 %749
+%2207 = OpCompositeExtract %uchar %2206 2
+OpStore %1190 %2207
+%2208 = OpLoad %_arr_uchar_uint_16 %755
+%2209 = OpCompositeExtract %uchar %2208 2
+OpStore %1191 %2209
+%2210 = OpLoad %uchar %1190
+%2211 = OpLoad %uchar %1191
+%2212 = OpIAdd %uchar %2210 %2211
+OpStore %1192 %2212
+%2213 = OpLoad %_arr_uchar_uint_16 %749
+%2214 = OpCompositeExtract %uchar %2213 3
+OpStore %1193 %2214
+%2215 = OpLoad %_arr_uchar_uint_16 %755
+%2216 = OpCompositeExtract %uchar %2215 3
+OpStore %1194 %2216
+%2217 = OpLoad %uchar %1193
+%2218 = OpLoad %uchar %1194
+%2219 = OpIAdd %uchar %2217 %2218
+OpStore %1195 %2219
+%2220 = OpLoad %_arr_uchar_uint_16 %749
+%2221 = OpCompositeExtract %uchar %2220 4
+OpStore %1196 %2221
+%2222 = OpLoad %_arr_uchar_uint_16 %755
+%2223 = OpCompositeExtract %uchar %2222 4
+OpStore %1197 %2223
+%2224 = OpLoad %uchar %1196
+%2225 = OpLoad %uchar %1197
+%2226 = OpIAdd %uchar %2224 %2225
+OpStore %1198 %2226
+%2227 = OpLoad %_arr_uchar_uint_16 %749
+%2228 = OpCompositeExtract %uchar %2227 5
+OpStore %1199 %2228
+%2229 = OpLoad %_arr_uchar_uint_16 %755
+%2230 = OpCompositeExtract %uchar %2229 5
+OpStore %1200 %2230
+%2231 = OpLoad %uchar %1199
+%2232 = OpLoad %uchar %1200
+%2233 = OpIAdd %uchar %2231 %2232
+OpStore %1201 %2233
+%2234 = OpLoad %_arr_uchar_uint_16 %749
+%2235 = OpCompositeExtract %uchar %2234 6
+OpStore %1202 %2235
+%2236 = OpLoad %_arr_uchar_uint_16 %755
+%2237 = OpCompositeExtract %uchar %2236 6
+OpStore %1203 %2237
+%2238 = OpLoad %uchar %1202
+%2239 = OpLoad %uchar %1203
+%2240 = OpIAdd %uchar %2238 %2239
+OpStore %1204 %2240
+%2241 = OpLoad %_arr_uchar_uint_16 %749
+%2242 = OpCompositeExtract %uchar %2241 7
+OpStore %1205 %2242
+%2243 = OpLoad %_arr_uchar_uint_16 %755
+%2244 = OpCompositeExtract %uchar %2243 7
+OpStore %1206 %2244
+%2245 = OpLoad %uchar %1205
+%2246 = OpLoad %uchar %1206
+%2247 = OpIAdd %uchar %2245 %2246
+OpStore %1207 %2247
+%2248 = OpLoad %_arr_uchar_uint_16 %749
+%2249 = OpCompositeExtract %uchar %2248 8
+OpStore %1208 %2249
+%2250 = OpLoad %_arr_uchar_uint_16 %755
+%2251 = OpCompositeExtract %uchar %2250 8
+OpStore %1209 %2251
+%2252 = OpLoad %uchar %1208
+%2253 = OpLoad %uchar %1209
+%2254 = OpIAdd %uchar %2252 %2253
+OpStore %1210 %2254
+%2255 = OpLoad %_arr_uchar_uint_16 %749
+%2256 = OpCompositeExtract %uchar %2255 9
+OpStore %1211 %2256
+%2257 = OpLoad %_arr_uchar_uint_16 %755
+%2258 = OpCompositeExtract %uchar %2257 9
+OpStore %1212 %2258
+%2259 = OpLoad %uchar %1211
+%2260 = OpLoad %uchar %1212
+%2261 = OpIAdd %uchar %2259 %2260
+OpStore %1213 %2261
+%2262 = OpLoad %_arr_uchar_uint_16 %749
+%2263 = OpCompositeExtract %uchar %2262 10
+OpStore %1214 %2263
+%2264 = OpLoad %_arr_uchar_uint_16 %755
+%2265 = OpCompositeExtract %uchar %2264 10
+OpStore %1215 %2265
+%2266 = OpLoad %uchar %1214
+%2267 = OpLoad %uchar %1215
+%2268 = OpIAdd %uchar %2266 %2267
+OpStore %1216 %2268
+%2269 = OpLoad %_arr_uchar_uint_16 %749
+%2270 = OpCompositeExtract %uchar %2269 11
+OpStore %1217 %2270
+%2271 = OpLoad %_arr_uchar_uint_16 %755
+%2272 = OpCompositeExtract %uchar %2271 11
+OpStore %1218 %2272
+%2273 = OpLoad %uchar %1217
+%2274 = OpLoad %uchar %1218
+%2275 = OpIAdd %uchar %2273 %2274
+OpStore %1219 %2275
+%2276 = OpLoad %_arr_uchar_uint_16 %749
+%2277 = OpCompositeExtract %uchar %2276 12
+OpStore %1220 %2277
+%2278 = OpLoad %_arr_uchar_uint_16 %755
+%2279 = OpCompositeExtract %uchar %2278 12
+OpStore %1221 %2279
+%2280 = OpLoad %uchar %1220
+%2281 = OpLoad %uchar %1221
+%2282 = OpIAdd %uchar %2280 %2281
+OpStore %1222 %2282
+%2283 = OpLoad %_arr_uchar_uint_16 %749
+%2284 = OpCompositeExtract %uchar %2283 13
+OpStore %1223 %2284
+%2285 = OpLoad %_arr_uchar_uint_16 %755
+%2286 = OpCompositeExtract %uchar %2285 13
+OpStore %1224 %2286
+%2287 = OpLoad %uchar %1223
+%2288 = OpLoad %uchar %1224
+%2289 = OpIAdd %uchar %2287 %2288
+OpStore %1225 %2289
+%2290 = OpLoad %_arr_uchar_uint_16 %749
+%2291 = OpCompositeExtract %uchar %2290 14
+OpStore %1226 %2291
+%2292 = OpLoad %_arr_uchar_uint_16 %755
+%2293 = OpCompositeExtract %uchar %2292 14
+OpStore %1227 %2293
+%2294 = OpLoad %uchar %1226
+%2295 = OpLoad %uchar %1227
+%2296 = OpIAdd %uchar %2294 %2295
+OpStore %1228 %2296
+%2297 = OpLoad %_arr_uchar_uint_16 %749
+%2298 = OpCompositeExtract %uchar %2297 15
+OpStore %1229 %2298
+%2299 = OpLoad %_arr_uchar_uint_16 %755
+%2300 = OpCompositeExtract %uchar %2299 15
+OpStore %1230 %2300
+%2301 = OpLoad %uchar %1229
+%2302 = OpLoad %uchar %1230
+%2303 = OpIAdd %uchar %2301 %2302
+OpStore %1231 %2303
+%2304 = OpLoad %_arr_uchar_uint_16 %749
+%2305 = OpLoad %uchar %1186
+%2306 = OpCompositeInsert %_arr_uchar_uint_16 %2305 %2304 0
+OpStore %1232 %2306
+%2307 = OpLoad %_arr_uchar_uint_16 %1232
+%2308 = OpLoad %uchar %1189
+%2309 = OpCompositeInsert %_arr_uchar_uint_16 %2308 %2307 1
+OpStore %1233 %2309
+%2310 = OpLoad %_arr_uchar_uint_16 %1233
+%2311 = OpLoad %uchar %1192
+%2312 = OpCompositeInsert %_arr_uchar_uint_16 %2311 %2310 2
+OpStore %1234 %2312
+%2313 = OpLoad %_arr_uchar_uint_16 %1234
+%2314 = OpLoad %uchar %1195
+%2315 = OpCompositeInsert %_arr_uchar_uint_16 %2314 %2313 3
+OpStore %1235 %2315
+%2316 = OpLoad %_arr_uchar_uint_16 %1235
+%2317 = OpLoad %uchar %1198
+%2318 = OpCompositeInsert %_arr_uchar_uint_16 %2317 %2316 4
+OpStore %1236 %2318
+%2319 = OpLoad %_arr_uchar_uint_16 %1236
+%2320 = OpLoad %uchar %1201
+%2321 = OpCompositeInsert %_arr_uchar_uint_16 %2320 %2319 5
+OpStore %1237 %2321
+%2322 = OpLoad %_arr_uchar_uint_16 %1237
+%2323 = OpLoad %uchar %1204
+%2324 = OpCompositeInsert %_arr_uchar_uint_16 %2323 %2322 6
+OpStore %1238 %2324
+%2325 = OpLoad %_arr_uchar_uint_16 %1238
+%2326 = OpLoad %uchar %1207
+%2327 = OpCompositeInsert %_arr_uchar_uint_16 %2326 %2325 7
+OpStore %1239 %2327
+%2328 = OpLoad %_arr_uchar_uint_16 %1239
+%2329 = OpLoad %uchar %1210
+%2330 = OpCompositeInsert %_arr_uchar_uint_16 %2329 %2328 8
+OpStore %1240 %2330
+%2331 = OpLoad %_arr_uchar_uint_16 %1240
+%2332 = OpLoad %uchar %1213
+%2333 = OpCompositeInsert %_arr_uchar_uint_16 %2332 %2331 9
+OpStore %1241 %2333
+%2334 = OpLoad %_arr_uchar_uint_16 %1241
+%2335 = OpLoad %uchar %1216
+%2336 = OpCompositeInsert %_arr_uchar_uint_16 %2335 %2334 10
+OpStore %1242 %2336
+%2337 = OpLoad %_arr_uchar_uint_16 %1242
+%2338 = OpLoad %uchar %1219
+%2339 = OpCompositeInsert %_arr_uchar_uint_16 %2338 %2337 11
+OpStore %1243 %2339
+%2340 = OpLoad %_arr_uchar_uint_16 %1243
+%2341 = OpLoad %uchar %1222
+%2342 = OpCompositeInsert %_arr_uchar_uint_16 %2341 %2340 12
+OpStore %1244 %2342
+%2343 = OpLoad %_arr_uchar_uint_16 %1244
+%2344 = OpLoad %uchar %1225
+%2345 = OpCompositeInsert %_arr_uchar_uint_16 %2344 %2343 13
+OpStore %1245 %2345
+%2346 = OpLoad %_arr_uchar_uint_16 %1245
+%2347 = OpLoad %uchar %1228
+%2348 = OpCompositeInsert %_arr_uchar_uint_16 %2347 %2346 14
+OpStore %1246 %2348
+%2349 = OpLoad %_arr_uchar_uint_16 %1246
+%2350 = OpLoad %uchar %1231
+%2351 = OpCompositeInsert %_arr_uchar_uint_16 %2350 %2349 15
+OpStore %1247 %2351
+%2352 = OpLoad %ulong %757
+%2353 = OpLoad %_arr_uchar_uint_16 %1247
+%2354 = OpFunctionCall %ulong %1 %2352 %2353
+OpStore %758 %2354
+%2355 = OpLoad %_arr_uchar_uint_16 %749
+%2356 = OpCompositeExtract %uchar %2355 0
+OpStore %1248 %2356
+%2357 = OpLoad %_arr_uchar_uint_16 %755
+%2358 = OpCompositeExtract %uchar %2357 0
+OpStore %1249 %2358
+%2359 = OpLoad %uchar %1248
+%2360 = OpLoad %uchar %1249
+%2361 = OpISub %uchar %2359 %2360
+OpStore %1250 %2361
+%2362 = OpLoad %_arr_uchar_uint_16 %749
+%2363 = OpCompositeExtract %uchar %2362 1
+OpStore %1251 %2363
+%2364 = OpLoad %_arr_uchar_uint_16 %755
+%2365 = OpCompositeExtract %uchar %2364 1
+OpStore %1252 %2365
+%2366 = OpLoad %uchar %1251
+%2367 = OpLoad %uchar %1252
+%2368 = OpISub %uchar %2366 %2367
+OpStore %1253 %2368
+%2369 = OpLoad %_arr_uchar_uint_16 %749
+%2370 = OpCompositeExtract %uchar %2369 2
+OpStore %1254 %2370
+%2371 = OpLoad %_arr_uchar_uint_16 %755
+%2372 = OpCompositeExtract %uchar %2371 2
+OpStore %1255 %2372
+%2373 = OpLoad %uchar %1254
+%2374 = OpLoad %uchar %1255
+%2375 = OpISub %uchar %2373 %2374
+OpStore %1256 %2375
+%2376 = OpLoad %_arr_uchar_uint_16 %749
+%2377 = OpCompositeExtract %uchar %2376 3
+OpStore %1257 %2377
+%2378 = OpLoad %_arr_uchar_uint_16 %755
+%2379 = OpCompositeExtract %uchar %2378 3
+OpStore %1258 %2379
+%2380 = OpLoad %uchar %1257
+%2381 = OpLoad %uchar %1258
+%2382 = OpISub %uchar %2380 %2381
+OpStore %1259 %2382
+%2383 = OpLoad %_arr_uchar_uint_16 %749
+%2384 = OpCompositeExtract %uchar %2383 4
+OpStore %1260 %2384
+%2385 = OpLoad %_arr_uchar_uint_16 %755
+%2386 = OpCompositeExtract %uchar %2385 4
+OpStore %1261 %2386
+%2387 = OpLoad %uchar %1260
+%2388 = OpLoad %uchar %1261
+%2389 = OpISub %uchar %2387 %2388
+OpStore %1262 %2389
+%2390 = OpLoad %_arr_uchar_uint_16 %749
+%2391 = OpCompositeExtract %uchar %2390 5
+OpStore %1263 %2391
+%2392 = OpLoad %_arr_uchar_uint_16 %755
+%2393 = OpCompositeExtract %uchar %2392 5
+OpStore %1264 %2393
+%2394 = OpLoad %uchar %1263
+%2395 = OpLoad %uchar %1264
+%2396 = OpISub %uchar %2394 %2395
+OpStore %1265 %2396
+%2397 = OpLoad %_arr_uchar_uint_16 %749
+%2398 = OpCompositeExtract %uchar %2397 6
+OpStore %1266 %2398
+%2399 = OpLoad %_arr_uchar_uint_16 %755
+%2400 = OpCompositeExtract %uchar %2399 6
+OpStore %1267 %2400
+%2401 = OpLoad %uchar %1266
+%2402 = OpLoad %uchar %1267
+%2403 = OpISub %uchar %2401 %2402
+OpStore %1268 %2403
+%2404 = OpLoad %_arr_uchar_uint_16 %749
+%2405 = OpCompositeExtract %uchar %2404 7
+OpStore %1269 %2405
+%2406 = OpLoad %_arr_uchar_uint_16 %755
+%2407 = OpCompositeExtract %uchar %2406 7
+OpStore %1270 %2407
+%2408 = OpLoad %uchar %1269
+%2409 = OpLoad %uchar %1270
+%2410 = OpISub %uchar %2408 %2409
+OpStore %1271 %2410
+%2411 = OpLoad %_arr_uchar_uint_16 %749
+%2412 = OpCompositeExtract %uchar %2411 8
+OpStore %1272 %2412
+%2413 = OpLoad %_arr_uchar_uint_16 %755
+%2414 = OpCompositeExtract %uchar %2413 8
+OpStore %1273 %2414
+%2415 = OpLoad %uchar %1272
+%2416 = OpLoad %uchar %1273
+%2417 = OpISub %uchar %2415 %2416
+OpStore %1274 %2417
+%2418 = OpLoad %_arr_uchar_uint_16 %749
+%2419 = OpCompositeExtract %uchar %2418 9
+OpStore %1275 %2419
+%2420 = OpLoad %_arr_uchar_uint_16 %755
+%2421 = OpCompositeExtract %uchar %2420 9
+OpStore %1276 %2421
+%2422 = OpLoad %uchar %1275
+%2423 = OpLoad %uchar %1276
+%2424 = OpISub %uchar %2422 %2423
+OpStore %1277 %2424
+%2425 = OpLoad %_arr_uchar_uint_16 %749
+%2426 = OpCompositeExtract %uchar %2425 10
+OpStore %1278 %2426
+%2427 = OpLoad %_arr_uchar_uint_16 %755
+%2428 = OpCompositeExtract %uchar %2427 10
+OpStore %1279 %2428
+%2429 = OpLoad %uchar %1278
+%2430 = OpLoad %uchar %1279
+%2431 = OpISub %uchar %2429 %2430
+OpStore %1280 %2431
+%2432 = OpLoad %_arr_uchar_uint_16 %749
+%2433 = OpCompositeExtract %uchar %2432 11
+OpStore %1281 %2433
+%2434 = OpLoad %_arr_uchar_uint_16 %755
+%2435 = OpCompositeExtract %uchar %2434 11
+OpStore %1282 %2435
+%2436 = OpLoad %uchar %1281
+%2437 = OpLoad %uchar %1282
+%2438 = OpISub %uchar %2436 %2437
+OpStore %1283 %2438
+%2439 = OpLoad %_arr_uchar_uint_16 %749
+%2440 = OpCompositeExtract %uchar %2439 12
+OpStore %1284 %2440
+%2441 = OpLoad %_arr_uchar_uint_16 %755
+%2442 = OpCompositeExtract %uchar %2441 12
+OpStore %1285 %2442
+%2443 = OpLoad %uchar %1284
+%2444 = OpLoad %uchar %1285
+%2445 = OpISub %uchar %2443 %2444
+OpStore %1286 %2445
+%2446 = OpLoad %_arr_uchar_uint_16 %749
+%2447 = OpCompositeExtract %uchar %2446 13
+OpStore %1287 %2447
+%2448 = OpLoad %_arr_uchar_uint_16 %755
+%2449 = OpCompositeExtract %uchar %2448 13
+OpStore %1288 %2449
+%2450 = OpLoad %uchar %1287
+%2451 = OpLoad %uchar %1288
+%2452 = OpISub %uchar %2450 %2451
+OpStore %1289 %2452
+%2453 = OpLoad %_arr_uchar_uint_16 %749
+%2454 = OpCompositeExtract %uchar %2453 14
+OpStore %1290 %2454
+%2455 = OpLoad %_arr_uchar_uint_16 %755
+%2456 = OpCompositeExtract %uchar %2455 14
+OpStore %1291 %2456
+%2457 = OpLoad %uchar %1290
+%2458 = OpLoad %uchar %1291
+%2459 = OpISub %uchar %2457 %2458
+OpStore %1292 %2459
+%2460 = OpLoad %_arr_uchar_uint_16 %749
+%2461 = OpCompositeExtract %uchar %2460 15
+OpStore %1293 %2461
+%2462 = OpLoad %_arr_uchar_uint_16 %755
+%2463 = OpCompositeExtract %uchar %2462 15
+OpStore %1294 %2463
+%2464 = OpLoad %uchar %1293
+%2465 = OpLoad %uchar %1294
+%2466 = OpISub %uchar %2464 %2465
+OpStore %1295 %2466
+%2467 = OpLoad %_arr_uchar_uint_16 %749
+%2468 = OpLoad %uchar %1250
+%2469 = OpCompositeInsert %_arr_uchar_uint_16 %2468 %2467 0
+OpStore %1296 %2469
+%2470 = OpLoad %_arr_uchar_uint_16 %1296
+%2471 = OpLoad %uchar %1253
+%2472 = OpCompositeInsert %_arr_uchar_uint_16 %2471 %2470 1
+OpStore %1297 %2472
+%2473 = OpLoad %_arr_uchar_uint_16 %1297
+%2474 = OpLoad %uchar %1256
+%2475 = OpCompositeInsert %_arr_uchar_uint_16 %2474 %2473 2
+OpStore %1298 %2475
+%2476 = OpLoad %_arr_uchar_uint_16 %1298
+%2477 = OpLoad %uchar %1259
+%2478 = OpCompositeInsert %_arr_uchar_uint_16 %2477 %2476 3
+OpStore %1299 %2478
+%2479 = OpLoad %_arr_uchar_uint_16 %1299
+%2480 = OpLoad %uchar %1262
+%2481 = OpCompositeInsert %_arr_uchar_uint_16 %2480 %2479 4
+OpStore %1300 %2481
+%2482 = OpLoad %_arr_uchar_uint_16 %1300
+%2483 = OpLoad %uchar %1265
+%2484 = OpCompositeInsert %_arr_uchar_uint_16 %2483 %2482 5
+OpStore %1301 %2484
+%2485 = OpLoad %_arr_uchar_uint_16 %1301
+%2486 = OpLoad %uchar %1268
+%2487 = OpCompositeInsert %_arr_uchar_uint_16 %2486 %2485 6
+OpStore %1302 %2487
+%2488 = OpLoad %_arr_uchar_uint_16 %1302
+%2489 = OpLoad %uchar %1271
+%2490 = OpCompositeInsert %_arr_uchar_uint_16 %2489 %2488 7
+OpStore %1303 %2490
+%2491 = OpLoad %_arr_uchar_uint_16 %1303
+%2492 = OpLoad %uchar %1274
+%2493 = OpCompositeInsert %_arr_uchar_uint_16 %2492 %2491 8
+OpStore %1304 %2493
+%2494 = OpLoad %_arr_uchar_uint_16 %1304
+%2495 = OpLoad %uchar %1277
+%2496 = OpCompositeInsert %_arr_uchar_uint_16 %2495 %2494 9
+OpStore %1305 %2496
+%2497 = OpLoad %_arr_uchar_uint_16 %1305
+%2498 = OpLoad %uchar %1280
+%2499 = OpCompositeInsert %_arr_uchar_uint_16 %2498 %2497 10
+OpStore %1306 %2499
+%2500 = OpLoad %_arr_uchar_uint_16 %1306
+%2501 = OpLoad %uchar %1283
+%2502 = OpCompositeInsert %_arr_uchar_uint_16 %2501 %2500 11
+OpStore %1307 %2502
+%2503 = OpLoad %_arr_uchar_uint_16 %1307
+%2504 = OpLoad %uchar %1286
+%2505 = OpCompositeInsert %_arr_uchar_uint_16 %2504 %2503 12
+OpStore %1308 %2505
+%2506 = OpLoad %_arr_uchar_uint_16 %1308
+%2507 = OpLoad %uchar %1289
+%2508 = OpCompositeInsert %_arr_uchar_uint_16 %2507 %2506 13
+OpStore %1309 %2508
+%2509 = OpLoad %_arr_uchar_uint_16 %1309
+%2510 = OpLoad %uchar %1292
+%2511 = OpCompositeInsert %_arr_uchar_uint_16 %2510 %2509 14
+OpStore %1310 %2511
+%2512 = OpLoad %_arr_uchar_uint_16 %1310
+%2513 = OpLoad %uchar %1295
+%2514 = OpCompositeInsert %_arr_uchar_uint_16 %2513 %2512 15
+OpStore %1311 %2514
+%2515 = OpLoad %ulong %758
+%2516 = OpLoad %_arr_uchar_uint_16 %1311
+%2517 = OpFunctionCall %ulong %1 %2515 %2516
+OpStore %759 %2517
+%2518 = OpLoad %_arr_uchar_uint_16 %755
+%2519 = OpCompositeExtract %uchar %2518 0
+OpStore %1312 %2519
+%2520 = OpLoad %_arr_uchar_uint_16 %749
+%2521 = OpCompositeExtract %uchar %2520 0
+OpStore %1313 %2521
+%2522 = OpLoad %uchar %1312
+%2523 = OpLoad %uchar %1313
+%2524 = OpISub %uchar %2522 %2523
+OpStore %1314 %2524
+%2525 = OpLoad %_arr_uchar_uint_16 %755
+%2526 = OpCompositeExtract %uchar %2525 1
+OpStore %1315 %2526
+%2527 = OpLoad %_arr_uchar_uint_16 %749
+%2528 = OpCompositeExtract %uchar %2527 1
+OpStore %1316 %2528
+%2529 = OpLoad %uchar %1315
+%2530 = OpLoad %uchar %1316
+%2531 = OpISub %uchar %2529 %2530
+OpStore %1317 %2531
+%2532 = OpLoad %_arr_uchar_uint_16 %755
+%2533 = OpCompositeExtract %uchar %2532 2
+OpStore %1318 %2533
+%2534 = OpLoad %_arr_uchar_uint_16 %749
+%2535 = OpCompositeExtract %uchar %2534 2
+OpStore %1319 %2535
+%2536 = OpLoad %uchar %1318
+%2537 = OpLoad %uchar %1319
+%2538 = OpISub %uchar %2536 %2537
+OpStore %1320 %2538
+%2539 = OpLoad %_arr_uchar_uint_16 %755
+%2540 = OpCompositeExtract %uchar %2539 3
+OpStore %1321 %2540
+%2541 = OpLoad %_arr_uchar_uint_16 %749
+%2542 = OpCompositeExtract %uchar %2541 3
+OpStore %1322 %2542
+%2543 = OpLoad %uchar %1321
+%2544 = OpLoad %uchar %1322
+%2545 = OpISub %uchar %2543 %2544
+OpStore %1323 %2545
+%2546 = OpLoad %_arr_uchar_uint_16 %755
+%2547 = OpCompositeExtract %uchar %2546 4
+OpStore %1324 %2547
+%2548 = OpLoad %_arr_uchar_uint_16 %749
+%2549 = OpCompositeExtract %uchar %2548 4
+OpStore %1325 %2549
+%2550 = OpLoad %uchar %1324
+%2551 = OpLoad %uchar %1325
+%2552 = OpISub %uchar %2550 %2551
+OpStore %1326 %2552
+%2553 = OpLoad %_arr_uchar_uint_16 %755
+%2554 = OpCompositeExtract %uchar %2553 5
+OpStore %1327 %2554
+%2555 = OpLoad %_arr_uchar_uint_16 %749
+%2556 = OpCompositeExtract %uchar %2555 5
+OpStore %1328 %2556
+%2557 = OpLoad %uchar %1327
+%2558 = OpLoad %uchar %1328
+%2559 = OpISub %uchar %2557 %2558
+OpStore %1329 %2559
+%2560 = OpLoad %_arr_uchar_uint_16 %755
+%2561 = OpCompositeExtract %uchar %2560 6
+OpStore %1330 %2561
+%2562 = OpLoad %_arr_uchar_uint_16 %749
+%2563 = OpCompositeExtract %uchar %2562 6
+OpStore %1331 %2563
+%2564 = OpLoad %uchar %1330
+%2565 = OpLoad %uchar %1331
+%2566 = OpISub %uchar %2564 %2565
+OpStore %1332 %2566
+%2567 = OpLoad %_arr_uchar_uint_16 %755
+%2568 = OpCompositeExtract %uchar %2567 7
+OpStore %1333 %2568
+%2569 = OpLoad %_arr_uchar_uint_16 %749
+%2570 = OpCompositeExtract %uchar %2569 7
+OpStore %1334 %2570
+%2571 = OpLoad %uchar %1333
+%2572 = OpLoad %uchar %1334
+%2573 = OpISub %uchar %2571 %2572
+OpStore %1335 %2573
+%2574 = OpLoad %_arr_uchar_uint_16 %755
+%2575 = OpCompositeExtract %uchar %2574 8
+OpStore %1336 %2575
+%2576 = OpLoad %_arr_uchar_uint_16 %749
+%2577 = OpCompositeExtract %uchar %2576 8
+OpStore %1337 %2577
+%2578 = OpLoad %uchar %1336
+%2579 = OpLoad %uchar %1337
+%2580 = OpISub %uchar %2578 %2579
+OpStore %1338 %2580
+%2581 = OpLoad %_arr_uchar_uint_16 %755
+%2582 = OpCompositeExtract %uchar %2581 9
+OpStore %1339 %2582
+%2583 = OpLoad %_arr_uchar_uint_16 %749
+%2584 = OpCompositeExtract %uchar %2583 9
+OpStore %1340 %2584
+%2585 = OpLoad %uchar %1339
+%2586 = OpLoad %uchar %1340
+%2587 = OpISub %uchar %2585 %2586
+OpStore %1341 %2587
+%2588 = OpLoad %_arr_uchar_uint_16 %755
+%2589 = OpCompositeExtract %uchar %2588 10
+OpStore %1342 %2589
+%2590 = OpLoad %_arr_uchar_uint_16 %749
+%2591 = OpCompositeExtract %uchar %2590 10
+OpStore %1343 %2591
+%2592 = OpLoad %uchar %1342
+%2593 = OpLoad %uchar %1343
+%2594 = OpISub %uchar %2592 %2593
+OpStore %1344 %2594
+%2595 = OpLoad %_arr_uchar_uint_16 %755
+%2596 = OpCompositeExtract %uchar %2595 11
+OpStore %1345 %2596
+%2597 = OpLoad %_arr_uchar_uint_16 %749
+%2598 = OpCompositeExtract %uchar %2597 11
+OpStore %1346 %2598
+%2599 = OpLoad %uchar %1345
+%2600 = OpLoad %uchar %1346
+%2601 = OpISub %uchar %2599 %2600
+OpStore %1347 %2601
+%2602 = OpLoad %_arr_uchar_uint_16 %755
+%2603 = OpCompositeExtract %uchar %2602 12
+OpStore %1348 %2603
+%2604 = OpLoad %_arr_uchar_uint_16 %749
+%2605 = OpCompositeExtract %uchar %2604 12
+OpStore %1349 %2605
+%2606 = OpLoad %uchar %1348
+%2607 = OpLoad %uchar %1349
+%2608 = OpISub %uchar %2606 %2607
+OpStore %1350 %2608
+%2609 = OpLoad %_arr_uchar_uint_16 %755
+%2610 = OpCompositeExtract %uchar %2609 13
+OpStore %1351 %2610
+%2611 = OpLoad %_arr_uchar_uint_16 %749
+%2612 = OpCompositeExtract %uchar %2611 13
+OpStore %1352 %2612
+%2613 = OpLoad %uchar %1351
+%2614 = OpLoad %uchar %1352
+%2615 = OpISub %uchar %2613 %2614
+OpStore %1353 %2615
+%2616 = OpLoad %_arr_uchar_uint_16 %755
+%2617 = OpCompositeExtract %uchar %2616 14
+OpStore %1354 %2617
+%2618 = OpLoad %_arr_uchar_uint_16 %749
+%2619 = OpCompositeExtract %uchar %2618 14
+OpStore %1355 %2619
+%2620 = OpLoad %uchar %1354
+%2621 = OpLoad %uchar %1355
+%2622 = OpISub %uchar %2620 %2621
+OpStore %1356 %2622
+%2623 = OpLoad %_arr_uchar_uint_16 %755
+%2624 = OpCompositeExtract %uchar %2623 15
+OpStore %1357 %2624
+%2625 = OpLoad %_arr_uchar_uint_16 %749
+%2626 = OpCompositeExtract %uchar %2625 15
+OpStore %1358 %2626
+%2627 = OpLoad %uchar %1357
+%2628 = OpLoad %uchar %1358
+%2629 = OpISub %uchar %2627 %2628
+OpStore %1359 %2629
+%2630 = OpLoad %_arr_uchar_uint_16 %755
+%2631 = OpLoad %uchar %1314
+%2632 = OpCompositeInsert %_arr_uchar_uint_16 %2631 %2630 0
+OpStore %1360 %2632
+%2633 = OpLoad %_arr_uchar_uint_16 %1360
+%2634 = OpLoad %uchar %1317
+%2635 = OpCompositeInsert %_arr_uchar_uint_16 %2634 %2633 1
+OpStore %1361 %2635
+%2636 = OpLoad %_arr_uchar_uint_16 %1361
+%2637 = OpLoad %uchar %1320
+%2638 = OpCompositeInsert %_arr_uchar_uint_16 %2637 %2636 2
+OpStore %1362 %2638
+%2639 = OpLoad %_arr_uchar_uint_16 %1362
+%2640 = OpLoad %uchar %1323
+%2641 = OpCompositeInsert %_arr_uchar_uint_16 %2640 %2639 3
+OpStore %1363 %2641
+%2642 = OpLoad %_arr_uchar_uint_16 %1363
+%2643 = OpLoad %uchar %1326
+%2644 = OpCompositeInsert %_arr_uchar_uint_16 %2643 %2642 4
+OpStore %1364 %2644
+%2645 = OpLoad %_arr_uchar_uint_16 %1364
+%2646 = OpLoad %uchar %1329
+%2647 = OpCompositeInsert %_arr_uchar_uint_16 %2646 %2645 5
+OpStore %1365 %2647
+%2648 = OpLoad %_arr_uchar_uint_16 %1365
+%2649 = OpLoad %uchar %1332
+%2650 = OpCompositeInsert %_arr_uchar_uint_16 %2649 %2648 6
+OpStore %1366 %2650
+%2651 = OpLoad %_arr_uchar_uint_16 %1366
+%2652 = OpLoad %uchar %1335
+%2653 = OpCompositeInsert %_arr_uchar_uint_16 %2652 %2651 7
+OpStore %1367 %2653
+%2654 = OpLoad %_arr_uchar_uint_16 %1367
+%2655 = OpLoad %uchar %1338
+%2656 = OpCompositeInsert %_arr_uchar_uint_16 %2655 %2654 8
+OpStore %1368 %2656
+%2657 = OpLoad %_arr_uchar_uint_16 %1368
+%2658 = OpLoad %uchar %1341
+%2659 = OpCompositeInsert %_arr_uchar_uint_16 %2658 %2657 9
+OpStore %1369 %2659
+%2660 = OpLoad %_arr_uchar_uint_16 %1369
+%2661 = OpLoad %uchar %1344
+%2662 = OpCompositeInsert %_arr_uchar_uint_16 %2661 %2660 10
+OpStore %1370 %2662
+%2663 = OpLoad %_arr_uchar_uint_16 %1370
+%2664 = OpLoad %uchar %1347
+%2665 = OpCompositeInsert %_arr_uchar_uint_16 %2664 %2663 11
+OpStore %1371 %2665
+%2666 = OpLoad %_arr_uchar_uint_16 %1371
+%2667 = OpLoad %uchar %1350
+%2668 = OpCompositeInsert %_arr_uchar_uint_16 %2667 %2666 12
+OpStore %1372 %2668
+%2669 = OpLoad %_arr_uchar_uint_16 %1372
+%2670 = OpLoad %uchar %1353
+%2671 = OpCompositeInsert %_arr_uchar_uint_16 %2670 %2669 13
+OpStore %1373 %2671
+%2672 = OpLoad %_arr_uchar_uint_16 %1373
+%2673 = OpLoad %uchar %1356
+%2674 = OpCompositeInsert %_arr_uchar_uint_16 %2673 %2672 14
+OpStore %1374 %2674
+%2675 = OpLoad %_arr_uchar_uint_16 %1374
+%2676 = OpLoad %uchar %1359
+%2677 = OpCompositeInsert %_arr_uchar_uint_16 %2676 %2675 15
+OpStore %1375 %2677
+%2678 = OpLoad %ulong %759
+%2679 = OpLoad %_arr_uchar_uint_16 %1375
+%2680 = OpFunctionCall %ulong %1 %2678 %2679
+OpStore %760 %2680
+%2681 = OpLoad %_arr_uchar_uint_16 %749
+%2682 = OpCompositeExtract %uchar %2681 0
+OpStore %1376 %2682
+%2683 = OpLoad %_arr_uchar_uint_16 %755
+%2684 = OpCompositeExtract %uchar %2683 0
+OpStore %1377 %2684
+%2685 = OpLoad %uchar %1376
+%2686 = OpLoad %uchar %1377
+%2687 = OpIMul %uchar %2685 %2686
+OpStore %1378 %2687
+%2688 = OpLoad %_arr_uchar_uint_16 %749
+%2689 = OpCompositeExtract %uchar %2688 1
+OpStore %1379 %2689
+%2690 = OpLoad %_arr_uchar_uint_16 %755
+%2691 = OpCompositeExtract %uchar %2690 1
+OpStore %1380 %2691
+%2692 = OpLoad %uchar %1379
+%2693 = OpLoad %uchar %1380
+%2694 = OpIMul %uchar %2692 %2693
+OpStore %1381 %2694
+%2695 = OpLoad %_arr_uchar_uint_16 %749
+%2696 = OpCompositeExtract %uchar %2695 2
+OpStore %1382 %2696
+%2697 = OpLoad %_arr_uchar_uint_16 %755
+%2698 = OpCompositeExtract %uchar %2697 2
+OpStore %1383 %2698
+%2699 = OpLoad %uchar %1382
+%2700 = OpLoad %uchar %1383
+%2701 = OpIMul %uchar %2699 %2700
+OpStore %1384 %2701
+%2702 = OpLoad %_arr_uchar_uint_16 %749
+%2703 = OpCompositeExtract %uchar %2702 3
+OpStore %1385 %2703
+%2704 = OpLoad %_arr_uchar_uint_16 %755
+%2705 = OpCompositeExtract %uchar %2704 3
+OpStore %1386 %2705
+%2706 = OpLoad %uchar %1385
+%2707 = OpLoad %uchar %1386
+%2708 = OpIMul %uchar %2706 %2707
+OpStore %1387 %2708
+%2709 = OpLoad %_arr_uchar_uint_16 %749
+%2710 = OpCompositeExtract %uchar %2709 4
+OpStore %1388 %2710
+%2711 = OpLoad %_arr_uchar_uint_16 %755
+%2712 = OpCompositeExtract %uchar %2711 4
+OpStore %1389 %2712
+%2713 = OpLoad %uchar %1388
+%2714 = OpLoad %uchar %1389
+%2715 = OpIMul %uchar %2713 %2714
+OpStore %1390 %2715
+%2716 = OpLoad %_arr_uchar_uint_16 %749
+%2717 = OpCompositeExtract %uchar %2716 5
+OpStore %1391 %2717
+%2718 = OpLoad %_arr_uchar_uint_16 %755
+%2719 = OpCompositeExtract %uchar %2718 5
+OpStore %1392 %2719
+%2720 = OpLoad %uchar %1391
+%2721 = OpLoad %uchar %1392
+%2722 = OpIMul %uchar %2720 %2721
+OpStore %1393 %2722
+%2723 = OpLoad %_arr_uchar_uint_16 %749
+%2724 = OpCompositeExtract %uchar %2723 6
+OpStore %1394 %2724
+%2725 = OpLoad %_arr_uchar_uint_16 %755
+%2726 = OpCompositeExtract %uchar %2725 6
+OpStore %1395 %2726
+%2727 = OpLoad %uchar %1394
+%2728 = OpLoad %uchar %1395
+%2729 = OpIMul %uchar %2727 %2728
+OpStore %1396 %2729
+%2730 = OpLoad %_arr_uchar_uint_16 %749
+%2731 = OpCompositeExtract %uchar %2730 7
+OpStore %1397 %2731
+%2732 = OpLoad %_arr_uchar_uint_16 %755
+%2733 = OpCompositeExtract %uchar %2732 7
+OpStore %1398 %2733
+%2734 = OpLoad %uchar %1397
+%2735 = OpLoad %uchar %1398
+%2736 = OpIMul %uchar %2734 %2735
+OpStore %1399 %2736
+%2737 = OpLoad %_arr_uchar_uint_16 %749
+%2738 = OpCompositeExtract %uchar %2737 8
+OpStore %1400 %2738
+%2739 = OpLoad %_arr_uchar_uint_16 %755
+%2740 = OpCompositeExtract %uchar %2739 8
+OpStore %1401 %2740
+%2741 = OpLoad %uchar %1400
+%2742 = OpLoad %uchar %1401
+%2743 = OpIMul %uchar %2741 %2742
+OpStore %1402 %2743
+%2744 = OpLoad %_arr_uchar_uint_16 %749
+%2745 = OpCompositeExtract %uchar %2744 9
+OpStore %1403 %2745
+%2746 = OpLoad %_arr_uchar_uint_16 %755
+%2747 = OpCompositeExtract %uchar %2746 9
+OpStore %1404 %2747
+%2748 = OpLoad %uchar %1403
+%2749 = OpLoad %uchar %1404
+%2750 = OpIMul %uchar %2748 %2749
+OpStore %1405 %2750
+%2751 = OpLoad %_arr_uchar_uint_16 %749
+%2752 = OpCompositeExtract %uchar %2751 10
+OpStore %1406 %2752
+%2753 = OpLoad %_arr_uchar_uint_16 %755
+%2754 = OpCompositeExtract %uchar %2753 10
+OpStore %1407 %2754
+%2755 = OpLoad %uchar %1406
+%2756 = OpLoad %uchar %1407
+%2757 = OpIMul %uchar %2755 %2756
+OpStore %1408 %2757
+%2758 = OpLoad %_arr_uchar_uint_16 %749
+%2759 = OpCompositeExtract %uchar %2758 11
+OpStore %1409 %2759
+%2760 = OpLoad %_arr_uchar_uint_16 %755
+%2761 = OpCompositeExtract %uchar %2760 11
+OpStore %1410 %2761
+%2762 = OpLoad %uchar %1409
+%2763 = OpLoad %uchar %1410
+%2764 = OpIMul %uchar %2762 %2763
+OpStore %1411 %2764
+%2765 = OpLoad %_arr_uchar_uint_16 %749
+%2766 = OpCompositeExtract %uchar %2765 12
+OpStore %1412 %2766
+%2767 = OpLoad %_arr_uchar_uint_16 %755
+%2768 = OpCompositeExtract %uchar %2767 12
+OpStore %1413 %2768
+%2769 = OpLoad %uchar %1412
+%2770 = OpLoad %uchar %1413
+%2771 = OpIMul %uchar %2769 %2770
+OpStore %1414 %2771
+%2772 = OpLoad %_arr_uchar_uint_16 %749
+%2773 = OpCompositeExtract %uchar %2772 13
+OpStore %1415 %2773
+%2774 = OpLoad %_arr_uchar_uint_16 %755
+%2775 = OpCompositeExtract %uchar %2774 13
+OpStore %1416 %2775
+%2776 = OpLoad %uchar %1415
+%2777 = OpLoad %uchar %1416
+%2778 = OpIMul %uchar %2776 %2777
+OpStore %1417 %2778
+%2779 = OpLoad %_arr_uchar_uint_16 %749
+%2780 = OpCompositeExtract %uchar %2779 14
+OpStore %1418 %2780
+%2781 = OpLoad %_arr_uchar_uint_16 %755
+%2782 = OpCompositeExtract %uchar %2781 14
+OpStore %1419 %2782
+%2783 = OpLoad %uchar %1418
+%2784 = OpLoad %uchar %1419
+%2785 = OpIMul %uchar %2783 %2784
+OpStore %1420 %2785
+%2786 = OpLoad %_arr_uchar_uint_16 %749
+%2787 = OpCompositeExtract %uchar %2786 15
+OpStore %1421 %2787
+%2788 = OpLoad %_arr_uchar_uint_16 %755
+%2789 = OpCompositeExtract %uchar %2788 15
+OpStore %1422 %2789
+%2790 = OpLoad %uchar %1421
+%2791 = OpLoad %uchar %1422
+%2792 = OpIMul %uchar %2790 %2791
+OpStore %1423 %2792
+%2793 = OpLoad %_arr_uchar_uint_16 %749
+%2794 = OpLoad %uchar %1378
+%2795 = OpCompositeInsert %_arr_uchar_uint_16 %2794 %2793 0
+OpStore %1424 %2795
+%2796 = OpLoad %_arr_uchar_uint_16 %1424
+%2797 = OpLoad %uchar %1381
+%2798 = OpCompositeInsert %_arr_uchar_uint_16 %2797 %2796 1
+OpStore %1425 %2798
+%2799 = OpLoad %_arr_uchar_uint_16 %1425
+%2800 = OpLoad %uchar %1384
+%2801 = OpCompositeInsert %_arr_uchar_uint_16 %2800 %2799 2
+OpStore %1426 %2801
+%2802 = OpLoad %_arr_uchar_uint_16 %1426
+%2803 = OpLoad %uchar %1387
+%2804 = OpCompositeInsert %_arr_uchar_uint_16 %2803 %2802 3
+OpStore %1427 %2804
+%2805 = OpLoad %_arr_uchar_uint_16 %1427
+%2806 = OpLoad %uchar %1390
+%2807 = OpCompositeInsert %_arr_uchar_uint_16 %2806 %2805 4
+OpStore %1428 %2807
+%2808 = OpLoad %_arr_uchar_uint_16 %1428
+%2809 = OpLoad %uchar %1393
+%2810 = OpCompositeInsert %_arr_uchar_uint_16 %2809 %2808 5
+OpStore %1429 %2810
+%2811 = OpLoad %_arr_uchar_uint_16 %1429
+%2812 = OpLoad %uchar %1396
+%2813 = OpCompositeInsert %_arr_uchar_uint_16 %2812 %2811 6
+OpStore %1430 %2813
+%2814 = OpLoad %_arr_uchar_uint_16 %1430
+%2815 = OpLoad %uchar %1399
+%2816 = OpCompositeInsert %_arr_uchar_uint_16 %2815 %2814 7
+OpStore %1431 %2816
+%2817 = OpLoad %_arr_uchar_uint_16 %1431
+%2818 = OpLoad %uchar %1402
+%2819 = OpCompositeInsert %_arr_uchar_uint_16 %2818 %2817 8
+OpStore %1432 %2819
+%2820 = OpLoad %_arr_uchar_uint_16 %1432
+%2821 = OpLoad %uchar %1405
+%2822 = OpCompositeInsert %_arr_uchar_uint_16 %2821 %2820 9
+OpStore %1433 %2822
+%2823 = OpLoad %_arr_uchar_uint_16 %1433
+%2824 = OpLoad %uchar %1408
+%2825 = OpCompositeInsert %_arr_uchar_uint_16 %2824 %2823 10
+OpStore %1434 %2825
+%2826 = OpLoad %_arr_uchar_uint_16 %1434
+%2827 = OpLoad %uchar %1411
+%2828 = OpCompositeInsert %_arr_uchar_uint_16 %2827 %2826 11
+OpStore %1435 %2828
+%2829 = OpLoad %_arr_uchar_uint_16 %1435
+%2830 = OpLoad %uchar %1414
+%2831 = OpCompositeInsert %_arr_uchar_uint_16 %2830 %2829 12
+OpStore %1436 %2831
+%2832 = OpLoad %_arr_uchar_uint_16 %1436
+%2833 = OpLoad %uchar %1417
+%2834 = OpCompositeInsert %_arr_uchar_uint_16 %2833 %2832 13
+OpStore %1437 %2834
+%2835 = OpLoad %_arr_uchar_uint_16 %1437
+%2836 = OpLoad %uchar %1420
+%2837 = OpCompositeInsert %_arr_uchar_uint_16 %2836 %2835 14
+OpStore %1438 %2837
+%2838 = OpLoad %_arr_uchar_uint_16 %1438
+%2839 = OpLoad %uchar %1423
+%2840 = OpCompositeInsert %_arr_uchar_uint_16 %2839 %2838 15
+OpStore %1439 %2840
+%2841 = OpLoad %ulong %760
+%2842 = OpLoad %_arr_uchar_uint_16 %1439
+%2843 = OpFunctionCall %ulong %1 %2841 %2842
+OpStore %761 %2843
+%2844 = OpLoad %_arr_uchar_uint_16 %749
+%2845 = OpCompositeExtract %uchar %2844 0
+OpStore %1440 %2845
+%2846 = OpLoad %_arr_uchar_uint_16 %742
+%2847 = OpCompositeExtract %uchar %2846 0
+OpStore %1441 %2847
+%2848 = OpLoad %uchar %1440
+%2849 = OpLoad %uchar %1441
+%2850 = OpIMul %uchar %2848 %2849
+OpStore %1442 %2850
+%2851 = OpLoad %_arr_uchar_uint_16 %749
+%2852 = OpCompositeExtract %uchar %2851 1
+OpStore %1443 %2852
+%2853 = OpLoad %_arr_uchar_uint_16 %742
+%2854 = OpCompositeExtract %uchar %2853 1
+OpStore %1444 %2854
+%2855 = OpLoad %uchar %1443
+%2856 = OpLoad %uchar %1444
+%2857 = OpIMul %uchar %2855 %2856
+OpStore %1445 %2857
+%2858 = OpLoad %_arr_uchar_uint_16 %749
+%2859 = OpCompositeExtract %uchar %2858 2
+OpStore %1446 %2859
+%2860 = OpLoad %_arr_uchar_uint_16 %742
+%2861 = OpCompositeExtract %uchar %2860 2
+OpStore %1447 %2861
+%2862 = OpLoad %uchar %1446
+%2863 = OpLoad %uchar %1447
+%2864 = OpIMul %uchar %2862 %2863
+OpStore %1448 %2864
+%2865 = OpLoad %_arr_uchar_uint_16 %749
+%2866 = OpCompositeExtract %uchar %2865 3
+OpStore %1449 %2866
+%2867 = OpLoad %_arr_uchar_uint_16 %742
+%2868 = OpCompositeExtract %uchar %2867 3
+OpStore %1450 %2868
+%2869 = OpLoad %uchar %1449
+%2870 = OpLoad %uchar %1450
+%2871 = OpIMul %uchar %2869 %2870
+OpStore %1451 %2871
+%2872 = OpLoad %_arr_uchar_uint_16 %749
+%2873 = OpCompositeExtract %uchar %2872 4
+OpStore %1452 %2873
+%2874 = OpLoad %_arr_uchar_uint_16 %742
+%2875 = OpCompositeExtract %uchar %2874 4
+OpStore %1453 %2875
+%2876 = OpLoad %uchar %1452
+%2877 = OpLoad %uchar %1453
+%2878 = OpIMul %uchar %2876 %2877
+OpStore %1454 %2878
+%2879 = OpLoad %_arr_uchar_uint_16 %749
+%2880 = OpCompositeExtract %uchar %2879 5
+OpStore %1455 %2880
+%2881 = OpLoad %_arr_uchar_uint_16 %742
+%2882 = OpCompositeExtract %uchar %2881 5
+OpStore %1456 %2882
+%2883 = OpLoad %uchar %1455
+%2884 = OpLoad %uchar %1456
+%2885 = OpIMul %uchar %2883 %2884
+OpStore %1457 %2885
+%2886 = OpLoad %_arr_uchar_uint_16 %749
+%2887 = OpCompositeExtract %uchar %2886 6
+OpStore %1458 %2887
+%2888 = OpLoad %_arr_uchar_uint_16 %742
+%2889 = OpCompositeExtract %uchar %2888 6
+OpStore %1459 %2889
+%2890 = OpLoad %uchar %1458
+%2891 = OpLoad %uchar %1459
+%2892 = OpIMul %uchar %2890 %2891
+OpStore %1460 %2892
+%2893 = OpLoad %_arr_uchar_uint_16 %749
+%2894 = OpCompositeExtract %uchar %2893 7
+OpStore %1461 %2894
+%2895 = OpLoad %_arr_uchar_uint_16 %742
+%2896 = OpCompositeExtract %uchar %2895 7
+OpStore %1462 %2896
+%2897 = OpLoad %uchar %1461
+%2898 = OpLoad %uchar %1462
+%2899 = OpIMul %uchar %2897 %2898
+OpStore %1463 %2899
+%2900 = OpLoad %_arr_uchar_uint_16 %749
+%2901 = OpCompositeExtract %uchar %2900 8
+OpStore %1464 %2901
+%2902 = OpLoad %_arr_uchar_uint_16 %742
+%2903 = OpCompositeExtract %uchar %2902 8
+OpStore %1465 %2903
+%2904 = OpLoad %uchar %1464
+%2905 = OpLoad %uchar %1465
+%2906 = OpIMul %uchar %2904 %2905
+OpStore %1466 %2906
+%2907 = OpLoad %_arr_uchar_uint_16 %749
+%2908 = OpCompositeExtract %uchar %2907 9
+OpStore %1467 %2908
+%2909 = OpLoad %_arr_uchar_uint_16 %742
+%2910 = OpCompositeExtract %uchar %2909 9
+OpStore %1468 %2910
+%2911 = OpLoad %uchar %1467
+%2912 = OpLoad %uchar %1468
+%2913 = OpIMul %uchar %2911 %2912
+OpStore %1469 %2913
+%2914 = OpLoad %_arr_uchar_uint_16 %749
+%2915 = OpCompositeExtract %uchar %2914 10
+OpStore %1470 %2915
+%2916 = OpLoad %_arr_uchar_uint_16 %742
+%2917 = OpCompositeExtract %uchar %2916 10
+OpStore %1471 %2917
+%2918 = OpLoad %uchar %1470
+%2919 = OpLoad %uchar %1471
+%2920 = OpIMul %uchar %2918 %2919
+OpStore %1472 %2920
+%2921 = OpLoad %_arr_uchar_uint_16 %749
+%2922 = OpCompositeExtract %uchar %2921 11
+OpStore %1473 %2922
+%2923 = OpLoad %_arr_uchar_uint_16 %742
+%2924 = OpCompositeExtract %uchar %2923 11
+OpStore %1474 %2924
+%2925 = OpLoad %uchar %1473
+%2926 = OpLoad %uchar %1474
+%2927 = OpIMul %uchar %2925 %2926
+OpStore %1475 %2927
+%2928 = OpLoad %_arr_uchar_uint_16 %749
+%2929 = OpCompositeExtract %uchar %2928 12
+OpStore %1476 %2929
+%2930 = OpLoad %_arr_uchar_uint_16 %742
+%2931 = OpCompositeExtract %uchar %2930 12
+OpStore %1477 %2931
+%2932 = OpLoad %uchar %1476
+%2933 = OpLoad %uchar %1477
+%2934 = OpIMul %uchar %2932 %2933
+OpStore %1478 %2934
+%2935 = OpLoad %_arr_uchar_uint_16 %749
+%2936 = OpCompositeExtract %uchar %2935 13
+OpStore %1479 %2936
+%2937 = OpLoad %_arr_uchar_uint_16 %742
+%2938 = OpCompositeExtract %uchar %2937 13
+OpStore %1480 %2938
+%2939 = OpLoad %uchar %1479
+%2940 = OpLoad %uchar %1480
+%2941 = OpIMul %uchar %2939 %2940
+OpStore %1481 %2941
+%2942 = OpLoad %_arr_uchar_uint_16 %749
+%2943 = OpCompositeExtract %uchar %2942 14
+OpStore %1482 %2943
+%2944 = OpLoad %_arr_uchar_uint_16 %742
+%2945 = OpCompositeExtract %uchar %2944 14
+OpStore %1483 %2945
+%2946 = OpLoad %uchar %1482
+%2947 = OpLoad %uchar %1483
+%2948 = OpIMul %uchar %2946 %2947
+OpStore %1484 %2948
+%2949 = OpLoad %_arr_uchar_uint_16 %749
+%2950 = OpCompositeExtract %uchar %2949 15
+OpStore %1485 %2950
+%2951 = OpLoad %_arr_uchar_uint_16 %742
+%2952 = OpCompositeExtract %uchar %2951 15
+OpStore %1486 %2952
+%2953 = OpLoad %uchar %1485
+%2954 = OpLoad %uchar %1486
+%2955 = OpIMul %uchar %2953 %2954
+OpStore %1487 %2955
+%2956 = OpLoad %_arr_uchar_uint_16 %749
+%2957 = OpLoad %uchar %1442
+%2958 = OpCompositeInsert %_arr_uchar_uint_16 %2957 %2956 0
+OpStore %1488 %2958
+%2959 = OpLoad %_arr_uchar_uint_16 %1488
+%2960 = OpLoad %uchar %1445
+%2961 = OpCompositeInsert %_arr_uchar_uint_16 %2960 %2959 1
+OpStore %1489 %2961
+%2962 = OpLoad %_arr_uchar_uint_16 %1489
+%2963 = OpLoad %uchar %1448
+%2964 = OpCompositeInsert %_arr_uchar_uint_16 %2963 %2962 2
+OpStore %1490 %2964
+%2965 = OpLoad %_arr_uchar_uint_16 %1490
+%2966 = OpLoad %uchar %1451
+%2967 = OpCompositeInsert %_arr_uchar_uint_16 %2966 %2965 3
+OpStore %1491 %2967
+%2968 = OpLoad %_arr_uchar_uint_16 %1491
+%2969 = OpLoad %uchar %1454
+%2970 = OpCompositeInsert %_arr_uchar_uint_16 %2969 %2968 4
+OpStore %1492 %2970
+%2971 = OpLoad %_arr_uchar_uint_16 %1492
+%2972 = OpLoad %uchar %1457
+%2973 = OpCompositeInsert %_arr_uchar_uint_16 %2972 %2971 5
+OpStore %1493 %2973
+%2974 = OpLoad %_arr_uchar_uint_16 %1493
+%2975 = OpLoad %uchar %1460
+%2976 = OpCompositeInsert %_arr_uchar_uint_16 %2975 %2974 6
+OpStore %1494 %2976
+%2977 = OpLoad %_arr_uchar_uint_16 %1494
+%2978 = OpLoad %uchar %1463
+%2979 = OpCompositeInsert %_arr_uchar_uint_16 %2978 %2977 7
+OpStore %1495 %2979
+%2980 = OpLoad %_arr_uchar_uint_16 %1495
+%2981 = OpLoad %uchar %1466
+%2982 = OpCompositeInsert %_arr_uchar_uint_16 %2981 %2980 8
+OpStore %1496 %2982
+%2983 = OpLoad %_arr_uchar_uint_16 %1496
+%2984 = OpLoad %uchar %1469
+%2985 = OpCompositeInsert %_arr_uchar_uint_16 %2984 %2983 9
+OpStore %1497 %2985
+%2986 = OpLoad %_arr_uchar_uint_16 %1497
+%2987 = OpLoad %uchar %1472
+%2988 = OpCompositeInsert %_arr_uchar_uint_16 %2987 %2986 10
+OpStore %1498 %2988
+%2989 = OpLoad %_arr_uchar_uint_16 %1498
+%2990 = OpLoad %uchar %1475
+%2991 = OpCompositeInsert %_arr_uchar_uint_16 %2990 %2989 11
+OpStore %1499 %2991
+%2992 = OpLoad %_arr_uchar_uint_16 %1499
+%2993 = OpLoad %uchar %1478
+%2994 = OpCompositeInsert %_arr_uchar_uint_16 %2993 %2992 12
+OpStore %1500 %2994
+%2995 = OpLoad %_arr_uchar_uint_16 %1500
+%2996 = OpLoad %uchar %1481
+%2997 = OpCompositeInsert %_arr_uchar_uint_16 %2996 %2995 13
+OpStore %1501 %2997
+%2998 = OpLoad %_arr_uchar_uint_16 %1501
+%2999 = OpLoad %uchar %1484
+%3000 = OpCompositeInsert %_arr_uchar_uint_16 %2999 %2998 14
+OpStore %1502 %3000
+%3001 = OpLoad %_arr_uchar_uint_16 %1502
+%3002 = OpLoad %uchar %1487
+%3003 = OpCompositeInsert %_arr_uchar_uint_16 %3002 %3001 15
+OpStore %1503 %3003
+%3004 = OpLoad %ulong %761
+%3005 = OpLoad %_arr_uchar_uint_16 %1503
+%3006 = OpFunctionCall %ulong %1 %3004 %3005
+OpStore %762 %3006
+%3007 = OpLoad %_arr_uchar_uint_16 %755
+%3008 = OpCompositeExtract %uchar %3007 0
+OpStore %1504 %3008
+%3009 = OpLoad %_arr_uchar_uint_16 %742
+%3010 = OpCompositeExtract %uchar %3009 0
+OpStore %1505 %3010
+%3011 = OpLoad %uchar %1504
+%3012 = OpLoad %uchar %1505
+%3013 = OpIMul %uchar %3011 %3012
+OpStore %1506 %3013
+%3014 = OpLoad %_arr_uchar_uint_16 %755
+%3015 = OpCompositeExtract %uchar %3014 1
+OpStore %1507 %3015
+%3016 = OpLoad %_arr_uchar_uint_16 %742
+%3017 = OpCompositeExtract %uchar %3016 1
+OpStore %1508 %3017
+%3018 = OpLoad %uchar %1507
+%3019 = OpLoad %uchar %1508
+%3020 = OpIMul %uchar %3018 %3019
+OpStore %1509 %3020
+%3021 = OpLoad %_arr_uchar_uint_16 %755
+%3022 = OpCompositeExtract %uchar %3021 2
+OpStore %1510 %3022
+%3023 = OpLoad %_arr_uchar_uint_16 %742
+%3024 = OpCompositeExtract %uchar %3023 2
+OpStore %1511 %3024
+%3025 = OpLoad %uchar %1510
+%3026 = OpLoad %uchar %1511
+%3027 = OpIMul %uchar %3025 %3026
+OpStore %1512 %3027
+%3028 = OpLoad %_arr_uchar_uint_16 %755
+%3029 = OpCompositeExtract %uchar %3028 3
+OpStore %1513 %3029
+%3030 = OpLoad %_arr_uchar_uint_16 %742
+%3031 = OpCompositeExtract %uchar %3030 3
+OpStore %1514 %3031
+%3032 = OpLoad %uchar %1513
+%3033 = OpLoad %uchar %1514
+%3034 = OpIMul %uchar %3032 %3033
+OpStore %1515 %3034
+%3035 = OpLoad %_arr_uchar_uint_16 %755
+%3036 = OpCompositeExtract %uchar %3035 4
+OpStore %1516 %3036
+%3037 = OpLoad %_arr_uchar_uint_16 %742
+%3038 = OpCompositeExtract %uchar %3037 4
+OpStore %1517 %3038
+%3039 = OpLoad %uchar %1516
+%3040 = OpLoad %uchar %1517
+%3041 = OpIMul %uchar %3039 %3040
+OpStore %1518 %3041
+%3042 = OpLoad %_arr_uchar_uint_16 %755
+%3043 = OpCompositeExtract %uchar %3042 5
+OpStore %1519 %3043
+%3044 = OpLoad %_arr_uchar_uint_16 %742
+%3045 = OpCompositeExtract %uchar %3044 5
+OpStore %1520 %3045
+%3046 = OpLoad %uchar %1519
+%3047 = OpLoad %uchar %1520
+%3048 = OpIMul %uchar %3046 %3047
+OpStore %1521 %3048
+%3049 = OpLoad %_arr_uchar_uint_16 %755
+%3050 = OpCompositeExtract %uchar %3049 6
+OpStore %1522 %3050
+%3051 = OpLoad %_arr_uchar_uint_16 %742
+%3052 = OpCompositeExtract %uchar %3051 6
+OpStore %1523 %3052
+%3053 = OpLoad %uchar %1522
+%3054 = OpLoad %uchar %1523
+%3055 = OpIMul %uchar %3053 %3054
+OpStore %1524 %3055
+%3056 = OpLoad %_arr_uchar_uint_16 %755
+%3057 = OpCompositeExtract %uchar %3056 7
+OpStore %1525 %3057
+%3058 = OpLoad %_arr_uchar_uint_16 %742
+%3059 = OpCompositeExtract %uchar %3058 7
+OpStore %1526 %3059
+%3060 = OpLoad %uchar %1525
+%3061 = OpLoad %uchar %1526
+%3062 = OpIMul %uchar %3060 %3061
+OpStore %1527 %3062
+%3063 = OpLoad %_arr_uchar_uint_16 %755
+%3064 = OpCompositeExtract %uchar %3063 8
+OpStore %1528 %3064
+%3065 = OpLoad %_arr_uchar_uint_16 %742
+%3066 = OpCompositeExtract %uchar %3065 8
+OpStore %1529 %3066
+%3067 = OpLoad %uchar %1528
+%3068 = OpLoad %uchar %1529
+%3069 = OpIMul %uchar %3067 %3068
+OpStore %1530 %3069
+%3070 = OpLoad %_arr_uchar_uint_16 %755
+%3071 = OpCompositeExtract %uchar %3070 9
+OpStore %1531 %3071
+%3072 = OpLoad %_arr_uchar_uint_16 %742
+%3073 = OpCompositeExtract %uchar %3072 9
+OpStore %1532 %3073
+%3074 = OpLoad %uchar %1531
+%3075 = OpLoad %uchar %1532
+%3076 = OpIMul %uchar %3074 %3075
+OpStore %1533 %3076
+%3077 = OpLoad %_arr_uchar_uint_16 %755
+%3078 = OpCompositeExtract %uchar %3077 10
+OpStore %1534 %3078
+%3079 = OpLoad %_arr_uchar_uint_16 %742
+%3080 = OpCompositeExtract %uchar %3079 10
+OpStore %1535 %3080
+%3081 = OpLoad %uchar %1534
+%3082 = OpLoad %uchar %1535
+%3083 = OpIMul %uchar %3081 %3082
+OpStore %1536 %3083
+%3084 = OpLoad %_arr_uchar_uint_16 %755
+%3085 = OpCompositeExtract %uchar %3084 11
+OpStore %1537 %3085
+%3086 = OpLoad %_arr_uchar_uint_16 %742
+%3087 = OpCompositeExtract %uchar %3086 11
+OpStore %1538 %3087
+%3088 = OpLoad %uchar %1537
+%3089 = OpLoad %uchar %1538
+%3090 = OpIMul %uchar %3088 %3089
+OpStore %1539 %3090
+%3091 = OpLoad %_arr_uchar_uint_16 %755
+%3092 = OpCompositeExtract %uchar %3091 12
+OpStore %1540 %3092
+%3093 = OpLoad %_arr_uchar_uint_16 %742
+%3094 = OpCompositeExtract %uchar %3093 12
+OpStore %1541 %3094
+%3095 = OpLoad %uchar %1540
+%3096 = OpLoad %uchar %1541
+%3097 = OpIMul %uchar %3095 %3096
+OpStore %1542 %3097
+%3098 = OpLoad %_arr_uchar_uint_16 %755
+%3099 = OpCompositeExtract %uchar %3098 13
+OpStore %1543 %3099
+%3100 = OpLoad %_arr_uchar_uint_16 %742
+%3101 = OpCompositeExtract %uchar %3100 13
+OpStore %1544 %3101
+%3102 = OpLoad %uchar %1543
+%3103 = OpLoad %uchar %1544
+%3104 = OpIMul %uchar %3102 %3103
+OpStore %1545 %3104
+%3105 = OpLoad %_arr_uchar_uint_16 %755
+%3106 = OpCompositeExtract %uchar %3105 14
+OpStore %1546 %3106
+%3107 = OpLoad %_arr_uchar_uint_16 %742
+%3108 = OpCompositeExtract %uchar %3107 14
+OpStore %1547 %3108
+%3109 = OpLoad %uchar %1546
+%3110 = OpLoad %uchar %1547
+%3111 = OpIMul %uchar %3109 %3110
+OpStore %1548 %3111
+%3112 = OpLoad %_arr_uchar_uint_16 %755
+%3113 = OpCompositeExtract %uchar %3112 15
+OpStore %1549 %3113
+%3114 = OpLoad %_arr_uchar_uint_16 %742
+%3115 = OpCompositeExtract %uchar %3114 15
+OpStore %1550 %3115
+%3116 = OpLoad %uchar %1549
+%3117 = OpLoad %uchar %1550
+%3118 = OpIMul %uchar %3116 %3117
+OpStore %1551 %3118
+%3119 = OpLoad %_arr_uchar_uint_16 %755
+%3120 = OpLoad %uchar %1506
+%3121 = OpCompositeInsert %_arr_uchar_uint_16 %3120 %3119 0
+OpStore %1552 %3121
+%3122 = OpLoad %_arr_uchar_uint_16 %1552
+%3123 = OpLoad %uchar %1509
+%3124 = OpCompositeInsert %_arr_uchar_uint_16 %3123 %3122 1
+OpStore %1553 %3124
+%3125 = OpLoad %_arr_uchar_uint_16 %1553
+%3126 = OpLoad %uchar %1512
+%3127 = OpCompositeInsert %_arr_uchar_uint_16 %3126 %3125 2
+OpStore %1554 %3127
+%3128 = OpLoad %_arr_uchar_uint_16 %1554
+%3129 = OpLoad %uchar %1515
+%3130 = OpCompositeInsert %_arr_uchar_uint_16 %3129 %3128 3
+OpStore %1555 %3130
+%3131 = OpLoad %_arr_uchar_uint_16 %1555
+%3132 = OpLoad %uchar %1518
+%3133 = OpCompositeInsert %_arr_uchar_uint_16 %3132 %3131 4
+OpStore %1556 %3133
+%3134 = OpLoad %_arr_uchar_uint_16 %1556
+%3135 = OpLoad %uchar %1521
+%3136 = OpCompositeInsert %_arr_uchar_uint_16 %3135 %3134 5
+OpStore %1557 %3136
+%3137 = OpLoad %_arr_uchar_uint_16 %1557
+%3138 = OpLoad %uchar %1524
+%3139 = OpCompositeInsert %_arr_uchar_uint_16 %3138 %3137 6
+OpStore %1558 %3139
+%3140 = OpLoad %_arr_uchar_uint_16 %1558
+%3141 = OpLoad %uchar %1527
+%3142 = OpCompositeInsert %_arr_uchar_uint_16 %3141 %3140 7
+OpStore %1559 %3142
+%3143 = OpLoad %_arr_uchar_uint_16 %1559
+%3144 = OpLoad %uchar %1530
+%3145 = OpCompositeInsert %_arr_uchar_uint_16 %3144 %3143 8
+OpStore %1560 %3145
+%3146 = OpLoad %_arr_uchar_uint_16 %1560
+%3147 = OpLoad %uchar %1533
+%3148 = OpCompositeInsert %_arr_uchar_uint_16 %3147 %3146 9
+OpStore %1561 %3148
+%3149 = OpLoad %_arr_uchar_uint_16 %1561
+%3150 = OpLoad %uchar %1536
+%3151 = OpCompositeInsert %_arr_uchar_uint_16 %3150 %3149 10
+OpStore %1562 %3151
+%3152 = OpLoad %_arr_uchar_uint_16 %1562
+%3153 = OpLoad %uchar %1539
+%3154 = OpCompositeInsert %_arr_uchar_uint_16 %3153 %3152 11
+OpStore %1563 %3154
+%3155 = OpLoad %_arr_uchar_uint_16 %1563
+%3156 = OpLoad %uchar %1542
+%3157 = OpCompositeInsert %_arr_uchar_uint_16 %3156 %3155 12
+OpStore %1564 %3157
+%3158 = OpLoad %_arr_uchar_uint_16 %1564
+%3159 = OpLoad %uchar %1545
+%3160 = OpCompositeInsert %_arr_uchar_uint_16 %3159 %3158 13
+OpStore %1565 %3160
+%3161 = OpLoad %_arr_uchar_uint_16 %1565
+%3162 = OpLoad %uchar %1548
+%3163 = OpCompositeInsert %_arr_uchar_uint_16 %3162 %3161 14
+OpStore %1566 %3163
+%3164 = OpLoad %_arr_uchar_uint_16 %1566
+%3165 = OpLoad %uchar %1551
+%3166 = OpCompositeInsert %_arr_uchar_uint_16 %3165 %3164 15
+OpStore %1567 %3166
+%3167 = OpLoad %ulong %762
+%3168 = OpLoad %_arr_uchar_uint_16 %1567
+%3169 = OpFunctionCall %ulong %1 %3167 %3168
+OpStore %763 %3169
+%3170 = OpLoad %_arr_uchar_uint_16 %1247
+%3171 = OpCompositeExtract %uchar %3170 0
+OpStore %1568 %3171
+%3172 = OpLoad %_arr_uchar_uint_16 %742
+%3173 = OpCompositeExtract %uchar %3172 0
+OpStore %1569 %3173
+%3174 = OpLoad %uchar %1568
+%3175 = OpLoad %uchar %1569
+%3176 = OpIMul %uchar %3174 %3175
+OpStore %1570 %3176
+%3177 = OpLoad %_arr_uchar_uint_16 %1247
+%3178 = OpCompositeExtract %uchar %3177 1
+OpStore %1571 %3178
+%3179 = OpLoad %_arr_uchar_uint_16 %742
+%3180 = OpCompositeExtract %uchar %3179 1
+OpStore %1572 %3180
+%3181 = OpLoad %uchar %1571
+%3182 = OpLoad %uchar %1572
+%3183 = OpIMul %uchar %3181 %3182
+OpStore %1573 %3183
+%3184 = OpLoad %_arr_uchar_uint_16 %1247
+%3185 = OpCompositeExtract %uchar %3184 2
+OpStore %1574 %3185
+%3186 = OpLoad %_arr_uchar_uint_16 %742
+%3187 = OpCompositeExtract %uchar %3186 2
+OpStore %1575 %3187
+%3188 = OpLoad %uchar %1574
+%3189 = OpLoad %uchar %1575
+%3190 = OpIMul %uchar %3188 %3189
+OpStore %1576 %3190
+%3191 = OpLoad %_arr_uchar_uint_16 %1247
+%3192 = OpCompositeExtract %uchar %3191 3
+OpStore %1577 %3192
+%3193 = OpLoad %_arr_uchar_uint_16 %742
+%3194 = OpCompositeExtract %uchar %3193 3
+OpStore %1578 %3194
+%3195 = OpLoad %uchar %1577
+%3196 = OpLoad %uchar %1578
+%3197 = OpIMul %uchar %3195 %3196
+OpStore %1579 %3197
+%3198 = OpLoad %_arr_uchar_uint_16 %1247
+%3199 = OpCompositeExtract %uchar %3198 4
+OpStore %1580 %3199
+%3200 = OpLoad %_arr_uchar_uint_16 %742
+%3201 = OpCompositeExtract %uchar %3200 4
+OpStore %1581 %3201
+%3202 = OpLoad %uchar %1580
+%3203 = OpLoad %uchar %1581
+%3204 = OpIMul %uchar %3202 %3203
+OpStore %1582 %3204
+%3205 = OpLoad %_arr_uchar_uint_16 %1247
+%3206 = OpCompositeExtract %uchar %3205 5
+OpStore %1583 %3206
+%3207 = OpLoad %_arr_uchar_uint_16 %742
+%3208 = OpCompositeExtract %uchar %3207 5
+OpStore %1584 %3208
+%3209 = OpLoad %uchar %1583
+%3210 = OpLoad %uchar %1584
+%3211 = OpIMul %uchar %3209 %3210
+OpStore %1585 %3211
+%3212 = OpLoad %_arr_uchar_uint_16 %1247
+%3213 = OpCompositeExtract %uchar %3212 6
+OpStore %1586 %3213
+%3214 = OpLoad %_arr_uchar_uint_16 %742
+%3215 = OpCompositeExtract %uchar %3214 6
+OpStore %1587 %3215
+%3216 = OpLoad %uchar %1586
+%3217 = OpLoad %uchar %1587
+%3218 = OpIMul %uchar %3216 %3217
+OpStore %1588 %3218
+%3219 = OpLoad %_arr_uchar_uint_16 %1247
+%3220 = OpCompositeExtract %uchar %3219 7
+OpStore %1589 %3220
+%3221 = OpLoad %_arr_uchar_uint_16 %742
+%3222 = OpCompositeExtract %uchar %3221 7
+OpStore %1590 %3222
+%3223 = OpLoad %uchar %1589
+%3224 = OpLoad %uchar %1590
+%3225 = OpIMul %uchar %3223 %3224
+OpStore %1591 %3225
+%3226 = OpLoad %_arr_uchar_uint_16 %1247
+%3227 = OpCompositeExtract %uchar %3226 8
+OpStore %1592 %3227
+%3228 = OpLoad %_arr_uchar_uint_16 %742
+%3229 = OpCompositeExtract %uchar %3228 8
+OpStore %1593 %3229
+%3230 = OpLoad %uchar %1592
+%3231 = OpLoad %uchar %1593
+%3232 = OpIMul %uchar %3230 %3231
+OpStore %1594 %3232
+%3233 = OpLoad %_arr_uchar_uint_16 %1247
+%3234 = OpCompositeExtract %uchar %3233 9
+OpStore %1595 %3234
+%3235 = OpLoad %_arr_uchar_uint_16 %742
+%3236 = OpCompositeExtract %uchar %3235 9
+OpStore %1596 %3236
+%3237 = OpLoad %uchar %1595
+%3238 = OpLoad %uchar %1596
+%3239 = OpIMul %uchar %3237 %3238
+OpStore %1597 %3239
+%3240 = OpLoad %_arr_uchar_uint_16 %1247
+%3241 = OpCompositeExtract %uchar %3240 10
+OpStore %1598 %3241
+%3242 = OpLoad %_arr_uchar_uint_16 %742
+%3243 = OpCompositeExtract %uchar %3242 10
+OpStore %1599 %3243
+%3244 = OpLoad %uchar %1598
+%3245 = OpLoad %uchar %1599
+%3246 = OpIMul %uchar %3244 %3245
+OpStore %1600 %3246
+%3247 = OpLoad %_arr_uchar_uint_16 %1247
+%3248 = OpCompositeExtract %uchar %3247 11
+OpStore %1601 %3248
+%3249 = OpLoad %_arr_uchar_uint_16 %742
+%3250 = OpCompositeExtract %uchar %3249 11
+OpStore %1602 %3250
+%3251 = OpLoad %uchar %1601
+%3252 = OpLoad %uchar %1602
+%3253 = OpIMul %uchar %3251 %3252
+OpStore %1603 %3253
+%3254 = OpLoad %_arr_uchar_uint_16 %1247
+%3255 = OpCompositeExtract %uchar %3254 12
+OpStore %1604 %3255
+%3256 = OpLoad %_arr_uchar_uint_16 %742
+%3257 = OpCompositeExtract %uchar %3256 12
+OpStore %1605 %3257
+%3258 = OpLoad %uchar %1604
+%3259 = OpLoad %uchar %1605
+%3260 = OpIMul %uchar %3258 %3259
+OpStore %1606 %3260
+%3261 = OpLoad %_arr_uchar_uint_16 %1247
+%3262 = OpCompositeExtract %uchar %3261 13
+OpStore %1607 %3262
+%3263 = OpLoad %_arr_uchar_uint_16 %742
+%3264 = OpCompositeExtract %uchar %3263 13
+OpStore %1608 %3264
+%3265 = OpLoad %uchar %1607
+%3266 = OpLoad %uchar %1608
+%3267 = OpIMul %uchar %3265 %3266
+OpStore %1609 %3267
+%3268 = OpLoad %_arr_uchar_uint_16 %1247
+%3269 = OpCompositeExtract %uchar %3268 14
+OpStore %1610 %3269
+%3270 = OpLoad %_arr_uchar_uint_16 %742
+%3271 = OpCompositeExtract %uchar %3270 14
+OpStore %1611 %3271
+%3272 = OpLoad %uchar %1610
+%3273 = OpLoad %uchar %1611
+%3274 = OpIMul %uchar %3272 %3273
+OpStore %1612 %3274
+%3275 = OpLoad %_arr_uchar_uint_16 %1247
+%3276 = OpCompositeExtract %uchar %3275 15
+OpStore %1613 %3276
+%3277 = OpLoad %_arr_uchar_uint_16 %742
+%3278 = OpCompositeExtract %uchar %3277 15
+OpStore %1614 %3278
+%3279 = OpLoad %uchar %1613
+%3280 = OpLoad %uchar %1614
+%3281 = OpIMul %uchar %3279 %3280
+OpStore %1615 %3281
+%3282 = OpLoad %_arr_uchar_uint_16 %1247
+%3283 = OpLoad %uchar %1570
+%3284 = OpCompositeInsert %_arr_uchar_uint_16 %3283 %3282 0
+OpStore %1616 %3284
+%3285 = OpLoad %_arr_uchar_uint_16 %1616
+%3286 = OpLoad %uchar %1573
+%3287 = OpCompositeInsert %_arr_uchar_uint_16 %3286 %3285 1
+OpStore %1617 %3287
+%3288 = OpLoad %_arr_uchar_uint_16 %1617
+%3289 = OpLoad %uchar %1576
+%3290 = OpCompositeInsert %_arr_uchar_uint_16 %3289 %3288 2
+OpStore %1618 %3290
+%3291 = OpLoad %_arr_uchar_uint_16 %1618
+%3292 = OpLoad %uchar %1579
+%3293 = OpCompositeInsert %_arr_uchar_uint_16 %3292 %3291 3
+OpStore %1619 %3293
+%3294 = OpLoad %_arr_uchar_uint_16 %1619
+%3295 = OpLoad %uchar %1582
+%3296 = OpCompositeInsert %_arr_uchar_uint_16 %3295 %3294 4
+OpStore %1620 %3296
+%3297 = OpLoad %_arr_uchar_uint_16 %1620
+%3298 = OpLoad %uchar %1585
+%3299 = OpCompositeInsert %_arr_uchar_uint_16 %3298 %3297 5
+OpStore %1621 %3299
+%3300 = OpLoad %_arr_uchar_uint_16 %1621
+%3301 = OpLoad %uchar %1588
+%3302 = OpCompositeInsert %_arr_uchar_uint_16 %3301 %3300 6
+OpStore %1622 %3302
+%3303 = OpLoad %_arr_uchar_uint_16 %1622
+%3304 = OpLoad %uchar %1591
+%3305 = OpCompositeInsert %_arr_uchar_uint_16 %3304 %3303 7
+OpStore %1623 %3305
+%3306 = OpLoad %_arr_uchar_uint_16 %1623
+%3307 = OpLoad %uchar %1594
+%3308 = OpCompositeInsert %_arr_uchar_uint_16 %3307 %3306 8
+OpStore %1624 %3308
+%3309 = OpLoad %_arr_uchar_uint_16 %1624
+%3310 = OpLoad %uchar %1597
+%3311 = OpCompositeInsert %_arr_uchar_uint_16 %3310 %3309 9
+OpStore %1625 %3311
+%3312 = OpLoad %_arr_uchar_uint_16 %1625
+%3313 = OpLoad %uchar %1600
+%3314 = OpCompositeInsert %_arr_uchar_uint_16 %3313 %3312 10
+OpStore %1626 %3314
+%3315 = OpLoad %_arr_uchar_uint_16 %1626
+%3316 = OpLoad %uchar %1603
+%3317 = OpCompositeInsert %_arr_uchar_uint_16 %3316 %3315 11
+OpStore %1627 %3317
+%3318 = OpLoad %_arr_uchar_uint_16 %1627
+%3319 = OpLoad %uchar %1606
+%3320 = OpCompositeInsert %_arr_uchar_uint_16 %3319 %3318 12
+OpStore %1628 %3320
+%3321 = OpLoad %_arr_uchar_uint_16 %1628
+%3322 = OpLoad %uchar %1609
+%3323 = OpCompositeInsert %_arr_uchar_uint_16 %3322 %3321 13
+OpStore %1629 %3323
+%3324 = OpLoad %_arr_uchar_uint_16 %1629
+%3325 = OpLoad %uchar %1612
+%3326 = OpCompositeInsert %_arr_uchar_uint_16 %3325 %3324 14
+OpStore %1630 %3326
+%3327 = OpLoad %_arr_uchar_uint_16 %1630
+%3328 = OpLoad %uchar %1615
+%3329 = OpCompositeInsert %_arr_uchar_uint_16 %3328 %3327 15
+OpStore %1631 %3329
+%3330 = OpLoad %ulong %763
+%3331 = OpLoad %_arr_uchar_uint_16 %1631
+%3332 = OpFunctionCall %ulong %1 %3330 %3331
+OpStore %764 %3332
+%3333 = OpLoad %_arr_uchar_uint_16 %743
+%3334 = OpCompositeExtract %uchar %3333 0
+OpStore %1632 %3334
+%3335 = OpLoad %_arr_uchar_uint_16 %749
+%3336 = OpCompositeExtract %uchar %3335 0
+OpStore %1633 %3336
+%3337 = OpLoad %uchar %1632
+%3338 = OpLoad %uchar %1633
+%3339 = OpISub %uchar %3337 %3338
+OpStore %1634 %3339
+%3340 = OpLoad %_arr_uchar_uint_16 %743
+%3341 = OpCompositeExtract %uchar %3340 1
+OpStore %1635 %3341
+%3342 = OpLoad %_arr_uchar_uint_16 %749
+%3343 = OpCompositeExtract %uchar %3342 1
+OpStore %1636 %3343
+%3344 = OpLoad %uchar %1635
+%3345 = OpLoad %uchar %1636
+%3346 = OpISub %uchar %3344 %3345
+OpStore %1637 %3346
+%3347 = OpLoad %_arr_uchar_uint_16 %743
+%3348 = OpCompositeExtract %uchar %3347 2
+OpStore %1638 %3348
+%3349 = OpLoad %_arr_uchar_uint_16 %749
+%3350 = OpCompositeExtract %uchar %3349 2
+OpStore %1639 %3350
+%3351 = OpLoad %uchar %1638
+%3352 = OpLoad %uchar %1639
+%3353 = OpISub %uchar %3351 %3352
+OpStore %1640 %3353
+%3354 = OpLoad %_arr_uchar_uint_16 %743
+%3355 = OpCompositeExtract %uchar %3354 3
+OpStore %1641 %3355
+%3356 = OpLoad %_arr_uchar_uint_16 %749
+%3357 = OpCompositeExtract %uchar %3356 3
+OpStore %1642 %3357
+%3358 = OpLoad %uchar %1641
+%3359 = OpLoad %uchar %1642
+%3360 = OpISub %uchar %3358 %3359
+OpStore %1643 %3360
+%3361 = OpLoad %_arr_uchar_uint_16 %743
+%3362 = OpCompositeExtract %uchar %3361 4
+OpStore %1644 %3362
+%3363 = OpLoad %_arr_uchar_uint_16 %749
+%3364 = OpCompositeExtract %uchar %3363 4
+OpStore %1645 %3364
+%3365 = OpLoad %uchar %1644
+%3366 = OpLoad %uchar %1645
+%3367 = OpISub %uchar %3365 %3366
+OpStore %1646 %3367
+%3368 = OpLoad %_arr_uchar_uint_16 %743
+%3369 = OpCompositeExtract %uchar %3368 5
+OpStore %1647 %3369
+%3370 = OpLoad %_arr_uchar_uint_16 %749
+%3371 = OpCompositeExtract %uchar %3370 5
+OpStore %1648 %3371
+%3372 = OpLoad %uchar %1647
+%3373 = OpLoad %uchar %1648
+%3374 = OpISub %uchar %3372 %3373
+OpStore %1649 %3374
+%3375 = OpLoad %_arr_uchar_uint_16 %743
+%3376 = OpCompositeExtract %uchar %3375 6
+OpStore %1650 %3376
+%3377 = OpLoad %_arr_uchar_uint_16 %749
+%3378 = OpCompositeExtract %uchar %3377 6
+OpStore %1651 %3378
+%3379 = OpLoad %uchar %1650
+%3380 = OpLoad %uchar %1651
+%3381 = OpISub %uchar %3379 %3380
+OpStore %1652 %3381
+%3382 = OpLoad %_arr_uchar_uint_16 %743
+%3383 = OpCompositeExtract %uchar %3382 7
+OpStore %1653 %3383
+%3384 = OpLoad %_arr_uchar_uint_16 %749
+%3385 = OpCompositeExtract %uchar %3384 7
+OpStore %1654 %3385
+%3386 = OpLoad %uchar %1653
+%3387 = OpLoad %uchar %1654
+%3388 = OpISub %uchar %3386 %3387
+OpStore %1655 %3388
+%3389 = OpLoad %_arr_uchar_uint_16 %743
+%3390 = OpCompositeExtract %uchar %3389 8
+OpStore %1656 %3390
+%3391 = OpLoad %_arr_uchar_uint_16 %749
+%3392 = OpCompositeExtract %uchar %3391 8
+OpStore %1657 %3392
+%3393 = OpLoad %uchar %1656
+%3394 = OpLoad %uchar %1657
+%3395 = OpISub %uchar %3393 %3394
+OpStore %1658 %3395
+%3396 = OpLoad %_arr_uchar_uint_16 %743
+%3397 = OpCompositeExtract %uchar %3396 9
+OpStore %1659 %3397
+%3398 = OpLoad %_arr_uchar_uint_16 %749
+%3399 = OpCompositeExtract %uchar %3398 9
+OpStore %1660 %3399
+%3400 = OpLoad %uchar %1659
+%3401 = OpLoad %uchar %1660
+%3402 = OpISub %uchar %3400 %3401
+OpStore %1661 %3402
+%3403 = OpLoad %_arr_uchar_uint_16 %743
+%3404 = OpCompositeExtract %uchar %3403 10
+OpStore %1662 %3404
+%3405 = OpLoad %_arr_uchar_uint_16 %749
+%3406 = OpCompositeExtract %uchar %3405 10
+OpStore %1663 %3406
+%3407 = OpLoad %uchar %1662
+%3408 = OpLoad %uchar %1663
+%3409 = OpISub %uchar %3407 %3408
+OpStore %1664 %3409
+%3410 = OpLoad %_arr_uchar_uint_16 %743
+%3411 = OpCompositeExtract %uchar %3410 11
+OpStore %1665 %3411
+%3412 = OpLoad %_arr_uchar_uint_16 %749
+%3413 = OpCompositeExtract %uchar %3412 11
+OpStore %1666 %3413
+%3414 = OpLoad %uchar %1665
+%3415 = OpLoad %uchar %1666
+%3416 = OpISub %uchar %3414 %3415
+OpStore %1667 %3416
+%3417 = OpLoad %_arr_uchar_uint_16 %743
+%3418 = OpCompositeExtract %uchar %3417 12
+OpStore %1668 %3418
+%3419 = OpLoad %_arr_uchar_uint_16 %749
+%3420 = OpCompositeExtract %uchar %3419 12
+OpStore %1669 %3420
+%3421 = OpLoad %uchar %1668
+%3422 = OpLoad %uchar %1669
+%3423 = OpISub %uchar %3421 %3422
+OpStore %1670 %3423
+%3424 = OpLoad %_arr_uchar_uint_16 %743
+%3425 = OpCompositeExtract %uchar %3424 13
+OpStore %1671 %3425
+%3426 = OpLoad %_arr_uchar_uint_16 %749
+%3427 = OpCompositeExtract %uchar %3426 13
+OpStore %1672 %3427
+%3428 = OpLoad %uchar %1671
+%3429 = OpLoad %uchar %1672
+%3430 = OpISub %uchar %3428 %3429
+OpStore %1673 %3430
+%3431 = OpLoad %_arr_uchar_uint_16 %743
+%3432 = OpCompositeExtract %uchar %3431 14
+OpStore %1674 %3432
+%3433 = OpLoad %_arr_uchar_uint_16 %749
+%3434 = OpCompositeExtract %uchar %3433 14
+OpStore %1675 %3434
+%3435 = OpLoad %uchar %1674
+%3436 = OpLoad %uchar %1675
+%3437 = OpISub %uchar %3435 %3436
+OpStore %1676 %3437
+%3438 = OpLoad %_arr_uchar_uint_16 %743
+%3439 = OpCompositeExtract %uchar %3438 15
+OpStore %1677 %3439
+%3440 = OpLoad %_arr_uchar_uint_16 %749
+%3441 = OpCompositeExtract %uchar %3440 15
+OpStore %1678 %3441
+%3442 = OpLoad %uchar %1677
+%3443 = OpLoad %uchar %1678
+%3444 = OpISub %uchar %3442 %3443
+OpStore %1679 %3444
+%3445 = OpLoad %_arr_uchar_uint_16 %743
+%3446 = OpLoad %uchar %1634
+%3447 = OpCompositeInsert %_arr_uchar_uint_16 %3446 %3445 0
+OpStore %1680 %3447
+%3448 = OpLoad %_arr_uchar_uint_16 %1680
+%3449 = OpLoad %uchar %1637
+%3450 = OpCompositeInsert %_arr_uchar_uint_16 %3449 %3448 1
+OpStore %1681 %3450
+%3451 = OpLoad %_arr_uchar_uint_16 %1681
+%3452 = OpLoad %uchar %1640
+%3453 = OpCompositeInsert %_arr_uchar_uint_16 %3452 %3451 2
+OpStore %1682 %3453
+%3454 = OpLoad %_arr_uchar_uint_16 %1682
+%3455 = OpLoad %uchar %1643
+%3456 = OpCompositeInsert %_arr_uchar_uint_16 %3455 %3454 3
+OpStore %1683 %3456
+%3457 = OpLoad %_arr_uchar_uint_16 %1683
+%3458 = OpLoad %uchar %1646
+%3459 = OpCompositeInsert %_arr_uchar_uint_16 %3458 %3457 4
+OpStore %1684 %3459
+%3460 = OpLoad %_arr_uchar_uint_16 %1684
+%3461 = OpLoad %uchar %1649
+%3462 = OpCompositeInsert %_arr_uchar_uint_16 %3461 %3460 5
+OpStore %1685 %3462
+%3463 = OpLoad %_arr_uchar_uint_16 %1685
+%3464 = OpLoad %uchar %1652
+%3465 = OpCompositeInsert %_arr_uchar_uint_16 %3464 %3463 6
+OpStore %1686 %3465
+%3466 = OpLoad %_arr_uchar_uint_16 %1686
+%3467 = OpLoad %uchar %1655
+%3468 = OpCompositeInsert %_arr_uchar_uint_16 %3467 %3466 7
+OpStore %1687 %3468
+%3469 = OpLoad %_arr_uchar_uint_16 %1687
+%3470 = OpLoad %uchar %1658
+%3471 = OpCompositeInsert %_arr_uchar_uint_16 %3470 %3469 8
+OpStore %1688 %3471
+%3472 = OpLoad %_arr_uchar_uint_16 %1688
+%3473 = OpLoad %uchar %1661
+%3474 = OpCompositeInsert %_arr_uchar_uint_16 %3473 %3472 9
+OpStore %1689 %3474
+%3475 = OpLoad %_arr_uchar_uint_16 %1689
+%3476 = OpLoad %uchar %1664
+%3477 = OpCompositeInsert %_arr_uchar_uint_16 %3476 %3475 10
+OpStore %1690 %3477
+%3478 = OpLoad %_arr_uchar_uint_16 %1690
+%3479 = OpLoad %uchar %1667
+%3480 = OpCompositeInsert %_arr_uchar_uint_16 %3479 %3478 11
+OpStore %1691 %3480
+%3481 = OpLoad %_arr_uchar_uint_16 %1691
+%3482 = OpLoad %uchar %1670
+%3483 = OpCompositeInsert %_arr_uchar_uint_16 %3482 %3481 12
+OpStore %1692 %3483
+%3484 = OpLoad %_arr_uchar_uint_16 %1692
+%3485 = OpLoad %uchar %1673
+%3486 = OpCompositeInsert %_arr_uchar_uint_16 %3485 %3484 13
+OpStore %1693 %3486
+%3487 = OpLoad %_arr_uchar_uint_16 %1693
+%3488 = OpLoad %uchar %1676
+%3489 = OpCompositeInsert %_arr_uchar_uint_16 %3488 %3487 14
+OpStore %1694 %3489
+%3490 = OpLoad %_arr_uchar_uint_16 %1694
+%3491 = OpLoad %uchar %1679
+%3492 = OpCompositeInsert %_arr_uchar_uint_16 %3491 %3490 15
+OpStore %1695 %3492
+%3493 = OpLoad %ulong %764
+%3494 = OpLoad %_arr_uchar_uint_16 %1695
+%3495 = OpFunctionCall %ulong %1 %3493 %3494
+OpStore %765 %3495
+%3496 = OpLoad %_arr_uchar_uint_16 %743
+%3497 = OpCompositeExtract %uchar %3496 0
+OpStore %1696 %3497
+%3498 = OpLoad %_arr_uchar_uint_16 %755
+%3499 = OpCompositeExtract %uchar %3498 0
+OpStore %1697 %3499
+%3500 = OpLoad %uchar %1696
+%3501 = OpLoad %uchar %1697
+%3502 = OpISub %uchar %3500 %3501
+OpStore %1698 %3502
+%3503 = OpLoad %_arr_uchar_uint_16 %743
+%3504 = OpCompositeExtract %uchar %3503 1
+OpStore %1699 %3504
+%3505 = OpLoad %_arr_uchar_uint_16 %755
+%3506 = OpCompositeExtract %uchar %3505 1
+OpStore %1700 %3506
+%3507 = OpLoad %uchar %1699
+%3508 = OpLoad %uchar %1700
+%3509 = OpISub %uchar %3507 %3508
+OpStore %1701 %3509
+%3510 = OpLoad %_arr_uchar_uint_16 %743
+%3511 = OpCompositeExtract %uchar %3510 2
+OpStore %1702 %3511
+%3512 = OpLoad %_arr_uchar_uint_16 %755
+%3513 = OpCompositeExtract %uchar %3512 2
+OpStore %1703 %3513
+%3514 = OpLoad %uchar %1702
+%3515 = OpLoad %uchar %1703
+%3516 = OpISub %uchar %3514 %3515
+OpStore %1704 %3516
+%3517 = OpLoad %_arr_uchar_uint_16 %743
+%3518 = OpCompositeExtract %uchar %3517 3
+OpStore %1705 %3518
+%3519 = OpLoad %_arr_uchar_uint_16 %755
+%3520 = OpCompositeExtract %uchar %3519 3
+OpStore %1706 %3520
+%3521 = OpLoad %uchar %1705
+%3522 = OpLoad %uchar %1706
+%3523 = OpISub %uchar %3521 %3522
+OpStore %1707 %3523
+%3524 = OpLoad %_arr_uchar_uint_16 %743
+%3525 = OpCompositeExtract %uchar %3524 4
+OpStore %1708 %3525
+%3526 = OpLoad %_arr_uchar_uint_16 %755
+%3527 = OpCompositeExtract %uchar %3526 4
+OpStore %1709 %3527
+%3528 = OpLoad %uchar %1708
+%3529 = OpLoad %uchar %1709
+%3530 = OpISub %uchar %3528 %3529
+OpStore %1710 %3530
+%3531 = OpLoad %_arr_uchar_uint_16 %743
+%3532 = OpCompositeExtract %uchar %3531 5
+OpStore %1711 %3532
+%3533 = OpLoad %_arr_uchar_uint_16 %755
+%3534 = OpCompositeExtract %uchar %3533 5
+OpStore %1712 %3534
+%3535 = OpLoad %uchar %1711
+%3536 = OpLoad %uchar %1712
+%3537 = OpISub %uchar %3535 %3536
+OpStore %1713 %3537
+%3538 = OpLoad %_arr_uchar_uint_16 %743
+%3539 = OpCompositeExtract %uchar %3538 6
+OpStore %1714 %3539
+%3540 = OpLoad %_arr_uchar_uint_16 %755
+%3541 = OpCompositeExtract %uchar %3540 6
+OpStore %1715 %3541
+%3542 = OpLoad %uchar %1714
+%3543 = OpLoad %uchar %1715
+%3544 = OpISub %uchar %3542 %3543
+OpStore %1716 %3544
+%3545 = OpLoad %_arr_uchar_uint_16 %743
+%3546 = OpCompositeExtract %uchar %3545 7
+OpStore %1717 %3546
+%3547 = OpLoad %_arr_uchar_uint_16 %755
+%3548 = OpCompositeExtract %uchar %3547 7
+OpStore %1718 %3548
+%3549 = OpLoad %uchar %1717
+%3550 = OpLoad %uchar %1718
+%3551 = OpISub %uchar %3549 %3550
+OpStore %1719 %3551
+%3552 = OpLoad %_arr_uchar_uint_16 %743
+%3553 = OpCompositeExtract %uchar %3552 8
+OpStore %1720 %3553
+%3554 = OpLoad %_arr_uchar_uint_16 %755
+%3555 = OpCompositeExtract %uchar %3554 8
+OpStore %1721 %3555
+%3556 = OpLoad %uchar %1720
+%3557 = OpLoad %uchar %1721
+%3558 = OpISub %uchar %3556 %3557
+OpStore %1722 %3558
+%3559 = OpLoad %_arr_uchar_uint_16 %743
+%3560 = OpCompositeExtract %uchar %3559 9
+OpStore %1723 %3560
+%3561 = OpLoad %_arr_uchar_uint_16 %755
+%3562 = OpCompositeExtract %uchar %3561 9
+OpStore %1724 %3562
+%3563 = OpLoad %uchar %1723
+%3564 = OpLoad %uchar %1724
+%3565 = OpISub %uchar %3563 %3564
+OpStore %1725 %3565
+%3566 = OpLoad %_arr_uchar_uint_16 %743
+%3567 = OpCompositeExtract %uchar %3566 10
+OpStore %1726 %3567
+%3568 = OpLoad %_arr_uchar_uint_16 %755
+%3569 = OpCompositeExtract %uchar %3568 10
+OpStore %1727 %3569
+%3570 = OpLoad %uchar %1726
+%3571 = OpLoad %uchar %1727
+%3572 = OpISub %uchar %3570 %3571
+OpStore %1728 %3572
+%3573 = OpLoad %_arr_uchar_uint_16 %743
+%3574 = OpCompositeExtract %uchar %3573 11
+OpStore %1729 %3574
+%3575 = OpLoad %_arr_uchar_uint_16 %755
+%3576 = OpCompositeExtract %uchar %3575 11
+OpStore %1730 %3576
+%3577 = OpLoad %uchar %1729
+%3578 = OpLoad %uchar %1730
+%3579 = OpISub %uchar %3577 %3578
+OpStore %1731 %3579
+%3580 = OpLoad %_arr_uchar_uint_16 %743
+%3581 = OpCompositeExtract %uchar %3580 12
+OpStore %1732 %3581
+%3582 = OpLoad %_arr_uchar_uint_16 %755
+%3583 = OpCompositeExtract %uchar %3582 12
+OpStore %1733 %3583
+%3584 = OpLoad %uchar %1732
+%3585 = OpLoad %uchar %1733
+%3586 = OpISub %uchar %3584 %3585
+OpStore %1734 %3586
+%3587 = OpLoad %_arr_uchar_uint_16 %743
+%3588 = OpCompositeExtract %uchar %3587 13
+OpStore %1735 %3588
+%3589 = OpLoad %_arr_uchar_uint_16 %755
+%3590 = OpCompositeExtract %uchar %3589 13
+OpStore %1736 %3590
+%3591 = OpLoad %uchar %1735
+%3592 = OpLoad %uchar %1736
+%3593 = OpISub %uchar %3591 %3592
+OpStore %1737 %3593
+%3594 = OpLoad %_arr_uchar_uint_16 %743
+%3595 = OpCompositeExtract %uchar %3594 14
+OpStore %1738 %3595
+%3596 = OpLoad %_arr_uchar_uint_16 %755
+%3597 = OpCompositeExtract %uchar %3596 14
+OpStore %1739 %3597
+%3598 = OpLoad %uchar %1738
+%3599 = OpLoad %uchar %1739
+%3600 = OpISub %uchar %3598 %3599
+OpStore %1740 %3600
+%3601 = OpLoad %_arr_uchar_uint_16 %743
+%3602 = OpCompositeExtract %uchar %3601 15
+OpStore %1741 %3602
+%3603 = OpLoad %_arr_uchar_uint_16 %755
+%3604 = OpCompositeExtract %uchar %3603 15
+OpStore %1742 %3604
+%3605 = OpLoad %uchar %1741
+%3606 = OpLoad %uchar %1742
+%3607 = OpISub %uchar %3605 %3606
+OpStore %1743 %3607
+%3608 = OpLoad %_arr_uchar_uint_16 %743
+%3609 = OpLoad %uchar %1698
+%3610 = OpCompositeInsert %_arr_uchar_uint_16 %3609 %3608 0
+OpStore %1744 %3610
+%3611 = OpLoad %_arr_uchar_uint_16 %1744
+%3612 = OpLoad %uchar %1701
+%3613 = OpCompositeInsert %_arr_uchar_uint_16 %3612 %3611 1
+OpStore %1745 %3613
+%3614 = OpLoad %_arr_uchar_uint_16 %1745
+%3615 = OpLoad %uchar %1704
+%3616 = OpCompositeInsert %_arr_uchar_uint_16 %3615 %3614 2
+OpStore %1746 %3616
+%3617 = OpLoad %_arr_uchar_uint_16 %1746
+%3618 = OpLoad %uchar %1707
+%3619 = OpCompositeInsert %_arr_uchar_uint_16 %3618 %3617 3
+OpStore %1747 %3619
+%3620 = OpLoad %_arr_uchar_uint_16 %1747
+%3621 = OpLoad %uchar %1710
+%3622 = OpCompositeInsert %_arr_uchar_uint_16 %3621 %3620 4
+OpStore %1748 %3622
+%3623 = OpLoad %_arr_uchar_uint_16 %1748
+%3624 = OpLoad %uchar %1713
+%3625 = OpCompositeInsert %_arr_uchar_uint_16 %3624 %3623 5
+OpStore %1749 %3625
+%3626 = OpLoad %_arr_uchar_uint_16 %1749
+%3627 = OpLoad %uchar %1716
+%3628 = OpCompositeInsert %_arr_uchar_uint_16 %3627 %3626 6
+OpStore %1750 %3628
+%3629 = OpLoad %_arr_uchar_uint_16 %1750
+%3630 = OpLoad %uchar %1719
+%3631 = OpCompositeInsert %_arr_uchar_uint_16 %3630 %3629 7
+OpStore %1751 %3631
+%3632 = OpLoad %_arr_uchar_uint_16 %1751
+%3633 = OpLoad %uchar %1722
+%3634 = OpCompositeInsert %_arr_uchar_uint_16 %3633 %3632 8
+OpStore %1752 %3634
+%3635 = OpLoad %_arr_uchar_uint_16 %1752
+%3636 = OpLoad %uchar %1725
+%3637 = OpCompositeInsert %_arr_uchar_uint_16 %3636 %3635 9
+OpStore %1753 %3637
+%3638 = OpLoad %_arr_uchar_uint_16 %1753
+%3639 = OpLoad %uchar %1728
+%3640 = OpCompositeInsert %_arr_uchar_uint_16 %3639 %3638 10
+OpStore %1754 %3640
+%3641 = OpLoad %_arr_uchar_uint_16 %1754
+%3642 = OpLoad %uchar %1731
+%3643 = OpCompositeInsert %_arr_uchar_uint_16 %3642 %3641 11
+OpStore %1755 %3643
+%3644 = OpLoad %_arr_uchar_uint_16 %1755
+%3645 = OpLoad %uchar %1734
+%3646 = OpCompositeInsert %_arr_uchar_uint_16 %3645 %3644 12
+OpStore %1756 %3646
+%3647 = OpLoad %_arr_uchar_uint_16 %1756
+%3648 = OpLoad %uchar %1737
+%3649 = OpCompositeInsert %_arr_uchar_uint_16 %3648 %3647 13
+OpStore %1757 %3649
+%3650 = OpLoad %_arr_uchar_uint_16 %1757
+%3651 = OpLoad %uchar %1740
+%3652 = OpCompositeInsert %_arr_uchar_uint_16 %3651 %3650 14
+OpStore %1758 %3652
+%3653 = OpLoad %_arr_uchar_uint_16 %1758
+%3654 = OpLoad %uchar %1743
+%3655 = OpCompositeInsert %_arr_uchar_uint_16 %3654 %3653 15
+OpStore %1759 %3655
+%3656 = OpLoad %ulong %765
+%3657 = OpLoad %_arr_uchar_uint_16 %1759
+%3658 = OpFunctionCall %ulong %1 %3656 %3657
+OpStore %766 %3658
+%3659 = OpLoad %_arr_uchar_uint_16 %749
+%3660 = OpCompositeExtract %uchar %3659 0
+OpStore %1760 %3660
+%3661 = OpLoad %_arr_uchar_uint_16 %755
+%3662 = OpCompositeExtract %uchar %3661 0
+OpStore %1761 %3662
+%3663 = OpLoad %uchar %1760
+%3664 = OpLoad %uchar %1761
+%3665 = OpBitwiseAnd %uchar %3663 %3664
+OpStore %1762 %3665
+%3666 = OpLoad %_arr_uchar_uint_16 %749
+%3667 = OpCompositeExtract %uchar %3666 1
+OpStore %1763 %3667
+%3668 = OpLoad %_arr_uchar_uint_16 %755
+%3669 = OpCompositeExtract %uchar %3668 1
+OpStore %1764 %3669
+%3670 = OpLoad %uchar %1763
+%3671 = OpLoad %uchar %1764
+%3672 = OpBitwiseAnd %uchar %3670 %3671
+OpStore %1765 %3672
+%3673 = OpLoad %_arr_uchar_uint_16 %749
+%3674 = OpCompositeExtract %uchar %3673 2
+OpStore %1766 %3674
+%3675 = OpLoad %_arr_uchar_uint_16 %755
+%3676 = OpCompositeExtract %uchar %3675 2
+OpStore %1767 %3676
+%3677 = OpLoad %uchar %1766
+%3678 = OpLoad %uchar %1767
+%3679 = OpBitwiseAnd %uchar %3677 %3678
+OpStore %1768 %3679
+%3680 = OpLoad %_arr_uchar_uint_16 %749
+%3681 = OpCompositeExtract %uchar %3680 3
+OpStore %1769 %3681
+%3682 = OpLoad %_arr_uchar_uint_16 %755
+%3683 = OpCompositeExtract %uchar %3682 3
+OpStore %1770 %3683
+%3684 = OpLoad %uchar %1769
+%3685 = OpLoad %uchar %1770
+%3686 = OpBitwiseAnd %uchar %3684 %3685
+OpStore %1771 %3686
+%3687 = OpLoad %_arr_uchar_uint_16 %749
+%3688 = OpCompositeExtract %uchar %3687 4
+OpStore %1772 %3688
+%3689 = OpLoad %_arr_uchar_uint_16 %755
+%3690 = OpCompositeExtract %uchar %3689 4
+OpStore %1773 %3690
+%3691 = OpLoad %uchar %1772
+%3692 = OpLoad %uchar %1773
+%3693 = OpBitwiseAnd %uchar %3691 %3692
+OpStore %1774 %3693
+%3694 = OpLoad %_arr_uchar_uint_16 %749
+%3695 = OpCompositeExtract %uchar %3694 5
+OpStore %1775 %3695
+%3696 = OpLoad %_arr_uchar_uint_16 %755
+%3697 = OpCompositeExtract %uchar %3696 5
+OpStore %1776 %3697
+%3698 = OpLoad %uchar %1775
+%3699 = OpLoad %uchar %1776
+%3700 = OpBitwiseAnd %uchar %3698 %3699
+OpStore %1777 %3700
+%3701 = OpLoad %_arr_uchar_uint_16 %749
+%3702 = OpCompositeExtract %uchar %3701 6
+OpStore %1778 %3702
+%3703 = OpLoad %_arr_uchar_uint_16 %755
+%3704 = OpCompositeExtract %uchar %3703 6
+OpStore %1779 %3704
+%3705 = OpLoad %uchar %1778
+%3706 = OpLoad %uchar %1779
+%3707 = OpBitwiseAnd %uchar %3705 %3706
+OpStore %1780 %3707
+%3708 = OpLoad %_arr_uchar_uint_16 %749
+%3709 = OpCompositeExtract %uchar %3708 7
+OpStore %1781 %3709
+%3710 = OpLoad %_arr_uchar_uint_16 %755
+%3711 = OpCompositeExtract %uchar %3710 7
+OpStore %1782 %3711
+%3712 = OpLoad %uchar %1781
+%3713 = OpLoad %uchar %1782
+%3714 = OpBitwiseAnd %uchar %3712 %3713
+OpStore %1783 %3714
+%3715 = OpLoad %_arr_uchar_uint_16 %749
+%3716 = OpCompositeExtract %uchar %3715 8
+OpStore %1784 %3716
+%3717 = OpLoad %_arr_uchar_uint_16 %755
+%3718 = OpCompositeExtract %uchar %3717 8
+OpStore %1785 %3718
+%3719 = OpLoad %uchar %1784
+%3720 = OpLoad %uchar %1785
+%3721 = OpBitwiseAnd %uchar %3719 %3720
+OpStore %1786 %3721
+%3722 = OpLoad %_arr_uchar_uint_16 %749
+%3723 = OpCompositeExtract %uchar %3722 9
+OpStore %1787 %3723
+%3724 = OpLoad %_arr_uchar_uint_16 %755
+%3725 = OpCompositeExtract %uchar %3724 9
+OpStore %1788 %3725
+%3726 = OpLoad %uchar %1787
+%3727 = OpLoad %uchar %1788
+%3728 = OpBitwiseAnd %uchar %3726 %3727
+OpStore %1789 %3728
+%3729 = OpLoad %_arr_uchar_uint_16 %749
+%3730 = OpCompositeExtract %uchar %3729 10
+OpStore %1790 %3730
+%3731 = OpLoad %_arr_uchar_uint_16 %755
+%3732 = OpCompositeExtract %uchar %3731 10
+OpStore %1791 %3732
+%3733 = OpLoad %uchar %1790
+%3734 = OpLoad %uchar %1791
+%3735 = OpBitwiseAnd %uchar %3733 %3734
+OpStore %1792 %3735
+%3736 = OpLoad %_arr_uchar_uint_16 %749
+%3737 = OpCompositeExtract %uchar %3736 11
+OpStore %1793 %3737
+%3738 = OpLoad %_arr_uchar_uint_16 %755
+%3739 = OpCompositeExtract %uchar %3738 11
+OpStore %1794 %3739
+%3740 = OpLoad %uchar %1793
+%3741 = OpLoad %uchar %1794
+%3742 = OpBitwiseAnd %uchar %3740 %3741
+OpStore %1795 %3742
+%3743 = OpLoad %_arr_uchar_uint_16 %749
+%3744 = OpCompositeExtract %uchar %3743 12
+OpStore %1796 %3744
+%3745 = OpLoad %_arr_uchar_uint_16 %755
+%3746 = OpCompositeExtract %uchar %3745 12
+OpStore %1797 %3746
+%3747 = OpLoad %uchar %1796
+%3748 = OpLoad %uchar %1797
+%3749 = OpBitwiseAnd %uchar %3747 %3748
+OpStore %1798 %3749
+%3750 = OpLoad %_arr_uchar_uint_16 %749
+%3751 = OpCompositeExtract %uchar %3750 13
+OpStore %1799 %3751
+%3752 = OpLoad %_arr_uchar_uint_16 %755
+%3753 = OpCompositeExtract %uchar %3752 13
+OpStore %1800 %3753
+%3754 = OpLoad %uchar %1799
+%3755 = OpLoad %uchar %1800
+%3756 = OpBitwiseAnd %uchar %3754 %3755
+OpStore %1801 %3756
+%3757 = OpLoad %_arr_uchar_uint_16 %749
+%3758 = OpCompositeExtract %uchar %3757 14
+OpStore %1802 %3758
+%3759 = OpLoad %_arr_uchar_uint_16 %755
+%3760 = OpCompositeExtract %uchar %3759 14
+OpStore %1803 %3760
+%3761 = OpLoad %uchar %1802
+%3762 = OpLoad %uchar %1803
+%3763 = OpBitwiseAnd %uchar %3761 %3762
+OpStore %1804 %3763
+%3764 = OpLoad %_arr_uchar_uint_16 %749
+%3765 = OpCompositeExtract %uchar %3764 15
+OpStore %1805 %3765
+%3766 = OpLoad %_arr_uchar_uint_16 %755
+%3767 = OpCompositeExtract %uchar %3766 15
+OpStore %1806 %3767
+%3768 = OpLoad %uchar %1805
+%3769 = OpLoad %uchar %1806
+%3770 = OpBitwiseAnd %uchar %3768 %3769
+OpStore %1807 %3770
+%3771 = OpLoad %_arr_uchar_uint_16 %749
+%3772 = OpLoad %uchar %1762
+%3773 = OpCompositeInsert %_arr_uchar_uint_16 %3772 %3771 0
+OpStore %1808 %3773
+%3774 = OpLoad %_arr_uchar_uint_16 %1808
+%3775 = OpLoad %uchar %1765
+%3776 = OpCompositeInsert %_arr_uchar_uint_16 %3775 %3774 1
+OpStore %1809 %3776
+%3777 = OpLoad %_arr_uchar_uint_16 %1809
+%3778 = OpLoad %uchar %1768
+%3779 = OpCompositeInsert %_arr_uchar_uint_16 %3778 %3777 2
+OpStore %1810 %3779
+%3780 = OpLoad %_arr_uchar_uint_16 %1810
+%3781 = OpLoad %uchar %1771
+%3782 = OpCompositeInsert %_arr_uchar_uint_16 %3781 %3780 3
+OpStore %1811 %3782
+%3783 = OpLoad %_arr_uchar_uint_16 %1811
+%3784 = OpLoad %uchar %1774
+%3785 = OpCompositeInsert %_arr_uchar_uint_16 %3784 %3783 4
+OpStore %1812 %3785
+%3786 = OpLoad %_arr_uchar_uint_16 %1812
+%3787 = OpLoad %uchar %1777
+%3788 = OpCompositeInsert %_arr_uchar_uint_16 %3787 %3786 5
+OpStore %1813 %3788
+%3789 = OpLoad %_arr_uchar_uint_16 %1813
+%3790 = OpLoad %uchar %1780
+%3791 = OpCompositeInsert %_arr_uchar_uint_16 %3790 %3789 6
+OpStore %1814 %3791
+%3792 = OpLoad %_arr_uchar_uint_16 %1814
+%3793 = OpLoad %uchar %1783
+%3794 = OpCompositeInsert %_arr_uchar_uint_16 %3793 %3792 7
+OpStore %1815 %3794
+%3795 = OpLoad %_arr_uchar_uint_16 %1815
+%3796 = OpLoad %uchar %1786
+%3797 = OpCompositeInsert %_arr_uchar_uint_16 %3796 %3795 8
+OpStore %1816 %3797
+%3798 = OpLoad %_arr_uchar_uint_16 %1816
+%3799 = OpLoad %uchar %1789
+%3800 = OpCompositeInsert %_arr_uchar_uint_16 %3799 %3798 9
+OpStore %1817 %3800
+%3801 = OpLoad %_arr_uchar_uint_16 %1817
+%3802 = OpLoad %uchar %1792
+%3803 = OpCompositeInsert %_arr_uchar_uint_16 %3802 %3801 10
+OpStore %1818 %3803
+%3804 = OpLoad %_arr_uchar_uint_16 %1818
+%3805 = OpLoad %uchar %1795
+%3806 = OpCompositeInsert %_arr_uchar_uint_16 %3805 %3804 11
+OpStore %1819 %3806
+%3807 = OpLoad %_arr_uchar_uint_16 %1819
+%3808 = OpLoad %uchar %1798
+%3809 = OpCompositeInsert %_arr_uchar_uint_16 %3808 %3807 12
+OpStore %1820 %3809
+%3810 = OpLoad %_arr_uchar_uint_16 %1820
+%3811 = OpLoad %uchar %1801
+%3812 = OpCompositeInsert %_arr_uchar_uint_16 %3811 %3810 13
+OpStore %1821 %3812
+%3813 = OpLoad %_arr_uchar_uint_16 %1821
+%3814 = OpLoad %uchar %1804
+%3815 = OpCompositeInsert %_arr_uchar_uint_16 %3814 %3813 14
+OpStore %1822 %3815
+%3816 = OpLoad %_arr_uchar_uint_16 %1822
+%3817 = OpLoad %uchar %1807
+%3818 = OpCompositeInsert %_arr_uchar_uint_16 %3817 %3816 15
+OpStore %1823 %3818
+%3819 = OpLoad %ulong %766
+%3820 = OpLoad %_arr_uchar_uint_16 %1823
+%3821 = OpFunctionCall %ulong %1 %3819 %3820
+OpStore %767 %3821
+%3822 = OpLoad %_arr_uchar_uint_16 %749
+%3823 = OpCompositeExtract %uchar %3822 0
+OpStore %1824 %3823
+%3824 = OpLoad %_arr_uchar_uint_16 %755
+%3825 = OpCompositeExtract %uchar %3824 0
+OpStore %1825 %3825
+%3826 = OpLoad %uchar %1824
+%3827 = OpLoad %uchar %1825
+%3828 = OpBitwiseOr %uchar %3826 %3827
+OpStore %1826 %3828
+%3829 = OpLoad %_arr_uchar_uint_16 %749
+%3830 = OpCompositeExtract %uchar %3829 1
+OpStore %1827 %3830
+%3831 = OpLoad %_arr_uchar_uint_16 %755
+%3832 = OpCompositeExtract %uchar %3831 1
+OpStore %1828 %3832
+%3833 = OpLoad %uchar %1827
+%3834 = OpLoad %uchar %1828
+%3835 = OpBitwiseOr %uchar %3833 %3834
+OpStore %1829 %3835
+%3836 = OpLoad %_arr_uchar_uint_16 %749
+%3837 = OpCompositeExtract %uchar %3836 2
+OpStore %1830 %3837
+%3838 = OpLoad %_arr_uchar_uint_16 %755
+%3839 = OpCompositeExtract %uchar %3838 2
+OpStore %1831 %3839
+%3840 = OpLoad %uchar %1830
+%3841 = OpLoad %uchar %1831
+%3842 = OpBitwiseOr %uchar %3840 %3841
+OpStore %1832 %3842
+%3843 = OpLoad %_arr_uchar_uint_16 %749
+%3844 = OpCompositeExtract %uchar %3843 3
+OpStore %1833 %3844
+%3845 = OpLoad %_arr_uchar_uint_16 %755
+%3846 = OpCompositeExtract %uchar %3845 3
+OpStore %1834 %3846
+%3847 = OpLoad %uchar %1833
+%3848 = OpLoad %uchar %1834
+%3849 = OpBitwiseOr %uchar %3847 %3848
+OpStore %1835 %3849
+%3850 = OpLoad %_arr_uchar_uint_16 %749
+%3851 = OpCompositeExtract %uchar %3850 4
+OpStore %1836 %3851
+%3852 = OpLoad %_arr_uchar_uint_16 %755
+%3853 = OpCompositeExtract %uchar %3852 4
+OpStore %1837 %3853
+%3854 = OpLoad %uchar %1836
+%3855 = OpLoad %uchar %1837
+%3856 = OpBitwiseOr %uchar %3854 %3855
+OpStore %1838 %3856
+%3857 = OpLoad %_arr_uchar_uint_16 %749
+%3858 = OpCompositeExtract %uchar %3857 5
+OpStore %1839 %3858
+%3859 = OpLoad %_arr_uchar_uint_16 %755
+%3860 = OpCompositeExtract %uchar %3859 5
+OpStore %1840 %3860
+%3861 = OpLoad %uchar %1839
+%3862 = OpLoad %uchar %1840
+%3863 = OpBitwiseOr %uchar %3861 %3862
+OpStore %1841 %3863
+%3864 = OpLoad %_arr_uchar_uint_16 %749
+%3865 = OpCompositeExtract %uchar %3864 6
+OpStore %1842 %3865
+%3866 = OpLoad %_arr_uchar_uint_16 %755
+%3867 = OpCompositeExtract %uchar %3866 6
+OpStore %1843 %3867
+%3868 = OpLoad %uchar %1842
+%3869 = OpLoad %uchar %1843
+%3870 = OpBitwiseOr %uchar %3868 %3869
+OpStore %1844 %3870
+%3871 = OpLoad %_arr_uchar_uint_16 %749
+%3872 = OpCompositeExtract %uchar %3871 7
+OpStore %1845 %3872
+%3873 = OpLoad %_arr_uchar_uint_16 %755
+%3874 = OpCompositeExtract %uchar %3873 7
+OpStore %1846 %3874
+%3875 = OpLoad %uchar %1845
+%3876 = OpLoad %uchar %1846
+%3877 = OpBitwiseOr %uchar %3875 %3876
+OpStore %1847 %3877
+%3878 = OpLoad %_arr_uchar_uint_16 %749
+%3879 = OpCompositeExtract %uchar %3878 8
+OpStore %1848 %3879
+%3880 = OpLoad %_arr_uchar_uint_16 %755
+%3881 = OpCompositeExtract %uchar %3880 8
+OpStore %1849 %3881
+%3882 = OpLoad %uchar %1848
+%3883 = OpLoad %uchar %1849
+%3884 = OpBitwiseOr %uchar %3882 %3883
+OpStore %1850 %3884
+%3885 = OpLoad %_arr_uchar_uint_16 %749
+%3886 = OpCompositeExtract %uchar %3885 9
+OpStore %1851 %3886
+%3887 = OpLoad %_arr_uchar_uint_16 %755
+%3888 = OpCompositeExtract %uchar %3887 9
+OpStore %1852 %3888
+%3889 = OpLoad %uchar %1851
+%3890 = OpLoad %uchar %1852
+%3891 = OpBitwiseOr %uchar %3889 %3890
+OpStore %1853 %3891
+%3892 = OpLoad %_arr_uchar_uint_16 %749
+%3893 = OpCompositeExtract %uchar %3892 10
+OpStore %1854 %3893
+%3894 = OpLoad %_arr_uchar_uint_16 %755
+%3895 = OpCompositeExtract %uchar %3894 10
+OpStore %1855 %3895
+%3896 = OpLoad %uchar %1854
+%3897 = OpLoad %uchar %1855
+%3898 = OpBitwiseOr %uchar %3896 %3897
+OpStore %1856 %3898
+%3899 = OpLoad %_arr_uchar_uint_16 %749
+%3900 = OpCompositeExtract %uchar %3899 11
+OpStore %1857 %3900
+%3901 = OpLoad %_arr_uchar_uint_16 %755
+%3902 = OpCompositeExtract %uchar %3901 11
+OpStore %1858 %3902
+%3903 = OpLoad %uchar %1857
+%3904 = OpLoad %uchar %1858
+%3905 = OpBitwiseOr %uchar %3903 %3904
+OpStore %1859 %3905
+%3906 = OpLoad %_arr_uchar_uint_16 %749
+%3907 = OpCompositeExtract %uchar %3906 12
+OpStore %1860 %3907
+%3908 = OpLoad %_arr_uchar_uint_16 %755
+%3909 = OpCompositeExtract %uchar %3908 12
+OpStore %1861 %3909
+%3910 = OpLoad %uchar %1860
+%3911 = OpLoad %uchar %1861
+%3912 = OpBitwiseOr %uchar %3910 %3911
+OpStore %1862 %3912
+%3913 = OpLoad %_arr_uchar_uint_16 %749
+%3914 = OpCompositeExtract %uchar %3913 13
+OpStore %1863 %3914
+%3915 = OpLoad %_arr_uchar_uint_16 %755
+%3916 = OpCompositeExtract %uchar %3915 13
+OpStore %1864 %3916
+%3917 = OpLoad %uchar %1863
+%3918 = OpLoad %uchar %1864
+%3919 = OpBitwiseOr %uchar %3917 %3918
+OpStore %1865 %3919
+%3920 = OpLoad %_arr_uchar_uint_16 %749
+%3921 = OpCompositeExtract %uchar %3920 14
+OpStore %1866 %3921
+%3922 = OpLoad %_arr_uchar_uint_16 %755
+%3923 = OpCompositeExtract %uchar %3922 14
+OpStore %1867 %3923
+%3924 = OpLoad %uchar %1866
+%3925 = OpLoad %uchar %1867
+%3926 = OpBitwiseOr %uchar %3924 %3925
+OpStore %1868 %3926
+%3927 = OpLoad %_arr_uchar_uint_16 %749
+%3928 = OpCompositeExtract %uchar %3927 15
+OpStore %1869 %3928
+%3929 = OpLoad %_arr_uchar_uint_16 %755
+%3930 = OpCompositeExtract %uchar %3929 15
+OpStore %1870 %3930
+%3931 = OpLoad %uchar %1869
+%3932 = OpLoad %uchar %1870
+%3933 = OpBitwiseOr %uchar %3931 %3932
+OpStore %1871 %3933
+%3934 = OpLoad %_arr_uchar_uint_16 %749
+%3935 = OpLoad %uchar %1826
+%3936 = OpCompositeInsert %_arr_uchar_uint_16 %3935 %3934 0
+OpStore %1872 %3936
+%3937 = OpLoad %_arr_uchar_uint_16 %1872
+%3938 = OpLoad %uchar %1829
+%3939 = OpCompositeInsert %_arr_uchar_uint_16 %3938 %3937 1
+OpStore %1873 %3939
+%3940 = OpLoad %_arr_uchar_uint_16 %1873
+%3941 = OpLoad %uchar %1832
+%3942 = OpCompositeInsert %_arr_uchar_uint_16 %3941 %3940 2
+OpStore %1874 %3942
+%3943 = OpLoad %_arr_uchar_uint_16 %1874
+%3944 = OpLoad %uchar %1835
+%3945 = OpCompositeInsert %_arr_uchar_uint_16 %3944 %3943 3
+OpStore %1875 %3945
+%3946 = OpLoad %_arr_uchar_uint_16 %1875
+%3947 = OpLoad %uchar %1838
+%3948 = OpCompositeInsert %_arr_uchar_uint_16 %3947 %3946 4
+OpStore %1876 %3948
+%3949 = OpLoad %_arr_uchar_uint_16 %1876
+%3950 = OpLoad %uchar %1841
+%3951 = OpCompositeInsert %_arr_uchar_uint_16 %3950 %3949 5
+OpStore %1877 %3951
+%3952 = OpLoad %_arr_uchar_uint_16 %1877
+%3953 = OpLoad %uchar %1844
+%3954 = OpCompositeInsert %_arr_uchar_uint_16 %3953 %3952 6
+OpStore %1878 %3954
+%3955 = OpLoad %_arr_uchar_uint_16 %1878
+%3956 = OpLoad %uchar %1847
+%3957 = OpCompositeInsert %_arr_uchar_uint_16 %3956 %3955 7
+OpStore %1879 %3957
+%3958 = OpLoad %_arr_uchar_uint_16 %1879
+%3959 = OpLoad %uchar %1850
+%3960 = OpCompositeInsert %_arr_uchar_uint_16 %3959 %3958 8
+OpStore %1880 %3960
+%3961 = OpLoad %_arr_uchar_uint_16 %1880
+%3962 = OpLoad %uchar %1853
+%3963 = OpCompositeInsert %_arr_uchar_uint_16 %3962 %3961 9
+OpStore %1881 %3963
+%3964 = OpLoad %_arr_uchar_uint_16 %1881
+%3965 = OpLoad %uchar %1856
+%3966 = OpCompositeInsert %_arr_uchar_uint_16 %3965 %3964 10
+OpStore %1882 %3966
+%3967 = OpLoad %_arr_uchar_uint_16 %1882
+%3968 = OpLoad %uchar %1859
+%3969 = OpCompositeInsert %_arr_uchar_uint_16 %3968 %3967 11
+OpStore %1883 %3969
+%3970 = OpLoad %_arr_uchar_uint_16 %1883
+%3971 = OpLoad %uchar %1862
+%3972 = OpCompositeInsert %_arr_uchar_uint_16 %3971 %3970 12
+OpStore %1884 %3972
+%3973 = OpLoad %_arr_uchar_uint_16 %1884
+%3974 = OpLoad %uchar %1865
+%3975 = OpCompositeInsert %_arr_uchar_uint_16 %3974 %3973 13
+OpStore %1885 %3975
+%3976 = OpLoad %_arr_uchar_uint_16 %1885
+%3977 = OpLoad %uchar %1868
+%3978 = OpCompositeInsert %_arr_uchar_uint_16 %3977 %3976 14
+OpStore %1886 %3978
+%3979 = OpLoad %_arr_uchar_uint_16 %1886
+%3980 = OpLoad %uchar %1871
+%3981 = OpCompositeInsert %_arr_uchar_uint_16 %3980 %3979 15
+OpStore %1887 %3981
+%3982 = OpLoad %ulong %767
+%3983 = OpLoad %_arr_uchar_uint_16 %1887
+%3984 = OpFunctionCall %ulong %1 %3982 %3983
+OpStore %768 %3984
+%3985 = OpLoad %_arr_uchar_uint_16 %749
+%3986 = OpCompositeExtract %uchar %3985 0
+OpStore %1888 %3986
+%3987 = OpLoad %_arr_uchar_uint_16 %755
+%3988 = OpCompositeExtract %uchar %3987 0
+OpStore %1889 %3988
+%3989 = OpLoad %uchar %1888
+%3990 = OpLoad %uchar %1889
+%3991 = OpBitwiseXor %uchar %3989 %3990
+OpStore %1890 %3991
+%3992 = OpLoad %_arr_uchar_uint_16 %749
+%3993 = OpCompositeExtract %uchar %3992 1
+OpStore %1891 %3993
+%3994 = OpLoad %_arr_uchar_uint_16 %755
+%3995 = OpCompositeExtract %uchar %3994 1
+OpStore %1892 %3995
+%3996 = OpLoad %uchar %1891
+%3997 = OpLoad %uchar %1892
+%3998 = OpBitwiseXor %uchar %3996 %3997
+OpStore %1893 %3998
+%3999 = OpLoad %_arr_uchar_uint_16 %749
+%4000 = OpCompositeExtract %uchar %3999 2
+OpStore %1894 %4000
+%4001 = OpLoad %_arr_uchar_uint_16 %755
+%4002 = OpCompositeExtract %uchar %4001 2
+OpStore %1895 %4002
+%4003 = OpLoad %uchar %1894
+%4004 = OpLoad %uchar %1895
+%4005 = OpBitwiseXor %uchar %4003 %4004
+OpStore %1896 %4005
+%4006 = OpLoad %_arr_uchar_uint_16 %749
+%4007 = OpCompositeExtract %uchar %4006 3
+OpStore %1897 %4007
+%4008 = OpLoad %_arr_uchar_uint_16 %755
+%4009 = OpCompositeExtract %uchar %4008 3
+OpStore %1898 %4009
+%4010 = OpLoad %uchar %1897
+%4011 = OpLoad %uchar %1898
+%4012 = OpBitwiseXor %uchar %4010 %4011
+OpStore %1899 %4012
+%4013 = OpLoad %_arr_uchar_uint_16 %749
+%4014 = OpCompositeExtract %uchar %4013 4
+OpStore %1900 %4014
+%4015 = OpLoad %_arr_uchar_uint_16 %755
+%4016 = OpCompositeExtract %uchar %4015 4
+OpStore %1901 %4016
+%4017 = OpLoad %uchar %1900
+%4018 = OpLoad %uchar %1901
+%4019 = OpBitwiseXor %uchar %4017 %4018
+OpStore %1902 %4019
+%4020 = OpLoad %_arr_uchar_uint_16 %749
+%4021 = OpCompositeExtract %uchar %4020 5
+OpStore %1903 %4021
+%4022 = OpLoad %_arr_uchar_uint_16 %755
+%4023 = OpCompositeExtract %uchar %4022 5
+OpStore %1904 %4023
+%4024 = OpLoad %uchar %1903
+%4025 = OpLoad %uchar %1904
+%4026 = OpBitwiseXor %uchar %4024 %4025
+OpStore %1905 %4026
+%4027 = OpLoad %_arr_uchar_uint_16 %749
+%4028 = OpCompositeExtract %uchar %4027 6
+OpStore %1906 %4028
+%4029 = OpLoad %_arr_uchar_uint_16 %755
+%4030 = OpCompositeExtract %uchar %4029 6
+OpStore %1907 %4030
+%4031 = OpLoad %uchar %1906
+%4032 = OpLoad %uchar %1907
+%4033 = OpBitwiseXor %uchar %4031 %4032
+OpStore %1908 %4033
+%4034 = OpLoad %_arr_uchar_uint_16 %749
+%4035 = OpCompositeExtract %uchar %4034 7
+OpStore %1909 %4035
+%4036 = OpLoad %_arr_uchar_uint_16 %755
+%4037 = OpCompositeExtract %uchar %4036 7
+OpStore %1910 %4037
+%4038 = OpLoad %uchar %1909
+%4039 = OpLoad %uchar %1910
+%4040 = OpBitwiseXor %uchar %4038 %4039
+OpStore %1911 %4040
+%4041 = OpLoad %_arr_uchar_uint_16 %749
+%4042 = OpCompositeExtract %uchar %4041 8
+OpStore %1912 %4042
+%4043 = OpLoad %_arr_uchar_uint_16 %755
+%4044 = OpCompositeExtract %uchar %4043 8
+OpStore %1913 %4044
+%4045 = OpLoad %uchar %1912
+%4046 = OpLoad %uchar %1913
+%4047 = OpBitwiseXor %uchar %4045 %4046
+OpStore %1914 %4047
+%4048 = OpLoad %_arr_uchar_uint_16 %749
+%4049 = OpCompositeExtract %uchar %4048 9
+OpStore %1915 %4049
+%4050 = OpLoad %_arr_uchar_uint_16 %755
+%4051 = OpCompositeExtract %uchar %4050 9
+OpStore %1916 %4051
+%4052 = OpLoad %uchar %1915
+%4053 = OpLoad %uchar %1916
+%4054 = OpBitwiseXor %uchar %4052 %4053
+OpStore %1917 %4054
+%4055 = OpLoad %_arr_uchar_uint_16 %749
+%4056 = OpCompositeExtract %uchar %4055 10
+OpStore %1918 %4056
+%4057 = OpLoad %_arr_uchar_uint_16 %755
+%4058 = OpCompositeExtract %uchar %4057 10
+OpStore %1919 %4058
+%4059 = OpLoad %uchar %1918
+%4060 = OpLoad %uchar %1919
+%4061 = OpBitwiseXor %uchar %4059 %4060
+OpStore %1920 %4061
+%4062 = OpLoad %_arr_uchar_uint_16 %749
+%4063 = OpCompositeExtract %uchar %4062 11
+OpStore %1921 %4063
+%4064 = OpLoad %_arr_uchar_uint_16 %755
+%4065 = OpCompositeExtract %uchar %4064 11
+OpStore %1922 %4065
+%4066 = OpLoad %uchar %1921
+%4067 = OpLoad %uchar %1922
+%4068 = OpBitwiseXor %uchar %4066 %4067
+OpStore %1923 %4068
+%4069 = OpLoad %_arr_uchar_uint_16 %749
+%4070 = OpCompositeExtract %uchar %4069 12
+OpStore %1924 %4070
+%4071 = OpLoad %_arr_uchar_uint_16 %755
+%4072 = OpCompositeExtract %uchar %4071 12
+OpStore %1925 %4072
+%4073 = OpLoad %uchar %1924
+%4074 = OpLoad %uchar %1925
+%4075 = OpBitwiseXor %uchar %4073 %4074
+OpStore %1926 %4075
+%4076 = OpLoad %_arr_uchar_uint_16 %749
+%4077 = OpCompositeExtract %uchar %4076 13
+OpStore %1927 %4077
+%4078 = OpLoad %_arr_uchar_uint_16 %755
+%4079 = OpCompositeExtract %uchar %4078 13
+OpStore %1928 %4079
+%4080 = OpLoad %uchar %1927
+%4081 = OpLoad %uchar %1928
+%4082 = OpBitwiseXor %uchar %4080 %4081
+OpStore %1929 %4082
+%4083 = OpLoad %_arr_uchar_uint_16 %749
+%4084 = OpCompositeExtract %uchar %4083 14
+OpStore %1930 %4084
+%4085 = OpLoad %_arr_uchar_uint_16 %755
+%4086 = OpCompositeExtract %uchar %4085 14
+OpStore %1931 %4086
+%4087 = OpLoad %uchar %1930
+%4088 = OpLoad %uchar %1931
+%4089 = OpBitwiseXor %uchar %4087 %4088
+OpStore %1932 %4089
+%4090 = OpLoad %_arr_uchar_uint_16 %749
+%4091 = OpCompositeExtract %uchar %4090 15
+OpStore %1933 %4091
+%4092 = OpLoad %_arr_uchar_uint_16 %755
+%4093 = OpCompositeExtract %uchar %4092 15
+OpStore %1934 %4093
+%4094 = OpLoad %uchar %1933
+%4095 = OpLoad %uchar %1934
+%4096 = OpBitwiseXor %uchar %4094 %4095
+OpStore %1935 %4096
+%4097 = OpLoad %_arr_uchar_uint_16 %749
+%4098 = OpLoad %uchar %1890
+%4099 = OpCompositeInsert %_arr_uchar_uint_16 %4098 %4097 0
+OpStore %1936 %4099
+%4100 = OpLoad %_arr_uchar_uint_16 %1936
+%4101 = OpLoad %uchar %1893
+%4102 = OpCompositeInsert %_arr_uchar_uint_16 %4101 %4100 1
+OpStore %1937 %4102
+%4103 = OpLoad %_arr_uchar_uint_16 %1937
+%4104 = OpLoad %uchar %1896
+%4105 = OpCompositeInsert %_arr_uchar_uint_16 %4104 %4103 2
+OpStore %1938 %4105
+%4106 = OpLoad %_arr_uchar_uint_16 %1938
+%4107 = OpLoad %uchar %1899
+%4108 = OpCompositeInsert %_arr_uchar_uint_16 %4107 %4106 3
+OpStore %1939 %4108
+%4109 = OpLoad %_arr_uchar_uint_16 %1939
+%4110 = OpLoad %uchar %1902
+%4111 = OpCompositeInsert %_arr_uchar_uint_16 %4110 %4109 4
+OpStore %1940 %4111
+%4112 = OpLoad %_arr_uchar_uint_16 %1940
+%4113 = OpLoad %uchar %1905
+%4114 = OpCompositeInsert %_arr_uchar_uint_16 %4113 %4112 5
+OpStore %1941 %4114
+%4115 = OpLoad %_arr_uchar_uint_16 %1941
+%4116 = OpLoad %uchar %1908
+%4117 = OpCompositeInsert %_arr_uchar_uint_16 %4116 %4115 6
+OpStore %1942 %4117
+%4118 = OpLoad %_arr_uchar_uint_16 %1942
+%4119 = OpLoad %uchar %1911
+%4120 = OpCompositeInsert %_arr_uchar_uint_16 %4119 %4118 7
+OpStore %1943 %4120
+%4121 = OpLoad %_arr_uchar_uint_16 %1943
+%4122 = OpLoad %uchar %1914
+%4123 = OpCompositeInsert %_arr_uchar_uint_16 %4122 %4121 8
+OpStore %1944 %4123
+%4124 = OpLoad %_arr_uchar_uint_16 %1944
+%4125 = OpLoad %uchar %1917
+%4126 = OpCompositeInsert %_arr_uchar_uint_16 %4125 %4124 9
+OpStore %1945 %4126
+%4127 = OpLoad %_arr_uchar_uint_16 %1945
+%4128 = OpLoad %uchar %1920
+%4129 = OpCompositeInsert %_arr_uchar_uint_16 %4128 %4127 10
+OpStore %1946 %4129
+%4130 = OpLoad %_arr_uchar_uint_16 %1946
+%4131 = OpLoad %uchar %1923
+%4132 = OpCompositeInsert %_arr_uchar_uint_16 %4131 %4130 11
+OpStore %1947 %4132
+%4133 = OpLoad %_arr_uchar_uint_16 %1947
+%4134 = OpLoad %uchar %1926
+%4135 = OpCompositeInsert %_arr_uchar_uint_16 %4134 %4133 12
+OpStore %1948 %4135
+%4136 = OpLoad %_arr_uchar_uint_16 %1948
+%4137 = OpLoad %uchar %1929
+%4138 = OpCompositeInsert %_arr_uchar_uint_16 %4137 %4136 13
+OpStore %1949 %4138
+%4139 = OpLoad %_arr_uchar_uint_16 %1949
+%4140 = OpLoad %uchar %1932
+%4141 = OpCompositeInsert %_arr_uchar_uint_16 %4140 %4139 14
+OpStore %1950 %4141
+%4142 = OpLoad %_arr_uchar_uint_16 %1950
+%4143 = OpLoad %uchar %1935
+%4144 = OpCompositeInsert %_arr_uchar_uint_16 %4143 %4142 15
+OpStore %1951 %4144
+%4145 = OpLoad %ulong %768
+%4146 = OpLoad %_arr_uchar_uint_16 %1951
+%4147 = OpFunctionCall %ulong %1 %4145 %4146
+OpStore %769 %4147
+%4148 = OpLoad %_arr_uchar_uint_16 %749
+%4149 = OpCompositeExtract %uchar %4148 0
+OpStore %1952 %4149
+%4150 = OpLoad %uchar %1952
+%4151 = OpNot %uchar %4150
+OpStore %1953 %4151
+%4152 = OpLoad %_arr_uchar_uint_16 %749
+%4153 = OpCompositeExtract %uchar %4152 1
+OpStore %1954 %4153
+%4154 = OpLoad %uchar %1954
+%4155 = OpNot %uchar %4154
+OpStore %1955 %4155
+%4156 = OpLoad %_arr_uchar_uint_16 %749
+%4157 = OpCompositeExtract %uchar %4156 2
+OpStore %1956 %4157
+%4158 = OpLoad %uchar %1956
+%4159 = OpNot %uchar %4158
+OpStore %1957 %4159
+%4160 = OpLoad %_arr_uchar_uint_16 %749
+%4161 = OpCompositeExtract %uchar %4160 3
+OpStore %1958 %4161
+%4162 = OpLoad %uchar %1958
+%4163 = OpNot %uchar %4162
+OpStore %1959 %4163
+%4164 = OpLoad %_arr_uchar_uint_16 %749
+%4165 = OpCompositeExtract %uchar %4164 4
+OpStore %1960 %4165
+%4166 = OpLoad %uchar %1960
+%4167 = OpNot %uchar %4166
+OpStore %1961 %4167
+%4168 = OpLoad %_arr_uchar_uint_16 %749
+%4169 = OpCompositeExtract %uchar %4168 5
+OpStore %1962 %4169
+%4170 = OpLoad %uchar %1962
+%4171 = OpNot %uchar %4170
+OpStore %1963 %4171
+%4172 = OpLoad %_arr_uchar_uint_16 %749
+%4173 = OpCompositeExtract %uchar %4172 6
+OpStore %1964 %4173
+%4174 = OpLoad %uchar %1964
+%4175 = OpNot %uchar %4174
+OpStore %1965 %4175
+%4176 = OpLoad %_arr_uchar_uint_16 %749
+%4177 = OpCompositeExtract %uchar %4176 7
+OpStore %1966 %4177
+%4178 = OpLoad %uchar %1966
+%4179 = OpNot %uchar %4178
+OpStore %1967 %4179
+%4180 = OpLoad %_arr_uchar_uint_16 %749
+%4181 = OpCompositeExtract %uchar %4180 8
+OpStore %1968 %4181
+%4182 = OpLoad %uchar %1968
+%4183 = OpNot %uchar %4182
+OpStore %1969 %4183
+%4184 = OpLoad %_arr_uchar_uint_16 %749
+%4185 = OpCompositeExtract %uchar %4184 9
+OpStore %1970 %4185
+%4186 = OpLoad %uchar %1970
+%4187 = OpNot %uchar %4186
+OpStore %1971 %4187
+%4188 = OpLoad %_arr_uchar_uint_16 %749
+%4189 = OpCompositeExtract %uchar %4188 10
+OpStore %1972 %4189
+%4190 = OpLoad %uchar %1972
+%4191 = OpNot %uchar %4190
+OpStore %1973 %4191
+%4192 = OpLoad %_arr_uchar_uint_16 %749
+%4193 = OpCompositeExtract %uchar %4192 11
+OpStore %1974 %4193
+%4194 = OpLoad %uchar %1974
+%4195 = OpNot %uchar %4194
+OpStore %1975 %4195
+%4196 = OpLoad %_arr_uchar_uint_16 %749
+%4197 = OpCompositeExtract %uchar %4196 12
+OpStore %1976 %4197
+%4198 = OpLoad %uchar %1976
+%4199 = OpNot %uchar %4198
+OpStore %1977 %4199
+%4200 = OpLoad %_arr_uchar_uint_16 %749
+%4201 = OpCompositeExtract %uchar %4200 13
+OpStore %1978 %4201
+%4202 = OpLoad %uchar %1978
+%4203 = OpNot %uchar %4202
+OpStore %1979 %4203
+%4204 = OpLoad %_arr_uchar_uint_16 %749
+%4205 = OpCompositeExtract %uchar %4204 14
+OpStore %1980 %4205
+%4206 = OpLoad %uchar %1980
+%4207 = OpNot %uchar %4206
+OpStore %1981 %4207
+%4208 = OpLoad %_arr_uchar_uint_16 %749
+%4209 = OpCompositeExtract %uchar %4208 15
+OpStore %1982 %4209
+%4210 = OpLoad %uchar %1982
+%4211 = OpNot %uchar %4210
+OpStore %1983 %4211
+%4212 = OpLoad %_arr_uchar_uint_16 %749
+%4213 = OpLoad %uchar %1953
+%4214 = OpCompositeInsert %_arr_uchar_uint_16 %4213 %4212 0
+OpStore %1984 %4214
+%4215 = OpLoad %_arr_uchar_uint_16 %1984
+%4216 = OpLoad %uchar %1955
+%4217 = OpCompositeInsert %_arr_uchar_uint_16 %4216 %4215 1
+OpStore %1985 %4217
+%4218 = OpLoad %_arr_uchar_uint_16 %1985
+%4219 = OpLoad %uchar %1957
+%4220 = OpCompositeInsert %_arr_uchar_uint_16 %4219 %4218 2
+OpStore %1986 %4220
+%4221 = OpLoad %_arr_uchar_uint_16 %1986
+%4222 = OpLoad %uchar %1959
+%4223 = OpCompositeInsert %_arr_uchar_uint_16 %4222 %4221 3
+OpStore %1987 %4223
+%4224 = OpLoad %_arr_uchar_uint_16 %1987
+%4225 = OpLoad %uchar %1961
+%4226 = OpCompositeInsert %_arr_uchar_uint_16 %4225 %4224 4
+OpStore %1988 %4226
+%4227 = OpLoad %_arr_uchar_uint_16 %1988
+%4228 = OpLoad %uchar %1963
+%4229 = OpCompositeInsert %_arr_uchar_uint_16 %4228 %4227 5
+OpStore %1989 %4229
+%4230 = OpLoad %_arr_uchar_uint_16 %1989
+%4231 = OpLoad %uchar %1965
+%4232 = OpCompositeInsert %_arr_uchar_uint_16 %4231 %4230 6
+OpStore %1990 %4232
+%4233 = OpLoad %_arr_uchar_uint_16 %1990
+%4234 = OpLoad %uchar %1967
+%4235 = OpCompositeInsert %_arr_uchar_uint_16 %4234 %4233 7
+OpStore %1991 %4235
+%4236 = OpLoad %_arr_uchar_uint_16 %1991
+%4237 = OpLoad %uchar %1969
+%4238 = OpCompositeInsert %_arr_uchar_uint_16 %4237 %4236 8
+OpStore %1992 %4238
+%4239 = OpLoad %_arr_uchar_uint_16 %1992
+%4240 = OpLoad %uchar %1971
+%4241 = OpCompositeInsert %_arr_uchar_uint_16 %4240 %4239 9
+OpStore %1993 %4241
+%4242 = OpLoad %_arr_uchar_uint_16 %1993
+%4243 = OpLoad %uchar %1973
+%4244 = OpCompositeInsert %_arr_uchar_uint_16 %4243 %4242 10
+OpStore %1994 %4244
+%4245 = OpLoad %_arr_uchar_uint_16 %1994
+%4246 = OpLoad %uchar %1975
+%4247 = OpCompositeInsert %_arr_uchar_uint_16 %4246 %4245 11
+OpStore %1995 %4247
+%4248 = OpLoad %_arr_uchar_uint_16 %1995
+%4249 = OpLoad %uchar %1977
+%4250 = OpCompositeInsert %_arr_uchar_uint_16 %4249 %4248 12
+OpStore %1996 %4250
+%4251 = OpLoad %_arr_uchar_uint_16 %1996
+%4252 = OpLoad %uchar %1979
+%4253 = OpCompositeInsert %_arr_uchar_uint_16 %4252 %4251 13
+OpStore %1997 %4253
+%4254 = OpLoad %_arr_uchar_uint_16 %1997
+%4255 = OpLoad %uchar %1981
+%4256 = OpCompositeInsert %_arr_uchar_uint_16 %4255 %4254 14
+OpStore %1998 %4256
+%4257 = OpLoad %_arr_uchar_uint_16 %1998
+%4258 = OpLoad %uchar %1983
+%4259 = OpCompositeInsert %_arr_uchar_uint_16 %4258 %4257 15
+OpStore %1999 %4259
+%4260 = OpLoad %ulong %769
+%4261 = OpLoad %_arr_uchar_uint_16 %1999
+%4262 = OpFunctionCall %ulong %1 %4260 %4261
+OpStore %770 %4262
+%4263 = OpLoad %_arr_uchar_uint_16 %755
+%4264 = OpCompositeExtract %uchar %4263 0
+OpStore %2000 %4264
+%4265 = OpLoad %uchar %2000
+%4266 = OpNot %uchar %4265
+OpStore %2001 %4266
+%4267 = OpLoad %_arr_uchar_uint_16 %755
+%4268 = OpCompositeExtract %uchar %4267 1
+OpStore %2002 %4268
+%4269 = OpLoad %uchar %2002
+%4270 = OpNot %uchar %4269
+OpStore %2003 %4270
+%4271 = OpLoad %_arr_uchar_uint_16 %755
+%4272 = OpCompositeExtract %uchar %4271 2
+OpStore %2004 %4272
+%4273 = OpLoad %uchar %2004
+%4274 = OpNot %uchar %4273
+OpStore %2005 %4274
+%4275 = OpLoad %_arr_uchar_uint_16 %755
+%4276 = OpCompositeExtract %uchar %4275 3
+OpStore %2006 %4276
+%4277 = OpLoad %uchar %2006
+%4278 = OpNot %uchar %4277
+OpStore %2007 %4278
+%4279 = OpLoad %_arr_uchar_uint_16 %755
+%4280 = OpCompositeExtract %uchar %4279 4
+OpStore %2008 %4280
+%4281 = OpLoad %uchar %2008
+%4282 = OpNot %uchar %4281
+OpStore %2009 %4282
+%4283 = OpLoad %_arr_uchar_uint_16 %755
+%4284 = OpCompositeExtract %uchar %4283 5
+OpStore %2010 %4284
+%4285 = OpLoad %uchar %2010
+%4286 = OpNot %uchar %4285
+OpStore %2011 %4286
+%4287 = OpLoad %_arr_uchar_uint_16 %755
+%4288 = OpCompositeExtract %uchar %4287 6
+OpStore %2012 %4288
+%4289 = OpLoad %uchar %2012
+%4290 = OpNot %uchar %4289
+OpStore %2013 %4290
+%4291 = OpLoad %_arr_uchar_uint_16 %755
+%4292 = OpCompositeExtract %uchar %4291 7
+OpStore %2014 %4292
+%4293 = OpLoad %uchar %2014
+%4294 = OpNot %uchar %4293
+OpStore %2015 %4294
+%4295 = OpLoad %_arr_uchar_uint_16 %755
+%4296 = OpCompositeExtract %uchar %4295 8
+OpStore %2016 %4296
+%4297 = OpLoad %uchar %2016
+%4298 = OpNot %uchar %4297
+OpStore %2017 %4298
+%4299 = OpLoad %_arr_uchar_uint_16 %755
+%4300 = OpCompositeExtract %uchar %4299 9
+OpStore %2018 %4300
+%4301 = OpLoad %uchar %2018
+%4302 = OpNot %uchar %4301
+OpStore %2019 %4302
+%4303 = OpLoad %_arr_uchar_uint_16 %755
+%4304 = OpCompositeExtract %uchar %4303 10
+OpStore %2020 %4304
+%4305 = OpLoad %uchar %2020
+%4306 = OpNot %uchar %4305
+OpStore %2021 %4306
+%4307 = OpLoad %_arr_uchar_uint_16 %755
+%4308 = OpCompositeExtract %uchar %4307 11
+OpStore %2022 %4308
+%4309 = OpLoad %uchar %2022
+%4310 = OpNot %uchar %4309
+OpStore %2023 %4310
+%4311 = OpLoad %_arr_uchar_uint_16 %755
+%4312 = OpCompositeExtract %uchar %4311 12
+OpStore %2024 %4312
+%4313 = OpLoad %uchar %2024
+%4314 = OpNot %uchar %4313
+OpStore %2025 %4314
+%4315 = OpLoad %_arr_uchar_uint_16 %755
+%4316 = OpCompositeExtract %uchar %4315 13
+OpStore %2026 %4316
+%4317 = OpLoad %uchar %2026
+%4318 = OpNot %uchar %4317
+OpStore %2027 %4318
+%4319 = OpLoad %_arr_uchar_uint_16 %755
+%4320 = OpCompositeExtract %uchar %4319 14
+OpStore %2028 %4320
+%4321 = OpLoad %uchar %2028
+%4322 = OpNot %uchar %4321
+OpStore %2029 %4322
+%4323 = OpLoad %_arr_uchar_uint_16 %755
+%4324 = OpCompositeExtract %uchar %4323 15
+OpStore %2030 %4324
+%4325 = OpLoad %uchar %2030
+%4326 = OpNot %uchar %4325
+OpStore %2031 %4326
+%4327 = OpLoad %_arr_uchar_uint_16 %755
+%4328 = OpLoad %uchar %2001
+%4329 = OpCompositeInsert %_arr_uchar_uint_16 %4328 %4327 0
+OpStore %2032 %4329
+%4330 = OpLoad %_arr_uchar_uint_16 %2032
+%4331 = OpLoad %uchar %2003
+%4332 = OpCompositeInsert %_arr_uchar_uint_16 %4331 %4330 1
+OpStore %2033 %4332
+%4333 = OpLoad %_arr_uchar_uint_16 %2033
+%4334 = OpLoad %uchar %2005
+%4335 = OpCompositeInsert %_arr_uchar_uint_16 %4334 %4333 2
+OpStore %2034 %4335
+%4336 = OpLoad %_arr_uchar_uint_16 %2034
+%4337 = OpLoad %uchar %2007
+%4338 = OpCompositeInsert %_arr_uchar_uint_16 %4337 %4336 3
+OpStore %2035 %4338
+%4339 = OpLoad %_arr_uchar_uint_16 %2035
+%4340 = OpLoad %uchar %2009
+%4341 = OpCompositeInsert %_arr_uchar_uint_16 %4340 %4339 4
+OpStore %2036 %4341
+%4342 = OpLoad %_arr_uchar_uint_16 %2036
+%4343 = OpLoad %uchar %2011
+%4344 = OpCompositeInsert %_arr_uchar_uint_16 %4343 %4342 5
+OpStore %2037 %4344
+%4345 = OpLoad %_arr_uchar_uint_16 %2037
+%4346 = OpLoad %uchar %2013
+%4347 = OpCompositeInsert %_arr_uchar_uint_16 %4346 %4345 6
+OpStore %2038 %4347
+%4348 = OpLoad %_arr_uchar_uint_16 %2038
+%4349 = OpLoad %uchar %2015
+%4350 = OpCompositeInsert %_arr_uchar_uint_16 %4349 %4348 7
+OpStore %2039 %4350
+%4351 = OpLoad %_arr_uchar_uint_16 %2039
+%4352 = OpLoad %uchar %2017
+%4353 = OpCompositeInsert %_arr_uchar_uint_16 %4352 %4351 8
+OpStore %2040 %4353
+%4354 = OpLoad %_arr_uchar_uint_16 %2040
+%4355 = OpLoad %uchar %2019
+%4356 = OpCompositeInsert %_arr_uchar_uint_16 %4355 %4354 9
+OpStore %2041 %4356
+%4357 = OpLoad %_arr_uchar_uint_16 %2041
+%4358 = OpLoad %uchar %2021
+%4359 = OpCompositeInsert %_arr_uchar_uint_16 %4358 %4357 10
+OpStore %2042 %4359
+%4360 = OpLoad %_arr_uchar_uint_16 %2042
+%4361 = OpLoad %uchar %2023
+%4362 = OpCompositeInsert %_arr_uchar_uint_16 %4361 %4360 11
+OpStore %2043 %4362
+%4363 = OpLoad %_arr_uchar_uint_16 %2043
+%4364 = OpLoad %uchar %2025
+%4365 = OpCompositeInsert %_arr_uchar_uint_16 %4364 %4363 12
+OpStore %2044 %4365
+%4366 = OpLoad %_arr_uchar_uint_16 %2044
+%4367 = OpLoad %uchar %2027
+%4368 = OpCompositeInsert %_arr_uchar_uint_16 %4367 %4366 13
+OpStore %2045 %4368
+%4369 = OpLoad %_arr_uchar_uint_16 %2045
+%4370 = OpLoad %uchar %2029
+%4371 = OpCompositeInsert %_arr_uchar_uint_16 %4370 %4369 14
+OpStore %2046 %4371
+%4372 = OpLoad %_arr_uchar_uint_16 %2046
+%4373 = OpLoad %uchar %2031
+%4374 = OpCompositeInsert %_arr_uchar_uint_16 %4373 %4372 15
+OpStore %2047 %4374
+%4375 = OpLoad %ulong %770
+%4376 = OpLoad %_arr_uchar_uint_16 %2047
+%4377 = OpFunctionCall %ulong %1 %4375 %4376
+OpStore %771 %4377
+%4378 = OpLoad %_arr_uchar_uint_16 %1823
+%4379 = OpCompositeExtract %uchar %4378 0
+OpStore %2048 %4379
+%4380 = OpLoad %_arr_uchar_uint_16 %1887
+%4381 = OpCompositeExtract %uchar %4380 0
+OpStore %2049 %4381
+%4382 = OpLoad %uchar %2048
+%4383 = OpLoad %uchar %2049
+%4384 = OpBitwiseXor %uchar %4382 %4383
+OpStore %2050 %4384
+%4385 = OpLoad %_arr_uchar_uint_16 %1823
+%4386 = OpCompositeExtract %uchar %4385 1
+OpStore %2051 %4386
+%4387 = OpLoad %_arr_uchar_uint_16 %1887
+%4388 = OpCompositeExtract %uchar %4387 1
+OpStore %2052 %4388
+%4389 = OpLoad %uchar %2051
+%4390 = OpLoad %uchar %2052
+%4391 = OpBitwiseXor %uchar %4389 %4390
+OpStore %2053 %4391
+%4392 = OpLoad %_arr_uchar_uint_16 %1823
+%4393 = OpCompositeExtract %uchar %4392 2
+OpStore %2054 %4393
+%4394 = OpLoad %_arr_uchar_uint_16 %1887
+%4395 = OpCompositeExtract %uchar %4394 2
+OpStore %2055 %4395
+%4396 = OpLoad %uchar %2054
+%4397 = OpLoad %uchar %2055
+%4398 = OpBitwiseXor %uchar %4396 %4397
+OpStore %2056 %4398
+%4399 = OpLoad %_arr_uchar_uint_16 %1823
+%4400 = OpCompositeExtract %uchar %4399 3
+OpStore %2057 %4400
+%4401 = OpLoad %_arr_uchar_uint_16 %1887
+%4402 = OpCompositeExtract %uchar %4401 3
+OpStore %2058 %4402
+%4403 = OpLoad %uchar %2057
+%4404 = OpLoad %uchar %2058
+%4405 = OpBitwiseXor %uchar %4403 %4404
+OpStore %2059 %4405
+%4406 = OpLoad %_arr_uchar_uint_16 %1823
+%4407 = OpCompositeExtract %uchar %4406 4
+OpStore %2060 %4407
+%4408 = OpLoad %_arr_uchar_uint_16 %1887
+%4409 = OpCompositeExtract %uchar %4408 4
+OpStore %2061 %4409
+%4410 = OpLoad %uchar %2060
+%4411 = OpLoad %uchar %2061
+%4412 = OpBitwiseXor %uchar %4410 %4411
+OpStore %2062 %4412
+%4413 = OpLoad %_arr_uchar_uint_16 %1823
+%4414 = OpCompositeExtract %uchar %4413 5
+OpStore %2063 %4414
+%4415 = OpLoad %_arr_uchar_uint_16 %1887
+%4416 = OpCompositeExtract %uchar %4415 5
+OpStore %2064 %4416
+%4417 = OpLoad %uchar %2063
+%4418 = OpLoad %uchar %2064
+%4419 = OpBitwiseXor %uchar %4417 %4418
+OpStore %2065 %4419
+%4420 = OpLoad %_arr_uchar_uint_16 %1823
+%4421 = OpCompositeExtract %uchar %4420 6
+OpStore %2066 %4421
+%4422 = OpLoad %_arr_uchar_uint_16 %1887
+%4423 = OpCompositeExtract %uchar %4422 6
+OpStore %2067 %4423
+%4424 = OpLoad %uchar %2066
+%4425 = OpLoad %uchar %2067
+%4426 = OpBitwiseXor %uchar %4424 %4425
+OpStore %2068 %4426
+%4427 = OpLoad %_arr_uchar_uint_16 %1823
+%4428 = OpCompositeExtract %uchar %4427 7
+OpStore %2069 %4428
+%4429 = OpLoad %_arr_uchar_uint_16 %1887
+%4430 = OpCompositeExtract %uchar %4429 7
+OpStore %2070 %4430
+%4431 = OpLoad %uchar %2069
+%4432 = OpLoad %uchar %2070
+%4433 = OpBitwiseXor %uchar %4431 %4432
+OpStore %2071 %4433
+%4434 = OpLoad %_arr_uchar_uint_16 %1823
+%4435 = OpCompositeExtract %uchar %4434 8
+OpStore %2072 %4435
+%4436 = OpLoad %_arr_uchar_uint_16 %1887
+%4437 = OpCompositeExtract %uchar %4436 8
+OpStore %2073 %4437
+%4438 = OpLoad %uchar %2072
+%4439 = OpLoad %uchar %2073
+%4440 = OpBitwiseXor %uchar %4438 %4439
+OpStore %2074 %4440
+%4441 = OpLoad %_arr_uchar_uint_16 %1823
+%4442 = OpCompositeExtract %uchar %4441 9
+OpStore %2075 %4442
+%4443 = OpLoad %_arr_uchar_uint_16 %1887
+%4444 = OpCompositeExtract %uchar %4443 9
+OpStore %2076 %4444
+%4445 = OpLoad %uchar %2075
+%4446 = OpLoad %uchar %2076
+%4447 = OpBitwiseXor %uchar %4445 %4446
+OpStore %2077 %4447
+%4448 = OpLoad %_arr_uchar_uint_16 %1823
+%4449 = OpCompositeExtract %uchar %4448 10
+OpStore %2078 %4449
+%4450 = OpLoad %_arr_uchar_uint_16 %1887
+%4451 = OpCompositeExtract %uchar %4450 10
+OpStore %2079 %4451
+%4452 = OpLoad %uchar %2078
+%4453 = OpLoad %uchar %2079
+%4454 = OpBitwiseXor %uchar %4452 %4453
+OpStore %2080 %4454
+%4455 = OpLoad %_arr_uchar_uint_16 %1823
+%4456 = OpCompositeExtract %uchar %4455 11
+OpStore %2081 %4456
+%4457 = OpLoad %_arr_uchar_uint_16 %1887
+%4458 = OpCompositeExtract %uchar %4457 11
+OpStore %2082 %4458
+%4459 = OpLoad %uchar %2081
+%4460 = OpLoad %uchar %2082
+%4461 = OpBitwiseXor %uchar %4459 %4460
+OpStore %2083 %4461
+%4462 = OpLoad %_arr_uchar_uint_16 %1823
+%4463 = OpCompositeExtract %uchar %4462 12
+OpStore %2084 %4463
+%4464 = OpLoad %_arr_uchar_uint_16 %1887
+%4465 = OpCompositeExtract %uchar %4464 12
+OpStore %2085 %4465
+%4466 = OpLoad %uchar %2084
+%4467 = OpLoad %uchar %2085
+%4468 = OpBitwiseXor %uchar %4466 %4467
+OpStore %2086 %4468
+%4469 = OpLoad %_arr_uchar_uint_16 %1823
+%4470 = OpCompositeExtract %uchar %4469 13
+OpStore %2087 %4470
+%4471 = OpLoad %_arr_uchar_uint_16 %1887
+%4472 = OpCompositeExtract %uchar %4471 13
+OpStore %2088 %4472
+%4473 = OpLoad %uchar %2087
+%4474 = OpLoad %uchar %2088
+%4475 = OpBitwiseXor %uchar %4473 %4474
+OpStore %2089 %4475
+%4476 = OpLoad %_arr_uchar_uint_16 %1823
+%4477 = OpCompositeExtract %uchar %4476 14
+OpStore %2090 %4477
+%4478 = OpLoad %_arr_uchar_uint_16 %1887
+%4479 = OpCompositeExtract %uchar %4478 14
+OpStore %2091 %4479
+%4480 = OpLoad %uchar %2090
+%4481 = OpLoad %uchar %2091
+%4482 = OpBitwiseXor %uchar %4480 %4481
+OpStore %2092 %4482
+%4483 = OpLoad %_arr_uchar_uint_16 %1823
+%4484 = OpCompositeExtract %uchar %4483 15
+OpStore %2093 %4484
+%4485 = OpLoad %_arr_uchar_uint_16 %1887
+%4486 = OpCompositeExtract %uchar %4485 15
+OpStore %2094 %4486
+%4487 = OpLoad %uchar %2093
+%4488 = OpLoad %uchar %2094
+%4489 = OpBitwiseXor %uchar %4487 %4488
+OpStore %2095 %4489
+%4490 = OpLoad %_arr_uchar_uint_16 %1823
+%4491 = OpLoad %uchar %2050
+%4492 = OpCompositeInsert %_arr_uchar_uint_16 %4491 %4490 0
+OpStore %2096 %4492
+%4493 = OpLoad %_arr_uchar_uint_16 %2096
+%4494 = OpLoad %uchar %2053
+%4495 = OpCompositeInsert %_arr_uchar_uint_16 %4494 %4493 1
+OpStore %2097 %4495
+%4496 = OpLoad %_arr_uchar_uint_16 %2097
+%4497 = OpLoad %uchar %2056
+%4498 = OpCompositeInsert %_arr_uchar_uint_16 %4497 %4496 2
+OpStore %2098 %4498
+%4499 = OpLoad %_arr_uchar_uint_16 %2098
+%4500 = OpLoad %uchar %2059
+%4501 = OpCompositeInsert %_arr_uchar_uint_16 %4500 %4499 3
+OpStore %2099 %4501
+%4502 = OpLoad %_arr_uchar_uint_16 %2099
+%4503 = OpLoad %uchar %2062
+%4504 = OpCompositeInsert %_arr_uchar_uint_16 %4503 %4502 4
+OpStore %2100 %4504
+%4505 = OpLoad %_arr_uchar_uint_16 %2100
+%4506 = OpLoad %uchar %2065
+%4507 = OpCompositeInsert %_arr_uchar_uint_16 %4506 %4505 5
+OpStore %2101 %4507
+%4508 = OpLoad %_arr_uchar_uint_16 %2101
+%4509 = OpLoad %uchar %2068
+%4510 = OpCompositeInsert %_arr_uchar_uint_16 %4509 %4508 6
+OpStore %2102 %4510
+%4511 = OpLoad %_arr_uchar_uint_16 %2102
+%4512 = OpLoad %uchar %2071
+%4513 = OpCompositeInsert %_arr_uchar_uint_16 %4512 %4511 7
+OpStore %2103 %4513
+%4514 = OpLoad %_arr_uchar_uint_16 %2103
+%4515 = OpLoad %uchar %2074
+%4516 = OpCompositeInsert %_arr_uchar_uint_16 %4515 %4514 8
+OpStore %2104 %4516
+%4517 = OpLoad %_arr_uchar_uint_16 %2104
+%4518 = OpLoad %uchar %2077
+%4519 = OpCompositeInsert %_arr_uchar_uint_16 %4518 %4517 9
+OpStore %2105 %4519
+%4520 = OpLoad %_arr_uchar_uint_16 %2105
+%4521 = OpLoad %uchar %2080
+%4522 = OpCompositeInsert %_arr_uchar_uint_16 %4521 %4520 10
+OpStore %2106 %4522
+%4523 = OpLoad %_arr_uchar_uint_16 %2106
+%4524 = OpLoad %uchar %2083
+%4525 = OpCompositeInsert %_arr_uchar_uint_16 %4524 %4523 11
+OpStore %2107 %4525
+%4526 = OpLoad %_arr_uchar_uint_16 %2107
+%4527 = OpLoad %uchar %2086
+%4528 = OpCompositeInsert %_arr_uchar_uint_16 %4527 %4526 12
+OpStore %2108 %4528
+%4529 = OpLoad %_arr_uchar_uint_16 %2108
+%4530 = OpLoad %uchar %2089
+%4531 = OpCompositeInsert %_arr_uchar_uint_16 %4530 %4529 13
+OpStore %2109 %4531
+%4532 = OpLoad %_arr_uchar_uint_16 %2109
+%4533 = OpLoad %uchar %2092
+%4534 = OpCompositeInsert %_arr_uchar_uint_16 %4533 %4532 14
+OpStore %2110 %4534
+%4535 = OpLoad %_arr_uchar_uint_16 %2110
+%4536 = OpLoad %uchar %2095
+%4537 = OpCompositeInsert %_arr_uchar_uint_16 %4536 %4535 15
+OpStore %2111 %4537
+%4538 = OpLoad %ulong %771
+%4539 = OpLoad %_arr_uchar_uint_16 %2111
+%4540 = OpFunctionCall %ulong %1 %4538 %4539
+OpStore %772 %4540
+%4541 = OpLoad %ulong %772
+OpStore %790 %4541
+%4542 = OpLoad %_arr_uchar_uint_16 %749
+OpStore %791 %4542
+%4543 = OpLoad %_arr_uchar_uint_16 %743
+OpStore %792 %4543
+%4544 = OpLoad %_arr_uchar_uint_16 %743
+OpStore %793 %4544
+OpStore %794 %ulong_0
+OpBranch %717
+%717 = OpLabel
+%4545 = OpLoad %ulong %794
+%4547 = OpULessThan %bool %4545 %ulong_6
+OpStore %773 %4547
+%4548 = OpLoad %bool %773
+OpLoopMerge %719 %730 None
+OpBranchConditional %4548 %718 %719
+%719 = OpLabel
+OpStore %734 %4549
+%4551 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_0
+%4552 = OpLoad %_arr_uchar_uint_16 %791
+OpStore %4551 %4552
+%4553 = OpLoad %_arr_uchar_uint_16 %791
+%4554 = OpCompositeExtract %uchar %4553 0
+OpStore %1056 %4554
+%4555 = OpLoad %_arr_uchar_uint_16 %755
+%4556 = OpCompositeExtract %uchar %4555 0
+OpStore %1057 %4556
+%4557 = OpLoad %uchar %1056
+%4558 = OpLoad %uchar %1057
+%4559 = OpIAdd %uchar %4557 %4558
+OpStore %1058 %4559
+%4560 = OpLoad %_arr_uchar_uint_16 %791
+%4561 = OpCompositeExtract %uchar %4560 1
+OpStore %1059 %4561
+%4562 = OpLoad %_arr_uchar_uint_16 %755
+%4563 = OpCompositeExtract %uchar %4562 1
+OpStore %1060 %4563
+%4564 = OpLoad %uchar %1059
+%4565 = OpLoad %uchar %1060
+%4566 = OpIAdd %uchar %4564 %4565
+OpStore %1061 %4566
+%4567 = OpLoad %_arr_uchar_uint_16 %791
+%4568 = OpCompositeExtract %uchar %4567 2
+OpStore %1062 %4568
+%4569 = OpLoad %_arr_uchar_uint_16 %755
+%4570 = OpCompositeExtract %uchar %4569 2
+OpStore %1063 %4570
+%4571 = OpLoad %uchar %1062
+%4572 = OpLoad %uchar %1063
+%4573 = OpIAdd %uchar %4571 %4572
+OpStore %1064 %4573
+%4574 = OpLoad %_arr_uchar_uint_16 %791
+%4575 = OpCompositeExtract %uchar %4574 3
+OpStore %1065 %4575
+%4576 = OpLoad %_arr_uchar_uint_16 %755
+%4577 = OpCompositeExtract %uchar %4576 3
+OpStore %1066 %4577
+%4578 = OpLoad %uchar %1065
+%4579 = OpLoad %uchar %1066
+%4580 = OpIAdd %uchar %4578 %4579
+OpStore %1067 %4580
+%4581 = OpLoad %_arr_uchar_uint_16 %791
+%4582 = OpCompositeExtract %uchar %4581 4
+OpStore %1068 %4582
+%4583 = OpLoad %_arr_uchar_uint_16 %755
+%4584 = OpCompositeExtract %uchar %4583 4
+OpStore %1069 %4584
+%4585 = OpLoad %uchar %1068
+%4586 = OpLoad %uchar %1069
+%4587 = OpIAdd %uchar %4585 %4586
+OpStore %1070 %4587
+%4588 = OpLoad %_arr_uchar_uint_16 %791
+%4589 = OpCompositeExtract %uchar %4588 5
+OpStore %1071 %4589
+%4590 = OpLoad %_arr_uchar_uint_16 %755
+%4591 = OpCompositeExtract %uchar %4590 5
+OpStore %1072 %4591
+%4592 = OpLoad %uchar %1071
+%4593 = OpLoad %uchar %1072
+%4594 = OpIAdd %uchar %4592 %4593
+OpStore %1073 %4594
+%4595 = OpLoad %_arr_uchar_uint_16 %791
+%4596 = OpCompositeExtract %uchar %4595 6
+OpStore %1074 %4596
+%4597 = OpLoad %_arr_uchar_uint_16 %755
+%4598 = OpCompositeExtract %uchar %4597 6
+OpStore %1075 %4598
+%4599 = OpLoad %uchar %1074
+%4600 = OpLoad %uchar %1075
+%4601 = OpIAdd %uchar %4599 %4600
+OpStore %1076 %4601
+%4602 = OpLoad %_arr_uchar_uint_16 %791
+%4603 = OpCompositeExtract %uchar %4602 7
+OpStore %1077 %4603
+%4604 = OpLoad %_arr_uchar_uint_16 %755
+%4605 = OpCompositeExtract %uchar %4604 7
+OpStore %1078 %4605
+%4606 = OpLoad %uchar %1077
+%4607 = OpLoad %uchar %1078
+%4608 = OpIAdd %uchar %4606 %4607
+OpStore %1079 %4608
+%4609 = OpLoad %_arr_uchar_uint_16 %791
+%4610 = OpCompositeExtract %uchar %4609 8
+OpStore %1080 %4610
+%4611 = OpLoad %_arr_uchar_uint_16 %755
+%4612 = OpCompositeExtract %uchar %4611 8
+OpStore %1081 %4612
+%4613 = OpLoad %uchar %1080
+%4614 = OpLoad %uchar %1081
+%4615 = OpIAdd %uchar %4613 %4614
+OpStore %1082 %4615
+%4616 = OpLoad %_arr_uchar_uint_16 %791
+%4617 = OpCompositeExtract %uchar %4616 9
+OpStore %1083 %4617
+%4618 = OpLoad %_arr_uchar_uint_16 %755
+%4619 = OpCompositeExtract %uchar %4618 9
+OpStore %1084 %4619
+%4620 = OpLoad %uchar %1083
+%4621 = OpLoad %uchar %1084
+%4622 = OpIAdd %uchar %4620 %4621
+OpStore %1085 %4622
+%4623 = OpLoad %_arr_uchar_uint_16 %791
+%4624 = OpCompositeExtract %uchar %4623 10
+OpStore %1086 %4624
+%4625 = OpLoad %_arr_uchar_uint_16 %755
+%4626 = OpCompositeExtract %uchar %4625 10
+OpStore %1087 %4626
+%4627 = OpLoad %uchar %1086
+%4628 = OpLoad %uchar %1087
+%4629 = OpIAdd %uchar %4627 %4628
+OpStore %1088 %4629
+%4630 = OpLoad %_arr_uchar_uint_16 %791
+%4631 = OpCompositeExtract %uchar %4630 11
+OpStore %1089 %4631
+%4632 = OpLoad %_arr_uchar_uint_16 %755
+%4633 = OpCompositeExtract %uchar %4632 11
+OpStore %1090 %4633
+%4634 = OpLoad %uchar %1089
+%4635 = OpLoad %uchar %1090
+%4636 = OpIAdd %uchar %4634 %4635
+OpStore %1091 %4636
+%4637 = OpLoad %_arr_uchar_uint_16 %791
+%4638 = OpCompositeExtract %uchar %4637 12
+OpStore %1092 %4638
+%4639 = OpLoad %_arr_uchar_uint_16 %755
+%4640 = OpCompositeExtract %uchar %4639 12
+OpStore %1093 %4640
+%4641 = OpLoad %uchar %1092
+%4642 = OpLoad %uchar %1093
+%4643 = OpIAdd %uchar %4641 %4642
+OpStore %1094 %4643
+%4644 = OpLoad %_arr_uchar_uint_16 %791
+%4645 = OpCompositeExtract %uchar %4644 13
+OpStore %1095 %4645
+%4646 = OpLoad %_arr_uchar_uint_16 %755
+%4647 = OpCompositeExtract %uchar %4646 13
+OpStore %1096 %4647
+%4648 = OpLoad %uchar %1095
+%4649 = OpLoad %uchar %1096
+%4650 = OpIAdd %uchar %4648 %4649
+OpStore %1097 %4650
+%4651 = OpLoad %_arr_uchar_uint_16 %791
+%4652 = OpCompositeExtract %uchar %4651 14
+OpStore %1098 %4652
+%4653 = OpLoad %_arr_uchar_uint_16 %755
+%4654 = OpCompositeExtract %uchar %4653 14
+OpStore %1099 %4654
+%4655 = OpLoad %uchar %1098
+%4656 = OpLoad %uchar %1099
+%4657 = OpIAdd %uchar %4655 %4656
+OpStore %1100 %4657
+%4658 = OpLoad %_arr_uchar_uint_16 %791
+%4659 = OpCompositeExtract %uchar %4658 15
+OpStore %1101 %4659
+%4660 = OpLoad %_arr_uchar_uint_16 %755
+%4661 = OpCompositeExtract %uchar %4660 15
+OpStore %1102 %4661
+%4662 = OpLoad %uchar %1101
+%4663 = OpLoad %uchar %1102
+%4664 = OpIAdd %uchar %4662 %4663
+OpStore %1103 %4664
+%4665 = OpLoad %_arr_uchar_uint_16 %791
+%4666 = OpLoad %uchar %1058
+%4667 = OpCompositeInsert %_arr_uchar_uint_16 %4666 %4665 0
+OpStore %1104 %4667
+%4668 = OpLoad %_arr_uchar_uint_16 %1104
+%4669 = OpLoad %uchar %1061
+%4670 = OpCompositeInsert %_arr_uchar_uint_16 %4669 %4668 1
+OpStore %1105 %4670
+%4671 = OpLoad %_arr_uchar_uint_16 %1105
+%4672 = OpLoad %uchar %1064
+%4673 = OpCompositeInsert %_arr_uchar_uint_16 %4672 %4671 2
+OpStore %1106 %4673
+%4674 = OpLoad %_arr_uchar_uint_16 %1106
+%4675 = OpLoad %uchar %1067
+%4676 = OpCompositeInsert %_arr_uchar_uint_16 %4675 %4674 3
+OpStore %1107 %4676
+%4677 = OpLoad %_arr_uchar_uint_16 %1107
+%4678 = OpLoad %uchar %1070
+%4679 = OpCompositeInsert %_arr_uchar_uint_16 %4678 %4677 4
+OpStore %1108 %4679
+%4680 = OpLoad %_arr_uchar_uint_16 %1108
+%4681 = OpLoad %uchar %1073
+%4682 = OpCompositeInsert %_arr_uchar_uint_16 %4681 %4680 5
+OpStore %1109 %4682
+%4683 = OpLoad %_arr_uchar_uint_16 %1109
+%4684 = OpLoad %uchar %1076
+%4685 = OpCompositeInsert %_arr_uchar_uint_16 %4684 %4683 6
+OpStore %1110 %4685
+%4686 = OpLoad %_arr_uchar_uint_16 %1110
+%4687 = OpLoad %uchar %1079
+%4688 = OpCompositeInsert %_arr_uchar_uint_16 %4687 %4686 7
+OpStore %1111 %4688
+%4689 = OpLoad %_arr_uchar_uint_16 %1111
+%4690 = OpLoad %uchar %1082
+%4691 = OpCompositeInsert %_arr_uchar_uint_16 %4690 %4689 8
+OpStore %1112 %4691
+%4692 = OpLoad %_arr_uchar_uint_16 %1112
+%4693 = OpLoad %uchar %1085
+%4694 = OpCompositeInsert %_arr_uchar_uint_16 %4693 %4692 9
+OpStore %1113 %4694
+%4695 = OpLoad %_arr_uchar_uint_16 %1113
+%4696 = OpLoad %uchar %1088
+%4697 = OpCompositeInsert %_arr_uchar_uint_16 %4696 %4695 10
+OpStore %1114 %4697
+%4698 = OpLoad %_arr_uchar_uint_16 %1114
+%4699 = OpLoad %uchar %1091
+%4700 = OpCompositeInsert %_arr_uchar_uint_16 %4699 %4698 11
+OpStore %1115 %4700
+%4701 = OpLoad %_arr_uchar_uint_16 %1115
+%4702 = OpLoad %uchar %1094
+%4703 = OpCompositeInsert %_arr_uchar_uint_16 %4702 %4701 12
+OpStore %1116 %4703
+%4704 = OpLoad %_arr_uchar_uint_16 %1116
+%4705 = OpLoad %uchar %1097
+%4706 = OpCompositeInsert %_arr_uchar_uint_16 %4705 %4704 13
+OpStore %1117 %4706
+%4707 = OpLoad %_arr_uchar_uint_16 %1117
+%4708 = OpLoad %uchar %1100
+%4709 = OpCompositeInsert %_arr_uchar_uint_16 %4708 %4707 14
+OpStore %1118 %4709
+%4710 = OpLoad %_arr_uchar_uint_16 %1118
+%4711 = OpLoad %uchar %1103
+%4712 = OpCompositeInsert %_arr_uchar_uint_16 %4711 %4710 15
+OpStore %1119 %4712
+%4714 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_1
+%4715 = OpLoad %_arr_uchar_uint_16 %1119
+OpStore %4714 %4715
+%4716 = OpLoad %_arr_uchar_uint_16 %791
+%4717 = OpCompositeExtract %uchar %4716 0
+OpStore %1120 %4717
+%4718 = OpLoad %_arr_uchar_uint_16 %742
+%4719 = OpCompositeExtract %uchar %4718 0
+OpStore %1121 %4719
+%4720 = OpLoad %uchar %1120
+%4721 = OpLoad %uchar %1121
+%4722 = OpIMul %uchar %4720 %4721
+OpStore %1122 %4722
+%4723 = OpLoad %_arr_uchar_uint_16 %791
+%4724 = OpCompositeExtract %uchar %4723 1
+OpStore %1123 %4724
+%4725 = OpLoad %_arr_uchar_uint_16 %742
+%4726 = OpCompositeExtract %uchar %4725 1
+OpStore %1124 %4726
+%4727 = OpLoad %uchar %1123
+%4728 = OpLoad %uchar %1124
+%4729 = OpIMul %uchar %4727 %4728
+OpStore %1125 %4729
+%4730 = OpLoad %_arr_uchar_uint_16 %791
+%4731 = OpCompositeExtract %uchar %4730 2
+OpStore %1126 %4731
+%4732 = OpLoad %_arr_uchar_uint_16 %742
+%4733 = OpCompositeExtract %uchar %4732 2
+OpStore %1127 %4733
+%4734 = OpLoad %uchar %1126
+%4735 = OpLoad %uchar %1127
+%4736 = OpIMul %uchar %4734 %4735
+OpStore %1128 %4736
+%4737 = OpLoad %_arr_uchar_uint_16 %791
+%4738 = OpCompositeExtract %uchar %4737 3
+OpStore %1129 %4738
+%4739 = OpLoad %_arr_uchar_uint_16 %742
+%4740 = OpCompositeExtract %uchar %4739 3
+OpStore %1130 %4740
+%4741 = OpLoad %uchar %1129
+%4742 = OpLoad %uchar %1130
+%4743 = OpIMul %uchar %4741 %4742
+OpStore %1131 %4743
+%4744 = OpLoad %_arr_uchar_uint_16 %791
+%4745 = OpCompositeExtract %uchar %4744 4
+OpStore %1132 %4745
+%4746 = OpLoad %_arr_uchar_uint_16 %742
+%4747 = OpCompositeExtract %uchar %4746 4
+OpStore %1133 %4747
+%4748 = OpLoad %uchar %1132
+%4749 = OpLoad %uchar %1133
+%4750 = OpIMul %uchar %4748 %4749
+OpStore %1134 %4750
+%4751 = OpLoad %_arr_uchar_uint_16 %791
+%4752 = OpCompositeExtract %uchar %4751 5
+OpStore %1135 %4752
+%4753 = OpLoad %_arr_uchar_uint_16 %742
+%4754 = OpCompositeExtract %uchar %4753 5
+OpStore %1136 %4754
+%4755 = OpLoad %uchar %1135
+%4756 = OpLoad %uchar %1136
+%4757 = OpIMul %uchar %4755 %4756
+OpStore %1137 %4757
+%4758 = OpLoad %_arr_uchar_uint_16 %791
+%4759 = OpCompositeExtract %uchar %4758 6
+OpStore %1138 %4759
+%4760 = OpLoad %_arr_uchar_uint_16 %742
+%4761 = OpCompositeExtract %uchar %4760 6
+OpStore %1139 %4761
+%4762 = OpLoad %uchar %1138
+%4763 = OpLoad %uchar %1139
+%4764 = OpIMul %uchar %4762 %4763
+OpStore %1140 %4764
+%4765 = OpLoad %_arr_uchar_uint_16 %791
+%4766 = OpCompositeExtract %uchar %4765 7
+OpStore %1141 %4766
+%4767 = OpLoad %_arr_uchar_uint_16 %742
+%4768 = OpCompositeExtract %uchar %4767 7
+OpStore %1142 %4768
+%4769 = OpLoad %uchar %1141
+%4770 = OpLoad %uchar %1142
+%4771 = OpIMul %uchar %4769 %4770
+OpStore %1143 %4771
+%4772 = OpLoad %_arr_uchar_uint_16 %791
+%4773 = OpCompositeExtract %uchar %4772 8
+OpStore %1144 %4773
+%4774 = OpLoad %_arr_uchar_uint_16 %742
+%4775 = OpCompositeExtract %uchar %4774 8
+OpStore %1145 %4775
+%4776 = OpLoad %uchar %1144
+%4777 = OpLoad %uchar %1145
+%4778 = OpIMul %uchar %4776 %4777
+OpStore %1146 %4778
+%4779 = OpLoad %_arr_uchar_uint_16 %791
+%4780 = OpCompositeExtract %uchar %4779 9
+OpStore %1147 %4780
+%4781 = OpLoad %_arr_uchar_uint_16 %742
+%4782 = OpCompositeExtract %uchar %4781 9
+OpStore %1148 %4782
+%4783 = OpLoad %uchar %1147
+%4784 = OpLoad %uchar %1148
+%4785 = OpIMul %uchar %4783 %4784
+OpStore %1149 %4785
+%4786 = OpLoad %_arr_uchar_uint_16 %791
+%4787 = OpCompositeExtract %uchar %4786 10
+OpStore %1150 %4787
+%4788 = OpLoad %_arr_uchar_uint_16 %742
+%4789 = OpCompositeExtract %uchar %4788 10
+OpStore %1151 %4789
+%4790 = OpLoad %uchar %1150
+%4791 = OpLoad %uchar %1151
+%4792 = OpIMul %uchar %4790 %4791
+OpStore %1152 %4792
+%4793 = OpLoad %_arr_uchar_uint_16 %791
+%4794 = OpCompositeExtract %uchar %4793 11
+OpStore %1153 %4794
+%4795 = OpLoad %_arr_uchar_uint_16 %742
+%4796 = OpCompositeExtract %uchar %4795 11
+OpStore %1154 %4796
+%4797 = OpLoad %uchar %1153
+%4798 = OpLoad %uchar %1154
+%4799 = OpIMul %uchar %4797 %4798
+OpStore %1155 %4799
+%4800 = OpLoad %_arr_uchar_uint_16 %791
+%4801 = OpCompositeExtract %uchar %4800 12
+OpStore %1156 %4801
+%4802 = OpLoad %_arr_uchar_uint_16 %742
+%4803 = OpCompositeExtract %uchar %4802 12
+OpStore %1157 %4803
+%4804 = OpLoad %uchar %1156
+%4805 = OpLoad %uchar %1157
+%4806 = OpIMul %uchar %4804 %4805
+OpStore %1158 %4806
+%4807 = OpLoad %_arr_uchar_uint_16 %791
+%4808 = OpCompositeExtract %uchar %4807 13
+OpStore %1159 %4808
+%4809 = OpLoad %_arr_uchar_uint_16 %742
+%4810 = OpCompositeExtract %uchar %4809 13
+OpStore %1160 %4810
+%4811 = OpLoad %uchar %1159
+%4812 = OpLoad %uchar %1160
+%4813 = OpIMul %uchar %4811 %4812
+OpStore %1161 %4813
+%4814 = OpLoad %_arr_uchar_uint_16 %791
+%4815 = OpCompositeExtract %uchar %4814 14
+OpStore %1162 %4815
+%4816 = OpLoad %_arr_uchar_uint_16 %742
+%4817 = OpCompositeExtract %uchar %4816 14
+OpStore %1163 %4817
+%4818 = OpLoad %uchar %1162
+%4819 = OpLoad %uchar %1163
+%4820 = OpIMul %uchar %4818 %4819
+OpStore %1164 %4820
+%4821 = OpLoad %_arr_uchar_uint_16 %791
+%4822 = OpCompositeExtract %uchar %4821 15
+OpStore %1165 %4822
+%4823 = OpLoad %_arr_uchar_uint_16 %742
+%4824 = OpCompositeExtract %uchar %4823 15
+OpStore %1166 %4824
+%4825 = OpLoad %uchar %1165
+%4826 = OpLoad %uchar %1166
+%4827 = OpIMul %uchar %4825 %4826
+OpStore %1167 %4827
+%4828 = OpLoad %_arr_uchar_uint_16 %791
+%4829 = OpLoad %uchar %1122
+%4830 = OpCompositeInsert %_arr_uchar_uint_16 %4829 %4828 0
+OpStore %1168 %4830
+%4831 = OpLoad %_arr_uchar_uint_16 %1168
+%4832 = OpLoad %uchar %1125
+%4833 = OpCompositeInsert %_arr_uchar_uint_16 %4832 %4831 1
+OpStore %1169 %4833
+%4834 = OpLoad %_arr_uchar_uint_16 %1169
+%4835 = OpLoad %uchar %1128
+%4836 = OpCompositeInsert %_arr_uchar_uint_16 %4835 %4834 2
+OpStore %1170 %4836
+%4837 = OpLoad %_arr_uchar_uint_16 %1170
+%4838 = OpLoad %uchar %1131
+%4839 = OpCompositeInsert %_arr_uchar_uint_16 %4838 %4837 3
+OpStore %1171 %4839
+%4840 = OpLoad %_arr_uchar_uint_16 %1171
+%4841 = OpLoad %uchar %1134
+%4842 = OpCompositeInsert %_arr_uchar_uint_16 %4841 %4840 4
+OpStore %1172 %4842
+%4843 = OpLoad %_arr_uchar_uint_16 %1172
+%4844 = OpLoad %uchar %1137
+%4845 = OpCompositeInsert %_arr_uchar_uint_16 %4844 %4843 5
+OpStore %1173 %4845
+%4846 = OpLoad %_arr_uchar_uint_16 %1173
+%4847 = OpLoad %uchar %1140
+%4848 = OpCompositeInsert %_arr_uchar_uint_16 %4847 %4846 6
+OpStore %1174 %4848
+%4849 = OpLoad %_arr_uchar_uint_16 %1174
+%4850 = OpLoad %uchar %1143
+%4851 = OpCompositeInsert %_arr_uchar_uint_16 %4850 %4849 7
+OpStore %1175 %4851
+%4852 = OpLoad %_arr_uchar_uint_16 %1175
+%4853 = OpLoad %uchar %1146
+%4854 = OpCompositeInsert %_arr_uchar_uint_16 %4853 %4852 8
+OpStore %1176 %4854
+%4855 = OpLoad %_arr_uchar_uint_16 %1176
+%4856 = OpLoad %uchar %1149
+%4857 = OpCompositeInsert %_arr_uchar_uint_16 %4856 %4855 9
+OpStore %1177 %4857
+%4858 = OpLoad %_arr_uchar_uint_16 %1177
+%4859 = OpLoad %uchar %1152
+%4860 = OpCompositeInsert %_arr_uchar_uint_16 %4859 %4858 10
+OpStore %1178 %4860
+%4861 = OpLoad %_arr_uchar_uint_16 %1178
+%4862 = OpLoad %uchar %1155
+%4863 = OpCompositeInsert %_arr_uchar_uint_16 %4862 %4861 11
+OpStore %1179 %4863
+%4864 = OpLoad %_arr_uchar_uint_16 %1179
+%4865 = OpLoad %uchar %1158
+%4866 = OpCompositeInsert %_arr_uchar_uint_16 %4865 %4864 12
+OpStore %1180 %4866
+%4867 = OpLoad %_arr_uchar_uint_16 %1180
+%4868 = OpLoad %uchar %1161
+%4869 = OpCompositeInsert %_arr_uchar_uint_16 %4868 %4867 13
+OpStore %1181 %4869
+%4870 = OpLoad %_arr_uchar_uint_16 %1181
+%4871 = OpLoad %uchar %1164
+%4872 = OpCompositeInsert %_arr_uchar_uint_16 %4871 %4870 14
+OpStore %1182 %4872
+%4873 = OpLoad %_arr_uchar_uint_16 %1182
+%4874 = OpLoad %uchar %1167
+%4875 = OpCompositeInsert %_arr_uchar_uint_16 %4874 %4873 15
+OpStore %1183 %4875
+%4877 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_2
+%4878 = OpLoad %_arr_uchar_uint_16 %1183
+OpStore %4877 %4878
+%4880 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_3
+%4881 = OpLoad %_arr_uchar_uint_16 %792
+OpStore %4880 %4881
+%4882 = OpLoad %ulong %790
+OpStore %789 %4882
+OpStore %795 %ulong_0
+OpBranch %720
+%720 = OpLabel
+%4883 = OpLoad %ulong %795
+%4885 = OpULessThan %bool %4883 %ulong_4
+OpStore %779 %4885
+%4886 = OpLoad %bool %779
+OpLoopMerge %722 %729 None
+OpBranchConditional %4886 %721 %722
+%722 = OpLabel
+OpStore %737 %4887
+%4888 = OpAccessChain %_ptr_Function_uint %737 %uint_0
+OpStore %4888 %uint_4294967295
+%4890 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %uint_2
+%4891 = OpLoad %_arr_uchar_uint_16 %4890
+OpStore %783 %4891
+%4892 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %737 %uint_1
+%4893 = OpLoad %_arr_uchar_uint_16 %783
+OpStore %4892 %4893
+%4894 = OpAccessChain %_ptr_Function_uint %737 %uint_2
+OpStore %4894 %uint_305419896
+%4896 = OpLoad %uint %4888
+OpStore %785 %4896
+OpBranch %725
+%725 = OpLabel
+%4897 = OpLoad %uint %785
+%4898 = OpUConvert %ulong %4897
+OpStore %796 %4898
+%4899 = OpLoad %ulong %789
+%4900 = OpLoad %ulong %796
+%4901 = OpFunctionCall %ulong %3 %4899 %4900
+OpStore %797 %4901
+OpBranch %726
+%726 = OpLabel
+%4902 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %737 %uint_1
+%4903 = OpLoad %_arr_uchar_uint_16 %4902
+OpStore %786 %4903
+%4904 = OpLoad %ulong %797
+%4905 = OpLoad %_arr_uchar_uint_16 %786
+%4906 = OpFunctionCall %ulong %1 %4904 %4905
+OpStore %787 %4906
+%4907 = OpAccessChain %_ptr_Function_uint %737 %uint_2
+%4908 = OpLoad %uint %4907
+OpStore %788 %4908
+OpBranch %727
+%727 = OpLabel
+%4909 = OpLoad %uint %788
+%4910 = OpUConvert %ulong %4909
+OpStore %798 %4910
+%4911 = OpLoad %ulong %787
+%4912 = OpLoad %ulong %798
+%4913 = OpFunctionCall %ulong %3 %4911 %4912
+OpStore %799 %4913
+OpBranch %728
+%728 = OpLabel
+%4914 = OpLoad %ulong %799
+OpReturnValue %4914
+%721 = OpLabel
+%4915 = OpLoad %ulong %795
+%4916 = OpAccessChain %_ptr_Function__arr_uchar_uint_16 %734 %4915
+%4917 = OpLoad %_arr_uchar_uint_16 %4916
+OpStore %780 %4917
+%4918 = OpLoad %ulong %789
+%4919 = OpLoad %_arr_uchar_uint_16 %780
+%4920 = OpFunctionCall %ulong %1 %4918 %4919
+OpStore %781 %4920
+%4921 = OpLoad %ulong %795
+%4922 = OpIAdd %ulong %4921 %ulong_1
+OpStore %782 %4922
+%4923 = OpLoad %ulong %781
+OpStore %789 %4923
+%4924 = OpLoad %ulong %782
+OpStore %795 %4924
+OpBranch %729
+%718 = OpLabel
+%4925 = OpLoad %_arr_uchar_uint_16 %791
+%4926 = OpCompositeExtract %uchar %4925 0
+OpStore %800 %4926
+%4927 = OpLoad %_arr_uchar_uint_16 %742
+%4928 = OpCompositeExtract %uchar %4927 0
+OpStore %801 %4928
+%4929 = OpLoad %uchar %800
+%4930 = OpLoad %uchar %801
+%4931 = OpIMul %uchar %4929 %4930
+OpStore %802 %4931
+%4932 = OpLoad %_arr_uchar_uint_16 %791
+%4933 = OpCompositeExtract %uchar %4932 1
+OpStore %803 %4933
+%4934 = OpLoad %_arr_uchar_uint_16 %742
+%4935 = OpCompositeExtract %uchar %4934 1
+OpStore %804 %4935
+%4936 = OpLoad %uchar %803
+%4937 = OpLoad %uchar %804
+%4938 = OpIMul %uchar %4936 %4937
+OpStore %805 %4938
+%4939 = OpLoad %_arr_uchar_uint_16 %791
+%4940 = OpCompositeExtract %uchar %4939 2
+OpStore %806 %4940
+%4941 = OpLoad %_arr_uchar_uint_16 %742
+%4942 = OpCompositeExtract %uchar %4941 2
+OpStore %807 %4942
+%4943 = OpLoad %uchar %806
+%4944 = OpLoad %uchar %807
+%4945 = OpIMul %uchar %4943 %4944
+OpStore %808 %4945
+%4946 = OpLoad %_arr_uchar_uint_16 %791
+%4947 = OpCompositeExtract %uchar %4946 3
+OpStore %809 %4947
+%4948 = OpLoad %_arr_uchar_uint_16 %742
+%4949 = OpCompositeExtract %uchar %4948 3
+OpStore %810 %4949
+%4950 = OpLoad %uchar %809
+%4951 = OpLoad %uchar %810
+%4952 = OpIMul %uchar %4950 %4951
+OpStore %811 %4952
+%4953 = OpLoad %_arr_uchar_uint_16 %791
+%4954 = OpCompositeExtract %uchar %4953 4
+OpStore %812 %4954
+%4955 = OpLoad %_arr_uchar_uint_16 %742
+%4956 = OpCompositeExtract %uchar %4955 4
+OpStore %813 %4956
+%4957 = OpLoad %uchar %812
+%4958 = OpLoad %uchar %813
+%4959 = OpIMul %uchar %4957 %4958
+OpStore %814 %4959
+%4960 = OpLoad %_arr_uchar_uint_16 %791
+%4961 = OpCompositeExtract %uchar %4960 5
+OpStore %815 %4961
+%4962 = OpLoad %_arr_uchar_uint_16 %742
+%4963 = OpCompositeExtract %uchar %4962 5
+OpStore %816 %4963
+%4964 = OpLoad %uchar %815
+%4965 = OpLoad %uchar %816
+%4966 = OpIMul %uchar %4964 %4965
+OpStore %817 %4966
+%4967 = OpLoad %_arr_uchar_uint_16 %791
+%4968 = OpCompositeExtract %uchar %4967 6
+OpStore %818 %4968
+%4969 = OpLoad %_arr_uchar_uint_16 %742
+%4970 = OpCompositeExtract %uchar %4969 6
+OpStore %819 %4970
+%4971 = OpLoad %uchar %818
+%4972 = OpLoad %uchar %819
+%4973 = OpIMul %uchar %4971 %4972
+OpStore %820 %4973
+%4974 = OpLoad %_arr_uchar_uint_16 %791
+%4975 = OpCompositeExtract %uchar %4974 7
+OpStore %821 %4975
+%4976 = OpLoad %_arr_uchar_uint_16 %742
+%4977 = OpCompositeExtract %uchar %4976 7
+OpStore %822 %4977
+%4978 = OpLoad %uchar %821
+%4979 = OpLoad %uchar %822
+%4980 = OpIMul %uchar %4978 %4979
+OpStore %823 %4980
+%4981 = OpLoad %_arr_uchar_uint_16 %791
+%4982 = OpCompositeExtract %uchar %4981 8
+OpStore %824 %4982
+%4983 = OpLoad %_arr_uchar_uint_16 %742
+%4984 = OpCompositeExtract %uchar %4983 8
+OpStore %825 %4984
+%4985 = OpLoad %uchar %824
+%4986 = OpLoad %uchar %825
+%4987 = OpIMul %uchar %4985 %4986
+OpStore %826 %4987
+%4988 = OpLoad %_arr_uchar_uint_16 %791
+%4989 = OpCompositeExtract %uchar %4988 9
+OpStore %827 %4989
+%4990 = OpLoad %_arr_uchar_uint_16 %742
+%4991 = OpCompositeExtract %uchar %4990 9
+OpStore %828 %4991
+%4992 = OpLoad %uchar %827
+%4993 = OpLoad %uchar %828
+%4994 = OpIMul %uchar %4992 %4993
+OpStore %829 %4994
+%4995 = OpLoad %_arr_uchar_uint_16 %791
+%4996 = OpCompositeExtract %uchar %4995 10
+OpStore %830 %4996
+%4997 = OpLoad %_arr_uchar_uint_16 %742
+%4998 = OpCompositeExtract %uchar %4997 10
+OpStore %831 %4998
+%4999 = OpLoad %uchar %830
+%5000 = OpLoad %uchar %831
+%5001 = OpIMul %uchar %4999 %5000
+OpStore %832 %5001
+%5002 = OpLoad %_arr_uchar_uint_16 %791
+%5003 = OpCompositeExtract %uchar %5002 11
+OpStore %833 %5003
+%5004 = OpLoad %_arr_uchar_uint_16 %742
+%5005 = OpCompositeExtract %uchar %5004 11
+OpStore %834 %5005
+%5006 = OpLoad %uchar %833
+%5007 = OpLoad %uchar %834
+%5008 = OpIMul %uchar %5006 %5007
+OpStore %835 %5008
+%5009 = OpLoad %_arr_uchar_uint_16 %791
+%5010 = OpCompositeExtract %uchar %5009 12
+OpStore %836 %5010
+%5011 = OpLoad %_arr_uchar_uint_16 %742
+%5012 = OpCompositeExtract %uchar %5011 12
+OpStore %837 %5012
+%5013 = OpLoad %uchar %836
+%5014 = OpLoad %uchar %837
+%5015 = OpIMul %uchar %5013 %5014
+OpStore %838 %5015
+%5016 = OpLoad %_arr_uchar_uint_16 %791
+%5017 = OpCompositeExtract %uchar %5016 13
+OpStore %839 %5017
+%5018 = OpLoad %_arr_uchar_uint_16 %742
+%5019 = OpCompositeExtract %uchar %5018 13
+OpStore %840 %5019
+%5020 = OpLoad %uchar %839
+%5021 = OpLoad %uchar %840
+%5022 = OpIMul %uchar %5020 %5021
+OpStore %841 %5022
+%5023 = OpLoad %_arr_uchar_uint_16 %791
+%5024 = OpCompositeExtract %uchar %5023 14
+OpStore %842 %5024
+%5025 = OpLoad %_arr_uchar_uint_16 %742
+%5026 = OpCompositeExtract %uchar %5025 14
+OpStore %843 %5026
+%5027 = OpLoad %uchar %842
+%5028 = OpLoad %uchar %843
+%5029 = OpIMul %uchar %5027 %5028
+OpStore %844 %5029
+%5030 = OpLoad %_arr_uchar_uint_16 %791
+%5031 = OpCompositeExtract %uchar %5030 15
+OpStore %845 %5031
+%5032 = OpLoad %_arr_uchar_uint_16 %742
+%5033 = OpCompositeExtract %uchar %5032 15
+OpStore %846 %5033
+%5034 = OpLoad %uchar %845
+%5035 = OpLoad %uchar %846
+%5036 = OpIMul %uchar %5034 %5035
+OpStore %847 %5036
+%5037 = OpLoad %_arr_uchar_uint_16 %791
+%5038 = OpLoad %uchar %802
+%5039 = OpCompositeInsert %_arr_uchar_uint_16 %5038 %5037 0
+OpStore %848 %5039
+%5040 = OpLoad %_arr_uchar_uint_16 %848
+%5041 = OpLoad %uchar %805
+%5042 = OpCompositeInsert %_arr_uchar_uint_16 %5041 %5040 1
+OpStore %849 %5042
+%5043 = OpLoad %_arr_uchar_uint_16 %849
+%5044 = OpLoad %uchar %808
+%5045 = OpCompositeInsert %_arr_uchar_uint_16 %5044 %5043 2
+OpStore %850 %5045
+%5046 = OpLoad %_arr_uchar_uint_16 %850
+%5047 = OpLoad %uchar %811
+%5048 = OpCompositeInsert %_arr_uchar_uint_16 %5047 %5046 3
+OpStore %851 %5048
+%5049 = OpLoad %_arr_uchar_uint_16 %851
+%5050 = OpLoad %uchar %814
+%5051 = OpCompositeInsert %_arr_uchar_uint_16 %5050 %5049 4
+OpStore %852 %5051
+%5052 = OpLoad %_arr_uchar_uint_16 %852
+%5053 = OpLoad %uchar %817
+%5054 = OpCompositeInsert %_arr_uchar_uint_16 %5053 %5052 5
+OpStore %853 %5054
+%5055 = OpLoad %_arr_uchar_uint_16 %853
+%5056 = OpLoad %uchar %820
+%5057 = OpCompositeInsert %_arr_uchar_uint_16 %5056 %5055 6
+OpStore %854 %5057
+%5058 = OpLoad %_arr_uchar_uint_16 %854
+%5059 = OpLoad %uchar %823
+%5060 = OpCompositeInsert %_arr_uchar_uint_16 %5059 %5058 7
+OpStore %855 %5060
+%5061 = OpLoad %_arr_uchar_uint_16 %855
+%5062 = OpLoad %uchar %826
+%5063 = OpCompositeInsert %_arr_uchar_uint_16 %5062 %5061 8
+OpStore %856 %5063
+%5064 = OpLoad %_arr_uchar_uint_16 %856
+%5065 = OpLoad %uchar %829
+%5066 = OpCompositeInsert %_arr_uchar_uint_16 %5065 %5064 9
+OpStore %857 %5066
+%5067 = OpLoad %_arr_uchar_uint_16 %857
+%5068 = OpLoad %uchar %832
+%5069 = OpCompositeInsert %_arr_uchar_uint_16 %5068 %5067 10
+OpStore %858 %5069
+%5070 = OpLoad %_arr_uchar_uint_16 %858
+%5071 = OpLoad %uchar %835
+%5072 = OpCompositeInsert %_arr_uchar_uint_16 %5071 %5070 11
+OpStore %859 %5072
+%5073 = OpLoad %_arr_uchar_uint_16 %859
+%5074 = OpLoad %uchar %838
+%5075 = OpCompositeInsert %_arr_uchar_uint_16 %5074 %5073 12
+OpStore %860 %5075
+%5076 = OpLoad %_arr_uchar_uint_16 %860
+%5077 = OpLoad %uchar %841
+%5078 = OpCompositeInsert %_arr_uchar_uint_16 %5077 %5076 13
+OpStore %861 %5078
+%5079 = OpLoad %_arr_uchar_uint_16 %861
+%5080 = OpLoad %uchar %844
+%5081 = OpCompositeInsert %_arr_uchar_uint_16 %5080 %5079 14
+OpStore %862 %5081
+%5082 = OpLoad %_arr_uchar_uint_16 %862
+%5083 = OpLoad %uchar %847
+%5084 = OpCompositeInsert %_arr_uchar_uint_16 %5083 %5082 15
+OpStore %863 %5084
+%5085 = OpLoad %ulong %790
+%5086 = OpLoad %_arr_uchar_uint_16 %863
+%5087 = OpFunctionCall %ulong %1 %5085 %5086
+OpStore %774 %5087
+%5088 = OpLoad %_arr_uchar_uint_16 %792
+%5089 = OpCompositeExtract %uchar %5088 0
+OpStore %864 %5089
+%5090 = OpLoad %_arr_uchar_uint_16 %863
+%5091 = OpCompositeExtract %uchar %5090 0
+OpStore %865 %5091
+%5092 = OpLoad %uchar %864
+%5093 = OpLoad %uchar %865
+%5094 = OpBitwiseXor %uchar %5092 %5093
+OpStore %866 %5094
+%5095 = OpLoad %_arr_uchar_uint_16 %792
+%5096 = OpCompositeExtract %uchar %5095 1
+OpStore %867 %5096
+%5097 = OpLoad %_arr_uchar_uint_16 %863
+%5098 = OpCompositeExtract %uchar %5097 1
+OpStore %868 %5098
+%5099 = OpLoad %uchar %867
+%5100 = OpLoad %uchar %868
+%5101 = OpBitwiseXor %uchar %5099 %5100
+OpStore %869 %5101
+%5102 = OpLoad %_arr_uchar_uint_16 %792
+%5103 = OpCompositeExtract %uchar %5102 2
+OpStore %870 %5103
+%5104 = OpLoad %_arr_uchar_uint_16 %863
+%5105 = OpCompositeExtract %uchar %5104 2
+OpStore %871 %5105
+%5106 = OpLoad %uchar %870
+%5107 = OpLoad %uchar %871
+%5108 = OpBitwiseXor %uchar %5106 %5107
+OpStore %872 %5108
+%5109 = OpLoad %_arr_uchar_uint_16 %792
+%5110 = OpCompositeExtract %uchar %5109 3
+OpStore %873 %5110
+%5111 = OpLoad %_arr_uchar_uint_16 %863
+%5112 = OpCompositeExtract %uchar %5111 3
+OpStore %874 %5112
+%5113 = OpLoad %uchar %873
+%5114 = OpLoad %uchar %874
+%5115 = OpBitwiseXor %uchar %5113 %5114
+OpStore %875 %5115
+%5116 = OpLoad %_arr_uchar_uint_16 %792
+%5117 = OpCompositeExtract %uchar %5116 4
+OpStore %876 %5117
+%5118 = OpLoad %_arr_uchar_uint_16 %863
+%5119 = OpCompositeExtract %uchar %5118 4
+OpStore %877 %5119
+%5120 = OpLoad %uchar %876
+%5121 = OpLoad %uchar %877
+%5122 = OpBitwiseXor %uchar %5120 %5121
+OpStore %878 %5122
+%5123 = OpLoad %_arr_uchar_uint_16 %792
+%5124 = OpCompositeExtract %uchar %5123 5
+OpStore %879 %5124
+%5125 = OpLoad %_arr_uchar_uint_16 %863
+%5126 = OpCompositeExtract %uchar %5125 5
+OpStore %880 %5126
+%5127 = OpLoad %uchar %879
+%5128 = OpLoad %uchar %880
+%5129 = OpBitwiseXor %uchar %5127 %5128
+OpStore %881 %5129
+%5130 = OpLoad %_arr_uchar_uint_16 %792
+%5131 = OpCompositeExtract %uchar %5130 6
+OpStore %882 %5131
+%5132 = OpLoad %_arr_uchar_uint_16 %863
+%5133 = OpCompositeExtract %uchar %5132 6
+OpStore %883 %5133
+%5134 = OpLoad %uchar %882
+%5135 = OpLoad %uchar %883
+%5136 = OpBitwiseXor %uchar %5134 %5135
+OpStore %884 %5136
+%5137 = OpLoad %_arr_uchar_uint_16 %792
+%5138 = OpCompositeExtract %uchar %5137 7
+OpStore %885 %5138
+%5139 = OpLoad %_arr_uchar_uint_16 %863
+%5140 = OpCompositeExtract %uchar %5139 7
+OpStore %886 %5140
+%5141 = OpLoad %uchar %885
+%5142 = OpLoad %uchar %886
+%5143 = OpBitwiseXor %uchar %5141 %5142
+OpStore %887 %5143
+%5144 = OpLoad %_arr_uchar_uint_16 %792
+%5145 = OpCompositeExtract %uchar %5144 8
+OpStore %888 %5145
+%5146 = OpLoad %_arr_uchar_uint_16 %863
+%5147 = OpCompositeExtract %uchar %5146 8
+OpStore %889 %5147
+%5148 = OpLoad %uchar %888
+%5149 = OpLoad %uchar %889
+%5150 = OpBitwiseXor %uchar %5148 %5149
+OpStore %890 %5150
+%5151 = OpLoad %_arr_uchar_uint_16 %792
+%5152 = OpCompositeExtract %uchar %5151 9
+OpStore %891 %5152
+%5153 = OpLoad %_arr_uchar_uint_16 %863
+%5154 = OpCompositeExtract %uchar %5153 9
+OpStore %892 %5154
+%5155 = OpLoad %uchar %891
+%5156 = OpLoad %uchar %892
+%5157 = OpBitwiseXor %uchar %5155 %5156
+OpStore %893 %5157
+%5158 = OpLoad %_arr_uchar_uint_16 %792
+%5159 = OpCompositeExtract %uchar %5158 10
+OpStore %894 %5159
+%5160 = OpLoad %_arr_uchar_uint_16 %863
+%5161 = OpCompositeExtract %uchar %5160 10
+OpStore %895 %5161
+%5162 = OpLoad %uchar %894
+%5163 = OpLoad %uchar %895
+%5164 = OpBitwiseXor %uchar %5162 %5163
+OpStore %896 %5164
+%5165 = OpLoad %_arr_uchar_uint_16 %792
+%5166 = OpCompositeExtract %uchar %5165 11
+OpStore %897 %5166
+%5167 = OpLoad %_arr_uchar_uint_16 %863
+%5168 = OpCompositeExtract %uchar %5167 11
+OpStore %898 %5168
+%5169 = OpLoad %uchar %897
+%5170 = OpLoad %uchar %898
+%5171 = OpBitwiseXor %uchar %5169 %5170
+OpStore %899 %5171
+%5172 = OpLoad %_arr_uchar_uint_16 %792
+%5173 = OpCompositeExtract %uchar %5172 12
+OpStore %900 %5173
+%5174 = OpLoad %_arr_uchar_uint_16 %863
+%5175 = OpCompositeExtract %uchar %5174 12
+OpStore %901 %5175
+%5176 = OpLoad %uchar %900
+%5177 = OpLoad %uchar %901
+%5178 = OpBitwiseXor %uchar %5176 %5177
+OpStore %902 %5178
+%5179 = OpLoad %_arr_uchar_uint_16 %792
+%5180 = OpCompositeExtract %uchar %5179 13
+OpStore %903 %5180
+%5181 = OpLoad %_arr_uchar_uint_16 %863
+%5182 = OpCompositeExtract %uchar %5181 13
+OpStore %904 %5182
+%5183 = OpLoad %uchar %903
+%5184 = OpLoad %uchar %904
+%5185 = OpBitwiseXor %uchar %5183 %5184
+OpStore %905 %5185
+%5186 = OpLoad %_arr_uchar_uint_16 %792
+%5187 = OpCompositeExtract %uchar %5186 14
+OpStore %906 %5187
+%5188 = OpLoad %_arr_uchar_uint_16 %863
+%5189 = OpCompositeExtract %uchar %5188 14
+OpStore %907 %5189
+%5190 = OpLoad %uchar %906
+%5191 = OpLoad %uchar %907
+%5192 = OpBitwiseXor %uchar %5190 %5191
+OpStore %908 %5192
+%5193 = OpLoad %_arr_uchar_uint_16 %792
+%5194 = OpCompositeExtract %uchar %5193 15
+OpStore %909 %5194
+%5195 = OpLoad %_arr_uchar_uint_16 %863
+%5196 = OpCompositeExtract %uchar %5195 15
+OpStore %910 %5196
+%5197 = OpLoad %uchar %909
+%5198 = OpLoad %uchar %910
+%5199 = OpBitwiseXor %uchar %5197 %5198
+OpStore %911 %5199
+%5200 = OpLoad %_arr_uchar_uint_16 %792
+%5201 = OpLoad %uchar %866
+%5202 = OpCompositeInsert %_arr_uchar_uint_16 %5201 %5200 0
+OpStore %912 %5202
+%5203 = OpLoad %_arr_uchar_uint_16 %912
+%5204 = OpLoad %uchar %869
+%5205 = OpCompositeInsert %_arr_uchar_uint_16 %5204 %5203 1
+OpStore %913 %5205
+%5206 = OpLoad %_arr_uchar_uint_16 %913
+%5207 = OpLoad %uchar %872
+%5208 = OpCompositeInsert %_arr_uchar_uint_16 %5207 %5206 2
+OpStore %914 %5208
+%5209 = OpLoad %_arr_uchar_uint_16 %914
+%5210 = OpLoad %uchar %875
+%5211 = OpCompositeInsert %_arr_uchar_uint_16 %5210 %5209 3
+OpStore %915 %5211
+%5212 = OpLoad %_arr_uchar_uint_16 %915
+%5213 = OpLoad %uchar %878
+%5214 = OpCompositeInsert %_arr_uchar_uint_16 %5213 %5212 4
+OpStore %916 %5214
+%5215 = OpLoad %_arr_uchar_uint_16 %916
+%5216 = OpLoad %uchar %881
+%5217 = OpCompositeInsert %_arr_uchar_uint_16 %5216 %5215 5
+OpStore %917 %5217
+%5218 = OpLoad %_arr_uchar_uint_16 %917
+%5219 = OpLoad %uchar %884
+%5220 = OpCompositeInsert %_arr_uchar_uint_16 %5219 %5218 6
+OpStore %918 %5220
+%5221 = OpLoad %_arr_uchar_uint_16 %918
+%5222 = OpLoad %uchar %887
+%5223 = OpCompositeInsert %_arr_uchar_uint_16 %5222 %5221 7
+OpStore %919 %5223
+%5224 = OpLoad %_arr_uchar_uint_16 %919
+%5225 = OpLoad %uchar %890
+%5226 = OpCompositeInsert %_arr_uchar_uint_16 %5225 %5224 8
+OpStore %920 %5226
+%5227 = OpLoad %_arr_uchar_uint_16 %920
+%5228 = OpLoad %uchar %893
+%5229 = OpCompositeInsert %_arr_uchar_uint_16 %5228 %5227 9
+OpStore %921 %5229
+%5230 = OpLoad %_arr_uchar_uint_16 %921
+%5231 = OpLoad %uchar %896
+%5232 = OpCompositeInsert %_arr_uchar_uint_16 %5231 %5230 10
+OpStore %922 %5232
+%5233 = OpLoad %_arr_uchar_uint_16 %922
+%5234 = OpLoad %uchar %899
+%5235 = OpCompositeInsert %_arr_uchar_uint_16 %5234 %5233 11
+OpStore %923 %5235
+%5236 = OpLoad %_arr_uchar_uint_16 %923
+%5237 = OpLoad %uchar %902
+%5238 = OpCompositeInsert %_arr_uchar_uint_16 %5237 %5236 12
+OpStore %924 %5238
+%5239 = OpLoad %_arr_uchar_uint_16 %924
+%5240 = OpLoad %uchar %905
+%5241 = OpCompositeInsert %_arr_uchar_uint_16 %5240 %5239 13
+OpStore %925 %5241
+%5242 = OpLoad %_arr_uchar_uint_16 %925
+%5243 = OpLoad %uchar %908
+%5244 = OpCompositeInsert %_arr_uchar_uint_16 %5243 %5242 14
+OpStore %926 %5244
+%5245 = OpLoad %_arr_uchar_uint_16 %926
+%5246 = OpLoad %uchar %911
+%5247 = OpCompositeInsert %_arr_uchar_uint_16 %5246 %5245 15
+OpStore %927 %5247
+%5248 = OpLoad %ulong %774
+%5249 = OpLoad %_arr_uchar_uint_16 %927
+%5250 = OpFunctionCall %ulong %1 %5248 %5249
+OpStore %775 %5250
+%5251 = OpLoad %_arr_uchar_uint_16 %793
+%5252 = OpCompositeExtract %uchar %5251 0
+OpStore %928 %5252
+%5253 = OpLoad %_arr_uchar_uint_16 %791
+%5254 = OpCompositeExtract %uchar %5253 0
+OpStore %929 %5254
+%5255 = OpLoad %uchar %928
+%5256 = OpLoad %uchar %929
+%5257 = OpIAdd %uchar %5255 %5256
+OpStore %930 %5257
+%5258 = OpLoad %_arr_uchar_uint_16 %793
+%5259 = OpCompositeExtract %uchar %5258 1
+OpStore %931 %5259
+%5260 = OpLoad %_arr_uchar_uint_16 %791
+%5261 = OpCompositeExtract %uchar %5260 1
+OpStore %932 %5261
+%5262 = OpLoad %uchar %931
+%5263 = OpLoad %uchar %932
+%5264 = OpIAdd %uchar %5262 %5263
+OpStore %933 %5264
+%5265 = OpLoad %_arr_uchar_uint_16 %793
+%5266 = OpCompositeExtract %uchar %5265 2
+OpStore %934 %5266
+%5267 = OpLoad %_arr_uchar_uint_16 %791
+%5268 = OpCompositeExtract %uchar %5267 2
+OpStore %935 %5268
+%5269 = OpLoad %uchar %934
+%5270 = OpLoad %uchar %935
+%5271 = OpIAdd %uchar %5269 %5270
+OpStore %936 %5271
+%5272 = OpLoad %_arr_uchar_uint_16 %793
+%5273 = OpCompositeExtract %uchar %5272 3
+OpStore %937 %5273
+%5274 = OpLoad %_arr_uchar_uint_16 %791
+%5275 = OpCompositeExtract %uchar %5274 3
+OpStore %938 %5275
+%5276 = OpLoad %uchar %937
+%5277 = OpLoad %uchar %938
+%5278 = OpIAdd %uchar %5276 %5277
+OpStore %939 %5278
+%5279 = OpLoad %_arr_uchar_uint_16 %793
+%5280 = OpCompositeExtract %uchar %5279 4
+OpStore %940 %5280
+%5281 = OpLoad %_arr_uchar_uint_16 %791
+%5282 = OpCompositeExtract %uchar %5281 4
+OpStore %941 %5282
+%5283 = OpLoad %uchar %940
+%5284 = OpLoad %uchar %941
+%5285 = OpIAdd %uchar %5283 %5284
+OpStore %942 %5285
+%5286 = OpLoad %_arr_uchar_uint_16 %793
+%5287 = OpCompositeExtract %uchar %5286 5
+OpStore %943 %5287
+%5288 = OpLoad %_arr_uchar_uint_16 %791
+%5289 = OpCompositeExtract %uchar %5288 5
+OpStore %944 %5289
+%5290 = OpLoad %uchar %943
+%5291 = OpLoad %uchar %944
+%5292 = OpIAdd %uchar %5290 %5291
+OpStore %945 %5292
+%5293 = OpLoad %_arr_uchar_uint_16 %793
+%5294 = OpCompositeExtract %uchar %5293 6
+OpStore %946 %5294
+%5295 = OpLoad %_arr_uchar_uint_16 %791
+%5296 = OpCompositeExtract %uchar %5295 6
+OpStore %947 %5296
+%5297 = OpLoad %uchar %946
+%5298 = OpLoad %uchar %947
+%5299 = OpIAdd %uchar %5297 %5298
+OpStore %948 %5299
+%5300 = OpLoad %_arr_uchar_uint_16 %793
+%5301 = OpCompositeExtract %uchar %5300 7
+OpStore %949 %5301
+%5302 = OpLoad %_arr_uchar_uint_16 %791
+%5303 = OpCompositeExtract %uchar %5302 7
+OpStore %950 %5303
+%5304 = OpLoad %uchar %949
+%5305 = OpLoad %uchar %950
+%5306 = OpIAdd %uchar %5304 %5305
+OpStore %951 %5306
+%5307 = OpLoad %_arr_uchar_uint_16 %793
+%5308 = OpCompositeExtract %uchar %5307 8
+OpStore %952 %5308
+%5309 = OpLoad %_arr_uchar_uint_16 %791
+%5310 = OpCompositeExtract %uchar %5309 8
+OpStore %953 %5310
+%5311 = OpLoad %uchar %952
+%5312 = OpLoad %uchar %953
+%5313 = OpIAdd %uchar %5311 %5312
+OpStore %954 %5313
+%5314 = OpLoad %_arr_uchar_uint_16 %793
+%5315 = OpCompositeExtract %uchar %5314 9
+OpStore %955 %5315
+%5316 = OpLoad %_arr_uchar_uint_16 %791
+%5317 = OpCompositeExtract %uchar %5316 9
+OpStore %956 %5317
+%5318 = OpLoad %uchar %955
+%5319 = OpLoad %uchar %956
+%5320 = OpIAdd %uchar %5318 %5319
+OpStore %957 %5320
+%5321 = OpLoad %_arr_uchar_uint_16 %793
+%5322 = OpCompositeExtract %uchar %5321 10
+OpStore %958 %5322
+%5323 = OpLoad %_arr_uchar_uint_16 %791
+%5324 = OpCompositeExtract %uchar %5323 10
+OpStore %959 %5324
+%5325 = OpLoad %uchar %958
+%5326 = OpLoad %uchar %959
+%5327 = OpIAdd %uchar %5325 %5326
+OpStore %960 %5327
+%5328 = OpLoad %_arr_uchar_uint_16 %793
+%5329 = OpCompositeExtract %uchar %5328 11
+OpStore %961 %5329
+%5330 = OpLoad %_arr_uchar_uint_16 %791
+%5331 = OpCompositeExtract %uchar %5330 11
+OpStore %962 %5331
+%5332 = OpLoad %uchar %961
+%5333 = OpLoad %uchar %962
+%5334 = OpIAdd %uchar %5332 %5333
+OpStore %963 %5334
+%5335 = OpLoad %_arr_uchar_uint_16 %793
+%5336 = OpCompositeExtract %uchar %5335 12
+OpStore %964 %5336
+%5337 = OpLoad %_arr_uchar_uint_16 %791
+%5338 = OpCompositeExtract %uchar %5337 12
+OpStore %965 %5338
+%5339 = OpLoad %uchar %964
+%5340 = OpLoad %uchar %965
+%5341 = OpIAdd %uchar %5339 %5340
+OpStore %966 %5341
+%5342 = OpLoad %_arr_uchar_uint_16 %793
+%5343 = OpCompositeExtract %uchar %5342 13
+OpStore %967 %5343
+%5344 = OpLoad %_arr_uchar_uint_16 %791
+%5345 = OpCompositeExtract %uchar %5344 13
+OpStore %968 %5345
+%5346 = OpLoad %uchar %967
+%5347 = OpLoad %uchar %968
+%5348 = OpIAdd %uchar %5346 %5347
+OpStore %969 %5348
+%5349 = OpLoad %_arr_uchar_uint_16 %793
+%5350 = OpCompositeExtract %uchar %5349 14
+OpStore %970 %5350
+%5351 = OpLoad %_arr_uchar_uint_16 %791
+%5352 = OpCompositeExtract %uchar %5351 14
+OpStore %971 %5352
+%5353 = OpLoad %uchar %970
+%5354 = OpLoad %uchar %971
+%5355 = OpIAdd %uchar %5353 %5354
+OpStore %972 %5355
+%5356 = OpLoad %_arr_uchar_uint_16 %793
+%5357 = OpCompositeExtract %uchar %5356 15
+OpStore %973 %5357
+%5358 = OpLoad %_arr_uchar_uint_16 %791
+%5359 = OpCompositeExtract %uchar %5358 15
+OpStore %974 %5359
+%5360 = OpLoad %uchar %973
+%5361 = OpLoad %uchar %974
+%5362 = OpIAdd %uchar %5360 %5361
+OpStore %975 %5362
+%5363 = OpLoad %_arr_uchar_uint_16 %793
+%5364 = OpLoad %uchar %930
+%5365 = OpCompositeInsert %_arr_uchar_uint_16 %5364 %5363 0
+OpStore %976 %5365
+%5366 = OpLoad %_arr_uchar_uint_16 %976
+%5367 = OpLoad %uchar %933
+%5368 = OpCompositeInsert %_arr_uchar_uint_16 %5367 %5366 1
+OpStore %977 %5368
+%5369 = OpLoad %_arr_uchar_uint_16 %977
+%5370 = OpLoad %uchar %936
+%5371 = OpCompositeInsert %_arr_uchar_uint_16 %5370 %5369 2
+OpStore %978 %5371
+%5372 = OpLoad %_arr_uchar_uint_16 %978
+%5373 = OpLoad %uchar %939
+%5374 = OpCompositeInsert %_arr_uchar_uint_16 %5373 %5372 3
+OpStore %979 %5374
+%5375 = OpLoad %_arr_uchar_uint_16 %979
+%5376 = OpLoad %uchar %942
+%5377 = OpCompositeInsert %_arr_uchar_uint_16 %5376 %5375 4
+OpStore %980 %5377
+%5378 = OpLoad %_arr_uchar_uint_16 %980
+%5379 = OpLoad %uchar %945
+%5380 = OpCompositeInsert %_arr_uchar_uint_16 %5379 %5378 5
+OpStore %981 %5380
+%5381 = OpLoad %_arr_uchar_uint_16 %981
+%5382 = OpLoad %uchar %948
+%5383 = OpCompositeInsert %_arr_uchar_uint_16 %5382 %5381 6
+OpStore %982 %5383
+%5384 = OpLoad %_arr_uchar_uint_16 %982
+%5385 = OpLoad %uchar %951
+%5386 = OpCompositeInsert %_arr_uchar_uint_16 %5385 %5384 7
+OpStore %983 %5386
+%5387 = OpLoad %_arr_uchar_uint_16 %983
+%5388 = OpLoad %uchar %954
+%5389 = OpCompositeInsert %_arr_uchar_uint_16 %5388 %5387 8
+OpStore %984 %5389
+%5390 = OpLoad %_arr_uchar_uint_16 %984
+%5391 = OpLoad %uchar %957
+%5392 = OpCompositeInsert %_arr_uchar_uint_16 %5391 %5390 9
+OpStore %985 %5392
+%5393 = OpLoad %_arr_uchar_uint_16 %985
+%5394 = OpLoad %uchar %960
+%5395 = OpCompositeInsert %_arr_uchar_uint_16 %5394 %5393 10
+OpStore %986 %5395
+%5396 = OpLoad %_arr_uchar_uint_16 %986
+%5397 = OpLoad %uchar %963
+%5398 = OpCompositeInsert %_arr_uchar_uint_16 %5397 %5396 11
+OpStore %987 %5398
+%5399 = OpLoad %_arr_uchar_uint_16 %987
+%5400 = OpLoad %uchar %966
+%5401 = OpCompositeInsert %_arr_uchar_uint_16 %5400 %5399 12
+OpStore %988 %5401
+%5402 = OpLoad %_arr_uchar_uint_16 %988
+%5403 = OpLoad %uchar %969
+%5404 = OpCompositeInsert %_arr_uchar_uint_16 %5403 %5402 13
+OpStore %989 %5404
+%5405 = OpLoad %_arr_uchar_uint_16 %989
+%5406 = OpLoad %uchar %972
+%5407 = OpCompositeInsert %_arr_uchar_uint_16 %5406 %5405 14
+OpStore %990 %5407
+%5408 = OpLoad %_arr_uchar_uint_16 %990
+%5409 = OpLoad %uchar %975
+%5410 = OpCompositeInsert %_arr_uchar_uint_16 %5409 %5408 15
+OpStore %991 %5410
+%5411 = OpLoad %ulong %775
+%5412 = OpLoad %_arr_uchar_uint_16 %991
+%5413 = OpFunctionCall %ulong %1 %5411 %5412
+OpStore %776 %5413
+%5414 = OpLoad %_arr_uchar_uint_16 %791
+%5415 = OpCompositeExtract %uchar %5414 0
+OpStore %992 %5415
+%5416 = OpLoad %_arr_uchar_uint_16 %755
+%5417 = OpCompositeExtract %uchar %5416 0
+OpStore %993 %5417
+%5418 = OpLoad %uchar %992
+%5419 = OpLoad %uchar %993
+%5420 = OpIAdd %uchar %5418 %5419
+OpStore %994 %5420
+%5421 = OpLoad %_arr_uchar_uint_16 %791
+%5422 = OpCompositeExtract %uchar %5421 1
+OpStore %995 %5422
+%5423 = OpLoad %_arr_uchar_uint_16 %755
+%5424 = OpCompositeExtract %uchar %5423 1
+OpStore %996 %5424
+%5425 = OpLoad %uchar %995
+%5426 = OpLoad %uchar %996
+%5427 = OpIAdd %uchar %5425 %5426
+OpStore %997 %5427
+%5428 = OpLoad %_arr_uchar_uint_16 %791
+%5429 = OpCompositeExtract %uchar %5428 2
+OpStore %998 %5429
+%5430 = OpLoad %_arr_uchar_uint_16 %755
+%5431 = OpCompositeExtract %uchar %5430 2
+OpStore %999 %5431
+%5432 = OpLoad %uchar %998
+%5433 = OpLoad %uchar %999
+%5434 = OpIAdd %uchar %5432 %5433
+OpStore %1000 %5434
+%5435 = OpLoad %_arr_uchar_uint_16 %791
+%5436 = OpCompositeExtract %uchar %5435 3
+OpStore %1001 %5436
+%5437 = OpLoad %_arr_uchar_uint_16 %755
+%5438 = OpCompositeExtract %uchar %5437 3
+OpStore %1002 %5438
+%5439 = OpLoad %uchar %1001
+%5440 = OpLoad %uchar %1002
+%5441 = OpIAdd %uchar %5439 %5440
+OpStore %1003 %5441
+%5442 = OpLoad %_arr_uchar_uint_16 %791
+%5443 = OpCompositeExtract %uchar %5442 4
+OpStore %1004 %5443
+%5444 = OpLoad %_arr_uchar_uint_16 %755
+%5445 = OpCompositeExtract %uchar %5444 4
+OpStore %1005 %5445
+%5446 = OpLoad %uchar %1004
+%5447 = OpLoad %uchar %1005
+%5448 = OpIAdd %uchar %5446 %5447
+OpStore %1006 %5448
+%5449 = OpLoad %_arr_uchar_uint_16 %791
+%5450 = OpCompositeExtract %uchar %5449 5
+OpStore %1007 %5450
+%5451 = OpLoad %_arr_uchar_uint_16 %755
+%5452 = OpCompositeExtract %uchar %5451 5
+OpStore %1008 %5452
+%5453 = OpLoad %uchar %1007
+%5454 = OpLoad %uchar %1008
+%5455 = OpIAdd %uchar %5453 %5454
+OpStore %1009 %5455
+%5456 = OpLoad %_arr_uchar_uint_16 %791
+%5457 = OpCompositeExtract %uchar %5456 6
+OpStore %1010 %5457
+%5458 = OpLoad %_arr_uchar_uint_16 %755
+%5459 = OpCompositeExtract %uchar %5458 6
+OpStore %1011 %5459
+%5460 = OpLoad %uchar %1010
+%5461 = OpLoad %uchar %1011
+%5462 = OpIAdd %uchar %5460 %5461
+OpStore %1012 %5462
+%5463 = OpLoad %_arr_uchar_uint_16 %791
+%5464 = OpCompositeExtract %uchar %5463 7
+OpStore %1013 %5464
+%5465 = OpLoad %_arr_uchar_uint_16 %755
+%5466 = OpCompositeExtract %uchar %5465 7
+OpStore %1014 %5466
+%5467 = OpLoad %uchar %1013
+%5468 = OpLoad %uchar %1014
+%5469 = OpIAdd %uchar %5467 %5468
+OpStore %1015 %5469
+%5470 = OpLoad %_arr_uchar_uint_16 %791
+%5471 = OpCompositeExtract %uchar %5470 8
+OpStore %1016 %5471
+%5472 = OpLoad %_arr_uchar_uint_16 %755
+%5473 = OpCompositeExtract %uchar %5472 8
+OpStore %1017 %5473
+%5474 = OpLoad %uchar %1016
+%5475 = OpLoad %uchar %1017
+%5476 = OpIAdd %uchar %5474 %5475
+OpStore %1018 %5476
+%5477 = OpLoad %_arr_uchar_uint_16 %791
+%5478 = OpCompositeExtract %uchar %5477 9
+OpStore %1019 %5478
+%5479 = OpLoad %_arr_uchar_uint_16 %755
+%5480 = OpCompositeExtract %uchar %5479 9
+OpStore %1020 %5480
+%5481 = OpLoad %uchar %1019
+%5482 = OpLoad %uchar %1020
+%5483 = OpIAdd %uchar %5481 %5482
+OpStore %1021 %5483
+%5484 = OpLoad %_arr_uchar_uint_16 %791
+%5485 = OpCompositeExtract %uchar %5484 10
+OpStore %1022 %5485
+%5486 = OpLoad %_arr_uchar_uint_16 %755
+%5487 = OpCompositeExtract %uchar %5486 10
+OpStore %1023 %5487
+%5488 = OpLoad %uchar %1022
+%5489 = OpLoad %uchar %1023
+%5490 = OpIAdd %uchar %5488 %5489
+OpStore %1024 %5490
+%5491 = OpLoad %_arr_uchar_uint_16 %791
+%5492 = OpCompositeExtract %uchar %5491 11
+OpStore %1025 %5492
+%5493 = OpLoad %_arr_uchar_uint_16 %755
+%5494 = OpCompositeExtract %uchar %5493 11
+OpStore %1026 %5494
+%5495 = OpLoad %uchar %1025
+%5496 = OpLoad %uchar %1026
+%5497 = OpIAdd %uchar %5495 %5496
+OpStore %1027 %5497
+%5498 = OpLoad %_arr_uchar_uint_16 %791
+%5499 = OpCompositeExtract %uchar %5498 12
+OpStore %1028 %5499
+%5500 = OpLoad %_arr_uchar_uint_16 %755
+%5501 = OpCompositeExtract %uchar %5500 12
+OpStore %1029 %5501
+%5502 = OpLoad %uchar %1028
+%5503 = OpLoad %uchar %1029
+%5504 = OpIAdd %uchar %5502 %5503
+OpStore %1030 %5504
+%5505 = OpLoad %_arr_uchar_uint_16 %791
+%5506 = OpCompositeExtract %uchar %5505 13
+OpStore %1031 %5506
+%5507 = OpLoad %_arr_uchar_uint_16 %755
+%5508 = OpCompositeExtract %uchar %5507 13
+OpStore %1032 %5508
+%5509 = OpLoad %uchar %1031
+%5510 = OpLoad %uchar %1032
+%5511 = OpIAdd %uchar %5509 %5510
+OpStore %1033 %5511
+%5512 = OpLoad %_arr_uchar_uint_16 %791
+%5513 = OpCompositeExtract %uchar %5512 14
+OpStore %1034 %5513
+%5514 = OpLoad %_arr_uchar_uint_16 %755
+%5515 = OpCompositeExtract %uchar %5514 14
+OpStore %1035 %5515
+%5516 = OpLoad %uchar %1034
+%5517 = OpLoad %uchar %1035
+%5518 = OpIAdd %uchar %5516 %5517
+OpStore %1036 %5518
+%5519 = OpLoad %_arr_uchar_uint_16 %791
+%5520 = OpCompositeExtract %uchar %5519 15
+OpStore %1037 %5520
+%5521 = OpLoad %_arr_uchar_uint_16 %755
+%5522 = OpCompositeExtract %uchar %5521 15
+OpStore %1038 %5522
+%5523 = OpLoad %uchar %1037
+%5524 = OpLoad %uchar %1038
+%5525 = OpIAdd %uchar %5523 %5524
+OpStore %1039 %5525
+%5526 = OpLoad %_arr_uchar_uint_16 %791
+%5527 = OpLoad %uchar %994
+%5528 = OpCompositeInsert %_arr_uchar_uint_16 %5527 %5526 0
+OpStore %1040 %5528
+%5529 = OpLoad %_arr_uchar_uint_16 %1040
+%5530 = OpLoad %uchar %997
+%5531 = OpCompositeInsert %_arr_uchar_uint_16 %5530 %5529 1
+OpStore %1041 %5531
+%5532 = OpLoad %_arr_uchar_uint_16 %1041
+%5533 = OpLoad %uchar %1000
+%5534 = OpCompositeInsert %_arr_uchar_uint_16 %5533 %5532 2
+OpStore %1042 %5534
+%5535 = OpLoad %_arr_uchar_uint_16 %1042
+%5536 = OpLoad %uchar %1003
+%5537 = OpCompositeInsert %_arr_uchar_uint_16 %5536 %5535 3
+OpStore %1043 %5537
+%5538 = OpLoad %_arr_uchar_uint_16 %1043
+%5539 = OpLoad %uchar %1006
+%5540 = OpCompositeInsert %_arr_uchar_uint_16 %5539 %5538 4
+OpStore %1044 %5540
+%5541 = OpLoad %_arr_uchar_uint_16 %1044
+%5542 = OpLoad %uchar %1009
+%5543 = OpCompositeInsert %_arr_uchar_uint_16 %5542 %5541 5
+OpStore %1045 %5543
+%5544 = OpLoad %_arr_uchar_uint_16 %1045
+%5545 = OpLoad %uchar %1012
+%5546 = OpCompositeInsert %_arr_uchar_uint_16 %5545 %5544 6
+OpStore %1046 %5546
+%5547 = OpLoad %_arr_uchar_uint_16 %1046
+%5548 = OpLoad %uchar %1015
+%5549 = OpCompositeInsert %_arr_uchar_uint_16 %5548 %5547 7
+OpStore %1047 %5549
+%5550 = OpLoad %_arr_uchar_uint_16 %1047
+%5551 = OpLoad %uchar %1018
+%5552 = OpCompositeInsert %_arr_uchar_uint_16 %5551 %5550 8
+OpStore %1048 %5552
+%5553 = OpLoad %_arr_uchar_uint_16 %1048
+%5554 = OpLoad %uchar %1021
+%5555 = OpCompositeInsert %_arr_uchar_uint_16 %5554 %5553 9
+OpStore %1049 %5555
+%5556 = OpLoad %_arr_uchar_uint_16 %1049
+%5557 = OpLoad %uchar %1024
+%5558 = OpCompositeInsert %_arr_uchar_uint_16 %5557 %5556 10
+OpStore %1050 %5558
+%5559 = OpLoad %_arr_uchar_uint_16 %1050
+%5560 = OpLoad %uchar %1027
+%5561 = OpCompositeInsert %_arr_uchar_uint_16 %5560 %5559 11
+OpStore %1051 %5561
+%5562 = OpLoad %_arr_uchar_uint_16 %1051
+%5563 = OpLoad %uchar %1030
+%5564 = OpCompositeInsert %_arr_uchar_uint_16 %5563 %5562 12
+OpStore %1052 %5564
+%5565 = OpLoad %_arr_uchar_uint_16 %1052
+%5566 = OpLoad %uchar %1033
+%5567 = OpCompositeInsert %_arr_uchar_uint_16 %5566 %5565 13
+OpStore %1053 %5567
+%5568 = OpLoad %_arr_uchar_uint_16 %1053
+%5569 = OpLoad %uchar %1036
+%5570 = OpCompositeInsert %_arr_uchar_uint_16 %5569 %5568 14
+OpStore %1054 %5570
+%5571 = OpLoad %_arr_uchar_uint_16 %1054
+%5572 = OpLoad %uchar %1039
+%5573 = OpCompositeInsert %_arr_uchar_uint_16 %5572 %5571 15
+OpStore %1055 %5573
+%5574 = OpLoad %ulong %776
+%5575 = OpLoad %_arr_uchar_uint_16 %1055
+%5576 = OpFunctionCall %ulong %1 %5574 %5575
+OpStore %777 %5576
+%5577 = OpLoad %ulong %794
+%5578 = OpIAdd %ulong %5577 %ulong_1
+OpStore %778 %5578
+%5579 = OpLoad %ulong %777
+OpStore %790 %5579
+%5580 = OpLoad %_arr_uchar_uint_16 %1055
+OpStore %791 %5580
+%5581 = OpLoad %_arr_uchar_uint_16 %927
+OpStore %792 %5581
+%5582 = OpLoad %_arr_uchar_uint_16 %991
+OpStore %793 %5582
+%5583 = OpLoad %ulong %778
+OpStore %794 %5583
+OpBranch %730
+%729 = OpLabel
+OpBranch %720
+%730 = OpLabel
+OpBranch %717
 OpFunctionEnd
-%3 = OpFunction %ulong None %4995
-%4996 = OpLabel
-OpReturnValue %ulong_14695981039346656037
-OpFunctionEnd
-%4 = OpFunction %ulong None %4998
-%4999 = OpFunctionParameter %ulong
-%5000 = OpFunctionParameter %uchar
-%5001 = OpLabel
-%5008 = OpVariable %_ptr_Function_ulong Function
-%5009 = OpVariable %_ptr_Function_uchar Function
-%5010 = OpVariable %_ptr_Function_ulong Function
-%5011 = OpVariable %_ptr_Function_bool Function
-%5012 = OpVariable %_ptr_Function_ulong Function
-%5013 = OpVariable %_ptr_Function_ulong Function
-%5014 = OpVariable %_ptr_Function_ulong Function
-%5015 = OpVariable %_ptr_Function_ulong Function
-%5016 = OpVariable %_ptr_Function_ulong Function
-%5017 = OpVariable %_ptr_Function_ulong Function
-%5018 = OpVariable %_ptr_Function_ulong Function
-%5019 = OpVariable %_ptr_Function_ulong Function
-OpStore %5008 %4999
-OpStore %5009 %5000
-%5020 = OpLoad %uchar %5009
-%5021 = OpUConvert %ulong %5020
-OpStore %5010 %5021
-OpBranch %5002
-%5002 = OpLabel
-%5022 = OpLoad %ulong %5008
-OpStore %5018 %5022
-OpStore %5019 %ulong_0
-OpBranch %5003
-%5003 = OpLabel
-%5023 = OpLoad %ulong %5019
-%5025 = OpULessThan %bool %5023 %ulong_8
-OpStore %5011 %5025
-%5026 = OpLoad %bool %5011
-OpLoopMerge %5005 %5007 None
-OpBranchConditional %5026 %5004 %5005
-%5005 = OpLabel
-OpBranch %5006
-%5006 = OpLabel
-%5027 = OpLoad %ulong %5018
-OpReturnValue %5027
-%5004 = OpLabel
-%5028 = OpLoad %ulong %5019
-%5029 = OpIMul %ulong %5028 %ulong_8
-OpStore %5012 %5029
-%5030 = OpLoad %ulong %5010
-%5031 = OpLoad %ulong %5012
-%5032 = OpShiftRightLogical %ulong %5030 %5031
-OpStore %5013 %5032
-%5033 = OpLoad %ulong %5013
-%5035 = OpBitwiseAnd %ulong %5033 %ulong_255
-OpStore %5014 %5035
-%5036 = OpLoad %ulong %5018
-%5037 = OpLoad %ulong %5014
-%5038 = OpBitwiseXor %ulong %5036 %5037
-OpStore %5015 %5038
-%5039 = OpLoad %ulong %5015
-%5041 = OpIMul %ulong %5039 %ulong_1099511628211
-OpStore %5016 %5041
-%5042 = OpLoad %ulong %5019
-%5043 = OpIAdd %ulong %5042 %ulong_1
-OpStore %5017 %5043
-%5044 = OpLoad %ulong %5016
-OpStore %5018 %5044
-%5045 = OpLoad %ulong %5017
-OpStore %5019 %5045
-OpBranch %5007
-%5007 = OpLabel
-OpBranch %5003
-OpFunctionEnd
-%5 = OpFunction %ulong None %5046
-%5047 = OpFunctionParameter %ulong
-%5048 = OpFunctionParameter %uint
-%5049 = OpLabel
-%5056 = OpVariable %_ptr_Function_ulong Function
-%5057 = OpVariable %_ptr_Function_uint Function
-%5058 = OpVariable %_ptr_Function_ulong Function
-%5059 = OpVariable %_ptr_Function_bool Function
-%5060 = OpVariable %_ptr_Function_ulong Function
-%5061 = OpVariable %_ptr_Function_ulong Function
-%5062 = OpVariable %_ptr_Function_ulong Function
-%5063 = OpVariable %_ptr_Function_ulong Function
-%5064 = OpVariable %_ptr_Function_ulong Function
-%5065 = OpVariable %_ptr_Function_ulong Function
-%5066 = OpVariable %_ptr_Function_ulong Function
-%5067 = OpVariable %_ptr_Function_ulong Function
-OpStore %5056 %5047
-OpStore %5057 %5048
-%5068 = OpLoad %uint %5057
-%5069 = OpUConvert %ulong %5068
-OpStore %5058 %5069
-OpBranch %5050
-%5050 = OpLabel
-%5070 = OpLoad %ulong %5056
-OpStore %5066 %5070
-OpStore %5067 %ulong_0
-OpBranch %5051
-%5051 = OpLabel
-%5071 = OpLoad %ulong %5067
-%5072 = OpULessThan %bool %5071 %ulong_8
-OpStore %5059 %5072
-%5073 = OpLoad %bool %5059
-OpLoopMerge %5053 %5055 None
-OpBranchConditional %5073 %5052 %5053
-%5053 = OpLabel
-OpBranch %5054
-%5054 = OpLabel
-%5074 = OpLoad %ulong %5066
-OpReturnValue %5074
-%5052 = OpLabel
-%5075 = OpLoad %ulong %5067
-%5076 = OpIMul %ulong %5075 %ulong_8
-OpStore %5060 %5076
-%5077 = OpLoad %ulong %5058
-%5078 = OpLoad %ulong %5060
-%5079 = OpShiftRightLogical %ulong %5077 %5078
-OpStore %5061 %5079
-%5080 = OpLoad %ulong %5061
-%5081 = OpBitwiseAnd %ulong %5080 %ulong_255
-OpStore %5062 %5081
-%5082 = OpLoad %ulong %5066
-%5083 = OpLoad %ulong %5062
-%5084 = OpBitwiseXor %ulong %5082 %5083
-OpStore %5063 %5084
-%5085 = OpLoad %ulong %5063
-%5086 = OpIMul %ulong %5085 %ulong_1099511628211
-OpStore %5064 %5086
-%5087 = OpLoad %ulong %5067
-%5088 = OpIAdd %ulong %5087 %ulong_1
-OpStore %5065 %5088
-%5089 = OpLoad %ulong %5064
-OpStore %5066 %5089
-%5090 = OpLoad %ulong %5065
-OpStore %5067 %5090
-OpBranch %5055
-%5055 = OpLabel
-OpBranch %5051
+%3 = OpFunction %ulong None %5584
+%5585 = OpFunctionParameter %ulong
+%5586 = OpFunctionParameter %ulong
+%5587 = OpLabel
+%5592 = OpVariable %_ptr_Function_ulong Function
+%5593 = OpVariable %_ptr_Function_ulong Function
+%5594 = OpVariable %_ptr_Function_bool Function
+%5595 = OpVariable %_ptr_Function_ulong Function
+%5596 = OpVariable %_ptr_Function_ulong Function
+%5597 = OpVariable %_ptr_Function_ulong Function
+%5598 = OpVariable %_ptr_Function_ulong Function
+%5599 = OpVariable %_ptr_Function_ulong Function
+%5600 = OpVariable %_ptr_Function_ulong Function
+%5601 = OpVariable %_ptr_Function_ulong Function
+%5602 = OpVariable %_ptr_Function_ulong Function
+OpStore %5592 %5585
+OpStore %5593 %5586
+%5603 = OpLoad %ulong %5592
+OpStore %5601 %5603
+OpStore %5602 %ulong_0
+OpBranch %5588
+%5588 = OpLabel
+%5604 = OpLoad %ulong %5602
+%5605 = OpULessThan %bool %5604 %ulong_8
+OpStore %5594 %5605
+%5606 = OpLoad %bool %5594
+OpLoopMerge %5590 %5591 None
+OpBranchConditional %5606 %5589 %5590
+%5590 = OpLabel
+%5607 = OpLoad %ulong %5601
+OpReturnValue %5607
+%5589 = OpLabel
+%5608 = OpLoad %ulong %5602
+%5609 = OpIMul %ulong %5608 %ulong_8
+OpStore %5595 %5609
+%5610 = OpLoad %ulong %5593
+%5611 = OpLoad %ulong %5595
+%5612 = OpShiftRightLogical %ulong %5610 %5611
+OpStore %5596 %5612
+%5613 = OpLoad %ulong %5596
+%5614 = OpBitwiseAnd %ulong %5613 %ulong_255
+OpStore %5597 %5614
+%5615 = OpLoad %ulong %5601
+%5616 = OpLoad %ulong %5597
+%5617 = OpBitwiseXor %ulong %5615 %5616
+OpStore %5598 %5617
+%5618 = OpLoad %ulong %5598
+%5619 = OpIMul %ulong %5618 %ulong_1099511628211
+OpStore %5599 %5619
+%5620 = OpLoad %ulong %5602
+%5621 = OpIAdd %ulong %5620 %ulong_1
+OpStore %5600 %5621
+%5622 = OpLoad %ulong %5599
+OpStore %5601 %5622
+%5623 = OpLoad %ulong %5600
+OpStore %5602 %5623
+OpBranch %5591
+%5591 = OpLabel
+OpBranch %5588
 OpFunctionEnd

--- a/test/golden/x86_64-darwin/bits/logic_u32.dis
+++ b/test/golden/x86_64-darwin/bits/logic_u32.dis
@@ -11,178 +11,460 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x48(%rbp)
                	movq	%r14, -0x50(%rbp)
                	movq	%r15, -0x58(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       ## imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      ## imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      ## imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      ## imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%r12d, %r15d
-               	andl	%ebx, %r15d
-               	movl	%r15d, %esi
-               	callq	 <L1>
+               	xorl	%ebx, %r14d
+               	movl	%ebx, %eax
+               	andl	%r12d, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r8d
-               	orl	%ebx, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
+               	movl	%ebx, %edx
+               	orl	%r12d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	xorl	%ebx, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	xorl	$-0x1, %edx
+               	movl	%ebx, %edx
+               	xorl	%r12d, %edx
                	movl	%edx, %esi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
                	movl	%ebx, %edx
                	xorl	$-0x1, %edx
                	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movl	%r12d, %edx
+               	xorl	$-0x1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movl	%r13d, %edx
                	andl	%r14d, %edx
                	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
                	movl	%r13d, %edx
                	orl	%r14d, %edx
                	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r8d
-               	xorl	%r14d, %r8d
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	xorl	$-0x1, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	xorl	$-0x1, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	andl	%r13d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	orl	%r14d, %esi
-               	callq	 <L12>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	andl	%r14d, %esi
-               	callq	 <L13>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	orl	%r13d, %esi
-               	callq	 <L14>
+               	movl	%r13d, %edx
+               	xorl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r15d, %esi
-               	orl	%r8d, %esi
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	xorl	$-0x1, %r15d
-               	movl	%r15d, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %edx
+               	movl	%r13d, %edx
                	xorl	$-0x1, %edx
                	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	%rax, %r15
-               	movl	$0x0, %r8d
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	%r14d, %edx
+               	xorl	$-0x1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	%ebx, %edx
+               	andl	%r13d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movl	%r12d, %edx
+               	orl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movl	%ebx, %edx
+               	andl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movl	%r12d, %edx
+               	orl	%r13d, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L26>
+<L26>:
+               	movl	%ebx, %r15d
+               	andl	%r12d, %r15d
+               	movl	%r13d, %r8d
+               	xorl	%r14d, %r8d
                	movq	%r8, -0x28(%rbp)
                	movq	-0x28(%rbp), %r8
-               	cmpl	$0x8, %r8d
-               	jb	 <L19>
-               	jmp	 <L23>
-<L19>:
-               	movq	-0x28(%rbp), %r9
-               	movl	%r12d, %r8d
-               	xorl	%r9d, %r8d
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x28(%rbp), %r8
-               	movl	%ebx, %edx
-               	orl	%r8d, %edx
-               	movq	-0x28(%rbp), %r8
-               	movl	%r14d, %esi
-               	xorl	%r8d, %esi
-               	movl	%r13d, %r8d
-               	andl	%esi, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	movl	%r8d, %esi
-               	andl	%edx, %esi
-               	movq	%r15, %rdi
-               	callq	 <L20>
-<L20>:
+               	movl	%r15d, %esi
+               	orl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
+               	callq	 <L27>
+<L27>:
+               	movl	%ebx, %esi
+               	orl	%r12d, %esi
+               	xorl	$-0x1, %esi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	xorl	$-0x1, %r15d
+               	movq	%rax, %rdi
+               	movl	%r15d, %esi
+               	callq	 <L29>
+<L29>:
+               	movq	-0x28(%rbp), %r8
                	movl	%r8d, %edx
-               	orl	%r9d, %edx
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
+               	xorl	$-0x1, %edx
                	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x20(%rbp)
                	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movl	%r8d, %ecx
-               	xorl	%r9d, %ecx
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	movq	-0x28(%rbp), %r8
+               	cmpl	$0x8, %r8d
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
+               	movl	%ebx, %r8d
+               	xorl	%r9d, %r8d
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movl	%r12d, %edi
+               	orl	%r8d, %edi
+               	movq	-0x20(%rbp), %r8
+               	movl	%r14d, %r15d
+               	xorl	%r8d, %r15d
+               	movl	%r13d, %r8d
+               	andl	%r15d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %r15d
+               	andl	%edi, %r15d
+               	movl	%r15d, %edi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	orl	%r9d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	xorl	%r9d, %eax
+               	xorl	$-0x1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x20(%rbp), %r8
                	movl	%r8d, %eax
                	addl	$0x1, %eax
+               	movq	%r15, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpl	$0x8, %r8d
-               	jb	 <L19>
-<L23>:
-               	movq	%r15, %rax
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13

--- a/test/golden/x86_64-darwin/bits/logic_u64.dis
+++ b/test/golden/x86_64-darwin/bits/logic_u64.dis
@@ -12,170 +12,442 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x50(%rbp)
                	movq	%r15, -0x58(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 ## imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 ## imm = 0x5555555555555555
                	xorq	%rbx, %r14
-               	movq	%rbx, %r15
-               	andq	%r12, %r15
-               	movq	%r15, %rsi
-               	callq	 <L1>
+               	movq	%rbx, %rax
+               	andq	%r12, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r8
-               	orq	%r12, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
+               	movq	%rbx, %rax
+               	orq	%r12, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	xorq	%r12, %rsi
-               	callq	 <L3>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L4>
+               	movq	%rbx, %rax
+               	xorq	%r12, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L5>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	andq	%r14, %rsi
-               	callq	 <L6>
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	orq	%r14, %rsi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %r8
-               	xorq	%r14, %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	%r12, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L9>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L10>
+               	movq	%r13, %rax
+               	andq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	andq	%r13, %rsi
-               	callq	 <L11>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	orq	%r14, %rsi
-               	callq	 <L12>
+               	movq	%r13, %rax
+               	orq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	andq	%r14, %rsi
-               	callq	 <L13>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
+               	movq	%r13, %rax
+               	xorq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r13, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%rbx, %rax
+               	andq	%r13, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movq	%r12, %rax
+               	orq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movq	%rbx, %rax
+               	andq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
                	movq	%r12, %rsi
                	orq	%r13, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movq	%rdx, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	%rbx, %r15
+               	andq	%r12, %r15
+               	movq	%r13, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x28(%rbp), %r8
                	movq	%r15, %rsi
                	orq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L27>
+<L27>:
+               	movq	%rbx, %rsi
+               	orq	%r12, %rsi
+               	xorq	$-0x1, %rsi
                	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
                	xorq	$-0x1, %r15
-               	movq	%r15, %rsi
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movq	%r15, %rsi
+               	callq	 <L29>
+<L29>:
+               	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdx
                	xorq	$-0x1, %rdx
+               	movq	%rax, %rdi
                	movq	%rdx, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r15
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L19>
-               	jmp	 <L23>
-<L19>:
-               	movq	-0x28(%rbp), %r9
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
                	movq	%rbx, %r8
                	xorq	%r9, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x28(%rbp), %r8
-               	movq	%r12, %rdx
-               	orq	%r8, %rdx
-               	movq	-0x28(%rbp), %r8
-               	movq	%r14, %rsi
-               	xorq	%r8, %rsi
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r12, %rdi
+               	orq	%r8, %rdi
+               	movq	-0x20(%rbp), %r8
+               	movq	%r14, %r15
+               	xorq	%r8, %r15
                	movq	%r13, %r8
-               	andq	%rsi, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	andq	%rdx, %rsi
+               	andq	%r15, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %r15
+               	andq	%rdi, %r15
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	orq	%r9, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
                	movq	%r15, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	xorq	%r9, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
                	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movq	%r8, %rsi
-               	orq	%r9, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	movq	-0x28(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L19>
-<L23>:
-               	movq	%r15, %rax
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13

--- a/test/golden/x86_64-darwin/bits/shift_i32.dis
+++ b/test/golden/x86_64-darwin/bits/shift_i32.dis
@@ -11,218 +11,497 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       ## imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      ## imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      ## imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      ## imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%ebx, %esi
-               	callq	 <L1>
-<L1>:
+               	xorl	%ebx, %r14d
+               	movslq	%r12d, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L4>
+               	movl	%r12d, %eax
+               	shll	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L5>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L6>
+               	movslq	%r12d, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L8>
+               	movl	%r12d, %eax
+               	sarl	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L9>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	%r12d, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
                	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shll	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movl	%r13d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	sarl	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L14>
+               	movl	%r13d, %eax
+               	sarl	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L15>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L16>
+               	movl	%r13d, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L17>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L18>
+               	movl	%r14d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L19>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
+               	movl	%r14d, %eax
+               	sarl	%eax
+               	movq	%rdx, %rdi
+               	movl	%eax, %esi
                	callq	 <L20>
 <L20>:
+               	movl	%ebx, %edx
+               	shll	$0x5, %edx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	$0x3f, %edx
                	movl	%edx, %esi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L22>
-               	jmp	 <L27>
-<L22>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
                	movl	%ebx, %edx
-               	shll	%cl, %edx
-               	movq	%r15, %rdi
+               	sarl	$0x5, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L22>
+<L22>:
+               	movl	%r12d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L23>
 <L23>:
+               	movl	%r12d, %edx
+               	sarl	$0x20, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L24>
 <L24>:
+               	movl	%r12d, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r12d, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r13d, %esi
-               	shll	%cl, %esi
+               	movl	%edx, %esi
                	callq	 <L25>
 <L25>:
+               	movl	%r12d, %edx
+               	sarl	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r14d, %edx
-               	sarl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L22>
+               	movl	%r12d, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L27>
 <L27>:
-               	movl	$0x1e, %r13d
-               	cmpl	$0x28, %r13d
-               	jb	 <L28>
-               	jmp	 <L31>
+               	movl	%r12d, %edx
+               	sarl	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L28>
 <L28>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r15, %rdi
-               	movl	%eax, %esi
+               	movl	%r13d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
                	callq	 <L29>
 <L29>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
+               	movl	%r13d, %edx
+               	sarl	$0x3f, %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L30>
 <L30>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %r15
-               	cmpl	$0x28, %r13d
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movslq	%esi, %rdi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rsi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r13d, %eax
+               	shll	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r14d, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movl	%edx, %esi
+               	addl	%ebx, %esi
+               	movl	%esi, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movslq	%esi, %rdi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%r12d, %edi
+               	sarl	%cl, %edi
+               	movslq	%edi, %r13
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %edx
+               	movq	%rsi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+<L46>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/bits/shift_i64.dis
+++ b/test/golden/x86_64-darwin/bits/shift_i64.dis
@@ -12,192 +12,469 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 ## imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 ## imm = 0x5555555555555555
                	xorq	%rbx, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r12, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	%rsi
-               	callq	 <L2>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x3f, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L4>
+               	movq	%r12, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	%rsi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x3f, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	%rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	%rsi
-               	callq	 <L8>
+               	movq	%r12, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	$0x3f, %rsi
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shlq	%rsi
-               	callq	 <L10>
+               	movq	%r12, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movq	%r13, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	%r13, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r13, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
                	movq	%r14, %rsi
                	sarq	%rsi
-               	callq	 <L11>
-<L11>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	shlq	$0x5, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	sarq	$0x5, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x40, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x41, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x41, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x7f, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x7f, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	$0x40, %rsi
                	callq	 <L20>
 <L20>:
+               	movq	%rbx, %rsi
+               	shlq	$0x5, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	$0x7f, %rsi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L22>
-               	jmp	 <L27>
+               	movq	%rbx, %rsi
+               	sarq	$0x5, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	sarq	%cl, %rsi
+               	sarq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
+               	movq	%r12, %rsi
+               	shlq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rsi
-               	shlq	%cl, %rsi
                	callq	 <L25>
 <L25>:
+               	movq	%r12, %rsi
+               	sarq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rsi
-               	sarq	%cl, %rsi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L22>
-<L27>:
-               	movq	$0x3c, %r13
-               	cmpq	$0x48, %r13
-               	jb	 <L28>
-               	jmp	 <L31>
-<L28>:
-               	movq	%r13, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movq	%r12, %rsi
+               	sarq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	%r13, %rsi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movq	%r14, %rcx
-               	movq	%r12, %rsi
-               	sarq	%cl, %rsi
+               	movq	%r13, %rsi
+               	sarq	$0x7f, %rsi
                	movq	%rax, %rdi
                	callq	 <L30>
 <L30>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r15
-               	cmpq	$0x48, %r13
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rsi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r13, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	sarq	%cl, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+<L45>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+<L46>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/bits/shift_u32.dis
+++ b/test/golden/x86_64-darwin/bits/shift_u32.dis
@@ -11,212 +11,491 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       ## imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      ## imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      ## imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      ## imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%ebx, %esi
-               	callq	 <L1>
-<L1>:
+               	xorl	%ebx, %r14d
+               	movl	%r12d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L4>
+               	movl	%r12d, %eax
+               	shll	$0x1f, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L5>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L6>
+               	movl	%r12d, %eax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L8>
+               	movl	%r12d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
                	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L9>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	%r12d, %eax
+               	shrl	$0x1f, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
                	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shll	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shrl	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movl	%r13d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L14>
+               	movl	%r13d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L15>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L16>
+               	movl	%r14d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L17>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L18>
+               	movl	%r14d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L19>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shrl	$0x3f, %edx
-               	movl	%edx, %esi
+               	movl	%ebx, %eax
+               	shll	$0x5, %eax
+               	movq	%rdx, %rdi
+               	movl	%eax, %esi
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L21>
-               	jmp	 <L26>
-<L21>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
                	movl	%ebx, %edx
-               	shll	%cl, %edx
-               	movq	%r15, %rdi
+               	shrl	$0x5, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L21>
+<L21>:
+               	movl	%r12d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L22>
 <L22>:
+               	movl	%r12d, %edx
+               	shrl	$0x20, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L23>
 <L23>:
+               	movl	%r12d, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r12d, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r13d, %esi
-               	shll	%cl, %esi
+               	movl	%edx, %esi
                	callq	 <L24>
 <L24>:
+               	movl	%r12d, %edx
+               	shrl	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r14d, %edx
-               	shrl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L21>
+               	movl	%r12d, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L26>
 <L26>:
-               	movl	$0x1e, %r13d
-               	cmpl	$0x28, %r13d
-               	jb	 <L27>
-               	jmp	 <L30>
+               	movl	%r12d, %edx
+               	shrl	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L27>
 <L27>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r15, %rdi
-               	movl	%eax, %esi
+               	movl	%r13d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
                	callq	 <L28>
 <L28>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
+               	movl	%r13d, %edx
+               	shrl	$0x3f, %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L29>
 <L29>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %r15
-               	cmpl	$0x28, %r13d
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movl	%esi, %edi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rsi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r13d, %eax
+               	shll	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r14d, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movl	%edx, %esi
+               	addl	%ebx, %esi
+               	movl	%esi, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movl	%esi, %edi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%r12d, %edi
+               	shrl	%cl, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+<L44>:
+               	addl	$0x1, %edx
+               	movq	%rsi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+<L45>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/bits/shift_u64.dis
+++ b/test/golden/x86_64-darwin/bits/shift_u64.dis
@@ -12,187 +12,464 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 ## imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 ## imm = 0x5555555555555555
                	xorq	%rbx, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r12, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	%rsi
-               	callq	 <L2>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x3f, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L4>
+               	movq	%r12, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	%rsi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x3f, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	%rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shrq	%rsi
-               	callq	 <L8>
+               	movq	%r12, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shlq	%rsi
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shrq	%rsi
-               	callq	 <L10>
+               	movq	%r12, %rdx
+               	shrq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movq	%r13, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	%r13, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r14, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
                	movq	%rbx, %rsi
                	shlq	$0x5, %rsi
-               	callq	 <L11>
-<L11>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	shrq	$0x5, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x40, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x41, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x41, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x7f, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x7f, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shrq	$0x7f, %rsi
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L21>
-               	jmp	 <L26>
+               	movq	%rbx, %rsi
+               	shrq	$0x5, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L21>
 <L21>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shrq	%cl, %rsi
+               	shrq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
+               	movq	%r12, %rsi
+               	shlq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rsi
-               	shlq	%cl, %rsi
                	callq	 <L24>
 <L24>:
+               	movq	%r12, %rsi
+               	shrq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rsi
-               	shrq	%cl, %rsi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L21>
-<L26>:
-               	movq	$0x3c, %r13
-               	cmpq	$0x48, %r13
-               	jb	 <L27>
-               	jmp	 <L30>
-<L27>:
-               	movq	%r13, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	%r12, %rsi
+               	shrq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movq	%r13, %rsi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L28>
 <L28>:
-               	movq	%r14, %rcx
-               	movq	%r12, %rsi
-               	shrq	%cl, %rsi
+               	movq	%r13, %rsi
+               	shrq	$0x7f, %rsi
                	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r15
-               	cmpq	$0x48, %r13
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rsi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r13, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+<L44>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+<L45>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/call/call_chain.dis
+++ b/test/golden/x86_64-darwin/call/call_chain.dis
@@ -58,51 +58,52 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_chain.burn>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x110, %rsp            ## imm = 0x110
-               	movq	%rbx, -0xe8(%rbp)
-               	movq	%r12, -0xf0(%rbp)
-               	movq	%r13, -0xf8(%rbp)
-               	movq	%r14, -0x100(%rbp)
-               	movq	%r15, -0x108(%rbp)
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
                	movq	%rdi, %r8
                	xorq	$0x1, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rdi, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r8
-               	addq	$0x2, %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	%rdi, %rdx
-               	xorq	$-0x1, %rdx
+               	imulq	$0x3, %rdx, %rdx
                	movq	%rdx, %r8
-               	addq	$0x3, %r8
+               	addq	$0x2, %r8
                	movq	%r8, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	imulq	$0x5, %rbx, %rbx
-               	addq	$0x4, %rbx
+               	movq	%rdi, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	%rsi, %r8
+               	addq	$0x3, %r8
+               	movq	%r8, -0x28(%rbp)
                	movq	%rdi, %r12
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %r12
+               	imulq	$0x5, %r12, %r12
+               	addq	$0x4, %r12
                	movq	%rdi, %r13
-               	imulq	$0x7, %r13, %r13
-               	addq	$0x6, %r13
-               	movq	%rdx, %r14
-               	imulq	$0x9, %r14, %r14
-               	movq	%rdi, %r15
-               	addq	$0x12345678, %r15       ## imm = 0x12345678
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %r13
+               	movq	%rdi, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	$0x6, %r14
+               	movq	%rsi, %r15
+               	imulq	$0x9, %r15, %r15
+               	movq	%rdi, %r8
+               	addq	$0x12345678, %r8        ## imm = 0x12345678
+               	movq	%r8, -0x8(%rbp)
                	movq	%rdi, %rax
                	imulq	$0xb, %rax, %rax
                	addq	$0xa, %rax
                	movq	%rdi, %r8
                	xorq	$0x55555555, %r8        ## imm = 0x55555555
-               	movq	%r8, -0x10(%rbp)
-               	movq	%rdi, %rcx
-               	imulq	$0xd, %rcx, %rcx
-               	addq	$0xc, %rcx
-               	xorq	%rdi, %rdx
-               	movq	%rdi, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
-               	movq	%rsi, %r11
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rdi, %rdx
+               	imulq	$0xd, %rdx, %rdx
+               	addq	$0xc, %rdx
+               	xorq	%rdi, %rsi
+               	movq	%rdi, %rbx
+               	andq	$0x3ff, %rbx            ## imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
@@ -116,11 +117,11 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L1>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0xfd>
-               	movq	%rdi, %rsi
-               	shrq	$0x5, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
-               	movq	%rsi, %r11
+               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0x101>
+               	movq	%rdi, %rbx
+               	shrq	$0x5, %rbx
+               	andq	$0x3ff, %rbx            ## imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L2>
                	cvtsi2sd	%r11, %xmm0
@@ -134,11 +135,11 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L3>:
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x143>
-               	movq	%rdi, %rsi
-               	shrq	$0xb, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
-               	movq	%rsi, %r11
+               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x147>
+               	movq	%rdi, %rbx
+               	shrq	$0xb, %rbx
+               	andq	$0x3ff, %rbx            ## imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L4>
                	cvtsi2sd	%r11, %xmm0
@@ -152,11 +153,11 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L5>:
                	movsd	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x189>
-               	movq	%rdi, %rsi
-               	shrq	$0x11, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x18d>
+               	movq	%rdi, %rbx
+               	shrq	$0x11, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
@@ -170,11 +171,11 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x1cf>
-               	movq	%rdi, %rsi
-               	shrq	$0x17, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x1d3>
+               	movq	%rdi, %rbx
+               	shrq	$0x17, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
@@ -188,7 +189,7 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x215>
+               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x219>
                	shrq	$0x1d, %rdi
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
@@ -205,165 +206,221 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x258>
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x18(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x20(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x30(%rbp)
+               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x25c>
                	movq	-0x10(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	%rcx, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	-0x28(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x38(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x78(%rbp)
-               	movsd	%xmm1, -0x88(%rbp)
-               	movsd	%xmm2, -0x98(%rbp)
-               	movsd	%xmm3, -0xa8(%rbp)
-               	movsd	%xmm4, -0xb8(%rbp)
-               	movsd	%xmm5, -0xc8(%rbp)
-               	movsd	%xmm6, -0xd8(%rbp)
-               	movq	$0x0, %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x18(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
+               	movq	%rdx, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	movq	-0x60(%rbp), %r8
-               	movq	-0x68(%rbp), %r9
-               	movq	%r8, %rsi
-               	addq	%r9, %rsi
-               	movq	-0x68(%rbp), %r8
-               	movq	-0x28(%rbp), %r9
-               	movq	%r8, %rdi
-               	xorq	%r9, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%rbx, %rdx
-               	xorq	%r12, %rbx
-               	addq	%r13, %r12
-               	xorq	%r14, %r13
-               	addq	%r15, %r14
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%rbx, %r15
                	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r15
-               	movq	-0x30(%rbp), %r9
-               	movq	-0x70(%rbp), %r10
+               	xorq	%r8, %rbx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%r12, %rax
+               	xorq	%r13, %r12
+               	addq	%r14, %r13
+               	movq	-0x50(%rbp), %r8
+               	xorq	%r8, %r14
+               	movq	-0x50(%rbp), %r8
+               	movq	-0x38(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x58(%rbp), %r9
+               	movq	%r8, %rsi
+               	xorq	%r9, %rsi
+               	movq	-0x58(%rbp), %r9
+               	movq	-0x40(%rbp), %r10
                	movq	%r9, %r8
                	addq	%r10, %r8
+               	movq	%r8, -0x70(%rbp)
+               	movq	-0x40(%rbp), %r9
+               	movq	-0x60(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x78(%rbp)
+               	movq	-0x60(%rbp), %r9
+               	movq	-0x68(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x88(%rbp)
+               	addsd	%xmm2, %xmm1
+               	subsd	%xmm3, %xmm2
+               	addsd	%xmm1, %xmm3
+               	addss	%xmm5, %xmm4
+               	subss	%xmm6, %xmm5
+               	addss	%xmm4, %xmm6
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
                	movq	%r8, -0x48(%rbp)
-               	movq	-0x70(%rbp), %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x70(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x78(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x80(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	-0x88(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x68(%rbp)
+               	cmpq	$0x6, %rdi
+               	jb	 <L12>
+<L13>:
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rbx, %rax
+               	movq	-0x30(%rbp), %r8
+               	xorq	%r8, %rax
+               	xorq	%r12, %rax
+               	xorq	%r13, %rax
+               	xorq	%r14, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	-0x50(%rbp), %r8
                	movq	-0x38(%rbp), %r9
                	movq	%r8, %rax
                	xorq	%r9, %rax
-               	movq	-0x38(%rbp), %r9
-               	movq	-0x78(%rbp), %r10
-               	movq	%r9, %r8
-               	addq	%r10, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	%rsi, %rcx
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
-               	movsd	-0x98(%rbp), %xmm1
-               	subsd	-0xa8(%rbp), %xmm1
-               	movsd	-0xa8(%rbp), %xmm2
-               	addsd	%xmm0, %xmm2
-               	movss	-0xb8(%rbp), %xmm3
-               	addss	-0xc8(%rbp), %xmm3
-               	movss	-0xc8(%rbp), %xmm4
-               	subss	-0xd8(%rbp), %xmm4
-               	movss	-0xd8(%rbp), %xmm5
-               	addss	%xmm3, %xmm5
-               	movq	-0x40(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x48(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x78(%rbp)
-               	movsd	%xmm0, -0x88(%rbp)
-               	movsd	%xmm1, -0x98(%rbp)
-               	movsd	%xmm2, -0xa8(%rbp)
-               	movsd	%xmm3, -0xb8(%rbp)
-               	movsd	%xmm4, -0xc8(%rbp)
-               	movsd	%xmm5, -0xd8(%rbp)
-               	movq	-0x58(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	-0x58(%rbp), %r8
+               	xorq	%r8, %rax
                	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L12>
-<L13>:
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdx
+               	xorq	%r8, %rax
                	movq	-0x60(%rbp), %r8
-               	movq	-0x68(%rbp), %r9
-               	movq	%r8, %rsi
-               	xorq	%r9, %rsi
-               	movq	-0x28(%rbp), %r8
-               	xorq	%r8, %rsi
-               	xorq	%rbx, %rsi
-               	xorq	%r12, %rsi
-               	xorq	%r13, %rsi
-               	movq	%rdx, %rdi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	xorq	%r15, %r14
-               	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x70(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x38(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x78(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	xorq	%r8, %rax
+               	movq	-0x68(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movsd	-0x88(%rbp), %xmm6
-               	addsd	-0x98(%rbp), %xmm6
-               	movsd	%xmm6, %xmm0            ## xmm0 = xmm6[0],xmm0[1]
-               	addsd	-0xa8(%rbp), %xmm0
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movss	-0xb8(%rbp), %xmm0
-               	addss	-0xc8(%rbp), %xmm0
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	-0xd8(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L18>
+               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
+               	addsd	%xmm2, %xmm0
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	addsd	%xmm3, %xmm1
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	-0xe8(%rbp), %rbx
-               	movq	-0xf0(%rbp), %r12
-               	movq	-0xf8(%rbp), %r13
-               	movq	-0x100(%rbp), %r14
-               	movq	-0x108(%rbp), %r15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
+               	addss	%xmm5, %xmm0
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	addss	%xmm6, %xmm1
+               	movd	%xmm1, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%rdx, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -371,12 +428,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_chain.chain>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x100, %rsp            ## imm = 0x100
+               	movq	%rbx, -0xd8(%rbp)
+               	movq	%r12, -0xe0(%rbp)
+               	movq	%r13, -0xe8(%rbp)
+               	movq	%r14, -0xf0(%rbp)
+               	movq	%r15, -0xf8(%rbp)
                	movq	%rdi, %rbx
                	movq	%rsi, %r12
                	movq	%rdx, %r13
@@ -384,51 +441,52 @@ Disassembly of section __TEXT,__text:
                	imulq	$0x3, %rax, %rax
                	movq	%rax, %r8
                	addq	$0x1, %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	%r12, %r15
                	xorq	$0x12345678, %r15       ## imm = 0x12345678
                	movq	%r12, %r8
-               	movq	%r8, -0x50(%rbp)
+               	movq	%r8, -0x68(%rbp)
                	xorq	$-0x1, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	%r12, %rcx
-               	imulq	$0x5, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	%r12, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	%rbx, %r8
                	movq	%r8, -0x8(%rbp)
                	movq	%r12, %r8
                	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
                	addq	%r11, %r8
-               	movq	%r8, -0x58(%rbp)
+               	movq	%r8, -0x60(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x7, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x3, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	%r12, %r14
-               	xorq	$0x55555555, %r14       ## imm = 0x55555555
+               	movq	%r8, -0x18(%rbp)
+               	movq	%r12, %r8
+               	xorq	$0x55555555, %r8        ## imm = 0x55555555
+               	movq	%r8, -0x20(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x9, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x50(%rbp), %r9
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x68(%rbp), %r9
                	movq	%r9, %r8
                	addq	$0xb, %r8
-               	movq	%r8, -0x28(%rbp)
+               	movq	%r8, -0x30(%rbp)
                	movq	%r12, %rdx
                	imulq	$0xd, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x5, %r8
-               	movq	%r8, -0x30(%rbp)
+               	movq	%r8, -0x38(%rbp)
                	movq	%r12, %r8
                	xorq	%rbx, %r8
-               	movq	%r8, -0x38(%rbp)
+               	movq	%r8, -0x40(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x11, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x7, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	%r8, -0x48(%rbp)
                	movq	%r12, %rdx
                	shrq	%rdx
                	andq	$0x3ff, %rdx            ## imm = 0x3FF
@@ -446,8 +504,8 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L1>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x138>
-               	movsd	%xmm14, -0x68(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x13c>
+               	movsd	%xmm14, -0x78(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x9, %rdx
                	andq	$0x3ff, %rdx            ## imm = 0x3FF
@@ -465,8 +523,8 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L3>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x186>
-               	movsd	%xmm14, -0x78(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x18a>
+               	movsd	%xmm14, -0x88(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x13, %rdx
                	andq	$0x3ff, %rdx            ## imm = 0x3FF
@@ -484,8 +542,8 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L5>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x1d4>
-               	movsd	%xmm14, -0x88(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x1db>
+               	movsd	%xmm14, -0x98(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x3, %rdx
                	andq	$0xff, %rdx
@@ -503,8 +561,8 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x225>
-               	movss	%xmm14, -0x98(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x22c>
+               	movss	%xmm14, -0xa8(%rbp)
                	movq	%r12, %rdx
                	shrq	$0xd, %rdx
                	andq	$0xff, %rdx
@@ -522,8 +580,8 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x276>
-               	movss	%xmm14, -0xa8(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x27d>
+               	movss	%xmm14, -0xb8(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x19, %rdx
                	andq	$0xff, %rdx
@@ -541,149 +599,350 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x2c7>
-               	movss	%xmm14, -0xb8(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x2ce>
+               	movss	%xmm14, -0xc8(%rbp)
                	movq	$0x0, %r11
                	cmpq	%rbx, %r11
-               	jb	 <L14>
+               	jb	 <L15>
                	movq	%r12, %rdi
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L13>
+               	movq	%rax, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	movq	%r13, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x48(%rbp)
-               	jmp	 <L16>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x58(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
 <L14>:
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %r14
+               	jmp	 <L17>
+<L15>:
                	movq	%rbx, %rdi
                	subq	$0x1, %rdi
                	imulq	$0x3, %r12, %r12
                	addq	%rbx, %r12
                	movq	%r12, %rsi
                	movq	%r13, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x48(%rbp)
+               	callq	 <L16>
 <L16>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L17>
+               	movq	%rax, %r14
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x10(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L22>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L23>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L25>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
 <L25>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L28>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	%rax, %rdi
-               	movsd	-0x68(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movsd	-0x78(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movsd	-0x88(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L34>
-<L34>:
-               	movsd	-0x68(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	subsd	-0x88(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L35>
-<L35>:
-               	movss	-0x98(%rbp), %xmm0
-               	addss	-0xa8(%rbp), %xmm0
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	-0xb8(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L36>
-<L36>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x18(%rbp), %r8
-               	movq	-0x10(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
-               	movq	-0x40(%rbp), %r8
-               	xorq	%r8, %rcx
-               	movq	%rax, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L37>
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
 <L37>:
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	%r14, %rdi
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L40>
+<L40>:
+               	movq	-0x78(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	-0x88(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	movq	-0x98(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movl	-0xa8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	movl	-0xb8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
+               	movl	-0xc8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
+               	movsd	-0x78(%rbp), %xmm0
+               	addsd	-0x88(%rbp), %xmm0
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	subsd	-0x98(%rbp), %xmm1
+               	movq	%xmm1, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
+               	movss	-0xa8(%rbp), %xmm0
+               	addss	-0xb8(%rbp), %xmm0
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	-0xc8(%rbp), %xmm1
+               	movd	%xmm1, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	-0x10(%rbp), %r8
+               	movq	-0x18(%rbp), %r9
+               	movq	%r8, %rdx
+               	xorq	%r9, %rdx
+               	movq	-0x48(%rbp), %r8
+               	xorq	%r8, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L49>
+<L49>:
+               	movq	-0xd8(%rbp), %rbx
+               	movq	-0xe0(%rbp), %r12
+               	movq	-0xe8(%rbp), %r13
+               	movq	-0xf0(%rbp), %r14
+               	movq	-0xf8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -760,12 +1019,13 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, %rsi
                	callq	 <L8>
 <L8>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
+               	movl	-0x20(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x20(%rbp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	-0x28(%rbp), %rbx
@@ -932,11 +1192,12 @@ Disassembly of section __TEXT,__text:
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
+               	movq	-0x60(%rbp), %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
+               	movl	-0x70(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
@@ -961,15 +1222,16 @@ Disassembly of section __TEXT,__text:
                	callq	 <L21>
 <L21>:
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
+               	movq	-0x20(%rbp), %rsi
                	callq	 <L22>
 <L22>:
                	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
+               	movq	-0x30(%rbp), %rsi
                	callq	 <L23>
 <L23>:
                	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
+               	movl	-0x40(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
@@ -1264,11 +1526,13 @@ Disassembly of section __TEXT,__text:
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
-               	movsd	-0xe8(%rbp), %xmm0
+               	movq	-0xe8(%rbp), %rsi
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rdi
-               	movss	-0xf8(%rbp), %xmm0
+               	movl	-0xf8(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rdi
@@ -1297,15 +1561,17 @@ Disassembly of section __TEXT,__text:
                	callq	 <L31>
 <L31>:
                	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
+               	movq	-0xb8(%rbp), %rsi
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rdi
-               	movsd	-0xc8(%rbp), %xmm0
+               	movq	-0xc8(%rbp), %rsi
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
+               	movl	-0xd8(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
@@ -1346,24 +1612,26 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
+               	movq	-0x68(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x68(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x78(%rbp), %xmm0
                	callq	 <L44>
 <L44>:
+               	movq	-0x88(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x88(%rbp), %xmm0
                	callq	 <L45>
 <L45>:
+               	movl	-0x98(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
                	callq	 <L46>
 <L46>:
+               	movl	-0xa8(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
                	callq	 <L47>
 <L47>:
                	addq	%r15, %r12
@@ -1771,11 +2039,13 @@ Disassembly of section __TEXT,__text:
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rdi
-               	movsd	-0x180(%rbp), %xmm0
+               	movq	-0x180(%rbp), %rsi
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
+               	movl	-0x98(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
@@ -1804,15 +2074,17 @@ Disassembly of section __TEXT,__text:
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movsd	-0x150(%rbp), %xmm0
+               	movq	-0x150(%rbp), %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movsd	-0x160(%rbp), %xmm0
+               	movq	-0x160(%rbp), %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movss	-0x170(%rbp), %xmm0
+               	movl	-0x170(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
@@ -1857,24 +2129,28 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x100(%rbp), %xmm0
                	callq	 <L51>
 <L51>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
                	callq	 <L52>
 <L52>:
+               	movq	-0x120(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x120(%rbp), %xmm0
                	callq	 <L53>
 <L53>:
+               	movl	-0x130(%rbp), %esi
+               	movl	%esi, %ebx
                	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
+               	movq	%rbx, %rsi
                	callq	 <L54>
 <L54>:
+               	movl	-0x140(%rbp), %esi
+               	movl	%esi, %ebx
                	movq	%rax, %rdi
-               	movss	-0x140(%rbp), %xmm0
+               	movq	%rbx, %rsi
                	callq	 <L55>
 <L55>:
                	movq	-0x20(%rbp), %r8
@@ -1927,20 +2203,22 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, %rsi
                	callq	 <L65>
 <L65>:
+               	movq	-0xb8(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
                	callq	 <L66>
 <L66>:
+               	movq	-0xc8(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xc8(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
+               	movl	-0xd8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
+               	movl	-0xe8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xe8(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
                	movq	-0xa0(%rbp), %r8
@@ -1970,8 +2248,6 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x1f0(%rbp)
                	movq	%r15, -0x1f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1979,43 +2255,43 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
                	movq	$0x10, %rdi
                	addq	%rbx, %rdi
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdx
-               	callq	 <L3>
-<L3>:
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	movq	$0x1, %rdi
                	addq	%rbx, %rdi
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdx
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L5>
-               	jmp	 <L77>
-<L5>:
+               	jb	 <L4>
+               	jmp	 <L76>
+<L4>:
                	leaq	(%r12,%r14,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
@@ -2057,76 +2333,76 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rdx            ## imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L6>
+               	jl	 <L5>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L7>
-<L6>:
+               	jmp	 <L6>
+<L5>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L7>:
+<L6>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x1d9>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x1db>
                	movsd	%xmm14, -0x100(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x12, %rdx
                	andq	$0x3ff, %rdx            ## imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L8>
+               	jl	 <L7>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
+               	jmp	 <L8>
+<L7>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L9>:
+<L8>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x22a>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x22c>
                	movsd	%xmm14, -0x110(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0xb, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L10>
+               	jl	 <L9>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L11>
-<L10>:
+               	jmp	 <L10>
+<L9>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L11>:
+<L10>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x27b>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x27d>
                	movss	%xmm14, -0x120(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x13, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L12>
+               	jl	 <L11>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L13>
-<L12>:
+               	jmp	 <L12>
+<L11>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L13>:
+<L12>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x2cc>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x2ce>
                	movss	%xmm14, -0x130(%rbp)
                	imulq	$0x3, %rcx, %rcx
                	addq	$0x5, %rcx
@@ -2160,95 +2436,95 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L14>
+               	jl	 <L13>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L15>
-<L14>:
+               	jmp	 <L14>
+<L13>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L15>:
+<L14>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x392>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x394>
                	movsd	%xmm14, -0x148(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x10, %rsi
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L16>
+               	jl	 <L15>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L17>
-<L16>:
+               	jmp	 <L16>
+<L15>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L17>:
+<L16>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x3e3>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x3e5>
                	movsd	%xmm14, -0x158(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x1a, %rsi
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L17>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L18>
+<L17>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
+<L18>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x434>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x436>
                	movsd	%xmm14, -0x168(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x9, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L19>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L20>
+<L19>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L21>:
+<L20>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x485>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x487>
                	movss	%xmm14, -0x178(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x1b, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d6>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d8>
                	movss	%xmm14, -0x188(%rbp)
                	addq	$0x1d, %rcx
                	movq	%rcx, %r8
@@ -2276,57 +2552,57 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x588>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x58a>
                	movsd	%xmm14, -0x198(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0xe, %rsi
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5d9>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5db>
                	movsd	%xmm14, -0x1a8(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x15, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x62a>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x62c>
                	movss	%xmm14, -0x1b8(%rbp)
                	imulq	$0x7, %rcx, %rcx
                	addq	$0x1, %rcx
@@ -2345,169 +2621,173 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L31>:
+<L30>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b4>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b6>
                	movsd	%xmm14, -0x1c8(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x7, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L33>:
+<L32>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x705>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x707>
                	movss	%xmm14, -0xe8(%rbp)
                	xorq	$0x3039, %rcx           ## imm = 0x3039
                	movq	%rcx, %rdi
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %rsi
                	movq	%r13, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	%rax, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
+               	movq	-0xd0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
+               	movq	-0xd8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L37>
 <L37>:
                	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x1c8(%rbp), %rsi
                	callq	 <L38>
 <L38>:
                	movq	%rax, %rdi
-               	movsd	-0x1c8(%rbp), %xmm0
+               	movl	-0xe8(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movss	-0xe8(%rbp), %xmm0
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x198(%rbp), %rsi
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rdi
-               	movsd	-0x198(%rbp), %xmm0
+               	movq	-0x1a8(%rbp), %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movsd	-0x1a8(%rbp), %xmm0
+               	movl	-0x1b8(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rdi
-               	movss	-0x1b8(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
                	movq	%rax, %rdi
                	movq	-0xa0(%rbp), %r8
                	movq	-0xc0(%rbp), %r9
                	movq	%r8, %rsi
                	xorq	%r9, %rsi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rdi
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L55>
 <L55>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x148(%rbp), %rsi
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rdi
-               	movsd	-0x148(%rbp), %xmm0
+               	movq	-0x158(%rbp), %rsi
                	callq	 <L57>
 <L57>:
                	movq	%rax, %rdi
-               	movsd	-0x158(%rbp), %xmm0
+               	movq	-0x168(%rbp), %rsi
                	callq	 <L58>
 <L58>:
                	movq	%rax, %rdi
-               	movsd	-0x168(%rbp), %xmm0
+               	movl	-0x178(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L59>
 <L59>:
                	movq	%rax, %rdi
-               	movss	-0x178(%rbp), %xmm0
+               	movl	-0x188(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L60>
 <L60>:
-               	movq	%rax, %rdi
-               	movss	-0x188(%rbp), %xmm0
-               	callq	 <L61>
-<L61>:
                	movq	%rax, %rdi
                	movq	-0x70(%rbp), %r8
                	movq	-0x80(%rbp), %r9
@@ -2516,91 +2796,93 @@ Disassembly of section __TEXT,__text:
                	movq	-0x98(%rbp), %r8
                	addq	%r8, %rcx
                	movq	%rcx, %rsi
+               	callq	 <L61>
+<L61>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L62>
 <L62>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L63>
 <L63>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L64>
 <L64>:
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
+               	movq	-0x40(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L65>
 <L65>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
+               	movq	-0x48(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L66>
 <L66>:
                	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L67>
 <L67>:
                	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
+               	movq	-0x58(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
+               	movq	-0x60(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L69>
 <L69>:
                	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L70>
 <L70>:
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L71>
 <L71>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x100(%rbp), %xmm0
                	callq	 <L72>
 <L72>:
+               	movl	-0x120(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
                	callq	 <L73>
 <L73>:
+               	movl	-0x130(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x120(%rbp), %xmm0
                	callq	 <L74>
 <L74>:
-               	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
                	movq	-0x48(%rbp), %r8
                	xorq	%r8, %r15
                	movq	-0x68(%rbp), %r8
                	xorq	%r8, %r15
                	movq	%rax, %rdi
                	movq	%r15, %rsi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L5>
-<L77>:
+               	jb	 <L4>
+<L76>:
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
                	movq	%rcx, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L77>
+<L77>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L78>
+<L78>:
                	movq	-0x1d8(%rbp), %rbx
                	movq	-0x1e0(%rbp), %r12
                	movq	-0x1e8(%rbp), %r13

--- a/test/golden/x86_64-darwin/call/call_float_regs.dis
+++ b/test/golden/x86_64-darwin/call/call_float_regs.dis
@@ -56,135 +56,417 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_float_regs.takef16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            ## imm = 0x100
-               	movss	%xmm0, -0x40(%rbp)
-               	movsd	%xmm1, -0x50(%rbp)
-               	movss	%xmm2, -0x60(%rbp)
-               	movsd	%xmm3, -0x70(%rbp)
-               	movss	%xmm4, -0x80(%rbp)
-               	movsd	%xmm5, -0x90(%rbp)
-               	movss	%xmm6, -0xa0(%rbp)
-               	movsd	%xmm7, -0xb0(%rbp)
+               	subq	$0xe0, %rsp
+               	movq	%rbx, -0xd8(%rbp)
+               	movss	%xmm0, -0x30(%rbp)
+               	movsd	%xmm1, -0x40(%rbp)
+               	movsd	%xmm3, -0x50(%rbp)
+               	movsd	%xmm5, -0x60(%rbp)
+               	movsd	%xmm7, -0x70(%rbp)
                	movq	0x10(%rbp), %r11
-               	movq	%r11, -0xc0(%rbp)
+               	movq	%r11, -0x80(%rbp)
                	movq	0x18(%rbp), %r11
-               	movq	%r11, -0x20(%rbp)
+               	movq	%r11, -0x90(%rbp)
                	movq	0x20(%rbp), %r11
-               	movq	%r11, -0xd0(%rbp)
+               	movq	%r11, -0xa0(%rbp)
                	movq	0x28(%rbp), %r11
-               	movq	%r11, -0xe0(%rbp)
+               	movq	%r11, -0xb0(%rbp)
                	movq	0x30(%rbp), %r11
-               	movq	%r11, -0xf0(%rbp)
+               	movq	%r11, -0xc0(%rbp)
                	movq	0x38(%rbp), %r11
-               	movq	%r11, -0x10(%rbp)
+               	movq	%r11, -0xd0(%rbp)
                	movq	0x40(%rbp), %r11
-               	movq	%r11, -0x100(%rbp)
+               	movq	%r11, -0x10(%rbp)
                	movq	0x48(%rbp), %r11
-               	movq	%r11, -0x30(%rbp)
-               	callq	 <L0>
+               	movq	%r11, -0x20(%rbp)
+               	movl	-0x30(%rbp), %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x50(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	-0x40(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L4>
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x80(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L6>
+               	movq	-0x50(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	-0xb0(%rbp), %xmm0
-               	callq	 <L8>
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	-0x60(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm0
-               	callq	 <L12>
+               	movd	%xmm6, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movss	-0xf0(%rbp), %xmm0
-               	callq	 <L13>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L14>
+               	movq	-0x70(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
-               	callq	 <L16>
+               	movl	-0x80(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
-               	mulss	-0x80(%rbp), %xmm0
-               	movss	-0x40(%rbp), %xmm1
-               	addss	%xmm0, %xmm1
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	subss	-0xa0(%rbp), %xmm0
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
+               	movq	-0x90(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movl	-0xa0(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0xb0(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movl	-0xc0(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0xd0(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movl	-0x10(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movq	-0x20(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
+               	mulss	%xmm4, %xmm0
+               	movss	-0x30(%rbp), %xmm2
+               	addss	%xmm0, %xmm2
+               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
+               	subss	%xmm6, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	mulsd	-0x90(%rbp), %xmm0
-               	movsd	-0x50(%rbp), %xmm1
+               	callq	 <L32>
+<L32>:
+               	movsd	-0x50(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movsd	-0x40(%rbp), %xmm1
                	addsd	%xmm0, %xmm1
                	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	subsd	-0xb0(%rbp), %xmm0
-               	callq	 <L18>
-<L18>:
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%xmm0, %rsi
                	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	-0xd0(%rbp), %xmm0
-               	movss	-0xf0(%rbp), %xmm1
-               	mulss	-0x100(%rbp), %xmm1
+               	callq	 <L33>
+<L33>:
+               	movss	-0x80(%rbp), %xmm0
+               	subss	-0xa0(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm1
+               	mulss	-0x10(%rbp), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
-               	callq	 <L19>
-<L19>:
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	subsd	-0xe0(%rbp), %xmm0
-               	movsd	-0x10(%rbp), %xmm1
-               	mulsd	-0x30(%rbp), %xmm1
+               	callq	 <L34>
+<L34>:
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
+               	movsd	-0xd0(%rbp), %xmm1
+               	mulsd	-0x20(%rbp), %xmm1
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
                	addsd	%xmm1, %xmm2
-               	movsd	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1]
-               	callq	 <L20>
-<L20>:
+               	movq	%xmm2, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movq	-0xd8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -193,10 +475,10 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x100, %rsp            ## imm = 0x100
-               	movss	%xmm0, -0x40(%rbp)
-               	movss	%xmm1, -0x50(%rbp)
-               	movss	%xmm2, -0x60(%rbp)
-               	movss	%xmm3, -0x10(%rbp)
+               	movss	%xmm0, -0x30(%rbp)
+               	movss	%xmm1, -0x40(%rbp)
+               	movss	%xmm2, -0x50(%rbp)
+               	movss	%xmm3, -0x60(%rbp)
                	movss	%xmm4, -0x70(%rbp)
                	movss	%xmm5, -0x80(%rbp)
                	movss	%xmm6, -0x90(%rbp)
@@ -214,90 +496,94 @@ Disassembly of section __TEXT,__text:
                	movq	0x38(%rbp), %r11
                	movq	%r11, -0x100(%rbp)
                	movq	0x40(%rbp), %r11
-               	movq	%r11, -0x20(%rbp)
+               	movq	%r11, -0x10(%rbp)
                	movq	0x48(%rbp), %r11
-               	movq	%r11, -0x30(%rbp)
+               	movq	%r11, -0x20(%rbp)
+               	movl	-0x30(%rbp), %eax
+               	movl	%eax, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	movl	-0x40(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movl	-0x50(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x50(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movl	-0x60(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
+               	movl	-0x70(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	movl	-0x80(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movss	-0x80(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movss	-0x90(%rbp), %xmm0
+               	movss	-0xa0(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
+               	movss	-0xb0(%rbp), %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movss	-0xb0(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
+               	movss	-0xe0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
+               	movss	-0xf0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movss	-0xf0(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movss	-0x10(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
                	movss	-0x20(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movss	-0x30(%rbp), %xmm0
+               	addss	-0x20(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
                	movss	-0xa0(%rbp), %xmm0
                	subss	-0xf0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
-               	mulss	-0x20(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -305,119 +591,113 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_float_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4b0, %rsp            ## imm = 0x4B0
-               	movq	%rbx, -0x448(%rbp)
-               	movq	%r12, -0x450(%rbp)
-               	movq	%r13, -0x458(%rbp)
-               	movq	%r14, -0x460(%rbp)
-               	movq	%r15, -0x468(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x310, %rsp            ## imm = 0x310
+               	movq	%rbx, -0x2a8(%rbp)
+               	movq	%r12, -0x2b0(%rbp)
+               	movq	%r13, -0x2b8(%rbp)
+               	movq	%r14, -0x2c0(%rbp)
+               	movq	%r15, -0x2c8(%rbp)
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0xa0, %rdx
 <L0>:
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0xa0, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L0>
+               	movq	$0x0, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	movq	$0x0, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rdx, %rsi
+               	movq	%rcx, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rsi
+               	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rsi
-               	addq	%rbx, %rsi
-               	leaq	(%rcx,%rdx,8), %rdi
-               	movq	%rsi, (%rdi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L2>
+               	addq	%r11, %rdx
+               	addq	%rdi, %rdx
+               	leaq	(%rax,%rcx,8), %rsi
+               	movq	%rdx, (%rsi)
+               	addq	$0x1, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x50(%rbp), %rbx
+               	leaq	(%rbx), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x50, %rdx
 <L3>:
-               	leaq	-0xf0(%rbp), %rbx
-               	leaq	(%rbx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0x50, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L3>
+               	leaq	-0xf0(%rbp), %r12
+               	leaq	(%r12), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0xa0, %rdx
 <L4>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L4>
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0xa0, %rsi
+               	movq	$0x0, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+               	jmp	 <L10>
 <L5>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L5>
-               	movq	$0x0, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-               	jmp	 <L11>
-<L6>:
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfff, %rsi            ## imm = 0xFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x176>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x15e>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x182>
-               	leaq	(%rbx,%rdx,4), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
-               	movq	%rdi, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x16a>
+               	leaq	(%rbx,%rcx,4), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1d0>
+               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1b8>
                	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1dc>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8,%rdx,8), %rsi
-               	movsd	%xmm0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-<L11>:
-               	movq	%rax, %r8
+               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1c4>
+               	leaq	(%r12,%rcx,8), %rdx
+               	movsd	%xmm0, (%rdx)
+               	addq	$0x1, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+<L10>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x1a0(%rbp)
                	movq	$0x0, %r8
                	movq	%r8, -0x198(%rbp)
@@ -425,80 +705,74 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-               	jmp	 <L38>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L18>
+<L11>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0x3, %rax
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x27d>
-               	movss	%xmm14, -0x288(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x265>
+               	movss	%xmm14, -0x278(%rbp)
                	leaq	(%rbx), %r8
-               	movq	%r8, -0x290(%rbp)
-               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r8
                	movss	(%r8), %xmm0
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0x288(%rbp), %xmm14
+               	addss	-0x278(%rbp), %xmm14
                	movss	%xmm14, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
+               	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %r11
                	movq	%r11, -0x1d8(%rbp)
                	leaq	0x8(%rbx), %r8
-               	movq	%r8, -0x298(%rbp)
-               	movq	-0x298(%rbp), %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
                	movl	(%r8), %r11d
                	movl	%r11d, -0x1e8(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r12), %rdx
                	movsd	(%rdx), %xmm4
                	leaq	0x10(%rbx), %r8
-               	movq	%r8, -0x2a0(%rbp)
-               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x290(%rbp), %r8
                	movss	(%r8), %xmm5
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x28(%r8), %rsi
+               	leaq	0x28(%r12), %rsi
                	movsd	(%rsi), %xmm6
                	leaq	0x18(%rbx), %r14
                	movss	(%r14), %xmm7
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x38(%r8), %rsi
+               	leaq	0x38(%r12), %rsi
                	movsd	(%rsi), %xmm9
                	leaq	0x20(%rbx), %r13
                	movss	(%r13), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x48(%r8), %rsi
+               	leaq	0x48(%r12), %rsi
                	movsd	(%rsi), %xmm10
                	leaq	0x28(%rbx), %r15
                	movss	(%r15), %xmm11
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x58(%r8), %rsi
+               	leaq	0x58(%r12), %rsi
                	movsd	(%rsi), %xmm12
-               	leaq	0x30(%rbx), %r12
-               	movss	(%r12), %xmm13
+               	leaq	0x30(%rbx), %r8
+               	movq	%r8, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %r8
-               	leaq	0x68(%r8), %rsi
+               	movss	(%r8), %xmm13
+               	leaq	0x68(%r12), %rsi
                	movsd	(%rsi), %xmm1
                	leaq	0x38(%rbx), %r8
                	movq	%r8, -0x1c8(%rbp)
                	movq	-0x1c8(%rbp), %r8
                	movss	(%r8), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x78(%r8), %rsi
+               	leaq	0x78(%r12), %rsi
                	movsd	(%rsi), %xmm3
                	movsd	%xmm0, (%rsp)
                	movsd	%xmm10, 0x8(%rsp)
@@ -516,366 +790,197 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm5            ## xmm5 = xmm6[0],xmm5[1]
                	movss	%xmm7, %xmm6            ## xmm6 = xmm7[0],xmm6[1,2,3]
                	movsd	%xmm9, %xmm7            ## xmm7 = xmm9[0],xmm7[1]
-               	callq	 <L15>
-<L15>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rsi
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %r8
-               	movq	%r8, -0x2a8(%rbp)
-               	movq	-0x2a8(%rbp), %r8
-               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	movq	-0x280(%rbp), %r8
                	movl	(%r8), %r11d
-               	movl	%r11d, -0x208(%rbp)
+               	movl	%r11d, -0x1f8(%rbp)
                	leaq	0x4(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x2b8(%rbp)
-               	movq	-0x298(%rbp), %r8
-               	movl	(%r8), %r11d
-               	movl	%r11d, -0x2c8(%rbp)
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x1f8(%rbp)
-               	movq	-0x2a0(%rbp), %r8
-               	movl	(%r8), %r11d
-               	movl	%r11d, -0x2d8(%rbp)
-               	leaq	0x14(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2e8(%rbp)
-               	movl	(%r14), %r11d
-               	movl	%r11d, -0x2f8(%rbp)
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x308(%rbp)
-               	movl	(%r13), %r11d
-               	movl	%r11d, -0x318(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x328(%rbp)
-               	movl	(%r15), %r11d
-               	movl	%r11d, -0x338(%rbp)
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x348(%rbp)
-               	movl	(%r12), %r11d
-               	movl	%r11d, -0x358(%rbp)
-               	leaq	0x34(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x368(%rbp)
-               	movq	-0x1c8(%rbp), %r8
+               	movl	%r11d, -0x208(%rbp)
+               	movq	-0x288(%rbp), %r8
                	movl	(%r8), %r11d
                	movl	%r11d, -0x218(%rbp)
-               	leaq	0x3c(%rbx), %rax
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r11d
+               	movl	%r11d, -0x228(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movss	(%r8), %xmm4
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	movss	(%r14), %xmm6
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm7
+               	movss	(%r13), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	movss	(%r15), %xmm11
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	movq	-0x1b0(%rbp), %r8
+               	movss	(%r8), %xmm13
+               	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm0
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0x288(%rbp), %xmm14
-               	movss	%xmm14, -0x228(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movss	(%r8), %xmm1
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
+               	addss	-0x278(%rbp), %xmm3
+               	movsd	%xmm9, (%rsp)
+               	movsd	%xmm10, 0x8(%rsp)
+               	movsd	%xmm11, 0x10(%rsp)
+               	movsd	%xmm12, 0x18(%rsp)
+               	movsd	%xmm13, 0x20(%rsp)
+               	movsd	%xmm0, 0x28(%rsp)
+               	movsd	%xmm1, 0x30(%rsp)
+               	movsd	%xmm3, 0x38(%rsp)
+               	movss	-0x1f8(%rbp), %xmm0
+               	movss	-0x208(%rbp), %xmm1
+               	movss	-0x218(%rbp), %xmm2
+               	movss	-0x228(%rbp), %xmm3
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r13
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r13, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movss	-0x208(%rbp), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movss	-0x2b8(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movss	-0x2c8(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movss	-0x1f8(%rbp), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movss	-0x2d8(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0x2e8(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movss	-0x2f8(%rbp), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movss	-0x308(%rbp), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movss	-0x318(%rbp), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movss	-0x328(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movss	-0x338(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movss	-0x348(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movss	-0x358(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	-0x368(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0x218(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	-0x228(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movss	-0x208(%rbp), %xmm0
-               	addss	-0x228(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movss	-0x308(%rbp), %xmm0
-               	subss	-0x358(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movss	-0x1f8(%rbp), %xmm0
-               	mulss	-0x218(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r12
-               	movq	-0x2a8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L37>
-<L37>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
                	movq	%r8, -0x1a0(%rbp)
-               	movq	%r12, %r8
+               	movq	%r13, %r8
                	movq	%r8, -0x198(%rbp)
                	movq	%rcx, %r8
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-<L38>:
+               	jb	 <L11>
+<L18>:
                	leaq	0x4c(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x258(%rbp)
+               	movl	%r11d, -0x238(%rbp)
                	leaq	0x48(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x378(%rbp)
-               	leaq	0x44(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x388(%rbp)
-               	leaq	0x40(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x238(%rbp)
-               	leaq	0x3c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x398(%rbp)
-               	leaq	0x38(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3a8(%rbp)
-               	leaq	0x34(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3b8(%rbp)
-               	leaq	0x30(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3c8(%rbp)
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3d8(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3e8(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3f8(%rbp)
-               	leaq	0x20(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x408(%rbp)
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x418(%rbp)
-               	leaq	0x18(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x428(%rbp)
-               	leaq	0x14(%rbx), %rax
-               	movl	(%rax), %r11d
                	movl	%r11d, -0x248(%rbp)
+               	leaq	0x44(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	leaq	0x40(%rbx), %rax
+               	movss	(%rax), %xmm3
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm4
+               	leaq	0x38(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	leaq	0x34(%rbx), %rax
+               	movss	(%rax), %xmm6
+               	leaq	0x30(%rbx), %rax
+               	movss	(%rax), %xmm7
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm8
+               	leaq	0x28(%rbx), %rax
+               	movss	(%rax), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	leaq	0x20(%rbx), %rax
+               	movss	(%rax), %xmm11
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	leaq	0x18(%rbx), %rax
+               	movss	(%rax), %xmm13
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm0
                	leaq	0x10(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x438(%rbp)
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movss	-0x258(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	movss	-0x378(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	movss	-0x388(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
+               	movss	(%rax), %xmm1
+               	movsd	%xmm8, (%rsp)
+               	movsd	%xmm9, 0x8(%rsp)
+               	movsd	%xmm10, 0x10(%rsp)
+               	movsd	%xmm11, 0x18(%rsp)
+               	movsd	%xmm12, 0x20(%rsp)
+               	movsd	%xmm13, 0x28(%rsp)
+               	movsd	%xmm0, 0x30(%rsp)
+               	movsd	%xmm1, 0x38(%rsp)
                	movss	-0x238(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movss	-0x398(%rbp), %xmm0
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movss	-0x3a8(%rbp), %xmm0
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movss	-0x3b8(%rbp), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movss	-0x3c8(%rbp), %xmm0
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
-               	movss	-0x3d8(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movss	-0x3e8(%rbp), %xmm0
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	movss	-0x3f8(%rbp), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movss	-0x408(%rbp), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	movss	-0x418(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movss	-0x428(%rbp), %xmm0
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movss	-0x248(%rbp), %xmm0
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movss	-0x438(%rbp), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movss	-0x258(%rbp), %xmm0
-               	addss	-0x438(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movss	-0x3c8(%rbp), %xmm0
-               	subss	-0x418(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	movss	-0x238(%rbp), %xmm0
-               	mulss	-0x248(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	movss	-0x248(%rbp), %xmm1
+               	callq	 <L19>
+<L19>:
                	andq	$0xfff, %rax            ## imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
-<L59>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L60>:
+<L21>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x926>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x667>
                	movss	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x934>
-               	movss	%xmm14, -0x268(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rax
+               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x675>
+               	movss	%xmm14, -0x258(%rbp)
+               	leaq	(%r12), %rax
                	movq	(%rax), %r11
-               	movq	%r11, -0x278(%rbp)
+               	movq	%r11, -0x268(%rbp)
                	leaq	0x4(%rbx), %rax
                	movss	(%rax), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x10(%r8), %rax
+               	leaq	0x10(%r12), %rax
                	movsd	(%rax), %xmm3
                	leaq	0xc(%rbx), %rax
                	movss	(%rax), %xmm4
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x20(%r8), %rax
+               	leaq	0x20(%r12), %rax
                	movsd	(%rax), %xmm5
                	leaq	0x14(%rbx), %rax
                	movss	(%rax), %xmm6
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x30(%r8), %rax
+               	leaq	0x30(%r12), %rax
                	movsd	(%rax), %xmm7
                	movq	-0x198(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0xfff, %rax            ## imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L22>
                	cvtsi2ss	%r11, %xmm8
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm8
                	addss	%xmm8, %xmm8
-<L62>:
+<L23>:
                	movss	%xmm8, %xmm9            ## xmm9 = xmm8[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x9e2>
+               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x70b>
                	movss	%xmm9, %xmm8            ## xmm8 = xmm9[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x9f0>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x40(%r8), %rax
+               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x719>
+               	leaq	0x40(%r12), %rax
                	movsd	(%rax), %xmm9
                	leaq	0x24(%rbx), %rax
                	movss	(%rax), %xmm10
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x50(%r8), %rax
+               	leaq	0x50(%r12), %rax
                	movsd	(%rax), %xmm11
                	leaq	0x2c(%rbx), %rax
                	movss	(%rax), %xmm12
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x60(%r8), %rax
+               	leaq	0x60(%r12), %rax
                	movsd	(%rax), %xmm13
                	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x70(%r8), %rax
+               	leaq	0x70(%r12), %rax
                	movsd	(%rax), %xmm1
                	movsd	%xmm8, (%rsp)
                	movsd	%xmm9, 0x8(%rsp)
@@ -885,20 +990,20 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm13, 0x28(%rsp)
                	movsd	%xmm0, 0x30(%rsp)
                	movsd	%xmm1, 0x38(%rsp)
-               	movss	-0x268(%rbp), %xmm0
-               	movsd	-0x278(%rbp), %xmm1
-               	callq	 <L63>
-<L63>:
+               	movss	-0x258(%rbp), %xmm0
+               	movsd	-0x268(%rbp), %xmm1
+               	callq	 <L24>
+<L24>:
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x448(%rbp), %rbx
-               	movq	-0x450(%rbp), %r12
-               	movq	-0x458(%rbp), %r13
-               	movq	-0x460(%rbp), %r14
-               	movq	-0x468(%rbp), %r15
+               	callq	 <L25>
+<L25>:
+               	movq	-0x2a8(%rbp), %rbx
+               	movq	-0x2b0(%rbp), %r12
+               	movq	-0x2b8(%rbp), %r13
+               	movq	-0x2c0(%rbp), %r14
+               	movq	-0x2c8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_indirect.dis
+++ b/test/golden/x86_64-darwin/call/call_indirect.dis
@@ -59,28 +59,81 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_indirect.fold24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -174,85 +227,280 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_indirect.wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movl	%esi, %r12d
-               	movsd	%xmm0, -0x18(%rbp)
-               	movq	%rdx, %r13
-               	movss	%xmm1, -0x28(%rbp)
-               	movq	%rcx, %r14
-               	movl	%r8d, %r15d
-               	movsd	%xmm2, -0x38(%rbp)
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%r8d, %ebx
                	movq	%r9, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	%r8, -0x18(%rbp)
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x48(%rbp)
-               	movss	%xmm3, -0x58(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	0x18(%rbp), %r8
                	movq	%r8, -0x8(%rbp)
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %r15 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%r14, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r14
+               	movq	%r12, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movsd	-0x18(%rbp), %xmm0
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L4>
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x28(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	-0x38(%rbp), %xmm0
-               	callq	 <L8>
+               	movd	%xmm1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm0
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movslq	%ebx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	%r15, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -323,49 +571,46 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_indirect.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            ## imm = 0x2E0
-               	movq	%rbx, -0x298(%rbp)
-               	movq	%r12, -0x2a0(%rbp)
-               	movq	%r13, -0x2a8(%rbp)
-               	movq	%r14, -0x2b0(%rbp)
-               	movq	%r15, -0x2b8(%rbp)
+               	subq	$0x300, %rsp            ## imm = 0x300
+               	movq	%rbx, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
                	movq	%rdi, %r8
-               	movq	%r8, -0x120(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x130(%rbp)
-               	movq	-0x130(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	leaq	-0xe0(%rbp), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
                	movq	$0x60, %rdi
-<L1>:
+<L0>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
-               	jne	 <L1>
+               	jne	 <L0>
                	movq	$0x0, %rsi
                	cmpq	$0xc, %rsi
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rsi, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdi
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
                	addq	%r11, %rdi
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %rdi
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	leaq	(%r8,%rsi,8), %r13
                	movq	%rdi, (%r13)
                	addq	$0x1, %rsi
                	cmpq	$0xc, %rsi
-               	jb	 <L2>
-<L3>:
-               	leaq	-0x90(%rbp), %r13
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x30(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -373,24 +618,24 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x116>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x10e>
                	movq	%rdi, (%rsi)
                	leaq	0x8(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x124>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x11c>
                	movq	%rdi, (%rsi)
                	leaq	0x10(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x132>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x12a>
                	movq	%rdi, (%rsi)
                	leaq	0x18(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x140>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x138>
                	movq	%rdi, (%rsi)
                	leaq	0x20(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x14e>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x146>
                	movq	%rdi, (%rsi)
                	leaq	0x28(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x15c>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x154>
                	movq	%rdi, (%rsi)
-               	leaq	-0xa0(%rbp), %r8
+               	leaq	-0x40(%rbp), %r8
                	movq	%r8, -0x128(%rbp)
                	movq	-0x128(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -398,197 +643,113 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x8(%r8)
                	movq	-0x128(%rbp), %r8
                	leaq	(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x19b>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x190>
                	movq	%rdi, (%rsi)
                	movq	-0x128(%rbp), %r8
                	leaq	0x8(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1b0>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1a5>
                	movq	%rdi, (%rsi)
-               	leaq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x138(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1ef>
-               	movq	%rdi, (%rsi)
-               	movq	-0x138(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x204>
-               	movq	%rdi, (%rsi)
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0x150(%rbp), %r8
-               	cmpq	$0xc, %r8
-               	jb	 <L4>
-               	jmp	 <L15>
-<L4>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %r14
-               	movq	(%r14), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r12
-               	leaq	(%r13,%r12,8), %r15
-               	movq	(%r15), %rcx
-               	movq	(%r14), %rsi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%rcx
-               	movq	%rax, %r8
+               	leaq	-0x50(%rbp), %r8
                	movq	%r8, -0x148(%rbp)
                	movq	-0x148(%rbp), %r8
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	$0x0, (%r8)
                	movq	-0x148(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1e1>
+               	movq	%rdi, (%rsi)
+               	movq	-0x148(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1f6>
+               	movq	%rdi, (%rsi)
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L5>
+               	addq	$0x1, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x118(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0xc, %r14
+               	jb	 <L3>
+               	jmp	 <L15>
+<L3>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	leaq	(%r13,%r8,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x138(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %r15
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x158(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rbx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x158(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %r8
-               	movq	(%r15), %rbx
-               	movq	(%r14), %rsi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%rbx
+               	movq	-0x130(%rbp), %r8
+               	leaq	(%r13,%r8,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%r15, %rdi
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x160(%rbp), %r8
+               	callq	*%r8
                	movq	%rax, %rsi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%rbx, %rdi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	movq	%r12, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %r12
                	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %r14
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
-               	movq	%rax, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rbx
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	cmpq	$0x0, %rcx
-               	je	 <L12>
-               	cmpq	$0x1, %rcx
-               	je	 <L11>
-               	cmpq	$0x2, %rcx
-               	je	 <L10>
-               	cmpq	$0x3, %rcx
-               	je	 <L9>
-               	cmpq	$0x4, %rcx
-               	je	 <L8>
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3bb>
-               	jmp	 <L13>
-<L8>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3c7>
-               	jmp	 <L13>
-<L9>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3d3>
-               	jmp	 <L13>
-<L10>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3df>
-               	jmp	 <L13>
-<L11>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3eb>
-               	jmp	 <L13>
-<L12>:
-               	leaq	, %r12 <L13>
-<L13>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%r12
-               	movq	%rax, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x148(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0x150(%rbp), %r8
-               	cmpq	$0xc, %r8
-               	jb	 <L4>
-<L15>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rbx
-               	movq	-0x140(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	$0x0, %r14
-               	movq	%rcx, %r15
-               	cmpq	$0x8, %r14
-               	jb	 <L16>
-               	jmp	 <L18>
-<L16>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	addq	%r14, %rsi
                	movq	%rsi, %rax
                	movq	$0x6, %rsi
                	xorl	%edx, %edx
@@ -596,14 +757,131 @@ Disassembly of section __TEXT,__text:
                	movq	%rdx, %rsi
                	leaq	(%r13,%rsi,8), %rdi
                	movq	(%rdi), %r8
-               	movq	%r8, -0x158(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x158(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%r15, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x170(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x170(%rbp), %r8
                	callq	*%r8
                	movq	%rax, %rsi
+               	movq	%rbx, %rdi
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	cmpq	$0x0, %rsi
+               	je	 <L12>
+               	cmpq	$0x1, %rsi
+               	je	 <L11>
+               	cmpq	$0x2, %rsi
+               	je	 <L10>
+               	cmpq	$0x3, %rsi
+               	je	 <L9>
+               	cmpq	$0x4, %rsi
+               	je	 <L8>
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x469>
+               	jmp	 <L13>
+<L8>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x475>
+               	jmp	 <L13>
+<L9>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x481>
+               	jmp	 <L13>
+<L10>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x48d>
+               	jmp	 <L13>
+<L11>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x499>
+               	jmp	 <L13>
+<L12>:
+               	leaq	, %r12 <L13>
+<L13>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%r15, %rdi
                	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	*%r12
+               	movq	%rax, %rsi
+               	movq	%rbx, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x120(%rbp)
+               	cmpq	$0xc, %r14
+               	jb	 <L3>
+<L15>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	(%r13,%rsi,8), %rdi
+               	movq	(%rdi), %rsi
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	-0x120(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r14
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L18>
+<L16>:
+               	movq	-0x180(%rbp), %r9
+               	leaq	(%r9,%r14,8), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	addq	%r14, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%r13,%rdi,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x198(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %rsi
+               	movq	-0x208(%rbp), %r8
                	movq	%r8, %rdi
                	callq	*%r15
                	movq	%rax, %r12
@@ -614,478 +892,424 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rbx
                	addq	$0x1, %r14
                	movq	%r12, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x158(%rbp), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x198(%rbp), %r8
                	movq	%r8, %r15
                	cmpq	$0x8, %r14
                	jb	 <L16>
 <L18>:
+               	movq	%rbx, %r8
+               	movq	%r8, -0x238(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x8, %r13
                	jb	 <L19>
-               	jmp	 <L25>
+               	jmp	 <L28>
 <L19>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8,%r13,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x2, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r14
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x2, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r15
-               	leaq	-0xc8(%rbp), %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0x188(%rbp), %r8
-               	addq	%r8, %rsi
-               	leaq	-0xe0(%rbp), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x168(%rbp), %r8
-               	callq	*%r8
-               	movq	-0x1e8(%rbp), %r8
-               	movq	-0x1e8(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x1e8(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x1e8(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	-0x170(%rbp), %r9
-               	movq	%r9, 0x10(%r8)
-               	movq	-0x160(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x160(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x178(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x180(%rbp)
-               	movq	%rbx, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
                	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1f0(%rbp)
-               	movq	-0x1f0(%rbp), %r8
-               	movq	-0x128(%rbp), %r8
-               	leaq	(%r8,%r15,8), %r12
-               	movq	(%r12), %r15
-               	leaq	-0xf8(%rbp), %rsi
-               	movq	-0x160(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0x160(%rbp), %r9
-               	movq	0x8(%r9), %r8
-               	movq	%r8, -0x190(%rbp)
-               	movq	-0x160(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	%rdi, (%rsi)
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, 0x8(%rsi)
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, 0x10(%rsi)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	0x10(%rsi), %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%rdi, (%rsp)
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, 0x8(%rsp)
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, 0x10(%rsp)
-               	callq	*%r15
-               	movq	%rax, %rsi
-               	movq	-0x1f0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %r15
-               	movq	(%r12), %r8
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rsi
-               	movq	(%rsi), %r12
-               	movq	-0x130(%rbp), %r8
                	leaq	(%r8,%r13,8), %rsi
-               	movq	(%rsi), %r14
-               	leaq	-0x110(%rbp), %r8
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x2, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r14
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x2, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r15
+               	leaq	-0x68(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	-0x208(%rbp), %r8
+               	movq	%rdi, %rsi
+               	addq	%r8, %rsi
+               	leaq	-0x80(%rbp), %r8
                	movq	%r8, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
+               	movq	-0x1a8(%rbp), %r8
+               	callq	*%r8
                	movq	-0x1b0(%rbp), %r8
                	movq	-0x1b0(%rbp), %r8
                	movq	(%r8), %rsi
                	movq	-0x1b0(%rbp), %r8
                	movq	0x8(%r8), %rdi
-               	movq	-0x1b0(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+<L21>:
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	movq	-0x1e8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x270(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movq	-0x128(%rbp), %r8
+               	leaq	(%r8,%r15,8), %r12
+               	movq	(%r12), %r15
+               	leaq	-0xf8(%rbp), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x1a0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x1a0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	-0x218(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	-0x220(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x210(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x210(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	callq	*%r15
+               	movq	%rax, %r15
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L26>
+<L26>:
+               	movq	%rax, %r15
+               	movq	(%r12), %rbx
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r12
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r13,8), %rsi
+               	movq	(%rsi), %r14
+               	leaq	-0x110(%rbp), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	*%r12
+               	movq	-0x240(%rbp), %r8
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x240(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x240(%rbp), %r8
                	movq	0x10(%r8), %r12
                	movq	%rsi, (%rsp)
                	movq	%rdi, 0x8(%rsp)
                	movq	%r12, 0x10(%rsp)
-               	movq	-0x1f8(%rbp), %r8
-               	callq	*%r8
+               	callq	*%rbx
                	movq	%rax, %rsi
                	movq	%r15, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rbx
+               	callq	 <L27>
+<L27>:
+               	movq	%rax, %rsi
                	addq	$0x1, %r13
+               	movq	%rsi, %r8
+               	movq	%r8, -0x238(%rbp)
                	cmpq	$0x8, %r13
                	jb	 <L19>
-<L25>:
-               	movq	%rbx, %r8
-               	movq	%r8, -0x1b8(%rbp)
+<L28>:
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x248(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L26>
-               	jmp	 <L71>
-<L26>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x1c0(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	movq	%rsi, %r13
+               	jb	 <L29>
+               	jmp	 <L42>
+<L29>:
+               	movq	-0x180(%rbp), %r8
+               	movq	-0x268(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	movq	%rdi, %r13
                	addq	%r8, %r13
                	movl	%r13d, %r14d
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            ## imm = 0xFFF
-               	movq	%rcx, %r11
+               	movq	%r13, %rsi
+               	andq	$0xfff, %rsi            ## imm = 0xFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L28>
-<L27>:
+               	jl	 <L30>
+               	cvtsi2sd	%r11, %xmm14
+               	jmp	 <L31>
+<L30>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L28>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x8c5>
-               	movsd	%xmm14, -0x208(%rbp)
-               	movb	%r13b, %r15b
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm14
+               	addsd	%xmm14, %xmm14
+<L31>:
+               	movsd	%xmm14, -0x280(%rbp)
+               	movsd	-0x280(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xb85>
+               	movb	%r13b, %r8b
+               	movq	%r8, -0x258(%rbp)
+               	movq	%r13, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L30>:
-               	movss	%xmm14, -0x218(%rbp)
+<L33>:
+               	movss	%xmm14, -0x290(%rbp)
                	movq	%r13, %r8
                	imulq	$0x3, %r8, %r8
-               	movq	%r8, -0x220(%rbp)
+               	movq	%r8, -0x260(%rbp)
                	movq	%r13, %rsi
                	andq	$0xffff, %rsi           ## imm = 0xFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L31>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L32>
-<L31>:
+               	jl	 <L34>
+               	cvtsi2sd	%r11, %xmm14
+               	jmp	 <L35>
+<L34>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L32>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x963>
-               	movsd	%xmm14, -0x230(%rbp)
-               	movw	%r13w, %bx
-               	movq	%r13, %r12
-               	xorq	$-0x1, %r12
+               	cvtsi2sd	%r11, %xmm14
+               	addsd	%xmm14, %xmm14
+<L35>:
+               	movsd	%xmm14, -0x2a0(%rbp)
+               	movsd	-0x2a0(%rbp), %xmm2
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xc2d>
+               	movw	%r13w, %r8w
+               	movq	%r8, -0x250(%rbp)
+               	movq	%r13, %r15
+               	xorq	$-0x1, %r15
                	movq	%r13, %rsi
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L33>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L34>
-<L33>:
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L34>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x9bb>
-               	movss	%xmm14, -0x240(%rbp)
-               	movq	-0x188(%rbp), %r9
-               	movq	%r13, %r8
-               	xorq	%r9, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L37>
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
 <L37>:
-               	movq	%rax, %rdi
-               	movsd	-0x208(%rbp), %xmm0
+               	movss	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1,2,3]
+               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xc83>
+               	movss	%xmm14, -0x2b0(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r13, %rbx
+               	xorq	%r8, %rbx
+               	movq	%r15, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r13, %rdi
+               	movl	%r14d, %esi
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x290(%rbp), %xmm1
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rcx
+               	movl	%r14d, %r8d
+               	movq	-0x250(%rbp), %r9
+               	movss	-0x2b0(%rbp), %xmm3
                	callq	 <L38>
 <L38>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	%rax, %rsi
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %rdi
-               	movss	-0x218(%rbp), %xmm0
+               	movq	%rax, %r12
+               	movsd	-0x280(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xd00>
+               	movsd	-0x2a0(%rbp), %xmm2
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xd10>
+               	movq	%r15, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r13, %rdi
+               	movl	%r14d, %esi
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x290(%rbp), %xmm1
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rcx
+               	movl	%r14d, %r8d
+               	movq	-0x250(%rbp), %r9
+               	movss	-0x2b0(%rbp), %xmm3
                	callq	 <L40>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0x220(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rsi
+               	movq	%r12, %rdi
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movsd	-0x230(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movss	-0x240(%rbp), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L47>
-<L47>:
                	movq	%rax, %rsi
-               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x268(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x1d0(%rbp), %r8
-               	movl	%r13d, %r12d
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            ## imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L49>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L50>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xaed>
-               	movsd	%xmm14, -0x250(%rbp)
-               	movb	%r13b, %r14b
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L51>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L52>
-<L51>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L52>:
-               	movss	%xmm14, -0x260(%rbp)
-               	movq	%r13, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	%r13, %rcx
-               	andq	$0xffff, %rcx           ## imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L53>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L54>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xb84>
-               	movsd	%xmm14, -0x270(%rbp)
-               	movw	%r13w, %r8w
-               	movq	%r8, -0x278(%rbp)
-               	movq	%r13, %rbx
-               	xorq	$-0x1, %rbx
-               	movq	%r13, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L55>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L56>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xbe3>
-               	movss	%xmm14, -0x288(%rbp)
-               	movq	-0x188(%rbp), %r9
-               	movq	%r13, %r8
-               	xorq	%r9, %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movsd	-0x250(%rbp), %xmm0
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movss	-0x260(%rbp), %xmm0
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
-               	movsd	-0x270(%rbp), %xmm0
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	-0x278(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movss	-0x288(%rbp), %xmm0
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1b8(%rbp)
+               	addq	$0x1, %rdi
                	movq	%rsi, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L26>
-<L71>:
-               	movq	-0x1b8(%rbp), %r8
+               	jb	 <L29>
+<L42>:
+               	movq	-0x248(%rbp), %r8
                	movq	%r8, %rax
-               	movq	-0x298(%rbp), %rbx
-               	movq	-0x2a0(%rbp), %r12
-               	movq	-0x2a8(%rbp), %r13
-               	movq	-0x2b0(%rbp), %r14
-               	movq	-0x2b8(%rbp), %r15
+               	movq	-0x2b8(%rbp), %rbx
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_int_regs.dis
+++ b/test/golden/x86_64-darwin/call/call_int_regs.dis
@@ -20,110 +20,375 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x78(%rbp)
                	movq	%r14, -0x80(%rbp)
                	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	movq	%rdx, %r13
-               	movq	%rcx, %r14
-               	movl	%r8d, %r15d
+               	movq	%rcx, %rax
+               	movl	%r8d, %ebx
                	movl	%r9d, %r8d
-               	movq	%r8, -0x50(%rbp)
-               	movq	0x10(%rbp), %r8
                	movq	%r8, -0x58(%rbp)
+               	movq	0x10(%rbp), %r8
+               	movq	%r8, -0x50(%rbp)
                	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x30(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x40(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x50(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	0x58(%rbp), %r8
+               	movq	0x20(%rbp), %r8
                	movq	%r8, -0x48(%rbp)
-               	callq	 <L0>
+               	movq	0x28(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x30(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%dil, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movsbq	%sil, %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L4>
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L5>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L6>
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L13>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L14>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
                	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
+               	movzbq	%r8b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x28(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x68(%rbp), %rbx
                	movq	-0x70(%rbp), %r12
                	movq	-0x78(%rbp), %r13
@@ -136,121 +401,116 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_int_regs.take16n>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	movq	%rdx, %r13
-               	movq	%rcx, %r14
-               	movq	%r8, %r15
-               	movq	%r9, %r8
-               	movq	%r8, -0x50(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	movq	%rsi, %rbx
+               	movq	%rdx, %r12
+               	movq	%rcx, %r13
+               	movq	%r8, %r14
+               	movq	%r9, %r15
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x30(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x40(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x50(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	0x58(%rbp), %r8
+               	movq	0x18(%rbp), %r8
                	movq	%r8, -0x48(%rbp)
+               	movq	0x20(%rbp), %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	0x28(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x30(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%dil, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movzbq	%bl, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
+               	movsbq	%r12b, %rsi
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
+               	movsbq	%r13b, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	%r14, %rsi
+               	movzwq	%r14w, %rsi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movzwq	%r15w, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x40(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L6>
 <L6>:
+               	movq	-0x48(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
+               	movq	-0x50(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
+               	movq	-0x20(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
+               	movq	-0x28(%rbp), %r8
+               	movsbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L13>
 <L13>:
+               	movq	-0x30(%rbp), %r8
+               	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
+               	movq	-0x38(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -258,820 +518,551 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_int_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x390, %rsp            ## imm = 0x390
-               	movq	%rbx, -0x368(%rbp)
-               	movq	%r12, -0x370(%rbp)
-               	movq	%r13, -0x378(%rbp)
-               	movq	%r14, -0x380(%rbp)
-               	movq	%r15, -0x388(%rbp)
+               	subq	$0x3c0, %rsp            ## imm = 0x3C0
+               	movq	%rbx, -0x348(%rbp)
+               	movq	%r12, -0x350(%rbp)
+               	movq	%r13, -0x358(%rbp)
+               	movq	%r14, -0x360(%rbp)
+               	movq	%r15, -0x368(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0xa0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xa0, %rdx
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0xa0, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x210(%rbp)
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x188(%rbp)
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-               	jmp	 <L41>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L8>
+<L3>:
                	movq	%r15, %rax
                	imulq	$0x7, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	leaq	(%r12), %rax
-               	movq	(%rax), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x2f0(%rbp)
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x2f8(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
                	movq	%r8, -0xa8(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r9
-               	movq	%rdi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0xd8(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0xe0(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xe8(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xf0(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xf8(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x330(%rbp)
+               	movq	-0x330(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
                	movq	%r8, -0x100(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r9
-               	movq	%rdi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x108(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x110(%rbp)
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0x2f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x2f8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
+               	leaq	0x8(%r12), %r8
+               	movq	%r8, -0xb0(%rbp)
                	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x110(%rbp)
+               	leaq	0x10(%r12), %r8
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x118(%rbp)
+               	leaq	0x18(%r12), %r8
+               	movq	%r8, -0xc0(%rbp)
                	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0xc8(%rbp)
+               	leaq	0x20(%r12), %r8
+               	movq	%r8, -0xd0(%rbp)
                	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0xd8(%rbp)
+               	leaq	0x28(%r12), %r8
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0xf0(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rcx
+               	leaq	0x38(%r12), %r8
+               	movq	%r8, -0xf8(%rbp)
                	movq	-0xf8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rdi
+               	leaq	0x40(%r12), %r8
+               	movq	%r8, -0x108(%rbp)
                	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rsi
+               	movb	%sil, %dl
+               	leaq	0x48(%r12), %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x128(%rbp)
+               	leaq	0x50(%r12), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movw	%si, %r8w
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x58(%r12), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movw	%si, %r8w
+               	movq	%r8, -0x148(%rbp)
+               	leaq	0x60(%r12), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	leaq	0x68(%r12), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x168(%rbp)
+               	leaq	0x70(%r12), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rsi
+               	leaq	0x78(%r12), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	%rcx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rdx, 0x10(%rsp)
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rsi, 0x40(%rsp)
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
                	movq	-0x110(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	-0x210(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x300(%rbp)
-               	movq	-0x300(%rbp), %r8
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x308(%rbp)
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x118(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x120(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x128(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x130(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x138(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x140(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x148(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r8
-               	addq	%r8, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x150(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x158(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x160(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x168(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r8
-               	addq	%r8, %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x310(%rbp)
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0x308(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
                	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x150(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movq	-0x310(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	movq	-0x300(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L40>
-<L40>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0x210(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %r14
-               	cmpq	$0x3, %r15
-               	jb	 <L4>
-<L41>:
-               	leaq	(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %bl
-               	leaq	0x8(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r15b
-               	leaq	0x10(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x320(%rbp)
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x328(%rbp)
-               	leaq	0x20(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x330(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x188(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x1b0(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x1b8(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x1c8(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movq	-0x328(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movq	-0x330(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe8(%rbp), %r9
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rsi
                	movq	-0x188(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r13
+               	movq	-0x330(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %di
+               	movq	-0xf8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %si
+               	movq	-0x108(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rax
+               	movb	%al, %dl
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %cl
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdx, 0x10(%rsp)
+               	movq	%rcx, 0x18(%rsp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
                	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
                	movq	-0x1b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdx
                	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L58>
-<L58>:
-               	movb	%al, %r8b
-               	movq	%r8, -0x240(%rbp)
-               	leaq	0x8(%r12), %rax
+               	movq	%r8, %rcx
+               	movq	-0x190(%rbp), %r8
+               	movq	-0x198(%rbp), %r9
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r14
+               	movq	%r13, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L7>
+<L7>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x188(%rbp)
+               	cmpq	$0x3, %r15
+               	jb	 <L3>
+<L8>:
+               	leaq	(%r12), %rax
                	movq	(%rax), %rcx
                	movb	%cl, %r8b
-               	movq	%r8, -0x268(%rbp)
-               	leaq	0x10(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x278(%rbp)
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x288(%rbp)
-               	movl	%r14d, %r8d
+               	movq	%r8, -0x1f0(%rbp)
+               	leaq	0x8(%r12), %rbx
+               	movq	(%rbx), %rax
+               	movb	%al, %r8b
                	movq	%r8, -0x220(%rbp)
-               	leaq	0x28(%r12), %r8
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	-0x1f8(%rbp), %r8
+               	leaq	0x10(%r12), %r13
+               	movq	(%r13), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x230(%rbp)
+               	leaq	0x18(%r12), %r15
+               	movq	(%r15), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x238(%rbp)
+               	leaq	0x20(%r12), %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x338(%rbp), %r8
                	movq	(%r8), %rdi
                	movl	%edi, %r8d
-               	movq	%r8, -0x230(%rbp)
-               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	leaq	0x28(%r12), %r8
                	movq	%r8, -0x200(%rbp)
-               	movq	-0x200(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	leaq	0x38(%r12), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x1e8(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1f0(%rbp)
-               	leaq	0x80(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x338(%rbp)
-               	leaq	0x88(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x208(%rbp)
-               	movq	-0x208(%rbp), %r8
-               	movb	%r8b, %r13b
-               	leaq	0x90(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x218(%rbp)
-               	movq	-0x218(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x340(%rbp)
-               	leaq	0x98(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x228(%rbp)
-               	movq	-0x228(%rbp), %r8
-               	movb	%r8b, %r14b
-               	leaq	0x20(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x238(%rbp)
-               	movq	-0x238(%rbp), %r8
-               	movw	%r8w, %bx
-               	movq	-0x1f8(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x248(%rbp)
                	movq	-0x200(%rbp), %r8
                	movq	(%r8), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x250(%rbp)
-               	movq	-0x1e8(%rbp), %r8
+               	movl	%edi, %r8d
+               	movq	%r8, -0x208(%rbp)
+               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
                	movq	(%r8), %rdi
-               	movw	%di, %r8w
+               	leaq	0x38(%r12), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	leaq	0x40(%r12), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %cl
+               	leaq	0x48(%r12), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x248(%rbp)
+               	leaq	0x50(%r12), %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
                	movq	%r8, -0x258(%rbp)
-               	leaq	0x40(%r12), %rdi
-               	movq	(%rdi), %r8
+               	leaq	0x58(%r12), %r8
                	movq	%r8, -0x260(%rbp)
                	movq	-0x260(%rbp), %r8
-               	movb	%r8b, %r15b
-               	leaq	0x48(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x268(%rbp)
+               	leaq	0x60(%r12), %r8
                	movq	%r8, -0x270(%rbp)
-               	movq	-0x270(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x348(%rbp)
-               	leaq	0x50(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x278(%rbp)
+               	leaq	0x68(%r12), %r8
                	movq	%r8, -0x280(%rbp)
-               	movq	-0x280(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x350(%rbp)
-               	leaq	0x58(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x288(%rbp)
+               	leaq	0x70(%r12), %r8
                	movq	%r8, -0x290(%rbp)
-               	movq	-0x290(%rbp), %r9
-               	movw	%r9w, %r8w
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rdx
+               	leaq	0x78(%r12), %r8
                	movq	%r8, -0x298(%rbp)
-               	leaq	0x60(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
                	movq	%r8, -0x2a0(%rbp)
-               	movq	-0x2a0(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x2a8(%rbp)
-               	leaq	0x68(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2b0(%rbp)
-               	movq	-0x2b0(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x2b8(%rbp)
-               	leaq	0x70(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2c0(%rbp)
-               	movq	-0x2c0(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x2c8(%rbp)
-               	leaq	0x78(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2d0(%rbp)
-               	movq	-0x2d0(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x2d8(%rbp)
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movq	-0x338(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movq	-0x340(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
                	movq	-0x248(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	-0x250(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rdi
+               	movq	%r8, 0x18(%rsp)
                	movq	-0x258(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rdx, 0x40(%rsp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x220(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	movq	-0x348(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	movq	-0x350(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x1f8(%rbp), %r8
+               	movq	-0x208(%rbp), %r9
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	(%rbx), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	(%r13), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	(%r15), %rcx
+               	movw	%cx, %r15w
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r14d
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %r13
+               	leaq	0x80(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x88(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2d8(%rbp)
+               	leaq	0x90(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2e0(%rbp)
+               	leaq	0x98(%r12), %rdx
+               	movq	(%rdx), %r12
+               	movb	%r12b, %r8b
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x338(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %di
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %si
+               	movq	-0x228(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %cl
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %al
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r12w
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x308(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x310(%rbp)
                	movq	-0x298(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movq	-0x2a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movq	-0x2b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	movq	-0x2c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x318(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
+               	movq	%rax, 0x18(%rsp)
+               	movq	%r12, 0x20(%rsp)
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x300(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x318(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x2d0(%rbp), %r8
+               	movq	%r8, %rdi
                	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L75>
-<L75>:
-               	movb	%al, %bl
-               	leaq	0x48(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r13b
-               	leaq	0x50(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r14w
-               	leaq	0x58(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r15w
-               	leaq	0x60(%r12), %rax
-               	movq	(%rax), %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x358(%rbp)
-               	leaq	0x68(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x360(%rbp)
-               	leaq	0x70(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x2e0(%rbp)
-               	leaq	0x78(%r12), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rdi
-               	movq	-0x240(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rdi
-               	movq	-0x268(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rdi
-               	movq	-0x278(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x288(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movq	-0x220(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movq	-0x230(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-               	movq	-0x1f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L84>
-<L84>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %rdi
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L89>
-<L89>:
-               	movq	%rax, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L90>
-<L90>:
-               	movq	%rax, %rdi
                	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x2f0(%rbp), %r9
+               	callq	 <L10>
+<L10>:
+               	movb	%al, %cl
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %dl
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %si
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %di
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rax
+               	movl	%eax, %r12d
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	%rbx, (%rsp)
+               	movq	%r13, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
+               	movq	%rdx, 0x18(%rsp)
+               	movq	%rsi, 0x20(%rsp)
+               	movq	%rdi, 0x28(%rsp)
+               	movq	%r12, 0x30(%rsp)
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rax, 0x40(%rsp)
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x2b8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x210(%rbp), %r8
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	%r15, %rcx
+               	movq	-0x2b0(%rbp), %r8
+               	movl	%r14d, %r9d
+               	callq	 <L11>
+<L11>:
+               	movq	-0x188(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x368(%rbp), %rbx
-               	movq	-0x370(%rbp), %r12
-               	movq	-0x378(%rbp), %r13
-               	movq	-0x380(%rbp), %r14
-               	movq	-0x388(%rbp), %r15
+               	callq	 <L12>
+<L12>:
+               	movq	-0x348(%rbp), %rbx
+               	movq	-0x350(%rbp), %r12
+               	movq	-0x358(%rbp), %r13
+               	movq	-0x360(%rbp), %r14
+               	movq	-0x368(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_mixed.dis
+++ b/test/golden/x86_64-darwin/call/call_mixed.dis
@@ -56,260 +56,584 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_mixed.mixed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1a0, %rsp            ## imm = 0x1A0
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%r15, -0x198(%rbp)
-               	movq	%rdi, %r10
-               	movq	%r10, -0x78(%rbp)
-               	movss	%xmm0, -0xa8(%rbp)
-               	movl	%esi, %r12d
-               	movsd	%xmm1, -0xb8(%rbp)
-               	movups	%xmm2, -0xd0(%rbp)
-               	movq	%rdx, %r13
-               	movss	%xmm3, -0xe0(%rbp)
-               	movq	%rcx, %r14
-               	movsd	%xmm5, -0xf0(%rbp)
-               	movq	%r8, %r10
+               	subq	$0x1d0, %rsp            ## imm = 0x1D0
+               	movq	%rbx, -0x1a8(%rbp)
+               	movq	%r12, -0x1b0(%rbp)
+               	movq	%r13, -0x1b8(%rbp)
+               	movq	%r14, -0x1c0(%rbp)
+               	movq	%r15, -0x1c8(%rbp)
+               	movq	%rdi, %rbx
+               	movss	%xmm0, -0x120(%rbp)
+               	movl	%esi, %r10d
+               	movq	%r10, -0xa0(%rbp)
+               	movsd	%xmm1, -0x130(%rbp)
+               	movups	%xmm2, -0x140(%rbp)
+               	movq	%rdx, %r10
                	movq	%r10, -0x98(%rbp)
-               	movss	%xmm6, -0x100(%rbp)
-               	movq	%r9, %r8
-               	movq	%r8, -0x90(%rbp)
-               	movsd	%xmm7, -0x110(%rbp)
-               	movsd	0x10(%rbp), %xmm0
-               	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x118(%rbp)
+               	movss	%xmm3, -0x150(%rbp)
+               	movq	%rcx, %r10
+               	movq	%r10, -0x90(%rbp)
+               	movsd	%xmm5, -0x160(%rbp)
+               	movq	%r8, %r12
+               	movss	%xmm6, -0x170(%rbp)
+               	movq	%r9, %r13
+               	movsd	%xmm7, -0x180(%rbp)
+               	movsd	0x10(%rbp), %xmm7
+               	movq	0x18(%rbp), %r14
                	movq	0x20(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x88(%rbp)
+               	movq	%r11, -0x190(%rbp)
+               	movq	0x28(%rbp), %r15
                	movq	0x30(%rbp), %r11
-               	movq	%r11, -0x138(%rbp)
+               	movq	%r11, -0x1a0(%rbp)
                	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x80(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r8, -0x78(%rbp)
+               	leaq	-0xc(%rbp), %r8
+               	movq	%r8, -0xa8(%rbp)
                	leaq	-0x20(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	leaq	-0x28(%rbp), %r15
-               	movups	-0xd0(%rbp), %xmm14
+               	movq	%r8, -0x80(%rbp)
+               	leaq	-0x28(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	movups	-0x140(%rbp), %xmm14
                	movups	%xmm14, -0x38(%rbp)
-               	movq	-0x38(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x30(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x38(%rbp), %rax
+               	movq	-0xa8(%rbp), %r8
+               	movq	%rax, (%r8)
+               	movl	-0x30(%rbp), %eax
+               	movq	-0xa8(%rbp), %r8
+               	movl	%eax, 0x8(%r8)
+               	movq	-0x80(%rbp), %r8
                	movups	%xmm4, (%r8)
-               	movsd	%xmm0, (%r15)
-               	callq	 <L0>
+               	movq	-0x88(%rbp), %r8
+               	movsd	%xmm7, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L1>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L2>
+               	movl	-0x120(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xb0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
-               	callq	 <L4>
+               	movq	-0xa0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L6>
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	movq	-0xa8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xc8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
+               	movq	-0xa8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0xa8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movl	-0x150(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xe0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x90(%rbp), %r9
+               	movzwq	%r9w, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xf0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movl	-0x170(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movzbq	%r13b, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movq	-0x180(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	movq	%rax, %rdi
                	movq	%r14, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L37>
+<L37>:
+               	movl	-0x190(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r11d
-               	movl	%r11d, -0x150(%rbp)
-               	movss	-0x150(%rbp), %xmm0
-               	callq	 <L11>
-<L11>:
+               	callq	 <L38>
+<L38>:
+               	movslq	%r15d, %rsi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r11d
-               	movl	%r11d, -0x160(%rbp)
-               	movss	-0x160(%rbp), %xmm0
-               	callq	 <L12>
-<L12>:
+               	callq	 <L39>
+<L39>:
+               	movq	-0x1a0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L13>
-<L13>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movsd	-0xf0(%rbp), %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0x170(%rbp)
-               	movss	-0x170(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0x128(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movsd	-0x138(%rbp), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	-0x118(%rbp), %r9
-               	movq	%r8, %rcx
-               	imulq	%r9, %rcx
                	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%rcx, %rdx
+               	movq	%r8, %rsi
+               	callq	 <L41>
+<L41>:
+               	imulq	%r14, %r12
+               	addq	%r12, %rbx
+               	movq	-0x78(%rbp), %r8
+               	subq	%r8, %rbx
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L42>
+<L42>:
+               	movss	-0x150(%rbp), %xmm4
+               	mulss	-0x170(%rbp), %xmm4
+               	movss	-0x120(%rbp), %xmm2
+               	addss	%xmm4, %xmm2
+               	movss	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1,2,3]
+               	subss	-0x190(%rbp), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movsd	-0x160(%rbp), %xmm2
+               	mulsd	-0x180(%rbp), %xmm2
+               	movsd	-0x130(%rbp), %xmm3
+               	addsd	%xmm2, %xmm3
+               	movsd	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1]
+               	subsd	-0x1a0(%rbp), %xmm0
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	-0x44(%rbp), %rdx
                	movq	-0x80(%rbp), %r8
-               	subq	%r8, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
-               	mulss	-0x100(%rbp), %xmm0
-               	movss	-0xa8(%rbp), %xmm2
-               	addss	%xmm0, %xmm2
-               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
-               	subss	-0x128(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0xf0(%rbp), %xmm0
-               	mulsd	-0x110(%rbp), %xmm0
-               	movsd	-0xb8(%rbp), %xmm2
-               	addsd	%xmm0, %xmm2
-               	movsd	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1]
-               	subsd	-0x138(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	leaq	-0x44(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	-0x150(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	-0x160(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	-0x170(%rbp), %r11d
-               	movl	%r11d, (%rdx)
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
                	movq	$0x0, -0x54(%rbp)
                	movq	$0x0, -0x4c(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x54(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x4c(%rbp)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x54(%rbp)
+               	movl	0x8(%rdx), %esi
+               	movl	%esi, -0x4c(%rbp)
                	movups	-0x54(%rbp), %xmm0
-               	movaps	-0xd0(%rbp), %xmm14
+               	movaps	-0x140(%rbp), %xmm14
                	addps	%xmm0, %xmm14
                	movaps	%xmm14, %xmm1
                	leaq	-0x60(%rbp), %rbx
                	movups	%xmm1, -0x70(%rbp)
-               	movq	-0x70(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x68(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
+               	movq	-0x70(%rbp), %rdx
+               	movq	%rdx, (%rbx)
+               	movl	-0x68(%rbp), %edx
+               	movl	%edx, 0x8(%rbx)
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
+               	callq	 <L45>
+<L45>:
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
-               	movq	-0x198(%rbp), %r15
+               	callq	 <L46>
+<L46>:
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
+               	movq	-0x1a8(%rbp), %rbx
+               	movq	-0x1b0(%rbp), %r12
+               	movq	-0x1b8(%rbp), %r13
+               	movq	-0x1c0(%rbp), %r14
+               	movq	-0x1c8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -324,68 +648,66 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x380(%rbp)
                	movq	%r15, -0x388(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	leaq	-0xd8(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rcx
 <L0>:
-               	leaq	-0xc0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xc0, %rdx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %r13
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-               	jmp	 <L36>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L35>
+<L3>:
                	movq	%r15, %rax
                	imulq	$0xb, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
                	movq	%r8, -0x190(%rbp)
-               	leaq	-0xcc(%rbp), %rax
+               	leaq	-0xc(%rbp), %rax
                	leaq	0x80(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
+<L5>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x136>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x135>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x142>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x141>
                	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x88(%r12), %rdx
@@ -393,21 +715,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x193>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x192>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x19f>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x19e>
                	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x90(%r12), %rdx
@@ -415,21 +737,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f1>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f0>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1fd>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1fc>
                	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movq	$0x0, -0xe8(%rbp)
@@ -446,21 +768,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L11>
+               	jl	 <L10>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L12>
-<L11>:
+               	jmp	 <L11>
+<L10>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L12>:
+<L11>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x28f>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x28e>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x29b>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x29a>
                	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa0(%r12), %rdx
@@ -468,21 +790,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2ec>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2eb>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2f8>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2f7>
                	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa8(%r12), %rdx
@@ -490,21 +812,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L15>
+               	jl	 <L14>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L16>
-<L15>:
+               	jmp	 <L15>
+<L14>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L16>:
+<L15>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x34a>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x349>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x356>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x355>
                	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xb0(%r12), %rdx
@@ -512,21 +834,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L16>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L18>:
+<L17>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a8>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a7>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3b4>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3b3>
                	leaq	0xc(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rax), %xmm14
@@ -538,21 +860,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rsi            ## imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L19>
+               	jl	 <L18>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
-<L19>:
+               	jmp	 <L19>
+<L18>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L20>:
+<L19>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x420>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x41f>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x42c>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x42b>
                	movq	-0x1b8(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
@@ -563,8 +885,8 @@ Disassembly of section __TEXT,__text:
                	movq	-0x190(%rbp), %r8
                	addq	%r8, %rsi
                	movq	%rsi, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L20>
+<L20>:
                	movq	-0x1b8(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movss	%xmm0, (%rsi)
@@ -579,8 +901,8 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x1d8(%rbp)
                	leaq	0x8(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L22>
-<L22>:
+               	callq	 <L21>
+<L21>:
                	movss	%xmm0, -0x1e8(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rsi
@@ -591,29 +913,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L23>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L24>
-<L23>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L24>:
+<L23>:
                	movsd	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1]
-               	subsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x50d>
+               	subsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x50c>
                	movsd	%xmm5, %xmm14           ## xmm14 = xmm5[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x51b>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x51a>
                	movsd	%xmm14, -0x200(%rbp)
                	leaq	0x20(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x138(%rbp)
                	leaq	0x28(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L24>
+<L24>:
                	movss	%xmm0, -0x210(%rbp)
                	leaq	0x30(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -624,29 +946,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm6
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm6
                	addsd	%xmm6, %xmm6
-<L27>:
+<L26>:
                	movsd	%xmm6, %xmm7            ## xmm7 = xmm6[0],xmm7[1]
-               	subsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x5a2>
+               	subsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x5a1>
                	movsd	%xmm7, %xmm14           ## xmm14 = xmm7[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5b0>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5af>
                	movsd	%xmm14, -0x220(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x148(%rbp)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L28>
-<L28>:
+               	callq	 <L27>
+<L27>:
                	movss	%xmm0, -0x230(%rbp)
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -657,29 +979,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L28>
                	cvtsi2sd	%r11, %xmm8
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L29>
+<L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm8
                	addsd	%xmm8, %xmm8
-<L30>:
+<L29>:
                	movsd	%xmm8, %xmm9            ## xmm9 = xmm8[0],xmm9[1]
-               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x639>
+               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x638>
                	movsd	%xmm9, %xmm14           ## xmm14 = xmm9[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x647>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x646>
                	movsd	%xmm14, -0x240(%rbp)
                	leaq	0x60(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x158(%rbp)
                	leaq	0x68(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L31>
-<L31>:
+               	callq	 <L30>
+<L30>:
                	movss	%xmm0, %xmm9            ## xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x70(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -690,21 +1012,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2sd	%r11, %xmm10
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm10
                	addsd	%xmm10, %xmm10
-<L33>:
+<L32>:
                	movsd	%xmm10, %xmm11          ## xmm11 = xmm10[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x6cd>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x6cc>
                	movsd	%xmm11, %xmm10          ## xmm10 = xmm11[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x6db>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x6da>
                	leaq	0x8(%r12), %rsi
                	movq	(%rsi), %rdi
                	movq	-0x190(%rbp), %r8
@@ -736,38 +1058,38 @@ Disassembly of section __TEXT,__text:
                	movss	-0x230(%rbp), %xmm6
                	movq	-0x150(%rbp), %r9
                	movsd	-0x240(%rbp), %xmm7
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-<L36>:
-               	leaq	-0xd8(%rbp), %rax
+               	jb	 <L3>
+<L35>:
+               	leaq	-0x18(%rbp), %rax
                	movq	%r14, %rcx
                	andq	$0xfff, %rcx            ## imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L37>
+               	jl	 <L36>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L38>
-<L37>:
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L38>:
+<L37>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x804>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x800>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x810>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x80c>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%r12), %rcx
@@ -775,21 +1097,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L40>:
+<L39>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x85e>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x85a>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x86a>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x866>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%r12), %rcx
@@ -797,21 +1119,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L41>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L41>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b9>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b5>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8c5>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8c1>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -828,21 +1150,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L43>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x954>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x950>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x960>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x95c>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%r12), %rcx
@@ -850,21 +1172,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L45>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9ae>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9aa>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9ba>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9b6>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%r12), %rcx
@@ -872,21 +1194,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L47>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa09>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa05>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa15>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa11>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%r12), %rcx
@@ -894,21 +1216,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L49>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa64>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa60>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa70>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa6c>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm14
@@ -919,27 +1241,27 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rcx            ## imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L51>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xad2>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xace>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xade>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xada>
                	leaq	(%rbx), %rax
                	movss	%xmm0, (%rax)
                	leaq	0x48(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L52>
+<L52>:
                	leaq	0x4(%rbx), %rax
                	movss	%xmm0, (%rax)
                	movq	(%rbx), %r11
@@ -948,8 +1270,8 @@ Disassembly of section __TEXT,__text:
                	movq	(%rax), %rbx
                	leaq	0x8(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L53>
+<L53>:
                	movss	%xmm0, -0x280(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rcx
@@ -959,29 +1281,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rcx          ## imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L55>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L56>
-<L55>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L56>:
+<L55>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xb72>
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xb6e>
                	movsd	%xmm2, %xmm14           ## xmm14 = xmm2[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xb80>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xb7c>
                	movsd	%xmm14, -0x298(%rbp)
                	leaq	0x20(%r12), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x288(%rbp)
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L56>
+<L56>:
                	movss	%xmm0, -0x2a8(%rbp)
                	leaq	0x30(%r12), %rax
                	movq	(%rax), %rdx
@@ -992,29 +1314,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L58>
+               	jl	 <L57>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L59>
-<L58>:
+               	jmp	 <L58>
+<L57>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L59>:
+<L58>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc07>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc03>
                	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc15>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc11>
                	movsd	%xmm14, -0x2c0(%rbp)
                	leaq	0x40(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x168(%rbp)
                	leaq	0x48(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L59>
+<L59>:
                	movss	%xmm0, -0x2d0(%rbp)
                	leaq	0x50(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -1025,29 +1347,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L60>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L61>
+<L60>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L62>:
+<L61>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc9b>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc97>
                	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xca9>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xca5>
                	movsd	%xmm14, -0x2e8(%rbp)
                	leaq	0x60(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x2d8(%rbp)
                	leaq	0x68(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L62>
+<L62>:
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	leaq	0x70(%r12), %rdx
                	movq	(%rdx), %rdi
@@ -1058,21 +1380,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdx          ## imm = 0xFFFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L64>
+               	jl	 <L63>
                	cvtsi2sd	%r11, %xmm4
-               	jmp	 <L65>
-<L64>:
+               	jmp	 <L64>
+<L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm4
                	addsd	%xmm4, %xmm4
-<L65>:
+<L64>:
                	movsd	%xmm4, %xmm11           ## xmm11 = xmm4[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xd2d>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xd29>
                	movsd	%xmm11, %xmm4           ## xmm4 = xmm11[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd3a>
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd36>
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %rdi
                	movq	-0x270(%rbp), %r11
@@ -1100,13 +1422,13 @@ Disassembly of section __TEXT,__text:
                	movss	-0x2d0(%rbp), %xmm6
                	movq	-0x170(%rbp), %r9
                	movsd	-0x2e8(%rbp), %xmm7
-               	callq	 <L66>
-<L66>:
+               	callq	 <L65>
+<L65>:
                	movq	%rax, %rbx
                	leaq	0x18(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L67>
-<L67>:
+               	callq	 <L66>
+<L66>:
                	movss	%xmm0, -0x2f8(%rbp)
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rcx
@@ -1116,29 +1438,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rcx          ## imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L68>
+               	jl	 <L67>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L69>
-<L68>:
+               	jmp	 <L68>
+<L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L69>:
+<L68>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe4b>
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe47>
                	movsd	%xmm2, %xmm14           ## xmm14 = xmm2[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xe59>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xe55>
                	movsd	%xmm14, -0x310(%rbp)
                	leaq	0x48(%r12), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x300(%rbp)
                	leaq	0x58(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L70>
-<L70>:
+               	callq	 <L69>
+<L69>:
                	movss	%xmm0, -0x320(%rbp)
                	leaq	0x68(%r12), %rax
                	movq	(%rax), %rdx
@@ -1149,29 +1471,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L71>
+               	jl	 <L70>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L71>
+<L70>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L72>:
+<L71>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xee0>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xedc>
                	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xeee>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xeea>
                	movsd	%xmm14, -0x338(%rbp)
                	leaq	0x88(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x180(%rbp)
                	leaq	0x98(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L72>
+<L72>:
                	movss	%xmm0, -0x348(%rbp)
                	leaq	0xa8(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -1182,29 +1504,29 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L74>
+               	jl	 <L73>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L75>
-<L74>:
+               	jmp	 <L74>
+<L73>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L75>:
+<L74>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xf80>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xf7c>
                	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf8e>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf8a>
                	movsd	%xmm14, -0x360(%rbp)
                	leaq	0x10(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x350(%rbp)
                	leaq	0x20(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	leaq	0x30(%r12), %rdx
                	movq	(%rdx), %rdi
@@ -1214,21 +1536,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %r12          ## imm = 0xFFFFF
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L77>
+               	jl	 <L76>
                	cvtsi2sd	%r11, %xmm4
-               	jmp	 <L78>
-<L77>:
+               	jmp	 <L77>
+<L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm4
                	addsd	%xmm4, %xmm4
-<L78>:
+<L77>:
                	movsd	%xmm4, %xmm11           ## xmm11 = xmm4[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x100a>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x1006>
                	movsd	%xmm11, %xmm4           ## xmm4 = xmm11[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1017>
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1013>
                	movq	-0x270(%rbp), %r11
                	movq	%r11, (%rsp)
                	movq	-0x350(%rbp), %r8
@@ -1253,12 +1575,12 @@ Disassembly of section __TEXT,__text:
                	movss	-0x348(%rbp), %xmm6
                	movq	-0x188(%rbp), %r9
                	movsd	-0x360(%rbp), %xmm7
-               	callq	 <L79>
-<L79>:
+               	callq	 <L78>
+<L78>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L80>
-<L80>:
+               	callq	 <L79>
+<L79>:
                	movq	-0x368(%rbp), %rbx
                	movq	-0x370(%rbp), %r12
                	movq	-0x378(%rbp), %r13

--- a/test/golden/x86_64-darwin/call/call_rec_edge.dis
+++ b/test/golden/x86_64-darwin/call/call_rec_edge.dis
@@ -18,36 +18,75 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x18(%rbp), %rbx
-               	leaq	-0x10(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0xf(%rbp), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, (%rbx)
-               	callq	 <L0>
+               	leaq	-0x18(%rbp), %rax
+               	leaq	-0x10(%rbp), %rdx
+               	movzbl	(%rdx), %esi
+               	leaq	-0xf(%rbp), %rdx
+               	movq	(%rdx), %rbx
+               	movq	%rbx, (%rax)
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L1>
-               	jmp	 <L3>
-<L1>:
-               	leaq	(%rbx,%r13), %rax
-               	movzbl	(%rax), %esi
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
                	movq	%r12, %rdi
-               	callq	 <L2>
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L1>
+               	leaq	(%rax,%rdx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%r12, %rax
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -55,30 +94,85 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.fold_e12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -88,19 +182,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -109,19 +240,57 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movsd	%xmm1, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm1
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -130,19 +299,56 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -154,39 +360,78 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	-0x11(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r14, -0x40(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	-0x11(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rbx
+               	movb	0x10(%rax), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	leaq	(%rdx), %rax
+               	movzbl	(%rax), %esi
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L1>
-               	jmp	 <L3>
-<L1>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
                	movq	%r12, %rdi
-               	callq	 <L2>
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L1>
+               	leaq	0x1(%rdx), %rsi
+               	leaq	(%rsi,%rax), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	%rdi, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%r12, %rax
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x10, %rax
+               	jb	 <L2>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -194,55 +439,91 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x9, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x9, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L3>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0xc, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x11, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x10, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x11, %rsi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
@@ -250,11 +531,11 @@ Disassembly of section __TEXT,__text:
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
@@ -262,9 +543,21 @@ Disassembly of section __TEXT,__text:
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L20>
+<L20>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -272,497 +565,435 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.take_edge>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            ## imm = 0x290
-               	movq	%rbx, -0x268(%rbp)
-               	movq	%r12, -0x270(%rbp)
-               	movq	%r13, -0x278(%rbp)
-               	movq	%r14, -0x280(%rbp)
-               	movq	%r15, -0x288(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x2a0, %rsp            ## imm = 0x2A0
+               	movq	%rbx, -0x258(%rbp)
+               	movq	%r12, -0x260(%rbp)
+               	movq	%r13, -0x268(%rbp)
+               	movq	%r14, -0x270(%rbp)
+               	movq	%r15, -0x278(%rbp)
+               	movq	%rdi, %r10
+               	movq	%r10, -0x190(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	movl	%ecx, %r12d
+               	movl	%ecx, %ebx
                	movq	%r8, -0x20(%rbp)
                	movq	%r9, -0x18(%rbp)
-               	movsd	%xmm0, -0x208(%rbp)
-               	leaq	0x10(%rbp), %rcx
+               	movsd	%xmm0, -0x200(%rbp)
+               	leaq	0x10(%rbp), %rdx
                	movsd	%xmm1, -0x30(%rbp)
                	movsd	%xmm2, -0x28(%rbp)
-               	leaq	0x20(%rbp), %rdx
-               	movq	0x30(%rbp), %r13
-               	leaq	0x38(%rbp), %rsi
+               	leaq	0x20(%rbp), %rsi
+               	movq	0x30(%rbp), %r12
+               	leaq	0x38(%rbp), %rdi
                	leaq	0x50(%rbp), %r8
-               	movq	%r8, -0x188(%rbp)
+               	movq	%r8, -0x1b8(%rbp)
                	leaq	0x60(%rbp), %r8
                	movq	%r8, -0x1b0(%rbp)
                	leaq	0x70(%rbp), %r8
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x80(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	movss	%xmm3, -0x218(%rbp)
-               	movq	0x98(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	leaq	-0x38(%rbp), %r8
-               	movq	%r8, -0x148(%rbp)
-               	leaq	-0x40(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	leaq	-0x48(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	leaq	-0x50(%rbp), %r8
-               	movq	%r8, -0x160(%rbp)
-               	leaq	-0x58(%rbp), %r8
-               	movq	%r8, -0x168(%rbp)
-               	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x170(%rbp)
-               	leaq	-0x10(%rbp), %r15
-               	movzbl	(%r15), %r8d
-               	movq	%r8, -0x180(%rbp)
-               	leaq	-0xf(%rbp), %r15
-               	movq	(%r15), %rdi
-               	movq	-0x148(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	leaq	-0x20(%rbp), %rdi
-               	movl	(%rdi), %r15d
-               	leaq	-0x1c(%rbp), %rdi
-               	movl	(%rdi), %r8d
-               	movq	%r8, -0x190(%rbp)
-               	leaq	-0x18(%rbp), %rdi
-               	movl	(%rdi), %r8d
-               	movq	%r8, -0x198(%rbp)
-               	leaq	(%rcx), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x8(%rcx), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x228(%rbp)
-               	leaq	-0x30(%rbp), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x238(%rbp)
-               	leaq	-0x28(%rbp), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x248(%rbp)
-               	leaq	(%rdx), %rdi
-               	movq	(%rdi), %r8
                	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x8(%rdx), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x258(%rbp)
-               	leaq	-0x71(%rbp), %r8
-               	movq	%r8, -0x220(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %r14
-               	movb	0x10(%rsi), %r8b
-               	movq	%r8, -0x1b8(%rbp)
-               	movq	-0x220(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x220(%rbp), %r8
-               	movq	%r14, 0x8(%r8)
-               	movq	-0x220(%rbp), %r8
-               	movq	-0x1b8(%rbp), %r9
-               	movb	%r9b, 0x10(%r8)
-               	movq	-0x188(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzbl	(%rsi), %r14d
-               	movq	-0x188(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x150(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	leaq	0x80(%rbp), %r8
                	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movss	%xmm3, -0x210(%rbp)
+               	movq	0x98(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	leaq	-0x39(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x10(%rbp), %r15
+               	movb	-0x8(%rbp), %r14b
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movb	%r14b, 0x8(%r8)
+               	leaq	-0x48(%rbp), %r14
+               	movq	-0x20(%rbp), %r15
+               	movl	-0x18(%rbp), %r13d
+               	movq	%r15, (%r14)
+               	movl	%r13d, 0x8(%r14)
+               	leaq	-0x58(%rbp), %r13
+               	movq	(%rdx), %r15
+               	movq	0x8(%rdx), %rax
+               	movq	%r15, (%r13)
+               	movq	%rax, 0x8(%r13)
+               	leaq	-0x30(%rbp), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x228(%rbp)
+               	leaq	-0x28(%rbp), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x238(%rbp)
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %r15
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x248(%rbp)
+               	leaq	-0x69(%rbp), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %rsi
+               	movb	0x10(%rdi), %r8b
                	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	leaq	-0x82(%rbp), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x138(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x138(%rbp), %r9
-               	movb	0x10(%r9), %r8b
-               	movq	%r8, -0x1f0(%rbp)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	-0x1f0(%rbp), %r9
+               	movq	-0x218(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x218(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x218(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r9
                	movb	%r9b, 0x10(%r8)
+               	leaq	-0x72(%rbp), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movb	0x8(%r8), %sil
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1d0(%rbp), %r8
+               	movb	%sil, 0x8(%r8)
+               	leaq	-0x80(%rbp), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1b0(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1d8(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	leaq	-0x90(%rbp), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	leaq	-0xa1(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x1c0(%rbp), %r8
+               	movb	0x10(%r8), %dil
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x1e8(%rbp), %r8
+               	movb	%dil, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	leaq	-0xcc(%rbp), %rdx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1a0(%rbp), %r8
+               	movb	0x8(%r8), %dil
+               	movq	%rsi, (%rdx)
+               	movb	%dil, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0xd8(%rbp)
+               	movb	0x8(%rdx), %dil
+               	movb	%dil, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %rdx
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	-0x148(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x158(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x168(%rbp), %r8
-               	movq	%rsi, (%r8)
                	movq	%rax, %rdi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
+               	movl	%ebx, %esi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r8
-               	movq	%r8, -0x260(%rbp)
-               	movq	-0x260(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
-               	jmp	 <L5>
+               	movq	%rax, %rdi
+               	leaq	-0xe4(%rbp), %rdx
+               	movq	(%r14), %rsi
+               	movl	0x8(%r14), %ebx
+               	movq	%rsi, (%rdx)
+               	movl	%ebx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0xf0(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %rdx
+               	callq	 <L3>
 <L3>:
-               	movq	-0x168(%rbp), %r8
-               	movq	-0x260(%rbp), %r9
-               	leaq	(%r8,%r9), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	%rbx, %rdi
-               	movq	-0x1f8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rdi
+               	movq	-0x200(%rbp), %rsi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rbx
-               	movq	-0x260(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x260(%rbp)
-               	movq	-0x260(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
+               	movq	%rax, %rdi
+               	leaq	-0x100(%rbp), %rdx
+               	movq	(%r13), %rsi
+               	movq	0x8(%r13), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L5>
 <L5>:
-               	movq	%rbx, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L6>
+               	movq	%rax, %rdx
+               	movq	-0x228(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
+               	movq	-0x238(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x198(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x208(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x228(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movq	-0x248(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movsd	-0x238(%rbp), %xmm0
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x248(%rbp), %xmm0
+               	movq	%rdx, %rdi
+               	movq	%r12, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0x111(%rbp), %rdx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movb	0x10(%rdx), %r12b
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movsd	-0x258(%rbp), %xmm0
+               	leaq	-0x11a(%rbp), %rdx
+               	movq	-0x1d0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1d0(%rbp), %r8
+               	movb	0x8(%r8), %bl
+               	movq	%rsi, (%rdx)
+               	movb	%bl, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x128(%rbp)
+               	movb	0x8(%rdx), %bl
+               	movb	%bl, -0x128(%rbp)
+               	movq	-0x128(%rbp), %rdx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
+               	leaq	-0x134(%rbp), %rdx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1d8(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movq	%rsi, (%rdx)
+               	movl	%ebx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x140(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0x140(%rbp)
+               	movq	-0x140(%rbp), %rdx
                	callq	 <L17>
 <L17>:
-               	leaq	-0xd7(%rbp), %rcx
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x220(%rbp), %r8
-               	movb	0x10(%r8), %bl
-               	movq	%rsi, (%rcx)
-               	movq	%rdi, 0x8(%rcx)
-               	movb	%bl, 0x10(%rcx)
-               	leaq	-0xe8(%rbp), %rbx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rsi, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
                	movq	%rax, %rdi
+               	leaq	-0x150(%rbp), %rdx
+               	movq	-0x1e0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rbx, %rdx
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L20>
-<L20>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L19>
-<L21>:
-               	movq	-0x150(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x160(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x170(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L23>
-               	jmp	 <L25>
-<L23>:
-               	movq	-0x170(%rbp), %r8
-               	leaq	(%r8,%r12), %rax
-               	movzbl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L24>
-<L24>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x8, %r12
-               	jb	 <L23>
-<L25>:
-               	movq	%rbx, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
                	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	leaq	-0xf9(%rbp), %rcx
+               	leaq	-0x161(%rbp), %rdx
                	movq	-0x1e8(%rbp), %r8
                	movq	(%r8), %rsi
                	movq	-0x1e8(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x1e8(%rbp), %r8
-               	movb	0x10(%r8), %bl
-               	movq	%rsi, (%rcx)
-               	movq	%rdi, 0x8(%rcx)
-               	movb	%bl, 0x10(%rcx)
-               	leaq	-0x10a(%rbp), %rbx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rsi, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L32>
-               	jmp	 <L34>
-<L32>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L32>
-<L34>:
-               	movq	%r12, %rdi
-               	movss	-0x218(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L36>
-<L36>:
-               	leaq	-0x11b(%rbp), %rcx
-               	leaq	-0x12c(%rbp), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0x220(%rbp), %r8
                	movq	0x8(%r8), %rbx
-               	movq	-0x220(%rbp), %r8
+               	movq	-0x1e8(%rbp), %r8
                	movb	0x10(%r8), %r12b
-               	movq	%rdi, (%rsi)
-               	movq	%rbx, 0x8(%rsi)
-               	movb	%r12b, 0x10(%rsi)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %rbx
-               	movb	0x10(%rsi), %r12b
-               	movq	%rdi, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movb	%r12b, 0x10(%rcx)
-               	leaq	(%rcx), %rsi
-               	movzbl	(%rsi), %edi
-               	addl	$0x1, %edi
-               	movb	%dil, (%rsi)
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movb	0x10(%rdx), %r12b
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movl	-0x210(%rbp), %edx
+               	movl	%edx, %esi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %rdi
+               	leaq	-0x172(%rbp), %rdx
+               	leaq	-0x183(%rbp), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %r12
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r13b
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movb	%r13b, 0x10(%rsi)
+               	movq	(%rsi), %rbx
+               	movq	0x8(%rsi), %r12
+               	movb	0x10(%rsi), %r13b
+               	movq	%rbx, (%rdx)
+               	movq	%r12, 0x8(%rdx)
+               	movb	%r13b, 0x10(%rdx)
+               	leaq	(%rdx), %rsi
+               	movzbl	(%rsi), %ebx
+               	addl	$0x1, %ebx
+               	movb	%bl, (%rsi)
                	movq	$0x0, %rsi
                	cmpq	$0x10, %rsi
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
-               	leaq	0x1(%rcx), %rdi
-               	leaq	(%rdi,%rsi), %rbx
-               	movzbl	(%rbx), %edi
-               	movb	%sil, %r12b
-               	addl	%r12d, %edi
-               	addl	$0x1, %edi
-               	movb	%dil, (%rbx)
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	leaq	0x1(%rdx), %rbx
+               	leaq	(%rbx,%rsi), %r12
+               	movzbl	(%r12), %ebx
+               	movb	%sil, %r13b
+               	addl	%r13d, %ebx
+               	addl	$0x1, %ebx
+               	movb	%bl, (%r12)
                	addq	$0x1, %rsi
                	cmpq	$0x10, %rsi
-               	jb	 <L37>
-<L38>:
-               	leaq	-0x93(%rbp), %rsi
-               	movq	(%rcx), %rdi
-               	movq	0x8(%rcx), %rbx
-               	movb	0x10(%rcx), %r12b
-               	movq	%rdi, (%rsi)
-               	movq	%rbx, 0x8(%rsi)
-               	movb	%r12b, 0x10(%rsi)
-               	leaq	-0xa4(%rbp), %rbx
-               	movq	(%rsi), %rcx
-               	movq	0x8(%rsi), %rdi
+               	jb	 <L22>
+<L23>:
+               	leaq	-0xb2(%rbp), %rsi
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %r12
+               	movb	0x10(%rdx), %r13b
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movb	%r13b, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rbx
                	movb	0x10(%rsi), %r12b
-               	movq	%rcx, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
+               	callq	 <L24>
+<L24>:
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L40>
-               	jmp	 <L42>
-<L40>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L41>
-<L41>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L40>
-<L42>:
-               	leaq	-0xb5(%rbp), %rax
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x220(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movb	0x10(%r8), %dil
-               	movq	%rcx, (%rax)
-               	movq	%rsi, 0x8(%rax)
-               	movb	%dil, 0x10(%rax)
-               	leaq	-0xc6(%rbp), %rbx
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movb	0x10(%rax), %sil
-               	movq	%rcx, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movb	%sil, 0x10(%rbx)
-               	leaq	(%rbx), %rax
-               	movzbl	(%rax), %esi
-               	movq	%r12, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L44>
-               	jmp	 <L46>
-<L44>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L45>
-<L45>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L44>
-<L46>:
-               	movq	%r12, %rax
-               	movq	-0x268(%rbp), %rbx
-               	movq	-0x270(%rbp), %r12
-               	movq	-0x278(%rbp), %r13
-               	movq	-0x280(%rbp), %r14
-               	movq	-0x288(%rbp), %r15
+               	leaq	-0xc3(%rbp), %rdx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movb	0x10(%rdx), %bl
+               	movq	%rax, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movb	%bl, 0x10(%rsp)
+               	callq	 <L25>
+<L25>:
+               	movq	-0x258(%rbp), %rbx
+               	movq	-0x260(%rbp), %r12
+               	movq	-0x268(%rbp), %r13
+               	movq	-0x270(%rbp), %r14
+               	movq	-0x278(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1009,46 +1240,85 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x370(%rbp)
                	movq	%r15, -0x378(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x9, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0xc, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x10, %rsi
-               	callq	 <L5>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
                	movq	%rax, %rdi
-               	movq	$0x11, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x11, %rsi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
@@ -1056,19 +1326,19 @@ Disassembly of section __TEXT,__text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
@@ -1080,24 +1350,32 @@ Disassembly of section __TEXT,__text:
                	callq	 <L17>
 <L17>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L18>
 <L18>:
-               	leaq	-0x60(%rbp), %r12
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x88(%rbp), %r12
                	leaq	(%r12), %rdx
                	addq	$0x0, %rdx
                	movq	$0x60, %rsi
-<L19>:
+<L21>:
                	movq	$0x0, (%rdx)
                	addq	$0x8, %rdx
                	subq	$0x8, %rsi
                	cmpq	$0x0, %rsi
-               	jne	 <L19>
+               	jne	 <L21>
                	movq	$0x0, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-               	jmp	 <L21>
-<L20>:
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
                	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rsi
@@ -1108,15 +1386,15 @@ Disassembly of section __TEXT,__text:
                	movq	%rsi, (%rdi)
                	addq	$0x1, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-<L21>:
+               	jb	 <L22>
+<L23>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L22>
-               	jmp	 <L43>
-<L22>:
+               	jb	 <L24>
+               	jmp	 <L45>
+<L24>:
                	movq	%r15, %rax
                	imulq	$0x11, %rax, %rax
                	movq	%rax, %r8
@@ -1131,7 +1409,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x228(%rbp)
-               	leaq	-0x69(%rbp), %r8
+               	leaq	-0x9(%rbp), %r8
                	movq	%r8, -0x230(%rbp)
                	movq	-0x230(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -1144,9 +1422,9 @@ Disassembly of section __TEXT,__text:
                	movb	%sil, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-               	jmp	 <L24>
-<L23>:
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
                	movq	%rax, %rsi
                	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1162,9 +1440,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-<L24>:
-               	leaq	-0x72(%rbp), %r8
+               	jb	 <L25>
+<L26>:
+               	leaq	-0x12(%rbp), %r8
                	movq	%r8, -0x240(%rbp)
                	movq	-0x230(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1180,7 +1458,7 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x238(%rbp)
                	leaq	0x18(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x90(%rbp), %r8
+               	leaq	-0x94(%rbp), %r8
                	movq	%r8, -0x258(%rbp)
                	movl	%esi, %edi
                	movq	-0x258(%rbp), %r8
@@ -1202,17 +1480,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L25>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L26>:
+<L28>:
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rsi
                	movq	-0x220(%rbp), %r8
@@ -1235,25 +1513,6 @@ Disassembly of section __TEXT,__text:
                	andq	$0xffff, %rax           ## imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L28>:
-               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x415>
-               	movq	-0x250(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movsd	%xmm2, (%rax)
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
                	jl	 <L29>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L30>
@@ -1266,7 +1525,26 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm1, %xmm1
 <L30>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x462>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4f2>
+               	movq	-0x250(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movsd	%xmm2, (%rax)
+               	andq	$0xfff, %rdi            ## imm = 0xFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L32>:
+               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x53f>
                	movq	-0x250(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1282,19 +1560,19 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ffff, %rdi          ## imm = 0x3FFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L31>
+               	jl	 <L33>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L32>
-<L31>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L32>:
+<L34>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4dd>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x5ba>
                	movq	-0x268(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movsd	%xmm2, (%rdx)
@@ -1321,9 +1599,9 @@ Disassembly of section __TEXT,__text:
                	movb	%al, (%rsi)
                	movq	$0x0, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
                	movq	%rax, %rsi
                	imulq	$0x4, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1339,8 +1617,8 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L33>
-<L34>:
+               	jb	 <L35>
+<L36>:
                	leaq	-0x122(%rbp), %r8
                	movq	%r8, -0x280(%rbp)
                	movq	-0x278(%rbp), %r8
@@ -1371,9 +1649,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-               	jmp	 <L36>
-<L35>:
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
                	movq	%rax, %rdi
                	imulq	$0x8, %rdi, %rdi
                	movq	%rdi, %rcx
@@ -1389,8 +1667,8 @@ Disassembly of section __TEXT,__text:
                	movb	%sil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-<L36>:
+               	jb	 <L37>
+<L38>:
                	leaq	-0x156(%rbp), %r8
                	movq	%r8, -0x298(%rbp)
                	movq	-0x290(%rbp), %r8
@@ -1452,9 +1730,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dl, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
                	movq	%rax, %rdx
                	imulq	$0x4, %rdx, %rdx
                	movq	%rdx, %rcx
@@ -1470,8 +1748,8 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rsi)
                	addq	$0x1, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-<L38>:
+               	jb	 <L39>
+<L40>:
                	leaq	-0x1c2(%rbp), %rax
                	movq	-0x2b8(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1487,17 +1765,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L41>
                	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm3
                	addss	%xmm3, %xmm3
-<L40>:
+<L42>:
                	leaq	0x18(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x2e0(%rbp)
@@ -1582,19 +1860,19 @@ Disassembly of section __TEXT,__text:
                	movl	%r8d, %ecx
                	movq	-0x2c8(%rbp), %r8
                	movq	-0x2d0(%rbp), %r9
-               	callq	 <L41>
-<L41>:
+               	callq	 <L43>
+<L43>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L42>
-<L42>:
+               	callq	 <L44>
+<L44>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L22>
-<L43>:
-               	leaq	-0x7b(%rbp), %rax
+               	jb	 <L24>
+<L45>:
+               	leaq	-0x1b(%rbp), %rax
                	movq	$0x0, (%rax)
                	movb	$0x0, 0x8(%rax)
                	movb	%r14b, %dl
@@ -1602,9 +1880,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dl, (%rsi)
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-               	jmp	 <L45>
-<L44>:
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
                	movq	%rdx, %rsi
                	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1618,9 +1896,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rbx)
                	addq	$0x1, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-<L45>:
-               	leaq	-0x84(%rbp), %r8
+               	jb	 <L46>
+<L47>:
+               	leaq	-0x24(%rbp), %r8
                	movq	%r8, -0x2f0(%rbp)
                	movq	(%rax), %rsi
                	movb	0x8(%rax), %dil
@@ -1630,7 +1908,7 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, 0x8(%r8)
                	movl	%r14d, %r8d
                	movq	%r8, -0x2e8(%rbp)
-               	leaq	-0x9c(%rbp), %r8
+               	leaq	-0xa0(%rbp), %r8
                	movq	%r8, -0x318(%rbp)
                	movl	%r14d, %edi
                	movq	-0x318(%rbp), %r8
@@ -1652,17 +1930,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rdi            ## imm = 0x3FF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L48>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L47>:
+<L49>:
                	leaq	-0xc0(%rbp), %r8
                	movq	%r8, -0x300(%rbp)
                	movq	-0x300(%rbp), %r8
@@ -1680,26 +1958,6 @@ Disassembly of section __TEXT,__text:
                	andq	$0xffff, %r15           ## imm = 0xFFFF
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L49>
-<L48>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L49>:
-               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc12>
-               	movq	-0x308(%rbp), %r8
-               	leaq	(%r8), %r15
-               	movsd	%xmm2, (%r15)
-               	movq	%r14, %r15
-               	andq	$0xfff, %r15            ## imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
                	jl	 <L50>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L51>
@@ -1712,7 +1970,27 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm1, %xmm1
 <L51>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc63>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xcec>
+               	movq	-0x308(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movsd	%xmm2, (%r15)
+               	movq	%r14, %r15
+               	andq	$0xfff, %r15            ## imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L52>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L53>
+<L52>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L53>:
+               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xd3d>
                	movq	-0x308(%rbp), %r8
                	leaq	0x8(%r8), %r15
                	movsd	%xmm2, (%r15)
@@ -1727,19 +2005,19 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ffff, %rax          ## imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L52>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L53>
-<L52>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L53>:
+<L55>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xcda>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xdb4>
                	movq	-0x310(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1757,9 +2035,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dil, (%rdx)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-               	jmp	 <L55>
-<L54>:
+               	jb	 <L56>
+               	jmp	 <L57>
+<L56>:
                	movq	%rdx, %rdi
                	imulq	$0x4, %rdi, %rdi
                	movq	%rdi, %rcx
@@ -1773,8 +2051,8 @@ Disassembly of section __TEXT,__text:
                	movb	%bl, (%r15)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-<L55>:
+               	jb	 <L56>
+<L57>:
                	leaq	-0x144(%rbp), %r8
                	movq	%r8, -0x320(%rbp)
                	movq	(%rax), %rdi
@@ -1796,9 +2074,9 @@ Disassembly of section __TEXT,__text:
                	movb	%bl, (%r15)
                	movq	$0x0, %rbx
                	cmpq	$0x8, %rbx
-               	jb	 <L56>
-               	jmp	 <L57>
-<L56>:
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
                	movq	%rbx, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
@@ -1812,8 +2090,8 @@ Disassembly of section __TEXT,__text:
                	movb	%sil, (%rdx)
                	addq	$0x1, %rbx
                	cmpq	$0x8, %rbx
-               	jb	 <L56>
-<L57>:
+               	jb	 <L58>
+<L59>:
                	leaq	-0x168(%rbp), %r8
                	movq	%r8, -0x328(%rbp)
                	movq	(%rax), %rsi
@@ -1866,9 +2144,9 @@ Disassembly of section __TEXT,__text:
                	movb	%dl, (%r15)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-               	jmp	 <L59>
-<L58>:
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
                	movq	%rdx, %r15
                	imulq	$0x4, %r15, %r15
                	movq	%r15, %rcx
@@ -1882,8 +2160,8 @@ Disassembly of section __TEXT,__text:
                	movb	%sil, (%rax)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-<L59>:
+               	jb	 <L60>
+<L61>:
                	leaq	-0x1fa(%rbp), %rax
                	movq	(%rdi), %rdx
                	movq	0x8(%rdi), %rsi
@@ -1896,17 +2174,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L62>
                	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L63>
+<L62>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm3
                	addss	%xmm3, %xmm3
-<L61>:
+<L63>:
                	leaq	0x20(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x348(%rbp)
@@ -1986,12 +2264,12 @@ Disassembly of section __TEXT,__text:
                	movl	%r8d, %ecx
                	movq	%r12, %r8
                	movq	%r15, %r9
-               	callq	 <L62>
-<L62>:
+               	callq	 <L64>
+<L64>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L65>
+<L65>:
                	movq	-0x358(%rbp), %rbx
                	movq	-0x360(%rbp), %r12
                	movq	-0x368(%rbp), %r13

--- a/test/golden/x86_64-darwin/call/call_rec_large.dis
+++ b/test/golden/x86_64-darwin/call/call_rec_large.dis
@@ -14,28 +14,81 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_large.fold_l24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -43,26 +96,80 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_large.fold_l24f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movsd	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movsd	(%rdx), %xmm2
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -71,34 +178,105 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
                	movl	(%rdx), %ebx
-               	leaq	0x14(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	callq	 <L0>
+               	leaq	0x14(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L2>
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
+               	movl	%ebx, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -110,32 +288,101 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r14, -0x20(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r12
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r13
-               	callq	 <L0>
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -148,32 +395,64 @@ Disassembly of section __TEXT,__text:
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	leaq	(%rdx), %rsi
                	movq	(%rsi), %rbx
                	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r12
-               	leaq	0x10(%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %r13
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r14
-               	movq	%rbx, %rsi
-               	callq	 <L0>
+               	movq	(%rsi), %rdx
+               	leaq	0x10(%rax), %rsi
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %r12
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%r12, %rsi
+               	callq	 <L4>
+<L4>:
                	movq	%rax, %rdi
                	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
-<L3>:
+               	callq	 <L5>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
@@ -262,20 +541,20 @@ Disassembly of section __TEXT,__text:
                	movq	(%rdx), %r14
                	callq	 <L0>
 <L0>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movl	%ebx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	movl	%r12d, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
@@ -371,484 +650,714 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_large.take_large>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1f0, %rsp            ## imm = 0x1F0
-               	movq	%rbx, -0x1c8(%rbp)
-               	movq	%r12, -0x1d0(%rbp)
-               	movq	%r13, -0x1d8(%rbp)
-               	movq	%r14, -0x1e0(%rbp)
-               	movq	%r15, -0x1e8(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x28(%rbp), %rdi
+               	subq	$0x340, %rsp            ## imm = 0x340
+               	movq	%rbx, -0x2f8(%rbp)
+               	movq	%r12, -0x300(%rbp)
+               	movq	%r13, -0x308(%rbp)
+               	movq	%r14, -0x310(%rbp)
+               	movq	%r15, -0x318(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	leaq	0x10(%rbp), %rdi
+               	leaq	0x28(%rbp), %rbx
                	leaq	0x40(%rbp), %r12
                	movl	%esi, %r13d
                	leaq	0x58(%rbp), %rsi
-               	leaq	0x78(%rbp), %r14
-               	movsd	%xmm0, -0x140(%rbp)
-               	leaq	0x98(%rbp), %r15
+               	leaq	0x78(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movsd	%xmm0, -0x268(%rbp)
+               	leaq	0x98(%rbp), %r8
+               	movq	%r8, -0x120(%rbp)
                	leaq	0xc8(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r8, -0x118(%rbp)
                	leaq	0xf8(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
+               	movq	%r8, -0xf0(%rbp)
                	leaq	0x110(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	leaq	0x130(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movss	%xmm1, -0x150(%rbp)
+               	movq	%r8, -0x100(%rbp)
+               	movss	%xmm1, -0x278(%rbp)
                	movq	%rdx, %r8
-               	movq	%r8, -0x28(%rbp)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x30(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x38(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x158(%rbp)
-               	leaq	(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x168(%rbp)
-               	leaq	0x8(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x178(%rbp)
-               	leaq	0x10(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x188(%rbp)
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x40(%rbp)
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x198(%rbp)
-               	leaq	0x10(%r12), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	0x14(%r12), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x50(%rbp)
-               	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x10(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x60(%rbp)
-               	leaq	0x18(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x68(%rbp)
-               	leaq	(%r14), %rdx
-               	leaq	(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x70(%rbp)
-               	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0x10(%r14), %rsi
-               	leaq	(%rsi), %rdi
+               	movq	%r8, -0x108(%rbp)
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x280(%rbp)
                	movq	(%rdi), %r14
+               	movq	0x8(%rdi), %rax
+               	movq	0x10(%rdi), %r15
+               	movq	-0x280(%rbp), %r8
+               	movq	%r14, (%r8)
+               	movq	-0x280(%rbp), %r8
+               	movq	%rax, 0x8(%r8)
+               	movq	-0x280(%rbp), %r8
+               	movq	%r15, 0x10(%r8)
+               	leaq	(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x290(%rbp)
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2a0(%rbp)
+               	leaq	0x10(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2b0(%rbp)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2c0(%rbp)
+               	leaq	0x10(%r12), %rax
+               	movl	(%rax), %r14d
+               	leaq	0x14(%r12), %rax
+               	movl	(%rax), %r12d
+               	leaq	-0x38(%rbp), %r15
+               	movq	(%rsi), %rax
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	0x18(%rsi), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	%rax, (%r15)
+               	movq	%rdi, 0x8(%r15)
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, 0x10(%r15)
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, 0x18(%r15)
+               	movq	-0x110(%rbp), %r8
+               	leaq	(%r8), %rax
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x8(%rax), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x140(%rbp)
                	leaq	0x8(%rsi), %rdi
                	movq	(%rdi), %r8
-               	movq	%r8, -0x78(%rbp)
-               	leaq	(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x80(%rbp)
-               	leaq	0x8(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x10(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x90(%rbp)
-               	leaq	0x18(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x98(%rbp)
-               	leaq	0x20(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x28(%r15), %rsi
-               	movq	(%rsi), %r15
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x120(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %r11
-               	movq	%r11, -0x1a8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r11, -0x2d0(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x14(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x18(%r8), %rsi
                	movq	(%rsi), %r11
-               	movq	%r11, -0x1b8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r11, -0x2e0(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xc0(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x28(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xf0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xf8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x1c0(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r9
+               	movq	%r9, 0x18(%r8)
+               	movq	-0x100(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x18(%rbp), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x18(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x18(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	-0x20(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x20(%rbp), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x28(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x130(%rbp)
+               	movq	%r8, -0x1f8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	leaq	-0x88(%rbp), %rsi
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x280(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x280(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
+               	movq	%rax, %rdx
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x220(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L3>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L4>
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x168(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x238(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x178(%rbp), %xmm0
-               	callq	 <L6>
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movsd	-0x188(%rbp), %xmm0
-               	callq	 <L7>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x248(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	-0x248(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movsd	-0x198(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x250(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L11>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %rdx
+               	xorq	%rbx, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L12>
+               	movl	%r14d, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
+               	movl	%r12d, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
+               	movl	%r13d, %edx
+               	movq	%rsi, %rdi
+               	movq	%rdx, %rsi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %rbx
+               	movq	0x10(%r15), %r12
+               	movq	0x18(%r15), %r13
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r12, 0x10(%rsp)
+               	movq	%r13, 0x18(%rsp)
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L19>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
-               	callq	 <L21>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x2e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	%rdx, %rdi
+               	movq	-0x140(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L22>
 <L22>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L23>
 <L23>:
+               	movq	-0x268(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L27>
 <L27>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L28>
 <L28>:
                	movq	%rax, %rdi
-               	movsd	-0x1a8(%rbp), %xmm0
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L29>
 <L29>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L30>
 <L30>:
                	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L31>
 <L31>:
+               	movq	-0x2d0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x1b8(%rbp), %xmm0
                	callq	 <L32>
 <L32>:
+               	movq	-0x188(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L33>
 <L33>:
+               	movq	-0x190(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L34>
 <L34>:
+               	movq	-0x2e0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0x198(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L37>
 <L37>:
+               	leaq	-0xc0(%rbp), %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x10(%r8), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%rbx, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %rbx
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rbx, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L38>
 <L38>:
+               	leaq	-0xe0(%rbp), %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x10(%r8), %rbx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x18(%r8), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%rbx, 0x10(%rdx)
+               	movq	%r12, 0x18(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %rbx
+               	movq	0x18(%rdx), %r12
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rbx, 0x10(%rsp)
+               	movq	%r12, 0x18(%rsp)
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
+               	movq	-0x1d0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x1e0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x1e8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x1f0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x1f8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L45>
 <L45>:
+               	movl	-0x278(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rdi
-               	movss	-0x150(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L49>
-<L49>:
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	addq	$0x1, %rsi
-               	movq	%r15, %rbx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rbx
                	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
                	xorq	%r11, %rbx
                	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rdi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rdi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L55>
 <L55>:
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L57>
 <L57>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L58>
 <L58>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x178(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L59>
 <L59>:
-               	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x1c8(%rbp), %rbx
-               	movq	-0x1d0(%rbp), %r12
-               	movq	-0x1d8(%rbp), %r13
-               	movq	-0x1e0(%rbp), %r14
-               	movq	-0x1e8(%rbp), %r15
+               	movq	-0x2f8(%rbp), %rbx
+               	movq	-0x300(%rbp), %r12
+               	movq	-0x308(%rbp), %r13
+               	movq	-0x310(%rbp), %r14
+               	movq	-0x318(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1218,6 +1727,8 @@ Disassembly of section __TEXT,__text:
                	movq	%r14, -0x500(%rbp)
                	movq	%r15, -0x508(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x18, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -1229,7 +1740,7 @@ Disassembly of section __TEXT,__text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -1237,7 +1748,7 @@ Disassembly of section __TEXT,__text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x30, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
@@ -1245,7 +1756,7 @@ Disassembly of section __TEXT,__text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x30, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
@@ -1257,7 +1768,7 @@ Disassembly of section __TEXT,__text:
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
@@ -1265,44 +1776,40 @@ Disassembly of section __TEXT,__text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x14, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x14, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movq	$0x28, %rsi
-               	callq	 <L17>
-<L17>:
-               	leaq	-0x60(%rbp), %r12
+               	leaq	-0x90(%rbp), %r12
                	leaq	(%r12), %rcx
                	addq	$0x0, %rcx
                	movq	$0x60, %rdx
-<L18>:
+<L17>:
                	movq	$0x0, (%rcx)
                	addq	$0x8, %rcx
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L18>
+               	jne	 <L17>
                	movq	$0x0, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-               	jmp	 <L20>
-<L19>:
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
                	movq	%rcx, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
@@ -1313,16 +1820,16 @@ Disassembly of section __TEXT,__text:
                	movq	%rdx, (%rsi)
                	addq	$0x1, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-<L20>:
+               	jb	 <L18>
+<L19>:
                	movq	%rax, %r8
                	movq	%r8, -0x3c0(%rbp)
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L21>
-               	jmp	 <L37>
-<L21>:
+               	jb	 <L20>
+               	jmp	 <L36>
+<L20>:
                	movq	%r15, %rax
                	imulq	$0x13, %rax, %rax
                	movq	%rax, %r8
@@ -1336,7 +1843,7 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x498(%rbp)
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x78(%rbp), %r8
+               	leaq	-0x18(%rbp), %r8
                	movq	%r8, -0x4b0(%rbp)
                	movq	-0x4b0(%rbp), %r8
                	leaq	(%r8), %rdi
@@ -1359,19 +1866,19 @@ Disassembly of section __TEXT,__text:
                	andq	$0xffff, %rdi           ## imm = 0xFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2a9>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2ae>
                	movq	-0x4b8(%rbp), %r8
                	leaq	(%r8), %rdi
                	movsd	%xmm1, (%rdi)
@@ -1379,38 +1886,38 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdi            ## imm = 0xFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2f9>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2fe>
                	movq	-0x4b8(%rbp), %r8
                	leaq	0x8(%r8), %rdi
                	movsd	%xmm1, (%rdi)
                	andq	$0x3ffff, %rsi          ## imm = 0x3FFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x347>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x34c>
                	movq	-0x4b8(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movsd	%xmm1, (%rsi)
@@ -1428,19 +1935,19 @@ Disassembly of section __TEXT,__text:
                	andq	$0x7fff, %rsi           ## imm = 0x7FFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3d0>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3d5>
                	movq	-0x350(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movsd	%xmm1, (%rsi)
@@ -1548,17 +2055,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rdi            ## imm = 0x3FF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L31>:
+<L30>:
                	movsd	%xmm14, -0x4a8(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
@@ -1607,8 +2114,8 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, %rdi
                	movq	-0x3b8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L31>
+<L31>:
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x3d0(%rbp)
@@ -1703,17 +2210,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L33>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L34>
-<L33>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L34>:
+<L33>:
                	leaq	0x10(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x3f8(%rbp)
@@ -1856,21 +2363,21 @@ Disassembly of section __TEXT,__text:
                	movsd	-0x4a8(%rbp), %xmm0
                	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	movq	%rax, %r14
                	movq	-0x3c0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r14, %rsi
-               	callq	 <L36>
-<L36>:
+               	callq	 <L35>
+<L35>:
                	addq	$0x1, %r15
                	movq	%rax, %r8
                	movq	%r8, -0x3c0(%rbp)
                	cmpq	$0x3, %r15
-               	jb	 <L21>
-<L37>:
-               	leaq	-0x90(%rbp), %rbx
+               	jb	 <L20>
+<L36>:
+               	leaq	-0x30(%rbp), %rbx
                	leaq	(%rbx), %rax
                	movq	%r14, (%rax)
                	movq	%r14, %rax
@@ -1887,57 +2394,57 @@ Disassembly of section __TEXT,__text:
                	andq	$0xffff, %rax           ## imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L38>
+               	jl	 <L37>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L39>
-<L38>:
+               	jmp	 <L38>
+<L37>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L39>:
+<L38>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xce4>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xce6>
                	leaq	(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r14, %rax
                	andq	$0xfff, %rax            ## imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L40>
+               	jl	 <L39>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
+               	jmp	 <L40>
+<L39>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L41>:
+<L40>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd2e>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd30>
                	leaq	0x8(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r14, %rax
                	andq	$0x3ffff, %rax          ## imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L42>
+               	jl	 <L41>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L43>
-<L42>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L43>:
+<L42>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd78>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd7a>
                	leaq	0x10(%r13), %rax
                	movsd	%xmm1, (%rax)
                	leaq	-0xf0(%rbp), %r15
@@ -1947,19 +2454,19 @@ Disassembly of section __TEXT,__text:
                	andq	$0x7fff, %rax           ## imm = 0x7FFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L44>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L45>
-<L44>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L45>:
+<L44>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xdcf>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xdd1>
                	leaq	0x8(%r15), %rax
                	movsd	%xmm1, (%rax)
                	movl	%r14d, %eax
@@ -2042,17 +2549,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L45>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L46>
+<L45>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L47>:
+<L46>:
                	movsd	%xmm14, -0x4c8(%rbp)
                	leaq	-0x240(%rbp), %r8
                	movq	%r8, -0x4e0(%rbp)
@@ -2090,8 +2597,8 @@ Disassembly of section __TEXT,__text:
                	movq	-0x458(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r14, %rsi
-               	callq	 <L48>
-<L48>:
+               	callq	 <L47>
+<L47>:
                	movq	-0x458(%rbp), %r8
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %r8
@@ -2187,17 +2694,17 @@ Disassembly of section __TEXT,__text:
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L50>:
+<L49>:
                	leaq	0x18(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x490(%rbp)
@@ -2324,13 +2831,13 @@ Disassembly of section __TEXT,__text:
                	movsd	-0x4c8(%rbp), %xmm0
                	movq	-0x490(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L51>
-<L51>:
+               	callq	 <L50>
+<L50>:
                	movq	-0x3c0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L52>
-<L52>:
+               	callq	 <L51>
+<L51>:
                	movq	-0x4e8(%rbp), %rbx
                	movq	-0x4f0(%rbp), %r12
                	movq	-0x4f8(%rbp), %r13

--- a/test/golden/x86_64-darwin/call/call_rec_small.dis
+++ b/test/golden/x86_64-darwin/call/call_rec_small.dis
@@ -14,12 +14,34 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r1>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -29,18 +51,57 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0x7(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0x7(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -48,28 +109,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0x7(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x6(%rbp), %rcx
-               	movzwl	(%rcx), %r12d
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0x7(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x6(%rbp), %rax
+               	movzwl	(%rax), %ebx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzwq	%bx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -77,29 +194,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.fold_r8>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x4(%rbp), %rcx
-               	movzwl	(%rcx), %ebx
-               	leaq	-0x2(%rbp), %rcx
-               	movzbl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0x4(%rbp), %rax
+               	movzwl	(%rax), %esi
+               	leaq	-0x2(%rbp), %rax
+               	movzbl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzwq	%si, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -107,57 +279,169 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x1, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L3>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x2, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x4, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L7>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L8>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x2, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	$0x4, %rsi
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L9>
-<L9>:
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rdi
                	movq	$0x2, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L11>
-<L11>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rdi
                	movq	$0x6, %rsi
-               	callq	 <L12>
-<L12>:
+               	callq	 <L19>
+<L19>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -165,237 +449,247 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.take_small>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            ## imm = 0x100
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
-               	movq	%r15, -0xf8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x160, %rsp            ## imm = 0x160
+               	movq	%rbx, -0x138(%rbp)
+               	movq	%r12, -0x140(%rbp)
+               	movq	%r13, -0x148(%rbp)
+               	movq	%r14, -0x150(%rbp)
+               	movq	%r15, -0x158(%rbp)
+               	movq	%rdi, %r10
+               	movq	%r10, -0xb0(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	movl	%edx, %r12d
+               	movl	%edx, %ebx
                	movq	%rcx, -0x10(%rbp)
-               	movsd	%xmm0, -0xb0(%rbp)
+               	movsd	%xmm0, -0x110(%rbp)
                	movq	%r8, -0x18(%rbp)
-               	movq	%r9, %r13
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x18(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	leaq	0x20(%rbp), %rsi
-               	leaq	0x28(%rbp), %rdi
-               	leaq	0x30(%rbp), %r14
-               	movss	%xmm1, -0xc0(%rbp)
-               	movq	0x38(%rbp), %r15
-               	leaq	-0x8(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x28(%rbp)
-               	leaq	-0x10(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x30(%rbp)
-               	leaq	-0xf(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x38(%rbp)
-               	leaq	-0x18(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x40(%rbp)
-               	leaq	-0x17(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	-0x16(%rbp), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x50(%rbp)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x4(%rcx), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x60(%rbp)
-               	leaq	0x6(%rcx), %rdx
-               	movzbl	(%rdx), %r8d
+               	movq	%r9, %r12
+               	leaq	0x10(%rbp), %rdx
+               	leaq	0x18(%rbp), %rsi
+               	leaq	0x20(%rbp), %r8
+               	movq	%r8, -0xd0(%rbp)
+               	leaq	0x28(%rbp), %r8
                	movq	%r8, -0xc8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x68(%rbp)
+               	leaq	0x30(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movss	%xmm1, -0x120(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	leaq	-0x1a(%rbp), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movw	-0x10(%rbp), %r14w
+               	movq	-0x128(%rbp), %r8
+               	movw	%r14w, (%r8)
+               	leaq	-0x1e(%rbp), %r14
+               	movl	-0x18(%rbp), %r13d
+               	movl	%r13d, (%r14)
+               	leaq	-0x28(%rbp), %r13
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%r13)
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x70(%rbp)
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x78(%rbp)
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x80(%rbp)
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x2(%rdi), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x90(%rbp)
-               	leaq	(%r14), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x98(%rbp)
-               	leaq	0x4(%r14), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x6(%r14), %rdx
-               	movzbl	(%rdx), %r14d
+               	movq	%r8, -0xd8(%rbp)
+               	leaq	-0x2a(%rbp), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movw	(%r8), %si
+               	movq	-0x130(%rbp), %r8
+               	movw	%si, (%r8)
+               	leaq	-0x2e(%rbp), %r15
+               	movq	-0xc8(%rbp), %r8
+               	movl	(%r8), %esi
+               	movl	%esi, (%r15)
+               	leaq	-0x38(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xe8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	movq	-0xb8(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
+               	movq	-0x100(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L2>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
+               	movl	%ebx, %esi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0x3a(%rbp), %rsi
+               	movq	-0x128(%rbp), %r8
+               	movw	(%r8), %bx
+               	movw	%bx, (%rsi)
+               	movq	$0x0, -0x48(%rbp)
+               	movw	(%rsi), %ax
+               	movw	%ax, -0x48(%rbp)
+               	movq	-0x48(%rbp), %rsi
                	callq	 <L4>
 <L4>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
+               	leaq	-0x4c(%rbp), %rsi
+               	movl	(%r14), %edi
+               	movl	%edi, (%rsi)
+               	movq	$0x0, -0x58(%rbp)
+               	movl	(%rsi), %edi
+               	movl	%edi, -0x58(%rbp)
+               	movq	-0x58(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xb0(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r12, %rsi
                	callq	 <L7>
 <L7>:
+               	leaq	-0x60(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rbx
                	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	-0xd8(%rbp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L10>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
 <L10>:
+               	leaq	-0x62(%rbp), %rsi
+               	movq	-0x130(%rbp), %r8
+               	movw	(%r8), %di
+               	movw	%di, (%rsi)
+               	movq	$0x0, -0x70(%rbp)
+               	movw	(%rsi), %dx
+               	movw	%dx, -0x70(%rbp)
+               	movq	-0x70(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
                	callq	 <L11>
 <L11>:
+               	leaq	-0x74(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x80(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x80(%rbp)
+               	movq	-0x80(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
+               	leaq	-0x88(%rbp), %rdx
+               	movq	-0xe8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L13>
 <L13>:
+               	movl	-0x120(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
+               	leaq	-0x90(%rbp), %rdx
+               	leaq	-0x98(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edi
+               	addl	$0x2, %edi
+               	movw	%di, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movzbl	(%rsi), %edi
+               	addl	$0x3, %edi
+               	movb	%dil, (%rsi)
+               	leaq	-0xa0(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdx
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rdx, %rsi
                	callq	 <L16>
 <L16>:
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r13), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %edx
-               	addl	$0x1, %edx
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %ebx
-               	addl	$0x2, %ebx
-               	movq	-0xc8(%rbp), %r8
-               	movl	%r8d, %r12d
-               	addl	$0x3, %r12d
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
-               	movq	-0xf8(%rbp), %r15
+               	movq	-0x138(%rbp), %rbx
+               	movq	-0x140(%rbp), %r12
+               	movq	-0x148(%rbp), %r13
+               	movq	-0x150(%rbp), %r14
+               	movq	-0x158(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -487,349 +781,438 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1c0, %rsp            ## imm = 0x1C0
-               	movq	%rbx, -0x168(%rbp)
-               	movq	%r12, -0x170(%rbp)
-               	movq	%r13, -0x178(%rbp)
-               	movq	%r14, -0x180(%rbp)
-               	movq	%r15, -0x188(%rbp)
+               	subq	$0x1e0, %rsp            ## imm = 0x1E0
+               	movq	%rbx, -0x188(%rbp)
+               	movq	%r12, -0x190(%rbp)
+               	movq	%r13, -0x198(%rbp)
+               	movq	%r14, -0x1a0(%rbp)
+               	movq	%r15, -0x1a8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x1, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x4, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L5>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L9>
-<L9>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rdi
                	movq	$0x2, %rsi
-               	callq	 <L11>
-<L11>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L12>
-<L12>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rdi
                	movq	$0x6, %rsi
-               	callq	 <L13>
-<L13>:
-               	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L14>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L14>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-               	jmp	 <L16>
-<L15>:
-               	movq	%rcx, %rdx
+               	callq	 <L19>
+<L19>:
+               	leaq	-0x68(%rbp), %r12
+               	leaq	(%r12), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rsi
+<L20>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L20>
+               	movq	$0x0, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-<L16>:
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+<L22>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L17>
-               	jmp	 <L24>
-<L17>:
+               	jb	 <L23>
+               	jmp	 <L30>
+<L23>:
                	movq	%r15, %rax
                	imulq	$0xd, %rax, %rax
                	addq	%rbx, %rax
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, %r8
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rsi, %r8
                	addq	%rax, %r8
                	movq	%r8, -0xe0(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x61(%rbp), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movb	%sil, %dil
-               	movq	-0xe8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movb	%dil, (%rsi)
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	-0x1(%rbp), %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movb	%dil, %sil
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movb	%sil, (%rdi)
                	leaq	0x10(%r12), %rsi
                	movq	(%rsi), %rdi
                	movl	%edi, %r8d
-               	movq	%r8, -0xd8(%rbp)
+               	movq	%r8, -0xe8(%rbp)
                	leaq	0x18(%r12), %rsi
                	movq	(%rsi), %rdi
-               	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0xf0(%rbp)
+               	leaq	-0x6a(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
                	movb	%dil, %dl
-               	movq	-0xf0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%dl, (%rcx)
+               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dl, (%rsi)
                	shrq	$0x8, %rdi
-               	movb	%dil, %cl
-               	movq	-0xf0(%rbp), %r8
-               	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0x3ff, %rdx            ## imm = 0x3FF
-               	movq	%rdx, %r11
+               	movb	%dil, %dl
+               	movq	-0xf8(%rbp), %r8
+               	leaq	0x1(%r8), %rsi
+               	movb	%dl, (%rsi)
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0x3ff, %rsi            ## imm = 0x3FF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L24>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L25>
+<L24>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x6a(%rbp), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movb	%dl, %dil
-               	movq	-0x108(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	movq	%rdx, %rsi
-               	shrq	$0x8, %rsi
+<L25>:
+               	leaq	0x28(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0x100(%rbp)
                	movb	%sil, %dil
-               	movq	-0x108(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %si
-               	movq	-0x108(%rbp), %r8
-               	leaq	0x2(%r8), %rdx
-               	movw	%si, (%rdx)
+               	movq	-0x100(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movb	%dil, (%rdx)
+               	movq	%rsi, %rdx
+               	shrq	$0x8, %rdx
+               	movb	%dl, %dil
+               	movq	-0x100(%rbp), %r8
+               	leaq	0x1(%r8), %rdx
+               	movb	%dil, (%rdx)
+               	shrq	$0x10, %rsi
+               	movw	%si, %dx
+               	movq	-0x100(%rbp), %r8
+               	leaq	0x2(%r8), %rsi
+               	movw	%dx, (%rsi)
                	leaq	0x30(%r12), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0xf8(%rbp)
+               	movq	%r8, -0x108(%rbp)
                	leaq	0x38(%r12), %rdx
                	movq	(%rdx), %rsi
                	addq	%rax, %rsi
-               	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x110(%rbp)
+               	leaq	-0x7c(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
                	movl	%esi, %edx
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	(%r8), %rdi
                	movl	%edx, (%rdi)
                	movq	%rsi, %rdx
                	shrq	$0x20, %rdx
                	movw	%dx, %di
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movw	%di, (%rdx)
                	shrq	$0x30, %rsi
                	movb	%sil, %dl
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	0x6(%r8), %rsi
                	movb	%dl, (%rsi)
                	leaq	0x40(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x81(%rbp), %r8
-               	movq	%r8, -0x100(%rbp)
+               	leaq	-0x85(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
                	movb	%sil, %dil
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	leaq	(%r8), %rsi
                	movb	%dil, (%rsi)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	leaq	-0x84(%rbp), %r8
-               	movq	%r8, -0x118(%rbp)
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x120(%rbp)
                	movb	%dil, %dl
-               	movq	-0x118(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%dl, (%rcx)
+               	movq	-0x120(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movb	%dl, (%rax)
                	shrq	$0x8, %rdi
-               	movb	%dil, %cl
-               	movq	-0x118(%rbp), %r8
+               	movb	%dil, %al
+               	movq	-0x120(%rbp), %r8
                	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x50(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x8a(%rbp), %rcx
-               	movb	%dl, %dil
-               	leaq	(%rcx), %rax
-               	movb	%dil, (%rax)
-               	movq	%rdx, %rax
-               	shrq	$0x8, %rax
-               	movb	%al, %dil
-               	leaq	0x1(%rcx), %rax
-               	movb	%dil, (%rax)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %ax
-               	leaq	0x2(%rcx), %rdx
-               	movw	%ax, (%rdx)
-               	leaq	0x58(%r12), %rax
+               	movb	%al, (%rdx)
+               	leaq	0x50(%r12), %rax
                	movq	(%rax), %rdx
-               	leaq	-0x98(%rbp), %rax
-               	movl	%edx, %edi
-               	leaq	(%rax), %rsi
-               	movl	%edi, (%rsi)
+               	leaq	-0x8e(%rbp), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movb	%dl, %dil
+               	movq	-0x128(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dil, (%rsi)
                	movq	%rdx, %rsi
-               	shrq	$0x20, %rsi
-               	movw	%si, %di
-               	leaq	0x4(%rax), %rsi
-               	movw	%di, (%rsi)
-               	shrq	$0x30, %rdx
-               	movb	%dl, %sil
-               	leaq	0x6(%rax), %rdx
-               	movb	%sil, (%rdx)
-               	leaq	(%r12), %rdx
+               	shrq	$0x8, %rsi
+               	movb	%sil, %dil
+               	movq	-0x128(%rbp), %r8
+               	leaq	0x1(%r8), %rsi
+               	movb	%dil, (%rsi)
+               	shrq	$0x10, %rdx
+               	movw	%dx, %si
+               	movq	-0x128(%rbp), %r8
+               	leaq	0x2(%r8), %rdx
+               	movw	%si, (%rdx)
+               	leaq	0x58(%r12), %rdx
                	movq	(%rdx), %rsi
+               	leaq	-0x9c(%rbp), %rdx
+               	movl	%esi, %edi
+               	leaq	(%rdx), %rax
+               	movl	%edi, (%rax)
+               	movq	%rsi, %rax
+               	shrq	$0x20, %rax
+               	movw	%ax, %di
+               	leaq	0x4(%rdx), %rax
+               	movw	%di, (%rax)
+               	shrq	$0x30, %rsi
+               	movb	%sil, %al
+               	leaq	0x6(%rdx), %rsi
+               	movb	%al, (%rsi)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L26>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L27>
+<L26>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L21>:
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movq	$0x0, -0xa0(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xa0(%rbp)
-               	movq	-0xa0(%rbp), %rdx
+<L27>:
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rsi
                	movq	$0x0, -0xa8(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movw	(%r8), %di
-               	movw	%di, -0xa8(%rbp)
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, -0x120(%rbp)
+               	movb	(%r8), %al
+               	movb	%al, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %rax
                	movq	$0x0, -0xb0(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	movl	(%r8), %edi
-               	movl	%edi, -0xb0(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	movw	(%r8), %di
+               	movw	%di, -0xb0(%rbp)
                	movq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x110(%rbp), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, -0xb8(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	movl	(%r8), %edi
+               	movl	%edi, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x118(%rbp), %r8
                	movq	(%r8), %rdi
                	movq	%rdi, (%rsp)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	movb	(%r8), %dil
                	movb	%dil, 0x8(%rsp)
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x120(%rbp), %r8
                	movw	(%r8), %di
                	movw	%di, 0x10(%rsp)
-               	movl	(%rcx), %edi
+               	movq	-0x128(%rbp), %r8
+               	movl	(%r8), %edi
                	movl	%edi, 0x18(%rsp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, 0x20(%rsp)
+               	movq	(%rdx), %rdi
+               	movq	%rdi, 0x20(%rsp)
                	movq	%rsi, 0x28(%rsp)
                	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%rdx, %rsi
-               	movq	-0xd8(%rbp), %r8
+               	movq	%rax, %rsi
+               	movq	-0xe8(%rbp), %r8
                	movl	%r8d, %edx
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	callq	 <L22>
-<L22>:
+               	movq	-0x138(%rbp), %r8
+               	movq	-0x108(%rbp), %r9
+               	callq	 <L28>
+<L28>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L23>
-<L23>:
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L17>
-<L24>:
-               	leaq	-0x62(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	movb	%r14b, %cl
-               	movq	-0x140(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movb	%cl, (%rdx)
+               	jb	 <L23>
+<L30>:
+               	leaq	-0x2(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movb	%r14b, %dl
+               	movq	-0x150(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dl, (%rsi)
                	movl	%r14d, %r8d
-               	movq	%r8, -0x130(%rbp)
-               	leaq	-0x66(%rbp), %r8
-               	movq	%r8, -0x148(%rbp)
-               	movb	%r14b, %sil
-               	movq	-0x148(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movb	%sil, (%rdi)
-               	movq	%r14, %rsi
-               	shrq	$0x8, %rsi
-               	movb	%sil, %dil
-               	movq	-0x148(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	movq	%r14, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L25>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L26>:
-               	leaq	-0x6e(%rbp), %r8
+               	movq	%r8, -0x140(%rbp)
+               	leaq	-0x6c(%rbp), %r8
                	movq	%r8, -0x158(%rbp)
                	movb	%r14b, %dil
                	movq	-0x158(%rbp), %r8
@@ -842,141 +1225,172 @@ Disassembly of section __TEXT,__text:
                	leaq	0x1(%r8), %rdi
                	movb	%bl, (%rdi)
                	movq	%r14, %rdi
-               	shrq	$0x10, %rdi
-               	movw	%di, %bx
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x2(%r8), %rdi
-               	movw	%bx, (%rdi)
-               	leaq	0x30(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x138(%rbp)
-               	leaq	-0x80(%rbp), %rdi
-               	movl	%r14d, %r15d
-               	leaq	(%rdi), %rcx
-               	movl	%r15d, (%rcx)
-               	movq	%r14, %rcx
-               	shrq	$0x20, %rcx
-               	movw	%cx, %r15w
-               	leaq	0x4(%rdi), %rcx
-               	movw	%r15w, (%rcx)
-               	movq	%r14, %rcx
-               	shrq	$0x30, %rcx
-               	movb	%cl, %r15b
-               	leaq	0x6(%rdi), %rcx
-               	movb	%r15b, (%rcx)
-               	leaq	0x40(%r12), %rcx
-               	movq	(%rcx), %r15
-               	leaq	-0x82(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	movb	%r15b, %bl
-               	movq	-0x150(%rbp), %r8
+               	andq	$0x3ff, %rdi            ## imm = 0x3FF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L32>:
+               	leaq	-0x74(%rbp), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movb	%r14b, %bl
+               	movq	-0x168(%rbp), %r8
                	leaq	(%r8), %r15
                	movb	%bl, (%r15)
-               	leaq	0x48(%r12), %rbx
-               	movq	(%rbx), %r15
-               	leaq	-0x86(%rbp), %rbx
-               	movb	%r15b, %al
-               	leaq	(%rbx), %rdx
-               	movb	%al, (%rdx)
-               	shrq	$0x8, %r15
-               	movb	%r15b, %al
-               	leaq	0x1(%rbx), %rdx
-               	movb	%al, (%rdx)
-               	leaq	0x50(%r12), %rax
-               	movq	(%rax), %rdx
-               	leaq	-0x8e(%rbp), %rax
-               	movb	%dl, %r15b
-               	leaq	(%rax), %rcx
-               	movb	%r15b, (%rcx)
-               	movq	%rdx, %rcx
-               	shrq	$0x8, %rcx
-               	movb	%cl, %r15b
-               	leaq	0x1(%rax), %rcx
-               	movb	%r15b, (%rcx)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %cx
-               	leaq	0x2(%rax), %rdx
-               	movw	%cx, (%rdx)
-               	leaq	0x58(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0xb8(%rbp), %rcx
-               	movl	%edx, %r15d
-               	leaq	(%rcx), %rsi
-               	movl	%r15d, (%rsi)
-               	movq	%rdx, %rsi
-               	shrq	$0x20, %rsi
-               	movw	%si, %r15w
-               	leaq	0x4(%rcx), %rsi
-               	movw	%r15w, (%rsi)
+               	movq	%r14, %rbx
+               	shrq	$0x8, %rbx
+               	movb	%bl, %r15b
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x1(%r8), %rbx
+               	movb	%r15b, (%rbx)
+               	movq	%r14, %rbx
+               	shrq	$0x10, %rbx
+               	movw	%bx, %r15w
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x2(%r8), %rbx
+               	movw	%r15w, (%rbx)
+               	leaq	0x30(%r12), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x148(%rbp)
+               	leaq	-0x84(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movl	%r14d, %edx
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movl	%edx, (%r15)
+               	movq	%r14, %rdx
+               	shrq	$0x20, %rdx
+               	movw	%dx, %r15w
+               	movq	-0x170(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movw	%r15w, (%rdx)
+               	movq	%r14, %rdx
                	shrq	$0x30, %rdx
-               	movb	%dl, %sil
-               	leaq	0x6(%rcx), %rdx
+               	movb	%dl, %r15b
+               	movq	-0x170(%rbp), %r8
+               	leaq	0x6(%r8), %rdx
+               	movb	%r15b, (%rdx)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %r15
+               	leaq	-0x86(%rbp), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movb	%r15b, %al
+               	movq	-0x160(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movb	%al, (%r15)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %r15
+               	leaq	-0x8a(%rbp), %rax
+               	movb	%r15b, %sil
+               	leaq	(%rax), %rdx
                	movb	%sil, (%rdx)
-               	leaq	(%r12), %rdx
+               	shrq	$0x8, %r15
+               	movb	%r15b, %dl
+               	leaq	0x1(%rax), %rsi
+               	movb	%dl, (%rsi)
+               	leaq	0x50(%r12), %rdx
                	movq	(%rdx), %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	leaq	-0x92(%rbp), %rdx
+               	movb	%sil, %r15b
+               	leaq	(%rdx), %rdi
+               	movb	%r15b, (%rdi)
+               	movq	%rsi, %rdi
+               	shrq	$0x8, %rdi
+               	movb	%dil, %r15b
+               	leaq	0x1(%rdx), %rdi
+               	movb	%r15b, (%rdi)
+               	shrq	$0x10, %rsi
+               	movw	%si, %di
+               	leaq	0x2(%rdx), %rsi
+               	movw	%di, (%rsi)
+               	leaq	0x58(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	-0xc0(%rbp), %rsi
+               	movl	%edi, %r15d
+               	leaq	(%rsi), %rbx
+               	movl	%r15d, (%rbx)
+               	movq	%rdi, %rbx
+               	shrq	$0x20, %rbx
+               	movw	%bx, %r15w
+               	leaq	0x4(%rsi), %rbx
+               	movw	%r15w, (%rbx)
+               	shrq	$0x30, %rdi
+               	movb	%dil, %bl
+               	leaq	0x6(%rsi), %rdi
+               	movb	%bl, (%rdi)
+               	leaq	(%r12), %rdi
+               	movq	(%rdi), %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L33>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L28>:
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movq	$0x0, -0xc0(%rbp)
-               	movq	-0x140(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %rdx
+<L34>:
+               	leaq	0x10(%r12), %rdi
+               	movq	(%rdi), %rbx
                	movq	$0x0, -0xc8(%rbp)
-               	movq	-0x148(%rbp), %r8
-               	movw	(%r8), %r12w
-               	movw	%r12w, -0xc8(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movb	(%r8), %dil
+               	movb	%dil, -0xc8(%rbp)
                	movq	-0xc8(%rbp), %r12
                	movq	$0x0, -0xd0(%rbp)
                	movq	-0x158(%rbp), %r8
-               	movl	(%r8), %r15d
-               	movl	%r15d, -0xd0(%rbp)
+               	movw	(%r8), %di
+               	movw	%di, -0xd0(%rbp)
                	movq	-0xd0(%rbp), %r15
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, -0xd8(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	movl	(%r8), %edi
+               	movl	%edi, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, (%rsp)
                	movq	-0x160(%rbp), %r8
-               	movq	%r8, (%rsp)
-               	movq	-0x150(%rbp), %r8
                	movb	(%r8), %dil
                	movb	%dil, 0x8(%rsp)
-               	movw	(%rbx), %di
+               	movw	(%rax), %di
                	movw	%di, 0x10(%rsp)
-               	movl	(%rax), %edi
-               	movl	%edi, 0x18(%rsp)
-               	movq	(%rcx), %rax
+               	movl	(%rdx), %eax
+               	movl	%eax, 0x18(%rsp)
+               	movq	(%rsi), %rax
                	movq	%rax, 0x20(%rsp)
-               	movq	%rsi, 0x28(%rsp)
+               	movq	%rbx, 0x28(%rsp)
                	movq	%r14, %rdi
-               	movq	%rdx, %rsi
-               	movq	-0x130(%rbp), %r8
+               	movq	%r12, %rsi
+               	movq	-0x140(%rbp), %r8
                	movl	%r8d, %edx
-               	movq	%r12, %rcx
-               	movq	%r15, %r8
-               	movq	-0x138(%rbp), %r9
-               	callq	 <L29>
-<L29>:
+               	movq	%r15, %rcx
+               	movq	-0x178(%rbp), %r8
+               	movq	-0x148(%rbp), %r9
+               	callq	 <L35>
+<L35>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x168(%rbp), %rbx
-               	movq	-0x170(%rbp), %r12
-               	movq	-0x178(%rbp), %r13
-               	movq	-0x180(%rbp), %r14
-               	movq	-0x188(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x188(%rbp), %rbx
+               	movq	-0x190(%rbp), %r12
+               	movq	-0x198(%rbp), %r13
+               	movq	-0x1a0(%rbp), %r14
+               	movq	-0x1a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_recursive.dis
+++ b/test/golden/x86_64-darwin/call/call_recursive.dis
@@ -14,12 +14,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.descend>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%r13, -0x58(%rbp)
-               	movq	%r14, -0x60(%rbp)
-               	movq	%r15, -0x68(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -35,14 +35,14 @@ Disassembly of section __TEXT,__text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rsi, %rdi
-               	imulq	%rcx, %rdi
-               	addq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %r13
-               	movq	%rdi, (%r13)
-               	movq	%rcx, %rax
+               	movq	%rax, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r13
+               	imulq	%rdi, %r13
+               	addq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %r14
+               	movq	%r13, (%r14)
+               	movq	%rdi, %rax
                	cmpq	$0x8, %rax
                	jb	 <L0>
 <L1>:
@@ -62,34 +62,87 @@ Disassembly of section __TEXT,__text:
 <L3>:
                	movq	%rax, %r14
 <L4>:
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L9>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %r12
-               	movq	-0x58(%rbp), %r13
-               	movq	-0x60(%rbp), %r14
-               	movq	-0x68(%rbp), %r15
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r14, %rax
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -97,11 +150,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.ping>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
                	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x20(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -113,13 +167,13 @@ Disassembly of section __TEXT,__text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	%rsi, %rdi
-               	addq	%rcx, %rdi
-               	addq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	%rdi, (%rcx)
+               	movq	%rax, %rdi
+               	imulq	$0x7, %rdi, %rdi
+               	movq	%rsi, %r13
+               	addq	%rdi, %r13
+               	addq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %rdi
+               	movq	%r13, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x4, %rax
                	jb	 <L0>
@@ -137,30 +191,66 @@ Disassembly of section __TEXT,__text:
 <L3>:
                	movq	%rax, %r13
 <L4>:
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
+               	movq	$0x0, %rax
+               	cmpq	$0x4, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%r13, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L5>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	imulq	$0x2, %rbx, %rbx
-               	movq	%r13, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r13
+               	cmpq	$0x4, %rax
+               	jb	 <L5>
 <L8>:
+               	imulq	$0x2, %rbx, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	%r13, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
                	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -168,12 +258,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.pong>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
-               	movq	%r14, -0x50(%rbp)
-               	movq	%r15, -0x58(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -187,13 +277,13 @@ Disassembly of section __TEXT,__text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rsi, %rdi
-               	imulq	%rcx, %rdi
-               	subq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	%rdi, (%rcx)
+               	movq	%rax, %rdi
+               	addq	$0x3, %rdi
+               	movq	%rsi, %r13
+               	imulq	%rdi, %r13
+               	subq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %rdi
+               	movq	%r13, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x6, %rax
                	jb	 <L0>
@@ -213,31 +303,274 @@ Disassembly of section __TEXT,__text:
 <L3>:
                	movq	%rax, %r14
 <L4>:
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x6, %r15
-               	jb	 <L5>
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r14
+               	cmpq	$0x6, %rax
+               	jb	 <L5>
 <L8>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
                	imulq	$0x3, %rbx, %rbx
                	addq	$0x1, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r14, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_recursive.tree>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
+               	imulq	%r11, %rsi
+               	movq	%rsi, %r12
+               	addq	%rbx, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %r11
+               	cmpq	%rbx, %r11
+               	jb	 <L2>
+               	movq	%rdx, %r13
+               	jmp	 <L7>
+<L2>:
+               	movq	%rbx, %rdi
+               	subq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	addq	$0x1, %rsi
+               	callq	 <L3>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L9>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	subq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	movq	%rbx, %rdi
+               	movq	%rax, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r13
+<L7>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r12, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
+               	movq	%r13, %rax
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_recursive.tail>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x28(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	%rdi, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r12, %r13
+               	leaq	(%rax,%rbx,8), %r12
+               	movq	%r13, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	movq	%rdx, %r12
+               	cmpq	$0x4, %rbx
+               	jb	 <L2>
+               	jmp	 <L5>
+<L2>:
+               	leaq	(%rax,%rbx,8), %rdx
+               	movq	(%rdx), %r13
+               	movq	%r12, %rdx
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r12
+               	cmpq	$0x4, %rbx
+               	jb	 <L2>
+<L5>:
+               	cmpq	$0x0, %rdi
+               	je	 <L7>
+               	subq	$0x1, %rdi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x5, %rax, %rax
+               	addq	$0x3, %rax
+               	movq	%rax, %rsi
+               	movq	%r12, %rdx
+               	callq	 <L6>
+<L6>:
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13
@@ -246,403 +579,13 @@ Disassembly of section __TEXT,__text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-
-<corpus.cases.call.call_recursive.tree>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0xa0, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%r12, -0x80(%rbp)
-               	movq	%r13, -0x88(%rbp)
-               	movq	%r14, -0x90(%rbp)
-               	movq	%r15, -0x98(%rbp)
-               	movq	%rdi, %rbx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	movq	%rsi, %r12
-               	addq	%rbx, %r12
-               	movq	%rdx, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L0>
-<L0>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L1>
-               	movq	%rax, %r13
-               	jmp	 <L41>
-<L1>:
-               	movq	%rbx, %r14
-               	subq	$0x1, %r14
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r15
-               	addq	%r14, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	$0x0, %r11
-               	cmpq	%r14, %r11
-               	jb	 <L3>
-               	movq	%rax, %r8
-               	movq	%r8, -0x58(%rbp)
-               	jmp	 <L19>
-<L3>:
-               	movq	%r14, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	%r15, %rsi
-               	addq	$0x1, %rsi
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	movq	-0x50(%rbp), %r9
-               	movq	%rsi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	-0x50(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L5>
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-               	jmp	 <L9>
-<L5>:
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
 <L7>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-<L9>:
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L11>
-<L11>:
-               	subq	$0x1, %r14
-               	movq	%r15, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rdx
-               	movq	%rdx, %r8
-               	addq	%r14, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	$0x0, %r11
-               	cmpq	%r14, %r11
-               	jb	 <L13>
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	jmp	 <L17>
-<L13>:
-               	subq	$0x1, %r14
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%r14, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	%r14, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-<L17>:
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x58(%rbp)
-<L19>:
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L21>
-<L21>:
-               	subq	$0x1, %rbx
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L23>
-               	movq	%rax, %r15
-               	jmp	 <L39>
-<L23>:
-               	movq	%rbx, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	%r14, %rdx
-               	addq	$0x1, %rdx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rdx
-               	movq	-0x60(%rbp), %r9
-               	movq	%rdx, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x60(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L25>
-               	movq	%rax, %r8
-               	movq	%r8, -0x38(%rbp)
-               	jmp	 <L29>
-<L25>:
-               	movq	-0x60(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x38(%rbp)
-<L29>:
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L31>
-<L31>:
-               	subq	$0x1, %rbx
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L33>
-               	movq	%rax, %r8
-               	movq	%r8, -0x68(%rbp)
-               	jmp	 <L37>
-<L33>:
-               	subq	$0x1, %rbx
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rbx, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	%rbx, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x68(%rbp)
-<L37>:
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r15
-<L39>:
-               	movq	%r15, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r13
-<L41>:
-               	movq	%r13, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %r12
-               	movq	-0x88(%rbp), %r13
-               	movq	-0x90(%rbp), %r14
-               	movq	-0x98(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_recursive.tail>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	leaq	-0x20(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, 0x18(%r13)
-               	movq	$0x0, %rax
-               	cmpq	$0x4, %rax
-               	jb	 <L0>
-               	jmp	 <L1>
-<L0>:
-               	movq	%rax, %rcx
-               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
-               	imulq	%r11, %rcx
-               	addq	%rbx, %rcx
-               	movq	%r12, %rsi
-               	xorq	%rcx, %rsi
-               	leaq	(%r13,%rax,8), %rcx
-               	movq	%rsi, (%rcx)
-               	addq	$0x1, %rax
-               	cmpq	$0x4, %rax
-               	jb	 <L0>
-<L1>:
-               	movq	$0x0, %r14
-               	movq	%rdx, %r15
-               	cmpq	$0x4, %r14
-               	jb	 <L2>
-               	jmp	 <L4>
-<L2>:
-               	leaq	(%r13,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r15, %rdi
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r15
-               	cmpq	$0x4, %r14
-               	jb	 <L2>
-<L4>:
-               	cmpq	$0x0, %rbx
-               	je	 <L6>
-               	subq	$0x1, %rbx
-               	imulq	$0x5, %r12, %r12
-               	addq	$0x3, %r12
-               	movq	%rbx, %rdi
-               	movq	%r12, %rsi
-               	movq	%r15, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-<L6>:
-               	movq	%r15, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r12, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -742,130 +685,178 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_recursive.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x30(%rbp), %r12
+               	leaq	-0x48(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
                	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
+               	leaq	(%r12,%rax,8), %rsi
                	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
                	movq	$0x28, %rdi
                	addq	%rbx, %rdi
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
+               	movq	$0x21, %r13
+               	addq	%rbx, %r13
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%r13, %rdi
                	movq	%rax, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	$0x21, %r13
-               	addq	%rbx, %r13
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x10(%r12), %rdx
+               	movq	(%rdx), %rsi
                	movq	%r13, %rdi
                	movq	%rax, %rdx
                	callq	 <L4>
 <L4>:
-               	leaq	0x10(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%r13, %rdi
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	movq	$0x8, %rdi
                	movq	%rax, %rdx
                	callq	 <L5>
 <L5>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	movq	$0x8, %rdi
-               	movq	%rdx, %rsi
+               	movq	$0x30, %rdi
+               	addq	%rbx, %rdi
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdx
                	callq	 <L6>
 <L6>:
-               	movq	$0x30, %rdi
-               	addq	%rbx, %rdi
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdx
-               	callq	 <L7>
-<L7>:
                	movq	$0x18, %r13
                	addq	%rbx, %r13
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L8>
-               	jmp	 <L13>
-<L8>:
+               	jb	 <L7>
+               	jmp	 <L15>
+<L7>:
                	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x48(%rbp), %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	-0x50(%rbp), %r8
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r13, %rsi
-               	movq	%rcx, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	-0x50(%rbp), %r8
-               	movq	-0x50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	-0x50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
+               	callq	 <L8>
+<L8>:
+               	movq	-0x68(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r8
                	movq	%r8, -0x60(%rbp)
-               	movq	%r14, %rdi
-               	callq	 <L10>
-<L10>:
+               	movq	-0x68(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x68(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
                	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x58(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
 <L12>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L8>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L13>
+<L14>:
+               	addq	$0x1, %r15
+               	movq	%rdx, %r14
+               	cmpq	$0x4, %r15
+               	jb	 <L7>
+<L15>:
                	movq	%r14, %rax
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x78(%rbp), %rbx
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_ret_large.dis
+++ b/test/golden/x86_64-darwin/call/call_ret_large.dis
@@ -14,44 +14,134 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold20>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r15, -0x28(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movl	(%rdx), %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movl	(%rdx), %ebx
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movl	(%rdx), %r12d
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movl	(%rdx), %r13d
-               	leaq	0x10(%rcx), %rdx
-               	movl	(%rdx), %r14d
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%ebx, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L4>
+               	movl	%r12d, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%r13d, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -59,28 +149,81 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -88,26 +231,80 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold24f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movsd	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movsd	(%rdx), %xmm2
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -119,32 +316,101 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r14, -0x20(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r12
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r13
-               	callq	 <L0>
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -152,50 +418,68 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold40m>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	0x14(%rax), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x18(%rax), %rdx
                	movq	(%rdx), %r11
                	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movl	(%rdx), %ebx
-               	leaq	0x14(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	leaq	0x20(%rcx), %rdx
+               	leaq	0x20(%rax), %rdx
                	movq	(%rdx), %r13
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %r14
+               	xorq	%rdx, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
+               	movq	%xmm0, %rsi
                	callq	 <L2>
 <L2>:
+               	movl	%ebx, %esi
                	movq	%rax, %rdi
-               	movl	%r12d, %esi
                	callq	 <L3>
 <L3>:
+               	movl	%r12d, %esi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
+               	movq	%rax, %rdi
+               	movq	%r13, %rsi
+               	callq	 <L6>
+<L6>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -256,54 +540,62 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.fold_nest>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
-               	leaq	0x8(%rcx), %rdx
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r13
-               	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r14
-               	leaq	0x20(%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r15
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	-0x30(%rbp), %rbx
+               	movq	(%rax), %rcx
+               	movq	0x8(%rax), %rdx
+               	movq	0x10(%rax), %rsi
+               	movq	0x18(%rax), %r12
+               	movq	0x20(%rax), %r13
+               	movq	0x28(%rax), %r14
+               	movq	%rcx, (%rbx)
+               	movq	%rdx, 0x8(%rbx)
+               	movq	%rsi, 0x10(%rbx)
+               	movq	%r12, 0x18(%rbx)
+               	movq	%r13, 0x20(%rbx)
+               	movq	%r14, 0x28(%rbx)
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
                	callq	 <L0>
 <L0>:
+               	leaq	0x8(%rbx), %rcx
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rdi
+               	movq	0x10(%rcx), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	(%rdx), %rcx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rcx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
                	callq	 <L1>
 <L1>:
+               	leaq	0x20(%rbx), %r12
+               	leaq	(%r12), %rcx
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L2>
 <L2>:
+               	leaq	0x8(%r12), %rcx
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movq	%r14, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -913,38 +1205,45 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.take_two>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
-               	movq	%r14, -0x50(%rbp)
-               	movq	%r15, -0x58(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x40(%rbp), %rdx
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	0x40(%rbp), %rcx
                	movq	%rdi, %rbx
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %r12
-               	leaq	0x8(%rcx), %rsi
-               	movq	(%rsi), %r13
-               	leaq	0x10(%rcx), %rsi
-               	movq	(%rsi), %r14
-               	leaq	0x18(%rcx), %rsi
-               	movq	(%rsi), %r15
-               	leaq	0x20(%rcx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x8(%rbp)
-               	leaq	0x28(%rcx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x20(%rbp)
-               	leaq	(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x10(%rbp)
-               	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x18(%rbp)
-               	leaq	0x10(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x28(%rbp)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x38(%rbp)
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %r13
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %r14
+               	leaq	0x20(%rax), %rdx
+               	movq	(%rdx), %r15
+               	leaq	0x28(%rax), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x50(%rbp)
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	(%rcx), %rdi
+               	movq	0x8(%rcx), %rsi
+               	movq	0x10(%rcx), %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x48(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x48(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x48(%rbp), %r8
+               	movq	-0x40(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -964,39 +1263,38 @@ Disassembly of section __TEXT,__text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
+               	leaq	-0x30(%rbp), %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x48(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x48(%rbp), %r8
+               	movq	0x10(%r8), %r12
+               	movq	%rsi, (%rcx)
+               	movq	%rdi, 0x8(%rcx)
+               	movq	%r12, 0x10(%rcx)
+               	movq	(%rcx), %rdx
+               	movq	0x8(%rcx), %rsi
+               	movq	0x10(%rcx), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	-0x38(%rbp), %rbx
-               	movq	-0x40(%rbp), %r12
-               	movq	-0x48(%rbp), %r13
-               	movq	-0x50(%rbp), %r14
-               	movq	-0x58(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1004,18 +1302,19 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x790, %rsp            ## imm = 0x790
-               	movq	%rbx, -0x738(%rbp)
-               	movq	%r12, -0x740(%rbp)
-               	movq	%r13, -0x748(%rbp)
-               	movq	%r14, -0x750(%rbp)
-               	movq	%r15, -0x758(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x508(%rbp)
+               	subq	$0xa80, %rsp            ## imm = 0xA80
+               	movq	%rbx, -0xa28(%rbp)
+               	movq	%r12, -0xa30(%rbp)
+               	movq	%r13, -0xa38(%rbp)
+               	movq	%r14, -0xa40(%rbp)
+               	movq	%r15, -0xa48(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x14, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movq	$0x14, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
@@ -1023,15 +1322,15 @@ Disassembly of section __TEXT,__text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x30, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
@@ -1039,18 +1338,14 @@ Disassembly of section __TEXT,__text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x30, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	$0x20, %rsi
-               	callq	 <L9>
-<L9>:
-               	leaq	-0x1c0(%rbp), %r12
+               	leaq	-0x2d8(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -1059,119 +1354,197 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-               	jmp	 <L11>
-<L10>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x508(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-<L11>:
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L12>
-               	jmp	 <L51>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L57>
+<L11>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x508(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
                	movl	%r15d, %eax
-               	movq	%r15, %rcx
-               	shrq	$0x8, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x610(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4a8(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x18, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4b0(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4b8(%rbp)
-               	movq	%r13, %rdi
-               	movl	%eax, %esi
-               	callq	 <L13>
+               	movq	%r15, %rdx
+               	shrq	$0x8, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x650(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x10, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x648(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x18, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x638(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x20, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x640(%rbp)
+               	movl	%eax, %r8d
+               	movq	%r8, -0x658(%rbp)
+               	movq	%r13, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x658(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x610(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L14>
+               	movq	-0x650(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x660(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x4a8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x660(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x4b0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
+               	movq	-0x648(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x668(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movq	-0x4b8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L17>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x668(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movq	%r15, %r8
-               	movq	%r8, -0x618(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x618(%rbp)
+               	movq	-0x638(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x670(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x640(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	%rax, %r8
+               	movq	%r8, -0x678(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x678(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	-0x390(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
                	movq	%r15, %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	%rdx, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x4c0(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x618(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x4c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           ## imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L21>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L22>
 <L22>:
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x2c6>
-               	movq	%r15, %rcx
-               	andq	$0xfff, %rcx            ## imm = 0xFFF
-               	movq	%rcx, %r11
+               	movq	%r15, %rdx
+               	andq	$0xffff, %rdx           ## imm = 0xFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
@@ -1184,12 +1557,11 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L24>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	subsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x30a>
-               	movsd	%xmm14, -0x628(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          ## imm = 0x3FFFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x475>
+               	movq	%r15, %rdx
+               	andq	$0xfff, %rdx            ## imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
@@ -1202,76 +1574,127 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L26>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x357>
-               	movsd	%xmm14, -0x638(%rbp)
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movsd	-0x628(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0x638(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%r15, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x640(%rbp)
-               	movq	%r15, %r8
-               	imulq	$0x5, %r8, %r8
-               	movq	%r8, -0x648(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x640(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x648(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movq	-0x4c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%r15, %rcx
-               	andq	$0x1fff, %rcx           ## imm = 0x1FFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_ret_large.checksum+0x4b7>
+               	movq	%r15, %rdx
+               	andq	$0x3ffff, %rdx          ## imm = 0x3FFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L34>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L35>
-<L34>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
+<L28>:
+               	movsd	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.call.call_ret_large.checksum+0x4f9>
+               	movq	%xmm1, %r8
+               	movq	%r8, -0x680(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	%xmm2, %r8
+               	movq	%r8, -0x688(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x688(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+<L32>:
+               	movq	%xmm3, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x690(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L33>
+<L34>:
+               	leaq	-0x4a0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x18(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x698(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L35>
 <L35>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x442>
-               	movsd	%xmm14, -0x658(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0x660(%rbp)
                	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x4d0(%rbp)
-               	movq	%r15, %rdx
-               	andq	$0x1ffff, %rdx          ## imm = 0x1FFFF
+               	andq	$0x1fff, %rdx           ## imm = 0x1FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L36>
@@ -1285,95 +1708,1053 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L37>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x6ea>
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x980(%rbp)
+               	movq	%r15, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x6a0(%rbp)
+               	movq	%r15, %rsi
+               	andq	$0x1ffff, %rsi          ## imm = 0x1FFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L38>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L39>
+<L38>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L39>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x4aa>
-               	movsd	%xmm14, -0x670(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x749>
+               	movsd	%xmm14, -0x990(%rbp)
                	movq	%r15, %r8
                	imulq	$0x7, %r8, %r8
-               	movq	%r8, -0x678(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movsd	-0x658(%rbp), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movq	-0x660(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L40>
+               	movq	%r8, -0x6a8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0x4d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L41>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rdi
-               	movsd	-0x670(%rbp), %xmm0
+               	movq	%xmm1, %rsi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L42>
 <L42>:
+               	movq	-0x980(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0x678(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
-               	movq	%r15, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x680(%rbp)
-               	movq	%r15, %r8
-               	addq	$0x2, %r8
-               	movq	%r8, -0x688(%rbp)
-               	movq	%r15, %r8
-               	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x4d8(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	movq	%r15, %r8
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %r8
-               	movq	%r8, -0x4e8(%rbp)
+               	movq	-0x6a0(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
                	callq	 <L44>
 <L44>:
+               	movq	-0x990(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x680(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rdi
-               	movq	-0x688(%rbp), %r8
+               	movq	-0x6a8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
+               	movq	%r15, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x998(%rbp)
+               	movq	%r15, %r8
+               	addq	$0x2, %r8
+               	movq	%r8, -0x6b8(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x9, %r8, %r8
+               	movq	%r8, -0x6c0(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	xorq	$-0x1, %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	movq	%r15, %r8
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %r8
+               	movq	%r8, -0x6d0(%rbp)
                	movq	%rax, %rdi
-               	movq	-0x4d8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r15, %rsi
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rdi
-               	movq	-0x4e0(%rbp), %r8
+               	movq	-0x998(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rdi
-               	movq	-0x4e8(%rbp), %r8
+               	movq	-0x6b8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
+               	movq	%rax, %rdi
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %rdi
+               	movq	-0x6c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L51>
+<L51>:
+               	movq	%rax, %rdi
+               	movq	-0x6d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %r8
-               	movq	%r8, -0x4f0(%rbp)
-               	movq	-0x4f0(%rbp), %r8
-               	leaq	-0x478(%rbp), %r8
-               	movq	%r8, -0x4f8(%rbp)
-               	movl	%r15d, %edx
-               	movq	-0x4f8(%rbp), %r8
+               	movq	%r8, -0x6d8(%rbp)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	-0x5c0(%rbp), %r8
+               	movq	%r8, -0x6e0(%rbp)
+               	movl	%r15d, %esi
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%esi, (%rdi)
+               	leaq	-0x5d8(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	%r15, (%rdi)
+               	movq	%r15, %rdi
+               	xorq	$-0x1, %rdi
+               	leaq	0x8(%rsi), %rax
+               	movq	%rdi, (%rax)
+               	movq	%r15, %rax
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	%rdi, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	movq	-0x6e8(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	leaq	-0x5e8(%rbp), %rax
+               	movq	%r15, %rdx
+               	imulq	$0xb, %rdx, %rdx
+               	leaq	(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	xorq	$-0x1, %r15
+               	leaq	0x8(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	leaq	-0x618(%rbp), %r15
+               	movq	-0x6e0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x10(%r8), %rsi
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x18(%r8), %rdi
+               	movq	-0x6e0(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x6e0(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x6f8(%rbp)
+               	movq	%rax, (%r15)
+               	movq	%rdx, 0x8(%r15)
+               	movq	%rsi, 0x10(%r15)
+               	movq	%rdi, 0x18(%r15)
+               	movq	-0x6f0(%rbp), %r8
+               	movq	%r8, 0x20(%r15)
+               	movq	-0x6f8(%rbp), %r8
+               	movq	%r8, 0x28(%r15)
+               	leaq	(%r15), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %esi
+               	movq	-0x6d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L53>
+<L53>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	leaq	0x8(%r15), %rdx
+               	leaq	-0x630(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %rax
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x708(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	%rax, 0x8(%rsi)
+               	movq	-0x708(%rbp), %r8
+               	movq	%r8, 0x10(%rsi)
+               	movq	(%rsi), %rax
+               	movq	0x8(%rsi), %rdx
+               	movq	0x10(%rsi), %rdi
+               	movq	%rax, (%rsp)
+               	movq	%rdx, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L54>
+<L54>:
+               	leaq	0x20(%r15), %r8
+               	movq	%r8, -0x9a0(%rbp)
+               	movq	-0x9a0(%rbp), %r8
                	leaq	(%r8), %rsi
-               	movl	%edx, (%rsi)
-               	leaq	-0x490(%rbp), %rdx
+               	movq	(%rsi), %r15
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L55>
+<L55>:
+               	movq	-0x9a0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L56>
+<L56>:
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L11>
+<L57>:
+               	leaq	-0x18(%rbp), %r14
+               	movq	%rbx, %rax
+               	addq	$0x1, %rax
+               	leaq	-0x1d0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	%rax, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L58>
+               	jmp	 <L60>
+<L58>:
+               	leaq	(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x718(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x720(%rbp)
+               	leaq	0x10(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x710(%rbp)
+               	leaq	(%r12,%r15,8), %rax
+               	movq	(%rax), %rdi
+               	leaq	-0x1e8(%rbp), %rax
+               	movq	-0x718(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%rdi, %rdx
+               	leaq	(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	-0x720(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rdi, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	-0x710(%rbp), %r8
+               	movq	-0x718(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	leaq	-0x200(%rbp), %rax
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %rsi
+               	movq	0x10(%r14), %rdi
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	%r13, %rdi
+               	callq	 <L59>
+<L59>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L58>
+<L60>:
+               	leaq	-0x48(%rbp), %r14
+               	movq	%rbx, %rax
+               	addq	$0x2, %rax
+               	leaq	-0x230(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	%rax, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %rax
+               	leaq	0x28(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x728(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x730(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	%r15, 0x18(%r14)
+               	movq	-0x728(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x730(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L61>
+               	jmp	 <L69>
+<L61>:
+               	leaq	-0x78(%rbp), %rax
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %rsi
+               	movq	0x10(%r14), %rdi
+               	movq	0x18(%r14), %r8
+               	movq	%r8, -0x738(%rbp)
+               	movq	0x20(%r14), %r8
+               	movq	%r8, -0x740(%rbp)
+               	movq	0x28(%r14), %r8
+               	movq	%r8, -0x748(%rbp)
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	-0x740(%rbp), %r8
+               	movq	%r8, 0x20(%rax)
+               	movq	-0x748(%rbp), %r8
+               	movq	%r8, 0x28(%rax)
+               	leaq	(%r12,%r15,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x750(%rbp)
+               	leaq	-0xa8(%rbp), %r8
+               	movq	%r8, -0x9a8(%rbp)
+               	movq	(%rax), %rdi
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x758(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x760(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x768(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x770(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	-0x758(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x760(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x768(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x770(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x750(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L62>
+<L62>:
+               	movq	-0x9a8(%rbp), %r8
+               	movq	-0x9a8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x9a8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x9a8(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x778(%rbp)
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	-0x778(%rbp), %r8
+               	movq	%r8, 0x18(%r14)
+               	movq	-0x780(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x788(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	leaq	(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9b0(%rbp)
+               	leaq	0x10(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x18(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0x20(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0x28(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x7a8(%rbp)
+               	movq	%r13, %rdi
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	movq	-0x9b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rdi
+               	movq	-0x790(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rdi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movq	-0x7a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rdi
+               	movq	-0x7a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L68>
+<L68>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L61>
+<L69>:
+               	leaq	-0x168(%rbp), %r14
+               	leaq	(%r14), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rdx
+<L70>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L70>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+               	jmp	 <L72>
+<L71>:
+               	movq	-0x7b0(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	leaq	-0x250(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rsi, %rdi
+               	addq	$0x1, %rdi
+               	leaq	0x8(%rdx), %r15
+               	movq	%rdi, (%r15)
+               	movq	%rsi, %rdi
+               	imulq	$0x5, %rdi, %rdi
+               	leaq	0x10(%rdx), %r15
+               	movq	%rdi, (%r15)
+               	xorq	$-0x1, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r14,%rsi), %rdi
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r15
+               	movq	0x10(%rdx), %rax
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x7b8(%rbp)
+               	movq	%rsi, (%rdi)
+               	movq	%r15, 0x8(%rdi)
+               	movq	%rax, 0x10(%rdi)
+               	movq	-0x7b8(%rbp), %r8
+               	movq	%r8, 0x18(%rdi)
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+<L72>:
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L73>
+               	jmp	 <L75>
+<L73>:
+               	movq	%r15, %rax
+               	imulq	$0x20, %rax, %rax
+               	leaq	(%r14,%rax), %rdx
+               	leaq	-0x188(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x7c8(%rbp)
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	movq	-0x7c8(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x7d0(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x7d0(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	%r13, %rdi
+               	callq	 <L74>
+<L74>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x6, %r15
+               	jb	 <L73>
+<L75>:
+               	leaq	-0x1b8(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	leaq	(%rax), %rdx
+               	movl	$0x12345678, (%rdx)     ## imm = 0x12345678
+               	movq	%rbx, %rdx
+               	addq	$0x3, %rdx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	xorq	$-0x1, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	%rdx, %rdi
+               	imulq	$0x3, %rdi, %rdi
+               	movq	%rdi, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	(%r12), %r14
+               	movq	(%r14), %r15
+               	leaq	-0x2f0(%rbp), %r14
+               	movq	%rdx, %rdi
+               	addq	%r15, %rdi
+               	leaq	(%r14), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%r15, %rsi
+               	leaq	0x8(%r14), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x7d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%rdx, %rsi
+               	leaq	0x10(%r14), %rdx
+               	movq	%rsi, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	(%r14), %rsi
+               	movq	0x8(%r14), %rdi
+               	movq	0x10(%r14), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r15, 0x10(%rdx)
+               	leaq	-0x300(%rbp), %rdx
+               	leaq	0x8(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	leaq	0x20(%rax), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r14
+               	movq	%rdi, (%rsi)
+               	movq	%r14, 0x8(%rsi)
+               	leaq	-0x330(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	0x10(%rax), %r14
+               	movq	0x18(%rax), %r15
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x7e8(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x7f0(%rbp)
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
+               	movq	%r15, 0x18(%rdx)
+               	movq	-0x7e8(%rbp), %r8
+               	movq	%r8, 0x20(%rdx)
+               	movq	-0x7f0(%rbp), %r8
+               	movq	%r8, 0x28(%rdx)
+               	leaq	-0x3c0(%rbp), %r14
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	%r15, 0x18(%r14)
+               	movq	-0x7f8(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x800(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	leaq	(%r14), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %esi
+               	movq	%r13, %rdi
+               	callq	 <L76>
+<L76>:
+               	leaq	0x8(%r14), %rdx
+               	leaq	-0x3d8(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r15
+               	movq	%rdi, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movq	%r15, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r13
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r13, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
+               	leaq	0x20(%r14), %r13
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L79>
+<L79>:
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x4, %r14
+               	jb	 <L80>
+               	jmp	 <L106>
+<L80>:
+               	leaq	(%r12,%r14,8), %rax
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
+               	leaq	-0x268(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	leaq	-0x298(%rbp), %r8
+               	movq	%r8, -0x9b8(%rbp)
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x808(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x808(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L81>
+<L81>:
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	-0x360(%rbp), %rax
+               	leaq	(%rax), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x378(%rbp), %r8
+               	movq	%r8, -0x9c0(%rbp)
+               	movq	(%rax), %rdi
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x818(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x820(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x828(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x830(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x810(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x818(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x820(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x828(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x830(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L82>
+<L82>:
+               	movq	-0x9c0(%rbp), %r8
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x838(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x840(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x848(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x850(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x20(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x858(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x28(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9d0(%rbp)
+               	leaq	-0x3f0(%rbp), %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	movq	-0x9c0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9c0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x860(%rbp)
+               	movq	-0x9c0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	-0x860(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	-0x868(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	-0x838(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L83>
+<L83>:
+               	movq	%rax, %rdi
+               	movq	-0x840(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L84>
+<L84>:
+               	movq	%rax, %rdi
+               	movq	-0x848(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L85>
+<L85>:
+               	movq	%rax, %rdi
+               	movq	-0x850(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L86>
+<L86>:
+               	movq	%rax, %rdi
+               	movq	-0x858(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L87>
+<L87>:
+               	movq	%rax, %rdi
+               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L88>
+<L88>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x870(%rbp)
+               	movq	-0x870(%rbp), %r8
+               	leaq	-0x408(%rbp), %rdx
+               	movq	-0x9c8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x9c8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x9c8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x878(%rbp)
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	-0x878(%rbp), %r8
+               	movq	%r8, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rax, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x870(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L90>
+<L90>:
+               	movq	%r13, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x9d8(%rbp)
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	-0x438(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x450(%rbp), %r8
+               	movq	%r8, -0x9e0(%rbp)
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x880(%rbp)
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x888(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x890(%rbp)
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x898(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x880(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x888(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x890(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x898(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L92>
+<L92>:
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	-0x480(%rbp), %r8
+               	movq	%r8, -0x9e8(%rbp)
+               	movq	-0x9e0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9e0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	-0x9e0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8a8(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8b0(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L93>
+<L93>:
+               	movq	-0x9e8(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	%rax, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L95>
+<L95>:
+               	movq	%rax, %rdi
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L96>
+<L96>:
+               	movq	%rax, %rdi
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L97>
+<L97>:
+               	movq	%rax, %rdi
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L98>
+<L98>:
+               	movq	%rax, %rdi
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L99>
+<L99>:
+               	movq	%rax, %r8
+               	movq	%r8, -0xa00(%rbp)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	-0x4b8(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movq	%r15, (%rsi)
                	movq	%r15, %rsi
@@ -1385,910 +2766,211 @@ Disassembly of section __TEXT,__text:
                	addq	$0x1, %rsi
                	leaq	0x10(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movq	-0x4f8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
+               	leaq	-0x4e8(%rbp), %r8
+               	movq	%r8, -0x9f8(%rbp)
                	movq	(%rdx), %rdi
-               	movq	0x8(%rdx), %rax
-               	movq	0x10(%rdx), %rcx
-               	movq	%rdi, (%rsi)
-               	movq	%rax, 0x8(%rsi)
-               	movq	%rcx, 0x10(%rsi)
-               	leaq	-0x4a0(%rbp), %rax
-               	movq	%r15, %rcx
-               	imulq	$0xb, %rcx, %rcx
-               	leaq	(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	xorq	$-0x1, %r15
-               	leaq	0x8(%rax), %rcx
-               	movq	%r15, (%rcx)
-               	movq	-0x4f8(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	-0x4f8(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x8(%r8), %rcx
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x10(%r8), %rdx
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x18(%r8), %rsi
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x20(%r8), %rdi
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x28(%r8), %r15
-               	movq	%rax, (%rsp)
-               	movq	%rcx, 0x8(%rsp)
-               	movq	%rdx, 0x10(%rsp)
-               	movq	%rsi, 0x18(%rsp)
-               	movq	%rdi, 0x20(%rsp)
-               	movq	%r15, 0x28(%rsp)
-               	movq	-0x4f0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L50>
-<L50>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x8, %r14
-               	jb	 <L12>
-<L51>:
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rax, %rdx
-               	imulq	$0x3, %rdx, %rdx
-               	addq	$0x1, %rdx
-               	movq	$0x0, %r14
-               	movq	%rax, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x698(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x6a0(%rbp)
-               	cmpq	$0x8, %r14
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
-               	leaq	(%r12,%r14,8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%r15, %r8
-               	addq	%rsi, %r8
-               	movq	%r8, -0x690(%rbp)
-               	movq	-0x698(%rbp), %r9
-               	movq	%r9, %r8
-               	xorq	%rsi, %r8
-               	movq	%r8, -0x500(%rbp)
-               	movq	-0x6a0(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	%r15, %rbx
-               	movq	%r13, %rdi
-               	movq	-0x690(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	-0x500(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-               	addq	$0x1, %r14
-               	movq	%rsi, %r13
-               	movq	-0x690(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	-0x500(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x698(%rbp)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x6a0(%rbp)
-               	cmpq	$0x8, %r14
-               	jb	 <L52>
-<L56>:
-               	leaq	-0x30(%rbp), %rbx
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x2, %rax
-               	leaq	-0x1f0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	%rax, %rdx
-               	addq	$0x1, %rdx
-               	leaq	0x8(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	addq	$0x2, %rdx
-               	leaq	0x10(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	imulq	$0x9, %rdx, %rdx
-               	leaq	0x18(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	xorq	$-0x1, %rdx
-               	leaq	0x20(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %rdi
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	%rax, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movq	%rsi, 0x10(%rbx)
-               	movq	%rdi, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
-               	movq	%r15, 0x28(%rbx)
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
-               	jb	 <L57>
-               	jmp	 <L65>
-<L57>:
-               	leaq	-0x60(%rbp), %rax
-               	movq	(%rbx), %rcx
-               	movq	0x8(%rbx), %rdx
-               	movq	0x10(%rbx), %rsi
-               	movq	0x18(%rbx), %rdi
-               	movq	0x20(%rbx), %r15
-               	movq	0x28(%rbx), %r8
-               	movq	%r8, -0x510(%rbp)
-               	movq	%rcx, (%rax)
-               	movq	%rdx, 0x8(%rax)
-               	movq	%rsi, 0x10(%rax)
-               	movq	%rdi, 0x18(%rax)
-               	movq	%r15, 0x20(%rax)
-               	movq	-0x510(%rbp), %r8
-               	movq	%r8, 0x28(%rax)
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x518(%rbp)
-               	leaq	-0x90(%rbp), %r15
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %rsi
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x520(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x528(%rbp)
-               	movq	%rcx, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	%rsi, 0x18(%rsp)
-               	movq	-0x520(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x528(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	%r15, %rdi
-               	movq	-0x518(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	(%r15), %rax
-               	movq	0x8(%r15), %rcx
-               	movq	0x10(%r15), %rdx
-               	movq	0x18(%r15), %rsi
-               	movq	0x20(%r15), %rdi
-               	movq	0x28(%r15), %r8
-               	movq	%r8, -0x530(%rbp)
-               	movq	%rax, (%rbx)
-               	movq	%rcx, 0x8(%rbx)
-               	movq	%rdx, 0x10(%rbx)
-               	movq	%rsi, 0x18(%rbx)
-               	movq	%rdi, 0x20(%rbx)
-               	movq	-0x530(%rbp), %r8
-               	movq	%r8, 0x28(%rbx)
-               	leaq	(%rbx), %rax
-               	movq	(%rax), %rsi
-               	leaq	0x8(%rbx), %rax
-               	movq	(%rax), %r15
-               	leaq	0x10(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6a8(%rbp)
-               	leaq	0x18(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6b0(%rbp)
-               	leaq	0x20(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x538(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x540(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	-0x6a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movq	-0x6b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	-0x538(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movq	-0x540(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L64>
-<L64>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x8, %r14
-               	jb	 <L57>
-<L65>:
-               	leaq	-0x150(%rbp), %rbx
-               	leaq	(%rbx), %rax
-               	addq	$0x0, %rax
-               	movq	$0xc0, %rcx
-<L66>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L66>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x508(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0x210(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rdx, %rsi
-               	addq	$0x1, %rsi
-               	leaq	0x8(%rcx), %rdi
-               	movq	%rsi, (%rdi)
-               	movq	%rdx, %rsi
-               	imulq	$0x5, %rsi, %rsi
-               	leaq	0x10(%rcx), %rdi
-               	movq	%rsi, (%rdi)
-               	xorq	$-0x1, %rdx
-               	leaq	0x18(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	imulq	$0x20, %rdx, %rdx
-               	leaq	(%rbx,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r14
-               	movq	0x18(%rcx), %r15
-               	movq	%rdx, (%rsi)
-               	movq	%rdi, 0x8(%rsi)
-               	movq	%r14, 0x10(%rsi)
-               	movq	%r15, 0x18(%rsi)
-               	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-<L68>:
-               	movq	$0x0, %r14
-               	cmpq	$0x6, %r14
-               	jb	 <L69>
-               	jmp	 <L74>
-<L69>:
-               	movq	%r14, %rax
-               	imulq	$0x20, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movq	(%rax), %rsi
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r15
-               	leaq	0x10(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6b8(%rbp)
-               	leaq	0x18(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6c0(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movq	-0x6b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x6, %r14
-               	jb	 <L69>
-<L74>:
-               	leaq	-0x180(%rbp), %rax
-               	movq	$0x0, (%rax)
-               	movq	$0x0, 0x8(%rax)
-               	movq	$0x0, 0x10(%rax)
-               	movq	$0x0, 0x18(%rax)
-               	movq	$0x0, 0x20(%rax)
-               	movq	$0x0, 0x28(%rax)
-               	leaq	(%rax), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rdx
-               	xorq	$-0x1, %rdx
-               	movq	%rcx, %rsi
-               	imulq	$0x3, %rsi, %rsi
-               	addq	$0x1, %rsi
-               	leaq	(%r12), %rdi
-               	movq	(%rdi), %rbx
-               	leaq	-0x270(%rbp), %rdi
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	leaq	(%rdi), %r15
-               	movq	%r14, (%r15)
-               	xorq	%rbx, %rdx
-               	leaq	0x8(%rdi), %rbx
-               	movq	%rdx, (%rbx)
-               	addq	%rcx, %rsi
-               	leaq	0x10(%rdi), %rcx
-               	movq	%rsi, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rdi), %rdx
-               	movq	0x8(%rdi), %rsi
-               	movq	0x10(%rdi), %rbx
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%rbx, 0x10(%rcx)
-               	leaq	-0x280(%rbp), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%rcx), %rdx
-               	movq	%rsi, (%rdx)
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	%rsi, (%rdx)
-               	leaq	0x20(%rax), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	leaq	-0x2b0(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %rbx
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%rdi, 0x10(%rcx)
-               	movq	%rbx, 0x18(%rcx)
-               	movq	%r14, 0x20(%rcx)
-               	movq	%r15, 0x28(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %rdi
-               	movq	0x20(%rcx), %rbx
-               	movq	0x28(%rcx), %r14
-               	movq	%rax, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rsi, 0x10(%rsp)
-               	movq	%rdi, 0x18(%rsp)
-               	movq	%rbx, 0x20(%rsp)
-               	movq	%r14, 0x28(%rsp)
-               	movq	%r13, %rdi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L76>
-               	jmp	 <L109>
-<L76>:
-               	leaq	(%r12,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x508(%rbp), %r8
-               	movq	%rcx, %r14
-               	addq	%r8, %r14
-               	leaq	-0x228(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x258(%rbp), %r15
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	%rcx, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rsi, 0x10(%rsp)
-               	movq	%r15, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	-0x2e0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x2f8(%rbp), %r8
-               	movq	%r8, -0x6c8(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x548(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x550(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x558(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x548(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x550(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x558(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x6c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6d0(%rbp)
-               	leaq	0x8(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x560(%rbp)
-               	leaq	0x10(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x568(%rbp)
-               	leaq	0x18(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x570(%rbp)
-               	leaq	0x20(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x578(%rbp)
-               	leaq	0x28(%r15), %rax
-               	movq	(%rax), %r15
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x580(%rbp)
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x588(%rbp)
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6d8(%rbp)
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x6d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movq	-0x560(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movq	-0x568(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movq	-0x570(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-               	movq	-0x578(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L84>
-<L84>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rdi
-               	movq	-0x580(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %rdi
-               	movq	-0x588(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rdi
-               	movq	-0x6d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L89>
-<L89>:
-               	movq	%rbx, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L90>
-<L90>:
-               	movq	%rax, %r15
-               	leaq	-0x328(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x6e0(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x590(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x598(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x5a0(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x590(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x598(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x5a0(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x6e0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	-0x6e0(%rbp), %r8
-               	leaq	-0x370(%rbp), %r8
-               	movq	%r8, -0x6e8(%rbp)
-               	movq	-0x6e0(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x6e0(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x6e0(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x6e8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x6e8(%rbp), %r8
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x6f0(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5a8(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5b0(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5b8(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x28(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x6f8(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %rdi
-               	movq	-0x6f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %rdi
-               	movq	-0x5a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %rdi
-               	movq	-0x5b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rdi
-               	movq	-0x5b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %rdi
-               	movq	-0x6f8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r15
-               	leaq	-0x388(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x3b8(%rbp), %r8
-               	movq	%r8, -0x700(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x700(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	-0x700(%rbp), %r8
-               	leaq	-0x3d0(%rbp), %r8
-               	movq	%r8, -0x708(%rbp)
-               	movq	-0x700(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x700(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x700(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	-0x700(%rbp), %r9
-               	movq	0x18(%r9), %r8
-               	movq	%r8, -0x5c0(%rbp)
-               	movq	-0x700(%rbp), %r9
-               	movq	0x20(%r9), %r8
-               	movq	%r8, -0x5c8(%rbp)
-               	movq	-0x700(%rbp), %r9
-               	movq	0x28(%r9), %r8
-               	movq	%r8, -0x5d0(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5c0(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x5c8(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x5d0(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x708(%rbp), %r8
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8e8(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9f8(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L100>
 <L100>:
-               	movq	-0x708(%rbp), %r8
-               	movq	-0x708(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x708(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x710(%rbp)
-               	movq	-0x708(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x718(%rbp)
-               	movq	%r15, %rdi
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	-0x500(%rbp), %r8
+               	movq	%r8, -0xa08(%rbp)
+               	movq	-0x9f8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x910(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8f0(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8f8(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x908(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x910(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0xa08(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L101>
 <L101>:
-               	movq	%rax, %rdi
-               	movq	-0x710(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa08(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xa08(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xa08(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x918(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x918(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0xa00(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L102>
 <L102>:
-               	movq	%rax, %rdi
-               	movq	-0x718(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xa10(%rbp)
+               	movq	-0xa10(%rbp), %r8
+               	leaq	-0x530(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x560(%rbp), %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x930(%rbp)
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x938(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x940(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x928(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x930(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x938(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x940(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x920(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
                	callq	 <L103>
 <L103>:
-               	movq	%rax, %r15
-               	leaq	-0x400(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       ## imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x430(%rbp), %r8
-               	movq	%r8, -0x720(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x5d8(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x5e0(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x5e8(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5d8(%rbp), %r8
+               	movq	-0x920(%rbp), %r8
+               	leaq	-0x578(%rbp), %r8
+               	movq	%r8, -0xa18(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x920(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x920(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x948(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x958(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x960(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x948(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x950(%rbp), %r8
                	movq	%r8, 0x18(%rsp)
-               	movq	-0x5e0(%rbp), %r8
+               	movq	-0x958(%rbp), %r8
                	movq	%r8, 0x20(%rsp)
-               	movq	-0x5e8(%rbp), %r8
+               	movq	-0x960(%rbp), %r8
                	movq	%r8, 0x28(%rsp)
-               	movq	-0x720(%rbp), %r8
+               	movq	-0xa18(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%r14, %rsi
                	callq	 <L104>
 <L104>:
-               	movq	-0x720(%rbp), %r8
-               	leaq	-0x448(%rbp), %r8
-               	movq	%r8, -0x728(%rbp)
-               	movq	-0x720(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x720(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x720(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	-0x720(%rbp), %r9
-               	movq	0x18(%r9), %r8
-               	movq	%r8, -0x5f0(%rbp)
-               	movq	-0x720(%rbp), %r9
-               	movq	0x20(%r9), %r8
-               	movq	%r8, -0x5f8(%rbp)
-               	movq	-0x720(%rbp), %r9
-               	movq	0x28(%r9), %r8
-               	movq	%r8, -0x600(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x968(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x978(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x970(%rbp)
+               	leaq	-0x590(%rbp), %rsi
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%r15, %rdx
+               	leaq	(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	-0x978(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%r15, %rdx
+               	leaq	0x8(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	-0x970(%rbp), %r8
+               	movq	-0x968(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	leaq	0x10(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r15
                	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5f0(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x5f8(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x600(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x728(%rbp), %r8
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r15, 0x10(%rsp)
+               	movq	-0xa10(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L105>
 <L105>:
-               	movq	-0x728(%rbp), %r8
-               	movq	-0x728(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x728(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x728(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %rax
-               	movq	%rdx, %rcx
-               	addq	%r14, %rcx
-               	movq	%rsi, %r8
-               	xorq	%r14, %r8
-               	movq	%r8, -0x608(%rbp)
-               	movq	%rax, %r14
-               	addq	%rdx, %r14
-               	movq	%r15, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L106>
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x4, %r14
+               	jb	 <L80>
 <L106>:
-               	movq	%rax, %rdi
-               	movq	-0x608(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L108>
-<L108>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	cmpq	$0x4, %r13
-               	jb	 <L76>
-<L109>:
-               	movq	%rbx, %rax
-               	movq	-0x738(%rbp), %rbx
-               	movq	-0x740(%rbp), %r12
-               	movq	-0x748(%rbp), %r13
-               	movq	-0x750(%rbp), %r14
-               	movq	-0x758(%rbp), %r15
+               	movq	%r13, %rax
+               	movq	-0xa28(%rbp), %rbx
+               	movq	-0xa30(%rbp), %r12
+               	movq	-0xa38(%rbp), %r13
+               	movq	-0xa40(%rbp), %r14
+               	movq	-0xa48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_ret_small.dis
+++ b/test/golden/x86_64-darwin/call/call_ret_small.dis
@@ -292,19 +292,57 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x4(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0x4(%rbp), %rax
+               	movl	(%rax), %esi
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -313,18 +351,58 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	-0x4(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0x18(%rbp)
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movss	(%rax), %xmm0
+               	leaq	-0x4(%rbp), %rax
+               	movss	(%rax), %xmm1
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x18(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movd	%xmm1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -332,30 +410,85 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.fold12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -365,19 +498,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -386,19 +556,57 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movsd	%xmm1, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm1
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -407,19 +615,56 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -429,19 +674,57 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rdx
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -449,19 +732,31 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x1, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x2, %rsi
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -469,11 +764,11 @@ Disassembly of section __TEXT,__text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0xc, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0xc, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
@@ -488,6 +783,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x10, %rsi
                	callq	 <L9>
 <L9>:
+               	movq	%rax, %rdi
+               	movq	$0x10, %rsi
+               	callq	 <L10>
+<L10>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -495,12 +794,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.regain>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x130, %rsp            ## imm = 0x130
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%r15, -0x128(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x8(%rbp)
                	movsd	%xmm0, -0x20(%rbp)
@@ -511,102 +810,96 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x38(%rbp)
                	movq	%r9, -0x48(%rbp)
                	movsd	%xmm3, -0x50(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	leaq	-0x20(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x70(%rbp)
-               	leaq	-0x18(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x80(%rbp)
-               	leaq	-0x30(%rbp), %rcx
-               	movq	(%rcx), %r13
-               	leaq	-0x28(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x90(%rbp)
-               	leaq	-0x40(%rbp), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	-0x3c(%rbp), %rcx
-               	movl	(%rcx), %r15d
-               	leaq	-0x38(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x98(%rbp)
-               	leaq	-0x48(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x58(%rbp)
-               	leaq	-0x44(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x60(%rbp)
-               	leaq	-0x50(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0xa8(%rbp)
-               	leaq	-0x4c(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0xb8(%rbp)
+               	leaq	-0x60(%rbp), %rax
+               	movq	-0x10(%rbp), %rcx
+               	movq	-0x8(%rbp), %rdx
+               	movq	%rcx, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	leaq	-0x70(%rbp), %rbx
+               	movq	-0x20(%rbp), %rcx
+               	movq	-0x18(%rbp), %rdx
+               	movq	%rcx, (%rbx)
+               	movq	%rdx, 0x8(%rbx)
+               	leaq	-0x80(%rbp), %r12
+               	movq	-0x30(%rbp), %rcx
+               	movq	-0x28(%rbp), %rdx
+               	movq	%rcx, (%r12)
+               	movq	%rdx, 0x8(%r12)
+               	leaq	-0x8c(%rbp), %r13
+               	movq	-0x40(%rbp), %rcx
+               	movl	-0x38(%rbp), %edx
+               	movq	%rcx, (%r13)
+               	movl	%edx, 0x8(%r13)
+               	leaq	-0x94(%rbp), %r14
+               	movq	-0x48(%rbp), %rcx
+               	movq	%rcx, (%r14)
+               	leaq	-0x9c(%rbp), %r15
+               	movq	-0x50(%rbp), %rcx
+               	movq	%rcx, (%r15)
+               	leaq	-0xb0(%rbp), %rcx
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	leaq	-0xc0(%rbp), %rcx
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movsd	(%rcx), %xmm0
+               	movsd	0x8(%rcx), %xmm1
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
                	callq	 <L1>
 <L1>:
+               	leaq	-0xd0(%rbp), %rcx
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movsd	0x8(%rcx), %xmm0
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
                	callq	 <L2>
 <L2>:
+               	leaq	-0xdc(%rbp), %rcx
+               	movq	(%r13), %rdx
+               	movl	0x8(%r13), %esi
+               	movq	%rdx, (%rcx)
+               	movl	%esi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	$0x0, -0xe8(%rbp)
+               	movl	0x8(%rcx), %edx
+               	movl	%edx, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %rdx
                	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
+               	leaq	-0xf0(%rbp), %rcx
+               	movq	(%r14), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	leaq	-0xf8(%rbp), %rcx
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rdx
+               	movq	%rdx, -0x100(%rbp)
+               	movsd	-0x100(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
+               	movq	-0x128(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -614,21 +907,34 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x240, %rsp            ## imm = 0x240
-               	movq	%rbx, -0x218(%rbp)
-               	movq	%r12, -0x220(%rbp)
-               	movq	%r13, -0x228(%rbp)
-               	movq	%r14, -0x230(%rbp)
-               	movq	%r15, -0x238(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x140(%rbp)
-               	callq	 <L0>
+               	subq	$0x360, %rsp            ## imm = 0x360
+               	movq	%rbx, -0x338(%rbp)
+               	movq	%r12, -0x340(%rbp)
+               	movq	%r13, -0x348(%rbp)
+               	movq	%r14, -0x350(%rbp)
+               	movq	%r15, -0x358(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
                	movq	$0x2, %rsi
                	callq	 <L2>
 <L2>:
@@ -664,7 +970,7 @@ Disassembly of section __TEXT,__text:
                	movq	$0x10, %rsi
                	callq	 <L10>
 <L10>:
-               	leaq	-0xe8(%rbp), %r12
+               	leaq	-0x130(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -673,144 +979,196 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
                	jmp	 <L12>
 <L11>:
-               	movq	%rcx, %rdx
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
 <L12>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
                	jb	 <L13>
-               	jmp	 <L44>
+               	jmp	 <L39>
 <L13>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movb	%r15b, %sil
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
+               	movb	%r15b, %al
+               	movzbq	%al, %rsi
                	movq	%r13, %rdi
                	callq	 <L14>
 <L14>:
-               	movw	%r15w, %si
+               	movw	%r15w, %dx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movl	%r15d, %ecx
+               	movl	%r15d, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
-               	movl	%r15d, %ecx
-               	movq	%r15, %rdx
-               	shrq	$0x20, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x110(%rbp)
+               	leaq	-0x184(%rbp), %rdx
+               	movl	%r15d, %esi
+               	leaq	(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movq	%r15, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
+               	leaq	-0x240(%rbp), %rdx
+               	movq	%r15, %rsi
+               	andq	$0xfff, %rsi            ## imm = 0xFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L18>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L19>
 <L18>:
-               	movq	%r15, %rcx
-               	andq	$0xfff, %rcx            ## imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L19>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
+               	addss	%xmm0, %xmm0
 <L19>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L20>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x237>
-               	movq	%r15, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x273>
+               	leaq	(%rdx), %rsi
+               	movss	%xmm1, (%rsi)
+               	movq	%r15, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L21>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L22>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x27b>
-               	movss	%xmm14, -0x158(%rbp)
+<L21>:
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x2bc>
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm1, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x248(%rbp)
+               	movsd	-0x248(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
+               	callq	 <L22>
+<L22>:
+               	leaq	-0x254(%rbp), %rdx
+               	movl	%r15d, %esi
+               	leaq	(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movq	%r15, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	%r15, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %edi
+               	leaq	0x8(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x260(%rbp)
+               	movl	0x8(%rdx), %edi
+               	movl	%edi, -0x260(%rbp)
+               	movq	-0x260(%rbp), %rdx
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
+               	leaq	-0x270(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x298(%rbp)
                	movq	%rax, %rdi
-               	movss	-0x158(%rbp), %xmm0
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L24>
 <L24>:
-               	movl	%r15d, %ecx
-               	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x20, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x120(%rbp)
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
-               	movq	%r15, %r8
-               	movq	%r8, -0x160(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	%rax, %rdi
+               	leaq	-0x280(%rbp), %rdx
                	movq	%r15, %rsi
-               	callq	 <L28>
+               	andq	$0xffff, %rsi           ## imm = 0xFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L25>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L26>
+<L25>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L26>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x3b5>
+               	leaq	(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movq	%r15, %rsi
+               	andq	$0x3ffff, %rsi          ## imm = 0x3FFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L27>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L28>
+<L27>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L28>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x3fe>
+               	leaq	0x8(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movsd	(%rdx), %xmm0
+               	movsd	0x8(%rdx), %xmm1
                	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L29>
 <L29>:
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           ## imm = 0xFFFF
-               	movq	%rcx, %r11
+               	leaq	-0x290(%rbp), %rdx
+               	movq	%r15, %rsi
+               	imulq	$0x3, %rsi, %rsi
+               	addq	$0x1, %rsi
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	andq	$0x7fff, %rsi           ## imm = 0x7FFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L30>
                	cvtsi2sd	%r11, %xmm0
@@ -824,440 +1182,530 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L31>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x367>
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          ## imm = 0x3FFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L32>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L33>
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x471>
+               	leaq	0x8(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movq	(%rdx), %rsi
+               	movsd	0x8(%rdx), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L33>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x3ab>
-               	movsd	%xmm14, -0x170(%rbp)
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movsd	-0x170(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%r15, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
                	movq	%r15, %rdx
-               	andq	$0x7fff, %rdx           ## imm = 0x7FFF
+               	andq	$0x1fff, %rdx           ## imm = 0x1FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L36>
+               	jl	 <L33>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L37>
-<L36>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L37>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x41f>
-               	movsd	%xmm14, -0x180(%rbp)
-               	movq	%rax, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movsd	-0x180(%rbp), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%r15, %rcx
-               	andq	$0x1fff, %rcx           ## imm = 0x1FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L40>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L41>:
+<L34>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x485>
-               	xorq	$0x12345678, %r15       ## imm = 0x12345678
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x4cb>
+               	movq	%r15, %r8
+               	xorq	$0x12345678, %r8        ## imm = 0x12345678
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L43>
-<L43>:
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x8, %r14
                	jb	 <L13>
-<L44>:
+<L39>:
                	leaq	-0x48(%rbp), %r14
                	leaq	(%r14), %rax
                	addq	$0x0, %rax
-               	movq	$0x48, %rcx
-<L45>:
+               	movq	$0x48, %rdx
+<L40>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L45>
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L40>
                	leaq	-0xa8(%rbp), %r15
                	leaq	(%r15), %rax
                	addq	$0x0, %rax
-               	movq	$0x60, %rcx
-<L46>:
+               	movq	$0x60, %rdx
+<L41>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L46>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0xf4(%rbp), %rcx
-               	movl	%edx, %esi
-               	leaq	(%rcx), %rdi
-               	movl	%esi, (%rdi)
-               	movq	%rdx, %rsi
-               	shrq	$0x10, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L41>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x2a8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	-0x2a8(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	leaq	-0xdc(%rbp), %rdx
                	movl	%esi, %edi
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edi, (%rsi)
-               	shrq	$0x20, %rdx
-               	movl	%edx, %esi
-               	leaq	0x8(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movq	%rax, %rdx
-               	imulq	$0xc, %rdx, %rdx
-               	leaq	(%r14,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movl	0x8(%rcx), %edi
-               	movq	%rdx, (%rsi)
+               	leaq	(%rdx), %rax
+               	movl	%edi, (%rax)
+               	movq	%rsi, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %edi
+               	leaq	0x4(%rdx), %rax
+               	movl	%edi, (%rax)
+               	shrq	$0x20, %rsi
+               	movl	%esi, %eax
+               	leaq	0x8(%rdx), %rsi
+               	movl	%eax, (%rsi)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0xc, %rax, %rax
+               	leaq	(%r14,%rax), %rsi
+               	movq	(%rdx), %rax
+               	movl	0x8(%rdx), %edi
+               	movq	%rax, (%rsi)
                	movl	%edi, 0x8(%rsi)
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
+               	movq	-0x2a8(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rax
+               	movq	(%rax), %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0x108(%rbp), %rcx
+               	addq	%rbx, %rdx
+               	leaq	-0x140(%rbp), %rax
                	movq	%rdx, %rsi
                	imulq	$0x3, %rsi, %rsi
                	addq	$0x1, %rsi
-               	leaq	(%rcx), %rdi
+               	leaq	(%rax), %rdi
                	movq	%rsi, (%rdi)
                	andq	$0x7fff, %rdx           ## imm = 0x7FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L49>
-<L48>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L49>:
+<L44>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x5e0>
-               	leaq	0x8(%rcx), %rdx
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x6de>
+               	leaq	0x8(%rax), %rdx
                	movsd	%xmm1, (%rdx)
-               	movq	%rax, %rdx
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rdi
                	movq	%rdx, (%rsi)
                	movq	%rdi, 0x8(%rsi)
-               	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-<L50>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x188(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L51>
-               	jmp	 <L57>
-<L51>:
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r14,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x128(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x190(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r15,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x1a0(%rbp)
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movsd	-0x1a0(%rbp), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	movq	-0x188(%rbp), %r8
+               	movq	-0x2a8(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r13
                	movq	%rax, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x188(%rbp), %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x2a8(%rbp), %r8
                	cmpq	$0x6, %r8
-               	jb	 <L51>
-<L57>:
+               	jb	 <L42>
+<L45>:
+               	movq	$0x0, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L46>
+               	jmp	 <L49>
+<L46>:
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0xc, %rdx, %rdx
+               	leaq	(%r14,%rdx), %rsi
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	(%rsi), %rdi
+               	movl	0x8(%rsi), %edx
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x2b0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x2b0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	$0x0, -0xc0(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %rdx
+               	movq	%r13, %rdi
+               	callq	 <L47>
+<L47>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x2b8(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r15,%rdx), %rsi
+               	leaq	-0xd0(%rbp), %r8
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%rdx, 0x8(%r8)
+               	movq	-0x2c0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2c0(%rbp), %r8
+               	movsd	0x8(%r8), %xmm0
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %r13
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L46>
+<L49>:
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L58>
-               	jmp	 <L84>
-<L58>:
+               	jb	 <L50>
+               	jmp	 <L68>
+<L50>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movq	%r15, %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           ## imm = 0xFFFF
-               	movq	%rcx, %r11
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%rdx, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x150(%rbp), %r8
+               	movq	%r8, -0x2d0(%rbp)
+               	movq	%rdx, %rdi
+               	andq	$0xffff, %rdi           ## imm = 0xFFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L51>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L52>
+<L51>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L52>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x902>
+               	movq	-0x2d0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movsd	%xmm1, (%rdi)
+               	movq	%rdx, %rdi
+               	andq	$0x3ffff, %rdi          ## imm = 0x3FFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L53>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L54>
+<L53>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L54>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x952>
+               	movq	-0x2d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movsd	%xmm1, (%rdi)
+               	leaq	-0x160(%rbp), %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	%rdx, %r15
+               	imulq	$0x3, %r15, %r15
+               	addq	$0x1, %r15
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	%r15, (%rax)
+               	movq	%rdx, %rax
+               	andq	$0x7fff, %rax           ## imm = 0x7FFF
+               	movq	%rax, %r11
+               	testq	%r11, %r11
+               	jl	 <L55>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L56>
+<L55>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L56>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x9c9>
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movsd	%xmm1, (%rax)
+               	leaq	-0x16c(%rbp), %rax
+               	movl	%edx, %r15d
+               	leaq	(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movq	%rdx, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %r15d
+               	leaq	0x4(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movq	%rdx, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %r15d
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	leaq	-0x174(%rbp), %r8
+               	movq	%r8, -0x2e0(%rbp)
+               	movl	%edx, %r15d
+               	movq	-0x2e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%r15d, (%rdi)
+               	movq	%rdx, %rdi
+               	shrq	$0x20, %rdi
+               	movl	%edi, %r15d
+               	movq	-0x2e0(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movl	%r15d, (%rdi)
+               	leaq	-0x17c(%rbp), %r8
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	%rdx, %r15
+               	andq	$0xfff, %r15            ## imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L57>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L58>
+<L57>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L58>:
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xa90>
+               	movq	-0x2e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm1, (%r15)
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L59>
-               	cvtsi2sd	%r11, %xmm0
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L60>
 <L59>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L60>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x782>
-               	movsd	%xmm14, -0x1b8(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          ## imm = 0x3FFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L61>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L62>
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xade>
+               	movq	-0x2e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x198(%rbp), %rdx
+               	movq	-0x2c8(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x2c8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	%r15, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	leaq	-0x1a8(%rbp), %r15
+               	movq	-0x2d0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	%rsi, (%r15)
+               	movq	%rdi, 0x8(%r15)
+               	leaq	-0x1b8(%rbp), %r8
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2d8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	leaq	-0x1c4(%rbp), %r8
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	(%rax), %rsi
+               	movl	0x8(%rax), %edi
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%edi, 0x8(%r8)
+               	leaq	-0x1cc(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x2e0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x328(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	leaq	-0x1d4(%rbp), %r8
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x2e8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x300(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	leaq	-0x1e8(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x308(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r8
+               	movq	%r8, -0x310(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	%rdx, %rsi
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L61>
 <L61>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
+               	leaq	-0x1f8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movsd	(%rdx), %xmm0
+               	movsd	0x8(%rdx), %xmm1
+               	movq	-0x318(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L62>
 <L62>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x7cf>
-               	movsd	%xmm14, -0x1c8(%rbp)
-               	movq	%r15, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x7fff, %rcx           ## imm = 0x7FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L63>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L64>
+               	movq	%rax, %rdi
+               	leaq	-0x208(%rbp), %rdx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2f0(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%r15, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movsd	0x8(%rdx), %xmm0
+               	callq	 <L63>
 <L63>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %rdi
+               	leaq	-0x214(%rbp), %rdx
+               	movq	-0x2f8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2f8(%rbp), %r8
+               	movl	0x8(%r8), %r15d
+               	movq	%rsi, (%rdx)
+               	movl	%r15d, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x220(%rbp)
+               	movl	0x8(%rdx), %r15d
+               	movl	%r15d, -0x220(%rbp)
+               	movq	-0x220(%rbp), %rdx
+               	callq	 <L64>
 <L64>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x831>
-               	movsd	%xmm14, -0x1e0(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	%r15, %rsi
-               	shrq	$0x10, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x130(%rbp)
-               	movq	%r15, %rsi
-               	shrq	$0x20, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x138(%rbp)
-               	movl	%r15d, %ebx
-               	movq	%r15, %rsi
-               	shrq	$0x20, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x148(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L66>
+               	movq	%rax, %rdi
+               	leaq	-0x228(%rbp), %rdx
+               	movq	-0x328(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	callq	 <L65>
 <L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	leaq	-0x230(%rbp), %rdx
+               	movq	-0x300(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x238(%rbp)
+               	movsd	-0x238(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L66>
 <L66>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x8be>
-               	movss	%xmm14, -0x1f8(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L68>
-<L67>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L68>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x90b>
-               	movss	%xmm14, -0x208(%rbp)
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movsd	-0x1b8(%rbp), %xmm0
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movsd	-0x1c8(%rbp), %xmm0
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
-               	movsd	-0x1e0(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rdi
-               	movq	-0x1e8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x148(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movss	-0x1f8(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movss	-0x208(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L67>
+<L67>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L58>
-<L84>:
+               	jb	 <L50>
+<L68>:
                	movq	%r13, %rax
-               	movq	-0x218(%rbp), %rbx
-               	movq	-0x220(%rbp), %r12
-               	movq	-0x228(%rbp), %r13
-               	movq	-0x230(%rbp), %r14
-               	movq	-0x238(%rbp), %r15
+               	movq	-0x338(%rbp), %rbx
+               	movq	-0x340(%rbp), %r12
+               	movq	-0x348(%rbp), %r13
+               	movq	-0x350(%rbp), %r14
+               	movq	-0x358(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/call/call_variadic.dis
+++ b/test/golden/x86_64-darwin/call/call_variadic.dis
@@ -14,77 +14,96 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_variadic.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1a0, %rsp            ## imm = 0x1A0
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%r15, -0x198(%rbp)
+               	subq	$0x2e0, %rsp            ## imm = 0x2E0
+               	movq	%rbx, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
                	movq	%rdi, %r8
-               	movq	%r8, -0x80(%rbp)
-               	callq	 <L0>
-<L0>:
+               	movq	%r8, -0x68(%rbp)
                	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 ## imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
+               	leaq	(%r12,%rax,8), %rsi
                	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
+               	addq	$0x1, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L4>
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L5>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L6>
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L7>
-               	jmp	 <L91>
-<L7>:
+               	jb	 <L9>
+               	jmp	 <L106>
+<L9>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x80(%rbp), %r8
-               	movq	%rcx, %r15
+               	movq	(%rax), %rdx
+               	movq	-0x68(%rbp), %r8
+               	movq	%rdx, %r15
                	addq	%r8, %r15
                	movb	%r15b, %r8b
-               	movq	%r8, -0xe0(%rbp)
+               	movq	%r8, -0x228(%rbp)
                	movw	%r15w, %r8w
-               	movq	%r8, -0xe8(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%r8, -0x230(%rbp)
+               	movl	%r15d, %ebx
                	movq	%r15, %rsi
                	shrq	$0x7, %rsi
                	movb	%sil, %r8b
-               	movq	%r8, -0x68(%rbp)
+               	movq	%r8, -0x88(%rbp)
                	movq	%r15, %rsi
                	shrq	$0x3, %rsi
                	movw	%si, %r8w
@@ -95,24 +114,6 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x78(%rbp)
                	movq	%r15, %rsi
                	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L8>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L9>:
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x19b>
-               	movss	%xmm14, -0x100(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L10>
@@ -127,10 +128,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x1e8>
-               	movss	%xmm14, -0x110(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x205>
+               	movss	%xmm14, -0x240(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x3ff, %rsi            ## imm = 0x3FF
+               	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L12>
@@ -145,10 +146,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L13>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x235>
-               	movss	%xmm14, -0x120(%rbp)
+               	subss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x252>
+               	movss	%xmm14, -0x250(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x1ff, %rsi            ## imm = 0x1FF
+               	andq	$0x3ff, %rsi            ## imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L14>
@@ -163,28 +164,28 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L15>:
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x282>
-               	movss	%xmm14, -0x130(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x29f>
+               	movss	%xmm14, -0x260(%rbp)
                	movq	%r15, %rsi
-               	andq	$0xffff, %rsi           ## imm = 0xFFFF
+               	andq	$0x1ff, %rsi            ## imm = 0x1FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L16>
-               	cvtsi2sd	%r11, %xmm0
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L17>
 <L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L17>:
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x2cf>
-               	movsd	%xmm14, -0x140(%rbp)
+               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x2ec>
+               	movss	%xmm14, -0x270(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x3ffff, %rsi          ## imm = 0x3FFFF
+               	andq	$0xffff, %rsi           ## imm = 0xFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L18>
@@ -199,10 +200,10 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L19>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x31c>
-               	movsd	%xmm14, -0x150(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x339>
+               	movsd	%xmm14, -0x280(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x1fff, %rsi           ## imm = 0x1FFF
+               	andq	$0x3ffff, %rsi          ## imm = 0x3FFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L20>
@@ -217,297 +218,665 @@ Disassembly of section __TEXT,__text:
                	addsd	%xmm0, %xmm0
 <L21>:
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x369>
-               	movsd	%xmm14, -0x160(%rbp)
-               	movq	%r15, %rbx
-               	imulq	$0x3, %rbx, %rbx
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x386>
+               	movsd	%xmm14, -0x290(%rbp)
                	movq	%r15, %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movslq	%r8d, %rsi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	addq	%r15, %rbx
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %r8
+               	andq	$0x1fff, %rsi           ## imm = 0x1FFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L22>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L23>
+<L22>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L23>:
+               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x3d3>
+               	movsd	%xmm14, -0x2a0(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x3, %r8, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	-0x228(%rbp), %r9
+               	movzbq	%r9b, %r8
                	movq	%r8, -0x90(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %r8
+               	movq	%r13, %r8
                	movq	%r8, -0x98(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %r8
+               	movq	$0x0, %r8
                	movq	%r8, -0xa0(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	%rbx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
+               	movq	-0xa0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0xa0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movq	-0x230(%rbp), %r9
+               	movswq	%r9w, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0x98(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+<L27>:
+               	movl	%ebx, %r8d
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xb0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+<L29>:
+               	movq	-0xc8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+<L31>:
+               	movq	-0x88(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+<L33>:
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x78(%rbp), %r8
+               	movslq	%r8d, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
+               	movq	%rax, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	leaq	(%r12), %rdi
+               	movq	(%rdi), %rsi
+               	movq	%rsi, %r8
+               	addq	%r15, %r8
+               	movq	%r8, -0x160(%rbp)
+               	leaq	0x8(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x108(%rbp)
+               	leaq	0x10(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x110(%rbp)
+               	leaq	0x18(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x118(%rbp)
+               	leaq	0x20(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x120(%rbp)
+               	leaq	0x28(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x128(%rbp)
+               	leaq	0x30(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x130(%rbp)
+               	leaq	0x38(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x40(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x140(%rbp)
+               	leaq	0x48(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x148(%rbp)
+               	leaq	0x50(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x150(%rbp)
+               	leaq	0x58(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L39>
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
 <L39>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L40>
+               	movq	-0x168(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L41>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L42>
+               	movq	-0x178(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L43>
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
 <L43>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L44>
+               	movq	-0x188(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
+               	jmp	 <L45>
 <L44>:
-               	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
-               	callq	 <L45>
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
 <L45>:
-               	movq	%rax, %rdi
-               	movss	-0x110(%rbp), %xmm0
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movsd	-0x150(%rbp), %xmm0
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x5, %rbx, %rbx
-               	movq	%r15, %rsi
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	$0xc, %rsi
                	callq	 <L54>
 <L54>:
-               	movq	%rax, %rdi
-               	movq	$0x6, %rsi
-               	callq	 <L55>
+               	movq	%rax, %rsi
+               	movl	-0x240(%rbp), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
+               	jmp	 <L56>
 <L55>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x7, %rbx, %rbx
-               	movq	%r15, %rsi
-               	callq	 <L56>
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
 <L56>:
-               	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	addq	%r15, %rsi
-               	callq	 <L57>
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
+               	jmp	 <L58>
 <L57>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	addq	%r15, %rsi
-               	callq	 <L58>
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
 <L58>:
-               	movq	%rax, %rdi
-               	addq	%r15, %rbx
-               	movq	%rbx, %rsi
+               	movl	-0x250(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L59>
 <L59>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rsi
-               	addq	%r15, %rsi
+               	movq	-0x290(%rbp), %rsi
                	callq	 <L60>
 <L60>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
                	callq	 <L61>
 <L61>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L62>
+               	movq	%rax, %rsi
+               	movq	%r15, %r8
+               	imulq	$0x5, %r8, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+               	jmp	 <L63>
 <L62>:
-               	movq	%rax, %rdi
-               	movss	-0x120(%rbp), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r15, %rsi
-               	addq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+<L63>:
+               	movl	-0x240(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L64>
 <L64>:
                	movq	%rax, %rdi
-               	movsd	-0x160(%rbp), %xmm0
+               	movl	%ebx, %esi
                	callq	 <L65>
 <L65>:
                	movq	%rax, %rdi
-               	movq	$0x3, %rsi
+               	movq	-0x280(%rbp), %rsi
                	callq	 <L66>
 <L66>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L67>
 <L67>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	$0x6, %rsi
                	callq	 <L69>
 <L69>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L70>
+               	movq	%rax, %rsi
+               	movq	%r15, %r8
+               	imulq	$0x7, %r8, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
+               	jmp	 <L71>
 <L70>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L71>
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
 <L71>:
-               	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x228(%rbp), %r8
                	movzbq	%r8b, %rsi
+               	addq	%r15, %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L72>
 <L72>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movl	%ebx, %esi
+               	addq	%r15, %rsi
                	callq	 <L73>
 <L73>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%r15, %rsi
                	callq	 <L74>
 <L74>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rsi
+               	addq	%r15, %rsi
                	callq	 <L75>
 <L75>:
                	movq	%rax, %rdi
@@ -519,53 +888,42 @@ Disassembly of section __TEXT,__text:
                	callq	 <L77>
 <L77>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movl	-0x260(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L78>
 <L78>:
                	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
+               	movq	%r15, %rsi
+               	addq	%r15, %rsi
                	callq	 <L79>
 <L79>:
                	movq	%rax, %rdi
-               	movq	$0x3, %rsi
+               	movq	-0x2a0(%rbp), %rsi
                	callq	 <L80>
 <L80>:
                	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x7, %rbx, %rbx
-               	movq	%r15, %r8
-               	imulq	$0x3, %r8, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x3, %rsi
                	callq	 <L81>
 <L81>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x228(%rbp), %r8
                	movzbq	%r8b, %rsi
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rsi
                	callq	 <L82>
 <L82>:
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rsi
                	movq	%rax, %rdi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L83>
 <L83>:
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rbx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movl	%ebx, %esi
                	callq	 <L84>
 <L84>:
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rdx
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rdx
                	movq	%rax, %rdi
-               	movq	%rdx, %rsi
+               	movq	%r15, %rsi
                	callq	 <L85>
 <L85>:
                	movq	%rax, %rdi
@@ -573,32 +931,116 @@ Disassembly of section __TEXT,__text:
                	callq	 <L86>
 <L86>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x228(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	callq	 <L87>
 <L87>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L88>
 <L88>:
                	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
+               	movl	%ebx, %esi
                	callq	 <L89>
 <L89>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	%r15, %rsi
                	callq	 <L90>
 <L90>:
+               	movq	%rax, %rdi
+               	movq	$0x4, %rsi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L92>
+<L92>:
+               	movq	%rax, %rdi
+               	movl	-0x240(%rbp), %edx
+               	movl	%edx, %esi
+               	callq	 <L93>
+<L93>:
+               	movq	%rax, %rdi
+               	movq	-0x280(%rbp), %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	%rax, %rdi
+               	movq	$0x3, %rsi
+               	callq	 <L95>
+<L95>:
+               	movq	%rax, %rdi
+               	movq	%r15, %r8
+               	imulq	$0x7, %r8, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x3, %r8, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L96>
+<L96>:
+               	movq	%rax, %rdi
+               	movq	-0x228(%rbp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rsi
+               	callq	 <L97>
+<L97>:
+               	movl	%ebx, %esi
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L98>
+<L98>:
+               	movq	-0x2a8(%rbp), %r8
+               	movq	-0x220(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L99>
+<L99>:
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L100>
+<L100>:
+               	movq	%rax, %rdi
+               	movq	$0x4, %rsi
+               	callq	 <L101>
+<L101>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L102>
+<L102>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L103>
+<L103>:
+               	movl	-0x270(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L104>
+<L104>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L105>
+<L105>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L7>
-<L91>:
+               	jb	 <L9>
+<L106>:
                	movq	%r13, %rax
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
-               	movq	-0x198(%rbp), %r15
+               	movq	-0x2b8(%rbp), %rbx
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -798,18 +1240,21 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, -0x10(%rbp)
                	movss	%xmm2, -0x20(%rbp)
                	movsd	%xmm3, -0x30(%rbp)
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movl	-0x20(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movq	-0x30(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -834,20 +1279,21 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, %r13
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movl	%ebx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	movswq	%r12w, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
@@ -931,17 +1377,18 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, %rsi
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	addq	%rbx, %r12
+               	movq	%rax, %rdi
                	movq	%r12, %rsi
                	callq	 <L2>
 <L2>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -1036,12 +1483,13 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
@@ -1122,6 +1570,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_variadic.fold_pack$pack$f32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -1177,12 +1627,13 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
@@ -1201,12 +1652,13 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi

--- a/test/golden/x86_64-darwin/cmp/branch_nest.dis
+++ b/test/golden/x86_64-darwin/cmp/branch_nest.dis
@@ -5,162 +5,196 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.branch_nest.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movq	%r15, -0x28(%rbp)
+               	movl	%edi, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x14, %esi
+               	jb	 <L0>
+               	jmp	 <L43>
 <L0>:
-               	movl	%ebx, %r12d
-               	movq	%rax, %rbx
-               	movl	$0x0, %r13d
-               	cmpl	$0x14, %r13d
-               	jb	 <L1>
-               	jmp	 <L42>
+               	movl	%esi, %edi
+               	addl	%eax, %edi
+               	cmpl	$0x4, %edi
+               	jb	 <L31>
+               	cmpl	$0x8, %edi
+               	jb	 <L23>
+               	cmpl	$0xc, %edi
+               	jb	 <L15>
+               	cmpl	$0x10, %edi
+               	jb	 <L7>
+               	cmpl	$0x10, %edi
+               	je	 <L5>
+               	cmpl	$0x11, %edi
+               	je	 <L3>
+               	cmpl	$0x12, %edi
+               	je	 <L1>
+               	movl	$0x1f7, %ebx            ## imm = 0x1F7
+               	jmp	 <L2>
 <L1>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	cmpl	$0x4, %r14d
-               	jb	 <L32>
-               	cmpl	$0x8, %r14d
-               	jb	 <L24>
-               	cmpl	$0xc, %r14d
-               	jb	 <L16>
-               	cmpl	$0x10, %r14d
-               	jb	 <L8>
-               	cmpl	$0x10, %r14d
-               	je	 <L6>
-               	cmpl	$0x11, %r14d
-               	je	 <L4>
-               	cmpl	$0x12, %r14d
-               	je	 <L2>
-               	movl	$0x1f7, %eax            ## imm = 0x1F7
-               	jmp	 <L3>
+               	movl	$0x1f6, %ebx            ## imm = 0x1F6
 <L2>:
-               	movl	$0x1f6, %eax            ## imm = 0x1F6
+               	jmp	 <L4>
 <L3>:
-               	jmp	 <L5>
+               	movl	$0x1f5, %ebx            ## imm = 0x1F5
 <L4>:
-               	movl	$0x1f5, %eax            ## imm = 0x1F5
+               	jmp	 <L6>
 <L5>:
-               	jmp	 <L7>
+               	movl	$0x1f4, %ebx            ## imm = 0x1F4
 <L6>:
-               	movl	$0x1f4, %eax            ## imm = 0x1F4
-<L7>:
-               	jmp	 <L15>
-<L8>:
-               	cmpl	$0xe, %r14d
-               	jb	 <L11>
-               	cmpl	$0xe, %r14d
-               	je	 <L9>
-               	movl	$0x193, %ecx            ## imm = 0x193
-               	jmp	 <L10>
-<L9>:
-               	movl	$0x192, %ecx            ## imm = 0x192
-<L10>:
                	jmp	 <L14>
-<L11>:
-               	cmpl	$0xc, %r14d
-               	je	 <L12>
-               	movl	$0x191, %edx            ## imm = 0x191
+<L7>:
+               	cmpl	$0xe, %edi
+               	jb	 <L10>
+               	cmpl	$0xe, %edi
+               	je	 <L8>
+               	movl	$0x193, %r12d           ## imm = 0x193
+               	jmp	 <L9>
+<L8>:
+               	movl	$0x192, %r12d           ## imm = 0x192
+<L9>:
                	jmp	 <L13>
+<L10>:
+               	cmpl	$0xc, %edi
+               	je	 <L11>
+               	movl	$0x191, %r13d           ## imm = 0x191
+               	jmp	 <L12>
+<L11>:
+               	movl	$0x190, %r13d           ## imm = 0x190
 <L12>:
-               	movl	$0x190, %edx            ## imm = 0x190
+               	movq	%r13, %r12
 <L13>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rbx
 <L14>:
-               	movq	%rcx, %rax
-<L15>:
-               	jmp	 <L23>
-<L16>:
-               	cmpl	$0x8, %r14d
-               	je	 <L21>
-               	cmpl	$0x9, %r14d
-               	je	 <L19>
-               	cmpl	$0xa, %r14d
-               	je	 <L17>
-               	movl	$0x12f, %ecx            ## imm = 0x12F
-               	jmp	 <L18>
-<L17>:
-               	movl	$0x12e, %ecx            ## imm = 0x12E
-<L18>:
-               	jmp	 <L20>
-<L19>:
-               	movl	$0x12d, %ecx            ## imm = 0x12D
-<L20>:
                	jmp	 <L22>
+<L15>:
+               	cmpl	$0x8, %edi
+               	je	 <L20>
+               	cmpl	$0x9, %edi
+               	je	 <L18>
+               	cmpl	$0xa, %edi
+               	je	 <L16>
+               	movl	$0x12f, %r12d           ## imm = 0x12F
+               	jmp	 <L17>
+<L16>:
+               	movl	$0x12e, %r12d           ## imm = 0x12E
+<L17>:
+               	jmp	 <L19>
+<L18>:
+               	movl	$0x12d, %r12d           ## imm = 0x12D
+<L19>:
+               	jmp	 <L21>
+<L20>:
+               	movl	$0x12c, %r12d           ## imm = 0x12C
 <L21>:
-               	movl	$0x12c, %ecx            ## imm = 0x12C
+               	movq	%r12, %rbx
 <L22>:
-               	movq	%rcx, %rax
-<L23>:
-               	jmp	 <L31>
-<L24>:
-               	cmpl	$0x6, %r14d
-               	jb	 <L27>
-               	cmpl	$0x6, %r14d
-               	je	 <L25>
-               	movl	$0xcb, %ecx
-               	jmp	 <L26>
-<L25>:
-               	movl	$0xca, %ecx
-<L26>:
                	jmp	 <L30>
-<L27>:
-               	cmpl	$0x4, %r14d
-               	je	 <L28>
-               	movl	$0xc9, %edx
+<L23>:
+               	cmpl	$0x6, %edi
+               	jb	 <L26>
+               	cmpl	$0x6, %edi
+               	je	 <L24>
+               	movl	$0xcb, %r12d
+               	jmp	 <L25>
+<L24>:
+               	movl	$0xca, %r12d
+<L25>:
                	jmp	 <L29>
+<L26>:
+               	cmpl	$0x4, %edi
+               	je	 <L27>
+               	movl	$0xc9, %r13d
+               	jmp	 <L28>
+<L27>:
+               	movl	$0xc8, %r13d
 <L28>:
-               	movl	$0xc8, %edx
+               	movq	%r13, %r12
 <L29>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rbx
 <L30>:
-               	movq	%rcx, %rax
-<L31>:
-               	jmp	 <L39>
-<L32>:
-               	cmpl	$0x0, %r14d
-               	je	 <L37>
-               	cmpl	$0x1, %r14d
-               	je	 <L35>
-               	cmpl	$0x2, %r14d
-               	je	 <L33>
-               	movl	$0x67, %ecx
-               	jmp	 <L34>
-<L33>:
-               	movl	$0x66, %ecx
-<L34>:
-               	jmp	 <L36>
-<L35>:
-               	movl	$0x65, %ecx
-<L36>:
                	jmp	 <L38>
+<L31>:
+               	cmpl	$0x0, %edi
+               	je	 <L36>
+               	cmpl	$0x1, %edi
+               	je	 <L34>
+               	cmpl	$0x2, %edi
+               	je	 <L32>
+               	movl	$0x67, %r12d
+               	jmp	 <L33>
+<L32>:
+               	movl	$0x66, %r12d
+<L33>:
+               	jmp	 <L35>
+<L34>:
+               	movl	$0x65, %r12d
+<L35>:
+               	jmp	 <L37>
+<L36>:
+               	movl	$0x64, %r12d
 <L37>:
-               	movl	$0x64, %ecx
+               	movq	%r12, %rbx
 <L38>:
-               	movq	%rcx, %rax
+               	movl	%ebx, %r12d
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
+               	jmp	 <L40>
 <L39>:
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L40>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
 <L40>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L41>
+               	movl	%edi, %r12d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x14, %r13d
-               	jb	 <L1>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L41>
 <L42>:
-               	movq	%rbx, %rax
+               	addl	$0x1, %esi
+               	movq	%rbx, %rdx
+               	cmpl	$0x14, %esi
+               	jb	 <L0>
+<L43>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/cmp/cmp_i32.dis
+++ b/test/golden/x86_64-darwin/cmp/cmp_i32.dis
@@ -5,137 +5,240 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     ## imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%rdi, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %r13
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     ## imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%r13)
-               	movq	%rsi, 0x8(%r13)
-               	movq	%rdi, 0x10(%r13)
-               	movl	%r14d, 0x18(%r13)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%rbx,%r15,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r8d
-               	addl	%r12d, %r8d
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x78(%rbp)
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %r8d
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     ## imm = 0xFFFFFFFF
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     ## imm = 0x7FFFFFFF
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     ## imm = 0x80000000
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     ## imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     ## imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movl	0x18(%rsi), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rsi
+               	leaq	-0x70(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     ## imm = 0xFFFFFFFF
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     ## imm = 0x80000000
+               	leaq	0x10(%rdi), %rbx
+               	movl	$0x7fffffff, (%rbx)     ## imm = 0x7FFFFFFF
+               	leaq	0x14(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     ## imm = 0xFFFFFFFF
+               	leaq	0x18(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     ## imm = 0x80000000
+               	movq	(%rdi), %rbx
+               	movq	0x8(%rdi), %r12
+               	movq	0x10(%rdi), %r13
+               	movl	0x18(%rdi), %r14d
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movl	%r14d, 0x18(%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
                	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
+               	addl	%r8d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	cmpl	%r14d, %r13d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	cmpl	%r13d, %r14d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	cmpl	%r14d, %r13d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/cmp/cmp_i64.dis
+++ b/test/golden/x86_64-darwin/cmp/cmp_i64.dis
@@ -11,149 +11,250 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x118(%rbp)
                	movq	%r14, -0x120(%rbp)
                	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	movq	%rdi, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %r12
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movq	%rdi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
-               	movq	%r15, 0x28(%r12)
-               	movq	%rax, 0x30(%r12)
-               	leaq	-0xa8(%rbp), %r13
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	0x18(%rax), %rdi
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%r13)
-               	movq	%rdx, 0x8(%r13)
-               	movq	%rsi, 0x10(%r13)
-               	movq	%rdi, 0x18(%r13)
-               	movq	%r14, 0x20(%r13)
-               	movq	%r15, 0x28(%r13)
+               	leaq	-0x70(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	0x20(%rdx), %r14
+               	movq	0x28(%rdx), %r15
+               	movq	0x30(%rdx), %rdi
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%r13)
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rdx
+               	leaq	-0xe0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x10(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	leaq	0x20(%rsi), %rdi
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdi)
+               	leaq	0x28(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movq	0x18(%rsi), %r13
+               	movq	0x20(%rsi), %r14
+               	movq	0x28(%rsi), %r15
+               	movq	0x30(%rsi), %rax
+               	movq	%rdi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	%r14, 0x20(%rdx)
+               	movq	%r15, 0x28(%rdx)
+               	movq	%rax, 0x30(%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0xf8(%rbp)
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	-0xe8(%rbp), %r8
+               	addq	%r8, %rbx
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %r12
+               	cmpq	%r12, %rbx
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r13
                	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
+               	movq	%r8, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	cmpq	%r12, %rbx
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpq	%r12, %rbx
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpq	%rbx, %r12
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
+               	cmpq	%r12, %rbx
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rbx, %r12
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13

--- a/test/golden/x86_64-darwin/cmp/cmp_u32.dis
+++ b/test/golden/x86_64-darwin/cmp/cmp_u32.dis
@@ -5,137 +5,240 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.cmp_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     ## imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%rdi, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %r13
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     ## imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%r13)
-               	movq	%rsi, 0x8(%r13)
-               	movq	%rdi, 0x10(%r13)
-               	movl	%r14d, 0x18(%r13)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%rbx,%r15,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r8d
-               	addl	%r12d, %r8d
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x78(%rbp)
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %r8d
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     ## imm = 0xFFFFFFFF
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     ## imm = 0x7FFFFFFF
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     ## imm = 0x80000000
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     ## imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     ## imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movl	0x18(%rsi), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rsi
+               	leaq	-0x70(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     ## imm = 0xFFFFFFFF
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     ## imm = 0x80000000
+               	leaq	0x10(%rdi), %rbx
+               	movl	$0x7fffffff, (%rbx)     ## imm = 0x7FFFFFFF
+               	leaq	0x14(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     ## imm = 0xFFFFFFFF
+               	leaq	0x18(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     ## imm = 0x80000000
+               	movq	(%rdi), %rbx
+               	movq	0x8(%rdi), %r12
+               	movq	0x10(%rdi), %r13
+               	movl	0x18(%rdi), %r14d
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movl	%r14d, 0x18(%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
                	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
+               	addl	%r8d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	cmpl	%r14d, %r13d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	cmpl	%r13d, %r14d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	cmpl	%r14d, %r13d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/cmp/cmp_u64.dis
+++ b/test/golden/x86_64-darwin/cmp/cmp_u64.dis
@@ -11,149 +11,250 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x118(%rbp)
                	movq	%r14, -0x120(%rbp)
                	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	movq	%rdi, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %r12
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movq	%rdi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
-               	movq	%r15, 0x28(%r12)
-               	movq	%rax, 0x30(%r12)
-               	leaq	-0xa8(%rbp), %r13
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	0x18(%rax), %rdi
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%r13)
-               	movq	%rdx, 0x8(%r13)
-               	movq	%rsi, 0x10(%r13)
-               	movq	%rdi, 0x18(%r13)
-               	movq	%r14, 0x20(%r13)
-               	movq	%r15, 0x28(%r13)
+               	leaq	-0x70(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	0x20(%rdx), %r14
+               	movq	0x28(%rdx), %r15
+               	movq	0x30(%rdx), %rdi
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%r13)
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rdx
+               	leaq	-0xe0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x10(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	leaq	0x20(%rsi), %rdi
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdi)
+               	leaq	0x28(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movq	0x18(%rsi), %r13
+               	movq	0x20(%rsi), %r14
+               	movq	0x28(%rsi), %r15
+               	movq	0x30(%rsi), %rax
+               	movq	%rdi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	%r14, 0x20(%rdx)
+               	movq	%r15, 0x28(%rdx)
+               	movq	%rax, 0x30(%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0xf8(%rbp)
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	-0xe8(%rbp), %r8
+               	addq	%r8, %rbx
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %r12
+               	cmpq	%r12, %rbx
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r13
                	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
+               	movq	%r8, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	cmpq	%r12, %rbx
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpq	%r12, %rbx
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpq	%rbx, %r12
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
+               	cmpq	%r12, %rbx
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rbx, %r12
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13

--- a/test/golden/x86_64-darwin/cmp/loop_shapes.dis
+++ b/test/golden/x86_64-darwin/cmp/loop_shapes.dis
@@ -5,155 +5,242 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.loop_shapes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movq	%rax, %rbx
-               	movl	$0x0, %r13d
-               	movq	%r12, %r14
-               	cmpl	$0x10, %r13d
-               	jb	 <L1>
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	%r13d, %eax
-               	imull	$0x3, %eax, %eax
-               	movl	%r14d, %ecx
-               	addl	%eax, %ecx
-               	movl	%ecx, %r14d
-               	addl	$0x1, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r13d
+<L0>:
+               	movl	%esi, %ebx
+               	imull	$0x3, %ebx, %ebx
+               	movl	%edi, %r12d
+               	addl	%ebx, %r12d
+               	addl	$0x1, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rdx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-<L3>:
-               	movl	$0x62, %eax
-               	addl	%r12d, %eax
-               	movq	%rax, %r13
-               	movl	$0x0, %r11d
-               	cmpl	%r13d, %r11d
-               	jb	 <L4>
-               	jmp	 <L6>
-<L4>:
-               	subl	$0x7, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rbx
-               	movl	$0x0, %r11d
-               	cmpl	%r13d, %r11d
-               	jb	 <L4>
-<L6>:
-               	movl	$0x0, %r13d
-               	cmpl	$0x6, %r13d
-               	jb	 <L7>
-               	jmp	 <L13>
-<L7>:
-               	movl	%r13d, %r14d
-               	imull	$0x6, %r14d, %r14d
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
                	movq	%rbx, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rdx
+               	movq	%r12, %rdi
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
+<L3>:
                	movq	-0x8(%rbp), %r8
-               	cmpl	$0x6, %r8d
+               	movl	$0x62, %eax
+               	addl	%r8d, %eax
+               	movl	$0x0, %r11d
+               	cmpl	%eax, %r11d
+               	jb	 <L4>
+               	jmp	 <L7>
+<L4>:
+               	movl	%eax, %esi
+               	subl	$0x7, %esi
+               	movl	%esi, %edi
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+<L6>:
+               	movq	%rbx, %rdx
+               	movq	%rsi, %rax
+               	movl	$0x0, %r11d
+               	cmpl	%eax, %r11d
+               	jb	 <L4>
+<L7>:
+               	movl	$0x0, %eax
+               	cmpl	$0x6, %eax
                	jb	 <L8>
-               	jmp	 <L12>
+               	jmp	 <L15>
 <L8>:
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x3, %r8d
-               	je	 <L10>
-               	movq	-0x8(%rbp), %r8
-               	movl	%r14d, %ecx
-               	addl	%r8d, %ecx
-               	addl	%r12d, %ecx
-               	movq	%r15, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movl	%eax, %r8d
+               	imull	$0x6, %r8d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rdx, %rdi
+               	movl	$0x0, %ebx
+               	cmpl	$0x6, %ebx
+               	jb	 <L9>
+               	jmp	 <L14>
 <L9>:
-               	movq	%rax, %r15
+               	cmpl	$0x3, %ebx
+               	je	 <L12>
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	addl	%ebx, %r12d
                	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
+               	addl	%r8d, %r12d
+               	movl	%r12d, %r13d
+               	movq	%rdi, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
 <L11>:
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x6, %r8d
-               	jb	 <L8>
+               	addl	$0x1, %ebx
+               	movq	%r12, %rdi
+               	jmp	 <L13>
 <L12>:
-               	addl	$0x1, %r13d
-               	movq	%r15, %rbx
-               	cmpl	$0x6, %r13d
-               	jb	 <L7>
+               	addl	$0x1, %ebx
 <L13>:
-               	movl	$0x9, %r13d
-               	addl	%r12d, %r13d
-               	movq	%r12, %r14
-               	cmpl	$0xf4240, %r14d         ## imm = 0xF4240
-               	jb	 <L14>
-               	jmp	 <L16>
+               	cmpl	$0x6, %ebx
+               	jb	 <L9>
 <L14>:
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L15>
+               	addl	$0x1, %eax
+               	movq	%rdi, %rdx
+               	cmpl	$0x6, %eax
+               	jb	 <L8>
 <L15>:
-               	cmpl	%r13d, %r14d
-               	je	 <L17>
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0xf4240, %r14d         ## imm = 0xF4240
-               	jb	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9, %eax
+               	addl	%r8d, %eax
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	cmpl	$0xf4240, %esi          ## imm = 0xF4240
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
+               	movl	%esi, %edi
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
                	jmp	 <L18>
 <L17>:
-               	movq	%rax, %rbx
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
 <L18>:
-               	movl	$0x1, %eax
-               	addl	%r12d, %eax
-               	movq	%rax, %r12
-               	movl	$0x1, %r13d
-               	movl	$0x0, %r14d
-               	cmpl	$0x14, %r14d
-               	jb	 <L19>
-               	jmp	 <L21>
+               	cmpl	%eax, %esi
+               	je	 <L20>
+               	addl	$0x1, %esi
+               	movq	%rbx, %rdx
+               	cmpl	$0xf4240, %esi          ## imm = 0xF4240
+               	jb	 <L16>
 <L19>:
-               	movl	%r12d, %r15d
-               	addl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r13, %r12
-               	movq	%r15, %r13
-               	cmpl	$0x14, %r14d
-               	jb	 <L19>
+               	movq	%rbx, %rdx
 <L21>:
-               	movq	%rbx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x1, %eax
+               	addl	%r8d, %eax
+               	movq	%rax, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x1, %esi
+               	movl	$0x0, %edi
+               	cmpl	$0x14, %edi
+               	jb	 <L22>
+               	jmp	 <L25>
+<L22>:
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %ebx
+               	addl	%esi, %ebx
+               	movl	%ebx, %r12d
+               	movq	%rdx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+<L24>:
+               	addl	$0x1, %edi
+               	movq	%r13, %rdx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rbx, %rsi
+               	cmpl	$0x14, %edi
+               	jb	 <L22>
+<L25>:
+               	movq	%rdx, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/cmp/short_circuit.dis
+++ b/test/golden/x86_64-darwin/cmp/short_circuit.dis
@@ -40,42 +40,96 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.short_circuit.fold_state>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.fold_state+0x1f>
-               	callq	 <L0>
+               	movq	%r15, -0x28(%rbp)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.fold_state+0x23>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.fold_state+0x2b>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.fold_state+0x32>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L1>
-               	jmp	 <L4>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L2>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.fold_state+0x7c>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.fold_state+0x83>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+               	jmp	 <L7>
 <L2>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L3>
+               	leaq	(%rax,%rsi,8), %rbx
+               	movq	(%rbx), %r12
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L1>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%r13, %rax
+               	leaq	(%rdx,%rsi,8), %r12
+               	movq	(%r12), %r13
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+<L6>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdi
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -83,580 +137,524 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.cmp.short_circuit.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
+               	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movb	%bl, %r12b
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x2e>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x39>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x40>
+               	movb	%dil, %bl
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x1a>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x25>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2c>
                	movq	$0x0, %rsi
                	cmpq	$0x4, %rsi
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	leaq	(%rcx,%rsi,8), %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	leaq	(%rax,%rsi,8), %rdi
                	movq	$0x0, (%rdi)
                	leaq	(%rdx,%rsi,8), %rdi
                	movq	$0x0, (%rdi)
                	addq	$0x1, %rsi
                	cmpq	$0x4, %rsi
-               	jb	 <L1>
-<L2>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x81>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x93>
-               	movq	(%rcx), %rdx
+               	jb	 <L0>
+<L1>:
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x78>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7f>
+               	movq	(%rax), %rdx
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0xa4>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0xab>
-               	movq	%rcx, (%rdx)
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L3>
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x90>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x97>
+               	movq	%rax, (%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x0, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0xc4>
-               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0xd3>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0xda>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x106>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x111>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x118>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
-               	jmp	 <L8>
+               	jmp	 <L6>
 <L5>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
-<L6>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
+<L6>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x15b>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x166>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x16d>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x17e>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x185>
+               	movq	%rdx, (%rsi)
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x196>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x1a1>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1b0>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1b9>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x1c8>
+               	movq	%rsi, (%rdi)
+               	cmpb	$0x1, %dl
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x12a>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x135>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x13c>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
-               	jmp	 <L10>
+               	movq	%rax, %rdi
+               	callq	 <L9>
 <L9>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x233>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x23e>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x245>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x17d>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x188>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x18f>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1a0>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a7>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %eax
-               	xorl	%r12d, %eax
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b9>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1d3>
-               	movq	(%rcx), %rdx
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+<L11>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x288>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1dc>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1eb>
-               	movq	%rcx, (%rdx)
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x293>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x29a>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2ab>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2b2>
+               	movq	%rdx, (%rsi)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x31d>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x328>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x32f>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L17>
+<L17>:
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L18>
+               	movl	$0x1, %eax
+               	xorl	%ebx, %eax
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x39c>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x3a7>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x3b6>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x3bf>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x3ce>
+               	movq	%rsi, (%rdi)
                	cmpb	$0x1, %al
                	sete	%sil
                	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L11>
-<L11>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x200>
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20f>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x216>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L13>
-               	jmp	 <L16>
-<L13>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L13>
-<L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x266>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x271>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x278>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
-               	jmp	 <L18>
-<L17>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
+               	jmp	 <L19>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b9>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c4>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2cb>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2dc>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2e3>
-               	movq	%rax, (%rcx)
-               	movq	%r14, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L19>
+               	movq	%rdx, %rsi
 <L19>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2fc>
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x30b>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x312>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L21>
-               	jmp	 <L24>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
+               	movq	%r12, %rdi
                	callq	 <L22>
 <L22>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x444>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x44f>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x456>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L21>
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L23>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x362>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x36d>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x374>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-<L26>:
                	movq	$0x0, %rdi
                	movq	$0x0, %rsi
-               	callq	 <L27>
-<L27>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movl	$0x1, %eax
-               	xorl	%r12d, %eax
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3e2>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3ed>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3fc>
-               	movq	(%rdx), %rsi
-               	addq	$0x1, %rsi
-               	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x405>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x414>
-               	movq	%rdx, (%rsi)
+               	callq	 <L25>
+<L25>:
                	cmpb	$0x1, %al
                	sete	%dl
                	movzbq	%dl, %rdx
-               	jmp	 <L29>
-<L28>:
-               	movq	%rcx, %rdx
-<L29>:
-               	movq	%r14, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x433>
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x442>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x449>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L32>
-               	jmp	 <L35>
-<L32>:
-               	leaq	(%rbx,%r15,8), %rax
+               	testb	%dl, %dl
+               	jne	 <L26>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4bc>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4c7>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4d6>
                	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L33>
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4df>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x4ee>
+               	movq	%rax, (%rsi)
+               	movq	$0x1, %rax
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rax
+<L27>:
+               	testb	%al, %al
+               	jne	 <L28>
+               	jmp	 <L31>
+<L28>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x50c>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x517>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x52e>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x52f>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x546>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %bl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L29>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x552>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x55d>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x57c>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x575>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x594>
+               	movq	%rsi, (%rdi)
+               	movq	$0x1, %rsi
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdx, %rsi
+<L30>:
+               	movq	%rsi, %rax
+<L31>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
 <L33>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
+               	movq	%r12, %rdi
                	callq	 <L34>
 <L34>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L32>
-<L35>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x499>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4a4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4ab>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
-               	jmp	 <L37>
-<L36>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
-<L37>:
-               	movq	$0x0, %rdi
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x5f9>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x604>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x60b>
                	movq	$0x0, %rsi
-               	callq	 <L38>
-<L38>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L39>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x511>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51c>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x52b>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x534>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x543>
-               	movq	%rax, (%rdx)
-               	movq	$0x1, %rax
-               	jmp	 <L40>
-<L39>:
-               	movq	%rcx, %rax
-<L40>:
-               	testb	%al, %al
-               	jne	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x561>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x56c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x583>
-               	movq	(%rcx), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x584>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x59b>
-               	movq	%rcx, (%rdx)
-               	cmpb	$0x1, %r12b
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L42>
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5a8>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5b3>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5d2>
-               	movq	(%rdx), %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
                	addq	$0x1, %rsi
-               	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5cb>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5ea>
-               	movq	%rdx, (%rsi)
-               	movq	$0x1, %rdx
-               	jmp	 <L43>
-<L42>:
-               	movq	%rcx, %rdx
-<L43>:
-               	movq	%rdx, %rax
-<L44>:
-               	movq	%r14, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5f9>
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x608>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x60f>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L48>
-<L48>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L47>
-<L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x65f>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x66a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x671>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-               	jmp	 <L52>
-<L51>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-<L52>:
+               	cmpq	$0x4, %rsi
+               	jb	 <L35>
+<L36>:
                	movq	$0x0, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L37>
+<L37>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L54>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d7>
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L38>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x671>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6e2>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6f1>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6fa>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x709>
-               	movq	%rax, (%rdx)
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x67c>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x68b>
+               	movq	(%rax), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x694>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x6a3>
+               	movq	%rax, (%rsi)
                	movq	$0x1, %rax
-               	jmp	 <L55>
-<L54>:
-               	movq	%rcx, %rax
-<L55>:
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdx, %rax
+<L39>:
                	testb	%al, %al
-               	jne	 <L56>
-               	jmp	 <L57>
-<L56>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x727>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x732>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x749>
-               	movq	(%rcx), %rdx
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6c1>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x74a>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x761>
-               	movq	%rcx, (%rdx)
-               	movl	$0x1, %ecx
-               	xorl	%r12d, %ecx
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x763>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x76e>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x78d>
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x6cc>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6e3>
                	movq	(%rdx), %rsi
                	addq	$0x1, %rsi
                	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x786>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7a5>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6e4>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x6fb>
                	movq	%rdx, (%rsi)
-               	cmpb	$0x1, %cl
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rdx, %rax
-<L57>:
-               	movq	%r14, %rdi
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x6fc>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x707>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x726>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x71f>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x73e>
+               	movq	%rsi, (%rdi)
+               	cmpb	$0x1, %dl
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movq	%rsi, %rax
+<L41>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
                	movq	%rax, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7af>
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7be>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x7c5>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L60>
-               	jmp	 <L63>
-<L60>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L60>
-<L63>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x815>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x827>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-               	jmp	 <L65>
-<L64>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-<L65>:
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+<L43>:
+               	movq	%r12, %rdi
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x79f>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7aa>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x7b1>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L45>
+               	jmp	 <L46>
+<L45>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L45>
+<L46>:
                	movq	$0x0, %rdi
                	movq	$0x0, %rsi
-               	callq	 <L66>
-<L66>:
+               	callq	 <L47>
+<L47>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L67>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L48>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x817>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x898>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8a7>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8b0>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8bf>
-               	movq	%rax, (%rdx)
-               	cmpb	$0x1, %r12b
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x822>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x831>
+               	movq	(%rax), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x83a>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x849>
+               	movq	%rax, (%rsi)
+               	cmpb	$0x1, %bl
                	sete	%al
                	movzbq	%al, %rax
-               	jmp	 <L68>
-<L67>:
-               	movq	%rcx, %rax
-<L68>:
+               	jmp	 <L49>
+<L48>:
+               	movq	%rdx, %rax
+<L49>:
                	testb	%al, %al
-               	jne	 <L69>
-               	jmp	 <L70>
-<L69>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8e1>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8ec>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x903>
-               	movq	(%rcx), %rdx
+               	jne	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x86a>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x904>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x91b>
-               	movq	%rcx, (%rdx)
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x875>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x88c>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x8a4>
+               	movq	%rdx, (%rsi)
                	movq	$0x1, %rax
-<L70>:
-               	movq	%r14, %rdi
+<L51>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
                	movq	%rax, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x927>
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x936>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x93d>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L73>
-               	jmp	 <L76>
-<L73>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L73>
-<L76>:
-               	movq	%r13, %rax
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+<L53>:
+               	movq	%r12, %rdi
+               	callq	 <L54>
+<L54>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/comptime/ct_runtime_agree.dis
+++ b/test/golden/x86_64-darwin/comptime/ct_runtime_agree.dis
@@ -32,549 +32,808 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            ## imm = 0x100
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
-               	movq	%r15, -0xf8(%rbp)
+               	subq	$0x120, %rsp            ## imm = 0x120
+               	movq	%rbx, -0xf8(%rbp)
+               	movq	%r12, -0x100(%rbp)
+               	movq	%r13, -0x108(%rbp)
+               	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	$0x12345678, %r12       ## imm = 0x12345678
-               	addq	%rbx, %r12
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r13
-               	addq	$0x7, %r13
-               	movq	%r13, %rcx
-               	shlq	$0xd, %rcx
-               	movq	%rcx, %r14
-               	movabsq	$0xf0f0f0f0f, %r11      ## imm = 0xF0F0F0F0F
-               	xorq	%r11, %r14
-               	movq	%r14, %rcx
-               	shrq	$0x7, %rcx
-               	movq	%r14, %r15
-               	xorq	%rcx, %r15
-               	movq	%r15, %r8
-               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
-               	andq	%r11, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	-0x48(%rbp), %r9
-               	movq	%r9, %r8
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %r8
+               	movq	$0x12345678, %r8        ## imm = 0x12345678
+               	addq	%rbx, %r8
                	movq	%r8, -0x50(%rbp)
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	shrq	$0x11, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	-0x38(%rbp), %r9
-               	movq	-0x48(%rbp), %r10
-               	movq	%r9, %r8
-               	addq	%r10, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	$0x12345678, %rsi       ## imm = 0x12345678
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	$0x369d036f, %rsi       ## imm = 0x369D036F
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movabsq	$0x6dcaf62ef0f, %rsi    ## imm = 0x6DCAF62EF0F
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movabsq	$0x6d1163c2ad1, %rsi    ## imm = 0x6D1163C2AD1
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	$0x163c2ad1, %rsi       ## imm = 0x163C2AD1
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	movq	%rdx, %r8
+               	addq	$0x7, %r8
+               	movq	%r8, -0x48(%rbp)
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
+               	shlq	$0xd, %rsi
+               	movq	%rsi, %r8
+               	movabsq	$0xf0f0f0f0f, %r11      ## imm = 0xF0F0F0F0F
+               	xorq	%r11, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	$0x7, %rdi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %r12
+               	xorq	%rdi, %r12
+               	movq	%r12, %r13
+               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
+               	andq	%r11, %r13
+               	movq	%r13, %r14
+               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
+               	imulq	%r11, %r14
+               	movq	%r14, %r15
+               	shrq	$0x11, %r15
+               	movq	%r15, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x12345678, %rdx       ## imm = 0x12345678
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
                	movq	%rax, %rdi
-               	movabsq	$0xdbdf3ec00bd6381, %rsi ## imm = 0xDBDF3EC00BD6381
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x369d036f, %rdx       ## imm = 0x369D036F
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0x6dcaf62ef0f, %rdx    ## imm = 0x6DCAF62EF0F
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x6d1163c2ad1, %rsi    ## imm = 0x6D1163C2AD1
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movabsq	$0x6def9f6005e, %rsi    ## imm = 0x6DEF9F6005E
+               	movq	%r12, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x163c2ad1, %rsi       ## imm = 0x163C2AD1
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movabsq	$0x6df10322b2f, %rsi    ## imm = 0x6DF10322B2F
+               	movq	%r13, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
+               	movabsq	$0xdbdf3ec00bd6381, %rsi ## imm = 0xDBDF3EC00BD6381
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L17>
+<L17>:
+               	movq	%rax, %rdi
+               	movabsq	$0x6def9f6005e, %rsi    ## imm = 0x6DEF9F6005E
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movabsq	$0x6df10322b2f, %rsi    ## imm = 0x6DF10322B2F
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L18>:
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1e6>
+<L23>:
+               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x38f>
                	addsd	%xmm0, %xmm1
                	movsd	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1f8>
-               	movsd	%xmm14, -0x60(%rbp)
-               	movsd	-0x60(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x20b>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	subsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x219>
-               	movsd	%xmm14, -0x70(%rbp)
-               	movsd	-0x70(%rbp), %xmm14
-               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x22e>
-               	movsd	%xmm14, -0x80(%rbp)
-               	movsd	-0x80(%rbp), %xmm0
-               	mulsd	-0x80(%rbp), %xmm0
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x60(%rbp), %xmm14
-               	movsd	%xmm14, -0x90(%rbp)
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x25a>
-               	callq	 <L19>
-<L19>:
+               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3a1>
+               	movsd	%xmm14, -0x78(%rbp)
+               	movsd	-0x78(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3b4>
+               	movsd	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1]
+               	subsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3c2>
+               	movsd	%xmm14, -0x88(%rbp)
+               	movsd	-0x88(%rbp), %xmm14
+               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3dd>
+               	movsd	%xmm14, -0x98(%rbp)
+               	movsd	-0x98(%rbp), %xmm3
+               	mulsd	-0x98(%rbp), %xmm3
+               	movsd	%xmm3, %xmm14           ## xmm14 = xmm3[0],xmm14[1]
+               	addsd	-0x78(%rbp), %xmm14
+               	movsd	%xmm14, -0xa8(%rbp)
+               	movabsq	$0x3fd5555555555555, %rsi ## imm = 0x3FD5555555555555
                	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x277>
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x294>
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L24>
 <L24>:
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2b1>
                	callq	 <L25>
 <L25>:
+               	movabsq	$0x3fd5555555555550, %rsi ## imm = 0x3FD5555555555550
                	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
+               	movq	-0x88(%rbp), %rsi
                	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movabsq	$0x3fd364d9364d9360, %rsi ## imm = 0x3FD364D9364D9360
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	-0x98(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movabsq	$0x3fdb35d5373e4baf, %rsi ## imm = 0x3FDB35D5373E4BAF
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movq	-0xa8(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L28>:
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2fd>
+<L33>:
+               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4bf>
                	addss	%xmm0, %xmm1
                	movss	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x30f>
-               	movss	%xmm14, -0xa0(%rbp)
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x328>
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x336>
-               	movss	%xmm14, -0xb0(%rbp)
-               	movss	-0xb0(%rbp), %xmm14
-               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x351>
-               	movss	%xmm14, -0xc0(%rbp)
-               	movss	-0xc0(%rbp), %xmm0
-               	mulss	-0xc0(%rbp), %xmm0
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0xa0(%rbp), %xmm14
-               	movss	%xmm14, -0xd0(%rbp)
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x389>
-               	callq	 <L29>
-<L29>:
+               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4d1>
+               	movss	%xmm14, -0xb8(%rbp)
+               	movss	-0xb8(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4ea>
+               	movss	%xmm1, %xmm14           ## xmm14 = xmm1[0],xmm14[1,2,3]
+               	subss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4f8>
+               	movss	%xmm14, -0xc8(%rbp)
+               	movss	-0xc8(%rbp), %xmm14
+               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x513>
+               	movss	%xmm14, -0xd8(%rbp)
+               	movss	-0xd8(%rbp), %xmm3
+               	mulss	-0xd8(%rbp), %xmm3
+               	movss	%xmm3, %xmm14           ## xmm14 = xmm3[0],xmm14[1,2,3]
+               	addss	-0xb8(%rbp), %xmm14
+               	movss	%xmm14, -0xe8(%rbp)
+               	movl	$0x3eaaaaab, %edx       ## imm = 0x3EAAAAAB
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3a9>
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0xb0(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3c9>
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L34>
 <L34>:
+               	movl	-0xb8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3e9>
                	callq	 <L35>
 <L35>:
+               	movl	$0x3eaaaab0, %edx       ## imm = 0x3EAAAAB0
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L36>
 <L36>:
+               	movl	-0xc8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x9e3779b1, %rsi       ## imm = 0x9E3779B1
                	callq	 <L37>
 <L37>:
+               	movl	$0x3e9b26ce, %edx       ## imm = 0x3E9B26CE
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x1449114a2, %rsi      ## imm = 0x1449114A2
                	callq	 <L38>
 <L38>:
+               	movl	-0xd8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x517154775, %rsi      ## imm = 0x517154775
                	callq	 <L39>
 <L39>:
+               	movl	$0x3ed9aead, %edx       ## imm = 0x3ED9AEAD
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0xc5255662a, %rsi      ## imm = 0xC5255662A
                	callq	 <L40>
 <L40>:
+               	movl	-0xe8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x1f7ae2da45, %rsi     ## imm = 0x1F7AE2DA45
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movabsq	$0x39954428ca, %rsi     ## imm = 0x39954428CA
+               	movabsq	$0x9e3779b1, %rsi       ## imm = 0x9E3779B1
                	callq	 <L42>
 <L42>:
-               	leaq	-0x30(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
+               	movq	%rax, %rdi
+               	movabsq	$0x1449114a2, %rsi      ## imm = 0x1449114A2
+               	callq	 <L43>
+<L43>:
+               	movq	%rax, %rdi
+               	movabsq	$0x517154775, %rsi      ## imm = 0x517154775
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %rdi
+               	movabsq	$0xc5255662a, %rsi      ## imm = 0xC5255662A
+               	callq	 <L45>
+<L45>:
+               	movq	%rax, %rdi
+               	movabsq	$0x1f7ae2da45, %rsi     ## imm = 0x1F7AE2DA45
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rdi
+               	movabsq	$0x39954428ca, %rsi     ## imm = 0x39954428CA
+               	callq	 <L47>
+<L47>:
+               	leaq	-0x30(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movq	$0x0, 0x10(%rdx)
+               	movq	$0x0, 0x18(%rdx)
+               	movq	$0x0, 0x20(%rdx)
+               	movq	$0x0, 0x28(%rdx)
                	movq	$0x1, %rsi
                	addq	%rbx, %rsi
-               	leaq	(%r12), %rdi
+               	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x3, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x8(%r12), %rdi
+               	leaq	0x8(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x7, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x10(%r12), %rdi
+               	leaq	0x10(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0xf, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x18(%r12), %rdi
+               	leaq	0x18(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x1f, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x20(%r12), %rdi
+               	leaq	0x20(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x3f, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x28(%r12), %rdi
+               	leaq	0x28(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L43>
-               	jmp	 <L45>
-<L43>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	xorq	%rsi, %r14
-               	movq	%r13, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L44>
-<L44>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L43>
-<L45>:
-               	movq	%r13, %rdi
-               	movq	$0xb, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %r12
-               	movq	-0x40(%rbp), %r8
-               	movq	-0x50(%rbp), %r9
-               	cmpq	%r9, %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L48>
-               	movq	%r12, %rdi
-               	movq	$0x16, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r13
-               	jmp	 <L50>
+               	jmp	 <L51>
 <L48>:
-               	movq	%r12, %rdi
-               	movq	$0xb, %rsi
-               	callq	 <L49>
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	(%r12), %r15
+               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
+               	imulq	%r11, %r15
+               	movq	-0x58(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L49>
+               	jmp	 <L50>
 <L49>:
-               	movq	%rax, %r13
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r15, %r12
+               	xorq	%rax, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L49>
 <L50>:
-               	movq	%r13, %rdi
-               	movq	$0x21, %rsi
-               	callq	 <L51>
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	cmpq	$0x6, %rdi
+               	jb	 <L48>
 <L51>:
-               	movq	%rax, %r12
-               	movq	-0x48(%rbp), %r8
-               	movq	$0xffff, %r11           ## imm = 0xFFFF
-               	cmpq	%r8, %r11
-               	jb	 <L53>
-               	movq	%r12, %rdi
-               	movq	$0x2c, %rsi
-               	callq	 <L52>
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
+               	jmp	 <L53>
 <L52>:
-               	movq	%rax, %r13
-               	jmp	 <L55>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0xb, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
 <L53>:
-               	movq	%r12, %rdi
-               	movq	$0x21, %rsi
-               	callq	 <L54>
+               	movq	-0x38(%rbp), %r8
+               	cmpq	%r14, %r8
+               	jb	 <L56>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
 <L54>:
-               	movq	%rax, %r13
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x16, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
 <L55>:
+               	jmp	 <L59>
+<L56>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0xb, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+<L58>:
+               	movq	%rax, %rdx
+<L59>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x21, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+<L61>:
+               	movq	$0xffff, %r11           ## imm = 0xFFFF
+               	cmpq	%r13, %r11
+               	jb	 <L64>
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x2c, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+<L63>:
+               	jmp	 <L67>
+<L64>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x21, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+<L66>:
+               	movq	%rdx, %rax
+<L67>:
                	movb	%bl, %r12b
                	movl	$0x1, %ebx
                	addl	%r12d, %ebx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rax
-               	shrq	$0x1d, %rax
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	xorq	%rax, %rdx
-               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
-               	imulq	%r11, %rdx
-               	movq	%r13, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L56>
-<L56>:
-               	cmpb	$0x0, %r12b
-               	je	 <L59>
-               	cmpb	$0x1, %r12b
-               	je	 <L57>
-               	movq	$0x0, %rdx
-               	jmp	 <L58>
-<L57>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shlq	$0x11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rsi
-               	addq	$0x3039, %rsi           ## imm = 0x3039
-               	movq	%rsi, %rdx
-<L58>:
-               	jmp	 <L60>
-<L59>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x1d, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rsi, %rdi
-               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	shlq	$0x11, %rdx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x2f, %rsi
-               	orq	%rsi, %rdx
-               	addq	$0x3039, %rdx           ## imm = 0x3039
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L62>
-<L62>:
-               	cmpb	$0x0, %bl
-               	je	 <L65>
-               	cmpb	$0x1, %bl
-               	je	 <L63>
-               	movq	$0x0, %rdx
-               	jmp	 <L64>
-<L63>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shlq	$0x11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rsi
-               	addq	$0x3039, %rsi           ## imm = 0x3039
-               	movq	%rsi, %rdx
-<L64>:
-               	jmp	 <L66>
-<L65>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x1d, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rsi, %rdi
-               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L66>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x1d, %rdx
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	xorq	%rdx, %rsi
                	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
                	imulq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	cmpb	$0x0, %r12b
-               	je	 <L71>
-               	cmpb	$0x1, %r12b
-               	je	 <L69>
                	movq	$0x0, %rdx
-               	jmp	 <L70>
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
+               	jmp	 <L69>
+<L68>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
 <L69>:
-               	movq	-0x48(%rbp), %r8
+               	cmpb	$0x0, %r12b
+               	je	 <L72>
+               	cmpb	$0x1, %r12b
+               	je	 <L70>
+               	movq	$0x0, %rdx
+               	jmp	 <L71>
+<L70>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	addq	$0x3039, %rsi           ## imm = 0x3039
                	movq	%rsi, %rdx
-<L70>:
-               	jmp	 <L72>
 <L71>:
-               	movq	-0x48(%rbp), %r8
+               	jmp	 <L73>
+<L72>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x1d, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	xorq	%rsi, %rdi
                	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
                	imulq	%r11, %rdi
                	movq	%rdi, %rdx
-<L72>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L73>
 <L73>:
-               	movq	-0x48(%rbp), %r8
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+<L75>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdx
                	shlq	$0x11, %rdx
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x2f, %rsi
                	orq	%rsi, %rdx
                	addq	$0x3039, %rdx           ## imm = 0x3039
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L74>
-<L74>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+<L77>:
                	cmpb	$0x0, %bl
-               	je	 <L77>
+               	je	 <L80>
                	cmpb	$0x1, %bl
-               	je	 <L75>
+               	je	 <L78>
                	movq	$0x0, %rdx
-               	jmp	 <L76>
-<L75>:
-               	movq	-0x48(%rbp), %r8
+               	jmp	 <L79>
+<L78>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	addq	$0x3039, %rsi           ## imm = 0x3039
                	movq	%rsi, %rdx
-<L76>:
-               	jmp	 <L78>
-<L77>:
-               	movq	-0x48(%rbp), %r8
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x1d, %rsi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	%rsi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
                	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
-               	imulq	%r11, %rcx
-               	movq	%rcx, %rdx
-<L78>:
+               	imulq	%r11, %rdi
+               	movq	%rdi, %rdx
+<L81>:
                	movq	%rax, %rdi
                	movq	%rdx, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
-               	movq	-0xf8(%rbp), %r15
+               	callq	 <L82>
+<L82>:
+               	movq	%r13, %rdx
+               	shrq	$0x1d, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L83>
+<L83>:
+               	cmpb	$0x0, %r12b
+               	je	 <L86>
+               	cmpb	$0x1, %r12b
+               	je	 <L84>
+               	movq	$0x0, %rdx
+               	jmp	 <L85>
+<L84>:
+               	movq	%r13, %rsi
+               	shlq	$0x11, %rsi
+               	movq	%r13, %rdi
+               	shrq	$0x2f, %rdi
+               	orq	%rdi, %rsi
+               	addq	$0x3039, %rsi           ## imm = 0x3039
+               	movq	%rsi, %rdx
+<L85>:
+               	jmp	 <L87>
+<L86>:
+               	movq	%r13, %rsi
+               	shrq	$0x1d, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	%rdi, %rdx
+<L87>:
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L88>
+<L88>:
+               	movq	%r13, %rdx
+               	shlq	$0x11, %rdx
+               	movq	%r13, %rsi
+               	shrq	$0x2f, %rsi
+               	orq	%rsi, %rdx
+               	addq	$0x3039, %rdx           ## imm = 0x3039
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L89>
+<L89>:
+               	cmpb	$0x0, %bl
+               	je	 <L92>
+               	cmpb	$0x1, %bl
+               	je	 <L90>
+               	movq	$0x0, %rdx
+               	jmp	 <L91>
+<L90>:
+               	movq	%r13, %rsi
+               	shlq	$0x11, %rsi
+               	movq	%r13, %rdi
+               	shrq	$0x2f, %rdi
+               	orq	%rdi, %rsi
+               	addq	$0x3039, %rsi           ## imm = 0x3039
+               	movq	%rsi, %rdx
+<L91>:
+               	jmp	 <L93>
+<L92>:
+               	movq	%r13, %rsi
+               	shrq	$0x1d, %rsi
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	movq	%r13, %rdx
+<L93>:
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	-0xf8(%rbp), %rbx
+               	movq	-0x100(%rbp), %r12
+               	movq	-0x108(%rbp), %r13
+               	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/bitcast.dis
+++ b/test/golden/x86_64-darwin/convert/bitcast.dis
@@ -5,65 +5,235 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.bitcast.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movl	%edi, %eax
+               	xorl	$0xc0490fdb, %eax       ## imm = 0xC0490FDB
+               	movd	%eax, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%eax, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	xorl	$0xc0490fdb, %ecx       ## imm = 0xC0490FDB
-               	movl	%ecx, -0x10(%rbp)
-               	movl	-0x10(%rbp), %r12d
-               	movl	%ecx, %esi
-               	callq	 <L1>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
-               	callq	 <L2>
+               	movd	%xmm0, %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movabsq	$0x400921fb54442d18, %r11 ## imm = 0x400921FB54442D18
-               	xorq	%r11, %rbx
-               	movq	%rbx, -0x20(%rbp)
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbx, %rsi
-               	callq	 <L4>
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movabsq	$0x400921fb54442d18, %r11 ## imm = 0x400921FB54442D18
+               	xorq	%r11, %rdi
+               	movq	%rdi, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	$0x40490fdb, %ecx       ## imm = 0x40490FDB
-               	movl	%ecx, -0x30(%rbp)
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movss	-0x30(%rbp), %xmm0
-               	callq	 <L8>
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movabsq	$0x4005bf0a8b145769, %rsi ## imm = 0x4005BF0A8B145769
-               	movq	%rsi, -0x40(%rbp)
-               	callq	 <L9>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %r12
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movl	$0x40490fdb, %edx       ## imm = 0x40490FDB
+               	movd	%edx, %xmm0
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movabsq	$0x4005bf0a8b145769, %rdx ## imm = 0x4005BF0A8B145769
+               	movq	%rdx, %xmm0
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/ext_sign.dis
+++ b/test/golden/x86_64-darwin/convert/ext_sign.dis
@@ -11,99 +11,337 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movl	%r12d, %r13d
-               	xorl	$-0x1, %r13d
-               	movw	%bx, %cx
-               	movl	%ecx, %r14d
-               	orl	$0x8000, %r14d          ## imm = 0x8000
-               	movl	%r14d, %r15d
-               	xorl	$-0x1, %r15d
-               	movl	%ebx, %ecx
-               	movl	%ecx, %ebx
-               	orl	$0x80000000, %ebx       ## imm = 0x80000000
-               	movl	%ebx, %r8d
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movl	%eax, %edx
+               	xorl	$-0x1, %edx
+               	movw	%di, %si
+               	orl	$0x8000, %esi           ## imm = 0x8000
+               	movl	%esi, %ebx
+               	xorl	$-0x1, %ebx
+               	movl	%edi, %r12d
+               	movl	%r12d, %r8d
+               	orl	$0x80000000, %r8d       ## imm = 0x80000000
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r9
+               	movl	%r9d, %r8d
                	movq	%r8, -0x8(%rbp)
                	xorl	$-0x1, %r8d
                	movq	%r8, -0x8(%rbp)
-               	movsbl	%r12b, %esi
-               	callq	 <L1>
+               	movsbl	%al, %r13d
+               	movswq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsbl	%r13b, %esi
-               	callq	 <L2>
+               	movsbl	%dl, %edi
+               	movswq	%di, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movsbl	%r12b, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsbl	%r13b, %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
+               	movsbl	%al, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsbq	%r12b, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsbq	%r13b, %r12
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movsbl	%dl, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movswl	%r14w, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movswl	%r15w, %esi
-               	callq	 <L8>
+               	movsbq	%al, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movswq	%r14w, %r13
-               	movq	%r13, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movswq	%r15w, %r14
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	movsbq	%dl, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movslq	%ebx, %r15
-               	movq	%r15, %rsi
-               	callq	 <L11>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movslq	%r8d, %rbx
-               	movq	%rbx, %rsi
-               	callq	 <L12>
+               	movswl	%si, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%r13, %rdx
-               	addq	%r15, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	addq	%r14, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	callq	 <L14>
+               	movswl	%bx, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movswq	%si, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movswq	%bx, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movsbq	%al, %rdi
+               	movswq	%si, %rax
+               	addq	%rax, %rdi
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rax
+               	addq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movsbq	%dl, %rax
+               	movswq	%bx, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/convert/ext_zero.dis
+++ b/test/golden/x86_64-darwin/convert/ext_zero.dis
@@ -11,98 +11,335 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movl	$0xff, %r13d
-               	subl	%r12d, %r13d
-               	movw	%bx, %cx
-               	movl	%ecx, %r14d
-               	orl	$0x8000, %r14d          ## imm = 0x8000
-               	movl	$0xffff, %r15d          ## imm = 0xFFFF
-               	subl	%r14d, %r15d
-               	movl	%ebx, %ecx
-               	movl	%ecx, %ebx
-               	orl	$0x80000000, %ebx       ## imm = 0x80000000
-               	movl	$0xffffffff, %r8d       ## imm = 0xFFFFFFFF
-               	subl	%ebx, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movzbl	%r12b, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movzbl	%r13b, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movzbl	%r12b, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movzbl	%r13b, %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movzbq	%r12b, %r8
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movl	$0xff, %edx
+               	subl	%eax, %edx
+               	movw	%di, %si
+               	orl	$0x8000, %esi           ## imm = 0x8000
+               	movl	$0xffff, %r8d           ## imm = 0xFFFF
+               	subl	%esi, %r8d
                	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movl	%edi, %r12d
+               	orl	$0x80000000, %r12d      ## imm = 0x80000000
+               	movl	$0xffffffff, %r8d       ## imm = 0xFFFFFFFF
+               	subl	%r12d, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movzbl	%al, %r13d
+               	movzwq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+<L1>:
+               	movzbl	%dl, %edi
+               	movzwq	%di, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+<L3>:
+               	movzbl	%al, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movzbq	%r13b, %r12
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movzbl	%dl, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movzwl	%r14w, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movzwl	%r15w, %esi
-               	callq	 <L8>
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movzwq	%r14w, %r13
-               	movq	%r13, %rsi
-               	callq	 <L9>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movzwq	%r15w, %r14
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	movzbq	%dl, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r15d
-               	movq	%r15, %rsi
-               	callq	 <L11>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ebx
-               	movq	%rbx, %rsi
-               	callq	 <L12>
+               	movzwl	%si, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%r13, %rdx
-               	addq	%r15, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	addq	%r14, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	callq	 <L14>
+               	movq	-0x10(%rbp), %r8
+               	movzwl	%r8w, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movzwq	%si, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movl	%r12d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movzbq	%al, %rdi
+               	movzwq	%si, %rax
+               	addq	%rax, %rdi
+               	movl	%r12d, %eax
+               	addq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movzbq	%dl, %rax
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %edx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/convert/f2f.dis
+++ b/test/golden/x86_64-darwin/convert/f2f.dis
@@ -5,98 +5,265 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2f.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm14
-               	addsd	%xmm14, %xmm14
-<L2>:
-               	movsd	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
+<L3>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x6c>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movss	%xmm14, -0x20(%rbp)
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0x8b>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x30(%rbp)
-               	movss	-0x30(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	callq	 <L5>
-<L5>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movss	-0x30(%rbp), %xmm0
-               	callq	 <L6>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
                	movq	%rax, %rdi
-               	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L7>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0xd6>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movss	-0x50(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	callq	 <L8>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movss	-0x50(%rbp), %xmm0
-               	callq	 <L9>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L10>
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x191>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0x121>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x70(%rbp)
-               	callq	 <L11>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
-               	callq	 <L12>
+               	movd	%xmm3, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x14e>
-               	addss	-0x20(%rbp), %xmm0
-               	cvtss2sd	%xmm0, %xmm14
-               	movsd	%xmm14, -0x80(%rbp)
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
-               	callq	 <L14>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	-0x88(%rbp), %rbx
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x2ac>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm0
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x36c>
+               	addss	%xmm1, %xmm0
+               	cvtss2sd	%xmm0, %xmm1
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movq	%rdx, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/f2i.dis
+++ b/test/golden/x86_64-darwin/convert/f2i.dis
@@ -5,128 +5,394 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2i.fold_pos>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movss	%xmm0, -0x10(%rbp)
-               	movsd	%xmm1, -0x20(%rbp)
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	cvttss2si	%xmm0, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	cvttss2si	%xmm0, %r11
+               	movw	%r11w, %ax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x65>
-               	jb	 <L3>
-               	movaps	%xmm14, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x78>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L4>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	cvttss2si	%xmm14, %r11
+               	cvttss2si	%xmm0, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r11, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
+               	ucomiss	, %xmm0 <corpus.cases.convert.f2i.fold_pos+0x12c>
+               	jb	 <L6>
+               	movaps	%xmm0, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x13f>
                	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	callq	 <L9>
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L7>
+<L6>:
+               	cvttss2si	%xmm0, %r11
+<L7>:
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	callq	 <L10>
+               	cvttss2si	%xmm0, %r11d
+               	movb	%r11b, %al
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	callq	 <L11>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	cvttss2si	%xmm0, %r11d
+               	movw	%r11w, %ax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x14e>
-               	jb	 <L13>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x161>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm0, %r11d
+               	movl	%r11d, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	cvttsd2si	%xmm1, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	cvttsd2si	%xmm1, %r11
+               	movw	%r11w, %ax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm1, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	ucomisd	, %xmm1 <corpus.cases.convert.f2i.fold_pos+0x445>
+               	jb	 <L24>
+               	movaps	%xmm1, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x458>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L14>
-<L13>:
-               	cvttsd2si	%xmm14, %r11
-<L14>:
-               	movq	%r11, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	callq	 <L19>
-<L19>:
+               	jmp	 <L25>
+<L24>:
+               	cvttsd2si	%xmm1, %r11
+<L25>:
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	cvttsd2si	%xmm1, %r11d
+               	movb	%r11b, %al
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	cvttsd2si	%xmm1, %r11d
+               	movw	%r11w, %ax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm1, %r11d
+               	movl	%r11d, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm1, %r11
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -139,51 +405,55 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, -0x20(%rbp)
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %al
+               	movsbq	%al, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %cx
+               	movswq	%cx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
-               	movl	%ecx, %esi
+               	movslq	%ecx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %cl
+               	movsbq	%cl, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %cx
+               	movswq	%cx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
                	movl	%r11d, %ecx
-               	movl	%ecx, %esi
+               	movslq	%ecx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
                	movq	%rbp, %rsp
@@ -193,260 +463,529 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2i.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
+<L1>:
                	movss	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L4>:
+<L3>:
                	movsd	%xmm14, -0x20(%rbp)
-               	movss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x86>
-               	addss	-0x10(%rbp), %xmm14
-               	movss	%xmm14, -0x30(%rbp)
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x9b>
-               	addsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7a>
+               	addss	-0x10(%rbp), %xmm2
+               	movsd	, %xmm3 <corpus.cases.convert.f2i.checksum+0x87>
+               	addsd	-0x20(%rbp), %xmm3
+               	cvttss2si	%xmm2, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	cvttss2si	%xmm2, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movss	-0x30(%rbp), %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.convert.f2i.checksum+0xfa>
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L8>
-               	movaps	%xmm14, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x10d>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L9>
 <L8>:
-               	cvttss2si	%xmm14, %r11
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movss	-0x30(%rbp), %xmm14
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x1b6>
+               	jb	 <L10>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1c9>
                	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L11>
+<L10>:
+               	cvttss2si	%xmm2, %r11
+<L11>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm2, %r11d
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L16>
+               	cvttss2si	%xmm2, %r11d
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movsd	-0x40(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1e3>
+               	cvttss2si	%xmm2, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1f6>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	cvttss2si	%xmm2, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm3, %r11
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	cvttsd2si	%xmm3, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	cvttsd2si	%xmm3, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	ucomisd	, %xmm3 <corpus.cases.convert.f2i.checksum+0x4cf>
+               	jb	 <L28>
+               	movaps	%xmm3, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x4e2>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L19>
-<L18>:
-               	cvttsd2si	%xmm14, %r11
-<L19>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L23>
-<L23>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x280>
-               	xorps	, %xmm2 <corpus.cases.convert.f2i.checksum+0x287>
+               	jmp	 <L29>
+<L28>:
+               	cvttsd2si	%xmm3, %r11
+<L29>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm3, %r11d
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm3, %r11d
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	cvttsd2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	cvttsd2si	%xmm3, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+<L39>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x6cf>
+               	xorps	, %xmm2 <corpus.cases.convert.f2i.checksum+0x6d6>
                	movss	%xmm2, %xmm14           ## xmm14 = xmm2[0],xmm14[1,2,3]
                	subss	-0x10(%rbp), %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x2a1>
+               	movss	%xmm14, -0x30(%rbp)
+               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x6f0>
                	subsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	movss	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x40(%rbp)
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L40>
+<L40>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L41>
+<L41>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L27>
-<L27>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L42>
+<L42>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L43>
+<L43>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L44>
+<L44>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L45>
+<L45>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L31>
-<L31>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L46>
+<L46>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x36b>
+               	callq	 <L47>
+<L47>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7cc>
                	addss	-0x10(%rbp), %xmm2
                	cvttss2si	%xmm2, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x388>
+               	callq	 <L48>
+<L48>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7ed>
                	addss	-0x10(%rbp), %xmm2
                	cvttss2si	%xmm2, %r11
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x3a6>
+               	callq	 <L49>
+<L49>:
+               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x80f>
                	addsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x70(%rbp)
-               	movsd	-0x70(%rbp), %xmm14
+               	movsd	%xmm14, -0x50(%rbp)
+               	movsd	-0x50(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movsd	-0x70(%rbp), %xmm14
+               	callq	 <L50>
+<L50>:
+               	movsd	-0x50(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x3e6>
+               	callq	 <L51>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x857>
                	subsd	-0x20(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x78(%rbp), %rbx
+               	callq	 <L52>
+<L52>:
+               	movq	-0x58(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/f2u_high.dis
+++ b/test/golden/x86_64-darwin/convert/f2u_high.dis
@@ -5,11 +5,33 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2u_high.f32_u32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
                	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L0>
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -17,11 +39,33 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2u_high.f64_u32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
                	cvttsd2si	%xmm0, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L0>
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -29,10 +73,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2u_high.f32_u64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.f32_u64+0xb>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.f32_u64+0x13>
                	jb	 <L0>
                	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x1e>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x26>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -40,9 +86,29 @@ Disassembly of section __TEXT,__text:
 <L0>:
                	cvttss2si	%xmm0, %r11
 <L1>:
-               	movq	%r11, %rsi
-               	callq	 <L2>
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -50,10 +116,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2u_high.f64_u64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.f64_u64+0xc>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.f64_u64+0x14>
                	jb	 <L0>
                	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x1f>
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x27>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -61,9 +129,29 @@ Disassembly of section __TEXT,__text:
 <L0>:
                	cvttsd2si	%xmm0, %r11
 <L1>:
-               	movq	%r11, %rsi
-               	callq	 <L2>
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -71,176 +159,291 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.f2u_high.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm14
-               	addsd	%xmm14, %xmm14
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L3>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6c>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movsd	%xmm14, -0x20(%rbp)
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x82>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xa1>
-               	addss	-0x10(%rbp), %xmm2
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xde>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xc0>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xdf>
-               	addss	-0x10(%rbp), %xmm2
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x146>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xfe>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x11d>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
-<L10>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x13c>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
-<L11>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x15b>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
-<L12>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x17a>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x199>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
-<L14>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1b8>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1c4>
-               	jb	 <L15>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x1d7>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L16>
-<L15>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1ae>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x216>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x27e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2e6>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x206>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x212>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x34e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x225>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L19>
 <L18>:
-               	cvttss2si	%xmm2, %r11
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x3b6>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x254>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x260>
-               	jb	 <L21>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x273>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L22>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	cvttss2si	%xmm2, %r11
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x41e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2a2>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2ae>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x486>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x491>
                	jb	 <L24>
                	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x2c1>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x4a4>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -248,113 +451,334 @@ Disassembly of section __TEXT,__text:
 <L24>:
                	cvttss2si	%xmm2, %r11
 <L25>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L26>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2f0>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2fc>
-               	jb	 <L27>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x51d>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x528>
+               	jb	 <L28>
                	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x30f>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x53b>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L28>
-<L27>:
-               	cvttss2si	%xmm2, %r11
+               	jmp	 <L29>
 <L28>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
+               	cvttss2si	%xmm2, %r11
 <L29>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x33e>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x34b>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L30>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x35e>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L31>
 <L30>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
 <L31>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x38d>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x39a>
-               	jb	 <L33>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x3ad>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5b4>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5bf>
+               	jb	 <L32>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x5d2>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L34>
+               	jmp	 <L33>
+<L32>:
+               	cvttss2si	%xmm2, %r11
 <L33>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
 <L35>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3dc>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3e9>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x64b>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x656>
                	jb	 <L36>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x3fc>
-               	cvttsd2si	%xmm14, %r11
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x669>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
                	jmp	 <L37>
 <L36>:
-               	cvttsd2si	%xmm0, %r11
+               	cvttss2si	%xmm2, %r11
 <L37>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L38>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x42b>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x438>
-               	jb	 <L39>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x44b>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L40>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
 <L39>:
-               	cvttsd2si	%xmm0, %r11
-<L40>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x47a>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x487>
-               	jb	 <L42>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x49a>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6e2>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6ed>
+               	jb	 <L40>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x700>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
+               	jmp	 <L41>
+<L40>:
+               	cvttss2si	%xmm2, %r11
+<L41>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L42>
                	jmp	 <L43>
 <L42>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L42>
 <L43>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x779>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x785>
+               	jb	 <L44>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x798>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L45>
 <L44>:
-               	movq	-0x28(%rbp), %rbx
+               	cvttsd2si	%xmm0, %r11
+<L45>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L46>
+<L47>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x811>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x81d>
+               	jb	 <L48>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x830>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L49>
+<L48>:
+               	cvttsd2si	%xmm0, %r11
+<L49>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L50>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8a9>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8b5>
+               	jb	 <L52>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x8c8>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L53>
+<L52>:
+               	cvttsd2si	%xmm0, %r11
+<L53>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+<L55>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x941>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x94d>
+               	jb	 <L56>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x960>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L57>
+<L56>:
+               	cvttsd2si	%xmm0, %r11
+<L57>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L58>
+<L59>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9d9>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9e5>
+               	jb	 <L60>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x9f8>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L61>
+<L60>:
+               	cvttsd2si	%xmm0, %r11
+<L61>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+<L63>:
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/i2f.dis
+++ b/test/golden/x86_64-darwin/convert/i2f.dis
@@ -11,124 +11,423 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x38(%rbp)
                	movq	%r14, -0x40(%rbp)
                	movq	%r15, -0x48(%rbp)
-               	movq	%rsi, %rbx
-               	movq	%rdx, %r12
-               	movl	%ecx, %r13d
-               	movq	%r8, %r14
-               	movq	%r9, %r15
+               	movl	%ecx, %eax
+               	movq	%r8, %rbx
+               	movq	%r9, %r8
+               	movq	%r8, -0x20(%rbp)
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r8, -0x18(%rbp)
                	movq	0x18(%rbp), %r8
                	movq	%r8, -0x10(%rbp)
                	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movzbq	%bl, %r11
+               	movq	%r8, -0x8(%rbp)
+               	movzbq	%sil, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L0>
+               	movd	%xmm0, %r15d
+               	movl	%r15d, %r14d
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzbq	%bl, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L1>
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movzwq	%r12w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L2>
+               	movzbq	%sil, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movzwq	%r12w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r11d
+               	movzwq	%dx, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L4>
+               	movd	%xmm0, %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r11d
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L5>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %r11
-               	testq	%r11, %r11
-               	jl	 <L6>
-               	cvtsi2ss	%r11, %xmm0
+               	movzwq	%dx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
                	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%eax, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movl	%eax, %r11d
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L12>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L7>:
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %r11
+<L13>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L16>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L10>:
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movsbq	%r15b, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movsbq	%r15b, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movswq	%r8w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movswq	%r8w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
                	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
-               	callq	 <L19>
-<L19>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
@@ -141,179 +440,482 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.convert.i2f.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movw	%bx, %cx
-               	movl	%ecx, %r13d
-               	orl	$0x8000, %r13d          ## imm = 0x8000
-               	movl	%ebx, %ecx
-               	movl	%ecx, %r14d
-               	orl	$0x80000000, %r14d      ## imm = 0x80000000
-               	movq	%rbx, %r15
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movw	%di, %dx
+               	orl	$0x8000, %edx           ## imm = 0x8000
+               	movl	%edi, %esi
+               	orl	$0x80000000, %esi       ## imm = 0x80000000
+               	movq	%rdi, %r8
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	orq	%r11, %r15
-               	movzbq	%r12b, %r11
+               	orq	%r11, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movzbq	%al, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L1>
+               	movd	%xmm0, %r12d
+               	movl	%r12d, %r13d
+               	movabsq	$-0x340d631b7bdddcdb, %r12 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movzbq	%r12b, %r11
+               	movzbq	%al, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L2>
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movzwq	%r13w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L3>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
 <L3>:
-               	movzwq	%r13w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L4>
+               	movzwq	%dx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movl	%r14d, %r11d
+               	movzwq	%dx, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L7>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
 <L7>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
+               	movl	%esi, %r11d
                	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L10>
+               	movl	%esi, %r11d
                	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movsbq	%r12b, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	movsbq	%r12b, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	movswq	%r13w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	movswq	%r13w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movslq	%r14d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	movslq	%r14d, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%r15, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%r15, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	orq	$0x1, %rbx
-               	movq	$0x0, %r12
-               	subq	%rbx, %r12
-               	movq	%rbx, %r11
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L21>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L22>:
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	%rbx, %r11
+<L13>:
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L16>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%r12, %r11
+<L17>:
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+<L19>:
+               	movsbq	%al, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	%r12, %r11
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movsbq	%al, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movswq	%dx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movswq	%dx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movslq	%esi, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movslq	%esi, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rbx
+               	orq	$0x1, %rbx
+               	movq	$0x0, %r13
+               	subq	%rbx, %r13
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L37>
+<L36>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L37>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	%r12, %rdi
+               	callq	 <L38>
+<L38>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L39>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L40>
+<L39>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L40>:
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	%r13, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	movq	%r13, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/convert/trunc.dis
+++ b/test/golden/x86_64-darwin/convert/trunc.dis
@@ -11,67 +11,204 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
-               	xorq	%r11, %rbx
-               	orq	$0x1, %rbx
-               	movl	%ebx, %r12d
-               	movw	%bx, %r13w
-               	movb	%bl, %r14b
-               	movl	%r12d, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	xorl	$0x55555555, %ecx       ## imm = 0x55555555
-               	movw	%cx, %bx
-               	movb	%cl, %r15b
-               	movq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	xorl	$0x5555, %ecx           ## imm = 0x5555
-               	movb	%cl, %r8b
+               	xorq	%r11, %rdi
+               	orq	$0x1, %rdi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movw	%di, %dx
+               	movb	%dil, %r8b
                	movq	%r8, -0x8(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %rbx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
+<L1>:
+               	movzwq	%dx, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L6>
+               	movzbq	%r8b, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+<L5>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edi
+               	xorl	$0x55555555, %edi       ## imm = 0x55555555
+               	movw	%di, %r12w
+               	movb	%dil, %r13b
+               	movzwq	%r12w, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	movzwq	%r13w, %rsi
-               	addq	%rsi, %rcx
-               	movzbq	%r14b, %rsi
-               	addq	%rsi, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L7>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rbx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rbx
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movzwq	%bx, %rcx
-               	movzbq	%r15b, %rsi
-               	addq	%rsi, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	addq	%rsi, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L8>
+               	movzbq	%r13b, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+<L9>:
+               	movl	%edx, %esi
+               	xorl	$0x5555, %esi           ## imm = 0x5555
+               	movb	%sil, %dil
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rsi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rbx, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rbx
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+<L11>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	movzwq	%dx, %rsi
+               	addq	%rsi, %rax
+               	movq	-0x8(%rbp), %r8
+               	movzbq	%r8b, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movzwq	%r12w, %rax
+               	movzbq	%r13b, %rdx
+               	addq	%rdx, %rax
+               	movzbq	%dil, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-darwin/float/arith_f32.dis
+++ b/test/golden/x86_64-darwin/float/arith_f32.dis
@@ -12,27 +12,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       ## imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -44,138 +83,69 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x108(%rbp)
                	movq	%r12, -0x110(%rbp)
                	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
-               	movl	%ebx, %r13d
+               	movl	%edi, %ebx
                	movl	$0x3f800000, %eax       ## imm = 0x3F800000
-               	addl	%r13d, %eax
+               	addl	%ebx, %eax
                	movl	%eax, -0x30(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x49>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x35>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x10(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x5e>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4a>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x20(%rbp)
                	movss	-0x10(%rbp), %xmm0
                	addss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
-<L2>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rbx
-<L4>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movss	-0x10(%rbp), %xmm0
                	subss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rdi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
-<L6>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %r12
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movss	-0x20(%rbp), %xmm0
                	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
-<L10>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rbx
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L2>
+<L2>:
                	movss	-0x10(%rbp), %xmm0
                	mulss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
-<L14>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %r12
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	movss	-0x10(%rbp), %xmm0
                	divss	-0x20(%rbp), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	movss	-0x20(%rbp), %xmm0
                	divss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movss	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1a6>
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd5>
                	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm14, %xmm14
                	subss	-0x10(%rbp), %xmm14
                	movss	%xmm14, -0x40(%rbp)
                	movq	%rax, %rdi
                	movss	-0x40(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movss	-0x10(%rbp), %xmm0
                	subss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movss	-0x40(%rbp), %xmm0
                	addss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1f8>
+               	callq	 <L9>
+<L9>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x127>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x50(%rbp)
                	movss	-0x30(%rbp), %xmm14
@@ -183,13 +153,13 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm14, -0x60(%rbp)
                	movq	%rax, %rdi
                	movss	-0x60(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movss	-0x60(%rbp), %xmm0
                	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movss	-0x30(%rbp), %xmm0
                	subss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
@@ -197,24 +167,24 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
                	subss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x266>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x195>
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27b>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1aa>
                	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x28b>
+               	callq	 <L14>
+<L14>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1ba>
                	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x2a1>
+               	callq	 <L15>
+<L15>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1d0>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x70(%rbp)
                	movss	-0x70(%rbp), %xmm14
@@ -222,1306 +192,1109 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm14, -0x80(%rbp)
                	movq	%rax, %rdi
                	movss	-0x80(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movss	-0x80(%rbp), %xmm0
                	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movss	-0x30(%rbp), %xmm0
                	addss	-0x30(%rbp), %xmm0
                	movss	-0x70(%rbp), %xmm5
                	addss	%xmm0, %xmm5
                	movq	%rax, %rdi
                	movss	%xmm5, %xmm0            ## xmm0 = xmm5[0],xmm0[1,2,3]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movss	-0x70(%rbp), %xmm0
                	subss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movss	-0x80(%rbp), %xmm0
                	subss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulss	-0x30(%rbp), %xmm0
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
                	movsd	%xmm0, -0xa0(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x18, %r12d
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	movl	$0x0, %r13d
+               	cmpl	$0x18, %r13d
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movss	-0xa0(%rbp), %xmm0
                	addss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x364>
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x293>
                	movss	%xmm14, -0x90(%rbp)
-               	movss	-0x90(%rbp), %xmm14
-               	ucomiss	-0x90(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
-               	movq	%rbx, %rdi
+               	movq	%r12, %rdi
                	movss	-0x90(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r14
-               	jmp	 <L38>
-<L36>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
-<L38>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
+               	callq	 <L22>
+<L22>:
+               	addl	$0x1, %r13d
+               	movq	%rax, %r12
                	movq	-0x90(%rbp), %r11
                	movq	%r11, -0xa0(%rbp)
-               	cmpl	$0x18, %r12d
-               	jb	 <L34>
-<L39>:
+               	cmpl	$0x18, %r13d
+               	jb	 <L21>
+<L23>:
                	movl	$0x7f7fffff, %eax       ## imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
+               	addl	%ebx, %eax
                	movl	%eax, -0xb0(%rbp)
-               	movss	-0xb0(%rbp), %xmm14
-               	ucomiss	-0xb0(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
-               	movq	%rbx, %rdi
-               	movss	-0xb0(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r12
-               	jmp	 <L43>
-<L41>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r12
-<L43>:
-               	movss	-0xb0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x448>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
                	movq	%r12, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rbx
-               	jmp	 <L47>
-<L45>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rbx
-<L47>:
+               	movss	-0xb0(%rbp), %xmm0
+               	callq	 <L24>
+<L24>:
+               	movss	-0xb0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x2f8>
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	movss	-0xb0(%rbp), %xmm0
                	addss	-0xb0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%rbx, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r12
-               	jmp	 <L51>
-<L49>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %r12
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	movss	-0xb0(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4dc>
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x32a>
                	movss	%xmm14, -0xc0(%rbp)
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
                	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm0, %xmm0
                	subss	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movss	-0xb0(%rbp), %xmm0
                	mulss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movss	-0xb0(%rbp), %xmm0
                	subss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movl	$0x800000, %ecx         ## imm = 0x800000
-               	addl	%r13d, %ecx
+               	addl	%ebx, %ecx
                	movl	%ecx, -0xd0(%rbp)
                	movl	$0x1, %ecx
-               	addl	%r13d, %ecx
+               	addl	%ebx, %ecx
                	movl	%ecx, -0xe0(%rbp)
                	movss	-0xd0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x564>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3b0>
                	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movss	-0xd0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57c>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3c8>
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movss	-0xd0(%rbp), %xmm0
                	subss	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movss	-0xd0(%rbp), %xmm0
                	mulss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movss	-0xe0(%rbp), %xmm0
                	addss	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5d9>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x425>
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5f1>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x43d>
                	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x609>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x455>
                	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movss	-0xe0(%rbp), %xmm0
                	divss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x635>
+               	callq	 <L39>
+<L39>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x47e>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0xf0(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x64d>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x496>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x100(%rbp)
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movss	-0xf0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x693>
-               	movss	-0xf0(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movss	-0xf0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x4dc>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	movss	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomiss	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	-0xf0(%rbp), %xmm0
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xf0(%rbp), %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	-0x100(%rbp), %xmm4
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm4, %xmm4
                	subss	-0x100(%rbp), %xmm4
-<L72>:
+<L47>:
                	movss	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x75c>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x5a5>
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-<L73>:
+<L48>:
                	ucomiss	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm7            ## xmm7 = xmm0[0],xmm7[1]
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-<L74>:
+<L49>:
                	ucomiss	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movss	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomiss	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
-<L79>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7e2>
+<L54>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x62b>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L74>
-<L80>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f4>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x63d>
+               	jmp	 <L48>
+<L56>:
                	movss	-0xf0(%rbp), %xmm0
                	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
                	mulss	-0x100(%rbp), %xmm4
                	movss	-0xf0(%rbp), %xmm9
                	subss	%xmm4, %xmm9
-<L82>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rdi
+<L57>:
+               	movq	%rax, %rdi
                	movss	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r12
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subss	-0xf0(%rbp), %xmm0
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8b0>
-               	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x6c7>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm4, %xmm4
-               	subss	%xmm0, %xmm4
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	-0x100(%rbp), %xmm5
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm5, %xmm5
                	subss	-0x100(%rbp), %xmm5
-<L94>:
+<L66>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x95a>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x771>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L95>:
+<L67>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9e1>
+<L73>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x7f8>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L96>
-<L102>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9f3>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x80a>
+               	jmp	 <L67>
+<L75>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	-0x100(%rbp), %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	-0x100(%rbp), %xmm5
                	movss	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
-<L104>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%r12, %rdi
+<L76>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subss	-0x100(%rbp), %xmm0
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movss	-0xf0(%rbp), %xmm4
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaa2>
-               	movss	-0xf0(%rbp), %xmm14
-               	ucomiss	%xmm4, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movss	-0xf0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x887>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm4, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	movss	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomiss	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	-0xf0(%rbp), %xmm4
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm4, %xmm4
-               	subss	-0xf0(%rbp), %xmm4
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0xf0(%rbp), %xmm4
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm5, %xmm5
                	subss	%xmm0, %xmm5
-<L116>:
+<L85>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb5f>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x944>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L117>:
+<L86>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbe6>
+<L92>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9cb>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L118>
-<L124>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbf8>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9dd>
+               	jmp	 <L86>
+<L94>:
                	movss	-0xf0(%rbp), %xmm4
                	divss	%xmm0, %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm0, %xmm5
                	movss	-0xf0(%rbp), %xmm10
                	subss	%xmm5, %xmm10
-<L126>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rdi
+<L95>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r12
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subss	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
                	subss	-0x100(%rbp), %xmm2
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm2
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xcae>
-               	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa61>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
-               	testb	%cl, %cl
-               	jne	 <L147>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm4, %xmm4
-               	subss	%xmm0, %xmm4
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm2, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L137>
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm2, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-               	jmp	 <L138>
-<L137>:
+               	jmp	 <L104>
+<L103>:
                	xorps	%xmm5, %xmm5
                	subss	%xmm2, %xmm5
-<L138>:
+<L104>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd4c>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xaff>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L139>:
+<L105>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L146>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
                	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L140>:
+<L106>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
                	testb	%cl, %cl
-               	jne	 <L143>
-               	testb	%al, %al
-               	jne	 <L141>
+               	jne	 <L107>
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L142>
-<L141>:
+               	jmp	 <L108>
+<L107>:
                	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L142>
-<L142>:
-               	jmp	 <L148>
-<L143>:
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L144>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L145>
-<L144>:
+               	jmp	 <L111>
+<L110>:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdd3>
+<L111>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xb86>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L140>
-<L146>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xde5>
-               	jmp	 <L139>
-<L147>:
+               	jmp	 <L106>
+<L112>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xb98>
+               	jmp	 <L105>
+<L113>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	%xmm2, %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm2, %xmm5
                	movss	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
-<L148>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
+<L114>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe5b>
+               	callq	 <L115>
+<L115>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xbdc>
                	mulss	-0x30(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe69>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbea>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe93>
-               	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
+               	jne	 <L118>
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xc14>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L154>:
-               	jmp	 <L156>
-<L155>:
-               	movq	%rax, %rcx
-<L156>:
-               	testb	%cl, %cl
-               	jne	 <L169>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L117>:
+               	jmp	 <L119>
+<L118>:
+               	movq	%rcx, %rdx
+<L119>:
+               	testb	%dl, %dl
+               	jne	 <L132>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L158>
-<L157>:
-               	xorps	%xmm2, %xmm2
-               	subss	%xmm0, %xmm2
-<L158>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xf0a>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L159>
-               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf21>
-               	jmp	 <L160>
-<L159>:
+               	jne	 <L120>
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L121>
+<L120>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L121>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xc8b>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L122>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	jmp	 <L123>
+<L122>:
                	xorps	%xmm4, %xmm4
-               	subss	, %xmm4 <L160>
-<L160>:
+               	subss	, %xmm4 <L123>
+<L123>:
                	movss	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf3d>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xcbe>
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-<L161>:
+<L124>:
                	ucomiss	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L168>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
                	movsd	%xmm2, %xmm7            ## xmm7 = xmm2[0],xmm7[1]
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-<L162>:
+<L125>:
                	ucomiss	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L128>
                	testb	%cl, %cl
-               	jne	 <L165>
-               	testb	%al, %al
-               	jne	 <L163>
+               	jne	 <L126>
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L164>
-<L163>:
+               	jmp	 <L127>
+<L126>:
                	movss	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L164>
-<L164>:
-               	jmp	 <L170>
-<L165>:
+               	xorps	, %xmm9 <L127>
+<L127>:
+               	jmp	 <L133>
+<L128>:
                	ucomiss	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L166>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L129>
                	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L167>
-<L166>:
+               	jmp	 <L130>
+<L129>:
                	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
-<L167>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfc3>
+<L130>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xd44>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L162>
-<L168>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfd5>
-               	jmp	 <L161>
-<L169>:
+               	jmp	 <L125>
+<L131>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd56>
+               	jmp	 <L124>
+<L132>:
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfe6>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xd67>
                	cvttss2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1002>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xd83>
                	movss	%xmm0, %xmm9            ## xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm4, %xmm9
-<L170>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rdi
+<L133>:
+               	movq	%rax, %rdi
                	movss	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1,2,3]
-               	callq	 <L171>
-<L171>:
-               	movq	%rax, %r12
-               	jmp	 <L174>
-<L172>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L173>
-<L173>:
-               	movq	%rax, %r12
-<L174>:
+               	callq	 <L134>
+<L134>:
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L177>
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
                	movss	-0x30(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x107f>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xdce>
                	movss	-0x30(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L135>
+               	jmp	 <L136>
+<L135>:
+               	movss	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L136>:
+               	jmp	 <L138>
+<L137>:
+               	movq	%rcx, %rdx
+<L138>:
+               	testb	%dl, %dl
+               	jne	 <L151>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x30(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L139>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L140>
+<L139>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x30(%rbp), %xmm0
+<L140>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L141>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L142>:
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xe88>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L143>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L144>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	testb	%cl, %cl
+               	jne	 <L145>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L146>
+<L145>:
+               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L146>
+<L146>:
+               	jmp	 <L152>
+<L147>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L148>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L149>
+<L148>:
+               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L149>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xf0a>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L144>
+<L150>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf1c>
+               	jmp	 <L143>
+<L151>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x30(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L152>:
+               	movq	%rax, %rdi
+               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L153>
+<L153>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L156>
+               	movss	-0x100(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf99>
+               	movss	-0x100(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L154>
+               	jmp	 <L155>
+<L154>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L155>:
+               	jmp	 <L157>
+<L156>:
+               	movq	%rcx, %rdx
+<L157>:
+               	testb	%dl, %dl
+               	jne	 <L170>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L158>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L159>
+<L158>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x100(%rbp), %xmm0
+<L159>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L160>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L161>
+<L160>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L161>:
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1062>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L162>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L163>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L165>
+<L164>:
+               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L165>
+<L165>:
+               	jmp	 <L171>
+<L166>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L167>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L168>
+<L167>:
+               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L168>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x10e4>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L163>
+<L169>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x10f6>
+               	jmp	 <L162>
+<L170>:
+               	movss	-0x100(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x100(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L171>:
+               	movq	%rax, %rdi
+               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L172>
+<L172>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x114a>
+               	mulss	-0x30(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L175>
-               	jmp	 <L176>
-<L175>:
-               	movss	-0x30(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L176>:
-               	jmp	 <L178>
-<L177>:
-               	movq	%rax, %rcx
-<L178>:
-               	testb	%cl, %cl
-               	jne	 <L191>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x30(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movsd	-0x30(%rbp), %xmm0
-               	jmp	 <L180>
-<L179>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x30(%rbp), %xmm0
-<L180>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L181>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L182>
-<L181>:
-               	xorps	%xmm2, %xmm2
-               	subss	-0x100(%rbp), %xmm2
-<L182>:
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1139>
-               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L183>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L190>
-               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L184>:
-               	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	testb	%al, %al
-               	jne	 <L185>
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L186>
-<L185>:
-               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L186>
-<L186>:
-               	jmp	 <L192>
-<L187>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L188>
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L189>
-<L188>:
-               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
-               	subss	%xmm7, %xmm9
-<L189>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11bb>
-               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L184>
-<L190>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11cd>
-               	jmp	 <L183>
-<L191>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	-0x100(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0x100(%rbp), %xmm2
-               	movss	-0x30(%rbp), %xmm8
-               	subss	%xmm2, %xmm8
-<L192>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L194>
-               	movq	%r12, %rdi
-               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L193>
-<L193>:
-               	movq	%rax, %rbx
-               	jmp	 <L196>
-<L194>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L195>
-<L195>:
-               	movq	%rax, %rbx
-<L196>:
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L199>
-               	movss	-0x100(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x127c>
-               	movss	-0x100(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L197>
-               	jmp	 <L198>
-<L197>:
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L198>:
-               	jmp	 <L200>
-<L199>:
-               	movq	%rax, %rcx
-<L200>:
-               	testb	%cl, %cl
-               	jne	 <L213>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L201>
-               	movsd	-0x100(%rbp), %xmm0
-               	jmp	 <L202>
-<L201>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x100(%rbp), %xmm0
-<L202>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L203>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L204>
-<L203>:
-               	xorps	%xmm2, %xmm2
-               	subss	-0x100(%rbp), %xmm2
-<L204>:
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1345>
-               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L205>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L212>
-               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L206>:
-               	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	testb	%al, %al
-               	jne	 <L207>
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L208>
-<L207>:
-               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L208>
-<L208>:
-               	jmp	 <L214>
-<L209>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L210>
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L211>
-<L210>:
-               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
-               	subss	%xmm7, %xmm9
-<L211>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13c7>
-               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L206>
-<L212>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13d9>
-               	jmp	 <L205>
-<L213>:
-               	movss	-0x100(%rbp), %xmm0
-               	divss	-0x100(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0x100(%rbp), %xmm2
-               	movss	-0x100(%rbp), %xmm8
-               	subss	%xmm2, %xmm8
-<L214>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L216>
-               	movq	%rbx, %rdi
-               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %r12
-               	jmp	 <L218>
-<L216>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r12
-<L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x145f>
-               	mulss	-0x30(%rbp), %xmm0
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L221>
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1497>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1182>
                	ucomiss	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L219>
-               	jmp	 <L220>
-<L219>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L173>
+               	jmp	 <L174>
+<L173>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L220>:
-               	jmp	 <L222>
-<L221>:
-               	movq	%rax, %rcx
-<L222>:
-               	testb	%cl, %cl
-               	jne	 <L235>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L174>:
+               	jmp	 <L176>
+<L175>:
+               	movq	%rcx, %rdx
+<L176>:
+               	testb	%dl, %dl
+               	jne	 <L189>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L223>
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L224>
-<L223>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-<L224>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L225>
+               	jne	 <L177>
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L178>
+<L177>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L178>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L179>
                	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	xorps	%xmm2, %xmm2
                	subss	-0x100(%rbp), %xmm2
-<L226>:
+<L180>:
                	movss	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1541>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x122c>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L227>:
+<L181>:
                	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L234>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L188>
                	movsd	%xmm1, %xmm6            ## xmm6 = xmm1[0],xmm6[1]
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L228>:
+<L182>:
                	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L185>
                	testb	%cl, %cl
-               	jne	 <L231>
-               	testb	%al, %al
-               	jne	 <L229>
+               	jne	 <L183>
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L230>
-<L229>:
+               	jmp	 <L184>
+<L183>:
                	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L230>
-<L230>:
-               	jmp	 <L236>
-<L231>:
+               	xorps	, %xmm8 <L184>
+<L184>:
+               	jmp	 <L190>
+<L185>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L232>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L186>
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L233>
-<L232>:
+               	jmp	 <L187>
+<L186>:
                	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
-<L233>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15c3>
+<L187>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x12ae>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L228>
-<L234>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15d5>
-               	jmp	 <L227>
-<L235>:
+               	jmp	 <L182>
+<L188>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x12c0>
+               	jmp	 <L181>
+<L189>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	-0x100(%rbp), %xmm1
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	-0x100(%rbp), %xmm2
                	movss	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1,2,3]
                	subss	%xmm2, %xmm8
-<L236>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r12, %rdi
+<L190>:
+               	movq	%rax, %rdi
                	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
-               	movq	%rbx, %rax
+               	callq	 <L191>
+<L191>:
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/arith_f64.dis
+++ b/test/golden/x86_64-darwin/float/arith_f64.dis
@@ -12,27 +12,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -44,137 +83,69 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x108(%rbp)
                	movq	%r12, -0x110(%rbp)
                	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
                	movabsq	$0x3ff0000000000000, %rax ## imm = 0x3FF0000000000000
                	addq	%rbx, %rax
                	movq	%rax, -0x30(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4c>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x3d>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x10(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x61>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x52>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x20(%rbp)
                	movsd	-0x10(%rbp), %xmm0
                	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %r13
-               	jmp	 <L4>
-<L2>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r13
-<L4>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movsd	-0x10(%rbp), %xmm0
                	subsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%r13, %rdi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
-<L6>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %r12
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movsd	-0x20(%rbp), %xmm0
                	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r13
-               	jmp	 <L12>
-<L10>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %r13
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L2>
+<L2>:
                	movsd	-0x10(%rbp), %xmm0
                	mulsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%r13, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
-<L14>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %r12
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	movsd	-0x10(%rbp), %xmm0
                	divsd	-0x20(%rbp), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	movsd	-0x20(%rbp), %xmm0
                	divsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movsd	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b5>
+               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xdd>
                	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm14, %xmm14
                	subsd	-0x10(%rbp), %xmm14
                	movsd	%xmm14, -0x40(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movsd	-0x10(%rbp), %xmm0
                	subsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movsd	-0x40(%rbp), %xmm0
                	addsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x207>
+               	callq	 <L9>
+<L9>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x12f>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x50(%rbp)
                	movsd	-0x30(%rbp), %xmm14
@@ -182,13 +153,13 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm14, -0x60(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movsd	-0x60(%rbp), %xmm0
                	mulsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movsd	-0x30(%rbp), %xmm0
                	subsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
@@ -196,24 +167,24 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
                	subsd	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x275>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x19d>
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x28a>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b2>
                	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x29a>
+               	callq	 <L14>
+<L14>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1c2>
                	divsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x2b0>
+               	callq	 <L15>
+<L15>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x1d8>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x70(%rbp)
                	movsd	-0x70(%rbp), %xmm14
@@ -221,161 +192,95 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm14, -0x80(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x80(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movsd	-0x80(%rbp), %xmm0
                	addsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movsd	-0x30(%rbp), %xmm0
                	addsd	-0x30(%rbp), %xmm0
                	movsd	-0x70(%rbp), %xmm5
                	addsd	%xmm0, %xmm5
                	movq	%rax, %rdi
                	movsd	%xmm5, %xmm0            ## xmm0 = xmm5[0],xmm0[1]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movsd	-0x70(%rbp), %xmm0
                	subsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movsd	-0x80(%rbp), %xmm0
                	subsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulsd	-0x30(%rbp), %xmm0
                	movq	%rax, %r12
                	movsd	%xmm0, -0xa0(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x18, %r13
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movsd	-0xa0(%rbp), %xmm0
                	addsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x374>
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x29c>
                	movsd	%xmm14, -0x90(%rbp)
-               	movsd	-0x90(%rbp), %xmm14
-               	ucomisd	-0x90(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
                	movq	%r12, %rdi
                	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r14
-               	jmp	 <L38>
-<L36>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
-<L38>:
+               	callq	 <L22>
+<L22>:
                	addq	$0x1, %r13
-               	movq	%r14, %r12
+               	movq	%rax, %r12
                	movq	-0x90(%rbp), %r11
                	movq	%r11, -0xa0(%rbp)
                	cmpq	$0x18, %r13
-               	jb	 <L34>
-<L39>:
+               	jb	 <L21>
+<L23>:
                	movabsq	$0x7fefffffffffffff, %rax ## imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, -0xb0(%rbp)
-               	movsd	-0xb0(%rbp), %xmm14
-               	ucomisd	-0xb0(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
                	movq	%r12, %rdi
                	movsd	-0xb0(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r13
-               	jmp	 <L43>
-<L41>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r13
-<L43>:
+               	callq	 <L24>
+<L24>:
                	movsd	-0xb0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x464>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
-               	movq	%r13, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %r12
-               	jmp	 <L47>
-<L45>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %r12
-<L47>:
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x308>
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	movsd	-0xb0(%rbp), %xmm0
                	addsd	-0xb0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%r12, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r13
-               	jmp	 <L51>
-<L49>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %r13
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	movsd	-0xb0(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4fe>
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x33a>
                	movsd	%xmm14, -0xc0(%rbp)
-               	movq	%r13, %rdi
+               	movq	%rax, %rdi
                	movsd	-0xc0(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movsd	-0xb0(%rbp), %xmm0
                	mulsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movsd	-0xb0(%rbp), %xmm0
                	subsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movabsq	$0x10000000000000, %rcx ## imm = 0x10000000000000
                	addq	%rbx, %rcx
                	movq	%rcx, -0xd0(%rbp)
@@ -383,1119 +288,988 @@ Disassembly of section __TEXT,__text:
                	addq	%rbx, %rcx
                	movq	%rcx, -0xe0(%rbp)
                	movsd	-0xd0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x58f>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x3cb>
                	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movsd	-0xd0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5a7>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x3e3>
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movsd	-0xd0(%rbp), %xmm0
                	subsd	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movsd	-0xd0(%rbp), %xmm0
                	mulsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movsd	-0xe0(%rbp), %xmm0
                	addsd	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x604>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x440>
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x61c>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x458>
                	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x634>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x470>
                	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movsd	-0xe0(%rbp), %xmm0
                	divsd	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x660>
+               	callq	 <L39>
+<L39>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x499>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0xf0(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x678>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4b1>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x100(%rbp)
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movsd	-0xf0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x6bf>
-               	movsd	-0xf0(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x4f8>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	movsd	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomisd	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	-0xf0(%rbp), %xmm0
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xf0(%rbp), %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	-0x100(%rbp), %xmm4
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm4, %xmm4
                	subsd	-0x100(%rbp), %xmm4
-<L72>:
+<L47>:
                	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x78c>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x5c5>
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-<L73>:
+<L48>:
                	ucomisd	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm7            ## xmm7 = xmm0[0],xmm7[1]
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-<L74>:
+<L49>:
                	ucomisd	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomisd	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
                	subsd	%xmm8, %xmm10
-<L79>:
-               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x815>
+<L54>:
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x64e>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L74>
-<L80>:
-               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x827>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x660>
+               	jmp	 <L48>
+<L56>:
                	movsd	-0xf0(%rbp), %xmm0
                	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
                	mulsd	-0x100(%rbp), %xmm4
                	movsd	-0xf0(%rbp), %xmm9
                	subsd	%xmm4, %xmm9
-<L82>:
-               	ucomisd	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rdi
+<L57>:
+               	movq	%rax, %rdi
                	movsd	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r12
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf0(%rbp), %xmm0
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e7>
-               	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x6eb>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm4, %xmm4
-               	subsd	%xmm0, %xmm4
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	-0x100(%rbp), %xmm5
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm5, %xmm5
                	subsd	-0x100(%rbp), %xmm5
-<L94>:
+<L66>:
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x995>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x799>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L95>:
+<L67>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa1f>
+<L73>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x823>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L96>
-<L102>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa31>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x835>
+               	jmp	 <L67>
+<L75>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
                	divsd	-0x100(%rbp), %xmm4
                	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	mulsd	-0x100(%rbp), %xmm5
                	movsd	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1]
                	subsd	%xmm5, %xmm10
-<L104>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%r12, %rdi
+<L76>:
+               	movq	%rax, %rdi
                	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subsd	-0x100(%rbp), %xmm0
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movsd	-0xf0(%rbp), %xmm4
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xae4>
-               	movsd	-0xf0(%rbp), %xmm14
-               	ucomisd	%xmm4, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movsd	-0xf0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8b3>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm4, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	movsd	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomisd	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	-0xf0(%rbp), %xmm4
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm4, %xmm4
-               	subsd	-0xf0(%rbp), %xmm4
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0xf0(%rbp), %xmm4
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm5, %xmm5
                	subsd	%xmm0, %xmm5
-<L116>:
+<L85>:
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xba5>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x974>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L117>:
+<L86>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc2f>
+<L92>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x9fe>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L118>
-<L124>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc41>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa10>
+               	jmp	 <L86>
+<L94>:
                	movsd	-0xf0(%rbp), %xmm4
                	divsd	%xmm0, %xmm4
                	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm0, %xmm5
                	movsd	-0xf0(%rbp), %xmm10
                	subsd	%xmm5, %xmm10
-<L126>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rdi
+<L95>:
+               	movq	%rax, %rdi
                	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r12
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
                	subsd	-0x100(%rbp), %xmm2
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm2
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcfb>
-               	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xa95>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L104>
+<L103>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm2, %xmm5
+<L104>:
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb37>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L105>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L106>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
+               	testb	%cl, %cl
+               	jne	 <L107>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L108>
+<L107>:
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L111>
+<L110>:
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L111>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xbc1>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L106>
+<L112>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xbd3>
+               	jmp	 <L105>
+<L113>:
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	%xmm2, %xmm4
+               	cvttsd2si	%xmm4, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm4
+               	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
+               	mulsd	%xmm2, %xmm5
+               	movsd	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L114>:
+               	movq	%rax, %rdi
+               	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L115>
+<L115>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xc17>
+               	mulsd	-0x30(%rbp), %xmm0
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xc28>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
                	setne	%cl
                	setp	%r11b
                	orb	%r11b, %cl
                	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
+<L117>:
                	testb	%cl, %cl
-               	jne	 <L147>
+               	jne	 <L128>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm4, %xmm4
-               	subsd	%xmm0, %xmm4
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm2, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L137>
-               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-               	jmp	 <L138>
-<L137>:
-               	xorps	%xmm5, %xmm5
-               	subsd	%xmm2, %xmm5
-<L138>:
-               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd9d>
-               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L139>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L146>
-               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
-               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-<L140>:
-               	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L143>
-               	testb	%al, %al
-               	jne	 <L141>
-               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L142>
-<L141>:
-               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L142>
-<L142>:
-               	jmp	 <L148>
-<L143>:
-               	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L144>
-               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L145>
-<L144>:
-               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
-               	subsd	%xmm9, %xmm11
-<L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe27>
-               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L140>
-<L146>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe39>
-               	jmp	 <L139>
-<L147>:
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	%xmm2, %xmm4
-               	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm4
-               	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
-               	mulsd	%xmm2, %xmm5
-               	movsd	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1]
-               	subsd	%xmm5, %xmm10
-<L148>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
-               	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xeb2>
-               	mulsd	-0x30(%rbp), %xmm0
+               	jne	 <L118>
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xec3>
-               	ucomisd	%xmm2, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-<L154>:
-               	testb	%al, %al
-               	jne	 <L165>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L156>
-<L155>:
+               	jmp	 <L119>
+<L118>:
                	xorps	%xmm2, %xmm2
                	subsd	%xmm0, %xmm2
-<L156>:
+<L119>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf35>
-               	movsd	, %xmm5 <L157>
-<L157>:
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc9a>
+               	movsd	, %xmm5 <L120>
+<L120>:
                	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L164>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L127>
                	movsd	%xmm2, %xmm6            ## xmm6 = xmm2[0],xmm6[1]
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L158>:
-               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf60>
-               	setae	%cl
-               	movzbq	%cl, %rcx
+<L121>:
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xcc5>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L124>
                	testb	%cl, %cl
-               	jne	 <L161>
-               	testb	%al, %al
-               	jne	 <L159>
+               	jne	 <L122>
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L160>
-<L159>:
+               	jmp	 <L123>
+<L122>:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L160>
-<L160>:
-               	jmp	 <L166>
-<L161>:
+               	xorps	, %xmm8 <L123>
+<L123>:
+               	jmp	 <L129>
+<L124>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L162>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L125>
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L163>
-<L162>:
+               	jmp	 <L126>
+<L125>:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
-<L163>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfc2>
+<L126>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xd27>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L158>
-<L164>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfd4>
-               	jmp	 <L157>
-<L165>:
+               	jmp	 <L121>
+<L127>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xd39>
+               	jmp	 <L120>
+<L128>:
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfe5>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xd4a>
                	cvttsd2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm2
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1001>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xd66>
                	movsd	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm4, %xmm8
-<L166>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L168>
-               	movq	%rbx, %rdi
+<L129>:
+               	movq	%rax, %rdi
                	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L167>
-<L167>:
-               	movq	%rax, %r12
-               	jmp	 <L170>
-<L168>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L169>
-<L169>:
-               	movq	%rax, %r12
-<L170>:
+               	callq	 <L130>
+<L130>:
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L173>
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L133>
                	movsd	-0x30(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1082>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xdb2>
                	movsd	-0x30(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	movsd	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rcx, %rdx
+<L134>:
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x30(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L135>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x30(%rbp), %xmm0
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L137>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L138>:
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xe70>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L139>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L146>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L140>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L143>
+               	testb	%cl, %cl
+               	jne	 <L141>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L142>
+<L141>:
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L142>
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L144>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L145>
+<L144>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L145>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xef5>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xf07>
+               	jmp	 <L139>
+<L147>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x30(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L148>:
+               	movq	%rax, %rdi
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L149>
+<L149>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L152>
+               	movsd	-0x100(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xf85>
+               	movsd	-0x100(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	jmp	 <L151>
+<L150>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L151>:
+               	jmp	 <L153>
+<L152>:
+               	movq	%rcx, %rdx
+<L153>:
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L154>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L155>
+<L154>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x100(%rbp), %xmm0
+<L155>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L156>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L157>
+<L156>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L157>:
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1052>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L158>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L165>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L159>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L162>
+               	testb	%cl, %cl
+               	jne	 <L160>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L161>
+<L160>:
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L161>
+<L161>:
+               	jmp	 <L167>
+<L162>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L163>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L164>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x10d7>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L159>
+<L165>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x10e9>
+               	jmp	 <L158>
+<L166>:
+               	movsd	-0x100(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x100(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L167>:
+               	movq	%rax, %rdi
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L168>
+<L168>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x113d>
+               	mulsd	-0x30(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L171>
-               	jmp	 <L172>
-<L171>:
-               	movsd	-0x30(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L172>:
-               	jmp	 <L174>
-<L173>:
-               	movq	%rax, %rcx
-<L174>:
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x30(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movsd	-0x30(%rbp), %xmm0
-               	jmp	 <L176>
-<L175>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x30(%rbp), %xmm0
-<L176>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L177>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L178>
-<L177>:
-               	xorps	%xmm2, %xmm2
-               	subsd	-0x100(%rbp), %xmm2
-<L178>:
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1140>
-               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L179>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L186>
-               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L180>:
-               	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L183>
-               	testb	%al, %al
-               	jne	 <L181>
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L182>
-<L181>:
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L182>
-<L182>:
-               	jmp	 <L188>
-<L183>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L184>
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L185>
-<L184>:
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	subsd	%xmm7, %xmm9
-<L185>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11c5>
-               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L180>
-<L186>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d7>
-               	jmp	 <L179>
-<L187>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	-0x100(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0x100(%rbp), %xmm2
-               	movsd	-0x30(%rbp), %xmm8
-               	subsd	%xmm2, %xmm8
-<L188>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L190>
-               	movq	%r12, %rdi
-               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L189>
-<L189>:
-               	movq	%rax, %rbx
-               	jmp	 <L192>
-<L190>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L191>
-<L191>:
-               	movq	%rax, %rbx
-<L192>:
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L195>
-               	movsd	-0x100(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x128a>
-               	movsd	-0x100(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L193>
-               	jmp	 <L194>
-<L193>:
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L194>:
-               	jmp	 <L196>
-<L195>:
-               	movq	%rax, %rcx
-<L196>:
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L197>
-               	movsd	-0x100(%rbp), %xmm0
-               	jmp	 <L198>
-<L197>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x100(%rbp), %xmm0
-<L198>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L199>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L200>
-<L199>:
-               	xorps	%xmm2, %xmm2
-               	subsd	-0x100(%rbp), %xmm2
-<L200>:
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1357>
-               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L201>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L208>
-               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L202>:
-               	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L205>
-               	testb	%al, %al
-               	jne	 <L203>
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L204>
-<L203>:
-               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L204>
-<L204>:
-               	jmp	 <L210>
-<L205>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L206>
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L207>
-<L206>:
-               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	subsd	%xmm7, %xmm9
-<L207>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13dc>
-               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L202>
-<L208>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13ee>
-               	jmp	 <L201>
-<L209>:
-               	movsd	-0x100(%rbp), %xmm0
-               	divsd	-0x100(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0x100(%rbp), %xmm2
-               	movsd	-0x100(%rbp), %xmm8
-               	subsd	%xmm2, %xmm8
-<L210>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L212>
-               	movq	%rbx, %rdi
-               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r12
-               	jmp	 <L214>
-<L212>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %r12
-<L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1477>
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L217>
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x14b0>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1176>
                	ucomisd	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L215>
-               	jmp	 <L216>
-<L215>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	jmp	 <L170>
+<L169>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L216>:
-               	jmp	 <L218>
-<L217>:
-               	movq	%rax, %rcx
-<L218>:
-               	testb	%cl, %cl
-               	jne	 <L231>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L170>:
+               	jmp	 <L172>
+<L171>:
+               	movq	%rcx, %rdx
+<L172>:
+               	testb	%dl, %dl
+               	jne	 <L185>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L219>
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L220>
-<L219>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-<L220>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L221>
+               	jne	 <L173>
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L174>
+<L173>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L174>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L175>
                	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L222>
-<L221>:
+               	jmp	 <L176>
+<L175>:
                	xorps	%xmm2, %xmm2
                	subsd	-0x100(%rbp), %xmm2
-<L222>:
+<L176>:
                	movsd	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x155e>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1224>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
-<L223>:
+<L177>:
                	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L230>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L184>
                	movsd	%xmm1, %xmm6            ## xmm6 = xmm1[0],xmm6[1]
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
-<L224>:
+<L178>:
                	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L181>
                	testb	%cl, %cl
-               	jne	 <L227>
-               	testb	%al, %al
-               	jne	 <L225>
+               	jne	 <L179>
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L226>
-<L226>:
-               	jmp	 <L232>
-<L227>:
+               	xorps	, %xmm8 <L180>
+<L180>:
+               	jmp	 <L186>
+<L181>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L228>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L182>
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L229>
-<L228>:
+               	jmp	 <L183>
+<L182>:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
-<L229>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15e3>
+<L183>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x12a9>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L224>
-<L230>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15f5>
-               	jmp	 <L223>
-<L231>:
+               	jmp	 <L178>
+<L184>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x12bb>
+               	jmp	 <L177>
+<L185>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
                	divsd	-0x100(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
                	mulsd	-0x100(%rbp), %xmm2
                	movsd	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm2, %xmm8
-<L232>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%r12, %rdi
+<L186>:
+               	movq	%rax, %rdi
                	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %rbx
-               	jmp	 <L236>
-<L234>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %rbx
-<L236>:
-               	movq	%rbx, %rax
+               	callq	 <L187>
+<L187>:
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/cmp_f32.dis
+++ b/test/golden/x86_64-darwin/float/cmp_f32.dis
@@ -7,27 +7,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       ## imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,16 +74,13 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.cmp_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movl	%edi, %eax
                	leaq	-0x30(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
@@ -53,470 +89,648 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x20(%rbx)
                	movq	$0x0, 0x28(%rbx)
                	movl	$0xff800000, %edx       ## imm = 0xFF800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0xbf800000, %edx       ## imm = 0xBF800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x4(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80800000, %edx       ## imm = 0x80800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x8(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80000001, %edx       ## imm = 0x80000001
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0xc(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80000000, %edx       ## imm = 0x80000000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x10(%rbx), %rdx
                	movss	%xmm0, (%rdx)
-               	movd	%ecx, %xmm0
+               	movd	%eax, %xmm0
                	leaq	0x14(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x1, %edx
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x18(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x3f800000, %edx       ## imm = 0x3F800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x1c(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f7fffff, %edx       ## imm = 0x7F7FFFFF
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x20(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f800000, %edx       ## imm = 0x7F800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x24(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7fc00000, %edx       ## imm = 0x7FC00000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x28(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f800001, %edx       ## imm = 0x7F800001
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
-               	leaq	0x2c(%rbx), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	%rax, %r12
-               	movl	$0x0, %r13d
-               	cmpl	$0xc, %r13d
+               	leaq	0x2c(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x40(%rbp)
+               	movl	$0x0, %eax
+               	cmpl	$0xc, %eax
+               	jb	 <L0>
+               	jmp	 <L47>
+<L0>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	movl	$0x0, %r12d
+               	cmpl	$0xc, %r12d
                	jb	 <L1>
-               	jmp	 <L36>
+               	jmp	 <L46>
 <L1>:
-               	movl	%r13d, %eax
-               	leaq	(%rbx,%rax,4), %r14
-               	movq	%r12, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	cmpl	$0xc, %r8d
-               	jb	 <L2>
-               	jmp	 <L35>
-<L2>:
-               	movl	(%r14), %r11d
-               	movl	%r11d, -0x48(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x58(%rbp)
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%sil
+               	movq	-0x38(%rbp), %r8
+               	movss	(%r8), %xmm0
+               	movl	%r12d, %r13d
+               	leaq	(%rbx,%r13,4), %r14
+               	movss	(%r14), %xmm1
+               	ucomiss	%xmm1, %xmm0
+               	sete	%r13b
                	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%r15, %rdi
-               	callq	 <L3>
+               	andb	%r11b, %r13b
+               	movzbq	%r13b, %r13
+               	movzbq	%r13b, %r14
+               	movq	%rdx, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm1, %xmm0
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm1
                	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm1
                	setae	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L8>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	testb	%r8b, %r8b
-               	jne	 <L9>
-               	movq	$0x0, %rcx
-               	jmp	 <L10>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	$0x1, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L11>
-               	movq	%rcx, %rdx
-               	jmp	 <L12>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	addl	$0x2, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L13>
-               	movq	%rdx, %rcx
-               	jmp	 <L14>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	addl	$0x4, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L14>
+               	movq	$0x0, %rsi
+               	jmp	 <L15>
 <L14>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L15>
-               	movq	%rcx, %rdx
-               	jmp	 <L16>
+               	movq	$0x1, %rsi
 <L15>:
-               	addl	$0x8, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm0, %xmm1
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L16>
+               	movq	%rsi, %rdi
+               	jmp	 <L17>
 <L16>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L17>
-               	movq	%rdx, %rcx
-               	jmp	 <L18>
+               	addl	$0x2, %esi
+               	movq	%rsi, %rdi
 <L17>:
-               	addl	$0x10, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L18>
+               	movq	%rdi, %rsi
+               	jmp	 <L19>
 <L18>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L19>
-               	movq	%rcx, %rsi
-               	jmp	 <L20>
+               	addl	$0x4, %edi
+               	movq	%rdi, %rsi
 <L19>:
-               	addl	$0x20, %ecx
-               	movq	%rcx, %rsi
+               	ucomiss	%xmm1, %xmm0
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L20>
+               	movq	%rsi, %rdi
+               	jmp	 <L21>
 <L20>:
-               	callq	 <L21>
+               	addl	$0x8, %esi
+               	movq	%rsi, %rdi
 <L21>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm1, %xmm0
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
                	jne	 <L22>
+               	movq	%rdi, %rsi
                	jmp	 <L23>
 <L22>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
+               	addl	$0x10, %edi
+               	movq	%rdi, %rsi
 <L23>:
-               	movq	%rcx, %rsi
-               	callq	 <L24>
+               	ucomiss	%xmm1, %xmm0
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L24>
+               	movq	%rsi, %rdi
+               	jmp	 <L25>
 <L24>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L25>
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	jmp	 <L26>
+               	addl	$0x20, %esi
+               	movq	%rsi, %rdi
 <L25>:
-               	movq	%rcx, %rdx
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rdx, %rsi
-               	callq	 <L27>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	cmpb	$0x1, %cl
-               	setne	%sil
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L28>
+               	testb	%sil, %sil
+               	jne	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L29>
-               	jmp	 <L30>
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
 <L29>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
 <L30>:
-               	movq	%rcx, %rsi
-               	callq	 <L31>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
 <L31>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
                	jne	 <L32>
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%dil
+               	movzbq	%dil, %rdi
                	jmp	 <L33>
 <L32>:
-               	movq	%rcx, %rdx
+               	movq	%rsi, %rdi
 <L33>:
-               	movq	%rdx, %rsi
-               	callq	 <L34>
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	movq	%rax, %r15
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	cmpl	$0xc, %r8d
-               	jb	 <L2>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
 <L35>:
-               	addl	$0x1, %r13d
-               	movq	%r15, %r12
-               	cmpl	$0xc, %r13d
-               	jb	 <L1>
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	cmpb	$0x1, %sil
+               	setne	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
+               	jmp	 <L37>
 <L36>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
+<L37>:
+               	ucomiss	%xmm0, %xmm0
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	ucomiss	%xmm1, %xmm1
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+<L39>:
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+<L41>:
+               	ucomiss	%xmm0, %xmm0
+               	setne	%sil
+               	setp	%r11b
+               	orb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L42>
+               	ucomiss	%xmm1, %xmm1
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L43>
+<L42>:
+               	movq	%rsi, %rdi
+<L43>:
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %r12d
+               	movq	%r13, %rdx
+               	cmpl	$0xc, %r12d
+               	jb	 <L1>
+<L46>:
+               	addl	$0x1, %eax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x40(%rbp)
+               	cmpl	$0xc, %eax
+               	jb	 <L0>
+<L47>:
                	leaq	(%rbx), %rax
                	movss	(%rax), %xmm0
                	movss	(%rax), %xmm1
-               	movsd	%xmm1, -0x78(%rbp)
+               	movsd	%xmm1, -0x60(%rbp)
                	movl	$0x1, %eax
                	cmpl	$0xc, %eax
-               	jb	 <L37>
-               	jmp	 <L42>
-<L37>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
+               	jb	 <L48>
+               	jmp	 <L53>
+<L48>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
                	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L38>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L49>
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L39>
-<L38>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
-<L39>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm3
-               	ucomiss	-0x78(%rbp), %xmm3
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L40>
-               	movsd	-0x78(%rbp), %xmm3
-               	jmp	 <L41>
-<L40>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm3
-<L41>:
+               	jmp	 <L50>
+<L49>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
+<L50>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm3
+               	ucomiss	-0x60(%rbp), %xmm3
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L51>
+               	movsd	-0x60(%rbp), %xmm3
+               	jmp	 <L52>
+<L51>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm3
+<L52>:
                	addl	$0x1, %eax
                	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	movsd	%xmm3, -0x78(%rbp)
+               	movsd	%xmm3, -0x60(%rbp)
                	cmpl	$0xc, %eax
-               	jb	 <L37>
-<L42>:
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L44>
-               	movq	%r12, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-               	jmp	 <L46>
-<L44>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r13
-<L46>:
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L48>
-               	movq	%r13, %rdi
-               	movss	-0x78(%rbp), %xmm0
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-               	jmp	 <L50>
-<L48>:
-               	movq	%r13, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r12
-<L50>:
+               	jb	 <L48>
+<L53>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L54>
+<L54>:
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	callq	 <L55>
+<L55>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x48(%rbp), %r8
                	movl	$0x0, %r8d
-               	movq	%r8, -0x38(%rbp)
-               	movl	$0x0, %ecx
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-               	jmp	 <L54>
-<L51>:
-               	movl	%ecx, %edx
-               	leaq	(%rbx,%rdx,4), %rsi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
-               	movl	$0x0, %edi
-               	cmpl	$0xc, %edi
-               	jb	 <L52>
-               	jmp	 <L53>
-<L52>:
-               	movss	(%rsi), %xmm0
-               	movl	%edi, %r13d
-               	leaq	(%rbx,%r13,4), %r14
-               	movss	(%r14), %xmm1
+               	movq	%r8, -0x50(%rbp)
+               	movl	$0x0, %esi
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+               	jmp	 <L59>
+<L56>:
+               	movl	%esi, %edi
+               	leaq	(%rbx,%rdi,4), %r12
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdi
+               	movl	$0x0, %r13d
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movss	(%r12), %xmm0
+               	movl	%r13d, %r14d
+               	leaq	(%rbx,%r14,4), %r15
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	seta	%r13b
-               	movzbq	%r13b, %r13
-               	movzbl	%r13b, %r15d
-               	movl	%edx, %r13d
-               	addl	%r15d, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	seta	%r14b
+               	movzbq	%r14b, %r14
+               	movzbl	%r14b, %eax
+               	movl	%edi, %r14d
+               	addl	%eax, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	setae	%r15b
-               	movzbq	%r15b, %r15
-               	movzbl	%r15b, %eax
-               	addl	%eax, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r14d
-               	addl	%r14d, %r13d
-               	addl	$0x1, %edi
-               	movq	%r13, %rdx
-               	cmpl	$0xc, %edi
-               	jb	 <L52>
-<L53>:
-               	addl	$0x1, %ecx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x38(%rbp)
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-<L54>:
-               	movq	%r12, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L55>
-<L55>:
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	addl	$0x1, %r13d
+               	movq	%r14, %rdi
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+<L58>:
+               	addl	$0x1, %esi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x50(%rbp)
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+<L59>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L60>
+<L61>:
+               	movq	%rdx, %rax
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/cmp_f64.dis
+++ b/test/golden/x86_64-darwin/float/cmp_f64.dis
@@ -7,27 +7,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,614 +74,1053 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.cmp_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            ## imm = 0x130
-               	movq	%rbx, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x60(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
+               	subq	$0x290, %rsp            ## imm = 0x290
+               	movq	%rbx, -0x268(%rbp)
+               	movq	%r12, -0x270(%rbp)
+               	movq	%r13, -0x278(%rbp)
+               	movq	%r14, -0x280(%rbp)
+               	movq	%r15, -0x288(%rbp)
+               	movl	%edi, %ebx
+               	leaq	-0x80(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movabsq	$-0x10000000000000, %rcx ## imm = 0xFFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x4010000000000000, %rcx ## imm = 0xBFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7ff0000000000000, %rcx ## imm = 0x8010000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7fffffffffffffff, %rcx ## imm = 0x8000000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x18(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x8000000000000000, %rcx ## imm = 0x8000000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x20(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rbx, %xmm0
-               	leaq	0x28(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x30(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x3ff0000000000000, %rcx ## imm = 0x3FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x38(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7fefffffffffffff, %rcx ## imm = 0x7FEFFFFFFFFFFFFF
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x40(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000000, %rcx ## imm = 0x7FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x48(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff8000000000000, %rcx ## imm = 0x7FF8000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x50(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000001, %rcx ## imm = 0x7FF0000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x58(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rax, %rbx
+               	jne	 <L0>
+               	movabsq	$-0x10000000000000, %rax ## imm = 0xFFF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x4010000000000000, %rax ## imm = 0xBFF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x8(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x7ff0000000000000, %rax ## imm = 0x8010000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x10(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x7fffffffffffffff, %rax ## imm = 0x8000000000000001
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x18(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x8000000000000000, %rax ## imm = 0x8000000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x20(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movq	%rdi, %xmm0
+               	leaq	0x28(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movq	$0x1, %rax
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x30(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x3ff0000000000000, %rax ## imm = 0x3FF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x38(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7fefffffffffffff, %rax ## imm = 0x7FEFFFFFFFFFFFFF
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x40(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff0000000000000, %rax ## imm = 0x7FF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x48(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff8000000000000, %rax ## imm = 0x7FF8000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x50(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff0000000000001, %rax ## imm = 0x7FF0000000000001
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x58(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
                	movq	$0x0, %r14
                	cmpq	$0xc, %r14
-               	jb	 <L2>
-               	jmp	 <L37>
-<L2>:
-               	leaq	(%r13,%r14,8), %r15
-               	movq	%rbx, %r8
-               	movq	%r8, -0xb0(%rbp)
+               	jb	 <L1>
+               	jmp	 <L46>
+<L1>:
+               	leaq	(%r12,%r14,8), %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x210(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
                	cmpq	$0xc, %r8
-               	jb	 <L3>
-               	jmp	 <L36>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L45>
+<L2>:
                	movq	(%r15), %r11
-               	movq	%r11, -0x98(%rbp)
-               	movq	-0xb8(%rbp), %r8
-               	leaq	(%r13,%r8,8), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0xa8(%rbp)
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movq	%r11, -0x1f8(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rsi
+               	movq	(%rsi), %r11
+               	movq	%r11, -0x208(%rbp)
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	-0xb0(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	-0x210(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L4>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0x90(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xa8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	-0xc0(%rbp), %r8
-               	testb	%r8b, %r8b
-               	jne	 <L10>
-               	movq	$0x0, %rdx
-               	jmp	 <L11>
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
+<L8>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
 <L10>:
-               	movq	$0x1, %rdx
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L11>
 <L11>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
-               	testb	%sil, %sil
-               	jne	 <L12>
-               	movq	%rdx, %rsi
-               	jmp	 <L13>
+               	callq	 <L12>
 <L12>:
-               	addl	$0x2, %edx
-               	movq	%rdx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L13>
+               	movq	$0x0, %rdi
+               	jmp	 <L14>
 <L13>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L14>
-               	movq	%rsi, %rdx
-               	jmp	 <L15>
+               	movq	$0x1, %rdi
 <L14>:
-               	addl	$0x4, %esi
-               	movq	%rsi, %rdx
-<L15>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	testb	%sil, %sil
-               	jne	 <L16>
-               	movq	%rdx, %rsi
-               	jmp	 <L17>
+               	jne	 <L15>
+               	movq	%rdi, %rsi
+               	jmp	 <L16>
+<L15>:
+               	addl	$0x2, %edi
+               	movq	%rdi, %rsi
 <L16>:
-               	addl	$0x8, %edx
-               	movq	%rdx, %rsi
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L17>
+               	movq	%rsi, %rdi
+               	jmp	 <L18>
 <L17>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L18>
-               	movq	%rsi, %rdx
-               	jmp	 <L19>
+               	addl	$0x4, %esi
+               	movq	%rsi, %rdi
 <L18>:
-               	addl	$0x10, %esi
-               	movq	%rsi, %rdx
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L19>
+               	movq	%rdi, %rsi
+               	jmp	 <L20>
 <L19>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	addl	$0x8, %edi
+               	movq	%rdi, %rsi
+<L20>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	sete	%dil
+               	setnp	%r11b
+               	andb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L21>
+               	movq	%rsi, %rdi
+               	jmp	 <L22>
+<L21>:
+               	addl	$0x10, %esi
+               	movq	%rsi, %rdi
+<L22>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	testb	%sil, %sil
-               	jne	 <L20>
-               	movq	%rdx, %rsi
-               	jmp	 <L21>
-<L20>:
-               	addl	$0x20, %edx
-               	movq	%rdx, %rsi
-<L21>:
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
                	jne	 <L23>
+               	movq	%rdi, %rsi
                	jmp	 <L24>
 <L23>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
+               	addl	$0x20, %edi
+               	movq	%rdi, %rsi
 <L24>:
-               	movq	%rdx, %rsi
-               	callq	 <L25>
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L26>
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+<L26>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	jmp	 <L27>
-<L26>:
-               	movq	%rdx, %rsi
+               	testb	%sil, %sil
+               	jne	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	cmpb	$0x1, %dl
-               	setne	%sil
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L29>
+<L28>:
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
+               	jmp	 <L30>
 <L29>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L30>
-               	jmp	 <L31>
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
 <L30>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L31>
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L32>
 <L31>:
-               	movq	%rdx, %rsi
-               	callq	 <L32>
+               	movq	%rsi, %rdi
 <L32>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L33>
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x118(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+<L34>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	cmpb	$0x1, %sil
+               	setne	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+<L36>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+<L38>:
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x148(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+<L40>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	jmp	 <L34>
-<L33>:
-               	movq	%rdx, %rsi
-<L34>:
-               	callq	 <L35>
-<L35>:
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rax, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
+               	testb	%sil, %sil
+               	jne	 <L41>
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L42>
+<L41>:
+               	movq	%rsi, %rdi
+<L42>:
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x160(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+<L44>:
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	-0x178(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
                	cmpq	$0xc, %r8
-               	jb	 <L3>
-<L36>:
-               	addq	$0x1, %r14
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rbx
-               	cmpq	$0xc, %r14
                	jb	 <L2>
-<L37>:
-               	leaq	-0x80(%rbp), %r14
+<L45>:
+               	addq	$0x1, %r14
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %r13
+               	cmpq	$0xc, %r14
+               	jb	 <L1>
+<L46>:
+               	leaq	-0x20(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
                	movq	$0x0, 0x10(%r14)
                	movq	$0x0, 0x18(%r14)
                	movl	$0xff800000, %eax       ## imm = 0xFF800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0xbf800000, %eax       ## imm = 0xBF800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x4(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x80000000, %eax       ## imm = 0x80000000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x8(%r14), %rax
                	movss	%xmm0, (%rax)
-               	movd	%r12d, %xmm0
+               	movd	%ebx, %xmm0
                	leaq	0xc(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x1, %eax
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x10(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x3f800000, %eax       ## imm = 0x3F800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x14(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7f800000, %eax       ## imm = 0x7F800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x18(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7fc00000, %eax       ## imm = 0x7FC00000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x1c(%r14), %rax
                	movss	%xmm0, (%rax)
-               	movq	$0x0, %r12
-               	cmpq	$0xc, %r12
-               	jb	 <L38>
-               	jmp	 <L47>
-<L38>:
-               	leaq	(%r13,%r12,8), %r15
-               	movq	%rbx, %r8
-               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
+               	jmp	 <L59>
+<L47>:
+               	leaq	(%r12,%rbx,8), %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x240(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L39>
-               	jmp	 <L46>
-<L39>:
+               	jb	 <L48>
+               	jmp	 <L58>
+<L48>:
                	movq	(%r15), %r11
-               	movq	%r11, -0xd0(%rbp)
-               	movq	-0xf0(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdx
-               	movss	(%rdx), %xmm1
-               	cvtss2sd	%xmm1, %xmm14
-               	movsd	%xmm14, -0xe0(%rbp)
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
+               	movq	%r11, -0x228(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	leaq	(%r14,%r8,4), %rsi
+               	movl	(%rsi), %r11d
+               	movl	%r11d, -0x238(%rbp)
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	-0xe8(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x240(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x190(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+<L50>:
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm14
-               	ucomisd	-0xd0(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm14
-               	ucomisd	-0xd0(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rax, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0xf0(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x190(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L39>
-<L46>:
-               	addq	$0x1, %r12
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rbx
-               	cmpq	$0xc, %r12
-               	jb	 <L38>
-<L47>:
-               	leaq	(%r13), %rax
-               	movsd	(%rax), %xmm0
-               	movsd	(%rax), %xmm1
-               	movsd	%xmm1, -0x100(%rbp)
-               	movq	$0x1, %rax
-               	cmpq	$0xc, %rax
-               	jb	 <L48>
-               	jmp	 <L53>
-<L48>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
-               	ucomisd	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L49>
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L50>
-<L49>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
-<L50>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm3
-               	ucomisd	-0x100(%rbp), %xmm3
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L51>
-               	movsd	-0x100(%rbp), %xmm3
+               	jb	 <L51>
                	jmp	 <L52>
 <L51>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm3
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L51>
 <L52>:
-               	addq	$0x1, %rax
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	movsd	%xmm3, -0x100(%rbp)
-               	cmpq	$0xc, %rax
-               	jb	 <L48>
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	ucomisd	-0x228(%rbp), %xmm2
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1a8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
+               	jmp	 <L54>
 <L53>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L55>
-               	movq	%rbx, %rdi
-               	callq	 <L54>
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
 <L54>:
-               	movq	%rax, %r12
-               	jmp	 <L57>
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	ucomisd	-0x228(%rbp), %xmm2
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L55>
 <L55>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
+               	movq	%rax, %rdi
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L56>
 <L56>:
-               	movq	%rax, %r12
+               	movq	%rax, %rdi
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	callq	 <L57>
 <L57>:
-               	movsd	-0x100(%rbp), %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L59>
-               	movq	%r12, %rdi
-               	movsd	-0x100(%rbp), %xmm0
-               	callq	 <L58>
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L48>
 <L58>:
-               	movq	%rax, %rbx
-               	jmp	 <L61>
+               	addq	$0x1, %rbx
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r13
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
 <L59>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rbx
-<L61>:
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x88(%rbp)
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
+               	leaq	(%r12), %rax
+               	movsd	(%rax), %xmm0
+               	movsd	(%rax), %xmm1
+               	movsd	%xmm1, -0x258(%rbp)
+               	movq	$0x1, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L60>
                	jmp	 <L65>
+<L60>:
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
+               	ucomisd	%xmm1, %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L61>
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L62>
+<L61>:
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
 <L62>:
-               	leaq	(%r13,%rcx,8), %rdx
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0xc, %rdi
-               	jb	 <L63>
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm3
+               	ucomisd	-0x258(%rbp), %xmm3
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L63>
+               	movsd	-0x258(%rbp), %xmm3
                	jmp	 <L64>
 <L63>:
-               	movsd	(%rdx), %xmm0
-               	leaq	(%r13,%rdi,8), %r12
-               	movsd	(%r12), %xmm1
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm3
+<L64>:
+               	addq	$0x1, %rax
+               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
+               	movsd	%xmm3, -0x258(%rbp)
+               	cmpq	$0xc, %rax
+               	jb	 <L60>
+<L65>:
+               	movq	%r13, %rdi
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movsd	-0x258(%rbp), %xmm0
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0xc, %rsi
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	leaq	(%r12,%rsi,8), %rdi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movsd	(%rdi), %xmm0
+               	leaq	(%r12,%r13,8), %r14
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm0, %xmm1
-               	seta	%r14b
-               	movzbq	%r14b, %r14
-               	movzbl	%r14b, %r15d
-               	movl	%esi, %r14d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
-               	ucomisd	%xmm0, %xmm1
-               	setae	%r15b
+               	seta	%r15b
                	movzbq	%r15b, %r15
                	movzbl	%r15b, %eax
-               	addl	%eax, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
+               	movl	%ebx, %r15d
+               	addl	%eax, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
+               	ucomisd	%xmm0, %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r12d
-               	addl	%r12d, %r14d
-               	addq	$0x1, %rdi
-               	movq	%r14, %rsi
-               	cmpq	$0xc, %rdi
-               	jb	 <L63>
-<L64>:
-               	addq	$0x1, %rcx
-               	movq	%rsi, %r8
-               	movq	%r8, -0x88(%rbp)
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
-<L65>:
-               	movq	%rbx, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x108(%rbp), %rbx
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	cmpq	$0xc, %rsi
+               	jb	 <L68>
+<L71>:
+               	movq	-0x1e8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L72>
+<L73>:
+               	movq	%rdx, %rax
+               	movq	-0x268(%rbp), %rbx
+               	movq	-0x270(%rbp), %r12
+               	movq	-0x278(%rbp), %r13
+               	movq	-0x280(%rbp), %r14
+               	movq	-0x288(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/special_f32.dis
+++ b/test/golden/x86_64-darwin/float/special_f32.dis
@@ -12,27 +12,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       ## imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,941 +79,916 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.special_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x190, %rsp            ## imm = 0x190
-               	movq	%rbx, -0x168(%rbp)
-               	movq	%r12, -0x170(%rbp)
-               	movq	%r13, -0x178(%rbp)
-               	movq	%r14, -0x180(%rbp)
-               	movq	%r15, -0x188(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x130, %rsp            ## imm = 0x130
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%r15, -0x128(%rbp)
+               	movl	%edi, %ebx
+               	movl	$0x3f800000, %eax       ## imm = 0x3F800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x30(%rbp)
+               	movl	$0xbf800000, %eax       ## imm = 0xBF800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x40(%rbp)
+               	movl	%ebx, -0x50(%rbp)
+               	movl	$0x80000000, %eax       ## imm = 0x80000000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x60(%rbp)
+               	movl	$0x7f800000, %eax       ## imm = 0x7F800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x70(%rbp)
+               	movl	$0xff800000, %eax       ## imm = 0xFF800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x80(%rbp)
+               	movl	$0x7fc00000, %eax       ## imm = 0x7FC00000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x90(%rbp)
+               	movl	$0x7f7fffff, %eax       ## imm = 0x7F7FFFFF
+               	addl	%ebx, %eax
+               	movl	%eax, -0xa0(%rbp)
+               	movl	$0x800000, %eax         ## imm = 0x800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0xb0(%rbp)
+               	movl	$0x7fffff, %eax         ## imm = 0x7FFFFF
+               	addl	%ebx, %eax
+               	movl	%eax, -0xc0(%rbp)
+               	movl	$0x1, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movss	-0x50(%rbp), %xmm0
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %r12
-               	movl	%ebx, %r13d
-               	movl	$0x3f800000, %eax       ## imm = 0x3F800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x38(%rbp)
-               	movl	$0xbf800000, %eax       ## imm = 0xBF800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x48(%rbp)
-               	movl	%r13d, -0x58(%rbp)
-               	movl	$0x80000000, %eax       ## imm = 0x80000000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x68(%rbp)
-               	movl	$0x7f800000, %eax       ## imm = 0x7F800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x78(%rbp)
-               	movl	$0xff800000, %eax       ## imm = 0xFF800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x88(%rbp)
-               	movl	$0x7fc00000, %eax       ## imm = 0x7FC00000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x98(%rbp)
-               	movl	$0x7f7fffff, %eax       ## imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0xa8(%rbp)
-               	movl	$0x800000, %eax         ## imm = 0x800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0xb8(%rbp)
-               	movl	$0x7fffff, %eax         ## imm = 0x7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0xc8(%rbp)
-               	movl	$0x1, %eax
-               	addl	%r13d, %eax
-               	movl	%eax, -0xd8(%rbp)
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	movss	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
+               	movss	-0x50(%rbp), %xmm0
+               	addss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L2>
 <L2>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	addss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
 <L4>:
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rdi
-               	movss	-0x68(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
+               	movss	-0x50(%rbp), %xmm0
+               	subss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
 <L6>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %r12
+               	movss	-0x60(%rbp), %xmm0
+               	subss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
 <L8>:
-               	movss	-0x58(%rbp), %xmm0
-               	addss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
 <L10>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L12>
 <L12>:
-               	movss	-0x58(%rbp), %xmm0
-               	addss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
 <L14>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %r12
+               	movss	-0x50(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1cf>
+               	movq	%rax, %rdi
+               	callq	 <L16>
 <L16>:
-               	movss	-0x68(%rbp), %xmm0
-               	addss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%r12, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1e3>
+               	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
 <L18>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
 <L20>:
-               	movss	-0x68(%rbp), %xmm0
-               	addss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movss	-0x50(%rbp), %xmm14
+               	ucomiss	-0x60(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L23>
-<L23>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movss	-0x60(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movss	-0x58(%rbp), %xmm0
-               	subss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
 <L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
+               	movss	-0x50(%rbp), %xmm14
+               	ucomiss	-0x60(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L27>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rdi
+               	movss	-0x70(%rbp), %xmm0
+               	callq	 <L28>
 <L28>:
-               	movss	-0x58(%rbp), %xmm0
-               	subss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	movss	-0x80(%rbp), %xmm0
                	callq	 <L29>
 <L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
+               	movss	-0x70(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x398>
+               	movq	%rax, %rdi
+               	callq	 <L30>
 <L30>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movq	%rax, %r12
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
-               	movss	-0x68(%rbp), %xmm0
-               	subss	-0x58(%rbp), %xmm0
-               	movq	%r12, %rdi
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movss	-0x68(%rbp), %xmm0
-               	subss	-0x68(%rbp), %xmm0
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L34>
 <L34>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	addss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	subss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L38>
 <L38>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movss	-0x58(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x37a>
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	movss	-0x68(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x38e>
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L42>
 <L42>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0xa0(%rbp), %xmm0
+               	addss	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm14
+               	ucomiss	-0xa0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	xorps	%xmm0, %xmm0
+               	subss	-0xa0(%rbp), %xmm0
+               	ucomiss	-0x80(%rbp), %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L47>
 <L47>:
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0x70(%rbp), %xmm0
+               	subss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0x80(%rbp), %xmm0
+               	addss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L49>
 <L49>:
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	-0x78(%rbp), %xmm0
                	callq	 <L50>
 <L50>:
+               	movss	-0x80(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	-0x88(%rbp), %xmm0
                	callq	 <L51>
 <L51>:
-               	movss	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x45f>
+               	movss	-0x70(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x68(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movl	-0x90(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x68(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movss	-0x78(%rbp), %xmm0
-               	addss	-0x38(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	movss	-0x78(%rbp), %xmm0
-               	addss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	movss	-0x78(%rbp), %xmm0
-               	subss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x632>
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x650>
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x65b>
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L61>
 <L61>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L62>
 <L62>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0x30(%rbp), %xmm0
+               	addss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L63>
 <L63>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	subss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L65>
 <L65>:
-               	movss	-0x78(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	divss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L66>
 <L66>:
-               	movss	-0xa8(%rbp), %xmm0
-               	addss	-0xa8(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L67>
 <L67>:
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0xa8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xa8(%rbp), %xmm0
-               	ucomiss	-0x88(%rbp), %xmm0
-               	seta	%sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
-               	movss	-0x78(%rbp), %xmm0
-               	subss	-0x78(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movss	-0xb0(%rbp), %xmm0
                	callq	 <L70>
 <L70>:
-               	movss	-0x88(%rbp), %xmm0
-               	addss	-0x78(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm0
+               	addss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L71>
 <L71>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x58(%rbp), %xmm0
+               	movss	-0xb0(%rbp), %xmm0
+               	subss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movss	-0x88(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	addss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L73>
 <L73>:
-               	movss	-0x78(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x776>
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x78e>
                	movq	%rax, %rdi
                	callq	 <L75>
 <L75>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x7a5>
                	movq	%rax, %rdi
                	callq	 <L76>
 <L76>:
-               	movl	-0x98(%rbp), %ecx
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x7bd>
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L77>
 <L77>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	setne	%sil
-               	setp	%r11b
-               	orb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movss	-0xc0(%rbp), %xmm0
+               	divss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L78>
 <L78>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movss	-0xd0(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L79>
 <L79>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0xd0(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
+               	xorps	%xmm0, %xmm0
+               	subss	-0xd0(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	movss	-0x98(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0x6fb>
-               	movss	%xmm14, -0xe8(%rbp)
-               	movl	-0xe8(%rbp), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L82>
+               	movq	%rax, %r12
+               	movq	-0xb0(%rbp), %r11
+               	movq	%r11, -0xf0(%rbp)
+               	movl	$0x0, %r13d
+               	cmpl	$0x1e, %r13d
+               	jb	 <L82>
+               	jmp	 <L84>
 <L82>:
-               	movss	-0xe8(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x723>
-               	movd	%xmm2, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
+               	movss	-0xf0(%rbp), %xmm14
+               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x886>
+               	movss	%xmm14, -0xe0(%rbp)
+               	movq	%r12, %rdi
+               	movss	-0xe0(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	movss	-0x98(%rbp), %xmm0
-               	addss	-0x38(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
+               	addl	$0x1, %r13d
+               	movq	%rax, %r12
+               	movq	-0xe0(%rbp), %r11
+               	movq	%r11, -0xf0(%rbp)
+               	cmpl	$0x1e, %r13d
+               	jb	 <L82>
 <L84>:
-               	movss	-0x38(%rbp), %xmm0
-               	addss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
+               	leaq	-0x20(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	leaq	(%rax), %rdx
+               	movl	$0x0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movl	$0x80000000, (%rdx)     ## imm = 0x80000000
+               	leaq	0x8(%rax), %rdx
+               	movl	$0x1, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movl	$0x7f800000, (%rdx)     ## imm = 0x7F800000
+               	leaq	0x10(%rax), %rdx
+               	movl	$0xff800000, (%rdx)     ## imm = 0xFF800000
+               	leaq	0x14(%rax), %rdx
+               	movl	$0x7fc00000, (%rdx)     ## imm = 0x7FC00000
+               	leaq	0x18(%rax), %rdx
+               	movl	$0xffc0dead, (%rdx)     ## imm = 0xFFC0DEAD
+               	leaq	0x1c(%rax), %rdx
+               	movl	$0x7f800001, (%rdx)     ## imm = 0x7F800001
+               	movl	$0x0, %edx
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
+               	jmp	 <L88>
 <L85>:
-               	movss	-0x98(%rbp), %xmm0
-               	mulss	-0x58(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
+               	movl	%edx, %esi
+               	leaq	(%rax,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	addl	%ebx, %esi
+               	movd	%esi, %xmm0
+               	movd	%xmm0, %esi
+               	movl	%esi, %edi
+               	movq	%r12, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
+               	jmp	 <L87>
 <L86>:
-               	movss	-0x98(%rbp), %xmm0
-               	subss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
 <L87>:
-               	movss	-0x98(%rbp), %xmm0
-               	divss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	addl	$0x1, %edx
+               	movq	%rsi, %r12
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
 <L88>:
-               	movss	-0x98(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
+               	movl	$0x1000000, %eax        ## imm = 0x1000000
+               	addl	%ebx, %eax
+               	movl	$0x1000001, %r13d       ## imm = 0x1000001
+               	addl	%ebx, %r13d
+               	movl	$0x1000003, %r14d       ## imm = 0x1000003
+               	addl	%ebx, %r14d
+               	movl	$0xffffffff, %r15d      ## imm = 0xFFFFFFFF
+               	addl	%ebx, %r15d
+               	movl	$0xfeffffff, %r8d       ## imm = 0xFEFFFFFF
+               	addl	%ebx, %r8d
+               	movq	%r8, -0xf8(%rbp)
+               	movl	$0x80000000, %r8d       ## imm = 0x80000000
+               	addl	%ebx, %r8d
+               	movq	%r8, -0x100(%rbp)
+               	movl	%eax, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movq	%r12, %rdi
                	callq	 <L89>
 <L89>:
+               	movl	%r13d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
                	callq	 <L90>
 <L90>:
+               	movl	%r14d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xc8(%rbp), %xmm0
                	callq	 <L91>
 <L91>:
+               	movl	%r15d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
                	callq	 <L92>
 <L92>:
-               	movss	-0xc8(%rbp), %xmm0
-               	addss	-0xd8(%rbp), %xmm0
+               	movl	%ebx, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	movss	-0xb8(%rbp), %xmm0
-               	subss	-0xd8(%rbp), %xmm0
+               	movq	-0xf8(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	movss	-0xd8(%rbp), %xmm0
-               	addss	-0xd8(%rbp), %xmm0
+               	movq	-0x100(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x83e>
-               	movq	%rax, %rdi
-               	callq	 <L96>
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xa85>
+               	mulss	-0x30(%rbp), %xmm0
+               	movss	, %xmm2 <corpus.cases.float.special_f32.checksum+0xa92>
+               	mulss	-0x30(%rbp), %xmm2
+               	movss	, %xmm4 <corpus.cases.float.special_f32.checksum+0xa9f>
+               	mulss	-0x30(%rbp), %xmm4
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm0, %xmm5
+               	movss	, %xmm6 <corpus.cases.float.special_f32.checksum+0xab3>
+               	mulss	-0x30(%rbp), %xmm6
+               	cvttss2si	%xmm0, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
+               	jmp	 <L97>
 <L96>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x856>
-               	movq	%rax, %rdi
-               	callq	 <L97>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
 <L97>:
-               	movss	-0xd8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x86d>
-               	movq	%rax, %rdi
-               	callq	 <L98>
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
+               	jmp	 <L99>
 <L98>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x885>
-               	movq	%rax, %rdi
-               	callq	 <L99>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
 <L99>:
-               	movss	-0xc8(%rbp), %xmm0
-               	divss	-0xb8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L100>
+               	cvttss2si	%xmm4, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
+               	jmp	 <L101>
 <L100>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L101>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
 <L101>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L102>
+               	cvttss2si	%xmm6, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
+               	jmp	 <L103>
 <L102>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xd8(%rbp), %xmm0
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L103>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
 <L103>:
-               	movq	%rax, %rbx
-               	movq	-0xb8(%rbp), %r11
-               	movq	%r11, -0x108(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x1e, %r12d
+               	movss	-0x50(%rbp), %xmm14
+               	cvttss2si	%xmm14, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L104>
-               	jmp	 <L109>
+               	jmp	 <L105>
 <L104>:
-               	movss	-0x108(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x945>
-               	movss	%xmm14, -0xf8(%rbp)
-               	movss	-0xf8(%rbp), %xmm14
-               	ucomiss	-0xf8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%rbx, %rdi
-               	movss	-0xf8(%rbp), %xmm0
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %r14
-               	jmp	 <L108>
-<L106>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r14
-<L108>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
-               	movq	-0xf8(%rbp), %r11
-               	movq	%r11, -0x108(%rbp)
-               	cmpl	$0x1e, %r12d
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
                	jb	 <L104>
+<L105>:
+               	cvttss2si	%xmm5, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+               	jmp	 <L107>
+<L106>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+<L107>:
+               	cvttss2si	%xmm4, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
+               	jmp	 <L109>
+<L108>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
 <L109>:
-               	leaq	-0x20(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0x0, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movl	$0x80000000, (%rax)     ## imm = 0x80000000
-               	leaq	0x8(%r12), %rax
-               	movl	$0x1, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movl	$0x7f800000, (%rax)     ## imm = 0x7F800000
-               	leaq	0x10(%r12), %rax
-               	movl	$0xff800000, (%rax)     ## imm = 0xFF800000
-               	leaq	0x14(%r12), %rax
-               	movl	$0x7fc00000, (%rax)     ## imm = 0x7FC00000
-               	leaq	0x18(%r12), %rax
-               	movl	$0xffc0dead, (%rax)     ## imm = 0xFFC0DEAD
-               	leaq	0x1c(%r12), %rax
-               	movl	$0x7f800001, (%rax)     ## imm = 0x7F800001
-               	movl	$0x0, %r14d
-               	cmpl	$0x8, %r14d
-               	jb	 <L110>
-               	jmp	 <L112>
-<L110>:
-               	movl	%r14d, %eax
-               	leaq	(%r12,%rax,4), %rcx
-               	movl	(%rcx), %eax
-               	addl	%r13d, %eax
-               	movd	%eax, %xmm0
-               	movd	%xmm0, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L111>
-<L111>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r14d
-               	jb	 <L110>
-<L112>:
-               	movl	$0x1000000, %eax        ## imm = 0x1000000
-               	addl	%r13d, %eax
-               	movl	$0x1000001, %r12d       ## imm = 0x1000001
-               	addl	%r13d, %r12d
-               	movl	$0x1000003, %r14d       ## imm = 0x1000003
-               	addl	%r13d, %r14d
-               	movl	$0xffffffff, %r15d      ## imm = 0xFFFFFFFF
-               	addl	%r13d, %r15d
-               	movl	$0xfeffffff, %r8d       ## imm = 0xFEFFFFFF
-               	addl	%r13d, %r8d
-               	movq	%r8, -0x110(%rbp)
-               	movl	$0x80000000, %r8d       ## imm = 0x80000000
-               	addl	%r13d, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	movl	%eax, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L114>
-               	movq	%rbx, %rdi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	jmp	 <L116>
-<L114>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-<L116>:
-               	movl	%r12d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L118>
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rbx
-               	jmp	 <L120>
-<L118>:
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-<L120>:
-               	movl	%r14d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L122>
-               	movq	%rbx, %rdi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %r12
-               	jmp	 <L124>
-<L122>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %r12
-<L124>:
-               	movl	%r15d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
-               	movq	%r12, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %rbx
-               	jmp	 <L128>
-<L126>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-<L128>:
-               	movl	%r13d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L130>
-               	movq	%rbx, %rdi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-               	jmp	 <L132>
-<L130>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-<L132>:
-               	movq	-0x110(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L134>
-               	movq	%r12, %rdi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rbx
-               	jmp	 <L136>
-<L134>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-<L136>:
-               	movq	-0x118(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%rbx, %rdi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %r12
-               	jmp	 <L140>
-<L138>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r12
-<L140>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xcb0>
-               	mulss	-0x38(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcbe>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x128(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcd6>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x138(%rbp)
-               	xorps	%xmm14, %xmm14
-               	subss	%xmm0, %xmm14
-               	movss	%xmm14, -0x148(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xd00>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x158(%rbp)
-               	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %eax
-               	movq	%r12, %rdi
-               	movl	%eax, %esi
-               	callq	 <L141>
-<L141>:
-               	movss	-0x128(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L142>
-<L142>:
-               	movss	-0x138(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L143>
-<L143>:
-               	movss	-0x158(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L144>
-<L144>:
-               	movss	-0x58(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L145>
-<L145>:
-               	movss	-0x148(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L146>
-<L146>:
-               	movss	-0x138(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L147>
-<L147>:
                	xorps	%xmm0, %xmm0
-               	subss	-0x158(%rbp), %xmm0
+               	subss	%xmm6, %xmm0
                	cvttss2si	%xmm0, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L148>
-<L148>:
-               	movss	-0x148(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+               	jmp	 <L111>
+<L110>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+<L111>:
+               	cvttss2si	%xmm5, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L112>
+               	jmp	 <L113>
+<L112>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L112>
+<L113>:
                	xorps	%xmm0, %xmm0
-               	subss	-0x128(%rbp), %xmm0
+               	subss	%xmm2, %xmm0
                	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	movq	-0x168(%rbp), %rbx
-               	movq	-0x170(%rbp), %r12
-               	movq	-0x178(%rbp), %r13
-               	movq	-0x180(%rbp), %r14
-               	movq	-0x188(%rbp), %r15
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L114>
+               	jmp	 <L115>
+<L114>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L114>
+<L115>:
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
+               	movq	-0x128(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/special_f64.dis
+++ b/test/golden/x86_64-darwin/float/special_f64.dis
@@ -12,27 +12,66 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,1114 +79,1097 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.special_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x220, %rsp            ## imm = 0x220
-               	movq	%rbx, -0x1f8(%rbp)
-               	movq	%r12, -0x200(%rbp)
-               	movq	%r13, -0x208(%rbp)
-               	movq	%r14, -0x210(%rbp)
-               	movq	%r15, -0x218(%rbp)
+               	subq	$0x1c0, %rsp            ## imm = 0x1C0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%r15, -0x1b8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
                	movabsq	$0x3ff0000000000000, %rax ## imm = 0x3FF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x58(%rbp)
+               	movq	%rax, -0x50(%rbp)
                	movabsq	$-0x4010000000000000, %rax ## imm = 0xBFF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x68(%rbp)
-               	movq	%rbx, -0x78(%rbp)
+               	movq	%rax, -0x60(%rbp)
+               	movq	%rbx, -0x70(%rbp)
                	movabsq	$-0x8000000000000000, %rax ## imm = 0x8000000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x88(%rbp)
+               	movq	%rax, -0x80(%rbp)
                	movabsq	$0x7ff0000000000000, %rax ## imm = 0x7FF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x98(%rbp)
+               	movq	%rax, -0x90(%rbp)
                	movabsq	$-0x10000000000000, %rax ## imm = 0xFFF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xa8(%rbp)
+               	movq	%rax, -0xa0(%rbp)
                	movabsq	$0x7ff8000000000000, %rax ## imm = 0x7FF8000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xb8(%rbp)
+               	movq	%rax, -0xb0(%rbp)
                	movabsq	$0x7fefffffffffffff, %rax ## imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
-               	movq	%rax, -0xc8(%rbp)
+               	movq	%rax, -0xc0(%rbp)
                	movabsq	$0x10000000000000, %rax ## imm = 0x10000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xd8(%rbp)
+               	movq	%rax, -0xd0(%rbp)
                	movabsq	$0xfffffffffffff, %rax  ## imm = 0xFFFFFFFFFFFFF
                	addq	%rbx, %rax
-               	movq	%rax, -0xe8(%rbp)
+               	movq	%rax, -0xe0(%rbp)
                	movq	$0x1, %rax
                	addq	%rbx, %rax
-               	movq	%rax, -0xf8(%rbp)
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	movsd	-0x78(%rbp), %xmm0
+               	movq	%rax, -0xf0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movsd	-0x70(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %r13
-               	jmp	 <L4>
+               	movsd	-0x70(%rbp), %xmm0
+               	addsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L2>
 <L2>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	addsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
 <L4>:
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%r13, %rdi
-               	movsd	-0x88(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
+               	movsd	-0x70(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
 <L6>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	subsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %r12
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
 <L8>:
-               	movsd	-0x78(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %r13
-               	jmp	 <L12>
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
 <L10>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L12>
 <L12>:
-               	movsd	-0x78(%rbp), %xmm0
-               	addsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%r13, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
 <L14>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %r12
+               	movsd	-0x70(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x21a>
+               	movq	%rax, %rdi
+               	callq	 <L16>
 <L16>:
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%r12, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x22e>
+               	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %r13
-               	jmp	 <L20>
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
 <L18>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
 <L20>:
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x88(%rbp), %xmm0
-               	movq	%r13, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	-0x80(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
+               	movsd	-0x80(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
 <L25>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	-0x80(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0x90(%rbp), %xmm0
                	callq	 <L27>
 <L27>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0xa0(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x3a5>
                	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L30>
 <L30>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movsd	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x362>
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movsd	-0x88(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x379>
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	addsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L34>
 <L34>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	addsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L38>
 <L38>:
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm0
                	callq	 <L41>
 <L41>:
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	movsd	-0x98(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x462>
+               	movsd	-0x90(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	movsd	-0xc0(%rbp), %xmm0
+               	addsd	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x88(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm14
+               	ucomisd	-0xc0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xc0(%rbp), %xmm0
+               	ucomisd	-0xa0(%rbp), %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x88(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L47>
 <L47>:
-               	movsd	-0x98(%rbp), %xmm0
-               	addsd	-0x58(%rbp), %xmm0
+               	movsd	-0xa0(%rbp), %xmm0
+               	addsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movsd	-0x98(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L49>
 <L49>:
-               	movsd	-0x98(%rbp), %xmm0
-               	subsd	-0xa8(%rbp), %xmm0
+               	movsd	-0xa0(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L50>
 <L50>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x98(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L51>
 <L51>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0xa8(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movq	-0xb0(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0xa8(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movsd	-0x98(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	movsd	-0xc8(%rbp), %xmm0
-               	addsd	-0xc8(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xc8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xb0(%rbp), %xmm14
+               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x68e>
+               	movsd	%xmm14, -0x100(%rbp)
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xc8(%rbp), %xmm0
-               	ucomisd	-0xa8(%rbp), %xmm0
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x100(%rbp), %xmm2
+               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x6b5>
+               	movq	%xmm2, %rsi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
-               	movsd	-0x98(%rbp), %xmm0
-               	subsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	addsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L61>
 <L61>:
-               	movsd	-0xa8(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	addsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L62>
 <L62>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x78(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	mulsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L63>
 <L63>:
-               	movsd	-0xa8(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movsd	-0x98(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L65>
 <L65>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L66>
 <L66>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0xf0(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
-               	movq	-0xb8(%rbp), %rsi
                	movq	%rax, %rdi
+               	movsd	-0xe0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	setne	%sil
-               	setp	%r11b
-               	orb	%r11b, %sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movsd	-0xd0(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xe0(%rbp), %xmm0
+               	addsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L70>
 <L70>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xd0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L71>
 <L71>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	addsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x745>
-               	movsd	%xmm14, -0x108(%rbp)
-               	movq	-0x108(%rbp), %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x7d1>
                	movq	%rax, %rdi
                	callq	 <L73>
 <L73>:
-               	movsd	-0x108(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x76c>
-               	movq	%xmm2, %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x7e9>
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	addsd	-0x58(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x800>
                	movq	%rax, %rdi
                	callq	 <L75>
 <L75>:
-               	movsd	-0x58(%rbp), %xmm0
-               	addsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x818>
                	movq	%rax, %rdi
                	callq	 <L76>
 <L76>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	mulsd	-0x78(%rbp), %xmm0
+               	movsd	-0xe0(%rbp), %xmm0
+               	divsd	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L77>
 <L77>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	subsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L78>
 <L78>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	divsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L79>
 <L79>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movq	%rax, %rdi
-               	movsd	-0xf8(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movsd	-0xe8(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movsd	-0xd8(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movsd	-0xe8(%rbp), %xmm0
-               	addsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movsd	-0xd8(%rbp), %xmm0
-               	subsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	addsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x888>
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8a0>
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8b7>
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8cf>
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	movsd	-0xe8(%rbp), %xmm0
-               	divsd	-0xd8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xf8(%rbp), %xmm0
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
                	movq	%rax, %r12
-               	movq	-0xd8(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
+               	movq	-0xd0(%rbp), %r11
+               	movq	%r11, -0x120(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3c, %r13
-               	jb	 <L95>
-               	jmp	 <L100>
-<L95>:
-               	movsd	-0x128(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x996>
-               	movsd	%xmm14, -0x118(%rbp)
-               	movsd	-0x118(%rbp), %xmm14
-               	ucomisd	-0x118(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
+               	jb	 <L81>
+               	jmp	 <L83>
+<L81>:
+               	movsd	-0x120(%rbp), %xmm14
+               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x8e5>
+               	movsd	%xmm14, -0x110(%rbp)
                	movq	%r12, %rdi
-               	movsd	-0x118(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %r14
-               	jmp	 <L99>
-<L97>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r14
-<L99>:
+               	movsd	-0x110(%rbp), %xmm0
+               	callq	 <L82>
+<L82>:
                	addq	$0x1, %r13
-               	movq	%r14, %r12
-               	movq	-0x118(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
+               	movq	%rax, %r12
+               	movq	-0x110(%rbp), %r11
+               	movq	%r11, -0x120(%rbp)
                	cmpq	$0x3c, %r13
-               	jb	 <L95>
-<L100>:
-               	leaq	-0x40(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, 0x18(%r13)
-               	movq	$0x0, 0x20(%r13)
-               	movq	$0x0, 0x28(%r13)
-               	movq	$0x0, 0x30(%r13)
-               	movq	$0x0, 0x38(%r13)
-               	leaq	(%r13), %rax
+               	jb	 <L81>
+<L83>:
+               	leaq	-0x40(%rbp), %rax
                	movq	$0x0, (%rax)
-               	leaq	0x8(%r13), %rax
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	movq	$0x0, 0x30(%rax)
+               	movq	$0x0, 0x38(%rax)
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x10(%r13), %rax
-               	movq	$0x1, (%rax)
-               	leaq	0x18(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movq	$0x1, (%rdx)
+               	leaq	0x18(%rax), %rdx
                	movabsq	$0x7ff0000000000000, %r11 ## imm = 0x7FF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x20(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x20(%rax), %rdx
                	movabsq	$-0x10000000000000, %r11 ## imm = 0xFFF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x28(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x28(%rax), %rdx
                	movabsq	$0x7ff8000000000000, %r11 ## imm = 0x7FF8000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x30(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x30(%rax), %rdx
                	movabsq	$-0x7ffffff3f2153, %r11 ## imm = 0xFFF8000000C0DEAD
-               	movq	%r11, (%rax)
-               	leaq	0x38(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x38(%rax), %rdx
                	movabsq	$0x7ff0000000000001, %r11 ## imm = 0x7FF0000000000001
-               	movq	%r11, (%rax)
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
-               	jb	 <L101>
-               	jmp	 <L103>
-<L101>:
-               	leaq	(%r13,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
+               	movq	%r11, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+               	jmp	 <L87>
+<L84>:
+               	leaq	(%rax,%rdx,8), %rsi
+               	movq	(%rsi), %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %xmm0
                	movq	%xmm0, %rsi
                	movq	%r12, %rdi
-               	callq	 <L102>
-<L102>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r14
-               	jb	 <L101>
-<L103>:
-               	movsd	-0xc8(%rbp), %xmm15
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+               	jmp	 <L86>
+<L85>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+<L86>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+<L87>:
+               	movsd	-0xc0(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm0
-               	movsd	-0xf8(%rbp), %xmm15
-               	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x138(%rbp)
+               	movsd	-0xf0(%rbp), %xmm15
+               	cvtsd2ss	%xmm15, %xmm2
                	movabsq	$0x36a0000000000000, %rax ## imm = 0x36A0000000000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x148(%rbp)
+               	cvtsd2ss	%xmm5, %xmm7
                	movabsq	$0x3ff0000010000000, %rax ## imm = 0x3FF0000010000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x158(%rbp)
+               	cvtsd2ss	%xmm5, %xmm8
                	movabsq	$0x3ff0000030000000, %rax ## imm = 0x3FF0000030000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x168(%rbp)
-               	movsd	-0x88(%rbp), %xmm15
+               	cvtsd2ss	%xmm5, %xmm9
+               	movsd	-0x80(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x178(%rbp)
-               	movsd	-0xa8(%rbp), %xmm15
+               	movss	%xmm14, -0x130(%rbp)
+               	movsd	-0xa0(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x188(%rbp)
+               	movss	%xmm14, -0x140(%rbp)
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+               	jmp	 <L89>
+<L88>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+<L89>:
+               	movd	%xmm2, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+               	jmp	 <L91>
+<L90>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+<L91>:
+               	movd	%xmm7, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+               	jmp	 <L93>
+<L92>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+<L93>:
+               	movd	%xmm8, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+               	jmp	 <L95>
+<L94>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+<L95>:
+               	movd	%xmm9, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+               	jmp	 <L97>
+<L96>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+<L97>:
+               	movl	-0x130(%rbp), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+               	jmp	 <L99>
+<L98>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+<L99>:
+               	movl	-0x140(%rbp), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
+               	jmp	 <L101>
+<L100>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
+<L101>:
+               	cvtss2sd	%xmm7, %xmm0
+               	movq	%r12, %rdi
+               	callq	 <L102>
+<L102>:
+               	movss	-0x130(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L103>
+<L103>:
+               	movss	-0x140(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
-               	movq	%rax, %rdi
-               	movss	-0x138(%rbp), %xmm0
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rdi
-               	movss	-0x148(%rbp), %xmm0
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rdi
-               	movss	-0x158(%rbp), %xmm0
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rdi
-               	movss	-0x168(%rbp), %xmm0
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %rdi
-               	movss	-0x178(%rbp), %xmm0
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %rdi
-               	movss	-0x188(%rbp), %xmm0
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r12
-               	movss	-0x148(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %r13
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r13
-<L114>:
-               	movss	-0x178(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%r13, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movss	-0x188(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L120>
-               	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %r13
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %r13
-<L122>:
-               	movabsq	$0x20000000000000, %rax ## imm = 0x20000000000000
-               	addq	%rbx, %rax
+               	movabsq	$0x20000000000000, %rdx ## imm = 0x20000000000000
+               	addq	%rbx, %rdx
                	movabsq	$0x20000000000001, %r12 ## imm = 0x20000000000001
                	addq	%rbx, %r12
-               	movabsq	$0x20000000000003, %r14 ## imm = 0x20000000000003
+               	movabsq	$0x20000000000003, %r13 ## imm = 0x20000000000003
+               	addq	%rbx, %r13
+               	movq	$-0x1, %r14
                	addq	%rbx, %r14
-               	movq	$-0x1, %r15
+               	movabsq	$-0x20000000000001, %r15 ## imm = 0xFFDFFFFFFFFFFFFF
                	addq	%rbx, %r15
-               	movabsq	$-0x20000000000001, %r8 ## imm = 0xFFDFFFFFFFFFFFFF
-               	addq	%rbx, %r8
-               	movq	%r8, -0x190(%rbp)
                	movabsq	$-0x8000000000000000, %r8 ## imm = 0x8000000000000000
                	addq	%rbx, %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	%rax, %r11
+               	movq	%r8, -0x148(%rbp)
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L123>
+               	jl	 <L105>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L124>
-<L123>:
+               	jmp	 <L106>
+<L105>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L124>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
-               	movq	%r13, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-               	jmp	 <L128>
-<L126>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-<L128>:
+<L106>:
+               	movq	%rax, %rdi
+               	callq	 <L107>
+<L107>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L129>
+               	jl	 <L108>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L130>
-<L129>:
+               	jmp	 <L109>
+<L108>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L130>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L109>:
+               	movq	%rax, %rdi
+               	callq	 <L110>
+<L110>:
+               	movq	%r13, %r11
+               	testq	%r11, %r11
+               	jl	 <L111>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L112>
+<L111>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L112>:
+               	movq	%rax, %rdi
+               	callq	 <L113>
+<L113>:
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L135>
+               	jl	 <L114>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L136>
-<L135>:
+               	jmp	 <L115>
+<L114>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L136>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%r12, %rdi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %r13
-               	jmp	 <L140>
-<L138>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r13
-<L140>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L141>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L142>
-<L141>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L142>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r13, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %r12
-               	jmp	 <L146>
-<L144>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %r12
-<L146>:
+<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L116>
+<L116>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L147>
+               	jl	 <L117>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L148>
-<L147>:
+               	jmp	 <L118>
+<L117>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L148>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movq	-0x190(%rbp), %r8
+<L118>:
+               	movq	%rax, %rdi
+               	callq	 <L119>
+<L119>:
+               	movq	%r15, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L120>
+<L120>:
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L154>
-               	movq	%rbx, %rdi
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %r12
-               	jmp	 <L156>
-<L154>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L155>
-<L155>:
-               	movq	%rax, %r12
-<L156>:
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L158>
-               	movq	%r12, %rdi
-               	callq	 <L157>
-<L157>:
-               	movq	%rax, %rbx
-               	jmp	 <L160>
-<L158>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L159>
-<L159>:
-               	movq	%rax, %rbx
-<L160>:
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1020>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1a8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1b8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1050>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1c8(%rbp)
+               	movq	%rax, %rdi
+               	callq	 <L121>
+<L121>:
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf25>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x158(%rbp)
+               	movsd	, %xmm2 <corpus.cases.float.special_f64.checksum+0xf3c>
+               	mulsd	-0x50(%rbp), %xmm2
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf4a>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x168(%rbp)
                	xorps	%xmm14, %xmm14
-               	subsd	-0x1a8(%rbp), %xmm14
-               	movsd	%xmm14, -0x1d8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x107e>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1e8(%rbp)
-               	movsd	-0x1a8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x109f>
-               	jb	 <L161>
+               	subsd	-0x158(%rbp), %xmm14
+               	movsd	%xmm14, -0x178(%rbp)
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf78>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x188(%rbp)
+               	movsd	-0x158(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf99>
+               	jb	 <L122>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10b2>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xfac>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L162>
-<L161>:
+               	jmp	 <L123>
+<L122>:
                	cvttsd2si	%xmm14, %r11
-<L162>:
-               	movq	%r11, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
-               	movsd	-0x1b8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10eb>
-               	jb	 <L164>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10fe>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L165>
-<L164>:
-               	cvttsd2si	%xmm14, %r11
-<L165>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	movsd	-0x1c8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1137>
-               	jb	 <L167>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x114a>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L168>
-<L167>:
-               	cvttsd2si	%xmm14, %r11
-<L168>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
-               	movsd	-0x1e8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1183>
-               	jb	 <L170>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1196>
+<L123>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L124>
+               	jmp	 <L125>
+<L124>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L124>
+<L125>:
+               	ucomisd	, %xmm2 <corpus.cases.float.special_f64.checksum+0x1025>
+               	jb	 <L126>
+               	movaps	%xmm2, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L171>
-<L170>:
-               	cvttsd2si	%xmm14, %r11
-<L171>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L172>
-<L172>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11cc>
-               	jb	 <L173>
+               	jmp	 <L127>
+<L126>:
+               	cvttsd2si	%xmm2, %r11
+<L127>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L128>
+               	jmp	 <L129>
+<L128>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L128>
+<L129>:
+               	movsd	-0x168(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10bb>
+               	jb	 <L130>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11df>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10ce>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L174>
-<L173>:
+               	jmp	 <L131>
+<L130>:
                	cvttsd2si	%xmm14, %r11
-<L174>:
+<L131>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L132>
+               	jmp	 <L133>
+<L132>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L132>
+<L133>:
+               	movsd	-0x188(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1151>
+               	jb	 <L134>
+               	movaps	%xmm14, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1164>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L135>
+<L134>:
+               	cvttsd2si	%xmm14, %r11
+<L135>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L136>
+               	jmp	 <L137>
+<L136>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L136>
+<L137>:
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11e4>
+               	jb	 <L138>
+               	movaps	%xmm14, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11f7>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L139>
+<L138>:
+               	cvttsd2si	%xmm14, %r11
+<L139>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
-               	movsd	-0x1d8(%rbp), %xmm14
+               	callq	 <L140>
+<L140>:
+               	movsd	-0x178(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
-               	movsd	-0x1c8(%rbp), %xmm14
+               	callq	 <L141>
+<L141>:
+               	movsd	-0x168(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L142>
+<L142>:
                	xorps	%xmm1, %xmm1
-               	subsd	-0x1e8(%rbp), %xmm1
+               	subsd	-0x188(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
-               	movsd	-0x1d8(%rbp), %xmm14
+               	callq	 <L143>
+<L143>:
+               	movsd	-0x178(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L179>
-<L179>:
-               	movsd	-0x1a8(%rbp), %xmm14
+               	callq	 <L144>
+<L144>:
+               	movsd	-0x158(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L180>
-<L180>:
-               	movq	-0x1f8(%rbp), %rbx
-               	movq	-0x200(%rbp), %r12
-               	movq	-0x208(%rbp), %r13
-               	movq	-0x210(%rbp), %r14
-               	movq	-0x218(%rbp), %r15
+               	callq	 <L145>
+<L145>:
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
+               	movq	-0x1b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/frame/frame_align.dis
+++ b/test/golden/x86_64-darwin/frame/frame_align.dis
@@ -7,28 +7,108 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,18 +118,58 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -59,32 +179,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -161,73 +353,70 @@ Disassembly of section __TEXT,__text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	andq	$-0x40, %rsp
-               	subq	$0x3c0, %rsp            ## imm = 0x3C0
-               	movq	%rbx, 0x28(%rsp)
-               	movq	%r12, 0x20(%rsp)
-               	movq	%r13, 0x18(%rsp)
-               	movq	%r14, 0x10(%rsp)
-               	movq	%r15, 0x8(%rsp)
+               	subq	$0x380, %rsp            ## imm = 0x380
+               	movq	%rbx, 0x58(%rsp)
+               	movq	%r12, 0x50(%rsp)
+               	movq	%r13, 0x48(%rsp)
+               	movq	%r14, 0x40(%rsp)
+               	movq	%r15, 0x38(%rsp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, 0xe8(%rsp)
-               	movq	0xe8(%rsp), %r8
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L4>:
-               	leaq	0x3b0(%rsp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     ## imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xb4>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xbb>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     ## imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xd5>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xdc>
-               	leaq	0xc(%rcx), %rsi
-               	movss	%xmm2, (%rsi)
-               	movups	(%rcx), %xmm2
-               	leaq	0x3a0(%rsp), %r8
-               	movq	%r8, 0xe0(%rsp)
-               	movq	0xe0(%rsp), %r8
+<L3>:
+               	leaq	0x370(%rsp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     ## imm = 0x3FC00000
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x9c>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xa3>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     ## imm = 0x40700000
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xbd>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xc4>
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	0x360(%rsp), %r8
+               	movq	%r8, 0x148(%rsp)
+               	movq	0x148(%rsp), %r8
                	movups	%xmm2, (%r8)
-               	leaq	0x390(%rsp), %rsi
-               	leaq	(%rsi), %r12
+               	leaq	0x350(%rsp), %rdi
+               	leaq	(%rdi), %r12
                	movabsq	$0x3ff4000000000000, %r11 ## imm = 0x3FF4000000000000
                	movq	%r11, (%r12)
-               	leaq	0x8(%rsi), %r12
+               	leaq	0x8(%rdi), %r12
                	movabsq	$-0x3ff4000000000000, %r11 ## imm = 0xC00C000000000000
                	movq	%r11, (%r12)
-               	movups	(%rsi), %xmm3
-               	leaq	0x380(%rsp), %rsi
-               	movups	%xmm3, (%rsi)
-               	leaq	0x370(%rsp), %r12
+               	movups	(%rdi), %xmm3
+               	leaq	0x340(%rsp), %r8
+               	movq	%r8, 0x110(%rsp)
+               	movq	0x110(%rsp), %r8
+               	movups	%xmm3, (%r8)
+               	leaq	0x330(%rsp), %r12
                	leaq	(%r12), %r13
                	movl	$0xffffffff, (%r13)     ## imm = 0xFFFFFFFF
                	leaq	0x4(%r12), %r13
@@ -237,9 +426,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%r12), %r13
                	movl	$0x12345678, (%r13)     ## imm = 0x12345678
                	movups	(%r12), %xmm4
-               	leaq	0x360(%rsp), %r12
+               	leaq	0x320(%rsp), %r12
                	movups	%xmm4, (%r12)
-               	leaq	0x350(%rsp), %r13
+               	leaq	0x310(%rsp), %r13
                	leaq	(%r13), %r14
                	movabsq	$0x3fe0000000000000, %r11 ## imm = 0x3FE0000000000000
                	movq	%r11, (%r14)
@@ -247,663 +436,478 @@ Disassembly of section __TEXT,__text:
                	movabsq	$0x4019000000000000, %r11 ## imm = 0x4019000000000000
                	movq	%r11, (%r14)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, 0x80(%rsp)
-               	leaq	0x340(%rsp), %r13
-               	movups	0x80(%rsp), %xmm14
+               	movups	%xmm14, 0xc0(%rsp)
+               	leaq	0x300(%rsp), %r13
+               	leaq	(%r13), %r14
+               	movl	$0xc2b2ae3d, (%r14)     ## imm = 0xC2B2AE3D
+               	leaq	0x4(%r13), %r14
+               	movl	$0x85ebca77, (%r14)     ## imm = 0x85EBCA77
+               	leaq	0x8(%r13), %r14
+               	movl	$0x7, (%r14)
+               	leaq	0xc(%r13), %r14
+               	movl	$0xfffffffb, (%r14)     ## imm = 0xFFFFFFFB
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, 0xb0(%rsp)
+               	leaq	0x2f0(%rsp), %r13
+               	movups	0xb0(%rsp), %xmm14
                	movups	%xmm14, (%r13)
-               	leaq	0x330(%rsp), %r14
+               	leaq	0x200(%rsp), %r14
                	leaq	(%r14), %r15
-               	movl	$0xc2b2ae3d, (%r15)     ## imm = 0xC2B2AE3D
-               	leaq	0x4(%r14), %r15
-               	movl	$0x85ebca77, (%r15)     ## imm = 0x85EBCA77
-               	leaq	0x8(%r14), %r15
-               	movl	$0x7, (%r15)
-               	leaq	0xc(%r14), %r15
-               	movl	$0xfffffffb, (%r15)     ## imm = 0xFFFFFFFB
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, 0x70(%rsp)
-               	leaq	0x320(%rsp), %r14
-               	movups	0x70(%rsp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	0x240(%rsp), %r15
-               	leaq	(%r15), %rdi
-               	addq	$0x0, %rdi
-               	movq	$0xc0, %rcx
-<L5>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L5>
-               	leaq	0x200(%rsp), %r8
-               	movq	%r8, 0x68(%rsp)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, (%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x30(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x38(%r8)
-               	movq	%rbx, %rdi
-               	addq	$0x1, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xd8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x3, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xd0(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x5, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xc8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x7, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xc0(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0xfff1, %rdi           ## imm = 0xFFF1
-               	movw	%di, %r8w
-               	movq	%r8, 0xb8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0xfb, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xb0(%rsp)
-               	movq	0xe0(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm7
+               	addq	$0x0, %r15
+               	movq	$0xc0, %rsi
+<L4>:
+               	movq	$0x0, (%r15)
+               	addq	$0x8, %r15
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L4>
+               	leaq	0x1c0(%rsp), %r15
+               	movq	$0x0, (%r15)
+               	movq	$0x0, 0x8(%r15)
+               	movq	$0x0, 0x10(%r15)
+               	movq	$0x0, 0x18(%r15)
+               	movq	$0x0, 0x20(%r15)
+               	movq	$0x0, 0x28(%r15)
+               	movq	$0x0, 0x30(%r15)
+               	movq	$0x0, 0x38(%r15)
+               	movq	%rbx, %rsi
+               	addq	$0x1, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x140(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x3, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x138(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x5, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x130(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x7, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x128(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0xfff1, %rsi           ## imm = 0xFFF1
+               	movw	%si, %r8w
+               	movq	%r8, 0x120(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0xfb, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x118(%rsp)
+               	movq	0x148(%rsp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm7
                	movss	%xmm7, %xmm8            ## xmm8 = xmm7[0],xmm8[1,2,3]
                	addss	%xmm0, %xmm8
-               	leaq	0x1f0(%rsp), %r8
-               	movq	%r8, 0xa8(%rsp)
-               	movq	0xa8(%rsp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	0xa8(%rsp), %r8
-               	leaq	(%r8), %rdi
+               	leaq	0x1b0(%rsp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	(%rsi), %rdi
                	movss	%xmm8, (%rdi)
-               	movq	0xa8(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x50(%rsp)
-               	leaq	0x8(%rsi), %rdi
-               	movsd	(%rdi), %xmm0
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, 0xa0(%rsp)
+               	movq	0x110(%rsp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movsd	(%rsi), %xmm0
                	movsd	%xmm0, %xmm7            ## xmm7 = xmm0[0],xmm7[1]
                	addsd	%xmm1, %xmm7
-               	leaq	0x1e0(%rsp), %r8
-               	movq	%r8, 0x60(%rsp)
-               	movq	0x60(%rsp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	0x60(%rsp), %r8
-               	leaq	0x8(%r8), %rdi
+               	leaq	0x1a0(%rsp), %rsi
+               	movups	%xmm3, (%rsi)
+               	leaq	0x8(%rsi), %rdi
                	movsd	%xmm7, (%rdi)
-               	movq	0x60(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x40(%rsp)
-               	leaq	0x8(%r12), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%ebx, %edi
-               	addl	%edi, %r12d
-               	leaq	0x1d0(%rsp), %r8
-               	movq	%r8, 0xa0(%rsp)
-               	movq	0xa0(%rsp), %r8
-               	movups	%xmm4, (%r8)
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movl	%r12d, (%rdi)
-               	movq	0xa0(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x30(%rsp)
-               	movq	0xa8(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	0xe8(%rsp), %r8
-               	movq	%r8, %rdi
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, 0x90(%rsp)
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %edi
+               	movl	%ebx, %esi
+               	addl	%esi, %edi
+               	leaq	0x190(%rsp), %r12
+               	movups	%xmm4, (%r12)
+               	leaq	0x8(%r12), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, 0x80(%rsp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	0xa0(%rsp), %xmm0
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rdi
+               	movups	0x90(%rsp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0x4(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movups	0x80(%rsp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0x8(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movaps	0xa0(%rsp), %xmm14
+               	addps	0xa0(%rsp), %xmm14
+               	movaps	%xmm14, 0x70(%rsp)
+               	movups	0x70(%rsp), %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0xc(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movaps	0xa0(%rsp), %xmm14
+               	mulps	0xa0(%rsp), %xmm14
+               	movaps	%xmm14, 0x60(%rsp)
+               	movups	0x60(%rsp), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	0x60(%rsp), %r8
-               	leaq	(%r8), %r12
-               	movsd	(%r12), %xmm0
+               	movups	0xc0(%rsp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	0x60(%rsp), %r8
-               	leaq	0x8(%r8), %r12
-               	movsd	(%r12), %xmm0
+               	movaps	0x90(%rsp), %xmm14
+               	mulpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movaps	0x90(%rsp), %xmm14
+               	subpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movaps	0x90(%rsp), %xmm14
+               	divpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movups	0xb0(%rsp), %xmm0
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movq	%rax, %r8
+               	movq	%r8, 0x108(%rsp)
+               	movq	0x108(%rsp), %r8
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %r8d
+               	movq	%r8, 0x100(%rsp)
+               	leaq	(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movq	0x100(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, 0xf8(%rsp)
+               	leaq	0x4(%r12), %rdi
+               	movl	(%rdi), %r8d
+               	movq	%r8, 0xf0(%rsp)
+               	leaq	0x4(%r13), %rdi
+               	movl	(%rdi), %esi
+               	movq	0xf0(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, 0xe8(%rsp)
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %r8d
+               	movq	%r8, 0xe0(%rsp)
+               	leaq	0x8(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movq	0xe0(%rsp), %r8
+               	movl	%r8d, %esi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0xc(%r13), %rdi
+               	movl	(%rdi), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0x180(%rsp), %rdi
+               	movups	0x80(%rsp), %xmm14
+               	movups	%xmm14, (%rdi)
+               	leaq	(%rdi), %r13
+               	movq	0xf8(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x170(%rsp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rdi), %r13
+               	movq	0xe8(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x160(%rsp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x8(%rdi), %r13
+               	movl	%esi, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x150(%rsp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	%r12d, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movq	0x108(%rsp), %r8
+               	movq	%r8, %rdi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movaps	0x50(%rsp), %xmm14
-               	addps	0x50(%rsp), %xmm14
+               	movaps	0x80(%rsp), %xmm14
+               	paddd	0xb0(%rsp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1b0(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movss	(%rsi), %xmm0
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movaps	0x80(%rsp), %xmm14
+               	pxor	0xb0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm3, %xmm0
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	movups	0xa0(%rsp), %xmm0
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%r12, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rdi
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x1a0(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	movups	0x60(%rsp), %xmm0
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%r12, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	leaq	(%r15), %rsi
+               	movups	0xa0(%rsp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movups	0x70(%rsp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movups	0xa0(%rsp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	mulpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x190(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	subpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x180(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	divpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x170(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r8
-               	movq	%r8, 0x98(%rsp)
-               	movq	0x98(%rsp), %r8
-               	movq	0xa0(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	leaq	(%r14), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, 0x90(%rsp)
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r13d
-               	leaq	0x4(%r14), %rsi
-               	movl	(%rsi), %edi
-               	imull	%edi, %r13d
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %edi
-               	leaq	0x8(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	imull	%r12d, %edi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	leaq	0xc(%r14), %rsi
-               	movl	(%rsi), %r14d
-               	imull	%r14d, %r12d
-               	leaq	0x160(%rsp), %rsi
-               	movups	0x30(%rsp), %xmm14
+               	leaq	0x20(%r15), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x30(%r15), %rsi
+               	movups	0x60(%rsp), %xmm14
                	movups	%xmm14, (%rsi)
-               	leaq	(%rsi), %r14
-               	movq	0x90(%rsp), %r8
-               	movl	%r8d, (%r14)
-               	movups	(%rsi), %xmm0
-               	leaq	0x150(%rsp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x4(%rsi), %r14
-               	movl	%r13d, (%r14)
-               	movups	(%rsi), %xmm0
-               	leaq	0x140(%rsp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x8(%rsi), %r13
-               	movl	%edi, (%r13)
-               	movups	(%rsi), %xmm0
-               	leaq	0x130(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rsi
-               	movl	%r12d, (%rsi)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movq	0x98(%rsp), %r8
-               	movq	%r8, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movaps	0x30(%rsp), %xmm14
-               	paddd	0x70(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x120(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movaps	0x30(%rsp), %xmm14
-               	pxor	0x70(%rsp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x110(%rsp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-               	movups	0x50(%rsp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	leaq	0x100(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %r12
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L53>
-<L53>:
-               	leaq	0xf0(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r12
-               	movq	0x68(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movups	0x50(%rsp), %xmm14
-               	movups	%xmm14, (%rsi)
-               	movaps	0x50(%rsp), %xmm14
-               	addps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	0x68(%rsp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movups	%xmm0, (%rsi)
-               	movups	0x50(%rsp), %xmm0
-               	callq	 <L58>
-<L58>:
-               	movq	0x68(%rsp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movups	%xmm0, (%rsi)
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	movq	0x68(%rsp), %r8
-               	leaq	0x30(%r8), %rsi
-               	movups	%xmm2, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L59>
-               	jmp	 <L64>
-<L59>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rsi
                	imulq	$0x10, %rsi, %rsi
-               	movq	0x68(%rsp), %r8
-               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%r15,%rsi), %rdi
                	movups	(%rdi), %xmm0
-               	leaq	0x1c0(%rsp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %r12
+               	addq	$0x1, %r13
+               	cmpq	$0x4, %r13
+               	jb	 <L23>
+<L25>:
+               	movabsq	$0x1111111111111111, %r8 ## imm = 0x1111111111111111
+               	addq	%rbx, %r8
+               	movq	%r8, 0xd8(%rsp)
+               	movabsq	$0x7777777777777777, %rdi ## imm = 0x7777777777777777
+               	xorq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	0xd8(%rsp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %r13
                	movq	%rsi, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L59>
-<L64>:
-               	movabsq	$0x1111111111111111, %r13 ## imm = 0x1111111111111111
-               	addq	%rbx, %r13
-               	movabsq	$0x7777777777777777, %r14 ## imm = 0x7777777777777777
-               	xorq	%rbx, %r14
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rcx
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
                	movq	$0x0, %rsi
                	cmpq	$0x3, %rsi
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
                	movq	%rsi, %rdi
                	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
                	imulq	%r11, %rdi
                	addq	%rbx, %rdi
-               	movq	%rsi, %r12
-               	imulq	$0x40, %r12, %r12
-               	leaq	(%r15,%r12), %r14
-               	leaq	(%r14), %r12
-               	movq	%rdi, (%r12)
+               	movq	%rsi, %r13
+               	imulq	$0x40, %r13, %r13
+               	leaq	(%r14,%r13), %r15
+               	leaq	(%r15), %r13
+               	movq	%rdi, (%r13)
                	movq	%rsi, %rdi
                	shlq	$0x28, %rdi
-               	xorq	%r13, %rdi
-               	leaq	0x8(%r14), %r12
-               	movq	%rdi, (%r12)
+               	movq	0xd8(%rsp), %r8
+               	xorq	%r8, %rdi
+               	leaq	0x8(%r15), %r13
+               	movq	%rdi, (%r13)
                	addq	$0x1, %rsi
                	cmpq	$0x3, %rsi
-               	jb	 <L67>
-<L68>:
-               	movq	%rcx, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x3, %r12
-               	jb	 <L69>
-               	jmp	 <L72>
-<L69>:
-               	movq	%r12, %rcx
-               	imulq	$0x40, %rcx, %rcx
-               	leaq	(%r15,%rcx), %r13
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	cmpq	$0x3, %r12
-               	jb	 <L69>
-<L72>:
-               	movq	%rbx, %rdi
-               	movq	0xd8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
+               	jb	 <L30>
+<L31>:
+               	movq	%r12, %r8
+               	movq	%r8, 0xd0(%rsp)
                	movq	$0x0, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
+               	cmpq	$0x3, %rsi
+               	jb	 <L32>
+               	jmp	 <L37>
+<L32>:
+               	movq	%rsi, %rdi
+               	imulq	$0x40, %rdi, %rdi
+               	leaq	(%r14,%rdi), %rbx
+               	leaq	(%rbx), %rdi
+               	movq	(%rdi), %rbx
                	movq	0xd0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L75>
-<L75>:
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %r12
+               	xorq	%r15, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r13
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+<L34>:
+               	movq	%rsi, %rbx
+               	imulq	$0x40, %rbx, %rbx
+               	leaq	(%r14,%rbx), %r12
+               	leaq	0x8(%r12), %rbx
+               	movq	(%rbx), %r12
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L35>
+<L36>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, 0xd0(%rsp)
+               	cmpq	$0x3, %rsi
+               	jb	 <L32>
+<L37>:
+               	movq	0x140(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	0xd0(%rsp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+<L39>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x0, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+<L41>:
+               	movq	0x138(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L42>
+<L42>:
                	movq	%rax, %rdi
-               	movq	0xc8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L76>
-<L76>:
+               	movq	0x130(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L43>
+<L43>:
                	movq	%rax, %rdi
-               	movq	0xc0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L77>
-<L77>:
+               	movq	0x128(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %rdi
-               	movq	0xb8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L78>
-<L78>:
+               	movq	0x120(%rsp), %r8
+               	movzwq	%r8w, %rsi
+               	callq	 <L45>
+<L45>:
                	movq	%rax, %rdi
-               	movq	0xb0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	0x28(%rsp), %rbx
-               	movq	0x20(%rsp), %r12
-               	movq	0x18(%rsp), %r13
-               	movq	0x10(%rsp), %r14
-               	movq	0x8(%rsp), %r15
+               	movq	0x118(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	0x58(%rsp), %rbx
+               	movq	0x50(%rsp), %r12
+               	movq	0x48(%rsp), %r13
+               	movq	0x40(%rsp), %r14
+               	movq	0x38(%rsp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/frame/frame_large.dis
+++ b/test/golden/x86_64-darwin/frame/frame_large.dis
@@ -5,282 +5,547 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.frame.frame_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2070, %rsp           ## imm = 0x2070
-               	movq	%rbx, -0x2048(%rbp)
-               	movq	%r12, -0x2050(%rbp)
-               	movq	%r13, -0x2058(%rbp)
-               	movq	%r14, -0x2060(%rbp)
-               	movq	%r15, -0x2068(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x1400(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x1400, %rsi           ## imm = 0x1400
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	leaq	-0x1c00(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x800, %rsi            ## imm = 0x800
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L2>
-               	leaq	-0x2000(%rbp), %r8
+               	subq	$0x2050, %rsp           ## imm = 0x2050
+               	movq	%rbx, -0x2028(%rbp)
+               	movq	%r12, -0x2030(%rbp)
+               	movq	%r13, -0x2038(%rbp)
+               	movq	%r14, -0x2040(%rbp)
+               	movq	%r15, -0x2048(%rbp)
+               	movq	%rdi, %r8
                	movq	%r8, -0x2020(%rbp)
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x400, %rsi            ## imm = 0x400
-<L3>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L3>
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	leaq	0x13f8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7fc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	0x3ff(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x280, %rsi            ## imm = 0x280
-               	jb	 <L10>
-               	jmp	 <L11>
-<L10>:
-               	movq	%rsi, %rdi
-               	addq	%rbx, %rdi
-               	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdi
-               	movq	%rsi, %r15
-               	shlq	$0x11, %r15
-               	xorq	%r15, %rdi
-               	leaq	(%r12,%rsi,8), %r15
-               	movq	%rdi, (%r15)
-               	addq	$0x1, %rsi
-               	cmpq	$0x280, %rsi            ## imm = 0x280
-               	jb	 <L10>
-<L11>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
-               	jb	 <L12>
-               	jmp	 <L13>
-<L12>:
-               	movq	%rsi, %rdi
-               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rdi
-               	addq	%rbx, %rdi
-               	movq	%rsi, %r15
-               	shrq	$0x3, %r15
-               	xorq	%r15, %rdi
-               	movl	%edi, %r15d
-               	leaq	(%r13,%rsi,4), %rdi
-               	movl	%r15d, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
-               	jb	 <L12>
-<L13>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x400, %rsi            ## imm = 0x400
-               	jb	 <L14>
-               	jmp	 <L15>
-<L14>:
-               	movq	%rsi, %rdi
-               	imulq	$0x83, %rdi, %rdi
-               	addq	%rbx, %rdi
-               	movq	%rsi, %r15
-               	shrq	$0x2, %r15
-               	xorq	%r15, %rdi
-               	movb	%dil, %r15b
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8,%rsi), %rdi
-               	movb	%r15b, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x400, %rsi            ## imm = 0x400
-               	jb	 <L14>
-<L15>:
-               	movq	%rcx, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x2038(%rbp)
-               	movq	-0x2038(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L16>
-               	jmp	 <L20>
-<L16>:
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0x9, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x280, %rsi            ## imm = 0x280
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %rsi
-               	leaq	(%r12,%rsi,8), %rdi
-               	movq	(%rdi), %rsi
-               	movq	%r15, %rdi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %r8
+               	leaq	-0x1400(%rbp), %r8
+               	movq	%r8, -0x2018(%rbp)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x1400, %r12           ## imm = 0x1400
+<L0>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L0>
+               	leaq	-0x1c00(%rbp), %r8
+               	movq	%r8, -0x2010(%rbp)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0x800, %r13            ## imm = 0x800
+<L1>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L1>
+               	leaq	-0x2000(%rbp), %r8
                	movq	%r8, -0x2008(%rbp)
                	movq	-0x2008(%rbp), %r8
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	(%r8), %r13
+               	addq	$0x0, %r13
+               	movq	$0x400, %r14            ## imm = 0x400
+<L2>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L2>
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	(%r13), %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r15, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %rbx
+               	xorq	%r12, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L3>
+<L4>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rbx
+               	movq	(%rbx), %r12
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+<L6>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movl	(%rbx), %r12d
+               	movl	%r12d, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L7>
+<L8>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rbx
+               	movl	(%rbx), %r12d
+               	movl	%r12d, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
+<L10>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movzbl	(%rbx), %r12d
+               	movzbq	%r12b, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rbx
+               	movzbl	(%rbx), %r12d
+               	movzbq	%r12b, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L13>
+<L14>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x280, %rbx            ## imm = 0x280
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	-0x2020(%rbp), %r8
+               	movq	%rbx, %r12
+               	addq	%r8, %r12
+               	movabsq	$0x5851f42d4c957f2d, %r11 ## imm = 0x5851F42D4C957F2D
+               	imulq	%r11, %r12
+               	movq	%rbx, %r14
+               	shlq	$0x11, %r14
+               	xorq	%r14, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %r14
+               	movq	%r12, (%r14)
+               	addq	$0x1, %rbx
+               	cmpq	$0x280, %rbx            ## imm = 0x280
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rbx            ## imm = 0x200
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rbx, %r12
+               	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
+               	imulq	%r11, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rbx, %r14
+               	shrq	$0x3, %r14
+               	xorq	%r14, %r12
+               	movl	%r12d, %r14d
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	%r14d, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x200, %rbx            ## imm = 0x200
+               	jb	 <L17>
+<L18>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x400, %rbx            ## imm = 0x400
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%rbx, %r12
+               	imulq	$0x83, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rbx, %r14
+               	shrq	$0x2, %r14
+               	xorq	%r14, %r12
+               	movb	%r12b, %r14b
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rbx), %r12
+               	movb	%r14b, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x400, %rbx            ## imm = 0x400
+               	jb	 <L19>
+<L20>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x40, %rbx
+               	jb	 <L21>
+               	jmp	 <L28>
+<L21>:
+               	movq	%rbx, %r12
+               	imulq	$0x9, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%r12, %rax
+               	movq	$0x280, %r12            ## imm = 0x280
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r14
+               	movq	(%r14), %r12
+               	movq	%r13, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L22>
+<L23>:
+               	movq	%rbx, %rsi
                	imulq	$0xd, %rsi, %rsi
-               	addq	%rbx, %rsi
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rsi
                	movq	%rsi, %rax
                	movq	$0x200, %rsi            ## imm = 0x200
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	leaq	(%r13,%rsi,4), %rdi
-               	movl	(%rdi), %esi
-               	movq	-0x2008(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x2010(%rbp)
                	movq	-0x2010(%rbp), %r8
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rsi
                	imulq	$0x1d, %rsi, %rsi
-               	addq	%rbx, %rsi
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rsi
                	movq	%rsi, %rax
                	movq	$0x400, %rsi            ## imm = 0x400
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	movq	-0x2020(%rbp), %r8
+               	movq	-0x2008(%rbp), %r8
                	leaq	(%r8,%rsi), %rdi
                	movzbl	(%rdi), %esi
-               	movq	-0x2010(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r15
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x2038(%rbp)
-               	movq	-0x2038(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L16>
-<L20>:
-               	leaq	0x13f8(%r12), %r8
-               	movq	%r8, -0x2040(%rbp)
-               	movq	-0x2040(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x2018(%rbp)
-               	movq	%rbx, %rdi
-               	andq	$0x1, %rdi
-               	movq	$0x27f, %rsi            ## imm = 0x27F
-               	subq	%rdi, %rsi
-               	leaq	(%r12,%rsi,8), %rdi
-               	movq	-0x2018(%rbp), %r8
-               	movq	%r8, (%rdi)
-               	leaq	0x7fc(%r13), %r14
-               	movl	(%r14), %esi
-               	movl	%esi, %r8d
-               	addl	$0x7, %r8d
-               	movq	%r8, -0x2028(%rbp)
-               	movq	%rbx, %rdi
-               	andq	$0x3, %rdi
-               	movq	$0x1ff, %rsi            ## imm = 0x1FF
-               	subq	%rdi, %rsi
-               	leaq	(%r13,%rsi,4), %rdi
-               	movq	-0x2028(%rbp), %r8
-               	movl	%r8d, (%rdi)
-               	movq	-0x2020(%rbp), %r9
-               	leaq	0x3ff(%r9), %r8
-               	movq	%r8, -0x2030(%rbp)
-               	movq	-0x2030(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	addl	$0xb, %esi
-               	andq	$0x7, %rbx
-               	movq	$0x3ff, %rdi            ## imm = 0x3FF
-               	subq	%rbx, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8,%rdi), %rbx
-               	movb	%sil, (%rbx)
-               	leaq	0x13f0(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	movq	%r15, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x2040(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	leaq	0x7f0(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movl	(%r14), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	0x3f8(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x2030(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	callq	 <L26>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x2048(%rbp), %rbx
-               	movq	-0x2050(%rbp), %r12
-               	movq	-0x2058(%rbp), %r13
-               	movq	-0x2060(%rbp), %r14
-               	movq	-0x2068(%rbp), %r15
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x40, %rbx
+               	jb	 <L21>
+<L28>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x1, %rsi
+               	movq	$0x27f, %rbx            ## imm = 0x27F
+               	subq	%rsi, %rbx
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rsi
+               	movl	(%rsi), %edi
+               	addl	$0x7, %edi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x3, %rsi
+               	movq	$0x1ff, %rbx            ## imm = 0x1FF
+               	subq	%rsi, %rbx
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	addl	$0xb, %edi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x7, %rsi
+               	movq	$0x3ff, %rbx            ## imm = 0x3FF
+               	subq	%rsi, %rbx
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rbx), %rsi
+               	movb	%dil, (%rsi)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f0(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+<L32>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7f0(%r8), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+<L34>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+<L36>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3f8(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L37>
+<L38>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L39>
+<L40>:
+               	movq	%r13, %rax
+               	movq	-0x2028(%rbp), %rbx
+               	movq	-0x2030(%rbp), %r12
+               	movq	-0x2038(%rbp), %r13
+               	movq	-0x2040(%rbp), %r14
+               	movq	-0x2048(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/frame/frame_spill.dis
+++ b/test/golden/x86_64-darwin/frame/frame_spill.dis
@@ -22,144 +22,139 @@ Disassembly of section __TEXT,__text:
                	movq	%r13, -0x2b8(%rbp)
                	movq	%r14, -0x2c0(%rbp)
                	movq	%r15, -0x2c8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	movabsq	$0x5851f42d4c957f2d, %r8 ## imm = 0x5851F42D4C957F2D
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x48(%rbp)
                	movabsq	$0x14057b7ef767814f, %rdx ## imm = 0x14057B7EF767814F
-               	xorq	%rbx, %rdx
+               	xorq	%rdi, %rdx
                	movabsq	$-0x61c8864680b583eb, %rsi ## imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rsi
-               	movabsq	$-0x3d4d51c2d82b14b1, %rdi ## imm = 0xC2B2AE3D27D4EB4F
-               	xorq	%rbx, %rdi
+               	addq	%rdi, %rsi
+               	movabsq	$-0x3d4d51c2d82b14b1, %rbx ## imm = 0xC2B2AE3D27D4EB4F
+               	xorq	%rdi, %rbx
                	movabsq	$0x165667b19e3779f9, %r12 ## imm = 0x165667B19E3779F9
-               	addq	%rbx, %r12
+               	addq	%rdi, %r12
                	movabsq	$-0x7a1435883d4d519d, %r13 ## imm = 0x85EBCA77C2B2AE63
-               	xorq	%rbx, %r13
+               	xorq	%rdi, %r13
                	movabsq	$0x27d4eb2f165667c5, %r14 ## imm = 0x27D4EB2F165667C5
-               	addq	%rbx, %r14
+               	addq	%rdi, %r14
                	movabsq	$0x72a63cd72e2d1e61, %r15 ## imm = 0x72A63CD72E2D1E61
-               	xorq	%rbx, %r15
+               	xorq	%rdi, %r15
                	movabsq	$0x42f1ea7f85a51475, %r8 ## imm = 0x42F1EA7F85A51475
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x8(%rbp)
                	movabsq	$0x30befe08be84df1f, %r8 ## imm = 0x30BEFE08BE84DF1F
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x10(%rbp)
                	movabsq	$0x61c8864680b583eb, %r8 ## imm = 0x61C8864680B583EB
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x18(%rbp)
                	movabsq	$0x4cf43f349dbb99b1, %r8 ## imm = 0x4CF43F349DBB99B1
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x20(%rbp)
                	movabsq	$-0x5555555555555555, %r8 ## imm = 0xAAAAAAAAAAAAAAAB
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x28(%rbp)
                	movabsq	$-0x25c1c6346b46a425, %r8 ## imm = 0xDA3E39CB94B95BDB
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x30(%rbp)
                	movabsq	$0x1f2e512d5ac22ad1, %r8 ## imm = 0x1F2E512D5AC22AD1
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x38(%rbp)
                	movabsq	$0x2d54e746111a977f, %r8 ## imm = 0x2D54E746111A977F
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x40(%rbp)
-               	movabsq	$0x9e3779b1, %rcx       ## imm = 0x9E3779B1
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x9e3779b1, %rax       ## imm = 0x9E3779B1
+               	addq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x50(%rbp)
-               	movq	$0x9e37, %rcx           ## imm = 0x9E37
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movq	$0x9e37, %rax           ## imm = 0x9E37
+               	xorq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x58(%rbp)
-               	movabsq	$0x85ebca77, %rcx       ## imm = 0x85EBCA77
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x85ebca77, %rax       ## imm = 0x85EBCA77
+               	addq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x60(%rbp)
-               	movabsq	$0xc2b2ae3d, %rcx       ## imm = 0xC2B2AE3D
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0xc2b2ae3d, %rax       ## imm = 0xC2B2AE3D
+               	xorq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x68(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x1ab>
+<L1>:
+               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x1a3>
                	addsd	%xmm0, %xmm1
-               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x1b7>
+               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x1af>
                	addsd	%xmm0, %xmm2
-               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x1c3>
+               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x1bb>
                	addsd	%xmm0, %xmm3
-               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x1cf>
+               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x1c7>
                	addsd	%xmm0, %xmm4
-               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x1db>
+               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x1d3>
                	addsd	%xmm0, %xmm5
-               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x1e7>
+               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x1df>
                	addsd	%xmm0, %xmm6
-               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x1f3>
+               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x1eb>
                	addsd	%xmm0, %xmm7
-               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x200>
+               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x1f8>
                	addsd	%xmm0, %xmm8
-               	movq	%rax, %r8
-               	movq	%r8, -0xd8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x168(%rbp)
                	movq	-0x48(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x208(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	movq	%rdx, %r8
-               	movq	%r8, -0x210(%rbp)
+               	movq	%r8, -0x78(%rbp)
                	movq	%rsi, %r8
                	movq	%r8, -0x218(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	%r14, %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0x8(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x78(%rbp)
+               	movq	%r8, -0x80(%rbp)
                	movq	-0x10(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x80(%rbp)
+               	movq	%r8, -0x88(%rbp)
                	movq	-0x18(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x88(%rbp)
+               	movq	%r8, -0x90(%rbp)
                	movq	-0x20(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x90(%rbp)
+               	movq	%r8, -0x98(%rbp)
                	movq	-0x28(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x98(%rbp)
+               	movq	%r8, -0xa0(%rbp)
                	movq	-0x30(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xa0(%rbp)
+               	movq	%r8, -0xa8(%rbp)
                	movq	-0x38(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xa8(%rbp)
+               	movq	%r8, -0xb0(%rbp)
                	movq	-0x40(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xb0(%rbp)
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0x50(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xb8(%rbp)
+               	movq	%r8, -0xc0(%rbp)
                	movq	-0x58(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xc0(%rbp)
+               	movq	%r8, -0xc8(%rbp)
                	movq	-0x60(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xc8(%rbp)
+               	movq	%r8, -0xd0(%rbp)
                	movq	-0x68(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movq	%r8, -0xd8(%rbp)
                	movsd	%xmm1, -0x228(%rbp)
                	movsd	%xmm2, -0x238(%rbp)
                	movsd	%xmm3, -0x248(%rbp)
@@ -168,44 +163,44 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, -0x278(%rbp)
                	movsd	%xmm7, -0x288(%rbp)
                	movsd	%xmm8, -0x298(%rbp)
-               	movq	$0x0, %rbx
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
-               	jmp	 <L7>
-<L3>:
-               	movq	-0xb0(%rbp), %r8
+               	movq	$0x0, %r15
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+               	jmp	 <L6>
+<L2>:
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x1d, %rsi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x23, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x208(%rbp), %r9
+               	movq	-0x70(%rbp), %r9
                	movq	%r9, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x208(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x7, %rsi
-               	movq	-0x208(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x39, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x210(%rbp), %r9
+               	movq	-0x78(%rbp), %r9
                	movq	%r9, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x210(%rbp), %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0xb, %rsi
-               	movq	-0x210(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x35, %rdi
                	orq	%rdi, %rsi
                	movq	-0x218(%rbp), %r9
                	movq	%r9, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	movq	-0x218(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0xd, %rsi
@@ -213,20 +208,17 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, %rdi
                	shrq	$0x33, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x70(%rbp), %r9
-               	movq	%r9, %r8
+               	movq	%rbx, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, -0x100(%rbp)
+               	movq	%rbx, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%rbx, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	movq	%r12, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	%r8, -0x108(%rbp)
                	movq	%r12, %rsi
                	shlq	$0x13, %rsi
                	movq	%r12, %rdi
@@ -234,225 +226,223 @@ Disassembly of section __TEXT,__text:
                	orq	%rdi, %rsi
                	movq	%r13, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0x108(%rbp)
+               	movq	%r8, -0x110(%rbp)
                	movq	%r13, %rsi
                	shlq	$0x17, %rsi
                	movq	%r13, %rdi
                	shrq	$0x29, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x160(%rbp), %r9
-               	movq	%r9, %r8
+               	movq	%r14, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, -0x118(%rbp)
+               	movq	%r14, %rsi
                	shlq	$0x1f, %rsi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%r14, %rdi
                	shrq	$0x21, %rdi
                	orq	%rdi, %rsi
-               	movq	%r15, %r8
-               	addq	%rsi, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r15, %rsi
-               	shlq	$0x25, %rsi
-               	movq	%r15, %rdi
-               	shrq	$0x1b, %rdi
-               	orq	%rdi, %rsi
-               	movq	-0x78(%rbp), %r9
+               	movq	-0xe0(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x120(%rbp)
-               	movq	-0x78(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x29, %rsi
-               	movq	-0x78(%rbp), %r8
+               	shlq	$0x25, %rsi
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x17, %rdi
+               	shrq	$0x1b, %rdi
                	orq	%rdi, %rsi
                	movq	-0x80(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x128(%rbp)
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x2b, %rsi
+               	shlq	$0x29, %rsi
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x15, %rdi
+               	shrq	$0x17, %rdi
                	orq	%rdi, %rsi
                	movq	-0x88(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x130(%rbp)
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x2f, %rsi
+               	shlq	$0x2b, %rsi
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x11, %rdi
+               	shrq	$0x15, %rdi
                	orq	%rdi, %rsi
                	movq	-0x90(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x138(%rbp)
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x35, %rsi
+               	shlq	$0x2f, %rsi
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0xb, %rdi
+               	shrq	$0x11, %rdi
                	orq	%rdi, %rsi
                	movq	-0x98(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x140(%rbp)
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3b, %rsi
+               	shlq	$0x35, %rsi
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x5, %rdi
+               	shrq	$0xb, %rdi
                	orq	%rdi, %rsi
                	movq	-0xa0(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x148(%rbp)
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3d, %rsi
+               	shlq	$0x3b, %rsi
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x3, %rdi
+               	shrq	$0x5, %rdi
                	orq	%rdi, %rsi
                	movq	-0xa8(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x150(%rbp)
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3, %rsi
+               	shlq	$0x3d, %rsi
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x3d, %rdi
+               	shrq	$0x3, %rdi
                	orq	%rdi, %rsi
                	movq	-0xb0(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x158(%rbp)
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %r14
-               	addq	%rbx, %r14
-               	movq	-0x148(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shlq	$0x3, %rsi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	$0x3d, %rdi
+               	orq	%rdi, %rsi
                	movq	-0xb8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	xorl	%esi, %r8d
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r9, %r8
+               	addq	%rsi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	%r15, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x150(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xc0(%rbp), %r9
                	movl	%r9d, %r8d
-               	addl	%esi, %r8d
+               	xorl	%esi, %r8d
                	movq	%r8, -0x170(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0xf0(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xc8(%rbp), %r9
                	movl	%r9d, %r8d
-               	xorl	%esi, %r8d
+               	addl	%esi, %r8d
                	movq	%r8, -0x178(%rbp)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xd0(%rbp), %r9
                	movl	%r9d, %r8d
-               	addl	%esi, %r8d
+               	xorl	%esi, %r8d
                	movq	%r8, -0x180(%rbp)
-               	movsd	-0x228(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6a6>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
+               	movq	-0x130(%rbp), %r8
+               	movl	%r8d, %esi
+               	movq	-0xd8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	addl	%esi, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	movsd	-0x228(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x68f>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
                	addsd	-0x238(%rbp), %xmm14
-               	movsd	%xmm14, -0x190(%rbp)
-               	movsd	-0x238(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6cd>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x248(%rbp), %xmm14
-               	movsd	%xmm14, -0x1a0(%rbp)
-               	movsd	-0x248(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6f4>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x258(%rbp), %xmm14
-               	movsd	%xmm14, -0x1b0(%rbp)
-               	movsd	-0x258(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x71b>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x268(%rbp), %xmm14
-               	movsd	%xmm14, -0x1c0(%rbp)
-               	movsd	-0x268(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x742>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x278(%rbp), %xmm14
                	movsd	%xmm14, -0x1d0(%rbp)
-               	movsd	-0x278(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x769>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x288(%rbp), %xmm14
+               	movsd	-0x238(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x6b8>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x248(%rbp), %xmm14
                	movsd	%xmm14, -0x1e0(%rbp)
-               	movsd	-0x288(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x790>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x298(%rbp), %xmm14
+               	movsd	-0x248(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x6e1>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x258(%rbp), %xmm14
                	movsd	%xmm14, -0x1f0(%rbp)
-               	movsd	-0x298(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x7b7>
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x228(%rbp), %xmm14
+               	movsd	-0x258(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x70a>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x268(%rbp), %xmm14
                	movsd	%xmm14, -0x200(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movq	-0x128(%rbp), %r9
+               	movsd	-0x268(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x733>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x278(%rbp), %xmm14
+               	movsd	%xmm14, -0x210(%rbp)
+               	movsd	-0x278(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x75c>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x288(%rbp), %xmm14
+               	movsd	%xmm14, -0x198(%rbp)
+               	movsd	-0x288(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x785>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x298(%rbp), %xmm14
+               	movsd	%xmm14, -0x1a8(%rbp)
+               	movsd	-0x298(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x7ae>
+               	movsd	%xmm8, %xmm14           ## xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x228(%rbp), %xmm14
+               	movsd	%xmm14, -0x1b8(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	-0x130(%rbp), %r9
                	movq	%r8, %rsi
                	xorq	%r9, %rsi
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L3>
+<L3>:
+               	movq	%rax, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movl	%r8d, %esi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	-0x170(%rbp), %r8
-               	movl	%r8d, %esi
+               	movsd	-0x1d0(%rbp), %xmm8
+               	addsd	-0x210(%rbp), %xmm8
+               	movq	%xmm8, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x190(%rbp), %xmm0
-               	addsd	-0x1d0(%rbp), %xmm0
-               	callq	 <L6>
-<L6>:
                	movq	%rax, %rsi
-               	addq	$0x1, %rbx
+               	addq	$0x1, %r15
                	movq	%rsi, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xe8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x208(%rbp)
+               	movq	%r8, -0x168(%rbp)
                	movq	-0xf0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x210(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	movq	-0xf8(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x218(%rbp)
+               	movq	%r8, -0x78(%rbp)
                	movq	-0x100(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x70(%rbp)
+               	movq	%r8, -0x218(%rbp)
                	movq	-0x108(%rbp), %r8
-               	movq	%r8, %r12
+               	movq	%r8, %rbx
                	movq	-0x110(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %r13
-               	movq	-0x118(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x160(%rbp)
                	movq	-0x120(%rbp), %r8
-               	movq	%r8, %r15
+               	movq	%r8, %r14
                	movq	-0x128(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x78(%rbp)
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0x130(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x80(%rbp)
@@ -471,9 +461,10 @@ Disassembly of section __TEXT,__text:
                	movq	-0x158(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xa8(%rbp)
-               	movq	%r14, %r8
+               	movq	-0x160(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0xb0(%rbp)
-               	movq	-0x170(%rbp), %r9
+               	movq	-0x1c0(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xb8(%rbp)
                	movq	-0x178(%rbp), %r9
@@ -482,158 +473,417 @@ Disassembly of section __TEXT,__text:
                	movq	-0x180(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xc8(%rbp)
-               	movq	-0x168(%rbp), %r9
+               	movq	-0x188(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xd0(%rbp)
-               	movq	-0x190(%rbp), %r11
-               	movq	%r11, -0x228(%rbp)
-               	movq	-0x1a0(%rbp), %r11
-               	movq	%r11, -0x238(%rbp)
-               	movq	-0x1b0(%rbp), %r11
-               	movq	%r11, -0x248(%rbp)
-               	movq	-0x1c0(%rbp), %r11
-               	movq	%r11, -0x258(%rbp)
+               	movq	-0x170(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
                	movq	-0x1d0(%rbp), %r11
-               	movq	%r11, -0x268(%rbp)
+               	movq	%r11, -0x228(%rbp)
                	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, -0x278(%rbp)
+               	movq	%r11, -0x238(%rbp)
                	movq	-0x1f0(%rbp), %r11
-               	movq	%r11, -0x288(%rbp)
+               	movq	%r11, -0x248(%rbp)
                	movq	-0x200(%rbp), %r11
+               	movq	%r11, -0x258(%rbp)
+               	movq	-0x210(%rbp), %r11
+               	movq	%r11, -0x268(%rbp)
+               	movq	-0x198(%rbp), %r11
+               	movq	%r11, -0x278(%rbp)
+               	movq	-0x1a8(%rbp), %r11
+               	movq	%r11, -0x288(%rbp)
+               	movq	-0x1b8(%rbp), %r11
                	movq	%r11, -0x298(%rbp)
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+<L6>:
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x208(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x210(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x218(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+<L8>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+<L12>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+<L14>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+<L18>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
+<L20>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L17>
-<L17>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+<L24>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+<L26>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+<L28>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+<L30>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+<L32>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L23>
-<L23>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	movq	-0xc0(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L25>
-<L25>:
                	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
                	movq	-0xc8(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
                	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
                	movq	-0xd0(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
                	movq	%rax, %rdi
-               	movsd	-0x228(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
+               	callq	 <L41>
+<L41>:
+               	movq	-0xd8(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movsd	-0x238(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L42>
+<L42>:
+               	movq	-0x228(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x248(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
+               	callq	 <L43>
+<L43>:
+               	movq	-0x238(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x258(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
+               	callq	 <L44>
+<L44>:
+               	movq	-0x248(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x268(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
+               	callq	 <L45>
+<L45>:
+               	movq	-0x258(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x278(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
+               	callq	 <L46>
+<L46>:
+               	movq	-0x268(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x288(%rbp), %xmm0
-               	callq	 <L34>
-<L34>:
+               	callq	 <L47>
+<L47>:
+               	movq	-0x278(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x298(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
+               	callq	 <L48>
+<L48>:
+               	movq	-0x288(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	-0x298(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	movq	-0x2a8(%rbp), %rbx
                	movq	-0x2b0(%rbp), %r12
                	movq	-0x2b8(%rbp), %r13

--- a/test/golden/x86_64-darwin/imm/imm_add.dis
+++ b/test/golden/x86_64-darwin/imm/imm_add.dis
@@ -9,141 +9,404 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movl	%ebx, %eax
+               	addl	$0x7ff, %eax            ## imm = 0x7FF
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	movl	%ecx, %r12d
-               	addl	$0x7ff, %r12d           ## imm = 0x7FF
-               	movl	%r12d, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r13d
-               	addl	$0x800, %r13d           ## imm = 0x800
-               	movl	%r13d, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	addl	$0xfff, %r13d           ## imm = 0xFFF
-               	movl	%r13d, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	addl	$0x1000, %r13d          ## imm = 0x1000
-               	movl	%r13d, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	addl	$0x7fffffff, %r13d      ## imm = 0x7FFFFFFF
-               	movl	%r13d, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	addl	$0x80000000, %r13d      ## imm = 0x80000000
-               	movl	%r13d, %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	addl	$0xffffffff, %r13d      ## imm = 0xFFFFFFFF
-               	movl	%r13d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	addq	$0x7ff, %rbx            ## imm = 0x7FF
-               	movq	%rbx, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r13
-               	subq	$0x800, %r13            ## imm = 0x800
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
                	movq	%r13, %rsi
-               	callq	 <L9>
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+<L1>:
+               	addl	$0x800, %eax            ## imm = 0x800
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+<L3>:
+               	addl	$0xfff, %eax            ## imm = 0xFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+<L5>:
+               	addl	$0x1000, %eax           ## imm = 0x1000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+<L7>:
+               	addl	$0x7fffffff, %eax       ## imm = 0x7FFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r13, %r14
-               	addq	$0xfff000, %r14         ## imm = 0xFFF000
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	addl	$0x80000000, %eax       ## imm = 0x80000000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	addq	$0xffffff, %r14         ## imm = 0xFFFFFF
-               	movq	%r14, %rsi
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	addq	$0x7fffffff, %r14       ## imm = 0x7FFFFFFF
-               	movq	%r14, %rsi
-               	callq	 <L12>
+               	addl	$0xffffffff, %eax       ## imm = 0xFFFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movabsq	$0x80000000, %r11       ## imm = 0x80000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L14>
+               	movq	%rbx, %rax
+               	addq	$0x7ff, %rax            ## imm = 0x7FF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movabsq	$0x100000000, %r11      ## imm = 0x100000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L15>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	subq	$0x800, %rax            ## imm = 0x800
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	subl	$0x800, %r12d           ## imm = 0x800
-               	movl	%r12d, %esi
-               	callq	 <L18>
+               	addq	$0xfff000, %rax         ## imm = 0xFFF000
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	addl	$0x7fffffff, %r12d      ## imm = 0x7FFFFFFF
-               	movl	%r12d, %esi
-               	callq	 <L19>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	subl	$0x80000000, %r12d      ## imm = 0x80000000
-               	movl	%r12d, %esi
-               	callq	 <L20>
+               	addq	$0xffffff, %rax         ## imm = 0xFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	addq	$0x7fffffff, %rax       ## imm = 0x7FFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x80000000, %r11       ## imm = 0x80000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movabsq	$0x100000000, %r11      ## imm = 0x100000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movl	%ebx, %eax
+               	movl	%eax, %r12d
+               	addl	$0x7ff, %r12d           ## imm = 0x7FF
+               	movslq	%r12d, %rax
+               	movq	%rsi, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L32>
+<L32>:
+               	subl	$0x800, %r12d           ## imm = 0x800
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	addl	$0x7fffffff, %r12d      ## imm = 0x7FFFFFFF
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	subl	$0x80000000, %r12d      ## imm = 0x80000000
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	addq	$0x7ff, %rbx            ## imm = 0x7FF
                	movq	%rax, %rdi
                	movq	%rbx, %rsi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L36>
+<L36>:
+               	subq	$0x800, %rbx            ## imm = 0x800
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L22>
-<L22>:
+               	movq	%rbx, %rsi
+               	callq	 <L37>
+<L37>:
+               	addq	$0x7fffffff, %rbx       ## imm = 0x7FFFFFFF
                	movq	%rax, %rdi
-               	addq	$0x7fffffff, %r13       ## imm = 0x7FFFFFFF
-               	movq	%r13, %rsi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L38>
+<L38>:
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	subq	%r11, %r13
-               	movq	%r13, %rsi
-               	callq	 <L24>
-<L24>:
+               	subq	%r11, %rbx
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L39>
+<L39>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/imm/imm_addr.dis
+++ b/test/golden/x86_64-darwin/imm/imm_addr.dis
@@ -5,271 +5,596 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_addr.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x9390, %rsp           ## imm = 0x9390
-               	movq	%rbx, -0x9368(%rbp)
-               	movq	%r12, -0x9370(%rbp)
-               	movq	%r13, -0x9378(%rbp)
-               	movq	%r14, -0x9380(%rbp)
-               	movq	%r15, -0x9388(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x9360, %rsp           ## imm = 0x9360
+               	movq	%rbx, -0x9338(%rbp)
+               	movq	%r12, -0x9340(%rbp)
+               	movq	%r13, -0x9348(%rbp)
+               	movq	%r14, -0x9350(%rbp)
+               	movq	%r15, -0x9358(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9318(%rbp)
+               	leaq	-0x8400(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x8400, %r12           ## imm = 0x8400
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x8400(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x8400, %rsi           ## imm = 0x8400
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	leaq	-0x9300(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xf00, %rsi            ## imm = 0xF00
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L2>
-               	movq	%rbx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	(%r12), %rsi
-               	movq	%rcx, (%rsi)
-               	movq	%rbx, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x7f8(%r12), %r14
-               	movq	%rcx, (%r14)
-               	movq	%rbx, %rcx
-               	addq	$0x3, %rcx
-               	leaq	0x800(%r12), %r15
-               	movq	%rcx, (%r15)
-               	movq	%rbx, %rcx
-               	addq	$0x4, %rcx
-               	leaq	0x7ff8(%r12), %r8
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L0>
+               	leaq	-0x9300(%rbp), %r8
                	movq	%r8, -0x9308(%rbp)
                	movq	-0x9308(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	%rbx, %rcx
-               	addq	$0x5, %rcx
-               	leaq	0x8000(%r12), %r8
-               	movq	%r8, -0x9310(%rbp)
-               	movq	-0x9310(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	%rbx, %rcx
-               	addq	$0x6, %rcx
-               	leaq	0x83f8(%r12), %r8
-               	movq	%r8, -0x9318(%rbp)
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0xf00, %r13            ## imm = 0xF00
+<L1>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L1>
                	movq	-0x9318(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L3>
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	leaq	(%rbx), %r13
+               	movq	%r12, (%r13)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x2, %r12
+               	leaq	0x7f8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x3, %r12
+               	leaq	0x800(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x4, %r12
+               	leaq	0x7ff8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x5, %r12
+               	leaq	0x8000(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x6, %r12
+               	leaq	0x83f8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	(%r13), %r12
+               	movabsq	$-0x340d631b7bdddcdb, %r13 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	(%r14), %rsi
-               	callq	 <L4>
+               	leaq	0x7f8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	(%r15), %rsi
-               	callq	 <L5>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L6>
+               	leaq	0x800(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x9310(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L7>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x9318(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L8>
+               	leaq	0x7ff8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rax
-               	movq	$0x1080, %rcx           ## imm = 0x1080
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	%rbx, %rsi
-               	addq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %rax
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0x8000(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0x83f8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
                	movq	$0x1080, %rsi           ## imm = 0x1080
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	movq	%rbx, %r14
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0xfff, %r12            ## imm = 0xFFF
+               	movq	%r12, %rax
+               	movq	$0x1080, %r12           ## imm = 0x1080
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r14
                	addq	$0x800, %r14            ## imm = 0x800
                	movq	%r14, %rax
                	movq	$0x1080, %r14           ## imm = 0x1080
                	xorl	%edx, %edx
                	divq	%r14
-               	movq	%rdx, %r14
-               	leaq	(%r12,%rcx,8), %r15
-               	movq	(%r15), %rcx
-               	addq	$0x7, %rcx
-               	movq	%rcx, (%r15)
-               	leaq	(%r12,%rsi,8), %r8
-               	movq	%r8, -0x9358(%rbp)
-               	movq	-0x9358(%rbp), %r8
-               	movq	(%r8), %rsi
-               	addq	$0x8, %rsi
-               	movq	-0x9358(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	leaq	(%r12,%r14,8), %r8
-               	movq	%r8, -0x9320(%rbp)
-               	movq	-0x9320(%rbp), %r8
-               	movq	(%r8), %rsi
-               	addq	$0x9, %rsi
-               	movq	-0x9320(%rbp), %r8
-               	movq	%rsi, (%r8)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9310(%rbp)
+               	leaq	(%rbx,%rsi,8), %r15
                	movq	(%r15), %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x9358(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x9320(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rax
-               	movq	$0x60, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	%rbx, %rsi
-               	addq	$0x3f, %rsi
-               	movq	%rsi, %rax
+               	addq	$0x7, %rsi
+               	movq	%rsi, (%r15)
+               	leaq	(%rbx,%r12,8), %rsi
+               	movq	(%rsi), %r14
+               	addq	$0x8, %r14
+               	movq	%r14, (%rsi)
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rbx,%r8,8), %rsi
+               	movq	(%rsi), %r14
+               	addq	$0x9, %r14
+               	movq	%r14, (%rsi)
+               	movq	(%r15), %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rsi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+<L15>:
+               	leaq	(%rbx,%r12,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rbx,%r8,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
                	movq	$0x60, %rsi
                	xorl	%edx, %edx
                	divq	%rsi
-               	movq	%rdx, %rsi
-               	imulq	$0x28, %rcx, %rcx
-               	leaq	(%r13,%rcx), %r12
-               	leaq	(%r12), %rcx
-               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
-               	movq	%rbx, %r14
-               	addq	$0xa, %r14
-               	leaq	0x8(%r12), %r15
-               	leaq	(%r15), %r8
+               	movq	%rdx, %r8
                	movq	%r8, -0x9328(%rbp)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x3f, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x60, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9320(%rbp)
                	movq	-0x9328(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xb, %r14
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9330(%rbp)
-               	movq	-0x9330(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xc, %r14
-               	leaq	0x10(%r15), %r8
-               	movq	%r8, -0x9338(%rbp)
-               	movq	-0x9338(%rbp), %r8
-               	movq	%r14, (%r8)
-               	leaq	0x20(%r12), %r14
-               	movl	$0x12345678, (%r14)     ## imm = 0x12345678
+               	movq	%r8, %r12
+               	imulq	$0x28, %r12, %r12
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%r12), %r14
+               	leaq	(%r14), %r12
+               	movl	$0xffffffff, (%r12)     ## imm = 0xFFFFFFFF
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0xa, %r15
+               	leaq	0x8(%r14), %rdi
+               	leaq	(%rdi), %rsi
+               	movq	%r15, (%rsi)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xb, %rsi
+               	leaq	0x8(%rdi), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xc, %rsi
+               	leaq	0x10(%rdi), %r15
+               	movq	%rsi, (%r15)
+               	leaq	0x20(%r14), %rsi
+               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
                	imulq	$0x28, %rsi, %rsi
-               	leaq	(%r13,%rsi), %r12
-               	leaq	(%r12), %r13
-               	movl	$0xabcdef01, (%r13)     ## imm = 0xABCDEF01
-               	movq	%rbx, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	$0xabcdef01, (%rsi)     ## imm = 0xABCDEF01
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
                	addq	$0xd, %rsi
-               	leaq	0x8(%r12), %r15
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x9340(%rbp)
-               	movq	-0x9340(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	%rbx, %rsi
+               	leaq	0x8(%rdi), %r14
+               	leaq	(%r14), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
                	addq	$0xe, %rsi
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9348(%rbp)
-               	movq	-0x9348(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	addq	$0xf, %rbx
-               	leaq	0x10(%r15), %r8
-               	movq	%r8, -0x9350(%rbp)
-               	movq	-0x9350(%rbp), %r8
-               	movq	%rbx, (%r8)
-               	leaq	0x20(%r12), %rbx
-               	movl	$0x1234567, (%rbx)      ## imm = 0x1234567
-               	movl	(%rcx), %esi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x9328(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x9330(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x9338(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movl	(%r14), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movl	(%r13), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x9340(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x9348(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x9350(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L20>
+               	leaq	0x8(%r14), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xf, %rsi
+               	leaq	0x10(%r14), %r15
+               	movq	%rsi, (%r15)
+               	leaq	0x20(%rdi), %rsi
+               	movl	$0x1234567, (%rsi)      ## imm = 0x1234567
+               	movl	(%r12), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rdi
-               	movl	(%rbx), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L21>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rdi
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
                	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rcx
-               	addq	$0x10, %rcx
-               	movq	-0x9308(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L22>
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x9368(%rbp), %rbx
-               	movq	-0x9370(%rbp), %r12
-               	movq	-0x9378(%rbp), %r13
-               	movq	-0x9380(%rbp), %r14
-               	movq	-0x9388(%rbp), %r15
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	0x8(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	0x10(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x20(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+<L29>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L32>
+<L33>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %r12
+               	leaq	0x8(%r12), %r14
+               	leaq	0x8(%r14), %rsi
+               	movq	(%rsi), %r15
+               	movq	%r13, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L34>
+<L34>:
+               	movq	%rax, %rdi
+               	leaq	0x10(%r14), %rsi
+               	movq	(%rsi), %r13
+               	movq	%r13, %rsi
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %rdi
+               	leaq	0x20(%r12), %rsi
+               	movl	(%rsi), %r12d
+               	movl	%r12d, %esi
+               	callq	 <L36>
+<L36>:
+               	movq	%rax, %rdi
+               	leaq	0x7ff8(%rbx), %rsi
+               	movq	(%rsi), %rbx
+               	addq	$0x10, %rbx
+               	movq	%rbx, (%rsi)
+               	movq	(%rsi), %rbx
+               	movq	%rbx, %rsi
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	-0x9338(%rbp), %rbx
+               	movq	-0x9340(%rbp), %r12
+               	movq	-0x9348(%rbp), %r13
+               	movq	-0x9350(%rbp), %r14
+               	movq	-0x9358(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/imm/imm_logic.dis
+++ b/test/golden/x86_64-darwin/imm/imm_logic.dis
@@ -5,152 +5,416 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_logic.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movq	%r14, -0x20(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movl	%ebx, %eax
+               	movl	%eax, %edx
+               	orl	$0x55555555, %edx       ## imm = 0x55555555
+               	movl	%edx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	%r12d, %r13d
-               	orl	$0x55555555, %r13d      ## imm = 0x55555555
-               	movl	%r13d, %esi
-               	callq	 <L1>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	xorl	$0x55555555, %ecx       ## imm = 0x55555555
-               	andl	$0xf0f0f0f, %ecx        ## imm = 0xF0F0F0F
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movl	%eax, %esi
+               	xorl	$0x55555555, %esi       ## imm = 0x55555555
+               	andl	$0xf0f0f0f, %esi        ## imm = 0xF0F0F0F
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	orl	$0xffff0000, %ecx       ## imm = 0xFFFF0000
-               	movl	%ecx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	andl	$0xffff, %ecx           ## imm = 0xFFFF
-               	movl	%ecx, %esi
-               	callq	 <L4>
+               	movl	%eax, %esi
+               	orl	$0xffff0000, %esi       ## imm = 0xFFFF0000
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r14d
-               	xorl	$-0x1, %r14d
-               	movl	%r14d, %esi
-               	callq	 <L5>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %ecx
-               	orl	$0x55555555, %ecx       ## imm = 0x55555555
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %esi
+               	andl	$0xffff, %esi           ## imm = 0xFFFF
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	andl	$0xf0f0f0f, %ecx        ## imm = 0xF0F0F0F
-               	xorl	$0xffff0000, %ecx       ## imm = 0xFFFF0000
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r15
-               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
-               	orq	%r11, %r15
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rcx
-               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
-               	xorq	%r11, %rcx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 ## imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	movabsq	$-0xffff00010000, %r11  ## imm = 0xFFFF0000FFFF0000
-               	orq	%r11, %rsi
-               	callq	 <L10>
+               	orl	$0x55555555, %esi       ## imm = 0x55555555
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	movabsq	$0xff00ff00ff00ff, %r11 ## imm = 0xFF00FF00FF00FF
-               	andq	%r11, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	andl	$0xf0f0f0f, %eax        ## imm = 0xF0F0F0F
+               	xorl	$0xffff0000, %eax       ## imm = 0xFFFF0000
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
-               	orq	%r11, %rdx
-               	xorq	$-0x1, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rdx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 ## imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rdx
-               	movabsq	$-0xffff00010000, %r11  ## imm = 0xFFFF0000FFFF0000
-               	xorq	%r11, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L14>
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L15>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
+               	xorq	%r11, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 ## imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	xorl	%r14d, %r12d
-               	andl	$0xf0f0f0f, %r12d       ## imm = 0xF0F0F0F
-               	movl	%r12d, %esi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
+               	movq	%rbx, %rax
+               	movabsq	$-0xffff00010000, %r11  ## imm = 0xFFFF0000FFFF0000
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
+               	movq	%rbx, %rax
+               	movabsq	$0xff00ff00ff00ff, %r11 ## imm = 0xFF00FF00FF00FF
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	xorq	%r8, %rbx
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 ## imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movabsq	$-0xffff00010000, %r11  ## imm = 0xFFFF0000FFFF0000
+               	xorq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movl	%ebx, %eax
+               	movl	%eax, %esi
+               	orl	$0x55555555, %esi       ## imm = 0x55555555
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+<L31>:
+               	xorl	%esi, %eax
+               	andl	$0xf0f0f0f, %eax        ## imm = 0xF0F0F0F
+               	movslq	%eax, %rsi
+               	movq	%rdx, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rbx, %rsi
+               	movabsq	$0x5555555555555555, %r11 ## imm = 0x5555555555555555
+               	orq	%r11, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movq	%rbx, %r12
+               	xorq	$-0x1, %r12
+               	movq	%rax, %rdi
+               	movq	%r12, %rsi
+               	callq	 <L34>
+<L34>:
+               	xorq	%r12, %rbx
                	movabsq	$0xf0f0f0f0f0f0f0f, %r11 ## imm = 0xF0F0F0F0F0F0F0F
                	andq	%r11, %rbx
+               	movq	%rax, %rdi
                	movq	%rbx, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	callq	 <L35>
+<L35>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/imm/imm_mov.dis
+++ b/test/golden/x86_64-darwin/imm/imm_mov.dis
@@ -5,126 +5,318 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.imm.imm_mov.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x0, %r8
+               	je	 <L0>
+               	movl	$0x80000000, %esi       ## imm = 0x80000000
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	cmpq	$0x0, %rbx
-               	je	 <L1>
-               	movl	$0x80000000, %ecx       ## imm = 0x80000000
-               	jmp	 <L2>
+               	movl	$0x7ff, %esi            ## imm = 0x7FF
 <L1>:
-               	movl	$0x7ff, %ecx            ## imm = 0x7FF
+               	movl	%esi, %ebx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movl	%ecx, %esi
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	cmpq	$0x1, %rbx
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x1, %r8
                	je	 <L4>
-               	movabsq	$0x7fffffffffffffff, %rsi ## imm = 0x7FFFFFFFFFFFFFFF
+               	movabsq	$0x7fffffffffffffff, %rbx ## imm = 0x7FFFFFFFFFFFFFFF
                	jmp	 <L5>
 <L4>:
-               	movabsq	$0xffffffff, %rsi       ## imm = 0xFFFFFFFF
+               	movabsq	$0xffffffff, %rbx       ## imm = 0xFFFFFFFF
 <L5>:
-               	callq	 <L6>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	cmpq	$0x2, %rbx
-               	je	 <L7>
-               	movl	$0xf0f0f0f, %ecx        ## imm = 0xF0F0F0F
-               	jmp	 <L8>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movl	$0x55555555, %ecx       ## imm = 0x55555555
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x2, %r8
+               	je	 <L8>
+               	movl	$0xf0f0f0f, %ebx        ## imm = 0xF0F0F0F
+               	jmp	 <L9>
 <L8>:
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movl	$0x55555555, %ebx       ## imm = 0x55555555
 <L9>:
-               	movq	%rax, %rdi
-               	cmpq	$0x3, %rbx
-               	je	 <L10>
-               	movabsq	$-0xffff00010000, %rsi  ## imm = 0xFFFF0000FFFF0000
+               	movl	%ebx, %r12d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movabsq	$0x5555555555555555, %rsi ## imm = 0x5555555555555555
-<L11>:
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	leaq	-0x18(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	leaq	(%r12), %rcx
-               	movabsq	$0x100000000, %r11      ## imm = 0x100000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movabsq	$0xffff0000, %r11       ## imm = 0xFFFF0000
-               	movq	%r11, (%rcx)
-               	movq	%rbx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %r13
-               	leaq	(%r12,%r13,8), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
                	movq	%r13, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L14>
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	je	 <L12>
+               	movabsq	$-0xffff00010000, %rbx  ## imm = 0xFFFF0000FFFF0000
+               	jmp	 <L13>
+<L12>:
+               	movabsq	$0x5555555555555555, %rbx ## imm = 0x5555555555555555
+<L13>:
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	addq	$0x2, %r13
-               	movq	%r13, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L15>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	movl	$0x7ff, %esi            ## imm = 0x7FF
-               	addl	%ecx, %esi
-               	callq	 <L16>
+               	leaq	-0x18(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	leaq	(%rbx), %r12
+               	movabsq	$0x100000000, %r11      ## imm = 0x100000000
+               	movq	%r11, (%r12)
+               	leaq	0x8(%rbx), %r12
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%r12)
+               	leaq	0x10(%rbx), %r12
+               	movabsq	$0xffff0000, %r11       ## imm = 0xFFFF0000
+               	movq	%r11, (%r12)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3, %r12
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	leaq	(%rbx,%r12,8), %r13
+               	movq	(%r13), %r14
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movl	$0x80000000, %esi       ## imm = 0x80000000
-               	callq	 <L17>
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r14, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r13
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movabsq	$-0x8000000000000000, %rsi ## imm = 0x8000000000000000
-               	callq	 <L18>
+               	movq	%r12, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rbx,%rdi,8), %r13
+               	movq	(%r13), %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movl	$0x55555555, %esi       ## imm = 0x55555555
-               	callq	 <L19>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	addq	$0x2, %r12
+               	movq	%r12, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rbx,%rdi,8), %r12
+               	movq	(%r12), %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %edi
+               	movl	$0x7ff, %ebx            ## imm = 0x7FF
+               	addl	%edi, %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$0x80000000, %rbx       ## imm = 0x80000000
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$-0x8000000000000000, %rbx ## imm = 0x8000000000000000
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x55555555, %rbx       ## imm = 0x55555555
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+<L29>:
+               	movq	%rsi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/addr_modes.dis
+++ b/test/golden/x86_64-darwin/mem/addr_modes.dis
@@ -5,19 +5,14 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.addr_modes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x34f0, %rsp           ## imm = 0x34F0
-               	movq	%rbx, -0x34c8(%rbp)
-               	movq	%r12, -0x34d0(%rbp)
-               	movq	%r13, -0x34d8(%rbp)
-               	movq	%r14, -0x34e0(%rbp)
-               	movq	%r15, -0x34e8(%rbp)
+               	subq	$0x3540, %rsp           ## imm = 0x3540
+               	movq	%rbx, -0x3518(%rbp)
+               	movq	%r12, -0x3520(%rbp)
+               	movq	%r13, -0x3528(%rbp)
+               	movq	%r14, -0x3530(%rbp)
+               	movq	%r15, -0x3538(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x33e8(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	leaq	-0x40(%rbp), %r12
+               	leaq	-0x140(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -26,101 +21,102 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	-0xc0(%rbp), %r8
-               	movq	%r8, -0x3408(%rbp)
-               	movq	-0x3408(%rbp), %r8
+               	leaq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x33e0(%rbp)
+               	movq	-0x33e0(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
                	movq	$0x80, %rdi
+<L0>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L0>
+               	leaq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x3418(%rbp)
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x100, %rdi            ## imm = 0x100
 <L1>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L1>
-               	leaq	-0x1c0(%rbp), %r14
-               	leaq	(%r14), %rsi
+               	leaq	-0x4c0(%rbp), %r8
+               	movq	%r8, -0x3410(%rbp)
+               	movq	-0x3410(%rbp), %r8
+               	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x100, %rdi            ## imm = 0x100
+               	movq	$0x200, %rdi            ## imm = 0x200
 <L2>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L2>
-               	leaq	-0x3c0(%rbp), %r8
-               	movq	%r8, -0x3478(%rbp)
-               	movq	-0x3478(%rbp), %r8
+               	leaq	-0x8c0(%rbp), %r8
+               	movq	%r8, -0x33d8(%rbp)
+               	movq	-0x33d8(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x200, %rdi            ## imm = 0x200
+               	movq	$0x400, %rdi            ## imm = 0x400
 <L3>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L3>
-               	leaq	-0x7c0(%rbp), %r8
-               	movq	%r8, -0x33d8(%rbp)
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8), %rsi
+               	leaq	-0xbc0(%rbp), %r13
+               	leaq	(%r13), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x400, %rdi            ## imm = 0x400
+               	movq	$0x300, %rdi            ## imm = 0x300
 <L4>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L4>
-               	leaq	-0xac0(%rbp), %r8
-               	movq	%r8, -0x33e0(%rbp)
-               	movq	-0x33e0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x300, %rdi            ## imm = 0x300
-<L5>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L5>
                	movq	$0x0, %r8
-               	movq	%r8, -0x33f8(%rbp)
-               	movq	-0x33f8(%rbp), %r8
+               	movq	%r8, -0x33e8(%rbp)
+               	movq	-0x33e8(%rbp), %r8
                	cmpq	$0x40, %r8
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	-0x33f8(%rbp), %r8
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rdi
                	imulq	$0x3, %rdi, %rdi
                	addq	$0x1, %rdi
                	addq	%rbx, %rdi
-               	movb	%dil, %cl
-               	movq	-0x33f8(%rbp), %r8
+               	movb	%dil, %sil
+               	movq	-0x33e8(%rbp), %r8
                	leaq	(%r12,%r8), %rdi
-               	movb	%cl, (%rdi)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x44f, %rcx, %rcx      ## imm = 0x44F
-               	addq	$0x7, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %di
-               	movq	-0x3408(%rbp), %r8
-               	movq	-0x33f8(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rcx
-               	movw	%di, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
+               	movb	%sil, (%rdi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x44f, %rsi, %rsi      ## imm = 0x44F
+               	addq	$0x7, %rsi
+               	addq	%rbx, %rsi
+               	movw	%si, %di
+               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movw	%di, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
                	movabsq	$0x9e3779b1, %r11       ## imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	addq	$0xb, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %edi
-               	movq	-0x33f8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	%edi, (%rcx)
-               	movq	-0x33f8(%rbp), %r9
+               	imulq	%r11, %rsi
+               	addq	$0xb, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3418(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x33e8(%rbp), %r9
                	movq	%r9, %r8
                	addq	$0x1, %r8
                	movq	%r8, -0x33f0(%rbp)
@@ -128,547 +124,927 @@ Disassembly of section __TEXT,__text:
                	movabsq	$-0x61c8864680b583eb, %rdi ## imm = 0x9E3779B97F4A7C15
                	imulq	%r8, %rdi
                	addq	%rbx, %rdi
-               	movq	-0x3478(%rbp), %r8
-               	movq	-0x33f8(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	%rdi, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x5, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %di
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movw	%di, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x80, %rcx
-               	movb	%cl, %dil
-               	leaq	0x2(%rsi), %rcx
-               	movb	%dil, (%rcx)
-               	movq	-0x33f0(%rbp), %r8
-               	movabsq	$0x100000001b3, %rcx    ## imm = 0x100000001B3
-               	imulq	%r8, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x8(%rsi), %rdi
-               	movq	%rcx, (%rdi)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x11, %rcx, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x1, %rsi
-               	addq	%rbx, %rsi
-               	movl	%esi, %edi
-               	movq	-0x33f8(%rbp), %r8
+               	movq	-0x3410(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0xc, %rsi, %rsi
-               	movq	-0x33e0(%rbp), %r9
-               	leaq	(%r9,%rsi), %r8
-               	movq	%r8, -0x3400(%rbp)
-               	movq	-0x3400(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	%edi, (%rsi)
-               	movq	%rcx, %rsi
+               	imulq	$0x5, %rsi, %rsi
                	addq	$0x2, %rsi
                	addq	%rbx, %rsi
-               	movl	%esi, %edi
-               	movq	-0x3400(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	%edi, (%rsi)
-               	addq	$0x3, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %esi
-               	movq	-0x3400(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	%esi, (%rcx)
-               	movq	-0x33f0(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x33f8(%rbp)
-               	movq	-0x33f8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L6>
-<L7>:
-               	movq	-0x33e8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x34b0(%rbp)
-               	movq	$0x0, %r13
-               	cmpq	$0x40, %r13
-               	jb	 <L8>
-               	jmp	 <L19>
-<L8>:
-               	movq	%r13, %rsi
-               	imulq	$0xd, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %r8
-               	andq	$0x3f, %r8
-               	movq	%r8, -0x3410(%rbp)
-               	movq	-0x3410(%rbp), %r8
-               	leaq	(%r12,%r8), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x3418(%rbp)
-               	movq	-0x34b0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x3418(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x3408(%rbp), %r8
-               	movq	-0x3410(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x3420(%rbp)
-               	movq	-0x3420(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x3428(%rbp)
-               	movq	-0x3428(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0x3478(%rbp), %r8
-               	movq	-0x3410(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x3430(%rbp)
-               	movq	-0x3430(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
+               	movw	%si, %di
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rsi
                	imulq	$0x10, %rsi, %rsi
                	movq	-0x33d8(%rbp), %r9
                	leaq	(%r9,%rsi), %r8
+               	movq	%r8, -0x33f8(%rbp)
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movw	%di, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x80, %rsi
+               	movb	%sil, %dil
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	0x2(%r8), %rsi
+               	movb	%dil, (%rsi)
+               	movq	-0x33f0(%rbp), %r8
+               	movabsq	$0x100000001b3, %rsi    ## imm = 0x100000001B3
+               	imulq	%r8, %rsi
+               	addq	%rbx, %rsi
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x33e8(%rbp), %r9
+               	movq	%r9, %r8
+               	imulq	$0x11, %r8, %r8
+               	movq	%r8, -0x3400(%rbp)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %esi
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x3408(%rbp)
+               	movq	-0x3408(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%esi, (%rdi)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x2, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3408(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x3, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3408(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x33f0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x33e8(%rbp)
+               	movq	-0x33e8(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L5>
+<L6>:
+               	movabsq	$-0x340d631b7bdddcdb, %r15 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x40, %r14
+               	jb	 <L7>
+               	jmp	 <L22>
+<L7>:
+               	movq	%r14, %rsi
+               	imulq	$0xd, %rsi, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %r8
+               	andq	$0x3f, %r8
+               	movq	%r8, -0x3420(%rbp)
+               	movq	-0x3420(%rbp), %r8
+               	leaq	(%r12,%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x3428(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x3430(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x3438(%rbp)
                	movq	-0x3438(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	-0x3438(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3428(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3430(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3438(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3430(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3438(%rbp)
+               	movq	-0x3438(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+<L9>:
+               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movzwl	(%rsi), %edi
+               	movzwq	%di, %r8
                	movq	%r8, -0x3440(%rbp)
-               	movq	-0x3440(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x3438(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
-               	movzbl	(%rsi), %r8d
+               	movq	-0x3430(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x3448(%rbp)
-               	movq	-0x3448(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x3438(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
+               	movq	$0x0, %r8
                	movq	%r8, -0x3450(%rbp)
                	movq	-0x3450(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	-0x3450(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3440(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3448(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0xc, %rsi, %rsi
-               	movq	-0x33e0(%rbp), %r9
-               	leaq	(%r9,%rsi), %r8
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3450(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3448(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3450(%rbp)
+               	movq	-0x3450(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+<L11>:
+               	movq	-0x3418(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
                	movq	%r8, -0x3458(%rbp)
-               	movq	-0x3458(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	-0x3448(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x3460(%rbp)
-               	movq	-0x3460(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	-0x3458(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	$0x0, %r8
                	movq	%r8, -0x3468(%rbp)
                	movq	-0x3468(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	-0x3468(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x3458(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3460(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3468(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3460(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3468(%rbp)
+               	movq	-0x3468(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
+<L13>:
+               	movq	-0x3410(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	(%rsi), %r8
                	movq	%r8, -0x3470(%rbp)
-               	movq	-0x3470(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r13
-               	movq	%rcx, %r8
-               	movq	%r8, -0x34b0(%rbp)
-               	cmpq	$0x40, %r13
-               	jb	 <L8>
-<L19>:
-               	movq	-0x34b0(%rbp), %r8
-               	movq	%r8, %r13
+               	movq	-0x3460(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3478(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x34b8(%rbp)
-               	movq	-0x34b8(%rbp), %r8
-               	cmpq	$0x20, %r8
-               	jb	 <L20>
-               	jmp	 <L26>
-<L20>:
-               	movq	-0x34b8(%rbp), %r8
-               	movq	%r8, %r15
-               	imulq	$0x2, %r15, %r15
-               	leaq	(%r14,%r15,4), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x3480(%rbp)
-               	movq	%r13, %rdi
                	movq	-0x3480(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L21>
-<L21>:
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	-0x3480(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x3470(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x3478(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x3480(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3478(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3480(%rbp)
+               	movq	-0x3480(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+<L15>:
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movzwl	(%rsi), %edi
+               	movzwq	%di, %rsi
+               	movq	-0x3478(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r8
                	movq	%r8, -0x3488(%rbp)
                	movq	-0x3488(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	%rsi
-               	leaq	(%r14,%rsi,4), %rdi
-               	movl	(%rdi), %esi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x2(%rdi), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
                	movq	-0x3488(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L22>
-<L22>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %r8
-               	movq	%r8, -0x3498(%rbp)
-               	movq	-0x3498(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	$0x1, %r8
                	movq	%r8, -0x3490(%rbp)
                	movq	-0x3490(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x2, %rsi, %rsi
-               	subq	$0x2, %rsi
-               	movq	-0x3478(%rbp), %r8
-               	leaq	(%r8,%rsi,8), %rdi
-               	movq	(%rdi), %rsi
-               	movq	-0x3498(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x3498(%rbp)
+               	movq	-0x3490(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L23>
-<L23>:
+               	movq	-0x3498(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %r8
                	movq	%r8, -0x34a0(%rbp)
                	movq	-0x34a0(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
-               	movq	$0x3f, %rsi
-               	subq	%r8, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	movzbl	(%rdi), %esi
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
                	movq	-0x34a0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	addq	%rbx, %r15
-               	andq	$0x3f, %r15
-               	imulq	$0x10, %r15, %r15
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8,%r15), %rsi
-               	leaq	0x8(%rsi), %r15
-               	movq	(%r15), %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r13
-               	movq	-0x3490(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x34b8(%rbp)
-               	movq	-0x34b8(%rbp), %r8
-               	cmpq	$0x20, %r8
-               	jb	 <L20>
-<L26>:
-               	leaq	-0xbc0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x100, %rsi            ## imm = 0x100
-<L27>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L27>
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L28>
-               	jmp	 <L31>
-<L28>:
-               	movq	%rcx, %r8
-               	imulq	$0x47, %r8, %r8
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %r8
                	movq	%r8, -0x34a8(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0x20, %rdi, %rdi
-               	leaq	(%r12,%rdi), %r14
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L29>
-               	jmp	 <L30>
-<L29>:
-               	movq	%rdi, %r15
-               	imulq	$0xd, %r15, %r15
                	movq	-0x34a8(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	addq	%r15, %rsi
-               	addq	%rbx, %rsi
-               	movl	%esi, %r15d
-               	leaq	(%r14,%rdi,4), %rsi
-               	movl	%r15d, (%rsi)
-               	addq	$0x1, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L29>
-<L30>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L28>
-<L31>:
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	0x4(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	-0x34a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x34b0(%rbp)
+               	movq	-0x34b0(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	-0x34b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r15
+               	cmpq	$0x40, %r14
+               	jb	 <L7>
+<L22>:
+               	movq	$0x0, %r13
+               	cmpq	$0x20, %r13
+               	jb	 <L23>
+               	jmp	 <L32>
+<L23>:
+               	movq	%r13, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x34b8(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x34c0(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L32>
-               	jmp	 <L36>
-<L32>:
-               	movq	%r14, %rcx
-               	imulq	$0x20, %rcx, %rcx
-               	leaq	(%r12,%rcx), %r15
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r13, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0x60(%r12), %rcx
-               	leaq	(%rcx,%r14,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rcx
-               	addq	%rbx, %rcx
-               	andq	$0x7, %rcx
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x34b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x34c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x34c0(%rbp)
                	cmpq	$0x8, %r14
-               	jb	 <L32>
-<L36>:
-               	leaq	0xe0(%r12), %rcx
-               	leaq	0x1c(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%r13, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L37>
-<L37>:
+               	jb	 <L24>
+<L25>:
+               	movq	%r13, %rsi
+               	shlq	%rsi
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x34c8(%rbp)
+               	movq	-0x34c0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34d0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x34c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x34d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x34d0(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rsi
+               	addq	$0x1, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	subq	$0x2, %rsi
+               	movq	-0x3410(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x34d8(%rbp)
+               	movq	-0x34d0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34e0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x34d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x34e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r8
+               	movq	%r8, -0x34e0(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L28>
+<L29>:
+               	movq	$0x3f, %rsi
+               	subq	%r13, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movzbl	(%rdi), %esi
+               	movzbq	%sil, %r14
+               	movq	-0x34e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	-0x33d0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x2810, %rsi           ## imm = 0x2810
-<L39>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L39>
-               	movq	$0x12345678, %rcx       ## imm = 0x12345678
-               	addq	%rbx, %rcx
+               	movq	%r13, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	addq	%rbx, %rsi
+               	andq	$0x3f, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %r14
+               	leaq	0x8(%r14), %rsi
+               	movq	(%rsi), %r14
+               	movq	%r14, %rsi
+               	callq	 <L31>
+<L31>:
+               	movq	%rax, %r15
+               	addq	$0x1, %r13
+               	cmpq	$0x20, %r13
+               	jb	 <L23>
+<L32>:
+               	leaq	-0x100(%rbp), %r12
                	leaq	(%r12), %rsi
-               	movq	%rcx, (%rsi)
-               	movl	%ebx, %ecx
-               	movl	$0x9abcdef0, %esi       ## imm = 0x9ABCDEF0
-               	addl	%ecx, %esi
-               	leaq	0x2008(%r12), %rcx
-               	movl	%esi, (%rcx)
-               	movw	%bx, %cx
-               	movl	$0x1234, %esi           ## imm = 0x1234
-               	addl	%ecx, %esi
-               	leaq	0x280c(%r12), %rcx
-               	movw	%si, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	$0x400, %rcx            ## imm = 0x400
-               	jb	 <L40>
-               	jmp	 <L41>
+               	addq	$0x0, %rsi
+               	movq	$0x100, %rdi            ## imm = 0x100
+<L33>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L33>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+               	jmp	 <L37>
+<L34>:
+               	movq	%rsi, %r8
+               	imulq	$0x47, %r8, %r8
+               	movq	%r8, -0x34e8(%rbp)
+               	movq	%rsi, %r13
+               	imulq	$0x20, %r13, %r13
+               	leaq	(%r12,%r13), %r8
+               	movq	%r8, -0x34f0(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%r13, %rdi
+               	imulq	$0xd, %rdi, %rdi
+               	movq	-0x34e8(%rbp), %r8
+               	movq	%r8, %r14
+               	addq	%rdi, %r14
+               	addq	%rbx, %r14
+               	movl	%r14d, %edi
+               	movq	-0x34f0(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	%edi, (%r14)
+               	addq	$0x1, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L35>
+<L36>:
+               	addq	$0x1, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+<L37>:
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L38>
+               	jmp	 <L44>
+<L38>:
+               	movq	%r13, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	leaq	0xc(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x34f8(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x3500(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x34f8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x3500(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3500(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L39>
 <L40>:
-               	movq	%rcx, %rsi
-               	imulq	$0x1f, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	leaq	0x8(%r12), %r13
-               	leaq	(%r13,%rcx,8), %r14
-               	movq	%rsi, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	$0x400, %rcx            ## imm = 0x400
-               	jb	 <L40>
+               	leaq	0x60(%r12), %rsi
+               	leaq	(%rsi,%r13,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x3508(%rbp)
+               	movq	-0x3500(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3510(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	movq	$0x0, %rcx
-               	cmpq	$0x200, %rcx            ## imm = 0x200
-               	jb	 <L42>
-               	jmp	 <L43>
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3508(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3510(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3510(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
 <L42>:
-               	movq	%rcx, %rsi
-               	imulq	$0x25, %rsi, %rsi
+               	movq	%r13, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movq	%r13, %rsi
                	addq	%rbx, %rsi
-               	movl	%esi, %r13d
-               	leaq	0x200c(%r12), %rsi
-               	leaq	(%rsi,%rcx,4), %r14
-               	movl	%r13d, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	$0x200, %rcx            ## imm = 0x200
-               	jb	 <L42>
+               	andq	$0x7, %rsi
+               	leaq	(%rdi,%rsi,4), %r14
+               	movl	(%r14), %esi
+               	movl	%esi, %r14d
+               	movq	-0x3510(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L43>
 <L43>:
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L44>
+               	movq	%rax, %rsi
+               	addq	$0x1, %r13
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %r13
+               	jb	 <L38>
 <L44>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L45>
+               	leaq	0xe0(%r12), %rsi
+               	leaq	0x1c(%rsi), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L45>
+               	jmp	 <L46>
 <L45>:
-               	movq	%rax, %rdi
-               	leaq	0x1ff8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L46>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L45>
 <L46>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rcx
-               	addq	$0x2bc, %rcx            ## imm = 0x2BC
-               	movq	%rcx, %rax
-               	movq	$0x400, %rcx            ## imm = 0x400
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L47>
+               	leaq	(%r12), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L47>
+               	jmp	 <L48>
 <L47>:
-               	movq	%rax, %rdi
-               	leaq	0x2008(%r12), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L48>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L47>
 <L48>:
-               	movq	%rax, %rdi
-               	leaq	0x200c(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L49>
+               	leaq	-0x33d0(%rbp), %r12
+               	leaq	(%r12), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x2810, %rdi           ## imm = 0x2810
 <L49>:
-               	movq	%rax, %rdi
-               	leaq	0x7fc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L50>
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L49>
+               	movq	$0x12345678, %rsi       ## imm = 0x12345678
+               	addq	%rbx, %rsi
+               	leaq	(%r12), %rdi
+               	movq	%rsi, (%rdi)
+               	movl	%ebx, %esi
+               	movl	$0x9abcdef0, %edi       ## imm = 0x9ABCDEF0
+               	addl	%esi, %edi
+               	leaq	0x2008(%r12), %rsi
+               	movl	%edi, (%rsi)
+               	movw	%bx, %si
+               	movl	$0x1234, %edi           ## imm = 0x1234
+               	addl	%esi, %edi
+               	leaq	0x280c(%r12), %rsi
+               	movw	%di, (%rsi)
+               	movq	$0x0, %rsi
+               	cmpq	$0x400, %rsi            ## imm = 0x400
+               	jb	 <L50>
+               	jmp	 <L51>
 <L50>:
-               	movq	%rax, %rdi
-               	addq	$0x12c, %rbx            ## imm = 0x12C
-               	movq	%rbx, %rax
-               	movq	$0x200, %rcx            ## imm = 0x200
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L51>
+               	movq	%rsi, %rdi
+               	imulq	$0x1f, %rdi, %rdi
+               	addq	%rbx, %rdi
+               	leaq	0x8(%r12), %r13
+               	leaq	(%r13,%rsi,8), %r14
+               	movq	%rdi, (%r14)
+               	addq	$0x1, %rsi
+               	cmpq	$0x400, %rsi            ## imm = 0x400
+               	jb	 <L50>
 <L51>:
-               	movq	%rax, %rdi
-               	leaq	0x280c(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L52>
+               	movq	$0x0, %rsi
+               	cmpq	$0x200, %rsi            ## imm = 0x200
+               	jb	 <L52>
+               	jmp	 <L53>
 <L52>:
-               	movq	%rax, %rdi
-               	movq	$0x2008, %rsi           ## imm = 0x2008
-               	callq	 <L53>
+               	movq	%rsi, %rdi
+               	imulq	$0x25, %rdi, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r13d
+               	leaq	0x200c(%r12), %rdi
+               	leaq	(%rdi,%rsi,4), %r14
+               	movl	%r13d, (%r14)
+               	addq	$0x1, %rsi
+               	cmpq	$0x200, %rsi            ## imm = 0x200
+               	jb	 <L52>
 <L53>:
-               	movq	%rax, %rdi
-               	movq	$0x200c, %rsi           ## imm = 0x200C
-               	callq	 <L54>
+               	leaq	(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
 <L54>:
-               	movq	%rax, %rdi
-               	movq	$0x280c, %rsi           ## imm = 0x280C
-               	callq	 <L55>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
 <L55>:
-               	movq	%rax, %rdi
-               	movq	$0x2810, %rsi           ## imm = 0x2810
-               	callq	 <L56>
+               	leaq	0x8(%r12), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L56>
+               	jmp	 <L57>
 <L56>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x400, %rcx            ## imm = 0x400
-               	jb	 <L57>
-               	jmp	 <L58>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L56>
 <L57>:
-               	leaq	0x8(%r12), %rbx
-               	leaq	(%rbx,%rcx,8), %r13
-               	movq	(%r13), %rbx
-               	addq	$0x1, %rcx
-               	imulq	%rcx, %rbx
-               	xorq	%rbx, %rsi
-               	cmpq	$0x400, %rcx            ## imm = 0x400
-               	jb	 <L57>
+               	leaq	0x8(%r12), %rsi
+               	leaq	0x1ff8(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L58>
+               	jmp	 <L59>
 <L58>:
-               	callq	 <L59>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L58>
 <L59>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rcx            ## imm = 0x200
-               	jb	 <L60>
-               	jmp	 <L61>
+               	leaq	0x8(%r12), %rsi
+               	movq	%rbx, %rdi
+               	addq	$0x2bc, %rdi            ## imm = 0x2BC
+               	movq	%rdi, %rax
+               	movq	$0x400, %rdi            ## imm = 0x400
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rsi,%rdi,8), %r13
+               	movq	(%r13), %rsi
+               	movq	%r15, %rdi
+               	callq	 <L60>
 <L60>:
-               	leaq	0x200c(%r12), %rbx
-               	leaq	(%rbx,%rcx,4), %r13
-               	movl	(%r13), %ebx
-               	movl	%ebx, %r13d
-               	movq	%rcx, %rbx
-               	addq	$0x3, %rbx
-               	imulq	%rbx, %r13
-               	addq	%r13, %rsi
-               	addq	$0x1, %rcx
-               	cmpq	$0x200, %rcx            ## imm = 0x200
-               	jb	 <L60>
+               	movq	%rax, %rdi
+               	leaq	0x2008(%r12), %rsi
+               	movl	(%rsi), %r13d
+               	movl	%r13d, %esi
+               	callq	 <L61>
 <L61>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	leaq	(%rsi), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %r13d
+               	movq	%r13, %rsi
                	callq	 <L62>
 <L62>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x34c8(%rbp), %rbx
-               	movq	-0x34d0(%rbp), %r12
-               	movq	-0x34d8(%rbp), %r13
-               	movq	-0x34e0(%rbp), %r14
-               	movq	-0x34e8(%rbp), %r15
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	leaq	0x7fc(%rsi), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %r13d
+               	movq	%r13, %rsi
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	addq	$0x12c, %rbx            ## imm = 0x12C
+               	movq	%rbx, %rax
+               	movq	$0x200, %rbx            ## imm = 0x200
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rsi,%rbx,4), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rdi
+               	leaq	0x280c(%r12), %rsi
+               	movzwl	(%rsi), %ebx
+               	movzwq	%bx, %rsi
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rdi
+               	movq	$0x2008, %rsi           ## imm = 0x2008
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movq	$0x200c, %rsi           ## imm = 0x200C
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rdi
+               	movq	$0x280c, %rsi           ## imm = 0x280C
+               	callq	 <L68>
+<L68>:
+               	movq	%rax, %rdi
+               	movq	$0x2810, %rsi           ## imm = 0x2810
+               	callq	 <L69>
+<L69>:
+               	movq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x400, %rdi            ## imm = 0x400
+               	jb	 <L70>
+               	jmp	 <L71>
+<L70>:
+               	leaq	0x8(%r12), %r13
+               	leaq	(%r13,%rdi,8), %r14
+               	movq	(%r14), %r13
+               	addq	$0x1, %rdi
+               	imulq	%rdi, %r13
+               	xorq	%r13, %rbx
+               	cmpq	$0x400, %rdi            ## imm = 0x400
+               	jb	 <L70>
+<L71>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L72>
+<L73>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rdi            ## imm = 0x200
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	leaq	0x200c(%r12), %r13
+               	leaq	(%r13,%rdi,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r14d
+               	movq	%rdi, %r13
+               	addq	$0x3, %r13
+               	imulq	%r13, %r14
+               	addq	%r14, %rbx
+               	addq	$0x1, %rdi
+               	cmpq	$0x200, %rdi            ## imm = 0x200
+               	jb	 <L74>
+<L75>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+<L77>:
+               	movq	%rsi, %rax
+               	movq	-0x3518(%rbp), %rbx
+               	movq	-0x3520(%rbp), %r12
+               	movq	-0x3528(%rbp), %r13
+               	movq	-0x3530(%rbp), %r14
+               	movq	-0x3538(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/array_index.dis
+++ b/test/golden/x86_64-darwin/mem/array_index.dis
@@ -5,29 +5,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.array_index.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,676 +90,1002 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.array_index.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x200, %rsp            ## imm = 0x200
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%r12, -0x1e0(%rbp)
-               	movq	%r13, -0x1e8(%rbp)
-               	movq	%r14, -0x1f0(%rbp)
-               	movq	%r15, -0x1f8(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	callq	 <L0>
+               	subq	$0x2f0, %rsp            ## imm = 0x2F0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
+               	movq	%r15, -0x2e8(%rbp)
+               	movq	%rdi, %rbx
+               	leaq	-0x1c(%rbp), %r12
+               	leaq	-0x108(%rbp), %r13
+               	leaq	(%r13), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x80, %rdi
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x9c(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x80, %rsi
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L0>
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x20, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rsi
-               	addq	$0x1, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x1, %rdi
                	movabsq	$0x9e3779b1, %r14       ## imm = 0x9E3779B1
-               	imulq	%rsi, %r14
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %r14
+               	imulq	%rdi, %r14
+               	addq	%rbx, %r14
                	movl	%r14d, %r15d
-               	leaq	(%r13,%rcx,4), %r14
+               	leaq	(%r13,%rsi,4), %r14
                	movl	%r15d, (%r14)
-               	movq	%rsi, %rcx
-               	cmpq	$0x20, %rcx
-               	jb	 <L2>
+               	movq	%rdi, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L1>
+<L2>:
+               	leaq	(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x160(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L4>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x4(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x3c(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x3c(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	0x7c(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x7c(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x20, %r15
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x20, %r8
                	jb	 <L8>
-               	jmp	 <L10>
+               	jmp	 <L11>
 <L8>:
-               	movq	%r15, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rcx
-               	andq	$0x1f, %rcx
-               	leaq	(%r13,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%r14, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	%rbx, %r14
+               	andq	$0x1f, %r14
+               	leaq	(%r13,%r14,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %r14
-               	addq	$0x1, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L8>
+               	movq	%rsi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r14, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
 <L10>:
-               	movq	$0x20, %r15
-               	movq	$0x0, %r11
-               	cmpq	%r15, %r11
-               	jb	 <L11>
-               	jmp	 <L13>
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L8>
 <L11>:
-               	subq	$0x1, %r15
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r14, %rdi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %r14
+               	movq	-0x168(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	$0x20, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
                	movq	$0x0, %r11
-               	cmpq	%r15, %r11
-               	jb	 <L11>
-<L13>:
+               	cmpq	%r8, %r11
+               	jb	 <L12>
+               	jmp	 <L15>
+<L12>:
+               	movq	-0x198(%rbp), %r9
+               	movq	%r9, %r8
+               	subq	$0x1, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %r14
                	movq	$0x0, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L14>
-               	jmp	 <L16>
-<L14>:
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %esi
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r14, %rdi
-               	callq	 <L15>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+<L14>:
+               	movq	%r14, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x180(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	movq	$0x0, %r11
+               	cmpq	%r8, %r11
+               	jb	 <L12>
 <L15>:
-               	movq	%rax, %r14
-               	addq	$0x5, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L14>
+               	movq	-0x190(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
-               	leaq	-0xcc(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r15, %rdi
+               	xorq	%r14, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x5, %rsi
+               	movq	%r15, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+<L19>:
+               	leaq	-0x4c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	movq	$0x0, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
-               	jmp	 <L20>
-<L17>:
-               	movq	%rcx, %r8
-               	imulq	$0x64, %r8, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0xc, %rdi, %rdi
-               	leaq	(%r13,%rdi), %r8
-               	movq	%r8, -0x148(%rbp)
-               	movq	$0x0, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
-               	movq	%rdi, %rsi
-               	imulq	$0x7, %rsi, %rsi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %r15
-               	addq	%rsi, %r15
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %r15
-               	movw	%r15w, %si
-               	movq	-0x148(%rbp), %r8
-               	leaq	(%r8,%rdi,2), %r15
-               	movw	%si, (%r15)
-               	addq	$0x1, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L18>
-<L19>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L20>
+               	jmp	 <L23>
 <L20>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rsi
-               	movzwl	(%rsi), %ecx
-               	movq	%r14, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x24(%r13), %rcx
-               	leaq	0xa(%rcx), %rsi
-               	movzwl	(%rsi), %ecx
-               	movq	%rcx, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	andq	$0x3, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rsi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x4, %rcx
-               	andq	$0x3, %rcx
-               	leaq	(%rsi,%rcx,2), %r14
-               	movzwl	(%r14), %esi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%r15, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r13,%rcx), %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	%r14, %r8
+               	movq	%rsi, %r8
+               	imulq	$0x64, %r8, %r8
                	movq	%r8, -0x1b8(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L27>
-<L25>:
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8,%r12,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x160(%rbp)
+               	movq	%rsi, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r13,%r14), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x6, %r14
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%r14, %rdi
+               	imulq	$0x7, %rdi, %rdi
                	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%rdi, %r15
+               	addq	%rbx, %r15
+               	movw	%r15w, %di
+               	movq	-0x1c0(%rbp), %r8
+               	leaq	(%r8,%r14,2), %r15
+               	movw	%di, (%r15)
+               	addq	$0x1, %r14
+               	cmpq	$0x6, %r14
+               	jb	 <L21>
+<L22>:
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L20>
+<L23>:
+               	leaq	(%r13), %rsi
+               	leaq	(%rsi), %rdi
+               	movzwl	(%rdi), %esi
+               	movzwq	%si, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+<L25>:
+               	leaq	0x24(%r13), %rdi
+               	leaq	0xa(%rdi), %r14
+               	movzwl	(%r14), %edi
+               	movzwq	%di, %r14
+               	movq	%rsi, %rdi
+               	movq	%r14, %rsi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r12
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1b8(%rbp)
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L27>:
-               	addq	$0x1, %r15
-               	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L24>
-<L28>:
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L29>
-               	jmp	 <L33>
-<L29>:
-               	movq	%r14, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L30>
-               	jmp	 <L32>
-<L30>:
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	addq	$0x2, %rsi
+               	andq	$0x3, %rsi
                	imulq	$0xc, %rsi, %rsi
-               	leaq	(%r13,%rsi), %rdi
-               	leaq	(%rdi,%r12,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x168(%rbp)
-               	movq	%r15, %rdi
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r15
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	leaq	(%r13,%rsi), %r14
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	andq	$0x3, %rsi
+               	leaq	(%r14,%rsi,2), %r15
+               	movzwl	(%r15), %esi
+               	movzwq	%si, %r14
+               	movq	%r14, %rsi
+               	callq	 <L27>
+<L27>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L30>
-<L32>:
-               	addq	$0x1, %r12
-               	movq	%r15, %r14
-               	cmpq	$0x6, %r12
+               	jb	 <L28>
+               	jmp	 <L33>
+<L28>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r13,%r14), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x1d0(%rbp), %r8
+               	movq	-0x1f8(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movzwl	(%rsi), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L29>
+<L32>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x1e0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L28>
 <L33>:
-               	leaq	-0xe7(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movw	$0x0, 0x18(%r12)
-               	movb	$0x0, 0x1a(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
                	jmp	 <L39>
 <L34>:
-               	movq	%rcx, %r8
-               	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0x9, %rdi, %rdi
-               	leaq	(%r12,%rdi), %r8
-               	movq	%r8, -0x178(%rbp)
-               	movq	$0x0, %rdi
-               	cmpq	$0x3, %rdi
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
                	jmp	 <L38>
 <L35>:
-               	movq	%rdi, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x170(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%r15, %r8
-               	movq	%r8, -0x180(%rbp)
-               	movq	%rdi, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x178(%rbp), %r9
-               	leaq	(%r9,%r15), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	$0x0, %r15
-               	cmpq	$0x3, %r15
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	movq	-0x218(%rbp), %r8
+               	leaq	(%r14,%r8,2), %rsi
+               	movzwl	(%rsi), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L36>
                	jmp	 <L37>
 <L36>:
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	%r15, %rsi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rsi
-               	movb	%sil, %r13b
-               	movq	-0x188(%rbp), %r8
-               	leaq	(%r8,%r15), %rsi
-               	movb	%r13b, (%rsi)
-               	addq	$0x1, %r15
-               	cmpq	$0x3, %r15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
                	jb	 <L36>
 <L37>:
-               	addq	$0x1, %rdi
-               	cmpq	$0x3, %rdi
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
 <L38>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x208(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
 <L39>:
-               	movq	%r14, %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	$0x0, %r13
-               	cmpq	$0x3, %r13
+               	leaq	-0x67(%rbp), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movw	$0x0, 0x18(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movb	$0x0, 0x1a(%r8)
+               	movq	$0x0, %rdi
+               	cmpq	$0x3, %rdi
                	jb	 <L40>
-               	jmp	 <L46>
-<L40>:
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c8(%rbp), %r8
-               	cmpq	$0x3, %r8
-               	jb	 <L41>
                	jmp	 <L45>
-<L41>:
-               	movq	%r15, %rbx
+<L40>:
+               	movq	%rdi, %r8
+               	imulq	$0x9, %r8, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	%rdi, %r14
+               	imulq	$0x9, %r14, %r14
+               	movq	-0x230(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x238(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x3, %r14
-               	jb	 <L42>
+               	jb	 <L41>
                	jmp	 <L44>
+<L41>:
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x238(%rbp), %r9
+               	leaq	(%r9,%r13), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	%r14, %rsi
-               	imulq	$0x9, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	movq	-0x1c8(%rbp), %r8
+               	movq	-0x240(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x3, %rsi, %rsi
-               	leaq	(%rdi,%rsi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	-0x1a0(%rbp), %r8
+               	addq	%r13, %rsi
+               	addq	%rbx, %rsi
+               	movb	%sil, %r15b
+               	movq	-0x248(%rbp), %r8
                	leaq	(%r8,%r13), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%rbx, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L43>
+               	movb	%r15b, (%rsi)
+               	addq	$0x1, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L42>
 <L43>:
-               	movq	%rax, %rbx
                	addq	$0x1, %r14
                	cmpq	$0x3, %r14
-               	jb	 <L42>
-<L44>:
-               	movq	-0x1c8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rbx, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c8(%rbp), %r8
-               	cmpq	$0x3, %r8
                	jb	 <L41>
-<L45>:
-               	addq	$0x1, %r13
-               	movq	%r15, %r8
-               	movq	%r8, -0x198(%rbp)
-               	cmpq	$0x3, %r13
-               	jb	 <L40>
-<L46>:
-               	leaq	0x12(%r12), %rcx
-               	leaq	(%rcx), %rsi
-               	leaq	0x1(%rsi), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %rbx
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	movzbl	(%rsi), %ecx
-               	movq	%rcx, %rsi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	leaq	-0x138(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x50, %rdi
-<L49>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L49>
-               	movq	$0x0, %rsi
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	movq	%rsi, %rdi
-               	imulq	$0x3, %rdi, %rdi
+<L44>:
                	addq	$0x1, %rdi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rdi
-               	movw	%di, %r12w
-               	movq	%rsi, %rdi
-               	imulq	$0x10, %rdi, %rdi
-               	leaq	(%rbx,%rdi), %r13
-               	leaq	(%r13), %rdi
-               	movw	%r12w, (%rdi)
-               	movq	%rsi, %rdi
-               	addq	$0xc8, %rdi
-               	movb	%dil, %r12b
-               	leaq	0x2(%r13), %rdi
-               	movb	%r12b, (%rdi)
-               	addq	$0x1, %rsi
-               	movabsq	$0x100000001b3, %rdi    ## imm = 0x100000001B3
-               	imulq	%rsi, %rdi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rdi
-               	leaq	0x8(%r13), %r12
-               	movq	%rdi, (%r12)
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-<L51>:
-               	movq	%rcx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x5, %r13
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
+               	cmpq	$0x3, %rdi
+               	jb	 <L40>
+<L45>:
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+               	jmp	 <L53>
+<L46>:
+               	movq	-0x250(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+               	jmp	 <L52>
+<L47>:
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x3, %rsi
+               	jb	 <L48>
+               	jmp	 <L51>
+<L48>:
+               	movq	%rsi, %r13
+               	imulq	$0x9, %r13, %r13
+               	movq	-0x230(%rbp), %r8
+               	leaq	(%r8,%r13), %r15
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, %r13
+               	imulq	$0x3, %r13, %r13
+               	leaq	(%r15,%r13), %rdi
+               	movq	-0x268(%rbp), %r8
+               	leaq	(%rdi,%r8), %r13
+               	movzbl	(%r13), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
                	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %r14d
-               	leaq	0x2(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x1b0(%rbp), %r8
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+<L50>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x260(%rbp)
+               	cmpq	$0x3, %rsi
+               	jb	 <L48>
+<L51>:
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
+               	addq	$0x1, %rsi
+               	movq	-0x260(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+<L52>:
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+<L53>:
+               	movq	-0x230(%rbp), %r8
+               	leaq	0x12(%r8), %rsi
+               	leaq	(%rsi), %rdi
+               	leaq	0x1(%rdi), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
                	addq	$0x1, %r13
-               	movq	%rcx, %r12
-               	cmpq	$0x5, %r13
-               	jb	 <L52>
-<L56>:
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x5, %rcx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+<L55>:
+               	movq	%rbx, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x3, %rsi
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %r13d
-               	leaq	0x2(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	movq	%r12, %rdi
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	movq	-0x230(%rbp), %r8
+               	leaq	(%r8,%rsi), %r13
+               	movq	%rbx, %rsi
+               	addq	$0x2, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x3, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x3, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	movq	%rbx, %rax
+               	movq	$0x3, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	(%r14,%rsi), %r13
+               	movzbl	(%r13), %esi
+               	movzbq	%sil, %r13
                	movq	%r13, %rsi
-               	callq	 <L57>
+               	callq	 <L56>
+<L56>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	leaq	-0x158(%rbp), %r13
+               	leaq	(%r13), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x50, %r14
 <L57>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L58>
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L57>
+               	movq	$0x0, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L58>
+               	jmp	 <L59>
 <L58>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L59>
+               	movq	%rdi, %r14
+               	imulq	$0x3, %r14, %r14
+               	addq	$0x1, %r14
+               	addq	%rbx, %r14
+               	movw	%r14w, %r15w
+               	movq	%rdi, %r14
+               	imulq	$0x10, %r14, %r14
+               	leaq	(%r13,%r14), %rsi
+               	leaq	(%rsi), %r14
+               	movw	%r15w, (%r14)
+               	movq	%rdi, %r14
+               	addq	$0xc8, %r14
+               	movb	%r14b, %r15b
+               	leaq	0x2(%rsi), %r14
+               	movb	%r15b, (%r14)
+               	addq	$0x1, %rdi
+               	movabsq	$0x100000001b3, %r14    ## imm = 0x100000001B3
+               	imulq	%rdi, %r14
+               	addq	%rbx, %r14
+               	leaq	0x8(%rsi), %r15
+               	movq	%r14, (%r15)
+               	cmpq	$0x5, %rdi
+               	jb	 <L58>
 <L59>:
-               	movq	%rax, %rdi
-               	leaq	0x40(%rbx), %rcx
-               	leaq	0x8(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L60>
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L60>
+               	jmp	 <L62>
 <L60>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x5, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %esi
+               	movq	%r15, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	-0x78(%rbp), %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	0x8(%rdi), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x288(%rbp), %r8
+               	movq	-0x290(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x288(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x288(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	%r14, %rdi
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L61>
 <L61>:
+               	movq	%rax, %r14
+               	addq	$0x1, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L60>
+<L62>:
+               	movq	%rbx, %rsi
+               	addq	$0x3, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x5, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	(%rdi), %r15
+               	movq	0x8(%rdi), %rsi
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2a0(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	%r14, %rdi
+               	movq	%r15, %rdx
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rsi
+               	leaq	0x40(%r13), %rdi
+               	leaq	0x8(%rdi), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+<L65>:
+               	movq	%rbx, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x5, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r14
+               	leaq	(%r14), %rdi
+               	movzwl	(%rdi), %r13d
+               	movzwq	%r13w, %r14
+               	movq	%rsi, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L66>
+<L66>:
                	movq	%rax, %rdi
                	movq	$0x10, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x158(%rbp), %r8
-               	movl	$0x0, 0x18(%r8)
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	$0x0, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-               	jmp	 <L64>
-<L63>:
-               	movl	%esi, %ebx
-               	imull	$0x12345678, %ebx, %ebx ## imm = 0x12345678
-               	addl	%ecx, %ebx
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rsi,4), %r12
-               	movl	%ebx, (%r12)
-               	addq	$0x1, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-<L64>:
-               	movq	$0x11, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x7, %r12
-               	jb	 <L66>
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x7, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
                	callq	 <L67>
 <L67>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	cmpq	$0x7, %r12
-               	jb	 <L66>
+               	movq	%rax, %rsi
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	movq	$0x0, 0x10(%r12)
+               	movl	$0x0, 0x18(%r12)
+               	movl	%ebx, %edi
+               	movq	$0x0, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
+               	jmp	 <L69>
 <L68>:
-               	movq	%rbx, %rdi
-               	movq	$0x1234, %rsi           ## imm = 0x1234
-               	callq	 <L69>
+               	movl	%r13d, %r14d
+               	imull	$0x12345678, %r14d, %r14d ## imm = 0x12345678
+               	addl	%edi, %r14d
+               	leaq	(%r12,%r13,4), %r15
+               	movl	%r14d, (%r15)
+               	addq	$0x1, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
 <L69>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L70>
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L70>
+               	jmp	 <L71>
 <L70>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x10(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x14(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x18(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movl	%esi, %ebx
-               	xorl	$0xf0f0f0f0, %ebx       ## imm = 0xF0F0F0F0
-               	movl	(%rcx), %esi
-               	callq	 <L71>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	$0x11, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L70>
 <L71>:
+               	movq	%rsi, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x7, %rdi
+               	jb	 <L72>
+               	jmp	 <L75>
+<L72>:
+               	movq	%rdi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	%rbx, %r13
+               	movq	%r13, %rax
+               	movq	$0x7, %r13
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	leaq	(%r12,%r13,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+               	jmp	 <L74>
+<L73>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+<L74>:
+               	addq	$0x1, %rdi
+               	movq	%r13, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	cmpq	$0x7, %rdi
+               	jb	 <L72>
+<L75>:
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1234, %rbx           ## imm = 0x1234
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+<L77>:
+               	movq	$0x4, %rsi
+               	callq	 <L78>
+<L78>:
+               	movq	%rax, %rdi
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x4(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0xc(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x10(%r12), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x14(%r12), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x18(%r12), %r13
+               	movl	(%r13), %r12d
+               	xorl	$0xf0f0f0f0, %ebx       ## imm = 0xF0F0F0F0
+               	movl	(%rsi), %r12d
+               	movl	%r12d, %esi
+               	callq	 <L79>
+<L79>:
                	movq	%rax, %rdi
                	movl	%ebx, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L80>
+<L80>:
                	movq	%rax, %rdi
                	movq	$0x11, %rsi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L81>
+<L81>:
                	movq	%rax, %rdi
                	movq	$0x1234, %rsi           ## imm = 0x1234
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %r12
-               	movq	-0x1e8(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r14
-               	movq	-0x1f8(%rbp), %r15
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
+               	movq	-0x2e8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/global_data.dis
+++ b/test/golden/x86_64-darwin/mem/global_data.dis
@@ -5,29 +5,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,131 +90,355 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.fold_globals>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movzbl	, %esi <corpus.cases.mem.global_data.fold_globals+0x1b>
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movzbl	, %eax <corpus.cases.mem.global_data.fold_globals+0x1f>
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_data.fold_globals+0x2a>
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_data.fold_globals+0x38>
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movzwl	, %eax <corpus.cases.mem.global_data.fold_globals+0x7c>
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x49>
-               	callq	 <L3>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movzbl	, %esi <corpus.cases.mem.global_data.fold_globals+0x58>
-               	callq	 <L4>
+               	movl	, %eax <corpus.cases.mem.global_data.fold_globals+0xd8>
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_data.fold_globals+0x67>
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_data.fold_globals+0x75>
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movq	, %rax <corpus.cases.mem.global_data.fold_globals+0x133>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x86>
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x95>
-               	movss	(%rcx), %xmm0
-               	callq	 <L8>
+               	movzbl	, %eax <corpus.cases.mem.global_data.fold_globals+0x18c>
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0xa8>
-               	movsd	(%rcx), %xmm0
-               	callq	 <L9>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0xb8>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x6, %r13
+               	movzwl	, %eax <corpus.cases.mem.global_data.fold_globals+0x1e9>
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L10>
-               	jmp	 <L12>
+               	jmp	 <L11>
 <L10>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
-<L11>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x6, %r13
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
                	jb	 <L10>
+<L11>:
+               	movl	, %eax <corpus.cases.mem.global_data.fold_globals+0x245>
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0xf9>
-               	movzwl	(%rax), %esi
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x105>
-               	movzbl	(%rax), %ebx
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x115>
-               	movq	(%rax), %r13
-               	movq	%r12, %rdi
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L14>
+               	movq	, %rax <corpus.cases.mem.global_data.fold_globals+0x2a1>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L15>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x135>
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %esi
-               	leaq	0x2(%rcx), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	movq	%rax, %rdi
+               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x2fa>
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L16>
 <L16>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x311>
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rsi
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L18>
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x329>
+               	movq	$0x0, %rsi
+               	cmpq	$0x6, %rsi
+               	jb	 <L18>
+               	jmp	 <L21>
 <L18>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0x17e>
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
+               	leaq	(%rdx,%rsi,4), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	%rax, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
 <L20>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x6, %rsi
+               	jb	 <L18>
 <L21>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x1b9>
-               	movl	(%rcx), %edx
+               	leaq	-0x10(%rbp), %rdx
+               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x3b8>
+               	movq	, %rdi <corpus.cases.mem.global_data.fold_globals+0x3c7>
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rbx, %rdx
                	callq	 <L22>
 <L22>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x3df>
+               	leaq	-0x20(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rdi, (%rsi)
+               	movq	%rbx, 0x8(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rbx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	movq	%rbx, %rdx
+               	callq	 <L23>
+<L23>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x41d>
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x480>
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x4e4>
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x550>
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -291,263 +570,261 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x140, %rsp            ## imm = 0x140
-               	movq	%rbx, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movq	%r13, -0x128(%rbp)
-               	movq	%r14, -0x130(%rbp)
-               	movq	%r15, -0x138(%rbp)
+               	subq	$0x150, %rsp            ## imm = 0x150
+               	movq	%rbx, -0x128(%rbp)
+               	movq	%r12, -0x130(%rbp)
+               	movq	%r13, -0x138(%rbp)
+               	movq	%r14, -0x140(%rbp)
+               	movq	%r15, -0x148(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
+               	movabsq	$-0x61c8864680b583eb, %rsi ## imm = 0x9E3779B97F4A7C15
+               	addq	%rbx, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
-               	movabsq	$-0x61c8864680b583eb, %rsi ## imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rsi
+               	movq	$-0x12d687, %rsi        ## imm = 0xFFED2979
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movl	$0xffed2979, %esi       ## imm = 0xFFED2979
+               	movabsq	$0x3fc4000000000000, %rsi ## imm = 0x3FC4000000000000
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x6b>
-               	callq	 <L4>
-<L4>:
                	movq	%rax, %rcx
-               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0x7a>
-               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0x81>
-               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x8a>
-               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x97>
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x96>
-               	movq	%r8, -0x110(%rbp)
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xb4>
-               	movq	%r8, -0x48(%rbp)
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xc7>
-               	movq	%r8, -0x50(%rbp)
-               	movq	%rcx, %r8
+               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0x80>
+               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0x87>
+               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x90>
+               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x9d>
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x9c>
+               	movq	%r8, -0x120(%rbp)
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xba>
                	movq	%r8, -0x58(%rbp)
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xcd>
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x68(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
                	cmpq	$0x5, %r8
-               	jb	 <L5>
-               	jmp	 <L9>
-<L5>:
-               	movq	-0x108(%rbp), %r8
+               	jb	 <L4>
+               	jmp	 <L8>
+<L4>:
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0xfd>
-               	movq	-0x60(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %edi
-               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x116>
-               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x11d>
-               	movq	-0x60(%rbp), %r9
-               	movw	%r9w, %r8w
                	movq	%r8, -0x70(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %edi
-               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x137>
-               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x13d>
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
+               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x103>
+               	movq	-0x70(%rbp), %r9
+               	movb	%r9b, %r8b
                	movq	%r8, -0x78(%rbp)
                	movq	-0x78(%rbp), %r8
                	addl	%r8d, %edi
-               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x155>
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x15c>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rdi
-               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x16a>
-               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x171>
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %edi
-               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x17f>
-               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x186>
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %edi
-               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x194>
-               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x19a>
-               	movq	-0x78(%rbp), %r8
-               	addl	%r8d, %edi
-               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x1a7>
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x1ae>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rdi
-               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x1bc>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1c3>
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1d3>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1da>
-               	movss	%xmm1, (%rdi)
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1e5>
-               	movsd	(%rdi), %xmm0
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1f5>
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x201>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x208>
-               	movsd	%xmm0, (%rdi)
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
+               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x11c>
+               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x123>
+               	movq	-0x70(%rbp), %r9
+               	movw	%r9w, %r8w
                	movq	%r8, -0x80(%rbp)
-               	movq	$0x0, %r8
+               	movq	-0x80(%rbp), %r8
+               	addl	%r8d, %edi
+               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x13d>
+               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x143>
+               	movq	-0x70(%rbp), %r9
+               	movl	%r9d, %r8d
                	movq	%r8, -0x88(%rbp)
                	movq	-0x88(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	-0x88(%rbp), %r9
-               	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x90(%rbp)
-               	movq	-0x90(%rbp), %r9
-               	movl	(%r9), %r8d
-               	movq	%r8, -0x98(%rbp)
+               	addl	%r8d, %edi
+               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x161>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x168>
+               	movq	-0x70(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x176>
+               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x17d>
+               	movq	-0x78(%rbp), %r8
+               	addl	%r8d, %edi
+               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x18b>
+               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x192>
+               	movq	-0x80(%rbp), %r8
+               	addl	%r8d, %edi
+               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x1a0>
+               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x1a6>
                	movq	-0x88(%rbp), %r8
+               	addl	%r8d, %edi
+               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x1b6>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x1bd>
+               	movq	-0x70(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x1cb>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1d2>
+               	movss	(%rdi), %xmm0
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1e2>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1e9>
+               	movss	%xmm1, (%rdi)
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1f4>
+               	movsd	(%rdi), %xmm0
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x204>
+               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x210>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x217>
+               	movsd	%xmm0, (%rdi)
+               	movq	-0x70(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x90(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	-0x98(%rbp), %r9
+               	leaq	(%r12,%r9,4), %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0xa0(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0x98(%rbp), %r8
                	movl	%r8d, %edi
                	addl	$0x1, %edi
-               	movq	-0x80(%rbp), %r9
+               	movq	-0x90(%rbp), %r9
                	movl	%r9d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0xa0(%rbp)
-               	movq	-0x98(%rbp), %r8
-               	movq	-0xa0(%rbp), %r9
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xa8(%rbp), %r8
+               	movq	-0xb0(%rbp), %r9
                	movl	%r8d, %edi
                	xorl	%r9d, %edi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0xa0(%rbp), %r8
                	movl	%edi, (%r8)
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
-               	movq	%r8, -0x88(%rbp)
-               	movq	-0x88(%rbp), %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
                	cmpq	$0x6, %r8
-               	jb	 <L6>
-<L7>:
+               	jb	 <L5>
+<L6>:
                	movzwl	(%r13), %r8d
-               	movq	%r8, -0xa8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movw	%r8w, %di
-               	movq	-0xa8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%edi, %r8d
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
-               	movw	%r8w, (%r13)
-               	movzbl	(%r14), %r8d
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movb	%r8b, %dil
+               	movq	-0x70(%rbp), %r8
+               	movw	%r8w, %di
                	movq	-0xb8(%rbp), %r9
                	movl	%r9d, %r8d
-               	xorl	%edi, %r8d
+               	addl	%edi, %r8d
                	movq	%r8, -0xc0(%rbp)
                	movq	-0xc0(%rbp), %r8
+               	movw	%r8w, (%r13)
+               	movzbl	(%r14), %r8d
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0x70(%rbp), %r8
+               	movb	%r8b, %dil
+               	movq	-0xc8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	xorl	%edi, %r8d
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
                	movb	%r8b, (%r14)
                	movq	(%r15), %rdi
                	imulq	$0x3, %rdi, %rdi
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	addq	%r8, %rdi
                	movq	%rdi, (%r15)
-               	leaq	-0x40(%rbp), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x34b>
-               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x35a>
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xc8(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0xc8(%rbp), %r8
-               	movq	-0xd0(%rbp), %r9
-               	movq	%r9, 0x8(%r8)
-               	movq	-0xc8(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0xc8(%rbp), %r9
-               	movq	0x8(%r9), %r8
+               	leaq	-0x50(%rbp), %r8
                	movq	%r8, -0xd8(%rbp)
-               	movq	-0x110(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x110(%rbp), %r8
-               	movq	-0xd8(%rbp), %r9
-               	movq	%r9, 0x8(%r8)
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rax
-               	movq	$0x3, %rdi
-               	xorl	%edx, %edx
-               	divq	%rdi
-               	movq	%rdx, %rdi
-               	movq	-0x48(%rbp), %r9
-               	leaq	(%r9,%rdi,2), %r8
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x360>
+               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x36f>
                	movq	%r8, -0xe0(%rbp)
-               	movq	-0xe0(%rbp), %r8
-               	movzwl	(%r8), %edi
-               	movl	%edi, %r8d
-               	addl	$0x64, %r8d
+               	movq	-0xd8(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe0(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0xd8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0xd8(%rbp), %r9
+               	movq	0x8(%r9), %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x120(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x120(%rbp), %r8
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rax
                	movq	$0x3, %rdi
                	xorl	%edx, %edx
                	divq	%rdi
                	movq	%rdx, %rdi
-               	movq	-0x48(%rbp), %r9
+               	movq	-0x58(%rbp), %r9
                	leaq	(%r9,%rdi,2), %r8
                	movq	%r8, -0xf0(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movq	-0xe8(%rbp), %r9
-               	movw	%r9w, (%r8)
-               	movq	-0x50(%rbp), %r9
-               	movl	(%r9), %r8d
+               	movzwl	(%r8), %edi
+               	movl	%edi, %r8d
+               	addl	$0x64, %r8d
                	movq	%r8, -0xf8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %edi
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	movq	-0x58(%rbp), %r9
+               	leaq	(%r9,%rdi,2), %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
                	movq	-0xf8(%rbp), %r9
+               	movw	%r9w, (%r8)
+               	movq	-0x60(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x70(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	-0x108(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%edi, %r8d
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x50(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x60(%rbp), %r8
+               	movq	-0x110(%rbp), %r9
                	movl	%r9d, (%r8)
-               	movq	-0x58(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %rdi
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdi, %r8
-               	movq	%r8, -0x58(%rbp)
+               	movq	%r8, -0x68(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
                	cmpq	$0x5, %r8
-               	jb	 <L5>
-<L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x49f>
+               	jb	 <L4>
+<L8>:
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x4b4>
                	movabsq	$-0x61c8864680b583eb, %r11 ## imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x4b3>
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x4ba>
-               	movq	-0x58(%rbp), %r8
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x4c8>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x4cf>
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L9>
+<L9>:
                	movq	%rax, %rdi
                	leaq	-0x10(%rbp), %rcx
                	leaq	-0x20(%rbp), %rsi
-               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x4d8>
-               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4e7>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x4ed>
+               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4fc>
                	movq	%rbx, (%rsi)
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rbx
@@ -565,34 +842,28 @@ Disassembly of section __TEXT,__text:
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rcx
                	movq	0x8(%rsi), %rbx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x522>
-               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x531>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x530>
-               	movzwl	(%rcx), %esi
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x53c>
-               	movzbl	(%rcx), %ebx
-               	leaq	, %rcx <L11>
-               	movq	(%rcx), %r12
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x537>
+               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x546>
+               	leaq	-0x40(%rbp), %rcx
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x549>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x558>
+               	movq	%rsi, (%rcx)
+               	movq	%rbx, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0x118(%rbp), %rbx
-               	movq	-0x120(%rbp), %r12
-               	movq	-0x128(%rbp), %r13
-               	movq	-0x130(%rbp), %r14
-               	movq	-0x138(%rbp), %r15
+               	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %r12
+               	movq	-0x138(%rbp), %r13
+               	movq	-0x140(%rbp), %r14
+               	movq	-0x148(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/global_zero.dis
+++ b/test/golden/x86_64-darwin/mem/global_zero.dis
@@ -5,29 +5,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_zero.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,145 +90,342 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_zero.fold_zeros>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movzbl	, %esi <corpus.cases.mem.global_zero.fold_zeros+0x23>
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movzbl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x1f>
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_zero.fold_zeros+0x32>
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_zero.fold_zeros+0x40>
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movzwl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x7c>
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0x51>
-               	callq	 <L3>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_zero.fold_zeros+0x5f>
-               	movl	%ecx, %esi
-               	callq	 <L4>
+               	movl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0xd8>
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0x70>
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.fold_zeros+0x7f>
-               	movss	(%rcx), %xmm0
-               	callq	 <L6>
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x133>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.fold_zeros+0x92>
-               	movsd	(%rcx), %xmm0
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0xa5>
-               	callq	 <L8>
+               	movl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x18b>
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xb1>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x200, %r13            ## imm = 0x200
-               	jb	 <L9>
-               	jmp	 <L11>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x1e7>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x200, %r13            ## imm = 0x200
-               	jb	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xf8>
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x240>
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x2a4>
+               	movsd	(%rax), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x306>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x35f>
+               	movq	$0x0, %rdx
+               	cmpq	$0x200, %rdx            ## imm = 0x200
+               	jb	 <L18>
+               	jmp	 <L21>
+<L18>:
+               	leaq	(%rax,%rdx,4), %rsi
+               	movl	(%rsi), %ebx
+               	movl	%ebx, %esi
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+<L20>:
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x200, %rdx            ## imm = 0x200
+               	jb	 <L18>
+<L21>:
+               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x3f0>
+               	movq	%rdi, %r12
                	movq	$0x0, %r13
                	cmpq	$0x8, %r13
-               	jb	 <L12>
-               	jmp	 <L16>
-<L12>:
+               	jb	 <L22>
+               	jmp	 <L24>
+<L22>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %esi
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r14d
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r15
-               	movq	%r12, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L15>
-<L15>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L12>
-<L16>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x164>
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	0x2(%rax), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %r13
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L19>
-<L19>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x1ad>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%r13,8), %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
                	movq	(%rax), %rsi
-               	movq	%r12, %rdi
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L20>
-<L22>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.checksum+0xc>
-               	movzbl	(%rax), %esi
+               	movq	0x8(%rax), %rdx
                	movq	%r12, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	addq	$0x1, %r13
+               	movq	%rax, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L22>
+<L24>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x44d>
+               	leaq	-0x20(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rax
+               	movq	%r12, %rdi
+               	movq	%rax, %rdx
+               	callq	 <L25>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x488>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L26>
+               	jmp	 <L29>
+<L26>:
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+<L28>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rax
+               	cmpq	$0x4, %rsi
+               	jb	 <L26>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x532>
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -181,232 +433,254 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_zero.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x38(%rbp)
                	movq	%r12, -0x40(%rbp)
                	movq	%r13, -0x48(%rbp)
                	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	$0xc8, %esi
-               	addl	%ecx, %esi
-               	movb	%sil,  <corpus.cases.mem.global_zero.checksum+0x3b>
-               	movw	%bx, %cx
-               	movl	$0x9c40, %esi           ## imm = 0x9C40
-               	addl	%ecx, %esi
-               	movw	%si,  <corpus.cases.mem.global_zero.checksum+0x4c>
-               	movl	%ebx, %ecx
-               	movl	$0xb2d05e00, %esi       ## imm = 0xB2D05E00
-               	addl	%ecx, %esi
-               	movl	%esi,  <corpus.cases.mem.global_zero.checksum+0x5b>
-               	movabsq	$-0x123456789abcdf0, %rsi ## imm = 0xFEDCBA9876543210
+               	movb	%bl, %sil
+               	movl	$0xc8, %r12d
+               	addl	%esi, %r12d
+               	movb	%r12b,  <corpus.cases.mem.global_zero.checksum+0x44>
+               	movw	%bx, %si
+               	movl	$0x9c40, %r12d          ## imm = 0x9C40
+               	addl	%esi, %r12d
+               	movw	%r12w,  <corpus.cases.mem.global_zero.checksum+0x58>
+               	movl	%ebx, %esi
+               	movl	$0xb2d05e00, %r12d      ## imm = 0xB2D05E00
+               	addl	%esi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x6a>
+               	movabsq	$-0x123456789abcdf0, %r12 ## imm = 0xFEDCBA9876543210
+               	addq	%rbx, %r12
+               	movq	%r12,  <corpus.cases.mem.global_zero.checksum+0x7e>
+               	movl	$0x77359400, %r12d      ## imm = 0x77359400
+               	addl	%esi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x8e>
+               	movabsq	$0x7ce66c50e2840000, %rsi ## imm = 0x7CE66C50E2840000
                	addq	%rbx, %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0x6f>
-               	movl	$0x77359400, %esi       ## imm = 0x77359400
-               	addl	%ecx, %esi
-               	movl	%esi,  <corpus.cases.mem.global_zero.checksum+0x7c>
-               	movabsq	$0x7ce66c50e2840000, %rcx ## imm = 0x7CE66C50E2840000
-               	addq	%rbx, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_zero.checksum+0x90>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x97>
-               	movl	$0x3fe00000, (%rcx)     ## imm = 0x3FE00000
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0xa4>
+               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0xa2>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xa9>
+               	movl	$0x3fe00000, (%rsi)     ## imm = 0x3FE00000
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xb6>
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movabsq	$0x100000001b3, %rcx    ## imm = 0x100000001B3
-               	addq	%rbx, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_zero.checksum+0xc5>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0xcc>
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
-               	jb	 <L2>
-               	jmp	 <L3>
+               	movq	%r11, (%rsi)
+               	movabsq	$0x100000001b3, %rsi    ## imm = 0x100000001B3
+               	addq	%rbx, %rsi
+               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0xd7>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xde>
+               	movq	$0x0, %r12
+               	cmpq	$0x200, %r12            ## imm = 0x200
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movabsq	$0x9e3779b1, %r14       ## imm = 0x9E3779B1
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	movl	%r14d, %r15d
+               	leaq	(%rsi,%r12,4), %r14
+               	movl	%r15d, (%r14)
+               	movq	%r13, %r12
+               	cmpq	$0x200, %r12            ## imm = 0x200
+               	jb	 <L1>
 <L2>:
-               	movq	%rsi, %r12
-               	addq	$0x1, %r12
-               	movabsq	$0x9e3779b1, %r13       ## imm = 0x9E3779B1
-               	imulq	%r12, %r13
-               	addq	%rbx, %r13
-               	movl	%r13d, %r14d
-               	leaq	(%rcx,%rsi,4), %r13
-               	movl	%r14d, (%r13)
-               	movq	%r12, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
-               	jb	 <L2>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x130>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x11f>
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
-               	jb	 <L4>
-               	jmp	 <L5>
-<L4>:
-               	movq	%rsi, %r12
-               	imulq	$0xb, %r12, %r12
-               	addq	$0x3, %r12
-               	addq	%rbx, %r12
-               	movw	%r12w, %r13w
-               	movq	%rsi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rcx,%r12), %r14
-               	leaq	(%r14), %r12
-               	movw	%r13w, (%r12)
-               	movq	%rsi, %r12
-               	addq	$0xfa, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x2(%r14), %r12
-               	movb	%r13b, (%r12)
-               	addq	$0x1, %rsi
-               	movabsq	$-0x61c8864680b583eb, %r12 ## imm = 0x9E3779B97F4A7C15
-               	imulq	%rsi, %r12
-               	addq	%rbx, %r12
-               	leaq	0x8(%r14), %r13
-               	movq	%r12, (%r13)
-               	cmpq	$0x8, %rsi
-               	jb	 <L4>
-<L5>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x1cd>
-               	leaq	-0x10(%rbp), %rsi
-               	movq	(%rcx), %r12
-               	movq	0x8(%rcx), %r13
-               	movq	%r12, (%rsi)
-               	movq	%r13, 0x8(%rsi)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x1b6>
-               	movq	(%rsi), %r12
-               	movq	0x8(%rsi), %r13
-               	movq	%r12, (%rcx)
-               	movq	%r13, 0x8(%rcx)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x1db>
-               	movq	$0x0, %rsi
-               	cmpq	$0x4, %rsi
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	%rsi, %r12
+               	movq	%r12, %r13
+               	imulq	$0xb, %r13, %r13
+               	addq	$0x3, %r13
+               	addq	%rbx, %r13
+               	movw	%r13w, %r14w
+               	movq	%r12, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r15
+               	leaq	(%r15), %r13
+               	movw	%r14w, (%r13)
+               	movq	%r12, %r13
+               	addq	$0xfa, %r13
+               	movb	%r13b, %r14b
+               	leaq	0x2(%r15), %r13
+               	movb	%r14b, (%r13)
                	addq	$0x1, %r12
-               	movq	$0x12345678, %r13       ## imm = 0x12345678
+               	movabsq	$-0x61c8864680b583eb, %r13 ## imm = 0x9E3779B97F4A7C15
                	imulq	%r12, %r13
                	addq	%rbx, %r13
-               	leaq	(%rcx,%rsi,8), %r14
+               	leaq	0x8(%r15), %r14
                	movq	%r13, (%r14)
-               	movq	%r12, %rsi
-               	cmpq	$0x4, %rsi
-               	jb	 <L6>
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1dd>
+               	leaq	-0x10(%rbp), %r12
+               	movq	(%rsi), %r13
+               	movq	0x8(%rsi), %r14
+               	movq	%r13, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1c8>
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r14
+               	movq	%r13, (%rsi)
+               	movq	%r14, 0x8(%rsi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1ef>
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movq	$0x12345678, %r14       ## imm = 0x12345678
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	leaq	(%rsi,%r12,8), %r15
+               	movq	%r14, (%r15)
+               	movq	%r13, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+<L6>:
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x255>
+               	movb	$0x4d, (%rsi)
+               	callq	 <L7>
 <L7>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x241>
-               	movb	$0x4d, (%rcx)
-               	callq	 <L8>
+               	movq	%rax, %rsi
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0xa33>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0xa1f>
-               	movl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x634>
-               	movl	(%rcx), %esi
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x696>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %r13d
+               	movq	%rsi, %rdi
+               	movq	%r13, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
                	addq	$0x1f4, %rbx            ## imm = 0x1F4
                	movq	%rbx, %rax
-               	movq	$0x200, %rcx            ## imm = 0x200
+               	movq	$0x200, %rsi            ## imm = 0x200
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x25e>
-               	leaq	(%rsi,%rcx,4), %rbx
-               	movl	(%rbx), %ecx
-               	movl	%ecx, %esi
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x2ca>
+               	leaq	(%rbx,%rsi,4), %r12
+               	movl	(%r12), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x275>
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x2e6>
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rbx            ## imm = 0x200
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%rcx,%rsi,4), %rbx
-               	movl	$0x0, (%rbx)
-               	addq	$0x1, %rsi
-               	cmpq	$0x200, %rsi            ## imm = 0x200
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	$0x0, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x200, %rbx            ## imm = 0x200
                	jb	 <L12>
 <L13>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x2b0>
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x323>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L14>
                	jmp	 <L15>
 <L14>:
-               	leaq	-0x20(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movw	$0x0, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x0, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movq	$0x0, (%r12)
-               	movq	%rsi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rcx,%r12), %r13
-               	movq	(%rbx), %r12
-               	movq	0x8(%rbx), %r14
-               	movq	%r12, (%r13)
-               	movq	%r14, 0x8(%r13)
-               	addq	$0x1, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	-0x20(%rbp), %r12
+               	leaq	(%r12), %r13
+               	movw	$0x0, (%r13)
+               	leaq	0x2(%r12), %r13
+               	movb	$0x0, (%r13)
+               	leaq	0x8(%r12), %r13
+               	movq	$0x0, (%r13)
+               	movq	%rbx, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r14
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r15
+               	movq	%r13, (%r14)
+               	movq	%r15, 0x8(%r14)
+               	addq	$0x1, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L14>
 <L15>:
-               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x317>
-               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x31f>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x327>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x332>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x33c>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x347>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x352>
-               	movl	$0x0, (%rcx)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x35f>
-               	movq	$0x0, (%rcx)
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x36d>
-               	leaq	-0x30(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movw	$0x0, (%rsi)
-               	leaq	0x2(%rcx), %rsi
-               	movb	$0x0, (%rsi)
-               	leaq	0x8(%rcx), %rsi
+               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x38e>
+               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x396>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x39e>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3a9>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3b3>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3be>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3c9>
+               	movl	$0x0, (%rsi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3d6>
                	movq	$0x0, (%rsi)
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x396>
-               	movq	(%rcx), %rbx
-               	movq	0x8(%rcx), %r12
-               	movq	%rbx, (%rsi)
-               	movq	%r12, 0x8(%rsi)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x3bb>
-               	movq	$0x0, %rsi
-               	cmpq	$0x4, %rsi
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3e4>
+               	leaq	-0x30(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movw	$0x0, (%rbx)
+               	leaq	0x2(%rsi), %rbx
+               	movb	$0x0, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x0, (%rbx)
+               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x40d>
+               	movq	(%rsi), %r12
+               	movq	0x8(%rsi), %r13
+               	movq	%r12, (%rbx)
+               	movq	%r13, 0x8(%rbx)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x432>
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
                	jb	 <L16>
                	jmp	 <L17>
 <L16>:
-               	leaq	(%rcx,%rsi,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rsi
-               	cmpq	$0x4, %rsi
+               	leaq	(%rsi,%rbx,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
                	jb	 <L16>
 <L17>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x411>
-               	movb	$0x0, (%rcx)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x489>
+               	movb	$0x0, (%rsi)
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13
                	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/loadstore.dis
+++ b/test/golden/x86_64-darwin/mem/loadstore.dis
@@ -5,68 +5,208 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.loadstore.fold_packed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movzbl	(%rdx), %esi
-               	leaq	0x1(%rcx), %rdx
+               	leaq	0x1(%rax), %rdx
                	movzbl	(%rdx), %ebx
-               	leaq	0x2(%rcx), %rdx
+               	leaq	0x2(%rax), %rdx
                	movzbl	(%rdx), %r12d
-               	leaq	0x3(%rcx), %rdx
+               	leaq	0x3(%rax), %rdx
                	movzbl	(%rdx), %r13d
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movzwl	(%rdx), %r14d
-               	leaq	0x6(%rcx), %rdx
-               	movzwl	(%rdx), %r15d
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %r8d
+               	movq	%r8, -0x18(%rbp)
+               	leaq	0x8(%rax), %rdx
                	movl	(%rdx), %r8d
                	movq	%r8, -0x8(%rbp)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x10(%rbp)
-               	callq	 <L0>
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdx, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %r15
+               	xorq	%rax, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L4>
+               	movzbq	%r12b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L6>
+               	movzbq	%r13b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movzwq	%r14w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -74,36 +214,33 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.loadstore.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xe0, %rsp
-               	movq	%rbx, -0x98(%rbp)
-               	movq	%r12, -0xa0(%rbp)
-               	movq	%r13, -0xa8(%rbp)
-               	movq	%r14, -0xb0(%rbp)
-               	movq	%r15, -0xb8(%rbp)
+               	subq	$0x100, %rsp            ## imm = 0x100
+               	movq	%rbx, -0xb8(%rbp)
+               	movq	%r12, -0xc0(%rbp)
+               	movq	%r13, -0xc8(%rbp)
+               	movq	%r14, -0xd0(%rbp)
+               	movq	%r15, -0xd8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x18(%rbp), %r12
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
-               	leaq	-0x30(%rbp), %rdx
-               	movq	(%r12), %rsi
-               	movq	0x8(%r12), %r13
-               	movq	0x10(%r12), %r14
-               	movq	%rsi, (%rdx)
-               	movq	%r13, 0x8(%rdx)
-               	movq	%r14, 0x10(%rdx)
-               	movq	(%rdx), %rsi
-               	movq	0x8(%rdx), %r13
-               	movq	0x10(%rdx), %r14
-               	movq	%rsi, (%rsp)
-               	movq	%r13, 0x8(%rsp)
-               	movq	%r14, 0x10(%rsp)
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
+               	leaq	-0x58(%rbp), %rax
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %rsi
+               	movq	0x10(%r12), %rdi
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movabsq	$-0x123456789abcdf0, %r13 ## imm = 0xFEDCBA9876543210
                	addq	%rbx, %r13
                	movb	%r13b, %dl
@@ -137,27 +274,28 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, (%rsi)
                	leaq	0x10(%r12), %rdx
                	movq	%r13, (%rdx)
-               	leaq	-0x48(%rbp), %rdx
+               	leaq	-0x70(%rbp), %rdx
                	movq	(%r12), %rsi
-               	movq	0x8(%r12), %r14
-               	movq	0x10(%r12), %r15
+               	movq	0x8(%r12), %rdi
+               	movq	0x10(%r12), %r14
                	movq	%rsi, (%rdx)
-               	movq	%r14, 0x8(%rdx)
-               	movq	%r15, 0x10(%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
                	movq	(%rdx), %rsi
-               	movq	0x8(%rdx), %r14
-               	movq	0x10(%rdx), %r15
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r14
                	movq	%rsi, (%rsp)
-               	movq	%r14, 0x8(%rsp)
-               	movq	%r15, 0x10(%rsp)
-               	callq	 <L2>
-<L2>:
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r14, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x8, %r15
-               	jb	 <L3>
-               	jmp	 <L5>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L4>
+<L2>:
                	addq	$0x1, %r15
                	movq	%r13, %rax
                	imulq	%r15, %rax
@@ -174,7 +312,7 @@ Disassembly of section __TEXT,__text:
                	movl	%eax, %edx
                	leaq	0x8(%r12), %rax
                	movl	%edx, (%rax)
-               	leaq	-0x60(%rbp), %rax
+               	leaq	-0x18(%rbp), %rax
                	movq	(%r12), %rdx
                	movq	0x8(%r12), %rsi
                	movq	0x10(%r12), %rdi
@@ -188,139 +326,288 @@ Disassembly of section __TEXT,__text:
                	movq	%rsi, 0x8(%rsp)
                	movq	%rdi, 0x10(%rsp)
                	movq	%r14, %rdi
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %r14
                	cmpq	$0x8, %r15
-               	jb	 <L3>
-<L5>:
+               	jb	 <L2>
+<L4>:
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L6>
-               	jmp	 <L17>
-<L6>:
-               	addq	$0x1, %r12
-               	movabsq	$-0x61c8864680b583eb, %rax ## imm = 0x9E3779B97F4A7C15
-               	imulq	%r12, %rax
-               	movq	%rax, %r15
-               	addq	%rbx, %r15
-               	movb	%r15b, %r8b
+               	jb	 <L5>
+               	jmp	 <L21>
+<L5>:
+               	movq	%r12, %rax
+               	addq	$0x1, %rax
+               	movabsq	$-0x61c8864680b583eb, %rdx ## imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r8
+               	addq	%rbx, %r8
                	movq	%r8, -0x88(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x8, %rdx
-               	movw	%dx, %r8w
+               	movq	-0x88(%rbp), %r8
+               	movb	%r8b, %r15b
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x8, %rax
+               	movw	%ax, %r8w
                	movq	%r8, -0x78(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x80(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movsbq	%r15b, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	%r14, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rsi, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdi
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	-0x78(%rbp), %r9
+               	movswq	%r9w, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L10>
+               	movq	-0x80(%rbp), %r9
+               	movslq	%r9d, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movsbq	%r8b, %rsi
-               	callq	 <L11>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movswq	%r8w, %rsi
-               	callq	 <L12>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rsi, %rdi
+               	xorq	%rdx, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movsbq	%r15b, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x78(%rbp), %r8
+               	movswq	%r8w, %rax
+               	movq	%rsi, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L16>
+<L16>:
                	movq	-0x80(%rbp), %r8
                	movslq	%r8d, %rsi
-               	callq	 <L13>
-<L13>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	callq	 <L14>
-<L14>:
+               	callq	 <L17>
+<L17>:
+               	movzbq	%r15b, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
                	movq	-0x78(%rbp), %r8
                	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
+               	callq	 <L19>
+<L19>:
                	movq	-0x80(%rbp), %r8
                	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L20>
+<L20>:
+               	addq	$0x1, %r12
                	movq	%rax, %r14
                	cmpq	$0x6, %r12
-               	jb	 <L6>
-<L17>:
-               	leaq	-0x70(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
+               	jb	 <L5>
+<L21>:
+               	leaq	-0x28(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	andq	$0x7, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	movb	%sil, %dil
+               	movb	%dl, %sil
+               	addl	%esi, %edi
+               	leaq	(%rax,%rdx), %rsi
+               	movb	%dil, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+               	jmp	 <L27>
+<L24>:
+               	leaq	(%rax,%rdx), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	%r14, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+<L26>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+<L27>:
+               	movabsq	$-0x61c8864680b583eb, %r11 ## imm = 0x9E3779B97F4A7C15
+               	xorq	%r11, %r13
                	movq	$0x0, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
                	movq	%rax, %rdx
-               	andq	$0x7, %rdx
                	imulq	$0x8, %rdx, %rdx
                	movq	%rdx, %rcx
                	movq	%r13, %rdx
                	shrq	%cl, %rdx
-               	movb	%dl, %sil
-               	movb	%al, %dl
-               	addl	%edx, %esi
-               	leaq	(%rbx,%rax), %rdx
-               	movb	%sil, (%rdx)
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-<L19>:
-               	movq	$0x0, %r12
-               	cmpq	$0x10, %r12
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%r12), %rax
-               	movzbl	(%rax), %esi
-               	movq	%r14, %rdi
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %r12
-               	movq	%rax, %r14
-               	cmpq	$0x10, %r12
-               	jb	 <L20>
-<L22>:
-               	movabsq	$-0x61c8864680b583eb, %r11 ## imm = 0x9E3779B97F4A7C15
-               	xorq	%r11, %r13
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L23>
-<L23>:
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
                	addq	$0x1, %r13
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x98(%rbp), %rbx
-               	movq	-0xa0(%rbp), %r12
-               	movq	-0xa8(%rbp), %r13
-               	movq	-0xb0(%rbp), %r14
-               	movq	-0xb8(%rbp), %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%r14, %rax
+               	movq	-0xb8(%rbp), %rbx
+               	movq	-0xc0(%rbp), %r12
+               	movq	-0xc8(%rbp), %r13
+               	movq	-0xd0(%rbp), %r14
+               	movq	-0xd8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/ptr_arith.dis
+++ b/test/golden/x86_64-darwin/mem/ptr_arith.dis
@@ -5,29 +5,84 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.ptr_arith.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -60,17 +115,15 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.ptr_arith.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x160, %rsp            ## imm = 0x160
-               	movq	%rbx, -0x138(%rbp)
-               	movq	%r12, -0x140(%rbp)
-               	movq	%r13, -0x148(%rbp)
-               	movq	%r14, -0x150(%rbp)
-               	movq	%r15, -0x158(%rbp)
+               	subq	$0x1c0, %rsp            ## imm = 0x1C0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%r15, -0x1b8(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x20(%rbp), %r12
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x60(%rbp), %r13
+               	leaq	-0x80(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -79,443 +132,683 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r13)
                	movq	$0x0, 0x30(%r13)
                	movq	$0x0, 0x38(%r13)
-               	movq	$0x0, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	addq	$0x1, %rdx
                	movabsq	$0x9e3779b1, %rsi       ## imm = 0x9E3779B1
                	imulq	%rdx, %rsi
                	addq	%rbx, %rsi
                	movl	%esi, %edi
-               	leaq	(%r13,%rcx,4), %rsi
+               	leaq	(%r13,%rax,4), %rsi
                	movl	%edi, (%rsi)
-               	movq	%rdx, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-<L2>:
+               	movq	%rdx, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+<L1>:
                	leaq	(%r13), %r14
                	leaq	0x20(%r13), %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0xf0(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L3>
+               	jb	 <L2>
                	jmp	 <L5>
-<L3>:
-               	movq	-0xd8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0xd0(%rbp), %r8
+<L2>:
+               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r14,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xf0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L4>
-<L4>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0xf8(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf0(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L3>
+               	jb	 <L2>
 <L5>:
-               	movq	-0xd0(%rbp), %r9
+               	movq	-0xf0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xe0(%rbp)
+               	movq	%r8, -0x100(%rbp)
                	movq	$-0x8, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
                	cmpq	$0x8, %r8
                	jl	 <L6>
-               	jmp	 <L8>
+               	jmp	 <L9>
 <L6>:
-               	movq	-0xe8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
+               	leaq	(%r15,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x100(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+<L8>:
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x100(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
                	cmpq	$0x8, %r8
                	jl	 <L6>
-<L8>:
-               	movl	(%r15), %ecx
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
 <L9>:
-               	leaq	-0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	(%r15), %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	leaq	0x1c(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	leaq	-0x4(%r15), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%r15,%rcx,4), %rdx
-               	movl	(%rdx), %esi
-               	movl	%ecx, %edi
-               	addl	%edi, %esi
-               	addl	$0x1, %esi
-               	movl	%esi, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
                	jb	 <L12>
 <L13>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
-               	cmpq	$0x10, %r8
-               	jb	 <L14>
-               	jmp	 <L16>
-<L14>:
-               	movq	-0xf8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdx
+               	leaq	0x1c(%r15), %rdx
                	movl	(%rdx), %esi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L15>
+               	movl	%esi, %edx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x128(%rbp), %r8
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r15,%rdx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edx, %eax
+               	addl	%eax, %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+<L16>:
+               	movq	-0x128(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L17>
+               	jmp	 <L20>
+<L17>:
+               	movq	-0x140(%rbp), %r8
+               	leaq	(%r13,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movq	-0x140(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r8
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x130(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L14>
-<L16>:
+               	jb	 <L17>
+<L20>:
                	leaq	0x14(%r13), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x100(%rbp), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
                	movl	(%r8), %edx
                	xorl	$0xf0f0f0f0, %edx       ## imm = 0xF0F0F0F0
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movl	%edx, (%r8)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movl	(%r8), %edx
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	addl	$0x3, %ecx
-               	movq	-0x100(%rbp), %r8
-               	movl	%ecx, (%r8)
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	cmpq	%r14, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L21>
+               	movl	%edx, %r8d
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	cmpq	$0x0, %r14
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x150(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
 <L22>:
-               	cmpq	%r14, %r15
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	-0x180(%rbp), %r8
+               	movl	(%r8), %edx
+               	addl	$0x3, %edx
+               	movq	-0x180(%rbp), %r8
+               	movl	%edx, (%r8)
+               	movq	-0x180(%rbp), %r8
+               	movl	(%r8), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x150(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	leaq	-0xc0(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L24>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L24>
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	movq	%rcx, %rdx
-               	imulq	$0x5, %rdx, %rdx
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rdx
-               	addq	%rbx, %rdx
-               	movw	%dx, %si
-               	movq	%rcx, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r13,%rdx), %rdi
-               	leaq	(%rdi), %rdx
-               	movw	%si, (%rdx)
-               	movq	%rcx, %rdx
-               	addq	$0x64, %rdx
-               	movb	%dl, %sil
-               	leaq	0x2(%rdi), %rdx
-               	movb	%sil, (%rdx)
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    ## imm = 0x100000001B3
-               	imulq	%rcx, %rdx
-               	addq	%rbx, %rdx
-               	leaq	0x8(%rdi), %rsi
-               	movq	%rdx, (%rsi)
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
+               	movq	%rdi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+<L24>:
+               	leaq	0x14(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L25>
+<L25>:
+               	movq	%rax, %rdi
+               	movq	-0x180(%rbp), %r8
+               	movq	-0x180(%rbp), %r9
+               	cmpq	%r9, %r8
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	callq	 <L26>
 <L26>:
+               	movq	%rax, %rdi
+               	movq	-0x180(%rbp), %r8
+               	cmpq	%r14, %r8
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	callq	 <L27>
+<L27>:
+               	cmpq	$0x0, %r14
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	cmpq	%r14, %r15
+               	setne	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	leaq	-0xe0(%rbp), %r13
+               	leaq	(%r13), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rsi
+<L30>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L30>
+               	movq	$0x0, %rdx
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %rsi
+               	imulq	$0x5, %rsi, %rsi
+               	addq	$0x1, %rsi
+               	addq	%rbx, %rsi
+               	movw	%si, %di
+               	movq	%rdx, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	leaq	(%r14), %rsi
+               	movw	%di, (%rsi)
+               	movq	%rdx, %rsi
+               	addq	$0x64, %rsi
+               	movb	%sil, %dil
+               	leaq	0x2(%r14), %rsi
+               	movb	%dil, (%rsi)
+               	addq	$0x1, %rdx
+               	movabsq	$0x100000001b3, %rsi    ## imm = 0x100000001B3
+               	imulq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x8(%r14), %rdi
+               	movq	%rsi, (%rdi)
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+<L32>:
                	leaq	0x20(%r13), %r14
                	movq	%rax, %r15
                	movq	$-0x2, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x188(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jl	 <L27>
-               	jmp	 <L31>
-<L27>:
-               	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r14,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	0x2(%rdx), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rcx, %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jl	 <L27>
-<L31>:
-               	leaq	0x10(%r14), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
-               	addq	$0x11, %rax
-               	movq	%rax, (%rcx)
-               	leaq	-0x10(%r14), %rax
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %eax
-               	addl	$0x9, %eax
-               	movw	%ax, (%rcx)
-               	movq	$0x0, %r14
-               	cmpq	$0x6, %r14
-               	jb	 <L32>
-               	jmp	 <L36>
-<L32>:
-               	movq	%r14, %rax
-               	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %esi
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r8d
-               	movq	%r8, -0x118(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L33>
+               	jl	 <L33>
+               	jmp	 <L35>
 <L33>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r14,%rdx), %rsi
+               	leaq	-0x30(%rbp), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	-0x168(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x168(%rbp), %r8
+               	movq	%rdx, 0x8(%r8)
+               	movq	-0x168(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x168(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	%r15, %rdi
                	callq	 <L34>
 <L34>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	addq	$0x1, %r14
                	movq	%rax, %r15
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x188(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jl	 <L33>
+<L35>:
+               	leaq	0x10(%r14), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	$0x11, %rax
+               	movq	%rax, (%rdx)
+               	leaq	-0x10(%r14), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	addl	$0x9, %eax
+               	movw	%ax, (%rdx)
+               	movq	$0x0, %r14
                	cmpq	$0x6, %r14
-               	jb	 <L32>
+               	jb	 <L36>
+               	jmp	 <L38>
 <L36>:
-               	leaq	0x40(%r13), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
-               	imulq	$0x3, %rax, %rax
-               	movq	%rax, (%rcx)
-               	movq	(%rcx), %rsi
+               	movq	%r14, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r13,%rax), %rdx
+               	leaq	-0x40(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdx
                	movq	%r15, %rdi
                	callq	 <L37>
 <L37>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movw	%cx, (%rdx)
-               	movzwl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
+               	addq	$0x1, %r14
+               	movq	%rax, %r15
+               	cmpq	$0x6, %r14
+               	jb	 <L36>
 <L38>:
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movl	%ebx, %ecx
-               	movl	$0x12345678, %r13d      ## imm = 0x12345678
-               	addl	%ecx, %r13d
-               	movl	$0x9abcdef0, %r14d      ## imm = 0x9ABCDEF0
-               	addl	%ecx, %r14d
-               	movl	%ebx, %ecx
+               	leaq	0x40(%r13), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	imulq	$0x3, %rax, %rax
+               	movq	%rax, (%rdx)
+               	movq	(%rdx), %rax
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
                	jb	 <L39>
                	jmp	 <L40>
 <L39>:
-               	movl	%edx, %esi
-               	imull	$0x7, %esi, %esi
-               	addl	$0x3, %esi
-               	addl	%ecx, %esi
-               	leaq	(%r12,%rdx,4), %rdi
-               	movl	%esi, (%rdi)
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rdx
+               	movq	%rdi, %r15
                	cmpq	$0x8, %rdx
                	jb	 <L39>
 <L40>:
-               	leaq	0xc(%r12), %rbx
-               	movq	%rax, %r15
-               	movq	$-0x3, %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	cmpq	$0x5, %r8
-               	jl	 <L41>
-               	jmp	 <L43>
+               	leaq	(%r13), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	addl	$0x1, %eax
+               	movw	%ax, (%rdx)
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	movq	-0x128(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %edx
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r15, %rdi
-               	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r15
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rax
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	cmpq	$0x5, %r8
-               	jl	 <L41>
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
+<L42>:
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	movq	$0x0, 0x10(%r12)
+               	movq	$0x0, 0x18(%r12)
+               	movl	%ebx, %eax
+               	movl	$0x12345678, %r8d       ## imm = 0x12345678
+               	addl	%eax, %r8d
+               	movq	%r8, -0x178(%rbp)
+               	movl	$0x9abcdef0, %r8d       ## imm = 0x9ABCDEF0
+               	addl	%eax, %r8d
+               	movq	%r8, -0x170(%rbp)
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+               	jmp	 <L44>
 <L43>:
-               	leaq	(%r12), %rax
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
-               	jmp	 <L45>
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x3, %ebx
+               	addl	%eax, %ebx
+               	leaq	(%r12,%rdi,4), %r13
+               	movl	%ebx, (%r13)
+               	addq	$0x1, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
 <L44>:
-               	leaq	(%rax,%rcx,4), %rdx
-               	movl	(%rdx), %esi
-               	movl	%ecx, %edi
-               	addl	%edi, %esi
-               	addl	$0x1, %esi
-               	movl	%esi, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
+               	leaq	0xc(%r12), %rax
+               	movq	$-0x3, %rdi
+               	cmpq	$0x5, %rdi
+               	jl	 <L45>
+               	jmp	 <L48>
 <L45>:
-               	movq	%r15, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L46>
+               	leaq	(%rax,%rdi,4), %rbx
+               	movl	(%rbx), %r13d
+               	movl	%r13d, %ebx
+               	movq	%r15, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L46>
+               	jmp	 <L47>
 <L46>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L47>
-               	jmp	 <L49>
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L46>
 <L47>:
-               	leaq	(%r12,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L48>
+               	addq	$0x1, %rdi
+               	movq	%r13, %r15
+               	cmpq	$0x5, %rdi
+               	jl	 <L45>
 <L48>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	cmpq	$0x8, %r13
-               	jb	 <L47>
+               	leaq	(%r12), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
 <L49>:
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L50>
+               	leaq	(%rax,%rdx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edx, %ebx
+               	addl	%ebx, %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
 <L50>:
-               	movq	-0x138(%rbp), %rbx
-               	movq	-0x140(%rbp), %r12
-               	movq	-0x148(%rbp), %r13
-               	movq	-0x150(%rbp), %r14
-               	movq	-0x158(%rbp), %r15
+               	movq	-0x178(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+               	jmp	 <L52>
+<L51>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+<L52>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+               	jmp	 <L56>
+<L53>:
+               	leaq	(%r12,%rax,4), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	%r15, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L54>
+<L55>:
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+<L56>:
+               	movq	-0x170(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+<L58>:
+               	movq	%r15, %rax
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
+               	movq	-0x1b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/rec_layout.dis
+++ b/test/golden/x86_64-darwin/mem/rec_layout.dis
@@ -5,29 +5,85 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_tiny>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %r12d
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %ebx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,45 +91,135 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_mid>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r15, -0x28(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movzwl	(%rdx), %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	leaq	(%rdx), %rbx
                	movzbl	(%rbx), %r12d
                	leaq	0x4(%rdx), %rbx
                	movl	(%rbx), %r13d
                	leaq	0x8(%rdx), %rbx
-               	movzbl	(%rbx), %r14d
-               	leaq	0x10(%rcx), %rdx
-               	movzbl	(%rdx), %ebx
-               	callq	 <L0>
+               	movzbl	(%rbx), %edx
+               	leaq	0x10(%rax), %rbx
+               	movzbl	(%rbx), %eax
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
+               	movzbq	%r12b, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L4>
+               	movl	%r13d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -81,69 +227,162 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
+               	subq	$0x90, %rsp
                	movq	%rbx, -0x48(%rbp)
                	movq	%r12, -0x50(%rbp)
                	movq	%r13, -0x58(%rbp)
                	movq	%r14, -0x60(%rbp)
-               	leaq	0x10(%rbp), %rcx
+               	movq	%r15, -0x68(%rbp)
+               	leaq	0x10(%rbp), %rdx
                	leaq	-0x28(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %r12
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movq	%r13, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
-               	leaq	(%rbx), %rcx
-               	leaq	-0x3c(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rsi, (%rdx)
-               	movq	%r12, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %r12d
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%r12d, 0x10(%rsp)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r12
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
+               	movq	%rsi, (%rbx)
+               	movq	%r12, 0x8(%rbx)
+               	movq	%r13, 0x10(%rbx)
+               	movq	%r14, 0x18(%rbx)
+               	movq	%r15, 0x20(%rbx)
+               	leaq	(%rbx), %rdx
+               	leaq	-0x3c(%rbp), %rsi
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movl	%r14d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r12
+               	movl	0x10(%rsi), %r13d
+               	movq	%rdx, (%rsp)
+               	movq	%r12, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x18(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	leaq	0x18(%rbx), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	leaq	0x20(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x26(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	leaq	0x20(%rbx), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+<L6>:
+               	leaq	0x20(%rbx), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	leaq	0x26(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
                	movq	-0x48(%rbp), %rbx
                	movq	-0x50(%rbp), %r12
                	movq	-0x58(%rbp), %r13
                	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -151,154 +390,264 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.fold_nest>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            ## imm = 0x130
+               	subq	$0x140, %rsp            ## imm = 0x140
                	movq	%rbx, -0xf8(%rbp)
                	movq	%r12, -0x100(%rbp)
                	movq	%r13, -0x108(%rbp)
                	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
                	leaq	0x10(%rbp), %rax
                	leaq	-0x58(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	leaq	(%rax), %rdx
-               	cmpq	%rdx, %rcx
+               	leaq	(%rbx), %rdx
+               	leaq	(%rax), %rsi
+               	cmpq	%rsi, %rdx
                	jb	 <L1>
-               	movq	%rcx, %rax
+               	movq	%rdx, %rax
                	addq	$0x58, %rax
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %r12
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
 <L0>:
                	subq	$0x8, %rax
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r13
-               	movq	%r13, (%rax)
                	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rax)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
                	jne	 <L0>
                	jmp	 <L3>
 <L1>:
-               	addq	$0x0, %rcx
                	addq	$0x0, %rdx
+               	addq	$0x0, %rsi
                	movq	$0x58, %rax
 <L2>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rcx)
-               	addq	$0x8, %rcx
+               	movq	(%rsi), %r12
+               	movq	%r12, (%rdx)
                	addq	$0x8, %rdx
+               	addq	$0x8, %rsi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
                	jne	 <L2>
 <L3>:
                	leaq	(%rbx), %rax
-               	leaq	-0x80(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%r12, 0x10(%rcx)
-               	movq	%r13, 0x18(%rcx)
-               	movq	%r14, 0x20(%rcx)
+               	leaq	-0x80(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %r12
+               	movq	0x10(%rax), %r13
+               	movq	0x18(%rax), %r14
+               	movq	0x20(%rax), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%r12, 0x8(%rdx)
+               	movq	%r13, 0x10(%rdx)
+               	movq	%r14, 0x18(%rdx)
+               	movq	%r15, 0x20(%rdx)
                	leaq	-0xa8(%rbp), %r12
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
                	movq	%rax, (%r12)
-               	movq	%rdx, 0x8(%r12)
-               	movq	%rsi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
+               	movq	%rsi, 0x8(%r12)
+               	movq	%r13, 0x10(%r12)
+               	movq	%r14, 0x18(%r12)
+               	movq	%r15, 0x20(%r12)
                	leaq	(%r12), %rax
-               	leaq	-0xbc(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movl	0x10(%rax), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movl	0x10(%rcx), %esi
+               	leaq	-0xbc(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %r13
+               	movl	0x10(%rax), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movl	0x10(%rdx), %r13d
                	movq	%rax, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movl	%esi, 0x10(%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
                	callq	 <L4>
 <L4>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	leaq	0x20(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L7>
+               	leaq	0x20(%r12), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
 <L8>:
-               	leaq	0x26(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	leaq	0x20(%r12), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	leaq	0x28(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	leaq	-0xd0(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movl	0x10(%rcx), %r13d
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %edi
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
 <L10>:
-               	leaq	0x14(%r12), %rcx
-               	leaq	-0xe4(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movl	0x10(%rcx), %r12d
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movl	%r12d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %edi
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	leaq	0x20(%r12), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	leaq	0x50(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
 <L12>:
+               	leaq	0x26(%r12), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+<L14>:
+               	leaq	0x28(%rbx), %r12
+               	leaq	(%r12), %rdx
+               	leaq	-0xd0(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%rdi, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movl	%r14d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movl	0x10(%rsi), %r13d
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	leaq	0x14(%r12), %rdx
+               	leaq	-0xe4(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r12
+               	movl	0x10(%rdx), %r13d
+               	movq	%rdi, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movl	%r13d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movl	0x10(%rsi), %r12d
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r12d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
+               	leaq	0x50(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
                	movq	-0xf8(%rbp), %rbx
                	movq	-0x100(%rbp), %r12
                	movq	-0x108(%rbp), %r13
                	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -331,774 +680,880 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3e0, %rsp            ## imm = 0x3E0
-               	movq	%rbx, -0x358(%rbp)
-               	movq	%r12, -0x360(%rbp)
-               	movq	%r13, -0x368(%rbp)
-               	movq	%r14, -0x370(%rbp)
-               	movq	%r15, -0x378(%rbp)
+               	subq	$0x420, %rsp            ## imm = 0x420
+               	movq	%rbx, -0x398(%rbp)
+               	movq	%r12, -0x3a0(%rbp)
+               	movq	%r13, -0x3a8(%rbp)
+               	movq	%r14, -0x3b0(%rbp)
+               	movq	%r15, -0x3b8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movl	%ebx, %r12d
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0xc, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x14, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x58, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x28, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L5>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x58, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L8>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x4, %rsi
-               	callq	 <L9>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x26, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	$0x50, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rdi
+               	movq	$0x20, %rsi
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	$0x26, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x28, %rsi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	$0x50, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	%rax, %r8
                	movq	%r8, -0x330(%rbp)
                	movq	-0x330(%rbp), %r8
                	leaq	-0x58(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x58, %rdx
-<L18>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L18>
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L20>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
+               	leaq	(%r13), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x58, %rsi
+<L22>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L22>
+               	leaq	-0xb0(%rbp), %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x338(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L24>
                	movq	%rsi, %r14
                	addq	$0x58, %r14
-               	movq	$0x58, %r15
-<L19>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r14
-               	movq	(%r14), %rax
-               	movq	%rax, (%rdi)
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L19>
-               	jmp	 <L22>
-<L20>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
                	movq	$0x58, %rax
-<L21>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
+<L23>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L21>
-<L22>:
-               	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L24>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L23>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
                	jne	 <L23>
                	jmp	 <L26>
 <L24>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
-<L25>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L25>
-<L26>:
-               	movq	-0x330(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xa, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %r14
-               	movb	%dil, (%r14)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %r14
-               	movl	%edi, (%r14)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %r14b
-               	leaq	0x8(%rsi), %rdi
-               	movb	%r14b, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	movabsq	$-0x123456789abcdf0, %rcx ## imm = 0xFEDCBA9876543210
-               	addq	%rbx, %rcx
-               	leaq	(%r13), %rdx
-               	leaq	0x18(%rdx), %rsi
-               	movq	%rcx, (%rsi)
-               	movl	$0x14, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	0x20(%rdx), %rcx
-               	leaq	(%rcx), %rdi
-               	movw	%si, (%rdi)
-               	movl	$0x15, %esi
-               	addl	%r12d, %esi
-               	movw	%si, %di
-               	leaq	0x2(%rcx), %rsi
-               	movw	%di, (%rsi)
-               	movl	$0x16, %esi
-               	addl	%r12d, %esi
-               	movw	%si, %di
-               	leaq	0x4(%rcx), %rsi
-               	movw	%di, (%rsi)
-               	movl	$0x17, %ecx
-               	addl	%r12d, %ecx
-               	movb	%cl, %sil
-               	leaq	0x26(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	leaq	0x28(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x1e, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	%dil, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %rbx
-               	movl	%edi, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %bl
-               	leaq	0x8(%rsi), %rdi
-               	movb	%bl, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	leaq	0x28(%r13), %rcx
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0x28, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	%dil, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %rbx
-               	movl	%edi, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %bl
-               	leaq	0x8(%rsi), %rdi
-               	movb	%bl, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	movl	$0x32, %ecx
-               	addl	%r12d, %ecx
-               	leaq	0x50(%r13), %rbx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x108(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L29>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r12
-               	addq	$0x58, %r12
-               	movq	$0x58, %r14
-<L28>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r12
-               	movq	(%r12), %r15
-               	movq	%r15, (%rdi)
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L28>
-               	jmp	 <L31>
-<L29>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L30>:
-               	movq	(%rsi), %r12
-               	movq	%r12, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L30>
-<L31>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L33>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rsi, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %r12
-<L32>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L32>
-               	jmp	 <L35>
-<L33>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
-<L34>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L34>
-<L35>:
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x338(%rbp)
-               	movq	-0x338(%rbp), %r8
-               	leaq	(%r13), %r12
-               	leaq	(%r12), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	xorl	$0xf0f0f0f0, %edx       ## imm = 0xF0F0F0F0
-               	movl	%edx, (%rcx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L38>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r14
-               	addq	$0x58, %r14
-               	movq	$0x58, %r15
-<L37>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r14
-               	movq	(%r14), %rax
-               	movq	%rax, (%rdi)
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L37>
-               	jmp	 <L40>
-<L38>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
                	movq	$0x58, %rax
-<L39>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+<L25>:
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
                	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L39>
-<L40>:
+               	jne	 <L25>
+<L26>:
                	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
+               	movq	-0x338(%rbp), %r8
+               	leaq	(%r8), %rdx
                	cmpq	%rdx, %rax
-               	jb	 <L42>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
+               	jb	 <L28>
+               	movq	%rax, %rsi
                	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L41>:
-               	subq	$0x8, %rcx
+               	movq	%rdx, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r14
+<L27>:
                	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
                	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L41>
-               	jmp	 <L44>
-<L42>:
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L27>
+               	jmp	 <L30>
+<L28>:
                	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
-<L43>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
+               	movq	$0x58, %rsi
+<L29>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
                	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L43>
-<L44>:
-               	movq	-0x338(%rbp), %r8
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L29>
+<L30>:
+               	movq	-0x330(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L45>
-<L45>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %r8
                	movq	%r8, -0x340(%rbp)
                	movq	-0x340(%rbp), %r8
-               	leaq	0x28(%r13), %r14
-               	leaq	0x14(%r14), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x8(%rdx), %rcx
-               	movzbl	(%rcx), %edx
-               	addl	$0x7, %edx
-               	movb	%dl, (%rcx)
-               	leaq	-0x1b8(%rbp), %r8
-               	movq	%r8, -0x348(%rbp)
-               	movq	-0x348(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0xa, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %r14
+               	movw	%di, (%r14)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %r14b
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r15
+               	movb	%r14b, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x2, %r14d
+               	leaq	0x4(%rdi), %r15
+               	movl	%r14d, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x3, %r14d
+               	movb	%r14b, %r15b
+               	leaq	0x8(%rdi), %r14
+               	movb	%r15b, (%r14)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	movabsq	$-0x123456789abcdf0, %rdx ## imm = 0xFEDCBA9876543210
+               	addq	%rbx, %rdx
                	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L47>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r15
-               	addq	$0x58, %r15
-               	movq	$0x58, %rax
-<L46>:
-               	subq	$0x8, %rdi
+               	leaq	0x18(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movl	$0x14, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	0x20(%rsi), %rdx
+               	leaq	(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movl	$0x15, %edi
+               	addl	%r12d, %edi
+               	movw	%di, %bx
+               	leaq	0x2(%rdx), %rdi
+               	movw	%bx, (%rdi)
+               	movl	$0x16, %edi
+               	addl	%r12d, %edi
+               	movw	%di, %bx
+               	leaq	0x4(%rdx), %rdi
+               	movw	%bx, (%rdi)
+               	movl	$0x17, %edx
+               	addl	%r12d, %edx
+               	movb	%dl, %dil
+               	leaq	0x26(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	leaq	0x28(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x1e, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %rbx
+               	movw	%di, (%rbx)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %bl
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r14
+               	movb	%bl, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x2, %ebx
+               	leaq	0x4(%rdi), %r14
+               	movl	%ebx, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x3, %ebx
+               	movb	%bl, %r14b
+               	leaq	0x8(%rdi), %rbx
+               	movb	%r14b, (%rbx)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	leaq	0x28(%r13), %rdx
+               	leaq	0x14(%rdx), %rsi
+               	movl	$0x28, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %rbx
+               	movw	%di, (%rbx)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %bl
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r14
+               	movb	%bl, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x2, %ebx
+               	leaq	0x4(%rdi), %r14
+               	movl	%ebx, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x3, %ebx
+               	movb	%bl, %r14b
+               	leaq	0x8(%rdi), %rbx
+               	movb	%r14b, (%rbx)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	movl	$0x32, %edx
+               	addl	%r12d, %edx
+               	leaq	0x50(%r13), %rbx
+               	movl	%edx, (%rbx)
+               	leaq	-0x108(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L33>
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	%rdi, %r14
+               	addq	$0x58, %r14
+               	movq	$0x58, %r15
+<L32>:
+               	subq	$0x8, %r12
+               	subq	$0x8, %r14
+               	movq	(%r14), %rax
+               	movq	%rax, (%r12)
                	subq	$0x8, %r15
-               	movq	(%r15), %rcx
-               	movq	%rcx, (%rdi)
-               	subq	$0x8, %rax
-               	cmpq	$0x0, %rax
-               	jne	 <L46>
-               	jmp	 <L49>
-<L47>:
-               	addq	$0x0, %rdx
+               	cmpq	$0x0, %r15
+               	jne	 <L32>
+               	jmp	 <L35>
+<L33>:
                	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
                	movq	$0x58, %rax
-<L48>:
-               	movq	(%rsi), %rcx
-               	movq	%rcx, (%rdx)
-               	addq	$0x8, %rdx
+<L34>:
+               	movq	(%rdi), %r12
+               	movq	%r12, (%rsi)
                	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L48>
-<L49>:
+               	jne	 <L34>
+<L35>:
                	leaq	(%rsp), %rax
-               	movq	-0x348(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	cmpq	%rcx, %rax
-               	jb	 <L51>
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rax
+               	jb	 <L37>
                	movq	%rax, %rdx
                	addq	$0x58, %rdx
-               	movq	%rcx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L50>:
+               	movq	%rsi, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r12
+<L36>:
                	subq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r15
-               	movq	%r15, (%rdx)
                	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
+               	movq	(%rdi), %r14
+               	movq	%r14, (%rdx)
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L36>
+               	jmp	 <L39>
+<L37>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L38>:
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L38>
+<L39>:
+               	movq	-0x340(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	leaq	(%r13), %r12
+               	leaq	(%r12), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %esi
+               	xorl	$0xf0f0f0f0, %esi       ## imm = 0xF0F0F0F0
+               	movl	%esi, (%rdx)
+               	leaq	-0x160(%rbp), %r8
+               	movq	%r8, -0x350(%rbp)
+               	movq	-0x350(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L42>
+               	movq	%rsi, %r14
+               	addq	$0x58, %r14
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
+               	movq	$0x58, %rax
+<L41>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
+               	jne	 <L41>
+               	jmp	 <L44>
+<L42>:
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
+<L43>:
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
+               	jne	 <L43>
+<L44>:
+               	leaq	(%rsp), %rax
+               	movq	-0x350(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L46>
+               	movq	%rax, %rsi
+               	addq	$0x58, %rsi
+               	movq	%rdx, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r14
+<L45>:
+               	subq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L45>
+               	jmp	 <L48>
+<L46>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rdx
+               	movq	$0x58, %rsi
+<L47>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L47>
+<L48>:
+               	movq	-0x348(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	-0x358(%rbp), %r8
+               	leaq	0x28(%r13), %r14
+               	leaq	0x14(%r14), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	leaq	0x8(%rsi), %rdx
+               	movzbl	(%rdx), %esi
+               	addl	$0x7, %esi
+               	movb	%sil, (%rdx)
+               	leaq	-0x1b8(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x360(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x368(%rbp)
+               	leaq	(%r13), %rdi
+               	movq	-0x368(%rbp), %r8
+               	cmpq	%rdi, %r8
+               	jb	 <L51>
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0x58, %r15
+               	movq	%rdi, %rax
+               	addq	$0x58, %rax
+               	movq	$0x58, %rdx
+<L50>:
+               	subq	$0x8, %r15
+               	subq	$0x8, %rax
+               	movq	(%rax), %rsi
+               	movq	%rsi, (%r15)
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L50>
                	jmp	 <L53>
 <L51>:
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
                	addq	$0x0, %rax
-               	addq	$0x0, %rcx
+               	addq	$0x0, %rdi
                	movq	$0x58, %rdx
 <L52>:
-               	movq	(%rcx), %rsi
+               	movq	(%rdi), %rsi
                	movq	%rsi, (%rax)
                	addq	$0x8, %rax
-               	addq	$0x8, %rcx
+               	addq	$0x8, %rdi
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L52>
 <L53>:
-               	movq	-0x340(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x350(%rbp)
-               	movq	-0x350(%rbp), %r8
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	shrq	$0x3, %rdx
-               	movq	%rdx, (%rcx)
-               	leaq	-0x210(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L56>
+               	leaq	(%rsp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x360(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	-0x370(%rbp), %r8
+               	cmpq	%rdx, %r8
+               	jb	 <L55>
+               	movq	-0x370(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x58, %rsi
                	movq	%rdx, %rdi
                	addq	$0x58, %rdi
-               	movq	%rsi, %r12
-               	addq	$0x58, %r12
                	movq	$0x58, %r15
-<L55>:
+<L54>:
+               	subq	$0x8, %rsi
                	subq	$0x8, %rdi
-               	subq	$0x8, %r12
-               	movq	(%r12), %rax
-               	movq	%rax, (%rdi)
+               	movq	(%rdi), %rax
+               	movq	%rax, (%rsi)
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L55>
-               	jmp	 <L58>
-<L56>:
+               	jne	 <L54>
+               	jmp	 <L57>
+<L55>:
+               	movq	-0x370(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rax
-<L57>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
+               	movq	$0x58, %rsi
+<L56>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L56>
+<L57>:
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L58>
+<L58>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x378(%rbp)
+               	movq	-0x378(%rbp), %r8
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	shrq	$0x3, %rsi
+               	movq	%rsi, (%rdx)
+               	leaq	-0x210(%rbp), %r8
+               	movq	%r8, -0x380(%rbp)
+               	movq	-0x380(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L60>
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
+               	movq	$0x58, %rax
+<L59>:
+               	subq	$0x8, %r12
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r12)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L57>
-<L58>:
-               	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L60>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L59>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r12
-               	movq	%r12, (%rcx)
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
                	jne	 <L59>
                	jmp	 <L62>
 <L60>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
 <L61>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L61>
 <L62>:
-               	movq	-0x350(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L63>
-<L63>:
-               	movl	(%rbx), %ecx
-               	imull	$0x3, %ecx, %ecx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x268(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L65>
+               	leaq	(%rsp), %rax
+               	movq	-0x380(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L64>
+               	movq	%rax, %rsi
+               	addq	$0x58, %rsi
                	movq	%rdx, %rdi
                	addq	$0x58, %rdi
-               	movq	%rsi, %rbx
-               	addq	$0x58, %rbx
                	movq	$0x58, %r12
-<L64>:
+<L63>:
+               	subq	$0x8, %rsi
                	subq	$0x8, %rdi
-               	subq	$0x8, %rbx
-               	movq	(%rbx), %r15
-               	movq	%r15, (%rdi)
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L64>
-               	jmp	 <L67>
-<L65>:
+               	jne	 <L63>
+               	jmp	 <L66>
+<L64>:
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L66>:
-               	movq	(%rsi), %rbx
-               	movq	%rbx, (%rdx)
+               	movq	$0x58, %rsi
+<L65>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L66>
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L65>
+<L66>:
+               	movq	-0x378(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L67>
 <L67>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x388(%rbp)
+               	movq	-0x388(%rbp), %r8
+               	movl	(%rbx), %edx
+               	imull	$0x3, %edx, %edx
+               	movl	%edx, (%rbx)
+               	leaq	-0x268(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
                	jb	 <L69>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rsi, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %rbx
+               	movq	%rsi, %rbx
+               	addq	$0x58, %rbx
+               	movq	%rdi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r15
 <L68>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r12
-               	movq	%r12, (%rcx)
                	subq	$0x8, %rbx
-               	cmpq	$0x0, %rbx
+               	subq	$0x8, %r12
+               	movq	(%r12), %rax
+               	movq	%rax, (%rbx)
+               	subq	$0x8, %r15
+               	cmpq	$0x0, %r15
                	jne	 <L68>
                	jmp	 <L71>
 <L69>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
 <L70>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rdi), %rbx
+               	movq	%rbx, (%rsi)
                	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L70>
 <L71>:
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	-0x27c(%rbp), %rbx
-               	leaq	(%r14), %r12
-               	leaq	-0x290(%rbp), %rcx
-               	movq	(%r12), %rdx
-               	movq	0x8(%r12), %rsi
-               	movl	0x10(%r12), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movl	%edi, 0x10(%rbx)
-               	leaq	0x4(%rbx), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movl	%ecx, (%rdx)
-               	leaq	-0x2a4(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %rsi
-               	movl	0x10(%rbx), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	-0x2b8(%rbp), %rcx
-               	movq	(%r12), %rdx
-               	movq	0x8(%r12), %rsi
-               	movl	0x10(%r12), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x2cc(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %rsi
-               	movl	0x10(%rbx), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movl	%edi, 0x10(%r12)
-               	leaq	-0x328(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L76>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %rbx
-               	addq	$0x58, %rbx
-               	movq	$0x58, %r12
-<L75>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %rbx
-               	movq	(%rbx), %r13
-               	movq	%r13, (%rdi)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L75>
-               	jmp	 <L78>
-<L76>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L77>:
-               	movq	(%rsi), %rbx
-               	movq	%rbx, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L77>
-<L78>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L80>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
+               	leaq	(%rsp), %rax
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rax
+               	jb	 <L73>
+               	movq	%rax, %rdx
+               	addq	$0x58, %rdx
                	movq	%rsi, %rdi
                	addq	$0x58, %rdi
                	movq	$0x58, %rbx
-<L79>:
-               	subq	$0x8, %rcx
+<L72>:
+               	subq	$0x8, %rdx
                	subq	$0x8, %rdi
                	movq	(%rdi), %r12
-               	movq	%r12, (%rcx)
+               	movq	%r12, (%rdx)
                	subq	$0x8, %rbx
                	cmpq	$0x0, %rbx
+               	jne	 <L72>
+               	jmp	 <L75>
+<L73>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L74>:
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L74>
+<L75>:
+               	movq	-0x388(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x27c(%rbp), %rbx
+               	leaq	(%r14), %r12
+               	leaq	-0x290(%rbp), %rdx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movl	0x10(%r12), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movl	%r14d, 0x10(%rbx)
+               	leaq	0x4(%rbx), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	addl	$0x1, %edx
+               	movl	%edx, (%rsi)
+               	leaq	-0x2a4(%rbp), %rdx
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movl	0x10(%rbx), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r14d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
+               	leaq	-0x2b8(%rbp), %rdx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movl	0x10(%r12), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r14d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
+               	leaq	-0x2cc(%rbp), %rdx
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movl	0x10(%rbx), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %ebx
+               	movq	%rsi, (%r12)
+               	movq	%rdi, 0x8(%r12)
+               	movl	%ebx, 0x10(%r12)
+               	leaq	-0x328(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L80>
+               	movq	%rsi, %rbx
+               	addq	$0x58, %rbx
+               	movq	%rdi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
+<L79>:
+               	subq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rbx)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
                	jne	 <L79>
                	jmp	 <L82>
 <L80>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rbx
 <L81>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rdi), %r12
+               	movq	%r12, (%rsi)
                	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
                	jne	 <L81>
 <L82>:
-               	movq	%rax, %rdi
-               	callq	 <L83>
+               	leaq	(%rsp), %rsi
+               	leaq	(%rdx), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L84>
+               	movq	%rsi, %rdx
+               	addq	$0x58, %rdx
+               	movq	%rdi, %rbx
+               	addq	$0x58, %rbx
+               	movq	$0x58, %r12
 <L83>:
-               	movq	-0x358(%rbp), %rbx
-               	movq	-0x360(%rbp), %r12
-               	movq	-0x368(%rbp), %r13
-               	movq	-0x370(%rbp), %r14
-               	movq	-0x378(%rbp), %r15
+               	subq	$0x8, %rdx
+               	subq	$0x8, %rbx
+               	movq	(%rbx), %r13
+               	movq	%r13, (%rdx)
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L83>
+               	jmp	 <L86>
+<L84>:
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rdx
+<L85>:
+               	movq	(%rdi), %rbx
+               	movq	%rbx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L85>
+<L86>:
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
+               	movq	-0x398(%rbp), %rbx
+               	movq	-0x3a0(%rbp), %r12
+               	movq	-0x3a8(%rbp), %r13
+               	movq	-0x3b0(%rbp), %r14
+               	movq	-0x3b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/mem/uni_layout.dis
+++ b/test/golden/x86_64-darwin/mem/uni_layout.dis
@@ -23,46 +23,176 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0xc(%rbp), %rbx
-               	movl	-0x8(%rbp), %ecx
-               	movl	%ecx, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0xc(%rbp), %rax
+               	movl	-0x8(%rbp), %edx
+               	movl	%edx, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	(%rax), %rdx
+               	leaq	(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	leaq	(%rax), %rdx
+               	leaq	0x1(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	leaq	(%rax), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	leaq	(%rax), %rdx
+               	leaq	0x3(%rdx), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
@@ -76,58 +206,166 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movq	-0x8(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	-0x8(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	leaq	(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
                	movq	%r12, %rdi
-               	callq	 <L6>
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	(%rax), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%r12, %rax
+               	leaq	(%rax), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L13>
+<L10>:
+               	leaq	(%rax), %rsi
+               	leaq	(%rsi,%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	%rdi, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L13>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -135,353 +373,403 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.uni_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x140, %rsp            ## imm = 0x140
-               	movq	%rbx, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movq	%r13, -0x128(%rbp)
-               	movq	%r14, -0x130(%rbp)
-               	movq	%r15, -0x138(%rbp)
+               	subq	$0x110, %rsp            ## imm = 0x110
+               	movq	%rbx, -0xe8(%rbp)
+               	movq	%r12, -0xf0(%rbp)
+               	movq	%r13, -0xf8(%rbp)
+               	movq	%r14, -0x100(%rbp)
+               	movq	%r15, -0x108(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
+               	movabsq	$-0x340d631b7bdddcdb, %r12 ## imm = 0xCBF29CE484222325
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
                	movq	%r13, %rax
                	addq	$0x1, %rax
-               	movabsq	$-0x61c8864680b583eb, %rcx ## imm = 0x9E3779B97F4A7C15
-               	imulq	%rax, %rcx
-               	movq	%rcx, %r14
+               	movabsq	$-0x61c8864680b583eb, %rdx ## imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r14
                	addq	%rbx, %r14
                	leaq	-0x4(%rbp), %r15
                	movl	$0x0, (%r15)
                	movl	%r14d, %eax
                	andl	$0x807fffff, %eax       ## imm = 0x807FFFFF
                	orl	$0x3e800000, %eax       ## imm = 0x3E800000
-               	leaq	(%r15), %rcx
-               	movl	%eax, (%rcx)
-               	leaq	-0x54(%rbp), %rax
-               	movl	(%r15), %ecx
-               	movl	%ecx, (%rax)
-               	movq	$0x0, -0x60(%rbp)
-               	movl	(%rax), %ecx
-               	movl	%ecx, -0x60(%rbp)
-               	movq	-0x60(%rbp), %rsi
+               	leaq	(%r15), %rdx
+               	movl	%eax, (%rdx)
+               	leaq	-0x4c(%rbp), %rax
+               	movl	(%r15), %edx
+               	movl	%edx, (%rax)
+               	movq	$0x0, -0x58(%rbp)
+               	movl	(%rax), %edx
+               	movl	%edx, -0x58(%rbp)
+               	movq	-0x58(%rbp), %rsi
                	movq	%r12, %rdi
+               	callq	 <L1>
+<L1>:
+               	movq	%r14, %rdx
+               	shrq	$0x7, %rdx
+               	movl	%edx, %esi
+               	andl	$0x807fffff, %esi       ## imm = 0x807FFFFF
+               	orl	$0x3e800000, %esi       ## imm = 0x3E800000
+               	leaq	(%r15), %rdx
+               	movl	%esi, (%rdx)
+               	leaq	-0x5c(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x68(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x68(%rbp)
+               	movq	-0x68(%rbp), %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%r14, %rcx
-               	shrq	$0x7, %rcx
-               	movl	%ecx, %edx
-               	andl	$0x807fffff, %edx       ## imm = 0x807FFFFF
-               	orl	$0x3e800000, %edx       ## imm = 0x3E800000
-               	leaq	(%r15), %rcx
-               	movl	%edx, (%rcx)
-               	leaq	-0x74(%rbp), %rcx
-               	movl	(%r15), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x80(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x80(%rbp)
-               	movq	-0x80(%rbp), %rsi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0xfc>
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x6c(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x78(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x78(%rbp)
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0xfa>
-               	movss	%xmm1, (%rcx)
-               	leaq	-0x84(%rbp), %rcx
-               	movl	(%r15), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x90(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x90(%rbp)
-               	movq	-0x90(%rbp), %rsi
+               	leaq	-0x80(%rbp), %r15
+               	movq	$0x0, (%r15)
+               	movq	%r14, %rdx
+               	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
+               	andq	%r11, %rdx
+               	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
+               	orq	%r11, %rdx
+               	leaq	(%r15), %rsi
+               	movq	%rdx, (%rsi)
+               	leaq	-0x90(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	-0x98(%rbp), %r15
-               	movq	$0x0, (%r15)
-               	movq	%r14, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	(%r15), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0xa0(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
-<L5>:
                	shrq	$0x9, %r14
                	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
                	andq	%r11, %r14
                	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
                	orq	%r11, %r14
-               	leaq	(%r15), %rcx
-               	movq	%r14, (%rcx)
-               	leaq	-0xa8(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
+               	leaq	(%r15), %rdx
+               	movq	%r14, (%rdx)
+               	leaq	-0xa0(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
+               	leaq	(%r15), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1b7>
+               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1c3>
+               	movsd	%xmm0, (%rdx)
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	(%r15), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1c4>
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1d0>
-               	movsd	%xmm0, (%rcx)
-               	leaq	-0xb0(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x6, %r13
-               	jb	 <L1>
-<L8>:
+               	jb	 <L0>
+<L7>:
                	leaq	-0xc(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	%ebx, %r14d
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L9>
-               	jmp	 <L17>
-<L9>:
+               	jb	 <L8>
+               	jmp	 <L18>
+<L8>:
                	movl	%r15d, %eax
                	addl	$0x1, %eax
-               	movl	$0x9e3779b1, %ecx       ## imm = 0x9E3779B1
-               	imull	%eax, %ecx
-               	movl	%ecx, %r8d
+               	movl	$0x9e3779b1, %edx       ## imm = 0x9E3779B1
+               	imull	%eax, %edx
+               	movl	%edx, %r8d
                	addl	%r14d, %r8d
-               	movq	%r8, -0xe8(%rbp)
-               	leaq	-0x14(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	-0xe8(%rbp), %r8
-               	movl	%r8d, (%rdx)
-               	movq	-0xe8(%rbp), %r8
-               	movl	%r8d, %edx
-               	xorl	$0xf0f0f0f0, %edx       ## imm = 0xF0F0F0F0
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0xf0(%rbp), %r9
-               	leaq	(%r9), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
-               	movl	(%r8), %esi
-               	movq	%r12, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r9
-               	leaq	0x4(%r9), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	leaq	-0x14(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	-0xe0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movq	-0xe0(%rbp), %r8
+               	movl	%r8d, %esi
+               	xorl	$0xf0f0f0f0, %esi       ## imm = 0xF0F0F0F0
+               	leaq	0x4(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	leaq	(%r13), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %r8d
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %edx
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x100(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	movq	%r12, %r8
                	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
                	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+<L10>:
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %r8d
                	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xc8(%rbp), %r8
                	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	leaq	(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xd0(%rbp), %r8
-               	movl	%r8d, %esi
+               	leaq	(%r13), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
                	callq	 <L14>
 <L14>:
+               	movq	%rax, %rdi
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %r8
                	movq	%r8, -0xd8(%rbp)
                	movq	-0xd8(%rbp), %r8
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movw	%r8w, %di
+               	leaq	-0xb0(%rbp), %rdx
                	movq	-0xe0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movw	%di, (%rsi)
-               	movq	-0xe8(%rbp), %r8
+               	movw	%r8w, %si
+               	leaq	(%rdx), %rdi
+               	movw	%si, (%rdi)
+               	movq	-0xe0(%rbp), %r8
                	movl	%r8d, %esi
                	shrl	$0x10, %esi
                	movw	%si, %di
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
+               	leaq	0x2(%rdx), %rsi
                	movw	%di, (%rsi)
-               	movq	-0xe8(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movl	%r8d, %eax
                	addl	$0x1, %eax
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
+               	leaq	0x4(%rdx), %rsi
                	movl	%eax, (%rsi)
-               	movq	-0xe0(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x100(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0xf8(%rbp), %r8
-               	movl	(%r8), %eax
+               	leaq	(%r13), %rax
+               	movq	(%rdx), %rsi
+               	movq	%rsi, (%rax)
+               	leaq	(%r13), %rax
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %esi
                	movq	-0xd8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	callq	 <L15>
-<L15>:
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
                	addq	$0x1, %r15
                	movq	%rax, %r12
                	cmpq	$0x4, %r15
-               	jb	 <L9>
-<L17>:
-               	leaq	-0x30(%rbp), %r13
+               	jb	 <L8>
+<L18>:
+               	leaq	-0x28(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L18>
-               	jmp	 <L23>
-<L18>:
+               	jb	 <L19>
+               	jmp	 <L25>
+<L19>:
                	movq	%r14, %rax
                	addq	$0x1, %rax
-               	movb	%al, %cl
-               	leaq	(%r13), %rdx
-               	movb	%cl, (%rdx)
-               	movabsq	$-0x340d631b7bdddcdb, %rcx ## imm = 0xCBF29CE484222325
-               	imulq	%rax, %rcx
-               	addq	%rbx, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	0x8(%r13), %r15
-               	leaq	(%r15), %rax
-               	movq	%rcx, (%rax)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	movq	%r12, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	-0x68(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	(%r15), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x4bd>
-               	movsd	%xmm1, (%rcx)
-               	movq	-0x108(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	-0x70(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r14
-               	jb	 <L18>
-<L23>:
-               	leaq	-0x48(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, %rax
-               	cmpq	$0x3, %rax
-               	jb	 <L24>
-               	jmp	 <L25>
-<L24>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    ## imm = 0x100000001B3
-               	imulq	%rcx, %rdx
+               	movb	%al, %dl
+               	leaq	(%r13), %rsi
+               	movb	%dl, (%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	imulq	%rax, %rdx
                	addq	%rbx, %rdx
                	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
                	andq	%r11, %rdx
                	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
                	orq	%r11, %rdx
-               	leaq	(%r13,%rax,8), %rcx
-               	leaq	(%rcx), %rsi
+               	leaq	0x8(%r13), %rax
+               	leaq	(%rax), %rsi
                	movq	%rdx, (%rsi)
+               	leaq	(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	%r12, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	leaq	0x8(%r13), %r15
+               	leaq	-0x88(%rbp), %rax
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%rax)
+               	movq	(%rax), %rsi
+               	callq	 <L22>
+<L22>:
+               	leaq	(%r15), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x54b>
+               	movsd	%xmm1, (%rdx)
+               	leaq	(%r13), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L23>
+<L23>:
+               	leaq	0x8(%r13), %rdx
+               	leaq	-0x98(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L24>
+<L24>:
+               	addq	$0x1, %r14
+               	movq	%rax, %r12
+               	cmpq	$0x4, %r14
+               	jb	 <L19>
+<L25>:
+               	leaq	-0x40(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, %rax
+               	cmpq	$0x3, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdx
+               	addq	$0x1, %rdx
+               	movabsq	$0x100000001b3, %rsi    ## imm = 0x100000001B3
+               	imulq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movabsq	$-0x7ffffbffffe00001, %r11 ## imm = 0x80000400001FFFFF
+               	andq	%r11, %rsi
+               	movabsq	$0x3fd9999999999a00, %r11 ## imm = 0x3FD9999999999A00
+               	orq	%r11, %rsi
+               	leaq	(%r13,%rax,8), %rdx
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x3, %rax
-               	jb	 <L24>
-<L25>:
+               	jb	 <L26>
+<L27>:
                	movq	$0x0, %rbx
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-               	jmp	 <L28>
-<L26>:
+               	jb	 <L28>
+               	jmp	 <L30>
+<L28>:
                	leaq	(%r13,%rbx,8), %rax
-               	leaq	-0x50(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%r12, %rdi
-               	callq	 <L27>
-<L27>:
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %rbx
                	movq	%rax, %r12
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-<L28>:
+               	jb	 <L28>
+<L30>:
                	movq	%r12, %rax
-               	movq	-0x118(%rbp), %rbx
-               	movq	-0x120(%rbp), %r12
-               	movq	-0x128(%rbp), %r13
-               	movq	-0x130(%rbp), %r14
-               	movq	-0x138(%rbp), %r15
+               	movq	-0xe8(%rbp), %rbx
+               	movq	-0xf0(%rbp), %r12
+               	movq	-0xf8(%rbp), %r13
+               	movq	-0x100(%rbp), %r14
+               	movq	-0x108(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_i16.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_i16.dis
@@ -5,118 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_i16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movw	%di, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %edx           ## imm = 0xFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpw	$0x20, %di
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %r12w
-               	movl	$0xfff0, %ecx           ## imm = 0xFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movswq	%r12w, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpw	$0x20, %r14w
-               	jl	 <L1>
-               	jmp	 <L4>
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movswq	%r12w, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpw	$0x20, %r14w
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpw	$0x8, %r15w
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpw	$0x20, %di
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x3039, %eax, %eax     ## imm = 0x3039
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpw	$0x8, %di
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r15w
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x3039, %ebx, %ebx     ## imm = 0x3039
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movswq	%r12w, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %di
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %esi           ## imm = 0x7FFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %esi           ## imm = 0x8000
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movswq	%di, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %esi           ## imm = 0xFFFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7fff, %eax           ## imm = 0x7FFF
+               	addl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %eax           ## imm = 0x8000
+               	subl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %eax           ## imm = 0xFFFF
+               	addl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_i32.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_i32.dis
@@ -5,125 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %edx       ## imm = 0xFFFFFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x20, %edi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %r12d
-               	movl	$0xfffffff0, %ecx       ## imm = 0xFFFFFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movslq	%r12d, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpl	$0x20, %r14d
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movl	$0x0, %r15d
-               	cmpl	$0x8, %r15d
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x20, %edi
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x12345678, %eax, %eax ## imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %edi
+               	cmpl	$0x8, %edi
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r15d
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x12345678, %ebx, %ebx ## imm = 0x12345678
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %ecx
-               	subl	%r15d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %edi
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %ecx
-               	subl	%r12d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %ecx       ## imm = 0x7FFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %ecx       ## imm = 0x80000000
-               	subl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movslq	%edi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %ecx       ## imm = 0xFFFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %ecx
-               	addl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %ecx
-               	subl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movl	$0x7fffffff, %eax       ## imm = 0x7FFFFFFF
+               	addl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %eax       ## imm = 0x80000000
+               	subl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %eax       ## imm = 0xFFFFFFFF
+               	addl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_i64.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_i64.dis
@@ -5,118 +5,323 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rax
+               	addq	%r8, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	imulq	$0x7, %rbx, %rbx
+               	addq	$0x1, %rbx
                	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x20, %r14
-               	jl	 <L1>
-               	jmp	 <L4>
+               	addq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r14, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%r13, %r15
-               	addq	%rax, %r15
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	movq	%r15, %r13
-               	cmpq	$0x20, %r14
-               	jl	 <L1>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%rbx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
 <L5>:
-               	movq	%r15, %rax
-               	movabsq	$0x1234567890abcdef, %r11 ## imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r14
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r15
-               	jl	 <L5>
+               	movq	%rbx, %r12
+               	movabsq	$0x1234567890abcdef, %r11 ## imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rdx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	$0x0, %r15
-               	subq	%r13, %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0, %rsi
-               	subq	%r15, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addq	$0x1, %rbx
+               	movq	%r12, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jl	 <L6>
 <L9>:
-               	movq	$0x0, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movabsq	$0x7fffffffffffffff, %rsi ## imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movabsq	$-0x8000000000000000, %rsi ## imm = 0x8000000000000000
-               	subq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movq	$0x0, %rbx
+               	subq	%rdi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	$-0x1, %rsi
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%r13, %rsi
-               	addq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rdi
+               	subq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%r13, %rsi
-               	subq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	subq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movabsq	$0x7fffffffffffffff, %rdi ## imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rdi ## imm = 0x8000000000000000
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rdi
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rax, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	%rax, %rdi
+               	subq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	subq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rdx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_i8.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_i8.dis
@@ -5,118 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_i8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %edx
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpb	$0x20, %dil
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %r12b
-               	movl	$0xf0, %ecx
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movsbq	%r12b, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpb	$0x20, %r14b
-               	jl	 <L1>
-               	jmp	 <L4>
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movsbq	%r12b, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpb	$0x20, %r14b
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpb	$0x8, %r15b
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpb	$0x20, %dil
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x35, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpb	$0x8, %dil
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r15b
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x35, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movsbq	%r12b, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %dil
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %esi
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movsbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7f, %eax
+               	addl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %eax
+               	addl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_u16.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_u16.dis
@@ -5,118 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_u16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movw	%di, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %edx           ## imm = 0xFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpw	$0x20, %di
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %r12w
-               	movl	$0xfff0, %ecx           ## imm = 0xFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movzwq	%r12w, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpw	$0x20, %r14w
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpw	$0x20, %r14w
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movzwq	%r12w, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpw	$0x8, %r15w
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpw	$0x20, %di
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0xabcd, %eax, %eax     ## imm = 0xABCD
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpw	$0x8, %di
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r15w
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0xabcd, %ebx, %ebx     ## imm = 0xABCD
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movzwq	%r12w, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %di
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %esi           ## imm = 0x7FFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %esi           ## imm = 0x8000
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movzwq	%di, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %esi           ## imm = 0xFFFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7fff, %eax           ## imm = 0x7FFF
+               	addl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %eax           ## imm = 0x8000
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %eax           ## imm = 0xFFFF
+               	addl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_u32.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_u32.dis
@@ -5,125 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %edx       ## imm = 0xFFFFFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x20, %edi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %r12d
-               	movl	$0xfffffff0, %ecx       ## imm = 0xFFFFFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpl	$0x20, %r14d
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movl	%r12d, %eax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movl	$0x0, %r15d
-               	cmpl	$0x8, %r15d
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x20, %edi
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x12345678, %eax, %eax ## imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %edi
+               	cmpl	$0x8, %edi
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r15d
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x12345678, %ebx, %ebx ## imm = 0x12345678
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %ecx
-               	subl	%r15d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %edi
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %ecx
-               	subl	%r12d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %ecx       ## imm = 0x7FFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %ecx       ## imm = 0x80000000
-               	subl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movl	%edi, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %ecx       ## imm = 0xFFFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %ecx
-               	addl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %ecx
-               	subl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movl	$0x7fffffff, %eax       ## imm = 0x7FFFFFFF
+               	addl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %eax       ## imm = 0x80000000
+               	subl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %eax       ## imm = 0xFFFFFFFF
+               	addl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_u64.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_u64.dis
@@ -5,118 +5,323 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rax
+               	addq	%r8, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	imulq	$0x7, %rbx, %rbx
+               	addq	$0x1, %rbx
                	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x20, %r14
+               	addq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r14, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%r13, %r15
-               	addq	%rax, %r15
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	movq	%r15, %r13
-               	cmpq	$0x20, %r14
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
                	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%rbx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
 <L5>:
-               	movq	%r15, %rax
-               	movabsq	$0x1234567890abcdef, %r11 ## imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r14
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
+               	movq	%rbx, %r12
+               	movabsq	$0x1234567890abcdef, %r11 ## imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rdx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	$0x0, %r15
-               	subq	%r13, %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0, %rsi
-               	subq	%r15, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addq	$0x1, %rbx
+               	movq	%r12, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L9>:
-               	movq	$0x0, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movabsq	$0x7fffffffffffffff, %rsi ## imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movabsq	$-0x8000000000000000, %rsi ## imm = 0x8000000000000000
-               	subq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movq	$0x0, %rbx
+               	subq	%rdi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	$-0x1, %rsi
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%r13, %rsi
-               	addq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rdi
+               	subq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%r13, %rsi
-               	subq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	subq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movabsq	$0x7fffffffffffffff, %rdi ## imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rdi ## imm = 0x8000000000000000
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rdi
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rax, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	%rax, %rdi
+               	subq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	subq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rdx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/arith_u8.dis
+++ b/test/golden/x86_64-darwin/scalar/arith_u8.dis
@@ -5,118 +5,341 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.arith_u8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %edx
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpb	$0x20, %dil
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %r12b
-               	movl	$0xf0, %ecx
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movzbq	%r12b, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpb	$0x20, %r14b
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpb	$0x20, %r14b
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movzbq	%r12b, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpb	$0x8, %r15b
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpb	$0x20, %dil
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0xb5, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpb	$0x8, %dil
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r15b
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0xb5, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movzbq	%r12b, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %dil
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %esi
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7f, %eax
+               	addl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %eax
+               	addl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/divrem_i32.dis
+++ b/test/golden/x86_64-darwin/scalar/divrem_i32.dis
@@ -5,171 +5,418 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.divrem_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %r8d
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x8(%rbp)
                	movq	-0x8(%rbp), %r8
-               	movl	$0x77359400, %esi       ## imm = 0x77359400
-               	subl	%r8d, %esi
-               	movq	%rcx, %rbx
-               	movq	%rsi, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r14d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movq	-0x8(%rbp), %r8
-               	movl	%ecx, %r15d
-               	addl	%r8d, %r15d
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r15d
-               	movl	%eax, %r8d
+               	movl	$0x77359400, %edi       ## imm = 0x77359400
+               	subl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x10(%rbp)
-               	movl	%r13d, %eax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x0, %r12d
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	cltd
-               	idivl	%r15d
-               	movl	%edx, %r12d
-               	movq	%rbx, %rdi
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r15d
+               	movq	-0x20(%rbp), %r8
+               	movslq	%r8d, %rsi
                	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movslq	%r15d, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r15d, %esi
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %esi
+               	imull	%r9d, %esi
+               	addl	%r15d, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %esi
+               	subl	%r9d, %esi
+               	addl	$0x1, %r12d
+               	movq	%rbx, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x77359400, %esi       ## imm = 0x77359400
+               	addl	%r8d, %esi
+               	movl	$0x0, %edi
+               	subl	%esi, %edi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movl	$0x0, %ebx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %ebx
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movl	%ebx, %r12d
+               	imull	$0xc5, %r12d, %r12d
+               	addl	$0x5, %r12d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r12d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r14d
+               	movq	-0x40(%rbp), %r8
+               	movslq	%r8d, %r15
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r15, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+<L10>:
+               	movslq	%r14d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	movq	-0x48(%rbp), %r8
+               	movq	-0x40(%rbp), %r9
+               	movl	%r8d, %edi
+               	imull	%r9d, %edi
+               	addl	%r14d, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+<L14>:
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x48(%rbp), %r9
+               	movl	%r8d, %edi
+               	addl	%r9d, %edi
+               	addl	$0x1, %ebx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %ebx
+               	jl	 <L8>
+<L15>:
+               	movq	-0x8(%rbp), %r9
+               	movl	$0x7ffffffc, %r8d       ## imm = 0x7FFFFFFC
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x3, %edi
+               	addl	%r8d, %edi
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%edi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%edi
+               	movl	%edx, %r12d
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %r13
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+<L17>:
+               	movslq	%r12d, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x58(%rbp), %r8
+               	movl	%edi, %esi
                	imull	%r8d, %esi
                	addl	%r12d, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rbx
-               	subl	%r15d, %r13d
-               	addl	$0x1, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
-<L5>:
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x77359400, %ecx       ## imm = 0x77359400
-               	addl	%r8d, %ecx
-               	movl	$0x0, %esi
-               	subl	%ecx, %esi
-               	movl	$0x0, %r12d
-               	movq	%rsi, %r13
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movl	%r12d, %ecx
-               	imull	$0xc5, %ecx, %ecx
-               	addl	$0x5, %ecx
-               	movq	-0x8(%rbp), %r8
-               	movl	%ecx, %r14d
-               	addl	%r8d, %r14d
-               	movl	%r13d, %eax
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movl	%edi, %eax
+               	movq	-0x50(%rbp), %r8
                	cltd
-               	idivl	%r14d
-               	movl	%eax, %r15d
-               	movl	%r13d, %eax
+               	idivl	%r8d
+               	movl	%eax, %esi
+               	movl	%edi, %eax
+               	movq	-0x50(%rbp), %r8
                	cltd
-               	idivl	%r14d
-               	movl	%edx, %r8d
-               	movq	%r8, -0x18(%rbp)
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	imull	%r15d, %esi
-               	movq	-0x18(%rbp), %r8
-               	addl	%r8d, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rbx
-               	addl	%r14d, %r13d
-               	addl	$0x1, %r12d
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
-<L10>:
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x7ffffffc, %r12d      ## imm = 0x7FFFFFFC
-               	addl	%r8d, %r12d
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x3, %r13d
-               	addl	%r8d, %r13d
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%eax, %r14d
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%edx, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	addl	%r15d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%eax, %ebx
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%edx, %r13d
-               	movl	%ebx, %esi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	imull	%ebx, %r12d
-               	addl	%r13d, %r12d
-               	movl	%r12d, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	idivl	%r8d
+               	movl	%edx, %edi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movslq	%edi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+<L25>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %ebx
+               	imull	%esi, %ebx
+               	addl	%edi, %ebx
+               	movslq	%ebx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	%r14, %rax
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/divrem_i64.dis
+++ b/test/golden/x86_64-darwin/scalar/divrem_i64.dis
@@ -5,170 +5,391 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.divrem_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
                	movq	%rdi, %r8
                	movq	%r8, -0x8(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	-0x8(%rbp), %r8
                	movabsq	$0x7ce66c50e2840000, %rsi ## imm = 0x7CE66C50E2840000
                	subq	%r8, %rsi
-               	movq	%rcx, %r12
-               	movq	%rsi, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r14, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r15
-               	movq	%rax, %r8
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x10(%rbp)
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r15
-               	movq	%rdx, %rbx
-               	movq	%r12, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r15, %rsi
-               	imulq	%r8, %rsi
-               	addq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %r12
-               	subq	%r15, %r13
-               	addq	$0x1, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
-<L5>:
-               	movq	-0x8(%rbp), %r8
-               	movabsq	$0x7ce66c50e2840000, %rcx ## imm = 0x7CE66C50E2840000
-               	addq	%r8, %rcx
-               	movq	$0x0, %rsi
-               	subq	%rcx, %rsi
-               	movq	$0x0, %rbx
-               	movq	%rsi, %r13
-               	cmpq	$0x8, %rbx
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movq	%rbx, %rcx
-               	imulq	$0xc5, %rcx, %rcx
-               	addq	$0x5, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%rcx, %r14
-               	addq	%r8, %r14
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r14
-               	movq	%rax, %r15
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r14
-               	movq	%rdx, %r8
+               	movq	%rsi, %r8
                	movq	%r8, -0x18(%rbp)
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	imulq	%r15, %rsi
-               	movq	-0x18(%rbp), %r8
-               	addq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r12
-               	addq	%r14, %r13
-               	addq	$0x1, %rbx
-               	cmpq	$0x8, %rbx
-               	jl	 <L6>
-<L10>:
+               	movq	$0x0, %r12
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
                	movq	-0x8(%rbp), %r8
-               	movabsq	$0x7ffffffffffffffc, %rbx ## imm = 0x7FFFFFFFFFFFFFFC
-               	addq	%r8, %rbx
-               	movq	-0x8(%rbp), %r8
-               	movq	$0x3, %r13
                	addq	%r8, %r13
-               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
-               	movq	%rax, %r14
-               	movq	%rbx, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
                	movq	%rdx, %r15
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rcx
-               	imulq	%r14, %rcx
-               	addq	%r15, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%rbx
-               	movq	%rax, %r12
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%rbx
-               	movq	%rdx, %r13
-               	movq	%r12, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	imulq	%r12, %rbx
-               	addq	%r13, %rbx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rbx, %rsi
-               	callq	 <L16>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r15, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r15, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rsi
+               	subq	%r13, %rsi
+               	addq	$0x1, %r12
+               	movq	%rdi, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movabsq	$0x7ce66c50e2840000, %rsi ## imm = 0x7CE66C50E2840000
+               	addq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	subq	%rsi, %rdi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	$0x0, %rbx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rbx
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movq	%rbx, %r12
+               	imulq	$0xc5, %r12, %r12
+               	addq	$0x5, %r12
+               	movq	-0x8(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rax, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rdx, %r14
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+<L12>:
+               	movq	-0x38(%rbp), %r8
+               	movq	%r12, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r14, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+<L14>:
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%r12, %rsi
+               	addq	$0x1, %rbx
+               	movq	%r15, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rbx
+               	jl	 <L8>
+<L15>:
+               	movq	-0x8(%rbp), %r9
+               	movabsq	$0x7ffffffffffffffc, %r8 ## imm = 0x7FFFFFFFFFFFFFFC
+               	addq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x3, %rdi
+               	addq	%r8, %rdi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rdi
+               	movq	%rax, %rbx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rdi
+               	movq	%rdx, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%rdi, %rsi
+               	imulq	%rbx, %rsi
+               	addq	%r12, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rdi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rax, %rsi
+               	movq	%rdi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rdx, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	%rsi, %rbx
+               	addq	%rdi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/divrem_u32.dis
+++ b/test/golden/x86_64-darwin/scalar/divrem_u32.dis
@@ -5,123 +5,300 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.divrem_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	subl	%r12d, %esi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rsi, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r14d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movl	%ecx, %r15d
-               	addl	%r12d, %r15d
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%r15d
-               	movl	%eax, %r8d
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x10(%rbp)
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%r15d
-               	movl	%edx, %ebx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
                	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r15d, %esi
-               	imull	%r8d, %esi
-               	addl	%ebx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	subl	%r15d, %r13d
-               	addl	$0x1, %r14d
-               	movq	%rcx, %r8
+               	movl	$0xffffffff, %edi       ## imm = 0xFFFFFFFF
+               	subl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
                	movq	%r8, -0x8(%rbp)
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
-<L5>:
-               	movl	$0xfffffffd, %ebx       ## imm = 0xFFFFFFFD
-               	addl	%r12d, %ebx
-               	movl	$0x3, %r13d
-               	addl	%r12d, %r13d
-               	movl	%ebx, %eax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x0, %r12d
+               	cmpl	$0x10, %r12d
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x10(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
-               	movl	%eax, %r12d
-               	movl	%ebx, %eax
+               	divl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
-               	movl	%edx, %r14d
+               	divl	%r8d
+               	movl	%edx, %r15d
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %ebx
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L6>
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+<L2>:
+               	movl	%r15d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %edi
+               	imull	%r9d, %edi
+               	addl	%r15d, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %edi
+               	subl	%r9d, %edi
+               	addl	$0x1, %r12d
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jb	 <L0>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	imull	%r12d, %ecx
-               	addl	%r14d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movq	-0x10(%rbp), %r9
+               	movl	$0xfffffffd, %r8d       ## imm = 0xFFFFFFFD
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x30(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	$0x3, %edi
+               	addl	%r8d, %edi
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%edi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%edi
+               	movl	%edx, %r12d
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %r13d
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%eax, %r12d
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%edx, %r13d
-               	movl	%r12d, %esi
-               	callq	 <L9>
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L10>
+               	movl	%r12d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	imull	%r12d, %ebx
-               	addl	%r13d, %ebx
-               	movl	%ebx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x38(%rbp), %r8
+               	movl	%edi, %esi
+               	imull	%r8d, %esi
+               	addl	%r12d, %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movl	%edi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%eax, %esi
+               	movl	%edi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%edx, %edi
+               	movl	%esi, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+<L15>:
+               	movl	%edi, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %ebx
+               	imull	%esi, %ebx
+               	addl	%edi, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movq	%r14, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/divrem_u64.dis
+++ b/test/golden/x86_64-darwin/scalar/divrem_u64.dis
@@ -5,122 +5,282 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.divrem_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	$-0x1, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rsi, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r14, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %r15
-               	addq	%rbx, %r15
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r15
-               	movq	%rax, %r8
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rdi, %r8
                	movq	%r8, -0x10(%rbp)
-               	movq	%r13, %rax
+               	movq	-0x10(%rbp), %r8
+               	movq	$-0x1, %rsi
+               	subq	%r8, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x10, %r12
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
+               	movq	-0x10(%rbp), %r8
+               	addq	%r8, %r13
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	xorl	%edx, %edx
-               	divq	%r15
+               	divq	%r13
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r15
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r15, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rsi
+               	subq	%r13, %rsi
+               	addq	$0x1, %r12
+               	movq	%rbx, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jb	 <L0>
+<L7>:
+               	movq	-0x10(%rbp), %r9
+               	movq	$-0x3, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movq	$0x3, %rdi
+               	addq	%r8, %rdi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rax, %rbx
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rdi
                	movq	%rdx, %r12
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r15, %rsi
-               	imulq	%r8, %rsi
-               	addq	%r12, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	subq	%r15, %r13
-               	addq	$0x1, %r14
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
-<L5>:
-               	movq	$-0x3, %r12
-               	addq	%rbx, %r12
-               	movq	$0x3, %r13
-               	addq	%rbx, %r13
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%r13
-               	movq	%rax, %rbx
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%r13
-               	movq	%rdx, %r14
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rcx
-               	imulq	%rbx, %rcx
-               	addq	%r14, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L8>
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rax, %rbx
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rdx, %r13
-               	movq	%rbx, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rsi
-               	callq	 <L10>
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	imulq	%rbx, %r12
-               	addq	%r13, %r12
-               	movq	%r12, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	%rdi, %rsi
+               	imulq	%rbx, %rsi
+               	addq	%r12, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rax, %rsi
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rdx, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	%rsi, %rbx
+               	addq	%rdi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%r13, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/mul_i32.dis
+++ b/test/golden/x86_64-darwin/scalar/mul_i32.dis
@@ -5,79 +5,204 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.mul_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movl	$0x9e3779b9, %ecx       ## imm = 0x9E3779B9
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b9, %edx       ## imm = 0x9E3779B9
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x10, %edi
+               	jl	 <L0>
                	jmp	 <L3>
+<L0>:
+               	movl	$0x2, %ebx
+               	imull	%edi, %ebx
+               	addl	$0x3, %ebx
+               	movl	%edx, %r12d
+               	imull	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	$0x2, %eax
-               	imull	%r14d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x10, %edi
+               	jl	 <L0>
 <L3>:
-               	movl	$0xffffffbf, %r14d      ## imm = 0xFFFFFFBF
-               	addl	%r12d, %r14d
-               	movl	%r14d, %eax
-               	imull	%r14d, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L4>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %eax       ## imm = 0xFFFFFFBF
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	imull	%eax, %edi
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %ecx
-               	imull	$0xffffffff, %ecx, %ecx ## imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %edi
+               	imull	$0xffffffff, %edi, %edi ## imm = 0xFFFFFFFF
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imull	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          ## imm = 0x10001
-               	addl	%r12d, %ebx
-               	movl	%ebx, %ecx
-               	imull	%ebx, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%edx, %edi
+               	imull	%eax, %edi
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffffffff, %ebx, %ebx ## imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L9>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
+               	imull	%edx, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          ## imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movslq	%edx, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffffffff, %eax, %eax ## imm = 0xFFFFFFFF
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/mul_i64.dis
+++ b/test/golden/x86_64-darwin/scalar/mul_i64.dis
@@ -5,74 +5,192 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.mul_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx ## imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
+               	movq	%r15, -0x28(%rbp)
+               	movabsq	$-0x61c8864680b583eb, %rax ## imm = 0x9E3779B97F4A7C15
+               	addq	%rdi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r14, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %r13
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r14
+<L0>:
+               	movq	$0x2, %rbx
+               	imulq	%rsi, %rbx
+               	addq	$0x3, %rbx
                	movq	%rax, %r12
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
+               	imulq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
 <L3>:
-               	movq	$-0x3f, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rsi
-               	imulq	%r14, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L4>
+               	movq	$-0x3f, %rsi
+               	addq	%rdi, %rsi
+               	movq	%rsi, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r14, %rsi
-               	imulq	$-0x1, %rsi, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
 <L5>:
-               	movq	%r13, %rsi
-               	imulq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rsi, %rbx
+               	imulq	$-0x1, %rbx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imulq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %r12      ## imm = 0x10000000F
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	imulq	%r12, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rax, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imulq	$-0x1, %r12, %r12
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rax      ## imm = 0x10000000F
+               	addq	%rdi, %rax
+               	movq	%rax, %rsi
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	imulq	$-0x1, %rax, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/mul_u32.dis
+++ b/test/golden/x86_64-darwin/scalar/mul_u32.dis
@@ -5,79 +5,204 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.mul_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movl	$0x9e3779b1, %ecx       ## imm = 0x9E3779B1
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b1, %edx       ## imm = 0x9E3779B1
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi ## imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x10, %edi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	$0x2, %eax
-               	imull	%r14d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r14d
+<L0>:
+               	movl	$0x2, %ebx
+               	imull	%edi, %ebx
+               	addl	$0x3, %ebx
+               	movl	%edx, %r12d
+               	imull	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x10, %edi
+               	jb	 <L0>
 <L3>:
-               	movl	$0xffffffbf, %r14d      ## imm = 0xFFFFFFBF
-               	addl	%r12d, %r14d
-               	movl	%r14d, %eax
-               	imull	%r14d, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L4>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %eax       ## imm = 0xFFFFFFBF
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	imull	%eax, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %ecx
-               	imull	$0xffffffff, %ecx, %ecx ## imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %edi
+               	imull	$0xffffffff, %edi, %edi ## imm = 0xFFFFFFFF
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imull	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          ## imm = 0x10001
-               	addl	%r12d, %ebx
-               	movl	%ebx, %ecx
-               	imull	%ebx, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%edx, %edi
+               	imull	%eax, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffff, %ebx, %ebx     ## imm = 0xFFFF
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L9>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
+               	imull	%edx, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          ## imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movl	%edx, %edi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffff, %eax, %eax     ## imm = 0xFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/scalar/mul_u64.dis
+++ b/test/golden/x86_64-darwin/scalar/mul_u64.dis
@@ -5,75 +5,193 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.scalar.mul_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx ## imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
+               	movq	%r15, -0x28(%rbp)
+               	movabsq	$-0x61c8864680b583eb, %rax ## imm = 0x9E3779B97F4A7C15
+               	addq	%rdi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r14, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %r13
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r14
+<L0>:
+               	movq	$0x2, %rbx
+               	imulq	%rsi, %rbx
+               	addq	$0x3, %rbx
                	movq	%rax, %r12
-               	cmpq	$0x10, %r14
+               	imulq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
 <L3>:
-               	movq	$-0x3f, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rsi
-               	imulq	%r14, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L4>
+               	movq	$-0x3f, %rsi
+               	addq	%rdi, %rsi
+               	movq	%rsi, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r14, %rsi
-               	imulq	$-0x1, %rsi, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
 <L5>:
-               	movq	%r13, %rsi
-               	imulq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rsi, %rbx
+               	imulq	$-0x1, %rbx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imulq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %r12      ## imm = 0x10000000F
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	imulq	%r12, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rax, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
-               	imulq	%r11, %r12
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rax      ## imm = 0x10000000F
+               	addq	%rdi, %rax
+               	movq	%rax, %rsi
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	movabsq	$0xffffffff, %r11       ## imm = 0xFFFFFFFF
+               	imulq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/autovec_loop.dis
+++ b/test/golden/x86_64-darwin/vec/autovec_loop.dis
@@ -5,749 +5,929 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x9b0, %rsp            ## imm = 0x9B0
-               	movq	%rbx, -0x988(%rbp)
-               	movq	%r12, -0x990(%rbp)
-               	movq	%r13, -0x998(%rbp)
-               	movq	%r14, -0x9a0(%rbp)
-               	movq	%r15, -0x9a8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8a0(%rbp)
-               	movq	-0x8a0(%rbp), %r8
-               	movq	%rbx, %rsi
+               	subq	$0x940, %rsp            ## imm = 0x940
+               	movq	%rbx, -0x918(%rbp)
+               	movq	%r12, -0x920(%rbp)
+               	movq	%r13, -0x928(%rbp)
+               	movq	%r14, -0x930(%rbp)
+               	movq	%r15, -0x938(%rbp)
+               	movq	%rdi, %rsi
                	andq	$0x1, %rsi
-               	movq	$0x43, %r12
-               	subq	%rsi, %r12
-               	movq	$0x25, %r13
-               	subq	%rsi, %r13
-               	movl	%ebx, %r8d
-               	movq	%r8, -0x8a8(%rbp)
-               	movq	%rbx, %r11
+               	movq	$0x43, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	$0x25, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movl	%edi, %esi
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jl	 <L0>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x960(%rbp)
-               	leaq	-0x10c(%rbp), %rbx
-               	leaq	(%rbx), %rdi
-               	addq	$0x0, %rdi
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x680(%rbp), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	addq	$0x0, %r13
                	movq	$0x108, %r14            ## imm = 0x108
-<L3>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
+<L2>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L3>
-               	movl	$0x0, (%rdi)
-               	leaq	-0x218(%rbp), %r14
-               	leaq	(%r14), %rdi
-               	addq	$0x0, %rdi
+               	jne	 <L2>
+               	movl	$0x0, (%r13)
+               	leaq	-0x78c(%rbp), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	addq	$0x0, %r14
                	movq	$0x108, %r15            ## imm = 0x108
-<L4>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
+<L3>:
+               	movq	$0x0, (%r14)
+               	addq	$0x8, %r14
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L4>
+               	jne	 <L3>
+               	movl	$0x0, (%r14)
+               	movq	$0x0, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movl	%r14d, %r15d
+               	movl	%r15d, %edi
+               	imull	$0x9e3779b1, %edi, %edi ## imm = 0x9E3779B1
+               	addl	$0x3039, %edi           ## imm = 0x3039
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%edi, (%r13)
+               	imull	$0x9e37, %r15d, %r15d   ## imm = 0x9E37
+               	movl	$0xffffffff, %edi       ## imm = 0xFFFFFFFF
+               	subl	%r15d, %edi
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%edi, (%r13)
+               	addq	$0x1, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	(%rdi), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rdi)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movl	(%rdi), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rdi)
+               	leaq	-0x10c(%rbp), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %r13            ## imm = 0x108
+<L6>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L6>
                	movl	$0x0, (%rdi)
                	movq	$0x0, %rdi
-               	cmpq	%r12, %rdi
-               	jb	 <L5>
-               	jmp	 <L6>
-<L5>:
-               	movl	%edi, %r15d
-               	movl	%r15d, %ecx
-               	imull	$0x9e3779b1, %ecx, %ecx ## imm = 0x9E3779B1
-               	addl	$0x3039, %ecx           ## imm = 0x3039
-               	leaq	(%rbx,%rdi,4), %rsi
-               	movl	%ecx, (%rsi)
-               	imull	$0x9e37, %r15d, %r15d   ## imm = 0x9E37
-               	movl	$0xffffffff, %ecx       ## imm = 0xFFFFFFFF
-               	subl	%r15d, %ecx
-               	leaq	(%r14,%rdi,4), %rsi
-               	movl	%ecx, (%rsi)
-               	addq	$0x1, %rdi
-               	cmpq	%r12, %rdi
-               	jb	 <L5>
-<L6>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	-0x324(%rbp), %r8
-               	movq	%r8, -0x8b8(%rbp)
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            ## imm = 0x108
-<L7>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L7>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L8>
-               	jmp	 <L9>
-<L8>:
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
-               	movl	(%rsi), %edi
-               	imull	$0x3, %edi, %edi
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rsi
-               	movl	(%rsi), %ecx
-               	addl	%ecx, %edi
-               	movq	-0x8b8(%rbp), %r8
-               	movq	-0x8b0(%rbp), %r9
-               	leaq	(%r8,%r9,4), %rcx
-               	movl	%edi, (%rcx)
-               	movq	-0x8b0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L8>
-<L9>:
-               	movq	-0x8a0(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x968(%rbp)
-               	movq	$0x0, %r15
-               	cmpq	%r12, %r15
-               	jb	 <L10>
-               	jmp	 <L12>
-<L10>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%r15,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x968(%rbp), %r8
-               	movq	%r8, %rdi
                	movq	-0x8c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x968(%rbp)
-               	cmpq	%r12, %r15
+               	cmpq	%r8, %rdi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	(%r13), %r14d
+               	imull	$0x3, %r14d, %r14d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	(%r13), %r15d
+               	addl	%r15d, %r14d
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	%r14d, (%r13)
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L7>
+<L8>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
+               	jmp	 <L12>
+<L9>:
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r14d
+               	movq	%rdi, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %rbx
+               	xorq	%r12, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
 <L12>:
                	movq	$0x0, %rsi
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	cmpq	%r12, %rsi
+               	movl	$0x0, %ebx
+               	movl	$0x0, %r12d
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
                	jb	 <L13>
                	jmp	 <L14>
 <L13>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%rsi,4), %rdi
-               	movl	(%rdi), %r15d
-               	movq	-0x8d0(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r15d, %r8d
-               	movq	%r8, -0x8d8(%rbp)
-               	leaq	(%rbx,%rsi,4), %r15
-               	movl	(%r15), %edi
-               	movq	-0x8c8(%rbp), %r8
-               	movl	%r8d, %r15d
-               	xorl	%edi, %r15d
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r14d
+               	addl	%r14d, %ebx
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r14d
+               	xorl	%r14d, %r12d
                	addq	$0x1, %rsi
-               	movq	-0x8d8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x8d0(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x8c8(%rbp)
-               	cmpq	%r12, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
                	jb	 <L13>
 <L14>:
-               	movq	-0x968(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x8d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L15>
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x8c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
 <L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8e0(%rbp)
-               	movq	-0x8e0(%rbp), %r8
-               	leaq	-0x430(%rbp), %r15
-               	leaq	(%r15), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x108, %rdi            ## imm = 0x108
+               	movl	%r12d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L17>
-               	movl	$0x0, (%rsi)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L18>
-               	jmp	 <L21>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
 <L18>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rdi
-               	movl	(%rdi), %ecx
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdi
-               	movl	(%rdi), %esi
-               	cmpl	%ecx, %esi
-               	jb	 <L19>
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %edi
-               	subl	%edi, %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
-               	jmp	 <L20>
+               	leaq	-0x898(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x108, %r12            ## imm = 0x108
 <L19>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	(%rcx), %edi
-               	subl	%edi, %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L19>
+               	movl	$0x0, (%rbx)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L20>
+               	jmp	 <L23>
 <L20>:
-               	movq	-0x8e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L18>
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r13d, %r14d
+               	jb	 <L21>
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	%r13d, (%r12)
+               	jmp	 <L22>
 <L21>:
-               	movq	-0x8e0(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r8
-               	movq	%r8, -0x970(%rbp)
-               	movq	-0x970(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L22>
-               	jmp	 <L24>
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	%r13d, (%r12)
 <L22>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8f0(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x8f0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L23>
+               	addq	$0x1, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L20>
 <L23>:
-               	movq	%rax, %r14
-               	movq	-0x970(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x970(%rbp)
-               	movq	-0x970(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L22>
-<L24>:
-               	leaq	-0x53c(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            ## imm = 0x108
-<L25>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L25>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L26>
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L24>
                	jmp	 <L27>
+<L24>:
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
 <L26>:
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	$0xaaaaaaaa, (%rsi)     ## imm = 0xAAAAAAAA
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L26>
+               	addq	$0x1, %rbx
+               	movq	%r13, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L24>
 <L27>:
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L28>
-               	jmp	 <L29>
+               	leaq	-0x218(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %rbx            ## imm = 0x108
 <L28>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%rcx,4), %rsi
-               	movl	(%rsi), %edi
-               	xorl	$0x1, %edi
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	%edi, (%rsi)
-               	addq	$0x2, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L28>
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L28>
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L29>
+               	jmp	 <L30>
 <L29>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x978(%rbp)
-               	movq	-0x978(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L30>
-               	jmp	 <L32>
+               	leaq	(%rsi,%rdi,4), %rbx
+               	movl	$0xaaaaaaaa, (%rbx)     ## imm = 0xAAAAAAAA
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L29>
 <L30>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8f8(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x8f8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L31>
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L31>
+               	jmp	 <L32>
 <L31>:
-               	movq	%rax, %r14
-               	movq	-0x978(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x978(%rbp)
-               	movq	-0x978(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L30>
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movl	(%rbx), %r12d
+               	xorl	$0x1, %r12d
+               	leaq	(%rsi,%rdi,4), %rbx
+               	movl	%r12d, (%rbx)
+               	addq	$0x2, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L31>
 <L32>:
-               	leaq	-0x648(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            ## imm = 0x108
+               	movq	-0x8c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L33>
+               	jmp	 <L36>
 <L33>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L33>
-               	movl	$0x0, (%rcx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	leaq	(%r15), %rcx
-               	movl	%esi, (%rcx)
-               	movq	$0x1, %r8
-               	movq	%r8, -0x900(%rbp)
-               	movq	-0x900(%rbp), %r8
-               	cmpq	%r12, %r8
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L34>
                	jmp	 <L35>
 <L34>:
-               	movq	-0x900(%rbp), %r8
-               	movq	%r8, %rsi
-               	subq	$0x1, %rsi
-               	leaq	(%r15,%rsi,4), %rdi
-               	movl	(%rdi), %esi
-               	imull	$0x1f, %esi, %esi
-               	movq	-0x900(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rdi
-               	movl	(%rdi), %ecx
-               	addl	%ecx, %esi
-               	movq	-0x900(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
-               	movq	-0x900(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x900(%rbp)
-               	movq	-0x900(%rbp), %r8
-               	cmpq	%r12, %r8
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L34>
 <L35>:
-               	movq	$0x0, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L36>
-               	jmp	 <L38>
-<L36>:
-               	leaq	(%r15,%rbx,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r14, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
                	addq	$0x1, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L36>
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L33>
+<L36>:
+               	leaq	-0x324(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %rbx            ## imm = 0x108
+<L37>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L37>
+               	movl	$0x0, (%rdi)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	(%rdi), %ebx
+               	leaq	(%rsi), %rdi
+               	movl	%ebx, (%rdi)
+               	movq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	leaq	-0x6dc(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
+               	movq	%rdi, %rbx
+               	subq	$0x1, %rbx
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %ebx
+               	imull	$0x1f, %ebx, %ebx
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	addl	%r13d, %ebx
+               	leaq	(%rsi,%rdi,4), %r12
+               	movl	%ebx, (%r12)
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L38>
 <L39>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L39>
-               	movl	$0x0, (%rcx)
-               	leaq	-0x770(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L40>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L40>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L42>
-               	cvtsi2ss	%r11, %xmm1
+               	movq	-0x8d0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L40>
                	jmp	 <L43>
+<L40>:
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
 <L42>:
+               	addq	$0x1, %rbx
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L40>
+<L43>:
+               	leaq	-0x3b8(%rbp), %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x90, %rbx
+<L44>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L44>
+               	movl	$0x0, (%rdi)
+               	leaq	-0x44c(%rbp), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x90, %r12
+<L45>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L45>
+               	movl	$0x0, (%rbx)
+               	movq	$0x0, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L46>
+               	jmp	 <L49>
+<L46>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L47>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L48>
+<L47>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L43>:
+<L48>:
                	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	-0x960(%rbp), %xmm2
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0x7ac>
+               	addss	%xmm0, %xmm2
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movss	%xmm2, (%r12)
+               	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0x92a>
                	subss	%xmm1, %xmm2
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L41>
-<L44>:
-               	leaq	-0x804(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L45>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L45>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r13
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x908(%rbp)
-               	leaq	(%rbx), %rsi
-               	leaq	(%rbx,%r13,4), %rdi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x920(%rbp)
-               	leaq	(%r12,%r13,4), %r8
-               	movq	%r8, -0x910(%rbp)
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x918(%rbp)
-               	leaq	(%r15,%r13,4), %rcx
-               	cmpq	%rsi, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x928(%rbp)
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%r8, %rdi
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x928(%rbp), %r8
-               	movl	%r8d, %edi
-               	orl	%esi, %edi
-               	movq	-0x920(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x910(%rbp), %r8
-               	movq	-0x918(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %esi
-               	andl	%esi, %edi
-               	movq	-0x908(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%edi, %ecx
-               	testb	%cl, %cl
-               	jne	 <L47>
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movss	%xmm2, (%r12)
+               	addq	$0x1, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
                	jb	 <L46>
-               	jmp	 <L51>
-<L46>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+<L49>:
+               	leaq	-0x4e0(%rbp), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0x90, %r13
+<L50>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L50>
+               	movl	$0x0, (%r12)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	movl	%r12d, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movq	-0x8f0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rbx
+               	cmpq	%r13, %rbx
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rdi, %r14
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	orl	%r13d, %r12d
+               	cmpq	%r15, %rbx
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	cmpq	%rdi, %rsi
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	orl	%ebx, %r13d
+               	andl	%r13d, %r12d
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%r12d, %esi
+               	testb	%sil, %sil
+               	jne	 <L52>
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L51>
+               	jmp	 <L56>
+<L51>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L46>
-               	jmp	 <L51>
-<L47>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L48>
-               	jmp	 <L49>
-<L48>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movups	(%rsi), %xmm1
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L51>
+               	jmp	 <L56>
+<L52>:
+               	movq	$0x0, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L53>
+               	jmp	 <L54>
+<L53>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%r15,%rcx,4), %rsi
-               	movups	%xmm0, (%rsi)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %rsi
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	%xmm0, (%rdi)
                	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L48>
-<L49>:
-               	cmpq	%r13, %rcx
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L53>
+<L54>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L55>
+               	jmp	 <L56>
+<L55>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L50>
-<L51>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x980(%rbp)
-               	movq	-0x980(%rbp), %r8
-               	cmpq	%r13, %r8
-               	jb	 <L52>
-               	jmp	 <L54>
-<L52>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r14, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r14
-               	movq	-0x980(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x980(%rbp)
-               	movq	-0x980(%rbp), %r8
-               	cmpq	%r13, %r8
-               	jb	 <L52>
-<L54>:
-               	leaq	-0x898(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L55>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L55>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r13
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x930(%rbp)
-               	leaq	(%rbx), %rsi
-               	leaq	(%rbx,%r13,4), %rdi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x948(%rbp)
-               	leaq	(%r12,%r13,4), %r8
-               	movq	%r8, -0x938(%rbp)
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x940(%rbp)
-               	leaq	(%r15,%r13,4), %rcx
-               	cmpq	%rsi, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x950(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	cmpq	%r8, %rdi
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x950(%rbp), %r8
-               	movl	%r8d, %edi
-               	orl	%esi, %edi
-               	movq	-0x948(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x938(%rbp), %r8
-               	movq	-0x940(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %esi
-               	andl	%esi, %edi
-               	movq	-0x930(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%edi, %ecx
-               	testb	%cl, %cl
-               	jne	 <L57>
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L55>
 <L56>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	$0x0, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L57>
+               	jmp	 <L60>
 <L57>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L58>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r12d
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
                	jmp	 <L59>
 <L58>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movups	(%rsi), %xmm1
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
+<L59>:
+               	addq	$0x1, %rdi
+               	movq	%rbx, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L57>
+<L60>:
+               	leaq	-0x574(%rbp), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x90, %r12
+<L61>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L61>
+               	movl	$0x0, (%rbx)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	andl	$0x1, %ebx
+               	andl	$0x1, %ebx
+               	andl	$0x1, %ebx
+               	movl	%ebx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x910(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r13
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r15
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	-0x908(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rdi
+               	cmpq	%r12, %rdi
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	cmpq	%rsi, %r13
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	orl	%r12d, %ebx
+               	cmpq	%r14, %rdi
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rsi, %r15
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %r12d
+               	andl	%r12d, %ebx
+               	movq	-0x910(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ebx, %esi
+               	testb	%sil, %sil
+               	jne	 <L63>
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L62>
+               	jmp	 <L67>
+<L62>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L62>
+               	jmp	 <L67>
+<L63>:
+               	movq	$0x0, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movups	%xmm2, (%rsi)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %rsi
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	%xmm2, (%rdi)
                	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L58>
-<L59>:
-               	cmpq	%r13, %rcx
-               	jb	 <L60>
-               	jmp	 <L61>
-<L60>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L64>
+<L65>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L66>
+               	jmp	 <L67>
+<L66>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L60>
-<L61>:
-               	movq	$0x0, %rbx
-               	cmpq	%r13, %rbx
-               	jb	 <L62>
-               	jmp	 <L64>
-<L62>:
-               	leaq	(%r15,%rbx,4), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r14, %rdi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r14
-               	addq	$0x1, %rbx
-               	cmpq	%r13, %rbx
-               	jb	 <L62>
-<L64>:
-               	movq	$0x0, %rcx
-               	xorps	%xmm0, %xmm0
-               	cmpq	%r13, %rcx
-               	jb	 <L65>
-               	jmp	 <L66>
-<L65>:
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
-               	addss	%xmm1, %xmm0
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L65>
-<L66>:
-               	movq	%r14, %rdi
-               	callq	 <L67>
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L66>
 <L67>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x988(%rbp), %rbx
-               	movq	-0x990(%rbp), %r12
-               	movq	-0x998(%rbp), %r13
-               	movq	-0x9a0(%rbp), %r14
-               	movq	-0x9a8(%rbp), %r15
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r12d
+               	movq	%rsi, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rdi
+               	movq	%rbx, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L68>
+<L71>:
+               	movq	$0x0, %rdi
+               	xorps	%xmm0, %xmm0
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm1
+               	addss	%xmm1, %xmm0
+               	addq	$0x1, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L72>
+<L73>:
+               	movd	%xmm0, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L74>
+<L75>:
+               	movq	%rsi, %rax
+               	movq	-0x918(%rbp), %rbx
+               	movq	-0x920(%rbp), %r12
+               	movq	-0x928(%rbp), %r13
+               	movq	-0x930(%rbp), %r14
+               	movq	-0x938(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-darwin/vec/vec_cmp_i64.dis
@@ -7,18 +7,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -28,18 +66,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,787 +123,624 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x510, %rsp            ## imm = 0x510
-               	movq	%rbx, -0x4e8(%rbp)
-               	movq	%r12, -0x4f0(%rbp)
-               	movq	%r13, -0x4f8(%rbp)
-               	movq	%r14, -0x500(%rbp)
-               	movq	%r15, -0x508(%rbp)
+               	subq	$0x400, %rsp            ## imm = 0x400
+               	movq	%rbx, -0x3d8(%rbp)
+               	movq	%r12, -0x3e0(%rbp)
+               	movq	%r13, -0x3e8(%rbp)
+               	movq	%r14, -0x3f0(%rbp)
+               	movq	%r15, -0x3f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	leaq	-0x230(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x60, %rdx
 <L0>:
-               	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L0>
+               	leaq	-0x290(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L1>
-               	leaq	-0xc0(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L2>
-               	leaq	-0xd0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xf0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x110(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x120(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x130(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x140(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x150(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x200000000, %r11      ## imm = 0x200000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x170(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x10a, (%rdx)          ## imm = 0x10A
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x180(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0xa, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L3>
-               	jmp	 <L18>
-<L3>:
-               	movq	%r15, %rax
-               	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	movq	%r15, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
-               	addq	%rbx, %rax
-               	leaq	-0x1b0(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movq	%rax, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x1c0(%rbp), %rax
-               	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x1d0(%rbp), %r8
-               	movq	%r8, -0x428(%rbp)
-               	movq	-0x428(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x428(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x428(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L5>
-<L5>:
-               	movaps	-0x440(%rbp), %xmm15
-               	pxor	-0x450(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpgtd	-0x450(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpeqd	-0x450(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpgtd	-0x450(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x370(%rbp), %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x458(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	-0x458(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
-               	movaps	-0x440(%rbp), %xmm15
-               	pxor	-0x450(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpgtd	-0x450(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpeqd	-0x450(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpgtd	-0x450(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x390(%rbp), %r8
-               	movq	%r8, -0x460(%rbp)
-               	movq	-0x460(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x460(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	movq	-0x460(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3b0(%rbp), %r8
-               	movq	%r8, -0x468(%rbp)
-               	movq	-0x468(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x468(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	-0x468(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3d0(%rbp), %r8
-               	movq	%r8, -0x470(%rbp)
-               	movq	-0x470(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x470(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movq	-0x470(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3f0(%rbp), %r8
-               	movq	%r8, -0x478(%rbp)
-               	movq	-0x478(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x478(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	movq	-0x478(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x440(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x450(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x410(%rbp), %r8
-               	movq	%r8, -0x480(%rbp)
-               	movq	-0x480(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x480(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movq	-0x480(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x6, %r15
-               	jb	 <L3>
-<L18>:
-               	leaq	-0x220(%rbp), %r12
-               	leaq	(%r12), %rax
-               	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L19>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L19>
-               	leaq	-0x270(%rbp), %r13
-               	leaq	(%r13), %rax
-               	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L20>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L20>
-               	leaq	-0x280(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	(%r12), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	-0x290(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	(%r13), %rax
-               	movups	%xmm0, (%rax)
                	leaq	-0x2a0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x100000001, %r11      ## imm = 0x100000001
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2b0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2c0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2b0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2c0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x2e0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2d0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x2f0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2e0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rcx)
+               	leaq	-0x300(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2f0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
-               	movq	%r11, (%rcx)
+               	leaq	-0x310(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x300(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x10a, (%rcx)          ## imm = 0x10A
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x320(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x200000000, %r11      ## imm = 0x200000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x310(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0xa, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x330(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x340(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x10a, (%rdx)          ## imm = 0x10A
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x350(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r14 ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L2>
+               	jmp	 <L13>
+<L2>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r13,%rdx), %rsi
+               	movups	(%rsi), %xmm1
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x30(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x40(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pxor	-0x390(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpgtd	-0x390(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpeqd	-0x390(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, -0x380(%rbp)
+               	movq	%r14, %rdi
+               	movups	-0x380(%rbp), %xmm0
+               	callq	 <L3>
+<L3>:
+               	movaps	-0x390(%rbp), %xmm15
+               	pxor	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpgtd	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpeqd	-0x3a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
+               	movaps	-0x390(%rbp), %xmm15
+               	pxor	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpgtd	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpeqd	-0x3a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pxor	-0x390(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpgtd	-0x390(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpeqd	-0x390(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x380(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm0, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x360(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x360(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	-0x360(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x6, %r15
+               	jb	 <L2>
+<L13>:
+               	leaq	-0xa0(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rdx
+<L14>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L14>
+               	leaq	-0xf0(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rdx
+<L15>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L15>
+               	leaq	-0x100(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x110(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x120(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x130(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x140(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x150(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x160(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x170(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x180(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x10a, (%rdx)          ## imm = 0x10A
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%r13), %rax
                	movups	%xmm0, (%rax)
                	movq	$0x0, %r15
                	cmpq	$0x5, %r15
-               	jb	 <L21>
-               	jmp	 <L36>
-<L21>:
+               	jb	 <L16>
+               	jmp	 <L24>
+<L16>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rax
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	movq	%r15, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
+               	movq	%r15, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r13,%rdx), %rsi
+               	movups	(%rsi), %xmm1
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
                	addq	%rbx, %rax
-               	leaq	-0x340(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movq	%rax, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x350(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
                	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x4b0(%rbp)
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
+               	movups	%xmm14, -0x3d0(%rbp)
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pxor	-0x3c0(%rbp), %xmm15
                	pxor	%xmm14, %xmm14
                	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpgtd	-0x3c0(%rbp), %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpeqd	-0x3c0(%rbp), %xmm15
                	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
                	pand	%xmm14, %xmm15
                	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
                	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
                	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x360(%rbp), %r8
-               	movq	%r8, -0x488(%rbp)
-               	movq	-0x488(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x488(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%r14, %rdi
+               	movups	-0x3b0(%rbp), %xmm0
+               	callq	 <L17>
+<L17>:
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pxor	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpgtd	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpeqd	-0x3d0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pxor	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpgtd	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpeqd	-0x3d0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pxor	-0x3c0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpgtd	-0x3c0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpeqd	-0x3c0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pcmpeqd	-0x3d0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L21>
+<L21>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pcmpeqd	-0x3d0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x3d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm0, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movq	-0x488(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
                	callq	 <L23>
 <L23>:
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pxor	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpgtd	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpeqd	-0x4b0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x380(%rbp), %r8
-               	movq	%r8, -0x4b8(%rbp)
-               	movq	-0x4b8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4b8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x4b8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pxor	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpgtd	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpeqd	-0x4b0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3a0(%rbp), %r8
-               	movq	%r8, -0x4c0(%rbp)
-               	movq	-0x4c0(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4c0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0x4c0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3c0(%rbp), %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	movq	-0x4c8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4c8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0x4c8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqd	-0x4b0(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3e0(%rbp), %r8
-               	movq	%r8, -0x4d0(%rbp)
-               	movq	-0x4d0(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x4d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqd	-0x4b0(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x400(%rbp), %r8
-               	movq	%r8, -0x4d8(%rbp)
-               	movq	-0x4d8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0x4d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x4b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x420(%rbp), %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	movq	-0x4e0(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x4e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0x4e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x5, %r15
-               	jb	 <L21>
-<L36>:
+               	jb	 <L16>
+<L24>:
                	movq	%r14, %rax
-               	movq	-0x4e8(%rbp), %rbx
-               	movq	-0x4f0(%rbp), %r12
-               	movq	-0x4f8(%rbp), %r13
-               	movq	-0x500(%rbp), %r14
-               	movq	-0x508(%rbp), %r15
+               	movq	-0x3d8(%rbp), %rbx
+               	movq	-0x3e0(%rbp), %r12
+               	movq	-0x3e8(%rbp), %r13
+               	movq	-0x3f0(%rbp), %r14
+               	movq	-0x3f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-darwin/vec/vec_cmp_select.dis
@@ -7,88 +7,380 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -100,43 +392,51 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	leaq	(%rbx), %rax
+               	movzwl	(%rax), %ecx
+               	movzwq	%cx, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
                	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rdi
                	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
                	movq	-0x18(%rbp), %rbx
@@ -151,27 +451,27 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
                	movq	-0x18(%rbp), %rbx
@@ -207,23 +507,31 @@ Disassembly of section __TEXT,__text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
                	movq	-0x18(%rbp), %rbx
@@ -234,171 +542,169 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x510, %rsp            ## imm = 0x510
-               	movq	%rbx, -0x4e8(%rbp)
-               	movq	%r12, -0x4f0(%rbp)
-               	movq	%r13, -0x4f8(%rbp)
-               	movq	%r14, -0x500(%rbp)
-               	movq	%r15, -0x508(%rbp)
+               	subq	$0x4a0, %rsp            ## imm = 0x4A0
+               	movq	%rbx, -0x478(%rbp)
+               	movq	%r12, -0x480(%rbp)
+               	movq	%r13, -0x488(%rbp)
+               	movq	%r14, -0x490(%rbp)
+               	movq	%r15, -0x498(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	movl	%ebx, %r12d
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x3d0(%rbp)
+<L1>:
+               	movss	%xmm14, -0x350(%rbp)
                	movw	%bx, %r13w
                	movb	%bl, %r14b
-               	leaq	-0x10(%rbp), %rcx
+               	leaq	-0x10(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movl	$0xa, (%rcx)
+               	leaq	0x4(%rax), %rcx
+               	movl	$0x14, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movl	$0x1e, (%rcx)
+               	leaq	0xc(%rax), %rcx
+               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
+               	movups	(%rax), %xmm1
+               	leaq	-0x20(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	-0x30(%rbp), %rcx
                	leaq	(%rcx), %rdx
-               	movl	$0xa, (%rdx)
+               	movl	$0x14, (%rdx)
                	leaq	0x4(%rcx), %rdx
                	movl	$0x14, (%rdx)
                	leaq	0x8(%rcx), %rdx
-               	movl	$0x1e, (%rdx)
+               	movl	$0xa, (%rdx)
                	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movl	$0x14, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movl	$0x14, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movl	$0xa, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movl	$0x1, (%rsi)
-               	movups	(%rdx), %xmm2
-               	leaq	-0x40(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x50(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	(%rsi), %rdi
-               	movl	%ecx, (%rdi)
-               	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	leaq	0xc(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	addl	%r12d, %edx
-               	leaq	-0x60(%rbp), %rcx
+               	movl	$0x1, (%rdx)
+               	movups	(%rcx), %xmm2
+               	leaq	-0x40(%rbp), %rcx
                	movups	%xmm2, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	addl	%r12d, %eax
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	%eax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x360(%rbp)
+               	leaq	0xc(%rcx), %rax
+               	movl	(%rax), %ecx
+               	addl	%r12d, %ecx
+               	leaq	-0x60(%rbp), %rax
+               	movups	%xmm2, (%rax)
+               	leaq	0xc(%rax), %rdx
+               	movl	%ecx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x370(%rbp)
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x70(%rbp), %r15
                	movups	%xmm3, (%r15)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
+               	leaq	(%r15), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3f0(%rbp), %xmm14
+               	movaps	-0x370(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3e0(%rbp), %xmm15
+               	pxor	-0x360(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x80(%rbp), %r15
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	pcmpeqd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x360(%rbp), %xmm14
+               	pcmpeqd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x90(%rbp), %r15
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L11>
+<L11>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
+               	movq	%rax, %rdi
+               	callq	 <L12>
+<L12>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	pcmpeqd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x360(%rbp), %xmm14
+               	pcmpeqd	-0x370(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -406,33 +712,33 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -441,33 +747,33 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
+               	movq	%rax, %rdi
+               	callq	 <L20>
+<L20>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
+               	movq	%rax, %rdi
+               	callq	 <L21>
+<L21>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3f0(%rbp), %xmm14
+               	movaps	-0x370(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3e0(%rbp), %xmm15
+               	pxor	-0x360(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -476,44 +782,44 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
+               	movq	%rax, %rdi
+               	callq	 <L22>
+<L22>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
+               	movq	%rax, %rdi
+               	callq	 <L23>
+<L23>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
-               	movaps	%xmm15, -0x400(%rbp)
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x3e0(%rbp), %xmm14
+               	movaps	%xmm15, -0x380(%rbp)
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x3f0(%rbp), %xmm14
+               	pand	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -522,37 +828,37 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x3e0(%rbp), %xmm14
+               	pand	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -561,66 +867,66 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movaps	-0x360(%rbp), %xmm14
+               	paddd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pand	%xmm4, %xmm14
                	movaps	%xmm14, %xmm5
                	leaq	-0xf0(%rbp), %r15
                	movups	%xmm5, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	movaps	-0x400(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L37>
+<L37>:
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x3e0(%rbp), %xmm14
-               	psubd	-0x3f0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
+               	psubd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
                	movaps	%xmm4, %xmm14
                	por	%xmm1, %xmm14
@@ -629,28 +935,28 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L41>
-<L41>:
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
                	leaq	-0x110(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
@@ -683,7 +989,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -692,96 +998,96 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x420(%rbp)
-               	movaps	-0x420(%rbp), %xmm14
-               	pcmpgtd	-0x410(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x170(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L43>
-<L43>:
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L44>
-<L44>:
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L45>
-<L45>:
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpgtd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x180(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L47>
-<L47>:
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x190(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
+               	movq	%rax, %rdi
+               	callq	 <L51>
+<L51>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -789,30 +1095,30 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpgtd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -820,30 +1126,30 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	movaps	-0x420(%rbp), %xmm14
-               	pcmpgtd	-0x410(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -851,39 +1157,39 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	leaq	-0x1d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     ## imm = 0x3FC00000
                	xorps	%xmm1, %xmm1
-               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x95c>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x95e>
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm1, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40400000, (%rdx)     ## imm = 0x40400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x976>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x97d>
+               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x978>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x97f>
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm1, (%rdx)
                	movups	(%rcx), %xmm1
@@ -896,202 +1202,111 @@ Disassembly of section __TEXT,__text:
                	movl	$0x0, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movl	$0x40400000, (%rsi)     ## imm = 0x40400000
-               	movss	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9be>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c5>
+               	movss	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c0>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c7>
                	leaq	0xc(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	-0x200(%rbp), %r12
-               	movups	-0x430(%rbp), %xmm14
-               	movups	%xmm14, (%r12)
+               	movups	%xmm14, -0x3b0(%rbp)
                	leaq	(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x3d0(%rbp), %xmm4
-               	leaq	-0x210(%rbp), %r15
-               	movups	%xmm1, (%r15)
-               	leaq	(%r15), %rcx
-               	movss	%xmm4, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	addss	-0x350(%rbp), %xmm4
+               	leaq	-0x200(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movss	%xmm4, (%rdx)
+               	movups	(%rcx), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x3d0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L69>
 <L69>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x450(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
-               	movaps	-0x430(%rbp), %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	callq	 <L70>
+<L70>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	callq	 <L71>
+<L71>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movaps	-0x430(%rbp), %xmm14
-               	movaps	-0x440(%rbp), %xmm15
+               	callq	 <L72>
+<L72>:
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x450(%rbp), %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3d0(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3d0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm4, %xmm14
-               	pand	-0x430(%rbp), %xmm14
+               	pand	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm0, %xmm14
                	por	%xmm5, %xmm14
-               	movaps	%xmm14, -0x460(%rbp)
-               	leaq	-0x220(%rbp), %r12
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, (%r12)
-               	movaps	-0x450(%rbp), %xmm14
-               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
+               	movaps	-0x3d0(%rbp), %xmm14
+               	pand	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	movaps	%xmm4, %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm3, %xmm14
                	por	%xmm4, %xmm14
-               	movaps	%xmm14, -0x470(%rbp)
-               	leaq	-0x230(%rbp), %r15
-               	movups	-0x470(%rbp), %xmm14
-               	movups	%xmm14, (%r15)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	%xmm14, -0x3f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L74>
+<L74>:
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movaps	-0x470(%rbp), %xmm14
-               	subps	-0x460(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm0
+               	callq	 <L75>
+<L75>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	subps	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x240(%rbp), %r12
-               	movups	%xmm1, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	-0x250(%rbp), %rcx
+               	movaps	%xmm1, %xmm0
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x210(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 ## imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1099,104 +1314,104 @@ Disassembly of section __TEXT,__text:
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
+               	leaq	-0x220(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x270(%rbp), %rdx
+               	leaq	-0x230(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0x4004000000000000, %r11 ## imm = 0x4004000000000000
                	movq	%r11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$0x0, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	%xmm14, -0x400(%rbp)
                	leaq	(%rcx), %rdx
                	movsd	(%rdx), %xmm2
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L93>
+               	jl	 <L77>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L78>
+<L77>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L94>:
+<L78>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
                	addsd	%xmm3, %xmm4
-               	leaq	-0x280(%rbp), %rcx
+               	leaq	-0x240(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	%xmm4, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	movups	%xmm14, -0x410(%rbp)
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpltpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x290(%rbp), %rbx
+               	leaq	-0x250(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L79>
+<L79>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	callq	 <L80>
+<L80>:
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpeqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2a0(%rbp), %rbx
+               	leaq	-0x260(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	callq	 <L82>
+<L82>:
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpneqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2b0(%rbp), %rbx
+               	leaq	-0x270(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
+               	callq	 <L83>
+<L83>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	movaps	-0x480(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L84>
+<L84>:
+               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm15
                	cmplepd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2c0(%rbp), %rbx
+               	leaq	-0x280(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
+               	callq	 <L85>
+<L85>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	-0x2d0(%rbp), %rcx
+               	callq	 <L86>
+<L86>:
+               	leaq	-0x290(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
                	leaq	0x2(%rcx), %rdx
@@ -1214,9 +1429,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rcx), %rdx
                	movw	$0xfffe, (%rdx)         ## imm = 0xFFFE
                	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	-0x2a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x2f0(%rbp), %rdx
+               	leaq	-0x2b0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x2, (%rsi)
                	leaq	0x2(%rdx), %rsi
@@ -1234,232 +1449,70 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xffff, (%rsi)         ## imm = 0xFFFF
                	movups	(%rdx), %xmm1
-               	leaq	-0x300(%rbp), %rdx
+               	leaq	-0x2c0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzwl	(%rsi), %ecx
                	addl	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rsi
+               	leaq	-0x2d0(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movw	%cx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	0xe(%rdx), %rcx
                	movzwl	(%rcx), %edx
                	addl	%r13d, %edx
-               	leaq	-0x320(%rbp), %rcx
+               	leaq	-0x2e0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movw	%dx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4b0(%rbp)
-               	movaps	-0x4b0(%rbp), %xmm14
-               	psubusw	-0x4a0(%rbp), %xmm14
+               	movups	%xmm14, -0x440(%rbp)
+               	movaps	-0x440(%rbp), %xmm14
+               	psubusw	-0x430(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x330(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	%xmm14, -0x420(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x420(%rbp), %xmm0
+               	callq	 <L87>
+<L87>:
+               	movaps	-0x430(%rbp), %xmm14
+               	pcmpeqw	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqw	-0x4b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	psubusw	-0x4b0(%rbp), %xmm14
+               	callq	 <L88>
+<L88>:
+               	movaps	-0x430(%rbp), %xmm14
+               	psubusw	-0x440(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x350(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	movaps	-0x4b0(%rbp), %xmm14
-               	psubusw	-0x4a0(%rbp), %xmm14
-               	pxor	%xmm15, %xmm15
-               	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
+               	movaps	-0x420(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
-               	pand	-0x4b0(%rbp), %xmm14
+               	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	-0x370(%rbp), %rcx
+               	callq	 <L90>
+<L90>:
+               	leaq	-0x2f0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1493,9 +1546,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x1d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
+               	leaq	-0x300(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x390(%rbp), %rdx
+               	leaq	-0x310(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movb	$0x2, (%rsi)
                	leaq	0x1(%rdx), %rsi
@@ -1529,72 +1582,72 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rdx), %rsi
                	movb	$0x1e, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x3a0(%rbp), %rdx
+               	leaq	-0x320(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzbl	(%rsi), %ecx
                	addl	%r14d, %ecx
-               	leaq	-0x3b0(%rbp), %rsi
+               	leaq	-0x330(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movb	%cl, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4d0(%rbp)
+               	movups	%xmm14, -0x460(%rbp)
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
                	addl	%r14d, %edx
-               	leaq	-0x3c0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4e0(%rbp)
-               	movaps	-0x4e0(%rbp), %xmm14
-               	psubusb	-0x4d0(%rbp), %xmm14
+               	movups	%xmm14, -0x470(%rbp)
+               	movaps	-0x470(%rbp), %xmm14
+               	psubusb	-0x460(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, -0x4c0(%rbp)
+               	movaps	%xmm14, -0x450(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x4c0(%rbp), %xmm0
-               	callq	 <L135>
-<L135>:
-               	movaps	-0x4d0(%rbp), %xmm14
-               	pcmpeqb	-0x4e0(%rbp), %xmm14
+               	movups	-0x450(%rbp), %xmm0
+               	callq	 <L91>
+<L91>:
+               	movaps	-0x460(%rbp), %xmm14
+               	pcmpeqb	-0x470(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	psubusb	-0x4d0(%rbp), %xmm14
+               	callq	 <L92>
+<L92>:
+               	movaps	-0x470(%rbp), %xmm14
+               	psubusb	-0x460(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	movaps	-0x4c0(%rbp), %xmm14
-               	pand	-0x4d0(%rbp), %xmm14
+               	callq	 <L93>
+<L93>:
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x460(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x4c0(%rbp), %xmm14
+               	movaps	-0x450(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x4e0(%rbp), %xmm14
+               	pand	-0x470(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	movq	-0x4e8(%rbp), %rbx
-               	movq	-0x4f0(%rbp), %r12
-               	movq	-0x4f8(%rbp), %r13
-               	movq	-0x500(%rbp), %r14
-               	movq	-0x508(%rbp), %r15
+               	callq	 <L94>
+<L94>:
+               	movq	-0x478(%rbp), %rbx
+               	movq	-0x480(%rbp), %r12
+               	movq	-0x488(%rbp), %r13
+               	movq	-0x490(%rbp), %r14
+               	movq	-0x498(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f32x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f32x2.dis
@@ -7,18 +7,60 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,396 +68,290 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x190, %rsp            ## imm = 0x190
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x120, %rsp            ## imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x8(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movsd	(%rcx), %xmm1
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	%xmm1, (%rcx)
-               	leaq	-0x18(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x48(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     ## imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	movsd	(%rsi), %xmm1
+               	leaq	-0x50(%rbp), %rsi
+               	movsd	%xmm1, (%rsi)
+               	leaq	-0x58(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     ## imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     ## imm = 0x40800000
-               	movsd	(%rsi), %xmm2
-               	leaq	-0x20(%rbp), %rsi
-               	movsd	%xmm2, (%rsi)
-               	leaq	-0x28(%rbp), %rbx
+               	movsd	(%rdi), %xmm2
+               	leaq	-0x60(%rbp), %rdi
+               	movsd	%xmm2, (%rdi)
+               	leaq	-0x68(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movl	$0x3f800000, (%r12)     ## imm = 0x3F800000
                	leaq	0x4(%rbx), %r12
                	movl	$0x41d80000, (%r12)     ## imm = 0x41D80000
                	movq	(%rbx), %r11
-               	movq	%r11, -0x100(%rbp)
-               	leaq	(%rcx), %rbx
+               	movq	%r11, -0x90(%rbp)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x30(%rbp), %rbx
-               	movsd	%xmm1, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	%xmm5, (%rcx)
-               	movq	(%rbx), %r11
-               	movq	%r11, -0x110(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm4
+               	leaq	-0x70(%rbp), %rsi
+               	movsd	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
+               	movss	%xmm5, (%rbx)
+               	movq	(%rsi), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	leaq	0x4(%rdi), %rsi
+               	movss	(%rsi), %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x38(%rbp), %r12
-               	movsd	%xmm2, (%r12)
-               	leaq	0x4(%r12), %rcx
-               	movss	%xmm5, (%rcx)
-               	movq	(%r12), %r11
-               	movq	%r11, -0x120(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x78(%rbp), %rsi
+               	movsd	%xmm2, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movq	(%rsi), %r11
+               	movq	%r11, -0xb0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0xa0(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0xb0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	addps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xb0(%rbp), %xmm14
+               	subps	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	addps	-0x120(%rbp), %xmm14
+               	movaps	-0xa0(%rbp), %xmm14
+               	mulps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xa0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	divps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
+               	movaps	-0xb0(%rbp), %xmm14
+               	divps	-0xa0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x120(%rbp), %xmm14
-               	subps	-0x110(%rbp), %xmm14
+               	movaps	-0x90(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x90(%rbp), %xmm14
+               	divps	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	mulps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	movsd	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0xa0(%rbp), %xmm14
+               	movups	%xmm14, -0xd0(%rbp)
+               	movups	%xmm0, -0xe0(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xd0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
+               	movaps	%xmm14, -0xc0(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0xc0(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	divps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xe0(%rbp), %xmm14
+               	addps	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, -0xf0(%rbp)
+               	movups	-0xf0(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xd0(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, -0x100(%rbp)
+               	movups	-0x100(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x120(%rbp), %xmm14
-               	divps	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x100(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x100(%rbp), %xmm14
-               	divps	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0xf0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	movsd	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x110(%rbp), %xmm14
-               	movups	%xmm14, -0x140(%rbp)
-               	movups	%xmm0, -0x150(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
-               	movaps	-0x140(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
-               	movaps	%xmm14, -0x130(%rbp)
-               	leaq	-0x40(%rbp), %r13
-               	movq	-0x130(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	-0x150(%rbp), %xmm14
-               	addps	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, -0x160(%rbp)
-               	leaq	-0x98(%rbp), %r13
-               	movq	-0x160(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	-0x140(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, -0x170(%rbp)
-               	leaq	-0xa8(%rbp), %r13
-               	movq	-0x170(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x170(%rbp), %xmm14
-               	movups	%xmm14, -0x140(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x150(%rbp)
+               	movups	-0x100(%rbp), %xmm14
+               	movups	%xmm14, -0xd0(%rbp)
+               	movups	-0xf0(%rbp), %xmm14
+               	movups	%xmm14, -0xe0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L32>:
-               	leaq	-0x70(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rcx
-               	movq	-0x140(%rbp), %r11
-               	movq	%r11, (%rcx)
-               	movaps	-0x140(%rbp), %xmm14
-               	addps	-0x120(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movq	-0xd0(%rbp), %r11
+               	movq	%r11, (%rsi)
+               	movaps	-0xd0(%rbp), %xmm14
+               	addps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x8(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movaps	-0x140(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
+               	leaq	0x8(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	movaps	-0xd0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movq	-0x150(%rbp), %r11
-               	movq	%r11, (%rcx)
-               	movaps	-0x120(%rbp), %xmm14
-               	subps	-0x140(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	leaq	0x18(%r12), %rsi
+               	movq	-0xe0(%rbp), %r11
+               	movq	%r11, (%rsi)
+               	movaps	-0xb0(%rbp), %xmm14
+               	subps	-0xd0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x28(%r12), %rcx
-               	movq	-0x120(%rbp), %r11
-               	movq	%r11, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	leaq	0x28(%r12), %rsi
+               	movq	-0xb0(%rbp), %r11
+               	movq	%r11, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	leaq	(%r12,%r13,8), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x78(%rbp), %r14
-               	movsd	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	leaq	(%r12,%r13,8), %rsi
+               	movsd	(%rsi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x88(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x40(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
-               	leaq	0x10(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x10(%r12), %rdi
+               	movsd	(%rdi), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	movsd	%xmm0, (%rdi)
+               	leaq	0xc(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x4(%r13), %rsi
                	movsd	(%rsi), %xmm0
-               	leaq	0x4(%r13), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0xc(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movsd	(%r12), %xmm0
-               	leaq	-0x90(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0xc(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f32x3.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f32x3.dis
@@ -7,27 +7,88 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x30, %rsp
                	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r12, -0x30(%rbp)
+               	leaq	-0xc(%rbp), %rax
                	movups	%xmm0, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	-0x1c(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	movl	-0x14(%rbp), %edx
+               	movl	%edx, 0x8(%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,409 +96,292 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x3.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            ## imm = 0x290
-               	movq	%rbx, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movq	%r13, -0x288(%rbp)
-               	movq	%r14, -0x290(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x1f0, %rsp            ## imm = 0x1F0
+               	movq	%rbx, -0x1d8(%rbp)
+               	movq	%r12, -0x1e0(%rbp)
+               	movq	%r13, -0x1e8(%rbp)
+               	movq	%r14, -0x1f0(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0xc(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     ## imm = 0x40700000
-               	movq	$0x0, -0x1c(%rbp)
-               	movq	$0x0, -0x14(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	%rsi, -0x1c(%rbp)
-               	movl	0x8(%rcx), %esi
-               	movl	%esi, -0x14(%rbp)
-               	movups	-0x1c(%rbp), %xmm1
-               	leaq	-0x28(%rbp), %rcx
-               	movups	%xmm1, -0x38(%rbp)
-               	movq	-0x38(%rbp), %rsi
-               	movq	%rsi, (%rcx)
-               	movl	-0x30(%rbp), %esi
-               	movl	%esi, 0x8(%rcx)
-               	leaq	-0x44(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x50(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     ## imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     ## imm = 0x40700000
+               	movq	$0x0, -0x60(%rbp)
+               	movq	$0x0, -0x58(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x60(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x58(%rbp)
+               	movups	-0x60(%rbp), %xmm1
+               	leaq	-0x6c(%rbp), %rsi
+               	movups	%xmm1, -0x7c(%rbp)
+               	movq	-0x7c(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x74(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	-0x88(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     ## imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     ## imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe1>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe8>
-               	leaq	0x8(%rsi), %rbx
+               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xd9>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe0>
+               	leaq	0x8(%rdi), %rbx
                	movss	%xmm2, (%rbx)
-               	movq	$0x0, -0x54(%rbp)
-               	movq	$0x0, -0x4c(%rbp)
-               	movq	(%rsi), %rbx
-               	movq	%rbx, -0x54(%rbp)
-               	movl	0x8(%rsi), %ebx
-               	movl	%ebx, -0x4c(%rbp)
-               	movups	-0x54(%rbp), %xmm2
-               	leaq	-0x60(%rbp), %rsi
-               	movups	%xmm2, -0x70(%rbp)
-               	movq	-0x70(%rbp), %rbx
-               	movq	%rbx, (%rsi)
-               	movl	-0x68(%rbp), %ebx
-               	movl	%ebx, 0x8(%rsi)
-               	leaq	(%rcx), %rbx
+               	movq	$0x0, -0x98(%rbp)
+               	movq	$0x0, -0x90(%rbp)
+               	movq	(%rdi), %rbx
+               	movq	%rbx, -0x98(%rbp)
+               	movl	0x8(%rdi), %ebx
+               	movl	%ebx, -0x90(%rbp)
+               	movups	-0x98(%rbp), %xmm2
+               	leaq	-0xa4(%rbp), %rdi
+               	movups	%xmm2, -0xb4(%rbp)
+               	movq	-0xb4(%rbp), %rbx
+               	movq	%rbx, (%rdi)
+               	movl	-0xac(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdi)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x7c(%rbp), %rbx
-               	movups	%xmm1, -0x8c(%rbp)
-               	movq	-0x8c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x84(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	%xmm4, (%rcx)
-               	movq	$0x0, -0x9c(%rbp)
-               	movq	$0x0, -0x94(%rbp)
-               	movq	(%rbx), %rcx
-               	movq	%rcx, -0x9c(%rbp)
-               	movl	0x8(%rbx), %ecx
-               	movl	%ecx, -0x94(%rbp)
-               	movups	-0x9c(%rbp), %xmm14
-               	movups	%xmm14, -0x260(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm3
+               	leaq	-0xc0(%rbp), %rsi
+               	movups	%xmm1, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %rbx
+               	movq	%rbx, (%rsi)
+               	movl	-0xc8(%rbp), %ebx
+               	movl	%ebx, 0x8(%rsi)
+               	leaq	(%rsi), %rbx
+               	movss	%xmm4, (%rbx)
+               	movq	$0x0, -0xe0(%rbp)
+               	movq	$0x0, -0xd8(%rbp)
+               	movq	(%rsi), %rbx
+               	movq	%rbx, -0xe0(%rbp)
+               	movl	0x8(%rsi), %ebx
+               	movl	%ebx, -0xd8(%rbp)
+               	movups	-0xe0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	leaq	0x8(%rdi), %rsi
+               	movss	(%rsi), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0xa8(%rbp), %r12
-               	movups	%xmm2, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %rcx
-               	movq	%rcx, (%r12)
-               	movl	-0xb0(%rbp), %ecx
-               	movl	%ecx, 0x8(%r12)
-               	leaq	0x8(%r12), %rcx
-               	movss	%xmm4, (%rcx)
-               	movq	$0x0, -0xc8(%rbp)
-               	movq	$0x0, -0xc0(%rbp)
-               	movq	(%r12), %rcx
-               	movq	%rcx, -0xc8(%rbp)
-               	movl	0x8(%r12), %ecx
-               	movl	%ecx, -0xc0(%rbp)
-               	movups	-0xc8(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0xec(%rbp), %rsi
+               	movups	%xmm2, -0xfc(%rbp)
+               	movq	-0xfc(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0xf4(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm4, (%rdi)
+               	movq	$0x0, -0x10c(%rbp)
+               	movq	$0x0, -0x104(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x10c(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x104(%rbp)
+               	movups	-0x10c(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x1a0(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x1b0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	addps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1c0(%rbp)
+               	movups	-0x1c0(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	subps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1b0(%rbp), %xmm14
+               	subps	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	mulps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	divps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	addps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, -0x170(%rbp)
-               	movq	-0x170(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x168(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	subps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x17c(%rbp), %rbx
-               	movups	%xmm0, -0x18c(%rbp)
-               	movq	-0x18c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x184(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x270(%rbp), %xmm14
-               	subps	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x198(%rbp), %rbx
-               	movups	%xmm0, -0x1a8(%rbp)
-               	movq	-0x1a8(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1a0(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	mulps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b4(%rbp), %rbx
-               	movups	%xmm0, -0x1c4(%rbp)
-               	movq	-0x1c4(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1bc(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	divps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1d8(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	-0x210(%rbp), %rbx
+               	movq	%rax, %rsi
+               	leaq	-0x13c(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
                	movq	$0x0, 0x10(%rbx)
                	movq	$0x0, 0x18(%rbx)
                	movq	$0x0, 0x20(%rbx)
                	movq	$0x0, 0x28(%rbx)
-               	leaq	(%rbx), %rsi
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movq	-0x220(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x218(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	-0x260(%rbp), %xmm14
-               	addps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0xc(%rbx), %rsi
-               	movups	%xmm0, -0x230(%rbp)
-               	movq	-0x230(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x228(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	-0x260(%rbp), %xmm14
-               	mulps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm1
-               	leaq	0x18(%rbx), %rsi
-               	movups	%xmm1, -0x240(%rbp)
-               	movq	-0x240(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x238(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	leaq	0x24(%rbx), %rsi
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, -0x250(%rbp)
-               	movq	-0x250(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x248(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movq	%rcx, %r12
+               	leaq	(%rbx), %rdi
+               	movups	-0x1a0(%rbp), %xmm14
+               	movups	%xmm14, -0x14c(%rbp)
+               	movq	-0x14c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x144(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0xc(%rbx), %rdi
+               	movups	-0x1c0(%rbp), %xmm14
+               	movups	%xmm14, -0x15c(%rbp)
+               	movq	-0x15c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x154(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x18(%rbx), %rdi
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x16c(%rbp)
+               	movq	-0x16c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x164(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x24(%rbx), %rdi
+               	movups	-0x1b0(%rbp), %xmm14
+               	movups	%xmm14, -0x17c(%rbp)
+               	movq	-0x17c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x174(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	movq	%rsi, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%r13, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	movq	$0x0, -0xd8(%rbp)
-               	movq	$0x0, -0xd0(%rbp)
-               	movq	(%rsi), %rcx
-               	movq	%rcx, -0xd8(%rbp)
-               	movl	0x8(%rsi), %ecx
-               	movl	%ecx, -0xd0(%rbp)
-               	movups	-0xd8(%rbp), %xmm0
-               	leaq	-0xe4(%rbp), %r14
-               	movups	%xmm0, -0xf4(%rbp)
-               	movq	-0xf4(%rbp), %rcx
-               	movq	%rcx, (%r14)
-               	movl	-0xec(%rbp), %ecx
-               	movl	%ecx, 0x8(%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L9>
+               	jmp	 <L11>
+<L9>:
+               	movq	%r13, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%rbx,%rsi), %rdi
+               	movq	$0x0, -0x10(%rbp)
+               	movq	$0x0, -0x8(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x10(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x8(%rbp)
+               	movups	-0x10(%rbp), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %r12
                	addq	$0x1, %r13
-               	movq	%rcx, %r12
                	cmpq	$0x4, %r13
-               	jb	 <L24>
-<L28>:
-               	leaq	-0x108(%rbp), %r13
+               	jb	 <L9>
+<L11>:
+               	leaq	-0x24(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movl	$0x0, 0x10(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
-               	leaq	0x18(%rbx), %rsi
-               	movq	$0x0, -0x118(%rbp)
-               	movq	$0x0, -0x110(%rbp)
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x18(%rbx), %rdi
+               	movq	$0x0, -0x34(%rbp)
+               	movq	$0x0, -0x2c(%rbp)
+               	movq	(%rdi), %rbx
+               	movq	%rbx, -0x34(%rbp)
+               	movl	0x8(%rdi), %ebx
+               	movl	%ebx, -0x2c(%rbp)
+               	movups	-0x34(%rbp), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	movups	%xmm0, -0x44(%rbp)
+               	movq	-0x44(%rbp), %rbx
+               	movq	%rbx, (%rdi)
+               	movl	-0x3c(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdi)
+               	leaq	0x10(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x18c(%rbp)
+               	movq	$0x0, -0x184(%rbp)
                	movq	(%rsi), %rdi
-               	movq	%rdi, -0x118(%rbp)
+               	movq	%rdi, -0x18c(%rbp)
                	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x110(%rbp)
-               	movups	-0x118(%rbp), %xmm0
-               	leaq	0x4(%r13), %rbx
-               	movups	%xmm0, -0x128(%rbp)
-               	movq	-0x128(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x120(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	0x10(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rcx), %esi
+               	movl	%edi, -0x184(%rbp)
+               	movups	-0x18c(%rbp), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	$0x0, -0x138(%rbp)
-               	movq	$0x0, -0x130(%rbp)
-               	movq	(%rbx), %rcx
-               	movq	%rcx, -0x138(%rbp)
-               	movl	0x8(%rbx), %ecx
-               	movl	%ecx, -0x130(%rbp)
-               	movups	-0x138(%rbp), %xmm0
-               	leaq	-0x144(%rbp), %rbx
-               	movups	%xmm0, -0x154(%rbp)
-               	movq	-0x154(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14c(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x278(%rbp), %rbx
-               	movq	-0x280(%rbp), %r12
-               	movq	-0x288(%rbp), %r13
-               	movq	-0x290(%rbp), %r14
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rsi
+               	leaq	0x10(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+<L16>:
+               	movq	%rsi, %rax
+               	movq	-0x1d8(%rbp), %rbx
+               	movq	-0x1e0(%rbp), %r12
+               	movq	-0x1e8(%rbp), %r13
+               	movq	-0x1f0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f32x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f32x4.dis
@@ -7,28 +7,108 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -36,59 +116,55 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            ## imm = 0x290
-               	movq	%rbx, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movq	%r13, -0x288(%rbp)
-               	movq	%r14, -0x290(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x1b0, %rsp            ## imm = 0x1B0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     ## imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x94>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x9b>
-               	leaq	0xc(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     ## imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     ## imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x89>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x90>
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	movups	(%rsi), %xmm1
+               	leaq	-0x90(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	-0xa0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     ## imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     ## imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xcc>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xd3>
-               	leaq	0x8(%rsi), %rbx
+               	movss	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xc7>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xce>
+               	leaq	0x8(%rdi), %rbx
                	movss	%xmm2, (%rbx)
-               	leaq	0xc(%rsi), %rbx
+               	leaq	0xc(%rdi), %rbx
                	movl	$0x41000000, (%rbx)     ## imm = 0x41000000
-               	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
+               	movups	(%rdi), %xmm2
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm2, (%rdi)
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movl	$0x3f800000, (%r12)     ## imm = 0x3F800000
                	leaq	0x4(%rbx), %r12
@@ -98,418 +174,158 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rbx), %r12
                	movl	$0x41d80000, (%r12)     ## imm = 0x41D80000
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	(%rcx), %rbx
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rcx), %rbx
+               	leaq	-0xd0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
                	movss	%xmm5, (%rbx)
-               	movups	(%rcx), %xmm1
-               	leaq	0xc(%rcx), %rbx
+               	movups	(%rsi), %xmm1
+               	leaq	0xc(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x70(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movss	%xmm5, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm4
-               	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
-               	addss	%xmm0, %xmm5
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm5, (%rsi)
-               	movups	(%rcx), %xmm2
-               	leaq	0x8(%rcx), %rsi
+               	leaq	-0xe0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	0xc(%rsi), %rbx
+               	movss	%xmm5, (%rbx)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	leaq	0x4(%rdi), %rsi
                	movss	(%rsi), %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x90(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movss	%xmm5, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0xf0(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	0x8(%rsi), %rdi
+               	movss	(%rdi), %xmm4
+               	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
+               	addss	%xmm0, %xmm5
+               	leaq	-0x100(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x130(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x140(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	addps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	subps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	mulps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	divps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	divps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	addps	-0x220(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	divps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0x110(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	movups	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x160(%rbp)
+               	movups	%xmm0, -0x170(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x160(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x170(%rbp), %xmm14
+               	addps	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movups	-0x180(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x160(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
+               	movups	-0x190(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	subps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	mulps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	divps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	divps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	divps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	leaq	-0x1f0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	movups	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x240(%rbp)
-               	movups	%xmm0, -0x250(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L47>
-               	jmp	 <L60>
-<L47>:
-               	movaps	-0x240(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x230(%rbp)
-               	leaq	-0xa0(%rbp), %r13
-               	movups	-0x230(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	movaps	-0x250(%rbp), %xmm14
-               	addps	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0x140(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movaps	-0x240(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, -0x270(%rbp)
-               	leaq	-0x160(%rbp), %r13
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, -0x240(%rbp)
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, -0x250(%rbp)
+               	movups	-0x190(%rbp), %xmm14
+               	movups	%xmm14, -0x160(%rbp)
+               	movups	-0x180(%rbp), %xmm14
+               	movups	%xmm14, -0x170(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L47>
-<L60>:
-               	leaq	-0xe0(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -518,112 +334,110 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rcx
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	movaps	-0x240(%rbp), %xmm14
-               	addps	-0x220(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movaps	-0x160(%rbp), %xmm14
+               	addps	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	movaps	-0x240(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movups	%xmm0, (%rsi)
+               	movaps	-0x160(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm4, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movups	%xmm4, (%rsi)
+               	leaq	0x30(%r12), %rsi
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L61>
-               	jmp	 <L66>
-<L61>:
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	-0xf0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%r13, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L61>
-<L66>:
-               	leaq	-0x120(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r12), %rdi
+               	movups	(%rdi), %xmm0
+               	leaq	0x10(%r13), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x20(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r13), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movups	(%r12), %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x278(%rbp), %rbx
-               	movq	-0x280(%rbp), %r12
-               	movq	-0x288(%rbp), %r13
-               	movq	-0x290(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0x20(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f32x5.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f32x5.dis
@@ -7,39 +7,137 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0xa0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x34(%rbp), %rcx
-               	leaq	-0x48(%rbp), %rcx
-               	leaq	-0x5c(%rbp), %rcx
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	-0x84(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0xa0(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x34(%rbp), %rax
+               	leaq	-0x48(%rbp), %rax
+               	leaq	-0x5c(%rbp), %rax
+               	leaq	-0x70(%rbp), %rax
+               	leaq	-0x84(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,1992 +145,1449 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x5.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xd80, %rsp            ## imm = 0xD80
-               	movq	%rbx, -0xd58(%rbp)
-               	movq	%r12, -0xd60(%rbp)
-               	movq	%r13, -0xd68(%rbp)
-               	movq	%r14, -0xd70(%rbp)
-               	movq	%r15, -0xd78(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	-0x14(%rbp), %r12
-               	leaq	-0x28(%rbp), %r13
-               	leaq	-0x3c(%rbp), %r14
-               	leaq	-0x50(%rbp), %rcx
-               	leaq	-0x64(%rbp), %rcx
-               	leaq	-0x78(%rbp), %r15
-               	leaq	-0x8c(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xb4(%rbp), %r8
-               	movq	%r8, -0xd40(%rbp)
-               	leaq	-0xc8(%rbp), %rdx
-               	leaq	-0xdc(%rbp), %rdx
-               	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0xd48(%rbp)
-               	leaq	-0x104(%rbp), %rsi
-               	leaq	-0x118(%rbp), %rsi
-               	leaq	-0x12c(%rbp), %rsi
-               	leaq	-0x140(%rbp), %rsi
-               	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0xd50(%rbp)
-               	leaq	-0x168(%rbp), %rdi
-               	leaq	-0x17c(%rbp), %rdi
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0xcb0(%rbp)
+               	subq	$0x740, %rsp            ## imm = 0x740
+               	movq	%rbx, -0x718(%rbp)
+               	movq	%r12, -0x720(%rbp)
+               	movq	%r13, -0x728(%rbp)
+               	movq	%r14, -0x730(%rbp)
+               	movq	%r15, -0x738(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x668(%rbp)
+               	leaq	-0x14(%rbp), %rax
+               	leaq	-0x28(%rbp), %r8
+               	movq	%r8, -0x6f8(%rbp)
+               	leaq	-0x3c(%rbp), %rbx
+               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x64(%rbp), %rsi
+               	leaq	-0x78(%rbp), %rsi
+               	leaq	-0x8c(%rbp), %r12
+               	leaq	-0xa0(%rbp), %r12
+               	leaq	-0xb4(%rbp), %r12
+               	leaq	-0xc8(%rbp), %r13
+               	leaq	-0xdc(%rbp), %r13
+               	leaq	-0xf0(%rbp), %r13
+               	leaq	-0x104(%rbp), %r14
+               	leaq	-0x118(%rbp), %r14
+               	leaq	-0x12c(%rbp), %r14
+               	leaq	-0x140(%rbp), %r14
+               	leaq	-0x154(%rbp), %r14
+               	leaq	-0x168(%rbp), %r15
+               	leaq	-0x17c(%rbp), %r15
+               	leaq	-0x190(%rbp), %r15
                	leaq	-0x1a4(%rbp), %rdi
                	leaq	-0x1b8(%rbp), %rdi
                	leaq	-0x1cc(%rbp), %r8
-               	movq	%r8, -0xcb8(%rbp)
+               	movq	%r8, -0x670(%rbp)
                	leaq	-0x1e0(%rbp), %rdi
                	leaq	-0x1f4(%rbp), %rdi
                	leaq	-0x208(%rbp), %r8
-               	movq	%r8, -0xcc0(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	-0x21c(%rbp), %rdi
                	leaq	-0x230(%rbp), %rdi
                	leaq	-0x244(%rbp), %r8
-               	movq	%r8, -0xcc8(%rbp)
+               	movq	%r8, -0x680(%rbp)
                	leaq	-0x258(%rbp), %rdi
                	leaq	-0x26c(%rbp), %rdi
                	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0xcd0(%rbp)
+               	movq	%r8, -0x688(%rbp)
                	leaq	-0x294(%rbp), %rdi
                	leaq	-0x2a8(%rbp), %rdi
                	leaq	-0x2bc(%rbp), %r8
-               	movq	%r8, -0xcd8(%rbp)
+               	movq	%r8, -0x690(%rbp)
                	leaq	-0x2d0(%rbp), %rdi
                	leaq	-0x2e4(%rbp), %rdi
                	leaq	-0x2f8(%rbp), %r8
-               	movq	%r8, -0xce0(%rbp)
+               	movq	%r8, -0x698(%rbp)
                	leaq	-0x30c(%rbp), %rdi
                	leaq	-0x320(%rbp), %rdi
                	leaq	-0x334(%rbp), %r8
-               	movq	%r8, -0xce8(%rbp)
+               	movq	%r8, -0x6a0(%rbp)
                	leaq	-0x348(%rbp), %r8
-               	movq	%r8, -0xcf0(%rbp)
+               	movq	%r8, -0x6a8(%rbp)
                	leaq	-0x35c(%rbp), %rdi
                	leaq	-0x370(%rbp), %rdi
                	leaq	-0x384(%rbp), %r8
-               	movq	%r8, -0xcf8(%rbp)
+               	movq	%r8, -0x6b0(%rbp)
                	leaq	-0x398(%rbp), %rdi
                	leaq	-0x3ac(%rbp), %rdi
                	leaq	-0x3c0(%rbp), %rdi
                	leaq	-0x3d4(%rbp), %r8
-               	movq	%r8, -0xd00(%rbp)
+               	movq	%r8, -0x6b8(%rbp)
                	leaq	-0x3e8(%rbp), %rdi
                	leaq	-0x3fc(%rbp), %rdi
                	leaq	-0x410(%rbp), %rdi
                	leaq	-0x424(%rbp), %r8
-               	movq	%r8, -0xd08(%rbp)
+               	movq	%r8, -0x6c0(%rbp)
                	leaq	-0x438(%rbp), %rdi
                	leaq	-0x44c(%rbp), %rdi
                	leaq	-0x460(%rbp), %rdi
                	leaq	-0x474(%rbp), %rdi
                	leaq	-0x488(%rbp), %r8
-               	movq	%r8, -0xd10(%rbp)
+               	movq	%r8, -0x6c8(%rbp)
                	leaq	-0x49c(%rbp), %rdi
                	leaq	-0x4b0(%rbp), %rdi
                	leaq	-0x4c4(%rbp), %r8
-               	movq	%r8, -0xd18(%rbp)
+               	movq	%r8, -0x6d0(%rbp)
                	leaq	-0x4d8(%rbp), %rdi
                	leaq	-0x4ec(%rbp), %rdi
                	leaq	-0x500(%rbp), %rdi
                	leaq	-0x514(%rbp), %r8
-               	movq	%r8, -0xd20(%rbp)
+               	movq	%r8, -0x6d8(%rbp)
                	leaq	-0x528(%rbp), %rdi
                	leaq	-0x53c(%rbp), %r8
-               	movq	%r8, -0xd28(%rbp)
+               	movq	%r8, -0x6e0(%rbp)
                	leaq	-0x550(%rbp), %r8
-               	movq	%r8, -0xd30(%rbp)
+               	movq	%r8, -0x6e8(%rbp)
                	leaq	-0x564(%rbp), %r8
-               	movq	%r8, -0xd38(%rbp)
-               	leaq	-0x578(%rbp), %rdi
-               	leaq	-0x58c(%rbp), %rdi
-               	leaq	-0x5a0(%rbp), %rdi
-               	leaq	-0x5b4(%rbp), %rdi
-               	leaq	-0x5c8(%rbp), %rdi
-               	leaq	-0x5dc(%rbp), %rdi
-               	leaq	-0x5f0(%rbp), %rdi
-               	leaq	-0x604(%rbp), %rdi
-               	leaq	-0x618(%rbp), %rdi
-               	leaq	-0x62c(%rbp), %rdi
-               	leaq	-0x640(%rbp), %rdi
-               	leaq	-0x654(%rbp), %rdi
-               	leaq	-0x668(%rbp), %rdi
-               	leaq	-0x67c(%rbp), %rdi
-               	leaq	-0x690(%rbp), %rdi
-               	leaq	-0x6a4(%rbp), %rdi
-               	leaq	-0x6b8(%rbp), %rdi
-               	leaq	-0x6cc(%rbp), %rdi
-               	leaq	-0x6e0(%rbp), %rdi
-               	leaq	-0x6f4(%rbp), %rdi
-               	leaq	-0x708(%rbp), %rdi
-               	leaq	-0x71c(%rbp), %rdi
-               	leaq	-0x730(%rbp), %rdi
-               	leaq	-0x744(%rbp), %rdi
-               	leaq	-0x758(%rbp), %rdi
-               	leaq	-0x76c(%rbp), %rdi
-               	leaq	-0x780(%rbp), %rdi
-               	leaq	-0x794(%rbp), %rdi
-               	leaq	-0x7a8(%rbp), %rdi
-               	leaq	-0x7bc(%rbp), %rdi
-               	leaq	-0x7d0(%rbp), %rdi
-               	leaq	-0x7e4(%rbp), %rdi
-               	leaq	-0x7f8(%rbp), %rdi
-               	leaq	-0x80c(%rbp), %rdi
-               	leaq	-0x820(%rbp), %rdi
-               	leaq	-0x834(%rbp), %rdi
-               	leaq	-0x848(%rbp), %rdi
-               	leaq	-0x85c(%rbp), %rdi
-               	leaq	-0x870(%rbp), %rdi
-               	leaq	-0x884(%rbp), %rdi
-               	leaq	-0x898(%rbp), %rdi
-               	leaq	-0x8ac(%rbp), %rdi
-               	leaq	-0x8c0(%rbp), %rdi
-               	leaq	-0x8d4(%rbp), %rdi
-               	leaq	-0x8e8(%rbp), %rdi
-               	leaq	-0x8fc(%rbp), %rdi
-               	leaq	-0x910(%rbp), %rdi
-               	leaq	-0x924(%rbp), %rdi
-               	leaq	-0x938(%rbp), %rdi
-               	leaq	-0x94c(%rbp), %rdi
-               	leaq	-0x960(%rbp), %rdi
-               	leaq	-0x974(%rbp), %rdi
-               	leaq	-0x988(%rbp), %rdi
-               	leaq	-0x99c(%rbp), %rdi
-               	leaq	-0x9b0(%rbp), %rdi
-               	leaq	-0x9c4(%rbp), %rdi
-               	leaq	-0x9d8(%rbp), %rdi
-               	leaq	-0x9ec(%rbp), %rdi
-               	leaq	-0xa00(%rbp), %rdi
-               	leaq	-0xa14(%rbp), %rdi
-               	leaq	-0xa28(%rbp), %rdi
-               	leaq	-0xa3c(%rbp), %rdi
-               	leaq	-0xa50(%rbp), %rdi
-               	leaq	-0xa64(%rbp), %rdi
-               	leaq	-0xa78(%rbp), %rdi
-               	leaq	-0xa8c(%rbp), %rdi
-               	leaq	-0xaa0(%rbp), %rdi
-               	leaq	-0xab4(%rbp), %rdi
-               	leaq	-0xac8(%rbp), %rdi
-               	leaq	-0xadc(%rbp), %rdi
-               	leaq	-0xaf0(%rbp), %rdi
-               	leaq	-0xb04(%rbp), %rdi
-               	leaq	-0xb18(%rbp), %rdi
-               	leaq	-0xb2c(%rbp), %rdi
-               	leaq	-0xb40(%rbp), %rdi
-               	leaq	-0xb54(%rbp), %rdi
-               	leaq	-0xb68(%rbp), %rdi
-               	leaq	-0xb7c(%rbp), %rdi
-               	leaq	-0xb90(%rbp), %rdi
-               	leaq	-0xba4(%rbp), %rdi
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x668(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x624(%rbp), %rdi
+               	leaq	(%rdi), %rdx
+               	movl	$0x3fc00000, (%rdx)     ## imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2d2>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2d9>
+               	leaq	0x4(%rdi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movl	$0x40700000, (%rdx)     ## imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2f3>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2fa>
+               	leaq	0xc(%rdi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movl	$0x40c80000, (%rdx)     ## imm = 0x40C80000
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x638(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x3f000000, (%rdi)     ## imm = 0x3F000000
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x40800000, (%rdi)     ## imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x37c>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x383>
+               	leaq	0x8(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x41000000, (%rdi)     ## imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x39d>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x3a4>
+               	leaq	0x10(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x64c(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x3f800000, (%rdi)     ## imm = 0x3F800000
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x40400000, (%rdi)     ## imm = 0x40400000
+               	leaq	0x8(%rdx), %rdi
+               	movl	$0x41100000, (%rdi)     ## imm = 0x41100000
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x41d80000, (%rdi)     ## imm = 0x41D80000
+               	leaq	0x10(%rdx), %rdi
+               	movl	$0x42a20000, (%rdi)     ## imm = 0x42A20000
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x8(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0xc(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x10(%rbx), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rsi), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	(%rsi), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x4(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x8(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0xc(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm2, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%r13), %rax
+               	movss	%xmm2, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	%r12, %rsi
+               	callq	 <L2>
 <L2>:
-               	leaq	-0xbb8(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3fc00000, (%rbx)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x50e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x515>
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x40700000, (%rbx)     ## imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x52f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x536>
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x40c80000, (%rbx)     ## imm = 0x40C80000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0xbcc(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f000000, (%rbx)     ## imm = 0x3F000000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40800000, (%rbx)     ## imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5bd>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5c4>
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41000000, (%rbx)     ## imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5de>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5e5>
-               	leaq	0x10(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r13), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0xbe0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f800000, (%rbx)     ## imm = 0x3F800000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40400000, (%rbx)     ## imm = 0x40400000
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x41100000, (%rbx)     ## imm = 0x41100000
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41d80000, (%rbx)     ## imm = 0x41D80000
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x42a20000, (%rbx)     ## imm = 0x42A20000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r14), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	movq	%r13, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r14), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
                	callq	 <L4>
 <L4>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x688(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x698(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x6a0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd50(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	-0x660(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %r14
+               	movq	-0x6a8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	%r14, %rdi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x6b8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rax, %r14
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x6b8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
 <L17>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
+               	leaq	-0x5e0(%rbp), %r8
+               	movq	%r8, -0x708(%rbp)
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x78, %rsi
 <L18>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	-0xca4(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L18>
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	leaq	(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
                	movss	%xmm0, (%rsi)
-               	movq	%rax, %rbx
-               	movq	-0xd40(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0xcf0(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L58>
-               	jmp	 <L74>
-<L58>:
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %r15
-               	movq	%rax, %rbx
-               	movq	-0xd08(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0xd00(%rbp), %r8
-               	movq	%r8, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L58>
-<L74>:
-               	leaq	-0xc60(%rbp), %r15
-               	leaq	(%r15), %rax
-               	addq	$0x0, %rax
-               	movq	$0x78, %rcx
-<L75>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L75>
-               	leaq	(%r15), %rax
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r15), %rax
-               	movq	-0xd10(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x28(%r15), %rax
-               	movq	-0xd18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x3c(%r15), %rax
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x50(%r15), %rax
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x64(%r15), %rax
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L76>
-               	jmp	 <L82>
-<L76>:
-               	movq	%r12, %rax
-               	imulq	$0x14, %rax, %rax
-               	leaq	(%r15,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	movq	-0xd28(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x6, %r12
-               	jb	 <L76>
-<L82>:
-               	leaq	-0xc90(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0xffffffff, (%rax)     ## imm = 0xFFFFFFFF
-               	leaq	0x28(%r15), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x4(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x3c(%r8), %rdx
+               	leaq	(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x50(%r8), %rdx
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x64(%r8), %rdx
+               	leaq	(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	$0x0, %rbx
+               	cmpq	$0x6, %rbx
+               	jb	 <L19>
+               	jmp	 <L21>
+<L19>:
+               	movq	%rbx, %rdx
+               	imulq	$0x14, %rdx, %rdx
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8,%rdx), %rsi
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6e0(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %r13
-               	movq	-0xd30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%r12), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L83>
-<L83>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	leaq	0x24(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
-               	movq	-0xd58(%rbp), %rbx
-               	movq	-0xd60(%rbp), %r12
-               	movq	-0xd68(%rbp), %r13
-               	movq	-0xd70(%rbp), %r14
-               	movq	-0xd78(%rbp), %r15
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%r14, %rdi
+               	movq	-0x6e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %r14
+               	addq	$0x1, %rbx
+               	cmpq	$0x6, %rbx
+               	jb	 <L19>
+<L21>:
+               	leaq	-0x610(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	movq	$0x0, 0x18(%rbx)
+               	movq	$0x0, 0x20(%rbx)
+               	movq	$0x0, 0x28(%rbx)
+               	leaq	(%rbx), %rdx
+               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rbx), %rax
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x24(%rbx), %rax
+               	movl	$0x12345678, (%rax)     ## imm = 0x12345678
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	leaq	0x10(%rbx), %rax
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r14, %rdi
+               	movq	-0x6f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L24>
+<L24>:
+               	leaq	0x24(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+<L26>:
+               	movq	-0x718(%rbp), %rbx
+               	movq	-0x720(%rbp), %r12
+               	movq	-0x728(%rbp), %r13
+               	movq	-0x730(%rbp), %r14
+               	movq	-0x738(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f32x8.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f32x8.dis
@@ -7,57 +7,212 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x130, %rsp            ## imm = 0x130
                	movq	%rbx, -0x128(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x40(%rbp), %rcx
-               	leaq	-0x60(%rbp), %rcx
-               	leaq	-0x80(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xc0(%rbp), %rcx
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	-0x120(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x130(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x40(%rbp), %rax
+               	leaq	-0x60(%rbp), %rax
+               	leaq	-0x80(%rbp), %rax
+               	leaq	-0xa0(%rbp), %rax
+               	leaq	-0xc0(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rax
+               	leaq	-0x100(%rbp), %rax
+               	leaq	-0x120(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x14(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L5>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x18(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L6>
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x1c(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L7>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -65,2952 +220,2016 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f32x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1aa0, %rsp           ## imm = 0x1AA0
-               	movq	%rbx, -0x1a78(%rbp)
-               	movq	%r12, -0x1a80(%rbp)
-               	movq	%r13, -0x1a88(%rbp)
-               	movq	%r14, -0x1a90(%rbp)
-               	movq	%r15, -0x1a98(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	-0x20(%rbp), %r12
-               	leaq	-0x40(%rbp), %r13
-               	leaq	-0x60(%rbp), %r14
-               	leaq	-0x80(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xc0(%rbp), %r15
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	-0x120(%rbp), %r8
-               	movq	%r8, -0x1a58(%rbp)
-               	leaq	-0x140(%rbp), %rdx
-               	leaq	-0x160(%rbp), %rdx
+               	subq	$0xaa0, %rsp            ## imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
+               	leaq	-0xc0(%rbp), %rsi
+               	leaq	-0xe0(%rbp), %r12
+               	leaq	-0x100(%rbp), %r12
+               	leaq	-0x120(%rbp), %r12
+               	leaq	-0x140(%rbp), %r13
+               	leaq	-0x160(%rbp), %r13
                	leaq	-0x180(%rbp), %r8
-               	movq	%r8, -0x1a60(%rbp)
-               	leaq	-0x1a0(%rbp), %rsi
-               	leaq	-0x1c0(%rbp), %rsi
-               	leaq	-0x1e0(%rbp), %r8
-               	movq	%r8, -0x1a68(%rbp)
-               	leaq	-0x200(%rbp), %rdi
-               	leaq	-0x220(%rbp), %rdi
-               	leaq	-0x240(%rbp), %rdi
-               	leaq	-0x260(%rbp), %rdi
-               	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0x19c8(%rbp)
+               	movq	%r8, -0xa58(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	leaq	-0x1c0(%rbp), %r14
+               	leaq	-0x1e0(%rbp), %r14
+               	leaq	-0x200(%rbp), %r15
+               	leaq	-0x220(%rbp), %r15
+               	leaq	-0x240(%rbp), %r15
+               	leaq	-0x260(%rbp), %r15
+               	leaq	-0x280(%rbp), %r15
                	leaq	-0x2a0(%rbp), %rdi
                	leaq	-0x2c0(%rbp), %rdi
                	leaq	-0x2e0(%rbp), %r8
-               	movq	%r8, -0x19d0(%rbp)
+               	movq	%r8, -0x9d0(%rbp)
                	leaq	-0x300(%rbp), %rdi
                	leaq	-0x320(%rbp), %rdi
                	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x19d8(%rbp)
+               	movq	%r8, -0x9d8(%rbp)
                	leaq	-0x360(%rbp), %rdi
                	leaq	-0x380(%rbp), %rdi
                	leaq	-0x3a0(%rbp), %r8
-               	movq	%r8, -0x19e0(%rbp)
+               	movq	%r8, -0x9e0(%rbp)
                	leaq	-0x3c0(%rbp), %rdi
                	leaq	-0x3e0(%rbp), %rdi
                	leaq	-0x400(%rbp), %r8
-               	movq	%r8, -0x19e8(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	leaq	-0x420(%rbp), %rdi
                	leaq	-0x440(%rbp), %rdi
                	leaq	-0x460(%rbp), %r8
-               	movq	%r8, -0x19f0(%rbp)
+               	movq	%r8, -0x9f0(%rbp)
                	leaq	-0x480(%rbp), %rdi
                	leaq	-0x4a0(%rbp), %rdi
                	leaq	-0x4c0(%rbp), %r8
-               	movq	%r8, -0x19f8(%rbp)
+               	movq	%r8, -0x9f8(%rbp)
                	leaq	-0x4e0(%rbp), %rdi
                	leaq	-0x500(%rbp), %rdi
                	leaq	-0x520(%rbp), %r8
-               	movq	%r8, -0x1a00(%rbp)
+               	movq	%r8, -0xa00(%rbp)
                	leaq	-0x540(%rbp), %rdi
                	leaq	-0x560(%rbp), %rdi
                	leaq	-0x580(%rbp), %r8
-               	movq	%r8, -0x1a08(%rbp)
+               	movq	%r8, -0xa08(%rbp)
                	leaq	-0x5a0(%rbp), %r8
-               	movq	%r8, -0x1a10(%rbp)
+               	movq	%r8, -0xa10(%rbp)
                	leaq	-0x5c0(%rbp), %rdi
                	leaq	-0x5e0(%rbp), %rdi
                	leaq	-0x600(%rbp), %r8
-               	movq	%r8, -0x1a18(%rbp)
+               	movq	%r8, -0xa18(%rbp)
                	leaq	-0x620(%rbp), %rdi
                	leaq	-0x640(%rbp), %rdi
                	leaq	-0x660(%rbp), %rdi
                	leaq	-0x680(%rbp), %r8
-               	movq	%r8, -0x1a20(%rbp)
+               	movq	%r8, -0xa20(%rbp)
                	leaq	-0x6a0(%rbp), %rdi
                	leaq	-0x6c0(%rbp), %rdi
                	leaq	-0x6e0(%rbp), %rdi
                	leaq	-0x700(%rbp), %r8
-               	movq	%r8, -0x1a28(%rbp)
+               	movq	%r8, -0xa28(%rbp)
                	leaq	-0x720(%rbp), %rdi
                	leaq	-0x740(%rbp), %rdi
                	leaq	-0x760(%rbp), %rdi
                	leaq	-0x780(%rbp), %rdi
                	leaq	-0x7a0(%rbp), %r8
-               	movq	%r8, -0x1a30(%rbp)
+               	movq	%r8, -0xa30(%rbp)
                	leaq	-0x7c0(%rbp), %rdi
                	leaq	-0x7e0(%rbp), %rdi
                	leaq	-0x800(%rbp), %r8
-               	movq	%r8, -0x1a38(%rbp)
+               	movq	%r8, -0xa38(%rbp)
                	leaq	-0x820(%rbp), %rdi
                	leaq	-0x840(%rbp), %r8
-               	movq	%r8, -0x1a40(%rbp)
+               	movq	%r8, -0xa40(%rbp)
                	leaq	-0x860(%rbp), %r8
-               	movq	%r8, -0x1a48(%rbp)
+               	movq	%r8, -0xa48(%rbp)
                	leaq	-0x880(%rbp), %r8
-               	movq	%r8, -0x1a50(%rbp)
-               	leaq	-0x8a0(%rbp), %rdi
-               	leaq	-0x8c0(%rbp), %rdi
-               	leaq	-0x8e0(%rbp), %rdi
-               	leaq	-0x900(%rbp), %rdi
-               	leaq	-0x920(%rbp), %rdi
-               	leaq	-0x940(%rbp), %rdi
-               	leaq	-0x960(%rbp), %rdi
-               	leaq	-0x980(%rbp), %rdi
-               	leaq	-0x9a0(%rbp), %rdi
-               	leaq	-0x9c0(%rbp), %rdi
-               	leaq	-0x9e0(%rbp), %rdi
-               	leaq	-0xa00(%rbp), %rdi
-               	leaq	-0xa20(%rbp), %rdi
-               	leaq	-0xa40(%rbp), %rdi
-               	leaq	-0xa60(%rbp), %rdi
-               	leaq	-0xa80(%rbp), %rdi
-               	leaq	-0xaa0(%rbp), %rdi
-               	leaq	-0xac0(%rbp), %rdi
-               	leaq	-0xae0(%rbp), %rdi
-               	leaq	-0xb00(%rbp), %rdi
-               	leaq	-0xb20(%rbp), %rdi
-               	leaq	-0xb40(%rbp), %rdi
-               	leaq	-0xb60(%rbp), %rdi
-               	leaq	-0xb80(%rbp), %rdi
-               	leaq	-0xba0(%rbp), %rdi
-               	leaq	-0xbc0(%rbp), %rdi
-               	leaq	-0xbe0(%rbp), %rdi
-               	leaq	-0xc00(%rbp), %rdi
-               	leaq	-0xc20(%rbp), %rdi
-               	leaq	-0xc40(%rbp), %rdi
-               	leaq	-0xc60(%rbp), %rdi
-               	leaq	-0xc80(%rbp), %rdi
-               	leaq	-0xca0(%rbp), %rdi
-               	leaq	-0xcc0(%rbp), %rdi
-               	leaq	-0xce0(%rbp), %rdi
-               	leaq	-0xd00(%rbp), %rdi
-               	leaq	-0xd20(%rbp), %rdi
-               	leaq	-0xd40(%rbp), %rdi
-               	leaq	-0xd60(%rbp), %rdi
-               	leaq	-0xd80(%rbp), %rdi
-               	leaq	-0xda0(%rbp), %rdi
-               	leaq	-0xdc0(%rbp), %rdi
-               	leaq	-0xde0(%rbp), %rdi
-               	leaq	-0xe00(%rbp), %rdi
-               	leaq	-0xe20(%rbp), %rdi
-               	leaq	-0xe40(%rbp), %rdi
-               	leaq	-0xe60(%rbp), %rdi
-               	leaq	-0xe80(%rbp), %rdi
-               	leaq	-0xea0(%rbp), %rdi
-               	leaq	-0xec0(%rbp), %rdi
-               	leaq	-0xee0(%rbp), %rdi
-               	leaq	-0xf00(%rbp), %rdi
-               	leaq	-0xf20(%rbp), %rdi
-               	leaq	-0xf40(%rbp), %rdi
-               	leaq	-0xf60(%rbp), %rdi
-               	leaq	-0xf80(%rbp), %rdi
-               	leaq	-0xfa0(%rbp), %rdi
-               	leaq	-0xfc0(%rbp), %rdi
-               	leaq	-0xfe0(%rbp), %rdi
-               	leaq	-0x1000(%rbp), %rdi
-               	leaq	-0x1020(%rbp), %rdi
-               	leaq	-0x1040(%rbp), %rdi
-               	leaq	-0x1060(%rbp), %rdi
-               	leaq	-0x1080(%rbp), %rdi
-               	leaq	-0x10a0(%rbp), %rdi
-               	leaq	-0x10c0(%rbp), %rdi
-               	leaq	-0x10e0(%rbp), %rdi
-               	leaq	-0x1100(%rbp), %rdi
-               	leaq	-0x1120(%rbp), %rdi
-               	leaq	-0x1140(%rbp), %rdi
-               	leaq	-0x1160(%rbp), %rdi
-               	leaq	-0x1180(%rbp), %rdi
-               	leaq	-0x11a0(%rbp), %rdi
-               	leaq	-0x11c0(%rbp), %rdi
-               	leaq	-0x11e0(%rbp), %rdi
-               	leaq	-0x1200(%rbp), %rdi
-               	leaq	-0x1220(%rbp), %rdi
-               	leaq	-0x1240(%rbp), %rdi
-               	leaq	-0x1260(%rbp), %rdi
-               	leaq	-0x1280(%rbp), %rdi
-               	leaq	-0x12a0(%rbp), %rdi
-               	leaq	-0x12c0(%rbp), %rdi
-               	leaq	-0x12e0(%rbp), %rdi
-               	leaq	-0x1300(%rbp), %rdi
-               	leaq	-0x1320(%rbp), %rdi
-               	leaq	-0x1340(%rbp), %rdi
-               	leaq	-0x1360(%rbp), %rdi
-               	leaq	-0x1380(%rbp), %rdi
-               	leaq	-0x13a0(%rbp), %rdi
-               	leaq	-0x13c0(%rbp), %rdi
-               	leaq	-0x13e0(%rbp), %rdi
-               	leaq	-0x1400(%rbp), %rdi
-               	leaq	-0x1420(%rbp), %rdi
-               	leaq	-0x1440(%rbp), %rdi
-               	leaq	-0x1460(%rbp), %rdi
-               	leaq	-0x1480(%rbp), %rdi
-               	leaq	-0x14a0(%rbp), %rdi
-               	leaq	-0x14c0(%rbp), %rdi
-               	leaq	-0x14e0(%rbp), %rdi
-               	leaq	-0x1500(%rbp), %rdi
-               	leaq	-0x1520(%rbp), %rdi
-               	leaq	-0x1540(%rbp), %rdi
-               	leaq	-0x1560(%rbp), %rdi
-               	leaq	-0x1580(%rbp), %rdi
-               	leaq	-0x15a0(%rbp), %rdi
-               	leaq	-0x15c0(%rbp), %rdi
-               	leaq	-0x15e0(%rbp), %rdi
-               	leaq	-0x1600(%rbp), %rdi
-               	leaq	-0x1620(%rbp), %rdi
-               	leaq	-0x1640(%rbp), %rdi
-               	leaq	-0x1660(%rbp), %rdi
-               	leaq	-0x1680(%rbp), %rdi
-               	leaq	-0x16a0(%rbp), %rdi
-               	leaq	-0x16c0(%rbp), %rdi
-               	leaq	-0x16e0(%rbp), %rdi
-               	leaq	-0x1700(%rbp), %rdi
-               	leaq	-0x1720(%rbp), %rdi
-               	leaq	-0x1740(%rbp), %rdi
-               	leaq	-0x1760(%rbp), %rdi
-               	leaq	-0x1780(%rbp), %rdi
-               	leaq	-0x17a0(%rbp), %rdi
-               	leaq	-0x17c0(%rbp), %rdi
-               	leaq	-0x17e0(%rbp), %rdi
-               	leaq	-0x1800(%rbp), %rdi
-               	leaq	-0x1820(%rbp), %rdi
-               	leaq	-0x1840(%rbp), %rdi
-               	leaq	-0x1860(%rbp), %rdi
-               	leaq	-0x1880(%rbp), %rdi
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0xa50(%rbp)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x960(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3fc00000, (%r13)     ## imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2d3>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2da>
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movl	$0x40700000, (%r13)     ## imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2f8>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2ff>
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movl	$0x40c80000, (%r13)     ## imm = 0x40C80000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x31d>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x324>
+               	leaq	0x14(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movl	$0x3f400000, (%r13)     ## imm = 0x3F400000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x342>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x349>
+               	leaq	0x1c(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rax), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	-0x980(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3f000000, (%r13)     ## imm = 0x3F000000
+               	leaq	0x4(%rdi), %r13
+               	movl	$0x40800000, (%r13)     ## imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x415>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x41c>
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movl	$0x41000000, (%r13)     ## imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x43a>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x441>
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movl	$0x3fa00000, (%r13)     ## imm = 0x3FA00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x45f>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x466>
+               	leaq	0x18(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movl	$0x3d800000, (%r13)     ## imm = 0x3D800000
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	-0x9a0(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3f800000, (%r13)     ## imm = 0x3F800000
+               	leaq	0x4(%rdi), %r13
+               	movl	$0x40400000, (%r13)     ## imm = 0x40400000
+               	leaq	0x8(%rdi), %r13
+               	movl	$0x41100000, (%r13)     ## imm = 0x41100000
+               	leaq	0xc(%rdi), %r13
+               	movl	$0x41d80000, (%r13)     ## imm = 0x41D80000
+               	leaq	0x10(%rdi), %r13
+               	movl	$0x42a20000, (%r13)     ## imm = 0x42A20000
+               	leaq	0x14(%rdi), %r13
+               	movl	$0x43730000, (%r13)     ## imm = 0x43730000
+               	leaq	0x18(%rdi), %r13
+               	movl	$0x44364000, (%r13)     ## imm = 0x44364000
+               	leaq	0x1c(%rdi), %r13
+               	movl	$0x4508b000, (%r13)     ## imm = 0x4508B000
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x10(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x14(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x14(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x18(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x18(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x1c(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x1c(%rsi), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	(%rsi), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x4(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x8(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0xc(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x14(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x18(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x1c(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%r12), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0xc(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x14(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x18(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xa58(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x14(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x18(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x1c(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%r14), %rax
+               	movss	%xmm2, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movq	%r12, %rsi
+               	callq	 <L2>
 <L2>:
-               	leaq	-0x18a0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3fc00000, (%rbx)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x65d>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x664>
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x40700000, (%rbx)     ## imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x67e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x685>
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x40c80000, (%rbx)     ## imm = 0x40C80000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x69f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6a6>
-               	leaq	0x14(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movl	$0x3f400000, (%rbx)     ## imm = 0x3F400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6c0>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6c7>
-               	leaq	0x1c(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r12), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0x18c0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f000000, (%rbx)     ## imm = 0x3F000000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40800000, (%rbx)     ## imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x777>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x77e>
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41000000, (%rbx)     ## imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x798>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x79f>
-               	leaq	0x10(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movl	$0x3fa00000, (%rbx)     ## imm = 0x3FA00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7b9>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7c0>
-               	leaq	0x18(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movl	$0x3d800000, (%rbx)     ## imm = 0x3D800000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r13), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0x18e0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f800000, (%rbx)     ## imm = 0x3F800000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40400000, (%rbx)     ## imm = 0x40400000
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x41100000, (%rbx)     ## imm = 0x41100000
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41d80000, (%rbx)     ## imm = 0x41D80000
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x42a20000, (%rbx)     ## imm = 0x42A20000
-               	leaq	0x14(%rdi), %rbx
-               	movl	$0x43730000, (%rbx)     ## imm = 0x43730000
-               	leaq	0x18(%rdi), %rbx
-               	movl	$0x44364000, (%rbx)     ## imm = 0x44364000
-               	leaq	0x1c(%rdi), %rbx
-               	movl	$0x4508b000, (%rbx)     ## imm = 0x4508B000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r14), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x14(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x18(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x1c(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x1c(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x14(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x18(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x1c(%r15), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L4>
 <L4>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9e0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9e8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9f8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0xa00(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0xa08(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	-0x9c0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x14(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x1c(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %r13
+               	movq	-0xa10(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0xa60(%rbp)
+               	movq	-0xa60(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	%r13, %rdi
+               	movq	-0xa18(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa20(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa28(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rax, %r13
+               	movq	-0xa60(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	-0xa28(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0xa20(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0xa60(%rbp)
+               	movq	-0xa60(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
 <L17>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
+               	leaq	-0x900(%rbp), %r8
+               	movq	%r8, -0xa68(%rbp)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x80, %rsi
 <L18>:
-               	movq	-0x1a58(%rbp), %r8
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L18>
+               	movq	-0xa68(%rbp), %r8
                	leaq	(%r8), %rdx
+               	leaq	(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	0x8(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	0xc(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	0x10(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x14(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x14(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x14(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	0x1c(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	0x1c(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x1c(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
                	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x40(%r8), %rdx
+               	movq	-0xa38(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x60(%r8), %rdx
+               	leaq	(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L19>
+               	jmp	 <L21>
 <L19>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	movq	%rbx, %rdx
+               	imulq	$0x20, %rdx, %rdx
+               	movq	-0xa68(%rbp), %r8
+               	leaq	(%r8,%rdx), %rsi
+               	leaq	(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	movq	-0xa40(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%r13, %rdi
+               	movq	-0xa40(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L20>
 <L20>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
+               	movq	%rax, %r13
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L19>
 <L21>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	leaq	-0x940(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	movq	$0x0, 0x18(%rbx)
+               	movq	$0x0, 0x20(%rbx)
+               	movq	$0x0, 0x28(%rbx)
+               	movq	$0x0, 0x30(%rbx)
+               	movq	$0x0, 0x38(%rbx)
+               	leaq	(%rbx), %rdx
+               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x40(%r8), %rsi
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rbx), %rax
+               	movq	-0xa48(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x30(%rbx), %rax
+               	movl	$0x12345678, (%rax)     ## imm = 0x12345678
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
 <L23>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x10(%rbx), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	movq	-0xa50(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r13, %rdi
+               	movq	-0xa50(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L24>
 <L24>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
+               	leaq	0x30(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
 <L26>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	-0x19c0(%rbp), %rdx
-               	leaq	(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x10(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x14(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x18(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x1c(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x14(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x18(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x1c(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	movq	%rax, %rbx
-               	movq	-0x1a58(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0x1a10(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L91>
-               	jmp	 <L116>
-<L91>:
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	addq	$0x1, %r15
-               	movq	%rax, %rbx
-               	movq	-0x1a28(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0x1a20(%rbp), %r8
-               	movq	%r8, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L91>
-<L116>:
-               	leaq	-0x1960(%rbp), %r15
-               	leaq	(%r15), %rax
-               	addq	$0x0, %rax
-               	movq	$0x80, %rcx
-<L117>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L117>
-               	leaq	(%r15), %rax
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x20(%r15), %rax
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x40(%r15), %rax
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x60(%r15), %rax
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L118>
-               	jmp	 <L127>
-<L118>:
-               	movq	%r12, %rax
-               	imulq	$0x20, %rax, %rax
-               	leaq	(%r15,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x14(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x18(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x1c(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x4, %r12
-               	jb	 <L118>
-<L127>:
-               	leaq	-0x19a0(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, 0x30(%r12)
-               	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0xffffffff, (%rax)     ## imm = 0xFFFFFFFF
-               	leaq	0x40(%r15), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x14(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x1c(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %r13
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L128>
-<L128>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x30(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L137>
-<L137>:
-               	movq	-0x1a78(%rbp), %rbx
-               	movq	-0x1a80(%rbp), %r12
-               	movq	-0x1a88(%rbp), %r13
-               	movq	-0x1a90(%rbp), %r14
-               	movq	-0x1a98(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_f64x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_f64x2.dis
@@ -7,18 +7,58 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,49 +66,45 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_f64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x270, %rsp            ## imm = 0x270
-               	movq	%rbx, -0x258(%rbp)
-               	movq	%r12, -0x260(%rbp)
-               	movq	%r13, -0x268(%rbp)
-               	movq	%r14, -0x270(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x190, %rsp            ## imm = 0x190
+               	movq	%rbx, -0x178(%rbp)
+               	movq	%r12, -0x180(%rbp)
+               	movq	%r13, -0x188(%rbp)
+               	movq	%r14, -0x190(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rsi
+<L1>:
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdi
                	movabsq	$0x3ff8000000000000, %r11 ## imm = 0x3FF8000000000000
-               	movq	%r11, (%rsi)
-               	leaq	0x8(%rcx), %rsi
+               	movq	%r11, (%rdi)
+               	leaq	0x8(%rsi), %rdi
                	movabsq	$-0x3ffe000000000000, %r11 ## imm = 0xC002000000000000
-               	movq	%r11, (%rsi)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+               	movq	%r11, (%rdi)
+               	movups	(%rsi), %xmm1
+               	leaq	-0x90(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	-0xa0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movabsq	$0x3fe0000000000000, %r11 ## imm = 0x3FE0000000000000
                	movq	%r11, (%rbx)
-               	leaq	0x8(%rsi), %rbx
+               	leaq	0x8(%rdi), %rbx
                	movabsq	$0x4010000000000000, %r11 ## imm = 0x4010000000000000
                	movq	%r11, (%rbx)
-               	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
+               	movups	(%rdi), %xmm2
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm2, (%rdi)
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movabsq	$0x3ff0000000000000, %r11 ## imm = 0x3FF0000000000000
                	movq	%r11, (%r12)
@@ -76,256 +112,136 @@ Disassembly of section __TEXT,__text:
                	movabsq	$0x403b000000000000, %r11 ## imm = 0x403B000000000000
                	movq	%r11, (%r12)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x1e0(%rbp)
-               	leaq	(%rcx), %rbx
+               	movups	%xmm14, -0x100(%rbp)
+               	leaq	(%rsi), %rbx
                	movsd	(%rbx), %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	addsd	%xmm0, %xmm5
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	%xmm5, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x1f0(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movsd	(%rcx), %xmm4
+               	leaq	-0xd0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
+               	movsd	%xmm5, (%rbx)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x110(%rbp)
+               	leaq	0x8(%rdi), %rsi
+               	movsd	(%rsi), %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	addsd	%xmm0, %xmm5
-               	leaq	-0x70(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movsd	%xmm5, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	leaq	-0xe0(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movsd	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x110(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x120(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	addpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	subpd	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	addpd	-0x200(%rbp), %xmm14
+               	movaps	-0x110(%rbp), %xmm14
+               	mulpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	divpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm14
+               	divpd	-0x110(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	subpd	-0x1f0(%rbp), %xmm14
+               	movaps	-0x100(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x100(%rbp), %xmm14
+               	divpd	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	mulpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0xf0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movq	$0x0, (%rbx)
+               	leaq	0x8(%rdi), %rbx
+               	movq	$0x0, (%rbx)
+               	movups	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0x110(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movups	%xmm0, -0x150(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, -0x130(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0x130(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	divpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x150(%rbp), %xmm14
+               	addpd	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movups	-0x170(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	divpd	-0x1f0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x1e0(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x1e0(%rbp), %xmm14
-               	divpd	-0x1f0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0x1d0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	movups	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x1f0(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movups	%xmm0, -0x230(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
-               	movaps	-0x220(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
-               	movaps	%xmm14, -0x210(%rbp)
-               	leaq	-0x80(%rbp), %r13
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	-0x230(%rbp), %xmm14
-               	addpd	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	leaq	-0x120(%rbp), %r13
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	leaq	-0x140(%rbp), %r13
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L32>:
-               	leaq	-0xc0(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -334,92 +250,110 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rcx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	movaps	-0x220(%rbp), %xmm14
-               	addpd	-0x200(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movaps	-0x140(%rbp), %xmm14
+               	addpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	movaps	-0x220(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movups	%xmm0, (%rsi)
+               	movaps	-0x140(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm4, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movups	-0x230(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movups	%xmm4, (%rsi)
+               	leaq	0x30(%r12), %rsi
+               	movups	-0x150(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	-0xd0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movsd	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%r13, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x100(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r12), %rdi
+               	movups	(%rdi), %xmm0
+               	leaq	0x10(%r13), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x20(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r13), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movups	(%r12), %xmm0
-               	leaq	-0x110(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x258(%rbp), %rbx
-               	movq	-0x260(%rbp), %r12
-               	movq	-0x268(%rbp), %r13
-               	movq	-0x270(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0x20(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x178(%rbp), %rbx
+               	movq	-0x180(%rbp), %r12
+               	movq	-0x188(%rbp), %r13
+               	movq	-0x190(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i16x4.dis
@@ -7,28 +7,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -36,16 +112,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1f0, %rsp            ## imm = 0x1F0
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%r12, -0x1e0(%rbp)
-               	movq	%r13, -0x1e8(%rbp)
-               	movq	%r14, -0x1f0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x8(%rbp), %rdx
+               	subq	$0x190, %rsp            ## imm = 0x190
+               	movq	%rbx, -0x178(%rbp)
+               	movq	%r12, -0x180(%rbp)
+               	movq	%r13, -0x188(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x44(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x3e9, (%rsi)          ## imm = 0x3E9
                	leaq	0x2(%rdx), %rsi
@@ -55,9 +127,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rdx), %rsi
                	movw	$0xfaeb, (%rsi)         ## imm = 0xFAEB
                	movsd	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rdx
+               	leaq	-0x4c(%rbp), %rdx
                	movsd	%xmm0, (%rdx)
-               	leaq	-0x18(%rbp), %rsi
+               	leaq	-0x54(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0xd, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -67,9 +139,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rsi), %rdi
                	movw	$0xfff9, (%rdi)         ## imm = 0xFFF9
                	movsd	(%rsi), %xmm1
-               	leaq	-0x20(%rbp), %rsi
+               	leaq	-0x5c(%rbp), %rsi
                	movsd	%xmm1, (%rsi)
-               	leaq	-0x28(%rbp), %rdi
+               	leaq	-0x64(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -79,8 +151,8 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x4, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x110(%rbp)
-               	leaq	-0x30(%rbp), %rdi
+               	movq	%r11, -0xa0(%rbp)
+               	leaq	-0x6c(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -90,459 +162,198 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x120(%rbp)
+               	movq	%r11, -0xb0(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x38(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x74(%rbp), %rdi
                	movsd	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movsd	(%rdi), %xmm0
                	leaq	0x6(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x40(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	0x6(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movq	(%rbx), %r11
-               	movq	%r11, -0x130(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0x7c(%rbp), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	0x6(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movq	(%rdx), %r11
+               	movq	%r11, -0xc0(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x48(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x84(%rbp), %rdx
                	movsd	%xmm1, (%rdx)
                	leaq	0x2(%rdx), %rdi
                	movw	%si, (%rdi)
                	movsd	(%rdx), %xmm0
                	leaq	0x4(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x50(%rbp), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0x4(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movq	(%r12), %r11
-               	movq	%r11, -0x140(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x8c(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movq	(%rax), %r11
+               	movq	%r11, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0xc0(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0xd0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0xe0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0xe0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	psubw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xd0(%rbp), %xmm14
+               	psubw	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	pmullw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xd0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x130(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xb4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x130(%rbp), %xmm14
-               	psubw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x140(%rbp), %xmm14
-               	psubw	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pmullw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xdc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x140(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xec(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x130(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xf4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x120(%rbp), %xmm14
-               	psubw	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xfc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x120(%rbp), %xmm14
-               	psubw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pand	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x150(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x150(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x130(%rbp), %xmm14
-               	por	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x160(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x160(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pxor	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x140(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x150(%rbp), %xmm14
-               	pxor	-0x160(%rbp), %xmm14
+               	movaps	-0xe0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0xb0(%rbp), %xmm14
+               	psubw	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0xb0(%rbp), %xmm14
+               	psubw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pand	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0xf0(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xf0(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	por	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0x100(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x100(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pxor	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0xd0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0xf0(%rbp), %xmm14
+               	pxor	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x130(%rbp), %xmm14
-               	movups	%xmm14, -0x180(%rbp)
-               	movups	-0x120(%rbp), %xmm14
-               	movups	%xmm14, -0x190(%rbp)
-               	movups	-0x120(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0xc0(%rbp), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movups	-0xb0(%rbp), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	movups	-0xb0(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L48>
-               	jmp	 <L65>
-<L48>:
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, -0x170(%rbp)
-               	leaq	-0x58(%rbp), %r13
-               	movq	-0x170(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x120(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, -0x110(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x110(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x130(%rbp), %xmm14
+               	pxor	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x150(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x160(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x120(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x190(%rbp), %xmm14
-               	pxor	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, -0x1b0(%rbp)
-               	leaq	-0xac(%rbp), %r13
-               	movq	-0x1b0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, -0x1c0(%rbp)
-               	leaq	-0xbc(%rbp), %r13
-               	movq	-0x1c0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x180(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x1d0(%rbp)
-               	leaq	-0xcc(%rbp), %r13
-               	movq	-0x1d0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x1d0(%rbp), %xmm14
-               	movups	%xmm14, -0x180(%rbp)
-               	movups	-0x1b0(%rbp), %xmm14
-               	movups	%xmm14, -0x190(%rbp)
-               	movups	-0x1c0(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movups	-0x150(%rbp), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L48>
-<L65>:
-               	leaq	-0x88(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -550,110 +361,108 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
                	leaq	(%r12), %rax
-               	movq	-0x180(%rbp), %r11
+               	movq	-0x120(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x120(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x8(%r12), %rax
-               	movsd	%xmm3, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movsd	%xmm0, (%rax)
+               	movaps	-0x120(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r12), %rax
-               	movsd	%xmm3, (%rax)
+               	movsd	%xmm0, (%rax)
                	leaq	0x18(%r12), %rax
-               	movq	-0x190(%rbp), %r11
+               	movq	-0x130(%rbp), %r11
                	movq	%r11, (%rax)
                	leaq	0x20(%r12), %rax
-               	movq	-0x1a0(%rbp), %r11
+               	movq	-0x140(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	pxor	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	pxor	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	leaq	0x28(%r12), %rax
-               	movsd	%xmm0, (%rax)
+               	movsd	%xmm5, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L66>
-               	jmp	 <L71>
-<L66>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	leaq	(%r12,%r13,8), %rax
                	movsd	(%rax), %xmm0
-               	leaq	-0x90(%rbp), %r14
-               	movsd	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L66>
-<L71>:
-               	leaq	-0x9c(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x3c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	$0x0, 0x8(%r13)
                	leaq	(%r13), %rax
                	movb	$-0x25, (%rax)
-               	leaq	0x10(%r12), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	0x2(%r13), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0xa(%r13), %rcx
-               	movb	$-0x53, (%rcx)
-               	movzbl	(%rax), %esi
+               	leaq	0x10(%r12), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x2(%r13), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	0xa(%r13), %rdx
+               	movb	$-0x53, (%rdx)
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	callq	 <L72>
-<L72>:
-               	movsd	(%r12), %xmm0
-               	leaq	-0xa4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %r12
-               	movq	-0x1e8(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x2(%r13), %rax
+               	movsd	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0xa(%r13), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x178(%rbp), %rbx
+               	movq	-0x180(%rbp), %r12
+               	movq	-0x188(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i16x8.dis
@@ -7,48 +7,196 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
+               	leaq	0x8(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -56,16 +204,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            ## imm = 0x2E0
-               	movq	%rbx, -0x2c8(%rbp)
-               	movq	%r12, -0x2d0(%rbp)
-               	movq	%r13, -0x2d8(%rbp)
-               	movq	%r14, -0x2e0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x210, %rsp            ## imm = 0x210
+               	movq	%rbx, -0x1f8(%rbp)
+               	movq	%r12, -0x200(%rbp)
+               	movq	%r13, -0x208(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x3e9, (%rsi)          ## imm = 0x3E9
                	leaq	0x2(%rdx), %rsi
@@ -83,9 +227,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xf953, (%rsi)         ## imm = 0xF953
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0xd, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -103,9 +247,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0xffff, (%rdi)         ## imm = 0xFFFF
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xb0(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0xc0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -123,8 +267,8 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x8, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	-0x60(%rbp), %rdi
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	-0xd0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -142,739 +286,198 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
+               	movups	%xmm14, -0x130(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0xe0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movups	(%rdi), %xmm0
                	leaq	0xc(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x80(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0xf0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x90(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xe(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x140(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x220(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x230(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pand	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x240(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x220(%rbp), %xmm14
-               	por	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x250(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pxor	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x240(%rbp), %xmm14
-               	pxor	-0x250(%rbp), %xmm14
+               	movaps	-0x160(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L87>
-<L87>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pand	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x140(%rbp), %xmm14
+               	por	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x180(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pxor	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x150(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x170(%rbp), %xmm14
+               	pxor	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x190(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x1b0(%rbp), %xmm14
+               	pxor	-0x190(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1d0(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x1c0(%rbp), %xmm14
+               	paddw	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1e0(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x1f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x280(%rbp), %xmm14
-               	pxor	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, -0x2a0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
+               	movups	-0x1f0(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x1f0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x1e0(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -884,78 +487,39 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x270(%rbp), %xmm14
+               	movups	-0x1a0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x10(%r12), %rax
-               	movups	%xmm3, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rax
+               	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm5, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x280(%rbp), %xmm14
+               	movups	-0x1b0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -964,70 +528,65 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x20(%r12), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     ## imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L132>
-<L132>:
-               	movups	(%r12), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L141>
-<L141>:
-               	movq	-0x2c8(%rbp), %rbx
-               	movq	-0x2d0(%rbp), %r12
-               	movq	-0x2d8(%rbp), %r13
-               	movq	-0x2e0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%r13), %rax
+               	movups	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x1f8(%rbp), %rbx
+               	movq	-0x200(%rbp), %r12
+               	movq	-0x208(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i32x4.dis
@@ -7,32 +7,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,17 +112,14 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x480, %rsp            ## imm = 0x480
-               	movq	%rbx, -0x458(%rbp)
-               	movq	%r12, -0x460(%rbp)
-               	movq	%r13, -0x468(%rbp)
-               	movq	%r14, -0x470(%rbp)
-               	movq	%r15, -0x478(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x410, %rsp            ## imm = 0x410
+               	movq	%rbx, -0x3e8(%rbp)
+               	movq	%r12, -0x3f0(%rbp)
+               	movq	%r13, -0x3f8(%rbp)
+               	movq	%r14, -0x400(%rbp)
+               	movq	%r15, -0x408(%rbp)
+               	movl	%edi, %eax
+               	leaq	-0x110(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0x2717, (%rsi)         ## imm = 0x2717
                	leaq	0x4(%rdx), %rsi
@@ -60,9 +129,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdx), %rsi
                	movl	$0xffff8000, (%rsi)     ## imm = 0xFFFF8000
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x120(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x130(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0xfffffff9, (%rdi)     ## imm = 0xFFFFFFF9
                	leaq	0x4(%rsi), %rdi
@@ -72,9 +141,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x3, (%rdi)
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0x140(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x150(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movl	$0x1, (%rbx)
                	leaq	0x4(%rdi), %rbx
@@ -84,9 +153,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %rbx
                	movl	$0x1b, (%rbx)
                	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x160(%rbp), %rbx
                	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x170(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -96,529 +165,324 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x380(%rbp)
+               	movups	%xmm14, -0x310(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x180(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
                	movl	%edx, (%r12)
                	movups	(%rdi), %xmm0
                	leaq	0x8(%rdi), %rdx
                	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	addl	%eax, %edi
+               	leaq	-0x190(%rbp), %r12
                	movups	%xmm0, (%r12)
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x320(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r13
+               	addl	%eax, %edx
+               	leaq	-0x1b0(%rbp), %r13
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%r13), %rax
+               	movl	%edx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm14, -0x330(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x320(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x330(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x340(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x340(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x330(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rax, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%r13), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r13), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x390(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x3a0(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm0
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r12), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %edi
                	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x210(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%esi, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x220(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r13), %rdx
                	movl	(%rdx), %edi
                	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r12d
                	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r13), %rdx
                	movl	(%rdx), %r12d
                	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r12d
+               	leaq	0xc(%r13), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%esi, (%r13)
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r13d
+               	leaq	-0x250(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%esi, (%r15)
                	movups	(%rdx), %xmm0
-               	leaq	-0x320(%rbp), %rdx
+               	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x330(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %edi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	-0x290(%rbp), %rdx
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%esi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movl	%r12d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pand	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3b0(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x390(%rbp), %xmm14
-               	por	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3c0(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x390(%rbp), %xmm14
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pand	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x350(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x320(%rbp), %xmm14
+               	por	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x360(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x320(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x3a0(%rbp), %xmm14
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x330(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x3b0(%rbp), %xmm14
-               	pxor	-0x3c0(%rbp), %xmm14
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x350(%rbp), %xmm14
+               	pxor	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r12
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
                	movq	$0x0, %r13
-<L48>:
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x3e0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x90(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -628,356 +492,258 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rbx), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x358(%rbp)
+               	movl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x2e0(%rbp)
                	leaq	0x4(%r14), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %esi
                	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2e8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %edi
+               	leaq	0xc(%r14), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
                	movl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0x8(%r14), %rax
-               	movl	(%rax), %esi
-               	leaq	0x8(%rbx), %rax
-               	movl	(%rax), %edi
-               	imull	%edi, %esi
-               	leaq	0xc(%r14), %rax
-               	movl	(%rax), %edi
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %edi
-               	leaq	-0x150(%rbp), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	leaq	-0xa0(%rbp), %rax
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x160(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x170(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x180(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%edi, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rsi
+               	movq	-0x2e0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xb0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x2e8(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x3f0(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x3f8(%rbp)
-               	movq	-0x3f8(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
-               	movq	-0x3f8(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x400(%rbp)
-               	movq	-0x400(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x400(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x360(%rbp)
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x398(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x398(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	-0x368(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%r8, %rdi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x398(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x398(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x100(%rbp), %r8
+               	movq	%r8, -0x3a0(%rbp)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
+               	callq	 <L23>
+<L23>:
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdx
-               	movq	-0x3f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x3f8(%rbp)
-               	movq	-0x3f8(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x408(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L55>
-<L55>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x1d0(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x458(%rbp), %rbx
-               	movq	-0x460(%rbp), %r12
-               	movq	-0x468(%rbp), %r13
-               	movq	-0x470(%rbp), %r14
-               	movq	-0x478(%rbp), %r15
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x3e8(%rbp), %rbx
+               	movq	-0x3f0(%rbp), %r12
+               	movq	-0x3f8(%rbp), %r13
+               	movq	-0x400(%rbp), %r14
+               	movq	-0x408(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2f8(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %edi
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x3e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x420(%rbp)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r15d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%r8d, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r14
+               	movl	%edi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3b0(%rbp)
                	movq	%r12, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	paddd	-0x420(%rbp), %xmm14
-               	movaps	%xmm14, -0x430(%rbp)
-               	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L69>
-<L69>:
-               	movaps	-0x430(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x440(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	jmp	 <L48>
+               	movups	-0x3e0(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-darwin/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i64x2.dis
@@ -7,18 +7,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,24 +64,21 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3a0, %rsp            ## imm = 0x3A0
-               	movq	%rbx, -0x378(%rbp)
-               	movq	%r12, -0x380(%rbp)
-               	movq	%r13, -0x388(%rbp)
-               	movq	%r14, -0x390(%rbp)
-               	movq	%r15, -0x398(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x310, %rsp            ## imm = 0x310
+               	movq	%rbx, -0x2e8(%rbp)
+               	movq	%r12, -0x2f0(%rbp)
+               	movq	%r13, -0x2f8(%rbp)
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x308(%rbp)
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$0x3b9aca07, (%rdx)     ## imm = 0x3B9ACA07
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$-0x7735940b, (%rdx)    ## imm = 0x88CA6BF5
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0xb2d05e13, %r11       ## imm = 0xB2D05E13
                	movq	%r11, (%rsi)
@@ -51,311 +86,235 @@ Disassembly of section __TEXT,__text:
                	movabsq	$-0xee6b2825, %r11      ## imm = 0xFFFFFFFF1194D7DB
                	movq	%r11, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x1, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x3, (%rdi)
+               	leaq	-0x110(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movq	$0x1, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x3, (%rbx)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	-0x70(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
+               	leaq	-0x120(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x130(%rbp), %rsi
+               	leaq	(%rsi), %r12
+               	movq	$0x0, (%r12)
+               	leaq	0x8(%rsi), %r12
+               	movq	$0x0, (%r12)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movq	%rcx, (%rsi)
+               	movups	%xmm14, -0x200(%rbp)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rdi, %rax
+               	leaq	-0x140(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	(%r12), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x210(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rdi, %rdx
+               	leaq	-0x150(%rbp), %r13
+               	movups	%xmm1, (%r13)
+               	leaq	0x8(%r13), %rax
+               	movq	%rdx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x2b0(%rbp)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movups	%xmm14, -0x220(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x210(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x220(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x230(%rbp)
+               	leaq	-0x160(%rbp), %r14
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
+               	movups	-0x230(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %rdi
+               	leaq	-0x170(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%rsi, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x190(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1d0(%rbp), %rdx
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pand	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	por	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pxor	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x220(%rbp), %rcx
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pand	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2c0(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	por	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2d0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2d0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r12
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	movq	$0x0, %r13
-<L28>:
-               	leaq	-0xa0(%rbp), %r14
-               	movups	-0x2f0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x70(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -365,231 +324,211 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movq	(%rax), %rcx
-               	leaq	(%r12), %rax
                	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r14), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r12), %rax
+               	leaq	(%rbx), %rax
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
-               	leaq	-0x110(%rbp), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	-0x80(%rbp), %rax
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rsi
-               	movq	%rcx, (%rsi)
-               	movups	(%rax), %xmm2
-               	leaq	-0x120(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rdi
+               	movq	%rdx, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x90(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rsi, (%rdx)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x300(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x2d8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x320(%rbp)
-               	movq	-0x320(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x320(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x278(%rbp)
-               	movq	-0x2d8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x278(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x298(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdx
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x2d8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x328(%rbp)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x328(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x2d8(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x258(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L33>
-<L33>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x170(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movq	(%rdx), %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r15), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x378(%rbp), %rbx
-               	movq	-0x380(%rbp), %r12
-               	movq	-0x388(%rbp), %r13
-               	movq	-0x390(%rbp), %r14
-               	movq	-0x398(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x2e8(%rbp), %rbx
+               	movq	-0x2f0(%rbp), %r12
+               	movq	-0x2f8(%rbp), %r13
+               	movq	-0x300(%rbp), %r14
+               	movq	-0x308(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
+<L26>:
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	imulq	%rdi, %rsi
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xc0(%rbp), %r14
-               	movups	%xmm2, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x270(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rsi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x2b0(%rbp)
+               	movq	%r12, %rdi
+               	movups	-0x2b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movaps	-0x300(%rbp), %xmm14
-               	pxor	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x350(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x290(%rbp), %xmm14
+               	paddq	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x2e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x2f0(%rbp), %xmm14
-               	movaps	%xmm14, -0x360(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x370(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
+               	movups	-0x2e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
-               	jmp	 <L28>
+               	movq	%rax, %r12
+               	movups	-0x2e0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2d0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-darwin/vec/vec_i8x16.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i8x16.dis
@@ -7,88 +7,380 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -96,1101 +388,1086 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xac0, %rsp            ## imm = 0xAC0
-               	movq	%rbx, -0xa98(%rbp)
-               	movq	%r12, -0xaa0(%rbp)
-               	movq	%r13, -0xaa8(%rbp)
-               	movq	%r14, -0xab0(%rbp)
-               	movq	%r15, -0xab8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0xaa0, %rsp            ## imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movb	%dil, %al
+               	leaq	-0x290(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x9, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x5, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$0x3, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x4, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x6, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$-0x8, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x9, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x3, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x2, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x4, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$0x8, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x2b0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movb	$0x2, (%rsi)
+               	leaq	0x1(%rdx), %rsi
+               	movb	$-0x3, (%rsi)
+               	leaq	0x2(%rdx), %rsi
+               	movb	$0x4, (%rsi)
+               	leaq	0x3(%rdx), %rsi
+               	movb	$-0x5, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movb	$0x6, (%rsi)
+               	leaq	0x5(%rdx), %rsi
+               	movb	$-0x7, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movb	$0x8, (%rsi)
+               	leaq	0x7(%rdx), %rsi
+               	movb	$-0x9, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movb	$0x1, (%rsi)
+               	leaq	0x9(%rdx), %rsi
+               	movb	$-0x2, (%rsi)
+               	leaq	0xa(%rdx), %rsi
+               	movb	$0x3, (%rsi)
+               	leaq	0xb(%rdx), %rsi
+               	movb	$-0x4, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movb	$0x5, (%rsi)
+               	leaq	0xd(%rdx), %rsi
+               	movb	$-0x6, (%rsi)
+               	leaq	0xe(%rdx), %rsi
+               	movb	$0x7, (%rsi)
+               	leaq	0xf(%rdx), %rsi
+               	movb	$-0x1, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	-0x2d0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	-0x2e0(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x2f0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x990(%rbp)
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x300(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x310(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x7(%r12), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x9a0(%rbp)
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x330(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0xc(%r13), %rax
+               	movb	%cl, (%rax)
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, -0x9b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x9a0(%rbp), %xmm0
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movb	$-0x9, (%rsi)
-               	leaq	0x1(%rdx), %rsi
-               	movb	$0x7, (%rsi)
-               	leaq	0x2(%rdx), %rsi
-               	movb	$-0x5, (%rsi)
-               	leaq	0x3(%rdx), %rsi
-               	movb	$0x3, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movb	$-0x1, (%rsi)
-               	leaq	0x5(%rdx), %rsi
-               	movb	$0x2, (%rsi)
-               	leaq	0x6(%rdx), %rsi
-               	movb	$-0x4, (%rsi)
-               	leaq	0x7(%rdx), %rsi
-               	movb	$0x6, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movb	$-0x8, (%rsi)
-               	leaq	0x9(%rdx), %rsi
-               	movb	$0x9, (%rsi)
-               	leaq	0xa(%rdx), %rsi
-               	movb	$-0x3, (%rsi)
-               	leaq	0xb(%rdx), %rsi
-               	movb	$0x1, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movb	$-0x2, (%rsi)
-               	leaq	0xd(%rdx), %rsi
-               	movb	$0x4, (%rsi)
-               	leaq	0xe(%rdx), %rsi
-               	movb	$-0x6, (%rsi)
-               	leaq	0xf(%rdx), %rsi
-               	movb	$0x8, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	$0x2, (%rbx)
-               	leaq	0x1(%rsi), %rbx
-               	movb	$-0x3, (%rbx)
-               	leaq	0x2(%rsi), %rbx
-               	movb	$0x4, (%rbx)
-               	leaq	0x3(%rsi), %rbx
-               	movb	$-0x5, (%rbx)
-               	leaq	0x4(%rsi), %rbx
-               	movb	$0x6, (%rbx)
-               	leaq	0x5(%rsi), %rbx
-               	movb	$-0x7, (%rbx)
-               	leaq	0x6(%rsi), %rbx
-               	movb	$0x8, (%rbx)
-               	leaq	0x7(%rsi), %rbx
-               	movb	$-0x9, (%rbx)
-               	leaq	0x8(%rsi), %rbx
-               	movb	$0x1, (%rbx)
-               	leaq	0x9(%rsi), %rbx
-               	movb	$-0x2, (%rbx)
-               	leaq	0xa(%rsi), %rbx
-               	movb	$0x3, (%rbx)
-               	leaq	0xb(%rsi), %rbx
-               	movb	$-0x4, (%rbx)
-               	leaq	0xc(%rsi), %rbx
-               	movb	$0x5, (%rbx)
-               	leaq	0xd(%rsi), %rbx
-               	movb	$-0x6, (%rbx)
-               	leaq	0xe(%rsi), %rbx
-               	movb	$0x7, (%rbx)
-               	leaq	0xf(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x3(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x4(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x5(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x6(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x7(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x9(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xa(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xb(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xc(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0xd(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xe(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xf(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9b0(%rbp)
-               	leaq	(%rdx), %r12
-               	movzbl	(%r12), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%dl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rdx
-               	movzbl	(%rdx), %r12d
-               	addl	%ecx, %r12d
-               	leaq	-0x90(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x7(%r13), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x9c0(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x3(%rdx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rsi
-               	movzbl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rcx
-               	movb	%dl, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9d0(%rbp)
-               	movups	-0x9c0(%rbp), %xmm0
+               	movups	-0x9b0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9c0(%rbp)
+               	leaq	-0x340(%rbp), %r14
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movups	-0x9d0(%rbp), %xmm0
+               	movups	-0x9c0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9e0(%rbp)
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
-               	movaps	-0x9d0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L5>
-<L5>:
                	movq	%rax, %r8
                	movq	%r8, -0x748(%rbp)
                	movq	-0x748(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
                	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
                	movq	%r8, -0x750(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
                	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %r15d
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%r13), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
+               	imull	%edi, %r8d
                	movq	%r8, -0x758(%rbp)
-               	leaq	0x2(%r13), %rcx
-               	movzbl	(%rcx), %r15d
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x760(%rbp)
-               	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x768(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x770(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x780(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x788(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x790(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7a0(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x7a8(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7b0(%rbp)
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rdx
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rdx
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rdx
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rdx
-               	movq	-0x778(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rdx
-               	movq	-0x780(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rdx
-               	movq	-0x788(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	-0x790(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rdx
-               	movq	-0x798(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rdx
-               	movq	-0x7a0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rdx
-               	movq	-0x7a8(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movq	-0x7b0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x748(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7c0(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x2(%r13), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x760(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
                	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x768(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7d8(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x770(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x7e0(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x778(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x7f0(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	movq	%r8, -0x780(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %r15d
                	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x788(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f8(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x800(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x810(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x818(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x7a8(%rbp)
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x7f0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x7f8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x800(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x808(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x810(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x818(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x7b8(%rbp), %r8
+               	leaq	-0x350(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x750(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x360(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rsi
+               	movq	-0x758(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x370(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rsi
+               	movq	-0x760(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x380(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rsi
+               	movq	-0x768(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x390(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x770(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rsi
+               	movq	-0x778(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rsi
+               	movq	-0x780(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rsi
+               	movq	-0x788(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	-0x790(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rsi
+               	movq	-0x798(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rsi
+               	movq	-0x7a0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rsi
+               	movq	-0x7a8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x748(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
-<L7>:
+               	callq	 <L5>
+<L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x7b8(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7c0(%rbp)
                	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %eax
                	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x840(%rbp)
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x7d0(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x848(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x7e0(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7e8(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x7f8(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x800(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x808(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x450(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movq	-0x7b8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
+               	movq	-0x7c0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x7c8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x7d0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0x7d8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0x7e0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0x7e8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0x7f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0x7f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movq	-0x800(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r12
+               	movq	-0x808(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r12
+               	movb	%sil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	-0x810(%rbp), %r8
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x5(%rbx), %rcx
+               	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x850(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	movq	%r8, -0x818(%rbp)
+               	leaq	0x1(%r13), %rcx
                	movzbl	(%rcx), %esi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x858(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x7(%rbx), %rcx
+               	imull	%edi, %r8d
+               	movq	%r8, -0x820(%rbp)
+               	leaq	0x2(%r13), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x828(%rbp)
+               	leaq	0x3(%r13), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%r12d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x830(%rbp)
+               	leaq	0x4(%r13), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x838(%rbp)
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x840(%rbp)
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x848(%rbp)
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x850(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x858(%rbp)
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r12d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0x860(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x868(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x870(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x878(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %edx
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	-0x9d0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r12
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r12
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r12
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r12
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r12
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r12
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r12
-               	movq	-0x860(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r12
-               	movq	-0x868(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r12
-               	movq	-0x870(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r12
-               	movq	-0x878(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dil, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x550(%rbp), %rax
+               	movups	-0x9b0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x818(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x820(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
+               	movq	-0x828(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
+               	movq	-0x830(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movq	-0x838(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
+               	movq	-0x840(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
+               	movq	-0x848(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
+               	movq	-0x850(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movq	-0x858(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
+               	movq	-0x860(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
+               	movb	%r15b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x600(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%r12b, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x810(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x868(%rbp), %r8
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x870(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x878(%rbp)
                	leaq	0x2(%r14), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x880(%rbp)
+               	leaq	0x3(%r14), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%r12d, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x898(%rbp)
-               	leaq	0x3(%r14), %rcx
+               	movq	%r8, -0x888(%rbp)
+               	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x3(%rbx), %rcx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r13d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
-               	leaq	0x4(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0x890(%rbp)
                	leaq	0x5(%r14), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %r15d
                	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x898(%rbp)
+               	leaq	0x6(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
-               	leaq	0x6(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x8a0(%rbp)
+               	leaq	0x7(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
-               	leaq	0x7(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x8(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x9(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0xa(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xb(%r14), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xc(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0xd(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %esi
-               	leaq	0xe(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x8b0(%rbp)
+               	leaq	0x9(%r14), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xa(%r14), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xf(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
+               	leaq	0xb(%r14), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r13d
+               	leaq	0xc(%r14), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x650(%rbp), %rax
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r14
+               	movq	-0x870(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x878(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x880(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
                	movq	-0x888(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
                	movq	-0x890(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
                	movq	-0x898(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
                	movq	-0x8a0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
                	movq	-0x8a8(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
                	movq	-0x8b0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
                	movb	%dil, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdi
-               	movb	%dl, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r12b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x710(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x868(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pand	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9d0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	-0x9d0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	por	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9e0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pand	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9f0(%rbp)
-               	movups	-0x9f0(%rbp), %xmm0
+               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pxor	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	por	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa00(%rbp)
-               	movups	-0xa00(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pxor	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movaps	-0x9d0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	pxor	-0x9e0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
+               	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x9f0(%rbp), %xmm14
-               	pxor	-0xa00(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm0
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %r12
-               	movups	-0x9c0(%rbp), %xmm14
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0x990(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0x990(%rbp), %xmm14
                	movups	%xmm14, -0xa20(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
                	movq	$0x0, %r13
-<L18>:
-               	leaq	-0x4d0(%rbp), %r14
-               	movups	-0xa20(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x3, %r13
-               	jb	 <L25>
-               	leaq	-0x610(%rbp), %r15
+               	jb	 <L24>
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -1200,10 +1477,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
                	movups	%xmm0, (%rax)
@@ -1213,91 +1490,91 @@ Disassembly of section __TEXT,__text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0x8b8(%rbp)
                	leaq	0x1(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x2(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x2(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x3(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x3(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x4(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x5(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x6(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x7(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x8(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x9(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0xa(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xb(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xc(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xd(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rbx), %rax
@@ -1313,96 +1590,96 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %edi
-               	leaq	-0x620(%rbp), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x160(%rbp), %rax
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0x8b8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0x8c0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0x8c8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0x8d0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x1b0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x1e0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%sil, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%dil, (%rcx)
@@ -1410,163 +1687,175 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0xa30(%rbp), %xmm14
+               	movups	-0xa10(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	movq	-0xa48(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm0
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xa48(%rbp), %r8
+               	callq	 <L19>
+<L19>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x740(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	movq	$0x0, 0x10(%rcx)
-               	movq	$0x0, 0x18(%rcx)
-               	movq	$0x0, 0x20(%rcx)
-               	movq	$0x0, 0x28(%rcx)
-               	leaq	(%rcx), %rdx
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x280(%rbp), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%rcx), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0x20(%rcx), %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	movl	$0x12345678, (%r8)      ## imm = 0x12345678
-               	movl	(%rdx), %ecx
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%ecx, %esi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movups	(%r15), %xmm0
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movl	(%rdx), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x940(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xa98(%rbp), %rbx
-               	movq	-0xaa0(%rbp), %r12
-               	movq	-0xaa8(%rbp), %r13
-               	movq	-0xab0(%rbp), %r14
-               	movq	-0xab8(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x928(%rbp)
                	leaq	0x2(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x3(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x5(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x6(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x7(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x8(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x9(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0xa(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0xb(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x9a0(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xc(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rbx), %rcx
@@ -1587,131 +1876,131 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x20(%rbp), %rcx
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x70(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r15
                	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0x960(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0x968(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0x970(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0x978(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%dil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0xa60(%rbp)
+               	movups	%xmm14, -0xa40(%rbp)
                	movq	%r12, %rdi
-               	movups	-0xa60(%rbp), %xmm0
+               	movups	-0xa40(%rbp), %xmm0
+               	callq	 <L25>
+<L25>:
+               	movaps	-0xa10(%rbp), %xmm14
+               	pxor	-0xa40(%rbp), %xmm14
+               	movaps	%xmm14, -0xa50(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa50(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
-               	movaps	-0xa30(%rbp), %xmm14
-               	pxor	-0xa60(%rbp), %xmm14
+               	movaps	-0xa20(%rbp), %xmm14
+               	paddb	-0xa00(%rbp), %xmm14
+               	movaps	%xmm14, -0xa60(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa60(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, -0xa70(%rbp)
                	movq	%rax, %rdi
                	movups	-0xa70(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movaps	-0xa40(%rbp), %xmm14
-               	paddb	-0xa20(%rbp), %xmm14
-               	movaps	%xmm14, -0xa80(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa80(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa90(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa90(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0xa90(%rbp), %xmm14
-               	movups	%xmm14, -0xa20(%rbp)
                	movups	-0xa70(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0xa80(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
-               	jmp	 <L18>
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0xa50(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0xa60(%rbp), %xmm14
+               	movups	%xmm14, -0xa20(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-darwin/vec/vec_lane_ops.dis
+++ b/test/golden/x86_64-darwin/vec/vec_lane_ops.dis
@@ -7,32 +7,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -42,28 +114,108 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -73,18 +225,58 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -94,88 +286,217 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	leaq	(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rsi
                	callq	 <L12>
 <L12>:
+               	leaq	0x7(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L13>
 <L13>:
+               	leaq	0x8(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L14>
 <L14>:
+               	leaq	0x9(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L15>
 <L15>:
+               	leaq	0xa(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L16>
+<L16>:
+               	leaq	0xb(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L17>
+<L17>:
+               	leaq	0xc(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L18>
+<L18>:
+               	leaq	0xd(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L19>
+<L19>:
+               	leaq	0xe(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L20>
+<L20>:
+               	leaq	0xf(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -183,958 +504,615 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x710, %rsp            ## imm = 0x710
-               	movq	%rbx, -0x6e8(%rbp)
-               	movq	%r12, -0x6f0(%rbp)
-               	movq	%r13, -0x6f8(%rbp)
-               	movq	%r14, -0x700(%rbp)
-               	movq	%r15, -0x708(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	movq	%rbx, %r11
+               	subq	$0x650, %rsp            ## imm = 0x650
+               	movq	%rbx, -0x628(%rbp)
+               	movq	%r12, -0x630(%rbp)
+               	movq	%r13, -0x638(%rbp)
+               	movq	%r14, -0x640(%rbp)
+               	movq	%r15, -0x648(%rbp)
+               	movl	%edi, %eax
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x608(%rbp)
-               	movq	%rbx, %r11
+<L1>:
+               	movss	%xmm14, -0x558(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
+<L3>:
+               	movsd	%xmm14, -0x568(%rbp)
+               	movb	%dil, %bl
+               	leaq	-0x10(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movl	$0x11111111, (%rdx)     ## imm = 0x11111111
+               	leaq	0x4(%rcx), %rdx
+               	movl	$0x22222222, (%rdx)     ## imm = 0x22222222
+               	leaq	0x8(%rcx), %rdx
+               	movl	$0x33333333, (%rdx)     ## imm = 0x33333333
+               	leaq	0xc(%rcx), %rdx
+               	movl	$0x44444444, (%rdx)     ## imm = 0x44444444
+               	movups	(%rcx), %xmm0
+               	leaq	-0x20(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	%ecx, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%rdx), %rcx
+               	movl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x40(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0xc(%r12), %rax
+               	movl	%edx, (%rax)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x580(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x580(%rbp), %xmm0
+               	callq	 <L4>
 <L4>:
-               	movsd	%xmm14, -0x618(%rbp)
-               	movb	%bl, %r12b
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movl	$0x11111111, (%rsi)     ## imm = 0x11111111
-               	leaq	0x4(%rdx), %rsi
-               	movl	$0x22222222, (%rsi)     ## imm = 0x22222222
-               	leaq	0x8(%rdx), %rsi
-               	movl	$0x33333333, (%rsi)     ## imm = 0x33333333
-               	leaq	0xc(%rdx), %rsi
-               	movl	$0x44444444, (%rsi)     ## imm = 0x44444444
-               	movups	(%rdx), %xmm2
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x30(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	(%rsi), %rdi
-               	movl	%edx, (%rdi)
-               	movups	(%rsi), %xmm2
-               	leaq	0xc(%rsi), %rdx
-               	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x40(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x630(%rbp)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
                	leaq	-0x50(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	leaq	0xc(%r12), %rcx
+               	movl	(%rcx), %r14d
+               	movups	(%r13), %xmm0
                	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	%r14d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %r15d
+               	movups	(%r13), %xmm0
                	leaq	-0x70(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r15d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x4(%r12), %rcx
+               	movl	(%rcx), %r8d
+               	movq	%r8, -0x588(%rbp)
+               	movups	(%r13), %xmm0
                	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	(%r12), %rcx
+               	movl	(%rcx), %r8d
+               	movq	%r8, -0x590(%rbp)
+               	movups	(%r13), %xmm0
                	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	movups	(%r13), %xmm3
-               	leaq	-0xa0(%rbp), %r14
-               	movups	%xmm3, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	movups	(%r13), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x528(%rbp)
+               	movq	-0x528(%rbp), %r8
+               	leaq	-0xa0(%rbp), %r8
+               	movq	%r8, -0x598(%rbp)
+               	movq	-0x598(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movq	-0x528(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x538(%rbp)
+               	movq	-0x538(%rbp), %r8
+               	leaq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x530(%rbp)
+               	movq	-0x530(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x100(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movl	%r15d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x120(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x130(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movq	-0x538(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x540(%rbp)
+               	movq	-0x540(%rbp), %r8
+               	leaq	-0x140(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x150(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movl	%r15d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x160(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	movq	-0x540(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	leaq	-0x190(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rdi), %r15
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%r15)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x580(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L10>
 <L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x1d0(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	movups	(%rdx), %xmm0
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, %esi
+               	addl	$0x1, %esi
+               	leaq	-0x1e0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5b0(%rbp)
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L11>
 <L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	addl	%edi, %esi
+               	leaq	-0x1f0(%rbp), %r14
+               	movups	-0x5b0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	0x4(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5c0(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L12>
 <L12>:
-               	leaq	-0xb0(%rbp), %r14
-               	movq	$0x0, (%r14)
-               	movq	$0x0, 0x8(%r14)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	movups	(%r14), %xmm3
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm3, (%r15)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %edi
+               	xorl	%edi, %esi
+               	leaq	-0x200(%rbp), %r14
+               	movups	-0x5c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	0x8(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5d0(%rbp)
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L13>
 <L13>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%r12), %rdx
+               	movl	(%rdx), %edi
+               	subl	%edi, %esi
+               	leaq	-0x210(%rbp), %rdx
+               	movups	-0x5d0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x5e0(%rbp)
+               	leaq	0xc(%rdx), %rsi
+               	movl	(%rsi), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x5e0(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	(%r13), %xmm0
+               	movaps	%xmm0, %xmm14
+               	paddd	-0x580(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	leaq	-0x110(%rbp), %r15
-               	movq	$0x0, (%r15)
-               	movq	$0x0, 0x8(%r15)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	movups	(%r15), %xmm3
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x638(%rbp)
-               	movq	-0x638(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x638(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movaps	%xmm0, %xmm14
+               	psubd	-0x580(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
+               	movq	%rax, %r8
+               	movq	%r8, -0x548(%rbp)
+               	movq	-0x548(%rbp), %r8
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x220(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edi
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %r14d
+               	imull	%r14d, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %r14d
+               	leaq	0x4(%r12), %rsi
+               	movl	(%rsi), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%rdx), %rsi
+               	movl	(%rsi), %r15d
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%rdx), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%r14d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x250(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x260(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x548(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L18>
 <L18>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
+               	movups	(%r13), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm3
+               	movaps	%xmm0, %xmm14
+               	pxor	%xmm3, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	-0x170(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movups	(%rcx), %xmm3
-               	leaq	-0x180(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x190(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x4(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1a0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x8(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1b0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0xc(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x640(%rbp)
-               	movq	-0x640(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x640(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	-0x1d0(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1e0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x4(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1f0(%rbp), %r8
-               	movq	%r8, -0x648(%rbp)
-               	movq	-0x648(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x648(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x630(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x210(%rbp), %r8
-               	movq	%r8, -0x650(%rbp)
-               	movq	-0x650(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	%edx, (%rsi)
-               	movq	-0x650(%rbp), %r8
-               	movups	(%r8), %xmm3
-               	movq	-0x650(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L32>
-<L32>:
-               	leaq	-0x220(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	movups	(%rcx), %xmm3
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	addl	$0x1, %edx
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x660(%rbp)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x668(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x668(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0x668(%rbp), %r8
-               	movl	%r8d, %ecx
-               	addl	%esi, %ecx
-               	leaq	-0x240(%rbp), %rdx
-               	movups	-0x660(%rbp), %xmm14
-               	movups	%xmm14, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x680(%rbp)
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x688(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x688(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x688(%rbp), %r8
-               	movl	%r8d, %edx
-               	xorl	%esi, %edx
-               	leaq	-0x250(%rbp), %rcx
-               	movups	-0x680(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x6a0(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x6a8(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x6a8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0x6a8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	subl	%esi, %ecx
-               	leaq	-0x260(%rbp), %r8
-               	movq	%r8, -0x6b0(%rbp)
-               	movq	-0x6b0(%rbp), %r8
-               	movups	-0x6a0(%rbp), %xmm14
-               	movups	%xmm14, (%r8)
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	%ecx, (%rsi)
-               	movq	-0x6b0(%rbp), %r8
-               	movups	(%r8), %xmm3
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movups	(%r13), %xmm3
-               	movaps	%xmm3, %xmm14
-               	paddd	-0x630(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x270(%rbp), %r8
-               	movq	%r8, -0x6b8(%rbp)
-               	movq	-0x6b8(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L44>
-<L44>:
-               	movups	(%r14), %xmm3
-               	movaps	%xmm3, %xmm14
-               	psubd	-0x630(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0x6c0(%rbp)
-               	movq	-0x6c0(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x5f8(%rbp)
-               	movq	-0x5f8(%rbp), %r8
-               	movups	(%r15), %xmm2
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %r15d
-               	imull	%r15d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r15d
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %eax
-               	imull	%eax, %r15d
-               	leaq	0xc(%rcx), %rax
-               	movl	(%rax), %ecx
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %edx
-               	imull	%edx, %ecx
-               	leaq	-0x2a0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	(%rax), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2b0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2c0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movl	%r15d, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0xc(%rbx), %rax
-               	movl	%ecx, (%rax)
-               	movups	(%rbx), %xmm2
-               	leaq	(%rbx), %rax
-               	movl	(%rax), %ecx
-               	movq	-0x5f8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movups	(%r13), %xmm2
-               	movups	(%r14), %xmm3
-               	movaps	%xmm2, %xmm14
-               	pxor	%xmm3, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2f0(%rbp), %rcx
+               	leaq	-0x270(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     ## imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xaab>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xab2>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7b9>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7c0>
                	leaq	0x4(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
+               	movss	%xmm0, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40700000, (%rdx)     ## imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xacc>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xad3>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7da>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7e1>
                	leaq	0xc(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movss	%xmm0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x280(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x608(%rbp), %xmm4
-               	leaq	-0x310(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0x4(%rbx), %rcx
+               	addss	-0x558(%rbp), %xmm4
+               	leaq	-0x290(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x4(%r12), %rcx
                	movss	%xmm4, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	-0x320(%rbp), %r13
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x2a0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm1
+               	leaq	-0x2b0(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %r11d
+               	movl	%r11d, -0x5f0(%rbp)
+               	movups	(%r13), %xmm0
+               	leaq	-0x2c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x5f0(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm3
+               	leaq	-0x2d0(%rbp), %rcx
+               	movups	%xmm3, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	leaq	(%r12), %rcx
+               	movl	(%rcx), %r11d
+               	movl	%r11d, -0x600(%rbp)
+               	movups	(%r13), %xmm0
+               	leaq	-0x2e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x600(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
                	movups	(%r13), %xmm0
-               	leaq	-0x370(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	leaq	-0x380(%rbp), %r14
+               	callq	 <L21>
+<L21>:
+               	leaq	-0x2f0(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm0
+               	leaq	-0x300(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x600(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
+               	leaq	-0x310(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm4
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm4, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm0
+               	leaq	-0x330(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x5f0(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x3d0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	(%rdx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm1
+               	leaq	-0x350(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r14), %xmm0
-               	leaq	-0x3f0(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
+               	callq	 <L22>
+<L22>:
                	movups	(%r14), %xmm0
-               	movups	(%r13), %xmm2
+               	movups	(%r13), %xmm1
                	movaps	%xmm0, %xmm14
-               	mulps	%xmm2, %xmm14
+               	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x400(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	callq	 <L23>
+<L23>:
+               	movups	(%r13), %xmm0
+               	leaq	-0x360(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm2
-               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	subss	%xmm2, %xmm3
+               	movss	(%rdx), %xmm0
+               	movss	-0x600(%rbp), %xmm1
+               	subss	%xmm0, %xmm1
+               	movd	%xmm1, %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%rbx), %rcx
+               	callq	 <L24>
+<L24>:
+               	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm1
+               	leaq	-0x370(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm2
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	subss	%xmm2, %xmm3
+               	subss	%xmm1, %xmm3
+               	movd	%xmm3, %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x430(%rbp), %rcx
+               	callq	 <L25>
+<L25>:
+               	leaq	-0x380(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 ## imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1142,79 +1120,55 @@ Disassembly of section __TEXT,__text:
                	movabsq	$-0x3ffe000000000000, %r11 ## imm = 0xC002000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
+               	leaq	-0x390(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movsd	(%rdx), %xmm2
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	addsd	-0x618(%rbp), %xmm3
-               	leaq	-0x450(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	%xmm3, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x6d0(%rbp)
-               	leaq	-0x460(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movsd	(%rdx), %xmm1
+               	movsd	%xmm1, %xmm3            ## xmm3 = xmm1[0],xmm3[1]
+               	addsd	-0x568(%rbp), %xmm3
+               	leaq	-0x3a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movsd	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x480(%rbp), %rcx
+               	movsd	%xmm3, (%rdx)
+               	movups	(%rcx), %xmm14
+               	movups	%xmm14, -0x610(%rbp)
+               	leaq	-0x3b0(%rbp), %r12
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	leaq	0x8(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%r12), %xmm2
+               	leaq	-0x3c0(%rbp), %rdx
+               	movups	%xmm2, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movsd	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%r12)
+               	leaq	(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%r12), %xmm2
+               	leaq	-0x3d0(%rbp), %rcx
                	movups	%xmm2, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movsd	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movups	%xmm0, (%r12)
                	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movups	-0x610(%rbp), %xmm0
+               	callq	 <L26>
+<L26>:
+               	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x490(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movups	(%r13), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	subpd	-0x6d0(%rbp), %xmm14
+               	subpd	-0x610(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x4a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	leaq	-0x4b0(%rbp), %rcx
+               	callq	 <L28>
+<L28>:
+               	leaq	-0x3e0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$-0x9, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1248,36 +1202,36 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x8, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
+               	leaq	-0x3f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movzbl	(%rdx), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x4d0(%rbp), %rdx
+               	addl	%ebx, %ecx
+               	leaq	-0x400(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rsi
                	movb	%cl, (%rsi)
                	movups	(%rdx), %xmm0
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
-               	addl	%r12d, %edx
-               	leaq	-0x4e0(%rbp), %rbx
+               	addl	%ebx, %edx
+               	leaq	-0x410(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	0xf(%rbx), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x6e0(%rbp)
+               	movups	%xmm14, -0x620(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x6e0(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	leaq	-0x4f0(%rbp), %r12
+               	movups	-0x620(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	leaq	-0x420(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1286,7 +1240,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x440(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1295,7 +1249,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x450(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1304,7 +1258,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x460(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1313,7 +1267,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x470(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1322,7 +1276,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x480(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1331,7 +1285,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x490(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1340,7 +1294,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x4a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1349,7 +1303,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x4b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1358,7 +1312,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x4c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1367,7 +1321,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x4d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1376,7 +1330,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x4e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1385,7 +1339,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x4f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1394,7 +1348,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x500(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1403,7 +1357,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5e0(%rbp), %rcx
+               	leaq	-0x510(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1412,7 +1366,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1420,27 +1374,27 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm0, (%r12)
                	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
+               	callq	 <L30>
+<L30>:
                	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	paddb	-0x6e0(%rbp), %xmm14
+               	paddb	-0x620(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L31>
+<L31>:
                	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	pxor	-0x6e0(%rbp), %xmm14
+               	pxor	-0x620(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x6e8(%rbp), %rbx
-               	movq	-0x6f0(%rbp), %r12
-               	movq	-0x6f8(%rbp), %r13
-               	movq	-0x700(%rbp), %r14
-               	movq	-0x708(%rbp), %r15
+               	callq	 <L32>
+<L32>:
+               	movq	-0x628(%rbp), %rbx
+               	movq	-0x630(%rbp), %r12
+               	movq	-0x638(%rbp), %r13
+               	movq	-0x640(%rbp), %r14
+               	movq	-0x648(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_mem.dis
+++ b/test/golden/x86_64-darwin/vec/vec_mem.dis
@@ -7,27 +7,88 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x30, %rsp
                	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r12, -0x30(%rbp)
+               	leaq	-0xc(%rbp), %rax
                	movups	%xmm0, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	-0x1c(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	movl	-0x14(%rbp), %edx
+               	movl	%edx, 0x8(%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -37,39 +98,137 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0xa0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x34(%rbp), %rcx
-               	leaq	-0x48(%rbp), %rcx
-               	leaq	-0x5c(%rbp), %rcx
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	-0x84(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0xa0(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x34(%rbp), %rax
+               	leaq	-0x48(%rbp), %rax
+               	leaq	-0x5c(%rbp), %rax
+               	leaq	-0x70(%rbp), %rax
+               	leaq	-0x84(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -77,1543 +236,1436 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_mem.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xae0, %rsp            ## imm = 0xAE0
-               	movq	%rbx, -0xab8(%rbp)
-               	movq	%r12, -0xac0(%rbp)
-               	movq	%r13, -0xac8(%rbp)
-               	movq	%r14, -0xad0(%rbp)
-               	movq	%r15, -0xad8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x850, %rsp            ## imm = 0x850
+               	movq	%rbx, -0x828(%rbp)
+               	movq	%r12, -0x830(%rbp)
+               	movq	%r13, -0x838(%rbp)
+               	movq	%r14, -0x840(%rbp)
+               	movq	%r15, -0x848(%rbp)
                	leaq	-0x14(%rbp), %r8
-               	movq	%r8, -0x918(%rbp)
-               	leaq	-0x28(%rbp), %r8
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x688(%rbp)
+               	leaq	-0x28(%rbp), %r12
                	leaq	-0x3c(%rbp), %r8
-               	movq	%r8, -0x928(%rbp)
-               	leaq	-0x50(%rbp), %r8
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x6a0(%rbp)
+               	leaq	-0x50(%rbp), %r14
                	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x6d8(%rbp)
                	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x7e8(%rbp)
                	leaq	-0x8c(%rbp), %r8
-               	movq	%r8, -0x9a8(%rbp)
-               	leaq	-0xa0(%rbp), %r13
-               	leaq	-0xb4(%rbp), %r14
-               	leaq	-0xc8(%rbp), %r15
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	-0xa0(%rbp), %r8
+               	movq	%r8, -0x620(%rbp)
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x628(%rbp)
+               	leaq	-0xc8(%rbp), %r8
+               	movq	%r8, -0x630(%rbp)
                	leaq	-0xdc(%rbp), %r8
-               	movq	%r8, -0xa30(%rbp)
+               	movq	%r8, -0x638(%rbp)
                	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0x940(%rbp)
+               	movq	%r8, -0x640(%rbp)
                	leaq	-0x104(%rbp), %r8
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x648(%rbp)
                	leaq	-0x118(%rbp), %r8
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x650(%rbp)
                	leaq	-0x12c(%rbp), %r8
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x658(%rbp)
                	leaq	-0x140(%rbp), %r8
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x660(%rbp)
                	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x668(%rbp)
                	leaq	-0x168(%rbp), %r8
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x670(%rbp)
                	leaq	-0x17c(%rbp), %r8
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x980(%rbp)
-               	leaq	-0x1a4(%rbp), %rsi
-               	leaq	-0x1b8(%rbp), %rsi
-               	leaq	-0x1cc(%rbp), %rsi
-               	leaq	-0x1e0(%rbp), %rsi
-               	leaq	-0x1f4(%rbp), %rsi
-               	leaq	-0x208(%rbp), %rsi
-               	leaq	-0x21c(%rbp), %rsi
-               	leaq	-0x230(%rbp), %rsi
-               	leaq	-0x244(%rbp), %rsi
-               	leaq	-0x258(%rbp), %rsi
-               	leaq	-0x26c(%rbp), %rsi
-               	leaq	-0x280(%rbp), %rsi
-               	leaq	-0x294(%rbp), %rsi
-               	leaq	-0x2a8(%rbp), %rsi
-               	leaq	-0x2bc(%rbp), %rsi
-               	leaq	-0x2d0(%rbp), %rsi
-               	leaq	-0x2e4(%rbp), %rsi
-               	leaq	-0x2f8(%rbp), %rsi
-               	leaq	-0x30c(%rbp), %rsi
-               	leaq	-0x320(%rbp), %rsi
-               	leaq	-0x334(%rbp), %rsi
-               	leaq	-0x348(%rbp), %rsi
-               	leaq	-0x35c(%rbp), %rsi
-               	leaq	-0x370(%rbp), %rsi
-               	leaq	-0x384(%rbp), %rsi
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x988(%rbp)
-               	movq	-0x988(%rbp), %r8
-               	movq	%rbx, %r11
+               	movq	%r8, -0x680(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0xa40(%rbp)
-               	leaq	-0x3d8(%rbp), %rbx
+<L1>:
+               	movss	%xmm14, -0x7d8(%rbp)
+               	leaq	-0x404(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	addq	$0x0, %rsi
                	movq	$0x50, %rdi
-<L3>:
+<L2>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
-               	jne	 <L3>
+               	jne	 <L2>
                	movl	$0x0, (%rsi)
                	movq	$0x0, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0x690(%rbp), %r8
                	cmpq	$0x7, %r8
-               	jb	 <L4>
-               	jmp	 <L7>
-<L4>:
-               	movq	-0x990(%rbp), %r8
+               	jb	 <L3>
+               	jmp	 <L6>
+<L3>:
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
-               	leaq	-0x3e4(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movl	$0x0, 0x8(%rdi)
+<L5>:
+               	leaq	-0x19c(%rbp), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movl	$0x0, 0x8(%r8)
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	-0xa40(%rbp), %xmm2
-               	movq	$0x0, -0x3f4(%rbp)
-               	movq	$0x0, -0x3ec(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x3f4(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x3ec(%rbp)
-               	movups	-0x3f4(%rbp), %xmm3
-               	leaq	-0x400(%rbp), %rax
-               	movups	%xmm3, -0x410(%rbp)
-               	movq	-0x410(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x408(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x420(%rbp)
-               	movq	$0x0, -0x418(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x420(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x418(%rbp)
-               	movups	-0x420(%rbp), %xmm2
-               	movups	%xmm2, -0x430(%rbp)
-               	movq	-0x430(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x428(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
+               	addss	-0x7d8(%rbp), %xmm2
+               	movq	$0x0, -0x1ac(%rbp)
+               	movq	$0x0, -0x1a4(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x1ac(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x1a4(%rbp)
+               	movups	-0x1ac(%rbp), %xmm3
+               	leaq	-0x1b8(%rbp), %rsi
+               	movups	%xmm3, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x1c0(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x1d8(%rbp)
+               	movq	$0x0, -0x1d0(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x1d8(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x1d0(%rbp)
+               	movups	-0x1d8(%rbp), %xmm2
+               	movups	%xmm2, -0x1e8(%rbp)
+               	movq	-0x1e8(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x1e0(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x377>
-               	movq	$0x0, -0x440(%rbp)
-               	movq	$0x0, -0x438(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x440(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x438(%rbp)
-               	movups	-0x440(%rbp), %xmm3
-               	leaq	-0x44c(%rbp), %rax
-               	movups	%xmm3, -0x45c(%rbp)
-               	movq	-0x45c(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x454(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x4(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x46c(%rbp)
-               	movq	$0x0, -0x464(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x46c(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x464(%rbp)
-               	movups	-0x46c(%rbp), %xmm2
-               	movups	%xmm2, -0x47c(%rbp)
-               	movq	-0x47c(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x474(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x422>
+               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x2ea>
+               	movq	$0x0, -0x1f8(%rbp)
+               	movq	$0x0, -0x1f0(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x1f8(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x1f0(%rbp)
+               	movups	-0x1f8(%rbp), %xmm3
+               	leaq	-0x204(%rbp), %rsi
+               	movups	%xmm3, -0x214(%rbp)
+               	movq	-0x214(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x20c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x224(%rbp)
+               	movq	$0x0, -0x21c(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x224(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x21c(%rbp)
+               	movups	-0x224(%rbp), %xmm2
+               	movups	%xmm2, -0x234(%rbp)
+               	movq	-0x234(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x22c(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x3b3>
                	subss	%xmm0, %xmm2
-               	movq	$0x0, -0x48c(%rbp)
-               	movq	$0x0, -0x484(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x48c(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x484(%rbp)
-               	movups	-0x48c(%rbp), %xmm0
-               	leaq	-0x498(%rbp), %rax
-               	movups	%xmm0, -0x4a8(%rbp)
-               	movq	-0x4a8(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x4a0(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x8(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x4b8(%rbp)
-               	movq	$0x0, -0x4b0(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x4b8(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x4b0(%rbp)
-               	movups	-0x4b8(%rbp), %xmm0
-               	movups	%xmm0, -0x4c8(%rbp)
-               	movq	-0x4c8(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x4c0(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	movq	$0x0, -0x4d8(%rbp)
-               	movq	$0x0, -0x4d0(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x4d8(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x4d0(%rbp)
-               	movups	-0x4d8(%rbp), %xmm0
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	imulq	$0xc, %rax, %rax
-               	leaq	(%rbx,%rax), %rsi
-               	movups	%xmm0, -0x4e8(%rbp)
-               	movq	-0x4e8(%rbp), %rax
-               	movq	%rax, (%rsi)
-               	movl	-0x4e0(%rbp), %eax
-               	movl	%eax, 0x8(%rsi)
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
-               	cmpq	$0x7, %r8
-               	jb	 <L4>
-<L7>:
-               	movq	-0x988(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa50(%rbp)
-               	movq	$0x7, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-               	jmp	 <L12>
-<L8>:
-               	movq	-0xa58(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movq	%r8, %rdi
-               	imulq	$0xc, %rdi, %rdi
-               	leaq	(%rbx,%rdi), %r8
-               	movq	%r8, -0x9a0(%rbp)
-               	movq	$0x0, -0x4f8(%rbp)
-               	movq	$0x0, -0x4f0(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	%rdi, -0x4f8(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movl	0x8(%r8), %edi
-               	movl	%edi, -0x4f0(%rbp)
-               	movups	-0x4f8(%rbp), %xmm0
-               	leaq	-0x504(%rbp), %r12
-               	movups	%xmm0, -0x514(%rbp)
-               	movq	-0x514(%rbp), %rdi
-               	movq	%rdi, (%r12)
-               	movl	-0x50c(%rbp), %edi
-               	movl	%edi, 0x8(%r12)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa50(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b0(%rbp)
-               	movq	-0x9b0(%rbp), %r8
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9b0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b8(%rbp)
-               	movq	-0x9b8(%rbp), %r8
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9b8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%rdi, %r8
-               	movq	%r8, -0xa50(%rbp)
-               	movq	-0xa48(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-<L12>:
-               	leaq	-0x554(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, 0x30(%r12)
-               	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L13>
-               	jmp	 <L14>
-<L13>:
-               	movq	-0x9c0(%rbp), %r8
+               	movq	$0x0, -0x244(%rbp)
+               	movq	$0x0, -0x23c(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x244(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x23c(%rbp)
+               	movups	-0x244(%rbp), %xmm0
+               	leaq	-0x250(%rbp), %rsi
+               	movups	%xmm0, -0x260(%rbp)
+               	movq	-0x260(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x258(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x270(%rbp)
+               	movq	$0x0, -0x268(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x270(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x268(%rbp)
+               	movups	-0x270(%rbp), %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	movq	-0x280(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x278(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	movq	$0x0, -0x290(%rbp)
+               	movq	$0x0, -0x288(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x290(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x288(%rbp)
+               	movups	-0x290(%rbp), %xmm0
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %rsi
                	imulq	$0xc, %rsi, %rsi
                	leaq	(%rbx,%rsi), %rdi
-               	movq	$0x0, -0x564(%rbp)
-               	movq	$0x0, -0x55c(%rbp)
-               	movq	(%rdi), %rsi
-               	movq	%rsi, -0x564(%rbp)
-               	movl	0x8(%rdi), %esi
-               	movl	%esi, -0x55c(%rbp)
-               	movups	-0x564(%rbp), %xmm0
-               	movq	-0x9c0(%rbp), %r8
+               	movups	%xmm0, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %rsi
+               	movq	%rsi, (%rdi)
+               	movl	-0x298(%rbp), %esi
+               	movl	%esi, 0x8(%rdi)
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	(%rdi), %rsi
-               	movups	%xmm0, -0x574(%rbp)
-               	movq	-0x574(%rbp), %rdx
-               	movq	%rdx, (%rsi)
-               	movl	-0x56c(%rbp), %edx
-               	movl	%edx, 0x8(%rsi)
-               	movq	-0x9c0(%rbp), %r8
-               	movl	%r8d, %edx
-               	movl	$0xaaaaaaaa, %esi       ## imm = 0xAAAAAAAA
-               	subl	%edx, %esi
-               	leaq	0xc(%rdi), %rdx
-               	movl	%esi, (%rdx)
-               	movq	-0x9c0(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L13>
-<L14>:
-               	movq	-0xa50(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa60(%rbp)
+               	addq	$0x1, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0x690(%rbp), %r8
+               	cmpq	$0x7, %r8
+               	jb	 <L3>
+<L6>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 ## imm = 0xCBF29CE484222325
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	$0x7, %r13
+               	movq	$0x0, %r11
+               	cmpq	%r13, %r11
+               	jb	 <L7>
+               	jmp	 <L9>
+<L7>:
+               	subq	$0x1, %r13
+               	movq	%r13, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%rbx,%rdi), %r8
+               	movq	%r8, -0x6a8(%rbp)
+               	movq	$0x0, -0x2b0(%rbp)
+               	movq	$0x0, -0x2a8(%rbp)
+               	movq	-0x6a8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x2b0(%rbp)
+               	movq	-0x6a8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x2a8(%rbp)
+               	movups	-0x2b0(%rbp), %xmm0
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	$0x0, %r11
+               	cmpq	%r13, %r11
+               	jb	 <L7>
+<L9>:
+               	leaq	-0x2f0(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, 0x18(%r13)
+               	movq	$0x0, 0x20(%r13)
+               	movq	$0x0, 0x28(%r13)
+               	movq	$0x0, 0x30(%r13)
+               	movq	$0x0, 0x38(%r13)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa68(%rbp)
-               	movq	-0xa68(%rbp), %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	-0x6b0(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L15>
-               	jmp	 <L20>
-<L15>:
-               	movq	-0xa68(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	(%rdi), %rsi
-               	movq	$0x0, -0x584(%rbp)
-               	movq	$0x0, -0x57c(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x584(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x57c(%rbp)
-               	movups	-0x584(%rbp), %xmm0
-               	leaq	-0x590(%rbp), %r8
-               	movq	%r8, -0xa70(%rbp)
-               	movups	%xmm0, -0x5a0(%rbp)
-               	movq	-0x5a0(%rbp), %rdi
-               	movq	-0xa70(%rbp), %r8
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%rbx,%rdi), %r8
+               	movq	%r8, -0x6b8(%rbp)
+               	movq	$0x0, -0x300(%rbp)
+               	movq	$0x0, -0x2f8(%rbp)
+               	movq	-0x6b8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x300(%rbp)
+               	movq	-0x6b8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x2f8(%rbp)
+               	movups	-0x300(%rbp), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x6c0(%rbp)
+               	movq	-0x6c0(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	movups	%xmm0, -0x310(%rbp)
+               	movq	-0x310(%rbp), %rdi
+               	movq	-0x6c8(%rbp), %r8
                	movq	%rdi, (%r8)
-               	movl	-0x598(%rbp), %edi
-               	movq	-0xa70(%rbp), %r8
+               	movl	-0x308(%rbp), %edi
+               	movq	-0x6c8(%rbp), %r8
                	movl	%edi, 0x8(%r8)
-               	movq	-0xa70(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa60(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
+               	movl	%r8d, %edi
+               	movl	$0xaaaaaaaa, %r8d       ## imm = 0xAAAAAAAA
+               	subl	%edi, %r8d
+               	movq	%r8, -0x6d0(%rbp)
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movq	-0x6d0(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movq	-0x6b0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9c8(%rbp)
-               	movq	-0x9c8(%rbp), %r8
-               	movq	-0xa70(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9c8(%rbp), %r8
+               	addq	$0x1, %rdi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	-0x6b0(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L10>
+<L11>:
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	-0x7f8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L12>
+               	jmp	 <L16>
+<L12>:
+               	movq	-0x7f8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L17>
-<L17>:
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x6e0(%rbp)
+               	movq	-0x6e0(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	$0x0, -0x320(%rbp)
+               	movq	$0x0, -0x318(%rbp)
+               	movq	-0x6e8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x320(%rbp)
+               	movq	-0x6e8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x318(%rbp)
+               	movups	-0x320(%rbp), %xmm0
+               	movq	%r15, %rdi
+               	callq	 <L13>
+<L13>:
                	movq	%rax, %r8
-               	movq	%r8, -0x9d0(%rbp)
-               	movq	-0x9d0(%rbp), %r8
-               	movq	-0xa70(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x6f0(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movl	(%rdi), %r8d
+               	movq	%r8, -0x6f8(%rbp)
+               	movq	-0x6f8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x708(%rbp)
+               	movq	-0x6f0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x710(%rbp)
+               	movq	-0x710(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	-0x710(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9d8(%rbp)
-               	movq	-0x9d8(%rbp), %r8
-               	movq	-0xa68(%rbp), %r8
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x708(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x700(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x718(%rbp)
+               	movq	-0x718(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x710(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x720(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x720(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x710(%rbp)
+               	movq	-0x710(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+<L15>:
+               	movq	-0x7f8(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	0xc(%rdi), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x9e0(%rbp)
-               	movq	-0x9d8(%rbp), %r8
+               	addq	$0x1, %rsi
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rsi, %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	-0x7f8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L12>
+<L16>:
+               	leaq	-0x334(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movl	$0x0, 0x10(%r13)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x728(%rbp)
+               	movq	-0x728(%rbp), %r8
+               	movb	$-0x25, (%r8)
+               	leaq	0x3c(%rbx), %rdi
+               	movq	$0x0, -0x344(%rbp)
+               	movq	$0x0, -0x33c(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x344(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x33c(%rbp)
+               	movups	-0x344(%rbp), %xmm0
+               	leaq	0x4(%r13), %rsi
+               	movups	%xmm0, -0x354(%rbp)
+               	movq	-0x354(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x34c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x10(%r13), %rsi
+               	movb	$-0x53, (%rsi)
+               	movq	-0x728(%rbp), %r8
+               	movzbl	(%r8), %esi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x730(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x738(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x730(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x9e0(%rbp), %r8
-               	movl	%r8d, %esi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r8
+               	movq	%r8, -0x738(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x414(%rbp)
+               	movq	$0x0, -0x40c(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x414(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x40c(%rbp)
+               	movups	-0x414(%rbp), %xmm0
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rdx
-               	movq	-0xa68(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rdx, %r8
-               	movq	%r8, -0xa60(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0xa68(%rbp)
-               	movq	-0xa68(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L15>
+               	movq	%rax, %rsi
+               	leaq	0x10(%r13), %rdi
+               	movzbl	(%rdi), %r15d
+               	movzbq	%r15b, %r8
+               	movq	%r8, -0x748(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x740(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	leaq	-0x5b4(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movl	$0x0, 0x10(%r12)
-               	leaq	(%r12), %rax
-               	movb	$-0x25, (%rax)
-               	leaq	0x3c(%rbx), %rsi
-               	movq	$0x0, -0x5c4(%rbp)
-               	movq	$0x0, -0x5bc(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x5c4(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x5bc(%rbp)
-               	movups	-0x5c4(%rbp), %xmm0
-               	leaq	0x4(%r12), %r8
-               	movq	%r8, -0x9e8(%rbp)
-               	movups	%xmm0, -0x5d4(%rbp)
-               	movq	-0x5d4(%rbp), %rsi
-               	movq	-0x9e8(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x5cc(%rbp), %esi
-               	movq	-0x9e8(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	leaq	0x10(%r12), %rsi
-               	movb	$-0x53, (%rsi)
-               	movzbl	(%rax), %esi
-               	movq	-0xa60(%rbp), %r8
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x748(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x740(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L21>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r8
+               	movq	%r8, -0x740(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L20>
 <L21>:
-               	movq	$0x0, -0x5e4(%rbp)
-               	movq	$0x0, -0x5dc(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	%rdx, -0x5e4(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movl	0x8(%r8), %edx
-               	movl	%edx, -0x5dc(%rbp)
-               	movups	-0x5e4(%rbp), %xmm0
-               	leaq	-0x5f0(%rbp), %r8
-               	movq	%r8, -0xa78(%rbp)
-               	movups	%xmm0, -0x600(%rbp)
-               	movq	-0x600(%rbp), %rsi
-               	movq	-0xa78(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x5f8(%rbp), %esi
-               	movq	-0xa78(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa78(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0xa78(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0xa78(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	leaq	0x10(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9f0(%rbp)
-               	movq	-0x9f0(%rbp), %r8
-               	leaq	-0x6c4(%rbp), %r8
-               	movq	%r8, -0xa80(%rbp)
-               	leaq	-0x6d8(%rbp), %rsi
-               	movq	(%r12), %rdi
-               	movq	0x8(%r12), %rax
-               	movl	0x10(%r12), %r8d
-               	movq	%r8, -0x9f8(%rbp)
+               	leaq	-0x524(%rbp), %r15
+               	leaq	-0x538(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	0x8(%r13), %r8
+               	movq	%r8, -0x750(%rbp)
+               	movl	0x10(%r13), %r8d
+               	movq	%r8, -0x758(%rbp)
                	movq	%rdi, (%rsi)
-               	movq	%rax, 0x8(%rsi)
-               	movq	-0x9f8(%rbp), %r8
+               	movq	-0x750(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	-0x758(%rbp), %r8
                	movl	%r8d, 0x10(%rsi)
-               	movq	(%rsi), %rax
-               	movq	0x8(%rsi), %rdi
-               	movl	0x10(%rsi), %r8d
-               	movq	%r8, -0xa00(%rbp)
-               	movq	-0xa80(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0xa80(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0xa80(%rbp), %r8
-               	movq	-0xa00(%rbp), %r9
-               	movl	%r9d, 0x10(%r8)
-               	movq	-0xa80(%rbp), %r9
-               	leaq	0x4(%r9), %r8
-               	movq	%r8, -0xa88(%rbp)
-               	movq	$0x0, -0x6e8(%rbp)
-               	movq	$0x0, -0x6e0(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x6e8(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x6e0(%rbp)
-               	movups	-0x6e8(%rbp), %xmm0
-               	leaq	0xc(%rbx), %rsi
-               	movq	$0x0, -0x6f8(%rbp)
-               	movq	$0x0, -0x6f0(%rbp)
                	movq	(%rsi), %rdi
-               	movq	%rdi, -0x6f8(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x6f0(%rbp)
-               	movups	-0x6f8(%rbp), %xmm2
+               	movq	0x8(%rsi), %r8
+               	movq	%r8, -0x760(%rbp)
+               	movl	0x10(%rsi), %r8d
+               	movq	%r8, -0x768(%rbp)
+               	movq	%rdi, (%r15)
+               	movq	-0x760(%rbp), %r8
+               	movq	%r8, 0x8(%r15)
+               	movq	-0x768(%rbp), %r8
+               	movl	%r8d, 0x10(%r15)
+               	leaq	0x4(%r15), %r8
+               	movq	%r8, -0x770(%rbp)
+               	movq	$0x0, -0x548(%rbp)
+               	movq	$0x0, -0x540(%rbp)
+               	movq	-0x770(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x548(%rbp)
+               	movq	-0x770(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x540(%rbp)
+               	movups	-0x548(%rbp), %xmm0
+               	leaq	0xc(%rbx), %rdi
+               	movq	$0x0, -0x558(%rbp)
+               	movq	$0x0, -0x550(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x558(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x550(%rbp)
+               	movups	-0x558(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	addps	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x708(%rbp)
-               	movq	-0x708(%rbp), %rsi
-               	movq	-0xa88(%rbp), %r8
+               	movups	%xmm0, -0x568(%rbp)
+               	movq	-0x568(%rbp), %rsi
+               	movq	-0x770(%rbp), %r8
                	movq	%rsi, (%r8)
-               	movl	-0x700(%rbp), %esi
-               	movq	-0xa88(%rbp), %r8
+               	movl	-0x560(%rbp), %esi
+               	movq	-0x770(%rbp), %r8
                	movl	%esi, 0x8(%r8)
-               	movq	-0xa80(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0xa08(%rbp)
-               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%r15), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x778(%rbp)
+               	movq	-0x740(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	-0x788(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x788(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0xa08(%rbp), %r8
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x778(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x780(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L26>
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x788(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	-0x788(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	leaq	0x4(%r15), %rsi
+               	movq	$0x0, -0x578(%rbp)
+               	movq	$0x0, -0x570(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x578(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x570(%rbp)
+               	movups	-0x578(%rbp), %xmm0
+               	movq	-0x780(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %rsi
+               	leaq	0x10(%r15), %rdi
+               	movzbl	(%rdi), %r15d
+               	movzbq	%r15b, %r8
+               	movq	%r8, -0x790(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x798(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x790(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r15
+               	movq	%rsi, %r8
+               	movq	%r8, -0x798(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
 <L26>:
-               	movq	%rax, %rdi
-               	movq	$0x0, -0x718(%rbp)
-               	movq	$0x0, -0x710(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x718(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x710(%rbp)
-               	movups	-0x718(%rbp), %xmm0
-               	leaq	-0x724(%rbp), %r8
-               	movq	%r8, -0xa90(%rbp)
-               	movups	%xmm0, -0x734(%rbp)
-               	movq	-0x734(%rbp), %rsi
-               	movq	-0xa90(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x72c(%rbp), %esi
-               	movq	-0xa90(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa90(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	(%r13), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L27>
 <L27>:
                	movq	%rax, %rdi
-               	movq	-0xa90(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x588(%rbp)
+               	movq	$0x0, -0x580(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x588(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x580(%rbp)
+               	movups	-0x588(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
                	movq	%rax, %rdi
-               	movq	-0xa90(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	0x10(%r13), %rsi
+               	movzbl	(%rsi), %r13d
+               	movzbq	%r13b, %rsi
                	callq	 <L29>
 <L29>:
-               	movq	-0xa80(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movzbl	(%rsi), %edx
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x7a0(%rbp)
+               	movq	-0x7a0(%rbp), %r8
+               	leaq	-0x5b4(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, 0x18(%r13)
+               	movq	$0x0, 0x20(%r13)
+               	movl	$0x0, 0x28(%r13)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x7a8(%rbp)
+               	movq	-0x7a8(%rbp), %r8
+               	movl	$0xffffffff, (%r8)      ## imm = 0xFFFFFFFF
+               	leaq	(%rbx), %r15
+               	movq	$0x0, -0x5c4(%rbp)
+               	movq	$0x0, -0x5bc(%rbp)
+               	movq	(%r15), %rdi
+               	movq	%rdi, -0x5c4(%rbp)
+               	movl	0x8(%r15), %edi
+               	movl	%edi, -0x5bc(%rbp)
+               	movups	-0x5c4(%rbp), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	leaq	(%rdi), %r15
+               	movups	%xmm0, -0x5d4(%rbp)
+               	movq	-0x5d4(%rbp), %rsi
+               	movq	%rsi, (%r15)
+               	movl	-0x5cc(%rbp), %esi
+               	movl	%esi, 0x8(%r15)
+               	leaq	0x24(%rbx), %rsi
+               	movq	$0x0, -0x5e4(%rbp)
+               	movq	$0x0, -0x5dc(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x5e4(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x5dc(%rbp)
+               	movups	-0x5e4(%rbp), %xmm0
+               	leaq	0xc(%rdi), %rsi
+               	movups	%xmm0, -0x5f4(%rbp)
+               	movq	-0x5f4(%rbp), %r15
+               	movq	%r15, (%rsi)
+               	movl	-0x5ec(%rbp), %r15d
+               	movl	%r15d, 0x8(%rsi)
+               	leaq	0x48(%rbx), %rsi
+               	movq	$0x0, -0x604(%rbp)
+               	movq	$0x0, -0x5fc(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x604(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x5fc(%rbp)
+               	movups	-0x604(%rbp), %xmm0
+               	leaq	0x18(%rdi), %rsi
+               	movups	%xmm0, -0x614(%rbp)
+               	movq	-0x614(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x60c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x28(%r13), %rsi
+               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
+               	movq	-0x7a8(%rbp), %r8
+               	movl	(%r8), %esi
+               	movl	%esi, %r15d
+               	movq	-0x7a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
                	callq	 <L30>
 <L30>:
-               	leaq	(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x4(%r12), %rdx
-               	movq	$0x0, -0x744(%rbp)
-               	movq	$0x0, -0x73c(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x744(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x73c(%rbp)
-               	movups	-0x744(%rbp), %xmm0
-               	leaq	-0x750(%rbp), %r8
-               	movq	%r8, -0xa98(%rbp)
-               	movups	%xmm0, -0x760(%rbp)
-               	movq	-0x760(%rbp), %rsi
-               	movq	-0xa98(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x758(%rbp), %esi
-               	movq	-0xa98(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa98(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0xa98(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0xa98(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x10(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa10(%rbp)
-               	movq	-0xa10(%rbp), %r8
-               	leaq	-0x7f4(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movl	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	(%rbx), %rsi
-               	movq	$0x0, -0x804(%rbp)
-               	movq	$0x0, -0x7fc(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x804(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x7fc(%rbp)
-               	movups	-0x804(%rbp), %xmm0
-               	leaq	0x4(%r12), %rsi
-               	leaq	(%rsi), %rdi
-               	movups	%xmm0, -0x814(%rbp)
-               	movq	-0x814(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x80c(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	leaq	0x24(%rbx), %rax
-               	movq	$0x0, -0x824(%rbp)
-               	movq	$0x0, -0x81c(%rbp)
-               	movq	(%rax), %rdi
-               	movq	%rdi, -0x824(%rbp)
-               	movl	0x8(%rax), %edi
-               	movl	%edi, -0x81c(%rbp)
-               	movups	-0x824(%rbp), %xmm0
-               	leaq	0xc(%rsi), %rax
-               	movups	%xmm0, -0x834(%rbp)
-               	movq	-0x834(%rbp), %rdi
-               	movq	%rdi, (%rax)
-               	movl	-0x82c(%rbp), %edi
-               	movl	%edi, 0x8(%rax)
-               	leaq	0x48(%rbx), %rax
-               	movq	$0x0, -0x844(%rbp)
-               	movq	$0x0, -0x83c(%rbp)
-               	movq	(%rax), %rdi
-               	movq	%rdi, -0x844(%rbp)
-               	movl	0x8(%rax), %edi
-               	movl	%edi, -0x83c(%rbp)
-               	movups	-0x844(%rbp), %xmm0
-               	leaq	0x18(%rsi), %rax
-               	movups	%xmm0, -0x854(%rbp)
-               	movq	-0x854(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x84c(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x28(%r12), %rax
-               	movl	$0x12345678, (%rax)     ## imm = 0x12345678
-               	movl	(%rdx), %eax
-               	movq	-0xa10(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xaa0(%rbp)
+               	movq	%rax, %rsi
+               	movq	%rsi, %r15
                	movq	$0x0, %r8
-               	movq	%r8, -0xaa8(%rbp)
-               	movq	-0xaa8(%rbp), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	-0x800(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L37>
-               	jmp	 <L41>
-<L37>:
-               	leaq	0x4(%r12), %rsi
-               	movq	-0xaa8(%rbp), %r8
+               	jb	 <L31>
+               	jmp	 <L33>
+<L31>:
+               	leaq	0x4(%r13), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x800(%rbp), %r8
                	movq	%r8, %rdi
                	imulq	$0xc, %rdi, %rdi
-               	leaq	(%rsi,%rdi), %r8
-               	movq	%r8, -0xa18(%rbp)
-               	movq	$0x0, -0x610(%rbp)
-               	movq	$0x0, -0x608(%rbp)
-               	movq	-0xa18(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x610(%rbp)
-               	movq	-0xa18(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x608(%rbp)
-               	movups	-0x610(%rbp), %xmm0
-               	leaq	-0x61c(%rbp), %r8
-               	movq	%r8, -0xab0(%rbp)
-               	movups	%xmm0, -0x62c(%rbp)
-               	movq	-0x62c(%rbp), %rdi
-               	movq	-0xab0(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movl	-0x624(%rbp), %edi
-               	movq	-0xab0(%rbp), %r8
-               	movl	%edi, 0x8(%r8)
-               	movq	-0xab0(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xaa0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa20(%rbp)
-               	movq	-0xa20(%rbp), %r8
-               	movq	-0xab0(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa20(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa28(%rbp)
-               	movq	-0xa28(%rbp), %r8
-               	movq	-0xab0(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa28(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rsi
-               	movq	-0xaa8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
+               	movq	-0x7b0(%rbp), %r9
+               	leaq	(%r9,%rdi), %r8
+               	movq	%r8, -0x7b8(%rbp)
+               	movq	$0x0, -0x364(%rbp)
+               	movq	$0x0, -0x35c(%rbp)
+               	movq	-0x7b8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x364(%rbp)
+               	movq	-0x7b8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x35c(%rbp)
+               	movups	-0x364(%rbp), %xmm0
+               	movq	%r15, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rax, %r15
+               	movq	-0x800(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
                	movq	%rsi, %r8
-               	movq	%r8, -0xaa0(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0xaa8(%rbp)
-               	movq	-0xaa8(%rbp), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	-0x800(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L37>
-<L41>:
-               	leaq	0x28(%r12), %rax
-               	movl	(%rax), %esi
-               	movq	-0xaa0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x18(%rbx), %rdx
-               	movq	$0x0, -0x63c(%rbp)
-               	movq	$0x0, -0x634(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x63c(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x634(%rbp)
-               	movups	-0x63c(%rbp), %xmm0
-               	leaq	0x30(%rbx), %rdx
-               	movq	$0x0, -0x64c(%rbp)
-               	movq	$0x0, -0x644(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x64c(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x644(%rbp)
-               	movups	-0x64c(%rbp), %xmm2
+               	jb	 <L31>
+<L33>:
+               	leaq	0x28(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	%r15, %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+<L35>:
+               	leaq	0x18(%rbx), %r13
+               	movq	$0x0, -0x424(%rbp)
+               	movq	$0x0, -0x41c(%rbp)
+               	movq	(%r13), %rsi
+               	movq	%rsi, -0x424(%rbp)
+               	movl	0x8(%r13), %esi
+               	movl	%esi, -0x41c(%rbp)
+               	movups	-0x424(%rbp), %xmm0
+               	leaq	0x30(%rbx), %r15
+               	movq	$0x0, -0x434(%rbp)
+               	movq	$0x0, -0x42c(%rbp)
+               	movq	(%r15), %rsi
+               	movq	%rsi, -0x434(%rbp)
+               	movl	0x8(%r15), %esi
+               	movl	%esi, -0x42c(%rbp)
+               	movups	-0x434(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	addps	%xmm2, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x658(%rbp), %r12
-               	movups	%xmm0, -0x668(%rbp)
-               	movq	-0x668(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x660(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movaps	%xmm14, -0x810(%rbp)
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movups	-0x810(%rbp), %xmm0
+               	callq	 <L36>
+<L36>:
                	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	leaq	0x24(%rbx), %rdx
-               	movq	$0x0, -0x770(%rbp)
-               	movq	$0x0, -0x768(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x770(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x768(%rbp)
-               	movups	-0x770(%rbp), %xmm0
-               	leaq	-0x77c(%rbp), %rsi
-               	leaq	(%rsi), %rdi
+               	movups	-0x810(%rbp), %xmm0
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x7c8(%rbp)
+               	movq	-0x7c8(%rbp), %r8
+               	leaq	0x24(%rbx), %r8
+               	movq	%r8, -0x818(%rbp)
+               	movq	$0x0, -0x444(%rbp)
+               	movq	$0x0, -0x43c(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	%rbx, -0x444(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movl	%ebx, -0x43c(%rbp)
+               	movups	-0x444(%rbp), %xmm0
+               	leaq	-0x450(%rbp), %rbx
+               	leaq	(%rbx), %rdi
                	movl	$0x40000000, (%rdi)     ## imm = 0x40000000
-               	leaq	0x4(%rsi), %rdi
+               	leaq	0x4(%rbx), %rdi
                	movl	$0x40800000, (%rdi)     ## imm = 0x40800000
-               	leaq	0x8(%rsi), %rdi
+               	leaq	0x8(%rbx), %rdi
                	movl	$0x41000000, (%rdi)     ## imm = 0x41000000
-               	movq	$0x0, -0x78c(%rbp)
-               	movq	$0x0, -0x784(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x78c(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x784(%rbp)
-               	movups	-0x78c(%rbp), %xmm2
+               	movq	$0x0, -0x460(%rbp)
+               	movq	$0x0, -0x458(%rbp)
+               	movq	(%rbx), %rdi
+               	movq	%rdi, -0x460(%rbp)
+               	movl	0x8(%rbx), %edi
+               	movl	%edi, -0x458(%rbp)
+               	movups	-0x460(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	mulps	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x79c(%rbp)
-               	movq	-0x79c(%rbp), %rsi
-               	movq	%rsi, (%rdx)
-               	movl	-0x794(%rbp), %esi
-               	movl	%esi, 0x8(%rdx)
-               	leaq	0x18(%rbx), %rdx
-               	movq	$0x0, -0x7ac(%rbp)
-               	movq	$0x0, -0x7a4(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x7ac(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x7a4(%rbp)
-               	movups	-0x7ac(%rbp), %xmm0
-               	leaq	-0x7b8(%rbp), %r12
-               	movups	%xmm0, -0x7c8(%rbp)
-               	movq	-0x7c8(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x7c0(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movups	%xmm0, -0x470(%rbp)
+               	movq	-0x470(%rbp), %rdi
+               	movq	-0x818(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movl	-0x468(%rbp), %edi
+               	movq	-0x818(%rbp), %r8
+               	movl	%edi, 0x8(%r8)
+               	movq	$0x0, -0x480(%rbp)
+               	movq	$0x0, -0x478(%rbp)
+               	movq	(%r13), %rdi
+               	movq	%rdi, -0x480(%rbp)
+               	movl	0x8(%r13), %edi
+               	movl	%edi, -0x478(%rbp)
+               	movups	-0x480(%rbp), %xmm0
+               	movq	-0x7c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L38>
+<L38>:
                	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movq	$0x0, -0x490(%rbp)
+               	movq	$0x0, -0x488(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	%rbx, -0x490(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movl	%ebx, -0x488(%rbp)
+               	movups	-0x490(%rbp), %xmm0
+               	callq	 <L39>
+<L39>:
                	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x24(%rbx), %rdx
-               	movq	$0x0, -0x864(%rbp)
-               	movq	$0x0, -0x85c(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x864(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x85c(%rbp)
-               	movups	-0x864(%rbp), %xmm0
-               	leaq	-0x870(%rbp), %r12
-               	movups	%xmm0, -0x880(%rbp)
-               	movq	-0x880(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x878(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x30(%rbx), %rdx
-               	movq	$0x0, -0x890(%rbp)
-               	movq	$0x0, -0x888(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x890(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x888(%rbp)
-               	movups	-0x890(%rbp), %xmm0
-               	leaq	-0x89c(%rbp), %rbx
-               	movups	%xmm0, -0x8ac(%rbp)
-               	movq	-0x8ac(%rbp), %rdx
-               	movq	%rdx, (%rbx)
-               	movl	-0x8a4(%rbp), %edx
-               	movl	%edx, 0x8(%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	-0x910(%rbp), %rbx
-               	leaq	(%rbx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0x60, %rsi
-<L58>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L58>
-               	movl	$0x0, (%rdx)
-               	movq	$0x0, %rdx
-               	cmpq	$0x5, %rdx
-               	jb	 <L59>
-               	jmp	 <L62>
-<L59>:
-               	movq	%rdx, %r11
+               	movq	$0x0, -0x4a0(%rbp)
+               	movq	$0x0, -0x498(%rbp)
+               	movq	(%r15), %rsi
+               	movq	%rsi, -0x4a0(%rbp)
+               	movl	0x8(%r15), %esi
+               	movl	%esi, -0x498(%rbp)
+               	movups	-0x4a0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rsi
+               	leaq	-0x510(%rbp), %rbx
+               	leaq	(%rbx), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x60, %r13
+<L41>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L41>
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L43>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L61>:
-               	leaq	-0x67c(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movl	$0x0, 0x10(%rsi)
+<L44>:
+               	leaq	-0x378(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movl	$0x0, 0x10(%r13)
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	-0xa40(%rbp), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	addss	-0x7d8(%rbp), %xmm2
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x4(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x8(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0xc(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x10(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	(%r12), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x4(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x8(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0xc(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x10(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1674>
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1801>
+               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x150a>
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x4(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x8(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0xc(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x10(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r14), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x4(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x8(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0xc(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x10(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x166b>
                	subss	%xmm0, %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1996>
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x4(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x8(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0xc(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x10(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	addss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1821>
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	xorps	%xmm2, %xmm2
                	subss	%xmm0, %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	%rdx, %rsi
-               	imulq	$0x14, %rsi, %rsi
-               	leaq	(%rbx,%rsi), %rdi
-               	movq	-0xa30(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x5, %rdx
-               	jb	 <L59>
-<L62>:
-               	movq	%rax, %r12
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	%rdi, %r13
+               	imulq	$0x14, %r13, %r13
+               	leaq	(%rbx,%r13), %r15
+               	movq	-0x638(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x4(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x8(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0xc(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x10(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	addq	$0x1, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L42>
+<L45>:
+               	movq	%rsi, %r12
                	movq	$0x5, %r13
                	movq	$0x0, %r11
                	cmpq	%r13, %r11
-               	jb	 <L63>
-               	jmp	 <L69>
-<L63>:
-               	movq	%r13, %r14
-               	subq	$0x1, %r14
-               	movq	%r14, %rax
+               	jb	 <L46>
+               	jmp	 <L48>
+<L46>:
+               	subq	$0x1, %r13
+               	movq	%r13, %rax
                	imulq	$0x14, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
+               	leaq	0x4(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
+               	leaq	0x8(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
+               	leaq	0xc(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
+               	leaq	0x10(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm0, (%rax)
-               	movq	-0x940(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
+               	movq	-0x640(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %r12
-               	movq	%r14, %r13
                	movq	$0x0, %r11
                	cmpq	%r13, %r11
-               	jb	 <L63>
-<L69>:
-               	leaq	-0x6b0(%rbp), %r13
+               	jb	 <L46>
+<L48>:
+               	leaq	-0x3b0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1622,431 +1674,365 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     ## imm = 0xFFFFFFFF
-               	leaq	0x3c(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	0x3c(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %r14
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x10(%r13), %rdx
+               	movq	-0x648(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x24(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     ## imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x24(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+<L50>:
+               	leaq	0x10(%r13), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r12, %rdi
+               	movq	-0x650(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L51>
+<L51>:
+               	leaq	0x24(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+<L53>:
+               	leaq	0x14(%rbx), %r12
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x50(%rbx), %rdx
                	leaq	(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x4(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x10(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	(%rcx), %rdx
+               	leaq	(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %rdi
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L54>
+<L54>:
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x970(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	movq	%rax, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L55>
+<L55>:
+               	leaq	0x28(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	leaq	0x28(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	-0xab8(%rbp), %rbx
-               	movq	-0xac0(%rbp), %r12
-               	movq	-0xac8(%rbp), %r13
-               	movq	-0xad0(%rbp), %r14
-               	movq	-0xad8(%rbp), %r15
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L56>
+<L56>:
+               	movq	-0x828(%rbp), %rbx
+               	movq	-0x830(%rbp), %r12
+               	movq	-0x838(%rbp), %r13
+               	movq	-0x840(%rbp), %r14
+               	movq	-0x848(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_scalar_mix.dis
+++ b/test/golden/x86_64-darwin/vec/vec_scalar_mix.dis
@@ -7,28 +7,108 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,32 +118,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -73,32 +225,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -106,847 +330,734 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4c0, %rsp            ## imm = 0x4C0
-               	movq	%rbx, -0x498(%rbp)
-               	movq	%r12, -0x4a0(%rbp)
-               	movq	%r13, -0x4a8(%rbp)
-               	movq	%r14, -0x4b0(%rbp)
-               	movq	%r15, -0x4b8(%rbp)
+               	subq	$0x400, %rsp            ## imm = 0x400
+               	movq	%rbx, -0x3d8(%rbp)
+               	movq	%r12, -0x3e0(%rbp)
+               	movq	%r13, -0x3e8(%rbp)
+               	movq	%r14, -0x3f0(%rbp)
+               	movq	%r15, -0x3f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movl	%ebx, %r12d
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	-0x60(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movl	$0x3fc00000, (%rdx)     ## imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7d>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x84>
-               	leaq	0x4(%rcx), %rdx
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x75>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7c>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movl	$0x40700000, (%rdx)     ## imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x9e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xa5>
-               	leaq	0xc(%rcx), %rdx
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x96>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x9d>
+               	leaq	0xc(%rax), %rdx
                	movss	%xmm1, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm1
+               	leaq	-0x70(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0x3f000000, (%rsi)     ## imm = 0x3F000000
                	leaq	0x4(%rdx), %rsi
                	movl	$0x40800000, (%rsi)     ## imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xd6>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xdd>
+               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xce>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xd5>
                	leaq	0x8(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movl	$0x41000000, (%rsi)     ## imm = 0x41000000
                	movups	(%rdx), %xmm2
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm2, (%rdx)
-               	leaq	(%rcx), %rsi
+               	leaq	(%rax), %rsi
                	movss	(%rsi), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x50(%rbp), %r13
+               	leaq	-0xa0(%rbp), %r13
                	movups	%xmm1, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	%xmm4, (%rcx)
+               	leaq	(%r13), %rax
+               	movss	%xmm4, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movss	(%rcx), %xmm3
+               	movups	%xmm14, -0x330(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movss	(%rax), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r13), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3b0(%rbp)
+               	leaq	-0xb0(%rbp), %r14
+               	movups	%xmm2, (%r14)
+               	leaq	0x8(%r14), %rax
+               	movss	%xmm4, (%rax)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x340(%rbp)
+               	leaq	(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r14), %rax
+               	movss	(%rax), %xmm3
                	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	-0x3b0(%rbp), %xmm14
-               	movss	%xmm14, -0x350(%rbp)
-               	leaq	0x4(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3c0(%rbp)
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3d0(%rbp)
-               	movss	-0x3c0(%rbp), %xmm14
-               	mulss	-0x3d0(%rbp), %xmm14
-               	movss	%xmm14, -0x360(%rbp)
-               	leaq	0x8(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3e0(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	-0x3e0(%rbp), %xmm14
-               	mulss	%xmm0, %xmm14
-               	movss	%xmm14, -0x370(%rbp)
-               	leaq	0xc(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3f0(%rbp)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	-0x3f0(%rbp), %xmm14
-               	mulss	%xmm0, %xmm14
-               	movss	%xmm14, -0x380(%rbp)
-               	movss	-0x350(%rbp), %xmm0
-               	callq	 <L3>
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x2e8(%rbp)
+               	leaq	0x4(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x2f8(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x308(%rbp)
+               	leaq	0xc(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x318(%rbp)
+               	movl	-0x2e8(%rbp), %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax ## imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movss	-0x360(%rbp), %xmm0
-               	callq	 <L4>
+               	movl	-0x2f8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x370(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
+               	movl	-0x308(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x380(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
+               	movl	-0x318(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x350(%rbp), %xmm14
-               	addss	-0x360(%rbp), %xmm14
-               	movss	%xmm14, -0x400(%rbp)
-               	movss	-0x400(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
+               	movss	-0x2e8(%rbp), %xmm14
+               	addss	-0x2f8(%rbp), %xmm14
+               	movss	%xmm14, -0x350(%rbp)
+               	movl	-0x350(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x400(%rbp), %xmm14
-               	addss	-0x370(%rbp), %xmm14
-               	movss	%xmm14, -0x410(%rbp)
-               	movss	-0x410(%rbp), %xmm0
                	callq	 <L8>
 <L8>:
+               	movss	-0x350(%rbp), %xmm14
+               	addss	-0x308(%rbp), %xmm14
+               	movss	%xmm14, -0x360(%rbp)
+               	movl	-0x360(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x410(%rbp), %xmm14
-               	addss	-0x380(%rbp), %xmm14
-               	movss	%xmm14, -0x420(%rbp)
-               	movss	-0x420(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
-               	leaq	-0x70(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	-0x420(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movss	-0x3f0(%rbp), %xmm4
-               	subss	-0x3b0(%rbp), %xmm4
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movss	-0x3d0(%rbp), %xmm3
-               	addss	-0x3e0(%rbp), %xmm3
-               	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm3, (%rdx)
-               	movups	(%rcx), %xmm0
-               	xorps	%xmm3, %xmm3
-               	subss	-0x3c0(%rbp), %xmm3
-               	leaq	-0xa0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm3, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	movss	-0x360(%rbp), %xmm14
+               	addss	-0x318(%rbp), %xmm14
+               	movss	%xmm14, -0x370(%rbp)
+               	movl	-0x370(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	-0x370(%rbp), %r11d
+               	movl	%r11d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm4
+               	movss	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1,2,3]
+               	subss	%xmm4, %xmm5
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm3
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm4
+               	movss	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1,2,3]
+               	addss	%xmm4, %xmm5
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r11d
+               	movl	%r11d, -0x380(%rbp)
+               	xorps	%xmm4, %xmm4
+               	subss	-0x380(%rbp), %xmm4
+               	leaq	-0x2d0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm4, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x390(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x390(%rbp), %xmm14
+               	mulps	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	movss	-0x380(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movaps	-0x430(%rbp), %xmm14
-               	mulps	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L14>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm0, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L16>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L16>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm0, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L18>
-               	jmp	 <L19>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L18>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L20>
-               	jmp	 <L21>
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L20>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L22>
-               	movsd	%xmm0, -0x440(%rbp)
-               	jmp	 <L23>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L22>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	movsd	%xmm2, -0x440(%rbp)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L24>
-               	jmp	 <L25>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L24>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L26>
-               	jmp	 <L27>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
 <L26>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movsd	%xmm0, -0x450(%rbp)
-               	jmp	 <L29>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
 <L28>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	movsd	%xmm3, -0x450(%rbp)
+               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
+               	subss	%xmm2, %xmm3
+               	movd	%xmm3, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L29>
 <L29>:
-               	movq	%rax, %rdi
-               	movss	-0x440(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	-0x450(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movss	-0x440(%rbp), %xmm0
-               	subss	-0x450(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x7, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xfffffff3, (%rdx)     ## imm = 0xFFFFFFF3
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x15, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffe1, (%rdx)     ## imm = 0xFFFFFFE1
-               	movups	(%rcx), %xmm0
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	movl	%ebx, %edx
-               	addl	%edx, %ecx
-               	leaq	-0xd0(%rbp), %rbx
+               	leaq	-0xc0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x7, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0xfffffff3, (%rsi)     ## imm = 0xFFFFFFF3
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x15, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0xffffffe1, (%rsi)     ## imm = 0xFFFFFFE1
+               	movups	(%rdx), %xmm0
+               	leaq	-0xd0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%ebx, %esi
+               	addl	%esi, %edx
+               	leaq	-0xe0(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	0x4(%rbx), %rdx
-               	movl	%ecx, (%rdx)
+               	leaq	0x4(%rbx), %rsi
+               	movl	%edx, (%rsi)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x460(%rbp)
-               	leaq	-0xe0(%rbp), %r13
+               	movups	%xmm14, -0x3a0(%rbp)
+               	leaq	-0xf0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x100(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x110(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x120(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x130(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
                	movups	(%r13), %xmm0
-               	leaq	-0x130(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
+               	callq	 <L30>
+<L30>:
                	movups	(%r13), %xmm0
                	movaps	%xmm0, %xmm14
-               	mulps	-0x390(%rbp), %xmm14
+               	mulps	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	-0x1b0(%rbp), %r14
+               	callq	 <L31>
+<L31>:
+               	leaq	-0x140(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
+               	leaq	-0x150(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
                	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x75c>
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x76f>
                	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x160(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x170(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7b4>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x180(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x190(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7fa>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x1a0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x840>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x1c0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r14), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movups	(%r14), %xmm0
                	leaq	-0x1d0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7a1>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r14), %xmm0
-               	leaq	-0x1f0(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
+               	movl	(%rsi), %edi
+               	leaq	(%rbx), %rsi
+               	movl	(%rsi), %r13d
+               	imull	%r13d, %edi
                	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7e7>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r14), %xmm0
-               	leaq	-0x210(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
+               	movl	(%rsi), %r13d
+               	leaq	0x4(%rbx), %rsi
+               	movl	(%rsi), %r15d
+               	imull	%r15d, %r13d
                	leaq	0x8(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x82d>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
+               	movl	(%rsi), %r15d
+               	leaq	0x8(%rbx), %rsi
+               	movl	(%rsi), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%rdx), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x210(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L33>
+<L33>:
                	movups	(%r14), %xmm0
+               	movaps	%xmm0, %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	leaq	-0x220(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x1, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0xaaaaaaaa, (%rsi)     ## imm = 0xAAAAAAAA
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
+               	movups	(%rdx), %xmm0
                	leaq	-0x230(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0xc(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r14), %xmm0
-               	leaq	-0x240(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L44>
-<L44>:
-               	movups	(%r14), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
+               	movl	(%rsi), %edx
+               	addl	%r12d, %edx
+               	leaq	-0x240(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	0xc(%rbx), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rbx), %xmm14
+               	movups	%xmm14, -0x3b0(%rbp)
                	leaq	(%rbx), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
+               	movl	(%rdx), %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
                	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r13d
+               	movl	(%rdx), %esi
+               	xorl	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L37>
+<L37>:
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	imull	%ebx, %ecx
+               	movl	(%rdx), %esi
+               	subl	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	-0x250(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movups	(%r13), %xmm0
                	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rbx
-               	movl	%esi, (%rbx)
+               	leaq	(%rdx), %rsi
+               	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x270(%rbp), %rdx
+               	movups	%xmm0, (%r13)
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%r12d, %edx
+               	xorl	%esi, %edx
+               	movups	(%r13), %xmm0
+               	leaq	-0x270(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%r12d, %edx
+               	addl	%esi, %edx
+               	movups	(%r13), %xmm0
+               	leaq	-0x280(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	subl	%esi, %r12d
+               	movups	(%r13), %xmm0
+               	leaq	-0x290(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%edi, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x280(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rsi
-               	movl	%r13d, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, (%r13)
+               	movups	(%r13), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movups	(%r14), %xmm0
+               	callq	 <L39>
+<L39>:
+               	movups	(%r13), %xmm0
                	movaps	%xmm0, %xmm14
-               	psubd	-0x460(%rbp), %xmm14
+               	paddd	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	leaq	-0x2b0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xaaaaaaaa, (%rdx)     ## imm = 0xAAAAAAAA
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x12345678, (%rdx)     ## imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	movl	%r12d, %r14d
-               	xorl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	subl	%edx, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2e0(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movl	%r14d, %ecx
-               	xorl	%r12d, %ecx
-               	movups	(%rbx), %xmm2
-               	leaq	-0x300(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movl	%r14d, %ecx
-               	addl	%r13d, %ecx
-               	movups	(%rbx), %xmm2
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	0x8(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	subl	%r15d, %r14d
-               	movups	(%rbx), %xmm2
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x330(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movups	(%rbx), %xmm2
-               	movaps	%xmm2, %xmm14
-               	paddd	-0x470(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rbx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	$0x0, %r12
-<L65>:
-               	leaq	-0x140(%rbp), %rcx
-               	movups	-0x480(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+<L41>:
+               	leaq	-0x10(%rbp), %rdx
+               	movups	-0x3c0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
                	cmpq	$0x4, %r12
-               	jb	 <L66>
+               	jb	 <L42>
                	movq	%rbx, %rax
-               	movq	-0x498(%rbp), %rbx
-               	movq	-0x4a0(%rbp), %r12
-               	movq	-0x4a8(%rbp), %r13
-               	movq	-0x4b0(%rbp), %r14
-               	movq	-0x4b8(%rbp), %r15
+               	movq	-0x3d8(%rbp), %rbx
+               	movq	-0x3e0(%rbp), %r12
+               	movq	-0x3e8(%rbp), %r13
+               	movq	-0x3f0(%rbp), %r14
+               	movq	-0x3f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L66>:
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm1
+<L42>:
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
                	addss	%xmm1, %xmm3
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm4
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm4
                	movss	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1,2,3]
                	subss	%xmm4, %xmm5
                	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xc5f>
+               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xb65>
                	movss	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1,2,3]
-               	addss	, %xmm4 <corpus.cases.vec.vec_scalar_mix.checksum+0xc6b>
-               	leaq	-0x150(%rbp), %rcx
-               	movups	-0x480(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm3, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm5, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm4, (%rcx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	addss	, %xmm4 <corpus.cases.vec.vec_scalar_mix.checksum+0xb71>
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x3c0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm4, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3d0(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L43>
+<L43>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
-               	jmp	 <L65>
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
+               	jmp	 <L41>

--- a/test/golden/x86_64-darwin/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u16x8.dis
@@ -7,48 +7,196 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
+               	leaq	0x8(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -56,16 +204,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            ## imm = 0x2E0
-               	movq	%rbx, -0x2c8(%rbp)
-               	movq	%r12, -0x2d0(%rbp)
-               	movq	%r13, -0x2d8(%rbp)
-               	movq	%r14, -0x2e0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x210, %rsp            ## imm = 0x210
+               	movq	%rbx, -0x1f8(%rbp)
+               	movq	%r12, -0x200(%rbp)
+               	movq	%r13, -0x208(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0xfff0, (%rsi)         ## imm = 0xFFF0
                	leaq	0x2(%rdx), %rsi
@@ -83,9 +227,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0x3039, (%rsi)         ## imm = 0x3039
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x11, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -103,9 +247,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0xd431, (%rdi)         ## imm = 0xD431
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xb0(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0xc0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -123,8 +267,8 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x88b, (%rbx)          ## imm = 0x88B
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	-0x60(%rbp), %rdi
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	-0xd0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -142,739 +286,198 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
+               	movups	%xmm14, -0x130(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0xe0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movups	(%rdi), %xmm0
                	leaq	0xc(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x80(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0xf0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x90(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xe(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x140(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x220(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x230(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pand	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x240(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x220(%rbp), %xmm14
-               	por	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x250(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pxor	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x240(%rbp), %xmm14
-               	pxor	-0x250(%rbp), %xmm14
+               	movaps	-0x160(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L87>
-<L87>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pand	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x140(%rbp), %xmm14
+               	por	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x180(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pxor	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x150(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x170(%rbp), %xmm14
+               	pxor	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x190(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x1b0(%rbp), %xmm14
+               	pxor	-0x190(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1d0(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x1c0(%rbp), %xmm14
+               	paddw	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1e0(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x1f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x280(%rbp), %xmm14
-               	pxor	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, -0x2a0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
+               	movups	-0x1f0(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x1f0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x1e0(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -884,78 +487,39 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x270(%rbp), %xmm14
+               	movups	-0x1a0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x10(%r12), %rax
-               	movups	%xmm3, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rax
+               	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm5, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x280(%rbp), %xmm14
+               	movups	-0x1b0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -964,70 +528,65 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     ## imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x20(%r12), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     ## imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L132>
-<L132>:
-               	movups	(%r12), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L141>
-<L141>:
-               	movq	-0x2c8(%rbp), %rbx
-               	movq	-0x2d0(%rbp), %r12
-               	movq	-0x2d8(%rbp), %r13
-               	movq	-0x2e0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%r13), %rax
+               	movups	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x1f8(%rbp), %rbx
+               	movq	-0x200(%rbp), %r12
+               	movq	-0x208(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u32x4.dis
@@ -7,32 +7,104 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,17 +112,14 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x490, %rsp            ## imm = 0x490
-               	movq	%rbx, -0x468(%rbp)
-               	movq	%r12, -0x470(%rbp)
-               	movq	%r13, -0x478(%rbp)
-               	movq	%r14, -0x480(%rbp)
-               	movq	%r15, -0x488(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x420, %rsp            ## imm = 0x420
+               	movq	%rbx, -0x3f8(%rbp)
+               	movq	%r12, -0x400(%rbp)
+               	movq	%r13, -0x408(%rbp)
+               	movq	%r14, -0x410(%rbp)
+               	movq	%r15, -0x418(%rbp)
+               	movl	%edi, %eax
+               	leaq	-0x110(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0xfffffff0, (%rsi)     ## imm = 0xFFFFFFF0
                	leaq	0x4(%rdx), %rsi
@@ -60,9 +129,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdx), %rsi
                	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x120(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x130(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x11, (%rdi)
                	leaq	0x4(%rsi), %rdi
@@ -72,9 +141,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x1, (%rdi)
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0x140(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x150(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movl	$0x1, (%rbx)
                	leaq	0x4(%rdi), %rbx
@@ -84,9 +153,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %rbx
                	movl	$0x1b, (%rbx)
                	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x160(%rbp), %rbx
                	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x170(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -96,531 +165,326 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x380(%rbp)
+               	movups	%xmm14, -0x310(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x180(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
                	movl	%edx, (%r12)
                	movups	(%rdi), %xmm0
                	leaq	0x8(%rdi), %rdx
                	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	addl	%eax, %edi
+               	leaq	-0x190(%rbp), %r12
                	movups	%xmm0, (%r12)
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x320(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r13
+               	addl	%eax, %edx
+               	leaq	-0x1b0(%rbp), %r13
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%r13), %rax
+               	movl	%edx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm14, -0x330(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x320(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x330(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x340(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x340(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x330(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rax, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%r13), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r13), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x390(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x3a0(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm0
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r12), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %edi
                	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x210(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%esi, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x220(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r13), %rdx
                	movl	(%rdx), %edi
                	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r12d
                	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r13), %rdx
                	movl	(%rdx), %r12d
                	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r12d
+               	leaq	0xc(%r13), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%esi, (%r13)
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r13d
+               	leaq	-0x250(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%esi, (%r15)
                	movups	(%rdx), %xmm0
-               	leaq	-0x320(%rbp), %rdx
+               	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x330(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %edi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	-0x290(%rbp), %rdx
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%esi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movl	%r12d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pand	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3b0(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x390(%rbp), %xmm14
-               	por	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3c0(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x390(%rbp), %xmm14
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pand	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x350(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x320(%rbp), %xmm14
+               	por	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x360(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x320(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x3a0(%rbp), %xmm14
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x330(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x3b0(%rbp), %xmm14
-               	pxor	-0x3c0(%rbp), %xmm14
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x350(%rbp), %xmm14
+               	pxor	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r12
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
                	movq	$0x0, %r13
-<L48>:
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x3e0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x90(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -630,358 +494,260 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rbx), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x358(%rbp)
+               	movl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x2e0(%rbp)
                	leaq	0x4(%r14), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %esi
                	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2e8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %edi
+               	leaq	0xc(%r14), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
                	movl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0x8(%r14), %rax
-               	movl	(%rax), %esi
-               	leaq	0x8(%rbx), %rax
-               	movl	(%rax), %edi
-               	imull	%edi, %esi
-               	leaq	0xc(%r14), %rax
-               	movl	(%rax), %edi
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %edi
-               	leaq	-0x150(%rbp), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	leaq	-0xa0(%rbp), %rax
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x160(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x170(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x180(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%edi, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rsi
+               	movq	-0x2e0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xb0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x2e8(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x3f0(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
-               	movq	-0x408(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x410(%rbp)
-               	movq	-0x410(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x410(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x360(%rbp)
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	-0x3a8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	-0x368(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%r8, %rdi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	-0x3a8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x100(%rbp), %r8
+               	movq	%r8, -0x3b0(%rbp)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
+               	callq	 <L23>
+<L23>:
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdx
-               	movq	-0x408(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x418(%rbp)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x418(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L55>
-<L55>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x1d0(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x468(%rbp), %rbx
-               	movq	-0x470(%rbp), %r12
-               	movq	-0x478(%rbp), %r13
-               	movq	-0x480(%rbp), %r14
-               	movq	-0x488(%rbp), %r15
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x3f8(%rbp), %rbx
+               	movq	-0x400(%rbp), %r12
+               	movq	-0x408(%rbp), %r13
+               	movq	-0x410(%rbp), %r14
+               	movq	-0x418(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2f8(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %edi
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x3e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r15d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%r8d, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r14
+               	movl	%edi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	%r12, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x3a0(%rbp), %xmm14
+               	paddd	-0x380(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3f0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	pxor	-0x430(%rbp), %xmm14
-               	movaps	%xmm14, -0x440(%rbp)
-               	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L69>
-<L69>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x3e0(%rbp), %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x460(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
+               	movups	-0x3f0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
-               	jmp	 <L48>
+               	movups	-0x3f0(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	movups	-0x3e0(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-darwin/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u64x2.dis
@@ -7,18 +7,56 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,334 +64,255 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3a0, %rsp            ## imm = 0x3A0
-               	movq	%rbx, -0x378(%rbp)
-               	movq	%r12, -0x380(%rbp)
-               	movq	%r13, -0x388(%rbp)
-               	movq	%r14, -0x390(%rbp)
-               	movq	%r15, -0x398(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x310, %rsp            ## imm = 0x310
+               	movq	%rbx, -0x2e8(%rbp)
+               	movq	%r12, -0x2f0(%rbp)
+               	movq	%r13, -0x2f8(%rbp)
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x308(%rbp)
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$-0x10, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$0x12345678, (%rdx)     ## imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movq	$0x11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$-0x1, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x1, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x1b, (%rdi)
+               	leaq	-0x110(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movq	$0x1, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x1b, (%rbx)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	-0x70(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
+               	leaq	-0x120(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x130(%rbp), %rsi
+               	leaq	(%rsi), %r12
+               	movq	$0x0, (%r12)
+               	leaq	0x8(%rsi), %r12
+               	movq	$0x0, (%r12)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movq	%rcx, (%rsi)
+               	movups	%xmm14, -0x200(%rbp)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rdi, %rax
+               	leaq	-0x140(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	(%r12), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x210(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rdi, %rdx
+               	leaq	-0x150(%rbp), %r13
+               	movups	%xmm1, (%r13)
+               	leaq	0x8(%r13), %rax
+               	movq	%rdx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x2b0(%rbp)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movups	%xmm14, -0x220(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x210(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x220(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x230(%rbp)
+               	leaq	-0x160(%rbp), %r14
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
+               	movups	-0x230(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %rdi
+               	leaq	-0x170(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%rsi, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x190(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1d0(%rbp), %rdx
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pand	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	por	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pxor	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x220(%rbp), %rcx
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pand	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2c0(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	por	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2d0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2d0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r12
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	movq	$0x0, %r13
-<L28>:
-               	leaq	-0xa0(%rbp), %r14
-               	movups	-0x2f0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x70(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -363,231 +322,211 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movq	(%rax), %rcx
-               	leaq	(%r12), %rax
                	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r14), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r12), %rax
+               	leaq	(%rbx), %rax
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
-               	leaq	-0x110(%rbp), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	-0x80(%rbp), %rax
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rsi
-               	movq	%rcx, (%rsi)
-               	movups	(%rax), %xmm2
-               	leaq	-0x120(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rdi
+               	movq	%rdx, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x90(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rsi, (%rdx)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x300(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x2d8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x320(%rbp)
-               	movq	-0x320(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x320(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x278(%rbp)
-               	movq	-0x2d8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x278(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x298(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdx
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x2d8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x328(%rbp)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x328(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x2d8(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x258(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L33>
-<L33>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x170(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movq	(%rdx), %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     ## imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     ## imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r15), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x378(%rbp), %rbx
-               	movq	-0x380(%rbp), %r12
-               	movq	-0x388(%rbp), %r13
-               	movq	-0x390(%rbp), %r14
-               	movq	-0x398(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x2e8(%rbp), %rbx
+               	movq	-0x2f0(%rbp), %r12
+               	movq	-0x2f8(%rbp), %r13
+               	movq	-0x300(%rbp), %r14
+               	movq	-0x308(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
+<L26>:
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	imulq	%rdi, %rsi
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xc0(%rbp), %r14
-               	movups	%xmm2, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x270(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rsi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x2b0(%rbp)
+               	movq	%r12, %rdi
+               	movups	-0x2b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movaps	-0x300(%rbp), %xmm14
-               	pxor	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x350(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x290(%rbp), %xmm14
+               	paddq	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x2e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x2f0(%rbp), %xmm14
-               	movaps	%xmm14, -0x360(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x370(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
+               	movups	-0x2e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
-               	jmp	 <L28>
+               	movq	%rax, %r12
+               	movups	-0x2e0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2d0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-darwin/vec/vec_u8x16.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u8x16.dis
@@ -7,88 +7,380 @@ Disassembly of section __TEXT,__text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    ## imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -96,1101 +388,1086 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xac0, %rsp            ## imm = 0xAC0
-               	movq	%rbx, -0xa98(%rbp)
-               	movq	%r12, -0xaa0(%rbp)
-               	movq	%r13, -0xaa8(%rbp)
-               	movq	%r14, -0xab0(%rbp)
-               	movq	%r15, -0xab8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0xaa0, %rsp            ## imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movb	%dil, %al
+               	leaq	-0x290(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x10, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$0x11, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x38, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x63, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$0x0, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x21, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x40, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$0x5, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$-0x39, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x2b0(%rbp), %rdx
                	leaq	(%rdx), %rsi
-               	movb	$-0x10, (%rsi)
-               	leaq	0x1(%rdx), %rsi
-               	movb	$0x1, (%rsi)
-               	leaq	0x2(%rdx), %rsi
-               	movb	$-0x80, (%rsi)
-               	leaq	0x3(%rdx), %rsi
-               	movb	$-0x1, (%rsi)
-               	leaq	0x4(%rdx), %rsi
                	movb	$0x11, (%rsi)
-               	leaq	0x5(%rdx), %rsi
-               	movb	$0x2, (%rsi)
-               	leaq	0x6(%rdx), %rsi
+               	leaq	0x1(%rdx), %rsi
+               	movb	$-0x1, (%rsi)
+               	leaq	0x2(%rdx), %rsi
+               	movb	$-0x7f, (%rsi)
+               	leaq	0x3(%rdx), %rsi
+               	movb	$0x1, (%rsi)
+               	leaq	0x4(%rdx), %rsi
                	movb	$-0x38, (%rsi)
+               	leaq	0x5(%rdx), %rsi
+               	movb	$0x64, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movb	$0x39, (%rsi)
                	leaq	0x7(%rdx), %rsi
-               	movb	$0x63, (%rsi)
+               	movb	$0x15, (%rsi)
                	leaq	0x8(%rdx), %rsi
-               	movb	$0x0, (%rsi)
+               	movb	$-0x1, (%rsi)
                	leaq	0x9(%rdx), %rsi
-               	movb	$0x7, (%rsi)
+               	movb	$0x3, (%rsi)
                	leaq	0xa(%rdx), %rsi
-               	movb	$-0x6, (%rsi)
+               	movb	$0x6, (%rsi)
                	leaq	0xb(%rdx), %rsi
-               	movb	$0x21, (%rsi)
+               	movb	$-0x22, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movb	$-0x80, (%rsi)
                	leaq	0xd(%rdx), %rsi
-               	movb	$0x40, (%rsi)
+               	movb	$-0x40, (%rsi)
                	leaq	0xe(%rdx), %rsi
-               	movb	$0x5, (%rsi)
+               	movb	$-0x5, (%rsi)
                	leaq	0xf(%rdx), %rsi
-               	movb	$-0x39, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	$0x11, (%rbx)
-               	leaq	0x1(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	leaq	0x2(%rsi), %rbx
-               	movb	$-0x7f, (%rbx)
-               	leaq	0x3(%rsi), %rbx
-               	movb	$0x1, (%rbx)
-               	leaq	0x4(%rsi), %rbx
-               	movb	$-0x38, (%rbx)
-               	leaq	0x5(%rsi), %rbx
-               	movb	$0x64, (%rbx)
-               	leaq	0x6(%rsi), %rbx
-               	movb	$0x39, (%rbx)
-               	leaq	0x7(%rsi), %rbx
-               	movb	$0x15, (%rbx)
-               	leaq	0x8(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	leaq	0x9(%rsi), %rbx
-               	movb	$0x3, (%rbx)
-               	leaq	0xa(%rsi), %rbx
-               	movb	$0x6, (%rbx)
-               	leaq	0xb(%rsi), %rbx
-               	movb	$-0x22, (%rbx)
-               	leaq	0xc(%rsi), %rbx
-               	movb	$-0x80, (%rbx)
-               	leaq	0xd(%rsi), %rbx
-               	movb	$-0x40, (%rbx)
-               	leaq	0xe(%rsi), %rbx
-               	movb	$-0x5, (%rbx)
-               	leaq	0xf(%rsi), %rbx
-               	movb	$0x39, (%rbx)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x9, (%r12)
-               	leaq	0x3(%rbx), %r12
-               	movb	$0x1b, (%r12)
-               	leaq	0x4(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x5(%rbx), %r12
-               	movb	$0x6, (%r12)
-               	leaq	0x6(%rbx), %r12
-               	movb	$0x12, (%r12)
-               	leaq	0x7(%rbx), %r12
-               	movb	$0x36, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movb	$0x4, (%r12)
-               	leaq	0x9(%rbx), %r12
-               	movb	$0xc, (%r12)
-               	leaq	0xa(%rbx), %r12
-               	movb	$0x24, (%r12)
-               	leaq	0xb(%rbx), %r12
-               	movb	$0x6c, (%r12)
-               	leaq	0xc(%rbx), %r12
-               	movb	$0x8, (%r12)
-               	leaq	0xd(%rbx), %r12
-               	movb	$0x18, (%r12)
-               	leaq	0xe(%rbx), %r12
-               	movb	$0x48, (%r12)
-               	leaq	0xf(%rbx), %r12
-               	movb	$-0x28, (%r12)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9b0(%rbp)
-               	leaq	(%rdx), %r12
-               	movzbl	(%r12), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%dl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rdx
-               	movzbl	(%rdx), %r12d
-               	addl	%ecx, %r12d
-               	leaq	-0x90(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x7(%r13), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x9c0(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	movb	$0x39, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x2c0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	0x3(%rdx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rsi
-               	movzbl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r12
+               	leaq	-0x2d0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x9, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x1b, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x6, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x12, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x36, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x4, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0xc, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x24, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x6c, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x8, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x18, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x48, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$-0x28, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	-0x2e0(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x2f0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x990(%rbp)
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x300(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x310(%rbp), %r12
                	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rcx
-               	movb	%dl, (%rcx)
+               	leaq	0x7(%r12), %rcx
+               	movb	%sil, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9d0(%rbp)
-               	movups	-0x9c0(%rbp), %xmm0
+               	movups	%xmm14, -0x9a0(%rbp)
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x330(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0xc(%r13), %rax
+               	movb	%cl, (%rax)
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, -0x9b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi ## imm = 0xCBF29CE484222325
+               	movups	-0x9a0(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	movups	-0x9b0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9c0(%rbp)
+               	leaq	-0x340(%rbp), %r14
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movups	-0x9d0(%rbp), %xmm0
+               	movups	-0x9c0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9e0(%rbp)
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
-               	movaps	-0x9d0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L5>
-<L5>:
                	movq	%rax, %r8
                	movq	%r8, -0x748(%rbp)
                	movq	-0x748(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
                	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
                	movq	%r8, -0x750(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
                	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %r15d
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%r13), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
+               	imull	%edi, %r8d
                	movq	%r8, -0x758(%rbp)
-               	leaq	0x2(%r13), %rcx
-               	movzbl	(%rcx), %r15d
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x760(%rbp)
-               	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x768(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x770(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x780(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x788(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x790(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7a0(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x7a8(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7b0(%rbp)
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rdx
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rdx
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rdx
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rdx
-               	movq	-0x778(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rdx
-               	movq	-0x780(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rdx
-               	movq	-0x788(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	-0x790(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rdx
-               	movq	-0x798(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rdx
-               	movq	-0x7a0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rdx
-               	movq	-0x7a8(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movq	-0x7b0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x748(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7c0(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x2(%r13), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x760(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
                	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x768(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7d8(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x770(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x7e0(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x778(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x7f0(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	movq	%r8, -0x780(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %r15d
                	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x788(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f8(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x800(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x810(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x818(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x7a8(%rbp)
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x7f0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x7f8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x800(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x808(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x810(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x818(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x7b8(%rbp), %r8
+               	leaq	-0x350(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x750(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x360(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rsi
+               	movq	-0x758(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x370(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rsi
+               	movq	-0x760(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x380(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rsi
+               	movq	-0x768(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x390(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x770(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rsi
+               	movq	-0x778(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rsi
+               	movq	-0x780(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rsi
+               	movq	-0x788(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	-0x790(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rsi
+               	movq	-0x798(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rsi
+               	movq	-0x7a0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rsi
+               	movq	-0x7a8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x748(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
-<L7>:
+               	callq	 <L5>
+<L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x7b8(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7c0(%rbp)
                	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %eax
                	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x840(%rbp)
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x7d0(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x848(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x7e0(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7e8(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x7f8(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x800(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x808(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x450(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movq	-0x7b8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
+               	movq	-0x7c0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x7c8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x7d0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0x7d8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0x7e0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0x7e8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0x7f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0x7f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movq	-0x800(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r12
+               	movq	-0x808(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r12
+               	movb	%sil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	-0x810(%rbp), %r8
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x5(%rbx), %rcx
+               	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x850(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	movq	%r8, -0x818(%rbp)
+               	leaq	0x1(%r13), %rcx
                	movzbl	(%rcx), %esi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x858(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x7(%rbx), %rcx
+               	imull	%edi, %r8d
+               	movq	%r8, -0x820(%rbp)
+               	leaq	0x2(%r13), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x828(%rbp)
+               	leaq	0x3(%r13), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%r12d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x830(%rbp)
+               	leaq	0x4(%r13), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x838(%rbp)
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x840(%rbp)
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x848(%rbp)
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x850(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x858(%rbp)
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r12d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0x860(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x868(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x870(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x878(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %edx
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	-0x9d0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r12
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r12
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r12
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r12
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r12
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r12
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r12
-               	movq	-0x860(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r12
-               	movq	-0x868(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r12
-               	movq	-0x870(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r12
-               	movq	-0x878(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dil, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x550(%rbp), %rax
+               	movups	-0x9b0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x818(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x820(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
+               	movq	-0x828(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
+               	movq	-0x830(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movq	-0x838(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
+               	movq	-0x840(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
+               	movq	-0x848(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
+               	movq	-0x850(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movq	-0x858(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
+               	movq	-0x860(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
+               	movb	%r15b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x600(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%r12b, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x810(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x868(%rbp), %r8
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x870(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x878(%rbp)
                	leaq	0x2(%r14), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x880(%rbp)
+               	leaq	0x3(%r14), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%r12d, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x898(%rbp)
-               	leaq	0x3(%r14), %rcx
+               	movq	%r8, -0x888(%rbp)
+               	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x3(%rbx), %rcx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r13d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
-               	leaq	0x4(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0x890(%rbp)
                	leaq	0x5(%r14), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %r15d
                	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x898(%rbp)
+               	leaq	0x6(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
-               	leaq	0x6(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x8a0(%rbp)
+               	leaq	0x7(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
-               	leaq	0x7(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x8(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x9(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0xa(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xb(%r14), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xc(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0xd(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %esi
-               	leaq	0xe(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x8b0(%rbp)
+               	leaq	0x9(%r14), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xa(%r14), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xf(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
+               	leaq	0xb(%r14), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r13d
+               	leaq	0xc(%r14), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x650(%rbp), %rax
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r14
+               	movq	-0x870(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x878(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x880(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
                	movq	-0x888(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
                	movq	-0x890(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
                	movq	-0x898(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
                	movq	-0x8a0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
                	movq	-0x8a8(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
                	movq	-0x8b0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
                	movb	%dil, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdi
-               	movb	%dl, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r12b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x710(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x868(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pand	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9d0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	-0x9d0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	por	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9e0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pand	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9f0(%rbp)
-               	movups	-0x9f0(%rbp), %xmm0
+               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pxor	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	por	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa00(%rbp)
-               	movups	-0xa00(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pxor	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movaps	-0x9d0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	pxor	-0x9e0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
+               	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x9f0(%rbp), %xmm14
-               	pxor	-0xa00(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm0
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %r12
-               	movups	-0x9c0(%rbp), %xmm14
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0x990(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0x990(%rbp), %xmm14
                	movups	%xmm14, -0xa20(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
                	movq	$0x0, %r13
-<L18>:
-               	leaq	-0x4d0(%rbp), %r14
-               	movups	-0xa20(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L25>
-               	leaq	-0x610(%rbp), %r15
+               	jb	 <L24>
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -1200,10 +1477,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
                	movups	%xmm0, (%rax)
@@ -1213,91 +1490,91 @@ Disassembly of section __TEXT,__text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0x8b8(%rbp)
                	leaq	0x1(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x2(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x2(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x3(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x3(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x4(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x5(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x6(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x7(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x8(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x9(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0xa(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xb(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xc(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xd(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rbx), %rax
@@ -1313,96 +1590,96 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %edi
-               	leaq	-0x620(%rbp), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x160(%rbp), %rax
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0x8b8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0x8c0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0x8c8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0x8d0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x1b0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x1e0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%sil, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%dil, (%rcx)
@@ -1410,163 +1687,175 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0xa30(%rbp), %xmm14
+               	movups	-0xa10(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	movq	-0xa48(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm0
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xa48(%rbp), %r8
+               	callq	 <L19>
+<L19>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x740(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	movq	$0x0, 0x10(%rcx)
-               	movq	$0x0, 0x18(%rcx)
-               	movq	$0x0, 0x20(%rcx)
-               	movq	$0x0, 0x28(%rcx)
-               	leaq	(%rcx), %rdx
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x280(%rbp), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%rcx), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0x20(%rcx), %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	movl	$0x12345678, (%r8)      ## imm = 0x12345678
-               	movl	(%rdx), %ecx
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%ecx, %esi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movups	(%r15), %xmm0
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movl	(%rdx), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x940(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xa98(%rbp), %rbx
-               	movq	-0xaa0(%rbp), %r12
-               	movq	-0xaa8(%rbp), %r13
-               	movq	-0xab0(%rbp), %r14
-               	movq	-0xab8(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x928(%rbp)
                	leaq	0x2(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x3(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x5(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x6(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x7(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x8(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x9(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0xa(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0xb(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x9a0(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xc(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rbx), %rcx
@@ -1587,131 +1876,131 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x20(%rbp), %rcx
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x70(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r15
                	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0x960(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0x968(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0x970(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0x978(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%dil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0xa60(%rbp)
+               	movups	%xmm14, -0xa40(%rbp)
                	movq	%r12, %rdi
-               	movups	-0xa60(%rbp), %xmm0
+               	movups	-0xa40(%rbp), %xmm0
+               	callq	 <L25>
+<L25>:
+               	movaps	-0xa10(%rbp), %xmm14
+               	pxor	-0xa40(%rbp), %xmm14
+               	movaps	%xmm14, -0xa50(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa50(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
-               	movaps	-0xa30(%rbp), %xmm14
-               	pxor	-0xa60(%rbp), %xmm14
+               	movaps	-0xa20(%rbp), %xmm14
+               	paddb	-0xa00(%rbp), %xmm14
+               	movaps	%xmm14, -0xa60(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa60(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, -0xa70(%rbp)
                	movq	%rax, %rdi
                	movups	-0xa70(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movaps	-0xa40(%rbp), %xmm14
-               	paddb	-0xa20(%rbp), %xmm14
-               	movaps	%xmm14, -0xa80(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa80(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa90(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa90(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0xa90(%rbp), %xmm14
-               	movups	%xmm14, -0xa20(%rbp)
                	movups	-0xa70(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0xa80(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
-               	jmp	 <L18>
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0xa50(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0xa60(%rbp), %xmm14
+               	movups	%xmm14, -0xa20(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/bits/logic_u32.dis
+++ b/test/golden/x86_64-windows/bits/logic_u32.dis
@@ -5,163 +5,471 @@ Disassembly of section .text:
 <corpus.cases.bits.logic_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %esi
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%esi, %ebx
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %ebx
+               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	xorl	%ebx, %esi
                	movl	$0xaaaaaaaa, %edi       # imm = 0xAAAAAAAA
-               	xorl	%esi, %edi
+               	xorl	%ebx, %edi
                	movl	$0x55555555, %r12d      # imm = 0x55555555
-               	xorl	%esi, %r12d
-               	movl	%esi, %r13d
-               	andl	%ebx, %r13d
-               	movl	%r13d, %edx
-               	callq	 <L1>
+               	xorl	%ebx, %r12d
+               	movl	%ebx, %eax
+               	andl	%esi, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%esi, %r14d
-               	orl	%ebx, %r14d
-               	movl	%r14d, %edx
-               	callq	 <L2>
+               	movl	%ebx, %edx
+               	orl	%esi, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	xorl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	xorl	$-0x1, %edx
-               	callq	 <L4>
+               	movl	%ebx, %edx
+               	xorl	%esi, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
                	movl	%ebx, %edx
                	xorl	$-0x1, %edx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movl	%esi, %edx
+               	xorl	$-0x1, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movl	%edi, %edx
                	andl	%r12d, %edx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
                	movl	%edi, %edx
                	orl	%r12d, %edx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movl	%edi, %r15d
-               	xorl	%r12d, %r15d
-               	movl	%r15d, %edx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movl	%edi, %edx
+               	xorl	%r12d, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
                	movl	%edi, %edx
                	xorl	$-0x1, %edx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
                	movl	%r12d, %edx
                	xorl	$-0x1, %edx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	andl	%edi, %edx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	orl	%r12d, %edx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	andl	%r12d, %edx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	orl	%edi, %edx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	orl	%r15d, %edx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	xorl	$-0x1, %r14d
-               	movl	%r14d, %edx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	xorl	$-0x1, %r13d
-               	movl	%r13d, %edx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	xorl	$-0x1, %r15d
-               	movl	%r15d, %edx
-               	callq	 <L18>
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x8, %r14d
-               	jb	 <L19>
-               	jmp	 <L23>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movl	%esi, %r15d
-               	xorl	%r14d, %r15d
-               	movl	%ebx, %eax
-               	orl	%r14d, %eax
-               	movl	%r12d, %ecx
-               	xorl	%r14d, %ecx
-               	movl	%edi, %r8d
-               	andl	%ecx, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movl	%r15d, %edx
-               	andl	%eax, %edx
-               	movq	%r13, %rcx
-               	callq	 <L20>
+               	movl	%ebx, %edx
+               	andl	%edi, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r15d, %edx
-               	orl	%r8d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	movq	-0x8(%rbp), %r8
-               	xorl	%r8d, %r15d
-               	xorl	$-0x1, %r15d
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L22>
+               	movl	%esi, %edx
+               	orl	%r12d, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %r13
-               	cmpl	$0x8, %r14d
-               	jb	 <L19>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movq	%r13, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movl	%ebx, %edx
+               	andl	%r12d, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movl	%esi, %edx
+               	orl	%edi, %edx
+               	movq	%rax, %rcx
+               	callq	 <L26>
+<L26>:
+               	movl	%ebx, %r13d
+               	andl	%esi, %r13d
+               	movl	%edi, %r14d
+               	xorl	%r12d, %r14d
+               	movl	%r13d, %edx
+               	orl	%r14d, %edx
+               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movl	%ebx, %edx
+               	orl	%esi, %edx
+               	xorl	$-0x1, %edx
+               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
+               	xorl	$-0x1, %r13d
+               	movq	%rax, %rcx
+               	movl	%r13d, %edx
+               	callq	 <L29>
+<L29>:
+               	xorl	$-0x1, %r14d
+               	movq	%rax, %rcx
+               	movl	%r14d, %edx
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpl	$0x8, %r8d
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
+               	movl	%ebx, %r8d
+               	xorl	%r9d, %r8d
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movl	%esi, %r14d
+               	orl	%r8d, %r14d
+               	movq	-0x20(%rbp), %r8
+               	movl	%r12d, %r15d
+               	xorl	%r8d, %r15d
+               	movl	%edi, %r8d
+               	andl	%r15d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %r15d
+               	andl	%r14d, %r15d
+               	movl	%r15d, %r14d
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %rdx
+               	xorq	%r13, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	orl	%r9d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	xorl	%r9d, %eax
+               	xorl	$-0x1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%r15, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpl	$0x8, %r8d
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/bits/logic_u64.dis
+++ b/test/golden/x86_64-windows/bits/logic_u64.dis
@@ -5,162 +5,455 @@ Disassembly of section .text:
 <corpus.cases.bits.logic_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	$-0x1, %rsi
                	xorq	%rbx, %rsi
                	movabsq	$-0x5555555555555556, %rdi # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %rdi
                	movabsq	$0x5555555555555555, %r12 # imm = 0x5555555555555555
                	xorq	%rbx, %r12
+               	movq	%rbx, %rax
+               	andq	%rsi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
+<L1>:
+               	movq	%rbx, %rax
+               	orq	%rsi, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+<L3>:
+               	movq	%rbx, %rax
+               	xorq	%rsi, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
+<L5>:
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+<L7>:
+               	movq	%rsi, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
+               	andq	%r12, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+<L11>:
+               	movq	%rdi, %rax
+               	orq	%r12, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
+<L13>:
+               	movq	%rdi, %rax
+               	xorq	%r12, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+<L17>:
+               	movq	%r12, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+<L19>:
+               	movq	%rbx, %rax
+               	andq	%rdi, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+<L21>:
+               	movq	%rsi, %rax
+               	orq	%r12, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L22>
+<L23>:
+               	movq	%rbx, %rax
+               	andq	%r12, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	orq	%rdi, %rax
+               	movq	%rdx, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L26>
+<L26>:
                	movq	%rbx, %r13
                	andq	%rsi, %r13
+               	movq	%rdi, %r14
+               	xorq	%r12, %r14
                	movq	%r13, %rdx
-               	callq	 <L1>
-<L1>:
+               	orq	%r14, %rdx
                	movq	%rax, %rcx
-               	movq	%rbx, %r14
-               	orq	%rsi, %r14
-               	movq	%r14, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
                	movq	%rbx, %rdx
-               	xorq	%rsi, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	orq	%rsi, %rdx
                	xorq	$-0x1, %rdx
-               	callq	 <L4>
-<L4>:
                	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	xorq	$-0x1, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	andq	%r12, %rdx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	orq	%r12, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %r15
-               	xorq	%r12, %r15
-               	movq	%r15, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	xorq	$-0x1, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	xorq	$-0x1, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	andq	%rdi, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	orq	%r12, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	andq	%r12, %rdx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	orq	%rdi, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	orq	%r15, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	xorq	$-0x1, %r14
-               	movq	%r14, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
                	xorq	$-0x1, %r13
+               	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L17>
-<L17>:
+               	callq	 <L29>
+<L29>:
+               	xorq	$-0x1, %r14
                	movq	%rax, %rcx
-               	xorq	$-0x1, %r15
-               	movq	%r15, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
-               	jb	 <L19>
-               	jmp	 <L23>
-<L19>:
-               	movq	%rbx, %r15
-               	xorq	%r14, %r15
-               	movq	%rsi, %rax
-               	orq	%r14, %rax
-               	movq	%r12, %rcx
-               	xorq	%r14, %rcx
-               	movq	%rdi, %r8
-               	andq	%rcx, %r8
+               	movq	%r14, %rdx
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
                	movq	%r8, -0x8(%rbp)
-               	movq	%r15, %rdx
-               	andq	%rax, %rdx
-               	movq	%r13, %rcx
-               	callq	 <L20>
-<L20>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r15, %rdx
-               	orq	%r8, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
+               	movq	%rbx, %r8
+               	xorq	%r9, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%rsi, %r14
+               	orq	%r8, %r14
+               	movq	-0x20(%rbp), %r8
+               	movq	%r12, %r15
                	xorq	%r8, %r15
-               	xorq	$-0x1, %r15
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L22>
-<L22>:
-               	addq	$0x1, %r14
+               	movq	%rdi, %r8
+               	andq	%r15, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %r15
+               	andq	%r14, %r15
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
                	movq	%rax, %r13
-               	cmpq	$0x8, %r14
-               	jb	 <L19>
-<L23>:
-               	movq	%r13, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r15, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %rdx
+               	xorq	%r13, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	orq	%r9, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	xorq	%r9, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r14, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/bits/shift_i32.dis
+++ b/test/golden/x86_64-windows/bits/shift_i32.dis
@@ -5,238 +5,503 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %esi
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%esi, %ebx
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %ebx
+               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	xorl	%ebx, %esi
                	movl	$0xaaaaaaaa, %edi       # imm = 0xAAAAAAAA
-               	xorl	%esi, %edi
+               	xorl	%ebx, %edi
                	movl	$0x55555555, %r12d      # imm = 0x55555555
-               	xorl	%esi, %r12d
-               	movq	%rdx, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L1>
+               	xorl	%ebx, %r12d
+               	movslq	%esi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	shll	%eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x1f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L3>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L4>
+               	movl	%esi, %eax
+               	shll	$0x1f, %eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	sarl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L5>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	sarl	$0x1f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L6>
+               	movslq	%esi, %rax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L7>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	sarl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L8>
+               	movl	%esi, %eax
+               	sarl	%eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	sarl	$0x1f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L9>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdx
-               	movl	%r12d, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L10>
+               	movl	%esi, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdx
-               	movl	%r12d, %r13d
-               	sarl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L11>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdx
-               	movl	%esi, %r13d
-               	shll	$0x5, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L12>
+               	movl	%edi, %eax
+               	shll	%eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdx
-               	movl	%esi, %r13d
-               	sarl	$0x5, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L13>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x20, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L14>
+               	movl	%edi, %eax
+               	sarl	%eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	sarl	$0x20, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L15>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x21, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L16>
+               	movl	%edi, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	sarl	$0x21, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L17>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x3f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L18>
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movslq	%eax, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	sarl	$0x3f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L19>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shll	$0x20, %r13d
+               	movl	%r12d, %eax
+               	sarl	%eax
                	movq	%rdx, %rcx
-               	movl	%r13d, %edx
+               	movl	%eax, %edx
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	sarl	$0x3f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
+               	movl	%ebx, %edx
+               	shll	$0x5, %edx
+               	movq	%rax, %rcx
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
-               	jb	 <L22>
-               	jmp	 <L27>
+               	movl	%ebx, %edx
+               	sarl	$0x5, %edx
+               	movq	%rax, %rcx
+               	callq	 <L22>
 <L22>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r13, %rcx
-               	movl	%eax, %edx
+               	movl	%esi, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
+               	movl	%esi, %edx
+               	sarl	$0x20, %edx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movl	%r14d, %r15d
-               	addl	%esi, %r15d
-               	movl	%r15d, %ecx
-               	movl	%edi, %edx
-               	shll	%cl, %edx
+               	movl	%esi, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rcx
                	callq	 <L25>
 <L25>:
-               	movl	%r15d, %ecx
-               	movl	%r12d, %edx
-               	sarl	%cl, %edx
+               	movl	%esi, %edx
+               	sarl	$0x21, %edx
                	movq	%rax, %rcx
                	callq	 <L26>
 <L26>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %r13
-               	cmpl	$0x20, %r14d
-               	jb	 <L22>
+               	movl	%esi, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rcx
+               	callq	 <L27>
 <L27>:
-               	movl	$0x1e, %edi
-               	cmpl	$0x28, %edi
-               	jb	 <L28>
-               	jmp	 <L31>
+               	movl	%esi, %edx
+               	sarl	$0x3f, %edx
+               	movq	%rax, %rcx
+               	callq	 <L28>
 <L28>:
-               	movl	%edi, %r12d
-               	addl	%esi, %r12d
-               	movl	%r12d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r13, %rcx
-               	movl	%eax, %edx
+               	movl	%edi, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rcx
                	callq	 <L29>
 <L29>:
-               	movl	%r12d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
+               	movl	%edi, %edx
+               	sarl	$0x3f, %edx
                	movq	%rax, %rcx
                	callq	 <L30>
 <L30>:
-               	addl	$0x1, %edi
-               	movq	%rax, %r13
-               	cmpl	$0x28, %edi
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
-               	movq	%r13, %rax
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%esi, %r13d
+               	shll	%cl, %r13d
+               	movslq	%r13d, %r14
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r13, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%esi, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%edi, %eax
+               	shll	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r12d, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%r13, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%esi, %edi
+               	shll	%cl, %edi
+               	movslq	%edi, %r12
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movl	%r12d, %ecx
+               	movl	%esi, %r12d
+               	sarl	%cl, %r12d
+               	movslq	%r12d, %r13
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %edx
+               	movq	%rdi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+<L46>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/bits/shift_i64.dis
+++ b/test/golden/x86_64-windows/bits/shift_i64.dis
@@ -5,235 +5,485 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdx
                	movq	$-0x1, %rsi
                	xorq	%rbx, %rsi
                	movabsq	$-0x5555555555555556, %rdi # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %rdi
                	movabsq	$0x5555555555555555, %r12 # imm = 0x5555555555555555
                	xorq	%rbx, %r12
-               	movq	%rdx, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x3f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %rcx
                	movq	%rsi, %rdx
-               	callq	 <L4>
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+<L3>:
+               	movq	%rsi, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	sarq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L5>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	sarq	$0x3f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L7>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	sarq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
+               	movq	%rsi, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	sarq	$0x3f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L9>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdx
-               	movq	%r12, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L10>
+               	movq	%rsi, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdx
-               	movq	%r12, %r13
-               	sarq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L11>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdx
-               	movq	%rbx, %r13
-               	shlq	$0x5, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L12>
+               	movq	%rdi, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdx
-               	movq	%rbx, %r13
-               	sarq	$0x5, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L13>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L14>
+               	movq	%rdi, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	sarq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L15>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x41, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L16>
+               	movq	%rdi, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	sarq	$0x41, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L17>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L18>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	sarq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L19>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shlq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
+               	movq	%r12, %rdx
+               	sarq	%rdx
+               	movq	%rax, %rcx
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	sarq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
+               	movq	%rbx, %rdx
+               	shlq	$0x5, %rdx
+               	movq	%rax, %rcx
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x40, %r14
-               	jb	 <L22>
-               	jmp	 <L27>
+               	movq	%rbx, %rdx
+               	sarq	$0x5, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L22>
 <L22>:
-               	movq	%r14, %rcx
                	movq	%rsi, %rdx
-               	shlq	%cl, %rdx
-               	movq	%r13, %rcx
+               	shlq	$0x40, %rdx
+               	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movq	%r14, %rcx
                	movq	%rsi, %rdx
-               	sarq	%cl, %rdx
+               	sarq	$0x40, %rdx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movq	%r14, %r15
-               	addq	%rbx, %r15
-               	movq	%r15, %rcx
-               	movq	%rdi, %rdx
-               	shlq	%cl, %rdx
+               	movq	%rsi, %rdx
+               	shlq	$0x41, %rdx
                	movq	%rax, %rcx
                	callq	 <L25>
 <L25>:
-               	movq	%r15, %rcx
-               	movq	%r12, %rdx
-               	sarq	%cl, %rdx
+               	movq	%rsi, %rdx
+               	sarq	$0x41, %rdx
                	movq	%rax, %rcx
                	callq	 <L26>
 <L26>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x40, %r14
-               	jb	 <L22>
-<L27>:
-               	movq	$0x3c, %rdi
-               	cmpq	$0x48, %rdi
-               	jb	 <L28>
-               	jmp	 <L31>
-<L28>:
-               	movq	%rdi, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rcx
                	movq	%rsi, %rdx
-               	shlq	%cl, %rdx
-               	movq	%r13, %rcx
+               	shlq	$0x7f, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movq	%rsi, %rdx
+               	sarq	$0x7f, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
+               	movq	%rdi, %rdx
+               	shlq	$0x40, %rdx
+               	movq	%rax, %rcx
                	callq	 <L29>
 <L29>:
-               	movq	%r12, %rcx
-               	movq	%rsi, %rdx
-               	sarq	%cl, %rdx
+               	movq	%rdi, %rdx
+               	sarq	$0x7f, %rdx
                	movq	%rax, %rcx
                	callq	 <L30>
 <L30>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %r13
-               	cmpq	$0x48, %rdi
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rsi, %r13
+               	shlq	%cl, %r13
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
                	movq	%r13, %rax
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r14, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rsi, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r12, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r14, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movq	%rdx, %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shlq	%cl, %rdi
+               	movq	%rax, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movq	%rdx, %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	sarq	%cl, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+<L45>:
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+<L46>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/bits/shift_u32.dis
+++ b/test/golden/x86_64-windows/bits/shift_u32.dis
@@ -5,231 +5,498 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %esi
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%esi, %ebx
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %ebx
+               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	xorl	%ebx, %esi
                	movl	$0xaaaaaaaa, %edi       # imm = 0xAAAAAAAA
-               	xorl	%esi, %edi
+               	xorl	%ebx, %edi
                	movl	$0x55555555, %r12d      # imm = 0x55555555
-               	xorl	%esi, %r12d
-               	movq	%rdx, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L1>
+               	xorl	%ebx, %r12d
+               	movl	%esi, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	shll	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x1f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L3>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L4>
+               	movl	%esi, %eax
+               	shll	$0x1f, %eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shrl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L5>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shrl	$0x1f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L6>
+               	movl	%esi, %eax
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L7>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shrl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L8>
+               	movl	%esi, %eax
+               	shrl	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdx
-               	movl	%r12d, %r13d
-               	shll	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L9>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdx
-               	movl	%r12d, %r13d
-               	shrl	%r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L10>
+               	movl	%esi, %eax
+               	shrl	$0x1f, %eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdx
-               	movl	%esi, %r13d
-               	shll	$0x5, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L11>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdx
-               	movl	%esi, %r13d
-               	shrl	$0x5, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L12>
+               	movl	%edi, %eax
+               	shll	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x20, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L13>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shrl	$0x20, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L14>
+               	movl	%edi, %eax
+               	shrl	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x21, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L15>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shrl	$0x21, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L16>
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shll	$0x3f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L17>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdx
-               	movl	%ebx, %r13d
-               	shrl	$0x3f, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L18>
+               	movl	%r12d, %eax
+               	shrl	%eax
+               	movl	%eax, %r13d
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shll	$0x20, %r13d
-               	movq	%rdx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L19>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdx
-               	movl	%edi, %r13d
-               	shrl	$0x3f, %r13d
+               	movl	%ebx, %eax
+               	shll	$0x5, %eax
                	movq	%rdx, %rcx
-               	movl	%r13d, %edx
+               	movl	%eax, %edx
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
-               	jb	 <L21>
-               	jmp	 <L26>
+               	movl	%ebx, %edx
+               	shrl	$0x5, %edx
+               	movq	%rax, %rcx
+               	callq	 <L21>
 <L21>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r13, %rcx
-               	movl	%eax, %edx
+               	movl	%esi, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rcx
                	callq	 <L22>
 <L22>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
+               	movl	%esi, %edx
+               	shrl	$0x20, %edx
                	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movl	%r14d, %r15d
-               	addl	%esi, %r15d
-               	movl	%r15d, %ecx
-               	movl	%edi, %edx
-               	shll	%cl, %edx
+               	movl	%esi, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movl	%r15d, %ecx
-               	movl	%r12d, %edx
-               	shrl	%cl, %edx
+               	movl	%esi, %edx
+               	shrl	$0x21, %edx
                	movq	%rax, %rcx
                	callq	 <L25>
 <L25>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %r13
-               	cmpl	$0x20, %r14d
-               	jb	 <L21>
+               	movl	%esi, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rcx
+               	callq	 <L26>
 <L26>:
-               	movl	$0x1e, %edi
-               	cmpl	$0x28, %edi
-               	jb	 <L27>
-               	jmp	 <L30>
+               	movl	%esi, %edx
+               	shrl	$0x3f, %edx
+               	movq	%rax, %rcx
+               	callq	 <L27>
 <L27>:
-               	movl	%edi, %r12d
-               	addl	%esi, %r12d
-               	movl	%r12d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r13, %rcx
-               	movl	%eax, %edx
+               	movl	%edi, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rcx
                	callq	 <L28>
 <L28>:
-               	movl	%r12d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
+               	movl	%edi, %edx
+               	shrl	$0x3f, %edx
                	movq	%rax, %rcx
                	callq	 <L29>
 <L29>:
-               	addl	$0x1, %edi
-               	movq	%rax, %r13
-               	cmpl	$0x28, %edi
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
-               	movq	%r13, %rax
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%esi, %r13d
+               	shll	%cl, %r13d
+               	movl	%r13d, %r14d
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r13, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%esi, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%edi, %eax
+               	shll	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r12d, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%r13, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%esi, %edi
+               	shll	%cl, %edi
+               	movl	%edi, %r12d
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movl	%r12d, %ecx
+               	movl	%esi, %r12d
+               	shrl	%cl, %r12d
+               	movl	%r12d, %r13d
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L43>
+<L44>:
+               	addl	$0x1, %edx
+               	movq	%rdi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+<L45>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/bits/shift_u64.dis
+++ b/test/golden/x86_64-windows/bits/shift_u64.dis
@@ -5,228 +5,480 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdx
                	movq	$-0x1, %rsi
                	xorq	%rbx, %rsi
                	movabsq	$-0x5555555555555556, %rdi # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %rdi
                	movabsq	$0x5555555555555555, %r12 # imm = 0x5555555555555555
                	xorq	%rbx, %r12
-               	movq	%rdx, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x3f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %rcx
                	movq	%rsi, %rdx
-               	callq	 <L4>
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+<L3>:
+               	movq	%rsi, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shrq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L5>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shrq	$0x3f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L7>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shrq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
+               	movq	%rsi, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdx
-               	movq	%r12, %r13
-               	shlq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L9>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdx
-               	movq	%r12, %r13
-               	shrq	%r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L10>
+               	movq	%rsi, %rdx
+               	shrq	$0x3f, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdx
-               	movq	%rbx, %r13
-               	shlq	$0x5, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L11>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdx
-               	movq	%rbx, %r13
-               	shrq	$0x5, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L12>
+               	movq	%rdi, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L13>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shrq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L14>
+               	movq	%rdi, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x41, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L15>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shrq	$0x41, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L16>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shlq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L17>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdx
-               	movq	%rsi, %r13
-               	shrq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L18>
+               	movq	%r12, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shlq	$0x40, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L19>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %r13
-               	shrq	$0x7f, %r13
-               	movq	%rdx, %rcx
-               	movq	%r13, %rdx
+               	movq	%rbx, %rdx
+               	shlq	$0x5, %rdx
+               	movq	%rax, %rcx
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x40, %r14
-               	jb	 <L21>
-               	jmp	 <L26>
+               	movq	%rbx, %rdx
+               	shrq	$0x5, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L21>
 <L21>:
-               	movq	%r14, %rcx
                	movq	%rsi, %rdx
-               	shlq	%cl, %rdx
-               	movq	%r13, %rcx
+               	shlq	$0x40, %rdx
+               	movq	%rax, %rcx
                	callq	 <L22>
 <L22>:
-               	movq	%r14, %rcx
                	movq	%rsi, %rdx
-               	shrq	%cl, %rdx
+               	shrq	$0x40, %rdx
                	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movq	%r14, %r15
-               	addq	%rbx, %r15
-               	movq	%r15, %rcx
-               	movq	%rdi, %rdx
-               	shlq	%cl, %rdx
+               	movq	%rsi, %rdx
+               	shlq	$0x41, %rdx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movq	%r15, %rcx
-               	movq	%r12, %rdx
-               	shrq	%cl, %rdx
+               	movq	%rsi, %rdx
+               	shrq	$0x41, %rdx
                	movq	%rax, %rcx
                	callq	 <L25>
 <L25>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x40, %r14
-               	jb	 <L21>
-<L26>:
-               	movq	$0x3c, %rdi
-               	cmpq	$0x48, %rdi
-               	jb	 <L27>
-               	jmp	 <L30>
-<L27>:
-               	movq	%rdi, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rcx
                	movq	%rsi, %rdx
-               	shlq	%cl, %rdx
-               	movq	%r13, %rcx
+               	shlq	$0x7f, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L26>
+<L26>:
+               	movq	%rsi, %rdx
+               	shrq	$0x7f, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movq	%rdi, %rdx
+               	shlq	$0x40, %rdx
+               	movq	%rax, %rcx
                	callq	 <L28>
 <L28>:
-               	movq	%r12, %rcx
-               	movq	%rsi, %rdx
-               	shrq	%cl, %rdx
+               	movq	%rdi, %rdx
+               	shrq	$0x7f, %rdx
                	movq	%rax, %rcx
                	callq	 <L29>
 <L29>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %r13
-               	cmpq	$0x48, %rdi
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rsi, %r13
+               	shlq	%cl, %r13
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
                	movq	%r13, %rax
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r14, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rsi, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r12, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r14, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movq	%rdx, %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shlq	%cl, %rdi
+               	movq	%rax, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movq	%rdx, %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+<L44>:
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+<L45>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_chain.dis
+++ b/test/golden/x86_64-windows/call/call_chain.dis
@@ -78,6 +78,387 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.burn>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x100, %rsp            # imm = 0x100
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movq	%r13, -0xb8(%rbp)
+               	movq	%r14, -0xc0(%rbp)
+               	movq	%r15, -0xc8(%rbp)
+               	movaps	%xmm6, -0xe0(%rbp)
+               	movaps	%xmm14, -0xf0(%rbp)
+               	movaps	%xmm15, -0x100(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rax, %r8
+               	xorq	$0x1, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rax, %rbx
+               	imulq	$0x3, %rbx, %rbx
+               	movq	%rbx, %r8
+               	addq	$0x2, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	%rax, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	%rsi, %r8
+               	addq	$0x3, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	%rax, %r12
+               	imulq	$0x5, %r12, %r12
+               	addq	$0x4, %r12
+               	movq	%rax, %r13
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %r13
+               	movq	%rax, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	$0x6, %r14
+               	movq	%rsi, %r15
+               	imulq	$0x9, %r15, %r15
+               	movq	%rax, %r8
+               	addq	$0x12345678, %r8        # imm = 0x12345678
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %rdx
+               	imulq	$0xb, %rdx, %rdx
+               	addq	$0xa, %rdx
+               	movq	%rax, %r8
+               	xorq	$0x55555555, %r8        # imm = 0x55555555
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rax, %rbx
+               	imulq	$0xd, %rbx, %rbx
+               	addq	$0xc, %rbx
+               	xorq	%rax, %rsi
+               	movq	%rax, %rdi
+               	andq	$0x3ff, %rdi            # imm = 0x3FF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L1>
+<L0>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L1>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0x129>
+               	movq	%rax, %rdi
+               	shrq	$0x5, %rdi
+               	andq	$0x3ff, %rdi            # imm = 0x3FF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L2>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L3>
+<L2>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L3>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x16f>
+               	movq	%rax, %rdi
+               	shrq	$0xb, %rdi
+               	andq	$0x3ff, %rdi            # imm = 0x3FF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L4>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L5>
+<L4>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L5>:
+               	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x1b5>
+               	movq	%rax, %rdi
+               	shrq	$0x11, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L6>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L7>
+<L6>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L7>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x1fb>
+               	movq	%rax, %rdi
+               	shrq	$0x17, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L8>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L9>
+<L8>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L9>:
+               	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
+               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x241>
+               	shrq	$0x1d, %rax
+               	andq	$0xff, %rax
+               	movq	%rax, %r11
+               	testq	%r11, %r11
+               	jl	 <L10>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L11>
+<L10>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L11>:
+               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x284>
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x28(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x18(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%rdi, %r15
+               	movq	-0x30(%rbp), %r8
+               	xorq	%r8, %rdi
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%r12, %rdx
+               	xorq	%r13, %r12
+               	addq	%r14, %r13
+               	movq	-0x50(%rbp), %r8
+               	xorq	%r8, %r14
+               	movq	-0x50(%rbp), %r8
+               	movq	-0x38(%rbp), %r9
+               	movq	%r8, %rbx
+               	addq	%r9, %rbx
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x58(%rbp), %r9
+               	movq	%r8, %rsi
+               	xorq	%r9, %rsi
+               	movq	-0x58(%rbp), %r9
+               	movq	-0x40(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x70(%rbp)
+               	movq	-0x40(%rbp), %r9
+               	movq	-0x60(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x78(%rbp)
+               	movq	-0x60(%rbp), %r9
+               	movq	-0x68(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x88(%rbp)
+               	addsd	%xmm2, %xmm1
+               	subsd	%xmm3, %xmm2
+               	addsd	%xmm1, %xmm3
+               	addss	%xmm5, %xmm4
+               	subss	%xmm6, %xmm5
+               	addss	%xmm4, %xmm6
+               	addq	$0x1, %rax
+               	movq	%r15, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x70(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x78(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x80(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	-0x88(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x68(%rbp)
+               	cmpq	$0x6, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movq	-0x30(%rbp), %r8
+               	xorq	%r8, %rax
+               	xorq	%r12, %rax
+               	xorq	%r13, %rax
+               	xorq	%r14, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x50(%rbp), %r8
+               	movq	-0x38(%rbp), %r9
+               	movq	%r8, %rax
+               	xorq	%r9, %rax
+               	movq	-0x58(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	-0x40(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	-0x60(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	-0x68(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	%xmm2, %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	addsd	%xmm3, %xmm1
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
+               	addss	%xmm5, %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	addss	%xmm6, %xmm1
+               	movd	%xmm1, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%rdx, %rax
+               	movaps	-0xe0(%rbp), %xmm6
+               	movaps	-0xf0(%rbp), %xmm14
+               	movaps	-0x100(%rbp), %xmm15
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
+               	movq	-0xb8(%rbp), %r13
+               	movq	-0xc0(%rbp), %r14
+               	movq	-0xc8(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_chain.chain>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
                	subq	$0x150, %rsp            # imm = 0x150
                	movq	%rbx, -0x78(%rbp)
                	movq	%rdi, -0x80(%rbp)
@@ -94,311 +475,6 @@ Disassembly of section .text:
                	movaps	%xmm11, -0x110(%rbp)
                	movaps	%xmm14, -0x120(%rbp)
                	movaps	%xmm15, -0x130(%rbp)
-               	movq	%rcx, %r8
-               	xorq	$0x1, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rcx, %rdx
-               	imulq	$0x3, %rdx, %rdx
-               	movq	%rdx, %r8
-               	addq	$0x2, %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	%rcx, %rbx
-               	xorq	$-0x1, %rbx
-               	movq	%rbx, %r8
-               	addq	$0x3, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0x5, %rdi, %rdi
-               	addq	$0x4, %rdi
-               	movq	%rcx, %r12
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %r12
-               	movq	%rcx, %r13
-               	imulq	$0x7, %r13, %r13
-               	addq	$0x6, %r13
-               	movq	%rbx, %r14
-               	imulq	$0x9, %r14, %r14
-               	movq	%rcx, %r15
-               	addq	$0x12345678, %r15       # imm = 0x12345678
-               	movq	%rcx, %rax
-               	imulq	$0xb, %rax, %rax
-               	addq	$0xa, %rax
-               	movq	%rcx, %r8
-               	xorq	$0x55555555, %r8        # imm = 0x55555555
-               	movq	%r8, -0x10(%rbp)
-               	movq	%rcx, %rdx
-               	imulq	$0xd, %rdx, %rdx
-               	addq	$0xc, %rdx
-               	xorq	%rcx, %rbx
-               	movq	%rcx, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L0>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L1>
-<L0>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L1>:
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0x143>
-               	movq	%rcx, %rsi
-               	shrq	$0x5, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L2>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L3>
-<L2>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L3>:
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x189>
-               	movq	%rcx, %rsi
-               	shrq	$0xb, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L4>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L5>
-<L4>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L5>:
-               	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x1cf>
-               	movq	%rcx, %rsi
-               	shrq	$0x11, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L6>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L7>
-<L6>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L7>:
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x215>
-               	movq	%rcx, %rsi
-               	shrq	$0x17, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L8>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L9>:
-               	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x25b>
-               	shrq	$0x1d, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L10>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L11>
-<L10>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L11>:
-               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x29e>
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	-0x18(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x20(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	-0x10(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movsd	%xmm1, %xmm7            # xmm7 = xmm1[0],xmm7[1]
-               	movsd	%xmm2, %xmm8            # xmm8 = xmm2[0],xmm8[1]
-               	movsd	%xmm3, %xmm9            # xmm9 = xmm3[0],xmm9[1]
-               	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
-               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
-               	movq	$0x0, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L12>
-               	jmp	 <L13>
-<L12>:
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	-0x60(%rbp), %r8
-               	movq	-0x28(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%rdi, %rdx
-               	xorq	%r12, %rdi
-               	addq	%r13, %r12
-               	xorq	%r14, %r13
-               	addq	%r15, %r14
-               	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r15
-               	movq	-0x30(%rbp), %r9
-               	movq	-0x68(%rbp), %r10
-               	movq	%r9, %r8
-               	addq	%r10, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	movq	-0x38(%rbp), %r9
-               	movq	%r8, %rax
-               	xorq	%r9, %rax
-               	movq	-0x38(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x50(%rbp)
-               	xorq	%rsi, %rbx
-               	addsd	%xmm8, %xmm7
-               	subsd	%xmm9, %xmm8
-               	addsd	%xmm7, %xmm9
-               	addss	%xmm11, %xmm10
-               	subss	%xmm6, %xmm11
-               	addss	%xmm10, %xmm6
-               	movq	-0x40(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x48(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	-0x58(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L12>
-<L13>:
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdx
-               	movq	-0x60(%rbp), %r8
-               	xorq	%r8, %rsi
-               	movq	-0x28(%rbp), %r8
-               	xorq	%r8, %rsi
-               	xorq	%rdi, %rsi
-               	xorq	%r12, %rsi
-               	xorq	%r13, %rsi
-               	movq	%rdx, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	xorq	%r15, %r14
-               	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x68(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x38(%rbp), %r8
-               	xorq	%r8, %r14
-               	xorq	%rbx, %r14
-               	movq	%r14, %rdx
-               	callq	 <L16>
-<L16>:
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	addsd	%xmm8, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	addsd	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
-               	addss	%xmm11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	movaps	-0xc0(%rbp), %xmm6
-               	movaps	-0xd0(%rbp), %xmm7
-               	movaps	-0xe0(%rbp), %xmm8
-               	movaps	-0xf0(%rbp), %xmm9
-               	movaps	-0x100(%rbp), %xmm10
-               	movaps	-0x110(%rbp), %xmm11
-               	movaps	-0x120(%rbp), %xmm14
-               	movaps	-0x130(%rbp), %xmm15
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %rdi
-               	movq	-0x88(%rbp), %rsi
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_chain.chain>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
-               	movq	%rbx, -0x58(%rbp)
-               	movq	%rdi, -0x60(%rbp)
-               	movq	%rsi, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movaps	%xmm6, -0xa0(%rbp)
-               	movaps	%xmm7, -0xb0(%rbp)
-               	movaps	%xmm8, -0xc0(%rbp)
-               	movaps	%xmm9, -0xd0(%rbp)
-               	movaps	%xmm10, -0xe0(%rbp)
-               	movaps	%xmm11, -0xf0(%rbp)
-               	movaps	%xmm14, -0x100(%rbp)
-               	movaps	%xmm15, -0x110(%rbp)
                	movq	%rcx, %rbx
                	movq	%rdx, %rsi
                	movq	%r8, %rdi
@@ -418,39 +494,40 @@ Disassembly of section .text:
                	movq	%rsi, %r8
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	addq	%r11, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	%rsi, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%r8, -0x70(%rbp)
+               	movq	%rsi, %rdx
+               	imulq	$0x7, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	$0x3, %r8
                	movq	%r8, -0x8(%rbp)
-               	movq	%rsi, %r12
-               	xorq	$0x55555555, %r12       # imm = 0x55555555
-               	movq	%rsi, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%rsi, %r8
+               	xorq	$0x55555555, %r8        # imm = 0x55555555
+               	movq	%r8, -0x68(%rbp)
+               	movq	%rsi, %rdx
+               	imulq	$0x9, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	%rbx, %r8
                	movq	%r8, -0x18(%rbp)
                	movq	%r14, %r8
                	addq	$0xb, %r8
                	movq	%r8, -0x20(%rbp)
-               	movq	%rsi, %rcx
-               	imulq	$0xd, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%rsi, %rdx
+               	imulq	$0xd, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	$0x5, %r8
                	movq	%r8, -0x28(%rbp)
                	movq	%rsi, %r8
                	xorq	%rbx, %r8
                	movq	%r8, -0x30(%rbp)
-               	movq	%rsi, %rcx
-               	imulq	$0x11, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%rsi, %rdx
+               	imulq	$0x11, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	$0x7, %r8
                	movq	%r8, -0x38(%rbp)
-               	movq	%rsi, %rcx
-               	shrq	%rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
+               	movq	%rsi, %rdx
+               	shrq	%rdx
+               	andq	$0x3ff, %rdx            # imm = 0x3FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
@@ -464,11 +541,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L1>:
                	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_chain.chain+0x160>
-               	movq	%rsi, %rcx
-               	shrq	$0x9, %rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
+               	divsd	, %xmm6 <corpus.cases.call.call_chain.chain+0x170>
+               	movq	%rsi, %rdx
+               	shrq	$0x9, %rdx
+               	andq	$0x3ff, %rdx            # imm = 0x3FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L2>
                	cvtsi2sd	%r11, %xmm0
@@ -482,11 +559,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L3>:
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_chain.chain+0x1a6>
-               	movq	%rsi, %rcx
-               	shrq	$0x13, %rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
+               	divsd	, %xmm7 <corpus.cases.call.call_chain.chain+0x1b6>
+               	movq	%rsi, %rdx
+               	shrq	$0x13, %rdx
+               	andq	$0x3ff, %rdx            # imm = 0x3FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L4>
                	cvtsi2sd	%r11, %xmm0
@@ -500,11 +577,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L5>:
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_chain.chain+0x1ee>
-               	movq	%rsi, %rcx
-               	shrq	$0x3, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divsd	, %xmm8 <corpus.cases.call.call_chain.chain+0x1fe>
+               	movq	%rsi, %rdx
+               	shrq	$0x3, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
@@ -518,11 +595,11 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_chain.chain+0x236>
-               	movq	%rsi, %rcx
-               	shrq	$0xd, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divss	, %xmm9 <corpus.cases.call.call_chain.chain+0x246>
+               	movq	%rsi, %rdx
+               	shrq	$0xd, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
@@ -536,11 +613,11 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
-               	divss	, %xmm10 <corpus.cases.call.call_chain.chain+0x27e>
-               	movq	%rsi, %rcx
-               	shrq	$0x19, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divss	, %xmm10 <corpus.cases.call.call_chain.chain+0x28e>
+               	movq	%rsi, %rdx
+               	shrq	$0x19, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L10>
                	cvtsi2ss	%r11, %xmm0
@@ -554,154 +631,374 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_chain.chain+0x2c6>
+               	divss	, %xmm11 <corpus.cases.call.call_chain.chain+0x2d6>
                	movq	$0x0, %r11
                	cmpq	%rbx, %r11
-               	jb	 <L14>
+               	jb	 <L15>
                	movq	%rsi, %rcx
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x40(%rbp)
-               	jmp	 <L16>
-<L14>:
-               	movq	%rbx, %rcx
-               	subq	$0x1, %rcx
-               	imulq	$0x3, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x48(%rbp), %r8
                	movq	%rdi, %r8
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r8
                	movq	%r8, -0x40(%rbp)
-<L16>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x10(%rbp), %r8
+               	movq	$0x0, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L21>
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x40(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x50(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x60(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L13>
+<L14>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %r12
+               	jmp	 <L17>
+<L15>:
+               	movq	%rbx, %rdx
+               	subq	$0x1, %rdx
+               	imulq	$0x3, %rsi, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	movq	%rdi, %r8
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r12
+<L17>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r13, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rcx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r14, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r15, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x18(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x20(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x30(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	%r12, %rcx
                	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L28>
-<L28>:
+               	callq	 <L40>
+<L40>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L29>
-<L29>:
+               	callq	 <L41>
+<L41>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L30>
-<L30>:
+               	callq	 <L42>
+<L42>:
+               	movq	%xmm8, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L43>
+<L43>:
+               	movd	%xmm9, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
+               	movq	%rbx, %rdx
+               	callq	 <L44>
+<L44>:
+               	movd	%xmm10, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
+               	movq	%rbx, %rdx
+               	callq	 <L45>
+<L45>:
+               	movd	%xmm11, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
+               	movq	%rbx, %rdx
+               	callq	 <L46>
+<L46>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
                	addsd	%xmm7, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	subsd	%xmm8, %xmm1
+               	movq	%xmm1, %rdx
                	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
+               	callq	 <L47>
+<L47>:
                	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
                	addss	%xmm10, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	subss	%xmm11, %xmm1
+               	movd	%xmm1, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
+               	movq	%rbx, %rdx
+               	callq	 <L48>
+<L48>:
                	movq	-0x10(%rbp), %r8
                	movq	-0x8(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
+               	movq	%r8, %rdx
+               	xorq	%r9, %rdx
                	movq	-0x38(%rbp), %r8
-               	movq	%rcx, %rdx
                	xorq	%r8, %rdx
                	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	movaps	-0xa0(%rbp), %xmm6
-               	movaps	-0xb0(%rbp), %xmm7
-               	movaps	-0xc0(%rbp), %xmm8
-               	movaps	-0xd0(%rbp), %xmm9
-               	movaps	-0xe0(%rbp), %xmm10
-               	movaps	-0xf0(%rbp), %xmm11
-               	movaps	-0x100(%rbp), %xmm14
-               	movaps	-0x110(%rbp), %xmm15
-               	movq	-0x58(%rbp), %rbx
-               	movq	-0x60(%rbp), %rdi
-               	movq	-0x68(%rbp), %rsi
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	callq	 <L49>
+<L49>:
+               	movaps	-0xc0(%rbp), %xmm6
+               	movaps	-0xd0(%rbp), %xmm7
+               	movaps	-0xe0(%rbp), %xmm8
+               	movaps	-0xf0(%rbp), %xmm9
+               	movaps	-0x100(%rbp), %xmm10
+               	movaps	-0x110(%rbp), %xmm11
+               	movaps	-0x120(%rbp), %xmm14
+               	movaps	-0x130(%rbp), %xmm15
+               	movq	-0x78(%rbp), %rbx
+               	movq	-0x80(%rbp), %rdi
+               	movq	-0x88(%rbp), %rsi
+               	movq	-0x90(%rbp), %r12
+               	movq	-0x98(%rbp), %r13
+               	movq	-0xa0(%rbp), %r14
+               	movq	-0xa8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -780,12 +1077,13 @@ Disassembly of section .text:
                	movq	%r12, %rdx
                	callq	 <L8>
 <L8>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L9>
 <L9>:
+               	movd	%xmm7, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	callq	 <L10>
 <L10>:
                	movaps	-0x30(%rbp), %xmm6
@@ -956,12 +1254,13 @@ Disassembly of section .text:
                	movq	%r8, %rdx
                	callq	 <L14>
 <L14>:
+               	movq	%xmm9, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	callq	 <L15>
 <L15>:
+               	movd	%xmm10, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
@@ -984,16 +1283,17 @@ Disassembly of section .text:
                	movq	%r14, %rdx
                	callq	 <L21>
 <L21>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L22>
 <L22>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L23>
 <L23>:
+               	movd	%xmm8, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	callq	 <L24>
 <L24>:
                	xorq	%r14, %rsi
@@ -1298,11 +1598,13 @@ Disassembly of section .text:
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rcx
-               	movsd	-0x58(%rbp), %xmm1
+               	movq	-0x58(%rbp), %rdx
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rcx
-               	movss	-0x68(%rbp), %xmm1
+               	movl	-0x68(%rbp), %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rcx
@@ -1331,15 +1633,17 @@ Disassembly of section .text:
                	callq	 <L31>
 <L31>:
                	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
+               	movq	%xmm11, %rdx
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
+               	movq	%xmm12, %rdx
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
+               	movd	%xmm13, %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rcx
@@ -1379,23 +1683,27 @@ Disassembly of section .text:
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
+               	movq	%xmm6, %rdx
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	movq	%xmm7, %rdx
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	movq	%xmm8, %rdx
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movd	%xmm9, %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
+               	movd	%xmm10, %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rcx
@@ -1817,11 +2125,13 @@ Disassembly of section .text:
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rcx
-               	movsd	-0xf0(%rbp), %xmm1
+               	movq	-0xf0(%rbp), %rdx
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rcx
-               	movss	-0x98(%rbp), %xmm1
+               	movl	-0x98(%rbp), %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rcx
@@ -1850,15 +2160,17 @@ Disassembly of section .text:
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rcx
-               	movsd	-0xc0(%rbp), %xmm1
+               	movq	-0xc0(%rbp), %rdx
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rcx
-               	movsd	-0xd0(%rbp), %xmm1
+               	movq	-0xd0(%rbp), %rdx
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rcx
-               	movss	-0xe0(%rbp), %xmm1
+               	movl	-0xe0(%rbp), %edx
+               	movl	%edx, %ebx
+               	movq	%rbx, %rdx
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rcx
@@ -1903,24 +2215,26 @@ Disassembly of section .text:
                	movq	%r8, %rdx
                	callq	 <L50>
 <L50>:
+               	movq	%xmm10, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	callq	 <L51>
 <L51>:
+               	movq	%xmm11, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	callq	 <L52>
 <L52>:
+               	movq	%xmm12, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	callq	 <L53>
 <L53>:
+               	movd	%xmm13, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
                	callq	 <L54>
 <L54>:
+               	movl	-0xb0(%rbp), %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	-0xb0(%rbp), %xmm1
                	callq	 <L55>
 <L55>:
                	movq	-0x20(%rbp), %r8
@@ -1972,20 +2286,22 @@ Disassembly of section .text:
                	movq	%r8, %rdx
                	callq	 <L65>
 <L65>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L66>
 <L66>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L67>
 <L67>:
+               	movd	%xmm8, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	callq	 <L68>
 <L68>:
+               	movd	%xmm9, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	callq	 <L69>
 <L69>:
                	xorq	%r14, %rsi
@@ -2019,27 +2335,25 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x240, %rsp            # imm = 0x240
-               	movq	%rbx, -0x148(%rbp)
-               	movq	%rdi, -0x150(%rbp)
-               	movq	%rsi, -0x158(%rbp)
-               	movq	%r12, -0x160(%rbp)
-               	movq	%r13, -0x168(%rbp)
-               	movq	%r14, -0x170(%rbp)
-               	movq	%r15, -0x178(%rbp)
-               	movaps	%xmm6, -0x190(%rbp)
-               	movaps	%xmm7, -0x1a0(%rbp)
-               	movaps	%xmm8, -0x1b0(%rbp)
-               	movaps	%xmm9, -0x1c0(%rbp)
-               	movaps	%xmm10, -0x1d0(%rbp)
-               	movaps	%xmm11, -0x1e0(%rbp)
-               	movaps	%xmm12, -0x1f0(%rbp)
-               	movaps	%xmm13, -0x200(%rbp)
-               	movaps	%xmm14, -0x210(%rbp)
-               	movaps	%xmm15, -0x220(%rbp)
+               	subq	$0x250, %rsp            # imm = 0x250
+               	movq	%rbx, -0x158(%rbp)
+               	movq	%rdi, -0x160(%rbp)
+               	movq	%rsi, -0x168(%rbp)
+               	movq	%r12, -0x170(%rbp)
+               	movq	%r13, -0x178(%rbp)
+               	movq	%r14, -0x180(%rbp)
+               	movq	%r15, -0x188(%rbp)
+               	movaps	%xmm6, -0x1a0(%rbp)
+               	movaps	%xmm7, -0x1b0(%rbp)
+               	movaps	%xmm8, -0x1c0(%rbp)
+               	movaps	%xmm9, -0x1d0(%rbp)
+               	movaps	%xmm10, -0x1e0(%rbp)
+               	movaps	%xmm11, -0x1f0(%rbp)
+               	movaps	%xmm12, -0x200(%rbp)
+               	movaps	%xmm13, -0x210(%rbp)
+               	movaps	%xmm14, -0x220(%rbp)
+               	movaps	%xmm15, -0x230(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0x30(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
@@ -2047,45 +2361,44 @@ Disassembly of section .text:
                	movq	$0x0, 0x18(%rsi)
                	movq	$0x0, 0x20(%rsi)
                	movq	$0x0, 0x28(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
                	movq	$0x10, %rcx
                	addq	%rbx, %rcx
-               	leaq	(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	movq	%rdi, %rdx
-               	movq	%rax, %r8
-               	callq	 <L3>
-<L3>:
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	movq	$0x1, %rcx
                	addq	%rbx, %rcx
                	leaq	0x8(%rsi), %rdx
                	movq	(%rdx), %rdi
                	movq	%rdi, %rdx
                	movq	%rax, %r8
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	cmpq	$0x4, %r12
-               	jb	 <L5>
-               	jmp	 <L77>
-<L5>:
+               	jb	 <L4>
+               	jmp	 <L76>
+<L4>:
                	leaq	(%rsi,%r12,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
@@ -2125,73 +2438,73 @@ Disassembly of section .text:
                	andq	$0x3ff, %rax            # imm = 0x3FF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L6>
+               	jl	 <L5>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L7>
-<L6>:
+               	jmp	 <L6>
+<L5>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L7>:
+<L6>:
                	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_chain.checksum+0x226>
+               	divsd	, %xmm6 <corpus.cases.call.call_chain.checksum+0x225>
                	movq	%rcx, %rax
                	shrq	$0x12, %rax
                	andq	$0x3ff, %rax            # imm = 0x3FF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L8>
+               	jl	 <L7>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
+               	jmp	 <L8>
+<L7>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L9>:
+<L8>:
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_chain.checksum+0x26c>
+               	divsd	, %xmm7 <corpus.cases.call.call_chain.checksum+0x26b>
                	movq	%rcx, %rax
                	shrq	$0xb, %rax
                	andq	$0xff, %rax
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L10>
+               	jl	 <L9>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L11>
-<L10>:
+               	jmp	 <L10>
+<L9>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L11>:
+<L10>:
                	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.call.call_chain.checksum+0x2b4>
+               	divss	, %xmm8 <corpus.cases.call.call_chain.checksum+0x2b3>
                	movq	%rcx, %rax
                	shrq	$0x13, %rax
                	andq	$0xff, %rax
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L12>
+               	jl	 <L11>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L13>
-<L12>:
+               	jmp	 <L12>
+<L11>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L13>:
+<L12>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_chain.checksum+0x2fc>
+               	divss	, %xmm9 <corpus.cases.call.call_chain.checksum+0x2fb>
                	imulq	$0x3, %rcx, %rcx
                	addq	$0x5, %rcx
                	movq	%rcx, %rax
@@ -2201,7 +2514,7 @@ Disassembly of section .text:
                	movq	%r8, -0x68(%rbp)
                	movq	%rcx, %r8
                	xorq	$0x55555555, %r8        # imm = 0x55555555
-               	movq	%r8, -0xe8(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	movq	%rcx, %rdx
                	xorq	$-0x1, %rdx
                	movq	%rdx, %r8
@@ -2224,92 +2537,92 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L14>
+               	jl	 <L13>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L15>
-<L14>:
+               	jmp	 <L14>
+<L13>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L15>:
+<L14>:
                	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_chain.checksum+0x3b6>
+               	divsd	, %xmm10 <corpus.cases.call.call_chain.checksum+0x3b5>
                	movq	%rcx, %rdx
                	shrq	$0x10, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L16>
+               	jl	 <L15>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L17>
-<L16>:
+               	jmp	 <L16>
+<L15>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L17>:
+<L16>:
                	movsd	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1]
-               	divsd	, %xmm11 <corpus.cases.call.call_chain.checksum+0x3fe>
+               	divsd	, %xmm11 <corpus.cases.call.call_chain.checksum+0x3fd>
                	movq	%rcx, %rdx
                	shrq	$0x1a, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L17>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L18>
+<L17>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
+<L18>:
                	movsd	%xmm0, %xmm12           # xmm12 = xmm0[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_chain.checksum+0x446>
+               	divsd	, %xmm12 <corpus.cases.call.call_chain.checksum+0x445>
                	movq	%rcx, %rdx
                	shrq	$0x9, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L19>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L20>
+<L19>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L21>:
+<L20>:
                	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
-               	divss	, %xmm13 <corpus.cases.call.call_chain.checksum+0x48e>
+               	divss	, %xmm13 <corpus.cases.call.call_chain.checksum+0x48d>
                	movq	%rcx, %rdx
                	shrq	$0x1b, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d6>
-               	movss	%xmm14, -0xf8(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d5>
+               	movss	%xmm14, -0x108(%rbp)
                	addq	$0x1d, %rcx
                	movq	%rcx, %r8
                	xorq	$0xb, %r8
@@ -2336,58 +2649,58 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x588>
-               	movsd	%xmm14, -0x108(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x587>
+               	movsd	%xmm14, -0x118(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0xe, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5d9>
-               	movsd	%xmm14, -0x118(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5d8>
+               	movsd	%xmm14, -0x128(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x15, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x62a>
-               	movss	%xmm14, -0x128(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x629>
+               	movss	%xmm14, -0x138(%rbp)
                	imulq	$0x7, %rcx, %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, %r8
@@ -2405,168 +2718,178 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L31>:
+<L30>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b4>
-               	movsd	%xmm14, -0x138(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b3>
+               	movsd	%xmm14, -0x148(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x7, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L33>:
+<L32>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x705>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x704>
                	movss	%xmm14, -0xe0(%rbp)
                	xorq	$0x3039, %rcx           # imm = 0x3039
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %rdx
                	movq	%rdi, %rcx
+               	callq	 <L34>
+<L34>:
+               	movq	%rax, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rcx
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0xc8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rcx
-               	movq	-0xc8(%rbp), %r8
+               	movq	-0xd0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L37>
 <L37>:
                	movq	%rax, %rcx
-               	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	-0x148(%rbp), %rdx
                	callq	 <L38>
 <L38>:
                	movq	%rax, %rcx
-               	movsd	-0x138(%rbp), %xmm1
+               	movl	-0xe0(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rcx
-               	movss	-0xe0(%rbp), %xmm1
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
+               	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rcx
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rcx
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	-0x118(%rbp), %rdx
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rcx
-               	movsd	-0x108(%rbp), %xmm1
+               	movq	-0x128(%rbp), %rdx
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rcx
-               	movsd	-0x118(%rbp), %xmm1
+               	movl	-0x138(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rcx
-               	movss	-0x128(%rbp), %xmm1
-               	callq	 <L48>
-<L48>:
                	movq	%rax, %rcx
                	movq	-0x98(%rbp), %r8
                	movq	-0xb8(%rbp), %r9
                	movq	%r8, %rdx
                	xorq	%r9, %rdx
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L49>
 <L49>:
                	movq	%rax, %rcx
-               	movq	-0x68(%rbp), %r8
+               	movq	-0xf8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rcx
-               	movq	-0xe8(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rcx
-               	movq	-0x70(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rcx
-               	movq	-0x78(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rcx
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x88(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L55>
 <L55>:
+               	movq	%xmm10, %rdx
                	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L56>
 <L56>:
+               	movq	%xmm11, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	callq	 <L57>
 <L57>:
+               	movq	%xmm12, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	callq	 <L58>
 <L58>:
+               	movd	%xmm13, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	callq	 <L59>
 <L59>:
+               	movl	-0x108(%rbp), %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
                	callq	 <L60>
 <L60>:
-               	movq	%rax, %rcx
-               	movss	-0xf8(%rbp), %xmm1
-               	callq	 <L61>
-<L61>:
                	movq	-0x68(%rbp), %r8
                	movq	-0x78(%rbp), %r9
                	movq	%r8, %rcx
@@ -2575,105 +2898,107 @@ Disassembly of section .text:
                	movq	%rcx, %rdx
                	addq	%r8, %rdx
                	movq	%rax, %rcx
+               	callq	 <L61>
+<L61>:
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
                	callq	 <L62>
 <L62>:
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
+               	movq	%r14, %rdx
                	callq	 <L63>
 <L63>:
                	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	%r15, %rdx
                	callq	 <L64>
 <L64>:
                	movq	%rax, %rcx
-               	movq	%r15, %rdx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L65>
 <L65>:
                	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
+               	movq	-0x40(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L66>
 <L66>:
                	movq	%rax, %rcx
-               	movq	-0x40(%rbp), %r8
+               	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L67>
 <L67>:
                	movq	%rax, %rcx
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rcx
-               	movq	-0x50(%rbp), %r8
+               	movq	-0x58(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L69>
 <L69>:
                	movq	%rax, %rcx
-               	movq	-0x58(%rbp), %r8
+               	movq	-0x60(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L70>
 <L70>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L71>
 <L71>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L72>
 <L72>:
+               	movd	%xmm8, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L73>
 <L73>:
+               	movd	%xmm9, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	callq	 <L74>
 <L74>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L75>
-<L75>:
                	movq	-0x40(%rbp), %r8
                	xorq	%r8, %r13
                	movq	-0x60(%rbp), %r8
                	xorq	%r8, %r13
                	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x4, %r12
-               	jb	 <L5>
-<L77>:
+               	jb	 <L4>
+<L76>:
                	leaq	0x28(%rsi), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
-               	callq	 <L78>
-<L78>:
+               	callq	 <L77>
+<L77>:
                	movq	%rdi, %rcx
                	movq	%rax, %rdx
-               	callq	 <L79>
-<L79>:
-               	movaps	-0x190(%rbp), %xmm6
-               	movaps	-0x1a0(%rbp), %xmm7
-               	movaps	-0x1b0(%rbp), %xmm8
-               	movaps	-0x1c0(%rbp), %xmm9
-               	movaps	-0x1d0(%rbp), %xmm10
-               	movaps	-0x1e0(%rbp), %xmm11
-               	movaps	-0x1f0(%rbp), %xmm12
-               	movaps	-0x200(%rbp), %xmm13
-               	movaps	-0x210(%rbp), %xmm14
-               	movaps	-0x220(%rbp), %xmm15
-               	movq	-0x148(%rbp), %rbx
-               	movq	-0x150(%rbp), %rdi
-               	movq	-0x158(%rbp), %rsi
-               	movq	-0x160(%rbp), %r12
-               	movq	-0x168(%rbp), %r13
-               	movq	-0x170(%rbp), %r14
-               	movq	-0x178(%rbp), %r15
+               	callq	 <L78>
+<L78>:
+               	movaps	-0x1a0(%rbp), %xmm6
+               	movaps	-0x1b0(%rbp), %xmm7
+               	movaps	-0x1c0(%rbp), %xmm8
+               	movaps	-0x1d0(%rbp), %xmm9
+               	movaps	-0x1e0(%rbp), %xmm10
+               	movaps	-0x1f0(%rbp), %xmm11
+               	movaps	-0x200(%rbp), %xmm12
+               	movaps	-0x210(%rbp), %xmm13
+               	movaps	-0x220(%rbp), %xmm14
+               	movaps	-0x230(%rbp), %xmm15
+               	movq	-0x158(%rbp), %rbx
+               	movq	-0x160(%rbp), %rdi
+               	movq	-0x168(%rbp), %rsi
+               	movq	-0x170(%rbp), %r12
+               	movq	-0x178(%rbp), %r13
+               	movq	-0x180(%rbp), %r14
+               	movq	-0x188(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_float_regs.dis
+++ b/test/golden/x86_64-windows/call/call_float_regs.dis
@@ -74,155 +74,441 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.takef16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x140, %rsp            # imm = 0x140
-               	movaps	%xmm6, -0x90(%rbp)
-               	movaps	%xmm7, -0xa0(%rbp)
-               	movaps	%xmm8, -0xb0(%rbp)
-               	movaps	%xmm9, -0xc0(%rbp)
-               	movaps	%xmm10, -0xd0(%rbp)
-               	movaps	%xmm11, -0xe0(%rbp)
-               	movaps	%xmm12, -0xf0(%rbp)
-               	movaps	%xmm13, -0x100(%rbp)
-               	movaps	%xmm14, -0x110(%rbp)
-               	movaps	%xmm15, -0x120(%rbp)
-               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	movsd	%xmm1, %xmm7            # xmm7 = xmm1[0],xmm7[1]
-               	movss	%xmm2, %xmm8            # xmm8 = xmm2[0],xmm8[1,2,3]
-               	movsd	%xmm3, %xmm9            # xmm9 = xmm3[0],xmm9[1]
-               	movsd	0x30(%rbp), %xmm10
-               	movsd	0x38(%rbp), %xmm11
-               	movsd	0x40(%rbp), %xmm12
-               	movsd	0x48(%rbp), %xmm13
-               	movq	0x50(%rbp), %r11
-               	movq	%r11, -0x40(%rbp)
-               	movq	0x58(%rbp), %r11
-               	movq	%r11, -0x20(%rbp)
-               	movq	0x60(%rbp), %r11
-               	movq	%r11, -0x50(%rbp)
-               	movq	0x68(%rbp), %r11
-               	movq	%r11, -0x60(%rbp)
+               	subq	$0x130, %rsp            # imm = 0x130
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, -0x60(%rbp)
+               	movq	%rsi, -0x68(%rbp)
+               	movaps	%xmm6, -0x80(%rbp)
+               	movaps	%xmm7, -0x90(%rbp)
+               	movaps	%xmm8, -0xa0(%rbp)
+               	movaps	%xmm9, -0xb0(%rbp)
+               	movaps	%xmm10, -0xc0(%rbp)
+               	movaps	%xmm11, -0xd0(%rbp)
+               	movaps	%xmm12, -0xe0(%rbp)
+               	movaps	%xmm13, -0xf0(%rbp)
+               	movaps	%xmm14, -0x100(%rbp)
+               	movaps	%xmm15, -0x110(%rbp)
+               	movss	%xmm0, -0x30(%rbp)
+               	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
+               	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
+               	movsd	0x30(%rbp), %xmm1
+               	movsd	0x38(%rbp), %xmm8
+               	movsd	0x40(%rbp), %xmm3
+               	movsd	0x48(%rbp), %xmm9
+               	movsd	0x50(%rbp), %xmm10
+               	movsd	0x58(%rbp), %xmm11
+               	movsd	0x60(%rbp), %xmm12
+               	movsd	0x68(%rbp), %xmm13
                	movq	0x70(%rbp), %r11
-               	movq	%r11, -0x70(%rbp)
+               	movq	%r11, -0x40(%rbp)
                	movq	0x78(%rbp), %r11
-               	movq	%r11, -0x10(%rbp)
+               	movq	%r11, -0x50(%rbp)
                	movq	0x80(%rbp), %r11
-               	movq	%r11, -0x80(%rbp)
+               	movq	%r11, -0x10(%rbp)
                	movq	0x88(%rbp), %r11
-               	movq	%r11, -0x30(%rbp)
-               	callq	 <L0>
+               	movq	%r11, -0x20(%rbp)
+               	movl	-0x30(%rbp), %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L2>
+               	movq	%xmm6, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L4>
+               	movd	%xmm2, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
-               	callq	 <L6>
+               	movq	%xmm7, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L7>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movsd	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1]
-               	callq	 <L8>
+               	movd	%xmm1, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movss	-0x40(%rbp), %xmm1
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movsd	-0x20(%rbp), %xmm1
-               	callq	 <L10>
+               	movq	%xmm8, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movss	-0x50(%rbp), %xmm1
-               	callq	 <L11>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movsd	-0x60(%rbp), %xmm1
-               	callq	 <L12>
+               	movd	%xmm3, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movss	-0x70(%rbp), %xmm1
-               	callq	 <L13>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movsd	-0x10(%rbp), %xmm1
-               	callq	 <L14>
+               	movq	%xmm9, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	movss	-0x80(%rbp), %xmm1
-               	callq	 <L15>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rcx
-               	movsd	-0x30(%rbp), %xmm1
-               	callq	 <L16>
+               	movd	%xmm10, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm10, %xmm1
-               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
-               	addss	%xmm1, %xmm8
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	subss	%xmm12, %xmm1
-               	callq	 <L17>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm11, %xmm1
-               	movsd	%xmm7, %xmm6            # xmm6 = xmm7[0],xmm6[1]
-               	addsd	%xmm1, %xmm6
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	subsd	%xmm13, %xmm1
-               	callq	 <L18>
+               	movq	%xmm11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rcx
-               	movss	-0x40(%rbp), %xmm1
-               	subss	-0x50(%rbp), %xmm1
-               	movss	-0x70(%rbp), %xmm0
-               	mulss	-0x80(%rbp), %xmm0
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	callq	 <L19>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
 <L19>:
+               	movd	%xmm12, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	%xmm13, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movl	-0x40(%rbp), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x50(%rbp), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movl	-0x10(%rbp), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movq	-0x20(%rbp), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
+               	mulss	%xmm1, %xmm0
+               	movss	-0x30(%rbp), %xmm1
+               	addss	%xmm0, %xmm1
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	subss	%xmm3, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movsd	-0x20(%rbp), %xmm0
-               	subsd	-0x60(%rbp), %xmm0
-               	movsd	-0x10(%rbp), %xmm1
-               	mulsd	-0x30(%rbp), %xmm1
+               	movq	%rbx, %rdx
+               	callq	 <L32>
+<L32>:
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	mulsd	%xmm8, %xmm0
+               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
+               	addsd	%xmm0, %xmm1
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	subsd	%xmm9, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L33>
+<L33>:
+               	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
+               	subss	%xmm12, %xmm0
+               	movss	-0x40(%rbp), %xmm1
+               	mulss	-0x10(%rbp), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movd	%xmm2, %edx
+               	movl	%edx, %ebx
+               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L34>
+<L34>:
+               	movsd	%xmm11, %xmm0           # xmm0 = xmm11[0],xmm0[1]
+               	subsd	%xmm13, %xmm0
+               	movsd	-0x50(%rbp), %xmm1
+               	mulsd	-0x20(%rbp), %xmm1
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
                	addsd	%xmm1, %xmm2
-               	movsd	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1]
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x90(%rbp), %xmm6
-               	movaps	-0xa0(%rbp), %xmm7
-               	movaps	-0xb0(%rbp), %xmm8
-               	movaps	-0xc0(%rbp), %xmm9
-               	movaps	-0xd0(%rbp), %xmm10
-               	movaps	-0xe0(%rbp), %xmm11
-               	movaps	-0xf0(%rbp), %xmm12
-               	movaps	-0x100(%rbp), %xmm13
-               	movaps	-0x110(%rbp), %xmm14
-               	movaps	-0x120(%rbp), %xmm15
+               	movq	%xmm2, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L35>
+<L35>:
+               	movaps	-0x80(%rbp), %xmm6
+               	movaps	-0x90(%rbp), %xmm7
+               	movaps	-0xa0(%rbp), %xmm8
+               	movaps	-0xb0(%rbp), %xmm9
+               	movaps	-0xc0(%rbp), %xmm10
+               	movaps	-0xd0(%rbp), %xmm11
+               	movaps	-0xe0(%rbp), %xmm12
+               	movaps	-0xf0(%rbp), %xmm13
+               	movaps	-0x100(%rbp), %xmm14
+               	movaps	-0x110(%rbp), %xmm15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %rdi
+               	movq	-0x68(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -264,90 +550,94 @@ Disassembly of section .text:
                	movq	%r11, -0x20(%rbp)
                	movq	0x88(%rbp), %r11
                	movq	%r11, -0x30(%rbp)
+               	movd	%xmm6, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	movd	%xmm7, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	movd	%xmm8, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	callq	 <L2>
 <L2>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movd	%xmm10, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	-0x10(%rbp), %xmm1
                	callq	 <L4>
 <L4>:
+               	movd	%xmm11, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
+               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
+               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
+               	movss	-0x40(%rbp), %xmm1
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rcx
-               	movss	-0x40(%rbp), %xmm1
+               	movss	-0x50(%rbp), %xmm1
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
-               	movss	-0x50(%rbp), %xmm1
+               	movss	-0x60(%rbp), %xmm1
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
-               	movss	-0x60(%rbp), %xmm1
+               	movss	-0x70(%rbp), %xmm1
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movss	-0x70(%rbp), %xmm1
+               	movss	-0x80(%rbp), %xmm1
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movss	-0x80(%rbp), %xmm1
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movss	-0x20(%rbp), %xmm1
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movss	-0x20(%rbp), %xmm1
+               	movss	-0x30(%rbp), %xmm1
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rcx
-               	movss	-0x30(%rbp), %xmm1
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
                	addss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L16>
+<L16>:
+               	movss	%xmm13, %xmm0           # xmm0 = xmm13[0],xmm0[1,2,3]
+               	subss	-0x80(%rbp), %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L17>
 <L17>:
+               	movss	-0x10(%rbp), %xmm0
+               	mulss	-0x20(%rbp), %xmm0
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm0           # xmm0 = xmm13[0],xmm0[1,2,3]
-               	subss	-0x80(%rbp), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rcx
-               	movss	-0x10(%rbp), %xmm0
-               	mulss	-0x20(%rbp), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
                	movaps	-0x90(%rbp), %xmm6
                	movaps	-0xa0(%rbp), %xmm7
                	movaps	-0xb0(%rbp), %xmm8
@@ -365,131 +655,125 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x490, %rsp            # imm = 0x490
-               	movq	%rbx, -0x338(%rbp)
-               	movq	%rdi, -0x340(%rbp)
-               	movq	%rsi, -0x348(%rbp)
-               	movq	%r12, -0x350(%rbp)
-               	movq	%r13, -0x358(%rbp)
-               	movq	%r14, -0x360(%rbp)
-               	movq	%r15, -0x368(%rbp)
-               	movaps	%xmm6, -0x380(%rbp)
-               	movaps	%xmm7, -0x390(%rbp)
-               	movaps	%xmm8, -0x3a0(%rbp)
-               	movaps	%xmm9, -0x3b0(%rbp)
-               	movaps	%xmm10, -0x3c0(%rbp)
-               	movaps	%xmm11, -0x3d0(%rbp)
-               	movaps	%xmm12, -0x3e0(%rbp)
-               	movaps	%xmm13, -0x3f0(%rbp)
-               	movaps	%xmm14, -0x400(%rbp)
-               	movaps	%xmm15, -0x410(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x3e0, %rsp            # imm = 0x3E0
+               	movq	%rbx, -0x288(%rbp)
+               	movq	%rdi, -0x290(%rbp)
+               	movq	%rsi, -0x298(%rbp)
+               	movq	%r12, -0x2a0(%rbp)
+               	movq	%r13, -0x2a8(%rbp)
+               	movq	%r14, -0x2b0(%rbp)
+               	movq	%r15, -0x2b8(%rbp)
+               	movaps	%xmm6, -0x2d0(%rbp)
+               	movaps	%xmm7, -0x2e0(%rbp)
+               	movaps	%xmm8, -0x2f0(%rbp)
+               	movaps	%xmm9, -0x300(%rbp)
+               	movaps	%xmm10, -0x310(%rbp)
+               	movaps	%xmm11, -0x320(%rbp)
+               	movaps	%xmm12, -0x330(%rbp)
+               	movaps	%xmm13, -0x340(%rbp)
+               	movaps	%xmm14, -0x350(%rbp)
+               	movaps	%xmm15, -0x360(%rbp)
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rdx
                	addq	$0x0, %rdx
-               	movq	$0xa0, %rsi
-<L1>:
+               	movq	$0xa0, %rbx
+<L0>:
                	movq	$0x0, (%rdx)
                	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L0>
                	movq	$0x0, %rdx
                	cmpq	$0x14, %rdx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rdx, %rsi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdx, %rbx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rsi
+               	imulq	%r11, %rbx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rsi
-               	addq	%rbx, %rsi
-               	leaq	(%rcx,%rdx,8), %rdi
-               	movq	%rsi, (%rdi)
+               	addq	%r11, %rbx
+               	addq	%rcx, %rbx
+               	leaq	(%rax,%rdx,8), %rsi
+               	movq	%rbx, (%rsi)
                	addq	$0x1, %rdx
                	cmpq	$0x14, %rdx
-               	jb	 <L2>
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x50(%rbp), %rbx
+               	leaq	(%rbx), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x50, %rdx
 <L3>:
-               	leaq	-0xf0(%rbp), %rbx
-               	leaq	(%rbx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0x50, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L3>
+               	leaq	-0xf0(%rbp), %rsi
+               	leaq	(%rsi), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0xa0, %rdx
 <L4>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L4>
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0xa0, %rdi
+               	movq	$0x0, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+               	jmp	 <L10>
 <L5>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L5>
-               	movq	$0x0, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-               	jmp	 <L11>
-<L6>:
-               	leaq	(%rcx,%rdx,8), %rdi
-               	movq	(%rdi), %r12
-               	andq	$0xfff, %r12            # imm = 0xFFF
-               	movq	%r12, %r11
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rdi
+               	andq	$0xfff, %rdi            # imm = 0xFFF
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1d2>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1b9>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1de>
-               	leaq	(%rbx,%rdx,4), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	(%rcx,%rdx,8), %rdi
-               	movq	(%rdi), %r12
-               	andq	$0xfffff, %r12          # imm = 0xFFFFF
-               	movq	%r12, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1c5>
+               	leaq	(%rbx,%rcx,4), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rdi
+               	andq	$0xfffff, %rdi          # imm = 0xFFFFF
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x22c>
+               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x213>
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x238>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8,%rdx,8), %rdi
-               	movsd	%xmm0, (%rdi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-<L11>:
-               	movq	%rax, %r8
+               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x21f>
+               	leaq	(%rsi,%rcx,8), %rdx
+               	movsd	%xmm0, (%rdx)
+               	addq	$0x1, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+<L10>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x1a0(%rbp)
                	movq	$0x0, %r8
                	movq	%r8, -0x198(%rbp)
@@ -497,75 +781,69 @@ Disassembly of section .text:
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-               	jmp	 <L38>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L18>
+<L11>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0x3, %rax
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_float_regs.checksum+0x2d7>
+               	divss	, %xmm6 <corpus.cases.call.call_float_regs.checksum+0x2be>
                	leaq	(%rbx), %r14
                	movss	(%r14), %xmm0
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
                	addss	%xmm6, %xmm14
                	movss	%xmm14, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x8(%r8), %rax
+               	leaq	0x8(%rsi), %rax
                	movq	(%rax), %r11
                	movq	%r11, -0x1d8(%rbp)
                	leaq	0x8(%rbx), %r15
                	movl	(%r15), %r11d
                	movl	%r11d, -0x1e8(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x18(%r8), %rax
+               	leaq	0x18(%rsi), %rax
                	movsd	(%rax), %xmm4
                	leaq	0x10(%rbx), %r8
-               	movq	%r8, -0x280(%rbp)
-               	movq	-0x280(%rbp), %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r8
                	movss	(%r8), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x28(%r8), %rcx
+               	leaq	0x28(%rsi), %rcx
                	movsd	(%rcx), %xmm5
                	leaq	0x18(%rbx), %r12
                	movss	(%r12), %xmm7
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x38(%r8), %rcx
+               	leaq	0x38(%rsi), %rcx
                	movsd	(%rcx), %xmm8
                	leaq	0x20(%rbx), %rdi
                	movss	(%rdi), %xmm9
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x48(%r8), %rcx
+               	leaq	0x48(%rsi), %rcx
                	movsd	(%rcx), %xmm10
                	leaq	0x28(%rbx), %r13
                	movss	(%r13), %xmm11
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x58(%r8), %rcx
+               	leaq	0x58(%rsi), %rcx
                	movsd	(%rcx), %xmm12
-               	leaq	0x30(%rbx), %rsi
-               	movss	(%rsi), %xmm13
+               	leaq	0x30(%rbx), %r8
+               	movq	%r8, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %r8
-               	leaq	0x68(%r8), %rcx
+               	movss	(%r8), %xmm13
+               	leaq	0x68(%rsi), %rcx
                	movsd	(%rcx), %xmm1
                	leaq	0x38(%rbx), %r8
                	movq	%r8, -0x1c8(%rbp)
                	movq	-0x1c8(%rbp), %r8
                	movss	(%r8), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x78(%r8), %rcx
+               	leaq	0x78(%rsi), %rcx
                	movsd	(%rcx), %xmm3
                	movsd	%xmm0, 0x20(%rsp)
                	movsd	%xmm5, 0x28(%rsp)
@@ -583,353 +861,203 @@ Disassembly of section .text:
                	movsd	-0x1d8(%rbp), %xmm1
                	movss	-0x1e8(%rbp), %xmm2
                	movsd	%xmm4, %xmm3            # xmm3 = xmm4[0],xmm3[1]
-               	callq	 <L15>
-<L15>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rdx
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rcx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	movl	(%r14), %r11d
+               	movl	%r11d, -0x1f8(%rbp)
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r11d
+               	movl	%r11d, -0x208(%rbp)
+               	movl	(%r15), %r11d
+               	movl	%r11d, -0x218(%rbp)
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r11d
+               	movl	%r11d, -0x228(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movss	(%r8), %xmm4
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	movss	(%r12), %xmm7
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm8
+               	movss	(%rdi), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	movss	(%r13), %xmm11
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	movq	-0x1b0(%rbp), %r8
+               	movss	(%r8), %xmm13
+               	leaq	0x34(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x1c8(%rbp), %r8
+               	movss	(%r8), %xmm1
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
+               	addss	%xmm6, %xmm3
+               	movsd	%xmm4, 0x20(%rsp)
+               	movsd	%xmm5, 0x28(%rsp)
+               	movsd	%xmm7, 0x30(%rsp)
+               	movsd	%xmm8, 0x38(%rsp)
+               	movsd	%xmm9, 0x40(%rsp)
+               	movsd	%xmm10, 0x48(%rsp)
+               	movsd	%xmm11, 0x50(%rsp)
+               	movsd	%xmm12, 0x58(%rsp)
+               	movsd	%xmm13, 0x60(%rsp)
+               	movsd	%xmm0, 0x68(%rsp)
+               	movsd	%xmm1, 0x70(%rsp)
+               	movsd	%xmm3, 0x78(%rsp)
+               	movss	-0x1f8(%rbp), %xmm0
+               	movss	-0x208(%rbp), %xmm1
+               	movss	-0x218(%rbp), %xmm2
+               	movss	-0x228(%rbp), %xmm3
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x288(%rbp)
-               	movq	-0x288(%rbp), %r8
-               	movl	(%r14), %r11d
-               	movl	%r11d, -0x208(%rbp)
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm8
-               	movss	(%r15), %xmm9
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0x1f8(%rbp)
-               	movq	-0x280(%rbp), %r8
-               	movss	(%r8), %xmm11
-               	leaq	0x14(%rbx), %rax
-               	movss	(%rax), %xmm12
-               	movss	(%r12), %xmm13
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x298(%rbp)
-               	movl	(%rdi), %r11d
-               	movl	%r11d, -0x2a8(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2b8(%rbp)
-               	movl	(%r13), %r11d
-               	movl	%r11d, -0x2c8(%rbp)
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2d8(%rbp)
-               	movss	(%rsi), %xmm10
-               	leaq	0x34(%rbx), %rax
-               	movss	(%rax), %xmm7
-               	movq	-0x1c8(%rbp), %r8
-               	movl	(%r8), %r11d
-               	movl	%r11d, -0x218(%rbp)
-               	leaq	0x3c(%rbx), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
-               	addss	%xmm6, %xmm14
-               	movss	%xmm14, -0x228(%rbp)
+               	movq	%rax, %rdi
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rdi, %rdx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rcx
-               	movss	-0x208(%rbp), %xmm1
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movss	-0x1f8(%rbp), %xmm1
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	movss	-0x298(%rbp), %xmm1
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	movss	-0x2a8(%rbp), %xmm1
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movss	-0x2b8(%rbp), %xmm1
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movss	-0x2c8(%rbp), %xmm1
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movss	-0x2d8(%rbp), %xmm1
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	movss	-0x218(%rbp), %xmm1
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	movss	-0x228(%rbp), %xmm1
-               	callq	 <L33>
-<L33>:
-               	movss	-0x208(%rbp), %xmm1
-               	addss	-0x228(%rbp), %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	movss	-0x298(%rbp), %xmm1
-               	subss	%xmm10, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	movss	-0x1f8(%rbp), %xmm0
-               	mulss	-0x218(%rbp), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rsi
-               	movq	-0x288(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L37>
-<L37>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
                	movq	%r8, -0x1a0(%rbp)
-               	movq	%rsi, %r8
+               	movq	%rdi, %r8
                	movq	%r8, -0x198(%rbp)
                	movq	%rcx, %r8
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-<L38>:
+               	jb	 <L11>
+<L18>:
                	leaq	0x4c(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x258(%rbp)
-               	leaq	0x48(%rbx), %rax
-               	movss	(%rax), %xmm7
-               	leaq	0x44(%rbx), %rax
-               	movss	(%rax), %xmm8
-               	leaq	0x40(%rbx), %rax
-               	movl	(%rax), %r11d
                	movl	%r11d, -0x238(%rbp)
-               	leaq	0x3c(%rbx), %rax
-               	movss	(%rax), %xmm10
-               	leaq	0x38(%rbx), %rax
-               	movss	(%rax), %xmm11
-               	leaq	0x34(%rbx), %rax
-               	movss	(%rax), %xmm12
-               	leaq	0x30(%rbx), %rax
-               	movss	(%rax), %xmm13
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2e8(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2f8(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x308(%rbp)
-               	leaq	0x20(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x318(%rbp)
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x328(%rbp)
-               	leaq	0x18(%rbx), %rax
-               	movss	(%rax), %xmm9
-               	leaq	0x14(%rbx), %rax
+               	leaq	0x48(%rbx), %rax
                	movl	(%rax), %r11d
                	movl	%r11d, -0x248(%rbp)
-               	leaq	0x10(%rbx), %rax
+               	leaq	0x44(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	leaq	0x40(%rbx), %rax
+               	movss	(%rax), %xmm3
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm4
+               	leaq	0x38(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm6
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	movss	-0x258(%rbp), %xmm1
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
-               	movss	-0x238(%rbp), %xmm1
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rcx
-               	movss	-0x2e8(%rbp), %xmm1
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	movss	-0x2f8(%rbp), %xmm1
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rcx
-               	movss	-0x308(%rbp), %xmm1
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	movss	-0x318(%rbp), %xmm1
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
-               	movss	-0x328(%rbp), %xmm1
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movss	-0x248(%rbp), %xmm1
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	movss	-0x258(%rbp), %xmm0
-               	addss	%xmm6, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	movss	%xmm13, %xmm0           # xmm0 = xmm13[0],xmm0[1,2,3]
-               	subss	-0x328(%rbp), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
+               	leaq	0x30(%rbx), %rax
+               	movss	(%rax), %xmm7
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm8
+               	leaq	0x28(%rbx), %rax
+               	movss	(%rax), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	leaq	0x20(%rbx), %rax
+               	movss	(%rax), %xmm11
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	leaq	0x18(%rbx), %rax
+               	movss	(%rax), %xmm13
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%rbx), %rax
+               	movss	(%rax), %xmm1
+               	movsd	%xmm4, 0x20(%rsp)
+               	movsd	%xmm5, 0x28(%rsp)
+               	movsd	%xmm6, 0x30(%rsp)
+               	movsd	%xmm7, 0x38(%rsp)
+               	movsd	%xmm8, 0x40(%rsp)
+               	movsd	%xmm9, 0x48(%rsp)
+               	movsd	%xmm10, 0x50(%rsp)
+               	movsd	%xmm11, 0x58(%rsp)
+               	movsd	%xmm12, 0x60(%rsp)
+               	movsd	%xmm13, 0x68(%rsp)
+               	movsd	%xmm0, 0x70(%rsp)
+               	movsd	%xmm1, 0x78(%rsp)
                	movss	-0x238(%rbp), %xmm0
-               	mulss	-0x248(%rbp), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L58>
-<L58>:
+               	movss	-0x248(%rbp), %xmm1
+               	callq	 <L19>
+<L19>:
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
-<L59>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L60>:
+<L21>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x8d7>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x6bd>
                	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x8e5>
-               	movss	%xmm14, -0x268(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rax
+               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x6cb>
+               	movss	%xmm14, -0x258(%rbp)
+               	leaq	(%rsi), %rax
                	movq	(%rax), %r11
-               	movq	%r11, -0x278(%rbp)
+               	movq	%r11, -0x268(%rbp)
                	leaq	0x4(%rbx), %rax
                	movss	(%rax), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x10(%r8), %rax
+               	leaq	0x10(%rsi), %rax
                	movsd	(%rax), %xmm3
                	leaq	0xc(%rbx), %rax
                	movss	(%rax), %xmm4
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x20(%r8), %rax
+               	leaq	0x20(%rsi), %rax
                	movsd	(%rax), %xmm5
                	leaq	0x14(%rbx), %rax
                	movss	(%rax), %xmm6
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x30(%r8), %rax
+               	leaq	0x30(%rsi), %rax
                	movsd	(%rax), %xmm7
                	movq	-0x198(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L22>
                	cvtsi2ss	%r11, %xmm8
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm8
                	addss	%xmm8, %xmm8
-<L62>:
+<L23>:
                	movss	%xmm8, %xmm9            # xmm9 = xmm8[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x993>
+               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x75d>
                	movss	%xmm9, %xmm8            # xmm8 = xmm9[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x9a1>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x40(%r8), %rax
+               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x76b>
+               	leaq	0x40(%rsi), %rax
                	movsd	(%rax), %xmm9
                	leaq	0x24(%rbx), %rax
                	movss	(%rax), %xmm10
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x50(%r8), %rax
+               	leaq	0x50(%rsi), %rax
                	movsd	(%rax), %xmm11
                	leaq	0x2c(%rbx), %rax
                	movss	(%rax), %xmm12
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x60(%r8), %rax
+               	leaq	0x60(%rsi), %rax
                	movsd	(%rax), %xmm13
                	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x70(%r8), %rax
+               	leaq	0x70(%rsi), %rax
                	movsd	(%rax), %xmm1
                	movsd	%xmm4, 0x20(%rsp)
                	movsd	%xmm5, 0x28(%rsp)
@@ -943,32 +1071,32 @@ Disassembly of section .text:
                	movsd	%xmm13, 0x68(%rsp)
                	movsd	%xmm0, 0x70(%rsp)
                	movsd	%xmm1, 0x78(%rsp)
-               	movss	-0x268(%rbp), %xmm0
-               	movsd	-0x278(%rbp), %xmm1
-               	callq	 <L63>
-<L63>:
+               	movss	-0x258(%rbp), %xmm0
+               	movsd	-0x268(%rbp), %xmm1
+               	callq	 <L24>
+<L24>:
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rax, %rdx
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x380(%rbp), %xmm6
-               	movaps	-0x390(%rbp), %xmm7
-               	movaps	-0x3a0(%rbp), %xmm8
-               	movaps	-0x3b0(%rbp), %xmm9
-               	movaps	-0x3c0(%rbp), %xmm10
-               	movaps	-0x3d0(%rbp), %xmm11
-               	movaps	-0x3e0(%rbp), %xmm12
-               	movaps	-0x3f0(%rbp), %xmm13
-               	movaps	-0x400(%rbp), %xmm14
-               	movaps	-0x410(%rbp), %xmm15
-               	movq	-0x338(%rbp), %rbx
-               	movq	-0x340(%rbp), %rdi
-               	movq	-0x348(%rbp), %rsi
-               	movq	-0x350(%rbp), %r12
-               	movq	-0x358(%rbp), %r13
-               	movq	-0x360(%rbp), %r14
-               	movq	-0x368(%rbp), %r15
+               	callq	 <L25>
+<L25>:
+               	movaps	-0x2d0(%rbp), %xmm6
+               	movaps	-0x2e0(%rbp), %xmm7
+               	movaps	-0x2f0(%rbp), %xmm8
+               	movaps	-0x300(%rbp), %xmm9
+               	movaps	-0x310(%rbp), %xmm10
+               	movaps	-0x320(%rbp), %xmm11
+               	movaps	-0x330(%rbp), %xmm12
+               	movaps	-0x340(%rbp), %xmm13
+               	movaps	-0x350(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm15
+               	movq	-0x288(%rbp), %rbx
+               	movq	-0x290(%rbp), %rdi
+               	movq	-0x298(%rbp), %rsi
+               	movq	-0x2a0(%rbp), %r12
+               	movq	-0x2a8(%rbp), %r13
+               	movq	-0x2b0(%rbp), %r14
+               	movq	-0x2b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_indirect.dis
+++ b/test/golden/x86_64-windows/call/call_indirect.dis
@@ -70,32 +70,84 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.fold24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movq	(%rbx), %rsi
                	leaq	0x8(%rdx), %rbx
                	movq	(%rbx), %rdi
                	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -201,93 +253,289 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movaps	%xmm6, -0x60(%rbp)
-               	movaps	%xmm7, -0x70(%rbp)
-               	movaps	%xmm8, -0x80(%rbp)
-               	movaps	%xmm9, -0x90(%rbp)
-               	movq	%rcx, %rbx
-               	movl	%edx, %esi
-               	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
-               	movq	%r9, %rdi
-               	movsd	0x30(%rbp), %xmm7
-               	movq	0x38(%rbp), %r12
-               	movq	0x40(%rbp), %r13
-               	movsd	0x48(%rbp), %xmm8
-               	movq	0x50(%rbp), %r14
-               	movq	0x58(%rbp), %r15
-               	movsd	0x60(%rbp), %xmm9
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rcx, %rax
+               	movq	%r9, %rbx
+               	movsd	0x30(%rbp), %xmm0
+               	movq	0x38(%rbp), %rsi
+               	movq	0x40(%rbp), %rdi
+               	movsd	0x48(%rbp), %xmm1
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movsd	0x60(%rbp), %xmm3
                	movq	0x68(%rbp), %r8
                	movq	%r8, -0x8(%rbp)
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %r15 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%r14, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r14
+               	movq	%r12, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L3>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L4>
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L5>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L7>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L8>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L9>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L10>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L11>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
+               	movslq	%edi, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r15, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x60(%rbp), %xmm6
-               	movaps	-0x70(%rbp), %xmm7
-               	movaps	-0x80(%rbp), %xmm8
-               	movaps	-0x90(%rbp), %xmm9
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	%r15, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -361,57 +609,54 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2a0, %rsp            # imm = 0x2A0
-               	movq	%rbx, -0x1e8(%rbp)
-               	movq	%rdi, -0x1f0(%rbp)
-               	movq	%rsi, -0x1f8(%rbp)
-               	movq	%r12, -0x200(%rbp)
-               	movq	%r13, -0x208(%rbp)
-               	movq	%r14, -0x210(%rbp)
-               	movq	%r15, -0x218(%rbp)
-               	movaps	%xmm6, -0x230(%rbp)
-               	movaps	%xmm7, -0x240(%rbp)
-               	movaps	%xmm8, -0x250(%rbp)
-               	movaps	%xmm9, -0x260(%rbp)
-               	movaps	%xmm14, -0x270(%rbp)
-               	movaps	%xmm15, -0x280(%rbp)
+               	subq	$0x390, %rsp            # imm = 0x390
+               	movq	%rbx, -0x298(%rbp)
+               	movq	%rdi, -0x2a0(%rbp)
+               	movq	%rsi, -0x2a8(%rbp)
+               	movq	%r12, -0x2b0(%rbp)
+               	movq	%r13, -0x2b8(%rbp)
+               	movq	%r14, -0x2c0(%rbp)
+               	movq	%r15, -0x2c8(%rbp)
+               	movaps	%xmm6, -0x2e0(%rbp)
+               	movaps	%xmm7, -0x2f0(%rbp)
+               	movaps	%xmm8, -0x300(%rbp)
+               	movaps	%xmm9, -0x310(%rbp)
+               	movaps	%xmm14, -0x320(%rbp)
+               	movaps	%xmm15, -0x330(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x148(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	movq	-0x158(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	leaq	-0xe0(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
                	leaq	(%r8), %rdi
                	addq	$0x0, %rdi
                	movq	$0x60, %r12
-<L1>:
+<L0>:
                	movq	$0x0, (%rdi)
                	addq	$0x8, %rdi
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L1>
+               	jne	 <L0>
                	movq	$0x0, %rdi
                	cmpq	$0xc, %rdi
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rdi, %r12
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %r12
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %r12
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %r12
-               	movq	-0x158(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	leaq	(%r8,%rdi,8), %r13
                	movq	%r12, (%r13)
                	addq	$0x1, %rdi
                	cmpq	$0xc, %rdi
-               	jb	 <L2>
-<L3>:
-               	leaq	-0x90(%rbp), %rdi
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x30(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
@@ -419,38 +664,38 @@ Disassembly of section .text:
                	movq	$0x0, 0x20(%rdi)
                	movq	$0x0, 0x28(%rdi)
                	leaq	(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x150>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x148>
                	movq	%r13, (%r12)
                	leaq	0x8(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x15f>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x157>
                	movq	%r13, (%r12)
                	leaq	0x10(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x16e>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x166>
                	movq	%r13, (%r12)
                	leaq	0x18(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x17d>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x175>
                	movq	%r13, (%r12)
                	leaq	0x20(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x18c>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x184>
                	movq	%r13, (%r12)
                	leaq	0x28(%rdi), %r12
-               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x19b>
+               	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x193>
                	movq	%r13, (%r12)
-               	leaq	-0xa0(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0x150(%rbp), %r8
+               	leaq	-0x40(%rbp), %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x148(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x150(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x150(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	leaq	(%r8), %r13
-               	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x1db>
+               	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x1d0>
                	movq	%r14, (%r13)
-               	movq	-0x150(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	leaq	0x8(%r8), %r13
-               	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x1f1>
+               	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x1e6>
                	movq	%r14, (%r13)
-               	leaq	-0xb0(%rbp), %r8
+               	leaq	-0x50(%rbp), %r8
                	movq	%r8, -0x160(%rbp)
                	movq	-0x160(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -458,222 +703,261 @@ Disassembly of section .text:
                	movq	$0x0, 0x8(%r8)
                	movq	-0x160(%rbp), %r8
                	leaq	(%r8), %r14
-               	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x231>
+               	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x223>
                	movq	%r15, (%r14)
                	movq	-0x160(%rbp), %r8
                	leaq	0x8(%r8), %r14
-               	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x246>
+               	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x238>
                	movq	%r15, (%r14)
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %r14
                	addq	$0x1, %r14
-               	movq	%rcx, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	%r14, %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	$0x0, %rbx
-               	cmpq	$0xc, %rbx
-               	jb	 <L4>
-               	jmp	 <L15>
-<L4>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rbx,8), %r12
-               	movq	(%r12), %rcx
-               	movq	-0x148(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rsi
-               	leaq	(%rdi,%rsi,8), %r13
-               	movq	(%r13), %r15
-               	movq	(%r12), %r14
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rdx
-               	callq	*%r15
-               	movq	%rax, %r8
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x178(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %r15
-               	movq	(%r13), %r14
-               	movq	(%r12), %r13
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rdx
-               	callq	*%r14
-               	movq	%rax, %r12
-               	movq	%r15, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %r12
-               	addq	$0x1, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%rdi,%rcx,8), %rsi
-               	movq	(%rsi), %r13
+               	movq	$0x0, %r12
+               	cmpq	$0xc, %r12
+               	jb	 <L3>
+               	jmp	 <L15>
+<L3>:
+               	movq	-0x170(%rbp), %r9
+               	leaq	(%r9,%r12,8), %r8
+               	movq	%r8, -0x158(%rbp)
                	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rbx,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%rsi, %rdx
-               	callq	*%r13
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	*%r13
-               	movq	%rax, %rsi
-               	movq	%r12, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rsi
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rbx,8), %rcx
-               	movq	(%rcx), %r12
-               	movq	-0x148(%rbp), %r8
-               	addq	%r8, %r12
-               	movq	%r12, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	cmpq	$0x0, %rcx
-               	je	 <L12>
-               	cmpq	$0x1, %rcx
-               	je	 <L11>
-               	cmpq	$0x2, %rcx
-               	je	 <L10>
-               	cmpq	$0x3, %rcx
-               	je	 <L9>
-               	cmpq	$0x4, %rcx
-               	je	 <L8>
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3d6>
-               	jmp	 <L13>
-<L8>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3e2>
-               	jmp	 <L13>
-<L9>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3ee>
-               	jmp	 <L13>
-<L10>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3fa>
-               	jmp	 <L13>
-<L11>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x406>
-               	jmp	 <L13>
-<L12>:
-               	leaq	, %r12 <L13>
-<L13>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rbx,8), %rcx
-               	movq	(%rcx), %r13
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rdx
-               	callq	*%r12
-               	movq	%rax, %r12
-               	movq	%rsi, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rbx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0x178(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x170(%rbp)
-               	cmpq	$0xc, %rbx
-               	jb	 <L4>
-<L15>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rbx
-               	movq	-0x148(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %rbx
                	movq	%rbx, %rax
-               	movq	$0x6, %rcx
+               	movq	$0x6, %rbx
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%rdi,%rcx,8), %rbx
-               	movq	(%rbx), %rcx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rdi,%rbx,8), %r13
+               	movq	(%r13), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x158(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	%r14, %rcx
+               	movq	%r13, %rdx
                	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rbx
-               	movq	-0x170(%rbp), %r9
-               	movq	%r9, %r8
+               	callq	*%r8
+               	movq	%rax, %r13
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0x1, %r15
+               	movq	%r15, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
+<L5>:
+               	leaq	(%rdi,%rbx,8), %r15
+               	movq	(%r15), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r15
+               	movq	(%r15), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	%r13, %rcx
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x190(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %r15
+               	movq	%rsi, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %rbx
+               	movq	%rbx, %rax
+               	movq	$0x6, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rdi,%rbx,8), %r15
+               	movq	(%r15), %rbx
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r15
+               	movq	(%r15), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	%r13, %rcx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	*%rbx
+               	movq	%rax, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	*%rbx
+               	movq	%rax, %rbx
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8,%r12,8), %rsi
+               	movq	(%rsi), %r15
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %r15
+               	movq	%r15, %rax
+               	movq	$0x6, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	cmpq	$0x0, %rsi
+               	je	 <L12>
+               	cmpq	$0x1, %rsi
+               	je	 <L11>
+               	cmpq	$0x2, %rsi
+               	je	 <L10>
+               	cmpq	$0x3, %rsi
+               	je	 <L9>
+               	cmpq	$0x4, %rsi
+               	je	 <L8>
+               	leaq	, %rsi <corpus.cases.call.call_indirect.checksum+0x480>
+               	jmp	 <L13>
+<L8>:
+               	leaq	, %rsi <corpus.cases.call.call_indirect.checksum+0x48c>
+               	jmp	 <L13>
+<L9>:
+               	leaq	, %rsi <corpus.cases.call.call_indirect.checksum+0x498>
+               	jmp	 <L13>
+<L10>:
+               	leaq	, %rsi <corpus.cases.call.call_indirect.checksum+0x4a4>
+               	jmp	 <L13>
+<L11>:
+               	leaq	, %rsi <corpus.cases.call.call_indirect.checksum+0x4b0>
+               	jmp	 <L13>
+<L12>:
+               	leaq	, %rsi <L13>
+<L13>:
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r15
+               	movq	(%r15), %r8
                	movq	%r8, -0x1a8(%rbp)
+               	movq	%r13, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	*%rsi
+               	movq	%rax, %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rbx
+               	addq	$0x1, %r12
+               	movq	%rbx, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%r13, %r14
+               	cmpq	$0xc, %r12
+               	jb	 <L3>
+<L15>:
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movq	(%rbx), %rsi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x6, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rdi,%rbx,8), %rsi
+               	movq	(%rsi), %rbx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x238(%rbp)
                	movq	$0x0, %r12
-               	movq	%rcx, %r13
                	cmpq	$0x8, %r12
                	jb	 <L16>
                	jmp	 <L18>
 <L16>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%r12,8), %rcx
-               	movq	(%rcx), %r14
-               	movq	-0x148(%rbp), %r8
-               	addq	%r8, %r14
-               	addq	%r12, %r14
-               	movq	%r14, %rax
-               	movq	$0x6, %r14
+               	movq	-0x170(%rbp), %r9
+               	leaq	(%r9,%r12,8), %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %r15
+               	addq	%r12, %r15
+               	movq	%r15, %rax
+               	movq	$0x6, %r15
                	xorl	%edx, %edx
-               	divq	%r14
-               	movq	%rdx, %r14
-               	leaq	(%rdi,%r14,8), %r15
-               	movq	(%r15), %r14
-               	movq	(%rcx), %r15
-               	movq	-0x1a8(%rbp), %r8
+               	divq	%r15
+               	movq	%rdx, %r15
+               	leaq	(%rdi,%r15,8), %r13
+               	movq	(%r13), %r15
+               	movq	-0x1b0(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	-0x238(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	callq	*%r14
-               	movq	%rax, %r15
-               	movq	-0x1a8(%rbp), %r8
+               	movq	%r13, %rdx
+               	callq	*%r15
+               	movq	%rax, %r13
+               	movq	-0x238(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	callq	*%r13
-               	movq	%rax, %rsi
-               	movq	%rbx, %rcx
-               	movq	%rsi, %rdx
+               	movq	%r13, %rdx
+               	callq	*%rbx
+               	movq	%rax, %r14
+               	movq	%rsi, %rcx
+               	movq	%r14, %rdx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rsi
                	addq	$0x1, %r12
-               	movq	%rsi, %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%r14, %r13
+               	movq	%r14, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	%r15, %rbx
                	cmpq	$0x8, %r12
                	jb	 <L16>
 <L18>:
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L19>
-               	jmp	 <L25>
+               	jmp	 <L28>
 <L19>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rdi,8), %rcx
-               	movq	(%rcx), %r12
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x170(%rbp), %r9
+               	leaq	(%r9,%rbx,8), %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %r12
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %r12
                	movq	%r12, %rax
                	movq	$0x2, %r12
                	xorl	%edx, %edx
                	divq	%r12
                	movq	%rdx, %r12
-               	movq	(%rcx), %r13
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %r13
                	addq	$0x1, %r13
                	movq	%r13, %rax
@@ -681,431 +965,390 @@ Disassembly of section .text:
                	xorl	%edx, %edx
                	divq	%r13
                	movq	%rdx, %r13
-               	leaq	-0xc8(%rbp), %r14
+               	leaq	-0x68(%rbp), %r15
                	movq	-0x160(%rbp), %r8
-               	leaq	(%r8,%r12,8), %r15
-               	movq	(%r15), %r8
-               	movq	%r8, -0x180(%rbp)
-               	movq	(%rcx), %r15
-               	movq	-0x1a8(%rbp), %r8
-               	addq	%r8, %r15
-               	leaq	-0xe0(%rbp), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	movq	-0x180(%rbp), %r8
-               	callq	*%r8
-               	movq	-0x188(%rbp), %r8
-               	movq	-0x188(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x188(%rbp), %r8
-               	movq	0x8(%r8), %r15
-               	movq	-0x188(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x190(%rbp)
-               	movq	%rcx, (%r14)
-               	movq	%r15, 0x8(%r14)
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, 0x10(%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %r15
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0x10(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	%rbx, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8,%r13,8), %rsi
-               	movq	(%rsi), %r13
-               	leaq	-0xf8(%rbp), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	(%r14), %rcx
-               	movq	0x8(%r14), %r8
-               	movq	%r8, -0x1b8(%rbp)
-               	movq	0x10(%r14), %r8
+               	leaq	(%r8,%r12,8), %rdi
+               	movq	(%rdi), %r8
                	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x1b0(%rbp), %r8
-               	movq	-0x1b8(%rbp), %r9
-               	movq	%r9, 0x8(%r8)
-               	movq	-0x1b0(%rbp), %r8
-               	movq	-0x1c0(%rbp), %r9
-               	movq	%r9, 0x10(%r8)
-               	movq	-0x1b0(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x1b0(%rbp), %r8
-               	movq	0x8(%r8), %r14
-               	movq	-0x1b0(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	%rcx, -0x110(%rbp)
-               	movq	%r14, -0x108(%rbp)
-               	movq	-0x1c8(%rbp), %r8
-               	movq	%r8, -0x100(%rbp)
-               	leaq	-0x110(%rbp), %rcx
-               	callq	*%r13
-               	movq	%rax, %r13
-               	movq	%r15, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %r13
-               	movq	(%rsi), %r14
-               	movq	-0x160(%rbp), %r8
-               	leaq	(%r8,%r12,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rdi,8), %rcx
-               	movq	(%rcx), %r12
-               	leaq	-0x128(%rbp), %r15
-               	movq	%r15, %rcx
-               	movq	%r12, %rdx
-               	callq	*%rsi
-               	movq	(%r15), %rcx
-               	movq	0x8(%r15), %rsi
-               	movq	0x10(%r15), %r12
-               	movq	%rcx, -0x140(%rbp)
-               	movq	%rsi, -0x138(%rbp)
-               	movq	%r12, -0x130(%rbp)
-               	leaq	-0x140(%rbp), %rcx
-               	callq	*%r14
-               	movq	%rax, %rsi
-               	movq	%r13, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L19>
-<L25>:
-               	movq	%rbx, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	movq	-0x1d8(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L26>
-               	jmp	 <L71>
-<L26>:
-               	movq	-0x158(%rbp), %r8
-               	movq	-0x1d8(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rdi
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x238(%rbp), %r8
                	addq	%r8, %rdi
-               	movl	%edi, %r12d
+               	leaq	-0x80(%rbp), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rdi, %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	callq	*%r8
+               	movq	-0x1c8(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x1c8(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1c8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rdi, (%r15)
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, 0x8(%r15)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, 0x10(%r15)
+               	leaq	(%r15), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	leaq	0x8(%r15), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	leaq	0x10(%r15), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x250(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
                	movq	%rdi, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L28>
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x1f8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x210(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+<L21>:
+               	movq	-0x1f8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x218(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x220(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x230(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r14
+               	addq	$0x1, %r14
+               	movq	%r14, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8,%r13,8), %r14
+               	movq	(%r14), %r13
+               	leaq	-0xf8(%rbp), %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x258(%rbp), %r8
+               	movq	-0x260(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x258(%rbp), %r8
+               	movq	-0x268(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x258(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x258(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0x258(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	%rsi, -0x110(%rbp)
+               	movq	%r15, -0x108(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, -0x100(%rbp)
+               	leaq	-0x110(%rbp), %rsi
+               	movq	%rsi, %rcx
+               	callq	*%r13
+               	movq	%rax, %rsi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L26>
+<L26>:
+               	movq	%rax, %rsi
+               	movq	(%r14), %rdi
+               	movq	-0x160(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r13
+               	movq	(%r13), %r12
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %r13
+               	movq	(%r13), %r14
+               	leaq	-0x128(%rbp), %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %rdx
+               	callq	*%r12
+               	movq	(%r13), %r12
+               	movq	0x8(%r13), %r14
+               	movq	0x10(%r13), %r15
+               	movq	%r12, -0x140(%rbp)
+               	movq	%r14, -0x138(%rbp)
+               	movq	%r15, -0x130(%rbp)
+               	leaq	-0x140(%rbp), %r12
+               	movq	%r12, %rcx
+               	callq	*%rdi
+               	movq	%rax, %rdi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L27>
 <L27>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %rbx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x250(%rbp)
+               	cmpq	$0x8, %rbx
+               	jb	 <L19>
+<L28>:
+               	movq	-0x250(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L29>
+               	jmp	 <L42>
+<L29>:
+               	movq	-0x170(%rbp), %r8
+               	movq	-0x288(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rdi
+               	movq	(%rdi), %r12
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %r12
+               	movl	%r12d, %edi
+               	movq	%r12, %r13
+               	andq	$0xfff, %r13            # imm = 0xFFF
+               	movq	%r13, %r11
+               	testq	%r11, %r11
+               	jl	 <L30>
+               	cvtsi2sd	%r11, %xmm6
+               	jmp	 <L31>
+<L30>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L28>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0x863>
-               	movb	%dil, %r13b
-               	movq	%rdi, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm6
+               	addsd	%xmm6, %xmm6
+<L31>:
+               	movsd	%xmm6, %xmm2            # xmm2 = xmm6[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xb5c>
+               	movb	%r12b, %r8b
+               	movq	%r8, -0x280(%rbp)
+               	movq	%r12, %r14
+               	andq	$0xff, %r14
+               	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm7
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm7
                	addss	%xmm7, %xmm7
-<L30>:
-               	movq	%rdi, %r14
-               	imulq	$0x3, %r14, %r14
-               	movq	%rdi, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L31>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L32>
-<L31>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L32>:
-               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0x8e7>
-               	movw	%di, %r15w
-               	movq	%rdi, %rbx
-               	xorq	$-0x1, %rbx
-               	movq	%rdi, %rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L33>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L34>
 <L33>:
+               	movq	%r12, %r14
+               	imulq	$0x3, %r14, %r14
+               	movq	%r12, %r15
+               	andq	$0xffff, %r15           # imm = 0xFFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L34>
+               	cvtsi2sd	%r11, %xmm8
+               	jmp	 <L35>
+<L34>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L34>:
-               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0x936>
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%rdi, %rsi
-               	xorq	%r8, %rsi
-               	callq	 <L35>
+               	cvtsi2sd	%r11, %xmm8
+               	addsd	%xmm8, %xmm8
 <L35>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L36>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xbe7>
+               	movw	%r12w, %r15w
+               	movq	%r12, %rbx
+               	xorq	$-0x1, %rbx
+               	movq	%r12, %r13
+               	andq	$0x3ff, %r13            # imm = 0x3FF
+               	movq	%r13, %r11
+               	testq	%r11, %r11
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L37>
 <L36>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L37>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
 <L37>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
+               	movss	%xmm1, %xmm9            # xmm9 = xmm1[0],xmm9[1,2,3]
+               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0xc36>
+               	movq	-0x238(%rbp), %r8
+               	movq	%r12, %r13
+               	xorq	%r8, %r13
+               	movsd	%xmm7, 0x20(%rsp)
+               	movq	%r14, 0x28(%rsp)
+               	movq	%rdi, 0x30(%rsp)
+               	movsd	%xmm0, 0x38(%rsp)
+               	movq	%r15, 0x40(%rsp)
+               	movq	%rbx, 0x48(%rsp)
+               	movsd	%xmm9, 0x50(%rsp)
+               	movq	%r13, 0x58(%rsp)
+               	movq	%r12, %rcx
+               	movl	%edi, %edx
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, %r9
                	callq	 <L38>
 <L38>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
+               	movq	%rax, %rsi
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rsi, %rdx
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	movq	%rax, %rsi
+               	movsd	%xmm6, %xmm2            # xmm2 = xmm6[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xca7>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xcb4>
+               	movsd	%xmm7, 0x20(%rsp)
+               	movq	%r14, 0x28(%rsp)
+               	movq	%rdi, 0x30(%rsp)
+               	movsd	%xmm0, 0x38(%rsp)
+               	movq	%r15, 0x40(%rsp)
+               	movq	%rbx, 0x48(%rsp)
+               	movsd	%xmm9, 0x50(%rsp)
+               	movq	%r13, 0x58(%rsp)
+               	movq	%r12, %rcx
+               	movl	%edi, %edx
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, %r9
                	callq	 <L40>
 <L40>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	%rax, %rbx
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L47>
-<L47>:
                	movq	%rax, %rbx
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %r8
-               	movl	%edi, %esi
-               	movq	%rdi, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L49>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L50>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0xa3c>
-               	movb	%dil, %r12b
-               	movq	%rdi, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L51>
-               	cvtsi2ss	%r11, %xmm7
-               	jmp	 <L52>
-<L51>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm7
-               	addss	%xmm7, %xmm7
-<L52>:
-               	movq	%rdi, %r13
-               	imulq	$0x3, %r13, %r13
-               	movq	%rdi, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L53>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L54>:
-               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0xac0>
-               	movw	%di, %r14w
-               	movq	%rdi, %r15
-               	xorq	$-0x1, %r15
-               	movq	%rdi, %rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L55>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L56>:
-               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0xb0f>
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%rdi, %rbx
-               	xorq	%r8, %rbx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rbx
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	$0x1, %rbx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
                	movq	%rbx, %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L26>
-<L71>:
-               	movq	-0x1d0(%rbp), %r8
+               	jb	 <L29>
+<L42>:
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rax
-               	movaps	-0x230(%rbp), %xmm6
-               	movaps	-0x240(%rbp), %xmm7
-               	movaps	-0x250(%rbp), %xmm8
-               	movaps	-0x260(%rbp), %xmm9
-               	movaps	-0x270(%rbp), %xmm14
-               	movaps	-0x280(%rbp), %xmm15
-               	movq	-0x1e8(%rbp), %rbx
-               	movq	-0x1f0(%rbp), %rdi
-               	movq	-0x1f8(%rbp), %rsi
-               	movq	-0x200(%rbp), %r12
-               	movq	-0x208(%rbp), %r13
-               	movq	-0x210(%rbp), %r14
-               	movq	-0x218(%rbp), %r15
+               	movaps	-0x2e0(%rbp), %xmm6
+               	movaps	-0x2f0(%rbp), %xmm7
+               	movaps	-0x300(%rbp), %xmm8
+               	movaps	-0x310(%rbp), %xmm9
+               	movaps	-0x320(%rbp), %xmm14
+               	movaps	-0x330(%rbp), %xmm15
+               	movq	-0x298(%rbp), %rbx
+               	movq	-0x2a0(%rbp), %rdi
+               	movq	-0x2a8(%rbp), %rsi
+               	movq	-0x2b0(%rbp), %r12
+               	movq	-0x2b8(%rbp), %r13
+               	movq	-0x2c0(%rbp), %r14
+               	movq	-0x2c8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_int_regs.dis
+++ b/test/golden/x86_64-windows/call/call_int_regs.dis
@@ -14,121 +14,391 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.take16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x58(%rbp)
-               	movq	%rdi, -0x60(%rbp)
-               	movq	%rsi, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rcx, %rbx
-               	movq	%rdx, %rsi
-               	movq	%r8, %rdi
-               	movq	%r9, %r12
-               	movq	0x30(%rbp), %r13
-               	movq	0x38(%rbp), %r14
-               	movq	0x40(%rbp), %r15
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%rdi, -0x70(%rbp)
+               	movq	%rsi, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
+               	movq	%rcx, %rax
+               	movq	%r8, %rbx
+               	movq	%r9, %rsi
+               	movq	0x30(%rbp), %rdi
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x50(%rbp)
                	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	0x50(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x58(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x60(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x68(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x70(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x78(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x80(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	0x88(%rbp), %r8
+               	movq	0x50(%rbp), %r8
                	movq	%r8, -0x48(%rbp)
-               	callq	 <L0>
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x60(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x68(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x70(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x78(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x80(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	0x88(%rbp), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%al, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rax
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	movsbq	%dl, %r12
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L4>
+               	movzwq	%bx, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L5>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L6>
+               	movswq	%si, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L7>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L8>
+               	movl	%edi, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L9>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L10>
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L11>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L12>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L13>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L14>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
                	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L15>
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rcx
                	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
+               	movzbq	%r8b, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x58(%rbp), %rbx
-               	movq	-0x60(%rbp), %rdi
-               	movq	-0x68(%rbp), %rsi
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x28(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -136,121 +406,116 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.take16n>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x58(%rbp)
-               	movq	%rdi, -0x60(%rbp)
-               	movq	%rsi, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rcx, %rbx
-               	movq	%rdx, %rsi
-               	movq	%r8, %rdi
-               	movq	%r9, %r12
-               	movq	0x30(%rbp), %r13
-               	movq	0x38(%rbp), %r14
-               	movq	0x40(%rbp), %r15
-               	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	movq	%rdx, %rbx
+               	movq	%r8, %rsi
+               	movq	%r9, %rdi
+               	movq	0x30(%rbp), %r12
+               	movq	0x38(%rbp), %r13
+               	movq	0x40(%rbp), %r14
+               	movq	0x48(%rbp), %r15
                	movq	0x50(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x58(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x60(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x68(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x70(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x78(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x80(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x60(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x68(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x70(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x78(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x80(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
                	movq	0x88(%rbp), %r8
-               	movq	%r8, -0x48(%rbp)
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%cl, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	movzbq	%bl, %rdx
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rcx
-               	movq	%rsi, %rdx
+               	movsbq	%sil, %rdx
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movsbq	%dil, %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
-               	movq	%r12, %rdx
+               	movzwq	%r12w, %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
+               	movzwq	%r13w, %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movswq	%r14w, %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	%r15, %rdx
+               	movswq	%r15w, %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	-0x40(%rbp), %r8
+               	movzbq	%r8b, %rdx
                	callq	 <L8>
 <L8>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rdx
                	movq	%rax, %rcx
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L9>
 <L9>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdx
                	movq	%rax, %rcx
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L10>
 <L10>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rdx
                	movq	%rax, %rcx
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L11>
 <L11>:
+               	movq	-0x20(%rbp), %r8
+               	movzbq	%r8b, %rdx
                	movq	%rax, %rcx
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L12>
 <L12>:
+               	movq	-0x28(%rbp), %r8
+               	movsbq	%r8b, %rdx
                	movq	%rax, %rcx
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L13>
 <L13>:
+               	movq	-0x30(%rbp), %r8
+               	movzwq	%r8w, %rdx
                	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L14>
 <L14>:
+               	movq	-0x38(%rbp), %r8
+               	movswq	%r8w, %rdx
                	movq	%rax, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	-0x58(%rbp), %rbx
-               	movq	-0x60(%rbp), %rdi
-               	movq	-0x68(%rbp), %rsi
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -258,783 +523,557 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x340, %rsp            # imm = 0x340
-               	movq	%rbx, -0x2e8(%rbp)
-               	movq	%rdi, -0x2f0(%rbp)
-               	movq	%rsi, -0x2f8(%rbp)
-               	movq	%r12, -0x300(%rbp)
-               	movq	%r13, -0x308(%rbp)
-               	movq	%r14, -0x310(%rbp)
-               	movq	%r15, -0x318(%rbp)
+               	subq	$0x410, %rsp            # imm = 0x410
+               	movq	%rbx, -0x358(%rbp)
+               	movq	%rdi, -0x360(%rbp)
+               	movq	%rsi, -0x368(%rbp)
+               	movq	%r12, -0x370(%rbp)
+               	movq	%r13, -0x378(%rbp)
+               	movq	%r14, -0x380(%rbp)
+               	movq	%r15, -0x388(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0xa0(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xa0, %rdx
+               	leaq	(%rsi), %rax
+               	addq	$0x0, %rax
+               	movq	$0xa0, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %rdi
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x188(%rbp)
                	movq	$0x0, %r12
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
-               	jb	 <L4>
-               	jmp	 <L41>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L8>
+<L3>:
                	movq	%r13, %rax
                	imulq	$0x7, %rax, %rax
                	movq	%rax, %r14
                	addq	%rbx, %r14
-               	leaq	(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r15b
-               	leaq	0x8(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, -0x2c0(%rbp)
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0xa8(%rbp)
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x20(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x30(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, %r8
-               	addq	%r14, %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x38(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
+               	leaq	(%rsi), %r15
+               	movq	(%r15), %rax
+               	movb	%al, %r8b
                	movq	%r8, -0xd8(%rbp)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	0x8(%rsi), %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	movq	(%r8), %rdx
                	movb	%dl, %r8b
-               	movq	%r8, -0xe0(%rbp)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	movq	%r8, -0xa8(%rbp)
+               	leaq	0x10(%rsi), %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	movq	(%r8), %rdx
                	movw	%dx, %r8w
-               	movq	%r8, -0xe8(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	movq	%r8, -0xb8(%rbp)
+               	leaq	0x18(%rsi), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rdx
                	movw	%dx, %r8w
-               	movq	%r8, -0xf0(%rbp)
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	movq	%r8, -0xc8(%rbp)
+               	leaq	0x20(%rsi), %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movq	(%r8), %rdx
                	movl	%edx, %r8d
-               	movq	%r8, -0xf8(%rbp)
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x100(%rbp)
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, %r8
-               	addq	%r14, %r8
-               	movq	%r8, -0x108(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %r8
                	movq	%r8, -0x110(%rbp)
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	movq	-0x2c0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
+               	leaq	0x28(%rsi), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	leaq	0x30(%rsi), %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	addq	%r14, %rdx
+               	leaq	0x38(%rsi), %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x100(%rbp)
+               	leaq	0x40(%rsi), %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x118(%rbp)
+               	leaq	0x48(%rsi), %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x128(%rbp)
+               	leaq	0x50(%rsi), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x58(%rsi), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x148(%rbp)
+               	leaq	0x60(%rsi), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	leaq	0x68(%rsi), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x168(%rbp)
+               	leaq	0x70(%rsi), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rcx
+               	addq	%r14, %rcx
+               	leaq	0x78(%rsi), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	%rdx, 0x30(%rsp)
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, 0x50(%rsp)
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, 0x58(%rsp)
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, 0x60(%rsp)
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, 0x68(%rsp)
+               	movq	%rcx, 0x70(%rsp)
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, 0x78(%rsp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rcx
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc8(%rbp), %r9
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rdx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rdi
+               	movq	(%r15), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1a0(%rbp)
                	movq	-0xb0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %dx
+               	movq	-0xe0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %ax
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r15w
+               	movq	-0xf8(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	movq	(%r8), %rcx
+               	addq	%r14, %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	movq	(%r8), %rcx
+               	addq	%r14, %rcx
+               	movw	%cx, %r14w
+               	movq	%rdx, 0x20(%rsp)
+               	movq	%rax, 0x28(%rsp)
+               	movq	%r15, 0x30(%rsp)
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, 0x50(%rsp)
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, 0x58(%rsp)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, 0x60(%rsp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, 0x68(%rsp)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, 0x70(%rsp)
+               	movq	%r14, 0x78(%rsp)
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	-0x190(%rbp), %r9
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L7>
+<L7>:
+               	addq	$0x1, %r13
+               	movq	%rax, %r8
+               	movq	%r8, -0x188(%rbp)
+               	cmpq	$0x3, %r13
+               	jb	 <L3>
+<L8>:
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1f8(%rbp)
+               	leaq	0x8(%rsi), %rbx
+               	movq	(%rbx), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x208(%rbp)
+               	leaq	0x10(%rsi), %rdi
+               	movq	(%rdi), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x220(%rbp)
+               	leaq	0x18(%rsi), %r14
+               	movq	(%r14), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x230(%rbp)
+               	leaq	0x20(%rsi), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x240(%rbp)
+               	leaq	0x28(%rsi), %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x250(%rbp)
+               	leaq	0x30(%rsi), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rcx
+               	leaq	0x38(%rsi), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %r13
+               	leaq	0x40(%rsi), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	(%r8), %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, -0x238(%rbp)
+               	leaq	0x48(%rsi), %r15
+               	movq	(%r15), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x248(%rbp)
+               	leaq	0x50(%rsi), %r8
+               	movq	%r8, -0x350(%rbp)
+               	movq	-0x350(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x258(%rbp)
+               	leaq	0x58(%rsi), %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x268(%rbp)
+               	leaq	0x60(%rsi), %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x278(%rbp)
+               	leaq	0x68(%rsi), %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x288(%rbp)
+               	leaq	0x70(%rsi), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rdx
+               	leaq	0x78(%rsi), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	%rcx, 0x30(%rsp)
+               	movq	%r13, 0x38(%rsp)
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, 0x50(%rsp)
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, 0x58(%rsp)
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, 0x60(%rsp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, 0x68(%rsp)
+               	movq	%rdx, 0x70(%rsp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, 0x78(%rsp)
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x220(%rbp), %r8
+               	movq	-0x230(%rbp), %r9
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
-               	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	movq	-0xf8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	movq	-0x100(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movq	-0x110(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L21>
-<L21>:
-               	movq	%rdi, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	leaq	(%rsi), %rax
-               	movq	(%rax), %rcx
                	movb	%cl, %r8b
-               	movq	%r8, -0x2c8(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x118(%rbp)
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x120(%rbp)
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x128(%rbp)
-               	leaq	0x20(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x130(%rbp)
-               	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x138(%rbp)
-               	leaq	0x30(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x140(%rbp)
-               	leaq	0x38(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x148(%rbp)
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%r14, %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x150(%rbp)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x158(%rbp)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x160(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x168(%rbp)
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%r14, %rdx
-               	movw	%dx, %r14w
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	-0x2c8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movq	-0x130(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	-0x138(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rcx
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rcx
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r14
-               	movq	%r15, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L40>
-<L40>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rdi
-               	movq	%r14, %r12
-               	cmpq	$0x3, %r13
-               	jb	 <L4>
-<L41>:
-               	leaq	(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %bl
-               	leaq	0x8(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r13b
-               	leaq	0x10(%rsi), %rax
-               	movq	(%rax), %rcx
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	(%rbx), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	(%rdi), %rcx
+               	movw	%cx, %di
+               	movq	(%r14), %rcx
                	movw	%cx, %r14w
-               	leaq	0x18(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r15w
-               	leaq	0x20(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x2d0(%rbp)
-               	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x188(%rbp)
-               	leaq	0x30(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x38(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x1b0(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x1b8(%rbp)
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x1c8(%rbp)
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	movq	-0x2d0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rcx
-               	movq	-0x188(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	movq	-0x1b0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	movq	-0x1c0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
-               	movq	-0x1c8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rcx
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L58>
-<L58>:
-               	movb	%al, %bl
-               	leaq	0x8(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r13b
-               	leaq	0x10(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r14w
-               	leaq	0x18(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r15w
                	movl	%r12d, %r8d
-               	movq	%r8, -0x2d8(%rbp)
-               	leaq	0x28(%rsi), %r8
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	-0x1f8(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movl	%edx, %r12d
-               	leaq	0x30(%rsi), %r8
-               	movq	%r8, -0x200(%rbp)
-               	movq	-0x200(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	leaq	0x38(%rsi), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x1e8(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1f0(%rbp)
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r12d
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rbx
                	leaq	0x80(%rsi), %rcx
                	movq	(%rcx), %rdx
                	movb	%dl, %r8b
-               	movq	%r8, -0x208(%rbp)
-               	leaq	0x88(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x210(%rbp)
+               	movq	%r8, -0x2c0(%rbp)
+               	leaq	0x88(%rsi), %rdx
+               	movq	(%rdx), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2c8(%rbp)
                	leaq	0x90(%rsi), %rcx
                	movq	(%rcx), %rdx
                	movb	%dl, %r8b
-               	movq	%r8, -0x218(%rbp)
+               	movq	%r8, -0x2d0(%rbp)
                	leaq	0x98(%rsi), %rcx
                	movq	(%rcx), %rdx
                	movb	%dl, %r8b
-               	movq	%r8, -0x220(%rbp)
-               	leaq	0x20(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x228(%rbp)
-               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x1f0(%rbp), %r8
                	movq	(%r8), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x230(%rbp)
+               	movw	%cx, %dx
                	movq	-0x200(%rbp), %r8
                	movq	(%r8), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x238(%rbp)
-               	movq	-0x1e8(%rbp), %r8
+               	movw	%cx, %si
+               	movq	-0x210(%rbp), %r8
                	movq	(%r8), %rcx
                	movw	%cx, %r8w
-               	movq	%r8, -0x240(%rbp)
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x248(%rbp)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x250(%rbp)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x258(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x260(%rbp)
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x268(%rbp)
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x270(%rbp)
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x278(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x280(%rbp)
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rcx
-               	movq	-0x208(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	movq	-0x210(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rcx
+               	movq	%r8, -0x2e0(%rbp)
                	movq	-0x218(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rcx
-               	movq	-0x220(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x2e8(%rbp)
                	movq	-0x228(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rcx
-               	movq	-0x230(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	-0x238(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rcx
-               	movq	-0x240(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rcx
-               	movq	-0x248(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rcx
-               	movq	-0x250(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rcx
-               	movq	-0x258(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	-0x260(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rcx
-               	movq	-0x268(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movq	-0x270(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rcx
-               	movq	-0x278(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movq	-0x280(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rcx
+               	movq	(%r8), %rcx
                	movb	%cl, %r8b
-               	movq	%r8, -0x288(%rbp)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x290(%rbp)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x298(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x2a0(%rbp)
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x2a8(%rbp)
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x2b0(%rbp)
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x2b8(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rcx
-               	movq	-0x2d8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rcx
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rcx
-               	movq	-0x1f0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L84>
-<L84>:
-               	movq	%rax, %rcx
-               	movq	-0x288(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rcx
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	(%r15), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	-0x350(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x308(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x310(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x318(%rbp)
                	movq	-0x290(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %rcx
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x320(%rbp)
                	movq	-0x298(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x328(%rbp)
+               	movq	%rdx, 0x20(%rsp)
+               	movq	%rsi, 0x28(%rsp)
+               	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x2e8(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x300(%rbp), %r8
+               	movq	%r8, 0x50(%rsp)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, 0x58(%rsp)
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, 0x60(%rsp)
+               	movq	-0x318(%rbp), %r8
+               	movq	%r8, 0x68(%rsp)
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, 0x70(%rsp)
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, 0x78(%rsp)
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x2c8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L87>
-<L87>:
+               	movq	-0x2d0(%rbp), %r8
+               	movq	-0x2d8(%rbp), %r9
+               	callq	 <L10>
+<L10>:
                	movq	%rax, %rcx
-               	movq	-0x2a0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %rcx
+               	movb	%cl, %dl
+               	movq	(%r15), %rcx
+               	movb	%cl, %sil
+               	movq	-0x350(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %ax
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movw	%cx, %r15w
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x330(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x340(%rbp)
                	movq	-0x2a8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L89>
-<L89>:
-               	movq	%rax, %rcx
+               	movq	%r8, 0x20(%rsp)
+               	movq	%r12, 0x28(%rsp)
+               	movq	%r13, 0x30(%rsp)
+               	movq	%rbx, 0x38(%rsp)
+               	movq	%rdx, 0x40(%rsp)
+               	movq	%rsi, 0x48(%rsp)
+               	movq	%rax, 0x50(%rsp)
+               	movq	%r15, 0x58(%rsp)
+               	movq	-0x330(%rbp), %r8
+               	movq	%r8, 0x60(%rsp)
+               	movq	-0x338(%rbp), %r8
+               	movq	%r8, 0x68(%rsp)
+               	movq	%rcx, 0x70(%rsp)
+               	movq	-0x340(%rbp), %r8
+               	movq	%r8, 0x78(%rsp)
                	movq	-0x2b0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L90>
-<L90>:
-               	movq	%rax, %rcx
+               	movq	%r8, %rcx
                	movq	-0x2b8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L92>
-<L92>:
-               	movq	%rdi, %rcx
+               	movq	%rdi, %r8
+               	movq	%r14, %r9
+               	callq	 <L11>
+<L11>:
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rcx
                	movq	%rax, %rdx
-               	callq	 <L93>
-<L93>:
-               	movq	-0x2e8(%rbp), %rbx
-               	movq	-0x2f0(%rbp), %rdi
-               	movq	-0x2f8(%rbp), %rsi
-               	movq	-0x300(%rbp), %r12
-               	movq	-0x308(%rbp), %r13
-               	movq	-0x310(%rbp), %r14
-               	movq	-0x318(%rbp), %r15
+               	callq	 <L12>
+<L12>:
+               	movq	-0x358(%rbp), %rbx
+               	movq	-0x360(%rbp), %rdi
+               	movq	-0x368(%rbp), %rsi
+               	movq	-0x370(%rbp), %r12
+               	movq	-0x378(%rbp), %r13
+               	movq	-0x380(%rbp), %r14
+               	movq	-0x388(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_mixed.dis
+++ b/test/golden/x86_64-windows/call/call_mixed.dis
@@ -74,238 +74,643 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.mixed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1f0, %rsp            # imm = 0x1F0
-               	movq	%rbx, -0xf8(%rbp)
-               	movq	%rdi, -0x100(%rbp)
-               	movq	%rsi, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movaps	%xmm6, -0x140(%rbp)
-               	movaps	%xmm7, -0x150(%rbp)
-               	movaps	%xmm8, -0x160(%rbp)
-               	movaps	%xmm9, -0x170(%rbp)
-               	movaps	%xmm10, -0x180(%rbp)
-               	movaps	%xmm11, -0x190(%rbp)
-               	movaps	%xmm12, -0x1a0(%rbp)
-               	movaps	%xmm13, -0x1b0(%rbp)
-               	movaps	%xmm14, -0x1c0(%rbp)
-               	movaps	%xmm15, -0x1d0(%rbp)
-               	movq	%rcx, %r9
-               	movq	%r9, -0x88(%rbp)
+               	subq	$0x2b0, %rsp            # imm = 0x2B0
+               	movq	%rbx, -0x1b8(%rbp)
+               	movq	%rdi, -0x1c0(%rbp)
+               	movq	%rsi, -0x1c8(%rbp)
+               	movq	%r12, -0x1d0(%rbp)
+               	movq	%r13, -0x1d8(%rbp)
+               	movq	%r14, -0x1e0(%rbp)
+               	movq	%r15, -0x1e8(%rbp)
+               	movaps	%xmm6, -0x200(%rbp)
+               	movaps	%xmm7, -0x210(%rbp)
+               	movaps	%xmm8, -0x220(%rbp)
+               	movaps	%xmm9, -0x230(%rbp)
+               	movaps	%xmm10, -0x240(%rbp)
+               	movaps	%xmm11, -0x250(%rbp)
+               	movaps	%xmm12, -0x260(%rbp)
+               	movaps	%xmm13, -0x270(%rbp)
+               	movaps	%xmm14, -0x280(%rbp)
+               	movaps	%xmm15, -0x290(%rbp)
+               	movq	%rcx, %rbx
                	movss	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1,2,3]
-               	movl	%r8d, %esi
+               	movl	%r8d, %r9d
+               	movq	%r9, -0xa8(%rbp)
                	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
-               	movq	0x30(%rbp), %rcx
+               	movq	0x30(%rbp), %rdx
                	movq	$0x0, -0x10(%rbp)
                	movq	$0x0, -0x8(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x10(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x8(%rbp)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x10(%rbp)
+               	movl	0x8(%rdx), %esi
+               	movl	%esi, -0x8(%rbp)
                	movups	-0x10(%rbp), %xmm8
-               	movq	0x38(%rbp), %rdi
-               	movsd	0x40(%rbp), %xmm9
-               	movq	0x48(%rbp), %r12
-               	movq	0x50(%rbp), %rcx
-               	movups	(%rcx), %xmm0
-               	movsd	0x58(%rbp), %xmm10
-               	movq	0x60(%rbp), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	movsd	0x68(%rbp), %xmm11
-               	movq	0x70(%rbp), %r8
+               	movq	0x38(%rbp), %r8
                	movq	%r8, -0xa0(%rbp)
+               	movsd	0x40(%rbp), %xmm9
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	0x50(%rbp), %rdi
+               	movups	(%rdi), %xmm0
+               	movsd	0x58(%rbp), %xmm10
+               	movq	0x60(%rbp), %rdi
+               	movsd	0x68(%rbp), %xmm11
+               	movq	0x70(%rbp), %r12
                	movsd	0x78(%rbp), %xmm12
                	movsd	0x80(%rbp), %xmm1
-               	movq	0x88(%rbp), %r15
+               	movq	0x88(%rbp), %r13
                	movsd	0x90(%rbp), %xmm13
-               	movq	0x98(%rbp), %r8
-               	movq	%r8, -0x98(%rbp)
+               	movq	0x98(%rbp), %r14
                	movq	0xa0(%rbp), %r11
-               	movq	%r11, -0xb8(%rbp)
-               	movq	0xa8(%rbp), %r8
+               	movq	%r11, -0x1a8(%rbp)
+               	movq	0xa8(%rbp), %r15
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0xb0(%rbp)
+               	leaq	-0x30(%rbp), %r8
                	movq	%r8, -0x90(%rbp)
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x30(%rbp), %r14
-               	leaq	-0x38(%rbp), %r13
+               	leaq	-0x38(%rbp), %r8
+               	movq	%r8, -0x98(%rbp)
                	movups	%xmm8, -0x48(%rbp)
-               	movq	-0x48(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x40(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	movups	%xmm0, (%r14)
-               	movsd	%xmm1, (%r13)
-               	callq	 <L0>
+               	movq	-0x48(%rbp), %rdx
+               	movq	-0xb0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x40(%rbp), %edx
+               	movq	-0xb0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x90(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x98(%rbp), %r8
+               	movsd	%xmm1, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0xb8(%rbp)
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L1>
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	movd	%xmm6, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xb8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L4>
+               	movq	-0xa8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xc8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
+               	movq	%xmm7, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L7>
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L8>
+               	movq	-0xb0(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L9>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L10>
+               	movq	-0xb0(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	leaq	(%r14), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0xc8(%rbp)
-               	movss	-0xc8(%rbp), %xmm1
-               	callq	 <L11>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x108(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r14), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0xd8(%rbp)
-               	movss	-0xd8(%rbp), %xmm1
-               	callq	 <L12>
+               	movq	-0xb0(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x108(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	callq	 <L13>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x118(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	callq	 <L14>
+               	movq	-0x118(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x120(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movd	%xmm9, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x120(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x128(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L18>
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x130(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	-0x88(%rbp), %r9
+               	movzwq	%r9w, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
-               	callq	 <L19>
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x140(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	leaq	(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0xe8(%rbp)
-               	movss	-0xe8(%rbp), %xmm1
-               	callq	 <L20>
+               	movq	-0x90(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x140(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r13), %rdx
-               	movss	(%rdx), %xmm1
-               	callq	 <L21>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x150(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
 <L21>:
+               	movq	-0x90(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x150(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x160(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movq	-0x90(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x160(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x170(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	-0x90(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x170(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x180(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movq	%xmm10, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x180(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x190(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movq	-0x190(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x198(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movd	%xmm11, %eax
+               	movl	%eax, %edx
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L32>
+<L32>:
+               	movzbq	%r12b, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L33>
+<L33>:
+               	movq	%xmm12, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L34>
+<L34>:
+               	movq	-0x98(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L35>
+<L35>:
+               	movq	-0x98(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L36>
+<L36>:
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L37>
+<L37>:
+               	movd	%xmm13, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L38>
+<L38>:
+               	movslq	%r14d, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L39>
+<L39>:
+               	movq	-0x1a8(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rcx
                	movq	%r15, %rdx
-               	callq	 <L22>
-<L22>:
+               	callq	 <L41>
+<L41>:
+               	imulq	%r13, %rdi
+               	addq	%rdi, %rbx
+               	subq	%r15, %rbx
                	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	movsd	-0xb8(%rbp), %xmm1
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	%r15, %rdx
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	%rdx, %rbx
-               	movq	-0x90(%rbp), %r8
-               	subq	%r8, %rbx
                	movq	%rbx, %rdx
-               	callq	 <L27>
-<L27>:
+               	callq	 <L42>
+<L42>:
+               	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
+               	mulss	%xmm11, %xmm0
+               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
+               	addss	%xmm0, %xmm1
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	subss	%xmm13, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm11, %xmm1
-               	movss	%xmm6, %xmm5            # xmm5 = xmm6[0],xmm5[1,2,3]
-               	addss	%xmm1, %xmm5
-               	movss	%xmm5, %xmm1            # xmm1 = xmm5[0],xmm1[1,2,3]
-               	subss	%xmm13, %xmm1
-               	callq	 <L28>
-<L28>:
+               	movq	%rbx, %rdx
+               	callq	 <L43>
+<L43>:
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	mulsd	%xmm12, %xmm0
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	addsd	%xmm0, %xmm1
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	subsd	-0x1a8(%rbp), %xmm0
+               	movq	%xmm0, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	mulsd	%xmm12, %xmm1
-               	movsd	%xmm7, %xmm5            # xmm5 = xmm7[0],xmm5[1]
-               	addsd	%xmm1, %xmm5
-               	movsd	%xmm5, %xmm1            # xmm1 = xmm5[0],xmm1[1]
-               	subsd	-0xb8(%rbp), %xmm1
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
+               	callq	 <L44>
+<L44>:
                	leaq	-0x54(%rbp), %rdx
+               	movq	-0x90(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movss	(%rbx), %xmm0
                	leaq	(%rdx), %rbx
-               	movl	-0xc8(%rbp), %r11d
-               	movl	%r11d, (%rbx)
+               	movss	%xmm0, (%rbx)
+               	movq	-0x90(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
+               	movss	(%rbx), %xmm0
                	leaq	0x4(%rdx), %rbx
-               	movl	-0xd8(%rbp), %r11d
-               	movl	%r11d, (%rbx)
+               	movss	%xmm0, (%rbx)
+               	movq	-0x98(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movss	(%rbx), %xmm0
                	leaq	0x8(%rdx), %rbx
-               	movl	-0xe8(%rbp), %r11d
-               	movl	%r11d, (%rbx)
+               	movss	%xmm0, (%rbx)
                	movq	$0x0, -0x64(%rbp)
                	movq	$0x0, -0x5c(%rbp)
                	movq	(%rdx), %rbx
@@ -324,38 +729,43 @@ Disassembly of section .text:
                	movl	%edx, 0x8(%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L45>
+<L45>:
                	leaq	0x4(%rbx), %rdx
                	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L46>
+<L46>:
                	leaq	0x8(%rbx), %rdx
                	movss	(%rdx), %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x140(%rbp), %xmm6
-               	movaps	-0x150(%rbp), %xmm7
-               	movaps	-0x160(%rbp), %xmm8
-               	movaps	-0x170(%rbp), %xmm9
-               	movaps	-0x180(%rbp), %xmm10
-               	movaps	-0x190(%rbp), %xmm11
-               	movaps	-0x1a0(%rbp), %xmm12
-               	movaps	-0x1b0(%rbp), %xmm13
-               	movaps	-0x1c0(%rbp), %xmm14
-               	movaps	-0x1d0(%rbp), %xmm15
-               	movq	-0xf8(%rbp), %rbx
-               	movq	-0x100(%rbp), %rdi
-               	movq	-0x108(%rbp), %rsi
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	callq	 <L47>
+<L47>:
+               	movaps	-0x200(%rbp), %xmm6
+               	movaps	-0x210(%rbp), %xmm7
+               	movaps	-0x220(%rbp), %xmm8
+               	movaps	-0x230(%rbp), %xmm9
+               	movaps	-0x240(%rbp), %xmm10
+               	movaps	-0x250(%rbp), %xmm11
+               	movaps	-0x260(%rbp), %xmm12
+               	movaps	-0x270(%rbp), %xmm13
+               	movaps	-0x280(%rbp), %xmm14
+               	movaps	-0x290(%rbp), %xmm15
+               	movq	-0x1b8(%rbp), %rbx
+               	movq	-0x1c0(%rbp), %rdi
+               	movq	-0x1c8(%rbp), %rsi
+               	movq	-0x1d0(%rbp), %r12
+               	movq	-0x1d8(%rbp), %r13
+               	movq	-0x1e0(%rbp), %r14
+               	movq	-0x1e8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -382,69 +792,67 @@ Disassembly of section .text:
                	movaps	%xmm14, -0x370(%rbp)
                	movaps	%xmm15, -0x380(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
+               	leaq	-0xd8(%rbp), %rsi
+               	leaq	(%rsi), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rcx
 <L0>:
-               	leaq	-0xc0(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xc0, %rdx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %r8
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x1d8(%rbp)
                	movq	$0x0, %r8
                	movq	%r8, -0x200(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
-               	jb	 <L4>
-               	jmp	 <L36>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L35>
+<L3>:
                	movq	%r13, %rax
                	imulq	$0xb, %rax, %rax
                	movq	%rax, %r14
                	addq	%rbx, %r14
-               	leaq	-0xcc(%rbp), %rax
+               	leaq	-0xc(%rbp), %rax
                	leaq	0x80(%rsi), %rcx
                	movq	(%rcx), %rdx
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
+<L5>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x197>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x196>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1a3>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1a2>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x88(%rsi), %rcx
@@ -452,21 +860,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f3>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f2>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1ff>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1fe>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x90(%rsi), %rcx
@@ -474,21 +882,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x250>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x24f>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x25c>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x25b>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0xe8(%rbp)
@@ -504,21 +912,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L11>
+               	jl	 <L10>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L12>
-<L11>:
+               	jmp	 <L11>
+<L10>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L12>:
+<L11>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2e4>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2e3>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2f0>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2ef>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0xa0(%rsi), %rcx
@@ -526,21 +934,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x340>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x33f>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x34c>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x34b>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0xa8(%rsi), %rcx
@@ -548,21 +956,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L15>
+               	jl	 <L14>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L16>
-<L15>:
+               	jmp	 <L15>
+<L14>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L16>:
+<L15>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x39d>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x39c>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3a9>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3a8>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0xb0(%rsi), %rcx
@@ -570,21 +978,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L16>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L18>:
+<L17>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3fa>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3f9>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x406>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x405>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm7
@@ -594,21 +1002,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L19>
+               	jl	 <L18>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
-<L19>:
+               	jmp	 <L19>
+<L18>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L20>:
+<L19>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x461>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x460>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x46d>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x46c>
                	leaq	(%r15), %rax
                	movss	%xmm0, (%rax)
                	leaq	(%rsi), %r8
@@ -616,8 +1024,8 @@ Disassembly of section .text:
                	movq	-0x248(%rbp), %r8
                	movq	(%r8), %rcx
                	addq	%r14, %rcx
-               	callq	 <L21>
-<L21>:
+               	callq	 <L20>
+<L20>:
                	leaq	0x4(%r15), %rcx
                	movss	%xmm0, (%rcx)
                	movsd	(%r15), %xmm8
@@ -627,8 +1035,8 @@ Disassembly of section .text:
                	addq	%r14, %r15
                	leaq	0x8(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L22>
-<L22>:
+               	callq	 <L21>
+<L21>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x10(%rsi), %rax
                	movq	(%rax), %rcx
@@ -639,21 +1047,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdx          # imm = 0xFFFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L23>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L24>
-<L23>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L24>:
+<L23>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x515>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x514>
                	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x523>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x522>
                	leaq	0x20(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x258(%rbp)
@@ -662,8 +1070,8 @@ Disassembly of section .text:
                	movq	%r8, -0x1c8(%rbp)
                	movq	-0x1c8(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L25>
-<L25>:
+               	callq	 <L24>
+<L24>:
                	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
                	leaq	0x30(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -678,21 +1086,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5c3>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5c2>
                	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x5d1>
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x5d0>
                	leaq	0x40(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x1e8(%rbp)
@@ -701,8 +1109,8 @@ Disassembly of section .text:
                	movq	%r8, -0x1f0(%rbp)
                	movq	-0x1f0(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L28>
-<L28>:
+               	callq	 <L27>
+<L27>:
                	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
                	leaq	0x50(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -717,21 +1125,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L28>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L29>
+<L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L30>:
+<L29>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x670>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x66f>
                	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x67e>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x67d>
                	movsd	%xmm14, -0x268(%rbp)
                	leaq	0x60(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -741,8 +1149,8 @@ Disassembly of section .text:
                	movq	%r8, -0x218(%rbp)
                	movq	-0x218(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L31>
-<L31>:
+               	callq	 <L30>
+<L30>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	leaq	0x70(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -758,21 +1166,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L33>:
+<L32>:
                	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x72c>
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x72b>
                	movsd	%xmm3, %xmm2            # xmm2 = xmm3[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x738>
+               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x737>
                	leaq	0x8(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x238(%rbp)
@@ -812,43 +1220,43 @@ Disassembly of section .text:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	movq	-0x250(%rbp), %r8
                	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %rdi
                	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rdi, %rdx
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r13
                	movq	%rax, %r8
                	movq	%r8, -0x1d8(%rbp)
                	movq	%rdi, %r8
                	movq	%r8, -0x200(%rbp)
                	cmpq	$0x3, %r13
-               	jb	 <L4>
-<L36>:
-               	leaq	-0xd8(%rbp), %rax
+               	jb	 <L3>
+<L35>:
+               	leaq	-0x18(%rbp), %rax
                	movq	-0x200(%rbp), %r8
                	movq	%r8, %rcx
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L37>
+               	jl	 <L36>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L38>
-<L37>:
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L38>:
+<L37>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b4>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b0>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8c0>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8bc>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%rsi), %rcx
@@ -856,21 +1264,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L40>:
+<L39>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x90d>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x909>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x919>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x915>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%rsi), %rcx
@@ -878,21 +1286,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L41>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L41>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x967>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x963>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x973>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x96f>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -908,21 +1316,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L43>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9f8>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9f4>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa04>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa00>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%rsi), %rcx
@@ -930,21 +1338,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L45>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa51>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa4d>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa5d>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa59>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%rsi), %rcx
@@ -952,21 +1360,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L47>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xaab>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xaa7>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xab7>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xab3>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%rsi), %rcx
@@ -974,21 +1382,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L49>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb05>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb01>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb11>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb0d>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm7
@@ -998,27 +1406,27 @@ Disassembly of section .text:
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L51>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb69>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb65>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb75>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb71>
                	leaq	(%rbx), %rax
                	movss	%xmm0, (%rax)
                	leaq	0x48(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L52>
+<L52>:
                	leaq	0x4(%rbx), %rax
                	movss	%xmm0, (%rax)
                	movsd	(%rbx), %xmm8
@@ -1026,8 +1434,8 @@ Disassembly of section .text:
                	movq	(%rax), %rbx
                	leaq	0x8(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L54>
-<L54>:
+               	callq	 <L53>
+<L53>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x10(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1037,27 +1445,27 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L55>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L56>:
+<L55>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xbfb>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xbf7>
                	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xc09>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xc05>
                	leaq	0x20(%rsi), %rax
                	movq	(%rax), %r12
                	leaq	0x28(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L57>
-<L57>:
+               	callq	 <L56>
+<L56>:
                	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
                	leaq	0x30(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1067,27 +1475,27 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L58>
+               	jl	 <L57>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L59>
-<L58>:
+               	jmp	 <L58>
+<L57>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L59>:
+<L58>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc72>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc6e>
                	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xc80>
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xc7c>
                	leaq	0x40(%rsi), %rax
                	movq	(%rax), %r14
                	leaq	0x48(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L60>
-<L60>:
+               	callq	 <L59>
+<L59>:
                	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
                	leaq	0x50(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1097,29 +1505,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L60>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L61>
+<L60>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L62>:
+<L61>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xce8>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xce4>
                	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xcf6>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xcf2>
                	movsd	%xmm14, -0x280(%rbp)
                	leaq	0x60(%rsi), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x270(%rbp)
                	leaq	0x68(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L63>
-<L63>:
+               	callq	 <L62>
+<L62>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	leaq	0x70(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1130,21 +1538,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rax          # imm = 0xFFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L64>
+               	jl	 <L63>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L65>
-<L64>:
+               	jmp	 <L64>
+<L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L65>:
+<L64>:
                	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xd74>
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xd70>
                	movsd	%xmm3, %xmm2            # xmm2 = xmm3[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xd80>
+               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xd7c>
                	leaq	0x8(%rsi), %rax
                	movq	(%rax), %rcx
                	movups	%xmm6, -0x180(%rbp)
@@ -1178,13 +1586,13 @@ Disassembly of section .text:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	movl	%edi, %r8d
                	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
-               	callq	 <L66>
-<L66>:
+               	callq	 <L65>
+<L65>:
                	movq	%rax, %rbx
                	leaq	0x18(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L67>
-<L67>:
+               	callq	 <L66>
+<L66>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x28(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1194,27 +1602,27 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L68>
+               	jl	 <L67>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L69>
-<L68>:
+               	jmp	 <L68>
+<L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L69>:
+<L68>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xeb0>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xeac>
                	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xebe>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xeba>
                	leaq	0x48(%rsi), %rax
                	movq	(%rax), %r12
                	leaq	0x58(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L70>
-<L70>:
+               	callq	 <L69>
+<L69>:
                	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
                	leaq	0x68(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1224,27 +1632,27 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L71>
+               	jl	 <L70>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L71>
+<L70>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L72>:
+<L71>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xf27>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xf23>
                	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xf35>
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xf31>
                	leaq	0x88(%rsi), %rax
                	movq	(%rax), %r14
                	leaq	0x98(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L72>
+<L72>:
                	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
                	leaq	0xa8(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1254,29 +1662,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L74>
+               	jl	 <L73>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L75>
-<L74>:
+               	jmp	 <L74>
+<L73>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L75>:
+<L74>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xfa9>
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xfa5>
                	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xfb7>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xfb3>
                	movsd	%xmm14, -0x298(%rbp)
                	leaq	0x10(%rsi), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x288(%rbp)
                	leaq	0x20(%rsi), %rax
                	movq	(%rax), %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	leaq	0x30(%rsi), %rax
                	movq	(%rax), %rcx
@@ -1286,21 +1694,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L77>
+               	jl	 <L76>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L78>
-<L77>:
+               	jmp	 <L77>
+<L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L78>:
+<L77>:
                	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x102d>
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x1029>
                	movsd	%xmm3, %xmm2            # xmm2 = xmm3[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x1039>
+               	divsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x1035>
                	movups	%xmm6, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %rcx
                	movq	%rcx, -0x1a0(%rbp)
@@ -1332,13 +1740,13 @@ Disassembly of section .text:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	movl	%edi, %r8d
                	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
-               	callq	 <L79>
-<L79>:
+               	callq	 <L78>
+<L78>:
                	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rax, %rdx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L79>
+<L79>:
                	movaps	-0x2f0(%rbp), %xmm6
                	movaps	-0x300(%rbp), %xmm7
                	movaps	-0x310(%rbp), %xmm8

--- a/test/golden/x86_64-windows/call/call_rec_edge.dis
+++ b/test/golden/x86_64-windows/call/call_rec_edge.dis
@@ -14,39 +14,81 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e9>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rdi, -0x20(%rbp)
                	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%rcx, %rax
                	leaq	-0x8(%rbp), %rbx
                	leaq	(%rdx), %rsi
                	movzbl	(%rsi), %edi
                	leaq	0x1(%rdx), %rsi
                	movq	(%rsi), %rdx
                	movq	%rdx, (%rbx)
-               	movq	%rdi, %rdx
-               	callq	 <L0>
+               	movzbq	%dil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L1>
-               	jmp	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	leaq	(%rbx,%rdi), %rax
-               	movzbl	(%rax), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x8, %rdi
-               	jb	 <L1>
+               	leaq	(%rbx,%rdx), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rsi, %rax
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L5>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rdi
                	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -54,28 +96,144 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movl	(%rbx), %esi
                	leaq	0x4(%rdx), %rbx
                	movl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movl	(%rbx), %r12d
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	movl	(%rbx), %edx
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L2>
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_edge.fold_e16>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -84,24 +242,60 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_rec_edge.fold_e16>:
+<corpus.cases.call.call_rec_edge.fold_e16f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
+               	movsd	(%rbx), %xmm0
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rdi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movsd	(%rbx), %xmm1
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -109,49 +303,62 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_rec_edge.fold_e16f>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	leaq	(%rdx), %rbx
-               	movsd	(%rbx), %xmm1
-               	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
-<L1>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movq	-0x8(%rbp), %rbx
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
 <corpus.cases.call.call_rec_edge.fold_e16m>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rsi, -0x10(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movq	(%rbx), %rsi
                	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movsd	(%rbx), %xmm0
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x20(%rbp), %xmm6
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rsi
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -159,11 +366,14 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e17>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%rdi, -0x30(%rbp)
                	movq	%rsi, -0x38(%rbp)
                	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%rcx, %rax
                	leaq	-0x11(%rbp), %rbx
                	movq	(%rdx), %rsi
                	movq	0x8(%rdx), %rdi
@@ -173,31 +383,68 @@ Disassembly of section .text:
                	movb	%r12b, 0x10(%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x10, %rdi
-               	jb	 <L1>
-               	jmp	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %rdi
+               	leaq	0x1(%rbx), %rsi
+               	leaq	(%rsi,%rdx), %rdi
+               	movzbl	(%rdi), %esi
+               	movzbq	%sil, %rdi
                	movq	%rax, %rsi
-               	cmpq	$0x10, %rdi
-               	jb	 <L1>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rdx
                	movq	%rsi, %rax
+               	cmpq	$0x10, %rdx
+               	jb	 <L2>
+<L5>:
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %rdi
                	movq	-0x38(%rbp), %rsi
                	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -205,56 +452,96 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	$0x9, %rdx
-               	callq	 <L0>
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rsi, -0x10(%rbp)
+               	movq	%rcx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0xc, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x9, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0xc, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	$0x11, %rdx
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x10, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	$0x4, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x11, %rdx
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
@@ -262,11 +549,11 @@ Disassembly of section .text:
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
@@ -274,9 +561,23 @@ Disassembly of section .text:
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rcx
+               	movq	$0x8, %rdx
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rcx
+               	movq	$0x8, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rcx
+               	movq	$0x1, %rdx
+               	callq	 <L20>
+<L20>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -284,382 +585,377 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.take_edge>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x280, %rsp            # imm = 0x280
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%rdi, -0x1e0(%rbp)
-               	movq	%rsi, -0x1e8(%rbp)
-               	movq	%r12, -0x1f0(%rbp)
-               	movq	%r13, -0x1f8(%rbp)
-               	movq	%r14, -0x200(%rbp)
-               	movq	%r15, -0x208(%rbp)
-               	movaps	%xmm6, -0x220(%rbp)
-               	movaps	%xmm7, -0x230(%rbp)
-               	movaps	%xmm8, -0x240(%rbp)
-               	movaps	%xmm9, -0x250(%rbp)
-               	movaps	%xmm10, -0x260(%rbp)
-               	movq	%rcx, %rbx
-               	movl	%r8d, %esi
-               	movq	%r9, %rcx
+               	subq	$0x370, %rsp            # imm = 0x370
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%rdi, -0x2d0(%rbp)
+               	movq	%rsi, -0x2d8(%rbp)
+               	movq	%r12, -0x2e0(%rbp)
+               	movq	%r13, -0x2e8(%rbp)
+               	movq	%r14, -0x2f0(%rbp)
+               	movq	%r15, -0x2f8(%rbp)
+               	movaps	%xmm6, -0x310(%rbp)
+               	movaps	%xmm7, -0x320(%rbp)
+               	movaps	%xmm8, -0x330(%rbp)
+               	movaps	%xmm9, -0x340(%rbp)
+               	movaps	%xmm10, -0x350(%rbp)
+               	movq	%rcx, %r10
+               	movq	%r10, -0x1f0(%rbp)
+               	movl	%r8d, %ebx
+               	movq	%r9, %rsi
                	movsd	0x30(%rbp), %xmm6
                	movq	0x38(%rbp), %rdi
                	movq	0x40(%rbp), %r12
                	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r8, -0x228(%rbp)
                	movq	0x50(%rbp), %r14
                	movq	0x58(%rbp), %r15
                	movq	0x60(%rbp), %r8
-               	movq	%r8, -0x108(%rbp)
+               	movq	%r8, -0x220(%rbp)
                	movq	0x68(%rbp), %r8
-               	movq	%r8, -0x110(%rbp)
+               	movq	%r8, -0x1f8(%rbp)
                	movq	0x70(%rbp), %r8
-               	movq	%r8, -0x118(%rbp)
+               	movq	%r8, -0x200(%rbp)
                	movq	0x78(%rbp), %r8
-               	movq	%r8, -0x120(%rbp)
+               	movq	%r8, -0x208(%rbp)
                	movsd	0x80(%rbp), %xmm7
                	movq	0x88(%rbp), %r8
-               	movq	%r8, -0x128(%rbp)
-               	leaq	-0x8(%rbp), %r8
-               	movq	%r8, -0x130(%rbp)
-               	leaq	-0x10(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	leaq	-0x18(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	leaq	-0x20(%rbp), %r8
-               	movq	%r8, -0x148(%rbp)
-               	leaq	-0x28(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	leaq	-0x30(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	leaq	(%rdx), %r13
-               	movzbl	(%r13), %r8d
-               	movq	%r8, -0x168(%rbp)
-               	leaq	0x1(%rdx), %r13
-               	movq	(%r13), %rdx
-               	movq	-0x130(%rbp), %r8
-               	movq	%rdx, (%r8)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r13d
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x178(%rbp)
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdi
-               	leaq	(%r12), %rcx
-               	movsd	(%rcx), %xmm8
-               	leaq	0x8(%r12), %rcx
-               	movsd	(%rcx), %xmm9
-               	movq	-0x160(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %r12
-               	movq	-0x160(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movsd	(%rcx), %xmm10
-               	leaq	-0x41(%rbp), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	(%r15), %rcx
+               	movq	%r8, -0x210(%rbp)
+               	leaq	-0x9(%rbp), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	(%rdx), %rax
+               	movb	0x8(%rdx), %r13b
+               	movq	-0x218(%rbp), %r8
+               	movq	%rax, (%r8)
+               	movq	-0x218(%rbp), %r8
+               	movb	%r13b, 0x8(%r8)
+               	leaq	-0x18(%rbp), %r13
+               	movq	(%rsi), %rax
+               	movl	0x8(%rsi), %edx
+               	movq	%rax, (%r13)
+               	movl	%edx, 0x8(%r13)
+               	leaq	-0x28(%rbp), %rsi
+               	movq	(%rdi), %rax
+               	movq	0x8(%rdi), %rdx
+               	movq	%rax, (%rsi)
+               	movq	%rdx, 0x8(%rsi)
+               	leaq	(%r12), %rax
+               	movsd	(%rax), %xmm8
+               	leaq	0x8(%r12), %rax
+               	movsd	(%rax), %xmm9
+               	movq	-0x228(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	(%rax), %rdi
+               	movq	-0x228(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movsd	(%rax), %xmm10
+               	leaq	-0x39(%rbp), %r12
+               	movq	(%r15), %rax
                	movq	0x8(%r15), %rdx
                	movb	0x10(%r15), %r8b
-               	movq	%r8, -0x190(%rbp)
-               	movq	-0x188(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x188(%rbp), %r8
-               	movq	%rdx, 0x8(%r8)
-               	movq	-0x188(%rbp), %r8
-               	movq	-0x190(%rbp), %r9
-               	movb	%r9b, 0x10(%r8)
-               	movq	-0x108(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movzbl	(%rcx), %r15d
-               	movq	-0x108(%rbp), %r8
-               	leaq	0x1(%r8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x138(%rbp), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	%rax, (%r12)
+               	movq	%rdx, 0x8(%r12)
+               	movq	-0x230(%rbp), %r8
+               	movb	%r8b, 0x10(%r12)
+               	leaq	-0x42(%rbp), %r15
+               	movq	-0x220(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x220(%rbp), %r8
+               	movb	0x8(%r8), %dl
+               	movq	%rax, (%r15)
+               	movb	%dl, 0x8(%r15)
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1f8(%rbp), %r9
+               	movl	0x8(%r9), %r8d
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0x2b8(%rbp), %r8
                	movq	%rdx, (%r8)
-               	movq	-0x110(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x198(%rbp)
-               	movq	-0x110(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	-0x110(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	-0x118(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	-0x118(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1b8(%rbp)
-               	leaq	-0x52(%rbp), %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x120(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x120(%rbp), %r8
-               	movq	0x8(%r8), %rdx
-               	movq	-0x120(%rbp), %r9
+               	movq	-0x2b8(%rbp), %r8
+               	movq	-0x238(%rbp), %r9
+               	movl	%r9d, 0x8(%r8)
+               	leaq	-0x60(%rbp), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x200(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x240(%rbp), %r8
+               	movq	-0x248(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	leaq	-0x71(%rbp), %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x208(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	-0x208(%rbp), %r9
                	movb	0x10(%r9), %r8b
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%rdx, 0x8(%r8)
-               	movq	-0x1c0(%rbp), %r8
-               	movq	-0x1c8(%rbp), %r9
+               	movq	%r8, -0x260(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x250(%rbp), %r8
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x250(%rbp), %r8
+               	movq	-0x260(%rbp), %r9
                	movb	%r9b, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
+               	leaq	-0xcc(%rbp), %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x218(%rbp), %r9
+               	movb	0x8(%r9), %r8b
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x270(%rbp), %r8
+               	movq	-0x278(%rbp), %r9
+               	movb	%r9b, 0x8(%r8)
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x270(%rbp), %r9
+               	movb	0x8(%r9), %r8b
+               	movq	%r8, -0x280(%rbp)
+               	movq	%rdx, -0xdc(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movb	%r8b, -0xd4(%rbp)
+               	leaq	-0xdc(%rbp), %rdx
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L1>
 <L1>:
-               	movq	-0x130(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x140(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x150(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	%rax, %rcx
-               	movq	-0x168(%rbp), %r8
+               	movq	%rax, %rdx
+               	movl	%ebx, %r8d
+               	movq	%r8, -0x288(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x288(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x1d0(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
-               	jmp	 <L5>
+               	movq	%rax, %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	leaq	-0xe8(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	(%r13), %rdx
+               	movl	0x8(%r13), %ebx
+               	movq	-0x298(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x298(%rbp), %r8
+               	movl	%ebx, 0x8(%r8)
+               	movq	-0x298(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x298(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movq	%rdx, -0xf8(%rbp)
+               	movl	%ebx, -0xf0(%rbp)
+               	leaq	-0xf8(%rbp), %rdx
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L3>
 <L3>:
-               	movq	-0x150(%rbp), %r8
-               	movq	-0x1d0(%rbp), %r9
-               	leaq	(%r8,%r9), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rbx, %rcx
+               	movq	%rax, %rdx
+               	movq	%xmm6, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rbx
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
                	movq	%rax, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x1d0(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	-0x108(%rbp), %rbx
+               	movq	(%rsi), %r13
+               	movq	0x8(%rsi), %rdx
+               	movq	%r13, (%rbx)
+               	movq	%rdx, 0x8(%rbx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movq	%rdx, -0x118(%rbp)
+               	movq	%rsi, -0x110(%rbp)
+               	leaq	-0x118(%rbp), %rdx
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L5>
 <L5>:
-               	movq	%rbx, %rcx
-               	movl	%esi, %edx
-               	callq	 <L6>
+               	movq	%rax, %rdx
+               	movq	%xmm8, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L7>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %rbx
+               	xorq	%r13, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	-0x170(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L8>
+               	movq	%xmm9, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	-0x178(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L9>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %rbx
+               	xorq	%r13, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L10>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L11>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L12>
+               	movq	%xmm10, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	movq	%rdx, %rcx
+               	movq	%r14, %rdx
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
+               	movq	%rax, %rdx
+               	leaq	-0x129(%rbp), %rbx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movb	0x10(%r12), %r13b
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movb	%r13b, 0x10(%rbx)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movb	0x10(%rbx), %r13b
+               	movq	%rsi, -0x141(%rbp)
+               	movq	%rdi, -0x139(%rbp)
+               	movb	%r13b, -0x131(%rbp)
+               	leaq	-0x141(%rbp), %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	movq	%rax, %rdx
+               	leaq	-0x14a(%rbp), %rbx
+               	movq	(%r15), %rsi
+               	movb	0x8(%r15), %dil
+               	movq	%rsi, (%rbx)
+               	movb	%dil, 0x8(%rbx)
+               	movq	(%rbx), %rsi
+               	movb	0x8(%rbx), %dil
+               	movq	%rsi, -0x15a(%rbp)
+               	movb	%dil, -0x152(%rbp)
+               	leaq	-0x15a(%rbp), %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	%rax, %rdx
+               	leaq	-0x168(%rbp), %rbx
+               	movq	-0x2b8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2b8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movq	%rsi, (%rbx)
+               	movl	%edi, 0x8(%rbx)
+               	movq	(%rbx), %rax
+               	movl	0x8(%rbx), %esi
+               	movq	%rax, -0x178(%rbp)
+               	movl	%esi, -0x170(%rbp)
+               	leaq	-0x178(%rbp), %rax
+               	movq	%rdx, %rcx
+               	movq	%rax, %rdx
                	callq	 <L17>
 <L17>:
-               	leaq	-0xa7(%rbp), %rcx
-               	movq	-0x188(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x188(%rbp), %r8
-               	movq	0x8(%r8), %rbx
-               	movq	-0x188(%rbp), %r8
-               	movb	0x10(%r8), %sil
-               	movq	%rdx, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movb	%sil, 0x10(%rcx)
-               	leaq	-0xb8(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movb	0x10(%rcx), %dil
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movb	%dil, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	leaq	-0x188(%rbp), %rdx
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x240(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	%rbx, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %rsi
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%rsi, -0x190(%rbp)
+               	leaq	-0x198(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x10, %rdi
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L20>
-<L20>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %rdi
-               	jb	 <L19>
-<L21>:
-               	movq	-0x138(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x148(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0x148(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x158(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	%rsi, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
-               	jb	 <L23>
-               	jmp	 <L25>
-<L23>:
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rsi), %rax
-               	movzbl	(%rax), %edx
-               	movq	%rbx, %rcx
-               	callq	 <L24>
-<L24>:
-               	addq	$0x1, %rsi
-               	movq	%rax, %rbx
-               	cmpq	$0x8, %rsi
-               	jb	 <L23>
-<L25>:
-               	movq	%rbx, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	-0x1a0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movq	-0x1a8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	-0x1b0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L30>
-<L30>:
-               	leaq	-0xc9(%rbp), %rcx
-               	movq	-0x1c0(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x1c0(%rbp), %r8
-               	movq	0x8(%r8), %rbx
-               	movq	-0x1c0(%rbp), %r8
-               	movb	0x10(%r8), %sil
-               	movq	%rdx, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movb	%sil, 0x10(%rcx)
-               	leaq	-0xda(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movb	0x10(%rcx), %dil
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movb	%dil, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x10, %rdi
-               	jb	 <L32>
-               	jmp	 <L34>
-<L32>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L33>
-<L33>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %rdi
-               	jb	 <L32>
-<L34>:
-               	movq	%rsi, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L36>
-<L36>:
-               	leaq	-0xeb(%rbp), %rcx
-               	leaq	-0xfc(%rbp), %rdx
-               	movq	-0x188(%rbp), %r8
+               	leaq	-0x1a9(%rbp), %rdx
+               	movq	-0x250(%rbp), %r8
                	movq	(%r8), %rbx
-               	movq	-0x188(%rbp), %r8
+               	movq	-0x250(%rbp), %r8
                	movq	0x8(%r8), %rsi
-               	movq	-0x188(%rbp), %r8
+               	movq	-0x250(%rbp), %r8
                	movb	0x10(%r8), %dil
                	movq	%rbx, (%rdx)
                	movq	%rsi, 0x8(%rdx)
@@ -667,117 +963,104 @@ Disassembly of section .text:
                	movq	(%rdx), %rbx
                	movq	0x8(%rdx), %rsi
                	movb	0x10(%rdx), %dil
-               	movq	%rbx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movb	%dil, 0x10(%rcx)
-               	leaq	(%rcx), %rdx
-               	movzbl	(%rdx), %ebx
-               	addl	$0x1, %ebx
-               	movb	%bl, (%rdx)
-               	movq	$0x0, %rdx
-               	cmpq	$0x10, %rdx
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
-               	leaq	0x1(%rcx), %rbx
-               	leaq	(%rbx,%rdx), %rsi
-               	movzbl	(%rsi), %ebx
-               	movb	%dl, %dil
-               	addl	%edi, %ebx
-               	addl	$0x1, %ebx
-               	movb	%bl, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x10, %rdx
-               	jb	 <L37>
-<L38>:
-               	leaq	-0x63(%rbp), %rdx
-               	movq	(%rcx), %rbx
-               	movq	0x8(%rcx), %rsi
-               	movb	0x10(%rcx), %dil
+               	movq	%rbx, -0x1c1(%rbp)
+               	movq	%rsi, -0x1b9(%rbp)
+               	movb	%dil, -0x1b1(%rbp)
+               	leaq	-0x1c1(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movd	%xmm7, %edx
+               	movl	%edx, %ebx
+               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rcx
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L21>
+<L21>:
+               	leaq	-0x1d2(%rbp), %rdx
+               	leaq	-0x1e3(%rbp), %rbx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movb	0x10(%r12), %r13b
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movb	%r13b, 0x10(%rbx)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movb	0x10(%rbx), %r13b
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movb	%r13b, 0x10(%rdx)
+               	leaq	(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	addl	$0x1, %esi
+               	movb	%sil, (%rbx)
+               	movq	$0x0, %rbx
+               	cmpq	$0x10, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	leaq	0x1(%rdx), %rsi
+               	leaq	(%rsi,%rbx), %rdi
+               	movzbl	(%rdi), %esi
+               	movb	%bl, %r13b
+               	addl	%r13d, %esi
+               	addl	$0x1, %esi
+               	movb	%sil, (%rdi)
+               	addq	$0x1, %rbx
+               	cmpq	$0x10, %rbx
+               	jb	 <L22>
+<L23>:
+               	leaq	-0x82(%rbp), %rbx
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movb	0x10(%rdx), %r13b
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movb	%r13b, 0x10(%rbx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movb	0x10(%rbx), %dil
+               	movq	%rdx, -0x9a(%rbp)
+               	movq	%rsi, -0x92(%rbp)
+               	movb	%dil, -0x8a(%rbp)
+               	leaq	-0x9a(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L24>
+<L24>:
+               	leaq	-0xab(%rbp), %rdx
+               	movq	(%r12), %rbx
+               	movq	0x8(%r12), %rsi
+               	movb	0x10(%r12), %dil
                	movq	%rbx, (%rdx)
                	movq	%rsi, 0x8(%rdx)
                	movb	%dil, 0x10(%rdx)
-               	leaq	-0x74(%rbp), %rbx
-               	movq	(%rdx), %rcx
+               	movq	(%rdx), %rbx
                	movq	0x8(%rdx), %rsi
                	movb	0x10(%rdx), %dil
-               	movq	%rcx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movb	%dil, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	movq	%rbx, -0xc3(%rbp)
+               	movq	%rsi, -0xbb(%rbp)
+               	movb	%dil, -0xb3(%rbp)
+               	leaq	-0xc3(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x10, %rdi
-               	jb	 <L40>
-               	jmp	 <L42>
-<L40>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L41>
-<L41>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %rdi
-               	jb	 <L40>
-<L42>:
-               	leaq	-0x85(%rbp), %rax
-               	movq	-0x188(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x188(%rbp), %r8
-               	movq	0x8(%r8), %rdx
-               	movq	-0x188(%rbp), %r8
-               	movb	0x10(%r8), %bl
-               	movq	%rcx, (%rax)
-               	movq	%rdx, 0x8(%rax)
-               	movb	%bl, 0x10(%rax)
-               	leaq	-0x96(%rbp), %rbx
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movb	0x10(%rax), %dil
-               	movq	%rcx, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movb	%dil, 0x10(%rbx)
-               	leaq	(%rbx), %rax
-               	movzbl	(%rax), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x10, %rdi
-               	jb	 <L44>
-               	jmp	 <L46>
-<L44>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L45>
-<L45>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %rdi
-               	jb	 <L44>
-<L46>:
-               	movq	%rsi, %rax
-               	movaps	-0x220(%rbp), %xmm6
-               	movaps	-0x230(%rbp), %xmm7
-               	movaps	-0x240(%rbp), %xmm8
-               	movaps	-0x250(%rbp), %xmm9
-               	movaps	-0x260(%rbp), %xmm10
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %rdi
-               	movq	-0x1e8(%rbp), %rsi
-               	movq	-0x1f0(%rbp), %r12
-               	movq	-0x1f8(%rbp), %r13
-               	movq	-0x200(%rbp), %r14
-               	movq	-0x208(%rbp), %r15
+               	callq	 <L25>
+<L25>:
+               	movaps	-0x310(%rbp), %xmm6
+               	movaps	-0x320(%rbp), %xmm7
+               	movaps	-0x330(%rbp), %xmm8
+               	movaps	-0x340(%rbp), %xmm9
+               	movaps	-0x350(%rbp), %xmm10
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %rdi
+               	movq	-0x2d8(%rbp), %rsi
+               	movq	-0x2e0(%rbp), %r12
+               	movq	-0x2e8(%rbp), %r13
+               	movq	-0x2f0(%rbp), %r14
+               	movq	-0x2f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1064,46 +1347,85 @@ Disassembly of section .text:
                	movaps	%xmm14, -0x4c0(%rbp)
                	movaps	%xmm15, -0x4d0(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0x9, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x9, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	$0xc, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0xc, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x10, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
                	movq	%rax, %rcx
-               	movq	$0x11, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
-               	movq	$0x4, %rdx
+               	movq	$0x11, %rdx
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
@@ -1111,19 +1433,19 @@ Disassembly of section .text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x1, %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
@@ -1135,24 +1457,32 @@ Disassembly of section .text:
                	callq	 <L17>
 <L17>:
                	movq	%rax, %rcx
-               	movq	$0x1, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L18>
 <L18>:
-               	leaq	-0x60(%rbp), %rsi
+               	movq	%rax, %rcx
+               	movq	$0x8, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rcx
+               	movq	$0x1, %rdx
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x88(%rbp), %rsi
                	leaq	(%rsi), %rdx
                	addq	$0x0, %rdx
                	movq	$0x60, %rdi
-<L19>:
+<L21>:
                	movq	$0x0, (%rdx)
                	addq	$0x8, %rdx
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
-               	jne	 <L19>
+               	jne	 <L21>
                	movq	$0x0, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-               	jmp	 <L21>
-<L20>:
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
                	movq	%rdx, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdi
@@ -1163,15 +1493,15 @@ Disassembly of section .text:
                	movq	%rdi, (%r12)
                	addq	$0x1, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-<L21>:
+               	jb	 <L22>
+<L23>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
-               	jb	 <L22>
-               	jmp	 <L43>
-<L22>:
+               	jb	 <L24>
+               	jmp	 <L45>
+<L24>:
                	movq	%r13, %rax
                	imulq	$0x11, %rax, %rax
                	movq	%rax, %r8
@@ -1186,7 +1516,7 @@ Disassembly of section .text:
                	leaq	0x8(%rsi), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x368(%rbp)
-               	leaq	-0x69(%rbp), %r8
+               	leaq	-0x9(%rbp), %r8
                	movq	%r8, -0x370(%rbp)
                	movq	-0x370(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -1199,9 +1529,9 @@ Disassembly of section .text:
                	movb	%r14b, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-               	jmp	 <L24>
-<L23>:
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
                	movq	%rax, %r14
                	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
@@ -1217,9 +1547,9 @@ Disassembly of section .text:
                	movb	%r15b, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-<L24>:
-               	leaq	-0x72(%rbp), %r8
+               	jb	 <L25>
+<L26>:
+               	leaq	-0x12(%rbp), %r8
                	movq	%r8, -0x380(%rbp)
                	movq	-0x370(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1235,7 +1565,7 @@ Disassembly of section .text:
                	movq	%r8, -0x378(%rbp)
                	leaq	0x18(%rsi), %rdx
                	movq	(%rdx), %r14
-               	leaq	-0x90(%rbp), %r8
+               	leaq	-0x94(%rbp), %r8
                	movq	%r8, -0x3a8(%rbp)
                	movl	%r14d, %r15d
                	movq	-0x3a8(%rbp), %r8
@@ -1257,17 +1587,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %r14            # imm = 0x3FF
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L25>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L26>:
+<L28>:
                	leaq	0x28(%rsi), %rax
                	movq	(%rax), %r14
                	movq	-0x360(%rbp), %r8
@@ -1290,25 +1620,6 @@ Disassembly of section .text:
                	andq	$0xffff, %rax           # imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L28>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x433>
-               	movq	-0x390(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movsd	%xmm2, (%rax)
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
                	jl	 <L29>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L30>
@@ -1321,7 +1632,26 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L30>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x480>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x510>
+               	movq	-0x390(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movsd	%xmm2, (%rax)
+               	andq	$0xfff, %r15            # imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L32>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x55d>
                	movq	-0x390(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1337,19 +1667,19 @@ Disassembly of section .text:
                	andq	$0x3ffff, %r15          # imm = 0x3FFFF
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L31>
+               	jl	 <L33>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L32>
-<L31>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L32>:
+<L34>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4fa>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x5d7>
                	movq	-0x398(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1376,9 +1706,9 @@ Disassembly of section .text:
                	movb	%dl, (%r14)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
                	movq	%rdx, %r14
                	imulq	$0x4, %r14, %r14
                	movq	%r14, %rcx
@@ -1394,8 +1724,8 @@ Disassembly of section .text:
                	movb	%r15b, (%rax)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L33>
-<L34>:
+               	jb	 <L35>
+<L36>:
                	leaq	-0x122(%rbp), %r8
                	movq	%r8, -0x3c0(%rbp)
                	movq	-0x3b8(%rbp), %r8
@@ -1426,9 +1756,9 @@ Disassembly of section .text:
                	movb	%r15b, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-               	jmp	 <L36>
-<L35>:
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
                	movq	%rax, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
@@ -1444,8 +1774,8 @@ Disassembly of section .text:
                	movb	%r14b, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-<L36>:
+               	jb	 <L37>
+<L38>:
                	leaq	-0x156(%rbp), %r8
                	movq	%r8, -0x3d8(%rbp)
                	movq	-0x3d0(%rbp), %r8
@@ -1507,9 +1837,9 @@ Disassembly of section .text:
                	movb	%dl, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
                	movq	%rax, %rdx
                	imulq	$0x4, %rdx, %rdx
                	movq	%rdx, %rcx
@@ -1525,8 +1855,8 @@ Disassembly of section .text:
                	movb	%r15b, (%r14)
                	addq	$0x1, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-<L38>:
+               	jb	 <L39>
+<L40>:
                	leaq	-0x1c2(%rbp), %rax
                	movq	-0x3f8(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1542,17 +1872,17 @@ Disassembly of section .text:
                	andq	$0xff, %r14
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L41>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L40>:
+<L42>:
                	leaq	0x18(%rsi), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x400(%rbp)
@@ -1651,19 +1981,19 @@ Disassembly of section .text:
                	movq	%r8, %rdx
                	movq	-0x378(%rbp), %r8
                	movq	-0x410(%rbp), %r9
-               	callq	 <L41>
-<L41>:
+               	callq	 <L43>
+<L43>:
                	movq	%rax, %r12
                	movq	%rdi, %rcx
                	movq	%r12, %rdx
-               	callq	 <L42>
-<L42>:
+               	callq	 <L44>
+<L44>:
                	addq	$0x1, %r13
                	movq	%rax, %rdi
                	cmpq	$0x3, %r13
-               	jb	 <L22>
-<L43>:
-               	leaq	-0x7b(%rbp), %rax
+               	jb	 <L24>
+<L45>:
+               	leaq	-0x1b(%rbp), %rax
                	movq	$0x0, (%rax)
                	movb	$0x0, 0x8(%rax)
                	movb	%r12b, %dl
@@ -1671,9 +2001,9 @@ Disassembly of section .text:
                	movb	%dl, (%rbx)
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-               	jmp	 <L45>
-<L44>:
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
                	movq	%rdx, %rbx
                	imulq	$0x8, %rbx, %rbx
                	movq	%rbx, %rcx
@@ -1687,9 +2017,9 @@ Disassembly of section .text:
                	movb	%r13b, (%r14)
                	addq	$0x1, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-<L45>:
-               	leaq	-0x84(%rbp), %r8
+               	jb	 <L46>
+<L47>:
+               	leaq	-0x24(%rbp), %r8
                	movq	%r8, -0x420(%rbp)
                	movq	(%rax), %rbx
                	movb	0x8(%rax), %r13b
@@ -1699,7 +2029,7 @@ Disassembly of section .text:
                	movb	%r13b, 0x8(%r8)
                	movl	%r12d, %r8d
                	movq	%r8, -0x418(%rbp)
-               	leaq	-0x9c(%rbp), %r8
+               	leaq	-0xa0(%rbp), %r8
                	movq	%r8, -0x448(%rbp)
                	movl	%r12d, %r13d
                	movq	-0x448(%rbp), %r8
@@ -1721,17 +2051,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %r13            # imm = 0x3FF
                	movq	%r13, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L48>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L47>:
+<L49>:
                	leaq	-0xc0(%rbp), %r8
                	movq	%r8, -0x430(%rbp)
                	movq	-0x430(%rbp), %r8
@@ -1749,26 +2079,6 @@ Disassembly of section .text:
                	andq	$0xffff, %r15           # imm = 0xFFFF
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L49>
-<L48>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L49>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xca1>
-               	movq	-0x438(%rbp), %r8
-               	leaq	(%r8), %r15
-               	movsd	%xmm2, (%r15)
-               	movq	%r12, %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
                	jl	 <L50>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L51>
@@ -1781,7 +2091,27 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L51>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xcf2>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xd7b>
+               	movq	-0x438(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movsd	%xmm2, (%r15)
+               	movq	%r12, %r15
+               	andq	$0xfff, %r15            # imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L52>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L53>
+<L52>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L53>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xdcc>
                	movq	-0x438(%rbp), %r8
                	leaq	0x8(%r8), %r15
                	movsd	%xmm2, (%r15)
@@ -1796,19 +2126,19 @@ Disassembly of section .text:
                	andq	$0x3ffff, %rax          # imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L52>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L53>
-<L52>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L53>:
+<L55>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xd69>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xe43>
                	movq	-0x440(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1826,9 +2156,9 @@ Disassembly of section .text:
                	movb	%r13b, (%rdx)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-               	jmp	 <L55>
-<L54>:
+               	jb	 <L56>
+               	jmp	 <L57>
+<L56>:
                	movq	%rdx, %r13
                	imulq	$0x4, %r13, %r13
                	movq	%r13, %rcx
@@ -1842,8 +2172,8 @@ Disassembly of section .text:
                	movb	%r14b, (%r15)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-<L55>:
+               	jb	 <L56>
+<L57>:
                	leaq	-0x144(%rbp), %r8
                	movq	%r8, -0x450(%rbp)
                	movq	(%rax), %r13
@@ -1865,9 +2195,9 @@ Disassembly of section .text:
                	movb	%r14b, (%r15)
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L56>
-               	jmp	 <L57>
-<L56>:
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
                	movq	%r14, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
@@ -1881,8 +2211,8 @@ Disassembly of section .text:
                	movb	%bl, (%rdx)
                	addq	$0x1, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L56>
-<L57>:
+               	jb	 <L58>
+<L59>:
                	leaq	-0x168(%rbp), %r8
                	movq	%r8, -0x458(%rbp)
                	movq	(%rax), %rbx
@@ -1935,9 +2265,9 @@ Disassembly of section .text:
                	movb	%dl, (%r15)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-               	jmp	 <L59>
-<L58>:
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
                	movq	%rdx, %r15
                	imulq	$0x4, %r15, %r15
                	movq	%r15, %rcx
@@ -1951,8 +2281,8 @@ Disassembly of section .text:
                	movb	%bl, (%rax)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-<L59>:
+               	jb	 <L60>
+<L61>:
                	leaq	-0x29a(%rbp), %rax
                	movq	(%r13), %rdx
                	movq	0x8(%r13), %rbx
@@ -1965,17 +2295,17 @@ Disassembly of section .text:
                	andq	$0xff, %rbx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L62>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L63>
+<L62>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L61>:
+<L63>:
                	leaq	0x20(%rsi), %rdx
                	movq	(%rdx), %rbx
                	movq	-0x420(%rbp), %r8
@@ -2067,12 +2397,12 @@ Disassembly of section .text:
                	movq	%r12, %rcx
                	movq	-0x418(%rbp), %r8
                	movq	%rsi, %r9
-               	callq	 <L62>
-<L62>:
+               	callq	 <L64>
+<L64>:
                	movq	%rdi, %rcx
                	movq	%rax, %rdx
-               	callq	 <L63>
-<L63>:
+               	callq	 <L65>
+<L65>:
                	movaps	-0x4c0(%rbp), %xmm14
                	movaps	-0x4d0(%rbp), %xmm15
                	movq	-0x478(%rbp), %rbx

--- a/test/golden/x86_64-windows/call/call_rec_large.dis
+++ b/test/golden/x86_64-windows/call/call_rec_large.dis
@@ -14,139 +14,79 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.fold_l24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rdi
-               	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_rec_large.fold_l24f>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movaps	%xmm7, -0x30(%rbp)
-               	leaq	(%rdx), %rbx
-               	movsd	(%rbx), %xmm1
-               	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	leaq	0x10(%rdx), %rbx
-               	movsd	(%rbx), %xmm7
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L2>
-<L2>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movaps	-0x30(%rbp), %xmm7
-               	movq	-0x8(%rbp), %rbx
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_rec_large.fold_l24m>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movaps	%xmm6, -0x30(%rbp)
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
-               	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	leaq	0x10(%rdx), %rbx
-               	movl	(%rbx), %edi
-               	leaq	0x14(%rdx), %rbx
-               	movl	(%rbx), %r12d
-               	movq	%rsi, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L3>
-<L3>:
-               	movaps	-0x30(%rbp), %xmm6
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_rec_large.fold_l32>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movq	(%rbx), %rsi
                	leaq	0x8(%rdx), %rbx
                	movq	(%rbx), %rdi
                	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	leaq	0x18(%rdx), %rbx
-               	movq	(%rbx), %r13
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -156,14 +96,320 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_rec_large.fold_l32n>:
+<corpus.cases.call.call_rec_large.fold_l24f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm1
+               	leaq	0x10(%rdx), %rbx
+               	movsd	(%rbx), %xmm2
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_large.fold_l24m>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	leaq	0x10(%rdx), %rbx
+               	movl	(%rbx), %edi
+               	leaq	0x14(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_large.fold_l32>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdi
+               	leaq	0x10(%rdx), %rbx
+               	movq	(%rbx), %r12
+               	leaq	0x18(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_large.fold_l32n>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	leaq	(%rbx), %rsi
                	movq	(%rsi), %rdi
@@ -174,25 +420,60 @@ Disassembly of section .text:
                	movq	(%rdx), %r12
                	leaq	0x8(%rsi), %rdx
                	movq	(%rdx), %rsi
-               	movq	%rdi, %rdx
-               	callq	 <L0>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
                	movq	%rax, %rcx
                	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
+               	callq	 <L4>
+<L4>:
                	movq	%rax, %rcx
                	movq	%rsi, %rdx
-               	callq	 <L3>
-<L3>:
+               	callq	 <L5>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -283,20 +564,20 @@ Disassembly of section .text:
                	movq	%rsi, %rdx
                	callq	 <L0>
 <L0>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
                	movl	%edi, %edx
+               	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rcx
                	movl	%r12d, %edx
+               	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
@@ -397,488 +678,817 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.take_large>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x210, %rsp            # imm = 0x210
-               	movq	%rbx, -0x138(%rbp)
-               	movq	%rdi, -0x140(%rbp)
-               	movq	%rsi, -0x148(%rbp)
-               	movq	%r12, -0x150(%rbp)
-               	movq	%r13, -0x158(%rbp)
-               	movq	%r14, -0x160(%rbp)
-               	movq	%r15, -0x168(%rbp)
-               	movaps	%xmm6, -0x180(%rbp)
-               	movaps	%xmm7, -0x190(%rbp)
-               	movaps	%xmm8, -0x1a0(%rbp)
-               	movaps	%xmm9, -0x1b0(%rbp)
-               	movaps	%xmm10, -0x1c0(%rbp)
-               	movaps	%xmm11, -0x1d0(%rbp)
-               	movaps	%xmm12, -0x1e0(%rbp)
-               	movaps	%xmm13, -0x1f0(%rbp)
-               	movq	%rcx, %rbx
-               	movq	%r8, %rcx
+               	subq	$0x450, %rsp            # imm = 0x450
+               	movq	%rbx, -0x378(%rbp)
+               	movq	%rdi, -0x380(%rbp)
+               	movq	%rsi, -0x388(%rbp)
+               	movq	%r12, -0x390(%rbp)
+               	movq	%r13, -0x398(%rbp)
+               	movq	%r14, -0x3a0(%rbp)
+               	movq	%r15, -0x3a8(%rbp)
+               	movaps	%xmm6, -0x3c0(%rbp)
+               	movaps	%xmm7, -0x3d0(%rbp)
+               	movaps	%xmm8, -0x3e0(%rbp)
+               	movaps	%xmm9, -0x3f0(%rbp)
+               	movaps	%xmm10, -0x400(%rbp)
+               	movaps	%xmm11, -0x410(%rbp)
+               	movaps	%xmm12, -0x420(%rbp)
+               	movaps	%xmm13, -0x430(%rbp)
+               	movq	%rcx, %r10
+               	movq	%r10, -0x158(%rbp)
+               	movq	%r8, %rbx
                	movq	%r9, %rsi
                	movq	0x30(%rbp), %rdi
                	movq	0x38(%rbp), %r12
                	movq	0x40(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
+               	movq	%r8, -0x188(%rbp)
                	movsd	0x48(%rbp), %xmm6
-               	movq	0x50(%rbp), %r14
-               	movq	0x58(%rbp), %r15
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x190(%rbp)
                	movq	0x60(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r8, -0x180(%rbp)
                	movq	0x68(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
+               	movq	%r8, -0x160(%rbp)
                	movq	0x70(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0x168(%rbp)
                	movsd	0x78(%rbp), %xmm7
                	movq	0x80(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	leaq	(%rdx), %r13
-               	movq	(%r13), %r8
-               	movq	%r8, -0x30(%rbp)
-               	leaq	0x8(%rdx), %r13
-               	movq	(%r13), %r8
-               	movq	%r8, -0x38(%rbp)
-               	leaq	0x10(%rdx), %r13
-               	movq	(%r13), %r8
-               	movq	%r8, -0x40(%rbp)
-               	leaq	(%rcx), %rdx
-               	movsd	(%rdx), %xmm8
-               	leaq	0x8(%rcx), %rdx
-               	movsd	(%rdx), %xmm9
-               	leaq	0x10(%rcx), %rdx
-               	movsd	(%rdx), %xmm10
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	leaq	0x8(%rsi), %rcx
-               	movsd	(%rcx), %xmm11
-               	leaq	0x10(%rsi), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	0x14(%rsi), %rcx
-               	movl	(%rcx), %esi
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x50(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x10(%r12), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x60(%rbp)
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %r12
-               	movq	-0x28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r8, -0x170(%rbp)
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r15
+               	movq	-0x178(%rbp), %r8
+               	movq	%rax, (%r8)
+               	movq	-0x178(%rbp), %r8
+               	movq	%r13, 0x8(%r8)
+               	movq	-0x178(%rbp), %r8
+               	movq	%r15, 0x10(%r8)
+               	leaq	(%rbx), %rax
+               	movsd	(%rax), %xmm8
+               	leaq	0x8(%rbx), %rax
+               	movsd	(%rax), %xmm9
+               	leaq	0x10(%rbx), %rax
+               	movsd	(%rax), %xmm10
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%rsi), %rax
+               	movsd	(%rax), %xmm11
+               	leaq	0x10(%rsi), %rax
+               	movl	(%rax), %r13d
+               	leaq	0x14(%rsi), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x38(%rbp), %r15
+               	movq	(%r12), %rax
+               	movq	0x8(%r12), %rdx
+               	movq	0x10(%r12), %r14
+               	movq	0x18(%r12), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	%rax, (%r15)
+               	movq	%rdx, 0x8(%r15)
+               	movq	%r14, 0x10(%r15)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, 0x18(%r15)
+               	movq	-0x188(%rbp), %r8
+               	leaq	(%r8), %rax
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %r14
+               	movq	-0x188(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x68(%rbp)
-               	leaq	0x8(%rcx), %rdx
+               	movq	%r8, -0x1a8(%rbp)
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	-0x28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x78(%rbp)
-               	leaq	0x8(%rcx), %rdx
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x80(%rbp)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x90(%rbp)
-               	leaq	0x10(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x98(%rbp)
-               	leaq	0x18(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x20(%r14), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	leaq	0x28(%r14), %rcx
-               	movq	(%rcx), %r14
-               	leaq	(%r15), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x8(%r15), %rcx
-               	movsd	(%rcx), %xmm12
-               	leaq	0x10(%r15), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x14(%r15), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x18(%r15), %rcx
-               	movsd	(%rcx), %xmm13
-               	leaq	0x20(%r15), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x28(%r15), %rcx
-               	movq	(%rcx), %r15
-               	movq	-0x8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x28(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x130(%rbp)
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movsd	(%rdx), %xmm12
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movl	(%rdx), %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movl	(%rdx), %r8d
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movsd	(%rdx), %xmm13
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x200(%rbp)
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x180(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x180(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x208(%rbp), %r8
+               	movq	-0x210(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x208(%rbp), %r8
+               	movq	-0x218(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x160(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x160(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x160(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x220(%rbp), %r8
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x220(%rbp), %r8
+               	movq	-0x230(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x220(%rbp), %r8
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, 0x18(%r8)
+               	movq	-0x168(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x268(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x178(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x178(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x278(%rbp), %r8
+               	movq	-0x280(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x278(%rbp), %r8
+               	movq	-0x288(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x278(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x278(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x278(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	%rdx, -0xa0(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, -0x90(%rbp)
+               	leaq	-0xa0(%rbp), %rdx
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L2>
+               	movq	%rax, %rdx
+               	movq	%xmm8, %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
+               	movq	-0x2b0(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L3>
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x2a8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x2b0(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x2c0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L4>
+               	movq	%xmm9, %r8
+               	movq	%r8, -0x2d0(%rbp)
+               	movq	-0x2a8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L5>
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x2d0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x2c8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x2e0(%rbp)
+               	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x2d8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2e8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L6>
+               	movq	%xmm10, %r8
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	-0x2c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x300(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L7>
+               	movq	-0x300(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x2f0(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x308(%rbp)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x300(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x310(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x310(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x300(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
+               	movq	-0x2f0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
-               	callq	 <L9>
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x318(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x320(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x330(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x330(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	-0x48(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L10>
+               	movq	%xmm11, %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x318(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x340(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L11>
+               	movq	-0x348(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x338(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	-0x340(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rbx, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x348(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x340(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L12>
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x350(%rbp)
+               	movq	-0x340(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movq	-0x50(%rbp), %r8
+               	movq	%r13, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x350(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L13>
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r13
+               	movq	%rbx, %r8
+               	movq	%r8, -0x358(%rbp)
+               	cmpq	$0x8, %r13
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L14>
+               	movl	%esi, %r8d
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L15>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x360(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %rdx
+               	xorq	%r13, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
+               	movl	%edi, %edx
+               	movq	%rbx, %rcx
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
+               	leaq	-0xc0(%rbp), %rbx
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %rdi
+               	movq	0x10(%r15), %r13
+               	movq	0x18(%r15), %rdx
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movq	%r13, 0x10(%rbx)
+               	movq	%rdx, 0x18(%rbx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movq	0x10(%rbx), %rdi
+               	movq	0x18(%rbx), %r13
+               	movq	%rdx, -0xe0(%rbp)
+               	movq	%rsi, -0xd8(%rbp)
+               	movq	%rdi, -0xd0(%rbp)
+               	movq	%r13, -0xc8(%rbp)
+               	leaq	-0xe0(%rbp), %rdx
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rcx
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L18>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L19>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L20>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L21>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
+               	movq	%rdx, %rcx
+               	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L22>
 <L22>:
-               	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x370(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L23>
 <L23>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x1b8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L27>
 <L27>:
                	movq	%rax, %rcx
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L28>
 <L28>:
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L29>
 <L29>:
                	movq	%rax, %rcx
-               	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L30>
 <L30>:
                	movq	%rax, %rcx
-               	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L31>
 <L31>:
+               	movq	%xmm12, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1]
                	callq	 <L32>
 <L32>:
+               	movq	-0x1e8(%rbp), %r8
+               	movl	%r8d, %edx
                	movq	%rax, %rcx
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L33>
 <L33>:
+               	movq	-0x1f0(%rbp), %r8
+               	movl	%r8d, %edx
                	movq	%rax, %rcx
-               	movq	%r15, %rdx
                	callq	 <L34>
 <L34>:
+               	movq	%xmm13, %rdx
                	movq	%rax, %rcx
-               	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rcx
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0x1f8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x200(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L37>
 <L37>:
+               	leaq	-0xf8(%rbp), %rdx
+               	movq	-0x208(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x208(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	%rbx, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	movq	%rdi, 0x10(%rdx)
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rbx, -0x110(%rbp)
+               	movq	%rsi, -0x108(%rbp)
+               	movq	%rdi, -0x100(%rbp)
+               	leaq	-0x110(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L38>
 <L38>:
+               	leaq	-0x130(%rbp), %rdx
+               	movq	-0x220(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x220(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x220(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0x220(%rbp), %r8
+               	movq	0x18(%r8), %r12
+               	movq	%rbx, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	movq	%rdi, 0x10(%rdx)
+               	movq	%r12, 0x18(%rdx)
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r12
+               	movq	%rbx, -0x150(%rbp)
+               	movq	%rsi, -0x148(%rbp)
+               	movq	%rdi, -0x140(%rbp)
+               	movq	%r12, -0x138(%rbp)
+               	leaq	-0x150(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rcx
-               	movq	-0xf8(%rbp), %r8
+               	movq	-0x240(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rcx
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x248(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rcx
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x250(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rcx
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x258(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rcx
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x260(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rcx
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x268(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L45>
 <L45>:
+               	movd	%xmm7, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rcx
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L49>
-<L49>:
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r8
                	movq	%r8, %rdx
                	addq	$0x1, %rdx
-               	movq	%r14, %rbx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rbx
                	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
                	xorq	%r11, %rbx
                	movq	%rax, %rcx
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rcx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rcx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x1d0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L55>
 <L55>:
                	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x1c0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L57>
 <L57>:
                	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x1d0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L58>
 <L58>:
                	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L59>
 <L59>:
-               	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L61>
-<L61>:
-               	movaps	-0x180(%rbp), %xmm6
-               	movaps	-0x190(%rbp), %xmm7
-               	movaps	-0x1a0(%rbp), %xmm8
-               	movaps	-0x1b0(%rbp), %xmm9
-               	movaps	-0x1c0(%rbp), %xmm10
-               	movaps	-0x1d0(%rbp), %xmm11
-               	movaps	-0x1e0(%rbp), %xmm12
-               	movaps	-0x1f0(%rbp), %xmm13
-               	movq	-0x138(%rbp), %rbx
-               	movq	-0x140(%rbp), %rdi
-               	movq	-0x148(%rbp), %rsi
-               	movq	-0x150(%rbp), %r12
-               	movq	-0x158(%rbp), %r13
-               	movq	-0x160(%rbp), %r14
-               	movq	-0x168(%rbp), %r15
+               	movaps	-0x3c0(%rbp), %xmm6
+               	movaps	-0x3d0(%rbp), %xmm7
+               	movaps	-0x3e0(%rbp), %xmm8
+               	movaps	-0x3f0(%rbp), %xmm9
+               	movaps	-0x400(%rbp), %xmm10
+               	movaps	-0x410(%rbp), %xmm11
+               	movaps	-0x420(%rbp), %xmm12
+               	movaps	-0x430(%rbp), %xmm13
+               	movq	-0x378(%rbp), %rbx
+               	movq	-0x380(%rbp), %rdi
+               	movq	-0x388(%rbp), %rsi
+               	movq	-0x390(%rbp), %r12
+               	movq	-0x398(%rbp), %r13
+               	movq	-0x3a0(%rbp), %r14
+               	movq	-0x3a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1293,6 +1903,8 @@ Disassembly of section .text:
                	movaps	%xmm14, -0x7c0(%rbp)
                	movaps	%xmm15, -0x7d0(%rbp)
                	movq	%rcx, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	$0x18, %rdx
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
@@ -1304,7 +1916,7 @@ Disassembly of section .text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
-               	movq	$0x18, %rdx
+               	movq	$0x20, %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
@@ -1312,7 +1924,7 @@ Disassembly of section .text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
-               	movq	$0x20, %rdx
+               	movq	$0x30, %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
@@ -1320,7 +1932,7 @@ Disassembly of section .text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	$0x30, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
@@ -1332,7 +1944,7 @@ Disassembly of section .text:
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
@@ -1340,44 +1952,40 @@ Disassembly of section .text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	$0x10, %rdx
+               	movq	$0x14, %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movq	$0x14, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	$0x10, %rdx
+               	movq	$0x28, %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movq	$0x28, %rdx
+               	movq	$0x18, %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
-               	movq	$0x18, %rdx
+               	movq	$0x28, %rdx
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	$0x28, %rdx
-               	callq	 <L17>
-<L17>:
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x90(%rbp), %rsi
                	leaq	(%rsi), %rcx
                	addq	$0x0, %rcx
                	movq	$0x60, %rdx
-<L18>:
+<L17>:
                	movq	$0x0, (%rcx)
                	addq	$0x8, %rcx
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L18>
+               	jne	 <L17>
                	movq	$0x0, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-               	jmp	 <L20>
-<L19>:
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
                	movq	%rcx, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
@@ -1388,16 +1996,16 @@ Disassembly of section .text:
                	movq	%rdx, (%rdi)
                	addq	$0x1, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-<L20>:
+               	jb	 <L18>
+<L19>:
                	movq	%rax, %r8
                	movq	%r8, -0x6e8(%rbp)
                	movq	$0x0, %r12
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
-               	jb	 <L21>
-               	jmp	 <L37>
-<L21>:
+               	jb	 <L20>
+               	jmp	 <L36>
+<L20>:
                	movq	%r13, %rax
                	imulq	$0x13, %rax, %rax
                	movq	%rax, %r8
@@ -1410,7 +2018,7 @@ Disassembly of section .text:
                	addq	%r8, %r14
                	leaq	0x8(%rsi), %rcx
                	movq	(%rcx), %rdx
-               	leaq	-0x78(%rbp), %r15
+               	leaq	-0x18(%rbp), %r15
                	leaq	(%r15), %rcx
                	movq	%rdx, (%rcx)
                	movq	%rdx, %rcx
@@ -1429,19 +2037,19 @@ Disassembly of section .text:
                	andq	$0xffff, %rdx           # imm = 0xFFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2a7>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2ac>
                	movq	-0x758(%rbp), %r8
                	leaq	(%r8), %rdx
                	movsd	%xmm1, (%rdx)
@@ -1449,38 +2057,38 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2f7>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2fc>
                	movq	-0x758(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movsd	%xmm1, (%rdx)
                	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x345>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x34a>
                	movq	-0x758(%rbp), %r8
                	leaq	0x10(%r8), %rcx
                	movsd	%xmm1, (%rcx)
@@ -1498,19 +2106,19 @@ Disassembly of section .text:
                	andq	$0x7fff, %rcx           # imm = 0x7FFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3cd>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3d2>
                	movq	-0x5f0(%rbp), %r8
                	leaq	0x8(%r8), %rcx
                	movsd	%xmm1, (%rcx)
@@ -1618,17 +2226,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm6
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm6
                	addsd	%xmm6, %xmm6
-<L31>:
+<L30>:
                	leaq	0x40(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x650(%rbp)
@@ -1675,8 +2283,8 @@ Disassembly of section .text:
                	movq	%r8, -0x658(%rbp)
                	movq	-0x658(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L32>
-<L32>:
+               	callq	 <L31>
+<L31>:
                	movq	-0x658(%rbp), %r8
                	leaq	0x50(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -1772,17 +2380,17 @@ Disassembly of section .text:
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L33>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L34>
-<L33>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L34>:
+<L33>:
                	leaq	0x10(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x690(%rbp)
@@ -1954,21 +2562,21 @@ Disassembly of section .text:
                	movq	%r8, %rdx
                	movq	-0x6a8(%rbp), %r8
                	movq	-0x6b0(%rbp), %r9
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	movq	%rax, %r12
                	movq	-0x6e8(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r12, %rdx
-               	callq	 <L36>
-<L36>:
+               	callq	 <L35>
+<L35>:
                	addq	$0x1, %r13
                	movq	%rax, %r8
                	movq	%r8, -0x6e8(%rbp)
                	cmpq	$0x3, %r13
-               	jb	 <L21>
-<L37>:
-               	leaq	-0x90(%rbp), %rbx
+               	jb	 <L20>
+<L36>:
+               	leaq	-0x30(%rbp), %rbx
                	leaq	(%rbx), %rax
                	movq	%r12, (%rax)
                	movq	%r12, %rax
@@ -1985,57 +2593,57 @@ Disassembly of section .text:
                	andq	$0xffff, %rax           # imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L38>
+               	jl	 <L37>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L39>
-<L38>:
+               	jmp	 <L38>
+<L37>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L39>:
+<L38>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd90>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd92>
                	leaq	(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r12, %rax
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L40>
+               	jl	 <L39>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
+               	jmp	 <L40>
+<L39>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L41>:
+<L40>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xdda>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xddc>
                	leaq	0x8(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r12, %rax
                	andq	$0x3ffff, %rax          # imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L42>
+               	jl	 <L41>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L43>
-<L42>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L43>:
+<L42>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xe24>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xe26>
                	leaq	0x10(%r13), %rax
                	movsd	%xmm1, (%rax)
                	leaq	-0xf0(%rbp), %r14
@@ -2045,19 +2653,19 @@ Disassembly of section .text:
                	andq	$0x7fff, %rax           # imm = 0x7FFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L44>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L45>
-<L44>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L45>:
+<L44>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xe7b>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xe7d>
                	leaq	0x8(%r14), %rax
                	movsd	%xmm1, (%rax)
                	movl	%r12d, %eax
@@ -2136,17 +2744,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rcx            # imm = 0x3FF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L45>
                	cvtsi2sd	%r11, %xmm6
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L46>
+<L45>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm6
                	addsd	%xmm6, %xmm6
-<L47>:
+<L46>:
                	leaq	-0x240(%rbp), %r8
                	movq	%r8, -0x710(%rbp)
                	movq	-0x710(%rbp), %r8
@@ -2183,8 +2791,8 @@ Disassembly of section .text:
                	movq	-0x718(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r12, %rdx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L47>
+<L47>:
                	movq	-0x718(%rbp), %r8
                	leaq	0x50(%rsi), %rcx
                	movq	(%rcx), %r8
@@ -2280,17 +2888,17 @@ Disassembly of section .text:
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L49>:
                	leaq	0x18(%rsi), %rcx
                	movq	(%rcx), %r8
                	movq	%r8, -0x750(%rbp)
@@ -2432,13 +3040,13 @@ Disassembly of section .text:
                	movq	%r12, %rcx
                	movq	%rbx, %r8
                	movq	%rsi, %r9
-               	callq	 <L51>
-<L51>:
+               	callq	 <L50>
+<L50>:
                	movq	-0x6e8(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rax, %rdx
-               	callq	 <L52>
-<L52>:
+               	callq	 <L51>
+<L51>:
                	movaps	-0x7b0(%rbp), %xmm6
                	movaps	-0x7c0(%rbp), %xmm14
                	movaps	-0x7d0(%rbp), %xmm15

--- a/test/golden/x86_64-windows/call/call_rec_small.dis
+++ b/test/golden/x86_64-windows/call/call_rec_small.dis
@@ -14,68 +14,35 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r1>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_rec_small.fold_r2>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	-0x7(%rbp), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rbx, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_rec_small.fold_r4>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rdi, -0x20(%rbp)
                	movq	%rsi, -0x28(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
                	leaq	-0x8(%rbp), %rdx
                	movzbl	(%rdx), %ebx
-               	leaq	-0x7(%rbp), %rdx
-               	movzbl	(%rdx), %esi
-               	leaq	-0x6(%rbp), %rdx
-               	movzwl	(%rdx), %edi
-               	movq	%rbx, %rdx
-               	callq	 <L0>
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L2>
-<L2>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rdi
                	movq	-0x28(%rbp), %rsi
@@ -83,13 +50,169 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_rec_small.fold_r8>:
+<corpus.cases.call.call_rec_small.fold_r2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rdi, -0x20(%rbp)
                	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rdx, -0x8(%rbp)
+               	leaq	-0x8(%rbp), %rdx
+               	movzbl	(%rdx), %ebx
+               	leaq	-0x7(%rbp), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_small.fold_r4>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rdx, -0x8(%rbp)
+               	leaq	-0x8(%rbp), %rdx
+               	movzbl	(%rdx), %ebx
+               	leaq	-0x7(%rbp), %rdx
+               	movzbl	(%rdx), %esi
+               	leaq	-0x6(%rbp), %rdx
+               	movzwl	(%rdx), %edi
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movzwq	%di, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_rec_small.fold_r8>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
                	leaq	-0x8(%rbp), %rdx
                	movl	(%rdx), %ebx
@@ -98,19 +221,73 @@ Disassembly of section .text:
                	leaq	-0x2(%rbp), %rdx
                	movzbl	(%rdx), %edi
                	movl	%ebx, %edx
-               	callq	 <L0>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L2>
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movzbq	%dil, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rdi
                	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -118,58 +295,176 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	$0x1, %rdx
-               	callq	 <L0>
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rsi, -0x10(%rbp)
+               	movq	%rcx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0x2, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x8, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x2, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x4, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	$0x2, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x2, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
                	movq	%rax, %rcx
                	movq	$0x4, %rdx
-               	callq	 <L7>
-<L7>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L8>
-<L8>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L9>
-<L9>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rcx
                	movq	$0x2, %rdx
-               	callq	 <L10>
-<L10>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rcx
                	movq	$0x4, %rdx
-               	callq	 <L11>
-<L11>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rcx
                	movq	$0x6, %rdx
-               	callq	 <L12>
-<L12>:
+               	callq	 <L19>
+<L19>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -177,238 +472,259 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.take_small>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x110, %rsp            # imm = 0x110
-               	movq	%rbx, -0x98(%rbp)
-               	movq	%rdi, -0xa0(%rbp)
-               	movq	%rsi, -0xa8(%rbp)
-               	movq	%r12, -0xb0(%rbp)
-               	movq	%r13, -0xb8(%rbp)
-               	movq	%r14, -0xc0(%rbp)
-               	movq	%r15, -0xc8(%rbp)
-               	movaps	%xmm6, -0xe0(%rbp)
-               	movaps	%xmm7, -0xf0(%rbp)
-               	movq	%rcx, %rbx
+               	subq	$0x190, %rsp            # imm = 0x190
+               	movq	%rbx, -0x118(%rbp)
+               	movq	%rdi, -0x120(%rbp)
+               	movq	%rsi, -0x128(%rbp)
+               	movq	%r12, -0x130(%rbp)
+               	movq	%r13, -0x138(%rbp)
+               	movq	%r14, -0x140(%rbp)
+               	movq	%r15, -0x148(%rbp)
+               	movaps	%xmm6, -0x160(%rbp)
+               	movaps	%xmm7, -0x170(%rbp)
+               	movq	%rcx, %r10
+               	movq	%r10, -0xb0(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	movl	%r8d, %esi
+               	movl	%r8d, %ebx
                	movq	%r9, -0x10(%rbp)
                	movsd	0x30(%rbp), %xmm6
-               	leaq	0x38(%rbp), %rcx
-               	movq	0x40(%rbp), %rdi
-               	leaq	0x48(%rbp), %rdx
-               	leaq	0x50(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
+               	leaq	0x38(%rbp), %rdx
+               	movq	0x40(%rbp), %rsi
+               	leaq	0x48(%rbp), %rdi
+               	leaq	0x50(%rbp), %r12
                	leaq	0x58(%rbp), %r13
-               	leaq	0x60(%rbp), %r14
-               	leaq	0x68(%rbp), %r15
+               	leaq	0x60(%rbp), %r8
+               	movq	%r8, -0xc8(%rbp)
+               	leaq	0x68(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
                	movsd	0x70(%rbp), %xmm7
                	movq	0x78(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	leaq	-0x8(%rbp), %r12
-               	movzbl	(%r12), %r8d
-               	movq	%r8, -0x28(%rbp)
-               	leaq	-0x10(%rbp), %r12
-               	movzbl	(%r12), %r8d
-               	movq	%r8, -0x30(%rbp)
-               	leaq	-0xf(%rbp), %r12
-               	movzbl	(%r12), %r8d
-               	movq	%r8, -0x38(%rbp)
-               	leaq	(%rcx), %r12
-               	movzbl	(%r12), %r8d
-               	movq	%r8, -0x40(%rbp)
-               	leaq	0x1(%rcx), %r12
-               	movzbl	(%r12), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	0x2(%rcx), %r12
-               	movzwl	(%r12), %r8d
-               	movq	%r8, -0x50(%rbp)
-               	leaq	(%rdx), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0x4(%rdx), %rcx
-               	movzwl	(%rcx), %r8d
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x6(%rdx), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x68(%rbp)
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x70(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	(%r14), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x78(%rbp)
-               	leaq	0x1(%r14), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x80(%rbp)
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %r14d
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x4(%r15), %rcx
-               	movzwl	(%rcx), %r8d
-               	movq	%r8, -0x90(%rbp)
-               	leaq	0x6(%r15), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0xa8(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	leaq	-0x12(%rbp), %r8
+               	movq	%r8, -0x108(%rbp)
+               	movw	-0x10(%rbp), %r15w
+               	movq	-0x108(%rbp), %r8
+               	movw	%r15w, (%r8)
+               	leaq	-0x16(%rbp), %r15
+               	movl	(%rdx), %r14d
+               	movl	%r14d, (%r15)
+               	leaq	-0x20(%rbp), %r14
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%r14)
+               	leaq	(%r12), %rdx
+               	movzbl	(%rdx), %edi
+               	leaq	-0x22(%rbp), %r12
+               	movw	(%r13), %dx
+               	movw	%dx, (%r12)
+               	leaq	-0x26(%rbp), %r13
+               	movq	-0xc8(%rbp), %r8
+               	movl	(%r8), %edx
+               	movl	%edx, (%r13)
+               	leaq	-0x30(%rbp), %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	movq	-0xb8(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	-0x28(%rbp), %r8
+               	movq	-0xe8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L2>
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xe0(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
+               	movl	%ebx, %edx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	leaq	-0x32(%rbp), %rbx
+               	movq	-0x108(%rbp), %r8
+               	movw	(%r8), %dx
+               	movw	%dx, (%rbx)
+               	movq	$0x0, -0x40(%rbp)
+               	movw	(%rbx), %ax
+               	movw	%ax, -0x40(%rbp)
+               	movq	-0x40(%rbp), %rdx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L4>
 <L4>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L5>
 <L5>:
+               	leaq	-0x44(%rbp), %rdx
+               	movl	(%r15), %ebx
+               	movl	%ebx, (%rdx)
+               	movq	$0x0, -0x50(%rbp)
+               	movl	(%rdx), %ebx
+               	movl	%ebx, -0x50(%rbp)
+               	movq	-0x50(%rbp), %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rsi, %rdx
                	callq	 <L7>
 <L7>:
+               	leaq	-0x58(%rbp), %rdx
+               	movq	(%r14), %rbx
+               	movq	%rbx, (%rdx)
+               	movq	(%rdx), %rbx
                	movq	%rax, %rcx
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L9>
+               	movzbq	%dil, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L10>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
 <L10>:
+               	leaq	-0x5a(%rbp), %rdx
+               	movw	(%r12), %bx
+               	movw	%bx, (%rdx)
+               	movq	$0x0, -0x68(%rbp)
+               	movw	(%rdx), %bx
+               	movw	%bx, -0x68(%rbp)
+               	movq	-0x68(%rbp), %rdx
                	movq	%rax, %rcx
-               	movl	%r12d, %edx
                	callq	 <L11>
 <L11>:
+               	leaq	-0x6c(%rbp), %rdx
+               	movl	(%r13), %ebx
+               	movl	%ebx, (%rdx)
+               	movq	$0x0, -0x78(%rbp)
+               	movl	(%rdx), %ebx
+               	movl	%ebx, -0x78(%rbp)
+               	movq	-0x78(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L12>
 <L12>:
+               	leaq	-0x80(%rbp), %rdx
+               	movq	-0xd0(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	%rbx, (%rdx)
+               	movq	(%rdx), %rbx
                	movq	%rax, %rcx
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L13>
 <L13>:
+               	movd	%xmm7, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movq	-0x70(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L15>
 <L15>:
+               	leaq	-0x88(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rbx
+               	movq	(%r14), %rsi
+               	movq	%rsi, (%rbx)
+               	movq	(%rbx), %rsi
+               	movq	%rsi, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	addl	$0x1, %esi
+               	movl	%esi, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	addl	$0x2, %esi
+               	movw	%si, (%rbx)
+               	leaq	0x6(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	addl	$0x3, %esi
+               	movb	%sil, (%rbx)
+               	leaq	-0x98(%rbp), %rbx
+               	movq	(%rdx), %rsi
+               	movq	%rsi, (%rbx)
+               	movq	(%rbx), %rdx
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L24>
-<L24>:
-               	movl	%r12d, %edx
-               	addl	$0x1, %edx
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %ebx
-               	addl	$0x2, %ebx
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %esi
-               	addl	$0x3, %esi
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
+               	leaq	-0xa0(%rbp), %rdx
+               	movq	(%r14), %rbx
+               	movq	%rbx, (%rdx)
+               	movq	(%rdx), %rbx
                	movq	%rax, %rcx
                	movq	%rbx, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L30>
-<L30>:
-               	movaps	-0xe0(%rbp), %xmm6
-               	movaps	-0xf0(%rbp), %xmm7
-               	movq	-0x98(%rbp), %rbx
-               	movq	-0xa0(%rbp), %rdi
-               	movq	-0xa8(%rbp), %rsi
-               	movq	-0xb0(%rbp), %r12
-               	movq	-0xb8(%rbp), %r13
-               	movq	-0xc0(%rbp), %r14
-               	movq	-0xc8(%rbp), %r15
+               	callq	 <L17>
+<L17>:
+               	movaps	-0x160(%rbp), %xmm6
+               	movaps	-0x170(%rbp), %xmm7
+               	movq	-0x118(%rbp), %rbx
+               	movq	-0x120(%rbp), %rdi
+               	movq	-0x128(%rbp), %rsi
+               	movq	-0x130(%rbp), %r12
+               	movq	-0x138(%rbp), %r13
+               	movq	-0x140(%rbp), %r14
+               	movq	-0x148(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -506,350 +822,440 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x210, %rsp            # imm = 0x210
-               	movq	%rbx, -0x148(%rbp)
-               	movq	%rdi, -0x150(%rbp)
-               	movq	%rsi, -0x158(%rbp)
-               	movq	%r12, -0x160(%rbp)
-               	movq	%r13, -0x168(%rbp)
-               	movq	%r14, -0x170(%rbp)
-               	movq	%r15, -0x178(%rbp)
-               	movaps	%xmm14, -0x190(%rbp)
-               	movaps	%xmm15, -0x1a0(%rbp)
+               	subq	$0x230, %rsp            # imm = 0x230
+               	movq	%rbx, -0x168(%rbp)
+               	movq	%rdi, -0x170(%rbp)
+               	movq	%rsi, -0x178(%rbp)
+               	movq	%r12, -0x180(%rbp)
+               	movq	%r13, -0x188(%rbp)
+               	movq	%r14, -0x190(%rbp)
+               	movq	%r15, -0x198(%rbp)
+               	movaps	%xmm14, -0x1b0(%rbp)
+               	movaps	%xmm15, -0x1c0(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	$0x2, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x8, %rdx
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x4, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	$0x2, %rdx
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
                	movq	%rax, %rcx
                	movq	$0x4, %rdx
-               	callq	 <L8>
-<L8>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L9>
-<L9>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L10>
-<L10>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rcx
                	movq	$0x2, %rdx
-               	callq	 <L11>
-<L11>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rcx
                	movq	$0x4, %rdx
-               	callq	 <L12>
-<L12>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rcx
                	movq	$0x6, %rdx
-               	callq	 <L13>
-<L13>:
-               	leaq	-0x60(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L14>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L14>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-               	jmp	 <L16>
-<L15>:
-               	movq	%rcx, %rdx
+               	callq	 <L19>
+<L19>:
+               	leaq	-0x68(%rbp), %rsi
+               	leaq	(%rsi), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rdi
+<L20>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L20>
+               	movq	$0x0, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rdi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-<L16>:
+               	addq	%r11, %rdi
+               	addq	%rbx, %rdi
+               	leaq	(%rsi,%rdx,8), %r12
+               	movq	%rdi, (%r12)
+               	addq	$0x1, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+<L22>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
-               	jb	 <L17>
-               	jmp	 <L24>
-<L17>:
+               	jb	 <L23>
+               	jmp	 <L30>
+<L23>:
                	movq	%r13, %rax
                	imulq	$0xd, %rax, %rax
                	addq	%rbx, %rax
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, %r8
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	movq	%r14, %r8
                	addq	%rax, %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	leaq	-0x61(%rbp), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movb	%r14b, %r15b
-               	movq	-0xd8(%rbp), %r8
-               	leaq	(%r8), %r14
-               	movb	%r15b, (%r14)
+               	movq	%r8, -0xd0(%rbp)
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r15
+               	leaq	-0x1(%rbp), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movb	%r15b, %r14b
+               	movq	-0xe0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movb	%r14b, (%r15)
                	leaq	0x10(%rsi), %r14
                	movq	(%r14), %r15
                	movl	%r15d, %r8d
-               	movq	%r8, -0xd0(%rbp)
+               	movq	%r8, -0xd8(%rbp)
                	leaq	0x18(%rsi), %r15
-               	movq	(%r15), %rdx
-               	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movb	%dl, %r14b
-               	movq	-0xe0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%r14b, (%rcx)
-               	shrq	$0x8, %rdx
-               	movb	%dl, %cl
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x20(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0x3ff, %rdx            # imm = 0x3FF
-               	movq	%rdx, %r11
+               	movq	(%r15), %r14
+               	leaq	-0x6a(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movb	%r14b, %dl
+               	movq	-0xe8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movb	%dl, (%r15)
+               	shrq	$0x8, %r14
+               	movb	%r14b, %dl
+               	movq	-0xe8(%rbp), %r8
+               	leaq	0x1(%r8), %r14
+               	movb	%dl, (%r14)
+               	leaq	0x20(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	andq	$0x3ff, %r14            # imm = 0x3FF
+               	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L24>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L25>
+<L24>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
-               	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x6a(%rbp), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movb	%dl, %r14b
-               	movq	-0xf8(%rbp), %r8
-               	leaq	(%r8), %r15
-               	movb	%r14b, (%r15)
-               	movq	%rdx, %r14
-               	shrq	$0x8, %r14
+<L25>:
+               	leaq	0x28(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0xf0(%rbp)
                	movb	%r14b, %r15b
-               	movq	-0xf8(%rbp), %r8
-               	leaq	0x1(%r8), %r14
-               	movb	%r15b, (%r14)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %r14w
-               	movq	-0xf8(%rbp), %r8
-               	leaq	0x2(%r8), %rdx
-               	movw	%r14w, (%rdx)
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movb	%r15b, (%rdx)
+               	movq	%r14, %rdx
+               	shrq	$0x8, %rdx
+               	movb	%dl, %r15b
+               	movq	-0xf0(%rbp), %r8
+               	leaq	0x1(%r8), %rdx
+               	movb	%r15b, (%rdx)
+               	shrq	$0x10, %r14
+               	movw	%r14w, %dx
+               	movq	-0xf0(%rbp), %r8
+               	leaq	0x2(%r8), %r14
+               	movw	%dx, (%r14)
                	leaq	0x30(%rsi), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0xe8(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	leaq	0x38(%rsi), %rdx
                	movq	(%rdx), %r15
                	addq	%rax, %r15
-               	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x100(%rbp)
+               	leaq	-0x7c(%rbp), %r8
+               	movq	%r8, -0x108(%rbp)
                	movl	%r15d, %edx
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	leaq	(%r8), %r14
                	movl	%edx, (%r14)
                	movq	%r15, %rdx
                	shrq	$0x20, %rdx
                	movw	%dx, %r14w
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movw	%r14w, (%rdx)
                	shrq	$0x30, %r15
                	movb	%r15b, %dl
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	leaq	0x6(%r8), %r14
                	movb	%dl, (%r14)
                	leaq	0x40(%rsi), %rdx
                	movq	(%rdx), %r14
-               	leaq	-0x81(%rbp), %r8
-               	movq	%r8, -0xf0(%rbp)
+               	leaq	-0x85(%rbp), %r8
+               	movq	%r8, -0x100(%rbp)
                	movb	%r14b, %r15b
-               	movq	-0xf0(%rbp), %r8
+               	movq	-0x100(%rbp), %r8
                	leaq	(%r8), %r14
                	movb	%r15b, (%r14)
                	leaq	0x48(%rsi), %r14
                	movq	(%r14), %r15
-               	leaq	-0x84(%rbp), %r8
-               	movq	%r8, -0x108(%rbp)
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
                	movb	%r15b, %dl
-               	movq	-0x108(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%dl, (%rcx)
+               	movq	-0x110(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movb	%dl, (%rax)
                	shrq	$0x8, %r15
-               	movb	%r15b, %cl
-               	movq	-0x108(%rbp), %r8
+               	movb	%r15b, %al
+               	movq	-0x110(%rbp), %r8
                	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x8a(%rbp), %rcx
-               	movb	%dl, %r15b
-               	leaq	(%rcx), %rax
-               	movb	%r15b, (%rax)
-               	movq	%rdx, %rax
-               	shrq	$0x8, %rax
-               	movb	%al, %r15b
-               	leaq	0x1(%rcx), %rax
-               	movb	%r15b, (%rax)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %ax
-               	leaq	0x2(%rcx), %rdx
-               	movw	%ax, (%rdx)
-               	leaq	0x58(%rsi), %rax
+               	movb	%al, (%rdx)
+               	leaq	0x50(%rsi), %rax
                	movq	(%rax), %rdx
-               	leaq	-0x98(%rbp), %rax
-               	movl	%edx, %r15d
-               	leaq	(%rax), %r14
-               	movl	%r15d, (%r14)
+               	leaq	-0x8e(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movb	%dl, %r15b
+               	movq	-0x118(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movb	%r15b, (%r14)
                	movq	%rdx, %r14
-               	shrq	$0x20, %r14
-               	movw	%r14w, %r15w
-               	leaq	0x4(%rax), %r14
-               	movw	%r15w, (%r14)
-               	shrq	$0x30, %rdx
-               	movb	%dl, %r14b
-               	leaq	0x6(%rax), %rdx
-               	movb	%r14b, (%rdx)
-               	leaq	(%rsi), %rdx
+               	shrq	$0x8, %r14
+               	movb	%r14b, %r15b
+               	movq	-0x118(%rbp), %r8
+               	leaq	0x1(%r8), %r14
+               	movb	%r15b, (%r14)
+               	shrq	$0x10, %rdx
+               	movw	%dx, %r14w
+               	movq	-0x118(%rbp), %r8
+               	leaq	0x2(%r8), %rdx
+               	movw	%r14w, (%rdx)
+               	leaq	0x58(%rsi), %rdx
                	movq	(%rdx), %r14
+               	leaq	-0x9c(%rbp), %rdx
+               	movl	%r14d, %r15d
+               	leaq	(%rdx), %rax
+               	movl	%r15d, (%rax)
+               	movq	%r14, %rax
+               	shrq	$0x20, %rax
+               	movw	%ax, %r15w
+               	leaq	0x4(%rdx), %rax
+               	movw	%r15w, (%rax)
+               	shrq	$0x30, %r14
+               	movb	%r14b, %al
+               	leaq	0x6(%rdx), %r14
+               	movb	%al, (%r14)
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %r14
                	andq	$0xff, %r14
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L26>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L27>
+<L26>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L21>:
-               	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	$0x0, -0xa0(%rbp)
-               	movq	-0xd8(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xa0(%rbp)
-               	movq	-0xa0(%rbp), %rdx
+<L27>:
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x120(%rbp)
                	movq	$0x0, -0xa8(%rbp)
                	movq	-0xe0(%rbp), %r8
+               	movb	(%r8), %al
+               	movb	%al, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %rax
+               	movq	$0x0, -0xb0(%rbp)
+               	movq	-0xe8(%rbp), %r8
                	movw	(%r8), %r15w
-               	movw	%r15w, -0xa8(%rbp)
-               	movq	-0xa8(%rbp), %r15
+               	movw	%r15w, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r15
                	movsd	%xmm0, 0x20(%rsp)
-               	movq	-0xf8(%rbp), %r8
+               	movq	-0xf0(%rbp), %r8
                	movl	(%r8), %r14d
                	movl	%r14d, 0x28(%rsp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	-0xf8(%rbp), %r8
                	movq	%r8, 0x30(%rsp)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	movq	(%r8), %r14
                	movq	%r14, 0x38(%rsp)
-               	movq	-0xf0(%rbp), %r8
+               	movq	-0x100(%rbp), %r8
                	movb	(%r8), %r14b
                	movb	%r14b, 0x40(%rsp)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	movw	(%r8), %r14w
                	movw	%r14w, 0x48(%rsp)
-               	movl	(%rcx), %r14d
+               	movq	-0x118(%rbp), %r8
+               	movl	(%r8), %r14d
                	movl	%r14d, 0x50(%rsp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, 0x58(%rsp)
+               	movq	(%rdx), %r14
+               	movq	%r14, 0x58(%rsp)
                	movsd	%xmm1, 0x60(%rsp)
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x120(%rbp), %r8
                	movq	%r8, 0x68(%rsp)
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rax, %rdx
+               	movq	-0xd8(%rbp), %r8
                	movq	%r15, %r9
-               	callq	 <L22>
-<L22>:
+               	callq	 <L28>
+<L28>:
                	movq	%rax, %r12
                	movq	%rdi, %rcx
                	movq	%r12, %rdx
-               	callq	 <L23>
-<L23>:
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %r13
                	movq	%rax, %rdi
                	cmpq	$0x3, %r13
-               	jb	 <L17>
-<L24>:
-               	leaq	-0x62(%rbp), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movb	%r12b, %cl
-               	movq	-0x128(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	movl	%r12d, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	leaq	-0x66(%rbp), %r8
-               	movq	%r8, -0x130(%rbp)
+               	jb	 <L23>
+<L30>:
+               	leaq	-0x2(%rbp), %r8
+               	movq	%r8, -0x138(%rbp)
                	movb	%r12b, %dl
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8), %r13
-               	movb	%dl, (%r13)
-               	movq	%r12, %rdx
-               	shrq	$0x8, %rdx
-               	movb	%dl, %r13b
-               	movq	-0x130(%rbp), %r8
-               	leaq	0x1(%r8), %rdx
-               	movb	%r13b, (%rdx)
-               	movq	%r12, %rdx
-               	andq	$0x3ff, %rdx            # imm = 0x3FF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L25>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L26>:
-               	leaq	-0x6e(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movb	%dl, (%rbx)
+               	movl	%r12d, %r8d
+               	movq	%r8, -0x128(%rbp)
+               	leaq	-0x6c(%rbp), %r8
                	movq	%r8, -0x140(%rbp)
                	movb	%r12b, %r13b
                	movq	-0x140(%rbp), %r8
@@ -862,141 +1268,174 @@ Disassembly of section .text:
                	leaq	0x1(%r8), %r13
                	movb	%r14b, (%r13)
                	movq	%r12, %r13
-               	shrq	$0x10, %r13
-               	movw	%r13w, %r14w
-               	movq	-0x140(%rbp), %r8
-               	leaq	0x2(%r8), %r13
-               	movw	%r14w, (%r13)
-               	leaq	0x30(%rsi), %r13
-               	movq	(%r13), %r8
-               	movq	%r8, -0x120(%rbp)
-               	leaq	-0x80(%rbp), %r13
-               	movl	%r12d, %r15d
-               	leaq	(%r13), %rbx
-               	movl	%r15d, (%rbx)
+               	andq	$0x3ff, %r13            # imm = 0x3FF
+               	movq	%r13, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L32>:
+               	leaq	-0x74(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movb	%r12b, %r14b
+               	movq	-0x150(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movb	%r14b, (%r15)
+               	movq	%r12, %r14
+               	shrq	$0x8, %r14
+               	movb	%r14b, %r15b
+               	movq	-0x150(%rbp), %r8
+               	leaq	0x1(%r8), %r14
+               	movb	%r15b, (%r14)
+               	movq	%r12, %r14
+               	shrq	$0x10, %r14
+               	movw	%r14w, %r15w
+               	movq	-0x150(%rbp), %r8
+               	leaq	0x2(%r8), %r14
+               	movw	%r15w, (%r14)
+               	leaq	0x30(%rsi), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x130(%rbp)
+               	leaq	-0x84(%rbp), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movl	%r12d, %ebx
+               	movq	-0x158(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movl	%ebx, (%r15)
                	movq	%r12, %rbx
                	shrq	$0x20, %rbx
                	movw	%bx, %r15w
-               	leaq	0x4(%r13), %rbx
+               	movq	-0x158(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
                	movw	%r15w, (%rbx)
                	movq	%r12, %rbx
                	shrq	$0x30, %rbx
                	movb	%bl, %r15b
-               	leaq	0x6(%r13), %rbx
+               	movq	-0x158(%rbp), %r8
+               	leaq	0x6(%r8), %rbx
                	movb	%r15b, (%rbx)
                	leaq	0x40(%rsi), %rbx
                	movq	(%rbx), %r15
-               	leaq	-0x82(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	movb	%r15b, %r14b
-               	movq	-0x138(%rbp), %r8
+               	leaq	-0x86(%rbp), %r8
+               	movq	%r8, -0x148(%rbp)
+               	movb	%r15b, %al
+               	movq	-0x148(%rbp), %r8
                	leaq	(%r8), %r15
-               	movb	%r14b, (%r15)
-               	leaq	0x48(%rsi), %r14
-               	movq	(%r14), %r15
-               	leaq	-0x86(%rbp), %r14
-               	movb	%r15b, %al
-               	leaq	(%r14), %rcx
-               	movb	%al, (%rcx)
-               	shrq	$0x8, %r15
-               	movb	%r15b, %al
-               	leaq	0x1(%r14), %rcx
-               	movb	%al, (%rcx)
-               	leaq	0x50(%rsi), %rax
-               	movq	(%rax), %rcx
-               	leaq	-0x8e(%rbp), %rax
-               	movb	%cl, %r15b
+               	movb	%al, (%r15)
+               	leaq	0x48(%rsi), %rax
+               	movq	(%rax), %r15
+               	leaq	-0x8a(%rbp), %rax
+               	movb	%r15b, %dl
                	leaq	(%rax), %rbx
-               	movb	%r15b, (%rbx)
-               	movq	%rcx, %rbx
-               	shrq	$0x8, %rbx
-               	movb	%bl, %r15b
-               	leaq	0x1(%rax), %rbx
-               	movb	%r15b, (%rbx)
-               	shrq	$0x10, %rcx
-               	movw	%cx, %bx
-               	leaq	0x2(%rax), %rcx
-               	movw	%bx, (%rcx)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	-0xb0(%rbp), %rcx
-               	movl	%ebx, %r15d
-               	leaq	(%rcx), %rdx
-               	movl	%r15d, (%rdx)
-               	movq	%rbx, %rdx
-               	shrq	$0x20, %rdx
-               	movw	%dx, %r15w
-               	leaq	0x4(%rcx), %rdx
-               	movw	%r15w, (%rdx)
-               	shrq	$0x30, %rbx
-               	movb	%bl, %dl
-               	leaq	0x6(%rcx), %rbx
                	movb	%dl, (%rbx)
-               	leaq	(%rsi), %rdx
+               	shrq	$0x8, %r15
+               	movb	%r15b, %dl
+               	leaq	0x1(%rax), %rbx
+               	movb	%dl, (%rbx)
+               	leaq	0x50(%rsi), %rdx
                	movq	(%rdx), %rbx
-               	andq	$0xff, %rbx
-               	movq	%rbx, %r11
+               	leaq	-0x92(%rbp), %rdx
+               	movb	%bl, %r15b
+               	leaq	(%rdx), %r13
+               	movb	%r15b, (%r13)
+               	movq	%rbx, %r13
+               	shrq	$0x8, %r13
+               	movb	%r13b, %r15b
+               	leaq	0x1(%rdx), %r13
+               	movb	%r15b, (%r13)
+               	shrq	$0x10, %rbx
+               	movw	%bx, %r13w
+               	leaq	0x2(%rdx), %rbx
+               	movw	%r13w, (%rbx)
+               	leaq	0x58(%rsi), %rbx
+               	movq	(%rbx), %r13
+               	leaq	-0xb8(%rbp), %rbx
+               	movl	%r13d, %r15d
+               	leaq	(%rbx), %r14
+               	movl	%r15d, (%r14)
+               	movq	%r13, %r14
+               	shrq	$0x20, %r14
+               	movw	%r14w, %r15w
+               	leaq	0x4(%rbx), %r14
+               	movw	%r15w, (%r14)
+               	shrq	$0x30, %r13
+               	movb	%r13b, %r14b
+               	leaq	0x6(%rbx), %r13
+               	movb	%r14b, (%r13)
+               	leaq	(%rsi), %r13
+               	movq	(%r13), %r14
+               	andq	$0xff, %r14
+               	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L33>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L28>:
-               	leaq	0x10(%rsi), %rdx
-               	movq	(%rdx), %rbx
-               	movq	$0x0, -0xb8(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %rdx
+<L34>:
+               	leaq	0x10(%rsi), %r13
+               	movq	(%r13), %rsi
                	movq	$0x0, -0xc0(%rbp)
-               	movq	-0x130(%rbp), %r8
-               	movw	(%r8), %si
-               	movw	%si, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %rsi
-               	movsd	%xmm0, 0x20(%rsp)
-               	movq	-0x140(%rbp), %r8
-               	movl	(%r8), %r15d
-               	movl	%r15d, 0x28(%rsp)
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, 0x30(%rsp)
-               	movq	(%r13), %r15
-               	movq	%r15, 0x38(%rsp)
                	movq	-0x138(%rbp), %r8
                	movb	(%r8), %r13b
-               	movb	%r13b, 0x40(%rsp)
-               	movw	(%r14), %r13w
-               	movw	%r13w, 0x48(%rsp)
-               	movl	(%rax), %r13d
-               	movl	%r13d, 0x50(%rsp)
-               	movq	(%rcx), %rax
+               	movb	%r13b, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r13
+               	movq	$0x0, -0xc8(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movw	(%r8), %r14w
+               	movw	%r14w, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r14
+               	movsd	%xmm0, 0x20(%rsp)
+               	movq	-0x150(%rbp), %r8
+               	movl	(%r8), %r15d
+               	movl	%r15d, 0x28(%rsp)
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x158(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	%r15, 0x38(%rsp)
+               	movq	-0x148(%rbp), %r8
+               	movb	(%r8), %r15b
+               	movb	%r15b, 0x40(%rsp)
+               	movw	(%rax), %r15w
+               	movw	%r15w, 0x48(%rsp)
+               	movl	(%rdx), %eax
+               	movl	%eax, 0x50(%rsp)
+               	movq	(%rbx), %rax
                	movq	%rax, 0x58(%rsp)
                	movsd	%xmm1, 0x60(%rsp)
-               	movq	%rbx, 0x68(%rsp)
+               	movq	%rsi, 0x68(%rsp)
                	movq	%r12, %rcx
-               	movq	-0x118(%rbp), %r8
-               	movq	%rsi, %r9
-               	callq	 <L29>
-<L29>:
+               	movq	%r13, %rdx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r14, %r9
+               	callq	 <L35>
+<L35>:
                	movq	%rdi, %rcx
                	movq	%rax, %rdx
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x190(%rbp), %xmm14
-               	movaps	-0x1a0(%rbp), %xmm15
-               	movq	-0x148(%rbp), %rbx
-               	movq	-0x150(%rbp), %rdi
-               	movq	-0x158(%rbp), %rsi
-               	movq	-0x160(%rbp), %r12
-               	movq	-0x168(%rbp), %r13
-               	movq	-0x170(%rbp), %r14
-               	movq	-0x178(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movaps	-0x1b0(%rbp), %xmm14
+               	movaps	-0x1c0(%rbp), %xmm15
+               	movq	-0x168(%rbp), %rbx
+               	movq	-0x170(%rbp), %rdi
+               	movq	-0x178(%rbp), %rsi
+               	movq	-0x180(%rbp), %r12
+               	movq	-0x188(%rbp), %r13
+               	movq	-0x190(%rbp), %r14
+               	movq	-0x198(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_recursive.dis
+++ b/test/golden/x86_64-windows/call/call_recursive.dis
@@ -14,12 +14,14 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.descend>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%rdi, -0x50(%rbp)
-               	movq	%rsi, -0x58(%rbp)
-               	movq	%r12, -0x60(%rbp)
-               	movq	%r13, -0x68(%rbp)
+               	subq	$0xb0, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, -0x60(%rbp)
+               	movq	%rsi, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
                	movq	%rcx, %rbx
                	movq	%r8, %rax
                	leaq	-0x40(%rbp), %rsi
@@ -31,20 +33,20 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rcx, %rdi
-               	addq	$0x1, %rdi
-               	movq	%rdx, %r12
-               	imulq	%rdi, %r12
-               	addq	%rbx, %r12
-               	leaq	(%rsi,%rcx,8), %r13
-               	movq	%r12, (%r13)
-               	movq	%rdi, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	%rdi, %r12
+               	addq	$0x1, %r12
+               	movq	%rdx, %r13
+               	imulq	%r12, %r13
+               	addq	%rbx, %r13
+               	leaq	(%rsi,%rdi,8), %r14
+               	movq	%r13, (%r14)
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdi
                	jb	 <L0>
 <L1>:
                	movq	%rdx, %rdi
@@ -55,205 +57,104 @@ Disassembly of section .text:
                	movq	%rax, %r12
                	jmp	 <L4>
 <L2>:
-               	movq	%rbx, %rcx
-               	subq	$0x1, %rcx
+               	movq	%rbx, %r13
+               	subq	$0x1, %r13
                	imulq	$0x3, %rdx, %rdx
                	addq	$0x1, %rdx
+               	movq	%r13, %rcx
                	movq	%rax, %r8
                	callq	 <L3>
 <L3>:
                	movq	%rax, %r12
 <L4>:
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L6>
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	%r12, %rdx
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r14
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
 <L7>:
-               	movq	%r12, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L9>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %rdi
-               	movq	-0x58(%rbp), %rsi
-               	movq	-0x60(%rbp), %r12
-               	movq	-0x68(%rbp), %r13
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rdi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r12, %rax
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %rdi
+               	movq	-0x68(%rbp), %rsi
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
 
 <corpus.cases.call.call_recursive.ping>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%rdi, -0x30(%rbp)
-               	movq	%rsi, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%rcx, %rbx
-               	movq	%r8, %rax
-               	leaq	-0x20(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L0>
-               	jmp	 <L1>
-<L0>:
-               	movq	%rcx, %rdi
-               	imulq	$0x7, %rdi, %rdi
-               	movq	%rdx, %r12
-               	addq	%rdi, %r12
-               	addq	%rbx, %r12
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%r12, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L0>
-<L1>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L2>
-               	movq	%rax, %rdi
-               	jmp	 <L4>
-<L2>:
-               	movq	%rbx, %rcx
-               	subq	$0x1, %rcx
-               	xorq	$0x12345678, %rdx       # imm = 0x12345678
-               	movq	%rax, %r8
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-<L4>:
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L6>
-<L6>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rdi
-               	cmpq	$0x4, %r12
-               	jb	 <L5>
-<L7>:
-               	imulq	$0x2, %rbx, %rbx
-               	movq	%rdi, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %rdi
-               	movq	-0x38(%rbp), %rsi
-               	movq	-0x40(%rbp), %r12
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_recursive.pong>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%rdi, -0x40(%rbp)
-               	movq	%rsi, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%r13, -0x58(%rbp)
-               	movq	%rcx, %rbx
-               	movq	%r8, %rax
-               	leaq	-0x30(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movq	$0x0, 0x20(%rsi)
-               	movq	$0x0, 0x28(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L0>
-               	jmp	 <L1>
-<L0>:
-               	movq	%rcx, %rdi
-               	addq	$0x3, %rdi
-               	movq	%rdx, %r12
-               	imulq	%rdi, %r12
-               	subq	%rbx, %r12
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%r12, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L0>
-<L1>:
-               	movq	%rdx, %rdi
-               	xorq	$-0x1, %rdi
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L2>
-               	movq	%rax, %r12
-               	jmp	 <L4>
-<L2>:
-               	movq	%rbx, %rcx
-               	subq	$0x1, %rcx
-               	addq	$0xb, %rdx
-               	movq	%rax, %r8
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r12
-<L4>:
-               	movq	$0x0, %r13
-               	cmpq	$0x6, %r13
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L6>
-<L6>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x6, %r13
-               	jb	 <L5>
-<L7>:
-               	movq	%r12, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L8>
-<L8>:
-               	imulq	$0x3, %rbx, %rbx
-               	addq	$0x1, %rbx
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	-0x38(%rbp), %rbx
-               	movq	-0x40(%rbp), %rdi
-               	movq	-0x48(%rbp), %rsi
-               	movq	-0x50(%rbp), %r12
-               	movq	-0x58(%rbp), %r13
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_recursive.tree>:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x80, %rsp
@@ -265,269 +166,98 @@ Disassembly of section .text:
                	movq	%r14, -0x50(%rbp)
                	movq	%r15, -0x58(%rbp)
                	movq	%rcx, %rbx
-               	movq	%r8, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rdx
-               	movq	%rdx, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	%r8, %rax
+               	leaq	-0x20(%rbp), %rsi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movq	$0x0, 0x18(%rsi)
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rdi, %r12
+               	imulq	$0x7, %r12, %r12
+               	movq	%rdx, %r13
+               	addq	%r12, %r13
+               	addq	%rbx, %r13
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	%r13, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L0>
+<L1>:
                	movq	$0x0, %r11
                	cmpq	%rbx, %r11
-               	jb	 <L1>
+               	jb	 <L2>
                	movq	%rax, %rdi
-               	jmp	 <L41>
-<L1>:
+               	jmp	 <L4>
+<L2>:
                	movq	%rbx, %r12
                	subq	$0x1, %r12
-               	movq	%rsi, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r13
-               	addq	%r12, %r13
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	$0x0, %r11
-               	cmpq	%r12, %r11
-               	jb	 <L3>
-               	movq	%rax, %r14
-               	jmp	 <L19>
+               	xorq	$0x12345678, %rdx       # imm = 0x12345678
+               	movq	%r12, %rcx
+               	movq	%rax, %r8
+               	callq	 <L3>
 <L3>:
-               	movq	%r12, %r15
-               	subq	$0x1, %r15
-               	movq	%r13, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r8
-               	addq	%r15, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	$0x0, %r11
-               	cmpq	%r15, %r11
-               	jb	 <L5>
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-               	jmp	 <L9>
-<L5>:
-               	subq	$0x1, %r15
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	$0x1, %rdx
-               	movq	%r15, %rcx
-               	movq	%rax, %r8
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movq	%r15, %rcx
-               	movq	%rax, %r8
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-<L9>:
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L11>
-<L11>:
-               	subq	$0x1, %r12
-               	movq	%r13, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r15
-               	addq	%r12, %r15
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	$0x0, %r11
-               	cmpq	%r12, %r11
-               	jb	 <L13>
-               	movq	%rax, %r8
-               	movq	%r8, -0x18(%rbp)
-               	jmp	 <L17>
-<L13>:
-               	subq	$0x1, %r12
-               	movq	%r15, %rdx
-               	addq	$0x1, %rdx
-               	movq	%r12, %rcx
-               	movq	%rax, %r8
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%r15, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movq	%r12, %rcx
-               	movq	%rax, %r8
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x18(%rbp)
-<L17>:
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r14
-<L19>:
-               	movq	%r14, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L21>
-<L21>:
-               	subq	$0x1, %rbx
-               	movq	%rsi, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r12
-               	addq	%rbx, %r12
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L23>
-               	movq	%rax, %r13
-               	jmp	 <L39>
-<L23>:
-               	movq	%rbx, %r14
-               	subq	$0x1, %r14
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r15
-               	addq	%r14, %r15
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	$0x0, %r11
-               	cmpq	%r14, %r11
-               	jb	 <L25>
-               	movq	%rax, %r8
-               	movq	%r8, -0x20(%rbp)
-               	jmp	 <L29>
-<L25>:
-               	subq	$0x1, %r14
-               	movq	%r15, %rdx
-               	addq	$0x1, %rdx
-               	movq	%r14, %rcx
-               	movq	%rax, %r8
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%r15, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movq	%r14, %rcx
-               	movq	%rax, %r8
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x20(%rbp)
-<L29>:
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L31>
-<L31>:
-               	subq	$0x1, %rbx
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L32>
-<L32>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L33>
-               	movq	%rax, %r15
-               	jmp	 <L37>
-<L33>:
-               	subq	$0x1, %rbx
-               	movq	%r14, %rdx
-               	addq	$0x1, %rdx
-               	movq	%rbx, %rcx
-               	movq	%rax, %r8
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L35>
-<L35>:
-               	movq	%r14, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movq	%rbx, %rcx
-               	movq	%rax, %r8
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r15
-<L37>:
-               	movq	%r15, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r13
-<L39>:
-               	movq	%r13, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L40>
-<L40>:
                	movq	%rax, %rdi
-<L41>:
-               	movq	%rdi, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L42>
-<L42>:
+<L4>:
+               	movq	$0x0, %rax
+               	cmpq	$0x4, %rax
+               	jb	 <L5>
+               	jmp	 <L8>
+<L5>:
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	(%rdx), %r12
+               	movq	%rdi, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+<L7>:
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x4, %rax
+               	jb	 <L5>
+<L8>:
+               	imulq	$0x2, %rbx, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %rdi
                	movq	-0x38(%rbp), %rsi
@@ -539,81 +269,359 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_recursive.tail>:
+<corpus.cases.call.call_recursive.pong>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%rdi, -0x30(%rbp)
-               	movq	%rsi, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
                	movq	%rcx, %rbx
-               	movq	%rdx, %rsi
                	movq	%r8, %rax
-               	leaq	-0x20(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movq	$0x0, 0x8(%rdi)
-               	movq	$0x0, 0x10(%rdi)
-               	movq	$0x0, 0x18(%rdi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x4, %rcx
+               	leaq	-0x30(%rbp), %rsi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movq	$0x0, 0x18(%rsi)
+               	movq	$0x0, 0x20(%rsi)
+               	movq	$0x0, 0x28(%rsi)
+               	movq	$0x0, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rcx, %rdx
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	movq	%rsi, %r12
-               	xorq	%rdx, %r12
-               	leaq	(%rdi,%rcx,8), %rdx
-               	movq	%r12, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x4, %rcx
+               	movq	%rdi, %r12
+               	addq	$0x3, %r12
+               	movq	%rdx, %r13
+               	imulq	%r12, %r13
+               	subq	%rbx, %r13
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	%r13, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L0>
 <L1>:
-               	movq	$0x0, %r12
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r12
+               	movq	%rdx, %rdi
+               	xorq	$-0x1, %rdi
+               	movq	$0x0, %r11
+               	cmpq	%rbx, %r11
                	jb	 <L2>
+               	movq	%rax, %r12
                	jmp	 <L4>
 <L2>:
-               	leaq	(%rdi,%r12,8), %rax
-               	movq	(%rax), %rdx
+               	movq	%rbx, %r13
+               	subq	$0x1, %r13
+               	addq	$0xb, %rdx
                	movq	%r13, %rcx
+               	movq	%rax, %r8
                	callq	 <L3>
 <L3>:
-               	addq	$0x1, %r12
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r12
-               	jb	 <L2>
+               	movq	%rax, %r12
 <L4>:
-               	cmpq	$0x0, %rbx
-               	je	 <L6>
-               	subq	$0x1, %rbx
-               	imulq	$0x5, %rsi, %rsi
-               	addq	$0x3, %rsi
-               	movq	%rbx, %rcx
-               	movq	%rsi, %rdx
-               	movq	%r13, %r8
-               	callq	 <L5>
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L5>
+               	jmp	 <L8>
 <L5>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %rdi
-               	movq	-0x38(%rbp), %rsi
-               	movq	-0x40(%rbp), %r12
-               	movq	-0x48(%rbp), %r13
+               	leaq	(%rsi,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	%r12, %rdx
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r14
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+<L7>:
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x6, %rax
+               	jb	 <L5>
+<L8>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rdi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	imulq	$0x3, %rbx, %rbx
+               	addq	$0x1, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r12, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L6>:
+
+<corpus.cases.call.call_recursive.tree>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rbx
+               	movq	%r8, %rax
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %rdx
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %r11
+               	cmpq	%rbx, %r11
+               	jb	 <L2>
+               	movq	%rax, %rdi
+               	jmp	 <L7>
+<L2>:
+               	movq	%rbx, %rdx
+               	subq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	addq	$0x1, %r12
+               	movq	%rdx, %rcx
+               	movq	%r12, %rdx
+               	movq	%rax, %r8
+               	callq	 <L3>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
                	movq	%r13, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %rdi
-               	movq	-0x38(%rbp), %rsi
-               	movq	-0x40(%rbp), %r12
-               	movq	-0x48(%rbp), %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	subq	$0x1, %rbx
+               	movq	%rsi, %rdx
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rdx
+               	movq	%rbx, %rcx
+               	movq	%rax, %r8
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rdi
+<L7>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_recursive.tail>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%rdi, -0x40(%rbp)
+               	movq	%rsi, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rdx, %r9
+               	movq	%r9, -0x28(%rbp)
+               	movq	%r8, %rbx
+               	leaq	-0x20(%rbp), %rsi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movq	$0x0, 0x18(%rsi)
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	%rax, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r12, %r13
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	%r13, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L2>
+               	jmp	 <L5>
+<L2>:
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	(%r12), %r13
+               	movq	%rbx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %rbx
+               	cmpq	$0x4, %rdi
+               	jb	 <L2>
+<L5>:
+               	cmpq	$0x0, %rax
+               	je	 <L7>
+               	subq	$0x1, %rax
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	addq	$0x3, %rdx
+               	movq	%rax, %rcx
+               	movq	%rbx, %r8
+               	callq	 <L6>
+<L6>:
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %rdi
+               	movq	-0x48(%rbp), %rsi
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+<L7>:
+               	movq	%rbx, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %rdi
+               	movq	-0x48(%rbp), %rsi
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -721,126 +729,185 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x58(%rbp)
-               	movq	%rdi, -0x60(%rbp)
-               	movq	%rsi, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%rdi, -0x70(%rbp)
+               	movq	%rsi, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x48(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
                	movq	$0x0, 0x18(%rsi)
                	movq	$0x0, 0x20(%rsi)
                	movq	$0x0, 0x28(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
                	addq	%rbx, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
+               	leaq	(%rsi,%rax,8), %rdi
                	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
-               	movq	$0x28, %rcx
-               	addq	%rbx, %rcx
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	$0x28, %rax
+               	addq	%rbx, %rax
                	leaq	(%rsi), %rdx
                	movq	(%rdx), %rdi
+               	movq	%rax, %rcx
                	movq	%rdi, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
+               	movq	$0x21, %rdi
+               	addq	%rbx, %rdi
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
                	movq	%rax, %r8
                	callq	 <L3>
 <L3>:
-               	movq	$0x21, %rdi
-               	addq	%rbx, %rdi
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	0x10(%rsi), %rdx
+               	movq	(%rdx), %r12
                	movq	%rdi, %rcx
+               	movq	%r12, %rdx
                	movq	%rax, %r8
                	callq	 <L4>
 <L4>:
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdi, %rcx
+               	leaq	0x18(%rsi), %rdx
+               	movq	(%rdx), %rdi
+               	addq	%rbx, %rdi
+               	movq	$0x8, %rcx
+               	movq	%rdi, %rdx
                	movq	%rax, %r8
                	callq	 <L5>
 <L5>:
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
+               	movq	$0x30, %rdx
                	addq	%rbx, %rdx
-               	movq	$0x8, %rcx
+               	leaq	0x20(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	%rdx, %rcx
+               	movq	%r12, %rdx
                	movq	%rax, %r8
                	callq	 <L6>
 <L6>:
-               	movq	$0x30, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x20(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	movq	%rdi, %rdx
-               	movq	%rax, %r8
-               	callq	 <L7>
-<L7>:
                	movq	$0x18, %rdi
                	addq	%rbx, %rdi
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L8>
-               	jmp	 <L13>
-<L8>:
+               	jb	 <L7>
+               	jmp	 <L15>
+<L7>:
                	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %rax
+               	movq	(%rax), %rdx
+               	movq	%rdx, %rax
                	addq	%rbx, %rax
-               	leaq	-0x48(%rbp), %r14
+               	leaq	-0x18(%rbp), %r14
                	movq	%r14, %rcx
                	movq	%rdi, %rdx
                	movq	%rax, %r8
-               	callq	 <L9>
-<L9>:
+               	callq	 <L8>
+<L8>:
                	leaq	(%r14), %rax
-               	movq	(%rax), %rdx
+               	movq	(%rax), %r8
+               	movq	%r8, -0x60(%rbp)
                	leaq	0x8(%r14), %rax
-               	movq	(%rax), %r15
+               	movq	(%rax), %r8
+               	movq	%r8, -0x58(%rbp)
                	leaq	0x10(%r14), %rax
-               	movq	(%rax), %r14
-               	movq	%r12, %rcx
-               	callq	 <L10>
+               	movq	(%rax), %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%r12, %rax
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L9>
 <L10>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L11>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L12>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
 <L12>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+<L14>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x4, %r13
-               	jb	 <L8>
-<L13>:
+               	jb	 <L7>
+<L15>:
                	movq	%r12, %rax
-               	movq	-0x58(%rbp), %rbx
-               	movq	-0x60(%rbp), %rdi
-               	movq	-0x68(%rbp), %rsi
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_ret_large.dis
+++ b/test/golden/x86_64-windows/call/call_ret_large.dis
@@ -14,13 +14,15 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold20>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movl	(%rbx), %esi
                	leaq	0x4(%rdx), %rbx
@@ -30,26 +32,391 @@ Disassembly of section .text:
                	leaq	0xc(%rdx), %rbx
                	movl	(%rbx), %r13d
                	leaq	0x10(%rdx), %rbx
-               	movl	(%rbx), %r14d
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	movl	(%rbx), %edx
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L2>
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L4>
+               	movl	%r12d, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%r13d, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_ret_large.fold24>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdi
+               	leaq	0x10(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_ret_large.fold24f>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm1
+               	leaq	0x10(%rdx), %rbx
+               	movsd	(%rbx), %xmm2
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_ret_large.fold32>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdi
+               	leaq	0x10(%rdx), %rbx
+               	movq	(%rbx), %r12
+               	leaq	0x18(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -60,163 +427,77 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_ret_large.fold24>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rdi
-               	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_ret_large.fold24f>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movaps	%xmm7, -0x30(%rbp)
-               	leaq	(%rdx), %rbx
-               	movsd	(%rbx), %xmm1
-               	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	leaq	0x10(%rdx), %rbx
-               	movsd	(%rbx), %xmm7
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L2>
-<L2>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movaps	-0x30(%rbp), %xmm7
-               	movq	-0x8(%rbp), %rbx
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_ret_large.fold32>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rdi
-               	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	leaq	0x18(%rdx), %rbx
-               	movq	(%rbx), %r13
-               	movq	%rsi, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
 <corpus.cases.call.call_ret_large.fold40m>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
                	movaps	%xmm6, -0x40(%rbp)
-               	movaps	%xmm7, -0x50(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movq	(%rbx), %rsi
                	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
+               	movsd	(%rbx), %xmm0
                	leaq	0x10(%rdx), %rbx
                	movl	(%rbx), %edi
                	leaq	0x14(%rdx), %rbx
                	movl	(%rbx), %r12d
                	leaq	0x18(%rdx), %rbx
-               	movsd	(%rbx), %xmm7
+               	movsd	(%rbx), %xmm6
                	leaq	0x20(%rdx), %rbx
                	movq	(%rbx), %r13
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm0, %rdx
                	movq	%rax, %rcx
-               	movl	%edi, %edx
                	callq	 <L2>
 <L2>:
+               	movl	%edi, %edx
                	movq	%rax, %rcx
-               	movl	%r12d, %edx
                	callq	 <L3>
 <L3>:
+               	movl	%r12d, %edx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L4>
 <L4>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
                	callq	 <L5>
 <L5>:
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L6>
+<L6>:
                	movaps	-0x40(%rbp), %xmm6
-               	movaps	-0x50(%rbp), %xmm7
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -281,56 +562,67 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold_nest>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	leaq	(%rdx), %rbx
-               	movl	(%rbx), %esi
-               	leaq	0x8(%rdx), %rbx
-               	leaq	(%rbx), %rdi
-               	movq	(%rdi), %r12
-               	leaq	0x8(%rbx), %rdi
-               	movq	(%rdi), %r13
-               	leaq	0x10(%rbx), %rdi
-               	movq	(%rdi), %rbx
-               	leaq	0x20(%rdx), %rdi
-               	leaq	(%rdi), %rdx
-               	movq	(%rdx), %r14
-               	leaq	0x8(%rdi), %rdx
-               	movq	(%rdx), %rdi
-               	movl	%esi, %edx
+               	subq	$0xb0, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%rdi, -0x70(%rbp)
+               	movq	%rsi, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	leaq	-0x30(%rbp), %rbx
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r12
+               	movq	0x20(%rdx), %r13
+               	movq	0x28(%rdx), %r14
+               	movq	%rax, (%rbx)
+               	movq	%rsi, 0x8(%rbx)
+               	movq	%rdi, 0x10(%rbx)
+               	movq	%r12, 0x18(%rbx)
+               	movq	%r13, 0x20(%rbx)
+               	movq	%r14, 0x28(%rbx)
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	%rax, %rdx
                	callq	 <L0>
 <L0>:
+               	leaq	0x8(%rbx), %rcx
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rdi
+               	movq	0x10(%rcx), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	(%rdx), %rcx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rcx, -0x60(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	%r12, %rdx
                	callq	 <L1>
 <L1>:
+               	leaq	0x20(%rbx), %rsi
+               	leaq	(%rsi), %rcx
+               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
                	callq	 <L2>
 <L2>:
+               	leaq	0x8(%rsi), %rcx
+               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	movq	%rbx, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -991,36 +1283,44 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.take_two>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%rdi, -0x30(%rbp)
-               	movq	%rsi, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
-               	movq	%r14, -0x50(%rbp)
-               	movq	%r15, -0x58(%rbp)
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%rdi, -0x70(%rbp)
+               	movq	%rsi, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
                	movq	%r8, %rbx
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %rdi
-               	leaq	0x8(%rcx), %rsi
-               	movq	(%rsi), %r12
-               	leaq	0x10(%rcx), %rsi
-               	movq	(%rsi), %r13
-               	leaq	0x18(%rcx), %rsi
-               	movq	(%rsi), %r14
-               	leaq	0x20(%rcx), %rsi
-               	movq	(%rsi), %r15
-               	leaq	0x28(%rcx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x8(%rbp)
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x10(%rbp)
-               	leaq	0x10(%rdx), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x18(%rbp)
+               	leaq	(%rcx), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x50(%rbp)
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rdi
+               	leaq	0x10(%rcx), %rax
+               	movq	(%rax), %r12
+               	leaq	0x18(%rcx), %rax
+               	movq	(%rax), %r13
+               	leaq	0x20(%rcx), %rax
+               	movq	(%rax), %r14
+               	leaq	0x28(%rcx), %rax
+               	movq	(%rax), %r15
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	(%rdx), %rcx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x60(%rbp), %r8
+               	movq	%rcx, (%r8)
+               	movq	-0x60(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x60(%rbp), %r8
+               	movq	-0x58(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
@@ -1044,35 +1344,36 @@ Disassembly of section .text:
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
+               	leaq	-0x30(%rbp), %rdx
+               	movq	-0x60(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x60(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x60(%rbp), %r8
+               	movq	0x10(%r8), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rax, -0x48(%rbp)
+               	movq	%rsi, -0x40(%rbp)
+               	movq	%rdi, -0x38(%rbp)
+               	leaq	-0x48(%rbp), %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	%rsi, %rdx
+               	movq	%rbx, %rdx
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %rdi
-               	movq	-0x38(%rbp), %rsi
-               	movq	-0x40(%rbp), %r12
-               	movq	-0x48(%rbp), %r13
-               	movq	-0x50(%rbp), %r14
-               	movq	-0x58(%rbp), %r15
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1080,24 +1381,24 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x860, %rsp            # imm = 0x860
-               	movq	%rbx, -0x7c8(%rbp)
-               	movq	%rdi, -0x7d0(%rbp)
-               	movq	%rsi, -0x7d8(%rbp)
-               	movq	%r12, -0x7e0(%rbp)
-               	movq	%r13, -0x7e8(%rbp)
-               	movq	%r14, -0x7f0(%rbp)
-               	movq	%r15, -0x7f8(%rbp)
-               	movaps	%xmm6, -0x810(%rbp)
-               	movaps	%xmm7, -0x820(%rbp)
-               	movaps	%xmm14, -0x830(%rbp)
-               	movaps	%xmm15, -0x840(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x6c0(%rbp)
+               	subq	$0xc70, %rsp            # imm = 0xC70
+               	movq	%rbx, -0xbe8(%rbp)
+               	movq	%rdi, -0xbf0(%rbp)
+               	movq	%rsi, -0xbf8(%rbp)
+               	movq	%r12, -0xc00(%rbp)
+               	movq	%r13, -0xc08(%rbp)
+               	movq	%r14, -0xc10(%rbp)
+               	movq	%r15, -0xc18(%rbp)
+               	movaps	%xmm6, -0xc30(%rbp)
+               	movaps	%xmm14, -0xc40(%rbp)
+               	movaps	%xmm15, -0xc50(%rbp)
+               	movq	%rcx, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	$0x14, %rdx
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
-               	movq	$0x14, %rdx
+               	movq	$0x18, %rdx
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rcx
@@ -1105,15 +1406,15 @@ Disassembly of section .text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
-               	movq	$0x18, %rdx
+               	movq	$0x20, %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
-               	movq	$0x20, %rdx
+               	movq	$0x28, %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
-               	movq	$0x28, %rdx
+               	movq	$0x30, %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
@@ -1121,18 +1422,14 @@ Disassembly of section .text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
-               	movq	$0x30, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x20, %rdx
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	$0x20, %rdx
-               	callq	 <L9>
-<L9>:
-               	leaq	-0x1f0(%rbp), %rsi
+               	leaq	-0x358(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -1141,110 +1438,198 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-               	jmp	 <L11>
-<L10>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rdi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x6c0(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-<L11>:
+               	addq	%r11, %rdi
+               	addq	%rbx, %rdi
+               	leaq	(%rsi,%rdx,8), %r12
+               	movq	%rdi, (%r12)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	cmpq	$0x8, %r12
-               	jb	 <L12>
-               	jmp	 <L51>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L57>
+<L11>:
                	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%rcx, %r13
-               	addq	%r8, %r13
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r13
+               	addq	%rbx, %r13
                	movl	%r13d, %eax
-               	movq	%r13, %rcx
-               	shrq	$0x8, %rcx
-               	movl	%ecx, %r14d
-               	movq	%r13, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r15d
-               	movq	%r13, %rcx
-               	shrq	$0x18, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x670(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x678(%rbp)
-               	movq	%rdi, %rcx
-               	movl	%eax, %edx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movq	-0x670(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movq	-0x678(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L17>
-<L17>:
-               	movq	%r13, %r14
-               	xorq	$-0x1, %r14
-               	movq	%r13, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r15
-               	addq	$0x1, %r15
-               	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L18>
+               	shrq	$0x8, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	%r13, %rdx
+               	shrq	$0x10, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x898(%rbp)
+               	movq	%r13, %rdx
+               	shrq	$0x18, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x888(%rbp)
+               	movq	%r13, %rdx
+               	shrq	$0x20, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x890(%rbp)
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	%rdi, %rax
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%r15, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x8a8(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %rdx
+               	xorq	%r14, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r15
+               	jb	 <L12>
+<L13>:
+               	movq	-0x8a0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x8b0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+<L15>:
+               	movq	-0x898(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x8b8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+<L17>:
+               	movq	-0x888(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L19>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x8c0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L20>
+               	movq	-0x890(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	%rax, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%r13, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L21>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L22>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L20>
 <L21>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	%r13, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r15
+               	movq	%rdx, -0x458(%rbp)
+               	movq	%r14, -0x450(%rbp)
+               	movq	%r15, -0x448(%rbp)
+               	leaq	-0x458(%rbp), %rdx
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L22>
 <L22>:
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x2ab>
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
+               	movq	%r13, %rdx
+               	andq	$0xffff, %rdx           # imm = 0xFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
@@ -1257,11 +1642,11 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L24>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	subsd	, %xmm6 <corpus.cases.call.call_ret_large.checksum+0x2ed>
-               	movq	%r13, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x4a1>
+               	movq	%r13, %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
@@ -1274,68 +1659,129 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L26>:
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_ret_large.checksum+0x32f>
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L29>
-<L29>:
-               	movq	%r13, %r14
-               	addq	$0x1, %r14
-               	movq	%r13, %r15
-               	imulq	$0x5, %r15, %r15
-               	movq	%r13, %r8
-               	movq	%r8, -0x680(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x680(%rbp)
-               	movq	%rax, %rcx
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_ret_large.checksum+0x4e3>
                	movq	%r13, %rdx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	movq	-0x680(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L33>
-<L33>:
-               	movq	%r13, %rcx
-               	andq	$0x1fff, %rcx           # imm = 0x1FFF
-               	movq	%rcx, %r11
+               	andq	$0x3ffff, %rdx          # imm = 0x3FFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L34>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L35>
-<L34>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
+<L28>:
+               	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.call.call_ret_large.checksum+0x525>
+               	movq	%xmm1, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L29>
+<L30>:
+               	movq	%xmm2, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L31>
+<L32>:
+               	movq	%xmm3, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L33>
+<L34>:
+               	leaq	-0x5e0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	%r13, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	leaq	0x10(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x18(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r15
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	%rdx, -0x600(%rbp)
+               	movq	%r14, -0x5f8(%rbp)
+               	movq	%r15, -0x5f0(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	movq	%r8, -0x5e8(%rbp)
+               	leaq	-0x600(%rbp), %rdx
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L35>
 <L35>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_ret_large.checksum+0x3e7>
-               	movl	%r13d, %r14d
-               	movq	%r13, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r15d
-               	movq	%r13, %rcx
-               	andq	$0x1ffff, %rcx          # imm = 0x1FFFF
-               	movq	%rcx, %r11
+               	movq	%r13, %rdx
+               	andq	$0x1fff, %rdx           # imm = 0x1FFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L36>
                	cvtsi2sd	%r11, %xmm0
@@ -1348,939 +1794,1238 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L37>:
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_ret_large.checksum+0x436>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x726>
+               	movl	%r13d, %r14d
+               	movq	%r13, %rdx
+               	shrq	$0x10, %rdx
+               	movl	%edx, %r15d
+               	movq	%r13, %rdx
+               	andq	$0x1ffff, %rdx          # imm = 0x1FFFF
+               	movq	%rdx, %r11
+               	testq	%r11, %r11
+               	jl	 <L38>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L39>
+<L38>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L39>:
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.call.call_ret_large.checksum+0x775>
                	movq	%r13, %r8
                	imulq	$0x7, %r8, %r8
-               	movq	%r8, -0x688(%rbp)
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L40>
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x900(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L41>
+               	movq	%r13, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x8f8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x900(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	movq	%xmm1, %rdx
+               	movq	-0x8f8(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L42>
 <L42>:
+               	movl	%r14d, %edx
                	movq	%rax, %rcx
-               	movq	-0x688(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L43>
 <L43>:
+               	movl	%r15d, %edx
+               	movq	%rax, %rcx
+               	callq	 <L44>
+<L44>:
+               	movq	%xmm6, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L45>
+<L45>:
+               	movq	%rax, %rcx
+               	movq	-0x8f0(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L46>
+<L46>:
                	movq	%r13, %r14
                	addq	$0x1, %r14
                	movq	%r13, %r15
                	addq	$0x2, %r15
                	movq	%r13, %r8
                	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x690(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	movq	%r13, %r8
-               	movq	%r8, -0x698(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	xorq	$-0x1, %r8
-               	movq	%r8, -0x698(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	movq	%r13, %r8
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %r8
-               	movq	%r8, -0x6a0(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	movq	-0x690(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rcx
-               	movq	-0x698(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%r14, %rdx
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rcx
-               	movq	-0x6a0(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%r15, %rdx
                	callq	 <L49>
 <L49>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x6a8(%rbp)
-               	movq	-0x6a8(%rbp), %r8
-               	leaq	-0x610(%rbp), %r8
-               	movq	%r8, -0x6b0(%rbp)
-               	movl	%r13d, %edx
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	(%r8), %r14
-               	movl	%edx, (%r14)
-               	leaq	-0x628(%rbp), %rdx
-               	leaq	(%rdx), %r14
-               	movq	%r13, (%r14)
-               	movq	%r13, %r14
-               	xorq	$-0x1, %r14
-               	leaq	0x8(%rdx), %r15
-               	movq	%r14, (%r15)
-               	movq	%r13, %r14
-               	imulq	$0x3, %r14, %r14
-               	addq	$0x1, %r14
-               	leaq	0x10(%rdx), %r15
-               	movq	%r14, (%r15)
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x8(%r8), %r14
-               	movq	(%rdx), %r15
-               	movq	0x8(%rdx), %rax
-               	movq	0x10(%rdx), %rcx
-               	movq	%r15, (%r14)
-               	movq	%rax, 0x8(%r14)
-               	movq	%rcx, 0x10(%r14)
-               	leaq	-0x638(%rbp), %rax
-               	movq	%r13, %rcx
-               	imulq	$0xb, %rcx, %rcx
-               	leaq	(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	xorq	$-0x1, %r13
-               	leaq	0x8(%rax), %rcx
-               	movq	%r13, (%rcx)
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %r13
-               	movq	%rdx, (%rcx)
-               	movq	%r13, 0x8(%rcx)
-               	movq	-0x6b0(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x6b0(%rbp), %r8
-               	movq	0x8(%r8), %rcx
-               	movq	-0x6b0(%rbp), %r8
-               	movq	0x10(%r8), %rdx
-               	movq	-0x6b0(%rbp), %r8
-               	movq	0x18(%r8), %r13
-               	movq	-0x6b0(%rbp), %r8
-               	movq	0x20(%r8), %r14
-               	movq	-0x6b0(%rbp), %r8
-               	movq	0x28(%r8), %r15
-               	movq	%rax, -0x668(%rbp)
-               	movq	%rcx, -0x660(%rbp)
-               	movq	%rdx, -0x658(%rbp)
-               	movq	%r13, -0x650(%rbp)
-               	movq	%r14, -0x648(%rbp)
-               	movq	%r15, -0x640(%rbp)
-               	leaq	-0x668(%rbp), %rdx
-               	movq	-0x6a8(%rbp), %r8
-               	movq	%r8, %rcx
+               	movq	%rax, %rcx
+               	movq	-0x908(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L50>
 <L50>:
+               	movq	%rax, %rcx
+               	movq	-0x910(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L51>
+<L51>:
+               	movq	%rax, %rcx
+               	movq	-0x918(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L52>
+<L52>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	leaq	-0x7f8(%rbp), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movl	%r13d, %r14d
+               	movq	-0x928(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movl	%r14d, (%r15)
+               	leaq	-0x810(%rbp), %r14
+               	leaq	(%r14), %r15
+               	movq	%r13, (%r15)
+               	movq	%r13, %r15
+               	xorq	$-0x1, %r15
+               	leaq	0x8(%r14), %rax
+               	movq	%r15, (%rax)
+               	movq	%r13, %rax
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%r14), %r15
+               	movq	%rax, (%r15)
+               	movq	-0x928(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movq	(%r14), %r15
+               	movq	0x8(%r14), %rdx
+               	movq	0x10(%r14), %r8
+               	movq	%r8, -0x930(%rbp)
+               	movq	%r15, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	movq	-0x930(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	leaq	-0x820(%rbp), %rax
+               	movq	%r13, %rdx
+               	imulq	$0xb, %rdx, %rdx
+               	leaq	(%rax), %r14
+               	movq	%rdx, (%r14)
+               	xorq	$-0x1, %r13
+               	leaq	0x8(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	-0x928(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rax), %r13
+               	movq	0x8(%rax), %r14
+               	movq	%r13, (%rdx)
+               	movq	%r14, 0x8(%rdx)
+               	leaq	-0x850(%rbp), %r13
+               	movq	-0x928(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x928(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x928(%rbp), %r8
+               	movq	0x10(%r8), %r14
+               	movq	-0x928(%rbp), %r8
+               	movq	0x18(%r8), %r15
+               	movq	-0x928(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x938(%rbp)
+               	movq	-0x928(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x940(%rbp)
+               	movq	%rax, (%r13)
+               	movq	%rdx, 0x8(%r13)
+               	movq	%r14, 0x10(%r13)
+               	movq	%r15, 0x18(%r13)
+               	movq	-0x938(%rbp), %r8
+               	movq	%r8, 0x20(%r13)
+               	movq	-0x940(%rbp), %r8
+               	movq	%r8, 0x28(%r13)
+               	leaq	(%r13), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	-0x920(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L53>
+<L53>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x948(%rbp)
+               	movq	-0x948(%rbp), %r8
+               	leaq	0x8(%r13), %rdx
+               	leaq	-0x868(%rbp), %r14
+               	movq	(%rdx), %r15
+               	movq	0x8(%rdx), %rax
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	%r15, (%r14)
+               	movq	%rax, 0x8(%r14)
+               	movq	-0x950(%rbp), %r8
+               	movq	%r8, 0x10(%r14)
+               	movq	(%r14), %rax
+               	movq	0x8(%r14), %rdx
+               	movq	0x10(%r14), %r15
+               	movq	%rax, -0x880(%rbp)
+               	movq	%rdx, -0x878(%rbp)
+               	movq	%r15, -0x870(%rbp)
+               	leaq	-0x880(%rbp), %rdx
+               	movq	-0x948(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L54>
+<L54>:
+               	leaq	0x20(%r13), %r14
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %r13
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L55>
+<L55>:
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %r13
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L56>
+<L56>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x8, %r12
-               	jb	 <L12>
-<L51>:
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rax, %rdx
-               	imulq	$0x3, %rdx, %rdx
-               	addq	$0x1, %rdx
-               	movq	$0x0, %r12
-               	movq	%rax, %r13
-               	movq	%rcx, %r14
-               	movq	%rdx, %r15
-               	cmpq	$0x8, %r12
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
-               	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%r13, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x7c0(%rbp)
-               	movq	%r14, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x6b8(%rbp)
-               	movq	%r15, %rbx
-               	addq	%r13, %rbx
-               	movq	%rdi, %rcx
-               	movq	-0x7c0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movq	-0x6b8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r12
-               	movq	%rcx, %rdi
-               	movq	-0x7c0(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	-0x6b8(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	%rbx, %r15
-               	cmpq	$0x8, %r12
-               	jb	 <L52>
-<L56>:
-               	leaq	-0x30(%rbp), %rbx
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x2, %rax
-               	leaq	-0x220(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	%rax, %rdx
-               	addq	$0x1, %rdx
-               	leaq	0x8(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movq	%rax, %rdx
-               	addq	$0x2, %rdx
-               	leaq	0x10(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movq	%rax, %rdx
-               	imulq	$0x9, %rdx, %rdx
-               	leaq	0x18(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movq	%rax, %rdx
-               	xorq	$-0x1, %rdx
-               	leaq	0x20(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %r12
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	%rax, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movq	%r13, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
-               	movq	%r15, 0x28(%rbx)
-               	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L57>
-               	jmp	 <L65>
+               	jb	 <L11>
 <L57>:
-               	leaq	-0x60(%rbp), %rax
-               	movq	(%rbx), %rcx
-               	movq	0x8(%rbx), %rdx
-               	movq	0x10(%rbx), %r13
-               	movq	0x18(%rbx), %r14
-               	movq	0x20(%rbx), %r15
-               	movq	0x28(%rbx), %r8
-               	movq	%r8, -0x6c8(%rbp)
-               	movq	%rcx, (%rax)
-               	movq	%rdx, 0x8(%rax)
-               	movq	%r13, 0x10(%rax)
-               	movq	%r14, 0x18(%rax)
-               	movq	%r15, 0x20(%rax)
-               	movq	-0x6c8(%rbp), %r8
-               	movq	%r8, 0x28(%rax)
-               	leaq	(%rsi,%r12,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x6d0(%rbp)
-               	leaq	-0x90(%rbp), %r14
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r15
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x6d8(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x6e0(%rbp)
-               	movq	%rcx, -0xc0(%rbp)
-               	movq	%rdx, -0xb8(%rbp)
-               	movq	%r15, -0xb0(%rbp)
-               	movq	%r13, -0xa8(%rbp)
-               	movq	-0x6d8(%rbp), %r8
-               	movq	%r8, -0xa0(%rbp)
-               	movq	-0x6e0(%rbp), %r8
-               	movq	%r8, -0x98(%rbp)
-               	leaq	-0xc0(%rbp), %rdx
-               	movq	%r14, %rcx
-               	movq	-0x6d0(%rbp), %r8
-               	callq	 <L58>
+               	leaq	-0x18(%rbp), %r12
+               	movq	%rbx, %rax
+               	addq	$0x1, %rax
+               	leaq	-0x220(%rbp), %rdx
+               	leaq	(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	%rax, %r13
+               	xorq	$-0x1, %r13
+               	leaq	0x8(%rdx), %r14
+               	movq	%r13, (%r14)
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r14
+               	movq	%rax, (%r12)
+               	movq	%r13, 0x8(%r12)
+               	movq	%r14, 0x10(%r12)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
+               	jmp	 <L60>
 <L58>:
-               	movq	(%r14), %rax
-               	movq	0x8(%r14), %rcx
-               	movq	0x10(%r14), %rdx
-               	movq	0x18(%r14), %r13
-               	movq	0x20(%r14), %r15
-               	movq	0x28(%r14), %r8
-               	movq	%r8, -0x6e8(%rbp)
-               	movq	%rax, (%rbx)
-               	movq	%rcx, 0x8(%rbx)
-               	movq	%rdx, 0x10(%rbx)
-               	movq	%r13, 0x18(%rbx)
-               	movq	%r15, 0x20(%rbx)
-               	movq	-0x6e8(%rbp), %r8
-               	movq	%r8, 0x28(%rbx)
-               	leaq	(%rbx), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%rbx), %rax
-               	movq	(%rax), %r13
-               	leaq	0x10(%rbx), %rax
-               	movq	(%rax), %r14
-               	leaq	0x18(%rbx), %rax
+               	leaq	(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x960(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x968(%rbp)
+               	leaq	0x10(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x958(%rbp)
+               	leaq	(%rsi,%r13,8), %rax
                	movq	(%rax), %r15
-               	leaq	0x20(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6f0(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6f8(%rbp)
+               	leaq	-0x238(%rbp), %rax
+               	movq	-0x960(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%r15, %rdx
+               	leaq	(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%r15, %rdx
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	-0x958(%rbp), %r8
+               	movq	-0x960(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	leaq	0x10(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r15
+               	movq	%rdx, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	movq	%r15, 0x10(%r12)
+               	leaq	-0x250(%rbp), %rax
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %r14
+               	movq	0x10(%r12), %r15
+               	movq	%rdx, (%rax)
+               	movq	%r14, 0x8(%rax)
+               	movq	%r15, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r15
+               	movq	%rdx, -0x268(%rbp)
+               	movq	%r14, -0x260(%rbp)
+               	movq	%r15, -0x258(%rbp)
+               	leaq	-0x268(%rbp), %rdx
                	movq	%rdi, %rcx
                	callq	 <L59>
 <L59>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rcx
-               	movq	-0x6f0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
-               	movq	-0x6f8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L64>
-<L64>:
-               	addq	$0x1, %r12
+               	addq	$0x1, %r13
                	movq	%rax, %rdi
-               	cmpq	$0x8, %r12
-               	jb	 <L57>
-<L65>:
-               	leaq	-0x180(%rbp), %rbx
-               	leaq	(%rbx), %rax
-               	addq	$0x0, %rax
-               	movq	$0xc0, %rcx
-<L66>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L66>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
-               	leaq	(%rsi,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x6c0(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0x240(%rbp), %rcx
-               	leaq	(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movq	%rdx, %r12
-               	addq	$0x1, %r12
-               	leaq	0x8(%rcx), %r13
-               	movq	%r12, (%r13)
-               	movq	%rdx, %r12
-               	imulq	$0x5, %r12, %r12
-               	leaq	0x10(%rcx), %r13
-               	movq	%r12, (%r13)
-               	xorq	$-0x1, %rdx
-               	leaq	0x18(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movq	%rax, %rdx
-               	imulq	$0x20, %rdx, %rdx
-               	leaq	(%rbx,%rdx), %r12
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r13
-               	movq	0x10(%rcx), %r14
-               	movq	0x18(%rcx), %r15
-               	movq	%rdx, (%r12)
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
+<L60>:
+               	leaq	-0x48(%rbp), %r12
+               	movq	%rbx, %rax
+               	addq	$0x2, %rax
+               	leaq	-0x298(%rbp), %rdx
+               	leaq	(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	%rax, %r13
+               	addq	$0x1, %r13
+               	leaq	0x8(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movq	%rax, %r13
+               	addq	$0x2, %r13
+               	leaq	0x10(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movq	%rax, %r13
+               	imulq	$0x9, %r13, %r13
+               	leaq	0x18(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movq	%rax, %r13
+               	xorq	$-0x1, %r13
+               	leaq	0x20(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rax
+               	leaq	0x28(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r14
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x970(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x978(%rbp)
+               	movq	%rax, (%r12)
                	movq	%r13, 0x8(%r12)
                	movq	%r14, 0x10(%r12)
                	movq	%r15, 0x18(%r12)
-               	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-<L68>:
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L69>
-               	jmp	 <L74>
-<L69>:
-               	movq	%r12, %rax
-               	imulq	$0x20, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	movq	-0x970(%rbp), %r8
+               	movq	%r8, 0x20(%r12)
+               	movq	-0x978(%rbp), %r8
+               	movq	%r8, 0x28(%r12)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L61>
+               	jmp	 <L69>
+<L61>:
+               	leaq	-0x78(%rbp), %rax
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %r14
+               	movq	0x10(%r12), %r15
+               	movq	0x18(%r12), %r8
+               	movq	%r8, -0x980(%rbp)
+               	movq	0x20(%r12), %r8
+               	movq	%r8, -0x988(%rbp)
+               	movq	0x28(%r12), %r8
+               	movq	%r8, -0x990(%rbp)
+               	movq	%rdx, (%rax)
+               	movq	%r14, 0x8(%rax)
+               	movq	%r15, 0x10(%rax)
+               	movq	-0x980(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	-0x988(%rbp), %r8
+               	movq	%r8, 0x20(%rax)
+               	movq	-0x990(%rbp), %r8
+               	movq	%r8, 0x28(%rax)
+               	leaq	(%rsi,%r13,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x998(%rbp)
+               	leaq	-0xa8(%rbp), %r15
                	movq	(%rax), %rdx
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r13
-               	leaq	0x10(%rcx), %rax
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x9a0(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x9a8(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x9b0(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x9b8(%rbp)
+               	movq	%rdx, -0xd8(%rbp)
+               	movq	%r14, -0xd0(%rbp)
+               	movq	-0x9a0(%rbp), %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0x9a8(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0x9b0(%rbp), %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	movq	%r8, -0xb0(%rbp)
+               	leaq	-0xd8(%rbp), %rdx
+               	movq	%r15, %rcx
+               	movq	-0x998(%rbp), %r8
+               	callq	 <L62>
+<L62>:
+               	movq	(%r15), %rax
+               	movq	0x8(%r15), %rdx
+               	movq	0x10(%r15), %r14
+               	movq	0x18(%r15), %r8
+               	movq	%r8, -0x9c0(%rbp)
+               	movq	0x20(%r15), %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	movq	0x28(%r15), %r8
+               	movq	%r8, -0x9d0(%rbp)
+               	movq	%rax, (%r12)
+               	movq	%rdx, 0x8(%r12)
+               	movq	%r14, 0x10(%r12)
+               	movq	-0x9c0(%rbp), %r8
+               	movq	%r8, 0x18(%r12)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	%r8, 0x20(%r12)
+               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, 0x28(%r12)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rdx
+               	leaq	0x8(%r12), %rax
                	movq	(%rax), %r14
-               	leaq	0x18(%rcx), %rax
+               	leaq	0x10(%r12), %rax
                	movq	(%rax), %r15
+               	leaq	0x18(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9d8(%rbp)
+               	leaq	0x20(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9e0(%rbp)
+               	leaq	0x28(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9e8(%rbp)
                	movq	%rdi, %rcx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L71>
-<L71>:
+               	callq	 <L63>
+<L63>:
                	movq	%rax, %rcx
                	movq	%r14, %rdx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L64>
+<L64>:
                	movq	%rax, %rcx
                	movq	%r15, %rdx
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %r12
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rcx
+               	movq	-0x9d8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rcx
+               	movq	-0x9e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rcx
+               	movq	-0x9e8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L68>
+<L68>:
+               	addq	$0x1, %r13
                	movq	%rax, %rdi
-               	cmpq	$0x6, %r12
-               	jb	 <L69>
+               	cmpq	$0x8, %r13
+               	jb	 <L61>
+<L69>:
+               	leaq	-0x198(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rdx
+<L70>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L70>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9f0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+               	jmp	 <L72>
+<L71>:
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%rsi,%r8,8), %rdx
+               	movq	(%rdx), %r13
+               	addq	%rbx, %r13
+               	leaq	-0x2b8(%rbp), %rdx
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movq	%r13, %r14
+               	addq	$0x1, %r14
+               	leaq	0x8(%rdx), %r15
+               	movq	%r14, (%r15)
+               	movq	%r13, %r14
+               	imulq	$0x5, %r14, %r14
+               	leaq	0x10(%rdx), %r15
+               	movq	%r14, (%r15)
+               	xorq	$-0x1, %r13
+               	leaq	0x18(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %r13
+               	imulq	$0x20, %r13, %r13
+               	leaq	(%r12,%r13), %r14
+               	movq	(%rdx), %r13
+               	movq	0x8(%rdx), %r15
+               	movq	0x10(%rdx), %rax
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x9f8(%rbp)
+               	movq	%r13, (%r14)
+               	movq	%r15, 0x8(%r14)
+               	movq	%rax, 0x10(%r14)
+               	movq	-0x9f8(%rbp), %r8
+               	movq	%r8, 0x18(%r14)
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9f0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+<L72>:
+               	movq	$0x0, %r13
+               	cmpq	$0x6, %r13
+               	jb	 <L73>
+               	jmp	 <L75>
+<L73>:
+               	movq	%r13, %rax
+               	imulq	$0x20, %rax, %rax
+               	leaq	(%r12,%rax), %rdx
+               	leaq	-0x1b8(%rbp), %rax
+               	movq	(%rdx), %r14
+               	movq	0x8(%rdx), %r15
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0xa00(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0xa08(%rbp)
+               	movq	%r14, (%rax)
+               	movq	%r15, 0x8(%rax)
+               	movq	-0xa00(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	movq	-0xa08(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	0x10(%rax), %r15
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0xa10(%rbp)
+               	movq	%rdx, -0x1d8(%rbp)
+               	movq	%r14, -0x1d0(%rbp)
+               	movq	%r15, -0x1c8(%rbp)
+               	movq	-0xa10(%rbp), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	leaq	-0x1d8(%rbp), %rdx
+               	movq	%rdi, %rcx
+               	callq	 <L74>
 <L74>:
-               	leaq	-0x1b0(%rbp), %rax
+               	addq	$0x1, %r13
+               	movq	%rax, %rdi
+               	cmpq	$0x6, %r13
+               	jb	 <L73>
+<L75>:
+               	leaq	-0x208(%rbp), %rax
                	movq	$0x0, (%rax)
                	movq	$0x0, 0x8(%rax)
                	movq	$0x0, 0x10(%rax)
                	movq	$0x0, 0x18(%rax)
                	movq	$0x0, 0x20(%rax)
                	movq	$0x0, 0x28(%rax)
-               	leaq	(%rax), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rdx
-               	xorq	$-0x1, %rdx
-               	movq	%rcx, %rbx
-               	imulq	$0x3, %rbx, %rbx
-               	addq	$0x1, %rbx
-               	leaq	(%rsi), %r12
-               	movq	(%r12), %r13
-               	leaq	-0x2b8(%rbp), %r12
-               	movq	%rcx, %r14
-               	addq	%r13, %r14
-               	leaq	(%r12), %r15
-               	movq	%r14, (%r15)
-               	xorq	%r13, %rdx
-               	leaq	0x8(%r12), %r13
-               	movq	%rdx, (%r13)
-               	addq	%rcx, %rbx
-               	leaq	0x10(%r12), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	(%r12), %rdx
-               	movq	0x8(%r12), %rbx
-               	movq	0x10(%r12), %r13
-               	movq	%rdx, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movq	%r13, 0x10(%rcx)
-               	leaq	-0x2c8(%rbp), %rcx
-               	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %rbx
-               	leaq	(%rcx), %rdx
-               	movq	%rbx, (%rdx)
-               	leaq	0x10(%rsi), %rdx
-               	movq	(%rdx), %rbx
-               	leaq	0x8(%rcx), %rdx
-               	movq	%rbx, (%rdx)
-               	leaq	0x20(%rax), %rdx
-               	movq	(%rcx), %rbx
-               	movq	0x8(%rcx), %r12
-               	movq	%rbx, (%rdx)
-               	movq	%r12, 0x8(%rdx)
-               	leaq	-0x2f8(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rbx
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	%rdx, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movq	%r12, 0x10(%rcx)
-               	movq	%r13, 0x18(%rcx)
-               	movq	%r14, 0x20(%rcx)
-               	movq	%r15, 0x28(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rbx
-               	movq	0x18(%rcx), %r12
-               	movq	0x20(%rcx), %r13
-               	movq	0x28(%rcx), %r14
-               	movq	%rax, -0x328(%rbp)
-               	movq	%rdx, -0x320(%rbp)
-               	movq	%rbx, -0x318(%rbp)
-               	movq	%r12, -0x310(%rbp)
-               	movq	%r13, -0x308(%rbp)
-               	movq	%r14, -0x300(%rbp)
-               	leaq	-0x328(%rbp), %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %rdi
-               	cmpq	$0x4, %rdi
-               	jb	 <L76>
-               	jmp	 <L109>
-<L76>:
-               	leaq	(%rsi,%rdi,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%rcx, %r12
-               	addq	%r8, %r12
-               	leaq	-0x258(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r12, (%rcx)
-               	movq	%r12, %rcx
-               	xorq	$-0x1, %rcx
+               	leaq	(%rax), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movq	%rbx, %rdx
+               	addq	$0x3, %rdx
+               	movq	%rdx, %r8
+               	movq	%r8, -0xa20(%rbp)
+               	xorq	$-0x1, %r8
+               	movq	%r8, -0xa20(%rbp)
+               	movq	%rdx, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	%r13, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0xa18(%rbp)
+               	leaq	(%rsi), %r14
+               	movq	(%r14), %r15
+               	leaq	-0x370(%rbp), %r14
+               	movq	%rdx, %r13
+               	addq	%r15, %r13
+               	leaq	(%r14), %r12
+               	movq	%r13, (%r12)
+               	movq	-0xa20(%rbp), %r8
+               	movq	%r8, %r12
+               	xorq	%r15, %r12
+               	leaq	0x8(%r14), %r13
+               	movq	%r12, (%r13)
+               	movq	-0xa18(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	%rdx, %r12
+               	leaq	0x10(%r14), %rdx
+               	movq	%r12, (%rdx)
                	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x288(%rbp), %r13
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
+               	movq	(%r14), %r12
+               	movq	0x8(%r14), %r13
+               	movq	0x10(%r14), %r15
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movq	%r15, 0x10(%rdx)
+               	leaq	-0x380(%rbp), %rdx
+               	leaq	0x8(%rsi), %r12
+               	movq	(%r12), %r13
+               	leaq	(%rdx), %r12
+               	movq	%r13, (%r12)
+               	leaq	0x10(%rsi), %r12
+               	movq	(%r12), %r13
+               	leaq	0x8(%rdx), %r12
+               	movq	%r13, (%r12)
+               	leaq	0x20(%rax), %r12
+               	movq	(%rdx), %r13
+               	movq	0x8(%rdx), %r14
+               	movq	%r13, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	leaq	-0x3b0(%rbp), %rdx
+               	movq	(%rax), %r12
+               	movq	0x8(%rax), %r13
                	movq	0x10(%rax), %r14
-               	movq	%rcx, -0x2a0(%rbp)
-               	movq	%rdx, -0x298(%rbp)
-               	movq	%r14, -0x290(%rbp)
-               	leaq	-0x2a0(%rbp), %rdx
-               	movq	%r13, %rcx
+               	movq	0x18(%rax), %r15
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
+               	movq	%r15, 0x18(%rdx)
+               	movq	-0xa28(%rbp), %r8
+               	movq	%r8, 0x20(%rdx)
+               	movq	-0xa30(%rbp), %r8
+               	movq	%r8, 0x28(%rdx)
+               	leaq	-0x488(%rbp), %r12
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r14
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0xa38(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0xa40(%rbp)
+               	movq	%rax, (%r12)
+               	movq	%r13, 0x8(%r12)
+               	movq	%r14, 0x10(%r12)
+               	movq	%r15, 0x18(%r12)
+               	movq	-0xa38(%rbp), %r8
+               	movq	%r8, 0x20(%r12)
+               	movq	-0xa40(%rbp), %r8
+               	movq	%r8, 0x28(%r12)
+               	leaq	(%r12), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L76>
+<L76>:
+               	leaq	0x8(%r12), %rdx
+               	leaq	-0x4a0(%rbp), %rdi
+               	movq	(%rdx), %r13
+               	movq	0x8(%rdx), %r14
+               	movq	0x10(%rdx), %r15
+               	movq	%r13, (%rdi)
+               	movq	%r14, 0x8(%rdi)
+               	movq	%r15, 0x10(%rdi)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %r13
+               	movq	0x10(%rdi), %r14
+               	movq	%rdx, -0x4b8(%rbp)
+               	movq	%r13, -0x4b0(%rbp)
+               	movq	%r14, -0x4a8(%rbp)
+               	leaq	-0x4b8(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L77>
 <L77>:
-               	leaq	-0x358(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r12, (%rcx)
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x370(%rbp), %r14
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r15
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x700(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x708(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x710(%rbp)
-               	movq	%rcx, -0x3a0(%rbp)
-               	movq	%rdx, -0x398(%rbp)
-               	movq	%r15, -0x390(%rbp)
-               	movq	-0x700(%rbp), %r8
-               	movq	%r8, -0x388(%rbp)
-               	movq	-0x708(%rbp), %r8
-               	movq	%r8, -0x380(%rbp)
-               	movq	-0x710(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
-               	leaq	-0x3a0(%rbp), %rdx
-               	movq	%r14, %rcx
+               	leaq	0x20(%r12), %rdi
+               	leaq	(%rdi), %rdx
+               	movq	(%rdx), %r12
+               	movq	%rax, %rcx
+               	movq	%r12, %rdx
                	callq	 <L78>
 <L78>:
-               	leaq	(%r13), %rax
-               	movq	(%rax), %r15
-               	leaq	0x8(%r13), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x718(%rbp)
-               	leaq	0x10(%r13), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x720(%rbp)
-               	leaq	0x18(%r13), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x728(%rbp)
-               	leaq	0x20(%r13), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x730(%rbp)
-               	leaq	0x28(%r13), %rax
-               	movq	(%rax), %r13
-               	leaq	(%r14), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x738(%rbp)
-               	leaq	0x8(%r14), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x740(%rbp)
-               	leaq	0x10(%r14), %rax
-               	movq	(%rax), %r14
+               	leaq	0x8(%rdi), %rdx
+               	movq	(%rdx), %rdi
+               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
                	callq	 <L79>
 <L79>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L80>
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L80>
+               	jmp	 <L106>
 <L80>:
-               	movq	%rax, %rcx
-               	movq	-0x718(%rbp), %r8
-               	movq	%r8, %rdx
+               	leaq	(%rsi,%r12,8), %rax
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r13
+               	addq	%rbx, %r13
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
+               	movq	%r13, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %r14
+               	movq	%rdx, (%r14)
+               	leaq	-0x300(%rbp), %r14
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r15
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0xa48(%rbp)
+               	movq	%rdx, -0x318(%rbp)
+               	movq	%r15, -0x310(%rbp)
+               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0x308(%rbp)
+               	leaq	-0x318(%rbp), %rdx
+               	movq	%r14, %rcx
                	callq	 <L81>
 <L81>:
-               	movq	%rax, %rcx
-               	movq	-0x720(%rbp), %r8
-               	movq	%r8, %rdx
+               	leaq	-0x3e0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	addq	$0x2, %rdx
+               	leaq	0x10(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	imulq	$0x9, %rdx, %rdx
+               	leaq	0x18(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x20(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rdx
+               	leaq	0x28(%rax), %r15
+               	movq	%rdx, (%r15)
+               	leaq	-0x3f8(%rbp), %r15
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0xa50(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0xa58(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0xa60(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0xa68(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0xa70(%rbp)
+               	movq	%rdx, -0x428(%rbp)
+               	movq	-0xa50(%rbp), %r8
+               	movq	%r8, -0x420(%rbp)
+               	movq	-0xa58(%rbp), %r8
+               	movq	%r8, -0x418(%rbp)
+               	movq	-0xa60(%rbp), %r8
+               	movq	%r8, -0x410(%rbp)
+               	movq	-0xa68(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0xa70(%rbp), %r8
+               	movq	%r8, -0x400(%rbp)
+               	leaq	-0x428(%rbp), %rdx
+               	movq	%r15, %rcx
                	callq	 <L82>
 <L82>:
-               	movq	%rax, %rcx
-               	movq	-0x728(%rbp), %r8
+               	leaq	(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0xa98(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0xa78(%rbp)
+               	leaq	0x10(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0xa80(%rbp)
+               	leaq	0x18(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0xa88(%rbp)
+               	leaq	0x20(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0xa90(%rbp)
+               	leaq	0x28(%r14), %rax
+               	movq	(%rax), %r14
+               	leaq	-0x4d0(%rbp), %r8
+               	movq	%r8, -0xbc0(%rbp)
+               	movq	(%r15), %rdx
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0xaa0(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0xaa8(%rbp)
+               	movq	-0xbc0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0xbc0(%rbp), %r8
+               	movq	-0xaa0(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0xbc0(%rbp), %r8
+               	movq	-0xaa8(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	-0xa98(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L83>
 <L83>:
-               	movq	%rax, %rcx
-               	movq	-0x730(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xa78(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L84>
 <L84>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xa80(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L85>
 <L85>:
-               	movq	%rax, %rcx
-               	movq	-0x738(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xa88(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L86>
 <L86>:
-               	movq	%rax, %rcx
-               	movq	-0x740(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xa90(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L87>
 <L87>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
                	movq	%r14, %rdx
                	callq	 <L88>
 <L88>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0xab0(%rbp)
+               	movq	-0xab0(%rbp), %r8
+               	leaq	-0x4e8(%rbp), %r14
+               	movq	-0xbc0(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0xbc0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0xbc0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0xab8(%rbp)
+               	movq	%r15, (%r14)
+               	movq	%rdx, 0x8(%r14)
+               	movq	-0xab8(%rbp), %r8
+               	movq	%r8, 0x10(%r14)
+               	movq	(%r14), %rax
+               	movq	0x8(%r14), %rdx
+               	movq	0x10(%r14), %r15
+               	movq	%rax, -0x500(%rbp)
+               	movq	%rdx, -0x4f8(%rbp)
+               	movq	%r15, -0x4f0(%rbp)
+               	leaq	-0x500(%rbp), %rdx
+               	movq	-0xab0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L89>
 <L89>:
-               	movq	%rbx, %rcx
-               	movq	%rax, %rdx
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
                	callq	 <L90>
 <L90>:
-               	movq	%rax, %r13
-               	leaq	-0x3d0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r12, (%rcx)
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x3e8(%rbp), %r14
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r15
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x748(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x750(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x758(%rbp)
-               	movq	%rcx, -0x418(%rbp)
-               	movq	%rdx, -0x410(%rbp)
-               	movq	%r15, -0x408(%rbp)
-               	movq	-0x748(%rbp), %r8
-               	movq	%r8, -0x400(%rbp)
-               	movq	-0x750(%rbp), %r8
-               	movq	%r8, -0x3f8(%rbp)
-               	movq	-0x758(%rbp), %r8
-               	movq	%r8, -0x3f0(%rbp)
-               	leaq	-0x418(%rbp), %rdx
-               	movq	%r14, %rcx
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdx
                	callq	 <L91>
 <L91>:
-               	leaq	-0x448(%rbp), %r15
-               	movq	(%r14), %rax
-               	movq	0x8(%r14), %rcx
-               	movq	0x10(%r14), %rdx
-               	movq	%rax, -0x460(%rbp)
-               	movq	%rcx, -0x458(%rbp)
-               	movq	%rdx, -0x450(%rbp)
-               	leaq	-0x460(%rbp), %rdx
+               	movq	%rax, %r14
+               	leaq	-0x530(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	addq	$0x2, %rdx
+               	leaq	0x10(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	imulq	$0x9, %rdx, %rdx
+               	leaq	0x18(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x20(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rdx
+               	leaq	0x28(%rax), %r15
+               	movq	%rdx, (%r15)
+               	leaq	-0x548(%rbp), %r15
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0xac0(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0xac8(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0xad0(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0xad8(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0xae0(%rbp)
+               	movq	%rdx, -0x578(%rbp)
+               	movq	-0xac0(%rbp), %r8
+               	movq	%r8, -0x570(%rbp)
+               	movq	-0xac8(%rbp), %r8
+               	movq	%r8, -0x568(%rbp)
+               	movq	-0xad0(%rbp), %r8
+               	movq	%r8, -0x560(%rbp)
+               	movq	-0xad8(%rbp), %r8
+               	movq	%r8, -0x558(%rbp)
+               	movq	-0xae0(%rbp), %r8
+               	movq	%r8, -0x550(%rbp)
+               	leaq	-0x578(%rbp), %rdx
                	movq	%r15, %rcx
                	callq	 <L92>
 <L92>:
-               	leaq	(%r15), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r15), %rax
-               	movq	(%rax), %r14
-               	leaq	0x10(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x760(%rbp)
-               	leaq	0x18(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x768(%rbp)
-               	leaq	0x20(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x770(%rbp)
-               	leaq	0x28(%r15), %rax
-               	movq	(%rax), %r15
-               	movq	%r13, %rcx
+               	leaq	-0x5a8(%rbp), %r8
+               	movq	%r8, -0xbc8(%rbp)
+               	movq	(%r15), %rdx
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0xae8(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0xaf0(%rbp)
+               	movq	%rdx, -0x5c0(%rbp)
+               	movq	-0xae8(%rbp), %r8
+               	movq	%r8, -0x5b8(%rbp)
+               	movq	-0xaf0(%rbp), %r8
+               	movq	%r8, -0x5b0(%rbp)
+               	leaq	-0x5c0(%rbp), %rdx
+               	movq	-0xbc8(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L93>
 <L93>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	-0xbc8(%rbp), %r8
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r15
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xaf8(%rbp)
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xb00(%rbp)
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xb08(%rbp)
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xb10(%rbp)
+               	movq	-0xbc8(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xbd0(%rbp)
+               	movq	%r14, %rcx
+               	movq	%r15, %rdx
                	callq	 <L94>
 <L94>:
-               	movq	%rax, %rcx
-               	movq	-0x760(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xaf8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L95>
 <L95>:
-               	movq	%rax, %rcx
-               	movq	-0x768(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb00(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L96>
 <L96>:
-               	movq	%rax, %rcx
-               	movq	-0x770(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb08(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L97>
 <L97>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb10(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L98>
 <L98>:
-               	movq	%rax, %r13
-               	leaq	-0x478(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r12, (%rcx)
-               	movq	%r12, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x4a8(%rbp), %r14
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r15
-               	movq	%rcx, -0x4c0(%rbp)
-               	movq	%rdx, -0x4b8(%rbp)
-               	movq	%r15, -0x4b0(%rbp)
-               	leaq	-0x4c0(%rbp), %rdx
-               	movq	%r14, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xbd0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L99>
 <L99>:
-               	leaq	-0x4d8(%rbp), %r15
-               	movq	(%r14), %rax
-               	movq	0x8(%r14), %rcx
-               	movq	0x10(%r14), %rdx
-               	movq	0x18(%r14), %r8
-               	movq	%r8, -0x778(%rbp)
-               	movq	0x20(%r14), %r8
-               	movq	%r8, -0x780(%rbp)
-               	movq	0x28(%r14), %r8
-               	movq	%r8, -0x788(%rbp)
-               	movq	%rax, -0x508(%rbp)
-               	movq	%rcx, -0x500(%rbp)
-               	movq	%rdx, -0x4f8(%rbp)
-               	movq	-0x778(%rbp), %r8
-               	movq	%r8, -0x4f0(%rbp)
-               	movq	-0x780(%rbp), %r8
-               	movq	%r8, -0x4e8(%rbp)
-               	movq	-0x788(%rbp), %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	leaq	-0x508(%rbp), %rdx
+               	movq	%rax, %r14
+               	leaq	-0x618(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %r15
+               	movq	%rdx, (%r15)
+               	leaq	-0x648(%rbp), %r15
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0xb18(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0xb20(%rbp)
+               	movq	%rdx, -0x660(%rbp)
+               	movq	-0xb18(%rbp), %r8
+               	movq	%r8, -0x658(%rbp)
+               	movq	-0xb20(%rbp), %r8
+               	movq	%r8, -0x650(%rbp)
+               	leaq	-0x660(%rbp), %rdx
                	movq	%r15, %rcx
                	callq	 <L100>
 <L100>:
-               	leaq	(%r15), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r15), %rax
-               	movq	(%rax), %r14
-               	leaq	0x10(%r15), %rax
-               	movq	(%rax), %r15
-               	movq	%r13, %rcx
+               	leaq	-0x678(%rbp), %r8
+               	movq	%r8, -0xbd8(%rbp)
+               	movq	(%r15), %rdx
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0xb28(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0xb30(%rbp)
+               	movq	0x18(%r15), %r8
+               	movq	%r8, -0xb38(%rbp)
+               	movq	0x20(%r15), %r8
+               	movq	%r8, -0xb40(%rbp)
+               	movq	0x28(%r15), %r8
+               	movq	%r8, -0xb48(%rbp)
+               	movq	%rdx, -0x6a8(%rbp)
+               	movq	-0xb28(%rbp), %r8
+               	movq	%r8, -0x6a0(%rbp)
+               	movq	-0xb30(%rbp), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	-0xb38(%rbp), %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0xb40(%rbp), %r8
+               	movq	%r8, -0x688(%rbp)
+               	movq	-0xb48(%rbp), %r8
+               	movq	%r8, -0x680(%rbp)
+               	leaq	-0x6a8(%rbp), %rdx
+               	movq	-0xbd8(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L101>
 <L101>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
+               	movq	-0xbd8(%rbp), %r8
+               	movq	-0xbd8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xbd8(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0xbd8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0xb50(%rbp)
+               	movq	%rdx, -0x6c0(%rbp)
+               	movq	%r15, -0x6b8(%rbp)
+               	movq	-0xb50(%rbp), %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	leaq	-0x6c0(%rbp), %rdx
+               	movq	%r14, %rcx
                	callq	 <L102>
 <L102>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
+               	movq	%rax, %r14
+               	leaq	-0x6f0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r13, (%rdx)
+               	movq	%r13, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	addq	$0x2, %rdx
+               	leaq	0x10(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	imulq	$0x9, %rdx, %rdx
+               	leaq	0x18(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x20(%rax), %r15
+               	movq	%rdx, (%r15)
+               	movq	%r13, %rdx
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rdx
+               	leaq	0x28(%rax), %r15
+               	movq	%rdx, (%r15)
+               	leaq	-0x720(%rbp), %r15
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0xb58(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0xb60(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0xb68(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0xb70(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0xb78(%rbp)
+               	movq	%rdx, -0x750(%rbp)
+               	movq	-0xb58(%rbp), %r8
+               	movq	%r8, -0x748(%rbp)
+               	movq	-0xb60(%rbp), %r8
+               	movq	%r8, -0x740(%rbp)
+               	movq	-0xb68(%rbp), %r8
+               	movq	%r8, -0x738(%rbp)
+               	movq	-0xb70(%rbp), %r8
+               	movq	%r8, -0x730(%rbp)
+               	movq	-0xb78(%rbp), %r8
+               	movq	%r8, -0x728(%rbp)
+               	leaq	-0x750(%rbp), %rdx
+               	movq	%r15, %rcx
+               	movq	%r13, %r8
                	callq	 <L103>
 <L103>:
-               	movq	%rax, %r13
-               	leaq	-0x538(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r12, (%rcx)
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x568(%rbp), %r14
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r15
-               	movq	0x18(%rax), %r8
+               	leaq	-0x768(%rbp), %r8
+               	movq	%r8, -0xbe0(%rbp)
+               	movq	(%r15), %rdx
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0xb80(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0xb88(%rbp)
+               	movq	0x18(%r15), %r8
+               	movq	%r8, -0xb90(%rbp)
+               	movq	0x20(%r15), %r8
+               	movq	%r8, -0xb98(%rbp)
+               	movq	0x28(%r15), %r8
+               	movq	%r8, -0xba0(%rbp)
+               	movq	%rdx, -0x798(%rbp)
+               	movq	-0xb80(%rbp), %r8
                	movq	%r8, -0x790(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x798(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x7a0(%rbp)
-               	movq	%rcx, -0x598(%rbp)
-               	movq	%rdx, -0x590(%rbp)
-               	movq	%r15, -0x588(%rbp)
-               	movq	-0x790(%rbp), %r8
-               	movq	%r8, -0x580(%rbp)
-               	movq	-0x798(%rbp), %r8
-               	movq	%r8, -0x578(%rbp)
-               	movq	-0x7a0(%rbp), %r8
-               	movq	%r8, -0x570(%rbp)
-               	leaq	-0x598(%rbp), %rdx
-               	movq	%r14, %rcx
-               	movq	%r12, %r8
+               	movq	-0xb88(%rbp), %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	-0xb90(%rbp), %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	-0xb98(%rbp), %r8
+               	movq	%r8, -0x778(%rbp)
+               	movq	-0xba0(%rbp), %r8
+               	movq	%r8, -0x770(%rbp)
+               	leaq	-0x798(%rbp), %rdx
+               	movq	-0xbe0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L104>
 <L104>:
-               	leaq	-0x5b0(%rbp), %r15
-               	movq	(%r14), %rax
-               	movq	0x8(%r14), %rcx
-               	movq	0x10(%r14), %rdx
-               	movq	0x18(%r14), %r8
-               	movq	%r8, -0x7a8(%rbp)
-               	movq	0x20(%r14), %r8
-               	movq	%r8, -0x7b0(%rbp)
-               	movq	0x28(%r14), %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	%rax, -0x5e0(%rbp)
-               	movq	%rcx, -0x5d8(%rbp)
-               	movq	%rdx, -0x5d0(%rbp)
-               	movq	-0x7a8(%rbp), %r8
-               	movq	%r8, -0x5c8(%rbp)
-               	movq	-0x7b0(%rbp), %r8
-               	movq	%r8, -0x5c0(%rbp)
-               	movq	-0x7b8(%rbp), %r8
-               	movq	%r8, -0x5b8(%rbp)
-               	leaq	-0x5e0(%rbp), %rdx
-               	movq	%r15, %rcx
+               	movq	-0xbe0(%rbp), %r8
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xba8(%rbp)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xbb8(%rbp)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0xbb0(%rbp)
+               	leaq	-0x7b0(%rbp), %rdx
+               	movq	-0xba8(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%r13, %rax
+               	leaq	(%rdx), %r15
+               	movq	%rax, (%r15)
+               	movq	-0xbb8(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%r13, %rax
+               	leaq	0x8(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	-0xbb0(%rbp), %r8
+               	movq	-0xba8(%rbp), %r9
+               	movq	%r8, %rax
+               	addq	%r9, %rax
+               	leaq	0x10(%rdx), %r13
+               	movq	%rax, (%r13)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r15
+               	movq	%rax, -0x7c8(%rbp)
+               	movq	%r13, -0x7c0(%rbp)
+               	movq	%r15, -0x7b8(%rbp)
+               	leaq	-0x7c8(%rbp), %rdx
+               	movq	%r14, %rcx
                	callq	 <L105>
 <L105>:
-               	leaq	(%r15), %rax
-               	movq	(%rax), %rcx
-               	leaq	0x8(%r15), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x10(%r15), %rax
-               	movq	(%rax), %r14
-               	movq	%rcx, %rax
-               	addq	%r12, %rax
-               	movq	%rdx, %r15
-               	xorq	%r12, %r15
-               	addq	%rcx, %r14
-               	movq	%r13, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L106>
+               	addq	$0x1, %r12
+               	movq	%rax, %rdi
+               	cmpq	$0x4, %r12
+               	jb	 <L80>
 <L106>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L108>
-<L108>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rbx
-               	cmpq	$0x4, %rdi
-               	jb	 <L76>
-<L109>:
-               	movq	%rbx, %rax
-               	movaps	-0x810(%rbp), %xmm6
-               	movaps	-0x820(%rbp), %xmm7
-               	movaps	-0x830(%rbp), %xmm14
-               	movaps	-0x840(%rbp), %xmm15
-               	movq	-0x7c8(%rbp), %rbx
-               	movq	-0x7d0(%rbp), %rdi
-               	movq	-0x7d8(%rbp), %rsi
-               	movq	-0x7e0(%rbp), %r12
-               	movq	-0x7e8(%rbp), %r13
-               	movq	-0x7f0(%rbp), %r14
-               	movq	-0x7f8(%rbp), %r15
+               	movq	%rdi, %rax
+               	movaps	-0xc30(%rbp), %xmm6
+               	movaps	-0xc40(%rbp), %xmm14
+               	movaps	-0xc50(%rbp), %xmm15
+               	movq	-0xbe8(%rbp), %rbx
+               	movq	-0xbf0(%rbp), %rdi
+               	movq	-0xbf8(%rbp), %rsi
+               	movq	-0xc00(%rbp), %r12
+               	movq	-0xc08(%rbp), %r13
+               	movq	-0xc10(%rbp), %r14
+               	movq	-0xc18(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_ret_small.dis
+++ b/test/golden/x86_64-windows/call/call_ret_small.dis
@@ -329,23 +329,63 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold8>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
                	leaq	-0x8(%rbp), %rdx
                	movl	(%rdx), %ebx
                	leaq	-0x4(%rbp), %rdx
                	movl	(%rdx), %esi
                	movl	%ebx, %edx
-               	callq	 <L0>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
+               	movl	%esi, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -353,21 +393,63 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold8f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movaps	%xmm6, -0x20(%rbp)
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
                	leaq	-0x8(%rbp), %rdx
                	movss	(%rdx), %xmm0
                	leaq	-0x4(%rbp), %rdx
-               	movss	(%rdx), %xmm6
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movss	(%rdx), %xmm1
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x20(%rbp), %xmm6
+               	movd	%xmm1, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -375,28 +457,144 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movl	(%rbx), %esi
                	leaq	0x4(%rdx), %rbx
                	movl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movl	(%rbx), %r12d
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	movl	(%rbx), %edx
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L2>
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_ret_small.fold16>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -405,24 +603,60 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_ret_small.fold16>:
+<corpus.cases.call.call_ret_small.fold16f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
-               	movq	(%rbx), %rsi
+               	movsd	(%rbx), %xmm0
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rdi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movsd	(%rbx), %xmm1
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -430,49 +664,62 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
-<corpus.cases.call.call_ret_small.fold16f>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	leaq	(%rdx), %rbx
-               	movsd	(%rbx), %xmm1
-               	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
-<L1>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movq	-0x8(%rbp), %rbx
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
 <corpus.cases.call.call_ret_small.fold16m>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rsi, -0x10(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movq	(%rbx), %rsi
                	leaq	0x8(%rdx), %rbx
-               	movsd	(%rbx), %xmm6
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movsd	(%rbx), %xmm0
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x20(%rbp), %xmm6
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rsi
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -480,21 +727,61 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold16n>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rsi, -0x10(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
-               	movsd	(%rbx), %xmm1
+               	movsd	(%rbx), %xmm0
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %rsi
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rsi
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -502,20 +789,36 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	$0x1, %rdx
-               	callq	 <L0>
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rsi, -0x10(%rbp)
+               	movq	%rcx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0x2, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
                	movq	%rax, %rcx
-               	movq	$0x4, %rdx
+               	movq	$0x2, %rdx
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
@@ -523,11 +826,11 @@ Disassembly of section .text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
-               	movq	$0xc, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rcx
-               	movq	$0x10, %rdx
+               	movq	$0xc, %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rcx
@@ -542,6 +845,12 @@ Disassembly of section .text:
                	movq	$0x10, %rdx
                	callq	 <L9>
 <L9>:
+               	movq	%rax, %rcx
+               	movq	$0x10, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -549,119 +858,117 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.regain>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xc0, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movaps	%xmm6, -0x60(%rbp)
-               	movaps	%xmm7, -0x70(%rbp)
-               	movaps	%xmm8, -0x80(%rbp)
-               	movaps	%xmm9, -0x90(%rbp)
-               	movaps	%xmm10, -0xa0(%rbp)
-               	movq	%r8, %rbx
-               	movq	%r9, %rsi
-               	leaq	0x30(%rbp), %rdi
-               	leaq	0x38(%rbp), %r12
-               	leaq	(%rcx), %r13
-               	movq	(%r13), %r14
-               	leaq	0x8(%rcx), %r13
-               	movq	(%r13), %r15
-               	leaq	(%rdx), %rcx
-               	movsd	(%rcx), %xmm6
-               	leaq	0x8(%rdx), %rcx
-               	movsd	(%rcx), %xmm7
-               	leaq	(%rbx), %rcx
+               	subq	$0x140, %rsp            # imm = 0x140
+               	movq	%rbx, -0xe8(%rbp)
+               	movq	%rdi, -0xf0(%rbp)
+               	movq	%rsi, -0xf8(%rbp)
+               	movq	%r12, -0x100(%rbp)
+               	movq	%r13, -0x108(%rbp)
+               	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
+               	movq	%r8, %rax
+               	movq	%r9, %rbx
+               	leaq	0x30(%rbp), %rsi
+               	leaq	0x38(%rbp), %rdi
+               	leaq	-0x10(%rbp), %r12
                	movq	(%rcx), %r13
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm8
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x8(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %esi
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x10(%rbp)
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm9
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm10
+               	movq	0x8(%rcx), %r14
+               	movq	%r13, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	leaq	-0x20(%rbp), %r13
+               	movq	(%rdx), %rcx
+               	movq	0x8(%rdx), %r14
+               	movq	%rcx, (%r13)
+               	movq	%r14, 0x8(%r13)
+               	leaq	-0x30(%rbp), %r14
+               	movq	(%rax), %rcx
+               	movq	0x8(%rax), %rdx
+               	movq	%rcx, (%r14)
+               	movq	%rdx, 0x8(%r14)
+               	leaq	-0x3c(%rbp), %r15
+               	movq	(%rbx), %rax
+               	movl	0x8(%rbx), %ecx
+               	movq	%rax, (%r15)
+               	movl	%ecx, 0x8(%r15)
+               	leaq	-0x44(%rbp), %rbx
+               	movq	(%rsi), %rax
+               	movq	%rax, (%rbx)
+               	leaq	-0x4c(%rbp), %rsi
+               	movq	(%rdi), %rax
+               	movq	%rax, (%rsi)
+               	leaq	-0x60(%rbp), %rax
+               	movq	(%r12), %rcx
+               	movq	0x8(%r12), %rdx
+               	movq	%rcx, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	movq	(%rax), %rcx
+               	movq	0x8(%rax), %rdx
+               	movq	%rcx, -0x70(%rbp)
+               	movq	%rdx, -0x68(%rbp)
+               	leaq	-0x70(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	leaq	-0x80(%rbp), %rcx
+               	movq	(%r13), %rdx
+               	movq	0x8(%r13), %rdi
+               	movq	%rdx, (%rcx)
+               	movq	%rdi, 0x8(%rcx)
+               	movq	(%rcx), %rdx
+               	movq	0x8(%rcx), %rdi
+               	movq	%rdx, -0x90(%rbp)
+               	movq	%rdi, -0x88(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	%r14, %rdx
                	callq	 <L1>
 <L1>:
+               	leaq	-0xa0(%rbp), %rcx
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %rdi
+               	movq	%rdx, (%rcx)
+               	movq	%rdi, 0x8(%rcx)
+               	movq	(%rcx), %rdx
+               	movq	0x8(%rcx), %rdi
+               	movq	%rdx, -0xb0(%rbp)
+               	movq	%rdi, -0xa8(%rbp)
+               	leaq	-0xb0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	%r15, %rdx
                	callq	 <L2>
 <L2>:
+               	leaq	-0xbc(%rbp), %rcx
+               	movq	(%r15), %rdx
+               	movl	0x8(%r15), %edi
+               	movq	%rdx, (%rcx)
+               	movl	%edi, 0x8(%rcx)
+               	movq	(%rcx), %rdx
+               	movl	0x8(%rcx), %edi
+               	movq	%rdx, -0xcc(%rbp)
+               	movl	%edi, -0xc4(%rbp)
+               	leaq	-0xcc(%rbp), %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L3>
 <L3>:
+               	leaq	-0xd4(%rbp), %rcx
+               	movq	(%rbx), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L4>
 <L4>:
+               	leaq	-0xdc(%rbp), %rcx
+               	movq	(%rsi), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movaps	-0x60(%rbp), %xmm6
-               	movaps	-0x70(%rbp), %xmm7
-               	movaps	-0x80(%rbp), %xmm8
-               	movaps	-0x90(%rbp), %xmm9
-               	movaps	-0xa0(%rbp), %xmm10
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	-0xe8(%rbp), %rbx
+               	movq	-0xf0(%rbp), %rdi
+               	movq	-0xf8(%rbp), %rsi
+               	movq	-0x100(%rbp), %r12
+               	movq	-0x108(%rbp), %r13
+               	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -669,28 +976,38 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x210, %rsp            # imm = 0x210
-               	movq	%rbx, -0x148(%rbp)
-               	movq	%rdi, -0x150(%rbp)
-               	movq	%rsi, -0x158(%rbp)
-               	movq	%r12, -0x160(%rbp)
-               	movq	%r13, -0x168(%rbp)
-               	movq	%r14, -0x170(%rbp)
-               	movq	%r15, -0x178(%rbp)
-               	movaps	%xmm6, -0x190(%rbp)
-               	movaps	%xmm7, -0x1a0(%rbp)
-               	movaps	%xmm8, -0x1b0(%rbp)
-               	movaps	%xmm9, -0x1c0(%rbp)
-               	movaps	%xmm10, -0x1d0(%rbp)
-               	movaps	%xmm14, -0x1e0(%rbp)
-               	movaps	%xmm15, -0x1f0(%rbp)
+               	subq	$0x440, %rsp            # imm = 0x440
+               	movq	%rbx, -0x3c8(%rbp)
+               	movq	%rdi, -0x3d0(%rbp)
+               	movq	%rsi, -0x3d8(%rbp)
+               	movq	%r12, -0x3e0(%rbp)
+               	movq	%r13, -0x3e8(%rbp)
+               	movq	%r14, -0x3f0(%rbp)
+               	movq	%r15, -0x3f8(%rbp)
+               	movaps	%xmm14, -0x410(%rbp)
+               	movaps	%xmm15, -0x420(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x128(%rbp)
-               	callq	 <L0>
+               	movq	%r8, -0x368(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
                	movq	%rax, %rcx
                	movq	$0x2, %rdx
@@ -728,7 +1045,7 @@ Disassembly of section .text:
                	movq	$0x10, %rdx
                	callq	 <L10>
 <L10>:
-               	leaq	-0xe8(%rbp), %rsi
+               	leaq	-0x148(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -737,130 +1054,203 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
                	jmp	 <L12>
 <L11>:
-               	movq	%rcx, %rdx
+               	movq	%rdx, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rdi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x128(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
-               	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	addq	%r11, %rdi
+               	movq	-0x368(%rbp), %r8
+               	addq	%r8, %rdi
+               	leaq	(%rsi,%rdx,8), %r12
+               	movq	%rdi, (%r12)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
 <L12>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	cmpq	$0x8, %r12
                	jb	 <L13>
-               	jmp	 <L44>
+               	jmp	 <L39>
 <L13>:
                	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	%rcx, %r13
+               	movq	(%rax), %rdx
+               	movq	-0x368(%rbp), %r8
+               	movq	%rdx, %r13
                	addq	%r8, %r13
-               	movb	%r13b, %dl
+               	movb	%r13b, %al
+               	movzbq	%al, %rdx
                	movq	%rdi, %rcx
                	callq	 <L14>
 <L14>:
                	movw	%r13w, %dx
+               	movzwq	%dx, %r14
                	movq	%rax, %rcx
+               	movq	%r14, %rdx
                	callq	 <L15>
 <L15>:
                	movl	%r13d, %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
+               	movq	%r14, %rdx
                	callq	 <L16>
 <L16>:
-               	movl	%r13d, %edx
-               	movq	%r13, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r14d
+               	leaq	-0x19c(%rbp), %rdx
+               	movl	%r13d, %r14d
+               	leaq	(%rdx), %r15
+               	movl	%r14d, (%r15)
+               	movq	%r13, %r14
+               	shrq	$0x20, %r14
+               	movl	%r14d, %r15d
+               	leaq	0x4(%rdx), %r14
+               	movl	%r15d, (%r14)
+               	movq	(%rdx), %r14
                	movq	%rax, %rcx
+               	movq	%r14, %rdx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L18>
+               	leaq	-0x284(%rbp), %rdx
+               	movq	%r13, %r14
+               	andq	$0xfff, %r14            # imm = 0xFFF
+               	movq	%r14, %r11
+               	testq	%r11, %r11
+               	jl	 <L18>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L19>
 <L18>:
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L19>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
+               	addss	%xmm0, %xmm0
 <L19>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L20>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x261>
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x2af>
+               	leaq	(%rdx), %r14
+               	movss	%xmm1, (%r14)
+               	movq	%r13, %r14
+               	andq	$0xff, %r14
+               	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L21>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L21>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x2f9>
+               	leaq	0x4(%rdx), %r14
+               	movss	%xmm1, (%r14)
+               	movq	(%rdx), %r14
+               	movq	%rax, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L22>
 <L22>:
-               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	subss	, %xmm6 <corpus.cases.call.call_ret_small.checksum+0x2a3>
+               	leaq	-0x290(%rbp), %rdx
+               	movl	%r13d, %r14d
+               	leaq	(%rdx), %r15
+               	movl	%r14d, (%r15)
+               	movq	%r13, %r14
+               	shrq	$0x10, %r14
+               	movl	%r14d, %r15d
+               	leaq	0x4(%rdx), %r14
+               	movl	%r15d, (%r14)
+               	movq	%r13, %r14
+               	shrq	$0x20, %r14
+               	movl	%r14d, %r15d
+               	leaq	0x8(%rdx), %r14
+               	movl	%r15d, (%r14)
+               	movq	(%rdx), %r14
+               	movl	0x8(%rdx), %r15d
+               	movq	%r14, -0x2a0(%rbp)
+               	movl	%r15d, -0x298(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movl	%r13d, %edx
-               	movq	%r13, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r14d
-               	movq	%r13, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r15d
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L27>
-<L27>:
+               	leaq	-0x2b0(%rbp), %rdx
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
                	movq	%r13, %r14
                	xorq	$-0x1, %r14
+               	leaq	0x8(%rdx), %r15
+               	movq	%r14, (%r15)
+               	movq	(%rdx), %r14
+               	movq	0x8(%rdx), %r15
+               	movq	%r14, -0x2c0(%rbp)
+               	movq	%r15, -0x2b8(%rbp)
+               	leaq	-0x2c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L28>
+               	callq	 <L24>
+<L24>:
+               	leaq	-0x2d0(%rbp), %rdx
+               	movq	%r13, %r14
+               	andq	$0xffff, %r14           # imm = 0xFFFF
+               	movq	%r14, %r11
+               	testq	%r11, %r11
+               	jl	 <L25>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L26>
+<L25>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L26>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x3ee>
+               	leaq	(%rdx), %r14
+               	movsd	%xmm1, (%r14)
+               	movq	%r13, %r14
+               	andq	$0x3ffff, %r14          # imm = 0x3FFFF
+               	movq	%r14, %r11
+               	testq	%r11, %r11
+               	jl	 <L27>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L28>
+<L27>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L28>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x438>
+               	leaq	0x8(%rdx), %r14
+               	movsd	%xmm1, (%r14)
+               	movq	(%rdx), %r14
+               	movq	0x8(%rdx), %r15
+               	movq	%r14, -0x2e0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
+               	leaq	-0x2e0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movq	%r14, %rdx
                	callq	 <L29>
 <L29>:
-               	movq	%r13, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
+               	leaq	-0x2f0(%rbp), %rdx
+               	movq	%r13, %r14
+               	imulq	$0x3, %r14, %r14
+               	addq	$0x1, %r14
+               	leaq	(%rdx), %r15
+               	movq	%r14, (%r15)
+               	movq	%r13, %r14
+               	andq	$0x7fff, %r14           # imm = 0x7FFF
+               	movq	%r14, %r11
                	testq	%r11, %r11
                	jl	 <L30>
                	cvtsi2sd	%r11, %xmm0
@@ -874,423 +1264,565 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L31>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x34b>
-               	movq	%r13, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L32>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L33>
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x4bf>
+               	leaq	0x8(%rdx), %r14
+               	movsd	%xmm1, (%r14)
+               	movq	(%rdx), %r14
+               	movq	0x8(%rdx), %r15
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x2f8(%rbp)
+               	leaq	-0x300(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L32>
 <L32>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L33>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_ret_small.checksum+0x38d>
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L35>
-<L35>:
-               	movq	%r13, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %rdx
-               	addq	$0x1, %rdx
-               	movq	%r13, %rcx
-               	andq	$0x7fff, %rcx           # imm = 0x7FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L36>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L37>
-<L36>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L37>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_ret_small.checksum+0x3f1>
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L39>
-<L39>:
-               	movq	%r13, %rcx
-               	andq	$0x1fff, %rcx           # imm = 0x1FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L40>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L41>:
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x447>
-               	xorq	$0x12345678, %r13       # imm = 0x12345678
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L43>
-<L43>:
+               	andq	$0x1fff, %rdx           # imm = 0x1FFF
+               	movq	%rdx, %r11
+               	testq	%r11, %r11
+               	jl	 <L33>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L34>
+<L33>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L34>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x52e>
+               	movq	%r13, %r8
+               	xorq	$0x12345678, %r8        # imm = 0x12345678
+               	movq	%r8, -0x308(%rbp)
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r14
+               	movq	%r13, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x8, %r12
                	jb	 <L13>
-<L44>:
+<L39>:
                	leaq	-0x48(%rbp), %r12
                	leaq	(%r12), %rax
                	addq	$0x0, %rax
-               	movq	$0x48, %rcx
-<L45>:
+               	movq	$0x48, %rdx
+<L40>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L45>
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L40>
                	leaq	-0xa8(%rbp), %r13
                	leaq	(%r13), %rax
                	addq	$0x0, %rax
-               	movq	$0x60, %rcx
-<L46>:
+               	movq	$0x60, %rdx
+<L41>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L46>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%rsi,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x128(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0xf4(%rbp), %rcx
-               	movl	%edx, %r14d
-               	leaq	(%rcx), %r15
-               	movl	%r14d, (%r15)
-               	movq	%rdx, %r14
-               	shrq	$0x10, %r14
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L41>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x310(%rbp)
+               	movq	-0x310(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	-0x310(%rbp), %r8
+               	leaq	(%rsi,%r8,8), %rdx
+               	movq	(%rdx), %r14
+               	movq	-0x368(%rbp), %r8
+               	addq	%r8, %r14
+               	leaq	-0xf4(%rbp), %rdx
                	movl	%r14d, %r15d
-               	leaq	0x4(%rcx), %r14
-               	movl	%r15d, (%r14)
-               	shrq	$0x20, %rdx
-               	movl	%edx, %r14d
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movq	%rax, %rdx
-               	imulq	$0xc, %rdx, %rdx
-               	leaq	(%r12,%rdx), %r14
-               	movq	(%rcx), %rdx
-               	movl	0x8(%rcx), %r15d
-               	movq	%rdx, (%r14)
+               	leaq	(%rdx), %rax
+               	movl	%r15d, (%rax)
+               	movq	%r14, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %r15d
+               	leaq	0x4(%rdx), %rax
+               	movl	%r15d, (%rax)
+               	shrq	$0x20, %r14
+               	movl	%r14d, %eax
+               	leaq	0x8(%rdx), %r14
+               	movl	%eax, (%r14)
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0xc, %rax, %rax
+               	leaq	(%r12,%rax), %r14
+               	movq	(%rdx), %rax
+               	movl	0x8(%rdx), %r15d
+               	movq	%rax, (%r14)
                	movl	%r15d, 0x8(%r14)
-               	leaq	(%rsi,%rax,8), %rcx
-               	movq	(%rcx), %rdx
+               	movq	-0x310(%rbp), %r8
+               	leaq	(%rsi,%r8,8), %rax
+               	movq	(%rax), %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x368(%rbp), %r8
                	addq	%r8, %rdx
-               	leaq	-0x108(%rbp), %rcx
+               	leaq	-0x158(%rbp), %rax
                	movq	%rdx, %r14
                	imulq	$0x3, %r14, %r14
                	addq	$0x1, %r14
-               	leaq	(%rcx), %r15
+               	leaq	(%rax), %r15
                	movq	%r14, (%r15)
                	andq	$0x7fff, %rdx           # imm = 0x7FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L49>
-<L48>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L49>:
+<L44>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x5a8>
-               	leaq	0x8(%rcx), %rdx
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x759>
+               	leaq	0x8(%rax), %rdx
                	movsd	%xmm1, (%rdx)
-               	movq	%rax, %rdx
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r13,%rdx), %r14
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r15
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r15
                	movq	%rdx, (%r14)
                	movq	%r15, 0x8(%r14)
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, %rax
                	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-<L50>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x310(%rbp)
+               	movq	-0x310(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L42>
+<L45>:
                	movq	$0x0, %r14
                	cmpq	$0x6, %r14
-               	jb	 <L51>
-               	jmp	 <L57>
-<L51>:
+               	jb	 <L46>
+               	jmp	 <L49>
+<L46>:
                	movq	%r14, %rax
                	imulq	$0xc, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movl	(%rax), %edx
-               	leaq	0x4(%rcx), %rax
-               	movl	(%rax), %r15d
-               	leaq	0x8(%rcx), %rax
-               	movl	(%rax), %r8d
-               	movq	%r8, -0x110(%rbp)
+               	leaq	(%r12,%rax), %rdx
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	(%rdx), %r15
+               	movl	0x8(%rdx), %eax
+               	movq	-0x318(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x318(%rbp), %r8
+               	movl	%eax, 0x8(%r8)
+               	movq	-0x318(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x318(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movq	%rax, -0xc4(%rbp)
+               	movl	%edx, -0xbc(%rbp)
+               	leaq	-0xc4(%rbp), %rdx
                	movq	%rdi, %rcx
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movq	-0x110(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L54>
-<L54>:
-               	movq	%r14, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %r15
-               	leaq	0x8(%rdx), %rcx
-               	movsd	(%rcx), %xmm6
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L56>
-<L56>:
+               	callq	 <L47>
+<L47>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	movq	%r14, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r13,%rdx), %r15
+               	leaq	-0xd8(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	(%r15), %rax
+               	movq	0x8(%r15), %rdx
+               	movq	-0x328(%rbp), %r8
+               	movq	%rax, (%r8)
+               	movq	-0x328(%rbp), %r8
+               	movq	%rdx, 0x8(%r8)
+               	movq	-0x328(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x328(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	%rax, -0xe8(%rbp)
+               	movq	%rdx, -0xe0(%rbp)
+               	leaq	-0xe8(%rbp), %rdx
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L48>
+<L48>:
                	addq	$0x1, %r14
                	movq	%rax, %rdi
                	cmpq	$0x6, %r14
-               	jb	 <L51>
-<L57>:
+               	jb	 <L46>
+<L49>:
                	movq	$0x0, %r12
                	cmpq	$0x4, %r12
-               	jb	 <L58>
-               	jmp	 <L84>
-<L58>:
+               	jb	 <L50>
+               	jmp	 <L68>
+<L50>:
                	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	%rcx, %r13
-               	addq	%r8, %r13
-               	movq	%r13, %r14
-               	xorq	$-0x1, %r14
-               	movq	%r13, %rax
-               	andq	$0xffff, %rax           # imm = 0xFFFF
+               	movq	(%rax), %rdx
+               	movq	-0x368(%rbp), %r8
+               	addq	%r8, %rdx
+               	leaq	-0x108(%rbp), %r8
+               	movq	%r8, -0x330(%rbp)
+               	movq	-0x330(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	%rdx, (%r13)
+               	movq	%rdx, %r13
+               	xorq	$-0x1, %r13
+               	movq	-0x330(%rbp), %r8
+               	leaq	0x8(%r8), %r14
+               	movq	%r13, (%r14)
+               	leaq	-0x168(%rbp), %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	%rdx, %r14
+               	andq	$0xffff, %r14           # imm = 0xFFFF
+               	movq	%r14, %r11
+               	testq	%r11, %r11
+               	jl	 <L51>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L52>
+<L51>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L52>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x95f>
+               	movq	-0x338(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movsd	%xmm1, (%r14)
+               	movq	%rdx, %r14
+               	andq	$0x3ffff, %r14          # imm = 0x3FFFF
+               	movq	%r14, %r11
+               	testq	%r11, %r11
+               	jl	 <L53>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L54>
+<L53>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L54>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x9b0>
+               	movq	-0x338(%rbp), %r8
+               	leaq	0x8(%r8), %r14
+               	movsd	%xmm1, (%r14)
+               	leaq	-0x178(%rbp), %r8
+               	movq	%r8, -0x340(%rbp)
+               	movq	%rdx, %r15
+               	imulq	$0x3, %r15, %r15
+               	addq	$0x1, %r15
+               	movq	-0x340(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	%r15, (%rax)
+               	movq	%rdx, %rax
+               	andq	$0x7fff, %rax           # imm = 0x7FFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L55>
                	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L56>
+<L55>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L56>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xa28>
+               	movq	-0x340(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movsd	%xmm1, (%rax)
+               	leaq	-0x184(%rbp), %r8
+               	movq	%r8, -0x358(%rbp)
+               	movl	%edx, %r15d
+               	movq	-0x358(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movl	%r15d, (%r13)
+               	movq	%rdx, %r13
+               	shrq	$0x10, %r13
+               	movl	%r13d, %r15d
+               	movq	-0x358(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movl	%r15d, (%r13)
+               	movq	%rdx, %r13
+               	shrq	$0x20, %r13
+               	movl	%r13d, %r15d
+               	movq	-0x358(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movl	%r15d, (%r13)
+               	leaq	-0x18c(%rbp), %r8
+               	movq	%r8, -0x348(%rbp)
+               	movl	%edx, %r15d
+               	movq	-0x348(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movl	%r15d, (%r14)
+               	movq	%rdx, %r14
+               	shrq	$0x20, %r14
+               	movl	%r14d, %r15d
+               	movq	-0x348(%rbp), %r8
+               	leaq	0x4(%r8), %r14
+               	movl	%r15d, (%r14)
+               	leaq	-0x194(%rbp), %r8
+               	movq	%r8, -0x350(%rbp)
+               	movq	%rdx, %r15
+               	andq	$0xfff, %r15            # imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L57>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L58>
+<L57>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L58>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xb0e>
+               	movq	-0x350(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm1, (%r15)
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
+               	testq	%r11, %r11
+               	jl	 <L59>
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L60>
 <L59>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L60>:
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_ret_small.checksum+0x6ed>
-               	movq	%r13, %rax
-               	andq	$0x3ffff, %rax          # imm = 0x3FFFF
-               	movq	%rax, %r11
-               	testq	%r11, %r11
-               	jl	 <L61>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L62>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xb5c>
+               	movq	-0x350(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x1b0(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x330(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x330(%rbp), %r8
+               	movq	0x8(%r8), %r13
+               	movq	-0x360(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x360(%rbp), %r8
+               	movq	%r13, 0x8(%r8)
+               	leaq	-0x1c0(%rbp), %r13
+               	movq	-0x338(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x338(%rbp), %r8
+               	movq	0x8(%r8), %r14
+               	movq	%r15, (%r13)
+               	movq	%r14, 0x8(%r13)
+               	leaq	-0x1d0(%rbp), %r14
+               	movq	-0x340(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x340(%rbp), %r8
+               	movq	0x8(%r8), %rax
+               	movq	%r15, (%r14)
+               	movq	%rax, 0x8(%r14)
+               	leaq	-0x1dc(%rbp), %r15
+               	movq	-0x358(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x358(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movq	%rax, (%r15)
+               	movl	%edx, 0x8(%r15)
+               	leaq	-0x1e4(%rbp), %r8
+               	movq	%r8, -0x3b8(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x3b8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	leaq	-0x1ec(%rbp), %rbx
+               	movq	-0x350(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, (%rbx)
+               	leaq	-0x200(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x360(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x360(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x378(%rbp)
+               	movq	-0x370(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x370(%rbp), %r8
+               	movq	-0x378(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x370(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x370(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x380(%rbp)
+               	movq	%rdx, -0x210(%rbp)
+               	movq	-0x380(%rbp), %r8
+               	movq	%r8, -0x208(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L61>
 <L61>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %r8
+               	movq	%r8, -0x388(%rbp)
+               	movq	-0x388(%rbp), %r8
+               	leaq	-0x220(%rbp), %r8
+               	movq	%r8, -0x390(%rbp)
+               	movq	(%r13), %rdx
+               	movq	0x8(%r13), %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x390(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x390(%rbp), %r8
+               	movq	-0x398(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x390(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x390(%rbp), %r8
+               	movq	0x8(%r8), %r13
+               	movq	%rdx, -0x230(%rbp)
+               	movq	%r13, -0x228(%rbp)
+               	leaq	-0x230(%rbp), %rdx
+               	movq	-0x388(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L62>
 <L62>:
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_ret_small.checksum+0x72f>
-               	movq	%r13, %rax
-               	imulq	$0x3, %rax, %rax
-               	movq	%rax, %r15
-               	addq	$0x1, %r15
-               	movq	%r13, %rax
-               	andq	$0x7fff, %rax           # imm = 0x7FFF
-               	movq	%rax, %r11
-               	testq	%r11, %r11
-               	jl	 <L63>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L64>
+               	movq	%rax, %r8
+               	movq	%r8, -0x3a0(%rbp)
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	-0x240(%rbp), %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %r13
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%r13, 0x8(%r8)
+               	movq	-0x3a8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x3a8(%rbp), %r8
+               	movq	0x8(%r8), %r13
+               	movq	%rdx, -0x250(%rbp)
+               	movq	%r13, -0x248(%rbp)
+               	leaq	-0x250(%rbp), %rdx
+               	movq	-0x3a0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L63>
 <L63>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %r8
+               	movq	%r8, -0x3b0(%rbp)
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	-0x25c(%rbp), %r13
+               	movq	(%r15), %r14
+               	movl	0x8(%r15), %edx
+               	movq	%r14, (%r13)
+               	movl	%edx, 0x8(%r13)
+               	movq	(%r13), %rdx
+               	movl	0x8(%r13), %r14d
+               	movq	%rdx, -0x26c(%rbp)
+               	movl	%r14d, -0x264(%rbp)
+               	leaq	-0x26c(%rbp), %rdx
+               	movq	-0x3b0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L64>
 <L64>:
-               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_ret_small.checksum+0x781>
-               	movl	%r13d, %r8d
-               	movq	%r8, -0x138(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x120(%rbp)
-               	movl	%r13d, %ebx
-               	movq	%r13, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x130(%rbp)
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L66>
+               	movq	%rax, %rdx
+               	leaq	-0x274(%rbp), %r13
+               	movq	-0x3b8(%rbp), %r8
+               	movq	(%r8), %r14
+               	movq	%r14, (%r13)
+               	movq	(%r13), %rax
+               	movq	%rdx, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L65>
 <L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	leaq	-0x27c(%rbp), %rdx
+               	movq	(%rbx), %r13
+               	movq	%r13, (%rdx)
+               	movq	(%rdx), %rbx
+               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L66>
 <L66>:
-               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_ret_small.checksum+0x805>
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L68>
-<L67>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L68>:
-               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
-               	subss	, %xmm10 <corpus.cases.call.call_ret_small.checksum+0x849>
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rcx
-               	movq	-0x138(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rcx
-               	movq	-0x118(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rcx
-               	movq	-0x120(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rcx
-               	movq	-0x130(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L82>
-<L82>:
                	movq	%rdi, %rcx
                	movq	%rax, %rdx
-               	callq	 <L83>
-<L83>:
+               	callq	 <L67>
+<L67>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x4, %r12
-               	jb	 <L58>
-<L84>:
+               	jb	 <L50>
+<L68>:
                	movq	%rdi, %rax
-               	movaps	-0x190(%rbp), %xmm6
-               	movaps	-0x1a0(%rbp), %xmm7
-               	movaps	-0x1b0(%rbp), %xmm8
-               	movaps	-0x1c0(%rbp), %xmm9
-               	movaps	-0x1d0(%rbp), %xmm10
-               	movaps	-0x1e0(%rbp), %xmm14
-               	movaps	-0x1f0(%rbp), %xmm15
-               	movq	-0x148(%rbp), %rbx
-               	movq	-0x150(%rbp), %rdi
-               	movq	-0x158(%rbp), %rsi
-               	movq	-0x160(%rbp), %r12
-               	movq	-0x168(%rbp), %r13
-               	movq	-0x170(%rbp), %r14
-               	movq	-0x178(%rbp), %r15
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x420(%rbp), %xmm15
+               	movq	-0x3c8(%rbp), %rbx
+               	movq	-0x3d0(%rbp), %rdi
+               	movq	-0x3d8(%rbp), %rsi
+               	movq	-0x3e0(%rbp), %r12
+               	movq	-0x3e8(%rbp), %r13
+               	movq	-0x3f0(%rbp), %r14
+               	movq	-0x3f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_variadic.dis
+++ b/test/golden/x86_64-windows/call/call_variadic.dis
@@ -14,114 +14,117 @@ Disassembly of section .text:
 <corpus.cases.call.call_variadic.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1d0, %rsp            # imm = 0x1D0
-               	movq	%rbx, -0xe8(%rbp)
-               	movq	%rdi, -0xf0(%rbp)
-               	movq	%rsi, -0xf8(%rbp)
-               	movq	%r12, -0x100(%rbp)
-               	movq	%r13, -0x108(%rbp)
-               	movq	%r14, -0x110(%rbp)
-               	movq	%r15, -0x118(%rbp)
-               	movaps	%xmm6, -0x130(%rbp)
-               	movaps	%xmm7, -0x140(%rbp)
-               	movaps	%xmm8, -0x150(%rbp)
-               	movaps	%xmm9, -0x160(%rbp)
-               	movaps	%xmm10, -0x170(%rbp)
-               	movaps	%xmm11, -0x180(%rbp)
-               	movaps	%xmm12, -0x190(%rbp)
-               	movaps	%xmm14, -0x1a0(%rbp)
-               	movaps	%xmm15, -0x1b0(%rbp)
+               	subq	$0x390, %rsp            # imm = 0x390
+               	movq	%rbx, -0x2a8(%rbp)
+               	movq	%rdi, -0x2b0(%rbp)
+               	movq	%rsi, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
+               	movaps	%xmm6, -0x2f0(%rbp)
+               	movaps	%xmm7, -0x300(%rbp)
+               	movaps	%xmm8, -0x310(%rbp)
+               	movaps	%xmm9, -0x320(%rbp)
+               	movaps	%xmm10, -0x330(%rbp)
+               	movaps	%xmm11, -0x340(%rbp)
+               	movaps	%xmm12, -0x350(%rbp)
+               	movaps	%xmm14, -0x360(%rbp)
+               	movaps	%xmm15, -0x370(%rbp)
                	movq	%rcx, %r8
                	movq	%r8, -0x80(%rbp)
-               	callq	 <L0>
-<L0>:
                	leaq	-0x60(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
+               	leaq	(%rsi), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
                	movq	-0x80(%rbp), %r8
                	addq	%r8, %rdx
-               	leaq	(%rsi,%rcx,8), %rdi
+               	leaq	(%rsi,%rax,8), %rdi
                	movq	%rdx, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
+               	addq	$0x1, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rdx
-               	callq	 <L4>
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rcx
                	movq	$0x0, %rdx
-               	callq	 <L5>
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rdx
-               	callq	 <L6>
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
                	movq	%rax, %rdi
                	movq	$0x0, %r12
                	cmpq	$0x4, %r12
-               	jb	 <L7>
-               	jmp	 <L91>
-<L7>:
+               	jb	 <L9>
+               	jmp	 <L106>
+<L9>:
                	leaq	(%rsi,%r12,8), %rax
-               	movq	(%rax), %rcx
+               	movq	(%rax), %rdx
                	movq	-0x80(%rbp), %r8
-               	movq	%rcx, %r13
+               	movq	%rdx, %r13
                	addq	%r8, %r13
                	movb	%r13b, %r14b
                	movw	%r13w, %r15w
                	movl	%r13d, %r8d
-               	movq	%r8, -0xe0(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0x7, %rcx
-               	movb	%cl, %r8b
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	%r13, %rdx
+               	shrq	$0x7, %rdx
+               	movb	%dl, %r8b
                	movq	%r8, -0x68(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0x3, %rcx
-               	movw	%cx, %r8w
+               	movq	%r13, %rdx
+               	shrq	$0x3, %rdx
+               	movw	%dx, %r8w
                	movq	%r8, -0x70(%rbp)
-               	movq	%r13, %rcx
-               	shrq	$0xb, %rcx
-               	movl	%ecx, %r8d
+               	movq	%r13, %rdx
+               	shrq	$0xb, %rdx
+               	movl	%edx, %r8d
                	movq	%r8, -0x78(%rbp)
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L8>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L9>:
-               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_variadic.checksum+0x1de>
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	movq	%r13, %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L10>
                	cvtsi2ss	%r11, %xmm0
@@ -134,11 +137,11 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
 <L11>:
-               	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
-               	subss	, %xmm7 <corpus.cases.call.call_variadic.checksum+0x220>
-               	movq	%r13, %rcx
-               	andq	$0x3ff, %rcx            # imm = 0x3FF
-               	movq	%rcx, %r11
+               	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.call.call_variadic.checksum+0x24c>
+               	movq	%r13, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
@@ -151,11 +154,11 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
 <L13>:
-               	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.call.call_variadic.checksum+0x264>
-               	movq	%r13, %rcx
-               	andq	$0x1ff, %rcx            # imm = 0x1FF
-               	movq	%rcx, %r11
+               	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
+               	subss	, %xmm7 <corpus.cases.call.call_variadic.checksum+0x28e>
+               	movq	%r13, %rdx
+               	andq	$0x3ff, %rdx            # imm = 0x3FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L14>
                	cvtsi2ss	%r11, %xmm0
@@ -168,28 +171,28 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
 <L15>:
-               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_variadic.checksum+0x2a8>
-               	movq	%r13, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
+               	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
+               	divss	, %xmm8 <corpus.cases.call.call_variadic.checksum+0x2d2>
+               	movq	%r13, %rdx
+               	andq	$0x1ff, %rdx            # imm = 0x1FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L16>
-               	cvtsi2sd	%r11, %xmm0
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L17>
 <L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L17>:
-               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_variadic.checksum+0x2ec>
-               	movq	%r13, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	divss	, %xmm9 <corpus.cases.call.call_variadic.checksum+0x316>
+               	movq	%r13, %rdx
+               	andq	$0xffff, %rdx           # imm = 0xFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L18>
                	cvtsi2sd	%r11, %xmm0
@@ -202,11 +205,11 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L19>:
-               	movsd	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1]
-               	divsd	, %xmm11 <corpus.cases.call.call_variadic.checksum+0x330>
-               	movq	%r13, %rcx
-               	andq	$0x1fff, %rcx           # imm = 0x1FFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	divsd	, %xmm10 <corpus.cases.call.call_variadic.checksum+0x35a>
+               	movq	%r13, %rdx
+               	andq	$0x3ffff, %rdx          # imm = 0x3FFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L20>
                	cvtsi2sd	%r11, %xmm0
@@ -219,384 +222,929 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L21>:
+               	movsd	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1]
+               	divsd	, %xmm11 <corpus.cases.call.call_variadic.checksum+0x39e>
+               	movq	%r13, %rdx
+               	andq	$0x1fff, %rdx           # imm = 0x1FFF
+               	movq	%rdx, %r11
+               	testq	%r11, %r11
+               	jl	 <L22>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L23>
+<L22>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L23>:
                	movsd	%xmm0, %xmm12           # xmm12 = xmm0[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_variadic.checksum+0x374>
+               	divsd	, %xmm12 <corpus.cases.call.call_variadic.checksum+0x3e2>
                	movq	%r13, %rbx
                	imulq	$0x3, %rbx, %rbx
-               	movzbq	%r14b, %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movswq	%r15w, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	movq	-0x68(%rbp), %r8
-               	movzbq	%r8b, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movq	-0x78(%rbp), %r8
-               	movslq	%r8d, %rdx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	$0x8, %rdx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rdx
-               	movq	(%rdx), %rbx
-               	addq	%r13, %rbx
-               	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x10(%rsi), %rdx
-               	movq	(%rdx), %r8
+               	movzbq	%r14b, %r8
                	movq	%r8, -0x90(%rbp)
-               	leaq	0x18(%rsi), %rdx
-               	movq	(%rdx), %r8
+               	movq	%rdi, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x98(%rbp)
-               	leaq	0x20(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x28(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	leaq	0x30(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x38(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x40(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x48(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x50(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x58(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	%rbx, %rdx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x88(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x98(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	-0xa8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movswq	%r15w, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0x88(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xb0(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xd0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+<L27>:
+               	movq	-0x2a0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xb0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+<L29>:
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x108(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x118(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+<L31>:
+               	movq	-0x68(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x120(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x140(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+<L33>:
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L34>
 <L34>:
-               	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
+               	movq	%rax, %rdx
+               	movq	-0x78(%rbp), %r9
+               	movslq	%r9d, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L35>
 <L35>:
-               	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L36>
 <L36>:
-               	movq	%rax, %rcx
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x8, %rdx
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %rcx
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L38>
+               	movq	%rax, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	leaq	(%rsi), %rbx
+               	movq	(%rbx), %rdx
+               	movq	%rdx, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	leaq	0x8(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x158(%rbp)
+               	leaq	0x10(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x160(%rbp)
+               	leaq	0x18(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x168(%rbp)
+               	leaq	0x20(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x170(%rbp)
+               	leaq	0x28(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x178(%rbp)
+               	leaq	0x30(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x180(%rbp)
+               	leaq	0x38(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x188(%rbp)
+               	leaq	0x40(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x190(%rbp)
+               	leaq	0x48(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x198(%rbp)
+               	leaq	0x50(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	leaq	0x58(%rsi), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x150(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movq	%rax, %rcx
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	-0x1b8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L39>
+               	xorq	%rbx, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
 <L39>:
-               	movq	%rax, %rcx
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L40>
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
-               	movq	%rax, %rcx
-               	movq	-0xd0(%rbp), %r8
+               	movq	-0x1d0(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L41>
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rcx
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L42>
+               	movq	-0x1c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	%rax, %rcx
-               	movq	$0xc, %rdx
-               	callq	 <L43>
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
 <L43>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L44>
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
+               	jmp	 <L45>
 <L44>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L45>
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
 <L45>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L46>
 <L46>:
-               	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L48>
 <L48>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rbx
-               	imulq	$0x5, %rbx, %rbx
-               	movq	%r13, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L49>
 <L49>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L50>
 <L50>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L51>
 <L51>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L52>
 <L52>:
-               	movq	%rax, %rcx
-               	movswq	%r15w, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L53>
 <L53>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0xc, %rdx
                	callq	 <L54>
 <L54>:
-               	movq	%rax, %rcx
-               	movq	$0x6, %rdx
-               	callq	 <L55>
+               	movq	%rax, %rdx
+               	movd	%xmm6, %ebx
+               	movl	%ebx, %r8d
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
+               	jmp	 <L56>
 <L55>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rbx
-               	imulq	$0x7, %rbx, %rbx
-               	movq	%r13, %rdx
-               	callq	 <L56>
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
 <L56>:
-               	movq	%rax, %rcx
-               	movzbq	%r14b, %rdx
-               	addq	%r13, %rdx
-               	callq	 <L57>
+               	movq	%xmm10, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
+               	jmp	 <L58>
 <L57>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
-               	addq	%r13, %rdx
-               	callq	 <L58>
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rbx, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
 <L58>:
-               	movq	%rax, %rcx
-               	addq	%r13, %rbx
+               	movd	%xmm7, %edx
+               	movl	%edx, %ebx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rcx
                	movq	%rbx, %rdx
                	callq	 <L59>
 <L59>:
-               	movq	%rax, %rcx
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rdx
-               	addq	%r13, %rdx
+               	movq	%rax, %rdx
+               	movq	%xmm11, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L60>
 <L60>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
                	movq	$0x4, %rdx
                	callq	 <L61>
 <L61>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L62>
+               	movq	%rax, %rdx
+               	movq	%r13, %rbx
+               	imulq	$0x5, %rbx, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x230(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+               	jmp	 <L63>
 <L62>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	%r13, %rdx
-               	addq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x230(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x240(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x230(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+<L63>:
+               	movd	%xmm6, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L64>
 <L64>:
-               	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
+               	movq	%rax, %rdx
+               	movq	-0x2a0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x250(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L65>
 <L65>:
-               	movq	%rax, %rcx
-               	movq	$0x3, %rdx
+               	movq	%rax, %rdx
+               	movq	%xmm10, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L66>
 <L66>:
-               	movq	%rax, %rcx
-               	movzbq	%r14b, %rdx
+               	movq	%rax, %rdx
+               	movswq	%r15w, %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L67>
 <L67>:
-               	movq	%rax, %rcx
-               	movswq	%r15w, %rdx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L68>
 <L68>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x6, %rdx
                	callq	 <L69>
 <L69>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L70>
+               	movq	%rax, %rdx
+               	movq	%r13, %rbx
+               	imulq	$0x7, %rbx, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
+               	jmp	 <L71>
 <L70>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L71>
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x268(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x270(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x280(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
 <L71>:
-               	movq	%rax, %rcx
                	movzbq	%r14b, %rdx
+               	addq	%r13, %rdx
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L72>
 <L72>:
-               	movq	%rax, %rcx
-               	movswq	%r15w, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	movq	-0x2a0(%rbp), %r8
+               	movl	%r8d, %edx
+               	addq	%r13, %rdx
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L73>
 <L73>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	%rax, %rdx
+               	addq	%r13, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L74>
 <L74>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
+               	movq	%rax, %rdx
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rbx
+               	addq	%r13, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L75>
 <L75>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
                	movq	$0x4, %rdx
                	callq	 <L76>
 <L76>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
                	movq	%r13, %rdx
                	callq	 <L77>
 <L77>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
+               	movq	%rax, %rdx
+               	movd	%xmm8, %ebx
+               	movl	%ebx, %r8d
+               	movq	%r8, -0x290(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L78>
 <L78>:
-               	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	movq	%rax, %rdx
+               	movq	%r13, %rbx
+               	addq	%r13, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L79>
 <L79>:
-               	movq	%rax, %rcx
-               	movq	$0x3, %rdx
+               	movq	%rax, %rdx
+               	movq	%xmm12, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
                	callq	 <L80>
 <L80>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x3, %rdx
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rdx
+               	movzbq	%r14b, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rdx
+               	movswq	%r15w, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L83>
+<L83>:
+               	movq	%rax, %rdx
+               	movq	-0x2a0(%rbp), %r8
+               	movl	%r8d, %ebx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L84>
+<L84>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L85>
+<L85>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x4, %rdx
+               	callq	 <L86>
+<L86>:
+               	movq	%rax, %rdx
+               	movzbq	%r14b, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L87>
+<L87>:
+               	movq	%rax, %rdx
+               	movswq	%r15w, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L88>
+<L88>:
+               	movq	%rax, %rdx
+               	movq	-0x2a0(%rbp), %r8
+               	movl	%r8d, %ebx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L90>
+<L90>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x4, %rdx
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L92>
+<L92>:
+               	movq	%rax, %rdx
+               	movd	%xmm6, %ebx
+               	movl	%ebx, %r15d
+               	movq	%rdx, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L93>
+<L93>:
+               	movq	%rax, %rdx
+               	movq	%xmm10, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L94>
+<L94>:
+               	movq	%rax, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x3, %rdx
+               	callq	 <L95>
+<L95>:
+               	movq	%rax, %rdx
                	movq	%r13, %rbx
                	imulq	$0x7, %rbx, %rbx
                	movq	%r13, %r15
                	imulq	$0x3, %r15, %r15
+               	movq	%rdx, %rcx
                	movq	%r15, %rdx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rcx
+               	callq	 <L96>
+<L96>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
                	movzbq	%r14b, %rdx
                	addq	%r15, %rdx
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rcx
-               	movq	-0xe0(%rbp), %r8
-               	movl	%r8d, %edx
-               	addq	%r15, %rdx
-               	callq	 <L83>
-<L83>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L97>
+<L97>:
+               	movq	%rax, %rdx
+               	movq	-0x2a0(%rbp), %r8
+               	movl	%r8d, %r14d
+               	addq	%r15, %r14
+               	movq	%rdx, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L98>
+<L98>:
                	addq	%r15, %rbx
                	movq	%rax, %rcx
                	movq	%rbx, %rdx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L99>
+<L99>:
                	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rcx
-               	movq	%rcx, %rdx
+               	movzwq	%r8w, %rdx
                	addq	%r15, %rdx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
+               	callq	 <L100>
+<L100>:
                	movq	%rax, %rcx
                	movq	$0x4, %rdx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L101>
+<L101>:
                	movq	%rax, %rcx
                	movq	%r13, %rdx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L102>
+<L102>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L103>
+<L103>:
+               	movd	%xmm9, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L89>
-<L89>:
+               	movq	%rbx, %rdx
+               	callq	 <L104>
+<L104>:
                	movq	%rax, %rcx
                	movq	$0x1, %rdx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L105>
+<L105>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x4, %r12
-               	jb	 <L7>
-<L91>:
+               	jb	 <L9>
+<L106>:
                	movq	%rdi, %rax
-               	movaps	-0x130(%rbp), %xmm6
-               	movaps	-0x140(%rbp), %xmm7
-               	movaps	-0x150(%rbp), %xmm8
-               	movaps	-0x160(%rbp), %xmm9
-               	movaps	-0x170(%rbp), %xmm10
-               	movaps	-0x180(%rbp), %xmm11
-               	movaps	-0x190(%rbp), %xmm12
-               	movaps	-0x1a0(%rbp), %xmm14
-               	movaps	-0x1b0(%rbp), %xmm15
-               	movq	-0xe8(%rbp), %rbx
-               	movq	-0xf0(%rbp), %rdi
-               	movq	-0xf8(%rbp), %rsi
-               	movq	-0x100(%rbp), %r12
-               	movq	-0x108(%rbp), %r13
-               	movq	-0x110(%rbp), %r14
-               	movq	-0x118(%rbp), %r15
+               	movaps	-0x2f0(%rbp), %xmm6
+               	movaps	-0x300(%rbp), %xmm7
+               	movaps	-0x310(%rbp), %xmm8
+               	movaps	-0x320(%rbp), %xmm9
+               	movaps	-0x330(%rbp), %xmm10
+               	movaps	-0x340(%rbp), %xmm11
+               	movaps	-0x350(%rbp), %xmm12
+               	movaps	-0x360(%rbp), %xmm14
+               	movaps	-0x370(%rbp), %xmm15
+               	movq	-0x2a8(%rbp), %rbx
+               	movq	-0x2b0(%rbp), %rdi
+               	movq	-0x2b8(%rbp), %rsi
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -814,18 +1362,21 @@ Disassembly of section .text:
                	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
                	movss	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1,2,3]
                	movsd	0x30(%rbp), %xmm8
+               	movd	%xmm1, %eax
+               	movl	%eax, %edx
                	callq	 <L0>
 <L0>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	callq	 <L1>
 <L1>:
+               	movd	%xmm7, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	callq	 <L2>
 <L2>:
+               	movq	%xmm8, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
@@ -857,20 +1408,21 @@ Disassembly of section .text:
                	movq	0x40(%rbp), %rdi
                	callq	 <L0>
 <L0>:
+               	movd	%xmm6, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
                	movl	%ebx, %edx
+               	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
                	movswq	%si, %rdx
+               	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
@@ -959,17 +1511,18 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L0>
 <L0>:
+               	movd	%xmm6, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
                	addq	%rbx, %rsi
+               	movq	%rax, %rcx
                	movq	%rsi, %rdx
                	callq	 <L2>
 <L2>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
@@ -1074,12 +1627,13 @@ Disassembly of section .text:
                	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
                	callq	 <L0>
 <L0>:
+               	movd	%xmm6, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
@@ -1170,6 +1724,8 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movd	%xmm1, %eax
+               	movl	%eax, %edx
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
@@ -1233,12 +1789,13 @@ Disassembly of section .text:
                	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
                	callq	 <L0>
 <L0>:
+               	movd	%xmm6, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
@@ -1263,12 +1820,13 @@ Disassembly of section .text:
                	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
                	callq	 <L0>
 <L0>:
+               	movd	%xmm6, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx

--- a/test/golden/x86_64-windows/cmp/branch_nest.dis
+++ b/test/golden/x86_64-windows/cmp/branch_nest.dis
@@ -10,157 +10,195 @@ Disassembly of section .text:
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movl	$0x0, %ebx
+               	cmpl	$0x14, %ebx
+               	jb	 <L0>
+               	jmp	 <L43>
 <L0>:
                	movl	%ebx, %esi
-               	movq	%rax, %rbx
-               	movl	$0x0, %edi
-               	cmpl	$0x14, %edi
-               	jb	 <L1>
-               	jmp	 <L42>
+               	addl	%edx, %esi
+               	cmpl	$0x4, %esi
+               	jb	 <L31>
+               	cmpl	$0x8, %esi
+               	jb	 <L23>
+               	cmpl	$0xc, %esi
+               	jb	 <L15>
+               	cmpl	$0x10, %esi
+               	jb	 <L7>
+               	cmpl	$0x10, %esi
+               	je	 <L5>
+               	cmpl	$0x11, %esi
+               	je	 <L3>
+               	cmpl	$0x12, %esi
+               	je	 <L1>
+               	movl	$0x1f7, %edi            # imm = 0x1F7
+               	jmp	 <L2>
 <L1>:
-               	movl	%edi, %r12d
-               	addl	%esi, %r12d
-               	cmpl	$0x4, %r12d
-               	jb	 <L32>
-               	cmpl	$0x8, %r12d
-               	jb	 <L24>
-               	cmpl	$0xc, %r12d
-               	jb	 <L16>
-               	cmpl	$0x10, %r12d
-               	jb	 <L8>
-               	cmpl	$0x10, %r12d
-               	je	 <L6>
-               	cmpl	$0x11, %r12d
-               	je	 <L4>
-               	cmpl	$0x12, %r12d
-               	je	 <L2>
-               	movl	$0x1f7, %eax            # imm = 0x1F7
-               	jmp	 <L3>
+               	movl	$0x1f6, %edi            # imm = 0x1F6
 <L2>:
-               	movl	$0x1f6, %eax            # imm = 0x1F6
+               	jmp	 <L4>
 <L3>:
-               	jmp	 <L5>
+               	movl	$0x1f5, %edi            # imm = 0x1F5
 <L4>:
-               	movl	$0x1f5, %eax            # imm = 0x1F5
+               	jmp	 <L6>
 <L5>:
-               	jmp	 <L7>
+               	movl	$0x1f4, %edi            # imm = 0x1F4
 <L6>:
-               	movl	$0x1f4, %eax            # imm = 0x1F4
-<L7>:
-               	jmp	 <L15>
-<L8>:
-               	cmpl	$0xe, %r12d
-               	jb	 <L11>
-               	cmpl	$0xe, %r12d
-               	je	 <L9>
-               	movl	$0x193, %ecx            # imm = 0x193
-               	jmp	 <L10>
-<L9>:
-               	movl	$0x192, %ecx            # imm = 0x192
-<L10>:
                	jmp	 <L14>
-<L11>:
-               	cmpl	$0xc, %r12d
-               	je	 <L12>
-               	movl	$0x191, %edx            # imm = 0x191
+<L7>:
+               	cmpl	$0xe, %esi
+               	jb	 <L10>
+               	cmpl	$0xe, %esi
+               	je	 <L8>
+               	movl	$0x193, %r12d           # imm = 0x193
+               	jmp	 <L9>
+<L8>:
+               	movl	$0x192, %r12d           # imm = 0x192
+<L9>:
                	jmp	 <L13>
+<L10>:
+               	cmpl	$0xc, %esi
+               	je	 <L11>
+               	movl	$0x191, %r13d           # imm = 0x191
+               	jmp	 <L12>
+<L11>:
+               	movl	$0x190, %r13d           # imm = 0x190
 <L12>:
-               	movl	$0x190, %edx            # imm = 0x190
+               	movq	%r13, %r12
 <L13>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rdi
 <L14>:
-               	movq	%rcx, %rax
-<L15>:
-               	jmp	 <L23>
-<L16>:
-               	cmpl	$0x8, %r12d
-               	je	 <L21>
-               	cmpl	$0x9, %r12d
-               	je	 <L19>
-               	cmpl	$0xa, %r12d
-               	je	 <L17>
-               	movl	$0x12f, %ecx            # imm = 0x12F
-               	jmp	 <L18>
-<L17>:
-               	movl	$0x12e, %ecx            # imm = 0x12E
-<L18>:
-               	jmp	 <L20>
-<L19>:
-               	movl	$0x12d, %ecx            # imm = 0x12D
-<L20>:
                	jmp	 <L22>
+<L15>:
+               	cmpl	$0x8, %esi
+               	je	 <L20>
+               	cmpl	$0x9, %esi
+               	je	 <L18>
+               	cmpl	$0xa, %esi
+               	je	 <L16>
+               	movl	$0x12f, %r12d           # imm = 0x12F
+               	jmp	 <L17>
+<L16>:
+               	movl	$0x12e, %r12d           # imm = 0x12E
+<L17>:
+               	jmp	 <L19>
+<L18>:
+               	movl	$0x12d, %r12d           # imm = 0x12D
+<L19>:
+               	jmp	 <L21>
+<L20>:
+               	movl	$0x12c, %r12d           # imm = 0x12C
 <L21>:
-               	movl	$0x12c, %ecx            # imm = 0x12C
+               	movq	%r12, %rdi
 <L22>:
-               	movq	%rcx, %rax
-<L23>:
-               	jmp	 <L31>
-<L24>:
-               	cmpl	$0x6, %r12d
-               	jb	 <L27>
-               	cmpl	$0x6, %r12d
-               	je	 <L25>
-               	movl	$0xcb, %ecx
-               	jmp	 <L26>
-<L25>:
-               	movl	$0xca, %ecx
-<L26>:
                	jmp	 <L30>
-<L27>:
-               	cmpl	$0x4, %r12d
-               	je	 <L28>
-               	movl	$0xc9, %edx
+<L23>:
+               	cmpl	$0x6, %esi
+               	jb	 <L26>
+               	cmpl	$0x6, %esi
+               	je	 <L24>
+               	movl	$0xcb, %r12d
+               	jmp	 <L25>
+<L24>:
+               	movl	$0xca, %r12d
+<L25>:
                	jmp	 <L29>
+<L26>:
+               	cmpl	$0x4, %esi
+               	je	 <L27>
+               	movl	$0xc9, %r13d
+               	jmp	 <L28>
+<L27>:
+               	movl	$0xc8, %r13d
 <L28>:
-               	movl	$0xc8, %edx
+               	movq	%r13, %r12
 <L29>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rdi
 <L30>:
-               	movq	%rcx, %rax
-<L31>:
-               	jmp	 <L39>
-<L32>:
-               	cmpl	$0x0, %r12d
-               	je	 <L37>
-               	cmpl	$0x1, %r12d
-               	je	 <L35>
-               	cmpl	$0x2, %r12d
-               	je	 <L33>
-               	movl	$0x67, %ecx
-               	jmp	 <L34>
-<L33>:
-               	movl	$0x66, %ecx
-<L34>:
-               	jmp	 <L36>
-<L35>:
-               	movl	$0x65, %ecx
-<L36>:
                	jmp	 <L38>
+<L31>:
+               	cmpl	$0x0, %esi
+               	je	 <L36>
+               	cmpl	$0x1, %esi
+               	je	 <L34>
+               	cmpl	$0x2, %esi
+               	je	 <L32>
+               	movl	$0x67, %r12d
+               	jmp	 <L33>
+<L32>:
+               	movl	$0x66, %r12d
+<L33>:
+               	jmp	 <L35>
+<L34>:
+               	movl	$0x65, %r12d
+<L35>:
+               	jmp	 <L37>
+<L36>:
+               	movl	$0x64, %r12d
 <L37>:
-               	movl	$0x64, %ecx
+               	movq	%r12, %rdi
 <L38>:
-               	movq	%rcx, %rax
+               	movl	%edi, %r12d
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
+               	jmp	 <L40>
 <L39>:
-               	movq	%rbx, %rcx
-               	movl	%eax, %edx
-               	callq	 <L40>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
 <L40>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L41>
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	addl	$0x1, %edi
-               	movq	%rax, %rbx
-               	cmpl	$0x14, %edi
-               	jb	 <L1>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L41>
 <L42>:
-               	movq	%rbx, %rax
+               	addl	$0x1, %ebx
+               	movq	%rdi, %rax
+               	cmpl	$0x14, %ebx
+               	jb	 <L0>
+<L43>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/cmp_i32.dis
+++ b/test/golden/x86_64-windows/cmp/cmp_i32.dis
@@ -6,126 +6,244 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0xd0, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%rdi, -0x80(%rbp)
-               	movq	%rsi, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movq	%r13, -0xb8(%rbp)
+               	movq	%r14, -0xc0(%rbp)
+               	movq	%r15, -0xc8(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x78(%rbp)
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rbx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0xc(%rbx), %rsi
+               	movl	$0x7fffffff, (%rsi)     # imm = 0x7FFFFFFF
+               	leaq	0x10(%rbx), %rsi
+               	movl	$0x80000000, (%rsi)     # imm = 0x80000000
+               	leaq	0x14(%rbx), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rbx), %rsi
+               	movl	$0x80000000, (%rsi)     # imm = 0x80000000
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movl	0x18(%rbx), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     # imm = 0x7FFFFFFF
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %r12
+               	movq	0x10(%rsi), %r13
+               	movl	0x18(%rsi), %r14d
+               	movq	%rdi, (%rbx)
+               	movq	%r12, 0x8(%rbx)
+               	movq	%r13, 0x10(%rbx)
+               	movl	%r14d, 0x18(%rbx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x7, %rdi
+               	jb	 <L0>
+               	jmp	 <L13>
 <L0>:
-               	movl	%ebx, %esi
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r12
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %rdi
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r12
-               	movq	0x10(%rcx), %r13
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%rdi)
-               	movq	%r12, 0x8(%rdi)
-               	movq	%r13, 0x10(%rdi)
-               	movl	%r14d, 0x18(%rdi)
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x7, %r13
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x78(%rbp), %r8
+               	addl	%r8d, %r13d
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L1>
-               	jmp	 <L8>
+               	jmp	 <L2>
 <L1>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r14d
-               	addl	%esi, %r14d
-               	leaq	(%rdi,%r13,4), %rax
-               	movl	(%rax), %r15d
-               	cmpl	%r15d, %r14d
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%r12, %rcx
-               	callq	 <L2>
-<L2>:
-               	cmpl	%r15d, %r14d
-               	setne	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L3>
-<L3>:
-               	cmpl	%r15d, %r14d
-               	setl	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L4>
-<L4>:
-               	cmpl	%r14d, %r15d
-               	setl	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	cmpl	%r15d, %r14d
-               	setle	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	cmpl	%r14d, %r15d
-               	setle	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x7, %r13
-               	jb	 <L1>
-<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rax
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %rdi
-               	movq	-0x88(%rbp), %rsi
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpl	%r14d, %r13d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpl	%r13d, %r14d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+<L8>:
+               	cmpl	%r14d, %r13d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rdi
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
+               	movq	-0xb8(%rbp), %r13
+               	movq	-0xc0(%rbp), %r14
+               	movq	-0xc8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/cmp_i64.dis
+++ b/test/golden/x86_64-windows/cmp/cmp_i64.dis
@@ -5,150 +5,265 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x150, %rsp            # imm = 0x150
-               	movq	%rbx, -0xf8(%rbp)
-               	movq	%rdi, -0x100(%rbp)
-               	movq	%rsi, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	subq	$0x140, %rsp            # imm = 0x140
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%rdi, -0x110(%rbp)
+               	movq	%rsi, -0x118(%rbp)
+               	movq	%r12, -0x120(%rbp)
+               	movq	%r13, -0x128(%rbp)
+               	movq	%r14, -0x130(%rbp)
+               	movq	%r15, -0x138(%rbp)
+               	movq	%rcx, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %rsi
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r12
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%rsi)
-               	movq	%rdi, 0x8(%rsi)
-               	movq	%r12, 0x10(%rsi)
-               	movq	%r13, 0x18(%rsi)
-               	movq	%r14, 0x20(%rsi)
-               	movq	%r15, 0x28(%rsi)
-               	movq	%rax, 0x30(%rsi)
-               	leaq	-0xa8(%rbp), %rdi
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%rdi)
-               	movq	%rdx, 0x8(%rdi)
-               	movq	%r12, 0x10(%rdi)
-               	movq	%r13, 0x18(%rdi)
-               	movq	%r14, 0x20(%rdi)
-               	movq	%r15, 0x28(%rdi)
+               	leaq	-0x70(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rbx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movq	0x18(%rbx), %r13
+               	movq	0x20(%rbx), %r14
+               	movq	0x28(%rbx), %r15
+               	movq	0x30(%rbx), %rax
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%rdi)
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rax, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x10(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x18(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rbx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movq	0x18(%rbx), %r13
+               	movq	0x20(%rbx), %r14
+               	movq	0x28(%rbx), %r15
+               	movq	0x30(%rbx), %rdx
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	%r12, 0x10(%rax)
+               	movq	%r13, 0x18(%rax)
+               	movq	%r14, 0x20(%rax)
+               	movq	%r15, 0x28(%rax)
+               	movq	%rdx, 0x30(%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %rsi
+               	movq	(%rsi), %rdi
                	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x7, %r13
+               	addq	%r8, %rdi
+               	leaq	(%rax,%rbx,8), %rsi
+               	movq	(%rsi), %r12
+               	cmpq	%r12, %rdi
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r13
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L8>
+               	jmp	 <L2>
 <L1>:
-               	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	leaq	(%rdi,%r13,8), %rax
-               	movq	(%rax), %r15
-               	cmpq	%r15, %r14
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%r12, %rcx
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	cmpq	%r15, %r14
+               	cmpq	%r12, %rdi
                	setne	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L3>
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	cmpq	%r15, %r14
-               	setl	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L4>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	cmpq	%r14, %r15
+               	cmpq	%r12, %rdi
                	setl	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	cmpq	%r15, %r14
-               	setle	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
-               	cmpq	%r14, %r15
+               	cmpq	%rdi, %r12
+               	setl	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	cmpq	%r12, %rdi
                	setle	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x7, %r13
-               	jb	 <L1>
-<L8>:
-               	movq	%r12, %rax
-               	movq	-0xf8(%rbp), %rbx
-               	movq	-0x100(%rbp), %rdi
-               	movq	-0x108(%rbp), %rsi
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rdi, %r12
+               	setle	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %rdi
+               	movq	-0x118(%rbp), %rsi
+               	movq	-0x120(%rbp), %r12
+               	movq	-0x128(%rbp), %r13
+               	movq	-0x130(%rbp), %r14
+               	movq	-0x138(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/cmp_u32.dis
+++ b/test/golden/x86_64-windows/cmp/cmp_u32.dis
@@ -6,126 +6,244 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0xd0, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%rdi, -0x80(%rbp)
-               	movq	%rsi, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movq	%r13, -0xb8(%rbp)
+               	movq	%r14, -0xc0(%rbp)
+               	movq	%r15, -0xc8(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x78(%rbp)
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rbx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0xc(%rbx), %rsi
+               	movl	$0x7fffffff, (%rsi)     # imm = 0x7FFFFFFF
+               	leaq	0x10(%rbx), %rsi
+               	movl	$0x80000000, (%rsi)     # imm = 0x80000000
+               	leaq	0x14(%rbx), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rbx), %rsi
+               	movl	$0x80000000, (%rsi)     # imm = 0x80000000
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movl	0x18(%rbx), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     # imm = 0x7FFFFFFF
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %r12
+               	movq	0x10(%rsi), %r13
+               	movl	0x18(%rsi), %r14d
+               	movq	%rdi, (%rbx)
+               	movq	%r12, 0x8(%rbx)
+               	movq	%r13, 0x10(%rbx)
+               	movl	%r14d, 0x18(%rbx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x7, %rdi
+               	jb	 <L0>
+               	jmp	 <L13>
 <L0>:
-               	movl	%ebx, %esi
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r12
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %rdi
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r12
-               	movq	0x10(%rcx), %r13
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%rdi)
-               	movq	%r12, 0x8(%rdi)
-               	movq	%r13, 0x10(%rdi)
-               	movl	%r14d, 0x18(%rdi)
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x7, %r13
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x78(%rbp), %r8
+               	addl	%r8d, %r13d
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L1>
-               	jmp	 <L8>
+               	jmp	 <L2>
 <L1>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r14d
-               	addl	%esi, %r14d
-               	leaq	(%rdi,%r13,4), %rax
-               	movl	(%rax), %r15d
-               	cmpl	%r15d, %r14d
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%r12, %rcx
-               	callq	 <L2>
-<L2>:
-               	cmpl	%r15d, %r14d
-               	setne	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L3>
-<L3>:
-               	cmpl	%r15d, %r14d
-               	setb	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L4>
-<L4>:
-               	cmpl	%r14d, %r15d
-               	setb	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	cmpl	%r15d, %r14d
-               	setbe	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	cmpl	%r14d, %r15d
-               	setbe	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x7, %r13
-               	jb	 <L1>
-<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rax
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %rdi
-               	movq	-0x88(%rbp), %rsi
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpl	%r14d, %r13d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpl	%r13d, %r14d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+<L8>:
+               	cmpl	%r14d, %r13d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rdi
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
+               	movq	-0xb8(%rbp), %r13
+               	movq	-0xc0(%rbp), %r14
+               	movq	-0xc8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/cmp_u64.dis
+++ b/test/golden/x86_64-windows/cmp/cmp_u64.dis
@@ -5,150 +5,265 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x150, %rsp            # imm = 0x150
-               	movq	%rbx, -0xf8(%rbp)
-               	movq	%rdi, -0x100(%rbp)
-               	movq	%rsi, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	subq	$0x140, %rsp            # imm = 0x140
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%rdi, -0x110(%rbp)
+               	movq	%rsi, -0x118(%rbp)
+               	movq	%r12, -0x120(%rbp)
+               	movq	%r13, -0x128(%rbp)
+               	movq	%r14, -0x130(%rbp)
+               	movq	%r15, -0x138(%rbp)
+               	movq	%rcx, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %rsi
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r12
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%rsi)
-               	movq	%rdi, 0x8(%rsi)
-               	movq	%r12, 0x10(%rsi)
-               	movq	%r13, 0x18(%rsi)
-               	movq	%r14, 0x20(%rsi)
-               	movq	%r15, 0x28(%rsi)
-               	movq	%rax, 0x30(%rsi)
-               	leaq	-0xa8(%rbp), %rdi
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%rdi)
-               	movq	%rdx, 0x8(%rdi)
-               	movq	%r12, 0x10(%rdi)
-               	movq	%r13, 0x18(%rdi)
-               	movq	%r14, 0x20(%rdi)
-               	movq	%r15, 0x28(%rdi)
+               	leaq	-0x70(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rbx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movq	0x18(%rbx), %r13
+               	movq	0x20(%rbx), %r14
+               	movq	0x28(%rbx), %r15
+               	movq	0x30(%rbx), %rax
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%rdi)
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rax, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x10(%rbx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x18(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rbx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rbx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rbx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	0x10(%rbx), %r12
+               	movq	0x18(%rbx), %r13
+               	movq	0x20(%rbx), %r14
+               	movq	0x28(%rbx), %r15
+               	movq	0x30(%rbx), %rdx
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	%r12, 0x10(%rax)
+               	movq	%r13, 0x18(%rax)
+               	movq	%r14, 0x20(%rax)
+               	movq	%r15, 0x28(%rax)
+               	movq	%rdx, 0x30(%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %rsi
+               	movq	(%rsi), %rdi
                	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x7, %r13
+               	addq	%r8, %rdi
+               	leaq	(%rax,%rbx,8), %rsi
+               	movq	(%rsi), %r12
+               	cmpq	%r12, %rdi
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r13
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L8>
+               	jmp	 <L2>
 <L1>:
-               	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	leaq	(%rdi,%r13,8), %rax
-               	movq	(%rax), %r15
-               	cmpq	%r15, %r14
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%r12, %rcx
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	cmpq	%r15, %r14
+               	cmpq	%r12, %rdi
                	setne	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L3>
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	cmpq	%r15, %r14
-               	setb	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L4>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	cmpq	%r14, %r15
+               	cmpq	%r12, %rdi
                	setb	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	cmpq	%r15, %r14
-               	setbe	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
-               	cmpq	%r14, %r15
+               	cmpq	%rdi, %r12
+               	setb	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	cmpq	%r12, %rdi
                	setbe	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x7, %r13
-               	jb	 <L1>
-<L8>:
-               	movq	%r12, %rax
-               	movq	-0xf8(%rbp), %rbx
-               	movq	-0x100(%rbp), %rdi
-               	movq	-0x108(%rbp), %rsi
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	movzbq	%dl, %r13
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rdi, %r12
+               	setbe	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %rdi
+               	movq	-0x118(%rbp), %rsi
+               	movq	-0x120(%rbp), %r12
+               	movq	-0x128(%rbp), %r13
+               	movq	-0x130(%rbp), %r14
+               	movq	-0x138(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/loop_shapes.dis
+++ b/test/golden/x86_64-windows/cmp/loop_shapes.dis
@@ -5,144 +5,246 @@ Disassembly of section .text:
 <corpus.cases.cmp.loop_shapes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %esi
-               	movq	%rax, %rbx
-               	movl	$0x0, %edi
-               	movq	%rsi, %r12
-               	cmpl	$0x10, %edi
-               	jb	 <L1>
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movl	$0x0, %ebx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	cmpl	$0x10, %ebx
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	%edi, %eax
-               	imull	$0x3, %eax, %eax
-               	movl	%r12d, %ecx
-               	addl	%eax, %ecx
-               	movl	%ecx, %r12d
+<L0>:
+               	movl	%ebx, %edi
+               	imull	$0x3, %edi, %edi
+               	movl	%esi, %r12d
+               	addl	%edi, %r12d
                	addl	$0x1, %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %edi
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %edi
+               	movl	%r12d, %edi
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %ebx
+               	movq	%r13, %rax
+               	movq	%r12, %rsi
+               	cmpl	$0x10, %ebx
+               	jb	 <L0>
 <L3>:
-               	movl	$0x62, %eax
-               	addl	%esi, %eax
-               	movq	%rax, %rdi
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x62, %edx
+               	addl	%r8d, %edx
                	movl	$0x0, %r11d
-               	cmpl	%edi, %r11d
+               	cmpl	%edx, %r11d
                	jb	 <L4>
-               	jmp	 <L6>
+               	jmp	 <L7>
 <L4>:
-               	subl	$0x7, %edi
-               	movq	%rbx, %rcx
-               	movl	%edi, %edx
-               	callq	 <L5>
+               	movl	%edx, %ebx
+               	subl	$0x7, %ebx
+               	movl	%ebx, %esi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rbx
-               	movl	$0x0, %r11d
-               	cmpl	%edi, %r11d
-               	jb	 <L4>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
 <L6>:
+               	movq	%rdi, %rax
+               	movq	%rbx, %rdx
+               	movl	$0x0, %r11d
+               	cmpl	%edx, %r11d
+               	jb	 <L4>
+<L7>:
+               	movl	$0x0, %edx
+               	cmpl	$0x6, %edx
+               	jb	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movl	%edx, %r8d
+               	imull	$0x6, %r8d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rax, %rsi
                	movl	$0x0, %edi
                	cmpl	$0x6, %edi
-               	jb	 <L7>
-               	jmp	 <L13>
-<L7>:
-               	movl	%edi, %r12d
-               	imull	$0x6, %r12d, %r12d
-               	movq	%rbx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x6, %r14d
-               	jb	 <L8>
-               	jmp	 <L12>
-<L8>:
-               	cmpl	$0x3, %r14d
-               	je	 <L10>
-               	movl	%r12d, %eax
-               	addl	%r14d, %eax
-               	addl	%esi, %eax
-               	movq	%r13, %rcx
-               	movl	%eax, %edx
-               	callq	 <L9>
+               	jb	 <L9>
+               	jmp	 <L14>
 <L9>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %r13
+               	cmpl	$0x3, %edi
+               	je	 <L12>
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	addl	%edi, %r12d
+               	movq	-0x8(%rbp), %r8
+               	addl	%r8d, %r12d
+               	movl	%r12d, %r13d
+               	movq	%rsi, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	addl	$0x1, %r14d
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
 <L11>:
-               	cmpl	$0x6, %r14d
-               	jb	 <L8>
+               	addl	$0x1, %edi
+               	movq	%r12, %rsi
+               	jmp	 <L13>
 <L12>:
                	addl	$0x1, %edi
-               	movq	%r13, %rbx
-               	cmpl	$0x6, %edi
-               	jb	 <L7>
 <L13>:
-               	movl	$0x9, %edi
-               	addl	%esi, %edi
-               	movq	%rsi, %r12
-               	cmpl	$0xf4240, %r12d         # imm = 0xF4240
-               	jb	 <L14>
-               	jmp	 <L16>
+               	cmpl	$0x6, %edi
+               	jb	 <L9>
 <L14>:
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L15>
+               	addl	$0x1, %edx
+               	movq	%rsi, %rax
+               	cmpl	$0x6, %edx
+               	jb	 <L8>
 <L15>:
-               	cmpl	%edi, %r12d
-               	je	 <L17>
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	cmpl	$0xf4240, %r12d         # imm = 0xF4240
-               	jb	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9, %edx
+               	addl	%r8d, %edx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rbx
+               	cmpl	$0xf4240, %ebx          # imm = 0xF4240
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
+               	movl	%ebx, %esi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
                	jmp	 <L18>
 <L17>:
-               	movq	%rax, %rbx
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
 <L18>:
-               	movl	$0x1, %eax
-               	addl	%esi, %eax
-               	movq	%rax, %rsi
-               	movl	$0x1, %edi
-               	movl	$0x0, %r12d
-               	cmpl	$0x14, %r12d
-               	jb	 <L19>
-               	jmp	 <L21>
+               	cmpl	%edx, %ebx
+               	je	 <L20>
+               	addl	$0x1, %ebx
+               	movq	%rdi, %rax
+               	cmpl	$0xf4240, %ebx          # imm = 0xF4240
+               	jb	 <L16>
 <L19>:
-               	movl	%esi, %r13d
-               	addl	%edi, %r13d
-               	movq	%rbx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%rdi, %rsi
-               	movq	%r13, %rdi
-               	cmpl	$0x14, %r12d
-               	jb	 <L19>
+               	movq	%rdi, %rax
 <L21>:
-               	movq	%rbx, %rax
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x1, %edx
+               	addl	%r8d, %edx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x1, %ebx
+               	movl	$0x0, %esi
+               	cmpl	$0x14, %esi
+               	jb	 <L22>
+               	jmp	 <L25>
+<L22>:
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %r12d
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+<L24>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rax
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rdi, %rbx
+               	cmpl	$0x14, %esi
+               	jb	 <L22>
+<L25>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/short_circuit.dis
+++ b/test/golden/x86_64-windows/cmp/short_circuit.dis
@@ -61,37 +61,95 @@ Disassembly of section .text:
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.fold_state+0x1f>
-               	callq	 <L0>
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.fold_state+0x2e>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.fold_state+0x2b>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.fold_state+0x32>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L1>
-               	jmp	 <L4>
-<L1>:
-               	leaq	(%rbx,%r12,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L2>
-<L2>:
-               	leaq	(%rsi,%r12,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rdi
-               	cmpq	$0x4, %r12
-               	jb	 <L1>
-<L4>:
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
                	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+<L1>:
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.fold_state+0x87>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.fold_state+0x8e>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+               	jmp	 <L7>
+<L2>:
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %r12
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+<L4>:
+               	leaq	(%rbx,%rsi,8), %r12
+               	movq	(%r12), %r13
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+<L6>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rax
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+<L7>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -99,579 +157,530 @@ Disassembly of section .text:
 <corpus.cases.cmp.short_circuit.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rcx, %rax
+               	movb	%al, %bl
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x24>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2f>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x36>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movb	%bl, %sil
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x2e>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x39>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x40>
-               	movq	$0x0, %rbx
-               	cmpq	$0x4, %rbx
-               	jb	 <L1>
-               	jmp	 <L2>
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L0>
 <L1>:
-               	leaq	(%rcx,%rbx,8), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	(%rdx,%rbx,8), %rdi
-               	movq	$0x0, (%rdi)
-               	addq	$0x1, %rbx
-               	cmpq	$0x4, %rbx
-               	jb	 <L1>
-<L2>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x81>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x93>
-               	movq	(%rcx), %rdx
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x77>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x82>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x89>
+               	movq	(%rax), %rdx
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0xa4>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0xab>
-               	movq	%rcx, (%rdx)
-               	movq	%rax, %rcx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x9a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0xa1>
+               	movq	%rax, (%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
                	movq	$0x0, %rdx
-               	callq	 <L3>
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x0, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0xc4>
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0xd3>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0xda>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x113>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x11e>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x125>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
-               	jmp	 <L8>
+               	jmp	 <L6>
 <L5>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L6>
-<L6>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
-<L8>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x129>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x134>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x13b>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
-               	jmp	 <L10>
-<L9>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
+<L6>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x168>
                	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
-<L10>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x17c>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x187>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x18e>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x19f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a6>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %eax
-               	xorl	%esi, %eax
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b7>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c2>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1d1>
-               	movq	(%rcx), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1da>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1e9>
-               	movq	%rcx, (%rdx)
-               	cmpb	$0x1, %al
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%r12, %rcx
-               	callq	 <L11>
-<L11>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1fd>
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20c>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x213>
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x173>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x17a>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x18b>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x192>
+               	movq	%rdx, (%rsi)
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1a3>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x1ae>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1bd>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1c6>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x1d5>
+               	movq	%rsi, (%rdi)
+               	cmpb	$0x1, %dl
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L13>
-               	jmp	 <L16>
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+<L8>:
+               	movq	%rax, %rcx
+               	callq	 <L9>
+<L9>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x240>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x24b>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x252>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+<L11>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x295>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x2a0>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2a7>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2b8>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2bf>
+               	movq	%rdx, (%rsi)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
+               	movq	%rax, %rcx
                	callq	 <L14>
 <L14>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rax, %rsi
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x32a>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x335>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x33c>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L13>
+               	leaq	(%rax,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L15>
 <L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x262>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x26d>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x274>
+               	movq	$0x0, %rcx
                	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
-               	jmp	 <L18>
+               	callq	 <L17>
 <L17>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L18>
+               	movl	$0x1, %eax
+               	xorl	%ebx, %eax
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x3ab>
+               	addq	$0x1, %rdi
+               	movq	%rdi,  <corpus.cases.cmp.short_circuit.checksum+0x3b6>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x3c5>
+               	movq	(%rdi), %r12
+               	addq	$0x1, %r12
+               	movq	%r12, (%rdi)
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x3ce>
+               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x3dd>
+               	movq	%rdi, (%r12)
+               	cmpb	$0x1, %al
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L19>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b5>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c0>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2c7>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2d8>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2df>
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L19>
+               	movq	%rdx, %rdi
 <L19>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2f8>
-               	movq	%rax, %rcx
-               	callq	 <L20>
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x307>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x30e>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L21>
-               	jmp	 <L24>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
+               	movq	%rsi, %rcx
                	callq	 <L22>
 <L22>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L23>
+               	movq	%rax, %rsi
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x454>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x45f>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x466>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L21>
+               	leaq	(%rax,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L23>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x35d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x368>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x36f>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-<L26>:
                	movq	$0x0, %rcx
                	movq	$0x0, %rdx
-               	callq	 <L27>
-<L27>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movl	$0x1, %eax
-               	xorl	%esi, %eax
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3dc>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3e7>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3f6>
-               	movq	(%rdx), %rbx
-               	addq	$0x1, %rbx
-               	movq	%rbx, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3ff>
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x40e>
-               	movq	%rdx, (%rbx)
+               	callq	 <L25>
+<L25>:
                	cmpb	$0x1, %al
                	sete	%dl
                	movzbq	%dl, %rdx
-               	jmp	 <L29>
+               	testb	%dl, %dl
+               	jne	 <L26>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4ce>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4d9>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4e8>
+               	movq	(%rax), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4f1>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x500>
+               	movq	%rax, (%rdi)
+               	movq	$0x1, %rax
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rax
+<L27>:
+               	testb	%al, %al
+               	jne	 <L28>
+               	jmp	 <L31>
 <L28>:
-               	movq	%rcx, %rdx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x51e>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x529>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x540>
+               	movq	(%rdx), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x541>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x558>
+               	movq	%rdx, (%rdi)
+               	cmpb	$0x1, %bl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L29>
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x564>
+               	addq	$0x1, %rdi
+               	movq	%rdi,  <corpus.cases.cmp.short_circuit.checksum+0x56f>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x58e>
+               	movq	(%rdi), %r12
+               	addq	$0x1, %r12
+               	movq	%r12, (%rdi)
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x587>
+               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x5a6>
+               	movq	%rdi, (%r12)
+               	movq	$0x1, %rdi
+               	jmp	 <L30>
 <L29>:
-               	movq	%r12, %rcx
-               	callq	 <L30>
+               	movq	%rdx, %rdi
 <L30>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x42a>
-               	movq	%rax, %rcx
-               	callq	 <L31>
+               	movq	%rdi, %rax
 <L31>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x439>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x440>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L32>
-               	jmp	 <L35>
+               	jmp	 <L33>
 <L32>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L33>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
 <L33>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
+               	movq	%rsi, %rcx
                	callq	 <L34>
 <L34>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L32>
+               	movq	%rax, %rsi
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x60c>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x617>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x61e>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L35>
+               	jmp	 <L36>
 <L35>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x48f>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x49a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4a1>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
-               	jmp	 <L37>
+               	leaq	(%rax,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L35>
 <L36>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
+               	movq	$0x0, %rcx
+               	movq	$0x1, %rdx
+               	callq	 <L37>
 <L37>:
-               	movq	$0x0, %rcx
-               	movq	$0x0, %rdx
-               	callq	 <L38>
-<L38>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L39>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x507>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x512>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x521>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x52a>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x539>
-               	movq	%rax, (%rdx)
-               	movq	$0x1, %rax
-               	jmp	 <L40>
-<L39>:
-               	movq	%rcx, %rax
-<L40>:
-               	testb	%al, %al
-               	jne	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x557>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x562>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x579>
-               	movq	(%rcx), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x57a>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x591>
-               	movq	%rcx, (%rdx)
-               	cmpb	$0x1, %sil
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L42>
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x59e>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5a9>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5c8>
-               	movq	(%rdx), %rbx
-               	addq	$0x1, %rbx
-               	movq	%rbx, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5c1>
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5e0>
-               	movq	%rdx, (%rbx)
-               	movq	$0x1, %rdx
-               	jmp	 <L43>
-<L42>:
-               	movq	%rcx, %rdx
-<L43>:
-               	movq	%rdx, %rax
-<L44>:
-               	movq	%r12, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L45>
-<L45>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5ef>
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5fe>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x605>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L48>
-<L48>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L47>
-<L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x654>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x65f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x666>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-               	jmp	 <L52>
-<L51>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-<L52>:
-               	movq	$0x0, %rcx
-               	movq	$0x1, %rdx
-               	callq	 <L53>
-<L53>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L54>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6cc>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6d7>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6e6>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6ef>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6fe>
-               	movq	%rax, (%rdx)
-               	movq	$0x1, %rax
-               	jmp	 <L55>
-<L54>:
-               	movq	%rcx, %rax
-<L55>:
-               	testb	%al, %al
-               	jne	 <L56>
-               	jmp	 <L57>
-<L56>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x71c>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x727>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x73e>
-               	movq	(%rcx), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x73f>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x756>
-               	movq	%rcx, (%rdx)
-               	movl	$0x1, %ecx
-               	xorl	%esi, %ecx
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x757>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x762>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x781>
-               	movq	(%rdx), %rbx
-               	addq	$0x1, %rbx
-               	movq	%rbx, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x77a>
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x799>
-               	movq	%rdx, (%rbx)
-               	cmpb	$0x1, %cl
                	sete	%dl
                	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L38>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x686>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x691>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6a0>
+               	movq	(%rax), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6a9>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x6b8>
+               	movq	%rax, (%rdi)
+               	movq	$0x1, %rax
+               	jmp	 <L39>
+<L38>:
                	movq	%rdx, %rax
-<L57>:
-               	movq	%r12, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L58>
-<L58>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x7a3>
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7b2>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x7b9>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L60>
-               	jmp	 <L63>
-<L60>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%r12, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L60>
-<L63>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x808>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x813>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x81a>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-               	jmp	 <L65>
-<L64>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
+<L39>:
+               	testb	%al, %al
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6d6>
                	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-<L65>:
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x6e1>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6f8>
+               	movq	(%rdx), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6f9>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x710>
+               	movq	%rdx, (%rdi)
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x711>
+               	addq	$0x1, %rdi
+               	movq	%rdi,  <corpus.cases.cmp.short_circuit.checksum+0x71c>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x73b>
+               	movq	(%rdi), %r12
+               	addq	$0x1, %r12
+               	movq	%r12, (%rdi)
+               	movq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x734>
+               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x753>
+               	movq	%rdi, (%r12)
+               	cmpb	$0x1, %dl
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	movq	%rdi, %rax
+<L41>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+<L43>:
+               	movq	%rsi, %rcx
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %rsi
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x7b5>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7c0>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x7c7>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L45>
+               	jmp	 <L46>
+<L45>:
+               	leaq	(%rax,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L45>
+<L46>:
                	movq	$0x0, %rcx
                	movq	$0x0, %rdx
-               	callq	 <L66>
-<L66>:
+               	callq	 <L47>
+<L47>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L67>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x880>
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L48>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x82f>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x88b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x89a>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8a3>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8b2>
-               	movq	%rax, (%rdx)
-               	cmpb	$0x1, %sil
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x83a>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x849>
+               	movq	(%rax), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x852>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x861>
+               	movq	%rax, (%rdi)
+               	cmpb	$0x1, %bl
                	sete	%al
                	movzbq	%al, %rax
-               	jmp	 <L68>
-<L67>:
-               	movq	%rcx, %rax
-<L68>:
+               	jmp	 <L49>
+<L48>:
+               	movq	%rdx, %rax
+<L49>:
                	testb	%al, %al
-               	jne	 <L69>
-               	jmp	 <L70>
-<L69>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8d4>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8df>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f6>
-               	movq	(%rcx), %rdx
+               	jne	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x882>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f7>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x90e>
-               	movq	%rcx, (%rdx)
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8a4>
+               	movq	(%rdx), %rbx
+               	addq	$0x1, %rbx
+               	movq	%rbx, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8a5>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x8bc>
+               	movq	%rdx, (%rbx)
                	movq	$0x1, %rax
-<L70>:
-               	movq	%r12, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x91a>
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x929>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x930>
-               	movq	%rax, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L73>
-               	jmp	 <L76>
-<L73>:
-               	leaq	(%rbx,%r12,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	(%rsi,%r12,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rdi
-               	cmpq	$0x4, %r12
-               	jb	 <L73>
-<L76>:
-               	movq	%rdi, %rax
+<L51>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+<L53>:
+               	movq	%rsi, %rcx
+               	callq	 <L54>
+<L54>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/comptime/ct_runtime_agree.dis
+++ b/test/golden/x86_64-windows/comptime/ct_runtime_agree.dis
@@ -39,535 +39,843 @@ Disassembly of section .text:
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            # imm = 0x100
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%rdi, -0x50(%rbp)
-               	movq	%rsi, -0x58(%rbp)
-               	movq	%r12, -0x60(%rbp)
-               	movq	%r13, -0x68(%rbp)
-               	movq	%r14, -0x70(%rbp)
-               	movq	%r15, -0x78(%rbp)
-               	movaps	%xmm6, -0x90(%rbp)
-               	movaps	%xmm7, -0xa0(%rbp)
-               	movaps	%xmm8, -0xb0(%rbp)
-               	movaps	%xmm9, -0xc0(%rbp)
-               	movaps	%xmm14, -0xd0(%rbp)
-               	movaps	%xmm15, -0xe0(%rbp)
+               	subq	$0x160, %rsp            # imm = 0x160
+               	movq	%rbx, -0xa8(%rbp)
+               	movq	%rdi, -0xb0(%rbp)
+               	movq	%rsi, -0xb8(%rbp)
+               	movq	%r12, -0xc0(%rbp)
+               	movq	%r13, -0xc8(%rbp)
+               	movq	%r14, -0xd0(%rbp)
+               	movq	%r15, -0xd8(%rbp)
+               	movaps	%xmm6, -0xf0(%rbp)
+               	movaps	%xmm7, -0x100(%rbp)
+               	movaps	%xmm8, -0x110(%rbp)
+               	movaps	%xmm9, -0x120(%rbp)
+               	movaps	%xmm14, -0x130(%rbp)
+               	movaps	%xmm15, -0x140(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	$0x12345678, %rsi       # imm = 0x12345678
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
+               	movq	$0x12345678, %r8        # imm = 0x12345678
+               	addq	%rbx, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	%rdx, %rdi
-               	addq	$0x7, %rdi
-               	movq	%rdi, %rdx
-               	shlq	$0xd, %rdx
-               	movq	%rdx, %r12
-               	movabsq	$0xf0f0f0f0f, %r11      # imm = 0xF0F0F0F0F
-               	xorq	%r11, %r12
-               	movq	%r12, %rdx
-               	shrq	$0x7, %rdx
-               	movq	%r12, %r13
-               	xorq	%rdx, %r13
-               	movq	%r13, %r14
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	andq	%r11, %r14
-               	movq	%r14, %r15
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %r15
-               	movq	%r15, %r8
-               	shrq	$0x11, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	-0x38(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%r14, %r8
+               	movq	%rdx, %r8
+               	addq	$0x7, %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	$0x12345678, %rdx       # imm = 0x12345678
-               	callq	 <L1>
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rsi
+               	shlq	$0xd, %rsi
+               	movq	%rsi, %r8
+               	movabsq	$0xf0f0f0f0f, %r11      # imm = 0xF0F0F0F0F
+               	xorq	%r11, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	$0x7, %rdi
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %r12
+               	xorq	%rdi, %r12
+               	movq	%r12, %rdi
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	andq	%r11, %rdi
+               	movq	%rdi, %r13
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %r13
+               	movq	%r13, %r14
+               	shrq	$0x11, %r14
+               	movq	%r14, %r15
+               	addq	%rdi, %r15
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x50(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	$0x12345678, %rax       # imm = 0x12345678
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rax, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x50(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	movq	-0x50(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x369d036f, %rdx       # imm = 0x369D036F
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x58(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L4>
+               	movq	-0x58(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movabsq	$0x6dcaf62ef0f, %rdx    # imm = 0x6DCAF62EF0F
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x369d036f, %rsi       # imm = 0x369D036F
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x60(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	-0x60(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movabsq	$0x6d1163c2ad1, %rdx    # imm = 0x6D1163C2AD1
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x68(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x70(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	$0x163c2ad1, %rdx       # imm = 0x163C2AD1
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movabsq	$0x6dcaf62ef0f, %rsi    # imm = 0x6DCAF62EF0F
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x70(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L10>
+               	movq	-0x70(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x78(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movabsq	$0xdbdf3ec00bd6381, %rdx # imm = 0xDBDF3EC00BD6381
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x78(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rsi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x78(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
+               	movq	-0x78(%rbp), %r8
+               	movq	%r8, %rcx
+               	movabsq	$0x6d1163c2ad1, %rdx    # imm = 0x6D1163C2AD1
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movabsq	$0x6def9f6005e, %rdx    # imm = 0x6DEF9F6005E
+               	movq	%r12, %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
+               	movq	$0x163c2ad1, %rdx       # imm = 0x163C2AD1
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movabsq	$0x6df10322b2f, %rdx    # imm = 0x6DF10322B2F
+               	movq	%rdi, %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
+               	movabsq	$0xdbdf3ec00bd6381, %rdx # imm = 0xDBDF3EC00BD6381
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L17>
+<L17>:
+               	movq	%rax, %rcx
+               	movabsq	$0x6def9f6005e, %rdx    # imm = 0x6DEF9F6005E
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rcx
+               	movabsq	$0x6df10322b2f, %rdx    # imm = 0x6DF10322B2F
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L21>
+<L21>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L18>:
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1f1>
+<L23>:
+               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x435>
                	addsd	%xmm0, %xmm1
                	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.comptime.ct_runtime_agree.checksum+0x201>
+               	divsd	, %xmm6 <corpus.cases.comptime.ct_runtime_agree.checksum+0x445>
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x20d>
+               	mulsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x451>
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	subsd	, %xmm7 <corpus.cases.comptime.ct_runtime_agree.checksum+0x219>
+               	subsd	, %xmm7 <corpus.cases.comptime.ct_runtime_agree.checksum+0x45d>
                	movsd	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.comptime.ct_runtime_agree.checksum+0x227>
+               	divsd	, %xmm8 <corpus.cases.comptime.ct_runtime_agree.checksum+0x46b>
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
                	mulsd	%xmm8, %xmm0
                	movsd	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1]
                	addsd	%xmm6, %xmm9
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x243>
-               	callq	 <L19>
-<L19>:
+               	movabsq	$0x3fd5555555555555, %rdx # imm = 0x3FD5555555555555
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x25f>
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x27b>
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	callq	 <L24>
 <L24>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x298>
                	callq	 <L25>
 <L25>:
+               	movabsq	$0x3fd5555555555550, %rdx # imm = 0x3FD5555555555550
                	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	callq	 <L26>
 <L26>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movabsq	$0x3fd364d9364d9360, %rdx # imm = 0x3FD364D9364D9360
+               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
+               	movq	%xmm8, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L29>
+<L29>:
+               	movabsq	$0x3fdb35d5373e4baf, %rdx # imm = 0x3FDB35D5373E4BAF
+               	movq	%rax, %rcx
+               	callq	 <L30>
+<L30>:
+               	movq	%xmm9, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L31>
+<L31>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L28>:
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2e1>
+<L33>:
+               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x52f>
                	addss	%xmm0, %xmm1
                	movss	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2f1>
+               	divss	, %xmm6 <corpus.cases.comptime.ct_runtime_agree.checksum+0x53f>
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2fd>
+               	mulss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x54b>
                	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
-               	subss	, %xmm7 <corpus.cases.comptime.ct_runtime_agree.checksum+0x309>
+               	subss	, %xmm7 <corpus.cases.comptime.ct_runtime_agree.checksum+0x557>
                	movss	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.comptime.ct_runtime_agree.checksum+0x317>
+               	divss	, %xmm8 <corpus.cases.comptime.ct_runtime_agree.checksum+0x565>
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	mulss	%xmm8, %xmm0
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	addss	%xmm6, %xmm9
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x333>
-               	callq	 <L29>
-<L29>:
+               	movl	$0x3eaaaaab, %edx       # imm = 0x3EAAAAAB
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x34f>
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x36b>
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	movq	%rsi, %rdx
                	callq	 <L34>
 <L34>:
+               	movd	%xmm6, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x388>
+               	movq	%rsi, %rdx
                	callq	 <L35>
 <L35>:
+               	movl	$0x3eaaaab0, %edx       # imm = 0x3EAAAAB0
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movq	%rsi, %rdx
                	callq	 <L36>
 <L36>:
+               	movd	%xmm7, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movabsq	$0x9e3779b1, %rdx       # imm = 0x9E3779B1
+               	movq	%rsi, %rdx
                	callq	 <L37>
 <L37>:
+               	movl	$0x3e9b26ce, %edx       # imm = 0x3E9B26CE
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movabsq	$0x1449114a2, %rdx      # imm = 0x1449114A2
+               	movq	%rsi, %rdx
                	callq	 <L38>
 <L38>:
+               	movd	%xmm8, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movabsq	$0x517154775, %rdx      # imm = 0x517154775
+               	movq	%rsi, %rdx
                	callq	 <L39>
 <L39>:
+               	movl	$0x3ed9aead, %edx       # imm = 0x3ED9AEAD
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movabsq	$0xc5255662a, %rdx      # imm = 0xC5255662A
+               	movq	%rsi, %rdx
                	callq	 <L40>
 <L40>:
+               	movd	%xmm9, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	movabsq	$0x1f7ae2da45, %rdx     # imm = 0x1F7AE2DA45
+               	movq	%rsi, %rdx
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rcx
-               	movabsq	$0x39954428ca, %rdx     # imm = 0x39954428CA
+               	movabsq	$0x9e3779b1, %rdx       # imm = 0x9E3779B1
                	callq	 <L42>
 <L42>:
-               	leaq	-0x30(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movq	$0x0, 0x20(%rsi)
-               	movq	$0x0, 0x28(%rsi)
-               	movq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	leaq	(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	$0x3, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x8(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	$0x7, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x10(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	$0xf, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x18(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	$0x1f, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x20(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	$0x3f, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x28(%rsi), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%rax, %rdi
-               	movq	$0x0, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x6, %r13
-               	jb	 <L43>
-               	jmp	 <L45>
+               	movq	%rax, %rcx
+               	movabsq	$0x1449114a2, %rdx      # imm = 0x1449114A2
+               	callq	 <L43>
 <L43>:
-               	leaq	(%rsi,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	xorq	%rcx, %r12
-               	movq	%rdi, %rcx
-               	movq	%r12, %rdx
+               	movq	%rax, %rcx
+               	movabsq	$0x517154775, %rdx      # imm = 0x517154775
                	callq	 <L44>
 <L44>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rdi
-               	cmpq	$0x6, %r13
-               	jb	 <L43>
+               	movq	%rax, %rcx
+               	movabsq	$0xc5255662a, %rdx      # imm = 0xC5255662A
+               	callq	 <L45>
 <L45>:
-               	movq	%rdi, %rcx
-               	movq	$0xb, %rdx
+               	movq	%rax, %rcx
+               	movabsq	$0x1f7ae2da45, %rdx     # imm = 0x1F7AE2DA45
                	callq	 <L46>
 <L46>:
-               	movq	%rax, %rsi
-               	movq	-0x40(%rbp), %r8
-               	cmpq	%r15, %r8
-               	jb	 <L48>
-               	movq	%rsi, %rcx
-               	movq	$0x16, %rdx
+               	movq	%rax, %rcx
+               	movabsq	$0x39954428ca, %rdx     # imm = 0x39954428CA
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rdi
-               	jmp	 <L50>
+               	leaq	-0x30(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movq	$0x0, 0x10(%rdx)
+               	movq	$0x0, 0x18(%rdx)
+               	movq	$0x0, 0x20(%rdx)
+               	movq	$0x0, 0x28(%rdx)
+               	movq	$0x1, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	$0x3, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x8(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	$0x7, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x10(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	$0xf, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x18(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	$0x1f, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x20(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	$0x3f, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x28(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movq	%rax, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L48>
+               	jmp	 <L51>
 <L48>:
-               	movq	%rsi, %rcx
-               	movq	$0xb, %rdx
-               	callq	 <L49>
+               	movq	-0x98(%rbp), %r8
+               	leaq	(%rdx,%r8,8), %r14
+               	movq	(%r14), %rsi
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %rsi
+               	movq	-0x80(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rsi, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L49>
+               	jmp	 <L50>
 <L49>:
-               	movq	%rax, %rdi
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r12
+               	xorq	%r14, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L49>
 <L50>:
-               	movq	%rdi, %rcx
-               	movq	$0x21, %rdx
-               	callq	 <L51>
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rsi, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	-0x90(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L48>
 <L51>:
-               	movq	%rax, %rsi
-               	movq	$0xffff, %r11           # imm = 0xFFFF
-               	cmpq	%r14, %r11
-               	jb	 <L53>
-               	movq	%rsi, %rcx
-               	movq	$0x2c, %rdx
-               	callq	 <L52>
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
+               	jmp	 <L53>
 <L52>:
-               	movq	%rax, %rdi
-               	jmp	 <L55>
-<L53>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	movq	$0x21, %rdx
-               	callq	 <L54>
+               	movq	$0xb, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
+<L53>:
+               	cmpq	%r13, %r15
+               	jb	 <L56>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
 <L54>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	$0x16, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
 <L55>:
+               	jmp	 <L59>
+<L56>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	$0xb, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+<L58>:
+               	movq	%rax, %rdx
+<L59>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x21, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+<L61>:
+               	movq	$0xffff, %r11           # imm = 0xFFFF
+               	cmpq	%rdi, %r11
+               	jb	 <L64>
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	$0x2c, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+<L63>:
+               	jmp	 <L67>
+<L64>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	$0x21, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+<L66>:
+               	movq	%rdx, %rax
+<L67>:
                	movb	%bl, %sil
                	movl	$0x1, %ebx
                	addl	%esi, %ebx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rax
-               	shrq	$0x1d, %rax
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	%rax, %rcx
-               	movq	%rcx, %rdx
+               	movq	%r15, %rdx
+               	shrq	$0x1d, %rdx
+               	movq	%r15, %r12
+               	xorq	%rdx, %r12
                	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L56>
-<L56>:
-               	cmpb	$0x0, %sil
-               	je	 <L59>
-               	cmpb	$0x1, %sil
-               	je	 <L57>
-               	movq	$0x0, %rcx
-               	jmp	 <L58>
-<L57>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	shlq	$0x11, %rdx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rdx, %rcx
-<L58>:
-               	movq	%rcx, %rdx
-               	jmp	 <L60>
-<L59>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rcx
-               	shrq	$0x1d, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rcx, %rdi
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L60>:
-               	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x11, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	shrq	$0x2f, %rdx
-               	orq	%rdx, %rcx
-               	movq	%rcx, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	cmpb	$0x0, %bl
-               	je	 <L65>
-               	cmpb	$0x1, %bl
-               	je	 <L63>
-               	movq	$0x0, %rcx
-               	jmp	 <L64>
-<L63>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	shlq	$0x11, %rdx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rdx, %rcx
-<L64>:
-               	movq	%rcx, %rdx
-               	jmp	 <L66>
-<L65>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rcx
-               	shrq	$0x1d, %rcx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rcx, %rdi
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L66>:
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	movq	%r14, %rcx
-               	shrq	$0x1d, %rcx
-               	movq	%r14, %rdx
-               	xorq	%rcx, %rdx
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L68>
+               	imulq	%r11, %r12
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
+               	jmp	 <L69>
 <L68>:
-               	cmpb	$0x0, %sil
-               	je	 <L71>
-               	cmpb	$0x1, %sil
-               	je	 <L69>
-               	movq	$0x0, %rcx
-               	jmp	 <L70>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
 <L69>:
-               	movq	%r14, %rdx
+               	cmpb	$0x0, %sil
+               	je	 <L72>
+               	cmpb	$0x1, %sil
+               	je	 <L70>
+               	movq	$0x0, %rdx
+               	jmp	 <L71>
+<L70>:
+               	movq	%r15, %r12
+               	shlq	$0x11, %r12
+               	movq	%r15, %r13
+               	shrq	$0x2f, %r13
+               	orq	%r13, %r12
+               	addq	$0x3039, %r12           # imm = 0x3039
+               	movq	%r12, %rdx
+<L71>:
+               	jmp	 <L73>
+<L72>:
+               	movq	%r15, %r12
+               	shrq	$0x1d, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	movq	%r13, %rdx
+<L73>:
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rax
+               	cmpq	$0x8, %r12
+               	jb	 <L74>
+<L75>:
+               	movq	%r15, %rdx
                	shlq	$0x11, %rdx
-               	movq	%r14, %rsi
+               	movq	%r15, %r12
+               	shrq	$0x2f, %r12
+               	orq	%r12, %rdx
+               	addq	$0x3039, %rdx           # imm = 0x3039
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rax
+               	cmpq	$0x8, %r12
+               	jb	 <L76>
+<L77>:
+               	cmpb	$0x0, %bl
+               	je	 <L80>
+               	cmpb	$0x1, %bl
+               	je	 <L78>
+               	movq	$0x0, %rdx
+               	jmp	 <L79>
+<L78>:
+               	movq	%r15, %r12
+               	shlq	$0x11, %r12
+               	movq	%r15, %r13
+               	shrq	$0x2f, %r13
+               	orq	%r13, %r12
+               	addq	$0x3039, %r12           # imm = 0x3039
+               	movq	%r12, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%r15, %r12
+               	shrq	$0x1d, %r12
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	movq	%r15, %rdx
+<L81>:
+               	movq	%rax, %rcx
+               	callq	 <L82>
+<L82>:
+               	movq	%rdi, %rdx
+               	shrq	$0x1d, %rdx
+               	movq	%rdi, %r12
+               	xorq	%rdx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	movq	%rax, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L83>
+<L83>:
+               	cmpb	$0x0, %sil
+               	je	 <L86>
+               	cmpb	$0x1, %sil
+               	je	 <L84>
+               	movq	$0x0, %rdx
+               	jmp	 <L85>
+<L84>:
+               	movq	%rdi, %rsi
+               	shlq	$0x11, %rsi
+               	movq	%rdi, %r12
+               	shrq	$0x2f, %r12
+               	orq	%r12, %rsi
+               	addq	$0x3039, %rsi           # imm = 0x3039
+               	movq	%rsi, %rdx
+<L85>:
+               	jmp	 <L87>
+<L86>:
+               	movq	%rdi, %rsi
+               	shrq	$0x1d, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	movq	%r12, %rdx
+<L87>:
+               	movq	%rax, %rcx
+               	callq	 <L88>
+<L88>:
+               	movq	%rdi, %rdx
+               	shlq	$0x11, %rdx
+               	movq	%rdi, %rsi
                	shrq	$0x2f, %rsi
                	orq	%rsi, %rdx
                	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rdx, %rcx
-<L70>:
-               	movq	%rcx, %rdx
-               	jmp	 <L72>
-<L71>:
-               	movq	%r14, %rcx
-               	shrq	$0x1d, %rcx
-               	movq	%r14, %rsi
-               	xorq	%rcx, %rsi
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rsi
-               	movq	%rsi, %rdx
-<L72>:
                	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
-               	movq	%r14, %rcx
-               	shlq	$0x11, %rcx
-               	movq	%r14, %rdx
-               	shrq	$0x2f, %rdx
-               	orq	%rdx, %rcx
-               	movq	%rcx, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L89>
+<L89>:
                	cmpb	$0x0, %bl
-               	je	 <L77>
+               	je	 <L92>
                	cmpb	$0x1, %bl
-               	je	 <L75>
-               	movq	$0x0, %rcx
-               	jmp	 <L76>
-<L75>:
-               	movq	%r14, %rdx
-               	shlq	$0x11, %rdx
-               	movq	%r14, %rbx
-               	shrq	$0x2f, %rbx
-               	orq	%rbx, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rdx, %rcx
-<L76>:
-               	movq	%rcx, %rdx
-               	jmp	 <L78>
-<L77>:
-               	movq	%r14, %rcx
-               	shrq	$0x1d, %rcx
-               	xorq	%rcx, %r14
+               	je	 <L90>
+               	movq	$0x0, %rdx
+               	jmp	 <L91>
+<L90>:
+               	movq	%rdi, %rbx
+               	shlq	$0x11, %rbx
+               	movq	%rdi, %rsi
+               	shrq	$0x2f, %rsi
+               	orq	%rsi, %rbx
+               	addq	$0x3039, %rbx           # imm = 0x3039
+               	movq	%rbx, %rdx
+<L91>:
+               	jmp	 <L93>
+<L92>:
+               	movq	%rdi, %rbx
+               	shrq	$0x1d, %rbx
+               	xorq	%rbx, %rdi
                	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %r14
-               	movq	%r14, %rdx
-<L78>:
+               	imulq	%r11, %rdi
+               	movq	%rdi, %rdx
+<L93>:
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	movaps	-0x90(%rbp), %xmm6
-               	movaps	-0xa0(%rbp), %xmm7
-               	movaps	-0xb0(%rbp), %xmm8
-               	movaps	-0xc0(%rbp), %xmm9
-               	movaps	-0xd0(%rbp), %xmm14
-               	movaps	-0xe0(%rbp), %xmm15
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %rdi
-               	movq	-0x58(%rbp), %rsi
-               	movq	-0x60(%rbp), %r12
-               	movq	-0x68(%rbp), %r13
-               	movq	-0x70(%rbp), %r14
-               	movq	-0x78(%rbp), %r15
+               	callq	 <L94>
+<L94>:
+               	movaps	-0xf0(%rbp), %xmm6
+               	movaps	-0x100(%rbp), %xmm7
+               	movaps	-0x110(%rbp), %xmm8
+               	movaps	-0x120(%rbp), %xmm9
+               	movaps	-0x130(%rbp), %xmm14
+               	movaps	-0x140(%rbp), %xmm15
+               	movq	-0xa8(%rbp), %rbx
+               	movq	-0xb0(%rbp), %rdi
+               	movq	-0xb8(%rbp), %rsi
+               	movq	-0xc0(%rbp), %r12
+               	movq	-0xc8(%rbp), %r13
+               	movq	-0xd0(%rbp), %r14
+               	movq	-0xd8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/bitcast.dis
+++ b/test/golden/x86_64-windows/convert/bitcast.dis
@@ -5,65 +5,241 @@ Disassembly of section .text:
 <corpus.cases.convert.bitcast.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rsi, -0x10(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %edx
                	xorl	$0xc0490fdb, %edx       # imm = 0xC0490FDB
-               	movd	%edx, %xmm6
-               	movd	%xmm6, %esi
-               	callq	 <L1>
+               	movd	%edx, %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%edx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	movd	%xmm0, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movabsq	$0x400921fb54442d18, %r11 # imm = 0x400921FB54442D18
-               	xorq	%r11, %rbx
-               	movq	%rbx, %xmm6
-               	movq	%xmm6, %rsi
-               	movq	%rbx, %rdx
-               	callq	 <L4>
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L5>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	movabsq	$0x400921fb54442d18, %r11 # imm = 0x400921FB54442D18
+               	xorq	%r11, %rax
+               	movq	%rax, %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movl	$0x40490fdb, %edx       # imm = 0x40490FDB
-               	movd	%edx, %xmm6
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L8>
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movabsq	$0x4005bf0a8b145769, %rdx # imm = 0x4005BF0A8B145769
-               	movq	%rdx, %xmm6
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L10>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movaps	-0x20(%rbp), %xmm6
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movl	$0x40490fdb, %eax       # imm = 0x40490FDB
+               	movd	%eax, %xmm0
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movabsq	$0x4005bf0a8b145769, %rax # imm = 0x4005BF0A8B145769
+               	movq	%rax, %xmm0
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rsi
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/ext_sign.dis
+++ b/test/golden/x86_64-windows/convert/ext_sign.dis
@@ -5,105 +5,353 @@ Disassembly of section .text:
 <corpus.cases.convert.ext_sign.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movb	%bl, %dl
-               	movl	%edx, %esi
-               	orl	$0x80, %esi
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movb	%al, %dl
+               	orl	$0x80, %edx
+               	movl	%edx, %ebx
+               	xorl	$-0x1, %ebx
+               	movw	%ax, %si
+               	orl	$0x8000, %esi           # imm = 0x8000
                	movl	%esi, %edi
                	xorl	$-0x1, %edi
-               	movw	%bx, %dx
-               	movl	%edx, %r12d
-               	orl	$0x8000, %r12d          # imm = 0x8000
-               	movl	%r12d, %r13d
-               	xorl	$-0x1, %r13d
-               	movl	%ebx, %edx
-               	movl	%edx, %ebx
-               	orl	$0x80000000, %ebx       # imm = 0x80000000
-               	movl	%ebx, %r14d
-               	xorl	$-0x1, %r14d
-               	movsbl	%sil, %edx
-               	callq	 <L1>
+               	movl	%eax, %r12d
+               	movl	%r12d, %r8d
+               	orl	$0x80000000, %r8d       # imm = 0x80000000
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	xorl	$-0x1, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movsbl	%dl, %r13d
+               	movswq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r13, %r12
+               	xorq	%rax, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movsbl	%dil, %edx
-               	callq	 <L2>
+               	movsbl	%bl, %eax
+               	movswq	%ax, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movsbl	%sil, %edx
-               	callq	 <L3>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movsbl	%dil, %edx
-               	callq	 <L4>
+               	movsbl	%dl, %eax
+               	movslq	%eax, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movsbq	%sil, %r15
-               	movq	%r15, %rdx
-               	callq	 <L5>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movsbq	%dil, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	movsbl	%bl, %eax
+               	movslq	%eax, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movswl	%r12w, %edx
-               	callq	 <L7>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movswl	%r13w, %edx
-               	callq	 <L8>
+               	movsbq	%dl, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movswq	%r12w, %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L9>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movswq	%r13w, %r12
-               	movq	%r12, %rdx
-               	callq	 <L10>
+               	movsbq	%bl, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movslq	%ebx, %r13
-               	movq	%r13, %rdx
-               	callq	 <L11>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movslq	%r14d, %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L12>
+               	movswl	%si, %eax
+               	movslq	%eax, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	addq	%rdi, %r15
-               	addq	%r13, %r15
-               	movq	%r15, %rdx
-               	callq	 <L13>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	addq	%r12, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
+               	movswl	%di, %eax
+               	movslq	%eax, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movswq	%si, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movswq	%di, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movsbq	%dl, %rax
+               	movswq	%si, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movsbq	%bl, %rax
+               	movswq	%di, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/ext_zero.dis
+++ b/test/golden/x86_64-windows/convert/ext_zero.dis
@@ -5,105 +5,351 @@ Disassembly of section .text:
 <corpus.cases.convert.ext_zero.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movb	%al, %dl
+               	orl	$0x80, %edx
+               	movl	$0xff, %ebx
+               	subl	%edx, %ebx
+               	movw	%ax, %si
+               	orl	$0x8000, %esi           # imm = 0x8000
+               	movl	$0xffff, %r8d           # imm = 0xFFFF
+               	subl	%esi, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movl	%eax, %r12d
+               	orl	$0x80000000, %r12d      # imm = 0x80000000
+               	movl	$0xffffffff, %r8d       # imm = 0xFFFFFFFF
+               	subl	%r12d, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movzbl	%dl, %r13d
+               	movzwq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movb	%bl, %dl
-               	movl	%edx, %esi
-               	orl	$0x80, %esi
-               	movl	$0xff, %edi
-               	subl	%esi, %edi
-               	movw	%bx, %dx
-               	movl	%edx, %r12d
-               	orl	$0x8000, %r12d          # imm = 0x8000
-               	movl	$0xffff, %r13d          # imm = 0xFFFF
-               	subl	%r12d, %r13d
-               	movl	%ebx, %edx
-               	movl	%edx, %ebx
-               	orl	$0x80000000, %ebx       # imm = 0x80000000
-               	movl	$0xffffffff, %r14d      # imm = 0xFFFFFFFF
-               	subl	%ebx, %r14d
-               	movzbl	%sil, %edx
-               	callq	 <L1>
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r13, %rdi
+               	xorq	%rax, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movzbl	%dil, %edx
-               	callq	 <L2>
+               	movzbl	%bl, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movzbl	%sil, %edx
-               	callq	 <L3>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movzbl	%dil, %edx
-               	callq	 <L4>
+               	movzbl	%dl, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movzbq	%sil, %r15
-               	movq	%r15, %rdx
-               	callq	 <L5>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movzbq	%dil, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	movzbl	%bl, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movzwl	%r12w, %edx
-               	callq	 <L7>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movzwl	%r13w, %edx
-               	callq	 <L8>
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movzwq	%r12w, %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L9>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movzwq	%r13w, %r12
-               	movq	%r12, %rdx
-               	callq	 <L10>
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %r13d
-               	movq	%r13, %rdx
-               	callq	 <L11>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movl	%r14d, %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L12>
+               	movzwl	%si, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	addq	%rdi, %r15
-               	addq	%r13, %r15
-               	movq	%r15, %rdx
-               	callq	 <L13>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	addq	%r12, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
+               	movq	-0x10(%rbp), %r8
+               	movzwl	%r8w, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movzwq	%si, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+<L17>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movl	%r12d, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movzbq	%dl, %rax
+               	movzwq	%si, %rdx
+               	addq	%rdx, %rax
+               	movl	%r12d, %edx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movzbq	%bl, %rax
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %edx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/f2f.dis
+++ b/test/golden/x86_64-windows/convert/f2f.dis
@@ -5,101 +5,274 @@ Disassembly of section .text:
 <corpus.cases.convert.f2f.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movaps	%xmm7, -0x30(%rbp)
-               	movaps	%xmm8, -0x40(%rbp)
-               	movaps	%xmm9, -0x50(%rbp)
-               	movaps	%xmm14, -0x60(%rbp)
-               	movaps	%xmm15, -0x70(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rax, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2sd	%r11, %xmm6
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm6
-               	addsd	%xmm6, %xmm6
-<L2>:
-               	movq	%rbx, %r11
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2ss	%r11, %xmm7
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm7
-               	addss	%xmm7, %xmm7
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
+<L3>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x81>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movsd	, %xmm1 <corpus.cases.convert.f2f.checksum+0x96>
-               	addsd	%xmm6, %xmm1
-               	cvtsd2ss	%xmm1, %xmm8
-               	cvtss2sd	%xmm8, %xmm9
-               	callq	 <L5>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L6>
+               	movd	%xmm3, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L7>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.convert.f2f.checksum+0xce>
-               	addsd	%xmm6, %xmm1
-               	cvtsd2ss	%xmm1, %xmm8
-               	cvtss2sd	%xmm8, %xmm9
-               	callq	 <L8>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L9>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L10>
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x1a6>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.convert.f2f.checksum+0x106>
-               	addsd	%xmm6, %xmm1
-               	cvtsd2ss	%xmm1, %xmm6
-               	callq	 <L11>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L12>
+               	movd	%xmm3, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x12a>
-               	addss	%xmm7, %xmm0
-               	cvtss2sd	%xmm0, %xmm6
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L14>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movaps	-0x30(%rbp), %xmm7
-               	movaps	-0x40(%rbp), %xmm8
-               	movaps	-0x50(%rbp), %xmm9
-               	movaps	-0x60(%rbp), %xmm14
-               	movaps	-0x70(%rbp), %xmm15
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x2c1>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm0
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x381>
+               	addss	%xmm1, %xmm0
+               	cvtss2sd	%xmm0, %xmm1
+               	movd	%xmm0, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/f2i.dis
+++ b/test/golden/x86_64-windows/convert/f2i.dis
@@ -5,116 +5,402 @@ Disassembly of section .text:
 <corpus.cases.convert.f2i.fold_pos>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movaps	%xmm6, -0x10(%rbp)
-               	movaps	%xmm7, -0x20(%rbp)
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
                	movaps	%xmm14, -0x30(%rbp)
                	movaps	%xmm15, -0x40(%rbp)
-               	movss	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1,2,3]
-               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
-               	cvttss2si	%xmm6, %r11
+               	movq	%rcx, %rax
+               	cvttss2si	%xmm1, %r11
                	movb	%r11b, %dl
-               	callq	 <L0>
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11
-               	movw	%r11w, %dx
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11
-               	movl	%r11d, %edx
-               	callq	 <L2>
+               	cvttss2si	%xmm1, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	ucomiss	, %xmm6 <corpus.cases.convert.f2i.fold_pos+0x5a>
-               	jb	 <L3>
-               	movaps	%xmm6, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x6d>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	cvttss2si	%xmm1, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	ucomiss	, %xmm1 <corpus.cases.convert.f2i.fold_pos+0x141>
+               	jb	 <L6>
+               	movaps	%xmm1, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x154>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L4>
-<L3>:
-               	cvttss2si	%xmm6, %r11
-<L4>:
-               	movq	%r11, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11d
-               	movb	%r11b, %dl
-               	callq	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11d
-               	movw	%r11w, %dx
-               	callq	 <L7>
+               	cvttss2si	%xmm1, %r11
 <L7>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11d
-               	movl	%r11d, %edx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	cvttss2si	%xmm6, %r11
                	movq	%r11, %rdx
-               	callq	 <L9>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11
+               	cvttss2si	%xmm1, %r11d
                	movb	%r11b, %dl
-               	callq	 <L10>
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11
-               	movw	%r11w, %dx
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11
-               	movl	%r11d, %edx
-               	callq	 <L12>
+               	cvttss2si	%xmm1, %r11d
+               	movw	%r11w, %dx
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	ucomisd	, %xmm7 <corpus.cases.convert.f2i.fold_pos+0x10e>
-               	jb	 <L13>
-               	movaps	%xmm7, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x121>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm1, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	cvttss2si	%xmm1, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	cvttsd2si	%xmm2, %r11
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	cvttsd2si	%xmm2, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	ucomisd	, %xmm2 <corpus.cases.convert.f2i.fold_pos+0x45a>
+               	jb	 <L24>
+               	movaps	%xmm2, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x46d>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L14>
-<L13>:
-               	cvttsd2si	%xmm7, %r11
-<L14>:
+               	jmp	 <L25>
+<L24>:
+               	cvttsd2si	%xmm2, %r11
+<L25>:
                	movq	%r11, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	cvttsd2si	%xmm2, %r11d
                	movb	%r11b, %dl
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11d
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	cvttsd2si	%xmm2, %r11d
                	movw	%r11w, %dx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11d
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm2, %r11d
                	movl	%r11d, %edx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	cvttsd2si	%xmm7, %r11
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm2, %r11
                	movq	%r11, %rdx
-               	callq	 <L19>
-<L19>:
-               	movaps	-0x10(%rbp), %xmm6
-               	movaps	-0x20(%rbp), %xmm7
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+<L35>:
                	movaps	-0x30(%rbp), %xmm14
                	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -130,42 +416,48 @@ Disassembly of section .text:
                	movss	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1,2,3]
                	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
                	cvttss2si	%xmm6, %r11d
-               	movb	%r11b, %dl
+               	movb	%r11b, %al
+               	movsbq	%al, %rdx
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
                	cvttss2si	%xmm6, %r11d
-               	movw	%r11w, %dx
+               	movw	%r11w, %cx
+               	movswq	%cx, %rdx
+               	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
                	cvttss2si	%xmm6, %r11d
-               	movl	%r11d, %edx
+               	movl	%r11d, %ecx
+               	movslq	%ecx, %rdx
+               	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rcx
                	cvttss2si	%xmm6, %r11
                	movq	%r11, %rdx
+               	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
                	cvttsd2si	%xmm7, %r11d
-               	movb	%r11b, %dl
+               	movb	%r11b, %cl
+               	movsbq	%cl, %rdx
+               	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rcx
                	cvttsd2si	%xmm7, %r11d
-               	movw	%r11w, %dx
+               	movw	%r11w, %cx
+               	movswq	%cx, %rdx
+               	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rcx
                	cvttsd2si	%xmm7, %r11d
-               	movl	%r11d, %edx
+               	movl	%r11d, %ecx
+               	movslq	%ecx, %rdx
+               	movq	%rax, %rcx
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rcx
                	cvttsd2si	%xmm7, %r11
                	movq	%r11, %rdx
+               	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
                	movaps	-0x10(%rbp), %xmm6
@@ -179,233 +471,542 @@ Disassembly of section .text:
 <corpus.cases.convert.f2i.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
+               	subq	$0xa0, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movaps	%xmm7, -0x30(%rbp)
-               	movaps	%xmm8, -0x40(%rbp)
-               	movaps	%xmm9, -0x50(%rbp)
-               	movaps	%xmm14, -0x60(%rbp)
-               	movaps	%xmm15, -0x70(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm6, -0x30(%rbp)
+               	movaps	%xmm7, -0x40(%rbp)
+               	movaps	%xmm8, -0x50(%rbp)
+               	movaps	%xmm9, -0x60(%rbp)
+               	movaps	%xmm14, -0x70(%rbp)
+               	movaps	%xmm15, -0x80(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm6
                	addss	%xmm6, %xmm6
-<L2>:
-               	movq	%rbx, %r11
+<L1>:
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm7
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm7
                	addsd	%xmm7, %xmm7
+<L3>:
+               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x96>
+               	addss	%xmm6, %xmm0
+               	movsd	, %xmm1 <corpus.cases.convert.f2i.checksum+0xa2>
+               	addsd	%xmm7, %xmm1
+               	cvttss2si	%xmm0, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movss	, %xmm8 <corpus.cases.convert.f2i.checksum+0x94>
-               	addss	%xmm6, %xmm8
-               	movsd	, %xmm9 <corpus.cases.convert.f2i.checksum+0xa2>
-               	addsd	%xmm7, %xmm9
-               	cvttss2si	%xmm8, %r11
-               	movb	%r11b, %dl
-               	movq	%rax, %rcx
-               	callq	 <L5>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	cvttss2si	%xmm8, %r11
+               	cvttss2si	%xmm0, %r11
                	movw	%r11w, %dx
-               	movq	%rax, %rcx
-               	callq	 <L6>
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	cvttss2si	%xmm8, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	ucomiss	, %xmm8 <corpus.cases.convert.f2i.checksum+0xe0>
+               	cvttss2si	%xmm0, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L8>
-               	movaps	%xmm8, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0xf3>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	ucomiss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x1d0>
+               	jb	 <L10>
+               	movaps	%xmm0, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1e3>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L9>
-<L8>:
-               	cvttss2si	%xmm8, %r11
-<L9>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	cvttss2si	%xmm8, %r11d
-               	movb	%r11b, %dl
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	cvttss2si	%xmm0, %r11
 <L11>:
-               	cvttss2si	%xmm8, %r11d
-               	movw	%r11w, %dx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	cvttss2si	%xmm8, %r11d
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	cvttss2si	%xmm8, %r11
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	cvttsd2si	%xmm9, %r11
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm0, %r11d
                	movb	%r11b, %dl
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	cvttsd2si	%xmm9, %r11
+               	cvttss2si	%xmm0, %r11d
                	movw	%r11w, %dx
-               	movq	%rax, %rcx
-               	callq	 <L16>
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	cvttsd2si	%xmm9, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	ucomisd	, %xmm9 <corpus.cases.convert.f2i.checksum+0x195>
+               	cvttss2si	%xmm0, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm9, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1a8>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm1, %r11
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	cvttsd2si	%xmm1, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	cvttsd2si	%xmm1, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	ucomisd	, %xmm1 <corpus.cases.convert.f2i.checksum+0x4e9>
+               	jb	 <L28>
+               	movaps	%xmm1, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x4fc>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L19>
-<L18>:
-               	cvttsd2si	%xmm9, %r11
-<L19>:
+               	jmp	 <L29>
+<L28>:
+               	cvttsd2si	%xmm1, %r11
+<L29>:
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	cvttsd2si	%xmm9, %r11d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm1, %r11d
                	movb	%r11b, %dl
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	cvttsd2si	%xmm9, %r11d
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm1, %r11d
                	movw	%r11w, %dx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	cvttsd2si	%xmm9, %r11d
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	cvttsd2si	%xmm1, %r11d
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	cvttsd2si	%xmm9, %r11
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x218>
-               	xorps	, %xmm0 <corpus.cases.convert.f2i.checksum+0x21f>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+<L39>:
+               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x6e9>
+               	xorps	, %xmm0 <corpus.cases.convert.f2i.checksum+0x6f0>
                	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
                	subss	%xmm6, %xmm8
-               	movsd	, %xmm9 <corpus.cases.convert.f2i.checksum+0x232>
+               	movsd	, %xmm9 <corpus.cases.convert.f2i.checksum+0x703>
                	subsd	%xmm7, %xmm9
                	cvttss2si	%xmm8, %r11d
                	movb	%r11b, %dl
+               	movsbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
+               	movq	%rbx, %rdx
+               	callq	 <L40>
+<L40>:
                	cvttss2si	%xmm8, %r11d
                	movw	%r11w, %dx
+               	movswq	%dx, %rbx
                	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
+               	movq	%rbx, %rdx
+               	callq	 <L41>
+<L41>:
                	cvttss2si	%xmm8, %r11d
                	movl	%r11d, %edx
+               	movslq	%edx, %rbx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	movq	%rbx, %rdx
+               	callq	 <L42>
+<L42>:
                	cvttss2si	%xmm8, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	callq	 <L43>
+<L43>:
                	cvttsd2si	%xmm9, %r11d
                	movb	%r11b, %dl
+               	movsbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
+               	movq	%rbx, %rdx
+               	callq	 <L44>
+<L44>:
                	cvttsd2si	%xmm9, %r11d
                	movw	%r11w, %dx
+               	movswq	%dx, %rbx
                	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
+               	movq	%rbx, %rdx
+               	callq	 <L45>
+<L45>:
                	cvttsd2si	%xmm9, %r11d
                	movl	%r11d, %edx
+               	movslq	%edx, %rbx
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
+               	movq	%rbx, %rdx
+               	callq	 <L46>
+<L46>:
                	cvttsd2si	%xmm9, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x2c1>
+               	callq	 <L47>
+<L47>:
+               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x7ba>
                	addss	%xmm6, %xmm0
                	cvttss2si	%xmm0, %r11d
                	movb	%r11b, %dl
+               	movsbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x2dd>
+               	movq	%rbx, %rdx
+               	callq	 <L48>
+<L48>:
+               	movss	, %xmm0 <corpus.cases.convert.f2i.checksum+0x7dd>
                	addss	%xmm6, %xmm0
                	cvttss2si	%xmm0, %r11
                	movb	%r11b, %dl
+               	movzbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	movsd	, %xmm6 <corpus.cases.convert.f2i.checksum+0x2f9>
+               	movq	%rbx, %rdx
+               	callq	 <L49>
+<L49>:
+               	movsd	, %xmm6 <corpus.cases.convert.f2i.checksum+0x800>
                	addsd	%xmm7, %xmm6
                	cvttsd2si	%xmm6, %r11
                	movb	%r11b, %dl
+               	movzbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
+               	movq	%rbx, %rdx
+               	callq	 <L50>
+<L50>:
                	cvttsd2si	%xmm6, %r11d
                	movb	%r11b, %dl
+               	movsbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x325>
+               	movq	%rbx, %rdx
+               	callq	 <L51>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x83a>
                	subsd	%xmm7, %xmm0
                	cvttsd2si	%xmm0, %r11d
                	movb	%r11b, %dl
+               	movsbq	%dl, %rbx
                	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movaps	-0x30(%rbp), %xmm7
-               	movaps	-0x40(%rbp), %xmm8
-               	movaps	-0x50(%rbp), %xmm9
-               	movaps	-0x60(%rbp), %xmm14
-               	movaps	-0x70(%rbp), %xmm15
+               	movq	%rbx, %rdx
+               	callq	 <L52>
+<L52>:
+               	movaps	-0x30(%rbp), %xmm6
+               	movaps	-0x40(%rbp), %xmm7
+               	movaps	-0x50(%rbp), %xmm8
+               	movaps	-0x60(%rbp), %xmm9
+               	movaps	-0x70(%rbp), %xmm14
+               	movaps	-0x80(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/f2u_high.dis
+++ b/test/golden/x86_64-windows/convert/f2u_high.dis
@@ -6,14 +6,40 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x40, %rsp
-               	movaps	%xmm14, -0x10(%rbp)
-               	movaps	%xmm15, -0x20(%rbp)
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
                	cvttss2si	%xmm1, %r11
                	movl	%r11d, %edx
-               	callq	 <L0>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x10(%rbp), %xmm14
-               	movaps	-0x20(%rbp), %xmm15
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -22,14 +48,40 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x40, %rsp
-               	movaps	%xmm14, -0x10(%rbp)
-               	movaps	%xmm15, -0x20(%rbp)
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
                	cvttsd2si	%xmm1, %r11
                	movl	%r11d, %edx
-               	callq	 <L0>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x10(%rbp), %xmm14
-               	movaps	-0x20(%rbp), %xmm15
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,12 +90,16 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x40, %rsp
-               	movaps	%xmm14, -0x10(%rbp)
-               	movaps	%xmm15, -0x20(%rbp)
-               	ucomiss	, %xmm1 <corpus.cases.convert.f2u_high.f32_u64+0x19>
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
+               	ucomiss	, %xmm1 <corpus.cases.convert.f2u_high.f32_u64+0x28>
                	jb	 <L0>
                	movaps	%xmm1, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x2c>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x3b>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -52,10 +108,31 @@ Disassembly of section .text:
                	cvttss2si	%xmm1, %r11
 <L1>:
                	movq	%r11, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movaps	-0x10(%rbp), %xmm14
-               	movaps	-0x20(%rbp), %xmm15
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -64,12 +141,16 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x40, %rsp
-               	movaps	%xmm14, -0x10(%rbp)
-               	movaps	%xmm15, -0x20(%rbp)
-               	ucomisd	, %xmm1 <corpus.cases.convert.f2u_high.f64_u64+0x1a>
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
+               	ucomisd	, %xmm1 <corpus.cases.convert.f2u_high.f64_u64+0x29>
                	jb	 <L0>
                	movaps	%xmm1, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x2d>
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x3c>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -78,10 +159,31 @@ Disassembly of section .text:
                	cvttsd2si	%xmm1, %r11
 <L1>:
                	movq	%r11, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movaps	-0x10(%rbp), %xmm14
-               	movaps	-0x20(%rbp), %xmm15
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -89,286 +191,635 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm6, -0x20(%rbp)
-               	movaps	%xmm7, -0x30(%rbp)
-               	movaps	%xmm14, -0x40(%rbp)
-               	movaps	%xmm15, -0x50(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rax
+               	movq	%rax, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm6
-               	addss	%xmm6, %xmm6
-<L2>:
-               	movq	%rbx, %r11
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2sd	%r11, %xmm7
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm7
-               	addsd	%xmm7, %xmm7
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L3>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x81>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x86>
-               	addss	%xmm6, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L5>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0xa2>
-               	addss	%xmm6, %xmm0
-               	cvttss2si	%xmm0, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xf3>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0xbe>
-               	addss	%xmm6, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0xda>
-               	addss	%xmm6, %xmm0
-               	cvttss2si	%xmm0, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x15b>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0xf6>
-               	addss	%xmm6, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x112>
-               	addsd	%xmm7, %xmm0
-               	cvttsd2si	%xmm0, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1c3>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x12e>
-               	addsd	%xmm7, %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x14a>
-               	addsd	%xmm7, %xmm0
-               	cvttsd2si	%xmm0, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x22b>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x166>
-               	addsd	%xmm7, %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x182>
-               	addsd	%xmm7, %xmm0
-               	cvttsd2si	%xmm0, %r11
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x293>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x19e>
-               	addss	%xmm6, %xmm0
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x1a9>
-               	jb	 <L15>
-               	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x1bc>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L16>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	cvttss2si	%xmm0, %r11
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2fb>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L17>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x1eb>
-               	addss	%xmm6, %xmm0
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x1f6>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x363>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x209>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L19>
 <L18>:
-               	cvttss2si	%xmm0, %r11
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x3cb>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x238>
-               	addss	%xmm6, %xmm0
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x243>
-               	jb	 <L21>
-               	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x256>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L22>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	cvttss2si	%xmm0, %r11
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x433>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L23>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x285>
-               	addss	%xmm6, %xmm0
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x290>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x49b>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x4a6>
                	jb	 <L24>
-               	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x2a3>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x4b9>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
                	jmp	 <L25>
 <L24>:
-               	cvttss2si	%xmm0, %r11
+               	cvttss2si	%xmm2, %r11
 <L25>:
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L26>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x2d2>
-               	addss	%xmm6, %xmm0
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x2dd>
-               	jb	 <L27>
-               	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x2f0>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x532>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x53d>
+               	jb	 <L28>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x550>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L28>
-<L27>:
-               	cvttss2si	%xmm0, %r11
+               	jmp	 <L29>
 <L28>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L29>
+               	cvttss2si	%xmm2, %r11
 <L29>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x31f>
-               	addsd	%xmm7, %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x32b>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L30>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x33e>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L31>
 <L30>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
 <L31>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x36d>
-               	addsd	%xmm7, %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x379>
-               	jb	 <L33>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x38c>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5c9>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5d4>
+               	jb	 <L32>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x5e7>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L34>
+               	jmp	 <L33>
+<L32>:
+               	cvttss2si	%xmm2, %r11
 <L33>:
-               	cvttsd2si	%xmm0, %r11
-<L34>:
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L35>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
 <L35>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3bb>
-               	addsd	%xmm7, %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3c7>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x660>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x66b>
                	jb	 <L36>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x3da>
-               	cvttsd2si	%xmm14, %r11
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x67e>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
                	jmp	 <L37>
 <L36>:
-               	cvttsd2si	%xmm0, %r11
+               	cvttss2si	%xmm2, %r11
 <L37>:
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L38>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x409>
-               	addsd	%xmm7, %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x415>
-               	jb	 <L39>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x428>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L40>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
 <L39>:
-               	cvttsd2si	%xmm0, %r11
-<L40>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x457>
-               	addsd	%xmm7, %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x463>
-               	jb	 <L42>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x476>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6f7>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x702>
+               	jb	 <L40>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x715>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
+               	jmp	 <L41>
+<L40>:
+               	cvttss2si	%xmm2, %r11
+<L41>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L42>
                	jmp	 <L43>
 <L42>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L42>
 <L43>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L44>
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x78e>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x79a>
+               	jb	 <L44>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x7ad>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L45>
 <L44>:
-               	movaps	-0x20(%rbp), %xmm6
-               	movaps	-0x30(%rbp), %xmm7
-               	movaps	-0x40(%rbp), %xmm14
-               	movaps	-0x50(%rbp), %xmm15
+               	cvttsd2si	%xmm0, %r11
+<L45>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L46>
+<L47>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x826>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x832>
+               	jb	 <L48>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x845>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L49>
+<L48>:
+               	cvttsd2si	%xmm0, %r11
+<L49>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L50>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8be>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8ca>
+               	jb	 <L52>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x8dd>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L53>
+<L52>:
+               	cvttsd2si	%xmm0, %r11
+<L53>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L54>
+<L55>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x956>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x962>
+               	jb	 <L56>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x975>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L57>
+<L56>:
+               	cvttsd2si	%xmm0, %r11
+<L57>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L58>
+<L59>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9ee>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9fa>
+               	jb	 <L60>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0xa0d>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L61>
+<L60>:
+               	cvttsd2si	%xmm0, %r11
+<L61>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L62>
+<L63>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/i2f.dis
+++ b/test/golden/x86_64-windows/convert/i2f.dis
@@ -5,6 +5,450 @@ Disassembly of section .text:
 <corpus.cases.convert.i2f.fold_from>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movaps	%xmm14, -0x70(%rbp)
+               	movaps	%xmm15, -0x80(%rbp)
+               	movq	%rcx, %rax
+               	movq	%r8, %rbx
+               	movl	%r9d, %esi
+               	movq	0x30(%rbp), %rdi
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movzbq	%dl, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %r15d
+               	movl	%r15d, %r14d
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rax
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+<L1>:
+               	movzbq	%dl, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rax
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+<L3>:
+               	movzwq	%bx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %r12d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rax, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movzwq	%bx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	movl	%esi, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movl	%esi, %r11d
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L12>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L13>
+<L12>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L13>:
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L16>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L17>
+<L16>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L17>:
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+<L35>:
+               	movaps	-0x70(%rbp), %xmm14
+               	movaps	-0x80(%rbp), %xmm15
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.convert.i2f.checksum>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
                	subq	$0x90, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rdi, -0x20(%rbp)
@@ -15,126 +459,473 @@ Disassembly of section .text:
                	movq	%r15, -0x48(%rbp)
                	movaps	%xmm14, -0x60(%rbp)
                	movaps	%xmm15, -0x70(%rbp)
-               	movq	%rdx, %rbx
-               	movq	%r8, %rsi
-               	movl	%r9d, %edi
-               	movq	0x30(%rbp), %r12
-               	movq	0x38(%rbp), %r13
-               	movq	0x40(%rbp), %r14
-               	movq	0x48(%rbp), %r15
-               	movq	0x50(%rbp), %r8
+               	movq	%rcx, %rax
+               	movb	%al, %dl
+               	orl	$0x80, %edx
+               	movw	%ax, %bx
+               	orl	$0x8000, %ebx           # imm = 0x8000
+               	movl	%eax, %esi
+               	orl	$0x80000000, %esi       # imm = 0x80000000
+               	movq	%rax, %r8
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	orq	%r11, %r8
                	movq	%r8, -0x8(%rbp)
-               	movzbq	%bl, %r11
+               	movzbq	%dl, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movd	%xmm0, %r12d
+               	movl	%r12d, %r13d
+               	movabsq	$-0x340d631b7bdddcdb, %r12 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movzbq	%bl, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L1>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movzwq	%si, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	movzbq	%dl, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movzwq	%si, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L3>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movl	%edi, %r11d
+               	movzwq	%bx, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
+               	movd	%xmm0, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movl	%edi, %r11d
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L5>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	%r12, %r11
-               	testq	%r11, %r11
-               	jl	 <L6>
-               	cvtsi2ss	%r11, %xmm0
+               	movzwq	%bx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
                	jmp	 <L7>
 <L6>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+<L7>:
+               	movl	%esi, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+<L9>:
+               	movl	%esi, %r11d
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	testq	%r11, %r11
+               	jl	 <L12>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L7>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	%r12, %r11
+<L13>:
+               	movd	%xmm0, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L10>
-<L9>:
+               	jl	 <L16>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L10>:
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movsbq	%r13b, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movsbq	%r13b, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movswq	%r14w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movswq	%r14w, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movslq	%r15d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movslq	%r15d, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L17>
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L17>:
-               	movq	%rax, %rcx
+               	movq	%xmm0, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+<L19>:
+               	movsbq	%dl, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movsbq	%dl, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movswq	%bx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %edi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movswq	%bx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movslq	%esi, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movslq	%esi, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
                	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
                	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	callq	 <L19>
-<L19>:
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+<L35>:
+               	movq	%rax, %rbx
+               	orq	$0x1, %rbx
+               	movq	$0x0, %rsi
+               	subq	%rbx, %rsi
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L37>
+<L36>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L37>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%r12, %rcx
+               	callq	 <L38>
+<L38>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L39>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L40>
+<L39>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L40>:
+               	movq	%xmm0, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L41>
+<L41>:
+               	movq	%rsi, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L42>
+<L42>:
+               	movq	%rsi, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L43>
+<L43>:
                	movaps	-0x60(%rbp), %xmm14
                	movaps	-0x70(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
@@ -144,200 +935,6 @@ Disassembly of section .text:
                	movq	-0x38(%rbp), %r13
                	movq	-0x40(%rbp), %r14
                	movq	-0x48(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.convert.i2f.checksum>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movaps	%xmm14, -0x40(%rbp)
-               	movaps	%xmm15, -0x50(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movb	%bl, %cl
-               	movl	%ecx, %esi
-               	orl	$0x80, %esi
-               	movw	%bx, %cx
-               	movl	%ecx, %edi
-               	orl	$0x8000, %edi           # imm = 0x8000
-               	movl	%ebx, %ecx
-               	movl	%ecx, %r12d
-               	orl	$0x80000000, %r12d      # imm = 0x80000000
-               	movq	%rbx, %r13
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	orq	%r11, %r13
-               	movzbq	%sil, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
-<L1>:
-               	movzbq	%sil, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L2>
-<L2>:
-               	movzwq	%di, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
-<L3>:
-               	movzwq	%di, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L4>
-<L4>:
-               	movl	%r12d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
-<L5>:
-               	movl	%r12d, %r11d
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	movq	%r13, %r11
-               	testq	%r11, %r11
-               	jl	 <L7>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L8>:
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%r13, %r11
-               	testq	%r11, %r11
-               	jl	 <L10>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L11>
-<L10>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L11>:
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	movsbq	%sil, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movsbq	%sil, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	movswq	%di, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
-<L15>:
-               	movswq	%di, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movslq	%r12d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movslq	%r12d, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	movq	%r13, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%r13, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	orq	$0x1, %rbx
-               	movq	$0x0, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L21>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L22>:
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L24>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L25>
-<L24>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L25>:
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	movq	%rsi, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movq	%rsi, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x40(%rbp), %xmm14
-               	movaps	-0x50(%rbp), %xmm15
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/convert/trunc.dis
+++ b/test/golden/x86_64-windows/convert/trunc.dis
@@ -6,74 +6,219 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
                	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
-               	xorq	%r11, %rbx
-               	orq	$0x1, %rbx
-               	movl	%ebx, %esi
-               	movw	%bx, %di
-               	movb	%bl, %r12b
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	xorq	%r11, %rax
+               	orq	$0x1, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movw	%ax, %bx
+               	movb	%al, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L2>
+               	movzwq	%bx, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	xorl	$0x55555555, %edx       # imm = 0x55555555
-               	movw	%dx, %bx
-               	movb	%dl, %r13b
-               	movq	%rbx, %rdx
-               	callq	 <L4>
+               	movq	-0x8(%rbp), %r8
+               	movzbq	%r8b, %rax
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L5>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	xorl	$0x5555, %edx           # imm = 0x5555
-               	movb	%dl, %r14b
-               	movq	%r14, %rdx
-               	callq	 <L6>
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	$0x55555555, %eax       # imm = 0x55555555
+               	movw	%ax, %r12w
+               	movb	%al, %r13b
+               	movzwq	%r12w, %rax
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	movzwq	%di, %rsi
-               	addq	%rsi, %rdx
-               	movzbq	%r12b, %rsi
-               	addq	%rsi, %rdx
-               	callq	 <L7>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rax, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movzwq	%bx, %rdx
-               	movzbq	%r13b, %rbx
-               	addq	%rbx, %rdx
-               	movzbq	%r14b, %rbx
-               	addq	%rbx, %rdx
-               	callq	 <L8>
+               	movzbq	%r13b, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	movl	%ebx, %eax
+               	xorl	$0x5555, %eax           # imm = 0x5555
+               	movb	%al, %sil
+               	movzbq	%sil, %rax
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rax, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+<L11>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	movzwq	%bx, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movzbq	%r8b, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movzwq	%r12w, %rax
+               	movzbq	%r13b, %rdx
+               	addq	%rdx, %rax
+               	movzbq	%sil, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/arith_f32.dis
+++ b/test/golden/x86_64-windows/float/arith_f32.dis
@@ -10,35 +10,81 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f32.fold32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomiss	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm1, %eax
+               	movl	%eax, %ebx
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$0xffffffff, %rbx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -50,7 +96,6 @@ Disassembly of section .text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
                	movaps	%xmm6, -0x30(%rbp)
                	movaps	%xmm7, -0x40(%rbp)
                	movaps	%xmm8, -0x50(%rbp)
@@ -59,156 +104,88 @@ Disassembly of section .text:
                	movaps	%xmm11, -0x80(%rbp)
                	movaps	%xmm14, -0x90(%rbp)
                	movaps	%xmm15, -0xa0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rsi
-               	movl	%ebx, %edi
+               	movl	%ecx, %ebx
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm6
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x68>
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x59>
                	mulss	%xmm6, %xmm7
-               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x75>
+               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x66>
                	mulss	%xmm6, %xmm8
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%rsi, %rcx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L0>
+<L0>:
+               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	subss	%xmm8, %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
-<L2>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rbx
-<L4>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	subss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rsi
-               	jmp	 <L8>
-<L6>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rsi
-<L8>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	subss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
-<L10>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rbx
-<L12>:
+               	callq	 <L2>
+<L2>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	mulss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rsi
-               	jmp	 <L16>
-<L14>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rsi
-<L16>:
+               	callq	 <L3>
+<L3>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	divss	%xmm8, %xmm0
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
+               	callq	 <L4>
+<L4>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	divss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1c7>
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xfb>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm8, %xmm8
                	subss	%xmm7, %xmm8
                	movq	%rax, %rcx
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	addss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x21a>
+               	callq	 <L9>
+<L9>:
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x14e>
                	mulss	%xmm6, %xmm7
                	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
                	divss	%xmm7, %xmm8
                	movq	%rax, %rcx
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	mulss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
                	subss	%xmm8, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -217,1324 +194,1129 @@ Disassembly of section .text:
                	subss	%xmm8, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27d>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1b1>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x295>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1c9>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x2a9>
+               	callq	 <L14>
+<L14>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1dd>
                	divss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x2c1>
+               	callq	 <L15>
+<L15>:
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x1f5>
                	mulss	%xmm6, %xmm7
                	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
                	addss	%xmm6, %xmm9
                	movq	%rax, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
                	addss	%xmm6, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
                	addss	%xmm6, %xmm0
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	addss	%xmm0, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm6, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
                	subss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulss	%xmm6, %xmm0
-               	movq	%rax, %rbx
+               	movq	%rax, %rsi
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	movl	$0x0, %esi
-               	cmpl	$0x18, %esi
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	movl	$0x0, %edi
+               	cmpl	$0x18, %edi
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
-               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	mulss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x36a>
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
-               	movq	%rbx, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r12
-               	jmp	 <L38>
-<L36>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-<L38>:
-               	addl	$0x1, %esi
-               	movq	%r12, %rbx
-               	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
-               	cmpl	$0x18, %esi
-               	jb	 <L34>
-<L39>:
-               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
-               	addl	%edi, %eax
-               	movd	%eax, %xmm7
-               	ucomiss	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
-               	movq	%rbx, %rcx
+               	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x29c>
+               	movq	%rsi, %rcx
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
+               	callq	 <L22>
+<L22>:
+               	addl	$0x1, %edi
                	movq	%rax, %rsi
-               	jmp	 <L43>
-<L41>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rsi
-<L43>:
+               	cmpl	$0x18, %edi
+               	jb	 <L21>
+<L23>:
+               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
+               	addl	%ebx, %eax
+               	movd	%eax, %xmm7
+               	movq	%rsi, %rcx
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L24>
+<L24>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x412>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
-               	movq	%rsi, %rcx
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x2db>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rbx
-               	jmp	 <L47>
-<L45>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rbx
-<L47>:
+               	callq	 <L25>
+<L25>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rsi
-               	jmp	 <L51>
-<L49>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rsi
-<L51>:
+               	callq	 <L26>
+<L26>:
                	movss	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1,2,3]
-               	mulss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x4a2>
-               	movq	%rsi, %rcx
+               	mulss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x309>
+               	movq	%rax, %rcx
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm8, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	mulss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movl	$0x800000, %ecx         # imm = 0x800000
-               	addl	%edi, %ecx
+               	addl	%ebx, %ecx
                	movd	%ecx, %xmm7
                	movl	$0x1, %ecx
-               	addl	%edi, %ecx
+               	addl	%ebx, %ecx
                	movd	%ecx, %xmm8
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x50f>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x376>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x527>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x38e>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm8, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	mulss	%xmm6, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57f>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3e6>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x598>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3ff>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5b1>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x418>
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	divss	%xmm7, %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x5dd>
+               	callq	 <L39>
+<L39>:
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x441>
                	mulss	%xmm6, %xmm7
-               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x5ea>
+               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x44e>
                	mulss	%xmm6, %xmm8
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x619>
-               	ucomiss	%xmm0, %xmm7
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x47d>
+               	ucomiss	%xmm0, %xmm7
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm7
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm7, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subss	%xmm7, %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm7, %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm1, %xmm1
                	subss	%xmm8, %xmm1
-<L72>:
+<L47>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x6b9>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x51d>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L73>:
+<L48>:
                	ucomiss	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L74>:
+<L49>:
                	ucomiss	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movss	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
-<L79>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x73b>
+<L54>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x59f>
                	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
-               	jmp	 <L74>
-<L80>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x74d>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x5b1>
+               	jmp	 <L48>
+<L56>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	divss	%xmm8, %xmm0
                	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
                	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
                	subss	%xmm1, %xmm9
-<L82>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rcx
+<L57>:
+               	movq	%rax, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rsi
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rsi
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm7, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x7ee>
-               	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x620>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm2, %xmm2
                	subss	%xmm8, %xmm2
-<L94>:
+<L66>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x88e>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x6c0>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L95>:
+<L67>:
                	ucomiss	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomiss	%xmm2, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomiss	%xmm9, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x914>
+<L73>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x746>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
-               	jmp	 <L96>
-<L102>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x926>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x758>
+               	jmp	 <L67>
+<L75>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm8, %xmm2
                	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm2, %xmm10
-<L104>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%rsi, %rcx
+<L76>:
+               	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm8, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x9c8>
-               	ucomiss	%xmm1, %xmm7
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x7c8>
+               	ucomiss	%xmm1, %xmm7
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm7
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm7, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm7, %xmm1
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm7, %xmm1
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm2, %xmm2
                	subss	%xmm0, %xmm2
-<L116>:
+<L85>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xa66>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x866>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L117>:
+<L86>:
                	ucomiss	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomiss	%xmm2, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomiss	%xmm9, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xaec>
+<L92>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x8ec>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
-               	jmp	 <L118>
-<L124>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xafe>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8fe>
+               	jmp	 <L86>
+<L94>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm0, %xmm1
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm0, %xmm2
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm2, %xmm10
-<L126>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rcx
+<L95>:
+               	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rsi
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rsi
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm7, %xmm0
                	xorps	%xmm1, %xmm1
                	subss	%xmm8, %xmm1
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm1
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xba5>
-               	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x973>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
-               	testb	%cl, %cl
-               	jne	 <L147>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm2, %xmm2
-               	subss	%xmm0, %xmm2
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm1, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L137>
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm1, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	jmp	 <L138>
-<L137>:
+               	jmp	 <L104>
+<L103>:
                	xorps	%xmm3, %xmm3
                	subss	%xmm1, %xmm3
-<L138>:
+<L104>:
                	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xc43>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa11>
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L139>:
+<L105>:
                	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L146>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
                	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
-<L140>:
+<L106>:
                	ucomiss	%xmm3, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
                	testb	%cl, %cl
-               	jne	 <L143>
-               	testb	%al, %al
-               	jne	 <L141>
+               	jne	 <L107>
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L142>
-<L141>:
+               	jmp	 <L108>
+<L107>:
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L142>
-<L142>:
-               	jmp	 <L148>
-<L143>:
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
                	ucomiss	%xmm9, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L144>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
                	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
-               	jmp	 <L145>
-<L144>:
+               	jmp	 <L111>
+<L110>:
                	movss	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xcc9>
+<L111>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xa97>
                	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
-               	jmp	 <L140>
-<L146>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xcdb>
-               	jmp	 <L139>
-<L147>:
+               	jmp	 <L106>
+<L112>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xaa9>
+               	jmp	 <L105>
+<L113>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
                	cvttss2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
                	mulss	%xmm1, %xmm3
                	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm3, %xmm10
-<L148>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%rsi, %rcx
+<L114>:
+               	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd51>
+               	callq	 <L115>
+<L115>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xaed>
                	mulss	%xmm6, %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xd5e>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xafa>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xd88>
-               	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
+               	jne	 <L118>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xb24>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L154>:
-               	jmp	 <L156>
-<L155>:
-               	movq	%rax, %rcx
-<L156>:
-               	testb	%cl, %cl
-               	jne	 <L169>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L117>:
+               	jmp	 <L119>
+<L118>:
+               	movq	%rcx, %rdx
+<L119>:
+               	testb	%dl, %dl
+               	jne	 <L132>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L158>
-<L157>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-<L158>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xdff>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L159>
-               	movss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe16>
-               	jmp	 <L160>
-<L159>:
+               	jne	 <L120>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L121>
+<L120>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L121>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xb9b>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L122>
+               	movss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xbb2>
+               	jmp	 <L123>
+<L122>:
                	xorps	%xmm2, %xmm2
-               	subss	, %xmm2 <L160>
-<L160>:
+               	subss	, %xmm2 <L123>
+<L123>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xe32>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xbce>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L161>:
+<L124>:
                	ucomiss	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L168>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-<L162>:
+<L125>:
                	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L128>
                	testb	%cl, %cl
-               	jne	 <L165>
-               	testb	%al, %al
-               	jne	 <L163>
+               	jne	 <L126>
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
-               	jmp	 <L164>
-<L163>:
+               	jmp	 <L127>
+<L126>:
                	movss	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L164>
-<L164>:
-               	jmp	 <L170>
-<L165>:
+               	xorps	, %xmm9 <L127>
+<L127>:
+               	jmp	 <L133>
+<L128>:
                	ucomiss	%xmm7, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L166>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L129>
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	jmp	 <L167>
-<L166>:
+               	jmp	 <L130>
+<L129>:
                	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
                	subss	%xmm7, %xmm10
-<L167>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xeb4>
+<L130>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xc50>
                	movsd	%xmm10, %xmm5           # xmm5 = xmm10[0],xmm5[1]
-               	jmp	 <L162>
-<L168>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xec6>
-               	jmp	 <L161>
-<L169>:
+               	jmp	 <L125>
+<L131>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xc62>
+               	jmp	 <L124>
+<L132>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xed7>
+               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xc73>
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xef3>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xc8f>
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm2, %xmm9
-<L170>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rcx
+<L133>:
+               	movq	%rax, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L171>
-<L171>:
-               	movq	%rax, %rsi
-               	jmp	 <L174>
-<L172>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L173>
-<L173>:
-               	movq	%rax, %rsi
-<L174>:
+               	callq	 <L134>
+<L134>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm8
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L177>
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf66>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xcd0>
                	ucomiss	%xmm0, %xmm6
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L135>
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm6
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L136>:
+               	jmp	 <L138>
+<L137>:
+               	movq	%rcx, %rdx
+<L138>:
+               	testb	%dl, %dl
+               	jne	 <L151>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm6, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L139>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	jmp	 <L140>
+<L139>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm6, %xmm0
+<L140>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L141>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+<L142>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xd70>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L143>:
+               	ucomiss	%xmm3, %xmm2
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L144>:
+               	ucomiss	%xmm1, %xmm5
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	testb	%cl, %cl
+               	jne	 <L145>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L146>
+<L145>:
+               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
+               	xorps	, %xmm7 <L146>
+<L146>:
+               	jmp	 <L152>
+<L147>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L148>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L149>
+<L148>:
+               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
+               	subss	%xmm5, %xmm9
+<L149>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xdef>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L144>
+<L150>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xe01>
+               	jmp	 <L143>
+<L151>:
+               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
+               	divss	%xmm8, %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	%xmm8, %xmm1
+               	movss	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1,2,3]
+               	subss	%xmm1, %xmm7
+<L152>:
+               	movq	%rax, %rcx
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L153>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L156>
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe67>
+               	ucomiss	%xmm0, %xmm8
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L154>
+               	jmp	 <L155>
+<L154>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L155>:
+               	jmp	 <L157>
+<L156>:
+               	movq	%rcx, %rdx
+<L157>:
+               	testb	%dl, %dl
+               	jne	 <L170>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L158>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	jmp	 <L159>
+<L158>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm8, %xmm0
+<L159>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L160>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L161>
+<L160>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+<L161>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xf0a>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L162>:
+               	ucomiss	%xmm3, %xmm2
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L163>:
+               	ucomiss	%xmm1, %xmm5
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L165>
+<L164>:
+               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
+               	xorps	, %xmm7 <L165>
+<L165>:
+               	jmp	 <L171>
+<L166>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L167>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L168>
+<L167>:
+               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
+               	subss	%xmm5, %xmm9
+<L168>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf89>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L163>
+<L169>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xf9b>
+               	jmp	 <L162>
+<L170>:
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	divss	%xmm8, %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	%xmm8, %xmm1
+               	movss	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1,2,3]
+               	subss	%xmm1, %xmm7
+<L171>:
+               	movq	%rax, %rcx
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L172>
+<L172>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xfe0>
+               	mulss	%xmm6, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L175>
-               	jmp	 <L176>
-<L175>:
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm6
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L176>:
-               	jmp	 <L178>
-<L177>:
-               	movq	%rax, %rcx
-<L178>:
-               	testb	%cl, %cl
-               	jne	 <L191>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm6, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	jmp	 <L180>
-<L179>:
-               	xorps	%xmm0, %xmm0
-               	subss	%xmm6, %xmm0
-<L180>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L181>
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L182>
-<L181>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm8, %xmm1
-<L182>:
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x1006>
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L183>:
-               	ucomiss	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L190>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L184>:
-               	ucomiss	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	testb	%al, %al
-               	jne	 <L185>
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	jmp	 <L186>
-<L185>:
-               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
-               	xorps	, %xmm7 <L186>
-<L186>:
-               	jmp	 <L192>
-<L187>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L188>
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L189>
-<L188>:
-               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
-               	subss	%xmm5, %xmm9
-<L189>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1085>
-               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
-               	jmp	 <L184>
-<L190>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1097>
-               	jmp	 <L183>
-<L191>:
-               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	%xmm8, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	%xmm8, %xmm1
-               	movss	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1,2,3]
-               	subss	%xmm1, %xmm7
-<L192>:
-               	ucomiss	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L194>
-               	movq	%rsi, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L193>
-<L193>:
-               	movq	%rax, %rbx
-               	jmp	 <L196>
-<L194>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L195>
-<L195>:
-               	movq	%rax, %rbx
-<L196>:
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L199>
-               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x112e>
-               	ucomiss	%xmm0, %xmm8
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L197>
-               	jmp	 <L198>
-<L197>:
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm8
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L198>:
-               	jmp	 <L200>
-<L199>:
-               	movq	%rax, %rcx
-<L200>:
-               	testb	%cl, %cl
-               	jne	 <L213>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L201>
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	jmp	 <L202>
-<L201>:
-               	xorps	%xmm0, %xmm0
-               	subss	%xmm8, %xmm0
-<L202>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L203>
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L204>
-<L203>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm8, %xmm1
-<L204>:
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x11d1>
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L205>:
-               	ucomiss	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L212>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L206>:
-               	ucomiss	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	testb	%al, %al
-               	jne	 <L207>
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	jmp	 <L208>
-<L207>:
-               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
-               	xorps	, %xmm7 <L208>
-<L208>:
-               	jmp	 <L214>
-<L209>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L210>
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L211>
-<L210>:
-               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
-               	subss	%xmm5, %xmm9
-<L211>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1250>
-               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
-               	jmp	 <L206>
-<L212>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1262>
-               	jmp	 <L205>
-<L213>:
-               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	divss	%xmm8, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	%xmm8, %xmm1
-               	movss	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1,2,3]
-               	subss	%xmm1, %xmm7
-<L214>:
-               	ucomiss	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L216>
-               	movq	%rbx, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %rsi
-               	jmp	 <L218>
-<L216>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %rsi
-<L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x12d8>
-               	mulss	%xmm6, %xmm0
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L221>
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1306>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x100e>
                	ucomiss	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L219>
-               	jmp	 <L220>
-<L219>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L173>
+               	jmp	 <L174>
+<L173>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L220>:
-               	jmp	 <L222>
-<L221>:
-               	movq	%rax, %rcx
-<L222>:
-               	testb	%cl, %cl
-               	jne	 <L235>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L174>:
+               	jmp	 <L176>
+<L175>:
+               	movq	%rcx, %rdx
+<L176>:
+               	testb	%dl, %dl
+               	jne	 <L189>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L223>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L224>
-<L223>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-<L224>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L225>
+               	jne	 <L177>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L178>
+<L177>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L178>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L179>
                	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	xorps	%xmm2, %xmm2
                	subss	%xmm8, %xmm2
-<L226>:
+<L180>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x13a6>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x10ae>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L227>:
+<L181>:
                	ucomiss	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L234>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L188>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-<L228>:
+<L182>:
                	ucomiss	%xmm2, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L185>
                	testb	%cl, %cl
-               	jne	 <L231>
-               	testb	%al, %al
-               	jne	 <L229>
+               	jne	 <L183>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-               	jmp	 <L230>
-<L229>:
+               	jmp	 <L184>
+<L183>:
                	movss	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1,2,3]
-               	xorps	, %xmm7 <L230>
-<L230>:
-               	jmp	 <L236>
-<L231>:
+               	xorps	, %xmm7 <L184>
+<L184>:
+               	jmp	 <L190>
+<L185>:
                	ucomiss	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L232>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L186>
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
-               	jmp	 <L233>
-<L232>:
+               	jmp	 <L187>
+<L186>:
                	movss	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1,2,3]
                	subss	%xmm6, %xmm9
-<L233>:
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x1425>
+<L187>:
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x112d>
                	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
-               	jmp	 <L228>
-<L234>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1437>
-               	jmp	 <L227>
-<L235>:
+               	jmp	 <L182>
+<L188>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x113f>
+               	jmp	 <L181>
+<L189>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm8, %xmm2
                	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
                	subss	%xmm2, %xmm7
-<L236>:
-               	ucomiss	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%rsi, %rcx
+<L190>:
+               	movq	%rax, %rcx
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
-               	movq	%rbx, %rax
+               	callq	 <L191>
+<L191>:
                	movaps	-0x30(%rbp), %xmm6
                	movaps	-0x40(%rbp), %xmm7
                	movaps	-0x50(%rbp), %xmm8
@@ -1546,7 +1328,6 @@ Disassembly of section .text:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/arith_f64.dis
+++ b/test/golden/x86_64-windows/float/arith_f64.dis
@@ -10,35 +10,81 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f64.fold64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm1, %rax
+               	movq	%rdx, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rbx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$-0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -50,7 +96,6 @@ Disassembly of section .text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
                	movaps	%xmm6, -0x30(%rbp)
                	movaps	%xmm7, -0x40(%rbp)
                	movaps	%xmm8, -0x50(%rbp)
@@ -60,144 +105,77 @@ Disassembly of section .text:
                	movaps	%xmm14, -0x90(%rbp)
                	movaps	%xmm15, -0xa0(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rsi
                	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm6
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x6c>
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x60>
                	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x79>
+               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x6d>
                	mulsd	%xmm6, %xmm8
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%rsi, %rcx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	jmp	 <L4>
-<L2>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-<L4>:
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rdi, %rcx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rsi
-               	jmp	 <L8>
-<L6>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rsi
-<L8>:
+               	movq	%rax, %rcx
+               	callq	 <L1>
+<L1>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	subsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%rsi, %rcx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	jmp	 <L12>
-<L10>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-<L12>:
+               	movq	%rax, %rcx
+               	callq	 <L2>
+<L2>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rdi, %rcx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rsi
-               	jmp	 <L16>
-<L14>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rsi
-<L16>:
+               	movq	%rax, %rcx
+               	callq	 <L3>
+<L3>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	movq	%rsi, %rcx
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1bf>
+               	xorps	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xea>
                	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm8, %xmm8
                	subsd	%xmm7, %xmm8
                	movq	%rax, %rcx
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	addsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x206>
+               	callq	 <L9>
+<L9>:
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x131>
                	mulsd	%xmm6, %xmm7
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	divsd	%xmm7, %xmm8
                	movq	%rax, %rcx
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
                	subsd	%xmm8, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
@@ -206,178 +184,113 @@ Disassembly of section .text:
                	subsd	%xmm8, %xmm0
                	movq	%rax, %rcx
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x265>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x190>
                	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x279>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1a4>
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	movsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x289>
+               	callq	 <L14>
+<L14>:
+               	movsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1b4>
                	divsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x29d>
+               	callq	 <L15>
+<L15>:
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x1c8>
                	mulsd	%xmm6, %xmm7
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
                	addsd	%xmm6, %xmm9
                	movq	%rax, %rcx
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	addsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
                	addsd	%xmm6, %xmm0
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm0, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	subsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulsd	%xmm6, %xmm0
                	movq	%rax, %rsi
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	movq	$0x0, %rdi
                	cmpq	$0x18, %rdi
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
                	addsd	%xmm8, %xmm0
-               	movsd	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1]
-               	mulsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x33d>
-               	ucomisd	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x266>
                	movq	%rsi, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r12
-               	jmp	 <L38>
-<L36>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-<L38>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L22>
+<L22>:
                	addq	$0x1, %rdi
-               	movq	%r12, %rsi
-               	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
+               	movq	%rax, %rsi
                	cmpq	$0x18, %rdi
-               	jb	 <L34>
-<L39>:
+               	jb	 <L21>
+<L23>:
                	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, %xmm7
-               	ucomisd	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
                	movq	%rsi, %rcx
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	jmp	 <L43>
-<L41>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-<L43>:
+               	callq	 <L24>
+<L24>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x3f3>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
-               	movq	%rdi, %rcx
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rsi
-               	jmp	 <L47>
-<L45>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rsi
-<L47>:
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x2ad>
+               	movq	%rax, %rcx
+               	callq	 <L25>
+<L25>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%rsi, %rcx
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	jmp	 <L51>
-<L49>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-<L51>:
+               	movq	%rax, %rcx
+               	callq	 <L26>
+<L26>:
                	movsd	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1]
-               	mulsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x481>
-               	movq	%rdi, %rcx
+               	mulsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x2d3>
+               	movq	%rax, %rcx
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm1, %xmm1
                	subsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movabsq	$0x10000000000000, %rcx # imm = 0x10000000000000
                	addq	%rbx, %rcx
                	movq	%rcx, %xmm7
@@ -385,1100 +298,970 @@ Disassembly of section .text:
                	addq	%rbx, %rcx
                	movq	%rcx, %xmm8
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x4eb>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x33d>
                	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x4ff>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x351>
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	mulsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	addsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x547>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x399>
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x55c>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x3ae>
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x571>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x3c3>
                	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x595>
+               	callq	 <L39>
+<L39>:
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x3e4>
                	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x5a2>
+               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x3f1>
                	mulsd	%xmm6, %xmm8
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5d2>
-               	ucomisd	%xmm0, %xmm7
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x421>
+               	ucomisd	%xmm0, %xmm7
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm7
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm7, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subsd	%xmm7, %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm7, %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm1, %xmm1
                	subsd	%xmm8, %xmm1
-<L72>:
+<L47>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x676>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x4c5>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L73>:
+<L48>:
                	ucomisd	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L74>:
+<L49>:
                	ucomisd	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
                	subsd	%xmm5, %xmm10
-<L79>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x6fb>
+<L54>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x54a>
                	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
-               	jmp	 <L74>
-<L80>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x70d>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x55c>
+               	jmp	 <L48>
+<L56>:
                	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
                	divsd	%xmm8, %xmm0
                	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
                	subsd	%xmm1, %xmm9
-<L82>:
-               	ucomisd	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rcx
+<L57>:
+               	movq	%rax, %rcx
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rsi
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rsi
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm7, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x7b2>
-               	ucomisd	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x5cc>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm2, %xmm2
                	subsd	%xmm8, %xmm2
-<L94>:
+<L66>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x856>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x670>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L95>:
+<L67>:
                	ucomisd	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomisd	%xmm2, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomisd	%xmm9, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x8df>
+<L73>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x6f9>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
-               	jmp	 <L96>
-<L102>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8f1>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x70b>
+               	jmp	 <L67>
+<L75>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm8, %xmm2
                	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
                	subsd	%xmm2, %xmm10
-<L104>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%rsi, %rcx
+<L76>:
+               	movq	%rax, %rcx
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm8, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x997>
-               	ucomisd	%xmm1, %xmm7
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x77c>
+               	ucomisd	%xmm1, %xmm7
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm7
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm7, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm7, %xmm1
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm7, %xmm1
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm2, %xmm2
                	subsd	%xmm0, %xmm2
-<L116>:
+<L85>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xa39>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x81e>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L117>:
+<L86>:
                	ucomisd	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomisd	%xmm2, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomisd	%xmm9, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xac2>
+<L92>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x8a7>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
-               	jmp	 <L118>
-<L124>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xad4>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8b9>
+               	jmp	 <L86>
+<L94>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm0, %xmm1
                	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm0, %xmm2
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
                	subsd	%xmm2, %xmm10
-<L126>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rcx
+<L95>:
+               	movq	%rax, %rcx
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rsi
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rsi
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm7, %xmm0
                	xorps	%xmm1, %xmm1
                	subsd	%xmm8, %xmm1
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm1
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xb7f>
-               	ucomisd	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x92f>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm0, %xmm2
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm1, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	jmp	 <L104>
+<L103>:
+               	xorps	%xmm3, %xmm3
+               	subsd	%xmm1, %xmm3
+<L104>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x9d1>
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L105>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
+               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+<L106>:
+               	ucomisd	%xmm3, %xmm9
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
+               	testb	%cl, %cl
+               	jne	 <L107>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L108>
+<L107>:
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
+               	ucomisd	%xmm9, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
+               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	jmp	 <L111>
+<L110>:
+               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L111>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa5a>
+               	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
+               	jmp	 <L106>
+<L112>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xa6c>
+               	jmp	 <L105>
+<L113>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
+               	mulsd	%xmm1, %xmm3
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm3, %xmm10
+<L114>:
+               	movq	%rax, %rcx
+               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	callq	 <L115>
+<L115>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xab0>
+               	mulsd	%xmm6, %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xac0>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
                	setne	%cl
                	setp	%r11b
                	orb	%r11b, %cl
                	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
+<L117>:
                	testb	%cl, %cl
-               	jne	 <L147>
+               	jne	 <L128>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm2, %xmm2
-               	subsd	%xmm0, %xmm2
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm1, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
+               	jne	 <L118>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L119>
+<L118>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L119>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xb32>
+               	movsd	, %xmm3 <L120>
+<L120>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L127>
+               	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L121>:
+               	ucomisd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xb5d>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L124>
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L123>
+<L122>:
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L123>
+<L123>:
+               	jmp	 <L129>
+<L124>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L125>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L126>
+<L125>:
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	subsd	%xmm5, %xmm9
+<L126>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xbbc>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L121>
+<L127>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xbce>
+               	jmp	 <L120>
+<L128>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xbdf>
+               	cvttsd2si	%xmm1, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xbfb>
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	subsd	%xmm2, %xmm7
+<L129>:
+               	movq	%rax, %rcx
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L130>
+<L130>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L133>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xc3a>
+               	ucomisd	%xmm0, %xmm6
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm6
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rcx, %rdx
+<L134>:
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm6, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L135>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm6, %xmm0
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
                	jne	 <L137>
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	jmp	 <L138>
 <L137>:
-               	xorps	%xmm3, %xmm3
-               	subsd	%xmm1, %xmm3
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm8, %xmm1
 <L138>:
-               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc21>
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xcde>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
 <L139>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomisd	%xmm3, %xmm2
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
                	jne	 <L146>
-               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
-               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
 <L140>:
-               	ucomisd	%xmm3, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomisd	%xmm1, %xmm5
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
                	jne	 <L143>
-               	testb	%al, %al
+               	testb	%cl, %cl
                	jne	 <L141>
-               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L142>
 <L141>:
-               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	xorps	, %xmm10 <L142>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
-               	ucomisd	%xmm9, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
                	jne	 <L144>
-               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	jmp	 <L145>
 <L144>:
-               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
-               	subsd	%xmm9, %xmm11
-<L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xcaa>
-               	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
-               	jmp	 <L140>
-<L146>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xcbc>
-               	jmp	 <L139>
-<L147>:
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	%xmm1, %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	mulsd	%xmm1, %xmm3
-               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
-               	subsd	%xmm3, %xmm10
-<L148>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%rsi, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xd35>
-               	mulsd	%xmm6, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xd45>
-               	ucomisd	%xmm1, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-<L154>:
-               	testb	%al, %al
-               	jne	 <L165>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L156>
-<L155>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-<L156>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xdb7>
-               	movsd	, %xmm3 <L157>
-<L157>:
-               	ucomisd	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L164>
-               	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L158>:
-               	ucomisd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xde2>
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L161>
-               	testb	%al, %al
-               	jne	 <L159>
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	jmp	 <L160>
-<L159>:
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	xorps	, %xmm7 <L160>
-<L160>:
-               	jmp	 <L166>
-<L161>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L162>
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L163>
-<L162>:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	subsd	%xmm5, %xmm9
-<L163>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xe41>
+<L145>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xd60>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
-               	jmp	 <L158>
-<L164>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xe53>
-               	jmp	 <L157>
-<L165>:
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xd72>
+               	jmp	 <L139>
+<L147>:
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	divsd	%xmm8, %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xe64>
-               	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe80>
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	subsd	%xmm2, %xmm7
-<L166>:
-               	ucomisd	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L168>
-               	movq	%rbx, %rcx
+               	mulsd	%xmm8, %xmm1
+               	movsd	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1]
+               	subsd	%xmm1, %xmm7
+<L148>:
+               	movq	%rax, %rcx
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L167>
-<L167>:
-               	movq	%rax, %rsi
-               	jmp	 <L170>
-<L168>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L169>
-<L169>:
-               	movq	%rax, %rsi
-<L170>:
+               	callq	 <L149>
+<L149>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm8
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L173>
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xef3>
-               	ucomisd	%xmm0, %xmm6
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L152>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xdd9>
+               	ucomisd	%xmm0, %xmm8
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	jmp	 <L151>
+<L150>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L151>:
+               	jmp	 <L153>
+<L152>:
+               	movq	%rcx, %rdx
+<L153>:
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L154>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	jmp	 <L155>
+<L154>:
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm8, %xmm0
+<L155>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L156>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L157>
+<L156>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm8, %xmm1
+<L157>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe80>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L158>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L165>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L159>:
+               	ucomisd	%xmm1, %xmm5
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L162>
+               	testb	%cl, %cl
+               	jne	 <L160>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L161>
+<L160>:
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L161>
+<L161>:
+               	jmp	 <L167>
+<L162>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L163>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	subsd	%xmm5, %xmm9
+<L164>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xf02>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L159>
+<L165>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xf14>
+               	jmp	 <L158>
+<L166>:
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	divsd	%xmm8, %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	%xmm8, %xmm1
+               	movsd	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1]
+               	subsd	%xmm1, %xmm7
+<L167>:
+               	movq	%rax, %rcx
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L168>
+<L168>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xf59>
+               	mulsd	%xmm6, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L171>
-               	jmp	 <L172>
-<L171>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm6
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L172>:
-               	jmp	 <L174>
-<L173>:
-               	movq	%rax, %rcx
-<L174>:
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm6, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	jmp	 <L176>
-<L175>:
-               	xorps	%xmm0, %xmm0
-               	subsd	%xmm6, %xmm0
-<L176>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L177>
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L178>
-<L177>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm8, %xmm1
-<L178>:
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xf97>
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L179>:
-               	ucomisd	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L186>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L180>:
-               	ucomisd	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L183>
-               	testb	%al, %al
-               	jne	 <L181>
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	jmp	 <L182>
-<L181>:
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	xorps	, %xmm7 <L182>
-<L182>:
-               	jmp	 <L188>
-<L183>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L184>
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L185>
-<L184>:
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	subsd	%xmm5, %xmm9
-<L185>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x1019>
-               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
-               	jmp	 <L180>
-<L186>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x102b>
-               	jmp	 <L179>
-<L187>:
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	divsd	%xmm8, %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	%xmm8, %xmm1
-               	movsd	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1]
-               	subsd	%xmm1, %xmm7
-<L188>:
-               	ucomisd	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L190>
-               	movq	%rsi, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L189>
-<L189>:
-               	movq	%rax, %rbx
-               	jmp	 <L192>
-<L190>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L191>
-<L191>:
-               	movq	%rax, %rbx
-<L192>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L195>
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x10c6>
-               	ucomisd	%xmm0, %xmm8
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L193>
-               	jmp	 <L194>
-<L193>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm8
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L194>:
-               	jmp	 <L196>
-<L195>:
-               	movq	%rax, %rcx
-<L196>:
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L197>
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	jmp	 <L198>
-<L197>:
-               	xorps	%xmm0, %xmm0
-               	subsd	%xmm8, %xmm0
-<L198>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L199>
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	jmp	 <L200>
-<L199>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm8, %xmm1
-<L200>:
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x116d>
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-<L201>:
-               	ucomisd	%xmm3, %xmm2
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L208>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-<L202>:
-               	ucomisd	%xmm1, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L205>
-               	testb	%al, %al
-               	jne	 <L203>
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	jmp	 <L204>
-<L203>:
-               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
-               	xorps	, %xmm7 <L204>
-<L204>:
-               	jmp	 <L210>
-<L205>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L206>
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	jmp	 <L207>
-<L206>:
-               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
-               	subsd	%xmm5, %xmm9
-<L207>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11ef>
-               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
-               	jmp	 <L202>
-<L208>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1201>
-               	jmp	 <L201>
-<L209>:
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	divsd	%xmm8, %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	%xmm8, %xmm1
-               	movsd	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1]
-               	subsd	%xmm1, %xmm7
-<L210>:
-               	ucomisd	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L212>
-               	movq	%rbx, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %rsi
-               	jmp	 <L214>
-<L212>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %rsi
-<L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x127a>
-               	mulsd	%xmm6, %xmm0
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm8
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L217>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x12a9>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xf88>
                	ucomisd	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L215>
-               	jmp	 <L216>
-<L215>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	jmp	 <L170>
+<L169>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L216>:
-               	jmp	 <L218>
-<L217>:
-               	movq	%rax, %rcx
-<L218>:
-               	testb	%cl, %cl
-               	jne	 <L231>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L170>:
+               	jmp	 <L172>
+<L171>:
+               	movq	%rcx, %rdx
+<L172>:
+               	testb	%dl, %dl
+               	jne	 <L185>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L219>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L220>
-<L219>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-<L220>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm8, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L221>
+               	jne	 <L173>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L174>
+<L173>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L174>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L175>
                	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
-               	jmp	 <L222>
-<L221>:
+               	jmp	 <L176>
+<L175>:
                	xorps	%xmm2, %xmm2
                	subsd	%xmm8, %xmm2
-<L222>:
+<L176>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x134d>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x102c>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-<L223>:
+<L177>:
                	ucomisd	%xmm4, %xmm3
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L230>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L184>
                	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-<L224>:
+<L178>:
                	ucomisd	%xmm2, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L181>
                	testb	%cl, %cl
-               	jne	 <L227>
-               	testb	%al, %al
-               	jne	 <L225>
+               	jne	 <L179>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-               	xorps	, %xmm7 <L226>
-<L226>:
-               	jmp	 <L232>
-<L227>:
+               	xorps	, %xmm7 <L180>
+<L180>:
+               	jmp	 <L186>
+<L181>:
                	ucomisd	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L228>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L182>
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
-               	jmp	 <L229>
-<L228>:
+               	jmp	 <L183>
+<L182>:
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
                	subsd	%xmm6, %xmm9
-<L229>:
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x13cf>
+<L183>:
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x10ae>
                	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
-               	jmp	 <L224>
-<L230>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x13e1>
-               	jmp	 <L223>
-<L231>:
+               	jmp	 <L178>
+<L184>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x10c0>
+               	jmp	 <L177>
+<L185>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm8, %xmm2
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	subsd	%xmm2, %xmm7
-<L232>:
-               	ucomisd	%xmm7, %xmm7
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%rsi, %rcx
+<L186>:
+               	movq	%rax, %rcx
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %rbx
-               	jmp	 <L236>
-<L234>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %rbx
-<L236>:
-               	movq	%rbx, %rax
+               	callq	 <L187>
+<L187>:
                	movaps	-0x30(%rbp), %xmm6
                	movaps	-0x40(%rbp), %xmm7
                	movaps	-0x50(%rbp), %xmm8
@@ -1490,7 +1273,6 @@ Disassembly of section .text:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/cmp_f32.dis
+++ b/test/golden/x86_64-windows/float/cmp_f32.dis
@@ -5,35 +5,81 @@ Disassembly of section .text:
 <corpus.cases.float.cmp_f32.fold32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomiss	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm1, %eax
+               	movl	%eax, %ebx
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$0xffffffff, %rbx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -42,21 +88,18 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0xe0, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%rdi, -0x50(%rbp)
-               	movq	%rsi, -0x58(%rbp)
-               	movq	%r12, -0x60(%rbp)
-               	movq	%r13, -0x68(%rbp)
-               	movq	%r14, -0x70(%rbp)
-               	movq	%r15, -0x78(%rbp)
-               	movaps	%xmm6, -0x90(%rbp)
-               	movaps	%xmm7, -0xa0(%rbp)
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, -0x60(%rbp)
+               	movq	%rsi, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movaps	%xmm6, -0xa0(%rbp)
                	movaps	%xmm14, -0xb0(%rbp)
                	movaps	%xmm15, -0xc0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
+               	movq	%rcx, %rax
+               	movl	%eax, %edx
                	leaq	-0x30(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
@@ -64,442 +107,655 @@ Disassembly of section .text:
                	movq	$0x0, 0x18(%rbx)
                	movq	$0x0, 0x20(%rbx)
                	movq	$0x0, 0x28(%rbx)
-               	movl	$0xff800000, %edx       # imm = 0xFF800000
-               	addl	%ecx, %edx
+               	movl	$0xff800000, %eax       # imm = 0xFF800000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0xbf800000, %eax       # imm = 0xBF800000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x4(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x80800000, %eax       # imm = 0x80800000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x8(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x80000001, %eax       # imm = 0x80000001
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0xc(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x80000000, %eax       # imm = 0x80000000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x10(%rbx), %rax
+               	movss	%xmm0, (%rax)
                	movd	%edx, %xmm0
-               	leaq	(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0xbf800000, %edx       # imm = 0xBF800000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x4(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x80800000, %edx       # imm = 0x80800000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x8(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x80000001, %edx       # imm = 0x80000001
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0xc(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x80000000, %edx       # imm = 0x80000000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x10(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movd	%ecx, %xmm0
-               	leaq	0x14(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x1, %edx
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x18(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x3f800000, %edx       # imm = 0x3F800000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x1c(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x7f7fffff, %edx       # imm = 0x7F7FFFFF
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x20(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x7f800000, %edx       # imm = 0x7F800000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x24(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x7fc00000, %edx       # imm = 0x7FC00000
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x28(%rbx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movl	$0x7f800001, %edx       # imm = 0x7F800001
-               	addl	%ecx, %edx
-               	movd	%edx, %xmm0
-               	leaq	0x2c(%rbx), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	%rax, %rsi
-               	movl	$0x0, %edi
-               	cmpl	$0xc, %edi
+               	leaq	0x14(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x1, %eax
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x18(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x3f800000, %eax       # imm = 0x3F800000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x1c(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x20(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x7f800000, %eax       # imm = 0x7F800000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x24(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x28(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movl	$0x7f800001, %eax       # imm = 0x7F800001
+               	addl	%edx, %eax
+               	movd	%eax, %xmm0
+               	leaq	0x2c(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x40(%rbp)
+               	movl	$0x0, %edx
+               	cmpl	$0xc, %edx
+               	jb	 <L0>
+               	jmp	 <L47>
+<L0>:
+               	movl	%edx, %esi
+               	leaq	(%rbx,%rsi,4), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rsi
+               	movl	$0x0, %r12d
+               	cmpl	$0xc, %r12d
                	jb	 <L1>
-               	jmp	 <L36>
+               	jmp	 <L46>
 <L1>:
-               	movl	%edi, %eax
-               	leaq	(%rbx,%rax,4), %r12
+               	movq	-0x38(%rbp), %r8
+               	movss	(%r8), %xmm0
+               	movl	%r12d, %r13d
+               	leaq	(%rbx,%r13,4), %r14
+               	movss	(%r14), %xmm1
+               	ucomiss	%xmm1, %xmm0
+               	sete	%r13b
+               	setnp	%r11b
+               	andb	%r11b, %r13b
+               	movzbq	%r13b, %r13
+               	movzbq	%r13b, %r14
                	movq	%rsi, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0xc, %r14d
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
                	jb	 <L2>
-               	jmp	 <L35>
+               	jmp	 <L3>
 <L2>:
-               	movss	(%r12), %xmm6
-               	movl	%r14d, %eax
-               	leaq	(%rbx,%rax,4), %rcx
-               	movss	(%rcx), %xmm7
-               	ucomiss	%xmm7, %xmm6
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	movq	%r13, %rcx
-               	callq	 <L3>
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L2>
 <L3>:
-               	ucomiss	%xmm7, %xmm6
-               	setne	%dl
+               	ucomiss	%xmm1, %xmm0
+               	setne	%al
                	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L4>
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	ucomiss	%xmm6, %xmm7
-               	seta	%r15b
-               	movzbq	%r15b, %r15
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L5>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	ucomiss	%xmm6, %xmm7
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
+               	ucomiss	%xmm0, %xmm1
+               	seta	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	ucomiss	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	ucomiss	%xmm0, %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	testb	%r15b, %r15b
-               	jne	 <L9>
-               	movq	$0x0, %rcx
-               	jmp	 <L10>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	$0x1, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	ucomiss	%xmm6, %xmm7
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L11>
-               	movq	%rcx, %rdx
-               	jmp	 <L12>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	addl	$0x2, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	ucomiss	%xmm7, %xmm6
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L13>
-               	movq	%rdx, %rcx
-               	jmp	 <L14>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	addl	$0x4, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm0, %xmm1
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L14>
+               	movq	$0x0, %rax
+               	jmp	 <L15>
 <L14>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L15>
-               	movq	%rcx, %rdx
-               	jmp	 <L16>
+               	movq	$0x1, %rax
 <L15>:
-               	addl	$0x8, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm0, %xmm1
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L16>
+               	movq	%rax, %rdi
+               	jmp	 <L17>
 <L16>:
-               	ucomiss	%xmm7, %xmm6
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L17>
-               	movq	%rdx, %rcx
-               	jmp	 <L18>
+               	addl	$0x2, %eax
+               	movq	%rax, %rdi
 <L17>:
-               	addl	$0x10, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L18>
+               	movq	%rdi, %rax
+               	jmp	 <L19>
 <L18>:
-               	ucomiss	%xmm7, %xmm6
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L19>
-               	movq	%rcx, %rdx
-               	jmp	 <L20>
+               	addl	$0x4, %edi
+               	movq	%rdi, %rax
 <L19>:
-               	addl	$0x20, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L20>
+               	movq	%rax, %rdi
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rcx
-               	callq	 <L21>
+               	addl	$0x8, %eax
+               	movq	%rax, %rdi
 <L21>:
-               	ucomiss	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm1, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
                	jne	 <L22>
-               	movq	%rcx, %rdx
+               	movq	%rdi, %rax
                	jmp	 <L23>
 <L22>:
-               	ucomiss	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
+               	addl	$0x10, %edi
+               	movq	%rdi, %rax
 <L23>:
-               	movq	%rax, %rcx
-               	callq	 <L24>
+               	ucomiss	%xmm1, %xmm0
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L24>
+               	movq	%rax, %rdi
+               	jmp	 <L25>
 <L24>:
-               	ucomiss	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L25>
-               	ucomiss	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	jmp	 <L26>
+               	addl	$0x20, %eax
+               	movq	%rax, %rdi
 <L25>:
-               	movq	%rcx, %rdx
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rax, %rcx
-               	callq	 <L27>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
 <L27>:
-               	ucomiss	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	cmpb	$0x1, %cl
-               	setne	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L28>
+               	ucomiss	%xmm0, %xmm1
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	ucomiss	%xmm6, %xmm6
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L29>
-               	movq	%rcx, %rdx
-               	jmp	 <L30>
+               	ucomiss	%xmm1, %xmm0
+               	seta	%al
+               	movzbq	%al, %rax
 <L29>:
-               	ucomiss	%xmm7, %xmm7
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
 <L30>:
-               	movq	%rax, %rcx
-               	callq	 <L31>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
 <L31>:
-               	ucomiss	%xmm6, %xmm6
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm0, %xmm1
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
                	jne	 <L32>
-               	ucomiss	%xmm7, %xmm7
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%dil
+               	movzbq	%dil, %rdi
                	jmp	 <L33>
 <L32>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rdi
 <L33>:
-               	movq	%rax, %rcx
-               	callq	 <L34>
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %r13
-               	cmpl	$0xc, %r14d
-               	jb	 <L2>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
 <L35>:
-               	addl	$0x1, %edi
-               	movq	%r13, %rsi
-               	cmpl	$0xc, %edi
-               	jb	 <L1>
+               	ucomiss	%xmm0, %xmm1
+               	seta	%al
+               	movzbq	%al, %rax
+               	cmpb	$0x1, %al
+               	setne	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
+               	jmp	 <L37>
 <L36>:
-               	leaq	(%rbx), %rax
-               	movss	(%rax), %xmm0
-               	movss	(%rax), %xmm1
-               	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
-               	movl	$0x1, %eax
-               	cmpl	$0xc, %eax
-               	jb	 <L37>
-               	jmp	 <L42>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
 <L37>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
-               	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm0, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
                	jne	 <L38>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	jmp	 <L39>
 <L38>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
+               	ucomiss	%xmm1, %xmm1
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
 <L39>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm2
-               	ucomiss	%xmm6, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L40>
-               	movsd	%xmm6, %xmm2            # xmm2 = xmm6[0],xmm2[1]
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L40>
                	jmp	 <L41>
 <L40>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm2
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L40>
 <L41>:
-               	addl	$0x1, %eax
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
-               	cmpl	$0xc, %eax
-               	jb	 <L37>
-<L42>:
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L44>
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	jmp	 <L46>
-<L44>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-<L46>:
-               	ucomiss	%xmm6, %xmm6
-               	setne	%al
+               	jne	 <L42>
+               	ucomiss	%xmm1, %xmm1
+               	setne	%dil
                	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L48>
-               	movq	%rdi, %rcx
-               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rsi
-               	jmp	 <L50>
-<L48>:
-               	movq	%rdi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rsi
-<L50>:
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x38(%rbp)
-               	movl	$0x0, %ecx
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-               	jmp	 <L54>
-<L51>:
-               	movl	%ecx, %edx
-               	leaq	(%rbx,%rdx,4), %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
-               	movl	$0x0, %r12d
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L43>
+<L42>:
+               	movq	%rax, %rdi
+<L43>:
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %r12d
+               	movq	%r13, %rsi
                	cmpl	$0xc, %r12d
-               	jb	 <L52>
+               	jb	 <L1>
+<L46>:
+               	addl	$0x1, %edx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x40(%rbp)
+               	cmpl	$0xc, %edx
+               	jb	 <L0>
+<L47>:
+               	leaq	(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	movss	(%rax), %xmm1
+               	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
+               	movl	$0x1, %eax
+               	cmpl	$0xc, %eax
+               	jb	 <L48>
                	jmp	 <L53>
+<L48>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
+               	ucomiss	%xmm1, %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L49>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L50>
+<L49>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
+<L50>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm2
+               	ucomiss	%xmm6, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L51>
+               	movsd	%xmm6, %xmm2            # xmm2 = xmm6[0],xmm2[1]
+               	jmp	 <L52>
+<L51>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm2
 <L52>:
-               	movss	(%rdi), %xmm0
-               	movl	%r12d, %r13d
-               	leaq	(%rbx,%r13,4), %r14
-               	movss	(%r14), %xmm1
+               	addl	$0x1, %eax
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
+               	cmpl	$0xc, %eax
+               	jb	 <L48>
+<L53>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L54>
+<L54>:
+               	movq	%rax, %rcx
+               	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
+               	callq	 <L55>
+<L55>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x48(%rbp), %r8
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x50(%rbp)
+               	movl	$0x0, %esi
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+               	jmp	 <L59>
+<L56>:
+               	movl	%esi, %edi
+               	leaq	(%rbx,%rdi,4), %r12
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdi
+               	movl	$0x0, %r13d
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movss	(%r12), %xmm0
+               	movl	%r13d, %r14d
+               	leaq	(%rbx,%r14,4), %r15
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	seta	%r13b
-               	movzbq	%r13b, %r13
-               	movzbl	%r13b, %r15d
-               	movl	%edx, %r13d
-               	addl	%r15d, %r13d
-               	movss	(%rdi), %xmm0
-               	movss	(%r14), %xmm1
+               	seta	%r14b
+               	movzbq	%r14b, %r14
+               	movzbl	%r14b, %eax
+               	movl	%edi, %r14d
+               	addl	%eax, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	setae	%r15b
-               	movzbq	%r15b, %r15
-               	movzbl	%r15b, %eax
-               	addl	%eax, %r13d
-               	movss	(%rdi), %xmm0
-               	movss	(%r14), %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r13d
-               	movss	(%rdi), %xmm0
-               	movss	(%r14), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r14d
-               	addl	%r14d, %r13d
-               	addl	$0x1, %r12d
-               	movq	%r13, %rdx
-               	cmpl	$0xc, %r12d
-               	jb	 <L52>
-<L53>:
-               	addl	$0x1, %ecx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x38(%rbp)
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-<L54>:
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	addl	$0x1, %r13d
+               	movq	%r14, %rdi
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+<L58>:
+               	addl	$0x1, %esi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x50(%rbp)
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+<L59>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L55>
-<L55>:
-               	movaps	-0x90(%rbp), %xmm6
-               	movaps	-0xa0(%rbp), %xmm7
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L60>
+<L61>:
+               	movq	%rdx, %rax
+               	movaps	-0xa0(%rbp), %xmm6
                	movaps	-0xb0(%rbp), %xmm14
                	movaps	-0xc0(%rbp), %xmm15
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %rdi
-               	movq	-0x58(%rbp), %rsi
-               	movq	-0x60(%rbp), %r12
-               	movq	-0x68(%rbp), %r13
-               	movq	-0x70(%rbp), %r14
-               	movq	-0x78(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %rdi
+               	movq	-0x68(%rbp), %rsi
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/cmp_f64.dis
+++ b/test/golden/x86_64-windows/float/cmp_f64.dis
@@ -5,35 +5,81 @@ Disassembly of section .text:
 <corpus.cases.float.cmp_f64.fold64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm1, %rax
+               	movq	%rdx, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rbx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$-0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -41,572 +87,1002 @@ Disassembly of section .text:
 <corpus.cases.float.cmp_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
-               	movq	%rbx, -0x98(%rbp)
-               	movq	%rdi, -0xa0(%rbp)
-               	movq	%rsi, -0xa8(%rbp)
-               	movq	%r12, -0xb0(%rbp)
-               	movq	%r13, -0xb8(%rbp)
-               	movq	%r14, -0xc0(%rbp)
-               	movq	%r15, -0xc8(%rbp)
-               	movaps	%xmm6, -0xe0(%rbp)
-               	movaps	%xmm7, -0xf0(%rbp)
-               	movaps	%xmm14, -0x100(%rbp)
-               	movaps	%xmm15, -0x110(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	subq	$0x280, %rsp            # imm = 0x280
+               	movq	%rbx, -0x1e8(%rbp)
+               	movq	%rdi, -0x1f0(%rbp)
+               	movq	%rsi, -0x1f8(%rbp)
+               	movq	%r12, -0x200(%rbp)
+               	movq	%r13, -0x208(%rbp)
+               	movq	%r14, -0x210(%rbp)
+               	movq	%r15, -0x218(%rbp)
+               	movaps	%xmm6, -0x230(%rbp)
+               	movaps	%xmm7, -0x240(%rbp)
+               	movaps	%xmm14, -0x250(%rbp)
+               	movaps	%xmm15, -0x260(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %ebx
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rdi
 <L0>:
-               	movl	%ebx, %esi
-               	leaq	-0x60(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movabsq	$-0x10000000000000, %rcx # imm = 0xFFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x4010000000000000, %rcx # imm = 0xBFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x8(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7ff0000000000000, %rcx # imm = 0x8010000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x10(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7fffffffffffffff, %rcx # imm = 0x8000000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x18(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x8000000000000000, %rcx # imm = 0x8000000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x20(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rbx, %xmm0
-               	leaq	0x28(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x30(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x3ff0000000000000, %rcx # imm = 0x3FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x38(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7fefffffffffffff, %rcx # imm = 0x7FEFFFFFFFFFFFFF
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x40(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000000, %rcx # imm = 0x7FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x48(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff8000000000000, %rcx # imm = 0x7FF8000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x50(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000001, %rcx # imm = 0x7FF0000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x58(%rdi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rax, %rbx
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L0>
+               	movabsq	$-0x10000000000000, %rdx # imm = 0xFFF0000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$-0x4010000000000000, %rdx # imm = 0xBFF0000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x8(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$-0x7ff0000000000000, %rdx # imm = 0x8010000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x10(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$-0x7fffffffffffffff, %rdx # imm = 0x8000000000000001
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x18(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$-0x8000000000000000, %rdx # imm = 0x8000000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x20(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movq	%rax, %xmm0
+               	leaq	0x28(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movq	$0x1, %rdx
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x30(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$0x3ff0000000000000, %rdx # imm = 0x3FF0000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x38(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$0x7fefffffffffffff, %rdx # imm = 0x7FEFFFFFFFFFFFFF
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x40(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$0x7ff0000000000000, %rdx # imm = 0x7FF0000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x48(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$0x7ff8000000000000, %rdx # imm = 0x7FF8000000000000
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x50(%rsi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	movabsq	$0x7ff0000000000001, %rdx # imm = 0x7FF0000000000001
+               	addq	%rax, %rdx
+               	movq	%rdx, %xmm0
+               	leaq	0x58(%rsi), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	movq	$0x0, %r12
                	cmpq	$0xc, %r12
-               	jb	 <L2>
-               	jmp	 <L37>
-<L2>:
-               	leaq	(%rdi,%r12,8), %r13
-               	movq	%rbx, %r14
+               	jb	 <L1>
+               	jmp	 <L46>
+<L1>:
+               	leaq	(%rsi,%r12,8), %r13
+               	movq	%rdi, %r14
                	movq	$0x0, %r15
                	cmpq	$0xc, %r15
-               	jb	 <L3>
-               	jmp	 <L36>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L45>
+<L2>:
                	movsd	(%r13), %xmm6
-               	leaq	(%rdi,%r15,8), %rax
+               	leaq	(%rsi,%r15,8), %rax
                	movsd	(%rax), %xmm7
                	ucomisd	%xmm7, %xmm6
-               	sete	%dl
+               	sete	%al
                	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	movq	%r14, %rcx
-               	callq	 <L4>
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	%r14, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
 <L4>:
                	ucomisd	%xmm7, %xmm6
-               	setne	%dl
+               	setne	%al
                	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0x90(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	ucomisd	%xmm6, %xmm7
-               	seta	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x88(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L6>
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
 <L6>:
                	ucomisd	%xmm6, %xmm7
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
+               	seta	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xa8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	ucomisd	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	callq	 <L8>
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
 <L8>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	ucomisd	%xmm6, %xmm7
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	-0x88(%rbp), %r8
-               	testb	%r8b, %r8b
-               	jne	 <L10>
-               	movq	$0x0, %rcx
-               	jmp	 <L11>
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
 <L10>:
-               	movq	$0x1, %rcx
+               	ucomisd	%xmm7, %xmm6
+               	seta	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L11>
 <L11>:
-               	ucomisd	%xmm6, %xmm7
+               	ucomisd	%xmm7, %xmm6
                	setae	%dl
                	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L12>
-               	movq	%rcx, %rdx
-               	jmp	 <L13>
+               	movq	%rax, %rcx
+               	callq	 <L12>
 <L12>:
-               	addl	$0x2, %ecx
-               	movq	%rcx, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %r8
+               	ucomisd	%xmm6, %xmm7
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L13>
+               	movq	$0x0, %rdx
+               	jmp	 <L14>
 <L13>:
-               	ucomisd	%xmm7, %xmm6
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L14>
-               	movq	%rdx, %rcx
-               	jmp	 <L15>
+               	movq	$0x1, %rdx
 <L14>:
-               	addl	$0x4, %edx
-               	movq	%rdx, %rcx
+               	ucomisd	%xmm6, %xmm7
+               	setae	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L15>
+               	movq	%rdx, %rax
+               	jmp	 <L16>
 <L15>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L16>
-               	movq	%rcx, %rdx
-               	jmp	 <L17>
+               	addl	$0x2, %edx
+               	movq	%rdx, %rax
 <L16>:
-               	addl	$0x8, %ecx
-               	movq	%rcx, %rdx
-<L17>:
                	ucomisd	%xmm7, %xmm6
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L18>
-               	movq	%rdx, %rcx
-               	jmp	 <L19>
-<L18>:
-               	addl	$0x10, %edx
-               	movq	%rdx, %rcx
-<L19>:
-               	ucomisd	%xmm7, %xmm6
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
+               	seta	%dl
                	movzbq	%dl, %rdx
                	testb	%dl, %dl
-               	jne	 <L20>
-               	movq	%rcx, %rdx
-               	jmp	 <L21>
+               	jne	 <L17>
+               	movq	%rax, %rdx
+               	jmp	 <L18>
+<L17>:
+               	addl	$0x4, %eax
+               	movq	%rax, %rdx
+<L18>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L19>
+               	movq	%rdx, %rax
+               	jmp	 <L20>
+<L19>:
+               	addl	$0x8, %edx
+               	movq	%rdx, %rax
 <L20>:
-               	addl	$0x20, %ecx
-               	movq	%rcx, %rdx
-<L21>:
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	ucomisd	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L23>
-               	movq	%rcx, %rdx
-               	jmp	 <L24>
-<L23>:
                	ucomisd	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
-<L24>:
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	ucomisd	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L26>
-               	ucomisd	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	jmp	 <L27>
-<L26>:
-               	movq	%rcx, %rdx
-<L27>:
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	ucomisd	%xmm6, %xmm7
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	cmpb	$0x1, %cl
-               	setne	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	ucomisd	%xmm6, %xmm6
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L30>
-               	movq	%rcx, %rdx
-               	jmp	 <L31>
-<L30>:
-               	ucomisd	%xmm7, %xmm7
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
-<L31>:
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	ucomisd	%xmm6, %xmm6
-               	setne	%cl
+               	testb	%dl, %dl
+               	jne	 <L21>
+               	movq	%rax, %rdx
+               	jmp	 <L22>
+<L21>:
+               	addl	$0x10, %eax
+               	movq	%rax, %rdx
+<L22>:
+               	ucomisd	%xmm7, %xmm6
+               	setne	%al
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L33>
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L23>
+               	movq	%rdx, %rax
+               	jmp	 <L24>
+<L23>:
+               	addl	$0x20, %edx
+               	movq	%rdx, %rax
+<L24>:
+               	movzbq	%al, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+<L26>:
+               	ucomisd	%xmm6, %xmm7
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	ucomisd	%xmm7, %xmm6
+               	seta	%al
+               	movzbq	%al, %rax
+<L28>:
+               	movzbq	%al, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
+<L30>:
+               	ucomisd	%xmm6, %xmm7
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L31>
+               	ucomisd	%xmm7, %xmm6
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	jmp	 <L32>
+<L31>:
+               	movq	%rax, %rdx
+<L32>:
+               	movzbq	%dl, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x110(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+<L34>:
+               	ucomisd	%xmm6, %xmm7
+               	seta	%al
+               	movzbq	%al, %rax
+               	cmpb	$0x1, %al
+               	setne	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x128(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x148(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x148(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+<L36>:
+               	ucomisd	%xmm6, %xmm6
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	ucomisd	%xmm7, %xmm7
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+<L38>:
+               	movzbq	%al, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x140(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+<L40>:
+               	ucomisd	%xmm6, %xmm6
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L41>
                	ucomisd	%xmm7, %xmm7
                	setne	%dl
                	setp	%r11b
                	orb	%r11b, %dl
                	movzbq	%dl, %rdx
-               	jmp	 <L34>
-<L33>:
-               	movq	%rcx, %rdx
-<L34>:
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
+               	jmp	 <L42>
+<L41>:
+               	movq	%rax, %rdx
+<L42>:
+               	movzbq	%dl, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x158(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+<L44>:
                	addq	$0x1, %r15
-               	movq	%rax, %r14
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %r14
                	cmpq	$0xc, %r15
-               	jb	 <L3>
-<L36>:
-               	addq	$0x1, %r12
-               	movq	%r14, %rbx
-               	cmpq	$0xc, %r12
                	jb	 <L2>
-<L37>:
-               	leaq	-0x80(%rbp), %r12
+<L45>:
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0xc, %r12
+               	jb	 <L1>
+<L46>:
+               	leaq	-0x20(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
                	movq	$0x0, 0x18(%r12)
                	movl	$0xff800000, %eax       # imm = 0xFF800000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0xbf800000, %eax       # imm = 0xBF800000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x4(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x80000000, %eax       # imm = 0x80000000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x8(%r12), %rax
                	movss	%xmm0, (%rax)
-               	movd	%esi, %xmm0
+               	movd	%ebx, %xmm0
                	leaq	0xc(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x1, %eax
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x10(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x14(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7f800000, %eax       # imm = 0x7F800000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x18(%r12), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
-               	addl	%esi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x1c(%r12), %rax
                	movss	%xmm0, (%rax)
-               	movq	$0x0, %rsi
-               	cmpq	$0xc, %rsi
-               	jb	 <L38>
-               	jmp	 <L47>
-<L38>:
-               	leaq	(%rdi,%rsi,8), %r13
-               	movq	%rbx, %r14
+               	movq	$0x0, %rbx
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
+               	jmp	 <L59>
+<L47>:
+               	leaq	(%rsi,%rbx,8), %r13
+               	movq	%rdi, %r14
                	movq	$0x0, %r15
                	cmpq	$0x8, %r15
-               	jb	 <L39>
-               	jmp	 <L46>
-<L39>:
+               	jb	 <L48>
+               	jmp	 <L58>
+<L48>:
                	movsd	(%r13), %xmm6
                	leaq	(%r12,%r15,4), %rax
-               	movss	(%rax), %xmm0
-               	cvtss2sd	%xmm0, %xmm7
-               	ucomisd	%xmm7, %xmm6
-               	sete	%dl
+               	movss	(%rax), %xmm7
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm0, %xmm6
+               	sete	%al
                	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	movq	%r14, %rcx
-               	callq	 <L40>
-<L40>:
-               	ucomisd	%xmm7, %xmm6
-               	setne	%dl
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	%r14, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+<L50>:
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm0, %xmm6
+               	setne	%al
                	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x188(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L51>
+               	jmp	 <L52>
+<L51>:
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	ucomisd	%xmm6, %xmm7
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L51>
+<L52>:
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm6, %xmm0
+               	seta	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1a0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
+               	jmp	 <L54>
+<L53>:
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
+<L54>:
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm6, %xmm0
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L55>
+<L55>:
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm0, %xmm6
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %r8
+               	movq	%r8, -0x1c8(%rbp)
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	ucomisd	%xmm6, %xmm7
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L56>
+<L56>:
+               	cvtss2sd	%xmm7, %xmm0
+               	ucomisd	%xmm0, %xmm6
                	setae	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	ucomisd	%xmm7, %xmm6
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L57>
+<L57>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x8, %r15
-               	jb	 <L39>
-<L46>:
-               	addq	$0x1, %rsi
-               	movq	%r14, %rbx
-               	cmpq	$0xc, %rsi
-               	jb	 <L38>
-<L47>:
-               	leaq	(%rdi), %rax
+               	jb	 <L48>
+<L58>:
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
+<L59>:
+               	leaq	(%rsi), %rax
                	movsd	(%rax), %xmm0
                	movsd	(%rax), %xmm1
                	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
                	movq	$0x1, %rax
                	cmpq	$0xc, %rax
-               	jb	 <L48>
-               	jmp	 <L53>
-<L48>:
-               	leaq	(%rdi,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
+               	jb	 <L60>
+               	jmp	 <L65>
+<L60>:
+               	leaq	(%rsi,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
                	ucomisd	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L49>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L61>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L50>
-<L49>:
-               	leaq	(%rdi,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
-<L50>:
-               	leaq	(%rdi,%rax,8), %rcx
-               	movsd	(%rcx), %xmm2
+               	jmp	 <L62>
+<L61>:
+               	leaq	(%rsi,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
+<L62>:
+               	leaq	(%rsi,%rax,8), %rdx
+               	movsd	(%rdx), %xmm2
                	ucomisd	%xmm6, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L51>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L63>
                	movsd	%xmm6, %xmm2            # xmm2 = xmm6[0],xmm2[1]
-               	jmp	 <L52>
-<L51>:
-               	leaq	(%rdi,%rax,8), %rcx
-               	movsd	(%rcx), %xmm2
-<L52>:
+               	jmp	 <L64>
+<L63>:
+               	leaq	(%rsi,%rax,8), %rdx
+               	movsd	(%rdx), %xmm2
+<L64>:
                	addq	$0x1, %rax
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
                	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
                	cmpq	$0xc, %rax
-               	jb	 <L48>
-<L53>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L55>
-               	movq	%rbx, %rcx
+               	jb	 <L60>
+<L65>:
+               	movq	%rdi, %rcx
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rsi
-               	jmp	 <L57>
-<L55>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rsi
-<L57>:
-               	ucomisd	%xmm6, %xmm6
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L59>
-               	movq	%rsi, %rcx
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rcx
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rbx
-               	jmp	 <L61>
-<L59>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rbx
-<L61>:
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
                	movl	$0x0, %r8d
-               	movq	%r8, -0x90(%rbp)
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
-               	jmp	 <L65>
-<L62>:
-               	leaq	(%rdi,%rcx,8), %rdx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	$0x0, %r12
-               	cmpq	$0xc, %r12
-               	jb	 <L63>
-               	jmp	 <L64>
-<L63>:
-               	movsd	(%rdx), %xmm0
-               	leaq	(%rdi,%r12,8), %r13
-               	movsd	(%r13), %xmm1
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0xc, %rbx
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	leaq	(%rsi,%rbx,8), %rdi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movsd	(%rdi), %xmm0
+               	leaq	(%rsi,%r13,8), %r14
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm0, %xmm1
-               	seta	%r14b
-               	movzbq	%r14b, %r14
-               	movzbl	%r14b, %r15d
-               	movl	%esi, %r14d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r13), %xmm1
-               	ucomisd	%xmm0, %xmm1
-               	setae	%r15b
+               	seta	%r15b
                	movzbq	%r15b, %r15
                	movzbl	%r15b, %eax
-               	addl	%eax, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r13), %xmm1
+               	movl	%r12d, %r15d
+               	addl	%eax, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
+               	ucomisd	%xmm0, %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r13), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r13d
-               	addl	%r13d, %r14d
-               	addq	$0x1, %r12
-               	movq	%r14, %rsi
-               	cmpq	$0xc, %r12
-               	jb	 <L63>
-<L64>:
-               	addq	$0x1, %rcx
-               	movq	%rsi, %r8
-               	movq	%r8, -0x90(%rbp)
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
-<L65>:
-               	movq	%rbx, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L66>
-<L66>:
-               	movaps	-0xe0(%rbp), %xmm6
-               	movaps	-0xf0(%rbp), %xmm7
-               	movaps	-0x100(%rbp), %xmm14
-               	movaps	-0x110(%rbp), %xmm15
-               	movq	-0x98(%rbp), %rbx
-               	movq	-0xa0(%rbp), %rdi
-               	movq	-0xa8(%rbp), %rsi
-               	movq	-0xb0(%rbp), %r12
-               	movq	-0xb8(%rbp), %r13
-               	movq	-0xc0(%rbp), %r14
-               	movq	-0xc8(%rbp), %r15
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	cmpq	$0xc, %rbx
+               	jb	 <L68>
+<L71>:
+               	movq	-0x1d8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L72>
+<L73>:
+               	movq	%rdx, %rax
+               	movaps	-0x230(%rbp), %xmm6
+               	movaps	-0x240(%rbp), %xmm7
+               	movaps	-0x250(%rbp), %xmm14
+               	movaps	-0x260(%rbp), %xmm15
+               	movq	-0x1e8(%rbp), %rbx
+               	movq	-0x1f0(%rbp), %rdi
+               	movq	-0x1f8(%rbp), %rsi
+               	movq	-0x200(%rbp), %r12
+               	movq	-0x208(%rbp), %r13
+               	movq	-0x210(%rbp), %r14
+               	movq	-0x218(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/special_f32.dis
+++ b/test/golden/x86_64-windows/float/special_f32.dis
@@ -10,35 +10,81 @@ Disassembly of section .text:
 <corpus.cases.float.special_f32.fold32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomiss	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm1, %eax
+               	movl	%eax, %ebx
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$0xffffffff, %rbx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -46,931 +92,941 @@ Disassembly of section .text:
 <corpus.cases.float.special_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x160, %rsp            # imm = 0x160
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%rdi, -0x70(%rbp)
-               	movq	%rsi, -0x78(%rbp)
-               	movq	%r12, -0x80(%rbp)
-               	movq	%r13, -0x88(%rbp)
-               	movq	%r14, -0x90(%rbp)
-               	movq	%r15, -0x98(%rbp)
-               	movaps	%xmm6, -0xb0(%rbp)
-               	movaps	%xmm7, -0xc0(%rbp)
-               	movaps	%xmm8, -0xd0(%rbp)
-               	movaps	%xmm9, -0xe0(%rbp)
-               	movaps	%xmm10, -0xf0(%rbp)
-               	movaps	%xmm11, -0x100(%rbp)
-               	movaps	%xmm12, -0x110(%rbp)
-               	movaps	%xmm13, -0x120(%rbp)
-               	movaps	%xmm14, -0x130(%rbp)
-               	movaps	%xmm15, -0x140(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rsi
-               	movl	%ebx, %edi
+               	subq	$0x150, %rsp            # imm = 0x150
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, -0x60(%rbp)
+               	movq	%rsi, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movaps	%xmm6, -0xa0(%rbp)
+               	movaps	%xmm7, -0xb0(%rbp)
+               	movaps	%xmm8, -0xc0(%rbp)
+               	movaps	%xmm9, -0xd0(%rbp)
+               	movaps	%xmm10, -0xe0(%rbp)
+               	movaps	%xmm11, -0xf0(%rbp)
+               	movaps	%xmm12, -0x100(%rbp)
+               	movaps	%xmm13, -0x110(%rbp)
+               	movaps	%xmm14, -0x120(%rbp)
+               	movaps	%xmm15, -0x130(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %ebx
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm6
                	movl	$0xbf800000, %eax       # imm = 0xBF800000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm7
-               	movd	%edi, %xmm8
+               	movd	%ebx, %xmm8
                	movl	$0x80000000, %eax       # imm = 0x80000000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm9
                	movl	$0x7f800000, %eax       # imm = 0x7F800000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm10
                	movl	$0xff800000, %eax       # imm = 0xFF800000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm11
                	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm12
                	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
-               	addl	%edi, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm13
                	movl	$0x800000, %eax         # imm = 0x800000
-               	addl	%edi, %eax
-               	movl	%eax, -0x38(%rbp)
+               	addl	%ebx, %eax
+               	movl	%eax, -0x30(%rbp)
                	movl	$0x7fffff, %eax         # imm = 0x7FFFFF
-               	addl	%edi, %eax
-               	movl	%eax, -0x48(%rbp)
+               	addl	%ebx, %eax
+               	movl	%eax, -0x40(%rbp)
                	movl	$0x1, %eax
-               	addl	%edi, %eax
-               	movl	%eax, -0x58(%rbp)
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%rsi, %rcx
+               	addl	%ebx, %eax
+               	movl	%eax, -0x50(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	addss	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L2>
 <L2>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	addss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rbx
-<L4>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	addss	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	addss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rsi
-               	jmp	 <L8>
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	subss	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L6>
 <L6>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	subss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rsi
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	subss	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L8>
 <L8>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	addss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%rsi, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	subss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L10>
 <L10>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rbx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L12>
 <L12>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	addss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rsi
-               	jmp	 <L16>
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm9, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L14>
 <L14>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rsi
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x219>
+               	movq	%rax, %rcx
+               	callq	 <L16>
 <L16>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	addss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%rsi, %rcx
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x22d>
+               	movq	%rax, %rcx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	divss	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L18>
 <L18>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	divss	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rbx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	divss	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L20>
 <L20>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	addss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rcx
+               	divss	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rsi
-               	jmp	 <L24>
-<L22>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rsi
-<L24>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	subss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%rsi, %rcx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
-<L26>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-<L28>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	subss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rcx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rsi
-               	jmp	 <L32>
-<L30>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rsi
-<L32>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	subss	%xmm8, %xmm1
-               	movq	%rsi, %rcx
-               	callq	 <L33>
-<L33>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	subss	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x3aa>
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x3be>
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	divss	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	divss	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	divss	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	divss	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
                	ucomiss	%xmm9, %xmm8
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
                	ucomiss	%xmm8, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
                	ucomiss	%xmm9, %xmm8
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
                	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
+               	callq	 <L28>
+<L28>:
                	movq	%rax, %rcx
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
+               	callq	 <L29>
+<L29>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x470>
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x3c9>
                	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	callq	 <L30>
+<L30>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L31>
+<L31>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
+               	callq	 <L32>
+<L32>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
+               	callq	 <L33>
+<L33>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	callq	 <L34>
+<L34>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
+               	callq	 <L35>
+<L35>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	addss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
+               	callq	 <L36>
+<L36>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	subss	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
+               	callq	 <L37>
+<L37>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	callq	 <L38>
+<L38>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
+               	callq	 <L39>
+<L39>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
+               	callq	 <L40>
+<L40>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
+               	callq	 <L41>
+<L41>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
+               	callq	 <L42>
+<L42>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
+               	callq	 <L43>
+<L43>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	divss	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
+               	callq	 <L44>
+<L44>:
                	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
                	addss	%xmm13, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
+               	callq	 <L45>
+<L45>:
                	ucomiss	%xmm13, %xmm10
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
+               	movq	%rsi, %rdx
+               	callq	 <L46>
+<L46>:
                	xorps	%xmm1, %xmm1
                	subss	%xmm13, %xmm1
                	ucomiss	%xmm11, %xmm1
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
+               	movq	%rsi, %rdx
+               	callq	 <L47>
+<L47>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	subss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
+               	callq	 <L48>
+<L48>:
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
                	addss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
+               	callq	 <L49>
+<L49>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L50>
+<L50>:
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
                	mulss	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L51>
+<L51>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L52>
+<L52>:
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
+               	callq	 <L53>
+<L53>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L54>
+<L54>:
                	movd	%xmm12, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	movq	%rsi, %rdx
+               	callq	 <L55>
+<L55>:
                	ucomiss	%xmm12, %xmm12
                	setne	%dl
                	setp	%r11b
                	orb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
+               	movq	%rsi, %rdx
+               	callq	 <L56>
+<L56>:
                	ucomiss	%xmm12, %xmm12
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
+               	movq	%rsi, %rdx
+               	callq	 <L57>
+<L57>:
                	ucomiss	%xmm12, %xmm12
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	movq	%rsi, %rdx
+               	callq	 <L58>
+<L58>:
                	ucomiss	%xmm12, %xmm12
                	setae	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
-               	movss	%xmm12, %xmm7           # xmm7 = xmm12[0],xmm7[1,2,3]
-               	xorps	, %xmm7 <corpus.cases.float.special_f32.checksum+0x69b>
-               	movd	%xmm7, %edx
-               	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x6b3>
+               	movq	%rsi, %rdx
+               	callq	 <L59>
+<L59>:
+               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x623>
                	movd	%xmm1, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
+               	movq	%rsi, %rdx
+               	callq	 <L60>
+<L60>:
+               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x641>
+               	movss	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1,2,3]
+               	xorps	, %xmm4 <corpus.cases.float.special_f32.checksum+0x64c>
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L61>
+<L61>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L62>
+<L62>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	addss	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
+               	callq	 <L63>
+<L63>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L64>
+<L64>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	subss	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L65>
+<L65>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	divss	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L66>
+<L66>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
+               	callq	 <L67>
+<L67>:
                	movq	%rax, %rcx
-               	movss	-0x58(%rbp), %xmm1
-               	callq	 <L90>
-<L90>:
+               	movss	-0x50(%rbp), %xmm1
+               	callq	 <L68>
+<L68>:
                	movq	%rax, %rcx
-               	movss	-0x48(%rbp), %xmm1
-               	callq	 <L91>
-<L91>:
+               	movss	-0x40(%rbp), %xmm1
+               	callq	 <L69>
+<L69>:
                	movq	%rax, %rcx
-               	movss	-0x38(%rbp), %xmm1
-               	callq	 <L92>
-<L92>:
-               	movss	-0x48(%rbp), %xmm1
-               	addss	-0x58(%rbp), %xmm1
+               	movss	-0x30(%rbp), %xmm1
+               	callq	 <L70>
+<L70>:
+               	movss	-0x40(%rbp), %xmm1
+               	addss	-0x50(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	movss	-0x38(%rbp), %xmm1
-               	subss	-0x58(%rbp), %xmm1
+               	callq	 <L71>
+<L71>:
+               	movss	-0x30(%rbp), %xmm1
+               	subss	-0x50(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
-               	movss	-0x58(%rbp), %xmm1
-               	addss	-0x58(%rbp), %xmm1
+               	callq	 <L72>
+<L72>:
+               	movss	-0x50(%rbp), %xmm1
+               	addss	-0x50(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x794>
+               	callq	 <L73>
+<L73>:
+               	movss	-0x50(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x732>
                	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
-               	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7a9>
+               	callq	 <L74>
+<L74>:
+               	movss	-0x50(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x747>
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	movss	-0x58(%rbp), %xmm1
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7bd>
+               	callq	 <L75>
+<L75>:
+               	movss	-0x50(%rbp), %xmm1
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x75b>
                	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7d2>
+               	callq	 <L76>
+<L76>:
+               	movss	-0x50(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x770>
                	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
-               	movss	-0x48(%rbp), %xmm1
-               	divss	-0x38(%rbp), %xmm1
+               	callq	 <L77>
+<L77>:
+               	movss	-0x40(%rbp), %xmm1
+               	divss	-0x30(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	movss	-0x58(%rbp), %xmm14
+               	callq	 <L78>
+<L78>:
+               	movss	-0x50(%rbp), %xmm14
                	ucomiss	%xmm8, %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
-               	movss	-0x58(%rbp), %xmm14
+               	movq	%rsi, %rdx
+               	callq	 <L79>
+<L79>:
+               	movss	-0x50(%rbp), %xmm14
                	ucomiss	%xmm8, %xmm14
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
+               	movq	%rsi, %rdx
+               	callq	 <L80>
+<L80>:
                	xorps	%xmm1, %xmm1
-               	subss	-0x58(%rbp), %xmm1
+               	subss	-0x50(%rbp), %xmm1
                	ucomiss	%xmm1, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %rbx
-               	movsd	-0x38(%rbp), %xmm7
-               	movl	$0x0, %esi
-               	cmpl	$0x1e, %esi
-               	jb	 <L104>
-               	jmp	 <L109>
-<L104>:
-               	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
-               	mulss	, %xmm9 <corpus.cases.float.special_f32.checksum+0x869>
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%rbx, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %r12
-               	jmp	 <L108>
-<L106>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r12
-<L108>:
-               	addl	$0x1, %esi
-               	movq	%r12, %rbx
-               	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
-               	cmpl	$0x1e, %esi
-               	jb	 <L104>
-<L109>:
-               	leaq	-0x20(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	leaq	(%rsi), %rax
-               	movl	$0x0, (%rax)
-               	leaq	0x4(%rsi), %rax
-               	movl	$0x80000000, (%rax)     # imm = 0x80000000
-               	leaq	0x8(%rsi), %rax
-               	movl	$0x1, (%rax)
-               	leaq	0xc(%rsi), %rax
-               	movl	$0x7f800000, (%rax)     # imm = 0x7F800000
-               	leaq	0x10(%rsi), %rax
-               	movl	$0xff800000, (%rax)     # imm = 0xFF800000
-               	leaq	0x14(%rsi), %rax
-               	movl	$0x7fc00000, (%rax)     # imm = 0x7FC00000
-               	leaq	0x18(%rsi), %rax
-               	movl	$0xffc0dead, (%rax)     # imm = 0xFFC0DEAD
-               	leaq	0x1c(%rsi), %rax
-               	movl	$0x7f800001, (%rax)     # imm = 0x7F800001
-               	movl	$0x0, %r12d
-               	cmpl	$0x8, %r12d
-               	jb	 <L110>
-               	jmp	 <L112>
-<L110>:
-               	movl	%r12d, %eax
-               	leaq	(%rsi,%rax,4), %rcx
-               	movl	(%rcx), %eax
-               	addl	%edi, %eax
-               	movd	%eax, %xmm0
-               	movd	%xmm0, %eax
-               	movq	%rbx, %rcx
-               	movl	%eax, %edx
-               	callq	 <L111>
-<L111>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r12d
-               	jb	 <L110>
-<L112>:
+               	movq	%rsi, %rdx
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rsi
+               	movsd	-0x30(%rbp), %xmm7
+               	movl	$0x0, %edi
+               	cmpl	$0x1e, %edi
+               	jb	 <L82>
+               	jmp	 <L84>
+<L82>:
+               	mulss	, %xmm7 <corpus.cases.float.special_f32.checksum+0x816>
+               	movq	%rsi, %rcx
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L83>
+<L83>:
+               	addl	$0x1, %edi
+               	movq	%rax, %rsi
+               	cmpl	$0x1e, %edi
+               	jb	 <L82>
+<L84>:
+               	leaq	-0x20(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	leaq	(%rax), %rdx
+               	movl	$0x0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
+               	leaq	0x8(%rax), %rdx
+               	movl	$0x1, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movl	$0x7f800000, (%rdx)     # imm = 0x7F800000
+               	leaq	0x10(%rax), %rdx
+               	movl	$0xff800000, (%rdx)     # imm = 0xFF800000
+               	leaq	0x14(%rax), %rdx
+               	movl	$0x7fc00000, (%rdx)     # imm = 0x7FC00000
+               	leaq	0x18(%rax), %rdx
+               	movl	$0xffc0dead, (%rdx)     # imm = 0xFFC0DEAD
+               	leaq	0x1c(%rax), %rdx
+               	movl	$0x7f800001, (%rdx)     # imm = 0x7F800001
+               	movl	$0x0, %edx
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
+               	jmp	 <L88>
+<L85>:
+               	movl	%edx, %edi
+               	leaq	(%rax,%rdi,4), %r12
+               	movl	(%r12), %edi
+               	addl	%ebx, %edi
+               	movd	%edi, %xmm0
+               	movd	%xmm0, %edi
+               	movl	%edi, %r12d
+               	movq	%rsi, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
+               	jmp	 <L87>
+<L86>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
+<L87>:
+               	addl	$0x1, %edx
+               	movq	%rdi, %rsi
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
+<L88>:
                	movl	$0x1000000, %eax        # imm = 0x1000000
-               	addl	%edi, %eax
-               	movl	$0x1000001, %esi        # imm = 0x1000001
-               	addl	%edi, %esi
+               	addl	%ebx, %eax
+               	movl	$0x1000001, %edi        # imm = 0x1000001
+               	addl	%ebx, %edi
                	movl	$0x1000003, %r12d       # imm = 0x1000003
-               	addl	%edi, %r12d
+               	addl	%ebx, %r12d
                	movl	$0xffffffff, %r13d      # imm = 0xFFFFFFFF
-               	addl	%edi, %r13d
+               	addl	%ebx, %r13d
                	movl	$0xfeffffff, %r14d      # imm = 0xFEFFFFFF
-               	addl	%edi, %r14d
+               	addl	%ebx, %r14d
                	movl	$0x80000000, %r15d      # imm = 0x80000000
-               	addl	%edi, %r15d
+               	addl	%ebx, %r15d
                	movl	%eax, %r11d
                	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L114>
-               	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	jmp	 <L116>
-<L114>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-<L116>:
-               	movl	%esi, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L118>
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rbx
-               	jmp	 <L120>
-<L118>:
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-<L120>:
-               	movl	%r12d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L122>
-               	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rsi
-               	jmp	 <L124>
-<L122>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %rsi
-<L124>:
-               	movl	%r13d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %rbx
-               	jmp	 <L128>
-<L126>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-<L128>:
+               	callq	 <L89>
+<L89>:
                	movl	%edi, %r11d
                	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L130>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rsi
-               	jmp	 <L132>
-<L130>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %rsi
-<L132>:
+               	callq	 <L90>
+<L90>:
+               	movl	%r12d, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L91>
+<L91>:
+               	movl	%r13d, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L92>
+<L92>:
+               	movl	%ebx, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L93>
+<L93>:
                	movslq	%r14d, %r11
                	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L134>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rbx
-               	jmp	 <L136>
-<L134>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-<L136>:
+               	callq	 <L94>
+<L94>:
                	movslq	%r15d, %r11
                	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rsi
-               	jmp	 <L140>
-<L138>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %rsi
-<L140>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xba0>
+               	callq	 <L95>
+<L95>:
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x9f9>
                	mulss	%xmm6, %xmm0
-               	movss	, %xmm7 <corpus.cases.float.special_f32.checksum+0xbac>
-               	mulss	%xmm6, %xmm7
-               	movss	, %xmm9 <corpus.cases.float.special_f32.checksum+0xbb9>
-               	mulss	%xmm6, %xmm9
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm0, %xmm10
-               	movss	, %xmm11 <corpus.cases.float.special_f32.checksum+0xbd0>
-               	mulss	%xmm6, %xmm11
+               	movss	, %xmm1 <corpus.cases.float.special_f32.checksum+0xa05>
+               	mulss	%xmm6, %xmm1
+               	movss	, %xmm2 <corpus.cases.float.special_f32.checksum+0xa11>
+               	mulss	%xmm6, %xmm2
+               	xorps	%xmm3, %xmm3
+               	subss	%xmm0, %xmm3
+               	movss	, %xmm4 <corpus.cases.float.special_f32.checksum+0xa24>
+               	mulss	%xmm6, %xmm4
                	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %eax
+               	movl	%r11d, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
+               	jmp	 <L97>
+<L96>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	movl	%eax, %edx
-               	callq	 <L141>
-<L141>:
-               	cvttss2si	%xmm7, %r11
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
+<L97>:
+               	cvttss2si	%xmm1, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L142>
-<L142>:
-               	cvttss2si	%xmm9, %r11
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
+               	jmp	 <L99>
+<L98>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
+<L99>:
+               	cvttss2si	%xmm2, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L143>
-<L143>:
-               	cvttss2si	%xmm11, %r11
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
+               	jmp	 <L101>
+<L100>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
+<L101>:
+               	cvttss2si	%xmm4, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L144>
-<L144>:
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
+               	jmp	 <L103>
+<L102>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
+<L103>:
                	cvttss2si	%xmm8, %r11
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L145>
-<L145>:
-               	cvttss2si	%xmm10, %r11d
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L104>
+               	jmp	 <L105>
+<L104>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L104>
+<L105>:
+               	cvttss2si	%xmm3, %r11d
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L146>
-<L146>:
-               	cvttss2si	%xmm9, %r11d
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+               	jmp	 <L107>
+<L106>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+<L107>:
+               	cvttss2si	%xmm2, %r11d
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L147>
-<L147>:
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
+               	jmp	 <L109>
+<L108>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
+<L109>:
                	xorps	%xmm0, %xmm0
-               	subss	%xmm11, %xmm0
+               	subss	%xmm4, %xmm0
                	cvttss2si	%xmm0, %r11d
                	movl	%r11d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L148>
-<L148>:
-               	cvttss2si	%xmm10, %r11
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+               	jmp	 <L111>
+<L110>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+<L111>:
+               	cvttss2si	%xmm3, %r11
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L149>
-<L149>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L112>
+               	jmp	 <L113>
+<L112>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L112>
+<L113>:
                	xorps	%xmm0, %xmm0
-               	subss	%xmm7, %xmm0
+               	subss	%xmm1, %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L150>
-<L150>:
-               	movaps	-0xb0(%rbp), %xmm6
-               	movaps	-0xc0(%rbp), %xmm7
-               	movaps	-0xd0(%rbp), %xmm8
-               	movaps	-0xe0(%rbp), %xmm9
-               	movaps	-0xf0(%rbp), %xmm10
-               	movaps	-0x100(%rbp), %xmm11
-               	movaps	-0x110(%rbp), %xmm12
-               	movaps	-0x120(%rbp), %xmm13
-               	movaps	-0x130(%rbp), %xmm14
-               	movaps	-0x140(%rbp), %xmm15
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %rdi
-               	movq	-0x78(%rbp), %rsi
-               	movq	-0x80(%rbp), %r12
-               	movq	-0x88(%rbp), %r13
-               	movq	-0x90(%rbp), %r14
-               	movq	-0x98(%rbp), %r15
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L114>
+               	jmp	 <L115>
+<L114>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L114>
+<L115>:
+               	movaps	-0xa0(%rbp), %xmm6
+               	movaps	-0xb0(%rbp), %xmm7
+               	movaps	-0xc0(%rbp), %xmm8
+               	movaps	-0xd0(%rbp), %xmm9
+               	movaps	-0xe0(%rbp), %xmm10
+               	movaps	-0xf0(%rbp), %xmm11
+               	movaps	-0x100(%rbp), %xmm12
+               	movaps	-0x110(%rbp), %xmm13
+               	movaps	-0x120(%rbp), %xmm14
+               	movaps	-0x130(%rbp), %xmm15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %rdi
+               	movq	-0x68(%rbp), %rsi
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/float/special_f64.dis
+++ b/test/golden/x86_64-windows/float/special_f64.dis
@@ -10,35 +10,81 @@ Disassembly of section .text:
 <corpus.cases.float.special_f64.fold64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movaps	%xmm14, -0x20(%rbp)
-               	movaps	%xmm15, -0x30(%rbp)
-               	movq	%rcx, %rbx
+               	movq	%rdi, -0x10(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rcx, %rdx
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rcx
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm1, %rax
+               	movq	%rdx, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rbx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L2>
 <L2>:
-               	movaps	-0x20(%rbp), %xmm14
-               	movaps	-0x30(%rbp), %xmm15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$-0x1, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdx, %rax
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %rdi
+               	movq	-0x18(%rbp), %rsi
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -46,28 +92,25 @@ Disassembly of section .text:
 <corpus.cases.float.special_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x190, %rsp            # imm = 0x190
-               	movq	%rbx, -0x98(%rbp)
-               	movq	%rdi, -0xa0(%rbp)
-               	movq	%rsi, -0xa8(%rbp)
-               	movq	%r12, -0xb0(%rbp)
-               	movq	%r13, -0xb8(%rbp)
-               	movq	%r14, -0xc0(%rbp)
-               	movq	%r15, -0xc8(%rbp)
-               	movaps	%xmm6, -0xe0(%rbp)
-               	movaps	%xmm7, -0xf0(%rbp)
-               	movaps	%xmm8, -0x100(%rbp)
-               	movaps	%xmm9, -0x110(%rbp)
-               	movaps	%xmm10, -0x120(%rbp)
-               	movaps	%xmm11, -0x130(%rbp)
-               	movaps	%xmm12, -0x140(%rbp)
-               	movaps	%xmm13, -0x150(%rbp)
-               	movaps	%xmm14, -0x160(%rbp)
-               	movaps	%xmm15, -0x170(%rbp)
+               	subq	$0x170, %rsp            # imm = 0x170
+               	movq	%rbx, -0x78(%rbp)
+               	movq	%rdi, -0x80(%rbp)
+               	movq	%rsi, -0x88(%rbp)
+               	movq	%r12, -0x90(%rbp)
+               	movq	%r13, -0x98(%rbp)
+               	movq	%r14, -0xa0(%rbp)
+               	movq	%r15, -0xa8(%rbp)
+               	movaps	%xmm6, -0xc0(%rbp)
+               	movaps	%xmm7, -0xd0(%rbp)
+               	movaps	%xmm8, -0xe0(%rbp)
+               	movaps	%xmm9, -0xf0(%rbp)
+               	movaps	%xmm10, -0x100(%rbp)
+               	movaps	%xmm11, -0x110(%rbp)
+               	movaps	%xmm12, -0x120(%rbp)
+               	movaps	%xmm13, -0x130(%rbp)
+               	movaps	%xmm14, -0x140(%rbp)
+               	movaps	%xmm15, -0x150(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rsi
                	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm6
@@ -92,1047 +135,1054 @@ Disassembly of section .text:
                	movq	%rax, %xmm13
                	movabsq	$0x10000000000000, %rax # imm = 0x10000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x58(%rbp)
+               	movq	%rax, -0x50(%rbp)
                	movabsq	$0xfffffffffffff, %rax  # imm = 0xFFFFFFFFFFFFF
                	addq	%rbx, %rax
-               	movq	%rax, -0x68(%rbp)
+               	movq	%rax, -0x60(%rbp)
                	movq	$0x1, %rax
                	addq	%rbx, %rax
-               	movq	%rax, -0x78(%rbp)
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%rsi, %rcx
+               	movq	%rax, -0x70(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rcx
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
-               	jmp	 <L4>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	addsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L2>
 <L2>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	addsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-<L4>:
-               	ucomisd	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rdi, %rcx
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	addsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	addsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rsi
-               	jmp	 <L8>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	subsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L6>
 <L6>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	subsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rsi
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	subsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L8>
 <L8>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	addsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%rsi, %rcx
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	subsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rdi
-               	jmp	 <L12>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L10>
 <L10>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rdi
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L12>
 <L12>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	addsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rdi, %rcx
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rsi
-               	jmp	 <L16>
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L14>
 <L14>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rsi
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x25f>
+               	movq	%rax, %rcx
+               	callq	 <L16>
 <L16>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	addsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%rsi, %rcx
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x273>
+               	movq	%rax, %rcx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	jmp	 <L20>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	divsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L18>
 <L18>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	divsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rdi
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	divsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L20>
 <L20>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	addsd	%xmm9, %xmm1
-               	movq	%rdi, %rcx
+               	divsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L21>
 <L21>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	subsd	%xmm8, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	subsd	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	subsd	%xmm8, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	subsd	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm9, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x36c>
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x380>
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	divsd	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	divsd	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	divsd	%xmm6, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	divsd	%xmm7, %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
                	ucomisd	%xmm9, %xmm8
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
                	ucomisd	%xmm8, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
                	ucomisd	%xmm9, %xmm8
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
+               	movq	%rsi, %rdx
+               	callq	 <L26>
+<L26>:
                	movq	%rax, %rcx
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L41>
-<L41>:
+               	callq	 <L27>
+<L27>:
                	movq	%rax, %rcx
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
-               	callq	 <L42>
-<L42>:
+               	callq	 <L28>
+<L28>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x435>
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x3cb>
                	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L29>
+<L29>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
+               	callq	 <L30>
+<L30>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L31>
+<L31>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L32>
+<L32>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L33>
+<L33>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	addsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L34>
+<L34>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	addsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
+               	callq	 <L35>
+<L35>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	subsd	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
+               	callq	 <L36>
+<L36>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
+               	callq	 <L37>
+<L37>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	callq	 <L38>
+<L38>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L39>
+<L39>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
+               	callq	 <L40>
+<L40>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
+               	callq	 <L41>
+<L41>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm11, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	callq	 <L42>
+<L42>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	divsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
+               	callq	 <L43>
+<L43>:
                	movsd	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1]
                	addsd	%xmm13, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
+               	callq	 <L44>
+<L44>:
                	ucomisd	%xmm13, %xmm10
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
+               	movq	%rsi, %rdx
+               	callq	 <L45>
+<L45>:
                	xorps	%xmm1, %xmm1
                	subsd	%xmm13, %xmm1
                	ucomisd	%xmm11, %xmm1
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movq	%rsi, %rdx
+               	callq	 <L46>
+<L46>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	subsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
+               	callq	 <L47>
+<L47>:
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	addsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
+               	callq	 <L48>
+<L48>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
+               	callq	 <L49>
+<L49>:
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	mulsd	%xmm9, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
+               	callq	 <L50>
+<L50>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	divsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
+               	callq	 <L51>
+<L51>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
+               	callq	 <L52>
+<L52>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
+               	callq	 <L53>
+<L53>:
                	movq	%xmm12, %rdx
                	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
+               	callq	 <L54>
+<L54>:
                	ucomisd	%xmm12, %xmm12
                	setne	%dl
                	setp	%r11b
                	orb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
+               	movq	%rsi, %rdx
+               	callq	 <L55>
+<L55>:
                	ucomisd	%xmm12, %xmm12
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
+               	movq	%rsi, %rdx
+               	callq	 <L56>
+<L56>:
                	ucomisd	%xmm12, %xmm12
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
+               	movq	%rsi, %rdx
+               	callq	 <L57>
+<L57>:
                	ucomisd	%xmm12, %xmm12
                	setae	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
+               	movq	%rsi, %rdx
+               	callq	 <L58>
+<L58>:
                	movsd	%xmm12, %xmm7           # xmm7 = xmm12[0],xmm7[1]
-               	xorps	, %xmm7 <corpus.cases.float.special_f64.checksum+0x666>
+               	xorps	, %xmm7 <corpus.cases.float.special_f64.checksum+0x626>
                	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L59>
+<L59>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x67e>
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x63e>
                	movq	%xmm1, %rdx
                	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L60>
+<L60>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	addsd	%xmm6, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
+               	callq	 <L61>
+<L61>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	addsd	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L62>
+<L62>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L63>
+<L63>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	subsd	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
+               	callq	 <L64>
+<L64>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	divsd	%xmm12, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
+               	callq	 <L65>
+<L65>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	divsd	%xmm10, %xmm1
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L66>
+<L66>:
                	movq	%rax, %rcx
-               	movsd	-0x78(%rbp), %xmm1
-               	callq	 <L81>
-<L81>:
+               	movsd	-0x70(%rbp), %xmm1
+               	callq	 <L67>
+<L67>:
                	movq	%rax, %rcx
-               	movsd	-0x68(%rbp), %xmm1
-               	callq	 <L82>
-<L82>:
+               	movsd	-0x60(%rbp), %xmm1
+               	callq	 <L68>
+<L68>:
                	movq	%rax, %rcx
-               	movsd	-0x58(%rbp), %xmm1
-               	callq	 <L83>
-<L83>:
-               	movsd	-0x68(%rbp), %xmm1
-               	addsd	-0x78(%rbp), %xmm1
+               	movsd	-0x50(%rbp), %xmm1
+               	callq	 <L69>
+<L69>:
+               	movsd	-0x60(%rbp), %xmm1
+               	addsd	-0x70(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
-               	movsd	-0x58(%rbp), %xmm1
-               	subsd	-0x78(%rbp), %xmm1
+               	callq	 <L70>
+<L70>:
+               	movsd	-0x50(%rbp), %xmm1
+               	subsd	-0x70(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	movsd	-0x78(%rbp), %xmm1
-               	addsd	-0x78(%rbp), %xmm1
+               	callq	 <L71>
+<L71>:
+               	movsd	-0x70(%rbp), %xmm1
+               	addsd	-0x70(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
-               	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x75f>
+               	callq	 <L72>
+<L72>:
+               	movsd	-0x70(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x71f>
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
-               	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x774>
+               	callq	 <L73>
+<L73>:
+               	movsd	-0x70(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x734>
                	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
-               	movsd	-0x78(%rbp), %xmm1
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x788>
+               	callq	 <L74>
+<L74>:
+               	movsd	-0x70(%rbp), %xmm1
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x748>
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
-               	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x79d>
+               	callq	 <L75>
+<L75>:
+               	movsd	-0x70(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x75d>
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
-               	movsd	-0x68(%rbp), %xmm1
-               	divsd	-0x58(%rbp), %xmm1
+               	callq	 <L76>
+<L76>:
+               	movsd	-0x60(%rbp), %xmm1
+               	divsd	-0x50(%rbp), %xmm1
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	movsd	-0x78(%rbp), %xmm14
+               	callq	 <L77>
+<L77>:
+               	movsd	-0x70(%rbp), %xmm14
                	ucomisd	%xmm8, %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	movsd	-0x78(%rbp), %xmm14
+               	movq	%rsi, %rdx
+               	callq	 <L78>
+<L78>:
+               	movsd	-0x70(%rbp), %xmm14
                	ucomisd	%xmm8, %xmm14
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
+               	movq	%rsi, %rdx
+               	callq	 <L79>
+<L79>:
                	xorps	%xmm1, %xmm1
-               	subsd	-0x78(%rbp), %xmm1
+               	subsd	-0x70(%rbp), %xmm1
                	ucomisd	%xmm1, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
+               	movq	%rsi, %rdx
+               	callq	 <L80>
+<L80>:
                	movq	%rax, %rsi
-               	movsd	-0x58(%rbp), %xmm7
+               	movsd	-0x50(%rbp), %xmm7
                	movq	$0x0, %rdi
                	cmpq	$0x3c, %rdi
-               	jb	 <L95>
-               	jmp	 <L100>
-<L95>:
-               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	mulsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0x83a>
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
+               	jb	 <L81>
+               	jmp	 <L83>
+<L81>:
+               	mulsd	, %xmm7 <corpus.cases.float.special_f64.checksum+0x809>
                	movq	%rsi, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %r12
-               	jmp	 <L99>
-<L97>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r12
-<L99>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L82>
+<L82>:
                	addq	$0x1, %rdi
-               	movq	%r12, %rsi
-               	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
+               	movq	%rax, %rsi
                	cmpq	$0x3c, %rdi
-               	jb	 <L95>
-<L100>:
-               	leaq	-0x40(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movq	$0x0, 0x8(%rdi)
-               	movq	$0x0, 0x10(%rdi)
-               	movq	$0x0, 0x18(%rdi)
-               	movq	$0x0, 0x20(%rdi)
-               	movq	$0x0, 0x28(%rdi)
-               	movq	$0x0, 0x30(%rdi)
-               	movq	$0x0, 0x38(%rdi)
-               	leaq	(%rdi), %rax
+               	jb	 <L81>
+<L83>:
+               	leaq	-0x40(%rbp), %rax
                	movq	$0x0, (%rax)
-               	leaq	0x8(%rdi), %rax
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	movq	$0x0, 0x30(%rax)
+               	movq	$0x0, 0x38(%rax)
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x10(%rdi), %rax
-               	movq	$0x1, (%rax)
-               	leaq	0x18(%rdi), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movq	$0x1, (%rdx)
+               	leaq	0x18(%rax), %rdx
                	movabsq	$0x7ff0000000000000, %r11 # imm = 0x7FF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x20(%rdi), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x20(%rax), %rdx
                	movabsq	$-0x10000000000000, %r11 # imm = 0xFFF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x28(%rdi), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x28(%rax), %rdx
                	movabsq	$0x7ff8000000000000, %r11 # imm = 0x7FF8000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x30(%rdi), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x30(%rax), %rdx
                	movabsq	$-0x7ffffff3f2153, %r11 # imm = 0xFFF8000000C0DEAD
-               	movq	%r11, (%rax)
-               	leaq	0x38(%rdi), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x38(%rax), %rdx
                	movabsq	$0x7ff0000000000001, %r11 # imm = 0x7FF0000000000001
-               	movq	%r11, (%rax)
-               	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L101>
-               	jmp	 <L103>
+               	movq	%r11, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+               	jmp	 <L87>
+<L84>:
+               	leaq	(%rax,%rdx,8), %rdi
+               	movq	(%rdi), %r12
+               	addq	%rbx, %r12
+               	movq	%r12, %xmm0
+               	movq	%xmm0, %rdi
+               	movq	%rsi, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+               	jmp	 <L86>
+<L85>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+<L86>:
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+<L87>:
+               	cvtsd2ss	%xmm13, %xmm0
+               	movsd	-0x70(%rbp), %xmm15
+               	cvtsd2ss	%xmm15, %xmm1
+               	movabsq	$0x36a0000000000000, %rax # imm = 0x36A0000000000000
+               	addq	%rbx, %rax
+               	movq	%rax, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	movabsq	$0x3ff0000010000000, %rax # imm = 0x3FF0000010000000
+               	addq	%rbx, %rax
+               	movq	%rax, %xmm2
+               	cvtsd2ss	%xmm2, %xmm4
+               	movabsq	$0x3ff0000030000000, %rax # imm = 0x3FF0000030000000
+               	addq	%rbx, %rax
+               	movq	%rax, %xmm2
+               	cvtsd2ss	%xmm2, %xmm5
+               	cvtsd2ss	%xmm9, %xmm7
+               	cvtsd2ss	%xmm11, %xmm9
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+               	jmp	 <L89>
+<L88>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+<L89>:
+               	movd	%xmm1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+               	jmp	 <L91>
+<L90>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+<L91>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+               	jmp	 <L93>
+<L92>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+<L93>:
+               	movd	%xmm4, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+               	jmp	 <L95>
+<L94>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+<L95>:
+               	movd	%xmm5, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+               	jmp	 <L97>
+<L96>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+<L97>:
+               	movd	%xmm7, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+               	jmp	 <L99>
+<L98>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+<L99>:
+               	movd	%xmm9, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
+               	jmp	 <L101>
+<L100>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
 <L101>:
-               	leaq	(%rdi,%r12,8), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	movq	%xmm0, %rdx
+               	cvtss2sd	%xmm3, %xmm1
                	movq	%rsi, %rcx
                	callq	 <L102>
 <L102>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	cmpq	$0x8, %r12
-               	jb	 <L101>
+               	cvtss2sd	%xmm7, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L103>
 <L103>:
-               	cvtsd2ss	%xmm13, %xmm0
-               	movsd	-0x78(%rbp), %xmm15
-               	cvtsd2ss	%xmm15, %xmm7
-               	movabsq	$0x36a0000000000000, %rax # imm = 0x36A0000000000000
-               	addq	%rbx, %rax
-               	movq	%rax, %xmm1
-               	cvtsd2ss	%xmm1, %xmm10
-               	movabsq	$0x3ff0000010000000, %rax # imm = 0x3FF0000010000000
-               	addq	%rbx, %rax
-               	movq	%rax, %xmm1
-               	cvtsd2ss	%xmm1, %xmm12
-               	movabsq	$0x3ff0000030000000, %rax # imm = 0x3FF0000030000000
-               	addq	%rbx, %rax
-               	movq	%rax, %xmm1
-               	cvtsd2ss	%xmm1, %xmm13
-               	cvtsd2ss	%xmm9, %xmm14
-               	movss	%xmm14, -0x88(%rbp)
-               	cvtsd2ss	%xmm11, %xmm9
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	cvtss2sd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L104>
 <L104>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rcx
-               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rcx
-               	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %rcx
-               	movss	-0x88(%rbp), %xmm1
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %rcx
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %rsi
-               	cvtss2sd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%rsi, %rcx
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %rdi
-               	jmp	 <L114>
-<L112>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %rdi
-<L114>:
-               	movss	-0x88(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%rdi, %rcx
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %rsi
-               	jmp	 <L118>
-<L116>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rsi
-<L118>:
-               	cvtss2sd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L120>
-               	movq	%rsi, %rcx
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rdi
-               	jmp	 <L122>
-<L120>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rdi
-<L122>:
-               	movabsq	$0x20000000000000, %rax # imm = 0x20000000000000
-               	addq	%rbx, %rax
+               	movabsq	$0x20000000000000, %rdx # imm = 0x20000000000000
+               	addq	%rbx, %rdx
                	movabsq	$0x20000000000001, %rsi # imm = 0x20000000000001
                	addq	%rbx, %rsi
-               	movabsq	$0x20000000000003, %r12 # imm = 0x20000000000003
+               	movabsq	$0x20000000000003, %rdi # imm = 0x20000000000003
+               	addq	%rbx, %rdi
+               	movq	$-0x1, %r12
                	addq	%rbx, %r12
-               	movq	$-0x1, %r13
+               	movabsq	$-0x20000000000001, %r13 # imm = 0xFFDFFFFFFFFFFFFF
                	addq	%rbx, %r13
-               	movabsq	$-0x20000000000001, %r14 # imm = 0xFFDFFFFFFFFFFFFF
+               	movabsq	$-0x8000000000000000, %r14 # imm = 0x8000000000000000
                	addq	%rbx, %r14
-               	movabsq	$-0x8000000000000000, %r15 # imm = 0x8000000000000000
-               	addq	%rbx, %r15
-               	movq	%rax, %r11
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L123>
+               	jl	 <L105>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L124>
-<L123>:
+               	jmp	 <L106>
+<L105>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L124>:
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
-               	movq	%rdi, %rcx
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-               	jmp	 <L128>
-<L126>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-<L128>:
+<L106>:
+               	movq	%rax, %rcx
+               	callq	 <L107>
+<L107>:
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L129>
+               	jl	 <L108>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L130>
-<L129>:
+               	jmp	 <L109>
+<L108>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L130>:
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %rsi
-               	jmp	 <L134>
-<L132>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rsi
-<L134>:
+<L109>:
+               	movq	%rax, %rcx
+               	callq	 <L110>
+<L110>:
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L111>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L112>
+<L111>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L112>:
+               	movq	%rax, %rcx
+               	callq	 <L113>
+<L113>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L135>
+               	jl	 <L114>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L136>
-<L135>:
+               	jmp	 <L115>
+<L114>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L136>:
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%rsi, %rcx
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rdi
-               	jmp	 <L140>
-<L138>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %rdi
-<L140>:
-               	movq	%r13, %r11
-               	testq	%r11, %r11
-               	jl	 <L141>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L142>
-<L141>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L142>:
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%rdi, %rcx
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rsi
-               	jmp	 <L146>
-<L144>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rsi
-<L146>:
+<L115>:
+               	movq	%rax, %rcx
+               	callq	 <L116>
+<L116>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L147>
+               	jl	 <L117>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L148>
-<L147>:
+               	jmp	 <L118>
+<L117>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L148>:
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%rsi, %rcx
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
+<L118>:
+               	movq	%rax, %rcx
+               	callq	 <L119>
+<L119>:
+               	movq	%r13, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L120>
+<L120>:
                	movq	%r14, %r11
                	cvtsi2sd	%r11, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L154>
-               	movq	%rbx, %rcx
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rsi
-               	jmp	 <L156>
-<L154>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L155>
-<L155>:
-               	movq	%rax, %rsi
-<L156>:
-               	movq	%r15, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L158>
-               	movq	%rsi, %rcx
-               	callq	 <L157>
-<L157>:
-               	movq	%rax, %rbx
-               	jmp	 <L160>
-<L158>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L159>
-<L159>:
-               	movq	%rax, %rbx
-<L160>:
-               	movsd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xe19>
+               	movq	%rax, %rcx
+               	callq	 <L121>
+<L121>:
+               	movsd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xddb>
                	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xe26>
+               	movsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0xde7>
+               	mulsd	%xmm6, %xmm0
+               	movsd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xdf4>
                	mulsd	%xmm6, %xmm9
-               	movsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0xe34>
-               	mulsd	%xmm6, %xmm10
-               	xorps	%xmm11, %xmm11
-               	subsd	%xmm7, %xmm11
-               	movsd	, %xmm12 <corpus.cases.float.special_f64.checksum+0xe4b>
-               	mulsd	%xmm6, %xmm12
-               	ucomisd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xe58>
-               	jb	 <L161>
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm7, %xmm10
+               	movsd	, %xmm11 <corpus.cases.float.special_f64.checksum+0xe0b>
+               	mulsd	%xmm6, %xmm11
+               	ucomisd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xe18>
+               	jb	 <L122>
                	movaps	%xmm7, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xe6b>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xe2b>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L162>
-<L161>:
+               	jmp	 <L123>
+<L122>:
                	cvttsd2si	%xmm7, %r11
-<L162>:
+<L123>:
                	movq	%r11, %rdx
-               	movq	%rbx, %rcx
-               	callq	 <L163>
-<L163>:
-               	ucomisd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xe9b>
-               	jb	 <L164>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L124>
+               	jmp	 <L125>
+<L124>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L124>
+<L125>:
+               	ucomisd	, %xmm0 <corpus.cases.float.special_f64.checksum+0xea4>
+               	jb	 <L126>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xeb7>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L127>
+<L126>:
+               	cvttsd2si	%xmm0, %r11
+<L127>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L128>
+               	jmp	 <L129>
+<L128>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L128>
+<L129>:
+               	ucomisd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xf31>
+               	jb	 <L130>
                	movaps	%xmm9, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xeae>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf44>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L165>
-<L164>:
+               	jmp	 <L131>
+<L130>:
                	cvttsd2si	%xmm9, %r11
-<L165>:
+<L131>:
                	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L166>
-<L166>:
-               	ucomisd	, %xmm10 <corpus.cases.float.special_f64.checksum+0xede>
-               	jb	 <L167>
-               	movaps	%xmm10, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xef1>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L132>
+               	jmp	 <L133>
+<L132>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L132>
+<L133>:
+               	ucomisd	, %xmm11 <corpus.cases.float.special_f64.checksum+0xfbe>
+               	jb	 <L134>
+               	movaps	%xmm11, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xfd1>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L168>
-<L167>:
-               	cvttsd2si	%xmm10, %r11
-<L168>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L169>
-<L169>:
-               	ucomisd	, %xmm12 <corpus.cases.float.special_f64.checksum+0xf21>
-               	jb	 <L170>
-               	movaps	%xmm12, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf34>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L171>
-<L170>:
-               	cvttsd2si	%xmm12, %r11
-<L171>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L172>
-<L172>:
-               	ucomisd	, %xmm8 <corpus.cases.float.special_f64.checksum+0xf64>
-               	jb	 <L173>
-               	movaps	%xmm8, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf77>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L174>
-<L173>:
-               	cvttsd2si	%xmm8, %r11
-<L174>:
-               	movq	%r11, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L175>
-<L175>:
+               	jmp	 <L135>
+<L134>:
                	cvttsd2si	%xmm11, %r11
+<L135>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L136>
+               	jmp	 <L137>
+<L136>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L136>
+<L137>:
+               	ucomisd	, %xmm8 <corpus.cases.float.special_f64.checksum+0x104b>
+               	jb	 <L138>
+               	movaps	%xmm8, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x105e>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L139>
+<L138>:
+               	cvttsd2si	%xmm8, %r11
+<L139>:
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L176>
-<L176>:
+               	callq	 <L140>
+<L140>:
                	cvttsd2si	%xmm10, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L177>
-<L177>:
+               	callq	 <L141>
+<L141>:
+               	cvttsd2si	%xmm9, %r11
+               	movq	%r11, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L142>
+<L142>:
                	xorps	%xmm0, %xmm0
-               	subsd	%xmm12, %xmm0
+               	subsd	%xmm11, %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L178>
-<L178>:
-               	cvttsd2si	%xmm11, %r11d
+               	callq	 <L143>
+<L143>:
+               	cvttsd2si	%xmm10, %r11d
                	movl	%r11d, %edx
+               	movslq	%edx, %rbx
                	movq	%rax, %rcx
-               	callq	 <L179>
-<L179>:
+               	movq	%rbx, %rdx
+               	callq	 <L144>
+<L144>:
                	cvttsd2si	%xmm7, %r11
                	movl	%r11d, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	callq	 <L180>
-<L180>:
-               	movaps	-0xe0(%rbp), %xmm6
-               	movaps	-0xf0(%rbp), %xmm7
-               	movaps	-0x100(%rbp), %xmm8
-               	movaps	-0x110(%rbp), %xmm9
-               	movaps	-0x120(%rbp), %xmm10
-               	movaps	-0x130(%rbp), %xmm11
-               	movaps	-0x140(%rbp), %xmm12
-               	movaps	-0x150(%rbp), %xmm13
-               	movaps	-0x160(%rbp), %xmm14
-               	movaps	-0x170(%rbp), %xmm15
-               	movq	-0x98(%rbp), %rbx
-               	movq	-0xa0(%rbp), %rdi
-               	movq	-0xa8(%rbp), %rsi
-               	movq	-0xb0(%rbp), %r12
-               	movq	-0xb8(%rbp), %r13
-               	movq	-0xc0(%rbp), %r14
-               	movq	-0xc8(%rbp), %r15
+               	movq	%rbx, %rdx
+               	callq	 <L145>
+<L145>:
+               	movaps	-0xc0(%rbp), %xmm6
+               	movaps	-0xd0(%rbp), %xmm7
+               	movaps	-0xe0(%rbp), %xmm8
+               	movaps	-0xf0(%rbp), %xmm9
+               	movaps	-0x100(%rbp), %xmm10
+               	movaps	-0x110(%rbp), %xmm11
+               	movaps	-0x120(%rbp), %xmm12
+               	movaps	-0x130(%rbp), %xmm13
+               	movaps	-0x140(%rbp), %xmm14
+               	movaps	-0x150(%rbp), %xmm15
+               	movq	-0x78(%rbp), %rbx
+               	movq	-0x80(%rbp), %rdi
+               	movq	-0x88(%rbp), %rsi
+               	movq	-0x90(%rbp), %r12
+               	movq	-0x98(%rbp), %r13
+               	movq	-0xa0(%rbp), %r14
+               	movq	-0xa8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/frame/frame_align.dis
+++ b/test/golden/x86_64-windows/frame/frame_align.dis
@@ -5,39 +5,119 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -45,25 +125,69 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_f64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -71,41 +195,115 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -188,72 +386,69 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	andq	$-0x40, %rsp
-               	subq	$0x440, %rsp            # imm = 0x440
-               	movq	%rbx, 0xd8(%rsp)
-               	movq	%rdi, 0xd0(%rsp)
-               	movq	%rsi, 0xc8(%rsp)
-               	movq	%r12, 0xc0(%rsp)
-               	movq	%r13, 0xb8(%rsp)
-               	movq	%r14, 0xb0(%rsp)
-               	movq	%r15, 0xa8(%rsp)
-               	movaps	%xmm6, 0x90(%rsp)
-               	movaps	%xmm7, 0x80(%rsp)
-               	movaps	%xmm8, 0x70(%rsp)
-               	movaps	%xmm9, 0x60(%rsp)
-               	movaps	%xmm10, 0x50(%rsp)
-               	movaps	%xmm14, 0x40(%rsp)
-               	movaps	%xmm15, 0x30(%rsp)
+               	subq	$0x4c0, %rsp            # imm = 0x4C0
+               	movq	%rbx, 0xe8(%rsp)
+               	movq	%rdi, 0xe0(%rsp)
+               	movq	%rsi, 0xd8(%rsp)
+               	movq	%r12, 0xd0(%rsp)
+               	movq	%r13, 0xc8(%rsp)
+               	movq	%r14, 0xc0(%rsp)
+               	movq	%r15, 0xb8(%rsp)
+               	movaps	%xmm6, 0xa0(%rsp)
+               	movaps	%xmm7, 0x90(%rsp)
+               	movaps	%xmm8, 0x80(%rsp)
+               	movaps	%xmm9, 0x70(%rsp)
+               	movaps	%xmm10, 0x60(%rsp)
+               	movaps	%xmm11, 0x50(%rsp)
+               	movaps	%xmm12, 0x40(%rsp)
+               	movaps	%xmm14, 0x30(%rsp)
+               	movaps	%xmm15, 0x20(%rsp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, 0x138(%rsp)
-               	movq	0x138(%rsp), %r8
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L4>:
-               	leaq	0x430(%rsp), %rsi
+<L3>:
+               	leaq	0x4a0(%rsp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x101>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x108>
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xf8>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xff>
                	leaq	0x4(%rsi), %rdi
                	movss	%xmm2, (%rdi)
                	leaq	0x8(%rsi), %rdi
                	movl	$0x40700000, (%rdi)     # imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x122>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x129>
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x119>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x120>
                	leaq	0xc(%rsi), %rdi
                	movss	%xmm2, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	0x420(%rsp), %r8
-               	movq	%r8, 0x130(%rsp)
-               	movq	0x130(%rsp), %r8
+               	leaq	0x490(%rsp), %r8
+               	movq	%r8, 0x168(%rsp)
+               	movq	0x168(%rsp), %r8
                	movups	%xmm2, (%r8)
-               	leaq	0x410(%rsp), %rdi
+               	leaq	0x480(%rsp), %rdi
                	leaq	(%rdi), %r12
                	movabsq	$0x3ff4000000000000, %r11 # imm = 0x3FF4000000000000
                	movq	%r11, (%r12)
@@ -261,9 +456,11 @@ Disassembly of section .text:
                	movabsq	$-0x3ff4000000000000, %r11 # imm = 0xC00C000000000000
                	movq	%r11, (%r12)
                	movups	(%rdi), %xmm3
-               	leaq	0x400(%rsp), %rdi
-               	movups	%xmm3, (%rdi)
-               	leaq	0x3f0(%rsp), %r12
+               	leaq	0x470(%rsp), %r8
+               	movq	%r8, 0x130(%rsp)
+               	movq	0x130(%rsp), %r8
+               	movups	%xmm3, (%r8)
+               	leaq	0x460(%rsp), %r12
                	leaq	(%r12), %r13
                	movl	$0xffffffff, (%r13)     # imm = 0xFFFFFFFF
                	leaq	0x4(%r12), %r13
@@ -273,9 +470,9 @@ Disassembly of section .text:
                	leaq	0xc(%r12), %r13
                	movl	$0x12345678, (%r13)     # imm = 0x12345678
                	movups	(%r12), %xmm4
-               	leaq	0x3e0(%rsp), %r12
+               	leaq	0x450(%rsp), %r12
                	movups	%xmm4, (%r12)
-               	leaq	0x3d0(%rsp), %r13
+               	leaq	0x440(%rsp), %r13
                	leaq	(%r13), %r14
                	movabsq	$0x3fe0000000000000, %r11 # imm = 0x3FE0000000000000
                	movq	%r11, (%r14)
@@ -283,31 +480,29 @@ Disassembly of section .text:
                	movabsq	$0x4019000000000000, %r11 # imm = 0x4019000000000000
                	movq	%r11, (%r14)
                	movups	(%r13), %xmm6
-               	leaq	0x3c0(%rsp), %r13
-               	movups	%xmm6, (%r13)
-               	leaq	0x3b0(%rsp), %r14
+               	leaq	0x430(%rsp), %r13
+               	leaq	(%r13), %r14
+               	movl	$0xc2b2ae3d, (%r14)     # imm = 0xC2B2AE3D
+               	leaq	0x4(%r13), %r14
+               	movl	$0x85ebca77, (%r14)     # imm = 0x85EBCA77
+               	leaq	0x8(%r13), %r14
+               	movl	$0x7, (%r14)
+               	leaq	0xc(%r13), %r14
+               	movl	$0xfffffffb, (%r14)     # imm = 0xFFFFFFFB
+               	movups	(%r13), %xmm7
+               	leaq	0x420(%rsp), %r13
+               	movups	%xmm7, (%r13)
+               	leaq	0x340(%rsp), %r14
                	leaq	(%r14), %r15
-               	movl	$0xc2b2ae3d, (%r15)     # imm = 0xC2B2AE3D
-               	leaq	0x4(%r14), %r15
-               	movl	$0x85ebca77, (%r15)     # imm = 0x85EBCA77
-               	leaq	0x8(%r14), %r15
-               	movl	$0x7, (%r15)
-               	leaq	0xc(%r14), %r15
-               	movl	$0xfffffffb, (%r15)     # imm = 0xFFFFFFFB
-               	movups	(%r14), %xmm7
-               	leaq	0x3a0(%rsp), %r14
-               	movups	%xmm7, (%r14)
-               	leaq	0x2c0(%rsp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
+               	addq	$0x0, %r15
                	movq	$0xc0, %rsi
-<L5>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L4>:
+               	movq	$0x0, (%r15)
+               	addq	$0x8, %r15
                	subq	$0x8, %rsi
                	cmpq	$0x0, %rsi
-               	jne	 <L5>
-               	leaq	0x280(%rsp), %rsi
+               	jne	 <L4>
+               	leaq	0x300(%rsp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -316,640 +511,515 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	movq	%rbx, %rcx
-               	addq	$0x1, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, 0x128(%rsp)
-               	movq	%rbx, %rcx
-               	addq	$0x3, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, 0x120(%rsp)
-               	movq	%rbx, %rcx
-               	addq	$0x5, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, 0x118(%rsp)
-               	movq	%rbx, %rcx
-               	addq	$0x7, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, 0x110(%rsp)
-               	movq	%rbx, %rcx
-               	addq	$0xfff1, %rcx           # imm = 0xFFF1
-               	movw	%cx, %r8w
-               	movq	%r8, 0x108(%rsp)
-               	movq	%rbx, %rcx
-               	addq	$0xfb, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, 0x100(%rsp)
-               	movq	0x130(%rsp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm5
+               	movq	%rbx, %r15
+               	addq	$0x1, %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, 0x160(%rsp)
+               	movq	%rbx, %r15
+               	addq	$0x3, %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, 0x158(%rsp)
+               	movq	%rbx, %r15
+               	addq	$0x5, %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, 0x150(%rsp)
+               	movq	%rbx, %r15
+               	addq	$0x7, %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, 0x148(%rsp)
+               	movq	%rbx, %r15
+               	addq	$0xfff1, %r15           # imm = 0xFFF1
+               	movw	%r15w, %r8w
+               	movq	%r8, 0x140(%rsp)
+               	movq	%rbx, %r15
+               	addq	$0xfb, %r15
+               	movb	%r15b, %r8b
+               	movq	%r8, 0x138(%rsp)
+               	movq	0x168(%rsp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm5
                	movss	%xmm5, %xmm8            # xmm8 = xmm5[0],xmm8[1,2,3]
                	addss	%xmm0, %xmm8
-               	leaq	0x270(%rsp), %r8
-               	movq	%r8, 0xf8(%rsp)
-               	movq	0xf8(%rsp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	0xf8(%rsp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm8, (%rcx)
-               	movq	0xf8(%rsp), %r8
-               	movups	(%r8), %xmm8
-               	leaq	0x8(%rdi), %rcx
-               	movsd	(%rcx), %xmm0
+               	leaq	0x2f0(%rsp), %r15
+               	movups	%xmm2, (%r15)
+               	leaq	(%r15), %rdi
+               	movss	%xmm8, (%rdi)
+               	movups	(%r15), %xmm8
+               	movq	0x130(%rsp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movsd	(%rdi), %xmm0
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
                	addsd	%xmm1, %xmm2
-               	leaq	0x260(%rsp), %rdi
+               	leaq	0x2e0(%rsp), %rdi
                	movups	%xmm3, (%rdi)
-               	leaq	0x8(%rdi), %rcx
-               	movsd	%xmm2, (%rcx)
+               	leaq	0x8(%rdi), %r15
+               	movsd	%xmm2, (%r15)
                	movups	(%rdi), %xmm9
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	movl	%ebx, %ecx
-               	addl	%ecx, %r12d
-               	leaq	0x250(%rsp), %r8
-               	movq	%r8, 0xf0(%rsp)
-               	movq	0xf0(%rsp), %r8
-               	movups	%xmm4, (%r8)
-               	movq	0xf0(%rsp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	%r12d, (%rcx)
-               	movq	0xf0(%rsp), %r8
-               	movups	(%r8), %xmm10
-               	movq	0xf8(%rsp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	0x138(%rsp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	0x8(%r12), %rdi
+               	movl	(%rdi), %r12d
+               	movl	%ebx, %edi
+               	addl	%edi, %r12d
+               	leaq	0x2d0(%rsp), %rdi
+               	movups	%xmm4, (%rdi)
+               	leaq	0x8(%rdi), %r15
+               	movl	%r12d, (%r15)
+               	movups	(%rdi), %xmm10
+               	movups	%xmm8, 0x2c0(%rsp)
+               	leaq	0x2c0(%rsp), %r12
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%r12, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r12
+               	movups	%xmm9, 0x2b0(%rsp)
+               	leaq	0x2b0(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	0xf8(%rsp), %r8
-               	leaq	0x4(%r8), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r12
+               	movups	%xmm10, 0x2a0(%rsp)
+               	leaq	0x2a0(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	0xf8(%rsp), %r8
-               	leaq	0x8(%r8), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	0xf8(%rsp), %r8
-               	leaq	0xc(%r8), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	0xf0(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	0xf0(%rsp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	0xf0(%rsp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	0xf0(%rsp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
+               	movq	%rax, %r12
                	movaps	%xmm8, %xmm14
                	addps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x230(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm11
+               	movups	%xmm11, 0x290(%rsp)
+               	leaq	0x290(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %r12
                	movaps	%xmm8, %xmm14
                	mulps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x220(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	(%r13), %rdi
-               	movsd	(%rdi), %xmm1
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r13), %rdi
-               	movsd	(%rdi), %xmm1
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm12
+               	movups	%xmm12, 0x280(%rsp)
+               	leaq	0x280(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %r12
+               	movups	%xmm6, 0x270(%rsp)
+               	leaq	0x270(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %r12
                	movaps	%xmm9, %xmm14
                	mulpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x210(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, 0x260(%rsp)
+               	leaq	0x260(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L11>
+<L11>:
+               	movq	%rax, %r12
                	movaps	%xmm9, %xmm14
                	subpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x200(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, 0x250(%rsp)
+               	leaq	0x250(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L12>
+<L12>:
+               	movq	%rax, %r12
                	movaps	%xmm9, %xmm14
                	divpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1f0(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	leaq	(%r14), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r14), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r14), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r14), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L35>
-<L35>:
+               	movups	%xmm0, 0x240(%rsp)
+               	leaq	0x240(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L13>
+<L13>:
+               	movq	%rax, %r12
+               	movups	%xmm7, 0x230(%rsp)
+               	leaq	0x230(%rsp), %r15
+               	movq	%r12, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %r8
-               	movq	%r8, 0xe8(%rsp)
-               	movq	0xe8(%rsp), %r8
-               	movq	0xf0(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	leaq	(%r14), %rdi
-               	movl	(%rdi), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, 0xe0(%rsp)
-               	movq	0xf0(%rsp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movl	(%rdi), %r13d
-               	leaq	0x4(%r14), %rdi
-               	movl	(%rdi), %ecx
-               	imull	%ecx, %r13d
-               	movq	0xf0(%rsp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	movq	0xf0(%rsp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	0x1e0(%rsp), %rcx
-               	movups	%xmm10, (%rcx)
-               	leaq	(%rcx), %r14
-               	movq	0xe0(%rsp), %r8
-               	movl	%r8d, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	0x1d0(%rsp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movl	%r13d, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	0x1c0(%rsp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movl	%edi, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	0x1b0(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %r12d
-               	movq	0xe8(%rsp), %r8
-               	movq	%r8, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rcx
+               	movq	%r8, 0x128(%rsp)
+               	movq	0x128(%rsp), %r8
+               	leaq	(%rdi), %r15
+               	movl	(%r15), %r8d
+               	movq	%r8, 0x120(%rsp)
+               	leaq	(%r13), %r15
+               	movl	(%r15), %r12d
+               	movq	0x120(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, 0x118(%rsp)
                	leaq	0x4(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
+               	movl	(%r12), %r8d
+               	movq	%r8, 0x110(%rsp)
+               	leaq	0x4(%r13), %r12
+               	movl	(%r12), %r15d
+               	movq	0x110(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, 0x108(%rsp)
+               	leaq	0x8(%rdi), %r15
+               	movl	(%r15), %r8d
+               	movq	%r8, 0x100(%rsp)
+               	leaq	0x8(%r13), %r15
+               	movl	(%r15), %r12d
+               	movq	0x100(%rsp), %r8
+               	movl	%r8d, %r15d
+               	imull	%r12d, %r15d
                	leaq	0xc(%rdi), %r12
                	movl	(%r12), %edi
-               	movl	%edi, %edx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
+               	leaq	0xc(%r13), %r12
+               	movl	(%r12), %r13d
+               	imull	%r13d, %edi
+               	leaq	0x220(%rsp), %r12
+               	movups	%xmm10, (%r12)
+               	leaq	(%r12), %r13
+               	movq	0x118(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%r12), %xmm0
+               	leaq	0x210(%rsp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x4(%r12), %r13
+               	movq	0x108(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%r12), %xmm0
+               	leaq	0x200(%rsp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x8(%r12), %r13
+               	movl	%r15d, (%r13)
+               	movups	(%r12), %xmm0
+               	leaq	0x1f0(%rsp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0xc(%r12), %r13
+               	movl	%edi, (%r13)
+               	movups	(%r12), %xmm0
+               	movups	%xmm0, 0x1e0(%rsp)
+               	leaq	0x1e0(%rsp), %rdi
+               	movq	0x128(%rsp), %r8
+               	movq	%r8, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
                	movaps	%xmm10, %xmm14
                	paddd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1a0(%rsp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movl	(%r12), %edi
-               	movl	%edi, %edx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, 0x1d0(%rsp)
+               	leaq	0x1d0(%rsp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rdi
                	movaps	%xmm10, %xmm14
                	pxor	%xmm7, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	0x190(%rsp), %rdi
-               	movups	%xmm10, (%rdi)
-               	leaq	(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movl	(%r12), %edi
-               	movl	%edi, %edx
-               	callq	 <L47>
-<L47>:
+               	movups	%xmm10, 0x1c0(%rsp)
+               	leaq	0x1c0(%rsp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rdi
-               	movups	%xmm8, 0x180(%rsp)
-               	leaq	0x180(%rsp), %rcx
-               	callq	 <L48>
-<L48>:
+               	movups	%xmm8, 0x1b0(%rsp)
+               	leaq	0x1b0(%rsp), %r12
+               	movq	%r12, %rcx
+               	callq	 <L18>
+<L18>:
+               	movups	%xmm0, 0x1a0(%rsp)
+               	leaq	0x1a0(%rsp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movups	%xmm12, 0x190(%rsp)
+               	leaq	0x190(%rsp), %r12
+               	movq	%r12, %rcx
+               	callq	 <L20>
+<L20>:
+               	movups	%xmm0, 0x180(%rsp)
+               	leaq	0x180(%rsp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %rdi
+               	leaq	(%rsi), %r12
+               	movups	%xmm8, (%r12)
+               	leaq	0x10(%rsi), %r12
+               	movups	%xmm11, (%r12)
+               	movups	%xmm8, 0x170(%rsp)
                	leaq	0x170(%rsp), %r12
+               	movq	%r12, %rcx
+               	callq	 <L22>
+<L22>:
+               	leaq	0x20(%rsi), %r12
                	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rdi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movaps	%xmm8, %xmm14
-               	mulps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, 0x160(%rsp)
-               	leaq	0x160(%rsp), %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x150(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rdi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	leaq	(%rsi), %rcx
-               	movups	%xmm8, (%rcx)
-               	movaps	%xmm8, %xmm14
-               	addps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x10(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	movups	%xmm8, 0x140(%rsp)
-               	leaq	0x140(%rsp), %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x20(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	movaps	%xmm8, %xmm14
-               	mulps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm8
-               	leaq	0x30(%rsi), %rcx
-               	movups	%xmm8, (%rcx)
+               	leaq	0x30(%rsi), %r12
+               	movups	%xmm12, (%r12)
                	movq	$0x0, %r12
                	cmpq	$0x4, %r12
-               	jb	 <L59>
-               	jmp	 <L64>
-<L59>:
-               	movq	%r12, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %r13
-               	movups	(%r13), %xmm0
-               	leaq	0x240(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
+               	movq	%r12, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r15
+               	movups	(%r15), %xmm0
+               	movups	%xmm0, 0x4b0(%rsp)
+               	leaq	0x4b0(%rsp), %r13
                	movq	%rdi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r13), %r14
-               	movss	(%r14), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r13), %r14
-               	movss	(%r14), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r13), %r14
-               	movss	(%r14), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %rdi
                	addq	$0x1, %r12
-               	movq	%rcx, %rdi
                	cmpq	$0x4, %r12
-               	jb	 <L59>
-<L64>:
-               	movabsq	$0x1111111111111111, %rsi # imm = 0x1111111111111111
-               	addq	%rbx, %rsi
+               	jb	 <L23>
+<L25>:
+               	movabsq	$0x1111111111111111, %r8 # imm = 0x1111111111111111
+               	addq	%rbx, %r8
+               	movq	%r8, 0xf8(%rsp)
                	movabsq	$0x7777777777777777, %r12 # imm = 0x7777777777777777
                	xorq	%rbx, %r12
-               	movq	%rdi, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rdi
-               	cmpq	$0x3, %rdi
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
-               	movq	%rdi, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	0xf8(%rsp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r13
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x3, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %r12
                	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
                	imulq	%r11, %r12
                	addq	%rbx, %r12
-               	movq	%rdi, %r13
+               	movq	%rsi, %r13
                	imulq	$0x40, %r13, %r13
-               	leaq	(%r15,%r13), %r14
-               	leaq	(%r14), %r13
+               	leaq	(%r14,%r13), %r15
+               	leaq	(%r15), %r13
                	movq	%r12, (%r13)
-               	movq	%rdi, %r12
+               	movq	%rsi, %r12
                	shlq	$0x28, %r12
-               	xorq	%rsi, %r12
-               	leaq	0x8(%r14), %r13
+               	movq	0xf8(%rsp), %r8
+               	xorq	%r8, %r12
+               	leaq	0x8(%r15), %r13
                	movq	%r12, (%r13)
-               	addq	$0x1, %rdi
-               	cmpq	$0x3, %rdi
-               	jb	 <L67>
-<L68>:
-               	movq	%rcx, %rbx
-               	movq	$0x0, %rsi
-               	cmpq	$0x3, %rsi
-               	jb	 <L69>
-               	jmp	 <L72>
-<L69>:
-               	movq	%rsi, %rcx
-               	imulq	$0x40, %rcx, %rcx
-               	leaq	(%r15,%rcx), %rdi
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %r12
-               	movq	%rbx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movq	(%r12), %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rbx
                	addq	$0x1, %rsi
                	cmpq	$0x3, %rsi
-               	jb	 <L69>
-<L72>:
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %r8
+               	movq	%r8, 0xf0(%rsp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x3, %rbx
+               	jb	 <L32>
+               	jmp	 <L37>
+<L32>:
+               	movq	%rbx, %rsi
+               	imulq	$0x40, %rsi, %rsi
+               	leaq	(%r14,%rsi), %r12
+               	leaq	(%r12), %rsi
+               	movq	(%rsi), %r12
+               	movq	0xf0(%rsp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r13
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+<L34>:
+               	movq	%rbx, %rdi
+               	imulq	$0x40, %rdi, %rdi
+               	leaq	(%r14,%rdi), %r12
+               	leaq	0x8(%r12), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+<L36>:
+               	addq	$0x1, %rbx
+               	movq	%rsi, %r8
+               	movq	%r8, 0xf0(%rsp)
+               	cmpq	$0x3, %rbx
+               	jb	 <L32>
+<L37>:
+               	movq	0x160(%rsp), %r8
+               	movzbq	%r8b, %rbx
+               	movq	0xf0(%rsp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L38>
+<L39>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x0, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L40>
+<L41>:
+               	movq	0x158(%rsp), %r8
+               	movzbq	%r8b, %rbx
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %rbx
+               	movq	0x150(%rsp), %r8
+               	movzbq	%r8b, %rsi
                	movq	%rbx, %rcx
-               	movq	0x128(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rdx
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movq	0x120(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rcx
-               	movq	0x118(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rcx
-               	movq	0x110(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rcx
-               	movq	0x108(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rcx
-               	movq	0x100(%rsp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	0x90(%rsp), %xmm6
-               	movaps	0x80(%rsp), %xmm7
-               	movaps	0x70(%rsp), %xmm8
-               	movaps	0x60(%rsp), %xmm9
-               	movaps	0x50(%rsp), %xmm10
-               	movaps	0x40(%rsp), %xmm14
-               	movaps	0x30(%rsp), %xmm15
-               	movq	0xd8(%rsp), %rbx
-               	movq	0xd0(%rsp), %rdi
-               	movq	0xc8(%rsp), %rsi
-               	movq	0xc0(%rsp), %r12
-               	movq	0xb8(%rsp), %r13
-               	movq	0xb0(%rsp), %r14
-               	movq	0xa8(%rsp), %r15
+               	movq	%rsi, %rdx
+               	callq	 <L43>
+<L43>:
+               	movq	%rax, %rbx
+               	movq	0x148(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %rbx
+               	movq	0x140(%rsp), %r8
+               	movzwq	%r8w, %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L45>
+<L45>:
+               	movq	%rax, %rbx
+               	movq	0x138(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rax
+               	movaps	0xa0(%rsp), %xmm6
+               	movaps	0x90(%rsp), %xmm7
+               	movaps	0x80(%rsp), %xmm8
+               	movaps	0x70(%rsp), %xmm9
+               	movaps	0x60(%rsp), %xmm10
+               	movaps	0x50(%rsp), %xmm11
+               	movaps	0x40(%rsp), %xmm12
+               	movaps	0x30(%rsp), %xmm14
+               	movaps	0x20(%rsp), %xmm15
+               	movq	0xe8(%rsp), %rbx
+               	movq	0xe0(%rsp), %rdi
+               	movq	0xd8(%rsp), %rsi
+               	movq	0xd0(%rsp), %r12
+               	movq	0xc8(%rsp), %r13
+               	movq	0xc0(%rsp), %r14
+               	movq	0xb8(%rsp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/frame/frame_large.dis
+++ b/test/golden/x86_64-windows/frame/frame_large.dis
@@ -5,7 +5,7 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x20a0, %r11           # imm = 0x20A0
+               	movq	$0x2060, %r11           # imm = 0x2060
 <L0>:
                	subq	$0x1000, %rsp           # imm = 0x1000
                	movq	%r11, (%rsp)
@@ -13,283 +13,550 @@ Disassembly of section .text:
                	cmpq	$0x1000, %r11           # imm = 0x1000
                	ja	 <L0>
                	subq	%r11, %rsp
-               	movq	%rbx, -0x2048(%rbp)
-               	movq	%rdi, -0x2050(%rbp)
-               	movq	%rsi, -0x2058(%rbp)
-               	movq	%r12, -0x2060(%rbp)
-               	movq	%r13, -0x2068(%rbp)
-               	movq	%r14, -0x2070(%rbp)
-               	movq	%r15, -0x2078(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	leaq	-0x1400(%rbp), %rsi
-               	leaq	(%rsi), %rdi
+               	movq	%rbx, -0x2028(%rbp)
+               	movq	%rdi, -0x2030(%rbp)
+               	movq	%rsi, -0x2038(%rbp)
+               	movq	%r12, -0x2040(%rbp)
+               	movq	%r13, -0x2048(%rbp)
+               	movq	%r14, -0x2050(%rbp)
+               	movq	%r15, -0x2058(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x2020(%rbp)
+               	leaq	-0x1400(%rbp), %r8
+               	movq	%r8, -0x2018(%rbp)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %rdi
                	addq	$0x0, %rdi
                	movq	$0x1400, %r12           # imm = 0x1400
-<L2>:
+<L1>:
                	movq	$0x0, (%rdi)
                	addq	$0x8, %rdi
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L2>
-               	leaq	-0x1c00(%rbp), %rdi
-               	leaq	(%rdi), %r12
+               	jne	 <L1>
+               	leaq	-0x1c00(%rbp), %r8
+               	movq	%r8, -0x2010(%rbp)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %r12
                	addq	$0x0, %r12
                	movq	$0x800, %r13            # imm = 0x800
-<L3>:
+<L2>:
                	movq	$0x0, (%r12)
                	addq	$0x8, %r12
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
-               	jne	 <L3>
-               	leaq	-0x2000(%rbp), %r12
-               	leaq	(%r12), %r13
+               	jne	 <L2>
+               	leaq	-0x2000(%rbp), %r8
+               	movq	%r8, -0x2008(%rbp)
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8), %r13
                	addq	$0x0, %r13
                	movq	$0x400, %r14            # imm = 0x400
-<L4>:
+<L3>:
                	movq	$0x0, (%r13)
                	addq	$0x8, %r13
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L4>
-               	leaq	(%rsi), %r13
+               	jne	 <L3>
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %r13
                	movq	(%r13), %r14
-               	movq	%r14, %rdx
-               	callq	 <L5>
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r15, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %rdi
+               	xorq	%r12, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x13f8(%rsi), %r13
-               	movq	(%r13), %r14
-               	movq	%r14, %rdx
-               	callq	 <L6>
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	(%rdi), %r13
-               	movl	(%r13), %r14d
-               	movl	%r14d, %edx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x7fc(%rdi), %r13
-               	movl	(%r13), %r14d
-               	movl	%r14d, %edx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	leaq	(%r12), %r13
-               	movzbl	(%r13), %r14d
-               	movq	%r14, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0x3ff(%r12), %r13
-               	movzbl	(%r13), %r14d
-               	movq	%r14, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %r13
-               	cmpq	$0x280, %r13            # imm = 0x280
-               	jb	 <L11>
-               	jmp	 <L12>
-<L11>:
-               	movq	%r13, %r14
-               	addq	%rbx, %r14
-               	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %r14
-               	movq	%r13, %r15
-               	shlq	$0x11, %r15
-               	xorq	%r15, %r14
-               	leaq	(%rsi,%r13,8), %r15
-               	movq	%r14, (%r15)
-               	addq	$0x1, %r13
-               	cmpq	$0x280, %r13            # imm = 0x280
-               	jb	 <L11>
-<L12>:
-               	movq	$0x0, %r13
-               	cmpq	$0x200, %r13            # imm = 0x200
-               	jb	 <L13>
-               	jmp	 <L14>
-<L13>:
-               	movq	%r13, %r14
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %r14
-               	addq	%rbx, %r14
-               	movq	%r13, %r15
-               	shrq	$0x3, %r15
-               	xorq	%r15, %r14
-               	movl	%r14d, %r15d
-               	leaq	(%rdi,%r13,4), %r14
-               	movl	%r15d, (%r14)
-               	addq	$0x1, %r13
-               	cmpq	$0x200, %r13            # imm = 0x200
-               	jb	 <L13>
-<L14>:
-               	movq	$0x0, %r13
-               	cmpq	$0x400, %r13            # imm = 0x400
-               	jb	 <L15>
-               	jmp	 <L16>
-<L15>:
-               	movq	%r13, %r14
-               	imulq	$0x83, %r14, %r14
-               	addq	%rbx, %r14
-               	movq	%r13, %r15
-               	shrq	$0x2, %r15
-               	xorq	%r15, %r14
-               	movb	%r14b, %r15b
-               	leaq	(%r12,%r13), %r14
-               	movb	%r15b, (%r14)
-               	addq	$0x1, %r13
-               	cmpq	$0x400, %r13            # imm = 0x400
-               	jb	 <L15>
-<L16>:
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x40, %r14
-               	jb	 <L17>
-               	jmp	 <L21>
-<L17>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x280, %rcx            # imm = 0x280
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%rsi,%rcx,8), %r15
-               	movq	(%r15), %r8
-               	movq	%r8, -0x2008(%rbp)
-               	movq	%r13, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+<L7>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+<L9>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rdi
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
+<L11>:
                	movq	-0x2008(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x2010(%rbp)
-               	movq	-0x2010(%rbp), %r8
-               	movq	%r14, %r15
-               	imulq	$0xd, %r15, %r15
-               	addq	%rbx, %r15
-               	movq	%r15, %rax
-               	movq	$0x200, %r15            # imm = 0x200
-               	xorl	%edx, %edx
-               	divq	%r15
-               	movq	%rdx, %r15
-               	leaq	(%rdi,%r15,4), %rcx
-               	movl	(%rcx), %r15d
-               	movq	-0x2010(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x2018(%rbp)
-               	movq	-0x2018(%rbp), %r8
-               	movq	%r14, %r15
-               	imulq	$0x1d, %r15, %r15
-               	addq	%rbx, %r15
-               	movq	%r15, %rax
-               	movq	$0x400, %r15            # imm = 0x400
-               	xorl	%edx, %edx
-               	divq	%r15
-               	movq	%rdx, %r15
-               	leaq	(%r12,%r15), %rcx
-               	movzbl	(%rcx), %r15d
-               	movq	-0x2018(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %r13
-               	addq	$0x1, %r14
-               	cmpq	$0x40, %r14
-               	jb	 <L17>
-<L21>:
-               	leaq	0x13f8(%rsi), %r14
-               	movq	(%r14), %rcx
-               	movq	%rcx, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x2020(%rbp)
-               	movq	%rbx, %r15
-               	andq	$0x1, %r15
-               	movq	$0x27f, %rcx            # imm = 0x27F
-               	subq	%r15, %rcx
-               	leaq	(%rsi,%rcx,8), %r15
+               	leaq	(%r8), %rdi
+               	movzbl	(%rdi), %r12d
+               	movzbq	%r12b, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L12>
+<L13>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rdi
+               	movzbl	(%rdi), %r12d
+               	movzbq	%r12b, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+<L15>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x280, %rdi            # imm = 0x280
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
                	movq	-0x2020(%rbp), %r8
-               	movq	%r8, (%r15)
-               	leaq	0x7fc(%rdi), %r15
-               	movl	(%r15), %ecx
-               	movl	%ecx, %r8d
-               	addl	$0x7, %r8d
-               	movq	%r8, -0x2028(%rbp)
-               	movq	%rbx, %rcx
-               	andq	$0x3, %rcx
-               	movq	$0x1ff, %r8             # imm = 0x1FF
-               	subq	%rcx, %r8
-               	movq	%r8, -0x2030(%rbp)
-               	movq	-0x2030(%rbp), %r8
-               	leaq	(%rdi,%r8,4), %rcx
-               	movq	-0x2028(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	leaq	0x3ff(%r12), %r8
-               	movq	%r8, -0x2038(%rbp)
-               	movq	-0x2038(%rbp), %r8
-               	movzbl	(%r8), %ecx
-               	movl	%ecx, %r8d
-               	addl	$0xb, %r8d
-               	movq	%r8, -0x2040(%rbp)
-               	andq	$0x7, %rbx
-               	movq	$0x3ff, %rcx            # imm = 0x3FF
-               	subq	%rbx, %rcx
-               	leaq	(%r12,%rcx), %rbx
-               	movq	-0x2040(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	leaq	0x13f0(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	movq	%r13, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L22>
+               	movq	%rdi, %r12
+               	addq	%r8, %r12
+               	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
+               	imulq	%r11, %r12
+               	movq	%rdi, %r14
+               	shlq	$0x11, %r14
+               	xorq	%r14, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rdi,8), %r14
+               	movq	%r12, (%r14)
+               	addq	$0x1, %rdi
+               	cmpq	$0x280, %rdi            # imm = 0x280
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %r12
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rdi, %r14
+               	shrq	$0x3, %r14
+               	xorq	%r14, %r12
+               	movl	%r12d, %r14d
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	%r14d, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L18>
+<L19>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r12
+               	imulq	$0x83, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rdi, %r14
+               	shrq	$0x2, %r14
+               	xorq	%r14, %r12
+               	movb	%r12b, %r14b
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rdi), %r12
+               	movb	%r14b, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x40, %rdi
+               	jb	 <L22>
+               	jmp	 <L29>
 <L22>:
-               	movq	%rax, %rcx
-               	movq	(%r14), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L23>
+               	movq	%rdi, %r12
+               	imulq	$0x9, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%r12, %rax
+               	movq	$0x280, %r12            # imm = 0x280
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r14
+               	movq	(%r14), %r12
+               	movq	%r13, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	movq	%rax, %rcx
-               	leaq	0x7f0(%rdi), %rbx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L24>
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L23>
 <L24>:
-               	movq	%rax, %rcx
-               	movl	(%r15), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L25>
+               	movq	%rdi, %rbx
+               	imulq	$0xd, %rbx, %rbx
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rbx
+               	movq	%rbx, %rax
+               	movq	$0x200, %rbx            # imm = 0x200
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movl	(%rsi), %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	movq	%rax, %rcx
-               	leaq	0x3f8(%r12), %rbx
-               	movzbl	(%rbx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L26>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
 <L26>:
-               	movq	%rax, %rcx
-               	movq	-0x2038(%rbp), %r8
-               	movzbl	(%r8), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L27>
+               	movq	%rdi, %rbx
+               	imulq	$0x1d, %rbx, %rbx
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rbx
+               	movq	%rbx, %rax
+               	movq	$0x400, %rbx            # imm = 0x400
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rbx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x2048(%rbp), %rbx
-               	movq	-0x2050(%rbp), %rdi
-               	movq	-0x2058(%rbp), %rsi
-               	movq	-0x2060(%rbp), %r12
-               	movq	-0x2068(%rbp), %r13
-               	movq	-0x2070(%rbp), %r14
-               	movq	-0x2078(%rbp), %r15
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L27>
+<L28>:
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x40, %rdi
+               	jb	 <L22>
+<L29>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rbx
+               	movq	(%rbx), %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rbx
+               	andq	$0x1, %rbx
+               	movq	$0x27f, %rdi            # imm = 0x27F
+               	subq	%rbx, %rdi
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rdi,8), %rbx
+               	movq	%rsi, (%rbx)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rbx
+               	movl	(%rbx), %esi
+               	addl	$0x7, %esi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rbx
+               	andq	$0x3, %rbx
+               	movq	$0x1ff, %rdi            # imm = 0x1FF
+               	subq	%rbx, %rdi
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movl	%esi, (%rbx)
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rbx
+               	movzbl	(%rbx), %esi
+               	addl	$0xb, %esi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rbx
+               	andq	$0x7, %rbx
+               	movq	$0x3ff, %rdi            # imm = 0x3FF
+               	subq	%rbx, %rdi
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rdi), %rbx
+               	movb	%sil, (%rbx)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f0(%r8), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L32>
+<L33>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7f0(%r8), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+<L35>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L36>
+<L37>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3f8(%r8), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+<L39>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+<L41>:
+               	movq	%r13, %rax
+               	movq	-0x2028(%rbp), %rbx
+               	movq	-0x2030(%rbp), %rdi
+               	movq	-0x2038(%rbp), %rsi
+               	movq	-0x2040(%rbp), %r12
+               	movq	-0x2048(%rbp), %r13
+               	movq	-0x2050(%rbp), %r14
+               	movq	-0x2058(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/frame/frame_spill.dis
+++ b/test/golden/x86_64-windows/frame/frame_spill.dis
@@ -27,122 +27,120 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_spill.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2a0, %rsp            # imm = 0x2A0
-               	movq	%rbx, -0x1a8(%rbp)
-               	movq	%rdi, -0x1b0(%rbp)
-               	movq	%rsi, -0x1b8(%rbp)
-               	movq	%r12, -0x1c0(%rbp)
-               	movq	%r13, -0x1c8(%rbp)
-               	movq	%r14, -0x1d0(%rbp)
-               	movq	%r15, -0x1d8(%rbp)
-               	movaps	%xmm6, -0x1f0(%rbp)
-               	movaps	%xmm7, -0x200(%rbp)
-               	movaps	%xmm8, -0x210(%rbp)
-               	movaps	%xmm9, -0x220(%rbp)
-               	movaps	%xmm10, -0x230(%rbp)
-               	movaps	%xmm11, -0x240(%rbp)
-               	movaps	%xmm12, -0x250(%rbp)
-               	movaps	%xmm13, -0x260(%rbp)
-               	movaps	%xmm14, -0x270(%rbp)
-               	movaps	%xmm15, -0x280(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
+               	subq	$0x420, %rsp            # imm = 0x420
+               	movq	%rbx, -0x328(%rbp)
+               	movq	%rdi, -0x330(%rbp)
+               	movq	%rsi, -0x338(%rbp)
+               	movq	%r12, -0x340(%rbp)
+               	movq	%r13, -0x348(%rbp)
+               	movq	%r14, -0x350(%rbp)
+               	movq	%r15, -0x358(%rbp)
+               	movaps	%xmm6, -0x370(%rbp)
+               	movaps	%xmm7, -0x380(%rbp)
+               	movaps	%xmm8, -0x390(%rbp)
+               	movaps	%xmm9, -0x3a0(%rbp)
+               	movaps	%xmm10, -0x3b0(%rbp)
+               	movaps	%xmm11, -0x3c0(%rbp)
+               	movaps	%xmm12, -0x3d0(%rbp)
+               	movaps	%xmm13, -0x3e0(%rbp)
+               	movaps	%xmm14, -0x3f0(%rbp)
+               	movaps	%xmm15, -0x400(%rbp)
+               	movq	%rcx, %rax
                	movabsq	$0x5851f42d4c957f2d, %r8 # imm = 0x5851F42D4C957F2D
-               	addq	%rbx, %r8
+               	addq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-               	movabsq	$0x14057b7ef767814f, %rdx # imm = 0x14057B7EF767814F
-               	xorq	%rbx, %rdx
+               	movabsq	$0x14057b7ef767814f, %rbx # imm = 0x14057B7EF767814F
+               	xorq	%rax, %rbx
                	movabsq	$-0x61c8864680b583eb, %rsi # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rsi
+               	addq	%rax, %rsi
                	movabsq	$-0x3d4d51c2d82b14b1, %rdi # imm = 0xC2B2AE3D27D4EB4F
-               	xorq	%rbx, %rdi
+               	xorq	%rax, %rdi
                	movabsq	$0x165667b19e3779f9, %r12 # imm = 0x165667B19E3779F9
-               	addq	%rbx, %r12
+               	addq	%rax, %r12
                	movabsq	$-0x7a1435883d4d519d, %r13 # imm = 0x85EBCA77C2B2AE63
-               	xorq	%rbx, %r13
+               	xorq	%rax, %r13
                	movabsq	$0x27d4eb2f165667c5, %r14 # imm = 0x27D4EB2F165667C5
-               	addq	%rbx, %r14
+               	addq	%rax, %r14
                	movabsq	$0x72a63cd72e2d1e61, %r15 # imm = 0x72A63CD72E2D1E61
-               	xorq	%rbx, %r15
+               	xorq	%rax, %r15
                	movabsq	$0x42f1ea7f85a51475, %r8 # imm = 0x42F1EA7F85A51475
-               	addq	%rbx, %r8
+               	addq	%rax, %r8
                	movq	%r8, -0x8(%rbp)
                	movabsq	$0x30befe08be84df1f, %r8 # imm = 0x30BEFE08BE84DF1F
-               	xorq	%rbx, %r8
+               	xorq	%rax, %r8
                	movq	%r8, -0x10(%rbp)
                	movabsq	$0x61c8864680b583eb, %r8 # imm = 0x61C8864680B583EB
-               	addq	%rbx, %r8
+               	addq	%rax, %r8
                	movq	%r8, -0x18(%rbp)
                	movabsq	$0x4cf43f349dbb99b1, %r8 # imm = 0x4CF43F349DBB99B1
-               	xorq	%rbx, %r8
+               	xorq	%rax, %r8
                	movq	%r8, -0x20(%rbp)
                	movabsq	$-0x5555555555555555, %r8 # imm = 0xAAAAAAAAAAAAAAAB
-               	addq	%rbx, %r8
+               	addq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
                	movabsq	$-0x25c1c6346b46a425, %r8 # imm = 0xDA3E39CB94B95BDB
-               	xorq	%rbx, %r8
+               	xorq	%rax, %r8
                	movq	%r8, -0x30(%rbp)
                	movabsq	$0x1f2e512d5ac22ad1, %r8 # imm = 0x1F2E512D5AC22AD1
-               	addq	%rbx, %r8
+               	addq	%rax, %r8
                	movq	%r8, -0x38(%rbp)
                	movabsq	$0x2d54e746111a977f, %r8 # imm = 0x2D54E746111A977F
-               	xorq	%rbx, %r8
+               	xorq	%rax, %r8
                	movq	%r8, -0x40(%rbp)
-               	movabsq	$0x9e3779b1, %rcx       # imm = 0x9E3779B1
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x9e3779b1, %rdx       # imm = 0x9E3779B1
+               	addq	%rax, %rdx
+               	movl	%edx, %r8d
                	movq	%r8, -0x50(%rbp)
-               	movq	$0x9e37, %rcx           # imm = 0x9E37
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movq	$0x9e37, %rdx           # imm = 0x9E37
+               	xorq	%rax, %rdx
+               	movl	%edx, %r8d
                	movq	%r8, -0x58(%rbp)
-               	movabsq	$0x85ebca77, %rcx       # imm = 0x85EBCA77
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x85ebca77, %rdx       # imm = 0x85EBCA77
+               	addq	%rax, %rdx
+               	movl	%edx, %r8d
                	movq	%r8, -0x60(%rbp)
-               	movabsq	$0xc2b2ae3d, %rcx       # imm = 0xC2B2AE3D
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0xc2b2ae3d, %rdx       # imm = 0xC2B2AE3D
+               	xorq	%rax, %rdx
+               	movl	%edx, %r8d
                	movq	%r8, -0x68(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x207>
+<L1>:
+               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x202>
                	addsd	%xmm0, %xmm1
-               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x213>
+               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x20e>
                	addsd	%xmm0, %xmm2
-               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x21f>
+               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x21a>
                	addsd	%xmm0, %xmm3
-               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x22b>
+               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x226>
                	addsd	%xmm0, %xmm4
-               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x237>
+               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x232>
                	addsd	%xmm0, %xmm5
-               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x243>
+               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x23e>
                	addsd	%xmm0, %xmm6
-               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x24f>
+               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x24a>
                	addsd	%xmm0, %xmm7
-               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x25c>
+               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x257>
                	addsd	%xmm0, %xmm8
-               	movq	%rax, %r8
-               	movq	%r8, -0xd8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x108(%rbp)
                	movq	-0x48(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	%rdx, %r8
                	movq	%r8, -0x70(%rbp)
                	movq	%r14, %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r8, -0x120(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0xd8(%rbp)
                	movq	-0x8(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x78(%rbp)
@@ -184,457 +182,817 @@ Disassembly of section .text:
                	movsd	%xmm3, %xmm11           # xmm11 = xmm3[0],xmm11[1]
                	movsd	%xmm4, %xmm12           # xmm12 = xmm4[0],xmm12[1]
                	movsd	%xmm5, %xmm13           # xmm13 = xmm5[0],xmm13[1]
-               	movq	$0x0, %rbx
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
-               	jmp	 <L7>
-<L3>:
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x1d, %rcx
+               	movq	$0x0, %r15
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+               	jmp	 <L6>
+<L2>:
+               	movq	-0xb0(%rbp), %r9
+               	movq	%r9, %r8
+               	shlq	$0x1d, %r8
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x23, %rdx
-               	orq	%rdx, %rcx
-               	movq	-0x198(%rbp), %r9
+               	movq	-0xe0(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x7, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	shrq	$0x39, %rdx
-               	orq	%rdx, %rcx
+               	orq	%rdx, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0x70(%rbp), %r9
+               	movq	-0xe8(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0xf0(%rbp)
                	movq	-0x70(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0xb, %rcx
+               	shlq	$0x7, %r8
+               	movq	%r8, -0xf8(%rbp)
                	movq	-0x70(%rbp), %r8
                	movq	%r8, %rdx
+               	shrq	$0x39, %rdx
+               	movq	-0xf8(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%rbx, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	%rbx, %r8
+               	shlq	$0xb, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	%rbx, %rdx
                	shrq	$0x35, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x110(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	movq	%rsi, %r14
+               	xorq	%r8, %r14
                	movq	%rsi, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	%rsi, %rcx
-               	shlq	$0xd, %rcx
+               	shlq	$0xd, %r8
+               	movq	%r8, -0x128(%rbp)
                	movq	%rsi, %rdx
                	shrq	$0x33, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x128(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r9
                	movq	%rdi, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	%rdi, %rcx
-               	shlq	$0x11, %rcx
+               	addq	%r9, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	%rdi, %r8
+               	shlq	$0x11, %r8
+               	movq	%r8, -0x140(%rbp)
                	movq	%rdi, %rdx
                	shrq	$0x2f, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x140(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x148(%rbp), %r9
                	movq	%r12, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	%r12, %rcx
-               	shlq	$0x13, %rcx
+               	xorq	%r9, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	%r12, %r8
+               	shlq	$0x13, %r8
+               	movq	%r8, -0x158(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x2d, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x158(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r9
                	movq	%r13, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	%r13, %rcx
-               	shlq	$0x17, %rcx
+               	addq	%r9, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%r13, %r8
+               	shlq	$0x17, %r8
+               	movq	%r8, -0x170(%rbp)
                	movq	%r13, %rdx
                	shrq	$0x29, %rdx
-               	orq	%rdx, %rcx
-               	movq	-0x160(%rbp), %r9
+               	movq	-0x170(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x1f, %rcx
-               	movq	-0x160(%rbp), %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x120(%rbp), %r9
+               	movq	-0x178(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x120(%rbp), %r9
+               	movq	%r9, %r8
+               	shlq	$0x1f, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x120(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x21, %rdx
-               	orq	%rdx, %rcx
-               	movq	%r15, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r15, %rcx
-               	shlq	$0x25, %rcx
-               	movq	%r15, %rdx
+               	movq	-0x188(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0xd8(%rbp), %r9
+               	movq	-0x190(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	shlq	$0x25, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
                	shrq	$0x1b, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x1a0(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x78(%rbp), %r9
+               	movq	-0x1a8(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x1b0(%rbp)
                	movq	-0x78(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x29, %rcx
+               	shlq	$0x29, %r8
+               	movq	%r8, -0x1b8(%rbp)
                	movq	-0x78(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x17, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x80(%rbp), %r9
+               	movq	-0x1c0(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x1c8(%rbp)
                	movq	-0x80(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x2b, %rcx
+               	shlq	$0x2b, %r8
+               	movq	%r8, -0x1d0(%rbp)
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x15, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x1d0(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x88(%rbp), %r9
+               	movq	-0x1d8(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x1e0(%rbp)
                	movq	-0x88(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x130(%rbp)
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x2f, %rcx
+               	shlq	$0x2f, %r8
+               	movq	%r8, -0x1e8(%rbp)
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x11, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x1e8(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x90(%rbp), %r9
+               	movq	-0x1f0(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x1f8(%rbp)
                	movq	-0x90(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x138(%rbp)
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x35, %rcx
+               	shlq	$0x35, %r8
+               	movq	%r8, -0x200(%rbp)
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0xb, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x98(%rbp), %r9
+               	movq	-0x208(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x210(%rbp)
                	movq	-0x98(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x3b, %rcx
+               	shlq	$0x3b, %r8
+               	movq	%r8, -0x218(%rbp)
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x5, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x218(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0xa0(%rbp), %r9
+               	movq	-0x220(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x228(%rbp)
                	movq	-0xa0(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x148(%rbp)
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x3d, %rcx
+               	shlq	$0x3d, %r8
+               	movq	%r8, -0x230(%rbp)
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x3, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x230(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0xa8(%rbp), %r9
+               	movq	-0x238(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x240(%rbp)
                	movq	-0xa8(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rcx, %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rcx
-               	shlq	$0x3, %rcx
+               	shlq	$0x3, %r8
+               	movq	%r8, -0x248(%rbp)
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x3d, %rdx
-               	orq	%rdx, %rcx
+               	movq	-0x248(%rbp), %r9
+               	movq	%r9, %r8
+               	orq	%rdx, %r8
+               	movq	%r8, -0x250(%rbp)
                	movq	-0xb0(%rbp), %r9
+               	movq	-0x250(%rbp), %r10
                	movq	%r9, %r8
-               	addq	%rcx, %r8
-               	movq	%r8, -0x158(%rbp)
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %r14
-               	addq	%rbx, %r14
-               	movq	-0x148(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	-0xb8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	xorl	%ecx, %r8d
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	-0xc0(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%ecx, %r8d
-               	movq	%r8, -0x170(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	-0xc8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	xorl	%ecx, %r8d
-               	movq	%r8, -0x178(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	-0xd0(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%ecx, %r8d
-               	movq	%r8, -0x180(%rbp)
-               	movsd	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x699>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	%xmm10, %xmm14
-               	movsd	%xmm14, -0x190(%rbp)
-               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6b9>
-               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
-               	addsd	%xmm11, %xmm10
-               	movsd	%xmm11, %xmm0           # xmm0 = xmm11[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6d0>
-               	movsd	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1]
-               	addsd	%xmm12, %xmm11
-               	movsd	%xmm12, %xmm0           # xmm0 = xmm12[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6e7>
-               	movsd	%xmm0, %xmm12           # xmm12 = xmm0[0],xmm12[1]
-               	addsd	%xmm13, %xmm12
-               	movsd	%xmm13, %xmm0           # xmm0 = xmm13[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6fe>
-               	movsd	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1]
-               	addsd	%xmm6, %xmm13
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x714>
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	addsd	%xmm7, %xmm6
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x728>
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	addsd	%xmm8, %xmm7
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x73e>
-               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	addsd	%xmm9, %xmm8
-               	movq	-0xe8(%rbp), %r8
-               	movq	-0x128(%rbp), %r9
-               	movq	%r8, %rdx
-               	xorq	%r9, %rdx
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	movq	-0x170(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	movsd	-0x190(%rbp), %xmm1
-               	addsd	%xmm13, %xmm1
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rbx
-               	movq	%rcx, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xe8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x198(%rbp)
+               	addq	%r10, %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	-0xf0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	-0xf8(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	-0x100(%rbp), %r8
-               	movq	%r8, %rdi
+               	addq	%r15, %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	-0xb8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	xorl	%edx, %r8d
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	-0xc0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	addl	%edx, %r8d
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	-0xc8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	xorl	%edx, %r8d
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	-0xd0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	addl	%edx, %r8d
+               	movq	%r8, -0x280(%rbp)
+               	movsd	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x88b>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm10, %xmm14
+               	movsd	%xmm14, -0x2d8(%rbp)
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x8ab>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm11, %xmm14
+               	movsd	%xmm14, -0x2e8(%rbp)
+               	movsd	%xmm11, %xmm0           # xmm0 = xmm11[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x8cb>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm12, %xmm14
+               	movsd	%xmm14, -0x2f8(%rbp)
+               	movsd	%xmm12, %xmm0           # xmm0 = xmm12[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x8eb>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm13, %xmm14
+               	movsd	%xmm14, -0x308(%rbp)
+               	movsd	%xmm13, %xmm0           # xmm0 = xmm13[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x90b>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm6, %xmm14
+               	movsd	%xmm14, -0x318(%rbp)
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x92a>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm7, %xmm14
+               	movsd	%xmm14, -0x290(%rbp)
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x949>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm8, %xmm14
+               	movsd	%xmm14, -0x2a0(%rbp)
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x969>
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	addsd	%xmm9, %xmm14
+               	movsd	%xmm14, -0x2b0(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r9
+               	movq	%r8, %rdx
+               	xorq	%r9, %rdx
                	movq	-0x108(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0x110(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	-0x118(%rbp), %r9
+               	movq	%r8, %rcx
+               	callq	 <L3>
+<L3>:
+               	movq	%rax, %rdx
+               	movq	-0x270(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rdx
+               	movsd	-0x2d8(%rbp), %xmm0
+               	addsd	-0x318(%rbp), %xmm0
+               	movq	%xmm0, %r8
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	%rdx, %rcx
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x2c8(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	-0x128(%rbp), %r9
+               	movq	%r8, -0x70(%rbp)
+               	movq	%r14, %rbx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	-0x198(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	-0x1c8(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x78(%rbp)
-               	movq	-0x130(%rbp), %r9
+               	movq	-0x1e0(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x80(%rbp)
-               	movq	-0x138(%rbp), %r9
+               	movq	-0x1f8(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x88(%rbp)
-               	movq	-0x140(%rbp), %r9
+               	movq	-0x210(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x90(%rbp)
-               	movq	-0x148(%rbp), %r9
+               	movq	-0x228(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x98(%rbp)
-               	movq	-0x150(%rbp), %r9
+               	movq	-0x240(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xa0(%rbp)
-               	movq	-0x158(%rbp), %r9
+               	movq	-0x258(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xa8(%rbp)
-               	movq	%r14, %r8
+               	movq	-0x260(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0xb0(%rbp)
-               	movq	-0x170(%rbp), %r9
+               	movq	-0x270(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0x178(%rbp), %r9
+               	movq	-0x278(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xc0(%rbp)
-               	movq	-0x180(%rbp), %r9
+               	movq	-0x280(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xc8(%rbp)
-               	movq	-0x168(%rbp), %r9
+               	movq	-0x268(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xd0(%rbp)
-               	movsd	-0x190(%rbp), %xmm9
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
+               	movsd	-0x2d8(%rbp), %xmm9
+               	movsd	-0x2e8(%rbp), %xmm10
+               	movsd	-0x2f8(%rbp), %xmm11
+               	movsd	-0x308(%rbp), %xmm12
+               	movsd	-0x318(%rbp), %xmm13
+               	movsd	-0x290(%rbp), %xmm6
+               	movsd	-0x2a0(%rbp), %xmm7
+               	movsd	-0x2b0(%rbp), %xmm8
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+<L6>:
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
                	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L9>
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L10>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
 <L10>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L11>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L12>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
 <L12>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L13>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	%rax, %rcx
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L14>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
 <L14>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L15>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r12, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L17>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	movq	%rax, %rcx
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L18>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r13, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L19>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L20>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
 <L20>:
-               	movq	%rax, %rcx
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L21>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	movq	%rax, %rcx
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L22>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
 <L22>:
-               	movq	%rax, %rcx
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L23>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	movq	%rax, %rcx
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x78(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+<L24>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+<L26>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+<L28>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+<L30>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+<L32>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	movq	-0xb8(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L24>
-<L24>:
                	movq	%rax, %rcx
+               	callq	 <L39>
+<L39>:
                	movq	-0xc0(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L25>
-<L25>:
                	movq	%rax, %rcx
+               	callq	 <L40>
+<L40>:
                	movq	-0xc8(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L26>
-<L26>:
                	movq	%rax, %rcx
+               	callq	 <L41>
+<L41>:
                	movq	-0xd0(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L27>
-<L27>:
                	movq	%rax, %rcx
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L28>
-<L28>:
+               	callq	 <L42>
+<L42>:
+               	movq	%xmm9, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L29>
-<L29>:
+               	callq	 <L43>
+<L43>:
+               	movq	%xmm10, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
-               	callq	 <L30>
-<L30>:
+               	callq	 <L44>
+<L44>:
+               	movq	%xmm11, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L45>
+<L45>:
+               	movq	%xmm12, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1]
-               	callq	 <L32>
-<L32>:
+               	callq	 <L46>
+<L46>:
+               	movq	%xmm13, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	callq	 <L33>
-<L33>:
+               	callq	 <L47>
+<L47>:
+               	movq	%xmm6, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L34>
-<L34>:
+               	callq	 <L48>
+<L48>:
+               	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L35>
-<L35>:
-               	movaps	-0x1f0(%rbp), %xmm6
-               	movaps	-0x200(%rbp), %xmm7
-               	movaps	-0x210(%rbp), %xmm8
-               	movaps	-0x220(%rbp), %xmm9
-               	movaps	-0x230(%rbp), %xmm10
-               	movaps	-0x240(%rbp), %xmm11
-               	movaps	-0x250(%rbp), %xmm12
-               	movaps	-0x260(%rbp), %xmm13
-               	movaps	-0x270(%rbp), %xmm14
-               	movaps	-0x280(%rbp), %xmm15
-               	movq	-0x1a8(%rbp), %rbx
-               	movq	-0x1b0(%rbp), %rdi
-               	movq	-0x1b8(%rbp), %rsi
-               	movq	-0x1c0(%rbp), %r12
-               	movq	-0x1c8(%rbp), %r13
-               	movq	-0x1d0(%rbp), %r14
-               	movq	-0x1d8(%rbp), %r15
+               	callq	 <L49>
+<L49>:
+               	movq	%xmm8, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L50>
+<L50>:
+               	movaps	-0x370(%rbp), %xmm6
+               	movaps	-0x380(%rbp), %xmm7
+               	movaps	-0x390(%rbp), %xmm8
+               	movaps	-0x3a0(%rbp), %xmm9
+               	movaps	-0x3b0(%rbp), %xmm10
+               	movaps	-0x3c0(%rbp), %xmm11
+               	movaps	-0x3d0(%rbp), %xmm12
+               	movaps	-0x3e0(%rbp), %xmm13
+               	movaps	-0x3f0(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
+               	movq	-0x328(%rbp), %rbx
+               	movq	-0x330(%rbp), %rdi
+               	movq	-0x338(%rbp), %rsi
+               	movq	-0x340(%rbp), %r12
+               	movq	-0x348(%rbp), %r13
+               	movq	-0x350(%rbp), %r14
+               	movq	-0x358(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/imm/imm_add.dis
+++ b/test/golden/x86_64-windows/imm/imm_add.dis
@@ -5,145 +5,411 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_add.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movl	%ebx, %eax
+               	addl	$0x7ff, %eax            # imm = 0x7FF
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	movl	%edx, %esi
-               	addl	$0x7ff, %esi            # imm = 0x7FF
-               	movl	%esi, %edx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edi
-               	addl	$0x800, %edi            # imm = 0x800
-               	movl	%edi, %edx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	addl	$0xfff, %edi            # imm = 0xFFF
-               	movl	%edi, %edx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
-               	addl	$0x1000, %edi           # imm = 0x1000
-               	movl	%edi, %edx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	addl	$0x7fffffff, %edi       # imm = 0x7FFFFFFF
-               	movl	%edi, %edx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	addl	$0x80000000, %edi       # imm = 0x80000000
-               	movl	%edi, %edx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	addl	$0xffffffff, %edi       # imm = 0xFFFFFFFF
-               	movl	%edi, %edx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	addq	$0x7ff, %rbx            # imm = 0x7FF
-               	movq	%rbx, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdi
-               	subq	$0x800, %rdi            # imm = 0x800
-               	movq	%rdi, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
                	movq	%rdi, %r12
-               	addq	$0xfff000, %r12         # imm = 0xFFF000
-               	movq	%r12, %rdx
-               	callq	 <L10>
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+<L1>:
+               	addl	$0x800, %eax            # imm = 0x800
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+<L3>:
+               	addl	$0xfff, %eax            # imm = 0xFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+<L5>:
+               	addl	$0x1000, %eax           # imm = 0x1000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+<L7>:
+               	addl	$0x7fffffff, %eax       # imm = 0x7FFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+<L9>:
+               	addl	$0x80000000, %eax       # imm = 0x80000000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	addq	$0xffffff, %r12         # imm = 0xFFFFFF
-               	movq	%r12, %rdx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	addq	$0x7fffffff, %r12       # imm = 0x7FFFFFFF
-               	movq	%r12, %rdx
-               	callq	 <L12>
+               	addl	$0xffffffff, %eax       # imm = 0xFFFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	movabsq	$0x80000000, %r11       # imm = 0x80000000
-               	addq	%r11, %r12
-               	movq	%r12, %rdx
-               	callq	 <L13>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	addq	%r11, %r12
-               	movq	%r12, %rdx
-               	callq	 <L14>
+               	movq	%rbx, %rax
+               	addq	$0x7ff, %rax            # imm = 0x7FF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	movabsq	$0x100000000, %r11      # imm = 0x100000000
-               	addq	%r11, %r12
-               	movq	%r12, %rdx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	addq	%r11, %r12
-               	movq	%r12, %rdx
-               	callq	 <L16>
+               	subq	$0x800, %rax            # imm = 0x800
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rcx
-               	subl	$0x800, %esi            # imm = 0x800
-               	movl	%esi, %edx
-               	callq	 <L18>
+               	addq	$0xfff000, %rax         # imm = 0xFFF000
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rcx
-               	addl	$0x7fffffff, %esi       # imm = 0x7FFFFFFF
-               	movl	%esi, %edx
-               	callq	 <L19>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	subl	$0x80000000, %esi       # imm = 0x80000000
-               	movl	%esi, %edx
-               	callq	 <L20>
+               	addq	$0xffffff, %rax         # imm = 0xFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	addq	$0x7fffffff, %rax       # imm = 0x7FFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x80000000, %r11       # imm = 0x80000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movabsq	$0x100000000, %r11      # imm = 0x100000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movl	%ebx, %eax
+               	movl	%eax, %edi
+               	addl	$0x7ff, %edi            # imm = 0x7FF
+               	movslq	%edi, %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L32>
+<L32>:
+               	subl	$0x800, %edi            # imm = 0x800
+               	movslq	%edi, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L33>
+<L33>:
+               	addl	$0x7fffffff, %edi       # imm = 0x7FFFFFFF
+               	movslq	%edi, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L34>
+<L34>:
+               	subl	$0x80000000, %edi       # imm = 0x80000000
+               	movslq	%edi, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L35>
+<L35>:
+               	addq	$0x7ff, %rbx            # imm = 0x7FF
                	movq	%rax, %rcx
                	movq	%rbx, %rdx
-               	callq	 <L21>
-<L21>:
+               	callq	 <L36>
+<L36>:
+               	subq	$0x800, %rbx            # imm = 0x800
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L22>
-<L22>:
+               	movq	%rbx, %rdx
+               	callq	 <L37>
+<L37>:
+               	addq	$0x7fffffff, %rbx       # imm = 0x7FFFFFFF
                	movq	%rax, %rcx
-               	addq	$0x7fffffff, %rdi       # imm = 0x7FFFFFFF
-               	movq	%rdi, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L38>
+<L38>:
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	subq	%r11, %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L24>
-<L24>:
+               	subq	%r11, %rbx
+               	movq	%rax, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L39>
+<L39>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/imm/imm_addr.dis
+++ b/test/golden/x86_64-windows/imm/imm_addr.dis
@@ -5,7 +5,7 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_addr.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x93a0, %r11           # imm = 0x93A0
+               	movq	$0x9390, %r11           # imm = 0x9390
 <L0>:
                	subq	$0x1000, %rsp           # imm = 0x1000
                	movq	%r11, (%rsp)
@@ -13,279 +13,603 @@ Disassembly of section .text:
                	cmpq	$0x1000, %r11           # imm = 0x1000
                	ja	 <L0>
                	subq	%r11, %rsp
-               	movq	%rbx, -0x9348(%rbp)
-               	movq	%rdi, -0x9350(%rbp)
-               	movq	%rsi, -0x9358(%rbp)
-               	movq	%r12, -0x9360(%rbp)
-               	movq	%r13, -0x9368(%rbp)
-               	movq	%r14, -0x9370(%rbp)
-               	movq	%r15, -0x9378(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
+               	movq	%rbx, -0x9338(%rbp)
+               	movq	%rdi, -0x9340(%rbp)
+               	movq	%rsi, -0x9348(%rbp)
+               	movq	%r12, -0x9350(%rbp)
+               	movq	%r13, -0x9358(%rbp)
+               	movq	%r14, -0x9360(%rbp)
+               	movq	%r15, -0x9368(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x9318(%rbp)
                	leaq	-0x8400(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	addq	$0x0, %rdi
                	movq	$0x8400, %r12           # imm = 0x8400
-<L2>:
+<L1>:
                	movq	$0x0, (%rdi)
                	addq	$0x8, %rdi
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L2>
-               	leaq	-0x9300(%rbp), %rdi
-               	leaq	(%rdi), %r12
+               	jne	 <L1>
+               	leaq	-0x9300(%rbp), %r8
+               	movq	%r8, -0x9308(%rbp)
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8), %r12
                	addq	$0x0, %r12
                	movq	$0xf00, %r13            # imm = 0xF00
-<L3>:
+<L2>:
                	movq	$0x0, (%r12)
                	addq	$0x8, %r12
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
-               	jne	 <L3>
-               	movq	%rbx, %r12
+               	jne	 <L2>
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x1, %r12
                	leaq	(%rsi), %r13
                	movq	%r12, (%r13)
-               	movq	%rbx, %r12
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x2, %r12
                	leaq	0x7f8(%rsi), %r14
                	movq	%r12, (%r14)
-               	movq	%rbx, %r12
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x3, %r12
-               	leaq	0x800(%rsi), %r15
-               	movq	%r12, (%r15)
-               	movq	%rbx, %r12
+               	leaq	0x800(%rsi), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x4, %r12
-               	leaq	0x7ff8(%rsi), %r8
-               	movq	%r8, -0x9308(%rbp)
-               	movq	-0x9308(%rbp), %r8
-               	movq	%r12, (%r8)
-               	movq	%rbx, %r12
+               	leaq	0x7ff8(%rsi), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x5, %r12
-               	leaq	0x8000(%rsi), %r8
-               	movq	%r8, -0x9310(%rbp)
-               	movq	-0x9310(%rbp), %r8
-               	movq	%r12, (%r8)
-               	movq	%rbx, %r12
+               	leaq	0x8000(%rsi), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
                	addq	$0x6, %r12
-               	leaq	0x83f8(%rsi), %r8
-               	movq	%r8, -0x9318(%rbp)
-               	movq	-0x9318(%rbp), %r8
-               	movq	%r12, (%r8)
+               	leaq	0x83f8(%rsi), %r14
+               	movq	%r12, (%r14)
                	movq	(%r13), %r12
-               	movq	%r12, %rdx
-               	callq	 <L4>
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	(%r14), %r12
-               	movq	%r12, %rdx
-               	callq	 <L5>
+               	leaq	0x7f8(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	(%r15), %r12
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %r12
-               	movq	%r12, %rdx
-               	callq	 <L7>
+               	leaq	0x800(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	-0x9310(%rbp), %r8
-               	movq	(%r8), %r12
-               	movq	%r12, %rdx
-               	callq	 <L8>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L7>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	-0x9318(%rbp), %r8
-               	movq	(%r8), %r12
-               	movq	%r12, %rdx
-               	callq	 <L9>
+               	leaq	0x7ff8(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rax
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+<L10>:
+               	leaq	0x8000(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L11>
+<L12>:
+               	leaq	0x83f8(%rsi), %rdi
+               	movq	(%rdi), %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+<L14>:
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x1080, %rdi           # imm = 0x1080
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0xfff, %r12            # imm = 0xFFF
+               	movq	%r12, %rax
                	movq	$0x1080, %r12           # imm = 0x1080
                	xorl	%edx, %edx
                	divq	%r12
                	movq	%rdx, %r12
-               	movq	%rbx, %r13
-               	addq	$0xfff, %r13            # imm = 0xFFF
-               	movq	%r13, %rax
-               	movq	$0x1080, %r13           # imm = 0x1080
-               	xorl	%edx, %edx
-               	divq	%r13
-               	movq	%rdx, %r13
-               	movq	%rbx, %r14
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r14
                	addq	$0x800, %r14            # imm = 0x800
                	movq	%r14, %rax
                	movq	$0x1080, %r14           # imm = 0x1080
                	xorl	%edx, %edx
                	divq	%r14
-               	movq	%rdx, %r14
-               	leaq	(%rsi,%r12,8), %r15
-               	movq	(%r15), %r12
-               	addq	$0x7, %r12
-               	movq	%r12, (%r15)
-               	leaq	(%rsi,%r13,8), %r12
-               	movq	(%r12), %r13
-               	addq	$0x8, %r13
-               	movq	%r13, (%r12)
-               	leaq	(%rsi,%r14,8), %r13
-               	movq	(%r13), %rsi
-               	addq	$0x9, %rsi
-               	movq	%rsi, (%r13)
-               	movq	(%r15), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	(%r12), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	(%r13), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rax
-               	movq	$0x60, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %rsi
-               	movq	%rbx, %r12
-               	addq	$0x3f, %r12
-               	movq	%r12, %rax
-               	movq	$0x60, %r12
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rdx, %r12
-               	imulq	$0x28, %rsi, %rsi
-               	leaq	(%rdi,%rsi), %r13
-               	leaq	(%r13), %rsi
-               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
-               	movq	%rbx, %r14
-               	addq	$0xa, %r14
-               	leaq	0x8(%r13), %r15
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x9320(%rbp)
-               	movq	-0x9320(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xb, %r14
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9328(%rbp)
-               	movq	-0x9328(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xc, %r14
-               	leaq	0x10(%r15), %r8
-               	movq	%r8, -0x9330(%rbp)
-               	movq	-0x9330(%rbp), %r8
-               	movq	%r14, (%r8)
-               	leaq	0x20(%r13), %r14
-               	movl	$0x12345678, (%r14)     # imm = 0x12345678
-               	imulq	$0x28, %r12, %r12
-               	leaq	(%rdi,%r12), %r13
-               	leaq	(%r13), %rdi
-               	movl	$0xabcdef01, (%rdi)     # imm = 0xABCDEF01
-               	movq	%rbx, %r12
-               	addq	$0xd, %r12
-               	leaq	0x8(%r13), %r15
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x9338(%rbp)
-               	movq	-0x9338(%rbp), %r8
-               	movq	%r12, (%r8)
-               	movq	%rbx, %r12
-               	addq	$0xe, %r12
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9340(%rbp)
-               	movq	-0x9340(%rbp), %r8
-               	movq	%r12, (%r8)
-               	addq	$0xf, %rbx
-               	leaq	0x10(%r15), %r12
-               	movq	%rbx, (%r12)
-               	leaq	0x20(%r13), %rbx
-               	movl	$0x1234567, (%rbx)      # imm = 0x1234567
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	-0x9320(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	-0x9328(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L15>
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9310(%rbp)
+               	leaq	(%rsi,%rdi,8), %r15
+               	movq	(%r15), %rdi
+               	addq	$0x7, %rdi
+               	movq	%rdi, (%r15)
+               	leaq	(%rsi,%r12,8), %rdi
+               	movq	(%rdi), %r14
+               	addq	$0x8, %r14
+               	movq	%r14, (%rdi)
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rsi,%r8,8), %rdi
+               	movq	(%rdi), %r14
+               	addq	$0x9, %r14
+               	movq	%r14, (%rdi)
+               	movq	(%r15), %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	-0x9330(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L16>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L15>
 <L16>:
-               	movq	%rax, %rcx
-               	movl	(%r14), %esi
-               	movl	%esi, %edx
-               	callq	 <L17>
+               	leaq	(%rsi,%r12,8), %rbx
+               	movq	(%rbx), %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	movq	%rax, %rcx
-               	movl	(%rdi), %esi
-               	movl	%esi, %edx
-               	callq	 <L18>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	-0x9338(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L19>
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rsi,%r8,8), %rbx
+               	movq	(%rbx), %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	-0x9340(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L20>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L19>
 <L20>:
-               	movq	%rax, %rcx
-               	movq	(%r12), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L21>
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x60, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9328(%rbp)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x3f, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x60, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9320(%rbp)
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %r12
+               	imulq	$0x28, %r12, %r12
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%r12), %r14
+               	leaq	(%r14), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0xa, %r15
+               	leaq	0x8(%r14), %rdi
+               	leaq	(%rdi), %rbx
+               	movq	%r15, (%rbx)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0xb, %rbx
+               	leaq	0x8(%rdi), %r15
+               	movq	%rbx, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0xc, %rbx
+               	leaq	0x10(%rdi), %r15
+               	movq	%rbx, (%r15)
+               	leaq	0x20(%r14), %rbx
+               	movl	$0x12345678, (%rbx)     # imm = 0x12345678
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0xabcdef01, (%rbx)     # imm = 0xABCDEF01
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0xd, %rbx
+               	leaq	0x8(%rdi), %r14
+               	leaq	(%r14), %r15
+               	movq	%rbx, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0xe, %rbx
+               	leaq	0x8(%r14), %r15
+               	movq	%rbx, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	$0xf, %rbx
+               	leaq	0x10(%r14), %r15
+               	movq	%rbx, (%r15)
+               	leaq	0x20(%rdi), %rbx
+               	movl	$0x1234567, (%rbx)      # imm = 0x1234567
+               	movl	(%r12), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	movq	%rax, %rcx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L22>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L21>
 <L22>:
-               	movq	%rax, %rcx
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
                	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rbx
-               	addq	$0x10, %rbx
-               	movq	-0x9308(%rbp), %r8
-               	movq	%rbx, (%r8)
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L23>
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x8(%rdi), %rbx
+               	leaq	(%rbx), %rdi
+               	movq	(%rdi), %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x9348(%rbp), %rbx
-               	movq	-0x9350(%rbp), %rdi
-               	movq	-0x9358(%rbp), %rsi
-               	movq	-0x9360(%rbp), %r12
-               	movq	-0x9368(%rbp), %r13
-               	movq	-0x9370(%rbp), %r14
-               	movq	-0x9378(%rbp), %r15
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L23>
+<L24>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x8(%rdi), %rbx
+               	leaq	0x8(%rbx), %rdi
+               	movq	(%rdi), %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L25>
+<L26>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x8(%rdi), %rbx
+               	leaq	0x10(%rbx), %rdi
+               	movq	(%rdi), %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L27>
+<L28>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x20(%rdi), %rbx
+               	movl	(%rbx), %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	(%rbx), %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L31>
+<L32>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x8(%rdi), %rbx
+               	leaq	(%rbx), %rdi
+               	movq	(%rdi), %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+<L34>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	$0x28, %rbx, %rbx
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rbx), %rdi
+               	leaq	0x8(%rdi), %rbx
+               	leaq	0x8(%rbx), %r12
+               	movq	(%r12), %r14
+               	movq	%r13, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %r12
+               	leaq	0x10(%rbx), %r13
+               	movq	(%r13), %rbx
+               	movq	%r12, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L36>
+<L36>:
+               	movq	%rax, %rbx
+               	leaq	0x20(%rdi), %r12
+               	movl	(%r12), %edi
+               	movl	%edi, %r12d
+               	movq	%rbx, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %rbx
+               	leaq	0x7ff8(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	addq	$0x10, %rsi
+               	movq	%rsi, (%rdi)
+               	movq	(%rdi), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L38>
+<L38>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rax
+               	movq	-0x9338(%rbp), %rbx
+               	movq	-0x9340(%rbp), %rdi
+               	movq	-0x9348(%rbp), %rsi
+               	movq	-0x9350(%rbp), %r12
+               	movq	-0x9358(%rbp), %r13
+               	movq	-0x9360(%rbp), %r14
+               	movq	-0x9368(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/imm/imm_logic.dis
+++ b/test/golden/x86_64-windows/imm/imm_logic.dis
@@ -13,126 +13,407 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %esi
-               	movl	%esi, %edi
-               	orl	$0x55555555, %edi       # imm = 0x55555555
-               	movl	%edi, %edx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	xorl	$0x55555555, %edx       # imm = 0x55555555
-               	andl	$0xf0f0f0f, %edx        # imm = 0xF0F0F0F
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	orl	$0xffff0000, %edx       # imm = 0xFFFF0000
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	andl	$0xffff, %edx           # imm = 0xFFFF
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	movl	%esi, %r12d
-               	xorl	$-0x1, %r12d
-               	movl	%r12d, %edx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
+               	movl	%ebx, %eax
+               	movl	%eax, %edx
                	orl	$0x55555555, %edx       # imm = 0x55555555
-               	xorl	$-0x1, %edx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	andl	$0xf0f0f0f, %edx        # imm = 0xF0F0F0F
-               	xorl	$0xffff0000, %edx       # imm = 0xFFFF0000
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %r13
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	orq	%r11, %r13
+               	movl	%edx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
                	movq	%r13, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	xorq	%r11, %rdx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
-               	orq	%r11, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	movabsq	$0xff00ff00ff00ff, %r11 # imm = 0xFF00FF00FF00FF
-               	andq	%r11, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %r14
-               	xorq	$-0x1, %r14
-               	movq	%r14, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	orq	%r11, %rdx
-               	xorq	$-0x1, %rdx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rdx
-               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
-               	xorq	%r11, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	xorl	%r12d, %esi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+<L1>:
+               	movl	%eax, %esi
+               	xorl	$0x55555555, %esi       # imm = 0x55555555
                	andl	$0xf0f0f0f, %esi        # imm = 0xF0F0F0F
-               	movl	%esi, %edx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
                	movq	%r13, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movl	%eax, %esi
+               	orl	$0xffff0000, %esi       # imm = 0xFFFF0000
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%eax, %esi
+               	andl	$0xffff, %esi           # imm = 0xFFFF
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
                	movq	%r14, %rdx
-               	callq	 <L19>
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+<L9>:
+               	orl	$0x55555555, %esi       # imm = 0x55555555
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	andl	$0xf0f0f0f, %eax        # imm = 0xF0F0F0F
+               	xorl	$0xffff0000, %eax       # imm = 0xFFFF0000
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	xorq	%r11, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%rbx, %rax
+               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
+               	movq	%rbx, %rax
+               	movabsq	$0xff00ff00ff00ff, %r11 # imm = 0xFF00FF00FF00FF
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
+               	xorq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movl	%ebx, %eax
+               	movl	%eax, %esi
+               	orl	$0x55555555, %esi       # imm = 0x55555555
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+<L31>:
+               	xorl	%esi, %eax
+               	andl	$0xf0f0f0f, %eax        # imm = 0xF0F0F0F
+               	movslq	%eax, %rsi
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L32>
+<L32>:
+               	movq	%rbx, %rdx
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rdx
                	movq	%rax, %rcx
-               	xorq	%r14, %rbx
+               	callq	 <L33>
+<L33>:
+               	movq	%rbx, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	%rax, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L34>
+<L34>:
+               	xorq	%rsi, %rbx
                	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
                	andq	%r11, %rbx
+               	movq	%rax, %rcx
                	movq	%rbx, %rdx
-               	callq	 <L20>
-<L20>:
+               	callq	 <L35>
+<L35>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi

--- a/test/golden/x86_64-windows/imm/imm_mov.dis
+++ b/test/golden/x86_64-windows/imm/imm_mov.dis
@@ -5,134 +5,322 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_mov.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%rdi, -0x30(%rbp)
                	movq	%rsi, -0x38(%rbp)
                	movq	%r12, -0x40(%rbp)
                	movq	%r13, -0x48(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	cmpq	$0x0, %rbx
-               	je	 <L1>
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x0, %r8
+               	je	 <L0>
                	movl	$0x80000000, %esi       # imm = 0x80000000
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movl	$0x7ff, %esi            # imm = 0x7FF
+<L1>:
+               	movl	%esi, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movl	%esi, %edx
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	cmpq	$0x1, %rbx
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x1, %r8
                	je	 <L4>
-               	movabsq	$0x7fffffffffffffff, %rsi # imm = 0x7FFFFFFFFFFFFFFF
+               	movabsq	$0x7fffffffffffffff, %rdi # imm = 0x7FFFFFFFFFFFFFFF
                	jmp	 <L5>
 <L4>:
-               	movabsq	$0xffffffff, %rsi       # imm = 0xFFFFFFFF
+               	movabsq	$0xffffffff, %rdi       # imm = 0xFFFFFFFF
 <L5>:
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	cmpq	$0x2, %rbx
-               	je	 <L7>
-               	movl	$0xf0f0f0f, %esi        # imm = 0xF0F0F0F
-               	jmp	 <L8>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movl	$0x55555555, %esi       # imm = 0x55555555
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x2, %r8
+               	je	 <L8>
+               	movl	$0xf0f0f0f, %edi        # imm = 0xF0F0F0F
+               	jmp	 <L9>
 <L8>:
-               	movl	%esi, %edx
-               	callq	 <L9>
+               	movl	$0x55555555, %edi       # imm = 0x55555555
 <L9>:
-               	movq	%rax, %rcx
-               	cmpq	$0x3, %rbx
-               	je	 <L10>
-               	movabsq	$-0xffff00010000, %rsi  # imm = 0xFFFF0000FFFF0000
+               	movl	%edi, %r12d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movabsq	$0x5555555555555555, %rsi # imm = 0x5555555555555555
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rsi, %rdx
-               	callq	 <L12>
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	je	 <L12>
+               	movabsq	$-0xffff00010000, %rdi  # imm = 0xFFFF0000FFFF0000
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	-0x18(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	leaq	(%rsi), %rdi
-               	movabsq	$0x100000000, %r11      # imm = 0x100000000
-               	movq	%r11, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movabsq	$0xffff0000, %r11       # imm = 0xFFFF0000
-               	movq	%r11, (%rdi)
-               	movq	%rbx, %rax
-               	movq	$0x3, %rdi
-               	xorl	%edx, %edx
-               	divq	%rdi
-               	movq	%rdx, %rdi
-               	leaq	(%rsi,%rdi,8), %r12
-               	movq	(%r12), %r13
-               	movq	%r13, %rdx
-               	callq	 <L13>
+               	movabsq	$0x5555555555555555, %rdi # imm = 0x5555555555555555
 <L13>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %r12
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
                	addq	$0x1, %r12
-               	movq	%r12, %rax
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+<L15>:
+               	leaq	-0x18(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movq	$0x0, 0x10(%rdi)
+               	leaq	(%rdi), %r12
+               	movabsq	$0x100000000, %r11      # imm = 0x100000000
+               	movq	%r11, (%r12)
+               	leaq	0x8(%rdi), %r12
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%r12)
+               	leaq	0x10(%rdi), %r12
+               	movabsq	$0xffff0000, %r11       # imm = 0xFFFF0000
+               	movq	%r11, (%r12)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rax
                	movq	$0x3, %r12
                	xorl	%edx, %edx
                	divq	%r12
                	movq	%rdx, %r12
-               	leaq	(%rsi,%r12,8), %r13
-               	movq	(%r13), %r12
-               	movq	%r12, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	addq	$0x2, %rdi
-               	movq	%rdi, %rax
-               	movq	$0x3, %rdi
-               	xorl	%edx, %edx
-               	divq	%rdi
-               	movq	%rdx, %rdi
-               	leaq	(%rsi,%rdi,8), %r12
-               	movq	(%r12), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %esi
-               	movl	$0x7ff, %ebx            # imm = 0x7FF
-               	addl	%esi, %ebx
-               	movl	%ebx, %edx
-               	callq	 <L16>
+               	leaq	(%rdi,%r12,8), %r13
+               	movq	(%r13), %r14
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movl	$0x80000000, %edx       # imm = 0x80000000
-               	callq	 <L17>
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r14, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r13
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rcx
-               	movabsq	$-0x8000000000000000, %rdx # imm = 0x8000000000000000
-               	callq	 <L18>
+               	movq	%r12, %rbx
+               	addq	$0x1, %rbx
+               	movq	%rbx, %rax
+               	movq	$0x3, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rdi,%rbx,8), %r13
+               	movq	(%r13), %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rcx
-               	movl	$0x55555555, %edx       # imm = 0x55555555
-               	callq	 <L19>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	addq	$0x2, %r12
+               	movq	%r12, %rax
+               	movq	$0x3, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rdi,%rbx,8), %r12
+               	movq	(%r12), %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %ebx
+               	movl	$0x7ff, %edi            # imm = 0x7FF
+               	addl	%ebx, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movabsq	$0x80000000, %rdi       # imm = 0x80000000
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movabsq	$-0x8000000000000000, %rdi # imm = 0x8000000000000000
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x55555555, %rdi       # imm = 0x55555555
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L28>
+<L29>:
+               	movq	%rsi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %rdi
                	movq	-0x38(%rbp), %rsi
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/addr_modes.dis
+++ b/test/golden/x86_64-windows/mem/addr_modes.dis
@@ -5,7 +5,7 @@ Disassembly of section .text:
 <corpus.cases.mem.addr_modes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x35d0, %r11           # imm = 0x35D0
+               	movq	$0x3670, %r11           # imm = 0x3670
 <L0>:
                	subq	$0x1000, %rsp           # imm = 0x1000
                	movq	%r11, (%rsp)
@@ -13,20 +13,15 @@ Disassembly of section .text:
                	cmpq	$0x1000, %r11           # imm = 0x1000
                	ja	 <L0>
                	subq	%r11, %rsp
-               	movq	%rbx, -0x3578(%rbp)
-               	movq	%rdi, -0x3580(%rbp)
-               	movq	%rsi, -0x3588(%rbp)
-               	movq	%r12, -0x3590(%rbp)
-               	movq	%r13, -0x3598(%rbp)
-               	movq	%r14, -0x35a0(%rbp)
-               	movq	%r15, -0x35a8(%rbp)
+               	movq	%rbx, -0x3618(%rbp)
+               	movq	%rdi, -0x3620(%rbp)
+               	movq	%rsi, -0x3628(%rbp)
+               	movq	%r12, -0x3630(%rbp)
+               	movq	%r13, -0x3638(%rbp)
+               	movq	%r14, -0x3640(%rbp)
+               	movq	%r15, -0x3648(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x33d8(%rbp)
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0x140(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -35,732 +30,1113 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	leaq	-0xc0(%rbp), %r8
-               	movq	%r8, -0x3468(%rbp)
-               	movq	-0x3468(%rbp), %r8
+               	leaq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x33e0(%rbp)
+               	movq	-0x33e0(%rbp), %r8
                	leaq	(%r8), %r12
                	addq	$0x0, %r12
                	movq	$0x80, %r13
-<L2>:
+<L1>:
                	movq	$0x0, (%r12)
                	addq	$0x8, %r12
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
-               	jne	 <L2>
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x3558(%rbp)
-               	movq	-0x3558(%rbp), %r8
+               	jne	 <L1>
+               	leaq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x3470(%rbp)
+               	movq	-0x3470(%rbp), %r8
                	leaq	(%r8), %r13
                	addq	$0x0, %r13
                	movq	$0x100, %r14            # imm = 0x100
-<L3>:
+<L2>:
                	movq	$0x0, (%r13)
                	addq	$0x8, %r13
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L3>
-               	leaq	-0x3c0(%rbp), %r8
-               	movq	%r8, -0x3520(%rbp)
-               	movq	-0x3520(%rbp), %r8
+               	jne	 <L2>
+               	leaq	-0x4c0(%rbp), %r8
+               	movq	%r8, -0x3468(%rbp)
+               	movq	-0x3468(%rbp), %r8
                	leaq	(%r8), %r14
                	addq	$0x0, %r14
                	movq	$0x200, %r15            # imm = 0x200
-<L4>:
+<L3>:
                	movq	$0x0, (%r14)
                	addq	$0x8, %r14
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L4>
-               	leaq	-0x7c0(%rbp), %r8
-               	movq	%r8, -0x3540(%rbp)
-               	movq	-0x3540(%rbp), %r8
+               	jne	 <L3>
+               	leaq	-0x8c0(%rbp), %r8
+               	movq	%r8, -0x3478(%rbp)
+               	movq	-0x3478(%rbp), %r8
                	leaq	(%r8), %r15
-               	addq	$0x0, %r15
-               	movq	$0x400, %rcx            # imm = 0x400
-<L5>:
-               	movq	$0x0, (%r15)
-               	addq	$0x8, %r15
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L5>
-               	leaq	-0xac0(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	movq	%rcx, %r8
+               	movq	%r15, %r8
                	addq	$0x0, %r8
-               	movq	%r8, -0x33e0(%rbp)
-               	movq	$0x300, %rcx            # imm = 0x300
-<L6>:
-               	movq	-0x33e0(%rbp), %r8
+               	movq	%r8, -0x33d8(%rbp)
+               	movq	$0x400, %r15            # imm = 0x400
+<L4>:
+               	movq	-0x33d8(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x33d8(%rbp), %r8
                	addq	$0x8, %r8
-               	movq	%r8, -0x33e0(%rbp)
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L6>
-               	movq	$0x0, %r8
+               	movq	%r8, -0x33d8(%rbp)
+               	subq	$0x8, %r15
+               	cmpq	$0x0, %r15
+               	jne	 <L4>
+               	leaq	-0xbc0(%rbp), %r15
+               	leaq	(%r15), %rdi
+               	movq	%rdi, %r8
+               	addq	$0x0, %r8
                	movq	%r8, -0x33e8(%rbp)
+               	movq	$0x300, %rdi            # imm = 0x300
+<L5>:
                	movq	-0x33e8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L7>
-               	jmp	 <L8>
-<L7>:
+               	movq	$0x0, (%r8)
                	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	movb	%cl, %r8b
+               	addq	$0x8, %r8
+               	movq	%r8, -0x33e8(%rbp)
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L5>
+               	movq	$0x0, %r8
                	movq	%r8, -0x33f0(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	leaq	(%rsi,%r8), %rcx
                	movq	-0x33f0(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x44f, %rcx, %rcx      # imm = 0x44F
-               	addq	$0x7, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %r8w
+               	cmpq	$0x40, %r8
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x3, %rdi, %rdi
+               	addq	$0x1, %rdi
+               	addq	%rbx, %rdi
+               	movb	%dil, %r8b
                	movq	%r8, -0x33f8(%rbp)
-               	movq	-0x3468(%rbp), %r8
-               	movq	-0x33e8(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rcx
+               	movq	-0x33f0(%rbp), %r8
+               	leaq	(%rsi,%r8), %rdi
                	movq	-0x33f8(%rbp), %r8
-               	movw	%r8w, (%rcx)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	addq	$0xb, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movb	%r8b, (%rdi)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x44f, %rdi, %rdi      # imm = 0x44F
+               	addq	$0x7, %rdi
+               	addq	%rbx, %rdi
+               	movw	%di, %r8w
                	movq	%r8, -0x3400(%rbp)
-               	movq	-0x3558(%rbp), %r8
-               	movq	-0x33e8(%rbp), %r9
-               	leaq	(%r8,%r9,4), %rcx
+               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x33f0(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rdi
                	movq	-0x3400(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movq	-0x33e8(%rbp), %r9
+               	movw	%r8w, (%rdi)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %rdi
+               	addq	$0xb, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x3408(%rbp)
+               	movq	-0x3470(%rbp), %r8
+               	movq	-0x33f0(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rdi
+               	movq	-0x3408(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movq	-0x33f0(%rbp), %r9
                	movq	%r9, %r8
                	addq	$0x1, %r8
-               	movq	%r8, -0x3408(%rbp)
-               	movq	-0x3408(%rbp), %r8
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	imulq	%r8, %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
                	movq	%r8, -0x3410(%rbp)
-               	movq	-0x3520(%rbp), %r8
-               	movq	-0x33e8(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
                	movq	-0x3410(%rbp), %r8
-               	movq	%r8, (%rcx)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x5, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x3418(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	movq	-0x3540(%rbp), %r9
-               	leaq	(%r9,%rcx), %r8
-               	movq	%r8, -0x3420(%rbp)
-               	movq	-0x3420(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	-0x3418(%rbp), %r8
-               	movw	%r8w, (%rcx)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x80, %rcx
-               	movb	%cl, %r8b
-               	movq	%r8, -0x3428(%rbp)
-               	movq	-0x3420(%rbp), %r8
-               	leaq	0x2(%r8), %rcx
-               	movq	-0x3428(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movq	-0x3408(%rbp), %r8
-               	movabsq	$0x100000001b3, %rcx    # imm = 0x100000001B3
-               	imulq	%r8, %rcx
-               	movq	%rcx, %r8
+               	movabsq	$-0x61c8864680b583eb, %rdi # imm = 0x9E3779B97F4A7C15
+               	imulq	%r8, %rdi
+               	movq	%rdi, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x3430(%rbp)
+               	movq	%r8, -0x3418(%rbp)
+               	movq	-0x3468(%rbp), %r8
+               	movq	-0x33f0(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rdi
+               	movq	-0x3418(%rbp), %r8
+               	movq	%r8, (%rdi)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x5, %rdi, %rdi
+               	addq	$0x2, %rdi
+               	addq	%rbx, %rdi
+               	movw	%di, %r8w
+               	movq	%r8, -0x3420(%rbp)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x10, %rdi, %rdi
+               	movq	-0x3478(%rbp), %r9
+               	leaq	(%r9,%rdi), %r8
+               	movq	%r8, -0x3428(%rbp)
+               	movq	-0x3428(%rbp), %r8
+               	leaq	(%r8), %rdi
                	movq	-0x3420(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
+               	movw	%r8w, (%rdi)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x80, %rdi
+               	movb	%dil, %r8b
+               	movq	%r8, -0x3430(%rbp)
+               	movq	-0x3428(%rbp), %r8
+               	leaq	0x2(%r8), %rdi
                	movq	-0x3430(%rbp), %r8
-               	movq	%r8, (%rcx)
-               	movq	-0x33e8(%rbp), %r9
+               	movb	%r8b, (%rdi)
+               	movq	-0x3410(%rbp), %r8
+               	movabsq	$0x100000001b3, %rdi    # imm = 0x100000001B3
+               	imulq	%r8, %rdi
+               	movq	%rdi, %r8
+               	addq	%rbx, %r8
+               	movq	%r8, -0x3438(%rbp)
+               	movq	-0x3428(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movq	-0x3438(%rbp), %r8
+               	movq	%r8, (%rdi)
+               	movq	-0x33f0(%rbp), %r9
                	movq	%r9, %r8
                	imulq	$0x11, %r8, %r8
-               	movq	%r8, -0x3438(%rbp)
-               	movq	-0x3438(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
                	movq	%r8, -0x3440(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r15,%rcx), %r8
-               	movq	%r8, -0x3448(%rbp)
-               	movq	-0x3448(%rbp), %r8
-               	leaq	(%r8), %rcx
                	movq	-0x3440(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movq	-0x3438(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x3448(%rbp)
+               	movq	-0x33f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%r15,%rdi), %r8
                	movq	%r8, -0x3450(%rbp)
-               	movq	-0x3448(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
                	movq	-0x3450(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movq	-0x3438(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x3458(%rbp)
+               	leaq	(%r8), %rdi
                	movq	-0x3448(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
+               	movl	%r8d, (%rdi)
+               	movq	-0x3440(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x2, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x3458(%rbp)
+               	movq	-0x3450(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
                	movq	-0x3458(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movq	-0x3408(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x33e8(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L7>
-<L8>:
-               	movq	-0x33d8(%rbp), %r9
-               	movq	%r9, %r8
+               	movl	%r8d, (%rdi)
+               	movq	-0x3440(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x3, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r8d
                	movq	%r8, -0x3460(%rbp)
-               	movq	$0x0, %rdi
-               	cmpq	$0x40, %rdi
-               	jb	 <L9>
-               	jmp	 <L20>
-<L9>:
-               	movq	%rdi, %rcx
-               	imulq	$0xd, %rcx, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %r8
-               	andq	$0x3f, %r8
-               	movq	%r8, -0x3470(%rbp)
-               	movq	-0x3470(%rbp), %r8
-               	leaq	(%rsi,%r8), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x3478(%rbp)
+               	movq	-0x3450(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
                	movq	-0x3460(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x3478(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %r8
+               	movl	%r8d, (%rdi)
+               	movq	-0x3410(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x33f0(%rbp)
+               	movq	-0x33f0(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L6>
+<L7>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x40, %r13
+               	jb	 <L8>
+               	jmp	 <L23>
+<L8>:
+               	movq	%r13, %r12
+               	imulq	$0xd, %r12, %r12
+               	addq	%rbx, %r12
+               	andq	$0x3f, %r12
+               	leaq	(%rsi,%r12), %r14
+               	movzbl	(%r14), %r8d
                	movq	%r8, -0x3480(%rbp)
-               	movq	-0x3480(%rbp), %r8
-               	movq	-0x3468(%rbp), %r8
-               	movq	-0x3470(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rcx
-               	movzwl	(%rcx), %r8d
-               	movq	%r8, -0x3488(%rbp)
-               	movq	-0x3480(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x3488(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %r8
+               	movq	-0x3480(%rbp), %r9
+               	movzbq	%r9b, %r8
                	movq	%r8, -0x3490(%rbp)
-               	movq	-0x3490(%rbp), %r8
-               	movq	-0x3558(%rbp), %r8
-               	movq	-0x3470(%rbp), %r9
-               	leaq	(%r8,%r9,4), %rcx
-               	movl	(%rcx), %r8d
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3488(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x3498(%rbp)
-               	movq	-0x3490(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	-0x3498(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	-0x3498(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x3490(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x3488(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r14, %r8
                	movq	%r8, -0x34a0(%rbp)
                	movq	-0x34a0(%rbp), %r8
-               	movq	-0x3520(%rbp), %r8
-               	movq	-0x3470(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %r8
+               	movq	%r8, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	movq	-0x3498(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
                	movq	%r8, -0x34a8(%rbp)
-               	movq	-0x34a0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x34a8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %r8
+               	movq	%r14, %r8
+               	movq	%r8, -0x3488(%rbp)
+               	movq	-0x34a8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3498(%rbp)
+               	movq	-0x3498(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
+<L10>:
+               	movq	-0x33e0(%rbp), %r8
+               	leaq	(%r8,%r12,2), %r14
+               	movzwl	(%r14), %r8d
                	movq	%r8, -0x34b0(%rbp)
-               	movq	-0x34b0(%rbp), %r8
-               	movq	-0x3470(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	movq	-0x3540(%rbp), %r9
-               	leaq	(%r9,%rcx), %r8
-               	movq	%r8, -0x34b8(%rbp)
-               	movq	-0x34b8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movzwl	(%rcx), %r8d
+               	movq	-0x34b0(%rbp), %r9
+               	movzwq	%r9w, %r8
                	movq	%r8, -0x34c0(%rbp)
-               	movq	-0x34b0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x34c0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %r8
+               	movq	-0x3488(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34b8(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x34c8(%rbp)
                	movq	-0x34c8(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
-               	leaq	0x2(%r8), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x34d0(%rbp)
+               	cmpq	$0x8, %r8
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
                	movq	-0x34c8(%rbp), %r8
-               	movq	%r8, %rcx
+               	movq	%r8, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x34c0(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x34b8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x34d0(%rbp)
                	movq	-0x34d0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %r8
+               	movq	%r8, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	movq	-0x34c8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
                	movq	%r8, -0x34d8(%rbp)
-               	movq	-0x34d8(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x34e0(%rbp)
-               	movq	-0x34d8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x34e0(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x34e8(%rbp)
-               	movq	-0x34e8(%rbp), %r8
+               	movq	%r14, %r8
+               	movq	%r8, -0x34b8(%rbp)
+               	movq	-0x34d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34c8(%rbp)
+               	movq	-0x34c8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L11>
+<L12>:
                	movq	-0x3470(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r15,%rcx), %r8
+               	leaq	(%r8,%r12,4), %r14
+               	movl	(%r14), %r8d
+               	movq	%r8, -0x34e0(%rbp)
+               	movq	-0x34e0(%rbp), %r9
+               	movl	%r9d, %r8d
                	movq	%r8, -0x34f0(%rbp)
-               	movq	-0x34f0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %r8d
+               	movq	-0x34b8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34e8(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x34f8(%rbp)
-               	movq	-0x34e8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	-0x34f8(%rbp), %r8
-               	movl	%r8d, %edx
+               	cmpq	$0x8, %r8
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	-0x34f8(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x34f0(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x34e8(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x3500(%rbp)
+               	movq	-0x3500(%rbp), %r8
+               	movq	%r8, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	movq	-0x34f8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x3508(%rbp)
+               	movq	%r14, %r8
+               	movq	%r8, -0x34e8(%rbp)
+               	movq	-0x3508(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34f8(%rbp)
+               	movq	-0x34f8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L13>
+<L14>:
+               	movq	-0x3468(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x3510(%rbp)
+               	movq	-0x34e8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3518(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x3520(%rbp)
+               	movq	-0x3520(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	-0x3520(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x3510(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x3518(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x3528(%rbp)
+               	movq	-0x3528(%rbp), %r8
+               	movq	%r8, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	movq	-0x3520(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x3530(%rbp)
+               	movq	%r14, %r8
+               	movq	%r8, -0x3518(%rbp)
+               	movq	-0x3530(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3520(%rbp)
+               	movq	-0x3520(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L15>
+<L16>:
+               	movq	%r12, %r14
+               	imulq	$0x10, %r14, %r14
+               	movq	-0x3478(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x3538(%rbp)
+               	movq	-0x3538(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movzwl	(%r14), %r8d
+               	movq	%r8, -0x3540(%rbp)
+               	movq	-0x3540(%rbp), %r8
+               	movzwq	%r8w, %r14
+               	movq	-0x3518(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r14, %rdx
                	callq	 <L17>
 <L17>:
                	movq	%rax, %r8
-               	movq	%r8, -0x3500(%rbp)
-               	movq	-0x3500(%rbp), %r8
-               	movq	-0x34f0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x3508(%rbp)
-               	movq	-0x3500(%rbp), %r8
+               	movq	%r8, -0x3548(%rbp)
+               	movq	-0x3548(%rbp), %r8
+               	movq	%r12, %r14
+               	imulq	$0x10, %r14, %r14
+               	movq	-0x3478(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x3550(%rbp)
+               	movq	-0x3550(%rbp), %r8
+               	leaq	0x2(%r8), %r14
+               	movzbl	(%r14), %r8d
+               	movq	%r8, -0x3558(%rbp)
+               	movq	-0x3558(%rbp), %r8
+               	movzbq	%r8b, %r14
+               	movq	-0x3548(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	-0x3508(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	%r14, %rdx
                	callq	 <L18>
 <L18>:
                	movq	%rax, %r8
-               	movq	%r8, -0x3510(%rbp)
-               	movq	-0x3510(%rbp), %r8
-               	movq	-0x34f0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x3518(%rbp)
-               	movq	-0x3510(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x3518(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rdi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x3460(%rbp)
-               	cmpq	$0x40, %rdi
-               	jb	 <L9>
-<L20>:
-               	movq	-0x3460(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	$0x0, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L21>
-               	jmp	 <L27>
-<L21>:
-               	movq	%r15, %r13
-               	imulq	$0x2, %r13, %r13
-               	movq	-0x3558(%rbp), %r8
-               	leaq	(%r8,%r13,4), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x3528(%rbp)
-               	movq	%rdi, %rcx
-               	movq	-0x3528(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x3530(%rbp)
-               	movq	-0x3530(%rbp), %r8
-               	movq	%r15, %rcx
-               	shlq	%rcx
-               	movq	-0x3558(%rbp), %r9
-               	leaq	(%r9,%rcx,4), %r8
-               	movq	%r8, -0x3538(%rbp)
-               	movq	-0x3538(%rbp), %r8
-               	movl	(%r8), %r14d
-               	movq	-0x3530(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x3548(%rbp)
-               	movq	-0x3548(%rbp), %r8
-               	movq	%r15, %r14
-               	addq	$0x1, %r14
-               	movq	%r14, %rcx
-               	imulq	$0x2, %rcx, %rcx
-               	subq	$0x2, %rcx
-               	movq	-0x3520(%rbp), %r9
-               	leaq	(%r9,%rcx,8), %r8
-               	movq	%r8, -0x3550(%rbp)
-               	movq	-0x3550(%rbp), %r8
-               	movq	(%r8), %r12
-               	movq	-0x3548(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %r8
                	movq	%r8, -0x3560(%rbp)
                	movq	-0x3560(%rbp), %r8
-               	movq	$0x3f, %r12
-               	subq	%r15, %r12
-               	leaq	(%rsi,%r12), %rcx
-               	movzbl	(%rcx), %r12d
+               	movq	%r12, %r14
+               	imulq	$0x10, %r14, %r14
+               	movq	-0x3478(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x3568(%rbp)
+               	movq	-0x3568(%rbp), %r8
+               	leaq	0x8(%r8), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x3570(%rbp)
                	movq	-0x3560(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	addq	%rbx, %r13
-               	andq	$0x3f, %r13
-               	imulq	$0x10, %r13, %r13
-               	movq	-0x3540(%rbp), %r8
-               	leaq	(%r8,%r13), %r12
-               	leaq	0x8(%r12), %r13
-               	movq	(%r13), %r12
-               	movq	%r12, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	%r14, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L21>
-<L27>:
-               	leaq	-0xbc0(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x100, %r12            # imm = 0x100
-<L28>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L28>
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
-               	movq	%rcx, %r8
-               	imulq	$0x47, %r8, %r8
-               	movq	%r8, -0x3568(%rbp)
-               	movq	%rcx, %r13
-               	imulq	$0x20, %r13, %r13
-               	leaq	(%rsi,%r13), %r14
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L30>
-               	jmp	 <L31>
-<L30>:
-               	movq	%r13, %r15
-               	imulq	$0xd, %r15, %r15
-               	movq	-0x3568(%rbp), %r8
-               	movq	%r8, %r12
-               	addq	%r15, %r12
-               	addq	%rbx, %r12
-               	movl	%r12d, %r15d
-               	leaq	(%r14,%r13,4), %r12
-               	movl	%r15d, (%r12)
-               	addq	$0x1, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L30>
-<L31>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L29>
-<L32>:
-               	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L33>
-               	jmp	 <L37>
-<L33>:
-               	movq	%r12, %rcx
-               	imulq	$0x20, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %r13
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r14d
-               	movq	%rdi, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	leaq	0x60(%rsi), %r14
-               	leaq	(%r14,%r12,4), %r15
-               	movl	(%r15), %r14d
-               	movl	%r14d, %edx
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	movq	-0x3570(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x3578(%rbp)
+               	movq	-0x3578(%rbp), %r8
                	movq	%r12, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r15,%r14), %r8
+               	movq	%r8, -0x3580(%rbp)
+               	movq	-0x3580(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movl	(%r14), %r8d
+               	movq	%r8, -0x3588(%rbp)
+               	movq	-0x3588(%rbp), %r8
+               	movl	%r8d, %r14d
+               	movq	-0x3578(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x3590(%rbp)
+               	movq	-0x3590(%rbp), %r8
+               	movq	%r12, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r15,%r14), %r8
+               	movq	%r8, -0x3598(%rbp)
+               	movq	-0x3598(%rbp), %r8
+               	leaq	0x4(%r8), %r14
+               	movl	(%r14), %r8d
+               	movq	%r8, -0x35a0(%rbp)
+               	movq	-0x35a0(%rbp), %r8
+               	movl	%r8d, %r14d
+               	movq	-0x3590(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x35a8(%rbp)
+               	movq	-0x35a8(%rbp), %r8
+               	imulq	$0xc, %r12, %r12
+               	leaq	(%r15,%r12), %r14
+               	leaq	0x8(%r14), %r12
+               	movl	(%r12), %r14d
+               	movl	%r14d, %r12d
+               	movq	-0x35a8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L22>
+<L22>:
+               	movq	%rax, %r12
+               	addq	$0x1, %r13
+               	movq	%r12, %rdi
+               	cmpq	$0x40, %r13
+               	jb	 <L8>
+<L23>:
+               	movq	$0x0, %r12
+               	cmpq	$0x20, %r12
+               	jb	 <L24>
+               	jmp	 <L33>
+<L24>:
+               	movq	%r12, %r13
+               	imulq	$0x2, %r13, %r13
+               	movq	-0x3470(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x35b0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x35b8(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r15, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x35b0(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x35b8(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x35b8(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
+<L26>:
+               	movq	%r12, %r13
+               	shlq	%r13
+               	movq	-0x3470(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x35c0(%rbp)
+               	movq	-0x35b8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x35c8(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%r15, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x35c0(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x35c8(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x35c8(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L27>
+<L28>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	imulq	$0x2, %r13, %r13
+               	subq	$0x2, %r13
+               	movq	-0x3468(%rbp), %r8
+               	leaq	(%r8,%r13,8), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x35d0(%rbp)
+               	movq	-0x35c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x35d8(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x35d0(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x35d8(%rbp), %r8
+               	movq	%r8, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r8
+               	movq	%r8, -0x35d8(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L29>
+<L30>:
+               	movq	$0x3f, %r13
+               	subq	%r12, %r13
+               	leaq	(%rsi,%r13), %r14
+               	movzbl	(%r14), %r13d
+               	movzbq	%r13b, %r14
+               	movq	-0x35d8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L31>
+<L31>:
+               	movq	%rax, %r13
+               	movq	%r12, %r14
+               	imulq	$0x2, %r14, %r14
                	addq	%rbx, %r14
-               	andq	$0x7, %r14
-               	leaq	(%r13,%r14,4), %r15
-               	movl	(%r15), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L36>
-<L36>:
+               	andq	$0x3f, %r14
+               	imulq	$0x10, %r14, %r14
+               	movq	-0x3478(%rbp), %r8
+               	leaq	(%r8,%r14), %r15
+               	leaq	0x8(%r15), %r14
+               	movq	(%r14), %r15
+               	movq	%r13, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L32>
+<L32>:
                	movq	%rax, %rdi
                	addq	$0x1, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L33>
-<L37>:
-               	leaq	0xe0(%rsi), %rcx
-               	leaq	0x1c(%rcx), %r12
-               	movl	(%r12), %r13d
-               	movq	%rdi, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rdi
-               	leaq	(%rdi), %rsi
-               	movl	(%rsi), %edi
-               	movl	%edi, %edx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	leaq	-0x33d0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	addq	$0x0, %rdi
-               	movq	$0x2810, %r12           # imm = 0x2810
-<L40>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L40>
-               	movq	$0x12345678, %rdi       # imm = 0x12345678
-               	addq	%rbx, %rdi
+               	cmpq	$0x20, %r12
+               	jb	 <L24>
+<L33>:
+               	leaq	-0x100(%rbp), %rsi
                	leaq	(%rsi), %r12
-               	movq	%rdi, (%r12)
-               	movl	%ebx, %edi
-               	movl	$0x9abcdef0, %r12d      # imm = 0x9ABCDEF0
-               	addl	%edi, %r12d
-               	leaq	0x2008(%rsi), %rdi
-               	movl	%r12d, (%rdi)
-               	movw	%bx, %di
-               	movl	$0x1234, %r12d          # imm = 0x1234
-               	addl	%edi, %r12d
-               	leaq	0x280c(%rsi), %rdi
-               	movw	%r12w, (%rdi)
-               	movq	$0x0, %rdi
-               	cmpq	$0x400, %rdi            # imm = 0x400
-               	jb	 <L41>
-               	jmp	 <L42>
+               	addq	$0x0, %r12
+               	movq	$0x100, %r13            # imm = 0x100
+<L34>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L34>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L35>
+               	jmp	 <L38>
+<L35>:
+               	movq	%r12, %r8
+               	imulq	$0x47, %r8, %r8
+               	movq	%r8, -0x35e0(%rbp)
+               	movq	%r12, %r14
+               	imulq	$0x20, %r14, %r14
+               	leaq	(%rsi,%r14), %r8
+               	movq	%r8, -0x35e8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%r14, %r13
+               	imulq	$0xd, %r13, %r13
+               	movq	-0x35e0(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%r13, %r15
+               	addq	%rbx, %r15
+               	movl	%r15d, %r13d
+               	movq	-0x35e8(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r15
+               	movl	%r13d, (%r15)
+               	addq	$0x1, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L36>
+<L37>:
+               	addq	$0x1, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L35>
+<L38>:
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L39>
+               	jmp	 <L45>
+<L39>:
+               	movq	%r12, %r13
+               	imulq	$0x20, %r13, %r13
+               	leaq	(%rsi,%r13), %r14
+               	leaq	0xc(%r14), %r13
+               	movl	(%r13), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x35f0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x35f8(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x35f0(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x35f8(%rbp), %r8
+               	movq	%r8, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r8
+               	movq	%r8, -0x35f8(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L40>
 <L41>:
-               	movq	%rdi, %r12
-               	imulq	$0x1f, %r12, %r12
-               	addq	%rbx, %r12
-               	leaq	0x8(%rsi), %r13
-               	leaq	(%r13,%rdi,8), %r14
-               	movq	%r12, (%r14)
-               	addq	$0x1, %rdi
-               	cmpq	$0x400, %rdi            # imm = 0x400
-               	jb	 <L41>
+               	leaq	0x60(%rsi), %r13
+               	leaq	(%r13,%r12,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x3600(%rbp)
+               	movq	-0x35f8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3608(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	$0x0, %rdi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L43>
-               	jmp	 <L44>
+               	movq	%r15, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x3600(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	-0x3608(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x3608(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L42>
 <L43>:
-               	movq	%rdi, %r12
-               	imulq	$0x25, %r12, %r12
-               	addq	%rbx, %r12
-               	movl	%r12d, %r13d
-               	leaq	0x200c(%rsi), %r12
-               	leaq	(%r12,%rdi,4), %r14
-               	movl	%r13d, (%r14)
-               	addq	$0x1, %rdi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L43>
+               	movq	%r12, %r13
+               	imulq	$0x20, %r13, %r13
+               	leaq	(%rsi,%r13), %r14
+               	movq	%r12, %r13
+               	addq	%rbx, %r13
+               	andq	$0x7, %r13
+               	leaq	(%r14,%r13,4), %r15
+               	movl	(%r15), %r13d
+               	movl	%r13d, %r14d
+               	movq	-0x3608(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L44>
 <L44>:
-               	leaq	(%rsi), %rdi
-               	movq	(%rdi), %r12
-               	movq	%r12, %rdx
-               	callq	 <L45>
+               	movq	%rax, %r13
+               	addq	$0x1, %r12
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L39>
 <L45>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rsi), %rdi
-               	leaq	(%rdi), %r12
-               	movq	(%r12), %r13
-               	movq	%r13, %rdx
-               	callq	 <L46>
+               	leaq	0xe0(%rsi), %r12
+               	leaq	0x1c(%r12), %r13
+               	movl	(%r13), %r12d
+               	movl	%r12d, %r13d
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L46>
+               	jmp	 <L47>
 <L46>:
-               	movq	%rax, %rcx
-               	leaq	0x1ff8(%rdi), %r12
-               	movq	(%r12), %r13
-               	movq	%r13, %rdx
-               	callq	 <L47>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L46>
 <L47>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %r12
-               	addq	$0x2bc, %r12            # imm = 0x2BC
-               	movq	%r12, %rax
-               	movq	$0x400, %r12            # imm = 0x400
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rdx, %r12
-               	leaq	(%rdi,%r12,8), %r13
-               	movq	(%r13), %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L48>
+               	leaq	(%rsi), %r12
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %r12d
+               	movl	%r12d, %esi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L48>
+               	jmp	 <L49>
 <L48>:
-               	movq	%rax, %rcx
-               	leaq	0x2008(%rsi), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%r12d, %edx
-               	callq	 <L49>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L48>
 <L49>:
-               	movq	%rax, %rcx
-               	leaq	0x200c(%rsi), %rdi
-               	leaq	(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L50>
+               	leaq	-0x33d0(%rbp), %rsi
+               	leaq	(%rsi), %r12
+               	addq	$0x0, %r12
+               	movq	$0x2810, %r13           # imm = 0x2810
 <L50>:
-               	movq	%rax, %rcx
-               	leaq	0x7fc(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L51>
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L50>
+               	movq	$0x12345678, %r12       # imm = 0x12345678
+               	addq	%rbx, %r12
+               	leaq	(%rsi), %r13
+               	movq	%r12, (%r13)
+               	movl	%ebx, %r12d
+               	movl	$0x9abcdef0, %r13d      # imm = 0x9ABCDEF0
+               	addl	%r12d, %r13d
+               	leaq	0x2008(%rsi), %r12
+               	movl	%r13d, (%r12)
+               	movw	%bx, %r12w
+               	movl	$0x1234, %r13d          # imm = 0x1234
+               	addl	%r12d, %r13d
+               	leaq	0x280c(%rsi), %r12
+               	movw	%r13w, (%r12)
+               	movq	$0x0, %r12
+               	cmpq	$0x400, %r12            # imm = 0x400
+               	jb	 <L51>
+               	jmp	 <L52>
 <L51>:
-               	movq	%rax, %rcx
+               	movq	%r12, %r13
+               	imulq	$0x1f, %r13, %r13
+               	addq	%rbx, %r13
+               	leaq	0x8(%rsi), %r14
+               	leaq	(%r14,%r12,8), %r15
+               	movq	%r13, (%r15)
+               	addq	$0x1, %r12
+               	cmpq	$0x400, %r12            # imm = 0x400
+               	jb	 <L51>
+<L52>:
+               	movq	$0x0, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L53>
+               	jmp	 <L54>
+<L53>:
+               	movq	%r12, %r13
+               	imulq	$0x25, %r13, %r13
+               	addq	%rbx, %r13
+               	movl	%r13d, %r14d
+               	leaq	0x200c(%rsi), %r13
+               	leaq	(%r13,%r12,4), %r15
+               	movl	%r14d, (%r15)
+               	addq	$0x1, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L53>
+<L54>:
+               	leaq	(%rsi), %r12
+               	movq	(%r12), %r13
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L55>
+               	jmp	 <L56>
+<L55>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L55>
+<L56>:
+               	leaq	0x8(%rsi), %r12
+               	leaq	(%r12), %r13
+               	movq	(%r13), %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L57>
+<L58>:
+               	leaq	0x8(%rsi), %r12
+               	leaq	0x1ff8(%r12), %r13
+               	movq	(%r13), %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L59>
+               	jmp	 <L60>
+<L59>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L59>
+<L60>:
+               	leaq	0x8(%rsi), %r12
+               	movq	%rbx, %r13
+               	addq	$0x2bc, %r13            # imm = 0x2BC
+               	movq	%r13, %rax
+               	movq	$0x400, %r13            # imm = 0x400
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	leaq	(%r12,%r13,8), %r14
+               	movq	(%r14), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L61>
+<L61>:
+               	movq	%rax, %rdi
+               	leaq	0x2008(%rsi), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L62>
+<L62>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%rsi), %r12
+               	leaq	(%r12), %r13
+               	movl	(%r13), %r12d
+               	movl	%r12d, %r13d
+               	movq	%rdi, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%rsi), %r12
+               	leaq	0x7fc(%r12), %r13
+               	movl	(%r13), %r12d
+               	movl	%r12d, %r13d
+               	movq	%rdi, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%rsi), %r12
                	addq	$0x12c, %rbx            # imm = 0x12C
                	movq	%rbx, %rax
                	movq	$0x200, %rbx            # imm = 0x200
                	xorl	%edx, %edx
                	divq	%rbx
                	movq	%rdx, %rbx
-               	leaq	(%rdi,%rbx,4), %r12
-               	movl	(%r12), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	leaq	0x280c(%rsi), %rbx
-               	movzwl	(%rbx), %edi
-               	movq	%rdi, %rdx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movq	$0x2008, %rdx           # imm = 0x2008
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	movq	$0x200c, %rdx           # imm = 0x200C
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
-               	movq	$0x280c, %rdx           # imm = 0x280C
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	movq	$0x2810, %rdx           # imm = 0x2810
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rbx
-               	movq	$0x0, %rdi
-               	cmpq	$0x400, %rbx            # imm = 0x400
-               	jb	 <L58>
-               	jmp	 <L59>
-<L58>:
-               	leaq	0x8(%rsi), %r12
-               	leaq	(%r12,%rbx,8), %r13
-               	movq	(%r13), %r12
-               	addq	$0x1, %rbx
-               	imulq	%rbx, %r12
-               	xorq	%r12, %rdi
-               	cmpq	$0x400, %rbx            # imm = 0x400
-               	jb	 <L58>
-<L59>:
-               	movq	%rdi, %rdx
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rbx
-               	movq	$0x0, %rdi
-               	cmpq	$0x200, %rbx            # imm = 0x200
-               	jb	 <L61>
-               	jmp	 <L62>
-<L61>:
-               	leaq	0x200c(%rsi), %r12
                	leaq	(%r12,%rbx,4), %r13
-               	movl	(%r13), %r12d
-               	movl	%r12d, %r13d
-               	movq	%rbx, %r12
-               	addq	$0x3, %r12
-               	imulq	%r12, %r13
-               	addq	%r13, %rdi
-               	addq	$0x1, %rbx
-               	cmpq	$0x200, %rbx            # imm = 0x200
-               	jb	 <L61>
-<L62>:
+               	movl	(%r13), %ebx
+               	movl	%ebx, %r12d
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rbx
+               	leaq	0x280c(%rsi), %rdi
+               	movzwl	(%rdi), %r12d
+               	movzwq	%r12w, %rdi
+               	movq	%rbx, %rcx
                	movq	%rdi, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x3578(%rbp), %rbx
-               	movq	-0x3580(%rbp), %rdi
-               	movq	-0x3588(%rbp), %rsi
-               	movq	-0x3590(%rbp), %r12
-               	movq	-0x3598(%rbp), %r13
-               	movq	-0x35a0(%rbp), %r14
-               	movq	-0x35a8(%rbp), %r15
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x2008, %rdx           # imm = 0x2008
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x200c, %rdx           # imm = 0x200C
+               	callq	 <L68>
+<L68>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x280c, %rdx           # imm = 0x280C
+               	callq	 <L69>
+<L69>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x2810, %rdx           # imm = 0x2810
+               	callq	 <L70>
+<L70>:
+               	movq	%rax, %rbx
+               	movq	$0x0, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L71>
+               	jmp	 <L72>
+<L71>:
+               	leaq	0x8(%rsi), %r13
+               	leaq	(%r13,%rdi,8), %r14
+               	movq	(%r14), %r13
+               	addq	$0x1, %rdi
+               	imulq	%rdi, %r13
+               	xorq	%r13, %r12
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L71>
+<L72>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L73>
+               	jmp	 <L74>
+<L73>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L73>
+<L74>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L75>
+               	jmp	 <L76>
+<L75>:
+               	leaq	0x200c(%rsi), %r13
+               	leaq	(%r13,%rdi,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r14d
+               	movq	%rdi, %r13
+               	addq	$0x3, %r13
+               	imulq	%r13, %r14
+               	addq	%r14, %r12
+               	addq	$0x1, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L75>
+<L76>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L77>
+               	jmp	 <L78>
+<L77>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L77>
+<L78>:
+               	movq	%rbx, %rax
+               	movq	-0x3618(%rbp), %rbx
+               	movq	-0x3620(%rbp), %rdi
+               	movq	-0x3628(%rbp), %rsi
+               	movq	-0x3630(%rbp), %r12
+               	movq	-0x3638(%rbp), %r13
+               	movq	-0x3640(%rbp), %r14
+               	movq	-0x3648(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/array_index.dis
+++ b/test/golden/x86_64-windows/mem/array_index.dis
@@ -5,32 +5,86 @@ Disassembly of section .text:
 <corpus.cases.mem.array_index.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzwl	(%rbx), %esi
                	leaq	0x2(%rdx), %rbx
                	movzbl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movzbq	%dil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,659 +92,1026 @@ Disassembly of section .text:
 <corpus.cases.mem.array_index.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x200, %rsp            # imm = 0x200
-               	movq	%rbx, -0x1a8(%rbp)
-               	movq	%rdi, -0x1b0(%rbp)
-               	movq	%rsi, -0x1b8(%rbp)
-               	movq	%r12, -0x1c0(%rbp)
-               	movq	%r13, -0x1c8(%rbp)
-               	movq	%r14, -0x1d0(%rbp)
-               	movq	%r15, -0x1d8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x180(%rbp)
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	leaq	-0x9c(%rbp), %rdi
+               	subq	$0x330, %rsp            # imm = 0x330
+               	movq	%rbx, -0x2d8(%rbp)
+               	movq	%rdi, -0x2e0(%rbp)
+               	movq	%rsi, -0x2e8(%rbp)
+               	movq	%r12, -0x2f0(%rbp)
+               	movq	%r13, -0x2f8(%rbp)
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x308(%rbp)
+               	movq	%rcx, %rbx
+               	leaq	-0x1c(%rbp), %rsi
+               	leaq	-0x128(%rbp), %rdi
                	leaq	(%rdi), %r12
                	addq	$0x0, %r12
                	movq	$0x80, %r13
-<L1>:
+<L0>:
                	movq	$0x0, (%r12)
                	addq	$0x8, %r12
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
-               	jne	 <L1>
+               	jne	 <L0>
                	movq	$0x0, %r12
                	cmpq	$0x20, %r12
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%r12, %r13
                	addq	$0x1, %r13
                	movabsq	$0x9e3779b1, %r14       # imm = 0x9E3779B1
                	imulq	%r13, %r14
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %r14
+               	addq	%rbx, %r14
                	movl	%r14d, %r15d
                	leaq	(%rdi,%r12,4), %r14
                	movl	%r15d, (%r14)
                	movq	%r13, %r12
                	cmpq	$0x20, %r12
-               	jb	 <L2>
-<L3>:
+               	jb	 <L1>
+<L2>:
                	leaq	(%rdi), %r12
                	movl	(%r12), %r13d
-               	movl	%r13d, %edx
-               	callq	 <L4>
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x180(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %r12
+               	xorq	%r15, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r14
+               	movq	%r12, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rcx
                	leaq	0x4(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
+               	movl	(%r12), %r14d
+               	movl	%r14d, %r12d
+               	movq	%r13, %rcx
+               	movq	%r12, %rdx
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x3c(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
+               	movq	%rax, %r12
+               	leaq	0x3c(%rdi), %r13
+               	movl	(%r13), %r14d
+               	movl	%r14d, %r13d
+               	movq	%r12, %rcx
+               	movq	%r13, %rdx
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0x7c(%rdi), %r12
-               	movl	(%r12), %r13d
-               	movl	%r13d, %edx
+               	movq	%rax, %r12
+               	leaq	0x7c(%rdi), %r13
+               	movl	(%r13), %r14d
+               	movl	%r14d, %r13d
+               	movq	%r12, %rcx
+               	movq	%r13, %rdx
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x20, %r13
+               	movq	%rax, %r12
+               	movq	%r12, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x20, %r8
                	jb	 <L8>
-               	jmp	 <L10>
+               	jmp	 <L11>
 <L8>:
-               	movq	%r13, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %rcx
-               	andq	$0x1f, %rcx
-               	leaq	(%rdi,%rcx,4), %r14
-               	movl	(%r14), %r15d
-               	movq	%r12, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L9>
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	%rbx, %r14
+               	andq	$0x1f, %r14
+               	leaq	(%rdi,%r14,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %r12
-               	addq	$0x1, %r13
-               	cmpq	$0x20, %r13
-               	jb	 <L8>
+               	movq	%r12, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r14, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r12
+               	movq	%r13, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
 <L10>:
-               	movq	$0x20, %r13
-               	movq	$0x0, %r11
-               	cmpq	%r13, %r11
-               	jb	 <L11>
-               	jmp	 <L13>
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	movq	%r14, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L8>
 <L11>:
-               	subq	$0x1, %r13
-               	leaq	(%rdi,%r13,4), %rcx
-               	movl	(%rcx), %r14d
-               	movq	%r12, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %r12
+               	movq	-0x188(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	$0x20, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
                	movq	$0x0, %r11
-               	cmpq	%r13, %r11
-               	jb	 <L11>
+               	cmpq	%r8, %r11
+               	jb	 <L12>
+               	jmp	 <L15>
+<L12>:
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%r9, %r8
+               	subq	$0x1, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	(%rdi,%r8,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	$0x0, %r13
-               	cmpq	$0x20, %r13
-               	jb	 <L14>
-               	jmp	 <L16>
-<L14>:
-               	leaq	(%rdi,%r13,4), %rcx
-               	movl	(%rcx), %r14d
+               	movq	%r15, %r12
+               	imulq	$0x8, %r12, %r12
                	movq	%r12, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L15>
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r15
+               	movq	%r13, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+<L14>:
+               	movq	%r14, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1a0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	$0x0, %r11
+               	cmpq	%r8, %r11
+               	jb	 <L12>
 <L15>:
-               	movq	%rax, %r12
-               	addq	$0x5, %r13
-               	cmpq	$0x20, %r13
-               	jb	 <L14>
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
-               	leaq	-0xcc(%rbp), %rdi
+               	movq	-0x1d0(%rbp), %r8
+               	leaq	(%rdi,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r15, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r12
+               	movq	%r13, %r15
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
+<L18>:
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x5, %r12
+               	movq	%r15, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+<L19>:
+               	leaq	-0x4c(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
                	movq	$0x0, 0x18(%rdi)
                	movq	$0x0, 0x20(%rdi)
                	movq	$0x0, 0x28(%rdi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
-               	jmp	 <L20>
-<L17>:
-               	movq	%rcx, %r8
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L20>
+               	jmp	 <L23>
+<L20>:
+               	movq	%r12, %r8
                	imulq	$0x64, %r8, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	%rcx, %r14
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%r12, %r14
                	imulq	$0xc, %r14, %r14
                	leaq	(%rdi,%r14), %r8
-               	movq	%r8, -0x148(%rbp)
+               	movq	%r8, -0x1e0(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x6, %r14
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
                	movq	%r14, %r13
                	imulq	$0x7, %r13, %r13
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %r15
                	addq	%r13, %r15
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %r15
+               	addq	%rbx, %r15
                	movw	%r15w, %r13w
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x1e0(%rbp), %r8
                	leaq	(%r8,%r14,2), %r15
                	movw	%r13w, (%r15)
                	addq	$0x1, %r14
                	cmpq	$0x6, %r14
-               	jb	 <L18>
-<L19>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
-<L20>:
-               	leaq	(%rdi), %rcx
-               	leaq	(%rcx), %r13
-               	movzwl	(%r13), %r14d
+               	jb	 <L21>
+<L22>:
+               	addq	$0x1, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L20>
+<L23>:
+               	leaq	(%rdi), %r12
+               	leaq	(%r12), %r13
+               	movzwl	(%r13), %r12d
+               	movzwq	%r12w, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r14
+               	movq	%r13, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+<L25>:
+               	leaq	0x24(%rdi), %r13
+               	leaq	0xa(%r13), %r14
+               	movzwl	(%r14), %r13d
+               	movzwq	%r13w, %r14
                	movq	%r12, %rcx
                	movq	%r14, %rdx
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0x24(%rdi), %r12
-               	leaq	0xa(%r12), %r13
-               	movzwl	(%r13), %r12d
-               	movq	%r12, %rdx
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %r12
-               	addq	$0x2, %r12
-               	andq	$0x3, %r12
-               	imulq	$0xc, %r12, %r12
-               	leaq	(%rdi,%r12), %r13
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %r12
-               	addq	$0x4, %r12
-               	andq	$0x3, %r12
-               	leaq	(%r13,%r12,2), %r14
-               	movzwl	(%r14), %r12d
-               	movq	%r12, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%r13, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rdi,%rcx), %r14
-               	movq	%r12, %r15
-               	movq	$0x0, %rsi
-               	cmpq	$0x6, %rsi
-               	jb	 <L25>
-               	jmp	 <L27>
-<L25>:
-               	leaq	(%r14,%rsi,2), %rcx
-               	movzwl	(%rcx), %r8d
-               	movq	%r8, -0x158(%rbp)
-               	movq	%r15, %rcx
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rdx
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %r15
-               	addq	$0x1, %rsi
-               	cmpq	$0x6, %rsi
-               	jb	 <L25>
+               	movq	%rax, %r12
+               	movq	%rbx, %r13
+               	addq	$0x2, %r13
+               	andq	$0x3, %r13
+               	imulq	$0xc, %r13, %r13
+               	leaq	(%rdi,%r13), %r14
+               	movq	%rbx, %r13
+               	addq	$0x4, %r13
+               	andq	$0x3, %r13
+               	leaq	(%r14,%r13,2), %r15
+               	movzwl	(%r15), %r13d
+               	movzwq	%r13w, %r14
+               	movq	%r12, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L27>
 <L27>:
-               	addq	$0x1, %r13
-               	movq	%r15, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L24>
-<L28>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x6, %rsi
-               	jb	 <L29>
+               	movq	%rax, %r12
+               	movq	%r12, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L28>
                	jmp	 <L33>
-<L29>:
-               	movq	%r12, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L30>
-               	jmp	 <L32>
-<L30>:
-               	movq	%r14, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rdi,%rcx), %r15
-               	leaq	(%r15,%rsi,2), %rcx
-               	movzwl	(%rcx), %r15d
-               	movq	%r13, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r13
-               	addq	$0x1, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L30>
-<L32>:
-               	addq	$0x1, %rsi
-               	movq	%r13, %r12
-               	cmpq	$0x6, %rsi
+<L28>:
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%rdi,%r14), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	-0x218(%rbp), %r9
+               	leaq	(%r8,%r9,2), %r12
+               	movzwl	(%r12), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+<L31>:
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	movq	%r14, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L29>
+<L32>:
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L28>
 <L33>:
-               	leaq	-0xe7(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movw	$0x0, 0x18(%rsi)
-               	movb	$0x0, 0x1a(%rsi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x1f8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0x238(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
                	jmp	 <L39>
 <L34>:
-               	movq	%rcx, %r8
-               	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	%rcx, %r13
-               	imulq	$0x9, %r13, %r13
-               	leaq	(%rsi,%r13), %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	$0x0, %r13
-               	cmpq	$0x3, %r13
+               	movq	-0x220(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
                	jmp	 <L38>
 <L35>:
-               	movq	%r13, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x160(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%r15, %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	%r13, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x168(%rbp), %r9
-               	leaq	(%r9,%r15), %r8
-               	movq	%r8, -0x178(%rbp)
-               	movq	$0x0, %r15
-               	cmpq	$0x3, %r15
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r12
+               	imulq	$0xc, %r12, %r12
+               	leaq	(%rdi,%r12), %r14
+               	movq	-0x238(%rbp), %r8
+               	leaq	(%r14,%r8,2), %r12
+               	movzwl	(%r12), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
                	jb	 <L36>
                	jmp	 <L37>
 <L36>:
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rdi
-               	addq	%r15, %rdi
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %rdi
-               	movb	%dil, %r14b
-               	movq	-0x178(%rbp), %r8
-               	leaq	(%r8,%r15), %rdi
-               	movb	%r14b, (%rdi)
-               	addq	$0x1, %r15
-               	cmpq	$0x3, %r15
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
                	jb	 <L36>
 <L37>:
-               	addq	$0x1, %r13
-               	cmpq	$0x3, %r13
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	movq	%r14, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
 <L38>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	-0x238(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
 <L39>:
-               	movq	$0x0, %rdi
-               	cmpq	$0x3, %rdi
+               	leaq	-0x67(%rbp), %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x250(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x250(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x250(%rbp), %r8
+               	movw	$0x0, 0x18(%r8)
+               	movq	-0x250(%rbp), %r8
+               	movb	$0x0, 0x1a(%r8)
+               	movq	$0x0, %r12
+               	cmpq	$0x3, %r12
                	jb	 <L40>
-               	jmp	 <L46>
+               	jmp	 <L45>
 <L40>:
-               	movq	%r12, %r13
+               	movq	%r12, %r8
+               	imulq	$0x9, %r8, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	%r12, %r14
+               	imulq	$0x9, %r14, %r14
+               	movq	-0x250(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x3, %r14
                	jb	 <L41>
-               	jmp	 <L45>
-<L41>:
-               	movq	%r13, %r15
-               	movq	$0x0, %rbx
-               	cmpq	$0x3, %rbx
-               	jb	 <L42>
                	jmp	 <L44>
-<L42>:
-               	movq	%rbx, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	-0x188(%rbp), %r9
-               	leaq	(%r9,%rcx), %r8
-               	movq	%r8, -0x190(%rbp)
-               	movq	-0x190(%rbp), %r8
-               	leaq	(%r8,%rdi), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0x198(%rbp)
-               	movq	%r15, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r15
-               	addq	$0x1, %rbx
-               	cmpq	$0x3, %rbx
+<L41>:
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x248(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x258(%rbp), %r9
+               	leaq	(%r9,%r13), %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x3, %r13
                	jb	 <L42>
-<L44>:
+               	jmp	 <L43>
+<L42>:
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	%r13, %rdi
+               	addq	%rbx, %rdi
+               	movb	%dil, %r15b
+               	movq	-0x268(%rbp), %r8
+               	leaq	(%r8,%r13), %rdi
+               	movb	%r15b, (%rdi)
+               	addq	$0x1, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L42>
+<L43>:
                	addq	$0x1, %r14
-               	movq	%r15, %r13
                	cmpq	$0x3, %r14
                	jb	 <L41>
-<L45>:
-               	addq	$0x1, %rdi
-               	movq	%r13, %r12
-               	cmpq	$0x3, %rdi
+<L44>:
+               	addq	$0x1, %r12
+               	cmpq	$0x3, %r12
                	jb	 <L40>
+<L45>:
+               	movq	-0x220(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+               	jmp	 <L53>
 <L46>:
-               	leaq	0x12(%rsi), %rcx
-               	leaq	(%rcx), %rbx
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %ebx
-               	movq	%r12, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L47>
+               	movq	-0x270(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+               	jmp	 <L52>
 <L47>:
-               	movq	%rax, %rcx
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	$0x1, %rbx
-               	movq	%rbx, %rax
-               	movq	$0x3, %rbx
-               	xorl	%edx, %edx
-               	divq	%rbx
-               	movq	%rdx, %rbx
-               	imulq	$0x9, %rbx, %rbx
-               	leaq	(%rsi,%rbx), %rdi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	$0x2, %rbx
-               	movq	%rbx, %rax
-               	movq	$0x3, %rbx
-               	xorl	%edx, %edx
-               	divq	%rbx
-               	movq	%rdx, %rbx
-               	imulq	$0x3, %rbx, %rbx
-               	leaq	(%rdi,%rbx), %rsi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rax
-               	movq	$0x3, %rbx
-               	xorl	%edx, %edx
-               	divq	%rbx
-               	movq	%rdx, %rbx
-               	leaq	(%rsi,%rbx), %rdi
-               	movzbl	(%rdi), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	leaq	-0x138(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x50, %rdi
-<L49>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L49>
-               	movq	$0x0, %rsi
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	movq	%rsi, %rdi
-               	imulq	$0x3, %rdi, %rdi
-               	addq	$0x1, %rdi
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %rdi
-               	movw	%di, %r12w
-               	movq	%rsi, %rdi
-               	imulq	$0x10, %rdi, %rdi
-               	leaq	(%rbx,%rdi), %r13
-               	leaq	(%r13), %rdi
-               	movw	%r12w, (%rdi)
-               	movq	%rsi, %rdi
-               	addq	$0xc8, %rdi
-               	movb	%dil, %r12b
-               	leaq	0x2(%r13), %rdi
-               	movb	%r12b, (%rdi)
-               	addq	$0x1, %rsi
-               	movabsq	$0x100000001b3, %rdi    # imm = 0x100000001B3
-               	imulq	%rsi, %rdi
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %rdi
-               	leaq	0x8(%r13), %r12
-               	movq	%rdi, (%r12)
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-<L51>:
-               	movq	%rcx, %rsi
+               	movq	-0x278(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x280(%rbp)
                	movq	$0x0, %rdi
-               	cmpq	$0x5, %rdi
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
-               	movq	%rdi, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %r12
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %r13d
-               	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %r12
-               	movq	%rsi, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
+               	cmpq	$0x3, %rdi
+               	jb	 <L48>
+               	jmp	 <L51>
+<L48>:
+               	movq	%rdi, %r13
+               	imulq	$0x9, %r13, %r13
+               	movq	-0x250(%rbp), %r8
+               	leaq	(%r8,%r13), %r15
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %r13
+               	imulq	$0x3, %r13, %r13
+               	leaq	(%r15,%r13), %r12
+               	movq	-0x288(%rbp), %r8
+               	leaq	(%r12,%r8), %r13
+               	movzbl	(%r13), %r12d
+               	movzbq	%r12b, %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r12
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+<L50>:
                	addq	$0x1, %rdi
-               	movq	%rcx, %rsi
-               	cmpq	$0x5, %rdi
-               	jb	 <L52>
-<L56>:
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x5, %rcx
+               	movq	%r12, %r8
+               	movq	%r8, -0x280(%rbp)
+               	cmpq	$0x3, %rdi
+               	jb	 <L48>
+<L51>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	-0x280(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+<L52>:
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	-0x278(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+<L53>:
+               	movq	-0x250(%rbp), %r8
+               	leaq	0x12(%r8), %rdi
+               	leaq	(%rdi), %r12
+               	leaq	0x1(%r12), %rdi
+               	movzbl	(%rdi), %r12d
+               	movzbq	%r12b, %rdi
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+<L55>:
+               	movq	%rbx, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rdi
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rdi
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %r12d
-               	leaq	0x2(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdi
-               	movq	%rsi, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rcx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x9, %rdi, %rdi
+               	movq	-0x250(%rbp), %r8
+               	leaq	(%r8,%rdi), %r13
+               	movq	%rbx, %rdi
+               	addq	$0x2, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x3, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r14
+               	movq	%rbx, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%r14,%rdi), %r13
+               	movzbl	(%r13), %edi
+               	movzbq	%dil, %r13
+               	movq	%r12, %rcx
                	movq	%r13, %rdx
-               	callq	 <L58>
+               	callq	 <L56>
+<L56>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	-0x178(%rbp), %r12
+               	leaq	(%r12), %r13
+               	addq	$0x0, %r13
+               	movq	$0x50, %r14
+<L57>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L57>
+               	movq	$0x0, %r13
+               	cmpq	$0x5, %r13
+               	jb	 <L58>
+               	jmp	 <L59>
 <L58>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L59>
+               	movq	%r13, %r14
+               	imulq	$0x3, %r14, %r14
+               	addq	$0x1, %r14
+               	addq	%rbx, %r14
+               	movw	%r14w, %r15w
+               	movq	%r13, %r14
+               	imulq	$0x10, %r14, %r14
+               	leaq	(%r12,%r14), %rdi
+               	leaq	(%rdi), %r14
+               	movw	%r15w, (%r14)
+               	movq	%r13, %r14
+               	addq	$0xc8, %r14
+               	movb	%r14b, %r15b
+               	leaq	0x2(%rdi), %r14
+               	movb	%r15b, (%r14)
+               	addq	$0x1, %r13
+               	movabsq	$0x100000001b3, %r14    # imm = 0x100000001B3
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	leaq	0x8(%rdi), %r15
+               	movq	%r14, (%r15)
+               	cmpq	$0x5, %r13
+               	jb	 <L58>
 <L59>:
-               	movq	%rax, %rcx
-               	leaq	0x40(%rbx), %rsi
-               	leaq	0x8(%rsi), %rdi
-               	movq	(%rdi), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L60>
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x5, %r13
+               	jb	 <L60>
+               	jmp	 <L62>
 <L60>:
-               	movq	%rax, %rcx
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x5, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%rbx,%rsi), %rdi
-               	leaq	(%rdi), %rbx
-               	movzwl	(%rbx), %esi
-               	movq	%rsi, %rdx
+               	movq	%r13, %r14
+               	imulq	$0x10, %r14, %r14
+               	leaq	(%r12,%r14), %r15
+               	leaq	-0x78(%rbp), %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	(%r15), %r14
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r14, (%r8)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	-0x2b0(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	(%r8), %r14
+               	movq	-0x2a8(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	%r14, -0x88(%rbp)
+               	movq	%r15, -0x80(%rbp)
+               	leaq	-0x88(%rbp), %r14
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdx
                	callq	 <L61>
 <L61>:
-               	movq	%rax, %rcx
-               	movq	$0x10, %rdx
-               	callq	 <L62>
+               	movq	%rax, %rdi
+               	addq	$0x1, %r13
+               	cmpq	$0x5, %r13
+               	jb	 <L60>
 <L62>:
-               	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x150(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x150(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x150(%rbp), %r8
-               	movl	$0x0, 0x18(%r8)
-               	movq	-0x180(%rbp), %r8
-               	movl	%r8d, %ebx
-               	movq	$0x0, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-               	jmp	 <L64>
-<L63>:
-               	movl	%esi, %edi
-               	imull	$0x12345678, %edi, %edi # imm = 0x12345678
-               	addl	%ebx, %edi
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8,%rsi,4), %r12
-               	movl	%edi, (%r12)
-               	addq	$0x1, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-<L64>:
-               	movq	$0x11, %rdx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rbx
-               	movq	$0x0, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L66>
-               	jmp	 <L68>
-<L66>:
-               	movq	%rsi, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	-0x180(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x7, %rcx
+               	movq	%rbx, %r13
+               	addq	$0x3, %r13
+               	movq	%r13, %rax
+               	movq	$0x5, %r13
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8,%rcx,4), %rdi
-               	movl	(%rdi), %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%r12,%r13), %r14
+               	leaq	-0x98(%rbp), %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	(%r14), %r15
+               	movq	0x8(%r14), %r13
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r13, 0x8(%r8)
+               	movq	-0x2b8(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	-0x2b8(%rbp), %r8
+               	movq	0x8(%r8), %r14
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xa0(%rbp)
+               	leaq	-0xa8(%rbp), %r13
+               	movq	%rdi, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	leaq	0x40(%r12), %r13
+               	leaq	0x8(%r13), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %r13
+               	xorq	%r15, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %r14
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+<L65>:
+               	movq	%rbx, %r13
+               	addq	$0x1, %r13
+               	movq	%r13, %rax
+               	movq	$0x5, %r13
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%r12,%r13), %r14
+               	leaq	(%r14), %r12
+               	movzwl	(%r12), %r13d
+               	movzwq	%r13w, %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x10, %rdx
                	callq	 <L67>
 <L67>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L66>
+               	movq	%rax, %rdi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movl	$0x0, 0x18(%rsi)
+               	movl	%ebx, %r12d
+               	movq	$0x0, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
+               	jmp	 <L69>
 <L68>:
+               	movl	%r13d, %r14d
+               	imull	$0x12345678, %r14d, %r14d # imm = 0x12345678
+               	addl	%r12d, %r14d
+               	leaq	(%rsi,%r13,4), %r15
+               	movl	%r14d, (%r15)
+               	addq	$0x1, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
+<L69>:
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L70>
+               	jmp	 <L71>
+<L70>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	$0x11, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L70>
+<L71>:
+               	movq	%rdi, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x7, %r12
+               	jb	 <L72>
+               	jmp	 <L75>
+<L72>:
+               	movq	%r12, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	%rbx, %r13
+               	movq	%r13, %rax
+               	movq	$0x7, %r13
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	leaq	(%rsi,%r13,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x2d0(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+               	jmp	 <L74>
+<L73>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x2d0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+<L74>:
+               	addq	$0x1, %r12
+               	movq	%r13, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	cmpq	$0x7, %r12
+               	jb	 <L72>
+<L75>:
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	$0x1234, %r12           # imm = 0x1234
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+<L77>:
+               	movq	%rbx, %rcx
+               	movq	$0x4, %rdx
+               	callq	 <L78>
+<L78>:
+               	movq	%rax, %rbx
+               	leaq	(%rsi), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0x4(%rsi), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0x8(%rsi), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0xc(%rsi), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0x10(%rsi), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x14(%rsi), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x18(%rsi), %r13
+               	movl	(%r13), %esi
+               	xorl	$0xf0f0f0f0, %r12d      # imm = 0xF0F0F0F0
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L79>
+<L79>:
+               	movq	%rax, %rbx
+               	movl	%r12d, %esi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L80>
+<L80>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x11, %rdx
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rbx
                	movq	%rbx, %rcx
                	movq	$0x1234, %rdx           # imm = 0x1234
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8), %rbx
-               	movl	(%rbx), %esi
-               	movq	-0x150(%rbp), %r8
-               	leaq	0x4(%r8), %rbx
-               	movl	(%rbx), %esi
-               	movq	-0x150(%rbp), %r8
-               	leaq	0x8(%r8), %rbx
-               	movl	(%rbx), %esi
-               	movq	-0x150(%rbp), %r8
-               	leaq	0xc(%r8), %rbx
-               	movl	(%rbx), %esi
-               	movq	-0x150(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movq	-0x150(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	movq	-0x150(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movl	(%rdi), %r12d
-               	xorl	$0xf0f0f0f0, %esi       # imm = 0xF0F0F0F0
-               	movl	(%rbx), %edi
-               	movl	%edi, %edx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rcx
-               	movl	%esi, %edx
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movq	$0x11, %rdx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rcx
-               	movq	$0x1234, %rdx           # imm = 0x1234
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x1a8(%rbp), %rbx
-               	movq	-0x1b0(%rbp), %rdi
-               	movq	-0x1b8(%rbp), %rsi
-               	movq	-0x1c0(%rbp), %r12
-               	movq	-0x1c8(%rbp), %r13
-               	movq	-0x1d0(%rbp), %r14
-               	movq	-0x1d8(%rbp), %r15
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rax
+               	movq	-0x2d8(%rbp), %rbx
+               	movq	-0x2e0(%rbp), %rdi
+               	movq	-0x2e8(%rbp), %rsi
+               	movq	-0x2f0(%rbp), %r12
+               	movq	-0x2f8(%rbp), %r13
+               	movq	-0x300(%rbp), %r14
+               	movq	-0x308(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/global_data.dis
+++ b/test/golden/x86_64-windows/mem/global_data.dis
@@ -5,32 +5,86 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzwl	(%rbx), %esi
                	leaq	0x2(%rdx), %rbx
                	movzbl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movzbq	%dil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,129 +92,365 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.fold_globals>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movzbl	, %edx <corpus.cases.mem.global_data.fold_globals+0x1b>
-               	callq	 <L0>
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%rcx, %rax
+               	movzbl	, %edx <corpus.cases.mem.global_data.fold_globals+0x2d>
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movzwl	, %edx <corpus.cases.mem.global_data.fold_globals+0x2a>
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	, %edx <corpus.cases.mem.global_data.fold_globals+0x38>
-               	callq	 <L2>
+               	movzwl	, %edx <corpus.cases.mem.global_data.fold_globals+0x8a>
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x47>
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movzbl	, %edx <corpus.cases.mem.global_data.fold_globals+0x56>
-               	callq	 <L4>
+               	movl	, %edx <corpus.cases.mem.global_data.fold_globals+0xe6>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movzwl	, %edx <corpus.cases.mem.global_data.fold_globals+0x65>
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movl	, %edx <corpus.cases.mem.global_data.fold_globals+0x73>
-               	callq	 <L6>
+               	movq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x141>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x82>
-               	callq	 <L7>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x91>
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
+               	movzbl	, %edx <corpus.cases.mem.global_data.fold_globals+0x19a>
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0xa8>
-               	movsd	(%rdx), %xmm1
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0xb8>
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x6, %rdi
+               	movzwl	, %edx <corpus.cases.mem.global_data.fold_globals+0x1f7>
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L10>
-               	jmp	 <L12>
+               	jmp	 <L11>
 <L10>:
-               	leaq	(%rbx,%rdi,4), %rax
-               	movl	(%rax), %edx
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	callq	 <L11>
-<L11>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x6, %rdi
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
                	jb	 <L10>
+<L11>:
+               	movl	, %edx <corpus.cases.mem.global_data.fold_globals+0x253>
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0xf7>
-               	movzwl	(%rax), %edx
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x103>
-               	movzbl	(%rax), %ebx
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x113>
-               	movq	(%rax), %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	callq	 <L13>
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L14>
+               	movq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x2af>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L15>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x133>
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %ebx
-               	leaq	0x2(%rcx), %rdx
-               	movzbl	(%rdx), %esi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rdi
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x308>
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
                	movq	%rbx, %rdx
                	callq	 <L16>
 <L16>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x325>
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
                	movq	%rax, %rcx
-               	movq	%rsi, %rdx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L18>
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x33d>
+               	movq	$0x0, %rbx
+               	cmpq	$0x6, %rbx
+               	jb	 <L18>
+               	jmp	 <L21>
 <L18>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0x17f>
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
+               	leaq	(%rdx,%rbx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
 <L20>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x6, %rbx
+               	jb	 <L18>
 <L21>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x1ba>
-               	movl	(%rcx), %edx
+               	leaq	-0x10(%rbp), %rdx
+               	movq	, %rbx <corpus.cases.mem.global_data.fold_globals+0x3cc>
+               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x3db>
+               	movq	%rbx, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %rsi
+               	movq	%rbx, -0x20(%rbp)
+               	movq	%rsi, -0x18(%rbp)
+               	leaq	-0x20(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L22>
 <L22>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x3fc>
+               	leaq	-0x30(%rbp), %rbx
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movq	%rdx, -0x40(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	leaq	-0x40(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L23>
+<L23>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x440>
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x4a3>
+               	leaq	0x2(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x507>
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x573>
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -300,257 +590,256 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x180, %rsp            # imm = 0x180
-               	movq	%rbx, -0x108(%rbp)
-               	movq	%rdi, -0x110(%rbp)
-               	movq	%rsi, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movq	%r13, -0x128(%rbp)
-               	movq	%r14, -0x130(%rbp)
-               	movq	%r15, -0x138(%rbp)
-               	movaps	%xmm14, -0x150(%rbp)
-               	movaps	%xmm15, -0x160(%rbp)
+               	subq	$0x1a0, %rsp            # imm = 0x1A0
+               	movq	%rbx, -0x128(%rbp)
+               	movq	%rdi, -0x130(%rbp)
+               	movq	%rsi, -0x138(%rbp)
+               	movq	%r12, -0x140(%rbp)
+               	movq	%r13, -0x148(%rbp)
+               	movq	%r14, -0x150(%rbp)
+               	movq	%r15, -0x158(%rbp)
+               	movaps	%xmm14, -0x170(%rbp)
+               	movaps	%xmm15, -0x180(%rbp)
                	movq	%rcx, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
-               	callq	 <L1>
-<L1>:
                	movq	%rax, %rcx
                	movabsq	$-0x61c8864680b583eb, %rsi # imm = 0x9E3779B97F4A7C15
                	addq	%rbx, %rsi
                	movq	%rsi, %rdx
+               	callq	 <L1>
+<L1>:
+               	movq	%rax, %rcx
+               	movq	$-0x12d687, %rdx        # imm = 0xFFED2979
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
-               	movl	$0xffed2979, %edx       # imm = 0xFFED2979
+               	movabsq	$0x3fc4000000000000, %rsi # imm = 0x3FC4000000000000
+               	movq	%rsi, %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
-               	movsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x8c>
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x9b>
-               	movq	%r8, -0x58(%rbp)
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0xa6>
-               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0xaf>
-               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0xbc>
-               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0xbb>
-               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0xd2>
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xe1>
-               	movq	%r8, -0x48(%rbp)
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xa4>
+               	movq	%r8, -0x78(%rbp)
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0xaf>
+               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0xb8>
+               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0xc5>
+               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0xc4>
+               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0xdb>
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xea>
+               	movq	%r8, -0x68(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x50(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	movq	$0x0, %rsi
                	cmpq	$0x5, %rsi
-               	jb	 <L5>
-               	jmp	 <L9>
-<L5>:
+               	jb	 <L4>
+               	jmp	 <L8>
+<L4>:
                	movq	%rsi, %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movzbl	, %ecx <corpus.cases.mem.global_data.checksum+0x102>
-               	movq	-0x60(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movb	%cl,  <corpus.cases.mem.global_data.checksum+0x11a>
-               	movzwl	, %ecx <corpus.cases.mem.global_data.checksum+0x121>
-               	movq	-0x60(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x70(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movw	%cx,  <corpus.cases.mem.global_data.checksum+0x13b>
-               	movl	, %ecx <corpus.cases.mem.global_data.checksum+0x141>
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
-               	movq	%r8, -0x78(%rbp)
-               	movq	-0x78(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movl	%ecx,  <corpus.cases.mem.global_data.checksum+0x159>
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x160>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x16e>
-               	movzbl	, %ecx <corpus.cases.mem.global_data.checksum+0x175>
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movb	%cl,  <corpus.cases.mem.global_data.checksum+0x182>
-               	movzwl	, %ecx <corpus.cases.mem.global_data.checksum+0x189>
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movw	%cx,  <corpus.cases.mem.global_data.checksum+0x197>
-               	movl	, %ecx <corpus.cases.mem.global_data.checksum+0x19d>
-               	movq	-0x78(%rbp), %r8
-               	addl	%r8d, %ecx
-               	movl	%ecx,  <corpus.cases.mem.global_data.checksum+0x1aa>
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x1b1>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x1bf>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x1c6>
-               	movss	(%rcx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1d6>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x1dd>
-               	movss	%xmm1, (%rcx)
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x1e8>
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1f8>
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x204>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x20b>
-               	movsd	%xmm0, (%rcx)
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
                	movq	%r8, -0x80(%rbp)
-               	movq	$0x0, %r8
+               	movzbl	, %ecx <corpus.cases.mem.global_data.checksum+0x10b>
+               	movq	-0x80(%rbp), %r9
+               	movb	%r9b, %r8b
                	movq	%r8, -0x88(%rbp)
                	movq	-0x88(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	-0x58(%rbp), %r9
-               	movq	-0x88(%rbp), %r10
-               	leaq	(%r9,%r10,4), %r8
+               	addl	%r8d, %ecx
+               	movb	%cl,  <corpus.cases.mem.global_data.checksum+0x129>
+               	movzwl	, %ecx <corpus.cases.mem.global_data.checksum+0x130>
+               	movq	-0x80(%rbp), %r9
+               	movw	%r9w, %r8w
                	movq	%r8, -0x90(%rbp)
-               	movq	-0x90(%rbp), %r9
-               	movl	(%r9), %r8d
-               	movq	%r8, -0x98(%rbp)
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %ecx
-               	addl	$0x1, %ecx
+               	movq	-0x90(%rbp), %r8
+               	addl	%r8d, %ecx
+               	movw	%cx,  <corpus.cases.mem.global_data.checksum+0x150>
+               	movl	, %ecx <corpus.cases.mem.global_data.checksum+0x156>
                	movq	-0x80(%rbp), %r9
                	movl	%r9d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0xa0(%rbp)
+               	movq	%r8, -0x98(%rbp)
                	movq	-0x98(%rbp), %r8
+               	addl	%r8d, %ecx
+               	movl	%ecx,  <corpus.cases.mem.global_data.checksum+0x174>
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x17b>
+               	movq	-0x80(%rbp), %r8
+               	addq	%r8, %rcx
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x189>
+               	movzbl	, %ecx <corpus.cases.mem.global_data.checksum+0x190>
+               	movq	-0x88(%rbp), %r8
+               	addl	%r8d, %ecx
+               	movb	%cl,  <corpus.cases.mem.global_data.checksum+0x1a0>
+               	movzwl	, %ecx <corpus.cases.mem.global_data.checksum+0x1a7>
+               	movq	-0x90(%rbp), %r8
+               	addl	%r8d, %ecx
+               	movw	%cx,  <corpus.cases.mem.global_data.checksum+0x1b8>
+               	movl	, %ecx <corpus.cases.mem.global_data.checksum+0x1be>
+               	movq	-0x98(%rbp), %r8
+               	addl	%r8d, %ecx
+               	movl	%ecx,  <corpus.cases.mem.global_data.checksum+0x1ce>
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x1d5>
+               	movq	-0x80(%rbp), %r8
+               	addq	%r8, %rcx
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x1e3>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x1ea>
+               	movss	(%rcx), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1fa>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x201>
+               	movss	%xmm1, (%rcx)
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x20c>
+               	movsd	(%rcx), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x21c>
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x228>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x22f>
+               	movsd	%xmm0, (%rcx)
+               	movq	-0x80(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0xa0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	-0x78(%rbp), %r9
+               	movq	-0xa8(%rbp), %r10
+               	leaq	(%r9,%r10,4), %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xa8(%rbp), %r8
+               	movl	%r8d, %ecx
+               	addl	$0x1, %ecx
                	movq	-0xa0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc0(%rbp), %r9
                	movl	%r8d, %ecx
                	xorl	%r9d, %ecx
-               	movq	-0x90(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movl	%ecx, (%r8)
-               	movq	-0x88(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, %r8
-               	movq	%r8, -0x88(%rbp)
-               	movq	-0x88(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L6>
-<L7>:
-               	movzwl	(%rdi), %r8d
                	movq	%r8, -0xa8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L5>
+<L6>:
+               	movzwl	(%rdi), %r8d
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0x80(%rbp), %r8
                	movw	%r8w, %cx
-               	movq	-0xa8(%rbp), %r9
+               	movq	-0xc8(%rbp), %r9
                	movl	%r9d, %r8d
                	addl	%ecx, %r8d
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
                	movw	%r8w, (%rdi)
                	movzbl	(%r12), %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	-0x80(%rbp), %r8
                	movb	%r8b, %cl
-               	movq	-0xb8(%rbp), %r9
+               	movq	-0xd8(%rbp), %r9
                	movl	%r9d, %r8d
                	xorl	%ecx, %r8d
-               	movq	%r8, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
                	movb	%r8b, (%r12)
                	movq	(%r13), %rcx
                	imulq	$0x3, %rcx, %rcx
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	addq	%r8, %rcx
                	movq	%rcx, (%r13)
-               	leaq	-0x40(%rbp), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x354>
-               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x363>
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xc8(%rbp), %r8
+               	leaq	-0x60(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x37e>
+               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x38d>
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xe8(%rbp), %r8
                	movq	%rcx, (%r8)
-               	movq	-0xc8(%rbp), %r8
-               	movq	-0xd0(%rbp), %r9
+               	movq	-0xe8(%rbp), %r8
+               	movq	-0xf0(%rbp), %r9
                	movq	%r9, 0x8(%r8)
-               	movq	-0xc8(%rbp), %r8
+               	movq	-0xe8(%rbp), %r8
                	movq	(%r8), %rcx
-               	movq	-0xc8(%rbp), %r9
+               	movq	-0xe8(%rbp), %r9
                	movq	0x8(%r9), %r8
-               	movq	%r8, -0xd8(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	movq	%rcx, (%r14)
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0xf8(%rbp), %r8
                	movq	%r8, 0x8(%r14)
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rax
                	movq	$0x3, %rcx
                	xorl	%edx, %edx
                	divq	%rcx
                	movq	%rdx, %rcx
                	leaq	(%r15,%rcx,2), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
                	movzwl	(%r8), %ecx
                	movl	%ecx, %r8d
                	addl	$0x64, %r8d
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rax
                	movq	$0x3, %rcx
                	xorl	%edx, %edx
                	divq	%rcx
                	movq	%rdx, %rcx
                	leaq	(%r15,%rcx,2), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0xf0(%rbp), %r8
-               	movq	-0xe8(%rbp), %r9
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	movq	-0x108(%rbp), %r9
                	movw	%r9w, (%r8)
-               	movq	-0x48(%rbp), %r9
+               	movq	-0x68(%rbp), %r9
                	movl	(%r9), %r8d
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x80(%rbp), %r8
                	movl	%r8d, %ecx
-               	movq	-0xf8(%rbp), %r9
+               	movq	-0x118(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%ecx, %r8d
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x48(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x68(%rbp), %r8
+               	movq	-0x120(%rbp), %r9
                	movl	%r9d, (%r8)
-               	movq	-0x50(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %rcx
                	addq	$0x1, %rsi
                	movq	%rcx, %r8
-               	movq	%r8, -0x50(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	cmpq	$0x5, %rsi
-               	jb	 <L5>
-<L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x477>
+               	jb	 <L4>
+<L8>:
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x4a1>
                	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x48b>
-               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x492>
-               	movq	-0x50(%rbp), %r8
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x4b5>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x4bc>
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rbx, %rdx
-               	callq	 <L10>
-<L10>:
+               	callq	 <L9>
+<L9>:
                	movq	%rax, %rcx
                	leaq	-0x10(%rbp), %rbx
                	leaq	-0x20(%rbp), %rsi
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x4b3>
-               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4c2>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x4dd>
+               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4ec>
                	movq	%rdi, (%rsi)
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rdi
@@ -568,39 +857,35 @@ Disassembly of section .text:
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rbx
                	movq	0x8(%rsi), %rdi
-               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x4fd>
-               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x50c>
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x50b>
-               	movzwl	(%rbx), %esi
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x517>
-               	movzbl	(%rbx), %edi
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x527>
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
+               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x527>
+               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x536>
+               	leaq	-0x40(%rbp), %rbx
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x539>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x548>
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movq	%rsi, -0x50(%rbp)
+               	movq	%rdi, -0x48(%rbp)
+               	leaq	-0x50(%rbp), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rcx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movaps	-0x150(%rbp), %xmm14
-               	movaps	-0x160(%rbp), %xmm15
-               	movq	-0x108(%rbp), %rbx
-               	movq	-0x110(%rbp), %rdi
-               	movq	-0x118(%rbp), %rsi
-               	movq	-0x120(%rbp), %r12
-               	movq	-0x128(%rbp), %r13
-               	movq	-0x130(%rbp), %r14
-               	movq	-0x138(%rbp), %r15
+               	movaps	-0x170(%rbp), %xmm14
+               	movaps	-0x180(%rbp), %xmm15
+               	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %rdi
+               	movq	-0x138(%rbp), %rsi
+               	movq	-0x140(%rbp), %r12
+               	movq	-0x148(%rbp), %r13
+               	movq	-0x150(%rbp), %r14
+               	movq	-0x158(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/global_zero.dis
+++ b/test/golden/x86_64-windows/mem/global_zero.dis
@@ -5,171 +5,81 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	leaq	(%rdx), %rbx
-               	movzwl	(%rbx), %esi
-               	leaq	0x2(%rdx), %rbx
-               	movzbl	(%rbx), %edi
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.mem.global_zero.fold_zeros>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
-               	movzbl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x23>
-               	callq	 <L0>
+               	movq	%rcx, %rax
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	leaq	0x2(%rdx), %rbx
+               	movzbl	(%rbx), %edi
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movzwl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x32>
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x40>
-               	callq	 <L2>
+               	movzbq	%dil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x4f>
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x5d>
-               	callq	 <L4>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x6c>
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x7b>
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x92>
-               	movsd	(%rdx), %xmm1
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0xa5>
-               	callq	 <L8>
-<L8>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xb1>
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L9>
-               	jmp	 <L11>
-<L9>:
-               	leaq	(%rbx,%rdi,4), %rax
-               	movl	(%rax), %edx
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
-               	callq	 <L10>
-<L10>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L9>
-<L11>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xf6>
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L12>
-               	jmp	 <L16>
-<L12>:
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
                	movq	%rdi, %rax
-               	imulq	$0x10, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %edx
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r12d
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r13
-               	movq	%rsi, %rcx
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L15>
-<L15>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x8, %rdi
-               	jb	 <L12>
-<L16>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x162>
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %edx
-               	leaq	0x2(%rax), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rdi
-               	movq	%rsi, %rcx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L19>
-<L19>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x1ab>
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x4, %rdi
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%rdi,8), %rax
-               	movq	(%rax), %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x4, %rdi
-               	jb	 <L20>
-<L22>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.checksum+0xc>
-               	movzbl	(%rax), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L23>
-<L23>:
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
@@ -179,241 +89,617 @@ Disassembly of section .text:
                	popq	%rbp
                	retq
 
+<corpus.cases.mem.global_zero.fold_zeros>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%rcx, %rax
+               	movzbl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x2d>
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movzwl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x8a>
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0xe6>
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x141>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	movl	, %edx <corpus.cases.mem.global_zero.fold_zeros+0x199>
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x1f5>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x24e>
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x2b2>
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x314>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x36d>
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rbx            # imm = 0x200
+               	jb	 <L18>
+               	jmp	 <L21>
+<L18>:
+               	leaq	(%rdx,%rbx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+<L20>:
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x200, %rbx            # imm = 0x200
+               	jb	 <L18>
+<L21>:
+               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x3fe>
+               	movq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L24>
+<L22>:
+               	movq	%rdi, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movq	%r12, (%rax)
+               	movq	%r13, 0x8(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r12
+               	movq	%rdx, -0x20(%rbp)
+               	movq	%r12, -0x18(%rbp)
+               	leaq	-0x20(%rbp), %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L23>
+<L23>:
+               	addq	$0x1, %rdi
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L24>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x467>
+               	leaq	-0x30(%rbp), %rdx
+               	movq	(%rax), %rbx
+               	movq	0x8(%rax), %rdi
+               	movq	%rbx, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rbx
+               	movq	%rax, -0x40(%rbp)
+               	movq	%rbx, -0x38(%rbp)
+               	leaq	-0x40(%rbp), %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L25>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x4ab>
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L26>
+               	jmp	 <L29>
+<L26>:
+               	leaq	(%rdx,%rbx,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+<L28>:
+               	addq	$0x1, %rbx
+               	movq	%rsi, %rax
+               	cmpq	$0x4, %rbx
+               	jb	 <L26>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x555>
+               	movzbl	(%rdx), %ebx
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
 <corpus.cases.mem.global_zero.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
+               	subq	$0x90, %rsp
                	movq	%rbx, -0x38(%rbp)
                	movq	%rdi, -0x40(%rbp)
                	movq	%rsi, -0x48(%rbp)
                	movq	%r12, -0x50(%rbp)
                	movq	%r13, -0x58(%rbp)
                	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
                	movq	%rcx, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rcx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	movb	%bl, %sil
-               	movl	$0xc8, %edi
-               	addl	%esi, %edi
-               	movb	%dil,  <corpus.cases.mem.global_zero.checksum+0x47>
-               	movw	%bx, %si
-               	movl	$0x9c40, %edi           # imm = 0x9C40
-               	addl	%esi, %edi
-               	movw	%di,  <corpus.cases.mem.global_zero.checksum+0x58>
-               	movl	%ebx, %esi
-               	movl	$0xb2d05e00, %edi       # imm = 0xB2D05E00
-               	addl	%esi, %edi
-               	movl	%edi,  <corpus.cases.mem.global_zero.checksum+0x67>
-               	movabsq	$-0x123456789abcdf0, %rdi # imm = 0xFEDCBA9876543210
+               	movq	%rax, %rsi
+               	movb	%bl, %dil
+               	movl	$0xc8, %r12d
+               	addl	%edi, %r12d
+               	movb	%r12b,  <corpus.cases.mem.global_zero.checksum+0x4f>
+               	movw	%bx, %di
+               	movl	$0x9c40, %r12d          # imm = 0x9C40
+               	addl	%edi, %r12d
+               	movw	%r12w,  <corpus.cases.mem.global_zero.checksum+0x63>
+               	movl	%ebx, %edi
+               	movl	$0xb2d05e00, %r12d      # imm = 0xB2D05E00
+               	addl	%edi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x75>
+               	movabsq	$-0x123456789abcdf0, %r12 # imm = 0xFEDCBA9876543210
+               	addq	%rbx, %r12
+               	movq	%r12,  <corpus.cases.mem.global_zero.checksum+0x89>
+               	movl	$0x77359400, %r12d      # imm = 0x77359400
+               	addl	%edi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x99>
+               	movabsq	$0x7ce66c50e2840000, %rdi # imm = 0x7CE66C50E2840000
                	addq	%rbx, %rdi
-               	movq	%rdi,  <corpus.cases.mem.global_zero.checksum+0x7b>
-               	movl	$0x77359400, %edi       # imm = 0x77359400
-               	addl	%esi, %edi
-               	movl	%edi,  <corpus.cases.mem.global_zero.checksum+0x88>
-               	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
-               	addq	%rbx, %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0x9c>
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xa3>
-               	movl	$0x3fe00000, (%rsi)     # imm = 0x3FE00000
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xb0>
+               	movq	%rdi,  <corpus.cases.mem.global_zero.checksum+0xad>
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0xb4>
+               	movl	$0x3fe00000, (%rdi)     # imm = 0x3FE00000
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0xc1>
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rsi)
-               	movabsq	$0x100000001b3, %rsi    # imm = 0x100000001B3
-               	addq	%rbx, %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0xd1>
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xd8>
-               	movq	$0x0, %rdi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L2>
-               	jmp	 <L3>
+               	movq	%r11, (%rdi)
+               	movabsq	$0x100000001b3, %rdi    # imm = 0x100000001B3
+               	addq	%rbx, %rdi
+               	movq	%rdi,  <corpus.cases.mem.global_zero.checksum+0xe2>
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0xe9>
+               	movq	$0x0, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movabsq	$0x9e3779b1, %r14       # imm = 0x9E3779B1
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	movl	%r14d, %r15d
+               	leaq	(%rdi,%r12,4), %r14
+               	movl	%r15d, (%r14)
+               	movq	%r13, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L1>
 <L2>:
-               	movq	%rdi, %r12
-               	addq	$0x1, %r12
-               	movabsq	$0x9e3779b1, %r13       # imm = 0x9E3779B1
-               	imulq	%r12, %r13
-               	addq	%rbx, %r13
-               	movl	%r13d, %r14d
-               	leaq	(%rsi,%rdi,4), %r13
-               	movl	%r14d, (%r13)
-               	movq	%r12, %rdi
-               	cmpq	$0x200, %rdi            # imm = 0x200
-               	jb	 <L2>
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x13b>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x12b>
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L4>
-               	jmp	 <L5>
-<L4>:
-               	movq	%rdi, %r12
-               	imulq	$0xb, %r12, %r12
-               	addq	$0x3, %r12
-               	addq	%rbx, %r12
-               	movw	%r12w, %r13w
-               	movq	%rdi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rsi,%r12), %r14
-               	leaq	(%r14), %r12
-               	movw	%r13w, (%r12)
-               	movq	%rdi, %r12
-               	addq	$0xfa, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x2(%r14), %r12
-               	movb	%r13b, (%r12)
-               	addq	$0x1, %rdi
-               	movabsq	$-0x61c8864680b583eb, %r12 # imm = 0x9E3779B97F4A7C15
-               	imulq	%rdi, %r12
-               	addq	%rbx, %r12
-               	leaq	0x8(%r14), %r13
-               	movq	%r12, (%r13)
-               	cmpq	$0x8, %rdi
-               	jb	 <L4>
-<L5>:
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1d9>
-               	leaq	-0x10(%rbp), %rdi
-               	movq	(%rsi), %r12
-               	movq	0x8(%rsi), %r13
-               	movq	%r12, (%rdi)
-               	movq	%r13, 0x8(%rdi)
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1c2>
-               	movq	(%rdi), %r12
-               	movq	0x8(%rdi), %r13
-               	movq	%r12, (%rsi)
-               	movq	%r13, 0x8(%rsi)
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1e7>
-               	movq	$0x0, %rdi
-               	cmpq	$0x4, %rdi
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	%rdi, %r12
+               	movq	%r12, %r13
+               	imulq	$0xb, %r13, %r13
+               	addq	$0x3, %r13
+               	addq	%rbx, %r13
+               	movw	%r13w, %r14w
+               	movq	%r12, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rdi,%r13), %r15
+               	leaq	(%r15), %r13
+               	movw	%r14w, (%r13)
+               	movq	%r12, %r13
+               	addq	$0xfa, %r13
+               	movb	%r13b, %r14b
+               	leaq	0x2(%r15), %r13
+               	movb	%r14b, (%r13)
                	addq	$0x1, %r12
-               	movq	$0x12345678, %r13       # imm = 0x12345678
+               	movabsq	$-0x61c8864680b583eb, %r13 # imm = 0x9E3779B97F4A7C15
                	imulq	%r12, %r13
                	addq	%rbx, %r13
-               	leaq	(%rsi,%rdi,8), %r14
+               	leaq	0x8(%r15), %r14
                	movq	%r13, (%r14)
-               	movq	%r12, %rdi
-               	cmpq	$0x4, %rdi
-               	jb	 <L6>
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x1e8>
+               	leaq	-0x10(%rbp), %r12
+               	movq	(%rdi), %r13
+               	movq	0x8(%rdi), %r14
+               	movq	%r13, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x1d3>
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r14
+               	movq	%r13, (%rdi)
+               	movq	%r14, 0x8(%rdi)
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x1fa>
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movq	$0x12345678, %r14       # imm = 0x12345678
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	leaq	(%rdi,%r12,8), %r15
+               	movq	%r14, (%r15)
+               	movq	%r13, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+<L6>:
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x260>
+               	movb	$0x4d, (%rdi)
+               	movq	%rsi, %rcx
+               	callq	 <L7>
 <L7>:
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x24d>
-               	movb	$0x4d, (%rsi)
-               	callq	 <L8>
+               	movq	%rax, %rsi
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0xa41>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xa2b>
-               	movl	(%rsi), %edi
-               	movl	%edi, %edx
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x642>
-               	movl	(%rsi), %edi
-               	movl	%edi, %edx
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x6a4>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rdx
                	callq	 <L10>
 <L10>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rsi
                	addq	$0x1f4, %rbx            # imm = 0x1F4
                	movq	%rbx, %rax
                	movq	$0x200, %rbx            # imm = 0x200
                	xorl	%edx, %edx
                	divq	%rbx
                	movq	%rdx, %rbx
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x26e>
-               	leaq	(%rsi,%rbx,4), %rdi
-               	movl	(%rdi), %ebx
-               	movl	%ebx, %edx
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x2d8>
+               	leaq	(%rdi,%rbx,4), %r12
+               	movl	(%r12), %ebx
+               	movl	%ebx, %edi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rdx
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rcx
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x285>
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
+               	movq	%rax, %rbx
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x2f7>
+               	movq	$0x0, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%rbx,%rsi,4), %rdi
-               	movl	$0x0, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
+               	leaq	(%rsi,%rdi,4), %r12
+               	movl	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
                	jb	 <L12>
 <L13>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x2c0>
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x334>
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
                	jb	 <L14>
                	jmp	 <L15>
 <L14>:
-               	leaq	-0x20(%rbp), %rdi
-               	leaq	(%rdi), %r12
-               	movw	$0x0, (%r12)
-               	leaq	0x2(%rdi), %r12
-               	movb	$0x0, (%r12)
-               	leaq	0x8(%rdi), %r12
-               	movq	$0x0, (%r12)
-               	movq	%rsi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rbx,%r12), %r13
-               	movq	(%rdi), %r12
-               	movq	0x8(%rdi), %r14
-               	movq	%r12, (%r13)
-               	movq	%r14, 0x8(%r13)
-               	addq	$0x1, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	-0x20(%rbp), %r12
+               	leaq	(%r12), %r13
+               	movw	$0x0, (%r13)
+               	leaq	0x2(%r12), %r13
+               	movb	$0x0, (%r13)
+               	leaq	0x8(%r12), %r13
+               	movq	$0x0, (%r13)
+               	movq	%rdi, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r14
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r15
+               	movq	%r13, (%r14)
+               	movq	%r15, 0x8(%r14)
+               	addq	$0x1, %rdi
+               	cmpq	$0x8, %rdi
                	jb	 <L14>
 <L15>:
-               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x327>
-               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x32f>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x337>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x342>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x34c>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x357>
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x362>
-               	movl	$0x0, (%rbx)
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x36f>
-               	movq	$0x0, (%rbx)
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x37d>
-               	leaq	-0x30(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	movw	$0x0, (%rsi)
-               	leaq	0x2(%rbx), %rsi
-               	movb	$0x0, (%rsi)
-               	leaq	0x8(%rbx), %rsi
+               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x39f>
+               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3a7>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3af>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3ba>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3c4>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3cf>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3da>
+               	movl	$0x0, (%rsi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3e7>
                	movq	$0x0, (%rsi)
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3a6>
-               	movq	(%rbx), %rdi
-               	movq	0x8(%rbx), %r12
-               	movq	%rdi, (%rsi)
-               	movq	%r12, 0x8(%rsi)
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x3cb>
-               	movq	$0x0, %rsi
-               	cmpq	$0x4, %rsi
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3f5>
+               	leaq	-0x30(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movw	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x41e>
+               	movq	(%rsi), %r12
+               	movq	0x8(%rsi), %r13
+               	movq	%r12, (%rdi)
+               	movq	%r13, 0x8(%rdi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x443>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L16>
                	jmp	 <L17>
 <L16>:
-               	leaq	(%rbx,%rsi,8), %rdi
-               	movq	$0x0, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x4, %rsi
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L16>
 <L17>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x421>
-               	movb	$0x0, (%rbx)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x49a>
+               	movb	$0x0, (%rsi)
+               	movq	%rbx, %rcx
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	movq	%rax, %rbx
+               	movq	%rbx, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %rdi
                	movq	-0x48(%rbp), %rsi
                	movq	-0x50(%rbp), %r12
                	movq	-0x58(%rbp), %r13
                	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/loadstore.dis
+++ b/test/golden/x86_64-windows/mem/loadstore.dis
@@ -5,14 +5,15 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.fold_packed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%rdi, -0x30(%rbp)
+               	movq	%rsi, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzbl	(%rbx), %esi
                	leaq	0x1(%rdx), %rbx
@@ -24,53 +25,191 @@ Disassembly of section .text:
                	leaq	0x4(%rdx), %rbx
                	movzwl	(%rbx), %r14d
                	leaq	0x6(%rdx), %rbx
-               	movzwl	(%rbx), %r15d
+               	movzwl	(%rbx), %r8d
+               	movq	%r8, -0x18(%rbp)
                	leaq	0x8(%rdx), %rbx
                	movl	(%rbx), %r8d
                	movq	%r8, -0x8(%rbp)
                	leaq	0x10(%rdx), %rbx
                	movq	(%rbx), %r8
                	movq	%r8, -0x10(%rbp)
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rax, %r15
+               	xorq	%rdx, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movzbq	%dil, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L4>
+               	movzbq	%r12b, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L5>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
+               	movzbq	%r13b, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	movzwq	%r14w, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+<L9>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
                	movq	-0x8(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
                	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %rdi
+               	movq	-0x38(%rbp), %rsi
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -78,98 +217,92 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x120, %rsp            # imm = 0x120
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%rdi, -0xd0(%rbp)
-               	movq	%rsi, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
-               	movq	%r15, -0xf8(%rbp)
+               	subq	$0x190, %rsp            # imm = 0x190
+               	movq	%rbx, -0x138(%rbp)
+               	movq	%rdi, -0x140(%rbp)
+               	movq	%rsi, -0x148(%rbp)
+               	movq	%r12, -0x150(%rbp)
+               	movq	%r13, -0x158(%rbp)
+               	movq	%r14, -0x160(%rbp)
+               	movq	%r15, -0x168(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdx
-               	leaq	-0x18(%rbp), %rsi
+               	leaq	-0x58(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
-               	leaq	-0x30(%rbp), %rdi
+               	leaq	-0x70(%rbp), %rax
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r12
+               	movq	%rdx, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	%r12, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rdi
+               	movq	0x10(%rax), %r12
+               	movq	%rdx, -0x88(%rbp)
+               	movq	%rdi, -0x80(%rbp)
+               	movq	%r12, -0x78(%rbp)
+               	leaq	-0x88(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movabsq	$-0x123456789abcdf0, %rdi # imm = 0xFEDCBA9876543210
+               	addq	%rbx, %rdi
+               	movb	%dil, %dl
+               	leaq	(%rsi), %r12
+               	movb	%dl, (%r12)
+               	movq	%rdi, %rdx
+               	shrq	$0x8, %rdx
+               	movb	%dl, %r12b
+               	leaq	0x1(%rsi), %rdx
+               	movb	%r12b, (%rdx)
+               	movq	%rdi, %rdx
+               	shrq	$0x10, %rdx
+               	movb	%dl, %r12b
+               	leaq	0x2(%rsi), %rdx
+               	movb	%r12b, (%rdx)
+               	movq	%rdi, %rdx
+               	shrq	$0x18, %rdx
+               	movb	%dl, %r12b
+               	leaq	0x3(%rsi), %rdx
+               	movb	%r12b, (%rdx)
+               	movw	%di, %dx
+               	leaq	0x4(%rsi), %r12
+               	movw	%dx, (%r12)
+               	movq	%rdi, %rdx
+               	shrq	$0x20, %rdx
+               	movw	%dx, %r12w
+               	leaq	0x6(%rsi), %rdx
+               	movw	%r12w, (%rdx)
+               	movl	%edi, %edx
+               	leaq	0x8(%rsi), %r12
+               	movl	%edx, (%r12)
+               	leaq	0x10(%rsi), %rdx
+               	movq	%rdi, (%rdx)
+               	leaq	-0xa0(%rbp), %rdx
                	movq	(%rsi), %r12
                	movq	0x8(%rsi), %r13
                	movq	0x10(%rsi), %r14
-               	movq	%r12, (%rdi)
-               	movq	%r13, 0x8(%rdi)
-               	movq	%r14, 0x10(%rdi)
-               	movq	(%rdi), %r12
-               	movq	0x8(%rdi), %r13
-               	movq	0x10(%rdi), %r14
-               	movq	%r12, -0x48(%rbp)
-               	movq	%r13, -0x40(%rbp)
-               	movq	%r14, -0x38(%rbp)
-               	leaq	-0x48(%rbp), %rdi
-               	movq	%rdx, %rcx
-               	movq	%rdi, %rdx
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r14
+               	movq	%r12, -0xb8(%rbp)
+               	movq	%r13, -0xb0(%rbp)
+               	movq	%r14, -0xa8(%rbp)
+               	leaq	-0xb8(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdx
-               	movabsq	$-0x123456789abcdf0, %rdi # imm = 0xFEDCBA9876543210
-               	addq	%rbx, %rdi
-               	movb	%dil, %r12b
-               	leaq	(%rsi), %r13
-               	movb	%r12b, (%r13)
-               	movq	%rdi, %r12
-               	shrq	$0x8, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x1(%rsi), %r12
-               	movb	%r13b, (%r12)
-               	movq	%rdi, %r12
-               	shrq	$0x10, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x2(%rsi), %r12
-               	movb	%r13b, (%r12)
-               	movq	%rdi, %r12
-               	shrq	$0x18, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x3(%rsi), %r12
-               	movb	%r13b, (%r12)
-               	movw	%di, %r12w
-               	leaq	0x4(%rsi), %r13
-               	movw	%r12w, (%r13)
-               	movq	%rdi, %r12
-               	shrq	$0x20, %r12
-               	movw	%r12w, %r13w
-               	leaq	0x6(%rsi), %r12
-               	movw	%r13w, (%r12)
-               	movl	%edi, %r12d
-               	leaq	0x8(%rsi), %r13
-               	movl	%r12d, (%r13)
-               	leaq	0x10(%rsi), %r12
-               	movq	%rdi, (%r12)
-               	leaq	-0x60(%rbp), %r12
-               	movq	(%rsi), %r13
-               	movq	0x8(%rsi), %r14
-               	movq	0x10(%rsi), %r15
-               	movq	%r13, (%r12)
-               	movq	%r14, 0x8(%r12)
-               	movq	%r15, 0x10(%r12)
-               	movq	(%r12), %r13
-               	movq	0x8(%r12), %r14
-               	movq	0x10(%r12), %r15
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x70(%rbp)
-               	movq	%r15, -0x68(%rbp)
-               	leaq	-0x78(%rbp), %r12
-               	movq	%rdx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
-<L2>:
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x8, %r13
-               	jb	 <L3>
-               	jmp	 <L5>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L4>
+<L2>:
                	addq	$0x1, %r13
                	movq	%rdi, %rax
                	imulq	%r13, %rax
@@ -186,7 +319,7 @@ Disassembly of section .text:
                	movl	%eax, %edx
                	leaq	0x8(%rsi), %rax
                	movl	%edx, (%rax)
-               	leaq	-0x90(%rbp), %rax
+               	leaq	-0x18(%rbp), %rax
                	movq	(%rsi), %rdx
                	movq	0x8(%rsi), %r14
                	movq	0x10(%rsi), %r15
@@ -196,138 +329,350 @@ Disassembly of section .text:
                	movq	(%rax), %rdx
                	movq	0x8(%rax), %r14
                	movq	0x10(%rax), %r15
-               	movq	%rdx, -0xa8(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0x98(%rbp)
-               	leaq	-0xa8(%rbp), %rdx
+               	movq	%rdx, -0x30(%rbp)
+               	movq	%r14, -0x28(%rbp)
+               	movq	%r15, -0x20(%rbp)
+               	leaq	-0x30(%rbp), %rdx
                	movq	%r12, %rcx
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %r12
                	cmpq	$0x8, %r13
-               	jb	 <L3>
-<L5>:
+               	jb	 <L2>
+<L4>:
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L6>
-               	jmp	 <L17>
-<L6>:
-               	addq	$0x1, %rsi
-               	movabsq	$-0x61c8864680b583eb, %rax # imm = 0x9E3779B97F4A7C15
-               	imulq	%rsi, %rax
-               	movq	%rax, %r13
-               	addq	%rbx, %r13
-               	movb	%r13b, %r14b
-               	movq	%r13, %rax
-               	shrq	$0x8, %rax
-               	movw	%ax, %r15w
-               	movq	%r13, %rax
-               	shrq	$0x10, %rax
-               	movl	%eax, %r8d
+               	jb	 <L5>
+               	jmp	 <L21>
+<L5>:
+               	movq	%rsi, %rax
+               	addq	$0x1, %rax
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r8
+               	addq	%rbx, %r8
                	movq	%r8, -0xc0(%rbp)
-               	movq	%r12, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L7>
+               	movq	-0xc0(%rbp), %r8
+               	movb	%r8b, %r13b
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x8, %rax
+               	movw	%ax, %r14w
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %r15d
+               	movsbq	%r13b, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L8>
+               	movswq	%r14w, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xd0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L9>
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L10>
+               	movslq	%r15d, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movsbq	%r14b, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
 <L11>:
-               	movswq	%r15w, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	-0xc0(%rbp), %r8
-               	movslq	%r8d, %rdx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
 <L13>:
-               	movzbq	%r14b, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movsbq	%r13b, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x110(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movzwq	%r15w, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
 <L15>:
-               	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %edx
-               	movq	%rax, %rcx
+               	movswq	%r14w, %rdx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L16>
 <L16>:
+               	movslq	%r15d, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L17>
+<L17>:
+               	movzbq	%r13b, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L18>
+<L18>:
+               	movzwq	%r14w, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movl	%r15d, %edx
+               	movq	%rax, %rcx
+               	callq	 <L20>
+<L20>:
+               	addq	$0x1, %rsi
                	movq	%rax, %r12
                	cmpq	$0x6, %rsi
-               	jb	 <L6>
-<L17>:
-               	leaq	-0xb8(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
+               	jb	 <L5>
+<L21>:
+               	leaq	-0x40(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rbx
+               	andq	$0x7, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	movb	%bl, %sil
+               	movb	%dl, %bl
+               	addl	%ebx, %esi
+               	leaq	(%rax,%rdx), %rbx
+               	movb	%sil, (%rbx)
+               	addq	$0x1, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+               	jmp	 <L27>
+<L24>:
+               	leaq	(%rax,%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	%r12, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L25>
+<L26>:
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r12
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+<L27>:
+               	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
+               	xorq	%r11, %rdi
                	movq	$0x0, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
                	movq	%rax, %rdx
-               	andq	$0x7, %rdx
                	imulq	$0x8, %rdx, %rdx
                	movq	%rdx, %rcx
                	movq	%rdi, %rdx
                	shrq	%cl, %rdx
-               	movb	%dl, %sil
-               	movb	%al, %dl
-               	addl	%edx, %esi
-               	leaq	(%rbx,%rax), %rdx
-               	movb	%sil, (%rdx)
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
                	addq	$0x1, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-<L19>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x10, %rsi
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%rsi), %rax
-               	movzbl	(%rax), %edx
-               	movq	%r12, %rcx
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %rsi
-               	movq	%rax, %r12
-               	cmpq	$0x10, %rsi
-               	jb	 <L20>
-<L22>:
-               	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
-               	xorq	%r11, %rdi
-               	movq	%r12, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L23>
-<L23>:
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
                	addq	$0x1, %rdi
-               	movq	%rax, %rcx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	%rdi, %rdx
-               	callq	 <L24>
-<L24>:
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %rdi
-               	movq	-0xd8(%rbp), %rsi
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
-               	movq	-0xf8(%rbp), %r15
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r12, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%r12, %rax
+               	movq	-0x138(%rbp), %rbx
+               	movq	-0x140(%rbp), %rdi
+               	movq	-0x148(%rbp), %rsi
+               	movq	-0x150(%rbp), %r12
+               	movq	-0x158(%rbp), %r13
+               	movq	-0x160(%rbp), %r14
+               	movq	-0x168(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/ptr_arith.dis
+++ b/test/golden/x86_64-windows/mem/ptr_arith.dis
@@ -5,32 +5,86 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzwl	(%rbx), %esi
                	leaq	0x2(%rdx), %rbx
                	movzbl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movq	(%rbx), %rdx
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movzbq	%dil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -67,19 +121,17 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%rdi, -0xe0(%rbp)
-               	movq	%rsi, -0xe8(%rbp)
-               	movq	%r12, -0xf0(%rbp)
-               	movq	%r13, -0xf8(%rbp)
-               	movq	%r14, -0x100(%rbp)
-               	movq	%r15, -0x108(%rbp)
+               	subq	$0x200, %rsp            # imm = 0x200
+               	movq	%rbx, -0x1a8(%rbp)
+               	movq	%rdi, -0x1b0(%rbp)
+               	movq	%rsi, -0x1b8(%rbp)
+               	movq	%r12, -0x1c0(%rbp)
+               	movq	%r13, -0x1c8(%rbp)
+               	movq	%r14, -0x1d0(%rbp)
+               	movq	%r15, -0x1d8(%rbp)
                	movq	%rcx, %rbx
                	leaq	-0x20(%rbp), %rsi
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x60(%rbp), %rdi
+               	leaq	-0xa0(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
@@ -88,367 +140,676 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rdi)
                	movq	$0x0, 0x30(%rdi)
                	movq	$0x0, 0x38(%rdi)
-               	movq	$0x0, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	addq	$0x1, %rdx
                	movabsq	$0x9e3779b1, %r12       # imm = 0x9E3779B1
                	imulq	%rdx, %r12
                	addq	%rbx, %r12
                	movl	%r12d, %r13d
-               	leaq	(%rdi,%rcx,4), %r12
+               	leaq	(%rdi,%rax,4), %r12
                	movl	%r13d, (%r12)
-               	movq	%rdx, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-<L2>:
+               	movq	%rdx, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+<L1>:
                	leaq	(%rdi), %r12
                	leaq	0x20(%rdi), %r13
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x10, %r15
-               	jb	 <L3>
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x110(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L2>
                	jmp	 <L5>
-<L3>:
-               	leaq	(%r12,%r15,4), %rax
-               	movl	(%rax), %edx
-               	movq	%r14, %rcx
-               	callq	 <L4>
-<L4>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x10, %r15
+<L2>:
+               	movq	-0x118(%rbp), %r8
+               	leaq	(%r12,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r15, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+<L4>:
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r15, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L2>
 <L5>:
-               	movq	$-0x8, %r15
-               	cmpq	$0x8, %r15
+               	movq	-0x110(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	$-0x8, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
                	jl	 <L6>
-               	jmp	 <L8>
+               	jmp	 <L9>
 <L6>:
-               	leaq	(%r13,%r15,4), %rax
-               	movl	(%rax), %edx
-               	movq	%r14, %rcx
-               	callq	 <L7>
+               	movq	-0x130(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	addq	$0x1, %r15
                	movq	%rax, %r14
-               	cmpq	$0x8, %r15
-               	jl	 <L6>
-<L8>:
-               	movl	(%r13), %eax
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	movl	%eax, %edx
-               	callq	 <L9>
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r15, %rdx
+               	xorq	%r14, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+<L8>:
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r15, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jl	 <L6>
 <L9>:
-               	leaq	-0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	movl	(%r13), %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	leaq	0x1c(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
 <L11>:
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	leaq	-0x4(%r13), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x140(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%r13,%rcx,4), %rdx
-               	movl	(%rdx), %r14d
-               	movl	%ecx, %r15d
-               	addl	%r15d, %r14d
-               	addl	$0x1, %r14d
-               	movl	%r14d, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
                	jb	 <L12>
 <L13>:
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x10, %r15
-               	jb	 <L14>
-               	jmp	 <L16>
+               	leaq	0x1c(%r13), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r14d, %edx
+               	movq	%rax, %rcx
+               	callq	 <L14>
 <L14>:
-               	leaq	(%rdi,%r15,4), %rax
-               	movl	(%rax), %edx
-               	movq	%r14, %rcx
-               	callq	 <L15>
+               	movq	%rax, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x148(%rbp), %r8
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x10, %r15
-               	jb	 <L14>
+               	leaq	(%r13,%rdx,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%edx, %eax
+               	addl	%eax, %r15d
+               	addl	$0x1, %r15d
+               	movl	%r15d, (%r14)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
 <L16>:
-               	leaq	0x14(%rdi), %r15
-               	movl	(%r15), %eax
-               	xorl	$0xf0f0f0f0, %eax       # imm = 0xF0F0F0F0
-               	movl	%eax, (%r15)
-               	movl	(%r15), %eax
-               	movq	%r14, %rcx
-               	movl	%eax, %edx
-               	callq	 <L17>
+               	movq	-0x148(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L17>
+               	jmp	 <L20>
 <L17>:
-               	movl	(%r15), %ecx
-               	addl	$0x3, %ecx
-               	movl	%ecx, (%r15)
-               	movl	(%r15), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
+               	movq	-0x160(%rbp), %r8
+               	leaq	(%rdi,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movl	(%r15), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r15, %rdx
+               	xorq	%r14, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	cmpq	%r15, %r15
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%r15, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L17>
 <L20>:
-               	cmpq	%r12, %r15
+               	leaq	0x14(%rdi), %r14
+               	movl	(%r14), %eax
+               	xorl	$0xf0f0f0f0, %eax       # imm = 0xF0F0F0F0
+               	movl	%eax, (%r14)
+               	movl	(%r14), %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x150(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%r15, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x170(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L21>
+<L22>:
+               	movl	(%r14), %eax
+               	addl	$0x3, %eax
+               	movl	%eax, (%r14)
+               	movl	(%r14), %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x170(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%r15, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x180(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L23>
+<L24>:
+               	leaq	0x14(%rdi), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L25>
+<L25>:
+               	cmpq	%r14, %r14
                	sete	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
                	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
+               	movq	%rdi, %rdx
+               	callq	 <L26>
+<L26>:
+               	cmpq	%r12, %r14
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
+               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L27>
+<L27>:
                	cmpq	$0x0, %r12
                	sete	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
                	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
+               	movq	%rdi, %rdx
+               	callq	 <L28>
+<L28>:
                	cmpq	%r12, %r13
                	setne	%dl
                	movzbq	%dl, %rdx
+               	movzbq	%dl, %rdi
                	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	-0xc0(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L24>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L24>
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	movq	%rcx, %rdx
-               	imulq	$0x5, %rdx, %rdx
+               	movq	%rdi, %rdx
+               	callq	 <L29>
+<L29>:
+               	leaq	-0x100(%rbp), %rdi
+               	leaq	(%rdi), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %r12
+<L30>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L30>
+               	movq	$0x0, %rdx
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %r12
+               	imulq	$0x5, %r12, %r12
+               	addq	$0x1, %r12
+               	addq	%rbx, %r12
+               	movw	%r12w, %r13w
+               	movq	%rdx, %r12
+               	imulq	$0x10, %r12, %r12
+               	leaq	(%rdi,%r12), %r14
+               	leaq	(%r14), %r12
+               	movw	%r13w, (%r12)
+               	movq	%rdx, %r12
+               	addq	$0x64, %r12
+               	movb	%r12b, %r13b
+               	leaq	0x2(%r14), %r12
+               	movb	%r13b, (%r12)
                	addq	$0x1, %rdx
-               	addq	%rbx, %rdx
-               	movw	%dx, %r12w
-               	movq	%rcx, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%rdi,%rdx), %r13
-               	leaq	(%r13), %rdx
-               	movw	%r12w, (%rdx)
-               	movq	%rcx, %rdx
-               	addq	$0x64, %rdx
-               	movb	%dl, %r12b
-               	leaq	0x2(%r13), %rdx
-               	movb	%r12b, (%rdx)
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    # imm = 0x100000001B3
-               	imulq	%rcx, %rdx
-               	addq	%rbx, %rdx
-               	leaq	0x8(%r13), %r12
-               	movq	%rdx, (%r12)
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
-<L26>:
+               	movabsq	$0x100000001b3, %r12    # imm = 0x100000001B3
+               	imulq	%rdx, %r12
+               	addq	%rbx, %r12
+               	leaq	0x8(%r14), %r13
+               	movq	%r12, (%r13)
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+<L32>:
                	leaq	0x20(%rdi), %r12
                	movq	%rax, %r13
                	movq	$-0x2, %r14
                	cmpq	$0x4, %r14
-               	jl	 <L27>
-               	jmp	 <L31>
-<L27>:
+               	jl	 <L33>
+               	jmp	 <L35>
+<L33>:
                	movq	%r14, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %edx
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r15d
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0xc8(%rbp)
+               	leaq	(%r12,%rax), %rdx
+               	leaq	-0x30(%rbp), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	(%rdx), %r15
+               	movq	0x8(%rdx), %rax
+               	movq	-0x188(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x188(%rbp), %r8
+               	movq	%rax, 0x8(%r8)
+               	movq	-0x188(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x188(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	%rax, -0x40(%rbp)
+               	movq	%rdx, -0x38(%rbp)
+               	leaq	-0x40(%rbp), %rdx
                	movq	%r13, %rcx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rdx
-               	callq	 <L30>
-<L30>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jl	 <L27>
-<L31>:
+               	jl	 <L33>
+<L35>:
                	leaq	0x10(%r12), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
                	addq	$0x11, %rax
-               	movq	%rax, (%rcx)
+               	movq	%rax, (%rdx)
                	leaq	-0x10(%r12), %rax
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %eax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
                	addl	$0x9, %eax
-               	movw	%ax, (%rcx)
+               	movw	%ax, (%rdx)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L32>
-               	jmp	 <L36>
-<L32>:
+               	jb	 <L36>
+               	jmp	 <L38>
+<L36>:
                	movq	%r12, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rdi,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %edx
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r14d
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r15
-               	movq	%r13, %rcx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L35>
-<L35>:
-               	addq	$0x1, %r12
-               	movq	%rax, %r13
-               	cmpq	$0x6, %r12
-               	jb	 <L32>
-<L36>:
-               	leaq	0x40(%rdi), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
-               	imulq	$0x3, %rax, %rax
-               	movq	%rax, (%rcx)
-               	movq	(%rcx), %rdx
+               	leaq	(%rdi,%rax), %rdx
+               	leaq	-0x50(%rbp), %rax
+               	movq	(%rdx), %r14
+               	movq	0x8(%rdx), %r15
+               	movq	%r14, (%rax)
+               	movq	%r15, 0x8(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %r14
+               	movq	%rdx, -0x60(%rbp)
+               	movq	%r14, -0x58(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%r13, %rcx
                	callq	 <L37>
 <L37>:
-               	leaq	(%rdi), %rcx
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movw	%cx, (%rdx)
-               	movzwl	(%rdx), %edi
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L38>
+               	addq	$0x1, %r12
+               	movq	%rax, %r13
+               	cmpq	$0x6, %r12
+               	jb	 <L36>
 <L38>:
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movl	%ebx, %ecx
-               	movl	$0x12345678, %edi       # imm = 0x12345678
-               	addl	%ecx, %edi
-               	movl	$0x9abcdef0, %r12d      # imm = 0x9ABCDEF0
-               	addl	%ecx, %r12d
-               	movl	%ebx, %ecx
+               	leaq	0x40(%rdi), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	imulq	$0x3, %rax, %rax
+               	movq	%rax, (%rdx)
+               	movq	(%rdx), %rax
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
                	jb	 <L39>
                	jmp	 <L40>
 <L39>:
-               	movl	%edx, %ebx
-               	imull	$0x7, %ebx, %ebx
-               	addl	$0x3, %ebx
-               	addl	%ecx, %ebx
-               	leaq	(%rsi,%rdx,4), %r13
-               	movl	%ebx, (%r13)
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
                	addq	$0x1, %rdx
+               	movq	%r14, %r13
                	cmpq	$0x8, %rdx
                	jb	 <L39>
 <L40>:
-               	leaq	0xc(%rsi), %rbx
-               	movq	%rax, %r13
-               	movq	$-0x3, %r14
-               	cmpq	$0x5, %r14
-               	jl	 <L41>
-               	jmp	 <L43>
+               	leaq	(%rdi), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	addl	$0x1, %eax
+               	movw	%ax, (%rdx)
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	leaq	(%rbx,%r14,4), %rax
-               	movl	(%rax), %edx
-               	movq	%r13, %rcx
-               	callq	 <L42>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
 <L42>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x5, %r14
-               	jl	 <L41>
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movq	$0x0, 0x18(%rsi)
+               	movl	%ebx, %eax
+               	movl	$0x12345678, %r8d       # imm = 0x12345678
+               	addl	%eax, %r8d
+               	movq	%r8, -0x198(%rbp)
+               	movl	$0x9abcdef0, %r8d       # imm = 0x9ABCDEF0
+               	addl	%eax, %r8d
+               	movq	%r8, -0x190(%rbp)
+               	movl	%ebx, %eax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L43>
+               	jmp	 <L44>
 <L43>:
-               	leaq	(%rsi), %rax
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
-               	jmp	 <L45>
+               	movl	%ebx, %r12d
+               	imull	$0x7, %r12d, %r12d
+               	addl	$0x3, %r12d
+               	addl	%eax, %r12d
+               	leaq	(%rsi,%rbx,4), %r14
+               	movl	%r12d, (%r14)
+               	addq	$0x1, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L43>
 <L44>:
-               	leaq	(%rax,%rcx,4), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ecx, %r14d
-               	addl	%r14d, %ebx
-               	addl	$0x1, %ebx
-               	movl	%ebx, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
+               	leaq	0xc(%rsi), %rax
+               	movq	$-0x3, %rbx
+               	cmpq	$0x5, %rbx
+               	jl	 <L45>
+               	jmp	 <L48>
 <L45>:
-               	movq	%r13, %rcx
-               	movl	%edi, %edx
-               	callq	 <L46>
+               	leaq	(%rax,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	movl	%r14d, %r12d
+               	movq	%r13, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L46>
+               	jmp	 <L47>
 <L46>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L46>
+<L47>:
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x5, %rbx
+               	jl	 <L45>
+<L48>:
+               	leaq	(%rsi), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	leaq	(%rax,%rdx,4), %rbx
+               	movl	(%rbx), %edi
+               	movl	%edx, %r12d
+               	addl	%r12d, %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rbx)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+<L50>:
+               	movq	-0x198(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+               	jmp	 <L52>
+<L51>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
                	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+<L52>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+               	jmp	 <L56>
+<L53>:
+               	leaq	(%rsi,%rax,4), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	%r13, %rbx
                	movq	$0x0, %rdi
                	cmpq	$0x8, %rdi
-               	jb	 <L47>
-               	jmp	 <L49>
-<L47>:
-               	leaq	(%rsi,%rdi,4), %rax
-               	movl	(%rax), %edx
-               	movq	%rbx, %rcx
-               	callq	 <L48>
-<L48>:
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
                	addq	$0x1, %rdi
-               	movq	%rax, %rbx
+               	movq	%r14, %rbx
                	cmpq	$0x8, %rdi
-               	jb	 <L47>
-<L49>:
+               	jb	 <L54>
+<L55>:
+               	addq	$0x1, %rax
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+<L56>:
+               	movq	-0x190(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
                	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L50>
-<L50>:
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %rdi
-               	movq	-0xe8(%rbp), %rsi
-               	movq	-0xf0(%rbp), %r12
-               	movq	-0xf8(%rbp), %r13
-               	movq	-0x100(%rbp), %r14
-               	movq	-0x108(%rbp), %r15
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %rsi
+               	xorq	%rbx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+<L58>:
+               	movq	%r13, %rax
+               	movq	-0x1a8(%rbp), %rbx
+               	movq	-0x1b0(%rbp), %rdi
+               	movq	-0x1b8(%rbp), %rsi
+               	movq	-0x1c0(%rbp), %r12
+               	movq	-0x1c8(%rbp), %r13
+               	movq	-0x1d0(%rbp), %r14
+               	movq	-0x1d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/rec_layout.dis
+++ b/test/golden/x86_64-windows/mem/rec_layout.dis
@@ -5,32 +5,87 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_tiny>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzbl	(%rbx), %esi
                	leaq	0x4(%rdx), %rbx
                	movl	(%rbx), %edi
                	leaq	0x8(%rdx), %rbx
-               	movzbl	(%rbx), %r12d
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movzbl	(%rbx), %edx
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L2>
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,13 +93,15 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_mid>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
                	leaq	(%rdx), %rbx
                	movzwl	(%rbx), %esi
                	leaq	0x4(%rdx), %rbx
@@ -55,32 +112,119 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rdi
                	movzbl	(%rdi), %ebx
                	leaq	0x10(%rdx), %rdi
-               	movzbl	(%rdi), %r14d
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movzbl	(%rdi), %edx
+               	movzwq	%si, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L2>
+               	movzbq	%r12b, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L3>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L4>
+               	movl	%r13d, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+<L5>:
+               	movzbq	%bl, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13
                	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -88,26 +232,395 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
+               	subq	$0xc0, %rsp
                	movq	%rbx, -0x68(%rbp)
                	movq	%rdi, -0x70(%rbp)
                	movq	%rsi, -0x78(%rbp)
                	movq	%r12, -0x80(%rbp)
                	movq	%r13, -0x88(%rbp)
                	movq	%r14, -0x90(%rbp)
-               	leaq	-0x28(%rbp), %rbx
-               	movq	(%rdx), %rsi
-               	movq	0x8(%rdx), %rdi
-               	movq	0x10(%rdx), %r12
-               	movq	0x18(%rdx), %r13
-               	movq	0x20(%rdx), %r14
-               	movq	%rsi, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movq	%r13, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
+               	movq	%r15, -0x98(%rbp)
+               	movq	%rcx, %rbx
+               	leaq	-0x28(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r12
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
+               	movq	%rdi, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movq	%r14, 0x18(%rsi)
+               	movq	%r15, 0x20(%rsi)
+               	leaq	(%rsi), %rdx
+               	leaq	-0x3c(%rbp), %rdi
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rdi)
+               	movq	%r13, 0x8(%rdi)
+               	movl	%r14d, 0x10(%rdi)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %r12
+               	movl	0x10(%rdi), %r13d
+               	movq	%rdx, -0x54(%rbp)
+               	movq	%r12, -0x4c(%rbp)
+               	movl	%r13d, -0x44(%rbp)
+               	leaq	-0x54(%rbp), %rdx
+               	movq	%rbx, %rcx
+               	callq	 <L0>
+<L0>:
+               	leaq	0x18(%rsi), %rdx
+               	movq	(%rdx), %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+<L2>:
+               	leaq	0x20(%rsi), %rdx
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+<L4>:
+               	leaq	0x20(%rsi), %rdx
+               	leaq	0x2(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+<L6>:
+               	leaq	0x20(%rsi), %rdx
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	leaq	0x26(%rsi), %rdx
+               	movzbl	(%rdx), %ebx
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
+<L10>:
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.mem.rec_layout.fold_nest>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x190, %rsp            # imm = 0x190
+               	movq	%rbx, -0x138(%rbp)
+               	movq	%rdi, -0x140(%rbp)
+               	movq	%rsi, -0x148(%rbp)
+               	movq	%r12, -0x150(%rbp)
+               	movq	%r13, -0x158(%rbp)
+               	movq	%r14, -0x160(%rbp)
+               	movq	%r15, -0x168(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x58(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	leaq	(%rdx), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L1>
+               	movq	%rsi, %rdx
+               	addq	$0x58, %rdx
+               	movq	%rdi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
+<L0>:
+               	subq	$0x8, %rdx
+               	subq	$0x8, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rdx)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L0>
+               	jmp	 <L3>
+<L1>:
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rdx
+<L2>:
+               	movq	(%rdi), %r12
+               	movq	%r12, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L2>
+<L3>:
                	leaq	(%rbx), %rdx
-               	leaq	-0x3c(%rbp), %rsi
+               	leaq	-0x80(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r12
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
+               	movq	%rdi, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movq	%r14, 0x18(%rsi)
+               	movq	%r15, 0x20(%rsi)
+               	leaq	-0xa8(%rbp), %rdi
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r12
+               	movq	0x10(%rsi), %r13
+               	movq	0x18(%rsi), %r14
+               	movq	0x20(%rsi), %r15
+               	movq	%rdx, (%rdi)
+               	movq	%r12, 0x8(%rdi)
+               	movq	%r13, 0x10(%rdi)
+               	movq	%r14, 0x18(%rdi)
+               	movq	%r15, 0x20(%rdi)
+               	leaq	(%rdi), %rdx
+               	leaq	-0xbc(%rbp), %rsi
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movl	%r14d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r12
+               	movl	0x10(%rsi), %r13d
+               	movq	%rdx, -0xd4(%rbp)
+               	movq	%r12, -0xcc(%rbp)
+               	movl	%r13d, -0xc4(%rbp)
+               	leaq	-0xd4(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
+               	leaq	0x18(%rdi), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+<L6>:
+               	leaq	0x20(%rdi), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	leaq	0x20(%rdi), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
+               	leaq	0x20(%rdi), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	leaq	0x26(%rdi), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+<L14>:
+               	leaq	0x28(%rbx), %rsi
+               	leaq	(%rsi), %rdx
+               	leaq	-0xe8(%rbp), %rdi
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rdi)
+               	movq	%r13, 0x8(%rdi)
+               	movl	%r14d, 0x10(%rdi)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %r12
+               	movl	0x10(%rdi), %r13d
+               	movq	%rdx, -0x100(%rbp)
+               	movq	%r12, -0xf8(%rbp)
+               	movl	%r13d, -0xf0(%rbp)
+               	leaq	-0x100(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
+               	leaq	0x14(%rsi), %rdx
+               	leaq	-0x114(%rbp), %rsi
                	movq	(%rdx), %rdi
                	movq	0x8(%rdx), %r12
                	movl	0x10(%rdx), %r13d
@@ -117,209 +630,43 @@ Disassembly of section .text:
                	movq	(%rsi), %rdx
                	movq	0x8(%rsi), %rdi
                	movl	0x10(%rsi), %r12d
-               	movq	%rdx, -0x54(%rbp)
-               	movq	%rdi, -0x4c(%rbp)
-               	movl	%r12d, -0x44(%rbp)
-               	leaq	-0x54(%rbp), %rdx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	leaq	0x18(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
-               	leaq	0x20(%rbx), %rsi
-               	leaq	(%rsi), %rdx
-               	movzwl	(%rdx), %edi
-               	movq	%rdi, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rsi), %rdx
-               	movzwl	(%rdx), %edi
-               	movq	%rdi, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rsi), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	0x26(%rbx), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %rdi
-               	movq	-0x78(%rbp), %rsi
-               	movq	-0x80(%rbp), %r12
-               	movq	-0x88(%rbp), %r13
-               	movq	-0x90(%rbp), %r14
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.mem.rec_layout.fold_nest>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x180, %rsp            # imm = 0x180
-               	movq	%rbx, -0x138(%rbp)
-               	movq	%rdi, -0x140(%rbp)
-               	movq	%rsi, -0x148(%rbp)
-               	movq	%r12, -0x150(%rbp)
-               	movq	%r13, -0x158(%rbp)
-               	movq	%r14, -0x160(%rbp)
-               	leaq	-0x58(%rbp), %rbx
-               	leaq	(%rbx), %rax
-               	leaq	(%rdx), %rsi
-               	cmpq	%rsi, %rax
-               	jb	 <L1>
-               	movq	%rax, %rdx
-               	addq	$0x58, %rdx
-               	movq	%rsi, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %r12
-<L0>:
-               	subq	$0x8, %rdx
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r13
-               	movq	%r13, (%rdx)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L0>
-               	jmp	 <L3>
-<L1>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rdx
-<L2>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L2>
-<L3>:
-               	leaq	(%rbx), %rax
-               	leaq	-0x80(%rbp), %rdx
-               	movq	(%rax), %rsi
-               	movq	0x8(%rax), %rdi
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movq	%r12, 0x10(%rdx)
-               	movq	%r13, 0x18(%rdx)
-               	movq	%r14, 0x20(%rdx)
-               	leaq	-0xa8(%rbp), %rsi
-               	movq	(%rdx), %rax
-               	movq	0x8(%rdx), %rdi
-               	movq	0x10(%rdx), %r12
-               	movq	0x18(%rdx), %r13
-               	movq	0x20(%rdx), %r14
-               	movq	%rax, (%rsi)
-               	movq	%rdi, 0x8(%rsi)
-               	movq	%r12, 0x10(%rsi)
-               	movq	%r13, 0x18(%rsi)
-               	movq	%r14, 0x20(%rsi)
-               	leaq	(%rsi), %rax
-               	leaq	-0xbc(%rbp), %rdx
-               	movq	(%rax), %rdi
-               	movq	0x8(%rax), %r12
-               	movl	0x10(%rax), %r13d
-               	movq	%rdi, (%rdx)
-               	movq	%r12, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rax
-               	movq	0x8(%rdx), %rdi
-               	movl	0x10(%rdx), %r12d
-               	movq	%rax, -0xd4(%rbp)
-               	movq	%rdi, -0xcc(%rbp)
-               	movl	%r12d, -0xc4(%rbp)
-               	leaq	-0xd4(%rbp), %rdx
-               	callq	 <L4>
-<L4>:
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	leaq	0x20(%rsi), %rdi
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	leaq	0x26(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x28(%rbx), %rsi
-               	leaq	(%rsi), %rcx
-               	leaq	-0xe8(%rbp), %rdx
-               	movq	(%rcx), %rdi
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rdi, (%rdx)
-               	movq	%r12, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rdi
-               	movl	0x10(%rdx), %r12d
-               	movq	%rcx, -0x100(%rbp)
-               	movq	%rdi, -0xf8(%rbp)
-               	movl	%r12d, -0xf0(%rbp)
-               	leaq	-0x100(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x14(%rsi), %rcx
-               	leaq	-0x114(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movl	0x10(%rcx), %r12d
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movl	%r12d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %edi
-               	movq	%rcx, -0x12c(%rbp)
-               	movq	%rsi, -0x124(%rbp)
-               	movl	%edi, -0x11c(%rbp)
+               	movq	%rdx, -0x12c(%rbp)
+               	movq	%rdi, -0x124(%rbp)
+               	movl	%r12d, -0x11c(%rbp)
                	leaq	-0x12c(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x50(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
+               	callq	 <L16>
+<L16>:
+               	leaq	0x50(%rbx), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
+<L18>:
                	movq	-0x138(%rbp), %rbx
                	movq	-0x140(%rbp), %rdi
                	movq	-0x148(%rbp), %rsi
                	movq	-0x150(%rbp), %r12
                	movq	-0x158(%rbp), %r13
                	movq	-0x160(%rbp), %r14
+               	movq	-0x168(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -361,787 +708,893 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x650, %rsp            # imm = 0x650
-               	movq	%rbx, -0x5f8(%rbp)
-               	movq	%rdi, -0x600(%rbp)
-               	movq	%rsi, -0x608(%rbp)
-               	movq	%r12, -0x610(%rbp)
-               	movq	%r13, -0x618(%rbp)
-               	movq	%r14, -0x620(%rbp)
-               	movq	%r15, -0x628(%rbp)
+               	subq	$0x680, %rsp            # imm = 0x680
+               	movq	%rbx, -0x628(%rbp)
+               	movq	%rdi, -0x630(%rbp)
+               	movq	%rsi, -0x638(%rbp)
+               	movq	%r12, -0x640(%rbp)
+               	movq	%r13, -0x648(%rbp)
+               	movq	%r14, -0x650(%rbp)
+               	movq	%r15, -0x658(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movl	%ebx, %esi
-               	movq	$0xc, %rdx
-               	callq	 <L1>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0xc, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	movq	$0x14, %rdx
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	movq	$0x28, %rdx
-               	callq	 <L3>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movq	$0x58, %rdx
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L5>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x28, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	$0x8, %rdx
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x58, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	$0x8, %rdx
-               	callq	 <L8>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	$0x4, %rdx
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x4, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
                	movq	%rax, %rcx
-               	movq	$0x8, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
-               	movq	$0x4, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	$0x10, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movq	$0x18, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	$0x20, %rdx
+               	movq	$0x8, %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
-               	movq	$0x26, %rdx
+               	movq	$0x4, %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
-               	movq	$0x28, %rdx
+               	movq	$0x10, %rdx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
-               	movq	$0x50, %rdx
+               	movq	$0x18, %rdx
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rcx
+               	movq	$0x20, %rdx
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rcx
+               	movq	$0x26, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rcx
+               	movq	$0x28, %rdx
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rcx
+               	movq	$0x50, %rdx
+               	callq	 <L21>
+<L21>:
                	movq	%rax, %r8
                	movq	%r8, -0x5c8(%rbp)
                	movq	-0x5c8(%rbp), %r8
                	leaq	-0x58(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x58, %rdx
-<L18>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L18>
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%rdi), %r12
-               	cmpq	%r12, %rdx
-               	jb	 <L20>
-               	movq	%rdx, %r13
-               	addq	$0x58, %r13
+               	leaq	(%rdi), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x58, %r12
+<L22>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L22>
+               	leaq	-0xb0(%rbp), %r8
+               	movq	%r8, -0x5d0(%rbp)
+               	movq	-0x5d0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	leaq	(%rdi), %r13
+               	cmpq	%r13, %r12
+               	jb	 <L24>
                	movq	%r12, %r14
                	addq	$0x58, %r14
-               	movq	$0x58, %r15
-<L19>:
-               	subq	$0x8, %r13
-               	subq	$0x8, %r14
-               	movq	(%r14), %rax
-               	movq	%rax, (%r13)
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L19>
-               	jmp	 <L22>
-<L20>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %r12
+               	movq	%r13, %r15
+               	addq	$0x58, %r15
                	movq	$0x58, %rax
-<L21>:
-               	movq	(%r12), %r13
-               	movq	%r13, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %r12
+<L23>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L21>
-<L22>:
-               	leaq	-0x108(%rbp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L24>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %r12
-               	addq	$0x58, %r12
-               	movq	$0x58, %r13
-<L23>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %r12
-               	movq	(%r12), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %r13
-               	cmpq	$0x0, %r13
                	jne	 <L23>
                	jmp	 <L26>
 <L24>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %r12
+               	addq	$0x0, %r13
+               	movq	$0x58, %rax
 <L25>:
-               	movq	(%rdx), %r12
-               	movq	%r12, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	movq	(%r13), %rdx
+               	movq	%rdx, (%r12)
+               	addq	$0x8, %r12
+               	addq	$0x8, %r13
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L25>
 <L26>:
-               	leaq	-0x108(%rbp), %rdx
-               	movq	-0x5c8(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	(%rdi), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xa, %ecx
-               	addl	%esi, %ecx
-               	movw	%cx, %r12w
-               	leaq	(%rdx), %r13
-               	movw	%r12w, (%r13)
-               	movl	%ecx, %r12d
-               	addl	$0x1, %r12d
-               	movb	%r12b, %r13b
-               	leaq	0x4(%rdx), %r12
-               	leaq	(%r12), %r14
-               	movb	%r13b, (%r14)
-               	movl	%ecx, %r13d
-               	addl	$0x2, %r13d
-               	leaq	0x4(%r12), %r14
-               	movl	%r13d, (%r14)
-               	movl	%ecx, %r13d
-               	addl	$0x3, %r13d
-               	movb	%r13b, %r14b
-               	leaq	0x8(%r12), %r13
-               	movb	%r14b, (%r13)
-               	addl	$0x4, %ecx
-               	movb	%cl, %r12b
-               	leaq	0x10(%rdx), %rcx
-               	movb	%r12b, (%rcx)
-               	movabsq	$-0x123456789abcdf0, %rcx # imm = 0xFEDCBA9876543210
-               	addq	%rbx, %rcx
-               	leaq	(%rdi), %rdx
-               	leaq	0x18(%rdx), %rbx
-               	movq	%rcx, (%rbx)
-               	movl	$0x14, %ecx
-               	addl	%esi, %ecx
-               	movw	%cx, %bx
-               	leaq	0x20(%rdx), %rcx
-               	leaq	(%rcx), %r12
-               	movw	%bx, (%r12)
-               	movl	$0x15, %ebx
-               	addl	%esi, %ebx
-               	movw	%bx, %r12w
-               	leaq	0x2(%rcx), %rbx
-               	movw	%r12w, (%rbx)
-               	movl	$0x16, %ebx
-               	addl	%esi, %ebx
-               	movw	%bx, %r12w
-               	leaq	0x4(%rcx), %rbx
-               	movw	%r12w, (%rbx)
-               	movl	$0x17, %ecx
-               	addl	%esi, %ecx
-               	movb	%cl, %bl
-               	leaq	0x26(%rdx), %rcx
-               	movb	%bl, (%rcx)
-               	leaq	0x28(%rdi), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x1e, %ecx
-               	addl	%esi, %ecx
-               	movw	%cx, %bx
-               	leaq	(%rdx), %r12
-               	movw	%bx, (%r12)
-               	movl	%ecx, %ebx
-               	addl	$0x1, %ebx
-               	movb	%bl, %r12b
-               	leaq	0x4(%rdx), %rbx
-               	leaq	(%rbx), %r13
-               	movb	%r12b, (%r13)
-               	movl	%ecx, %r12d
-               	addl	$0x2, %r12d
-               	leaq	0x4(%rbx), %r13
-               	movl	%r12d, (%r13)
-               	movl	%ecx, %r12d
-               	addl	$0x3, %r12d
-               	movb	%r12b, %r13b
-               	leaq	0x8(%rbx), %r12
-               	movb	%r13b, (%r12)
-               	addl	$0x4, %ecx
-               	movb	%cl, %bl
-               	leaq	0x10(%rdx), %rcx
-               	movb	%bl, (%rcx)
-               	leaq	0x28(%rdi), %rcx
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0x28, %ecx
-               	addl	%esi, %ecx
-               	movw	%cx, %bx
-               	leaq	(%rdx), %r12
-               	movw	%bx, (%r12)
-               	movl	%ecx, %ebx
-               	addl	$0x1, %ebx
-               	movb	%bl, %r12b
-               	leaq	0x4(%rdx), %rbx
-               	leaq	(%rbx), %r13
-               	movb	%r12b, (%r13)
-               	movl	%ecx, %r12d
-               	addl	$0x2, %r12d
-               	leaq	0x4(%rbx), %r13
-               	movl	%r12d, (%r13)
-               	movl	%ecx, %r12d
-               	addl	$0x3, %r12d
-               	movb	%r12b, %r13b
-               	leaq	0x8(%rbx), %r12
-               	movb	%r13b, (%r12)
-               	addl	$0x4, %ecx
-               	movb	%cl, %bl
-               	leaq	0x10(%rdx), %rcx
-               	movb	%bl, (%rcx)
-               	movl	$0x32, %ecx
-               	addl	%esi, %ecx
-               	leaq	0x50(%rdi), %rbx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%rdi), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L29>
-               	movq	%rdx, %r12
+               	leaq	-0x108(%rbp), %rax
+               	movq	-0x5d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L28>
+               	movq	%rax, %r12
                	addq	$0x58, %r12
-               	movq	%rsi, %r13
+               	movq	%rdx, %r13
                	addq	$0x58, %r13
                	movq	$0x58, %r14
-<L28>:
+<L27>:
                	subq	$0x8, %r12
                	subq	$0x8, %r13
                	movq	(%r13), %r15
                	movq	%r15, (%r12)
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L28>
-               	jmp	 <L31>
-<L29>:
+               	jne	 <L27>
+               	jmp	 <L30>
+<L28>:
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
                	movq	$0x58, %r12
-<L30>:
-               	movq	(%rsi), %r13
-               	movq	%r13, (%rdx)
+<L29>:
+               	movq	(%rdx), %r13
+               	movq	%r13, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L30>
+               	jne	 <L29>
+<L30>:
+               	leaq	-0x108(%rbp), %rdx
+               	movq	-0x5c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L31>
 <L31>:
-               	leaq	-0x1b8(%rbp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L33>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rsi, %r12
-               	addq	$0x58, %r12
-               	movq	$0x58, %r13
-<L32>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %r12
-               	movq	(%r12), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %r13
-               	cmpq	$0x0, %r13
-               	jne	 <L32>
-               	jmp	 <L35>
-<L33>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
-<L34>:
-               	movq	(%rsi), %r12
-               	movq	%r12, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L34>
-<L35>:
-               	leaq	-0x1b8(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
                	movq	%rax, %r8
-               	movq	%r8, -0x5d0(%rbp)
-               	movq	-0x5d0(%rbp), %r8
-               	leaq	(%rdi), %rsi
-               	leaq	(%rsi), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
-               	movl	%edx, (%rcx)
-               	leaq	-0x210(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r8, -0x5d8(%rbp)
+               	movq	-0x5d8(%rbp), %r8
+               	leaq	(%rdi), %rdx
+               	leaq	(%rdx), %r12
+               	movl	$0xa, %edx
+               	addl	%esi, %edx
+               	movw	%dx, %r13w
+               	leaq	(%r12), %r14
+               	movw	%r13w, (%r14)
+               	movl	%edx, %r13d
+               	addl	$0x1, %r13d
+               	movb	%r13b, %r14b
+               	leaq	0x4(%r12), %r13
+               	leaq	(%r13), %r15
+               	movb	%r14b, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x2, %r14d
+               	leaq	0x4(%r13), %r15
+               	movl	%r14d, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x3, %r14d
+               	movb	%r14b, %r15b
+               	leaq	0x8(%r13), %r14
+               	movb	%r15b, (%r14)
+               	addl	$0x4, %edx
+               	movb	%dl, %r13b
+               	leaq	0x10(%r12), %rdx
+               	movb	%r13b, (%rdx)
+               	movabsq	$-0x123456789abcdf0, %rdx # imm = 0xFEDCBA9876543210
+               	addq	%rbx, %rdx
+               	leaq	(%rdi), %rbx
+               	leaq	0x18(%rbx), %r12
+               	movq	%rdx, (%r12)
+               	movl	$0x14, %edx
+               	addl	%esi, %edx
+               	movw	%dx, %r12w
+               	leaq	0x20(%rbx), %rdx
+               	leaq	(%rdx), %r13
+               	movw	%r12w, (%r13)
+               	movl	$0x15, %r12d
+               	addl	%esi, %r12d
+               	movw	%r12w, %r13w
+               	leaq	0x2(%rdx), %r12
+               	movw	%r13w, (%r12)
+               	movl	$0x16, %r12d
+               	addl	%esi, %r12d
+               	movw	%r12w, %r13w
+               	leaq	0x4(%rdx), %r12
+               	movw	%r13w, (%r12)
+               	movl	$0x17, %edx
+               	addl	%esi, %edx
+               	movb	%dl, %r12b
+               	leaq	0x26(%rbx), %rdx
+               	movb	%r12b, (%rdx)
+               	leaq	0x28(%rdi), %rdx
+               	leaq	(%rdx), %rbx
+               	movl	$0x1e, %edx
+               	addl	%esi, %edx
+               	movw	%dx, %r12w
+               	leaq	(%rbx), %r13
+               	movw	%r12w, (%r13)
+               	movl	%edx, %r12d
+               	addl	$0x1, %r12d
+               	movb	%r12b, %r13b
+               	leaq	0x4(%rbx), %r12
+               	leaq	(%r12), %r14
+               	movb	%r13b, (%r14)
+               	movl	%edx, %r13d
+               	addl	$0x2, %r13d
+               	leaq	0x4(%r12), %r14
+               	movl	%r13d, (%r14)
+               	movl	%edx, %r13d
+               	addl	$0x3, %r13d
+               	movb	%r13b, %r14b
+               	leaq	0x8(%r12), %r13
+               	movb	%r14b, (%r13)
+               	addl	$0x4, %edx
+               	movb	%dl, %r12b
+               	leaq	0x10(%rbx), %rdx
+               	movb	%r12b, (%rdx)
+               	leaq	0x28(%rdi), %rdx
+               	leaq	0x14(%rdx), %rbx
+               	movl	$0x28, %edx
+               	addl	%esi, %edx
+               	movw	%dx, %r12w
+               	leaq	(%rbx), %r13
+               	movw	%r12w, (%r13)
+               	movl	%edx, %r12d
+               	addl	$0x1, %r12d
+               	movb	%r12b, %r13b
+               	leaq	0x4(%rbx), %r12
+               	leaq	(%r12), %r14
+               	movb	%r13b, (%r14)
+               	movl	%edx, %r13d
+               	addl	$0x2, %r13d
+               	leaq	0x4(%r12), %r14
+               	movl	%r13d, (%r14)
+               	movl	%edx, %r13d
+               	addl	$0x3, %r13d
+               	movb	%r13b, %r14b
+               	leaq	0x8(%r12), %r13
+               	movb	%r14b, (%r13)
+               	addl	$0x4, %edx
+               	movb	%dl, %r12b
+               	leaq	0x10(%rbx), %rdx
+               	movb	%r12b, (%rdx)
+               	movl	$0x32, %edx
+               	addl	%esi, %edx
+               	leaq	0x50(%rdi), %rbx
+               	movl	%edx, (%rbx)
+               	leaq	-0x160(%rbp), %rdx
+               	leaq	(%rdx), %rsi
                	leaq	(%rdi), %r12
-               	cmpq	%r12, %rdx
-               	jb	 <L38>
-               	movq	%rdx, %r13
+               	cmpq	%r12, %rsi
+               	jb	 <L33>
+               	movq	%rsi, %r13
                	addq	$0x58, %r13
                	movq	%r12, %r14
                	addq	$0x58, %r14
                	movq	$0x58, %r15
-<L37>:
+<L32>:
                	subq	$0x8, %r13
                	subq	$0x8, %r14
                	movq	(%r14), %rax
                	movq	%rax, (%r13)
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L37>
-               	jmp	 <L40>
-<L38>:
-               	addq	$0x0, %rdx
+               	jne	 <L32>
+               	jmp	 <L35>
+<L33>:
+               	addq	$0x0, %rsi
                	addq	$0x0, %r12
                	movq	$0x58, %rax
-<L39>:
+<L34>:
                	movq	(%r12), %r13
-               	movq	%r13, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	%r13, (%rsi)
+               	addq	$0x8, %rsi
                	addq	$0x8, %r12
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L39>
-<L40>:
-               	leaq	-0x268(%rbp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L42>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %r12
+               	jne	 <L34>
+<L35>:
+               	leaq	-0x1b8(%rbp), %rax
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rax
+               	jb	 <L37>
+               	movq	%rax, %rdx
+               	addq	$0x58, %rdx
+               	movq	%rsi, %r12
                	addq	$0x58, %r12
                	movq	$0x58, %r13
-<L41>:
-               	subq	$0x8, %rcx
+<L36>:
+               	subq	$0x8, %rdx
                	subq	$0x8, %r12
                	movq	(%r12), %r14
-               	movq	%r14, (%rcx)
+               	movq	%r14, (%rdx)
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
-               	jne	 <L41>
-               	jmp	 <L44>
-<L42>:
+               	jne	 <L36>
+               	jmp	 <L39>
+<L37>:
                	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
-<L43>:
-               	movq	(%rdx), %r12
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L38>:
+               	movq	(%rsi), %r12
                	movq	%r12, (%rax)
                	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L43>
-<L44>:
-               	leaq	-0x268(%rbp), %rdx
-               	movq	-0x5d0(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x5d8(%rbp)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L38>
+<L39>:
+               	leaq	-0x1b8(%rbp), %rdx
                	movq	-0x5d8(%rbp), %r8
-               	leaq	0x28(%rdi), %r12
-               	leaq	0x14(%r12), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x8(%rdx), %rcx
-               	movzbl	(%rcx), %edx
-               	addl	$0x7, %edx
-               	movb	%dl, (%rcx)
-               	leaq	-0x2c0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r8
                	movq	%r8, -0x5e0(%rbp)
                	movq	-0x5e0(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%rdi), %rsi
+               	leaq	(%rsi), %rdx
+               	leaq	0x4(%rdx), %r12
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r12d
+               	xorl	$0xf0f0f0f0, %r12d      # imm = 0xF0F0F0F0
+               	movl	%r12d, (%rdx)
+               	leaq	-0x210(%rbp), %r8
+               	movq	%r8, -0x5e8(%rbp)
+               	movq	-0x5e8(%rbp), %r8
+               	leaq	(%r8), %r12
                	leaq	(%rdi), %r13
-               	cmpq	%r13, %rdx
-               	jb	 <L47>
-               	movq	%rdx, %r14
+               	cmpq	%r13, %r12
+               	jb	 <L42>
+               	movq	%r12, %r14
                	addq	$0x58, %r14
                	movq	%r13, %r15
                	addq	$0x58, %r15
                	movq	$0x58, %rax
-<L46>:
+<L41>:
                	subq	$0x8, %r14
                	subq	$0x8, %r15
-               	movq	(%r15), %rcx
-               	movq	%rcx, (%r14)
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L46>
-               	jmp	 <L49>
-<L47>:
-               	addq	$0x0, %rdx
+               	jne	 <L41>
+               	jmp	 <L44>
+<L42>:
+               	addq	$0x0, %r12
                	addq	$0x0, %r13
                	movq	$0x58, %rax
-<L48>:
-               	movq	(%r13), %rcx
-               	movq	%rcx, (%rdx)
-               	addq	$0x8, %rdx
+<L43>:
+               	movq	(%r13), %rdx
+               	movq	%rdx, (%r12)
+               	addq	$0x8, %r12
                	addq	$0x8, %r13
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L48>
-<L49>:
-               	leaq	-0x318(%rbp), %rax
-               	movq	-0x5e0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	cmpq	%rcx, %rax
-               	jb	 <L51>
-               	movq	%rax, %rdx
-               	addq	$0x58, %rdx
-               	movq	%rcx, %r13
+               	jne	 <L43>
+<L44>:
+               	leaq	-0x268(%rbp), %rax
+               	movq	-0x5e8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L46>
+               	movq	%rax, %r12
+               	addq	$0x58, %r12
+               	movq	%rdx, %r13
                	addq	$0x58, %r13
                	movq	$0x58, %r14
-<L50>:
-               	subq	$0x8, %rdx
+<L45>:
+               	subq	$0x8, %r12
                	subq	$0x8, %r13
                	movq	(%r13), %r15
-               	movq	%r15, (%rdx)
+               	movq	%r15, (%r12)
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
+               	jne	 <L45>
+               	jmp	 <L48>
+<L46>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rdx
+               	movq	$0x58, %r12
+<L47>:
+               	movq	(%rdx), %r13
+               	movq	%r13, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rdx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L47>
+<L48>:
+               	leaq	-0x268(%rbp), %rdx
+               	movq	-0x5e0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x5f0(%rbp)
+               	movq	-0x5f0(%rbp), %r8
+               	leaq	0x28(%rdi), %r12
+               	leaq	0x14(%r12), %rdx
+               	leaq	0x4(%rdx), %r13
+               	leaq	0x8(%r13), %rdx
+               	movzbl	(%rdx), %r13d
+               	addl	$0x7, %r13d
+               	movb	%r13b, (%rdx)
+               	leaq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x5f8(%rbp)
+               	movq	-0x5f8(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x600(%rbp)
+               	leaq	(%rdi), %r14
+               	movq	-0x600(%rbp), %r8
+               	cmpq	%r14, %r8
+               	jb	 <L51>
+               	movq	-0x600(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0x58, %r15
+               	movq	%r14, %rax
+               	addq	$0x58, %rax
+               	movq	$0x58, %rdx
+<L50>:
+               	subq	$0x8, %r15
+               	subq	$0x8, %rax
+               	movq	(%rax), %r13
+               	movq	%r13, (%r15)
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L50>
                	jmp	 <L53>
 <L51>:
+               	movq	-0x600(%rbp), %r8
+               	movq	%r8, %rax
                	addq	$0x0, %rax
-               	addq	$0x0, %rcx
+               	addq	$0x0, %r14
                	movq	$0x58, %rdx
 <L52>:
-               	movq	(%rcx), %r13
+               	movq	(%r14), %r13
                	movq	%r13, (%rax)
                	addq	$0x8, %rax
-               	addq	$0x8, %rcx
+               	addq	$0x8, %r14
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L52>
 <L53>:
-               	leaq	-0x318(%rbp), %rdx
-               	movq	-0x5d8(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x5e8(%rbp)
-               	movq	-0x5e8(%rbp), %r8
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	shrq	$0x3, %rdx
-               	movq	%rdx, (%rcx)
-               	leaq	-0x370(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%rdi), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L56>
-               	movq	%rdx, %r13
+               	leaq	-0x318(%rbp), %r8
+               	movq	%r8, -0x608(%rbp)
+               	movq	-0x5f8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	-0x608(%rbp), %r8
+               	cmpq	%rdx, %r8
+               	jb	 <L55>
+               	movq	-0x608(%rbp), %r8
+               	movq	%r8, %r13
                	addq	$0x58, %r13
-               	movq	%rsi, %r14
+               	movq	%rdx, %r14
                	addq	$0x58, %r14
                	movq	$0x58, %r15
-<L55>:
+<L54>:
                	subq	$0x8, %r13
                	subq	$0x8, %r14
                	movq	(%r14), %rax
                	movq	%rax, (%r13)
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L55>
-               	jmp	 <L58>
-<L56>:
+               	jne	 <L54>
+               	jmp	 <L57>
+<L55>:
+               	movq	-0x608(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rax
-<L57>:
-               	movq	(%rsi), %r13
-               	movq	%r13, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rax
-               	cmpq	$0x0, %rax
-               	jne	 <L57>
-<L58>:
-               	leaq	-0x3c8(%rbp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L60>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
                	movq	$0x58, %r13
-<L59>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
+<L56>:
+               	movq	(%rdx), %r14
+               	movq	%r14, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rdx
                	subq	$0x8, %r13
                	cmpq	$0x0, %r13
+               	jne	 <L56>
+<L57>:
+               	leaq	-0x318(%rbp), %rdx
+               	movq	-0x5f0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L58>
+<L58>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x610(%rbp)
+               	movq	-0x610(%rbp), %r8
+               	leaq	0x18(%rsi), %rdx
+               	movq	(%rdx), %rsi
+               	shrq	$0x3, %rsi
+               	movq	%rsi, (%rdx)
+               	leaq	-0x370(%rbp), %r8
+               	movq	%r8, -0x618(%rbp)
+               	movq	-0x618(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%rdi), %r13
+               	cmpq	%r13, %rsi
+               	jb	 <L60>
+               	movq	%rsi, %r14
+               	addq	$0x58, %r14
+               	movq	%r13, %r15
+               	addq	$0x58, %r15
+               	movq	$0x58, %rax
+<L59>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L59>
                	jmp	 <L62>
 <L60>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rsi
+               	addq	$0x0, %r13
+               	movq	$0x58, %rax
 <L61>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	movq	(%r13), %rdx
+               	movq	%rdx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %r13
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L61>
 <L62>:
-               	leaq	-0x3c8(%rbp), %rdx
-               	movq	-0x5e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L63>
-<L63>:
-               	movl	(%rbx), %ecx
-               	imull	$0x3, %ecx, %ecx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x420(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%rdi), %rbx
-               	cmpq	%rbx, %rdx
-               	jb	 <L65>
-               	movq	%rdx, %rsi
+               	leaq	-0x3c8(%rbp), %rax
+               	movq	-0x618(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L64>
+               	movq	%rax, %rsi
                	addq	$0x58, %rsi
-               	movq	%rbx, %r13
+               	movq	%rdx, %r13
                	addq	$0x58, %r13
                	movq	$0x58, %r14
-<L64>:
+<L63>:
                	subq	$0x8, %rsi
                	subq	$0x8, %r13
                	movq	(%r13), %r15
                	movq	%r15, (%rsi)
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L64>
-               	jmp	 <L67>
-<L65>:
+               	jne	 <L63>
+               	jmp	 <L66>
+<L64>:
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rbx
                	movq	$0x58, %rsi
-<L66>:
-               	movq	(%rbx), %r13
-               	movq	%r13, (%rdx)
+<L65>:
+               	movq	(%rdx), %r13
+               	movq	%r13, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rbx
                	subq	$0x8, %rsi
                	cmpq	$0x0, %rsi
-               	jne	 <L66>
+               	jne	 <L65>
+<L66>:
+               	leaq	-0x3c8(%rbp), %rdx
+               	movq	-0x610(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L67>
 <L67>:
-               	leaq	-0x478(%rbp), %rdx
-               	leaq	(%rcx), %rbx
-               	cmpq	%rbx, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x620(%rbp)
+               	movq	-0x620(%rbp), %r8
+               	movl	(%rbx), %edx
+               	imull	$0x3, %edx, %edx
+               	movl	%edx, (%rbx)
+               	leaq	-0x420(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	leaq	(%rdi), %rsi
+               	cmpq	%rsi, %rbx
                	jb	 <L69>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rbx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %r13
+               	movq	%rbx, %r13
+               	addq	$0x58, %r13
+               	movq	%rsi, %r14
+               	addq	$0x58, %r14
+               	movq	$0x58, %r15
 <L68>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
                	subq	$0x8, %r13
-               	cmpq	$0x0, %r13
+               	subq	$0x8, %r14
+               	movq	(%r14), %rax
+               	movq	%rax, (%r13)
+               	subq	$0x8, %r15
+               	cmpq	$0x0, %r15
                	jne	 <L68>
                	jmp	 <L71>
 <L69>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rbx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rax
 <L70>:
-               	movq	(%rbx), %rsi
-               	movq	%rsi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rsi), %r13
+               	movq	%r13, (%rbx)
                	addq	$0x8, %rbx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L70>
 <L71>:
-               	leaq	-0x478(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
-               	leaq	-0x48c(%rbp), %rbx
-               	leaq	(%r12), %rsi
-               	leaq	-0x4a0(%rbp), %rcx
-               	movq	(%rsi), %rdx
-               	movq	0x8(%rsi), %r12
-               	movl	0x10(%rsi), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%r12, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%r12, 0x8(%rbx)
-               	movl	%r13d, 0x10(%rbx)
-               	leaq	0x4(%rbx), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movl	%ecx, (%rdx)
-               	leaq	-0x4b4(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %r12
-               	movl	0x10(%rbx), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%r12, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rdx, -0x4cc(%rbp)
-               	movq	%r12, -0x4c4(%rbp)
-               	movl	%r13d, -0x4bc(%rbp)
-               	leaq	-0x4cc(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
-               	leaq	-0x4e0(%rbp), %rcx
-               	movq	(%rsi), %rdx
-               	movq	0x8(%rsi), %r12
-               	movl	0x10(%rsi), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%r12, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rdx, -0x4f8(%rbp)
-               	movq	%r12, -0x4f0(%rbp)
-               	movl	%r13d, -0x4e8(%rbp)
-               	leaq	-0x4f8(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x50c(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %r12
-               	movl	0x10(%rbx), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%r12, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rbx
-               	movl	0x10(%rcx), %r12d
-               	movq	%rdx, (%rsi)
-               	movq	%rbx, 0x8(%rsi)
-               	movl	%r12d, 0x10(%rsi)
-               	leaq	-0x568(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%rdi), %rbx
-               	cmpq	%rbx, %rdx
-               	jb	 <L76>
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	%rbx, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %r12
-<L75>:
-               	subq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r13
-               	movq	%r13, (%rsi)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L75>
-               	jmp	 <L78>
-<L76>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rbx
-               	movq	$0x58, %rsi
-<L77>:
-               	movq	(%rbx), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rbx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L77>
-<L78>:
-               	leaq	-0x5c0(%rbp), %rdx
-               	leaq	(%rcx), %rbx
-               	cmpq	%rbx, %rdx
-               	jb	 <L80>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
+               	leaq	-0x478(%rbp), %rax
+               	leaq	(%rdx), %rbx
+               	cmpq	%rbx, %rax
+               	jb	 <L73>
+               	movq	%rax, %rdx
+               	addq	$0x58, %rdx
                	movq	%rbx, %rsi
                	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L79>:
-               	subq	$0x8, %rcx
+               	movq	$0x58, %r13
+<L72>:
+               	subq	$0x8, %rdx
                	subq	$0x8, %rsi
+               	movq	(%rsi), %r14
+               	movq	%r14, (%rdx)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L72>
+               	jmp	 <L75>
+<L73>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rbx
+               	movq	$0x58, %rdx
+<L74>:
+               	movq	(%rbx), %rsi
+               	movq	%rsi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rbx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L74>
+<L75>:
+               	leaq	-0x478(%rbp), %rdx
+               	movq	-0x620(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x48c(%rbp), %rbx
+               	leaq	(%r12), %rsi
+               	leaq	-0x4a0(%rbp), %rdx
                	movq	(%rsi), %r12
-               	movq	%r12, (%rcx)
+               	movq	0x8(%rsi), %r13
+               	movl	0x10(%rsi), %r14d
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rbx)
+               	movq	%r13, 0x8(%rbx)
+               	movl	%r14d, 0x10(%rbx)
+               	leaq	0x4(%rbx), %rdx
+               	leaq	0x4(%rdx), %r12
+               	movl	(%r12), %edx
+               	addl	$0x1, %edx
+               	movl	%edx, (%r12)
+               	leaq	-0x4b4(%rbp), %rdx
+               	movq	(%rbx), %r12
+               	movq	0x8(%rbx), %r13
+               	movl	0x10(%rbx), %r14d
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, -0x4cc(%rbp)
+               	movq	%r13, -0x4c4(%rbp)
+               	movl	%r14d, -0x4bc(%rbp)
+               	leaq	-0x4cc(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L77>
+<L77>:
+               	leaq	-0x4e0(%rbp), %rdx
+               	movq	(%rsi), %r12
+               	movq	0x8(%rsi), %r13
+               	movl	0x10(%rsi), %r14d
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, -0x4f8(%rbp)
+               	movq	%r13, -0x4f0(%rbp)
+               	movl	%r14d, -0x4e8(%rbp)
+               	leaq	-0x4f8(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L78>
+<L78>:
+               	leaq	-0x50c(%rbp), %rdx
+               	movq	(%rbx), %r12
+               	movq	0x8(%rbx), %r13
+               	movl	0x10(%rbx), %r14d
+               	movq	%r12, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %r12
+               	movl	0x10(%rdx), %r13d
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movl	%r13d, 0x10(%rsi)
+               	leaq	-0x568(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	leaq	(%rdi), %rsi
+               	cmpq	%rsi, %rbx
+               	jb	 <L80>
+               	movq	%rbx, %rdi
+               	addq	$0x58, %rdi
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
+<L79>:
                	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
+               	subq	$0x8, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rdi)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
                	jne	 <L79>
                	jmp	 <L82>
 <L80>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rbx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdi
 <L81>:
-               	movq	(%rbx), %rsi
-               	movq	%rsi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rsi), %r12
+               	movq	%r12, (%rbx)
                	addq	$0x8, %rbx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
                	jne	 <L81>
 <L82>:
+               	leaq	-0x5c0(%rbp), %rbx
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rbx
+               	jb	 <L84>
+               	movq	%rbx, %rdx
+               	addq	$0x58, %rdx
+               	movq	%rsi, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r12
+<L83>:
+               	subq	$0x8, %rdx
+               	subq	$0x8, %rdi
+               	movq	(%rdi), %r13
+               	movq	%r13, (%rdx)
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L83>
+               	jmp	 <L86>
+<L84>:
+               	addq	$0x0, %rbx
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L85>:
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rbx)
+               	addq	$0x8, %rbx
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L85>
+<L86>:
                	leaq	-0x5c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	movq	-0x5f8(%rbp), %rbx
-               	movq	-0x600(%rbp), %rdi
-               	movq	-0x608(%rbp), %rsi
-               	movq	-0x610(%rbp), %r12
-               	movq	-0x618(%rbp), %r13
-               	movq	-0x620(%rbp), %r14
-               	movq	-0x628(%rbp), %r15
+               	callq	 <L87>
+<L87>:
+               	movq	-0x628(%rbp), %rbx
+               	movq	-0x630(%rbp), %rdi
+               	movq	-0x638(%rbp), %rsi
+               	movq	-0x640(%rbp), %r12
+               	movq	-0x648(%rbp), %r13
+               	movq	-0x650(%rbp), %r14
+               	movq	-0x658(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/uni_layout.dis
+++ b/test/golden/x86_64-windows/mem/uni_layout.dis
@@ -19,57 +19,186 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.fold_w4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0xc(%rbp), %rbx
-               	movl	-0x8(%rbp), %edx
-               	movl	%edx, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0xc(%rbp), %rdx
+               	movl	-0x8(%rbp), %ebx
+               	movl	%ebx, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rsi
-               	leaq	(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L4>
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L5>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L6>
+               	leaq	(%rdx), %rbx
+               	leaq	(%rbx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	leaq	(%rdx), %rbx
+               	leaq	0x1(%rbx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+<L9>:
+               	leaq	(%rdx), %rbx
+               	leaq	0x2(%rbx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	leaq	(%rdx), %rbx
+               	leaq	0x3(%rbx), %rdx
+               	movzbl	(%rdx), %ebx
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -77,64 +206,174 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.fold_w8>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x40, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rdi, -0x20(%rbp)
                	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movq	-0x8(%rbp), %rdx
-               	movq	%rdx, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movq	-0x8(%rbp), %rbx
+               	movq	%rbx, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L2>
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	(%rbx), %rsi
-               	leaq	(%rsi), %rdx
-               	movl	(%rdx), %edi
-               	movl	%edi, %edx
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rsi), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L4>
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L5>
-               	jmp	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	leaq	(%rbx), %rax
-               	leaq	(%rax,%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L6>
+               	leaq	(%rdx), %rbx
+               	leaq	(%rbx), %rsi
+               	movl	(%rsi), %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rsi
-               	cmpq	$0x8, %rdi
-               	jb	 <L5>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L7>:
+               	leaq	(%rdx), %rbx
+               	leaq	0x4(%rbx), %rsi
+               	movl	(%rsi), %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L13>
+<L10>:
+               	leaq	(%rdx), %rsi
+               	leaq	(%rsi,%rbx), %rdi
+               	movzbl	(%rdi), %esi
+               	movzbq	%sil, %rdi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
                	movq	%rsi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L13>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rdi
                	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -142,339 +381,411 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x170, %rsp            # imm = 0x170
-               	movq	%rbx, -0xf8(%rbp)
-               	movq	%rdi, -0x100(%rbp)
-               	movq	%rsi, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movaps	%xmm14, -0x140(%rbp)
-               	movaps	%xmm15, -0x150(%rbp)
+               	subq	$0x160, %rsp            # imm = 0x160
+               	movq	%rbx, -0xe8(%rbp)
+               	movq	%rdi, -0xf0(%rbp)
+               	movq	%rsi, -0xf8(%rbp)
+               	movq	%r12, -0x100(%rbp)
+               	movq	%r13, -0x108(%rbp)
+               	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
+               	movaps	%xmm14, -0x130(%rbp)
+               	movaps	%xmm15, -0x140(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
                	movq	$0x0, %rdi
                	cmpq	$0x6, %rdi
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
                	movq	%rdi, %rax
                	addq	$0x1, %rax
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	imulq	%rax, %rcx
-               	movq	%rcx, %r12
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r12
                	addq	%rbx, %r12
                	leaq	-0x4(%rbp), %r13
                	movl	$0x0, (%r13)
                	movl	%r12d, %eax
                	andl	$0x807fffff, %eax       # imm = 0x807FFFFF
                	orl	$0x3e800000, %eax       # imm = 0x3E800000
-               	leaq	(%r13), %rcx
-               	movl	%eax, (%rcx)
-               	leaq	-0x54(%rbp), %rax
-               	movl	(%r13), %ecx
-               	movl	%ecx, (%rax)
-               	movq	$0x0, -0x60(%rbp)
-               	movl	(%rax), %ecx
-               	movl	%ecx, -0x60(%rbp)
-               	movq	-0x60(%rbp), %rdx
+               	leaq	(%r13), %rdx
+               	movl	%eax, (%rdx)
+               	leaq	-0x4c(%rbp), %rax
+               	movl	(%r13), %edx
+               	movl	%edx, (%rax)
+               	movq	$0x0, -0x58(%rbp)
+               	movl	(%rax), %edx
+               	movl	%edx, -0x58(%rbp)
+               	movq	-0x58(%rbp), %rdx
                	movq	%rsi, %rcx
+               	callq	 <L1>
+<L1>:
+               	movq	%r12, %rdx
+               	shrq	$0x7, %rdx
+               	movl	%edx, %r14d
+               	andl	$0x807fffff, %r14d      # imm = 0x807FFFFF
+               	orl	$0x3e800000, %r14d      # imm = 0x3E800000
+               	leaq	(%r13), %rdx
+               	movl	%r14d, (%rdx)
+               	leaq	-0x5c(%rbp), %rdx
+               	movl	(%r13), %r14d
+               	movl	%r14d, (%rdx)
+               	movq	$0x0, -0x68(%rbp)
+               	movl	(%rdx), %r14d
+               	movl	%r14d, -0x68(%rbp)
+               	movq	-0x68(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	movq	%r12, %rcx
-               	shrq	$0x7, %rcx
-               	movl	%ecx, %edx
-               	andl	$0x807fffff, %edx       # imm = 0x807FFFFF
-               	orl	$0x3e800000, %edx       # imm = 0x3E800000
-               	leaq	(%r13), %rcx
-               	movl	%edx, (%rcx)
-               	leaq	-0x74(%rbp), %rcx
-               	movl	(%r13), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x80(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x80(%rbp)
-               	movq	-0x80(%rbp), %rdx
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x127>
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x6c(%rbp), %rdx
+               	movl	(%r13), %r14d
+               	movl	%r14d, (%rdx)
+               	movq	$0x0, -0x78(%rbp)
+               	movl	(%rdx), %r13d
+               	movl	%r13d, -0x78(%rbp)
+               	movq	-0x78(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x11e>
-               	movss	%xmm1, (%rcx)
-               	leaq	-0x84(%rbp), %rcx
-               	movl	(%r13), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x90(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x90(%rbp)
-               	movq	-0x90(%rbp), %rdx
+               	leaq	-0x80(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	%r12, %rdx
+               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
+               	andq	%r11, %rdx
+               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
+               	orq	%r11, %rdx
+               	leaq	(%r13), %r14
+               	movq	%rdx, (%r14)
+               	leaq	-0x90(%rbp), %rdx
+               	movq	(%r13), %r14
+               	movq	%r14, (%rdx)
+               	movq	(%rdx), %r14
                	movq	%rax, %rcx
+               	movq	%r14, %rdx
                	callq	 <L4>
 <L4>:
-               	leaq	-0x98(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	%r12, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	(%r13), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0xa0(%rbp), %rcx
-               	movq	(%r13), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
                	shrq	$0x9, %r12
                	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
                	andq	%r11, %r12
                	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
                	orq	%r11, %r12
-               	leaq	(%r13), %rcx
-               	movq	%r12, (%rcx)
-               	leaq	-0xa8(%rbp), %rcx
-               	movq	(%r13), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
+               	leaq	(%r13), %rdx
+               	movq	%r12, (%rdx)
+               	leaq	-0xa0(%rbp), %rdx
+               	movq	(%r13), %r12
+               	movq	%r12, (%rdx)
+               	movq	(%rdx), %r12
                	movq	%rax, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L5>
+<L5>:
+               	leaq	(%r13), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1f2>
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1fe>
+               	movsd	%xmm0, (%rdx)
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r13), %r12
+               	movq	%r12, (%rdx)
+               	movq	(%rdx), %r12
+               	movq	%rax, %rcx
+               	movq	%r12, %rdx
                	callq	 <L6>
 <L6>:
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1ef>
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1fb>
-               	movsd	%xmm0, (%rcx)
-               	leaq	-0xb0(%rbp), %rcx
-               	movq	(%r13), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
                	addq	$0x1, %rdi
                	movq	%rax, %rsi
                	cmpq	$0x6, %rdi
-               	jb	 <L1>
-<L8>:
+               	jb	 <L0>
+<L7>:
                	leaq	-0xc(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movl	%ebx, %r12d
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L9>
-               	jmp	 <L17>
-<L9>:
+               	jb	 <L8>
+               	jmp	 <L18>
+<L8>:
                	movl	%r13d, %eax
                	addl	$0x1, %eax
-               	movl	$0x9e3779b1, %ecx       # imm = 0x9E3779B1
-               	imull	%eax, %ecx
-               	movl	%ecx, %r14d
+               	movl	$0x9e3779b1, %edx       # imm = 0x9E3779B1
+               	imull	%eax, %edx
+               	movl	%edx, %r14d
                	addl	%r12d, %r14d
                	leaq	-0x14(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movl	%r14d, (%rcx)
-               	movl	%r14d, %ecx
-               	xorl	$0xf0f0f0f0, %ecx       # imm = 0xF0F0F0F0
-               	leaq	0x4(%rax), %rdx
-               	movl	%ecx, (%rdx)
-               	leaq	(%rdi), %r15
-               	movq	(%rax), %rcx
-               	movq	%rcx, (%r15)
-               	leaq	(%r15), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movl	(%r8), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r15), %r8
+               	leaq	(%rax), %rdx
+               	movl	%r14d, (%rdx)
+               	movl	%r14d, %edx
+               	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
+               	leaq	0x4(%rax), %r15
+               	movl	%edx, (%r15)
+               	leaq	(%rdi), %rdx
+               	movq	(%rax), %r15
+               	movq	%r15, (%rdx)
+               	leaq	(%rdx), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %r8d
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %edx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	leaq	(%rdi), %r15
-               	leaq	(%r15), %rdx
-               	movzwl	(%rdx), %r8d
+               	movq	%rsi, %r8
                	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
                	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%r15), %rdx
-               	movzwl	(%rdx), %r8d
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L9>
+<L10>:
+               	leaq	(%rdi), %rax
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %r8d
                	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r15, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0xc8(%rbp), %r8
                	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L11>
+<L12>:
+               	leaq	(%rdi), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L13>
 <L13>:
+               	leaq	(%rdi), %rdx
+               	leaq	0x2(%rdx), %r15
+               	movzwl	(%r15), %edx
+               	movzwq	%dx, %r15
                	movq	%rax, %rcx
-               	leaq	0x4(%r15), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xd0(%rbp), %r8
-               	movl	%r8d, %edx
+               	movq	%r15, %rdx
                	callq	 <L14>
 <L14>:
+               	leaq	(%rdi), %rdx
+               	leaq	0x4(%rdx), %r15
+               	movl	(%r15), %edx
+               	movl	%edx, %r15d
+               	movq	%rax, %rcx
+               	movq	%r15, %rdx
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %r8
                	movq	%r8, -0xd8(%rbp)
                	movq	-0xd8(%rbp), %r8
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movw	%r14w, %cx
-               	movq	-0xe0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movw	%cx, (%rdx)
-               	movl	%r14d, %ecx
-               	shrl	$0x10, %ecx
-               	movw	%cx, %dx
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x2(%r8), %rcx
-               	movw	%dx, (%rcx)
+               	leaq	-0xb0(%rbp), %rdx
+               	movw	%r14w, %r15w
+               	leaq	(%rdx), %rax
+               	movw	%r15w, (%rax)
+               	movl	%r14d, %eax
+               	shrl	$0x10, %eax
+               	movw	%ax, %r15w
+               	leaq	0x2(%rdx), %rax
+               	movw	%r15w, (%rax)
                	addl	$0x1, %r14d
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	%r14d, (%rcx)
-               	movq	-0xe0(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	%rcx, (%r15)
-               	movq	-0xe8(%rbp), %r8
-               	movl	(%r8), %edx
+               	leaq	0x4(%rdx), %rax
+               	movl	%r14d, (%rax)
+               	leaq	(%rdi), %rax
+               	movq	(%rdx), %r14
+               	movq	%r14, (%rax)
+               	leaq	(%rdi), %rax
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
                	movq	-0xd8(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L15>
-<L15>:
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %edx
-               	movq	%rax, %rcx
                	callq	 <L16>
 <L16>:
+               	leaq	(%rdi), %rdx
+               	leaq	0x4(%rdx), %r14
+               	movl	(%r14), %edx
+               	movl	%edx, %r14d
+               	movq	%rax, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L17>
+<L17>:
                	addq	$0x1, %r13
                	movq	%rax, %rsi
                	cmpq	$0x4, %r13
-               	jb	 <L9>
-<L17>:
-               	leaq	-0x30(%rbp), %rdi
+               	jb	 <L8>
+<L18>:
+               	leaq	-0x28(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, %r12
                	cmpq	$0x4, %r12
-               	jb	 <L18>
-               	jmp	 <L23>
-<L18>:
+               	jb	 <L19>
+               	jmp	 <L25>
+<L19>:
                	movq	%r12, %rax
                	addq	$0x1, %rax
-               	movb	%al, %cl
-               	leaq	(%rdi), %rdx
-               	movb	%cl, (%rdx)
-               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
-               	imulq	%rax, %rcx
-               	addq	%rbx, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	0x8(%rdi), %r13
-               	leaq	(%r13), %rax
-               	movq	%rcx, (%rax)
-               	leaq	(%rdi), %r14
-               	movzbl	(%r14), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	-0x68(%rbp), %rcx
-               	movq	(%r13), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x465>
-               	movsd	%xmm1, (%rcx)
-               	movzbl	(%r14), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	-0x70(%rbp), %rcx
-               	movq	(%r13), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	cmpq	$0x4, %r12
-               	jb	 <L18>
-<L23>:
-               	leaq	-0x48(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movq	$0x0, 0x8(%rdi)
-               	movq	$0x0, 0x10(%rdi)
-               	movq	$0x0, %rax
-               	cmpq	$0x3, %rax
-               	jb	 <L24>
-               	jmp	 <L25>
-<L24>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    # imm = 0x100000001B3
-               	imulq	%rcx, %rdx
+               	movb	%al, %dl
+               	leaq	(%rdi), %r13
+               	movb	%dl, (%r13)
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	imulq	%rax, %rdx
                	addq	%rbx, %rdx
                	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
                	andq	%r11, %rdx
                	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
                	orq	%r11, %rdx
-               	leaq	(%rdi,%rax,8), %rcx
-               	leaq	(%rcx), %r12
-               	movq	%rdx, (%r12)
+               	leaq	0x8(%rdi), %rax
+               	leaq	(%rax), %r13
+               	movq	%rdx, (%r13)
+               	leaq	(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	%rsi, %rdx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+<L21>:
+               	leaq	0x8(%rdi), %r13
+               	leaq	-0x88(%rbp), %rax
+               	movq	(%r13), %r14
+               	movq	%r14, (%rax)
+               	movq	(%rax), %r14
+               	movq	%rdx, %rcx
+               	movq	%r14, %rdx
+               	callq	 <L22>
+<L22>:
+               	leaq	(%r13), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x570>
+               	movsd	%xmm1, (%rdx)
+               	leaq	(%rdi), %rdx
+               	movzbl	(%rdx), %r13d
+               	movzbq	%r13b, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L23>
+<L23>:
+               	leaq	0x8(%rdi), %rdx
+               	leaq	-0x98(%rbp), %r13
+               	movq	(%rdx), %r14
+               	movq	%r14, (%r13)
+               	movq	(%r13), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L24>
+<L24>:
+               	addq	$0x1, %r12
+               	movq	%rax, %rsi
+               	cmpq	$0x4, %r12
+               	jb	 <L19>
+<L25>:
+               	leaq	-0x40(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movq	$0x0, 0x10(%rdi)
+               	movq	$0x0, %rax
+               	cmpq	$0x3, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdx
+               	addq	$0x1, %rdx
+               	movabsq	$0x100000001b3, %r12    # imm = 0x100000001B3
+               	imulq	%rdx, %r12
+               	addq	%rbx, %r12
+               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
+               	andq	%r11, %r12
+               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
+               	orq	%r11, %r12
+               	leaq	(%rdi,%rax,8), %rdx
+               	leaq	(%rdx), %r13
+               	movq	%r12, (%r13)
                	addq	$0x1, %rax
                	cmpq	$0x3, %rax
-               	jb	 <L24>
-<L25>:
+               	jb	 <L26>
+<L27>:
                	movq	$0x0, %rbx
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-               	jmp	 <L28>
-<L26>:
+               	jb	 <L28>
+               	jmp	 <L30>
+<L28>:
                	leaq	(%rdi,%rbx,8), %rax
-               	leaq	-0x50(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rdx
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rax), %r12
+               	movq	%r12, (%rdx)
+               	movq	(%rdx), %rax
                	movq	%rsi, %rcx
-               	callq	 <L27>
-<L27>:
+               	movq	%rax, %rdx
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %rbx
                	movq	%rax, %rsi
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-<L28>:
+               	jb	 <L28>
+<L30>:
                	movq	%rsi, %rax
-               	movaps	-0x140(%rbp), %xmm14
-               	movaps	-0x150(%rbp), %xmm15
-               	movq	-0xf8(%rbp), %rbx
-               	movq	-0x100(%rbp), %rdi
-               	movq	-0x108(%rbp), %rsi
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	movaps	-0x130(%rbp), %xmm14
+               	movaps	-0x140(%rbp), %xmm15
+               	movq	-0xe8(%rbp), %rbx
+               	movq	-0xf0(%rbp), %rdi
+               	movq	-0xf8(%rbp), %rsi
+               	movq	-0x100(%rbp), %r12
+               	movq	-0x108(%rbp), %r13
+               	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_i16.dis
+++ b/test/golden/x86_64-windows/scalar/arith_i16.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %eax           # imm = 0xFFF0
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpw	$0x20, %si
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %si
-               	movl	$0xfff0, %ecx           # imm = 0xFFF0
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpw	$0x20, %r12w
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movswq	%r12w, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L2>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
+               	movswq	%r12w, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpw	$0x20, %r12w
-               	jl	 <L1>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
 <L4>:
-               	movq	%rsi, %r12
-               	movq	$0x0, %r13
-               	cmpw	$0x8, %r13w
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpw	$0x20, %si
+               	jl	 <L0>
 <L5>:
-               	movl	%r13d, %eax
-               	imull	$0x3039, %eax, %eax     # imm = 0x3039
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rsi
+               	cmpw	$0x8, %si
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r13w
-               	jl	 <L5>
+               	movl	%esi, %edi
+               	imull	$0x3039, %edi, %edi     # imm = 0x3039
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movswq	%r12w, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L8>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %si
+               	jl	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %edx           # imm = 0x7FFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %edx           # imm = 0x8000
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %edx           # imm = 0xFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L16>
+               	movl	$0x7fff, %edx           # imm = 0x7FFF
+               	addl	%eax, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %edx           # imm = 0x8000
+               	subl	%eax, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %edx           # imm = 0xFFFF
+               	addl	%eax, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movswq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_i32.dis
+++ b/test/golden/x86_64-windows/scalar/arith_i32.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %eax       # imm = 0xFFFFFFF0
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x20, %esi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %esi
-               	movl	$0xfffffff0, %ecx       # imm = 0xFFFFFFF0
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movl	$0x0, %r12d
-               	cmpl	$0x20, %r12d
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movslq	%r12d, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L3>
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
+               	movslq	%r12d, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpl	$0x20, %r12d
-               	jl	 <L1>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
 <L4>:
-               	movq	%rsi, %r12
-               	movl	$0x0, %r13d
-               	cmpl	$0x8, %r13d
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpl	$0x20, %esi
+               	jl	 <L0>
 <L5>:
-               	movl	%r13d, %eax
-               	imull	$0x12345678, %eax, %eax # imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %esi
+               	cmpl	$0x8, %esi
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r13d
-               	jl	 <L5>
+               	movl	%esi, %edi
+               	imull	$0x12345678, %edi, %edi # imm = 0x12345678
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movslq	%r12d, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %esi
+               	jl	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %edx       # imm = 0x7FFFFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %edx       # imm = 0x80000000
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L16>
+               	movl	$0x7fffffff, %edx       # imm = 0x7FFFFFFF
+               	addl	%eax, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %edx       # imm = 0x80000000
+               	subl	%eax, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	addl	%eax, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movslq	%edx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_i64.dis
+++ b/test/golden/x86_64-windows/scalar/arith_i64.dis
@@ -6,117 +6,326 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rdx
+               	addq	%r8, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rax, %rsi
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x20, %r12
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movq	%rsi, %rdi
+               	imulq	$0x7, %rdi, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r12
+               	addq	%rdi, %r12
+               	movq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r12, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%rdi, %r13
-               	addq	%rax, %r13
-               	movq	%rsi, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r13
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	movq	%r13, %rdi
-               	cmpq	$0x20, %r12
-               	jl	 <L1>
-<L4>:
-               	movq	%rbx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jl	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	movq	%r13, %rax
-               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r12
-               	movq	%rsi, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
-<L6>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
                	addq	$0x1, %r13
-               	movq	%rax, %rsi
+               	movq	%r15, %rdi
                	cmpq	$0x8, %r13
-               	jl	 <L5>
-<L7>:
+               	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
                	movq	$0x0, %r13
-               	subq	%rdi, %r13
-               	movq	%rsi, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	$0x0, %rdx
-               	subq	%r13, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	movq	$0x0, %rdx
-               	subq	%rbx, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	movabsq	$0x7fffffffffffffff, %rdx # imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	movabsq	$-0x8000000000000000, %rdx # imm = 0x8000000000000000
-               	subq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	movq	$-0x1, %rdx
-               	addq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	movq	%rdi, %rdx
-               	addq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	movq	%rdi, %rdx
-               	subq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	subq	%rdi, %r12
-               	movq	%rax, %rcx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rbx
                	movq	%r12, %rdx
-               	callq	 <L16>
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
+<L5>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jl	 <L6>
+               	jmp	 <L9>
+<L6>:
+               	movq	%rdi, %r12
+               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rbx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+<L8>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jl	 <L6>
+<L9>:
+               	movq	$0x0, %rax
+               	subq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rax
+               	subq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movabsq	$0x7fffffffffffffff, %rax # imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rax # imm = 0x8000000000000000
+               	subq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rax
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movq	%rdx, %rax
+               	addq	%rsi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	%rdx, %rax
+               	subq	%rsi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	subq	%rdx, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rbx, %rdi
+               	xorq	%rdx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_i8.dis
+++ b/test/golden/x86_64-windows/scalar/arith_i8.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %eax
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpb	$0x20, %sil
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %sil
-               	movl	$0xf0, %ecx
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpb	$0x20, %r12b
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movsbq	%r12b, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L2>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
+               	movsbq	%r12b, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpb	$0x20, %r12b
-               	jl	 <L1>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
 <L4>:
-               	movq	%rsi, %r12
-               	movq	$0x0, %r13
-               	cmpb	$0x8, %r13b
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpb	$0x20, %sil
+               	jl	 <L0>
 <L5>:
-               	movl	%r13d, %eax
-               	imull	$0x35, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rsi
+               	cmpb	$0x8, %sil
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r13b
-               	jl	 <L5>
+               	movl	%esi, %edi
+               	imull	$0x35, %edi, %edi
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movsbq	%r12b, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L8>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %sil
+               	jl	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %edx
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %edx
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %edx
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L16>
+               	movl	$0x7f, %edx
+               	addl	%eax, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %edx
+               	subl	%eax, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %edx
+               	addl	%eax, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_u16.dis
+++ b/test/golden/x86_64-windows/scalar/arith_u16.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %eax           # imm = 0xFFF0
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpw	$0x20, %si
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %si
-               	movl	$0xfff0, %ecx           # imm = 0xFFF0
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpw	$0x20, %r12w
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movzwq	%r12w, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpw	$0x20, %r12w
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
+               	movzwq	%r12w, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
 <L4>:
-               	movq	%rsi, %r12
-               	movq	$0x0, %r13
-               	cmpw	$0x8, %r13w
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpw	$0x20, %si
+               	jb	 <L0>
 <L5>:
-               	movl	%r13d, %eax
-               	imull	$0xabcd, %eax, %eax     # imm = 0xABCD
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rsi
+               	cmpw	$0x8, %si
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r13w
-               	jb	 <L5>
+               	movl	%esi, %edi
+               	imull	$0xabcd, %edi, %edi     # imm = 0xABCD
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movzwq	%r12w, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L8>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %si
+               	jb	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %edx           # imm = 0x7FFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %edx           # imm = 0x8000
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %edx           # imm = 0xFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L16>
+               	movl	$0x7fff, %edx           # imm = 0x7FFF
+               	addl	%eax, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %edx           # imm = 0x8000
+               	subl	%eax, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %edx           # imm = 0xFFFF
+               	addl	%eax, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_u32.dis
+++ b/test/golden/x86_64-windows/scalar/arith_u32.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %eax       # imm = 0xFFFFFFF0
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x20, %esi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %esi
-               	movl	$0xfffffff0, %ecx       # imm = 0xFFFFFFF0
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movl	$0x0, %r12d
-               	cmpl	$0x20, %r12d
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movl	%r12d, %edi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L2>
-<L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpl	$0x20, %r12d
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-<L4>:
-               	movq	%rsi, %r12
-               	movl	$0x0, %r13d
-               	cmpl	$0x8, %r13d
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	movl	%r13d, %eax
-               	imull	$0x12345678, %eax, %eax # imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
+<L2>:
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
                	movl	%r12d, %edx
-               	callq	 <L6>
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+<L4>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpl	$0x20, %esi
+               	jb	 <L0>
+<L5>:
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %esi
+               	cmpl	$0x8, %esi
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r13d
-               	jb	 <L5>
+               	movl	%esi, %edi
+               	imull	$0x12345678, %edi, %edi # imm = 0x12345678
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movl	%r12d, %edi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %esi
+               	jb	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %edx       # imm = 0x7FFFFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %edx       # imm = 0x80000000
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L16>
+               	movl	$0x7fffffff, %edx       # imm = 0x7FFFFFFF
+               	addl	%eax, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %edx       # imm = 0x80000000
+               	subl	%eax, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	addl	%eax, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_u64.dis
+++ b/test/golden/x86_64-windows/scalar/arith_u64.dis
@@ -6,117 +6,326 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rdx
+               	addq	%r8, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rax, %rsi
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x20, %r12
+               	movq	%rsi, %rdi
+               	imulq	$0x7, %rdi, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r12
+               	addq	%rdi, %r12
+               	movq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r12, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%rdi, %r13
-               	addq	%rax, %r13
-               	movq	%rsi, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r13
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	movq	%r13, %rdi
-               	cmpq	$0x20, %r12
-               	jb	 <L1>
-<L4>:
-               	movq	%rbx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	movq	%r13, %rax
-               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r12
-               	movq	%rsi, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
-<L6>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
                	addq	$0x1, %r13
-               	movq	%rax, %rsi
+               	movq	%r15, %rdi
                	cmpq	$0x8, %r13
-               	jb	 <L5>
-<L7>:
+               	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
                	movq	$0x0, %r13
-               	subq	%rdi, %r13
-               	movq	%rsi, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	$0x0, %rdx
-               	subq	%r13, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	movq	$0x0, %rdx
-               	subq	%rbx, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	movabsq	$0x7fffffffffffffff, %rdx # imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	movabsq	$-0x8000000000000000, %rdx # imm = 0x8000000000000000
-               	subq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	movq	$-0x1, %rdx
-               	addq	%rdi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	movq	%rdi, %rdx
-               	addq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	movq	%rdi, %rdx
-               	subq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	subq	%rdi, %r12
-               	movq	%rax, %rcx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rbx
                	movq	%r12, %rdx
-               	callq	 <L16>
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
+<L5>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L9>
+<L6>:
+               	movq	%rdi, %r12
+               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rbx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+<L8>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+<L9>:
+               	movq	$0x0, %rax
+               	subq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rax
+               	subq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movabsq	$0x7fffffffffffffff, %rax # imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rax # imm = 0x8000000000000000
+               	subq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rax
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movq	%rdx, %rax
+               	addq	%rsi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	%rdx, %rax
+               	subq	%rsi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	subq	%rdx, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rbx, %rdi
+               	xorq	%rdx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/arith_u8.dis
+++ b/test/golden/x86_64-windows/scalar/arith_u8.dis
@@ -6,117 +6,345 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x50, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %eax
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpb	$0x20, %sil
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %sil
-               	movl	$0xf0, %ecx
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpb	$0x20, %r12b
+               	movl	%esi, %edi
+               	imull	$0x7, %edi, %edi
+               	addl	$0x1, %edi
+               	movl	%eax, %r12d
+               	addl	%edi, %r12d
+               	movzbq	%r12b, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r12d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%edi, %r13d
-               	addl	%eax, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L2>
-<L2>:
-               	movl	%r12d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r13d
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	movq	%r13, %rdi
-               	cmpb	$0x20, %r12b
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%esi, %edx
+               	imull	$0x3, %edx, %edx
+               	addl	$0x2, %edx
+               	subl	%edx, %r12d
+               	movzbq	%r12b, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
 <L4>:
-               	movq	%rsi, %r12
-               	movq	$0x0, %r13
-               	cmpb	$0x8, %r13b
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpb	$0x20, %sil
+               	jb	 <L0>
 <L5>:
-               	movl	%r13d, %eax
-               	imull	$0xb5, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r12d
-               	movq	%rbx, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rsi
+               	cmpb	$0x8, %sil
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r13b
-               	jb	 <L5>
+               	movl	%esi, %edi
+               	imull	$0xb5, %edi, %edi
+               	addl	$0x1, %edi
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%edi, %r12d
+               	movzbq	%r12b, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r13d
-               	subl	%edi, %r13d
-               	movq	%rbx, %rcx
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rdx
-               	callq	 <L8>
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %edx
-               	subl	%r13d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %sil
+               	jb	 <L6>
 <L9>:
                	movl	$0x0, %edx
-               	subl	%esi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
+               	subl	%eax, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %edx
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %edx
-               	subl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
+               	movl	$0x0, %esi
+               	subl	%edx, %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %edx
-               	addl	%edi, %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movl	%edi, %edx
-               	addl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %edx
+               	subl	%r8d, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%edi, %edx
-               	subl	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	subl	%edi, %r12d
-               	movq	%rax, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L16>
+               	movl	$0x7f, %edx
+               	addl	%eax, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %edx
+               	subl	%eax, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %edx
+               	addl	%eax, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	addl	%r8d, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%eax, %edx
+               	subl	%r8d, %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edx
+               	subl	%eax, %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/divrem_i32.dis
+++ b/test/golden/x86_64-windows/scalar/divrem_i32.dis
@@ -5,172 +5,423 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%rdi, -0x70(%rbp)
+               	movq	%rsi, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %esi
-               	movl	$0x77359400, %ebx       # imm = 0x77359400
-               	subl	%esi, %ebx
-               	movq	%rcx, %rdi
-               	movl	$0x0, %r12d
-               	cmpl	$0x10, %r12d
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r12d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movl	%ecx, %r13d
-               	addl	%esi, %r13d
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%eax, %r14d
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%edx, %r15d
-               	movq	%rdi, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r8
+               	movl	%ebx, %r8d
                	movq	%r8, -0x8(%rbp)
                	movq	-0x8(%rbp), %r8
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movl	%ecx, %r14d
-               	addl	%r15d, %r14d
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	subl	%r13d, %ebx
-               	addl	$0x1, %r12d
-               	cmpl	$0x10, %r12d
-               	jl	 <L1>
-<L5>:
-               	movl	$0x77359400, %ecx       # imm = 0x77359400
-               	addl	%esi, %ecx
-               	movl	$0x0, %ebx
-               	subl	%ecx, %ebx
-               	movl	$0x0, %r12d
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movl	%r12d, %ecx
-               	imull	$0xc5, %ecx, %ecx
-               	addl	$0x5, %ecx
-               	movl	%ecx, %r13d
-               	addl	%esi, %r13d
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%eax, %r14d
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%edx, %r15d
-               	movq	%rdi, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %r8
+               	movl	$0x77359400, %ebx       # imm = 0x77359400
+               	subl	%r8d, %ebx
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x10(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x0, %r12d
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r15d
+               	movq	-0x20(%rbp), %r8
+               	movslq	%r8d, %rsi
                	movq	-0x10(%rbp), %r8
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movl	%ecx, %r14d
-               	addl	%r15d, %r14d
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	addl	%r13d, %ebx
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+<L2>:
+               	movslq	%r15d, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %ebx
+               	imull	%r9d, %ebx
+               	addl	%r15d, %ebx
+               	movslq	%ebx, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %ebx
+               	subl	%r9d, %ebx
                	addl	$0x1, %r12d
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
+               	movq	%rdi, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x77359400, %ebx       # imm = 0x77359400
+               	addl	%r8d, %ebx
+               	movl	$0x0, %esi
+               	subl	%ebx, %esi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movl	$0x0, %edi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %edi
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movl	%edi, %r12d
+               	imull	$0xc5, %r12d, %r12d
+               	addl	$0x5, %r12d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r12d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r14d
+               	movq	-0x40(%rbp), %r8
+               	movslq	%r8d, %r15
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r15, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
 <L10>:
-               	movl	$0x7ffffffc, %ebx       # imm = 0x7FFFFFFC
-               	addl	%esi, %ebx
-               	movl	$0x3, %r12d
-               	addl	%esi, %r12d
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%eax, %esi
-               	movl	%ebx, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%edx, %r13d
-               	movq	%rdi, %rcx
-               	movl	%esi, %edx
-               	callq	 <L11>
+               	movslq	%r14d, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L12>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
 <L12>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edi
-               	imull	%esi, %edi
-               	addl	%r13d, %edi
-               	movl	%edi, %edx
-               	callq	 <L13>
+               	movq	-0x48(%rbp), %r8
+               	movq	-0x40(%rbp), %r9
+               	movl	%r8d, %esi
+               	imull	%r9d, %esi
+               	addl	%r14d, %esi
+               	movslq	%esi, %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%ebx
-               	movl	%eax, %esi
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%ebx
-               	movl	%edx, %edi
-               	movl	%esi, %edx
-               	callq	 <L14>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
 <L14>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L15>
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x48(%rbp), %r9
+               	movl	%r8d, %esi
+               	addl	%r9d, %esi
+               	addl	$0x1, %edi
+               	movq	%rbx, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %edi
+               	jl	 <L8>
 <L15>:
-               	movq	%rax, %rcx
-               	imull	%esi, %ebx
-               	addl	%edi, %ebx
-               	movl	%ebx, %edx
-               	callq	 <L16>
+               	movq	-0x8(%rbp), %r9
+               	movl	$0x7ffffffc, %r8d       # imm = 0x7FFFFFFC
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x3, %esi
+               	addl	%r8d, %esi
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%esi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%esi
+               	movl	%edx, %r12d
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %r13
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r15, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r13, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+<L17>:
+               	movslq	%r12d, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x58(%rbp), %r8
+               	movl	%esi, %ebx
+               	imull	%r8d, %ebx
+               	addl	%r12d, %ebx
+               	movslq	%ebx, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movl	%esi, %eax
+               	movq	-0x50(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%eax, %ebx
+               	movl	%esi, %eax
+               	movq	-0x50(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %esi
+               	movslq	%ebx, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movslq	%esi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+<L25>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %edi
+               	imull	%ebx, %edi
+               	addl	%esi, %edi
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movq	%r14, %rax
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %rdi
+               	movq	-0x78(%rbp), %rsi
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/divrem_i64.dis
+++ b/test/golden/x86_64-windows/scalar/divrem_i64.dis
@@ -5,171 +5,395 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
-               	subq	%rbx, %rsi
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x10, %r12
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r12, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %r13
-               	addq	%rbx, %r13
-               	movq	%rsi, %rax
-               	cqto
-               	idivq	%r13
-               	movq	%rax, %r14
-               	movq	%rsi, %rax
-               	cqto
-               	idivq	%r13
-               	movq	%rdx, %r15
-               	movq	%rdi, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r8
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	movq	%rcx, %r8
                	movq	%r8, -0x8(%rbp)
                	movq	-0x8(%rbp), %r8
-               	movq	%r13, %rcx
-               	imulq	%r14, %rcx
-               	movq	%rcx, %r14
-               	addq	%r15, %r14
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	subq	%r13, %rsi
-               	addq	$0x1, %r12
-               	cmpq	$0x10, %r12
-               	jl	 <L1>
-<L5>:
-               	movabsq	$0x7ce66c50e2840000, %rcx # imm = 0x7CE66C50E2840000
-               	addq	%rbx, %rcx
-               	movq	$0x0, %rsi
-               	subq	%rcx, %rsi
+               	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
+               	subq	%r8, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
                	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movq	%r12, %rcx
-               	imulq	$0xc5, %rcx, %rcx
-               	addq	$0x5, %rcx
-               	movq	%rcx, %r13
-               	addq	%rbx, %r13
-               	movq	%rsi, %rax
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
+               	movq	-0x8(%rbp), %r8
+               	addq	%r8, %r13
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
-               	movq	%rax, %r14
-               	movq	%rsi, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
                	movq	%rdx, %r15
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
                	movq	%rdi, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r13, %rcx
-               	imulq	%r14, %rcx
-               	movq	%rcx, %r14
-               	addq	%r15, %r14
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	addq	%r13, %rsi
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r15, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rsi
+               	subq	%r13, %rsi
                	addq	$0x1, %r12
-               	cmpq	$0x8, %r12
-               	jl	 <L6>
+               	movq	%rbx, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movabsq	$0x7ce66c50e2840000, %rbx # imm = 0x7CE66C50E2840000
+               	addq	%r8, %rbx
+               	movq	$0x0, %rsi
+               	subq	%rbx, %rsi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	$0x0, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rdi
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movq	%rdi, %r12
+               	imulq	$0xc5, %r12, %r12
+               	addq	$0x5, %r12
+               	movq	-0x8(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rax, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rdx, %r14
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rbx
+               	jb	 <L9>
 <L10>:
-               	movabsq	$0x7ffffffffffffffc, %rsi # imm = 0x7FFFFFFFFFFFFFFC
-               	addq	%rbx, %rsi
-               	movq	$0x3, %r12
-               	addq	%rbx, %r12
-               	movq	%rsi, %rax
-               	cqto
-               	idivq	%r12
-               	movq	%rax, %rbx
-               	movq	%rsi, %rax
-               	cqto
-               	idivq	%r12
-               	movq	%rdx, %r13
-               	movq	%rdi, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L11>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L12>
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rbx
+               	jb	 <L11>
 <L12>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdi
-               	imulq	%rbx, %rdi
-               	addq	%r13, %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L13>
+               	movq	-0x38(%rbp), %r8
+               	movq	%r12, %rbx
+               	imulq	%r8, %rbx
+               	addq	%r14, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rax
-               	cqto
-               	idivq	%rsi
-               	movq	%rax, %rbx
-               	movq	%r12, %rax
-               	cqto
-               	idivq	%rsi
-               	movq	%rdx, %rdi
-               	movq	%rbx, %rdx
-               	callq	 <L14>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
 <L14>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L15>
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rbx
+               	addq	%r12, %rbx
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rdi
+               	jl	 <L8>
 <L15>:
-               	movq	%rax, %rcx
-               	imulq	%rbx, %rsi
-               	addq	%rdi, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L16>
+               	movq	-0x8(%rbp), %r9
+               	movabsq	$0x7ffffffffffffffc, %r8 # imm = 0x7FFFFFFFFFFFFFFC
+               	addq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x3, %rsi
+               	addq	%r8, %rsi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rsi
+               	movq	%rax, %rdi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rsi
+               	movq	%rdx, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	%rsi, %rbx
+               	imulq	%rdi, %rbx
+               	addq	%r12, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L20>
+<L21>:
+               	movq	%rsi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rax, %rbx
+               	movq	%rsi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rdx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	%rbx, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/divrem_u32.dis
+++ b/test/golden/x86_64-windows/scalar/divrem_u32.dis
@@ -5,124 +5,305 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%rdi, -0x50(%rbp)
+               	movq	%rsi, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %esi
+               	movl	%ebx, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
                	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	subl	%esi, %ebx
-               	movq	%rcx, %rdi
+               	subl	%r8d, %ebx
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
                	movl	$0x0, %r12d
                	cmpl	$0x10, %r12d
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r12d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movl	%ecx, %r13d
-               	addl	%esi, %r13d
-               	movl	%ebx, %eax
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x10(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
-               	movl	%eax, %r14d
-               	movl	%ebx, %eax
+               	divl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
+               	divl	%r8d
                	movl	%edx, %r15d
-               	movq	%rdi, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %edi
                	movq	-0x8(%rbp), %r8
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movl	%ecx, %r14d
-               	addl	%r15d, %r14d
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	subl	%r13d, %ebx
-               	addl	$0x1, %r12d
-               	cmpl	$0x10, %r12d
+               	movq	%r8, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+<L2>:
+               	movl	%r15d, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %ebx
+               	imull	%r9d, %ebx
+               	addl	%r15d, %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movl	$0xfffffffd, %ebx       # imm = 0xFFFFFFFD
-               	addl	%esi, %ebx
-               	movl	$0x3, %r12d
-               	addl	%esi, %r12d
-               	movl	%ebx, %eax
-               	xorl	%edx, %edx
-               	divl	%r12d
-               	movl	%eax, %esi
-               	movl	%ebx, %eax
-               	xorl	%edx, %edx
-               	divl	%r12d
-               	movl	%edx, %r13d
-               	movq	%rdi, %rcx
-               	movl	%esi, %edx
-               	callq	 <L6>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rcx
-               	movl	%r13d, %edx
-               	callq	 <L7>
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %ebx
+               	subl	%r9d, %ebx
+               	addl	$0x1, %r12d
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jb	 <L0>
 <L7>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %edi
-               	imull	%esi, %edi
-               	addl	%r13d, %edi
-               	movl	%edi, %edx
-               	callq	 <L8>
+               	movq	-0x10(%rbp), %r9
+               	movl	$0xfffffffd, %r8d       # imm = 0xFFFFFFFD
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x30(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	$0x3, %esi
+               	addl	%r8d, %esi
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%esi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%esi
+               	movl	%edx, %r12d
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %r13d
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movl	%r12d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%eax, %esi
-               	movl	%r12d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%edx, %edi
-               	movl	%esi, %edx
-               	callq	 <L9>
+               	movq	%r15, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r13, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %rdi
+               	xorq	%rbx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movl	%edi, %edx
-               	callq	 <L10>
+               	movl	%r12d, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	imull	%esi, %ebx
-               	addl	%edi, %ebx
-               	movl	%ebx, %edx
-               	callq	 <L11>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	-0x38(%rbp), %r8
+               	movl	%esi, %ebx
+               	imull	%r8d, %ebx
+               	addl	%r12d, %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	movl	%esi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%eax, %ebx
+               	movl	%esi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%edx, %esi
+               	movl	%ebx, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+<L15>:
+               	movl	%esi, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %edi
+               	imull	%ebx, %edi
+               	addl	%esi, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%r14, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %rdi
+               	movq	-0x58(%rbp), %rsi
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/divrem_u64.dis
+++ b/test/golden/x86_64-windows/scalar/divrem_u64.dis
@@ -6,122 +6,285 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x70, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%rdi, -0x20(%rbp)
-               	movq	%rsi, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%rdi, -0x40(%rbp)
+               	movq	%rsi, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
                	movq	$-0x1, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rcx, %rdi
+               	subq	%r8, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x10, %r12
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r12, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %r13
-               	addq	%rbx, %r13
-               	movq	%rsi, %rax
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
+               	movq	-0x10(%rbp), %r8
+               	addq	%r8, %r13
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	xorl	%edx, %edx
                	divq	%r13
-               	movq	%rax, %r14
-               	movq	%rsi, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	xorl	%edx, %edx
                	divq	%r13
                	movq	%rdx, %r15
-               	movq	%rdi, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
-               	movq	%r15, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
                	movq	-0x8(%rbp), %r8
-               	movq	%r13, %rcx
-               	imulq	%r14, %rcx
-               	movq	%rcx, %r14
-               	addq	%r15, %r14
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	subq	%r13, %rsi
-               	addq	$0x1, %r12
-               	cmpq	$0x10, %r12
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rbx
+               	imulq	%r8, %rbx
+               	addq	%r15, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	$-0x3, %rsi
-               	addq	%rbx, %rsi
-               	movq	$0x3, %r12
-               	addq	%rbx, %r12
-               	movq	%rsi, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rax, %rbx
-               	movq	%rsi, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rdx, %r13
-               	movq	%rdi, %rcx
-               	movq	%rbx, %rdx
-               	callq	 <L6>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rcx
-               	movq	%r13, %rdx
-               	callq	 <L7>
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rbx
+               	subq	%r13, %rbx
+               	addq	$0x1, %r12
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jb	 <L0>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rdi
-               	imulq	%rbx, %rdi
-               	addq	%r13, %rdi
-               	movq	%rdi, %rdx
-               	callq	 <L8>
+               	movq	-0x10(%rbp), %r9
+               	movq	$-0x3, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movq	$0x3, %rsi
+               	addq	%r8, %rsi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rax, %rdi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %r12
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rax, %rbx
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %rdi
-               	movq	%rbx, %rdx
-               	callq	 <L9>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L10>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	imulq	%rbx, %rsi
-               	addq	%rdi, %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rdi
-               	movq	-0x28(%rbp), %rsi
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%rsi, %rbx
+               	imulq	%rdi, %rbx
+               	addq	%r12, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	movq	%rsi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rax, %rbx
+               	movq	%rsi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rdx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L16>
+<L17>:
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	%rbx, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	%r13, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %rdi
+               	movq	-0x48(%rbp), %rsi
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/mul_i32.dis
+++ b/test/golden/x86_64-windows/scalar/mul_i32.dis
@@ -5,76 +5,209 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %esi
-               	movl	$0x9e3779b9, %ecx       # imm = 0x9E3779B9
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movl	$0x0, %r12d
-               	cmpl	$0x10, %r12d
-               	jl	 <L1>
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b9, %eax       # imm = 0x9E3779B9
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x10, %esi
+               	jl	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	$0x2, %eax
-               	imull	%r12d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %edi
-               	movq	%rbx, %rcx
-               	movl	%edi, %edx
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r12d
-               	jl	 <L1>
-<L3>:
-               	movl	$0xffffffbf, %r12d      # imm = 0xFFFFFFBF
-               	addl	%esi, %r12d
-               	movl	%r12d, %eax
-               	imull	%r12d, %eax
-               	movq	%rbx, %rcx
-               	movl	%eax, %edx
-               	callq	 <L4>
-<L4>:
-               	movl	%r12d, %edx
-               	imull	$0xffffffff, %edx, %edx # imm = 0xFFFFFFFF
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	movl	%edi, %edx
-               	imull	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
+<L0>:
+               	movl	$0x2, %edi
+               	imull	%esi, %edi
+               	addl	$0x3, %edi
+               	movl	%eax, %r12d
                	imull	%edi, %r12d
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L7>
+               	movslq	%r12d, %rdi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpl	$0x10, %esi
+               	jl	 <L0>
+<L3>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %edx       # imm = 0xFFFFFFBF
+               	addl	%r8d, %edx
+               	movl	%edx, %esi
+               	imull	%edx, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%edx, %esi
+               	imull	$0xffffffff, %esi, %esi # imm = 0xFFFFFFFF
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          # imm = 0x10001
-               	addl	%esi, %ebx
-               	movl	%ebx, %edx
-               	imull	%ebx, %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	movl	%eax, %esi
+               	imull	%edx, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffffffff, %ebx, %ebx # imm = 0xFFFFFFFF
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L9>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
+               	imull	%eax, %edx
+               	movslq	%edx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          # imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffffffff, %eax, %eax # imm = 0xFFFFFFFF
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/mul_i64.dis
+++ b/test/golden/x86_64-windows/scalar/mul_i64.dis
@@ -10,69 +10,192 @@ Disassembly of section .text:
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %rsi
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x10, %r12
-               	jl	 <L1>
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	addq	%rax, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r12, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %rdi
-               	movq	%rsi, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %r12
-               	jl	 <L1>
-<L3>:
-               	movq	$-0x3f, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rdx
-               	imulq	%r12, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L4>
-<L4>:
-               	movq	%r12, %rdx
-               	imulq	$-0x1, %rdx, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	movq	%rdi, %rdx
-               	imulq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
+<L0>:
+               	movq	$0x2, %rdi
+               	imulq	%rsi, %rdi
+               	addq	$0x3, %rdi
+               	movq	%rdx, %r12
                	imulq	%rdi, %r12
-               	movq	%rax, %rcx
+               	movq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rbx
                	movq	%r12, %rdx
-               	callq	 <L7>
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
+<L3>:
+               	movq	$-0x3f, %rsi
+               	addq	%rax, %rsi
+               	movq	%rsi, %rdi
+               	imulq	%rsi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+<L5>:
+               	movq	%rsi, %rdi
+               	imulq	$-0x1, %rdi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %rsi      # imm = 0x10000000F
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
-               	imulq	%rsi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	movq	%rdx, %rdi
+               	imulq	%rsi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imulq	$-0x1, %rsi, %rsi
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rdx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rdx      # imm = 0x10000000F
+               	addq	%rax, %rdx
+               	movq	%rdx, %rax
+               	imulq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	imulq	$-0x1, %rdx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/mul_u32.dis
+++ b/test/golden/x86_64-windows/scalar/mul_u32.dis
@@ -5,76 +5,209 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, -0x10(%rbp)
-               	movq	%rsi, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %esi
-               	movl	$0x9e3779b1, %ecx       # imm = 0x9E3779B1
-               	addl	%esi, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %rdi
-               	movl	$0x0, %r12d
-               	cmpl	$0x10, %r12d
-               	jb	 <L1>
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b1, %eax       # imm = 0x9E3779B1
+               	addl	%r8d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	$0x2, %eax
-               	imull	%r12d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %edi
-               	movq	%rbx, %rcx
-               	movl	%edi, %edx
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r12d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r12d
-               	jb	 <L1>
-<L3>:
-               	movl	$0xffffffbf, %r12d      # imm = 0xFFFFFFBF
-               	addl	%esi, %r12d
-               	movl	%r12d, %eax
-               	imull	%r12d, %eax
-               	movq	%rbx, %rcx
-               	movl	%eax, %edx
-               	callq	 <L4>
-<L4>:
-               	movl	%r12d, %edx
-               	imull	$0xffffffff, %edx, %edx # imm = 0xFFFFFFFF
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	movl	%edi, %edx
-               	imull	%r12d, %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
+<L0>:
+               	movl	$0x2, %edi
+               	imull	%esi, %edi
+               	addl	$0x3, %edi
+               	movl	%eax, %r12d
                	imull	%edi, %r12d
-               	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L7>
+               	movl	%r12d, %edi
+               	movq	%rbx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rbx
+               	movq	%r12, %rax
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
+<L3>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %edx       # imm = 0xFFFFFFBF
+               	addl	%r8d, %edx
+               	movl	%edx, %esi
+               	imull	%edx, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%edx, %esi
+               	imull	$0xffffffff, %esi, %esi # imm = 0xFFFFFFFF
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          # imm = 0x10001
-               	addl	%esi, %ebx
-               	movl	%ebx, %edx
-               	imull	%ebx, %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	movl	%eax, %esi
+               	imull	%edx, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffff, %ebx, %ebx     # imm = 0xFFFF
-               	movq	%rax, %rcx
-               	movl	%ebx, %edx
-               	callq	 <L9>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %rdi
-               	movq	-0x18(%rbp), %rsi
-               	movq	-0x20(%rbp), %r12
+               	imull	%eax, %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          # imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffff, %eax, %eax     # imm = 0xFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/scalar/mul_u64.dis
+++ b/test/golden/x86_64-windows/scalar/mul_u64.dis
@@ -10,70 +10,193 @@ Disassembly of section .text:
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %rsi
-               	movq	%rcx, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x10, %r12
-               	jb	 <L1>
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rcx, %rax
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	addq	%rax, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r12, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %rdi
-               	movq	%rsi, %rcx
-               	movq	%rdi, %rdx
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rsi
-               	cmpq	$0x10, %r12
-               	jb	 <L1>
-<L3>:
-               	movq	$-0x3f, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rdx
-               	imulq	%r12, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L4>
-<L4>:
-               	movq	%r12, %rdx
-               	imulq	$-0x1, %rdx, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	movq	%rdi, %rdx
-               	imulq	%r12, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
+<L0>:
+               	movq	$0x2, %rdi
+               	imulq	%rsi, %rdi
+               	addq	$0x3, %rdi
+               	movq	%rdx, %r12
                	imulq	%rdi, %r12
-               	movq	%rax, %rcx
+               	movq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rbx
                	movq	%r12, %rdx
-               	callq	 <L7>
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
+<L3>:
+               	movq	$-0x3f, %rsi
+               	addq	%rax, %rsi
+               	movq	%rsi, %rdi
+               	imulq	%rsi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+<L5>:
+               	movq	%rsi, %rdi
+               	imulq	$-0x1, %rdi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %rsi      # imm = 0x10000000F
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rdx
-               	imulq	%rsi, %rdx
-               	movq	%rax, %rcx
-               	callq	 <L8>
+               	movq	%rdx, %rdi
+               	imulq	%rsi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	imulq	%r11, %rsi
-               	movq	%rax, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rdx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rdx      # imm = 0x10000000F
+               	addq	%rax, %rdx
+               	movq	%rdx, %rax
+               	imulq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	imulq	%r11, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/autovec_loop.dis
+++ b/test/golden/x86_64-windows/vec/autovec_loop.dis
@@ -5,751 +5,938 @@ Disassembly of section .text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xa00, %rsp            # imm = 0xA00
-               	movq	%rbx, -0x978(%rbp)
-               	movq	%rdi, -0x980(%rbp)
-               	movq	%rsi, -0x988(%rbp)
-               	movq	%r12, -0x990(%rbp)
-               	movq	%r13, -0x998(%rbp)
-               	movq	%r14, -0x9a0(%rbp)
-               	movq	%r15, -0x9a8(%rbp)
-               	movaps	%xmm6, -0x9c0(%rbp)
-               	movaps	%xmm14, -0x9d0(%rbp)
-               	movaps	%xmm15, -0x9e0(%rbp)
+               	subq	$0x970, %rsp            # imm = 0x970
+               	movq	%rbx, -0x918(%rbp)
+               	movq	%rdi, -0x920(%rbp)
+               	movq	%rsi, -0x928(%rbp)
+               	movq	%r12, -0x930(%rbp)
+               	movq	%r13, -0x938(%rbp)
+               	movq	%r14, -0x940(%rbp)
+               	movq	%r15, -0x948(%rbp)
+               	movaps	%xmm14, -0x960(%rbp)
+               	movaps	%xmm15, -0x970(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8a0(%rbp)
-               	movq	-0x8a0(%rbp), %r8
                	movq	%rbx, %rsi
                	andq	$0x1, %rsi
-               	movq	$0x43, %rdi
-               	subq	%rsi, %rdi
-               	movq	$0x25, %r12
-               	subq	%rsi, %r12
-               	movl	%ebx, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	$0x43, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	$0x25, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movl	%ebx, %esi
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
-<L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm6
-               	addss	%xmm6, %xmm6
-<L2>:
-               	leaq	-0x10c(%rbp), %rbx
-               	leaq	(%rbx), %r13
-               	addq	$0x0, %r13
-               	movq	$0x108, %r14            # imm = 0x108
-<L3>:
-               	movq	$0x0, (%r13)
-               	addq	$0x8, %r13
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L3>
-               	movl	$0x0, (%r13)
-               	leaq	-0x218(%rbp), %r13
-               	leaq	(%r13), %r14
-               	addq	$0x0, %r14
-               	movq	$0x108, %r15            # imm = 0x108
-<L4>:
-               	movq	$0x0, (%r14)
-               	addq	$0x8, %r14
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L4>
-               	movl	$0x0, (%r14)
-               	movq	$0x0, %r14
-               	cmpq	%rdi, %r14
-               	jb	 <L5>
-               	jmp	 <L6>
-<L5>:
-               	movl	%r14d, %r15d
-               	movl	%r15d, %ecx
-               	imull	$0x9e3779b1, %ecx, %ecx # imm = 0x9E3779B1
-               	addl	$0x3039, %ecx           # imm = 0x3039
-               	leaq	(%rbx,%r14,4), %rsi
-               	movl	%ecx, (%rsi)
-               	imull	$0x9e37, %r15d, %r15d   # imm = 0x9E37
-               	movl	$0xffffffff, %ecx       # imm = 0xFFFFFFFF
-               	subl	%r15d, %ecx
-               	leaq	(%r13,%r14,4), %rsi
-               	movl	%ecx, (%rsi)
-               	addq	$0x1, %r14
-               	cmpq	%rdi, %r14
-               	jb	 <L5>
-<L6>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	-0x324(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %r14            # imm = 0x108
-<L7>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L7>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L8>
-               	jmp	 <L9>
-<L8>:
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %r14
-               	movl	(%r14), %r15d
-               	imull	$0x3, %r15d, %r15d
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%r13,%r8,4), %r14
-               	movl	(%r14), %ecx
-               	addl	%ecx, %r15d
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%rsi,%r8,4), %rcx
-               	movl	%r15d, (%rcx)
-               	movq	-0x8b0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L8>
-<L9>:
-               	movq	-0x8a0(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r15
-               	cmpq	%rdi, %r15
-               	jb	 <L10>
-               	jmp	 <L12>
-<L10>:
-               	leaq	(%rsi,%r15,4), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x8b8(%rbp)
-               	movq	%r14, %rcx
-               	movq	-0x8b8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %r14
-               	addq	$0x1, %r15
-               	cmpq	%rdi, %r15
-               	jb	 <L10>
-<L12>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8d0(%rbp)
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x8d0(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L13>
-               	jmp	 <L14>
-<L13>:
-               	movq	-0x8d0(%rbp), %r8
-               	leaq	(%rsi,%r8,4), %r15
-               	movl	(%r15), %ecx
-               	movq	-0x8c8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%ecx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
-               	movq	-0x8d0(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %r15d
-               	movq	-0x8c0(%rbp), %r8
-               	movl	%r8d, %ecx
-               	xorl	%r15d, %ecx
-               	movq	-0x8d0(%rbp), %r8
-               	movq	%r8, %r15
-               	addq	$0x1, %r15
-               	movq	%r15, %r8
-               	movq	%r8, -0x8d0(%rbp)
-               	movq	-0x8d8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x8c8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x8d0(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L13>
-<L14>:
-               	movq	%r14, %rcx
-               	movq	-0x8c8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	movq	-0x8c0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8e0(%rbp)
-               	movq	-0x8e0(%rbp), %r8
-               	leaq	-0x430(%rbp), %r14
-               	leaq	(%r14), %r15
-               	addq	$0x0, %r15
-               	movq	$0x108, %rcx            # imm = 0x108
-<L17>:
-               	movq	$0x0, (%r15)
-               	addq	$0x8, %r15
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L17>
-               	movl	$0x0, (%r15)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L18>
-               	jmp	 <L21>
-<L18>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %r15
-               	movl	(%r15), %r8d
-               	movq	%r8, -0x8f0(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %r15
-               	movl	(%r15), %ecx
-               	movq	-0x8f0(%rbp), %r8
-               	cmpl	%r8d, %ecx
-               	jb	 <L19>
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x8f8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %r15d
-               	movq	-0x8f8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	subl	%r15d, %ecx
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %r15
-               	movl	%ecx, (%r15)
-               	jmp	 <L20>
-<L19>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x900(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rcx
-               	movl	(%rcx), %r15d
-               	movq	-0x900(%rbp), %r8
-               	movl	%r8d, %ecx
-               	subl	%r15d, %ecx
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %r15
-               	movl	%ecx, (%r15)
-<L20>:
-               	movq	-0x8e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L18>
-<L21>:
-               	movq	-0x8e0(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	$0x0, %r15
-               	cmpq	%rdi, %r15
-               	jb	 <L22>
-               	jmp	 <L24>
-<L22>:
-               	leaq	(%r14,%r15,4), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x908(%rbp)
-               	movq	%r13, %rcx
-               	movq	-0x908(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %r13
-               	addq	$0x1, %r15
-               	cmpq	%rdi, %r15
-               	jb	 <L22>
-<L24>:
-               	leaq	-0x53c(%rbp), %r14
-               	leaq	(%r14), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %r15            # imm = 0x108
-<L25>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L25>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%rdi, %rcx
-               	jb	 <L26>
-               	jmp	 <L27>
-<L26>:
-               	leaq	(%r14,%rcx,4), %r15
-               	movl	$0xaaaaaaaa, (%r15)     # imm = 0xAAAAAAAA
-               	addq	$0x1, %rcx
-               	cmpq	%rdi, %rcx
-               	jb	 <L26>
-<L27>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x910(%rbp)
-               	movq	-0x910(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L28>
-               	jmp	 <L29>
-<L28>:
-               	movq	-0x910(%rbp), %r8
-               	leaq	(%rsi,%r8,4), %r15
-               	movl	(%r15), %ecx
-               	xorl	$0x1, %ecx
-               	movq	-0x910(%rbp), %r8
-               	leaq	(%r14,%r8,4), %r15
-               	movl	%ecx, (%r15)
-               	movq	-0x910(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x910(%rbp)
-               	movq	-0x910(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L28>
-<L29>:
-               	movq	$0x0, %rsi
-               	cmpq	%rdi, %rsi
-               	jb	 <L30>
-               	jmp	 <L32>
-<L30>:
-               	leaq	(%r14,%rsi,4), %rcx
-               	movl	(%rcx), %r15d
-               	movq	%r13, %rcx
-               	movl	%r15d, %edx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r13
-               	addq	$0x1, %rsi
-               	cmpq	%rdi, %rsi
-               	jb	 <L30>
-<L32>:
-               	leaq	-0x648(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %r14            # imm = 0x108
-<L33>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L33>
-               	movl	$0x0, (%rcx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	(%rsi), %rcx
-               	movl	%r14d, (%rcx)
-               	movq	$0x1, %r8
-               	movq	%r8, -0x918(%rbp)
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L34>
-               	jmp	 <L35>
-<L34>:
-               	movq	-0x918(%rbp), %r8
-               	movq	%r8, %r14
-               	subq	$0x1, %r14
-               	leaq	(%rsi,%r14,4), %r15
-               	movl	(%r15), %r14d
-               	imull	$0x1f, %r14d, %r14d
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %r15
-               	movl	(%r15), %ecx
-               	addl	%ecx, %r14d
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%rsi,%r8,4), %rcx
-               	movl	%r14d, (%rcx)
-               	movq	-0x918(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x918(%rbp)
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%rdi, %r8
-               	jb	 <L34>
-<L35>:
-               	movq	$0x0, %rbx
-               	cmpq	%rdi, %rbx
-               	jb	 <L36>
-               	jmp	 <L38>
-<L36>:
-               	leaq	(%rsi,%rbx,4), %rcx
-               	movl	(%rcx), %r14d
-               	movq	%r13, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r13
-               	addq	$0x1, %rbx
-               	cmpq	%rdi, %rbx
-               	jb	 <L36>
-<L38>:
-               	leaq	-0x6dc(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L39>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L39>
-               	movl	$0x0, (%rcx)
-               	leaq	-0x770(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rdi
-<L40>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L40>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L42>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L43>
-<L42>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L43>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	%xmm6, %xmm1
-               	leaq	(%rbx,%rcx,4), %rdi
-               	movss	%xmm1, (%rdi)
-               	movss	, %xmm1 <corpus.cases.vec.autovec_loop.checksum+0x7d2>
-               	subss	%xmm0, %xmm1
-               	leaq	(%rsi,%rcx,4), %rdi
-               	movss	%xmm1, (%rdi)
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L41>
-<L44>:
-               	leaq	-0x804(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %r14
-<L45>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L1>:
+               	leaq	-0x680(%rbp), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	addq	$0x0, %r13
+               	movq	$0x108, %r14            # imm = 0x108
+<L2>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
+               	jne	 <L2>
+               	movl	$0x0, (%r13)
+               	leaq	-0x78c(%rbp), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	addq	$0x0, %r14
+               	movq	$0x108, %r15            # imm = 0x108
+<L3>:
+               	movq	$0x0, (%r14)
+               	addq	$0x8, %r14
+               	subq	$0x8, %r15
+               	cmpq	$0x0, %r15
+               	jne	 <L3>
+               	movl	$0x0, (%r14)
+               	movq	$0x0, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movl	%r14d, %r15d
+               	movl	%r15d, %ebx
+               	imull	$0x9e3779b1, %ebx, %ebx # imm = 0x9E3779B1
+               	addl	$0x3039, %ebx           # imm = 0x3039
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%ebx, (%r13)
+               	imull	$0x9e37, %r15d, %r15d   # imm = 0x9E37
+               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
+               	subl	%r15d, %ebx
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%ebx, (%r13)
+               	addq	$0x1, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movl	(%rbx), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rbx)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
+               	movl	(%rbx), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rbx)
+               	leaq	-0x10c(%rbp), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x108, %r13            # imm = 0x108
+<L6>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L6>
+               	movl	$0x0, (%rsi)
+               	movq	$0x0, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r14d
+               	imull	$0x3, %r14d, %r14d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r15d
+               	addl	%r15d, %r14d
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	%r14d, (%r13)
+               	addq	$0x1, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L7>
+<L8>:
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
+               	jmp	 <L12>
+<L9>:
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r14d
+               	movq	%rsi, %r15
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %rdi
+               	xorq	%r12, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
+<L12>:
+               	movq	$0x0, %rbx
+               	movl	$0x0, %edi
+               	movl	$0x0, %r12d
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r13
+               	movl	(%r13), %r14d
+               	addl	%r14d, %edi
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r13
+               	movl	(%r13), %r14d
+               	xorl	%r14d, %r12d
+               	addq	$0x1, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L13>
+<L14>:
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L15>
+<L16>:
+               	movl	%r12d, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L17>
+<L18>:
+               	leaq	-0x898(%rbp), %rbx
+               	leaq	(%rbx), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %r12            # imm = 0x108
+<L19>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L19>
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L20>
+               	jmp	 <L23>
+<L20>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r13d, %r14d
+               	jb	 <L21>
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	%r13d, (%r12)
+               	jmp	 <L22>
+<L21>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	%r13d, (%r12)
+<L22>:
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L20>
+<L23>:
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L24>
+               	jmp	 <L27>
+<L24>:
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
+<L26>:
+               	addq	$0x1, %rdi
+               	movq	%r13, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L24>
+<L27>:
+               	leaq	-0x218(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x108, %rdi            # imm = 0x108
+<L28>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L28>
+               	movl	$0x0, (%rsi)
+               	movq	$0x0, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	leaq	(%rbx,%rsi,4), %rdi
+               	movl	$0xaaaaaaaa, (%rdi)     # imm = 0xAAAAAAAA
+               	addq	$0x1, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	$0x0, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %r12d
+               	xorl	$0x1, %r12d
+               	leaq	(%rbx,%rsi,4), %rdi
+               	movl	%r12d, (%rdi)
+               	addq	$0x2, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L31>
+<L32>:
+               	movq	-0x8c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L33>
+               	jmp	 <L36>
+<L33>:
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L34>
+<L35>:
+               	addq	$0x1, %rdi
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L33>
+<L36>:
+               	leaq	-0x324(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x108, %rdi            # imm = 0x108
+<L37>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L37>
+               	movl	$0x0, (%rsi)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	(%rsi), %edi
+               	leaq	(%rbx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	$0x1, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rsi, %rdi
+               	subq	$0x1, %rdi
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %edi
+               	imull	$0x1f, %edi, %edi
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r12
+               	movl	(%r12), %r13d
+               	addl	%r13d, %edi
+               	leaq	(%rbx,%rsi,4), %r12
+               	movl	%edi, (%r12)
+               	addq	$0x1, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L38>
+<L39>:
+               	movq	-0x8d0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L40>
+               	jmp	 <L43>
+<L40>:
+               	leaq	(%rbx,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+<L42>:
+               	addq	$0x1, %rdi
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L40>
+<L43>:
+               	leaq	-0x3b8(%rbp), %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x90, %rdi
+<L44>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L44>
+               	movl	$0x0, (%rsi)
+               	leaq	-0x44c(%rbp), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x90, %r12
+<L45>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
                	jne	 <L45>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r12
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x920(%rbp)
-               	leaq	(%rbx), %r14
-               	leaq	(%rbx,%r12,4), %r15
-               	leaq	(%rsi), %r8
-               	movq	%r8, -0x938(%rbp)
-               	leaq	(%rsi,%r12,4), %r8
-               	movq	%r8, -0x928(%rbp)
-               	leaq	(%rdi), %r8
-               	movq	%r8, -0x930(%rbp)
-               	leaq	(%rdi,%r12,4), %rcx
-               	cmpq	%r14, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x930(%rbp), %r8
-               	cmpq	%r8, %r15
-               	setbe	%r14b
-               	movzbq	%r14b, %r14
-               	movq	-0x940(%rbp), %r8
-               	movl	%r8d, %r15d
-               	orl	%r14d, %r15d
-               	movq	-0x938(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%r14b
-               	movzbq	%r14b, %r14
-               	movq	-0x928(%rbp), %r8
-               	movq	-0x930(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %r14d
-               	andl	%r14d, %r15d
-               	movq	-0x920(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%r15d, %ecx
-               	testb	%cl, %cl
-               	jne	 <L47>
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
                	jb	 <L46>
-               	jmp	 <L51>
+               	jmp	 <L49>
 <L46>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movss	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movss	(%r14), %xmm1
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L47>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L48>
+<L47>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
+<L48>:
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movss	%xmm2, (%r12)
+               	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0x94b>
+               	subss	%xmm1, %xmm2
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movss	%xmm2, (%r12)
+               	addq	$0x1, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L46>
+<L49>:
+               	leaq	-0x4e0(%rbp), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0x90, %r13
+<L50>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L50>
+               	movl	$0x0, (%r12)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	movl	%r12d, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rbx
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	-0x8f0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rdi
+               	cmpq	%r13, %rdi
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rsi, %r14
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	orl	%r13d, %r12d
+               	cmpq	%r15, %rdi
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	cmpq	%rsi, %rbx
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %r13d
+               	andl	%r13d, %r12d
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%r8d, %ebx
+               	andl	%r12d, %ebx
+               	testb	%bl, %bl
+               	jne	 <L52>
+               	movq	$0x0, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L51>
+               	jmp	 <L56>
+<L51>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%rdi,%rcx,4), %r14
-               	movss	%xmm2, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L46>
-               	jmp	 <L51>
-<L47>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %r14
-               	addq	$0x4, %r14
-               	cmpq	%r12, %r14
-               	jbe	 <L48>
-               	jmp	 <L49>
-<L48>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movups	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movups	(%r14), %xmm1
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L51>
+               	jmp	 <L56>
+<L52>:
+               	movq	$0x0, %rbx
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jbe	 <L53>
+               	jmp	 <L54>
+<L53>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%rdi,%rcx,4), %r14
-               	movups	%xmm0, (%r14)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %r14
-               	addq	$0x4, %r14
-               	cmpq	%r12, %r14
-               	jbe	 <L48>
-<L49>:
-               	cmpq	%r12, %rcx
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movss	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movss	(%r14), %xmm1
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	%xmm0, (%rsi)
+               	addq	$0x4, %rbx
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jbe	 <L53>
+<L54>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L55>
+               	jmp	 <L56>
+<L55>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%rdi,%rcx,4), %r14
-               	movss	%xmm2, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L50>
-<L51>:
-               	movq	$0x0, %r14
-               	cmpq	%r12, %r14
-               	jb	 <L52>
-               	jmp	 <L54>
-<L52>:
-               	leaq	(%rdi,%r14,4), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r13, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r13
-               	addq	$0x1, %r14
-               	cmpq	%r12, %r14
-               	jb	 <L52>
-<L54>:
-               	leaq	-0x898(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %r14
-<L55>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L55>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r12
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x948(%rbp)
-               	leaq	(%rbx), %r14
-               	leaq	(%rbx,%r12,4), %r15
-               	leaq	(%rsi), %r8
-               	movq	%r8, -0x960(%rbp)
-               	leaq	(%rsi,%r12,4), %r8
-               	movq	%r8, -0x950(%rbp)
-               	leaq	(%rdi), %r8
-               	movq	%r8, -0x958(%rbp)
-               	leaq	(%rdi,%r12,4), %rcx
-               	cmpq	%r14, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x968(%rbp)
-               	movq	-0x958(%rbp), %r8
-               	cmpq	%r8, %r15
-               	setbe	%r14b
-               	movzbq	%r14b, %r14
-               	movq	-0x968(%rbp), %r8
-               	movl	%r8d, %r15d
-               	orl	%r14d, %r15d
-               	movq	-0x960(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%r14b
-               	movzbq	%r14b, %r14
-               	movq	-0x950(%rbp), %r8
-               	movq	-0x958(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %r14d
-               	andl	%r14d, %r15d
-               	movq	-0x948(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%r15d, %ecx
-               	testb	%cl, %cl
-               	jne	 <L57>
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L55>
 <L56>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movss	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movss	(%r14), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	leaq	(%rdi,%rcx,4), %r14
-               	movss	%xmm2, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L57>
+               	jmp	 <L60>
 <L57>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %r14
-               	addq	$0x4, %r14
-               	cmpq	%r12, %r14
-               	jbe	 <L58>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movd	%xmm0, %edi
+               	movl	%edi, %r12d
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
                	jmp	 <L59>
 <L58>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movups	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movups	(%r14), %xmm1
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
+<L59>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L57>
+<L60>:
+               	leaq	-0x574(%rbp), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x90, %r12
+<L61>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L61>
+               	movl	$0x0, (%rdi)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	andl	$0x1, %edi
+               	andl	$0x1, %edi
+               	andl	$0x1, %edi
+               	movl	%edi, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x910(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r13
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r15
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movq	-0x908(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	cmpq	%r12, %rsi
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	cmpq	%rbx, %r13
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	orl	%r12d, %edi
+               	cmpq	%r14, %rsi
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rbx, %r15
+               	setbe	%sil
+               	movzbq	%sil, %rsi
+               	orl	%esi, %r12d
+               	andl	%r12d, %edi
+               	movq	-0x910(%rbp), %r8
+               	movl	%r8d, %ebx
+               	andl	%edi, %ebx
+               	testb	%bl, %bl
+               	jne	 <L63>
+               	movq	$0x0, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L62>
+               	jmp	 <L67>
+<L62>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L62>
+               	jmp	 <L67>
+<L63>:
+               	movq	$0x0, %rbx
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jbe	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%rdi,%rcx,4), %r14
-               	movups	%xmm2, (%r14)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %r14
-               	addq	$0x4, %r14
-               	cmpq	%r12, %r14
-               	jbe	 <L58>
-<L59>:
-               	cmpq	%r12, %rcx
-               	jb	 <L60>
-               	jmp	 <L61>
-<L60>:
-               	leaq	(%rbx,%rcx,4), %r14
-               	movss	(%r14), %xmm0
-               	leaq	(%rsi,%rcx,4), %r14
-               	movss	(%r14), %xmm1
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movups	%xmm2, (%rsi)
+               	addq	$0x4, %rbx
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jbe	 <L64>
+<L65>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L66>
+               	jmp	 <L67>
+<L66>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%rdi,%rcx,4), %r14
-               	movss	%xmm2, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L60>
-<L61>:
-               	movq	$0x0, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L62>
-               	jmp	 <L64>
-<L62>:
-               	leaq	(%rdi,%rbx,4), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r13, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r13
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movss	%xmm2, (%rsi)
                	addq	$0x1, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L62>
-<L64>:
-               	movq	$0x0, %rcx
-               	xorps	%xmm0, %xmm0
-               	cmpq	%r12, %rcx
-               	jb	 <L65>
-               	jmp	 <L66>
-<L65>:
-               	leaq	(%rdi,%rcx,4), %rbx
-               	movss	(%rbx), %xmm1
-               	addss	%xmm1, %xmm0
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L65>
-<L66>:
-               	movq	%r13, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L66>
 <L67>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	-0x9c0(%rbp), %xmm6
-               	movaps	-0x9d0(%rbp), %xmm14
-               	movaps	-0x9e0(%rbp), %xmm15
-               	movq	-0x978(%rbp), %rbx
-               	movq	-0x980(%rbp), %rdi
-               	movq	-0x988(%rbp), %rsi
-               	movq	-0x990(%rbp), %r12
-               	movq	-0x998(%rbp), %r13
-               	movq	-0x9a0(%rbp), %r14
-               	movq	-0x9a8(%rbp), %r15
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movd	%xmm0, %edi
+               	movl	%edi, %r12d
+               	movq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L68>
+<L71>:
+               	movq	$0x0, %rsi
+               	xorps	%xmm0, %xmm0
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
+               	addss	%xmm1, %xmm0
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L72>
+<L73>:
+               	movd	%xmm0, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+<L75>:
+               	movq	%rbx, %rax
+               	movaps	-0x960(%rbp), %xmm14
+               	movaps	-0x970(%rbp), %xmm15
+               	movq	-0x918(%rbp), %rbx
+               	movq	-0x920(%rbp), %rdi
+               	movq	-0x928(%rbp), %rsi
+               	movq	-0x930(%rbp), %r12
+               	movq	-0x938(%rbp), %r13
+               	movq	-0x940(%rbp), %r14
+               	movq	-0x948(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-windows/vec/vec_cmp_i64.dis
@@ -5,29 +5,67 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movq	(%rdx), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,29 +73,67 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movq	(%rdx), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -65,184 +141,184 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4b0, %rsp            # imm = 0x4B0
-               	movq	%rbx, -0x428(%rbp)
-               	movq	%rdi, -0x430(%rbp)
-               	movq	%rsi, -0x438(%rbp)
-               	movq	%r12, -0x440(%rbp)
-               	movq	%r13, -0x448(%rbp)
-               	movq	%r14, -0x450(%rbp)
-               	movaps	%xmm6, -0x460(%rbp)
-               	movaps	%xmm7, -0x470(%rbp)
-               	movaps	%xmm14, -0x480(%rbp)
-               	movaps	%xmm15, -0x490(%rbp)
+               	subq	$0x4f0, %rsp            # imm = 0x4F0
+               	movq	%rbx, -0x448(%rbp)
+               	movq	%rdi, -0x450(%rbp)
+               	movq	%rsi, -0x458(%rbp)
+               	movq	%r12, -0x460(%rbp)
+               	movq	%r13, -0x468(%rbp)
+               	movq	%r14, -0x470(%rbp)
+               	movq	%r15, -0x478(%rbp)
+               	movaps	%xmm6, -0x490(%rbp)
+               	movaps	%xmm7, -0x4a0(%rbp)
+               	movaps	%xmm8, -0x4b0(%rbp)
+               	movaps	%xmm14, -0x4c0(%rbp)
+               	movaps	%xmm15, -0x4d0(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
+               	leaq	-0x300(%rbp), %rsi
+               	leaq	(%rsi), %rax
+               	addq	$0x0, %rax
+               	movq	$0x60, %rdx
 <L0>:
-               	leaq	-0x60(%rbp), %rsi
-               	leaq	(%rsi), %rcx
-               	addq	$0x0, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L0>
+               	leaq	-0x360(%rbp), %rdi
+               	leaq	(%rdi), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L1>
-               	leaq	-0xc0(%rbp), %rdi
-               	leaq	(%rdi), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L2>
-               	leaq	-0xd0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	-0x370(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x100000001, %r11      # imm = 0x100000001
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x380(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x100000001, %r11      # imm = 0x100000001
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xf0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x390(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3a0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x110(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3b0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x120(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3c0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x130(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3d0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x140(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3e0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
                	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x150(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x3f0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x200000000, %r11      # imm = 0x200000000
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x400(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
                	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x170(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x410(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$0x10a, (%rdx)          # imm = 0x10A
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x180(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x420(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$0xa, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%rdi), %rcx
-               	movups	%xmm0, (%rcx)
-               	movq	%rax, %r12
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r12 # imm = 0xCBF29CE484222325
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L3>
-               	jmp	 <L18>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L13>
+<L2>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rsi,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rsi,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x10(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rdi,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
+               	movq	%r13, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%rdi,%rdx), %r14
+               	movups	(%r14), %xmm1
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %r14
+               	movq	(%r14), %rax
                	addq	%rbx, %rax
-               	leaq	-0x1b0(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r14
-               	movq	%rax, (%r14)
-               	movups	(%rdx), %xmm6
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x1c0(%rbp), %rax
+               	leaq	-0x30(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %r15
+               	movq	%rax, (%r15)
+               	movups	(%r14), %xmm6
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x40(%rbp), %rax
                	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
                	movups	(%rax), %xmm7
                	movaps	%xmm7, %xmm15
                	pxor	%xmm6, %xmm15
@@ -260,337 +336,320 @@ Disassembly of section .text:
                	pcmpgtd	%xmm6, %xmm14
                	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
                	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movq	(%rax), %rdx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x50(%rbp)
+               	leaq	-0x50(%rbp), %rdx
                	movq	%r12, %rcx
+               	callq	 <L3>
+<L3>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm6, %xmm14
+               	pcmpgtd	%xmm7, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm6, %xmm14
+               	pcmpgtd	%xmm7, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x70(%rbp)
+               	leaq	-0x70(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	movaps	%xmm6, %xmm15
-               	pxor	%xmm7, %xmm15
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
                	pxor	%xmm14, %xmm14
                	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpgtd	%xmm7, %xmm15
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpeqd	%xmm7, %xmm15
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
                	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
                	pand	%xmm14, %xmm15
                	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	%xmm6, %xmm14
-               	pcmpgtd	%xmm7, %xmm14
+               	movaps	%xmm7, %xmm14
+               	pcmpgtd	%xmm6, %xmm14
                	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
                	por	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x370(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
+               	movups	%xmm0, -0x80(%rbp)
+               	leaq	-0x80(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x90(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	movaps	%xmm6, %xmm15
-               	pxor	%xmm7, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpgtd	%xmm7, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpeqd	%xmm7, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
                	movaps	%xmm6, %xmm14
-               	pcmpgtd	%xmm7, %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x390(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
+               	movups	%xmm0, -0xa0(%rbp)
+               	leaq	-0xa0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L8>
 <L8>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	movaps	%xmm7, %xmm15
-               	pxor	%xmm6, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpgtd	%xmm6, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpeqd	%xmm6, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	%xmm7, %xmm14
-               	pcmpgtd	%xmm6, %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	movaps	%xmm6, %xmm14
-               	pcmpeqd	%xmm7, %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	movaps	%xmm6, %xmm14
-               	pcmpeqd	%xmm7, %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	movaps	%xmm7, %xmm15
-               	pxor	%xmm6, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpgtd	%xmm6, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpeqd	%xmm6, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	%xmm7, %xmm14
-               	pcmpgtd	%xmm6, %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm1, %xmm14
-               	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x410(%rbp), %r14
-               	movups	%xmm1, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
+               	movaps	%xmm1, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm0, %xmm14
+               	por	%xmm1, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0xb0(%rbp), %r8
+               	movq	%r8, -0x430(%rbp)
+               	movq	-0x430(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x430(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x428(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x428(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rdx
+               	xorq	%r15, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %r14
+               	jb	 <L9>
+<L10>:
+               	movq	-0x430(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x438(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x438(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %r14
+               	xorq	%r15, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x6, %r13
-               	jb	 <L3>
-<L18>:
-               	leaq	-0x220(%rbp), %rsi
+               	jb	 <L2>
+<L13>:
+               	leaq	-0x100(%rbp), %rsi
                	leaq	(%rsi), %rax
                	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L19>:
+               	movq	$0x50, %rdx
+<L14>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L19>
-               	leaq	-0x270(%rbp), %rdi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L14>
+               	leaq	-0x150(%rbp), %rdi
                	leaq	(%rdi), %rax
                	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L20>:
+               	movq	$0x50, %rdx
+<L15>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L20>
-               	leaq	-0x280(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L15>
+               	leaq	-0x160(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	(%rsi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x290(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	-0x170(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	(%rdi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2a0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	-0x180(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%rsi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2b0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%rdi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2c0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x1a0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%rsi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2d0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x1b0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%rdi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2e0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	-0x1c0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%rsi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2f0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	-0x1d0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%rdi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x300(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x10a, (%rcx)          # imm = 0x10A
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x1e0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x10a, (%rdx)          # imm = 0x10A
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%rsi), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x310(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0xa, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x1f0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%rdi), %rax
                	movups	%xmm0, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x5, %r13
-               	jb	 <L21>
-               	jmp	 <L36>
-<L21>:
+               	jb	 <L16>
+               	jmp	 <L24>
+<L16>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rsi,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rax
+               	leaq	(%rsi,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rdi,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
+               	movq	%r13, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%rdi,%rdx), %r14
+               	movups	(%r14), %xmm1
+               	leaq	-0x210(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %r14
+               	movq	(%r14), %rax
                	addq	%rbx, %rax
-               	leaq	-0x340(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r14
-               	movq	%rax, (%r14)
-               	movups	(%rdx), %xmm6
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x350(%rbp), %rax
+               	leaq	-0x220(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %r15
+               	movq	%rax, (%r15)
+               	movups	(%r14), %xmm6
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
+               	leaq	0x8(%rax), %r14
+               	movq	%rdx, (%r14)
                	movups	(%rax), %xmm7
                	movaps	%xmm7, %xmm15
                	pxor	%xmm6, %xmm15
@@ -606,196 +665,134 @@ Disassembly of section .text:
                	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
                	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
                	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x360(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movq	(%rax), %rdx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
                	movq	%r12, %rcx
+               	callq	 <L17>
+<L17>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L18>
+<L18>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x270(%rbp)
+               	leaq	-0x270(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L20>
+<L20>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L21>
+<L21>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L22>
 <L22>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm8, %xmm14
+               	pand	%xmm6, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm8, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm1, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm0, %xmm14
+               	por	%xmm1, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movaps	%xmm6, %xmm15
-               	pxor	%xmm7, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpgtd	%xmm7, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpeqd	%xmm7, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x380(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movaps	%xmm6, %xmm15
-               	pxor	%xmm7, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpgtd	%xmm7, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm6, %xmm15
-               	pcmpeqd	%xmm7, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3a0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	movaps	%xmm7, %xmm15
-               	pxor	%xmm6, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpgtd	%xmm6, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpeqd	%xmm6, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3c0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	movaps	%xmm6, %xmm14
-               	pcmpeqd	%xmm7, %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3e0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	movaps	%xmm6, %xmm14
-               	pcmpeqd	%xmm7, %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x400(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	movaps	%xmm7, %xmm15
-               	pxor	%xmm6, %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpgtd	%xmm6, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm7, %xmm15
-               	pcmpeqd	%xmm6, %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm1, %xmm14
-               	por	%xmm2, %xmm14
-               	movaps	%xmm14, %xmm1
-               	leaq	-0x420(%rbp), %r14
-               	movups	%xmm1, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x5, %r13
-               	jb	 <L21>
-<L36>:
+               	jb	 <L16>
+<L24>:
                	movq	%r12, %rax
-               	movaps	-0x460(%rbp), %xmm6
-               	movaps	-0x470(%rbp), %xmm7
-               	movaps	-0x480(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
-               	movq	-0x428(%rbp), %rbx
-               	movq	-0x430(%rbp), %rdi
-               	movq	-0x438(%rbp), %rsi
-               	movq	-0x440(%rbp), %r12
-               	movq	-0x448(%rbp), %r13
-               	movq	-0x450(%rbp), %r14
+               	movaps	-0x490(%rbp), %xmm6
+               	movaps	-0x4a0(%rbp), %xmm7
+               	movaps	-0x4b0(%rbp), %xmm8
+               	movaps	-0x4c0(%rbp), %xmm14
+               	movaps	-0x4d0(%rbp), %xmm15
+               	movq	-0x448(%rbp), %rbx
+               	movq	-0x450(%rbp), %rdi
+               	movq	-0x458(%rbp), %rsi
+               	movq	-0x460(%rbp), %r12
+               	movq	-0x468(%rbp), %r13
+               	movq	-0x470(%rbp), %r14
+               	movq	-0x478(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-windows/vec/vec_cmp_select.dis
@@ -5,113 +5,391 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_u8x16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x1(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x3(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
+               	leaq	0x2(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0x5(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	leaq	0x3(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0x7(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L8>
+               	leaq	0x4(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	leaq	0x9(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L10>
+               	leaq	0x5(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	leaq	0xb(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L12>
+               	leaq	0x6(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	0xd(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
+               	leaq	0x7(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	leaq	0xf(%rbx), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rdx), %rbx
+               	movzbl	(%rbx), %edx
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -127,50 +405,58 @@ Disassembly of section .text:
                	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
+               	leaq	(%rbx), %rax
+               	movzwl	(%rax), %edx
+               	movzwq	%dx, %rax
+               	movq	%rax, %rdx
                	callq	 <L0>
 <L0>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L1>
 <L1>:
+               	leaq	0x4(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L2>
 <L2>:
+               	leaq	0x6(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L3>
 <L3>:
+               	leaq	0x8(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L4>
 <L4>:
+               	leaq	0xa(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L5>
 <L5>:
+               	leaq	0xc(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
                	callq	 <L6>
 <L6>:
+               	leaq	0xe(%rbx), %rcx
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rbx
                	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
                	movq	%rbx, %rdx
                	callq	 <L7>
 <L7>:
@@ -193,27 +479,31 @@ Disassembly of section .text:
                	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	%rax, %rdx
                	callq	 <L0>
 <L0>:
+               	leaq	0x4(%rbx), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
+               	movq	%rsi, %rdx
                	callq	 <L1>
 <L1>:
+               	leaq	0x8(%rbx), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
+               	movq	%rsi, %rdx
                	callq	 <L2>
 <L2>:
+               	leaq	0xc(%rbx), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %ebx
                	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
+               	movq	%rbx, %rdx
                	callq	 <L3>
 <L3>:
                	movaps	-0x30(%rbp), %xmm14
@@ -264,27 +554,31 @@ Disassembly of section .text:
                	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
                	callq	 <L0>
 <L0>:
+               	leaq	0x4(%rbx), %rcx
+               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	leaq	0x8(%rbx), %rcx
+               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L2>
 <L2>:
+               	leaq	0xc(%rbx), %rcx
+               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
                	movaps	-0x30(%rbp), %xmm14
@@ -297,78 +591,76 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x510, %rsp            # imm = 0x510
-               	movq	%rbx, -0x468(%rbp)
-               	movq	%rdi, -0x470(%rbp)
-               	movq	%rsi, -0x478(%rbp)
-               	movq	%r12, -0x480(%rbp)
-               	movq	%r13, -0x488(%rbp)
-               	movq	%r14, -0x490(%rbp)
-               	movaps	%xmm6, -0x4a0(%rbp)
-               	movaps	%xmm7, -0x4b0(%rbp)
-               	movaps	%xmm8, -0x4c0(%rbp)
-               	movaps	%xmm9, -0x4d0(%rbp)
-               	movaps	%xmm14, -0x4e0(%rbp)
-               	movaps	%xmm15, -0x4f0(%rbp)
+               	subq	$0x520, %rsp            # imm = 0x520
+               	movq	%rbx, -0x478(%rbp)
+               	movq	%rdi, -0x480(%rbp)
+               	movq	%rsi, -0x488(%rbp)
+               	movq	%r12, -0x490(%rbp)
+               	movq	%r13, -0x498(%rbp)
+               	movq	%r14, -0x4a0(%rbp)
+               	movaps	%xmm6, -0x4b0(%rbp)
+               	movaps	%xmm7, -0x4c0(%rbp)
+               	movaps	%xmm8, -0x4d0(%rbp)
+               	movaps	%xmm9, -0x4e0(%rbp)
+               	movaps	%xmm14, -0x4f0(%rbp)
+               	movaps	%xmm15, -0x500(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
                	movl	%ebx, %esi
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm6
                	addss	%xmm6, %xmm6
-<L2>:
+<L1>:
                	movw	%bx, %di
                	movb	%bl, %r12b
-               	leaq	-0x10(%rbp), %rcx
+               	leaq	-0x10(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movl	$0xa, (%rcx)
+               	leaq	0x4(%rax), %rcx
+               	movl	$0x14, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movl	$0x1e, (%rcx)
+               	leaq	0xc(%rax), %rcx
+               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
+               	movups	(%rax), %xmm0
+               	leaq	-0x20(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x30(%rbp), %rcx
                	leaq	(%rcx), %rdx
-               	movl	$0xa, (%rdx)
+               	movl	$0x14, (%rdx)
                	leaq	0x4(%rcx), %rdx
                	movl	$0x14, (%rdx)
                	leaq	0x8(%rcx), %rdx
-               	movl	$0x1e, (%rdx)
+               	movl	$0xa, (%rdx)
                	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
-               	leaq	(%rdx), %r13
-               	movl	$0x14, (%r13)
-               	leaq	0x4(%rdx), %r13
-               	movl	$0x14, (%r13)
-               	leaq	0x8(%rdx), %r13
-               	movl	$0xa, (%r13)
-               	leaq	0xc(%rdx), %r13
-               	movl	$0x1, (%r13)
-               	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	(%rcx), %r13
-               	movl	(%r13), %ecx
-               	addl	%esi, %ecx
-               	leaq	-0x50(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %r14
-               	movl	%ecx, (%r14)
-               	movups	(%r13), %xmm7
-               	leaq	0xc(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	addl	%esi, %edx
-               	leaq	-0x60(%rbp), %rcx
+               	movl	$0x1, (%rdx)
+               	movups	(%rcx), %xmm1
+               	leaq	-0x40(%rbp), %rcx
                	movups	%xmm1, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm8
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	addl	%esi, %eax
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %r13
+               	movl	%eax, (%r13)
+               	movups	(%rdx), %xmm7
+               	leaq	0xc(%rcx), %rax
+               	movl	(%rax), %ecx
+               	addl	%esi, %ecx
+               	leaq	-0x60(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0xc(%rax), %rdx
+               	movl	%ecx, (%rdx)
+               	movups	(%rax), %xmm8
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
                	movaps	%xmm7, %xmm14
@@ -378,26 +670,33 @@ Disassembly of section .text:
                	movaps	%xmm15, %xmm0
                	leaq	-0x70(%rbp), %r13
                	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L3>
-<L3>:
+               	leaq	(%r13), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L4>
-<L4>:
+               	movq	%r14, %rdx
+               	callq	 <L3>
+<L3>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
+               	movq	%r14, %rdx
+               	callq	 <L4>
+<L4>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
+               	movq	%r13, %rdx
+               	callq	 <L5>
+<L5>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
                	movaps	%xmm8, %xmm14
@@ -409,24 +708,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
+               	movq	%r14, %rdx
+               	callq	 <L6>
+<L6>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
+               	movq	%r14, %rdx
+               	callq	 <L7>
+<L7>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
+               	movq	%r14, %rdx
+               	callq	 <L8>
+<L8>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
+               	movq	%r13, %rdx
+               	callq	 <L9>
+<L9>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
@@ -434,24 +741,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
+               	movq	%r14, %rdx
+               	callq	 <L10>
+<L10>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
+               	movq	%r14, %rdx
+               	callq	 <L11>
+<L11>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
+               	movq	%r14, %rdx
+               	callq	 <L12>
+<L12>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
+               	movq	%r13, %rdx
+               	callq	 <L13>
+<L13>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
@@ -461,24 +776,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
+               	movq	%r14, %rdx
+               	callq	 <L14>
+<L14>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
+               	movq	%r14, %rdx
+               	callq	 <L15>
+<L15>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
+               	movq	%r14, %rdx
+               	callq	 <L16>
+<L16>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
+               	movq	%r13, %rdx
+               	callq	 <L17>
+<L17>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
                	movaps	%xmm7, %xmm14
@@ -492,24 +815,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
+               	movq	%r14, %rdx
+               	callq	 <L18>
+<L18>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
+               	movq	%r14, %rdx
+               	callq	 <L19>
+<L19>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
+               	movq	%r14, %rdx
+               	callq	 <L20>
+<L20>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
+               	movq	%r13, %rdx
+               	callq	 <L21>
+<L21>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
                	movaps	%xmm8, %xmm14
@@ -523,24 +854,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
+               	movq	%r14, %rdx
+               	callq	 <L22>
+<L22>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
+               	movq	%r14, %rdx
+               	callq	 <L23>
+<L23>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
+               	movq	%r14, %rdx
+               	callq	 <L24>
+<L24>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
+               	movq	%r13, %rdx
+               	callq	 <L25>
+<L25>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
                	movaps	%xmm7, %xmm14
@@ -565,24 +904,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	movq	%r14, %rdx
+               	callq	 <L26>
+<L26>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	movq	%r14, %rdx
+               	callq	 <L27>
+<L27>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
+               	movq	%r14, %rdx
+               	callq	 <L28>
+<L28>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
+               	movq	%r13, %rdx
+               	callq	 <L29>
+<L29>:
                	movaps	%xmm9, %xmm14
                	pand	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
@@ -600,24 +947,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
+               	movq	%r14, %rdx
+               	callq	 <L30>
+<L30>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
+               	movq	%r14, %rdx
+               	callq	 <L31>
+<L31>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
+               	movq	%r14, %rdx
+               	callq	 <L32>
+<L32>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
+               	movq	%r13, %rdx
+               	callq	 <L33>
+<L33>:
                	movaps	%xmm7, %xmm14
                	paddd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
@@ -628,24 +983,32 @@ Disassembly of section .text:
                	movups	%xmm1, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
+               	movq	%r14, %rdx
+               	callq	 <L34>
+<L34>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
+               	movq	%r14, %rdx
+               	callq	 <L35>
+<L35>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
+               	movq	%r14, %rdx
+               	callq	 <L36>
+<L36>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
+               	movq	%r13, %rdx
+               	callq	 <L37>
+<L37>:
                	movaps	%xmm9, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -660,24 +1023,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
+               	movq	%r14, %rdx
+               	callq	 <L38>
+<L38>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
+               	movq	%r14, %rdx
+               	callq	 <L39>
+<L39>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r14d
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	movq	%r14, %rdx
+               	callq	 <L40>
+<L40>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
+               	movq	%r13, %rdx
+               	callq	 <L41>
+<L41>:
                	leaq	-0x110(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
@@ -725,24 +1096,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	movq	%r13, %rdx
+               	callq	 <L42>
+<L42>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
+               	movq	%r13, %rdx
+               	callq	 <L43>
+<L43>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
+               	movq	%r13, %rdx
+               	callq	 <L44>
+<L44>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	movq	%rsi, %rdx
+               	callq	 <L45>
+<L45>:
                	movaps	%xmm7, %xmm14
                	pcmpgtd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
@@ -750,24 +1129,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	movq	%r13, %rdx
+               	callq	 <L46>
+<L46>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movq	%r13, %rdx
+               	callq	 <L47>
+<L47>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
+               	movq	%r13, %rdx
+               	callq	 <L48>
+<L48>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
+               	movq	%rsi, %rdx
+               	callq	 <L49>
+<L49>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
@@ -775,24 +1162,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
+               	movq	%r13, %rdx
+               	callq	 <L50>
+<L50>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	movq	%r13, %rdx
+               	callq	 <L51>
+<L51>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
+               	movq	%r13, %rdx
+               	callq	 <L52>
+<L52>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
+               	movq	%rsi, %rdx
+               	callq	 <L53>
+<L53>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
@@ -802,24 +1197,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
+               	movq	%r13, %rdx
+               	callq	 <L54>
+<L54>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	movq	%r13, %rdx
+               	callq	 <L55>
+<L55>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
+               	movq	%r13, %rdx
+               	callq	 <L56>
+<L56>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
+               	movq	%rsi, %rdx
+               	callq	 <L57>
+<L57>:
                	movaps	%xmm7, %xmm14
                	pcmpgtd	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
@@ -829,24 +1232,32 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
+               	movq	%r13, %rdx
+               	callq	 <L58>
+<L58>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movq	%r13, %rdx
+               	callq	 <L59>
+<L59>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
+               	movq	%r13, %rdx
+               	callq	 <L60>
+<L60>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
+               	movq	%rsi, %rdx
+               	callq	 <L61>
+<L61>:
                	movaps	%xmm8, %xmm14
                	pcmpgtd	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
@@ -856,35 +1267,43 @@ Disassembly of section .text:
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
+               	movq	%r13, %rdx
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
+               	movq	%r13, %rdx
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
+               	movq	%r13, %rdx
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%rsi), %rcx
                	movl	(%rcx), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
+               	movq	%rsi, %rdx
+               	callq	 <L65>
+<L65>:
                	leaq	-0x1d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
                	xorps	%xmm0, %xmm0
-               	xorps	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x84d>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x9b5>
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40400000, (%rdx)     # imm = 0x40400000
-               	movss	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x867>
-               	xorps	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x86e>
+               	movss	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x9cf>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_cmp_select.checksum+0x9d6>
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
@@ -897,124 +1316,84 @@ Disassembly of section .text:
                	movl	$0x0, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movl	$0x40400000, (%rsi)     # imm = 0x40400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x8af>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x8b6>
+               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0xa17>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0xa1e>
                	leaq	0xc(%rdx), %rsi
                	movss	%xmm1, (%rsi)
                	movups	(%rdx), %xmm7
-               	leaq	-0x200(%rbp), %rsi
-               	movups	%xmm7, (%rsi)
                	leaq	(%rcx), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	addss	%xmm6, %xmm2
-               	leaq	-0x210(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	%xmm2, (%rcx)
-               	movups	(%r13), %xmm6
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x200(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movss	%xmm2, (%rdx)
+               	movups	(%rcx), %xmm6
+               	movups	%xmm6, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L66>
+<L66>:
+               	movups	%xmm7, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L67>
 <L67>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L72>
-<L72>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L74>
-<L74>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpltps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm8
-               	movups	%xmm8, -0x220(%rbp)
-               	leaq	-0x220(%rbp), %rdx
+               	movups	%xmm8, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
+               	callq	 <L68>
+<L68>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
                	cmpltps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x230(%rbp)
-               	leaq	-0x230(%rbp), %rdx
+               	movups	%xmm0, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L69>
+<L69>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x240(%rbp)
-               	leaq	-0x240(%rbp), %rdx
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L70>
+<L70>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x250(%rbp)
-               	leaq	-0x250(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
-               	movaps	%xmm6, %xmm14
-               	movaps	%xmm7, %xmm15
-               	cmpleps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x260(%rbp)
                	leaq	-0x260(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	movaps	%xmm7, %xmm14
-               	movaps	%xmm6, %xmm15
+               	callq	 <L71>
+<L71>:
+               	movaps	%xmm6, %xmm14
+               	movaps	%xmm7, %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x270(%rbp)
                	leaq	-0x270(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L72>
+<L72>:
+               	movaps	%xmm7, %xmm14
+               	movaps	%xmm6, %xmm15
+               	cmpleps	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L73>
+<L73>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
@@ -1028,8 +1407,6 @@ Disassembly of section .text:
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm9
-               	leaq	-0x280(%rbp), %rsi
-               	movups	%xmm9, (%rsi)
                	movaps	%xmm8, %xmm14
                	pand	%xmm7, %xmm14
                	movaps	%xmm14, %xmm8
@@ -1039,86 +1416,25 @@ Disassembly of section .text:
                	movaps	%xmm8, %xmm14
                	por	%xmm1, %xmm14
                	movaps	%xmm14, %xmm8
-               	leaq	-0x290(%rbp), %r13
-               	movups	%xmm8, (%r13)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm9, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
+               	callq	 <L74>
+<L74>:
+               	movups	%xmm8, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L82>
-<L82>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L84>
-<L84>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L85>
-<L85>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L86>
-<L86>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L87>
-<L87>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L88>
-<L88>:
+               	callq	 <L75>
+<L75>:
                	movaps	%xmm8, %xmm14
                	subps	%xmm9, %xmm14
                	movaps	%xmm14, %xmm8
-               	leaq	-0x2a0(%rbp), %rsi
-               	movups	%xmm8, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm8, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L89>
-<L89>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L90>
-<L90>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L91>
-<L91>:
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L92>
-<L92>:
-               	leaq	-0x2b0(%rbp), %rcx
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x2c0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1126,9 +1442,9 @@ Disassembly of section .text:
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
+               	leaq	-0x2d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x2d0(%rbp), %rdx
+               	leaq	-0x2e0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0x4004000000000000, %r11 # imm = 0x4004000000000000
                	movq	%r11, (%rsi)
@@ -1139,20 +1455,20 @@ Disassembly of section .text:
                	movsd	(%rdx), %xmm1
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L93>
+               	jl	 <L77>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L78>
+<L77>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L94>:
+<L78>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
                	addsd	%xmm2, %xmm3
-               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	-0x2f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	%xmm3, (%rdx)
@@ -1161,67 +1477,67 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm15
                	cmpltpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
-               	movaps	%xmm7, %xmm14
-               	movaps	%xmm6, %xmm15
-               	cmpeqpd	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
                	leaq	-0x300(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
+               	callq	 <L79>
+<L79>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
+               	callq	 <L80>
+<L80>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
-               	cmpneqpd	%xmm15, %xmm14
+               	cmpeqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	-0x310(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	movaps	%xmm6, %xmm14
-               	movaps	%xmm7, %xmm15
-               	cmplepd	%xmm15, %xmm14
+               	callq	 <L82>
+<L82>:
+               	movaps	%xmm7, %xmm14
+               	movaps	%xmm6, %xmm15
+               	cmpneqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	-0x320(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
+               	callq	 <L83>
+<L83>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
-               	leaq	-0x330(%rbp), %rcx
+               	callq	 <L84>
+<L84>:
+               	movaps	%xmm6, %xmm14
+               	movaps	%xmm7, %xmm15
+               	cmplepd	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x330(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L85>
+<L85>:
+               	leaq	0x8(%rbx), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L86>
+<L86>:
+               	leaq	-0x340(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
                	leaq	0x2(%rcx), %rdx
@@ -1239,9 +1555,9 @@ Disassembly of section .text:
                	leaq	0xe(%rcx), %rdx
                	movw	$0xfffe, (%rdx)         # imm = 0xFFFE
                	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
+               	leaq	-0x350(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x350(%rbp), %rdx
+               	leaq	-0x360(%rbp), %rdx
                	leaq	(%rdx), %rbx
                	movw	$0x2, (%rbx)
                	leaq	0x2(%rdx), %rbx
@@ -1259,12 +1575,12 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rbx
                	movw	$0xffff, (%rbx)         # imm = 0xFFFF
                	movups	(%rdx), %xmm1
-               	leaq	-0x360(%rbp), %rdx
+               	leaq	-0x370(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rbx
                	movzwl	(%rbx), %ecx
                	addl	%edi, %ecx
-               	leaq	-0x370(%rbp), %rbx
+               	leaq	-0x380(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rsi
                	movw	%cx, (%rsi)
@@ -1272,7 +1588,7 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rcx
                	movzwl	(%rcx), %edx
                	addl	%edi, %edx
-               	leaq	-0x380(%rbp), %rcx
+               	leaq	-0x390(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xe(%rcx), %rbx
                	movw	%dx, (%rbx)
@@ -1283,94 +1599,20 @@ Disassembly of section .text:
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x390(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x3a0(%rbp)
+               	leaq	-0x3a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L104>
-<L104>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L105>
-<L105>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L106>
-<L106>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L107>
-<L107>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L108>
-<L108>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L109>
-<L109>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L110>
-<L110>:
+               	callq	 <L87>
+<L87>:
                	movaps	%xmm6, %xmm14
                	pcmpeqw	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x3b0(%rbp)
+               	leaq	-0x3b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L111>
-<L111>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L112>
-<L112>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
+               	callq	 <L88>
+<L88>:
                	movaps	%xmm6, %xmm14
                	psubusw	%xmm7, %xmm14
                	pxor	%xmm15, %xmm15
@@ -1378,111 +1620,30 @@ Disassembly of section .text:
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L121>
-<L121>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L122>
-<L122>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L123>
-<L123>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
-               	movaps	%xmm7, %xmm14
-               	psubusw	%xmm6, %xmm14
-               	pxor	%xmm15, %xmm15
-               	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	callq	 <L89>
+<L89>:
+               	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm1, %xmm14
-               	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x3c0(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm1, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm0, %xmm14
+               	por	%xmm1, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x3d0(%rbp)
+               	leaq	-0x3d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L131>
-<L131>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L132>
-<L132>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
-               	leaq	-0x3d0(%rbp), %rcx
+               	callq	 <L90>
+<L90>:
+               	leaq	-0x3e0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1516,9 +1677,9 @@ Disassembly of section .text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x1d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
+               	leaq	-0x3f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x3f0(%rbp), %rdx
+               	leaq	-0x400(%rbp), %rdx
                	leaq	(%rdx), %rbx
                	movb	$0x2, (%rbx)
                	leaq	0x1(%rdx), %rbx
@@ -1552,12 +1713,12 @@ Disassembly of section .text:
                	leaq	0xf(%rdx), %rbx
                	movb	$0x1e, (%rbx)
                	movups	(%rdx), %xmm1
-               	leaq	-0x400(%rbp), %rdx
+               	leaq	-0x410(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rbx
                	movzbl	(%rbx), %ecx
                	addl	%r12d, %ecx
-               	leaq	-0x410(%rbp), %rbx
+               	leaq	-0x420(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rsi
                	movb	%cl, (%rsi)
@@ -1565,7 +1726,7 @@ Disassembly of section .text:
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
                	addl	%r12d, %edx
-               	leaq	-0x420(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xf(%rcx), %rbx
                	movb	%dl, (%rbx)
@@ -1577,29 +1738,29 @@ Disassembly of section .text:
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm8
-               	movups	%xmm8, -0x430(%rbp)
-               	leaq	-0x430(%rbp), %rdx
+               	movups	%xmm8, -0x440(%rbp)
+               	leaq	-0x440(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
+               	callq	 <L91>
+<L91>:
                	movaps	%xmm6, %xmm14
                	pcmpeqb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x440(%rbp)
-               	leaq	-0x440(%rbp), %rdx
+               	movups	%xmm0, -0x450(%rbp)
+               	leaq	-0x450(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
+               	callq	 <L92>
+<L92>:
                	movaps	%xmm7, %xmm14
                	psubusb	%xmm6, %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x450(%rbp)
-               	leaq	-0x450(%rbp), %rdx
+               	movups	%xmm0, -0x460(%rbp)
+               	leaq	-0x460(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L137>
-<L137>:
+               	callq	 <L93>
+<L93>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
@@ -1613,23 +1774,23 @@ Disassembly of section .text:
                	movaps	%xmm0, %xmm14
                	por	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x460(%rbp)
-               	leaq	-0x460(%rbp), %rdx
+               	movups	%xmm0, -0x470(%rbp)
+               	leaq	-0x470(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L138>
-<L138>:
-               	movaps	-0x4a0(%rbp), %xmm6
-               	movaps	-0x4b0(%rbp), %xmm7
-               	movaps	-0x4c0(%rbp), %xmm8
-               	movaps	-0x4d0(%rbp), %xmm9
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4f0(%rbp), %xmm15
-               	movq	-0x468(%rbp), %rbx
-               	movq	-0x470(%rbp), %rdi
-               	movq	-0x478(%rbp), %rsi
-               	movq	-0x480(%rbp), %r12
-               	movq	-0x488(%rbp), %r13
-               	movq	-0x490(%rbp), %r14
+               	callq	 <L94>
+<L94>:
+               	movaps	-0x4b0(%rbp), %xmm6
+               	movaps	-0x4c0(%rbp), %xmm7
+               	movaps	-0x4d0(%rbp), %xmm8
+               	movaps	-0x4e0(%rbp), %xmm9
+               	movaps	-0x4f0(%rbp), %xmm14
+               	movaps	-0x500(%rbp), %xmm15
+               	movq	-0x478(%rbp), %rbx
+               	movq	-0x480(%rbp), %rdi
+               	movq	-0x488(%rbp), %rsi
+               	movq	-0x490(%rbp), %r12
+               	movq	-0x498(%rbp), %r13
+               	movq	-0x4a0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x2.dis
@@ -5,27 +5,71 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, %xmm0
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -33,56 +77,53 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1c0, %rsp            # imm = 0x1C0
-               	movq	%rbx, -0xf8(%rbp)
-               	movq	%rdi, -0x100(%rbp)
-               	movq	%rsi, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movaps	%xmm6, -0x130(%rbp)
-               	movaps	%xmm7, -0x140(%rbp)
-               	movaps	%xmm8, -0x150(%rbp)
-               	movaps	%xmm9, -0x160(%rbp)
-               	movaps	%xmm10, -0x170(%rbp)
-               	movaps	%xmm11, -0x180(%rbp)
-               	movaps	%xmm14, -0x190(%rbp)
-               	movaps	%xmm15, -0x1a0(%rbp)
+               	subq	$0x140, %rsp            # imm = 0x140
+               	movq	%rbx, -0x88(%rbp)
+               	movq	%rdi, -0x90(%rbp)
+               	movq	%rsi, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movaps	%xmm6, -0xc0(%rbp)
+               	movaps	%xmm7, -0xd0(%rbp)
+               	movaps	%xmm8, -0xe0(%rbp)
+               	movaps	%xmm9, -0xf0(%rbp)
+               	movaps	%xmm10, -0x100(%rbp)
+               	movaps	%xmm14, -0x110(%rbp)
+               	movaps	%xmm15, -0x120(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x8(%rbp), %rbx
+<L1>:
+               	leaq	-0x48(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0xb8>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0xbf>
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0xaf>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0xb6>
                	leaq	0x4(%rbx), %rsi
                	movss	%xmm1, (%rsi)
                	movsd	(%rbx), %xmm1
-               	leaq	-0x10(%rbp), %rbx
+               	leaq	-0x50(%rbp), %rbx
                	movsd	%xmm1, (%rbx)
-               	leaq	-0x18(%rbp), %rsi
+               	leaq	-0x58(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x3f000000, (%rdi)     # imm = 0x3F000000
                	leaq	0x4(%rsi), %rdi
                	movl	$0x40800000, (%rdi)     # imm = 0x40800000
                	movsd	(%rsi), %xmm2
-               	leaq	-0x20(%rbp), %rsi
+               	leaq	-0x60(%rbp), %rsi
                	movsd	%xmm2, (%rsi)
-               	leaq	-0x28(%rbp), %rdi
+               	leaq	-0x68(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x3f800000, (%r12)     # imm = 0x3F800000
                	leaq	0x4(%rdi), %r12
@@ -92,376 +133,263 @@ Disassembly of section .text:
                	movss	(%rdi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x30(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rbx
                	movsd	%xmm1, (%rbx)
                	leaq	(%rbx), %rdi
                	movss	%xmm4, (%rdi)
                	movsd	(%rbx), %xmm7
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rsi), %rbx
+               	movss	(%rbx), %xmm1
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
                	addss	%xmm0, %xmm3
-               	leaq	-0x38(%rbp), %rsi
-               	movsd	%xmm2, (%rsi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm3, (%rdi)
-               	movsd	(%rsi), %xmm8
-               	leaq	(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	-0x78(%rbp), %rbx
+               	movsd	%xmm2, (%rbx)
+               	leaq	0x4(%rbx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movsd	(%rbx), %xmm8
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%xmm7, %rdx
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rbx
+               	movq	%rbx, %rcx
+               	movq	%xmm8, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xa0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	subps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	subps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xc0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	divps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xc8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	divps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xd0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xd8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	subps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xe0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L11>
+<L11>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	divps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xe8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0xf0(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	leaq	0x4(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	movsd	(%rbx), %xmm0
-               	movq	%rcx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L12>
+<L12>:
+               	movq	%rax, %rbx
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	movsd	(%rsi), %xmm0
                	movaps	%xmm0, %xmm9
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
+               	jb	 <L13>
+               	jmp	 <L17>
+<L13>:
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	-0x40(%rbp), %rdi
-               	movsd	%xmm10, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	movq	%xmm10, %rdx
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rdi
                	movaps	%xmm9, %xmm14
                	addps	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x98(%rbp), %rdi
-               	movsd	%xmm11, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm9
+               	movq	%rdi, %rcx
+               	movq	%xmm9, %rdx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
                	movaps	%xmm7, %xmm14
                	subps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0xa8(%rbp), %rdi
-               	movsd	%xmm10, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm7
+               	movq	%rdi, %rcx
+               	movq	%xmm7, %rdx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rsi
-               	movq	%rcx, %rbx
-               	movaps	%xmm10, %xmm7
-               	movaps	%xmm11, %xmm9
                	cmpq	$0x6, %rsi
-               	jb	 <L25>
-<L32>:
-               	leaq	-0x70(%rbp), %rsi
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x30(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
                	movq	$0x0, 0x18(%rsi)
                	movq	$0x0, 0x20(%rsi)
                	movq	$0x0, 0x28(%rsi)
-               	leaq	(%rsi), %rcx
-               	movsd	%xmm7, (%rcx)
+               	leaq	(%rsi), %rdi
+               	movsd	%xmm7, (%rdi)
                	movaps	%xmm7, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x8(%rsi), %rcx
-               	movsd	%xmm0, (%rcx)
+               	leaq	0x8(%rsi), %rdi
+               	movsd	%xmm0, (%rdi)
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%rsi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x18(%rsi), %rcx
-               	movsd	%xmm9, (%rcx)
+               	leaq	0x10(%rsi), %rdi
+               	movsd	%xmm0, (%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movsd	%xmm9, (%rdi)
                	movaps	%xmm8, %xmm14
                	subps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%rsi), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x28(%rsi), %rcx
-               	movsd	%xmm8, (%rcx)
+               	leaq	0x20(%rsi), %rdi
+               	movsd	%xmm0, (%rdi)
+               	leaq	0x28(%rsi), %rdi
+               	movsd	%xmm8, (%rdi)
                	movq	$0x0, %rdi
                	cmpq	$0x6, %rdi
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	leaq	(%rsi,%rdi,8), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x78(%rbp), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	leaq	(%rsi,%rdi,8), %r12
+               	movsd	(%r12), %xmm0
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rdi
-               	movq	%rcx, %rbx
                	cmpq	$0x6, %rdi
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x88(%rbp), %rdi
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x40(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x10(%rsi), %r12
-               	movsd	(%r12), %xmm0
+               	leaq	(%rdi), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	leaq	0x10(%rsi), %r13
+               	movsd	(%r13), %xmm0
                	leaq	0x4(%rdi), %rsi
                	movsd	%xmm0, (%rsi)
-               	leaq	0xc(%rdi), %r12
-               	movl	$0x12345678, (%r12)     # imm = 0x12345678
-               	movl	(%rcx), %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rcx
+               	leaq	0xc(%rdi), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%r12), %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x4(%rdi), %rsi
                	movsd	(%rsi), %xmm0
-               	leaq	-0x90(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %rbx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	-0x130(%rbp), %xmm6
-               	movaps	-0x140(%rbp), %xmm7
-               	movaps	-0x150(%rbp), %xmm8
-               	movaps	-0x160(%rbp), %xmm9
-               	movaps	-0x170(%rbp), %xmm10
-               	movaps	-0x180(%rbp), %xmm11
-               	movaps	-0x190(%rbp), %xmm14
-               	movaps	-0x1a0(%rbp), %xmm15
-               	movq	-0xf8(%rbp), %rbx
-               	movq	-0x100(%rbp), %rdi
-               	movq	-0x108(%rbp), %rsi
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
+               	movq	%rbx, %rcx
+               	movq	%xmm0, %rdx
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rbx
+               	leaq	0xc(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movaps	-0xc0(%rbp), %xmm6
+               	movaps	-0xd0(%rbp), %xmm7
+               	movaps	-0xe0(%rbp), %xmm8
+               	movaps	-0xf0(%rbp), %xmm9
+               	movaps	-0x100(%rbp), %xmm10
+               	movaps	-0x110(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm15
+               	movq	-0x88(%rbp), %rbx
+               	movq	-0x90(%rbp), %rdi
+               	movq	-0x98(%rbp), %rsi
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x3.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x3.dis
@@ -5,10 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x3.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
+               	subq	$0x70, %rsp
                	movq	%rbx, -0x38(%rbp)
-               	movaps	%xmm14, -0x50(%rbp)
-               	movaps	%xmm15, -0x60(%rbp)
+               	movq	%rdi, -0x40(%rbp)
+               	movq	%rsi, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movaps	%xmm14, -0x60(%rbp)
+               	movaps	%xmm15, -0x70(%rbp)
+               	movq	%rcx, %rax
                	movq	$0x0, -0x10(%rbp)
                	movq	$0x0, -0x8(%rbp)
                	movq	(%rdx), %rbx
@@ -16,32 +20,90 @@ Disassembly of section .text:
                	movl	0x8(%rdx), %ebx
                	movl	%ebx, -0x8(%rbp)
                	movups	-0x10(%rbp), %xmm0
-               	leaq	-0x1c(%rbp), %rbx
+               	leaq	-0x1c(%rbp), %rdx
                	movups	%xmm0, -0x2c(%rbp)
-               	movq	-0x2c(%rbp), %rdx
-               	movq	%rdx, (%rbx)
-               	movl	-0x24(%rbp), %edx
-               	movl	%edx, 0x8(%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movq	-0x2c(%rbp), %rbx
+               	movq	%rbx, (%rdx)
+               	movl	-0x24(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movaps	-0x50(%rbp), %xmm14
-               	movaps	-0x60(%rbp), %xmm15
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movaps	-0x60(%rbp), %xmm14
+               	movaps	-0x70(%rbp), %xmm15
                	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %rdi
+               	movq	-0x48(%rbp), %rsi
+               	movq	-0x50(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -49,444 +111,367 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x3.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            # imm = 0x2E0
-               	movq	%rbx, -0x258(%rbp)
-               	movq	%rdi, -0x260(%rbp)
-               	movq	%rsi, -0x268(%rbp)
-               	movq	%r12, -0x270(%rbp)
-               	movq	%r13, -0x278(%rbp)
-               	movaps	%xmm6, -0x290(%rbp)
-               	movaps	%xmm7, -0x2a0(%rbp)
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	movaps	%xmm15, -0x2c0(%rbp)
+               	subq	$0x360, %rsp            # imm = 0x360
+               	movq	%rbx, -0x2b8(%rbp)
+               	movq	%rdi, -0x2c0(%rbp)
+               	movq	%rsi, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
+               	movaps	%xmm6, -0x2f0(%rbp)
+               	movaps	%xmm7, -0x300(%rbp)
+               	movaps	%xmm8, -0x310(%rbp)
+               	movaps	%xmm9, -0x320(%rbp)
+               	movaps	%xmm14, -0x330(%rbp)
+               	movaps	%xmm15, -0x340(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0xc(%rbp), %rbx
+<L1>:
+               	leaq	-0x70(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x98>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x9f>
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0xa7>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0xae>
                	leaq	0x4(%rbx), %rsi
                	movss	%xmm1, (%rsi)
                	leaq	0x8(%rbx), %rsi
                	movl	$0x40700000, (%rsi)     # imm = 0x40700000
-               	movq	$0x0, -0x1c(%rbp)
-               	movq	$0x0, -0x14(%rbp)
+               	movq	$0x0, -0x80(%rbp)
+               	movq	$0x0, -0x78(%rbp)
                	movq	(%rbx), %rsi
-               	movq	%rsi, -0x1c(%rbp)
+               	movq	%rsi, -0x80(%rbp)
                	movl	0x8(%rbx), %esi
-               	movl	%esi, -0x14(%rbp)
-               	movups	-0x1c(%rbp), %xmm1
-               	leaq	-0x28(%rbp), %rbx
-               	movups	%xmm1, -0x38(%rbp)
-               	movq	-0x38(%rbp), %rsi
+               	movl	%esi, -0x78(%rbp)
+               	movups	-0x80(%rbp), %xmm1
+               	leaq	-0x8c(%rbp), %rbx
+               	movups	%xmm1, -0x9c(%rbp)
+               	movq	-0x9c(%rbp), %rsi
                	movq	%rsi, (%rbx)
-               	movl	-0x30(%rbp), %esi
+               	movl	-0x94(%rbp), %esi
                	movl	%esi, 0x8(%rbx)
-               	leaq	-0x44(%rbp), %rsi
+               	leaq	-0xa8(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x3f000000, (%rdi)     # imm = 0x3F000000
                	leaq	0x4(%rsi), %rdi
                	movl	$0x40800000, (%rdi)     # imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0x106>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0x10d>
+               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0x124>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0x12b>
                	leaq	0x8(%rsi), %rdi
                	movss	%xmm2, (%rdi)
-               	movq	$0x0, -0x54(%rbp)
-               	movq	$0x0, -0x4c(%rbp)
+               	movq	$0x0, -0xb8(%rbp)
+               	movq	$0x0, -0xb0(%rbp)
                	movq	(%rsi), %rdi
-               	movq	%rdi, -0x54(%rbp)
+               	movq	%rdi, -0xb8(%rbp)
                	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x4c(%rbp)
-               	movups	-0x54(%rbp), %xmm2
-               	leaq	-0x60(%rbp), %rsi
-               	movups	%xmm2, -0x70(%rbp)
-               	movq	-0x70(%rbp), %rdi
+               	movl	%edi, -0xb0(%rbp)
+               	movups	-0xb8(%rbp), %xmm2
+               	leaq	-0xc4(%rbp), %rsi
+               	movups	%xmm2, -0xd4(%rbp)
+               	movq	-0xd4(%rbp), %rdi
                	movq	%rdi, (%rsi)
-               	movl	-0x68(%rbp), %edi
+               	movl	-0xcc(%rbp), %edi
                	movl	%edi, 0x8(%rsi)
                	leaq	(%rbx), %rdi
                	movss	(%rdi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x7c(%rbp), %rbx
-               	movups	%xmm1, -0x8c(%rbp)
-               	movq	-0x8c(%rbp), %rdi
+               	leaq	-0xe0(%rbp), %rbx
+               	movups	%xmm1, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %rdi
                	movq	%rdi, (%rbx)
-               	movl	-0x84(%rbp), %edi
+               	movl	-0xe8(%rbp), %edi
                	movl	%edi, 0x8(%rbx)
                	leaq	(%rbx), %rdi
                	movss	%xmm4, (%rdi)
-               	movq	$0x0, -0x9c(%rbp)
-               	movq	$0x0, -0x94(%rbp)
+               	movq	$0x0, -0x100(%rbp)
+               	movq	$0x0, -0xf8(%rbp)
                	movq	(%rbx), %rdi
-               	movq	%rdi, -0x9c(%rbp)
+               	movq	%rdi, -0x100(%rbp)
                	movl	0x8(%rbx), %edi
-               	movl	%edi, -0x94(%rbp)
-               	movups	-0x9c(%rbp), %xmm6
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm1
+               	movl	%edi, -0xf8(%rbp)
+               	movups	-0x100(%rbp), %xmm6
+               	leaq	0x8(%rsi), %rbx
+               	movss	(%rbx), %xmm1
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
                	addss	%xmm0, %xmm3
-               	leaq	-0xa8(%rbp), %rsi
-               	movups	%xmm2, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0xb0(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	$0x0, -0xc8(%rbp)
-               	movq	$0x0, -0xc0(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0xc8(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0xc0(%rbp)
-               	movups	-0xc8(%rbp), %xmm7
-               	leaq	(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	-0x10c(%rbp), %rbx
+               	movups	%xmm2, -0x11c(%rbp)
+               	movq	-0x11c(%rbp), %rsi
+               	movq	%rsi, (%rbx)
+               	movl	-0x114(%rbp), %esi
+               	movl	%esi, 0x8(%rbx)
+               	leaq	0x8(%rbx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movq	$0x0, -0x12c(%rbp)
+               	movq	$0x0, -0x124(%rbp)
+               	movq	(%rbx), %rsi
+               	movq	%rsi, -0x12c(%rbp)
+               	movl	0x8(%rbx), %esi
+               	movl	%esi, -0x124(%rbp)
+               	movups	-0x12c(%rbp), %xmm7
+               	movups	%xmm6, -0x150(%rbp)
+               	movq	-0x150(%rbp), %rbx
+               	movq	%rbx, -0x140(%rbp)
+               	movl	-0x148(%rbp), %ebx
+               	movl	%ebx, -0x138(%rbp)
+               	leaq	-0x140(%rbp), %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%rbx, %rdx
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rbx
+               	movups	%xmm7, -0x170(%rbp)
+               	movq	-0x170(%rbp), %rsi
+               	movq	%rsi, -0x160(%rbp)
+               	movl	-0x168(%rbp), %esi
+               	movl	%esi, -0x158(%rbp)
+               	leaq	-0x160(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	addps	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, -0x170(%rbp)
-               	movq	-0x170(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x168(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %rsi
+               	movq	%rsi, -0x180(%rbp)
+               	movl	-0x188(%rbp), %esi
+               	movl	%esi, -0x178(%rbp)
+               	leaq	-0x180(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	subps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x17c(%rbp), %rbx
-               	movups	%xmm0, -0x18c(%rbp)
-               	movq	-0x18c(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x184(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %rsi
+               	movq	%rsi, -0x1a0(%rbp)
+               	movl	-0x1a8(%rbp), %esi
+               	movl	%esi, -0x198(%rbp)
+               	leaq	-0x1a0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	subps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x198(%rbp), %rbx
-               	movups	%xmm0, -0x1a8(%rbp)
-               	movq	-0x1a8(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x1a0(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %rsi
+               	movq	%rsi, -0x1c0(%rbp)
+               	movl	-0x1c8(%rbp), %esi
+               	movl	%esi, -0x1b8(%rbp)
+               	leaq	-0x1c0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	mulps	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b4(%rbp), %rbx
-               	movups	%xmm0, -0x1c4(%rbp)
-               	movq	-0x1c4(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x1bc(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %rsi
+               	movq	%rsi, -0x1e0(%rbp)
+               	movl	-0x1e8(%rbp), %esi
+               	movl	%esi, -0x1d8(%rbp)
+               	leaq	-0x1e0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	divps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x1d8(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	-0x210(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
-               	movq	$0x0, 0x10(%rbx)
-               	movq	$0x0, 0x18(%rbx)
-               	movq	$0x0, 0x20(%rbx)
-               	movq	$0x0, 0x28(%rbx)
-               	leaq	(%rbx), %rsi
-               	movups	%xmm6, -0x220(%rbp)
-               	movq	-0x220(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x218(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	%xmm6, %xmm14
-               	addps	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0xc(%rbx), %rsi
-               	movups	%xmm0, -0x230(%rbp)
-               	movq	-0x230(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x228(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	%xmm6, %xmm14
-               	mulps	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm6
-               	leaq	0x18(%rbx), %rsi
-               	movups	%xmm6, -0x240(%rbp)
-               	movq	-0x240(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x238(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	leaq	0x24(%rbx), %rsi
-               	movups	%xmm7, -0x250(%rbp)
-               	movq	-0x250(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x248(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movq	%rcx, %rsi
+               	movups	%xmm0, -0x210(%rbp)
+               	movq	-0x210(%rbp), %rsi
+               	movq	%rsi, -0x200(%rbp)
+               	movl	-0x208(%rbp), %esi
+               	movl	%esi, -0x1f8(%rbp)
+               	leaq	-0x200(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rbx
+               	leaq	-0x240(%rbp), %rsi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	movq	$0x0, 0x10(%rsi)
+               	movq	$0x0, 0x18(%rsi)
+               	movq	$0x0, 0x20(%rsi)
+               	movq	$0x0, 0x28(%rsi)
+               	leaq	(%rsi), %rdi
+               	movups	%xmm6, -0x250(%rbp)
+               	movq	-0x250(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x248(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movups	%xmm8, -0x260(%rbp)
+               	movq	-0x260(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x258(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movups	%xmm9, -0x270(%rbp)
+               	movq	-0x270(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x268(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x24(%rsi), %rdi
+               	movups	%xmm7, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x278(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%rdi, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %r12
-               	movq	$0x0, -0xd8(%rbp)
-               	movq	$0x0, -0xd0(%rbp)
-               	movq	(%r12), %rcx
-               	movq	%rcx, -0xd8(%rbp)
-               	movl	0x8(%r12), %ecx
-               	movl	%ecx, -0xd0(%rbp)
-               	movups	-0xd8(%rbp), %xmm0
-               	leaq	-0xe4(%rbp), %r12
-               	movups	%xmm0, -0xf4(%rbp)
-               	movq	-0xf4(%rbp), %rcx
-               	movq	%rcx, (%r12)
-               	movl	-0xec(%rbp), %ecx
-               	movl	%ecx, 0x8(%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	jb	 <L9>
+               	jmp	 <L11>
+<L9>:
+               	movq	%rdi, %r12
+               	imulq	$0xc, %r12, %r12
+               	leaq	(%rsi,%r12), %r13
+               	movq	$0x0, -0x10(%rbp)
+               	movq	$0x0, -0x8(%rbp)
+               	movq	(%r13), %r12
+               	movq	%r12, -0x10(%rbp)
+               	movl	0x8(%r13), %r12d
+               	movl	%r12d, -0x8(%rbp)
+               	movups	-0x10(%rbp), %xmm0
+               	movups	%xmm0, -0x30(%rbp)
+               	movq	-0x30(%rbp), %r12
+               	movq	%r12, -0x20(%rbp)
+               	movl	-0x28(%rbp), %r12d
+               	movl	%r12d, -0x18(%rbp)
+               	leaq	-0x20(%rbp), %r12
+               	movq	%rbx, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rdi
-               	movq	%rcx, %rsi
                	cmpq	$0x4, %rdi
-               	jb	 <L24>
-<L28>:
-               	leaq	-0x108(%rbp), %rdi
+               	jb	 <L9>
+<L11>:
+               	leaq	-0x44(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movl	$0x0, 0x10(%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rbx), %r12
-               	movq	$0x0, -0x118(%rbp)
-               	movq	$0x0, -0x110(%rbp)
-               	movq	(%r12), %rbx
-               	movq	%rbx, -0x118(%rbp)
-               	movl	0x8(%r12), %ebx
-               	movl	%ebx, -0x110(%rbp)
-               	movups	-0x118(%rbp), %xmm0
-               	leaq	0x4(%rdi), %rbx
-               	movups	%xmm0, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r12
-               	movq	%r12, (%rbx)
-               	movl	-0x120(%rbp), %r12d
-               	movl	%r12d, 0x8(%rbx)
-               	leaq	0x10(%rdi), %r12
-               	movl	$0x12345678, (%r12)     # imm = 0x12345678
-               	movl	(%rcx), %r12d
-               	movq	%rsi, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	movq	$0x0, -0x138(%rbp)
-               	movq	$0x0, -0x130(%rbp)
-               	movq	(%rbx), %rsi
-               	movq	%rsi, -0x138(%rbp)
-               	movl	0x8(%rbx), %esi
-               	movl	%esi, -0x130(%rbp)
-               	movups	-0x138(%rbp), %xmm0
-               	leaq	-0x144(%rbp), %rbx
-               	movups	%xmm0, -0x154(%rbp)
-               	movq	-0x154(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x14c(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	leaq	0x10(%rdi), %rbx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	-0x290(%rbp), %xmm6
-               	movaps	-0x2a0(%rbp), %xmm7
-               	movaps	-0x2b0(%rbp), %xmm14
-               	movaps	-0x2c0(%rbp), %xmm15
-               	movq	-0x258(%rbp), %rbx
-               	movq	-0x260(%rbp), %rdi
-               	movq	-0x268(%rbp), %rsi
-               	movq	-0x270(%rbp), %r12
-               	movq	-0x278(%rbp), %r13
+               	leaq	(%rdi), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %r13
+               	movq	$0x0, -0x54(%rbp)
+               	movq	$0x0, -0x4c(%rbp)
+               	movq	(%r13), %rsi
+               	movq	%rsi, -0x54(%rbp)
+               	movl	0x8(%r13), %esi
+               	movl	%esi, -0x4c(%rbp)
+               	movups	-0x54(%rbp), %xmm0
+               	leaq	0x4(%rdi), %rsi
+               	movups	%xmm0, -0x64(%rbp)
+               	movq	-0x64(%rbp), %r13
+               	movq	%r13, (%rsi)
+               	movl	-0x5c(%rbp), %r13d
+               	movl	%r13d, 0x8(%rsi)
+               	leaq	0x10(%rdi), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%r12), %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0x4(%rdi), %rsi
+               	movq	$0x0, -0x290(%rbp)
+               	movq	$0x0, -0x288(%rbp)
+               	movq	(%rsi), %r12
+               	movq	%r12, -0x290(%rbp)
+               	movl	0x8(%rsi), %r12d
+               	movl	%r12d, -0x288(%rbp)
+               	movups	-0x290(%rbp), %xmm0
+               	movups	%xmm0, -0x2b0(%rbp)
+               	movq	-0x2b0(%rbp), %rsi
+               	movq	%rsi, -0x2a0(%rbp)
+               	movl	-0x2a8(%rbp), %esi
+               	movl	%esi, -0x298(%rbp)
+               	leaq	-0x2a0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rbx
+               	leaq	0x10(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L15>
+<L16>:
+               	movq	%rbx, %rax
+               	movaps	-0x2f0(%rbp), %xmm6
+               	movaps	-0x300(%rbp), %xmm7
+               	movaps	-0x310(%rbp), %xmm8
+               	movaps	-0x320(%rbp), %xmm9
+               	movaps	-0x330(%rbp), %xmm14
+               	movaps	-0x340(%rbp), %xmm15
+               	movq	-0x2b8(%rbp), %rbx
+               	movq	-0x2c0(%rbp), %rdi
+               	movq	-0x2c8(%rbp), %rsi
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x4.dis
@@ -5,39 +5,119 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -45,54 +125,51 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2c0, %rsp            # imm = 0x2C0
-               	movq	%rbx, -0x1f8(%rbp)
-               	movq	%rdi, -0x200(%rbp)
-               	movq	%rsi, -0x208(%rbp)
-               	movq	%r12, -0x210(%rbp)
-               	movq	%r13, -0x218(%rbp)
-               	movaps	%xmm6, -0x230(%rbp)
-               	movaps	%xmm7, -0x240(%rbp)
-               	movaps	%xmm8, -0x250(%rbp)
-               	movaps	%xmm9, -0x260(%rbp)
-               	movaps	%xmm10, -0x270(%rbp)
-               	movaps	%xmm11, -0x280(%rbp)
-               	movaps	%xmm14, -0x290(%rbp)
-               	movaps	%xmm15, -0x2a0(%rbp)
+               	subq	$0x2d0, %rsp            # imm = 0x2D0
+               	movq	%rbx, -0x218(%rbp)
+               	movq	%rdi, -0x220(%rbp)
+               	movq	%rsi, -0x228(%rbp)
+               	movq	%r12, -0x230(%rbp)
+               	movq	%r13, -0x238(%rbp)
+               	movq	%r14, -0x240(%rbp)
+               	movaps	%xmm6, -0x250(%rbp)
+               	movaps	%xmm7, -0x260(%rbp)
+               	movaps	%xmm8, -0x270(%rbp)
+               	movaps	%xmm9, -0x280(%rbp)
+               	movaps	%xmm10, -0x290(%rbp)
+               	movaps	%xmm14, -0x2a0(%rbp)
+               	movaps	%xmm15, -0x2b0(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rbx
+<L1>:
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xb8>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xbf>
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xb2>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xb9>
                	leaq	0x4(%rbx), %rsi
                	movss	%xmm1, (%rsi)
                	leaq	0x8(%rbx), %rsi
                	movl	$0x40700000, (%rsi)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xd9>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xe0>
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xd3>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0xda>
                	leaq	0xc(%rbx), %rsi
                	movss	%xmm1, (%rsi)
                	movups	(%rbx), %xmm1
-               	leaq	-0x20(%rbp), %rbx
+               	leaq	-0xd0(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xe0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x3f000000, (%rdi)     # imm = 0x3F000000
                	leaq	0x4(%rsi), %rdi
@@ -104,9 +181,9 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x41000000, (%rdi)     # imm = 0x41000000
                	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xf0(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x100(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x3f800000, (%r12)     # imm = 0x3F800000
                	leaq	0x4(%rdi), %r12
@@ -120,7 +197,7 @@ Disassembly of section .text:
                	movss	(%rdi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x110(%rbp), %rbx
                	movups	%xmm1, (%rbx)
                	leaq	(%rbx), %rdi
                	movss	%xmm4, (%rdi)
@@ -129,451 +206,184 @@ Disassembly of section .text:
                	movss	(%rdi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x70(%rbp), %rbx
+               	leaq	-0x120(%rbp), %rbx
                	movups	%xmm1, (%rbx)
                	leaq	0xc(%rbx), %rdi
                	movss	%xmm4, (%rdi)
                	movups	(%rbx), %xmm7
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rsi), %rbx
+               	movss	(%rbx), %xmm1
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
                	addss	%xmm0, %xmm3
-               	leaq	-0x80(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm3, (%rdi)
-               	movups	(%rsi), %xmm1
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm2
+               	leaq	-0x130(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	0x4(%rbx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movups	(%rbx), %xmm1
+               	leaq	0x8(%rbx), %rsi
+               	movss	(%rsi), %xmm2
                	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
                	addss	%xmm0, %xmm3
-               	leaq	-0x90(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm3, (%rdi)
-               	movups	(%rsi), %xmm8
-               	leaq	(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	-0x140(%rbp), %rbx
+               	movups	%xmm1, (%rbx)
+               	leaq	0x8(%rbx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movups	(%rbx), %xmm8
+               	movups	%xmm7, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%rbx, %rdx
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rbx
+               	movups	%xmm8, -0x160(%rbp)
+               	leaq	-0x160(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rsi), %rbx
-               	movss	(%rbx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	subps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x180(%rbp)
+               	leaq	-0x180(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	subps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x190(%rbp)
+               	leaq	-0x190(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1a0(%rbp)
+               	leaq	-0x1a0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	divps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	divps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1d0(%rbp)
+               	leaq	-0x1d0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	subps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1e0(%rbp)
+               	leaq	-0x1e0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L11>
+<L11>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	divps	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	leaq	-0x1f0(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	leaq	0x4(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	leaq	0x8(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	leaq	0xc(%rbx), %rsi
-               	movl	$0x0, (%rsi)
-               	movups	(%rbx), %xmm0
-               	movq	%rcx, %rbx
+               	movups	%xmm0, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L12>
+<L12>:
+               	movq	%rax, %rbx
+               	leaq	-0x200(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	movups	(%rsi), %xmm0
                	movaps	%xmm0, %xmm9
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L47>
-               	jmp	 <L60>
-<L47>:
+               	jb	 <L13>
+               	jmp	 <L17>
+<L13>:
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	-0xa0(%rbp), %rdi
-               	movups	%xmm10, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm10, -0x10(%rbp)
+               	leaq	-0x10(%rbp), %rdi
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rdi
                	movaps	%xmm9, %xmm14
                	addps	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x140(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x20(%rbp)
+               	leaq	-0x20(%rbp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
                	movaps	%xmm7, %xmm14
                	subps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0x160(%rbp), %rdi
-               	movups	%xmm10, (%rdi)
-               	leaq	(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rdi), %r12
-               	movss	(%r12), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x30(%rbp)
+               	leaq	-0x30(%rbp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rsi
-               	movq	%rcx, %rbx
-               	movaps	%xmm10, %xmm7
-               	movaps	%xmm11, %xmm9
                	cmpq	$0x6, %rsi
-               	jb	 <L47>
-<L60>:
-               	leaq	-0xe0(%rbp), %rsi
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x70(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -582,129 +392,123 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	leaq	(%rsi), %rcx
-               	movups	%xmm7, (%rcx)
+               	leaq	(%rsi), %rdi
+               	movups	%xmm7, (%rdi)
                	movaps	%xmm7, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
+               	leaq	0x10(%rsi), %rdi
+               	movups	%xmm0, (%rdi)
                	movaps	%xmm7, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm7
-               	leaq	0x20(%rsi), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	0x30(%rsi), %rcx
-               	movups	%xmm9, (%rcx)
+               	leaq	0x20(%rsi), %rdi
+               	movups	%xmm7, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movups	%xmm9, (%rdi)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L61>
-               	jmp	 <L66>
-<L61>:
-               	movq	%rdi, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %r12
-               	movups	(%r12), %xmm0
-               	leaq	-0xf0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%rdi, %r12
+               	imulq	$0x10, %r12, %r12
+               	leaq	(%rsi,%r12), %r13
+               	movups	(%r13), %xmm0
+               	movups	%xmm0, -0x80(%rbp)
+               	leaq	-0x80(%rbp), %r12
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%r12), %r13
-               	movss	(%r13), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rdi
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L61>
-<L66>:
-               	leaq	-0x120(%rbp), %rdi
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xb0(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
                	movq	$0x0, 0x18(%rdi)
                	movq	$0x0, 0x20(%rdi)
                	movq	$0x0, 0x28(%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%rsi), %r12
-               	movups	(%r12), %xmm0
+               	leaq	(%rdi), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%rsi), %r13
+               	movups	(%r13), %xmm0
                	leaq	0x10(%rdi), %rsi
                	movups	%xmm0, (%rsi)
-               	leaq	0x20(%rdi), %r12
-               	movl	$0x12345678, (%r12)     # imm = 0x12345678
-               	movl	(%rcx), %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rcx
+               	leaq	0x20(%rdi), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%r12), %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%rdi), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rcx
-               	leaq	0x20(%rdi), %rbx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	-0x230(%rbp), %xmm6
-               	movaps	-0x240(%rbp), %xmm7
-               	movaps	-0x250(%rbp), %xmm8
-               	movaps	-0x260(%rbp), %xmm9
-               	movaps	-0x270(%rbp), %xmm10
-               	movaps	-0x280(%rbp), %xmm11
-               	movaps	-0x290(%rbp), %xmm14
-               	movaps	-0x2a0(%rbp), %xmm15
-               	movq	-0x1f8(%rbp), %rbx
-               	movq	-0x200(%rbp), %rdi
-               	movq	-0x208(%rbp), %rsi
-               	movq	-0x210(%rbp), %r12
-               	movq	-0x218(%rbp), %r13
+               	movups	%xmm0, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rbx
+               	leaq	0x20(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movaps	-0x250(%rbp), %xmm6
+               	movaps	-0x260(%rbp), %xmm7
+               	movaps	-0x270(%rbp), %xmm8
+               	movaps	-0x280(%rbp), %xmm9
+               	movaps	-0x290(%rbp), %xmm10
+               	movaps	-0x2a0(%rbp), %xmm14
+               	movaps	-0x2b0(%rbp), %xmm15
+               	movq	-0x218(%rbp), %rbx
+               	movq	-0x220(%rbp), %rdi
+               	movq	-0x228(%rbp), %rsi
+               	movq	-0x230(%rbp), %r12
+               	movq	-0x238(%rbp), %r13
+               	movq	-0x240(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x5.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x5.dis
@@ -5,46 +5,143 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x5.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xc0, %rsp
+               	subq	$0xb0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rdx, %rbx
-               	leaq	-0x20(%rbp), %rdx
-               	movq	%rbx, (%rdx)
-               	leaq	-0x34(%rbp), %rdx
-               	leaq	-0x48(%rbp), %rdx
-               	leaq	-0x5c(%rbp), %rdx
-               	leaq	-0x70(%rbp), %rdx
-               	leaq	-0x84(%rbp), %rdx
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x20(%rbp), %rbx
+               	movq	%rdx, (%rbx)
+               	leaq	-0x34(%rbp), %rbx
+               	leaq	-0x48(%rbp), %rbx
+               	leaq	-0x5c(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rbx
+               	leaq	-0x84(%rbp), %rbx
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x10(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -52,1817 +149,1483 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x5.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xdc0, %rsp            # imm = 0xDC0
-               	movq	%rbx, -0xd48(%rbp)
-               	movq	%rdi, -0xd50(%rbp)
-               	movq	%rsi, -0xd58(%rbp)
-               	movq	%r12, -0xd60(%rbp)
-               	movq	%r13, -0xd68(%rbp)
-               	movq	%r14, -0xd70(%rbp)
-               	movq	%r15, -0xd78(%rbp)
-               	movaps	%xmm14, -0xd90(%rbp)
-               	movaps	%xmm15, -0xda0(%rbp)
-               	movq	%rcx, %rbx
-               	leaq	-0x14(%rbp), %rsi
-               	leaq	-0x28(%rbp), %rdi
-               	leaq	-0x3c(%rbp), %r12
-               	leaq	-0x50(%rbp), %rcx
-               	leaq	-0x64(%rbp), %rcx
-               	leaq	-0x78(%rbp), %r13
-               	leaq	-0x8c(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xb4(%rbp), %r14
-               	leaq	-0xc8(%rbp), %rcx
-               	leaq	-0xdc(%rbp), %rcx
-               	leaq	-0xf0(%rbp), %r15
-               	leaq	-0x104(%rbp), %rcx
-               	leaq	-0x118(%rbp), %rcx
-               	leaq	-0x12c(%rbp), %rcx
-               	leaq	-0x140(%rbp), %rcx
-               	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0xd40(%rbp)
-               	leaq	-0x168(%rbp), %rcx
-               	leaq	-0x17c(%rbp), %rcx
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0xcb0(%rbp)
-               	leaq	-0x1a4(%rbp), %rcx
-               	leaq	-0x1b8(%rbp), %rcx
+               	subq	$0xa00, %rsp            # imm = 0xA00
+               	movq	%rbx, -0x988(%rbp)
+               	movq	%rdi, -0x990(%rbp)
+               	movq	%rsi, -0x998(%rbp)
+               	movq	%r12, -0x9a0(%rbp)
+               	movq	%r13, -0x9a8(%rbp)
+               	movq	%r14, -0x9b0(%rbp)
+               	movq	%r15, -0x9b8(%rbp)
+               	movaps	%xmm14, -0x9d0(%rbp)
+               	movaps	%xmm15, -0x9e0(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x868(%rbp)
+               	leaq	-0x14(%rbp), %r8
+               	movq	%r8, -0x880(%rbp)
+               	leaq	-0x28(%rbp), %r8
+               	movq	%r8, -0x870(%rbp)
+               	leaq	-0x3c(%rbp), %rsi
+               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x64(%rbp), %rdi
+               	leaq	-0x78(%rbp), %r8
+               	movq	%r8, -0x878(%rbp)
+               	leaq	-0x8c(%rbp), %r12
+               	leaq	-0xa0(%rbp), %r12
+               	leaq	-0xb4(%rbp), %r12
+               	leaq	-0xc8(%rbp), %r13
+               	leaq	-0xdc(%rbp), %r13
+               	leaq	-0xf0(%rbp), %r13
+               	leaq	-0x104(%rbp), %r14
+               	leaq	-0x118(%rbp), %r14
+               	leaq	-0x12c(%rbp), %r14
+               	leaq	-0x140(%rbp), %r14
+               	leaq	-0x154(%rbp), %r14
+               	leaq	-0x168(%rbp), %r15
+               	leaq	-0x17c(%rbp), %r15
+               	leaq	-0x190(%rbp), %r15
+               	leaq	-0x1a4(%rbp), %rax
+               	leaq	-0x1b8(%rbp), %rax
                	leaq	-0x1cc(%rbp), %r8
-               	movq	%r8, -0xcb8(%rbp)
-               	leaq	-0x1e0(%rbp), %rcx
-               	leaq	-0x1f4(%rbp), %rcx
-               	leaq	-0x208(%rbp), %r8
-               	movq	%r8, -0xcc0(%rbp)
-               	leaq	-0x21c(%rbp), %rcx
-               	leaq	-0x230(%rbp), %rcx
-               	leaq	-0x244(%rbp), %r8
-               	movq	%r8, -0xcc8(%rbp)
-               	leaq	-0x258(%rbp), %rcx
-               	leaq	-0x26c(%rbp), %rcx
+               	movq	%r8, -0x978(%rbp)
+               	leaq	-0x1e0(%rbp), %rbx
+               	leaq	-0x1f4(%rbp), %rbx
+               	leaq	-0x208(%rbp), %rbx
+               	leaq	-0x21c(%rbp), %rdi
+               	leaq	-0x230(%rbp), %rdi
+               	leaq	-0x244(%rbp), %rdi
+               	leaq	-0x258(%rbp), %rdx
+               	leaq	-0x26c(%rbp), %rdx
                	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0xcd0(%rbp)
-               	leaq	-0x294(%rbp), %rcx
-               	leaq	-0x2a8(%rbp), %rcx
+               	movq	%r8, -0x888(%rbp)
+               	leaq	-0x294(%rbp), %rdx
+               	leaq	-0x2a8(%rbp), %rdx
                	leaq	-0x2bc(%rbp), %r8
-               	movq	%r8, -0xcd8(%rbp)
-               	leaq	-0x2d0(%rbp), %rcx
-               	leaq	-0x2e4(%rbp), %rcx
+               	movq	%r8, -0x890(%rbp)
+               	leaq	-0x2d0(%rbp), %rdx
+               	leaq	-0x2e4(%rbp), %rdx
                	leaq	-0x2f8(%rbp), %r8
-               	movq	%r8, -0xce0(%rbp)
-               	leaq	-0x30c(%rbp), %rcx
-               	leaq	-0x320(%rbp), %rcx
+               	movq	%r8, -0x898(%rbp)
+               	leaq	-0x30c(%rbp), %rdx
+               	leaq	-0x320(%rbp), %rdx
                	leaq	-0x334(%rbp), %r8
-               	movq	%r8, -0xce8(%rbp)
+               	movq	%r8, -0x8a0(%rbp)
                	leaq	-0x348(%rbp), %r8
-               	movq	%r8, -0xcf0(%rbp)
-               	leaq	-0x35c(%rbp), %rcx
-               	leaq	-0x370(%rbp), %rcx
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	-0x35c(%rbp), %rdx
+               	leaq	-0x370(%rbp), %rdx
                	leaq	-0x384(%rbp), %r8
-               	movq	%r8, -0xcf8(%rbp)
-               	leaq	-0x398(%rbp), %rcx
-               	leaq	-0x3ac(%rbp), %rcx
-               	leaq	-0x3c0(%rbp), %rcx
+               	movq	%r8, -0x8b0(%rbp)
+               	leaq	-0x398(%rbp), %rdx
+               	leaq	-0x3ac(%rbp), %rdx
+               	leaq	-0x3c0(%rbp), %rdx
                	leaq	-0x3d4(%rbp), %r8
-               	movq	%r8, -0xd00(%rbp)
-               	leaq	-0x3e8(%rbp), %rcx
-               	leaq	-0x3fc(%rbp), %rcx
-               	leaq	-0x410(%rbp), %rcx
+               	movq	%r8, -0x8b8(%rbp)
+               	leaq	-0x3e8(%rbp), %rdx
+               	leaq	-0x3fc(%rbp), %rdx
+               	leaq	-0x410(%rbp), %rdx
                	leaq	-0x424(%rbp), %r8
-               	movq	%r8, -0xd08(%rbp)
-               	leaq	-0x438(%rbp), %rcx
-               	leaq	-0x44c(%rbp), %rcx
-               	leaq	-0x460(%rbp), %rcx
-               	leaq	-0x474(%rbp), %rcx
+               	movq	%r8, -0x8c0(%rbp)
+               	leaq	-0x438(%rbp), %rdx
+               	leaq	-0x44c(%rbp), %rdx
+               	leaq	-0x460(%rbp), %rdx
+               	leaq	-0x474(%rbp), %rdx
                	leaq	-0x488(%rbp), %r8
-               	movq	%r8, -0xd10(%rbp)
-               	leaq	-0x49c(%rbp), %rcx
-               	leaq	-0x4b0(%rbp), %rcx
+               	movq	%r8, -0x8c8(%rbp)
+               	leaq	-0x49c(%rbp), %rdx
+               	leaq	-0x4b0(%rbp), %rdx
                	leaq	-0x4c4(%rbp), %r8
-               	movq	%r8, -0xd18(%rbp)
-               	leaq	-0x4d8(%rbp), %rcx
-               	leaq	-0x4ec(%rbp), %rcx
-               	leaq	-0x500(%rbp), %rcx
+               	movq	%r8, -0x8d0(%rbp)
+               	leaq	-0x4d8(%rbp), %rdx
+               	leaq	-0x4ec(%rbp), %rdx
+               	leaq	-0x500(%rbp), %rdx
                	leaq	-0x514(%rbp), %r8
-               	movq	%r8, -0xd20(%rbp)
-               	leaq	-0x528(%rbp), %rcx
+               	movq	%r8, -0x8d8(%rbp)
+               	leaq	-0x528(%rbp), %rdx
                	leaq	-0x53c(%rbp), %r8
-               	movq	%r8, -0xd28(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	-0x550(%rbp), %r8
-               	movq	%r8, -0xd30(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	-0x564(%rbp), %r8
-               	movq	%r8, -0xd38(%rbp)
-               	leaq	-0x578(%rbp), %rcx
-               	leaq	-0x58c(%rbp), %rcx
-               	leaq	-0x5a0(%rbp), %rcx
-               	leaq	-0x5b4(%rbp), %rcx
-               	leaq	-0x5c8(%rbp), %rcx
-               	leaq	-0x5dc(%rbp), %rcx
-               	leaq	-0x5f0(%rbp), %rcx
-               	leaq	-0x604(%rbp), %rcx
-               	leaq	-0x618(%rbp), %rcx
-               	leaq	-0x62c(%rbp), %rcx
-               	leaq	-0x640(%rbp), %rcx
-               	leaq	-0x654(%rbp), %rcx
-               	leaq	-0x668(%rbp), %rcx
-               	leaq	-0x67c(%rbp), %rcx
-               	leaq	-0x690(%rbp), %rcx
-               	leaq	-0x6a4(%rbp), %rcx
-               	leaq	-0x6b8(%rbp), %rcx
-               	leaq	-0x6cc(%rbp), %rcx
-               	leaq	-0x6e0(%rbp), %rcx
-               	leaq	-0x6f4(%rbp), %rcx
-               	leaq	-0x708(%rbp), %rcx
-               	leaq	-0x71c(%rbp), %rcx
-               	leaq	-0x730(%rbp), %rcx
-               	leaq	-0x744(%rbp), %rcx
-               	leaq	-0x758(%rbp), %rcx
-               	leaq	-0x76c(%rbp), %rcx
-               	leaq	-0x780(%rbp), %rcx
-               	leaq	-0x794(%rbp), %rcx
-               	leaq	-0x7a8(%rbp), %rcx
-               	leaq	-0x7bc(%rbp), %rcx
-               	leaq	-0x7d0(%rbp), %rcx
-               	leaq	-0x7e4(%rbp), %rcx
-               	leaq	-0x7f8(%rbp), %rcx
-               	leaq	-0x80c(%rbp), %rcx
-               	leaq	-0x820(%rbp), %rcx
-               	leaq	-0x834(%rbp), %rcx
-               	leaq	-0x848(%rbp), %rcx
-               	leaq	-0x85c(%rbp), %rcx
-               	leaq	-0x870(%rbp), %rcx
-               	leaq	-0x884(%rbp), %rcx
-               	leaq	-0x898(%rbp), %rcx
-               	leaq	-0x8ac(%rbp), %rcx
-               	leaq	-0x8c0(%rbp), %rcx
-               	leaq	-0x8d4(%rbp), %rcx
-               	leaq	-0x8e8(%rbp), %rcx
-               	leaq	-0x8fc(%rbp), %rcx
-               	leaq	-0x910(%rbp), %rcx
-               	leaq	-0x924(%rbp), %rcx
-               	leaq	-0x938(%rbp), %rcx
-               	leaq	-0x94c(%rbp), %rcx
-               	leaq	-0x960(%rbp), %rcx
-               	leaq	-0x974(%rbp), %rcx
-               	leaq	-0x988(%rbp), %rcx
-               	leaq	-0x99c(%rbp), %rcx
-               	leaq	-0x9b0(%rbp), %rcx
-               	leaq	-0x9c4(%rbp), %rcx
-               	leaq	-0x9d8(%rbp), %rcx
-               	leaq	-0x9ec(%rbp), %rcx
-               	leaq	-0xa00(%rbp), %rcx
-               	leaq	-0xa14(%rbp), %rcx
-               	leaq	-0xa28(%rbp), %rcx
-               	leaq	-0xa3c(%rbp), %rcx
-               	leaq	-0xa50(%rbp), %rcx
-               	leaq	-0xa64(%rbp), %rcx
-               	leaq	-0xa78(%rbp), %rcx
-               	leaq	-0xa8c(%rbp), %rcx
-               	leaq	-0xaa0(%rbp), %rcx
-               	leaq	-0xab4(%rbp), %rcx
-               	leaq	-0xac8(%rbp), %rcx
-               	leaq	-0xadc(%rbp), %rcx
-               	leaq	-0xaf0(%rbp), %rcx
-               	leaq	-0xb04(%rbp), %rcx
-               	leaq	-0xb18(%rbp), %rcx
-               	leaq	-0xb2c(%rbp), %rcx
-               	leaq	-0xb40(%rbp), %rcx
-               	leaq	-0xb54(%rbp), %rcx
-               	leaq	-0xb68(%rbp), %rcx
-               	leaq	-0xb7c(%rbp), %rcx
-               	leaq	-0xb90(%rbp), %rcx
-               	leaq	-0xba4(%rbp), %rcx
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x868(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x6a4(%rbp), %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2fe>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x305>
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movl	$0x40700000, (%rdx)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x32d>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x334>
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movl	$0x40c80000, (%rdx)     # imm = 0x40C80000
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x880(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x880(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x8f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x6b8(%rbp), %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x900(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3f000000, (%rdx)     # imm = 0x3F000000
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movl	$0x40800000, (%rdx)     # imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x41f>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x426>
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movl	$0x41000000, (%rdx)     # imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x44e>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x455>
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x870(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x870(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x900(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x6cc(%rbp), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3f800000, (%rdx)     # imm = 0x3F800000
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movl	$0x40400000, (%rdx)     # imm = 0x40400000
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movl	$0x41100000, (%rdx)     # imm = 0x41100000
+               	movq	-0x908(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movl	$0x41d80000, (%rdx)     # imm = 0x41D80000
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movl	$0x42a20000, (%rdx)     # imm = 0x42A20000
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x880(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x880(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x878(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x880(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x878(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x878(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x870(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x870(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x870(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %r8
+               	movq	%r8, -0x910(%rbp)
+               	movl	0x10(%r12), %r8d
+               	movq	%r8, -0x918(%rbp)
+               	movq	%rdx, -0x6f0(%rbp)
+               	movq	-0x910(%rbp), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	-0x918(%rbp), %r8
+               	movl	%r8d, -0x6e0(%rbp)
+               	leaq	-0x6f0(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L2>
 <L2>:
-               	leaq	-0xbb8(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3fc00000, (%rbx)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x51e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x525>
-               	leaq	0x4(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movl	$0x40700000, (%rbx)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x53f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x546>
-               	leaq	0xc(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movl	$0x40c80000, (%rbx)     # imm = 0x40C80000
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%rsi), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	-0xbcc(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rcx), %rbx
-               	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5c8>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5cf>
-               	leaq	0x8(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movl	$0x41000000, (%rbx)     # imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5e9>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5f0>
-               	leaq	0x10(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%rdi), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	-0xbe0(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3f800000, (%rbx)     # imm = 0x3F800000
-               	leaq	0x4(%rcx), %rbx
-               	movl	$0x40400000, (%rbx)     # imm = 0x40400000
-               	leaq	0x8(%rcx), %rbx
-               	movl	$0x41100000, (%rbx)     # imm = 0x41100000
-               	leaq	0xc(%rcx), %rbx
-               	movl	$0x41d80000, (%rbx)     # imm = 0x41D80000
-               	leaq	0x10(%rcx), %rbx
-               	movl	$0x42a20000, (%rbx)     # imm = 0x42A20000
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	(%r13), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x4(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x8(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x10(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r15), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	movq	(%r13), %rdx
+               	movq	0x8(%r13), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movl	0x10(%r13), %r8d
+               	movq	%r8, -0x930(%rbp)
+               	movq	%rdx, -0x710(%rbp)
+               	movq	-0x928(%rbp), %r8
+               	movq	%r8, -0x708(%rbp)
+               	movq	-0x930(%rbp), %r8
+               	movl	%r8d, -0x700(%rbp)
+               	leaq	-0x710(%rbp), %rdx
+               	movq	-0x920(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x938(%rbp)
+               	movq	-0x938(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %r8
+               	movq	%r8, -0x940(%rbp)
+               	movl	0x10(%r14), %r8d
+               	movq	%r8, -0x948(%rbp)
+               	movq	%rdx, -0x730(%rbp)
+               	movq	-0x940(%rbp), %r8
+               	movq	%r8, -0x728(%rbp)
+               	movq	-0x948(%rbp), %r8
+               	movl	%r8d, -0x720(%rbp)
+               	leaq	-0x730(%rbp), %rdx
+               	movq	-0x938(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x950(%rbp), %r8
+               	leaq	(%r12), %r14
+               	movss	(%r14), %xmm0
+               	leaq	(%r13), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	(%r15), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x4(%r12), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x4(%r13), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x8(%r12), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x8(%r13), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0xc(%r12), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0xc(%r13), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x10(%r12), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x10(%r13), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %r14
+               	movss	%xmm2, (%r14)
+               	movq	(%r15), %r14
+               	movq	0x8(%r15), %rdx
+               	movl	0x10(%r15), %r8d
+               	movq	%r8, -0x958(%rbp)
+               	movq	%r14, -0x750(%rbp)
+               	movq	%rdx, -0x748(%rbp)
+               	movq	-0x958(%rbp), %r8
+               	movl	%r8d, -0x740(%rbp)
+               	leaq	-0x750(%rbp), %rdx
+               	movq	-0x950(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x960(%rbp)
+               	movq	-0x960(%rbp), %r8
+               	leaq	(%r13), %r14
+               	movss	(%r14), %xmm0
+               	leaq	(%r12), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x978(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x4(%r13), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x4(%r12), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x978(%rbp), %r8
+               	leaq	0x4(%r8), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x8(%r13), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x8(%r12), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x978(%rbp), %r8
+               	leaq	0x8(%r8), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0xc(%r13), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0xc(%r12), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x978(%rbp), %r8
+               	leaq	0xc(%r8), %r14
+               	movss	%xmm2, (%r14)
+               	leaq	0x10(%r13), %r14
+               	movss	(%r14), %xmm0
+               	leaq	0x10(%r12), %r14
+               	movss	(%r14), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x978(%rbp), %r8
+               	leaq	0x10(%r8), %r14
+               	movss	%xmm2, (%r14)
+               	movq	-0x978(%rbp), %r8
+               	movq	(%r8), %r14
+               	movq	-0x978(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0x978(%rbp), %r8
+               	movl	0x10(%r8), %edx
+               	movq	%r14, -0x770(%rbp)
+               	movq	%r15, -0x768(%rbp)
+               	movl	%edx, -0x760(%rbp)
+               	leaq	-0x770(%rbp), %rdx
+               	movq	-0x960(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x4(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x8(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0xc(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x10(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %r14
+               	movl	0x10(%rbx), %r15d
+               	movq	%rdx, -0x790(%rbp)
+               	movq	%r14, -0x788(%rbp)
+               	movl	%r15d, -0x780(%rbp)
+               	leaq	-0x790(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L7>
 <L7>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x4(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x8(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0xc(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x10(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %rbx
+               	movl	0x10(%rdi), %r14d
+               	movq	%rdx, -0x7b0(%rbp)
+               	movq	%rbx, -0x7a8(%rbp)
+               	movl	%r14d, -0x7a0(%rbp)
+               	leaq	-0x7b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L8>
 <L8>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x888(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x888(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x888(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x888(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x888(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rdx, -0x7d0(%rbp)
+               	movq	%rbx, -0x7c8(%rbp)
+               	movl	%edi, -0x7c0(%rbp)
+               	leaq	-0x7d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L9>
 <L9>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x890(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x890(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x890(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x890(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x890(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x890(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x890(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x890(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rdx, -0x7f0(%rbp)
+               	movq	%rbx, -0x7e8(%rbp)
+               	movl	%edi, -0x7e0(%rbp)
+               	leaq	-0x7f0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L10>
 <L10>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x898(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x898(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x898(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x898(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x898(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x898(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x898(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x898(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rdx, -0x810(%rbp)
+               	movq	%rbx, -0x808(%rbp)
+               	movl	%edi, -0x800(%rbp)
+               	leaq	-0x810(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L11>
 <L11>:
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x8a0(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x8a0(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rdx, -0x830(%rbp)
+               	movq	%rbx, -0x828(%rbp)
+               	movl	%edi, -0x820(%rbp)
+               	leaq	-0x830(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L12>
 <L12>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
+               	leaq	-0x844(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdx), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x10(%rdx), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x8(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0xc(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x10(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %rbx
+               	movq	-0x8a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x6, %r14
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x10(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	movq	-0x8b0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x8b0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x8b0(%rbp), %r8
+               	movl	0x10(%r8), %r15d
+               	movq	%rax, -0x580(%rbp)
+               	movq	%rdx, -0x578(%rbp)
+               	movl	%r15d, -0x570(%rbp)
+               	leaq	-0x580(%rbp), %rdx
+               	movq	%rbx, %rcx
                	callq	 <L14>
 <L14>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x968(%rbp)
+               	movq	-0x968(%rbp), %r8
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x8b8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x8b8(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0x8b8(%rbp), %r8
+               	movl	0x10(%r8), %eax
+               	movq	%rdx, -0x5a0(%rbp)
+               	movq	%r15, -0x598(%rbp)
+               	movl	%eax, -0x590(%rbp)
+               	leaq	-0x5a0(%rbp), %rdx
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L15>
 <L15>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0x970(%rbp)
+               	movq	-0x970(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x8c0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x8c0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x8c0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x8c0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x8c0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x8c0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x8c0(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0x8c0(%rbp), %r8
+               	movl	0x10(%r8), %eax
+               	movq	%rdx, -0x5c0(%rbp)
+               	movq	%r15, -0x5b8(%rbp)
+               	movl	%eax, -0x5b0(%rbp)
+               	leaq	-0x5c0(%rbp), %rdx
+               	movq	-0x970(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L16>
 <L16>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
+               	addq	$0x1, %r14
+               	movq	%rax, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	cmpq	$0x6, %r14
+               	jb	 <L13>
 <L17>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L36>
-<L36>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L41>
-<L41>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L42>
-<L42>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L43>
-<L43>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L47>
-<L47>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	leaq	-0xca4(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	%rax, %rbx
-               	movq	-0xcf0(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L58>
-               	jmp	 <L74>
-<L58>:
+               	leaq	-0x640(%rbp), %r14
                	leaq	(%r14), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L59>
-<L59>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L60>
-<L60>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L66>
-<L66>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
-<L67>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L72>
-<L72>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %rdi
-               	movq	%rax, %rbx
-               	movq	-0xd08(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	-0xd00(%rbp), %r8
-               	movq	%r8, %rsi
-               	cmpq	$0x6, %rdi
-               	jb	 <L58>
-<L74>:
-               	leaq	-0xc60(%rbp), %rdi
-               	leaq	(%rdi), %rax
                	addq	$0x0, %rax
-               	movq	$0x78, %rcx
-<L75>:
+               	movq	$0x78, %rdx
+<L18>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L75>
-               	leaq	(%rdi), %rax
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L18>
                	leaq	(%r14), %rax
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%r12), %rax
                	movss	(%rax), %xmm0
-               	leaq	(%r15), %rax
+               	leaq	(%r13), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
+               	movq	-0x8c8(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
+               	leaq	0x4(%r12), %rax
                	movss	(%rax), %xmm0
-               	leaq	0x4(%r15), %rax
+               	leaq	0x4(%r13), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
+               	movq	-0x8c8(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
+               	leaq	0x8(%r12), %rax
                	movss	(%rax), %xmm0
-               	leaq	0x8(%r15), %rax
+               	leaq	0x8(%r13), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
+               	movq	-0x8c8(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
+               	leaq	0xc(%r12), %rax
                	movss	(%rax), %xmm0
-               	leaq	0xc(%r15), %rax
+               	leaq	0xc(%r13), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
+               	movq	-0x8c8(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
+               	leaq	0x10(%r12), %rax
                	movss	(%rax), %xmm0
-               	leaq	0x10(%r15), %rax
+               	leaq	0x10(%r13), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
+               	movq	-0x8c8(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x14(%rdi), %rax
-               	movq	-0xd10(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r14), %rax
+               	leaq	0x14(%r14), %rax
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x10(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x28(%r14), %rax
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x3c(%r14), %rax
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%r13), %rax
                	movss	(%rax), %xmm0
                	leaq	(%r12), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
+               	subss	%xmm1, %xmm2
+               	movq	-0x8d8(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
+               	leaq	0x4(%r13), %rax
                	movss	(%rax), %xmm0
                	leaq	0x4(%r12), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
+               	subss	%xmm1, %xmm2
+               	movq	-0x8d8(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
+               	leaq	0x8(%r13), %rax
                	movss	(%rax), %xmm0
                	leaq	0x8(%r12), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
+               	subss	%xmm1, %xmm2
+               	movq	-0x8d8(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
+               	leaq	0xc(%r13), %rax
                	movss	(%rax), %xmm0
                	leaq	0xc(%r12), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
+               	subss	%xmm1, %xmm2
+               	movq	-0x8d8(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
+               	leaq	0x10(%r13), %rax
                	movss	(%rax), %xmm0
                	leaq	0x10(%r12), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
+               	subss	%xmm1, %xmm2
+               	movq	-0x8d8(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x28(%rdi), %rax
-               	movq	-0xd18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x3c(%rdi), %rax
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r15), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r15), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r15), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r15), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r15), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x50(%rdi), %rax
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x64(%rdi), %rax
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
+               	leaq	0x50(%r14), %rax
+               	movq	-0x8d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x8d8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x64(%r14), %rax
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L76>
-               	jmp	 <L82>
-<L76>:
+               	jb	 <L19>
+               	jmp	 <L21>
+<L19>:
                	movq	%rsi, %rax
                	imulq	$0x14, %rax, %rax
-               	leaq	(%rdi,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	leaq	(%r14,%rax), %rdx
+               	leaq	(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
+               	movq	-0x8e0(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
+               	leaq	0x4(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
+               	movq	-0x8e0(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
+               	leaq	0x8(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
+               	movq	-0x8e0(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
+               	leaq	0xc(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
+               	movq	-0x8e0(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
+               	leaq	0x10(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
+               	movq	-0x8e0(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm0, (%rax)
-               	movq	-0xd28(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
+               	movq	-0x8e0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x8e0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x8e0(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rax, -0x660(%rbp)
+               	movq	%rdx, -0x658(%rbp)
+               	movl	%edi, -0x650(%rbp)
+               	leaq	-0x660(%rbp), %rdx
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L77>
-<L77>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L78>
-<L78>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L79>
-<L79>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L80>
-<L80>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L81>
-<L81>:
+               	callq	 <L20>
+<L20>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
                	cmpq	$0x6, %rsi
-               	jb	 <L76>
-<L82>:
-               	leaq	-0xc90(%rbp), %rsi
+               	jb	 <L19>
+<L21>:
+               	leaq	-0x690(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -1871,138 +1634,153 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	leaq	(%rsi), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x28(%rdi), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x28(%r14), %rdx
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x4(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x8(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0xc(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x10(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x24(%rsi), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	leaq	0x10(%rsi), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x8f0(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x8f0(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x8f0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x8f0(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rsi), %rdi
-               	movq	-0xd30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%rsi), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %edx
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x8f0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x8f0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x8f0(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rax, -0x860(%rbp)
+               	movq	%rdx, -0x858(%rbp)
+               	movl	%edi, -0x850(%rbp)
+               	leaq	-0x860(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L83>
-<L83>:
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L84>
-<L84>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L85>
-<L85>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L86>
-<L86>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L87>
-<L87>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L88>
-<L88>:
-               	leaq	0x24(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
-               	movaps	-0xd90(%rbp), %xmm14
-               	movaps	-0xda0(%rbp), %xmm15
-               	movq	-0xd48(%rbp), %rbx
-               	movq	-0xd50(%rbp), %rdi
-               	movq	-0xd58(%rbp), %rsi
-               	movq	-0xd60(%rbp), %r12
-               	movq	-0xd68(%rbp), %r13
-               	movq	-0xd70(%rbp), %r14
-               	movq	-0xd78(%rbp), %r15
+               	callq	 <L24>
+<L24>:
+               	leaq	0x24(%rsi), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+<L26>:
+               	movaps	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9e0(%rbp), %xmm15
+               	movq	-0x988(%rbp), %rbx
+               	movq	-0x990(%rbp), %rdi
+               	movq	-0x998(%rbp), %rsi
+               	movq	-0x9a0(%rbp), %r12
+               	movq	-0x9a8(%rbp), %r13
+               	movq	-0x9b0(%rbp), %r14
+               	movq	-0x9b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x8.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x8.dis
@@ -5,67 +5,218 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x8.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x150, %rsp            # imm = 0x150
+               	subq	$0x140, %rsp            # imm = 0x140
                	movq	%rbx, -0x128(%rbp)
-               	movq	%rdx, %rbx
-               	leaq	-0x20(%rbp), %rdx
-               	movq	%rbx, (%rdx)
-               	leaq	-0x40(%rbp), %rdx
-               	leaq	-0x60(%rbp), %rdx
-               	leaq	-0x80(%rbp), %rdx
-               	leaq	-0xa0(%rbp), %rdx
-               	leaq	-0xc0(%rbp), %rdx
-               	leaq	-0xe0(%rbp), %rdx
-               	leaq	-0x100(%rbp), %rdx
-               	leaq	-0x120(%rbp), %rdx
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movq	%rdi, -0x130(%rbp)
+               	movq	%rsi, -0x138(%rbp)
+               	movq	%r12, -0x140(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x20(%rbp), %rbx
+               	movq	%rdx, (%rbx)
+               	leaq	-0x40(%rbp), %rbx
+               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x80(%rbp), %rbx
+               	leaq	-0xa0(%rbp), %rbx
+               	leaq	-0xc0(%rbp), %rbx
+               	leaq	-0xe0(%rbp), %rbx
+               	leaq	-0x100(%rbp), %rbx
+               	leaq	-0x120(%rbp), %rbx
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x10(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0x14(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L5>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x18(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L6>
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0x1c(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L7>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L7>:
+               	leaq	0x10(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+<L9>:
+               	leaq	0x14(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	leaq	0x18(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	leaq	0x1c(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
                	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %rdi
+               	movq	-0x138(%rbp), %rsi
+               	movq	-0x140(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -73,2782 +224,2096 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x1ae0, %r11           # imm = 0x1AE0
-<L0>:
-               	subq	$0x1000, %rsp           # imm = 0x1000
-               	movq	%r11, (%rsp)
-               	subq	$0x1000, %r11           # imm = 0x1000
-               	cmpq	$0x1000, %r11           # imm = 0x1000
-               	ja	 <L0>
-               	subq	%r11, %rsp
-               	movq	%rbx, -0x1a68(%rbp)
-               	movq	%rdi, -0x1a70(%rbp)
-               	movq	%rsi, -0x1a78(%rbp)
-               	movq	%r12, -0x1a80(%rbp)
-               	movq	%r13, -0x1a88(%rbp)
-               	movq	%r14, -0x1a90(%rbp)
-               	movq	%r15, -0x1a98(%rbp)
-               	movaps	%xmm14, -0x1ab0(%rbp)
-               	movaps	%xmm15, -0x1ac0(%rbp)
-               	movq	%rcx, %rbx
-               	leaq	-0x20(%rbp), %rsi
-               	leaq	-0x40(%rbp), %rdi
-               	leaq	-0x60(%rbp), %r12
-               	leaq	-0x80(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xc0(%rbp), %r13
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	-0x120(%rbp), %r14
-               	leaq	-0x140(%rbp), %rcx
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	-0x180(%rbp), %r15
-               	leaq	-0x1a0(%rbp), %rcx
-               	leaq	-0x1c0(%rbp), %rcx
-               	leaq	-0x1e0(%rbp), %r8
-               	movq	%r8, -0x1a58(%rbp)
-               	leaq	-0x200(%rbp), %rcx
-               	leaq	-0x220(%rbp), %rcx
-               	leaq	-0x240(%rbp), %rcx
-               	leaq	-0x260(%rbp), %rcx
-               	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0x19c8(%rbp)
-               	leaq	-0x2a0(%rbp), %rcx
-               	leaq	-0x2c0(%rbp), %rcx
+               	subq	$0xda0, %rsp            # imm = 0xDA0
+               	movq	%rbx, -0xd28(%rbp)
+               	movq	%rdi, -0xd30(%rbp)
+               	movq	%rsi, -0xd38(%rbp)
+               	movq	%r12, -0xd40(%rbp)
+               	movq	%r13, -0xd48(%rbp)
+               	movq	%r14, -0xd50(%rbp)
+               	movq	%r15, -0xd58(%rbp)
+               	movaps	%xmm14, -0xd70(%rbp)
+               	movaps	%xmm15, -0xd80(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0xbc8(%rbp)
+               	leaq	-0x20(%rbp), %r8
+               	movq	%r8, -0xbe8(%rbp)
+               	leaq	-0x40(%rbp), %r8
+               	movq	%r8, -0xbd8(%rbp)
+               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x80(%rbp), %rdi
+               	leaq	-0xa0(%rbp), %rdi
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0xbe0(%rbp)
+               	leaq	-0xe0(%rbp), %r12
+               	leaq	-0x100(%rbp), %r12
+               	leaq	-0x120(%rbp), %r12
+               	leaq	-0x140(%rbp), %r13
+               	leaq	-0x160(%rbp), %r13
+               	leaq	-0x180(%rbp), %r8
+               	movq	%r8, -0xbd0(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	leaq	-0x1c0(%rbp), %r14
+               	leaq	-0x1e0(%rbp), %r14
+               	leaq	-0x200(%rbp), %r15
+               	leaq	-0x220(%rbp), %r15
+               	leaq	-0x240(%rbp), %r15
+               	leaq	-0x260(%rbp), %r15
+               	leaq	-0x280(%rbp), %r15
+               	leaq	-0x2a0(%rbp), %rax
+               	leaq	-0x2c0(%rbp), %rax
                	leaq	-0x2e0(%rbp), %r8
-               	movq	%r8, -0x19d0(%rbp)
-               	leaq	-0x300(%rbp), %rcx
-               	leaq	-0x320(%rbp), %rcx
-               	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x19d8(%rbp)
-               	leaq	-0x360(%rbp), %rcx
-               	leaq	-0x380(%rbp), %rcx
-               	leaq	-0x3a0(%rbp), %r8
-               	movq	%r8, -0x19e0(%rbp)
-               	leaq	-0x3c0(%rbp), %rcx
-               	leaq	-0x3e0(%rbp), %rcx
-               	leaq	-0x400(%rbp), %r8
-               	movq	%r8, -0x19e8(%rbp)
-               	leaq	-0x420(%rbp), %rcx
-               	leaq	-0x440(%rbp), %rcx
+               	movq	%r8, -0xd20(%rbp)
+               	leaq	-0x300(%rbp), %r13
+               	leaq	-0x320(%rbp), %r13
+               	leaq	-0x340(%rbp), %r13
+               	leaq	-0x360(%rbp), %rbx
+               	leaq	-0x380(%rbp), %rbx
+               	leaq	-0x3a0(%rbp), %rbx
+               	leaq	-0x3c0(%rbp), %rdi
+               	leaq	-0x3e0(%rbp), %rdi
+               	leaq	-0x400(%rbp), %rdi
+               	leaq	-0x420(%rbp), %rdx
+               	leaq	-0x440(%rbp), %rdx
                	leaq	-0x460(%rbp), %r8
-               	movq	%r8, -0x19f0(%rbp)
-               	leaq	-0x480(%rbp), %rcx
-               	leaq	-0x4a0(%rbp), %rcx
+               	movq	%r8, -0xbf0(%rbp)
+               	leaq	-0x480(%rbp), %rdx
+               	leaq	-0x4a0(%rbp), %rdx
                	leaq	-0x4c0(%rbp), %r8
-               	movq	%r8, -0x19f8(%rbp)
-               	leaq	-0x4e0(%rbp), %rcx
-               	leaq	-0x500(%rbp), %rcx
+               	movq	%r8, -0xbf8(%rbp)
+               	leaq	-0x4e0(%rbp), %rdx
+               	leaq	-0x500(%rbp), %rdx
                	leaq	-0x520(%rbp), %r8
-               	movq	%r8, -0x1a00(%rbp)
-               	leaq	-0x540(%rbp), %rcx
-               	leaq	-0x560(%rbp), %rcx
+               	movq	%r8, -0xc00(%rbp)
+               	leaq	-0x540(%rbp), %rdx
+               	leaq	-0x560(%rbp), %rdx
                	leaq	-0x580(%rbp), %r8
-               	movq	%r8, -0x1a08(%rbp)
+               	movq	%r8, -0xc08(%rbp)
                	leaq	-0x5a0(%rbp), %r8
-               	movq	%r8, -0x1a10(%rbp)
-               	leaq	-0x5c0(%rbp), %rcx
-               	leaq	-0x5e0(%rbp), %rcx
+               	movq	%r8, -0xc10(%rbp)
+               	leaq	-0x5c0(%rbp), %rdx
+               	leaq	-0x5e0(%rbp), %rdx
                	leaq	-0x600(%rbp), %r8
-               	movq	%r8, -0x1a18(%rbp)
-               	leaq	-0x620(%rbp), %rcx
-               	leaq	-0x640(%rbp), %rcx
-               	leaq	-0x660(%rbp), %rcx
+               	movq	%r8, -0xc18(%rbp)
+               	leaq	-0x620(%rbp), %rdx
+               	leaq	-0x640(%rbp), %rdx
+               	leaq	-0x660(%rbp), %rdx
                	leaq	-0x680(%rbp), %r8
-               	movq	%r8, -0x1a20(%rbp)
-               	leaq	-0x6a0(%rbp), %rcx
-               	leaq	-0x6c0(%rbp), %rcx
-               	leaq	-0x6e0(%rbp), %rcx
+               	movq	%r8, -0xc20(%rbp)
+               	leaq	-0x6a0(%rbp), %rdx
+               	leaq	-0x6c0(%rbp), %rdx
+               	leaq	-0x6e0(%rbp), %rdx
                	leaq	-0x700(%rbp), %r8
-               	movq	%r8, -0x1a28(%rbp)
-               	leaq	-0x720(%rbp), %rcx
-               	leaq	-0x740(%rbp), %rcx
-               	leaq	-0x760(%rbp), %rcx
-               	leaq	-0x780(%rbp), %rcx
+               	movq	%r8, -0xc28(%rbp)
+               	leaq	-0x720(%rbp), %rdx
+               	leaq	-0x740(%rbp), %rdx
+               	leaq	-0x760(%rbp), %rdx
+               	leaq	-0x780(%rbp), %rdx
                	leaq	-0x7a0(%rbp), %r8
-               	movq	%r8, -0x1a30(%rbp)
-               	leaq	-0x7c0(%rbp), %rcx
-               	leaq	-0x7e0(%rbp), %rcx
+               	movq	%r8, -0xc30(%rbp)
+               	leaq	-0x7c0(%rbp), %rdx
+               	leaq	-0x7e0(%rbp), %rdx
                	leaq	-0x800(%rbp), %r8
-               	movq	%r8, -0x1a38(%rbp)
-               	leaq	-0x820(%rbp), %rcx
+               	movq	%r8, -0xc38(%rbp)
+               	leaq	-0x820(%rbp), %rdx
                	leaq	-0x840(%rbp), %r8
-               	movq	%r8, -0x1a40(%rbp)
+               	movq	%r8, -0xc40(%rbp)
                	leaq	-0x860(%rbp), %r8
-               	movq	%r8, -0x1a48(%rbp)
+               	movq	%r8, -0xc48(%rbp)
                	leaq	-0x880(%rbp), %r8
-               	movq	%r8, -0x1a50(%rbp)
-               	leaq	-0x8a0(%rbp), %rcx
-               	leaq	-0x8c0(%rbp), %rcx
-               	leaq	-0x8e0(%rbp), %rcx
-               	leaq	-0x900(%rbp), %rcx
-               	leaq	-0x920(%rbp), %rcx
-               	leaq	-0x940(%rbp), %rcx
-               	leaq	-0x960(%rbp), %rcx
-               	leaq	-0x980(%rbp), %rcx
-               	leaq	-0x9a0(%rbp), %rcx
-               	leaq	-0x9c0(%rbp), %rcx
-               	leaq	-0x9e0(%rbp), %rcx
-               	leaq	-0xa00(%rbp), %rcx
-               	leaq	-0xa20(%rbp), %rcx
-               	leaq	-0xa40(%rbp), %rcx
-               	leaq	-0xa60(%rbp), %rcx
-               	leaq	-0xa80(%rbp), %rcx
-               	leaq	-0xaa0(%rbp), %rcx
-               	leaq	-0xac0(%rbp), %rcx
-               	leaq	-0xae0(%rbp), %rcx
-               	leaq	-0xb00(%rbp), %rcx
-               	leaq	-0xb20(%rbp), %rcx
-               	leaq	-0xb40(%rbp), %rcx
-               	leaq	-0xb60(%rbp), %rcx
-               	leaq	-0xb80(%rbp), %rcx
-               	leaq	-0xba0(%rbp), %rcx
-               	leaq	-0xbc0(%rbp), %rcx
-               	leaq	-0xbe0(%rbp), %rcx
-               	leaq	-0xc00(%rbp), %rcx
-               	leaq	-0xc20(%rbp), %rcx
-               	leaq	-0xc40(%rbp), %rcx
-               	leaq	-0xc60(%rbp), %rcx
-               	leaq	-0xc80(%rbp), %rcx
-               	leaq	-0xca0(%rbp), %rcx
-               	leaq	-0xcc0(%rbp), %rcx
-               	leaq	-0xce0(%rbp), %rcx
-               	leaq	-0xd00(%rbp), %rcx
-               	leaq	-0xd20(%rbp), %rcx
-               	leaq	-0xd40(%rbp), %rcx
-               	leaq	-0xd60(%rbp), %rcx
-               	leaq	-0xd80(%rbp), %rcx
-               	leaq	-0xda0(%rbp), %rcx
-               	leaq	-0xdc0(%rbp), %rcx
-               	leaq	-0xde0(%rbp), %rcx
-               	leaq	-0xe00(%rbp), %rcx
-               	leaq	-0xe20(%rbp), %rcx
-               	leaq	-0xe40(%rbp), %rcx
-               	leaq	-0xe60(%rbp), %rcx
-               	leaq	-0xe80(%rbp), %rcx
-               	leaq	-0xea0(%rbp), %rcx
-               	leaq	-0xec0(%rbp), %rcx
-               	leaq	-0xee0(%rbp), %rcx
-               	leaq	-0xf00(%rbp), %rcx
-               	leaq	-0xf20(%rbp), %rcx
-               	leaq	-0xf40(%rbp), %rcx
-               	leaq	-0xf60(%rbp), %rcx
-               	leaq	-0xf80(%rbp), %rcx
-               	leaq	-0xfa0(%rbp), %rcx
-               	leaq	-0xfc0(%rbp), %rcx
-               	leaq	-0xfe0(%rbp), %rcx
-               	leaq	-0x1000(%rbp), %rcx
-               	leaq	-0x1020(%rbp), %rcx
-               	leaq	-0x1040(%rbp), %rcx
-               	leaq	-0x1060(%rbp), %rcx
-               	leaq	-0x1080(%rbp), %rcx
-               	leaq	-0x10a0(%rbp), %rcx
-               	leaq	-0x10c0(%rbp), %rcx
-               	leaq	-0x10e0(%rbp), %rcx
-               	leaq	-0x1100(%rbp), %rcx
-               	leaq	-0x1120(%rbp), %rcx
-               	leaq	-0x1140(%rbp), %rcx
-               	leaq	-0x1160(%rbp), %rcx
-               	leaq	-0x1180(%rbp), %rcx
-               	leaq	-0x11a0(%rbp), %rcx
-               	leaq	-0x11c0(%rbp), %rcx
-               	leaq	-0x11e0(%rbp), %rcx
-               	leaq	-0x1200(%rbp), %rcx
-               	leaq	-0x1220(%rbp), %rcx
-               	leaq	-0x1240(%rbp), %rcx
-               	leaq	-0x1260(%rbp), %rcx
-               	leaq	-0x1280(%rbp), %rcx
-               	leaq	-0x12a0(%rbp), %rcx
-               	leaq	-0x12c0(%rbp), %rcx
-               	leaq	-0x12e0(%rbp), %rcx
-               	leaq	-0x1300(%rbp), %rcx
-               	leaq	-0x1320(%rbp), %rcx
-               	leaq	-0x1340(%rbp), %rcx
-               	leaq	-0x1360(%rbp), %rcx
-               	leaq	-0x1380(%rbp), %rcx
-               	leaq	-0x13a0(%rbp), %rcx
-               	leaq	-0x13c0(%rbp), %rcx
-               	leaq	-0x13e0(%rbp), %rcx
-               	leaq	-0x1400(%rbp), %rcx
-               	leaq	-0x1420(%rbp), %rcx
-               	leaq	-0x1440(%rbp), %rcx
-               	leaq	-0x1460(%rbp), %rcx
-               	leaq	-0x1480(%rbp), %rcx
-               	leaq	-0x14a0(%rbp), %rcx
-               	leaq	-0x14c0(%rbp), %rcx
-               	leaq	-0x14e0(%rbp), %rcx
-               	leaq	-0x1500(%rbp), %rcx
-               	leaq	-0x1520(%rbp), %rcx
-               	leaq	-0x1540(%rbp), %rcx
-               	leaq	-0x1560(%rbp), %rcx
-               	leaq	-0x1580(%rbp), %rcx
-               	leaq	-0x15a0(%rbp), %rcx
-               	leaq	-0x15c0(%rbp), %rcx
-               	leaq	-0x15e0(%rbp), %rcx
-               	leaq	-0x1600(%rbp), %rcx
-               	leaq	-0x1620(%rbp), %rcx
-               	leaq	-0x1640(%rbp), %rcx
-               	leaq	-0x1660(%rbp), %rcx
-               	leaq	-0x1680(%rbp), %rcx
-               	leaq	-0x16a0(%rbp), %rcx
-               	leaq	-0x16c0(%rbp), %rcx
-               	leaq	-0x16e0(%rbp), %rcx
-               	leaq	-0x1700(%rbp), %rcx
-               	leaq	-0x1720(%rbp), %rcx
-               	leaq	-0x1740(%rbp), %rcx
-               	leaq	-0x1760(%rbp), %rcx
-               	leaq	-0x1780(%rbp), %rcx
-               	leaq	-0x17a0(%rbp), %rcx
-               	leaq	-0x17c0(%rbp), %rcx
-               	leaq	-0x17e0(%rbp), %rcx
-               	leaq	-0x1800(%rbp), %rcx
-               	leaq	-0x1820(%rbp), %rcx
-               	leaq	-0x1840(%rbp), %rcx
-               	leaq	-0x1860(%rbp), %rcx
-               	leaq	-0x1880(%rbp), %rcx
-               	callq	 <L1>
-<L1>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0xc50(%rbp)
+               	movq	-0xbc8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L2>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L3>
-<L2>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x9e0(%rbp), %r8
+               	movq	%r8, -0xc58(%rbp)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2fd>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x304>
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movl	$0x40700000, (%rdx)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x32c>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x333>
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movl	$0x40c80000, (%rdx)     # imm = 0x40C80000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x35b>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x362>
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movl	$0x3f400000, (%rdx)     # imm = 0x3F400000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x38a>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x391>
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc58(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0xa00(%rbp), %r8
+               	movq	%r8, -0xc60(%rbp)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3f000000, (%rdx)     # imm = 0x3F000000
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movl	$0x40800000, (%rdx)     # imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x4c5>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x4cc>
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movl	$0x41000000, (%rdx)     # imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x4f4>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x4fb>
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movl	$0x3fa00000, (%rdx)     # imm = 0x3FA00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x523>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x52a>
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movl	$0x3d800000, (%rdx)     # imm = 0x3D800000
+               	movq	-0xc60(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc60(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0xa20(%rbp), %r8
+               	movq	%r8, -0xc68(%rbp)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movl	$0x3f800000, (%rdx)     # imm = 0x3F800000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movl	$0x40400000, (%rdx)     # imm = 0x40400000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movl	$0x41100000, (%rdx)     # imm = 0x41100000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movl	$0x41d80000, (%rdx)     # imm = 0x41D80000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movl	$0x42a20000, (%rdx)     # imm = 0x42A20000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movl	$0x43730000, (%rdx)     # imm = 0x43730000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movl	$0x44364000, (%rdx)     # imm = 0x44364000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movl	$0x4508b000, (%rdx)     # imm = 0x4508B000
+               	movq	-0xc68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x14(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x18(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xc68(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x1c(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x14(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x18(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbe0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x1c(%r12), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xbd0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %r8
+               	movq	%r8, -0xc70(%rbp)
+               	movq	0x10(%r12), %r8
+               	movq	%r8, -0xc78(%rbp)
+               	movq	0x18(%r12), %r8
+               	movq	%r8, -0xc80(%rbp)
+               	movq	%rdx, -0xa40(%rbp)
+               	movq	-0xc70(%rbp), %r8
+               	movq	%r8, -0xa38(%rbp)
+               	movq	-0xc78(%rbp), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	-0xc80(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	leaq	-0xa40(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %r8
+               	movq	%r8, -0xc88(%rbp)
+               	movq	-0xc88(%rbp), %r8
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %r8
+               	movq	%r8, -0xc90(%rbp)
+               	movq	0x10(%r14), %r8
+               	movq	%r8, -0xc98(%rbp)
+               	movq	0x18(%r14), %r8
+               	movq	%r8, -0xca0(%rbp)
+               	movq	%rdx, -0xa60(%rbp)
+               	movq	-0xc90(%rbp), %r8
+               	movq	%r8, -0xa58(%rbp)
+               	movq	-0xc98(%rbp), %r8
+               	movq	%r8, -0xa50(%rbp)
+               	movq	-0xca0(%rbp), %r8
+               	movq	%r8, -0xa48(%rbp)
+               	leaq	-0xa60(%rbp), %rdx
+               	movq	-0xc88(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L3>
 <L3>:
-               	leaq	-0x18a0(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3fc00000, (%rbx)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x68f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x696>
-               	leaq	0x4(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movl	$0x40700000, (%rbx)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6b0>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6b7>
-               	leaq	0xc(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movl	$0x40c80000, (%rbx)     # imm = 0x40C80000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6d1>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6d8>
-               	leaq	0x14(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rcx), %rbx
-               	movl	$0x3f400000, (%rbx)     # imm = 0x3F400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6f2>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6f9>
-               	leaq	0x1c(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%rsi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%rsi), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	-0x18c0(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rcx), %rbx
-               	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7a1>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7a8>
-               	leaq	0x8(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movl	$0x41000000, (%rbx)     # imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7c2>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7c9>
-               	leaq	0x10(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rcx), %rbx
-               	movl	$0x3fa00000, (%rbx)     # imm = 0x3FA00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7e3>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7ea>
-               	leaq	0x18(%rcx), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
-               	movl	$0x3d800000, (%rbx)     # imm = 0x3D800000
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%rdi), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	-0x18e0(%rbp), %rcx
-               	leaq	(%rcx), %rbx
-               	movl	$0x3f800000, (%rbx)     # imm = 0x3F800000
-               	leaq	0x4(%rcx), %rbx
-               	movl	$0x40400000, (%rbx)     # imm = 0x40400000
-               	leaq	0x8(%rcx), %rbx
-               	movl	$0x41100000, (%rbx)     # imm = 0x41100000
-               	leaq	0xc(%rcx), %rbx
-               	movl	$0x41d80000, (%rbx)     # imm = 0x41D80000
-               	leaq	0x10(%rcx), %rbx
-               	movl	$0x42a20000, (%rbx)     # imm = 0x42A20000
-               	leaq	0x14(%rcx), %rbx
-               	movl	$0x43730000, (%rbx)     # imm = 0x43730000
-               	leaq	0x18(%rcx), %rbx
-               	movl	$0x44364000, (%rbx)     # imm = 0x44364000
-               	leaq	0x1c(%rcx), %rbx
-               	movl	$0x4508b000, (%rbx)     # imm = 0x4508B000
-               	leaq	(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r12), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x14(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x14(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x18(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x18(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x1c(%rsi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x1c(%r13), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	(%r13), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x4(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x8(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x10(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x14(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x18(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x1c(%r14), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x4(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x8(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0xc(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x10(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x10(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x14(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x14(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x18(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x18(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0x1c(%rdi), %rcx
-               	movss	(%rcx), %xmm1
-               	leaq	0x1c(%r15), %rcx
-               	movss	%xmm1, (%rcx)
-               	leaq	0xc(%r15), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0xca8(%rbp)
+               	movq	-0xca8(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x14(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x18(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x1c(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%r15), %rdx
+               	movq	0x8(%r15), %r8
+               	movq	%r8, -0xcb0(%rbp)
+               	movq	0x10(%r15), %r8
+               	movq	%r8, -0xcb8(%rbp)
+               	movq	0x18(%r15), %r8
+               	movq	%r8, -0xcc0(%rbp)
+               	movq	%rdx, -0xa80(%rbp)
+               	movq	-0xcb0(%rbp), %r8
+               	movq	%r8, -0xa78(%rbp)
+               	movq	-0xcb8(%rbp), %r8
+               	movq	%r8, -0xa70(%rbp)
+               	movq	-0xcc0(%rbp), %r8
+               	movq	%r8, -0xa68(%rbp)
+               	leaq	-0xa80(%rbp), %rdx
+               	movq	-0xca8(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0xcc8(%rbp)
+               	movq	-0xcc8(%rbp), %r8
+               	leaq	(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x4(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x4(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x8(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x8(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0xc(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0xc(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x10(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x10(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x14(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x14(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x14(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x18(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x18(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x18(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x1c(%r12), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x1c(%r14), %r15
+               	movss	(%r15), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xd20(%rbp), %r8
+               	leaq	0x1c(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0xd20(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0xd20(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0xd20(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0xcd0(%rbp)
+               	movq	-0xd20(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0xcd8(%rbp)
+               	movq	%r15, -0xaa0(%rbp)
+               	movq	%rdx, -0xa98(%rbp)
+               	movq	-0xcd0(%rbp), %r8
+               	movq	%r8, -0xa90(%rbp)
+               	movq	-0xcd8(%rbp), %r8
+               	movq	%r8, -0xa88(%rbp)
+               	leaq	-0xaa0(%rbp), %rdx
+               	movq	-0xcc8(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0xce0(%rbp)
+               	movq	-0xce0(%rbp), %r8
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x4(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x8(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0xc(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x10(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x14(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x18(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x1c(%r13), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%r13), %rdx
+               	movq	0x8(%r13), %r15
+               	movq	0x10(%r13), %rax
+               	movq	0x18(%r13), %r8
+               	movq	%r8, -0xce8(%rbp)
+               	movq	%rdx, -0xac0(%rbp)
+               	movq	%r15, -0xab8(%rbp)
+               	movq	%rax, -0xab0(%rbp)
+               	movq	-0xce8(%rbp), %r8
+               	movq	%r8, -0xaa8(%rbp)
+               	leaq	-0xac0(%rbp), %rdx
+               	movq	-0xce0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%rax, %r8
+               	movq	%r8, -0xcf0(%rbp)
+               	movq	-0xcf0(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x4(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x8(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0xc(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x10(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x14(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x18(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	leaq	0x1c(%rbx), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %r13
+               	movq	0x10(%rbx), %r15
+               	movq	0x18(%rbx), %rax
+               	movq	%rdx, -0xae0(%rbp)
+               	movq	%r13, -0xad8(%rbp)
+               	movq	%r15, -0xad0(%rbp)
+               	movq	%rax, -0xac8(%rbp)
+               	leaq	-0xae0(%rbp), %rdx
+               	movq	-0xcf0(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L7>
 <L7>:
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x4(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x8(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0xc(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x10(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x14(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x18(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	leaq	0x1c(%rdi), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %rbx
+               	movq	0x10(%rdi), %r13
+               	movq	0x18(%rdi), %r15
+               	movq	%rdx, -0xb00(%rbp)
+               	movq	%rbx, -0xaf8(%rbp)
+               	movq	%r13, -0xaf0(%rbp)
+               	movq	%r15, -0xae8(%rbp)
+               	leaq	-0xb00(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L8>
 <L8>:
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xbf0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xbf0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xbf0(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0xbf0(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xbf0(%rbp), %r8
+               	movq	0x18(%r8), %r13
+               	movq	%rdx, -0xb20(%rbp)
+               	movq	%rbx, -0xb18(%rbp)
+               	movq	%rdi, -0xb10(%rbp)
+               	movq	%r13, -0xb08(%rbp)
+               	leaq	-0xb20(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L9>
 <L9>:
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rsi), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xbf8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xbf8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xbf8(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0xbf8(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xbf8(%rbp), %r8
+               	movq	0x18(%r8), %r13
+               	movq	%rdx, -0xb40(%rbp)
+               	movq	%rbx, -0xb38(%rbp)
+               	movq	%rdi, -0xb30(%rbp)
+               	movq	%r13, -0xb28(%rbp)
+               	leaq	-0xb40(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L10>
 <L10>:
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xc00(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xc00(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xc00(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0xc00(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xc00(%rbp), %r8
+               	movq	0x18(%r8), %r13
+               	movq	%rdx, -0xb60(%rbp)
+               	movq	%rbx, -0xb58(%rbp)
+               	movq	%rdi, -0xb50(%rbp)
+               	movq	%r13, -0xb48(%rbp)
+               	leaq	-0xb60(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L11>
 <L11>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xc08(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xc08(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xc08(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0xc08(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xc08(%rbp), %r8
+               	movq	0x18(%r8), %r13
+               	movq	%rdx, -0xb80(%rbp)
+               	movq	%rbx, -0xb78(%rbp)
+               	movq	%rdi, -0xb70(%rbp)
+               	movq	%r13, -0xb68(%rbp)
+               	leaq	-0xb80(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L12>
 <L12>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
-<L13>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
-<L14>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
-<L15>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L19>
-<L19>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L20>
-<L20>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L21>
-<L21>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L26>
-<L26>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L36>
-<L36>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L41>
-<L41>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L42>
-<L42>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L43>
-<L43>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L47>
-<L47>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L58>
-<L58>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L59>
-<L59>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L60>
-<L60>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L66>
-<L66>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
-<L67>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L72>
-<L72>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L74>
-<L74>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L75>
-<L75>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L76>
-<L76>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L77>
-<L77>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L78>
-<L78>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L79>
-<L79>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L80>
-<L80>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L82>
-<L82>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L84>
-<L84>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L85>
-<L85>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L86>
-<L86>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L87>
-<L87>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L88>
-<L88>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L89>
-<L89>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L90>
-<L90>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L91>
-<L91>:
-               	leaq	-0x19c0(%rbp), %rcx
-               	leaq	(%rcx), %rbx
+               	leaq	-0xba0(%rbp), %rdx
+               	leaq	(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x4(%rcx), %rbx
+               	leaq	0x4(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x8(%rcx), %rbx
+               	leaq	0x8(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0xc(%rcx), %rbx
+               	leaq	0xc(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x10(%rcx), %rbx
+               	leaq	0x10(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x14(%rcx), %rbx
+               	leaq	0x14(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x18(%rcx), %rbx
+               	leaq	0x18(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
+               	leaq	0x1c(%rdx), %rbx
                	movl	$0x0, (%rbx)
-               	leaq	(%rcx), %rbx
+               	leaq	(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x4(%rcx), %rbx
+               	leaq	0x4(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0x4(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x8(%rcx), %rbx
+               	leaq	0x8(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0x8(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0xc(%rcx), %rbx
+               	leaq	0xc(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0xc(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x10(%rcx), %rbx
+               	leaq	0x10(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0x10(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x14(%rcx), %rbx
+               	leaq	0x14(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0x14(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x18(%rcx), %rbx
+               	leaq	0x18(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
+               	movq	-0xc10(%rbp), %r8
                	leaq	0x18(%r8), %rbx
                	movss	%xmm0, (%rbx)
-               	leaq	0x1c(%rcx), %rbx
+               	leaq	0x1c(%rdx), %rbx
                	movss	(%rbx), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
+               	movq	-0xc10(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
                	movq	%rax, %rbx
-               	movq	-0x1a10(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L92>
-               	jmp	 <L117>
-<L92>:
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm0
+               	movq	-0xc10(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x6, %r13
+               	jb	 <L13>
+               	jmp	 <L17>
+<L13>:
                	leaq	(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x10(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x14(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x14(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x14(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x18(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x18(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x18(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x1c(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x1c(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
+               	movq	-0xc18(%rbp), %r8
                	leaq	0x1c(%r8), %rax
                	movss	%xmm2, (%rax)
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xc18(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0xc18(%rbp), %r8
+               	movq	0x10(%r8), %r15
+               	movq	-0xc18(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0xcf8(%rbp)
+               	movq	%rax, -0x8a0(%rbp)
+               	movq	%rdx, -0x898(%rbp)
+               	movq	%r15, -0x890(%rbp)
+               	movq	-0xcf8(%rbp), %r8
+               	movq	%r8, -0x888(%rbp)
+               	leaq	-0x8a0(%rbp), %rdx
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L93>
-<L93>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L94>
-<L94>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L95>
-<L95>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L96>
-<L96>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L97>
-<L97>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L98>
-<L98>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L99>
-<L99>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L100>
-<L100>:
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %r8
+               	movq	%r8, -0xd00(%rbp)
+               	movq	-0xd00(%rbp), %r8
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xc18(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L101>
-<L101>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L102>
-<L102>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L103>
-<L103>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L104>
-<L104>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L106>
-<L106>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L107>
-<L107>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L108>
-<L108>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc20(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xc20(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xc20(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0xc20(%rbp), %r8
+               	movq	0x10(%r8), %rax
+               	movq	-0xc20(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0xd08(%rbp)
+               	movq	%rdx, -0x8c0(%rbp)
+               	movq	%r15, -0x8b8(%rbp)
+               	movq	%rax, -0x8b0(%rbp)
+               	movq	-0xd08(%rbp), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	-0x8c0(%rbp), %rdx
+               	movq	-0xd00(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %r8
+               	movq	%r8, -0xd10(%rbp)
+               	movq	-0xd10(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L109>
-<L109>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L110>
-<L110>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L111>
-<L111>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L112>
-<L112>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L113>
-<L113>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L114>
-<L114>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L115>
-<L115>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L116>
-<L116>:
-               	addq	$0x1, %rdi
+               	movq	-0xc28(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xc28(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0xc28(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	-0xc28(%rbp), %r8
+               	movq	0x10(%r8), %rax
+               	movq	-0xc28(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0xd18(%rbp)
+               	movq	%rdx, -0x8e0(%rbp)
+               	movq	%r15, -0x8d8(%rbp)
+               	movq	%rax, -0x8d0(%rbp)
+               	movq	-0xd18(%rbp), %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	leaq	-0x8e0(%rbp), %rdx
+               	movq	-0xd10(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L16>
+<L16>:
+               	addq	$0x1, %r13
                	movq	%rax, %rbx
-               	movq	-0x1a28(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	-0x1a20(%rbp), %r8
-               	movq	%r8, %rsi
-               	cmpq	$0x6, %rdi
-               	jb	 <L92>
-<L117>:
-               	leaq	-0x1960(%rbp), %rdi
-               	leaq	(%rdi), %rax
+               	movq	-0xc28(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0xc20(%rbp), %r8
+               	movq	%r8, %rdi
+               	cmpq	$0x6, %r13
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x960(%rbp), %r13
+               	leaq	(%r13), %rax
                	addq	$0x0, %rax
-               	movq	$0x80, %rcx
-<L118>:
+               	movq	$0x80, %rdx
+<L18>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L118>
-               	leaq	(%rdi), %rax
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x20(%rdi), %rax
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm0
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L18>
+               	leaq	(%r13), %rax
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rax), %rdx
+               	movss	%xmm0, (%rdx)
                	leaq	(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x10(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x14(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x14(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0x14(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x18(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x18(%r14), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
                	leaq	0x18(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm0
                	leaq	0x1c(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x1c(%r14), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x20(%r13), %rax
+               	movq	-0xc30(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc30(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%rsi), %rax
                	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
+               	movq	-0xc38(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x10(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x14(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x18(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x1c(%r12), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xc38(%rbp), %r8
                	leaq	0x1c(%r8), %rax
                	movss	%xmm2, (%rax)
-               	leaq	0x40(%rdi), %rax
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x60(%rdi), %rax
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
+               	leaq	0x40(%r13), %rax
+               	movq	-0xc38(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0xc38(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x60(%r13), %rax
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rax), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rax), %rdx
+               	movss	%xmm0, (%rdx)
                	movq	$0x0, %rsi
                	cmpq	$0x4, %rsi
-               	jb	 <L119>
-               	jmp	 <L128>
-<L119>:
+               	jb	 <L19>
+               	jmp	 <L21>
+<L19>:
                	movq	%rsi, %rax
                	imulq	$0x20, %rax, %rax
-               	leaq	(%rdi,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	leaq	(%r13,%rax), %rdx
+               	leaq	(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
+               	leaq	0x4(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
+               	leaq	0x8(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
+               	leaq	0xc(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
+               	leaq	0x10(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x14(%rcx), %rax
+               	leaq	0x14(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x14(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x18(%rcx), %rax
+               	leaq	0x18(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x18(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x1c(%rcx), %rax
+               	leaq	0x1c(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
+               	movq	-0xc40(%rbp), %r8
                	leaq	0x1c(%r8), %rax
                	movss	%xmm0, (%rax)
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
+               	movq	-0xc40(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xc40(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0xc40(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xc40(%rbp), %r8
+               	movq	0x18(%r8), %r12
+               	movq	%rax, -0x980(%rbp)
+               	movq	%rdx, -0x978(%rbp)
+               	movq	%rdi, -0x970(%rbp)
+               	movq	%r12, -0x968(%rbp)
+               	leaq	-0x980(%rbp), %rdx
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L120>
-<L120>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L121>
-<L121>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L122>
-<L122>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L123>
-<L123>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L124>
-<L124>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L125>
-<L125>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L126>
-<L126>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L127>
-<L127>:
+               	callq	 <L20>
+<L20>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
                	cmpq	$0x4, %rsi
-               	jb	 <L119>
-<L128>:
-               	leaq	-0x19a0(%rbp), %rsi
+               	jb	 <L19>
+<L21>:
+               	leaq	-0x9c0(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -2859,204 +2324,201 @@ Disassembly of section .text:
                	movq	$0x0, 0x38(%rsi)
                	leaq	(%rsi), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x40(%rdi), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x40(%r13), %rdx
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x14(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x14(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x18(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x18(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x1c(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movq	-0xc48(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x4(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x8(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0xc(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x10(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x14(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x14(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x18(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x18(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0xc48(%rbp), %r8
+               	leaq	0x1c(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x1c(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x30(%rsi), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	leaq	0x10(%rsi), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x14(%rcx), %rdx
+               	leaq	0x14(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0x14(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x18(%rcx), %rdx
+               	leaq	0x18(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
+               	movq	-0xc50(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x1c(%rcx), %rdx
+               	leaq	0x1c(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rsi), %rdi
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rdi), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x30(%rsi), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %edx
+               	movq	-0xc50(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xc50(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xc50(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0xc50(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0xc50(%rbp), %r8
+               	movq	0x18(%r8), %r12
+               	movq	%rax, -0xbc0(%rbp)
+               	movq	%rdx, -0xbb8(%rbp)
+               	movq	%rdi, -0xbb0(%rbp)
+               	movq	%r12, -0xba8(%rbp)
+               	leaq	-0xbc0(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L130>
-<L130>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L131>
-<L131>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L132>
-<L132>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L133>
-<L133>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L134>
-<L134>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L135>
-<L135>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L136>
-<L136>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L137>
-<L137>:
-               	leaq	0x30(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L138>
-<L138>:
-               	movaps	-0x1ab0(%rbp), %xmm14
-               	movaps	-0x1ac0(%rbp), %xmm15
-               	movq	-0x1a68(%rbp), %rbx
-               	movq	-0x1a70(%rbp), %rdi
-               	movq	-0x1a78(%rbp), %rsi
-               	movq	-0x1a80(%rbp), %r12
-               	movq	-0x1a88(%rbp), %r13
-               	movq	-0x1a90(%rbp), %r14
-               	movq	-0x1a98(%rbp), %r15
+               	callq	 <L24>
+<L24>:
+               	leaq	0x30(%rsi), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+<L26>:
+               	movaps	-0xd70(%rbp), %xmm14
+               	movaps	-0xd80(%rbp), %xmm15
+               	movq	-0xd28(%rbp), %rbx
+               	movq	-0xd30(%rbp), %rdi
+               	movq	-0xd38(%rbp), %rsi
+               	movq	-0xd40(%rbp), %r12
+               	movq	-0xd48(%rbp), %r13
+               	movq	-0xd50(%rbp), %r14
+               	movq	-0xd58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_f64x2.dis
@@ -5,25 +5,69 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -31,38 +75,35 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2a0, %rsp            # imm = 0x2A0
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%rdi, -0x1e0(%rbp)
-               	movq	%rsi, -0x1e8(%rbp)
-               	movq	%r12, -0x1f0(%rbp)
-               	movq	%r13, -0x1f8(%rbp)
-               	movaps	%xmm6, -0x210(%rbp)
-               	movaps	%xmm7, -0x220(%rbp)
-               	movaps	%xmm8, -0x230(%rbp)
-               	movaps	%xmm9, -0x240(%rbp)
-               	movaps	%xmm10, -0x250(%rbp)
-               	movaps	%xmm11, -0x260(%rbp)
-               	movaps	%xmm14, -0x270(%rbp)
-               	movaps	%xmm15, -0x280(%rbp)
+               	subq	$0x2b0, %rsp            # imm = 0x2B0
+               	movq	%rbx, -0x1f8(%rbp)
+               	movq	%rdi, -0x200(%rbp)
+               	movq	%rsi, -0x208(%rbp)
+               	movq	%r12, -0x210(%rbp)
+               	movq	%r13, -0x218(%rbp)
+               	movq	%r14, -0x220(%rbp)
+               	movaps	%xmm6, -0x230(%rbp)
+               	movaps	%xmm7, -0x240(%rbp)
+               	movaps	%xmm8, -0x250(%rbp)
+               	movaps	%xmm9, -0x260(%rbp)
+               	movaps	%xmm10, -0x270(%rbp)
+               	movaps	%xmm14, -0x280(%rbp)
+               	movaps	%xmm15, -0x290(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rbx
+<L1>:
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rsi)
@@ -70,9 +111,9 @@ Disassembly of section .text:
                	movabsq	$-0x3ffe000000000000, %r11 # imm = 0xC002000000000000
                	movq	%r11, (%rsi)
                	movups	(%rbx), %xmm1
-               	leaq	-0x20(%rbp), %rbx
+               	leaq	-0xd0(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xe0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movabsq	$0x3fe0000000000000, %r11 # imm = 0x3FE0000000000000
                	movq	%r11, (%rdi)
@@ -80,9 +121,9 @@ Disassembly of section .text:
                	movabsq	$0x4010000000000000, %r11 # imm = 0x4010000000000000
                	movq	%r11, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xf0(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x100(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movabsq	$0x3ff0000000000000, %r11 # imm = 0x3FF0000000000000
                	movq	%r11, (%r12)
@@ -94,242 +135,171 @@ Disassembly of section .text:
                	movsd	(%rdi), %xmm3
                	movsd	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1]
                	addsd	%xmm0, %xmm4
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x110(%rbp), %rbx
                	movups	%xmm1, (%rbx)
                	leaq	(%rbx), %rdi
                	movsd	%xmm4, (%rdi)
                	movups	(%rbx), %xmm7
-               	leaq	0x8(%rsi), %rdi
-               	movsd	(%rdi), %xmm1
-               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	addsd	%xmm0, %xmm3
-               	leaq	-0x70(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	0x8(%rsi), %rdi
-               	movsd	%xmm3, (%rdi)
-               	movups	(%rsi), %xmm8
-               	leaq	(%rbx), %rdi
-               	movsd	(%rdi), %xmm1
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdi
-               	movsd	(%rdi), %xmm1
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	leaq	(%rsi), %rbx
-               	movsd	(%rbx), %xmm1
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
                	leaq	0x8(%rsi), %rbx
                	movsd	(%rbx), %xmm1
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rcx
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	addsd	%xmm0, %xmm3
+               	leaq	-0x120(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	0x8(%rbx), %rsi
+               	movsd	%xmm3, (%rsi)
+               	movups	(%rbx), %xmm8
+               	movups	%xmm7, -0x130(%rbp)
+               	leaq	-0x130(%rbp), %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%rbx, %rdx
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rbx
+               	movups	%xmm8, -0x140(%rbp)
+               	leaq	-0x140(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L3>
+<L3>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	addpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	subpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x160(%rbp)
+               	leaq	-0x160(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	subpd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x180(%rbp)
+               	leaq	-0x180(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	divpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x190(%rbp)
+               	leaq	-0x190(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rbx
                	movaps	%xmm8, %xmm14
                	divpd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1a0(%rbp)
+               	leaq	-0x1a0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %rbx
                	movaps	%xmm7, %xmm14
                	mulpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	subpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rcx
+               	movups	%xmm0, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L11>
+<L11>:
+               	movq	%rax, %rbx
                	movaps	%xmm6, %xmm14
                	divpd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0x1d0(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	0x8(%rbx), %rsi
-               	movq	$0x0, (%rsi)
-               	movups	(%rbx), %xmm0
-               	movq	%rcx, %rbx
+               	movups	%xmm0, -0x1d0(%rbp)
+               	leaq	-0x1d0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L12>
+<L12>:
+               	movq	%rax, %rbx
+               	leaq	-0x1e0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	movups	(%rsi), %xmm0
                	movaps	%xmm0, %xmm9
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
+               	jb	 <L13>
+               	jmp	 <L17>
+<L13>:
                	movaps	%xmm7, %xmm14
                	mulpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	-0x80(%rbp), %rdi
-               	movups	%xmm10, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movsd	(%rcx), %xmm1
+               	movups	%xmm10, -0x10(%rbp)
+               	leaq	-0x10(%rbp), %rdi
                	movq	%rbx, %rcx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rdi
                	movaps	%xmm9, %xmm14
                	addpd	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x120(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x20(%rbp)
+               	leaq	-0x20(%rbp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
                	movaps	%xmm7, %xmm14
                	subpd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0x140(%rbp), %rdi
-               	movups	%xmm10, (%rdi)
-               	leaq	(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rdi), %r12
-               	movsd	(%r12), %xmm1
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x30(%rbp)
+               	leaq	-0x30(%rbp), %r12
+               	movq	%rdi, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rsi
-               	movq	%rcx, %rbx
-               	movaps	%xmm10, %xmm7
-               	movaps	%xmm11, %xmm9
                	cmpq	$0x6, %rsi
-               	jb	 <L25>
-<L32>:
-               	leaq	-0xc0(%rbp), %rsi
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x70(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -338,101 +308,123 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rsi)
                	movq	$0x0, 0x30(%rsi)
                	movq	$0x0, 0x38(%rsi)
-               	leaq	(%rsi), %rcx
-               	movups	%xmm7, (%rcx)
+               	leaq	(%rsi), %rdi
+               	movups	%xmm7, (%rdi)
                	movaps	%xmm7, %xmm14
                	addpd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%rsi), %rcx
-               	movups	%xmm0, (%rcx)
+               	leaq	0x10(%rsi), %rdi
+               	movups	%xmm0, (%rdi)
                	movaps	%xmm7, %xmm14
                	mulpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm7
-               	leaq	0x20(%rsi), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	0x30(%rsi), %rcx
-               	movups	%xmm9, (%rcx)
+               	leaq	0x20(%rsi), %rdi
+               	movups	%xmm7, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movups	%xmm9, (%rdi)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	movq	%rdi, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %r12
-               	movups	(%r12), %xmm0
-               	leaq	-0xd0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movsd	(%rcx), %xmm1
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%rdi, %r12
+               	imulq	$0x10, %r12, %r12
+               	leaq	(%rsi,%r12), %r13
+               	movups	(%r13), %xmm0
+               	movups	%xmm0, -0x80(%rbp)
+               	leaq	-0x80(%rbp), %r12
                	movq	%rbx, %rcx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%r12), %r13
-               	movsd	(%r13), %xmm1
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	movq	%r12, %rdx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %rdi
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x100(%rbp), %rdi
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xb0(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
                	movq	$0x0, 0x18(%rdi)
                	movq	$0x0, 0x20(%rdi)
                	movq	$0x0, 0x28(%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%rsi), %r12
-               	movups	(%r12), %xmm0
+               	leaq	(%rdi), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%rsi), %r13
+               	movups	(%r13), %xmm0
                	leaq	0x10(%rdi), %rsi
                	movups	%xmm0, (%rsi)
-               	leaq	0x20(%rdi), %r12
-               	movl	$0x12345678, (%r12)     # imm = 0x12345678
-               	movl	(%rcx), %r12d
-               	movq	%rbx, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rcx
+               	leaq	0x20(%rdi), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%r12), %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%rdi), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	-0x110(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rsi
-               	movsd	(%rsi), %xmm1
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rcx
-               	leaq	0x20(%rdi), %rbx
-               	movl	(%rbx), %esi
-               	movl	%esi, %edx
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movaps	-0x210(%rbp), %xmm6
-               	movaps	-0x220(%rbp), %xmm7
-               	movaps	-0x230(%rbp), %xmm8
-               	movaps	-0x240(%rbp), %xmm9
-               	movaps	-0x250(%rbp), %xmm10
-               	movaps	-0x260(%rbp), %xmm11
-               	movaps	-0x270(%rbp), %xmm14
-               	movaps	-0x280(%rbp), %xmm15
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %rdi
-               	movq	-0x1e8(%rbp), %rsi
-               	movq	-0x1f0(%rbp), %r12
-               	movq	-0x1f8(%rbp), %r13
+               	movups	%xmm0, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rsi
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rdx
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rbx
+               	leaq	0x20(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movaps	-0x230(%rbp), %xmm6
+               	movaps	-0x240(%rbp), %xmm7
+               	movaps	-0x250(%rbp), %xmm8
+               	movaps	-0x260(%rbp), %xmm9
+               	movaps	-0x270(%rbp), %xmm10
+               	movaps	-0x280(%rbp), %xmm14
+               	movaps	-0x290(%rbp), %xmm15
+               	movq	-0x1f8(%rbp), %rbx
+               	movq	-0x200(%rbp), %rdi
+               	movq	-0x208(%rbp), %rsi
+               	movq	-0x210(%rbp), %r12
+               	movq	-0x218(%rbp), %r13
+               	movq	-0x220(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_i16x4.dis
@@ -5,41 +5,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movq	%rdx, %xmm0
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x2(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0x6(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,38 +121,34 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1e0, %rsp            # imm = 0x1E0
-               	movq	%rbx, -0x108(%rbp)
-               	movq	%rdi, -0x110(%rbp)
-               	movq	%rsi, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movaps	%xmm6, -0x130(%rbp)
-               	movaps	%xmm7, -0x140(%rbp)
-               	movaps	%xmm8, -0x150(%rbp)
-               	movaps	%xmm9, -0x160(%rbp)
-               	movaps	%xmm10, -0x170(%rbp)
-               	movaps	%xmm11, -0x180(%rbp)
-               	movaps	%xmm12, -0x190(%rbp)
-               	movaps	%xmm13, -0x1a0(%rbp)
-               	movaps	%xmm14, -0x1b0(%rbp)
-               	movaps	%xmm15, -0x1c0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x8(%rbp), %rdx
-               	leaq	(%rdx), %rbx
+               	subq	$0x150, %rsp            # imm = 0x150
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movaps	%xmm6, -0xc0(%rbp)
+               	movaps	%xmm7, -0xd0(%rbp)
+               	movaps	%xmm8, -0xe0(%rbp)
+               	movaps	%xmm9, -0xf0(%rbp)
+               	movaps	%xmm10, -0x100(%rbp)
+               	movaps	%xmm11, -0x110(%rbp)
+               	movaps	%xmm14, -0x120(%rbp)
+               	movaps	%xmm15, -0x130(%rbp)
+               	movq	%rcx, %rax
+               	movw	%ax, %dx
+               	leaq	-0x44(%rbp), %rax
+               	leaq	(%rax), %rbx
                	movw	$0x3e9, (%rbx)          # imm = 0x3E9
-               	leaq	0x2(%rdx), %rbx
+               	leaq	0x2(%rax), %rbx
                	movw	$0xfbb1, (%rbx)         # imm = 0xFBB1
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x4(%rax), %rbx
                	movw	$0x4b7, (%rbx)          # imm = 0x4B7
-               	leaq	0x6(%rdx), %rbx
+               	leaq	0x6(%rax), %rbx
                	movw	$0xfaeb, (%rbx)         # imm = 0xFAEB
-               	movsd	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rdx
-               	movsd	%xmm0, (%rdx)
-               	leaq	-0x18(%rbp), %rbx
+               	movsd	(%rax), %xmm0
+               	leaq	-0x4c(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	-0x54(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movw	$0xd, (%rsi)
                	leaq	0x2(%rbx), %rsi
@@ -88,9 +158,9 @@ Disassembly of section .text:
                	leaq	0x6(%rbx), %rsi
                	movw	$0xfff9, (%rsi)         # imm = 0xFFF9
                	movsd	(%rbx), %xmm1
-               	leaq	-0x20(%rbp), %rbx
+               	leaq	-0x5c(%rbp), %rbx
                	movsd	%xmm1, (%rbx)
-               	leaq	-0x28(%rbp), %rsi
+               	leaq	-0x64(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x1, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -100,7 +170,7 @@ Disassembly of section .text:
                	leaq	0x6(%rsi), %rdi
                	movw	$0x4, (%rdi)
                	movsd	(%rsi), %xmm6
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x6c(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -110,448 +180,194 @@ Disassembly of section .text:
                	leaq	0x6(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	movsd	(%rsi), %xmm7
-               	leaq	(%rdx), %rsi
-               	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x38(%rbp), %rsi
+               	leaq	(%rax), %rsi
+               	movzwl	(%rsi), %eax
+               	addl	%edx, %eax
+               	leaq	-0x74(%rbp), %rsi
                	movsd	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
-               	movw	%dx, (%rdi)
+               	movw	%ax, (%rdi)
                	movsd	(%rsi), %xmm0
-               	leaq	0x6(%rsi), %rdx
-               	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x40(%rbp), %rdi
-               	movsd	%xmm0, (%rdi)
-               	leaq	0x6(%rdi), %rdx
-               	movw	%si, (%rdx)
-               	movsd	(%rdi), %xmm8
-               	leaq	0x2(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0x48(%rbp), %rdx
-               	movsd	%xmm1, (%rdx)
-               	leaq	0x2(%rdx), %rsi
+               	leaq	0x6(%rsi), %rax
+               	movzwl	(%rax), %esi
+               	addl	%edx, %esi
+               	leaq	-0x7c(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rdi
+               	movw	%si, (%rdi)
+               	movsd	(%rax), %xmm8
+               	leaq	0x2(%rbx), %rax
+               	movzwl	(%rax), %ebx
+               	addl	%edx, %ebx
+               	leaq	-0x84(%rbp), %rax
+               	movsd	%xmm1, (%rax)
+               	leaq	0x2(%rax), %rsi
                	movw	%bx, (%rsi)
-               	movsd	(%rdx), %xmm0
+               	movsd	(%rax), %xmm0
+               	leaq	0x4(%rax), %rbx
+               	movzwl	(%rbx), %eax
+               	addl	%edx, %eax
+               	leaq	-0x8c(%rbp), %rdx
+               	movsd	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rbx
-               	movzwl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x50(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	0x4(%rbx), %rcx
-               	movw	%dx, (%rcx)
-               	movsd	(%rbx), %xmm9
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movw	%ax, (%rbx)
+               	movsd	(%rdx), %xmm9
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	movq	%xmm8, %rdx
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rcx
+               	movq	%xmm9, %rdx
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L2>
-<L2>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L3>
-<L3>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L4>
-<L4>:
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xb4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
+               	movq	%xmm10, %rdx
+               	callq	 <L2>
+<L2>:
                	movaps	%xmm8, %xmm14
                	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xc4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
+               	movq	%xmm0, %rdx
+               	callq	 <L3>
+<L3>:
                	movaps	%xmm9, %xmm14
                	psubw	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xd4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
+               	movq	%xmm0, %rdx
+               	callq	 <L4>
+<L4>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xdc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
+               	movq	%xmm0, %rdx
+               	callq	 <L5>
+<L5>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xe4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	movq	%xmm0, %rdx
+               	callq	 <L6>
+<L6>:
                	movaps	%xmm9, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xec(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm8, %xmm14
-               	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	movq	%xmm0, %rdx
+               	callq	 <L7>
+<L7>:
+               	movaps	%xmm10, %xmm14
                	pmullw	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xf4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
+               	movq	%xmm10, %rdx
+               	callq	 <L8>
+<L8>:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xfc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
+               	movq	%xmm0, %rdx
+               	callq	 <L9>
+<L9>:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
                	movq	%xmm0, %rdx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L10>
+<L10>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
                	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
                	movq	%xmm10, %rdx
-               	callq	 <L42>
-<L42>:
+               	callq	 <L11>
+<L11>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
                	movaps	%xmm14, %xmm11
                	movq	%rax, %rcx
                	movq	%xmm11, %rdx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L12>
+<L12>:
                	movaps	%xmm8, %xmm14
                	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
                	movq	%xmm0, %rdx
-               	callq	 <L44>
-<L44>:
+               	callq	 <L13>
+<L13>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
                	movq	%xmm0, %rdx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L14>
+<L14>:
                	movaps	%xmm9, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
                	movq	%xmm0, %rdx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
                	movq	%xmm10, %rdx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L48>
-               	jmp	 <L65>
-<L48>:
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
-               	leaq	-0x58(%rbp), %rdi
-               	movsd	%xmm11, (%rdi)
-               	leaq	(%rdi), %rax
-               	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	movq	%xmm11, %rdx
+               	callq	 <L18>
+<L18>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0xac(%rbp), %rdi
-               	movsd	%xmm12, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	movq	%xmm10, %rdx
+               	callq	 <L19>
+<L19>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0xbc(%rbp), %rdi
-               	movsd	%xmm11, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm7
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movq	%xmm7, %rdx
+               	callq	 <L20>
+<L20>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm13
-               	leaq	-0xcc(%rbp), %rdi
-               	movsd	%xmm13, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm8
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
+               	movq	%xmm8, %rdx
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
-               	movaps	%xmm13, %xmm8
-               	movaps	%xmm12, %xmm10
-               	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L48>
-<L65>:
-               	leaq	-0x88(%rbp), %rsi
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x30(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -581,95 +397,94 @@ Disassembly of section .text:
                	movsd	%xmm8, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x6, %rdi
-               	jb	 <L66>
-               	jmp	 <L71>
-<L66>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	leaq	(%rsi,%rdi,8), %rax
                	movsd	(%rax), %xmm0
-               	leaq	-0x90(%rbp), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	(%r12), %rax
-               	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
+               	movq	%xmm0, %rdx
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x6, %rdi
-               	jb	 <L66>
-<L71>:
-               	leaq	-0x9c(%rbp), %rdi
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x3c(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movl	$0x0, 0x8(%rdi)
                	leaq	(%rdi), %rax
                	movb	$-0x25, (%rax)
-               	leaq	0x10(%rsi), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	0x2(%rdi), %rsi
-               	movsd	%xmm0, (%rsi)
-               	leaq	0xa(%rdi), %rcx
-               	movb	$-0x53, (%rcx)
+               	leaq	0x10(%rsi), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x2(%rdi), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	0xa(%rdi), %rdx
+               	movb	$-0x53, (%rdx)
                	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x2(%rdi), %rax
+               	movsd	(%rax), %xmm0
                	movq	%rbx, %rcx
-               	callq	 <L72>
-<L72>:
-               	movsd	(%rsi), %xmm0
-               	leaq	-0xa4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
-               	movaps	-0x130(%rbp), %xmm6
-               	movaps	-0x140(%rbp), %xmm7
-               	movaps	-0x150(%rbp), %xmm8
-               	movaps	-0x160(%rbp), %xmm9
-               	movaps	-0x170(%rbp), %xmm10
-               	movaps	-0x180(%rbp), %xmm11
-               	movaps	-0x190(%rbp), %xmm12
-               	movaps	-0x1a0(%rbp), %xmm13
-               	movaps	-0x1b0(%rbp), %xmm14
-               	movaps	-0x1c0(%rbp), %xmm15
-               	movq	-0x108(%rbp), %rbx
-               	movq	-0x110(%rbp), %rdi
-               	movq	-0x118(%rbp), %rsi
-               	movq	-0x120(%rbp), %r12
+               	movq	%xmm0, %rdx
+               	callq	 <L28>
+<L28>:
+               	leaq	0xa(%rdi), %rdx
+               	movzbl	(%rdx), %ebx
+               	movzbq	%bl, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+<L30>:
+               	movaps	-0xc0(%rbp), %xmm6
+               	movaps	-0xd0(%rbp), %xmm7
+               	movaps	-0xe0(%rbp), %xmm8
+               	movaps	-0xf0(%rbp), %xmm9
+               	movaps	-0x100(%rbp), %xmm10
+               	movaps	-0x110(%rbp), %xmm11
+               	movaps	-0x120(%rbp), %xmm14
+               	movaps	-0x130(%rbp), %xmm15
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-windows/vec/vec_i16x8.dis
@@ -5,65 +5,207 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x2(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	leaq	0x6(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movswq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movswq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -72,45 +214,41 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x340, %rsp            # imm = 0x340
-               	movq	%rbx, -0x268(%rbp)
-               	movq	%rdi, -0x270(%rbp)
-               	movq	%rsi, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movaps	%xmm6, -0x290(%rbp)
-               	movaps	%xmm7, -0x2a0(%rbp)
-               	movaps	%xmm8, -0x2b0(%rbp)
-               	movaps	%xmm9, -0x2c0(%rbp)
-               	movaps	%xmm10, -0x2d0(%rbp)
-               	movaps	%xmm11, -0x2e0(%rbp)
-               	movaps	%xmm12, -0x2f0(%rbp)
-               	movaps	%xmm13, -0x300(%rbp)
+               	movq	%rbx, -0x288(%rbp)
+               	movq	%rdi, -0x290(%rbp)
+               	movq	%rsi, -0x298(%rbp)
+               	movq	%r12, -0x2a0(%rbp)
+               	movaps	%xmm6, -0x2b0(%rbp)
+               	movaps	%xmm7, -0x2c0(%rbp)
+               	movaps	%xmm8, -0x2d0(%rbp)
+               	movaps	%xmm9, -0x2e0(%rbp)
+               	movaps	%xmm10, -0x2f0(%rbp)
+               	movaps	%xmm11, -0x300(%rbp)
                	movaps	%xmm14, -0x310(%rbp)
                	movaps	%xmm15, -0x320(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rbx
+               	movq	%rcx, %rax
+               	movw	%ax, %dx
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rbx
                	movw	$0x3e9, (%rbx)          # imm = 0x3E9
-               	leaq	0x2(%rdx), %rbx
+               	leaq	0x2(%rax), %rbx
                	movw	$0xfbb1, (%rbx)         # imm = 0xFBB1
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x4(%rax), %rbx
                	movw	$0x4b7, (%rbx)          # imm = 0x4B7
-               	leaq	0x6(%rdx), %rbx
+               	leaq	0x6(%rax), %rbx
                	movw	$0xfaeb, (%rbx)         # imm = 0xFAEB
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rax), %rbx
                	movw	$0x581, (%rbx)          # imm = 0x581
-               	leaq	0xa(%rdx), %rbx
+               	leaq	0xa(%rax), %rbx
                	movw	$0xfa19, (%rbx)         # imm = 0xFA19
-               	leaq	0xc(%rdx), %rbx
+               	leaq	0xc(%rax), %rbx
                	movw	$0x641, (%rbx)          # imm = 0x641
-               	leaq	0xe(%rdx), %rbx
+               	leaq	0xe(%rax), %rbx
                	movw	$0xf953, (%rbx)         # imm = 0xF953
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movw	$0xd, (%rsi)
                	leaq	0x2(%rbx), %rsi
@@ -128,9 +266,9 @@ Disassembly of section .text:
                	leaq	0xe(%rbx), %rsi
                	movw	$0xffff, (%rsi)         # imm = 0xFFFF
                	movups	(%rbx), %xmm1
-               	leaq	-0x40(%rbp), %rbx
+               	leaq	-0x100(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x110(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x1, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -148,7 +286,7 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0x8, (%rdi)
                	movups	(%rsi), %xmm6
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x120(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -166,735 +304,215 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	movups	(%rsi), %xmm7
-               	leaq	(%rdx), %rsi
-               	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rsi
+               	leaq	(%rax), %rsi
+               	movzwl	(%rsi), %eax
+               	addl	%edx, %eax
+               	leaq	-0x130(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
-               	movw	%dx, (%rdi)
+               	movw	%ax, (%rdi)
                	movups	(%rsi), %xmm0
-               	leaq	0xc(%rsi), %rdx
-               	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x80(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rdx
-               	movw	%si, (%rdx)
-               	movups	(%rdi), %xmm8
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0x90(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x4(%rdx), %rsi
+               	leaq	0xc(%rsi), %rax
+               	movzwl	(%rax), %esi
+               	addl	%edx, %esi
+               	leaq	-0x140(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movw	%si, (%rdi)
+               	movups	(%rax), %xmm8
+               	leaq	0x4(%rbx), %rax
+               	movzwl	(%rax), %ebx
+               	addl	%edx, %ebx
+               	leaq	-0x150(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x4(%rax), %rsi
                	movw	%bx, (%rsi)
-               	movups	(%rdx), %xmm0
+               	movups	(%rax), %xmm0
+               	leaq	0xe(%rax), %rbx
+               	movzwl	(%rbx), %eax
+               	addl	%edx, %eax
+               	leaq	-0x160(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
                	leaq	0xe(%rdx), %rbx
-               	movzwl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xe(%rbx), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%rbx), %xmm9
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movw	%ax, (%rbx)
+               	movups	(%rdx), %xmm9
+               	movups	%xmm8, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm9, -0x180(%rbp)
+               	leaq	-0x180(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	paddw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x190(%rbp)
+               	leaq	-0x190(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	psubw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1a0(%rbp)
+               	leaq	-0x1a0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm9, %xmm14
+               	psubw	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm8, %xmm14
-               	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm8, %xmm14
-               	psubw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm9, %xmm14
-               	psubw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L5>
+<L5>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1d0(%rbp)
+               	leaq	-0x1d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	callq	 <L6>
+<L6>:
                	movaps	%xmm9, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1e0(%rbp)
+               	leaq	-0x1e0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movaps	%xmm8, %xmm14
-               	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	callq	 <L7>
+<L7>:
+               	movaps	%xmm10, %xmm14
                	pmullw	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L8>
+<L8>:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
-               	movaps	%xmm7, %xmm14
-               	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x200(%rbp)
                	leaq	-0x200(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm7, %xmm14
+               	psubw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x210(%rbp)
-               	leaq	-0x210(%rbp), %rdx
+               	movups	%xmm10, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
+               	callq	 <L11>
+<L11>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
                	movaps	%xmm14, %xmm11
-               	movups	%xmm11, -0x220(%rbp)
-               	leaq	-0x220(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	movaps	%xmm8, %xmm14
-               	pxor	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x230(%rbp)
+               	movups	%xmm11, -0x230(%rbp)
                	leaq	-0x230(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L12>
+<L12>:
                	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x240(%rbp)
                	leaq	-0x240(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	movaps	%xmm9, %xmm14
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x250(%rbp)
                	leaq	-0x250(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm9, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x260(%rbp)
-               	leaq	-0x260(%rbp), %rdx
+               	movups	%xmm10, -0x270(%rbp)
+               	leaq	-0x270(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
-               	leaq	-0xb0(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %rax
-               	movzwl	(%rax), %edx
+               	movups	%xmm11, -0x10(%rbp)
+               	leaq	-0x10(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	callq	 <L18>
+<L18>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0x150(%rbp), %rdi
-               	movups	%xmm12, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x20(%rbp)
+               	leaq	-0x20(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L104>
-<L104>:
+               	callq	 <L19>
+<L19>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x170(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x30(%rbp)
+               	leaq	-0x30(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L112>
-<L112>:
+               	callq	 <L20>
+<L20>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm13
-               	leaq	-0x190(%rbp), %rdi
-               	movups	%xmm13, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x40(%rbp)
+               	leaq	-0x40(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
-               	movaps	%xmm13, %xmm8
-               	movaps	%xmm12, %xmm10
-               	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %rsi
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x80(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -919,61 +537,24 @@ Disassembly of section .text:
                	movups	%xmm10, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%rdi, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rsi,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rax
-               	movzwl	(%rax), %edx
+               	leaq	(%rsi,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x90(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %rdi
+               	jb	 <L23>
+<L25>:
+               	leaq	-0xc0(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
@@ -982,78 +563,76 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rdi)
                	leaq	(%rdi), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%rsi), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%rdi), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x20(%rdi), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%rsi), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%rdi), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%rdi), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%rdi), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L132>
-<L132>:
-               	movups	(%rsi), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L141>
-<L141>:
-               	movaps	-0x290(%rbp), %xmm6
-               	movaps	-0x2a0(%rbp), %xmm7
-               	movaps	-0x2b0(%rbp), %xmm8
-               	movaps	-0x2c0(%rbp), %xmm9
-               	movaps	-0x2d0(%rbp), %xmm10
-               	movaps	-0x2e0(%rbp), %xmm11
-               	movaps	-0x2f0(%rbp), %xmm12
-               	movaps	-0x300(%rbp), %xmm13
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%rdi), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+<L30>:
+               	movaps	-0x2b0(%rbp), %xmm6
+               	movaps	-0x2c0(%rbp), %xmm7
+               	movaps	-0x2d0(%rbp), %xmm8
+               	movaps	-0x2e0(%rbp), %xmm9
+               	movaps	-0x2f0(%rbp), %xmm10
+               	movaps	-0x300(%rbp), %xmm11
                	movaps	-0x310(%rbp), %xmm14
                	movaps	-0x320(%rbp), %xmm15
-               	movq	-0x268(%rbp), %rbx
-               	movq	-0x270(%rbp), %rdi
-               	movq	-0x278(%rbp), %rsi
-               	movq	-0x280(%rbp), %r12
+               	movq	-0x288(%rbp), %rbx
+               	movq	-0x290(%rbp), %rdi
+               	movq	-0x298(%rbp), %rsi
+               	movq	-0x2a0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_i32x4.dis
@@ -5,41 +5,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,38 +121,36 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4b0, %rsp            # imm = 0x4B0
-               	movq	%rbx, -0x3e8(%rbp)
-               	movq	%rdi, -0x3f0(%rbp)
-               	movq	%rsi, -0x3f8(%rbp)
-               	movq	%r12, -0x400(%rbp)
-               	movq	%r13, -0x408(%rbp)
-               	movq	%r14, -0x410(%rbp)
-               	movq	%r15, -0x418(%rbp)
-               	movaps	%xmm6, -0x430(%rbp)
-               	movaps	%xmm7, -0x440(%rbp)
-               	movaps	%xmm8, -0x450(%rbp)
-               	movaps	%xmm9, -0x460(%rbp)
-               	movaps	%xmm10, -0x470(%rbp)
-               	movaps	%xmm14, -0x480(%rbp)
-               	movaps	%xmm15, -0x490(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rbx
+               	subq	$0x540, %rsp            # imm = 0x540
+               	movq	%rbx, -0x478(%rbp)
+               	movq	%rdi, -0x480(%rbp)
+               	movq	%rsi, -0x488(%rbp)
+               	movq	%r12, -0x490(%rbp)
+               	movq	%r13, -0x498(%rbp)
+               	movq	%r14, -0x4a0(%rbp)
+               	movq	%r15, -0x4a8(%rbp)
+               	movaps	%xmm6, -0x4c0(%rbp)
+               	movaps	%xmm7, -0x4d0(%rbp)
+               	movaps	%xmm8, -0x4e0(%rbp)
+               	movaps	%xmm9, -0x4f0(%rbp)
+               	movaps	%xmm10, -0x500(%rbp)
+               	movaps	%xmm14, -0x510(%rbp)
+               	movaps	%xmm15, -0x520(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %edx
+               	leaq	-0x160(%rbp), %rax
+               	leaq	(%rax), %rbx
                	movl	$0x2717, (%rbx)         # imm = 0x2717
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x4(%rax), %rbx
                	movl	$0xffffb1d5, (%rbx)     # imm = 0xFFFFB1D5
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rax), %rbx
                	movl	$0x753d, (%rbx)         # imm = 0x753D
-               	leaq	0xc(%rdx), %rbx
+               	leaq	0xc(%rax), %rbx
                	movl	$0xffff8000, (%rbx)     # imm = 0xFFFF8000
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x180(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movl	$0xfffffff9, (%rsi)     # imm = 0xFFFFFFF9
                	leaq	0x4(%rbx), %rsi
@@ -88,9 +160,9 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rsi
                	movl	$0x3, (%rsi)
                	movups	(%rbx), %xmm1
-               	leaq	-0x40(%rbp), %rbx
+               	leaq	-0x190(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x1a0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x1, (%rdi)
                	leaq	0x4(%rsi), %rdi
@@ -100,9 +172,9 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x1b, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x1b0(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x1c0(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -112,489 +184,339 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm6
-               	leaq	(%rdx), %rdi
-               	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rax), %rdi
+               	movl	(%rdi), %eax
+               	addl	%edx, %eax
+               	leaq	-0x1d0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
-               	movl	%edx, (%r12)
+               	movl	%eax, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	0x8(%rdi), %rdx
-               	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	leaq	0x8(%rdi), %rax
+               	movl	(%rax), %edi
+               	addl	%edx, %edi
+               	leaq	-0x1e0(%rbp), %r12
                	movups	%xmm0, (%r12)
-               	leaq	0x8(%r12), %rdx
-               	movl	%edi, (%rdx)
+               	leaq	0x8(%r12), %rax
+               	movl	%edi, (%rax)
                	movups	(%r12), %xmm7
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0xa0(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x4(%rdx), %rdi
+               	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %ebx
+               	addl	%edx, %ebx
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x4(%rax), %rdi
                	movl	%ebx, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rbx
-               	movl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	0xc(%rax), %rbx
+               	movl	(%rbx), %eax
+               	addl	%edx, %eax
+               	leaq	-0x200(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%rbx), %rdx
+               	movl	%eax, (%rdx)
                	movups	(%rbx), %xmm8
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm7, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm8, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm7, %xmm14
+               	paddd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	leaq	-0x230(%rbp), %rdi
+               	movups	%xmm9, (%rdi)
+               	movups	%xmm9, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm7, %xmm14
+               	psubd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	psubd	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
+               	movq	%rax, %r8
+               	movq	%r8, -0x438(%rbp)
+               	movq	-0x438(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x440(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r13d
+               	imull	%r13d, %edx
+               	leaq	-0x270(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x440(%rbp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x280(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movl	%r14d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x290(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movl	%r15d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r13
+               	movl	%edx, (%r13)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
+               	movq	-0x438(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
+               	movq	%rax, %r8
+               	movq	%r8, -0x448(%rbp)
+               	movq	-0x448(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rsi), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x2c0(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%r13d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movl	%r14d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movl	%r15d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r12
+               	movl	%edx, (%r12)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x300(%rbp)
+               	leaq	-0x300(%rbp), %rdx
+               	movq	-0x448(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	movaps	%xmm7, %xmm14
-               	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	movaps	%xmm7, %xmm14
-               	psubd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm8, %xmm14
-               	psubd	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %ebx
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r12d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%ebx, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm7, %xmm14
-               	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %ebx
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r12d
                	leaq	(%rsi), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %ebx
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
-               	leaq	0x4(%rsi), %rdx
-               	movl	(%rdx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	0x8(%rsi), %rdx
                	movl	(%rdx), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	leaq	0xc(%rsi), %rdx
+               	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %ebx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%ebx, (%r13)
+               	movups	%xmm8, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%r12d, (%r15)
                	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rbx
-               	movl	%edi, (%rbx)
+               	leaq	0x4(%rdx), %r12
+               	movl	%r13d, (%r12)
                	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rdx), %r12
+               	movl	%r14d, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r12
+               	movl	%ebx, (%r12)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x350(%rbp)
+               	leaq	-0x350(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%rdi), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %ebx
+               	leaq	0x4(%rdi), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0x8(%rdi), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xc(%rdi), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %edi
+               	leaq	-0x360(%rbp), %rdx
+               	movups	%xmm9, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%ebx, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x370(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rbx
                	movl	%r12d, (%rbx)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movaps	%xmm6, %xmm14
-               	psubd	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	movaps	%xmm6, %xmm14
-               	psubd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x360(%rbp)
-               	leaq	-0x360(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x370(%rbp)
-               	leaq	-0x370(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x380(%rbp)
                	leaq	-0x380(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	movaps	%xmm7, %xmm14
-               	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x390(%rbp)
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rbx
+               	movl	%r13d, (%rbx)
+               	movups	(%rdx), %xmm0
                	leaq	-0x390(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	movaps	%xmm7, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movl	%edi, (%rbx)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, -0x3a0(%rbp)
                	leaq	-0x3a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	%xmm6, %xmm14
+               	psubd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x3b0(%rbp)
                	leaq	-0x3b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm6, %xmm14
+               	psubd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x3d0(%rbp)
+               	leaq	-0x3d0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
+               	movaps	%xmm7, %xmm14
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x3e0(%rbp)
+               	leaq	-0x3e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
+               	movaps	%xmm7, %xmm14
+               	pxor	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x3f0(%rbp)
+               	leaq	-0x3f0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm7, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x400(%rbp)
+               	leaq	-0x400(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm8, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x410(%rbp)
+               	leaq	-0x410(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x3c0(%rbp)
-               	leaq	-0x3c0(%rbp), %rdx
+               	movups	%xmm9, -0x420(%rbp)
+               	leaq	-0x420(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movq	$0x0, %rdi
-<L48>:
-               	leaq	-0xc0(%rbp), %r12
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r13
+               	jb	 <L26>
+               	leaq	-0xd0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -611,47 +533,50 @@ Disassembly of section .text:
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rsi), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movl	(%rax), %r14d
+               	movl	%edx, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x450(%rbp)
                	leaq	0x4(%r12), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %r14d
                	leaq	0x4(%rsi), %rax
+               	movl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x458(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movl	(%rax), %r15d
+               	leaq	0x8(%rsi), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rsi), %rax
                	movl	(%rax), %r14d
                	imull	%r14d, %edx
-               	leaq	0x8(%r12), %rax
-               	movl	(%rax), %r14d
-               	leaq	0x8(%rsi), %rax
-               	movl	(%rax), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xc(%r12), %rax
-               	movl	(%rax), %r15d
-               	leaq	0xc(%rsi), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %r15d
-               	leaq	-0x150(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rax
                	movups	%xmm7, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
-               	movl	%r8d, (%rcx)
+               	leaq	(%rax), %r14
+               	movq	-0x450(%rbp), %r8
+               	movl	%r8d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x160(%rbp), %rax
+               	leaq	-0xf0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0x4(%rax), %r14
+               	movq	-0x458(%rbp), %r8
+               	movl	%r8d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x170(%rbp), %rax
+               	leaq	-0x100(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%r14d, (%rcx)
+               	leaq	0x8(%rax), %r14
+               	movl	%r15d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x180(%rbp), %rax
+               	leaq	-0x110(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%r15d, (%rcx)
+               	leaq	0xc(%rax), %r14
+               	movl	%edx, (%r14)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
@@ -660,54 +585,24 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
-               	movups	%xmm0, (%r8)
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %edx
+               	leaq	(%r13,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x120(%rbp)
+               	leaq	-0x120(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x3d0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %eax
-               	movl	%eax, %edx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r15
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -716,199 +611,157 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r15)
                	leaq	(%r15), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r15), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%r15), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%r13), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r15), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r15), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x460(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x460(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %rax
+               	xorq	%r13, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r15), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x430(%rbp)
+               	leaq	-0x430(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L55>
-<L55>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x1d0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x20(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x430(%rbp), %xmm6
-               	movaps	-0x440(%rbp), %xmm7
-               	movaps	-0x450(%rbp), %xmm8
-               	movaps	-0x460(%rbp), %xmm9
-               	movaps	-0x470(%rbp), %xmm10
-               	movaps	-0x480(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
-               	movq	-0x3e8(%rbp), %rbx
-               	movq	-0x3f0(%rbp), %rdi
-               	movq	-0x3f8(%rbp), %rsi
-               	movq	-0x400(%rbp), %r12
-               	movq	-0x408(%rbp), %r13
-               	movq	-0x410(%rbp), %r14
-               	movq	-0x418(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	leaq	0x20(%r15), %rdx
+               	movl	(%rdx), %r13d
+               	movl	%r13d, %edx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+<L25>:
+               	movaps	-0x4c0(%rbp), %xmm6
+               	movaps	-0x4d0(%rbp), %xmm7
+               	movaps	-0x4e0(%rbp), %xmm8
+               	movaps	-0x4f0(%rbp), %xmm9
+               	movaps	-0x500(%rbp), %xmm10
+               	movaps	-0x510(%rbp), %xmm14
+               	movaps	-0x520(%rbp), %xmm15
+               	movq	-0x478(%rbp), %rbx
+               	movq	-0x480(%rbp), %rdi
+               	movq	-0x488(%rbp), %rsi
+               	movq	-0x490(%rbp), %r12
+               	movq	-0x498(%rbp), %r13
+               	movq	-0x4a0(%rbp), %r14
+               	movq	-0x4a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x468(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %r14d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r12d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm9
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r15d
+               	leaq	0xc(%r12), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r13
+               	movq	-0x468(%rbp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r13
+               	movl	%r14d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movl	%r15d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r13
+               	movl	%r12d, (%r13)
+               	movups	(%rdx), %xmm9
+               	movups	%xmm9, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm6, %xmm14
                	paddd	%xmm9, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	-0x1e0(%rbp), %r12
-               	movups	%xmm10, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm10, -0x70(%rbp)
+               	leaq	-0x70(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
+               	callq	 <L28>
+<L28>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	-0x200(%rbp), %r12
-               	movups	%xmm10, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm10, -0x80(%rbp)
+               	leaq	-0x80(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L29>
+<L29>:
                	movaps	%xmm7, %xmm14
                	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm9
-               	leaq	-0x220(%rbp), %r12
-               	movups	%xmm9, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x90(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
-               	movaps	%xmm9, %xmm7
                	movaps	%xmm10, %xmm6
-               	jmp	 <L48>
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_i64x2.dis
@@ -5,29 +5,67 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movq	(%rdx), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,346 +73,281 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3e0, %rsp            # imm = 0x3E0
-               	movq	%rbx, -0x2f8(%rbp)
-               	movq	%rdi, -0x300(%rbp)
-               	movq	%rsi, -0x308(%rbp)
-               	movq	%r12, -0x310(%rbp)
-               	movq	%r13, -0x318(%rbp)
-               	movq	%r14, -0x320(%rbp)
-               	movq	%r15, -0x328(%rbp)
-               	movaps	%xmm6, -0x340(%rbp)
-               	movaps	%xmm7, -0x350(%rbp)
-               	movaps	%xmm8, -0x360(%rbp)
-               	movaps	%xmm9, -0x370(%rbp)
-               	movaps	%xmm10, -0x380(%rbp)
-               	movaps	%xmm11, -0x390(%rbp)
-               	movaps	%xmm12, -0x3a0(%rbp)
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movaps	%xmm15, -0x3c0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x3b9aca07, (%rdx)     # imm = 0x3B9ACA07
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x7735940b, (%rdx)    # imm = 0x88CA6BF5
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
-               	leaq	(%rdx), %rsi
+               	subq	$0x430, %rsp            # imm = 0x430
+               	movq	%rbx, -0x368(%rbp)
+               	movq	%rdi, -0x370(%rbp)
+               	movq	%rsi, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
+               	movaps	%xmm6, -0x3b0(%rbp)
+               	movaps	%xmm7, -0x3c0(%rbp)
+               	movaps	%xmm8, -0x3d0(%rbp)
+               	movaps	%xmm9, -0x3e0(%rbp)
+               	movaps	%xmm10, -0x3f0(%rbp)
+               	movaps	%xmm14, -0x400(%rbp)
+               	movaps	%xmm15, -0x410(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x120(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movq	$0x3b9aca07, (%rbx)     # imm = 0x3B9ACA07
+               	leaq	0x8(%rdx), %rbx
+               	movq	$-0x7735940b, (%rbx)    # imm = 0x88CA6BF5
+               	movups	(%rdx), %xmm0
+               	leaq	-0x130(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	-0x140(%rbp), %rbx
+               	leaq	(%rbx), %rsi
                	movabsq	$0xb2d05e13, %r11       # imm = 0xB2D05E13
                	movq	%r11, (%rsi)
-               	leaq	0x8(%rdx), %rsi
+               	leaq	0x8(%rbx), %rsi
                	movabsq	$-0xee6b2825, %r11      # imm = 0xFFFFFFFF1194D7DB
                	movq	%r11, (%rsi)
-               	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
+               	movups	(%rbx), %xmm1
+               	leaq	-0x150(%rbp), %rbx
+               	movups	%xmm1, (%rbx)
+               	leaq	-0x160(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movq	$0x1, (%rdi)
                	leaq	0x8(%rsi), %rdi
                	movq	$0x3, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x170(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x180(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movq	$0x0, (%r12)
                	leaq	0x8(%rdi), %r12
                	movq	$0x0, (%r12)
                	movups	(%rdi), %xmm6
-               	leaq	(%rcx), %rdi
-               	movq	(%rdi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rdx), %rdi
+               	movq	(%rdi), %rdx
+               	addq	%rax, %rdx
+               	leaq	-0x190(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
-               	movq	%rcx, (%r12)
+               	movq	%rdx, (%r12)
                	movups	(%rdi), %xmm7
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm8
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
+               	addq	%rax, %rbx
+               	leaq	-0x1a0(%rbp), %r12
+               	movups	%xmm1, (%r12)
+               	leaq	0x8(%r12), %rax
+               	movq	%rbx, (%rax)
+               	movups	(%r12), %xmm8
+               	movups	%xmm7, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm8, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	paddq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	leaq	-0x1d0(%rbp), %rbx
+               	movups	%xmm9, (%rbx)
+               	movups	%xmm9, -0x1e0(%rbp)
+               	leaq	-0x1e0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	psubq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm8, %xmm14
+               	psubq	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	movaps	%xmm7, %xmm14
-               	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%rdi), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%rdi), %rdx
+               	movq	(%rdx), %r14
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %r14
+               	leaq	-0x210(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%r13, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x220(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%r14, (%r13)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%rdi), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%rdi), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x240(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x250(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%rdi, (%r13)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L6>
 <L6>:
-               	movaps	%xmm7, %xmm14
-               	psubq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r13
+               	imulq	%r13, %rdi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r13
+               	imulq	%r13, %r12
+               	leaq	-0x270(%rbp), %rdx
+               	movups	%xmm8, (%rdx)
+               	leaq	(%rdx), %r13
+               	movq	%rdi, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movq	%r12, (%rdi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	movaps	%xmm8, %xmm14
-               	psubq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdx
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %r12
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %r12
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	%rdx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%r12, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdx
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdi
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movq	%rdi, (%rcx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rbx
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0x8(%rdi), %rcx
-               	movq	%rbx, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm7, %xmm14
-               	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rbx
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	leaq	(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rbx
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
                	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rbx
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm9, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rdi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
+               	leaq	0x8(%rdx), %rdi
                	movq	%rbx, (%rdi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	movaps	%xmm6, %xmm14
-               	psubq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	movaps	%xmm6, %xmm14
-               	psubq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x280(%rbp)
-               	leaq	-0x280(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x290(%rbp)
-               	leaq	-0x290(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x2a0(%rbp)
-               	leaq	-0x2a0(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	movaps	%xmm7, %xmm14
-               	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x2b0(%rbp)
-               	leaq	-0x2b0(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm7, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x2c0(%rbp)
                	leaq	-0x2c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	%xmm6, %xmm14
+               	psubq	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x2d0(%rbp)
                	leaq	-0x2d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm6, %xmm14
+               	psubq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x2e0(%rbp)
+               	leaq	-0x2e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x2f0(%rbp)
+               	leaq	-0x2f0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
+               	movaps	%xmm7, %xmm14
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x300(%rbp)
+               	leaq	-0x300(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
+               	movaps	%xmm7, %xmm14
+               	pxor	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x310(%rbp)
+               	leaq	-0x310(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm7, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x320(%rbp)
+               	leaq	-0x320(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm8, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x330(%rbp)
+               	leaq	-0x330(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x2e0(%rbp)
-               	leaq	-0x2e0(%rbp), %rdx
+               	movups	%xmm9, -0x340(%rbp)
+               	leaq	-0x340(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L28>:
-               	leaq	-0xa0(%rbp), %r12
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r13
+               	jb	 <L26>
+               	leaq	-0xb0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -391,24 +364,24 @@ Disassembly of section .text:
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
-               	movq	(%rax), %rcx
+               	movq	(%rax), %rdx
                	leaq	(%rsi), %rax
-               	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r12), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%rsi), %rax
                	movq	(%rax), %r14
                	imulq	%r14, %rdx
-               	leaq	-0x110(%rbp), %rax
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %r14
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r15
+               	imulq	%r15, %r14
+               	leaq	-0xc0(%rbp), %rax
                	movups	%xmm7, (%rax)
-               	leaq	(%rax), %r14
-               	movq	%rcx, (%r14)
+               	leaq	(%rax), %r15
+               	movq	%rdx, (%r15)
                	movups	(%rax), %xmm0
-               	leaq	-0x120(%rbp), %rax
+               	leaq	-0xd0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
+               	leaq	0x8(%rax), %rdx
+               	movq	%r14, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
@@ -417,36 +390,24 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x2e8(%rbp), %r8
-               	movups	%xmm0, (%r8)
-               	movq	-0x2e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%r13,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0xe0(%rbp)
+               	leaq	-0xe0(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	-0x2e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rax
-               	movq	%rax, %rdx
-               	callq	 <L31>
-<L31>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r15
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x110(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -455,132 +416,133 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r15)
                	leaq	(%r15), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r15), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%r15), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%r13), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r15), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r15), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x358(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %rax
+               	xorq	%r13, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r15), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x350(%rbp)
+               	leaq	-0x350(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L33>
-<L33>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x170(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0x20(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x340(%rbp), %xmm6
-               	movaps	-0x350(%rbp), %xmm7
-               	movaps	-0x360(%rbp), %xmm8
-               	movaps	-0x370(%rbp), %xmm9
-               	movaps	-0x380(%rbp), %xmm10
-               	movaps	-0x390(%rbp), %xmm11
-               	movaps	-0x3a0(%rbp), %xmm12
-               	movaps	-0x3b0(%rbp), %xmm14
-               	movaps	-0x3c0(%rbp), %xmm15
-               	movq	-0x2f8(%rbp), %rbx
-               	movq	-0x300(%rbp), %rdi
-               	movq	-0x308(%rbp), %rsi
-               	movq	-0x310(%rbp), %r12
-               	movq	-0x318(%rbp), %r13
-               	movq	-0x320(%rbp), %r14
-               	movq	-0x328(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	leaq	0x20(%r15), %rdx
+               	movl	(%rdx), %r13d
+               	movl	%r13d, %edx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+<L25>:
+               	movaps	-0x3b0(%rbp), %xmm6
+               	movaps	-0x3c0(%rbp), %xmm7
+               	movaps	-0x3d0(%rbp), %xmm8
+               	movaps	-0x3e0(%rbp), %xmm9
+               	movaps	-0x3f0(%rbp), %xmm10
+               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm15
+               	movq	-0x368(%rbp), %rbx
+               	movq	-0x370(%rbp), %rdi
+               	movq	-0x378(%rbp), %rsi
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %rdx
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %r12
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %r12
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	%rdx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xc0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%r12, (%rcx)
-               	movups	(%r13), %xmm10
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
+<L26>:
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r12
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%r12, (%r13)
+               	movups	(%rdx), %xmm10
+               	movups	%xmm10, -0x40(%rbp)
+               	leaq	-0x40(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x180(%rbp), %r12
-               	movups	%xmm11, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x50(%rbp)
+               	leaq	-0x50(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L28>
+<L28>:
                	movaps	%xmm6, %xmm14
                	paddq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0x1a0(%rbp), %r12
-               	movups	%xmm10, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm6
+               	movups	%xmm6, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L29>
+<L29>:
                	movaps	%xmm7, %xmm14
                	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0x1c0(%rbp), %r12
-               	movups	%xmm12, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x70(%rbp)
+               	leaq	-0x70(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
-               	movaps	%xmm12, %xmm7
-               	movaps	%xmm11, %xmm9
-               	movaps	%xmm10, %xmm6
-               	jmp	 <L28>
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/vec/vec_i8x16.dis
+++ b/test/golden/x86_64-windows/vec/vec_i8x16.dis
@@ -5,113 +5,391 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i8x16.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x1(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x3(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
+               	leaq	0x2(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0x5(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	leaq	0x3(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0x7(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L8>
+               	leaq	0x4(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	leaq	0x9(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L10>
+               	leaq	0x5(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	leaq	0xb(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L12>
+               	leaq	0x6(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	0xd(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
+               	leaq	0x7(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	leaq	0xf(%rbx), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movsbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rdx), %rbx
+               	movzbl	(%rbx), %edx
+               	movsbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -119,1124 +397,1109 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xbe0, %rsp            # imm = 0xBE0
-               	movq	%rbx, -0xb18(%rbp)
-               	movq	%rdi, -0xb20(%rbp)
-               	movq	%rsi, -0xb28(%rbp)
-               	movq	%r12, -0xb30(%rbp)
-               	movq	%r13, -0xb38(%rbp)
-               	movq	%r14, -0xb40(%rbp)
-               	movq	%r15, -0xb48(%rbp)
-               	movaps	%xmm6, -0xb60(%rbp)
-               	movaps	%xmm7, -0xb70(%rbp)
-               	movaps	%xmm8, -0xb80(%rbp)
-               	movaps	%xmm9, -0xb90(%rbp)
-               	movaps	%xmm10, -0xba0(%rbp)
-               	movaps	%xmm14, -0xbb0(%rbp)
-               	movaps	%xmm15, -0xbc0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movb	%bl, %dl
-               	leaq	-0x10(%rbp), %rbx
+               	subq	$0xbc0, %rsp            # imm = 0xBC0
+               	movq	%rbx, -0xaf8(%rbp)
+               	movq	%rdi, -0xb00(%rbp)
+               	movq	%rsi, -0xb08(%rbp)
+               	movq	%r12, -0xb10(%rbp)
+               	movq	%r13, -0xb18(%rbp)
+               	movq	%r14, -0xb20(%rbp)
+               	movq	%r15, -0xb28(%rbp)
+               	movaps	%xmm6, -0xb40(%rbp)
+               	movaps	%xmm7, -0xb50(%rbp)
+               	movaps	%xmm8, -0xb60(%rbp)
+               	movaps	%xmm9, -0xb70(%rbp)
+               	movaps	%xmm10, -0xb80(%rbp)
+               	movaps	%xmm14, -0xb90(%rbp)
+               	movaps	%xmm15, -0xba0(%rbp)
+               	movb	%cl, %al
+               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x9, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x5, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$0x3, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x4, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x6, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$-0x8, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x9, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x3, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x2, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x4, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$0x8, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x300(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movb	$0x2, (%rbx)
+               	leaq	0x1(%rdx), %rbx
+               	movb	$-0x3, (%rbx)
+               	leaq	0x2(%rdx), %rbx
+               	movb	$0x4, (%rbx)
+               	leaq	0x3(%rdx), %rbx
+               	movb	$-0x5, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movb	$0x6, (%rbx)
+               	leaq	0x5(%rdx), %rbx
+               	movb	$-0x7, (%rbx)
+               	leaq	0x6(%rdx), %rbx
+               	movb	$0x8, (%rbx)
+               	leaq	0x7(%rdx), %rbx
+               	movb	$-0x9, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movb	$0x1, (%rbx)
+               	leaq	0x9(%rdx), %rbx
+               	movb	$-0x2, (%rbx)
+               	leaq	0xa(%rdx), %rbx
+               	movb	$0x3, (%rbx)
+               	leaq	0xb(%rdx), %rbx
+               	movb	$-0x4, (%rbx)
+               	leaq	0xc(%rdx), %rbx
+               	movb	$0x5, (%rbx)
+               	leaq	0xd(%rdx), %rbx
+               	movb	$-0x6, (%rbx)
+               	leaq	0xe(%rdx), %rbx
+               	movb	$0x7, (%rbx)
+               	leaq	0xf(%rdx), %rbx
+               	movb	$-0x1, (%rbx)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x310(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	-0x320(%rbp), %rbx
                	leaq	(%rbx), %rsi
-               	movb	$-0x9, (%rsi)
+               	movb	$0x1, (%rsi)
                	leaq	0x1(%rbx), %rsi
-               	movb	$0x7, (%rsi)
+               	movb	$0x2, (%rsi)
                	leaq	0x2(%rbx), %rsi
-               	movb	$-0x5, (%rsi)
-               	leaq	0x3(%rbx), %rsi
                	movb	$0x3, (%rsi)
+               	leaq	0x3(%rbx), %rsi
+               	movb	$0x2, (%rsi)
                	leaq	0x4(%rbx), %rsi
-               	movb	$-0x1, (%rsi)
+               	movb	$0x1, (%rsi)
                	leaq	0x5(%rbx), %rsi
                	movb	$0x2, (%rsi)
                	leaq	0x6(%rbx), %rsi
-               	movb	$-0x4, (%rsi)
+               	movb	$0x3, (%rsi)
                	leaq	0x7(%rbx), %rsi
-               	movb	$0x6, (%rsi)
+               	movb	$0x2, (%rsi)
                	leaq	0x8(%rbx), %rsi
-               	movb	$-0x8, (%rsi)
-               	leaq	0x9(%rbx), %rsi
-               	movb	$0x9, (%rsi)
-               	leaq	0xa(%rbx), %rsi
-               	movb	$-0x3, (%rsi)
-               	leaq	0xb(%rbx), %rsi
                	movb	$0x1, (%rsi)
+               	leaq	0x9(%rbx), %rsi
+               	movb	$0x2, (%rsi)
+               	leaq	0xa(%rbx), %rsi
+               	movb	$0x3, (%rsi)
+               	leaq	0xb(%rbx), %rsi
+               	movb	$0x2, (%rsi)
                	leaq	0xc(%rbx), %rsi
-               	movb	$-0x2, (%rsi)
+               	movb	$0x1, (%rsi)
                	leaq	0xd(%rbx), %rsi
-               	movb	$0x4, (%rsi)
+               	movb	$0x2, (%rsi)
                	leaq	0xe(%rbx), %rsi
-               	movb	$-0x6, (%rsi)
+               	movb	$0x3, (%rsi)
                	leaq	0xf(%rbx), %rsi
-               	movb	$0x8, (%rsi)
-               	movups	(%rbx), %xmm0
-               	leaq	-0x20(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	-0x30(%rbp), %rsi
+               	movb	$0x2, (%rsi)
+               	movups	(%rbx), %xmm2
+               	leaq	-0x330(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x340(%rbp), %rsi
                	leaq	(%rsi), %rdi
-               	movb	$0x2, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x1(%rsi), %rdi
-               	movb	$-0x3, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x2(%rsi), %rdi
-               	movb	$0x4, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x3(%rsi), %rdi
-               	movb	$-0x5, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x4(%rsi), %rdi
-               	movb	$0x6, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x5(%rsi), %rdi
-               	movb	$-0x7, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x6(%rsi), %rdi
-               	movb	$0x8, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x7(%rsi), %rdi
-               	movb	$-0x9, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x8(%rsi), %rdi
-               	movb	$0x1, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0x9(%rsi), %rdi
-               	movb	$-0x2, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xa(%rsi), %rdi
-               	movb	$0x3, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xb(%rsi), %rdi
-               	movb	$-0x4, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xc(%rsi), %rdi
-               	movb	$0x5, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xd(%rsi), %rdi
-               	movb	$-0x6, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xe(%rsi), %rdi
-               	movb	$0x7, (%rdi)
+               	movb	$0x0, (%rdi)
                	leaq	0xf(%rsi), %rdi
-               	movb	$-0x1, (%rdi)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
-               	leaq	(%rdi), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x2(%rdi), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x3(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x4(%rdi), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x5(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x6(%rdi), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x7(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x8(%rdi), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x9(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xa(%rdi), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xb(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xc(%rdi), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0xd(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xe(%rdi), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xf(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rdi
-               	movups	%xmm2, (%rdi)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm6
-               	leaq	(%rbx), %r12
-               	movzbl	(%r12), %ebx
-               	addl	%edx, %ebx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%bl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rbx
-               	movzbl	(%rbx), %r12d
-               	addl	%edx, %r12d
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x7(%rbx), %r13
-               	movb	%r12b, (%r13)
-               	movups	(%rbx), %xmm7
-               	leaq	0x3(%rsi), %r12
-               	movzbl	(%r12), %esi
-               	addl	%edx, %esi
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
-               	leaq	0x3(%r12), %r13
-               	movb	%sil, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0xc(%r12), %rsi
-               	movzbl	(%rsi), %r12d
-               	addl	%edx, %r12d
-               	leaq	-0xb0(%rbp), %rsi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm6
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x350(%rbp), %rsi
                	movups	%xmm0, (%rsi)
-               	leaq	0xc(%rsi), %rdx
-               	movb	%r12b, (%rdx)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x360(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x7(%rdi), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rdi), %xmm7
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x370(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x380(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rax
+               	movb	%cl, (%rax)
                	movups	(%rsi), %xmm8
-               	movups	%xmm7, -0xc0(%rbp)
-               	leaq	-0xc0(%rbp), %rdx
+               	movups	%xmm7, -0x390(%rbp)
+               	leaq	-0x390(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm8, -0x3a0(%rbp)
+               	leaq	-0x3a0(%rbp), %rdx
+               	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
-               	movups	%xmm8, -0xd0(%rbp)
-               	leaq	-0xd0(%rbp), %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	leaq	-0xe0(%rbp), %r12
+               	leaq	-0x3b0(%rbp), %r12
                	movups	%xmm9, (%r12)
-               	movups	%xmm9, -0xf0(%rbp)
-               	leaq	-0xf0(%rbp), %rdx
-               	callq	 <L3>
-<L3>:
+               	movups	%xmm9, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L2>
+<L2>:
                	movaps	%xmm7, %xmm14
                	psubb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x100(%rbp)
-               	leaq	-0x100(%rbp), %rdx
-               	callq	 <L4>
-<L4>:
+               	movups	%xmm0, -0x3d0(%rbp)
+               	leaq	-0x3d0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L3>
+<L3>:
                	movaps	%xmm8, %xmm14
                	psubb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x110(%rbp)
-               	leaq	-0x110(%rbp), %rdx
-               	callq	 <L5>
-<L5>:
+               	movups	%xmm0, -0x3e0(%rbp)
+               	leaq	-0x3e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
                	movq	%rax, %r8
                	movq	%r8, -0x8b8(%rbp)
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	(%rsi), %rdx
-               	movzbl	(%rdx), %r14d
+               	leaq	(%rdi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rsi), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x8c0(%rbp)
+               	leaq	0x1(%rdi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rsi), %rcx
+               	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r15d
+               	movq	%r8, -0x8c8(%rbp)
+               	leaq	0x2(%rdi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rsi), %rcx
+               	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x2(%rsi), %rdx
-               	movzbl	(%rdx), %ecx
+               	movq	%r8, -0x8d0(%rbp)
+               	leaq	0x3(%rdi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rsi), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x8d8(%rbp)
+               	leaq	0x4(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x8e0(%rbp)
+               	leaq	0x5(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x8e8(%rbp)
+               	leaq	0x6(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x6(%rsi), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x8f0(%rbp)
+               	leaq	0x7(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x7(%rsi), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	leaq	0x8(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rsi), %rax
+               	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x3(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8d8(%rbp)
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x4(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x8e0(%rbp)
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x5(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8e8(%rbp)
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x7(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8f8(%rbp)
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
                	movq	%r8, -0x900(%rbp)
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x908(%rbp)
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
+               	leaq	0x9(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x910(%rbp)
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
+               	movq	%r8, -0x908(%rbp)
+               	leaq	0xa(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rsi), %rax
+               	movzbl	(%rax), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x918(%rbp)
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
+               	movq	%r8, -0x910(%rbp)
+               	leaq	0xb(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rsi), %rax
+               	movzbl	(%rax), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x920(%rbp)
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xd(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x918(%rbp)
+               	leaq	0xc(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xc(%rsi), %rax
+               	movzbl	(%rax), %r15d
                	imull	%r15d, %r14d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0xd(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rsi), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %edx
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r13
                	movq	-0x8c0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x8c8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
                	movq	-0x8d0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x450(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r13
                	movb	%r14b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %r13
                	movb	%r15b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x220(%rbp)
-               	leaq	-0x220(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x4f0(%rbp)
+               	leaq	-0x4f0(%rbp), %rdx
                	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	leaq	(%rdi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x928(%rbp)
+               	leaq	0x1(%rdi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x930(%rbp)
+               	leaq	0x2(%rdi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x938(%rbp)
+               	leaq	0x3(%rdi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x940(%rbp)
+               	leaq	0x4(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x948(%rbp)
+               	leaq	0x5(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x950(%rbp)
+               	leaq	0x6(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x958(%rbp)
+               	leaq	0x7(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x960(%rbp)
+               	leaq	0x8(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x968(%rbp)
+               	leaq	0x9(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x970(%rbp)
+               	leaq	0xa(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x978(%rbp)
+               	leaq	0xb(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xc(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xd(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %edx
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %rdi
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rdi
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rdi
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rdi
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movq	-0x948(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x550(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rdi
+               	movq	-0x950(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rdi
+               	movq	-0x958(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rdi
+               	movq	-0x960(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movq	-0x968(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rdi
+               	movq	-0x970(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movq	-0x978(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r14b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x600(%rbp)
+               	leaq	-0x600(%rbp), %rdx
+               	movq	-0x920(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %r8
-               	movq	%r8, -0x928(%rbp)
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x930(%rbp)
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x938(%rbp)
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0x940(%rbp)
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x3(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x948(%rbp)
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x4(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x950(%rbp)
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x968(%rbp)
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x970(%rbp)
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
                	movq	%r8, -0x980(%rbp)
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x988(%rbp)
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %rbx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rbx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rbx
-               	movq	-0x940(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rbx
-               	movq	-0x948(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rbx
-               	movq	-0x950(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rbx
-               	movq	-0x958(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rbx
-               	movq	-0x960(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rbx
-               	movq	-0x968(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rbx
-               	movq	-0x970(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rbx
-               	movq	-0x978(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rbx
                	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rbx
+               	leaq	(%rsi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %edi
+               	movl	%edx, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x988(%rbp)
+               	leaq	0x1(%rsi), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x990(%rbp)
+               	leaq	0x2(%rsi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x998(%rbp)
+               	leaq	0x3(%rsi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x9a0(%rbp)
+               	leaq	0x4(%rsi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x9a8(%rbp)
+               	leaq	0x5(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x9b0(%rbp)
+               	leaq	0x6(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%edx, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x9b8(%rbp)
+               	leaq	0x7(%rsi), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x9c0(%rbp)
+               	leaq	0x8(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x9c8(%rbp)
+               	leaq	0x9(%rsi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x9d0(%rbp)
+               	leaq	0xa(%rsi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %edx
+               	leaq	0xd(%rsi), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %edi
+               	leaq	0xe(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xf(%rsi), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm8, (%rax)
+               	leaq	(%rax), %r14
                	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rbx
-               	movb	%r13b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rbx
-               	movb	%r14b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rbx
-               	movb	%r15b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rbx
-               	movb	%dl, (%rbx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x330(%rbp)
-               	leaq	-0x330(%rbp), %rdx
-               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x990(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x998(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
+               	movq	-0x9a0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x650(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
+               	movq	-0x9a8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
+               	movq	-0x9b0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
+               	movq	-0x9b8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
+               	movq	-0x9c0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
+               	movq	-0x9c8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
+               	movq	-0x9d0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r14
+               	movb	%r15b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r14
+               	movb	%cl, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%r13b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x710(%rbp)
+               	leaq	-0x710(%rbp), %rdx
+               	movq	-0x980(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
-               	leaq	(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x998(%rbp)
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x9a0(%rbp)
-               	leaq	0x2(%rsi), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x9a8(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x3(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0x9b0(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0x9b8(%rbp)
-               	leaq	0x5(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x9c0(%rbp)
-               	leaq	0x6(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x9c8(%rbp)
-               	leaq	0x7(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x9d0(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
                	movq	%r8, -0x9d8(%rbp)
-               	leaq	0x9(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0x9e0(%rbp)
-               	leaq	0xa(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x9e8(%rbp)
-               	leaq	0xb(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xd(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xe(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	0xf(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %ebx
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rsi
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rsi
-               	movq	-0x9a8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rsi
-               	movq	-0x9b0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movq	-0x9b8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rsi
-               	movq	-0x9c0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rsi
-               	movq	-0x9c8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rsi
-               	movq	-0x9d0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rsi
                	movq	-0x9d8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rsi
+               	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x9e0(%rbp)
+               	leaq	0x1(%r12), %rcx
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x9e8(%rbp)
+               	leaq	0x2(%r12), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x9f0(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x9f8(%rbp)
+               	leaq	0x4(%r12), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xa00(%rbp)
+               	leaq	0x5(%r12), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x5(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0xa08(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xa10(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0xa18(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0xa20(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %edi
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %esi
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm9, (%rax)
+               	leaq	(%rax), %r12
                	movq	-0x9e0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rsi
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
                	movq	-0x9e8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r14b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x440(%rbp)
-               	leaq	-0x440(%rbp), %rdx
-               	movq	-0x990(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x9f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x750(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x9f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x760(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0xa00(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x770(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0xa08(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x780(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0xa10(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x790(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0xa18(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0xa20(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movb	%dil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r14b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x800(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x810(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x820(%rbp)
+               	leaq	-0x820(%rbp), %rdx
+               	movq	-0x9d8(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9f0(%rbp)
-               	movq	-0x9f0(%rbp), %r8
-               	leaq	(%r12), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %esi
-               	movl	%ebx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x9f8(%rbp)
-               	leaq	0x1(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r13d
-               	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xa00(%rbp)
-               	leaq	0x2(%r12), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa08(%rbp)
-               	leaq	0x3(%r12), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x3(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa10(%rbp)
-               	leaq	0x4(%r12), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x4(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0xa18(%rbp)
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0xa20(%rbp)
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%ebx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0xa28(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xa30(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa38(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa40(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %ebx
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm9, (%rcx)
-               	leaq	(%rcx), %r14
-               	movq	-0x9f8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
-               	movq	-0xa00(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
-               	movq	-0xa08(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
-               	movq	-0xa10(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movq	-0xa18(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
-               	movq	-0xa20(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0xa28(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0xa30(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0xa38(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0xa40(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
-               	movb	%dl, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x550(%rbp)
-               	leaq	-0x550(%rbp), %rdx
-               	movq	-0x9f0(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x560(%rbp)
-               	leaq	-0x560(%rbp), %rdx
-               	callq	 <L10>
-<L10>:
+               	movups	%xmm0, -0x830(%rbp)
+               	leaq	-0x830(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L9>
+<L9>:
                	movaps	%xmm6, %xmm14
                	psubb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x570(%rbp)
-               	leaq	-0x570(%rbp), %rdx
-               	callq	 <L11>
-<L11>:
+               	movups	%xmm0, -0x840(%rbp)
+               	leaq	-0x840(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x580(%rbp)
-               	leaq	-0x580(%rbp), %rdx
-               	callq	 <L12>
-<L12>:
+               	movups	%xmm9, -0x850(%rbp)
+               	leaq	-0x850(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x590(%rbp)
-               	leaq	-0x590(%rbp), %rdx
-               	callq	 <L13>
-<L13>:
+               	movups	%xmm10, -0x860(%rbp)
+               	leaq	-0x860(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5a0(%rbp)
-               	leaq	-0x5a0(%rbp), %rdx
-               	callq	 <L14>
-<L14>:
+               	movups	%xmm0, -0x870(%rbp)
+               	leaq	-0x870(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5b0(%rbp)
-               	leaq	-0x5b0(%rbp), %rdx
-               	callq	 <L15>
-<L15>:
+               	movups	%xmm0, -0x880(%rbp)
+               	leaq	-0x880(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5c0(%rbp)
-               	leaq	-0x5c0(%rbp), %rdx
-               	callq	 <L16>
-<L16>:
+               	movups	%xmm0, -0x890(%rbp)
+               	leaq	-0x890(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x5d0(%rbp)
-               	leaq	-0x5d0(%rbp), %rdx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rbx
+               	movups	%xmm9, -0x8a0(%rbp)
+               	leaq	-0x8a0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rsi
                	movaps	%xmm6, %xmm9
-               	movq	$0x0, %rsi
-<L18>:
-               	leaq	-0x5e0(%rbp), %r12
+               	movq	$0x0, %rdi
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
-               	cmpq	$0x3, %rsi
-               	jb	 <L25>
-               	leaq	-0x760(%rbp), %r13
+               	cmpq	$0x3, %rdi
+               	jb	 <L24>
+               	leaq	-0x190(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1254,199 +1517,199 @@ Disassembly of section .text:
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	(%rdi), %rax
+               	leaq	(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xa28(%rbp)
+               	leaq	0x1(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x1(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%edx, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0xa30(%rbp)
+               	leaq	0x2(%r12), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x2(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xa38(%rbp)
+               	leaq	0x3(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x3(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0xa40(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa48(%rbp)
-               	leaq	0x1(%r12), %rax
+               	leaq	0x5(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0x1(%rdi), %rax
+               	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xa50(%rbp)
-               	leaq	0x2(%r12), %rax
+               	leaq	0x6(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0x2(%rdi), %rax
+               	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xa58(%rbp)
-               	leaq	0x3(%r12), %rax
+               	leaq	0x7(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0x3(%rdi), %rax
+               	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
                	movq	%r8, -0xa60(%rbp)
-               	leaq	0x4(%r12), %rax
+               	leaq	0x8(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	0x4(%rdi), %rax
+               	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa68(%rbp)
-               	leaq	0x5(%r12), %rax
+               	leaq	0x9(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0x5(%rdi), %rax
+               	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xa70(%rbp)
-               	leaq	0x6(%r12), %rax
+               	leaq	0xa(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0x6(%rdi), %rax
+               	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xa78(%rbp)
-               	leaq	0x7(%r12), %rax
+               	leaq	0xb(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0x7(%rdi), %rax
+               	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
                	movq	%r8, -0xa80(%rbp)
-               	leaq	0x8(%r12), %rax
+               	leaq	0xc(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	0x8(%rdi), %rax
+               	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa88(%rbp)
-               	leaq	0x9(%r12), %rax
-               	movzbl	(%rax), %edx
-               	leaq	0x9(%rdi), %rax
-               	movzbl	(%rax), %r14d
-               	movl	%edx, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa90(%rbp)
-               	leaq	0xa(%r12), %rax
-               	movzbl	(%rax), %r14d
-               	leaq	0xa(%rdi), %rax
-               	movzbl	(%rax), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa98(%rbp)
-               	leaq	0xb(%r12), %rax
-               	movzbl	(%rax), %r15d
-               	leaq	0xb(%rdi), %rax
-               	movzbl	(%rax), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0xaa0(%rbp)
-               	leaq	0xc(%r12), %rax
-               	movzbl	(%rax), %ecx
-               	leaq	0xc(%rdi), %rax
-               	movzbl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0xaa8(%rbp)
                	leaq	0xd(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0xd(%rdi), %rax
+               	leaq	0xd(%rbx), %rax
                	movzbl	(%rax), %r14d
                	imull	%r14d, %edx
                	leaq	0xe(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0xe(%rdi), %rax
+               	leaq	0xe(%rbx), %rax
                	movzbl	(%rax), %r15d
                	imull	%r15d, %r14d
                	leaq	0xf(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0xf(%rdi), %rax
+               	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %r15d
-               	leaq	-0x770(%rbp), %rax
+               	leaq	-0x1a0(%rbp), %rax
                	movups	%xmm7, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0xa28(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0xa30(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0xa38(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0xa40(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0xa48(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x780(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0xa50(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x790(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0xa58(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7a0(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0xa60(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7b0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0xa68(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7c0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0xa70(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7d0(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0xa78(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7e0(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0xa80(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7f0(%rbp), %rax
+               	leaq	-0x260(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0xa88(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x800(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0xa90(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x810(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0xa98(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x820(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0xaa0(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x830(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0xaa8(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x840(%rbp), %rax
+               	leaq	-0x270(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x850(%rbp), %rax
+               	leaq	-0x280(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%r14b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x860(%rbp), %rax
+               	leaq	-0x290(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%r15b, (%rcx)
@@ -1455,299 +1718,303 @@ Disassembly of section .text:
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r13), %rax
                	movups	%xmm9, (%rax)
-               	movq	%rbx, %r14
+               	movq	%rsi, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
                	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x870(%rbp)
-               	leaq	-0x870(%rbp), %rdx
+               	movups	%xmm0, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L20>
-<L20>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x8a0(%rbp), %rax
-               	movq	$0x0, (%rax)
-               	movq	$0x0, 0x8(%rax)
-               	movq	$0x0, 0x10(%rax)
-               	movq	$0x0, 0x18(%rax)
-               	movq	$0x0, 0x20(%rax)
-               	movq	$0x0, 0x28(%rax)
-               	leaq	(%rax), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rdx
-               	movups	(%rdx), %xmm0
-               	leaq	0x10(%rax), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%rax), %r15
-               	movl	$0x12345678, (%r15)     # imm = 0x12345678
-               	movl	(%rcx), %eax
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x2d0(%rbp), %r15
+               	movq	$0x0, (%r15)
+               	movq	$0x0, 0x8(%r15)
+               	movq	$0x0, 0x10(%r15)
+               	movq	$0x0, 0x18(%r15)
+               	movq	$0x0, 0x20(%r15)
+               	movq	$0x0, 0x28(%r15)
+               	leaq	(%r15), %rax
+               	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r13), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r15), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x20(%r15), %rcx
+               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	movl	(%rax), %ecx
+               	movl	%ecx, %edx
                	movq	%r14, %rcx
-               	movl	%eax, %edx
-               	callq	 <L22>
-<L22>:
-               	movups	(%r13), %xmm0
+               	callq	 <L21>
+<L21>:
+               	leaq	0x10(%r15), %rcx
+               	movups	(%rcx), %xmm0
                	movups	%xmm0, -0x8b0(%rbp)
                	leaq	-0x8b0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L22>
+<L22>:
+               	leaq	0x20(%r15), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %r13d
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
                	callq	 <L23>
 <L23>:
-               	movl	(%r15), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	-0xb60(%rbp), %xmm6
-               	movaps	-0xb70(%rbp), %xmm7
-               	movaps	-0xb80(%rbp), %xmm8
-               	movaps	-0xb90(%rbp), %xmm9
-               	movaps	-0xba0(%rbp), %xmm10
-               	movaps	-0xbb0(%rbp), %xmm14
-               	movaps	-0xbc0(%rbp), %xmm15
-               	movq	-0xb18(%rbp), %rbx
-               	movq	-0xb20(%rbp), %rdi
-               	movq	-0xb28(%rbp), %rsi
-               	movq	-0xb30(%rbp), %r12
-               	movq	-0xb38(%rbp), %r13
-               	movq	-0xb40(%rbp), %r14
-               	movq	-0xb48(%rbp), %r15
+               	movaps	-0xb40(%rbp), %xmm6
+               	movaps	-0xb50(%rbp), %xmm7
+               	movaps	-0xb60(%rbp), %xmm8
+               	movaps	-0xb70(%rbp), %xmm9
+               	movaps	-0xb80(%rbp), %xmm10
+               	movaps	-0xb90(%rbp), %xmm14
+               	movaps	-0xba0(%rbp), %xmm15
+               	movq	-0xaf8(%rbp), %rbx
+               	movq	-0xb00(%rbp), %rdi
+               	movq	-0xb08(%rbp), %rsi
+               	movq	-0xb10(%rbp), %r12
+               	movq	-0xb18(%rbp), %r13
+               	movq	-0xb20(%rbp), %r14
+               	movq	-0xb28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	(%rdi), %rcx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0xa90(%rbp)
+               	leaq	0x1(%r12), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0xa98(%rbp)
+               	leaq	0x2(%r12), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xaa0(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %edx
+               	movl	%r15d, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xaa8(%rbp)
+               	leaq	0x4(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
                	movq	%r8, -0xab0(%rbp)
-               	leaq	0x1(%r12), %rcx
+               	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x1(%rdi), %rcx
+               	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xab8(%rbp)
-               	leaq	0x2(%r12), %rcx
+               	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0x2(%rdi), %rcx
+               	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xac0(%rbp)
-               	leaq	0x3(%r12), %rcx
+               	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x3(%rdi), %rcx
+               	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xac8(%rbp)
-               	leaq	0x4(%r12), %rcx
+               	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x4(%rdi), %rcx
+               	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
                	movq	%r8, -0xad0(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x5(%rdi), %rcx
+               	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xad8(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0x6(%rdi), %rcx
+               	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xae0(%rbp)
-               	leaq	0x7(%r12), %rcx
+               	leaq	0xb(%r12), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x7(%rdi), %rcx
+               	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xae8(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xaf0(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xaf8(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xb00(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0xb08(%rbp)
                	leaq	0xc(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0xc(%rdi), %rcx
+               	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	imull	%r13d, %edx
                	leaq	0xd(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0xd(%rdi), %rcx
+               	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	imull	%r14d, %r13d
                	leaq	0xe(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0xe(%rdi), %rcx
+               	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	0xf(%r12), %rcx
                	movzbl	(%rcx), %r12d
-               	leaq	0xf(%rdi), %rcx
+               	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r12d
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x20(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0xa90(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0xa98(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0xaa0(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0xaa8(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
                	movq	-0xab0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x600(%rbp), %rcx
+               	leaq	-0x70(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x5(%rcx), %r15
                	movq	-0xab8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x610(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0xac0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x620(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0xac8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x630(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0xad0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x640(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0xad8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x650(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0xae0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x660(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0xae8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x670(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0xaf0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x680(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0xaf8(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x690(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0xb00(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x6a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0xb08(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x6b0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6c0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6d0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6e0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rcx), %xmm10
-               	movups	%xmm10, -0x6f0(%rbp)
-               	leaq	-0x6f0(%rbp), %rdx
-               	movq	%rbx, %rcx
-               	callq	 <L26>
-<L26>:
+               	movups	%xmm10, -0x120(%rbp)
+               	leaq	-0x120(%rbp), %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L25>
+<L25>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x700(%rbp)
-               	leaq	-0x700(%rbp), %rdx
+               	movups	%xmm9, -0x130(%rbp)
+               	leaq	-0x130(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	callq	 <L26>
+<L26>:
                	movaps	%xmm6, %xmm14
                	paddb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm6
-               	movups	%xmm6, -0x710(%rbp)
-               	leaq	-0x710(%rbp), %rdx
+               	movups	%xmm6, -0x140(%rbp)
+               	leaq	-0x140(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm7
-               	movups	%xmm7, -0x720(%rbp)
-               	leaq	-0x720(%rbp), %rdx
+               	movups	%xmm7, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	addq	$0x1, %rsi
-               	movq	%rax, %rbx
-               	jmp	 <L18>
+               	callq	 <L28>
+<L28>:
+               	addq	$0x1, %rdi
+               	movq	%rax, %rsi
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/vec/vec_lane_ops.dis
+++ b/test/golden/x86_64-windows/vec/vec_lane_ops.dis
@@ -5,41 +5,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,39 +121,119 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -87,25 +241,69 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_f64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movsd	(%rdx), %xmm1
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movsd	(%rbx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -113,113 +311,221 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_i8x16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x70, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	leaq	0x1(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rcx
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+<L3>:
                	leaq	0x2(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
                	leaq	0x3(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rcx
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
                	leaq	0x4(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
                	leaq	0x5(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rcx
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
                	leaq	0x6(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
-<L6>:
+               	movsbq	%sil, %rdx
                	movq	%rax, %rcx
-               	leaq	0x7(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rcx
-               	leaq	0x9(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rcx
-               	leaq	0xb(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	0xd(%rbx), %rdx
+               	leaq	0x7(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
+               	leaq	0x8(%rbx), %rdx
                	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
                	callq	 <L14>
 <L14>:
+               	leaq	0x9(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rcx
-               	leaq	0xf(%rbx), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0xa(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L16>
+<L16>:
+               	leaq	0xb(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L17>
+<L17>:
+               	leaq	0xc(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L18>
+<L18>:
+               	leaq	0xd(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	leaq	0xe(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L20>
+<L20>:
+               	leaq	0xf(%rbx), %rdx
+               	movzbl	(%rdx), %ebx
+               	movsbq	%bl, %rdx
+               	movq	%rax, %rcx
+               	callq	 <L21>
+<L21>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -227,411 +533,293 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x700, %rsp            # imm = 0x700
-               	movq	%rbx, -0x648(%rbp)
-               	movq	%rdi, -0x650(%rbp)
-               	movq	%rsi, -0x658(%rbp)
-               	movq	%r12, -0x660(%rbp)
-               	movq	%r13, -0x668(%rbp)
-               	movq	%r14, -0x670(%rbp)
-               	movq	%r15, -0x678(%rbp)
-               	movaps	%xmm6, -0x690(%rbp)
-               	movaps	%xmm7, -0x6a0(%rbp)
-               	movaps	%xmm8, -0x6b0(%rbp)
-               	movaps	%xmm9, -0x6c0(%rbp)
-               	movaps	%xmm14, -0x6d0(%rbp)
-               	movaps	%xmm15, -0x6e0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	movq	%rbx, %r11
+               	subq	$0x760, %rsp            # imm = 0x760
+               	movq	%rbx, -0x6a8(%rbp)
+               	movq	%rdi, -0x6b0(%rbp)
+               	movq	%rsi, -0x6b8(%rbp)
+               	movq	%r12, -0x6c0(%rbp)
+               	movq	%r13, -0x6c8(%rbp)
+               	movq	%r14, -0x6d0(%rbp)
+               	movq	%r15, -0x6d8(%rbp)
+               	movaps	%xmm6, -0x6f0(%rbp)
+               	movaps	%xmm7, -0x700(%rbp)
+               	movaps	%xmm8, -0x710(%rbp)
+               	movaps	%xmm9, -0x720(%rbp)
+               	movaps	%xmm14, -0x730(%rbp)
+               	movaps	%xmm15, -0x740(%rbp)
+               	movl	%ecx, %eax
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm6
                	addss	%xmm6, %xmm6
-<L2>:
-               	movq	%rbx, %r11
+<L1>:
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm7
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm7
                	addsd	%xmm7, %xmm7
-<L4>:
-               	movb	%bl, %sil
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rbx
-               	movl	$0x11111111, (%rbx)     # imm = 0x11111111
-               	leaq	0x4(%rdx), %rbx
-               	movl	$0x22222222, (%rbx)     # imm = 0x22222222
-               	leaq	0x8(%rdx), %rbx
-               	movl	$0x33333333, (%rbx)     # imm = 0x33333333
-               	leaq	0xc(%rdx), %rbx
-               	movl	$0x44444444, (%rbx)     # imm = 0x44444444
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+<L3>:
+               	movb	%cl, %bl
+               	leaq	-0x10(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movl	$0x11111111, (%rdx)     # imm = 0x11111111
+               	leaq	0x4(%rcx), %rdx
+               	movl	$0x22222222, (%rdx)     # imm = 0x22222222
+               	leaq	0x8(%rcx), %rdx
+               	movl	$0x33333333, (%rdx)     # imm = 0x33333333
+               	leaq	0xc(%rcx), %rdx
+               	movl	$0x44444444, (%rdx)     # imm = 0x44444444
+               	movups	(%rcx), %xmm0
+               	leaq	-0x20(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x30(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rbx
-               	movl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x30(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdi
-               	movl	%edx, (%rdi)
-               	movups	(%rbx), %xmm0
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0x40(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%ebx, (%rcx)
-               	movups	(%rdi), %xmm8
-               	leaq	(%rdi), %rcx
+               	leaq	(%rdx), %rsi
+               	movl	%ecx, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x40(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rax
+               	movl	%edx, (%rax)
+               	movups	(%rsi), %xmm8
+               	movups	%xmm8, -0x50(%rbp)
+               	leaq	-0x50(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L4>
+<L4>:
+               	leaq	-0x60(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	leaq	0xc(%rsi), %rcx
+               	movl	(%rcx), %r12d
+               	movups	(%rdi), %xmm0
+               	leaq	-0x70(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	%r12d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	0x8(%rsi), %rcx
+               	movl	(%rcx), %r13d
+               	movups	(%rdi), %xmm0
+               	leaq	-0x80(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r13d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rsi), %rcx
+               	movl	(%rcx), %r14d
+               	movups	(%rdi), %xmm0
+               	leaq	-0x90(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rdx
+               	movl	%r14d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rsi), %rcx
+               	movl	(%rcx), %r15d
+               	movups	(%rdi), %xmm0
+               	leaq	-0xa0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %rdx
+               	movl	%r15d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, -0xb0(%rbp)
+               	leaq	-0xb0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xd0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	%r14d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x698(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xe0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r13d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x698(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xf0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rdx
+               	movl	%r12d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x698(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x100(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %rdx
+               	movl	%r15d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x698(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movups	%xmm0, -0x110(%rbp)
+               	leaq	-0x110(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x120(%rbp), %r8
+               	movq	%r8, -0x6a0(%rbp)
+               	movq	-0x6a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x130(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	%r13d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x6a0(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x140(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r12d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x6a0(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x150(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rdx
+               	movl	%r15d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x6a0(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x160(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %rdx
+               	movl	%r14d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movq	-0x6a0(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movups	%xmm0, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	leaq	-0x50(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%rbx), %xmm0
-               	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %r12
-               	movl	%edx, (%r12)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%rbx), %xmm0
-               	leaq	-0x70(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r12
-               	movl	%edx, (%r12)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%rbx), %xmm0
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r12
-               	movl	%edx, (%r12)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%rbx), %xmm0
-               	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r12
-               	movl	%edx, (%r12)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	movups	(%rbx), %xmm0
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	-0xb0(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r12), %xmm0
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r12)
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r12), %xmm0
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r12), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r12)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r12), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r12)
-               	movups	(%r12), %xmm0
-               	leaq	-0x100(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	leaq	-0x110(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	movups	(%r13), %xmm0
-               	leaq	-0x160(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	-0x170(%rbp), %rcx
+               	leaq	-0x180(%rbp), %rcx
                	movq	$0x0, (%rcx)
                	movq	$0x0, 0x8(%rcx)
-               	leaq	0x8(%rdi), %rdx
-               	movl	(%rdx), %r14d
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r15
-               	movl	%r14d, (%r15)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%rcx)
                	movups	(%rcx), %xmm0
                	leaq	-0x190(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %r15
-               	movl	%r14d, (%r15)
+               	leaq	(%rdx), %r14
+               	movl	%r13d, (%r14)
                	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rcx)
                	movups	(%rcx), %xmm0
                	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %r15
-               	movl	%r14d, (%r15)
+               	leaq	0x4(%rdx), %r14
+               	movl	%r13d, (%r14)
                	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rcx)
                	movups	(%rcx), %xmm0
                	leaq	-0x1b0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0xc(%rdx), %r15
-               	movl	%r14d, (%r15)
+               	leaq	0x8(%rdx), %r14
+               	movl	%r13d, (%r14)
                	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rcx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r14
+               	movl	%r13d, (%r14)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%rcx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, -0x1d0(%rbp)
+               	leaq	-0x1d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	leaq	-0x1d0(%rbp), %rcx
+               	callq	 <L8>
+<L8>:
+               	leaq	-0x1e0(%rbp), %rcx
                	movq	$0x0, (%rcx)
                	movq	$0x0, 0x8(%rcx)
-               	leaq	(%rdi), %rdx
-               	movl	(%rdx), %r14d
                	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rdx
+               	leaq	-0x1f0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %r15
-               	movl	%r14d, (%r15)
+               	leaq	0x4(%rdx), %r13
+               	movl	%r15d, (%r13)
                	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rcx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x200(%rbp), %rcx
+               	callq	 <L9>
+<L9>:
+               	leaq	-0x210(%rbp), %rcx
                	movups	%xmm8, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movl	%edx, (%r14)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r15d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x210(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0x4(%r14), %rcx
-               	movl	%edx, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
                	leaq	-0x220(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r12d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	leaq	-0x240(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x0, (%rdx)
                	leaq	0x4(%rcx), %rdx
@@ -641,472 +829,312 @@ Disassembly of section .text:
                	leaq	0xc(%rcx), %rdx
                	movl	$0x0, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	(%rdi), %rcx
+               	addl	$0x1, %r15d
+               	leaq	-0x250(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	(%r12), %rcx
+               	movl	%r15d, (%rcx)
+               	movups	(%r12), %xmm9
+               	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	addl	$0x1, %edx
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm9
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r14d
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%rdi), %rcx
+               	movq	%r13, %rdx
+               	callq	 <L11>
+<L11>:
+               	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	addl	%edx, %r14d
-               	leaq	-0x240(%rbp), %rcx
+               	leaq	0x4(%rsi), %rcx
+               	movl	(%rcx), %r12d
+               	addl	%r12d, %edx
+               	leaq	-0x260(%rbp), %r12
+               	movups	%xmm9, (%r12)
+               	leaq	0x4(%r12), %rcx
+               	movl	%edx, (%rcx)
+               	movups	(%r12), %xmm9
+               	leaq	0x4(%r12), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %r13d
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L12>
+<L12>:
+               	leaq	0x4(%r12), %rcx
+               	movl	(%rcx), %edx
+               	leaq	0x8(%rsi), %rcx
+               	movl	(%rcx), %r12d
+               	xorl	%r12d, %edx
+               	leaq	-0x270(%rbp), %r12
+               	movups	%xmm9, (%r12)
+               	leaq	0x8(%r12), %rcx
+               	movl	%edx, (%rcx)
+               	movups	(%r12), %xmm9
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %r13d
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L13>
+<L13>:
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %edx
+               	leaq	0xc(%rsi), %rcx
+               	movl	(%rcx), %r12d
+               	subl	%r12d, %edx
+               	leaq	-0x280(%rbp), %rcx
                	movups	%xmm9, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%r14d, (%rdx)
+               	leaq	0xc(%rcx), %r12
+               	movl	%edx, (%r12)
                	movups	(%rcx), %xmm9
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %r14d
+               	leaq	0xc(%rcx), %rdx
+               	movl	(%rdx), %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	xorl	%edx, %r14d
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm9, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm9
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r14d
+               	callq	 <L14>
+<L14>:
+               	movups	%xmm9, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	movq	%rax, %rcx
-               	movl	%r14d, %edx
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	subl	%edx, %r14d
-               	leaq	-0x260(%rbp), %r15
-               	movups	%xmm9, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm0
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	movups	(%rbx), %xmm0
+               	callq	 <L15>
+<L15>:
+               	movups	(%rdi), %xmm0
                	movaps	%xmm0, %xmm14
                	paddd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	movups	(%r12), %xmm0
+               	callq	 <L16>
+<L16>:
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm0
                	movaps	%xmm0, %xmm14
                	psubd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x280(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x638(%rbp)
-               	movq	-0x638(%rbp), %r8
-               	movups	(%r13), %xmm0
-               	leaq	-0x290(%rbp), %rcx
+               	callq	 <L17>
+<L17>:
+               	movq	-0x6a0(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x2c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	(%rsi), %rdx
                	movl	(%rdx), %r13d
-               	leaq	(%rdi), %rdx
+               	imull	%r13d, %r12d
+               	leaq	0x4(%rcx), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %r14d
                	imull	%r14d, %r13d
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x8(%rcx), %rdx
                	movl	(%rdx), %r14d
-               	leaq	0x4(%rdi), %rdx
+               	leaq	0x8(%rsi), %rdx
                	movl	(%rdx), %r15d
                	imull	%r15d, %r14d
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r15d
-               	leaq	0x8(%rdi), %rdx
-               	movl	(%rdx), %eax
-               	imull	%eax, %r15d
-               	leaq	0xc(%rcx), %rax
-               	movl	(%rax), %ecx
-               	leaq	0xc(%rdi), %rax
-               	movl	(%rax), %edx
-               	imull	%edx, %ecx
-               	leaq	-0x2a0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	(%rax), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x2b0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x2c0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movl	%r15d, (%rdx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x2d0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rax
-               	movl	%ecx, (%rax)
+               	leaq	0xc(%rcx), %rdx
+               	movl	(%rdx), %ecx
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %esi
+               	imull	%esi, %ecx
+               	leaq	-0x2d0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	%r12d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2f0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movl	%r14d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x300(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%ecx, (%rsi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x310(%rbp)
+               	leaq	-0x310(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L18>
+<L18>:
                	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rax
-               	movl	(%rax), %edx
-               	movq	-0x638(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
-               	movups	(%rbx), %xmm0
-               	movups	(%r12), %xmm1
+               	movq	-0x698(%rbp), %r8
+               	movups	(%r8), %xmm1
                	movaps	%xmm0, %xmm14
                	pxor	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x320(%rbp)
+               	leaq	-0x320(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2f0(%rbp), %rcx
+               	callq	 <L19>
+<L19>:
+               	leaq	-0x330(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
-               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x8f5>
-               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x8fc>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x773>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x77a>
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40700000, (%rdx)     # imm = 0x40700000
-               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x916>
-               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x91d>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x794>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x79b>
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	addss	%xmm6, %xmm2
-               	leaq	-0x310(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x4(%rbx), %rcx
+               	leaq	-0x350(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x4(%rsi), %rcx
                	movss	%xmm2, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, -0x360(%rbp)
+               	leaq	-0x360(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L60>
-<L60>:
-               	leaq	-0x320(%rbp), %rdi
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x370(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x330(%rbp), %rcx
+               	leaq	-0x380(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%rdi), %xmm1
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	leaq	0x8(%rsi), %rcx
+               	movss	(%rcx), %xmm6
+               	movups	(%rdi), %xmm0
+               	leaq	-0x390(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movss	%xmm6, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x350(%rbp), %rcx
+               	leaq	-0x3a0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%rdi), %xmm1
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	leaq	(%rsi), %rcx
+               	movss	(%rcx), %xmm8
+               	movups	(%rdi), %xmm0
+               	leaq	-0x3b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movss	%xmm8, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rdi)
                	movups	(%rdi), %xmm0
-               	leaq	-0x370(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	leaq	-0x380(%rbp), %r12
+               	callq	 <L21>
+<L21>:
+               	leaq	-0x3d0(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r12), %xmm1
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	movups	(%r12), %xmm0
+               	leaq	-0x3e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movss	%xmm8, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
+               	leaq	-0x3f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm0
                	movups	(%r12), %xmm1
-               	leaq	-0x3b0(%rbp), %rcx
+               	leaq	-0x400(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r12)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r12), %xmm1
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	movups	(%r12), %xmm0
+               	leaq	-0x410(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movss	%xmm6, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	-0x3d0(%rbp), %rcx
+               	leaq	-0x420(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	(%rdx), %xmm0
                	movups	(%r12), %xmm1
-               	leaq	-0x3e0(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r12)
                	movups	(%r12), %xmm0
-               	leaq	-0x3f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x440(%rbp)
+               	leaq	-0x440(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
+               	callq	 <L22>
+<L22>:
                	movups	(%r12), %xmm0
                	movups	(%rdi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x400(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x450(%rbp)
+               	leaq	-0x450(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L72>
-<L72>:
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%rdi), %xmm1
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	callq	 <L23>
+<L23>:
+               	movups	(%rdi), %xmm0
+               	leaq	-0x460(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
+               	movss	(%rdx), %xmm0
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	subss	%xmm0, %xmm1
+               	movd	%xmm1, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%rbx), %rcx
+               	callq	 <L24>
+<L24>:
+               	leaq	0xc(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x420(%rbp), %rcx
+               	leaq	-0x470(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	subss	%xmm1, %xmm2
+               	movd	%xmm2, %ecx
+               	movl	%ecx, %edx
                	movq	%rax, %rcx
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x430(%rbp), %rcx
+               	callq	 <L25>
+<L25>:
+               	leaq	-0x480(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1114,78 +1142,59 @@ Disassembly of section .text:
                	movabsq	$-0x3ffe000000000000, %r11 # imm = 0xC002000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
+               	leaq	-0x490(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	(%rdx), %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	addsd	%xmm7, %xmm2
-               	leaq	-0x450(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	%xmm2, (%rcx)
-               	movups	(%rbx), %xmm6
-               	leaq	-0x460(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movq	$0x0, 0x8(%rdi)
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%rdi), %xmm1
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
+               	leaq	-0x4a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movsd	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%rdi), %xmm1
-               	leaq	-0x480(%rbp), %rcx
+               	movsd	%xmm2, (%rdx)
+               	movups	(%rcx), %xmm6
+               	leaq	-0x4b0(%rbp), %rsi
+               	movq	$0x0, (%rsi)
+               	movq	$0x0, 0x8(%rsi)
+               	leaq	0x8(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%rsi), %xmm1
+               	leaq	-0x4c0(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rdx), %rdi
+               	movsd	%xmm0, (%rdi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%rsi), %xmm1
+               	leaq	-0x4d0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movsd	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
+               	movups	%xmm0, (%rsi)
+               	movups	%xmm6, -0x4e0(%rbp)
+               	leaq	-0x4e0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
+               	callq	 <L26>
+<L26>:
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, -0x4f0(%rbp)
+               	leaq	-0x4f0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	movups	(%rdi), %xmm0
-               	leaq	-0x490(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
-               	movups	(%rdi), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movups	(%rsi), %xmm0
                	movaps	%xmm0, %xmm14
                	subpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x4a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
+               	movups	%xmm0, -0x500(%rbp)
+               	leaq	-0x500(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm1
-               	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
-               	leaq	-0x4b0(%rbp), %rcx
+               	callq	 <L28>
+<L28>:
+               	leaq	-0x510(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$-0x9, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1219,36 +1228,36 @@ Disassembly of section .text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x8, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movzbl	(%rdx), %ecx
-               	addl	%esi, %ecx
-               	leaq	-0x4d0(%rbp), %rdx
+               	addl	%ebx, %ecx
+               	leaq	-0x530(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rbx
-               	movb	%cl, (%rbx)
+               	leaq	(%rdx), %rsi
+               	movb	%cl, (%rsi)
                	movups	(%rdx), %xmm0
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
-               	addl	%esi, %edx
-               	leaq	-0x4e0(%rbp), %rbx
+               	addl	%ebx, %edx
+               	leaq	-0x540(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	0xf(%rbx), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rbx), %xmm6
-               	movups	%xmm6, -0x4f0(%rbp)
-               	leaq	-0x4f0(%rbp), %rdx
+               	movups	%xmm6, -0x550(%rbp)
+               	leaq	-0x550(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
-               	leaq	-0x500(%rbp), %rsi
+               	callq	 <L29>
+<L29>:
+               	leaq	-0x560(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x570(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1257,7 +1266,7 @@ Disassembly of section .text:
                	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x580(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1266,7 +1275,7 @@ Disassembly of section .text:
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x590(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1275,7 +1284,7 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x5a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1284,7 +1293,7 @@ Disassembly of section .text:
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x5b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1293,7 +1302,7 @@ Disassembly of section .text:
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x5c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1302,7 +1311,7 @@ Disassembly of section .text:
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x5d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1311,7 +1320,7 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x5e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1320,7 +1329,7 @@ Disassembly of section .text:
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x5f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1329,7 +1338,7 @@ Disassembly of section .text:
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x600(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1338,7 +1347,7 @@ Disassembly of section .text:
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x610(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1347,7 +1356,7 @@ Disassembly of section .text:
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x620(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1356,7 +1365,7 @@ Disassembly of section .text:
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x630(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1365,7 +1374,7 @@ Disassembly of section .text:
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5e0(%rbp), %rcx
+               	leaq	-0x640(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1374,7 +1383,7 @@ Disassembly of section .text:
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x650(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1383,49 +1392,49 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x600(%rbp), %rcx
+               	leaq	-0x660(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rbx
                	movb	%dl, (%rbx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rsi)
                	movups	(%rsi), %xmm0
-               	movups	%xmm0, -0x610(%rbp)
-               	leaq	-0x610(%rbp), %rdx
+               	movups	%xmm0, -0x670(%rbp)
+               	leaq	-0x670(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
+               	callq	 <L30>
+<L30>:
                	movups	(%rsi), %xmm0
                	movaps	%xmm0, %xmm14
                	paddb	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x620(%rbp)
-               	leaq	-0x620(%rbp), %rdx
+               	movups	%xmm0, -0x680(%rbp)
+               	leaq	-0x680(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
+               	callq	 <L31>
+<L31>:
                	movups	(%rsi), %xmm0
                	movaps	%xmm0, %xmm14
                	pxor	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x630(%rbp)
-               	leaq	-0x630(%rbp), %rdx
+               	movups	%xmm0, -0x690(%rbp)
+               	leaq	-0x690(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
-               	movaps	-0x690(%rbp), %xmm6
-               	movaps	-0x6a0(%rbp), %xmm7
-               	movaps	-0x6b0(%rbp), %xmm8
-               	movaps	-0x6c0(%rbp), %xmm9
-               	movaps	-0x6d0(%rbp), %xmm14
-               	movaps	-0x6e0(%rbp), %xmm15
-               	movq	-0x648(%rbp), %rbx
-               	movq	-0x650(%rbp), %rdi
-               	movq	-0x658(%rbp), %rsi
-               	movq	-0x660(%rbp), %r12
-               	movq	-0x668(%rbp), %r13
-               	movq	-0x670(%rbp), %r14
-               	movq	-0x678(%rbp), %r15
+               	callq	 <L32>
+<L32>:
+               	movaps	-0x6f0(%rbp), %xmm6
+               	movaps	-0x700(%rbp), %xmm7
+               	movaps	-0x710(%rbp), %xmm8
+               	movaps	-0x720(%rbp), %xmm9
+               	movaps	-0x730(%rbp), %xmm14
+               	movaps	-0x740(%rbp), %xmm15
+               	movq	-0x6a8(%rbp), %rbx
+               	movq	-0x6b0(%rbp), %rdi
+               	movq	-0x6b8(%rbp), %rsi
+               	movq	-0x6c0(%rbp), %r12
+               	movq	-0x6c8(%rbp), %r13
+               	movq	-0x6d0(%rbp), %r14
+               	movq	-0x6d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_mem.dis
+++ b/test/golden/x86_64-windows/vec/vec_mem.dis
@@ -5,10 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.fold3>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
+               	subq	$0x70, %rsp
                	movq	%rbx, -0x38(%rbp)
-               	movaps	%xmm14, -0x50(%rbp)
-               	movaps	%xmm15, -0x60(%rbp)
+               	movq	%rdi, -0x40(%rbp)
+               	movq	%rsi, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movaps	%xmm14, -0x60(%rbp)
+               	movaps	%xmm15, -0x70(%rbp)
+               	movq	%rcx, %rax
                	movq	$0x0, -0x10(%rbp)
                	movq	$0x0, -0x8(%rbp)
                	movq	(%rdx), %rbx
@@ -16,32 +20,90 @@ Disassembly of section .text:
                	movl	0x8(%rdx), %ebx
                	movl	%ebx, -0x8(%rbp)
                	movups	-0x10(%rbp), %xmm0
-               	leaq	-0x1c(%rbp), %rbx
+               	leaq	-0x1c(%rbp), %rdx
                	movups	%xmm0, -0x2c(%rbp)
-               	movq	-0x2c(%rbp), %rdx
-               	movq	%rdx, (%rbx)
-               	movl	-0x24(%rbp), %edx
-               	movl	%edx, 0x8(%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movq	-0x2c(%rbp), %rbx
+               	movq	%rbx, (%rdx)
+               	movl	-0x24(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movaps	-0x50(%rbp), %xmm14
-               	movaps	-0x60(%rbp), %xmm15
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movaps	-0x60(%rbp), %xmm14
+               	movaps	-0x70(%rbp), %xmm15
                	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %rdi
+               	movq	-0x48(%rbp), %rsi
+               	movq	-0x50(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -49,46 +111,143 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.fold5>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xc0, %rsp
+               	subq	$0xb0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rdx, %rbx
-               	leaq	-0x20(%rbp), %rdx
-               	movq	%rbx, (%rdx)
-               	leaq	-0x34(%rbp), %rdx
-               	leaq	-0x48(%rbp), %rdx
-               	leaq	-0x5c(%rbp), %rdx
-               	leaq	-0x70(%rbp), %rdx
-               	leaq	-0x84(%rbp), %rdx
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	movq	%rdi, -0xa0(%rbp)
+               	movq	%rsi, -0xa8(%rbp)
+               	movq	%r12, -0xb0(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x20(%rbp), %rbx
+               	movq	%rdx, (%rbx)
+               	leaq	-0x34(%rbp), %rbx
+               	leaq	-0x48(%rbp), %rbx
+               	leaq	-0x5c(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rbx
+               	leaq	-0x84(%rbp), %rbx
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x10(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L4>
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %rdi
+               	movq	-0xa8(%rbp), %rsi
+               	movq	-0xb0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -96,1539 +255,1507 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xaf0, %rsp            # imm = 0xAF0
-               	movq	%rbx, -0xa68(%rbp)
-               	movq	%rdi, -0xa70(%rbp)
-               	movq	%rsi, -0xa78(%rbp)
-               	movq	%r12, -0xa80(%rbp)
-               	movq	%r13, -0xa88(%rbp)
-               	movq	%r14, -0xa90(%rbp)
-               	movq	%r15, -0xa98(%rbp)
-               	movaps	%xmm6, -0xab0(%rbp)
-               	movaps	%xmm14, -0xac0(%rbp)
-               	movaps	%xmm15, -0xad0(%rbp)
-               	movq	%rcx, %rbx
+               	subq	$0xaa0, %rsp            # imm = 0xAA0
+               	movq	%rbx, -0xa08(%rbp)
+               	movq	%rdi, -0xa10(%rbp)
+               	movq	%rsi, -0xa18(%rbp)
+               	movq	%r12, -0xa20(%rbp)
+               	movq	%r13, -0xa28(%rbp)
+               	movq	%r14, -0xa30(%rbp)
+               	movq	%r15, -0xa38(%rbp)
+               	movaps	%xmm6, -0xa50(%rbp)
+               	movaps	%xmm7, -0xa60(%rbp)
+               	movaps	%xmm14, -0xa70(%rbp)
+               	movaps	%xmm15, -0xa80(%rbp)
+               	movq	%rcx, %rax
                	leaq	-0x14(%rbp), %r8
-               	movq	%r8, -0x918(%rbp)
-               	leaq	-0x28(%rbp), %r8
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
+               	leaq	-0x28(%rbp), %rsi
                	leaq	-0x3c(%rbp), %r8
-               	movq	%r8, -0x928(%rbp)
-               	leaq	-0x50(%rbp), %r8
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
+               	leaq	-0x50(%rbp), %r12
                	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0x938(%rbp)
-               	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x998(%rbp)
-               	leaq	-0x8c(%rbp), %r8
-               	movq	%r8, -0x9a8(%rbp)
-               	leaq	-0xa0(%rbp), %rdi
-               	leaq	-0xb4(%rbp), %r12
-               	leaq	-0xc8(%rbp), %r13
-               	leaq	-0xdc(%rbp), %r14
+               	movq	%r8, -0x908(%rbp)
+               	leaq	-0x78(%rbp), %r14
+               	leaq	-0x8c(%rbp), %r15
+               	leaq	-0xa0(%rbp), %r8
+               	movq	%r8, -0x828(%rbp)
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x830(%rbp)
+               	leaq	-0xc8(%rbp), %r8
+               	movq	%r8, -0x838(%rbp)
+               	leaq	-0xdc(%rbp), %r8
+               	movq	%r8, -0x840(%rbp)
                	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0x940(%rbp)
+               	movq	%r8, -0x848(%rbp)
                	leaq	-0x104(%rbp), %r8
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x850(%rbp)
                	leaq	-0x118(%rbp), %r8
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x858(%rbp)
                	leaq	-0x12c(%rbp), %r8
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x860(%rbp)
                	leaq	-0x140(%rbp), %r8
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x868(%rbp)
                	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x870(%rbp)
                	leaq	-0x168(%rbp), %r8
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x878(%rbp)
                	leaq	-0x17c(%rbp), %r8
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x880(%rbp)
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x980(%rbp)
-               	leaq	-0x1a4(%rbp), %rcx
-               	leaq	-0x1b8(%rbp), %rcx
-               	leaq	-0x1cc(%rbp), %rcx
-               	leaq	-0x1e0(%rbp), %rcx
-               	leaq	-0x1f4(%rbp), %rcx
-               	leaq	-0x208(%rbp), %rcx
-               	leaq	-0x21c(%rbp), %rcx
-               	leaq	-0x230(%rbp), %rcx
-               	leaq	-0x244(%rbp), %rcx
-               	leaq	-0x258(%rbp), %rcx
-               	leaq	-0x26c(%rbp), %rcx
-               	leaq	-0x280(%rbp), %rcx
-               	leaq	-0x294(%rbp), %rcx
-               	leaq	-0x2a8(%rbp), %rcx
-               	leaq	-0x2bc(%rbp), %rcx
-               	leaq	-0x2d0(%rbp), %rcx
-               	leaq	-0x2e4(%rbp), %rcx
-               	leaq	-0x2f8(%rbp), %rcx
-               	leaq	-0x30c(%rbp), %rcx
-               	leaq	-0x320(%rbp), %rcx
-               	leaq	-0x334(%rbp), %rcx
-               	leaq	-0x348(%rbp), %rcx
-               	leaq	-0x35c(%rbp), %rcx
-               	leaq	-0x370(%rbp), %rcx
-               	leaq	-0x384(%rbp), %rcx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x988(%rbp)
-               	movq	-0x988(%rbp), %r8
-               	movq	%rbx, %r11
+               	movq	%r8, -0x888(%rbp)
+               	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm6
                	addss	%xmm6, %xmm6
-<L2>:
-               	leaq	-0x3d8(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	addq	$0x0, %rcx
+<L1>:
+               	leaq	-0x484(%rbp), %r8
+               	movq	%r8, -0xa00(%rbp)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	%rdx, %r8
+               	addq	$0x0, %r8
+               	movq	%r8, -0x890(%rbp)
                	movq	$0x50, %rdx
-<L3>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L2>:
+               	movq	-0x890(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x890(%rbp), %r8
+               	addq	$0x8, %r8
+               	movq	%r8, -0x890(%rbp)
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L3>
-               	movl	$0x0, (%rcx)
+               	jne	 <L2>
+               	movq	-0x890(%rbp), %r8
+               	movl	$0x0, (%r8)
                	movq	$0x0, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
+               	movq	%r8, -0x898(%rbp)
+               	movq	-0x898(%rbp), %r8
                	cmpq	$0x7, %r8
-               	jb	 <L4>
-               	jmp	 <L7>
-<L4>:
-               	movq	-0x990(%rbp), %r8
+               	jb	 <L3>
+               	jmp	 <L6>
+<L3>:
+               	movq	-0x898(%rbp), %r8
                	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
-               	leaq	-0x3e4(%rbp), %rdx
-               	movq	$0x0, (%rdx)
-               	movl	$0x0, 0x8(%rdx)
+<L5>:
+               	leaq	-0x19c(%rbp), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x8a0(%rbp), %r8
+               	movl	$0x0, 0x8(%r8)
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
-               	movq	$0x0, -0x3f4(%rbp)
-               	movq	$0x0, -0x3ec(%rbp)
-               	movq	(%rdx), %rax
-               	movq	%rax, -0x3f4(%rbp)
-               	movl	0x8(%rdx), %eax
-               	movl	%eax, -0x3ec(%rbp)
-               	movups	-0x3f4(%rbp), %xmm2
-               	leaq	-0x400(%rbp), %rax
-               	movups	%xmm2, -0x410(%rbp)
-               	movq	-0x410(%rbp), %rcx
-               	movq	%rcx, (%rax)
-               	movl	-0x408(%rbp), %ecx
-               	movl	%ecx, 0x8(%rax)
-               	leaq	(%rax), %rcx
-               	movss	%xmm1, (%rcx)
-               	movq	$0x0, -0x420(%rbp)
-               	movq	$0x0, -0x418(%rbp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, -0x420(%rbp)
-               	movl	0x8(%rax), %ecx
-               	movl	%ecx, -0x418(%rbp)
-               	movups	-0x420(%rbp), %xmm1
-               	movups	%xmm1, -0x430(%rbp)
-               	movq	-0x430(%rbp), %rax
-               	movq	%rax, (%rdx)
-               	movl	-0x428(%rbp), %eax
-               	movl	%eax, 0x8(%rdx)
+               	movq	$0x0, -0x1ac(%rbp)
+               	movq	$0x0, -0x1a4(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x1ac(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x1a4(%rbp)
+               	movups	-0x1ac(%rbp), %xmm2
+               	leaq	-0x1b8(%rbp), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movups	%xmm2, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %rdx
+               	movq	-0x8a8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x1c0(%rbp), %edx
+               	movq	-0x8a8(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	$0x0, -0x1d8(%rbp)
+               	movq	$0x0, -0x1d0(%rbp)
+               	movq	-0x8a8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x1d8(%rbp)
+               	movq	-0x8a8(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x1d0(%rbp)
+               	movups	-0x1d8(%rbp), %xmm1
+               	movups	%xmm1, -0x1e8(%rbp)
+               	movq	-0x1e8(%rbp), %rdx
+               	movq	-0x8a0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x1e0(%rbp), %edx
+               	movq	-0x8a0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x387>
-               	movq	$0x0, -0x440(%rbp)
-               	movq	$0x0, -0x438(%rbp)
-               	movq	(%rdx), %rax
-               	movq	%rax, -0x440(%rbp)
-               	movl	0x8(%rdx), %eax
-               	movl	%eax, -0x438(%rbp)
-               	movups	-0x440(%rbp), %xmm2
-               	leaq	-0x44c(%rbp), %rax
-               	movups	%xmm2, -0x45c(%rbp)
-               	movq	-0x45c(%rbp), %rcx
-               	movq	%rcx, (%rax)
-               	movl	-0x454(%rbp), %ecx
-               	movl	%ecx, 0x8(%rax)
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm1, (%rcx)
-               	movq	$0x0, -0x46c(%rbp)
-               	movq	$0x0, -0x464(%rbp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, -0x46c(%rbp)
-               	movl	0x8(%rax), %ecx
-               	movl	%ecx, -0x464(%rbp)
-               	movups	-0x46c(%rbp), %xmm1
-               	movups	%xmm1, -0x47c(%rbp)
-               	movq	-0x47c(%rbp), %rax
-               	movq	%rax, (%rdx)
-               	movl	-0x474(%rbp), %eax
-               	movl	%eax, 0x8(%rdx)
-               	movss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x432>
+               	subss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x35e>
+               	movq	$0x0, -0x1f8(%rbp)
+               	movq	$0x0, -0x1f0(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x1f8(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x1f0(%rbp)
+               	movups	-0x1f8(%rbp), %xmm2
+               	leaq	-0x204(%rbp), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movups	%xmm2, -0x214(%rbp)
+               	movq	-0x214(%rbp), %rdx
+               	movq	-0x8b0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x20c(%rbp), %edx
+               	movq	-0x8b0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	$0x0, -0x224(%rbp)
+               	movq	$0x0, -0x21c(%rbp)
+               	movq	-0x8b0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x224(%rbp)
+               	movq	-0x8b0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x21c(%rbp)
+               	movups	-0x224(%rbp), %xmm1
+               	movups	%xmm1, -0x234(%rbp)
+               	movq	-0x234(%rbp), %rdx
+               	movq	-0x8a0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x22c(%rbp), %edx
+               	movq	-0x8a0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x453>
                	subss	%xmm0, %xmm1
-               	movq	$0x0, -0x48c(%rbp)
-               	movq	$0x0, -0x484(%rbp)
-               	movq	(%rdx), %rax
-               	movq	%rax, -0x48c(%rbp)
-               	movl	0x8(%rdx), %eax
-               	movl	%eax, -0x484(%rbp)
-               	movups	-0x48c(%rbp), %xmm0
-               	leaq	-0x498(%rbp), %rax
-               	movups	%xmm0, -0x4a8(%rbp)
-               	movq	-0x4a8(%rbp), %rcx
-               	movq	%rcx, (%rax)
-               	movl	-0x4a0(%rbp), %ecx
-               	movl	%ecx, 0x8(%rax)
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm1, (%rcx)
-               	movq	$0x0, -0x4b8(%rbp)
-               	movq	$0x0, -0x4b0(%rbp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, -0x4b8(%rbp)
-               	movl	0x8(%rax), %ecx
-               	movl	%ecx, -0x4b0(%rbp)
-               	movups	-0x4b8(%rbp), %xmm0
-               	movups	%xmm0, -0x4c8(%rbp)
-               	movq	-0x4c8(%rbp), %rax
-               	movq	%rax, (%rdx)
-               	movl	-0x4c0(%rbp), %eax
-               	movl	%eax, 0x8(%rdx)
-               	movq	$0x0, -0x4d8(%rbp)
-               	movq	$0x0, -0x4d0(%rbp)
-               	movq	(%rdx), %rax
-               	movq	%rax, -0x4d8(%rbp)
-               	movl	0x8(%rdx), %eax
-               	movl	%eax, -0x4d0(%rbp)
-               	movups	-0x4d8(%rbp), %xmm0
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	imulq	$0xc, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	movups	%xmm0, -0x4e8(%rbp)
-               	movq	-0x4e8(%rbp), %rax
-               	movq	%rax, (%rcx)
-               	movl	-0x4e0(%rbp), %eax
-               	movl	%eax, 0x8(%rcx)
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
-               	cmpq	$0x7, %r8
-               	jb	 <L4>
-<L7>:
-               	movq	-0x988(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa28(%rbp)
-               	movq	$0x7, %r8
-               	movq	%r8, -0xa30(%rbp)
-               	movq	-0xa30(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-               	jmp	 <L12>
-<L8>:
-               	movq	-0xa30(%rbp), %r8
-               	movq	%r8, %r15
-               	subq	$0x1, %r15
-               	movq	%r15, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %r8
-               	movq	%r8, -0x9a0(%rbp)
-               	movq	$0x0, -0x4f8(%rbp)
-               	movq	$0x0, -0x4f0(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	%rcx, -0x4f8(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movl	0x8(%r8), %ecx
-               	movl	%ecx, -0x4f0(%rbp)
-               	movups	-0x4f8(%rbp), %xmm0
-               	leaq	-0x504(%rbp), %rsi
-               	movups	%xmm0, -0x514(%rbp)
-               	movq	-0x514(%rbp), %rcx
-               	movq	%rcx, (%rsi)
-               	movl	-0x50c(%rbp), %ecx
-               	movl	%ecx, 0x8(%rsi)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xa28(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b0(%rbp)
-               	movq	-0x9b0(%rbp), %r8
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x9b0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b8(%rbp)
-               	movq	-0x9b8(%rbp), %r8
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x9b8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0xa28(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0xa30(%rbp)
-               	movq	-0xa30(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-<L12>:
-               	leaq	-0x554(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movq	$0x0, 0x20(%rsi)
-               	movq	$0x0, 0x28(%rsi)
-               	movq	$0x0, 0x30(%rsi)
-               	movq	$0x0, 0x38(%rsi)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L13>
-               	jmp	 <L14>
-<L13>:
-               	movq	-0x9c0(%rbp), %r8
+               	movq	$0x0, -0x244(%rbp)
+               	movq	$0x0, -0x23c(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x244(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x23c(%rbp)
+               	movups	-0x244(%rbp), %xmm0
+               	leaq	-0x250(%rbp), %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movups	%xmm0, -0x260(%rbp)
+               	movq	-0x260(%rbp), %rdx
+               	movq	-0x8b8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x258(%rbp), %edx
+               	movq	-0x8b8(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	movq	$0x0, -0x270(%rbp)
+               	movq	$0x0, -0x268(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x270(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x268(%rbp)
+               	movups	-0x270(%rbp), %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	movq	-0x280(%rbp), %rdx
+               	movq	-0x8a0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x278(%rbp), %edx
+               	movq	-0x8a0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	$0x0, -0x290(%rbp)
+               	movq	$0x0, -0x288(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x290(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x288(%rbp)
+               	movups	-0x290(%rbp), %xmm0
+               	movq	-0x898(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0xc, %rdx, %rdx
-               	leaq	(%rbx,%rdx), %r15
-               	movq	$0x0, -0x564(%rbp)
-               	movq	$0x0, -0x55c(%rbp)
-               	movq	(%r15), %rdx
-               	movq	%rdx, -0x564(%rbp)
-               	movl	0x8(%r15), %edx
-               	movl	%edx, -0x55c(%rbp)
-               	movups	-0x564(%rbp), %xmm0
-               	movq	-0x9c0(%rbp), %r8
+               	movq	-0xa00(%rbp), %r9
+               	leaq	(%r9,%rdx), %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movups	%xmm0, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %rdx
+               	movq	-0x8c0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x298(%rbp), %edx
+               	movq	-0x8c0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x898(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x898(%rbp)
+               	movq	-0x898(%rbp), %r8
+               	cmpq	$0x7, %r8
+               	jb	 <L3>
+<L6>:
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x7, %rdi
+               	movq	$0x0, %r11
+               	cmpq	%rdi, %r11
+               	jb	 <L7>
+               	jmp	 <L9>
+<L7>:
+               	subq	$0x1, %rdi
+               	movq	%rdi, %rdx
+               	imulq	$0xc, %rdx, %rdx
+               	movq	-0xa00(%rbp), %r9
+               	leaq	(%r9,%rdx), %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	$0x0, -0x2b0(%rbp)
+               	movq	$0x0, -0x2a8(%rbp)
+               	movq	-0x8d8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x2b0(%rbp)
+               	movq	-0x8d8(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x2a8(%rbp)
+               	movups	-0x2b0(%rbp), %xmm0
+               	movups	%xmm0, -0x2d0(%rbp)
+               	movq	-0x2d0(%rbp), %rdx
+               	movq	%rdx, -0x2c0(%rbp)
+               	movl	-0x2c8(%rbp), %edx
+               	movl	%edx, -0x2b8(%rbp)
+               	leaq	-0x2c0(%rbp), %rdx
+               	movq	%rbx, %rcx
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rbx
+               	movq	$0x0, %r11
+               	cmpq	%rdi, %r11
+               	jb	 <L7>
+<L9>:
+               	leaq	-0x310(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movq	$0x0, 0x10(%rdi)
+               	movq	$0x0, 0x18(%rdi)
+               	movq	$0x0, 0x20(%rdi)
+               	movq	$0x0, 0x28(%rdi)
+               	movq	$0x0, 0x30(%rdi)
+               	movq	$0x0, 0x38(%rdi)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0xc, %rdx, %rdx
+               	movq	-0xa00(%rbp), %r9
+               	leaq	(%r9,%rdx), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	$0x0, -0x320(%rbp)
+               	movq	$0x0, -0x318(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x320(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x318(%rbp)
+               	movups	-0x320(%rbp), %xmm0
+               	movq	-0x8e0(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
-               	leaq	(%rsi,%rdx), %r15
-               	leaq	(%r15), %rdx
-               	movups	%xmm0, -0x574(%rbp)
-               	movq	-0x574(%rbp), %rcx
-               	movq	%rcx, (%rdx)
-               	movl	-0x56c(%rbp), %ecx
-               	movl	%ecx, 0x8(%rdx)
-               	movq	-0x9c0(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	$0xaaaaaaaa, %edx       # imm = 0xAAAAAAAA
-               	subl	%ecx, %edx
-               	leaq	0xc(%r15), %rcx
-               	movl	%edx, (%rcx)
-               	movq	-0x9c0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
+               	leaq	(%rdi,%rdx), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x8f0(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movups	%xmm0, -0x330(%rbp)
+               	movq	-0x330(%rbp), %rdx
+               	movq	-0x8f8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x328(%rbp), %edx
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x8e0(%rbp), %r8
+               	movl	%r8d, %edx
+               	movl	$0xaaaaaaaa, %r8d       # imm = 0xAAAAAAAA
+               	subl	%edx, %r8d
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movq	-0x900(%rbp), %r8
+               	movl	%r8d, (%rdx)
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	-0x8e0(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L13>
-<L14>:
-               	movq	-0xa28(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0xa38(%rbp)
-               	movq	-0xa38(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L15>
-               	jmp	 <L20>
-<L15>:
-               	movq	-0xa38(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	$0x0, -0x584(%rbp)
-               	movq	$0x0, -0x57c(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x584(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x57c(%rbp)
-               	movups	-0x584(%rbp), %xmm0
-               	leaq	-0x590(%rbp), %r8
-               	movq	%r8, -0xa40(%rbp)
-               	movups	%xmm0, -0x5a0(%rbp)
-               	movq	-0x5a0(%rbp), %rcx
-               	movq	-0xa40(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movl	-0x598(%rbp), %ecx
-               	movq	-0xa40(%rbp), %r8
-               	movl	%ecx, 0x8(%r8)
-               	movq	-0xa40(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r15, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
-<L16>:
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %r13
+               	cmpq	$0x4, %r13
+               	jb	 <L12>
+               	jmp	 <L16>
+<L12>:
+               	movq	%r13, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%rdi,%rdx), %r8
+               	movq	%r8, -0x910(%rbp)
+               	movq	-0x910(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x918(%rbp)
+               	movq	$0x0, -0x340(%rbp)
+               	movq	$0x0, -0x338(%rbp)
+               	movq	-0x918(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x340(%rbp)
+               	movq	-0x918(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x338(%rbp)
+               	movups	-0x340(%rbp), %xmm0
+               	movups	%xmm0, -0x360(%rbp)
+               	movq	-0x360(%rbp), %rdx
+               	movq	%rdx, -0x350(%rbp)
+               	movl	-0x358(%rbp), %edx
+               	movl	%edx, -0x348(%rbp)
+               	leaq	-0x350(%rbp), %rdx
+               	movq	%rbx, %rcx
+               	callq	 <L13>
+<L13>:
                	movq	%rax, %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	movq	-0x910(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movl	(%rdx), %r8d
+               	movq	%r8, -0x928(%rbp)
+               	movq	-0x928(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x938(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x930(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x940(%rbp)
+               	movq	-0x940(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	-0x940(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x938(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x930(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdx, %r8
+               	movq	%r8, -0x948(%rbp)
+               	movq	-0x948(%rbp), %r8
+               	movq	%r8, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x940(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x930(%rbp)
+               	movq	-0x950(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x940(%rbp)
+               	movq	-0x940(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+<L15>:
+               	addq	$0x1, %r13
+               	movq	-0x930(%rbp), %r8
+               	movq	%r8, %rbx
+               	cmpq	$0x4, %r13
+               	jb	 <L12>
+<L16>:
+               	leaq	-0x374(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movl	$0x0, 0x10(%rdi)
+               	leaq	(%rdi), %r8
+               	movq	%r8, -0x958(%rbp)
+               	movq	-0x958(%rbp), %r8
+               	movb	$-0x25, (%r8)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x3c(%r8), %r13
+               	movq	$0x0, -0x384(%rbp)
+               	movq	$0x0, -0x37c(%rbp)
+               	movq	(%r13), %rdx
+               	movq	%rdx, -0x384(%rbp)
+               	movl	0x8(%r13), %edx
+               	movl	%edx, -0x37c(%rbp)
+               	movups	-0x384(%rbp), %xmm0
+               	leaq	0x4(%rdi), %rdx
+               	movups	%xmm0, -0x394(%rbp)
+               	movq	-0x394(%rbp), %r13
+               	movq	%r13, (%rdx)
+               	movl	-0x38c(%rbp), %r13d
+               	movl	%r13d, 0x8(%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movb	$-0x53, (%rdx)
+               	movq	-0x958(%rbp), %r8
+               	movzbl	(%r8), %edx
+               	movzbq	%dl, %r8
+               	movq	%r8, -0x960(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x968(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x960(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%r13, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r8
+               	movq	%r8, -0x968(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+<L18>:
+               	leaq	0x4(%rdi), %rdx
+               	movq	$0x0, -0x494(%rbp)
+               	movq	$0x0, -0x48c(%rbp)
+               	movq	(%rdx), %rbx
+               	movq	%rbx, -0x494(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0x48c(%rbp)
+               	movups	-0x494(%rbp), %xmm0
+               	movups	%xmm0, -0x4c0(%rbp)
+               	movq	-0x4c0(%rbp), %rdx
+               	movq	%rdx, -0x4b0(%rbp)
+               	movl	-0x4b8(%rbp), %edx
+               	movl	%edx, -0x4a8(%rbp)
+               	leaq	-0x4b0(%rbp), %rdx
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdx
+               	leaq	0x10(%rdi), %rbx
+               	movzbl	(%rbx), %r13d
+               	movzbq	%r13b, %r8
+               	movq	%r8, -0x978(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x970(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r13, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x978(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x970(%rbp), %r8
+               	movq	%r8, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r13
+               	movq	%rbx, %r8
+               	movq	%r8, -0x970(%rbp)
+               	cmpq	$0x8, %r13
+               	jb	 <L20>
+<L21>:
+               	leaq	-0x694(%rbp), %rbx
+               	leaq	-0x6a8(%rbp), %rdx
+               	movq	(%rdi), %r13
+               	movq	0x8(%rdi), %r8
+               	movq	%r8, -0x980(%rbp)
+               	movl	0x10(%rdi), %r8d
+               	movq	%r8, -0x988(%rbp)
+               	movq	%r13, (%rdx)
+               	movq	-0x980(%rbp), %r8
+               	movq	%r8, 0x8(%rdx)
+               	movq	-0x988(%rbp), %r8
+               	movl	%r8d, 0x10(%rdx)
+               	movq	(%rdx), %r13
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x990(%rbp)
+               	movl	0x10(%rdx), %r8d
+               	movq	%r8, -0x998(%rbp)
+               	movq	%r13, (%rbx)
+               	movq	-0x990(%rbp), %r8
+               	movq	%r8, 0x8(%rbx)
+               	movq	-0x998(%rbp), %r8
+               	movl	%r8d, 0x10(%rbx)
+               	leaq	0x4(%rbx), %r8
+               	movq	%r8, -0x9a0(%rbp)
+               	movq	$0x0, -0x6b8(%rbp)
+               	movq	$0x0, -0x6b0(%rbp)
+               	movq	-0x9a0(%rbp), %r8
+               	movq	(%r8), %r13
+               	movq	%r13, -0x6b8(%rbp)
+               	movq	-0x9a0(%rbp), %r8
+               	movl	0x8(%r8), %r13d
+               	movl	%r13d, -0x6b0(%rbp)
+               	movups	-0x6b8(%rbp), %xmm0
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movq	$0x0, -0x6c8(%rbp)
+               	movq	$0x0, -0x6c0(%rbp)
+               	movq	(%r13), %rdx
+               	movq	%rdx, -0x6c8(%rbp)
+               	movl	0x8(%r13), %edx
+               	movl	%edx, -0x6c0(%rbp)
+               	movups	-0x6c8(%rbp), %xmm1
+               	movaps	%xmm0, %xmm14
+               	addps	%xmm1, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x6d8(%rbp)
+               	movq	-0x6d8(%rbp), %rdx
+               	movq	-0x9a0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movl	-0x6d0(%rbp), %edx
+               	movq	-0x9a0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	leaq	(%rbx), %rdx
+               	movzbl	(%rdx), %r13d
+               	movzbq	%r13b, %r8
+               	movq	%r8, -0x9a8(%rbp)
+               	movq	-0x970(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x9b0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x9b8(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x9b8(%rbp), %r8
+               	movq	%r8, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x9a8(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x9b0(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%r13, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	movq	-0x9b8(%rbp), %r8
+               	movq	%r8, %r13
+               	addq	$0x1, %r13
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9b0(%rbp)
+               	movq	%r13, %r8
+               	movq	%r8, -0x9b8(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	leaq	0x4(%rbx), %rdx
+               	movq	$0x0, -0x740(%rbp)
+               	movq	$0x0, -0x738(%rbp)
+               	movq	(%rdx), %r13
+               	movq	%r13, -0x740(%rbp)
+               	movl	0x8(%rdx), %r13d
+               	movl	%r13d, -0x738(%rbp)
+               	movups	-0x740(%rbp), %xmm0
+               	movups	%xmm0, -0x760(%rbp)
+               	movq	-0x760(%rbp), %rdx
+               	movq	%rdx, -0x750(%rbp)
+               	movl	-0x758(%rbp), %edx
+               	movl	%edx, -0x748(%rbp)
+               	leaq	-0x750(%rbp), %rdx
+               	movq	-0x9b0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %rdx
+               	leaq	0x10(%rbx), %r13
+               	movzbl	(%r13), %ebx
+               	movzbq	%bl, %r8
+               	movq	%r8, -0x9c0(%rbp)
+               	movq	%rdx, %r8
                	movq	%r8, -0x9c8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x9c0(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
                	movq	-0x9c8(%rbp), %r8
-               	movq	-0xa40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
+               	movq	%r8, %rdx
+               	xorq	%r13, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+<L26>:
+               	leaq	(%rdi), %rdx
+               	movzbl	(%rdx), %ebx
+               	movzbq	%bl, %rdx
                	movq	-0x9c8(%rbp), %r8
                	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
-<L17>:
+               	callq	 <L27>
+<L27>:
+               	movq	%rax, %rdx
+               	leaq	0x4(%rdi), %rbx
+               	movq	$0x0, -0x770(%rbp)
+               	movq	$0x0, -0x768(%rbp)
+               	movq	(%rbx), %r13
+               	movq	%r13, -0x770(%rbp)
+               	movl	0x8(%rbx), %r13d
+               	movl	%r13d, -0x768(%rbp)
+               	movups	-0x770(%rbp), %xmm0
+               	movups	%xmm0, -0x790(%rbp)
+               	movq	-0x790(%rbp), %rbx
+               	movq	%rbx, -0x780(%rbp)
+               	movl	-0x788(%rbp), %ebx
+               	movl	%ebx, -0x778(%rbp)
+               	leaq	-0x780(%rbp), %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L28>
+<L28>:
+               	movq	%rax, %rdx
+               	leaq	0x10(%rdi), %rbx
+               	movzbl	(%rbx), %edi
+               	movzbq	%dil, %rbx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L29>
+<L29>:
                	movq	%rax, %r8
                	movq	%r8, -0x9d0(%rbp)
                	movq	-0x9d0(%rbp), %r8
-               	movq	-0xa40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x9d0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
+               	leaq	-0x7bc(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	movq	$0x0, 0x18(%rbx)
+               	movq	$0x0, 0x20(%rbx)
+               	movl	$0x0, 0x28(%rbx)
+               	leaq	(%rbx), %r8
                	movq	%r8, -0x9d8(%rbp)
                	movq	-0x9d8(%rbp), %r8
-               	movq	-0xa38(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%rsi,%rdx), %rcx
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x9e0(%rbp)
-               	movq	-0x9d8(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x9e0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r15
-               	movq	-0xa38(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0xa38(%rbp)
-               	movq	-0xa38(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L15>
-<L20>:
-               	leaq	-0x5b4(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movl	$0x0, 0x10(%rsi)
-               	leaq	(%rsi), %rax
-               	movb	$-0x25, (%rax)
-               	leaq	0x3c(%rbx), %rcx
-               	movq	$0x0, -0x5c4(%rbp)
-               	movq	$0x0, -0x5bc(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x5c4(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x5bc(%rbp)
-               	movups	-0x5c4(%rbp), %xmm0
-               	leaq	0x4(%rsi), %r8
-               	movq	%r8, -0x9e8(%rbp)
-               	movups	%xmm0, -0x5d4(%rbp)
-               	movq	-0x5d4(%rbp), %rcx
-               	movq	-0x9e8(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movl	-0x5cc(%rbp), %ecx
-               	movq	-0x9e8(%rbp), %r8
-               	movl	%ecx, 0x8(%r8)
-               	leaq	0x10(%rsi), %rcx
-               	movb	$-0x53, (%rcx)
-               	movzbl	(%rax), %edx
-               	movq	%r15, %rcx
-               	callq	 <L21>
-<L21>:
-               	movq	$0x0, -0x5e4(%rbp)
-               	movq	$0x0, -0x5dc(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	%rcx, -0x5e4(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movl	0x8(%r8), %ecx
-               	movl	%ecx, -0x5dc(%rbp)
-               	movups	-0x5e4(%rbp), %xmm0
-               	leaq	-0x5f0(%rbp), %r15
-               	movups	%xmm0, -0x600(%rbp)
-               	movq	-0x600(%rbp), %rcx
-               	movq	%rcx, (%r15)
-               	movl	-0x5f8(%rbp), %ecx
-               	movl	%ecx, 0x8(%r15)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L22>
-<L22>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L23>
-<L23>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L24>
-<L24>:
-               	leaq	0x10(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9f0(%rbp)
-               	movq	-0x9f0(%rbp), %r8
-               	leaq	-0x6c4(%rbp), %r15
-               	leaq	-0x6d8(%rbp), %rcx
-               	movq	(%rsi), %rdx
-               	movq	0x8(%rsi), %rax
-               	movl	0x10(%rsi), %r8d
-               	movq	%r8, -0x9f8(%rbp)
-               	movq	%rdx, (%rcx)
-               	movq	%rax, 0x8(%rcx)
-               	movq	-0x9f8(%rbp), %r8
-               	movl	%r8d, 0x10(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movl	0x10(%rcx), %r8d
-               	movq	%r8, -0xa00(%rbp)
-               	movq	%rax, (%r15)
-               	movq	%rdx, 0x8(%r15)
+               	movl	$0xffffffff, (%r8)      # imm = 0xFFFFFFFF
                	movq	-0xa00(%rbp), %r8
-               	movl	%r8d, 0x10(%r15)
-               	leaq	0x4(%r15), %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	$0x0, -0x6e8(%rbp)
-               	movq	$0x0, -0x6e0(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	%rcx, -0x6e8(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movl	0x8(%r8), %ecx
-               	movl	%ecx, -0x6e0(%rbp)
-               	movups	-0x6e8(%rbp), %xmm0
-               	leaq	0xc(%rbx), %rcx
-               	movq	$0x0, -0x6f8(%rbp)
-               	movq	$0x0, -0x6f0(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x6f8(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x6f0(%rbp)
-               	movups	-0x6f8(%rbp), %xmm1
-               	movaps	%xmm0, %xmm14
-               	addps	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x708(%rbp)
-               	movq	-0x708(%rbp), %rcx
-               	movq	-0xa48(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movl	-0x700(%rbp), %ecx
-               	movq	-0xa48(%rbp), %r8
-               	movl	%ecx, 0x8(%r8)
-               	leaq	(%r15), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	$0x0, -0x7cc(%rbp)
+               	movq	$0x0, -0x7c4(%rbp)
+               	movq	(%r13), %rdx
+               	movq	%rdx, -0x7cc(%rbp)
+               	movl	0x8(%r13), %edx
+               	movl	%edx, -0x7c4(%rbp)
+               	movups	-0x7cc(%rbp), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	leaq	(%rdx), %r13
+               	movups	%xmm0, -0x7dc(%rbp)
+               	movq	-0x7dc(%rbp), %rdi
+               	movq	%rdi, (%r13)
+               	movl	-0x7d4(%rbp), %edi
+               	movl	%edi, 0x8(%r13)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x24(%r8), %rdi
+               	movq	$0x0, -0x7ec(%rbp)
+               	movq	$0x0, -0x7e4(%rbp)
+               	movq	(%rdi), %r13
+               	movq	%r13, -0x7ec(%rbp)
+               	movl	0x8(%rdi), %r13d
+               	movl	%r13d, -0x7e4(%rbp)
+               	movups	-0x7ec(%rbp), %xmm0
+               	leaq	0xc(%rdx), %rdi
+               	movups	%xmm0, -0x7fc(%rbp)
+               	movq	-0x7fc(%rbp), %r13
+               	movq	%r13, (%rdi)
+               	movl	-0x7f4(%rbp), %r13d
+               	movl	%r13d, 0x8(%rdi)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x48(%r8), %rdi
+               	movq	$0x0, -0x80c(%rbp)
+               	movq	$0x0, -0x804(%rbp)
+               	movq	(%rdi), %r13
+               	movq	%r13, -0x80c(%rbp)
+               	movl	0x8(%rdi), %r13d
+               	movl	%r13d, -0x804(%rbp)
+               	movups	-0x80c(%rbp), %xmm0
+               	leaq	0x18(%rdx), %rdi
+               	movups	%xmm0, -0x81c(%rbp)
+               	movq	-0x81c(%rbp), %rdx
+               	movq	%rdx, (%rdi)
+               	movl	-0x814(%rbp), %edx
+               	movl	%edx, 0x8(%rdi)
+               	leaq	0x28(%rbx), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movq	-0x9d8(%rbp), %r8
+               	movl	(%r8), %edx
+               	movl	%edx, %edi
+               	movq	-0x9d0(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rcx
-               	movq	$0x0, -0x718(%rbp)
-               	movq	$0x0, -0x710(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	%rdx, -0x718(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movl	0x8(%r8), %edx
-               	movl	%edx, -0x710(%rbp)
-               	movups	-0x718(%rbp), %xmm0
-               	leaq	-0x724(%rbp), %r8
-               	movq	%r8, -0xa50(%rbp)
-               	movups	%xmm0, -0x734(%rbp)
-               	movq	-0x734(%rbp), %rdx
-               	movq	-0xa50(%rbp), %r8
-               	movq	%rdx, (%r8)
-               	movl	-0x72c(%rbp), %edx
-               	movq	-0xa50(%rbp), %r8
-               	movl	%edx, 0x8(%r8)
-               	movq	-0xa50(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
-               	movq	-0xa50(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rcx
-               	movq	-0xa50(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	leaq	0x10(%r15), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
                	callq	 <L30>
 <L30>:
-               	leaq	(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
+               	movq	%rax, %rdx
+               	movq	%rdx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L31>
+               	jmp	 <L33>
 <L31>:
-               	leaq	0x4(%rsi), %rcx
-               	movq	$0x0, -0x744(%rbp)
-               	movq	$0x0, -0x73c(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x744(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x73c(%rbp)
-               	movups	-0x744(%rbp), %xmm0
-               	leaq	-0x750(%rbp), %r15
-               	movups	%xmm0, -0x760(%rbp)
-               	movq	-0x760(%rbp), %rcx
-               	movq	%rcx, (%r15)
-               	movl	-0x758(%rbp), %ecx
-               	movl	%ecx, 0x8(%r15)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	leaq	0x4(%rbx), %r8
+               	movq	%r8, -0x9e0(%rbp)
+               	movq	%r13, %rdx
+               	imulq	$0xc, %rdx, %rdx
+               	movq	-0x9e0(%rbp), %r9
+               	leaq	(%r9,%rdx), %r8
+               	movq	%r8, -0x9e8(%rbp)
+               	movq	$0x0, -0x3a4(%rbp)
+               	movq	$0x0, -0x39c(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	%rdx, -0x3a4(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0x39c(%rbp)
+               	movups	-0x3a4(%rbp), %xmm0
+               	movups	%xmm0, -0x3d0(%rbp)
+               	movq	-0x3d0(%rbp), %rdx
+               	movq	%rdx, -0x3c0(%rbp)
+               	movl	-0x3c8(%rbp), %edx
+               	movl	%edx, -0x3b8(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
+               	movq	%rdi, %rcx
                	callq	 <L32>
 <L32>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
+               	movq	%rax, %rdi
+               	addq	$0x1, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L31>
 <L33>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
+               	leaq	0x28(%rbx), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	leaq	0x10(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%r13, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	cmpq	$0x8, %rbx
+               	jb	 <L34>
 <L35>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa08(%rbp)
-               	movq	-0xa08(%rbp), %r8
-               	leaq	-0x7f4(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movq	$0x0, 0x10(%rsi)
-               	movq	$0x0, 0x18(%rsi)
-               	movq	$0x0, 0x20(%rsi)
-               	movl	$0x0, 0x28(%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	(%rbx), %rdx
-               	movq	$0x0, -0x804(%rbp)
-               	movq	$0x0, -0x7fc(%rbp)
-               	movq	(%rdx), %r15
-               	movq	%r15, -0x804(%rbp)
-               	movl	0x8(%rdx), %r15d
-               	movl	%r15d, -0x7fc(%rbp)
-               	movups	-0x804(%rbp), %xmm0
-               	leaq	0x4(%rsi), %rdx
-               	leaq	(%rdx), %r15
-               	movups	%xmm0, -0x814(%rbp)
-               	movq	-0x814(%rbp), %rax
-               	movq	%rax, (%r15)
-               	movl	-0x80c(%rbp), %eax
-               	movl	%eax, 0x8(%r15)
-               	leaq	0x24(%rbx), %rax
-               	movq	$0x0, -0x824(%rbp)
-               	movq	$0x0, -0x81c(%rbp)
-               	movq	(%rax), %r15
-               	movq	%r15, -0x824(%rbp)
-               	movl	0x8(%rax), %r15d
-               	movl	%r15d, -0x81c(%rbp)
-               	movups	-0x824(%rbp), %xmm0
-               	leaq	0xc(%rdx), %rax
-               	movups	%xmm0, -0x834(%rbp)
-               	movq	-0x834(%rbp), %r15
-               	movq	%r15, (%rax)
-               	movl	-0x82c(%rbp), %r15d
-               	movl	%r15d, 0x8(%rax)
-               	leaq	0x48(%rbx), %rax
-               	movq	$0x0, -0x844(%rbp)
-               	movq	$0x0, -0x83c(%rbp)
-               	movq	(%rax), %r15
-               	movq	%r15, -0x844(%rbp)
-               	movl	0x8(%rax), %r15d
-               	movl	%r15d, -0x83c(%rbp)
-               	movups	-0x844(%rbp), %xmm0
-               	leaq	0x18(%rdx), %rax
-               	movups	%xmm0, -0x854(%rbp)
-               	movq	-0x854(%rbp), %rdx
-               	movq	%rdx, (%rax)
-               	movl	-0x84c(%rbp), %edx
-               	movl	%edx, 0x8(%rax)
-               	leaq	0x28(%rsi), %rax
-               	movl	$0x12345678, (%rax)     # imm = 0x12345678
-               	movl	(%rcx), %eax
-               	movq	-0xa08(%rbp), %r8
-               	movq	%r8, %rcx
-               	movl	%eax, %edx
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	cmpq	$0x3, %r8
-               	jb	 <L37>
-               	jmp	 <L41>
-<L37>:
-               	leaq	0x4(%rsi), %rcx
-               	movq	-0xa58(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0xc, %rdx, %rdx
-               	leaq	(%rcx,%rdx), %r8
-               	movq	%r8, -0xa10(%rbp)
-               	movq	$0x0, -0x610(%rbp)
-               	movq	$0x0, -0x608(%rbp)
-               	movq	-0xa10(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	%rcx, -0x610(%rbp)
-               	movq	-0xa10(%rbp), %r8
-               	movl	0x8(%r8), %ecx
-               	movl	%ecx, -0x608(%rbp)
-               	movups	-0x610(%rbp), %xmm0
-               	leaq	-0x61c(%rbp), %r8
-               	movq	%r8, -0xa60(%rbp)
-               	movups	%xmm0, -0x62c(%rbp)
-               	movq	-0x62c(%rbp), %rcx
-               	movq	-0xa60(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movl	-0x624(%rbp), %ecx
-               	movq	-0xa60(%rbp), %r8
-               	movl	%ecx, 0x8(%r8)
-               	movq	-0xa60(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r15, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa18(%rbp)
-               	movq	-0xa18(%rbp), %r8
-               	movq	-0xa60(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xa18(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa20(%rbp)
-               	movq	-0xa20(%rbp), %r8
-               	movq	-0xa60(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xa20(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	-0xa58(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rcx, %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	cmpq	$0x3, %r8
-               	jb	 <L37>
-<L41>:
-               	leaq	0x28(%rsi), %rax
-               	movl	(%rax), %edx
-               	movq	%r15, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x18(%rbx), %rcx
-               	movq	$0x0, -0x63c(%rbp)
-               	movq	$0x0, -0x634(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x63c(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x634(%rbp)
-               	movups	-0x63c(%rbp), %xmm0
-               	leaq	0x30(%rbx), %rcx
-               	movq	$0x0, -0x64c(%rbp)
-               	movq	$0x0, -0x644(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x64c(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x644(%rbp)
-               	movups	-0x64c(%rbp), %xmm1
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x18(%r8), %rbx
+               	movq	$0x0, -0x4d0(%rbp)
+               	movq	$0x0, -0x4c8(%rbp)
+               	movq	(%rbx), %rdx
+               	movq	%rdx, -0x4d0(%rbp)
+               	movl	0x8(%rbx), %edx
+               	movl	%edx, -0x4c8(%rbp)
+               	movups	-0x4d0(%rbp), %xmm0
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x30(%r8), %rdi
+               	movq	$0x0, -0x4e0(%rbp)
+               	movq	$0x0, -0x4d8(%rbp)
+               	movq	(%rdi), %rdx
+               	movq	%rdx, -0x4e0(%rbp)
+               	movl	0x8(%rdi), %edx
+               	movl	%edx, -0x4d8(%rbp)
+               	movups	-0x4e0(%rbp), %xmm1
                	movaps	%xmm0, %xmm14
                	addps	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x658(%rbp), %rsi
-               	movups	%xmm0, -0x668(%rbp)
-               	movq	-0x668(%rbp), %rcx
-               	movq	%rcx, (%rsi)
-               	movl	-0x660(%rbp), %ecx
-               	movl	%ecx, 0x8(%rsi)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L43>
-<L43>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L46>
-<L46>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L48>
-<L48>:
-               	leaq	0x24(%rbx), %rcx
-               	movq	$0x0, -0x770(%rbp)
-               	movq	$0x0, -0x768(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x770(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x768(%rbp)
-               	movups	-0x770(%rbp), %xmm0
-               	leaq	-0x77c(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movl	$0x40000000, (%rsi)     # imm = 0x40000000
-               	leaq	0x4(%rdx), %rsi
-               	movl	$0x40800000, (%rsi)     # imm = 0x40800000
-               	leaq	0x8(%rdx), %rsi
-               	movl	$0x41000000, (%rsi)     # imm = 0x41000000
-               	movq	$0x0, -0x78c(%rbp)
-               	movq	$0x0, -0x784(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x78c(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x784(%rbp)
-               	movups	-0x78c(%rbp), %xmm1
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x500(%rbp)
+               	movq	-0x500(%rbp), %rdx
+               	movq	%rdx, -0x4f0(%rbp)
+               	movl	-0x4f8(%rbp), %edx
+               	movl	%edx, -0x4e8(%rbp)
+               	leaq	-0x4f0(%rbp), %rdx
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L36>
+<L36>:
+               	movq	%rax, %rdx
+               	movups	%xmm7, -0x520(%rbp)
+               	movq	-0x520(%rbp), %r13
+               	movq	%r13, -0x510(%rbp)
+               	movl	-0x518(%rbp), %r13d
+               	movl	%r13d, -0x508(%rbp)
+               	leaq	-0x510(%rbp), %r13
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x9f8(%rbp)
+               	movq	-0x9f8(%rbp), %r8
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x24(%r8), %r13
+               	movq	$0x0, -0x530(%rbp)
+               	movq	$0x0, -0x528(%rbp)
+               	movq	(%r13), %rax
+               	movq	%rax, -0x530(%rbp)
+               	movl	0x8(%r13), %eax
+               	movl	%eax, -0x528(%rbp)
+               	movups	-0x530(%rbp), %xmm0
+               	leaq	-0x53c(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movl	$0x40000000, (%rdx)     # imm = 0x40000000
+               	leaq	0x4(%rax), %rdx
+               	movl	$0x40800000, (%rdx)     # imm = 0x40800000
+               	leaq	0x8(%rax), %rdx
+               	movl	$0x41000000, (%rdx)     # imm = 0x41000000
+               	movq	$0x0, -0x54c(%rbp)
+               	movq	$0x0, -0x544(%rbp)
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x54c(%rbp)
+               	movl	0x8(%rax), %edx
+               	movl	%edx, -0x544(%rbp)
+               	movups	-0x54c(%rbp), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x79c(%rbp)
-               	movq	-0x79c(%rbp), %rdx
-               	movq	%rdx, (%rcx)
-               	movl	-0x794(%rbp), %edx
-               	movl	%edx, 0x8(%rcx)
-               	leaq	0x18(%rbx), %rcx
-               	movq	$0x0, -0x7ac(%rbp)
-               	movq	$0x0, -0x7a4(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x7ac(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x7a4(%rbp)
-               	movups	-0x7ac(%rbp), %xmm0
-               	leaq	-0x7b8(%rbp), %rsi
-               	movups	%xmm0, -0x7c8(%rbp)
-               	movq	-0x7c8(%rbp), %rcx
-               	movq	%rcx, (%rsi)
-               	movl	-0x7c0(%rbp), %ecx
-               	movl	%ecx, 0x8(%rsi)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x55c(%rbp)
+               	movq	-0x55c(%rbp), %rax
+               	movq	%rax, (%r13)
+               	movl	-0x554(%rbp), %eax
+               	movl	%eax, 0x8(%r13)
+               	movq	$0x0, -0x56c(%rbp)
+               	movq	$0x0, -0x564(%rbp)
+               	movq	(%rbx), %rax
+               	movq	%rax, -0x56c(%rbp)
+               	movl	0x8(%rbx), %eax
+               	movl	%eax, -0x564(%rbp)
+               	movups	-0x56c(%rbp), %xmm0
+               	movups	%xmm0, -0x590(%rbp)
+               	movq	-0x590(%rbp), %rax
+               	movq	%rax, -0x580(%rbp)
+               	movl	-0x588(%rbp), %eax
+               	movl	%eax, -0x578(%rbp)
+               	leaq	-0x580(%rbp), %rdx
+               	movq	-0x9f8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L38>
+<L38>:
+               	movq	$0x0, -0x5a0(%rbp)
+               	movq	$0x0, -0x598(%rbp)
+               	movq	(%r13), %rdx
+               	movq	%rdx, -0x5a0(%rbp)
+               	movl	0x8(%r13), %edx
+               	movl	%edx, -0x598(%rbp)
+               	movups	-0x5a0(%rbp), %xmm0
+               	movups	%xmm0, -0x5c0(%rbp)
+               	movq	-0x5c0(%rbp), %rdx
+               	movq	%rdx, -0x5b0(%rbp)
+               	movl	-0x5b8(%rbp), %edx
+               	movl	%edx, -0x5a8(%rbp)
+               	leaq	-0x5b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
+               	callq	 <L39>
+<L39>:
+               	movq	$0x0, -0x5d0(%rbp)
+               	movq	$0x0, -0x5c8(%rbp)
+               	movq	(%rdi), %rdx
+               	movq	%rdx, -0x5d0(%rbp)
+               	movl	0x8(%rdi), %edx
+               	movl	%edx, -0x5c8(%rbp)
+               	movups	-0x5d0(%rbp), %xmm0
+               	movups	%xmm0, -0x5f0(%rbp)
+               	movq	-0x5f0(%rbp), %rdx
+               	movq	%rdx, -0x5e0(%rbp)
+               	movl	-0x5e8(%rbp), %edx
+               	movl	%edx, -0x5d8(%rbp)
+               	leaq	-0x5e0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L51>
-<L51>:
-               	leaq	0x24(%rbx), %rcx
-               	movq	$0x0, -0x864(%rbp)
-               	movq	$0x0, -0x85c(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x864(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x85c(%rbp)
-               	movups	-0x864(%rbp), %xmm0
-               	leaq	-0x870(%rbp), %rsi
-               	movups	%xmm0, -0x880(%rbp)
-               	movq	-0x880(%rbp), %rcx
-               	movq	%rcx, (%rsi)
-               	movl	-0x878(%rbp), %ecx
-               	movl	%ecx, 0x8(%rsi)
-               	leaq	(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L52>
-<L52>:
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L54>
-<L54>:
-               	leaq	0x30(%rbx), %rcx
-               	movq	$0x0, -0x890(%rbp)
-               	movq	$0x0, -0x888(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x890(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x888(%rbp)
-               	movups	-0x890(%rbp), %xmm0
-               	leaq	-0x89c(%rbp), %rbx
-               	movups	%xmm0, -0x8ac(%rbp)
-               	movq	-0x8ac(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x8a4(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L55>
-<L55>:
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L56>
-<L56>:
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	leaq	-0x910(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L58>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L58>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	$0x5, %rcx
-               	jb	 <L59>
-               	jmp	 <L62>
-<L59>:
-               	movq	%rcx, %r11
+               	callq	 <L40>
+<L40>:
+               	leaq	-0x660(%rbp), %rbx
+               	leaq	(%rbx), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rdi
+<L41>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L41>
+               	movl	$0x0, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x5, %rdx
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L43>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L61>:
-               	leaq	-0x67c(%rbp), %rdx
-               	movq	$0x0, (%rdx)
-               	movq	$0x0, 0x8(%rdx)
-               	movl	$0x0, 0x10(%rdx)
+<L44>:
+               	leaq	-0x3e4(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movl	$0x0, 0x10(%rdi)
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x4(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x8(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0xc(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x10(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	(%rsi), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x4(%rsi), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x8(%rsi), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0xc(%rsi), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8c8(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x10(%rsi), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	(%rsi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	(%rsi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rsi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rsi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rsi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rsi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x15e7>
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x4(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x8(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0xc(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x10(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x1774>
+               	subss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x1746>
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	(%r12), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x4(%r12), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x8(%r12), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0xc(%r12), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x10(%r12), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%r12), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	(%r12), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%r12), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%r12), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%r12), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%r12), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	movss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x18cf>
                	subss	%xmm0, %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x4(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x8(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0xc(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x10(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	(%r14), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x4(%r14), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x8(%r14), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0xc(%r14), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x908(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x10(%r14), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%r14), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	(%r14), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%r14), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%r14), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%r14), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%r14), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x1909>
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm2
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	leaq	(%rdi), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	leaq	0x4(%rdi), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	leaq	0x8(%rdi), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	leaq	0xc(%rdi), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm2
-               	leaq	0x10(%rdi), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%rdi), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	(%rdi), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x4(%rdi), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x4(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x8(%rdi), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x8(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0xc(%rdi), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0xc(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x10(%rdi), %rsi
-               	movss	(%rsi), %xmm1
-               	leaq	0x10(%rdx), %rsi
-               	movss	%xmm1, (%rsi)
+               	addss	, %xmm1 <corpus.cases.vec.vec_mem.checksum+0x1a55>
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	leaq	(%r15), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x4(%r15), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x8(%r15), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0xc(%r15), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm2
+               	leaq	0x10(%r15), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	(%r15), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x828(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x4(%r15), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x8(%r15), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0xc(%r15), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x828(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	leaq	0x10(%r15), %r13
+               	movss	(%r13), %xmm2
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm2, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x828(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
                	xorps	%xmm1, %xmm1
                	subss	%xmm0, %xmm1
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%r12), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%r12), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%r12), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%r12), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r13), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x4(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%r13), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x8(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%r13), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0xc(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%r13), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%r13), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%r13), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%rdx), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x4(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%rdx), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x8(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%rdx), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0xc(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%rdx), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%rdx), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r14), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%r14), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%r14), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%r14), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%r14), %rdx
-               	movss	%xmm0, (%rdx)
-               	movq	%rcx, %rdx
-               	imulq	$0x14, %rdx, %rdx
-               	leaq	(%rbx,%rdx), %rsi
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	(%rsi), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x4(%rsi), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%rsi), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%rsi), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x10(%rsi), %rdx
-               	movss	%xmm0, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x5, %rcx
-               	jb	 <L59>
-<L62>:
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x830(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x830(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x830(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x838(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x830(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x838(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x830(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm1, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	(%rdi), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x838(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x840(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x840(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm0
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	%rdx, %rdi
+               	imulq	$0x14, %rdi, %rdi
+               	leaq	(%rbx,%rdi), %r13
+               	movq	-0x840(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	(%r13), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x8(%r13), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x840(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0xc(%r13), %rdi
+               	movss	%xmm0, (%rdi)
+               	movq	-0x840(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x10(%r13), %rdi
+               	movss	%xmm0, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x5, %rdx
+               	jb	 <L42>
+<L45>:
                	movq	%rax, %rsi
                	movq	$0x5, %rdi
                	movq	$0x0, %r11
                	cmpq	%rdi, %r11
-               	jb	 <L63>
-               	jmp	 <L69>
-<L63>:
-               	movq	%rdi, %r12
-               	subq	$0x1, %r12
-               	movq	%r12, %rax
+               	jb	 <L46>
+               	jmp	 <L48>
+<L46>:
+               	subq	$0x1, %rdi
+               	movq	%rdi, %rax
                	imulq	$0x14, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x848(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
+               	leaq	0x4(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x848(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
+               	leaq	0x8(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x848(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
+               	leaq	0xc(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x848(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
+               	leaq	0x10(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x848(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm0, (%rax)
-               	movq	-0x940(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
+               	movq	-0x848(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x848(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x848(%rbp), %r8
+               	movl	0x10(%r8), %r12d
+               	movq	%rax, -0x400(%rbp)
+               	movq	%rdx, -0x3f8(%rbp)
+               	movl	%r12d, -0x3f0(%rbp)
+               	leaq	-0x400(%rbp), %rdx
                	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L64>
-<L64>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L66>
-<L66>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
-<L67>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %rsi
-               	movq	%r12, %rdi
                	movq	$0x0, %r11
                	cmpq	%rdi, %r11
-               	jb	 <L63>
-<L69>:
-               	leaq	-0x6b0(%rbp), %rdi
+               	jb	 <L46>
+<L48>:
+               	leaq	-0x430(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
@@ -1637,454 +1764,403 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rdi)
                	leaq	(%rdi), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x3c(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	0x3c(%rbx), %rdx
+               	leaq	(%rdx), %r12
+               	movss	(%r12), %xmm0
+               	movq	-0x850(%rbp), %r8
+               	leaq	(%r8), %r12
+               	movss	%xmm0, (%r12)
+               	leaq	0x4(%rdx), %r12
+               	movss	(%r12), %xmm0
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x4(%r8), %r12
+               	movss	%xmm0, (%r12)
+               	leaq	0x8(%rdx), %r12
+               	movss	(%r12), %xmm0
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x8(%r8), %r12
+               	movss	%xmm0, (%r12)
+               	leaq	0xc(%rdx), %r12
+               	movss	(%r12), %xmm0
+               	movq	-0x850(%rbp), %r8
+               	leaq	0xc(%r8), %r12
+               	movss	%xmm0, (%r12)
+               	leaq	0x10(%rdx), %r12
+               	movss	(%r12), %xmm0
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%rdi), %r12
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r12), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r12), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r12), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%rdi), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x10(%rdi), %rdx
+               	movq	-0x850(%rbp), %r8
+               	leaq	(%r8), %r12
+               	movss	(%r12), %xmm0
+               	leaq	(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x4(%r8), %r12
+               	movss	(%r12), %xmm0
+               	leaq	0x4(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x8(%r8), %r12
+               	movss	(%r12), %xmm0
+               	leaq	0x8(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movq	-0x850(%rbp), %r8
+               	leaq	0xc(%r8), %r12
+               	movss	(%r12), %xmm0
+               	leaq	0xc(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movq	-0x850(%rbp), %r8
+               	leaq	0x10(%r8), %r12
+               	movss	(%r12), %xmm0
+               	leaq	0x10(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	leaq	0x24(%rdi), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
-               	movq	%rsi, %rcx
-               	callq	 <L70>
-<L70>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L71>
-<L71>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L72>
-<L72>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L74>
-<L74>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L75>
-<L75>:
-               	leaq	0x24(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+<L50>:
+               	leaq	0x10(%rdi), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x858(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x858(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x858(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x858(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x858(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x858(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x858(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x858(%rbp), %r8
+               	movl	0x10(%r8), %r12d
+               	movq	%rax, -0x680(%rbp)
+               	movq	%rdx, -0x678(%rbp)
+               	movl	%r12d, -0x670(%rbp)
+               	leaq	-0x680(%rbp), %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L51>
+<L51>:
+               	leaq	0x24(%rdi), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+<L53>:
+               	leaq	0x14(%rbx), %rsi
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x860(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x860(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x860(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x860(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x860(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x50(%rbx), %rdx
-               	leaq	(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	0x10(%rdx), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x868(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x868(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x868(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x868(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x868(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x860(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x868(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x860(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x868(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x860(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x868(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x860(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x868(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x860(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x868(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	(%rcx), %rdx
+               	leaq	(%rsi), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rsi), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rsi), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rsi), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x870(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rsi), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	(%rbx), %rdx
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x878(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x878(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm0, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x878(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	-0x878(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x878(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x878(%rbp), %r8
+               	movl	0x10(%r8), %r12d
+               	movq	%rdx, -0x6f0(%rbp)
+               	movq	%rdi, -0x6e8(%rbp)
+               	movl	%r12d, -0x6e0(%rbp)
+               	leaq	-0x6f0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L54>
+<L54>:
+               	leaq	(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x880(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x880(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x880(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x880(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x970(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L77>
-<L77>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L78>
-<L78>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L79>
-<L79>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L80>
-<L80>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	movq	-0x880(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	movq	-0x880(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x880(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x880(%rbp), %r8
+               	movl	0x10(%r8), %edi
+               	movq	%rdx, -0x710(%rbp)
+               	movq	%rsi, -0x708(%rbp)
+               	movl	%edi, -0x700(%rbp)
+               	leaq	-0x710(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L55>
+<L55>:
+               	leaq	0x28(%rbx), %rdx
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x8(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	leaq	0xc(%r8), %rbx
+               	movss	%xmm0, (%rbx)
+               	leaq	0x10(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
+               	movq	-0x888(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x888(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x888(%rbp), %r8
+               	movl	0x10(%r8), %esi
+               	movq	%rdx, -0x730(%rbp)
+               	movq	%rbx, -0x728(%rbp)
+               	movl	%esi, -0x720(%rbp)
+               	leaq	-0x730(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L82>
-<L82>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L84>
-<L84>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L85>
-<L85>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L86>
-<L86>:
-               	leaq	0x28(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L87>
-<L87>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L88>
-<L88>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L89>
-<L89>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L90>
-<L90>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L91>
-<L91>:
-               	movaps	-0xab0(%rbp), %xmm6
-               	movaps	-0xac0(%rbp), %xmm14
-               	movaps	-0xad0(%rbp), %xmm15
-               	movq	-0xa68(%rbp), %rbx
-               	movq	-0xa70(%rbp), %rdi
-               	movq	-0xa78(%rbp), %rsi
-               	movq	-0xa80(%rbp), %r12
-               	movq	-0xa88(%rbp), %r13
-               	movq	-0xa90(%rbp), %r14
-               	movq	-0xa98(%rbp), %r15
+               	callq	 <L56>
+<L56>:
+               	movaps	-0xa50(%rbp), %xmm6
+               	movaps	-0xa60(%rbp), %xmm7
+               	movaps	-0xa70(%rbp), %xmm14
+               	movaps	-0xa80(%rbp), %xmm15
+               	movq	-0xa08(%rbp), %rbx
+               	movq	-0xa10(%rbp), %rdi
+               	movq	-0xa18(%rbp), %rsi
+               	movq	-0xa20(%rbp), %r12
+               	movq	-0xa28(%rbp), %r13
+               	movq	-0xa30(%rbp), %r14
+               	movq	-0xa38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_scalar_mix.dis
+++ b/test/golden/x86_64-windows/vec/vec_scalar_mix.dis
@@ -5,39 +5,119 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -45,41 +125,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_i32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movslq	%edx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -87,41 +241,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -129,7 +357,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x480, %rsp            # imm = 0x480
+               	subq	$0x470, %rsp            # imm = 0x470
                	movq	%rbx, -0x388(%rbp)
                	movq	%rdi, -0x390(%rbp)
                	movq	%rsi, -0x398(%rbp)
@@ -144,751 +372,679 @@ Disassembly of section .text:
                	movaps	%xmm10, -0x410(%rbp)
                	movaps	%xmm11, -0x420(%rbp)
                	movaps	%xmm12, -0x430(%rbp)
-               	movaps	%xmm13, -0x440(%rbp)
-               	movaps	%xmm14, -0x450(%rbp)
-               	movaps	%xmm15, -0x460(%rbp)
+               	movaps	%xmm14, -0x440(%rbp)
+               	movaps	%xmm15, -0x450(%rbp)
                	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movl	%ebx, %esi
-               	leaq	-0x10(%rbp), %rdx
+               	leaq	-0x70(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xc8>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xcf>
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movl	$0x40700000, (%rdx)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xe9>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xf0>
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	movups	(%rax), %xmm1
+               	leaq	-0x80(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	-0x90(%rbp), %rdx
                	leaq	(%rdx), %rdi
-               	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xd8>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xdf>
+               	movl	$0x3f000000, (%rdi)     # imm = 0x3F000000
                	leaq	0x4(%rdx), %rdi
-               	movss	%xmm1, (%rdi)
+               	movl	$0x40800000, (%rdi)     # imm = 0x40800000
+               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0x124>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0x12b>
                	leaq	0x8(%rdx), %rdi
-               	movl	$0x40700000, (%rdi)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xf9>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x100>
+               	movss	%xmm2, (%rdi)
                	leaq	0xc(%rdx), %rdi
-               	movss	%xmm1, (%rdi)
-               	movups	(%rdx), %xmm1
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	-0x30(%rbp), %rdi
-               	leaq	(%rdi), %r12
-               	movl	$0x3f000000, (%r12)     # imm = 0x3F000000
-               	leaq	0x4(%rdi), %r12
-               	movl	$0x40800000, (%r12)     # imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0x135>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0x13c>
-               	leaq	0x8(%rdi), %r12
-               	movss	%xmm2, (%r12)
-               	leaq	0xc(%rdi), %r12
-               	movl	$0x41000000, (%r12)     # imm = 0x41000000
-               	movups	(%rdi), %xmm2
-               	leaq	-0x40(%rbp), %rdi
-               	movups	%xmm2, (%rdi)
-               	leaq	(%rdx), %r12
-               	movss	(%r12), %xmm3
+               	movl	$0x41000000, (%rdi)     # imm = 0x41000000
+               	movups	(%rdx), %xmm2
+               	leaq	-0xa0(%rbp), %rdx
+               	movups	%xmm2, (%rdx)
+               	leaq	(%rax), %rdi
+               	movss	(%rdi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x50(%rbp), %r12
-               	movups	%xmm1, (%r12)
-               	leaq	(%r12), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%r12), %xmm6
-               	leaq	0x8(%rdi), %rdx
-               	movss	(%rdx), %xmm1
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm1, (%rdi)
+               	leaq	(%rdi), %rax
+               	movss	%xmm4, (%rax)
+               	movups	(%rdi), %xmm6
+               	leaq	0x8(%rdx), %rax
+               	movss	(%rax), %xmm1
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
                	addss	%xmm0, %xmm3
-               	leaq	-0x60(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	0x8(%rdx), %rdi
-               	movss	%xmm3, (%rdi)
-               	movups	(%rdx), %xmm7
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%rdx), %rdi
-               	movss	(%rdi), %xmm8
+               	leaq	-0xc0(%rbp), %r12
+               	movups	%xmm2, (%r12)
+               	leaq	0x8(%r12), %rax
+               	movss	%xmm3, (%rax)
+               	movups	(%r12), %xmm7
+               	leaq	(%rdi), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
+               	mulss	%xmm1, %xmm8
+               	leaq	0x4(%rdi), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r12), %rax
+               	movss	(%rax), %xmm1
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	mulss	%xmm8, %xmm9
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm10
-               	leaq	0x4(%rdx), %rdi
-               	movss	(%rdi), %xmm11
-               	movss	%xmm10, %xmm12          # xmm12 = xmm10[0],xmm12[1,2,3]
-               	mulss	%xmm11, %xmm12
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm13
-               	leaq	0x8(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movss	%xmm13, %xmm14          # xmm14 = xmm13[0],xmm14[1,2,3]
-               	mulss	%xmm0, %xmm14
-               	movss	%xmm14, -0x350(%rbp)
-               	leaq	0xc(%r12), %rdi
-               	movl	(%rdi), %r11d
-               	movl	%r11d, -0x370(%rbp)
-               	leaq	0xc(%rdx), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	-0x370(%rbp), %xmm14
-               	mulss	%xmm1, %xmm14
-               	movss	%xmm14, -0x360(%rbp)
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L3>
+               	mulss	%xmm1, %xmm9
+               	leaq	0x8(%rdi), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r12), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
+               	mulss	%xmm1, %xmm10
+               	leaq	0xc(%rdi), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r12), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	mulss	%xmm1, %xmm11
+               	movd	%xmm8, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L4>
+               	movd	%xmm9, %edx
+               	movl	%edx, %r13d
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	movss	-0x350(%rbp), %xmm1
-               	callq	 <L5>
+               	movq	%rdx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
+               	movd	%xmm10, %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movss	-0x360(%rbp), %xmm1
+               	movq	%r13, %rdx
                	callq	 <L6>
 <L6>:
+               	movd	%xmm11, %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm14           # xmm14 = xmm9[0],xmm14[1,2,3]
-               	addss	%xmm12, %xmm14
-               	movss	%xmm14, -0x380(%rbp)
-               	movss	-0x380(%rbp), %xmm1
+               	movq	%r13, %rdx
                	callq	 <L7>
 <L7>:
+               	movss	%xmm8, %xmm12           # xmm12 = xmm8[0],xmm12[1,2,3]
+               	addss	%xmm9, %xmm12
+               	movd	%xmm12, %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movss	-0x380(%rbp), %xmm9
-               	addss	-0x350(%rbp), %xmm9
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movq	%r13, %rdx
                	callq	 <L8>
 <L8>:
+               	movss	%xmm12, %xmm8           # xmm8 = xmm12[0],xmm8[1,2,3]
+               	addss	%xmm10, %xmm8
+               	movd	%xmm8, %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movss	%xmm9, %xmm12           # xmm12 = xmm9[0],xmm12[1,2,3]
-               	addss	-0x360(%rbp), %xmm12
-               	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
+               	movq	%r13, %rdx
                	callq	 <L9>
 <L9>:
-               	leaq	-0x70(%rbp), %rcx
-               	movups	%xmm6, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm12, (%rdx)
-               	movups	(%rcx), %xmm1
-               	movss	-0x370(%rbp), %xmm2
-               	subss	%xmm8, %xmm2
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	addss	%xmm13, %xmm1
-               	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm10, %xmm1
-               	leaq	-0xa0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movss	%xmm1, (%rcx)
-               	movups	(%rdi), %xmm8
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
+               	movss	%xmm8, %xmm9            # xmm9 = xmm8[0],xmm9[1,2,3]
+               	addss	%xmm11, %xmm9
+               	movd	%xmm9, %edx
+               	movl	%edx, %r13d
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	movq	%r13, %rdx
                	callq	 <L10>
 <L10>:
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x320(%rbp), %rdx
+               	movups	%xmm6, (%rdx)
+               	leaq	(%rdx), %r13
+               	movss	%xmm9, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm2
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	subss	%xmm2, %xmm3
+               	leaq	-0x330(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r13
+               	movss	%xmm3, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm2
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	addss	%xmm2, %xmm3
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r12
+               	movss	%xmm3, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm8
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+               	leaq	-0x350(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r12
+               	movss	%xmm1, (%r12)
+               	movups	(%rdx), %xmm9
+               	movups	%xmm9, -0x360(%rbp)
+               	leaq	-0x360(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	%xmm9, %xmm14
+               	mulps	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x370(%rbp)
+               	leaq	-0x370(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L12>
 <L12>:
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L13>
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm0
+               	ucomiss	%xmm0, %xmm8
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movaps	%xmm8, %xmm14
-               	mulps	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm8
-               	leaq	-0x190(%rbp), %rdi
-               	movups	%xmm8, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L14>
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm0
 <L14>:
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L15>
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	ucomiss	%xmm0, %xmm1
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L16>
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm0
 <L16>:
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L17>
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	ucomiss	%xmm0, %xmm1
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm0, %xmm1
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L18>
-               	jmp	 <L19>
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm0
 <L18>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm2, %xmm1
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm0, %xmm1
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L20>
-               	jmp	 <L21>
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm1
 <L20>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm2, %xmm1
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm0, %xmm1
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L22>
-               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	jmp	 <L23>
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm1
 <L22>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm7
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm2, %xmm1
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L24>
-               	jmp	 <L25>
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm1
 <L24>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %edi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L26>
-               	jmp	 <L27>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
 <L26>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm1, %edx
+               	movl	%edx, %edi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm1
-               	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	jmp	 <L29>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
 <L28>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm8
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movd	%xmm2, %edx
+               	movl	%edx, %edi
+               	movq	%rax, %rcx
+               	movq	%rdi, %rdx
+               	callq	 <L29>
 <L29>:
-               	movq	%rax, %rcx
-               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L31>
-<L31>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	subss	%xmm8, %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L32>
-<L32>:
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x7, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xfffffff3, (%rdx)     # imm = 0xFFFFFFF3
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x15, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffe1, (%rdx)     # imm = 0xFFFFFFE1
-               	movups	(%rcx), %xmm0
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	movl	%ebx, %edx
-               	addl	%edx, %ecx
-               	leaq	-0xd0(%rbp), %rbx
+               	leaq	-0xd0(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x7, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0xfffffff3, (%rdi)     # imm = 0xFFFFFFF3
+               	leaq	0x8(%rdx), %rdi
+               	movl	$0x15, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0xffffffe1, (%rdi)     # imm = 0xFFFFFFE1
+               	movups	(%rdx), %xmm0
+               	leaq	-0xe0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movl	(%rdi), %edx
+               	movl	%ebx, %edi
+               	addl	%edi, %edx
+               	leaq	-0xf0(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	0x4(%rbx), %rdx
-               	movl	%ecx, (%rdx)
+               	leaq	0x4(%rbx), %rdi
+               	movl	%edx, (%rdi)
                	movups	(%rbx), %xmm7
-               	leaq	-0xe0(%rbp), %rdi
+               	leaq	-0x100(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movslq	%r12d, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x110(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movslq	%r12d, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x120(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x4(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movslq	%r12d, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x130(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x8(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movslq	%r12d, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%rdi), %xmm1
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x140(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0xc(%rdx), %r12
+               	movss	%xmm0, (%r12)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%rdi)
                	movups	(%rdi), %xmm0
-               	leaq	-0x130(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L36>
-<L36>:
+               	callq	 <L30>
+<L30>:
                	movups	(%rdi), %xmm0
                	movaps	%xmm0, %xmm14
                	mulps	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	%xmm0, -0x160(%rbp)
+               	leaq	-0x160(%rbp), %rdx
                	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L40>
-<L40>:
-               	leaq	-0x1b0(%rbp), %r12
+               	callq	 <L31>
+<L31>:
+               	leaq	-0x170(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movups	(%rdi), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x73c>
-               	cvttss2si	%xmm1, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r12), %xmm0
-               	leaq	-0x1d0(%rbp), %rdx
+               	leaq	-0x180(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %r13
-               	movl	%ecx, (%r13)
-               	movups	(%rdx), %xmm0
+               	movss	(%r13), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x764>
+               	cvttss2si	%xmm1, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r12), %xmm0
+               	leaq	-0x190(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	(%r13), %r14
+               	movl	%edx, (%r14)
+               	movups	(%r13), %xmm0
                	movups	%xmm0, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x783>
-               	cvttss2si	%xmm1, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r12), %xmm0
-               	leaq	-0x1f0(%rbp), %rdx
+               	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %r13
-               	movl	%ecx, (%r13)
-               	movups	(%rdx), %xmm0
+               	movss	(%r13), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7b1>
+               	cvttss2si	%xmm1, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r12), %xmm0
+               	leaq	-0x1b0(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0x4(%r13), %r14
+               	movl	%edx, (%r14)
+               	movups	(%r13), %xmm0
                	movups	%xmm0, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movss	(%r13), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7cb>
+               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7fe>
                	cvttss2si	%xmm1, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movups	(%r12), %xmm0
+               	leaq	-0x1d0(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0x8(%r13), %r14
+               	movl	%edx, (%r14)
+               	movups	(%r13), %xmm0
+               	movups	%xmm0, (%r12)
+               	movups	(%rdi), %xmm0
+               	leaq	-0x1e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x849>
+               	cvttss2si	%xmm1, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r12), %xmm0
+               	leaq	-0x1f0(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0xc(%rdi), %r13
+               	movl	%edx, (%r13)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, (%r12)
+               	movups	(%r12), %xmm0
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L32>
+<L32>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x378(%rbp)
+               	movq	-0x378(%rbp), %r8
                	movups	(%r12), %xmm0
                	leaq	-0x210(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %r13
-               	movl	%ecx, (%r13)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r12)
-               	movups	(%rdi), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x813>
-               	cvttss2si	%xmm1, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r12), %xmm0
-               	leaq	-0x230(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0xc(%rdx), %rdi
-               	movl	%ecx, (%rdi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r12)
-               	movups	(%r12), %xmm0
-               	leaq	-0x240(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	movups	(%r12), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %edi
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %r13d
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %r14d
+               	leaq	(%rdx), %rdi
+               	movl	(%rdi), %r13d
+               	leaq	(%rbx), %rdi
+               	movl	(%rdi), %r14d
                	imull	%r14d, %r13d
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r14d
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %r15d
+               	leaq	0x4(%rdx), %rdi
+               	movl	(%rdi), %r14d
+               	leaq	0x4(%rbx), %rdi
+               	movl	(%rdi), %r15d
                	imull	%r15d, %r14d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	imull	%ebx, %ecx
-               	leaq	-0x260(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rbx
-               	movl	%edi, (%rbx)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x270(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x8(%rdx), %rdi
+               	movl	(%rdi), %r15d
+               	leaq	0x8(%rbx), %rdi
+               	movl	(%rdi), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%rdx), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %ebx
+               	imull	%ebx, %edx
+               	leaq	-0x220(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rbx
                	movl	%r13d, (%rbx)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x280(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rbx
                	movl	%r14d, (%rbx)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rbx
+               	movl	%r15d, (%rbx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x250(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rbx
+               	movl	%edx, (%rbx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	movq	-0x378(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L33>
+<L33>:
                	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
                	psubd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x270(%rbp)
+               	leaq	-0x270(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L34>
+<L34>:
+               	leaq	-0x280(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movl	$0xffffffff, (%rbx)     # imm = 0xFFFFFFFF
+               	leaq	0x4(%rdx), %rbx
+               	movl	$0x1, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movl	$0xaaaaaaaa, (%rbx)     # imm = 0xAAAAAAAA
+               	leaq	0xc(%rdx), %rbx
+               	movl	$0x12345678, (%rbx)     # imm = 0x12345678
+               	movups	(%rdx), %xmm0
+               	leaq	-0x290(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	addl	%esi, %edx
                	leaq	-0x2a0(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
-               	leaq	-0x2b0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xaaaaaaaa, (%rdx)     # imm = 0xAAAAAAAA
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	%esi, %ecx
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
+               	leaq	0xc(%rbx), %rsi
+               	movl	%edx, (%rsi)
                	movups	(%rbx), %xmm7
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rcx
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %esi
                	movl	%esi, %edx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	movl	%esi, %r12d
-               	xorl	%edi, %r12d
                	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
+               	callq	 <L35>
+<L35>:
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	xorl	%edi, %esi
+               	movl	%esi, %edx
                	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	subl	%edx, %r12d
+               	callq	 <L36>
+<L36>:
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	movl	%esi, %edx
                	movq	%rax, %rcx
-               	movl	%r12d, %edx
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2e0(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
-               	movups	(%rbx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	%r12d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	movl	%r12d, %ecx
-               	xorl	%esi, %ecx
-               	movups	(%rbx), %xmm0
+               	callq	 <L37>
+<L37>:
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	subl	%edi, %esi
+               	movl	%esi, %edx
+               	movq	%rax, %rcx
+               	callq	 <L38>
+<L38>:
+               	leaq	-0x2b0(%rbp), %rdi
+               	movq	$0x0, (%rdi)
+               	movq	$0x0, 0x8(%rdi)
+               	movups	(%rdi), %xmm0
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %r12
+               	movl	%esi, (%r12)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movl	%esi, %edx
+               	xorl	%r12d, %edx
+               	movups	(%rdi), %xmm0
+               	leaq	-0x2d0(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x4(%r12), %r13
+               	movl	%edx, (%r13)
+               	movups	(%r12), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	movl	%esi, %edx
+               	addl	%r12d, %edx
+               	movups	(%rdi), %xmm0
+               	leaq	-0x2e0(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x8(%r12), %r13
+               	movl	%edx, (%r13)
+               	movups	(%r12), %xmm0
+               	movups	%xmm0, (%rdi)
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %ebx
+               	subl	%ebx, %esi
+               	movups	(%rdi), %xmm0
+               	leaq	-0x2f0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movl	%esi, (%rbx)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%rdi)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, -0x300(%rbp)
                	leaq	-0x300(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	movl	%r12d, %ecx
-               	addl	%edi, %ecx
-               	movups	(%rbx), %xmm0
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	subl	%r13d, %r12d
-               	movups	(%rbx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	%r12d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%rbx)
-               	movups	(%rbx), %xmm0
-               	leaq	-0x330(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
-               	movups	(%rbx), %xmm0
+               	callq	 <L39>
+<L39>:
+               	movups	(%rdi), %xmm0
                	movaps	%xmm0, %xmm14
                	paddd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x310(%rbp)
+               	leaq	-0x310(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rbx
                	movq	$0x0, %rsi
-<L65>:
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm6, (%rcx)
+<L41>:
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm6, (%rdx)
                	cmpq	$0x4, %rsi
-               	jb	 <L66>
+               	jb	 <L42>
                	movq	%rbx, %rax
                	movaps	-0x3d0(%rbp), %xmm6
                	movaps	-0x3e0(%rbp), %xmm7
@@ -897,9 +1053,8 @@ Disassembly of section .text:
                	movaps	-0x410(%rbp), %xmm10
                	movaps	-0x420(%rbp), %xmm11
                	movaps	-0x430(%rbp), %xmm12
-               	movaps	-0x440(%rbp), %xmm13
-               	movaps	-0x450(%rbp), %xmm14
-               	movaps	-0x460(%rbp), %xmm15
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x450(%rbp), %xmm15
                	movq	-0x388(%rbp), %rbx
                	movq	-0x390(%rbp), %rdi
                	movq	-0x398(%rbp), %rsi
@@ -910,68 +1065,48 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L66>:
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm1
+<L42>:
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm3
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm0
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm3
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	subss	%xmm3, %xmm4
                	movss	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xc49>
+               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xbd8>
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	addss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0xc55>
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm6, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movss	%xmm3, (%rcx)
-               	movups	(%rdi), %xmm7
-               	leaq	(%rdi), %rcx
-               	movss	(%rcx), %xmm0
+               	addss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0xbe4>
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm6, (%rdx)
+               	leaq	(%rdx), %rdi
+               	movss	%xmm2, (%rdi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movss	%xmm4, (%rdi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movss	%xmm0, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movss	%xmm3, (%rdi)
+               	movups	(%rdx), %xmm6
+               	movups	%xmm6, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L67>
-<L67>:
-               	leaq	0x4(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	leaq	0xc(%rdi), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L70>
-<L70>:
+               	callq	 <L43>
+<L43>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
-               	movaps	%xmm7, %xmm6
-               	jmp	 <L65>
+               	jmp	 <L41>

--- a/test/golden/x86_64-windows/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-windows/vec/vec_u16x8.dis
@@ -5,65 +5,207 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x2(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
+               	leaq	0x4(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzwl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	leaq	0x6(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rdx), %rbx
+               	movzwl	(%rbx), %esi
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rdx), %rbx
+               	movzwl	(%rbx), %edx
+               	movzwq	%dx, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -72,45 +214,41 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x340, %rsp            # imm = 0x340
-               	movq	%rbx, -0x268(%rbp)
-               	movq	%rdi, -0x270(%rbp)
-               	movq	%rsi, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movaps	%xmm6, -0x290(%rbp)
-               	movaps	%xmm7, -0x2a0(%rbp)
-               	movaps	%xmm8, -0x2b0(%rbp)
-               	movaps	%xmm9, -0x2c0(%rbp)
-               	movaps	%xmm10, -0x2d0(%rbp)
-               	movaps	%xmm11, -0x2e0(%rbp)
-               	movaps	%xmm12, -0x2f0(%rbp)
-               	movaps	%xmm13, -0x300(%rbp)
+               	movq	%rbx, -0x288(%rbp)
+               	movq	%rdi, -0x290(%rbp)
+               	movq	%rsi, -0x298(%rbp)
+               	movq	%r12, -0x2a0(%rbp)
+               	movaps	%xmm6, -0x2b0(%rbp)
+               	movaps	%xmm7, -0x2c0(%rbp)
+               	movaps	%xmm8, -0x2d0(%rbp)
+               	movaps	%xmm9, -0x2e0(%rbp)
+               	movaps	%xmm10, -0x2f0(%rbp)
+               	movaps	%xmm11, -0x300(%rbp)
                	movaps	%xmm14, -0x310(%rbp)
                	movaps	%xmm15, -0x320(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rbx
+               	movq	%rcx, %rax
+               	movw	%ax, %dx
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rbx
                	movw	$0xfff0, (%rbx)         # imm = 0xFFF0
-               	leaq	0x2(%rdx), %rbx
+               	leaq	0x2(%rax), %rbx
                	movw	$0x1, (%rbx)
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x4(%rax), %rbx
                	movw	$0x8000, (%rbx)         # imm = 0x8000
-               	leaq	0x6(%rdx), %rbx
+               	leaq	0x6(%rax), %rbx
                	movw	$0xffff, (%rbx)         # imm = 0xFFFF
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rax), %rbx
                	movw	$0x1001, (%rbx)         # imm = 0x1001
-               	leaq	0xa(%rdx), %rbx
+               	leaq	0xa(%rax), %rbx
                	movw	$0x2, (%rbx)
-               	leaq	0xc(%rdx), %rbx
+               	leaq	0xc(%rax), %rbx
                	movw	$0x9c40, (%rbx)         # imm = 0x9C40
-               	leaq	0xe(%rdx), %rbx
+               	leaq	0xe(%rax), %rbx
                	movw	$0x3039, (%rbx)         # imm = 0x3039
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movw	$0x11, (%rsi)
                	leaq	0x2(%rbx), %rsi
@@ -128,9 +266,9 @@ Disassembly of section .text:
                	leaq	0xe(%rbx), %rsi
                	movw	$0xd431, (%rsi)         # imm = 0xD431
                	movups	(%rbx), %xmm1
-               	leaq	-0x40(%rbp), %rbx
+               	leaq	-0x100(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x110(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x1, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -148,7 +286,7 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0x88b, (%rdi)          # imm = 0x88B
                	movups	(%rsi), %xmm6
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x120(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -166,735 +304,215 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0x0, (%rdi)
                	movups	(%rsi), %xmm7
-               	leaq	(%rdx), %rsi
-               	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rsi
+               	leaq	(%rax), %rsi
+               	movzwl	(%rsi), %eax
+               	addl	%edx, %eax
+               	leaq	-0x130(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
-               	movw	%dx, (%rdi)
+               	movw	%ax, (%rdi)
                	movups	(%rsi), %xmm0
-               	leaq	0xc(%rsi), %rdx
-               	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x80(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rdx
-               	movw	%si, (%rdx)
-               	movups	(%rdi), %xmm8
-               	leaq	0x4(%rbx), %rdx
-               	movzwl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0x90(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x4(%rdx), %rsi
+               	leaq	0xc(%rsi), %rax
+               	movzwl	(%rax), %esi
+               	addl	%edx, %esi
+               	leaq	-0x140(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movw	%si, (%rdi)
+               	movups	(%rax), %xmm8
+               	leaq	0x4(%rbx), %rax
+               	movzwl	(%rax), %ebx
+               	addl	%edx, %ebx
+               	leaq	-0x150(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x4(%rax), %rsi
                	movw	%bx, (%rsi)
-               	movups	(%rdx), %xmm0
+               	movups	(%rax), %xmm0
+               	leaq	0xe(%rax), %rbx
+               	movzwl	(%rbx), %eax
+               	addl	%edx, %eax
+               	leaq	-0x160(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
                	leaq	0xe(%rdx), %rbx
-               	movzwl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xe(%rbx), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%rbx), %xmm9
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movw	%ax, (%rbx)
+               	movups	(%rdx), %xmm9
+               	movups	%xmm8, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm9, -0x180(%rbp)
+               	leaq	-0x180(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	paddw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x190(%rbp)
+               	leaq	-0x190(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	psubw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1a0(%rbp)
+               	leaq	-0x1a0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm9, %xmm14
+               	psubw	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L5>
-<L5>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L6>
-<L6>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm8, %xmm14
-               	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm8, %xmm14
-               	psubw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm9, %xmm14
-               	psubw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L5>
+<L5>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1d0(%rbp)
+               	leaq	-0x1d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	callq	 <L6>
+<L6>:
                	movaps	%xmm9, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x1e0(%rbp)
+               	leaq	-0x1e0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movaps	%xmm8, %xmm14
-               	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	callq	 <L7>
+<L7>:
+               	movaps	%xmm10, %xmm14
                	pmullw	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L8>
+<L8>:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
-               	movaps	%xmm7, %xmm14
-               	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x200(%rbp)
                	leaq	-0x200(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm7, %xmm14
+               	psubw	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x210(%rbp)
-               	leaq	-0x210(%rbp), %rdx
+               	movups	%xmm10, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
+               	callq	 <L11>
+<L11>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
                	movaps	%xmm14, %xmm11
-               	movups	%xmm11, -0x220(%rbp)
-               	leaq	-0x220(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	movaps	%xmm8, %xmm14
-               	pxor	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x230(%rbp)
+               	movups	%xmm11, -0x230(%rbp)
                	leaq	-0x230(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L12>
+<L12>:
                	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x240(%rbp)
                	leaq	-0x240(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	movaps	%xmm9, %xmm14
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x250(%rbp)
                	leaq	-0x250(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm9, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x260(%rbp)
-               	leaq	-0x260(%rbp), %rdx
+               	movups	%xmm10, -0x270(%rbp)
+               	leaq	-0x270(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
-               	leaq	-0xb0(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %rax
-               	movzwl	(%rax), %edx
+               	movups	%xmm11, -0x10(%rbp)
+               	leaq	-0x10(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	callq	 <L18>
+<L18>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0x150(%rbp), %rdi
-               	movups	%xmm12, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x20(%rbp)
+               	leaq	-0x20(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L104>
-<L104>:
+               	callq	 <L19>
+<L19>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x170(%rbp), %rdi
-               	movups	%xmm11, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x30(%rbp)
+               	leaq	-0x30(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L112>
-<L112>:
+               	callq	 <L20>
+<L20>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm13
-               	leaq	-0x190(%rbp), %rdi
-               	movups	%xmm13, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm8
+               	movups	%xmm8, -0x40(%rbp)
+               	leaq	-0x40(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%rdi), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
-               	movaps	%xmm13, %xmm8
-               	movaps	%xmm12, %xmm10
-               	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %rsi
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x80(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -919,61 +537,24 @@ Disassembly of section .text:
                	movups	%xmm10, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%rdi, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rsi,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rax
-               	movzwl	(%rax), %edx
+               	leaq	(%rsi,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x90(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %rdi
+               	jb	 <L23>
+<L25>:
+               	leaq	-0xc0(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
                	movq	$0x0, 0x10(%rdi)
@@ -982,78 +563,76 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%rdi)
                	leaq	(%rdi), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%rsi), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%rdi), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x20(%rdi), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%rsi), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%rdi), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%rdi), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%rdi), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L132>
-<L132>:
-               	movups	(%rsi), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L141>
-<L141>:
-               	movaps	-0x290(%rbp), %xmm6
-               	movaps	-0x2a0(%rbp), %xmm7
-               	movaps	-0x2b0(%rbp), %xmm8
-               	movaps	-0x2c0(%rbp), %xmm9
-               	movaps	-0x2d0(%rbp), %xmm10
-               	movaps	-0x2e0(%rbp), %xmm11
-               	movaps	-0x2f0(%rbp), %xmm12
-               	movaps	-0x300(%rbp), %xmm13
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%rdi), %rdx
+               	movl	(%rdx), %ebx
+               	movl	%ebx, %edx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L29>
+<L30>:
+               	movaps	-0x2b0(%rbp), %xmm6
+               	movaps	-0x2c0(%rbp), %xmm7
+               	movaps	-0x2d0(%rbp), %xmm8
+               	movaps	-0x2e0(%rbp), %xmm9
+               	movaps	-0x2f0(%rbp), %xmm10
+               	movaps	-0x300(%rbp), %xmm11
                	movaps	-0x310(%rbp), %xmm14
                	movaps	-0x320(%rbp), %xmm15
-               	movq	-0x268(%rbp), %rbx
-               	movq	-0x270(%rbp), %rdi
-               	movq	-0x278(%rbp), %rsi
-               	movq	-0x280(%rbp), %r12
+               	movq	-0x288(%rbp), %rbx
+               	movq	-0x290(%rbp), %rdi
+               	movq	-0x298(%rbp), %rsi
+               	movq	-0x2a0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_u32x4.dis
@@ -5,41 +5,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movl	%esi, %edx
-               	callq	 <L2>
+               	leaq	0x4(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	movl	%ebx, %edx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movl	(%rbx), %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rdx), %rbx
+               	movl	(%rbx), %edx
+               	movl	%edx, %ebx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,40 +121,36 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4d0, %rsp            # imm = 0x4D0
-               	movq	%rbx, -0x3e8(%rbp)
-               	movq	%rdi, -0x3f0(%rbp)
-               	movq	%rsi, -0x3f8(%rbp)
-               	movq	%r12, -0x400(%rbp)
-               	movq	%r13, -0x408(%rbp)
-               	movq	%r14, -0x410(%rbp)
-               	movq	%r15, -0x418(%rbp)
-               	movaps	%xmm6, -0x430(%rbp)
-               	movaps	%xmm7, -0x440(%rbp)
-               	movaps	%xmm8, -0x450(%rbp)
-               	movaps	%xmm9, -0x460(%rbp)
-               	movaps	%xmm10, -0x470(%rbp)
-               	movaps	%xmm11, -0x480(%rbp)
-               	movaps	%xmm12, -0x490(%rbp)
-               	movaps	%xmm14, -0x4a0(%rbp)
-               	movaps	%xmm15, -0x4b0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rbx
+               	subq	$0x540, %rsp            # imm = 0x540
+               	movq	%rbx, -0x478(%rbp)
+               	movq	%rdi, -0x480(%rbp)
+               	movq	%rsi, -0x488(%rbp)
+               	movq	%r12, -0x490(%rbp)
+               	movq	%r13, -0x498(%rbp)
+               	movq	%r14, -0x4a0(%rbp)
+               	movq	%r15, -0x4a8(%rbp)
+               	movaps	%xmm6, -0x4c0(%rbp)
+               	movaps	%xmm7, -0x4d0(%rbp)
+               	movaps	%xmm8, -0x4e0(%rbp)
+               	movaps	%xmm9, -0x4f0(%rbp)
+               	movaps	%xmm10, -0x500(%rbp)
+               	movaps	%xmm14, -0x510(%rbp)
+               	movaps	%xmm15, -0x520(%rbp)
+               	movq	%rcx, %rax
+               	movl	%eax, %edx
+               	leaq	-0x160(%rbp), %rax
+               	leaq	(%rax), %rbx
                	movl	$0xfffffff0, (%rbx)     # imm = 0xFFFFFFF0
-               	leaq	0x4(%rdx), %rbx
+               	leaq	0x4(%rax), %rbx
                	movl	$0x1, (%rbx)
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rax), %rbx
                	movl	$0x80000000, (%rbx)     # imm = 0x80000000
-               	leaq	0xc(%rdx), %rbx
+               	leaq	0xc(%rax), %rbx
                	movl	$0x12345678, (%rbx)     # imm = 0x12345678
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x180(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	movl	$0x11, (%rsi)
                	leaq	0x4(%rbx), %rsi
@@ -90,9 +160,9 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rsi
                	movl	$0x1, (%rsi)
                	movups	(%rbx), %xmm1
-               	leaq	-0x40(%rbp), %rbx
+               	leaq	-0x190(%rbp), %rbx
                	movups	%xmm1, (%rbx)
-               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x1a0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x1, (%rdi)
                	leaq	0x4(%rsi), %rdi
@@ -102,9 +172,9 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x1b, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x1b0(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x1c0(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -114,490 +184,340 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm6
-               	leaq	(%rdx), %rdi
-               	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rax), %rdi
+               	movl	(%rdi), %eax
+               	addl	%edx, %eax
+               	leaq	-0x1d0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
-               	movl	%edx, (%r12)
+               	movl	%eax, (%r12)
                	movups	(%rdi), %xmm0
-               	leaq	0x8(%rdi), %rdx
-               	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	leaq	0x8(%rdi), %rax
+               	movl	(%rax), %edi
+               	addl	%edx, %edi
+               	leaq	-0x1e0(%rbp), %r12
                	movups	%xmm0, (%r12)
-               	leaq	0x8(%r12), %rdx
-               	movl	%edi, (%rdx)
+               	leaq	0x8(%r12), %rax
+               	movl	%edi, (%rax)
                	movups	(%r12), %xmm7
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	addl	%ecx, %ebx
-               	leaq	-0xa0(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x4(%rdx), %rdi
+               	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %ebx
+               	addl	%edx, %ebx
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x4(%rax), %rdi
                	movl	%ebx, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rbx
-               	movl	(%rbx), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %rbx
+               	movups	(%rax), %xmm0
+               	leaq	0xc(%rax), %rbx
+               	movl	(%rbx), %eax
+               	addl	%edx, %eax
+               	leaq	-0x200(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%rbx), %rdx
+               	movl	%eax, (%rdx)
                	movups	(%rbx), %xmm8
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm7, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm8, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm7, %xmm14
+               	paddd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	leaq	-0x230(%rbp), %rdi
+               	movups	%xmm9, (%rdi)
+               	movups	%xmm9, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm7, %xmm14
+               	psubd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm8, %xmm14
+               	psubd	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
+               	movq	%rax, %r8
+               	movq	%r8, -0x438(%rbp)
+               	movq	-0x438(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x440(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r13d
+               	imull	%r13d, %edx
+               	leaq	-0x270(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x440(%rbp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x280(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movl	%r14d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x290(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movl	%r15d, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r13
+               	movl	%edx, (%r13)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
+               	movq	-0x438(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
+               	movq	%rax, %r8
+               	movq	%r8, -0x448(%rbp)
+               	movq	-0x448(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rsi), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x2c0(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%r13d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movl	%r14d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movl	%r15d, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x2f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r12
+               	movl	%edx, (%r12)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x300(%rbp)
+               	leaq	-0x300(%rbp), %rdx
+               	movq	-0x448(%rbp), %r8
+               	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	movaps	%xmm7, %xmm14
-               	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	movaps	%xmm7, %xmm14
-               	psubd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm8, %xmm14
-               	psubd	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %edx
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %ebx
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r12d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0xc(%rdi), %rcx
-               	movl	%ebx, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%rdi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm7, %xmm14
-               	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %ebx
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %r12d
                	leaq	(%rsi), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %ebx
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
-               	leaq	0x4(%rsi), %rdx
-               	movl	(%rdx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	0x8(%rsi), %rdx
                	movl	(%rdx), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	leaq	0xc(%rsi), %rdx
+               	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %ebx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%ebx, (%r13)
+               	movups	%xmm8, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%r12d, (%r15)
                	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rbx
-               	movl	%edi, (%rbx)
+               	leaq	0x4(%rdx), %r12
+               	movl	%r13d, (%r12)
                	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rbx
+               	leaq	0x8(%rdx), %r12
+               	movl	%r14d, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r12
+               	movl	%ebx, (%r12)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x350(%rbp)
+               	leaq	-0x350(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%rdi), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %ebx
+               	leaq	0x4(%rdi), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0x8(%rdi), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xc(%rdi), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %edi
+               	leaq	-0x360(%rbp), %rdx
+               	movups	%xmm9, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%ebx, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x370(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rbx
                	movl	%r12d, (%rbx)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movaps	%xmm6, %xmm14
-               	psubd	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	movaps	%xmm6, %xmm14
-               	psubd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x360(%rbp)
-               	leaq	-0x360(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x370(%rbp)
-               	leaq	-0x370(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x380(%rbp)
                	leaq	-0x380(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	movaps	%xmm7, %xmm14
-               	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x390(%rbp)
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rbx
+               	movl	%r13d, (%rbx)
+               	movups	(%rdx), %xmm0
                	leaq	-0x390(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	movaps	%xmm7, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movl	%edi, (%rbx)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, -0x3a0(%rbp)
                	leaq	-0x3a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	%xmm6, %xmm14
+               	psubd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x3b0(%rbp)
                	leaq	-0x3b0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm6, %xmm14
+               	psubd	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x3d0(%rbp)
+               	leaq	-0x3d0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
+               	movaps	%xmm7, %xmm14
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x3e0(%rbp)
+               	leaq	-0x3e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
+               	movaps	%xmm7, %xmm14
+               	pxor	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x3f0(%rbp)
+               	leaq	-0x3f0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm7, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x400(%rbp)
+               	leaq	-0x400(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm8, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x410(%rbp)
+               	leaq	-0x410(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x3c0(%rbp)
-               	leaq	-0x3c0(%rbp), %rdx
+               	movups	%xmm9, -0x420(%rbp)
+               	leaq	-0x420(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L48>:
-               	leaq	-0xc0(%rbp), %r12
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r13
+               	jb	 <L26>
+               	leaq	-0xd0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -614,47 +534,50 @@ Disassembly of section .text:
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rsi), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movl	(%rax), %r14d
+               	movl	%edx, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x450(%rbp)
                	leaq	0x4(%r12), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %r14d
                	leaq	0x4(%rsi), %rax
+               	movl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x458(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movl	(%rax), %r15d
+               	leaq	0x8(%rsi), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rsi), %rax
                	movl	(%rax), %r14d
                	imull	%r14d, %edx
-               	leaq	0x8(%r12), %rax
-               	movl	(%rax), %r14d
-               	leaq	0x8(%rsi), %rax
-               	movl	(%rax), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xc(%r12), %rax
-               	movl	(%rax), %r15d
-               	leaq	0xc(%rsi), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %r15d
-               	leaq	-0x150(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rax
                	movups	%xmm7, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
-               	movl	%r8d, (%rcx)
+               	leaq	(%rax), %r14
+               	movq	-0x450(%rbp), %r8
+               	movl	%r8d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x160(%rbp), %rax
+               	leaq	-0xf0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0x4(%rax), %r14
+               	movq	-0x458(%rbp), %r8
+               	movl	%r8d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x170(%rbp), %rax
+               	leaq	-0x100(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%r14d, (%rcx)
+               	leaq	0x8(%rax), %r14
+               	movl	%r15d, (%r14)
                	movups	(%rax), %xmm0
-               	leaq	-0x180(%rbp), %rax
+               	leaq	-0x110(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%r15d, (%rcx)
+               	leaq	0xc(%rax), %r14
+               	movl	%edx, (%r14)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
@@ -663,54 +586,24 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
-               	movups	%xmm0, (%r8)
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %edx
+               	leaq	(%r13,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x120(%rbp)
+               	leaq	-0x120(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x3d0(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
-               	movl	%r8d, %edx
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rcx
-               	movq	-0x3e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %eax
-               	movl	%eax, %edx
-               	callq	 <L53>
-<L53>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r15
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -719,202 +612,156 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r15)
                	leaq	(%r15), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r15), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%r15), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%r13), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r15), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r15), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x460(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x460(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %rax
+               	xorq	%r13, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r15), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x430(%rbp)
+               	leaq	-0x430(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L55>
-<L55>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x1d0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x20(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x430(%rbp), %xmm6
-               	movaps	-0x440(%rbp), %xmm7
-               	movaps	-0x450(%rbp), %xmm8
-               	movaps	-0x460(%rbp), %xmm9
-               	movaps	-0x470(%rbp), %xmm10
-               	movaps	-0x480(%rbp), %xmm11
-               	movaps	-0x490(%rbp), %xmm12
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	movq	-0x3e8(%rbp), %rbx
-               	movq	-0x3f0(%rbp), %rdi
-               	movq	-0x3f8(%rbp), %rsi
-               	movq	-0x400(%rbp), %r12
-               	movq	-0x408(%rbp), %r13
-               	movq	-0x410(%rbp), %r14
-               	movq	-0x418(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	leaq	0x20(%r15), %rdx
+               	movl	(%rdx), %r13d
+               	movl	%r13d, %edx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+<L25>:
+               	movaps	-0x4c0(%rbp), %xmm6
+               	movaps	-0x4d0(%rbp), %xmm7
+               	movaps	-0x4e0(%rbp), %xmm8
+               	movaps	-0x4f0(%rbp), %xmm9
+               	movaps	-0x500(%rbp), %xmm10
+               	movaps	-0x510(%rbp), %xmm14
+               	movaps	-0x520(%rbp), %xmm15
+               	movq	-0x478(%rbp), %rbx
+               	movq	-0x480(%rbp), %rdi
+               	movq	-0x488(%rbp), %rsi
+               	movq	-0x490(%rbp), %r12
+               	movq	-0x498(%rbp), %r13
+               	movq	-0x4a0(%rbp), %r14
+               	movq	-0x4a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %r13d
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x468(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %r14d
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %r14d
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r12d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%r13d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm10
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r15d
+               	leaq	0xc(%r12), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0xc(%rsi), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r13
+               	movq	-0x468(%rbp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r13
+               	movl	%r14d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movl	%r15d, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %r13
+               	movl	%r12d, (%r13)
+               	movups	(%rdx), %xmm10
+               	movups	%xmm10, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x1e0(%rbp), %r12
-               	movups	%xmm11, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x70(%rbp)
+               	leaq	-0x70(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L69>
-<L69>:
+               	callq	 <L28>
+<L28>:
                	movaps	%xmm6, %xmm14
                	paddd	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0x200(%rbp), %r12
-               	movups	%xmm10, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm6
+               	movups	%xmm6, -0x80(%rbp)
+               	leaq	-0x80(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L29>
+<L29>:
                	movaps	%xmm7, %xmm14
                	paddd	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0x220(%rbp), %r12
-               	movups	%xmm12, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x90(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
-               	movaps	%xmm12, %xmm7
-               	movaps	%xmm11, %xmm9
-               	movaps	%xmm10, %xmm6
-               	jmp	 <L48>
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_u64x2.dis
@@ -5,29 +5,67 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movq	(%rbx), %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movq	(%rdx), %rbx
-               	movq	%rbx, %rdx
-               	callq	 <L1>
+               	movq	%rbx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rbx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movq	(%rbx), %rdx
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rbx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rbx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+<L3>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,344 +73,279 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3e0, %rsp            # imm = 0x3E0
-               	movq	%rbx, -0x2f8(%rbp)
-               	movq	%rdi, -0x300(%rbp)
-               	movq	%rsi, -0x308(%rbp)
-               	movq	%r12, -0x310(%rbp)
-               	movq	%r13, -0x318(%rbp)
-               	movq	%r14, -0x320(%rbp)
-               	movq	%r15, -0x328(%rbp)
-               	movaps	%xmm6, -0x340(%rbp)
-               	movaps	%xmm7, -0x350(%rbp)
-               	movaps	%xmm8, -0x360(%rbp)
-               	movaps	%xmm9, -0x370(%rbp)
-               	movaps	%xmm10, -0x380(%rbp)
-               	movaps	%xmm11, -0x390(%rbp)
-               	movaps	%xmm12, -0x3a0(%rbp)
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movaps	%xmm15, -0x3c0(%rbp)
-               	movq	%rcx, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$-0x10, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x12345678, (%rdx)     # imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
-               	leaq	(%rdx), %rsi
+               	subq	$0x430, %rsp            # imm = 0x430
+               	movq	%rbx, -0x368(%rbp)
+               	movq	%rdi, -0x370(%rbp)
+               	movq	%rsi, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
+               	movaps	%xmm6, -0x3b0(%rbp)
+               	movaps	%xmm7, -0x3c0(%rbp)
+               	movaps	%xmm8, -0x3d0(%rbp)
+               	movaps	%xmm9, -0x3e0(%rbp)
+               	movaps	%xmm10, -0x3f0(%rbp)
+               	movaps	%xmm14, -0x400(%rbp)
+               	movaps	%xmm15, -0x410(%rbp)
+               	movq	%rcx, %rax
+               	leaq	-0x120(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movq	$-0x10, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movq	$0x12345678, (%rbx)     # imm = 0x12345678
+               	movups	(%rdx), %xmm0
+               	leaq	-0x130(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	-0x140(%rbp), %rbx
+               	leaq	(%rbx), %rsi
                	movq	$0x11, (%rsi)
-               	leaq	0x8(%rdx), %rsi
+               	leaq	0x8(%rbx), %rsi
                	movq	$-0x1, (%rsi)
-               	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
+               	movups	(%rbx), %xmm1
+               	leaq	-0x150(%rbp), %rbx
+               	movups	%xmm1, (%rbx)
+               	leaq	-0x160(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movq	$0x1, (%rdi)
                	leaq	0x8(%rsi), %rdi
                	movq	$0x1b, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %rsi
+               	leaq	-0x170(%rbp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x180(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movq	$0x0, (%r12)
                	leaq	0x8(%rdi), %r12
                	movq	$0x0, (%r12)
                	movups	(%rdi), %xmm6
-               	leaq	(%rcx), %rdi
-               	movq	(%rdi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rdx), %rdi
+               	movq	(%rdi), %rdx
+               	addq	%rax, %rdx
+               	leaq	-0x190(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
-               	movq	%rcx, (%r12)
+               	movq	%rdx, (%r12)
                	movups	(%rdi), %xmm7
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm8
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
+               	addq	%rax, %rbx
+               	leaq	-0x1a0(%rbp), %r12
+               	movups	%xmm1, (%r12)
+               	leaq	0x8(%r12), %rax
+               	movq	%rbx, (%rax)
+               	movups	(%r12), %xmm8
+               	movups	%xmm7, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
+               	movups	%xmm8, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	paddq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	leaq	-0x1d0(%rbp), %rbx
+               	movups	%xmm9, (%rbx)
+               	movups	%xmm9, -0x1e0(%rbp)
+               	leaq	-0x1e0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	psubq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x1f0(%rbp)
+               	leaq	-0x1f0(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm8, %xmm14
+               	psubq	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L4>
 <L4>:
-               	movaps	%xmm7, %xmm14
-               	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%rdi), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%rdi), %rdx
+               	movq	(%rdx), %r14
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %r14
+               	leaq	-0x210(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%r13, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x220(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%r14, (%r13)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%rdi), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%rdi), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x240(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x250(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%rdi, (%r13)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L6>
 <L6>:
-               	movaps	%xmm7, %xmm14
-               	psubq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r13
+               	imulq	%r13, %rdi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r13
+               	imulq	%r13, %r12
+               	leaq	-0x270(%rbp), %rdx
+               	movups	%xmm8, (%rdx)
+               	leaq	(%rdx), %r13
+               	movq	%rdi, (%r13)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movq	%r12, (%rdi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	movq	%rax, %rcx
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L8>
-<L8>:
-               	movaps	%xmm8, %xmm14
-               	psubq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L9>
-<L9>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L10>
-<L10>:
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdx
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %r12
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %r12
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	%rdx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%r12, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L11>
-<L11>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L12>
-<L12>:
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdx
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdi
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r12
-               	imulq	%r12, %rdi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	%rdx, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movq	%rdi, (%rcx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L13>
-<L13>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L14>
-<L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rbx
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rdi
-               	movups	%xmm0, (%rdi)
-               	leaq	0x8(%rdi), %rcx
-               	movq	%rbx, (%rcx)
-               	movups	(%rdi), %xmm0
-               	leaq	(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L15>
-<L15>:
-               	leaq	0x8(%rdi), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L16>
-<L16>:
-               	movaps	%xmm7, %xmm14
-               	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rbx
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	leaq	(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rbx
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
                	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rbx
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm9, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rdi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
+               	leaq	0x8(%rdx), %rdi
                	movq	%rbx, (%rdi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L18>
-<L18>:
-               	movaps	%xmm6, %xmm14
-               	psubq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L20>
-<L20>:
-               	movaps	%xmm6, %xmm14
-               	psubq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x280(%rbp)
-               	leaq	-0x280(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L21>
-<L21>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x290(%rbp)
-               	leaq	-0x290(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L22>
-<L22>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x2a0(%rbp)
-               	leaq	-0x2a0(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L23>
-<L23>:
-               	movaps	%xmm7, %xmm14
-               	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x2b0(%rbp)
-               	leaq	-0x2b0(%rbp), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm7, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x2c0(%rbp)
                	leaq	-0x2c0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	movaps	%xmm8, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	%xmm6, %xmm14
+               	psubq	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
                	movups	%xmm0, -0x2d0(%rbp)
                	leaq	-0x2d0(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm6, %xmm14
+               	psubq	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x2e0(%rbp)
+               	leaq	-0x2e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x2f0(%rbp)
+               	leaq	-0x2f0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
+               	movaps	%xmm7, %xmm14
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
+               	movups	%xmm10, -0x300(%rbp)
+               	leaq	-0x300(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
+               	movaps	%xmm7, %xmm14
+               	pxor	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x310(%rbp)
+               	leaq	-0x310(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm7, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x320(%rbp)
+               	leaq	-0x320(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
+               	movaps	%xmm8, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x330(%rbp)
+               	leaq	-0x330(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x2e0(%rbp)
-               	leaq	-0x2e0(%rbp), %rdx
+               	movups	%xmm9, -0x340(%rbp)
+               	leaq	-0x340(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L28>:
-               	leaq	-0xa0(%rbp), %r12
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r13
+               	jb	 <L26>
+               	leaq	-0xb0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -389,24 +362,24 @@ Disassembly of section .text:
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
-               	movq	(%rax), %rcx
+               	movq	(%rax), %rdx
                	leaq	(%rsi), %rax
-               	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r12), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%rsi), %rax
                	movq	(%rax), %r14
                	imulq	%r14, %rdx
-               	leaq	-0x110(%rbp), %rax
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %r14
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r15
+               	imulq	%r15, %r14
+               	leaq	-0xc0(%rbp), %rax
                	movups	%xmm7, (%rax)
-               	leaq	(%rax), %r14
-               	movq	%rcx, (%r14)
+               	leaq	(%rax), %r15
+               	movq	%rdx, (%r15)
                	movups	(%rax), %xmm0
-               	leaq	-0x120(%rbp), %rax
+               	leaq	-0xd0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
+               	leaq	0x8(%rax), %rdx
+               	movq	%r14, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
@@ -415,36 +388,24 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x2e8(%rbp), %r8
-               	movups	%xmm0, (%r8)
-               	movq	-0x2e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rdx
+               	leaq	(%r13,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, -0xe0(%rbp)
+               	leaq	-0xe0(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	-0x2e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rax
-               	movq	%rax, %rdx
-               	callq	 <L31>
-<L31>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r15
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x110(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -453,132 +414,133 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r15)
                	leaq	(%r15), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r15), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%r15), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	leaq	0x20(%r13), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r15), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r15), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
                	movl	(%rax), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x358(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %rax
+               	xorq	%r13, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r15), %rax
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x350(%rbp)
+               	leaq	-0x350(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L33>
-<L33>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x170(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L35>
-<L35>:
-               	leaq	0x20(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x340(%rbp), %xmm6
-               	movaps	-0x350(%rbp), %xmm7
-               	movaps	-0x360(%rbp), %xmm8
-               	movaps	-0x370(%rbp), %xmm9
-               	movaps	-0x380(%rbp), %xmm10
-               	movaps	-0x390(%rbp), %xmm11
-               	movaps	-0x3a0(%rbp), %xmm12
-               	movaps	-0x3b0(%rbp), %xmm14
-               	movaps	-0x3c0(%rbp), %xmm15
-               	movq	-0x2f8(%rbp), %rbx
-               	movq	-0x300(%rbp), %rdi
-               	movq	-0x308(%rbp), %rsi
-               	movq	-0x310(%rbp), %r12
-               	movq	-0x318(%rbp), %r13
-               	movq	-0x320(%rbp), %r14
-               	movq	-0x328(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	leaq	0x20(%r15), %rdx
+               	movl	(%rdx), %r13d
+               	movl	%r13d, %edx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rax, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rax
+               	cmpq	$0x8, %r13
+               	jb	 <L24>
+<L25>:
+               	movaps	-0x3b0(%rbp), %xmm6
+               	movaps	-0x3c0(%rbp), %xmm7
+               	movaps	-0x3d0(%rbp), %xmm8
+               	movaps	-0x3e0(%rbp), %xmm9
+               	movaps	-0x3f0(%rbp), %xmm10
+               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm15
+               	movq	-0x368(%rbp), %rbx
+               	movq	-0x370(%rbp), %rdi
+               	movq	-0x378(%rbp), %rsi
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %rdx
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %r12
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	imulq	%r13, %r12
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	%rdx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xc0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%r12, (%rcx)
-               	movups	(%r13), %xmm10
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
+<L26>:
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %r13
+               	leaq	(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r13
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %r12
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm7, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%r13, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %r13
+               	movq	%r12, (%r13)
+               	movups	(%rdx), %xmm10
+               	movups	%xmm10, -0x40(%rbp)
+               	leaq	-0x40(%rbp), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L39>
-<L39>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
-               	movaps	%xmm14, %xmm11
-               	leaq	-0x180(%rbp), %r12
-               	movups	%xmm11, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm9
+               	movups	%xmm9, -0x50(%rbp)
+               	leaq	-0x50(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L28>
+<L28>:
                	movaps	%xmm6, %xmm14
                	paddq	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm10
-               	leaq	-0x1a0(%rbp), %r12
-               	movups	%xmm10, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm6
+               	movups	%xmm6, -0x60(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L29>
+<L29>:
                	movaps	%xmm7, %xmm14
                	paddq	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm12
-               	leaq	-0x1c0(%rbp), %r12
-               	movups	%xmm12, (%r12)
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm14, %xmm7
+               	movups	%xmm7, -0x70(%rbp)
+               	leaq	-0x70(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
-               	movaps	%xmm12, %xmm7
-               	movaps	%xmm11, %xmm9
-               	movaps	%xmm10, %xmm6
-               	jmp	 <L28>
+               	jmp	 <L17>

--- a/test/golden/x86_64-windows/vec/vec_u8x16.dis
+++ b/test/golden/x86_64-windows/vec/vec_u8x16.dis
@@ -5,113 +5,391 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u8x16.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	movq	%rsi, -0x20(%rbp)
-               	movaps	%xmm14, -0x30(%rbp)
-               	movaps	%xmm15, -0x40(%rbp)
+               	movq	%rdi, -0x20(%rbp)
+               	movq	%rsi, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movaps	%xmm14, -0x40(%rbp)
+               	movaps	%xmm15, -0x50(%rbp)
+               	movq	%rcx, %rax
                	movups	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rcx
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L2>
+               	leaq	0x1(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rcx
-               	leaq	0x3(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rcx
-               	leaq	0x4(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L4>
+               	leaq	0x2(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rcx
-               	leaq	0x5(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rcx
-               	leaq	0x6(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L6>
+               	leaq	0x3(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rcx
-               	leaq	0x7(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rcx
-               	leaq	0x8(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L8>
+               	leaq	0x4(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rcx
-               	leaq	0x9(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rcx
-               	leaq	0xa(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L10>
+               	leaq	0x5(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rcx
-               	leaq	0xb(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	leaq	0xc(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L12>
+               	leaq	0x6(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rcx
-               	leaq	0xd(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L13>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rcx
-               	leaq	0xe(%rbx), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rsi, %rdx
-               	callq	 <L14>
+               	leaq	0x7(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rcx
-               	leaq	0xf(%rbx), %rdx
-               	movzbl	(%rdx), %ebx
-               	movq	%rbx, %rdx
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movaps	-0x30(%rbp), %xmm14
-               	movaps	-0x40(%rbp), %xmm15
+               	leaq	0x8(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rdx), %rbx
+               	movzbl	(%rbx), %edx
+               	movzbq	%dl, %rbx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movaps	-0x40(%rbp), %xmm14
+               	movaps	-0x50(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %rsi
+               	movq	-0x20(%rbp), %rdi
+               	movq	-0x28(%rbp), %rsi
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -119,1124 +397,1109 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xbe0, %rsp            # imm = 0xBE0
-               	movq	%rbx, -0xb18(%rbp)
-               	movq	%rdi, -0xb20(%rbp)
-               	movq	%rsi, -0xb28(%rbp)
-               	movq	%r12, -0xb30(%rbp)
-               	movq	%r13, -0xb38(%rbp)
-               	movq	%r14, -0xb40(%rbp)
-               	movq	%r15, -0xb48(%rbp)
-               	movaps	%xmm6, -0xb60(%rbp)
-               	movaps	%xmm7, -0xb70(%rbp)
-               	movaps	%xmm8, -0xb80(%rbp)
-               	movaps	%xmm9, -0xb90(%rbp)
-               	movaps	%xmm10, -0xba0(%rbp)
-               	movaps	%xmm14, -0xbb0(%rbp)
-               	movaps	%xmm15, -0xbc0(%rbp)
-               	movq	%rcx, %rbx
+               	subq	$0xbc0, %rsp            # imm = 0xBC0
+               	movq	%rbx, -0xaf8(%rbp)
+               	movq	%rdi, -0xb00(%rbp)
+               	movq	%rsi, -0xb08(%rbp)
+               	movq	%r12, -0xb10(%rbp)
+               	movq	%r13, -0xb18(%rbp)
+               	movq	%r14, -0xb20(%rbp)
+               	movq	%r15, -0xb28(%rbp)
+               	movaps	%xmm6, -0xb40(%rbp)
+               	movaps	%xmm7, -0xb50(%rbp)
+               	movaps	%xmm8, -0xb60(%rbp)
+               	movaps	%xmm9, -0xb70(%rbp)
+               	movaps	%xmm10, -0xb80(%rbp)
+               	movaps	%xmm14, -0xb90(%rbp)
+               	movaps	%xmm15, -0xba0(%rbp)
+               	movb	%cl, %al
+               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x10, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$0x11, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x38, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x63, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$0x0, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x21, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x40, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$0x5, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$-0x39, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x300(%rbp), %rdx
+               	leaq	(%rdx), %rbx
+               	movb	$0x11, (%rbx)
+               	leaq	0x1(%rdx), %rbx
+               	movb	$-0x1, (%rbx)
+               	leaq	0x2(%rdx), %rbx
+               	movb	$-0x7f, (%rbx)
+               	leaq	0x3(%rdx), %rbx
+               	movb	$0x1, (%rbx)
+               	leaq	0x4(%rdx), %rbx
+               	movb	$-0x38, (%rbx)
+               	leaq	0x5(%rdx), %rbx
+               	movb	$0x64, (%rbx)
+               	leaq	0x6(%rdx), %rbx
+               	movb	$0x39, (%rbx)
+               	leaq	0x7(%rdx), %rbx
+               	movb	$0x15, (%rbx)
+               	leaq	0x8(%rdx), %rbx
+               	movb	$-0x1, (%rbx)
+               	leaq	0x9(%rdx), %rbx
+               	movb	$0x3, (%rbx)
+               	leaq	0xa(%rdx), %rbx
+               	movb	$0x6, (%rbx)
+               	leaq	0xb(%rdx), %rbx
+               	movb	$-0x22, (%rbx)
+               	leaq	0xc(%rdx), %rbx
+               	movb	$-0x80, (%rbx)
+               	leaq	0xd(%rdx), %rbx
+               	movb	$-0x40, (%rbx)
+               	leaq	0xe(%rdx), %rbx
+               	movb	$-0x5, (%rbx)
+               	leaq	0xf(%rdx), %rbx
+               	movb	$0x39, (%rbx)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x310(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	-0x320(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	movb	$0x1, (%rsi)
+               	leaq	0x1(%rbx), %rsi
+               	movb	$0x3, (%rsi)
+               	leaq	0x2(%rbx), %rsi
+               	movb	$0x9, (%rsi)
+               	leaq	0x3(%rbx), %rsi
+               	movb	$0x1b, (%rsi)
+               	leaq	0x4(%rbx), %rsi
+               	movb	$0x2, (%rsi)
+               	leaq	0x5(%rbx), %rsi
+               	movb	$0x6, (%rsi)
+               	leaq	0x6(%rbx), %rsi
+               	movb	$0x12, (%rsi)
+               	leaq	0x7(%rbx), %rsi
+               	movb	$0x36, (%rsi)
+               	leaq	0x8(%rbx), %rsi
+               	movb	$0x4, (%rsi)
+               	leaq	0x9(%rbx), %rsi
+               	movb	$0xc, (%rsi)
+               	leaq	0xa(%rbx), %rsi
+               	movb	$0x24, (%rsi)
+               	leaq	0xb(%rbx), %rsi
+               	movb	$0x6c, (%rsi)
+               	leaq	0xc(%rbx), %rsi
+               	movb	$0x8, (%rsi)
+               	leaq	0xd(%rbx), %rsi
+               	movb	$0x18, (%rsi)
+               	leaq	0xe(%rbx), %rsi
+               	movb	$0x48, (%rsi)
+               	leaq	0xf(%rbx), %rsi
+               	movb	$-0x28, (%rsi)
+               	movups	(%rbx), %xmm2
+               	leaq	-0x330(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x340(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm6
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x350(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x360(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x7(%rdi), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rdi), %xmm7
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x370(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x380(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rax
+               	movb	%cl, (%rax)
+               	movups	(%rsi), %xmm8
+               	movups	%xmm7, -0x390(%rbp)
+               	leaq	-0x390(%rbp), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	movups	%xmm8, -0x3a0(%rbp)
+               	leaq	-0x3a0(%rbp), %rdx
                	movq	%rax, %rcx
-               	movb	%bl, %dl
-               	leaq	-0x10(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	movb	$-0x10, (%rsi)
-               	leaq	0x1(%rbx), %rsi
-               	movb	$0x1, (%rsi)
-               	leaq	0x2(%rbx), %rsi
-               	movb	$-0x80, (%rsi)
-               	leaq	0x3(%rbx), %rsi
-               	movb	$-0x1, (%rsi)
-               	leaq	0x4(%rbx), %rsi
-               	movb	$0x11, (%rsi)
-               	leaq	0x5(%rbx), %rsi
-               	movb	$0x2, (%rsi)
-               	leaq	0x6(%rbx), %rsi
-               	movb	$-0x38, (%rsi)
-               	leaq	0x7(%rbx), %rsi
-               	movb	$0x63, (%rsi)
-               	leaq	0x8(%rbx), %rsi
-               	movb	$0x0, (%rsi)
-               	leaq	0x9(%rbx), %rsi
-               	movb	$0x7, (%rsi)
-               	leaq	0xa(%rbx), %rsi
-               	movb	$-0x6, (%rsi)
-               	leaq	0xb(%rbx), %rsi
-               	movb	$0x21, (%rsi)
-               	leaq	0xc(%rbx), %rsi
-               	movb	$-0x80, (%rsi)
-               	leaq	0xd(%rbx), %rsi
-               	movb	$0x40, (%rsi)
-               	leaq	0xe(%rbx), %rsi
-               	movb	$0x5, (%rsi)
-               	leaq	0xf(%rbx), %rsi
-               	movb	$-0x39, (%rsi)
-               	movups	(%rbx), %xmm0
-               	leaq	-0x20(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movb	$0x11, (%rdi)
-               	leaq	0x1(%rsi), %rdi
-               	movb	$-0x1, (%rdi)
-               	leaq	0x2(%rsi), %rdi
-               	movb	$-0x7f, (%rdi)
-               	leaq	0x3(%rsi), %rdi
-               	movb	$0x1, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movb	$-0x38, (%rdi)
-               	leaq	0x5(%rsi), %rdi
-               	movb	$0x64, (%rdi)
-               	leaq	0x6(%rsi), %rdi
-               	movb	$0x39, (%rdi)
-               	leaq	0x7(%rsi), %rdi
-               	movb	$0x15, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movb	$-0x1, (%rdi)
-               	leaq	0x9(%rsi), %rdi
-               	movb	$0x3, (%rdi)
-               	leaq	0xa(%rsi), %rdi
-               	movb	$0x6, (%rdi)
-               	leaq	0xb(%rsi), %rdi
-               	movb	$-0x22, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movb	$-0x80, (%rdi)
-               	leaq	0xd(%rsi), %rdi
-               	movb	$-0x40, (%rdi)
-               	leaq	0xe(%rsi), %rdi
-               	movb	$-0x5, (%rdi)
-               	leaq	0xf(%rsi), %rdi
-               	movb	$0x39, (%rdi)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
-               	leaq	(%rdi), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rdi), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x2(%rdi), %r12
-               	movb	$0x9, (%r12)
-               	leaq	0x3(%rdi), %r12
-               	movb	$0x1b, (%r12)
-               	leaq	0x4(%rdi), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x5(%rdi), %r12
-               	movb	$0x6, (%r12)
-               	leaq	0x6(%rdi), %r12
-               	movb	$0x12, (%r12)
-               	leaq	0x7(%rdi), %r12
-               	movb	$0x36, (%r12)
-               	leaq	0x8(%rdi), %r12
-               	movb	$0x4, (%r12)
-               	leaq	0x9(%rdi), %r12
-               	movb	$0xc, (%r12)
-               	leaq	0xa(%rdi), %r12
-               	movb	$0x24, (%r12)
-               	leaq	0xb(%rdi), %r12
-               	movb	$0x6c, (%r12)
-               	leaq	0xc(%rdi), %r12
-               	movb	$0x8, (%r12)
-               	leaq	0xd(%rdi), %r12
-               	movb	$0x18, (%r12)
-               	leaq	0xe(%rdi), %r12
-               	movb	$0x48, (%r12)
-               	leaq	0xf(%rdi), %r12
-               	movb	$-0x28, (%r12)
-               	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rdi
-               	movups	%xmm2, (%rdi)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm6
-               	leaq	(%rbx), %r12
-               	movzbl	(%r12), %ebx
-               	addl	%edx, %ebx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%bl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rbx
-               	movzbl	(%rbx), %r12d
-               	addl	%edx, %r12d
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x7(%rbx), %r13
-               	movb	%r12b, (%r13)
-               	movups	(%rbx), %xmm7
-               	leaq	0x3(%rsi), %r12
-               	movzbl	(%r12), %esi
-               	addl	%edx, %esi
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
-               	leaq	0x3(%r12), %r13
-               	movb	%sil, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0xc(%r12), %rsi
-               	movzbl	(%rsi), %r12d
-               	addl	%edx, %r12d
-               	leaq	-0xb0(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0xc(%rsi), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rsi), %xmm8
-               	movups	%xmm7, -0xc0(%rbp)
-               	leaq	-0xc0(%rbp), %rdx
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rcx
-               	movups	%xmm8, -0xd0(%rbp)
-               	leaq	-0xd0(%rbp), %rdx
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	leaq	-0xe0(%rbp), %r12
+               	leaq	-0x3b0(%rbp), %r12
                	movups	%xmm9, (%r12)
-               	movups	%xmm9, -0xf0(%rbp)
-               	leaq	-0xf0(%rbp), %rdx
-               	callq	 <L3>
-<L3>:
+               	movups	%xmm9, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L2>
+<L2>:
                	movaps	%xmm7, %xmm14
                	psubb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x100(%rbp)
-               	leaq	-0x100(%rbp), %rdx
-               	callq	 <L4>
-<L4>:
+               	movups	%xmm0, -0x3d0(%rbp)
+               	leaq	-0x3d0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L3>
+<L3>:
                	movaps	%xmm8, %xmm14
                	psubb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x110(%rbp)
-               	leaq	-0x110(%rbp), %rdx
-               	callq	 <L5>
-<L5>:
+               	movups	%xmm0, -0x3e0(%rbp)
+               	leaq	-0x3e0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L4>
+<L4>:
                	movq	%rax, %r8
                	movq	%r8, -0x8b8(%rbp)
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	(%rsi), %rdx
-               	movzbl	(%rdx), %r14d
+               	leaq	(%rdi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rsi), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x8c0(%rbp)
+               	leaq	0x1(%rdi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rsi), %rcx
+               	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r15d
+               	movq	%r8, -0x8c8(%rbp)
+               	leaq	0x2(%rdi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rsi), %rcx
+               	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x2(%rsi), %rdx
-               	movzbl	(%rdx), %ecx
+               	movq	%r8, -0x8d0(%rbp)
+               	leaq	0x3(%rdi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rsi), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x8d8(%rbp)
+               	leaq	0x4(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x8e0(%rbp)
+               	leaq	0x5(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x8e8(%rbp)
+               	leaq	0x6(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x6(%rsi), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x8f0(%rbp)
+               	leaq	0x7(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x7(%rsi), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	leaq	0x8(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rsi), %rax
+               	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x3(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8d8(%rbp)
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x4(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x8e0(%rbp)
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x5(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8e8(%rbp)
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x7(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8f8(%rbp)
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
                	movq	%r8, -0x900(%rbp)
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x908(%rbp)
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
+               	leaq	0x9(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x910(%rbp)
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
+               	movq	%r8, -0x908(%rbp)
+               	leaq	0xa(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rsi), %rax
+               	movzbl	(%rax), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x918(%rbp)
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
+               	movq	%r8, -0x910(%rbp)
+               	leaq	0xb(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rsi), %rax
+               	movzbl	(%rax), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x920(%rbp)
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xd(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x918(%rbp)
+               	leaq	0xc(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xc(%rsi), %rax
+               	movzbl	(%rax), %r15d
                	imull	%r15d, %r14d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0xd(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rsi), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %edx
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %r13
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %r13
                	movq	-0x8c0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x8c8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
                	movq	-0x8d0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x450(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %r13
                	movb	%r14b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %r13
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %r13
                	movb	%r15b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x220(%rbp)
-               	leaq	-0x220(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x4f0(%rbp)
+               	leaq	-0x4f0(%rbp), %rdx
                	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	leaq	(%rdi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x928(%rbp)
+               	leaq	0x1(%rdi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x930(%rbp)
+               	leaq	0x2(%rdi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x938(%rbp)
+               	leaq	0x3(%rdi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x940(%rbp)
+               	leaq	0x4(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x948(%rbp)
+               	leaq	0x5(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x950(%rbp)
+               	leaq	0x6(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x958(%rbp)
+               	leaq	0x7(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x960(%rbp)
+               	leaq	0x8(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x968(%rbp)
+               	leaq	0x9(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x970(%rbp)
+               	leaq	0xa(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x978(%rbp)
+               	leaq	0xb(%rdi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xc(%rdi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xd(%rdi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%rdi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%rdi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %edx
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm7, (%rax)
+               	leaq	(%rax), %rdi
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rdi
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rdi
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rdi
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movq	-0x948(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x550(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rdi
+               	movq	-0x950(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rdi
+               	movq	-0x958(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rdi
+               	movq	-0x960(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movq	-0x968(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rdi
+               	movq	-0x970(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movq	-0x978(%rbp), %r8
+               	movb	%r8b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r14b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x600(%rbp)
+               	leaq	-0x600(%rbp), %rdx
+               	movq	-0x920(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %r8
-               	movq	%r8, -0x928(%rbp)
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%rbx), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x930(%rbp)
-               	leaq	0x1(%rbx), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x938(%rbp)
-               	leaq	0x2(%rbx), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0x940(%rbp)
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x3(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x948(%rbp)
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x4(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x950(%rbp)
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x968(%rbp)
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x970(%rbp)
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
                	movq	%r8, -0x980(%rbp)
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x988(%rbp)
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm7, (%rcx)
-               	leaq	(%rcx), %rbx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rbx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rbx
-               	movq	-0x940(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rbx
-               	movq	-0x948(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rbx
-               	movq	-0x950(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rbx
-               	movq	-0x958(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rbx
-               	movq	-0x960(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rbx
-               	movq	-0x968(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rbx
-               	movq	-0x970(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rbx
-               	movq	-0x978(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rbx
                	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rbx
+               	leaq	(%rsi), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %edi
+               	movl	%edx, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x988(%rbp)
+               	leaq	0x1(%rsi), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x990(%rbp)
+               	leaq	0x2(%rsi), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x998(%rbp)
+               	leaq	0x3(%rsi), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x9a0(%rbp)
+               	leaq	0x4(%rsi), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x9a8(%rbp)
+               	leaq	0x5(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x9b0(%rbp)
+               	leaq	0x6(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%edx, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x9b8(%rbp)
+               	leaq	0x7(%rsi), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x9c0(%rbp)
+               	leaq	0x8(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x9c8(%rbp)
+               	leaq	0x9(%rsi), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x9d0(%rbp)
+               	leaq	0xa(%rsi), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%rsi), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%rsi), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %edx
+               	leaq	0xd(%rsi), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %edi
+               	leaq	0xe(%rsi), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xf(%rsi), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm8, (%rax)
+               	leaq	(%rax), %r14
                	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rbx
-               	movb	%r13b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rbx
-               	movb	%r14b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rbx
-               	movb	%r15b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rbx
-               	movb	%dl, (%rbx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x330(%rbp)
-               	leaq	-0x330(%rbp), %rdx
-               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x990(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x998(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
+               	movq	-0x9a0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x650(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
+               	movq	-0x9a8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
+               	movq	-0x9b0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
+               	movq	-0x9b8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
+               	movq	-0x9c0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
+               	movq	-0x9c8(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
+               	movq	-0x9d0(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r14
+               	movb	%r15b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r14
+               	movb	%cl, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%r13b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x710(%rbp)
+               	leaq	-0x710(%rbp), %rdx
+               	movq	-0x980(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
-               	leaq	(%rsi), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x998(%rbp)
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x9a0(%rbp)
-               	leaq	0x2(%rsi), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x9a8(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x3(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0x9b0(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0x9b8(%rbp)
-               	leaq	0x5(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x9c0(%rbp)
-               	leaq	0x6(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0x9c8(%rbp)
-               	leaq	0x7(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x9d0(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
                	movq	%r8, -0x9d8(%rbp)
-               	leaq	0x9(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0x9e0(%rbp)
-               	leaq	0xa(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%ebx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x9e8(%rbp)
-               	leaq	0xb(%rsi), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xc(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	0xd(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xe(%rsi), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	0xf(%rsi), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %ebx
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm8, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rsi
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rsi
-               	movq	-0x9a8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rsi
-               	movq	-0x9b0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movq	-0x9b8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rsi
-               	movq	-0x9c0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rsi
-               	movq	-0x9c8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rsi
-               	movq	-0x9d0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rsi
                	movq	-0x9d8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rsi
+               	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x9e0(%rbp)
+               	leaq	0x1(%r12), %rcx
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x9e8(%rbp)
+               	leaq	0x2(%r12), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edi, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0x9f0(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0x9f8(%rbp)
+               	leaq	0x4(%r12), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xa00(%rbp)
+               	leaq	0x5(%r12), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x5(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0xa08(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xa10(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0xa18(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0xa20(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %edi
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %r13d
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %esi
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm9, (%rax)
+               	leaq	(%rax), %r12
                	movq	-0x9e0(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rsi
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
                	movq	-0x9e8(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r14b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x440(%rbp)
-               	leaq	-0x440(%rbp), %rdx
-               	movq	-0x990(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x9f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x750(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x9f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x760(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0xa00(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x770(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0xa08(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x780(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0xa10(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x790(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0xa18(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0xa20(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movb	%dil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r14b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x7f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x800(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x810(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, -0x820(%rbp)
+               	leaq	-0x820(%rbp), %rdx
+               	movq	-0x9d8(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9f0(%rbp)
-               	movq	-0x9f0(%rbp), %r8
-               	leaq	(%r12), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %esi
-               	movl	%ebx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x9f8(%rbp)
-               	leaq	0x1(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r13d
-               	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xa00(%rbp)
-               	leaq	0x2(%r12), %rdx
-               	movzbl	(%rdx), %r13d
-               	leaq	0x2(%rdi), %rdx
-               	movzbl	(%rdx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa08(%rbp)
-               	leaq	0x3(%r12), %rdx
-               	movzbl	(%rdx), %r14d
-               	leaq	0x3(%rdi), %rdx
-               	movzbl	(%rdx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa10(%rbp)
-               	leaq	0x4(%r12), %rdx
-               	movzbl	(%rdx), %r15d
-               	leaq	0x4(%rdi), %rdx
-               	movzbl	(%rdx), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0xa18(%rbp)
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x5(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	movl	%edx, %r8d
-               	imull	%ebx, %r8d
-               	movq	%r8, -0xa20(%rbp)
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x6(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%ebx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0xa28(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xa30(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa38(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa40(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %r15d
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %ebx
-               	imull	%ebx, %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0xc(%rdi), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %ebx
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xe(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xf(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm9, (%rcx)
-               	leaq	(%rcx), %r14
-               	movq	-0x9f8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
-               	movq	-0xa00(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
-               	movq	-0xa08(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
-               	movq	-0xa10(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movq	-0xa18(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
-               	movq	-0xa20(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0xa28(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0xa30(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0xa38(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0xa40(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
-               	movb	%dl, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x550(%rbp)
-               	leaq	-0x550(%rbp), %rdx
-               	movq	-0x9f0(%rbp), %r8
-               	movq	%r8, %rcx
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x560(%rbp)
-               	leaq	-0x560(%rbp), %rdx
-               	callq	 <L10>
-<L10>:
+               	movups	%xmm0, -0x830(%rbp)
+               	leaq	-0x830(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L9>
+<L9>:
                	movaps	%xmm6, %xmm14
                	psubb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x570(%rbp)
-               	leaq	-0x570(%rbp), %rdx
-               	callq	 <L11>
-<L11>:
+               	movups	%xmm0, -0x840(%rbp)
+               	leaq	-0x840(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x580(%rbp)
-               	leaq	-0x580(%rbp), %rdx
-               	callq	 <L12>
-<L12>:
+               	movups	%xmm9, -0x850(%rbp)
+               	leaq	-0x850(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
-               	movups	%xmm10, -0x590(%rbp)
-               	leaq	-0x590(%rbp), %rdx
-               	callq	 <L13>
-<L13>:
+               	movups	%xmm10, -0x860(%rbp)
+               	leaq	-0x860(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5a0(%rbp)
-               	leaq	-0x5a0(%rbp), %rdx
-               	callq	 <L14>
-<L14>:
+               	movups	%xmm0, -0x870(%rbp)
+               	leaq	-0x870(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5b0(%rbp)
-               	leaq	-0x5b0(%rbp), %rdx
-               	callq	 <L15>
-<L15>:
+               	movups	%xmm0, -0x880(%rbp)
+               	leaq	-0x880(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x5c0(%rbp)
-               	leaq	-0x5c0(%rbp), %rdx
-               	callq	 <L16>
-<L16>:
+               	movups	%xmm0, -0x890(%rbp)
+               	leaq	-0x890(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x5d0(%rbp)
-               	leaq	-0x5d0(%rbp), %rdx
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rbx
+               	movups	%xmm9, -0x8a0(%rbp)
+               	leaq	-0x8a0(%rbp), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %rsi
                	movaps	%xmm6, %xmm9
-               	movq	$0x0, %rsi
-<L18>:
-               	leaq	-0x5e0(%rbp), %r12
+               	movq	$0x0, %rdi
+<L17>:
+               	leaq	-0x10(%rbp), %r12
                	movups	%xmm7, (%r12)
-               	cmpq	$0x6, %rsi
-               	jb	 <L25>
-               	leaq	-0x760(%rbp), %r13
+               	cmpq	$0x6, %rdi
+               	jb	 <L24>
+               	leaq	-0x190(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1254,199 +1517,199 @@ Disassembly of section .text:
                	movups	%xmm0, (%rax)
                	leaq	(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	(%rdi), %rax
+               	leaq	(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xa28(%rbp)
+               	leaq	0x1(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x1(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	movl	%edx, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0xa30(%rbp)
+               	leaq	0x2(%r12), %rax
+               	movzbl	(%rax), %r14d
+               	leaq	0x2(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xa38(%rbp)
+               	leaq	0x3(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x3(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0xa40(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa48(%rbp)
-               	leaq	0x1(%r12), %rax
+               	leaq	0x5(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0x1(%rdi), %rax
+               	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xa50(%rbp)
-               	leaq	0x2(%r12), %rax
+               	leaq	0x6(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0x2(%rdi), %rax
+               	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xa58(%rbp)
-               	leaq	0x3(%r12), %rax
+               	leaq	0x7(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0x3(%rdi), %rax
+               	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
                	movq	%r8, -0xa60(%rbp)
-               	leaq	0x4(%r12), %rax
+               	leaq	0x8(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	0x4(%rdi), %rax
+               	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa68(%rbp)
-               	leaq	0x5(%r12), %rax
+               	leaq	0x9(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0x5(%rdi), %rax
+               	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xa70(%rbp)
-               	leaq	0x6(%r12), %rax
+               	leaq	0xa(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0x6(%rdi), %rax
+               	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xa78(%rbp)
-               	leaq	0x7(%r12), %rax
+               	leaq	0xb(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0x7(%rdi), %rax
+               	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
                	movq	%r8, -0xa80(%rbp)
-               	leaq	0x8(%r12), %rax
+               	leaq	0xc(%r12), %rax
                	movzbl	(%rax), %ecx
-               	leaq	0x8(%rdi), %rax
+               	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xa88(%rbp)
-               	leaq	0x9(%r12), %rax
-               	movzbl	(%rax), %edx
-               	leaq	0x9(%rdi), %rax
-               	movzbl	(%rax), %r14d
-               	movl	%edx, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xa90(%rbp)
-               	leaq	0xa(%r12), %rax
-               	movzbl	(%rax), %r14d
-               	leaq	0xa(%rdi), %rax
-               	movzbl	(%rax), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xa98(%rbp)
-               	leaq	0xb(%r12), %rax
-               	movzbl	(%rax), %r15d
-               	leaq	0xb(%rdi), %rax
-               	movzbl	(%rax), %ecx
-               	movl	%r15d, %r8d
-               	imull	%ecx, %r8d
-               	movq	%r8, -0xaa0(%rbp)
-               	leaq	0xc(%r12), %rax
-               	movzbl	(%rax), %ecx
-               	leaq	0xc(%rdi), %rax
-               	movzbl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0xaa8(%rbp)
                	leaq	0xd(%r12), %rax
                	movzbl	(%rax), %edx
-               	leaq	0xd(%rdi), %rax
+               	leaq	0xd(%rbx), %rax
                	movzbl	(%rax), %r14d
                	imull	%r14d, %edx
                	leaq	0xe(%r12), %rax
                	movzbl	(%rax), %r14d
-               	leaq	0xe(%rdi), %rax
+               	leaq	0xe(%rbx), %rax
                	movzbl	(%rax), %r15d
                	imull	%r15d, %r14d
                	leaq	0xf(%r12), %rax
                	movzbl	(%rax), %r15d
-               	leaq	0xf(%rdi), %rax
+               	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %r15d
-               	leaq	-0x770(%rbp), %rax
+               	leaq	-0x1a0(%rbp), %rax
                	movups	%xmm7, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0xa28(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0xa30(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0xa38(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0xa40(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0xa48(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x780(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0xa50(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x790(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0xa58(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7a0(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0xa60(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7b0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0xa68(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7c0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0xa70(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7d0(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0xa78(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7e0(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0xa80(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x7f0(%rbp), %rax
+               	leaq	-0x260(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0xa88(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x800(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0xa90(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x810(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0xa98(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x820(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0xaa0(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x830(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0xaa8(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x840(%rbp), %rax
+               	leaq	-0x270(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x850(%rbp), %rax
+               	leaq	-0x280(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%r14b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x860(%rbp), %rax
+               	leaq	-0x290(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%r15b, (%rcx)
@@ -1455,299 +1718,303 @@ Disassembly of section .text:
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r13), %rax
                	movups	%xmm9, (%rax)
-               	movq	%rbx, %r14
+               	movq	%rsi, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
                	movups	(%rcx), %xmm0
-               	movups	%xmm0, -0x870(%rbp)
-               	leaq	-0x870(%rbp), %rdx
+               	movups	%xmm0, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	movq	%r14, %rcx
-               	callq	 <L20>
-<L20>:
+               	callq	 <L19>
+<L19>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x8a0(%rbp), %rax
-               	movq	$0x0, (%rax)
-               	movq	$0x0, 0x8(%rax)
-               	movq	$0x0, 0x10(%rax)
-               	movq	$0x0, 0x18(%rax)
-               	movq	$0x0, 0x20(%rax)
-               	movq	$0x0, 0x28(%rax)
-               	leaq	(%rax), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r13), %rdx
-               	movups	(%rdx), %xmm0
-               	leaq	0x10(%rax), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x20(%rax), %r15
-               	movl	$0x12345678, (%r15)     # imm = 0x12345678
-               	movl	(%rcx), %eax
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x2d0(%rbp), %r15
+               	movq	$0x0, (%r15)
+               	movq	$0x0, 0x8(%r15)
+               	movq	$0x0, 0x10(%r15)
+               	movq	$0x0, 0x18(%r15)
+               	movq	$0x0, 0x20(%r15)
+               	movq	$0x0, 0x28(%r15)
+               	leaq	(%r15), %rax
+               	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r13), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r15), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x20(%r15), %rcx
+               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	movl	(%rax), %ecx
+               	movl	%ecx, %edx
                	movq	%r14, %rcx
-               	movl	%eax, %edx
-               	callq	 <L22>
-<L22>:
-               	movups	(%r13), %xmm0
+               	callq	 <L21>
+<L21>:
+               	leaq	0x10(%r15), %rcx
+               	movups	(%rcx), %xmm0
                	movups	%xmm0, -0x8b0(%rbp)
                	leaq	-0x8b0(%rbp), %rdx
                	movq	%rax, %rcx
+               	callq	 <L22>
+<L22>:
+               	leaq	0x20(%r15), %rcx
+               	movl	(%rcx), %edx
+               	movl	%edx, %r13d
+               	movq	%rax, %rcx
+               	movq	%r13, %rdx
                	callq	 <L23>
 <L23>:
-               	movl	(%r15), %edx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	-0xb60(%rbp), %xmm6
-               	movaps	-0xb70(%rbp), %xmm7
-               	movaps	-0xb80(%rbp), %xmm8
-               	movaps	-0xb90(%rbp), %xmm9
-               	movaps	-0xba0(%rbp), %xmm10
-               	movaps	-0xbb0(%rbp), %xmm14
-               	movaps	-0xbc0(%rbp), %xmm15
-               	movq	-0xb18(%rbp), %rbx
-               	movq	-0xb20(%rbp), %rdi
-               	movq	-0xb28(%rbp), %rsi
-               	movq	-0xb30(%rbp), %r12
-               	movq	-0xb38(%rbp), %r13
-               	movq	-0xb40(%rbp), %r14
-               	movq	-0xb48(%rbp), %r15
+               	movaps	-0xb40(%rbp), %xmm6
+               	movaps	-0xb50(%rbp), %xmm7
+               	movaps	-0xb60(%rbp), %xmm8
+               	movaps	-0xb70(%rbp), %xmm9
+               	movaps	-0xb80(%rbp), %xmm10
+               	movaps	-0xb90(%rbp), %xmm14
+               	movaps	-0xba0(%rbp), %xmm15
+               	movq	-0xaf8(%rbp), %rbx
+               	movq	-0xb00(%rbp), %rdi
+               	movq	-0xb08(%rbp), %rsi
+               	movq	-0xb10(%rbp), %r12
+               	movq	-0xb18(%rbp), %r13
+               	movq	-0xb20(%rbp), %r14
+               	movq	-0xb28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	(%rdi), %rcx
+               	leaq	(%rbx), %rcx
+               	movzbl	(%rcx), %r13d
+               	movl	%edx, %r8d
+               	imull	%r13d, %r8d
+               	movq	%r8, -0xa90(%rbp)
+               	leaq	0x1(%r12), %rcx
+               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %r14d
+               	movl	%r13d, %r8d
+               	imull	%r14d, %r8d
+               	movq	%r8, -0xa98(%rbp)
+               	leaq	0x2(%r12), %rcx
+               	movzbl	(%rcx), %r14d
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r15d
+               	movl	%r14d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0xaa0(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x3(%rbx), %rcx
+               	movzbl	(%rcx), %edx
+               	movl	%r15d, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0xaa8(%rbp)
+               	leaq	0x4(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
                	movq	%r8, -0xab0(%rbp)
-               	leaq	0x1(%r12), %rcx
+               	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x1(%rdi), %rcx
+               	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xab8(%rbp)
-               	leaq	0x2(%r12), %rcx
+               	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0x2(%rdi), %rcx
+               	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xac0(%rbp)
-               	leaq	0x3(%r12), %rcx
+               	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x3(%rdi), %rcx
+               	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xac8(%rbp)
-               	leaq	0x4(%r12), %rcx
+               	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x4(%rdi), %rcx
+               	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
                	movq	%r8, -0xad0(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x5(%rdi), %rcx
+               	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
                	movq	%r8, -0xad8(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0x6(%rdi), %rcx
+               	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0xae0(%rbp)
-               	leaq	0x7(%r12), %rcx
+               	leaq	0xb(%r12), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x7(%rdi), %rcx
+               	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
                	movq	%r8, -0xae8(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rdi), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%edx, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0xaf0(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rdi), %rcx
-               	movzbl	(%rcx), %r14d
-               	movl	%r13d, %r8d
-               	imull	%r14d, %r8d
-               	movq	%r8, -0xaf8(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0xa(%rdi), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r14d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0xb00(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xb(%rdi), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%r15d, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0xb08(%rbp)
                	leaq	0xc(%r12), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0xc(%rdi), %rcx
+               	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	imull	%r13d, %edx
                	leaq	0xd(%r12), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0xd(%rdi), %rcx
+               	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	imull	%r14d, %r13d
                	leaq	0xe(%r12), %rcx
                	movzbl	(%rcx), %r14d
-               	leaq	0xe(%rdi), %rcx
+               	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	0xf(%r12), %rcx
                	movzbl	(%rcx), %r12d
-               	leaq	0xf(%rdi), %rcx
+               	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r12d
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x20(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0xa90(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0xa98(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0xaa0(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0xaa8(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
                	movq	-0xab0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x600(%rbp), %rcx
+               	leaq	-0x70(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x5(%rcx), %r15
                	movq	-0xab8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x610(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0xac0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x620(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0xac8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x630(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0xad0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x640(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0xad8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x650(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0xae0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x660(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0xae8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x670(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0xaf0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x680(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0xaf8(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x690(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0xb00(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x6a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0xb08(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x6b0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6c0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6d0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x6e0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rcx), %xmm10
-               	movups	%xmm10, -0x6f0(%rbp)
-               	leaq	-0x6f0(%rbp), %rdx
-               	movq	%rbx, %rcx
-               	callq	 <L26>
-<L26>:
+               	movups	%xmm10, -0x120(%rbp)
+               	leaq	-0x120(%rbp), %rdx
+               	movq	%rsi, %rcx
+               	callq	 <L25>
+<L25>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movups	%xmm9, -0x700(%rbp)
-               	leaq	-0x700(%rbp), %rdx
+               	movups	%xmm9, -0x130(%rbp)
+               	leaq	-0x130(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
+               	callq	 <L26>
+<L26>:
                	movaps	%xmm6, %xmm14
                	paddb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm6
-               	movups	%xmm6, -0x710(%rbp)
-               	leaq	-0x710(%rbp), %rdx
+               	movups	%xmm6, -0x140(%rbp)
+               	leaq	-0x140(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	callq	 <L27>
+<L27>:
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm7
-               	movups	%xmm7, -0x720(%rbp)
-               	leaq	-0x720(%rbp), %rdx
+               	movups	%xmm7, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rdx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	addq	$0x1, %rsi
-               	movq	%rax, %rbx
-               	jmp	 <L18>
+               	callq	 <L28>
+<L28>:
+               	addq	$0x1, %rdi
+               	movq	%rax, %rsi
+               	jmp	 <L17>


### PR DESCRIPTION
#3110 (PR #3270) re-blessed the corpus layer B goldens on the three linux ISAs only. The four columns the pr lane decodes but does not execute failed layer B against `dev` at `da4fe7146`: 92 cells each on x86_64-windows, x86_64-darwin and aarch64-darwin, 84 on spirv (layer A green on all four, every failure a `layer b o2` cell). This blesses them with the same per-golden evidence, one commit per target, appended to `doc/design/inline-acceptance-3110.md`. riscv32 and mos6502 declare layer B away and need nothing.

Every golden on every column classifies as "calls removed". Per-golden call counts before and after are identical to the `x86_64-linux` / `aarch64-linux` tables for all 92 cases, which is what the target-independent case contract predicts.

| target | goldens | calls before | calls after | reaching zero | frame direction |
| --- | --- | --- | --- | --- | --- |
| x86_64-windows | 92 | 4337 | 1804 | 31 | larger 15, same 28, smaller 49 |
| x86_64-darwin | 92 | 4337 | 1804 | 31 | larger 37, same 45, smaller 10 |
| aarch64-darwin | 92 | 4337 | 1804 | 31 | larger 27, same 9, smaller 32, no adjustment 24 |
| spirv | 84 | 3880 | 1557 | 31 | n/a (module, `OpFunctionCall` counted) |

The linux tables read 4304 to 1791 over 91 goldens; these columns include `vec/vec_cmp_i64` (33 to 13, added by #3271 after those tables), so 4337 to 1804 over 92 is the same total.

spirv has no layer C, so its section carries two more script-checked facts: no golden gains an opcode kind and the only kind that vanishes from any module is `OpFunctionCall`. On 35 of 84 goldens the opcode multiset delta is exactly call removals, dropped helper bodies and copied helper bodies; the other 49 carry a residual listed per golden, all of it inlining consequences (a same-module callee that grew past the growth bound is inlined at fewer of its own sites, constant-specialized copies fold, single-digit expression changes around the copied loop). Per-golden spirv call counts match x86_64-linux on 83 of 84, with `frame/frame_align` three lower both before and after.

Verification, all with the compiler built from this branch:

- `test/run.sh --target <t> --layer a --layer b` after the bless: x86_64-windows 276 pass, 0 fail, 92 skip (debug unsupported by declaration); x86_64-darwin 368 pass, 0 fail; aarch64-darwin 368 pass, 0 fail; spirv 251 pass, 0 fail, 101 declared skips.
- `sh test/census.sh` clean.
- `mach test .` 2757 passed, 0 failed.

Refs #3110.
